### PR TITLE
feat(ui): add portable inspector shell

### DIFF
--- a/packages/ui/src/components/inspector.test.tsx
+++ b/packages/ui/src/components/inspector.test.tsx
@@ -4,16 +4,31 @@ import { describe, expect, test } from "bun:test";
 
 import {
   Inspector,
+  InspectorActions,
+  InspectorContent,
+  InspectorDescription,
   InspectorHeader,
+  InspectorHeaderText,
   InspectorProperty,
   InspectorPropertyLabel,
   InspectorPropertyList,
   InspectorPropertyValue,
+  InspectorSection,
+  InspectorSectionTitle,
   InspectorTab,
   InspectorTabList,
   InspectorTabPanel,
   InspectorTabs,
+  InspectorTitle,
 } from "./inspector";
+
+// Slots carrying caller-supplied record values; each must isolate its own bidi
+// context so a Latin value inside an RTL inspector keeps its character order.
+const RECORD_DATA_SLOTS = [
+  "inspector-description",
+  "inspector-property-value",
+  "inspector-title",
+] as const;
 
 describe("Inspector", () => {
   test("keeps one explicit content scroll owner", () => {
@@ -62,5 +77,86 @@ describe("Inspector", () => {
     expect(markup).toContain('tabindex="-1"');
     expect(markup).toContain('data-slot="inspector-property-label"');
     expect(markup).toContain('data-slot="inspector-property-value"');
+  });
+
+  test("isolates bidi on exactly the record-data slots", () => {
+    // Every exported slot is rendered, so the assertion below is a closed set
+    // over the whole shell rather than over whichever slots a case happened to
+    // use: a new record-data slot that forgets `dir` fails the first direction,
+    // and a chrome slot that grows one fails the second.
+    const markup = renderToStaticMarkup(
+      <>
+        <Inspector>
+          <InspectorHeader>
+            <InspectorHeaderText>
+              {/* A Latin identifier is exactly the value an RTL inspector reorders. */}
+              <InspectorTitle>
+                ECLI:CZ:NS:2024:25.CDO.1234.2023.1
+              </InspectorTitle>
+              <InspectorDescription>8 Tdo 1234/2023</InspectorDescription>
+            </InspectorHeaderText>
+            <InspectorActions>Actions</InspectorActions>
+          </InspectorHeader>
+          <InspectorTabs defaultValue="overview">
+            <InspectorTabList aria-label="Record views">
+              <InspectorTab value="overview">Overview</InspectorTab>
+            </InspectorTabList>
+            <InspectorTabPanel value="overview">
+              <InspectorSection>
+                <InspectorSectionTitle>Metadata</InspectorSectionTitle>
+                <InspectorPropertyList>
+                  <InspectorProperty>
+                    <InspectorPropertyLabel>Docket</InspectorPropertyLabel>
+                    <InspectorPropertyValue>
+                      25 Cdo 1234/2023
+                    </InspectorPropertyValue>
+                  </InspectorProperty>
+                </InspectorPropertyList>
+              </InspectorSection>
+            </InspectorTabPanel>
+          </InspectorTabs>
+        </Inspector>
+        <Inspector>
+          <InspectorContent>Untabbed layout</InspectorContent>
+        </Inspector>
+      </>,
+    );
+
+    const renderedSlots = new Set<string>();
+    const isolatedSlots = new Set<string>();
+
+    for (const tag of markup.match(/<[a-z][^>]*>/gu) ?? []) {
+      const slot = /data-slot="([^"]+)"/u.exec(tag)?.[1];
+
+      if (slot === undefined) {
+        continue;
+      }
+
+      renderedSlots.add(slot);
+
+      if (
+        tag.includes('dir="auto"') &&
+        tag.includes("[unicode-bidi:isolate]")
+      ) {
+        isolatedSlots.add(slot);
+      }
+    }
+
+    // Guards the closed-set claim: a declared slot that stopped rendering would
+    // otherwise let the comparison below pass while testing nothing.
+    for (const slot of RECORD_DATA_SLOTS) {
+      expect(renderedSlots).toContain(slot);
+    }
+
+    expect([...isolatedSlots].sort()).toEqual([...RECORD_DATA_SLOTS]);
+  });
+
+  test("lets callers force a direction on a record-data slot", () => {
+    const markup = renderToStaticMarkup(
+      <InspectorPropertyValue dir="ltr">CASE-1/2023</InspectorPropertyValue>,
+    );
+
+    expect(markup).toContain('dir="ltr"');
+    expect(markup).not.toContain('dir="auto"');
   });
 });

--- a/packages/ui/src/components/inspector.test.tsx
+++ b/packages/ui/src/components/inspector.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  Inspector,
+  InspectorContent,
+  InspectorHeader,
+  InspectorProperty,
+  InspectorPropertyLabel,
+  InspectorPropertyList,
+  InspectorPropertyValue,
+  InspectorTab,
+  InspectorTabs,
+} from "./inspector";
+
+describe("Inspector", () => {
+  test("keeps one explicit content scroll owner", () => {
+    const markup = renderToStaticMarkup(
+      <Inspector>
+        <InspectorHeader>Record</InspectorHeader>
+        <InspectorTabs aria-label="Record views">
+          <InspectorTab active>Overview</InspectorTab>
+        </InspectorTabs>
+        <InspectorContent>Long content</InspectorContent>
+      </Inspector>,
+    );
+
+    expect(markup).toContain('data-slot="inspector"');
+    expect(markup).toContain("overflow-hidden");
+    expect(markup).toContain('data-slot="inspector-content"');
+    expect(markup.match(/overflow-y-auto/gu)).toHaveLength(1);
+  });
+
+  test("exposes active tabs and semantic property rows", () => {
+    const markup = renderToStaticMarkup(
+      <Inspector>
+        <InspectorTabs aria-label="Record views">
+          <InspectorTab active>Overview</InspectorTab>
+          <InspectorTab>Activity</InspectorTab>
+        </InspectorTabs>
+        <InspectorContent>
+          <InspectorPropertyList>
+            <InspectorProperty>
+              <InspectorPropertyLabel>Owner</InspectorPropertyLabel>
+              <InspectorPropertyValue>Ada</InspectorPropertyValue>
+            </InspectorProperty>
+          </InspectorPropertyList>
+        </InspectorContent>
+      </Inspector>,
+    );
+
+    expect(markup).toContain('aria-selected="true"');
+    expect(markup).toContain('role="tablist"');
+    expect(markup).toContain('data-slot="inspector-property-label"');
+    expect(markup).toContain('data-slot="inspector-property-value"');
+  });
+});

--- a/packages/ui/src/components/inspector.test.tsx
+++ b/packages/ui/src/components/inspector.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { describe, expect, test } from "bun:test";
 
+import type * as InspectorModule from "./inspector";
 import {
   Inspector,
   InspectorActions,
@@ -22,13 +23,39 @@ import {
   InspectorTitle,
 } from "./inspector";
 
+// Total over the module's exports, so a new slot component cannot land without
+// being named here: `satisfies` fails to compile until it is, and the coverage
+// assertion below then fails until the fixture renders it and RECORD_DATA_SLOTS
+// classifies it as record data or chrome.
+const SLOT_BY_EXPORT = {
+  Inspector: "inspector",
+  InspectorActions: "inspector-actions",
+  InspectorContent: "inspector-content",
+  InspectorDescription: "inspector-description",
+  InspectorHeader: "inspector-header",
+  InspectorHeaderText: "inspector-header-text",
+  InspectorProperty: "inspector-property",
+  InspectorPropertyLabel: "inspector-property-label",
+  InspectorPropertyList: "inspector-property-list",
+  InspectorPropertyValue: "inspector-property-value",
+  InspectorSection: "inspector-section",
+  InspectorSectionTitle: "inspector-section-title",
+  InspectorTab: "inspector-tab",
+  InspectorTabList: "inspector-tab-list",
+  InspectorTabPanel: "inspector-tab-panel",
+  InspectorTabs: "inspector-tabs",
+  InspectorTitle: "inspector-title",
+} as const satisfies Record<keyof typeof InspectorModule, string>;
+
+type InspectorSlot = (typeof SLOT_BY_EXPORT)[keyof typeof SLOT_BY_EXPORT];
+
 // Slots carrying caller-supplied record values; each must isolate its own bidi
 // context so a Latin value inside an RTL inspector keeps its character order.
 const RECORD_DATA_SLOTS = [
   "inspector-description",
   "inspector-property-value",
   "inspector-title",
-] as const;
+] as const satisfies readonly InspectorSlot[];
 
 describe("Inspector", () => {
   test("keeps one explicit content scroll owner", () => {
@@ -142,11 +169,18 @@ describe("Inspector", () => {
       }
     }
 
-    // Guards the closed-set claim: a declared slot that stopped rendering would
-    // otherwise let the comparison below pass while testing nothing.
-    for (const slot of RECORD_DATA_SLOTS) {
-      expect(renderedSlots).toContain(slot);
-    }
+    // Closes the set in both directions against the module's exports rather
+    // than against whatever the fixture happens to use: every declared slot
+    // must be exercised, and any `inspector-*` slot the fixture renders must be
+    // declared. Slots owned by the underlying tabs primitive are not prefixed,
+    // so they stay out of this comparison.
+    const inspectorSlotsRendered = [...renderedSlots]
+      .filter((slot) => slot.startsWith("inspector"))
+      .sort();
+
+    expect(inspectorSlotsRendered).toEqual(
+      Object.values(SLOT_BY_EXPORT).toSorted(),
+    );
 
     expect([...isolatedSlots].sort()).toEqual([...RECORD_DATA_SLOTS]);
   });

--- a/packages/ui/src/components/inspector.test.tsx
+++ b/packages/ui/src/components/inspector.test.tsx
@@ -108,6 +108,10 @@ describe("Inspector", () => {
     expect(markup).toContain('data-slot="inspector-property-label"');
     expect(markup).toContain('data-slot="inspector-property-value"');
 
+    // Tabs sit flush inside the root's `overflow-hidden`, so the focus ring has
+    // to be drawn inside the tab or the indicator is clipped for keyboard users.
+    expect(markup).toContain("focus-visible:ring-inset");
+
     // The slot names above survive a swap to generic elements, so pin the
     // description-list tags too: the semantics are the point of these slots.
     expect(markup).toMatch(/<dl\b/u);

--- a/packages/ui/src/components/inspector.test.tsx
+++ b/packages/ui/src/components/inspector.test.tsx
@@ -1,6 +1,9 @@
+import type * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { describe, expect, test } from "bun:test";
+
+import type { Tabs } from "@stll/ui/components/tabs";
 
 import type * as InspectorModule from "./inspector";
 import {
@@ -183,6 +186,31 @@ describe("Inspector", () => {
     );
 
     expect([...isolatedSlots].sort()).toEqual([...RECORD_DATA_SLOTS]);
+  });
+
+  test("stays horizontal when a spread leaks a vertical orientation", () => {
+    // The omit on InspectorTabs only rejects a literal `orientation`; a spread
+    // of a wider props object still carries one through structural subtyping,
+    // so the runtime pin is what actually holds the layout. Typing the object
+    // as the full tabs props is exactly the shape that gets past the omit.
+    const leaked: React.ComponentProps<typeof Tabs> = {
+      defaultValue: "overview",
+      orientation: "vertical",
+    };
+
+    const markup = renderToStaticMarkup(
+      <Inspector>
+        <InspectorTabs {...leaked}>
+          <InspectorTabList aria-label="Record views">
+            <InspectorTab value="overview">Overview</InspectorTab>
+          </InspectorTabList>
+          <InspectorTabPanel value="overview">Content</InspectorTabPanel>
+        </InspectorTabs>
+      </Inspector>,
+    );
+
+    expect(markup).toContain('data-orientation="horizontal"');
+    expect(markup).not.toContain('data-orientation="vertical"');
   });
 
   test("lets callers force a direction on a record-data slot", () => {

--- a/packages/ui/src/components/inspector.test.tsx
+++ b/packages/ui/src/components/inspector.test.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { describe, expect, test } from "bun:test";
 
-import type { Tabs } from "@stll/ui/components/tabs";
+import type { Tabs, TabsList } from "@stll/ui/components/tabs";
 
 import type * as InspectorModule from "./inspector";
 import {
@@ -107,6 +107,12 @@ describe("Inspector", () => {
     expect(markup).toContain('tabindex="-1"');
     expect(markup).toContain('data-slot="inspector-property-label"');
     expect(markup).toContain('data-slot="inspector-property-value"');
+
+    // The slot names above survive a swap to generic elements, so pin the
+    // description-list tags too: the semantics are the point of these slots.
+    expect(markup).toMatch(/<dl\b/u);
+    expect(markup).toMatch(/<dt\b/u);
+    expect(markup).toMatch(/<dd\b/u);
   });
 
   test("isolates bidi on exactly the record-data slots", () => {
@@ -188,20 +194,25 @@ describe("Inspector", () => {
     expect([...isolatedSlots].sort()).toEqual([...RECORD_DATA_SLOTS]);
   });
 
-  test("stays horizontal when a spread leaks a vertical orientation", () => {
-    // The omit on InspectorTabs only rejects a literal `orientation`; a spread
-    // of a wider props object still carries one through structural subtyping,
-    // so the runtime pin is what actually holds the layout. Typing the object
-    // as the full tabs props is exactly the shape that gets past the omit.
-    const leaked: React.ComponentProps<typeof Tabs> = {
+  test("holds forced chrome props against a widened spread", () => {
+    // The omits on these wrappers only reject a literal `orientation`/`variant`.
+    // An object annotated with the full props type satisfies `Omit<...>` under
+    // structural width subtyping and the rest spread forwards it, so the pins
+    // after each spread are what actually hold the chrome. Both forced props in
+    // the shell are exercised here; `dir` is deliberately not among them, since
+    // record-data slots stay caller-overridable.
+    const leakedTabs: React.ComponentProps<typeof Tabs> = {
       defaultValue: "overview",
       orientation: "vertical",
+    };
+    const leakedTabList: React.ComponentProps<typeof TabsList> = {
+      variant: "default",
     };
 
     const markup = renderToStaticMarkup(
       <Inspector>
-        <InspectorTabs {...leaked}>
-          <InspectorTabList aria-label="Record views">
+        <InspectorTabs {...leakedTabs}>
+          <InspectorTabList {...leakedTabList} aria-label="Record views">
             <InspectorTab value="overview">Overview</InspectorTab>
           </InspectorTabList>
           <InspectorTabPanel value="overview">Content</InspectorTabPanel>
@@ -211,6 +222,15 @@ describe("Inspector", () => {
 
     expect(markup).toContain('data-orientation="horizontal"');
     expect(markup).not.toContain('data-orientation="vertical"');
+
+    // The variant is only observable through the indicator's styling: the
+    // underline strip paints `bg-primary`, the default variant a rounded chip.
+    const indicator = /<[a-z][^>]*data-slot="tab-indicator"[^>]*>/u.exec(
+      markup,
+    )?.[0];
+
+    expect(indicator).toContain("bg-primary");
+    expect(indicator).not.toContain("rounded-md");
   });
 
   test("lets callers force a direction on a record-data slot", () => {

--- a/packages/ui/src/components/inspector.test.tsx
+++ b/packages/ui/src/components/inspector.test.tsx
@@ -4,13 +4,14 @@ import { describe, expect, test } from "bun:test";
 
 import {
   Inspector,
-  InspectorContent,
   InspectorHeader,
   InspectorProperty,
   InspectorPropertyLabel,
   InspectorPropertyList,
   InspectorPropertyValue,
   InspectorTab,
+  InspectorTabList,
+  InspectorTabPanel,
   InspectorTabs,
 } from "./inspector";
 
@@ -19,39 +20,46 @@ describe("Inspector", () => {
     const markup = renderToStaticMarkup(
       <Inspector>
         <InspectorHeader>Record</InspectorHeader>
-        <InspectorTabs aria-label="Record views">
-          <InspectorTab active>Overview</InspectorTab>
+        <InspectorTabs defaultValue="overview">
+          <InspectorTabList aria-label="Record views">
+            <InspectorTab value="overview">Overview</InspectorTab>
+          </InspectorTabList>
+          <InspectorTabPanel value="overview">Long content</InspectorTabPanel>
         </InspectorTabs>
-        <InspectorContent>Long content</InspectorContent>
       </Inspector>,
     );
 
     expect(markup).toContain('data-slot="inspector"');
     expect(markup).toContain("overflow-hidden");
-    expect(markup).toContain('data-slot="inspector-content"');
+    expect(markup).toContain('data-slot="inspector-tab-panel"');
     expect(markup.match(/overflow-y-auto/gu)).toHaveLength(1);
   });
 
   test("exposes active tabs and semantic property rows", () => {
     const markup = renderToStaticMarkup(
       <Inspector>
-        <InspectorTabs aria-label="Record views">
-          <InspectorTab active>Overview</InspectorTab>
-          <InspectorTab>Activity</InspectorTab>
+        <InspectorTabs defaultValue="overview">
+          <InspectorTabList aria-label="Record views">
+            <InspectorTab value="overview">Overview</InspectorTab>
+            <InspectorTab value="activity">Activity</InspectorTab>
+          </InspectorTabList>
+          <InspectorTabPanel value="overview">
+            <InspectorPropertyList>
+              <InspectorProperty>
+                <InspectorPropertyLabel>Owner</InspectorPropertyLabel>
+                <InspectorPropertyValue>Ada</InspectorPropertyValue>
+              </InspectorProperty>
+            </InspectorPropertyList>
+          </InspectorTabPanel>
+          <InspectorTabPanel value="activity">No activity</InspectorTabPanel>
         </InspectorTabs>
-        <InspectorContent>
-          <InspectorPropertyList>
-            <InspectorProperty>
-              <InspectorPropertyLabel>Owner</InspectorPropertyLabel>
-              <InspectorPropertyValue>Ada</InspectorPropertyValue>
-            </InspectorProperty>
-          </InspectorPropertyList>
-        </InspectorContent>
       </Inspector>,
     );
 
     expect(markup).toContain('aria-selected="true"');
     expect(markup).toContain('role="tablist"');
+    expect(markup).toContain('tabindex="0"');
+    expect(markup).toContain('tabindex="-1"');
     expect(markup).toContain('data-slot="inspector-property-label"');
     expect(markup).toContain('data-slot="inspector-property-value"');
   });

--- a/packages/ui/src/components/inspector.tsx
+++ b/packages/ui/src/components/inspector.tsx
@@ -110,6 +110,11 @@ const InspectorTabs = ({
     className={cn("min-h-0 flex-1 gap-0 overflow-hidden", className)}
     data-slot="inspector-tabs"
     {...props}
+    // After the spread on purpose: the omit above only rejects a literal
+    // `orientation`, while a spread of a wider props object still carries one
+    // through structural subtyping. Pinning it here keeps the layout horizontal
+    // whatever reaches the spread.
+    orientation="horizontal"
   />
 );
 

--- a/packages/ui/src/components/inspector.tsx
+++ b/packages/ui/src/components/inspector.tsx
@@ -96,10 +96,16 @@ const InspectorActions = ({
   />
 );
 
+// `orientation` is omitted rather than passed through: the tabs root turns
+// `flex-row` when vertical, but the tab list is sized as a horizontal strip
+// (`h-11 w-full shrink-0`), so a vertical inspector would give the whole width
+// to the list and clip the panel against this root's `overflow-hidden`.
+// Supporting it needs vertical list sizing, so the shell excludes it instead of
+// exposing a prop that silently breaks the layout.
 const InspectorTabs = ({
   className,
   ...props
-}: React.ComponentProps<typeof Tabs>) => (
+}: Omit<React.ComponentProps<typeof Tabs>, "orientation">) => (
   <Tabs
     className={cn("min-h-0 flex-1 gap-0 overflow-hidden", className)}
     data-slot="inspector-tabs"

--- a/packages/ui/src/components/inspector.tsx
+++ b/packages/ui/src/components/inspector.tsx
@@ -46,14 +46,24 @@ const InspectorHeaderText = ({
   />
 );
 
+// Record-data slots (title, description, property value) hold caller-supplied
+// values such as case numbers, ECLI identifiers, and filenames. They isolate
+// their own bidi context so a Latin value inside an RTL inspector keeps its
+// character order and truncates from the correct end. Chrome slots stay in the
+// surrounding direction. `dir` precedes the prop spread so callers can force a
+// direction. `inspector.test.tsx` pins which slots belong to each group.
 const InspectorTitle = ({
   children,
   className,
   ...props
 }: React.ComponentProps<"h2">) => (
   <h2
-    className={cn("truncate text-sm font-semibold", className)}
+    className={cn(
+      "truncate text-sm font-semibold [unicode-bidi:isolate]",
+      className,
+    )}
     data-slot="inspector-title"
+    dir="auto"
     {...props}
   >
     {children}
@@ -65,8 +75,12 @@ const InspectorDescription = ({
   ...props
 }: React.ComponentProps<"p">) => (
   <p
-    className={cn("text-muted-foreground truncate text-xs", className)}
+    className={cn(
+      "text-muted-foreground truncate text-xs [unicode-bidi:isolate]",
+      className,
+    )}
     data-slot="inspector-description"
+    dir="auto"
     {...props}
   />
 );
@@ -219,8 +233,12 @@ const InspectorPropertyValue = ({
   ...props
 }: React.ComponentProps<"dd">) => (
   <dd
-    className={cn("min-w-0 truncate text-sm font-medium", className)}
+    className={cn(
+      "min-w-0 truncate text-sm font-medium [unicode-bidi:isolate]",
+      className,
+    )}
     data-slot="inspector-property-value"
+    dir="auto"
     {...props}
   />
 );

--- a/packages/ui/src/components/inspector.tsx
+++ b/packages/ui/src/components/inspector.tsx
@@ -1,0 +1,228 @@
+import type * as React from "react";
+
+import { cn } from "@stll/ui/lib/utils";
+
+type InspectorProps = React.ComponentProps<"aside">;
+
+/**
+ * App-agnostic right-side inspector chrome. The inspector itself owns the
+ * viewport height; only {@link InspectorContent} scrolls, keeping the header
+ * and tabs reachable while inspecting long records.
+ */
+const Inspector = ({ className, ...props }: InspectorProps) => (
+  <aside
+    className={cn(
+      "bg-background text-foreground flex h-full min-h-0 w-full flex-col overflow-hidden border-s shadow-lg",
+      className,
+    )}
+    data-slot="inspector"
+    {...props}
+  />
+);
+
+const InspectorHeader = ({
+  className,
+  ...props
+}: React.ComponentProps<"header">) => (
+  <header
+    className={cn(
+      "bg-background flex h-12 shrink-0 items-center gap-3 border-b px-3",
+      className,
+    )}
+    data-slot="inspector-header"
+    {...props}
+  />
+);
+
+const InspectorHeaderText = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn("min-w-0 flex-1", className)}
+    data-slot="inspector-header-text"
+    {...props}
+  />
+);
+
+const InspectorTitle = ({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"h2">) => (
+  <h2
+    className={cn("truncate text-sm font-semibold", className)}
+    data-slot="inspector-title"
+    {...props}
+  >
+    {children}
+  </h2>
+);
+
+const InspectorDescription = ({
+  className,
+  ...props
+}: React.ComponentProps<"p">) => (
+  <p
+    className={cn("text-muted-foreground truncate text-xs", className)}
+    data-slot="inspector-description"
+    {...props}
+  />
+);
+
+const InspectorActions = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn("ms-auto flex shrink-0 items-center gap-1", className)}
+    data-slot="inspector-actions"
+    {...props}
+  />
+);
+
+const InspectorTabs = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn(
+      "bg-background flex h-11 shrink-0 items-end gap-1 border-b px-3",
+      className,
+    )}
+    data-slot="inspector-tabs"
+    role="tablist"
+    {...props}
+  />
+);
+
+type InspectorTabProps = Omit<React.ComponentProps<"button">, "type"> & {
+  active?: boolean;
+};
+
+const InspectorTab = ({
+  active = false,
+  className,
+  ...props
+}: InspectorTabProps) => (
+  <button
+    aria-selected={active}
+    className={cn(
+      "text-muted-foreground hover:text-foreground focus-visible:ring-ring flex h-11 items-center gap-1.5 border-b-2 border-transparent px-2 text-xs font-medium outline-none focus-visible:ring-2",
+      active && "border-primary text-foreground",
+      className,
+    )}
+    data-active={active ? "" : undefined}
+    data-slot="inspector-tab"
+    role="tab"
+    {...props}
+    type="button"
+  />
+);
+
+const InspectorContent = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn(
+      "min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain",
+      className,
+    )}
+    data-slot="inspector-content"
+    {...props}
+  />
+);
+
+const InspectorSection = ({
+  className,
+  ...props
+}: React.ComponentProps<"section">) => (
+  <section
+    className={cn("border-b px-3 py-3 last:border-b-0", className)}
+    data-slot="inspector-section"
+    {...props}
+  />
+);
+
+const InspectorSectionTitle = ({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"h3">) => (
+  <h3
+    className={cn(
+      "text-muted-foreground mb-2 text-[11px] font-semibold tracking-wide uppercase",
+      className,
+    )}
+    data-slot="inspector-section-title"
+    {...props}
+  >
+    {children}
+  </h3>
+);
+
+const InspectorPropertyList = ({
+  className,
+  ...props
+}: React.ComponentProps<"dl">) => (
+  <dl
+    className={cn("divide-y", className)}
+    data-slot="inspector-property-list"
+    {...props}
+  />
+);
+
+const InspectorProperty = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn(
+      "grid min-h-9 grid-cols-[minmax(6rem,2fr)_minmax(0,3fr)] items-center gap-3 py-2",
+      className,
+    )}
+    data-slot="inspector-property"
+    {...props}
+  />
+);
+
+const InspectorPropertyLabel = ({
+  className,
+  ...props
+}: React.ComponentProps<"dt">) => (
+  <dt
+    className={cn("text-muted-foreground min-w-0 text-xs", className)}
+    data-slot="inspector-property-label"
+    {...props}
+  />
+);
+
+const InspectorPropertyValue = ({
+  className,
+  ...props
+}: React.ComponentProps<"dd">) => (
+  <dd
+    className={cn("min-w-0 truncate text-sm font-medium", className)}
+    data-slot="inspector-property-value"
+    {...props}
+  />
+);
+
+export {
+  Inspector,
+  InspectorActions,
+  InspectorContent,
+  InspectorDescription,
+  InspectorHeader,
+  InspectorHeaderText,
+  InspectorProperty,
+  InspectorPropertyLabel,
+  InspectorPropertyList,
+  InspectorPropertyValue,
+  InspectorSection,
+  InspectorSectionTitle,
+  InspectorTab,
+  InspectorTabs,
+  InspectorTitle,
+};

--- a/packages/ui/src/components/inspector.tsx
+++ b/packages/ui/src/components/inspector.tsx
@@ -144,7 +144,12 @@ const InspectorTab = ({
 }: React.ComponentProps<typeof TabsTab>) => (
   <TabsTab
     className={cn(
-      "h-11 grow-0 rounded-none px-2 text-xs sm:h-11 sm:text-xs",
+      // The tab fills the list's full height and the list sits flush against
+      // the tabs root, so the inherited outward `focus-visible:ring-2` would be
+      // clipped by that root's `overflow-hidden`. Drawing the ring inside the
+      // tab keeps the whole indicator visible without changing the strip's
+      // metrics.
+      "h-11 grow-0 rounded-none px-2 text-xs focus-visible:ring-inset sm:h-11 sm:text-xs",
       className,
     )}
     data-slot="inspector-tab"

--- a/packages/ui/src/components/inspector.tsx
+++ b/packages/ui/src/components/inspector.tsx
@@ -128,8 +128,13 @@ const InspectorTabList = ({
       className,
     )}
     data-slot="inspector-tab-list"
-    variant="underline"
     {...props}
+    // Pinned after the spread for the same reason as the tabs orientation: the
+    // omit above rejects a literal `variant`, but a spread of a wider props
+    // object still carries one. The default variant would draw a rounded
+    // indicator against this list's overridden `bg-background`, losing the
+    // underline strip the inspector chrome is built around.
+    variant="underline"
   />
 );
 

--- a/packages/ui/src/components/inspector.tsx
+++ b/packages/ui/src/components/inspector.tsx
@@ -1,13 +1,14 @@
 import type * as React from "react";
 
+import { Tabs, TabsList, TabsPanel, TabsTab } from "@stll/ui/components/tabs";
 import { cn } from "@stll/ui/lib/utils";
 
 type InspectorProps = React.ComponentProps<"aside">;
 
 /**
  * App-agnostic right-side inspector chrome. The inspector itself owns the
- * viewport height; only {@link InspectorContent} scrolls, keeping the header
- * and tabs reachable while inspecting long records.
+ * viewport height; only its content or active tab panel scrolls, keeping the
+ * header and tabs reachable while inspecting long records.
  */
 const Inspector = ({ className, ...props }: InspectorProps) => (
   <aside
@@ -84,39 +85,54 @@ const InspectorActions = ({
 const InspectorTabs = ({
   className,
   ...props
-}: React.ComponentProps<"div">) => (
-  <div
-    className={cn(
-      "bg-background flex h-11 shrink-0 items-end gap-1 border-b px-3",
-      className,
-    )}
+}: React.ComponentProps<typeof Tabs>) => (
+  <Tabs
+    className={cn("min-h-0 flex-1 gap-0 overflow-hidden", className)}
     data-slot="inspector-tabs"
-    role="tablist"
     {...props}
   />
 );
 
-type InspectorTabProps = Omit<React.ComponentProps<"button">, "type"> & {
-  active?: boolean;
-};
-
-const InspectorTab = ({
-  active = false,
+const InspectorTabList = ({
   className,
   ...props
-}: InspectorTabProps) => (
-  <button
-    aria-selected={active}
+}: Omit<React.ComponentProps<typeof TabsList>, "variant">) => (
+  <TabsList
     className={cn(
-      "text-muted-foreground hover:text-foreground focus-visible:ring-ring flex h-11 items-center gap-1.5 border-b-2 border-transparent px-2 text-xs font-medium outline-none focus-visible:ring-2",
-      active && "border-primary text-foreground",
+      "bg-background h-11 w-full shrink-0 justify-start gap-1 border-b px-3 py-0",
       className,
     )}
-    data-active={active ? "" : undefined}
-    data-slot="inspector-tab"
-    role="tab"
+    data-slot="inspector-tab-list"
+    variant="underline"
     {...props}
-    type="button"
+  />
+);
+
+const InspectorTab = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsTab>) => (
+  <TabsTab
+    className={cn(
+      "h-11 grow-0 rounded-none px-2 text-xs sm:h-11 sm:text-xs",
+      className,
+    )}
+    data-slot="inspector-tab"
+    {...props}
+  />
+);
+
+const InspectorTabPanel = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPanel>) => (
+  <TabsPanel
+    className={cn(
+      "min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain",
+      className,
+    )}
+    data-slot="inspector-tab-panel"
+    {...props}
   />
 );
 
@@ -223,6 +239,8 @@ export {
   InspectorSection,
   InspectorSectionTitle,
   InspectorTab,
+  InspectorTabList,
+  InspectorTabPanel,
   InspectorTabs,
   InspectorTitle,
 };


### PR DESCRIPTION
Adds an app-agnostic right-side inspector primitive to `@stll/ui`.

The shell keeps compact header and tab chrome outside the single scrollable content region, and includes semantic property-list building blocks for dense metadata views. Server-rendered contract coverage verifies the scroll-owner, tab, and description-list semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable inspector interface with headers, titles, descriptions, actions, tabs, sections, and property lists.
  * Supports accessible horizontal tab navigation, scrollable content, styling customisation, and right-to-left text handling.
  * Components accept standard interface properties for flexible integration.

* **Tests**
  * Added comprehensive coverage for accessibility semantics, tab orientation, scrolling behaviour, property markup, text direction, bidirectional text isolation, and rendered slot attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->