### PR TITLE
fix: advertise only verified releases

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -10,8 +10,9 @@ name: Release Desktop App
 # scripts/detect-desktop-release-changes.sh for the exact decision.
 # On a skipped STABLE release, the carry-forward job below copies the
 # previous stable's installers + latest.json onto the new release and
-# flips `--latest`, so the web app's /releases/latest/download deep
-# links never 404 and in-app updaters see no spurious update.
+# flips `--latest` only after production is re-verified, so the web app's
+# /releases/latest/download deep links never 404 and in-app updaters see no
+# spurious update.
 #
 # Builds Windows + macOS in parallel. Windows uses Azure Trusted
 # Signing; macOS uses a Developer ID Application cert + App Store
@@ -38,19 +39,17 @@ concurrency:
 
 jobs:
   resolve:
-    # Trigger on `success` OR `failure` of release.yml — desktop
-    # builds don't depend on the API/ingestion deploy succeeding.
-    # The release.yml `publish` job (which creates the GitHub
-    # Release object we upload to) runs before `promote` (the API
-    # deploy that's been the recurring failure point); as long as
-    # publish succeeded, the Release exists and resolve below can
-    # find it. If even publish failed, our own gh api lookup of
-    # the tag will fail-fast with a clear error.
+    # Only a successful Release Artifacts run may trigger the desktop
+    # publication path. Release Artifacts creates the GitHub Release before
+    # promotion, so accepting `failure` here would let a failed production
+    # promotion reach the latest and CDN publication steps below. Manual
+    # dispatch remains available for recovery, but its stable path is gated
+    # by the post-build production verification job.
     #
-    # Skip `cancelled` (a newer release.yml run replaced it; that
-    # newer run will trigger us instead) and `skipped` (release.yml
-    # never actually ran, so there's nothing for us to release).
-    if: ${{ github.event_name == 'workflow_dispatch' || (contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion) && startsWith(github.event.workflow_run.head_branch, 'v')) }}
+    # Skip `cancelled` (a newer release.yml run replaced it; that newer run
+    # will trigger us instead) and `skipped` (release.yml never actually ran,
+    # so there's nothing for us to release).
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -562,13 +561,51 @@ jobs:
           printf '  uploading %s\n' "${artifacts[@]}"
           gh release upload "$RELEASE_REF" "${artifacts[@]}" --clobber
 
+  verify-production:
+    # Build the signed desktop artifacts first, then confirm that production
+    # still serves this release immediately before publishing latest.json to
+    # the public updater feed. This closes the rollback window between the
+    # release workflow's promotion check and desktop publication.
+    needs: [resolve, build]
+    if: ${{ needs.resolve.outputs.should_build == 'true' && needs.resolve.outputs.channel == 'prod' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout release verification script
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve.outputs.release_sha }}
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+          no-cache: true
+
+      - name: Verify production serves the release commit
+        env:
+          API_DEPLOYMENT_EXPECTED_COMMIT: ${{ needs.resolve.outputs.release_sha }}
+          API_DEPLOYMENT_PROBE_PATH: ready
+          API_DEPLOYMENT_URL: https://api.stll.app
+        run: bun scripts/check-api-deployment.ts
+
+      - name: Verify production web serves the release commit
+        env:
+          API_DEPLOYMENT_EXPECTED_COMMIT: ${{ needs.resolve.outputs.release_sha }}
+          API_DEPLOYMENT_PROBE_PATH: version.json
+          API_DEPLOYMENT_URL: https://my.stll.app
+        run: bun scripts/check-api-deployment.ts
+
   manifest:
     # Build the Tauri updater manifest (latest.json) referencing the
     # signed artifacts on the GitHub Release. Runs once after every
     # platform finishes so a partial matrix doesn't ship a manifest
     # that promises an installer that doesn't exist.
-    needs: [resolve, build]
-    if: ${{ needs.resolve.outputs.should_build == 'true' }}
+    needs: [resolve, build, verify-production]
+    if: ${{ always() && needs.resolve.outputs.should_build == 'true' && (needs.resolve.outputs.channel != 'prod' || needs.verify-production.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -638,18 +675,21 @@ jobs:
             --paths "/$key" \
             --no-cli-pager > /dev/null
 
-      # Promote the release to "latest" only after the signed
-      # installers are attached. release.yml creates the release
-      # with --latest=false so /releases/latest/download/Stella-*
-      # keeps pointing at the previous fully-built release while
-      # this workflow is still building. Prereleases never get the
-      # latest flag (GitHub excludes them from /releases/latest by
-      # default) so we only flip for stable tags.
+  promote-latest:
+    # GitHub's /releases/latest is the source used by the self-host update
+    # banner. Keep this final pointer update separate from artifact and CDN
+    # publication so a failed manifest job cannot advertise a partial release.
+    needs: [resolve, manifest]
+    if: ${{ always() && needs.resolve.outputs.should_build == 'true' && needs.resolve.outputs.channel == 'prod' && needs.manifest.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
+    steps:
       - name: Promote release to latest
-        if: ${{ !contains(needs.resolve.outputs.release_ref, '-') }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
         run: gh release edit "$RELEASE_REF" --latest
 
   carry-forward:
@@ -659,7 +699,8 @@ jobs:
     #     /releases/latest/download/Stella-* deep links, and
     #   - NOT flipping it would strand /releases/latest on the old tag.
     # So copy the previous stable release's desktop assets (installers
-    # + latest.json) onto this release, then flip `--latest`. The
+    # + latest.json) onto this release, then re-verify production and flip
+    # `--latest`. The
     # carried latest.json still advertises the previous desktop version
     # and points at the previous release's download URLs, so in-app
     # updaters see no update: that is exactly the point (no redownload
@@ -682,7 +723,7 @@ jobs:
       RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
       PREVIOUS_TAG: ${{ needs.resolve.outputs.previous_tag }}
     steps:
-      - name: Copy previous stable desktop assets forward and promote
+      - name: Copy previous stable desktop assets forward
         run: |
           # A carry-forward with nothing to carry is a broken invariant:
           # the skip decision only produces should_build=false when it
@@ -701,8 +742,39 @@ jobs:
             --pattern 'latest.json' \
             --dir assets
 
-          # Attach first, THEN flip --latest (same ordering rationale as
-          # the manifest job's promote step): the deep links must
-          # resolve before /releases/latest points here.
+          # Attach first, THEN verify production and flip --latest: the deep
+          # links must resolve and the release must be deployed before
+          # /releases/latest points here.
           gh release upload "$RELEASE_REF" assets/* --clobber
-          gh release edit "$RELEASE_REF" --latest
+
+      - name: Checkout release verification script
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve.outputs.release_sha }}
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+          no-cache: true
+
+      - name: Verify production serves the release commit
+        env:
+          API_DEPLOYMENT_EXPECTED_COMMIT: ${{ needs.resolve.outputs.release_sha }}
+          API_DEPLOYMENT_PROBE_PATH: ready
+          API_DEPLOYMENT_URL: https://api.stll.app
+        run: bun scripts/check-api-deployment.ts
+
+      - name: Verify production web serves the release commit
+        env:
+          API_DEPLOYMENT_EXPECTED_COMMIT: ${{ needs.resolve.outputs.release_sha }}
+          API_DEPLOYMENT_PROBE_PATH: version.json
+          API_DEPLOYMENT_URL: https://my.stll.app
+        run: bun scripts/check-api-deployment.ts
+
+      - name: Promote release to latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
+        run: gh release edit "$RELEASE_REF" --latest

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -605,7 +605,7 @@ jobs:
     # platform finishes so a partial matrix doesn't ship a manifest
     # that promises an installer that doesn't exist.
     needs: [resolve, build, verify-production]
-    if: ${{ always() && needs.resolve.outputs.should_build == 'true' && (needs.resolve.outputs.channel != 'prod' || needs.verify-production.result == 'success') }}
+    if: ${{ always() && needs.resolve.outputs.should_build == 'true' && needs.build.result == 'success' && (needs.resolve.outputs.channel != 'prod' || needs.verify-production.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -713,7 +713,7 @@ jobs:
     needs: resolve
     if: ${{ needs.resolve.outputs.should_build == 'false' && needs.resolve.outputs.channel == 'prod' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     permissions:
       contents: write # download from / upload to / edit GitHub Releases
     env:

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -66,22 +66,28 @@ describe("API deployment health receipt", () => {
   });
 
   test("release promotion preserves the full online-migration window", async () => {
-    const [releaseWorkflow, stagingWorkflow, promoteAction] = await Promise.all(
-      [
-        Bun.file(
-          new URL("../.github/workflows/release.yml", import.meta.url),
-        ).text(),
-        Bun.file(
-          new URL("../.github/workflows/deploy-staging.yml", import.meta.url),
-        ).text(),
-        Bun.file(
-          new URL(
-            "../.github/actions/promote-dispatch/action.yml",
-            import.meta.url,
-          ),
-        ).text(),
-      ],
-    );
+    const [
+      releaseWorkflow,
+      releaseDesktopWorkflow,
+      stagingWorkflow,
+      promoteAction,
+    ] = await Promise.all([
+      Bun.file(
+        new URL("../.github/workflows/release.yml", import.meta.url),
+      ).text(),
+      Bun.file(
+        new URL("../.github/workflows/release-desktop.yml", import.meta.url),
+      ).text(),
+      Bun.file(
+        new URL("../.github/workflows/deploy-staging.yml", import.meta.url),
+      ).text(),
+      Bun.file(
+        new URL(
+          "../.github/actions/promote-dispatch/action.yml",
+          import.meta.url,
+        ),
+      ).text(),
+    ]);
     const promoteJobStart = releaseWorkflow.indexOf("\n  promote:\n");
     const stagingJobStart = releaseWorkflow.indexOf(
       "\n  promote-staging:\n",
@@ -171,6 +177,74 @@ describe("API deployment health receipt", () => {
     expect(promoteJob).not.toContain("steps.app-token.outputs.token");
     expect(stagingWorkflow).not.toContain(
       "steps.deployment-token.outputs.token",
+    );
+
+    const desktopResolveStart =
+      releaseDesktopWorkflow.indexOf("\n  resolve:\n");
+    const desktopBuildStart = releaseDesktopWorkflow.indexOf(
+      "\n  build:\n",
+      desktopResolveStart,
+    );
+    const desktopVerifyStart = releaseDesktopWorkflow.indexOf(
+      "\n  verify-production:\n",
+      desktopBuildStart,
+    );
+    const desktopManifestStart = releaseDesktopWorkflow.indexOf(
+      "\n  manifest:\n",
+      desktopVerifyStart,
+    );
+    const desktopPromoteStart = releaseDesktopWorkflow.indexOf(
+      "\n  promote-latest:\n",
+      desktopManifestStart,
+    );
+    const desktopCarryStart = releaseDesktopWorkflow.indexOf(
+      "\n  carry-forward:\n",
+      desktopPromoteStart,
+    );
+    const desktopResolve = releaseDesktopWorkflow.slice(
+      desktopResolveStart,
+      desktopBuildStart,
+    );
+    const desktopVerify = releaseDesktopWorkflow.slice(
+      desktopVerifyStart,
+      desktopManifestStart,
+    );
+    const desktopManifest = releaseDesktopWorkflow.slice(
+      desktopManifestStart,
+      desktopPromoteStart,
+    );
+    const desktopPromote = releaseDesktopWorkflow.slice(
+      desktopPromoteStart,
+      desktopCarryStart,
+    );
+    const desktopCarry = releaseDesktopWorkflow.slice(desktopCarryStart);
+
+    expect(desktopResolveStart).toBeGreaterThanOrEqual(0);
+    expect(desktopBuildStart).toBeGreaterThan(desktopResolveStart);
+    expect(desktopVerifyStart).toBeGreaterThan(desktopBuildStart);
+    expect(desktopManifestStart).toBeGreaterThan(desktopVerifyStart);
+    expect(desktopPromoteStart).toBeGreaterThan(desktopManifestStart);
+    expect(desktopCarryStart).toBeGreaterThan(desktopPromoteStart);
+    expect(desktopResolve).toContain(
+      "github.event.workflow_run.conclusion == 'success'",
+    );
+    expect(desktopResolve).not.toContain('["success", "failure"]');
+    expect(desktopVerify).toContain("API_DEPLOYMENT_PROBE_PATH: ready");
+    expect(desktopVerify).toContain("API_DEPLOYMENT_PROBE_PATH: version.json");
+    expect(desktopManifest).toContain(
+      "needs: [resolve, build, verify-production]",
+    );
+    expect(desktopManifest).toContain(
+      "needs.verify-production.result == 'success'",
+    );
+    expect(desktopManifest).not.toContain("gh release edit");
+    expect(desktopPromote).toContain("needs.manifest.result == 'success'");
+    expect(desktopPromote).toContain('gh release edit "$RELEASE_REF" --latest');
+    expect(
+      desktopCarry.indexOf("Verify production serves the release commit"),
+    ).toBeGreaterThan(desktopCarry.indexOf('gh release upload "$RELEASE_REF"'));
+    expect(desktopCarry.indexOf("Promote release to latest")).toBeGreaterThan(
+      desktopCarry.indexOf("Verify production web serves the release commit"),
     );
   });
 

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -237,12 +237,14 @@ describe("API deployment health receipt", () => {
     expect(desktopManifest).toContain(
       "needs.verify-production.result == 'success'",
     );
+    expect(desktopManifest).toContain("needs.build.result == 'success'");
     expect(desktopManifest).not.toContain("gh release edit");
     expect(desktopPromote).toContain("needs.manifest.result == 'success'");
     expect(desktopPromote).toContain('gh release edit "$RELEASE_REF" --latest');
     expect(
       desktopCarry.indexOf("Verify production serves the release commit"),
     ).toBeGreaterThan(desktopCarry.indexOf('gh release upload "$RELEASE_REF"'));
+    expect(desktopCarry).toContain("timeout-minutes: 15");
     expect(desktopCarry.indexOf("Promote release to latest")).toBeGreaterThan(
       desktopCarry.indexOf("Verify production web serves the release commit"),
     );


### PR DESCRIPTION
Release publication now waits for successful production verification before advancing public latest-release pointers. Stable desktop manifests and GitHub latest-release state are gated on the deployed API and web commit receipts; manual runs retain the same verification boundary.

CC on behalf of jan-kubica