### PR TITLE
fix(api): keep anonymized DOCX change authors visible

### DIFF
--- a/apps/api/src/lib/files/document-properties.test.ts
+++ b/apps/api/src/lib/files/document-properties.test.ts
@@ -340,15 +340,21 @@ describe("scrubDocumentProperties", () => {
     assertNoTrace(result, ["Jane Novak", "Nov&#225;k Legal"]);
   });
 
-  it("keeps typed OOXML metadata schema-valid while removing its values", async () => {
+  it("keeps typed OOXML collaboration metadata schema-valid and anonymous", async () => {
     const comments =
       '<x:comments xmlns:x="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
       '<x:comment x:author="Jane Novak" x:initials="JN" x:date="2024-01-01T00:00:00Z"/></x:comments>';
+    const document =
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p>' +
+      '<w:ins w:id="1" w:author="Jane Novak" w:date="2024-01-01T00:00:00Z"><w:r><w:t>added</w:t></w:r></w:ins>' +
+      '<w:del w:id="2" w:author="Jane Novak" w:date="2024-01-01T00:00:00Z"><w:r><w:delText>deleted</w:delText></w:r></w:del>' +
+      "</w:p></w:body></w:document>";
     const result = await scrubbed(
       await zipOf({
         "docProps/core.xml": CORE_XML,
         "docProps/app.xml": APP_XML,
         "word/comments.xml": comments,
+        "word/document.xml": document,
       }),
       DOCX_MIME_TYPE,
     );
@@ -359,13 +365,18 @@ describe("scrubDocumentProperties", () => {
     const scrubbedComments = await archive
       .file("word/comments.xml")
       ?.async("string");
+    const scrubbedDocument = await archive
+      .file("word/document.xml")
+      ?.async("string");
 
     expect(core).not.toMatch(
       /<(?:cp:revision|cp:lastPrinted|dcterms:(?:created|modified))\b/u,
     );
-    expect(scrubbedComments).toContain('x:author=""');
+    expect(scrubbedComments).toContain('x:author="Author"');
     expect(scrubbedComments).toContain('x:initials=""');
     expect(scrubbedComments).not.toMatch(/x:date=/u);
+    expect(scrubbedDocument?.match(/w:author="Author"/gu)).toHaveLength(2);
+    expect(scrubbedDocument).not.toMatch(/w:date=/u);
   });
 
   it("clears the OpenDocument meta part, statistics included", async () => {

--- a/apps/api/src/lib/files/document-properties.ts
+++ b/apps/api/src/lib/files/document-properties.ts
@@ -632,19 +632,21 @@ const scrubCustomProperties = (xml: string): string =>
   );
 
 type CollaborationAttributePolicies = {
-  author: "clear";
+  author: "anonymize";
   date: "remove";
   initials: "clear";
   providerId: "remove";
   userId: "remove";
 };
 
+const ANONYMIZED_COLLABORATION_AUTHOR = "Author";
+
 /**
- * A closed policy keeps schema-required authors present while making it
- * impossible to blank typed or optional collaboration attributes.
+ * A closed policy keeps schema-required author attributes usable while making
+ * it impossible to preserve typed or optional collaboration attributes.
  */
 const COLLABORATION_ATTRIBUTE_POLICIES = {
-  author: "clear",
+  author: "anonymize",
   date: "remove",
   initials: "clear",
   userId: "remove",
@@ -666,14 +668,24 @@ const removeNamespacedAttribute = (
   return scrubbed;
 };
 
-const clearNamespacedAttribute = (xml: string, element: XmlElement): string => {
+type ReplaceNamespacedAttributeOptions = {
+  element: XmlElement;
+  replacement: "" | typeof ANONYMIZED_COLLABORATION_AUTHOR;
+  xml: string;
+};
+
+const replaceNamespacedAttribute = ({
+  element,
+  replacement,
+  xml,
+}: ReplaceNamespacedAttributeOptions): string => {
   let scrubbed = xml;
   for (const name of qualifiedNames(xml, element)) {
-    const regex = new RegExp(
-      `(?<prefix>\\s${name}\\s*=\\s*)(?<quote>["'])[^"']*\\k<quote>`,
-      "gu",
+    const regex = new RegExp(`(\\s${name}\\s*=\\s*)(["'])[^"']*\\2`, "gu");
+    scrubbed = scrubbed.replace(
+      regex,
+      (_attribute, prefix) => `${prefix}"${replacement}"`,
     );
-    scrubbed = scrubbed.replace(regex, '$<prefix>""');
   }
   return scrubbed;
 };
@@ -686,8 +698,19 @@ const scrubCollaborationAttributes = (xml: string): string => {
     )) {
       const element = { namespace, localName };
       switch (action) {
+        case "anonymize":
+          scrubbed = replaceNamespacedAttribute({
+            element,
+            replacement: ANONYMIZED_COLLABORATION_AUTHOR,
+            xml: scrubbed,
+          });
+          break;
         case "clear":
-          scrubbed = clearNamespacedAttribute(scrubbed, element);
+          scrubbed = replaceNamespacedAttribute({
+            element,
+            replacement: "",
+            xml: scrubbed,
+          });
           break;
         case "remove":
           scrubbed = removeNamespacedAttribute(scrubbed, element);


### PR DESCRIPTION
DOCX metadata scrubbing now replaces collaboration author names with the neutral Author label instead of an empty value. This keeps Word comments and tracked changes usable without retaining the original author identity.

Regression coverage includes comments plus tracked insertions and deletions, while confirming timestamps and initials remain scrubbed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy scrubbing for Word collaboration metadata.
  * Anonymised tracked insertions and deletions with a generic author name.
  * Removed dates and user-identifying details while clearing initials.
  * Preserved schema validity for documents containing tracked changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->