### PR TITLE
chore: clean up pre-playbook controls and copy

### DIFF
--- a/apps/web/src/components/dev-sidebar-group.tsx
+++ b/apps/web/src/components/dev-sidebar-group.tsx
@@ -13,11 +13,7 @@ import { useShallow } from "zustand/react/shallow";
 
 import {
   MenuCheckboxItem,
-  MenuGroup,
-  MenuGroupLabel,
   MenuItem,
-  MenuRadioGroup,
-  MenuRadioItem,
   MenuSeparator,
   MenuSub,
   MenuSubPopup,
@@ -25,34 +21,9 @@ import {
 } from "@stll/ui/components/menu";
 import { stellaToast } from "@stll/ui/components/toast";
 
-import {
-  encodeModelSelection,
-  MODEL_OPTIONS_BY_PROVIDER,
-  PROVIDER_KEYS,
-  PROVIDER_LABELS,
-} from "@/components/ai-config-role-models.logic";
 import { api } from "@/lib/api";
 import { detached } from "@/lib/detached";
 import { useDevStore } from "@/lib/dev-store";
-
-/**
- * Options for the dev-only chat-model override.
- *
- * Sourced from MODEL_OPTIONS_BY_PROVIDER — the same catalog the org
- * BYOK picker uses — so this list never drifts from the real model
- * catalog. Values carry the provider so the API routes the override
- * through the matching model factory instead of the active provider.
- */
-const CHAT_MODELS: { value: string; label: string }[] = [
-  // Empty value falls through to getModelForRole("chat") on the API.
-  { value: "", label: "Default (chat role)" },
-  ...PROVIDER_KEYS.flatMap((provider) =>
-    MODEL_OPTIONS_BY_PROVIDER[provider].map((modelId) => ({
-      value: encodeModelSelection({ provider, modelId }),
-      label: `${PROVIDER_LABELS[provider]} · ${modelId}`,
-    })),
-  ),
-];
 
 const SEED_STATUS_POLL_INTERVAL_MS = 1000;
 const SEED_STATUS_MAX_POLLS = 180;
@@ -130,8 +101,6 @@ export const DevSidebarGroup = () => {
       setTanstackDevtools: s.setTanstackDevtools,
       sourceInspector: s.sourceInspector,
       setSourceInspector: s.setSourceInspector,
-      chatModelId: s.chatModelId,
-      setChatModelId: s.setChatModelId,
       reactGrab: s.reactGrab,
       setReactGrab: s.setReactGrab,
       publicLawPreview: s.publicLawPreview,
@@ -311,21 +280,6 @@ export const DevSidebarGroup = () => {
         >
           Simulate slow load
         </MenuCheckboxItem>
-        <MenuSeparator />
-        <MenuGroup>
-          <MenuGroupLabel>Chat Model</MenuGroupLabel>
-          <MenuRadioGroup value={dev.chatModelId ?? ""}>
-            {CHAT_MODELS.map((m) => (
-              <MenuRadioItem
-                key={m.value}
-                onClick={() => dev.setChatModelId(m.value || null)}
-                value={m.value}
-              >
-                {m.label}
-              </MenuRadioItem>
-            ))}
-          </MenuRadioGroup>
-        </MenuGroup>
         <MenuSeparator />
         <MenuItem
           disabled={seeding}

--- a/apps/web/src/features/chat/queries.ts
+++ b/apps/web/src/features/chat/queries.ts
@@ -46,7 +46,6 @@ import type { ChatThreadId, ChatThreadRef } from "@/lib/chat-thread-ref";
 import { getChatThreadKey, toChatThreadId } from "@/lib/chat-thread-ref";
 import { STALE_TIME } from "@/lib/consts";
 import { detached } from "@/lib/detached";
-import { useDevStore } from "@/lib/dev-store";
 import { APIError, toAPIError, unwrapEden } from "@/lib/errors/api";
 import { ClientOperationError } from "@/lib/errors/client";
 import { fetchWithTimeout } from "@/lib/fetch";
@@ -1368,13 +1367,6 @@ export const buildSendRequestBody = ({
           : { docxEditRepresentation }),
       },
     };
-  }
-
-  if (import.meta.env.DEV) {
-    const devModelId = useDevStore.getState().chatModelId;
-    if (devModelId) {
-      body.devModelId = devModelId;
-    }
   }
 
   if (run.resume === undefined) {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -3989,14 +3989,14 @@
           "trigger": "Spustil(a)",
           "webhook": "Webové volání"
         },
-        "empty": "V této věci zatím není žádná aktivita.",
+        "empty": "V tomto spisu zatím není žádná aktivita.",
         "filterLabel": "Filtrovat aktivitu",
         "filters": {
           "all": "Veškerá aktivita",
           "automation": "Automatizace",
           "court": "Soud",
           "documents": "Dokumenty",
-          "matter": "Věc",
+          "matter": "Údaje spisu",
           "tasks": "Položky agendy",
           "team": "Tým"
         },
@@ -4028,9 +4028,9 @@
           "automation": "automatizace",
           "court": "soudní záznam",
           "document": "dokument",
-          "matter": "věc",
+          "matter": "spis",
           "task": "položka agendy",
-          "team": "tým věci"
+          "team": "tým spisu"
         },
         "title": "Aktivita",
         "views": {

--- a/apps/web/src/lib/dev-store.ts
+++ b/apps/web/src/lib/dev-store.ts
@@ -7,7 +7,6 @@ import { getStorageKey } from "@/consts";
 type State = {
   tanstackDevtools: boolean;
   sourceInspector: boolean;
-  chatModelId: string | null;
   reactGrab: boolean;
   publicLawPreview: boolean;
   playbooksPreview: boolean;
@@ -20,7 +19,6 @@ type State = {
 type Actions = {
   setTanstackDevtools: (value: boolean) => void;
   setSourceInspector: (value: boolean) => void;
-  setChatModelId: (value: string | null) => void;
   setReactGrab: (value: boolean) => void;
   setPublicLawPreview: (value: boolean) => void;
   setPlaybooksPreview: (value: boolean) => void;
@@ -41,7 +39,6 @@ export const useDevStore = create<State & Actions>()(
     (set) => ({
       tanstackDevtools: false,
       sourceInspector: false,
-      chatModelId: null,
       reactGrab: false,
       publicLawPreview: false,
       playbooksPreview: false,
@@ -55,9 +52,6 @@ export const useDevStore = create<State & Actions>()(
       },
       setSourceInspector: (sourceInspector) => {
         set({ sourceInspector });
-      },
-      setChatModelId: (chatModelId) => {
-        set({ chatModelId });
       },
       setReactGrab: (reactGrab) => {
         set({ reactGrab });


### PR DESCRIPTION
## Summary

- remove the obsolete development-only chat model selector and request override
- align Czech matter activity copy with the established “spis” terminology
- keep the API evaluation override used by the existing evaluation script intact

## Verification

- bun run verify
- pre-push affected lint, typecheck, formatting, and i18n checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed the development-only chat model override controls from the sidebar.
  * Chat requests no longer use development-only model overrides.
  * Simplified development settings while retaining other available options.
* **Language**
  * Improved Czech translations by using more accurate “spis” terminology for activity states, matter filters, matter targets and team targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->