### PR TITLE
fix(web): enforce runtime asset contracts

### DIFF
--- a/apps/web/scripts/assert-start-runtime-build.ts
+++ b/apps/web/scripts/assert-start-runtime-build.ts
@@ -1,38 +1,324 @@
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const WEB_ROOT_URL = new URL("../", import.meta.url);
 const WEB_ROOT_PATH = fileURLToPath(WEB_ROOT_URL);
+const CLIENT_ROOT_PATH = fileURLToPath(new URL("dist/client/", WEB_ROOT_URL));
+
+type RuntimeAssetContract = {
+  expectedCount: number;
+  label: string;
+  pattern: string;
+  sourceEntry?: string;
+};
+
+// Every emitted worker/WASM asset must belong to this total registry. The
+// source-entry check below derives first-party worker entries from application
+// code, while the emitted-asset check rejects unregistered dependency workers
+// and WASM sidecars. A new runtime asset therefore cannot silently bypass the
+// production build contract.
+const RUNTIME_ASSET_CONTRACTS = [
+  {
+    expectedCount: 1,
+    label: "PDF.js worker",
+    pattern: "dist/client/assets/pdfjs-worker-????????.js",
+    sourceEntry: "src/lib/pdf/pdfjs-worker.ts",
+  },
+  {
+    expectedCount: 1,
+    label: "PDF search worker",
+    pattern: "dist/client/assets/pdf-search-worker-????????.js",
+    sourceEntry: "src/workers/pdf-search-worker.ts",
+  },
+  {
+    expectedCount: 1,
+    label: "chat anonymization worker",
+    pattern: "dist/client/assets/anonymize-chat-worker-????????.js",
+    sourceEntry: "src/workers/anonymize-chat-worker.ts",
+  },
+  {
+    expectedCount: 2,
+    label: "Office render workers",
+    pattern: "dist/client/assets/render-worker-host-*.js",
+  },
+  {
+    expectedCount: 1,
+    label: "Office font metrics worker",
+    pattern: "dist/client/assets/font-metrics.worker-????????.js",
+  },
+  {
+    expectedCount: 1,
+    label: "XLSX parser WASM",
+    pattern: "dist/client/assets/xlsx_parser_bg-????????.wasm",
+  },
+  {
+    expectedCount: 1,
+    label: "PPTX parser WASM",
+    pattern: "dist/client/assets/pptx_parser_bg-????????.wasm",
+  },
+  {
+    expectedCount: 1,
+    label: "anonymization WASM glue",
+    pattern: "dist/client/native/index.js",
+  },
+  {
+    expectedCount: 1,
+    label: "anonymization WASM binary",
+    pattern: "dist/client/native/index_bg.wasm",
+  },
+] as const satisfies readonly RuntimeAssetContract[];
+
+const hasPDFWorkerFallbackContract = (
+  value: unknown,
+): value is {
+  WorkerMessageHandler: { setup: (...args: unknown[]) => unknown };
+} => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  if (!("WorkerMessageHandler" in value)) {
+    return false;
+  }
+  const handler = value.WorkerMessageHandler;
+  return (
+    typeof handler === "function" &&
+    "setup" in handler &&
+    typeof handler.setup === "function"
+  );
+};
+
+const isNonEmptyFile = async (relativePath: string): Promise<boolean> => {
+  const file = Bun.file(new URL(relativePath, WEB_ROOT_URL));
+  return (await file.exists()) && file.size > 0;
+};
+
+const toWebRelativePath = (url: URL): string =>
+  path.relative(WEB_ROOT_PATH, fileURLToPath(url));
+
+const discoverSourceWorkerEntries = async (): Promise<Set<string>> => {
+  const sourceFiles = new Bun.Glob("src/**/*.{ts,tsx}");
+  const entries = new Set<string>();
+  const directWorkerPattern =
+    /new Worker\s*\(\s*new URL\(\s*["']([^"']+\.ts)["']\s*,\s*import\.meta\.url\s*\)/gu;
+  const workerUrlImportPattern = /from\s*["']([^"']+)\?worker&url["']/gu;
+
+  for await (const sourcePath of sourceFiles.scan({ cwd: WEB_ROOT_PATH })) {
+    const sourceUrl = new URL(sourcePath, WEB_ROOT_URL);
+    const source = await Bun.file(sourceUrl).text();
+    for (const pattern of [directWorkerPattern, workerUrlImportPattern]) {
+      pattern.lastIndex = 0;
+      for (const match of source.matchAll(pattern)) {
+        const specifier = match[1];
+        if (specifier !== undefined) {
+          const sourceSpecifier = specifier.endsWith(".ts")
+            ? specifier
+            : `${specifier}.ts`;
+          entries.add(toWebRelativePath(new URL(sourceSpecifier, sourceUrl)));
+        }
+      }
+    }
+  }
+
+  return entries;
+};
+
+const assetReferencePatterns = [
+  /(?:from\s*|import\s*\(\s*|import\s*)["'`]([^"'`]+)["'`]/gu,
+  /new URL\(\s*(["'`])([^"'`]+)\1\s*,[^)]{0,64}import\.meta\.url\s*\)/gu,
+] as const;
+
+const referencedAssetPath = (
+  emittedPath: string,
+  reference: string,
+): string | undefined => {
+  const cleanReference = reference.split(/[?#]/u).at(0);
+  if (cleanReference === undefined || !/\.(?:js|wasm)$/u.test(cleanReference)) {
+    return undefined;
+  }
+
+  const targetUrl = cleanReference.startsWith("/")
+    ? new URL(`dist/client${cleanReference}`, WEB_ROOT_URL)
+    : new URL(cleanReference, new URL(emittedPath, WEB_ROOT_URL));
+  const targetPath = fileURLToPath(targetUrl);
+  const relativeToClient = path.relative(CLIENT_ROOT_PATH, targetPath);
+  if (relativeToClient.startsWith("..") || path.isAbsolute(relativeToClient)) {
+    return undefined;
+  }
+
+  return toWebRelativePath(targetUrl);
+};
 
 const requiredFiles = [
   "dist/server/server.js",
   "dist/client/prepaint-init.js",
 ] as const;
+const contractErrors: string[] = [];
 
-const requiredFileExistence = await Promise.all(
-  requiredFiles.map(
-    async (path) => await Bun.file(new URL(path, WEB_ROOT_URL)).exists(),
-  ),
+const requiredFileChecks = await Promise.all(
+  requiredFiles.map(async (requiredFile) => ({
+    exists: await isNonEmptyFile(requiredFile),
+    requiredFile,
+  })),
 );
-const missingPaths: string[] = requiredFiles.filter(
-  (_, index) => !requiredFileExistence[index],
-);
+for (const { exists, requiredFile } of requiredFileChecks) {
+  if (!exists) {
+    contractErrors.push(`missing or empty ${requiredFile}`);
+  }
+}
 
 const clientAssetGlob = new Bun.Glob("dist/client/assets/*");
 const firstClientAsset = await clientAssetGlob
   .scan({ cwd: WEB_ROOT_PATH })
   .next();
-const hasClientAsset = !firstClientAsset.done;
-
-if (!hasClientAsset) {
-  missingPaths.push("dist/client/assets/*");
+if (firstClientAsset.done) {
+  contractErrors.push("missing dist/client/assets/*");
 }
 
-if (missingPaths.length > 0) {
+const discoveredSourceEntries = await discoverSourceWorkerEntries();
+const declaredSourceEntries = new Set<string>(
+  RUNTIME_ASSET_CONTRACTS.flatMap((contract) =>
+    "sourceEntry" in contract ? [contract.sourceEntry] : [],
+  ),
+);
+for (const entry of discoveredSourceEntries) {
+  if (!declaredSourceEntries.has(entry)) {
+    contractErrors.push(`worker source has no runtime contract: ${entry}`);
+  }
+}
+for (const entry of declaredSourceEntries) {
+  if (!discoveredSourceEntries.has(entry)) {
+    contractErrors.push(`runtime contract has no worker source: ${entry}`);
+  }
+}
+
+const claimedRuntimeAssets = new Set<string>();
+const contractAssets = new Map<string, readonly string[]>();
+const matchedContracts = await Promise.all(
+  RUNTIME_ASSET_CONTRACTS.map(async (contract) => ({
+    contract,
+    matches: await Array.fromAsync(
+      new Bun.Glob(contract.pattern).scan({ cwd: WEB_ROOT_PATH }),
+    ),
+  })),
+);
+for (const { contract, matches } of matchedContracts) {
+  contractAssets.set(contract.label, matches);
+  if (matches.length !== contract.expectedCount) {
+    contractErrors.push(
+      `${contract.label} expected ${contract.expectedCount} asset(s), found ${matches.length}: ${contract.pattern}`,
+    );
+  }
+  for (const match of matches) {
+    claimedRuntimeAssets.add(match);
+  }
+}
+const claimedAssetChecks = await Promise.all(
+  matchedContracts.flatMap(({ contract, matches }) =>
+    matches.map(async (match) => ({
+      contract,
+      exists: await isNonEmptyFile(match),
+      match,
+    })),
+  ),
+);
+for (const { contract, exists, match } of claimedAssetChecks) {
+  if (!exists) {
+    contractErrors.push(`${contract.label} is empty: ${match}`);
+  }
+}
+
+const emittedFiles = await Array.fromAsync(
+  new Bun.Glob("dist/client/**/*").scan({ cwd: WEB_ROOT_PATH }),
+);
+const emittedRuntimeAssets = emittedFiles.filter((emittedPath) => {
+  if (emittedPath.endsWith(".wasm")) {
+    return true;
+  }
+  const fileName = path.basename(emittedPath);
+  return (
+    emittedPath.endsWith(".js") &&
+    fileName.includes("worker") &&
+    !fileName.includes("worker-client")
+  );
+});
+for (const emittedPath of emittedRuntimeAssets) {
+  if (!claimedRuntimeAssets.has(emittedPath)) {
+    contractErrors.push(`emitted runtime asset is unclaimed: ${emittedPath}`);
+  }
+}
+
+const emittedJavaScript = emittedFiles.filter((emittedPath) =>
+  emittedPath.endsWith(".js"),
+);
+const emittedJavaScriptSources = await Promise.all(
+  emittedJavaScript.map(async (emittedPath) => ({
+    emittedPath,
+    source: await Bun.file(new URL(emittedPath, WEB_ROOT_URL)).text(),
+  })),
+);
+const assetReferences = new Map<string, string>();
+for (const { emittedPath, source } of emittedJavaScriptSources) {
+  for (const pattern of assetReferencePatterns) {
+    pattern.lastIndex = 0;
+    for (const match of source.matchAll(pattern)) {
+      const reference = match.at(-1);
+      if (reference === undefined) {
+        continue;
+      }
+      const targetPath = referencedAssetPath(emittedPath, reference);
+      if (targetPath) {
+        assetReferences.set(targetPath, emittedPath);
+      }
+    }
+  }
+}
+const assetReferenceChecks = await Promise.all(
+  [...assetReferences].map(async ([targetPath, emittedPath]) => ({
+    emittedPath,
+    exists: await isNonEmptyFile(targetPath),
+    targetPath,
+  })),
+);
+for (const { emittedPath, exists, targetPath } of assetReferenceChecks) {
+  if (!exists) {
+    contractErrors.push(
+      `${emittedPath} references missing or empty ${targetPath}`,
+    );
+  }
+}
+
+const pdfWorkerAsset = contractAssets.get("PDF.js worker")?.at(0);
+if (pdfWorkerAsset !== undefined) {
+  const workerModule: unknown = await import(
+    new URL(pdfWorkerAsset, WEB_ROOT_URL).href
+  );
+  if (!hasPDFWorkerFallbackContract(workerModule)) {
+    contractErrors.push(
+      `${pdfWorkerAsset} does not export WorkerMessageHandler.setup`,
+    );
+  }
+}
+
+const anonymizationWorkerAsset = contractAssets
+  .get("chat anonymization worker")
+  ?.at(0);
+if (anonymizationWorkerAsset !== undefined) {
+  const source = await Bun.file(
+    new URL(anonymizationWorkerAsset, WEB_ROOT_URL),
+  ).text();
+  if (!source.includes("/native/index.js")) {
+    contractErrors.push(
+      `${anonymizationWorkerAsset} does not anchor its runtime at /native/index.js`,
+    );
+  }
+}
+
+if (contractErrors.length > 0) {
   console.error(
     [
       "TanStack Start runtime build contract failed.",
-      "The deploy pipeline expects a server bundle plus client assets.",
-      ...missingPaths.map((path) => `Missing: apps/web/${path}`),
+      "The deploy pipeline expects a complete, loadable production asset graph.",
+      ...contractErrors.map((error) => `Invalid: ${error}`),
     ].join("\n"),
   );
   process.exit(1);

--- a/apps/web/scripts/assert-start-runtime-build.ts
+++ b/apps/web/scripts/assert-start-runtime-build.ts
@@ -1,9 +1,15 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  referencedAssetPath,
+  resolveSourceWorkerEntry,
+  SOURCE_WORKER_FILE_GLOB,
+  workerSourceSpecifiers,
+} from "./runtime-asset-contracts";
+
 const WEB_ROOT_URL = new URL("../", import.meta.url);
 const WEB_ROOT_PATH = fileURLToPath(WEB_ROOT_URL);
-const CLIENT_ROOT_PATH = fileURLToPath(new URL("dist/client/", WEB_ROOT_URL));
 
 type RuntimeAssetContract = {
   expectedCount: number;
@@ -92,29 +98,18 @@ const isNonEmptyFile = async (relativePath: string): Promise<boolean> => {
   return (await file.exists()) && file.size > 0;
 };
 
-const toWebRelativePath = (url: URL): string =>
-  path.relative(WEB_ROOT_PATH, fileURLToPath(url));
-
 const discoverSourceWorkerEntries = async (): Promise<Set<string>> => {
-  const sourceFiles = new Bun.Glob("src/**/*.{ts,tsx}");
+  const sourceFiles = new Bun.Glob(SOURCE_WORKER_FILE_GLOB);
   const entries = new Set<string>();
-  const directWorkerPattern =
-    /new Worker\s*\(\s*new URL\(\s*["']([^"']+\.ts)["']\s*,\s*import\.meta\.url\s*\)/gu;
-  const workerUrlImportPattern = /from\s*["']([^"']+)\?worker&url["']/gu;
 
   for await (const sourcePath of sourceFiles.scan({ cwd: WEB_ROOT_PATH })) {
     const sourceUrl = new URL(sourcePath, WEB_ROOT_URL);
     const source = await Bun.file(sourceUrl).text();
-    for (const pattern of [directWorkerPattern, workerUrlImportPattern]) {
-      pattern.lastIndex = 0;
-      for (const match of source.matchAll(pattern)) {
-        const specifier = match[1];
-        if (specifier !== undefined) {
-          const sourceSpecifier = specifier.endsWith(".ts")
-            ? specifier
-            : `${specifier}.ts`;
-          entries.add(toWebRelativePath(new URL(sourceSpecifier, sourceUrl)));
-        }
+    for (const specifier of workerSourceSpecifiers(source)) {
+      // oxlint-disable-next-line no-await-in-loop -- ordered source discovery resolves extensionless Vite imports against the filesystem
+      const entry = await resolveSourceWorkerEntry(specifier, sourceUrl);
+      if (entry !== undefined) {
+        entries.add(entry);
       }
     }
   }
@@ -126,27 +121,6 @@ const assetReferencePatterns = [
   /(?:from\s*|import\s*\(\s*|import\s*)["'`]([^"'`]+)["'`]/gu,
   /new URL\(\s*(["'`])([^"'`]+)\1\s*,[^)]{0,64}import\.meta\.url\s*\)/gu,
 ] as const;
-
-const referencedAssetPath = (
-  emittedPath: string,
-  reference: string,
-): string | undefined => {
-  const cleanReference = reference.split(/[?#]/u).at(0);
-  if (cleanReference === undefined || !/\.(?:js|wasm)$/u.test(cleanReference)) {
-    return undefined;
-  }
-
-  const targetUrl = cleanReference.startsWith("/")
-    ? new URL(`dist/client${cleanReference}`, WEB_ROOT_URL)
-    : new URL(cleanReference, new URL(emittedPath, WEB_ROOT_URL));
-  const targetPath = fileURLToPath(targetUrl);
-  const relativeToClient = path.relative(CLIENT_ROOT_PATH, targetPath);
-  if (relativeToClient.startsWith("..") || path.isAbsolute(relativeToClient)) {
-    return undefined;
-  }
-
-  return toWebRelativePath(targetUrl);
-};
 
 const requiredFiles = [
   "dist/server/server.js",

--- a/apps/web/scripts/runtime-asset-contracts.test.ts
+++ b/apps/web/scripts/runtime-asset-contracts.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  referencedAssetPath,
+  resolveSourceWorkerEntry,
+  workerSourceSpecifiers,
+} from "./runtime-asset-contracts";
+
+describe("runtime asset contracts", () => {
+  test("discovers every supported Vite worker form", () => {
+    const source = `
+      new Worker(new URL("./classic.js", import.meta.url));
+      new Worker(new URL("./common.cts", import.meta.url));
+      new SharedWorker(new URL("@/workers/shared.mts", import.meta.url));
+      import worker from "./default?worker";
+      import inlineWorker from "./inline?worker&inline";
+      import workerUrl from "@/workers/url?worker&url";
+      import sharedWorkerUrl from "./shared?sharedworker&url";
+    `;
+
+    expect(workerSourceSpecifiers(source)).toEqual([
+      "./classic.js",
+      "./common.cts",
+      "@/workers/shared.mts",
+      "./default",
+      "./inline",
+      "@/workers/url",
+      "./shared",
+    ]);
+  });
+
+  test("resolves aliases and ignores bare package worker imports", async () => {
+    const sourceUrl = new URL(
+      "../src/lib/pdf/pdfjs-loader.ts",
+      import.meta.url,
+    );
+
+    expect(await resolveSourceWorkerEntry("./pdfjs-worker", sourceUrl)).toBe(
+      "src/lib/pdf/pdfjs-worker.ts",
+    );
+    expect(
+      await resolveSourceWorkerEntry(
+        "@/workers/pdf-search-worker.ts",
+        sourceUrl,
+      ),
+    ).toBe("src/workers/pdf-search-worker.ts");
+    expect(
+      await resolveSourceWorkerEntry("dependency/worker.js", sourceUrl),
+    ).toBeUndefined();
+  });
+
+  test("keeps emitted graph checks inside the client build", () => {
+    expect(
+      referencedAssetPath(
+        "dist/client/assets/entry.js",
+        "https://cdn.example.com/worker.js",
+      ),
+    ).toBeUndefined();
+    expect(
+      referencedAssetPath(
+        "dist/client/assets/entry.js",
+        "data:application/javascript,worker.js",
+      ),
+    ).toBeUndefined();
+    expect(
+      referencedAssetPath(
+        "dist/client/assets/entry.js",
+        "//cdn.example.com/worker.js",
+      ),
+    ).toBeUndefined();
+    expect(
+      referencedAssetPath(
+        "dist/client/assets/entry.js",
+        "./worker-abcd1234.js",
+      ),
+    ).toBe("dist/client/assets/worker-abcd1234.js");
+    expect(
+      referencedAssetPath("dist/client/assets/entry.js", "/native/index.wasm"),
+    ).toBe("dist/client/native/index.wasm");
+  });
+});

--- a/apps/web/scripts/runtime-asset-contracts.ts
+++ b/apps/web/scripts/runtime-asset-contracts.ts
@@ -1,0 +1,118 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const WEB_ROOT_URL = new URL("../", import.meta.url);
+const WEB_ROOT_PATH = fileURLToPath(WEB_ROOT_URL);
+const SOURCE_ROOT_URL = new URL("src/", WEB_ROOT_URL);
+const CLIENT_ROOT_PATH = fileURLToPath(new URL("dist/client/", WEB_ROOT_URL));
+const SOURCE_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mts",
+  ".mjs",
+  ".cts",
+  ".cjs",
+] as const;
+const SOURCE_EXTENSION_PATTERN = /\.(?:[cm]?[jt]sx?)$/u;
+const DIRECT_WORKER_PATTERN =
+  /new\s+(?:Shared)?Worker\s*\(\s*new URL\(\s*["']([^"']+\.(?:[cm]?[jt]sx?))["']\s*,\s*import\.meta\.url\s*\)/gu;
+const WORKER_URL_IMPORT_PATTERN =
+  /from\s*["']([^"'?]+)\?(?:shared)?worker(?:&(?:inline|url))?["']/gu;
+const URL_SCHEME_PATTERN = /^[a-z][a-z\d+.-]*:/iu;
+
+export const SOURCE_WORKER_FILE_GLOB =
+  "src/**/*.{cjs,cts,js,jsx,mjs,mts,ts,tsx}";
+
+const toWebRelativePath = (url: URL): string =>
+  path.relative(WEB_ROOT_PATH, fileURLToPath(url));
+
+export const workerSourceSpecifiers = (source: string): readonly string[] => {
+  const specifiers = new Set<string>();
+
+  for (const pattern of [DIRECT_WORKER_PATTERN, WORKER_URL_IMPORT_PATTERN]) {
+    pattern.lastIndex = 0;
+    for (const match of source.matchAll(pattern)) {
+      const specifier = match[1];
+      if (specifier !== undefined) {
+        specifiers.add(specifier);
+      }
+    }
+  }
+
+  return [...specifiers];
+};
+
+const sourceSpecifierUrl = (
+  specifier: string,
+  sourceUrl: URL,
+): URL | undefined => {
+  if (specifier.startsWith("@/")) {
+    return new URL(specifier.slice(2), SOURCE_ROOT_URL);
+  }
+  if (specifier.startsWith("/")) {
+    return new URL(specifier.slice(1), WEB_ROOT_URL);
+  }
+  if (!specifier.startsWith(".")) {
+    return undefined;
+  }
+  return new URL(specifier, sourceUrl);
+};
+
+export const resolveSourceWorkerEntry = async (
+  specifier: string,
+  sourceUrl: URL,
+): Promise<string | undefined> => {
+  const targetUrl = sourceSpecifierUrl(specifier, sourceUrl);
+  if (targetUrl === undefined) {
+    return undefined;
+  }
+  if (SOURCE_EXTENSION_PATTERN.test(targetUrl.pathname)) {
+    return toWebRelativePath(targetUrl);
+  }
+
+  const candidates = await Promise.all(
+    SOURCE_EXTENSIONS.map(async (extension) => {
+      const candidateUrl = new URL(`${targetUrl.href}${extension}`);
+      return {
+        candidateUrl,
+        exists: await Bun.file(candidateUrl).exists(),
+      };
+    }),
+  );
+  const resolvedCandidate = candidates.find(({ exists }) => exists);
+  if (resolvedCandidate !== undefined) {
+    return toWebRelativePath(resolvedCandidate.candidateUrl);
+  }
+
+  // Keep an unresolved local specifier visible to the total registry check.
+  return toWebRelativePath(new URL(`${targetUrl.href}.ts`));
+};
+
+export const referencedAssetPath = (
+  emittedPath: string,
+  reference: string,
+): string | undefined => {
+  const cleanReference = reference.split(/[?#]/u).at(0);
+  if (cleanReference === undefined || !/\.(?:js|wasm)$/u.test(cleanReference)) {
+    return undefined;
+  }
+  if (
+    URL_SCHEME_PATTERN.test(cleanReference) ||
+    cleanReference.startsWith("//")
+  ) {
+    return undefined;
+  }
+
+  const targetUrl = cleanReference.startsWith("/")
+    ? new URL(`dist/client${cleanReference}`, WEB_ROOT_URL)
+    : new URL(cleanReference, new URL(emittedPath, WEB_ROOT_URL));
+  const targetPath = fileURLToPath(targetUrl);
+  const relativeToClient = path.relative(CLIENT_ROOT_PATH, targetPath);
+  if (relativeToClient.startsWith("..") || path.isAbsolute(relativeToClient)) {
+    return undefined;
+  }
+
+  return toWebRelativePath(targetUrl);
+};

--- a/apps/web/src/components/inspector/file-tab-panel.tsx
+++ b/apps/web/src/components/inspector/file-tab-panel.tsx
@@ -835,12 +835,7 @@ export const FileTabPanel = ({
   );
 
   const viewerErrorFallback = ({ reset }: { reset: () => void }) => (
-    <InspectorPdfErrorFallback
-      onClose={() => {
-        handleCloseTab(tab.id);
-      }}
-      onRetry={reset}
-    />
+    <InspectorPdfErrorFallback onRetry={reset} />
   );
 
   const handleViewerError = () => {
@@ -1308,26 +1303,24 @@ export const FileTabPanel = ({
           {sidepeekContent}
         </>
       ) : (
-        <MeasuredPdfProvider
-          active={isActive}
-          fallback={{
-            suspense: <PeekSuspenseFallback />,
-            error: (
-              <InspectorPdfErrorFallback
-                onClose={() => {
-                  handleCloseTab(tab.id);
-                }}
-              />
-            ),
-          }}
-          fieldId={tab.id}
-          initialScaleOffset={scaleOffsets.get(tab.id) ?? 0}
-          onError={handleViewerError}
-        >
+        <>
           {contextBar}
           {facetBar}
-          {sidepeekContent}
-        </MeasuredPdfProvider>
+          <div className="min-h-0 min-w-0 flex-1">
+            <MeasuredPdfProvider
+              active={isActive}
+              fallback={{
+                suspense: <PeekSuspenseFallback />,
+                error: <InspectorPdfErrorFallback />,
+              }}
+              fieldId={tab.id}
+              initialScaleOffset={scaleOffsets.get(tab.id) ?? 0}
+              onError={handleViewerError}
+            >
+              {sidepeekContent}
+            </MeasuredPdfProvider>
+          </div>
+        </>
       )}
     </div>
   );

--- a/apps/web/src/components/inspector/inspector-pdf-error-fallback.tsx
+++ b/apps/web/src/components/inspector/inspector-pdf-error-fallback.tsx
@@ -1,48 +1,26 @@
-import { AlertTriangleIcon, XIcon } from "lucide-react";
+import { AlertTriangleIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
-import { cn } from "@stll/ui/lib/utils";
-
-import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 
 export const InspectorPdfErrorFallback = ({
-  onClose,
   onRetry,
 }: {
-  onClose: () => void;
   onRetry?: (() => void) | undefined;
 }) => {
   const t = useTranslations();
 
   return (
-    <div className="flex h-full flex-col">
-      <div
-        className={cn(
-          "flex shrink-0 items-center justify-end border-b px-3",
-          TOOLBAR_ROW_HEIGHT,
-        )}
-      >
-        <Button
-          aria-label={t("common.close")}
-          onClick={onClose}
-          size="icon-xs"
-          variant="ghost"
-        >
-          <XIcon className="size-3.5" />
+    <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+      <AlertTriangleIcon className="text-foreground-disabled size-8" />
+      <p className="text-muted-foreground text-sm">
+        {t("common.somethingWentWrong")}
+      </p>
+      {onRetry && (
+        <Button onClick={onRetry} size="sm" variant="outline">
+          {t("common.tryAgain")}
         </Button>
-      </div>
-      <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
-        <AlertTriangleIcon className="text-foreground-disabled size-8" />
-        <p className="text-muted-foreground text-sm">
-          {t("common.somethingWentWrong")}
-        </p>
-        {onRetry && (
-          <Button onClick={onRetry} size="sm" variant="outline">
-            {t("common.tryAgain")}
-          </Button>
-        )}
-      </div>
+      )}
     </div>
   );
 };

--- a/apps/web/src/lib/pdf/pdfjs-worker.ts
+++ b/apps/web/src/lib/pdf/pdfjs-worker.ts
@@ -1,2 +1,6 @@
 import "@/lib/pdf/uint8array-to-hex-polyfill";
 import "pdfjs-dist/build/pdf.worker.mjs";
+
+// PDF.js dynamically imports workerSrc when a real worker cannot start. Vite
+// strips worker-entry exports, so the worker-only build plugin restores the
+// upstream WorkerMessageHandler export from its global registration.

--- a/apps/web/vite.config.test.ts
+++ b/apps/web/vite.config.test.ts
@@ -94,6 +94,16 @@ describe("vite config", () => {
       "pdfjs-dist/build/pdf.worker.mjs",
     );
   });
+
+  test("applies runtime asset contracts to worker sub-builds", async () => {
+    const workerPlugins = resolveConfig("test").worker?.plugins?.() ?? [];
+    const pluginNames = (await collectNamedPlugins(workerPlugins)).map(
+      (plugin) => plugin.name,
+    );
+
+    expect(pluginNames).toContain("stll-anonymize-wasm");
+    expect(pluginNames).toContain("stella-pdfjs-worker-module-contract");
+  });
 });
 
 const resolveConfig = (mode: string): UserConfig => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -117,25 +117,20 @@ const runtimeAssetPlugins = (): PluginOption[] => [
 
 const pdfjsWorkerModuleContractPlugin = (): Plugin => ({
   name: "stella-pdfjs-worker-module-contract",
-  generateBundle(_, bundle) {
-    for (const output of Object.values(bundle)) {
-      if (
-        output.type !== "chunk" ||
-        !output.isEntry ||
-        !output.facadeModuleId
-          ?.replaceAll("\\", "/")
-          .endsWith("/src/lib/pdf/pdfjs-worker.ts")
-      ) {
-        continue;
-      }
-
-      // Vite deliberately strips exports from worker entries. PDF.js also
-      // imports workerSrc as an ES module for its same-thread recovery path,
-      // so restore that public contract from the handler the upstream worker
-      // registers while evaluating.
-      output.code +=
-        "\nexport const WorkerMessageHandler = globalThis.pdfjsWorker.WorkerMessageHandler;\n";
+  renderChunk(code, chunk) {
+    if (
+      !chunk.isEntry ||
+      !chunk.facadeModuleId
+        ?.replaceAll("\\", "/")
+        .endsWith("/src/lib/pdf/pdfjs-worker.ts")
+    ) {
+      return null;
     }
+
+    // Vite deliberately strips exports from worker entries. PDF.js also
+    // imports workerSrc as an ES module for its same-thread recovery path,
+    // so restore that public contract before Rollup hashes the emitted chunk.
+    return `${code}\nexport { WorkerMessageHandler };\n`;
   },
 });
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -108,6 +108,42 @@ const ensurePluginOption = (option: unknown, label: string): PluginOption => {
   throw new TypeError(`Invalid Vite plugin option from ${label}`);
 };
 
+const runtimeAssetPlugins = (): PluginOption[] => [
+  ensurePluginOption(
+    stllAnonymizeWasm({ packages: "none" }),
+    "@stll/anonymize-wasm/vite",
+  ),
+];
+
+const pdfjsWorkerModuleContractPlugin = (): Plugin => ({
+  name: "stella-pdfjs-worker-module-contract",
+  generateBundle(_, bundle) {
+    for (const output of Object.values(bundle)) {
+      if (
+        output.type !== "chunk" ||
+        !output.isEntry ||
+        !output.facadeModuleId
+          ?.replaceAll("\\", "/")
+          .endsWith("/src/lib/pdf/pdfjs-worker.ts")
+      ) {
+        continue;
+      }
+
+      // Vite deliberately strips exports from worker entries. PDF.js also
+      // imports workerSrc as an ES module for its same-thread recovery path,
+      // so restore that public contract from the handler the upstream worker
+      // registers while evaluating.
+      output.code +=
+        "\nexport const WorkerMessageHandler = globalThis.pdfjsWorker.WorkerMessageHandler;\n";
+    }
+  },
+});
+
+const workerRuntimeAssetPlugins = (): PluginOption[] => [
+  ...runtimeAssetPlugins(),
+  pdfjsWorkerModuleContractPlugin(),
+];
+
 const isPluginOption = (value: unknown): value is PluginOption => {
   if (value === false || value === null || value === undefined) {
     return true;
@@ -178,10 +214,7 @@ export default defineConfig(({ mode }) => {
     // createNativePipelineFromConfig), so no bundled prepared packages
     // are needed — "none" skips emitting the ~20MB+ default/per-language
     // .stlanonpkg assets.
-    ensurePluginOption(
-      stllAnonymizeWasm({ packages: "none" }),
-      "@stll/anonymize-wasm/vite",
-    ),
+    ...runtimeAssetPlugins(),
     ensurePluginOption(tailwindcss(), "@tailwindcss/vite"),
     ensurePluginOption(
       tanstackStart({
@@ -274,6 +307,10 @@ export default defineConfig(({ mode }) => {
     // browser target the rest of the build already assumes (es2025).
     worker: {
       format: "es",
+      // Worker builds have their own Vite plugin pipeline. Reuse the runtime
+      // asset plugins so dependencies that rewrite and emit WASM sidecars keep
+      // the same contract when they move off the main thread.
+      plugins: workerRuntimeAssetPlugins,
     },
     build: {
       target: "es2025",


### PR DESCRIPTION
Restores the PDF.js worker module contract used by same-thread recovery and applies runtime-asset plugins inside Vite worker sub-builds.

Adds a total production-build guard for source worker entries, emitted worker/WASM assets, and static asset references; this also fixes the chat anonymization worker native-runtime path.

Keeps PDF error fallbacks inside the viewer body so the inspector header remains stable and owns the only close action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF viewer error handling by removing the close action while retaining retry support.
  * Refined PDF side-panel layout so navigation and filtering remain accessible during loading and error states.
  * Improved reliability of PDF.js and anonymisation worker assets in production builds.

* **Tests**
  * Added validation covering required runtime assets, worker outputs, WASM files, and PDF.js worker compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->