### PR TITLE
chore: update analytics sanitizers

### DIFF
--- a/apps/web/src/lib/analytics/posthog-ingestion.ts
+++ b/apps/web/src/lib/analytics/posthog-ingestion.ts
@@ -1,0 +1,20 @@
+// posthog-js discards any event whose `token`, `distinct_id`, or
+// `$cookieless_mode` property a `before_send` hook removed (its
+// properties-required-for-ingestion guard). Every sanitizer that rebuilds
+// event properties must spread this passthrough or the event is silently
+// dropped client-side.
+export const INGESTION_REQUIRED_KEYS = [
+  "token",
+  "distinct_id",
+  "$cookieless_mode",
+] as const;
+
+export const pickIngestionRequired = (
+  properties: Record<string, unknown>,
+): Record<string, unknown> =>
+  Object.fromEntries(
+    INGESTION_REQUIRED_KEYS.filter((key) => key in properties).map((key) => [
+      key,
+      properties[key],
+    ]),
+  );

--- a/apps/web/src/lib/analytics/posthog-route-error.ts
+++ b/apps/web/src/lib/analytics/posthog-route-error.ts
@@ -1,6 +1,7 @@
 import type { CaptureResult, PostHog } from "posthog-js";
 
 import { isErrorReference } from "@/lib/analytics/error-reference";
+import { pickIngestionRequired } from "@/lib/analytics/posthog-ingestion";
 import { WEB_ANALYTICS_EVENTS } from "@/lib/analytics/types";
 import type { RouteErrorLifecycleProperties } from "@/lib/analytics/types";
 
@@ -19,7 +20,6 @@ export const sanitizeRouteErrorLifecycleEvent = (
   event: CaptureResult,
 ): CaptureResult | null => {
   const properties: Record<string, unknown> = event.properties;
-  const distinctId = properties["$distinct_id"];
   const sessionId = properties["$session_id"];
   const appCommit = properties["app_commit"];
   const appVersion = properties["app_version"];
@@ -46,7 +46,7 @@ export const sanitizeRouteErrorLifecycleEvent = (
   return {
     ...event,
     properties: {
-      ...(typeof distinctId === "string" ? { $distinct_id: distinctId } : {}),
+      ...pickIngestionRequired(properties),
       ...(matches(sessionId, OPAQUE_SESSION_ID_PATTERN)
         ? { $session_id: sessionId }
         : {}),

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { INGESTION_REQUIRED_KEYS } from "@/lib/analytics/posthog-ingestion";
 import { WEB_ANALYTICS_EVENTS } from "@/lib/analytics/types";
 
 type CapturedBrowserEvent = {
@@ -177,7 +178,7 @@ describe("PostHog browser analytics adapter", () => {
     });
   });
 
-  test("keeps real exception types without messages or stacks", () => {
+  test("keeps real exception types and frames without messages", () => {
     createPostHogAnalytics("phc_test", "https://posthog.test");
 
     const event = {
@@ -195,10 +196,71 @@ describe("PostHog browser analytics adapter", () => {
     expect(initOptions?.before_send(event)).toEqual({
       event: WEB_ANALYTICS_EVENTS.exception,
       properties: {
-        $exception_list: [{ type: "TypeError", value: "" }],
+        $exception_list: [
+          {
+            type: "TypeError",
+            value: "",
+            stacktrace: {
+              type: "raw",
+              frames: [{ filename: "app.js", lineno: 42 }],
+            },
+          },
+        ],
         $exception_type: "TypeError",
       },
     });
+  });
+
+  test("keeps only structural stack frame fields", () => {
+    createPostHogAnalytics("phc_test", "https://posthog.test");
+
+    const sanitized = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
+        $exception_list: [
+          {
+            type: "TypeError",
+            value: "Client Smith v Example failed",
+            stacktrace: {
+              type: "raw",
+              frames: [
+                {
+                  platform: "web:javascript",
+                  filename:
+                    "https://my.stll.app/assets/app.js?token=private-token",
+                  function: "renderMatter",
+                  in_app: true,
+                  lineno: 42,
+                  colno: 7,
+                  context_line: "const title = matter.clientName;",
+                  vars: { clientName: "Smith" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(sanitized?.properties?.["$exception_list"]).toEqual([
+      {
+        type: "TypeError",
+        value: "",
+        stacktrace: {
+          type: "raw",
+          frames: [
+            {
+              platform: "web:javascript",
+              filename: "https://my.stll.app/assets/app.js",
+              function: "renderMatter",
+              in_app: true,
+              lineno: 42,
+              colno: 7,
+            },
+          ],
+        },
+      },
+    ]);
   });
 
   test("captureError ignores null and undefined", () => {
@@ -211,7 +273,7 @@ describe("PostHog browser analytics adapter", () => {
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
 
-  test("captureError sends only a structural error type", () => {
+  test("captureError sends the error type and a message-free stack", () => {
     const { analytics } = createPostHogAnalytics(
       "phc_test",
       "https://posthog.test",
@@ -226,7 +288,120 @@ describe("PostHog browser analytics adapter", () => {
     if (!(captured instanceof Error)) {
       throw new TypeError("Expected a redacted Error");
     }
-    expect(captured.stack).toBeUndefined();
+    expect(captured.stack).toStartWith("TypeError:\n");
+    expect(captured.stack).not.toContain("Privileged document name");
+    expect(captured.stack).toContain("    at ");
+  });
+
+  test("captureError survives a cyclic cause chain", () => {
+    const { analytics } = createPostHogAnalytics(
+      "phc_test",
+      "https://posthog.test",
+    );
+    const first = new Error("Privileged first");
+    const second = new Error("Privileged second", { cause: first });
+    first.cause = second;
+    analytics.captureError(second);
+    expect(captureExceptionMock.mock.calls.at(-1)?.[0]).toBeInstanceOf(Error);
+  });
+
+  test("drops frame function names that are not symbol-shaped", () => {
+    createPostHogAnalytics("phc_test", "https://posthog.test");
+    const sanitized = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
+        $exception_list: [
+          {
+            type: "TypeError",
+            value: "boom",
+            stacktrace: {
+              frames: [
+                { filename: "app.js", function: "Client Smith", lineno: 1 },
+                { filename: "app.js", function: "renderMatter", lineno: 2 },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(sanitized?.properties?.["$exception_list"]).toEqual([
+      {
+        type: "TypeError",
+        value: "",
+        stacktrace: {
+          type: "raw",
+          frames: [
+            { filename: "app.js", lineno: 1 },
+            { filename: "app.js", function: "renderMatter", lineno: 2 },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test("captureError keeps the stack of the deepest cause", () => {
+    const { analytics } = createPostHogAnalytics(
+      "phc_test",
+      "https://posthog.test",
+    );
+    const original = new RangeError("Privileged original message");
+    const wrapper = new Error("Privileged wrapper message", {
+      cause: original,
+    });
+    wrapper.name = "ClientTelemetryError";
+    // Distinguishable stacks: the wrapper's own stack must not win.
+    wrapper.stack = "Error: Privileged wrapper message\n    at boundary";
+    original.stack =
+      "RangeError: Privileged original message\n    at failureSite";
+    analytics.captureError(wrapper);
+
+    const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
+    if (!(captured instanceof Error)) {
+      throw new TypeError("Expected a redacted Error");
+    }
+    expect(captured.name).toBe("ClientTelemetryError");
+    expect(captured.stack).toBe("ClientTelemetryError:\n    at failureSite");
+  });
+
+  test("captureError attaches the telemetry area slug and nothing free-form", () => {
+    const { analytics } = createPostHogAnalytics(
+      "phc_test",
+      "https://posthog.test",
+    );
+    const boundaryError = new Error("Privileged message");
+    Object.assign(boundaryError, { area: "pdf-viewer" });
+    analytics.captureError(boundaryError);
+    expect(captureExceptionMock.mock.calls.at(-1)?.[1]).toEqual({
+      area: "pdf-viewer",
+    });
+
+    const freeFormError = new Error("Privileged message");
+    Object.assign(freeFormError, { area: "Client Smith v Example" });
+    analytics.captureError(freeFormError);
+    expect(captureExceptionMock.mock.calls.at(-1)?.[1]).toEqual({});
+  });
+
+  test("sanitizer keeps only slug-shaped area properties", () => {
+    createPostHogAnalytics("phc_test", "https://posthog.test");
+
+    const sanitizedSlug = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
+        area: "pdf-viewer",
+        $exception_list: [{ type: "Error", value: "boom" }],
+      },
+    });
+    expect(sanitizedSlug?.properties?.["area"]).toBe("pdf-viewer");
+
+    const sanitizedFreeForm = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
+        area: "Client Smith v Example",
+        $exception_list: [{ type: "Error", value: "boom" }],
+      },
+    });
+    expect(sanitizedFreeForm?.properties).not.toContainKey("area");
   });
 
   test("captureError correlates a recovery reference without error details", () => {
@@ -316,7 +491,7 @@ describe("PostHog browser analytics adapter", () => {
         properties: {
           $current_url:
             "https://staging.stll.app/workspaces/private-matter?document=secret#selection",
-          $distinct_id: "user_123",
+          distinct_id: "user_123",
           $pathname: "/workspaces/private-matter",
           $referrer: "https://mail.example.test/client-name",
           $raw_user_agent: "private browser fingerprint",
@@ -338,7 +513,7 @@ describe("PostHog browser analytics adapter", () => {
     ).toEqual({
       event: WEB_ANALYTICS_EVENTS.routeErrorRecovery,
       properties: {
-        $distinct_id: "user_123",
+        distinct_id: "user_123",
         $session_id: "018f9f0e-7b42-7cc8-9a5d-42db46f6842d",
         app_commit: "abc123",
         app_version: "test",
@@ -374,17 +549,21 @@ describe("PostHog browser analytics adapter", () => {
     ).toBeNull();
   });
 
-  test("before_send strips exception messages and stack frames", () => {
+  test("before_send strips exception messages and envelope noise", () => {
     createPostHogAnalytics("phc_test", "https://posthog.test");
     const sanitized = initOptions?.before_send({
       event: WEB_ANALYTICS_EVENTS.exception,
       properties: {
-        $distinct_id: "user_123",
+        token: "phc_test",
+        distinct_id: "018f9f0e-7b42-7cc8-9a5d-42db46f6842d",
+        $current_url: "https://my.stll.app/workspaces/private-matter#selection",
         $exception_list: [
           {
             type: "TypeError",
             value: "Privileged document name",
-            stacktrace: { frames: [{ filename: "/matters/secret" }] },
+            stacktrace: {
+              frames: [{ filename: "https://my.stll.app/assets/app.js" }],
+            },
           },
         ],
       },
@@ -393,11 +572,78 @@ describe("PostHog browser analytics adapter", () => {
     expect(sanitized).toEqual({
       event: WEB_ANALYTICS_EVENTS.exception,
       properties: {
-        $distinct_id: "user_123",
-        $exception_list: [{ type: "TypeError", value: "" }],
+        token: "phc_test",
+        distinct_id: "018f9f0e-7b42-7cc8-9a5d-42db46f6842d",
+        $exception_list: [
+          {
+            type: "TypeError",
+            value: "",
+            stacktrace: {
+              type: "raw",
+              frames: [{ filename: "https://my.stll.app/assets/app.js" }],
+            },
+          },
+        ],
         $exception_type: "TypeError",
       },
     });
+  });
+
+  // posthog-js drops any event whose ingestion-required property was
+  // removed by `before_send`, so a sanitizer stripping one of these keys
+  // silently disables the whole telemetry stream. Assert both directions:
+  // every declared key survives both sanitizers, and nothing else from the
+  // envelope leaks through the exception sanitizer.
+  test("sanitizers preserve every posthog ingestion-required property", () => {
+    createPostHogAnalytics("phc_test", "https://posthog.test");
+    // Independent restatement of the posthog-js contract (its
+    // properties-required-for-ingestion set). If `INGESTION_REQUIRED_KEYS`
+    // drifts from this literal, the guard fails instead of mirroring the
+    // mistake.
+    const requiredBySdk = ["token", "distinct_id", "$cookieless_mode"];
+    expect(requiredBySdk).toEqual([...INGESTION_REQUIRED_KEYS]);
+    const envelope = {
+      token: "phc_test",
+      distinct_id: "018f9f0e-7b42-7cc8-9a5d-42db46f6842d",
+      $cookieless_mode: true,
+      $session_id: "018f9f0e-7b42-7cc8-9a5d-42db46f6842d",
+      $lib: "web",
+      $current_url: "https://my.stll.app/workspaces/private-matter",
+    };
+
+    const exception = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
+        ...envelope,
+        $exception_list: [{ type: "TypeError", value: "Private matter" }],
+      },
+    });
+    for (const key of INGESTION_REQUIRED_KEYS) {
+      expect(exception?.properties?.[key]).toEqual(envelope[key]);
+    }
+    expect(exception?.properties).not.toContainKeys([
+      "$session_id",
+      "$lib",
+      "$current_url",
+    ]);
+
+    const routeError = sanitizeRouteErrorLifecycleEvent({
+      event: WEB_ANALYTICS_EVENTS.routeErrorRecovery,
+      properties: {
+        ...envelope,
+        error_reference: "ERR-DEAD-BEEF-1234",
+        error_fingerprint: "ERRFP-1234ABCD",
+        incident_reference: "ERR-DEAD-BEEF-1234",
+        inspector_state: "open",
+        recovery: "retry-route",
+        route_template: "/law/$country/cases/$court/$slug",
+        status: "shown",
+      },
+      uuid: "route-error-envelope-event",
+    });
+    for (const key of INGESTION_REQUIRED_KEYS) {
+      expect(routeError?.properties[key]).toEqual(envelope[key]);
+    }
   });
 
   test("before_send keeps only valid opaque recovery references", () => {

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -8,6 +8,7 @@ import {
   telemetryErrorType,
 } from "@/lib/analytics/error-diagnostics";
 import { isErrorReference } from "@/lib/analytics/error-reference";
+import { pickIngestionRequired } from "@/lib/analytics/posthog-ingestion";
 import type { sanitizeRouteErrorLifecycleEvent } from "@/lib/analytics/posthog-route-error";
 import { WEB_ANALYTICS_EVENTS } from "@/lib/analytics/types";
 import type {
@@ -70,35 +71,147 @@ const isNoiseException = (event: {
   });
 };
 
+// Telemetry areas are fixed subsystem slugs declared at error boundaries
+// (`ClientTelemetryError.area`). The pattern rejects anything free-form so
+// no dynamic string can ride along.
+const TELEMETRY_AREA = /^[a-z][a-z0-9-]{0,39}$/u;
+
+const telemetryAreaProperty = (
+  error: unknown,
+): Record<string, string> | undefined => {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+  const area = error["area"];
+  return typeof area === "string" && TELEMETRY_AREA.test(area)
+    ? { area }
+    : undefined;
+};
+
+// The deepest error in a `cause` chain carries the stack of the original
+// failure site; wrapper classes (boundary telemetry errors) only record
+// where they were constructed. `cause` is writable, so third-party code can
+// hand us a cycle; the visited set bounds the walk.
+const deepestCause = (error: Error): Error => {
+  let current = error;
+  const seen = new Set<Error>([error]);
+  while (current.cause instanceof Error && !seen.has(current.cause)) {
+    current = current.cause;
+    seen.add(current);
+  }
+  return current;
+};
+
+// A V8 stack begins with `<name>: <message>`; the message can carry PII, so
+// keep only the frame lines (`    at …`), which name bundled assets and
+// minified symbols but never user content.
+const redactedStack = (error: Error): string | undefined => {
+  const { stack } = deepestCause(error);
+  if (typeof stack !== "string") {
+    return undefined;
+  }
+  const frames = stack.split("\n").filter((line) => /^\s+at /u.test(line));
+  if (frames.length === 0) {
+    return undefined;
+  }
+  return [`${telemetryErrorType(error)}:`, ...frames].join("\n");
+};
+
 const toRedactedTelemetryError = (error: unknown): Error => {
   // eslint-disable-next-line unicorn/error-message -- the original message is intentionally dropped so telemetry cannot leak PII from the underlying error; the error class is carried in `.name` instead.
   const redacted = new Error("");
   redacted.name = telemetryErrorType(error);
-  Reflect.deleteProperty(redacted, "stack");
+  const stack = error instanceof Error ? redactedStack(error) : undefined;
+  if (stack === undefined) {
+    Reflect.deleteProperty(redacted, "stack");
+  } else {
+    redacted.stack = stack;
+  }
   return redacted;
+};
+
+// Structural frame fields only: code locations and symbol names from the
+// deployed bundle. Free-text fields (context lines, local variables) never
+// pass through.
+type SanitizedFrame = {
+  platform?: string;
+  filename?: string;
+  function?: string;
+  in_app?: boolean;
+  lineno?: number;
+  colno?: number;
+};
+
+// Symbol-shaped frame function names only. V8 embeds computed property keys
+// verbatim in stacks (`at Client Smith (…)`), so anything with whitespace or
+// beyond identifier punctuation is treated as untrusted and dropped.
+const FRAME_SYMBOL = /^[\w$.<>[\]#~]{1,120}$/u;
+
+const stripQuery = (url: string): string => {
+  const queryIndex = url.indexOf("?");
+  return queryIndex === -1 ? url : url.slice(0, queryIndex);
+};
+
+const sanitizeFrame = (frame: unknown): SanitizedFrame => {
+  if (!isRecord(frame)) {
+    return {};
+  }
+  const filename = frame["filename"];
+  const functionName = frame["function"];
+  const platform = frame["platform"];
+  const inApp = frame["in_app"];
+  const lineno = frame["lineno"];
+  const colno = frame["colno"];
+  return {
+    ...(typeof platform === "string" ? { platform } : {}),
+    // Query strings on asset URLs can carry tokens; keep only the path.
+    ...(typeof filename === "string" ? { filename: stripQuery(filename) } : {}),
+    ...(typeof functionName === "string" && FRAME_SYMBOL.test(functionName)
+      ? { function: functionName }
+      : {}),
+    ...(typeof inApp === "boolean" ? { in_app: inApp } : {}),
+    ...(typeof lineno === "number" ? { lineno } : {}),
+    ...(typeof colno === "number" ? { colno } : {}),
+  };
+};
+
+const sanitizeExceptionEntry = (entry: unknown) => {
+  const type = normalizeTelemetryErrorTypeName(readStringField(entry, "type"));
+  const stacktrace = isRecord(entry) ? entry["stacktrace"] : undefined;
+  const frames = isRecord(stacktrace) ? stacktrace["frames"] : undefined;
+  return {
+    type,
+    value: "",
+    ...(Array.isArray(frames)
+      ? { stacktrace: { type: "raw", frames: frames.map(sanitizeFrame) } }
+      : {}),
+  };
 };
 
 const sanitizeExceptionEvent = (event: CaptureResult): CaptureResult => {
   const properties: Record<string, unknown> = event.properties;
-  const distinctId = properties["$distinct_id"];
   const appCommit = properties["app_commit"];
   const appVersion = properties["app_version"];
+  const area = properties["area"];
   const errorReference = properties["error_reference"];
   const exceptionList = properties["$exception_list"];
-  const firstException: unknown = Array.isArray(exceptionList)
-    ? exceptionList.at(0)
-    : undefined;
-  const type = normalizeTelemetryErrorTypeName(
-    readStringField(firstException, "type"),
-  );
+  const entries: unknown[] = Array.isArray(exceptionList) ? exceptionList : [];
+  const sanitizedList =
+    entries.length > 0
+      ? entries.map(sanitizeExceptionEntry)
+      : [sanitizeExceptionEntry(undefined)];
+  const type = sanitizedList.at(0)?.type ?? normalizeTelemetryErrorTypeName("");
   return {
     ...event,
     properties: {
-      $exception_list: [{ type, value: "" }],
+      ...pickIngestionRequired(properties),
+      $exception_list: sanitizedList,
       $exception_type: type,
-      ...(typeof distinctId === "string" ? { $distinct_id: distinctId } : {}),
       ...(typeof appCommit === "string" ? { app_commit: appCommit } : {}),
       ...(typeof appVersion === "string" ? { app_version: appVersion } : {}),
+      ...(typeof area === "string" && TELEMETRY_AREA.test(area)
+        ? { area }
+        : {}),
       ...(isErrorReference(errorReference)
         ? { error_reference: errorReference }
         : {}),
@@ -221,10 +334,10 @@ export const createPostHogAnalytics = (
         return;
       }
       logDevError(error, devErrorContext(context));
-      posthog.captureException(
-        toRedactedTelemetryError(error),
-        errorContextProperties(context),
-      );
+      posthog.captureException(toRedactedTelemetryError(error), {
+        ...errorContextProperties(context),
+        ...telemetryAreaProperty(error),
+      });
     },
     capturePageViewed: ({ path }) => {
       posthog.capture(WEB_ANALYTICS_EVENTS.pageViewed, {


### PR DESCRIPTION
Aligns the web analytics sanitizers with the posthog-js capture contract and improves exception grouping fidelity.

- `before_send` sanitizers that rebuild event properties now pass through the properties posthog-js requires to survive the hook (`token`, `distinct_id`, `$cookieless_mode`) via a shared `pickIngestionRequired` helper; the SDK discards events that lose one of these keys.
- Exception events keep structural stack frames (asset path with query string stripped, symbol, line, column, platform, `in_app`) so issues group by failure site. Messages, URLs, and free-text frame fields (context lines, variables) are still dropped.
- Redacted telemetry errors now carry the frame lines of their deepest `cause`, so wrapped boundary errors group by the original failure site instead of the wrapper construction site. The stack header carries the class name only, never the message.
- Boundary errors contribute their subsystem `area` as an event property, validated against a slug pattern so nothing free-form passes.
- Replaces the `$distinct_id` property passthrough in both sanitizers: capture events carry `distinct_id`, so the old key never matched.
- Guard test loops `INGESTION_REQUIRED_KEYS` through both sanitizers in both directions with production-shaped fixtures, and pins the frame field allowlist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved analytics event handling, preserving required ingestion details and validated telemetry areas.
  * Enhanced error reporting with safer processing of nested causes and stack traces.

* **Bug Fixes**
  * Removed sensitive messages and frame details from captured exceptions.
  * Improved filtering of invalid telemetry data while retaining relevant diagnostic context.
  * Corrected lifecycle event identifiers for more consistent analytics tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->