### PR TITLE
fix: strip NUL bytes from search projection text

### DIFF
--- a/apps/api/src/lib/scheduler/tasks/search-semantic-timestamps.ts
+++ b/apps/api/src/lib/scheduler/tasks/search-semantic-timestamps.ts
@@ -122,6 +122,17 @@ export const repairSearchSemanticTimestamps = async ({
       LEFT JOIN search_documents sd ON sd.entity_id = e.id
       WHERE (${state.cursor}::uuid IS NULL OR e.id > ${state.cursor}::uuid)
         AND e.current_version_id IS NOT NULL
+        -- A parked repair (next_attempt_at = infinity) is a permanently
+        -- failing projection; retrying it inline every pass would loop
+        -- forever and keep verification dirty. The queue owns its fate: a
+        -- real edit re-marks the row and un-parks it.
+        AND NOT EXISTS (
+          SELECT 1
+          FROM search_projection_repair_queue parked
+          WHERE parked.kind = 'entity'
+            AND parked.source_id = e.id
+            AND parked.next_attempt_at = 'infinity'::timestamptz
+        )
       ORDER BY e.id
       LIMIT ${REPAIR_BATCH_SIZE}
     )
@@ -340,13 +351,22 @@ export const repairSearchSemanticTimestampsTask: SchedulerTask = async ({
     case "restart":
       logger.info("search.semantic_timestamp_repair.verification_started");
       return;
-    case "progress":
-      logger.info("search.semantic_timestamp_repair.progress", {
+    case "progress": {
+      const progress = {
         cursor: outcome.cursor,
         failed: outcome.failed,
         repaired: outcome.repaired,
-      });
+      };
+      // A failed reindex repeats on every pass until the entity repairs or
+      // parks, so it must reach the ERROR sink operators watch, not only
+      // exception telemetry.
+      if (outcome.failed > 0) {
+        logger.error("search.semantic_timestamp_repair.progress", progress);
+      } else {
+        logger.info("search.semantic_timestamp_repair.progress", progress);
+      }
       return;
+    }
     default: {
       const _exhaustive: never = outcome;
       panic(

--- a/apps/api/src/lib/search/index-entity.test.ts
+++ b/apps/api/src/lib/search/index-entity.test.ts
@@ -322,6 +322,53 @@ test("excludes stale extracted text and fences its observed provenance", async (
   );
 });
 
+// Postgres `text` rejects NUL; extracted text arrives via encrypted bytea
+// which preserves it, so the projection write must strip it or the entity
+// becomes permanently unindexable (every repair retry fails the same way).
+test("strips NUL bytes from indexed title and text", async () => {
+  findFirstMock.mockResolvedValueOnce({
+    ...entityRow,
+    name: "Closing\u0000 memo",
+    currentVersion: {
+      createdAt: entityRow.currentVersion.createdAt,
+      fields: [currentFileField],
+      id: entityRow.currentVersion.id,
+    },
+    extractedContent: {
+      ciphertext: Buffer.from("ciphertext"),
+      extractedAt,
+      iv: Buffer.from("iv"),
+      language: "en",
+      sourceEntityVersionId: entityRow.currentVersion.id,
+      sourceFieldId: currentFileField.id,
+      sourceFileId: currentFileField.content.id,
+      sourceSha256Hex: currentFileField.content.sha256Hex,
+    },
+  });
+  decryptContentMock.mockResolvedValueOnce("Extracted\u0000 text\u0000");
+  const { upsertSearchDocument } =
+    await import("@/api/lib/search/index-entity");
+
+  await upsertSearchDocument(toSafeId<"entity">("entity_1"));
+
+  const query = executeMock.mock.calls.at(0)?.[0];
+  expect(query).toBeDefined();
+  if (!query) {
+    return;
+  }
+  const compiled = new PgDialect().sqlToQuery(query);
+  const stringParams = compiled.params.filter(
+    (param): param is string => typeof param === "string",
+  );
+  expect(stringParams.some((param) => param.includes("Extracted text"))).toBe(
+    true,
+  );
+  expect(stringParams.some((param) => param.includes("Closing memo"))).toBe(
+    true,
+  );
+  expect(stringParams.some((param) => param.includes("\u0000"))).toBe(false);
+});
+
 test("preserves pre-provenance extracted text until a fenced writer replaces it", async () => {
   findFirstMock.mockResolvedValueOnce({
     ...entityRow,

--- a/apps/api/src/lib/search/index-entity.test.ts
+++ b/apps/api/src/lib/search/index-entity.test.ts
@@ -351,14 +351,14 @@ test("strips NUL bytes from indexed title and text", async () => {
 
   await upsertSearchDocument(toSafeId<"entity">("entity_1"));
 
-  const query = executeMock.mock.calls.at(0)?.[0];
-  expect(query).toBeDefined();
-  if (!query) {
-    return;
-  }
-  const compiled = new PgDialect().sqlToQuery(query);
-  const stringParams = compiled.params.filter(
-    (param): param is string => typeof param === "string",
+  // Sweep every execution: the preview-passage writes bind derived text in
+  // later queries, and a NUL surviving into any of them poisons the entity
+  // just the same.
+  expect(executeMock.mock.calls.length).toBeGreaterThan(0);
+  const stringParams = executeMock.mock.calls.flatMap(([executedQuery]) =>
+    new PgDialect()
+      .sqlToQuery(executedQuery)
+      .params.filter((param): param is string => typeof param === "string"),
   );
   expect(stringParams.some((param) => param.includes("Extracted text"))).toBe(
     true,

--- a/apps/api/src/lib/search/index-entity.ts
+++ b/apps/api/src/lib/search/index-entity.ts
@@ -269,13 +269,24 @@ const buildSearchDocument = async (
  * Build a search document and upsert it into `search_documents`,
  * computing the `tsv` column with the per-document regconfig.
  */
+// Postgres `text` and `tsvector` reject NUL (`\u0000`). Extracted document
+// text reaches this boundary through encrypted `bytea`, which preserves NULs
+// from binary-ish sources, so the projection write is the one place every
+// producer funnels through — strip here, not at each producer.
+const stripNulBytes = (text: string): string => text.replaceAll("\u0000", "");
+
 export const upsertSearchDocument = async (
   entityId: SafeId<"entity">,
 ): Promise<void> => {
-  const doc = await buildSearchDocument(entityId);
-  if (!doc) {
+  const built = await buildSearchDocument(entityId);
+  if (!built) {
     return;
   }
+  const doc = {
+    ...built,
+    searchableText: stripNulBytes(built.searchableText),
+    title: stripNulBytes(built.title),
+  };
 
   const regconfig = doc.language ?? "simple";
   const previewGeneration = Bun.randomUUIDv7();

--- a/apps/api/src/lib/search/projection-repair-queue.db.test.ts
+++ b/apps/api/src/lib/search/projection-repair-queue.db.test.ts
@@ -246,6 +246,41 @@ test("a drained repair removes its row; a failed one backs off out of the batch"
   expect(await queueRows()).toHaveLength(1);
 });
 
+test("a permanently failing repair parks at the attempt cap and un-parks on a real edit", async () => {
+  const matter = await seedWorkspace(workspaceId(1));
+  const poison = await seedEntity(entityId(10), matter);
+
+  await enqueueEntitySearchRepairs(asTx(), [poison]);
+  // One failure away from the cap (REPAIR_MAX_ATTEMPTS = 8), due now.
+  await db
+    .update(searchProjectionRepairQueue)
+    .set({ attempts: 7, nextAttemptAt: new Date() })
+    .where(eq(searchProjectionRepairQueue.sourceId, poison));
+
+  const capping = emptyLog();
+  capping.failing.add(poison);
+  expect(
+    await drainSearchProjectionRepairQueue({ deps: repairDeps(capping) }),
+  ).toEqual({ failed: 1, repaired: 0 });
+  expect((await queueRows()).at(0)?.attempts).toBe(8);
+
+  // Parked: never claimable again, even long after any finite backoff.
+  const parked = emptyLog();
+  parked.failing.add(poison);
+  expect(
+    await drainSearchProjectionRepairQueue({ deps: repairDeps(parked) }),
+  ).toEqual({ failed: 0, repaired: 0 });
+  expect(await queueRows()).toHaveLength(1);
+
+  // A real edit re-marks the row, resetting the schedule and un-parking it.
+  await enqueueEntitySearchRepairs(asTx(), [poison]);
+  const fresh = emptyLog();
+  expect(
+    await drainSearchProjectionRepairQueue({ deps: repairDeps(fresh) }),
+  ).toEqual({ failed: 0, repaired: 1 });
+  expect(await queueRows()).toEqual([]);
+});
+
 test("a queued source that no longer exists is dropped, not resurrected", async () => {
   const matter = await seedWorkspace(workspaceId(1));
   const document = await seedEntity(entityId(10), matter);

--- a/apps/api/src/lib/search/projection-repair-queue.ts
+++ b/apps/api/src/lib/search/projection-repair-queue.ts
@@ -50,6 +50,13 @@ const SEARCH_PROJECTION_REPAIR_CONCURRENCY = 4;
 
 const REPAIR_RETRY_BASE_SECONDS = 60;
 const REPAIR_RETRY_MAX_SECONDS = 6 * 60 * 60;
+/**
+ * A repair that fails this many times is parked (`next_attempt_at =
+ * infinity`): the claim query never picks it up again, so a permanently
+ * failing row cannot loop. A later real edit re-marks the row, which resets
+ * the schedule and un-parks it.
+ */
+const REPAIR_MAX_ATTEMPTS = 8;
 
 const SEARCH_PROJECTION_KIND = {
   contact: "contact",
@@ -282,17 +289,30 @@ const settleFailed = async (
   db: SearchProjectionRepairDb,
   claim: ClaimedRepair,
 ): Promise<void> => {
-  await db
+  const updated = await db
     .update(searchProjectionRepairQueue)
     .set({
       attempts: sql`${searchProjectionRepairQueue.attempts} + 1`,
-      nextAttemptAt: sql`now() + make_interval(secs => LEAST(
-        ${REPAIR_RETRY_BASE_SECONDS}::double precision
-          * power(2, ${searchProjectionRepairQueue.attempts}),
-        ${REPAIR_RETRY_MAX_SECONDS}::double precision
-      ))`,
+      nextAttemptAt: sql`CASE
+        WHEN ${searchProjectionRepairQueue.attempts} + 1 >= ${REPAIR_MAX_ATTEMPTS}
+          THEN 'infinity'::timestamptz
+        ELSE now() + make_interval(secs => LEAST(
+          ${REPAIR_RETRY_BASE_SECONDS}::double precision
+            * power(2, ${searchProjectionRepairQueue.attempts}),
+          ${REPAIR_RETRY_MAX_SECONDS}::double precision
+        ))
+      END`,
     })
-    .where(claimedRow(claim));
+    .where(claimedRow(claim))
+    .returning({ attempts: searchProjectionRepairQueue.attempts });
+  const attempts = updated.at(0)?.attempts ?? 0;
+  if (attempts >= REPAIR_MAX_ATTEMPTS) {
+    logger.error("search.projection_repair_parked", {
+      attempts,
+      searchProjectionKind: claim.kind,
+      searchProjectionSourceId: claim.sourceId,
+    });
+  }
 };
 
 type RepairRun = {


### PR DESCRIPTION
Postgres `text` and `tsvector` columns reject NUL (`\u0000`), but extracted document text reaches the search projection through encrypted `bytea`, which preserves NUL bytes from binary-ish sources. An affected entity fails every index attempt with an encoding error, and because the failure is permanent, the retry paths never converge.

Two layers:

**Strip NUL at the projection write** (`upsertSearchDocument`, the single funnel every producer passes through), covering title, searchable text, the tsvector input, and derived preview passages. Compiled-query test asserts no bound string parameter carries a NUL when both the entity name and decrypted extracted text contain them.

**Bound the retry loop for any permanent failure**, not just this one:
- The repair queue caps attempts (8) and parks the row at `next_attempt_at = 'infinity'` with an ERROR log; the claim query never picks a parked row up again. A later real edit re-marks the row, which resets the schedule and un-parks it — preserving the documented fresh-edit semantics.
- The semantic-timestamp scan skips parked rows so verification passes can complete instead of staying dirty forever.
- Repeated inline reindex failures now log at ERROR instead of INFO, so a recurring failure reaches the operator log sink rather than only exception telemetry.

DB test drives a row to the cap, asserts it is unclaimable afterward, and that a fresh mark un-parks it.