### PR TITLE
chore: group server exceptions by structural fingerprint

### DIFF
--- a/apps/api/src/lib/analytics/capture.test.ts
+++ b/apps/api/src/lib/analytics/capture.test.ts
@@ -96,3 +96,29 @@ describe("captureError repeat suppression", () => {
     expect(captured.at(1)?.properties["suppressed_repeats"]).toBe("7");
   });
 });
+
+describe("captureError issue grouping", () => {
+  // PostHog groups issues from `$exception_list`; with the message and stack
+  // redacted, every event of one class would collapse into a single issue and
+  // first-seen automations would never fire again for that class. The
+  // explicit fingerprint must therefore separate distinct defects while
+  // carrying no message content.
+  test("distinct defects produce distinct grouping fingerprints", () => {
+    captureFromSiteA();
+    captureFromSiteB();
+
+    const fingerprints = captured.map(
+      (event) => event.properties["$exception_fingerprint"],
+    );
+    expect(typeof fingerprints.at(0)).toBe("string");
+    expect(fingerprints.at(0)).not.toBe(fingerprints.at(1));
+  });
+
+  test("the grouping fingerprint never carries the error message", () => {
+    captureError(new Error("Privileged client matter detail"));
+
+    const fingerprint = captured.at(0)?.properties["$exception_fingerprint"];
+    expect(typeof fingerprint).toBe("string");
+    expect(fingerprint).not.toContain("Privileged");
+  });
+});

--- a/apps/api/src/lib/analytics/capture.ts
+++ b/apps/api/src/lib/analytics/capture.ts
@@ -137,10 +137,24 @@ const captureErrorWithOptions = (
   options: CaptureErrorOptions,
 ) => {
   const tag = errorTag(error);
+  const fingerprint = errorFingerprint(error);
   // PostHog ingestion drops `$exception` events that lack `$exception_list`,
   // so the entry is required even though we deliberately keep it empty —
   // the redaction contract above forbids shipping the message or stack.
   const properties: ExceptionProperties = {
+    // PostHog groups issues from `$exception_list` content; with the message
+    // and stack redacted, every event of one error class collapses into a
+    // single issue and first-seen automations never fire for new defects.
+    // Group by the structural fingerprint instead: same non-PII components,
+    // one issue per distinct defect. Positions are fixed (empty stays empty)
+    // so a frameless error's cause frame can never collide with another
+    // error's primary frame — the same shape `captureWindowKey` uses.
+    $exception_fingerprint: [
+      fingerprint["error.class"] ?? "",
+      fingerprint["error.code"] ?? "",
+      fingerprint["error.frame"] ?? "",
+      fingerprint["error.cause.frame"] ?? "",
+    ].join("|"),
     $exception_level: "error",
     $exception_list: [
       {
@@ -155,7 +169,7 @@ const captureErrorWithOptions = (
     // forbids the message and stack; a code location and class name
     // carry no client data, so they make the exception actionable in
     // the dashboard without violating it.
-    ...errorFingerprint(error),
+    ...fingerprint,
     ...options.context,
     ...(options.organizationId
       ? { organization_id: options.organizationId }


### PR DESCRIPTION
Server-side $exception events deliberately redact message and stack, which left the error-tracking backend grouping every event of one error class into a single long-lived issue; automations keyed on first-seen issues therefore stopped distinguishing new defects.

The capture helper already computes a structural, non-PII fingerprint (error class, stable code, top `file:line:col` frames of the error and its deepest cause) for repeat-suppression. This change also emits it as `$exception_fingerprint`, so grouping uses the same components: one issue per distinct defect, no content in the fingerprint.

Tests pin that distinct call sites produce distinct fingerprints and that message text never appears in the fingerprint.