### PR TITLE
chore: report page views as standard pageview events

### DIFF
--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -131,7 +131,7 @@ describe("PostHog browser analytics adapter", () => {
       }),
     ).toEqual({ event: WEB_ANALYTICS_EVENTS.pageViewed });
     expect(initOptions?.before_send({ event: "$autocapture" })).toBeNull();
-    expect(initOptions?.before_send({ event: "$pageview" })).toBeNull();
+    expect(initOptions?.before_send({ event: "$pageleave" })).toBeNull();
     expect(initOptions?.before_send({ event: "$heatmap" })).toBeNull();
   });
 
@@ -688,12 +688,21 @@ describe("PostHog browser analytics adapter", () => {
       "https://posthog.test",
     );
 
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: new URL("https://app.example.test"),
+    });
     analytics.capturePageViewed({
-      path: "/cases",
+      path: "/workspaces/$workspaceId",
     });
 
+    // The route template overrides the SDK's own URL properties so resolved
+    // resource ids never reach analytics, while web analytics still
+    // aggregates by page.
     expect(captureMock).toHaveBeenCalledWith(WEB_ANALYTICS_EVENTS.pageViewed, {
-      path: "/cases",
+      $current_url: "https://app.example.test/workspaces/$workspaceId",
+      $pathname: "/workspaces/$workspaceId",
+      path: "/workspaces/$workspaceId",
     });
   });
 

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -340,7 +340,18 @@ export const createPostHogAnalytics = (
       });
     },
     capturePageViewed: ({ path }) => {
+      // `path` is the matched route template (`/workspaces/$workspaceId`),
+      // never a resolved URL. Overriding the SDK's own `$current_url` and
+      // `$pathname` with the template keeps resource ids out of analytics
+      // while letting web analytics aggregate by page. DOM types claim
+      // `location` always exists, but during SSR it does not; the `in` check
+      // is the runtime truth the types cannot express.
+      const hasLocation = "location" in globalThis;
       posthog.capture(WEB_ANALYTICS_EVENTS.pageViewed, {
+        ...(hasLocation
+          ? { $current_url: `${globalThis.location.origin}${path}` }
+          : {}),
+        $pathname: path,
         path,
       });
     },

--- a/apps/web/src/lib/analytics/types.ts
+++ b/apps/web/src/lib/analytics/types.ts
@@ -3,7 +3,9 @@ import type { ErrorReference } from "@/lib/analytics/error-reference";
 export const WEB_ANALYTICS_EVENTS = {
   exception: "$exception",
   identify: "$identify",
-  pageViewed: "page_viewed",
+  // The standard event name, so PostHog web analytics aggregates our page
+  // views; the payload still carries route templates, never resolved URLs.
+  pageViewed: "$pageview",
   guideStepSkipped: "guide_step_skipped",
   routeErrorRecovery: "route_error_recovery",
 } as const;


### PR DESCRIPTION
Renames the custom `page_viewed` event to the standard `$pageview` so PostHog web analytics can aggregate page views; the custom name kept the whole product dark.

The payload still reports the matched route template (`/workspaces/$workspaceId`), never the resolved URL: the capture overrides the SDK's own `$current_url` and `$pathname` with the template, so resource ids stay out of analytics while pages group correctly. `location` is guarded for SSR, where the SDK drops the event anyway.

Existing insights keyed on `page_viewed` stop accruing with this rename; that cutover is intentional.