### PR TITLE
chore: emit standard ai generation telemetry

### DIFF
--- a/apps/api/src/lib/analytics/tanstack-ai.test.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.test.ts
@@ -137,8 +137,26 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
       usage,
     });
 
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
+    expect(events).toHaveLength(2);
+    const generation = events.find(
+      (event) => event.event === SERVER_ANALYTICS_EVENTS.aiGeneration,
+    );
+    expect(generation).toMatchObject({
+      distinctId: "user_123",
+      properties: {
+        $ai_model: "gpt-5.4-mini",
+        $ai_provider: "openai",
+        feature: "chat.stream",
+      },
+    });
+    // Privacy mode by construction: the standard event never carries prompt
+    // or completion content.
+    expect(generation?.properties).not.toHaveProperty("$ai_input");
+    expect(generation?.properties).not.toHaveProperty("$ai_output_choices");
+    const completed = events.find(
+      (event) => event.event === SERVER_ANALYTICS_EVENTS.aiGenerationCompleted,
+    );
+    expect(completed).toMatchObject({
       distinctId: "user_123",
       event: SERVER_ANALYTICS_EVENTS.aiGenerationCompleted,
       properties: {
@@ -150,7 +168,7 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
         workspace_id: "workspace_safe",
       },
     });
-    expect(events[0]?.properties).not.toHaveProperty("unsafe");
+    expect(completed?.properties).not.toHaveProperty("unsafe");
   });
 
   test("records usage through TanStack deferred side effects", async () => {
@@ -336,8 +354,18 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
     });
     callbacks.captureError(error);
 
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
+    // One standard failure record plus one internal event; the catch-path
+    // repeat must add neither.
+    expect(events).toHaveLength(2);
+    expect(
+      events.filter(
+        (event) => event.event === SERVER_ANALYTICS_EVENTS.aiGeneration,
+      ),
+    ).toHaveLength(1);
+    const failedEvent = events.find(
+      (event) => event.event === SERVER_ANALYTICS_EVENTS.aiGenerationFailed,
+    );
+    expect(failedEvent).toMatchObject({
       event: SERVER_ANALYTICS_EVENTS.aiGenerationFailed,
       properties: {
         failure_reason: "provider",
@@ -379,16 +407,25 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
       );
 
       expect(deferred).toHaveLength(0);
-      expect(events).toHaveLength(1);
-      expect(events[0]).toMatchObject({
+      expect(events).toHaveLength(2);
+      const failedEvent = events.find(
+        (event) => event.event === SERVER_ANALYTICS_EVENTS.aiGenerationFailed,
+      );
+      expect(failedEvent).toMatchObject({
         event: SERVER_ANALYTICS_EVENTS.aiGenerationFailed,
         properties: {
           failure_reason: "provider",
           feature: "chat.suggested-prompts",
         },
       });
-      expect(events[0]?.properties).not.toHaveProperty("model");
-      expect(events[0]?.properties).not.toHaveProperty("provider");
+      expect(failedEvent?.properties).not.toHaveProperty("model");
+      expect(failedEvent?.properties).not.toHaveProperty("provider");
+      // Without resolved model info the standard record still ships, just
+      // without model attribution.
+      const generation = events.find(
+        (event) => event.event === SERVER_ANALYTICS_EVENTS.aiGeneration,
+      );
+      expect(generation?.properties).not.toHaveProperty("$ai_model");
     } finally {
       env.REQUIRE_PERSONAL_AI_KEY = originalRequirePersonalAIKey;
     }

--- a/apps/api/src/lib/analytics/tanstack-ai.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.ts
@@ -293,7 +293,7 @@ export const createTanStackAIAnalyticsCallbacks = ({
       return modelInfo;
     };
 
-  const captureGenerationError = (error: unknown) => {
+  const captureGenerationError = (error: unknown, durationMs?: number) => {
     if (hasCapturedGenerationError) {
       return;
     }
@@ -331,6 +331,31 @@ export const createTanStackAIAnalyticsCallbacks = ({
       trace_id: config.traceId,
     });
 
+    // Standard-schema failure record for LLM observability: the error class
+    // name only, never the message. See the completion-side capture for the
+    // privacy contract.
+    analytics.capture({
+      distinctId,
+      event: SERVER_ANALYTICS_EVENTS.aiGeneration,
+      properties: {
+        $ai_error: errorTag(error),
+        $ai_is_error: true,
+        // The middleware's measured duration covers only the provider call;
+        // the construction-time clock is the catch-path fallback and can
+        // include setup work.
+        $ai_latency:
+          (durationMs ?? performance.now() - startedAt) / ONE_SECOND_MS,
+        $ai_trace_id: config.traceId,
+        feature: config.feature,
+        ...(resolvedModelInfo
+          ? {
+              $ai_model: resolvedModelInfo.modelId,
+              $ai_provider: resolvedModelInfo.provider,
+            }
+          : {}),
+      },
+    });
+
     analytics.capture({
       distinctId,
       event: SERVER_ANALYTICS_EVENTS.aiGenerationFailed,
@@ -364,8 +389,8 @@ export const createTanStackAIAnalyticsCallbacks = ({
       onAfterToolCall: () => {
         toolCount += 1;
       },
-      onError: (_ctx, { error }) => {
-        captureGenerationError(error);
+      onError: (_ctx, { duration, error }) => {
+        captureGenerationError(error, duration);
       },
       onFinish: (_ctx, { duration, usage }) => {
         if (!usage) {
@@ -375,6 +400,24 @@ export const createTanStackAIAnalyticsCallbacks = ({
         if (!resolvedModelInfo) {
           return;
         }
+
+        // The standard $ai_* schema feeds the analytics platform's LLM
+        // observability product. Privacy mode by construction: model, token
+        // counts, latency, and trace correlation only — prompt and completion
+        // content never leave the service.
+        analytics.capture({
+          distinctId,
+          event: SERVER_ANALYTICS_EVENTS.aiGeneration,
+          properties: {
+            $ai_input_tokens: usage.promptTokens,
+            $ai_latency: duration / ONE_SECOND_MS,
+            $ai_model: resolvedModelInfo.modelId,
+            $ai_output_tokens: usage.completionTokens,
+            $ai_provider: resolvedModelInfo.provider,
+            $ai_trace_id: config.traceId,
+            feature: config.feature,
+          },
+        });
 
         analytics.capture({
           distinctId,

--- a/apps/api/src/lib/templates/suggest-template-fields-error.test.ts
+++ b/apps/api/src/lib/templates/suggest-template-fields-error.test.ts
@@ -99,6 +99,9 @@ describe("suggestTemplateFieldsOrEmpty", () => {
     });
 
     expect(suggestions).toEqual([]);
-    expect(captured).toHaveLength(1);
+    // One standard $ai_generation failure record plus one internal failed
+    // event; the point pinned here is that the failure was captured rather
+    // than thrown.
+    expect(captured).toHaveLength(2);
   });
 });


### PR DESCRIPTION
Emits the standard `$ai_generation` event from the TanStack AI middleware hooks, alongside the existing internal events, so the analytics platform's LLM observability product gets model, provider, token counts, latency, and trace correlation for every generation — including failures, which carry the error class name and `$ai_is_error`.

Privacy mode by construction: the event never includes `$ai_input` or `$ai_output_choices`, so prompt and completion content cannot leave the service. Tests pin the two-event shape per generation, the dedupe of catch-path repeats, and that the standard record ships without model attribution when model info is unavailable.