### PR TITLE
fix(reconciliation): distinguish held and idle rotations

### DIFF
--- a/apps/legal-atlas-runner/src/runners/case-law-reconciliation.test.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-reconciliation.test.ts
@@ -314,11 +314,14 @@ describe("case law reconciliation loop", () => {
     ]);
   });
 
-  test("a held source does not cap the idle schedule of polled peers", async () => {
-    // A retry deadline belongs to the source that failed. When another source
-    // was actually polled and reported idle, that rotation must advance the
-    // ordinary idle schedule; shortening its wait to the held source's
-    // deadline would make the idle peer inherit the failed source's cadence.
+  test("a held source neither freezes the idle schedule nor outlives its own ceiling", async () => {
+    // The two costs a rotation of "one held source plus idle ones" trades off.
+    // Treating it as fully-held would pin the idle schedule at the failing
+    // source's retry cadence forever, so a settled corpus would never get
+    // cheap; treating it as plainly idle would let the sleep double past
+    // `failureBackoffMaxMs`, silently overriding the ceiling that decides how
+    // often a broken source is retried. It has to do both: advance the idle
+    // schedule, and cap the wait at the held source's deadline.
     const run = await runLoop({
       responders: [
         [
@@ -329,12 +332,7 @@ describe("case law reconciliation loop", () => {
         ],
         ["cz-ns", () => IDLE],
       ],
-      timing: {
-        ...TIMING,
-        idleSleepMs: 600,
-        idleSleepMaxMs: 2400,
-      },
-      turns: 7,
+      turns: 10,
     });
 
     expect(run.events.filter((event) => event.type === "turn")).toEqual([
@@ -343,14 +341,17 @@ describe("case law reconciliation loop", () => {
       { type: "turn", adapterKey: "cz-regional", atMs: 1000 },
       { type: "turn", adapterKey: "cz-ns", atMs: 1500 },
       { type: "turn", adapterKey: "cz-ns", atMs: 2000 },
-      // The mixed rotations pay 600ms and then 1200ms. The source becomes
-      // retryable at 3000ms, but that must not truncate its idle peer's wait.
-      { type: "turn", adapterKey: "cz-ns", atMs: 2600 },
-      { type: "turn", adapterKey: "cz-regional", atMs: 3800 },
+      { type: "turn", adapterKey: "cz-regional", atMs: 3000 },
+      { type: "turn", adapterKey: "cz-ns", atMs: 3500 },
+      { type: "turn", adapterKey: "cz-ns", atMs: 4000 },
+      // The idle schedule advances instead of freezing at the retry wait.
+      { type: "turn", adapterKey: "cz-ns", atMs: 5000 },
+      // It also stops at the held source's deadline instead of oversleeping.
+      { type: "turn", adapterKey: "cz-regional", atMs: 7000 },
     ]);
   });
 
-  test("a fully held rotation retries at the first deadline without a poll storm", async () => {
+  test("every source failing waits out the earliest retry rather than spinning", async () => {
     // A skipped turn costs no pacing gap, so a rotation in which every source
     // is held would otherwise spin at full speed. The wait is to the first
     // expiry, not the idle ceiling: the corpus is unreachable, not settled.

--- a/apps/legal-atlas-runner/src/runners/case-law-reconciliation.test.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-reconciliation.test.ts
@@ -268,7 +268,7 @@ describe("case law reconciliation loop", () => {
     // The streak is served in turns skipped, so the failing source is asked
     // progressively less often while the healthy one keeps its cadence.
     const failingTurns = turnOrder(run).filter((key) => key === "cz-regional");
-    expect(failingTurns.length).toBeLessThan(4);
+    expect(failingTurns).toHaveLength(3);
   });
 
   test("a failing source costs its own turns, never the healthy sources' cadence", async () => {
@@ -301,18 +301,24 @@ describe("case law reconciliation loop", () => {
     // `every` is vacuously true on an empty array, so the count is asserted
     // too: a regression that stopped the healthy sources taking any turn at
     // all would otherwise pass this.
-    expect(healthyGaps.length).toBeGreaterThan(0);
-    expect(healthyGaps.every((ms) => ms === TIMING.unitDelayMs)).toBe(true);
+    expect(healthyGaps).toEqual([
+      TIMING.unitDelayMs,
+      TIMING.unitDelayMs,
+      TIMING.unitDelayMs,
+      TIMING.unitDelayMs,
+      TIMING.unitDelayMs,
+      TIMING.unitDelayMs,
+      TIMING.unitDelayMs,
+      TIMING.unitDelayMs,
+      TIMING.unitDelayMs,
+    ]);
   });
 
-  test("a held source neither freezes the idle schedule nor outlives its own ceiling", async () => {
-    // The two costs a rotation of "one held source plus idle ones" trades off.
-    // Treating it as fully-held would pin the idle schedule at the failing
-    // source's retry cadence forever, so a settled corpus would never get
-    // cheap; treating it as plainly idle would let the sleep double past
-    // `failureBackoffMaxMs`, silently overriding the ceiling that decides how
-    // often a broken source is retried. It has to do both: advance the idle
-    // schedule, and cap the wait at the held source's deadline.
+  test("a held source does not cap the idle schedule of polled peers", async () => {
+    // A retry deadline belongs to the source that failed. When another source
+    // was actually polled and reported idle, that rotation must advance the
+    // ordinary idle schedule; shortening its wait to the held source's
+    // deadline would make the idle peer inherit the failed source's cadence.
     const run = await runLoop({
       responders: [
         [
@@ -323,7 +329,12 @@ describe("case law reconciliation loop", () => {
         ],
         ["cz-ns", () => IDLE],
       ],
-      turns: 10,
+      timing: {
+        ...TIMING,
+        idleSleepMs: 600,
+        idleSleepMaxMs: 2400,
+      },
+      turns: 7,
     });
 
     expect(run.events.filter((event) => event.type === "turn")).toEqual([
@@ -332,17 +343,14 @@ describe("case law reconciliation loop", () => {
       { type: "turn", adapterKey: "cz-regional", atMs: 1000 },
       { type: "turn", adapterKey: "cz-ns", atMs: 1500 },
       { type: "turn", adapterKey: "cz-ns", atMs: 2000 },
-      { type: "turn", adapterKey: "cz-regional", atMs: 3000 },
-      { type: "turn", adapterKey: "cz-ns", atMs: 3500 },
-      { type: "turn", adapterKey: "cz-ns", atMs: 4000 },
-      // The idle schedule advances instead of freezing at the retry wait.
-      { type: "turn", adapterKey: "cz-ns", atMs: 5000 },
-      // It also stops at the held source's deadline instead of oversleeping.
-      { type: "turn", adapterKey: "cz-regional", atMs: 7000 },
+      // The mixed rotations pay 600ms and then 1200ms. The source becomes
+      // retryable at 3000ms, but that must not truncate its idle peer's wait.
+      { type: "turn", adapterKey: "cz-ns", atMs: 2600 },
+      { type: "turn", adapterKey: "cz-regional", atMs: 3800 },
     ]);
   });
 
-  test("every source failing waits out the earliest retry rather than spinning", async () => {
+  test("a fully held rotation retries at the first deadline without a poll storm", async () => {
     // A skipped turn costs no pacing gap, so a rotation in which every source
     // is held would otherwise spin at full speed. The wait is to the first
     // expiry, not the idle ceiling: the corpus is unreachable, not settled.

--- a/apps/legal-atlas-runner/src/runners/case-law-reconciliation.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-reconciliation.ts
@@ -194,17 +194,15 @@ export type ReconciliationLoopOptions = {
  * - a worked turn is followed by `unitDelayMs`, whatever it produced. A unit
  *   that found nothing missing still listed a slice from a publisher; it does
  *   not earn a faster next turn.
- * - a rotation where at least one source reported idle or leased and none
- *   worked doubles its sleep towards the idle ceiling, so a settled corpus
- *   stops asking the database every half second. A held source does not cap
- *   that schedule; its retry deadline belongs to its own turns. Any worked
- *   turn resets it.
+ * - a turn where every source reported idle or leased doubles its sleep
+ *   towards the idle ceiling, so a settled corpus stops asking the database
+ *   every half second. Any worked turn resets it.
  * - a throw holds that source alone until its own backoff expires, doubling
  *   towards the failure ceiling. The loop keeps its pacing meanwhile, so a
  *   refusing publisher costs its own turns and nobody else's. Errors never
- *   break the loop. Only when every source is held at once — a database
- *   unreachable for all of them — does the loop wait to the earliest expiry,
- *   so a fully skipped rotation neither spins nor delays a ready retry.
+ *   break the loop, and when every source is held at once — a database
+ *   unreachable for all of them — the wait to the earliest expiry is the
+ *   loop's, so it neither spins nor oversleeps the recovery.
  */
 export const runCaseLawReconciliationLoop = async ({
   isDraining,
@@ -247,7 +245,6 @@ export const runCaseLawReconciliationLoop = async ({
   // iterations: a rotation that restarted at zero would starve every source
   // after the first whenever the loop backed off mid-rotation.
   let workedThisRotation = 0;
-  let skippedThisRotation = 0;
 
   while (!isDraining()) {
     const sourceIndex = cursor % sources.length;
@@ -263,7 +260,6 @@ export const runCaseLawReconciliationLoop = async ({
       // Serving its backoff. The turn asked nobody for anything, so it owes
       // the publisher-politeness gap nothing; the next source goes now.
       delayMs = 0;
-      skippedThisRotation += 1;
     } else {
       try {
         // oxlint-disable-next-line no-await-in-loop -- one bounded unit at a time is the point; the next turn only starts after this one is paced
@@ -318,21 +314,29 @@ export const runCaseLawReconciliationLoop = async ({
       // polling at the unit rate.
       if (workedThisRotation > 0) {
         idleMs = timing.idleSleepMs;
-      } else if (skippedThisRotation === sources.length) {
-        // Every source is held. Skips cost no time, so wait exactly until the
-        // first source becomes retryable; applying the idle schedule here
-        // would either spin or delay recovery from a shared outage.
-        const earliestRetryAt = Math.min(...retryAtMs.values());
-        delayMs = Math.max(delayMs, earliestRetryAt - now());
       } else {
-        // At least one source was polled and none worked. This is an idle
-        // rotation even when another source was held, so its schedule advances
-        // independently of that source's retry deadline.
-        delayMs = Math.max(delayMs, idleMs);
+        // The idle schedule advances on its own terms, whether or not a source
+        // is held: a rotation that found nothing to do is the thing it exists
+        // to make cheap, and freezing it would leave a settled corpus polling
+        // the database at some held source's retry cadence forever.
+        const idleWaitMs = idleMs;
         idleMs = Math.min(idleMs * 2, timing.idleSleepMaxMs);
+        // A held source only ever caps that wait. There is work to try the
+        // moment its deadline expires, so the idle schedule must not sleep
+        // past it, and the unit gap is the floor because a rotation of skips
+        // costs no time of its own and must not spin.
+        const earliestRetryAt = Math.min(...retryAtMs.values());
+        delayMs = Math.max(
+          delayMs,
+          Number.isFinite(earliestRetryAt)
+            ? Math.min(
+                idleWaitMs,
+                Math.max(earliestRetryAt - now(), timing.unitDelayMs),
+              )
+            : idleWaitMs,
+        );
       }
       workedThisRotation = 0;
-      skippedThisRotation = 0;
     }
 
     if (now() >= summaryDueAt) {

--- a/apps/legal-atlas-runner/src/runners/case-law-reconciliation.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-reconciliation.ts
@@ -194,15 +194,17 @@ export type ReconciliationLoopOptions = {
  * - a worked turn is followed by `unitDelayMs`, whatever it produced. A unit
  *   that found nothing missing still listed a slice from a publisher; it does
  *   not earn a faster next turn.
- * - a turn where every source reported idle or leased doubles its sleep
- *   towards the idle ceiling, so a settled corpus stops asking the database
- *   every half second. Any worked turn resets it.
+ * - a rotation where at least one source reported idle or leased and none
+ *   worked doubles its sleep towards the idle ceiling, so a settled corpus
+ *   stops asking the database every half second. A held source does not cap
+ *   that schedule; its retry deadline belongs to its own turns. Any worked
+ *   turn resets it.
  * - a throw holds that source alone until its own backoff expires, doubling
  *   towards the failure ceiling. The loop keeps its pacing meanwhile, so a
  *   refusing publisher costs its own turns and nobody else's. Errors never
- *   break the loop, and when every source is held at once — a database
- *   unreachable for all of them — the wait to the earliest expiry is the
- *   loop's, so it neither spins nor oversleeps the recovery.
+ *   break the loop. Only when every source is held at once — a database
+ *   unreachable for all of them — does the loop wait to the earliest expiry,
+ *   so a fully skipped rotation neither spins nor delays a ready retry.
  */
 export const runCaseLawReconciliationLoop = async ({
   isDraining,
@@ -245,6 +247,7 @@ export const runCaseLawReconciliationLoop = async ({
   // iterations: a rotation that restarted at zero would starve every source
   // after the first whenever the loop backed off mid-rotation.
   let workedThisRotation = 0;
+  let skippedThisRotation = 0;
 
   while (!isDraining()) {
     const sourceIndex = cursor % sources.length;
@@ -260,6 +263,7 @@ export const runCaseLawReconciliationLoop = async ({
       // Serving its backoff. The turn asked nobody for anything, so it owes
       // the publisher-politeness gap nothing; the next source goes now.
       delayMs = 0;
+      skippedThisRotation += 1;
     } else {
       try {
         // oxlint-disable-next-line no-await-in-loop -- one bounded unit at a time is the point; the next turn only starts after this one is paced
@@ -314,29 +318,21 @@ export const runCaseLawReconciliationLoop = async ({
       // polling at the unit rate.
       if (workedThisRotation > 0) {
         idleMs = timing.idleSleepMs;
-      } else {
-        // The idle schedule advances on its own terms, whether or not a source
-        // is held: a rotation that found nothing to do is the thing it exists
-        // to make cheap, and freezing it would leave a settled corpus polling
-        // the database at some held source's retry cadence forever.
-        const idleWaitMs = idleMs;
-        idleMs = Math.min(idleMs * 2, timing.idleSleepMaxMs);
-        // A held source only ever caps that wait. There is work to try the
-        // moment its deadline expires, so the idle schedule must not sleep
-        // past it, and the unit gap is the floor because a rotation of skips
-        // costs no time of its own and must not spin.
+      } else if (skippedThisRotation === sources.length) {
+        // Every source is held. Skips cost no time, so wait exactly until the
+        // first source becomes retryable; applying the idle schedule here
+        // would either spin or delay recovery from a shared outage.
         const earliestRetryAt = Math.min(...retryAtMs.values());
-        delayMs = Math.max(
-          delayMs,
-          Number.isFinite(earliestRetryAt)
-            ? Math.min(
-                idleWaitMs,
-                Math.max(earliestRetryAt - now(), timing.unitDelayMs),
-              )
-            : idleWaitMs,
-        );
+        delayMs = Math.max(delayMs, earliestRetryAt - now());
+      } else {
+        // At least one source was polled and none worked. This is an idle
+        // rotation even when another source was held, so its schedule advances
+        // independently of that source's retry deadline.
+        delayMs = Math.max(delayMs, idleMs);
+        idleMs = Math.min(idleMs * 2, timing.idleSleepMaxMs);
       }
       workedThisRotation = 0;
+      skippedThisRotation = 0;
     }
 
     if (now() >= summaryDueAt) {


### PR DESCRIPTION
## Summary

- distinguish fully skipped rotations from mixed held-and-idle rotations
- let idle peers retain their independently growing idle schedule
- wait to the earliest retry deadline only when every source is held
- replace vacuous backoff assertions with exact fake-clock cadence and deadline coverage

Follow-up to #2064.