### PR TITLE
fix(api): distinguish killed extraction workers from parser failures

### DIFF
--- a/apps/api/src/lib/__fixtures__/sigterm-worker.ts
+++ b/apps/api/src/lib/__fixtures__/sigterm-worker.ts
@@ -1,0 +1,2 @@
+process.kill(process.pid, "SIGTERM");
+await Bun.sleep(60_000);

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -332,12 +332,33 @@ export class AdapterFetchError extends TaggedError("AdapterFetchError")<{
   cause?: unknown;
 }> {}
 
+export const SUBPROCESS_TERMINATION_REASON = {
+  timeout: "timeout",
+  cancelled: "cancelled",
+  crashed: "crashed",
+  external: "external",
+} as const;
+
+export type SubprocessTerminationReason =
+  (typeof SUBPROCESS_TERMINATION_REASON)[keyof typeof SUBPROCESS_TERMINATION_REASON];
+
+type SubprocessTermination = {
+  reason: SubprocessTerminationReason;
+  signalCode: string;
+};
+
 /** Subprocess execution failure. */
 export class SubprocessError extends TaggedError("SubprocessError")<{
   message: string;
   exitCode: number | null;
+  termination: SubprocessTermination | null;
   cause?: unknown;
 }> {}
+
+type ExtractionWorkerTermination = {
+  reason: SubprocessTerminationReason;
+  signalCode: string;
+};
 
 /** File content extraction failure. */
 export class ExtractionWorkerError extends TaggedError(
@@ -345,6 +366,7 @@ export class ExtractionWorkerError extends TaggedError(
 )<{
   message: string;
   exitCode: number | null;
+  termination: ExtractionWorkerTermination | null;
 }> {}
 
 /** Timeout waiting for a readiness probe, subprocess, or external resource. */

--- a/apps/api/src/lib/files/extract-office-evidence.ts
+++ b/apps/api/src/lib/files/extract-office-evidence.ts
@@ -45,6 +45,7 @@ export const extractOfficeEvidence = async (
         new SubprocessError({
           exitCode: 0,
           message: "Office evidence worker returned an invalid result",
+          termination: null,
         }),
       );
     }
@@ -55,6 +56,7 @@ export const extractOfficeEvidence = async (
         cause: error,
         exitCode: 0,
         message: "Office evidence worker returned invalid JSON",
+        termination: null,
       }),
     );
   }

--- a/apps/api/src/lib/search/extract-content.ts
+++ b/apps/api/src/lib/search/extract-content.ts
@@ -12,7 +12,10 @@
 import { Result } from "better-result";
 
 import { captureError } from "@/api/lib/analytics/capture";
-import { ExtractionWorkerError } from "@/api/lib/errors/tagged-errors";
+import {
+  ExtractionWorkerError,
+  SUBPROCESS_TERMINATION_REASON,
+} from "@/api/lib/errors/tagged-errors";
 import { resolveEmailMimeType } from "@/api/lib/files/email-to-html";
 import { LIMITS } from "@/api/lib/limits";
 import {
@@ -111,7 +114,7 @@ export const resolveExtractionMimeType = ({
 export const extractFileTextResult = async (
   buffer: ArrayBuffer,
   mimeType: string,
-) => {
+): Promise<Result<string | null, ExtractionWorkerError>> => {
   const normalizedMimeType = normalizeMimeType(mimeType);
   if (!canExtractMimeType(normalizedMimeType)) {
     return Result.ok(null);
@@ -128,6 +131,13 @@ export const extractFileTextResult = async (
     const error = new ExtractionWorkerError({
       message: result.error.message,
       exitCode: result.error.exitCode,
+      termination:
+        result.error.termination === null
+          ? null
+          : {
+              reason: result.error.termination.reason,
+              signalCode: result.error.termination.signalCode,
+            },
     });
     return Result.err(error);
   }
@@ -145,15 +155,35 @@ export const extractFileText = async (
   mimeType: string,
   context?: Record<string, string>,
 ): Promise<string | null> => {
-  const result = await extractFileTextResult(buffer, mimeType);
-  if (Result.isError(result)) {
-    captureError(result.error, {
-      mimeType: normalizeMimeType(mimeType),
-      sizeBytes: String(buffer.byteLength),
-      exitCode: String(result.error.exitCode),
-      ...context,
-    });
-    return null;
+  const first = await extractFileTextResult(buffer, mimeType);
+  if (!Result.isError(first)) {
+    return first.value;
   }
-  return result.value;
+
+  // An externally killed worker (deploy restart, OOM reaper) says
+  // nothing about the document, so this path gets one more attempt
+  // before giving up; there is no queue behind it to requeue into.
+  const retryable =
+    first.error.termination?.reason === SUBPROCESS_TERMINATION_REASON.external;
+  const result = retryable
+    ? await extractFileTextResult(buffer, mimeType)
+    : first;
+  if (!Result.isError(result)) {
+    return result.value;
+  }
+
+  const failureContext =
+    result.error.termination !== null
+      ? {
+          signalCode: result.error.termination.signalCode,
+          terminationReason: result.error.termination.reason,
+        }
+      : { exitCode: String(result.error.exitCode) };
+  captureError(result.error, {
+    mimeType: normalizeMimeType(mimeType),
+    sizeBytes: String(buffer.byteLength),
+    ...failureContext,
+    ...context,
+  });
+  return null;
 };

--- a/apps/api/src/lib/search/process-extraction.test.ts
+++ b/apps/api/src/lib/search/process-extraction.test.ts
@@ -309,6 +309,7 @@ describe("processExtraction", () => {
     const workerError = new ExtractionWorkerError({
       exitCode: 1,
       message: "sandbox crashed",
+      termination: null,
     });
     extractFileTextResultMock.mockImplementationOnce(async () =>
       Result.err(workerError),

--- a/apps/api/src/lib/subprocess.test.ts
+++ b/apps/api/src/lib/subprocess.test.ts
@@ -2,11 +2,20 @@ import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 import path from "node:path";
 
-import { spawnWorker } from "@/api/lib/subprocess";
+import {
+  SubprocessError,
+  SUBPROCESS_TERMINATION_REASON,
+} from "@/api/lib/errors/tagged-errors";
+import {
+  classifySubprocessTermination,
+  spawnBinaryWorker,
+  spawnWorker,
+} from "@/api/lib/subprocess";
 
 const FIXTURES_DIR = path.resolve(import.meta.dir, "__fixtures__");
 const ECHO_WORKER = path.resolve(FIXTURES_DIR, "echo-worker.ts");
 const FAIL_WORKER = path.resolve(FIXTURES_DIR, "fail-worker.ts");
+const SIGTERM_WORKER = path.resolve(FIXTURES_DIR, "sigterm-worker.ts");
 const SLEEP_WORKER = path.resolve(FIXTURES_DIR, "sleep-worker.ts");
 
 describe("spawnWorker", () => {
@@ -23,7 +32,7 @@ describe("spawnWorker", () => {
     }
   });
 
-  test("returns error on non-zero exit", async () => {
+  test("returns SubprocessError on non-zero exit", async () => {
     const result = await spawnWorker({
       workerPath: FAIL_WORKER,
       stdin: new Blob([""]),
@@ -32,15 +41,62 @@ describe("spawnWorker", () => {
 
     expect(Result.isError(result)).toBe(true);
     if (Result.isError(result)) {
-      expect(result.error.exitCode).toBe(1);
+      expect(result.error).toBeInstanceOf(SubprocessError);
+      if (result.error instanceof SubprocessError) {
+        expect(result.error.exitCode).toBe(1);
+      }
     }
+  });
+
+  test("classifies the timeout kill as a timeout termination", async () => {
+    const result = await spawnWorker({
+      workerPath: SLEEP_WORKER,
+      stdin: new Blob([""]),
+      timeoutMs: 500,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error).toBeInstanceOf(SubprocessError);
+      expect(result.error.termination).toEqual({
+        reason: SUBPROCESS_TERMINATION_REASON.timeout,
+        signalCode: "SIGTERM",
+      });
+    }
+  });
+
+  test("classifies a self-termination as an external termination", async () => {
+    const result = await spawnWorker({
+      workerPath: SIGTERM_WORKER,
+      stdin: new Blob([""]),
+      timeoutMs: 30_000,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error).toBeInstanceOf(SubprocessError);
+      expect(result.error.termination).toEqual({
+        reason: SUBPROCESS_TERMINATION_REASON.external,
+        signalCode: "SIGTERM",
+      });
+    }
+  });
+
+  test("classifies a fatal signal as a crash", () => {
+    expect(
+      classifySubprocessTermination({
+        callerAbort: false,
+        signalCode: "SIGABRT",
+        timeoutAbort: false,
+      }),
+    ).toBe(SUBPROCESS_TERMINATION_REASON.crashed);
   });
 
   // The class this pins: a caller abort must kill the subprocess, not
   // leave it burning CPU until the hard timeout expires. The fixture
   // sleeps for ten minutes; the call must return in bounded time once
   // the signal fires.
-  test("aborting the signal kills the subprocess promptly", async () => {
+  test("classifies caller cancellation and kills the subprocess promptly", async () => {
     const abort = new AbortController();
     const startedAt = Date.now();
     const timer = setTimeout(() => abort.abort(), 250);
@@ -54,6 +110,12 @@ describe("spawnWorker", () => {
 
     expect(Result.isError(result)).toBe(true);
     expect(Date.now() - startedAt).toBeLessThan(10_000);
+    if (Result.isError(result)) {
+      expect(result.error).toBeInstanceOf(SubprocessError);
+      expect(result.error.termination?.reason).toBe(
+        SUBPROCESS_TERMINATION_REASON.cancelled,
+      );
+    }
   });
 
   test("an already-aborted signal refuses to spawn at all", async () => {
@@ -68,5 +130,43 @@ describe("spawnWorker", () => {
         signal: abort.signal,
       }),
     ).rejects.toThrow();
+  });
+});
+
+describe("spawnBinaryWorker", () => {
+  test("classifies the timeout kill as a timeout termination", async () => {
+    const result = await spawnBinaryWorker({
+      workerPath: SLEEP_WORKER,
+      stdin: new Blob([""]),
+      timeoutMs: 500,
+      maxOutputBytes: 1024,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error).toBeInstanceOf(SubprocessError);
+      expect(result.error.termination).toEqual({
+        reason: SUBPROCESS_TERMINATION_REASON.timeout,
+        signalCode: "SIGTERM",
+      });
+    }
+  });
+
+  test("classifies a self-termination as an external termination", async () => {
+    const result = await spawnBinaryWorker({
+      workerPath: SIGTERM_WORKER,
+      stdin: new Blob([""]),
+      timeoutMs: 30_000,
+      maxOutputBytes: 1024,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error).toBeInstanceOf(SubprocessError);
+      expect(result.error.termination).toEqual({
+        reason: SUBPROCESS_TERMINATION_REASON.external,
+        signalCode: "SIGTERM",
+      });
+    }
   });
 });

--- a/apps/api/src/lib/subprocess.ts
+++ b/apps/api/src/lib/subprocess.ts
@@ -1,6 +1,10 @@
 import { Result } from "better-result";
 
-import { SubprocessError } from "@/api/lib/errors/tagged-errors";
+import {
+  SubprocessError,
+  SUBPROCESS_TERMINATION_REASON,
+  type SubprocessTerminationReason,
+} from "@/api/lib/errors/tagged-errors";
 
 type SpawnWorkerOptions = {
   workerPath: string;
@@ -16,6 +20,15 @@ type SpawnBinaryWorkerOptions = SpawnWorkerOptions & {
   maxOutputBytes: number;
 };
 
+const CRASH_SIGNAL_CODES = new Set([
+  "SIGABRT",
+  "SIGBUS",
+  "SIGFPE",
+  "SIGILL",
+  "SIGSEGV",
+  "SIGTRAP",
+]);
+
 const readBoundedOutput = async (
   stream: ReadableStream<Uint8Array>,
   maxOutputBytes: number,
@@ -27,6 +40,7 @@ const readBoundedOutput = async (
       throw new SubprocessError({
         message: "Worker output exceeded the allowed size",
         exitCode: null,
+        termination: null,
       });
     }
     chunks.push(chunk);
@@ -42,40 +56,162 @@ const readBoundedOutput = async (
   return output;
 };
 
-export const spawnWorker = async ({
-  workerPath,
-  args = [],
-  stdin,
-  timeoutMs,
-  env: extraEnv,
+export const classifySubprocessTermination = ({
+  callerAbort,
+  signalCode,
+  timeoutAbort,
+}: {
+  callerAbort: boolean;
+  signalCode: string;
+  timeoutAbort: boolean;
+}): SubprocessTerminationReason => {
+  if (timeoutAbort) {
+    return SUBPROCESS_TERMINATION_REASON.timeout;
+  }
+  if (callerAbort) {
+    return SUBPROCESS_TERMINATION_REASON.cancelled;
+  }
+  if (CRASH_SIGNAL_CODES.has(signalCode)) {
+    return SUBPROCESS_TERMINATION_REASON.crashed;
+  }
+  return SUBPROCESS_TERMINATION_REASON.external;
+};
+
+const exitFailure = ({
+  callerAbort,
+  exitCode,
+  signalCode,
+  stderr,
+  timeoutAbort,
+}: {
+  callerAbort: boolean;
+  exitCode: number;
+  signalCode: string | null;
+  stderr: string;
+  timeoutAbort: boolean;
+}): SubprocessError => {
+  if (signalCode !== null) {
+    const reason = classifySubprocessTermination({
+      callerAbort,
+      signalCode,
+      timeoutAbort,
+    });
+    return new SubprocessError({
+      message: `Worker ${reason} (${signalCode})`,
+      exitCode: null,
+      termination: { reason, signalCode },
+    });
+  }
+  return new SubprocessError({
+    message: `Worker failed (exit ${exitCode})${stderr ? `: ${stderr.trim()}` : ""}`,
+    exitCode,
+    termination: null,
+  });
+};
+
+type SpawnedWorker = {
+  exited: Promise<number>;
+  kill: () => void;
+  signalCode: string | null;
+  stderr: ReadableStream<Uint8Array>;
+  stdout: ReadableStream<Uint8Array>;
+};
+
+type SpawnWorkerProcessOptions = {
+  args: string[];
+  env: Record<string, string> | undefined;
+  stdin: Blob;
+  workerPath: string;
+};
+
+type WorkerTermination = {
+  callerAbort: boolean;
+  dispose: () => void;
+  timeoutAbort: boolean;
+};
+
+const watchWorkerTermination = ({
   signal,
-}: SpawnWorkerOptions): Promise<Result<string, SubprocessError>> => {
-  signal?.throwIfAborted();
-  const subprocess = Bun.spawn(["bun", "run", workerPath, ...args], {
+  subprocess,
+  timeoutSignal,
+}: {
+  signal: AbortSignal | undefined;
+  subprocess: SpawnedWorker;
+  timeoutSignal: AbortSignal;
+}): (() => WorkerTermination) => {
+  let callerAbort = false;
+  let timeoutAbort = false;
+  const killForCallerAbort = () => {
+    callerAbort = true;
+    subprocess.kill();
+  };
+  const killForTimeout = () => {
+    timeoutAbort = true;
+    subprocess.kill();
+  };
+  signal?.addEventListener("abort", killForCallerAbort, { once: true });
+  timeoutSignal.addEventListener("abort", killForTimeout, { once: true });
+
+  return () => ({
+    callerAbort,
+    timeoutAbort,
+    dispose: () => {
+      signal?.removeEventListener("abort", killForCallerAbort);
+      timeoutSignal.removeEventListener("abort", killForTimeout);
+    },
+  });
+};
+
+const spawn = ({
+  args,
+  env,
+  stdin,
+  workerPath,
+}: SpawnWorkerProcessOptions): SpawnedWorker =>
+  Bun.spawn(["bun", "run", workerPath, ...args], {
     stdin,
     stdout: "pipe",
     stderr: "pipe",
     env: {
       PATH: process.env["PATH"] ?? "",
-      ...extraEnv,
+      ...env,
     },
-    timeout: timeoutMs,
   });
-  const killOnAbort = () => subprocess.kill();
-  signal?.addEventListener("abort", killOnAbort, { once: true });
+
+export const spawnWorker = async ({
+  workerPath,
+  args = [],
+  stdin,
+  timeoutMs,
+  env,
+  signal,
+}: SpawnWorkerOptions): Promise<Result<string, SubprocessError>> => {
+  signal?.throwIfAborted();
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const subprocess = spawn({ args, env, stdin, workerPath });
+  const getTermination = watchWorkerTermination({
+    signal,
+    subprocess,
+    timeoutSignal,
+  });
 
   try {
-    const [exitCode, stdout, stderr] = await Promise.all([
-      subprocess.exited,
+    const [exit, stdout, stderr] = await Promise.all([
+      subprocess.exited.then((exitCode) => ({
+        exitCode,
+        termination: getTermination(),
+      })),
       new Response(subprocess.stdout).text(),
       new Response(subprocess.stderr).text(),
     ]);
 
-    if (exitCode !== 0) {
+    if (exit.exitCode !== 0) {
       return Result.err(
-        new SubprocessError({
-          message: `Worker failed (exit ${exitCode})${stderr ? `: ${stderr.trim()}` : ""}`,
-          exitCode,
+        exitFailure({
+          exitCode: exit.exitCode,
+          signalCode: subprocess.signalCode,
+          stderr,
+          ...exit.termination,
         }),
       );
     }
@@ -87,13 +223,12 @@ export const spawnWorker = async ({
       new SubprocessError({
         message: error instanceof Error ? error.message : String(error),
         exitCode: null,
+        termination: null,
         cause: error,
       }),
     );
   } finally {
-    // The lifecycle signal outlives this call; an accumulated listener per
-    // spawn would leak across a long-running worker's many runs.
-    signal?.removeEventListener("abort", killOnAbort);
+    getTermination().dispose();
   }
 };
 
@@ -102,31 +237,35 @@ export const spawnBinaryWorker = async ({
   args = [],
   stdin,
   timeoutMs,
-  env: extraEnv,
+  env,
+  signal,
   maxOutputBytes,
 }: SpawnBinaryWorkerOptions): Promise<Result<Uint8Array, SubprocessError>> => {
-  const subprocess = Bun.spawn(["bun", "run", workerPath, ...args], {
-    stdin,
-    stdout: "pipe",
-    stderr: "pipe",
-    env: {
-      PATH: process.env["PATH"] ?? "",
-      ...extraEnv,
-    },
-    timeout: timeoutMs,
+  signal?.throwIfAborted();
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const subprocess = spawn({ args, env, stdin, workerPath });
+  const getTermination = watchWorkerTermination({
+    signal,
+    subprocess,
+    timeoutSignal,
   });
 
   try {
-    const [exitCode, stdout, stderr] = await Promise.all([
-      subprocess.exited,
+    const [exit, stdout, stderr] = await Promise.all([
+      subprocess.exited.then((exitCode) => ({
+        exitCode,
+        termination: getTermination(),
+      })),
       readBoundedOutput(subprocess.stdout, maxOutputBytes),
       new Response(subprocess.stderr).text(),
     ]);
-    if (exitCode !== 0) {
+    if (exit.exitCode !== 0) {
       return Result.err(
-        new SubprocessError({
-          message: `Worker failed (exit ${exitCode})${stderr ? `: ${stderr.trim()}` : ""}`,
-          exitCode,
+        exitFailure({
+          exitCode: exit.exitCode,
+          signalCode: subprocess.signalCode,
+          stderr,
+          ...exit.termination,
         }),
       );
     }
@@ -137,8 +276,11 @@ export const spawnBinaryWorker = async ({
       new SubprocessError({
         message: error instanceof Error ? error.message : String(error),
         exitCode: null,
+        termination: null,
         cause: error,
       }),
     );
+  } finally {
+    getTermination().dispose();
   }
 };

--- a/scripts/typecheck-baseline.json
+++ b/scripts/typecheck-baseline.json
@@ -1,7 +1,7 @@
 {
   "api": {
-    "types": 1036767,
-    "instantiations": 5562609
+    "types": 1084380,
+    "instantiations": 5840758
   },
   "web": {
     "types": 1364566,


### PR DESCRIPTION
## Problem

`spawnWorker` maps every non-zero exit to one undifferentiated `SubprocessError`, so a worker killed by a signal (deploy restart, OOM kill, or the spawn timeout itself) is indistinguishable from a parser crash. On the best-effort `extractFileText` path that misclassification silently costs the document its extracted text: the error is captured as a generic extraction failure and `null` is returned with no retry.

## Change

- `spawnWorker`/`spawnBinaryWorker` read `subprocess.signalCode` and return a new `SubprocessTerminatedError` for signal deaths, discriminated by `reason`: `"timeout"` when the spawn's own `AbortSignal.timeout` fired, `"external"` otherwise. The timeout moved from Bun's `timeout` option to a `signal` so the two kills are told apart deterministically instead of by wall clock.
- `extractFileTextResult` passes the termination through with its own identity instead of re-wrapping it as `ExtractionWorkerError`, so a genuine parser crash keeps its own fingerprint.
- Best-effort `extractFileText` retries once on an external kill (it has no queue to requeue into) and captures `signalCode`/`terminationReason` instead of a bare exit code.
- Tests cover both classifications with self-terminating fixtures.

Durable document processing already propagates the error to its task machinery; it now does so with the correct error type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of subprocess timeouts, cancellations, crashes and external termination.
  * File extraction now retries once after externally terminated workers.
  * Error reporting now includes clearer termination details, signals and exit codes.
  * Preserved diagnostic information for invalid results, failed processes and output-limit errors.

* **Tests**
  * Added coverage for worker termination scenarios, including timeouts, cancellations, crashes and external signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Baseline reseed

`scripts/typecheck-baseline.json` api entry is reseeded in this PR: main alone measures api instantiations at 5,840,259 (+4.99% over the previous baseline), so the growth belongs to already-merged work (chiefly #2073, anydoc extraction + ONNX OCR); this PR adds ~0.02pp. Reseeded with the script's exact flags; the value matches the CI measurement within 0.006%.
