### PR TITLE
fix(web): capture the real server error on cell retry failures

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-retry-cell.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-retry-cell.ts
@@ -5,6 +5,8 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
+import { toAPIError } from "@/lib/errors/api";
+import { ClientTelemetryError } from "@/lib/errors/telemetry";
 import { userErrorMessage } from "@/lib/errors/user-safe";
 import type { EntityId, PropertyId, WorkspaceId } from "@/lib/types";
 import { entitiesKeys } from "@/lib/workspaces/queries/entities";
@@ -35,7 +37,20 @@ export const useRetryCell = (workspaceId: WorkspaceId) => {
         });
 
       if (response.error) {
-        analytics.captureError(new Error("Failed to retry cell"));
+        const apiError = toAPIError(response.error);
+        // 4xx rejections (locked cell, concurrent workflow, read-only
+        // entity) are expected business refusals: the toast is their
+        // whole story. Only a 5xx — the enqueue path breaking — is an
+        // exception worth capturing.
+        if (apiError.status >= 500) {
+          analytics.captureError(
+            new ClientTelemetryError({
+              area: "cell-retry",
+              message: `Cell retry failed (status ${apiError.status})`,
+              cause: apiError,
+            }),
+          );
+        }
         // Surface server-side rejections (locked cell, concurrent
         // workflow, read-only entity) — without this the user just
         // sees the menu close and nothing happens. `userErrorMessage`


### PR DESCRIPTION
## Problem

`useRetryCell` captured a synthetic `new Error("Failed to retry cell")` on every rejected retry, discarding the server response it then reads for the toast. All distinct rejections (404 property/entity, 400 not AI-extracted, 409 locked/read-only/workflow-running, 500 enqueue failure) collapsed into one context-free fingerprint, and expected business refusals were reported as exceptions.

## Change

The failure branch converts the response with `toAPIError` and only captures 5xx, wrapped in a `ClientTelemetryError` with a `cell-retry` area and the `APIError` as `cause`, so the deepest stack survives the telemetry redaction contract. 4xx refusals keep their toast and stop generating exceptions. (Status, ids, and message cannot ride along as properties: the exception sanitizer strips everything but the error type, `area`, and `error_reference` by design.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when retrying workspace cells.
  * User-facing notifications continue to appear for expected request rejections.
  * Unexpected server-side failures are now recorded more accurately for diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->