### PR TITLE
feat(web): capture web vitals with a route-template sanitizer

### DIFF
--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -18,7 +18,9 @@ type PostHogInitOptions = {
   capture_dead_clicks: boolean;
   capture_heatmaps: boolean;
   capture_pageview: boolean;
-  capture_performance: boolean;
+  capture_performance:
+    | boolean
+    | { network_timing: boolean; web_vitals: boolean };
   disable_persistence: boolean;
   disable_session_recording: boolean;
   mask_all_text: boolean;
@@ -107,7 +109,7 @@ describe("PostHog browser analytics adapter", () => {
       capture_dead_clicks: false,
       capture_heatmaps: false,
       capture_pageview: false,
-      capture_performance: false,
+      capture_performance: { network_timing: false, web_vitals: true },
       disable_persistence: true,
       disable_session_recording: true,
       mask_all_text: true,
@@ -644,6 +646,18 @@ describe("PostHog browser analytics adapter", () => {
     for (const key of INGESTION_REQUIRED_KEYS) {
       expect(routeError?.properties[key]).toEqual(envelope[key]);
     }
+
+    const webVitals = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.webVitals,
+      properties: {
+        ...envelope,
+        $web_vitals_LCP_value: 1234.5,
+      },
+    });
+    for (const key of INGESTION_REQUIRED_KEYS) {
+      expect(webVitals?.properties?.[key]).toEqual(envelope[key]);
+    }
+    expect(webVitals?.properties).not.toContainKeys(["$lib", "$current_url"]);
   });
 
   test("before_send keeps only valid opaque recovery references", () => {
@@ -679,6 +693,86 @@ describe("PostHog browser analytics adapter", () => {
         $exception_list: [{ type: "TypeError", value: "" }],
         $exception_type: "TypeError",
       },
+    });
+  });
+
+  test("web vitals keep metric values and coarse context, never attribution or resolved URLs", () => {
+    const { analytics } = createPostHogAnalytics(
+      "phc_test",
+      "https://posthog.test",
+    );
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: new URL("https://app.example.test"),
+    });
+    analytics.capturePageViewed({ path: "/workspaces/$workspaceId" });
+
+    const sanitized = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.webVitals,
+      properties: {
+        token: "phc_test",
+        distinct_id: "018f9f0e-7b42-7cc8-9a5d-42db46f6842d",
+        $current_url:
+          "https://app.example.test/workspaces/private-matter-018f9f0e",
+        $pathname: "/workspaces/private-matter-018f9f0e",
+        $session_id: "018f9f0e-7b42-7cc8-9a5d-42db46f6842e",
+        $browser: "Chrome",
+        $web_vitals_LCP_value: 1234.5,
+        $web_vitals_CLS_value: 0.02,
+        $web_vitals_LCP_event: {
+          name: "LCP",
+          value: 1234.5,
+          $current_url:
+            "https://app.example.test/workspaces/private-matter-018f9f0e",
+          attribution: { element: "div#client-name" },
+        },
+        $web_vitals_CLS_event: { name: "CLS", value: 0.02 },
+      },
+    });
+
+    expect(sanitized).toEqual({
+      event: WEB_ANALYTICS_EVENTS.webVitals,
+      properties: {
+        token: "phc_test",
+        distinct_id: "018f9f0e-7b42-7cc8-9a5d-42db46f6842d",
+        $web_vitals_LCP_value: 1234.5,
+        $web_vitals_CLS_value: 0.02,
+        $session_id: "018f9f0e-7b42-7cc8-9a5d-42db46f6842e",
+        $browser: "Chrome",
+        $current_url: "https://app.example.test/workspaces/$workspaceId",
+        $pathname: "/workspaces/$workspaceId",
+      },
+    });
+  });
+
+  test("web vitals without metric values or a seen route are constrained", () => {
+    createPostHogAnalytics("phc_test", "https://posthog.test");
+
+    // No metric values: nothing worth ingesting.
+    expect(
+      initOptions?.before_send({
+        event: WEB_ANALYTICS_EVENTS.webVitals,
+        properties: {
+          token: "phc_test",
+          $current_url: "https://app.example.test/workspaces/private-matter",
+        },
+      }),
+    ).toBeNull();
+
+    // Metric values before any capturePageViewed: the resolved URL is
+    // dropped rather than substituted.
+    const sanitized = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.webVitals,
+      properties: {
+        token: "phc_test",
+        $current_url: "https://app.example.test/workspaces/private-matter",
+        $pathname: "/workspaces/private-matter",
+        $web_vitals_INP_value: 87,
+      },
+    });
+    expect(sanitized?.properties).toEqual({
+      token: "phc_test",
+      $web_vitals_INP_value: 87,
     });
   });
 

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -703,7 +703,9 @@ describe("PostHog browser analytics adapter", () => {
     );
     Object.defineProperty(globalThis, "location", {
       configurable: true,
-      value: new URL("https://app.example.test"),
+      value: new URL(
+        "https://app.example.test/workspaces/private-matter-018f9f0e",
+      ),
     });
     analytics.capturePageViewed({ path: "/workspaces/$workspaceId" });
 
@@ -745,7 +747,49 @@ describe("PostHog browser analytics adapter", () => {
     });
   });
 
-  test("web vitals without metric values or a seen route are constrained", () => {
+  // Vitals can flush after the next navigation resolves, so attribution
+  // must follow the metric's originating URL, not the latest route.
+  test("web vitals flushed after a navigation keep their originating route", () => {
+    const { analytics } = createPostHogAnalytics(
+      "phc_test",
+      "https://posthog.test",
+    );
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: new URL("https://app.example.test/workspaces/private-matter-a"),
+    });
+    analytics.capturePageViewed({ path: "/workspaces/$workspaceId" });
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: new URL("https://app.example.test/contacts"),
+    });
+    analytics.capturePageViewed({ path: "/contacts" });
+
+    // Measured on the workspace route, delivered while /contacts is
+    // current: the label must stay the workspace template.
+    const sanitized = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.webVitals,
+      properties: {
+        token: "phc_test",
+        $current_url: "https://app.example.test/contacts",
+        $pathname: "/contacts",
+        $web_vitals_INP_value: 87,
+        $web_vitals_INP_event: {
+          name: "INP",
+          value: 87,
+          $current_url: "https://app.example.test/workspaces/private-matter-a",
+        },
+      },
+    });
+    expect(sanitized?.properties?.["$pathname"]).toBe(
+      "/workspaces/$workspaceId",
+    );
+    expect(sanitized?.properties?.["$current_url"]).toBe(
+      "https://app.example.test/workspaces/$workspaceId",
+    );
+  });
+
+  test("web vitals without metric values or a known origin are constrained", () => {
     createPostHogAnalytics("phc_test", "https://posthog.test");
 
     // No metric values: nothing worth ingesting.
@@ -759,8 +803,8 @@ describe("PostHog browser analytics adapter", () => {
       }),
     ).toBeNull();
 
-    // Metric values before any capturePageViewed: the resolved URL is
-    // dropped rather than substituted.
+    // An originating URL no capturePageViewed ever recorded: the
+    // resolved URL is dropped rather than substituted or mislabeled.
     const sanitized = initOptions?.before_send({
       event: WEB_ANALYTICS_EVENTS.webVitals,
       properties: {
@@ -768,6 +812,11 @@ describe("PostHog browser analytics adapter", () => {
         $current_url: "https://app.example.test/workspaces/private-matter",
         $pathname: "/workspaces/private-matter",
         $web_vitals_INP_value: 87,
+        $web_vitals_INP_event: {
+          name: "INP",
+          value: 87,
+          $current_url: "https://app.example.test/workspaces/private-matter",
+        },
       },
     });
     expect(sanitized?.properties).toEqual({

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -223,19 +223,62 @@ type RouteErrorLifecycleSanitizer = typeof sanitizeRouteErrorLifecycleEvent;
 let routeErrorLifecycleSanitizer: RouteErrorLifecycleSanitizer | undefined;
 
 // The SDK stamps `$web_vitals` events with the resolved URL, which can
-// carry resource ids. `capturePageViewed` records the matched route
-// template here so the sanitizer can substitute it; until the first page
-// view lands the URL fields are dropped rather than leaked.
-let lastPageViewPath: string | null = null;
+// carry resource ids. `capturePageViewed` records resolved pathname →
+// route template for recent navigations; the sanitizer attributes each
+// event via its originating URL rather than the latest route, because
+// vitals (CLS, INP) can flush after the next navigation resolves. An
+// unknown origin drops the URL fields rather than mislabeling them.
+const ROUTE_TEMPLATE_HISTORY_LIMIT = 50;
+const routeTemplateByPath = new Map<string, string>();
 
-// Value keys per metric, total over the SDK's metric union so a new
+const recordRouteTemplate = (resolvedPath: string, template: string): void => {
+  routeTemplateByPath.delete(resolvedPath);
+  routeTemplateByPath.set(resolvedPath, template);
+  for (const key of routeTemplateByPath.keys()) {
+    if (routeTemplateByPath.size <= ROUTE_TEMPLATE_HISTORY_LIMIT) {
+      break;
+    }
+    routeTemplateByPath.delete(key);
+  }
+};
+
+// Property keys per metric, total over the SDK's metric union so a new
 // metric cannot land without a decision here.
-const WEB_VITALS_VALUE_KEYS = {
-  CLS: "$web_vitals_CLS_value",
-  FCP: "$web_vitals_FCP_value",
-  INP: "$web_vitals_INP_value",
-  LCP: "$web_vitals_LCP_value",
-} as const satisfies Record<SupportedWebVitalsMetrics, string>;
+const WEB_VITALS_KEYS = {
+  CLS: { value: "$web_vitals_CLS_value", event: "$web_vitals_CLS_event" },
+  FCP: { value: "$web_vitals_FCP_value", event: "$web_vitals_FCP_event" },
+  INP: { value: "$web_vitals_INP_value", event: "$web_vitals_INP_event" },
+  LCP: { value: "$web_vitals_LCP_value", event: "$web_vitals_LCP_event" },
+} as const satisfies Record<
+  SupportedWebVitalsMetrics,
+  { value: string; event: string }
+>;
+
+/**
+ * The URL the vitals were measured on, read from the SDK's per-metric
+ * event payloads (stamped when each metric fired, not when the batch
+ * flushed).
+ */
+const webVitalsOriginatingUrl = (
+  properties: Record<string, unknown>,
+): URL | null => {
+  for (const { event } of Object.values(WEB_VITALS_KEYS)) {
+    const entry = properties[event];
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const url = entry["$current_url"];
+    if (typeof url !== "string") {
+      continue;
+    }
+    try {
+      return new URL(url);
+    } catch {
+      continue;
+    }
+  }
+  return null;
+};
 
 // Coarse client context worth keeping on web vitals: device/viewport
 // slicing without URLs, element attribution, or user content.
@@ -259,7 +302,8 @@ const WEB_VITALS_CONTEXT_KEYS = [
 const sanitizeWebVitalsEvent = (event: CaptureResult): CaptureResult | null => {
   const properties: Record<string, unknown> = event.properties;
   const metricValues = Object.fromEntries(
-    Object.values(WEB_VITALS_VALUE_KEYS)
+    Object.values(WEB_VITALS_KEYS)
+      .map(({ value }) => value)
       .filter((key) => typeof properties[key] === "number")
       .map((key) => [key, properties[key]]),
   );
@@ -274,7 +318,9 @@ const sanitizeWebVitalsEvent = (event: CaptureResult): CaptureResult | null => {
   );
   const appCommit = properties["app_commit"];
   const appVersion = properties["app_version"];
-  const hasLocation = "location" in globalThis;
+  const origin = webVitalsOriginatingUrl(properties);
+  const template =
+    origin === null ? undefined : routeTemplateByPath.get(origin.pathname);
   return {
     ...event,
     properties: {
@@ -283,16 +329,12 @@ const sanitizeWebVitalsEvent = (event: CaptureResult): CaptureResult | null => {
       ...context,
       ...(typeof appCommit === "string" ? { app_commit: appCommit } : {}),
       ...(typeof appVersion === "string" ? { app_version: appVersion } : {}),
-      ...(lastPageViewPath === null
-        ? {}
-        : {
-            ...(hasLocation
-              ? {
-                  $current_url: `${globalThis.location.origin}${lastPageViewPath}`,
-                }
-              : {}),
-            $pathname: lastPageViewPath,
-          }),
+      ...(origin !== null && template !== undefined
+        ? {
+            $current_url: `${origin.origin}${template}`,
+            $pathname: template,
+          }
+        : {}),
     },
   };
 };
@@ -339,7 +381,7 @@ export const createPostHogAnalytics = (
   host: string,
 ): { analytics: Analytics; client: typeof posthog | undefined } => {
   const localDebugEnabled = import.meta.env.DEV && env.VITE_POSTHOG_LOCAL_DEBUG;
-  lastPageViewPath = null;
+  routeTemplateByPath.clear();
   const client = posthog.init(key, {
     opt_out_capturing_by_default: import.meta.env.DEV && !localDebugEnabled,
     api_host: host,
@@ -426,7 +468,9 @@ export const createPostHogAnalytics = (
       // `location` always exists, but during SSR it does not; the `in` check
       // is the runtime truth the types cannot express.
       const hasLocation = "location" in globalThis;
-      lastPageViewPath = path;
+      if (hasLocation) {
+        recordRouteTemplate(globalThis.location.pathname, path);
+      }
       posthog.capture(WEB_ANALYTICS_EVENTS.pageViewed, {
         ...(hasLocation
           ? { $current_url: `${globalThis.location.origin}${path}` }

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -1,6 +1,6 @@
 import { CancelledError } from "@tanstack/react-query";
 import { posthog } from "posthog-js";
-import type { CaptureResult } from "posthog-js";
+import type { CaptureResult, SupportedWebVitalsMetrics } from "posthog-js";
 
 import { env } from "@/env";
 import {
@@ -222,6 +222,81 @@ const sanitizeExceptionEvent = (event: CaptureResult): CaptureResult => {
 type RouteErrorLifecycleSanitizer = typeof sanitizeRouteErrorLifecycleEvent;
 let routeErrorLifecycleSanitizer: RouteErrorLifecycleSanitizer | undefined;
 
+// The SDK stamps `$web_vitals` events with the resolved URL, which can
+// carry resource ids. `capturePageViewed` records the matched route
+// template here so the sanitizer can substitute it; until the first page
+// view lands the URL fields are dropped rather than leaked.
+let lastPageViewPath: string | null = null;
+
+// Value keys per metric, total over the SDK's metric union so a new
+// metric cannot land without a decision here.
+const WEB_VITALS_VALUE_KEYS = {
+  CLS: "$web_vitals_CLS_value",
+  FCP: "$web_vitals_FCP_value",
+  INP: "$web_vitals_INP_value",
+  LCP: "$web_vitals_LCP_value",
+} as const satisfies Record<SupportedWebVitalsMetrics, string>;
+
+// Coarse client context worth keeping on web vitals: device/viewport
+// slicing without URLs, element attribution, or user content.
+const WEB_VITALS_CONTEXT_KEYS = [
+  "$session_id",
+  "$window_id",
+  "$browser",
+  "$browser_version",
+  "$os",
+  "$device_type",
+  "$viewport_height",
+  "$viewport_width",
+] as const;
+
+/**
+ * Rebuild a `$web_vitals` payload from an allowlist: metric values plus
+ * coarse client context. The SDK's per-metric `$web_vitals_*_event`
+ * objects (element attribution, resolved URLs) never pass through, and
+ * the URL fields are replaced with the last captured route template.
+ */
+const sanitizeWebVitalsEvent = (event: CaptureResult): CaptureResult | null => {
+  const properties: Record<string, unknown> = event.properties;
+  const metricValues = Object.fromEntries(
+    Object.values(WEB_VITALS_VALUE_KEYS)
+      .filter((key) => typeof properties[key] === "number")
+      .map((key) => [key, properties[key]]),
+  );
+  if (Object.keys(metricValues).length === 0) {
+    return null;
+  }
+  const context = Object.fromEntries(
+    WEB_VITALS_CONTEXT_KEYS.filter((key) => key in properties).map((key) => [
+      key,
+      properties[key],
+    ]),
+  );
+  const appCommit = properties["app_commit"];
+  const appVersion = properties["app_version"];
+  const hasLocation = "location" in globalThis;
+  return {
+    ...event,
+    properties: {
+      ...pickIngestionRequired(properties),
+      ...metricValues,
+      ...context,
+      ...(typeof appCommit === "string" ? { app_commit: appCommit } : {}),
+      ...(typeof appVersion === "string" ? { app_version: appVersion } : {}),
+      ...(lastPageViewPath === null
+        ? {}
+        : {
+            ...(hasLocation
+              ? {
+                  $current_url: `${globalThis.location.origin}${lastPageViewPath}`,
+                }
+              : {}),
+            $pathname: lastPageViewPath,
+          }),
+    },
+  };
+};
+
 const errorContextProperties = (
   context: ErrorCaptureContext | undefined,
 ): Record<string, string> | undefined => {
@@ -254,16 +329,17 @@ const devErrorContext = (
 /**
  * Initialize PostHog and return an Analytics adapter.
  *
- * Stella only sends error diagnostics through this adapter. Session
- * replay, heatmaps, autocapture, and remote PostHog feature configuration are
- * structurally disabled here rather than relying on deployment-specific
- * environment settings.
+ * Stella sends only error diagnostics, template-path page views, and web
+ * vitals through this adapter. Session replay, heatmaps, autocapture, and
+ * remote PostHog feature configuration are structurally disabled here
+ * rather than relying on deployment-specific environment settings.
  */
 export const createPostHogAnalytics = (
   key: string,
   host: string,
 ): { analytics: Analytics; client: typeof posthog | undefined } => {
   const localDebugEnabled = import.meta.env.DEV && env.VITE_POSTHOG_LOCAL_DEBUG;
+  lastPageViewPath = null;
   const client = posthog.init(key, {
     opt_out_capturing_by_default: import.meta.env.DEV && !localDebugEnabled,
     api_host: host,
@@ -288,7 +364,7 @@ export const createPostHogAnalytics = (
     mask_personal_data_properties: true,
     person_profiles: "identified_only",
     capture_heatmaps: false,
-    capture_performance: false,
+    capture_performance: { network_timing: false, web_vitals: true },
     capture_pageview: false,
     before_send: (event) => {
       if (import.meta.env.DEV && !localDebugEnabled) {
@@ -308,6 +384,9 @@ export const createPostHogAnalytics = (
       }
       if (event.event === WEB_ANALYTICS_EVENTS.routeErrorRecovery) {
         return routeErrorLifecycleSanitizer?.(event) ?? null;
+      }
+      if (event.event === WEB_ANALYTICS_EVENTS.webVitals) {
+        return sanitizeWebVitalsEvent(event);
       }
       return event;
     },
@@ -347,6 +426,7 @@ export const createPostHogAnalytics = (
       // `location` always exists, but during SSR it does not; the `in` check
       // is the runtime truth the types cannot express.
       const hasLocation = "location" in globalThis;
+      lastPageViewPath = path;
       posthog.capture(WEB_ANALYTICS_EVENTS.pageViewed, {
         ...(hasLocation
           ? { $current_url: `${globalThis.location.origin}${path}` }

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -224,21 +224,26 @@ let routeErrorLifecycleSanitizer: RouteErrorLifecycleSanitizer | undefined;
 
 // The SDK stamps `$web_vitals` events with the resolved URL, which can
 // carry resource ids. `capturePageViewed` records resolved pathname →
-// route template for recent navigations; the sanitizer attributes each
-// event via its originating URL rather than the latest route, because
-// vitals (CLS, INP) can flush after the next navigation resolves. An
-// unknown origin drops the URL fields rather than mislabeling them.
+// route template for recent navigations (a bounded, adapter-owned map);
+// the sanitizer attributes each event via its originating URL rather
+// than the latest route, because vitals (CLS, INP) can flush after the
+// next navigation resolves. An unknown origin drops the URL fields
+// rather than mislabeling them.
 const ROUTE_TEMPLATE_HISTORY_LIMIT = 50;
-const routeTemplateByPath = new Map<string, string>();
+type RouteTemplateHistory = Map<string, string>;
 
-const recordRouteTemplate = (resolvedPath: string, template: string): void => {
-  routeTemplateByPath.delete(resolvedPath);
-  routeTemplateByPath.set(resolvedPath, template);
-  for (const key of routeTemplateByPath.keys()) {
-    if (routeTemplateByPath.size <= ROUTE_TEMPLATE_HISTORY_LIMIT) {
+const recordRouteTemplate = (
+  history: RouteTemplateHistory,
+  resolvedPath: string,
+  template: string,
+): void => {
+  history.delete(resolvedPath);
+  history.set(resolvedPath, template);
+  for (const key of history.keys()) {
+    if (history.size <= ROUTE_TEMPLATE_HISTORY_LIMIT) {
       break;
     }
-    routeTemplateByPath.delete(key);
+    history.delete(key);
   }
 };
 
@@ -299,7 +304,10 @@ const WEB_VITALS_CONTEXT_KEYS = [
  * objects (element attribution, resolved URLs) never pass through, and
  * the URL fields are replaced with the last captured route template.
  */
-const sanitizeWebVitalsEvent = (event: CaptureResult): CaptureResult | null => {
+const sanitizeWebVitalsEvent = (
+  event: CaptureResult,
+  history: RouteTemplateHistory,
+): CaptureResult | null => {
   const properties: Record<string, unknown> = event.properties;
   const metricValues = Object.fromEntries(
     Object.values(WEB_VITALS_KEYS)
@@ -319,8 +327,7 @@ const sanitizeWebVitalsEvent = (event: CaptureResult): CaptureResult | null => {
   const appCommit = properties["app_commit"];
   const appVersion = properties["app_version"];
   const origin = webVitalsOriginatingUrl(properties);
-  const template =
-    origin === null ? undefined : routeTemplateByPath.get(origin.pathname);
+  const template = origin === null ? undefined : history.get(origin.pathname);
   return {
     ...event,
     properties: {
@@ -381,7 +388,7 @@ export const createPostHogAnalytics = (
   host: string,
 ): { analytics: Analytics; client: typeof posthog | undefined } => {
   const localDebugEnabled = import.meta.env.DEV && env.VITE_POSTHOG_LOCAL_DEBUG;
-  routeTemplateByPath.clear();
+  const routeTemplateHistory: RouteTemplateHistory = new Map();
   const client = posthog.init(key, {
     opt_out_capturing_by_default: import.meta.env.DEV && !localDebugEnabled,
     api_host: host,
@@ -428,7 +435,7 @@ export const createPostHogAnalytics = (
         return routeErrorLifecycleSanitizer?.(event) ?? null;
       }
       if (event.event === WEB_ANALYTICS_EVENTS.webVitals) {
-        return sanitizeWebVitalsEvent(event);
+        return sanitizeWebVitalsEvent(event, routeTemplateHistory);
       }
       return event;
     },
@@ -469,7 +476,11 @@ export const createPostHogAnalytics = (
       // is the runtime truth the types cannot express.
       const hasLocation = "location" in globalThis;
       if (hasLocation) {
-        recordRouteTemplate(globalThis.location.pathname, path);
+        recordRouteTemplate(
+          routeTemplateHistory,
+          globalThis.location.pathname,
+          path,
+        );
       }
       posthog.capture(WEB_ANALYTICS_EVENTS.pageViewed, {
         ...(hasLocation

--- a/apps/web/src/lib/analytics/types.ts
+++ b/apps/web/src/lib/analytics/types.ts
@@ -6,6 +6,9 @@ export const WEB_ANALYTICS_EVENTS = {
   // The standard event name, so PostHog web analytics aggregates our page
   // views; the payload still carries route templates, never resolved URLs.
   pageViewed: "$pageview",
+  // SDK-emitted performance metrics; `before_send` rebuilds the payload so
+  // only metric values and coarse client context leave the browser.
+  webVitals: "$web_vitals",
   guideStepSkipped: "guide_step_skipped",
   routeErrorRecovery: "route_error_recovery",
 } as const;


### PR DESCRIPTION
## What

Enables posthog-js web vitals autocapture and routes the resulting `$web_vitals` events through the same `before_send` privacy contract as the rest of the telemetry.

## How

- `capture_performance: { network_timing: false, web_vitals: true }`; network timing stays structurally off.
- `$web_vitals` joins the event allowlist with a dedicated sanitizer that rebuilds the payload from an allowlist: per-metric `$web_vitals_*_value` numbers (keys are a total map over the SDK's `SupportedWebVitalsMetrics` union, so a new SDK metric fails typecheck until a decision is made here), coarse client context (session/window ids, browser, OS, device type, viewport), build metadata, and the ingestion-required keys.
- The SDK's per-metric `*_event` objects (element attribution, resolved URLs) never pass through. `capturePageViewed` records the matched route template, and the sanitizer substitutes it for `$current_url`/`$pathname`, so vitals aggregate by route template exactly like page views. Events that fire before the first page view drop the URL fields instead of leaking them.
- Events with no metric values are dropped.

## Tests

Sanitizer rebuild, the no-metric and no-route edges, and the ingestion-required-keys guard extended to the new sanitizer (fixtures carry `token`/`distinct_id`, per the posthog-js drop-on-strip behavior).