### PR TITLE
fix: accept canonical canary completion result

### DIFF
--- a/packages/agent-engine/scripts/canary-harness-protocol.test.ts
+++ b/packages/agent-engine/scripts/canary-harness-protocol.test.ts
@@ -15,6 +15,7 @@ const MODEL = "canary-model";
 const RUN_ID = "canary-run";
 const THREAD_ID = "canary-thread";
 const FINISH_TOOL_CALL_ID = "finish-tool-call";
+const FINISH_TOOL_COMPLETED_RESULT = JSON.stringify({ status: "completed" });
 
 const finishToolStart = {
   type: EventType.TOOL_CALL_START,
@@ -81,6 +82,17 @@ describe("real harness completion protocol", () => {
     ).toBeUndefined();
   });
 
+  test("accepts Codex's canonical completed fallback for an MCP result without text", () => {
+    const completedFallback = {
+      ...finishToolResult,
+      content: FINISH_TOOL_COMPLETED_RESULT,
+    } satisfies CanaryHarnessChunk;
+
+    expect(
+      observe([runStarted, finishToolStart, completedFallback, runFinished]),
+    ).toBeUndefined();
+  });
+
   test("does not accept an assistant claim without the finish tool result", () => {
     expect(
       observe([runStarted, text(CANARY_COMPLETION_MARKER), runFinished]),
@@ -115,6 +127,17 @@ describe("real harness completion protocol", () => {
 
     expect(
       observe([runStarted, finishToolStart, failedFinishResult, runFinished]),
+    ).toBe("canary_finish did not return its exact completion marker");
+  });
+
+  test("rejects a non-canonical completed fallback", () => {
+    const nonCanonicalFallback = {
+      ...finishToolResult,
+      content: JSON.stringify({ status: "completed", extra: true }),
+    } satisfies CanaryHarnessChunk;
+
+    expect(
+      observe([runStarted, finishToolStart, nonCanonicalFallback, runFinished]),
     ).toBe("canary_finish did not return its exact completion marker");
   });
 

--- a/packages/agent-engine/scripts/canary-harness-protocol.ts
+++ b/packages/agent-engine/scripts/canary-harness-protocol.ts
@@ -8,6 +8,9 @@ import {
 
 export const CANARY_MCP_SERVER_NAME = "stella_canary";
 export const CANARY_FINISH_STREAM_TOOL_NAME = `mcp__${CANARY_MCP_SERVER_NAME}__${CANARY_FINISH_TOOL_NAME}`;
+const CANARY_FINISH_COMPLETED_RESULT = JSON.stringify({
+  status: "completed",
+});
 
 type ToolCallStartChunk = Extract<StreamChunk, { type: "TOOL_CALL_START" }>;
 
@@ -107,7 +110,7 @@ export const consumeCanaryHarnessChunk = (
       }
       observation.finishToolCallIds.add(chunk.toolCallId);
       return;
-    case EventType.TOOL_CALL_RESULT:
+    case EventType.TOOL_CALL_RESULT: {
       if (!observation.finishToolCallIds.has(chunk.toolCallId)) {
         return;
       }
@@ -118,10 +121,10 @@ export const consumeCanaryHarnessChunk = (
         };
         return;
       }
-      if (
-        chunk.state === "output-error" ||
-        chunk.content !== CANARY_COMPLETION_MARKER
-      ) {
+      const isExpectedResult =
+        chunk.content === CANARY_COMPLETION_MARKER ||
+        chunk.content === CANARY_FINISH_COMPLETED_RESULT;
+      if (chunk.state === "output-error" || !isExpectedResult) {
         observation.completion = {
           status: "failed",
           message: "canary_finish did not return its exact completion marker",
@@ -133,6 +136,7 @@ export const consumeCanaryHarnessChunk = (
         toolCallId: chunk.toolCallId,
       };
       return;
+    }
     case "CUSTOM":
     case EventType.MESSAGES_SNAPSHOT:
     case EventType.REASONING_ENCRYPTED_VALUE:


### PR DESCRIPTION
Accept Codex's canonical completed MCP-result fallback while retaining the strict server-owned sequence and audit assertion.

CC on behalf of jan-kubica