### PR TITLE
chore: enable incremental TypeScript checks

### DIFF
--- a/apps/api/tsconfig.contracts.json
+++ b/apps/api/tsconfig.contracts.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "${configDir}/.cache/tsbuildinfo.contracts.json"
+  },
   "include": ["contracts", "../../types"]
 }

--- a/apps/api/tsconfig.mcp-apps.json
+++ b/apps/api/tsconfig.mcp-apps.json
@@ -5,6 +5,7 @@
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "tsBuildInfoFile": "${configDir}/.cache/tsbuildinfo.mcp-apps.json",
     "types": ["vite/client"]
   },
   "include": ["src/mcp/apps/**/*.ts"]

--- a/apps/api/tsconfig.scripts.json
+++ b/apps/api/tsconfig.scripts.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "./.cache/tsbuildinfo.scripts.json"
+    "tsBuildInfoFile": "${configDir}/.cache/tsbuildinfo.scripts.json"
   },
   "include": ["src", "scripts", "drizzle.config.ts", "../../types"]
 }

--- a/apps/desktop/tsconfig.test.json
+++ b/apps/desktop/tsconfig.test.json
@@ -2,7 +2,7 @@
   "extends": "@stll/typescript-config/react-library.json",
   "compilerOptions": {
     "types": ["bun"],
-    "tsBuildInfoFile": "./.cache/tsbuildinfo.test.json"
+    "tsBuildInfoFile": "${configDir}/.cache/tsbuildinfo.test.json"
   },
   "include": ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
   "exclude": ["dist", "node_modules", "src-tauri"]

--- a/apps/web/e2e/tsconfig.json
+++ b/apps/web/e2e/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../packages/typescript-config/base.json",
   "compilerOptions": {
     "types": ["node"],
-    "tsBuildInfoFile": "./.cache/tsbuildinfo.json"
+    "tsBuildInfoFile": "${configDir}/.cache/tsbuildinfo.json"
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "unit"]

--- a/apps/web/e2e/unit/tsconfig.json
+++ b/apps/web/e2e/unit/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../packages/typescript-config/base.json",
   "compilerOptions": {
     "types": ["bun", "node"],
-    "tsBuildInfoFile": "./.cache/tsbuildinfo.json"
+    "tsBuildInfoFile": "${configDir}/.cache/tsbuildinfo.json"
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules"]

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -17,6 +17,8 @@
     "noUncheckedSideEffectImports": true,
     "module": "Preserve",
     "moduleResolution": "Bundler",
+    "incremental": true,
+    "tsBuildInfoFile": "${configDir}/.cache/tsbuildinfo.json",
     "noEmit": true,
     "strict": true,
     "noFallthroughCasesInSwitch": true,

--- a/scripts/typecheck-baseline.ts
+++ b/scripts/typecheck-baseline.ts
@@ -36,10 +36,12 @@ const BASELINE_PATH = path.resolve(SCRIPTS_DIR, "typecheck-baseline.json");
 const BASELINE_REL = "scripts/typecheck-baseline.json";
 const TSC_NATIVE = "packages/scripts/src/tsc-native.ts";
 const WRITE_HINT = "bun scripts/typecheck-baseline.ts --write-baseline";
+const COLD_MEASUREMENT_FLAGS = ["--incremental", "false"] as const;
 const MEASUREMENT_FLAGS = [
   "--noEmit",
   "--extendedDiagnostics",
   "--singleThreaded",
+  ...COLD_MEASUREMENT_FLAGS,
 ] as const;
 const CLI_MODES = [
   { flag: "--check", mode: "check" },
@@ -465,6 +467,11 @@ const runSelfTest = (): number => {
 
   if (!MEASUREMENT_FLAGS.includes("--singleThreaded")) {
     failures.push("measurement flags allow checker-pool partition noise");
+  }
+  if (
+    !MEASUREMENT_FLAGS.join("\0").includes(COLD_MEASUREMENT_FLAGS.join("\0"))
+  ) {
+    failures.push("measurement flags allow warm incremental state");
   }
 
   const parsed = parseCounters(SELF_TEST_DIAGNOSTICS, "apps/api");

--- a/scripts/typecheck-coverage.ts
+++ b/scripts/typecheck-coverage.ts
@@ -18,6 +18,7 @@
 import { panic } from "better-result";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
+import ts from "typescript";
 
 const REPO_ROOT = path.resolve(import.meta.dir, "..");
 const TSC_NATIVE = "packages/scripts/src/tsc-native.ts";
@@ -25,6 +26,14 @@ const WORKSPACE_PARENTS = ["apps", "packages"] as const;
 const EXEMPT_PREFIXES = [".oxlint-plugins/__fixtures__/"] as const;
 const CONVENTIONAL_TSCONFIG = "tsconfig.json";
 const ROOT_TSCONFIG = "tsconfig.json";
+const TURBO_CONFIG = "turbo.json";
+const TYPECHECK_CACHE_OUTPUTS = [
+  ".cache/tsbuildinfo*.json",
+  "**/.cache/tsbuildinfo*.json",
+] as const;
+// Astro remains on its isolated TypeScript 6 checker. It does not invoke the
+// native compiler or produce a build-info file for Turbo to restore.
+const INCREMENTAL_EXEMPT_PROJECTS = new Set(["apps/landing/tsconfig.json"]);
 // apps/web/public contains intentionally untyped static browser assets outside
 // the combined Oxc target.
 const OXC_DISCOVERY_EXEMPT_PREFIXES = ["apps/web/public/"] as const;
@@ -34,6 +43,11 @@ const PROJECT_ARGUMENT =
 type OxcProjectProxy = {
   config: string;
   target: string;
+};
+
+type ProjectBuildInfo = {
+  buildInfoFile: string;
+  project: string;
 };
 
 // Oxc discovers only tsconfig.json files while walking up from a source file.
@@ -247,6 +261,118 @@ const readJsonObject = (file: string): Record<string, unknown> => {
     );
   }
   return parsed;
+};
+
+const readCompilerOptions = (project: string): ts.CompilerOptions => {
+  const configFile = path.join(REPO_ROOT, project);
+  const read = ts.readConfigFile(configFile, (file) => ts.sys.readFile(file));
+  if (read.error) {
+    panic(ts.flattenDiagnosticMessageText(read.error.messageText, "\n"));
+  }
+  const parsed = ts.parseJsonConfigFileContent(
+    read.config,
+    ts.sys,
+    path.dirname(configFile),
+    undefined,
+    configFile,
+  );
+  if (parsed.errors.length > 0) {
+    panic(
+      `${project} is invalid:\n${parsed.errors
+        .map((error) =>
+          ts.flattenDiagnosticMessageText(error.messageText, "\n"),
+        )
+        .join("\n")}`,
+    );
+  }
+  return parsed.options;
+};
+
+const duplicateBuildInfoErrors = (projects: ProjectBuildInfo[]): string[] => {
+  const owners = new Map<string, string>();
+  const errors: string[] = [];
+  for (const { buildInfoFile, project } of projects) {
+    const owner = owners.get(buildInfoFile);
+    if (owner) {
+      errors.push(
+        `${project} and ${owner} share ${normalizeRepoPath(path.relative(REPO_ROOT, buildInfoFile))}`,
+      );
+      continue;
+    }
+    owners.set(buildInfoFile, project);
+  }
+  return errors;
+};
+
+const incrementalProjectErrors = (projects: string[]): string[] => {
+  const buildInfoFiles: ProjectBuildInfo[] = [];
+  const errors: string[] = [];
+  for (const project of projects) {
+    if (INCREMENTAL_EXEMPT_PROJECTS.has(project)) {
+      continue;
+    }
+    const options = readCompilerOptions(project);
+    if (options.incremental !== true) {
+      errors.push(`${project} must enable incremental compilation`);
+      continue;
+    }
+
+    const buildInfoFile = options.tsBuildInfoFile;
+    if (typeof buildInfoFile !== "string") {
+      errors.push(`${project} must set tsBuildInfoFile to a string path`);
+      continue;
+    }
+    const relativeBuildInfo = normalizeRepoPath(
+      path.relative(REPO_ROOT, buildInfoFile),
+    );
+    if (!/(?:^|\/)\.cache\/tsbuildinfo[^/]*\.json$/u.test(relativeBuildInfo)) {
+      errors.push(
+        `${project} stores incremental state outside a .cache/tsbuildinfo*.json path: ${relativeBuildInfo}`,
+      );
+    }
+    buildInfoFiles.push({ buildInfoFile, project });
+  }
+  errors.push(...duplicateBuildInfoErrors(buildInfoFiles));
+  return errors;
+};
+
+const turboTypecheckOutputErrors = (): string[] => {
+  const turbo = readJsonObject(path.join(REPO_ROOT, TURBO_CONFIG));
+  const tasks = turbo["tasks"];
+  const typecheck = isRecord(tasks) ? tasks["typecheck"] : undefined;
+  const outputs = isRecord(typecheck) ? typecheck["outputs"] : undefined;
+  if (
+    !Array.isArray(outputs) ||
+    !outputs.every((entry) => typeof entry === "string")
+  ) {
+    return [`${TURBO_CONFIG} typecheck.outputs must be a string array`];
+  }
+
+  const expected = new Set<string>(TYPECHECK_CACHE_OUTPUTS);
+  const actual = new Set(outputs);
+  const errors: string[] = [];
+  for (const output of expected) {
+    if (!actual.has(output)) {
+      errors.push(`${TURBO_CONFIG} typecheck.outputs is missing ${output}`);
+    }
+  }
+  for (const output of actual) {
+    if (!expected.has(output)) {
+      errors.push(`${TURBO_CONFIG} typecheck.outputs has unexpected ${output}`);
+    }
+  }
+  return errors;
+};
+
+const assertIncrementalProjectConfigs = (projects: string[]): void => {
+  const errors = [
+    ...incrementalProjectErrors(projects),
+    ...turboTypecheckOutputErrors(),
+  ];
+  assert(
+    errors.length === 0,
+    `TypeScript incremental configuration failed:\n${errors.join("\n")}`,
+  );
 };
 
 const assertRootConfigIsEmpty = (): void => {
@@ -490,6 +616,28 @@ const selfTest = (): void => {
     "must discover supplemental typecheck projects",
   );
 
+  const duplicateCacheErrors = duplicateBuildInfoErrors([
+    {
+      buildInfoFile: path.join(
+        REPO_ROOT,
+        "apps/example/.cache/tsbuildinfo.json",
+      ),
+      project: "apps/example/tsconfig.json",
+    },
+    {
+      buildInfoFile: path.join(
+        REPO_ROOT,
+        "apps/example/.cache/tsbuildinfo.json",
+      ),
+      project: "apps/example/tsconfig.test.json",
+    },
+  ]);
+  assert(
+    duplicateCacheErrors.length === 1 &&
+      duplicateCacheErrors[0]?.includes("tsconfig.test.json") === true,
+    "must reject TypeScript projects that share incremental state",
+  );
+
   const unaccountedProjectErrors = projectAccountingErrors(
     ["apps/example/tsconfig.json", "apps/example/tsconfig.extra.json"],
     [],
@@ -626,6 +774,7 @@ const main = (): void => {
 
   const projects = typecheckProjects();
   assertOxcProjectDiscovery(projects);
+  assertIncrementalProjectConfigs(projects);
   const repositoryFiles = repositoryTypeScriptFiles();
   const oxcFiles = repositoryOxcFiles();
   const filesByProject = coveredFilesByProject(projects);

--- a/tsconfig.oxlint-plugins.json
+++ b/tsconfig.oxlint-plugins.json
@@ -2,6 +2,7 @@
   "extends": "@stll/typescript-config/base.json",
   "compilerOptions": {
     "allowImportingTsExtensions": true,
+    "tsBuildInfoFile": "${configDir}/.cache/tsbuildinfo.oxlint-plugins.json",
     // Oxlint's JS-plugin runtime does not publish types for rule contexts or
     // its dynamic ESTree nodes. Helpers still narrow external nodes from
     // unknown; these two options preserve the runtime's callback/object API.

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,6 +1,7 @@
 {
   "extends": "@stll/typescript-config/base.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "${configDir}/.cache/tsbuildinfo.scripts.json",
     "paths": {
       "@/api/*": ["./apps/api/src/*"]
     },

--- a/tsconfig.tooling.json
+++ b/tsconfig.tooling.json
@@ -2,6 +2,7 @@
   "extends": "@stll/typescript-config/base.json",
   "compilerOptions": {
     "allowImportingTsExtensions": true,
+    "tsBuildInfoFile": "${configDir}/.cache/tsbuildinfo.tooling.json",
     "types": ["bun"]
   },
   "include": [

--- a/turbo.json
+++ b/turbo.json
@@ -25,7 +25,7 @@
     },
     "typecheck": {
       "dependsOn": ["transit"],
-      "outputs": [".cache/tsbuildinfo.json"]
+      "outputs": [".cache/tsbuildinfo*.json", "**/.cache/tsbuildinfo*.json"]
     },
     "@stll/landing#typecheck": {
       "dependsOn": ["transit"],


### PR DESCRIPTION
## Summary

- enable incremental TypeScript state through the shared config, using config-relative `.cache` paths
- give supplemental projects unique build-info files and cache all of them through Turbo
- extend the typecheck coverage guard to reject disabled, misplaced, or colliding incremental state

The `${configDir}` shape follows TypeScript guidance and the portable pattern used by Expo.

## Validation

- pre-push hooks: code-check, format, i18n, AI skill sync
- `bun scripts/typecheck-coverage.ts`: 4,692 files covered by 48 projects
- `bun run typecheck:repo`
- isolated report-export notification integration suite: 9 passed
- controlled `@stll/scripts` cold/warm run: check time fell from 1.011 s to 0.002 s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved TypeScript build performance through incremental compilation and persistent build metadata.
  * Standardised build-cache locations across projects for more reliable repeated checks.

* **Quality Assurance**
  * Added validation to ensure type-checking configurations use unique, correctly cached build information.
  * Improved cold type-check measurements and cache tracking for more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->