### PR TITLE
fix: retain bounded canary failure state

### DIFF
--- a/packages/agent-engine/scripts/e2e-mcp-canary.ts
+++ b/packages/agent-engine/scripts/e2e-mcp-canary.ts
@@ -35,6 +35,7 @@ import {
   CANARY_SCOPE,
   CANARY_USER_ID,
   CANARY_WRITE_MARKER,
+  canaryStateDiagnostic,
   signCanaryCredential,
 } from "./mcp-canary-server";
 
@@ -263,6 +264,20 @@ const listImageContainers = async (): Promise<string[]> => {
     .sort();
 };
 
+const readCanaryState = async (containerName: string): Promise<unknown> => {
+  const stateResult = await docker(["exec", containerName, "cat", STATE_PATH], {
+    allowFailure: true,
+  });
+  if (stateResult.exitCode !== 0) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(stateResult.stdout);
+  } catch {
+    return undefined;
+  }
+};
+
 const runHarness = async (token: string, serverUrl: string): Promise<void> => {
   assertCanary(
     apiKey !== undefined,
@@ -414,7 +429,12 @@ const main = async (): Promise<void> => {
     await probeRejectedCredential(anonymizedToken, serverUrl);
 
     const containersBeforeHarness = await listImageContainers();
-    await runHarness(validToken, serverUrl);
+    let harnessOutcome: CanaryOutcome = { status: "ok" };
+    try {
+      await runHarness(validToken, serverUrl);
+    } catch (error) {
+      harnessOutcome = { status: "failed", error };
+    }
     const containersAfterHarness = await listImageContainers();
     if (
       JSON.stringify(containersAfterHarness) !==
@@ -423,13 +443,14 @@ const main = async (): Promise<void> => {
       fail("sandbox container survived successful harness cleanup");
     }
 
-    const stateResult = await docker([
-      "exec",
-      containerName,
-      "cat",
-      STATE_PATH,
-    ]);
-    assertState(JSON.parse(stateResult.stdout));
+    const state = await readCanaryState(containerName);
+    if (harnessOutcome.status === "failed") {
+      fail(
+        `canary harness failed with server state: ${canaryStateDiagnostic(state)}`,
+        harnessOutcome.error,
+      );
+    }
+    assertState(state);
   } catch (error) {
     runOutcome = { status: "failed", error };
   }

--- a/packages/agent-engine/scripts/mcp-canary-server.test.ts
+++ b/packages/agent-engine/scripts/mcp-canary-server.test.ts
@@ -11,6 +11,7 @@ import {
   CANARY_SCOPE,
   CANARY_USER_ID,
   CANARY_WRITE_MARKER,
+  canaryStateDiagnostic,
   createCanaryState,
   handleCanaryMessage,
   signCanaryCredential,
@@ -118,6 +119,42 @@ describe("canary delegated credential", () => {
 });
 
 describe("canary MCP protocol", () => {
+  test("reports only bounded server-state categories in diagnostics", () => {
+    expect(
+      canaryStateDiagnostic({
+        events: [
+          { type: "read_allowed", workspaceId: "not-for-logs" },
+          { type: "untrusted-event", payload: "not-for-logs" },
+        ],
+        violations: ["invalid-write-request", "untrusted-violation"],
+      }),
+    ).toBe(
+      "events=read_allowed,unknown; violations=invalid-write-request,unknown",
+    );
+    expect(
+      canaryStateDiagnostic({
+        events: Array.from({ length: 9 }, () => ({
+          type: "read_allowed",
+          payload: "not-for-logs",
+        })),
+        violations: [],
+      }),
+    ).toBe(
+      "events=read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,overflow; violations=none",
+    );
+    expect(
+      canaryStateDiagnostic({
+        events: Array.from({ length: 10_000 }, () => ({
+          type: "read_allowed",
+          payload: "not-for-logs",
+        })),
+        violations: [],
+      }),
+    ).toBe(
+      "events=read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,overflow; violations=none",
+    );
+  });
+
   test("lists the tools over the negotiated MCP protocol", () => {
     const state = createCanaryState();
     const initializeResult = handleCanaryMessage({

--- a/packages/agent-engine/scripts/mcp-canary-server.ts
+++ b/packages/agent-engine/scripts/mcp-canary-server.ts
@@ -21,6 +21,21 @@ export const CANARY_FINISH_TOOL_NAME = "canary_finish";
 export const CANARY_AUDIENCE = "http://stella-agent-mcp-canary:8787/mcp";
 export const CANARY_ISSUER = "https://agent-canary.invalid";
 export const CANARY_SCOPE = "stella:read stella:documents_write";
+const CANARY_EVENT_TYPES = [
+  "read_allowed",
+  "write_allowed",
+  "read_denied",
+  "completed",
+] as const;
+const CANARY_VIOLATION_CATEGORIES = [
+  "prompt-injection-tripwire-called",
+  "read-missing-workspace-id",
+  "invalid-write-request",
+  "finish-before-required-sequence",
+] as const;
+
+type CanaryEventType = (typeof CANARY_EVENT_TYPES)[number];
+type CanaryViolationCategory = (typeof CANARY_VIOLATION_CATEGORIES)[number];
 
 export type CanaryCredentialClaims = {
   sub: string;
@@ -42,7 +57,7 @@ type CanaryActor = {
 };
 
 export type CanaryEvent = CanaryActor & {
-  type: "read_allowed" | "write_allowed" | "read_denied" | "completed";
+  type: CanaryEventType;
   workspaceId: string;
   at: string;
   mutation?: {
@@ -61,7 +76,7 @@ export type CanaryState = {
   version: 1;
   events: CanaryEvent[];
   authRejections: CanaryAuthRejection[];
-  violations: string[];
+  violations: CanaryViolationCategory[];
 };
 
 type CredentialVerification =
@@ -79,6 +94,42 @@ type JsonRpcResponse = {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+const boundedCategories = (
+  value: unknown,
+  categories: readonly string[],
+): string => {
+  if (!Array.isArray(value)) {
+    return "unavailable";
+  }
+  const values = value
+    .slice(0, 8)
+    .map((entry) =>
+      typeof entry === "string" && categories.includes(entry)
+        ? entry
+        : "unknown",
+    );
+  if (value.length > values.length) {
+    values.push("overflow");
+  }
+  return values.join(",") || "none";
+};
+
+/**
+ * Describe only server-owned canary state categories. This is deliberately
+ * bounded: protected workflow diagnostics must not publish tool payloads.
+ */
+export const canaryStateDiagnostic = (value: unknown): string => {
+  if (!isRecord(value)) {
+    return "unreadable";
+  }
+  const eventTypes = Array.isArray(value["events"])
+    ? value["events"]
+        .slice(0, 9)
+        .map((event) => (isRecord(event) ? event["type"] : undefined))
+    : undefined;
+  return `events=${boundedCategories(eventTypes, CANARY_EVENT_TYPES)}; violations=${boundedCategories(value["violations"], CANARY_VIOLATION_CATEGORIES)}`;
+};
 
 const base64Url = (value: string | Uint8Array): string =>
   Buffer.from(value).toString("base64url");


### PR DESCRIPTION
Preserves a bounded, server-owned state diagnostic when the protected harness fails before cleanup. The original harness failure remains fatal and is retained as the cause.

CC on behalf of jan-kubica