### PR TITLE
fix: retain canary state on cleanup failure

### DIFF
--- a/packages/agent-engine/scripts/e2e-mcp-canary.ts
+++ b/packages/agent-engine/scripts/e2e-mcp-canary.ts
@@ -35,7 +35,7 @@ import {
   CANARY_SCOPE,
   CANARY_USER_ID,
   CANARY_WRITE_MARKER,
-  canaryStateDiagnostic,
+  canaryFailureDiagnostic,
   signCanaryCredential,
 } from "./mcp-canary-server";
 
@@ -435,19 +435,22 @@ const main = async (): Promise<void> => {
     } catch (error) {
       harnessOutcome = { status: "failed", error };
     }
-    const containersAfterHarness = await listImageContainers();
-    if (
-      JSON.stringify(containersAfterHarness) !==
-      JSON.stringify(containersBeforeHarness)
-    ) {
-      fail("sandbox container survived successful harness cleanup");
-    }
-
     const state = await readCanaryState(containerName);
+    const containersAfterHarness = await listImageContainers();
+    const sandboxCleanup =
+      JSON.stringify(containersAfterHarness) ===
+      JSON.stringify(containersBeforeHarness)
+        ? "ok"
+        : "leaked";
     if (harnessOutcome.status === "failed") {
       fail(
-        `canary harness failed with server state: ${canaryStateDiagnostic(state)}`,
+        `canary harness failed with ${canaryFailureDiagnostic({ state, sandboxCleanup })}`,
         harnessOutcome.error,
+      );
+    }
+    if (sandboxCleanup === "leaked") {
+      fail(
+        `sandbox container survived successful harness cleanup with ${canaryFailureDiagnostic({ state, sandboxCleanup })}`,
       );
     }
     assertState(state);

--- a/packages/agent-engine/scripts/mcp-canary-server.test.ts
+++ b/packages/agent-engine/scripts/mcp-canary-server.test.ts
@@ -11,6 +11,7 @@ import {
   CANARY_SCOPE,
   CANARY_USER_ID,
   CANARY_WRITE_MARKER,
+  canaryFailureDiagnostic,
   canaryStateDiagnostic,
   createCanaryState,
   handleCanaryMessage,
@@ -152,6 +153,17 @@ describe("canary MCP protocol", () => {
       }),
     ).toBe(
       "events=read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,overflow; violations=none",
+    );
+    expect(
+      canaryFailureDiagnostic({
+        state: {
+          events: [{ type: "read_denied", payload: "not-for-logs" }],
+          violations: ["finish-before-required-sequence"],
+        },
+        sandboxCleanup: "leaked",
+      }),
+    ).toBe(
+      "server state: events=read_denied; violations=finish-before-required-sequence; sandboxCleanup=leaked",
     );
   });
 

--- a/packages/agent-engine/scripts/mcp-canary-server.ts
+++ b/packages/agent-engine/scripts/mcp-canary-server.ts
@@ -36,6 +36,7 @@ const CANARY_VIOLATION_CATEGORIES = [
 
 type CanaryEventType = (typeof CANARY_EVENT_TYPES)[number];
 type CanaryViolationCategory = (typeof CANARY_VIOLATION_CATEGORIES)[number];
+export type CanarySandboxCleanupStatus = "ok" | "leaked";
 
 export type CanaryCredentialClaims = {
   sub: string;
@@ -130,6 +131,15 @@ export const canaryStateDiagnostic = (value: unknown): string => {
     : undefined;
   return `events=${boundedCategories(eventTypes, CANARY_EVENT_TYPES)}; violations=${boundedCategories(value["violations"], CANARY_VIOLATION_CATEGORIES)}`;
 };
+
+export const canaryFailureDiagnostic = ({
+  state,
+  sandboxCleanup,
+}: {
+  state: unknown;
+  sandboxCleanup: CanarySandboxCleanupStatus;
+}): string =>
+  `server state: ${canaryStateDiagnostic(state)}; sandboxCleanup=${sandboxCleanup}`;
 
 const base64Url = (value: string | Uint8Array): string =>
   Buffer.from(value).toString("base64url");


### PR DESCRIPTION
Reports the bounded, server-owned canary state before evaluating sandbox cleanup. Both harness errors and successful-run cleanup leaks remain fatal.

CC on behalf of jan-kubica