### PR TITLE
fix: trace canary MCP method categories

### DIFF
--- a/packages/agent-engine/scripts/e2e-mcp-canary.ts
+++ b/packages/agent-engine/scripts/e2e-mcp-canary.ts
@@ -338,10 +338,12 @@ const assertState = (value: unknown): void => {
   assertCanary(isRecord(value), "canary state is not an object");
   const events = value["events"];
   const authRejections = value["authRejections"];
+  const authenticatedMethods = value["authenticatedMethods"];
   const violations = value["violations"];
   assertCanary(
     Array.isArray(events) &&
       Array.isArray(authRejections) &&
+      Array.isArray(authenticatedMethods) &&
       Array.isArray(violations),
     "canary state is missing required arrays",
   );

--- a/packages/agent-engine/scripts/mcp-canary-server.test.ts
+++ b/packages/agent-engine/scripts/mcp-canary-server.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 import {
   CANARY_ALLOWED_WORKSPACE_ID,
@@ -16,6 +20,7 @@ import {
   createCanaryState,
   handleCanaryMessage,
   signCanaryCredential,
+  startCanaryServer,
   verifyCanaryCredential,
   type CanaryCredentialClaims,
 } from "./mcp-canary-server";
@@ -120,6 +125,97 @@ describe("canary delegated credential", () => {
 });
 
 describe("canary MCP protocol", () => {
+  test("records only authenticated JSON-RPC method categories", async () => {
+    const stateDirectory = await mkdtemp(
+      path.join(tmpdir(), "stella-canary-method-test-"),
+    );
+    const statePath = path.join(stateDirectory, "state.json");
+    const server = startCanaryServer({
+      port: 0,
+      signingSecret: SIGNING_SECRET,
+      statePath,
+    });
+
+    try {
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("canary test server did not bind a TCP address");
+      }
+      const url = `http://127.0.0.1:${address.port}/mcp`;
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const message = {
+        jsonrpc: "2.0",
+        id: "not-for-logs",
+        method: "tools/list",
+        params: { payload: "not-for-logs" },
+      };
+      const rejected = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(message),
+      });
+      expect(rejected.status).toBe(401);
+
+      const accepted = await fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${signCanaryCredential(
+            claims({ iat: nowSeconds - 1, exp: nowSeconds + 900 }),
+            SIGNING_SECRET,
+          )}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(message),
+      });
+      expect(accepted.status).toBe(200);
+
+      const state: unknown = JSON.parse(await Bun.file(statePath).text());
+      expect(state).toEqual({
+        version: 1,
+        events: [],
+        authRejections: [{ reason: "missing", at: expect.any(String) }],
+        authenticatedMethods: ["tools/list"],
+        violations: [],
+      });
+      expect(canaryStateDiagnostic(state)).toBe(
+        "events=none; violations=none; authRejections=missing; authProbeBaseline=unexpected; authenticatedMethods=tools/list",
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+      await rm(stateDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("bounds authenticated method state before rendering diagnostics", () => {
+    const state = createCanaryState();
+    for (let index = 0; index < 10; index += 1) {
+      handleCanaryMessage({
+        message: { jsonrpc: "2.0", id: index, method: "untrusted-method" },
+        claims: acceptedClaims(),
+        state,
+        now: "2026-07-21T12:00:00.000Z",
+      });
+    }
+
+    expect(state.authenticatedMethods).toEqual([
+      "other",
+      "other",
+      "other",
+      "other",
+      "other",
+      "other",
+      "other",
+      "other",
+      "other",
+    ]);
+    expect(canaryStateDiagnostic(state)).toContain(
+      "authenticatedMethods=other,other,other,other,other,other,other,other,overflow",
+    );
+  });
+
   test("reports only bounded server-state categories in diagnostics", () => {
     expect(
       canaryStateDiagnostic({
@@ -130,7 +226,7 @@ describe("canary MCP protocol", () => {
         violations: ["invalid-write-request", "untrusted-violation"],
       }),
     ).toBe(
-      "events=read_allowed,unknown; violations=invalid-write-request,unknown; authRejections=unavailable; authProbeBaseline=unavailable",
+      "events=read_allowed,unknown; violations=invalid-write-request,unknown; authRejections=unavailable; authProbeBaseline=unavailable; authenticatedMethods=unavailable",
     );
     expect(
       canaryStateDiagnostic({
@@ -141,7 +237,7 @@ describe("canary MCP protocol", () => {
         violations: [],
       }),
     ).toBe(
-      "events=read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,overflow; violations=none; authRejections=unavailable; authProbeBaseline=unavailable",
+      "events=read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,overflow; violations=none; authRejections=unavailable; authProbeBaseline=unavailable; authenticatedMethods=unavailable",
     );
     expect(
       canaryStateDiagnostic({
@@ -152,7 +248,7 @@ describe("canary MCP protocol", () => {
         violations: [],
       }),
     ).toBe(
-      "events=read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,overflow; violations=none; authRejections=unavailable; authProbeBaseline=unavailable",
+      "events=read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,read_allowed,overflow; violations=none; authRejections=unavailable; authProbeBaseline=unavailable; authenticatedMethods=unavailable",
     );
     expect(
       canaryStateDiagnostic({
@@ -164,7 +260,7 @@ describe("canary MCP protocol", () => {
         ],
       }),
     ).toBe(
-      "events=none; violations=none; authRejections=expired,invalid-claims; authProbeBaseline=expected",
+      "events=none; violations=none; authRejections=expired,invalid-claims; authProbeBaseline=expected; authenticatedMethods=unavailable",
     );
     expect(
       canaryStateDiagnostic({
@@ -177,7 +273,7 @@ describe("canary MCP protocol", () => {
         ],
       }),
     ).toBe(
-      "events=none; violations=none; authRejections=expired,invalid-claims,missing; authProbeBaseline=extra",
+      "events=none; violations=none; authRejections=expired,invalid-claims,missing; authProbeBaseline=extra; authenticatedMethods=unavailable",
     );
     expect(
       canaryFailureDiagnostic({
@@ -188,7 +284,27 @@ describe("canary MCP protocol", () => {
         sandboxCleanup: "leaked",
       }),
     ).toBe(
-      "server state: events=read_denied; violations=finish-before-required-sequence; authRejections=unavailable; authProbeBaseline=unavailable; sandboxCleanup=leaked",
+      "server state: events=read_denied; violations=finish-before-required-sequence; authRejections=unavailable; authProbeBaseline=unavailable; authenticatedMethods=unavailable; sandboxCleanup=leaked",
+    );
+    expect(
+      canaryStateDiagnostic({
+        events: [],
+        violations: [],
+        authRejections: [],
+        authenticatedMethods: [
+          "initialize",
+          "tools/list",
+          "not-for-logs",
+          "tools/call",
+          "tools/call",
+          "tools/call",
+          "tools/call",
+          "tools/call",
+          "tools/call",
+        ],
+      }),
+    ).toBe(
+      "events=none; violations=none; authRejections=none; authProbeBaseline=unexpected; authenticatedMethods=initialize,tools/list,unknown,tools/call,tools/call,tools/call,tools/call,tools/call,overflow",
     );
   });
 
@@ -214,6 +330,7 @@ describe("canary MCP protocol", () => {
         capabilities: { tools: { listChanged: false } },
       },
     });
+    expect(state.authenticatedMethods).toEqual(["initialize"]);
 
     const listResult = handleCanaryMessage({
       message: {
@@ -246,6 +363,7 @@ describe("canary MCP protocol", () => {
         "canary_write_workspace",
       ].toSorted(),
     );
+    expect(state.authenticatedMethods).toEqual(["initialize", "tools/list"]);
   });
 
   test("requires the authorized read/write/deny sequence with an audit event", () => {
@@ -280,6 +398,12 @@ describe("canary MCP protocol", () => {
     toolCall("canary_finish", { summary: "complete" }, state);
 
     expect(state.violations).toEqual([]);
+    expect(state.authenticatedMethods).toEqual([
+      "tools/call",
+      "tools/call",
+      "tools/call",
+      "tools/call",
+    ]);
     expect(state.events.map((event) => event.type)).toEqual([
       "read_allowed",
       "write_allowed",

--- a/packages/agent-engine/scripts/mcp-canary-server.ts
+++ b/packages/agent-engine/scripts/mcp-canary-server.ts
@@ -8,6 +8,9 @@ import {
 
 const DEFAULT_PROTOCOL_VERSION = "2025-11-25";
 const MAX_REQUEST_BYTES = 64 * 1024;
+const MAX_DIAGNOSTIC_CATEGORY_VALUES = 8;
+const MAX_AUTHENTICATED_METHOD_TRACE_ENTRIES =
+  MAX_DIAGNOSTIC_CATEGORY_VALUES + 1;
 
 export const CANARY_ALLOWED_WORKSPACE_ID = "workspace_canary_allowed";
 export const CANARY_DENIED_WORKSPACE_ID = "workspace_canary_denied";
@@ -39,11 +42,20 @@ const CANARY_AUTH_REJECTION_REASONS = [
   "invalid-signature",
   "missing",
 ] as const;
+const CANARY_AUTHENTICATED_METHOD_CATEGORIES = [
+  "initialize",
+  "notifications/initialized",
+  "tools/list",
+  "tools/call",
+  "other",
+] as const;
 const EXPECTED_AUTH_PROBE_REASONS = ["expired", "invalid-claims"] as const;
 
 type CanaryEventType = (typeof CANARY_EVENT_TYPES)[number];
 type CanaryViolationCategory = (typeof CANARY_VIOLATION_CATEGORIES)[number];
 type CanaryAuthRejectionReason = (typeof CANARY_AUTH_REJECTION_REASONS)[number];
+type CanaryAuthenticatedMethodCategory =
+  (typeof CANARY_AUTHENTICATED_METHOD_CATEGORIES)[number];
 export type CanarySandboxCleanupStatus = "ok" | "leaked";
 
 export type CanaryCredentialClaims = {
@@ -85,6 +97,7 @@ export type CanaryState = {
   version: 1;
   events: CanaryEvent[];
   authRejections: CanaryAuthRejection[];
+  authenticatedMethods: CanaryAuthenticatedMethodCategory[];
   violations: CanaryViolationCategory[];
 };
 
@@ -112,7 +125,7 @@ const boundedCategories = (
     return "unavailable";
   }
   const values = value
-    .slice(0, 8)
+    .slice(0, MAX_DIAGNOSTIC_CATEGORY_VALUES)
     .map((entry) =>
       typeof entry === "string" && categories.includes(entry)
         ? entry
@@ -150,17 +163,17 @@ export const canaryStateDiagnostic = (value: unknown): string => {
   }
   const eventTypes = Array.isArray(value["events"])
     ? value["events"]
-        .slice(0, 9)
+        .slice(0, MAX_AUTHENTICATED_METHOD_TRACE_ENTRIES)
         .map((event) => (isRecord(event) ? event["type"] : undefined))
     : undefined;
   const authRejectionReasons = Array.isArray(value["authRejections"])
     ? value["authRejections"]
-        .slice(0, 9)
+        .slice(0, MAX_AUTHENTICATED_METHOD_TRACE_ENTRIES)
         .map((rejection) =>
           isRecord(rejection) ? rejection["reason"] : undefined,
         )
     : undefined;
-  return `events=${boundedCategories(eventTypes, CANARY_EVENT_TYPES)}; violations=${boundedCategories(value["violations"], CANARY_VIOLATION_CATEGORIES)}; authRejections=${boundedCategories(authRejectionReasons, CANARY_AUTH_REJECTION_REASONS)}; authProbeBaseline=${authProbeBaseline(value["authRejections"])}`;
+  return `events=${boundedCategories(eventTypes, CANARY_EVENT_TYPES)}; violations=${boundedCategories(value["violations"], CANARY_VIOLATION_CATEGORIES)}; authRejections=${boundedCategories(authRejectionReasons, CANARY_AUTH_REJECTION_REASONS)}; authProbeBaseline=${authProbeBaseline(value["authRejections"])}; authenticatedMethods=${boundedCategories(value["authenticatedMethods"], CANARY_AUTHENTICATED_METHOD_CATEGORIES)}`;
 };
 
 export const canaryFailureDiagnostic = ({
@@ -277,6 +290,7 @@ export const createCanaryState = (): CanaryState => ({
   version: 1,
   events: [],
   authRejections: [],
+  authenticatedMethods: [],
   violations: [],
 });
 
@@ -471,12 +485,42 @@ type HandleMessageInput = {
   now: string;
 };
 
+const authenticatedMethodCategory = (
+  message: unknown,
+): CanaryAuthenticatedMethodCategory => {
+  if (!isRecord(message)) {
+    return "other";
+  }
+  switch (message["method"]) {
+    case "initialize":
+    case "notifications/initialized":
+    case "tools/list":
+    case "tools/call":
+      return message["method"];
+    default:
+      return "other";
+  }
+};
+
+const recordAuthenticatedMethod = (
+  state: CanaryState,
+  message: unknown,
+): void => {
+  if (
+    state.authenticatedMethods.length >= MAX_AUTHENTICATED_METHOD_TRACE_ENTRIES
+  ) {
+    return;
+  }
+  state.authenticatedMethods.push(authenticatedMethodCategory(message));
+};
+
 export const handleCanaryMessage = ({
   message,
   claims,
   state,
   now,
 }: HandleMessageInput): JsonRpcResponse | undefined => {
+  recordAuthenticatedMethod(state, message);
   if (!isRecord(message) || message["jsonrpc"] !== "2.0") {
     return errorResponse(null, -32_600, "Invalid JSON-RPC request");
   }


### PR DESCRIPTION
## Summary

- record bounded authenticated JSON-RPC method categories in the protected canary state
- include the categorical trace in failure diagnostics without request identifiers or payloads
- cover authentication gating, trace bounds, and diagnostic redaction

## Validation

- `bun --filter @stll/agent-engine test`
- `bun --filter @stll/agent-engine typecheck`
- `bun --filter @stll/agent-engine lint`
- `bun run security:audit`

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated MCP method diagnostics to canary server state.
  * Diagnostics now categorise recorded methods and limit the list to prevent excessive output.
  * Added visibility into authenticated method activity before request validation.

* **Bug Fixes**
  * Improved handling and reporting of unknown, unauthorised, and excess method entries.
  * Enhanced canary checks for state persistence, cleanup, protocol handling, and request sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->