### PR TITLE
fix: approve trusted MCP tools

### DIFF
--- a/packages/agent-engine/src/run.ts
+++ b/packages/agent-engine/src/run.ts
@@ -45,6 +45,7 @@ const HARNESS_KEY_ENV = "STELLA_HARNESS_KEY";
 const HARNESS_PROVIDER_ID = "stella";
 const OPENAI_BASE_URL = "https://api.openai.com/v1";
 const STELLA_CODEX_HOME = `${STELLA_WORKSPACE_ROOT}/.codex`;
+const TRUSTED_MCP_TOOL_APPROVAL_MODE = '"approve"';
 
 const harnessBaseUrl = (input: StellaSandboxRunInput): string => {
   if (input.harnessProvider === "openai") {
@@ -67,10 +68,11 @@ export const buildCodexAdapterConfig = (input: StellaSandboxRunInput) => {
   const provider = HARNESS_PROVIDER_ID;
   return {
     // The outer TanStack/Docker sandbox is the real isolation boundary; codex
-    // may write within its workspace. Approval behavior is intentionally left
-    // to the Stella sandbox policy. Its `ask`/`deny` rules map to on-request;
-    // in non-interactive `codex exec`, approval-requiring actions fail closed.
-    // An adapter override would take precedence and bypass that mapping.
+    // may write within its workspace. Shell-command approval remains governed
+    // by the Stella sandbox policy: its `ask`/`deny` rules map to on-request,
+    // so approval-requiring commands fail closed in non-interactive `codex
+    // exec`. The trusted Stella MCP's tool approval is configured separately
+    // below; it does not alter command approval or network controls.
     sandboxMode: "workspace-write",
     env: {
       ...(input.mcp === SANDBOX_NO_MCP
@@ -86,6 +88,12 @@ export const buildCodexAdapterConfig = (input: StellaSandboxRunInput) => {
       [`model_providers.${provider}.base_url`]: `"${harnessBaseUrl(input)}"`,
       [`model_providers.${provider}.env_key`]: `"${HARNESS_KEY_ENV}"`,
       [`model_providers.${provider}.wire_api`]: `"responses"`,
+      ...(input.mcp === SANDBOX_NO_MCP
+        ? {}
+        : {
+            [`mcp_servers.${input.mcp.serverName}.default_tools_approval_mode`]:
+              TRUSTED_MCP_TOOL_APPROVAL_MODE,
+          }),
     },
   } as const satisfies CodexTextConfig;
 };

--- a/packages/agent-engine/src/sandbox.test.ts
+++ b/packages/agent-engine/src/sandbox.test.ts
@@ -165,6 +165,10 @@ describe("resolveStellaSandboxRun", () => {
       CODEX_HOME: `${STELLA_WORKSPACE_ROOT}/.codex`,
       STELLA_HARNESS_KEY: "sk-test",
     });
+    expect(Object.entries(config.config)).toContainEqual([
+      `mcp_servers.${baseRunInput.mcp.serverName}.default_tools_approval_mode`,
+      '"approve"',
+    ]);
     expect(JSON.stringify(config.config)).not.toContain(baseRunInput.mcp.token);
   });
 
@@ -175,6 +179,12 @@ describe("resolveStellaSandboxRun", () => {
     });
 
     expect(config.env).toEqual({ STELLA_HARNESS_KEY: "sk-test" });
+    expect(
+      Object.hasOwn(
+        config.config,
+        "mcp_servers.stella.default_tools_approval_mode",
+      ),
+    ).toBe(false);
   });
 
   test("pairs a codex adapter with sandbox middleware", () => {


### PR DESCRIPTION
## Summary

- configure Codex to approve calls to the trusted Stella MCP binding
- retain existing command approval and network controls
- cover projected MCP configuration and no-MCP smoke runs

Codex documents [`mcp_servers.<id>.default_tools_approval_mode`](https://developers.openai.com/codex/config-reference/) and the supported MCP approval modes in its [MCP configuration guide](https://developers.openai.com/codex/mcp/).

## Validation

- `bun --filter @stll/agent-engine test`
- `bun --filter @stll/agent-engine typecheck`
- `bun --filter @stll/agent-engine lint`
- `bunx oxfmt --check packages/agent-engine/src/run.ts packages/agent-engine/src/sandbox.test.ts`
- `bun run security:audit`

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MCP-enabled runs now automatically approve trusted MCP tools, reducing unnecessary approval prompts.
  - Command approvals continue to follow the configured sandbox policy.
  - Runs without MCP retain their existing approval behaviour.

- **Bug Fixes**
  - MCP credentials remain protected and are not exposed through generated configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->