### PR TITLE
fix(api): keep the derivative repair sweep moving past unreadable rows

### DIFF
--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -390,3 +390,26 @@ export class SchedulerJobTimeoutError extends TaggedError(
   jobId: string;
   timeoutMs: number;
 }> {}
+
+/**
+ * One row of the file-derivative repair sweep could not be requeued. Wraps
+ * the underlying failure so the capture carries a stable tag (a minified
+ * constructor name identifies nothing) while the cause keeps the real frame.
+ */
+export class FileDerivativeRepairError extends TaggedError(
+  "FileDerivativeRepairError",
+)<{
+  message: string;
+  cause: unknown;
+}> {}
+
+/**
+ * A persisted derivative state this build cannot judge: corrupt JSONB, or a
+ * status written by a newer build. The repair sweep reports it and moves on
+ * instead of retrying it or dying mid-scan.
+ */
+export class UnrecognizedDerivativeStateError extends TaggedError(
+  "UnrecognizedDerivativeStateError",
+)<{
+  message: string;
+}> {}

--- a/apps/api/src/lib/errors/utils.test.ts
+++ b/apps/api/src/lib/errors/utils.test.ts
@@ -120,10 +120,11 @@ describe("errorFingerprint", () => {
     expect(errorFingerprint(error)["error.code"]).toBe("ECONNRESET");
   });
 
-  test("surfaces the deepest cause's top frame", () => {
-    const root = new Error("root failure");
+  test("surfaces the deepest cause's class and top frame", () => {
+    const root = new TypeError("root failure");
     const wrapped = new Error("wrapped", { cause: root });
     const fingerprint = errorFingerprint(wrapped);
+    expect(fingerprint["error.cause.class"]).toBe("TypeError");
     expect(fingerprint["error.cause.frame"]).toMatch(/:\d+:\d+$/u);
   });
 

--- a/apps/api/src/lib/errors/utils.ts
+++ b/apps/api/src/lib/errors/utils.ts
@@ -311,6 +311,12 @@ export const errorFingerprint = (error: unknown): ErrorFingerprint => {
   }
   const cause = deepestCause(error);
   if (cause) {
+    // A wrapper (`UnhandledException`, a boundary TaggedError) otherwise
+    // hides what actually failed: the tag is structural, so it ships under
+    // the same contract as `error.class`. Deliberately absent from the
+    // grouping fingerprint and the suppression key — the wrap site is the
+    // defect's identity, the cause its detail.
+    fingerprint["error.cause.class"] = errorTag(cause);
     const causeFrame = topStackFrame(cause);
     if (causeFrame !== undefined) {
       fingerprint["error.cause.frame"] = causeFrame;

--- a/apps/api/src/lib/scheduler/tasks/file-derivative-repair.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/file-derivative-repair.test.ts
@@ -16,7 +16,7 @@ import {
   mock,
   test,
 } from "bun:test";
-import { eq, inArray } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 
 import {
   entities,
@@ -28,6 +28,10 @@ import type { FieldContent } from "@/api/db/schema-validators";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import {
+  FileDerivativeRepairError,
+  UnrecognizedDerivativeStateError,
+} from "@/api/lib/errors/tagged-errors";
 import { allocateFileObject } from "@/api/lib/files/file-object-ids";
 import { logger } from "@/api/lib/observability/logger";
 import {
@@ -51,9 +55,13 @@ const priorJobs = new Map<
   { data: { derivativeFileId?: string; fieldId: string }; state: string }
 >();
 const removedJobIds: string[] = [];
+const failingAddJobIds = new Set<string>();
 
 class StubQueue {
   async add(name: string, data: QueuedJob["data"], opts: QueuedJob["opts"]) {
+    if (failingAddJobIds.has(opts.jobId)) {
+      throw new Error("queue write refused");
+    }
     queued.push({ data, name, opts });
   }
 
@@ -82,6 +90,14 @@ const redisClientModule = await import("@/api/lib/redis-client");
 void mock.module("@/api/lib/redis-client", () => ({
   ...redisClientModule,
   createBullMqConnection: () => ({}),
+}));
+const captureErrorMock = mock(
+  (_error: unknown, _context?: Record<string, string>) => undefined,
+);
+const realCapture = await import("@/api/lib/analytics/capture");
+void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
+  captureError: captureErrorMock,
 }));
 
 const { REPAIR_FILE_DERIVATIVES_TASK, repairFileDerivatives } =
@@ -200,6 +216,8 @@ describe("file derivative repair", () => {
     queued.length = 0;
     removedJobIds.length = 0;
     priorJobs.clear();
+    failingAddJobIds.clear();
+    captureErrorMock.mockClear();
     await testDb
       .insert(schedulerJobs)
       .values({
@@ -352,5 +370,58 @@ describe("file derivative repair", () => {
     expect(queued.map(({ data }) => data.fieldId)).toEqual(
       seeded.slice(REQUEUE_LIMIT),
     );
+  });
+
+  // The pre-hardening bare `::jsonb` casts stored the serialized state as a
+  // jsonb *string*. Such a row used to panic the sweep mid-scan, which pinned
+  // the cursor on it and re-captured the same failure every tick.
+  test("reports a state it cannot read, skips it, and keeps sweeping", async () => {
+    const corrupt = await seedFileField();
+    const stuck = await seedFileField();
+    await testDb.execute(
+      sql`update ${fields}
+        set content = jsonb_set(content, '{pdfDerivative}', to_jsonb('{"status":"pending"}'::text), true)
+        where id = ${corrupt}`,
+    );
+
+    await runRepair();
+
+    expect(queued.map(({ data }) => data.fieldId)).toEqual([stuck]);
+    const reported = captureErrorMock.mock.calls.filter(
+      ([error]) => error instanceof UnrecognizedDerivativeStateError,
+    );
+    expect(reported.map(([, context]) => context?.["fieldId"])).toEqual([
+      corrupt,
+    ]);
+    // The tick finished: the cursor moved past both rows.
+    const [job] = await testDb
+      .select({ payload: schedulerJobs.payload })
+      .from(schedulerJobs)
+      .where(eq(schedulerJobs.id, SCHEDULER_JOB_ID));
+    expect(job?.payload).toEqual({ cursor: stuck });
+  });
+
+  // A row whose repair throws stops the tick (the queue may be down), but the
+  // cursor still moves past it: the next tick continues behind the row
+  // instead of replaying the same failure forever and starving what follows.
+  test("advances the cursor past a row whose repair throws", async () => {
+    const failing = await seedFileField();
+    const stuck = await seedFileField();
+    failingAddJobIds.add(
+      createBullMqJobId(ids.wsA1, failing, FILE_DERIVATIVE_KIND.PDF),
+    );
+
+    await runRepair();
+
+    expect(queued).toHaveLength(0);
+    expect(
+      captureErrorMock.mock.calls.some(
+        ([error]) => error instanceof FileDerivativeRepairError,
+      ),
+    ).toBe(true);
+
+    await runRepair();
+
+    expect(queued.map(({ data }) => data.fieldId)).toEqual([stuck]);
   });
 });

--- a/apps/api/src/lib/scheduler/tasks/file-derivative-repair.ts
+++ b/apps/api/src/lib/scheduler/tasks/file-derivative-repair.ts
@@ -236,15 +236,16 @@ type RowRepairResult = {
    * than dropped quietly, so an unrepairable population stays visible.
    */
   unattributed: boolean;
-  unrecognized: number;
+  /** Kinds skipped as unreadable, for the caller's per-row audit record. */
+  unrecognized: FileDerivativeKind[];
 };
 
 const requeueRow = async (row: RepairPageRow): Promise<RowRepairResult> => {
   if (row.content.type !== "file") {
-    return { requeued: 0, unattributed: false, unrecognized: 0 };
+    return { requeued: 0, unattributed: false, unrecognized: [] };
   }
   if (row.createdBy === null) {
-    return { requeued: 0, unattributed: true, unrecognized: 0 };
+    return { requeued: 0, unattributed: true, unrecognized: [] };
   }
   const userId = brandPersistedUserId(row.createdBy);
   const { stuck, unrecognized } = triageFileDerivatives(row.content);
@@ -281,7 +282,7 @@ const requeueRow = async (row: RepairPageRow): Promise<RowRepairResult> => {
   };
 
   await requeueFrom(0);
-  return { requeued, unattributed: false, unrecognized: unrecognized.length };
+  return { requeued, unattributed: false, unrecognized };
 };
 
 const persistCursor = async ({
@@ -359,7 +360,18 @@ export const repairFileDerivatives: SchedulerTask = async ({
     }
     requeued += outcome.value.requeued;
     unattributed += outcome.value.unattributed ? 1 : 0;
-    unrecognized += outcome.value.unrecognized;
+    unrecognized += outcome.value.unrecognized.length;
+    // Capture dedups identical errors inside its window, so with several
+    // unreadable rows in one page only the first field id reaches
+    // analytics. This log line is the per-row audit record; the rows also
+    // stay enumerable in SQL by their unreadable state.
+    for (const kind of outcome.value.unrecognized) {
+      logger.error("file_derivative.unrecognized_state", {
+        fieldId: row.fieldId,
+        kind,
+        workspaceId: row.workspaceId,
+      });
+    }
     await repairFrom(index + 1);
   };
 

--- a/apps/api/src/lib/scheduler/tasks/file-derivative-repair.ts
+++ b/apps/api/src/lib/scheduler/tasks/file-derivative-repair.ts
@@ -15,6 +15,10 @@ import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { isUuid } from "@/api/lib/custom-schema";
 import {
+  FileDerivativeRepairError,
+  UnrecognizedDerivativeStateError,
+} from "@/api/lib/errors/tagged-errors";
+import {
   FILE_DERIVATIVE_KIND,
   FILE_DERIVATIVE_REQUEUE_OUTCOME,
   requeueFileDerivative,
@@ -47,33 +51,64 @@ const SETTLE_MS = 15 * 60 * 1000;
 type FileFieldContent = Extract<FieldContent, { type: "file" }>;
 type DerivativeState = FileFieldContent["pdfDerivative"];
 
+const DERIVATIVE_RETRY_VERDICT = {
+  RETRYABLE: "retryable",
+  TERMINAL: "terminal",
+  /** Corrupt JSONB, or a status this build does not know. */
+  UNRECOGNIZED: "unrecognized",
+} as const;
+
+type DerivativeRetryVerdict =
+  (typeof DERIVATIVE_RETRY_VERDICT)[keyof typeof DERIVATIVE_RETRY_VERDICT];
+
 /**
  * Whether this derivative state can still be retried. Absent means `pending`:
  * that is the default every file field is written with. A `failed` state is
  * retryable only when the job never entered the queue; once the worker has
  * run and exhausted its attempts the verdict is terminal, and re-adding the
  * job would replay a conversion that has already been proven to fail.
+ *
+ * `fields.content` is unvalidated JSONB, so a state written by a buggy build
+ * (the bare-`::jsonb` string casts `file-derivative-queue` documents) or a
+ * newer one reaches this predicate as-is. Such a state is `unrecognized`:
+ * this standing sweep must judge it without dying, and replaying a verdict
+ * it cannot read is the costlier mistake.
  */
-const isRetryableDerivativeState = (state: DerivativeState): boolean => {
+const derivativeRetryVerdict = (
+  state: DerivativeState,
+): DerivativeRetryVerdict => {
   if (state === undefined) {
-    return true;
+    return DERIVATIVE_RETRY_VERDICT.RETRYABLE;
+  }
+  const raw: unknown = state;
+  if (typeof raw !== "object" || raw === null) {
+    return DERIVATIVE_RETRY_VERDICT.UNRECOGNIZED;
   }
   switch (state.status) {
     case "pending": {
-      return true;
+      return DERIVATIVE_RETRY_VERDICT.RETRYABLE;
     }
     case "failed": {
-      return state.reason === DERIVATIVE_FAILURE_REASON.ENQUEUE;
+      return state.reason === DERIVATIVE_FAILURE_REASON.ENQUEUE
+        ? DERIVATIVE_RETRY_VERDICT.RETRYABLE
+        : DERIVATIVE_RETRY_VERDICT.TERMINAL;
     }
     case "ready":
     case "not-required": {
-      return false;
+      return DERIVATIVE_RETRY_VERDICT.TERMINAL;
     }
     default: {
-      const unhandled: never = state;
-      return panic(`Unhandled derivative state: ${JSON.stringify(unhandled)}`);
+      state satisfies never;
+      return DERIVATIVE_RETRY_VERDICT.UNRECOGNIZED;
     }
   }
+};
+
+type FileDerivativeTriage = {
+  /** Nothing is driving these anymore; hand them back to the queue. */
+  stuck: FileDerivativeKind[];
+  /** Reported by the caller so an unreadable state cannot rot silently. */
+  unrecognized: FileDerivativeKind[];
 };
 
 /**
@@ -81,31 +116,45 @@ const isRetryableDerivativeState = (state: DerivativeState): boolean => {
  * authority; the SQL below only narrows the scan, and deliberately selects a
  * superset of what this returns.
  */
-export const stuckFileDerivatives = (
+export const triageFileDerivatives = (
   content: FileFieldContent,
-): FileDerivativeKind[] => {
-  const stuck: FileDerivativeKind[] = [];
-  if (
-    content.pdfFileId === null &&
-    isRetryableDerivativeState(content.pdfDerivative) &&
+): FileDerivativeTriage => {
+  const triage: FileDerivativeTriage = { stuck: [], unrecognized: [] };
+  const judge = (
+    kind: FileDerivativeKind,
+    derivativeFileId: string | null,
+    state: DerivativeState,
+    required: boolean,
+  ): void => {
+    if (derivativeFileId !== null || !required) {
+      return;
+    }
+    const verdict = derivativeRetryVerdict(state);
+    if (verdict === DERIVATIVE_RETRY_VERDICT.RETRYABLE) {
+      triage.stuck.push(kind);
+    } else if (verdict === DERIVATIVE_RETRY_VERDICT.UNRECOGNIZED) {
+      triage.unrecognized.push(kind);
+    }
+  };
+  judge(
+    FILE_DERIVATIVE_KIND.PDF,
+    content.pdfFileId,
+    content.pdfDerivative,
     shouldGeneratePdfDerivative({
       encrypted: content.encrypted,
       mimeType: content.mimeType,
-    })
-  ) {
-    stuck.push(FILE_DERIVATIVE_KIND.PDF);
-  }
-  if (
-    (content.thumbnailFileId ?? null) === null &&
-    isRetryableDerivativeState(content.thumbnailDerivative) &&
+    }),
+  );
+  judge(
+    FILE_DERIVATIVE_KIND.THUMBNAIL,
+    content.thumbnailFileId ?? null,
+    content.thumbnailDerivative,
     shouldGenerateImageThumbnail({
       encrypted: content.encrypted,
       mimeType: content.mimeType,
-    })
-  ) {
-    stuck.push(FILE_DERIVATIVE_KIND.THUMBNAIL);
-  }
-  return stuck;
+    }),
+  );
+  return triage;
 };
 
 const repairCursor = (
@@ -187,24 +236,33 @@ type RowRepairResult = {
    * than dropped quietly, so an unrepairable population stays visible.
    */
   unattributed: boolean;
+  unrecognized: number;
 };
 
 const requeueRow = async (row: RepairPageRow): Promise<RowRepairResult> => {
   if (row.content.type !== "file") {
-    return { requeued: 0, unattributed: false };
+    return { requeued: 0, unattributed: false, unrecognized: 0 };
   }
   if (row.createdBy === null) {
-    return { requeued: 0, unattributed: true };
+    return { requeued: 0, unattributed: true, unrecognized: 0 };
   }
   const userId = brandPersistedUserId(row.createdBy);
-  const kinds = stuckFileDerivatives(row.content);
+  const { stuck, unrecognized } = triageFileDerivatives(row.content);
+  for (const kind of unrecognized) {
+    captureError(
+      new UnrecognizedDerivativeStateError({
+        message: `Persisted ${kind} derivative state is unreadable to this build`,
+      }),
+      { fieldId: row.fieldId, kind, workspaceId: row.workspaceId },
+    );
+  }
   let requeued = 0;
 
   // Sequential by recursion: a field has at most two derivatives, and one
   // queue write at a time keeps a tick's Redis traffic proportional to the
   // bound rather than to the page.
   const requeueFrom = async (index: number): Promise<void> => {
-    const kind = kinds.at(index);
+    const kind = stuck.at(index);
     if (kind === undefined) {
       return;
     }
@@ -223,7 +281,7 @@ const requeueRow = async (row: RepairPageRow): Promise<RowRepairResult> => {
   };
 
   await requeueFrom(0);
-  return { requeued, unattributed: false };
+  return { requeued, unattributed: false, unrecognized: unrecognized.length };
 };
 
 const persistCursor = async ({
@@ -275,6 +333,7 @@ export const repairFileDerivatives: SchedulerTask = async ({
   let requeued = 0;
   let scanned = 0;
   let unattributed = 0;
+  let unrecognized = 0;
 
   const repairFrom = async (index: number): Promise<void> => {
     const row = page.at(index);
@@ -282,25 +341,31 @@ export const repairFileDerivatives: SchedulerTask = async ({
       return;
     }
     const outcome = await Result.tryPromise(async () => await requeueRow(row));
+    // The row counts as scanned either way: the cursor must advance past a
+    // row whose repair fails deterministically, or the sweep pins itself
+    // there, re-captures every tick, and starves every field after it.
+    scanned += 1;
     if (Result.isError(outcome)) {
-      // The queue is unreachable (or refused the write). Stop the tick and
-      // leave the cursor on the last repaired row: the rest of the page is
-      // still stuck, and the next tick starts exactly where this one gave up.
-      captureError(outcome.error, {
-        fieldId: row.fieldId,
-        workspaceId: row.workspaceId,
-      });
+      // The queue is unreachable, or this one row cannot be repaired. Stop
+      // the tick; the next full pass retries the row.
+      captureError(
+        new FileDerivativeRepairError({
+          message: "Requeueing one stuck file derivative failed",
+          cause: outcome.error,
+        }),
+        { fieldId: row.fieldId, workspaceId: row.workspaceId },
+      );
       return;
     }
     requeued += outcome.value.requeued;
     unattributed += outcome.value.unattributed ? 1 : 0;
-    scanned += 1;
+    unrecognized += outcome.value.unrecognized;
     await repairFrom(index + 1);
   };
 
   await repairFrom(0);
 
-  // Advance only over rows this tick actually finished, so a page cut short
+  // Advance only over rows this tick actually visited, so a page cut short
   // by the requeue bound or an unreachable queue is resumed, not skipped.
   const lastScanned = scanned === 0 ? undefined : page.at(scanned - 1);
   await persistCursor({
@@ -313,5 +378,6 @@ export const repairFileDerivatives: SchedulerTask = async ({
     "fileDerivatives.requeued": requeued,
     "fileDerivatives.scanned": scanned,
     "fileDerivatives.unattributed": unattributed,
+    "fileDerivatives.unrecognized": unrecognized,
   });
 };


### PR DESCRIPTION
## What

The file-derivative repair sweep (`files.repairDerivatives` scheduler task) could pin itself on a single row forever. Its tick stopped on the first row whose requeue threw and left the durable cursor *before* that row, so a row that fails deterministically was replayed every tick: the same error was captured over and over, and no field after the cursor was ever repaired.

One deterministic failure mode was inside the sweep itself: the retry predicate `panic`ed on a derivative state it could not read. `fields.content` is unvalidated JSONB, so a state persisted as a jsonb *string* (the historical bare-`::jsonb` cast defect that `file-derivative-queue`'s literals now guard against) or a status written by a newer build reaches the predicate as-is, and one such row was enough to park the whole reconciler.

## How

- The sweep counts a failed row as scanned, so the cursor advances past it. The tick still stops on failure (an unreachable queue would fail every row), but the row is retried once per full pass instead of every tick.
- The retry predicate returns a three-way verdict (`retryable` / `terminal` / `unrecognized`) instead of panicking. Unrecognized states are never requeued (replaying a verdict the build cannot read is the costlier mistake), are reported through capture with the field's correlation ids, and the tick keeps sweeping. Compile-time exhaustiveness over known statuses is kept via `satisfies never`.
- Row failures are captured wrapped in a new `FileDerivativeRepairError` TaggedError, so the event carries a stable `_tag` rather than a minified constructor name; the original error stays on `cause`.
- `errorFingerprint` now ships `error.cause.class` next to `error.cause.frame`, so any wrapper capture names what actually failed. Deliberately not part of the grouping fingerprint or the suppression key.

## Tests

- New: a row whose derivative state is a jsonb string (seeded via raw SQL, the production shape) is reported, skipped, and does not stop the sweep or the cursor.
- New: a row whose requeue throws stops the tick but the cursor moves past it, and the next tick repairs the rows behind it.
- Existing repair, error-utils, and capture suites pass unchanged apart from the extended cause-fingerprint assertion.
