### PR TITLE
fix(api): capture one exception per ingestion stall, not one per fetch

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -1946,14 +1946,15 @@ export const runIngestionPipeline = async ({
 
     const observedPage = observedPageResult.value;
     if (observedPage.type === "fetch-error") {
-      captureError(observedPage.error, {
-        adapterKey: adapter.key,
-        cursor: cursor ?? "",
-      });
+      // Expected operational failure (a source outage fails every attempt),
+      // so no per-attempt exception capture: this halt is recorded in the
+      // ingestion-events row and the structured log, and the runner captures
+      // one exception per sustained stall episode instead.
       haltReason = `Page fetch failed: ${observedPage.error.message}`;
       logger.error("case_law.ingestion.adapter_halted", {
         adapterKey: adapter.key,
         cursor: cursor ?? "",
+        httpStatus: String(observedPage.error.httpStatus ?? ""),
         reason: haltReason,
         inserted,
         skipped,

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -332,6 +332,17 @@ export class AdapterFetchError extends TaggedError("AdapterFetchError")<{
   cause?: unknown;
 }> {}
 
+/**
+ * One source made no progress for a sustained run of ingestion cycles.
+ * Captured once per stall episode; the per-cycle record lives in the
+ * ingestion-events table and the structured logs.
+ */
+export class IngestionStallError extends TaggedError("IngestionStallError")<{
+  message: string;
+  adapterKey: string;
+  noProgressCycles: number;
+}> {}
+
 export const SUBPROCESS_TERMINATION_REASON = {
   timeout: "timeout",
   cancelled: "cancelled",

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -336,10 +336,17 @@ export class AdapterFetchError extends TaggedError("AdapterFetchError")<{
  * One source made no progress for a sustained run of ingestion cycles.
  * Captured once per stall episode; the per-cycle record lives in the
  * ingestion-events table and the structured logs.
+ *
+ * `code` carries the adapter key: capture suppression and issue grouping key
+ * on class/code/frame and deliberately ignore context, so without it two
+ * sources stalling inside one suppression window would collapse into a
+ * single event while each loop's once-per-episode latch is already set,
+ * leaving the second stall with no exception at all.
  */
 export class IngestionStallError extends TaggedError("IngestionStallError")<{
   message: string;
   adapterKey: string;
+  code: string;
   noProgressCycles: number;
 }> {}
 

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -957,6 +957,7 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
             new IngestionStallError({
               message: `Source made no progress for ${stall.sustained} consecutive cycles`,
               adapterKey,
+              code: adapterKey,
               noProgressCycles: stall.sustained,
             }),
             { adapterKey },

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -42,7 +42,11 @@ import {
 } from "@/api/handlers/case-law/ingestion/source-totals";
 import { backfillLegislationCorpusIndex } from "@/api/handlers/legislation/corpus-index";
 import { backfillLegislationSearchIndex } from "@/api/handlers/legislation/search-index";
-import { TimeoutError } from "@/api/lib/errors/tagged-errors";
+import { captureError } from "@/api/lib/analytics/capture";
+import {
+  IngestionStallError,
+  TimeoutError,
+} from "@/api/lib/errors/tagged-errors";
 import { errorTag } from "@/api/lib/errors/utils";
 import { backfillSearchIndex } from "@/api/lib/legal-search/case-law-search-index";
 import { acquireCaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
@@ -93,8 +97,11 @@ import {
   type CycleOutcome,
   type CycleResult,
   INITIAL_CADENCE_STREAKS,
+  INITIAL_STALL_ALERT,
+  type StallAlertState,
   cycleMadeProgress,
   stepCadence,
+  stepStallAlert,
 } from "./cycle-progress";
 import {
   RECOMPUTE_OUTCOME,
@@ -828,13 +835,8 @@ const runOneCycle = async (
  */
 
 const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
-  /**
-   * Consecutive cycles that advanced no page, whatever their outcome (see
-   * `cycleMadeProgress`). A single streak so an adapter alternating between
-   * stall shapes, each of which would otherwise reset the other's counter,
-   * still reaches the sustained-failure alert.
-   */
-  let noProgressStreak = 0;
+  /** Stall streak plus the once-per-episode capture latch; see cycle-progress. */
+  let stallAlert: StallAlertState = INITIAL_STALL_ALERT;
   /** Separate counter for backoff; not reset by the alert threshold. */
   let backoffFailures = 0;
   /** Quiet and unproductive streaks; drive the inter-cycle delay. */
@@ -846,6 +848,8 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
       return;
     }
     let leaseBusy = false;
+    /** Null when the cycle never ran (lease busy), so it folds no evidence. */
+    let progressVerdict: boolean | null = null;
     try {
       // Bound concurrent cycles: the fetch/enrich/parse phase runs outside
       // the DB-write slot, so without this every source crawls its backlog
@@ -894,7 +898,7 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
         // A stall is a cycle that advanced no page, whatever its outcome; a halt
         // or a timeout that still walked pages moved the cursor.
         const madeProgress = cycleMadeProgress(cycle);
-        noProgressStreak = madeProgress ? 0 : noProgressStreak + 1;
+        progressVerdict = madeProgress;
 
         if (outcome === CYCLE_OUTCOME.FAILED && !madeProgress) {
           backoffFailures++;
@@ -921,7 +925,7 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
       }
     } catch (error) {
       // A thrown cycle made no forward progress either.
-      noProgressStreak++;
+      progressVerdict = false;
       backoffFailures++;
       const msg = error instanceof Error ? error.message : String(error);
       if (isTransientConnectionError(error)) {
@@ -931,17 +935,34 @@ const runAdapterLoop = async ({ adapterKey, name }: SourceDef) => {
       }
     }
 
-    // A run of cycles that advanced no page means the source is stalled;
-    // surface it on the sustained-failure metric.
-    if (noProgressStreak >= SUSTAINED_FAILURE_THRESHOLD) {
-      logger.error("case_law.ingestion.sustained_failure", {
-        adapterKey,
-        noProgressStreak,
-      });
-      // Reset to avoid flooding; backoffFailures stays high so the delay
-      // doesn't collapse. The value is read again at the top of the next
-      // iteration (`noProgressStreak + 1`).
-      noProgressStreak = 0;
+    // A run of cycles that advanced no page means the source is stalled.
+    // The log signal re-fires every threshold-worth of stalled cycles; the
+    // exception capture fires once per episode, when it begins, so a source
+    // outage reaches error tracking as one alert instead of one event per
+    // failed fetch.
+    if (progressVerdict !== null) {
+      const stall = stepStallAlert(
+        stallAlert,
+        progressVerdict,
+        SUSTAINED_FAILURE_THRESHOLD,
+      );
+      stallAlert = stall.state;
+      if (stall.sustained !== null) {
+        logger.error("case_law.ingestion.sustained_failure", {
+          adapterKey,
+          noProgressStreak: stall.sustained,
+        });
+        if (stall.capture) {
+          captureError(
+            new IngestionStallError({
+              message: `Source made no progress for ${stall.sustained} consecutive cycles`,
+              adapterKey,
+              noProgressCycles: stall.sustained,
+            }),
+            { adapterKey },
+          );
+        }
+      }
     }
 
     writeHeartbeat();

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.test.ts
@@ -9,11 +9,15 @@ import {
   type CycleOutcome,
   type CycleResult,
   INITIAL_CADENCE_STREAKS,
+  INITIAL_STALL_ALERT,
   QUIET_THRESHOLD,
+  type StallAlertState,
+  type StallAlertStep,
   UNPRODUCTIVE_THRESHOLD,
   classifyCycleProductivity,
   cycleMadeProgress,
   stepCadence,
+  stepStallAlert,
 } from "./cycle-progress";
 
 const OUTCOMES = Object.values(CYCLE_OUTCOME) satisfies readonly CycleOutcome[];
@@ -432,5 +436,58 @@ describe("stepCadence", () => {
     expect([...reached].toSorted()).toEqual(
       Object.values(CYCLE_CADENCE).toSorted(),
     );
+  });
+});
+
+describe("stepStallAlert", () => {
+  const THRESHOLD = 5;
+
+  /** Fold a progress sequence, returning every step in order. */
+  const runStalls = (verdicts: readonly boolean[]): StallAlertStep[] => {
+    let state: StallAlertState = INITIAL_STALL_ALERT;
+    return verdicts.map((madeProgress) => {
+      const step = stepStallAlert(state, madeProgress, THRESHOLD);
+      state = step.state;
+      return step;
+    });
+  };
+
+  test("a long outage logs every crossing but captures exactly once", () => {
+    const steps = runStalls(Array.from({ length: THRESHOLD * 3 }, () => false));
+
+    const sustained = steps.filter((step) => step.sustained !== null);
+    expect(sustained).toHaveLength(3);
+    expect(sustained.map((step) => step.sustained)).toEqual([
+      THRESHOLD,
+      THRESHOLD,
+      THRESHOLD,
+    ]);
+    expect(steps.filter((step) => step.capture)).toHaveLength(1);
+    expect(steps.findIndex((step) => step.capture)).toBe(THRESHOLD - 1);
+  });
+
+  test("below the threshold nothing is signalled", () => {
+    const steps = runStalls(Array.from({ length: THRESHOLD - 1 }, () => false));
+
+    expect(steps.every((step) => step.sustained === null)).toBe(true);
+    expect(steps.every((step) => !step.capture)).toBe(true);
+  });
+
+  test("progress re-arms the capture for the next episode", () => {
+    const outage = Array.from({ length: THRESHOLD }, () => false);
+    const steps = runStalls([...outage, true, ...outage]);
+
+    expect(steps.filter((step) => step.capture)).toHaveLength(2);
+  });
+
+  test("intermittent progress keeps the streak from accumulating", () => {
+    const flapping = Array.from(
+      { length: THRESHOLD * 4 },
+      (_, i) => i % 2 === 0,
+    );
+    const steps = runStalls(flapping);
+
+    expect(steps.every((step) => step.sustained === null)).toBe(true);
+    expect(steps.every((step) => !step.capture)).toBe(true);
   });
 });

--- a/apps/legal-atlas-runner/src/runners/cycle-progress.ts
+++ b/apps/legal-atlas-runner/src/runners/cycle-progress.ts
@@ -283,3 +283,62 @@ export const stepCadence = (
         : null,
   };
 };
+
+/**
+ * Consecutive cycles that advanced no page, and whether the running stall
+ * episode has already been reported as an exception. One streak whatever the
+ * stall's shape (failed cycle, thrown cycle, timeout with no pages), so an
+ * adapter alternating between shapes still reaches the threshold.
+ */
+export type StallAlertState = {
+  noProgressStreak: number;
+  captured: boolean;
+};
+
+export const INITIAL_STALL_ALERT = {
+  noProgressStreak: 0,
+  captured: false,
+} as const satisfies StallAlertState;
+
+export type StallAlertStep = {
+  state: StallAlertState;
+  /** The streak that reached the threshold this cycle; null below it. */
+  sustained: number | null;
+  /**
+   * True only on the episode's first threshold crossing. The sustained log
+   * signal re-fires on every crossing so an ongoing outage stays visible,
+   * but exception capture is for a human, and a human needs one exception
+   * per outage, not one per crossing of it.
+   */
+  capture: boolean;
+};
+
+/**
+ * Fold one cycle's progress verdict into the stall-alert state. Pure for the
+ * same reason as `stepCadence`: only a whole-sequence test can show that a
+ * long outage is captured exactly once and a recovery re-arms the capture.
+ */
+export const stepStallAlert = (
+  state: StallAlertState,
+  madeProgress: boolean,
+  threshold: number,
+): StallAlertStep => {
+  if (madeProgress) {
+    return { state: INITIAL_STALL_ALERT, sustained: null, capture: false };
+  }
+  const streak = state.noProgressStreak + 1;
+  if (streak < threshold) {
+    return {
+      state: { noProgressStreak: streak, captured: state.captured },
+      sustained: null,
+      capture: false,
+    };
+  }
+  // The streak resets on report so the log signal paces itself at one line
+  // per threshold-worth of cycles; the latch is what remembers the episode.
+  return {
+    state: { noProgressStreak: 0, captured: true },
+    sustained: streak,
+    capture: !state.captured,
+  };
+};


### PR DESCRIPTION
## What

A failed case-law page fetch halted the ingestion cycle and captured an exception every time. Since the daemon retries a failing source on a bounded backoff, an ordinary source outage emitted one exception per retry cycle for as long as it lasted, flooding error tracking with events no human acts on individually.

## How

- `AdapterFetchError` is an expected operational failure, so the per-attempt exception capture in the pipeline's fetch-error halt is removed. Each halt is still fully recorded: the `case_law.ingestion.adapter_halted` structured log (now also carrying the HTTP status) and the durable `case_law_ingestion_events` row.
- The exception path moves to the daemon's sustained-failure signal. Each adapter loop folds its cycle's progress verdict through a new pure state machine, `stepStallAlert` (in `cycle-progress`, next to `stepCadence`): the sustained-failure log keeps re-firing on every threshold crossing while the stall lasts, but a new `IngestionStallError` is captured exactly once per stall episode and re-armed when the source makes progress again. One outage, one exception.
- Crawl behavior (cadence, backoff, halting) is unchanged; only telemetry routing changed.

## Tests

Sequence tests over `stepStallAlert`: a long outage logs every crossing but captures once at onset; sub-threshold runs signal nothing; recovery re-arms the capture for the next episode; intermittent progress never accumulates a streak.
