### PR TITLE
chore(deps): bump @stll/folio-core to 0.17.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,10 @@
   "workspaces": {
     "": {
       "name": "stella",
+      "dependencies": {
+        "@stll/folio-agents": "^0.8.4",
+        "@stll/folio-core": "^0.17.1",
+      },
       "devDependencies": {
         "@changesets/changelog-github": "^0.7.0",
         "@changesets/cli": "^2.31.0",
@@ -818,7 +822,7 @@
     "@stll/anonymize-data": "0.0.9",
     "@stll/anonymize-wasm": "2.7.6",
     "@stll/folio-agents": "0.8.4",
-    "@stll/folio-core": "0.17.0",
+    "@stll/folio-core": "0.17.1",
     "@stll/folio-react": "0.13.4",
     "@t3-oss/env-core": "0.13.11",
     "@tailwindcss/postcss": "4.3.3",
@@ -2201,7 +2205,7 @@
 
     "@stll/folio-agents": ["@stll/folio-agents@0.8.4", "", { "dependencies": { "@stll/folio-core": "^0.17.0" } }, "sha512-1JNrIjr1QWBDB72T+TAusEDeVVt3CnM2CKT43fTW9K/BP4v0oqraTrRT1FXJBKJbhLWOrTs2jkCndPwLEEZE8A=="],
 
-    "@stll/folio-core": ["@stll/folio-core@0.17.0", "", { "dependencies": { "@stll/docx-core": "^0.13.0", "@stll/docx-utils": "^0.1.0", "@stll/template-conditions": "^0.1.0", "better-result": "2.10.0", "csstype": "^3.1.3", "dompurify": "^3.4.13", "fast-xml-parser": "^5.9.3", "hyphen": "1.14.1", "jszip": "3.10.1", "marked": "^18.0.5", "prosemirror-commands": "^1.7.1", "prosemirror-dropcursor": "^1.8.2", "prosemirror-gapcursor": "^1.4.1", "prosemirror-history": "^1.5.0", "prosemirror-keymap": "^1.2.3", "prosemirror-model": "^1.25.9", "prosemirror-state": "^1.4.4", "prosemirror-tables": "^1.8.5", "prosemirror-transform": "^1.12.0", "prosemirror-view": "^1.41.8", "utif2": "^4.1.0", "valibot": "1.4.2", "y-prosemirror": "^1.3.7", "yjs": "^13.6.31" } }, "sha512-bU4LTLRZDSn/JzXwcTtvB3GUQV43IB7fFScPGT5rraUD4iS48F0/xZFwA2wY5q59mgiG/t9/epgrIqGveKW6PQ=="],
+    "@stll/folio-core": ["@stll/folio-core@0.17.1", "", { "dependencies": { "@stll/docx-core": "^0.13.0", "@stll/docx-utils": "^0.1.0", "@stll/template-conditions": "^0.1.0", "better-result": "2.10.0", "csstype": "^3.1.3", "dompurify": "^3.4.13", "fast-xml-parser": "^5.9.3", "hyphen": "1.14.1", "jszip": "3.10.1", "marked": "^18.0.5", "prosemirror-commands": "^1.7.1", "prosemirror-dropcursor": "^1.8.2", "prosemirror-gapcursor": "^1.4.1", "prosemirror-history": "^1.5.0", "prosemirror-keymap": "^1.2.3", "prosemirror-model": "^1.25.9", "prosemirror-state": "^1.4.4", "prosemirror-tables": "^1.8.5", "prosemirror-transform": "^1.12.0", "prosemirror-view": "^1.41.8", "utif2": "^4.1.0", "valibot": "1.4.2", "y-prosemirror": "^1.3.7", "yjs": "^13.6.31" } }, "sha512-wWkNyqGkY6okdFpS1MugP2I+EQlufGUXP3ADypYsvekvD3l6hPz6bZnOZJ9GUwFigM2EBaSRhLQP07S9ncwVmw=="],
 
     "@stll/folio-react": ["@stll/folio-react@0.13.4", "", { "dependencies": { "@base-ui/react": "1.6.0", "@fontsource/arimo": "^5.2.8", "@fontsource/caladea": "^5.2.8", "@fontsource/carlito": "^5.2.8", "@fontsource/cousine": "^5.2.7", "@fontsource/lato": "^5.2.7", "@fontsource/noto-sans-arabic": "^5.2.7", "@fontsource/source-sans-3": "^5.2.9", "@fontsource/tinos": "^5.2.7", "@stll/folio-core": "^0.17.0", "better-result": "2.10.0", "lucide-react": "1.24.0", "prosemirror-history": "^1.5.0", "prosemirror-model": "^1.25.9", "prosemirror-state": "^1.4.4", "prosemirror-tables": "^1.8.5", "prosemirror-view": "^1.41.8", "react-compiler-runtime": "^1.0.0", "yjs": "^13.6.31" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "use-intl": ">=4.0.0" } }, "sha512-QNyARgylQK4yqz//1bY8XtMS8ulExpB2GVJqwKi/SW6NDmX69nQCO+2MsCx1T7JP6X9D4WB7jMafC3JY3GVrtg=="],
 
@@ -5193,11 +5197,14 @@
 
     "@stll/docx-core/better-result": ["better-result@2.10.0", "", {}, "sha512-oQhh0y1qo2/ZKdAAEvHZAqKKiHOFU5k/bW96fE2ScgQOVkJRiHwB+nOS1SgFsYqRlxMDWvefXi9Q3px7QvgNDw=="],
 
+
     "@stll/folio-core/@stll/template-conditions": ["@stll/template-conditions@0.1.0", "", { "dependencies": { "@stll/conditions": "^0.1.0", "better-result": "2.9.2" } }, "sha512-GkgzEDiSqpzG3GexlOfVXHgYiQSME8osQIZ645F9ooQbvDcsTVX5YVpfvmPwe3EOhRol6WjEyO2t/39+hNvQsg=="],
 
     "@stll/folio-core/better-result": ["better-result@2.10.0", "", {}, "sha512-oQhh0y1qo2/ZKdAAEvHZAqKKiHOFU5k/bW96fE2ScgQOVkJRiHwB+nOS1SgFsYqRlxMDWvefXi9Q3px7QvgNDw=="],
 
     "@stll/folio-react/@base-ui/react": ["@base-ui/react@1.6.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.3.1", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@date-fns/tz", "@types/react", "date-fns"] }, "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw=="],
+
+    "@stll/folio-react/@stll/folio-core": ["@stll/folio-core@0.17.0", "", { "dependencies": { "@stll/docx-core": "^0.13.0", "@stll/docx-utils": "^0.1.0", "@stll/template-conditions": "^0.1.0", "better-result": "2.10.0", "csstype": "^3.1.3", "dompurify": "^3.4.13", "fast-xml-parser": "^5.9.3", "hyphen": "1.14.1", "jszip": "3.10.1", "marked": "^18.0.5", "prosemirror-commands": "^1.7.1", "prosemirror-dropcursor": "^1.8.2", "prosemirror-gapcursor": "^1.4.1", "prosemirror-history": "^1.5.0", "prosemirror-keymap": "^1.2.3", "prosemirror-model": "^1.25.9", "prosemirror-state": "^1.4.4", "prosemirror-tables": "^1.8.5", "prosemirror-transform": "^1.12.0", "prosemirror-view": "^1.41.8", "utif2": "^4.1.0", "valibot": "1.4.2", "y-prosemirror": "^1.3.7", "yjs": "^13.6.31" } }, "sha512-bU4LTLRZDSn/JzXwcTtvB3GUQV43IB7fFScPGT5rraUD4iS48F0/xZFwA2wY5q59mgiG/t9/epgrIqGveKW6PQ=="],
 
     "@stll/folio-react/better-result": ["better-result@2.10.0", "", {}, "sha512-oQhh0y1qo2/ZKdAAEvHZAqKKiHOFU5k/bW96fE2ScgQOVkJRiHwB+nOS1SgFsYqRlxMDWvefXi9Q3px7QvgNDw=="],
 
@@ -5589,11 +5596,15 @@
 
     "@selderee/plugin-htmlparser2/domhandler/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
+
+
     "@stll/folio-core/@stll/template-conditions/@stll/conditions": ["@stll/conditions@0.1.0", "", { "dependencies": { "valibot": "1.4.1" } }, "sha512-38y+hAAQsOfniDr9xt03mbW4ShYKL9dUE50p9eo8ExXlRen08VAaeVt8Z2tDl9qPM45052XHJT8VoABp//MJ0w=="],
 
     "@stll/folio-core/@stll/template-conditions/better-result": ["better-result@2.9.2", "", {}, "sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q=="],
 
     "@stll/folio-react/@base-ui/react/@base-ui/utils": ["@base-ui/utils@0.3.1", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.2.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg=="],
+
+    "@stll/folio-react/@stll/folio-core/@stll/template-conditions": ["@stll/template-conditions@0.1.0", "", { "dependencies": { "@stll/conditions": "^0.1.0", "better-result": "2.9.2" } }, "sha512-GkgzEDiSqpzG3GexlOfVXHgYiQSME8osQIZ645F9ooQbvDcsTVX5YVpfvmPwe3EOhRol6WjEyO2t/39+hNvQsg=="],
 
     "@stll/web/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5935,7 +5946,13 @@
 
     "@react-grab/cli/ora/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
+
+
     "@stll/folio-core/@stll/template-conditions/@stll/conditions/valibot": ["valibot@1.4.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g=="],
+
+    "@stll/folio-react/@stll/folio-core/@stll/template-conditions/@stll/conditions": ["@stll/conditions@0.1.0", "", { "dependencies": { "valibot": "1.4.1" } }, "sha512-38y+hAAQsOfniDr9xt03mbW4ShYKL9dUE50p9eo8ExXlRen08VAaeVt8Z2tDl9qPM45052XHJT8VoABp//MJ0w=="],
+
+    "@stll/folio-react/@stll/folio-core/@stll/template-conditions/better-result": ["better-result@2.9.2", "", {}, "sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q=="],
 
     "@stll/web/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
 
@@ -5962,6 +5979,9 @@
     "@manypkg/find-root/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "@react-grab/cli/ora/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+
+    "@stll/folio-react/@stll/folio-core/@stll/template-conditions/@stll/conditions/valibot": ["valibot@1.4.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g=="],
 
     "log-symbols/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@stll/anonymize-data": "0.0.9",
     "@stll/anonymize-wasm": "2.7.6",
     "@stll/folio-agents": "0.8.4",
-    "@stll/folio-core": "0.17.0",
+    "@stll/folio-core": "0.17.1",
     "@stll/folio-react": "0.13.4",
     "@t3-oss/env-core": "0.13.11",
     "@tailwindcss/postcss": "4.3.3",
@@ -202,5 +202,9 @@
     "@tanstack/openai-base@0.9.10": "patches/@tanstack%2Fopenai-base@0.9.10.patch",
     "@tanstack/ai-mistral@0.2.4": "patches/@tanstack%2Fai-mistral@0.2.4.patch",
     "@tanstack/ai@0.43.1": "patches/@tanstack%2Fai@0.43.1.patch"
+  },
+  "dependencies": {
+    "@stll/folio-agents": "^0.8.4",
+    "@stll/folio-core": "^0.17.1"
   }
 }


### PR DESCRIPTION
## What

Bumps the `@stll/folio-core` catalog pin from 0.17.0 to 0.17.1, which keeps justified tabbed first lines within the paragraph's right margin ([folio#566](https://github.com/stella/folio/pull/566)).

## How

- Catalog entry in the root `package.json`; `api`, `web`, `landing`, and `playground` all consume it via `catalog:`, so every app renders with the same core.
- Drops the stale lockfile entries that nested `folio-core@0.17.0` under `@stll/folio-agents`: its `^0.17.0` range resolves to the hoisted copy, so exactly one core version ships (a duplicate copy of a prosemirror-holding package would break node identity across the boundary).

`folio-react` 0.13.4 and `folio-agents` 0.8.4 are already the latest. Landing build verified locally against 0.17.1 (272 pages, OG cards intact).