### PR TITLE
fix(e2e): retry the staging date-picker open until hydration accepts it

### DIFF
--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -165,7 +165,18 @@ test.describe("public hydration", () => {
     const datePickerTrigger = page
       .getByRole("button", { name: /select date|vybrat datum/iu })
       .first();
-    await datePickerTrigger.click();
+    // The route is SSR'd, so the trigger is visible just before React has
+    // attached its handler and a too-early click is dropped (same gotcha as
+    // public-tools.spec.ts). Retry the open until hydration has accepted it,
+    // clicking only while the popover is closed so a slow-but-successful
+    // open is not toggled shut again.
+    const dayGrid = page.locator('[role="gridcell"]').first();
+    await expect(async () => {
+      if (!(await dayGrid.isVisible())) {
+        await datePickerTrigger.click();
+      }
+      await expect(dayGrid).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 15_000 });
     await expect(
       page.locator('[role="gridcell"][aria-current="date"]'),
     ).toHaveAttribute("data-date", expectedToday);


### PR DESCRIPTION
## What

The staging smoke test "server-rendered public law decisions stay stable after hydration" failed intermittently (twice today, passing in between) with `element(s) not found` on the calendar's today cell.

## Why

The failure artifacts show the page fully hydrated with the trigger focused but no popover open: the test clicks the date filter as soon as the SSR markup is visible, which can precede React attaching the trigger's handler, and a pre-hydration click is silently dropped. The bilingual button-name regex in the test already acknowledges the pre-hydration window; the click needs the same treatment.

## How

Retry the first interaction until hydration has accepted it, the established pattern from `public-tools.spec.ts`, guarded to click only while the popover is closed so a slow-but-successful open is not toggled shut by the retry. The today-cell assertion is unchanged, so the product regression the test guards (missing `aria-current="date"` after hydration) still fails the run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date-picker interactions during public hydration smoke tests.
  * The date picker now reliably opens after page hydration, avoiding accidental toggling of an already-open calendar.
  * Added verification that the first day-grid cell becomes visible before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->