### PR TITLE
fix(web): combobox empty state, DOCX icon, and review footer height

### DIFF
--- a/apps/web/src/components/contact-picker.tsx
+++ b/apps/web/src/components/contact-picker.tsx
@@ -105,9 +105,24 @@ export const ContactPicker = ({
   };
 
   const showCreate = onCreate && query.trim().length > 0;
+  const createOptions: ContactResult[] = [];
+  if (showCreate && (!type || type === "organization")) {
+    createOptions.push({ ...CREATE_ORG_SENTINEL, displayName: query.trim() });
+  }
+  if (showCreate && (!type || type === "person")) {
+    createOptions.push({
+      ...CREATE_PERSON_SENTINEL,
+      displayName: query.trim(),
+    });
+  }
+  const items = [...results, ...createOptions];
 
   return (
     <Combobox<ContactResult>
+      // The server already filters by `q`; without `items` Base UI's
+      // filtered list stays empty and ComboboxEmpty renders permanently.
+      filter={null}
+      items={items}
       itemToStringLabel={(option) => option.displayName}
       onInputValueChange={(inputValue) => {
         setQuery(inputValue);
@@ -139,52 +154,28 @@ export const ContactPicker = ({
               </div>
             </ComboboxItem>
           ))}
-          {showCreate && (
-            <>
-              {(!type || type === "organization") && (
-                <ComboboxItem
-                  value={{
-                    ...CREATE_ORG_SENTINEL,
-                    displayName: query.trim(),
-                  }}
-                >
-                  <div className="text-primary flex items-center gap-2">
-                    <PlusIcon className="size-3.5" />
-                    <span>
-                      {t("contacts.createOrganization", {
-                        name: query.trim(),
+          {createOptions.map((option) => (
+            <ComboboxItem key={option.id} value={option}>
+              <div className="text-primary flex items-center gap-2">
+                <PlusIcon className="size-3.5" />
+                <span>
+                  {option.type === "organization"
+                    ? t("contacts.createOrganization", {
+                        name: option.displayName,
+                      })
+                    : t("contacts.createPerson", {
+                        name: option.displayName,
                       })}
-                    </span>
-                  </div>
-                </ComboboxItem>
-              )}
-              {(!type || type === "person") && (
-                <ComboboxItem
-                  value={{
-                    ...CREATE_PERSON_SENTINEL,
-                    displayName: query.trim(),
-                  }}
-                >
-                  <div className="text-primary flex items-center gap-2">
-                    <PlusIcon className="size-3.5" />
-                    <span>
-                      {t("contacts.createPerson", {
-                        name: query.trim(),
-                      })}
-                    </span>
-                  </div>
-                </ComboboxItem>
-              )}
-            </>
-          )}
+                </span>
+              </div>
+            </ComboboxItem>
+          ))}
         </ComboboxList>
-        {!showCreate && (
-          <ComboboxEmpty>
-            {query.length > 0
-              ? t("contacts.noContactsFound")
-              : t("workspaces.parties.searchContacts")}
-          </ComboboxEmpty>
-        )}
+        <ComboboxEmpty>
+          {query.length > 0
+            ? t("contacts.noContactsFound")
+            : t("workspaces.parties.searchContacts")}
+        </ComboboxEmpty>
       </ComboboxPopup>
     </Combobox>
   );

--- a/apps/web/src/components/inspector/playbook-facet.tsx
+++ b/apps/web/src/components/inspector/playbook-facet.tsx
@@ -109,6 +109,7 @@ import type {
   ReviewFixState,
   StartReviewResult,
 } from "@/components/ai-suggestions/playbook-review-store";
+import { DocumentIcon } from "@/components/document-icon";
 import { InlinePill } from "@/components/inline-pill";
 import { useInspectorCommandStore } from "@/components/inspector/inspector-command-store";
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
@@ -128,7 +129,7 @@ import { useFormatter } from "@/i18n/formatting-context";
 import type { TranslationKey } from "@/i18n/types";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
-import { DOCX_MIME } from "@/lib/consts";
+import { DOCX_MIME, TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { detached } from "@/lib/detached";
 import { toAPIError } from "@/lib/errors/api";
 import type {
@@ -902,7 +903,11 @@ const ReferenceFilePicker = ({
       </div>
       <Combobox<ReferenceFile>
         disabled={atLimit}
+        // The server already filters by `q`; without `items` Base UI's
+        // filtered list stays empty and ComboboxEmpty renders permanently.
+        filter={null}
         isItemEqualToValue={(a, b) => a.fileFieldId === b.fileFieldId}
+        items={availableSources}
         itemToStringLabel={(item) => item.name}
         onInputValueChange={(value) => {
           setQuery(value);
@@ -928,7 +933,10 @@ const ReferenceFilePicker = ({
             {availableSources.map((source) => (
               <ComboboxItem key={source.fileFieldId} value={source}>
                 <div className="flex min-w-0 items-center gap-2">
-                  <FileTextIcon className="text-muted-foreground size-3.5 shrink-0" />
+                  <DocumentIcon
+                    className="size-3.5 shrink-0"
+                    mimeType={DOCX_MIME}
+                  />
                   <div className="min-w-0">
                     <BidiText className="block truncate text-sm">
                       {source.name}
@@ -973,7 +981,10 @@ const ReferenceFilePicker = ({
               className="bg-muted/50 flex min-h-11 items-center gap-2 rounded-md px-2"
               key={reference.fileFieldId}
             >
-              <FileTextIcon className="text-muted-foreground size-3.5 shrink-0" />
+              <DocumentIcon
+                className="size-3.5 shrink-0"
+                mimeType={DOCX_MIME}
+              />
               <BidiText className="min-w-0 flex-1 truncate text-xs">
                 {reference.name}
               </BidiText>
@@ -1149,7 +1160,12 @@ const TopicEditor = ({
           {t("inspector.review.addTopic")}
         </Button>
       </div>
-      <footer className="flex items-center gap-2 border-t p-3">
+      <footer
+        className={cn(
+          "flex shrink-0 items-center gap-2 border-t px-3",
+          TOOLBAR_ROW_HEIGHT,
+        )}
+      >
         <Button className="flex-1" onClick={onBack} size="sm" variant="outline">
           {t("common.back")}
         </Button>


### PR DESCRIPTION
## What

- **Combobox empty state rendered permanently.** Base UI's `Combobox.Empty` requires the `items` prop on the root component; without it the derived filtered list is always empty, so the "no matches" message showed below real results whenever the popup was open. Affected the document-review reference picker (`playbook-facet.tsx`) and the contact picker. Both now pass `items` with `filter={null}` (both lists are filtered server-side by `q`), so the message only renders when the list is actually empty. `ComboboxEmpty` stays mounted unconditionally in the contact picker: it is an aria-live region, and Base UI nulls its children while items exist.
- **Contact picker create rows** are now derived from the same `createOptions` array that feeds `items`, replacing the duplicated inline sentinel blocks.
- **Reference picker rows** render the shared `DocumentIcon` with `DOCX_MIME` instead of the generic `FileTextIcon`; the sources endpoint (`list-sources.ts`) only returns DOCX files.
- **Topic editor footer** uses the shared `TOOLBAR_ROW_HEIGHT` row (`h-12`, matching the inspector rail and other panel footers) instead of an ad hoc `p-3` row that rendered taller than the rail cells.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact selection so creation options are correctly filtered by contact type and remain available alongside search results.
  * Fixed reference selection to display server-filtered results correctly without being removed by additional client-side filtering.
  * Ensured empty-state messaging is consistently shown when no results are available.

* **UI Improvements**
  * Updated reference icons to better represent DOCX documents.
  * Refined spacing and alignment in the topic editor footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->