### PR TITLE
fix(api): connect the reconciliation Redis client before the first cursor read

### DIFF
--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -17,6 +17,7 @@ import {
   isRetryableOcrDerivativeFailure,
   isRetryableSearchIndexFailure,
   mapWithConcurrency,
+  memoizeConnect,
   ownsPromotedManualOcrClaim,
   readRepairScanCursor,
   runDocumentProcessingReconciliationPhases,
@@ -228,6 +229,47 @@ describe("repair cursor Redis deadlines", () => {
       label: "document OCR repair cursor write",
       timeoutMs: 5,
     });
+  });
+});
+
+describe("reconciliation connection memo", () => {
+  test("connects once while the attempt succeeds", async () => {
+    let attempts = 0;
+    const ensureConnected = memoizeConnect(async () => {
+      attempts += 1;
+      await Promise.resolve();
+    });
+
+    await Promise.all([
+      ensureConnected(),
+      ensureConnected(),
+      ensureConnected(),
+    ]);
+    await ensureConnected();
+
+    expect(attempts).toBe(1);
+  });
+
+  test("retries after a failed attempt instead of caching the rejection", async () => {
+    let attempts = 0;
+    const ensureConnected = memoizeConnect(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("connection refused");
+      }
+      await Promise.resolve();
+    });
+
+    const rejection: unknown = await ensureConnected().then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(rejection).toBeInstanceOf(Error);
+
+    await ensureConnected();
+    await ensureConnected();
+
+    expect(attempts).toBe(2);
   });
 });
 

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -61,6 +61,7 @@ import {
 } from "@/api/lib/ocr-local/recognize-local";
 import { createOcrSearchablePdf } from "@/api/lib/ocr-searchable-pdf";
 import {
+  connectWithColdStartRetries,
   createBullMqConnection,
   createRedisClient,
 } from "@/api/lib/redis-client";
@@ -1439,6 +1440,42 @@ const getReconciliationRedis = () => {
   return reconciliationRedisClient;
 };
 
+/**
+ * Wrap `connect` so it runs at most once per process while it succeeds, and
+ * discards a rejected attempt so the next caller retries. Retaining the
+ * rejected promise would strand every later caller on the first failure.
+ */
+export const memoizeConnect = (
+  connect: () => Promise<void>,
+): (() => Promise<void>) => {
+  let connected: Promise<void> | null = null;
+  return async () => {
+    connected ??= connect().catch((error: unknown) => {
+      connected = null;
+      throw error;
+    });
+    await connected;
+  };
+};
+
+/**
+ * Establish the reconciliation client's connection before any cursor command
+ * is issued. The client disables the offline queue, so a command sent while it
+ * is still connecting rejects immediately instead of waiting for the socket,
+ * and the repair phase reads the cursor as its first action: without this the
+ * phase fails outright whenever it runs before the connection is up.
+ *
+ * Connecting here rather than inside `readRepairScanCursor` keeps the retry
+ * ladder outside that function's per-command deadline, which bounds command
+ * latency and is far shorter than a cold-start retry sequence.
+ */
+const ensureReconciliationRedisConnected = memoizeConnect(
+  async () =>
+    await connectWithColdStartRetries(async () => {
+      await getReconciliationRedis().connect();
+    }),
+);
+
 export const readRepairScanCursor = async (
   readCursor: () => Promise<string | null> = async () =>
     await getReconciliationRedis().get(REPAIR_SCAN_CURSOR_KEY),
@@ -2472,6 +2509,7 @@ const reconcileDocumentProcessing = async ({
   onComplete: () => void;
 }): Promise<void> => {
   try {
+    await ensureReconciliationRedisConnected();
     const counts = await runDocumentProcessingReconciliationPhases({
       phases: [
         {


### PR DESCRIPTION
## Proposed change

`getReconciliationRedis()` builds its client with `enableOfflineQueue: false`, so a command issued while the client is still connecting rejects immediately instead of waiting for the socket. Nothing connects that client explicitly, though: it is left to connect lazily on whichever command happens to be issued first.

That first command is the repair phase's `readRepairScanCursor()` call, since `recoverMissingNativeExtractionRuns` reads the scan cursor before it touches anything else, and `reconcileDocumentProcessing` runs the repair phase first. So the cursor read is what races the connection, and when it loses, the phase rejects and `runDocumentProcessingReconciliationPhases` reports it failed, even though the client is connected well before the next cycle 30s later.

`redis-client.ts` already documents this race and provides `connectWithColdStartRetries` for it, but that wrapper is only applied to the connection built by `createBullMqConnection()`. The reconciliation client is the one Redis consumer in this module that neither queues offline commands nor retries its initial connect, so it is the only one that can fail this way.

This connects it explicitly at the start of a reconcile cycle through the same helper, so a slow initial connect retries on the documented backoff and logs `redis.cold_start_reconnect` at warn instead of failing a phase. The connect deliberately sits outside `readRepairScanCursor`: that function's deadline bounds command latency and is shorter than the retry ladder, so running the ladder inside it would convert the failure into a timeout rather than avoid it. A connect that fails after exhausting its retries still propagates, so a genuine outage stays loud.

`memoizeConnect` keeps a successful connect to one attempt per process and drops a rejected one, so a failed attempt is retried by the next cycle instead of stranding reconciliation behind a cached rejection.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings. `tsc --noEmit -p apps/api` and scoped `oxlint --type-aware --type-check` on both changed files are clean; `bun test apps/api/src/lib/document-processing-queue.test.ts` passes 46/46.
- [x] **TESTING** | Changes tested. Two unit tests cover `memoizeConnect`: one attempt is kept while it succeeds, and a rejected attempt is discarded so the next call retries rather than inheriting the cached rejection.
- [ ] DARK MODE SUPPORT | **N/A** — no UI surface in this change.
- [ ] ISSUE LINKED | **N/A** — no tracking issue.
- [ ] SCREENSHOT INCLUDED | **N/A** — no user-visible change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtfw7eePX77ykB9fct134Z)_