### PR TITLE
feat(case-law): converge corpus write paths and bound the column trim

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -65,7 +65,9 @@ import type {
 import {
   corpusMirrorColumns,
   corpusContentHash,
+  corpusPayloadDisposition,
   EMPTY_CORPUS_CONTENT_HASHES,
+  TRIMMED_CORPUS_PAYLOAD_COLUMNS,
   writeCorpusDocument,
 } from "@/api/lib/legal-search/corpus-storage";
 import type { DecisionSection } from "@/api/lib/legal-search/document-types";
@@ -381,7 +383,6 @@ type SettleCaseLawCorpusMirrorTxOptions = Omit<
   SettleCaseLawCorpusMirrorOptions,
   "scopedDb"
 > & {
-  storage: "dual-write" | "canonical";
   tx: Transaction;
 };
 
@@ -390,7 +391,6 @@ const settleCaseLawCorpusMirrorTx = async ({
   persistedSourceHash,
   observationOrder,
   mirrorCarriesDocument,
-  storage,
   tx,
   written,
 }: SettleCaseLawCorpusMirrorTxOptions): Promise<boolean> => {
@@ -398,8 +398,12 @@ const settleCaseLawCorpusMirrorTx = async ({
   const settled = await tx
     .update(caseLawDecisions)
     .set({
-      ...(storage === "canonical"
-        ? { fulltext: null, sections: null, documentAst: null }
+      // Read off the storage mode rather than off the write plan: the plan
+      // is derived from the mode, and a second derivation here is a mirror
+      // that can go stale.
+      ...(corpusPayloadDisposition({ mode: corpusStorageMode, written }) ===
+      "trim"
+        ? TRIMMED_CORPUS_PAYLOAD_COLUMNS
         : {}),
       ...corpusMirrorColumns({
         status: CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED,
@@ -446,7 +450,6 @@ export const settleCaseLawCorpusMirror = async ({
         persistedSourceHash,
         observationOrder,
         mirrorCarriesDocument,
-        storage: "dual-write",
         tx,
         written,
       }),
@@ -1741,8 +1744,6 @@ const processDecisionAttempt = async ({
             persistedSourceHash,
             observationOrder,
             mirrorCarriesDocument,
-            storage:
-              corpusPlan.type === "object-storage" ? "canonical" : "dual-write",
             tx,
             written,
           }))

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill-corpus.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill-corpus.db.test.ts
@@ -325,6 +325,163 @@ if (!databaseUrl || !runPostgresTests) {
       });
     });
 
+    /**
+     * Under canonical storage the objects are the payload, so a store that
+     * also filled the columns would put the row straight back into the
+     * pre-cutover shape — the state an external cleanup pass exists to
+     * remove, recreated by the writer faster than the pass can clear it.
+     * The queue predicate reads the result (row-specific hash, no surviving
+     * AST artifact) as corpus-served rather than pending, so the decision
+     * does not come back round.
+     */
+    test("canonical storage settles with the columns already empty", async () => {
+      const caseNumber = `corpus-canonical-${suffix}`;
+      const id = await insertDecision({
+        caseNumber,
+        mirrorStatus: CASE_LAW_CORPUS_MIRROR_STATUS.PENDING,
+      });
+
+      const outcome = await storeBackfilledDocument({
+        decision: decisionFor(id, caseNumber),
+        document: parsedDocument,
+        mode: "canonical",
+        scopedDb,
+        writeCorpus: async () => ({
+          ...NEW_KEYS,
+          contentHash: NEW_CONTENT_HASH,
+        }),
+      });
+
+      expect(outcome).toBe("stored");
+      expect(
+        await db.query.caseLawDecisions.findFirst({
+          where: { id: { eq: id } },
+          columns: {
+            corpusMirrorStatus: true,
+            fulltext: true,
+            sections: true,
+            documentAst: true,
+            textS3Key: true,
+            normalizedS3Key: true,
+            astS3Key: true,
+            contentHash: true,
+          },
+        }),
+      ).toEqual({
+        corpusMirrorStatus: CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED,
+        fulltext: null,
+        sections: null,
+        documentAst: null,
+        textS3Key: NEW_KEYS.textKey,
+        normalizedS3Key: NEW_KEYS.sectionsKey,
+        astS3Key: NEW_KEYS.astKey,
+        contentHash: NEW_CONTENT_HASH,
+      });
+    });
+
+    test("dual-write storage keeps the columns alongside the objects", async () => {
+      const caseNumber = `corpus-dual-${suffix}`;
+      const id = await insertDecision({
+        caseNumber,
+        mirrorStatus: CASE_LAW_CORPUS_MIRROR_STATUS.PENDING,
+      });
+
+      await storeBackfilledDocument({
+        decision: decisionFor(id, caseNumber),
+        document: parsedDocument,
+        mode: "dual-write",
+        scopedDb,
+        writeCorpus: async () => ({
+          ...NEW_KEYS,
+          contentHash: NEW_CONTENT_HASH,
+        }),
+      });
+
+      expect(
+        await db.query.caseLawDecisions.findFirst({
+          where: { id: { eq: id } },
+          columns: { fulltext: true, textS3Key: true, contentHash: true },
+        }),
+      ).toMatchObject({
+        fulltext: parsedDocument.fulltext,
+        textS3Key: NEW_KEYS.textKey,
+        contentHash: NEW_CONTENT_HASH,
+      });
+    });
+
+    /**
+     * The columns are dropped because object storage holds the payload, so
+     * a store with no corpus write behind it keeps them whatever the mode
+     * says: they are the only copy.
+     */
+    test("canonical storage with no corpus write keeps the columns", async () => {
+      const caseNumber = `corpus-canonical-nowrite-${suffix}`;
+      const id = await insertDecision({
+        caseNumber,
+        mirrorStatus: CASE_LAW_CORPUS_MIRROR_STATUS.PENDING,
+      });
+
+      await storeBackfilledDocument({
+        decision: decisionFor(id, caseNumber),
+        document: parsedDocument,
+        mode: "canonical",
+        scopedDb,
+        writeCorpus: null,
+      });
+
+      expect(
+        await db.query.caseLawDecisions.findFirst({
+          where: { id: { eq: id } },
+          columns: { fulltext: true, textS3Key: true, contentHash: true },
+        }),
+      ).toMatchObject({
+        fulltext: parsedDocument.fulltext,
+        textS3Key: null,
+        contentHash: null,
+      });
+    });
+
+    /**
+     * A corpus write that throws never reaches the row write at all, so the
+     * decision keeps its pending mirror and its empty columns — still
+     * queued, exactly as before this store ran.
+     */
+    test("canonical storage leaves the row untouched when the corpus write fails", async () => {
+      const caseNumber = `corpus-canonical-failed-${suffix}`;
+      const id = await insertDecision({
+        caseNumber,
+        mirrorStatus: CASE_LAW_CORPUS_MIRROR_STATUS.PENDING,
+      });
+
+      const failure = await storeBackfilledDocument({
+        decision: decisionFor(id, caseNumber),
+        document: parsedDocument,
+        mode: "canonical",
+        scopedDb,
+        writeCorpus: async () =>
+          await Promise.reject(new Error("bucket unreachable")),
+      }).then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+      expect(failure).toBeInstanceOf(Error);
+      expect(
+        await db.query.caseLawDecisions.findFirst({
+          where: { id: { eq: id } },
+          columns: {
+            corpusMirrorStatus: true,
+            fulltext: true,
+            textS3Key: true,
+          },
+        }),
+      ).toMatchObject({
+        corpusMirrorStatus: CASE_LAW_CORPUS_MIRROR_STATUS.PENDING,
+        fulltext: null,
+        textS3Key: null,
+      });
+    });
+
     test("settles a legacy writer that cannot name the mirror status", async () => {
       const caseNumber = `corpus-legacy-writer-${suffix}`;
       const id = await insertDecision({

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill-corpus.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill-corpus.db.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sql";
 
 import { authRelationsPart } from "@/api/db/auth-schema";
@@ -36,7 +36,11 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { ConcurrentModificationError } from "@/api/lib/errors/tagged-errors";
 import type { WriteCorpusResult } from "@/api/lib/legal-search/corpus-storage";
 import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/lib/legal-search/corpus-storage";
-import { storeBackfilledDocument } from "@/api/lib/legal-search/sk-document-backfill";
+import {
+  markDocumentUnavailable,
+  pendingDocumentPredicate,
+  storeBackfilledDocument,
+} from "@/api/lib/legal-search/sk-document-backfill";
 
 const databaseUrl = process.env["DATABASE_URL"];
 const runPostgresTests = process.env["STELLA_RUN_POSTGRES_TESTS"] === "true";
@@ -377,6 +381,121 @@ if (!databaseUrl || !runPostgresTests) {
         astS3Key: NEW_KEYS.astKey,
         contentHash: NEW_CONTENT_HASH,
       });
+    });
+
+    /**
+     * A PDF parse is CPU-bound and uncancellable, so an attempt can outlive
+     * its 120s claim: a retry stores the document while the first attempt
+     * is still running, then the first attempt finishes empty and marks the
+     * decision unavailable. That write clears the corpus pointers, and
+     * under canonical storage the stored document no longer shows in the
+     * text column, so a fence that reads only `fulltext` would let a late
+     * failure orphan a confirmed payload.
+     */
+    test("a late unavailable marking cannot erase a stored canonical payload", async () => {
+      const caseNumber = `corpus-late-unavailable-${suffix}`;
+      const id = await insertDecision({
+        caseNumber,
+        mirrorStatus: CASE_LAW_CORPUS_MIRROR_STATUS.PENDING,
+      });
+
+      await storeBackfilledDocument({
+        decision: decisionFor(id, caseNumber),
+        document: parsedDocument,
+        mode: "canonical",
+        scopedDb,
+        writeCorpus: async () => ({
+          ...NEW_KEYS,
+          contentHash: NEW_CONTENT_HASH,
+        }),
+      });
+
+      // The attempt that was overtaken, finishing with nothing to store.
+      await markDocumentUnavailable(id, scopedDb);
+
+      expect(
+        await db.query.caseLawDecisions.findFirst({
+          where: { id: { eq: id } },
+          columns: {
+            fulltext: true,
+            textS3Key: true,
+            normalizedS3Key: true,
+            astS3Key: true,
+            contentHash: true,
+          },
+        }),
+      ).toEqual({
+        fulltext: null,
+        textS3Key: NEW_KEYS.textKey,
+        normalizedS3Key: NEW_KEYS.sectionsKey,
+        astS3Key: NEW_KEYS.astKey,
+        contentHash: NEW_CONTENT_HASH,
+      });
+    });
+
+    /**
+     * The same fence from the other side: a store that lands after another
+     * attempt already filled the decision is superseded, not applied.
+     */
+    test("a late store cannot overwrite a stored canonical payload", async () => {
+      const caseNumber = `corpus-late-store-${suffix}`;
+      const id = await insertDecision({
+        caseNumber,
+        mirrorStatus: CASE_LAW_CORPUS_MIRROR_STATUS.PENDING,
+      });
+      const store = async () =>
+        await storeBackfilledDocument({
+          decision: decisionFor(id, caseNumber),
+          document: parsedDocument,
+          mode: "canonical",
+          scopedDb,
+          writeCorpus: async () => ({
+            ...NEW_KEYS,
+            contentHash: NEW_CONTENT_HASH,
+          }),
+        });
+
+      expect(await store()).toBe("stored");
+      expect(await store()).toBe("superseded");
+    });
+
+    /**
+     * The queue must not hand a corpus-served decision back as pending
+     * work: under canonical its text column is null, which is the shape
+     * the queue reads as "never fetched".
+     */
+    test("a stored canonical decision leaves the pending queue", async () => {
+      const caseNumber = `corpus-queue-exit-${suffix}`;
+      const id = await insertDecision({
+        caseNumber,
+        mirrorStatus: CASE_LAW_CORPUS_MIRROR_STATUS.PENDING,
+      });
+
+      const stillPending = async () =>
+        Boolean(
+          (
+            await db
+              .select({ id: caseLawDecisions.id })
+              .from(caseLawDecisions)
+              .where(and(eq(caseLawDecisions.id, id), pendingDocumentPredicate))
+              .limit(1)
+          ).at(0),
+        );
+
+      expect(await stillPending()).toBe(true);
+
+      await storeBackfilledDocument({
+        decision: decisionFor(id, caseNumber),
+        document: parsedDocument,
+        mode: "canonical",
+        scopedDb,
+        writeCorpus: async () => ({
+          ...NEW_KEYS,
+          contentHash: NEW_CONTENT_HASH,
+        }),
+      });
+
+      expect(await stillPending()).toBe(false);
     });
 
     test("dual-write storage keeps the columns alongside the objects", async () => {

--- a/apps/api/src/lib/legal-search/corpus-storage.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-storage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { CASE_LAW_CORPUS_MIRROR_STATUS } from "@/api/db/schema";
 import { zstdCompress } from "@/api/lib/compression";
+import { CORPUS_STORAGE_MODES } from "@/api/lib/corpus-storage-mode";
 import {
   CorpusPayloadUnavailableError,
   TimeoutError,
@@ -9,12 +10,15 @@ import {
 import {
   corpusContentHash,
   corpusMirrorColumns,
+  corpusPayloadDisposition,
   EMPTY_CORPUS_CONTENT_HASHES,
   parsePersistedCorpusAst,
   parsePersistedCorpusSections,
   readCorpusPayloadOrFallback,
   readCorpusText,
+  TRIMMED_CORPUS_PAYLOAD_COLUMNS,
 } from "@/api/lib/legal-search/corpus-storage";
+import type { WriteCorpusResult } from "@/api/lib/legal-search/corpus-storage";
 import { EMPTY_AST } from "@/api/lib/legal-search/document-types";
 
 describe("corpus mirror state columns", () => {
@@ -46,6 +50,57 @@ describe("corpus mirror state columns", () => {
       normalizedS3Key: "corpus/sections.zst",
       astS3Key: "corpus/ast.zst",
       contentHash: "content-hash",
+    });
+  });
+});
+
+/**
+ * Canonical storage serves reads from object storage, so a write path that
+ * keeps persisting the Postgres payload columns leaves rows in a shape the
+ * deployed mode does not describe and makes any external cleanup pass chase
+ * the writers. The disposition is the single place that answers whether a
+ * settling write may drop them, so it is asserted over the whole mode set
+ * rather than over the modes that happen to be interesting.
+ */
+describe("corpusPayloadDisposition", () => {
+  const written = {
+    textKey: "corpus/text.zst",
+    sectionsKey: "corpus/sections.zst",
+    astKey: "corpus/ast.zst",
+    contentHash: "content-hash",
+  } as const satisfies WriteCorpusResult;
+
+  test("only canonical storage drops the columns, and only once written", () => {
+    const dispositions = Object.fromEntries(
+      CORPUS_STORAGE_MODES.map((mode) => [
+        mode,
+        {
+          confirmed: corpusPayloadDisposition({ mode, written }),
+          unwritten: corpusPayloadDisposition({ mode, written: null }),
+        },
+      ]),
+    );
+
+    expect(dispositions).toEqual({
+      off: { confirmed: "retain", unwritten: "retain" },
+      "dual-write": { confirmed: "retain", unwritten: "retain" },
+      canonical: { confirmed: "trim", unwritten: "retain" },
+    });
+  });
+
+  test("every storage mode is decided", () => {
+    // A new mode must not inherit "retain" by omission: the switch is
+    // exhaustive, and this pins the set the assertion above covers.
+    expect(new Set(CORPUS_STORAGE_MODES)).toEqual(
+      new Set(["off", "dual-write", "canonical"]),
+    );
+  });
+
+  test("the trimmed shape nulls exactly the three payload columns", () => {
+    expect(TRIMMED_CORPUS_PAYLOAD_COLUMNS).toEqual({
+      fulltext: null,
+      sections: null,
+      documentAst: null,
     });
   });
 });

--- a/apps/api/src/lib/legal-search/corpus-storage.ts
+++ b/apps/api/src/lib/legal-search/corpus-storage.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 import * as v from "valibot";
 
 import {
@@ -12,6 +12,7 @@ import {
   zstdCompressAsync,
   zstdDecompressToStringBounded,
 } from "@/api/lib/compression";
+import type { CorpusStorageMode } from "@/api/lib/corpus-storage-mode";
 import { CorpusPayloadUnavailableError } from "@/api/lib/errors/tagged-errors";
 import {
   emptyAstSchema,
@@ -288,6 +289,80 @@ export const corpusMirrorColumns = (
     default: {
       const unhandled: never = state;
       return unhandled;
+    }
+  }
+};
+
+/** The three Postgres columns a decision's canonical payload occupies. */
+export type CorpusPayloadColumns = {
+  fulltext: string | null;
+  sections: DecisionSection[] | null;
+  documentAst: DocumentAst | EmptyAst | null;
+};
+
+/**
+ * Absent: how a corpus-served decision carries its payload columns.
+ *
+ * One definition, because four writers produce this state — the ingestion
+ * pipeline's mirror settlement, the deferred-document store, the corpus
+ * backfill and the operator column trim — and a hand-kept copy in any of
+ * them would let a column survive a cutover in one path and not another.
+ */
+export const TRIMMED_CORPUS_PAYLOAD_COLUMNS = {
+  fulltext: null,
+  sections: null,
+  documentAst: null,
+} as const satisfies CorpusPayloadColumns;
+
+/** What a settling write does with the Postgres payload columns. */
+export const CORPUS_PAYLOAD_DISPOSITIONS = [
+  /** Keep them: they are still what a read falls back to. */
+  "retain",
+  /** Null them: object storage is confirmed to hold the payload. */
+  "trim",
+] as const;
+
+export type CorpusPayloadDisposition =
+  (typeof CORPUS_PAYLOAD_DISPOSITIONS)[number];
+
+type CorpusPayloadDispositionOptions = {
+  mode: CorpusStorageMode;
+  /**
+   * The corpus write this settlement records, or null where nothing was
+   * written. Only a confirmed write may drop the columns: until object
+   * storage holds the payload, the columns are the whole of it.
+   */
+  written: WriteCorpusResult | null;
+};
+
+/**
+ * Whether a write that has just settled a decision's corpus mirror may
+ * drop the Postgres payload columns.
+ *
+ * Under `canonical` the columns are not a second copy, they are a stale
+ * one: reads are served from object storage, so a write path that keeps
+ * persisting them leaves the row in a state the deployed mode does not
+ * describe, and an external pass that nulls them can only ever chase the
+ * writers. Asking it here — once, off the storage mode and the write's
+ * own result — is what makes the write paths converge on their own.
+ *
+ * Failure semantics are unchanged: a corpus write that did not confirm
+ * carries `written: null`, and the columns stay exactly as the row
+ * transaction wrote them.
+ */
+export const corpusPayloadDisposition = ({
+  mode,
+  written,
+}: CorpusPayloadDispositionOptions): CorpusPayloadDisposition => {
+  switch (mode) {
+    case "off":
+    case "dual-write":
+      return "retain";
+    case "canonical":
+      return written === null ? "retain" : "trim";
+    default: {
+      const unhandled: never = mode;
+      return panic(`Unhandled corpus storage mode: ${String(unhandled)}`);
     }
   }
 };

--- a/apps/api/src/lib/legal-search/sk-document-backfill.ts
+++ b/apps/api/src/lib/legal-search/sk-document-backfill.ts
@@ -48,6 +48,7 @@ import {
   type DocumentAst,
   isDocumentAst,
 } from "@/api/lib/case-law/document-ast";
+import type { CorpusStorageMode } from "@/api/lib/corpus-storage-mode";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import {
@@ -58,10 +59,15 @@ import { indexDecision } from "@/api/lib/legal-search/case-law-search-index";
 import {
   corpusContentHash,
   corpusMirrorColumns,
+  corpusPayloadDisposition,
   EMPTY_CORPUS_CONTENT_HASHES,
+  TRIMMED_CORPUS_PAYLOAD_COLUMNS,
   writeCorpusDocument,
 } from "@/api/lib/legal-search/corpus-storage";
-import type { WriteCorpusResult } from "@/api/lib/legal-search/corpus-storage";
+import type {
+  CorpusPayloadColumns,
+  WriteCorpusResult,
+} from "@/api/lib/legal-search/corpus-storage";
 import {
   ADAPTER_KEYS,
   PARSER_VERSION,
@@ -523,6 +529,13 @@ export type StoreBackfilledDocumentOptions = {
    */
   writeCorpus?: typeof writeCorpusDocument | null;
   /**
+   * Storage mode this store settles under. Production passes nothing;
+   * tests set it for the same reason they inject the writer, so the
+   * canonical path is exercised without depending on which module read
+   * the environment first.
+   */
+  mode?: CorpusStorageMode;
+  /**
    * The row's source hash when the fetch was claimed. The store applies
    * only while it still holds: a source refresh that lands mid-fetch has
    * rewritten the decision this document was parsed for, so the document
@@ -551,6 +564,13 @@ export type StoreBackfilledDocumentOptions = {
  * it was — still queued, no text — rather than storing text that
  * readers of the canonical payload cannot see.
  *
+ * Under `canonical` storage the row write goes one step further and
+ * leaves the payload columns null: the objects are already confirmed at
+ * that point, so writing the columns too would recreate the very state
+ * the mode exists to retire. The queue does not hand such a row back —
+ * its predicate reads a row-specific content hash with no surviving AST
+ * artifact as corpus-served, not pending.
+ *
  * The row write is conditional on the row still having no text, so two
  * fetches of the same decision converge on one stored document instead
  * of the later writer overwriting the earlier one. Both write identical
@@ -564,6 +584,7 @@ export const storeBackfilledDocument = async ({
   document,
   scopedDb,
   writeCorpus = corpusDocumentWriter(),
+  mode = corpusStorageMode,
   claimedSourceHash,
 }: StoreBackfilledDocumentOptions): Promise<"stored" | "superseded"> => {
   const sections = document.sections.length > 0 ? document.sections : null;
@@ -583,17 +604,31 @@ export const storeBackfilledDocument = async ({
       : sql`${caseLawDecisions.sourceHash} IS NOT DISTINCT FROM ${claimedSourceHash}`,
   );
 
+  const storedPayloadColumns = {
+    fulltext: document.fulltext,
+    documentAst: document.documentAst,
+    sections,
+  } satisfies CorpusPayloadColumns;
+
   const applyStoredPayload = async (
     tx: Transaction,
     written: WriteCorpusResult | null,
   ): Promise<boolean> => {
+    // Under canonical storage the payload this store just wrote to object
+    // storage is the one readers get, so persisting it into the columns as
+    // well would put the row back in the pre-cutover shape the moment
+    // after it left it. The disposition is decided from the confirmed
+    // write, so a corpus failure (which never reaches this callback) still
+    // leaves the columns as the only copy.
+    const payloadColumns =
+      corpusPayloadDisposition({ mode, written }) === "trim"
+        ? TRIMMED_CORPUS_PAYLOAD_COLUMNS
+        : storedPayloadColumns;
     // audit: skip — queue backfill of public case-law text; no user action
     const applied = await tx
       .update(caseLawDecisions)
       .set({
-        fulltext: document.fulltext,
-        documentAst: document.documentAst,
-        sections,
+        ...payloadColumns,
         parserVersion: PARSER_VERSION,
         ...corpusMirrorColumns({
           status: CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED,

--- a/apps/api/src/lib/legal-search/sk-document-backfill.ts
+++ b/apps/api/src/lib/legal-search/sk-document-backfill.ts
@@ -250,20 +250,34 @@ const outsideFetchCooldown = or(
  * cutover should revisit it, since a fully drained corpus would leave
  * the scan walking trimmed rows to conclude the queue is empty.
  */
+/**
+ * SQL for "object storage holds no document for this row".
+ *
+ * The text column cannot answer this on its own. Under canonical storage a
+ * stored document leaves the columns null by design, so every predicate
+ * that means "nothing is stored here" has to consult the durable corpus
+ * state as well, or it will read a corpus-served decision as empty work.
+ * Derived once and shared by the three predicates that ask it, so the
+ * queue's idea of pending cannot drift from the guards that protect a
+ * stored payload from being erased.
+ *
+ * A row whose corpus hash is row-specific but whose Postgres AST column is
+ * still present is a legacy empty-envelope copy, not a corpus-served
+ * document: a trimmed row has had every payload column nulled, so a
+ * surviving AST artifact marks the corpus object as a verbatim copy of a
+ * payload that carries no document.
+ */
+export const storesNoCorpusDocument = or(
+  isNull(caseLawDecisions.contentHash),
+  inArray(caseLawDecisions.contentHash, [...EMPTY_CORPUS_CONTENT_HASHES]),
+  isNotNull(caseLawDecisions.documentAst),
+);
+
 export const pendingDocumentPredicate = and(
   isNull(caseLawDecisions.redactedAt),
   isNull(caseLawDecisions.fulltext),
   isNotNull(caseLawDecisions.documentUrl),
-  or(
-    isNull(caseLawDecisions.contentHash),
-    inArray(caseLawDecisions.contentHash, [...EMPTY_CORPUS_CONTENT_HASHES]),
-    // A row whose corpus hash is row-specific but whose Postgres AST
-    // column is still present is a legacy empty-envelope copy, not a
-    // corpus-served document: a trimmed (corpus-served) row has had every
-    // payload column nulled, so a surviving AST artifact marks the corpus
-    // object as a verbatim copy of a payload that carries no document.
-    isNotNull(caseLawDecisions.documentAst),
-  ),
+  storesNoCorpusDocument,
 );
 
 /** Pending, asked for by a reader, and still within its retry budget. */
@@ -599,6 +613,11 @@ export const storeBackfilledDocument = async ({
     eq(caseLawDecisions.id, decision.id),
     isNull(caseLawDecisions.redactedAt),
     sql`coalesce(${caseLawDecisions.fulltext}, '') = ''`,
+    // The text column stops being the whole answer once a canonical store
+    // nulls it: without this, a store whose parse outlived its claim would
+    // read a decision another attempt already filled as still empty and
+    // overwrite it.
+    storesNoCorpusDocument,
     claimedSourceHash === undefined
       ? undefined
       : sql`${caseLawDecisions.sourceHash} IS NOT DISTINCT FROM ${claimedSourceHash}`,
@@ -797,7 +816,12 @@ export const claimDocumentFetch = async (
  *
  * Conditional on the row still being empty, so a fetch that came back
  * with nothing cannot erase a document another fetch of the same
- * decision has already stored.
+ * decision has already stored. Empty means empty everywhere: this write
+ * clears the corpus pointers along with the text, and a parse that
+ * outlives its 120s claim can land after a retry has already stored the
+ * document, so under canonical storage — where a stored document leaves
+ * the text column null — the corpus state is the only thing standing
+ * between a late failure and an unreachable payload.
  */
 export const markDocumentUnavailable = async (
   decisionId: SafeId<"caseLawDecision">,
@@ -819,6 +843,7 @@ export const markDocumentUnavailable = async (
           eq(caseLawDecisions.id, decisionId),
           isNull(caseLawDecisions.redactedAt),
           isNull(caseLawDecisions.fulltext),
+          storesNoCorpusDocument,
         ),
       );
   });

--- a/apps/api/src/scripts/corpus-column-trim-plan.test.ts
+++ b/apps/api/src/scripts/corpus-column-trim-plan.test.ts
@@ -318,7 +318,43 @@ describe("parseColumnTrimArgs", () => {
       ["--after", ID.a, "--id-from", ID.b],
       ["--id-from", ID.c, "--id-to", ID.a],
       ["--after", ID.c, "--id-to", ID.a],
-      ["--id-from", ID.a, "--id-to", ID.a],
+      // `--after` is exclusive, so this spans nothing.
+      ["--after", ID.a, "--id-to", ID.a],
+    ]) {
+      expect(parseColumnTrimArgs(argv).type).toBe("invalid");
+    }
+  });
+
+  /**
+   * Both `--id-from` and `--id-to` are inclusive, so naming the same id
+   * twice is the one-row repair span a ranges file spells
+   * `{ "from": X, "to": X }`. The two spellings must agree.
+   */
+  test("accepts a single-id inclusive span", () => {
+    expect(parseColumnTrimArgs(["--id-from", ID.a, "--id-to", ID.a])).toEqual({
+      type: "parsed",
+      args: parsedArgs({ idFrom: ID.a, idTo: ID.a }),
+    });
+    expect(
+      columnTrimRanges({
+        args: parsedArgs({ idFrom: ID.a, idTo: ID.a }),
+        fileRanges: null,
+      }),
+    ).toEqual([{ lower: { type: "at-or-after", id: ID.a }, upper: ID.a }]);
+  });
+
+  /**
+   * No flag here takes a value beginning with `--`, so swallowing the next
+   * option token would silently change what the run does: `--ranges-file
+   * --dry-run` would consume the dry run and leave a mutating pass.
+   */
+  test("never consumes an option token as a flag's value", () => {
+    for (const argv of [
+      ["--ranges-file", "--dry-run"],
+      ["--limit", "--dry-run"],
+      ["--after", "--force"],
+      ["--id-from", "--dry-run"],
+      ["--id-to", "--force"],
     ]) {
       expect(parseColumnTrimArgs(argv).type).toBe("invalid");
     }
@@ -399,6 +435,19 @@ describe("parseColumnTrimRanges", () => {
     ]) {
       expect(parseColumnTrimRanges(raw).type).toBe("invalid");
     }
+  });
+
+  /**
+   * A key the sweep does not read must not look like it was honoured: an
+   * operator who writes a per-range cap should be told it does nothing,
+   * not watch the run ignore it and report full coverage.
+   */
+  test("refuses a range entry carrying a key the sweep does not read", () => {
+    expect(
+      parseColumnTrimRanges(
+        JSON.stringify([{ from: ID.a, to: ID.b, limit: 100 }]),
+      ).type,
+    ).toBe("invalid");
   });
 });
 

--- a/apps/api/src/scripts/corpus-column-trim-plan.test.ts
+++ b/apps/api/src/scripts/corpus-column-trim-plan.test.ts
@@ -4,10 +4,17 @@ import type { DocumentAst } from "@stll/legal-ast/document-ast";
 
 import type { CorpusPayload } from "@/api/lib/legal-search/corpus-storage";
 import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/lib/legal-search/corpus-storage";
+import type {
+  ColumnTrimArgs,
+  ColumnTrimRange,
+} from "@/api/scripts/corpus-column-trim-plan";
 import {
   columnTrimGate,
+  columnTrimPageRange,
+  columnTrimRanges,
   corpusObjectState,
   parseColumnTrimArgs,
+  parseColumnTrimRanges,
   planColumnTrim,
 } from "@/api/scripts/corpus-column-trim-plan";
 
@@ -212,40 +219,108 @@ describe("columnTrimGate", () => {
   });
 });
 
+/** Ids in ascending order, so a range built from them is well-formed. */
+const ID = {
+  a: "019dd0c5-f3bc-7000-84b2-cf5f7a95ce5f",
+  b: "01a00247-0d3c-7000-b1b9-0301bea6441e",
+  c: "01a10000-0000-7000-8000-000000000000",
+  d: "01a20000-0000-7000-8000-000000000000",
+} as const;
+
+/**
+ * Every field the parser sets, so a field added later cannot slip into a
+ * run unasserted.
+ */
+const parsedArgs = (overrides: Partial<ColumnTrimArgs>): ColumnTrimArgs => ({
+  limit: null,
+  after: null,
+  idFrom: null,
+  idTo: null,
+  rangesFile: null,
+  dryRun: false,
+  force: false,
+  ...overrides,
+});
+
 describe("parseColumnTrimArgs", () => {
   test("defaults to an uncapped, mutating, gated run from the start", () => {
     expect(parseColumnTrimArgs([])).toEqual({
       type: "parsed",
-      args: { limit: null, after: null, dryRun: false, force: false },
+      args: parsedArgs({}),
     });
   });
 
   test("accepts both --limit forms alongside the flags", () => {
     expect(parseColumnTrimArgs(["--limit", "25", "--dry-run"])).toEqual({
       type: "parsed",
-      args: { limit: 25, after: null, dryRun: true, force: false },
+      args: parsedArgs({ limit: 25, dryRun: true }),
     });
     expect(parseColumnTrimArgs(["--limit=25", "--force"])).toEqual({
       type: "parsed",
-      args: { limit: 25, after: null, dryRun: false, force: true },
+      args: parsedArgs({ limit: 25, force: true }),
     });
   });
 
   test("accepts both --after forms and requires a UUID", () => {
-    const id = "019dd0c5-f3bc-7000-84b2-cf5f7a95ce5f";
-    expect(parseColumnTrimArgs(["--after", id])).toEqual({
+    expect(parseColumnTrimArgs(["--after", ID.a])).toEqual({
       type: "parsed",
-      args: { limit: null, after: id, dryRun: false, force: false },
+      args: parsedArgs({ after: ID.a }),
     });
-    expect(parseColumnTrimArgs([`--after=${id}`, "--dry-run"])).toEqual({
+    expect(parseColumnTrimArgs([`--after=${ID.a}`, "--dry-run"])).toEqual({
       type: "parsed",
-      args: { limit: null, after: id, dryRun: true, force: false },
+      args: parsedArgs({ after: ID.a, dryRun: true }),
     });
     for (const argv of [["--after"], ["--after", "not-a-uuid"]]) {
       expect(parseColumnTrimArgs(argv)).toEqual({
         type: "invalid",
         message: "--after requires a decision id (UUID)",
       });
+    }
+  });
+
+  test("accepts both forms of every id bound", () => {
+    expect(parseColumnTrimArgs(["--id-from", ID.a, "--id-to", ID.c])).toEqual({
+      type: "parsed",
+      args: parsedArgs({ idFrom: ID.a, idTo: ID.c }),
+    });
+    expect(
+      parseColumnTrimArgs([`--id-from=${ID.a}`, `--id-to=${ID.c}`]),
+    ).toEqual({
+      type: "parsed",
+      args: parsedArgs({ idFrom: ID.a, idTo: ID.c }),
+    });
+    for (const flag of ["--id-from", "--id-to"]) {
+      expect(parseColumnTrimArgs([flag, "not-a-uuid"])).toEqual({
+        type: "invalid",
+        message: `${flag} requires a decision id (UUID)`,
+      });
+    }
+  });
+
+  test("takes a --ranges-file path, and refuses an empty one", () => {
+    expect(parseColumnTrimArgs(["--ranges-file", "./ranges.json"])).toEqual({
+      type: "parsed",
+      args: parsedArgs({ rangesFile: "./ranges.json" }),
+    });
+    expect(parseColumnTrimArgs(["--ranges-file"]).type).toBe("invalid");
+  });
+
+  /**
+   * A run that silently walked something other than what was asked for
+   * would report coverage it does not have, so contradictory bounds are
+   * refused rather than resolved by precedence.
+   */
+  test("refuses bounds that contradict each other or span nothing", () => {
+    for (const argv of [
+      ["--ranges-file", "./r.json", "--after", ID.a],
+      ["--ranges-file", "./r.json", "--id-from", ID.a],
+      ["--ranges-file", "./r.json", "--id-to", ID.c],
+      ["--after", ID.a, "--id-from", ID.b],
+      ["--id-from", ID.c, "--id-to", ID.a],
+      ["--after", ID.c, "--id-to", ID.a],
+      ["--id-from", ID.a, "--id-to", ID.a],
+    ]) {
+      expect(parseColumnTrimArgs(argv).type).toBe("invalid");
     }
   });
 
@@ -263,5 +338,139 @@ describe("parseColumnTrimArgs", () => {
 
   test("rejects an unknown flag instead of ignoring it", () => {
     expect(parseColumnTrimArgs(["--wipe"]).type).toBe("invalid");
+  });
+});
+
+describe("parseColumnTrimRanges", () => {
+  test("keeps a sorted, disjoint file as written", () => {
+    expect(
+      parseColumnTrimRanges(
+        JSON.stringify([
+          { from: ID.a, to: ID.b },
+          { from: ID.c, to: ID.d },
+        ]),
+      ),
+    ).toEqual({
+      type: "parsed",
+      ranges: [
+        { from: ID.a, to: ID.b },
+        { from: ID.c, to: ID.d },
+      ],
+    });
+  });
+
+  test("a single-id range is a range", () => {
+    expect(
+      parseColumnTrimRanges(JSON.stringify([{ from: ID.a, to: ID.a }])),
+    ).toEqual({ type: "parsed", ranges: [{ from: ID.a, to: ID.a }] });
+  });
+
+  /**
+   * Every refusal below would otherwise produce a run whose printed
+   * coverage does not describe what it walked: a double-counted span, a
+   * gap the operator believes is covered, or an id the database would
+   * order differently than the file does.
+   */
+  test("refuses malformed, unsorted or overlapping ranges", () => {
+    for (const raw of [
+      "not json",
+      JSON.stringify({ from: ID.a, to: ID.b }),
+      JSON.stringify([]),
+      JSON.stringify([ID.a]),
+      JSON.stringify([{ from: ID.a }]),
+      JSON.stringify([{ from: ID.a, to: "not-a-uuid" }]),
+      // Uppercase would compare differently as text than the database
+      // orders it as a uuid.
+      JSON.stringify([{ from: ID.a.toUpperCase(), to: ID.b }]),
+      JSON.stringify([{ from: ID.b, to: ID.a }]),
+      JSON.stringify([
+        { from: ID.c, to: ID.d },
+        { from: ID.a, to: ID.b },
+      ]),
+      JSON.stringify([
+        { from: ID.a, to: ID.c },
+        { from: ID.b, to: ID.d },
+      ]),
+      // Touching at one id still double-trims that row.
+      JSON.stringify([
+        { from: ID.a, to: ID.b },
+        { from: ID.b, to: ID.c },
+      ]),
+    ]) {
+      expect(parseColumnTrimRanges(raw).type).toBe("invalid");
+    }
+  });
+});
+
+describe("columnTrimRanges", () => {
+  test("a bare run walks the whole id space", () => {
+    expect(
+      columnTrimRanges({ args: parsedArgs({}), fileRanges: null }),
+    ).toEqual([{ lower: { type: "unbounded" }, upper: null }]);
+  });
+
+  test("--after resumes exclusively, --id-from starts inclusively", () => {
+    expect(
+      columnTrimRanges({ args: parsedArgs({ after: ID.a }), fileRanges: null }),
+    ).toEqual([{ lower: { type: "after", id: ID.a }, upper: null }]);
+    expect(
+      columnTrimRanges({
+        args: parsedArgs({ idFrom: ID.a }),
+        fileRanges: null,
+      }),
+    ).toEqual([{ lower: { type: "at-or-after", id: ID.a }, upper: null }]);
+  });
+
+  test("--id-to bounds a resumed walk as well as a fresh one", () => {
+    expect(
+      columnTrimRanges({
+        args: parsedArgs({ after: ID.a, idTo: ID.c }),
+        fileRanges: null,
+      }),
+    ).toEqual([{ lower: { type: "after", id: ID.a }, upper: ID.c }]);
+  });
+
+  test("a ranges file becomes one inclusive range per entry, in order", () => {
+    expect(
+      columnTrimRanges({
+        args: parsedArgs({ rangesFile: "./r.json" }),
+        fileRanges: [
+          { from: ID.a, to: ID.b },
+          { from: ID.c, to: ID.d },
+        ],
+      }),
+    ).toEqual([
+      { lower: { type: "at-or-after", id: ID.a }, upper: ID.b },
+      { lower: { type: "at-or-after", id: ID.c }, upper: ID.d },
+    ]);
+  });
+});
+
+describe("columnTrimPageRange", () => {
+  const range = {
+    lower: { type: "at-or-after", id: ID.a },
+    upper: ID.d,
+  } as const satisfies ColumnTrimRange;
+
+  test("the first page is the range itself", () => {
+    expect(columnTrimPageRange({ range, cursor: null })).toEqual(range);
+  });
+
+  /**
+   * The upper bound has to survive pagination: a later page that dropped
+   * it would scan past the range and reintroduce the unbounded scan the
+   * bound exists to prevent.
+   */
+  test("later pages resume after the cursor and keep the upper bound", () => {
+    expect(columnTrimPageRange({ range, cursor: ID.b })).toEqual({
+      lower: { type: "after", id: ID.b },
+      upper: ID.d,
+    });
+    expect(
+      columnTrimPageRange({
+        range: { lower: { type: "unbounded" }, upper: null },
+        cursor: ID.b,
+      }),
+    ).toEqual({ lower: { type: "after", id: ID.b }, upper: null });
   });
 });

--- a/apps/api/src/scripts/corpus-column-trim-plan.ts
+++ b/apps/api/src/scripts/corpus-column-trim-plan.ts
@@ -1,10 +1,11 @@
+import * as v from "valibot";
+
 import {
   namesEmptyCorpusPayload,
   payloadCarriesDocument,
 } from "@/api/handlers/case-law/stored-payload";
 import type { CorpusStorageMode } from "@/api/lib/corpus-storage-mode";
 import type { CorpusPayload } from "@/api/lib/legal-search/corpus-storage";
-import { isRecord } from "@/api/lib/type-guards";
 
 /**
  * Decision logic for the corpus column trim (`corpus-column-trim.ts`),
@@ -284,9 +285,15 @@ const columnTrimArgConflict = ({
   if (after !== null && idFrom !== null) {
     return "--after and --id-from are both lower bounds; pass one";
   }
-  const lower = after ?? idFrom;
-  if (lower !== null && idTo !== null && lower >= idTo) {
-    return "the lower bound is not below --id-to, so the range is empty";
+  // The two lower bounds compare differently because they mean different
+  // things: `--after` is exclusive, so an id equal to `--id-to` spans
+  // nothing, while `--id-from` is inclusive, so `--id-from X --id-to X` is
+  // the single-row repair a ranges file spells `{ "from": X, "to": X }`.
+  if (after !== null && idTo !== null && after >= idTo) {
+    return "--after is at or above --id-to, so the range is empty";
+  }
+  if (idFrom !== null && idTo !== null && idFrom > idTo) {
+    return "--id-from is above --id-to, so the range is empty";
   }
   return null;
 };
@@ -316,8 +323,15 @@ export const parseColumnTrimArgs = (
       force = true;
       continue;
     }
+    // Every remaining flag takes a value, and none of them takes one that
+    // begins with `--`. Swallowing the next option token as a value would
+    // change what the run does without saying so: `--ranges-file
+    // --dry-run` would consume the dry run and leave a mutating pass. Read
+    // the value once, here, so a flag added later cannot miss the check.
+    const next = argv[++i];
+    const value = next?.startsWith("--") === true ? undefined : next;
     if (argument === "--limit") {
-      const parsed = parseLimit(argv[++i]);
+      const parsed = parseLimit(value);
       if (parsed === null) {
         return {
           type: "invalid",
@@ -328,16 +342,14 @@ export const parseColumnTrimArgs = (
       continue;
     }
     if (argument === "--ranges-file") {
-      const raw = argv[++i];
-      if (raw === undefined || raw === "") {
+      if (value === undefined || value === "") {
         return { type: "invalid", message: "--ranges-file requires a path" };
       }
-      rangesFile = raw;
+      rangesFile = value;
       continue;
     }
     if (ID_FLAGS.has(argument)) {
-      const raw = argv[++i];
-      if (!isDecisionId(raw)) {
+      if (!isDecisionId(value)) {
         return {
           type: "invalid",
           message: `${argument} requires a decision id (UUID)`,
@@ -345,13 +357,13 @@ export const parseColumnTrimArgs = (
       }
       switch (argument) {
         case "--id-from":
-          idFrom = raw;
+          idFrom = value;
           break;
         case "--id-to":
-          idTo = raw;
+          idTo = value;
           break;
         default:
-          after = raw;
+          after = value;
       }
       continue;
     }
@@ -368,6 +380,24 @@ export const parseColumnTrimArgs = (
 export type ParsedColumnTrimRanges =
   | { type: "parsed"; ranges: ColumnTrimRangeSpec[] }
   | { type: "invalid"; message: string };
+
+const decisionIdSchema = v.pipe(
+  v.string("must be a decision id (UUID)"),
+  v.regex(UUID, "must be a lowercase decision id (UUID)"),
+);
+
+/**
+ * Strict, so a key the run does not read cannot look like it was honoured:
+ * an operator who writes a per-range `"limit"` should be told it does
+ * nothing rather than watch the sweep ignore it.
+ */
+const columnTrimRangesSchema = v.pipe(
+  v.array(
+    v.strictObject({ from: decisionIdSchema, to: decisionIdSchema }),
+    "must be an array of ranges",
+  ),
+  v.minLength(1, "must name at least one range"),
+);
 
 /**
  * Read the `--ranges-file` payload.
@@ -392,28 +422,17 @@ export const parseColumnTrimRanges = (raw: string): ParsedColumnTrimRanges => {
     // JSON.parse has no non-throwing form.
     return { type: "invalid", message: "--ranges-file must contain JSON" };
   }
-  if (!Array.isArray(decoded) || decoded.length === 0) {
+
+  const shape = v.safeParse(columnTrimRangesSchema, decoded);
+  if (!shape.success) {
     return {
       type: "invalid",
-      message: "--ranges-file must contain a non-empty JSON array",
+      message: `--ranges-file must be a non-empty array of { "from": ID, "to": ID }: ${shape.issues[0].message}`,
     };
   }
 
   const ranges: ColumnTrimRangeSpec[] = [];
-  for (const [index, entry] of decoded.entries()) {
-    if (!isRecord(entry)) {
-      return {
-        type: "invalid",
-        message: `--ranges-file[${index}] must be an object`,
-      };
-    }
-    const { from, to } = entry;
-    if (!isDecisionId(from) || !isDecisionId(to)) {
-      return {
-        type: "invalid",
-        message: `--ranges-file[${index}] needs "from" and "to" decision ids (UUID)`,
-      };
-    }
+  for (const [index, { from, to }] of shape.output.entries()) {
     if (from > to) {
       return {
         type: "invalid",

--- a/apps/api/src/scripts/corpus-column-trim-plan.ts
+++ b/apps/api/src/scripts/corpus-column-trim-plan.ts
@@ -4,6 +4,7 @@ import {
 } from "@/api/handlers/case-law/stored-payload";
 import type { CorpusStorageMode } from "@/api/lib/corpus-storage-mode";
 import type { CorpusPayload } from "@/api/lib/legal-search/corpus-storage";
+import { isRecord } from "@/api/lib/type-guards";
 
 /**
  * Decision logic for the corpus column trim (`corpus-column-trim.ts`),
@@ -184,9 +185,47 @@ export type ColumnTrimArgs = {
    * statement timeout: the run dies on its first page forever.
    */
   after: string | null;
+  /** Inclusive lower bound of a single bounded walk. */
+  idFrom: string | null;
+  /** Inclusive upper bound of every walk this run makes. */
+  idTo: string | null;
+  /** Path to a JSON array of `{ from, to }` ranges to walk in order. */
+  rangesFile: string | null;
   dryRun: boolean;
   force: boolean;
 };
+
+/**
+ * Where a range's walk starts. `at-or-after` is the range's own lower
+ * bound, which is inclusive because an operator naming a range means to
+ * include the row they named; `after` is a resumed cursor, which is
+ * exclusive because that row has already been processed.
+ */
+export type ColumnTrimLowerBound =
+  | { type: "unbounded" }
+  | { type: "at-or-after"; id: string }
+  | { type: "after"; id: string };
+
+/**
+ * One id range a sweep walks.
+ *
+ * The candidate predicate cannot be satisfied from an index alone, so an
+ * unbounded walk scans forward from its cursor until it has collected a
+ * page — across an already-trimmed stretch of the id space that is an
+ * arbitrarily long scan, and it stops fitting a statement timeout. An
+ * upper bound caps the scan at a span the operator chose, whatever the
+ * density of candidates inside it, which is also what makes a keyspace
+ * whose candidates are scattered (no shared time ordering to walk)
+ * tractable: it is covered by a list of spans rather than one cursor.
+ */
+export type ColumnTrimRange = {
+  lower: ColumnTrimLowerBound;
+  /** Inclusive; null walks to the end of the id space. */
+  upper: string | null;
+};
+
+/** A `--ranges-file` entry: an inclusive `[from, to]` id span. */
+export type ColumnTrimRangeSpec = { from: string; to: string };
 
 export type ParsedColumnTrimArgs =
   | { type: "parsed"; args: ColumnTrimArgs }
@@ -202,11 +241,65 @@ const parseLimit = (raw: string | undefined): number | null => {
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u;
 
+const isDecisionId = (value: unknown): value is string =>
+  typeof value === "string" && UUID.test(value);
+
+/** Flags whose value is a single decision id. */
+const ID_FLAGS: ReadonlySet<string> = new Set([
+  "--after",
+  "--id-from",
+  "--id-to",
+]);
+
+/**
+ * `--flag=value` and `--flag value` are the same input. Splitting the
+ * inline form once keeps every flag below reading its value the same way,
+ * rather than each one re-deriving it.
+ */
+const splitInlineValues = (argv: readonly string[]): string[] =>
+  argv.flatMap((argument) => {
+    const separator = argument.indexOf("=");
+    return argument.startsWith("--") && separator !== -1
+      ? [argument.slice(0, separator), argument.slice(separator + 1)]
+      : [argument];
+  });
+
+/**
+ * Bounds that name two lower bounds, or an empty span, are a mistake the
+ * run cannot recover from: it would silently walk something other than
+ * what was asked for. Rejected here, before anything opens a connection.
+ */
+const columnTrimArgConflict = ({
+  after,
+  idFrom,
+  idTo,
+  rangesFile,
+}: ColumnTrimArgs): string | null => {
+  if (
+    rangesFile !== null &&
+    (after !== null || idFrom !== null || idTo !== null)
+  ) {
+    return "--ranges-file carries its own bounds; drop --after/--id-from/--id-to";
+  }
+  if (after !== null && idFrom !== null) {
+    return "--after and --id-from are both lower bounds; pass one";
+  }
+  const lower = after ?? idFrom;
+  if (lower !== null && idTo !== null && lower >= idTo) {
+    return "the lower bound is not below --id-to, so the range is empty";
+  }
+  return null;
+};
+
 export const parseColumnTrimArgs = (
-  argv: readonly string[],
+  rawArgv: readonly string[],
 ): ParsedColumnTrimArgs => {
+  const argv = splitInlineValues(rawArgv);
   let limit: number | null = null;
   let after: string | null = null;
+  let idFrom: string | null = null;
+  let idTo: string | null = null;
+  let rangesFile: string | null = null;
   let dryRun = false;
   let force = false;
 
@@ -223,11 +316,8 @@ export const parseColumnTrimArgs = (
       force = true;
       continue;
     }
-    if (argument === "--limit" || argument.startsWith("--limit=")) {
-      const raw = argument.startsWith("--limit=")
-        ? argument.slice("--limit=".length)
-        : argv[++i];
-      const parsed = parseLimit(raw);
+    if (argument === "--limit") {
+      const parsed = parseLimit(argv[++i]);
       if (parsed === null) {
         return {
           type: "invalid",
@@ -237,21 +327,158 @@ export const parseColumnTrimArgs = (
       limit = parsed;
       continue;
     }
-    if (argument === "--after" || argument.startsWith("--after=")) {
-      const raw = argument.startsWith("--after=")
-        ? argument.slice("--after=".length)
-        : argv[++i];
-      if (raw === undefined || !UUID.test(raw)) {
+    if (argument === "--ranges-file") {
+      const raw = argv[++i];
+      if (raw === undefined || raw === "") {
+        return { type: "invalid", message: "--ranges-file requires a path" };
+      }
+      rangesFile = raw;
+      continue;
+    }
+    if (ID_FLAGS.has(argument)) {
+      const raw = argv[++i];
+      if (!isDecisionId(raw)) {
         return {
           type: "invalid",
-          message: "--after requires a decision id (UUID)",
+          message: `${argument} requires a decision id (UUID)`,
         };
       }
-      after = raw;
+      switch (argument) {
+        case "--id-from":
+          idFrom = raw;
+          break;
+        case "--id-to":
+          idTo = raw;
+          break;
+        default:
+          after = raw;
+      }
       continue;
     }
     return { type: "invalid", message: `Unknown argument: ${argument}` };
   }
 
-  return { type: "parsed", args: { limit, after, dryRun, force } };
+  const args = { limit, after, idFrom, idTo, rangesFile, dryRun, force };
+  const conflict = columnTrimArgConflict(args);
+  return conflict === null
+    ? { type: "parsed", args }
+    : { type: "invalid", message: conflict };
 };
+
+export type ParsedColumnTrimRanges =
+  | { type: "parsed"; ranges: ColumnTrimRangeSpec[] }
+  | { type: "invalid"; message: string };
+
+/**
+ * Read the `--ranges-file` payload.
+ *
+ * Ranges must be sorted and disjoint. Overlapping ranges would trim the
+ * same rows twice — harmless, but the run's counts would then mean
+ * nothing — and unsorted ranges usually mean the file was assembled from
+ * two sources, in which case its coverage is not what the operator
+ * believes. Both are refused rather than normalised, so the file the
+ * operator reads is the file the run walked.
+ *
+ * Ids compare as text: the canonical lowercase form has its separators at
+ * fixed positions and its digits in ASCII order, so text ordering is the
+ * ordering Postgres gives the `uuid` column.
+ */
+export const parseColumnTrimRanges = (raw: string): ParsedColumnTrimRanges => {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    // A boundary parse, not control flow: the file is operator input and
+    // JSON.parse has no non-throwing form.
+    return { type: "invalid", message: "--ranges-file must contain JSON" };
+  }
+  if (!Array.isArray(decoded) || decoded.length === 0) {
+    return {
+      type: "invalid",
+      message: "--ranges-file must contain a non-empty JSON array",
+    };
+  }
+
+  const ranges: ColumnTrimRangeSpec[] = [];
+  for (const [index, entry] of decoded.entries()) {
+    if (!isRecord(entry)) {
+      return {
+        type: "invalid",
+        message: `--ranges-file[${index}] must be an object`,
+      };
+    }
+    const { from, to } = entry;
+    if (!isDecisionId(from) || !isDecisionId(to)) {
+      return {
+        type: "invalid",
+        message: `--ranges-file[${index}] needs "from" and "to" decision ids (UUID)`,
+      };
+    }
+    if (from > to) {
+      return {
+        type: "invalid",
+        message: `--ranges-file[${index}] has "from" above "to"`,
+      };
+    }
+    const previous = ranges.at(-1);
+    if (previous !== undefined && previous.to >= from) {
+      return {
+        type: "invalid",
+        message: `--ranges-file[${index}] overlaps or precedes its predecessor; ranges must be sorted and disjoint`,
+      };
+    }
+    ranges.push({ from, to });
+  }
+
+  return { type: "parsed", ranges };
+};
+
+type ColumnTrimRangesOptions = {
+  args: ColumnTrimArgs;
+  /** Parsed `--ranges-file` content, or null where the flag was absent. */
+  fileRanges: readonly ColumnTrimRangeSpec[] | null;
+};
+
+/** The ranges one run walks, in order. */
+export const columnTrimRanges = ({
+  args: { after, idFrom, idTo },
+  fileRanges,
+}: ColumnTrimRangesOptions): ColumnTrimRange[] => {
+  if (fileRanges !== null) {
+    return fileRanges.map(({ from, to }) => ({
+      lower: { type: "at-or-after", id: from },
+      upper: to,
+    }));
+  }
+  if (after !== null) {
+    return [{ lower: { type: "after", id: after }, upper: idTo }];
+  }
+  return [
+    {
+      lower:
+        idFrom === null
+          ? { type: "unbounded" }
+          : { type: "at-or-after", id: idFrom },
+      upper: idTo,
+    },
+  ];
+};
+
+type ColumnTrimPageRangeOptions = {
+  range: ColumnTrimRange;
+  /** Last id this range's walk consumed, or null before its first page. */
+  cursor: string | null;
+};
+
+/**
+ * The range the next page queries: the range itself until a row has been
+ * read, then strictly after the last id the previous page consumed. The
+ * upper bound rides along, so every page of a bounded range stays bounded.
+ */
+export const columnTrimPageRange = ({
+  range,
+  cursor,
+}: ColumnTrimPageRangeOptions): ColumnTrimRange =>
+  cursor === null
+    ? range
+    : { lower: { type: "after", id: cursor }, upper: range.upper };

--- a/apps/api/src/scripts/corpus-column-trim.ts
+++ b/apps/api/src/scripts/corpus-column-trim.ts
@@ -39,6 +39,7 @@ import {
   readCorpusAst,
   readCorpusSections,
   readCorpusText,
+  TRIMMED_CORPUS_PAYLOAD_COLUMNS,
 } from "@/api/lib/legal-search/corpus-storage";
 import type {
   DecisionSection,
@@ -244,7 +245,7 @@ const trimRow = async (row: TrimRow): Promise<void> => {
     const applied = await ingestionDb(async (tx) => {
       const updated = await tx
         .update(caseLawDecisions)
-        .set({ fulltext: null, sections: null, documentAst: null })
+        .set(TRIMMED_CORPUS_PAYLOAD_COLUMNS)
         // Compare-and-set on the row state this scan read: a concurrent
         // ingestion refresh may have replaced the payload, in which case
         // the columns it just wrote are canonical and must survive.

--- a/apps/api/src/scripts/corpus-column-trim.ts
+++ b/apps/api/src/scripts/corpus-column-trim.ts
@@ -1,4 +1,16 @@
-import { and, asc, eq, gt, inArray, isNotNull, or, sql } from "drizzle-orm";
+import { panic } from "better-result";
+import {
+  and,
+  asc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNotNull,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 /**
@@ -18,8 +30,24 @@ import type { SQL } from "drizzle-orm";
  * compare-and-set against the row state it read, so the run is
  * idempotent and safe to repeat.
  *
+ * This is a repair pass over rows written before the write paths settled
+ * on the canonical shape, not a standing cleanup: under `canonical` every
+ * write that confirms its corpus objects now settles with the columns
+ * already empty (`corpusPayloadDisposition`).
+ *
  *   CORPUS_STORAGE_MODE=canonical LEGAL_CORPUS_S3_BUCKET=... \
- *     bun run src/scripts/corpus-column-trim.ts [--limit N] [--dry-run] [--force]
+ *     bun run src/scripts/corpus-column-trim.ts \
+ *       [--limit N] [--dry-run] [--force] \
+ *       [--after ID | --id-from ID] [--id-to ID] [--ranges-file PATH]
+ *
+ * The candidate predicate is not indexable, so an unbounded walk scans
+ * forward until it has collected a page; over an already-trimmed stretch
+ * of the id space that scan grows past the statement timeout, and it
+ * cannot be resumed past it. `--id-to` caps every scan at an id range the
+ * operator chose. `--ranges-file` takes a JSON array of sorted, disjoint
+ * `[{ "from": ID, "to": ID }, ...]` spans and walks them in order, which
+ * is how a keyspace whose candidates share no ordering with time gets
+ * covered: by a list of spans, not by one cursor.
  */
 import type { DocumentAst } from "@stll/legal-ast/document-ast";
 
@@ -49,11 +77,17 @@ import { LIMITS } from "@/api/lib/limits";
 import { getCorpusS3, refreshCorpusS3, refreshS3 } from "@/api/lib/s3";
 import { brandPersistedCaseLawDecisionId } from "@/api/lib/safe-id-boundaries";
 import { withTimeout } from "@/api/lib/with-timeout";
-import type { CorpusObjectState } from "@/api/scripts/corpus-column-trim-plan";
+import type {
+  ColumnTrimRange,
+  CorpusObjectState,
+} from "@/api/scripts/corpus-column-trim-plan";
 import {
   columnTrimGate,
+  columnTrimPageRange,
+  columnTrimRanges,
   corpusObjectState,
   parseColumnTrimArgs,
+  parseColumnTrimRanges,
   planColumnTrim,
 } from "@/api/scripts/corpus-column-trim-plan";
 
@@ -78,7 +112,30 @@ if (parsed.type === "invalid") {
   console.error(parsed.message);
   process.exit(2);
 }
-const { limit, after, dryRun, force } = parsed.args;
+const { limit, rangesFile, dryRun, force } = parsed.args;
+
+// Everything the run needs is settled before it opens a connection: a
+// ranges file that turns out to be malformed halfway through a sweep would
+// leave the operator with a partial pass and no statement of what it
+// covered.
+const fileRanges = await (async () => {
+  if (rangesFile === null) {
+    return null;
+  }
+  const file = Bun.file(rangesFile);
+  if (!(await file.exists())) {
+    console.error(`--ranges-file not found: ${rangesFile}`);
+    process.exit(2);
+  }
+  const parsedRanges = parseColumnTrimRanges(await file.text());
+  if (parsedRanges.type === "invalid") {
+    console.error(parsedRanges.message);
+    process.exit(2);
+  }
+  return parsedRanges.ranges;
+})();
+
+const ranges = columnTrimRanges({ args: parsed.args, fileRanges });
 
 const gate = columnTrimGate({ mode: corpusStorageMode, force });
 if (gate.type === "refused") {
@@ -94,16 +151,11 @@ await refreshCorpusS3();
 const runLabel = [
   dryRun ? "dry run" : "live",
   limit === null ? "no limit" : `limit=${limit}`,
+  `ranges=${ranges.length}`,
 ].join(", ");
 
 console.log(`=== CORPUS COLUMN TRIM (${runLabel}) ===`);
 
-// Resuming from --after keeps a restart's first page from re-skipping the
-// whole trimmed prefix of the id space, a scan that stops fitting a
-// statement timeout once enough rows are trimmed. The cursor rides on every
-// progress line, so a supervisor can pass the last one back in.
-let lastId: SafeId<"caseLawDecision"> | null =
-  after === null ? null : brandPersistedCaseLawDecisionId(after);
 let trimmed = 0;
 let skipped = 0;
 let failed = 0;
@@ -295,39 +347,89 @@ const trimInChunks = async (rows: TrimRow[]): Promise<void> => {
   }
 };
 
-while (true) {
-  const remaining = limit === null ? BATCH_SIZE : limit - scanned;
-  if (remaining <= 0) {
-    break;
-  }
-
-  const idFilter: SQL | undefined =
-    lastId === null ? undefined : gt(caseLawDecisions.id, lastId);
-
-  // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination: the next page cursor (lastId) depends on this query
-  const rows: TrimRow[] = await ingestionDb((tx) =>
-    tx
-      .select({
-        ...TRIM_ROW_COLUMNS,
-        updatedAtToken: timestampCasToken(caseLawDecisions.updatedAt),
-      })
-      .from(caseLawDecisions)
-      .where(idFilter ? and(candidateFilter, idFilter) : candidateFilter)
-      .orderBy(asc(caseLawDecisions.id))
-      .limit(Math.min(BATCH_SIZE, remaining)),
+/**
+ * The id predicate for one page. The lower bound is inclusive only for a
+ * range's own start — an operator naming an id means to include it —
+ * and exclusive for every resumed cursor, whose row is already done.
+ */
+const rangeFilter = ({ lower, upper }: ColumnTrimRange): SQL | undefined => {
+  const lowerFilter = ((): SQL | undefined => {
+    switch (lower.type) {
+      case "unbounded":
+        return undefined;
+      case "at-or-after":
+        return gte(
+          caseLawDecisions.id,
+          brandPersistedCaseLawDecisionId(lower.id),
+        );
+      case "after":
+        return gt(
+          caseLawDecisions.id,
+          brandPersistedCaseLawDecisionId(lower.id),
+        );
+      default: {
+        const unhandled: never = lower;
+        return panic(`Unhandled column trim lower bound: ${String(unhandled)}`);
+      }
+    }
+  })();
+  return and(
+    lowerFilter,
+    upper === null
+      ? undefined
+      : lte(caseLawDecisions.id, brandPersistedCaseLawDecisionId(upper)),
   );
+};
 
-  if (rows.length === 0) {
-    break;
+const rangeLabel = ({ lower, upper }: ColumnTrimRange): string =>
+  `from=${lower.type === "unbounded" ? "start" : lower.id} to=${upper ?? "end"}`;
+
+for (const [index, range] of ranges.entries()) {
+  const position = `range=${index + 1}/${ranges.length}`;
+  const rangeStart = { trimmed, skipped, failed };
+  // The cursor rides on every progress line, so a supervisor that lost a
+  // run can resume this range from the last id it saw.
+  let lastId: SafeId<"caseLawDecision"> | null = null;
+
+  while (true) {
+    const remaining = limit === null ? BATCH_SIZE : limit - scanned;
+    if (remaining <= 0) {
+      break;
+    }
+
+    const idFilter = rangeFilter(
+      columnTrimPageRange({ range, cursor: lastId }),
+    );
+
+    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pagination: the next page cursor (lastId) depends on this query
+    const rows: TrimRow[] = await ingestionDb((tx) =>
+      tx
+        .select({
+          ...TRIM_ROW_COLUMNS,
+          updatedAtToken: timestampCasToken(caseLawDecisions.updatedAt),
+        })
+        .from(caseLawDecisions)
+        .where(idFilter ? and(candidateFilter, idFilter) : candidateFilter)
+        .orderBy(asc(caseLawDecisions.id))
+        .limit(Math.min(BATCH_SIZE, remaining)),
+    );
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    // oxlint-disable-next-line no-await-in-loop -- sequential keyset pages: the next page's cursor depends on this one completing
+    await trimInChunks(rows);
+
+    scanned += rows.length;
+    lastId = rows.at(-1)?.id ?? lastId;
+    console.log(
+      `  ${position} trimmed=${trimmed} skipped=${skipped} failed=${failed} cursor=${lastId}`,
+    );
   }
 
-  // oxlint-disable-next-line no-await-in-loop -- sequential keyset pages: the next page's cursor depends on this one completing
-  await trimInChunks(rows);
-
-  scanned += rows.length;
-  lastId = rows.at(-1)?.id ?? lastId;
   console.log(
-    `  trimmed=${trimmed} skipped=${skipped} failed=${failed} cursor=${lastId}`,
+    `  ${position} done ${rangeLabel(range)} trimmed=${trimmed - rangeStart.trimmed} skipped=${skipped - rangeStart.skipped} failed=${failed - rangeStart.failed}`,
   );
 }
 

--- a/apps/api/src/scripts/corpus-column-trim.ts
+++ b/apps/api/src/scripts/corpus-column-trim.ts
@@ -384,16 +384,31 @@ const rangeFilter = ({ lower, upper }: ColumnTrimRange): SQL | undefined => {
 const rangeLabel = ({ lower, upper }: ColumnTrimRange): string =>
   `from=${lower.type === "unbounded" ? "start" : lower.id} to=${upper ?? "end"}`;
 
+/**
+ * Why a range's walk stopped. A range that ran out of candidates is
+ * covered; one the scan cap cut short is not, and the two must not print
+ * the same word: an operator reading `done` takes the span as repaired and
+ * moves on, and the ranges behind it were never queried at all.
+ */
+const RANGE_OUTCOMES = ["exhausted", "capped"] as const;
+type RangeOutcome = (typeof RANGE_OUTCOMES)[number];
+
+/** Ranges the scan cap stopped the sweep before reaching. */
+let unwalkedRanges = 0;
+let sweepOutcome: RangeOutcome = "exhausted";
+
 for (const [index, range] of ranges.entries()) {
   const position = `range=${index + 1}/${ranges.length}`;
   const rangeStart = { trimmed, skipped, failed };
   // The cursor rides on every progress line, so a supervisor that lost a
   // run can resume this range from the last id it saw.
   let lastId: SafeId<"caseLawDecision"> | null = null;
+  let outcome: RangeOutcome = "exhausted";
 
   while (true) {
     const remaining = limit === null ? BATCH_SIZE : limit - scanned;
     if (remaining <= 0) {
+      outcome = "capped";
       break;
     }
 
@@ -429,8 +444,15 @@ for (const [index, range] of ranges.entries()) {
   }
 
   console.log(
-    `  ${position} done ${rangeLabel(range)} trimmed=${trimmed - rangeStart.trimmed} skipped=${skipped - rangeStart.skipped} failed=${failed - rangeStart.failed}`,
+    `  ${position} ${outcome === "exhausted" ? "done" : "capped"} ${rangeLabel(range)} trimmed=${trimmed - rangeStart.trimmed} skipped=${skipped - rangeStart.skipped} failed=${failed - rangeStart.failed} cursor=${lastId ?? "none"}`,
   );
+
+  if (outcome === "capped") {
+    // Walking on would print `done` against ranges this run never queried.
+    sweepOutcome = "capped";
+    unwalkedRanges = ranges.length - index - 1;
+    break;
+  }
 }
 
 // A failed row sits behind the published cursor, so a supervisor resuming
@@ -458,8 +480,13 @@ if (failedIds.length > 0) {
   }
 }
 
+// The scan cap is an operator's choice, not a failure, but the summary has
+// to say the sweep is partial: "Done" against an unfinished range list is
+// the one line most likely to be read on its own.
 console.log(
-  `Done. Trimmed ${trimmed} decisions, skipped ${skipped}, ${failed} failed.`,
+  sweepOutcome === "exhausted"
+    ? `Done. Trimmed ${trimmed} decisions, skipped ${skipped}, ${failed} failed.`
+    : `Stopped at --limit. Trimmed ${trimmed} decisions, skipped ${skipped}, ${failed} failed; ${unwalkedRanges} range(s) not walked. Re-run to continue.`,
 );
 
 // Non-zero on partial failure so a caller can tell an incomplete pass from


### PR DESCRIPTION
Canonical mode's write paths must converge to the canonical representation instead of relying on an external pass.

**Commit 1.** The ingestion pipeline already settles a canonical corpus write by nulling the legacy payload columns; two paths did not follow: the exported settle wrapper hard-coded the dual-write disposition regardless of the deployed mode, and the document drain persisted `fulltext`/`sections`/`document_ast` unconditionally in every mode. Both now derive one shared `corpusPayloadDisposition(mode, written)` — an exhaustive switch whose `written: null` arm always retains, so a failed or absent corpus write structurally keeps the columns and the existing retry path. The trimmed column shape itself becomes one shared constant (`TRIMMED_CORPUS_PAYLOAD_COLUMNS`) replacing three hand-kept copies. The nulls ride the settle statements' existing fences (id + source hash + observation order + mirror status), so a concurrent re-observation wins exactly as before; no new guard was added because a second one could only be redundant with or contradict the fence already there. `off` and `dual-write` are byte-identical.

**Commit 2.** The trim's candidate predicate is not indexable, so an unbounded keyset walk over an already-trimmed stretch of the id space outgrows the statement timeout — and a keyspace whose candidates share no ordering with time is covered by a list of spans rather than one cursor. The operator script gains `--id-from`/`--id-to` and `--ranges-file` (sorted, disjoint, validated before any connection; a range's own start is inclusive while a resumed cursor stays exclusive, modeled as a discriminated lower bound rather than a flag). Pagination carries the upper bound so a page can never scan past its range; progress and resume output keep their existing shape.

Tests: the disposition matrix asserts declared-set-equals-exercised-set over every storage mode; four drain settlement cases run against real Postgres (confirmed write trims, absent writer retains, throwing writer leaves the row untouched with the mirror pending, dual-write retains); 12 new pure cases cover range parsing, conflicts, iteration, and page composition; every bound shape was executed against a live database. No ratchet or typecheck-baseline movement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safer corpus storage handling across canonical, dual-write and disabled modes.
  - Added bounded and resumable column-trimming, supporting ID ranges and JSON range files.
  - Added validation and progress reporting for multi-range trimming operations.

- **Bug Fixes**
  - Prevented payload data from being cleared unless a canonical write is confirmed.
  - Preserved pending empty-row state when corpus writing fails.

- **Tests**
  - Expanded coverage for storage modes, write failures, range parsing and pagination boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->