### PR TITLE
fix(api): count reconciliation backlog as work when deciding to idle-exit

### DIFF
--- a/apps/api/src/lib/document-processing-idle-exit.test.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.test.ts
@@ -79,17 +79,23 @@ describe("createIdleExitCheck", () => {
         }),
     );
 
+    // A sample settles the reconciliation verdict before it counts, so let
+    // it reach the count before handing one over.
+    const countStarted = async () => await Bun.sleep(0);
+
     const first = h.tick();
     // The first sample is still in flight: further ticks must not start
     // a second count or advance the streak.
     expect(await h.tick()).toBe("skipped");
     expect(await h.tick()).toBe("skipped");
+    await countStarted();
     expect(resolvers).toHaveLength(1);
 
     resolvers.shift()?.(0);
     expect(await first).toBe("checked");
 
     const second = h.tick();
+    await countStarted();
     resolvers.shift()?.(0);
     expect(await second).toBe("exit");
   });
@@ -114,25 +120,28 @@ describe("createIdleExitCheck", () => {
     expect(await h.tick()).toBe("exit");
   });
 
-  test("a reconciliation that starts during the count is caught by that sample", async () => {
+  test("a reconciliation that starts after the verdict is caught by the next sample", async () => {
     let unfinished = false;
     let exits = 0;
     const tick = createIdleExitCheck({
       countPending: async () => {
-        // Reconciliation ticks are timer-driven, so one can begin while a
-        // sample's count is in flight; the sample must not certify the
-        // moment before it.
+        // Reconciliation ticks are timer-driven, so one can begin after
+        // this sample read its verdict. It marks itself unfinished before
+        // its own first await, which is what the next sample reads.
         unfinished = true;
         return 0;
       },
       hasUnfinishedReconciliation: async () => unfinished,
-      requiredIdleChecks: 1,
+      requiredIdleChecks: 2,
       onIdleExit: () => {
         exits += 1;
       },
       onCheckFailure: () => undefined,
     });
 
+    expect(await tick()).toBe("checked");
+    // The streak cannot span the tick that started inside the sample
+    // before it.
     expect(await tick()).toBe("checked");
     expect(exits).toBe(0);
   });

--- a/apps/api/src/lib/document-processing-idle-exit.test.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.test.ts
@@ -114,6 +114,29 @@ describe("createIdleExitCheck", () => {
     expect(await h.tick()).toBe("exit");
   });
 
+  test("a reconciliation that starts during the count is caught by that sample", async () => {
+    let unfinished = false;
+    let exits = 0;
+    const tick = createIdleExitCheck({
+      countPending: async () => {
+        // Reconciliation ticks are timer-driven, so one can begin while a
+        // sample's count is in flight; the sample must not certify the
+        // moment before it.
+        unfinished = true;
+        return 0;
+      },
+      hasUnfinishedReconciliation: () => unfinished,
+      requiredIdleChecks: 1,
+      onIdleExit: () => {
+        exits += 1;
+      },
+      onCheckFailure: () => undefined,
+    });
+
+    expect(await tick()).toBe("checked");
+    expect(exits).toBe(0);
+  });
+
   test("exit fires exactly once; later ticks are inert", async () => {
     const h = harness(1, sequence([0, 0, 0]));
     expect(await h.tick()).toBe("exit");

--- a/apps/api/src/lib/document-processing-idle-exit.test.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.test.ts
@@ -21,6 +21,7 @@ const harness = (
     countPending: counts,
     hasUnfinishedReconciliation,
     isReconciliationInFlight: () => false,
+    reconciliationGeneration: () => 0,
     requiredIdleChecks,
     onIdleExit: () => {
       exits += 1;
@@ -134,6 +135,7 @@ describe("createIdleExitCheck", () => {
       },
       hasUnfinishedReconciliation: async () => unfinished,
       isReconciliationInFlight: () => false,
+      reconciliationGeneration: () => 0,
       requiredIdleChecks: 2,
       onIdleExit: () => {
         exits += 1;
@@ -162,6 +164,34 @@ describe("createIdleExitCheck", () => {
         }),
       hasUnfinishedReconciliation: async () => false,
       isReconciliationInFlight: () => running,
+      reconciliationGeneration: () => 0,
+      requiredIdleChecks: 1,
+      onIdleExit: () => {
+        exits += 1;
+      },
+      onCheckFailure: () => undefined,
+    });
+
+    expect(await tick()).toBe("checked");
+    expect(exits).toBe(0);
+  });
+
+  test("a reconciliation that starts and finishes inside the count blocks the final sample", async () => {
+    let generation = 0;
+    let exits = 0;
+    const tick = createIdleExitCheck({
+      // A whole tick fits inside the count: by the time the sample
+      // resumes, nothing is running and the verdict it already took
+      // belongs to the tick before this one, so only the generation
+      // records that it happened.
+      countPending: async () =>
+        await Promise.resolve(0).then((pending) => {
+          generation += 1;
+          return pending;
+        }),
+      hasUnfinishedReconciliation: async () => false,
+      isReconciliationInFlight: () => false,
+      reconciliationGeneration: () => generation,
       requiredIdleChecks: 1,
       onIdleExit: () => {
         exits += 1;

--- a/apps/api/src/lib/document-processing-idle-exit.test.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  createIdleExitCheck,
-  startIdleExitSampling,
-} from "@/api/lib/document-processing-idle-exit";
+import { createIdleExitCheck } from "@/api/lib/document-processing-idle-exit";
 
 /**
  * The class these pin: an idle-exit decision driven by asynchronous
@@ -16,7 +13,7 @@ import {
 const harness = (
   requiredIdleChecks: number,
   counts: () => Promise<number>,
-  hasUnfinishedReconciliation: () => boolean = () => false,
+  hasUnfinishedReconciliation: () => Promise<boolean> = async () => false,
 ) => {
   let exits = 0;
   let failures = 0;
@@ -98,7 +95,7 @@ describe("createIdleExitCheck", () => {
   });
 
   test("an empty queue is not idle while reconciliation has work behind it", async () => {
-    const h = harness(2, sequence([0, 0, 0, 0]), () => true);
+    const h = harness(2, sequence([0, 0, 0, 0]), async () => true);
     expect(await h.tick()).toBe("checked");
     expect(await h.tick()).toBe("checked");
     expect(await h.tick()).toBe("checked");
@@ -107,7 +104,7 @@ describe("createIdleExitCheck", () => {
 
   test("reconciliation draining mid-streak resets it", async () => {
     let unfinished = false;
-    const h = harness(2, sequence([0, 0, 0, 0]), () => unfinished);
+    const h = harness(2, sequence([0, 0, 0, 0]), async () => unfinished);
     await h.tick();
     unfinished = true;
     // The streak must restart from this sample, not resume where it left off.
@@ -128,7 +125,7 @@ describe("createIdleExitCheck", () => {
         unfinished = true;
         return 0;
       },
-      hasUnfinishedReconciliation: () => unfinished,
+      hasUnfinishedReconciliation: async () => unfinished,
       requiredIdleChecks: 1,
       onIdleExit: () => {
         exits += 1;
@@ -146,72 +143,5 @@ describe("createIdleExitCheck", () => {
     expect(await h.tick()).toBe("skipped");
     expect(await h.tick()).toBe("skipped");
     expect(h.exits()).toBe(1);
-  });
-});
-
-/**
- * The class these pin: sampling starts after an offset, so there is a
- * window in which the worker can shut down before any interval exists. A
- * timer created after that point outlives the shutdown it should have been
- * cancelled by.
- */
-describe("startIdleExitSampling", () => {
-  const OFFSET_MS = 10;
-  const INTERVAL_MS = 5;
-  // Past the offset and several intervals, so a timer that was created
-  // anyway has had every chance to fire.
-  const PAST_OFFSET_MS = 60;
-
-  const samplingHarness = () => {
-    let samples = 0;
-    let shuttingDown = false;
-    const sampling = startIdleExitSampling({
-      intervalMs: INTERVAL_MS,
-      isShuttingDown: () => shuttingDown,
-      offsetMs: OFFSET_MS,
-      onSample: () => {
-        samples += 1;
-      },
-    });
-    return {
-      beginShutdown: () => {
-        shuttingDown = true;
-      },
-      samples: () => samples,
-      stop: sampling.stop,
-    };
-  };
-
-  test("samples on the interval once the offset expires", async () => {
-    const h = samplingHarness();
-
-    await Bun.sleep(PAST_OFFSET_MS);
-    h.stop();
-    const sampled = h.samples();
-
-    expect(sampled).toBeGreaterThan(0);
-    // Stopping ends sampling for good.
-    await Bun.sleep(PAST_OFFSET_MS);
-    expect(h.samples()).toBe(sampled);
-  });
-
-  test("stopping inside the offset window never starts sampling", async () => {
-    const h = samplingHarness();
-
-    h.stop();
-    await Bun.sleep(PAST_OFFSET_MS);
-
-    expect(h.samples()).toBe(0);
-  });
-
-  test("a shutdown inside the offset window never starts sampling", async () => {
-    const h = samplingHarness();
-
-    // Shutdown began but the deferred start was not cancelled: it must
-    // still refuse to create the interval.
-    h.beginShutdown();
-    await Bun.sleep(PAST_OFFSET_MS);
-
-    expect(h.samples()).toBe(0);
   });
 });

--- a/apps/api/src/lib/document-processing-idle-exit.test.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { createIdleExitCheck } from "@/api/lib/document-processing-idle-exit";
+import {
+  createIdleExitCheck,
+  startIdleExitSampling,
+} from "@/api/lib/document-processing-idle-exit";
 
 /**
  * The class these pin: an idle-exit decision driven by asynchronous
@@ -143,5 +146,72 @@ describe("createIdleExitCheck", () => {
     expect(await h.tick()).toBe("skipped");
     expect(await h.tick()).toBe("skipped");
     expect(h.exits()).toBe(1);
+  });
+});
+
+/**
+ * The class these pin: sampling starts after an offset, so there is a
+ * window in which the worker can shut down before any interval exists. A
+ * timer created after that point outlives the shutdown it should have been
+ * cancelled by.
+ */
+describe("startIdleExitSampling", () => {
+  const OFFSET_MS = 10;
+  const INTERVAL_MS = 5;
+  // Past the offset and several intervals, so a timer that was created
+  // anyway has had every chance to fire.
+  const PAST_OFFSET_MS = 60;
+
+  const samplingHarness = () => {
+    let samples = 0;
+    let shuttingDown = false;
+    const sampling = startIdleExitSampling({
+      intervalMs: INTERVAL_MS,
+      isShuttingDown: () => shuttingDown,
+      offsetMs: OFFSET_MS,
+      onSample: () => {
+        samples += 1;
+      },
+    });
+    return {
+      beginShutdown: () => {
+        shuttingDown = true;
+      },
+      samples: () => samples,
+      stop: sampling.stop,
+    };
+  };
+
+  test("samples on the interval once the offset expires", async () => {
+    const h = samplingHarness();
+
+    await Bun.sleep(PAST_OFFSET_MS);
+    h.stop();
+    const sampled = h.samples();
+
+    expect(sampled).toBeGreaterThan(0);
+    // Stopping ends sampling for good.
+    await Bun.sleep(PAST_OFFSET_MS);
+    expect(h.samples()).toBe(sampled);
+  });
+
+  test("stopping inside the offset window never starts sampling", async () => {
+    const h = samplingHarness();
+
+    h.stop();
+    await Bun.sleep(PAST_OFFSET_MS);
+
+    expect(h.samples()).toBe(0);
+  });
+
+  test("a shutdown inside the offset window never starts sampling", async () => {
+    const h = samplingHarness();
+
+    // Shutdown began but the deferred start was not cancelled: it must
+    // still refuse to create the interval.
+    h.beginShutdown();
+    await Bun.sleep(PAST_OFFSET_MS);
+
+    expect(h.samples()).toBe(0);
   });
 });

--- a/apps/api/src/lib/document-processing-idle-exit.test.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.test.ts
@@ -10,11 +10,16 @@ import { createIdleExitCheck } from "@/api/lib/document-processing-idle-exit";
  * directly.
  */
 
-const harness = (requiredIdleChecks: number, counts: () => Promise<number>) => {
+const harness = (
+  requiredIdleChecks: number,
+  counts: () => Promise<number>,
+  hasUnfinishedReconciliation: () => boolean = () => false,
+) => {
   let exits = 0;
   let failures = 0;
   const tick = createIdleExitCheck({
     countPending: counts,
+    hasUnfinishedReconciliation,
     requiredIdleChecks,
     onIdleExit: () => {
       exits += 1;
@@ -87,6 +92,26 @@ describe("createIdleExitCheck", () => {
     const second = h.tick();
     resolvers.shift()?.(0);
     expect(await second).toBe("exit");
+  });
+
+  test("an empty queue is not idle while reconciliation has work behind it", async () => {
+    const h = harness(2, sequence([0, 0, 0, 0]), () => true);
+    expect(await h.tick()).toBe("checked");
+    expect(await h.tick()).toBe("checked");
+    expect(await h.tick()).toBe("checked");
+    expect(h.exits()).toBe(0);
+  });
+
+  test("reconciliation draining mid-streak resets it", async () => {
+    let unfinished = false;
+    const h = harness(2, sequence([0, 0, 0, 0]), () => unfinished);
+    await h.tick();
+    unfinished = true;
+    // The streak must restart from this sample, not resume where it left off.
+    expect(await h.tick()).toBe("checked");
+    unfinished = false;
+    expect(await h.tick()).toBe("checked");
+    expect(await h.tick()).toBe("exit");
   });
 
   test("exit fires exactly once; later ticks are inert", async () => {

--- a/apps/api/src/lib/document-processing-idle-exit.test.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.test.ts
@@ -150,57 +150,98 @@ describe("createIdleExitCheck", () => {
     expect(exits).toBe(0);
   });
 
-  test("a reconciliation that starts as the count resolves blocks the final sample", async () => {
-    let running = false;
+  /**
+   * A reconciliation tick that crosses a sample's count leaves the
+   * sample's readings describing different moments. The sample measures
+   * again rather than calling the moment busy, so what decides it is the
+   * crossing tick's own verdict.
+   */
+  const crossedHarness = ({
+    crossEveryCount,
+    leftWorkBehind,
+    requiredIdleChecks,
+  }: {
+    crossEveryCount: boolean;
+    leftWorkBehind: boolean;
+    requiredIdleChecks: number;
+  }) => {
+    let counts = 0;
     let exits = 0;
+    let generation = 0;
+    let running = false;
+    let unfinished = false;
     const tick = createIdleExitCheck({
-      // The reconcile timer fires in the gap between the count resolving
-      // and the sampler resuming, which no later sample would cover: this
-      // is the last check the streak needs.
       countPending: async () =>
         await Promise.resolve(0).then((pending) => {
-          running = true;
+          counts += 1;
+          // The reconcile timer fires while the count is in flight. With
+          // `crossEveryCount` it fires during every one, which is what a
+          // sampler phase-locked inside reconciliation would see.
+          if (crossEveryCount || counts % 2 === 1) {
+            generation += 1;
+            running = true;
+          }
           return pending;
         }),
-      hasUnfinishedReconciliation: async () => false,
+      hasUnfinishedReconciliation: async () => {
+        // Waiting for a tick in flight is what completes it, and its
+        // verdict is what this sample gets.
+        if (running) {
+          running = false;
+          unfinished = leftWorkBehind;
+        }
+        return unfinished;
+      },
       isReconciliationInFlight: () => running,
-      reconciliationGeneration: () => 0,
-      requiredIdleChecks: 1,
+      reconciliationGeneration: () => generation,
+      requiredIdleChecks,
       onIdleExit: () => {
         exits += 1;
       },
       onCheckFailure: () => undefined,
     });
+    return { counts: () => counts, exits: () => exits, tick };
+  };
 
-    expect(await tick()).toBe("checked");
-    expect(exits).toBe(0);
+  test("a sample crossed by a saturated tick reads that tick's verdict", async () => {
+    const h = crossedHarness({
+      crossEveryCount: false,
+      leftWorkBehind: true,
+      requiredIdleChecks: 1,
+    });
+
+    expect(await h.tick()).toBe("checked");
+    expect(h.exits()).toBe(0);
   });
 
-  test("a reconciliation that starts and finishes inside the count blocks the final sample", async () => {
-    let generation = 0;
-    let exits = 0;
-    const tick = createIdleExitCheck({
-      // A whole tick fits inside the count: by the time the sample
-      // resumes, nothing is running and the verdict it already took
-      // belongs to the tick before this one, so only the generation
-      // records that it happened.
-      countPending: async () =>
-        await Promise.resolve(0).then((pending) => {
-          generation += 1;
-          return pending;
-        }),
-      hasUnfinishedReconciliation: async () => false,
-      isReconciliationInFlight: () => false,
-      reconciliationGeneration: () => generation,
-      requiredIdleChecks: 1,
-      onIdleExit: () => {
-        exits += 1;
-      },
-      onCheckFailure: () => undefined,
+  test("samples crossed by drained ticks still complete the streak", async () => {
+    // The livelock shape: every sample's count is crossed by a tick that
+    // reports drained. Reading the crossing as busy would reset the streak
+    // forever on a system with nothing left to do.
+    const h = crossedHarness({
+      crossEveryCount: false,
+      leftWorkBehind: false,
+      requiredIdleChecks: 2,
     });
 
-    expect(await tick()).toBe("checked");
-    expect(exits).toBe(0);
+    expect(await h.tick()).toBe("checked");
+    expect(await h.tick()).toBe("exit");
+    expect(h.exits()).toBe(1);
+  });
+
+  test("a producer that crosses every count is conceded, not chased forever", async () => {
+    const h = crossedHarness({
+      crossEveryCount: true,
+      leftWorkBehind: false,
+      requiredIdleChecks: 1,
+    });
+
+    expect(await h.tick()).toBe("checked");
+    expect(h.exits()).toBe(0);
+    // It measured again rather than deciding on the first reading, and
+    // stopped rather than spinning.
+    expect(h.counts()).toBeGreaterThan(1);
+    expect(h.counts()).toBeLessThan(8);
   });
 
   test("a final sample with nothing running still exits", async () => {

--- a/apps/api/src/lib/document-processing-idle-exit.test.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.test.ts
@@ -20,6 +20,7 @@ const harness = (
   const tick = createIdleExitCheck({
     countPending: counts,
     hasUnfinishedReconciliation,
+    isReconciliationInFlight: () => false,
     requiredIdleChecks,
     onIdleExit: () => {
       exits += 1;
@@ -132,6 +133,7 @@ describe("createIdleExitCheck", () => {
         return 0;
       },
       hasUnfinishedReconciliation: async () => unfinished,
+      isReconciliationInFlight: () => false,
       requiredIdleChecks: 2,
       onIdleExit: () => {
         exits += 1;
@@ -144,6 +146,38 @@ describe("createIdleExitCheck", () => {
     // before it.
     expect(await tick()).toBe("checked");
     expect(exits).toBe(0);
+  });
+
+  test("a reconciliation that starts as the count resolves blocks the final sample", async () => {
+    let running = false;
+    let exits = 0;
+    const tick = createIdleExitCheck({
+      // The reconcile timer fires in the gap between the count resolving
+      // and the sampler resuming, which no later sample would cover: this
+      // is the last check the streak needs.
+      countPending: async () =>
+        await Promise.resolve(0).then((pending) => {
+          running = true;
+          return pending;
+        }),
+      hasUnfinishedReconciliation: async () => false,
+      isReconciliationInFlight: () => running,
+      requiredIdleChecks: 1,
+      onIdleExit: () => {
+        exits += 1;
+      },
+      onCheckFailure: () => undefined,
+    });
+
+    expect(await tick()).toBe("checked");
+    expect(exits).toBe(0);
+  });
+
+  test("a final sample with nothing running still exits", async () => {
+    const h = harness(1, sequence([0]));
+
+    expect(await h.tick()).toBe("exit");
+    expect(h.exits()).toBe(1);
   });
 
   test("exit fires exactly once; later ticks are inert", async () => {

--- a/apps/api/src/lib/document-processing-idle-exit.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.ts
@@ -14,13 +14,14 @@
 type CreateIdleExitCheckOptions = {
   countPending: () => Promise<number>;
   /**
-   * Whether reconciliation is running or last stopped with work behind it.
-   * Read synchronously, so the reconciliation side must publish "running"
-   * before its first await; anything weaker would let a tick that outlives
-   * an idle window keep exposing the previous tick's drained answer.
-   * Required rather than optional so a new call site must decide.
+   * Whether reconciliation left work behind, answered no earlier than the
+   * tick that is running: the sample waits for a tick in flight instead of
+   * racing it, so the answer never depends on how the sampling cadence
+   * lines up with the reconciliation cadence, and never comes from the
+   * tick before. Required rather than optional so a new call site must
+   * decide.
    */
-  hasUnfinishedReconciliation: () => boolean;
+  hasUnfinishedReconciliation: () => Promise<boolean>;
   /** Consecutive empty samples required before exiting. */
   requiredIdleChecks: number;
   onIdleExit: () => void;
@@ -28,45 +29,6 @@ type CreateIdleExitCheckOptions = {
 };
 
 export type IdleExitTickOutcome = "checked" | "exit" | "skipped";
-
-type StartIdleExitSamplingOptions = {
-  intervalMs: number;
-  isShuttingDown: () => boolean;
-  /** Delay before the first sample, so sampling does not phase-lock. */
-  offsetMs: number;
-  onSample: () => void;
-};
-
-/**
- * Sampling on an interval that only begins after an offset, with one stop
- * handle covering both stages. The offset is a window in which the worker
- * can already be shutting down, so the deferred start is both cancellable
- * and guarded: `stop` clears whichever timer exists, and a start that was
- * not cancelled still refuses to create the interval once shutdown began.
- */
-export const startIdleExitSampling = ({
-  intervalMs,
-  isShuttingDown,
-  offsetMs,
-  onSample,
-}: StartIdleExitSamplingOptions): { stop: () => void } => {
-  let interval: ReturnType<typeof setInterval> | null = null;
-  const start = setTimeout(() => {
-    if (isShuttingDown()) {
-      return;
-    }
-    interval = setInterval(onSample, intervalMs);
-  }, offsetMs);
-  return {
-    stop: () => {
-      clearTimeout(start);
-      if (interval !== null) {
-        clearInterval(interval);
-        interval = null;
-      }
-    },
-  };
-};
 
 export const createIdleExitCheck = ({
   countPending,
@@ -89,10 +51,11 @@ export const createIdleExitCheck = ({
     inFlight = true;
     try {
       const pending = await countPending();
-      // Read reconciliation after the count settles: a reconciliation tick
-      // that starts while the count is in flight still lands in this
-      // sample, so a slow count cannot certify a moment it did not see.
-      const idle = pending === 0 && !hasUnfinishedReconciliation();
+      // Read reconciliation after the count settles, and wait for a tick in
+      // flight: a tick that starts while the count runs still lands in this
+      // sample, and one that outlives the count is answered by its own
+      // verdict rather than by whichever finished first.
+      const idle = pending === 0 && !(await hasUnfinishedReconciliation());
       consecutiveIdleChecks = idle ? consecutiveIdleChecks + 1 : 0;
     } catch (error) {
       onCheckFailure(error);

--- a/apps/api/src/lib/document-processing-idle-exit.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.ts
@@ -29,6 +29,13 @@ type CreateIdleExitCheckOptions = {
    * before its own first await.
    */
   isReconciliationInFlight: () => boolean;
+  /**
+   * How many reconciliation ticks have started, read synchronously and
+   * incremented in the same prologue as the flag above. Snapshotting it
+   * around the count is what catches a tick that both started and finished
+   * inside that window, which leaves no other trace.
+   */
+  reconciliationGeneration: () => number;
   /** Consecutive empty samples required before exiting. */
   requiredIdleChecks: number;
   onIdleExit: () => void;
@@ -43,6 +50,7 @@ export const createIdleExitCheck = ({
   isReconciliationInFlight,
   onCheckFailure,
   onIdleExit,
+  reconciliationGeneration,
   requiredIdleChecks,
 }: CreateIdleExitCheckOptions): (() => Promise<IdleExitTickOutcome>) => {
   let consecutiveIdleChecks = 0;
@@ -65,17 +73,28 @@ export const createIdleExitCheck = ({
       // count with the same tick's drained verdict and read idle while
       // fresh jobs wait, which a worker close does not drain.
       const unfinished = await hasUnfinishedReconciliation();
+      const generation = reconciliationGeneration();
       const pending = await countPending();
-      // The mirror of that window: a tick can start after the verdict and
-      // while the count is in flight, and on the last sample of a streak
-      // there is no later sample to catch it. So re-read the running flag
-      // here and decide in this frame. Reconciliation sets that flag in
-      // its tick's synchronous prologue, before its own first await, and
-      // nothing else runs between this read and the exit call below: no
-      // await separates them, and neither timers nor microtasks interleave
-      // inside one frame. Every tick that began before the decision is
-      // therefore visible to it, and none can begin during it.
-      const idle = pending === 0 && !unfinished && !isReconciliationInFlight();
+      // The count is the one window a sample cannot watch, so the decision
+      // is taken in the frame the count resumes it in: no await separates
+      // the reads below from the exit call, and neither timers nor
+      // microtasks interleave inside a frame, so no tick can begin during
+      // the decision itself. That leaves the ticks that began before it,
+      // and the four terms are what make those total. `pending` and
+      // `unfinished` answer for the tick this sample waited on and the
+      // work it left. `isReconciliationInFlight` catches a tick that
+      // started inside the count and is still running, which the verdict
+      // above predates. The generation catches the one that started and
+      // finished inside the count, leaving neither a running flag nor a
+      // verdict this sample ever read, having possibly enqueued after the
+      // count snapshot; a moved generation is not proof of work, so this
+      // sample is conservative and the next one reads that tick's own
+      // verdict. Every term covers a case the others provably do not.
+      const idle =
+        pending === 0 &&
+        !unfinished &&
+        !isReconciliationInFlight() &&
+        reconciliationGeneration() === generation;
       consecutiveIdleChecks = idle ? consecutiveIdleChecks + 1 : 0;
     } catch (error) {
       onCheckFailure(error);

--- a/apps/api/src/lib/document-processing-idle-exit.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.ts
@@ -44,6 +44,14 @@ type CreateIdleExitCheckOptions = {
 
 export type IdleExitTickOutcome = "checked" | "exit" | "skipped";
 
+/**
+ * How many times one sample may re-measure after a reconciliation tick
+ * crossed its readings. Reconciliation runs on a far slower cadence than a
+ * count takes, so a drained system settles on the first re-measure; the
+ * bound only exists so a pathological producer cannot spin a sample.
+ */
+const SAMPLE_CHASE_LIMIT = 3;
+
 export const createIdleExitCheck = ({
   countPending,
   hasUnfinishedReconciliation,
@@ -57,6 +65,59 @@ export const createIdleExitCheck = ({
   let inFlight = false;
   let exited = false;
 
+  /**
+   * One measurement of every source of work, re-measured while a
+   * reconciliation tick keeps crossing it.
+   *
+   * Reconciliation first, then the count: reconciliation produces queue
+   * entries and never consumes them, so waiting for the tick in flight to
+   * report before counting means everything it enqueued is already in the
+   * count. Counting first would pair a pre-enqueue count with the same
+   * tick's drained verdict and read idle while fresh jobs wait, which a
+   * worker close does not drain.
+   *
+   * The count is the one window a measurement cannot watch, so the verdict
+   * is taken in the frame the count resumes it in: no await separates the
+   * reads below from each other, and neither timers nor microtasks
+   * interleave inside a frame, so no tick can begin during the decision
+   * itself. That leaves ticks that began before it, and the reads are
+   * total over them. `pending` and `unfinished` answer for the tick this
+   * measurement waited on and the work it left. `isReconciliationInFlight`
+   * catches a tick that started inside the count and is still running,
+   * which the verdict above predates. The generation catches the one that
+   * started and finished inside the count, leaving neither a running flag
+   * nor a verdict this measurement ever read, and possibly enqueueing
+   * after the count was taken.
+   *
+   * Neither of those last two means work exists; they mean this
+   * measurement is not finished yet, so it measures again rather than
+   * declaring the sample busy. Declaring it busy instead would livelock
+   * exactly when the cadences line up: a tick that ends inside every
+   * count would reset the streak forever on a system that is drained.
+   * Re-measuring resolves it, because the next pass awaits that tick's own
+   * verdict.
+   */
+  const measureIdle = async (chasesLeft: number): Promise<boolean> => {
+    const unfinished = await hasUnfinishedReconciliation();
+    const generation = reconciliationGeneration();
+    const pending = await countPending();
+    if (unfinished || pending > 0) {
+      return false;
+    }
+    if (
+      !isReconciliationInFlight() &&
+      reconciliationGeneration() === generation
+    ) {
+      return true;
+    }
+    if (chasesLeft === 0) {
+      // A producer that keeps starting ticks is not something to certify
+      // as idle, however drained each one claims to be.
+      return false;
+    }
+    return await measureIdle(chasesLeft - 1);
+  };
+
   return async () => {
     // A slow count must not overlap the next tick: reordered completions
     // could stitch two stale empty samples across a busy interval and
@@ -66,35 +127,11 @@ export const createIdleExitCheck = ({
     }
     inFlight = true;
     try {
-      // Reconciliation first, then the count. Reconciliation produces
-      // queue entries and never consumes them, so waiting for the tick in
-      // flight to report before counting means everything it enqueued is
-      // already in the count. Counting first would pair a pre-enqueue
-      // count with the same tick's drained verdict and read idle while
-      // fresh jobs wait, which a worker close does not drain.
-      const unfinished = await hasUnfinishedReconciliation();
-      const generation = reconciliationGeneration();
-      const pending = await countPending();
-      // The count is the one window a sample cannot watch, so the decision
-      // is taken in the frame the count resumes it in: no await separates
-      // the reads below from the exit call, and neither timers nor
-      // microtasks interleave inside a frame, so no tick can begin during
-      // the decision itself. That leaves the ticks that began before it,
-      // and the four terms are what make those total. `pending` and
-      // `unfinished` answer for the tick this sample waited on and the
-      // work it left. `isReconciliationInFlight` catches a tick that
-      // started inside the count and is still running, which the verdict
-      // above predates. The generation catches the one that started and
-      // finished inside the count, leaving neither a running flag nor a
-      // verdict this sample ever read, having possibly enqueued after the
-      // count snapshot; a moved generation is not proof of work, so this
-      // sample is conservative and the next one reads that tick's own
-      // verdict. Every term covers a case the others provably do not.
-      const idle =
-        pending === 0 &&
-        !unfinished &&
-        !isReconciliationInFlight() &&
-        reconciliationGeneration() === generation;
+      const idle = await measureIdle(SAMPLE_CHASE_LIMIT);
+      // The verdict was taken in the frame its own reads shared. Only
+      // microtask resumptions separate it from this update and the exit
+      // below, and a timer cannot interleave those, so the timer-driven
+      // reconciliation loop cannot slip a tick in between.
       consecutiveIdleChecks = idle ? consecutiveIdleChecks + 1 : 0;
     } catch (error) {
       onCheckFailure(error);

--- a/apps/api/src/lib/document-processing-idle-exit.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.ts
@@ -4,10 +4,20 @@
  * tick by tick: only completed, non-overlapping samples advance the
  * streak, a failed count resets it (never exit on uncertainty), and the
  * exit callback fires exactly once.
+ *
+ * Idle means every source of work is empty, not just the job queue. The
+ * reconciliation loop drains its own backlogs one capped batch per tick
+ * without enqueueing jobs, so a worker that watched only queue depth
+ * would exit mid-drain and strand the remainder until the next start.
  */
 
 type CreateIdleExitCheckOptions = {
   countPending: () => Promise<number>;
+  /**
+   * Whether reconciliation still had work behind it on its last tick.
+   * Required rather than optional so a new call site must decide.
+   */
+  hasUnfinishedReconciliation: () => boolean;
   /** Consecutive empty samples required before exiting. */
   requiredIdleChecks: number;
   onIdleExit: () => void;
@@ -18,6 +28,7 @@ export type IdleExitTickOutcome = "checked" | "exit" | "skipped";
 
 export const createIdleExitCheck = ({
   countPending,
+  hasUnfinishedReconciliation,
   onCheckFailure,
   onIdleExit,
   requiredIdleChecks,
@@ -36,7 +47,10 @@ export const createIdleExitCheck = ({
     inFlight = true;
     try {
       const pending = await countPending();
-      consecutiveIdleChecks = pending === 0 ? consecutiveIdleChecks + 1 : 0;
+      // Read reconciliation after the count settles so both halves of the
+      // sample describe the same moment.
+      const idle = pending === 0 && !hasUnfinishedReconciliation();
+      consecutiveIdleChecks = idle ? consecutiveIdleChecks + 1 : 0;
     } catch (error) {
       onCheckFailure(error);
       consecutiveIdleChecks = 0;

--- a/apps/api/src/lib/document-processing-idle-exit.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.ts
@@ -14,7 +14,10 @@
 type CreateIdleExitCheckOptions = {
   countPending: () => Promise<number>;
   /**
-   * Whether reconciliation still had work behind it on its last tick.
+   * Whether reconciliation is running or last stopped with work behind it.
+   * Read synchronously, so the reconciliation side must publish "running"
+   * before its first await; anything weaker would let a tick that outlives
+   * an idle window keep exposing the previous tick's drained answer.
    * Required rather than optional so a new call site must decide.
    */
   hasUnfinishedReconciliation: () => boolean;
@@ -47,8 +50,9 @@ export const createIdleExitCheck = ({
     inFlight = true;
     try {
       const pending = await countPending();
-      // Read reconciliation after the count settles so both halves of the
-      // sample describe the same moment.
+      // Read reconciliation after the count settles: a reconciliation tick
+      // that starts while the count is in flight still lands in this
+      // sample, so a slow count cannot certify a moment it did not see.
       const idle = pending === 0 && !hasUnfinishedReconciliation();
       consecutiveIdleChecks = idle ? consecutiveIdleChecks + 1 : 0;
     } catch (error) {

--- a/apps/api/src/lib/document-processing-idle-exit.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.ts
@@ -29,6 +29,45 @@ type CreateIdleExitCheckOptions = {
 
 export type IdleExitTickOutcome = "checked" | "exit" | "skipped";
 
+type StartIdleExitSamplingOptions = {
+  intervalMs: number;
+  isShuttingDown: () => boolean;
+  /** Delay before the first sample, so sampling does not phase-lock. */
+  offsetMs: number;
+  onSample: () => void;
+};
+
+/**
+ * Sampling on an interval that only begins after an offset, with one stop
+ * handle covering both stages. The offset is a window in which the worker
+ * can already be shutting down, so the deferred start is both cancellable
+ * and guarded: `stop` clears whichever timer exists, and a start that was
+ * not cancelled still refuses to create the interval once shutdown began.
+ */
+export const startIdleExitSampling = ({
+  intervalMs,
+  isShuttingDown,
+  offsetMs,
+  onSample,
+}: StartIdleExitSamplingOptions): { stop: () => void } => {
+  let interval: ReturnType<typeof setInterval> | null = null;
+  const start = setTimeout(() => {
+    if (isShuttingDown()) {
+      return;
+    }
+    interval = setInterval(onSample, intervalMs);
+  }, offsetMs);
+  return {
+    stop: () => {
+      clearTimeout(start);
+      if (interval !== null) {
+        clearInterval(interval);
+        interval = null;
+      }
+    },
+  };
+};
+
 export const createIdleExitCheck = ({
   countPending,
   hasUnfinishedReconciliation,

--- a/apps/api/src/lib/document-processing-idle-exit.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.ts
@@ -50,12 +50,18 @@ export const createIdleExitCheck = ({
     }
     inFlight = true;
     try {
+      // Reconciliation first, then the count. Reconciliation produces
+      // queue entries and never consumes them, so waiting for the tick in
+      // flight to report before counting means everything it enqueued is
+      // already in the count. Counting first would pair a pre-enqueue
+      // count with the same tick's drained verdict and read idle while
+      // fresh jobs wait, which a worker close does not drain. A tick that
+      // starts after this verdict has already marked itself unfinished
+      // before its own first await, so the next sample reads it as
+      // running rather than reading its result.
+      const unfinished = await hasUnfinishedReconciliation();
       const pending = await countPending();
-      // Read reconciliation after the count settles, and wait for a tick in
-      // flight: a tick that starts while the count runs still lands in this
-      // sample, and one that outlives the count is answered by its own
-      // verdict rather than by whichever finished first.
-      const idle = pending === 0 && !(await hasUnfinishedReconciliation());
+      const idle = pending === 0 && !unfinished;
       consecutiveIdleChecks = idle ? consecutiveIdleChecks + 1 : 0;
     } catch (error) {
       onCheckFailure(error);

--- a/apps/api/src/lib/document-processing-idle-exit.ts
+++ b/apps/api/src/lib/document-processing-idle-exit.ts
@@ -22,6 +22,13 @@ type CreateIdleExitCheckOptions = {
    * decide.
    */
   hasUnfinishedReconciliation: () => Promise<boolean>;
+  /**
+   * Whether a reconciliation tick is running right now, read synchronously
+   * so the sample can re-check it in the frame it decides in. The
+   * reconciliation side must set this in the tick's synchronous prologue,
+   * before its own first await.
+   */
+  isReconciliationInFlight: () => boolean;
   /** Consecutive empty samples required before exiting. */
   requiredIdleChecks: number;
   onIdleExit: () => void;
@@ -33,6 +40,7 @@ export type IdleExitTickOutcome = "checked" | "exit" | "skipped";
 export const createIdleExitCheck = ({
   countPending,
   hasUnfinishedReconciliation,
+  isReconciliationInFlight,
   onCheckFailure,
   onIdleExit,
   requiredIdleChecks,
@@ -55,13 +63,19 @@ export const createIdleExitCheck = ({
       // flight to report before counting means everything it enqueued is
       // already in the count. Counting first would pair a pre-enqueue
       // count with the same tick's drained verdict and read idle while
-      // fresh jobs wait, which a worker close does not drain. A tick that
-      // starts after this verdict has already marked itself unfinished
-      // before its own first await, so the next sample reads it as
-      // running rather than reading its result.
+      // fresh jobs wait, which a worker close does not drain.
       const unfinished = await hasUnfinishedReconciliation();
       const pending = await countPending();
-      const idle = pending === 0 && !unfinished;
+      // The mirror of that window: a tick can start after the verdict and
+      // while the count is in flight, and on the last sample of a streak
+      // there is no later sample to catch it. So re-read the running flag
+      // here and decide in this frame. Reconciliation sets that flag in
+      // its tick's synchronous prologue, before its own first await, and
+      // nothing else runs between this read and the exit call below: no
+      // await separates them, and neither timers nor microtasks interleave
+      // inside one frame. Every tick that began before the decision is
+      // therefore visible to it, and none can begin during it.
+      const idle = pending === 0 && !unfinished && !isReconciliationInFlight();
       consecutiveIdleChecks = idle ? consecutiveIdleChecks + 1 : 0;
     } catch (error) {
       onCheckFailure(error);

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -10,6 +10,7 @@ import {
   classifyOcrWorkspaceDispatch,
   createDocumentProcessingLeaseRenewal,
   createReconciliationProgress,
+  DOCUMENT_PROCESSING_RECONCILIATION_PHASES,
   DocumentProcessingJobError,
   indexDocumentProjection,
   isCurrentNativeExtractionSource,
@@ -1117,17 +1118,23 @@ describe("reconciliationLeftWorkBehind", () => {
     ).toBe(false);
   });
 
-  test("every declared phase states its own signal", async () => {
+  test("every declared phase runs and states its own signal", async () => {
     const drained = await resultsOf([]);
-    // Both directions: a phase added to the reconciliation list that never
-    // reports, or a name left behind for a removed phase, fails here.
-    expect(Object.keys(drained).toSorted()).toEqual([
+    const declared = Object.keys(drained).toSorted();
+    // Both directions against the list the worker actually passes: a phase
+    // declared but never wired in reports nothing and would be read as
+    // drained; a phase run but not declared has nowhere to report.
+    expect(declared).toEqual([
       "delivery",
       "reindex",
       "repair",
       "retry",
       "stale-lease",
     ]);
+    const executed = DOCUMENT_PROCESSING_RECONCILIATION_PHASES.map(
+      ({ name }): string => name,
+    ).toSorted();
+    expect(executed).toEqual(declared);
     for (const phase of Object.keys(drained)) {
       expect(
         reconciliationLeftWorkBehind({
@@ -1148,6 +1155,17 @@ describe("reconciliationLeftWorkBehind", () => {
     ).toBe(true);
   });
 
+  test("repair runs first and delivery last, so a tick hands off what it created", () => {
+    // Repair inserts runs due now; delivery is the phase that hands them
+    // to the queue, so it has to come after everything that creates work.
+    expect(DOCUMENT_PROCESSING_RECONCILIATION_PHASES.at(0)?.name).toBe(
+      "repair",
+    );
+    expect(DOCUMENT_PROCESSING_RECONCILIATION_PHASES.at(-1)?.name).toBe(
+      "delivery",
+    );
+  });
+
   test("a failed phase counts as work left behind", async () => {
     // It drained nothing it can prove, and a zero count would otherwise
     // read as drained.
@@ -1166,10 +1184,12 @@ describe("reconciliationLeftWorkBehind", () => {
 });
 
 /**
- * The repair sweep is the phase where count and backlog diverge most: it
+ * The repair sweep is where count, cursor, and backlog all diverge: it
  * scans a page of candidate fields, filters nearly all of them, and
- * creates runs only for the survivors, so its created-run count says
- * nothing about whether the scan reached the end of the table.
+ * creates runs only for the survivors. The created-run count says nothing
+ * about whether the scan reached the end of the table, and the end of the
+ * scan says nothing about the runs it just created, which the delivery
+ * phase still has to hand off.
  */
 describe("resolveRepairScanPage", () => {
   const fieldIds = (count: number) =>
@@ -1187,16 +1207,29 @@ describe("resolveRepairScanPage", () => {
     });
   });
 
-  test("a short page ends the scan and resets the cursor", () => {
+  test("a short page that created runs ends the scan but not the tick's work", () => {
     const scannedFieldIds = fieldIds(RECONCILE_BATCH_SIZE - 1);
 
+    // The cursor resets, because the scan did reach the end; the tick is
+    // still unfinished, because those runs are queued for delivery.
     expect(
-      resolveRepairScanPage({
-        createdRunCount: scannedFieldIds.length,
-        scannedFieldIds,
-      }),
+      resolveRepairScanPage({ createdRunCount: 2, scannedFieldIds }),
     ).toEqual({
-      count: scannedFieldIds.length,
+      count: 2,
+      hasMore: true,
+      nextCursor: null,
+    });
+  });
+
+  test("a short page that created nothing is drained", () => {
+    const scannedFieldIds = fieldIds(RECONCILE_BATCH_SIZE - 1);
+
+    // The tick after the one above: nothing left to create, nothing left
+    // to deliver.
+    expect(
+      resolveRepairScanPage({ createdRunCount: 0, scannedFieldIds }),
+    ).toEqual({
+      count: 0,
       hasMore: false,
       nextCursor: null,
     });
@@ -1204,9 +1237,12 @@ describe("resolveRepairScanPage", () => {
 });
 
 /**
- * The idle sampler reads reconciliation progress synchronously, so a tick
- * that outlives an idle window must not keep exposing the previous tick's
- * drained answer.
+ * The class these pin: the sampler's verdict must not depend on how its
+ * cadence lines up with the reconciliation cadence. Reading a snapshot
+ * mid-tick gets that wrong in both directions: a sampler that keeps
+ * landing inside slow ticks would see "running" at every sample and never
+ * exit, and one that lands just before a tick reports would exit on the
+ * previous tick's answer. A sample therefore waits for the tick in flight.
  */
 describe("createReconciliationProgress", () => {
   /** A tick the test settles on demand, standing in for a slow drain. */
@@ -1223,24 +1259,9 @@ describe("createReconciliationProgress", () => {
     };
   };
 
-  test("a running tick reads as unfinished before it awaits anything", async () => {
-    const progress = createReconciliationProgress();
-    await progress.runTick(async () => false);
-    const tick = pendingTick();
-
-    const inFlight = progress.runTick(tick.run);
-
-    // Synchronously after the call, and across every later sample.
-    expect(progress.hasUnfinishedWork()).toBe(true);
-    await Bun.sleep(5);
-    expect(progress.hasUnfinishedWork()).toBe(true);
-    tick.settle(false);
-    await inFlight;
-    expect(progress.hasUnfinishedWork()).toBe(false);
-  });
-
-  test("an in-flight tick keeps the idle sampler from exiting until it drains", async () => {
-    const progress = createReconciliationProgress();
+  const sampler = (
+    progress: ReturnType<typeof createReconciliationProgress>,
+  ) => {
     let exits = 0;
     const sample = createIdleExitCheck({
       countPending: async () => 0,
@@ -1251,32 +1272,59 @@ describe("createReconciliationProgress", () => {
       },
       requiredIdleChecks: 1,
     });
+    return { exits: () => exits, sample };
+  };
+
+  test("a sample inside a tick waits for that tick, not the last one", async () => {
+    const progress = createReconciliationProgress();
+    // The last completed tick was drained: a snapshot read would exit on it.
+    await progress.runTick(async () => false);
     const tick = pendingTick();
     const inFlight = progress.runTick(tick.run);
+    const h = sampler(progress);
 
-    // The queue is empty for the whole window, and the exit still waits.
-    expect(await sample()).toBe("checked");
-    expect(await sample()).toBe("checked");
-    expect(exits).toBe(0);
+    const outcome = h.sample();
+    await Bun.sleep(5);
+    expect(h.exits()).toBe(0);
 
+    tick.settle(true);
+    await inFlight;
+
+    expect(await outcome).toBe("checked");
+    expect(h.exits()).toBe(0);
+  });
+
+  test("a slow tick that drains still lets the worker exit, whenever the sample lands", async () => {
+    const progress = createReconciliationProgress();
+    const tick = pendingTick();
+    const inFlight = progress.runTick(tick.run);
+    const h = sampler(progress);
+
+    // Every sample lands inside the tick, the alignment that would strand
+    // a snapshot-reading sampler forever.
+    const outcome = h.sample();
+    await Bun.sleep(5);
     tick.settle(false);
     await inFlight;
 
-    expect(await sample()).toBe("exit");
-    expect(exits).toBe(1);
+    expect(await outcome).toBe("exit");
+    expect(h.exits()).toBe(1);
   });
 
-  test("a saturated tick keeps it and a drained tick clears it", async () => {
+  test("a saturated tick keeps the worker alive", async () => {
     const progress = createReconciliationProgress();
-
     await progress.runTick(async () => true);
-    expect(progress.hasUnfinishedWork()).toBe(true);
+    const h = sampler(progress);
+
+    expect(await h.sample()).toBe("checked");
+    expect(h.exits()).toBe(0);
 
     await progress.runTick(async () => false);
-    expect(progress.hasUnfinishedWork()).toBe(false);
+
+    expect(await h.sample()).toBe("exit");
   });
 
-  test("a tick that never reported leaves it unfinished", async () => {
+  test("a tick that never reported leaves work unfinished", async () => {
     const progress = createReconciliationProgress();
     await progress.runTick(async () => false);
 
@@ -1290,6 +1338,6 @@ describe("createReconciliationProgress", () => {
       );
 
     expect(rejection).toBeInstanceOf(Error);
-    expect(progress.hasUnfinishedWork()).toBe(true);
+    expect(await progress.hasUnfinishedWork()).toBe(true);
   });
 });

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -1261,10 +1261,11 @@ describe("createReconciliationProgress", () => {
 
   const sampler = (
     progress: ReturnType<typeof createReconciliationProgress>,
+    countPending: () => Promise<number> = async () => 0,
   ) => {
     let exits = 0;
     const sample = createIdleExitCheck({
-      countPending: async () => 0,
+      countPending,
       hasUnfinishedReconciliation: progress.hasUnfinishedWork,
       onCheckFailure: () => undefined,
       onIdleExit: () => {
@@ -1309,6 +1310,26 @@ describe("createReconciliationProgress", () => {
 
     expect(await outcome).toBe("exit");
     expect(h.exits()).toBe(1);
+  });
+
+  test("jobs the tick enqueues before draining are in the count it is sampled against", async () => {
+    const progress = createReconciliationProgress();
+    let queueDepth = 0;
+    const tick = pendingTick();
+    const inFlight = progress.runTick(tick.run);
+    const h = sampler(progress, async () => queueDepth);
+
+    const outcome = h.sample();
+    await Bun.sleep(5);
+    // What the delivery phase does: hand recovered runs to the queue, then
+    // report the tick drained. Counting before waiting for that verdict
+    // would pair this tick's empty "before" with its drained "after".
+    queueDepth = 3;
+    tick.settle(false);
+    await inFlight;
+
+    expect(await outcome).toBe("checked");
+    expect(h.exits()).toBe(0);
   });
 
   test("a saturated tick keeps the worker alive", async () => {

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -10,6 +10,8 @@ import {
   classifyOcrWorkspaceDispatch,
   createDocumentProcessingLeaseRenewal,
   createReconciliationProgress,
+  dispatchScheduledDocumentProcessingRetries,
+  DOCUMENT_PROCESSING_RECONCILIATION_PHASE_FEEDS,
   DOCUMENT_PROCESSING_RECONCILIATION_PHASES,
   DocumentProcessingJobError,
   indexDocumentProjection,
@@ -26,6 +28,7 @@ import {
   RECONCILE_BATCH_SIZE,
   reconciliationLeftWorkBehind,
   resolveRepairScanPage,
+  resolveSearchIndexReplayBatch,
   runDocumentProcessingReconciliationPhases,
   runSearchIndexReplayAttempt,
   settleDocumentProcessingAttemptError,
@@ -1155,15 +1158,25 @@ describe("reconciliationLeftWorkBehind", () => {
     ).toBe(true);
   });
 
-  test("repair runs first and delivery last, so a tick hands off what it created", () => {
-    // Repair inserts runs due now; delivery is the phase that hands them
-    // to the queue, so it has to come after everything that creates work.
-    expect(DOCUMENT_PROCESSING_RECONCILIATION_PHASES.at(0)?.name).toBe(
-      "repair",
+  test("every phase runs ahead of the phases it feeds", () => {
+    const order = DOCUMENT_PROCESSING_RECONCILIATION_PHASES.map(
+      ({ name }): string => name,
     );
-    expect(DOCUMENT_PROCESSING_RECONCILIATION_PHASES.at(-1)?.name).toBe(
-      "delivery",
+    const feeds = Object.entries(
+      DOCUMENT_PROCESSING_RECONCILIATION_PHASE_FEEDS,
     );
+
+    // Both directions again, this time between the declared edges and the
+    // order they constrain: an edge whose consumer is missing from the
+    // order, or a phase that produces work for a phase that already ran,
+    // fails here. That second case is what leaves a tick's own output
+    // waiting for the next tick.
+    expect(feeds.map(([phase]) => phase).toSorted()).toEqual(order.toSorted());
+    for (const [phase, consumers] of feeds) {
+      for (const consumer of consumers) {
+        expect(order.indexOf(consumer)).toBeGreaterThan(order.indexOf(phase));
+      }
+    }
   });
 
   test("a failed phase counts as work left behind", async () => {
@@ -1207,32 +1220,67 @@ describe("resolveRepairScanPage", () => {
     });
   });
 
-  test("a short page that created runs ends the scan but not the tick's work", () => {
+  test("a short page ends the scan whether or not it created runs", () => {
     const scannedFieldIds = fieldIds(RECONCILE_BATCH_SIZE - 1);
 
-    // The cursor resets, because the scan did reach the end; the tick is
-    // still unfinished, because those runs are queued for delivery.
+    // The runs it created are due input for reindex and delivery, both of
+    // which run later in this tick and answer for them: this phase reports
+    // only its own backlog, which the short page ended.
+    for (const createdRunCount of [0, 2]) {
+      expect(
+        resolveRepairScanPage({ createdRunCount, scannedFieldIds }),
+      ).toEqual({
+        count: createdRunCount,
+        hasMore: false,
+        nextCursor: null,
+      });
+    }
+  });
+});
+
+/**
+ * Work a phase leaves for itself is the one kind the phase order cannot
+ * place, so each of those phases has to report it.
+ */
+describe("work a phase keeps for itself", () => {
+  test("a replay claimed but not completed keeps the reindex phase unfinished", () => {
+    // It went back to failed with a backoff, which is this phase's own
+    // input: no later phase selects it.
     expect(
-      resolveRepairScanPage({ createdRunCount: 2, scannedFieldIds }),
-    ).toEqual({
-      count: 2,
-      hasMore: true,
-      nextCursor: null,
-    });
+      resolveSearchIndexReplayBatch({
+        claimedCount: 4,
+        recoveredCount: 1,
+        saturated: false,
+      }),
+    ).toEqual({ count: 1, hasMore: true });
+
+    expect(
+      resolveSearchIndexReplayBatch({
+        claimedCount: 4,
+        recoveredCount: 4,
+        saturated: false,
+      }),
+    ).toEqual({ count: 4, hasMore: false });
   });
 
-  test("a short page that created nothing is drained", () => {
-    const scannedFieldIds = fieldIds(RECONCILE_BATCH_SIZE - 1);
-
-    // The tick after the one above: nothing left to create, nothing left
-    // to deliver.
+  test("a failed handoff keeps the delivery phase unfinished", async () => {
+    // The run stays queued and rescheduled, and delivery is the only phase
+    // that takes queued rows, so nothing later in this tick can.
     expect(
-      resolveRepairScanPage({ createdRunCount: 0, scannedFieldIds }),
-    ).toEqual({
-      count: 0,
-      hasMore: false,
-      nextCursor: null,
-    });
+      await dispatchScheduledDocumentProcessingRetries(async () => ({
+        attempted: 3,
+        hasMore: false,
+        retryAt: new Date("2030-01-01T00:00:30.000Z"),
+      })),
+    ).toEqual({ count: 3, hasMore: true });
+
+    expect(
+      await dispatchScheduledDocumentProcessingRetries(async () => ({
+        attempted: 3,
+        hasMore: false,
+        retryAt: null,
+      })),
+    ).toEqual({ count: 3, hasMore: false });
   });
 });
 

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, test } from "bun:test";
 
 import type { FieldContent } from "@/api/db/schema-validators";
 import { toSafeId } from "@/api/lib/branded-types";
+import { createIdleExitCheck } from "@/api/lib/document-processing-idle-exit";
 import {
   abortDocumentProcessingWorkerBeforeClose,
   automaticOcrRetryDelayMs,
   classifyOcrProjectionSource,
   classifyOcrWorkspaceDispatch,
   createDocumentProcessingLeaseRenewal,
+  createReconciliationProgress,
   DocumentProcessingJobError,
   indexDocumentProjection,
   isCurrentNativeExtractionSource,
@@ -20,7 +22,9 @@ import {
   memoizeConnect,
   ownsPromotedManualOcrClaim,
   readRepairScanCursor,
+  RECONCILE_BATCH_SIZE,
   reconciliationLeftWorkBehind,
+  resolveRepairScanPage,
   runDocumentProcessingReconciliationPhases,
   runSearchIndexReplayAttempt,
   settleDocumentProcessingAttemptError,
@@ -320,13 +324,13 @@ describe("reconciliation fault isolation", () => {
     const failures: { error: unknown; phase: string }[] = [];
     const repairError = new Error("repair unavailable");
 
-    const counts = await runDocumentProcessingReconciliationPhases({
+    const results = await runDocumentProcessingReconciliationPhases({
       phases: [
         {
           name: "delivery",
           run: async () => {
             calls.push("delivery");
-            return 5;
+            return { count: 5, hasMore: false };
           },
         },
         {
@@ -340,21 +344,21 @@ describe("reconciliation fault isolation", () => {
           name: "reindex",
           run: async () => {
             calls.push("reindex");
-            return 2;
+            return { count: 2, hasMore: false };
           },
         },
         {
           name: "retry",
           run: async () => {
             calls.push("retry");
-            return 3;
+            return { count: 3, hasMore: true };
           },
         },
         {
           name: "stale-lease",
           run: async () => {
             calls.push("stale-lease");
-            return 4;
+            return { count: 4, hasMore: false };
           },
         },
       ],
@@ -371,12 +375,12 @@ describe("reconciliation fault isolation", () => {
       "stale-lease",
     ]);
     expect(failures).toEqual([{ error: repairError, phase: "repair" }]);
-    expect(counts).toEqual({
-      delivery: 5,
-      reindex: 2,
-      repair: 0,
-      retry: 3,
-      "stale-lease": 4,
+    expect(results).toEqual({
+      delivery: { count: 5, hasMore: false },
+      reindex: { count: 2, hasMore: false },
+      repair: { count: 0, hasMore: true },
+      retry: { count: 3, hasMore: true },
+      "stale-lease": { count: 4, hasMore: false },
     });
   });
 
@@ -755,12 +759,12 @@ describe("bounded search-index replay", () => {
     const calls: string[] = [];
     const phaseErrors: unknown[] = [];
     let replayError: unknown;
-    const counts = await runDocumentProcessingReconciliationPhases({
+    const results = await runDocumentProcessingReconciliationPhases({
       phases: [
         {
           name: "reindex",
-          run: async () =>
-            Number(
+          run: async () => ({
+            count: Number(
               await runSearchIndexReplayAttempt({
                 indexEntity: async () => await new Promise<void>(() => {}),
                 onFailure: async (error) => {
@@ -774,12 +778,14 @@ describe("bounded search-index replay", () => {
                 timeoutMs: 5,
               }),
             ),
+            hasMore: false,
+          }),
         },
         {
           name: "retry",
           run: async () => {
             calls.push("retry");
-            return 2;
+            return { count: 2, hasMore: false };
           },
         },
       ],
@@ -795,8 +801,8 @@ describe("bounded search-index replay", () => {
     });
     expect(calls).toEqual(["reindex-failed", "retry"]);
     expect(phaseErrors).toEqual([]);
-    expect(counts.reindex).toBe(0);
-    expect(counts.retry).toBe(2);
+    expect(results.reindex.count).toBe(0);
+    expect(results.retry.count).toBe(2);
   });
 
   test("bounds stalled failure and success state transitions", async () => {
@@ -1080,72 +1086,210 @@ describe("worker interruption lifecycle", () => {
 });
 
 /**
- * The class these pin: reconciliation drains each backlog one capped
- * batch per tick, so "this phase returned its whole batch" is the only
- * signal that work remains. A phase whose limit is not represented, or a
- * partial batch read as saturated, both let the batch worker call itself
- * idle while a backlog is still draining.
+ * The class these pin: reconciliation drains each backlog one capped batch
+ * per tick, and a phase's effect count is routinely smaller than the rows
+ * it read (candidates filtered out, compare-and-set losses, replays that
+ * fail). Inferring "more remains" from that count therefore reads a
+ * saturated phase as drained and lets the batch worker exit mid-drain, so
+ * each phase states its own saturation and this only collects the answers.
  */
 describe("reconciliationLeftWorkBehind", () => {
-  const drainedCounts = async () =>
+  const resultsOf = async (
+    phases: Parameters<
+      typeof runDocumentProcessingReconciliationPhases
+    >[0]["phases"],
+  ) =>
     await runDocumentProcessingReconciliationPhases({
       onPhaseError: () => undefined,
-      phases: [],
+      phases,
     });
 
-  // Above every phase limit, so saturation is exercised without copying
-  // the limits themselves into the test.
-  const ABOVE_ANY_BATCH = 10_000;
-
-  test("a fully drained tick leaves nothing behind", async () => {
+  test("a large effect count with no phase saturated leaves nothing behind", async () => {
     expect(
-      reconciliationLeftWorkBehind({
-        counts: await drainedCounts(),
-        failedPhases: [],
-      }),
+      reconciliationLeftWorkBehind(
+        await resultsOf([
+          {
+            name: "repair",
+            run: async () => ({ count: 10_000, hasMore: false }),
+          },
+        ]),
+      ),
     ).toBe(false);
   });
 
-  test("every declared phase is watched for saturation", async () => {
-    const counts = await drainedCounts();
-    // Both directions: a phase added to the reconciliation list without a
-    // batch limit, or a limit left behind for a removed phase, fails here.
-    expect(Object.keys(counts).toSorted()).toEqual([
+  test("every declared phase states its own signal", async () => {
+    const drained = await resultsOf([]);
+    // Both directions: a phase added to the reconciliation list that never
+    // reports, or a name left behind for a removed phase, fails here.
+    expect(Object.keys(drained).toSorted()).toEqual([
       "delivery",
       "reindex",
       "repair",
       "retry",
       "stale-lease",
     ]);
-    for (const phase of Object.keys(counts)) {
+    for (const phase of Object.keys(drained)) {
       expect(
         reconciliationLeftWorkBehind({
-          counts: { ...counts, [phase]: ABOVE_ANY_BATCH },
-          failedPhases: [],
+          ...drained,
+          [phase]: { count: 0, hasMore: true },
         }),
       ).toBe(true);
     }
   });
 
-  test("a partial batch is progress, not a backlog", async () => {
-    const counts = await drainedCounts();
-    for (const phase of Object.keys(counts)) {
-      expect(
-        reconciliationLeftWorkBehind({
-          counts: { ...counts, [phase]: 1 },
-          failedPhases: [],
-        }),
-      ).toBe(false);
-    }
+  test("a phase that acted on almost nothing still reports its backlog", async () => {
+    expect(
+      reconciliationLeftWorkBehind(
+        await resultsOf([
+          { name: "repair", run: async () => ({ count: 1, hasMore: true }) },
+        ]),
+      ),
+    ).toBe(true);
   });
 
   test("a failed phase counts as work left behind", async () => {
-    // Its count stays 0, which would otherwise read as drained.
+    // It drained nothing it can prove, and a zero count would otherwise
+    // read as drained.
+    const results = await resultsOf([
+      {
+        name: "repair",
+        run: async () => {
+          throw new Error("repair unavailable");
+        },
+      },
+    ]);
+
+    expect(results.repair).toEqual({ count: 0, hasMore: true });
+    expect(reconciliationLeftWorkBehind(results)).toBe(true);
+  });
+});
+
+/**
+ * The repair sweep is the phase where count and backlog diverge most: it
+ * scans a page of candidate fields, filters nearly all of them, and
+ * creates runs only for the survivors, so its created-run count says
+ * nothing about whether the scan reached the end of the table.
+ */
+describe("resolveRepairScanPage", () => {
+  const fieldIds = (count: number) =>
+    Array.from({ length: count }, () => toSafeId<"field">(Bun.randomUUIDv7()));
+
+  test("a full page whose candidates were filtered out still has another page", () => {
+    const scannedFieldIds = fieldIds(RECONCILE_BATCH_SIZE);
+
     expect(
-      reconciliationLeftWorkBehind({
-        counts: await drainedCounts(),
-        failedPhases: ["repair"],
+      resolveRepairScanPage({ createdRunCount: 0, scannedFieldIds }),
+    ).toEqual({
+      count: 0,
+      hasMore: true,
+      nextCursor: scannedFieldIds.at(-1) ?? null,
+    });
+  });
+
+  test("a short page ends the scan and resets the cursor", () => {
+    const scannedFieldIds = fieldIds(RECONCILE_BATCH_SIZE - 1);
+
+    expect(
+      resolveRepairScanPage({
+        createdRunCount: scannedFieldIds.length,
+        scannedFieldIds,
       }),
-    ).toBe(true);
+    ).toEqual({
+      count: scannedFieldIds.length,
+      hasMore: false,
+      nextCursor: null,
+    });
+  });
+});
+
+/**
+ * The idle sampler reads reconciliation progress synchronously, so a tick
+ * that outlives an idle window must not keep exposing the previous tick's
+ * drained answer.
+ */
+describe("createReconciliationProgress", () => {
+  /** A tick the test settles on demand, standing in for a slow drain. */
+  const pendingTick = () => {
+    let settle: (leftWorkBehind: boolean) => void = () => undefined;
+    return {
+      run: async () =>
+        await new Promise<boolean>((resolve) => {
+          settle = resolve;
+        }),
+      settle: (leftWorkBehind: boolean) => {
+        settle(leftWorkBehind);
+      },
+    };
+  };
+
+  test("a running tick reads as unfinished before it awaits anything", async () => {
+    const progress = createReconciliationProgress();
+    await progress.runTick(async () => false);
+    const tick = pendingTick();
+
+    const inFlight = progress.runTick(tick.run);
+
+    // Synchronously after the call, and across every later sample.
+    expect(progress.hasUnfinishedWork()).toBe(true);
+    await Bun.sleep(5);
+    expect(progress.hasUnfinishedWork()).toBe(true);
+    tick.settle(false);
+    await inFlight;
+    expect(progress.hasUnfinishedWork()).toBe(false);
+  });
+
+  test("an in-flight tick keeps the idle sampler from exiting until it drains", async () => {
+    const progress = createReconciliationProgress();
+    let exits = 0;
+    const sample = createIdleExitCheck({
+      countPending: async () => 0,
+      hasUnfinishedReconciliation: progress.hasUnfinishedWork,
+      onCheckFailure: () => undefined,
+      onIdleExit: () => {
+        exits += 1;
+      },
+      requiredIdleChecks: 1,
+    });
+    const tick = pendingTick();
+    const inFlight = progress.runTick(tick.run);
+
+    // The queue is empty for the whole window, and the exit still waits.
+    expect(await sample()).toBe("checked");
+    expect(await sample()).toBe("checked");
+    expect(exits).toBe(0);
+
+    tick.settle(false);
+    await inFlight;
+
+    expect(await sample()).toBe("exit");
+    expect(exits).toBe(1);
+  });
+
+  test("a saturated tick keeps it and a drained tick clears it", async () => {
+    const progress = createReconciliationProgress();
+
+    await progress.runTick(async () => true);
+    expect(progress.hasUnfinishedWork()).toBe(true);
+
+    await progress.runTick(async () => false);
+    expect(progress.hasUnfinishedWork()).toBe(false);
+  });
+
+  test("a tick that never reported leaves it unfinished", async () => {
+    const progress = createReconciliationProgress();
+    await progress.runTick(async () => false);
+
+    const rejection: unknown = await progress
+      .runTick(async () => {
+        throw new Error("reconcile unavailable");
+      })
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+    expect(rejection).toBeInstanceOf(Error);
+    expect(progress.hasUnfinishedWork()).toBe(true);
   });
 });

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -20,6 +20,7 @@ import {
   memoizeConnect,
   ownsPromotedManualOcrClaim,
   readRepairScanCursor,
+  reconciliationLeftWorkBehind,
   runDocumentProcessingReconciliationPhases,
   runSearchIndexReplayAttempt,
   settleDocumentProcessingAttemptError,
@@ -1075,5 +1076,76 @@ describe("worker interruption lifecycle", () => {
     expect(
       transition.match(/\.update\(documentProcessingRuns\)/gu),
     ).toHaveLength(1);
+  });
+});
+
+/**
+ * The class these pin: reconciliation drains each backlog one capped
+ * batch per tick, so "this phase returned its whole batch" is the only
+ * signal that work remains. A phase whose limit is not represented, or a
+ * partial batch read as saturated, both let the batch worker call itself
+ * idle while a backlog is still draining.
+ */
+describe("reconciliationLeftWorkBehind", () => {
+  const drainedCounts = async () =>
+    await runDocumentProcessingReconciliationPhases({
+      onPhaseError: () => undefined,
+      phases: [],
+    });
+
+  // Above every phase limit, so saturation is exercised without copying
+  // the limits themselves into the test.
+  const ABOVE_ANY_BATCH = 10_000;
+
+  test("a fully drained tick leaves nothing behind", async () => {
+    expect(
+      reconciliationLeftWorkBehind({
+        counts: await drainedCounts(),
+        failedPhases: [],
+      }),
+    ).toBe(false);
+  });
+
+  test("every declared phase is watched for saturation", async () => {
+    const counts = await drainedCounts();
+    // Both directions: a phase added to the reconciliation list without a
+    // batch limit, or a limit left behind for a removed phase, fails here.
+    expect(Object.keys(counts).toSorted()).toEqual([
+      "delivery",
+      "reindex",
+      "repair",
+      "retry",
+      "stale-lease",
+    ]);
+    for (const phase of Object.keys(counts)) {
+      expect(
+        reconciliationLeftWorkBehind({
+          counts: { ...counts, [phase]: ABOVE_ANY_BATCH },
+          failedPhases: [],
+        }),
+      ).toBe(true);
+    }
+  });
+
+  test("a partial batch is progress, not a backlog", async () => {
+    const counts = await drainedCounts();
+    for (const phase of Object.keys(counts)) {
+      expect(
+        reconciliationLeftWorkBehind({
+          counts: { ...counts, [phase]: 1 },
+          failedPhases: [],
+        }),
+      ).toBe(false);
+    }
+  });
+
+  test("a failed phase counts as work left behind", async () => {
+    // Its count stays 0, which would otherwise read as drained.
+    expect(
+      reconciliationLeftWorkBehind({
+        counts: await drainedCounts(),
+        failedPhases: ["repair"],
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -1382,7 +1382,7 @@ describe("createReconciliationProgress", () => {
     expect(h.exits()).toBe(0);
   });
 
-  test("a tick that starts as the count resolves is seen by the sample deciding", async () => {
+  test("a tick that starts as the count resolves is waited out by that sample", async () => {
     const progress = createReconciliationProgress();
     const tick = pendingTick();
     const ticks: Promise<void>[] = [];
@@ -1392,7 +1392,8 @@ describe("createReconciliationProgress", () => {
         await Promise.resolve(0).then((pending) => {
           // The reconcile timer fires between the count resolving and the
           // sampler resuming. The tick's own prologue marks it running
-          // before its first await, which is what the decision re-reads.
+          // before its first await, so the sample measures again and that
+          // second pass waits for this tick's verdict.
           if (ticks.length === 0) {
             ticks.push(progress.runTick(tick.run));
           }
@@ -1400,16 +1401,16 @@ describe("createReconciliationProgress", () => {
         }),
     );
 
-    // One idle check is all this sampler needs, so nothing later could
-    // catch the tick if this sample missed it.
-    expect(await h.sample()).toBe("checked");
+    const outcome = h.sample();
+    await Bun.sleep(5);
+    // Still measuring: nothing has been decided on the stale verdict.
     expect(h.exits()).toBe(0);
 
-    tick.settle(false);
+    tick.settle(true);
     await Promise.all(ticks);
 
-    expect(await h.sample()).toBe("exit");
-    expect(h.exits()).toBe(1);
+    expect(await outcome).toBe("checked");
+    expect(h.exits()).toBe(0);
   });
 
   /**
@@ -1448,19 +1449,15 @@ describe("createReconciliationProgress", () => {
     expect(h.exits()).toBe(0);
   });
 
-  test("a drained tick that fits inside the count costs one sample, not the exit", async () => {
+  test("a drained tick that fits inside the count is resolved by the same sample", async () => {
     const progress = createReconciliationProgress();
     await progress.runTick(async () => false);
     const h = samplerRunningATickInsideTheCount(progress, false);
 
-    // Every other reading says drained; the moved generation is what
-    // holds this sample back, since that tick may have enqueued after the
-    // count was taken.
-    expect(await h.sample()).toBe("checked");
-    expect(h.exits()).toBe(0);
-
-    // Nothing runs under the next sample, so being conservative delays
-    // the exit by one check rather than preventing it.
+    // The crossing moved the generation, so the sample measures again: it
+    // re-reads the verdict, which is now that tick's own and drained, and
+    // re-counts what it enqueued. Nothing is left, so the sample completes
+    // rather than being spent on the crossing.
     expect(await h.sample()).toBe("exit");
     expect(h.exits()).toBe(1);
   });

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -1268,6 +1268,7 @@ describe("createReconciliationProgress", () => {
       countPending,
       hasUnfinishedReconciliation: progress.hasUnfinishedWork,
       isReconciliationInFlight: progress.isTickRunning,
+      reconciliationGeneration: progress.tickGeneration,
       onCheckFailure: () => undefined,
       onIdleExit: () => {
         exits += 1;
@@ -1359,6 +1360,59 @@ describe("createReconciliationProgress", () => {
     tick.settle(false);
     await Promise.all(ticks);
 
+    expect(await h.sample()).toBe("exit");
+    expect(h.exits()).toBe(1);
+  });
+
+  /**
+   * A tick can also open and close entirely inside the count: nothing is
+   * running when the sample resumes, and the verdict it took belongs to
+   * the tick before, so only the generation records that it ran at all.
+   */
+  const samplerRunningATickInsideTheCount = (
+    progress: ReturnType<typeof createReconciliationProgress>,
+    leftWorkBehind: boolean,
+  ) => {
+    let ran = false;
+    return sampler(
+      progress,
+      async () =>
+        await Promise.resolve(0).then(async (pending) => {
+          if (!ran) {
+            ran = true;
+            await progress.runTick(async () => leftWorkBehind);
+          }
+          return pending;
+        }),
+    );
+  };
+
+  test("a saturated tick that fits inside the count is not exited past", async () => {
+    const progress = createReconciliationProgress();
+    // The verdict this sample waits on is the drained tick before it.
+    await progress.runTick(async () => false);
+    const h = samplerRunningATickInsideTheCount(progress, true);
+
+    expect(await h.sample()).toBe("checked");
+    expect(h.exits()).toBe(0);
+    // And the sample after it reads that tick's own verdict.
+    expect(await h.sample()).toBe("checked");
+    expect(h.exits()).toBe(0);
+  });
+
+  test("a drained tick that fits inside the count costs one sample, not the exit", async () => {
+    const progress = createReconciliationProgress();
+    await progress.runTick(async () => false);
+    const h = samplerRunningATickInsideTheCount(progress, false);
+
+    // Every other reading says drained; the moved generation is what
+    // holds this sample back, since that tick may have enqueued after the
+    // count was taken.
+    expect(await h.sample()).toBe("checked");
+    expect(h.exits()).toBe(0);
+
+    // Nothing runs under the next sample, so being conservative delays
+    // the exit by one check rather than preventing it.
     expect(await h.sample()).toBe("exit");
     expect(h.exits()).toBe(1);
   });

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -1267,6 +1267,7 @@ describe("createReconciliationProgress", () => {
     const sample = createIdleExitCheck({
       countPending,
       hasUnfinishedReconciliation: progress.hasUnfinishedWork,
+      isReconciliationInFlight: progress.isTickRunning,
       onCheckFailure: () => undefined,
       onIdleExit: () => {
         exits += 1;
@@ -1330,6 +1331,36 @@ describe("createReconciliationProgress", () => {
 
     expect(await outcome).toBe("checked");
     expect(h.exits()).toBe(0);
+  });
+
+  test("a tick that starts as the count resolves is seen by the sample deciding", async () => {
+    const progress = createReconciliationProgress();
+    const tick = pendingTick();
+    const ticks: Promise<void>[] = [];
+    const h = sampler(
+      progress,
+      async () =>
+        await Promise.resolve(0).then((pending) => {
+          // The reconcile timer fires between the count resolving and the
+          // sampler resuming. The tick's own prologue marks it running
+          // before its first await, which is what the decision re-reads.
+          if (ticks.length === 0) {
+            ticks.push(progress.runTick(tick.run));
+          }
+          return pending;
+        }),
+    );
+
+    // One idle check is all this sampler needs, so nothing later could
+    // catch the tick if this sample missed it.
+    expect(await h.sample()).toBe("checked");
+    expect(h.exits()).toBe(0);
+
+    tick.settle(false);
+    await Promise.all(ticks);
+
+    expect(await h.sample()).toBe("exit");
+    expect(h.exits()).toBe(1);
   });
 
   test("a saturated tick keeps the worker alive", async () => {

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -81,8 +81,8 @@ import { withTimeout } from "@/api/lib/with-timeout";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 const WORKER_CONCURRENCY = 2;
-const RECONCILE_INTERVAL_MS = 30_000;
-const RECONCILE_BATCH_SIZE = 100;
+export const RECONCILE_INTERVAL_MS = 30_000;
+export const RECONCILE_BATCH_SIZE = 100;
 const ENQUEUE_VISIBILITY_TIMEOUT_MS = 5 * 60 * 1000;
 const ENQUEUE_FAILURE_RETRY_MS = 30_000;
 const QUEUED_OCR_SELECTION = {
@@ -1765,7 +1765,67 @@ export const tryEnqueueDocumentProcessingRun = async ({
   return { runId, status: "enqueued" };
 };
 
-const recoverMissingNativeExtractionRuns = async (): Promise<number> => {
+/**
+ * What one reconciliation phase reports for one tick. `count` is the
+ * effect the phase had (runs created, rows recovered, deliveries
+ * attempted); `hasMore` is the phase's own answer to "was there more than
+ * I could take this tick". The two are independent: a phase can scan a
+ * full page and act on none of it, so `count` can never stand in for
+ * saturation.
+ */
+type ReconciliationPhaseResult = {
+  count: number;
+  hasMore: boolean;
+};
+
+/**
+ * A capped selection that came back full stopped at the cap, not at the
+ * end of the backlog. Every phase computes this from the rows it selected,
+ * beside the `.limit()` that capped them.
+ */
+const cappedSelectionHasMore = ({
+  limit,
+  selected,
+}: {
+  limit: number;
+  selected: number;
+}): boolean => selected >= limit;
+
+type RepairScanPage = ReconciliationPhaseResult & {
+  nextCursor: SafeId<"field"> | null;
+};
+
+/**
+ * The repair sweep's resume position and its saturation signal are the
+ * same fact: a full page means the scan stopped at the cap, so the next
+ * tick resumes after the last scanned field; a short page means the scan
+ * reached the end of the table, so the cursor resets and nothing is left
+ * behind. Derived together so the two can never disagree, and kept apart
+ * from `createdRunCount` because most scanned fields are filtered out
+ * before a run is created.
+ */
+export const resolveRepairScanPage = ({
+  createdRunCount,
+  scannedFieldIds,
+}: {
+  createdRunCount: number;
+  scannedFieldIds: readonly SafeId<"field">[];
+}): RepairScanPage => {
+  const hasMore = cappedSelectionHasMore({
+    limit: RECONCILE_BATCH_SIZE,
+    selected: scannedFieldIds.length,
+  });
+  return {
+    count: createdRunCount,
+    hasMore,
+    nextCursor: hasMore ? (scannedFieldIds.at(-1) ?? null) : null,
+  };
+};
+
+// Return types are inferred so each producer's own `hasMore` reasoning
+// stays visible at the `return`, and the `ReconciliationPhase` contract
+// checks the shape where the phases are declared.
+const recoverMissingNativeExtractionRuns = async () => {
   const settledBefore = new Date(Date.now() - REPAIR_SETTLE_DELAY_MS);
   const cursor = await readRepairScanCursor();
   const candidates = await rootDb
@@ -1825,7 +1885,7 @@ const recoverMissingNativeExtractionRuns = async (): Promise<number> => {
     if (cursor !== null) {
       await writeRepairScanCursor({ expectedCursor: cursor, nextCursor: null });
     }
-    return 0;
+    return { count: 0, hasMore: false };
   }
 
   const repairCandidates = candidates.flatMap((candidate) => {
@@ -1838,14 +1898,15 @@ const recoverMissingNativeExtractionRuns = async (): Promise<number> => {
     return [{ ...candidate, content: candidate.content }];
   });
   const runIds = await persistMissingNativeExtractionRuns(repairCandidates);
+  const page = resolveRepairScanPage({
+    createdRunCount: runIds.length,
+    scannedFieldIds: candidates.map(({ fieldId }) => fieldId),
+  });
   await writeRepairScanCursor({
     expectedCursor: cursor,
-    nextCursor:
-      candidates.length < RECONCILE_BATCH_SIZE
-        ? null
-        : (candidates.at(-1)?.fieldId ?? null),
+    nextCursor: page.nextCursor,
   });
-  return runIds.length;
+  return { count: page.count, hasMore: page.hasMore };
 };
 
 const updateQueuedRunSchedule = async ({
@@ -1882,7 +1943,11 @@ export const dispatchQueuedDocumentProcessingRuns = async ({
   selection?:
     | typeof QUEUED_OCR_SELECTION.ALL_DUE
     | typeof QUEUED_OCR_SELECTION.SCHEDULED_RETRIES;
-} = {}): Promise<{ attempted: number; retryAt: Date | null }> => {
+} = {}): Promise<{
+  attempted: number;
+  hasMore: boolean;
+  retryAt: Date | null;
+}> => {
   const now = new Date();
   const runs = await rootDb
     .select({ id: documentProcessingRuns.id })
@@ -1939,6 +2004,7 @@ export const dispatchQueuedDocumentProcessingRuns = async ({
   });
   return {
     attempted: runs.length,
+    hasMore: cappedSelectionHasMore({ limit, selected: runs.length }),
     retryAt:
       failedIds.length === 0
         ? null
@@ -1946,12 +2012,15 @@ export const dispatchQueuedDocumentProcessingRuns = async ({
   };
 };
 
-const dispatchScheduledDocumentProcessingRetries = async (): Promise<number> =>
-  (
-    await dispatchQueuedDocumentProcessingRuns({
-      selection: QUEUED_OCR_SELECTION.SCHEDULED_RETRIES,
-    })
-  ).attempted;
+const dispatchScheduledDocumentProcessingRetries = async () => {
+  // Runs whose handoff failed are rescheduled into the future, so they are
+  // not due work this phase could still take; only a full selection means
+  // more was due than one batch could deliver.
+  const { attempted, hasMore } = await dispatchQueuedDocumentProcessingRuns({
+    selection: QUEUED_OCR_SELECTION.SCHEDULED_RETRIES,
+  });
+  return { count: attempted, hasMore };
+};
 
 // Manual searchable-PDF failures are retryable too, so the condition spans
 // both automatic OCR sources and every derivative failure.
@@ -1967,7 +2036,7 @@ const retryableOcrFailureCondition = () =>
     eq(documentProcessingRuns.errorCode, SEARCHABLE_PDF_FAILURE_CODE),
   );
 
-const recoverRetryableOcrFailures = async (): Promise<number> => {
+const recoverRetryableOcrFailures = async () => {
   const now = new Date();
   const retryableRuns = await rootDb
     .select({
@@ -1995,8 +2064,14 @@ const recoverRetryableOcrFailures = async (): Promise<number> => {
       asc(documentProcessingRuns.id),
     )
     .limit(RECONCILE_BATCH_SIZE);
+  // Only the selection is capped; the compare-and-set below can recover
+  // fewer rows than it read, which says nothing about the backlog.
+  const hasMore = cappedSelectionHasMore({
+    limit: RECONCILE_BATCH_SIZE,
+    selected: retryableRuns.length,
+  });
   if (retryableRuns.length === 0) {
-    return 0;
+    return { count: 0, hasMore };
   }
 
   const capturedSchedules = or(
@@ -2014,7 +2089,7 @@ const recoverRetryableOcrFailures = async (): Promise<number> => {
     ),
   );
   if (!capturedSchedules) {
-    return 0;
+    return { count: 0, hasMore };
   }
 
   const recovered = await rootDb
@@ -2032,7 +2107,7 @@ const recoverRetryableOcrFailures = async (): Promise<number> => {
       ),
     )
     .returning({ id: documentProcessingRuns.id });
-  return recovered.length;
+  return { count: recovered.length, hasMore };
 };
 
 type FailedSearchIndexCandidate = {
@@ -2179,7 +2254,7 @@ const recoverFailedSearchIndex = async ({
     },
   });
 
-const recoverFailedOcrSearchIndexes = async (): Promise<number> => {
+const recoverFailedOcrSearchIndexes = async () => {
   const now = new Date();
   // The failed run is the durable retry token, but the entity projection is
   // the indexing source of truth. Automatic OCR may have preserved valid text
@@ -2274,8 +2349,15 @@ const recoverFailedOcrSearchIndexes = async (): Promise<number> => {
     )
     .limit(SEARCH_INDEX_REPLAY_BATCH_SIZE);
 
+  // A replay that fails is rescheduled with backoff, so it is not work
+  // this phase could still take; only a full selection means more replays
+  // were due than one batch could claim.
+  const hasMore = cappedSelectionHasMore({
+    limit: SEARCH_INDEX_REPLAY_BATCH_SIZE,
+    selected: candidates.length,
+  });
   if (candidates.length === 0) {
-    return 0;
+    return { count: 0, hasMore };
   }
   const capturedSchedules = or(
     ...candidates.map(({ attemptCount, id, nextAttemptAtToken }) =>
@@ -2292,7 +2374,7 @@ const recoverFailedOcrSearchIndexes = async (): Promise<number> => {
     ),
   );
   if (!capturedSchedules) {
-    return 0;
+    return { count: 0, hasMore };
   }
 
   const claimToken = `search-index-replay:${Bun.randomUUIDv7()}`;
@@ -2328,10 +2410,10 @@ const recoverFailedOcrSearchIndexes = async (): Promise<number> => {
     limit: SEARCH_INDEX_REPLAY_CONCURRENCY,
     operation: recoverFailedSearchIndex,
   });
-  return recovered.filter(Boolean).length;
+  return { count: recovered.filter(Boolean).length, hasMore };
 };
 
-const recoverStaleDocumentProcessingRuns = async (): Promise<number> => {
+const recoverStaleDocumentProcessingRuns = async () => {
   const staleBefore = new Date(Date.now() - WORKER_LEASE_TIMEOUT_MS);
   const recoveredAt = new Date();
   const staleRuns = await rootDb
@@ -2353,8 +2435,14 @@ const recoverStaleDocumentProcessingRuns = async (): Promise<number> => {
       asc(documentProcessingRuns.id),
     )
     .limit(RECONCILE_BATCH_SIZE);
+  // The three updates below act on subsets of this selection, so their
+  // combined row count tracks the effect, not the remaining backlog.
+  const hasMore = cappedSelectionHasMore({
+    limit: RECONCILE_BATCH_SIZE,
+    selected: staleRuns.length,
+  });
   if (staleRuns.length === 0) {
-    return 0;
+    return { count: 0, hasMore };
   }
 
   const exhaustedAutomaticIds = staleRuns.flatMap((run) =>
@@ -2439,7 +2527,10 @@ const recoverStaleDocumentProcessingRuns = async (): Promise<number> => {
       ),
     )
     .returning({ id: documentProcessingRuns.id });
-  return exhausted.length + searchReplays.length + recovered.length;
+  return {
+    count: exhausted.length + searchReplays.length + recovered.length,
+    hasMore,
+  };
 };
 
 const handleDocumentProcessingFailure = ({
@@ -2467,51 +2558,60 @@ const RECONCILIATION_PHASE = {
 type ReconciliationPhaseName =
   (typeof RECONCILIATION_PHASE)[keyof typeof RECONCILIATION_PHASE];
 
-type ReconciliationCounts = Record<ReconciliationPhaseName, number>;
+type ReconciliationResults = Record<
+  ReconciliationPhaseName,
+  ReconciliationPhaseResult
+>;
 
 type ReconciliationPhase = {
   name: ReconciliationPhaseName;
-  run: () => Promise<number>;
+  run: () => Promise<ReconciliationPhaseResult>;
 };
-
-/**
- * Each phase drains at most one batch per tick, so a phase that returns
- * its whole batch is reporting "there was more than I could take", not
- * "done". Kept beside the phase list and derived from the same limits the
- * queries use, so a phase cannot change its limit without changing this.
- */
-const RECONCILIATION_PHASE_BATCH_SIZE = {
-  [RECONCILIATION_PHASE.DELIVERY]: RECONCILE_BATCH_SIZE,
-  [RECONCILIATION_PHASE.REINDEX]: SEARCH_INDEX_REPLAY_BATCH_SIZE,
-  [RECONCILIATION_PHASE.REPAIR]: RECONCILE_BATCH_SIZE,
-  [RECONCILIATION_PHASE.RETRY]: RECONCILE_BATCH_SIZE,
-  [RECONCILIATION_PHASE.STALE_LEASE]: RECONCILE_BATCH_SIZE,
-} as const satisfies Record<ReconciliationPhaseName, number>;
 
 const RECONCILIATION_PHASE_NAMES = Object.values(RECONCILIATION_PHASE);
 
-export const reconciliationLeftWorkBehind = ({
-  counts,
-  failedPhases,
-}: {
-  counts: ReconciliationCounts;
-  failedPhases: readonly ReconciliationPhaseName[];
-}): boolean =>
-  failedPhases.length > 0 ||
-  RECONCILIATION_PHASE_NAMES.some(
-    (phase) => counts[phase] >= RECONCILIATION_PHASE_BATCH_SIZE[phase],
-  );
-
-let unfinishedReconciliation = false;
+/**
+ * Whether the tick stopped short of draining every backlog. Each phase
+ * states its own saturation, so this only has to collect the answers: no
+ * count is reinterpreted here, because effect counts (runs created, rows
+ * recovered) are routinely smaller than the rows a phase read.
+ */
+export const reconciliationLeftWorkBehind = (
+  results: ReconciliationResults,
+): boolean =>
+  RECONCILIATION_PHASE_NAMES.some((phase) => results[phase].hasMore);
 
 /**
- * Whether the last completed reconciliation tick still had work queued
- * behind it. Batch mode reads this so the worker does not treat an empty
- * job queue as "nothing left to do" while the reconciliation loop is
- * still draining a backlog one capped batch at a time.
+ * Reconciliation progress as the idle sampler sees it. The sampler reads
+ * `hasUnfinishedWork()` synchronously, so `runTick` publishes "unfinished"
+ * in its synchronous prologue, before the first await: a tick that is
+ * still running, however long it runs, can never expose the previous
+ * tick's drained answer. The flag clears only when a tick resolves with a
+ * fully drained result; a rejected tick leaves it set, because a tick that
+ * never reported cannot prove the backlog is empty.
  */
-export const hasUnfinishedDocumentProcessingReconciliation = (): boolean =>
-  unfinishedReconciliation;
+export const createReconciliationProgress = () => {
+  let unfinished = false;
+  return {
+    hasUnfinishedWork: (): boolean => unfinished,
+    /** `tick` resolves with whether it left work behind. */
+    runTick: async (tick: () => Promise<boolean>): Promise<void> => {
+      unfinished = true;
+      unfinished = await tick();
+    },
+  };
+};
+
+const reconciliationProgress = createReconciliationProgress();
+
+/**
+ * Whether reconciliation is running or last stopped with work behind it.
+ * Batch mode reads this so the worker does not treat an empty job queue as
+ * "nothing left to do" while the reconciliation loop is still draining a
+ * backlog one capped batch at a time.
+ */
+export const hasUnfinishedDocumentProcessingReconciliation =
+  reconciliationProgress.hasUnfinishedWork;
 
 export const runDocumentProcessingReconciliationPhases = async ({
   onPhaseError,
@@ -2519,13 +2619,17 @@ export const runDocumentProcessingReconciliationPhases = async ({
 }: {
   onPhaseError: (error: unknown, phase: ReconciliationPhaseName) => void;
   phases: readonly ReconciliationPhase[];
-}): Promise<ReconciliationCounts> => {
-  const counts: ReconciliationCounts = {
-    [RECONCILIATION_PHASE.DELIVERY]: 0,
-    [RECONCILIATION_PHASE.REINDEX]: 0,
-    [RECONCILIATION_PHASE.REPAIR]: 0,
-    [RECONCILIATION_PHASE.RETRY]: 0,
-    [RECONCILIATION_PHASE.STALE_LEASE]: 0,
+}): Promise<ReconciliationResults> => {
+  const drained = (): ReconciliationPhaseResult => ({
+    count: 0,
+    hasMore: false,
+  });
+  const results: ReconciliationResults = {
+    [RECONCILIATION_PHASE.DELIVERY]: drained(),
+    [RECONCILIATION_PHASE.REINDEX]: drained(),
+    [RECONCILIATION_PHASE.REPAIR]: drained(),
+    [RECONCILIATION_PHASE.RETRY]: drained(),
+    [RECONCILIATION_PHASE.STALE_LEASE]: drained(),
   };
   for (const phase of phases) {
     // oxlint-disable-next-line no-await-in-loop -- repair phases are deliberately isolated and ordered
@@ -2535,11 +2639,14 @@ export const runDocumentProcessingReconciliationPhases = async ({
     });
     if (Result.isError(result)) {
       onPhaseError(result.error, phase.name);
+      // A phase that failed drained nothing it can prove, so its backlog
+      // is unknown: report it as work left behind rather than as drained.
+      results[phase.name] = { count: 0, hasMore: true };
       continue;
     }
-    counts[phase.name] = result.value;
+    results[phase.name] = result.value;
   }
-  return counts;
+  return results;
 };
 
 const reconcileDocumentProcessing = async ({
@@ -2547,64 +2654,64 @@ const reconcileDocumentProcessing = async ({
 }: {
   onComplete: () => void;
 }): Promise<void> => {
-  const failedPhases: ReconciliationPhaseName[] = [];
   try {
-    await ensureReconciliationRedisConnected();
-    const counts = await runDocumentProcessingReconciliationPhases({
-      phases: [
-        {
-          name: RECONCILIATION_PHASE.REPAIR,
-          run: recoverMissingNativeExtractionRuns,
+    // Marks reconciliation unfinished before the first await, so the idle
+    // sampler sees an in-flight tick as work in progress no matter how
+    // long the tick runs or where a sample lands inside it. The connect
+    // gate stays the cycle's first action, ahead of every phase, and a
+    // cycle that fails there reports no verdict at all.
+    await reconciliationProgress.runTick(async () => {
+      await ensureReconciliationRedisConnected();
+      const results = await runDocumentProcessingReconciliationPhases({
+        phases: [
+          {
+            name: RECONCILIATION_PHASE.REPAIR,
+            run: recoverMissingNativeExtractionRuns,
+          },
+          {
+            name: RECONCILIATION_PHASE.REINDEX,
+            run: recoverFailedOcrSearchIndexes,
+          },
+          {
+            name: RECONCILIATION_PHASE.RETRY,
+            run: recoverRetryableOcrFailures,
+          },
+          {
+            name: RECONCILIATION_PHASE.STALE_LEASE,
+            run: recoverStaleDocumentProcessingRuns,
+          },
+          {
+            name: RECONCILIATION_PHASE.DELIVERY,
+            run: dispatchScheduledDocumentProcessingRetries,
+          },
+        ],
+        onPhaseError: (error, phase) => {
+          captureError(error, { phase });
+          logger.error("document_processing.reconcile_phase_failed", {
+            "error.type": errorTag(error),
+            phase,
+          });
         },
-        {
-          name: RECONCILIATION_PHASE.REINDEX,
-          run: recoverFailedOcrSearchIndexes,
-        },
-        {
-          name: RECONCILIATION_PHASE.RETRY,
-          run: recoverRetryableOcrFailures,
-        },
-        {
-          name: RECONCILIATION_PHASE.STALE_LEASE,
-          run: recoverStaleDocumentProcessingRuns,
-        },
-        {
-          name: RECONCILIATION_PHASE.DELIVERY,
-          run: dispatchScheduledDocumentProcessingRetries,
-        },
-      ],
-      onPhaseError: (error, phase) => {
-        failedPhases.push(phase);
-        captureError(error, { phase });
-        logger.error("document_processing.reconcile_phase_failed", {
-          "error.type": errorTag(error),
-          phase,
-        });
-      },
-    });
-    unfinishedReconciliation = reconciliationLeftWorkBehind({
-      counts,
-      failedPhases,
-    });
-    if (
-      counts[RECONCILIATION_PHASE.DELIVERY] > 0 ||
-      counts[RECONCILIATION_PHASE.REPAIR] > 0 ||
-      counts[RECONCILIATION_PHASE.REINDEX] > 0 ||
-      counts[RECONCILIATION_PHASE.RETRY] > 0 ||
-      counts[RECONCILIATION_PHASE.STALE_LEASE] > 0
-    ) {
-      logger.info("document_processing.reconciled", {
-        deliveredCount: String(counts[RECONCILIATION_PHASE.DELIVERY]),
-        recoveredCount: String(counts[RECONCILIATION_PHASE.STALE_LEASE]),
-        reindexedCount: String(counts[RECONCILIATION_PHASE.REINDEX]),
-        repairedCount: String(counts[RECONCILIATION_PHASE.REPAIR]),
-        retriedCount: String(counts[RECONCILIATION_PHASE.RETRY]),
       });
-    }
+      if (
+        RECONCILIATION_PHASE_NAMES.some((phase) => results[phase].count > 0)
+      ) {
+        logger.info("document_processing.reconciled", {
+          deliveredCount: String(results[RECONCILIATION_PHASE.DELIVERY].count),
+          recoveredCount: String(
+            results[RECONCILIATION_PHASE.STALE_LEASE].count,
+          ),
+          reindexedCount: String(results[RECONCILIATION_PHASE.REINDEX].count),
+          repairedCount: String(results[RECONCILIATION_PHASE.REPAIR].count),
+          retriedCount: String(results[RECONCILIATION_PHASE.RETRY].count),
+        });
+      }
+      return reconciliationLeftWorkBehind(results);
+    });
   } catch (error) {
-    // The tick never produced counts, so the backlog is unknown. Same rule
-    // the idle check applies to a failed sample: never exit on uncertainty.
-    unfinishedReconciliation = true;
+    // The tick never reported, so the backlog stays unknown and
+    // `runTick` leaves reconciliation marked unfinished. Same rule the
+    // idle check applies to a failed sample: never exit on uncertainty.
     captureError(error);
     logger.error("document_processing.reconcile_failed", {
       "error.type": errorTag(error),

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -1802,15 +1802,14 @@ type RepairScanPage = ReconciliationPhaseResult & {
 };
 
 /**
- * The repair sweep's resume position follows the scan alone: a full page
- * means the scan stopped at the cap, so the next tick resumes after the
- * last scanned field; a short page means it reached the end of the table,
- * so the cursor resets. Work left behind has a second, independent
- * source: runs this page created are queued for the delivery phase, which
- * runs later in the same tick and may not take them all, so a page that
- * ended the scan still leaves work behind when it created anything. Both
- * are derived here so the cursor and the signal cannot disagree, and
- * neither is inferred from the created-run count alone, which most
+ * The repair sweep's resume position and its backlog are the same fact:
+ * a full page means the scan stopped at the cap, so the next tick resumes
+ * after the last scanned field; a short page means it reached the end of
+ * the table, so the cursor resets and this phase has nothing more to take.
+ * The runs the page created are not part of it: they are due input for the
+ * reindex and delivery phases, which run later in the same tick, and their
+ * own signals answer for them. Derived together so cursor and signal
+ * cannot disagree, and never from the created-run count, which most
  * scanned fields never reach.
  */
 export const resolveRepairScanPage = ({
@@ -1826,7 +1825,7 @@ export const resolveRepairScanPage = ({
   });
   return {
     count: createdRunCount,
-    hasMore: scanSaturated || createdRunCount > 0,
+    hasMore: scanSaturated,
     nextCursor: scanSaturated ? (scannedFieldIds.at(-1) ?? null) : null,
   };
 };
@@ -2021,14 +2020,16 @@ export const dispatchQueuedDocumentProcessingRuns = async ({
   };
 };
 
-const dispatchScheduledDocumentProcessingRetries = async () => {
-  // Runs whose handoff failed are rescheduled into the future, so they are
-  // not due work this phase could still take; only a full selection means
-  // more was due than one batch could deliver.
-  const { attempted, hasMore } = await dispatchQueuedDocumentProcessingRuns({
+export const dispatchScheduledDocumentProcessingRetries = async (
+  dispatch = dispatchQueuedDocumentProcessingRuns,
+) => {
+  const { attempted, hasMore, retryAt } = await dispatch({
     selection: QUEUED_OCR_SELECTION.SCHEDULED_RETRIES,
   });
-  return { count: attempted, hasMore };
+  // A run whose handoff failed is still queued and still nobody else's
+  // work: it comes back to this phase on a later tick, so the phase order
+  // cannot cover it and this phase has to report it itself.
+  return { count: attempted, hasMore: hasMore || retryAt !== null };
 };
 
 // Manual searchable-PDF failures are retryable too, so the condition spans
@@ -2263,6 +2264,26 @@ const recoverFailedSearchIndex = async ({
     },
   });
 
+/**
+ * A replay this phase claimed and did not complete went back to `failed`
+ * with a backoff, which is this phase's own input again: no later phase
+ * selects it, so the phase order cannot cover it and the phase reports it
+ * itself. Claims lost to another worker are that worker's problem and are
+ * not counted here.
+ */
+export const resolveSearchIndexReplayBatch = ({
+  claimedCount,
+  recoveredCount,
+  saturated,
+}: {
+  claimedCount: number;
+  recoveredCount: number;
+  saturated: boolean;
+}): ReconciliationPhaseResult => ({
+  count: recoveredCount,
+  hasMore: saturated || recoveredCount < claimedCount,
+});
+
 const recoverFailedOcrSearchIndexes = async () => {
   const now = new Date();
   // The failed run is the durable retry token, but the entity projection is
@@ -2419,7 +2440,11 @@ const recoverFailedOcrSearchIndexes = async () => {
     limit: SEARCH_INDEX_REPLAY_CONCURRENCY,
     operation: recoverFailedSearchIndex,
   });
-  return { count: recovered.filter(Boolean).length, hasMore };
+  return resolveSearchIndexReplayBatch({
+    claimedCount: claimed.length,
+    recoveredCount: recovered.filter(Boolean).length,
+    saturated: hasMore,
+  });
 };
 
 const recoverStaleDocumentProcessingRuns = async () => {
@@ -2592,18 +2617,61 @@ const RECONCILIATION_PHASE_RUNNERS = {
 >;
 
 /**
- * The phases the worker actually runs, in order: repair first because it
- * creates runs the later phases settle, delivery last so it hands off
- * what the tick produced. Assembled from the runner map rather than
- * written out again, so the only way to leave a declared phase unrun is
- * to leave it out of this order, which the reconciliation tests compare
- * against the declared names in both directions.
+ * Which phases each phase's transitions feed, read off its writes against
+ * every phase's selection predicate. A produced row counts as an edge only
+ * when the consumer would select it in the same tick, so future-scheduled
+ * rows (a replay backed off, a handoff rescheduled, an enqueued run parked
+ * behind its visibility timeout) are not edges here.
+ *
+ * - repair inserts queued runs due now (delivery selects queued rows with
+ *   a due schedule) and, where a current projection already exists, failed
+ *   runs coded `search_index_failed` and due now (reindex selects those).
+ * - retry moves retryable failures to queued, due now: delivery.
+ * - stale-lease returns expired leases to queued, due now (delivery), and
+ *   expired search-index replays to failed, `search_index_failed`,
+ *   unscheduled, which reindex selects. Its exhausted-attempt writes carry
+ *   `worker_lease_expired` past the attempt cap, which no phase selects.
+ * - reindex claims rows for itself; what it does not complete comes back
+ *   to reindex with a backoff, and what it completes is terminal.
+ * - delivery only moves rows into the job queue or reschedules them for a
+ *   later delivery.
+ *
+ * Work a phase leaves for itself is not listed: no ordering can help it,
+ * so that phase reports it in its own `hasMore` instead.
+ */
+export const DOCUMENT_PROCESSING_RECONCILIATION_PHASE_FEEDS = {
+  [RECONCILIATION_PHASE.DELIVERY]: [],
+  [RECONCILIATION_PHASE.REINDEX]: [],
+  [RECONCILIATION_PHASE.REPAIR]: [
+    RECONCILIATION_PHASE.REINDEX,
+    RECONCILIATION_PHASE.DELIVERY,
+  ],
+  [RECONCILIATION_PHASE.RETRY]: [RECONCILIATION_PHASE.DELIVERY],
+  [RECONCILIATION_PHASE.STALE_LEASE]: [
+    RECONCILIATION_PHASE.REINDEX,
+    RECONCILIATION_PHASE.DELIVERY,
+  ],
+} as const satisfies Record<
+  ReconciliationPhaseName,
+  readonly ReconciliationPhaseName[]
+>;
+
+/**
+ * The phases the worker actually runs, in the order those edges force:
+ * every producer ahead of every phase it feeds, so work a tick creates is
+ * taken by the same tick rather than waiting for the next one. Repair and
+ * stale-lease both feed reindex, all three of repair, retry and stale-lease
+ * feed delivery, and reindex and delivery feed nobody, which leaves repair,
+ * retry, stale-lease, reindex, delivery. Assembled from the runner map
+ * rather than written out again, so the only way to leave a declared phase
+ * unrun is to leave it out of this order, which the reconciliation tests
+ * check against both the declared names and the edges above.
  */
 export const DOCUMENT_PROCESSING_RECONCILIATION_PHASES = [
   RECONCILIATION_PHASE.REPAIR,
-  RECONCILIATION_PHASE.REINDEX,
   RECONCILIATION_PHASE.RETRY,
   RECONCILIATION_PHASE.STALE_LEASE,
+  RECONCILIATION_PHASE.REINDEX,
   RECONCILIATION_PHASE.DELIVERY,
 ].map((name) => ({
   name,

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -2641,6 +2641,13 @@ export const createReconciliationProgress = () => {
       await running;
       return unfinished;
     },
+    /**
+     * Whether a tick is running right now, for a caller that has already
+     * taken its other readings and is deciding in this frame: the awaited
+     * answer above can only describe the tick it waited for, so a tick
+     * that started afterwards is visible here and nowhere else.
+     */
+    isTickRunning: (): boolean => running !== null,
     /** `tick` resolves with whether it left work behind. */
     runTick: async (tick: () => Promise<boolean>): Promise<void> => {
       // Both published before the first await, so a caller that arrives
@@ -2671,6 +2678,10 @@ const reconciliationProgress = createReconciliationProgress();
  */
 export const hasUnfinishedDocumentProcessingReconciliation =
   reconciliationProgress.hasUnfinishedWork;
+
+/** Companion synchronous read for the idle sampler's decision frame. */
+export const isDocumentProcessingReconciliationInFlight =
+  reconciliationProgress.isTickRunning;
 
 export const runDocumentProcessingReconciliationPhases = async ({
   onPhaseError,

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -2474,6 +2474,45 @@ type ReconciliationPhase = {
   run: () => Promise<number>;
 };
 
+/**
+ * Each phase drains at most one batch per tick, so a phase that returns
+ * its whole batch is reporting "there was more than I could take", not
+ * "done". Kept beside the phase list and derived from the same limits the
+ * queries use, so a phase cannot change its limit without changing this.
+ */
+const RECONCILIATION_PHASE_BATCH_SIZE = {
+  [RECONCILIATION_PHASE.DELIVERY]: RECONCILE_BATCH_SIZE,
+  [RECONCILIATION_PHASE.REINDEX]: SEARCH_INDEX_REPLAY_BATCH_SIZE,
+  [RECONCILIATION_PHASE.REPAIR]: RECONCILE_BATCH_SIZE,
+  [RECONCILIATION_PHASE.RETRY]: RECONCILE_BATCH_SIZE,
+  [RECONCILIATION_PHASE.STALE_LEASE]: RECONCILE_BATCH_SIZE,
+} as const satisfies Record<ReconciliationPhaseName, number>;
+
+const RECONCILIATION_PHASE_NAMES = Object.values(RECONCILIATION_PHASE);
+
+export const reconciliationLeftWorkBehind = ({
+  counts,
+  failedPhases,
+}: {
+  counts: ReconciliationCounts;
+  failedPhases: readonly ReconciliationPhaseName[];
+}): boolean =>
+  failedPhases.length > 0 ||
+  RECONCILIATION_PHASE_NAMES.some(
+    (phase) => counts[phase] >= RECONCILIATION_PHASE_BATCH_SIZE[phase],
+  );
+
+let unfinishedReconciliation = false;
+
+/**
+ * Whether the last completed reconciliation tick still had work queued
+ * behind it. Batch mode reads this so the worker does not treat an empty
+ * job queue as "nothing left to do" while the reconciliation loop is
+ * still draining a backlog one capped batch at a time.
+ */
+export const hasUnfinishedDocumentProcessingReconciliation = (): boolean =>
+  unfinishedReconciliation;
+
 export const runDocumentProcessingReconciliationPhases = async ({
   onPhaseError,
   phases,
@@ -2508,6 +2547,7 @@ const reconcileDocumentProcessing = async ({
 }: {
   onComplete: () => void;
 }): Promise<void> => {
+  const failedPhases: ReconciliationPhaseName[] = [];
   try {
     await ensureReconciliationRedisConnected();
     const counts = await runDocumentProcessingReconciliationPhases({
@@ -2534,12 +2574,17 @@ const reconcileDocumentProcessing = async ({
         },
       ],
       onPhaseError: (error, phase) => {
+        failedPhases.push(phase);
         captureError(error, { phase });
         logger.error("document_processing.reconcile_phase_failed", {
           "error.type": errorTag(error),
           phase,
         });
       },
+    });
+    unfinishedReconciliation = reconciliationLeftWorkBehind({
+      counts,
+      failedPhases,
     });
     if (
       counts[RECONCILIATION_PHASE.DELIVERY] > 0 ||
@@ -2557,6 +2602,9 @@ const reconcileDocumentProcessing = async ({
       });
     }
   } catch (error) {
+    // The tick never produced counts, so the backlog is unknown. Same rule
+    // the idle check applies to a failed sample: never exit on uncertainty.
+    unfinishedReconciliation = true;
     captureError(error);
     logger.error("document_processing.reconcile_failed", {
       "error.type": errorTag(error),

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -81,7 +81,7 @@ import { withTimeout } from "@/api/lib/with-timeout";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 const WORKER_CONCURRENCY = 2;
-export const RECONCILE_INTERVAL_MS = 30_000;
+const RECONCILE_INTERVAL_MS = 30_000;
 export const RECONCILE_BATCH_SIZE = 100;
 const ENQUEUE_VISIBILITY_TIMEOUT_MS = 5 * 60 * 1000;
 const ENQUEUE_FAILURE_RETRY_MS = 30_000;
@@ -1621,6 +1621,7 @@ const persistMissingNativeExtractionRuns = async (
     const currentProjectionByEntityId = new Map(
       currentProjections.map((projection) => [projection.entityId, projection]),
     );
+    const queuedAt = new Date();
     const values = candidates.flatMap((candidate) => {
       const entity = lockedEntityById.get(candidate.entityId);
       const field = currentFieldById.get(candidate.fieldId);
@@ -1674,6 +1675,12 @@ const persistMissingNativeExtractionRuns = async (
           entityVersionId: candidate.entityVersionId,
           fieldId: candidate.fieldId,
           kind: "native-extraction",
+          // Due now rather than unscheduled, so the reconciliation tick
+          // that created this run also delivers it: the delivery phase
+          // runs last and selects scheduled work. Left unscheduled, the
+          // run would sit queued until the dispatch scheduler noticed it,
+          // which a batch worker may not outlive.
+          nextAttemptAt: queuedAt,
           organizationId: candidate.organizationId,
           processorVersion: DOCUMENT_NATIVE_EXTRACTION_PROCESSOR_VERSION,
           requestedBy: null,
@@ -1699,7 +1706,6 @@ const persistMissingNativeExtractionRuns = async (
       ],
       sql` AND `,
     );
-    const queuedAt = new Date();
     const queued = await tx
       .insert(documentProcessingRuns)
       .values(values)
@@ -1796,13 +1802,16 @@ type RepairScanPage = ReconciliationPhaseResult & {
 };
 
 /**
- * The repair sweep's resume position and its saturation signal are the
- * same fact: a full page means the scan stopped at the cap, so the next
- * tick resumes after the last scanned field; a short page means the scan
- * reached the end of the table, so the cursor resets and nothing is left
- * behind. Derived together so the two can never disagree, and kept apart
- * from `createdRunCount` because most scanned fields are filtered out
- * before a run is created.
+ * The repair sweep's resume position follows the scan alone: a full page
+ * means the scan stopped at the cap, so the next tick resumes after the
+ * last scanned field; a short page means it reached the end of the table,
+ * so the cursor resets. Work left behind has a second, independent
+ * source: runs this page created are queued for the delivery phase, which
+ * runs later in the same tick and may not take them all, so a page that
+ * ended the scan still leaves work behind when it created anything. Both
+ * are derived here so the cursor and the signal cannot disagree, and
+ * neither is inferred from the created-run count alone, which most
+ * scanned fields never reach.
  */
 export const resolveRepairScanPage = ({
   createdRunCount,
@@ -1811,14 +1820,14 @@ export const resolveRepairScanPage = ({
   createdRunCount: number;
   scannedFieldIds: readonly SafeId<"field">[];
 }): RepairScanPage => {
-  const hasMore = cappedSelectionHasMore({
+  const scanSaturated = cappedSelectionHasMore({
     limit: RECONCILE_BATCH_SIZE,
     selected: scannedFieldIds.length,
   });
   return {
     count: createdRunCount,
-    hasMore,
-    nextCursor: hasMore ? (scannedFieldIds.at(-1) ?? null) : null,
+    hasMore: scanSaturated || createdRunCount > 0,
+    nextCursor: scanSaturated ? (scannedFieldIds.at(-1) ?? null) : null,
   };
 };
 
@@ -2570,6 +2579,37 @@ type ReconciliationPhase = {
 
 const RECONCILIATION_PHASE_NAMES = Object.values(RECONCILIATION_PHASE);
 
+/** Total by type: a declared phase cannot exist without a producer. */
+const RECONCILIATION_PHASE_RUNNERS = {
+  [RECONCILIATION_PHASE.DELIVERY]: dispatchScheduledDocumentProcessingRetries,
+  [RECONCILIATION_PHASE.REINDEX]: recoverFailedOcrSearchIndexes,
+  [RECONCILIATION_PHASE.REPAIR]: recoverMissingNativeExtractionRuns,
+  [RECONCILIATION_PHASE.RETRY]: recoverRetryableOcrFailures,
+  [RECONCILIATION_PHASE.STALE_LEASE]: recoverStaleDocumentProcessingRuns,
+} as const satisfies Record<
+  ReconciliationPhaseName,
+  ReconciliationPhase["run"]
+>;
+
+/**
+ * The phases the worker actually runs, in order: repair first because it
+ * creates runs the later phases settle, delivery last so it hands off
+ * what the tick produced. Assembled from the runner map rather than
+ * written out again, so the only way to leave a declared phase unrun is
+ * to leave it out of this order, which the reconciliation tests compare
+ * against the declared names in both directions.
+ */
+export const DOCUMENT_PROCESSING_RECONCILIATION_PHASES = [
+  RECONCILIATION_PHASE.REPAIR,
+  RECONCILIATION_PHASE.REINDEX,
+  RECONCILIATION_PHASE.RETRY,
+  RECONCILIATION_PHASE.STALE_LEASE,
+  RECONCILIATION_PHASE.DELIVERY,
+].map((name) => ({
+  name,
+  run: RECONCILIATION_PHASE_RUNNERS[name],
+})) satisfies readonly ReconciliationPhase[];
+
 /**
  * Whether the tick stopped short of draining every backlog. Each phase
  * states its own saturation, so this only has to collect the answers: no
@@ -2582,22 +2622,40 @@ export const reconciliationLeftWorkBehind = (
   RECONCILIATION_PHASE_NAMES.some((phase) => results[phase].hasMore);
 
 /**
- * Reconciliation progress as the idle sampler sees it. The sampler reads
- * `hasUnfinishedWork()` synchronously, so `runTick` publishes "unfinished"
- * in its synchronous prologue, before the first await: a tick that is
- * still running, however long it runs, can never expose the previous
- * tick's drained answer. The flag clears only when a tick resolves with a
- * fully drained result; a rejected tick leaves it set, because a tick that
- * never reported cannot prove the backlog is empty.
+ * Reconciliation progress as the idle sampler sees it. A caller that
+ * arrives while a tick is running waits for that tick instead of reading
+ * the previous one's answer, which makes the answer independent of how
+ * the caller's cadence lines up with the reconciliation cadence: a
+ * snapshot read would let a sampler that keeps landing inside slow ticks
+ * see "running" at every sample and never let the worker exit, while
+ * still risking a stale drained answer from the tick before. The flag
+ * clears only when a tick resolves fully drained; a rejected tick leaves
+ * it set, because a tick that never reported cannot prove the backlog is
+ * empty. One tick at a time: the caller serialises them.
  */
 export const createReconciliationProgress = () => {
   let unfinished = false;
+  let running: Promise<void> | null = null;
   return {
-    hasUnfinishedWork: (): boolean => unfinished,
+    hasUnfinishedWork: async (): Promise<boolean> => {
+      await running;
+      return unfinished;
+    },
     /** `tick` resolves with whether it left work behind. */
     runTick: async (tick: () => Promise<boolean>): Promise<void> => {
+      // Both published before the first await, so a caller that arrives
+      // during this tick waits for it rather than reading the last one.
       unfinished = true;
-      unfinished = await tick();
+      let finish: () => void = () => undefined;
+      running = new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+      try {
+        unfinished = await tick();
+      } finally {
+        running = null;
+        finish();
+      }
     },
   };
 };
@@ -2605,10 +2663,11 @@ export const createReconciliationProgress = () => {
 const reconciliationProgress = createReconciliationProgress();
 
 /**
- * Whether reconciliation is running or last stopped with work behind it.
- * Batch mode reads this so the worker does not treat an empty job queue as
- * "nothing left to do" while the reconciliation loop is still draining a
- * backlog one capped batch at a time.
+ * Whether the latest reconciliation tick left work behind, waiting for a
+ * tick in flight to report. Batch mode reads this so the worker does not
+ * treat an empty job queue as "nothing left to do" while the
+ * reconciliation loop is still draining a backlog one capped batch at a
+ * time.
  */
 export const hasUnfinishedDocumentProcessingReconciliation =
   reconciliationProgress.hasUnfinishedWork;
@@ -2663,28 +2722,7 @@ const reconcileDocumentProcessing = async ({
     await reconciliationProgress.runTick(async () => {
       await ensureReconciliationRedisConnected();
       const results = await runDocumentProcessingReconciliationPhases({
-        phases: [
-          {
-            name: RECONCILIATION_PHASE.REPAIR,
-            run: recoverMissingNativeExtractionRuns,
-          },
-          {
-            name: RECONCILIATION_PHASE.REINDEX,
-            run: recoverFailedOcrSearchIndexes,
-          },
-          {
-            name: RECONCILIATION_PHASE.RETRY,
-            run: recoverRetryableOcrFailures,
-          },
-          {
-            name: RECONCILIATION_PHASE.STALE_LEASE,
-            run: recoverStaleDocumentProcessingRuns,
-          },
-          {
-            name: RECONCILIATION_PHASE.DELIVERY,
-            run: dispatchScheduledDocumentProcessingRetries,
-          },
-        ],
+        phases: DOCUMENT_PROCESSING_RECONCILIATION_PHASES,
         onPhaseError: (error, phase) => {
           captureError(error, { phase });
           logger.error("document_processing.reconcile_phase_failed", {

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -2636,6 +2636,7 @@ export const reconciliationLeftWorkBehind = (
 export const createReconciliationProgress = () => {
   let unfinished = false;
   let running: Promise<void> | null = null;
+  let generation = 0;
   return {
     hasUnfinishedWork: async (): Promise<boolean> => {
       await running;
@@ -2648,11 +2649,20 @@ export const createReconciliationProgress = () => {
      * that started afterwards is visible here and nowhere else.
      */
     isTickRunning: (): boolean => running !== null,
+    /**
+     * How many ticks have started. A caller that snapshots this and
+     * re-reads it before deciding sees any tick that began in between,
+     * including one that also finished there and so left neither a
+     * running flag nor a verdict of its own behind.
+     */
+    tickGeneration: (): number => generation,
     /** `tick` resolves with whether it left work behind. */
     runTick: async (tick: () => Promise<boolean>): Promise<void> => {
-      // Both published before the first await, so a caller that arrives
-      // during this tick waits for it rather than reading the last one.
+      // All three published before the first await, so a caller that
+      // arrives during this tick waits for it rather than reading the last
+      // one, and one that only overlaps it still sees that it happened.
       unfinished = true;
+      generation += 1;
       let finish: () => void = () => undefined;
       running = new Promise<void>((resolve) => {
         finish = resolve;
@@ -2679,9 +2689,12 @@ const reconciliationProgress = createReconciliationProgress();
 export const hasUnfinishedDocumentProcessingReconciliation =
   reconciliationProgress.hasUnfinishedWork;
 
-/** Companion synchronous read for the idle sampler's decision frame. */
+/** Companion synchronous reads for the idle sampler's decision frame. */
 export const isDocumentProcessingReconciliationInFlight =
   reconciliationProgress.isTickRunning;
+
+export const documentProcessingReconciliationGeneration =
+  reconciliationProgress.tickGeneration;
 
 export const runDocumentProcessingReconciliationPhases = async ({
   onPhaseError,

--- a/apps/api/src/lib/document-processing-reconciliation-feeds.db.test.ts
+++ b/apps/api/src/lib/document-processing-reconciliation-feeds.db.test.ts
@@ -1,0 +1,350 @@
+import { afterAll, beforeAll, beforeEach, expect, mock, test } from "bun:test";
+import { eq } from "drizzle-orm";
+
+import {
+  documentProcessingRuns,
+  entityVersions,
+  extractedContent,
+  fields,
+  workspaces,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import { DOCUMENT_OCR_PROCESSOR_VERSION } from "@/api/lib/document-processing-contract";
+import type {
+  DOCUMENT_PROCESSING_RECONCILIATION_PHASE_FEEDS as Feeds,
+  DOCUMENT_PROCESSING_RECONCILIATION_PHASES as Phases,
+} from "@/api/lib/document-processing-queue";
+import {
+  createTestIds,
+  setupRlsTestData,
+} from "@/api/tests/security/rls-helpers";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+/**
+ * The reconciliation phase order is only correct if the edge map it is
+ * ordered against describes what the phases really do. That map is a
+ * reading of each phase's writes against every phase's selection
+ * predicate, which is exactly the kind of mirror that drifts.
+ *
+ * This drives the real phases against a database: seed one phase's input,
+ * run it, record the rows it wrote, then run another phase and see whether
+ * it takes any of them. The observed edges must equal the declared ones,
+ * and the order the worker runs must place every producer ahead of every
+ * phase it feeds.
+ */
+
+const SETTLED_BEFORE_MS = 10 * 60 * 1000;
+const STALE_LEASE_MS = 60 * 60 * 1000;
+const EXTRACTABLE_FILE = {
+  encrypted: false,
+  fileName: "scan.pdf",
+  id: "",
+  mimeType: "application/pdf",
+  pdfFileId: null,
+  sha256Hex: "c".repeat(64),
+  sizeBytes: 64,
+  type: "file" as const,
+  version: 1 as const,
+};
+
+let testDb: TestDatabase;
+let ids: TestIds;
+let phases: typeof Phases;
+let feeds: typeof Feeds;
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  ids = createTestIds();
+  await setupRlsTestData(testDb, ids);
+  void mock.module("@/api/db/root", () => ({ rootDb: testDb, rlsDb: testDb }));
+  // Reconciliation reaches Redis for the repair cursor, BullMQ for the
+  // handoff, the search provider for a replay, and realtime for the
+  // broadcast. None of them decide which rows a phase selects, which is
+  // all this test observes.
+  // Each mock declares its module's whole surface, including the exports
+  // this test never reaches, so a module that grows one does not quietly
+  // lose it here. Spreading the real module instead would import it, and
+  // these are the modules being kept out of the process.
+  void mock.module("@/api/lib/redis-client", () => ({
+    connectWithColdStartRetries: async (connect: () => Promise<void>) =>
+      await connect(),
+    createBullMqConnection: () => ({}),
+    createRedisClient: () => ({
+      close: () => undefined,
+      connect: async () => undefined,
+      get: async () => null,
+      send: async () => 1,
+    }),
+    isRecoverableRedisPollError: () => false,
+  }));
+  void mock.module("@/api/lib/document-processing-enqueue", () => ({
+    countPendingDocumentProcessingJobs: async () => 0,
+    DOCUMENT_PROCESSING_OCR_JOB_NAME: "ocr",
+    DOCUMENT_PROCESSING_QUEUE_NAME: "document-processing",
+    enqueueDocumentProcessingRun: async () => undefined,
+  }));
+  void mock.module("@/api/lib/search/provider", () => ({
+    getSearchProvider: () => ({ indexEntity: async () => undefined }),
+  }));
+  void mock.module("@/api/lib/resource-realtime", () => ({
+    broadcastOrganizationResourceSetUpdated: () => undefined,
+    broadcastWorkspaceResourceChanges: () => undefined,
+    broadcastWorkspaceResourceDeleted: () => undefined,
+    broadcastWorkspaceResourceSetUpdated: () => undefined,
+    broadcastWorkspaceResourceUpdated: () => undefined,
+  }));
+  ({
+    DOCUMENT_PROCESSING_RECONCILIATION_PHASES: phases,
+    DOCUMENT_PROCESSING_RECONCILIATION_PHASE_FEEDS: feeds,
+  } = await import("@/api/lib/document-processing-queue"));
+}, 120_000);
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+const insertRun = async (
+  run: Partial<typeof documentProcessingRuns.$inferInsert>,
+) =>
+  await testDb.insert(documentProcessingRuns).values({
+    entityId: ids.entityA1,
+    entityVersionId: ids.entityVersionA1,
+    fieldId: ids.fileFieldA1,
+    id: toSafeId<"documentProcessingRun">(Bun.randomUUIDv7()),
+    kind: "ocr",
+    organizationId: ids.orgA,
+    processorVersion: DOCUMENT_OCR_PROCESSOR_VERSION,
+    requestedBy: null,
+    requestSource: "upload",
+    sourceFileId: ids.fileObjectA1,
+    sourceSha256Hex: EXTRACTABLE_FILE.sha256Hex,
+    workspaceId: ids.wsA1,
+    ...run,
+  });
+
+const past = (ms: number) => new Date(Date.now() - ms);
+
+/**
+ * Every transition a phase can make, as the state its input must be in
+ * for the phase to make it. One fixture per transition, so a declared edge
+ * that nothing produces shows up as an unobserved edge.
+ */
+const FIXTURES = [
+  {
+    label: "repair inserts a run for an unprocessed file field",
+    producer: "repair",
+    seed: async () => {
+      // No projection: the insert is a queued run rather than a failed
+      // search-index one.
+      await testDb
+        .delete(extractedContent)
+        .where(eq(extractedContent.entityId, ids.entityA1));
+    },
+  },
+  {
+    label: "repair inserts a search-index failure where a projection exists",
+    producer: "repair",
+    seed: async () => undefined,
+  },
+  {
+    label: "retry requeues a retryable automatic failure",
+    producer: "retry",
+    seed: async () => {
+      await insertRun({
+        attemptCount: 1,
+        errorCode: "processing_failed",
+        nextAttemptAt: past(1000),
+        status: "failed",
+      });
+    },
+  },
+  {
+    label: "stale-lease requeues an expired lease",
+    producer: "stale-lease",
+    seed: async () => {
+      await insertRun({
+        attemptCount: 1,
+        claimedAt: past(STALE_LEASE_MS),
+        claimedBy: "worker-gone",
+        status: "running",
+      });
+    },
+  },
+  {
+    label: "stale-lease returns an expired search-index replay to failed",
+    producer: "stale-lease",
+    seed: async () => {
+      await insertRun({
+        attemptCount: 1,
+        claimedAt: past(STALE_LEASE_MS),
+        claimedBy: "worker-gone",
+        errorCode: "search_index_failed",
+        status: "running",
+      });
+    },
+  },
+  {
+    label: "reindex replays a failed search index",
+    producer: "reindex",
+    seed: async () => {
+      await insertRun({
+        attemptCount: 0,
+        errorCode: "search_index_failed",
+        nextAttemptAt: null,
+        status: "failed",
+      });
+    },
+  },
+  {
+    label: "delivery hands a scheduled run to the queue",
+    producer: "delivery",
+    seed: async () => {
+      await insertRun({ nextAttemptAt: past(1000), status: "queued" });
+    },
+  },
+] as const;
+
+const resetFixtureState = async () => {
+  await testDb
+    .delete(documentProcessingRuns)
+    .where(eq(documentProcessingRuns.organizationId, ids.orgA));
+  await testDb
+    .delete(extractedContent)
+    .where(eq(extractedContent.entityId, ids.entityA1));
+  await testDb.insert(extractedContent).values({
+    charCount: 17,
+    ciphertext: Buffer.from("extracted text a1"),
+    entityId: ids.entityA1,
+    iv: Buffer.alloc(12, 0xa1),
+    language: "en",
+    organizationId: ids.orgA,
+    sourceEntityVersionId: ids.entityVersionA1,
+    sourceFieldId: ids.fileFieldA1,
+    sourceFileId: ids.fileObjectA1,
+    sourceSha256Hex: EXTRACTABLE_FILE.sha256Hex,
+    workspaceId: ids.wsA1,
+  });
+  // The repair sweep only scans settled versions of active workspaces, and
+  // only fields whose content it can extract without a PDF derivative.
+  await testDb
+    .update(workspaces)
+    .set({ status: "active" })
+    .where(eq(workspaces.id, ids.wsA1));
+  await testDb
+    .update(entityVersions)
+    .set({ createdAt: past(SETTLED_BEFORE_MS) })
+    .where(eq(entityVersions.id, ids.entityVersionA1));
+  await testDb
+    .update(fields)
+    .set({
+      content: { ...EXTRACTABLE_FILE, id: ids.fileObjectA1 },
+    })
+    .where(eq(fields.id, ids.fileFieldA1));
+};
+
+beforeEach(resetFixtureState);
+
+const snapshotRuns = async () =>
+  new Map(
+    (
+      await testDb
+        .select()
+        .from(documentProcessingRuns)
+        .where(eq(documentProcessingRuns.organizationId, ids.orgA))
+    ).map((run) => [run.id, JSON.stringify(run)]),
+  );
+
+const changedSince = (
+  before: Map<string, string>,
+  after: Map<string, string>,
+) =>
+  new Set(
+    [...after.entries()]
+      .filter(([id, row]) => before.get(id) !== row)
+      .map(([id]) => id),
+  );
+
+const runPhase = async (name: string) => {
+  const phase = phases.find((candidate) => candidate.name === name);
+  if (!phase) {
+    throw new Error(`unknown phase ${name}`);
+  }
+  return await phase.run();
+};
+
+type ObservedPair = {
+  producedRows: number;
+  takesProducedRows: boolean;
+};
+
+/**
+ * Seed one phase's input, run it, then run another phase and see whether
+ * it takes any row the first one wrote.
+ */
+const observePair = async ({
+  consumer,
+  producer,
+  seed,
+}: {
+  consumer: string;
+  producer: string;
+  seed: () => Promise<unknown>;
+}): Promise<ObservedPair> => {
+  await resetFixtureState();
+  await seed();
+  const before = await snapshotRuns();
+  await runPhase(producer);
+  const afterProducer = await snapshotRuns();
+  const producedRows = changedSince(before, afterProducer);
+  await runPhase(consumer);
+  const taken = changedSince(afterProducer, await snapshotRuns());
+  return {
+    producedRows: producedRows.size,
+    takesProducedRows: [...taken].some((id) => producedRows.has(id)),
+  };
+};
+
+test("the declared phase edges are the edges the phases actually produce", async () => {
+  const observed = new Set<string>();
+  const produced = new Set<string>();
+  const phaseNames = phases.map(({ name }) => name);
+
+  const pairs = FIXTURES.flatMap((fixture) =>
+    phaseNames
+      .filter((name) => name !== fixture.producer)
+      .map((consumer) => ({ consumer, fixture })),
+  );
+  for (const { consumer, fixture } of pairs) {
+    // oxlint-disable-next-line no-await-in-loop -- every pair needs the database to itself
+    const pair = await observePair({
+      consumer,
+      producer: fixture.producer,
+      seed: fixture.seed,
+    });
+    if (pair.producedRows > 0) {
+      produced.add(fixture.producer);
+    }
+    if (pair.takesProducedRows) {
+      observed.add(`${fixture.producer} -> ${consumer}`);
+    }
+  }
+
+  // Every fixture has to make its phase write something, or the edges it
+  // is meant to exercise would be trivially absent.
+  expect([...produced].toSorted()).toEqual(phaseNames.toSorted());
+
+  const declared = Object.entries(feeds).flatMap(([phase, consumers]) =>
+    consumers.map((consumer) => `${phase} -> ${consumer}`),
+  );
+  expect([...observed].toSorted()).toEqual(declared.toSorted());
+
+  const order = phases.map(({ name }): string => name);
+  for (const edge of observed) {
+    const [producer, consumer] = edge.split(" -> ");
+    expect(order.indexOf(consumer ?? "")).toBeGreaterThan(
+      order.indexOf(producer ?? ""),
+    );
+  }
+}, 120_000);

--- a/apps/api/src/lib/scheduler/tasks/document-processing-ocr.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/document-processing-ocr.test.ts
@@ -6,11 +6,17 @@ import {
 } from "@/api/lib/scheduler/tasks/document-processing-ocr";
 
 test("drains queued OCR in bounded batches", async () => {
-  const batchSizes = [100, 100, 17];
+  // `hasMore` is stated per batch rather than derived from `attempted`, so
+  // the fixture cannot silently re-encode the count-based continuation rule
+  // this loop no longer uses.
+  const batches = [
+    { attempted: 100, hasMore: true, retryAt: null },
+    { attempted: 100, hasMore: true, retryAt: null },
+    { attempted: 17, hasMore: false, retryAt: null },
+  ];
   const dispatch = mock(async ({ limit }: { limit?: number } = {}) => {
     expect(limit).toBe(100);
-    const attempted = batchSizes.shift() ?? 0;
-    return { attempted, hasMore: attempted === limit, retryAt: null };
+    return batches.shift() ?? { attempted: 0, hasMore: false, retryAt: null };
   });
 
   const result = await dispatchDocumentOcrBatches({
@@ -24,6 +30,31 @@ test("drains queued OCR in bounded batches", async () => {
     retryAt: null,
   });
   expect(dispatch).toHaveBeenCalledTimes(3);
+});
+
+test("continues on the dispatcher's saturation signal, not its attempt count", async () => {
+  // A short batch that still reports more behind it: the dispatcher can
+  // select fewer rows than its limit and know another page is due.
+  const batches = [
+    { attempted: 12, hasMore: true, retryAt: null },
+    { attempted: 3, hasMore: false, retryAt: null },
+  ];
+  const dispatch = mock(
+    async () =>
+      batches.shift() ?? { attempted: 0, hasMore: false, retryAt: null },
+  );
+
+  const result = await dispatchDocumentOcrBatches({
+    dispatch,
+    signal: new AbortController().signal,
+  });
+
+  expect(result).toEqual({
+    dispatched: 15,
+    reachedLimit: false,
+    retryAt: null,
+  });
+  expect(dispatch).toHaveBeenCalledTimes(2);
 });
 
 test("does not dispatch after scheduler cancellation", async () => {

--- a/apps/api/src/lib/scheduler/tasks/document-processing-ocr.test.ts
+++ b/apps/api/src/lib/scheduler/tasks/document-processing-ocr.test.ts
@@ -9,7 +9,8 @@ test("drains queued OCR in bounded batches", async () => {
   const batchSizes = [100, 100, 17];
   const dispatch = mock(async ({ limit }: { limit?: number } = {}) => {
     expect(limit).toBe(100);
-    return { attempted: batchSizes.shift() ?? 0, retryAt: null };
+    const attempted = batchSizes.shift() ?? 0;
+    return { attempted, hasMore: attempted === limit, retryAt: null };
   });
 
   const result = await dispatchDocumentOcrBatches({
@@ -28,7 +29,11 @@ test("drains queued OCR in bounded batches", async () => {
 test("does not dispatch after scheduler cancellation", async () => {
   const controller = new AbortController();
   controller.abort();
-  const dispatch = mock(async () => ({ attempted: 0, retryAt: null }));
+  const dispatch = mock(async () => ({
+    attempted: 0,
+    hasMore: false,
+    retryAt: null,
+  }));
 
   const result = await dispatchDocumentOcrBatches({
     dispatch,
@@ -44,7 +49,11 @@ test("does not dispatch after scheduler cancellation", async () => {
 });
 
 test("caps each scheduler tick at ten thousand OCR runs", async () => {
-  const dispatch = mock(async () => ({ attempted: 100, retryAt: null }));
+  const dispatch = mock(async () => ({
+    attempted: 100,
+    hasMore: true,
+    retryAt: null,
+  }));
 
   const result = await dispatchDocumentOcrBatches({
     dispatch,
@@ -63,13 +72,14 @@ test("preserves the earliest failed handoff retry across batches", async () => {
   const laterRetry = new Date("2030-01-01T00:01:00.000Z");
   const earlierRetry = new Date("2030-01-01T00:00:30.000Z");
   const batches = [
-    { attempted: 100, retryAt: laterRetry },
-    { attempted: 17, retryAt: earlierRetry },
+    { attempted: 100, hasMore: true, retryAt: laterRetry },
+    { attempted: 17, hasMore: false, retryAt: earlierRetry },
   ];
 
   const result = await dispatchDocumentOcrBatches({
     dispatch: mock(
-      async () => batches.shift() ?? { attempted: 0, retryAt: null },
+      async () =>
+        batches.shift() ?? { attempted: 0, hasMore: false, retryAt: null },
     ),
     signal: new AbortController().signal,
   });

--- a/apps/api/src/lib/scheduler/tasks/document-processing-ocr.ts
+++ b/apps/api/src/lib/scheduler/tasks/document-processing-ocr.ts
@@ -63,7 +63,9 @@ export const dispatchDocumentOcrBatches = async ({
       retryAt = batch.retryAt;
     }
 
-    if (batch.attempted < limit) {
+    // The dispatcher reports its own saturation; `attempted` counts the
+    // handoffs it tried, which is not the same question.
+    if (!batch.hasMore) {
       return;
     }
     return dispatchNextBatch();

--- a/apps/api/src/scripts/document-processing-worker.ts
+++ b/apps/api/src/scripts/document-processing-worker.ts
@@ -1,28 +1,16 @@
 import { envDocumentProcessingWorker } from "@/api/env-document-processing-worker";
 import { detached } from "@/api/lib/detached";
 import { countPendingDocumentProcessingJobs } from "@/api/lib/document-processing-enqueue";
-import {
-  createIdleExitCheck,
-  startIdleExitSampling,
-} from "@/api/lib/document-processing-idle-exit";
+import { createIdleExitCheck } from "@/api/lib/document-processing-idle-exit";
 import {
   hasUnfinishedDocumentProcessingReconciliation,
   initDocumentProcessingWorker,
-  RECONCILE_INTERVAL_MS,
 } from "@/api/lib/document-processing-queue";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { refreshS3 } from "@/api/lib/s3";
 
 const IDLE_CHECK_INTERVAL_MS = 60_000;
-// Both loops are intervals started at worker boot, and the sample period is
-// a multiple of the reconciliation period, so unoffset samples would land on
-// the same instant as every second reconciliation tick. A tick that is
-// running reads as unfinished by design, so a phase-locked sampler would see
-// one at every sample and never exit. Start half a reconciliation period
-// late, putting samples between ticks; a tick still running by then has slow
-// work genuinely in flight and should keep the worker alive.
-const IDLE_CHECK_OFFSET_MS = RECONCILE_INTERVAL_MS / 2;
 
 await refreshS3();
 const documentProcessingWorker = initDocumentProcessingWorker();
@@ -85,12 +73,10 @@ if (idleExitMinutes !== undefined) {
       detached(shutdown("idle-exit"), "document-processing.idle-exit");
     },
   });
-  stopIdleSampling = startIdleExitSampling({
-    intervalMs: IDLE_CHECK_INTERVAL_MS,
-    isShuttingDown: () => shuttingDown,
-    offsetMs: IDLE_CHECK_OFFSET_MS,
-    onSample: () => {
-      detached(idleTick(), "document-processing.idle-exit-check");
-    },
-  }).stop;
+  const idleTimer = setInterval(() => {
+    detached(idleTick(), "document-processing.idle-exit-check");
+  }, IDLE_CHECK_INTERVAL_MS);
+  stopIdleSampling = () => {
+    clearInterval(idleTimer);
+  };
 }

--- a/apps/api/src/scripts/document-processing-worker.ts
+++ b/apps/api/src/scripts/document-processing-worker.ts
@@ -5,12 +5,21 @@ import { createIdleExitCheck } from "@/api/lib/document-processing-idle-exit";
 import {
   hasUnfinishedDocumentProcessingReconciliation,
   initDocumentProcessingWorker,
+  RECONCILE_INTERVAL_MS,
 } from "@/api/lib/document-processing-queue";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { refreshS3 } from "@/api/lib/s3";
 
 const IDLE_CHECK_INTERVAL_MS = 60_000;
+// Both loops are intervals started at worker boot, and the sample period is
+// a multiple of the reconciliation period, so unoffset samples would land on
+// the same instant as every second reconciliation tick. A tick that is
+// running reads as unfinished by design, so a phase-locked sampler would see
+// one at every sample and never exit. Start half a reconciliation period
+// late, putting samples between ticks; a tick still running by then has slow
+// work genuinely in flight and should keep the worker alive.
+const IDLE_CHECK_OFFSET_MS = RECONCILE_INTERVAL_MS / 2;
 
 await refreshS3();
 const documentProcessingWorker = initDocumentProcessingWorker();
@@ -74,7 +83,9 @@ if (idleExitMinutes !== undefined) {
       detached(shutdown("idle-exit"), "document-processing.idle-exit");
     },
   });
-  idleTimer = setInterval(() => {
-    detached(idleTick(), "document-processing.idle-exit-check");
-  }, IDLE_CHECK_INTERVAL_MS);
+  setTimeout(() => {
+    idleTimer = setInterval(() => {
+      detached(idleTick(), "document-processing.idle-exit-check");
+    }, IDLE_CHECK_INTERVAL_MS);
+  }, IDLE_CHECK_OFFSET_MS);
 }

--- a/apps/api/src/scripts/document-processing-worker.ts
+++ b/apps/api/src/scripts/document-processing-worker.ts
@@ -5,6 +5,7 @@ import { createIdleExitCheck } from "@/api/lib/document-processing-idle-exit";
 import {
   hasUnfinishedDocumentProcessingReconciliation,
   initDocumentProcessingWorker,
+  isDocumentProcessingReconciliationInFlight,
 } from "@/api/lib/document-processing-queue";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
@@ -56,6 +57,7 @@ if (idleExitMinutes !== undefined) {
   const idleTick = createIdleExitCheck({
     countPending: countPendingDocumentProcessingJobs,
     hasUnfinishedReconciliation: hasUnfinishedDocumentProcessingReconciliation,
+    isReconciliationInFlight: isDocumentProcessingReconciliationInFlight,
     requiredIdleChecks,
     onCheckFailure: (error) => {
       logger.error("document_processing.idle_check_failed", {

--- a/apps/api/src/scripts/document-processing-worker.ts
+++ b/apps/api/src/scripts/document-processing-worker.ts
@@ -3,6 +3,7 @@ import { detached } from "@/api/lib/detached";
 import { countPendingDocumentProcessingJobs } from "@/api/lib/document-processing-enqueue";
 import { createIdleExitCheck } from "@/api/lib/document-processing-idle-exit";
 import {
+  documentProcessingReconciliationGeneration,
   hasUnfinishedDocumentProcessingReconciliation,
   initDocumentProcessingWorker,
   isDocumentProcessingReconciliationInFlight,
@@ -58,6 +59,7 @@ if (idleExitMinutes !== undefined) {
     countPending: countPendingDocumentProcessingJobs,
     hasUnfinishedReconciliation: hasUnfinishedDocumentProcessingReconciliation,
     isReconciliationInFlight: isDocumentProcessingReconciliationInFlight,
+    reconciliationGeneration: documentProcessingReconciliationGeneration,
     requiredIdleChecks,
     onCheckFailure: (error) => {
       logger.error("document_processing.idle_check_failed", {

--- a/apps/api/src/scripts/document-processing-worker.ts
+++ b/apps/api/src/scripts/document-processing-worker.ts
@@ -1,7 +1,10 @@
 import { envDocumentProcessingWorker } from "@/api/env-document-processing-worker";
 import { detached } from "@/api/lib/detached";
 import { countPendingDocumentProcessingJobs } from "@/api/lib/document-processing-enqueue";
-import { createIdleExitCheck } from "@/api/lib/document-processing-idle-exit";
+import {
+  createIdleExitCheck,
+  startIdleExitSampling,
+} from "@/api/lib/document-processing-idle-exit";
 import {
   hasUnfinishedDocumentProcessingReconciliation,
   initDocumentProcessingWorker,
@@ -25,11 +28,13 @@ await refreshS3();
 const documentProcessingWorker = initDocumentProcessingWorker();
 
 let shuttingDown = false;
+let stopIdleSampling: (() => void) | null = null;
 const shutdown = async (signal: string): Promise<void> => {
   if (shuttingDown) {
     return;
   }
   shuttingDown = true;
+  stopIdleSampling?.();
   logger.info("document_processing.shutdown_started", { signal });
   try {
     await documentProcessingWorker.close();
@@ -60,7 +65,6 @@ if (idleExitMinutes !== undefined) {
     1,
     Math.ceil((idleExitMinutes * 60_000) / IDLE_CHECK_INTERVAL_MS),
   );
-  let idleTimer: ReturnType<typeof setInterval> | null = null;
   const idleTick = createIdleExitCheck({
     countPending: countPendingDocumentProcessingJobs,
     hasUnfinishedReconciliation: hasUnfinishedDocumentProcessingReconciliation,
@@ -71,9 +75,7 @@ if (idleExitMinutes !== undefined) {
       });
     },
     onIdleExit: () => {
-      if (idleTimer !== null) {
-        clearInterval(idleTimer);
-      }
+      stopIdleSampling?.();
       if (shuttingDown) {
         return;
       }
@@ -83,9 +85,12 @@ if (idleExitMinutes !== undefined) {
       detached(shutdown("idle-exit"), "document-processing.idle-exit");
     },
   });
-  setTimeout(() => {
-    idleTimer = setInterval(() => {
+  stopIdleSampling = startIdleExitSampling({
+    intervalMs: IDLE_CHECK_INTERVAL_MS,
+    isShuttingDown: () => shuttingDown,
+    offsetMs: IDLE_CHECK_OFFSET_MS,
+    onSample: () => {
       detached(idleTick(), "document-processing.idle-exit-check");
-    }, IDLE_CHECK_INTERVAL_MS);
-  }, IDLE_CHECK_OFFSET_MS);
+    },
+  }).stop;
 }

--- a/apps/api/src/scripts/document-processing-worker.ts
+++ b/apps/api/src/scripts/document-processing-worker.ts
@@ -2,7 +2,10 @@ import { envDocumentProcessingWorker } from "@/api/env-document-processing-worke
 import { detached } from "@/api/lib/detached";
 import { countPendingDocumentProcessingJobs } from "@/api/lib/document-processing-enqueue";
 import { createIdleExitCheck } from "@/api/lib/document-processing-idle-exit";
-import { initDocumentProcessingWorker } from "@/api/lib/document-processing-queue";
+import {
+  hasUnfinishedDocumentProcessingReconciliation,
+  initDocumentProcessingWorker,
+} from "@/api/lib/document-processing-queue";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { refreshS3 } from "@/api/lib/s3";
@@ -38,8 +41,9 @@ process.once("SIGINT", () => {
 
 // Batch mode: when an idle-exit window is configured (the scheduled batch
 // task sets it; long-running deployments leave it unset), the worker exits
-// cleanly once the queue has stayed empty for the whole window, so the
-// task stops billing between batches.
+// cleanly once the queue has stayed empty and reconciliation has stopped
+// finding work for the whole window, so the task stops billing between
+// batches without abandoning a backlog mid-drain.
 const idleExitMinutes =
   envDocumentProcessingWorker.DOCUMENT_PROCESSING_IDLE_EXIT_MINUTES;
 if (idleExitMinutes !== undefined) {
@@ -50,6 +54,7 @@ if (idleExitMinutes !== undefined) {
   let idleTimer: ReturnType<typeof setInterval> | null = null;
   const idleTick = createIdleExitCheck({
     countPending: countPendingDocumentProcessingJobs,
+    hasUnfinishedReconciliation: hasUnfinishedDocumentProcessingReconciliation,
     requiredIdleChecks,
     onCheckFailure: (error) => {
       logger.error("document_processing.idle_check_failed", {


### PR DESCRIPTION
## Proposed change

`createIdleExitCheck` decides batch mode is idle from
`countPendingDocumentProcessingJobs` alone, but that is only one of the two
sources of work the worker owns.

`initDocumentProcessingWorker` also runs `reconcileDocumentProcessing` on a
30s timer, and every phase there drains at most one batch per tick:
`RECONCILE_BATCH_SIZE` for delivery/repair/retry/stale-lease,
`SEARCH_INDEX_REPLAY_BATCH_SIZE` for reindex. None of that work passes through
the job queue, so a phase can return its whole batch (meaning more remained
than it could take) on the same tick the queue reads empty. The idle streak
keeps advancing, the worker exits mid-drain, and the remainder waits for
whatever starts the worker next, which has nothing to do with the backlog's
size.

The change:

- `RECONCILIATION_PHASE_BATCH_SIZE`, a total
  `Record<ReconciliationPhaseName, number>` beside the phase list, so a new
  phase cannot land without declaring its limit.
- `reconciliationLeftWorkBehind`: true when any phase returned its whole
  batch, or when a phase threw. A phase that threw keeps its count at 0,
  otherwise indistinguishable from drained.
- `createIdleExitCheck` now requires `hasUnfinishedReconciliation` and
  advances the streak only when the queue is empty *and* reconciliation found
  nothing left. Required rather than optional so a new call site must decide.

A tick that throws before producing counts sets the flag too: the backlog is
unknown, and this module's existing rule is to never exit on uncertainty, the
same reason a failed `countPending` resets the streak.

One trade-off worth an opinion: this also means a phase that fails
persistently holds the worker up instead of letting it exit. That is
consistent with how the module already treats a failing `countPending`, so I
kept it that way; if the billing side should win, the failure branch is the
line to change.

Note for merge order: #2104 touches the adjacent line in
`reconcileDocumentProcessing`. The two are independent and should merge
cleanly, but they land in the same function.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
      `tsc --noEmit -p` on `apps/api` is clean, and scoped
      `oxlint -c oxlint.config.ts --deny-warnings --type-aware --type-check` on
      the touched files is clean.
- [x] **TESTING** | `bun test src/lib/document-processing-idle-exit.test.ts`
      (7 pass) and `bun test src/lib/document-processing-queue.test.ts`
      (48 pass). New cases cover: an empty queue is not idle while
      reconciliation has work behind it; reconciliation work mid-streak resets
      it; every declared phase is watched for saturation (asserted in both
      directions against the phase list); a partial batch is progress, not a
      backlog; a failed phase counts as work left behind. Verified locally
      because draft PRs skip repo CI.
- [ ] DARK MODE SUPPORT | Not applicable, no UI surface.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable, worker lifecycle only.

---
_Generated by [Claude Code](https://claude.ai/code/session_017yJi9krQ1b65jCU8z4jtuT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workers no longer exit while document reconciliation has outstanding work.
  - Reconciliation activity correctly resets idle detection.
  - In-flight and failed reconciliation work is tracked to prevent premature shutdown.
  - Batch processing continues reliably when more work remains beyond the current limit.
  - Idle-exit sampling now starts safely and stops cleanly during shutdown.

- **Tests**
  - Added coverage for reconciliation progress, pagination, retries, cancellation, and safe worker exit behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->