### PR TITLE
fix(api): tolerate a cancelled body in the MCP stream pull

### DIFF
--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -582,10 +582,37 @@ export const createMcpHttpRequestHandler = ({
         once: true,
       });
 
+      // A pull is suspended across the upstream read and the teardown that
+      // follows it, and the consumer can cancel `monitoredBody` during either
+      // await. Cancelling closes the controller, so the close/enqueue that
+      // resumes afterwards throws, and the catch below would report that as a
+      // failed transport read. A cancelled body is a normal end of the
+      // exchange, so absorb the closed-controller throw here, the way the SSE
+      // connection registries do, and leave the catch for real read failures.
+      const closeMonitoredBody = (
+        controller: ReadableStreamDefaultController<Uint8Array>,
+      ): void => {
+        try {
+          controller.close();
+        } catch {
+          // Already closed by a concurrent cancel.
+        }
+      };
+      const enqueueMonitoredChunk = (
+        controller: ReadableStreamDefaultController<Uint8Array>,
+        chunk: Uint8Array,
+      ): void => {
+        try {
+          controller.enqueue(chunk);
+        } catch {
+          // Already closed by a concurrent cancel.
+        }
+      };
+
       const monitoredBody = new ReadableStream<Uint8Array>({
         pull: async (controller) => {
           if (readerReleased) {
-            controller.close();
+            closeMonitoredBody(controller);
             return;
           }
           try {
@@ -595,10 +622,10 @@ export const createMcpHttpRequestHandler = ({
             }
             if (readResult.done) {
               await completeExchange();
-              controller.close();
+              closeMonitoredBody(controller);
               return;
             }
-            controller.enqueue(readResult.value);
+            enqueueMonitoredChunk(controller, readResult.value);
           } catch (error) {
             reportTransportError(error, "read_stream");
             await completeExchange();

--- a/apps/api/src/mcp/server.test.ts
+++ b/apps/api/src/mcp/server.test.ts
@@ -541,6 +541,7 @@ describe("handleMcpHttpRequest", () => {
 
     await reader.cancel();
     await firstRead;
+    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 
   test("refuses session termination with 405", async () => {


### PR DESCRIPTION
## Proposed change

`monitoredBody.pull` in `createMcpHttpRequestHandler` stays suspended across two awaits: the upstream `reader.read()`, and the `completeExchange()` that runs once the read reports `done`. A consumer that cancels the response body during either await closes the stream controller first, so the `controller.close()` / `controller.enqueue()` that resumes afterwards throws `ERR_INVALID_STATE`.

Both calls sit inside the pull's `try`, so that throw lands in the catch meant for upstream read failures and is reported through `reportTransportError` as `read_stream`. Cancelling a body is a normal way for the exchange to end, not a transport error, so it should not be classified as one.

This routes the two controller calls through local helpers that absorb a closed controller, matching how the SSE connection registries (`lib/sse.ts`, `handlers/entities/desktop-edit-session-events.ts`) already guard their own `enqueue`/`close`. The catch is otherwise unchanged and still reports genuine read failures.

Two sibling call sites have the same unguarded shape and are left alone here to keep this diff to one subsystem: `handlers/ai-autocomplete/stream.ts` guards its writes with `request.signal.aborted`, which tracks the request rather than the controller, and `lib/safe-outbound-fetch.ts` calls `enqueue`/`close` from Node stream listeners with no guard at all. Happy to follow up on either.

No regression test: the stream is constructed inside a closure in `serveLegacyRequest` and is not reachable from a test without extracting it. If it is worth the churn, the body-monitoring stream could move into a named helper that takes the reader and the teardown callbacks, which would make the cancel-during-read ordering directly testable.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings. `typecheck`, `lint` and `format` are clean for `@stll/api`.
- [ ] TESTING | Existing `src/mcp` suites pass unchanged; no new test added, see the note above.
- [ ] DARK MODE SUPPORT | Not applicable, server-side change.
- [ ] ISSUE LINKED | No linked issue.
- [ ] SCREENSHOT INCLUDED | Not applicable, no user-visible surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LCJhawg4x1eCo66tseMS3h)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream handling during cancellation to prevent closed connections from being incorrectly reported as transport read failures.
  * Genuine stream-reading errors continue to be reported and propagated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->