### PR TITLE
fix(api): give the reconciliation Redis client its own readiness

### DIFF
--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -1239,6 +1239,16 @@ describe("work a phase keeps for itself", () => {
         saturated: false,
       }),
     ).toEqual({ count: 3, hasMore: false });
+
+    // The other half of the rule: a selection that hit its cap reports
+    // more even when every handoff in it succeeded.
+    expect(
+      resolveScheduledDeliveryBatch({
+        attempted: RECONCILE_BATCH_SIZE,
+        retryAt: null,
+        saturated: true,
+      }),
+    ).toEqual({ count: RECONCILE_BATCH_SIZE, hasMore: true });
   });
 });
 

--- a/apps/api/src/lib/document-processing-queue.test.ts
+++ b/apps/api/src/lib/document-processing-queue.test.ts
@@ -10,7 +10,6 @@ import {
   classifyOcrWorkspaceDispatch,
   createDocumentProcessingLeaseRenewal,
   createReconciliationProgress,
-  dispatchScheduledDocumentProcessingRetries,
   DOCUMENT_PROCESSING_RECONCILIATION_PHASE_FEEDS,
   DOCUMENT_PROCESSING_RECONCILIATION_PHASES,
   DocumentProcessingJobError,
@@ -22,12 +21,12 @@ import {
   isRetryableOcrDerivativeFailure,
   isRetryableSearchIndexFailure,
   mapWithConcurrency,
-  memoizeConnect,
   ownsPromotedManualOcrClaim,
   readRepairScanCursor,
   RECONCILE_BATCH_SIZE,
   reconciliationLeftWorkBehind,
   resolveRepairScanPage,
+  resolveScheduledDeliveryBatch,
   resolveSearchIndexReplayBatch,
   runDocumentProcessingReconciliationPhases,
   runSearchIndexReplayAttempt,
@@ -238,47 +237,6 @@ describe("repair cursor Redis deadlines", () => {
       label: "document OCR repair cursor write",
       timeoutMs: 5,
     });
-  });
-});
-
-describe("reconciliation connection memo", () => {
-  test("connects once while the attempt succeeds", async () => {
-    let attempts = 0;
-    const ensureConnected = memoizeConnect(async () => {
-      attempts += 1;
-      await Promise.resolve();
-    });
-
-    await Promise.all([
-      ensureConnected(),
-      ensureConnected(),
-      ensureConnected(),
-    ]);
-    await ensureConnected();
-
-    expect(attempts).toBe(1);
-  });
-
-  test("retries after a failed attempt instead of caching the rejection", async () => {
-    let attempts = 0;
-    const ensureConnected = memoizeConnect(async () => {
-      attempts += 1;
-      if (attempts === 1) {
-        throw new Error("connection refused");
-      }
-      await Promise.resolve();
-    });
-
-    const rejection: unknown = await ensureConnected().then(
-      () => null,
-      (error: unknown) => error,
-    );
-    expect(rejection).toBeInstanceOf(Error);
-
-    await ensureConnected();
-    await ensureConnected();
-
-    expect(attempts).toBe(2);
   });
 });
 
@@ -1263,23 +1221,23 @@ describe("work a phase keeps for itself", () => {
     ).toEqual({ count: 4, hasMore: false });
   });
 
-  test("a failed handoff keeps the delivery phase unfinished", async () => {
+  test("a failed handoff keeps the delivery phase unfinished", () => {
     // The run stays queued and rescheduled, and delivery is the only phase
     // that takes queued rows, so nothing later in this tick can.
     expect(
-      await dispatchScheduledDocumentProcessingRetries(async () => ({
+      resolveScheduledDeliveryBatch({
         attempted: 3,
-        hasMore: false,
         retryAt: new Date("2030-01-01T00:00:30.000Z"),
-      })),
+        saturated: false,
+      }),
     ).toEqual({ count: 3, hasMore: true });
 
     expect(
-      await dispatchScheduledDocumentProcessingRetries(async () => ({
+      resolveScheduledDeliveryBatch({
         attempted: 3,
-        hasMore: false,
         retryAt: null,
-      })),
+        saturated: false,
+      }),
     ).toEqual({ count: 3, hasMore: false });
   });
 });

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -61,8 +61,8 @@ import {
 } from "@/api/lib/ocr-local/recognize-local";
 import { createOcrSearchablePdf } from "@/api/lib/ocr-searchable-pdf";
 import {
-  connectWithColdStartRetries,
   createBullMqConnection,
+  createLazyRedisClient,
   createRedisClient,
 } from "@/api/lib/redis-client";
 import { unboundedCoordinationKey } from "@/api/lib/redis-keys";
@@ -1429,56 +1429,23 @@ type DocumentProcessingCandidate = {
   workspaceId: SafeId<"workspace">;
 };
 
-let reconciliationRedisClient: ReturnType<typeof createRedisClient> | null =
-  null;
-
-const getReconciliationRedis = () => {
-  reconciliationRedisClient ??= createRedisClient({
+/**
+ * The repair sweep's cursor store, and the only Redis the reconciliation
+ * loop touches. It owns its connection: the client is unreachable except
+ * through `ready()`, so no call site here can issue a cursor command on a
+ * client that is still connecting, which this one would reject outright
+ * rather than wait for.
+ */
+const reconciliationRedis = createLazyRedisClient(() =>
+  createRedisClient({
     connectionTimeout: REPAIR_SCAN_CURSOR_COMMAND_TIMEOUT_MS,
     enableOfflineQueue: false,
-  });
-  return reconciliationRedisClient;
-};
-
-/**
- * Wrap `connect` so it runs at most once per process while it succeeds, and
- * discards a rejected attempt so the next caller retries. Retaining the
- * rejected promise would strand every later caller on the first failure.
- */
-export const memoizeConnect = (
-  connect: () => Promise<void>,
-): (() => Promise<void>) => {
-  let connected: Promise<void> | null = null;
-  return async () => {
-    connected ??= connect().catch((error: unknown) => {
-      connected = null;
-      throw error;
-    });
-    await connected;
-  };
-};
-
-/**
- * Establish the reconciliation client's connection before any cursor command
- * is issued. The client disables the offline queue, so a command sent while it
- * is still connecting rejects immediately instead of waiting for the socket,
- * and the repair phase reads the cursor as its first action: without this the
- * phase fails outright whenever it runs before the connection is up.
- *
- * Connecting here rather than inside `readRepairScanCursor` keeps the retry
- * ladder outside that function's per-command deadline, which bounds command
- * latency and is far shorter than a cold-start retry sequence.
- */
-const ensureReconciliationRedisConnected = memoizeConnect(
-  async () =>
-    await connectWithColdStartRetries(async () => {
-      await getReconciliationRedis().connect();
-    }),
+  }),
 );
 
 export const readRepairScanCursor = async (
   readCursor: () => Promise<string | null> = async () =>
-    await getReconciliationRedis().get(REPAIR_SCAN_CURSOR_KEY),
+    await (await reconciliationRedis.ready()).get(REPAIR_SCAN_CURSOR_KEY),
   timeoutMs = REPAIR_SCAN_CURSOR_COMMAND_TIMEOUT_MS,
 ): Promise<SafeId<"field"> | null> => {
   const cursor = await withTimeout(readCursor, {
@@ -1492,7 +1459,7 @@ export const writeRepairScanCursor = async ({
   expectedCursor,
   nextCursor,
   sendCommand = async (command, args) =>
-    Number(await getReconciliationRedis().send(command, args)),
+    Number(await (await reconciliationRedis.ready()).send(command, args)),
   timeoutMs = REPAIR_SCAN_CURSOR_COMMAND_TIMEOUT_MS,
 }: {
   expectedCursor: SafeId<"field"> | null;
@@ -1834,6 +1801,12 @@ export const resolveRepairScanPage = ({
 // stays visible at the `return`, and the `ReconciliationPhase` contract
 // checks the shape where the phases are declared.
 const recoverMissingNativeExtractionRuns = async () => {
+  // Take the connection before the cursor commands rather than inside
+  // them: their deadlines bound command latency and are far shorter than a
+  // cold-start retry ladder. A connect that fails here fails this phase,
+  // which is the only phase that needs Redis at all; the rest of the tick
+  // runs on the database alone and is not held to this.
+  await reconciliationRedis.ready();
   const settledBefore = new Date(Date.now() - REPAIR_SETTLE_DELAY_MS);
   const cursor = await readRepairScanCursor();
   const candidates = await rootDb
@@ -2020,16 +1993,34 @@ export const dispatchQueuedDocumentProcessingRuns = async ({
   };
 };
 
-export const dispatchScheduledDocumentProcessingRetries = async (
-  dispatch = dispatchQueuedDocumentProcessingRuns,
-) => {
-  const { attempted, hasMore, retryAt } = await dispatch({
-    selection: QUEUED_OCR_SELECTION.SCHEDULED_RETRIES,
+/**
+ * A run whose handoff failed is still queued and still nobody else's work:
+ * it comes back to this phase on a later tick, so the phase order cannot
+ * cover it and the phase reports it itself.
+ */
+export const resolveScheduledDeliveryBatch = ({
+  attempted,
+  retryAt,
+  saturated,
+}: {
+  attempted: number;
+  retryAt: Date | null;
+  saturated: boolean;
+}): ReconciliationPhaseResult => ({
+  count: attempted,
+  hasMore: saturated || retryAt !== null,
+});
+
+const dispatchScheduledDocumentProcessingRetries = async () => {
+  const { attempted, hasMore, retryAt } =
+    await dispatchQueuedDocumentProcessingRuns({
+      selection: QUEUED_OCR_SELECTION.SCHEDULED_RETRIES,
+    });
+  return resolveScheduledDeliveryBatch({
+    attempted,
+    retryAt,
+    saturated: hasMore,
   });
-  // A run whose handoff failed is still queued and still nobody else's
-  // work: it comes back to this phase on a later tick, so the phase order
-  // cannot cover it and this phase has to report it itself.
-  return { count: attempted, hasMore: hasMore || retryAt !== null };
 };
 
 // Manual searchable-PDF failures are retryable too, so the condition spans
@@ -2785,7 +2776,11 @@ export const runDocumentProcessingReconciliationPhases = async ({
   for (const phase of phases) {
     // oxlint-disable-next-line no-await-in-loop -- repair phases are deliberately isolated and ordered
     const result = await Result.tryPromise({
-      try: phase.run,
+      // Called through an arrow rather than passed by reference: a phase
+      // is defined as taking nothing, and handing the reference over lets
+      // whatever the caller supplies land in a parameter the phase never
+      // asked for.
+      try: async () => await phase.run(),
       catch: (cause) => cause,
     });
     if (Result.isError(result)) {
@@ -2808,11 +2803,8 @@ const reconcileDocumentProcessing = async ({
   try {
     // Marks reconciliation unfinished before the first await, so the idle
     // sampler sees an in-flight tick as work in progress no matter how
-    // long the tick runs or where a sample lands inside it. The connect
-    // gate stays the cycle's first action, ahead of every phase, and a
-    // cycle that fails there reports no verdict at all.
+    // long the tick runs or where a sample lands inside it.
     await reconciliationProgress.runTick(async () => {
-      await ensureReconciliationRedisConnected();
       const results = await runDocumentProcessingReconciliationPhases({
         phases: DOCUMENT_PROCESSING_RECONCILIATION_PHASES,
         onPhaseError: (error, phase) => {
@@ -2943,8 +2935,10 @@ export const initDocumentProcessingWorker = () => {
           await worker.close();
         },
       });
-      reconciliationRedisClient?.close();
-      reconciliationRedisClient = null;
+      // Drops the connection memo with the client, so a worker started
+      // again in this process connects a fresh one instead of trusting a
+      // resolved promise for a client that is gone.
+      reconciliationRedis.close();
     },
   };
 };

--- a/apps/api/src/lib/document-processing-reconciliation-feeds.db.test.ts
+++ b/apps/api/src/lib/document-processing-reconciliation-feeds.db.test.ts
@@ -13,6 +13,7 @@ import { DOCUMENT_OCR_PROCESSOR_VERSION } from "@/api/lib/document-processing-co
 import type {
   DOCUMENT_PROCESSING_RECONCILIATION_PHASE_FEEDS as Feeds,
   DOCUMENT_PROCESSING_RECONCILIATION_PHASES as Phases,
+  runDocumentProcessingReconciliationPhases as RunPhases,
 } from "@/api/lib/document-processing-queue";
 import {
   createTestIds,
@@ -51,8 +52,11 @@ const EXTRACTABLE_FILE = {
 
 let testDb: TestDatabase;
 let ids: TestIds;
+/** Flipped by the outage test; the repair phase is the only phase that asks. */
+let redisAvailable = true;
 let phases: typeof Phases;
 let feeds: typeof Feeds;
+let runPhases: typeof RunPhases;
 
 beforeAll(async () => {
   testDb = await getTestDb();
@@ -71,6 +75,18 @@ beforeAll(async () => {
     connectWithColdStartRetries: async (connect: () => Promise<void>) =>
       await connect(),
     createBullMqConnection: () => ({}),
+    createLazyRedisClient: () => ({
+      close: () => undefined,
+      ready: async () => {
+        if (!redisAvailable) {
+          throw new Error("redis unavailable");
+        }
+        return await Promise.resolve({
+          get: async () => null,
+          send: async () => 1,
+        });
+      },
+    }),
     createRedisClient: () => ({
       close: () => undefined,
       connect: async () => undefined,
@@ -98,6 +114,7 @@ beforeAll(async () => {
   ({
     DOCUMENT_PROCESSING_RECONCILIATION_PHASES: phases,
     DOCUMENT_PROCESSING_RECONCILIATION_PHASE_FEEDS: feeds,
+    runDocumentProcessingReconciliationPhases: runPhases,
   } = await import("@/api/lib/document-processing-queue"));
 }, 120_000);
 
@@ -207,6 +224,7 @@ const FIXTURES = [
 ] as const;
 
 const resetFixtureState = async () => {
+  redisAvailable = true;
   await testDb
     .delete(documentProcessingRuns)
     .where(eq(documentProcessingRuns.organizationId, ids.orgA));
@@ -347,4 +365,41 @@ test("the declared phase edges are the edges the phases actually produce", async
       order.indexOf(producer ?? ""),
     );
   }
+}, 120_000);
+
+test("a Redis outage fails only the phase that needs Redis", async () => {
+  await resetFixtureState();
+  // Work for two phases that never touch Redis: one retryable failure and
+  // one expired lease.
+  await insertRun({
+    attemptCount: 1,
+    errorCode: "processing_failed",
+    nextAttemptAt: past(1000),
+    status: "failed",
+  });
+  await insertRun({
+    attemptCount: 1,
+    claimedAt: past(STALE_LEASE_MS),
+    claimedBy: "worker-gone",
+    sourceSha256Hex: "e".repeat(64),
+    status: "running",
+  });
+  const failedPhases: string[] = [];
+  redisAvailable = false;
+
+  const results = await runPhases({
+    onPhaseError: (_error, phase) => {
+      failedPhases.push(phase);
+    },
+    phases,
+  });
+
+  // The repair sweep reads its cursor from Redis and can do nothing
+  // without it; every other phase works from the database alone and has to
+  // run regardless, which is what the tick would lose if the connection
+  // were taken before the phases rather than by the phase that needs it.
+  expect(failedPhases).toEqual(["repair"]);
+  expect(results.repair).toEqual({ count: 0, hasMore: true });
+  expect(results.retry.count).toBe(1);
+  expect(results["stale-lease"].count).toBeGreaterThan(0);
 }, 120_000);

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -165,6 +165,17 @@ export class HealthCheckError extends TaggedError("HealthCheckError")<{
 }> {}
 
 /**
+ * A Redis client was closed while a caller was waiting for it to connect.
+ * The caller must not be handed that client: it belongs to a shutdown that
+ * has already run, and the next caller builds a fresh one.
+ */
+export class RedisClientClosedError extends TaggedError(
+  "RedisClientClosedError",
+)<{
+  message: string;
+}> {}
+
+/**
  * A legal-corpus object could not be read and the row carries no Postgres
  * copy to serve instead. Under canonical corpus storage (or after a column
  * trim) the object *is* the document, so an object-storage outage has to

--- a/apps/api/src/lib/redis-client.test.ts
+++ b/apps/api/src/lib/redis-client.test.ts
@@ -16,6 +16,7 @@ void mock.module("bullmq", () => ({
 const {
   connectWithColdStartRetries,
   createBullMqConnection,
+  createLazyRedisClient,
   isRecoverableRedisPollError,
 } = await import("@/api/lib/redis-client");
 
@@ -97,5 +98,111 @@ describe("isRecoverableRedisPollError", () => {
     expect(
       isRecoverableRedisPollError({ code: "ERR_REDIS_INVALID_RESPONSE" }),
     ).toBe(false);
+  });
+});
+
+/**
+ * The class these pin: a client handed out before it is connected, or
+ * after it has been closed, turns a cold start or an ordinary shutdown
+ * into a command failure at whichever call site happens to be first.
+ * Readiness is the client's own property, so these drive it through
+ * `ready()` alone.
+ */
+describe("createLazyRedisClient", () => {
+  /** A stand-in for the real client, recording its own lifecycle. */
+  const fakeClient = () => {
+    const client = {
+      close: () => {
+        client.closed += 1;
+      },
+      closed: 0,
+      connect: async () => {
+        client.connects += 1;
+        await client.connectResult();
+      },
+      connectResult: async () => await Promise.resolve(),
+      connects: 0,
+    };
+    return client;
+  };
+
+  test("connects once for however many callers ask", async () => {
+    const client = fakeClient();
+    const lazy = createLazyRedisClient(() => client);
+
+    const [first, second] = await Promise.all([lazy.ready(), lazy.ready()]);
+    await lazy.ready();
+
+    expect(client.connects).toBe(1);
+    expect(first).toBe(second);
+  });
+
+  test("a caller after an exhausted connect starts a fresh one", async () => {
+    // Long enough to outlast the ladder above, so the first caller sees a
+    // real failure rather than a retry.
+    const failingAttempts = 5;
+    const client = fakeClient();
+    client.connectResult = async () => {
+      if (client.connects <= failingAttempts) {
+        throw Object.assign(new Error("connect ECONNREFUSED"), {
+          code: "ECONNREFUSED",
+        });
+      }
+      await Promise.resolve();
+    };
+    const lazy = createLazyRedisClient(() => client);
+
+    const rejection: unknown = await lazy.ready().then(
+      () => null,
+      (error: unknown) => error,
+    );
+    // Keeping the rejected attempt would strand every later caller behind
+    // the outage that has since cleared.
+    await lazy.ready();
+
+    expect(rejection).toBeInstanceOf(Error);
+    expect(client.connects).toBe(failingAttempts + 1);
+  });
+
+  test("closing drops the connection with the client", async () => {
+    const clients: ReturnType<typeof fakeClient>[] = [];
+    const lazy = createLazyRedisClient(() => {
+      const client = fakeClient();
+      clients.push(client);
+      return client;
+    });
+
+    const before = await lazy.ready();
+    lazy.close();
+    const after = await lazy.ready();
+
+    // A memo that outlived its client would hand the closed one back as
+    // connected, and every command after a restart would go into a dead
+    // socket.
+    expect(after).not.toBe(before);
+    expect(clients).toHaveLength(2);
+    expect(clients.at(0)?.closed).toBe(1);
+    expect(clients.at(1)?.connects).toBe(1);
+  });
+
+  test("a caller waiting on a client that gets closed is not handed it", async () => {
+    let releaseConnect: () => void = () => undefined;
+    const client = fakeClient();
+    client.connectResult = async () =>
+      await new Promise<void>((resolve) => {
+        releaseConnect = resolve;
+      });
+    const lazy = createLazyRedisClient(() => client);
+
+    const pending = lazy.ready();
+    lazy.close();
+    releaseConnect();
+    const rejection: unknown = await pending.then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection).toMatchObject({ _tag: "RedisClientClosedError" });
   });
 });

--- a/apps/api/src/lib/redis-client.test.ts
+++ b/apps/api/src/lib/redis-client.test.ts
@@ -185,6 +185,38 @@ describe("createLazyRedisClient", () => {
     expect(clients.at(1)?.connects).toBe(1);
   });
 
+  test("a stale attempt's failure leaves the client that replaced it alone", async () => {
+    const clients: ReturnType<typeof fakeClient>[] = [];
+    const lazy = createLazyRedisClient(() => {
+      const client = fakeClient();
+      if (clients.length === 0) {
+        // The client that is closed mid-ladder: every attempt fails, so
+        // its rejection lands well after its replacement is in place.
+        client.connectResult = async () => {
+          throw Object.assign(new Error("connect ECONNREFUSED"), {
+            code: "ECONNREFUSED",
+          });
+        };
+      }
+      clients.push(client);
+      return client;
+    });
+
+    const abandoned = lazy.ready();
+    lazy.close();
+    const replacement = await lazy.ready();
+    await abandoned.then(
+      () => null,
+      () => null,
+    );
+
+    // The abandoned ladder must not clear a memo it no longer owns, or the
+    // replacement would connect a second time underneath its own callers.
+    expect(await lazy.ready()).toBe(replacement);
+    expect(clients).toHaveLength(2);
+    expect(clients.at(1)?.connects).toBe(1);
+  });
+
   test("a caller waiting on a client that gets closed is not handed it", async () => {
     let releaseConnect: () => void = () => undefined;
     const client = fakeClient();

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -3,6 +3,7 @@ import { type BunRedisRawClient, createBunRedisClient } from "bullmq";
 import { type RedisOptions, RedisClient, sleep } from "bun";
 
 import { envDocumentProcessingWorker } from "@/api/env-document-processing-worker";
+import { RedisClientClosedError } from "@/api/lib/errors/tagged-errors";
 import { connectionErrorFields, safeErrorCode } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { redisConnectionOptions } from "@/api/lib/redis-options";
@@ -115,6 +116,63 @@ export const connectWithColdStartRetries = async (
     // oxlint-disable-next-line no-await-in-loop -- retries are intentionally sequential backoff, not parallel work
     await sleep(delayMs);
   }
+};
+
+/** The two capabilities a lazily connected client has to expose. */
+type ManagedRedisClient = {
+  close: () => void;
+  connect: () => Promise<void>;
+};
+
+type LazyRedisClient<Client> = {
+  close: () => void;
+  ready: () => Promise<Client>;
+};
+
+/**
+ * A client that owns its own readiness. It is reachable only through
+ * `ready()`, which builds it on first use and connects it through the
+ * retry ladder above before handing it out, so no caller can issue a
+ * command on a client that is still connecting. That matters for clients
+ * built with the offline queue disabled, where such a command rejects
+ * immediately instead of waiting for the socket.
+ *
+ * The connect runs once per client while it succeeds, and a rejected
+ * attempt is discarded so the next caller retries rather than inheriting a
+ * cached rejection. `close` drops the client and that memo together: a
+ * caller after a shutdown builds and connects a fresh one instead of
+ * receiving a resolved promise for a closed client, and a `ready()` still
+ * in flight across a `close` fails rather than handing out the client it
+ * was connecting.
+ */
+export const createLazyRedisClient = <Client extends ManagedRedisClient>(
+  createClient: () => Client,
+): LazyRedisClient<Client> => {
+  let client: Client | null = null;
+  let connected: Promise<void> | null = null;
+  return {
+    close: () => {
+      client?.close();
+      client = null;
+      connected = null;
+    },
+    ready: async () => {
+      const target = (client ??= createClient());
+      connected ??= connectWithColdStartRetries(async () => {
+        await target.connect();
+      }).catch((error: unknown) => {
+        connected = null;
+        throw error;
+      });
+      await connected;
+      if (client !== target) {
+        throw new RedisClientClosedError({
+          message: "Redis client closed while connecting",
+        });
+      }
+      return target;
+    },
+  };
 };
 
 const withColdStartConnectRetries = (

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -158,12 +158,21 @@ export const createLazyRedisClient = <Client extends ManagedRedisClient>(
     },
     ready: async () => {
       const target = (client ??= createClient());
-      connected ??= connectWithColdStartRetries(async () => {
-        await target.connect();
-      }).catch((error: unknown) => {
-        connected = null;
-        throw error;
-      });
+      if (connected === null) {
+        const attempt: Promise<void> = connectWithColdStartRetries(async () => {
+          await target.connect();
+        }).catch((error: unknown) => {
+          // Only this attempt may clear its own memo. A close and a later
+          // caller can install another client's attempt while this ladder
+          // is still climbing, and clearing that one would leave the new
+          // client connecting twice over.
+          if (connected === attempt) {
+            connected = null;
+          }
+          throw error;
+        });
+        connected = attempt;
+      }
       await connected;
       if (client !== target) {
         throw new RedisClientClosedError({


### PR DESCRIPTION
## Why

The reconciliation loop connects its Redis client before running any phase. Only
the repair sweep uses that client (it reads and writes the repair scan cursor);
the retry, stale-lease, reindex and delivery phases work from the database alone.
A Redis outage therefore failed every phase, including the four that had nothing
to ask of Redis.

The connect was also a call-site convention rather than a property of the client,
and its memo outlived `close()`, so a worker started again in the same process
would trust a resolved promise for a client that no longer exists.

## What

**Readiness belongs to the client.** `createLazyRedisClient` (in `redis-client.ts`,
beside the cold-start ladder it reuses) builds its client on first use and connects
it before handing it out. The client is unreachable except through `ready()`, so no
call site can issue a command on one that is still connecting, which a client with
the offline queue disabled rejects outright rather than waiting for.

**Per-phase fault isolation.** The reconcile cycle no longer gates on the
connection. The repair phase takes readiness itself, before its cursor commands, so
the retry ladder stays outside their per-command deadlines. A connect failure now
fails that phase alone: the phase runner reports it, marks that phase as having left
work behind, and the rest of the tick runs.

**Lifecycle.** `close()` drops the client and its connect memo together, and a
`ready()` in flight across a `close()` fails with `RedisClientClosedError` rather
than handing out the client it was connecting.

**Phase invocation.** The phase runner passed `phase.run` to the failure wrapper by
reference, so the wrapper's own argument landed in the delivery phase's first
parameter and shadowed the dispatcher it defaults to, failing that phase every tick.
Phases are now invoked explicitly with no arguments, and the delivery phase takes
none: its saturation rule moved into `resolveScheduledDeliveryBatch`, beside the one
the reindex phase already uses.

## Tests

- `createLazyRedisClient`: one connect however many callers ask; a caller after an
  exhausted connect starts a fresh one; `close` drops the connection with the
  client so the next caller gets a new connected one; a caller waiting on a client
  that gets closed is not handed it.
- Reconciliation feeds (database-backed): a Redis outage fails only the phase that
  needs Redis, while a seeded retryable failure and an expired lease are still
  recovered by their phases in the same tick. The existing edge/order binding test
  is unchanged and still passes.
- Delivery's saturation rule keeps its unit coverage through the extracted helper.

Local: affected document-processing and Redis suites, the module-mock completeness
guard, `tsc --noEmit`, type-aware oxlint, `oxfmt --check`, and `ratchet --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis connection handling during startup, retries, and shutdown.
  * Prevented closed connections from being returned while operations are waiting for readiness.
  * Ensured document-processing reconciliation continues database-backed work when Redis is unavailable.
  * Improved handling and reporting of scheduled delivery retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->