### PR TITLE
feat(api): fold diacritics in the corpus index doc mapping

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-config.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.test.ts
@@ -51,7 +51,7 @@ test("no field repeated across a document's passages is free-text searchable", (
   expect(
     config.doc_mapping.field_mappings.find((f) => f.name === "heading_path")
       ?.tokenizer,
-  ).toBe("default");
+  ).toBe("folded");
 
   // Anything else a default search field reaches must be per-passage content
   // (`text`) or written once per document (`title`).
@@ -73,6 +73,58 @@ test("passage fields are mapped for every family, heading_path searchable", () =
     expect(fields.get("seq")?.type).toBe("u64");
     // Section context is scored, not just stored.
     expect(fields.get("heading_path")?.fieldnorms).toBe(true);
+  }
+});
+
+// The engine never diffs an existing index's doc mapping, so a change here
+// only reaches documents indexed into a fresh generation. Pinning the exact
+// block keeps the shape a reviewer sees identical to the shape the engine is
+// asked to create.
+test("the doc mapping declares the folded tokenizer verbatim", () => {
+  for (const family of ["case_law", "legislation"] as const) {
+    expect(
+      corpusIndexConfig(family, `${family}_v3_cze`).doc_mapping.tokenizers,
+    ).toEqual([
+      {
+        name: "folded",
+        type: "simple",
+        filters: ["lower_caser", "ascii_folding", "remove_long"],
+      },
+    ]);
+  }
+});
+
+// Declared tokenizers and used tokenizers must match in both directions: a
+// field naming an undeclared tokenizer is rejected by the engine at index
+// creation, and a declared tokenizer nothing uses is dead config.
+test("every full-text field uses a declared tokenizer, and every declared one is used", () => {
+  const BUILT_IN_TOKENIZERS = new Set(["raw", "default", "en_stem"]);
+
+  for (const family of ["case_law", "legislation"] as const) {
+    const config = corpusIndexConfig(family, `${family}_v3_cze`);
+    const declared = new Set(config.doc_mapping.tokenizers.map((t) => t.name));
+    const used = new Set(
+      config.doc_mapping.field_mappings
+        .map((f) => f.tokenizer)
+        .filter((name) => name !== undefined)
+        .filter((name) => !BUILT_IN_TOKENIZERS.has(name)),
+    );
+    expect([...declared].sort()).toEqual([...used].sort());
+
+    // Position-recorded fields are exactly the free-text surface; every one of
+    // them folds, so a query typed without diacritics reaches text carrying
+    // them. A new full-text field added with `default` trips this.
+    const fullText = config.doc_mapping.field_mappings.filter(
+      (f) => f.record === "position",
+    );
+    expect(fullText.map((f) => f.name).sort()).toEqual([
+      "heading_path",
+      "text",
+      "title",
+    ]);
+    for (const field of fullText) {
+      expect(field.tokenizer).toBe("folded");
+    }
   }
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -8,6 +8,8 @@ import type { CorpusFamily } from "@/api/lib/legal-search/corpus-family";
  *
  * - `text` and `title` enable `fieldnorms` so BM25 scoring works
  *   (corpus index disables BM25 by default for latency).
+ * - full-text fields use the custom `folded` tokenizer so a query typed
+ *   without diacritics reaches text that carries them.
  * - jurisdiction / document_type / source (+ status for legislation) are
  *   `tag_fields` so queries prune irrelevant splits.
  * - date fields are fast datetime for range filtering, not the
@@ -23,10 +25,39 @@ type CorpusIndexFieldType =
   | "bool"
   | "datetime";
 
+type CorpusIndexTokenizer = {
+  name: string;
+  type: "simple" | "raw" | "regex";
+  filters: readonly string[];
+};
+
+/**
+ * The tokenizer every full-text field uses. `ascii_folding` is the reason it
+ * exists: the corpus is written with diacritics, and a query typed without
+ * them ("skody") has to reach the text that carries them ("škody"). The filter
+ * runs over both the indexed terms and the query terms, so the match is
+ * symmetric and neither side has to be normalized by hand. `remove_long`
+ * discards tokens past the default byte limit, keeping OCR runs out of the
+ * term dictionary; `lower_caser` is what `default` already did.
+ */
+const FOLDED_TOKENIZER = {
+  name: "folded",
+  type: "simple",
+  filters: ["lower_caser", "ascii_folding", "remove_long"],
+} as const satisfies CorpusIndexTokenizer;
+
+const CUSTOM_TOKENIZERS = [FOLDED_TOKENIZER] as const;
+
 type CorpusIndexFieldMapping = {
   name: string;
   type: CorpusIndexFieldType;
-  tokenizer?: "raw" | "default" | "en_stem";
+  // Built-in names plus whatever `CUSTOM_TOKENIZERS` declares, so a field can
+  // never name a tokenizer the doc mapping does not ship.
+  tokenizer?:
+    | "raw"
+    | "default"
+    | "en_stem"
+    | (typeof CUSTOM_TOKENIZERS)[number]["name"];
   record?: "basic" | "freq" | "position";
   fieldnorms?: boolean;
   fast?: boolean;
@@ -40,6 +71,7 @@ export type CorpusIndexConfig = {
   doc_mapping: {
     mode: "lenient" | "strict" | "dynamic";
     field_mappings: CorpusIndexFieldMapping[];
+    tokenizers: readonly CorpusIndexTokenizer[];
     tag_fields: string[];
     store_source: boolean;
   };
@@ -72,14 +104,14 @@ const CORE_FIELDS: CorpusIndexFieldMapping[] = [
   {
     name: "title",
     type: "text",
-    tokenizer: "default",
+    tokenizer: FOLDED_TOKENIZER.name,
     record: "position",
     fieldnorms: true,
   },
   {
     name: "text",
     type: "text",
-    tokenizer: "default",
+    tokenizer: FOLDED_TOKENIZER.name,
     record: "position",
     fieldnorms: true,
   },
@@ -114,7 +146,7 @@ const CORE_FIELDS: CorpusIndexFieldMapping[] = [
   {
     name: "heading_path",
     type: "text",
-    tokenizer: "default",
+    tokenizer: FOLDED_TOKENIZER.name,
     record: "position",
     fieldnorms: true,
     stored: true,
@@ -160,6 +192,7 @@ export const corpusIndexConfig = (
   doc_mapping: {
     mode: "lenient",
     field_mappings: [...CORE_FIELDS, ...FAMILY_FIELDS[family]],
+    tokenizers: CUSTOM_TOKENIZERS,
     tag_fields: FAMILY_TAG_FIELDS[family],
     store_source: false,
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,9 +92,14 @@ services:
   # Stores its splits in the RustFS `stella-quickwit` bucket. This is a
   # standalone opt-in service; select it with
   # LEGAL_SEARCH_PROVIDER=corpus-index and CORPUS_INDEX_ENDPOINT.
+  #
+  # The tag tracks the deployed engine version: an index created locally has to
+  # be one a deployed node can open, and doc-mapping features differ between
+  # minor releases. Digest is the multi-arch manifest list, so linux/amd64 and
+  # linux/arm64 both resolve.
   quickwit:
     profiles: [quickwit]
-    image: quickwit/quickwit:0.9.0@sha256:1e6169bf4e98a489fca397105f1698c1d80a0f9779f3cf652973bac8a0c3b2bd
+    image: quickwit/quickwit:0.8.2@sha256:363ff56ce45614e46eba1c308e420f56a9f2fd8ab5788cbca0ec6b68a2e0ef92
     command: run
     environment:
       QW_METASTORE_URI: s3://stella-quickwit/metastore


### PR DESCRIPTION
## What

Two changes to the corpus index, ahead of the next index generation.

**1. Fold diacritics in the doc mapping.** The corpus is Czech and Slovak
legal text, written with diacritics. The built-in `default` tokenizer only
lower-cases, so `skody` did not reach `škody` and `Nejvyssi` did not reach
`Nejvyšší`: readers who type without diacritics (a very common input mode)
silently got fewer results, with no signal that anything was missed.

The doc mapping now declares a custom tokenizer

```json
{ "name": "folded", "type": "simple",
  "filters": ["lower_caser", "ascii_folding", "remove_long"] }
```

and the three full-text fields (`title`, `text`, `heading_path`) use it
instead of `default`. `ascii_folding` runs over both indexed terms and query
terms, so the match is symmetric: neither the corpus nor the query has to be
normalized by hand, and a query *with* diacritics keeps working unchanged.
`remove_long` drops tokens past the default byte limit, keeping OCR runs out
of the term dictionary; `lower_caser` preserves what `default` already did.

Folding is lossy by design (it cannot tell `s` from `š`), which is the right
trade for recall-first retrieval where the API reranks afterwards. Raw-tokenized
identifier fields (`document_id`, `ecli`, `court`, …) are untouched, so exact
lookups keep their exact semantics.

**2. Align the dev engine with the deployed one.** The compose service ran
`0.9.0` while deployments run `0.8.2`, so a doc mapping validated locally was
validated against a different engine than the one that has to accept it. Now
pinned to `0.8.2` by multi-arch manifest list digest, matching how every other
compose service is pinned; `linux/amd64` and `linux/arm64` both resolve from it.

## Safe to land ahead of the rebuild

`ensureIndex` (`apps/api/src/lib/corpus-index/core.ts`) probes `indexExists`
and calls `createIndex` **only when the index is absent**. It never diffs,
patches, or re-applies the config of an index that already exists, and there
is no other caller that updates a doc mapping. So this change is inert for
every currently deployed index: they keep the mapping they were built with.
It takes effect when the next generation is created and backfilled, which is
the only point at which a doc-mapping change can take effect at all (the
engine cannot retokenize existing splits).

## Validation

The tokenizer JSON was checked against a real engine at the deployed version
(0.8.2), not just typechecked: a throwaway container was given the exact
config the code emits, then three Czech/Slovak documents were ingested.

```
== search: skody (no diacritics) should match 'škody' ==
num_hits: 2
 hit: doc-3 | Súd priznal náhradu škody, ktorá vznikla porušením povinnosti.
 hit: doc-1 | Žalobce se domáhal náhrady škody způsobené nesprávným úředním postupem.

== search: škody (with diacritics) ==
num_hits: 2
 hit: doc-3 | Súd priznal náhradu škody, ktorá vznikla porušením povinnosti.
 hit: doc-1 | Žalobce se domáhal náhrady škody způsobené nesprávným úředním postupem.

== search: NEJVYSSI (uppercase, folded) should match 'Nejvyšší' ==
num_hits: 1
 hit: doc-1 | Nejvyšší soud – náhrada škody
```

The engine also echoed the `tokenizers` block back verbatim in the stored
index config, so the shape is accepted as written rather than silently
defaulted.

## Guards

`CorpusIndexFieldMapping["tokenizer"]` is typed from the declared tokenizer
list, so a field cannot name a tokenizer the doc mapping does not ship (the
engine rejects that at index creation; now it fails at typecheck instead).
A test asserts declared and used tokenizer sets are equal **in both
directions**, and that every position-recorded field folds, so a new
full-text field added with `default` trips the suite rather than shipping a
half-folded mapping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved legal search matching across titles, text and heading paths by normalising capitalisation and accented characters.
  * Improved handling of unusually long search terms for more reliable results.

* **Bug Fixes**
  * Standardised text analysis across searchable fields, helping produce more consistent search results.

* **Compatibility**
  * Updated the search service configuration to maintain reliable operation across supported deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->