### PR TITLE
feat(api): read quoted spans as corpus-index phrase queries

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
@@ -447,6 +447,32 @@ test("the ingestion role can take every lock the corpus checkpoint holds", async
   }
 });
 
+// One assembler, or the two boundaries drift into two answers about what the
+// engine sees. The public search path and the shared provider must both reach
+// the engine through corpus-query.ts, and neither may re-derive quoting or
+// interpolate user text into the DSL itself.
+test("every case-law corpus query is assembled by the shared builder", async () => {
+  const consumers = await Promise.all(
+    [publicSearchSource, sharedSearchProviderSource].map(
+      async (source) => await Bun.file(source).text(),
+    ),
+  );
+  for (const source of consumers) {
+    expect(source).toContain(
+      'import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query"',
+    );
+    expect(source).toContain("caseLawCorpusQuery(");
+    // A local escaping helper is how the two paths diverged before.
+    expect(source).not.toMatch(/const quote = /u);
+    expect(source).not.toMatch(/replaceAll\('"'/u);
+    // No field clause is assembled outside the shared builder, and free text
+    // never reaches a template literal.
+    expect(source).not.toMatch(/`(?:document_type|source|language|court):/u);
+    expect(source).not.toMatch(/`decision_date:\[/u);
+    expect(source).not.toMatch(/\$\{\w+\.query\}/u);
+  }
+});
+
 test("every case-law corpus search boundary uses generation projection state", async () => {
   const consumers = await Promise.all(
     [publicSearchSource, sharedSearchProviderSource].map(

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -32,10 +32,7 @@ import {
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
-import {
-  corpusFreeTextClause,
-  quoteCorpusValue,
-} from "@/api/lib/legal-search/corpus-query";
+import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
 import { loadFtsSearchConfigs } from "@/api/lib/legal-search/fts-config";
 import {
   corpusIndexId,
@@ -432,31 +429,16 @@ const searchPostgresDecisions = async (
   };
 };
 
-const buildCorpusIndexQuery = (body: SearchDecisionsBody): string | null => {
-  const freeText = corpusFreeTextClause(body.query);
-  if (freeText === null) {
-    return null;
-  }
-  const clauses: string[] = [freeText];
-  if (body.decisionType) {
-    clauses.push(`document_type:${quoteCorpusValue(body.decisionType)}`);
-  }
-  if (body.sourceId) {
-    clauses.push(`source:${quoteCorpusValue(body.sourceId)}`);
-  }
-  if (body.language) {
-    clauses.push(`language:${quoteCorpusValue(body.language)}`);
-  }
-  if (body.court) {
-    clauses.push(`court:${quoteCorpusValue(body.court)}`);
-  }
-  if (body.dateFrom || body.dateTo) {
-    clauses.push(
-      `decision_date:[${body.dateFrom ?? "*"} TO ${body.dateTo ?? "*"}]`,
-    );
-  }
-  return clauses.join(" AND ");
-};
+// `country` is deliberately absent: it selects the index, not a clause.
+const buildCorpusIndexQuery = (body: SearchDecisionsBody): string | null =>
+  caseLawCorpusQuery(body.query, {
+    court: body.court,
+    dateFrom: body.dateFrom,
+    dateTo: body.dateTo,
+    documentType: body.decisionType,
+    language: body.language,
+    source: body.sourceId,
+  });
 
 const extractCorpusSnippet = (
   snippet: Record<string, unknown> | undefined,

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -16,6 +16,7 @@ import {
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
+import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
 import { loadDocumentContext } from "@/api/lib/legal-search/document-context";
 import {
   corpusIndexId,
@@ -52,32 +53,6 @@ import { encodeCursor, decodeCursor } from "@/api/lib/search/cursor";
 const toNullableString = (x: unknown): string | null =>
   x === null ? null : JSON.stringify(x);
 
-const quote = (value: string): string => `"${value.replaceAll('"', '\\"')}"`;
-
-const buildQuery = (query: LegalSearchQuery): string => {
-  // jurisdiction is not a query clause — it selects the index (one index
-  // per jurisdiction), so a scoped query only touches that index.
-  const clauses: string[] = [`(${query.query})`];
-  if (query.documentType) {
-    clauses.push(`document_type:${quote(query.documentType)}`);
-  }
-  if (query.source) {
-    clauses.push(`source:${quote(query.source)}`);
-  }
-  if (query.language) {
-    clauses.push(`language:${quote(query.language)}`);
-  }
-  if (query.court) {
-    clauses.push(`court:${quote(query.court)}`);
-  }
-  if (query.dateFrom || query.dateTo) {
-    const from = query.dateFrom ?? "*";
-    const to = query.dateTo ?? "*";
-    clauses.push(`decision_date:[${from} TO ${to}]`);
-  }
-  return clauses.join(" AND ");
-};
-
 const extractSnippet = (
   snippet: Record<string, unknown> | undefined,
 ): string | null => {
@@ -104,6 +79,20 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
 
   const parsedCursor = query.cursor ? decodeCursor(query.cursor) : null;
 
+  // jurisdiction is deliberately absent: it selected the index above, so a
+  // scoped query never needs a clause for it.
+  const engineQuery = caseLawCorpusQuery(query.query, {
+    court: query.court,
+    dateFrom: query.dateFrom,
+    dateTo: query.dateTo,
+    documentType: query.documentType,
+    language: query.language,
+    source: query.source,
+  });
+  if (engineQuery === null) {
+    return { hits: [], facets: null, nextCursor: null, limit };
+  }
+
   // Upper bound for the pagination early-stop: scanning may end only
   // once no unseen candidate could out-blend the page cursor.
   const [authorityBound] = await caseLawPublicReadDb((tx) =>
@@ -117,7 +106,7 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
 
   const searchPage = await readCorpusIndexSearchPage({
     indexId,
-    query: buildQuery(query),
+    query: engineQuery,
     limit,
     parsedCursor,
     snippetFields: ["text"],

--- a/apps/api/src/lib/legal-search/corpus-query.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-query.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from "bun:test";
 
 import {
+  caseLawCorpusQuery,
   corpusFreeTextClause,
   quoteCorpusValue,
+  tokenizeCorpusFreeText,
 } from "@/api/lib/legal-search/corpus-query";
 
 test("free text cannot escape into the query DSL", () => {
@@ -24,4 +26,224 @@ test("input without searchable terms yields no clause", () => {
 test("filter values escape backslashes before quotes", () => {
   expect(quoteCorpusValue("foo\\")).toBe('"foo\\\\"');
   expect(quoteCorpusValue('a"b')).toBe('"a\\"b"');
+});
+
+// Pins the pre-phrase clause shape for quote-free input: the phrase parser
+// must be invisible to every query that does not use quotes.
+test.each([
+  ["náhrada škody", '("náhrada" AND "škody")'],
+  ["  spaced   out  ", '("spaced" AND "out")'],
+  ["§ 2235 odst. 1", '("2235" AND "odst" AND "1")'],
+  ["one", '("one")'],
+])("quote-free input %p keeps its existing clause", (input, expected) => {
+  expect(corpusFreeTextClause(input)).toBe(expected);
+});
+
+test("a straight-quoted span becomes one phrase clause", () => {
+  expect(corpusFreeTextClause('"náhrada škody"')).toBe('("náhrada škody")');
+});
+
+test("phrases and loose terms keep their written order", () => {
+  expect(corpusFreeTextClause('bezdůvodné "náhrada škody" obohacení')).toBe(
+    '("bezdůvodné" AND "náhrada škody" AND "obohacení")',
+  );
+});
+
+test("several phrases each become their own clause", () => {
+  expect(corpusFreeTextClause('"dobrá víra" a "náhrada škody"')).toBe(
+    '("dobrá víra" AND "a" AND "náhrada škody")',
+  );
+});
+
+// The corpus is written in several typographic conventions; a phrase pasted
+// out of a judgment must be read as a phrase whichever pair it carries.
+test.each([
+  ["„náhrada škody“", "czech"],
+  ["„náhrada škody”", "polish"],
+  ["“náhrada škody”", "english"],
+  ["«náhrada škody»", "french"],
+  ["»náhrada škody«", "german-guillemet"],
+])("%p (%s quotes) is a phrase", (input) => {
+  expect(corpusFreeTextClause(input)).toBe('("náhrada škody")');
+});
+
+test("mixed quote conventions coexist in one query", () => {
+  expect(corpusFreeTextClause('„dobrá víra“ a "náhrada škody"')).toBe(
+    '("dobrá víra" AND "a" AND "náhrada škody")',
+  );
+});
+
+// Never an engine parse error: an unclosed quote degrades to the terms it
+// would have produced without it.
+test.each([
+  ['smlouva "náhrada škody', '("smlouva" AND "náhrada" AND "škody")'],
+  ['"', null],
+  ["„nájemné", '("nájemné")'],
+  ['a "b" "c', '("a" AND "b" AND "c")'],
+])("unbalanced quote in %p degrades to terms", (input, expected) => {
+  expect(corpusFreeTextClause(input)).toBe(expected);
+});
+
+test.each([
+  ['""', null],
+  ['"   "', null],
+  ["„ “", null],
+  ['smlouva ""', '("smlouva")'],
+  ['"" smlouva', '("smlouva")'],
+])("empty phrase %p contributes no clause", (input, expected) => {
+  expect(corpusFreeTextClause(input)).toBe(expected);
+});
+
+// Phrase content is tokenized to word characters exactly as a loose term is,
+// so nothing inside a phrase can reach the engine's parser. Every expectation
+// below is a clause with balanced quotes and no field, boolean, wildcard, or
+// escape left in it.
+test.each([
+  ['"a\\" OR text:*"', '("a" AND "OR" AND "text")'],
+  ['"náhrada\\" AND court:\\"X"', '("náhrada" AND "AND" AND "court" AND "X")'],
+  ['"foo\\\\"', '("foo")'],
+  ['"a" OR "b"', '("a" AND "OR" AND "b")'],
+  ['"text:* AND court:X"', '("text AND court X")'],
+  ['"(a OR b)"', '("a OR b")'],
+  ['"a~2 b^3"', '("a 2 b 3")'],
+  ['«court:"X"»', '("court X")'],
+])("injection attempt %p stays literal", (input, expected) => {
+  expect(corpusFreeTextClause(input)).toBe(expected);
+});
+
+test("no clause ever carries an unescaped quote or backslash", () => {
+  const attempts = [
+    '"a\\" OR text:*"',
+    'smlouva "náhrada\\škody"',
+    '„a\\"b“',
+    '"\\\\\\\\"',
+    'court:"X" "y\\"',
+  ];
+  for (const attempt of attempts) {
+    const clause = corpusFreeTextClause(attempt);
+    if (clause === null) {
+      continue;
+    }
+    expect(clause).not.toContain("\\");
+    // Balanced quoting: every clause is `("t" AND "t" ...)`, so the quote
+    // count is even and no bare quote can terminate a phrase early.
+    expect((clause.match(/"/gu) ?? []).length % 2).toBe(0);
+  }
+});
+
+test("a phrase collapses internal whitespace to single separators", () => {
+  expect(corpusFreeTextClause('"náhrada    škody"')).toBe('("náhrada škody")');
+  expect(corpusFreeTextClause('"náhrada\n\tškody"')).toBe('("náhrada škody")');
+});
+
+test("diacritics and non-Latin scripts survive a phrase", () => {
+  expect(corpusFreeTextClause('"příslušenství pohledávky"')).toBe(
+    '("příslušenství pohledávky")',
+  );
+  expect(corpusFreeTextClause('" عقد الإيجار"')).toBe('("عقد الإيجار")');
+});
+
+test("an apostrophe does not open a phrase span", () => {
+  expect(corpusFreeTextClause("l'état d'urgence")).toBe(
+    '("l" AND "état" AND "d" AND "urgence")',
+  );
+});
+
+// The tokenizer is the single splitter over this input: a consumer that
+// rewrites terms (and must leave phrases alone) reads these tokens rather than
+// re-scanning the raw query, so the phrase boundary is decided in one place.
+test("the tokenizer labels phrases and terms in written order", () => {
+  expect(
+    tokenizeCorpusFreeText('bezdůvodné "náhrada škody" a „dobrá víra“'),
+  ).toEqual([
+    { type: "term", value: "bezdůvodné" },
+    { type: "phrase", value: "náhrada škody" },
+    { type: "term", value: "a" },
+    { type: "phrase", value: "dobrá víra" },
+  ]);
+});
+
+test("a token's value is already reduced to word characters", () => {
+  expect(tokenizeCorpusFreeText('"text:* AND court:X" § 2235')).toEqual([
+    { type: "phrase", value: "text AND court X" },
+    { type: "term", value: "2235" },
+  ]);
+});
+
+test("a one-word quoted span is still a phrase token", () => {
+  expect(tokenizeCorpusFreeText('"smlouva"')).toEqual([
+    { type: "phrase", value: "smlouva" },
+  ]);
+});
+
+test("unbalanced and empty spans produce no phrase token", () => {
+  expect(tokenizeCorpusFreeText('smlouva "náhrada')).toEqual([
+    { type: "term", value: "smlouva" },
+    { type: "term", value: "náhrada" },
+  ]);
+  expect(tokenizeCorpusFreeText('""')).toEqual([]);
+});
+
+test("the clause is exactly the tokenization, quoted and ANDed", () => {
+  for (const input of [
+    'bezdůvodné "náhrada škody" obohacení',
+    "nájemné smlouvy § 2235",
+    '„dobrá víra“ a "náhrada škody"',
+    'smlouva) OR (court:"X" AND text:*',
+  ]) {
+    const tokens = tokenizeCorpusFreeText(input);
+    expect(corpusFreeTextClause(input)).toBe(
+      `(${tokens.map((token) => quoteCorpusValue(token.value)).join(" AND ")})`,
+    );
+  }
+});
+
+test("the assembler ANDs filter clauses onto the free-text clause", () => {
+  expect(
+    caseLawCorpusQuery('"náhrada škody"', {
+      court: "Nejvyšší soud",
+      dateFrom: "2020-01-01",
+      dateTo: "2024-12-31",
+      documentType: "rozsudek",
+      language: "cs",
+      source: "7449df27-2067-4827-b22f-3091f564ae50",
+    }),
+  ).toBe(
+    '("náhrada škody")' +
+      ' AND document_type:"rozsudek"' +
+      ' AND source:"7449df27-2067-4827-b22f-3091f564ae50"' +
+      ' AND language:"cs"' +
+      ' AND court:"Nejvyšší soud"' +
+      " AND decision_date:[2020-01-01 TO 2024-12-31]",
+  );
+});
+
+test("an open-ended date range keeps the wildcard bound", () => {
+  expect(caseLawCorpusQuery("smlouva", { dateFrom: "2020-01-01" })).toBe(
+    '("smlouva") AND decision_date:[2020-01-01 TO *]',
+  );
+  expect(caseLawCorpusQuery("smlouva", { dateTo: "2020-01-01" })).toBe(
+    '("smlouva") AND decision_date:[* TO 2020-01-01]',
+  );
+});
+
+test("no filters leaves the free-text clause alone", () => {
+  expect(caseLawCorpusQuery("smlouva", {})).toBe('("smlouva")');
+});
+
+test("text without a searchable term yields no query", () => {
+  expect(caseLawCorpusQuery("?!()", { court: "Nejvyšší soud" })).toBeNull();
+  expect(caseLawCorpusQuery('""', {})).toBeNull();
+});
+
+// A filter value reaching the engine unescaped would let a caller that does
+// not validate its inputs (the provider takes them straight from its caller)
+// close the clause and append DSL of its own.
+test("filter values cannot close their clause", () => {
+  expect(caseLawCorpusQuery("smlouva", { court: 'X" OR text:*' })).toBe(
+    '("smlouva") AND court:"X\\" OR text:*"',
+  );
+  expect(caseLawCorpusQuery("smlouva", { language: "cs\\" })).toBe(
+    '("smlouva") AND language:"cs\\\\"',
+  );
 });

--- a/apps/api/src/lib/legal-search/corpus-query.ts
+++ b/apps/api/src/lib/legal-search/corpus-query.ts
@@ -1,24 +1,199 @@
 /**
- * Convert free user text into a safe corpus-index query clause. The
- * engine's query string syntax (field clauses, AND/OR, parentheses,
- * quotes) must never be reachable from user input, mirroring how the
- * pg-fts path keeps user text literal via plainto_tsquery: keep only
- * unicode word characters, quote each term, AND them. Returns null when
- * no searchable term remains; callers return an empty page without
- * querying the engine.
- */
-export const corpusFreeTextClause = (text: string): string | null => {
-  const terms = text.match(/[\p{L}\p{N}]+/gu);
-  if (!terms) {
-    return null;
-  }
-  return `(${terms.map((term) => `"${term}"`).join(" AND ")})`;
-};
-
-/**
  * Quote a trusted-shape filter value for a corpus-index field clause.
  * Backslashes are escaped before quotes so a trailing backslash cannot
  * swallow the closing quote and let the remainder parse as DSL.
  */
 export const quoteCorpusValue = (value: string): string =>
   `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+
+/**
+ * Quote pairs a phrase may be written in. Straight quotes are symmetric; the
+ * others are the typographic conventions of the corpus's own jurisdictions
+ * (Czech/German „…“, Polish „…”, French/Russian «…», German »…«), so a phrase
+ * pasted out of a judgment is read as a phrase rather than as loose words.
+ *
+ * Single quotes are deliberately absent: an apostrophe inside a word (l'État,
+ * d'une) would open a span that never closes and swallow the rest of the query.
+ * `“` is both an opener (English) and a valid closer for `„` (Czech); reading
+ * it as an opener only where it starts a span keeps both conventions working.
+ */
+const PHRASE_QUOTE_CLOSERS = new Map<string, string>([
+  ['"', '"'],
+  ["“", "”"],
+  ["„", "“”"],
+  ["«", "»"],
+  ["»", "«"],
+]);
+
+/**
+ * Unicode word characters only, or null when the text holds none. Everything
+ * the engine could parse as DSL is dropped here rather than escaped, inside a
+ * phrase exactly as outside one.
+ */
+const corpusTerms = (text: string): RegExpMatchArray | null =>
+  text.match(/[\p{L}\p{N}]+/gu);
+
+/**
+ * Index of the first character in `closers`, or -1. Every quote character is
+ * in the BMP, so scanning UTF-16 units cannot split a surrogate pair into a
+ * false match.
+ */
+const findPhraseEnd = (text: string, from: number, closers: string): number => {
+  for (let index = from; index < text.length; index += 1) {
+    if (closers.includes(text.charAt(index))) {
+      return index;
+    }
+  }
+  return -1;
+};
+
+/**
+ * What one piece of user text asks the engine for. `value` is already reduced
+ * to unicode word characters (a phrase's words separated by single spaces), so
+ * a consumer never has to re-derive the safety rule. The distinction is not
+ * cosmetic: a term may be rewritten — expanded to morphological variants, say —
+ * where a phrase may not, because rewriting a phrase's words would silently
+ * change what the reader asked to match adjacently.
+ */
+export type CorpusQueryToken =
+  | { type: "phrase"; value: string }
+  | { type: "term"; value: string };
+
+/**
+ * Split free user text into phrase and term tokens. The single splitter over
+ * this input: anything that reads the query's structure (clause building,
+ * rewriting) consumes these tokens rather than re-scanning the raw string,
+ * so two scanners cannot drift into two answers about where a phrase ends.
+ *
+ * A balanced quoted span becomes one phrase token. An unbalanced quote carries
+ * no span, so its text degrades to ordinary terms rather than to an engine
+ * parse error; an empty span yields no token at all. Text without quotes yields
+ * exactly the terms it always did.
+ */
+export const tokenizeCorpusFreeText = (text: string): CorpusQueryToken[] => {
+  const tokens: CorpusQueryToken[] = [];
+  let plain = "";
+
+  const flushPlain = () => {
+    const terms = corpusTerms(plain);
+    plain = "";
+    if (terms === null) {
+      return;
+    }
+    for (const term of terms) {
+      tokens.push({ type: "term", value: term });
+    }
+  };
+
+  let index = 0;
+  while (index < text.length) {
+    const char = text.charAt(index);
+    const closers = PHRASE_QUOTE_CLOSERS.get(char);
+    if (closers === undefined) {
+      plain += char;
+      index += 1;
+      continue;
+    }
+
+    const end = findPhraseEnd(text, index + 1, closers);
+    if (end === -1) {
+      index += 1;
+      continue;
+    }
+
+    flushPlain();
+    const words = corpusTerms(text.slice(index + 1, end));
+    if (words !== null) {
+      tokens.push({ type: "phrase", value: words.join(" ") });
+    }
+    index = end + 1;
+  }
+  flushPlain();
+
+  return tokens;
+};
+
+/**
+ * Convert free user text into a safe corpus-index query clause. The engine's
+ * query string syntax (field clauses, AND/OR, parentheses, quotes) must never
+ * be reachable from user input, mirroring how the pg-fts path keeps user text
+ * literal via plainto_tsquery: keep only unicode word characters, quote each
+ * token, AND them. Returns null when no searchable token remains; callers
+ * return an empty page without querying the engine.
+ *
+ * `title` and `text` — the default search fields — record positions, so a bare
+ * quoted clause is a positional phrase match over both. A phrase and a term are
+ * quoted identically because a phrase is no more expressive than a term here:
+ * only the grouping differs.
+ */
+export const corpusFreeTextClause = (text: string): string | null => {
+  const clauses = tokenizeCorpusFreeText(text).map((token) => {
+    switch (token.type) {
+      case "phrase": {
+        return quoteCorpusValue(token.value);
+      }
+      case "term": {
+        return quoteCorpusValue(token.value);
+      }
+      default: {
+        return token satisfies never;
+      }
+    }
+  });
+
+  if (clauses.length === 0) {
+    return null;
+  }
+  return `(${clauses.join(" AND ")})`;
+};
+
+/**
+ * Filters a case-law corpus query may carry, named after the index fields
+ * rather than after either caller's request shape. `jurisdiction` is absent by
+ * design: it selects the index, so a scoped query never needs a clause for it.
+ */
+export type CaseLawCorpusFilters = {
+  court?: string | undefined;
+  dateFrom?: string | undefined;
+  dateTo?: string | undefined;
+  documentType?: string | undefined;
+  language?: string | undefined;
+  source?: string | undefined;
+};
+
+/**
+ * The one assembler for a case-law corpus-index query. Both read paths (the
+ * public search handler and the shared search provider) go through it, so
+ * there is a single answer to what the engine sees and a single escaping rule
+ * to audit. Null when the free text carries no searchable term: callers return
+ * an empty page rather than querying the engine.
+ */
+export const caseLawCorpusQuery = (
+  text: string,
+  filters: CaseLawCorpusFilters,
+): string | null => {
+  const freeText = corpusFreeTextClause(text);
+  if (freeText === null) {
+    return null;
+  }
+
+  const clauses: string[] = [freeText];
+  if (filters.documentType) {
+    clauses.push(`document_type:${quoteCorpusValue(filters.documentType)}`);
+  }
+  if (filters.source) {
+    clauses.push(`source:${quoteCorpusValue(filters.source)}`);
+  }
+  if (filters.language) {
+    clauses.push(`language:${quoteCorpusValue(filters.language)}`);
+  }
+  if (filters.court) {
+    clauses.push(`court:${quoteCorpusValue(filters.court)}`);
+  }
+  if (filters.dateFrom || filters.dateTo) {
+    clauses.push(
+      `decision_date:[${filters.dateFrom ?? "*"} TO ${filters.dateTo ?? "*"}]`,
+    );
+  }
+  return clauses.join(" AND ");
+};


### PR DESCRIPTION
## Phrase search

Free text reached the corpus index as individually quoted words ANDed together
(`("náhrada" AND "škody")`), so a reader asking for a phrase got every decision
mentioning both words anywhere in the text. `title` and `text` are indexed with
`record: position`, so the engine can answer the adjacency question directly.

A balanced quoted span now becomes a single phrase clause; the remaining words
keep the term treatment they had. Measured against the Czech case-law index:

| query | hits |
| --- | --- |
| `("náhrada" AND "škody")` | 21,087 |
| `("náhrada škody")` | 10,696 |

### Quote conventions

The corpus is written in several typographic conventions, so the parser accepts
the pairs its own documents use rather than only the English one:

| pair | convention |
| --- | --- |
| `"…"` | straight |
| `„…“` | Czech, German |
| `„…”` | Polish |
| `“…”` | English |
| `«…»` | French, Russian |
| `»…«` | German |

Single quotes are deliberately excluded: an apostrophe inside a word (`l'État`,
`d'une`) would open a span that never closes and swallow the rest of the query.
`“` is both an English opener and a Czech closer, which works because a
character is read as an opener only where it starts a span.

### Safety

A phrase is no more expressive than a term was. The span's content goes through
the same reduction a loose term does — tokenized to unicode word characters,
then quoted with `quoteCorpusValue` — so field clauses, booleans, wildcards,
parentheses and escapes cannot survive into the clause. Degradation is
deliberate rather than incidental:

- an unbalanced quote carries no span, and its text stays the terms it would
  have produced without the quote; never an engine parse error
- an empty or whitespace-only span contributes no clause at all
- quote-free input yields byte-identical clauses to before, pinned by test

Tests cover quoted, unquoted, mixed, multiple phrases, unbalanced and empty
spans, each quote convention, Czech diacritics, Arabic script, and injection
attempts carrying quotes, backslashes, field clauses and boolean operators.

## One query assembler

The two corpus-index read paths assembled their queries separately and had
already drifted apart: the public search handler used the shared clause builder,
while `corpus-index-provider.ts` kept a private `buildQuery`/`quote` pair that
interpolated its free text straight into the DSL and escaped quotes without
first escaping backslashes (so a trailing backslash in a filter value could
swallow its own closing quote).

Both paths now call one `caseLawCorpusQuery(text, filters)`. That leaves a
single escaping rule to audit, and it is why phrase support reaches both
without a second implementation. A guard test in
`corpus-index-query-guard.test.ts` fails the build if either path grows a local
quoting helper, a field clause of its own, or a template literal around user
text again.

## Tokenizer shape

The quoted-span split is exported as one `tokenizeCorpusFreeText` returning a
`{ type: "phrase" | "term"; value }` union, consumed by `corpusFreeTextClause`
through a switch with a `never` exhaustiveness check. A term may be rewritten
where a phrase may not, so a future rewriting pass reads the same token stream
rather than re-deriving the phrase boundary from the raw string.

## Not included: chronological browse from the index

The second half of the intended scope — serving the no-query decisions browse
from the corpus index, sorted by `decision_date` — is not here. It needs a
stable secondary sort key the engine does not have:

```
POST /api/v1/case_law_v2_cze/search  {"query":"seq:0","sort_by":"decision_date,document_id"}
-> Invalid argument: sort by field on type text is currently not supported `document_id`
```

`document_id` is a fast field but a text one, and the remaining numeric fast
fields (`year`, `seq`, `citation_count`, `citation_authority`) are not unique,
so a two-key sort cannot produce a stable tiebreak. Without one, a keyset
cursor over an offset-paged engine cannot guarantee that a page boundary lands
in the same place on the next request. Details and the measurements behind that
conclusion are in the PR discussion; the browse keeps its current SQL path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved case-law search handling for quoted phrases, multilingual text, punctuation, whitespace and Unicode characters.
  * Added support for combining free-text searches with court, date, document type, language and source filters.
  * Malformed or empty quoted phrases are handled safely without disrupting search.

* **Bug Fixes**
  * Strengthened query handling to prevent unsafe input from affecting search behaviour.
  * Standardised query construction across public case-law search experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->