### PR TITLE
fix(web): stabilize matter color interactions

### DIFF
--- a/apps/web/e2e/specs/matter-color-picker.spec.ts
+++ b/apps/web/e2e/specs/matter-color-picker.spec.ts
@@ -20,12 +20,25 @@ test("sidebar color picker stays open when custom colors are expanded", async ({
     });
     await expect(matterLink).toBeVisible({ timeout: 30_000 });
 
-    const colorTrigger = matterLink.locator("span").first();
+    const matterItem = sidebar.locator('[data-sidebar="menu-item"]', {
+      has: matterLink,
+    });
+    const colorTrigger = matterItem.getByRole("button", {
+      name: "Change color",
+    });
+    const colorPicker = page.locator('[data-slot="color-picker"]');
+
+    await colorTrigger.focus();
+    await page.keyboard.press("Enter");
+    await expect(colorPicker).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(colorPicker).toBeHidden();
+
     await colorTrigger.click({ button: "right" });
     await expect(
       colorTrigger.locator('[class~="animate-attention-flash"]'),
     ).toHaveCount(1);
-    await page.getByRole("button", { name: "Show more" }).click();
+    await colorPicker.getByRole("button", { name: "Show more" }).click();
 
     await expect(
       page.getByRole("textbox", { name: "Custom hex color" }),

--- a/apps/web/e2e/specs/matter-color-picker.spec.ts
+++ b/apps/web/e2e/specs/matter-color-picker.spec.ts
@@ -15,14 +15,12 @@ test("sidebar color picker stays open when custom colors are expanded", async ({
     });
 
     const sidebar = page.locator('[data-sidebar="sidebar"]');
-    const matterLink = sidebar.getByRole("link", {
-      name: new RegExp(workspaceName, "u"),
-    });
+    const matterItem = sidebar
+      .locator('[data-sidebar="menu-item"]')
+      .filter({ hasText: workspaceName });
+    const matterLink = matterItem.getByRole("link", { name: workspaceName });
     await expect(matterLink).toBeVisible({ timeout: 30_000 });
 
-    const matterItem = sidebar.locator('[data-sidebar="menu-item"]', {
-      has: matterLink,
-    });
     const colorTrigger = matterItem.getByRole("button", {
       name: "Change color",
     });

--- a/apps/web/e2e/specs/matter-color-picker.spec.ts
+++ b/apps/web/e2e/specs/matter-color-picker.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "../helpers/test";
+import { createTestWorkspace, deleteTestWorkspace } from "../helpers/workspace";
+
+test("sidebar color picker stays open when custom colors are expanded", async ({
+  page,
+  request,
+}) => {
+  const label = "matter-color-picker";
+  const workspace = await createTestWorkspace(request, label);
+  const workspaceName = `${label}-${workspace.id.slice(0, 8)}`;
+
+  try {
+    await page.goto(`/workspaces/${workspace.id}/${workspace.viewId}`, {
+      waitUntil: "commit",
+    });
+
+    const sidebar = page.locator('[data-sidebar="sidebar"]');
+    const matterLink = sidebar.getByRole("link", {
+      name: new RegExp(workspaceName, "u"),
+    });
+    await expect(matterLink).toBeVisible({ timeout: 30_000 });
+
+    const colorTrigger = matterLink.locator("span").first();
+    await colorTrigger.click({ button: "right" });
+    await expect(
+      colorTrigger.locator('[class~="animate-attention-flash"]'),
+    ).toHaveCount(1);
+    await page.getByRole("button", { name: "Show more" }).click();
+
+    await expect(
+      page.getByRole("textbox", { name: "Custom hex color" }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(
+      new RegExp(`/workspaces/${workspace.id}/${workspace.viewId}$`, "u"),
+    );
+  } finally {
+    await deleteTestWorkspace(request, workspace.id);
+  }
+});

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -98,6 +98,7 @@ import {
 import { CopyToMatterDialog } from "@/components/workspaces/copy-to-matter-dialog";
 import type { CopyToMatterEntity } from "@/components/workspaces/copy-to-matter-dialog.logic";
 import { EntityKindIcon } from "@/components/workspaces/entity-kind-icon";
+import { MatterColorContextPicker } from "@/components/workspaces/matter-color-picker";
 import {
   MatterMenuHeader,
   MatterMenuItems,
@@ -856,8 +857,14 @@ const NavContextMenu = ({
   );
 };
 
-const NavBadge = ({ digit }: { digit: number }) => (
-  <SidebarMenuBadge>
+const NavBadge = ({
+  className,
+  digit,
+}: {
+  className?: string;
+  digit: number;
+}) => (
+  <SidebarMenuBadge className={className}>
     <kbd className="animate-in bg-muted text-muted-foreground fade-in rounded border px-1.5 py-0.5 text-[0.625rem] duration-150">
       {digit}
     </kbd>
@@ -991,7 +998,10 @@ const MatterItem = ({
         return;
       }
       updateWorkspace.mutate(
-        { workspaceId: ws.id, name: value },
+        {
+          workspaceId: ws.id,
+          update: { type: "name", value },
+        },
         {
           onError: () => {
             stellaToast.add({
@@ -1221,7 +1231,7 @@ const MatterItem = ({
                 aria-label={
                   isExpanded ? t("common.showLess") : t("common.showMore")
                 }
-                className="text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute start-1 top-1 z-10 border-0 group-data-[collapsible=icon]:hidden before:hidden focus-visible:ring-1 focus-visible:ring-offset-0"
+                className="text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute end-1 top-1 z-10 border-0 group-data-[collapsible=icon]:hidden before:hidden focus-visible:ring-1 focus-visible:ring-offset-0"
                 onClick={onExpandedChange}
                 size="icon-xs"
                 type="button"
@@ -1241,7 +1251,10 @@ const MatterItem = ({
         )}
         <SidebarMenuButton
           asChild
-          className="ps-8 pe-12 group-data-[collapsible=icon]:ps-2"
+          className={cn(
+            "py-0 ps-2 group-data-[collapsible=icon]:ps-2",
+            activityIsKnownEmpty ? "pe-12" : "pe-20",
+          )}
           tooltip={[
             ws.name,
             ws.client?.displayName ?? t("workspaces.parties.personalLabel"),
@@ -1251,10 +1264,12 @@ const MatterItem = ({
             .join(" — ")}
         >
           <Link data-active={isActive || undefined} {...navigationTarget}>
-            <MatterIcon
-              className="size-4 shrink-0"
-              matter={{ id: ws.id, color: ws.color }}
-            />
+            <MatterColorContextPicker className="mt-0.5 self-start" matter={ws}>
+              <MatterIcon
+                className="size-4 shrink-0"
+                matter={{ id: ws.id, color: ws.color }}
+              />
+            </MatterColorContextPicker>
             <span className="flex min-w-0 flex-col">
               <BidiText as="span" className="truncate">
                 {ws.name}
@@ -1276,10 +1291,16 @@ const MatterItem = ({
           </Link>
         </SidebarMenuButton>
         {navBadge !== undefined ? (
-          <NavBadge digit={navBadge} />
+          <NavBadge
+            className={cn(!activityIsKnownEmpty && "end-7")}
+            digit={navBadge}
+          />
         ) : (
           <div
-            className="absolute end-1 top-1.5 flex items-center gap-0.5 opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 group-data-[collapsible=icon]:hidden data-[pinned]:opacity-100"
+            className={cn(
+              "absolute top-1.5 flex items-center gap-0.5 opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 group-data-[collapsible=icon]:hidden data-[pinned]:opacity-100",
+              activityIsKnownEmpty ? "end-1" : "end-7",
+            )}
             data-pinned={isPinned || undefined}
           >
             <Tooltip

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1249,10 +1249,20 @@ const MatterItem = ({
             />
           </Tooltip>
         )}
+        <MatterColorContextPicker
+          className="absolute start-2 top-2 z-10 size-4"
+          label={t("common.changeColor")}
+          matter={ws}
+        >
+          <MatterIcon
+            className="size-4 shrink-0"
+            matter={{ id: ws.id, color: ws.color }}
+          />
+        </MatterColorContextPicker>
         <SidebarMenuButton
           asChild
           className={cn(
-            "py-0 ps-2 group-data-[collapsible=icon]:ps-2",
+            "py-0 ps-8 group-data-[collapsible=icon]:ps-2",
             activityIsKnownEmpty ? "pe-12" : "pe-20",
           )}
           tooltip={[
@@ -1264,12 +1274,6 @@ const MatterItem = ({
             .join(" — ")}
         >
           <Link data-active={isActive || undefined} {...navigationTarget}>
-            <MatterColorContextPicker className="mt-0.5 self-start" matter={ws}>
-              <MatterIcon
-                className="size-4 shrink-0"
-                matter={{ id: ws.id, color: ws.color }}
-              />
-            </MatterColorContextPicker>
             <span className="flex min-w-0 flex-col">
               <BidiText as="span" className="truncate">
                 {ws.name}

--- a/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
@@ -235,7 +235,10 @@ export const WorkspaceBreadcrumb = ({
             if (isEditing) {
               return (
                 <>
-                  <MatterColorContextPicker matter={workspace}>
+                  <MatterColorContextPicker
+                    label={changeColorLabel}
+                    matter={workspace}
+                  >
                     <MatterIcon
                       className="size-3.5"
                       matter={{ id: workspaceId, color: workspace.color }}
@@ -269,47 +272,52 @@ export const WorkspaceBreadcrumb = ({
               );
             }
             return (
-              <Link
-                activeOptions={{
-                  exact: true,
-                  includeSearch: false,
-                }}
-                activeProps={{
-                  className: "text-foreground font-semibold",
-                }}
-                className="hover:text-foreground inline-flex max-w-80 items-center gap-1.5 font-semibold transition-colors"
-                onContextMenu={(e) => {
-                  e.preventDefault();
-                  startEditingName();
-                }}
-                params={{
-                  workspaceId,
-                }}
-                title={displayName}
-                to="/workspaces/$workspaceId"
-              >
-                <MatterColorContextPicker matter={workspace}>
+              <>
+                <MatterColorContextPicker
+                  label={changeColorLabel}
+                  matter={workspace}
+                >
                   <MatterIcon
                     className="size-3.5"
                     matter={{ id: workspaceId, color: workspace.color }}
                   />
                 </MatterColorContextPicker>
-                <BidiText as="span" className="truncate">
-                  {displayName}
-                </BidiText>
-                {workspace.reference && !isEditingRef ? (
-                  <span
-                    className="text-foreground-muted shrink-0 text-sm"
-                    onContextMenu={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      refRename.startEditing(workspace.reference);
-                    }}
-                  >
-                    {workspace.reference}
-                  </span>
-                ) : null}
-              </Link>
+                <Link
+                  activeOptions={{
+                    exact: true,
+                    includeSearch: false,
+                  }}
+                  activeProps={{
+                    className: "text-foreground font-semibold",
+                  }}
+                  className="hover:text-foreground inline-flex max-w-80 items-center gap-1.5 font-semibold transition-colors"
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    startEditingName();
+                  }}
+                  params={{
+                    workspaceId,
+                  }}
+                  title={displayName}
+                  to="/workspaces/$workspaceId"
+                >
+                  <BidiText as="span" className="truncate">
+                    {displayName}
+                  </BidiText>
+                  {workspace.reference && !isEditingRef ? (
+                    <span
+                      className="text-foreground-muted shrink-0 text-sm"
+                      onContextMenu={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        refRename.startEditing(workspace.reference);
+                      }}
+                    >
+                      {workspace.reference}
+                    </span>
+                  ) : null}
+                </Link>
+              </>
             );
           })()}
           {isEditingRef ? referenceSegment : null}

--- a/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
@@ -10,13 +10,7 @@ import {
   BreadcrumbItem,
   BreadcrumbSeparator,
 } from "@stll/ui/components/breadcrumb";
-import {
-  ColorPicker,
-  ColorPickerContent,
-  DEFAULT_PRESETS,
-} from "@stll/ui/components/color-picker";
 import { Input } from "@stll/ui/components/input";
-import { Popover, PopoverPopup } from "@stll/ui/components/popover";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
@@ -24,11 +18,14 @@ import { BreadcrumbLink } from "@/components/breadcrumbs/shared";
 import { MatterIcon } from "@/components/matter-icon";
 import { MatterNumberHint } from "@/components/matter-number-hint";
 import Tooltip from "@/components/tooltip";
+import {
+  MatterColorContextPicker,
+  MatterColorPicker,
+} from "@/components/workspaces/matter-color-picker";
 import { useInlineRename } from "@/hooks/use-inline-rename";
 import { detached } from "@/lib/detached";
 import { APIError } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
-import { getMatterPickerColor, toStoredMatterColor } from "@/lib/matter-colors";
 import { useUpdateWorkspace } from "@/lib/workspaces/mutations";
 import { workspaceOptions } from "@/lib/workspaces/queries";
 import { useConfigStore } from "@/stores/config-store";
@@ -47,8 +44,6 @@ export const WorkspaceBreadcrumb = ({
     shouldThrow: false,
   });
   const [refInputEl, setRefInputEl] = useState<HTMLInputElement | null>(null);
-  const [colorPickerOpen, setColorPickerOpen] = useState(false);
-  const [iconAnchor, setIconAnchor] = useState<HTMLSpanElement | null>(null);
   const { data: workspace } = useQuery(workspaceOptions(workspaceId));
   const updateWorkspace = useUpdateWorkspace();
   const updateMattersConfig = useConfigStore((s) => s.updateMatters);
@@ -56,7 +51,10 @@ export const WorkspaceBreadcrumb = ({
   const nameRename = useInlineRename({
     initial: workspace?.name ?? "",
     onCommit: (value) => {
-      updateWorkspace.mutate({ workspaceId, name: value });
+      updateWorkspace.mutate({
+        workspaceId,
+        update: { type: "name", value },
+      });
     },
   });
 
@@ -64,7 +62,10 @@ export const WorkspaceBreadcrumb = ({
     initial: workspace?.reference ?? "",
     onCommit: (value, { setError }) => {
       updateWorkspace.mutate(
-        { workspaceId, reference: value },
+        {
+          workspaceId,
+          update: { type: "reference", value },
+        },
         {
           onError: (error) => {
             if (APIError.is(error) && error.status === 409) {
@@ -106,22 +107,10 @@ export const WorkspaceBreadcrumb = ({
   const refError =
     refRename.state.mode === "edit" ? (refRename.state.error ?? "") : "";
 
-  const handleColorChange = (color: string) => {
-    updateWorkspace.mutate({
-      workspaceId,
-      color: toStoredMatterColor(color),
-    });
-  };
-
-  const activeSwatch = getMatterPickerColor(workspaceId, workspace.color);
   const changeColorLabel = t("common.changeColor");
 
   const colorPicker = match ? (
-    <ColorPicker
-      defaultExpanded={false}
-      onSelect={handleColorChange}
-      value={activeSwatch}
-    >
+    <MatterColorPicker matter={workspace}>
       <Tooltip
         content={changeColorLabel}
         render={
@@ -137,7 +126,7 @@ export const WorkspaceBreadcrumb = ({
           </button>
         }
       />
-    </ColorPicker>
+    </MatterColorPicker>
   ) : (
     <MatterIcon
       className="size-3.5 shrink-0"
@@ -246,20 +235,12 @@ export const WorkspaceBreadcrumb = ({
             if (isEditing) {
               return (
                 <>
-                  <span
-                    className="flex shrink-0"
-                    onContextMenu={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      setColorPickerOpen(true);
-                    }}
-                    ref={setIconAnchor}
-                  >
+                  <MatterColorContextPicker matter={workspace}>
                     <MatterIcon
                       className="size-3.5"
                       matter={{ id: workspaceId, color: workspace.color }}
                     />
-                  </span>
+                  </MatterColorContextPicker>
                   <Input
                     className={cn(matterNameInputClassName, "w-fit")}
                     disabled={updateWorkspace.isPending}
@@ -307,20 +288,12 @@ export const WorkspaceBreadcrumb = ({
                 title={displayName}
                 to="/workspaces/$workspaceId"
               >
-                <span
-                  className="flex shrink-0"
-                  onContextMenu={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setColorPickerOpen(true);
-                  }}
-                  ref={setIconAnchor}
-                >
+                <MatterColorContextPicker matter={workspace}>
                   <MatterIcon
                     className="size-3.5"
                     matter={{ id: workspaceId, color: workspace.color }}
                   />
-                </span>
+                </MatterColorContextPicker>
                 <BidiText as="span" className="truncate">
                   {displayName}
                 </BidiText>
@@ -342,22 +315,6 @@ export const WorkspaceBreadcrumb = ({
           {isEditingRef ? referenceSegment : null}
           {referenceHint}
         </BreadcrumbItem>
-        <Popover onOpenChange={setColorPickerOpen} open={colorPickerOpen}>
-          <PopoverPopup
-            align="start"
-            anchor={iconAnchor}
-            className="w-auto"
-            sideOffset={8}
-          >
-            <ColorPickerContent
-              columns={9}
-              defaultExpanded={false}
-              onSelect={handleColorChange}
-              presets={DEFAULT_PRESETS}
-              value={activeSwatch}
-            />
-          </PopoverPopup>
-        </Popover>
       </>
     );
   }

--- a/apps/web/src/components/workspaces/lead-section.tsx
+++ b/apps/web/src/components/workspaces/lead-section.tsx
@@ -47,7 +47,10 @@ export const LeadSection = ({ workspaceId }: LeadSectionProps) => {
       return;
     }
     updateWorkspace.mutate(
-      { workspaceId, leadUserId: value },
+      {
+        workspaceId,
+        update: { type: "leadUserId", value },
+      },
       {
         onError: () => {
           stellaToast.add({

--- a/apps/web/src/components/workspaces/matter-color-picker.tsx
+++ b/apps/web/src/components/workspaces/matter-color-picker.tsx
@@ -9,8 +9,10 @@ import {
   DEFAULT_PRESETS,
 } from "@stll/ui/components/color-picker";
 import { Popover, PopoverPopup } from "@stll/ui/components/popover";
+import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
+import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import {
   getMatterPickerColor,
   resolveMatterColor,
@@ -30,20 +32,14 @@ type MatterColorPickerContentProps = {
 const MatterColorPickerContent = ({
   matter,
 }: MatterColorPickerContentProps) => {
-  const t = useTranslations();
-  const updateWorkspace = useUpdateWorkspace();
+  const { moreLabel, selectColor } = useMatterColorPicker(matter);
 
   return (
     <ColorPickerContent
       columns={9}
       defaultExpanded={false}
-      moreLabel={t("common.showMore")}
-      onSelect={(color) => {
-        updateWorkspace.mutate({
-          workspaceId: matter.id,
-          update: { type: "color", value: toStoredMatterColor(color) },
-        });
-      }}
+      moreLabel={moreLabel}
+      onSelect={selectColor}
       presets={DEFAULT_PRESETS}
       value={getMatterPickerColor(matter.id, matter.color)}
     />
@@ -57,22 +53,17 @@ type MatterColorPickerProps = {
 
 type MatterColorContextPickerProps = MatterColorPickerProps & {
   className?: string;
+  label: string;
 };
 
 const MatterColorPicker = ({ children, matter }: MatterColorPickerProps) => {
-  const t = useTranslations();
-  const updateWorkspace = useUpdateWorkspace();
+  const { moreLabel, selectColor } = useMatterColorPicker(matter);
 
   return (
     <ColorPicker
       defaultExpanded={false}
-      moreLabel={t("common.showMore")}
-      onSelect={(color) => {
-        updateWorkspace.mutate({
-          workspaceId: matter.id,
-          update: { type: "color", value: toStoredMatterColor(color) },
-        });
-      }}
+      moreLabel={moreLabel}
+      onSelect={selectColor}
       value={getMatterPickerColor(matter.id, matter.color)}
     >
       {children}
@@ -83,21 +74,33 @@ const MatterColorPicker = ({ children, matter }: MatterColorPickerProps) => {
 const MatterColorContextPicker = ({
   children,
   className,
+  label,
   matter,
 }: MatterColorContextPickerProps) => {
   const [open, setOpen] = useState(false);
   const [anchor, setAnchor] = useState<HTMLSpanElement | null>(null);
 
+  const openPicker = () => setOpen(true);
+
   return (
     <>
-      <span
-        className={cn("relative flex shrink-0", className)}
+      <button
+        aria-label={label}
+        className={cn(
+          "relative flex shrink-0 items-center justify-center rounded outline-hidden focus-visible:ring-2",
+          className,
+        )}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          openPicker();
+        }}
         onContextMenu={(event) => {
           event.preventDefault();
           event.stopPropagation();
-          setOpen(true);
+          openPicker();
         }}
-        ref={setAnchor}
+        type="button"
       >
         <span
           aria-hidden
@@ -109,8 +112,10 @@ const MatterColorContextPicker = ({
             backgroundColor: `color-mix(in srgb, ${resolveMatterColor(matter.id, matter.color)} 18%, transparent)`,
           }}
         />
-        <span className="relative flex">{children}</span>
-      </span>
+        <span className="relative flex" ref={setAnchor}>
+          {children}
+        </span>
+      </button>
       <Popover onOpenChange={setOpen} open={open}>
         <PopoverPopup
           align="start"
@@ -124,6 +129,31 @@ const MatterColorContextPicker = ({
       </Popover>
     </>
   );
+};
+
+const useMatterColorPicker = (matter: MatterColorIdentity) => {
+  const t = useTranslations();
+  const updateWorkspace = useUpdateWorkspace();
+
+  return {
+    moreLabel: t("common.showMore"),
+    selectColor: (color: string) => {
+      updateWorkspace.mutate(
+        {
+          workspaceId: matter.id,
+          update: { type: "color", value: toStoredMatterColor(color) },
+        },
+        {
+          onError: (error) => {
+            stellaToast.add({
+              title: userErrorFromThrown(error, t("errors.actionFailed")),
+              type: "error",
+            });
+          },
+        },
+      );
+    },
+  };
 };
 
 export {

--- a/apps/web/src/components/workspaces/matter-color-picker.tsx
+++ b/apps/web/src/components/workspaces/matter-color-picker.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import type { ReactNode } from "react";
+
+import { useTranslations } from "use-intl";
+
+import {
+  ColorPicker,
+  ColorPickerContent,
+  DEFAULT_PRESETS,
+} from "@stll/ui/components/color-picker";
+import { Popover, PopoverPopup } from "@stll/ui/components/popover";
+import { cn } from "@stll/ui/lib/utils";
+
+import {
+  getMatterPickerColor,
+  resolveMatterColor,
+  toStoredMatterColor,
+} from "@/lib/matter-colors";
+import { useUpdateWorkspace } from "@/lib/workspaces/mutations";
+
+type MatterColorIdentity = {
+  color: string | null;
+  id: string;
+};
+
+type MatterColorPickerContentProps = {
+  matter: MatterColorIdentity;
+};
+
+const MatterColorPickerContent = ({
+  matter,
+}: MatterColorPickerContentProps) => {
+  const t = useTranslations();
+  const updateWorkspace = useUpdateWorkspace();
+
+  return (
+    <ColorPickerContent
+      columns={9}
+      defaultExpanded={false}
+      moreLabel={t("common.showMore")}
+      onSelect={(color) => {
+        updateWorkspace.mutate({
+          workspaceId: matter.id,
+          update: { type: "color", value: toStoredMatterColor(color) },
+        });
+      }}
+      presets={DEFAULT_PRESETS}
+      value={getMatterPickerColor(matter.id, matter.color)}
+    />
+  );
+};
+
+type MatterColorPickerProps = {
+  children: ReactNode;
+  matter: MatterColorIdentity;
+};
+
+type MatterColorContextPickerProps = MatterColorPickerProps & {
+  className?: string;
+};
+
+const MatterColorPicker = ({ children, matter }: MatterColorPickerProps) => {
+  const t = useTranslations();
+  const updateWorkspace = useUpdateWorkspace();
+
+  return (
+    <ColorPicker
+      defaultExpanded={false}
+      moreLabel={t("common.showMore")}
+      onSelect={(color) => {
+        updateWorkspace.mutate({
+          workspaceId: matter.id,
+          update: { type: "color", value: toStoredMatterColor(color) },
+        });
+      }}
+      value={getMatterPickerColor(matter.id, matter.color)}
+    >
+      {children}
+    </ColorPicker>
+  );
+};
+
+const MatterColorContextPicker = ({
+  children,
+  className,
+  matter,
+}: MatterColorContextPickerProps) => {
+  const [open, setOpen] = useState(false);
+  const [anchor, setAnchor] = useState<HTMLSpanElement | null>(null);
+
+  return (
+    <>
+      <span
+        className={cn("relative flex shrink-0", className)}
+        onContextMenu={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setOpen(true);
+        }}
+        ref={setAnchor}
+      >
+        <span
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute -inset-1 rounded-md opacity-0 motion-reduce:animate-none",
+            open && "animate-attention-flash",
+          )}
+          style={{
+            backgroundColor: `color-mix(in srgb, ${resolveMatterColor(matter.id, matter.color)} 18%, transparent)`,
+          }}
+        />
+        <span className="relative flex">{children}</span>
+      </span>
+      <Popover onOpenChange={setOpen} open={open}>
+        <PopoverPopup
+          align="start"
+          anchor={anchor}
+          className="w-auto"
+          onClick={(event) => event.stopPropagation()}
+          sideOffset={8}
+        >
+          <MatterColorPickerContent matter={matter} />
+        </PopoverPopup>
+      </Popover>
+    </>
+  );
+};
+
+export {
+  MatterColorContextPicker,
+  MatterColorPicker,
+  MatterColorPickerContent,
+};

--- a/apps/web/src/components/workspaces/matter-context-menu.tsx
+++ b/apps/web/src/components/workspaces/matter-context-menu.tsx
@@ -397,7 +397,10 @@ export const useMatterContextMenu = (
 
     const trimmed = rename.draft.trim();
     if (trimmed && trimmed !== target.name) {
-      updateWorkspace.mutate({ workspaceId: target.id, name: trimmed });
+      updateWorkspace.mutate({
+        workspaceId: target.id,
+        update: { type: "name", value: trimmed },
+      });
     }
     setRename({ status: "idle" });
   };

--- a/apps/web/src/components/workspaces/matter-metadata-sheet.tsx
+++ b/apps/web/src/components/workspaces/matter-metadata-sheet.tsx
@@ -118,7 +118,7 @@ export const MatterMetadataPanel = ({
     updateWorkspace.mutate(
       {
         workspaceId,
-        name: trimmed,
+        update: { type: "name", value: trimmed },
       },
       {
         onSuccess: () => {
@@ -150,7 +150,7 @@ export const MatterMetadataPanel = ({
     updateWorkspace.mutate(
       {
         workspaceId,
-        reference: trimmed,
+        update: { type: "reference", value: trimmed },
       },
       {
         onSuccess: () => {

--- a/apps/web/src/components/workspaces/parties-section.tsx
+++ b/apps/web/src/components/workspaces/parties-section.tsx
@@ -97,7 +97,10 @@ export const PartiesSection = ({ workspaceId }: PartiesSectionProps) => {
 
   const handleSetClient = (contact: { id: string; displayName: string }) => {
     updateWorkspace.mutate(
-      { workspaceId, clientId: contact.id },
+      {
+        workspaceId,
+        update: { type: "clientId", value: contact.id },
+      },
       {
         onSuccess: () => {
           stellaToast.add({
@@ -323,7 +326,10 @@ const PromoteDialog = ({ workspaceId }: PromoteDialogProps) => {
     updateWorkspace.mutate(
       {
         workspaceId,
-        promote: { clientId: selectedContact.id },
+        update: {
+          type: "promote",
+          value: { clientId: selectedContact.id },
+        },
       },
       {
         onSuccess: () => {

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -4231,8 +4231,8 @@
       "untitledColumn": "اسم العمود، مثل تاريخ السريان"
     },
     "reference": "الرقم المرجعي",
-    "referenceConventionHint": "تنسيق المؤسسة: {example}",
-    "referenceFormatWarning": "لا يطابق تنسيق المؤسسة.",
+    "referenceConventionHint": "التنسيق المفضل: {example}",
+    "referenceFormatWarning": "لا يطابق التنسيق المفضل.",
     "referencePlaceholder": "مثال: 2024/001",
     "referenceTaken": "هذا الرقم المرجعي مستخدَم بالفعل",
     "sections": {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -4231,8 +4231,8 @@
       "untitledColumn": "Název sloupce, např. Datum účinnosti"
     },
     "reference": "Referenční číslo",
-    "referenceConventionHint": "Formát organizace: {example}",
-    "referenceFormatWarning": "Neodpovídá formátu organizace.",
+    "referenceConventionHint": "Preferovaný formát: {example}",
+    "referenceFormatWarning": "Neodpovídá preferovanému formátu.",
     "referencePlaceholder": "např. 2024/001",
     "referenceTaken": "Toto referenční číslo je již použito",
     "sections": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -4231,8 +4231,8 @@
       "untitledColumn": "Spaltenname, z. B. Vertragsbeginn"
     },
     "reference": "Aktenzeichen",
-    "referenceConventionHint": "Organisationsformat: {example}",
-    "referenceFormatWarning": "Entspricht nicht dem Organisationsformat.",
+    "referenceConventionHint": "Bevorzugtes Format: {example}",
+    "referenceFormatWarning": "Entspricht nicht dem bevorzugten Format.",
     "referencePlaceholder": "z. B. 2024/001",
     "referenceTaken": "Diese Referenznummer wird bereits verwendet",
     "sections": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -4231,8 +4231,8 @@
       "untitledColumn": "Column name, e.g. Effective date"
     },
     "reference": "Reference number",
-    "referenceConventionHint": "Organization format: {example}",
-    "referenceFormatWarning": "Doesn't match the organization format.",
+    "referenceConventionHint": "Preferred format: {example}",
+    "referenceFormatWarning": "Doesn't match the preferred format.",
     "referencePlaceholder": "e.g. 2024/001",
     "referenceTaken": "This reference number is already in use",
     "sections": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -4231,8 +4231,8 @@
       "untitledColumn": "Nombre de columna, p. ej. Fecha de vigencia"
     },
     "reference": "Número de referencia",
-    "referenceConventionHint": "Formato de la organización: {example}",
-    "referenceFormatWarning": "No coincide con el formato de la organización.",
+    "referenceConventionHint": "Formato preferido: {example}",
+    "referenceFormatWarning": "No coincide con el formato preferido.",
     "referencePlaceholder": "p. ej. 2024/001",
     "referenceTaken": "Este número de referencia ya está en uso",
     "sections": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -4231,8 +4231,8 @@
       "untitledColumn": "Veeru nimi, nt jõustumiskuupäev"
     },
     "reference": "Viitenumber",
-    "referenceConventionHint": "Organisatsiooni vorming: {example}",
-    "referenceFormatWarning": "Ei vasta organisatsiooni vormingule.",
+    "referenceConventionHint": "Eelistatud vorming: {example}",
+    "referenceFormatWarning": "Ei vasta eelistatud vormingule.",
     "referencePlaceholder": "nt 2024/001",
     "referenceTaken": "See viitenumber on juba kasutusel",
     "sections": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -4231,8 +4231,8 @@
       "untitledColumn": "Nom de colonne, p. ex. Date d'effet"
     },
     "reference": "Numéro de référence",
-    "referenceConventionHint": "Format de l'organisation : {example}",
-    "referenceFormatWarning": "Ne correspond pas au format de l'organisation.",
+    "referenceConventionHint": "Format préféré : {example}",
+    "referenceFormatWarning": "Ne correspond pas au format préféré.",
     "referencePlaceholder": "ex. 2024/001",
     "referenceTaken": "Ce numéro de référence est déjà utilisé",
     "sections": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -4231,8 +4231,8 @@
       "untitledColumn": "Oszlop neve, pl. Hatálybalépés dátuma"
     },
     "reference": "Hivatkozási szám",
-    "referenceConventionHint": "Szervezeti formátum: {example}",
-    "referenceFormatWarning": "Nem egyezik a szervezeti formátummal.",
+    "referenceConventionHint": "Előnyben részesített formátum: {example}",
+    "referenceFormatWarning": "Nem egyezik az előnyben részesített formátummal.",
     "referencePlaceholder": "pl. 2024/001",
     "referenceTaken": "Ez a hivatkozási szám már használatban van",
     "sections": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -4231,8 +4231,8 @@
       "untitledColumn": "Stulpelio pavadinimas, pvz., įsigaliojimo data"
     },
     "reference": "Nuorodos numeris",
-    "referenceConventionHint": "Organizacijos formatas: {example}",
-    "referenceFormatWarning": "Neatitinka organizacijos formato.",
+    "referenceConventionHint": "Pageidaujamas formatas: {example}",
+    "referenceFormatWarning": "Neatitinka pageidaujamo formato.",
     "referencePlaceholder": "pvz. 2024/001",
     "referenceTaken": "Šis nuorodos numeris jau naudojamas",
     "sections": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -4231,8 +4231,8 @@
       "untitledColumn": "Kolonnas nosaukums, piem., spēkā stāšanās datums"
     },
     "reference": "Atsauces numurs",
-    "referenceConventionHint": "Organizācijas formāts: {example}",
-    "referenceFormatWarning": "Neatbilst organizācijas formātam.",
+    "referenceConventionHint": "Vēlamais formāts: {example}",
+    "referenceFormatWarning": "Neatbilst vēlamajam formātam.",
     "referencePlaceholder": "piem. 2024/001",
     "referenceTaken": "Šis atsauces numurs jau tiek izmantots",
     "sections": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -4234,8 +4234,8 @@ type Messages = {
       "untitledColumn": "Column name, e.g. Effective date";
     };
     "reference": "Reference number";
-    "referenceConventionHint": "Organization format: {example}";
-    "referenceFormatWarning": "Doesn't match the organization format.";
+    "referenceConventionHint": "Preferred format: {example}";
+    "referenceFormatWarning": "Doesn't match the preferred format.";
     "referencePlaceholder": "e.g. 2024/001";
     "referenceTaken": "This reference number is already in use";
     "sections": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -4231,8 +4231,8 @@
       "untitledColumn": "Nazwa kolumny, np. Data wejścia w życie"
     },
     "reference": "Numer referencyjny",
-    "referenceConventionHint": "Format organizacji: {example}",
-    "referenceFormatWarning": "Nie pasuje do formatu organizacji.",
+    "referenceConventionHint": "Preferowany format: {example}",
+    "referenceFormatWarning": "Nie pasuje do preferowanego formatu.",
     "referencePlaceholder": "np. 2024/001",
     "referenceTaken": "Ten numer referencyjny jest już w użyciu",
     "sections": {

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -4231,8 +4231,8 @@
       "untitledColumn": "Nome da coluna, ex.: Data de vigência"
     },
     "reference": "Número de referência",
-    "referenceConventionHint": "Formato de organização: {example}",
-    "referenceFormatWarning": "Não corresponde ao formato da organização.",
+    "referenceConventionHint": "Formato preferido: {example}",
+    "referenceFormatWarning": "Não corresponde ao formato preferido.",
     "referencePlaceholder": "por exemplo 2024/001",
     "referenceTaken": "Este número de referência já está em uso",
     "sections": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -4231,8 +4231,8 @@
       "untitledColumn": "Názov stĺpca, napr. Dátum účinnosti"
     },
     "reference": "Referenčné číslo",
-    "referenceConventionHint": "Formát organizácie: {example}",
-    "referenceFormatWarning": "Nezhoduje sa s formátom organizácie.",
+    "referenceConventionHint": "Preferovaný formát: {example}",
+    "referenceFormatWarning": "Nezhoduje sa s preferovaným formátom.",
     "referencePlaceholder": "napr. 2024/001",
     "referenceTaken": "Toto referenčné číslo sa už používa",
     "sections": {

--- a/apps/web/src/lib/folio-ui-components.ts
+++ b/apps/web/src/lib/folio-ui-components.ts
@@ -1,7 +1,12 @@
+import { createElement } from "react";
+
+import { useTranslations } from "use-intl";
+
 import type { FolioUIComponents } from "@stll/folio-react";
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { ColorPicker } from "@stll/ui/components/color-picker";
+import type { ColorPickerProps } from "@stll/ui/components/color-picker";
 import {
   Dialog,
   DialogBackdrop,
@@ -38,6 +43,15 @@ import {
 
 import { DatePickerPopover } from "@/components/date-picker-popover";
 
+const LocalizedColorPicker = (props: Omit<ColorPickerProps, "moreLabel">) => {
+  const t = useTranslations();
+
+  return createElement(ColorPicker, {
+    ...props,
+    moreLabel: t("common.showMore"),
+  });
+};
+
 /**
  * Chrome UI primitives injected into folio's `DocxEditor` so the editor keeps
  * the app's design system while folio itself stays UI-agnostic. The object
@@ -53,7 +67,7 @@ export const folioUIComponents: Partial<FolioUIComponents> = {
   Button,
   Checkbox,
   Input,
-  ColorPicker,
+  ColorPicker: LocalizedColorPicker,
   DatePickerPopover,
   OutlineRail,
   Dialog: {

--- a/apps/web/src/lib/workspaces/mutations.test.ts
+++ b/apps/web/src/lib/workspaces/mutations.test.ts
@@ -74,8 +74,10 @@ describe("workspace update cache invalidation", () => {
 
   test("maps every workspace update variant to its API body", async () => {
     const { workspaceUpdateBody } = await import("@/lib/workspaces/mutations");
+    const { toSafeId } = await import("@/lib/safe-id");
+    const contactId = toSafeId<"contact">("contact_test");
 
-    const bodies: unknown = [
+    const bodies = [
       workspaceUpdateBody({ type: "clientId", value: "contact_test" }),
       workspaceUpdateBody({ type: "color", value: "purple" }),
       workspaceUpdateBody({ type: "color", value: null }),
@@ -97,16 +99,16 @@ describe("workspace update cache invalidation", () => {
     ];
 
     expect(bodies).toEqual([
-      { clientId: "contact_test" },
+      { clientId: contactId },
       { color: "purple" },
       { color: null },
       { leadUserId: "user_test" },
       { leadUserId: null },
       { name: "Renamed matter" },
-      { promote: { clientId: "contact_test" } },
+      { promote: { clientId: contactId } },
       {
         promote: {
-          clientId: "contact_test",
+          clientId: contactId,
           memberUserIds: ["user_one", "user_two"],
         },
       },

--- a/apps/web/src/lib/workspaces/mutations.test.ts
+++ b/apps/web/src/lib/workspaces/mutations.test.ts
@@ -43,6 +43,32 @@ describe("workspace update cache invalidation", () => {
     ]);
   });
 
+  test("only name updates have a document-title side effect", async () => {
+    const { workspaceUpdateEffects } =
+      await import("@/lib/workspaces/mutations");
+
+    expect(
+      workspaceUpdateEffects({ type: "name", value: "Renamed matter" }),
+    ).toEqual({ documentTitle: "Renamed matter" });
+
+    expect([
+      workspaceUpdateEffects({ type: "clientId", value: "contact_test" }),
+      workspaceUpdateEffects({ type: "color", value: "purple" }),
+      workspaceUpdateEffects({ type: "leadUserId", value: "user_test" }),
+      workspaceUpdateEffects({
+        type: "promote",
+        value: { clientId: "contact_test" },
+      }),
+      workspaceUpdateEffects({ type: "reference", value: "REF-42" }),
+    ]).toEqual([
+      { documentTitle: null },
+      { documentTitle: null },
+      { documentTitle: null },
+      { documentTitle: null },
+      { documentTitle: null },
+    ]);
+  });
+
   test("member mutations invalidate the members query and the matters list", async () => {
     const { workspaceMemberMutationInvalidationKeys } =
       await import("@/lib/workspaces/mutations/workspace-members");

--- a/apps/web/src/lib/workspaces/mutations.test.ts
+++ b/apps/web/src/lib/workspaces/mutations.test.ts
@@ -43,29 +43,74 @@ describe("workspace update cache invalidation", () => {
     ]);
   });
 
-  test("only name updates have a document-title side effect", async () => {
-    const { workspaceUpdateEffects } =
+  test("only name updates invalidate the current route metadata", async () => {
+    const { workspaceUpdateInvalidatesRoute } =
       await import("@/lib/workspaces/mutations");
 
-    expect(
-      workspaceUpdateEffects({ type: "name", value: "Renamed matter" }),
-    ).toEqual({ documentTitle: "Renamed matter" });
-
     expect([
-      workspaceUpdateEffects({ type: "clientId", value: "contact_test" }),
-      workspaceUpdateEffects({ type: "color", value: "purple" }),
-      workspaceUpdateEffects({ type: "leadUserId", value: "user_test" }),
-      workspaceUpdateEffects({
+      workspaceUpdateInvalidatesRoute({
+        type: "name",
+        value: "Renamed matter",
+      }),
+      workspaceUpdateInvalidatesRoute({
+        type: "clientId",
+        value: "contact_test",
+      }),
+      workspaceUpdateInvalidatesRoute({ type: "color", value: "purple" }),
+      workspaceUpdateInvalidatesRoute({
+        type: "leadUserId",
+        value: "user_test",
+      }),
+      workspaceUpdateInvalidatesRoute({
         type: "promote",
         value: { clientId: "contact_test" },
       }),
-      workspaceUpdateEffects({ type: "reference", value: "REF-42" }),
-    ]).toEqual([
-      { documentTitle: null },
-      { documentTitle: null },
-      { documentTitle: null },
-      { documentTitle: null },
-      { documentTitle: null },
+      workspaceUpdateInvalidatesRoute({
+        type: "reference",
+        value: "REF-42",
+      }),
+    ]).toEqual([true, false, false, false, false, false]);
+  });
+
+  test("maps every workspace update variant to its API body", async () => {
+    const { workspaceUpdateBody } = await import("@/lib/workspaces/mutations");
+
+    const bodies: unknown = [
+      workspaceUpdateBody({ type: "clientId", value: "contact_test" }),
+      workspaceUpdateBody({ type: "color", value: "purple" }),
+      workspaceUpdateBody({ type: "color", value: null }),
+      workspaceUpdateBody({ type: "leadUserId", value: "user_test" }),
+      workspaceUpdateBody({ type: "leadUserId", value: null }),
+      workspaceUpdateBody({ type: "name", value: "Renamed matter" }),
+      workspaceUpdateBody({
+        type: "promote",
+        value: { clientId: "contact_test", memberUserIds: [] },
+      }),
+      workspaceUpdateBody({
+        type: "promote",
+        value: {
+          clientId: "contact_test",
+          memberUserIds: ["user_one", "user_two"],
+        },
+      }),
+      workspaceUpdateBody({ type: "reference", value: "REF-42" }),
+    ];
+
+    expect(bodies).toEqual([
+      { clientId: "contact_test" },
+      { color: "purple" },
+      { color: null },
+      { leadUserId: "user_test" },
+      { leadUserId: null },
+      { name: "Renamed matter" },
+      { promote: { clientId: "contact_test" } },
+      {
+        promote: {
+          clientId: "contact_test",
+          memberUserIds: ["user_one", "user_two"],
+        },
+      },
+      { reference: "REF-42" },
     ]);
   });
 

--- a/apps/web/src/lib/workspaces/mutations.ts
+++ b/apps/web/src/lib/workspaces/mutations.ts
@@ -3,7 +3,7 @@ import {
   useMutation,
   useQueryClient,
 } from "@tanstack/react-query";
-import { useRouter } from "@tanstack/react-router";
+import { useRouterState } from "@tanstack/react-router";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
@@ -13,6 +13,7 @@ import {
   toAPIError,
   unwrapEden,
 } from "@/lib/errors/api";
+import { pageTitleLiteral } from "@/lib/page-title";
 import { toSafeId } from "@/lib/safe-id";
 import { workspacesKeys } from "@/lib/workspaces/queries";
 
@@ -65,17 +66,86 @@ export const useCreateWorkspace = () => {
   });
 };
 
-type UpdateWorkspaceVars = {
-  workspaceId: string;
-  name?: string;
-  clientId?: string;
-  reference?: string;
-  color?: string | null;
-  leadUserId?: string | null;
-  promote?: {
+type WorkspaceUpdateValueByType = {
+  clientId: string;
+  color: string | null;
+  leadUserId: string | null;
+  name: string;
+  promote: {
     clientId: string;
     memberUserIds?: string[];
   };
+  reference: string;
+};
+
+type WorkspaceUpdateType = keyof WorkspaceUpdateValueByType;
+
+type WorkspaceUpdate = {
+  [Type in WorkspaceUpdateType]: {
+    type: Type;
+    value: WorkspaceUpdateValueByType[Type];
+  };
+}[WorkspaceUpdateType];
+
+type UpdateWorkspaceVars = {
+  workspaceId: string;
+  update: WorkspaceUpdate;
+};
+
+type WorkspaceUpdateEffects = {
+  documentTitle: string | null;
+};
+
+const NO_WORKSPACE_UPDATE_EFFECTS: WorkspaceUpdateEffects = {
+  documentTitle: null,
+};
+
+export const workspaceUpdateEffects = (
+  update: WorkspaceUpdate,
+): WorkspaceUpdateEffects => {
+  switch (update.type) {
+    case "name":
+      return { documentTitle: update.value };
+    case "clientId":
+    case "color":
+    case "leadUserId":
+    case "promote":
+    case "reference":
+      return NO_WORKSPACE_UPDATE_EFFECTS;
+    default: {
+      const unreachable: never = update;
+      return unreachable;
+    }
+  }
+};
+
+const workspaceUpdateBody = (update: WorkspaceUpdate) => {
+  switch (update.type) {
+    case "clientId":
+      return { clientId: toSafeId<"contact">(update.value) };
+    case "color":
+      return { color: update.value };
+    case "leadUserId":
+      return { leadUserId: update.value };
+    case "name":
+      return { name: update.value };
+    case "promote":
+      return {
+        promote: {
+          clientId: toSafeId<"contact">(update.value.clientId),
+          ...(update.value.memberUserIds &&
+            update.value.memberUserIds.length > 0 && {
+              memberUserIds: update.value.memberUserIds,
+            }),
+        },
+      };
+    case "reference":
+      return { reference: update.value };
+    default: {
+      const unreachable: never = update;
+      return unreachable;
+    }
+  }
 };
 
 export const workspaceUpdateInvalidationKeys = () => [workspacesKeys.all];
@@ -94,33 +164,25 @@ export const workspaceUpdateRefetchFilters = (
 export const useUpdateWorkspace = () => {
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
-  const router = useRouter();
+  const activeWorkspaceId = useRouterState({
+    select: (state) =>
+      state.matches.find(
+        (match) => match.routeId === "/_protected/workspaces/$workspaceId",
+      )?.params.workspaceId,
+  });
 
   return useMutation({
-    mutationFn: async ({ workspaceId, ...body }: UpdateWorkspaceVars) => {
-      const { clientId, promote, ...restBody } = body;
+    mutationFn: async ({ update, workspaceId }: UpdateWorkspaceVars) => {
       const response = await api
         .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
-        .post({
-          ...restBody,
-          ...(clientId !== undefined && {
-            clientId: toSafeId<"contact">(clientId),
-          }),
-          ...(promote !== undefined && {
-            promote: {
-              clientId: toSafeId<"contact">(promote.clientId),
-              ...(promote.memberUserIds && promote.memberUserIds.length > 0
-                ? { memberUserIds: promote.memberUserIds }
-                : {}),
-            },
-          }),
-        });
+        .post(workspaceUpdateBody(update));
 
       if (response.error) {
         throw toAPIError(response.error);
       }
     },
-    onSuccess: async (_data, { workspaceId }) => {
+    onSuccess: async (_data, variables) => {
+      const { workspaceId } = variables;
       await Promise.all(
         workspaceUpdateInvalidationKeys().map(async (queryKey) => {
           await queryClient.invalidateQueries({
@@ -136,11 +198,10 @@ export const useUpdateWorkspace = () => {
           },
         ),
       );
-      // Re-run route loaders so the document title (driven by the
-      // route `head` from loaderData) reflects the renamed matter
-      // without waiting for a navigation. Query invalidation alone
-      // refreshes components but not the cached loaderData.
-      await router.invalidate();
+      const effects = workspaceUpdateEffects(variables.update);
+      if (effects.documentTitle !== null && activeWorkspaceId === workspaceId) {
+        globalThis.document.title = pageTitleLiteral(effects.documentTitle);
+      }
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/lib/workspaces/mutations.ts
+++ b/apps/web/src/lib/workspaces/mutations.ts
@@ -3,7 +3,7 @@ import {
   useMutation,
   useQueryClient,
 } from "@tanstack/react-query";
-import { useRouterState } from "@tanstack/react-router";
+import { useRouter } from "@tanstack/react-router";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
@@ -13,7 +13,6 @@ import {
   toAPIError,
   unwrapEden,
 } from "@/lib/errors/api";
-import { pageTitleLiteral } from "@/lib/page-title";
 import { toSafeId } from "@/lib/safe-id";
 import { workspacesKeys } from "@/lib/workspaces/queries";
 
@@ -80,7 +79,7 @@ type WorkspaceUpdateValueByType = {
 
 type WorkspaceUpdateType = keyof WorkspaceUpdateValueByType;
 
-type WorkspaceUpdate = {
+export type WorkspaceUpdate = {
   [Type in WorkspaceUpdateType]: {
     type: Type;
     value: WorkspaceUpdateValueByType[Type];
@@ -92,26 +91,16 @@ type UpdateWorkspaceVars = {
   update: WorkspaceUpdate;
 };
 
-type WorkspaceUpdateEffects = {
-  documentTitle: string | null;
-};
-
-const NO_WORKSPACE_UPDATE_EFFECTS: WorkspaceUpdateEffects = {
-  documentTitle: null,
-};
-
-export const workspaceUpdateEffects = (
-  update: WorkspaceUpdate,
-): WorkspaceUpdateEffects => {
+export const workspaceUpdateInvalidatesRoute = (update: WorkspaceUpdate) => {
   switch (update.type) {
     case "name":
-      return { documentTitle: update.value };
+      return true;
     case "clientId":
     case "color":
     case "leadUserId":
     case "promote":
     case "reference":
-      return NO_WORKSPACE_UPDATE_EFFECTS;
+      return false;
     default: {
       const unreachable: never = update;
       return unreachable;
@@ -119,7 +108,7 @@ export const workspaceUpdateEffects = (
   }
 };
 
-const workspaceUpdateBody = (update: WorkspaceUpdate) => {
+export const workspaceUpdateBody = (update: WorkspaceUpdate) => {
   switch (update.type) {
     case "clientId":
       return { clientId: toSafeId<"contact">(update.value) };
@@ -164,12 +153,7 @@ export const workspaceUpdateRefetchFilters = (
 export const useUpdateWorkspace = () => {
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
-  const activeWorkspaceId = useRouterState({
-    select: (state) =>
-      state.matches.find(
-        (match) => match.routeId === "/_protected/workspaces/$workspaceId",
-      )?.params.workspaceId,
-  });
+  const router = useRouter();
 
   return useMutation({
     mutationFn: async ({ update, workspaceId }: UpdateWorkspaceVars) => {
@@ -198,9 +182,8 @@ export const useUpdateWorkspace = () => {
           },
         ),
       );
-      const effects = workspaceUpdateEffects(variables.update);
-      if (effects.documentTitle !== null && activeWorkspaceId === workspaceId) {
-        globalThis.document.title = pageTitleLiteral(effects.documentTitle);
+      if (workspaceUpdateInvalidatesRoute(variables.update)) {
+        await router.invalidate();
       }
     },
     onError: (error) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
@@ -355,6 +355,7 @@ export const KanbanColumn = ({
           if (color && onChangeColor) {
             return (
               <ColorPicker
+                moreLabel={t("common.showMore")}
                 value={optionColor}
                 onSelect={handleColorSelect}
                 side="bottom"
@@ -431,6 +432,7 @@ export const KanbanColumn = ({
                     <ColorPickerContent
                       columns={9}
                       defaultExpanded={false}
+                      moreLabel={t("common.showMore")}
                       onSelect={handleColorSelect}
                       presets={DEFAULT_PRESETS}
                       value={optionColor}

--- a/apps/web/src/routes/dev/-components/ui-playground.tsx
+++ b/apps/web/src/routes/dev/-components/ui-playground.tsx
@@ -290,6 +290,7 @@ const showUpdatingToast = () => {
 };
 
 export function UiPlayground() {
+  const t = useTranslations();
   const [checkboxChecked, setCheckboxChecked] = useState(true);
   const [selectValue, setSelectValue] = useState("litigation");
   const [comboboxQuery, setComboboxQuery] = useState("");
@@ -619,6 +620,7 @@ export function UiPlayground() {
                     value={dateValue}
                   />
                   <ColorPicker
+                    moreLabel={t("common.showMore")}
                     onClear={() => setColorValue("")}
                     onSelect={setColorValue}
                     value={colorValue}

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -39,6 +39,8 @@ type ColorPickerProps = {
   columns?: number;
   /** Start with hex input visible (default false) */
   defaultExpanded?: boolean;
+  /** Localized label for expanding the custom color controls. */
+  moreLabel: string;
   /** Popover trigger element */
   children: React.ReactNode;
   /** Popover placement side */
@@ -55,6 +57,7 @@ type ColorPickerContentProps = {
   presets: ColorPreset[];
   columns: number;
   defaultExpanded: boolean;
+  moreLabel: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -161,6 +164,7 @@ const ColorPickerContent = ({
   presets,
   columns,
   defaultExpanded,
+  moreLabel,
 }: ColorPickerContentProps) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
   // pickerHex: last valid 6-char hex from the visual picker (drives the picker's color prop)
@@ -241,7 +245,7 @@ const ColorPickerContent = ({
           onClick={() => setExpanded(true)}
           type="button"
         >
-          More
+          {moreLabel}
           <ChevronDownIcon className="size-3" />
         </button>
       ) : (
@@ -298,6 +302,7 @@ const ColorPicker = ({
   presets = DEFAULT_PRESETS,
   columns = 9,
   defaultExpanded = false,
+  moreLabel,
   children,
   side = "bottom",
   align = "start",
@@ -328,6 +333,7 @@ const ColorPicker = ({
           <ColorPickerContent
             columns={columns}
             defaultExpanded={defaultExpanded}
+            moreLabel={moreLabel}
             onClear={onClear}
             onSelect={onSelect}
             presets={presets}


### PR DESCRIPTION
## Summary

- model workspace metadata changes as exhaustive typed operations and update active titles without refreshing the route
- share the localized matter color picker across breadcrumb and sidebar, contain portal events, and align sidebar controls with a one-shot color flash
- cover custom-color expansion without navigation and replace organization-specific format wording across locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added workspace colour pickers to matter rows, context menus and workspace breadcrumbs.
  - Pickers support keyboard access, right-click actions, custom colours and hex values.
  - “More” labels in colour pickers are now translated.

- **Improvements**
  - Refined sidebar spacing, badges, action controls and right-to-left layouts.
  - Workspace edits now update titles and details more consistently.

- **Localisation**
  - Clarified reference-number guidance across supported languages.

- **Tests**
  - Added coverage for colour-picker behaviour and workspace update handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->