### PR TITLE
feat(api): morphological query expansion behind a flag

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -26,6 +26,11 @@
 # [secret] Optional. Logs otlp token.
 # LOGS_OTLP_TOKEN=""
 
+# [internal] Optional with a default. Morphological expansion of case-law
+# search terms: "off" builds today's query, "shadow" logs the expanded query
+# beside the unexpanded one it runs, "on" runs the expanded query.
+# QUERY_EXPANSION_MODE="off"
+
 # [secret] Required. Valkey or Redis URL used for cross-instance broadcasts
 # and rate limits. Treated as secret because it may contain credentials.
 REDIS_URL="redis://localhost:6379"

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -29,7 +29,8 @@
 # [internal] Optional with a default. Morphological expansion of case-law
 # search terms: "off" builds today's query, "shadow" runs the unexpanded query
 # and records leaf counts comparing it with the expanded one (never the query
-# text), "on" runs the expanded query.
+# text). "on" runs the expanded query and is currently refused at startup,
+# pending cursors that carry the dictionary version.
 # QUERY_EXPANSION_MODE="off"
 
 # [secret] Required. Valkey or Redis URL used for cross-instance broadcasts

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -27,8 +27,9 @@
 # LOGS_OTLP_TOKEN=""
 
 # [internal] Optional with a default. Morphological expansion of case-law
-# search terms: "off" builds today's query, "shadow" logs the expanded query
-# beside the unexpanded one it runs, "on" runs the expanded query.
+# search terms: "off" builds today's query, "shadow" runs the unexpanded query
+# and records leaf counts comparing it with the expanded one (never the query
+# text), "on" runs the expanded query.
 # QUERY_EXPANSION_MODE="off"
 
 # [secret] Required. Valkey or Redis URL used for cross-instance broadcasts

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -16,7 +16,10 @@ import {
   corpusStorageInvariantViolation,
   resolveCorpusStorageMode,
 } from "@/api/lib/corpus-storage-mode";
-import { QUERY_EXPANSION_MODES } from "@/api/lib/legal-search/query-expansion-mode";
+import {
+  QUERY_EXPANSION_MODES,
+  type QueryExpansionMode,
+} from "@/api/lib/legal-search/query-expansion-mode";
 import { isUsableStaticCredential } from "@/api/lib/s3-credentials";
 import { isTlsOrLoopbackUrl } from "@/api/lib/secure-service-url";
 
@@ -186,8 +189,9 @@ export const envBaseServerSchema = {
   // Morphological query expansion for case-law corpus-index searches.
   // `off` is byte-identical to the pre-expansion query builder and fetches
   // no dictionary; `shadow` executes the unexpanded query and records how the
-  // expanded one compares (leaf counts only, never query text); `on` executes
-  // the expanded query.
+  // expanded one compares (leaf counts only, never query text). `on` executes
+  // the expanded query and is refused at boot by the invariant below until
+  // corpus cursors carry the dictionary version they were built against.
   QUERY_EXPANSION_MODE: v.optional(v.picklist(QUERY_EXPANSION_MODES), "off"),
   isDev: v.boolean(),
 };
@@ -212,6 +216,7 @@ type EnvBaseInvariantInput = {
   DATABASE_URL: string;
   LEGAL_CORPUS_S3_BUCKET?: string | undefined;
   LEGAL_SEARCH_PROVIDER: "pg-fts" | "corpus-index";
+  QUERY_EXPANSION_MODE: QueryExpansionMode;
   S3_ACCESS_KEY_ID?: string | undefined;
   S3_CREDENTIALS_PROVIDER: "auto" | "env" | "aws-runtime" | "none";
   S3_ENDPOINT: string;
@@ -229,6 +234,7 @@ export const envBaseInvariantViolation = ({
   DATABASE_URL,
   LEGAL_CORPUS_S3_BUCKET,
   LEGAL_SEARCH_PROVIDER,
+  QUERY_EXPANSION_MODE,
   S3_ACCESS_KEY_ID,
   S3_CREDENTIALS_PROVIDER,
   S3_ENDPOINT,
@@ -258,6 +264,19 @@ export const envBaseInvariantViolation = ({
   }
   if (!isDev && CORPUS_INDEX_SEARCH_ENDPOINT !== undefined) {
     return "CORPUS_INDEX_SEARCH_ENDPOINT is only supported in local development.";
+  }
+  // REMOVAL CONDITION: delete this invariant in the PR that makes a corpus
+  // cursor carry the dictionary version it was built against.
+  //
+  // Under `on` the engine query depends on which dictionary the serving
+  // replica loaded, so a page-2 request landing on a replica mid-refresh
+  // rebuilds a different query and ranks a different result set against page
+  // 1's cursor, skipping or repeating decisions. `shadow` cannot reach this,
+  // because it executes the unexpanded query. Refusing the mode at boot is
+  // what keeps the broken combination unreachable rather than merely
+  // documented.
+  if (QUERY_EXPANSION_MODE === "on") {
+    return 'QUERY_EXPANSION_MODE="on" requires dictionary-version-carrying cursors; not yet implemented — use "shadow".';
   }
   if (
     CASE_LAW_DATABASE_URL !== undefined &&

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -16,6 +16,7 @@ import {
   corpusStorageInvariantViolation,
   resolveCorpusStorageMode,
 } from "@/api/lib/corpus-storage-mode";
+import { QUERY_EXPANSION_MODES } from "@/api/lib/legal-search/query-expansion-mode";
 import { isUsableStaticCredential } from "@/api/lib/s3-credentials";
 import { isTlsOrLoopbackUrl } from "@/api/lib/secure-service-url";
 
@@ -182,6 +183,11 @@ export const envBaseServerSchema = {
     min: 1,
     max: 32,
   }),
+  // Morphological query expansion for case-law corpus-index searches.
+  // `off` is byte-identical to the pre-expansion query builder and fetches
+  // no dictionary; `shadow` logs the expanded query beside the unexpanded
+  // one it still executes; `on` executes the expanded query.
+  QUERY_EXPANSION_MODE: v.optional(v.picklist(QUERY_EXPANSION_MODES), "off"),
   isDev: v.boolean(),
 };
 

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -185,8 +185,9 @@ export const envBaseServerSchema = {
   }),
   // Morphological query expansion for case-law corpus-index searches.
   // `off` is byte-identical to the pre-expansion query builder and fetches
-  // no dictionary; `shadow` logs the expanded query beside the unexpanded
-  // one it still executes; `on` executes the expanded query.
+  // no dictionary; `shadow` executes the unexpanded query and records how the
+  // expanded one compares (leaf counts only, never query text); `on` executes
+  // the expanded query.
   QUERY_EXPANSION_MODE: v.optional(v.picklist(QUERY_EXPANSION_MODES), "off"),
   isDev: v.boolean(),
 };

--- a/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
@@ -447,10 +447,17 @@ test("the ingestion role can take every lock the corpus checkpoint holds", async
   }
 });
 
+// The binding, not the statement's formatting: a consumer that imports the
+// shared builder alongside anything else, or across several lines, satisfies
+// this invariant exactly as much as a single-specifier import does. Pinning
+// the literal statement made a reformat look like a bypass.
+const SHARED_BUILDER_IMPORT =
+  /import\s*\{[^}]*\bcaseLawCorpusQuery\b[^}]*\}\s*from\s*"@\/api\/lib\/legal-search\/corpus-query"/su;
+
 // One assembler, or the two boundaries drift into two answers about what the
 // engine sees. The public search path and the shared provider must both reach
-// the engine through corpus-query.ts, and neither may re-derive quoting or
-// interpolate user text into the DSL itself.
+// the engine through corpus-query.ts, and neither may re-derive quoting,
+// interpolate user text into the DSL, or assemble a clause of its own.
 test("every case-law corpus query is assembled by the shared builder", async () => {
   const consumers = await Promise.all(
     [publicSearchSource, sharedSearchProviderSource].map(
@@ -458,18 +465,23 @@ test("every case-law corpus query is assembled by the shared builder", async () 
     ),
   );
   for (const source of consumers) {
-    expect(source).toContain(
-      'import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query"',
-    );
+    expect(source).toMatch(SHARED_BUILDER_IMPORT);
     expect(source).toContain("caseLawCorpusQuery(");
-    // A local escaping helper is how the two paths diverged before.
+    // A local escaping helper is how the two paths diverged before, and
+    // reaching for the shared quoting primitive is the same divergence with a
+    // shared name: quoting belongs to the builder that owns the clause.
     expect(source).not.toMatch(/const quote = /u);
     expect(source).not.toMatch(/replaceAll\('"'/u);
+    expect(source).not.toContain("quoteCorpusValue");
     // No field clause is assembled outside the shared builder, and free text
     // never reaches a template literal.
     expect(source).not.toMatch(/`(?:document_type|source|language|court):/u);
     expect(source).not.toMatch(/`decision_date:\[/u);
     expect(source).not.toMatch(/\$\{\w+\.query\}/u);
+    // Query expansion emits grouped OR leaves. That assembly is the builder's
+    // too: a consumer that grows its own group is the same drift in the shape
+    // the expander made reachable.
+    expect(source).not.toMatch(/"\s+OR\s+"/u);
   }
 });
 

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -36,11 +36,7 @@ import {
   caseLawCorpusQuery,
   type CorpusTermExpander,
 } from "@/api/lib/legal-search/corpus-query";
-import {
-  corpusTermExpander,
-  expansionLanguageForJurisdiction,
-  logShadowExpansion,
-} from "@/api/lib/legal-search/expansion";
+import { resolveExpandedCorpusQuery } from "@/api/lib/legal-search/expansion";
 import { loadFtsSearchConfigs } from "@/api/lib/legal-search/fts-config";
 import {
   corpusIndexId,
@@ -457,55 +453,15 @@ const buildCorpusIndexQuery = (
     expand,
   );
 
-/**
- * The query this request sends to the engine, under the deployment's
- * expansion mode.
- *
- * `off` never resolves a dictionary and returns the query the builder
- * produced before expansion existed. `shadow` builds both and runs the
- * unexpanded one, so the rewrite can be judged against real traffic before it
- * serves any. `on` runs the expanded one. Every failure inside the expander
- * resolves to no expander at all, so a search never depends on the dictionary
- * being reachable.
- */
+/** Mode, dictionary, and shadow accounting are the shared resolver's. */
 const resolveCorpusIndexQuery = async (
   body: SearchDecisionsBody,
-): Promise<string | null> => {
-  const mode = envBase.QUERY_EXPANSION_MODE;
-  const baseQuery = buildCorpusIndexQuery(body);
-  if (mode === "off" || baseQuery === null) {
-    return baseQuery;
-  }
-
-  const expand = await corpusTermExpander(body.country);
-  if (expand === null) {
-    return baseQuery;
-  }
-  // Both builds tokenize the same text, so this is null only when `baseQuery`
-  // already was; returning the base query keeps the branch total anyway.
-  const expandedQuery = buildCorpusIndexQuery(body, expand);
-  if (expandedQuery === null) {
-    return baseQuery;
-  }
-
-  switch (mode) {
-    case "on": {
-      return expandedQuery;
-    }
-    case "shadow": {
-      logShadowExpansion({
-        countryScoped: body.country !== undefined,
-        executedQuery: baseQuery,
-        expandedQuery,
-        language: expansionLanguageForJurisdiction(body.country),
-      });
-      return baseQuery;
-    }
-    default: {
-      return mode satisfies never;
-    }
-  }
-};
+): Promise<string | null> =>
+  await resolveExpandedCorpusQuery({
+    build: (expand) => buildCorpusIndexQuery(body, expand),
+    jurisdiction: body.country,
+    mode: envBase.QUERY_EXPANSION_MODE,
+  });
 
 const extractCorpusSnippet = (
   snippet: Record<string, unknown> | undefined,

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -461,6 +461,7 @@ const resolveCorpusIndexQuery = async (
     build: (expand) => buildCorpusIndexQuery(body, expand),
     jurisdiction: body.country,
     mode: envBase.QUERY_EXPANSION_MODE,
+    text: body.query,
   });
 
 const extractCorpusSnippet = (

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -32,7 +32,15 @@ import {
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
-import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
+import {
+  caseLawCorpusQuery,
+  type CorpusTermExpander,
+} from "@/api/lib/legal-search/corpus-query";
+import {
+  corpusTermExpander,
+  expansionLanguageForJurisdiction,
+  logShadowExpansion,
+} from "@/api/lib/legal-search/expansion";
 import { loadFtsSearchConfigs } from "@/api/lib/legal-search/fts-config";
 import {
   corpusIndexId,
@@ -429,16 +437,75 @@ const searchPostgresDecisions = async (
   };
 };
 
-// `country` is deliberately absent: it selects the index, not a clause.
-const buildCorpusIndexQuery = (body: SearchDecisionsBody): string | null =>
-  caseLawCorpusQuery(body.query, {
-    court: body.court,
-    dateFrom: body.dateFrom,
-    dateTo: body.dateTo,
-    documentType: body.decisionType,
-    language: body.language,
-    source: body.sourceId,
-  });
+// `country` is deliberately absent from the filters: it selects the index,
+// not a clause. It does select the expansion dictionary, which is why the
+// expander is resolved from it here rather than inside the query builder.
+const buildCorpusIndexQuery = (
+  body: SearchDecisionsBody,
+  expand?: CorpusTermExpander,
+): string | null =>
+  caseLawCorpusQuery(
+    body.query,
+    {
+      court: body.court,
+      dateFrom: body.dateFrom,
+      dateTo: body.dateTo,
+      documentType: body.decisionType,
+      language: body.language,
+      source: body.sourceId,
+    },
+    expand,
+  );
+
+/**
+ * The query this request sends to the engine, under the deployment's
+ * expansion mode.
+ *
+ * `off` never resolves a dictionary and returns the query the builder
+ * produced before expansion existed. `shadow` builds both and runs the
+ * unexpanded one, so the rewrite can be judged against real traffic before it
+ * serves any. `on` runs the expanded one. Every failure inside the expander
+ * resolves to no expander at all, so a search never depends on the dictionary
+ * being reachable.
+ */
+const resolveCorpusIndexQuery = async (
+  body: SearchDecisionsBody,
+): Promise<string | null> => {
+  const mode = envBase.QUERY_EXPANSION_MODE;
+  const baseQuery = buildCorpusIndexQuery(body);
+  if (mode === "off" || baseQuery === null) {
+    return baseQuery;
+  }
+
+  const expand = await corpusTermExpander(body.country);
+  if (expand === null) {
+    return baseQuery;
+  }
+  // Both builds tokenize the same text, so this is null only when `baseQuery`
+  // already was; returning the base query keeps the branch total anyway.
+  const expandedQuery = buildCorpusIndexQuery(body, expand);
+  if (expandedQuery === null) {
+    return baseQuery;
+  }
+
+  switch (mode) {
+    case "on": {
+      return expandedQuery;
+    }
+    case "shadow": {
+      logShadowExpansion({
+        countryScoped: body.country !== undefined,
+        executedQuery: baseQuery,
+        expandedQuery,
+        language: expansionLanguageForJurisdiction(body.country),
+      });
+      return baseQuery;
+    }
+    default: {
+      return mode satisfies never;
+    }
+  }
+};
 
 const extractCorpusSnippet = (
   snippet: Record<string, unknown> | undefined,
@@ -474,7 +541,7 @@ const searchCorpusIndexDecisions = async (
     ? corpusIndexId(generation, body.country)
     : corpusIndexPattern(generation);
 
-  const query = buildCorpusIndexQuery(body);
+  const query = await resolveCorpusIndexQuery(body);
   if (query === null) {
     return { hits: [], facets: null, totalCount: null, nextCursor: null };
   }

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -100,6 +100,7 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
       ),
     jurisdiction: query.jurisdiction,
     mode: envBase.QUERY_EXPANSION_MODE,
+    text: query.query,
   });
   if (engineQuery === null) {
     return { hits: [], facets: null, nextCursor: null, limit };

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -5,6 +5,7 @@ import {
   caseLawDecisions,
   caseLawSources,
 } from "@/api/db/schema";
+import { envBase } from "@/api/env-base";
 // eslint-disable-next-line no-restricted-imports -- search boundary: brands document ids returned by the corpus index before re-hydrating from Postgres
 import { toSafeId } from "@/api/lib/branded-types";
 import { caseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
@@ -18,6 +19,7 @@ import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
 import { loadDocumentContext } from "@/api/lib/legal-search/document-context";
+import { resolveExpandedCorpusQuery } from "@/api/lib/legal-search/expansion";
 import {
   corpusIndexId,
   corpusIndexPattern,
@@ -79,15 +81,25 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
 
   const parsedCursor = query.cursor ? decodeCursor(query.cursor) : null;
 
-  // jurisdiction is deliberately absent: it selected the index above, so a
-  // scoped query never needs a clause for it.
-  const engineQuery = caseLawCorpusQuery(query.query, {
-    court: query.court,
-    dateFrom: query.dateFrom,
-    dateTo: query.dateTo,
-    documentType: query.documentType,
-    language: query.language,
-    source: query.source,
+  // jurisdiction is deliberately absent from the filters: it selected the
+  // index above, so a scoped query never needs a clause for it. It does select
+  // the expansion dictionary, which is why the resolver takes it separately.
+  const engineQuery = await resolveExpandedCorpusQuery({
+    build: (expand) =>
+      caseLawCorpusQuery(
+        query.query,
+        {
+          court: query.court,
+          dateFrom: query.dateFrom,
+          dateTo: query.dateTo,
+          documentType: query.documentType,
+          language: query.language,
+          source: query.source,
+        },
+        expand,
+      ),
+    jurisdiction: query.jurisdiction,
+    mode: envBase.QUERY_EXPANSION_MODE,
   });
   if (engineQuery === null) {
     return { hits: [], facets: null, nextCursor: null, limit };

--- a/apps/api/src/lib/legal-search/corpus-query.ts
+++ b/apps/api/src/lib/legal-search/corpus-query.ts
@@ -114,6 +114,48 @@ export const tokenizeCorpusFreeText = (text: string): CorpusQueryToken[] => {
 };
 
 /**
+ * Extra surface forms to accept alongside a term the reader typed, most
+ * useful first. The typed term is deliberately NOT part of the return value:
+ * this builder always emits it first, so no expander can drop or reorder what
+ * the reader actually wrote. An expander that has nothing to add returns an
+ * empty array.
+ */
+export type CorpusTermExpander = (term: string) => readonly string[];
+
+const noTermExpansion: CorpusTermExpander = () => [];
+
+/**
+ * Whether a token kind may be rewritten before it is quoted. A phrase is
+ * verbatim because rewriting its words would silently change what the reader
+ * asked to match adjacently; a term stands for a word and may carry that
+ * word's other inflections. Total over the token union, so a new token kind
+ * cannot reach the engine without a decision recorded here.
+ */
+const TOKEN_EXPANSION_POLICY = {
+  phrase: "verbatim",
+  term: "expandable",
+} as const satisfies Record<
+  CorpusQueryToken["type"],
+  "verbatim" | "expandable"
+>;
+
+/**
+ * Quoted leaves one query may carry. Expansion multiplies leaves per term, so
+ * without a ceiling a long query would hand the engine a clause whose cost is
+ * quadratic in what the reader typed. Terms are expanded left to right until
+ * the next group would cross the ceiling; the rest stay single leaves.
+ */
+export const CORPUS_QUERY_LEAF_BUDGET = 24;
+
+/**
+ * `("typed" OR "other" ...)` — a bare grouped OR, never a field-scoped one:
+ * the engine parses `(a OR b)` inside the default fields, and a field-scoped
+ * group in this position does not parse at all.
+ */
+const orGroup = (typed: string, extras: readonly string[]): string =>
+  `(${[typed, ...extras].map(quoteCorpusValue).join(" OR ")})`;
+
+/**
  * Convert free user text into a safe corpus-index query clause. The engine's
  * query string syntax (field clauses, AND/OR, parentheses, quotes) must never
  * be reachable from user input, mirroring how the pg-fts path keeps user text
@@ -125,25 +167,44 @@ export const tokenizeCorpusFreeText = (text: string): CorpusQueryToken[] => {
  * quoted clause is a positional phrase match over both. A phrase and a term are
  * quoted identically because a phrase is no more expressive than a term here:
  * only the grouping differs.
+ *
+ * With no expander this emits exactly what it emitted before expansion
+ * existed, byte for byte; the expanded form differs only by OR groups in the
+ * positions expansion chose.
  */
-export const corpusFreeTextClause = (text: string): string | null => {
-  const clauses = tokenizeCorpusFreeText(text).map((token) => {
-    switch (token.type) {
-      case "phrase": {
+export const corpusFreeTextClause = (
+  text: string,
+  expand: CorpusTermExpander = noTermExpansion,
+): string | null => {
+  const tokens = tokenizeCorpusFreeText(text);
+  if (tokens.length === 0) {
+    return null;
+  }
+
+  let leaves = tokens.length;
+  const clauses = tokens.map((token) => {
+    const policy = TOKEN_EXPANSION_POLICY[token.type];
+    switch (policy) {
+      case "verbatim": {
         return quoteCorpusValue(token.value);
       }
-      case "term": {
-        return quoteCorpusValue(token.value);
+      case "expandable": {
+        const extras = expand(token.value);
+        if (
+          extras.length === 0 ||
+          leaves + extras.length > CORPUS_QUERY_LEAF_BUDGET
+        ) {
+          return quoteCorpusValue(token.value);
+        }
+        leaves += extras.length;
+        return orGroup(token.value, extras);
       }
       default: {
-        return token satisfies never;
+        return policy satisfies never;
       }
     }
   });
 
-  if (clauses.length === 0) {
-    return null;
-  }
   return `(${clauses.join(" AND ")})`;
 };
 
@@ -171,8 +232,9 @@ export type CaseLawCorpusFilters = {
 export const caseLawCorpusQuery = (
   text: string,
   filters: CaseLawCorpusFilters,
+  expand?: CorpusTermExpander,
 ): string | null => {
-  const freeText = corpusFreeTextClause(text);
+  const freeText = corpusFreeTextClause(text, expand);
   if (freeText === null) {
     return null;
   }

--- a/apps/api/src/lib/legal-search/expansion.property.test.ts
+++ b/apps/api/src/lib/legal-search/expansion.property.test.ts
@@ -48,6 +48,8 @@ const queryText = fc.oneof(
     "aaa aaab",
     '"aaa aaab" aaa',
     "aaa ".repeat(20),
+    // Past the leaf budget before a single expansion is considered.
+    "aaa ".repeat(30),
     "§ 2235 odst. 1",
     'x) OR (court:"y"',
   ),
@@ -128,7 +130,34 @@ test("no dictionary can produce a clause that escapes its own quoting", () => {
         return;
       }
       expect(isWellQuoted(clause)).toBe(true);
-      expect(leafCount(clause)).toBeLessThanOrEqual(CORPUS_QUERY_LEAF_BUDGET);
+    }),
+    propertyConfig(),
+  );
+});
+
+// The budget bounds what expansion adds, not what the reader typed: a query of
+// more than 24 words already carries more than 24 leaves before any expansion,
+// and the builder must not drop the reader's own terms to fit. So the ceiling
+// is the budget or the unexpanded clause, whichever is larger.
+test("expansion never pushes a clause past the leaf budget it started under", () => {
+  fc.assert(
+    fc.property(dictionaryText, queryText, (text, query) => {
+      const { entries } = parseExpansionDictionary(text);
+      const base = corpusFreeTextClause(query);
+      const expanded = corpusFreeTextClause(query, (term) =>
+        expandTermWith(entries, term),
+      );
+      if (base === null || expanded === null) {
+        return;
+      }
+      const baseLeaves = leafCount(base);
+      expect(leafCount(expanded)).toBeLessThanOrEqual(
+        Math.max(baseLeaves, CORPUS_QUERY_LEAF_BUDGET),
+      );
+      // Over the budget on its own, a query gets no expansion at all.
+      if (baseLeaves >= CORPUS_QUERY_LEAF_BUDGET) {
+        expect(expanded).toBe(base);
+      }
     }),
     propertyConfig(),
   );

--- a/apps/api/src/lib/legal-search/expansion.property.test.ts
+++ b/apps/api/src/lib/legal-search/expansion.property.test.ts
@@ -1,0 +1,156 @@
+import { expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { propertyConfig } from "@stll/property-testing";
+
+import {
+  CORPUS_QUERY_LEAF_BUDGET,
+  corpusFreeTextClause,
+} from "@/api/lib/legal-search/corpus-query";
+import { expandTermWith } from "@/api/lib/legal-search/expansion";
+import { parseExpansionDictionary } from "@/api/lib/legal-search/morphology/dictionary";
+
+/**
+ * Arbitrary serialized dictionaries, including hostile ones. Dictionary
+ * content is derived from corpus text and is therefore untrusted input to the
+ * query builder: a form carrying a quote or a backslash would close the
+ * clause and let the rest parse as DSL. Two independent layers stop that (the
+ * letters-only filter at parse, `quoteCorpusValue` at emit), and the point of
+ * generating the escapes is that neither layer may be the only one.
+ */
+const dictionaryText = fc
+  .array(
+    fc
+      .array(
+        fc.oneof(
+          fc.string({ minLength: 1, maxLength: 8 }),
+          fc.constantFrom(
+            'a"b',
+            "a\\",
+            "a b",
+            "a,b",
+            "a\tb",
+            "a1",
+            "aaa",
+            "aaab",
+          ),
+        ),
+        { minLength: 1, maxLength: 6 },
+      )
+      .map((forms) => `stem\t${forms.join(",")}\t7`),
+    { maxLength: 20 },
+  )
+  .map((lines) => lines.join("\n"));
+
+const queryText = fc.oneof(
+  fc.string({ maxLength: 60 }),
+  fc.constantFrom(
+    "aaa aaab",
+    '"aaa aaab" aaa',
+    "aaa ".repeat(20),
+    "§ 2235 odst. 1",
+    'x) OR (court:"y"',
+  ),
+);
+
+/**
+ * The emitted clause is balanced, and every quote in it is either a delimiter
+ * or escaped. Walking the string is the check, because "no value escaped its
+ * quoting" is exactly the property a regex over the result would beg.
+ */
+const isWellQuoted = (clause: string): boolean => {
+  let depth = 0;
+  let index = 0;
+  let inQuotes = false;
+  while (index < clause.length) {
+    const char = clause.charAt(index);
+    if (inQuotes) {
+      if (char === "\\") {
+        index += 2;
+        continue;
+      }
+      if (char === '"') {
+        inQuotes = false;
+      }
+      index += 1;
+      continue;
+    }
+    if (char === '"') {
+      inQuotes = true;
+    } else if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      depth -= 1;
+      if (depth < 0) {
+        return false;
+      }
+    }
+    index += 1;
+  }
+  return depth === 0 && !inQuotes;
+};
+
+/** Quoted leaves: quote characters that opened a span, counted outside one. */
+const leafCount = (clause: string): number => {
+  let leaves = 0;
+  let index = 0;
+  let inQuotes = false;
+  while (index < clause.length) {
+    const char = clause.charAt(index);
+    if (inQuotes) {
+      if (char === "\\") {
+        index += 2;
+        continue;
+      }
+      if (char === '"') {
+        inQuotes = false;
+      }
+      index += 1;
+      continue;
+    }
+    if (char === '"') {
+      inQuotes = true;
+      leaves += 1;
+    }
+    index += 1;
+  }
+  return leaves;
+};
+
+test("no dictionary can produce a clause that escapes its own quoting", () => {
+  fc.assert(
+    fc.property(dictionaryText, queryText, (text, query) => {
+      const { entries } = parseExpansionDictionary(text);
+      const clause = corpusFreeTextClause(query, (term) =>
+        expandTermWith(entries, term),
+      );
+      if (clause === null) {
+        return;
+      }
+      expect(isWellQuoted(clause)).toBe(true);
+      expect(leafCount(clause)).toBeLessThanOrEqual(CORPUS_QUERY_LEAF_BUDGET);
+    }),
+    propertyConfig(),
+  );
+});
+
+test("expansion only ever adds leaves to the unexpanded clause", () => {
+  fc.assert(
+    fc.property(dictionaryText, queryText, (text, query) => {
+      const { entries } = parseExpansionDictionary(text);
+      const base = corpusFreeTextClause(query);
+      const expanded = corpusFreeTextClause(query, (term) =>
+        expandTermWith(entries, term),
+      );
+      expect(expanded === null).toBe(base === null);
+      if (base === null || expanded === null) {
+        return;
+      }
+      expect(leafCount(expanded)).toBeGreaterThanOrEqual(leafCount(base));
+      // The reader's own terms are never dropped: every AND position the
+      // unexpanded clause has is still there.
+      expect(expanded.split(" AND ").length).toBe(base.split(" AND ").length);
+    }),
+    propertyConfig(),
+  );
+});

--- a/apps/api/src/lib/legal-search/expansion.test.ts
+++ b/apps/api/src/lib/legal-search/expansion.test.ts
@@ -206,8 +206,30 @@ test("every shadow-event attribute survives the log sanitizer", () => {
     expandedLeaves: 2,
     language: "cs",
     reach: "expanded",
+  } as const);
+  expect(sanitizeLogAttributes(attributes)).toEqual(attributes);
+});
+
+// Every disposition must survive the sanitizer, not just the happy one: a
+// reach value the sanitizer dropped would erase exactly the traffic the
+// rollout is trying to measure.
+test.each([
+  "dictionary_inert",
+  "expanded",
+  "no_dictionary",
+  "unsupported_jurisdiction",
+] as const)("the %p disposition survives the log sanitizer", (reach) => {
+  const attributes = shadowExpansionAttributes({
+    baseLeaves: 2,
+    countryScoped: reach !== "unsupported_jurisdiction",
+    expandedLeaves: reach === "expanded" ? 5 : 2,
+    language: reach === "unsupported_jurisdiction" ? null : "cs",
+    reach,
   });
   expect(sanitizeLogAttributes(attributes)).toEqual(attributes);
+  expect(attributes["reach"]).toBe(reach);
+  // `addedLeaves` is derived, never passed in, so it cannot disagree.
+  expect(attributes["addedLeaves"]).toBe(reach === "expanded" ? 3 : 0);
 });
 
 // The event measures the rewrite; it must not carry what the reader typed. A
@@ -220,7 +242,7 @@ test("the shadow event carries no query text", () => {
     expandedLeaves: 9,
     language: "cs",
     reach: "expanded",
-  });
+  } as const);
   for (const value of Object.values(attributes)) {
     expect(typeof value === "string" ? value : "").not.toContain('"');
   }

--- a/apps/api/src/lib/legal-search/expansion.test.ts
+++ b/apps/api/src/lib/legal-search/expansion.test.ts
@@ -219,6 +219,7 @@ test("every shadow-event attribute survives the log sanitizer", () => {
 // rollout is trying to measure.
 test.each([
   "dictionary_inert",
+  "dictionary_warming",
   "expanded",
   "no_dictionary",
   "unsupported_jurisdiction",

--- a/apps/api/src/lib/legal-search/expansion.test.ts
+++ b/apps/api/src/lib/legal-search/expansion.test.ts
@@ -203,6 +203,7 @@ test("every shadow-event attribute survives the log sanitizer", () => {
   const attributes = shadowExpansionAttributes({
     baseLeaves: 1,
     countryScoped: true,
+    dictionaryHash: "a1b2c3d4e5f6",
     expandedLeaves: 2,
     language: "cs",
     reach: "expanded",
@@ -222,6 +223,7 @@ test.each([
   const attributes = shadowExpansionAttributes({
     baseLeaves: 2,
     countryScoped: reach !== "unsupported_jurisdiction",
+    dictionaryHash: reach === "expanded" ? "a1b2c3d4e5f6" : "none",
     expandedLeaves: reach === "expanded" ? 5 : 2,
     language: reach === "unsupported_jurisdiction" ? null : "cs",
     reach,
@@ -239,6 +241,7 @@ test("the shadow event carries no query text", () => {
   const attributes = shadowExpansionAttributes({
     baseLeaves: 3,
     countryScoped: true,
+    dictionaryHash: "a1b2c3d4e5f6",
     expandedLeaves: 9,
     language: "cs",
     reach: "expanded",

--- a/apps/api/src/lib/legal-search/expansion.test.ts
+++ b/apps/api/src/lib/legal-search/expansion.test.ts
@@ -1,0 +1,199 @@
+import { expect, test } from "bun:test";
+
+import { extractCitations } from "@/api/handlers/case-law/ingestion/citation-extractor";
+import {
+  CORPUS_QUERY_LEAF_BUDGET,
+  corpusFreeTextClause,
+  tokenizeCorpusFreeText,
+} from "@/api/lib/legal-search/corpus-query";
+import {
+  expandTermWith,
+  expansionLanguageForJurisdiction,
+  shadowExpansionAttributes,
+} from "@/api/lib/legal-search/expansion";
+import {
+  type ExpansionBucket,
+  parseExpansionDictionary,
+  serializeExpansionDictionary,
+} from "@/api/lib/legal-search/morphology/dictionary";
+import { sanitizeLogAttributes } from "@/api/lib/observability/logger";
+
+const dictionaryOf = (buckets: readonly ExpansionBucket[]) =>
+  parseExpansionDictionary(serializeExpansionDictionary(buckets)).entries;
+
+/**
+ * Buckets the Czech light stemmer really produces. `vec` is the collision the
+ * prefix guard exists for: `věci`, `vek` and `veku` reduce to one stem without
+ * being one word, and folding `věci` to `veci` puts it in reach of `vek`.
+ */
+const CS_BUCKETS = [
+  {
+    documentFrequency: 4200,
+    forms: ["nájemné", "nájemného", "nájemném", "nájemnému"],
+    stem: "nájemn",
+  },
+  { documentFrequency: 900, forms: ["veci", "vek", "veku"], stem: "vec" },
+  { documentFrequency: 700, forms: ["ruka", "ruce", "rukou"], stem: "ruk" },
+  { documentFrequency: 300, forms: ["zlo", "zla"], stem: "zl" },
+] as const satisfies readonly ExpansionBucket[];
+
+test("a term expands to its bucket's other surface forms", () => {
+  const entries = dictionaryOf(CS_BUCKETS);
+  expect(expandTermWith(entries, "nájemné")).toEqual([
+    "nájemného",
+    "nájemném",
+    "nájemnému",
+  ]);
+});
+
+test("an unaccented spelling reaches the accented bucket", () => {
+  const entries = dictionaryOf(CS_BUCKETS);
+  expect(expandTermWith(entries, "najemne")).toEqual([
+    "nájemného",
+    "nájemném",
+    "nájemnému",
+  ]);
+});
+
+// Pinned from corpus data: `veci` and `vek`/`veku` share a stem but not a
+// word. Three shared leading characters is what separates them.
+test("a term never expands to a bucket member it shares under three characters with", () => {
+  const entries = dictionaryOf(CS_BUCKETS);
+  expect(expandTermWith(entries, "veci")).toEqual([]);
+  expect(expandTermWith(entries, "vek")).toEqual(["veku"]);
+});
+
+// The `ruk` family is the documented borderline: `ruka`/`rukou` share the
+// stem's three characters and expand into each other, `ruce` does not and is
+// dropped, even though the stemmer says all three are one word.
+test("the ruk family keeps only the members sharing the stem's prefix", () => {
+  const entries = dictionaryOf(CS_BUCKETS);
+  expect(expandTermWith(entries, "ruka")).toEqual(["rukou"]);
+  expect(expandTermWith(entries, "ruce")).toEqual([]);
+});
+
+// The floor is a constant 3, not min(3, term.length): the shorter-of rule let
+// two-character terms match a whole family of unrelated words.
+test("a term under three characters expands to nothing", () => {
+  const entries = dictionaryOf([
+    { documentFrequency: 300, forms: ["zl", "zla"], stem: "zl" },
+  ]);
+  expect(expandTermWith(entries, "zl")).toEqual([]);
+});
+
+test("terms carrying anything but letters expand to nothing", () => {
+  const entries = dictionaryOf([
+    ...CS_BUCKETS,
+    { documentFrequency: 800, forms: ["2020", "2021"], stem: "2020" },
+  ]);
+  for (const term of ["2020", "21cdo1234", "§", "c-679"]) {
+    expect(expandTermWith(entries, term)).toEqual([]);
+  }
+});
+
+test("a term with no bucket expands to nothing", () => {
+  expect(expandTermWith(dictionaryOf(CS_BUCKETS), "smlouva")).toEqual([]);
+});
+
+test("the typed term is never repeated inside its own group", () => {
+  const clause = corpusFreeTextClause("nájemné", (term) =>
+    expandTermWith(dictionaryOf(CS_BUCKETS), term),
+  );
+  expect(clause).toBe(
+    '(("nájemné" OR "nájemného" OR "nájemném" OR "nájemnému"))',
+  );
+});
+
+test("phrases are never expanded", () => {
+  const clause = corpusFreeTextClause('"nájemné smlouvy" nájemné', (term) =>
+    expandTermWith(dictionaryOf(CS_BUCKETS), term),
+  );
+  expect(clause).toBe(
+    '("nájemné smlouvy" AND ("nájemné" OR "nájemného" OR "nájemném" OR "nájemnému"))',
+  );
+});
+
+test("expansion stops at the leaf budget, leftmost terms first", () => {
+  const entries = dictionaryOf([
+    {
+      documentFrequency: 100,
+      forms: ["aaa", "aaab", "aaac", "aaad"],
+      stem: "aaa",
+    },
+  ]);
+  const clause = corpusFreeTextClause(
+    "aaa aaa aaa aaa aaa aaa aaa aaa",
+    (term) => expandTermWith(entries, term),
+  );
+  expect(clause).not.toBeNull();
+  // Eight tokens, each expandable by three: the budget admits five groups
+  // (8 + 5*3 = 23) and the sixth would cross it.
+  const leaves = [...(clause ?? "").matchAll(/"/gu)].length / 2;
+  expect(leaves).toBeLessThanOrEqual(CORPUS_QUERY_LEAF_BUDGET);
+  expect(clause?.split(" OR ").length).toBe(1 + 5 * 3);
+});
+
+// `off` mode must leave the query builder exactly where it was. The pinned
+// literals in corpus-query.test.ts hold the absolute shape; this holds the
+// relative one: an expander with nothing to add cannot change a single byte,
+// which is what a term the guards reject produces.
+test.each([
+  "náhrada škody",
+  '"dobrá víra" a "náhrada škody"',
+  "§ 2235 odst. 1",
+  'smlouva) OR (court:"X" AND text:*',
+  "  spaced   out  ",
+])("an expander with nothing to add leaves %p byte-identical", (text) => {
+  expect(corpusFreeTextClause(text, () => [])).toBe(corpusFreeTextClause(text));
+});
+
+// Citation identifiers reach the builder as whatever the tokenizer makes of
+// them, so the guard is bound to the extractor's real patterns rather than to
+// a second copy of them here: every digit-bearing token a real citation
+// decomposes into must expand to nothing.
+test("no digit-bearing token of a real citation expands", () => {
+  const entries = dictionaryOf(CS_BUCKETS);
+  const citations = extractCitations([
+    {
+      index: 0,
+      text: [
+        "ECLI:CZ:NS:2020:21.CDO.1234.2020.1",
+        "sp. zn. 21 Cdo 1234/2020",
+        "č. j. 27 Co 116, 119/2007-94",
+        "sygn. akt II CSK 123/20",
+        "C‑156/21, EU:C:2022:97",
+      ].join(" a dále "),
+    },
+  ]);
+  expect(citations.length).toBeGreaterThan(0);
+
+  const digitBearing = citations
+    .flatMap((citation) => tokenizeCorpusFreeText(citation.citationText))
+    .filter((token) => /\d/u.test(token.value));
+  expect(digitBearing.length).toBeGreaterThan(0);
+  for (const token of digitBearing) {
+    expect(expandTermWith(entries, token.value)).toEqual([]);
+  }
+});
+
+test("jurisdiction routing expands only the languages phase one publishes", () => {
+  expect(expansionLanguageForJurisdiction("CZE")).toBe("cs");
+  expect(expansionLanguageForJurisdiction("POL")).toBe("pl");
+  expect(expansionLanguageForJurisdiction("SVK")).toBeNull();
+  expect(expansionLanguageForJurisdiction("EU")).toBeNull();
+  expect(expansionLanguageForJurisdiction("XXX")).toBeNull();
+  // An unscoped search spans every index; no one language describes it.
+  expect(expansionLanguageForJurisdiction(undefined)).toBeNull();
+});
+
+// The log sanitizer drops payload-shaped attribute keys without failing, so a
+// shadow event whose keys it rejects looks emitted and measures nothing.
+test("every shadow-event attribute survives the log sanitizer", () => {
+  const attributes = shadowExpansionAttributes({
+    countryScoped: true,
+    executedQuery: '("nájemné")',
+    expandedQuery: '(("nájemné" OR "nájemného"))',
+    language: "cs",
+  });
+  expect(sanitizeLogAttributes(attributes)).toEqual(attributes);
+});

--- a/apps/api/src/lib/legal-search/expansion.test.ts
+++ b/apps/api/src/lib/legal-search/expansion.test.ts
@@ -95,6 +95,17 @@ test("a term with no bucket expands to nothing", () => {
   expect(expandTermWith(dictionaryOf(CS_BUCKETS), "smlouva")).toEqual([]);
 });
 
+// A macOS keyboard and an extracted PDF both produce decomposed text. The
+// shape guard runs on the folded spelling for exactly this reason: combining
+// marks are \p{M}, so testing before the fold would reject the word.
+test("a decomposed query term reaches the same bucket as its precomposed spelling", () => {
+  const entries = dictionaryOf(CS_BUCKETS);
+  expect(expandTermWith(entries, "nájemné".normalize("NFD"))).toEqual(
+    expandTermWith(entries, "nájemné"),
+  );
+  expect(expandTermWith(entries, "nájemné".normalize("NFD"))).not.toEqual([]);
+});
+
 test("the typed term is never repeated inside its own group", () => {
   const clause = corpusFreeTextClause("nájemné", (term) =>
     expandTermWith(dictionaryOf(CS_BUCKETS), term),
@@ -190,10 +201,30 @@ test("jurisdiction routing expands only the languages phase one publishes", () =
 // shadow event whose keys it rejects looks emitted and measures nothing.
 test("every shadow-event attribute survives the log sanitizer", () => {
   const attributes = shadowExpansionAttributes({
+    baseLeaves: 1,
     countryScoped: true,
-    executedQuery: '("nájemné")',
-    expandedQuery: '(("nájemné" OR "nájemného"))',
+    expandedLeaves: 2,
     language: "cs",
+    reach: "expanded",
   });
   expect(sanitizeLogAttributes(attributes)).toEqual(attributes);
+});
+
+// The event measures the rewrite; it must not carry what the reader typed. A
+// case-law query can name a client or a party, and nothing else in the request
+// path copies query text into telemetry.
+test("the shadow event carries no query text", () => {
+  const attributes = shadowExpansionAttributes({
+    baseLeaves: 3,
+    countryScoped: true,
+    expandedLeaves: 9,
+    language: "cs",
+    reach: "expanded",
+  });
+  for (const value of Object.values(attributes)) {
+    expect(typeof value === "string" ? value : "").not.toContain('"');
+  }
+  expect(Object.values(attributes)).toEqual(
+    expect.arrayContaining([3, 9, 6, true, "cs", "expanded"]),
+  );
 });

--- a/apps/api/src/lib/legal-search/expansion.test.ts
+++ b/apps/api/src/lib/legal-search/expansion.test.ts
@@ -75,9 +75,12 @@ test("the ruk family keeps only the members sharing the stem's prefix", () => {
 // The floor is a constant 3, not min(3, term.length): the shorter-of rule let
 // two-character terms match a whole family of unrelated words.
 test("a term under three characters expands to nothing", () => {
+  // The bucket is real and the short term prefixes it, so the empty result is
+  // the floor firing rather than a missing entry.
   const entries = dictionaryOf([
-    { documentFrequency: 300, forms: ["zl", "zla"], stem: "zl" },
+    { documentFrequency: 300, forms: ["zla", "zlo"], stem: "zl" },
   ]);
+  expect(entries.get("zla")).toBe("zla,zlo");
   expect(expandTermWith(entries, "zl")).toEqual([]);
 });
 

--- a/apps/api/src/lib/legal-search/expansion.ts
+++ b/apps/api/src/lib/legal-search/expansion.ts
@@ -23,7 +23,11 @@
 import { Result } from "better-result";
 
 import { zstdDecompressToStringBounded } from "@/api/lib/compression";
-import type { CorpusTermExpander } from "@/api/lib/legal-search/corpus-query";
+import { detached } from "@/api/lib/detached";
+import {
+  corpusFreeTextClause,
+  type CorpusTermExpander,
+} from "@/api/lib/legal-search/corpus-query";
 import {
   foldExpansionKey,
   isMorphologyDictionaryContentHash,
@@ -38,7 +42,7 @@ import type { MorphologyLanguage } from "@/api/lib/legal-search/morphology/stem"
 import type { QueryExpansionMode } from "@/api/lib/legal-search/query-expansion-mode";
 import type { LoggerAttributes } from "@/api/lib/observability/logger";
 import { logger } from "@/api/lib/observability/logger";
-import { readCorpusS3Bytes } from "@/api/lib/s3";
+import { readCorpusS3BytesBounded } from "@/api/lib/s3";
 
 /**
  * Jurisdictions the corpus index serves, and the language whose dictionary
@@ -135,6 +139,9 @@ const DICTIONARY_UNAVAILABLE_TTL_MS = 60_000;
  */
 const DICTIONARY_REFRESH_TTL_MS = 15 * 60_000;
 
+/** A pointer holds one sha256 hex string; anything larger is not a pointer. */
+const POINTER_MAX_BYTES = 1024;
+
 /** Structured events; swept for, so spelled once. */
 const DICTIONARY_UNAVAILABLE =
   "case_law.search.expansion_dictionary_unavailable";
@@ -169,19 +176,24 @@ const readDictionaryPayload = async (
   language: MorphologyLanguage,
 ): Promise<DictionaryPayload> => {
   const deadline = AbortSignal.timeout(DICTIONARY_RESOLVE_TIMEOUT_MS);
-  const pointer = await readCorpusS3Bytes(
-    morphologyDictionaryPointerKey(language),
-    deadline,
-  );
+  const pointer = await readCorpusS3BytesBounded({
+    key: morphologyDictionaryPointerKey(language),
+    maxBytes: POINTER_MAX_BYTES,
+    signal: deadline,
+  });
   const contentHash = new TextDecoder().decode(pointer).trim();
   if (!isMorphologyDictionaryContentHash(contentHash)) {
     return { reason: "malformed_pointer", status: "rejected" };
   }
 
-  const compressed = await readCorpusS3Bytes(
-    morphologyDictionaryKey(language, contentHash),
-    deadline,
-  );
+  // Bounded on the compressed transfer, not only on what it decodes to: the
+  // decompression ceiling below would otherwise run after the whole body was
+  // already resident.
+  const compressed = await readCorpusS3BytesBounded({
+    key: morphologyDictionaryKey(language, contentHash),
+    maxBytes: MORPHOLOGY_DICTIONARY_MAX_BYTES,
+    signal: deadline,
+  });
   const payload = await zstdDecompressToStringBounded(
     compressed,
     MORPHOLOGY_DICTIONARY_MAX_BYTES,
@@ -266,6 +278,42 @@ const lastLoaded = new Map<MorphologyLanguage, ReadonlyMap<string, string>>();
  * expansion because object storage blipped would be a recall regression the
  * reader sees, where serving a slightly stale dictionary is not.
  */
+// `async` only to satisfy the promise-returning convention; the body has no
+// await, so the cache entry below is installed synchronously by the caller's
+// own turn — which is what makes concurrent callers share this one read.
+const beginRefresh = async (
+  language: MorphologyLanguage,
+): Promise<DictionaryLoad> => {
+  const load = (async (): Promise<DictionaryLoad> => {
+    const result = await loadDictionary(language);
+    if (result.status === "loaded") {
+      lastLoaded.set(language, result.entries);
+      return result;
+    }
+    const previous = lastLoaded.get(language);
+    if (previous !== undefined) {
+      return { entries: previous, status: "loaded" };
+    }
+    // Nothing to serve at all: retry on the fast cycle rather than the slow
+    // one. Re-read the entry rather than closing over the promise being built.
+    const entry = cache.get(language);
+    if (entry !== undefined) {
+      cache.set(language, {
+        load: entry.load,
+        expiresAt: Date.now() + DICTIONARY_UNAVAILABLE_TTL_MS,
+      });
+    }
+    return result;
+  })();
+
+  // Set before anyone awaits, so concurrent callers share this one read.
+  cache.set(language, {
+    load,
+    expiresAt: Date.now() + DICTIONARY_REFRESH_TTL_MS,
+  });
+  return load;
+};
+
 const dictionaryFor = async (
   language: MorphologyLanguage,
 ): Promise<DictionaryLoad> => {
@@ -274,32 +322,20 @@ const dictionaryFor = async (
     return await cached.load;
   }
 
-  const load = (async (): Promise<DictionaryLoad> => {
-    const result = await loadDictionary(language);
-    if (result.status === "loaded") {
-      lastLoaded.set(language, result.entries);
-      return result;
-    }
-    const previous = lastLoaded.get(language);
-    return previous === undefined
-      ? result
-      : { entries: previous, status: "loaded" };
-  })();
-
-  // Deduplicates concurrent callers while the read is in flight; corrected to
-  // the retry window below if it turns out there is nothing to serve.
-  cache.set(language, {
-    load,
-    expiresAt: Date.now() + DICTIONARY_REFRESH_TTL_MS,
-  });
-  const result = await load;
-  if (result.status === "unavailable") {
-    cache.set(language, {
-      load,
-      expiresAt: Date.now() + DICTIONARY_UNAVAILABLE_TTL_MS,
-    });
+  const refresh = beginRefresh(language);
+  const previous = lastLoaded.get(language);
+  if (previous === undefined) {
+    // Cold: there is nothing to answer with, so this caller waits for the read.
+    return await refresh;
   }
-  return result;
+
+  // Warm: answer from the payload already in memory and let the refresh finish
+  // behind the request. Awaiting here would make every search that arrives
+  // during a refresh window inherit the read's latency — up to the full resolve
+  // deadline when object storage is slow — which is exactly the stall the
+  // fallback exists to prevent.
+  detached(refresh, "legal-search.expansion-dictionary-refresh");
+  return { entries: previous, status: "loaded" };
 };
 
 /**
@@ -397,13 +433,27 @@ type ShadowExpansionLog = {
    * or the ratio would be one by construction.
    */
   countryScoped: boolean;
-  /** Quoted leaves the expanded query carries; equals `baseLeaves` when inert. */
+  /** Free-text leaves after expansion; equals `baseLeaves` when nothing fired. */
   expandedLeaves: number;
   language: MorphologyLanguage | null;
-  /** Quoted leaves before expansion: one per token the reader typed. */
+  /**
+   * Free-text leaves before expansion: one per token the reader typed. Counted
+   * on the free-text clause alone, never on the assembled query, whose filter
+   * clauses (`court:"…"`, `language:"…"`, a date range) are quoted leaves the
+   * reader did not type and would dilute the multiplier this measures.
+   */
   baseLeaves: number;
-  /** Why this request expanded nothing, or "expanded" when it did. */
-  reach: "expanded" | "no_dictionary" | "unsupported_jurisdiction";
+  /**
+   * What actually happened, not what was available. `expanded` means leaves
+   * were added; a loaded dictionary that matched no term, lost every form to
+   * the guards, or ran out of budget reports `dictionary_inert`, so grouping
+   * by this field cannot overstate how often expansion fires.
+   */
+  reach:
+    | "dictionary_inert"
+    | "expanded"
+    | "no_dictionary"
+    | "unsupported_jurisdiction";
 };
 
 /**
@@ -473,11 +523,23 @@ const countLeaves = (clause: string): number => {
   return leaves;
 };
 
+/**
+ * Leaves the reader's own text contributes, with or without expansion. Built
+ * from the free-text clause rather than measured on the assembled query, so
+ * filter clauses never enter the count.
+ */
+const freeTextLeaves = (text: string, expand?: CorpusTermExpander): number => {
+  const clause = corpusFreeTextClause(text, expand);
+  return clause === null ? 0 : countLeaves(clause);
+};
+
 type ResolveExpandedQueryOptions = {
   /** Assemble the clause, with the expander when one is supplied. */
   build: (expand?: CorpusTermExpander) => string | null;
   jurisdiction: string | undefined;
   mode: QueryExpansionMode;
+  /** The reader's free text, for metrics that must exclude filter clauses. */
+  text: string;
 };
 
 /**
@@ -500,6 +562,7 @@ export const resolveExpandedCorpusQuery = async ({
   build,
   jurisdiction,
   mode,
+  text,
 }: ResolveExpandedQueryOptions): Promise<string | null> => {
   const baseQuery = build();
   if (mode === "off" || baseQuery === null) {
@@ -515,7 +578,7 @@ export const resolveExpandedCorpusQuery = async ({
   // would only ever describe the traffic expansion already covers.
   if (expand === null) {
     if (mode === "shadow") {
-      const baseLeaves = countLeaves(baseQuery);
+      const baseLeaves = freeTextLeaves(text);
       logShadowExpansion({
         baseLeaves,
         countryScoped,
@@ -539,12 +602,16 @@ export const resolveExpandedCorpusQuery = async ({
       return expandedQuery;
     }
     case "shadow": {
+      const baseLeaves = freeTextLeaves(text);
+      const expandedLeaves = freeTextLeaves(text, expand);
       logShadowExpansion({
-        baseLeaves: countLeaves(baseQuery),
+        baseLeaves,
         countryScoped,
-        expandedLeaves: countLeaves(expandedQuery),
+        expandedLeaves,
         language,
-        reach: "expanded",
+        // A dictionary that loaded but matched nothing, lost every form to the
+        // guards, or ran out of budget did not expand this query.
+        reach: expandedLeaves > baseLeaves ? "expanded" : "dictionary_inert",
       });
       return baseQuery;
     }

--- a/apps/api/src/lib/legal-search/expansion.ts
+++ b/apps/api/src/lib/legal-search/expansion.ts
@@ -148,7 +148,6 @@ const DICTIONARY_UNAVAILABLE =
 const DICTIONARY_DEGRADED = "case_law.search.expansion_dictionary_degraded";
 const DICTIONARY_LOADED = "case_law.search.expansion_dictionary_loaded";
 const EXPANSION_SHADOW = "case_law.search.expansion_shadow";
-const EXPANSION_MODE_UNVALIDATED = "case_law.search.expansion_mode_unvalidated";
 
 type LoadedDictionary = {
   /** sha256 of the payload: which build this replica is answering from. */
@@ -592,29 +591,6 @@ const freeTextLeaves = (text: string, expand?: CorpusTermExpander): number => {
   return clause === null ? 0 : countLeaves(clause);
 };
 
-let warnedModeUnvalidated = false;
-
-/**
- * Say once per process that `on` is serving expanded queries while the
- * pagination constraint below is still open.
- *
- * Deliberately a warning and not a refusal: blocking the mode outright would
- * decide, from inside an inert feature flag, that the product may not have it
- * — which is a rollout call for whoever owns the rollout. A comment alone was
- * the other extreme, readable only by someone already in this file. This is
- * the version an operator sees in their logs the moment they flip it.
- */
-const warnExpansionModeUnvalidated = (): void => {
-  if (warnedModeUnvalidated) {
-    return;
-  }
-  warnedModeUnvalidated = true;
-  logger.warn(EXPANSION_MODE_UNVALIDATED, {
-    mode: "on",
-    reason: "cursor_lacks_dictionary_version",
-  });
-};
-
 type ResolveExpandedQueryOptions = {
   /** Assemble the clause, with the expander when one is supplied. */
   build: (expand?: CorpusTermExpander) => string | null;
@@ -641,20 +617,23 @@ type ResolveExpandedQueryOptions = {
  * dictionary being reachable.
  */
 /**
- * Known limitation of `on`, recorded where the decision to flip it will be
- * made: the query a request builds depends on which dictionary its replica has
- * loaded, so a page-2 request served by a replica mid-refresh (or holding a
- * fallback payload) can rebuild a different engine query while reusing page 1's
- * cursor, which ranks a different result set against an old score/id boundary.
- * Replicas converge on the pointer, so the window is a rebuild or a failed
- * refresh rather than steady state, and `shadow` cannot hit it at all because
- * it executes the unexpanded query.
+ * `on` is unreachable by configuration, and this is why.
  *
- * Turning `on` on requires closing this first: the cursor has to carry the
- * dictionary version and later pages have to resolve that same version, which
- * means retaining superseded payloads. That is a rollout decision, not an
- * inert-flag one, so the shadow event reports which payload each replica used
- * (`dictionaryHash`) to make convergence measurable before the choice is made.
+ * The query a request builds depends on which dictionary its replica has
+ * loaded, so a page-2 request served by a replica mid-refresh (or holding a
+ * fallback payload) rebuilds a different engine query while reusing page 1's
+ * cursor, which ranks a different result set against an old score/id boundary
+ * and can skip or repeat decisions. Replicas converge on the pointer, so the
+ * window is a rebuild or a failed refresh rather than steady state, and
+ * `shadow` cannot hit it at all because it executes the unexpanded query.
+ *
+ * `envBaseInvariantViolation` refuses to boot under `on` for that reason;
+ * the branch below stays because the mode is part of the union, not because
+ * it is reachable today. Closing this means the cursor carries the dictionary
+ * version and later pages resolve that same version, which in turn means
+ * retaining superseded payloads. Until then the shadow event reports which
+ * payload answered (`dictionaryHash`), so replica convergence is measurable
+ * from real traffic before that work is scoped.
  */
 export const resolveExpandedCorpusQuery = async ({
   build,
@@ -698,7 +677,6 @@ export const resolveExpandedCorpusQuery = async ({
 
   switch (mode) {
     case "on": {
-      warnExpansionModeUnvalidated();
       return expandedQuery;
     }
     case "shadow": {

--- a/apps/api/src/lib/legal-search/expansion.ts
+++ b/apps/api/src/lib/legal-search/expansion.ts
@@ -145,8 +145,10 @@ const POINTER_MAX_BYTES = 1024;
 /** Structured events; swept for, so spelled once. */
 const DICTIONARY_UNAVAILABLE =
   "case_law.search.expansion_dictionary_unavailable";
+const DICTIONARY_DEGRADED = "case_law.search.expansion_dictionary_degraded";
 const DICTIONARY_LOADED = "case_law.search.expansion_dictionary_loaded";
 const EXPANSION_SHADOW = "case_law.search.expansion_shadow";
+const EXPANSION_MODE_UNVALIDATED = "case_law.search.expansion_mode_unvalidated";
 
 type LoadedDictionary = {
   /** sha256 of the payload: which build this replica is answering from. */
@@ -251,10 +253,14 @@ const loadDictionary = async (
     });
     return UNAVAILABLE;
   }
+  // Its own event, not the unavailable one: this dictionary is being served.
+  // Folding it into the unavailable event would make every alert on that name
+  // count successful loads, and a handful of collided keys is the normal state
+  // of a real dictionary (`rada`/`řada` is ordinary Czech), so the false
+  // positives would be continuous rather than occasional.
   if (skippedLines > 0 || collidedKeys > 0) {
-    logger.warn(DICTIONARY_UNAVAILABLE, {
+    logger.warn(DICTIONARY_DEGRADED, {
       language,
-      reason: "degraded_dictionary",
       skippedLines,
       collidedKeys,
       entries: entries.size,
@@ -586,6 +592,29 @@ const freeTextLeaves = (text: string, expand?: CorpusTermExpander): number => {
   return clause === null ? 0 : countLeaves(clause);
 };
 
+let warnedModeUnvalidated = false;
+
+/**
+ * Say once per process that `on` is serving expanded queries while the
+ * pagination constraint below is still open.
+ *
+ * Deliberately a warning and not a refusal: blocking the mode outright would
+ * decide, from inside an inert feature flag, that the product may not have it
+ * — which is a rollout call for whoever owns the rollout. A comment alone was
+ * the other extreme, readable only by someone already in this file. This is
+ * the version an operator sees in their logs the moment they flip it.
+ */
+const warnExpansionModeUnvalidated = (): void => {
+  if (warnedModeUnvalidated) {
+    return;
+  }
+  warnedModeUnvalidated = true;
+  logger.warn(EXPANSION_MODE_UNVALIDATED, {
+    mode: "on",
+    reason: "cursor_lacks_dictionary_version",
+  });
+};
+
 type ResolveExpandedQueryOptions = {
   /** Assemble the clause, with the expander when one is supplied. */
   build: (expand?: CorpusTermExpander) => string | null;
@@ -669,6 +698,7 @@ export const resolveExpandedCorpusQuery = async ({
 
   switch (mode) {
     case "on": {
+      warnExpansionModeUnvalidated();
       return expandedQuery;
     }
     case "shadow": {

--- a/apps/api/src/lib/legal-search/expansion.ts
+++ b/apps/api/src/lib/legal-search/expansion.ts
@@ -35,7 +35,7 @@ import {
   MORPHOLOGY_DICTIONARY_MAX_BYTES,
   morphologyDictionaryKey,
   morphologyDictionaryPointerKey,
-  parseExpansionDictionary,
+  parseExpansionDictionaryOffLoop,
   unpackExpansionForms,
 } from "@/api/lib/legal-search/morphology/dictionary";
 import type { MorphologyLanguage } from "@/api/lib/legal-search/morphology/stem";
@@ -263,9 +263,8 @@ const loadDictionary = async (
     return UNAVAILABLE;
   }
 
-  const { collidedKeys, entries, skippedLines } = parseExpansionDictionary(
-    read.value.payload,
-  );
+  const { collidedKeys, entries, skippedLines } =
+    await parseExpansionDictionaryOffLoop(read.value.payload);
   if (entries.size === 0) {
     logger.warn(DICTIONARY_UNAVAILABLE, {
       language,

--- a/apps/api/src/lib/legal-search/expansion.ts
+++ b/apps/api/src/lib/legal-search/expansion.ts
@@ -148,8 +148,17 @@ const DICTIONARY_UNAVAILABLE =
 const DICTIONARY_LOADED = "case_law.search.expansion_dictionary_loaded";
 const EXPANSION_SHADOW = "case_law.search.expansion_shadow";
 
+type LoadedDictionary = {
+  /** sha256 of the payload: which build this replica is answering from. */
+  contentHash: string;
+  entries: ReadonlyMap<string, string>;
+};
+
+/** Enough hash to tell two builds apart in telemetry, without the other 52. */
+const shortHash = (contentHash: string): string => contentHash.slice(0, 12);
+
 type DictionaryLoad =
-  | { entries: ReadonlyMap<string, string>; status: "loaded" }
+  | (LoadedDictionary & { status: "loaded" })
   | { status: "unavailable" };
 
 const UNAVAILABLE: DictionaryLoad = { status: "unavailable" };
@@ -158,7 +167,7 @@ const UNAVAILABLE: DictionaryLoad = { status: "unavailable" };
 type DictionaryRejection = "content_hash_mismatch" | "malformed_pointer";
 
 type DictionaryPayload =
-  | { payload: string; status: "read" }
+  | { contentHash: string; payload: string; status: "read" }
   | { reason: DictionaryRejection; status: "rejected" };
 
 /**
@@ -203,7 +212,7 @@ const readDictionaryPayload = async (
   if (hasher.digest("hex") !== contentHash) {
     return { reason: "content_hash_mismatch", status: "rejected" };
   }
-  return { payload, status: "read" };
+  return { contentHash, payload, status: "read" };
 };
 
 const loadDictionary = async (
@@ -255,8 +264,9 @@ const loadDictionary = async (
     language,
     entries: entries.size,
     collidedKeys,
+    dictionaryHash: shortHash(read.value.contentHash),
   });
-  return { entries, status: "loaded" };
+  return { contentHash: read.value.contentHash, entries, status: "loaded" };
 };
 
 type CacheEntry = {
@@ -266,7 +276,15 @@ type CacheEntry = {
 
 const cache = new Map<MorphologyLanguage, CacheEntry>();
 /** The last payload that parsed, per language; a failed refresh falls back here. */
-const lastLoaded = new Map<MorphologyLanguage, ReadonlyMap<string, string>>();
+const lastLoaded = new Map<MorphologyLanguage, LoadedDictionary>();
+/**
+ * Languages whose read is currently in flight. Distinct from the cache entry's
+ * expiry, which is set to the future the moment a refresh starts: without this,
+ * every request arriving during a refresh window sees a live entry and awaits
+ * the pending read, so only the caller that happened to start the refresh got
+ * the stale-serving fast path.
+ */
+const inFlight = new Set<MorphologyLanguage>();
 
 /**
  * The per-language lazy singleton. Concurrent uses share one read, a loaded
@@ -284,26 +302,36 @@ const lastLoaded = new Map<MorphologyLanguage, ReadonlyMap<string, string>>();
 const beginRefresh = async (
   language: MorphologyLanguage,
 ): Promise<DictionaryLoad> => {
+  inFlight.add(language);
   const load = (async (): Promise<DictionaryLoad> => {
-    const result = await loadDictionary(language);
-    if (result.status === "loaded") {
-      lastLoaded.set(language, result.entries);
+    try {
+      const result = await loadDictionary(language);
+      if (result.status === "loaded") {
+        lastLoaded.set(language, {
+          contentHash: result.contentHash,
+          entries: result.entries,
+        });
+        return result;
+      }
+      const previous = lastLoaded.get(language);
+      if (previous !== undefined) {
+        return { ...previous, status: "loaded" };
+      }
+      // Nothing to serve at all: retry on the fast cycle rather than the slow
+      // one. Re-read the entry rather than closing over the promise being built.
+      const entry = cache.get(language);
+      if (entry !== undefined) {
+        cache.set(language, {
+          load: entry.load,
+          expiresAt: Date.now() + DICTIONARY_UNAVAILABLE_TTL_MS,
+        });
+      }
       return result;
+    } finally {
+      // `finally`, not a trailing statement: a leaked marker would pin the
+      // language to its stale payload for the life of the process.
+      inFlight.delete(language);
     }
-    const previous = lastLoaded.get(language);
-    if (previous !== undefined) {
-      return { entries: previous, status: "loaded" };
-    }
-    // Nothing to serve at all: retry on the fast cycle rather than the slow
-    // one. Re-read the entry rather than closing over the promise being built.
-    const entry = cache.get(language);
-    if (entry !== undefined) {
-      cache.set(language, {
-        load: entry.load,
-        expiresAt: Date.now() + DICTIONARY_UNAVAILABLE_TTL_MS,
-      });
-    }
-    return result;
   })();
 
   // Set before anyone awaits, so concurrent callers share this one read.
@@ -317,13 +345,21 @@ const beginRefresh = async (
 const dictionaryFor = async (
   language: MorphologyLanguage,
 ): Promise<DictionaryLoad> => {
+  const previous = lastLoaded.get(language);
+
+  // A read in flight must not block a request that can already be answered.
+  // This is checked before the cache entry, because a refresh installs its
+  // entry with a future expiry the instant it starts.
+  if (previous !== undefined && inFlight.has(language)) {
+    return { ...previous, status: "loaded" };
+  }
+
   const cached = cache.get(language);
   if (cached && cached.expiresAt > Date.now()) {
     return await cached.load;
   }
 
   const refresh = beginRefresh(language);
-  const previous = lastLoaded.get(language);
   if (previous === undefined) {
     // Cold: there is nothing to answer with, so this caller waits for the read.
     return await refresh;
@@ -335,7 +371,7 @@ const dictionaryFor = async (
   // deadline when object storage is slow — which is exactly the stall the
   // fallback exists to prevent.
   detached(refresh, "legal-search.expansion-dictionary-refresh");
-  return { entries: previous, status: "loaded" };
+  return { ...previous, status: "loaded" };
 };
 
 /**
@@ -398,14 +434,20 @@ export const expandTermWith = (
   return extras;
 };
 
+type ResolvedExpander = {
+  /** Which payload answered, so telemetry can show replicas converging. */
+  contentHash: string;
+  expand: CorpusTermExpander;
+};
+
 /**
  * The expander for a request, or null when this request expands nothing.
  * Null covers an unscoped or unsupported jurisdiction and an unavailable
  * dictionary alike, so the caller has one branch rather than a mode matrix.
  */
-export const corpusTermExpander = async (
+const corpusTermExpander = async (
   country: string | undefined,
-): Promise<CorpusTermExpander | null> => {
+): Promise<ResolvedExpander | null> => {
   const language = expansionLanguageForJurisdiction(country);
   if (language === null) {
     return null;
@@ -416,7 +458,10 @@ export const corpusTermExpander = async (
       return null;
     }
     case "loaded": {
-      return (term) => expandTermWith(dictionary.entries, term);
+      return {
+        contentHash: dictionary.contentHash,
+        expand: (term) => expandTermWith(dictionary.entries, term),
+      };
     }
     default: {
       return dictionary satisfies never;
@@ -433,6 +478,12 @@ type ShadowExpansionLog = {
    * or the ratio would be one by construction.
    */
   countryScoped: boolean;
+  /**
+   * Short hash of the payload that answered, or "none". Replicas serving
+   * different builds is what makes a paginated `on` query inconsistent, so the
+   * rollout has to be able to see convergence before that mode is considered.
+   */
+  dictionaryHash: string;
   /** Free-text leaves after expansion; equals `baseLeaves` when nothing fired. */
   expandedLeaves: number;
   language: MorphologyLanguage | null;
@@ -476,12 +527,14 @@ type ShadowExpansionLog = {
 export const shadowExpansionAttributes = ({
   baseLeaves,
   countryScoped,
+  dictionaryHash,
   expandedLeaves,
   language,
   reach,
 }: ShadowExpansionLog): LoggerAttributes => ({
   baseLeaves,
   countryScoped,
+  dictionaryHash,
   expandedLeaves,
   addedLeaves: expandedLeaves - baseLeaves,
   language: language ?? "none",
@@ -558,6 +611,22 @@ type ResolveExpandedQueryOptions = {
  * inside resolves to the unexpanded query, so a search never depends on the
  * dictionary being reachable.
  */
+/**
+ * Known limitation of `on`, recorded where the decision to flip it will be
+ * made: the query a request builds depends on which dictionary its replica has
+ * loaded, so a page-2 request served by a replica mid-refresh (or holding a
+ * fallback payload) can rebuild a different engine query while reusing page 1's
+ * cursor, which ranks a different result set against an old score/id boundary.
+ * Replicas converge on the pointer, so the window is a rebuild or a failed
+ * refresh rather than steady state, and `shadow` cannot hit it at all because
+ * it executes the unexpanded query.
+ *
+ * Turning `on` on requires closing this first: the cursor has to carry the
+ * dictionary version and later pages have to resolve that same version, which
+ * means retaining superseded payloads. That is a rollout decision, not an
+ * inert-flag one, so the shadow event reports which payload each replica used
+ * (`dictionaryHash`) to make convergence measurable before the choice is made.
+ */
 export const resolveExpandedCorpusQuery = async ({
   build,
   jurisdiction,
@@ -582,6 +651,7 @@ export const resolveExpandedCorpusQuery = async ({
       logShadowExpansion({
         baseLeaves,
         countryScoped,
+        dictionaryHash: "none",
         expandedLeaves: baseLeaves,
         language,
         reach: language === null ? "unsupported_jurisdiction" : "no_dictionary",
@@ -592,7 +662,7 @@ export const resolveExpandedCorpusQuery = async ({
 
   // Both builds tokenize the same text, so this is null only when `baseQuery`
   // already was; returning the base query keeps the branch total anyway.
-  const expandedQuery = build(expand);
+  const expandedQuery = build(expand.expand);
   if (expandedQuery === null) {
     return baseQuery;
   }
@@ -603,10 +673,11 @@ export const resolveExpandedCorpusQuery = async ({
     }
     case "shadow": {
       const baseLeaves = freeTextLeaves(text);
-      const expandedLeaves = freeTextLeaves(text, expand);
+      const expandedLeaves = freeTextLeaves(text, expand.expand);
       logShadowExpansion({
         baseLeaves,
         countryScoped,
+        dictionaryHash: shortHash(expand.contentHash),
         expandedLeaves,
         language,
         // A dictionary that loaded but matched nothing, lost every form to the

--- a/apps/api/src/lib/legal-search/expansion.ts
+++ b/apps/api/src/lib/legal-search/expansion.ts
@@ -446,15 +446,35 @@ type ResolvedExpander = {
 };
 
 /**
+ * Whether a caller may wait for a cold dictionary.
+ *
+ * `on` must: the query it returns depends on the dictionary, so there is
+ * nothing to serve until the read finishes. `shadow` must not: it executes the
+ * unexpanded query whatever happens, so waiting on object storage would add
+ * that latency to a search purely to observe it — and on a cold replica with a
+ * slow store that is the full resolve deadline, paid by every request sharing
+ * the load. An observational mode that can slow the request path is not one
+ * anybody can safely leave on.
+ */
+type ExpanderAvailability = "await_cold_load" | "resident_only";
+
+/**
  * The expander for a request, or null when this request expands nothing.
- * Null covers an unscoped or unsupported jurisdiction and an unavailable
- * dictionary alike, so the caller has one branch rather than a mode matrix.
+ * Null covers an unscoped or unsupported jurisdiction, an unavailable
+ * dictionary, and (under `resident_only`) one not yet in memory, so the caller
+ * has one branch rather than a mode matrix.
  */
 const corpusTermExpander = async (
   country: string | undefined,
+  availability: ExpanderAvailability,
 ): Promise<ResolvedExpander | null> => {
   const language = expansionLanguageForJurisdiction(country);
   if (language === null) {
+    return null;
+  }
+  if (availability === "resident_only" && !lastLoaded.has(language)) {
+    // Warm it for the requests after this one, off the request path.
+    detached(dictionaryFor(language), "legal-search.expansion-dictionary-warm");
     return null;
   }
   const dictionary = await dictionaryFor(language);
@@ -507,6 +527,7 @@ type ShadowExpansionLog = {
    */
   reach:
     | "dictionary_inert"
+    | "dictionary_warming"
     | "expanded"
     | "no_dictionary"
     | "unsupported_jurisdiction";
@@ -591,6 +612,21 @@ const freeTextLeaves = (text: string, expand?: CorpusTermExpander): number => {
   return clause === null ? 0 : countLeaves(clause);
 };
 
+/**
+ * Why a request that routed to a supported language still got no expander.
+ * Distinguishing "not loaded yet" from "would not load" matters to the rollout:
+ * the first is a cold replica that will be answering normally in a moment, the
+ * second is an operational problem.
+ */
+const expanderMissReach = (
+  language: MorphologyLanguage | null,
+): "dictionary_warming" | "no_dictionary" | "unsupported_jurisdiction" => {
+  if (language === null) {
+    return "unsupported_jurisdiction";
+  }
+  return lastLoaded.has(language) ? "no_dictionary" : "dictionary_warming";
+};
+
 type ResolveExpandedQueryOptions = {
   /** Assemble the clause, with the expander when one is supplied. */
   build: (expand?: CorpusTermExpander) => string | null;
@@ -649,7 +685,12 @@ export const resolveExpandedCorpusQuery = async ({
   const countryScoped = jurisdiction !== undefined;
   const language = expansionLanguageForJurisdiction(jurisdiction);
   const expand =
-    language === null ? null : await corpusTermExpander(jurisdiction);
+    language === null
+      ? null
+      : await corpusTermExpander(
+          jurisdiction,
+          mode === "shadow" ? "resident_only" : "await_cold_load",
+        );
 
   // A request that reaches no dictionary still reports, or the reach metrics
   // would only ever describe the traffic expansion already covers.
@@ -662,7 +703,7 @@ export const resolveExpandedCorpusQuery = async ({
         dictionaryHash: "none",
         expandedLeaves: baseLeaves,
         language,
-        reach: language === null ? "unsupported_jurisdiction" : "no_dictionary",
+        reach: expanderMissReach(language),
       });
     }
     return baseQuery;

--- a/apps/api/src/lib/legal-search/expansion.ts
+++ b/apps/api/src/lib/legal-search/expansion.ts
@@ -1,0 +1,362 @@
+/**
+ * Morphological query expansion for the case-law corpus index.
+ *
+ * Czech and Polish inflect heavily, so a reader searching `nájemné` misses
+ * the judgments that write `nájemného`. Each term the reader types becomes an
+ * OR group of that word's other surface forms, AND-ed with the rest of the
+ * query exactly as before.
+ *
+ * The stemmer never runs here. Query text arrives folded, decomposed, and
+ * lowercased in whatever combination the reader's keyboard produced, and the
+ * suffix tables are written over accented, precomposed characters — stemming
+ * that input mis-stems a measurable fraction of it. Instead an offline build
+ * stems the accented corpus vocabulary once (see
+ * `scripts/build-expansion-dictionary.ts`) and query time is a Map lookup on
+ * the folded form.
+ *
+ * Everything here degrades to the identity: a missing dictionary, an
+ * unreachable bucket, a term the guards reject, or a budget that has run out
+ * all produce the query the reader would have gotten anyway. Expansion is
+ * allowed to add recall and is never allowed to remove it or to fail a search.
+ */
+
+import { Result } from "better-result";
+
+import { zstdDecompressToStringBounded } from "@/api/lib/compression";
+import type { CorpusTermExpander } from "@/api/lib/legal-search/corpus-query";
+import {
+  foldExpansionKey,
+  isMorphologyDictionaryContentHash,
+  isSurfaceForm,
+  morphologyDictionaryKey,
+  morphologyDictionaryPointerKey,
+  parseExpansionDictionary,
+  unpackExpansionForms,
+} from "@/api/lib/legal-search/morphology/dictionary";
+import type { MorphologyLanguage } from "@/api/lib/legal-search/morphology/stem";
+import type { LoggerAttributes } from "@/api/lib/observability/logger";
+import { logger } from "@/api/lib/observability/logger";
+import { readCorpusS3Bytes } from "@/api/lib/s3";
+
+/**
+ * Jurisdictions the corpus index serves, and the language whose dictionary
+ * their text is expanded against. `null` means the jurisdiction is served
+ * without expansion.
+ *
+ * Slovak resolves to `null` in phase 1: the stemmer exists, but no Slovak
+ * dictionary is published yet, and pointing SVK at a language with no payload
+ * would make every Slovak search pay a pointer read that can only miss.
+ * Publishing the dictionary and flipping this one entry enables it.
+ *
+ * The EU index carries 24 languages under one jurisdiction, so a single
+ * dictionary could not be chosen for it at all.
+ */
+const EXPANSION_LANGUAGE_BY_JURISDICTION = {
+  CZE: "cs",
+  EU: null,
+  POL: "pl",
+  SVK: null,
+} as const satisfies Record<string, MorphologyLanguage | null>;
+
+type ExpansionJurisdiction = keyof typeof EXPANSION_LANGUAGE_BY_JURISDICTION;
+
+const isExpansionJurisdiction = (
+  value: string,
+): value is ExpansionJurisdiction =>
+  Object.hasOwn(EXPANSION_LANGUAGE_BY_JURISDICTION, value);
+
+/**
+ * Which language a request's jurisdiction expands against, or null for no
+ * expansion. An unscoped search (no country: the index pattern spans every
+ * jurisdiction) resolves to null, because no one language describes its text.
+ * An unrecognised jurisdiction resolves to null for the same reason; this
+ * lookup's miss is the documented phase-1 scope, not a defect to report.
+ */
+export const expansionLanguageForJurisdiction = (
+  country: string | undefined,
+): MorphologyLanguage | null => {
+  if (country === undefined) {
+    return null;
+  }
+  const jurisdiction = country.toUpperCase();
+  return isExpansionJurisdiction(jurisdiction)
+    ? EXPANSION_LANGUAGE_BY_JURISDICTION[jurisdiction]
+    : null;
+};
+
+/**
+ * Hard floor on the length of a term worth expanding, in code points.
+ *
+ * Not `min(3, term.length)`: a two-character term shares its whole length
+ * with far too much of the vocabulary, and the shorter-of rule let Polish
+ * two-letter words expand into groups that had nothing to do with them.
+ */
+const MIN_EXPANDABLE_TERM_LENGTH = 3;
+
+/**
+ * Longest common prefix a form must share with the typed term, in code points
+ * of the folded spelling.
+ *
+ * A stem bucket is only as good as the stemmer, and a light stemmer
+ * occasionally over-strips: `veci` and `vek` reduce to the same stem without
+ * being the same word. Requiring three shared leading characters contains
+ * every incoherent bucket the corpus build reported, and costs nothing for
+ * real inflection, which varies at the end of a word rather than the start.
+ */
+const MIN_FORM_COMMON_PREFIX = 3;
+
+/** Decompressed ceiling for one dictionary payload; measured builds are ~2 MB. */
+const DICTIONARY_MAX_DECOMPRESSED_BYTES = 64 * 1024 * 1024;
+
+/** Wall-clock bound on the two object reads a first use costs. */
+const DICTIONARY_READ_TIMEOUT_MS = 30_000;
+
+/**
+ * How long an unavailable dictionary stays unavailable before another request
+ * retries the read. Long enough that an outage cannot turn every search into
+ * an object-store round trip, short enough that a first publish or a
+ * recovered store starts serving without a restart.
+ */
+const DICTIONARY_UNAVAILABLE_TTL_MS = 60_000;
+
+/** Structured events; swept for, so spelled once. */
+const DICTIONARY_UNAVAILABLE =
+  "case_law.search.expansion_dictionary_unavailable";
+const DICTIONARY_LOADED = "case_law.search.expansion_dictionary_loaded";
+const EXPANSION_SHADOW = "case_law.search.expansion_shadow";
+
+type DictionaryLoad =
+  | { entries: ReadonlyMap<string, string>; status: "loaded" }
+  | { status: "unavailable" };
+
+const UNAVAILABLE: DictionaryLoad = { status: "unavailable" };
+
+const readDictionaryObject = async (key: string): Promise<Uint8Array> =>
+  await readCorpusS3Bytes(key, AbortSignal.timeout(DICTIONARY_READ_TIMEOUT_MS));
+
+/**
+ * Resolve the pointer object to the payload key. The pointer is the one
+ * mutable name in the layout, so a rebuild is a small write and a rollback is
+ * the previous hash. Its contents choose which key is read, which is why the
+ * hash shape is enforced rather than trusted.
+ */
+const readDictionaryPayload = async (
+  language: MorphologyLanguage,
+): Promise<string | null> => {
+  const pointer = await readDictionaryObject(
+    morphologyDictionaryPointerKey(language),
+  );
+  const contentHash = new TextDecoder().decode(pointer).trim();
+  if (!isMorphologyDictionaryContentHash(contentHash)) {
+    return null;
+  }
+  const payload = await readDictionaryObject(
+    morphologyDictionaryKey(language, contentHash),
+  );
+  return await zstdDecompressToStringBounded(
+    payload,
+    DICTIONARY_MAX_DECOMPRESSED_BYTES,
+  );
+};
+
+const loadDictionary = async (
+  language: MorphologyLanguage,
+): Promise<DictionaryLoad> => {
+  const read = await Result.tryPromise({
+    try: async () => await readDictionaryPayload(language),
+    catch: (cause) => cause,
+  });
+
+  if (!Result.isOk(read)) {
+    logger.warn(DICTIONARY_UNAVAILABLE, {
+      language,
+      reason: "read_failed",
+      errorClass:
+        read.error instanceof Error ? read.error.constructor.name : "unknown",
+    });
+    return UNAVAILABLE;
+  }
+  if (read.value === null) {
+    logger.warn(DICTIONARY_UNAVAILABLE, {
+      language,
+      reason: "malformed_pointer",
+    });
+    return UNAVAILABLE;
+  }
+
+  const { entries, skippedLines } = parseExpansionDictionary(read.value);
+  if (entries.size === 0) {
+    logger.warn(DICTIONARY_UNAVAILABLE, {
+      language,
+      reason: "empty_dictionary",
+      skippedLines,
+    });
+    return UNAVAILABLE;
+  }
+  if (skippedLines > 0) {
+    logger.warn(DICTIONARY_UNAVAILABLE, {
+      language,
+      reason: "malformed_lines",
+      skippedLines,
+      entries: entries.size,
+    });
+  }
+  logger.info(DICTIONARY_LOADED, { language, entries: entries.size });
+  return { entries, status: "loaded" };
+};
+
+type CacheEntry = {
+  /** Null once the load succeeded: a loaded dictionary is immutable. */
+  expiresAt: number | null;
+  load: Promise<DictionaryLoad>;
+};
+
+const cache = new Map<MorphologyLanguage, CacheEntry>();
+
+/**
+ * The per-language lazy singleton. Concurrent first uses share one read, and
+ * an unavailable result is remembered for a bounded window rather than
+ * forever, so neither an outage nor a recovery needs a deploy.
+ */
+const dictionaryFor = async (
+  language: MorphologyLanguage,
+): Promise<DictionaryLoad> => {
+  const cached = cache.get(language);
+  if (cached && (cached.expiresAt === null || cached.expiresAt > Date.now())) {
+    return await cached.load;
+  }
+
+  const load = loadDictionary(language);
+  cache.set(language, {
+    load,
+    expiresAt: Date.now() + DICTIONARY_UNAVAILABLE_TTL_MS,
+  });
+  const result = await load;
+  if (result.status === "loaded") {
+    cache.set(language, { load, expiresAt: null });
+  }
+  return result;
+};
+
+/**
+ * Shared leading characters, counted in code points rather than UTF-16 units
+ * so a surrogate pair is one character on both sides of the comparison.
+ */
+const commonPrefixLength = (left: string, right: string): number => {
+  const a = Array.from(left);
+  const b = Array.from(right);
+  const bound = Math.min(a.length, b.length);
+  let shared = 0;
+  while (shared < bound && a[shared] === b[shared]) {
+    shared += 1;
+  }
+  return shared;
+};
+
+/**
+ * The extra forms one typed term contributes, given a dictionary.
+ *
+ * Exported for tests and for the offline coherence report; the request path
+ * reaches it through `corpusTermExpander`. Rejects, in order: anything that is
+ * not a bare word (digits, identifiers, and every citation fragment the
+ * tokenizer can produce fail this), anything shorter than the floor, a term
+ * with no bucket, and any form that does not share a prefix with what the
+ * reader typed.
+ */
+export const expandTermWith = (
+  entries: ReadonlyMap<string, string>,
+  term: string,
+): readonly string[] => {
+  if (!isSurfaceForm(term)) {
+    return [];
+  }
+  const folded = foldExpansionKey(term);
+  if (Array.from(folded).length < MIN_EXPANDABLE_TERM_LENGTH) {
+    return [];
+  }
+  const packed = entries.get(folded);
+  if (packed === undefined) {
+    return [];
+  }
+
+  const extras: string[] = [];
+  for (const form of unpackExpansionForms(packed)) {
+    const foldedForm = foldExpansionKey(form);
+    if (foldedForm === folded) {
+      continue;
+    }
+    if (commonPrefixLength(folded, foldedForm) < MIN_FORM_COMMON_PREFIX) {
+      continue;
+    }
+    extras.push(form);
+  }
+  return extras;
+};
+
+/**
+ * The expander for a request, or null when this request expands nothing.
+ * Null covers an unscoped or unsupported jurisdiction and an unavailable
+ * dictionary alike, so the caller has one branch rather than a mode matrix.
+ */
+export const corpusTermExpander = async (
+  country: string | undefined,
+): Promise<CorpusTermExpander | null> => {
+  const language = expansionLanguageForJurisdiction(country);
+  if (language === null) {
+    return null;
+  }
+  const dictionary = await dictionaryFor(language);
+  switch (dictionary.status) {
+    case "unavailable": {
+      return null;
+    }
+    case "loaded": {
+      return (term) => expandTermWith(dictionary.entries, term);
+    }
+    default: {
+      return dictionary satisfies never;
+    }
+  }
+};
+
+type ShadowExpansionLog = {
+  /**
+   * Whether the reader scoped the search to one jurisdiction. Unscoped
+   * searches fan out across every index and never expand, so the ratio of
+   * scoped to unscoped traffic is what says how much of the corpus this
+   * feature can reach at all.
+   */
+  countryScoped: boolean;
+  executedQuery: string;
+  expandedQuery: string;
+  language: MorphologyLanguage | null;
+};
+
+/**
+ * What the shadow event carries. Split from the emit so a test can assert
+ * `sanitizeLogAttributes` keeps every key: the sanitizer drops payload-shaped
+ * keys silently, and a dropped key here is an event that looks emitted and
+ * measures nothing. Deriving the assertion from this function rather than
+ * from a list of key names is what keeps the two from drifting.
+ *
+ * Both query strings are already reduced to quoted word tokens by the query
+ * builder, and this endpoint searches published case law, not workspace
+ * content.
+ */
+export const shadowExpansionAttributes = ({
+  countryScoped,
+  executedQuery,
+  expandedQuery,
+  language,
+}: ShadowExpansionLog): LoggerAttributes => ({
+  countryScoped,
+  executedQuery,
+  expandedQuery,
+  expanded: expandedQuery !== executedQuery,
+  language: language ?? "none",
+});
+
+/** Record what expansion would have done to a query that ran unexpanded. */
+export const logShadowExpansion = (log: ShadowExpansionLog): void => {
+  logger.info(EXPANSION_SHADOW, shadowExpansionAttributes(log));
+};

--- a/apps/api/src/lib/legal-search/expansion.ts
+++ b/apps/api/src/lib/legal-search/expansion.ts
@@ -169,7 +169,8 @@ type DictionaryRejection = "content_hash_mismatch" | "malformed_pointer";
 
 type DictionaryPayload =
   | { contentHash: string; payload: string; status: "read" }
-  | { reason: DictionaryRejection; status: "rejected" };
+  | { reason: DictionaryRejection; status: "rejected" }
+  | { status: "unchanged" };
 
 /**
  * Resolve the pointer object to the payload, under one shared deadline.
@@ -181,9 +182,17 @@ type DictionaryPayload =
  * actually hash to it. Without the second check an overwritten or mispublished
  * object at a content-addressed key would be served as though it were the
  * addressed content, which is the whole guarantee the layout exists to give.
+ *
+ * `residentHash` short-circuits the common case. A refresh exists to notice a
+ * pointer that moved, and most do not: re-fetching, decompressing, hashing and
+ * reparsing a payload of up to the ceiling every cycle would spend recurring
+ * object-store traffic and synchronous event-loop time to rebuild a map
+ * identical to the one already in memory. Only the pointer is read unless it
+ * names something new.
  */
 const readDictionaryPayload = async (
   language: MorphologyLanguage,
+  residentHash: string | undefined,
 ): Promise<DictionaryPayload> => {
   const deadline = AbortSignal.timeout(DICTIONARY_RESOLVE_TIMEOUT_MS);
   const pointer = await readCorpusS3BytesBounded({
@@ -194,6 +203,9 @@ const readDictionaryPayload = async (
   const contentHash = new TextDecoder().decode(pointer).trim();
   if (!isMorphologyDictionaryContentHash(contentHash)) {
     return { reason: "malformed_pointer", status: "rejected" };
+  }
+  if (contentHash === residentHash) {
+    return { status: "unchanged" };
   }
 
   // Bounded on the compressed transfer, not only on what it decodes to: the
@@ -219,8 +231,10 @@ const readDictionaryPayload = async (
 const loadDictionary = async (
   language: MorphologyLanguage,
 ): Promise<DictionaryLoad> => {
+  const resident = lastLoaded.get(language);
   const read = await Result.tryPromise({
-    try: async () => await readDictionaryPayload(language),
+    try: async () =>
+      await readDictionaryPayload(language, resident?.contentHash),
     catch: (cause) => cause,
   });
 
@@ -232,6 +246,14 @@ const loadDictionary = async (
         read.error instanceof Error ? read.error.constructor.name : "unknown",
     });
     return UNAVAILABLE;
+  }
+  // The pointer still names what is already in memory; nothing was fetched.
+  // Only reachable when a resident hash was passed in, so the fallback is
+  // unreachable rather than a real state — but it keeps the branch total.
+  if (read.value.status === "unchanged") {
+    return resident === undefined
+      ? UNAVAILABLE
+      : { ...resident, status: "loaded" };
   }
   if (read.value.status === "rejected") {
     logger.warn(DICTIONARY_UNAVAILABLE, {
@@ -290,6 +312,14 @@ const lastLoaded = new Map<MorphologyLanguage, LoadedDictionary>();
  * the stale-serving fast path.
  */
 const inFlight = new Set<MorphologyLanguage>();
+/**
+ * Languages whose most recent load resolved with nothing to serve. Tracked
+ * rather than inferred from `lastLoaded` being empty: those two states look
+ * identical from outside and mean opposite things — a replica still warming up
+ * versus one that cannot read its dictionary at all. Conflating them would
+ * report every persistent storage or configuration failure as a warm-up.
+ */
+const resolvedUnavailable = new Set<MorphologyLanguage>();
 
 /**
  * The per-language lazy singleton. Concurrent uses share one read, a loaded
@@ -316,8 +346,10 @@ const beginRefresh = async (
           contentHash: result.contentHash,
           entries: result.entries,
         });
+        resolvedUnavailable.delete(language);
         return result;
       }
+      resolvedUnavailable.add(language);
       const previous = lastLoaded.get(language);
       if (previous !== undefined) {
         return { ...previous, status: "loaded" };
@@ -624,7 +656,9 @@ const expanderMissReach = (
   if (language === null) {
     return "unsupported_jurisdiction";
   }
-  return lastLoaded.has(language) ? "no_dictionary" : "dictionary_warming";
+  return resolvedUnavailable.has(language)
+    ? "no_dictionary"
+    : "dictionary_warming";
 };
 
 type ResolveExpandedQueryOptions = {

--- a/apps/api/src/lib/legal-search/expansion.ts
+++ b/apps/api/src/lib/legal-search/expansion.ts
@@ -28,12 +28,14 @@ import {
   foldExpansionKey,
   isMorphologyDictionaryContentHash,
   isSurfaceForm,
+  MORPHOLOGY_DICTIONARY_MAX_BYTES,
   morphologyDictionaryKey,
   morphologyDictionaryPointerKey,
   parseExpansionDictionary,
   unpackExpansionForms,
 } from "@/api/lib/legal-search/morphology/dictionary";
 import type { MorphologyLanguage } from "@/api/lib/legal-search/morphology/stem";
+import type { QueryExpansionMode } from "@/api/lib/legal-search/query-expansion-mode";
 import type { LoggerAttributes } from "@/api/lib/observability/logger";
 import { logger } from "@/api/lib/observability/logger";
 import { readCorpusS3Bytes } from "@/api/lib/s3";
@@ -105,11 +107,14 @@ const MIN_EXPANDABLE_TERM_LENGTH = 3;
  */
 const MIN_FORM_COMMON_PREFIX = 3;
 
-/** Decompressed ceiling for one dictionary payload; measured builds are ~2 MB. */
-const DICTIONARY_MAX_DECOMPRESSED_BYTES = 64 * 1024 * 1024;
-
-/** Wall-clock bound on the two object reads a first use costs. */
-const DICTIONARY_READ_TIMEOUT_MS = 30_000;
+/**
+ * Wall-clock bound on resolving a dictionary, pointer read and payload read
+ * together. One deadline for the whole operation, not one per object: two
+ * sequential 30s bounds would let a stalled payload read keep the first search
+ * after startup waiting for a minute, including a `shadow` request that goes
+ * on to execute the unexpanded query anyway.
+ */
+const DICTIONARY_RESOLVE_TIMEOUT_MS = 30_000;
 
 /**
  * How long an unavailable dictionary stays unavailable before another request
@@ -118,6 +123,17 @@ const DICTIONARY_READ_TIMEOUT_MS = 30_000;
  * recovered store starts serving without a restart.
  */
 const DICTIONARY_UNAVAILABLE_TTL_MS = 60_000;
+
+/**
+ * How long a loaded dictionary is served before the pointer is rechecked.
+ *
+ * A loaded payload is immutable, but the pointer naming it is not: caching the
+ * payload forever would make a rebuild or a rollback reach only replicas that
+ * restart afterwards, so identical requests would get different queries from
+ * warm and new instances indefinitely. A failed refresh keeps serving the
+ * payload that last worked rather than falling back to no expansion.
+ */
+const DICTIONARY_REFRESH_TTL_MS = 15 * 60_000;
 
 /** Structured events; swept for, so spelled once. */
 const DICTIONARY_UNAVAILABLE =
@@ -131,32 +147,51 @@ type DictionaryLoad =
 
 const UNAVAILABLE: DictionaryLoad = { status: "unavailable" };
 
-const readDictionaryObject = async (key: string): Promise<Uint8Array> =>
-  await readCorpusS3Bytes(key, AbortSignal.timeout(DICTIONARY_READ_TIMEOUT_MS));
+/** Why a resolve produced no dictionary, for the warning's `reason`. */
+type DictionaryRejection = "content_hash_mismatch" | "malformed_pointer";
+
+type DictionaryPayload =
+  | { payload: string; status: "read" }
+  | { reason: DictionaryRejection; status: "rejected" };
 
 /**
- * Resolve the pointer object to the payload key. The pointer is the one
- * mutable name in the layout, so a rebuild is a small write and a rollback is
- * the previous hash. Its contents choose which key is read, which is why the
- * hash shape is enforced rather than trusted.
+ * Resolve the pointer object to the payload, under one shared deadline.
+ *
+ * The pointer is the layout's only mutable name, so a rebuild is a small write
+ * and a rollback is the previous hash. Two properties are enforced rather than
+ * trusted, because the pointer's contents choose which key is read: its shape
+ * must be a sha256 hex string, and the bytes found at the key it names must
+ * actually hash to it. Without the second check an overwritten or mispublished
+ * object at a content-addressed key would be served as though it were the
+ * addressed content, which is the whole guarantee the layout exists to give.
  */
 const readDictionaryPayload = async (
   language: MorphologyLanguage,
-): Promise<string | null> => {
-  const pointer = await readDictionaryObject(
+): Promise<DictionaryPayload> => {
+  const deadline = AbortSignal.timeout(DICTIONARY_RESOLVE_TIMEOUT_MS);
+  const pointer = await readCorpusS3Bytes(
     morphologyDictionaryPointerKey(language),
+    deadline,
   );
   const contentHash = new TextDecoder().decode(pointer).trim();
   if (!isMorphologyDictionaryContentHash(contentHash)) {
-    return null;
+    return { reason: "malformed_pointer", status: "rejected" };
   }
-  const payload = await readDictionaryObject(
+
+  const compressed = await readCorpusS3Bytes(
     morphologyDictionaryKey(language, contentHash),
+    deadline,
   );
-  return await zstdDecompressToStringBounded(
-    payload,
-    DICTIONARY_MAX_DECOMPRESSED_BYTES,
+  const payload = await zstdDecompressToStringBounded(
+    compressed,
+    MORPHOLOGY_DICTIONARY_MAX_BYTES,
   );
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(payload);
+  if (hasher.digest("hex") !== contentHash) {
+    return { reason: "content_hash_mismatch", status: "rejected" };
+  }
+  return { payload, status: "read" };
 };
 
 const loadDictionary = async (
@@ -176,15 +211,17 @@ const loadDictionary = async (
     });
     return UNAVAILABLE;
   }
-  if (read.value === null) {
+  if (read.value.status === "rejected") {
     logger.warn(DICTIONARY_UNAVAILABLE, {
       language,
-      reason: "malformed_pointer",
+      reason: read.value.reason,
     });
     return UNAVAILABLE;
   }
 
-  const { entries, skippedLines } = parseExpansionDictionary(read.value);
+  const { collidedKeys, entries, skippedLines } = parseExpansionDictionary(
+    read.value.payload,
+  );
   if (entries.size === 0) {
     logger.warn(DICTIONARY_UNAVAILABLE, {
       language,
@@ -193,47 +230,74 @@ const loadDictionary = async (
     });
     return UNAVAILABLE;
   }
-  if (skippedLines > 0) {
+  if (skippedLines > 0 || collidedKeys > 0) {
     logger.warn(DICTIONARY_UNAVAILABLE, {
       language,
-      reason: "malformed_lines",
+      reason: "degraded_dictionary",
       skippedLines,
+      collidedKeys,
       entries: entries.size,
     });
   }
-  logger.info(DICTIONARY_LOADED, { language, entries: entries.size });
+  logger.info(DICTIONARY_LOADED, {
+    language,
+    entries: entries.size,
+    collidedKeys,
+  });
   return { entries, status: "loaded" };
 };
 
 type CacheEntry = {
-  /** Null once the load succeeded: a loaded dictionary is immutable. */
-  expiresAt: number | null;
+  expiresAt: number;
   load: Promise<DictionaryLoad>;
 };
 
 const cache = new Map<MorphologyLanguage, CacheEntry>();
+/** The last payload that parsed, per language; a failed refresh falls back here. */
+const lastLoaded = new Map<MorphologyLanguage, ReadonlyMap<string, string>>();
 
 /**
- * The per-language lazy singleton. Concurrent first uses share one read, and
- * an unavailable result is remembered for a bounded window rather than
- * forever, so neither an outage nor a recovery needs a deploy.
+ * The per-language lazy singleton. Concurrent uses share one read, a loaded
+ * dictionary is rechecked against the pointer on a slow cycle, and an
+ * unavailable one is retried on a fast one, so neither a rebuild, a rollback,
+ * an outage, nor a recovery needs a deploy.
+ *
+ * A refresh that fails keeps serving the payload that last parsed: losing
+ * expansion because object storage blipped would be a recall regression the
+ * reader sees, where serving a slightly stale dictionary is not.
  */
 const dictionaryFor = async (
   language: MorphologyLanguage,
 ): Promise<DictionaryLoad> => {
   const cached = cache.get(language);
-  if (cached && (cached.expiresAt === null || cached.expiresAt > Date.now())) {
+  if (cached && cached.expiresAt > Date.now()) {
     return await cached.load;
   }
 
-  const load = loadDictionary(language);
+  const load = (async (): Promise<DictionaryLoad> => {
+    const result = await loadDictionary(language);
+    if (result.status === "loaded") {
+      lastLoaded.set(language, result.entries);
+      return result;
+    }
+    const previous = lastLoaded.get(language);
+    return previous === undefined
+      ? result
+      : { entries: previous, status: "loaded" };
+  })();
+
+  // Deduplicates concurrent callers while the read is in flight; corrected to
+  // the retry window below if it turns out there is nothing to serve.
   cache.set(language, {
     load,
-    expiresAt: Date.now() + DICTIONARY_UNAVAILABLE_TTL_MS,
+    expiresAt: Date.now() + DICTIONARY_REFRESH_TTL_MS,
   });
   const result = await load;
-  if (result.status === "loaded") {
-    cache.set(language, { load, expiresAt: null });
+  if (result.status === "unavailable") {
+    cache.set(language, {
+      load,
+      expiresAt: Date.now() + DICTIONARY_UNAVAILABLE_TTL_MS,
+    });
   }
   return result;
 };
@@ -267,10 +331,15 @@ export const expandTermWith = (
   entries: ReadonlyMap<string, string>,
   term: string,
 ): readonly string[] => {
-  if (!isSurfaceForm(term)) {
+  // Fold first, then test the shape. The fold canonicalises and strips
+  // combining marks, so a decomposed `žalobě` (routine from extracted PDFs and
+  // from macOS keyboards) is judged as the word it is rather than rejected for
+  // the marks it carries. Digits and punctuation survive the fold, so the
+  // letters-only rule still excludes every identifier it excluded before.
+  const folded = foldExpansionKey(term);
+  if (!isSurfaceForm(folded)) {
     return [];
   }
-  const folded = foldExpansionKey(term);
   if (Array.from(folded).length < MIN_EXPANDABLE_TERM_LENGTH) {
     return [];
   }
@@ -324,39 +393,163 @@ type ShadowExpansionLog = {
    * Whether the reader scoped the search to one jurisdiction. Unscoped
    * searches fan out across every index and never expand, so the ratio of
    * scoped to unscoped traffic is what says how much of the corpus this
-   * feature can reach at all.
+   * feature can reach at all. Emitted for requests that expanded nothing too,
+   * or the ratio would be one by construction.
    */
   countryScoped: boolean;
-  executedQuery: string;
-  expandedQuery: string;
+  /** Quoted leaves the expanded query carries; equals `baseLeaves` when inert. */
+  expandedLeaves: number;
   language: MorphologyLanguage | null;
+  /** Quoted leaves before expansion: one per token the reader typed. */
+  baseLeaves: number;
+  /** Why this request expanded nothing, or "expanded" when it did. */
+  reach: "expanded" | "no_dictionary" | "unsupported_jurisdiction";
 };
 
 /**
- * What the shadow event carries. Split from the emit so a test can assert
- * `sanitizeLogAttributes` keeps every key: the sanitizer drops payload-shaped
- * keys silently, and a dropped key here is an event that looks emitted and
- * measures nothing. Deriving the assertion from this function rather than
- * from a list of key names is what keeps the two from drifting.
+ * What the shadow event carries: counts, never text.
  *
- * Both query strings are already reduced to quoted word tokens by the query
- * builder, and this endpoint searches published case law, not workspace
- * content.
+ * The query strings are deliberately absent. They are the reader's own words,
+ * and a case-law search can carry a client name, a party, or the shape of a
+ * legal strategy; copying them into INFO telemetry, the stderr mirror, and any
+ * configured OTLP sink would be new exposure that nothing in the request path
+ * creates today. `sanitizeLogAttributes` would not have redacted them either,
+ * since neither key is payload-shaped. Leaf counts answer what the rollout
+ * needs to know (how often expansion fires, how much it widens a query, and
+ * how much traffic it can reach at all) and reconstruct nothing.
+ *
+ * Split from the emit so a test can assert the sanitizer keeps every key: it
+ * drops keys silently, and a dropped key is an event that looks emitted and
+ * measures nothing. The assertion derives from this function rather than from
+ * a hand-kept list of names, so the two cannot drift.
  */
 export const shadowExpansionAttributes = ({
+  baseLeaves,
   countryScoped,
-  executedQuery,
-  expandedQuery,
+  expandedLeaves,
   language,
+  reach,
 }: ShadowExpansionLog): LoggerAttributes => ({
+  baseLeaves,
   countryScoped,
-  executedQuery,
-  expandedQuery,
-  expanded: expandedQuery !== executedQuery,
+  expandedLeaves,
+  addedLeaves: expandedLeaves - baseLeaves,
   language: language ?? "none",
+  reach,
 });
 
 /** Record what expansion would have done to a query that ran unexpanded. */
 export const logShadowExpansion = (log: ShadowExpansionLog): void => {
   logger.info(EXPANSION_SHADOW, shadowExpansionAttributes(log));
+};
+
+/**
+ * Quoted leaves in an assembled clause: quote characters that open a span,
+ * counted outside one. Cheap, and it needs no access to the token stream.
+ */
+const countLeaves = (clause: string): number => {
+  let leaves = 0;
+  let index = 0;
+  let inQuotes = false;
+  while (index < clause.length) {
+    const char = clause.charAt(index);
+    if (inQuotes) {
+      if (char === "\\") {
+        index += 2;
+        continue;
+      }
+      if (char === '"') {
+        inQuotes = false;
+      }
+      index += 1;
+      continue;
+    }
+    if (char === '"') {
+      inQuotes = true;
+      leaves += 1;
+    }
+    index += 1;
+  }
+  return leaves;
+};
+
+type ResolveExpandedQueryOptions = {
+  /** Assemble the clause, with the expander when one is supplied. */
+  build: (expand?: CorpusTermExpander) => string | null;
+  jurisdiction: string | undefined;
+  mode: QueryExpansionMode;
+};
+
+/**
+ * The query a corpus-index search sends to the engine, under the deployment's
+ * expansion mode.
+ *
+ * Both case-law corpus-index boundaries (the public search handler and the
+ * shared provider) resolve through here, for the same reason both assemble
+ * through `caseLawCorpusQuery`: a rollout flag applied at one boundary and not
+ * the other is two answers to what the engine sees, which is exactly what the
+ * shared builder exists to prevent.
+ *
+ * `off` never resolves a dictionary and returns the byte-identical
+ * pre-expansion query. `shadow` builds both, records the comparison, and
+ * executes the unexpanded one. `on` executes the expanded one. Every failure
+ * inside resolves to the unexpanded query, so a search never depends on the
+ * dictionary being reachable.
+ */
+export const resolveExpandedCorpusQuery = async ({
+  build,
+  jurisdiction,
+  mode,
+}: ResolveExpandedQueryOptions): Promise<string | null> => {
+  const baseQuery = build();
+  if (mode === "off" || baseQuery === null) {
+    return baseQuery;
+  }
+
+  const countryScoped = jurisdiction !== undefined;
+  const language = expansionLanguageForJurisdiction(jurisdiction);
+  const expand =
+    language === null ? null : await corpusTermExpander(jurisdiction);
+
+  // A request that reaches no dictionary still reports, or the reach metrics
+  // would only ever describe the traffic expansion already covers.
+  if (expand === null) {
+    if (mode === "shadow") {
+      const baseLeaves = countLeaves(baseQuery);
+      logShadowExpansion({
+        baseLeaves,
+        countryScoped,
+        expandedLeaves: baseLeaves,
+        language,
+        reach: language === null ? "unsupported_jurisdiction" : "no_dictionary",
+      });
+    }
+    return baseQuery;
+  }
+
+  // Both builds tokenize the same text, so this is null only when `baseQuery`
+  // already was; returning the base query keeps the branch total anyway.
+  const expandedQuery = build(expand);
+  if (expandedQuery === null) {
+    return baseQuery;
+  }
+
+  switch (mode) {
+    case "on": {
+      return expandedQuery;
+    }
+    case "shadow": {
+      logShadowExpansion({
+        baseLeaves: countLeaves(baseQuery),
+        countryScoped,
+        expandedLeaves: countLeaves(expandedQuery),
+        language,
+        reach: "expanded",
+      });
+      return baseQuery;
+    }
+    default: {
+      return mode satisfies never;
+    }
+  }
 };

--- a/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
@@ -5,6 +5,8 @@ import {
   isMorphologyDictionaryContentHash,
   isSurfaceForm,
   MAX_FORMS_PER_BUCKET,
+  SURFACE_FORM_MAX_LENGTH,
+  SURFACE_FORM_MIN_LENGTH,
   morphologyDictionaryKey,
   morphologyDictionaryPointerKey,
   parseExpansionDictionary,
@@ -59,7 +61,7 @@ test("a bad line costs only itself", () => {
 
 test("the cap is what the parser enforces", () => {
   const forms = Array.from({ length: MAX_FORMS_PER_BUCKET }, (_, index) =>
-    "a".repeat(index + 2),
+    "a".repeat(index + SURFACE_FORM_MIN_LENGTH),
   );
   expect(
     parseExpansionDictionary(`s\t${forms.join(",")}\t9`).entries.size,
@@ -84,6 +86,16 @@ test("a decomposed word is still a surface form", () => {
   expect(isSurfaceForm("žalobě".normalize("NFD"))).toBe(true);
   expect(isSurfaceForm("žalobě")).toBe(true);
   expect(isSurfaceForm("21cdo")).toBe(false);
+});
+
+// The leaf budget caps how many quoted values a query carries, never how long
+// one is, so an unbounded form would let a payload pair an ordinary key with a
+// multi-megabyte value and have an ordinary search build an enormous clause.
+test("a surface form is bounded at both ends", () => {
+  expect(isSurfaceForm("a".repeat(SURFACE_FORM_MIN_LENGTH - 1))).toBe(false);
+  expect(isSurfaceForm("a".repeat(SURFACE_FORM_MIN_LENGTH))).toBe(true);
+  expect(isSurfaceForm("a".repeat(SURFACE_FORM_MAX_LENGTH))).toBe(true);
+  expect(isSurfaceForm("a".repeat(SURFACE_FORM_MAX_LENGTH + 1))).toBe(false);
 });
 
 // Keys are folded and values are not, so two stems that differ only by

--- a/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
@@ -10,6 +10,7 @@ import {
   morphologyDictionaryKey,
   morphologyDictionaryPointerKey,
   parseExpansionDictionary,
+  parseExpansionDictionaryOffLoop,
   serializeExpansionDictionary,
 } from "@/api/lib/legal-search/morphology/dictionary";
 
@@ -39,7 +40,12 @@ test.each([
   ["a singleton bucket", "nájemn\tnájemné\t12"],
   [
     "more forms than the cap",
-    `s\t${["aa", "ab", "ac", "ad", "ae"].join(",")}\t9`,
+    `s\t${["aaa", "aab", "aac", "aad", "aae"].join(",")}\t9`,
+  ],
+  ["a form under the length floor", "s\tab,abc\t9"],
+  [
+    "a form past the length ceiling",
+    `s\t${"a".repeat(SURFACE_FORM_MAX_LENGTH + 1)},abc\t9`,
   ],
   ["a form carrying a digit", "s\tform1,form2\t9"],
   ["a form carrying a quote", 's\tfo"rm,form\t9'],
@@ -49,6 +55,39 @@ test.each([
   const parsed = parseExpansionDictionary(line);
   expect(parsed.skippedLines).toBe(1);
   expect(parsed.entries.size).toBe(0);
+});
+
+// Two drivers over one line parser. If they ever disagree, a replica would be
+// serving a different dictionary than the builder validated, so the agreement
+// is asserted over input that exercises every branch: good lines, a malformed
+// one, a collision, and enough lines to cross a yield boundary.
+test("the yielding parse agrees with the synchronous one", async () => {
+  const lines = [
+    "rad\trada,rady,radu\t900",
+    "řad\třada,řady,řadě\t800",
+    "junk",
+  ];
+  for (let index = 0; index < 2500; index += 1) {
+    lines.push(
+      `s${index}\tform${"a".repeat(index % 5)}x,formbx\t${index + 60}`,
+    );
+  }
+  const text = lines.join("\n");
+
+  const sync = parseExpansionDictionary(text);
+  const offLoop = await parseExpansionDictionaryOffLoop(text);
+
+  expect(offLoop.skippedLines).toBe(sync.skippedLines);
+  expect(offLoop.collidedKeys).toBe(sync.collidedKeys);
+  const byKey = (left: [string, string], right: [string, string]): number =>
+    left[0] < right[0] ? -1 : 1;
+  expect([...offLoop.entries].sort(byKey)).toEqual(
+    [...sync.entries].sort(byKey),
+  );
+  // Non-vacuity: the fixture must actually reach the interesting branches.
+  expect(sync.skippedLines).toBeGreaterThan(0);
+  expect(sync.collidedKeys).toBeGreaterThan(0);
+  expect(sync.entries.size).toBeGreaterThan(0);
 });
 
 test("a bad line costs only itself", () => {

--- a/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 import {
   foldExpansionKey,
   isMorphologyDictionaryContentHash,
+  isSurfaceForm,
   MAX_FORMS_PER_BUCKET,
   morphologyDictionaryKey,
   morphologyDictionaryPointerKey,
@@ -67,10 +68,58 @@ test("the cap is what the parser enforces", () => {
 
 test("the fold is lowercase, NFC, and diacritic-free", () => {
   expect(foldExpansionKey("ŠKODY")).toBe("skody");
-  // NFD input (common from PDFs and macOS filesystems) folds identically.
-  expect(foldExpansionKey("s̋kody".normalize("NFD"))).toBe(
-    foldExpansionKey("s̋kody"),
+  // The same word decomposed (routine from extracted PDFs and macOS
+  // filesystems) must reach the same key, or half the corpus is unreachable
+  // from half the keyboards.
+  expect(foldExpansionKey("ŠKODY".normalize("NFD"))).toBe("skody");
+  expect(foldExpansionKey("žalobě".normalize("NFD"))).toBe(
+    foldExpansionKey("žalobě"),
   );
+});
+
+// A combining mark is \p{M}, not \p{L}, so a letters-only test that ran before
+// canonicalisation would reject decomposed spellings of words it accepts
+// precomposed.
+test("a decomposed word is still a surface form", () => {
+  expect(isSurfaceForm("žalobě".normalize("NFD"))).toBe(true);
+  expect(isSurfaceForm("žalobě")).toBe(true);
+  expect(isSurfaceForm("21cdo")).toBe(false);
+});
+
+// Keys are folded and values are not, so two stems that differ only by
+// diacritics claim one key. Czech rada/řada and Polish sad/sąd are ordinary
+// words: answering a query for one with the other's inflections is a wrong
+// answer the prefix guard cannot catch, because the folded spellings agree.
+test("a folded key two stems claim expands to nothing", () => {
+  const parsed = parseExpansionDictionary(
+    ["rad\trada,rady,radu\t900", "řad\třada,řady,řadě\t800"].join("\n"),
+  );
+  expect(parsed.collidedKeys).toBeGreaterThan(0);
+  expect(parsed.entries.get("rada")).toBeUndefined();
+  expect(parsed.entries.get("rady")).toBeUndefined();
+  // Keys only one stem claims are unaffected.
+  expect(parsed.entries.get("radu")).toBe("rada,rady,radu");
+  expect(parsed.entries.get("rade")).toBe("řada,řady,řadě");
+});
+
+// Order must not decide the answer: the same two buckets serialized either way
+// round drop the same keys.
+test("collision handling does not depend on serialization order", () => {
+  const first = "rad\trada,rady,radu\t900";
+  const second = "řad\třada,řady,řadě\t800";
+  const forward = parseExpansionDictionary([first, second].join("\n"));
+  const reverse = parseExpansionDictionary([second, first].join("\n"));
+  expect([...forward.entries.keys()].sort()).toEqual(
+    [...reverse.entries.keys()].sort(),
+  );
+  expect(forward.collidedKeys).toBe(reverse.collidedKeys);
+});
+
+// Two forms of one family may fold together; that is the same answer twice.
+test("forms folding together inside one bucket are not a collision", () => {
+  const parsed = parseExpansionDictionary("rad\trada,ráda,radu\t900");
+  expect(parsed.collidedKeys).toBe(0);
+  expect(parsed.entries.get("rada")).toBe("rada,ráda,radu");
 });
 
 // The pointer object's contents choose which key is read, so its shape is

--- a/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "bun:test";
+
+import {
+  foldExpansionKey,
+  isMorphologyDictionaryContentHash,
+  MAX_FORMS_PER_BUCKET,
+  morphologyDictionaryKey,
+  morphologyDictionaryPointerKey,
+  parseExpansionDictionary,
+  serializeExpansionDictionary,
+} from "@/api/lib/legal-search/morphology/dictionary";
+
+test("serialize and parse are the same contract", () => {
+  const { entries, skippedLines } = parseExpansionDictionary(
+    serializeExpansionDictionary([
+      {
+        documentFrequency: 12,
+        forms: ["nájemné", "nájemného"],
+        stem: "nájemn",
+      },
+    ]),
+  );
+  expect(skippedLines).toBe(0);
+  expect(entries.get("najemne")).toBe("nájemné,nájemného");
+  // Every member of a bucket keys the same packed value, which is what makes
+  // the lookup work from whichever inflection the reader typed.
+  expect(entries.get("najemneho")).toBe("nájemné,nájemného");
+});
+
+// A dictionary is built offline from corpus text. One bad line must cost one
+// bucket, never every query the language serves, so the parser skips and
+// counts rather than throwing.
+test.each([
+  ["missing a field", "nájemn\tnájemné"],
+  ["an extra field", "nájemn\tnájemné,nájemného\t12\textra"],
+  ["a singleton bucket", "nájemn\tnájemné\t12"],
+  [
+    "more forms than the cap",
+    `s\t${["aa", "ab", "ac", "ad", "ae"].join(",")}\t9`,
+  ],
+  ["a form carrying a digit", "s\tform1,form2\t9"],
+  ["a form carrying a quote", 's\tfo"rm,form\t9'],
+  ["a form carrying a backslash", "s\tfo\\rm,form\t9"],
+  ["a form carrying a space", "s\tfo rm,form\t9"],
+])("a line with %s is skipped, not thrown on", (_label, line) => {
+  const parsed = parseExpansionDictionary(line);
+  expect(parsed.skippedLines).toBe(1);
+  expect(parsed.entries.size).toBe(0);
+});
+
+test("a bad line costs only itself", () => {
+  const parsed = parseExpansionDictionary(
+    ["broken", "nájemn\tnájemné,nájemného\t12", ""].join("\n"),
+  );
+  expect(parsed.skippedLines).toBe(1);
+  expect(parsed.entries.size).toBe(2);
+});
+
+test("the cap is what the parser enforces", () => {
+  const forms = Array.from({ length: MAX_FORMS_PER_BUCKET }, (_, index) =>
+    "a".repeat(index + 2),
+  );
+  expect(
+    parseExpansionDictionary(`s\t${forms.join(",")}\t9`).entries.size,
+  ).toBe(MAX_FORMS_PER_BUCKET);
+});
+
+test("the fold is lowercase, NFC, and diacritic-free", () => {
+  expect(foldExpansionKey("ŠKODY")).toBe("skody");
+  // NFD input (common from PDFs and macOS filesystems) folds identically.
+  expect(foldExpansionKey("s̋kody".normalize("NFD"))).toBe(
+    foldExpansionKey("s̋kody"),
+  );
+});
+
+// The pointer object's contents choose which key is read, so its shape is
+// enforced rather than trusted: an unconstrained value would let a written
+// pointer address any object in the bucket.
+test.each([
+  "../../secrets",
+  "",
+  "0".repeat(63),
+  "0".repeat(65),
+  `${"0".repeat(63)}Z`,
+])("a content hash of %p is rejected", (value) => {
+  expect(isMorphologyDictionaryContentHash(value)).toBe(false);
+});
+
+test("a sha256 hex hash is accepted and addresses one key", () => {
+  const hash = "a".repeat(64);
+  expect(isMorphologyDictionaryContentHash(hash)).toBe(true);
+  expect(morphologyDictionaryKey("cs", hash)).toBe(
+    `legal-corpus/morphology/language=cs/${hash}/expansion.tsv.zst`,
+  );
+  expect(morphologyDictionaryPointerKey("pl")).toBe(
+    "legal-corpus/morphology/language=pl/current.txt",
+  );
+});

--- a/apps/api/src/lib/legal-search/morphology/dictionary.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.ts
@@ -181,57 +181,121 @@ export type ParsedExpansionDictionary = {
  * expands to nothing instead — an ambiguous lookup is resolved by declining
  * to answer, never by serialization order.
  */
+type ParseAccumulator = {
+  collided: Set<string>;
+  entries: Map<string, string>;
+  skippedLines: number;
+};
+
+/**
+ * Fold one line into the accumulator. The single definition of what a line
+ * means: both drivers below run exactly this, so a synchronous parse and a
+ * yielding one cannot drift into different readings of the format.
+ */
+const parseLine = (line: string, acc: ParseAccumulator): void => {
+  if (line.length === 0) {
+    return;
+  }
+  const fields = line.split("\t");
+  if (fields.length !== LINE_FIELDS) {
+    acc.skippedLines += 1;
+    return;
+  }
+  const [, packed] = fields;
+  if (packed === undefined) {
+    acc.skippedLines += 1;
+    return;
+  }
+  const forms = packed.split(FORM_SEPARATOR);
+  if (
+    forms.length < MIN_FORMS_PER_BUCKET ||
+    forms.length > MAX_FORMS_PER_BUCKET ||
+    !forms.every(isSurfaceForm)
+  ) {
+    acc.skippedLines += 1;
+    return;
+  }
+  for (const form of forms) {
+    const key = foldExpansionKey(form);
+    if (acc.collided.has(key)) {
+      continue;
+    }
+    const claimed = acc.entries.get(key);
+    if (claimed === undefined) {
+      acc.entries.set(key, packed);
+      continue;
+    }
+    // Two forms of one bucket may fold together (`rada` and `ráda` within
+    // the same family); that is the same answer twice, not a conflict.
+    if (claimed === packed) {
+      continue;
+    }
+    acc.entries.delete(key);
+    acc.collided.add(key);
+  }
+};
+
+const newParseAccumulator = (): ParseAccumulator => ({
+  collided: new Set<string>(),
+  entries: new Map<string, string>(),
+  skippedLines: 0,
+});
+
+const finishParse = ({
+  collided,
+  entries,
+  skippedLines,
+}: ParseAccumulator): ParsedExpansionDictionary => ({
+  collidedKeys: collided.size,
+  entries,
+  skippedLines,
+});
+
 export const parseExpansionDictionary = (
   text: string,
 ): ParsedExpansionDictionary => {
-  const entries = new Map<string, string>();
-  const collided = new Set<string>();
-  let skippedLines = 0;
-
+  const acc = newParseAccumulator();
   for (const line of text.split("\n")) {
-    if (line.length === 0) {
-      continue;
-    }
-    const fields = line.split("\t");
-    if (fields.length !== LINE_FIELDS) {
-      skippedLines += 1;
-      continue;
-    }
-    const [, packed] = fields;
-    if (packed === undefined) {
-      skippedLines += 1;
-      continue;
-    }
-    const forms = packed.split(FORM_SEPARATOR);
-    if (
-      forms.length < MIN_FORMS_PER_BUCKET ||
-      forms.length > MAX_FORMS_PER_BUCKET ||
-      !forms.every(isSurfaceForm)
-    ) {
-      skippedLines += 1;
-      continue;
-    }
-    for (const form of forms) {
-      const key = foldExpansionKey(form);
-      if (collided.has(key)) {
-        continue;
-      }
-      const claimed = entries.get(key);
-      if (claimed === undefined) {
-        entries.set(key, packed);
-        continue;
-      }
-      // Two forms of one bucket may fold together (`rada` and `ráda` within
-      // the same family); that is the same answer twice, not a conflict.
-      if (claimed === packed) {
-        continue;
-      }
-      entries.delete(key);
-      collided.add(key);
-    }
+    parseLine(line, acc);
   }
+  return finishParse(acc);
+};
 
-  return { collidedKeys: collided.size, entries, skippedLines };
+/** Lines folded per turn. Small enough that a single batch is imperceptible. */
+const PARSE_BATCH_LINES = 2000;
+
+/**
+ * The same parse, handing the event loop back between batches.
+ *
+ * Parsing is the CPU half of loading a dictionary and it is not cheap: every
+ * line splits twice, and every form is NFC-normalised, lower-cased, decomposed
+ * and stripped before it keys a Map. On a payload near the ceiling that is long
+ * enough to stall an API replica, and detaching the fetch does not help —
+ * a detached promise's continuation still runs on the same thread. A warm-up or
+ * a rebuild should not pause the requests happening around it.
+ */
+export const parseExpansionDictionaryOffLoop = async (
+  text: string,
+): Promise<ParsedExpansionDictionary> => {
+  const acc = newParseAccumulator();
+  const lines = text.split("\n");
+
+  const parseFrom = async (start: number): Promise<void> => {
+    const end = Math.min(start + PARSE_BATCH_LINES, lines.length);
+    for (let index = start; index < end; index += 1) {
+      parseLine(lines[index] ?? "", acc);
+    }
+    if (end >= lines.length) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    await parseFrom(end);
+  };
+
+  await parseFrom(0);
+  return finishParse(acc);
 };
 
 /** Unpack a stored bucket value into its surface forms. */

--- a/apps/api/src/lib/legal-search/morphology/dictionary.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.ts
@@ -1,0 +1,175 @@
+/**
+ * On-disk and in-memory shape of a morphological expansion dictionary.
+ *
+ * One module owns the object key, the serialized format, and the fold that
+ * turns a surface form into a lookup key, because the offline builder and the
+ * query-time loader are two sides of the same contract: a builder that
+ * serialized what the loader does not parse would degrade search silently
+ * rather than fail.
+ *
+ * The dictionary is derived from corpus text, so its contents are untrusted
+ * input to the query builder. Every value is filtered to letters here, at
+ * build time and again at load time; the query builder additionally quotes
+ * what it emits. Neither layer is allowed to be the only one.
+ */
+
+import { stripDiacritics } from "@stll/text-normalize";
+
+import type { MorphologyLanguage } from "@/api/lib/legal-search/morphology/stem";
+
+const KEY_PREFIX = "legal-corpus/morphology";
+
+/** sha256 hex, the only shape a dictionary payload is addressed by. */
+const CONTENT_HASH_PATTERN = /^[0-9a-f]{64}$/u;
+
+/**
+ * A surface form is letters and nothing else. Digits, punctuation, and
+ * whitespace are excluded at the source: a form that carried them could not
+ * be a word the stemmer bucketed, and letters-only is what lets the packed
+ * value use a comma as its separator without an escape rule.
+ */
+const SURFACE_FORM_PATTERN = /^\p{L}+$/u;
+
+/** Separator between packed surface forms, in the file and in memory alike. */
+const FORM_SEPARATOR = ",";
+
+/** Fields per serialized line: stem, packed forms, bucket document frequency. */
+const LINE_FIELDS = 3;
+
+/**
+ * A bucket with one member expands to nothing, so it is dropped at build
+ * time; the loader rejects one that reappears rather than storing a
+ * self-expansion no caller can use.
+ */
+const MIN_FORMS_PER_BUCKET = 2;
+
+/**
+ * Surface forms kept per stem, by descending corpus frequency. Four is what
+ * the corpus measurement supported: the tail past it is dominated by rare
+ * inflections that widen the query without adding recall.
+ */
+export const MAX_FORMS_PER_BUCKET = 4;
+
+/**
+ * Where the pointer for a language lives. The payload is content-addressed
+ * and therefore immutable; this object is the one mutable name, holding the
+ * current payload's content hash so a rebuild is a single small write and a
+ * rollback is the previous hash.
+ */
+export const morphologyDictionaryPointerKey = (
+  language: MorphologyLanguage,
+): string => `${KEY_PREFIX}/language=${language}/current.txt`;
+
+/**
+ * Where a payload lives. Callers must pass a hash that
+ * `isMorphologyDictionaryContentHash` accepted: the value reaches this
+ * function from object storage, and an unconstrained string here would let a
+ * pointer's contents choose which key is read.
+ */
+export const morphologyDictionaryKey = (
+  language: MorphologyLanguage,
+  contentHash: string,
+): string =>
+  `${KEY_PREFIX}/language=${language}/${contentHash}/expansion.tsv.zst`;
+
+export const isMorphologyDictionaryContentHash = (value: string): boolean =>
+  CONTENT_HASH_PATTERN.test(value);
+
+/**
+ * Lookup key for a surface form: NFC, lowercased, then diacritics stripped.
+ *
+ * Keys are folded, values are not. The corpus is written with diacritics and
+ * queries frequently are not, so folding the key is what lets "skody" reach
+ * the bucket "škody" sits in. The forms the query emits keep their accents,
+ * because the engine folds its own query terms and an accented form matches
+ * strictly more index terms than its folded spelling would.
+ *
+ * The stemmer deliberately runs the other way round (fold after stemming),
+ * which is why it is never called here: this fold destroys exactly the
+ * characters the suffix tables are written over.
+ */
+export const foldExpansionKey = (term: string): string =>
+  stripDiacritics(term.normalize("NFC").toLowerCase());
+
+export type ExpansionBucket = {
+  /** Corpus document frequency summed over the bucket's members. */
+  documentFrequency: number;
+  /** Surface forms, accented, most frequent first. */
+  forms: readonly string[];
+  stem: string;
+};
+
+export const isSurfaceForm = (value: string): boolean =>
+  SURFACE_FORM_PATTERN.test(value);
+
+/**
+ * `<stem>\t<form,form,...>\t<documentFrequency>` per line. Tab-separated
+ * because no field can contain a tab: stems and forms are letters, the
+ * frequency is a decimal integer.
+ */
+export const serializeExpansionDictionary = (
+  buckets: readonly ExpansionBucket[],
+): string =>
+  buckets
+    .map(
+      (bucket) =>
+        `${bucket.stem}\t${bucket.forms.join(FORM_SEPARATOR)}\t${bucket.documentFrequency}`,
+    )
+    .join("\n");
+
+export type ParsedExpansionDictionary = {
+  /**
+   * Folded surface form to the bucket's forms packed as one delimited
+   * string. One string per bucket is shared by every member's entry, so the
+   * heap cost is the bucket's text once plus a pointer per member.
+   */
+  entries: ReadonlyMap<string, string>;
+  /** Lines that did not parse, or carried a value the filter rejected. */
+  skippedLines: number;
+};
+
+/**
+ * Read a serialized dictionary. A malformed line is skipped and counted,
+ * never thrown on: the payload is built offline from corpus text, and one bad
+ * line must cost one bucket rather than every query the language serves.
+ */
+export const parseExpansionDictionary = (
+  text: string,
+): ParsedExpansionDictionary => {
+  const entries = new Map<string, string>();
+  let skippedLines = 0;
+
+  for (const line of text.split("\n")) {
+    if (line.length === 0) {
+      continue;
+    }
+    const fields = line.split("\t");
+    if (fields.length !== LINE_FIELDS) {
+      skippedLines += 1;
+      continue;
+    }
+    const [, packed] = fields;
+    if (packed === undefined) {
+      skippedLines += 1;
+      continue;
+    }
+    const forms = packed.split(FORM_SEPARATOR);
+    if (
+      forms.length < MIN_FORMS_PER_BUCKET ||
+      forms.length > MAX_FORMS_PER_BUCKET ||
+      !forms.every(isSurfaceForm)
+    ) {
+      skippedLines += 1;
+      continue;
+    }
+    for (const form of forms) {
+      entries.set(foldExpansionKey(form), packed);
+    }
+  }
+
+  return { entries, skippedLines };
+};
+
+/** Unpack a stored bucket value into its surface forms. */
+export const unpackExpansionForms = (packed: string): string[] =>
+  packed.split(FORM_SEPARATOR);

--- a/apps/api/src/lib/legal-search/morphology/dictionary.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.ts
@@ -51,6 +51,14 @@ const MIN_FORMS_PER_BUCKET = 2;
 export const MAX_FORMS_PER_BUCKET = 4;
 
 /**
+ * Decompressed ceiling for one payload. Shared with the builder, which refuses
+ * to publish past it: a dictionary the loader would reject is worse than no
+ * dictionary, because the pointer advances and every replica silently falls
+ * back to unexpanded search until an operator notices.
+ */
+export const MORPHOLOGY_DICTIONARY_MAX_BYTES = 64 * 1024 * 1024;
+
+/**
  * Where the pointer for a language lives. The payload is content-addressed
  * and therefore immutable; this object is the one mutable name, holding the
  * current payload's content hash so a rebuild is a single small write and a
@@ -99,8 +107,15 @@ export type ExpansionBucket = {
   stem: string;
 };
 
+/**
+ * Canonicalised first: a combining mark is `\p{M}`, not `\p{L}`, so decomposed
+ * text fails a letters-only test that precomposed text passes. Extracted
+ * corpus text and typed queries both arrive in whichever form their producer
+ * used, and rejecting one spelling of a word it accepts in the other is a
+ * silent recall loss rather than a safety property.
+ */
 export const isSurfaceForm = (value: string): boolean =>
-  SURFACE_FORM_PATTERN.test(value);
+  SURFACE_FORM_PATTERN.test(value.normalize("NFC"));
 
 /**
  * `<stem>\t<form,form,...>\t<documentFrequency>` per line. Tab-separated
@@ -119,6 +134,12 @@ export const serializeExpansionDictionary = (
 
 export type ParsedExpansionDictionary = {
   /**
+   * Folded keys two different buckets both claimed, and which therefore
+   * expand to nothing. Reported so the count is observable rather than
+   * inferred from missing recall.
+   */
+  collidedKeys: number;
+  /**
    * Folded surface form to the bucket's forms packed as one delimited
    * string. One string per bucket is shared by every member's entry, so the
    * heap cost is the bucket's text once plus a pointer per member.
@@ -132,11 +153,20 @@ export type ParsedExpansionDictionary = {
  * Read a serialized dictionary. A malformed line is skipped and counted,
  * never thrown on: the payload is built offline from corpus text, and one bad
  * line must cost one bucket rather than every query the language serves.
+ *
+ * Keys are folded and values are not, so two buckets whose stems differ only
+ * by diacritics claim the same key: Czech `rada`/`řada` and Polish `sad`/`sąd`
+ * are ordinary words, not edge cases. Letting the later line win would answer
+ * a query for one family with the other family's inflections, and the
+ * prefix guard cannot see it because the folded spellings agree. Such a key
+ * expands to nothing instead — an ambiguous lookup is resolved by declining
+ * to answer, never by serialization order.
  */
 export const parseExpansionDictionary = (
   text: string,
 ): ParsedExpansionDictionary => {
   const entries = new Map<string, string>();
+  const collided = new Set<string>();
   let skippedLines = 0;
 
   for (const line of text.split("\n")) {
@@ -163,11 +193,26 @@ export const parseExpansionDictionary = (
       continue;
     }
     for (const form of forms) {
-      entries.set(foldExpansionKey(form), packed);
+      const key = foldExpansionKey(form);
+      if (collided.has(key)) {
+        continue;
+      }
+      const claimed = entries.get(key);
+      if (claimed === undefined) {
+        entries.set(key, packed);
+        continue;
+      }
+      // Two forms of one bucket may fold together (`rada` and `ráda` within
+      // the same family); that is the same answer twice, not a conflict.
+      if (claimed === packed) {
+        continue;
+      }
+      entries.delete(key);
+      collided.add(key);
     }
   }
 
-  return { entries, skippedLines };
+  return { collidedKeys: collided.size, entries, skippedLines };
 };
 
 /** Unpack a stored bucket value into its surface forms. */

--- a/apps/api/src/lib/legal-search/morphology/dictionary.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.ts
@@ -23,12 +23,31 @@ const KEY_PREFIX = "legal-corpus/morphology";
 const CONTENT_HASH_PATTERN = /^[0-9a-f]{64}$/u;
 
 /**
- * A surface form is letters and nothing else. Digits, punctuation, and
- * whitespace are excluded at the source: a form that carried them could not
- * be a word the stemmer bucketed, and letters-only is what lets the packed
- * value use a comma as its separator without an escape rule.
+ * Shortest and longest a surface form may be, in characters. The bound is the
+ * same one the builder filters corpus tokens with, single-sourced here so the
+ * two cannot drift: a loader that accepted what the builder would never emit
+ * is a loader validating a different format than the one being produced.
  */
-const SURFACE_FORM_PATTERN = /^\p{L}+$/u;
+export const SURFACE_FORM_MIN_LENGTH = 3;
+export const SURFACE_FORM_MAX_LENGTH = 30;
+
+/**
+ * A surface form is letters and nothing else, within the length bound. Digits,
+ * punctuation, and whitespace are excluded at the source: a form that carried
+ * them could not be a word the stemmer bucketed, and letters-only is what lets
+ * the packed value use a comma as its separator without an escape rule.
+ *
+ * The length bound is load-bearing rather than cosmetic. The leaf budget caps
+ * how many quoted values a query may carry, not how long one may be, so an
+ * unbounded form would let a payload pair an ordinary key with a
+ * multi-megabyte value and have an ordinary search build an enormous clause.
+ * The dictionary is corpus-derived and read from object storage, so its
+ * contents are checked here rather than assumed.
+ */
+const SURFACE_FORM_PATTERN = new RegExp(
+  String.raw`^\p{L}{${SURFACE_FORM_MIN_LENGTH},${SURFACE_FORM_MAX_LENGTH}}$`,
+  "u",
+);
 
 /** Separator between packed surface forms, in the file and in memory alike. */
 const FORM_SEPARATOR = ",";

--- a/apps/api/src/lib/legal-search/query-expansion-mode.ts
+++ b/apps/api/src/lib/legal-search/query-expansion-mode.ts
@@ -3,9 +3,11 @@
  *
  * - `off`    Queries are built exactly as they were before expansion
  *            existed. No dictionary is fetched and no query byte changes.
- * - `shadow` The expanded query is built and logged next to the query that
- *            actually runs, which is still the unexpanded one. This is how
- *            the rewrite is judged against real traffic before it serves it.
+ * - `shadow` The expanded query is built and compared against the query that
+ *            actually runs, which is still the unexpanded one. Only the
+ *            comparison is recorded — leaf counts and a reach disposition,
+ *            never the query text. This is how the rewrite is judged against
+ *            real traffic before it serves any.
  * - `on`     The expanded query is what runs.
  *
  * Resolved once in `env-base`; every consumer reads that single value.

--- a/apps/api/src/lib/legal-search/query-expansion-mode.ts
+++ b/apps/api/src/lib/legal-search/query-expansion-mode.ts
@@ -1,0 +1,19 @@
+/**
+ * How much of the morphological query expansion is live.
+ *
+ * - `off`    Queries are built exactly as they were before expansion
+ *            existed. No dictionary is fetched and no query byte changes.
+ * - `shadow` The expanded query is built and logged next to the query that
+ *            actually runs, which is still the unexpanded one. This is how
+ *            the rewrite is judged against real traffic before it serves it.
+ * - `on`     The expanded query is what runs.
+ *
+ * Resolved once in `env-base`; every consumer reads that single value.
+ *
+ * A leaf module with no imports, for the same reason `corpus-storage-mode`
+ * is one: `env-base` imports it, and every project that typechecks `env-base`
+ * would otherwise pull in the search graph behind it.
+ */
+export const QUERY_EXPANSION_MODES = ["off", "shadow", "on"] as const;
+
+export type QueryExpansionMode = (typeof QUERY_EXPANSION_MODES)[number];

--- a/apps/api/src/lib/legal-search/query-expansion-mode.ts
+++ b/apps/api/src/lib/legal-search/query-expansion-mode.ts
@@ -8,7 +8,11 @@
  *            comparison is recorded — leaf counts and a reach disposition,
  *            never the query text. This is how the rewrite is judged against
  *            real traffic before it serves any.
- * - `on`     The expanded query is what runs.
+ * - `on`     The expanded query is what runs. Refused at boot today: a corpus
+ *            cursor does not yet carry the dictionary version it was built
+ *            against, so a paginated expanded search can rank a different
+ *            result set against an earlier page's cursor. See the invariant in
+ *            `env-base-schema`, which is deleted when that work lands.
  *
  * Resolved once in `env-base`; every consumer reads that single value.
  *

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -707,6 +707,46 @@ export const readCorpusS3Bytes = async (
 ): Promise<Uint8Array> =>
   await (await fetchObject(getCorpusS3(), key, signal)).bytes();
 
+type BoundedCorpusReadOptions = {
+  key: string;
+  /** Ceiling on the transferred (still-compressed) body. */
+  maxBytes: number;
+  signal: AbortSignal;
+};
+
+/**
+ * Read a legal-corpus object, refusing a body past `maxBytes`.
+ *
+ * `readCorpusS3Bytes` buffers whatever the store returns, so a decompression
+ * ceiling applied afterwards bounds the decoded size but not the transfer: an
+ * object overwritten with a very large body is already resident by the time
+ * anything inspects it. This variant rejects before reading the body at all.
+ *
+ * The bound is the declared `Content-Length`. Every S3-compatible store sends
+ * it for a GET of a stored object, because the length is known before the
+ * response starts; a response that omits it is refused rather than read, so
+ * the ceiling cannot be bypassed by withholding the header.
+ */
+export const readCorpusS3BytesBounded = async ({
+  key,
+  maxBytes,
+  signal,
+}: BoundedCorpusReadOptions): Promise<Uint8Array> => {
+  const response = await fetchObject(getCorpusS3(), key, signal);
+  const declared = Number(response.headers.get("content-length"));
+  if (!Number.isFinite(declared)) {
+    throw new S3ObjectReadError({
+      message: `Object read for ${key} declared no length; refusing an unbounded read`,
+    });
+  }
+  if (declared > maxBytes) {
+    throw new S3ObjectReadError({
+      message: `Object read for ${key} declares ${declared} bytes, past the ${maxBytes}-byte ceiling`,
+    });
+  }
+  return await response.bytes();
+};
+
 /** Read a documents-bucket object. See `fetchObject`. */
 export const readS3ArrayBuffer = async (
   key: string,

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -733,10 +733,16 @@ export const readCorpusS3BytesBounded = async ({
   signal,
 }: BoundedCorpusReadOptions): Promise<Uint8Array> => {
   const response = await fetchObject(getCorpusS3(), key, signal);
-  const declared = Number(response.headers.get("content-length"));
-  if (!Number.isFinite(declared)) {
+  // Tested as a header, not as a number. `Number(null)` is 0 and `Number("")`
+  // is 0, so converting first would turn a missing or empty `Content-Length`
+  // into a length of zero that passes every ceiling — making the refusal below
+  // unreachable in exactly the case it exists for.
+  const header = response.headers.get("content-length");
+  const declared =
+    header !== null && /^\d+$/u.test(header.trim()) ? Number(header) : null;
+  if (declared === null) {
     throw new S3ObjectReadError({
-      message: `Object read for ${key} declared no length; refusing an unbounded read`,
+      message: `Object read for ${key} declared no usable length; refusing an unbounded read`,
     });
   }
   if (declared > maxBytes) {

--- a/apps/api/src/scripts/build-expansion-dictionary.ts
+++ b/apps/api/src/scripts/build-expansion-dictionary.ts
@@ -1,0 +1,351 @@
+/**
+ * Build the morphological expansion dictionary for one language.
+ *
+ * Query-time expansion is a Map lookup, never a stem: query text arrives
+ * folded and decomposed in whatever combination a keyboard produced, and the
+ * suffix tables are written over accented, precomposed characters. So the
+ * stemming happens here, once, over the accented corpus vocabulary, and the
+ * request path only reads what this produced.
+ *
+ * The vocabulary comes from `ts_stat` over `to_tsvector('simple', ...)` of the
+ * decisions' searchable text — deliberately not the stored `tsv` column,
+ * which is unaccent-folded and would hand the stemmer exactly the input it
+ * mis-stems. Documents are read in keyset chunks with their own statement
+ * timeout, sequentially, so this stays safe to run against a live instance.
+ *
+ * Buckets are formed by stem, singletons dropped (a bucket of one expands to
+ * nothing), and each bucket capped at its most frequent surface forms. The
+ * payload is content-addressed; a small pointer object names the current hash
+ * so a rebuild is one small write and a rollback is the previous hash.
+ *
+ *   bun run src/scripts/build-expansion-dictionary.ts --language cs
+ *   bun run src/scripts/build-expansion-dictionary.ts --language pl \
+ *     --out expansion-pl.tsv
+ */
+import { sql } from "drizzle-orm";
+
+import { rlsDb } from "@/api/db/root";
+import { createIngestionDb } from "@/api/db/scoped";
+import { zstdCompress } from "@/api/lib/compression";
+import {
+  type ExpansionBucket,
+  foldExpansionKey,
+  isSurfaceForm,
+  MAX_FORMS_PER_BUCKET,
+  morphologyDictionaryKey,
+  morphologyDictionaryPointerKey,
+  serializeExpansionDictionary,
+} from "@/api/lib/legal-search/morphology/dictionary";
+import {
+  MORPHOLOGY_LANGUAGES,
+  type MorphologyLanguage,
+  stemLegalTerm,
+} from "@/api/lib/legal-search/morphology/stem";
+import { putCorpusS3ObjectWithSignal, refreshCorpusS3 } from "@/api/lib/s3";
+
+const DEFAULT_CHUNK_SIZE = 1000;
+/** Per-chunk ceiling. A measured chunk costs ~2s; this is the stall bound. */
+const CHUNK_STATEMENT_TIMEOUT = "60s";
+/** Corpus document frequency a token needs before it is worth bucketing. */
+const DEFAULT_MIN_DOCUMENT_FREQUENCY = 50;
+const TOKEN_PATTERN = /^\p{L}{3,30}$/u;
+/**
+ * Shared leading characters expected of a coherent bucket. Below this the
+ * bucket's members are probably not the same word, so it is reported for
+ * review; the query-time guard drops the offending forms either way.
+ */
+const COHERENCE_PREFIX = 3;
+const UPLOAD_TIMEOUT_MS = 60_000;
+
+const USAGE = `Usage: bun run src/scripts/build-expansion-dictionary.ts --language <cs|pl|sk> [options]
+
+  --language <code>    Language to build. Required.
+  --out <path>         Write the uncompressed dictionary here instead of uploading.
+  --chunk <n>          Documents scanned per query (default ${DEFAULT_CHUNK_SIZE}).
+  --min-df <n>         Minimum corpus document frequency (default ${DEFAULT_MIN_DOCUMENT_FREQUENCY}).`;
+
+// Annotated on the binding, not just the return position: TypeScript only
+// treats a call as never-returning (and narrows after it) when the callee is a
+// name carrying an explicit type annotation.
+const fail: (message: string) => never = (message) => {
+  console.error(message);
+  console.error(USAGE);
+  process.exit(2);
+};
+
+const flagValue = (name: string): string | undefined => {
+  const index = process.argv.indexOf(`--${name}`);
+  if (index === -1) {
+    return undefined;
+  }
+  const value = process.argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    fail(`--${name} requires a value`);
+  }
+  return value;
+};
+
+const DECIMAL_INTEGER = /^\d+$/u;
+
+const positiveInteger = (
+  raw: string | undefined,
+  fallback: number,
+  name: string,
+): number => {
+  if (raw === undefined) {
+    return fallback;
+  }
+  const parsed = DECIMAL_INTEGER.test(raw)
+    ? Number.parseInt(raw, 10)
+    : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    fail(`--${name} must be a positive integer, got: ${raw}`);
+  }
+  return parsed;
+};
+
+const isMorphologyLanguage = (value: string): value is MorphologyLanguage =>
+  MORPHOLOGY_LANGUAGES.some((language) => language === value);
+
+const languageArg = flagValue("language");
+if (languageArg === undefined) {
+  fail("--language is required");
+}
+if (!isMorphologyLanguage(languageArg)) {
+  fail(
+    `--language must be one of ${MORPHOLOGY_LANGUAGES.join(", ")}, got: ${languageArg}`,
+  );
+}
+const language: MorphologyLanguage = languageArg;
+const outPath = flagValue("out");
+const chunkSize = positiveInteger(
+  flagValue("chunk"),
+  DEFAULT_CHUNK_SIZE,
+  "chunk",
+);
+const minDocumentFrequency = positiveInteger(
+  flagValue("min-df"),
+  DEFAULT_MIN_DOCUMENT_FREQUENCY,
+  "min-df",
+);
+
+const ingestionDb = createIngestionDb(rlsDb);
+
+/** The keyset floor: uuids order lexically, so the nil uuid precedes them all. */
+const NIL_UUID = "00000000-0000-0000-0000-000000000000";
+
+const rowsOf = (result: unknown): Record<string, unknown>[] =>
+  Array.isArray(result) ? result : [];
+
+type VocabularyChunk = {
+  /** Exclusive upper bound reached, or null when the language is exhausted. */
+  lastId: string | null;
+  scanned: number;
+  tokens: Map<string, number>;
+};
+
+/**
+ * Document frequency per token over one keyset chunk of decisions.
+ *
+ * Two statements, one transaction. The first names the chunk's closed id
+ * range, because `ts_stat` returns word statistics and cannot also report
+ * where the chunk ended. The second runs `ts_stat` over exactly that range.
+ *
+ * `ts_stat` takes its input as SQL text, so the range is spliced by Postgres'
+ * own `format(%L)` from bound parameters rather than by string building here:
+ * the quoting is the server's, and no value from this process reaches the
+ * inner query unquoted.
+ *
+ * `simple` is the configuration on purpose. It neither stems nor unaccents,
+ * so tokens come back spelled as the corpus wrote them, which is the input
+ * the stemmer's suffix tables are written for. The stored `tsv` column is
+ * unaccent-folded and would be the wrong source for exactly that reason.
+ */
+const chunkVocabulary = async (afterId: string): Promise<VocabularyChunk> =>
+  await ingestionDb(async (tx) => {
+    await tx.execute(
+      sql`SELECT set_config('statement_timeout', ${CHUNK_STATEMENT_TIMEOUT}, true)`,
+    );
+
+    const bounds = rowsOf(
+      await tx.execute(sql`
+        SELECT max(decision_id)::text AS last_id, count(*)::int AS scanned
+        FROM (
+          SELECT sd.decision_id
+          FROM case_law_search_documents sd
+          WHERE sd.language = ${language}
+            AND sd.decision_id > ${afterId}::uuid
+          ORDER BY sd.decision_id
+          LIMIT ${chunkSize}
+        ) chunk
+      `),
+    );
+    const lastId = bounds.at(0)?.["last_id"];
+    const scanned = Number(bounds.at(0)?.["scanned"] ?? 0);
+    if (typeof lastId !== "string" || scanned === 0) {
+      return { lastId: null, scanned: 0, tokens: new Map() };
+    }
+
+    const stats = rowsOf(
+      await tx.execute(sql`
+        SELECT word, ndoc
+        FROM ts_stat(
+          format(
+            'SELECT to_tsvector(''simple'', sd.searchable_text)
+               FROM case_law_search_documents sd
+              WHERE sd.language = %L
+                AND sd.decision_id > %L::uuid
+                AND sd.decision_id <= %L::uuid',
+            ${language}, ${afterId}, ${lastId}
+          )
+        )
+      `),
+    );
+
+    const tokens = new Map<string, number>();
+    for (const row of stats) {
+      const word = row["word"];
+      const ndoc = Number(row["ndoc"]);
+      if (typeof word === "string" && Number.isFinite(ndoc)) {
+        tokens.set(word, ndoc);
+      }
+    }
+    return { lastId, scanned, tokens };
+  });
+
+console.log(
+  `=== BUILD EXPANSION DICTIONARY: ${language} (chunk ${chunkSize}, min df ${minDocumentFrequency}) ===`,
+);
+
+const documentFrequency = new Map<string, number>();
+let scannedDocuments = 0;
+
+/**
+ * Walk the language's documents one chunk at a time. Sequential by design:
+ * this may run against a small live instance, and concurrent `ts_stat` passes
+ * would multiply its cost for no wall-clock gain worth having.
+ */
+const scanFrom = async (afterId: string): Promise<void> => {
+  const chunk = await chunkVocabulary(afterId);
+  if (chunk.lastId === null) {
+    return;
+  }
+  for (const [word, ndoc] of chunk.tokens) {
+    documentFrequency.set(word, (documentFrequency.get(word) ?? 0) + ndoc);
+  }
+  scannedDocuments += chunk.scanned;
+  console.log(
+    `  scanned ${scannedDocuments} documents, ${documentFrequency.size} distinct tokens`,
+  );
+  await scanFrom(chunk.lastId);
+};
+
+await scanFrom(NIL_UUID);
+
+// Bucket by stem. The token is stemmed accented, exactly as the corpus wrote
+// it; folding here would strip the characters the suffix tables match on.
+const byStem = new Map<string, { df: number; form: string }[]>();
+let filteredTokens = 0;
+for (const [token, df] of documentFrequency) {
+  if (df < minDocumentFrequency || !TOKEN_PATTERN.test(token)) {
+    continue;
+  }
+  filteredTokens += 1;
+  const stem = stemLegalTerm(token, language);
+  const bucket = byStem.get(stem);
+  if (bucket === undefined) {
+    byStem.set(stem, [{ df, form: token }]);
+    continue;
+  }
+  bucket.push({ df, form: token });
+}
+
+const buckets: ExpansionBucket[] = [];
+const incoherent: string[] = [];
+for (const [stem, members] of byStem) {
+  if (members.length < 2) {
+    continue;
+  }
+  members.sort((left, right) => right.df - left.df);
+  const forms = members
+    .slice(0, MAX_FORMS_PER_BUCKET)
+    .map((member) => member.form)
+    .filter(isSurfaceForm);
+  if (forms.length < 2) {
+    continue;
+  }
+  buckets.push({
+    documentFrequency: members.reduce((sum, member) => sum + member.df, 0),
+    forms,
+    stem,
+  });
+
+  const folded = forms.map(foldExpansionKey);
+  const [first] = folded;
+  if (
+    first !== undefined &&
+    !folded.every(
+      (form) =>
+        form.slice(0, COHERENCE_PREFIX) === first.slice(0, COHERENCE_PREFIX),
+    )
+  ) {
+    incoherent.push(`${stem}\t${forms.join(",")}`);
+  }
+}
+
+// Code-unit order, not collation: the sort exists to make two builds of the
+// same corpus produce the same bytes, and a stem is a machine key.
+buckets.sort((left, right) => (left.stem < right.stem ? -1 : 1));
+
+const payload = serializeExpansionDictionary(buckets);
+
+console.log(
+  `tokens=${documentFrequency.size} kept=${filteredTokens} buckets=${buckets.length} incoherent=${incoherent.length}`,
+);
+if (incoherent.length > 0) {
+  console.log(
+    `--- buckets whose members share fewer than ${COHERENCE_PREFIX} leading characters (query-time prefix guard drops these forms) ---`,
+  );
+  for (const line of incoherent) {
+    console.log(`  ${line}`);
+  }
+}
+
+if (buckets.length === 0) {
+  console.error(
+    "build-expansion-dictionary: no buckets produced; refusing to publish an empty dictionary",
+  );
+  process.exit(1);
+}
+
+if (outPath !== undefined) {
+  await Bun.write(outPath, payload);
+  console.log(`Wrote ${payload.length} bytes to ${outPath}.`);
+  process.exit(0);
+}
+
+// Addressed by the dictionary's own bytes, not by the compressed frame, so
+// the same corpus republishes to the same key whatever the encoder does.
+const hasher = new Bun.CryptoHasher("sha256");
+hasher.update(payload);
+const contentHash = hasher.digest("hex");
+const compressed = zstdCompress(payload);
+
+await refreshCorpusS3();
+await putCorpusS3ObjectWithSignal(
+  morphologyDictionaryKey(language, contentHash),
+  compressed,
+  "application/zstd",
+  AbortSignal.timeout(UPLOAD_TIMEOUT_MS),
+);
+await putCorpusS3ObjectWithSignal(
+  morphologyDictionaryPointerKey(language),
+  new TextEncoder().encode(contentHash),
+  "text/plain",
+  AbortSignal.timeout(UPLOAD_TIMEOUT_MS),
+);
+
+console.log(
+  `Published ${buckets.length} buckets (${compressed.length} compressed bytes) at ${contentHash}.`,
+);
+process.exit(0);

--- a/apps/api/src/scripts/build-expansion-dictionary.ts
+++ b/apps/api/src/scripts/build-expansion-dictionary.ts
@@ -50,7 +50,6 @@ const DEFAULT_CHUNK_SIZE = 1000;
 const CHUNK_STATEMENT_TIMEOUT = "60s";
 /** Corpus document frequency a token needs before it is worth bucketing. */
 const DEFAULT_MIN_DOCUMENT_FREQUENCY = 50;
-const TOKEN_PATTERN = /^\p{L}{3,30}$/u;
 /**
  * Shared leading characters expected of a coherent bucket. Below this the
  * bucket's members are probably not the same word, so it is reported for
@@ -190,7 +189,7 @@ const chunkVocabulary = async (afterId: string): Promise<VocabularyChunk> =>
 
     // `normalize(..., NFC)` before tokenization: extracted PDF text is often
     // decomposed, and `to_tsvector` would then emit tokens carrying combining
-    // marks. Those are `\p{M}`, not `\p{L}`, so `TOKEN_PATTERN` would drop
+    // marks. Those are `\p{M}`, not `\p{L}`, so the token filter would drop
     // them and the corpus would silently lose the inflections of every
     // accented word that happened to arrive in NFD.
     const stats = rowsOf(
@@ -221,7 +220,7 @@ const chunkVocabulary = async (afterId: string): Promise<VocabularyChunk> =>
         continue;
       }
       const canonical = word.normalize("NFC");
-      if (TOKEN_PATTERN.test(canonical)) {
+      if (isSurfaceForm(canonical)) {
         tokens.set(canonical, ndoc);
       }
     }

--- a/apps/api/src/scripts/build-expansion-dictionary.ts
+++ b/apps/api/src/scripts/build-expansion-dictionary.ts
@@ -32,8 +32,10 @@ import {
   foldExpansionKey,
   isSurfaceForm,
   MAX_FORMS_PER_BUCKET,
+  MORPHOLOGY_DICTIONARY_MAX_BYTES,
   morphologyDictionaryKey,
   morphologyDictionaryPointerKey,
+  parseExpansionDictionary,
   serializeExpansionDictionary,
 } from "@/api/lib/legal-search/morphology/dictionary";
 import {
@@ -186,12 +188,17 @@ const chunkVocabulary = async (afterId: string): Promise<VocabularyChunk> =>
       return { lastId: null, scanned: 0, tokens: new Map() };
     }
 
+    // `normalize(..., NFC)` before tokenization: extracted PDF text is often
+    // decomposed, and `to_tsvector` would then emit tokens carrying combining
+    // marks. Those are `\p{M}`, not `\p{L}`, so `TOKEN_PATTERN` would drop
+    // them and the corpus would silently lose the inflections of every
+    // accented word that happened to arrive in NFD.
     const stats = rowsOf(
       await tx.execute(sql`
         SELECT word, ndoc
         FROM ts_stat(
           format(
-            'SELECT to_tsvector(''simple'', sd.searchable_text)
+            'SELECT to_tsvector(''simple'', normalize(sd.searchable_text, NFC))
                FROM case_law_search_documents sd
               WHERE sd.language = %L
                 AND sd.decision_id > %L::uuid
@@ -202,12 +209,20 @@ const chunkVocabulary = async (afterId: string): Promise<VocabularyChunk> =>
       `),
     );
 
+    // Shape-filtered here rather than after the whole scan: the frequency map
+    // lives for the length of the build, and an OCR-heavy corpus produces
+    // enough one-off garbage tokens to grow it without bound. Only the
+    // frequency threshold needs the global total, so only it waits.
     const tokens = new Map<string, number>();
     for (const row of stats) {
       const word = row["word"];
       const ndoc = Number(row["ndoc"]);
-      if (typeof word === "string" && Number.isFinite(ndoc)) {
-        tokens.set(word, ndoc);
+      if (typeof word !== "string" || !Number.isFinite(ndoc)) {
+        continue;
+      }
+      const canonical = word.normalize("NFC");
+      if (TOKEN_PATTERN.test(canonical)) {
+        tokens.set(canonical, ndoc);
       }
     }
     return { lastId, scanned, tokens };
@@ -244,10 +259,12 @@ await scanFrom(NIL_UUID);
 
 // Bucket by stem. The token is stemmed accented, exactly as the corpus wrote
 // it; folding here would strip the characters the suffix tables match on.
+// Token shape was already enforced during the scan, so only the corpus-wide
+// frequency threshold is left to apply.
 const byStem = new Map<string, { df: number; form: string }[]>();
 let filteredTokens = 0;
 for (const [token, df] of documentFrequency) {
-  if (df < minDocumentFrequency || !TOKEN_PATTERN.test(token)) {
+  if (df < minDocumentFrequency) {
     continue;
   }
   filteredTokens += 1;
@@ -299,9 +316,26 @@ buckets.sort((left, right) => (left.stem < right.stem ? -1 : 1));
 
 const payload = serializeExpansionDictionary(buckets);
 
+// The loader is the authority on what a folded key may resolve to, so the
+// report comes from its own parser rather than from a second implementation
+// here: whatever it drops for colliding keys is what the deployment will drop.
+const { collidedKeys, entries, skippedLines } =
+  parseExpansionDictionary(payload);
+
 console.log(
-  `tokens=${documentFrequency.size} kept=${filteredTokens} buckets=${buckets.length} incoherent=${incoherent.length}`,
+  `tokens=${documentFrequency.size} kept=${filteredTokens} buckets=${buckets.length} keys=${entries.size} incoherent=${incoherent.length} collided=${collidedKeys} skipped=${skippedLines}`,
 );
+if (skippedLines > 0) {
+  console.error(
+    `build-expansion-dictionary: ${skippedLines} serialized lines do not parse; refusing to publish`,
+  );
+  process.exit(1);
+}
+if (collidedKeys > 0) {
+  console.log(
+    `--- ${collidedKeys} folded keys are claimed by more than one stem and expand to nothing (e.g. rada/řada, sad/sąd) ---`,
+  );
+}
 if (incoherent.length > 0) {
   console.log(
     `--- buckets whose members share fewer than ${COHERENCE_PREFIX} leading characters (query-time prefix guard drops these forms) ---`,
@@ -314,6 +348,17 @@ if (incoherent.length > 0) {
 if (buckets.length === 0) {
   console.error(
     "build-expansion-dictionary: no buckets produced; refusing to publish an empty dictionary",
+  );
+  process.exit(1);
+}
+
+// Publishing past the loader's ceiling would advance the pointer to a payload
+// every replica then rejects, so the deployment would silently serve
+// unexpanded searches until an operator rolled it back. Fail here instead.
+const payloadBytes = Buffer.byteLength(payload, "utf-8");
+if (payloadBytes > MORPHOLOGY_DICTIONARY_MAX_BYTES) {
+  console.error(
+    `build-expansion-dictionary: ${payloadBytes} bytes exceeds the loader's ${MORPHOLOGY_DICTIONARY_MAX_BYTES}-byte ceiling; refusing to publish`,
   );
   process.exit(1);
 }

--- a/apps/api/src/scripts/build-expansion-dictionary.ts
+++ b/apps/api/src/scripts/build-expansion-dictionary.ts
@@ -304,13 +304,31 @@ for (const [token, df] of documentFrequency) {
   bucket.push({ df, form: token });
 }
 
+/** Code-unit order over two forms; a machine key, so no collation. */
+const compareForms = (
+  left: { form: string },
+  right: { form: string },
+): number => {
+  if (left.form < right.form) {
+    return -1;
+  }
+  return left.form > right.form ? 1 : 0;
+};
+
 const buckets: ExpansionBucket[] = [];
 const incoherent: string[] = [];
 for (const [stem, members] of byStem) {
   if (members.length < 2) {
     continue;
   }
-  members.sort((left, right) => right.df - left.df);
+  // Frequency first, then the form's own order. Without the tie-breaker, forms
+  // with equal frequency straddling the cap are kept in the order `ts_stat`
+  // happened to return them, so rebuilding the same corpus could select a
+  // different four, expand differently, and publish under a different content
+  // hash — which the content-addressed layout is supposed to rule out.
+  members.sort(
+    (left, right) => right.df - left.df || compareForms(left, right),
+  );
   const forms = members
     .slice(0, MAX_FORMS_PER_BUCKET)
     .map((member) => member.form)

--- a/apps/api/src/scripts/build-expansion-dictionary.ts
+++ b/apps/api/src/scripts/build-expansion-dictionary.ts
@@ -51,6 +51,14 @@ const CHUNK_STATEMENT_TIMEOUT = "60s";
 /** Corpus document frequency a token needs before it is worth bucketing. */
 const DEFAULT_MIN_DOCUMENT_FREQUENCY = 50;
 /**
+ * Ceiling on distinct tokens retained during the scan. The frequency threshold
+ * is a corpus-wide sum and cannot prune before the scan ends, so this is what
+ * turns "grows with the corpus vocabulary" into a bounded, reportable failure.
+ * Comfortably above a real Czech or Polish case-law vocabulary; a run that
+ * trips it is describing a corpus this script's in-memory design does not fit.
+ */
+const DEFAULT_MAX_VOCABULARY = 8_000_000;
+/**
  * Shared leading characters expected of a coherent bucket. Below this the
  * bucket's members are probably not the same word, so it is reported for
  * review; the query-time guard drops the offending forms either way.
@@ -63,7 +71,8 @@ const USAGE = `Usage: bun run src/scripts/build-expansion-dictionary.ts --langua
   --language <code>    Language to build. Required.
   --out <path>         Write the uncompressed dictionary here instead of uploading.
   --chunk <n>          Documents scanned per query (default ${DEFAULT_CHUNK_SIZE}).
-  --min-df <n>         Minimum corpus document frequency (default ${DEFAULT_MIN_DOCUMENT_FREQUENCY}).`;
+  --min-df <n>         Minimum corpus document frequency (default ${DEFAULT_MIN_DOCUMENT_FREQUENCY}).
+  --max-vocabulary <n> Distinct tokens retained before the run aborts (default ${DEFAULT_MAX_VOCABULARY}).`;
 
 // Annotated on the binding, not just the return position: TypeScript only
 // treats a call as never-returning (and narrows after it) when the callee is a
@@ -128,6 +137,11 @@ const minDocumentFrequency = positiveInteger(
   flagValue("min-df"),
   DEFAULT_MIN_DOCUMENT_FREQUENCY,
   "min-df",
+);
+const maxVocabulary = positiveInteger(
+  flagValue("max-vocabulary"),
+  DEFAULT_MAX_VOCABULARY,
+  "max-vocabulary",
 );
 
 const ingestionDb = createIngestionDb(rlsDb);
@@ -246,6 +260,20 @@ const scanFrom = async (afterId: string): Promise<void> => {
   }
   for (const [word, ndoc] of chunk.tokens) {
     documentFrequency.set(word, (documentFrequency.get(word) ?? 0) + ndoc);
+  }
+  // The frequency threshold is a corpus-wide sum, so it cannot be applied
+  // before the scan ends: a token reaching 50 documents may do so one document
+  // per chunk, and any early prune would silently drop real vocabulary. The
+  // retained map is therefore the language's whole distinct vocabulary,
+  // including whatever letters-only noise OCR produced, and the shape filter
+  // bounds its shape rather than its size. This is the size bound — chosen so
+  // an oversized corpus stops here, before publishing, with something an
+  // operator can act on, instead of being OOM-killed at an arbitrary point.
+  if (documentFrequency.size > maxVocabulary) {
+    console.error(
+      `build-expansion-dictionary: vocabulary exceeded ${maxVocabulary} distinct tokens after ${scannedDocuments} documents; refusing to continue. Raise --max-vocabulary on a host with the memory for it, or aggregate the counts in the database instead.`,
+    );
+    process.exit(1);
   }
   scannedDocuments += chunk.scanned;
   console.log(

--- a/scripts/env-catalog.ts
+++ b/scripts/env-catalog.ts
@@ -315,7 +315,7 @@ const DESCRIPTION_OVERRIDES: Record<string, string> = {
   PUBLIC_URL:
     "Public API origin for verification links and OAuth callbacks. Defaults to BETTER_AUTH_URL.",
   QUERY_EXPANSION_MODE:
-    'Morphological expansion of case-law search terms: "off" builds today\'s query, "shadow" runs the unexpanded query and records leaf counts comparing it with the expanded one (never the query text), "on" runs the expanded query.',
+    'Morphological expansion of case-law search terms: "off" builds today\'s query, "shadow" runs the unexpanded query and records leaf counts comparing it with the expanded one (never the query text). "on" runs the expanded query and is currently refused at startup, pending cursors that carry the dictionary version.',
   REDIS_URL:
     "Valkey or Redis URL used for cross-instance broadcasts and rate limits. Treated as secret because it may contain credentials.",
   S3_ACCESS_KEY_ID:

--- a/scripts/env-catalog.ts
+++ b/scripts/env-catalog.ts
@@ -135,6 +135,7 @@ const INTERNAL_SERVER_KEYS = new Set([
   "POSTHOG_LOCAL_DEBUG",
   "POSTHOG_LOCAL_DEBUG_AI_CONTENT",
   "PUBLIC_URL",
+  "QUERY_EXPANSION_MODE",
   "REQUIRE_PERSONAL_AI_KEY",
   "S3_BUCKET",
   "S3_CREDENTIALS_PROVIDER",
@@ -313,6 +314,8 @@ const DESCRIPTION_OVERRIDES: Record<string, string> = {
     "Include raw AI prompts and outputs in local diagnostics. This may expose privileged content.",
   PUBLIC_URL:
     "Public API origin for verification links and OAuth callbacks. Defaults to BETTER_AUTH_URL.",
+  QUERY_EXPANSION_MODE:
+    'Morphological expansion of case-law search terms: "off" builds today\'s query, "shadow" logs the expanded query beside the unexpanded one it runs, "on" runs the expanded query.',
   REDIS_URL:
     "Valkey or Redis URL used for cross-instance broadcasts and rate limits. Treated as secret because it may contain credentials.",
   S3_ACCESS_KEY_ID:

--- a/scripts/env-catalog.ts
+++ b/scripts/env-catalog.ts
@@ -315,7 +315,7 @@ const DESCRIPTION_OVERRIDES: Record<string, string> = {
   PUBLIC_URL:
     "Public API origin for verification links and OAuth callbacks. Defaults to BETTER_AUTH_URL.",
   QUERY_EXPANSION_MODE:
-    'Morphological expansion of case-law search terms: "off" builds today\'s query, "shadow" logs the expanded query beside the unexpanded one it runs, "on" runs the expanded query.',
+    'Morphological expansion of case-law search terms: "off" builds today\'s query, "shadow" runs the unexpanded query and records leaf counts comparing it with the expanded one (never the query text), "on" runs the expanded query.',
   REDIS_URL:
     "Valkey or Redis URL used for cross-instance broadcasts and rate limits. Treated as secret because it may contain credentials.",
   S3_ACCESS_KEY_ID:

--- a/scripts/env-tool.test.ts
+++ b/scripts/env-tool.test.ts
@@ -362,6 +362,13 @@ describe("environment doctor output", () => {
         "LEGAL_SEARCH_PROVIDER=corpus-index requires CORPUS_INDEX_SEARCH_ENDPOINT or CORPUS_INDEX_ENDPOINT to be set.",
       overrides: { LEGAL_SEARCH_PROVIDER: "corpus-index" },
     },
+    // Removed together with the invariant, in the PR that makes a corpus
+    // cursor carry the dictionary version it was built against.
+    {
+      expected:
+        'QUERY_EXPANSION_MODE="on" requires dictionary-version-carrying cursors; not yet implemented — use "shadow".',
+      overrides: { QUERY_EXPANSION_MODE: "on" },
+    },
     {
       expected:
         "CONTENT_ENCRYPTION_KEY is required when NODE_ENV is 'production' or 'staging'.",
@@ -529,6 +536,22 @@ describe("environment doctor output", () => {
       expect(result.issues).toContain(expected);
     }
   });
+
+  // The other half of the `on` invariant above: it must refuse exactly one
+  // mode. A guard that rejected `shadow` too would block the only way to
+  // gather the evidence for lifting it. Removed with the invariant, in the PR
+  // that makes a corpus cursor carry its dictionary version.
+  test.each(["off", "shadow"] as const)(
+    "QUERY_EXPANSION_MODE=%p passes the runtime invariants",
+    (mode) => {
+      expect(
+        validateDoctorEnvironment({
+          app: "api",
+          input: { ...validApiInput(), QUERY_EXPANSION_MODE: mode },
+        }).status,
+      ).toBe("valid");
+    },
+  );
 
   test("applies the selected API mode to runtime invariants", () => {
     const result = validateDoctorEnvironment({


### PR DESCRIPTION
Czech and Polish inflect heavily, so a corpus-index search for `nájemné` misses the judgments that write `nájemného`. This adds morphological expansion: each term the reader types becomes an OR group of that word's other surface forms, AND-ed with the rest of the query exactly as before. It is inert until `QUERY_EXPANSION_MODE` is flipped.

## Why the stemmer does not run at query time

Query text arrives folded, decomposed, and lowercased in whatever combination a keyboard produced, and the Snowball suffix tables are written over accented, precomposed characters. Stemming that input mis-stems a measurable share of it (~19% on real query-shaped input). So an offline operator script stems the accented corpus vocabulary once, and the request path is a Map lookup keyed on the folded surface form.

## Dictionary build

`apps/api/src/scripts/build-expansion-dictionary.ts`, operator-run, one language at a time:

- Keyset chunks of 1,000 documents; each chunk's vocabulary comes from `ts_stat` over `to_tsvector('simple', normalize(searchable_text, NFC))` under a 60s statement timeout, run sequentially. Deliberately not the stored `tsv` column, which is unaccent-folded and would hand the stemmer exactly the input it mis-stems. NFC first because extracted PDF text is often decomposed, and a combining mark is `\p{M}`, not `\p{L}`. A measured chunk costs ~2s.
- `ts_stat` takes its input as SQL text, so the chunk range is spliced by Postgres' own `format(%L)` from bound parameters; no value from the process reaches the inner query unquoted.
- Tokens are filtered to `/^\p{L}{3,30}$/u` during the scan (bounding what the frequency map retains on an OCR-heavy corpus) with corpus df >= 50 applied after, bucketed by stem, singleton buckets dropped, and each bucket capped at its four most frequent surface forms.
- The payload is content-addressed under `legal-corpus/morphology/language=<lang>/<hash>/expansion.tsv.zst`, with a small `current.txt` pointer naming the hash: a rebuild is one small write, a rollback is the previous hash. `--out <file>` writes locally instead.
- Before publishing, the builder parses its own payload back through the loader's parser and refuses to advance the pointer if any line fails to read back or if the payload exceeds the loader's ceiling. A published dictionary the deployment cannot consume would otherwise degrade every replica silently.
- It reports buckets whose members do not share a three-character prefix, and folded keys claimed by more than one stem, for operator review.

## Query-time guards

Every one of these degrades to the query the reader would have gotten anyway:

- **Phrases are never rewritten.** The token-kind policy is `as const satisfies Record<CorpusQueryToken["type"], ...>`, so a new token kind cannot reach the engine without a decision recorded.
- **Terms carrying anything but letters never expand**, which covers pure numbers and every digit-bearing fragment a citation decomposes into. The shape test runs on the folded spelling, so a decomposed term is judged as the word it is rather than rejected for its combining marks.
- **Hard three-character floor** on the typed term, not the shorter of three and its length.
- **A form must share three leading characters** with the typed term, measured on the folded spellings. Light stemmers over-strip: `veci` and `vek` reduce to one stem without being one word.
- **A folded key two stems both claim expands to nothing.** Keys are folded and values are not, so Czech `rada`/`řada` and Polish `sad`/`sąd` land on one key; letting the later bucket win would answer a query for one family with the other's inflections, and the prefix guard cannot see it because the folded spellings agree. An ambiguous lookup declines to answer rather than resolving by serialization order.
- **24 quoted leaves per query**, expanding left to right; past the ceiling the remaining terms stay single leaves.
- **The reader's term is always first.** The expander returns only the *additional* forms, so it structurally cannot drop or reorder what was typed.
- **Dictionary values are letters-only** by a build-time filter, re-checked at load, and quoted by `quoteCorpusValue` on the way out. The content is corpus-derived and therefore untrusted; neither layer may be the only one.
- **The payload is verified against the hash its pointer names** before it is parsed, so an object overwritten at a content-addressed key cannot be served as the content it is addressed by.
- **Failure is invisible to the reader.** A missing, unreadable, or mismatched dictionary, an unrecognised jurisdiction, and an unscoped search all resolve to no expander plus a structured warning. An unavailable dictionary is retried after 60s; a loaded one rechecks its pointer every 15 minutes so a rebuild or rollback needs no restart, and a failed refresh keeps serving the payload that last parsed rather than dropping to no expansion.

Emitted groups are bare `("typed" OR "other")` inside the default fields; a field-scoped group in that position does not parse on the engine.

## Flag

`QUERY_EXPANSION_MODE`:

- `off` (default) builds the byte-identical pre-expansion query and fetches no dictionary.
- `shadow` builds the expanded query, records how it compares to the unexpanded one, and executes the unexpanded one.
- `on` runs the expanded query, and **is refused at boot today**.

`on` is blocked by an invariant in `envBaseInvariantViolation`, not merely documented. Under `on` the engine query depends on which dictionary the serving replica has loaded, so a page-2 request landing on a replica mid-refresh rebuilds a different query and ranks a different result set against page 1's cursor, which can skip or repeat decisions. Replicas converge on the pointer, so the window is a rebuild or a failed refresh rather than steady state, and `shadow` cannot reach it at all because it executes the unexpanded query.

**Removal condition**, recorded at the invariant, the mode union, and the test: the invariant is deleted in the PR that makes a corpus cursor carry the dictionary version it was built against (which also requires retaining superseded payloads so a later page can resolve that version). Until then the shadow event reports `dictionaryHash`, so replica convergence is measurable on real traffic before that work is scoped.

Both case-law corpus-index boundaries (the public search handler and the shared search provider) resolve through one `resolveExpandedCorpusQuery`, for the same reason both assemble through `caseLawCorpusQuery`: a rollout flag applied at one boundary and not the other is two answers to what the engine sees. Czech and Polish route from the request's jurisdiction; Slovak and EU resolve to no expansion (no Slovak dictionary is published yet, and the EU index carries 24 languages under one jurisdiction). pg-fts and legislation are untouched.

The shadow event carries counts, never query text: `baseLeaves`, `expandedLeaves`, `addedLeaves`, `countryScoped`, `language`, `dictionaryHash`, and a `reach` discriminator recording what actually happened (`expanded`, `dictionary_inert`, `no_dictionary`, `unsupported_jurisdiction`). A case-law query can name a client or a party, and nothing else in the request path copies query text into telemetry; the counts answer what the rollout needs and reconstruct nothing. Requests that reach no dictionary emit too, so the scoped-traffic ratio is not one by construction.

## Tests

- Collision regressions pinned from corpus buckets: `veci` does not reach `vek`/`veku`, the `ruk` family keeps only prefix-sharing members, a two-character term expands to nothing, and a decomposed term reaches the same bucket as its precomposed spelling.
- Folded-key collisions drop while single-claim keys survive, independent of serialization order (asserted both ways round); two forms of one bucket folding together is not treated as a conflict.
- The digit guard is bound to the citation extractor's real patterns rather than to a second copy of them: every digit-bearing token a real citation decomposes into must expand to nothing.
- Properties over arbitrary dictionaries (including forms carrying quotes, backslashes, tabs, commas, and digits) and arbitrary queries: the emitted clause is always balanced and correctly quoted, expansion never pushes a clause past the leaf budget it started under, a query already over the budget expands not at all, expansion only ever adds leaves, and no AND position is ever lost.
- Dictionary parsing: every malformed line shape is skipped and counted, never thrown on, and a bad line costs only itself.
- The pointer's content-hash shape is enforced, so a written pointer cannot address an arbitrary object.
- The shadow event's attributes are asserted to survive `sanitizeLogAttributes` and to carry no query text, derived from the attribute builder rather than a hand-kept list.
