### PR TITLE
feat(web): show folder file statistics

### DIFF
--- a/apps/web/src/components/inspector/email-html-viewer.logic.test.ts
+++ b/apps/web/src/components/inspector/email-html-viewer.logic.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  getEmailAttachmentSize,
   getEmailBodyFrameHeight,
   localizeEmailBodyHtml,
   parseEmailDate,
@@ -18,26 +17,6 @@ describe("email viewer metadata", () => {
     expect(parseEmailDate("Mon, 02 Jun 2026 10:00:00 +0000")).toEqual(
       new Date("2026-06-02T10:00:00.000Z"),
     );
-  });
-
-  test("selects a readable unit for attachment sizes", () => {
-    expect(getEmailAttachmentSize(512)).toEqual({ unit: "byte", value: 512 });
-    expect(getEmailAttachmentSize(2000)).toEqual({
-      unit: "kilobyte",
-      value: 2,
-    });
-    expect(getEmailAttachmentSize(2 * 1000 * 1000)).toEqual({
-      unit: "megabyte",
-      value: 2,
-    });
-    expect(getEmailAttachmentSize(2 * 1000 * 1000 * 1000)).toEqual({
-      unit: "gigabyte",
-      value: 2,
-    });
-    expect(getEmailAttachmentSize(1_000_000)).toEqual({
-      unit: "megabyte",
-      value: 1,
-    });
   });
 
   test("uses vertical scroll extents to size legacy float layouts", () => {

--- a/apps/web/src/components/inspector/email-html-viewer.logic.ts
+++ b/apps/web/src/components/inspector/email-html-viewer.logic.ts
@@ -92,29 +92,6 @@ export const parseEmailDate = (value: string | null): Date | null => {
   return Number.isNaN(date.getTime()) ? null : date;
 };
 
-export type EmailAttachmentSize = {
-  unit: "byte" | "gigabyte" | "kilobyte" | "megabyte";
-  value: number;
-};
-
-export const getEmailAttachmentSize = (
-  sizeBytes: number,
-): EmailAttachmentSize => {
-  if (sizeBytes < 1000) {
-    return { unit: "byte", value: sizeBytes };
-  }
-
-  if (sizeBytes < 1000 * 1000) {
-    return { unit: "kilobyte", value: sizeBytes / 1000 };
-  }
-
-  if (sizeBytes < 1000 * 1000 * 1000) {
-    return { unit: "megabyte", value: sizeBytes / (1000 * 1000) };
-  }
-
-  return { unit: "gigabyte", value: sizeBytes / (1000 * 1000 * 1000) };
-};
-
 type EmailBodyFrameHeightMetrics = {
   body: {
     clientHeight: number;

--- a/apps/web/src/components/inspector/email-html-viewer.tsx
+++ b/apps/web/src/components/inspector/email-html-viewer.tsx
@@ -21,7 +21,6 @@ import {
   EMAIL_CHAT_HOST,
   EMAIL_CHAT_MODE,
   EMAIL_VIEWER_LAYOUT,
-  getEmailAttachmentSize,
   getEmailBodyFrameHeight,
   getEmailFileChatContext,
   localizeEmailBodyHtml,
@@ -35,6 +34,7 @@ import {
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { useFormatter } from "@/i18n/formatting-context";
 import { detached } from "@/lib/detached";
+import { getFileSizeDisplay } from "@/lib/file-size";
 import {
   EMAIL_CITATION_SCROLL_EVENT,
   isEmailCitationTargetDetail,
@@ -469,7 +469,7 @@ const formatAttachmentSize = (
   sizeBytes: number,
   format: ReturnType<typeof useFormatter>,
 ): string => {
-  const size = getEmailAttachmentSize(sizeBytes);
+  const size = getFileSizeDisplay(sizeBytes);
   return format.number(size.value, {
     maximumFractionDigits: 1,
     style: "unit",

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -3820,7 +3820,9 @@
     "filesystem": {
       "collapseAll": "طي جميع المجلدات",
       "expandAll": "توسيع جميع المجلدات",
+      "fileCount": "{count, plural, zero {لا ملفات} one {ملف واحد} two {ملفان} few {# ملفات} many {# ملفًا} other {# ملف}}",
       "lastUpdated": "آخر تحديث",
+      "matchingFileCount": "{count, plural, zero {لا ملفات مطابقة} one {ملف واحد مطابق} two {ملفان مطابقان} few {# ملفات مطابقة} many {# ملفًا مطابقًا} other {# ملف مطابق}}",
       "moveToRoot": "أفلِت هنا للنقل إلى المستوى الجذر",
       "newSubfolder": "مجلد فرعي جديد",
       "noFilesYet": "لا توجد ملفات بعد"

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -3820,7 +3820,9 @@
     "filesystem": {
       "collapseAll": "Sbalit všechny složky",
       "expandAll": "Rozbalit všechny složky",
+      "fileCount": "{count, plural, one {# soubor} few {# soubory} other {# souborů}}",
       "lastUpdated": "Naposledy aktualizováno",
+      "matchingFileCount": "{count, plural, one {# odpovídající soubor} few {# odpovídající soubory} other {# odpovídajících souborů}}",
       "moveToRoot": "Přetáhněte sem pro přesun do kořenové úrovně",
       "newSubfolder": "Nová podsložka",
       "noFilesYet": "Zatím žádné soubory"

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -3820,7 +3820,9 @@
     "filesystem": {
       "collapseAll": "Alle Ordner einklappen",
       "expandAll": "Alle Ordner ausklappen",
+      "fileCount": "{count, plural, one {# Datei} other {# Dateien}}",
       "lastUpdated": "Zuletzt aktualisiert",
+      "matchingFileCount": "{count, plural, one {# passende Datei} other {# passende Dateien}}",
       "moveToRoot": "Hier ablegen, um auf die oberste Ebene zu verschieben",
       "newSubfolder": "Neuer Unterordner",
       "noFilesYet": "Noch keine Dateien"

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -3820,7 +3820,9 @@
     "filesystem": {
       "collapseAll": "Collapse all folders",
       "expandAll": "Expand all folders",
+      "fileCount": "{count, plural, one {# file} other {# files}}",
       "lastUpdated": "Last updated",
+      "matchingFileCount": "{count, plural, one {# matching file} other {# matching files}}",
       "moveToRoot": "Drop here to move to root level",
       "newSubfolder": "New subfolder",
       "noFilesYet": "No files yet"

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -3820,7 +3820,9 @@
     "filesystem": {
       "collapseAll": "Contraer todas las carpetas",
       "expandAll": "Expandir todas las carpetas",
+      "fileCount": "{count, plural, one {# archivo} other {# archivos}}",
       "lastUpdated": "Última actualización",
+      "matchingFileCount": "{count, plural, one {# archivo coincidente} other {# archivos coincidentes}}",
       "moveToRoot": "Suelta aquí para mover al nivel raíz",
       "newSubfolder": "Nueva subcarpeta",
       "noFilesYet": "Aún no hay archivos"

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -3820,7 +3820,9 @@
     "filesystem": {
       "collapseAll": "Ahenda kõik kaustad",
       "expandAll": "Laienda kõik kaustad",
+      "fileCount": "{count, plural, one {# fail} other {# faili}}",
       "lastUpdated": "Viimati uuendatud",
+      "matchingFileCount": "{count, plural, one {# vastav fail} other {# vastavat faili}}",
       "moveToRoot": "Lohistage siia, et liigutada juuretasemele",
       "newSubfolder": "Uus alamkaust",
       "noFilesYet": "Faile pole veel"

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -3820,7 +3820,9 @@
     "filesystem": {
       "collapseAll": "Réduire tous les dossiers",
       "expandAll": "Développer tous les dossiers",
+      "fileCount": "{count, plural, one {# fichier} other {# fichiers}}",
       "lastUpdated": "Dernière mise à jour",
+      "matchingFileCount": "{count, plural, one {# fichier correspondant} other {# fichiers correspondants}}",
       "moveToRoot": "Déposez ici pour déplacer à la racine",
       "newSubfolder": "Nouveau sous-dossier",
       "noFilesYet": "Aucun fichier pour le moment"

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -3820,7 +3820,9 @@
     "filesystem": {
       "collapseAll": "Összes mappa összecsukása",
       "expandAll": "Összes mappa kinyitása",
+      "fileCount": "{count, plural, one {# fájl} other {# fájl}}",
       "lastUpdated": "Utoljára frissítve",
+      "matchingFileCount": "{count, plural, one {# egyező fájl} other {# egyező fájl}}",
       "moveToRoot": "Húzza ide a gyökérszintre helyezéshez",
       "newSubfolder": "Új almappa",
       "noFilesYet": "Még nincsenek fájlok"

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -3820,7 +3820,9 @@
     "filesystem": {
       "collapseAll": "Sutraukti visus aplankus",
       "expandAll": "Išskleisti visus aplankus",
+      "fileCount": "{count, plural, one {# failas} few {# failai} other {# failų}}",
       "lastUpdated": "Paskutinis atnaujinimas",
+      "matchingFileCount": "{count, plural, one {# atitinkantis failas} few {# atitinkantys failai} other {# atitinkančių failų}}",
       "moveToRoot": "Numeskite čia, kad perkeltumėte į šakninį lygį",
       "newSubfolder": "Naujas poaplankis",
       "noFilesYet": "Failų dar nėra"

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -3820,7 +3820,9 @@
     "filesystem": {
       "collapseAll": "Sakļaut visas mapes",
       "expandAll": "Izvērst visas mapes",
+      "fileCount": "{count, plural, zero {# failu} one {# fails} other {# faili}}",
       "lastUpdated": "Pēdējoreiz atjaunināts",
+      "matchingFileCount": "{count, plural, zero {# atbilstošu failu} one {# atbilstošs fails} other {# atbilstoši faili}}",
       "moveToRoot": "Nometiet šeit, lai pārvietotu uz saknes līmeni",
       "newSubfolder": "Jauna apakšmape",
       "noFilesYet": "Failu pagaidām nav"

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -3823,7 +3823,9 @@ type Messages = {
     "filesystem": {
       "collapseAll": "Collapse all folders";
       "expandAll": "Expand all folders";
+      "fileCount": "{count, plural, one {# file} other {# files}}";
       "lastUpdated": "Last updated";
+      "matchingFileCount": "{count, plural, one {# matching file} other {# matching files}}";
       "moveToRoot": "Drop here to move to root level";
       "newSubfolder": "New subfolder";
       "noFilesYet": "No files yet";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -3820,7 +3820,9 @@
     "filesystem": {
       "collapseAll": "Zwiń wszystkie foldery",
       "expandAll": "Rozwiń wszystkie foldery",
+      "fileCount": "{count, plural, one {# plik} few {# pliki} many {# plików} other {# pliku}}",
       "lastUpdated": "Ostatnia aktualizacja",
+      "matchingFileCount": "{count, plural, one {# pasujący plik} few {# pasujące pliki} many {# pasujących plików} other {# pasującego pliku}}",
       "moveToRoot": "Upuść tutaj, aby przenieść na poziom główny",
       "newSubfolder": "Nowy podfolder",
       "noFilesYet": "Brak plików"

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -3820,7 +3820,9 @@
     "filesystem": {
       "collapseAll": "Recolher todas as pastas",
       "expandAll": "Expandir todas as pastas",
+      "fileCount": "{count, plural, one {# arquivo} other {# arquivos}}",
       "lastUpdated": "Última atualização",
+      "matchingFileCount": "{count, plural, one {# arquivo correspondente} other {# arquivos correspondentes}}",
       "moveToRoot": "Solte aqui para passar para o nível raiz",
       "newSubfolder": "Nova subpasta",
       "noFilesYet": "Nenhum arquivo ainda"

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -3820,7 +3820,9 @@
     "filesystem": {
       "collapseAll": "Zbaliť všetky priečinky",
       "expandAll": "Rozbaliť všetky priečinky",
+      "fileCount": "{count, plural, one {# súbor} few {# súbory} other {# súborov}}",
       "lastUpdated": "Naposledy aktualizované",
+      "matchingFileCount": "{count, plural, one {# zodpovedajúci súbor} few {# zodpovedajúce súbory} other {# zodpovedajúcich súborov}}",
       "moveToRoot": "Presuňte sem pre presun do koreňovej úrovne",
       "newSubfolder": "Nový podpriečinok",
       "noFilesYet": "Zatiaľ žiadne súbory"

--- a/apps/web/src/lib/file-size.test.ts
+++ b/apps/web/src/lib/file-size.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { getFileSizeDisplay } from "@/lib/file-size";
+
+describe("file size display", () => {
+  test("selects a readable decimal unit", () => {
+    expect(getFileSizeDisplay(512)).toEqual({ unit: "byte", value: 512 });
+    expect(getFileSizeDisplay(2000)).toEqual({
+      unit: "kilobyte",
+      value: 2,
+    });
+    expect(getFileSizeDisplay(2 * 1000 * 1000)).toEqual({
+      unit: "megabyte",
+      value: 2,
+    });
+    expect(getFileSizeDisplay(2 * 1000 * 1000 * 1000)).toEqual({
+      unit: "gigabyte",
+      value: 2,
+    });
+    expect(getFileSizeDisplay(1_000_000)).toEqual({
+      unit: "megabyte",
+      value: 1,
+    });
+  });
+});

--- a/apps/web/src/lib/file-size.test.ts
+++ b/apps/web/src/lib/file-size.test.ts
@@ -22,4 +22,22 @@ describe("file size display", () => {
       value: 1,
     });
   });
+
+  test("changes units exactly at each decimal threshold", () => {
+    const cases = [
+      { sizeBytes: 999, unit: "byte", value: 999 },
+      { sizeBytes: 1000, unit: "kilobyte", value: 1 },
+      { sizeBytes: 1001, unit: "kilobyte", value: 1.001 },
+      { sizeBytes: 999_999, unit: "kilobyte", value: 999.999 },
+      { sizeBytes: 1_000_000, unit: "megabyte", value: 1 },
+      { sizeBytes: 1_000_001, unit: "megabyte", value: 1.000_001 },
+      { sizeBytes: 999_999_999, unit: "megabyte", value: 999.999_999 },
+      { sizeBytes: 1_000_000_000, unit: "gigabyte", value: 1 },
+      { sizeBytes: 1_000_000_001, unit: "gigabyte", value: 1.000_000_001 },
+    ] as const;
+
+    for (const { sizeBytes, unit, value } of cases) {
+      expect(getFileSizeDisplay(sizeBytes)).toEqual({ unit, value });
+    }
+  });
 });

--- a/apps/web/src/lib/file-size.test.ts
+++ b/apps/web/src/lib/file-size.test.ts
@@ -30,10 +30,18 @@ describe("file size display", () => {
       { sizeBytes: 1001, unit: "kilobyte", value: 1.001 },
       { sizeBytes: 999_999, unit: "kilobyte", value: 999.999 },
       { sizeBytes: 1_000_000, unit: "megabyte", value: 1 },
-      { sizeBytes: 1_000_001, unit: "megabyte", value: 1.000_001 },
-      { sizeBytes: 999_999_999, unit: "megabyte", value: 999.999_999 },
+      { sizeBytes: 1_000_001, unit: "megabyte", value: 1_000_001 / 1_000_000 },
+      {
+        sizeBytes: 999_999_999,
+        unit: "megabyte",
+        value: 999_999_999 / 1_000_000,
+      },
       { sizeBytes: 1_000_000_000, unit: "gigabyte", value: 1 },
-      { sizeBytes: 1_000_000_001, unit: "gigabyte", value: 1.000_000_001 },
+      {
+        sizeBytes: 1_000_000_001,
+        unit: "gigabyte",
+        value: 1_000_000_001 / 1_000_000_000,
+      },
     ] as const;
 
     for (const { sizeBytes, unit, value } of cases) {

--- a/apps/web/src/lib/file-size.ts
+++ b/apps/web/src/lib/file-size.ts
@@ -1,0 +1,15 @@
+export const getFileSizeDisplay = (sizeBytes: number) => {
+  if (sizeBytes < 1000) {
+    return { unit: "byte", value: sizeBytes };
+  }
+
+  if (sizeBytes < 1000 * 1000) {
+    return { unit: "kilobyte", value: sizeBytes / 1000 };
+  }
+
+  if (sizeBytes < 1000 * 1000 * 1000) {
+    return { unit: "megabyte", value: sizeBytes / (1000 * 1000) };
+  }
+
+  return { unit: "gigabyte", value: sizeBytes / (1000 * 1000 * 1000) };
+};

--- a/apps/web/src/lib/workspaces/queries/entities.ts
+++ b/apps/web/src/lib/workspaces/queries/entities.ts
@@ -240,8 +240,10 @@ export const filesystemEntitiesOptions = (
       // complete the ancestor chain for cross-matter copy/move dedup; never
       // rendered, so they stay out of selection and bulk actions.
       const ancestorLinks = data.ancestorLinks;
+      const isFiltered =
+        (key.filters?.length ?? 0) > 0 || Boolean(key.search?.trim());
 
-      return { entities, ancestorLinks };
+      return { entities, ancestorLinks, isFiltered };
     },
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });

--- a/apps/web/src/lib/workspaces/queries/entities.ts
+++ b/apps/web/src/lib/workspaces/queries/entities.ts
@@ -241,7 +241,7 @@ export const filesystemEntitiesOptions = (
       // rendered, so they stay out of selection and bulk actions.
       const ancestorLinks = data.ancestorLinks;
       const isFiltered =
-        (key.filters?.length ?? 0) > 0 || Boolean(key.search?.trim());
+        key.filters.length > 0 || Boolean(key.search?.trim());
 
       return { entities, ancestorLinks, isFiltered };
     },

--- a/apps/web/src/lib/workspaces/queries/entities.ts
+++ b/apps/web/src/lib/workspaces/queries/entities.ts
@@ -240,8 +240,7 @@ export const filesystemEntitiesOptions = (
       // complete the ancestor chain for cross-matter copy/move dedup; never
       // rendered, so they stay out of selection and bulk actions.
       const ancestorLinks = data.ancestorLinks;
-      const isFiltered =
-        key.filters.length > 0 || Boolean(key.search?.trim());
+      const isFiltered = key.filters.length > 0 || Boolean(key.search?.trim());
 
       return { entities, ancestorLinks, isFiltered };
     },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 
-import type { TableTreeNode } from "@/components/workspaces/table/types";
 import { toSafeId } from "@/lib/safe-id";
 import type { WorkspaceEntity } from "@/lib/types";
 
@@ -9,15 +8,15 @@ import { calculateFolderStatistics } from "./folder-statistics.logic";
 const entityId = (value: string) => toSafeId<"entity">(value);
 
 type EntityOptions = {
-  children?: TableTreeNode[];
+  parentId?: string;
   sizeBytes?: number;
 };
 
 const entity = (
   id: string,
   kind: WorkspaceEntity["kind"],
-  { children = [], sizeBytes }: EntityOptions = {},
-): TableTreeNode => {
+  { parentId, sizeBytes }: EntityOptions = {},
+): WorkspaceEntity => {
   const safeEntityId = entityId(id);
   const propertyId = toSafeId<"property">(`property-${id}`);
 
@@ -25,7 +24,7 @@ const entity = (
     entityId: safeEntityId,
     kind,
     name: id,
-    parentId: null,
+    parentId: parentId ? entityId(parentId) : null,
     createdAt: "2025-01-01T00:00:00.000Z",
     createdBy: null,
     createdByImage: null,
@@ -80,30 +79,32 @@ const entity = (
               },
             },
           },
-    children,
   };
 };
 
 describe("folder statistics", () => {
   test("aggregates all descendant files through nested and empty folders", () => {
-    const statistics = calculateFolderStatistics([
-      entity("root", "folder", {
-        children: [
-          entity("direct-document", "document", { sizeBytes: 100 }),
-          entity("nested", "folder", {
-            children: [
-              entity("nested-document", "document", { sizeBytes: 250 }),
-              entity("deep", "folder", {
-                children: [
-                  entity("deep-document", "document", { sizeBytes: 25 }),
-                ],
-              }),
-            ],
-          }),
-          entity("empty", "folder"),
-        ],
-      }),
-    ]);
+    const statistics = calculateFolderStatistics(
+      [
+        entity("root", "folder"),
+        entity("direct-document", "document", {
+          parentId: "root",
+          sizeBytes: 100,
+        }),
+        entity("nested", "folder", { parentId: "root" }),
+        entity("nested-document", "document", {
+          parentId: "nested",
+          sizeBytes: 250,
+        }),
+        entity("deep", "folder", { parentId: "nested" }),
+        entity("deep-document", "document", {
+          parentId: "deep",
+          sizeBytes: 25,
+        }),
+        entity("empty", "folder", { parentId: "root" }),
+      ],
+      [],
+    );
 
     expect(statistics.get(entityId("deep"))).toEqual({
       fileCount: 1,
@@ -124,18 +125,22 @@ describe("folder statistics", () => {
   });
 
   test("keeps parent totals equal to direct files plus child-folder totals", () => {
-    const directFile = entity("direct-document", "document", {
-      sizeBytes: 125,
-    });
-    const childFolder = entity("child", "folder", {
-      children: [
-        entity("child-document", "document", { sizeBytes: 275 }),
-        entity("missing-file-field", "document"),
+    const statistics = calculateFolderStatistics(
+      [
+        entity("parent", "folder"),
+        entity("direct-document", "document", {
+          parentId: "parent",
+          sizeBytes: 125,
+        }),
+        entity("child", "folder", { parentId: "parent" }),
+        entity("child-document", "document", {
+          parentId: "child",
+          sizeBytes: 275,
+        }),
+        entity("missing-file-field", "document", { parentId: "child" }),
       ],
-    });
-    const statistics = calculateFolderStatistics([
-      entity("parent", "folder", { children: [directFile, childFolder] }),
-    ]);
+      [],
+    );
     const childStatistics = statistics.get(entityId("child"));
 
     expect(childStatistics).toBeDefined();
@@ -146,6 +151,46 @@ describe("folder statistics", () => {
     expect(statistics.get(entityId("parent"))).toEqual({
       fileCount: 1 + childStatistics.fileCount,
       totalSizeBytes: 125 + childStatistics.totalSizeBytes,
+    });
+  });
+
+  test("ignores every non-document leaf kind", () => {
+    const statistics = calculateFolderStatistics(
+      [
+        entity("root", "folder"),
+        entity("task", "task", { parentId: "root", sizeBytes: 10 }),
+        entity("message", "message", { parentId: "root", sizeBytes: 20 }),
+        entity("link", "link", { parentId: "root", sizeBytes: 30 }),
+      ],
+      [],
+    );
+
+    expect(statistics.get(entityId("root"))).toEqual({
+      fileCount: 0,
+      totalSizeBytes: 0,
+    });
+  });
+
+  test("connects filtered documents through hidden ancestor folders", () => {
+    const statistics = calculateFolderStatistics(
+      [
+        entity("visible-root", "folder"),
+        entity("matching-document", "document", {
+          parentId: "hidden-folder",
+          sizeBytes: 425,
+        }),
+      ],
+      [
+        {
+          entityId: entityId("hidden-folder"),
+          parentId: entityId("visible-root"),
+        },
+      ],
+    );
+
+    expect(statistics.get(entityId("visible-root"))).toEqual({
+      fileCount: 1,
+      totalSizeBytes: 425,
     });
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+
+import type { TableTreeNode } from "@/components/workspaces/table/types";
+import { toSafeId } from "@/lib/safe-id";
+import type { WorkspaceEntity } from "@/lib/types";
+
+import { calculateFolderStatistics } from "./folder-statistics.logic";
+
+const entityId = (value: string) => toSafeId<"entity">(value);
+
+type EntityOptions = {
+  children?: TableTreeNode[];
+  sizeBytes?: number;
+};
+
+const entity = (
+  id: string,
+  kind: WorkspaceEntity["kind"],
+  { children = [], sizeBytes }: EntityOptions = {},
+): TableTreeNode => {
+  const safeEntityId = entityId(id);
+  const propertyId = toSafeId<"property">(`property-${id}`);
+
+  return {
+    entityId: safeEntityId,
+    kind,
+    name: id,
+    parentId: null,
+    createdAt: "2025-01-01T00:00:00.000Z",
+    createdBy: null,
+    createdByImage: null,
+    createdByDeletedAt: null,
+    updatedAt: null,
+    version: 1,
+    status: null,
+    priority: null,
+    listItemType: kind === "task" ? "task" : null,
+    dueDate: null,
+    agendaKind: "task",
+    startAt: null,
+    endAt: null,
+    occurredAt: null,
+    remindAt: null,
+    allDay: false,
+    timeZone: null,
+    location: null,
+    onlineMeetingUrl: null,
+    availability: null,
+    sensitivity: null,
+    organizer: null,
+    attendees: null,
+    recurrence: null,
+    agendaSource: "manual",
+    externalSource: null,
+    externalId: null,
+    externalChangeKey: null,
+    externalICalUid: null,
+    readOnly: false,
+    sortOrder: null,
+    activeEditBy: null,
+    cellMetadata: {},
+    fields:
+      sizeBytes === undefined
+        ? {}
+        : {
+            [propertyId]: {
+              entityId: safeEntityId,
+              id: toSafeId<"field">(`field-${id}`),
+              propertyId,
+              content: {
+                version: 1,
+                type: "file",
+                id: toSafeId<"userFile">(`file-${id}`),
+                fileName: `${id}.pdf`,
+                mimeType: "application/pdf",
+                sizeBytes,
+                encrypted: false,
+                sha256Hex: id,
+                pdfFileId: null,
+              },
+            },
+          },
+    children,
+  };
+};
+
+describe("folder statistics", () => {
+  test("aggregates all descendant files through nested and empty folders", () => {
+    const statistics = calculateFolderStatistics([
+      entity("root", "folder", {
+        children: [
+          entity("direct-document", "document", { sizeBytes: 100 }),
+          entity("nested", "folder", {
+            children: [
+              entity("nested-document", "document", { sizeBytes: 250 }),
+              entity("deep", "folder", {
+                children: [
+                  entity("deep-document", "document", { sizeBytes: 25 }),
+                ],
+              }),
+            ],
+          }),
+          entity("empty", "folder"),
+        ],
+      }),
+    ]);
+
+    expect(statistics.get(entityId("deep"))).toEqual({
+      fileCount: 1,
+      totalSizeBytes: 25,
+    });
+    expect(statistics.get(entityId("nested"))).toEqual({
+      fileCount: 2,
+      totalSizeBytes: 275,
+    });
+    expect(statistics.get(entityId("empty"))).toEqual({
+      fileCount: 0,
+      totalSizeBytes: 0,
+    });
+    expect(statistics.get(entityId("root"))).toEqual({
+      fileCount: 3,
+      totalSizeBytes: 375,
+    });
+  });
+
+  test("keeps parent totals equal to direct files plus child-folder totals", () => {
+    const directFile = entity("direct-document", "document", {
+      sizeBytes: 125,
+    });
+    const childFolder = entity("child", "folder", {
+      children: [
+        entity("child-document", "document", { sizeBytes: 275 }),
+        entity("missing-file-field", "document"),
+      ],
+    });
+    const statistics = calculateFolderStatistics([
+      entity("parent", "folder", { children: [directFile, childFolder] }),
+    ]);
+    const childStatistics = statistics.get(entityId("child"));
+
+    expect(childStatistics).toBeDefined();
+    if (!childStatistics) {
+      throw new Error("Expected child folder statistics");
+    }
+
+    expect(statistics.get(entityId("parent"))).toEqual({
+      fileCount: 1 + childStatistics.fileCount,
+      totalSizeBytes: 125 + childStatistics.totalSizeBytes,
+    });
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic.ts
@@ -1,0 +1,49 @@
+import { getFirstFile } from "@/components/workspaces/entity-utils";
+import type { TableTreeNode } from "@/components/workspaces/table/types";
+
+export type FolderStatistics = {
+  fileCount: number;
+  totalSizeBytes: number;
+};
+
+/**
+ * Counts each descendant document row once and sums only the current file that
+ * the row represents. Version history and generated derivatives are not part
+ * of the tree, so they are deliberately absent from these totals.
+ */
+export const calculateFolderStatistics = (
+  roots: readonly TableTreeNode[],
+): ReadonlyMap<TableTreeNode["entityId"], FolderStatistics> => {
+  const statisticsByFolderId = new Map<
+    TableTreeNode["entityId"],
+    FolderStatistics
+  >();
+
+  const visit = (node: TableTreeNode): FolderStatistics => {
+    if (node.kind !== "folder") {
+      return {
+        fileCount: 1,
+        totalSizeBytes: getFirstFile(node)?.sizeBytes ?? 0,
+      };
+    }
+
+    let fileCount = 0;
+    let totalSizeBytes = 0;
+
+    for (const child of node.children) {
+      const childStatistics = visit(child);
+      fileCount += childStatistics.fileCount;
+      totalSizeBytes += childStatistics.totalSizeBytes;
+    }
+
+    const statistics = { fileCount, totalSizeBytes };
+    statisticsByFolderId.set(node.entityId, statistics);
+    return statistics;
+  };
+
+  for (const root of roots) {
+    visit(root);
+  }
+
+  return statisticsByFolderId;
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic.ts
@@ -1,49 +1,111 @@
 import { getFirstFile } from "@/components/workspaces/entity-utils";
-import type { TableTreeNode } from "@/components/workspaces/table/types";
+import type { WorkspaceEntity } from "@/lib/types";
 
 export type FolderStatistics = {
   fileCount: number;
   totalSizeBytes: number;
 };
 
+type FolderAncestorLink = {
+  entityId: string;
+  parentId: string | null;
+};
+
+const EMPTY_STATISTICS = {
+  fileCount: 0,
+  totalSizeBytes: 0,
+} as const satisfies FolderStatistics;
+
 /**
  * Counts each descendant document row once and sums only the current file that
- * the row represents. Version history and generated derivatives are not part
- * of the tree, so they are deliberately absent from these totals.
+ * the row represents. Ancestor links reconnect filtered results through hidden
+ * intermediate folders without making those folders count as matches. Version
+ * history and generated derivatives are deliberately absent from these totals.
  */
 export const calculateFolderStatistics = (
-  roots: readonly TableTreeNode[],
-): ReadonlyMap<TableTreeNode["entityId"], FolderStatistics> => {
-  const statisticsByFolderId = new Map<
-    TableTreeNode["entityId"],
-    FolderStatistics
-  >();
+  entities: readonly WorkspaceEntity[],
+  ancestorLinks: readonly FolderAncestorLink[],
+): ReadonlyMap<string, FolderStatistics> => {
+  const entityById = new Map(
+    entities.map((entity) => [entity.entityId, entity] as const),
+  );
+  const parentById = new Map<string, string | null>();
+  const folderIds = new Set<string>();
 
-  const visit = (node: TableTreeNode): FolderStatistics => {
-    if (node.kind !== "folder") {
-      return {
-        fileCount: 1,
-        totalSizeBytes: getFirstFile(node)?.sizeBytes ?? 0,
-      };
+  for (const link of ancestorLinks) {
+    parentById.set(link.entityId, link.parentId);
+    folderIds.add(link.entityId);
+  }
+  for (const entity of entities) {
+    parentById.set(entity.entityId, entity.parentId);
+    if (entity.kind === "folder") {
+      folderIds.add(entity.entityId);
+    }
+  }
+
+  const childrenByParentId = new Map<string, string[]>();
+  for (const [entityId, parentId] of parentById) {
+    if (parentId === null) {
+      continue;
+    }
+    const children = childrenByParentId.get(parentId);
+    if (children) {
+      children.push(entityId);
+    } else {
+      childrenByParentId.set(parentId, [entityId]);
+    }
+  }
+
+  const memo = new Map<string, FolderStatistics>();
+  const visiting = new Set<string>();
+  const visit = (entityId: string): FolderStatistics => {
+    const cached = memo.get(entityId);
+    if (cached) {
+      return cached;
+    }
+    if (visiting.has(entityId)) {
+      return EMPTY_STATISTICS;
     }
 
-    let fileCount = 0;
-    let totalSizeBytes = 0;
+    visiting.add(entityId);
+    const entity = entityById.get(entityId);
+    let statistics: FolderStatistics;
 
-    for (const child of node.children) {
-      const childStatistics = visit(child);
-      fileCount += childStatistics.fileCount;
-      totalSizeBytes += childStatistics.totalSizeBytes;
+    if (!entity || entity.kind === "folder") {
+      let fileCount = 0;
+      let totalSizeBytes = 0;
+      for (const childId of childrenByParentId.get(entityId) ?? []) {
+        const childStatistics = visit(childId);
+        fileCount += childStatistics.fileCount;
+        totalSizeBytes += childStatistics.totalSizeBytes;
+      }
+      statistics = { fileCount, totalSizeBytes };
+    } else {
+      switch (entity.kind) {
+        case "document":
+          statistics = {
+            fileCount: 1,
+            totalSizeBytes: getFirstFile(entity)?.sizeBytes ?? 0,
+          };
+          break;
+        case "link":
+        case "message":
+        case "task":
+          statistics = EMPTY_STATISTICS;
+          break;
+        default:
+          return entity.kind satisfies never;
+      }
     }
 
-    const statistics = { fileCount, totalSizeBytes };
-    statisticsByFolderId.set(node.entityId, statistics);
+    visiting.delete(entityId);
+    memo.set(entityId, statistics);
     return statistics;
   };
 
-  for (const root of roots) {
-    visit(root);
+  const statisticsByFolderId = new Map<string, FolderStatistics>();
+  for (const folderId of folderIds) {
+    statisticsByFolderId.set(folderId, visit(folderId));
   }
-
   return statisticsByFolderId;
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic.ts
@@ -1,5 +1,5 @@
 import { getFirstFile } from "@/components/workspaces/entity-utils";
-import type { WorkspaceEntity } from "@/lib/types";
+import type { EntityId, WorkspaceEntity } from "@/lib/types";
 
 export type FolderStatistics = {
   fileCount: number;
@@ -7,8 +7,8 @@ export type FolderStatistics = {
 };
 
 type FolderAncestorLink = {
-  entityId: string;
-  parentId: string | null;
+  entityId: EntityId;
+  parentId: EntityId | null;
 };
 
 const EMPTY_STATISTICS = {
@@ -25,12 +25,12 @@ const EMPTY_STATISTICS = {
 export const calculateFolderStatistics = (
   entities: readonly WorkspaceEntity[],
   ancestorLinks: readonly FolderAncestorLink[],
-): ReadonlyMap<string, FolderStatistics> => {
+): ReadonlyMap<EntityId, FolderStatistics> => {
   const entityById = new Map(
     entities.map((entity) => [entity.entityId, entity] as const),
   );
-  const parentById = new Map<string, string | null>();
-  const folderIds = new Set<string>();
+  const parentById = new Map<EntityId, EntityId | null>();
+  const folderIds = new Set<EntityId>();
 
   for (const link of ancestorLinks) {
     parentById.set(link.entityId, link.parentId);
@@ -43,7 +43,7 @@ export const calculateFolderStatistics = (
     }
   }
 
-  const childrenByParentId = new Map<string, string[]>();
+  const childrenByParentId = new Map<EntityId, EntityId[]>();
   for (const [entityId, parentId] of parentById) {
     if (parentId === null) {
       continue;
@@ -56,9 +56,9 @@ export const calculateFolderStatistics = (
     }
   }
 
-  const memo = new Map<string, FolderStatistics>();
-  const visiting = new Set<string>();
-  const visit = (entityId: string): FolderStatistics => {
+  const memo = new Map<EntityId, FolderStatistics>();
+  const visiting = new Set<EntityId>();
+  const visit = (entityId: EntityId): FolderStatistics => {
     const cached = memo.get(entityId);
     if (cached) {
       return cached;
@@ -74,10 +74,13 @@ export const calculateFolderStatistics = (
     if (!entity || entity.kind === "folder") {
       let fileCount = 0;
       let totalSizeBytes = 0;
-      for (const childId of childrenByParentId.get(entityId) ?? []) {
-        const childStatistics = visit(childId);
-        fileCount += childStatistics.fileCount;
-        totalSizeBytes += childStatistics.totalSizeBytes;
+      const childIds = childrenByParentId.get(entityId);
+      if (childIds) {
+        for (const childId of childIds) {
+          const childStatistics = visit(childId);
+          fileCount += childStatistics.fileCount;
+          totalSizeBytes += childStatistics.totalSizeBytes;
+        }
       }
       statistics = { fileCount, totalSizeBytes };
     } else {
@@ -103,7 +106,7 @@ export const calculateFolderStatistics = (
     return statistics;
   };
 
-  const statisticsByFolderId = new Map<string, FolderStatistics>();
+  const statisticsByFolderId = new Map<EntityId, FolderStatistics>();
   for (const folderId of folderIds) {
     statisticsByFolderId.set(folderId, visit(folderId));
   }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -65,8 +65,9 @@ import type { InternalPropertyId } from "@/components/workspaces/entity-utils";
 import type { TableTreeNode } from "@/components/workspaces/table/types";
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { useLatestCallback } from "@/hooks/use-latest-callback";
-import { useLocale } from "@/i18n/formatting-context";
+import { useFormatter, useLocale } from "@/i18n/formatting-context";
 import { detached } from "@/lib/detached";
+import { getFileSizeDisplay } from "@/lib/file-size";
 import { toSafeId } from "@/lib/safe-id";
 import { readStoredJson, writeStoredJson } from "@/lib/stored-json";
 import { isFileDisplayable } from "@/lib/types";
@@ -91,6 +92,8 @@ import { useWorkspaceStore } from "@/lib/workspaces/store";
 import { ActiveEditBadge } from "@/routes/_protected.workspaces/$workspaceId/-components/active-edit-badge";
 import { AddEntityMenu } from "@/routes/_protected.workspaces/$workspaceId/-components/add-entity-menu";
 import { EmptyState } from "@/routes/_protected.workspaces/$workspaceId/-components/empty-state";
+import { calculateFolderStatistics } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic";
+import type { FolderStatistics } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic";
 import { getFolderClickIntent } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic";
 import { flattenFilesystemRows } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-virtualization";
 import {
@@ -388,6 +391,10 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     [parentById],
   );
   const tree = useMemo(() => buildTree(data), [data]);
+  const folderStatistics = useMemo(
+    () => calculateFolderStatistics(tree),
+    [tree],
+  );
   const treeNodeMap = useMemo(() => {
     const map = new Map<string, TableTreeNode>();
     const visit = (nodes: readonly TableTreeNode[]) => {
@@ -930,10 +937,12 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
                     editingEntityId={editingEntityId}
                     expandedIds={expandedIds}
                     extraColumns={extraColumns}
+                    folderStatistics={folderStatistics.get(row.node.entityId)}
                     getSelectedDragItems={getSelectedDragItems}
                     getSelectedEntities={getSelectedEntities}
                     getAncestorIds={getAncestorIds}
                     gridTemplate={gridTemplate}
+                    isFiltered={filters.length > 0}
                     node={row.node}
                     onNavigateToFolder={(folderId) => {
                       detached(
@@ -1132,7 +1141,9 @@ type FilesystemRowProps = {
   depth: number | undefined;
   workspaceId: string;
   extraColumns: ExtraColumn[];
+  folderStatistics: FolderStatistics | undefined;
   gridTemplate: string;
+  isFiltered: boolean;
   ancestorIds: Set<string>;
   expandedIds: Set<string>;
   selectedIds: Set<string>;
@@ -1155,7 +1166,9 @@ const FilesystemRow = ({
   depth = 0,
   workspaceId,
   extraColumns,
+  folderStatistics,
   gridTemplate,
+  isFiltered,
   ancestorIds,
   expandedIds,
   selectedIds,
@@ -1173,6 +1186,7 @@ const FilesystemRow = ({
   getAncestorIds,
 }: FilesystemRowProps) => {
   const t = useTranslations();
+  const format = useFormatter();
   // RowActions can open via two paths: a trigger-button click (anchors
   // the menu to the ellipsis button) or a right-click on the row (anchors
   // to the cursor position). Model both with a discriminated union so the
@@ -1191,6 +1205,17 @@ const FilesystemRow = ({
   const isSelected = selectedIds.has(node.entityId);
   const expanded = isFolder && expandedIds.has(node.entityId);
   const name = getEntityName(node);
+  const formattedFolderSize = folderStatistics
+    ? (() => {
+        const size = getFileSizeDisplay(folderStatistics.totalSizeBytes);
+        return format.number(size.value, {
+          maximumFractionDigits: 1,
+          style: "unit",
+          unit: size.unit,
+          unitDisplay: "short",
+        });
+      })()
+    : null;
 
   const file = isFolder ? null : getFirstFile(node);
   const navigable = file !== null && isFileDisplayable(file);
@@ -1477,6 +1502,22 @@ const FilesystemRow = ({
           <BidiText as="span" className="truncate" title={name}>
             {name}
           </BidiText>
+          {folderStatistics && formattedFolderSize && (
+            <span className="text-muted-foreground flex shrink-0 items-center gap-1 text-xs tabular-nums">
+              <span>
+                {t(
+                  isFiltered
+                    ? "workspaces.filesystem.matchingFileCount"
+                    : "workspaces.filesystem.fileCount",
+                  { count: folderStatistics.fileCount },
+                )}
+              </span>
+              <span className="flex items-center gap-1 opacity-0 transition-opacity duration-150 group-focus-within/row:opacity-100 group-hover/row:opacity-100">
+                <span aria-hidden="true">·</span>
+                <span>{formattedFolderSize}</span>
+              </span>
+            </span>
+          )}
           {node.activeEditBy && (
             <ActiveEditBadge
               className="shrink-0"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -362,9 +362,8 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
   );
   const data = entityData.entities;
   // Parent links of ancestor folders the API backfills when a filter/search
-  // hides an intermediate folder. Used ONLY to complete the ancestor lookup
-  // below so cross-matter copy/move dedup works across hidden folders; never
-  // rendered or selectable, so they cannot become an action target.
+  // hides an intermediate folder. They complete the ancestor lookup below and
+  // connect filtered folder statistics, but remain unrendered and unselectable.
   const ancestorLinks = entityData.ancestorLinks;
 
   // Build a lookup for drag preview data from selected entities.
@@ -392,8 +391,8 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
   );
   const tree = useMemo(() => buildTree(data), [data]);
   const folderStatistics = useMemo(
-    () => calculateFolderStatistics(tree),
-    [tree],
+    () => calculateFolderStatistics(data, ancestorLinks),
+    [data, ancestorLinks],
   );
   const treeNodeMap = useMemo(() => {
     const map = new Map<string, TableTreeNode>();
@@ -942,7 +941,7 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
                     getSelectedEntities={getSelectedEntities}
                     getAncestorIds={getAncestorIds}
                     gridTemplate={gridTemplate}
-                    isFiltered={filters.length > 0}
+                    isFiltered={entityData.isFiltered}
                     node={row.node}
                     onNavigateToFolder={(folderId) => {
                       detached(


### PR DESCRIPTION
Shows each folder’s recursive file count in the Files view, reveals the current-file total size on hover and keyboard focus without shifting the row, labels filtered totals as matching files, and localizes the new metadata across supported languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Folder views now show descendant file counts and total sizes.
  - Filtered views display matching-file counts.
  - Email previews dynamically adjust body height and support localised fold controls.
  - Attachment sizes use consistent file-size formatting across the app.

- **Localisation**
  - Added filesystem count labels for multiple languages, including Arabic, Czech, German, Spanish, French and Polish.

- **Bug Fixes**
  - Improved handling of nested, hidden and empty folders when calculating statistics.
  - Enhanced email HTML safety and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->