### PR TITLE
feat: add dev quick start

### DIFF
--- a/apps/api/scripts/seed-firm-knowledge.logic.test.ts
+++ b/apps/api/scripts/seed-firm-knowledge.logic.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { selectMatterNames } from "./seed-firm-knowledge.logic";
+
+const MATTERS = Array.from(
+  { length: 25 },
+  (_, index) => `matter-${String(index + 1).padStart(2, "0")}`,
+);
+
+describe("selectMatterNames", () => {
+  test("selects an exact, unique, reproducible seeded subset", () => {
+    const selection = selectMatterNames({
+      matterCount: 10,
+      matterNames: MATTERS,
+      selectionSeed: "quick-start-seed",
+    });
+    const repeated = selectMatterNames({
+      matterCount: 10,
+      matterNames: MATTERS.toReversed(),
+      selectionSeed: "quick-start-seed",
+    });
+
+    expect(selection).toEqual(repeated);
+    expect(selection).toHaveLength(10);
+    expect(new Set(selection).size).toBe(10);
+    expect(selection.every((matter) => MATTERS.includes(matter))).toBe(true);
+  });
+
+  test("does not mutate the manifest and never invents missing matters", () => {
+    const source = ["matter-c", "matter-a", "matter-b", "matter-a"];
+    const snapshot = [...source];
+
+    const selection = selectMatterNames({
+      matterCount: 10,
+      matterNames: source,
+      selectionSeed: "small-corpus",
+    });
+
+    expect(source).toEqual(snapshot);
+    expect(new Set(selection)).toEqual(
+      new Set(["matter-a", "matter-b", "matter-c"]),
+    );
+  });
+
+  test("preserves the CLI's alphabetical selection without a seed", () => {
+    expect(
+      selectMatterNames({ matterCount: 2, matterNames: ["c", "a", "b"] }),
+    ).toEqual(["a", "b"]);
+  });
+});

--- a/apps/api/scripts/seed-firm-knowledge.logic.ts
+++ b/apps/api/scripts/seed-firm-knowledge.logic.ts
@@ -1,0 +1,42 @@
+import { createHash } from "node:crypto";
+
+type SelectMatterNamesOptions = {
+  matterCount: number;
+  matterNames: readonly string[];
+  selectionSeed?: string;
+};
+
+/**
+ * Select a stable subset from the corpus manifest without mutating it.
+ *
+ * The CLI keeps its historical alphabetical selection when no seed is given.
+ * Dev Quick Start supplies a random seed, which makes each new workspace vary
+ * while keeping the exact selection reproducible from that seed.
+ */
+export const selectMatterNames = ({
+  matterCount,
+  matterNames,
+  selectionSeed,
+}: SelectMatterNamesOptions): string[] => {
+  const uniqueNames = [...new Set(matterNames)].sort((a, b) =>
+    a.localeCompare(b),
+  );
+  if (selectionSeed === undefined) {
+    return uniqueNames.slice(0, matterCount);
+  }
+
+  return uniqueNames
+    .map((name) => ({
+      name,
+      rank: createHash("sha256")
+        .update(selectionSeed)
+        .update("\0")
+        .update(name)
+        .digest("hex"),
+    }))
+    .sort(
+      (a, b) => a.rank.localeCompare(b.rank) || a.name.localeCompare(b.name),
+    )
+    .slice(0, matterCount)
+    .map(({ name }) => name);
+};

--- a/apps/api/scripts/seed-firm-knowledge.ts
+++ b/apps/api/scripts/seed-firm-knowledge.ts
@@ -28,6 +28,8 @@ import { STELLA_API_VERSION_PREFIX } from "@stll/api-contract";
 
 import { sessionCookieNameForDevPort } from "@/api/lib/auth-cookie-name";
 
+import { selectMatterNames } from "./seed-firm-knowledge.logic";
+
 const CORPUS_REPOSITORY = "https://github.com/harveyai/harvey-labs.git";
 // Pinned so every machine seeds identical documents and an upstream change
 // cannot arrive unreviewed. Bump deliberately.
@@ -211,7 +213,13 @@ const runCommand = async (command: string[], options: CommandOptions = {}) => {
 };
 
 /** Blobless sparse clone: only the seeded matters are materialised. */
-const ensureCorpus = async (matterCount: number): Promise<string> => {
+const ensureCorpus = async ({
+  matterCount,
+  selectionSeed,
+}: {
+  matterCount: number;
+  selectionSeed?: string;
+}): Promise<string> => {
   const cache = path.join(process.cwd(), CACHE_DIRECTORY);
   const cloned = await stat(path.join(cache, ".git")).then(
     () => true,
@@ -266,12 +274,15 @@ const ensureCorpus = async (matterCount: number): Promise<string> => {
   if (list.exitCode !== 0) {
     fail(`Could not list corpus matters: ${list.stderr}`);
   }
-  const matters = list.stdout
+  const matterNames = list.stdout
     .split("\n")
     .filter(Boolean)
-    .map((entry) => path.basename(entry))
-    .sort((a, b) => a.localeCompare(b))
-    .slice(0, matterCount);
+    .map((entry) => path.basename(entry));
+  const matters = selectMatterNames({
+    matterCount,
+    matterNames,
+    ...(selectionSeed === undefined ? {} : { selectionSeed }),
+  });
 
   if (matters.length === 0) {
     fail("Corpus listing returned no matters.");
@@ -452,6 +463,8 @@ export type SeedFirmKnowledgeOptions = {
   /** Session cookie header sent with every request; decides the owning org. */
   cookie: string;
   matters: number;
+  /** Stable seed for a randomized corpus subset; omitted keeps CLI ordering. */
+  selectionSeed?: string;
   /** Explicit CLI authorization to replace incomplete same-name matters. */
   replaceIncomplete?: boolean;
   /** Progress sink. The CLI prints; the dev endpoint collects. */
@@ -478,11 +491,15 @@ export const seedFirmKnowledge = async ({
   apiOrigin,
   cookie,
   matters: matterCount,
+  selectionSeed,
   replaceIncomplete = false,
   log = () => undefined,
 }: SeedFirmKnowledgeOptions): Promise<SeedFirmKnowledgeResult> => {
   const api = createApiClient(apiOrigin, cookie);
-  const corpusRoot = await ensureCorpus(matterCount);
+  const corpusRoot = await ensureCorpus({
+    matterCount,
+    ...(selectionSeed === undefined ? {} : { selectionSeed }),
+  });
   const reseeded: string[] = [];
 
   const matterDirectories = (

--- a/apps/api/src/handlers/dev/firm-knowledge-job-store.test.ts
+++ b/apps/api/src/handlers/dev/firm-knowledge-job-store.test.ts
@@ -2,12 +2,20 @@ import { describe, expect, test } from "bun:test";
 
 import { toSafeId } from "@/api/lib/branded-types";
 
-import { FirmKnowledgeJobStore } from "./firm-knowledge-job-store";
+import {
+  FirmKnowledgeJobStore,
+  isReusableFirmKnowledgeJob,
+} from "./firm-knowledge-job-store";
 
 const ORGANIZATION_1 = toSafeId<"organization">("organization-1");
 const ORGANIZATION_2 = toSafeId<"organization">("organization-2");
 const USER_1 = toSafeId<"user">("user-1");
 const USER_2 = toSafeId<"user">("user-2");
+const PARAMETERS = {
+  matters: 10,
+  replaceIncomplete: true,
+  selectionSeed: "quick-start-seed",
+} as const;
 
 describe("FirmKnowledgeJobStore", () => {
   test("retains an owned terminal job while a later job runs", () => {
@@ -21,6 +29,7 @@ describe("FirmKnowledgeJobStore", () => {
     });
     const first = store.create({
       organizationId: ORGANIZATION_1,
+      parameters: PARAMETERS,
       startedAt: "2026-08-16T10:00:00.000Z",
       userId: USER_1,
     });
@@ -33,6 +42,7 @@ describe("FirmKnowledgeJobStore", () => {
     now = 500;
     store.create({
       organizationId: ORGANIZATION_2,
+      parameters: PARAMETERS,
       startedAt: "2026-08-16T10:02:00.000Z",
       userId: USER_1,
     });
@@ -52,6 +62,7 @@ describe("FirmKnowledgeJobStore", () => {
     });
     const first = store.create({
       organizationId: ORGANIZATION_1,
+      parameters: PARAMETERS,
       startedAt: "2026-08-16T10:00:00.000Z",
       userId: USER_1,
     });
@@ -65,10 +76,75 @@ describe("FirmKnowledgeJobStore", () => {
     now = 1001;
     store.create({
       organizationId: ORGANIZATION_2,
+      parameters: PARAMETERS,
       startedAt: "2026-08-16T10:02:00.000Z",
       userId: USER_1,
     });
 
     expect(store.get(first.id)).toBeNull();
+  });
+
+  test("reuses an active job only for the same owner and exact seed parameters", () => {
+    const store = new FirmKnowledgeJobStore({ createId: () => "job-1" });
+    const job = store.create({
+      organizationId: ORGANIZATION_1,
+      parameters: PARAMETERS,
+      startedAt: "2026-08-16T10:00:00.000Z",
+      userId: USER_1,
+    });
+
+    expect(
+      isReusableFirmKnowledgeJob(job, {
+        organizationId: ORGANIZATION_1,
+        parameters: PARAMETERS,
+        userId: USER_1,
+      }),
+    ).toBeTrue();
+
+    const conflictingRequests = [
+      {
+        organizationId: ORGANIZATION_2,
+        parameters: PARAMETERS,
+        userId: USER_1,
+      },
+      {
+        organizationId: ORGANIZATION_1,
+        parameters: PARAMETERS,
+        userId: USER_2,
+      },
+      {
+        organizationId: ORGANIZATION_1,
+        parameters: { ...PARAMETERS, matters: 15 },
+        userId: USER_1,
+      },
+      {
+        organizationId: ORGANIZATION_1,
+        parameters: { ...PARAMETERS, replaceIncomplete: false },
+        userId: USER_1,
+      },
+      {
+        organizationId: ORGANIZATION_1,
+        parameters: { ...PARAMETERS, selectionSeed: "another-seed" },
+        userId: USER_1,
+      },
+    ];
+
+    for (const request of conflictingRequests) {
+      expect(isReusableFirmKnowledgeJob(job, request)).toBeFalse();
+    }
+
+    store.update(job.id, {
+      status: "succeeded",
+      startedAt: "2026-08-16T10:00:00.000Z",
+      finishedAt: "2026-08-16T10:01:00.000Z",
+    });
+    expect(store.get(job.id)?.parameters).toEqual(PARAMETERS);
+    expect(
+      isReusableFirmKnowledgeJob(store.get(job.id) ?? job, {
+        organizationId: ORGANIZATION_1,
+        parameters: PARAMETERS,
+        userId: USER_1,
+      }),
+    ).toBeFalse();
   });
 });

--- a/apps/api/src/handlers/dev/firm-knowledge-job-store.test.ts
+++ b/apps/api/src/handlers/dev/firm-knowledge-job-store.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+
+import { FirmKnowledgeJobStore } from "./firm-knowledge-job-store";
+
+const ORGANIZATION_1 = toSafeId<"organization">("organization-1");
+const ORGANIZATION_2 = toSafeId<"organization">("organization-2");
+const USER_1 = toSafeId<"user">("user-1");
+const USER_2 = toSafeId<"user">("user-2");
+
+describe("FirmKnowledgeJobStore", () => {
+  test("retains an owned terminal job while a later job runs", () => {
+    let now = 0;
+    const ids = ["job-1", "job-2"];
+    const store = new FirmKnowledgeJobStore({
+      createId: () => ids.shift() ?? "unexpected-job",
+      maxRetainedJobs: 2,
+      now: () => now,
+      retentionMs: 1000,
+    });
+    const first = store.create({
+      organizationId: ORGANIZATION_1,
+      startedAt: "2026-08-16T10:00:00.000Z",
+      userId: USER_1,
+    });
+    store.update(first.id, {
+      status: "succeeded",
+      startedAt: "2026-08-16T10:00:00.000Z",
+      finishedAt: "2026-08-16T10:01:00.000Z",
+    });
+
+    now = 500;
+    store.create({
+      organizationId: ORGANIZATION_2,
+      startedAt: "2026-08-16T10:02:00.000Z",
+      userId: USER_1,
+    });
+
+    expect(store.getOwned(first.id, USER_1)?.status.status).toBe("succeeded");
+    expect(store.getOwned(first.id, USER_2)).toBeNull();
+  });
+
+  test("expires terminal jobs before admitting a later job", () => {
+    let now = 0;
+    const ids = ["job-1", "job-2"];
+    const store = new FirmKnowledgeJobStore({
+      createId: () => ids.shift() ?? "unexpected-job",
+      maxRetainedJobs: 1,
+      now: () => now,
+      retentionMs: 1000,
+    });
+    const first = store.create({
+      organizationId: ORGANIZATION_1,
+      startedAt: "2026-08-16T10:00:00.000Z",
+      userId: USER_1,
+    });
+    store.update(first.id, {
+      status: "failed",
+      startedAt: "2026-08-16T10:00:00.000Z",
+      finishedAt: "2026-08-16T10:01:00.000Z",
+      message: "failed",
+    });
+
+    now = 1001;
+    store.create({
+      organizationId: ORGANIZATION_2,
+      startedAt: "2026-08-16T10:02:00.000Z",
+      userId: USER_1,
+    });
+
+    expect(store.get(first.id)).toBeNull();
+  });
+});

--- a/apps/api/src/handlers/dev/firm-knowledge-job-store.ts
+++ b/apps/api/src/handlers/dev/firm-knowledge-job-store.ts
@@ -13,9 +13,16 @@ export type FirmKnowledgeSeedStatus =
       message: string;
     };
 
+export type FirmKnowledgeSeedParameters = {
+  readonly matters: number;
+  readonly replaceIncomplete: boolean;
+  readonly selectionSeed?: string;
+};
+
 export type FirmKnowledgeJob = {
   id: string;
   organizationId: SafeId<"organization">;
+  parameters: FirmKnowledgeSeedParameters;
   status: FirmKnowledgeSeedStatus;
   userId: SafeId<"user">;
 };
@@ -26,7 +33,14 @@ type StoredFirmKnowledgeJob = FirmKnowledgeJob & {
 
 type CreateFirmKnowledgeJobOptions = {
   organizationId: SafeId<"organization">;
+  parameters: FirmKnowledgeSeedParameters;
   startedAt: string;
+  userId: SafeId<"user">;
+};
+
+type ReusableFirmKnowledgeJobOptions = {
+  organizationId: SafeId<"organization">;
+  parameters: FirmKnowledgeSeedParameters;
   userId: SafeId<"user">;
 };
 
@@ -47,6 +61,17 @@ const defaultOptions = {
   retentionMs: DEFAULT_RETENTION_MS,
 } satisfies FirmKnowledgeJobStoreOptions;
 
+export const isReusableFirmKnowledgeJob = (
+  job: FirmKnowledgeJob,
+  { organizationId, parameters, userId }: ReusableFirmKnowledgeJobOptions,
+): boolean =>
+  job.status.status === "running" &&
+  job.organizationId === organizationId &&
+  job.userId === userId &&
+  job.parameters.matters === parameters.matters &&
+  job.parameters.replaceIncomplete === parameters.replaceIncomplete &&
+  job.parameters.selectionSeed === parameters.selectionSeed;
+
 export class FirmKnowledgeJobStore {
   private readonly createId: () => string;
   private readonly jobs = new Map<string, StoredFirmKnowledgeJob>();
@@ -64,6 +89,7 @@ export class FirmKnowledgeJobStore {
 
   create({
     organizationId,
+    parameters,
     startedAt,
     userId,
   }: CreateFirmKnowledgeJobOptions): FirmKnowledgeJob {
@@ -72,6 +98,7 @@ export class FirmKnowledgeJobStore {
     const job = {
       id: this.createId(),
       organizationId,
+      parameters,
       status: { status: "running", startedAt },
       updatedAtMs: now,
       userId,
@@ -97,6 +124,7 @@ export class FirmKnowledgeJobStore {
     this.jobs.set(jobId, {
       id: job.id,
       organizationId: job.organizationId,
+      parameters: job.parameters,
       status,
       updatedAtMs: this.now(),
       userId: job.userId,

--- a/apps/api/src/handlers/dev/firm-knowledge-job-store.ts
+++ b/apps/api/src/handlers/dev/firm-knowledge-job-store.ts
@@ -1,0 +1,127 @@
+import { panic } from "better-result";
+
+import type { SafeId } from "@/api/lib/branded-types";
+
+export type FirmKnowledgeSeedStatus =
+  | { status: "idle" }
+  | { status: "running"; startedAt: string }
+  | { status: "succeeded"; startedAt: string; finishedAt: string }
+  | {
+      status: "failed";
+      startedAt: string;
+      finishedAt: string;
+      message: string;
+    };
+
+export type FirmKnowledgeJob = {
+  id: string;
+  organizationId: SafeId<"organization">;
+  status: FirmKnowledgeSeedStatus;
+  userId: SafeId<"user">;
+};
+
+type StoredFirmKnowledgeJob = FirmKnowledgeJob & {
+  updatedAtMs: number;
+};
+
+type CreateFirmKnowledgeJobOptions = {
+  organizationId: SafeId<"organization">;
+  startedAt: string;
+  userId: SafeId<"user">;
+};
+
+type FirmKnowledgeJobStoreOptions = {
+  createId: () => string;
+  maxRetainedJobs: number;
+  now: () => number;
+  retentionMs: number;
+};
+
+const DEFAULT_MAX_RETAINED_JOBS = 20;
+const DEFAULT_RETENTION_MS = 60 * 60 * 1000;
+
+const defaultOptions = {
+  createId: () => Bun.randomUUIDv7(),
+  maxRetainedJobs: DEFAULT_MAX_RETAINED_JOBS,
+  now: () => Date.now(),
+  retentionMs: DEFAULT_RETENTION_MS,
+} satisfies FirmKnowledgeJobStoreOptions;
+
+export class FirmKnowledgeJobStore {
+  private readonly createId: () => string;
+  private readonly jobs = new Map<string, StoredFirmKnowledgeJob>();
+  private readonly maxRetainedJobs: number;
+  private readonly now: () => number;
+  private readonly retentionMs: number;
+
+  constructor(options: Partial<FirmKnowledgeJobStoreOptions> = {}) {
+    this.createId = options.createId ?? defaultOptions.createId;
+    this.maxRetainedJobs =
+      options.maxRetainedJobs ?? defaultOptions.maxRetainedJobs;
+    this.now = options.now ?? defaultOptions.now;
+    this.retentionMs = options.retentionMs ?? defaultOptions.retentionMs;
+  }
+
+  create({
+    organizationId,
+    startedAt,
+    userId,
+  }: CreateFirmKnowledgeJobOptions): FirmKnowledgeJob {
+    this.prune();
+    const now = this.now();
+    const job = {
+      id: this.createId(),
+      organizationId,
+      status: { status: "running", startedAt },
+      updatedAtMs: now,
+      userId,
+    } satisfies StoredFirmKnowledgeJob;
+    this.jobs.set(job.id, job);
+    return job;
+  }
+
+  get(jobId: string): FirmKnowledgeJob | null {
+    return this.jobs.get(jobId) ?? null;
+  }
+
+  getOwned(jobId: string, userId: SafeId<"user">): FirmKnowledgeJob | null {
+    const job = this.jobs.get(jobId);
+    return job?.userId === userId ? job : null;
+  }
+
+  update(jobId: string, status: FirmKnowledgeSeedStatus): void {
+    const job = this.jobs.get(jobId);
+    if (!job) {
+      panic(`Missing firm-knowledge seed job ${jobId}.`);
+    }
+    this.jobs.set(jobId, {
+      id: job.id,
+      organizationId: job.organizationId,
+      status,
+      updatedAtMs: this.now(),
+      userId: job.userId,
+    });
+  }
+
+  private prune(): void {
+    const expiryCutoff = this.now() - this.retentionMs;
+    for (const [jobId, job] of this.jobs) {
+      if (job.status.status !== "running" && job.updatedAtMs <= expiryCutoff) {
+        this.jobs.delete(jobId);
+      }
+    }
+
+    for (const [jobId, job] of this.jobs) {
+      if (this.jobs.size < this.maxRetainedJobs) {
+        return;
+      }
+      if (job.status.status !== "running") {
+        this.jobs.delete(jobId);
+      }
+    }
+
+    if (this.jobs.size >= this.maxRetainedJobs) {
+      panic("Firm-knowledge seed job retention is full.");
+    }
+  }
+}

--- a/apps/api/src/handlers/dev/routes.ts
+++ b/apps/api/src/handlers/dev/routes.ts
@@ -1,7 +1,10 @@
+import { panic, Result } from "better-result";
 import { eq, inArray } from "drizzle-orm";
 import Elysia, { t } from "elysia";
 import { rmSync } from "node:fs";
 import path from "node:path";
+
+import { STELLA_API_VERSION_PREFIX } from "@stll/api-contract";
 
 import {
   contacts,
@@ -14,7 +17,11 @@ import {
 import { env } from "@/api/env";
 import { authMacro } from "@/api/lib/auth";
 import { readDevOtp } from "@/api/lib/dev-otp-store";
-import { mintDevSeedSession } from "@/api/lib/dev-seed-session-store";
+import {
+  mintDevSeedSession,
+  resolveMemberDevOrganization,
+} from "@/api/lib/dev-seed-session-store";
+import { fetchWithResolvedAddress } from "@/api/lib/safe-outbound-fetch";
 import { rebuildSupplementalSearchIndex } from "@/api/lib/search/index-global";
 import { getSearchProvider } from "@/api/lib/search/provider";
 
@@ -43,6 +50,7 @@ const firmKnowledgeJobs = new FirmKnowledgeJobStore();
 /** Matters to seed from the Dev menu; the CLI's own default. */
 const FIRM_KNOWLEDGE_MATTERS = 15;
 const MAX_FIRM_KNOWLEDGE_MATTERS = 50;
+const MAX_SKILL_SEED_RESPONSE_BYTES = 1024 * 1024;
 
 const INCOMPLETE_MATTER_MODE = {
   replace: "replace",
@@ -56,6 +64,13 @@ const getFirmKnowledgeJobResponse = (job: FirmKnowledgeJob) => ({
   jobId: job.id,
   ...job.status,
 });
+
+const getDevApiOrigin = (port: number | undefined): string => {
+  if (port === undefined) {
+    panic("The dev API server has no listening port.");
+  }
+  return `http://127.0.0.1:${String(port)}`;
+};
 
 export const devRoute = new Elysia({ prefix: "/dev" })
   .use(authMacro)
@@ -115,15 +130,71 @@ export const devRoute = new Elysia({ prefix: "/dev" })
       }),
     },
   )
+  .post(
+    "/seed-skills",
+    async (ctx) => {
+      const organizationId = await resolveMemberDevOrganization(
+        ctx.body.organizationId,
+        ctx.user.id,
+      );
+      if (organizationId === null) {
+        return new Response("Organization membership not found", {
+          status: 403,
+        });
+      }
+
+      const apiOrigin = getDevApiOrigin(ctx.server?.port);
+      const seedSession = await mintDevSeedSession({
+        organizationId,
+        userId: ctx.user.id,
+      });
+      // Pin the socket to loopback as well as constructing a loopback URL, so
+      // the isolated credential cannot leave this process's host.
+      const response = await fetchWithResolvedAddress({
+        addresses: [{ address: "127.0.0.1", family: 4 }],
+        body: "{}",
+        headers: {
+          cookie: seedSession.cookie,
+          "content-type": "application/json",
+        },
+        maxBytes: MAX_SKILL_SEED_RESPONSE_BYTES,
+        method: "POST",
+        timeoutMs: 30_000,
+        url: new URL(`${apiOrigin}${STELLA_API_VERSION_PREFIX}/skills/seed`),
+      });
+      if (Result.isError(response)) {
+        return new Response("Skill seed request failed", { status: 502 });
+      }
+      if (!response.value.ok) {
+        return new Response(new TextDecoder().decode(response.value.body), {
+          status: response.value.status,
+        });
+      }
+      return { ok: true };
+    },
+    {
+      body: t.Object({
+        organizationId: t.String({ minLength: 1, maxLength: 128 }),
+      }),
+    },
+  )
   // Uploads through this same API under a short-lived job session pinned to
   // the initiating user and organization. The corpus must travel the real
   // upload path to get derivatives and extraction.
   .post(
     "/seed-firm-knowledge",
-    (ctx) => {
-      const apiOrigin = new URL(ctx.request.url).origin;
-      const organizationId = ctx.session.activeOrganizationId;
+    async (ctx) => {
+      const apiOrigin = getDevApiOrigin(ctx.server?.port);
       const userId = ctx.user.id;
+      const organizationId =
+        ctx.body?.organizationId === undefined
+          ? ctx.session.activeOrganizationId
+          : await resolveMemberDevOrganization(ctx.body.organizationId, userId);
+      if (organizationId === null) {
+        return new Response("Organization membership not found", {
+          status: 403,
+        });
+      }
 
       if (firmKnowledgeInFlight) {
         const job =
@@ -195,6 +266,9 @@ export const devRoute = new Elysia({ prefix: "/dev" })
           ),
           matters: t.Optional(
             t.Integer({ minimum: 1, maximum: MAX_FIRM_KNOWLEDGE_MATTERS }),
+          ),
+          organizationId: t.Optional(
+            t.String({ minLength: 1, maxLength: 128 }),
           ),
           selectionSeed: t.Optional(t.String({ minLength: 1, maxLength: 128 })),
         }),

--- a/apps/api/src/handlers/dev/routes.ts
+++ b/apps/api/src/handlers/dev/routes.ts
@@ -14,6 +14,7 @@ import {
 import { env } from "@/api/env";
 import { authMacro } from "@/api/lib/auth";
 import { readDevOtp } from "@/api/lib/dev-otp-store";
+import { mintDevSeedSession } from "@/api/lib/dev-seed-session-store";
 import { rebuildSupplementalSearchIndex } from "@/api/lib/search/index-global";
 import { getSearchProvider } from "@/api/lib/search/provider";
 
@@ -33,14 +34,21 @@ type SeedStatus =
       message: string;
     };
 
+const IDLE_SEED_STATUS = { status: "idle" } as const satisfies SeedStatus;
+
 let seedInFlight: Promise<void> | null = null;
-let seedStatus: SeedStatus = { status: "idle" };
+let seedStatus: SeedStatus = IDLE_SEED_STATUS;
 
 let firmKnowledgeInFlight: Promise<void> | null = null;
-let firmKnowledgeStatus: SeedStatus = { status: "idle" };
+let firmKnowledgeStatus: SeedStatus = IDLE_SEED_STATUS;
+// The importer mutates one sparse-checkout cache, so jobs stay serialized;
+// bind status and the active job to its owning organization instead of making
+// another signed-in dev session observe or accidentally join that run.
+let firmKnowledgeOrganizationId: string | null = null;
 
 /** Matters to seed from the Dev menu; the CLI's own default. */
 const FIRM_KNOWLEDGE_MATTERS = 15;
+const MAX_FIRM_KNOWLEDGE_MATTERS = 50;
 
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : "Seed failed";
@@ -89,50 +97,82 @@ export const devRoute = new Elysia({ prefix: "/dev" })
 
     return seedStatus;
   })
-  .get("/seed-firm-knowledge", () => firmKnowledgeStatus)
-  // Uploads through this same API as the caller, using the caller's own cookie:
-  // the corpus must travel the real upload path to get derivatives and
-  // extraction, and running as the signed-in user is what puts the matters in
-  // the organization they are actually looking at.
-  .post("/seed-firm-knowledge", (ctx) => {
-    const cookie = ctx.request.headers.get("cookie");
-    if (!cookie) {
-      return new Response("No session cookie", { status: 401 });
-    }
-    const apiOrigin = new URL(ctx.request.url).origin;
+  .get("/seed-firm-knowledge", (ctx) =>
+    firmKnowledgeOrganizationId === null ||
+    firmKnowledgeOrganizationId === ctx.session.activeOrganizationId
+      ? firmKnowledgeStatus
+      : IDLE_SEED_STATUS,
+  )
+  // Uploads through this same API under a short-lived job session pinned to
+  // the initiating user and organization. The corpus must travel the real
+  // upload path to get derivatives and extraction.
+  .post(
+    "/seed-firm-knowledge",
+    (ctx) => {
+      const apiOrigin = new URL(ctx.request.url).origin;
+      const organizationId = ctx.session.activeOrganizationId;
+      const userId = ctx.user.id;
 
-    if (!firmKnowledgeInFlight) {
-      const startedAt = new Date().toISOString();
-      firmKnowledgeStatus = { status: "running", startedAt };
-      firmKnowledgeInFlight = (async () => {
-        try {
-          const { seedFirmKnowledge } =
-            await import("../../../scripts/seed-firm-knowledge");
-          await seedFirmKnowledge({
-            apiOrigin,
-            cookie,
-            matters: FIRM_KNOWLEDGE_MATTERS,
-          });
-          firmKnowledgeStatus = {
-            status: "succeeded",
-            startedAt,
-            finishedAt: new Date().toISOString(),
-          };
-        } catch (error: unknown) {
-          firmKnowledgeStatus = {
-            status: "failed",
-            startedAt,
-            finishedAt: new Date().toISOString(),
-            message: getErrorMessage(error),
-          };
-        } finally {
-          firmKnowledgeInFlight = null;
-        }
-      })();
-    }
+      if (
+        firmKnowledgeInFlight &&
+        firmKnowledgeOrganizationId !== organizationId
+      ) {
+        return new Response("A firm-knowledge seed is already running", {
+          status: 409,
+        });
+      }
 
-    return firmKnowledgeStatus;
-  })
+      if (!firmKnowledgeInFlight) {
+        const startedAt = new Date().toISOString();
+        firmKnowledgeOrganizationId = organizationId;
+        firmKnowledgeStatus = { status: "running", startedAt };
+        firmKnowledgeInFlight = (async () => {
+          try {
+            const seedSession = await mintDevSeedSession({
+              organizationId,
+              userId,
+            });
+            const { seedFirmKnowledge } =
+              await import("../../../scripts/seed-firm-knowledge");
+            await seedFirmKnowledge({
+              apiOrigin,
+              cookie: seedSession.cookie,
+              matters: ctx.body?.matters ?? FIRM_KNOWLEDGE_MATTERS,
+              ...(ctx.body?.selectionSeed === undefined
+                ? {}
+                : { selectionSeed: ctx.body.selectionSeed }),
+            });
+            firmKnowledgeStatus = {
+              status: "succeeded",
+              startedAt,
+              finishedAt: new Date().toISOString(),
+            };
+          } catch (error: unknown) {
+            firmKnowledgeStatus = {
+              status: "failed",
+              startedAt,
+              finishedAt: new Date().toISOString(),
+              message: getErrorMessage(error),
+            };
+          } finally {
+            firmKnowledgeInFlight = null;
+          }
+        })();
+      }
+
+      return firmKnowledgeStatus;
+    },
+    {
+      body: t.Optional(
+        t.Object({
+          matters: t.Optional(
+            t.Integer({ minimum: 1, maximum: MAX_FIRM_KNOWLEDGE_MATTERS }),
+          ),
+          selectionSeed: t.Optional(t.String({ minLength: 1, maxLength: 128 })),
+        }),
+      ),
+    },
+  )
   .post("/clean", async (ctx) => {
     const orgId = ctx.session.activeOrganizationId;
 

--- a/apps/api/src/handlers/dev/routes.ts
+++ b/apps/api/src/handlers/dev/routes.ts
@@ -50,6 +50,11 @@ let firmKnowledgeOrganizationId: string | null = null;
 const FIRM_KNOWLEDGE_MATTERS = 15;
 const MAX_FIRM_KNOWLEDGE_MATTERS = 50;
 
+const INCOMPLETE_MATTER_MODE = {
+  replace: "replace",
+  skip: "skip",
+} as const;
+
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : "Seed failed";
 
@@ -138,6 +143,9 @@ export const devRoute = new Elysia({ prefix: "/dev" })
               apiOrigin,
               cookie: seedSession.cookie,
               matters: ctx.body?.matters ?? FIRM_KNOWLEDGE_MATTERS,
+              replaceIncomplete:
+                ctx.body?.incompleteMatterMode ===
+                INCOMPLETE_MATTER_MODE.replace,
               ...(ctx.body?.selectionSeed === undefined
                 ? {}
                 : { selectionSeed: ctx.body.selectionSeed }),
@@ -165,6 +173,12 @@ export const devRoute = new Elysia({ prefix: "/dev" })
     {
       body: t.Optional(
         t.Object({
+          incompleteMatterMode: t.Optional(
+            t.Union([
+              t.Literal(INCOMPLETE_MATTER_MODE.skip),
+              t.Literal(INCOMPLETE_MATTER_MODE.replace),
+            ]),
+          ),
           matters: t.Optional(
             t.Integer({ minimum: 1, maximum: MAX_FIRM_KNOWLEDGE_MATTERS }),
           ),

--- a/apps/api/src/handlers/dev/routes.ts
+++ b/apps/api/src/handlers/dev/routes.ts
@@ -18,36 +18,27 @@ import { mintDevSeedSession } from "@/api/lib/dev-seed-session-store";
 import { rebuildSupplementalSearchIndex } from "@/api/lib/search/index-global";
 import { getSearchProvider } from "@/api/lib/search/provider";
 
+import {
+  type FirmKnowledgeJob,
+  FirmKnowledgeJobStore,
+  type FirmKnowledgeSeedStatus,
+} from "./firm-knowledge-job-store";
+
 const VITE_CACHE_DIR = path.resolve(
   import.meta.dir,
   "../../../../../apps/web/node_modules/.vite",
 );
 
-type SeedStatus =
-  | { status: "idle" }
-  | { status: "running"; startedAt: string }
-  | { status: "succeeded"; startedAt: string; finishedAt: string }
-  | {
-      status: "failed";
-      startedAt: string;
-      finishedAt: string;
-      message: string;
-    };
+type SeedStatus = FirmKnowledgeSeedStatus;
 
 const IDLE_SEED_STATUS = { status: "idle" } as const satisfies SeedStatus;
-
-type FirmKnowledgeJob = {
-  id: string;
-  organizationId: string;
-  status: SeedStatus;
-  userId: string;
-};
 
 let seedInFlight: Promise<void> | null = null;
 let seedStatus: SeedStatus = IDLE_SEED_STATUS;
 
 let firmKnowledgeInFlight: Promise<void> | null = null;
-let firmKnowledgeJob: FirmKnowledgeJob | null = null;
+let firmKnowledgeJobId: string | null = null;
+const firmKnowledgeJobs = new FirmKnowledgeJobStore();
 
 /** Matters to seed from the Dev menu; the CLI's own default. */
 const FIRM_KNOWLEDGE_MATTERS = 15;
@@ -112,11 +103,12 @@ export const devRoute = new Elysia({ prefix: "/dev" })
   })
   .get(
     "/seed-firm-knowledge",
-    (ctx) =>
-      firmKnowledgeJob?.id === ctx.query.jobId &&
-      firmKnowledgeJob.userId === ctx.user.id
-        ? getFirmKnowledgeJobResponse(firmKnowledgeJob)
-        : { jobId: ctx.query.jobId, ...IDLE_SEED_STATUS },
+    (ctx) => {
+      const job = firmKnowledgeJobs.getOwned(ctx.query.jobId, ctx.user.id);
+      return job
+        ? getFirmKnowledgeJobResponse(job)
+        : { jobId: ctx.query.jobId, ...IDLE_SEED_STATUS };
+    },
     {
       query: t.Object({
         jobId: t.String({ minLength: 1, maxLength: 128 }),
@@ -134,26 +126,26 @@ export const devRoute = new Elysia({ prefix: "/dev" })
       const userId = ctx.user.id;
 
       if (firmKnowledgeInFlight) {
-        if (
-          firmKnowledgeJob?.organizationId !== organizationId ||
-          firmKnowledgeJob.userId !== userId
-        ) {
+        const job =
+          firmKnowledgeJobId === null
+            ? null
+            : firmKnowledgeJobs.get(firmKnowledgeJobId);
+        if (job?.organizationId !== organizationId || job.userId !== userId) {
           return new Response("A firm-knowledge seed is already running", {
             status: 409,
           });
         }
 
-        return getFirmKnowledgeJobResponse(firmKnowledgeJob);
+        return getFirmKnowledgeJobResponse(job);
       }
 
       const startedAt = new Date().toISOString();
-      const job = {
-        id: Bun.randomUUIDv7(),
+      const job = firmKnowledgeJobs.create({
         organizationId,
-        status: { status: "running", startedAt },
+        startedAt,
         userId,
-      } satisfies FirmKnowledgeJob;
-      firmKnowledgeJob = job;
+      });
+      firmKnowledgeJobId = job.id;
       firmKnowledgeInFlight = (async () => {
         try {
           const seedSession = await mintDevSeedSession({
@@ -172,30 +164,21 @@ export const devRoute = new Elysia({ prefix: "/dev" })
               ? {}
               : { selectionSeed: ctx.body.selectionSeed }),
           });
-          firmKnowledgeJob = {
-            id: job.id,
-            organizationId,
-            status: {
-              status: "succeeded",
-              startedAt,
-              finishedAt: new Date().toISOString(),
-            },
-            userId,
-          } satisfies FirmKnowledgeJob;
+          firmKnowledgeJobs.update(job.id, {
+            status: "succeeded",
+            startedAt,
+            finishedAt: new Date().toISOString(),
+          } satisfies FirmKnowledgeSeedStatus);
         } catch (error: unknown) {
-          firmKnowledgeJob = {
-            id: job.id,
-            organizationId,
-            status: {
-              status: "failed",
-              startedAt,
-              finishedAt: new Date().toISOString(),
-              message: getErrorMessage(error),
-            },
-            userId,
-          } satisfies FirmKnowledgeJob;
+          firmKnowledgeJobs.update(job.id, {
+            status: "failed",
+            startedAt,
+            finishedAt: new Date().toISOString(),
+            message: getErrorMessage(error),
+          } satisfies FirmKnowledgeSeedStatus);
         } finally {
           firmKnowledgeInFlight = null;
+          firmKnowledgeJobId = null;
         }
       })();
 

--- a/apps/api/src/handlers/dev/routes.ts
+++ b/apps/api/src/handlers/dev/routes.ts
@@ -36,15 +36,18 @@ type SeedStatus =
 
 const IDLE_SEED_STATUS = { status: "idle" } as const satisfies SeedStatus;
 
+type FirmKnowledgeJob = {
+  id: string;
+  organizationId: string;
+  status: SeedStatus;
+  userId: string;
+};
+
 let seedInFlight: Promise<void> | null = null;
 let seedStatus: SeedStatus = IDLE_SEED_STATUS;
 
 let firmKnowledgeInFlight: Promise<void> | null = null;
-let firmKnowledgeStatus: SeedStatus = IDLE_SEED_STATUS;
-// The importer mutates one sparse-checkout cache, so jobs stay serialized;
-// bind status and the active job to its owning organization instead of making
-// another signed-in dev session observe or accidentally join that run.
-let firmKnowledgeOrganizationId: string | null = null;
+let firmKnowledgeJob: FirmKnowledgeJob | null = null;
 
 /** Matters to seed from the Dev menu; the CLI's own default. */
 const FIRM_KNOWLEDGE_MATTERS = 15;
@@ -57,6 +60,11 @@ const INCOMPLETE_MATTER_MODE = {
 
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : "Seed failed";
+
+const getFirmKnowledgeJobResponse = (job: FirmKnowledgeJob) => ({
+  jobId: job.id,
+  ...job.status,
+});
 
 export const devRoute = new Elysia({ prefix: "/dev" })
   .use(authMacro)
@@ -102,11 +110,18 @@ export const devRoute = new Elysia({ prefix: "/dev" })
 
     return seedStatus;
   })
-  .get("/seed-firm-knowledge", (ctx) =>
-    firmKnowledgeOrganizationId === null ||
-    firmKnowledgeOrganizationId === ctx.session.activeOrganizationId
-      ? firmKnowledgeStatus
-      : IDLE_SEED_STATUS,
+  .get(
+    "/seed-firm-knowledge",
+    (ctx) =>
+      firmKnowledgeJob?.id === ctx.query.jobId &&
+      firmKnowledgeJob.userId === ctx.user.id
+        ? getFirmKnowledgeJobResponse(firmKnowledgeJob)
+        : { jobId: ctx.query.jobId, ...IDLE_SEED_STATUS },
+    {
+      query: t.Object({
+        jobId: t.String({ minLength: 1, maxLength: 128 }),
+      }),
+    },
   )
   // Uploads through this same API under a short-lived job session pinned to
   // the initiating user and organization. The corpus must travel the real
@@ -118,57 +133,73 @@ export const devRoute = new Elysia({ prefix: "/dev" })
       const organizationId = ctx.session.activeOrganizationId;
       const userId = ctx.user.id;
 
-      if (
-        firmKnowledgeInFlight &&
-        firmKnowledgeOrganizationId !== organizationId
-      ) {
-        return new Response("A firm-knowledge seed is already running", {
-          status: 409,
-        });
+      if (firmKnowledgeInFlight) {
+        if (
+          firmKnowledgeJob?.organizationId !== organizationId ||
+          firmKnowledgeJob.userId !== userId
+        ) {
+          return new Response("A firm-knowledge seed is already running", {
+            status: 409,
+          });
+        }
+
+        return getFirmKnowledgeJobResponse(firmKnowledgeJob);
       }
 
-      if (!firmKnowledgeInFlight) {
-        const startedAt = new Date().toISOString();
-        firmKnowledgeOrganizationId = organizationId;
-        firmKnowledgeStatus = { status: "running", startedAt };
-        firmKnowledgeInFlight = (async () => {
-          try {
-            const seedSession = await mintDevSeedSession({
-              organizationId,
-              userId,
-            });
-            const { seedFirmKnowledge } =
-              await import("../../../scripts/seed-firm-knowledge");
-            await seedFirmKnowledge({
-              apiOrigin,
-              cookie: seedSession.cookie,
-              matters: ctx.body?.matters ?? FIRM_KNOWLEDGE_MATTERS,
-              replaceIncomplete:
-                ctx.body?.incompleteMatterMode ===
-                INCOMPLETE_MATTER_MODE.replace,
-              ...(ctx.body?.selectionSeed === undefined
-                ? {}
-                : { selectionSeed: ctx.body.selectionSeed }),
-            });
-            firmKnowledgeStatus = {
+      const startedAt = new Date().toISOString();
+      const job = {
+        id: Bun.randomUUIDv7(),
+        organizationId,
+        status: { status: "running", startedAt },
+        userId,
+      } satisfies FirmKnowledgeJob;
+      firmKnowledgeJob = job;
+      firmKnowledgeInFlight = (async () => {
+        try {
+          const seedSession = await mintDevSeedSession({
+            organizationId,
+            userId,
+          });
+          const { seedFirmKnowledge } =
+            await import("../../../scripts/seed-firm-knowledge");
+          await seedFirmKnowledge({
+            apiOrigin,
+            cookie: seedSession.cookie,
+            matters: ctx.body?.matters ?? FIRM_KNOWLEDGE_MATTERS,
+            replaceIncomplete:
+              ctx.body?.incompleteMatterMode === INCOMPLETE_MATTER_MODE.replace,
+            ...(ctx.body?.selectionSeed === undefined
+              ? {}
+              : { selectionSeed: ctx.body.selectionSeed }),
+          });
+          firmKnowledgeJob = {
+            id: job.id,
+            organizationId,
+            status: {
               status: "succeeded",
               startedAt,
               finishedAt: new Date().toISOString(),
-            };
-          } catch (error: unknown) {
-            firmKnowledgeStatus = {
+            },
+            userId,
+          } satisfies FirmKnowledgeJob;
+        } catch (error: unknown) {
+          firmKnowledgeJob = {
+            id: job.id,
+            organizationId,
+            status: {
               status: "failed",
               startedAt,
               finishedAt: new Date().toISOString(),
               message: getErrorMessage(error),
-            };
-          } finally {
-            firmKnowledgeInFlight = null;
-          }
-        })();
-      }
+            },
+            userId,
+          } satisfies FirmKnowledgeJob;
+        } finally {
+          firmKnowledgeInFlight = null;
+        }
+      })();
 
-      return firmKnowledgeStatus;
+      return getFirmKnowledgeJobResponse(job);
     },
     {
       body: t.Optional(

--- a/apps/api/src/handlers/dev/routes.ts
+++ b/apps/api/src/handlers/dev/routes.ts
@@ -28,7 +28,9 @@ import { getSearchProvider } from "@/api/lib/search/provider";
 import {
   type FirmKnowledgeJob,
   FirmKnowledgeJobStore,
+  type FirmKnowledgeSeedParameters,
   type FirmKnowledgeSeedStatus,
+  isReusableFirmKnowledgeJob,
 } from "./firm-knowledge-job-store";
 
 const VITE_CACHE_DIR = path.resolve(
@@ -196,12 +198,28 @@ export const devRoute = new Elysia({ prefix: "/dev" })
         });
       }
 
+      const parameters = {
+        matters: ctx.body?.matters ?? FIRM_KNOWLEDGE_MATTERS,
+        replaceIncomplete:
+          ctx.body?.incompleteMatterMode === INCOMPLETE_MATTER_MODE.replace,
+        ...(ctx.body?.selectionSeed === undefined
+          ? {}
+          : { selectionSeed: ctx.body.selectionSeed }),
+      } satisfies FirmKnowledgeSeedParameters;
+
       if (firmKnowledgeInFlight) {
         const job =
           firmKnowledgeJobId === null
             ? null
             : firmKnowledgeJobs.get(firmKnowledgeJobId);
-        if (job?.organizationId !== organizationId || job.userId !== userId) {
+        if (
+          job === null ||
+          !isReusableFirmKnowledgeJob(job, {
+            organizationId,
+            parameters,
+            userId,
+          })
+        ) {
           return new Response("A firm-knowledge seed is already running", {
             status: 409,
           });
@@ -213,6 +231,7 @@ export const devRoute = new Elysia({ prefix: "/dev" })
       const startedAt = new Date().toISOString();
       const job = firmKnowledgeJobs.create({
         organizationId,
+        parameters,
         startedAt,
         userId,
       });
@@ -228,12 +247,11 @@ export const devRoute = new Elysia({ prefix: "/dev" })
           await seedFirmKnowledge({
             apiOrigin,
             cookie: seedSession.cookie,
-            matters: ctx.body?.matters ?? FIRM_KNOWLEDGE_MATTERS,
-            replaceIncomplete:
-              ctx.body?.incompleteMatterMode === INCOMPLETE_MATTER_MODE.replace,
-            ...(ctx.body?.selectionSeed === undefined
+            matters: job.parameters.matters,
+            replaceIncomplete: job.parameters.replaceIncomplete,
+            ...(job.parameters.selectionSeed === undefined
               ? {}
-              : { selectionSeed: ctx.body.selectionSeed }),
+              : { selectionSeed: job.parameters.selectionSeed }),
           });
           firmKnowledgeJobs.update(job.id, {
             status: "succeeded",

--- a/apps/api/src/lib/dev-seed-session-store.ts
+++ b/apps/api/src/lib/dev-seed-session-store.ts
@@ -4,16 +4,36 @@ import { session } from "@/api/db/auth-schema";
 import { rootDb } from "@/api/db/root";
 import { env } from "@/api/env";
 import { sessionCookieName } from "@/api/lib/auth-cookie-name";
+import type { SafeId } from "@/api/lib/branded-types";
+import { parseExternalOrganizationId } from "@/api/lib/safe-id-boundaries";
 
 const DEV_SEED_SESSION_LIFETIME_MS = 2 * 60 * 60 * 1000;
 
 type MintDevSeedSessionOptions = {
-  organizationId: string;
-  userId: string;
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
 };
 
 type DevSeedSession = {
   cookie: string;
+};
+
+export const resolveMemberDevOrganization = async (
+  organizationIdValue: string,
+  userId: SafeId<"user">,
+): Promise<SafeId<"organization"> | null> => {
+  const organizationId = parseExternalOrganizationId(organizationIdValue);
+  if (organizationId === null) {
+    return null;
+  }
+  const membership = await rootDb.query.member.findFirst({
+    columns: { id: true },
+    where: {
+      organizationId: { eq: organizationId },
+      userId: { eq: userId },
+    },
+  });
+  return membership ? organizationId : null;
 };
 
 /**

--- a/apps/api/src/lib/dev-seed-session-store.ts
+++ b/apps/api/src/lib/dev-seed-session-store.ts
@@ -1,0 +1,57 @@
+import { panic } from "better-result";
+
+import { session } from "@/api/db/auth-schema";
+import { rootDb } from "@/api/db/root";
+import { env } from "@/api/env";
+import { sessionCookieName } from "@/api/lib/auth-cookie-name";
+
+const DEV_SEED_SESSION_LIFETIME_MS = 2 * 60 * 60 * 1000;
+
+type MintDevSeedSessionOptions = {
+  organizationId: string;
+  userId: string;
+};
+
+type DevSeedSession = {
+  cookie: string;
+};
+
+/**
+ * Mint an isolated session for the background importer.
+ *
+ * The browser session's active organization is mutable. Reusing that cookie
+ * would let a tab switch redirect later upload requests into another org, so
+ * the job gets its own short-lived session pinned to the server-bound user and
+ * organization captured by the authenticated dev route.
+ */
+export const mintDevSeedSession = async ({
+  organizationId,
+  userId,
+}: MintDevSeedSessionOptions): Promise<DevSeedSession> => {
+  if (!env.isDev) {
+    panic("Dev seed sessions are unavailable outside development.");
+  }
+
+  const now = new Date();
+  const token = Bun.randomUUIDv7();
+  // audit: skip — dev-only ephemeral auth state for a synthetic corpus import
+  await rootDb.insert(session).values({
+    id: `dev-seed-session-${token}`,
+    token,
+    userId,
+    activeOrganizationId: organizationId,
+    expiresAt: new Date(now.getTime() + DEV_SEED_SESSION_LIFETIME_MS),
+    createdAt: now,
+    updatedAt: now,
+    ipAddress: "dev-seed",
+    userAgent: "stella-dev-firm-knowledge-seed",
+  });
+
+  const signature = new Bun.CryptoHasher("sha256", env.BETTER_AUTH_SECRET)
+    .update(token)
+    .digest("base64");
+
+  return {
+    cookie: `${sessionCookieName()}=${token}.${signature}`,
+  };
+};

--- a/apps/web/src/components/dev-sidebar-group.tsx
+++ b/apps/web/src/components/dev-sidebar-group.tsx
@@ -161,10 +161,18 @@ export const DevSidebarGroup = () => {
       return;
     }
 
+    if (start.data instanceof Response) {
+      setSeedingFirmKnowledge(false);
+      stellaToast.add({ title: "Firm-knowledge seed failed", type: "error" });
+      return;
+    }
+
     await pollSeedJob({
       maxPolls: FIRM_KNOWLEDGE_MAX_POLLS,
       poll: async () => {
-        const { data, error } = await api.dev["seed-firm-knowledge"].get();
+        const { data, error } = await api.dev["seed-firm-knowledge"].get({
+          query: { jobId: start.data.jobId },
+        });
         if (error !== null) {
           return null;
         }

--- a/apps/web/src/components/dev-sidebar-group.tsx
+++ b/apps/web/src/components/dev-sidebar-group.tsx
@@ -166,12 +166,13 @@ export const DevSidebarGroup = () => {
       stellaToast.add({ title: "Firm-knowledge seed failed", type: "error" });
       return;
     }
+    const jobId = start.data.jobId;
 
     await pollSeedJob({
       maxPolls: FIRM_KNOWLEDGE_MAX_POLLS,
       poll: async () => {
         const { data, error } = await api.dev["seed-firm-knowledge"].get({
-          query: { jobId: start.data.jobId },
+          query: { jobId },
         });
         if (error !== null) {
           return null;

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -91,6 +91,25 @@
     "createFirstOrganization": "أنشئ مؤسستك الأولى للبدء",
     "createOrganization": "إنشاء مؤسسة",
     "createOrganizationButton": "إنشاء مؤسسة",
+    "devQuickStart": {
+      "button": "بدء سريع للتطوير",
+      "error": {
+        "fallback": "تحقّق من سجل API وحاول مرة أخرى.",
+        "matterImport": "تعذّر بدء استيراد Harvey LAB.",
+        "otpUnavailable": "رمز التحقق الخاص ببيئة التطوير غير متاح.",
+        "title": "فشل البدء السريع للتطوير"
+      },
+      "phase": {
+        "addingSkills": "إضافة المهارات",
+        "authenticating": "تسجيل الدخول",
+        "creatingOrganization": "إنشاء المؤسسة",
+        "startingImport": "بدء استيراد LAB"
+      },
+      "success": {
+        "description": "يجري استيراد 10 ملفات قانونية من Harvey LAB في الخلفية.",
+        "title": "إعداد التطوير جاهز"
+      }
+    },
     "emailPlaceholder": "you@example.com",
     "error": {
       "accountNotLinked": "يسجّل هذا البريد الإلكتروني الدخول بطريقة مختلفة. استخدم طريقة تسجيل الدخول الأصلية أو حاول مرة أخرى.",

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -103,10 +103,10 @@
         "addingSkills": "إضافة المهارات",
         "authenticating": "تسجيل الدخول",
         "creatingOrganization": "إنشاء المؤسسة",
-        "startingImport": "بدء استيراد LAB"
+        "startingImport": "استيراد ملفات LAB القانونية"
       },
       "success": {
-        "description": "يجري استيراد 10 ملفات قانونية من Harvey LAB في الخلفية.",
+        "description": "تم استيراد 10 ملفات قانونية من Harvey LAB؛ وتستمر معالجة المستندات في الخلفية.",
         "title": "إعداد التطوير جاهز"
       }
     },

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -103,10 +103,10 @@
         "addingSkills": "Přidávání dovedností",
         "authenticating": "Přihlašování",
         "creatingOrganization": "Vytváření organizace",
-        "startingImport": "Spouštění importu LAB"
+        "startingImport": "Import spisů z LAB"
       },
       "success": {
-        "description": "Na pozadí se importuje 10 spisů z Harvey LAB.",
+        "description": "Bylo importováno 10 spisů z Harvey LAB; zpracování dokumentů pokračuje na pozadí.",
         "title": "Vývojové nastavení je připravené"
       }
     },

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -91,6 +91,25 @@
     "createFirstOrganization": "Vytvořte svou první organizaci",
     "createOrganization": "Vytvořit organizaci",
     "createOrganizationButton": "Vytvořit organizaci",
+    "devQuickStart": {
+      "button": "Rychlý start pro vývoj",
+      "error": {
+        "fallback": "Zkontrolujte log API a zkuste to znovu.",
+        "matterImport": "Import Harvey LAB se nepodařilo spustit.",
+        "otpUnavailable": "Vývojové OTP nebylo k dispozici.",
+        "title": "Rychlý start pro vývoj se nezdařil"
+      },
+      "phase": {
+        "addingSkills": "Přidávání dovedností",
+        "authenticating": "Přihlašování",
+        "creatingOrganization": "Vytváření organizace",
+        "startingImport": "Spouštění importu LAB"
+      },
+      "success": {
+        "description": "Na pozadí se importuje 10 spisů z Harvey LAB.",
+        "title": "Vývojové nastavení je připravené"
+      }
+    },
     "emailPlaceholder": "vy@priklad.cz",
     "error": {
       "accountNotLinked": "Tento e-mail se přihlašuje jiným způsobem. Použijte svůj původní způsob přihlášení, nebo to zkuste znovu.",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -91,6 +91,25 @@
     "createFirstOrganization": "Erstellen Sie Ihre erste Organisation",
     "createOrganization": "Organisation erstellen",
     "createOrganizationButton": "Organisation erstellen",
+    "devQuickStart": {
+      "button": "Entwicklungs-Schnellstart",
+      "error": {
+        "fallback": "Prüfen Sie das API-Protokoll und versuchen Sie es erneut.",
+        "matterImport": "Der Harvey-LAB-Import konnte nicht gestartet werden.",
+        "otpUnavailable": "Das Entwicklungs-OTP war nicht verfügbar.",
+        "title": "Entwicklungs-Schnellstart fehlgeschlagen"
+      },
+      "phase": {
+        "addingSkills": "Skills werden hinzugefügt",
+        "authenticating": "Anmeldung läuft",
+        "creatingOrganization": "Organisation wird erstellt",
+        "startingImport": "LAB-Import wird gestartet"
+      },
+      "success": {
+        "description": "10 Harvey-LAB-Akten werden im Hintergrund importiert.",
+        "title": "Entwicklungssetup ist bereit"
+      }
+    },
     "emailPlaceholder": "sie@beispiel.de",
     "error": {
       "accountNotLinked": "Diese E-Mail meldet sich auf andere Weise an. Verwenden Sie Ihre ursprüngliche Anmeldemethode oder versuchen Sie es erneut.",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -103,10 +103,10 @@
         "addingSkills": "Skills werden hinzugefügt",
         "authenticating": "Anmeldung läuft",
         "creatingOrganization": "Organisation wird erstellt",
-        "startingImport": "LAB-Import wird gestartet"
+        "startingImport": "LAB-Akten werden importiert"
       },
       "success": {
-        "description": "10 Harvey-LAB-Akten werden im Hintergrund importiert.",
+        "description": "10 Harvey-LAB-Akten wurden importiert; die Dokumentverarbeitung läuft im Hintergrund weiter.",
         "title": "Entwicklungssetup ist bereit"
       }
     },

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -103,10 +103,10 @@
         "addingSkills": "Adding skills",
         "authenticating": "Signing in",
         "creatingOrganization": "Creating organization",
-        "startingImport": "Starting LAB import"
+        "startingImport": "Importing LAB matters"
       },
       "success": {
-        "description": "10 Harvey LAB matters are importing in the background.",
+        "description": "10 Harvey LAB matters were imported; document processing continues in the background.",
         "title": "Dev setup ready"
       }
     },

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -91,6 +91,25 @@
     "createFirstOrganization": "Create your first organization to get started",
     "createOrganization": "Create an organization",
     "createOrganizationButton": "Create organization",
+    "devQuickStart": {
+      "button": "Dev quick start",
+      "error": {
+        "fallback": "Check the API log and try again.",
+        "matterImport": "The Harvey LAB import could not start.",
+        "otpUnavailable": "The development OTP was not available.",
+        "title": "Dev quick start failed"
+      },
+      "phase": {
+        "addingSkills": "Adding skills",
+        "authenticating": "Signing in",
+        "creatingOrganization": "Creating organization",
+        "startingImport": "Starting LAB import"
+      },
+      "success": {
+        "description": "10 Harvey LAB matters are importing in the background.",
+        "title": "Dev setup ready"
+      }
+    },
     "emailPlaceholder": "you@example.com",
     "error": {
       "accountNotLinked": "This email already signs in a different way. Use your original sign-in method, or try again.",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -103,10 +103,10 @@
         "addingSkills": "Añadiendo habilidades",
         "authenticating": "Iniciando sesión",
         "creatingOrganization": "Creando la organización",
-        "startingImport": "Iniciando la importación de LAB"
+        "startingImport": "Importando asuntos de LAB"
       },
       "success": {
-        "description": "Se están importando 10 asuntos de Harvey LAB en segundo plano.",
+        "description": "Se importaron 10 asuntos de Harvey LAB; el procesamiento de documentos continúa en segundo plano.",
         "title": "La configuración de desarrollo está lista"
       }
     },

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -91,6 +91,25 @@
     "createFirstOrganization": "Cree su primera organización para comenzar",
     "createOrganization": "Crear una organización",
     "createOrganizationButton": "Crear organización",
+    "devQuickStart": {
+      "button": "Inicio rápido de desarrollo",
+      "error": {
+        "fallback": "Revisa el registro de la API e inténtalo de nuevo.",
+        "matterImport": "No se pudo iniciar la importación de Harvey LAB.",
+        "otpUnavailable": "El código de un solo uso de desarrollo no estaba disponible.",
+        "title": "El inicio rápido de desarrollo ha fallado"
+      },
+      "phase": {
+        "addingSkills": "Añadiendo habilidades",
+        "authenticating": "Iniciando sesión",
+        "creatingOrganization": "Creando la organización",
+        "startingImport": "Iniciando la importación de LAB"
+      },
+      "success": {
+        "description": "Se están importando 10 asuntos de Harvey LAB en segundo plano.",
+        "title": "La configuración de desarrollo está lista"
+      }
+    },
     "emailPlaceholder": "usted@example.com",
     "error": {
       "accountNotLinked": "Este correo inicia sesión de otra forma. Usa tu método de inicio de sesión original o inténtalo de nuevo.",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -103,10 +103,10 @@
         "addingSkills": "Oskuste lisamine",
         "authenticating": "Sisselogimine",
         "creatingOrganization": "Organisatsiooni loomine",
-        "startingImport": "LAB impordi käivitamine"
+        "startingImport": "LAB toimikute importimine"
       },
       "success": {
-        "description": "Taustal imporditakse 10 Harvey LAB toimikut.",
+        "description": "10 Harvey LAB toimikut imporditi; dokumentide töötlemine jätkub taustal.",
         "title": "Arenduse seadistus on valmis"
       }
     },

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -91,6 +91,25 @@
     "createFirstOrganization": "Alustamiseks looge oma esimene organisatsioon",
     "createOrganization": "Loo organisatsioon",
     "createOrganizationButton": "Loo organisatsioon",
+    "devQuickStart": {
+      "button": "Arenduse kiirkäivitus",
+      "error": {
+        "fallback": "Kontrollige API logi ja proovige uuesti.",
+        "matterImport": "Harvey LAB impordi käivitamine ebaõnnestus.",
+        "otpUnavailable": "Arenduskeskkonna ühekordne kood ei olnud saadaval.",
+        "title": "Arenduse kiirkäivitus ebaõnnestus"
+      },
+      "phase": {
+        "addingSkills": "Oskuste lisamine",
+        "authenticating": "Sisselogimine",
+        "creatingOrganization": "Organisatsiooni loomine",
+        "startingImport": "LAB impordi käivitamine"
+      },
+      "success": {
+        "description": "Taustal imporditakse 10 Harvey LAB toimikut.",
+        "title": "Arenduse seadistus on valmis"
+      }
+    },
     "emailPlaceholder": "teie@example.com",
     "error": {
       "accountNotLinked": "See e-post logib sisse teisiti. Kasutage oma algset sisselogimisviisi või proovige uuesti.",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -91,6 +91,25 @@
     "createFirstOrganization": "Créez votre première organisation pour commencer",
     "createOrganization": "Créer une organisation",
     "createOrganizationButton": "Créer l'organisation",
+    "devQuickStart": {
+      "button": "Démarrage rapide du développement",
+      "error": {
+        "fallback": "Consultez le journal de l’API et réessayez.",
+        "matterImport": "L’importation de Harvey LAB n’a pas pu démarrer.",
+        "otpUnavailable": "Le code à usage unique de développement n’était pas disponible.",
+        "title": "Échec du démarrage rapide du développement"
+      },
+      "phase": {
+        "addingSkills": "Ajout des compétences",
+        "authenticating": "Connexion en cours",
+        "creatingOrganization": "Création de l’organisation",
+        "startingImport": "Démarrage de l’importation LAB"
+      },
+      "success": {
+        "description": "10 dossiers Harvey LAB sont en cours d’importation en arrière-plan.",
+        "title": "La configuration de développement est prête"
+      }
+    },
     "emailPlaceholder": "vous@example.com",
     "error": {
       "accountNotLinked": "Cette adresse e-mail se connecte d'une autre manière. Utilisez votre méthode de connexion d'origine ou réessayez.",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -103,10 +103,10 @@
         "addingSkills": "Ajout des compétences",
         "authenticating": "Connexion en cours",
         "creatingOrganization": "Création de l’organisation",
-        "startingImport": "Démarrage de l’importation LAB"
+        "startingImport": "Importation des dossiers LAB"
       },
       "success": {
-        "description": "10 dossiers Harvey LAB sont en cours d’importation en arrière-plan.",
+        "description": "10 dossiers Harvey LAB ont été importés ; le traitement des documents se poursuit en arrière-plan.",
         "title": "La configuration de développement est prête"
       }
     },

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -91,6 +91,25 @@
     "createFirstOrganization": "Hozza létre első szervezetét a kezdéshez",
     "createOrganization": "Szervezet létrehozása",
     "createOrganizationButton": "Szervezet létrehozása",
+    "devQuickStart": {
+      "button": "Fejlesztői gyorsindítás",
+      "error": {
+        "fallback": "Ellenőrizze az API naplóját, majd próbálja újra.",
+        "matterImport": "A Harvey LAB importálása nem indult el.",
+        "otpUnavailable": "A fejlesztői egyszer használatos kód nem volt elérhető.",
+        "title": "A fejlesztői gyorsindítás sikertelen"
+      },
+      "phase": {
+        "addingSkills": "Készségek hozzáadása",
+        "authenticating": "Bejelentkezés",
+        "creatingOrganization": "Szervezet létrehozása",
+        "startingImport": "LAB-import indítása"
+      },
+      "success": {
+        "description": "10 Harvey LAB-ügy importálása folyamatban van a háttérben.",
+        "title": "A fejlesztői beállítás elkészült"
+      }
+    },
     "emailPlaceholder": "te@example.com",
     "error": {
       "accountNotLinked": "Ez az e-mail-cím másképp jelentkezik be. Használja az eredeti bejelentkezési módot, vagy próbálja újra.",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -103,10 +103,10 @@
         "addingSkills": "Készségek hozzáadása",
         "authenticating": "Bejelentkezés",
         "creatingOrganization": "Szervezet létrehozása",
-        "startingImport": "LAB-import indítása"
+        "startingImport": "LAB-ügyek importálása"
       },
       "success": {
-        "description": "10 Harvey LAB-ügy importálása folyamatban van a háttérben.",
+        "description": "10 Harvey LAB-ügy importálása befejeződött; a dokumentumfeldolgozás a háttérben folytatódik.",
         "title": "A fejlesztői beállítás elkészült"
       }
     },

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -91,6 +91,25 @@
     "createFirstOrganization": "Sukurkite savo pirmąją organizaciją",
     "createOrganization": "Sukurti organizaciją",
     "createOrganizationButton": "Sukurti organizaciją",
+    "devQuickStart": {
+      "button": "Spartusis kūrimo paleidimas",
+      "error": {
+        "fallback": "Patikrinkite API žurnalą ir bandykite dar kartą.",
+        "matterImport": "Nepavyko pradėti „Harvey LAB“ importavimo.",
+        "otpUnavailable": "Kūrimo aplinkos vienkartinis kodas nebuvo pasiekiamas.",
+        "title": "Spartusis kūrimo paleidimas nepavyko"
+      },
+      "phase": {
+        "addingSkills": "Pridedami įgūdžiai",
+        "authenticating": "Prisijungiama",
+        "creatingOrganization": "Kuriama organizacija",
+        "startingImport": "Pradedamas LAB importavimas"
+      },
+      "success": {
+        "description": "Fone importuojama 10 „Harvey LAB“ bylų.",
+        "title": "Kūrimo sąranka paruošta"
+      }
+    },
     "emailPlaceholder": "jus@example.com",
     "error": {
       "accountNotLinked": "Šis el. paštas prisijungia kitu būdu. Naudokite pradinį prisijungimo būdą arba bandykite dar kartą.",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -103,10 +103,10 @@
         "addingSkills": "Pridedami įgūdžiai",
         "authenticating": "Prisijungiama",
         "creatingOrganization": "Kuriama organizacija",
-        "startingImport": "Pradedamas LAB importavimas"
+        "startingImport": "Importuojamos LAB bylos"
       },
       "success": {
-        "description": "Fone importuojama 10 „Harvey LAB“ bylų.",
+        "description": "Importuota 10 „Harvey LAB“ bylų; dokumentai toliau apdorojami fone.",
         "title": "Kūrimo sąranka paruošta"
       }
     },

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -91,6 +91,25 @@
     "createFirstOrganization": "Izveidojiet savu pirmo organizāciju, lai sāktu darbu",
     "createOrganization": "Izveidot organizāciju",
     "createOrganizationButton": "Izveidot organizāciju",
+    "devQuickStart": {
+      "button": "Ātrā izstrādes sākšana",
+      "error": {
+        "fallback": "Pārbaudiet API žurnālu un mēģiniet vēlreiz.",
+        "matterImport": "Neizdevās sākt Harvey LAB importēšanu.",
+        "otpUnavailable": "Izstrādes vides vienreizējais kods nebija pieejams.",
+        "title": "Ātrā izstrādes sākšana neizdevās"
+      },
+      "phase": {
+        "addingSkills": "Prasmju pievienošana",
+        "authenticating": "Pierakstīšanās",
+        "creatingOrganization": "Organizācijas izveide",
+        "startingImport": "LAB importēšanas sākšana"
+      },
+      "success": {
+        "description": "Fonā tiek importētas 10 Harvey LAB lietas.",
+        "title": "Izstrādes iestatīšana ir pabeigta"
+      }
+    },
     "emailPlaceholder": "jus@example.com",
     "error": {
       "accountNotLinked": "Šis e-pasts pieslēdzas citādi. Izmantojiet savu sākotnējo pieslēgšanās veidu vai mēģiniet vēlreiz.",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -103,10 +103,10 @@
         "addingSkills": "Prasmju pievienošana",
         "authenticating": "Pierakstīšanās",
         "creatingOrganization": "Organizācijas izveide",
-        "startingImport": "LAB importēšanas sākšana"
+        "startingImport": "LAB lietu importēšana"
       },
       "success": {
-        "description": "Fonā tiek importētas 10 Harvey LAB lietas.",
+        "description": "Importētas 10 Harvey LAB lietas; dokumentu apstrāde turpinās fonā.",
         "title": "Izstrādes iestatīšana ir pabeigta"
       }
     },

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -106,10 +106,10 @@ type Messages = {
         "addingSkills": "Adding skills";
         "authenticating": "Signing in";
         "creatingOrganization": "Creating organization";
-        "startingImport": "Starting LAB import";
+        "startingImport": "Importing LAB matters";
       };
       "success": {
-        "description": "10 Harvey LAB matters are importing in the background.";
+        "description": "10 Harvey LAB matters were imported; document processing continues in the background.";
         "title": "Dev setup ready";
       };
     };

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -94,6 +94,25 @@ type Messages = {
     "createFirstOrganization": "Create your first organization to get started";
     "createOrganization": "Create an organization";
     "createOrganizationButton": "Create organization";
+    "devQuickStart": {
+      "button": "Dev quick start";
+      "error": {
+        "fallback": "Check the API log and try again.";
+        "matterImport": "The Harvey LAB import could not start.";
+        "otpUnavailable": "The development OTP was not available.";
+        "title": "Dev quick start failed";
+      };
+      "phase": {
+        "addingSkills": "Adding skills";
+        "authenticating": "Signing in";
+        "creatingOrganization": "Creating organization";
+        "startingImport": "Starting LAB import";
+      };
+      "success": {
+        "description": "10 Harvey LAB matters are importing in the background.";
+        "title": "Dev setup ready";
+      };
+    };
     "emailPlaceholder": "you@example.com";
     "error": {
       "accountNotLinked": "This email already signs in a different way. Use your original sign-in method, or try again.";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -91,6 +91,25 @@
     "createFirstOrganization": "Utwórz swoją pierwszą organizację, aby rozpocząć",
     "createOrganization": "Utwórz organizację",
     "createOrganizationButton": "Utwórz organizację",
+    "devQuickStart": {
+      "button": "Szybki start deweloperski",
+      "error": {
+        "fallback": "Sprawdź dziennik API i spróbuj ponownie.",
+        "matterImport": "Nie udało się rozpocząć importu Harvey LAB.",
+        "otpUnavailable": "Deweloperski kod jednorazowy nie był dostępny.",
+        "title": "Szybki start deweloperski nie powiódł się"
+      },
+      "phase": {
+        "addingSkills": "Dodawanie umiejętności",
+        "authenticating": "Logowanie",
+        "creatingOrganization": "Tworzenie organizacji",
+        "startingImport": "Uruchamianie importu LAB"
+      },
+      "success": {
+        "description": "W tle trwa importowanie 10 spraw z Harvey LAB.",
+        "title": "Konfiguracja deweloperska jest gotowa"
+      }
+    },
     "emailPlaceholder": "ty@example.com",
     "error": {
       "accountNotLinked": "Ten e-mail loguje się w inny sposób. Użyj swojej pierwotnej metody logowania lub spróbuj ponownie.",

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -103,10 +103,10 @@
         "addingSkills": "Dodawanie umiejętności",
         "authenticating": "Logowanie",
         "creatingOrganization": "Tworzenie organizacji",
-        "startingImport": "Uruchamianie importu LAB"
+        "startingImport": "Importowanie spraw z LAB"
       },
       "success": {
-        "description": "W tle trwa importowanie 10 spraw z Harvey LAB.",
+        "description": "Zaimportowano 10 spraw z Harvey LAB; przetwarzanie dokumentów trwa w tle.",
         "title": "Konfiguracja deweloperska jest gotowa"
       }
     },

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -91,6 +91,25 @@
     "createFirstOrganization": "Crie sua primeira organização para começar",
     "createOrganization": "Criar uma organização",
     "createOrganizationButton": "Criar organização",
+    "devQuickStart": {
+      "button": "Início rápido de desenvolvimento",
+      "error": {
+        "fallback": "Verifique o log da API e tente novamente.",
+        "matterImport": "Não foi possível iniciar a importação do Harvey LAB.",
+        "otpUnavailable": "O código de uso único de desenvolvimento não estava disponível.",
+        "title": "Falha no início rápido de desenvolvimento"
+      },
+      "phase": {
+        "addingSkills": "Adicionando habilidades",
+        "authenticating": "Entrando",
+        "creatingOrganization": "Criando a organização",
+        "startingImport": "Iniciando a importação do LAB"
+      },
+      "success": {
+        "description": "10 casos do Harvey LAB estão sendo importados em segundo plano.",
+        "title": "A configuração de desenvolvimento está pronta"
+      }
+    },
     "emailPlaceholder": "você@exemplo.com",
     "error": {
       "accountNotLinked": "Este e-mail faz login de outra forma. Use seu método de login original ou tente novamente.",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -103,10 +103,10 @@
         "addingSkills": "Adicionando habilidades",
         "authenticating": "Entrando",
         "creatingOrganization": "Criando a organização",
-        "startingImport": "Iniciando a importação do LAB"
+        "startingImport": "Importando casos do LAB"
       },
       "success": {
-        "description": "10 casos do Harvey LAB estão sendo importados em segundo plano.",
+        "description": "10 casos do Harvey LAB foram importados; o processamento dos documentos continua em segundo plano.",
         "title": "A configuração de desenvolvimento está pronta"
       }
     },

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -103,10 +103,10 @@
         "addingSkills": "Pridávanie zručností",
         "authenticating": "Prihlasovanie",
         "creatingOrganization": "Vytváranie organizácie",
-        "startingImport": "Spúšťanie importu LAB"
+        "startingImport": "Import spisov z LAB"
       },
       "success": {
-        "description": "Na pozadí sa importuje 10 spisov z Harvey LAB.",
+        "description": "Importovalo sa 10 spisov z Harvey LAB; spracovanie dokumentov pokračuje na pozadí.",
         "title": "Vývojové nastavenie je pripravené"
       }
     },

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -91,6 +91,25 @@
     "createFirstOrganization": "Vytvorte svoju prvú organizáciu",
     "createOrganization": "Vytvoriť organizáciu",
     "createOrganizationButton": "Vytvoriť organizáciu",
+    "devQuickStart": {
+      "button": "Rýchly štart pre vývoj",
+      "error": {
+        "fallback": "Skontrolujte log API a skúste to znova.",
+        "matterImport": "Import Harvey LAB sa nepodarilo spustiť.",
+        "otpUnavailable": "Vývojové OTP nebolo k dispozícii.",
+        "title": "Rýchly štart pre vývoj sa nepodaril"
+      },
+      "phase": {
+        "addingSkills": "Pridávanie zručností",
+        "authenticating": "Prihlasovanie",
+        "creatingOrganization": "Vytváranie organizácie",
+        "startingImport": "Spúšťanie importu LAB"
+      },
+      "success": {
+        "description": "Na pozadí sa importuje 10 spisov z Harvey LAB.",
+        "title": "Vývojové nastavenie je pripravené"
+      }
+    },
     "emailPlaceholder": "vy@example.com",
     "error": {
       "accountNotLinked": "Tento e-mail sa prihlasuje iným spôsobom. Použite svoj pôvodný spôsob prihlásenia alebo to skúste znova.",

--- a/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
+++ b/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
@@ -27,6 +27,9 @@ import {
 } from "./dev-quick-start.logic";
 
 const QUICK_START_MATTER_COUNT = 10;
+const MATTER_IMPORT_POLL_INTERVAL_MS = 1000;
+const MATTER_IMPORT_MAX_POLLS = 15 * 60;
+const QUICK_START_INCOMPLETE_MATTER_MODE = "replace";
 
 const PHASE_LABEL_KEYS = {
   [DEV_QUICK_START_PHASE.authenticate]:
@@ -125,8 +128,51 @@ const seedSkills = async () => {
   }
 };
 
+const waitForMatterImport = async () => {
+  for (let poll = 0; poll < MATTER_IMPORT_MAX_POLLS; poll++) {
+    // oxlint-disable-next-line no-await-in-loop -- each status probe must follow the prior poll interval
+    const { data, error } = await api.dev["seed-firm-knowledge"].get();
+    if (error !== null || data instanceof Response) {
+      throw new DevQuickStartError({
+        code: DEV_QUICK_START_ERROR.matterImport,
+        message: "The Harvey LAB import status was unavailable.",
+      });
+    }
+
+    switch (data.status) {
+      case "failed":
+        throw new DevQuickStartError({
+          code: DEV_QUICK_START_ERROR.matterImport,
+          message: data.message,
+        });
+      case "idle":
+        throw new DevQuickStartError({
+          code: DEV_QUICK_START_ERROR.matterImport,
+          message: "The Harvey LAB import stopped before completion.",
+        });
+      case "running":
+        break;
+      case "succeeded":
+        return undefined;
+      default:
+        return data satisfies never;
+    }
+
+    // oxlint-disable-next-line no-await-in-loop -- polling waits between sequential status probes
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, MATTER_IMPORT_POLL_INTERVAL_MS);
+    });
+  }
+
+  throw new DevQuickStartError({
+    code: DEV_QUICK_START_ERROR.matterImport,
+    message: "The Harvey LAB import did not finish before the timeout.",
+  });
+};
+
 const seedMatters = async ({ selectionSeed }: DevQuickStartIdentity) => {
   const response = await api.dev["seed-firm-knowledge"].post({
+    incompleteMatterMode: QUICK_START_INCOMPLETE_MATTER_MODE,
     matters: QUICK_START_MATTER_COUNT,
     selectionSeed,
   });
@@ -136,6 +182,8 @@ const seedMatters = async ({ selectionSeed }: DevQuickStartIdentity) => {
       message: "The Harvey LAB import could not start.",
     });
   }
+
+  await waitForMatterImport();
 };
 
 export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {

--- a/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
+++ b/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { Result, TaggedError } from "better-result";
 import { useTranslations } from "use-intl";
@@ -19,6 +19,8 @@ import { userErrorFromThrown } from "@/lib/errors/user-safe";
 
 import {
   DEV_QUICK_START_PHASE,
+  createDevQuickStartIdentity,
+  type DevQuickStartAttempt,
   type DevQuickStartIdentity,
   type DevQuickStartPhase,
   runDevQuickStart,
@@ -86,16 +88,30 @@ const createOrganization = async ({
   organizationName,
   organizationSlug,
 }: DevQuickStartIdentity) => {
-  const created = await authClient.organization.create({
-    name: organizationName,
-    slug: organizationSlug,
-  });
-  if (created.error) {
-    throw toAuthClientError(created.error);
+  const listed = await authClient.organization.list();
+  if (listed.error) {
+    throw toAuthClientError(listed.error);
   }
 
+  const existing = listed.data.find(({ slug }) => slug === organizationSlug);
+  const organizationId = await (async () => {
+    if (existing) {
+      return existing.id;
+    }
+
+    const created = await authClient.organization.create({
+      name: organizationName,
+      slug: organizationSlug,
+    });
+    if (created.error) {
+      throw toAuthClientError(created.error);
+    }
+
+    return created.data.id;
+  })();
+
   const active = await authClient.organization.setActive({
-    organizationId: created.data.id,
+    organizationId,
   });
   if (active.error) {
     throw toAuthClientError(active.error);
@@ -126,6 +142,7 @@ export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {
   const t = useTranslations();
   const analytics = useAnalytics();
   const invalidateSession = useInvalidateSession();
+  const attemptRef = useRef<DevQuickStartAttempt | null>(null);
   const [phase, setPhase] = useState<DevQuickStartPhase | null>(null);
 
   const handleQuickStart = async () => {
@@ -133,13 +150,27 @@ export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {
       return;
     }
 
+    const attempt =
+      attemptRef.current ??
+      ({
+        completedPhase: null,
+        identity: createDevQuickStartIdentity(crypto.randomUUID()),
+      } satisfies DevQuickStartAttempt);
+    attemptRef.current = attempt;
+
     const result = await Result.tryPromise({
       try: async () => {
         await runDevQuickStart({
+          attempt,
           authenticate,
           createOrganization,
           onPhase: setPhase,
-          randomId: crypto.randomUUID(),
+          onPhaseCompleted: (completedPhase) => {
+            attemptRef.current = {
+              completedPhase,
+              identity: attempt.identity,
+            };
+          },
           seedMatters,
           seedSkills,
         });

--- a/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
+++ b/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react";
 
 import { Result, TaggedError } from "better-result";
+import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { stellaToast } from "@stll/ui/components/toast";
 
 import { useInvalidateSession } from "@/hooks/use-invalidate-session";
+import type { TranslationKey } from "@/i18n/types";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { authClient } from "@/lib/auth";
@@ -24,14 +26,31 @@ import {
 
 const QUICK_START_MATTER_COUNT = 10;
 
-const PHASE_LABELS = {
-  [DEV_QUICK_START_PHASE.authenticate]: "SIGNING IN",
-  [DEV_QUICK_START_PHASE.organization]: "CREATING WORKSPACE",
-  [DEV_QUICK_START_PHASE.skills]: "ADDING SKILLS",
-  [DEV_QUICK_START_PHASE.matters]: "STARTING LAB IMPORT",
-} as const satisfies Record<DevQuickStartPhase, string>;
+const PHASE_LABEL_KEYS = {
+  [DEV_QUICK_START_PHASE.authenticate]:
+    "auth.devQuickStart.phase.authenticating",
+  [DEV_QUICK_START_PHASE.organization]:
+    "auth.devQuickStart.phase.creatingOrganization",
+  [DEV_QUICK_START_PHASE.skills]: "auth.devQuickStart.phase.addingSkills",
+  [DEV_QUICK_START_PHASE.matters]: "auth.devQuickStart.phase.startingImport",
+} as const satisfies Record<DevQuickStartPhase, TranslationKey>;
+
+const DEV_QUICK_START_ERROR = {
+  matterImport: "matterImport",
+  otpUnavailable: "otpUnavailable",
+} as const;
+
+type DevQuickStartErrorCode =
+  (typeof DEV_QUICK_START_ERROR)[keyof typeof DEV_QUICK_START_ERROR];
+
+const ERROR_MESSAGE_KEYS = {
+  [DEV_QUICK_START_ERROR.matterImport]: "auth.devQuickStart.error.matterImport",
+  [DEV_QUICK_START_ERROR.otpUnavailable]:
+    "auth.devQuickStart.error.otpUnavailable",
+} as const satisfies Record<DevQuickStartErrorCode, TranslationKey>;
 
 class DevQuickStartError extends TaggedError("DevQuickStartError")<{
+  code: DevQuickStartErrorCode;
   message: string;
 }> {}
 
@@ -46,7 +65,10 @@ const authenticate = async ({ email }: DevQuickStartIdentity) => {
 
   const otp = await fetchDevOtp(email);
   if (otp === null) {
-    throw new DevQuickStartError({ message: "Dev OTP was not available." });
+    throw new DevQuickStartError({
+      code: DEV_QUICK_START_ERROR.otpUnavailable,
+      message: "Dev OTP was not available.",
+    });
   }
 
   const signedIn = await authClient.signIn.emailOtp({ email, otp });
@@ -94,12 +116,14 @@ const seedMatters = async ({ selectionSeed }: DevQuickStartIdentity) => {
   });
   if (response.error) {
     throw new DevQuickStartError({
+      code: DEV_QUICK_START_ERROR.matterImport,
       message: "The Harvey LAB import could not start.",
     });
   }
 };
 
 export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {
+  const t = useTranslations();
   const analytics = useAnalytics();
   const invalidateSession = useInvalidateSession();
   const [phase, setPhase] = useState<DevQuickStartPhase | null>(null);
@@ -109,35 +133,40 @@ export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {
       return;
     }
 
-    const result = await Result.tryPromise(async () => {
-      await runDevQuickStart({
-        authenticate,
-        createOrganization,
-        onPhase: setPhase,
-        randomId: crypto.randomUUID(),
-        seedMatters,
-        seedSkills,
-      });
-      await invalidateSession.mutateAsync();
+    const result = await Result.tryPromise({
+      try: async () => {
+        await runDevQuickStart({
+          authenticate,
+          createOrganization,
+          onPhase: setPhase,
+          randomId: crypto.randomUUID(),
+          seedMatters,
+          seedSkills,
+        });
+        await invalidateSession.mutateAsync();
+      },
+      catch: (cause) => cause,
     });
 
     if (Result.isError(result)) {
       setPhase(null);
       analytics.captureError(result.error);
       stellaToast.add({
-        title: "Dev quick start failed",
-        description: userErrorFromThrown(
-          result.error,
-          "Check the API log and try again.",
-        ),
+        title: t("auth.devQuickStart.error.title"),
+        description: DevQuickStartError.is(result.error)
+          ? t(ERROR_MESSAGE_KEYS[result.error.code])
+          : userErrorFromThrown(
+              result.error,
+              t("auth.devQuickStart.error.fallback"),
+            ),
         type: "error",
       });
       return;
     }
 
     stellaToast.add({
-      title: "Dev workspace ready",
-      description: "10 Harvey LAB matters are importing in the background.",
+      title: t("auth.devQuickStart.success.title"),
+      description: t("auth.devQuickStart.success.description"),
       type: "success",
     });
     window.location.assign(redirectTo);
@@ -145,7 +174,7 @@ export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {
 
   return (
     <Button
-      className="w-full"
+      className="w-full uppercase"
       disabled={phase !== null}
       loading={phase !== null}
       onClick={() => {
@@ -155,7 +184,9 @@ export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {
       type="button"
       variant="outline"
     >
-      {phase === null ? "DEV QUICK START" : PHASE_LABELS[phase]}
+      {phase === null
+        ? t("auth.devQuickStart.button")
+        : t(PHASE_LABEL_KEYS[phase])}
     </Button>
   );
 };

--- a/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
+++ b/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
@@ -128,46 +128,46 @@ const seedSkills = async () => {
   }
 };
 
-const waitForMatterImport = async () => {
-  for (let poll = 0; poll < MATTER_IMPORT_MAX_POLLS; poll++) {
-    // oxlint-disable-next-line no-await-in-loop -- each status probe must follow the prior poll interval
-    const { data, error } = await api.dev["seed-firm-knowledge"].get();
-    if (error !== null || data instanceof Response) {
-      throw new DevQuickStartError({
-        code: DEV_QUICK_START_ERROR.matterImport,
-        message: "The Harvey LAB import status was unavailable.",
-      });
-    }
-
-    switch (data.status) {
-      case "failed":
-        throw new DevQuickStartError({
-          code: DEV_QUICK_START_ERROR.matterImport,
-          message: data.message,
-        });
-      case "idle":
-        throw new DevQuickStartError({
-          code: DEV_QUICK_START_ERROR.matterImport,
-          message: "The Harvey LAB import stopped before completion.",
-        });
-      case "running":
-        break;
-      case "succeeded":
-        return undefined;
-      default:
-        return data satisfies never;
-    }
-
-    // oxlint-disable-next-line no-await-in-loop -- polling waits between sequential status probes
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, MATTER_IMPORT_POLL_INTERVAL_MS);
+const waitForMatterImport = async (
+  remainingPolls = MATTER_IMPORT_MAX_POLLS,
+): Promise<void> => {
+  if (remainingPolls === 0) {
+    throw new DevQuickStartError({
+      code: DEV_QUICK_START_ERROR.matterImport,
+      message: "The Harvey LAB import did not finish before the timeout.",
     });
   }
 
-  throw new DevQuickStartError({
-    code: DEV_QUICK_START_ERROR.matterImport,
-    message: "The Harvey LAB import did not finish before the timeout.",
-  });
+  const { data, error } = await api.dev["seed-firm-knowledge"].get();
+  if (error !== null || data instanceof Response) {
+    throw new DevQuickStartError({
+      code: DEV_QUICK_START_ERROR.matterImport,
+      message: "The Harvey LAB import status was unavailable.",
+    });
+  }
+
+  switch (data.status) {
+    case "failed":
+      throw new DevQuickStartError({
+        code: DEV_QUICK_START_ERROR.matterImport,
+        message: data.message,
+      });
+    case "idle":
+      throw new DevQuickStartError({
+        code: DEV_QUICK_START_ERROR.matterImport,
+        message: "The Harvey LAB import stopped before completion.",
+      });
+    case "running":
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, MATTER_IMPORT_POLL_INTERVAL_MS);
+      });
+      await waitForMatterImport(remainingPolls - 1);
+      return undefined;
+    case "succeeded":
+      return undefined;
+    default:
+      return data satisfies never;
+  }
 };
 
 const seedMatters = async ({ selectionSeed }: DevQuickStartIdentity) => {

--- a/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
+++ b/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
@@ -224,70 +224,76 @@ export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {
   const navigate = useNavigate();
   const invalidateSession = useInvalidateSession();
   const attemptRef = useRef<DevQuickStartAttempt | null>(null);
+  const runningRef = useRef(false);
   const [phase, setPhase] = useState<DevQuickStartPhase | null>(null);
 
   const handleQuickStart = async () => {
-    if (phase !== null) {
+    if (runningRef.current) {
       return;
     }
+    runningRef.current = true;
 
-    const attempt =
-      attemptRef.current ??
-      readDevQuickStartAttempt() ??
-      ({
-        completedPhase: null,
-        identity: createDevQuickStartIdentity(crypto.randomUUID()),
-        organizationId: null,
-      } satisfies DevQuickStartAttempt);
-    attemptRef.current = attempt;
-    writeDevQuickStartAttempt(attempt);
-    setPhase(DEV_QUICK_START_PHASE.authenticate);
+    try {
+      const attempt =
+        attemptRef.current ??
+        readDevQuickStartAttempt() ??
+        ({
+          completedPhase: null,
+          identity: createDevQuickStartIdentity(crypto.randomUUID()),
+          organizationId: null,
+        } satisfies DevQuickStartAttempt);
+      attemptRef.current = attempt;
+      writeDevQuickStartAttempt(attempt);
+      setPhase(DEV_QUICK_START_PHASE.authenticate);
 
-    const result = await Result.tryPromise({
-      try: async () => await authenticate(attempt.identity),
-      catch: (cause) => cause,
-    });
-
-    if (Result.isError(result)) {
-      setPhase(null);
-      analytics.captureError(result.error);
-      stellaToast.add({
-        title: t("auth.devQuickStart.error.title"),
-        description: DevQuickStartError.is(result.error)
-          ? t(ERROR_MESSAGE_KEYS[result.error.code])
-          : userErrorFromThrown(
-              result.error,
-              t("auth.devQuickStart.error.fallback"),
-            ),
-        type: "error",
+      const result = await Result.tryPromise({
+        try: async () => await authenticate(attempt.identity),
+        catch: (cause) => cause,
       });
-      return;
-    }
 
-    const authenticatedAttempt =
-      attempt.completedPhase === null
-        ? {
-            completedPhase: DEV_QUICK_START_PHASE.authenticate,
-            identity: attempt.identity,
-            organizationId: attempt.organizationId,
-          }
-        : attempt;
-    attemptRef.current = authenticatedAttempt;
-    writeDevQuickStartAttempt(authenticatedAttempt);
+      if (Result.isError(result)) {
+        setPhase(null);
+        analytics.captureError(result.error);
+        stellaToast.add({
+          title: t("auth.devQuickStart.error.title"),
+          description: DevQuickStartError.is(result.error)
+            ? t(ERROR_MESSAGE_KEYS[result.error.code])
+            : userErrorFromThrown(
+                result.error,
+                t("auth.devQuickStart.error.fallback"),
+              ),
+          type: "error",
+        });
+        return;
+      }
 
-    if (result.value === AUTHENTICATION_OUTCOME.twoFactorRequired) {
+      const authenticatedAttempt =
+        attempt.completedPhase === null
+          ? {
+              completedPhase: DEV_QUICK_START_PHASE.authenticate,
+              identity: attempt.identity,
+              organizationId: attempt.organizationId,
+            }
+          : attempt;
+      attemptRef.current = authenticatedAttempt;
+      writeDevQuickStartAttempt(authenticatedAttempt);
+
+      if (result.value === AUTHENTICATION_OUTCOME.twoFactorRequired) {
+        await navigate({
+          to: "/auth/two-factor",
+          search: { devQuickStart: true, redirectTo },
+        });
+        return;
+      }
+
+      await invalidateSession.mutateAsync();
       await navigate({
-        to: "/auth/two-factor",
+        to: "/auth/organization",
         search: { devQuickStart: true, redirectTo },
       });
-      return;
+    } finally {
+      runningRef.current = false;
     }
-
-    await invalidateSession.mutateAsync();
-    await navigate({
-      to: "/auth/organization",
-      search: { devQuickStart: true, redirectTo },
-    });
   };
 
   return (

--- a/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
+++ b/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
@@ -1,0 +1,161 @@
+import { useState } from "react";
+
+import { Result, TaggedError } from "better-result";
+
+import { Button } from "@stll/ui/components/button";
+import { stellaToast } from "@stll/ui/components/toast";
+
+import { useInvalidateSession } from "@/hooks/use-invalidate-session";
+import { useAnalytics } from "@/lib/analytics/provider";
+import { api } from "@/lib/api";
+import { authClient } from "@/lib/auth";
+import { detached } from "@/lib/detached";
+import { fetchDevOtp } from "@/lib/dev-otp";
+import { toAPIError } from "@/lib/errors/api";
+import { toAuthClientError } from "@/lib/errors/auth";
+import { userErrorFromThrown } from "@/lib/errors/user-safe";
+
+import {
+  DEV_QUICK_START_PHASE,
+  type DevQuickStartIdentity,
+  type DevQuickStartPhase,
+  runDevQuickStart,
+} from "./dev-quick-start.logic";
+
+const QUICK_START_MATTER_COUNT = 10;
+
+const PHASE_LABELS = {
+  [DEV_QUICK_START_PHASE.authenticate]: "SIGNING IN",
+  [DEV_QUICK_START_PHASE.organization]: "CREATING WORKSPACE",
+  [DEV_QUICK_START_PHASE.skills]: "ADDING SKILLS",
+  [DEV_QUICK_START_PHASE.matters]: "STARTING LAB IMPORT",
+} as const satisfies Record<DevQuickStartPhase, string>;
+
+class DevQuickStartError extends TaggedError("DevQuickStartError")<{
+  message: string;
+}> {}
+
+const authenticate = async ({ email }: DevQuickStartIdentity) => {
+  const sent = await authClient.emailOtp.sendVerificationOtp({
+    email,
+    type: "sign-in",
+  });
+  if (sent.error) {
+    throw toAuthClientError(sent.error);
+  }
+
+  const otp = await fetchDevOtp(email);
+  if (otp === null) {
+    throw new DevQuickStartError({ message: "Dev OTP was not available." });
+  }
+
+  const signedIn = await authClient.signIn.emailOtp({ email, otp });
+  if (signedIn.error) {
+    throw toAuthClientError(signedIn.error);
+  }
+
+  const updated = await authClient.updateUser({ name: "Dev Quick Start" });
+  if (updated.error) {
+    throw toAuthClientError(updated.error);
+  }
+};
+
+const createOrganization = async ({
+  organizationName,
+  organizationSlug,
+}: DevQuickStartIdentity) => {
+  const created = await authClient.organization.create({
+    name: organizationName,
+    slug: organizationSlug,
+  });
+  if (created.error) {
+    throw toAuthClientError(created.error);
+  }
+
+  const active = await authClient.organization.setActive({
+    organizationId: created.data.id,
+  });
+  if (active.error) {
+    throw toAuthClientError(active.error);
+  }
+};
+
+const seedSkills = async () => {
+  const response = await api.skills.seed.post({});
+  if (response.error) {
+    throw toAPIError(response.error);
+  }
+};
+
+const seedMatters = async ({ selectionSeed }: DevQuickStartIdentity) => {
+  const response = await api.dev["seed-firm-knowledge"].post({
+    matters: QUICK_START_MATTER_COUNT,
+    selectionSeed,
+  });
+  if (response.error) {
+    throw new DevQuickStartError({
+      message: "The Harvey LAB import could not start.",
+    });
+  }
+};
+
+export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {
+  const analytics = useAnalytics();
+  const invalidateSession = useInvalidateSession();
+  const [phase, setPhase] = useState<DevQuickStartPhase | null>(null);
+
+  const handleQuickStart = async () => {
+    if (phase !== null) {
+      return;
+    }
+
+    const result = await Result.tryPromise(async () => {
+      await runDevQuickStart({
+        authenticate,
+        createOrganization,
+        onPhase: setPhase,
+        randomId: crypto.randomUUID(),
+        seedMatters,
+        seedSkills,
+      });
+      await invalidateSession.mutateAsync();
+    });
+
+    if (Result.isError(result)) {
+      setPhase(null);
+      analytics.captureError(result.error);
+      stellaToast.add({
+        title: "Dev quick start failed",
+        description: userErrorFromThrown(
+          result.error,
+          "Check the API log and try again.",
+        ),
+        type: "error",
+      });
+      return;
+    }
+
+    stellaToast.add({
+      title: "Dev workspace ready",
+      description: "10 Harvey LAB matters are importing in the background.",
+      type: "success",
+    });
+    window.location.assign(redirectTo);
+  };
+
+  return (
+    <Button
+      className="w-full"
+      disabled={phase !== null}
+      loading={phase !== null}
+      onClick={() => {
+        detached(handleQuickStart(), "dev-quick-start.run");
+      }}
+      size="lg"
+      type="button"
+      variant="outline"
+    >
+      {phase === null ? "DEV QUICK START" : PHASE_LABELS[phase]}
+    </Button>
+  );
+};

--- a/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
+++ b/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 
+import { useNavigate } from "@tanstack/react-router";
 import { Result, TaggedError } from "better-result";
 import { useTranslations } from "use-intl";
 
@@ -10,7 +11,7 @@ import { useInvalidateSession } from "@/hooks/use-invalidate-session";
 import type { TranslationKey } from "@/i18n/types";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { authClient } from "@/lib/auth";
+import { authClient, isTwoFactorRedirect } from "@/lib/auth";
 import { detached } from "@/lib/detached";
 import { fetchDevOtp } from "@/lib/dev-otp";
 import { toAPIError } from "@/lib/errors/api";
@@ -59,6 +60,10 @@ class DevQuickStartError extends TaggedError("DevQuickStartError")<{
   message: string;
 }> {}
 
+class DevQuickStartTwoFactorRequired extends TaggedError(
+  "DevQuickStartTwoFactorRequired",
+)<{ message: string }> {}
+
 const authenticate = async ({ email }: DevQuickStartIdentity) => {
   const sent = await authClient.emailOtp.sendVerificationOtp({
     email,
@@ -79,6 +84,11 @@ const authenticate = async ({ email }: DevQuickStartIdentity) => {
   const signedIn = await authClient.signIn.emailOtp({ email, otp });
   if (signedIn.error) {
     throw toAuthClientError(signedIn.error);
+  }
+  if (isTwoFactorRedirect(signedIn.data)) {
+    throw new DevQuickStartTwoFactorRequired({
+      message: "Two-factor authentication is required.",
+    });
   }
 
   const updated = await authClient.updateUser({ name: "Dev Quick Start" });
@@ -129,6 +139,7 @@ const seedSkills = async () => {
 };
 
 const waitForMatterImport = async (
+  jobId: string,
   remainingPolls = MATTER_IMPORT_MAX_POLLS,
 ): Promise<void> => {
   if (remainingPolls === 0) {
@@ -138,7 +149,9 @@ const waitForMatterImport = async (
     });
   }
 
-  const { data, error } = await api.dev["seed-firm-knowledge"].get();
+  const { data, error } = await api.dev["seed-firm-knowledge"].get({
+    query: { jobId },
+  });
   if (error !== null || data instanceof Response) {
     throw new DevQuickStartError({
       code: DEV_QUICK_START_ERROR.matterImport,
@@ -161,7 +174,7 @@ const waitForMatterImport = async (
       await new Promise<void>((resolve) => {
         setTimeout(resolve, MATTER_IMPORT_POLL_INTERVAL_MS);
       });
-      await waitForMatterImport(remainingPolls - 1);
+      await waitForMatterImport(jobId, remainingPolls - 1);
       return undefined;
     case "succeeded":
       return undefined;
@@ -183,12 +196,20 @@ const seedMatters = async ({ selectionSeed }: DevQuickStartIdentity) => {
     });
   }
 
-  await waitForMatterImport();
+  if (response.data instanceof Response) {
+    throw new DevQuickStartError({
+      code: DEV_QUICK_START_ERROR.matterImport,
+      message: "The Harvey LAB import could not start.",
+    });
+  }
+
+  await waitForMatterImport(response.data.jobId);
 };
 
 export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {
   const t = useTranslations();
   const analytics = useAnalytics();
+  const navigate = useNavigate();
   const invalidateSession = useInvalidateSession();
   const attemptRef = useRef<DevQuickStartAttempt | null>(null);
   const [phase, setPhase] = useState<DevQuickStartPhase | null>(null);
@@ -229,6 +250,13 @@ export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {
 
     if (Result.isError(result)) {
       setPhase(null);
+      if (DevQuickStartTwoFactorRequired.is(result.error)) {
+        await navigate({
+          to: "/auth/two-factor",
+          search: { redirectTo },
+        });
+        return;
+      }
       analytics.captureError(result.error);
       stellaToast.add({
         title: t("auth.devQuickStart.error.title"),

--- a/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
+++ b/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
@@ -227,73 +227,75 @@ export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {
   const runningRef = useRef(false);
   const [phase, setPhase] = useState<DevQuickStartPhase | null>(null);
 
+  const runQuickStart = async () => {
+    const attempt =
+      attemptRef.current ??
+      readDevQuickStartAttempt() ??
+      ({
+        completedPhase: null,
+        identity: createDevQuickStartIdentity(crypto.randomUUID()),
+        organizationId: null,
+      } satisfies DevQuickStartAttempt);
+    attemptRef.current = attempt;
+    writeDevQuickStartAttempt(attempt);
+    setPhase(DEV_QUICK_START_PHASE.authenticate);
+
+    const result = await Result.tryPromise({
+      try: async () => await authenticate(attempt.identity),
+      catch: (cause) => cause,
+    });
+
+    if (Result.isError(result)) {
+      setPhase(null);
+      analytics.captureError(result.error);
+      stellaToast.add({
+        title: t("auth.devQuickStart.error.title"),
+        description: DevQuickStartError.is(result.error)
+          ? t(ERROR_MESSAGE_KEYS[result.error.code])
+          : userErrorFromThrown(
+              result.error,
+              t("auth.devQuickStart.error.fallback"),
+            ),
+        type: "error",
+      });
+      return;
+    }
+
+    const authenticatedAttempt =
+      attempt.completedPhase === null
+        ? {
+            completedPhase: DEV_QUICK_START_PHASE.authenticate,
+            identity: attempt.identity,
+            organizationId: attempt.organizationId,
+          }
+        : attempt;
+    attemptRef.current = authenticatedAttempt;
+    writeDevQuickStartAttempt(authenticatedAttempt);
+
+    if (result.value === AUTHENTICATION_OUTCOME.twoFactorRequired) {
+      await navigate({
+        to: "/auth/two-factor",
+        search: { devQuickStart: true, redirectTo },
+      });
+      return;
+    }
+
+    await invalidateSession.mutateAsync();
+    await navigate({
+      to: "/auth/organization",
+      search: { devQuickStart: true, redirectTo },
+    });
+  };
+
   const handleQuickStart = async () => {
     if (runningRef.current) {
       return;
     }
     runningRef.current = true;
 
-    try {
-      const attempt =
-        attemptRef.current ??
-        readDevQuickStartAttempt() ??
-        ({
-          completedPhase: null,
-          identity: createDevQuickStartIdentity(crypto.randomUUID()),
-          organizationId: null,
-        } satisfies DevQuickStartAttempt);
-      attemptRef.current = attempt;
-      writeDevQuickStartAttempt(attempt);
-      setPhase(DEV_QUICK_START_PHASE.authenticate);
-
-      const result = await Result.tryPromise({
-        try: async () => await authenticate(attempt.identity),
-        catch: (cause) => cause,
-      });
-
-      if (Result.isError(result)) {
-        setPhase(null);
-        analytics.captureError(result.error);
-        stellaToast.add({
-          title: t("auth.devQuickStart.error.title"),
-          description: DevQuickStartError.is(result.error)
-            ? t(ERROR_MESSAGE_KEYS[result.error.code])
-            : userErrorFromThrown(
-                result.error,
-                t("auth.devQuickStart.error.fallback"),
-              ),
-          type: "error",
-        });
-        return;
-      }
-
-      const authenticatedAttempt =
-        attempt.completedPhase === null
-          ? {
-              completedPhase: DEV_QUICK_START_PHASE.authenticate,
-              identity: attempt.identity,
-              organizationId: attempt.organizationId,
-            }
-          : attempt;
-      attemptRef.current = authenticatedAttempt;
-      writeDevQuickStartAttempt(authenticatedAttempt);
-
-      if (result.value === AUTHENTICATION_OUTCOME.twoFactorRequired) {
-        await navigate({
-          to: "/auth/two-factor",
-          search: { devQuickStart: true, redirectTo },
-        });
-        return;
-      }
-
-      await invalidateSession.mutateAsync();
-      await navigate({
-        to: "/auth/organization",
-        search: { devQuickStart: true, redirectTo },
-      });
-    } finally {
+    await runQuickStart().finally(() => {
       runningRef.current = false;
-    }
+    });
   };
 
   return (

--- a/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
+++ b/apps/web/src/routes/auth/-components/dev-quick-start-button.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "use-intl";
 import { Button } from "@stll/ui/components/button";
 import { stellaToast } from "@stll/ui/components/toast";
 
+import { useMountEffect } from "@/hooks/use-effect";
 import { useInvalidateSession } from "@/hooks/use-invalidate-session";
 import type { TranslationKey } from "@/i18n/types";
 import { useAnalytics } from "@/lib/analytics/provider";
@@ -14,10 +15,14 @@ import { api } from "@/lib/api";
 import { authClient, isTwoFactorRedirect } from "@/lib/auth";
 import { detached } from "@/lib/detached";
 import { fetchDevOtp } from "@/lib/dev-otp";
-import { toAPIError } from "@/lib/errors/api";
 import { toAuthClientError } from "@/lib/errors/auth";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 
+import {
+  clearDevQuickStartAttempt,
+  readDevQuickStartAttempt,
+  writeDevQuickStartAttempt,
+} from "./dev-quick-start-storage";
 import {
   DEV_QUICK_START_PHASE,
   createDevQuickStartIdentity,
@@ -44,6 +49,7 @@ const PHASE_LABEL_KEYS = {
 const DEV_QUICK_START_ERROR = {
   matterImport: "matterImport",
   otpUnavailable: "otpUnavailable",
+  seed: "seed",
 } as const;
 
 type DevQuickStartErrorCode =
@@ -53,6 +59,7 @@ const ERROR_MESSAGE_KEYS = {
   [DEV_QUICK_START_ERROR.matterImport]: "auth.devQuickStart.error.matterImport",
   [DEV_QUICK_START_ERROR.otpUnavailable]:
     "auth.devQuickStart.error.otpUnavailable",
+  [DEV_QUICK_START_ERROR.seed]: "auth.devQuickStart.error.fallback",
 } as const satisfies Record<DevQuickStartErrorCode, TranslationKey>;
 
 class DevQuickStartError extends TaggedError("DevQuickStartError")<{
@@ -60,9 +67,10 @@ class DevQuickStartError extends TaggedError("DevQuickStartError")<{
   message: string;
 }> {}
 
-class DevQuickStartTwoFactorRequired extends TaggedError(
-  "DevQuickStartTwoFactorRequired",
-)<{ message: string }> {}
+const AUTHENTICATION_OUTCOME = {
+  authenticated: "authenticated",
+  twoFactorRequired: "twoFactorRequired",
+} as const;
 
 const authenticate = async ({ email }: DevQuickStartIdentity) => {
   const sent = await authClient.emailOtp.sendVerificationOtp({
@@ -86,15 +94,10 @@ const authenticate = async ({ email }: DevQuickStartIdentity) => {
     throw toAuthClientError(signedIn.error);
   }
   if (isTwoFactorRedirect(signedIn.data)) {
-    throw new DevQuickStartTwoFactorRequired({
-      message: "Two-factor authentication is required.",
-    });
+    return AUTHENTICATION_OUTCOME.twoFactorRequired;
   }
 
-  const updated = await authClient.updateUser({ name: "Dev Quick Start" });
-  if (updated.error) {
-    throw toAuthClientError(updated.error);
-  }
+  return AUTHENTICATION_OUTCOME.authenticated;
 };
 
 const createOrganization = async ({
@@ -129,12 +132,17 @@ const createOrganization = async ({
   if (active.error) {
     throw toAuthClientError(active.error);
   }
+
+  return organizationId;
 };
 
-const seedSkills = async () => {
-  const response = await api.skills.seed.post({});
+const seedSkills = async (organizationId: string) => {
+  const response = await api.dev["seed-skills"].post({ organizationId });
   if (response.error) {
-    throw toAPIError(response.error);
+    throw new DevQuickStartError({
+      code: DEV_QUICK_START_ERROR.seed,
+      message: "The default skills could not be installed.",
+    });
   }
 };
 
@@ -183,10 +191,14 @@ const waitForMatterImport = async (
   }
 };
 
-const seedMatters = async ({ selectionSeed }: DevQuickStartIdentity) => {
+const seedMatters = async (
+  { selectionSeed }: DevQuickStartIdentity,
+  organizationId: string,
+) => {
   const response = await api.dev["seed-firm-knowledge"].post({
     incompleteMatterMode: QUICK_START_INCOMPLETE_MATTER_MODE,
     matters: QUICK_START_MATTER_COUNT,
+    organizationId,
     selectionSeed,
   });
   if (response.error) {
@@ -221,42 +233,143 @@ export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {
 
     const attempt =
       attemptRef.current ??
+      readDevQuickStartAttempt() ??
       ({
         completedPhase: null,
         identity: createDevQuickStartIdentity(crypto.randomUUID()),
+        organizationId: null,
       } satisfies DevQuickStartAttempt);
     attemptRef.current = attempt;
+    writeDevQuickStartAttempt(attempt);
+    setPhase(DEV_QUICK_START_PHASE.authenticate);
 
     const result = await Result.tryPromise({
-      try: async () => {
-        await runDevQuickStart({
-          attempt,
-          authenticate,
-          createOrganization,
-          onPhase: setPhase,
-          onPhaseCompleted: (completedPhase) => {
-            attemptRef.current = {
-              completedPhase,
-              identity: attempt.identity,
-            };
-          },
-          seedMatters,
-          seedSkills,
-        });
-        await invalidateSession.mutateAsync();
-      },
+      try: async () => await authenticate(attempt.identity),
       catch: (cause) => cause,
     });
 
     if (Result.isError(result)) {
       setPhase(null);
-      if (DevQuickStartTwoFactorRequired.is(result.error)) {
-        await navigate({
-          to: "/auth/two-factor",
-          search: { redirectTo },
+      analytics.captureError(result.error);
+      stellaToast.add({
+        title: t("auth.devQuickStart.error.title"),
+        description: DevQuickStartError.is(result.error)
+          ? t(ERROR_MESSAGE_KEYS[result.error.code])
+          : userErrorFromThrown(
+              result.error,
+              t("auth.devQuickStart.error.fallback"),
+            ),
+        type: "error",
+      });
+      return;
+    }
+
+    const authenticatedAttempt =
+      attempt.completedPhase === null
+        ? {
+            completedPhase: DEV_QUICK_START_PHASE.authenticate,
+            identity: attempt.identity,
+            organizationId: attempt.organizationId,
+          }
+        : attempt;
+    attemptRef.current = authenticatedAttempt;
+    writeDevQuickStartAttempt(authenticatedAttempt);
+
+    if (result.value === AUTHENTICATION_OUTCOME.twoFactorRequired) {
+      await navigate({
+        to: "/auth/two-factor",
+        search: { devQuickStart: true, redirectTo },
+      });
+      return;
+    }
+
+    await invalidateSession.mutateAsync();
+    await navigate({
+      to: "/auth/organization",
+      search: { devQuickStart: true, redirectTo },
+    });
+  };
+
+  return (
+    <Button
+      className="w-full uppercase"
+      disabled={phase !== null}
+      loading={phase !== null}
+      onClick={() => {
+        detached(handleQuickStart(), "dev-quick-start.run");
+      }}
+      size="lg"
+      type="button"
+      variant="outline"
+    >
+      {phase === null
+        ? t("auth.devQuickStart.button")
+        : t(PHASE_LABEL_KEYS[phase])}
+    </Button>
+  );
+};
+
+export const DevQuickStartContinuation = ({
+  redirectTo,
+}: {
+  redirectTo: string;
+}) => {
+  const t = useTranslations();
+  const analytics = useAnalytics();
+  const invalidateSession = useInvalidateSession();
+  const attemptRef = useRef<DevQuickStartAttempt | null>(null);
+  const runningRef = useRef(false);
+  const [phase, setPhase] = useState<DevQuickStartPhase | null>(null);
+
+  const runContinuation = async () => {
+    if (runningRef.current) {
+      return;
+    }
+    runningRef.current = true;
+
+    const attempt =
+      attemptRef.current ??
+      readDevQuickStartAttempt() ??
+      ({
+        completedPhase: DEV_QUICK_START_PHASE.authenticate,
+        identity: createDevQuickStartIdentity(crypto.randomUUID()),
+        organizationId: null,
+      } satisfies DevQuickStartAttempt);
+    attemptRef.current = attempt;
+    writeDevQuickStartAttempt(attempt);
+
+    const result = await Result.tryPromise({
+      try: async () => {
+        const updated = await authClient.updateUser({
+          name: "Dev Quick Start",
         });
-        return;
-      }
+        if (updated.error) {
+          throw toAuthClientError(updated.error);
+        }
+
+        await runDevQuickStart({
+          attempt,
+          authenticate: async () => {
+            await Promise.resolve();
+          },
+          createOrganization,
+          onAttemptUpdated: (nextAttempt) => {
+            attemptRef.current = nextAttempt;
+            writeDevQuickStartAttempt(nextAttempt);
+          },
+          onPhase: setPhase,
+          seedMatters,
+          seedSkills,
+        });
+        await invalidateSession.mutateAsync();
+        clearDevQuickStartAttempt();
+      },
+      catch: (cause) => cause,
+    });
+
+    runningRef.current = false;
+    if (Result.isError(result)) {
+      setPhase(null);
       analytics.captureError(result.error);
       stellaToast.add({
         title: t("auth.devQuickStart.error.title"),
@@ -279,13 +392,17 @@ export const DevQuickStartButton = ({ redirectTo }: { redirectTo: string }) => {
     window.location.assign(redirectTo);
   };
 
+  useMountEffect(() => {
+    detached(runContinuation(), "dev-quick-start.continue");
+  });
+
   return (
     <Button
-      className="w-full uppercase"
+      className="w-full max-w-md uppercase"
       disabled={phase !== null}
       loading={phase !== null}
       onClick={() => {
-        detached(handleQuickStart(), "dev-quick-start.run");
+        detached(runContinuation(), "dev-quick-start.retry");
       }}
       size="lg"
       type="button"

--- a/apps/web/src/routes/auth/-components/dev-quick-start-storage.test.ts
+++ b/apps/web/src/routes/auth/-components/dev-quick-start-storage.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseDevQuickStartAttempt } from "./dev-quick-start-storage";
+import { DEV_QUICK_START_PHASE } from "./dev-quick-start.logic";
+
+const STORED_ATTEMPT = {
+  completedPhase: DEV_QUICK_START_PHASE.organization,
+  identity: {
+    email: "dev-quick-start@stella.dev",
+    organizationName: "Harvey LAB 018F1F7E",
+    organizationSlug: "dev-quick-start-018f1f7e",
+    selectionSeed: "018f1f7e-89ab-7def-8123-456789abcdef",
+  },
+  organizationId: "organization-quick-start",
+} as const;
+
+describe("parseDevQuickStartAttempt", () => {
+  test("restores the organization-pinned attempt after navigation", () => {
+    expect(parseDevQuickStartAttempt(JSON.stringify(STORED_ATTEMPT))).toEqual(
+      STORED_ATTEMPT,
+    );
+  });
+
+  test("rejects stale progress without its organization binding", () => {
+    const { organizationId: _organizationId, ...staleAttempt } = STORED_ATTEMPT;
+
+    expect(parseDevQuickStartAttempt(JSON.stringify(staleAttempt))).toBeNull();
+  });
+});

--- a/apps/web/src/routes/auth/-components/dev-quick-start-storage.test.ts
+++ b/apps/web/src/routes/auth/-components/dev-quick-start-storage.test.ts
@@ -15,7 +15,7 @@ const STORED_ATTEMPT = {
 } as const;
 
 describe("parseDevQuickStartAttempt", () => {
-  test("restores the organization-pinned attempt after navigation", () => {
+  test("restores the organization-pinned attempt after a tab restart", () => {
     expect(parseDevQuickStartAttempt(JSON.stringify(STORED_ATTEMPT))).toEqual(
       STORED_ATTEMPT,
     );

--- a/apps/web/src/routes/auth/-components/dev-quick-start-storage.ts
+++ b/apps/web/src/routes/auth/-components/dev-quick-start-storage.ts
@@ -1,0 +1,63 @@
+import * as v from "valibot";
+
+import { readStoredJson, writeStoredJson } from "@/lib/stored-json";
+
+import {
+  DEV_QUICK_START_PHASE,
+  type DevQuickStartAttempt,
+} from "./dev-quick-start.logic";
+
+const DEV_QUICK_START_STORAGE_KEY = "stella.devQuickStart.attempt";
+
+const devQuickStartAttemptSchema = v.strictObject({
+  completedPhase: v.nullable(
+    v.picklist([
+      DEV_QUICK_START_PHASE.authenticate,
+      DEV_QUICK_START_PHASE.organization,
+      DEV_QUICK_START_PHASE.skills,
+      DEV_QUICK_START_PHASE.matters,
+    ]),
+  ),
+  identity: v.strictObject({
+    email: v.pipe(v.string(), v.minLength(1), v.maxLength(254)),
+    organizationName: v.pipe(v.string(), v.minLength(1), v.maxLength(128)),
+    organizationSlug: v.pipe(v.string(), v.minLength(1), v.maxLength(128)),
+    selectionSeed: v.pipe(v.string(), v.minLength(1), v.maxLength(128)),
+  }),
+  organizationId: v.nullable(
+    v.pipe(v.string(), v.minLength(1), v.maxLength(128)),
+  ),
+});
+
+export const parseDevQuickStartAttempt = (
+  raw: string | null,
+): DevQuickStartAttempt | null =>
+  readStoredJson(raw, devQuickStartAttemptSchema);
+
+export const readDevQuickStartAttempt = (): DevQuickStartAttempt | null => {
+  try {
+    return parseDevQuickStartAttempt(
+      sessionStorage.getItem(DEV_QUICK_START_STORAGE_KEY),
+    );
+  } catch {
+    return null;
+  }
+};
+
+export const writeDevQuickStartAttempt = (
+  attempt: DevQuickStartAttempt,
+): void => {
+  try {
+    writeStoredJson(sessionStorage, DEV_QUICK_START_STORAGE_KEY, attempt);
+  } catch {
+    // Storage can be unavailable or blocked; persistence is best-effort.
+  }
+};
+
+export const clearDevQuickStartAttempt = (): void => {
+  try {
+    sessionStorage.removeItem(DEV_QUICK_START_STORAGE_KEY);
+  } catch {
+    // Storage can be unavailable or blocked; clearing is best-effort.
+  }
+};

--- a/apps/web/src/routes/auth/-components/dev-quick-start-storage.ts
+++ b/apps/web/src/routes/auth/-components/dev-quick-start-storage.ts
@@ -37,7 +37,7 @@ export const parseDevQuickStartAttempt = (
 export const readDevQuickStartAttempt = (): DevQuickStartAttempt | null => {
   try {
     return parseDevQuickStartAttempt(
-      sessionStorage.getItem(DEV_QUICK_START_STORAGE_KEY),
+      localStorage.getItem(DEV_QUICK_START_STORAGE_KEY),
     );
   } catch {
     return null;
@@ -48,7 +48,7 @@ export const writeDevQuickStartAttempt = (
   attempt: DevQuickStartAttempt,
 ): void => {
   try {
-    writeStoredJson(sessionStorage, DEV_QUICK_START_STORAGE_KEY, attempt);
+    writeStoredJson(localStorage, DEV_QUICK_START_STORAGE_KEY, attempt);
   } catch {
     // Storage can be unavailable or blocked; persistence is best-effort.
   }
@@ -56,7 +56,7 @@ export const writeDevQuickStartAttempt = (
 
 export const clearDevQuickStartAttempt = (): void => {
   try {
-    sessionStorage.removeItem(DEV_QUICK_START_STORAGE_KEY);
+    localStorage.removeItem(DEV_QUICK_START_STORAGE_KEY);
   } catch {
     // Storage can be unavailable or blocked; clearing is best-effort.
   }

--- a/apps/web/src/routes/auth/-components/dev-quick-start.logic.test.ts
+++ b/apps/web/src/routes/auth/-components/dev-quick-start.logic.test.ts
@@ -124,7 +124,15 @@ describe("runDevQuickStart", () => {
         },
       });
 
-    expect(run()).rejects.toThrow("import failed");
+    const firstRun = await run().then(
+      () => ({ status: "succeeded" }) as const,
+      (error: unknown) =>
+        ({
+          message: error instanceof Error ? error.message : "Unknown error",
+          status: "failed",
+        }) as const,
+    );
+    expect(firstRun).toEqual({ message: "import failed", status: "failed" });
     await run();
     await run();
 

--- a/apps/web/src/routes/auth/-components/dev-quick-start.logic.test.ts
+++ b/apps/web/src/routes/auth/-components/dev-quick-start.logic.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   createDevQuickStartIdentity,
   DEV_QUICK_START_PHASE,
+  type DevQuickStartPhase,
   runDevQuickStart,
 } from "./dev-quick-start.logic";
 
@@ -22,8 +23,10 @@ describe("createDevQuickStartIdentity", () => {
 describe("runDevQuickStart", () => {
   test("authenticates and establishes ownership before either seed", async () => {
     const calls: string[] = [];
+    const identity = createDevQuickStartIdentity(RANDOM_ID);
 
     await runDevQuickStart({
+      attempt: { completedPhase: null, identity },
       authenticate: async () => {
         calls.push("authenticate");
       },
@@ -33,7 +36,9 @@ describe("runDevQuickStart", () => {
       onPhase: (phase) => {
         calls.push(`phase:${phase}`);
       },
-      randomId: RANDOM_ID,
+      onPhaseCompleted: (phase) => {
+        calls.push(`completed:${phase}`);
+      },
       seedMatters: async () => {
         calls.push("matters");
       },
@@ -45,20 +50,26 @@ describe("runDevQuickStart", () => {
     expect(calls).toEqual([
       `phase:${DEV_QUICK_START_PHASE.authenticate}`,
       "authenticate",
+      `completed:${DEV_QUICK_START_PHASE.authenticate}`,
       `phase:${DEV_QUICK_START_PHASE.organization}`,
       "organization",
+      `completed:${DEV_QUICK_START_PHASE.organization}`,
       `phase:${DEV_QUICK_START_PHASE.skills}`,
       "skills",
+      `completed:${DEV_QUICK_START_PHASE.skills}`,
       `phase:${DEV_QUICK_START_PHASE.matters}`,
       "matters",
+      `completed:${DEV_QUICK_START_PHASE.matters}`,
     ]);
   });
 
   test("fails fast before organization-scoped seeds", async () => {
     const calls: string[] = [];
+    const identity = createDevQuickStartIdentity(RANDOM_ID);
 
     expect(
       runDevQuickStart({
+        attempt: { completedPhase: null, identity },
         authenticate: async () => {
           calls.push("authenticate");
         },
@@ -67,7 +78,7 @@ describe("runDevQuickStart", () => {
           throw new Error("organization failed");
         },
         onPhase: () => undefined,
-        randomId: RANDOM_ID,
+        onPhaseCompleted: () => undefined,
         seedMatters: async () => {
           calls.push("matters");
         },
@@ -77,5 +88,53 @@ describe("runDevQuickStart", () => {
       }),
     ).rejects.toThrow("organization failed");
     expect(calls).toEqual(["authenticate", "organization"]);
+  });
+
+  test("resumes after the last completed phase with the same identity", async () => {
+    const calls: string[] = [];
+    const identity = createDevQuickStartIdentity(RANDOM_ID);
+    const progress: { completedPhase: DevQuickStartPhase | null } = {
+      completedPhase: null,
+    };
+    let matterAttempts = 0;
+
+    const run = async () =>
+      runDevQuickStart({
+        attempt: { completedPhase: progress.completedPhase, identity },
+        authenticate: async () => {
+          calls.push("authenticate");
+        },
+        createOrganization: async () => {
+          calls.push("organization");
+        },
+        onPhase: () => undefined,
+        onPhaseCompleted: (phase) => {
+          progress.completedPhase = phase;
+        },
+        seedMatters: async (attemptIdentity) => {
+          expect(attemptIdentity).toBe(identity);
+          matterAttempts += 1;
+          calls.push("matters");
+          if (matterAttempts === 1) {
+            throw new Error("import failed");
+          }
+        },
+        seedSkills: async () => {
+          calls.push("skills");
+        },
+      });
+
+    expect(run()).rejects.toThrow("import failed");
+    await run();
+    await run();
+
+    expect(calls).toEqual([
+      "authenticate",
+      "organization",
+      "skills",
+      "matters",
+      "matters",
+    ]);
+    expect(progress.completedPhase).toBe(DEV_QUICK_START_PHASE.matters);
   });
 });

--- a/apps/web/src/routes/auth/-components/dev-quick-start.logic.test.ts
+++ b/apps/web/src/routes/auth/-components/dev-quick-start.logic.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./dev-quick-start.logic";
 
 const RANDOM_ID = "018f1f7e-89ab-7def-8123-456789abcdef";
+const ORGANIZATION_ID = "organization-quick-start";
 
 describe("createDevQuickStartIdentity", () => {
   test("reuses the local account with a unique org and reproducible seed", () => {
@@ -26,23 +27,26 @@ describe("runDevQuickStart", () => {
     const identity = createDevQuickStartIdentity(RANDOM_ID);
 
     await runDevQuickStart({
-      attempt: { completedPhase: null, identity },
+      attempt: { completedPhase: null, identity, organizationId: null },
       authenticate: async () => {
         calls.push("authenticate");
       },
       createOrganization: async () => {
         calls.push("organization");
+        return ORGANIZATION_ID;
+      },
+      onAttemptUpdated: ({ completedPhase }) => {
+        calls.push(`completed:${completedPhase}`);
       },
       onPhase: (phase) => {
         calls.push(`phase:${phase}`);
       },
-      onPhaseCompleted: (phase) => {
-        calls.push(`completed:${phase}`);
-      },
-      seedMatters: async () => {
+      seedMatters: async (_identity, organizationId) => {
+        expect(organizationId).toBe(ORGANIZATION_ID);
         calls.push("matters");
       },
-      seedSkills: async () => {
+      seedSkills: async (organizationId) => {
+        expect(organizationId).toBe(ORGANIZATION_ID);
         calls.push("skills");
       },
     });
@@ -69,7 +73,7 @@ describe("runDevQuickStart", () => {
 
     expect(
       runDevQuickStart({
-        attempt: { completedPhase: null, identity },
+        attempt: { completedPhase: null, identity, organizationId: null },
         authenticate: async () => {
           calls.push("authenticate");
         },
@@ -77,8 +81,8 @@ describe("runDevQuickStart", () => {
           calls.push("organization");
           throw new Error("organization failed");
         },
+        onAttemptUpdated: () => undefined,
         onPhase: () => undefined,
-        onPhaseCompleted: () => undefined,
         seedMatters: async () => {
           calls.push("matters");
         },
@@ -93,33 +97,40 @@ describe("runDevQuickStart", () => {
   test("resumes after the last completed phase with the same identity", async () => {
     const calls: string[] = [];
     const identity = createDevQuickStartIdentity(RANDOM_ID);
-    const progress: { completedPhase: DevQuickStartPhase | null } = {
+    let progress: {
+      completedPhase: DevQuickStartPhase | null;
+      organizationId: string | null;
+    } = {
       completedPhase: null,
+      organizationId: null,
     };
     let matterAttempts = 0;
 
     const run = async () =>
       runDevQuickStart({
-        attempt: { completedPhase: progress.completedPhase, identity },
+        attempt: { ...progress, identity },
         authenticate: async () => {
           calls.push("authenticate");
         },
         createOrganization: async () => {
           calls.push("organization");
+          return ORGANIZATION_ID;
+        },
+        onAttemptUpdated: ({ completedPhase, organizationId }) => {
+          progress = { completedPhase, organizationId };
         },
         onPhase: () => undefined,
-        onPhaseCompleted: (phase) => {
-          progress.completedPhase = phase;
-        },
-        seedMatters: async (attemptIdentity) => {
+        seedMatters: async (attemptIdentity, organizationId) => {
           expect(attemptIdentity).toBe(identity);
+          expect(organizationId).toBe(ORGANIZATION_ID);
           matterAttempts += 1;
           calls.push("matters");
           if (matterAttempts === 1) {
             throw new Error("import failed");
           }
         },
-        seedSkills: async () => {
+        seedSkills: async (organizationId) => {
+          expect(organizationId).toBe(ORGANIZATION_ID);
           calls.push("skills");
         },
       });
@@ -144,5 +155,31 @@ describe("runDevQuickStart", () => {
       "matters",
     ]);
     expect(progress.completedPhase).toBe(DEV_QUICK_START_PHASE.matters);
+    expect(progress.organizationId).toBe(ORGANIZATION_ID);
+  });
+
+  test("pins resumed seeds to the organization stored by the attempt", async () => {
+    const identity = createDevQuickStartIdentity(RANDOM_ID);
+    const seededOrganizations: string[] = [];
+
+    await runDevQuickStart({
+      attempt: {
+        completedPhase: DEV_QUICK_START_PHASE.organization,
+        identity,
+        organizationId: ORGANIZATION_ID,
+      },
+      authenticate: async () => undefined,
+      createOrganization: async () => "unexpected-organization",
+      onAttemptUpdated: () => undefined,
+      onPhase: () => undefined,
+      seedMatters: async (_identity, organizationId) => {
+        seededOrganizations.push(organizationId);
+      },
+      seedSkills: async (organizationId) => {
+        seededOrganizations.push(organizationId);
+      },
+    });
+
+    expect(seededOrganizations).toEqual([ORGANIZATION_ID, ORGANIZATION_ID]);
   });
 });

--- a/apps/web/src/routes/auth/-components/dev-quick-start.logic.test.ts
+++ b/apps/web/src/routes/auth/-components/dev-quick-start.logic.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createDevQuickStartIdentity,
+  DEV_QUICK_START_PHASE,
+  runDevQuickStart,
+} from "./dev-quick-start.logic";
+
+const RANDOM_ID = "018f1f7e-89ab-7def-8123-456789abcdef";
+
+describe("createDevQuickStartIdentity", () => {
+  test("reuses the local account with a unique org and reproducible seed", () => {
+    expect(createDevQuickStartIdentity(RANDOM_ID)).toEqual({
+      email: "dev-quick-start@stella.dev",
+      organizationName: "Harvey LAB 018F1F7E",
+      organizationSlug: "dev-quick-start-018f1f7e89ab7def8123456789abcdef",
+      selectionSeed: RANDOM_ID,
+    });
+  });
+});
+
+describe("runDevQuickStart", () => {
+  test("authenticates and establishes ownership before either seed", async () => {
+    const calls: string[] = [];
+
+    await runDevQuickStart({
+      authenticate: async () => {
+        calls.push("authenticate");
+      },
+      createOrganization: async () => {
+        calls.push("organization");
+      },
+      onPhase: (phase) => {
+        calls.push(`phase:${phase}`);
+      },
+      randomId: RANDOM_ID,
+      seedMatters: async () => {
+        calls.push("matters");
+      },
+      seedSkills: async () => {
+        calls.push("skills");
+      },
+    });
+
+    expect(calls).toEqual([
+      `phase:${DEV_QUICK_START_PHASE.authenticate}`,
+      "authenticate",
+      `phase:${DEV_QUICK_START_PHASE.organization}`,
+      "organization",
+      `phase:${DEV_QUICK_START_PHASE.skills}`,
+      "skills",
+      `phase:${DEV_QUICK_START_PHASE.matters}`,
+      "matters",
+    ]);
+  });
+
+  test("fails fast before organization-scoped seeds", async () => {
+    const calls: string[] = [];
+
+    expect(
+      runDevQuickStart({
+        authenticate: async () => {
+          calls.push("authenticate");
+        },
+        createOrganization: async () => {
+          calls.push("organization");
+          throw new Error("organization failed");
+        },
+        onPhase: () => undefined,
+        randomId: RANDOM_ID,
+        seedMatters: async () => {
+          calls.push("matters");
+        },
+        seedSkills: async () => {
+          calls.push("skills");
+        },
+      }),
+    ).rejects.toThrow("organization failed");
+    expect(calls).toEqual(["authenticate", "organization"]);
+  });
+});

--- a/apps/web/src/routes/auth/-components/dev-quick-start.logic.ts
+++ b/apps/web/src/routes/auth/-components/dev-quick-start.logic.ts
@@ -1,0 +1,66 @@
+export const DEV_QUICK_START_PHASE = {
+  authenticate: "authenticate",
+  organization: "organization",
+  skills: "skills",
+  matters: "matters",
+} as const;
+
+export type DevQuickStartPhase =
+  (typeof DEV_QUICK_START_PHASE)[keyof typeof DEV_QUICK_START_PHASE];
+
+export type DevQuickStartIdentity = {
+  email: string;
+  organizationName: string;
+  organizationSlug: string;
+  selectionSeed: string;
+};
+
+const DEV_QUICK_START_EMAIL = "dev-quick-start@stella.dev";
+
+export const createDevQuickStartIdentity = (
+  randomId: string,
+): DevQuickStartIdentity => {
+  const compactId = randomId.replaceAll("-", "").toLowerCase();
+  const label = compactId.slice(0, 8);
+  return {
+    email: DEV_QUICK_START_EMAIL,
+    organizationName: `Harvey LAB ${label.toUpperCase()}`,
+    organizationSlug: `dev-quick-start-${compactId}`,
+    selectionSeed: randomId,
+  };
+};
+
+type RunDevQuickStartOptions = {
+  authenticate: (identity: DevQuickStartIdentity) => Promise<void>;
+  createOrganization: (identity: DevQuickStartIdentity) => Promise<void>;
+  onPhase: (phase: DevQuickStartPhase) => void;
+  randomId: string;
+  seedMatters: (identity: DevQuickStartIdentity) => Promise<void>;
+  seedSkills: () => Promise<void>;
+};
+
+/** Runs the production-shaped boundaries in ownership order. */
+export const runDevQuickStart = async ({
+  authenticate,
+  createOrganization,
+  onPhase,
+  randomId,
+  seedMatters,
+  seedSkills,
+}: RunDevQuickStartOptions): Promise<DevQuickStartIdentity> => {
+  const identity = createDevQuickStartIdentity(randomId);
+
+  onPhase(DEV_QUICK_START_PHASE.authenticate);
+  await authenticate(identity);
+
+  onPhase(DEV_QUICK_START_PHASE.organization);
+  await createOrganization(identity);
+
+  onPhase(DEV_QUICK_START_PHASE.skills);
+  await seedSkills();
+
+  onPhase(DEV_QUICK_START_PHASE.matters);
+  await seedMatters(identity);
+
+  return identity;
+};

--- a/apps/web/src/routes/auth/-components/dev-quick-start.logic.ts
+++ b/apps/web/src/routes/auth/-components/dev-quick-start.logic.ts
@@ -1,3 +1,5 @@
+import { panic } from "better-result";
+
 export const DEV_QUICK_START_PHASE = {
   authenticate: "authenticate",
   organization: "organization",
@@ -18,6 +20,7 @@ export type DevQuickStartIdentity = {
 export type DevQuickStartAttempt = {
   completedPhase: DevQuickStartPhase | null;
   identity: DevQuickStartIdentity;
+  organizationId: string | null;
 };
 
 const DEV_QUICK_START_EMAIL = "dev-quick-start@stella.dev";
@@ -38,11 +41,14 @@ export const createDevQuickStartIdentity = (
 type RunDevQuickStartOptions = {
   attempt: DevQuickStartAttempt;
   authenticate: (identity: DevQuickStartIdentity) => Promise<void>;
-  createOrganization: (identity: DevQuickStartIdentity) => Promise<void>;
+  createOrganization: (identity: DevQuickStartIdentity) => Promise<string>;
+  onAttemptUpdated: (attempt: DevQuickStartAttempt) => void;
   onPhase: (phase: DevQuickStartPhase) => void;
-  onPhaseCompleted: (phase: DevQuickStartPhase) => void;
-  seedMatters: (identity: DevQuickStartIdentity) => Promise<void>;
-  seedSkills: () => Promise<void>;
+  seedMatters: (
+    identity: DevQuickStartIdentity,
+    organizationId: string,
+  ) => Promise<void>;
+  seedSkills: (organizationId: string) => Promise<void>;
 };
 
 const PHASE_ORDER = {
@@ -63,36 +69,63 @@ export const runDevQuickStart = async ({
   attempt,
   authenticate,
   createOrganization,
+  onAttemptUpdated,
   onPhase,
-  onPhaseCompleted,
   seedMatters,
   seedSkills,
 }: RunDevQuickStartOptions): Promise<void> => {
+  let currentAttempt = attempt;
+  const completePhase = (
+    completedPhase: DevQuickStartPhase,
+    organizationId = currentAttempt.organizationId,
+  ) => {
+    currentAttempt = {
+      completedPhase,
+      identity: currentAttempt.identity,
+      organizationId,
+    };
+    onAttemptUpdated(currentAttempt);
+  };
+
   if (
-    shouldRunPhase(attempt.completedPhase, DEV_QUICK_START_PHASE.authenticate)
+    shouldRunPhase(
+      currentAttempt.completedPhase,
+      DEV_QUICK_START_PHASE.authenticate,
+    )
   ) {
     onPhase(DEV_QUICK_START_PHASE.authenticate);
-    await authenticate(attempt.identity);
-    onPhaseCompleted(DEV_QUICK_START_PHASE.authenticate);
+    await authenticate(currentAttempt.identity);
+    completePhase(DEV_QUICK_START_PHASE.authenticate);
   }
 
   if (
-    shouldRunPhase(attempt.completedPhase, DEV_QUICK_START_PHASE.organization)
+    shouldRunPhase(
+      currentAttempt.completedPhase,
+      DEV_QUICK_START_PHASE.organization,
+    )
   ) {
     onPhase(DEV_QUICK_START_PHASE.organization);
-    await createOrganization(attempt.identity);
-    onPhaseCompleted(DEV_QUICK_START_PHASE.organization);
+    const organizationId = await createOrganization(currentAttempt.identity);
+    completePhase(DEV_QUICK_START_PHASE.organization, organizationId);
   }
 
-  if (shouldRunPhase(attempt.completedPhase, DEV_QUICK_START_PHASE.skills)) {
+  const organizationId =
+    currentAttempt.organizationId ??
+    panic("Dev quick start completed organization setup without an ID.");
+
+  if (
+    shouldRunPhase(currentAttempt.completedPhase, DEV_QUICK_START_PHASE.skills)
+  ) {
     onPhase(DEV_QUICK_START_PHASE.skills);
-    await seedSkills();
-    onPhaseCompleted(DEV_QUICK_START_PHASE.skills);
+    await seedSkills(organizationId);
+    completePhase(DEV_QUICK_START_PHASE.skills);
   }
 
-  if (shouldRunPhase(attempt.completedPhase, DEV_QUICK_START_PHASE.matters)) {
+  if (
+    shouldRunPhase(currentAttempt.completedPhase, DEV_QUICK_START_PHASE.matters)
+  ) {
     onPhase(DEV_QUICK_START_PHASE.matters);
-    await seedMatters(attempt.identity);
-    onPhaseCompleted(DEV_QUICK_START_PHASE.matters);
+    await seedMatters(currentAttempt.identity, organizationId);
+    completePhase(DEV_QUICK_START_PHASE.matters);
   }
 };

--- a/apps/web/src/routes/auth/-components/dev-quick-start.logic.ts
+++ b/apps/web/src/routes/auth/-components/dev-quick-start.logic.ts
@@ -15,6 +15,11 @@ export type DevQuickStartIdentity = {
   selectionSeed: string;
 };
 
+export type DevQuickStartAttempt = {
+  completedPhase: DevQuickStartPhase | null;
+  identity: DevQuickStartIdentity;
+};
+
 const DEV_QUICK_START_EMAIL = "dev-quick-start@stella.dev";
 
 export const createDevQuickStartIdentity = (
@@ -31,36 +36,63 @@ export const createDevQuickStartIdentity = (
 };
 
 type RunDevQuickStartOptions = {
+  attempt: DevQuickStartAttempt;
   authenticate: (identity: DevQuickStartIdentity) => Promise<void>;
   createOrganization: (identity: DevQuickStartIdentity) => Promise<void>;
   onPhase: (phase: DevQuickStartPhase) => void;
-  randomId: string;
+  onPhaseCompleted: (phase: DevQuickStartPhase) => void;
   seedMatters: (identity: DevQuickStartIdentity) => Promise<void>;
   seedSkills: () => Promise<void>;
 };
 
+const PHASE_ORDER = {
+  [DEV_QUICK_START_PHASE.authenticate]: 0,
+  [DEV_QUICK_START_PHASE.organization]: 1,
+  [DEV_QUICK_START_PHASE.skills]: 2,
+  [DEV_QUICK_START_PHASE.matters]: 3,
+} as const satisfies Record<DevQuickStartPhase, number>;
+
+const shouldRunPhase = (
+  completedPhase: DevQuickStartPhase | null,
+  phase: DevQuickStartPhase,
+): boolean =>
+  completedPhase === null || PHASE_ORDER[phase] > PHASE_ORDER[completedPhase];
+
 /** Runs the production-shaped boundaries in ownership order. */
 export const runDevQuickStart = async ({
+  attempt,
   authenticate,
   createOrganization,
   onPhase,
-  randomId,
+  onPhaseCompleted,
   seedMatters,
   seedSkills,
-}: RunDevQuickStartOptions): Promise<DevQuickStartIdentity> => {
-  const identity = createDevQuickStartIdentity(randomId);
+}: RunDevQuickStartOptions): Promise<void> => {
+  if (
+    shouldRunPhase(attempt.completedPhase, DEV_QUICK_START_PHASE.authenticate)
+  ) {
+    onPhase(DEV_QUICK_START_PHASE.authenticate);
+    await authenticate(attempt.identity);
+    onPhaseCompleted(DEV_QUICK_START_PHASE.authenticate);
+  }
 
-  onPhase(DEV_QUICK_START_PHASE.authenticate);
-  await authenticate(identity);
+  if (
+    shouldRunPhase(attempt.completedPhase, DEV_QUICK_START_PHASE.organization)
+  ) {
+    onPhase(DEV_QUICK_START_PHASE.organization);
+    await createOrganization(attempt.identity);
+    onPhaseCompleted(DEV_QUICK_START_PHASE.organization);
+  }
 
-  onPhase(DEV_QUICK_START_PHASE.organization);
-  await createOrganization(identity);
+  if (shouldRunPhase(attempt.completedPhase, DEV_QUICK_START_PHASE.skills)) {
+    onPhase(DEV_QUICK_START_PHASE.skills);
+    await seedSkills();
+    onPhaseCompleted(DEV_QUICK_START_PHASE.skills);
+  }
 
-  onPhase(DEV_QUICK_START_PHASE.skills);
-  await seedSkills();
-
-  onPhase(DEV_QUICK_START_PHASE.matters);
-  await seedMatters(identity);
-
-  return identity;
+  if (shouldRunPhase(attempt.completedPhase, DEV_QUICK_START_PHASE.matters)) {
+    onPhase(DEV_QUICK_START_PHASE.matters);
+    await seedMatters(attempt.identity);
+    onPhaseCompleted(DEV_QUICK_START_PHASE.matters);
+  }
 };

--- a/apps/web/src/routes/auth/index.tsx
+++ b/apps/web/src/routes/auth/index.tsx
@@ -1,3 +1,5 @@
+import * as React from "react";
+
 import { createFileRoute, redirect, useLocation } from "@tanstack/react-router";
 import * as v from "valibot";
 
@@ -9,6 +11,14 @@ import {
 } from "@/lib/oauth-provider";
 import { pageTitle } from "@/lib/page-title";
 import { normalizeRedirectTo } from "@/lib/redirect";
+
+const DevQuickStartButton = import.meta.env.DEV
+  ? React.lazy(async () => {
+      const module =
+        await import("@/routes/auth/-components/dev-quick-start-button");
+      return { default: module.DevQuickStartButton };
+    })
+  : null;
 
 const searchSchema = v.object({
   redirectTo: v.optional(v.pipe(v.string(), v.transform(normalizeRedirectTo))),
@@ -51,7 +61,16 @@ function LoginOrSignup() {
   });
   const redirectTo = getOauthPostLoginRedirectTo(location) ?? defaultRedirectTo;
 
-  return <SignInPanel redirectTo={redirectTo} />;
+  return (
+    <div className="flex w-full max-w-md flex-col gap-4">
+      <SignInPanel redirectTo={redirectTo} />
+      {DevQuickStartButton === null ? null : (
+        <React.Suspense fallback={null}>
+          <DevQuickStartButton redirectTo={redirectTo} />
+        </React.Suspense>
+      )}
+    </div>
+  );
 }
 
 const getOauthPostLoginRedirectTo = ({

--- a/apps/web/src/routes/auth/organization.tsx
+++ b/apps/web/src/routes/auth/organization.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { useRef } from "react";
 
 import { useForm } from "@tanstack/react-form";
@@ -52,8 +53,17 @@ import {
 import { toFormErrors } from "@/lib/schema";
 
 const searchSchema = v.object({
+  devQuickStart: v.optional(v.boolean()),
   redirectTo: v.optional(v.pipe(v.string(), v.transform(normalizeRedirectTo))),
 });
+
+const DevQuickStartContinuation = import.meta.env.DEV
+  ? React.lazy(async () => {
+      const module =
+        await import("@/routes/auth/-components/dev-quick-start-button");
+      return { default: module.DevQuickStartContinuation };
+    })
+  : null;
 
 export const Route = createFileRoute("/auth/organization")({
   validateSearch: searchSchema,
@@ -81,7 +91,10 @@ export const Route = createFileRoute("/auth/organization")({
     const isOauthPostLogin =
       bridgedQuery !== null || isOauthPostLoginFromSearch;
 
+    const isDevQuickStart =
+      import.meta.env.DEV && search.devQuickStart === true;
     if (
+      !isDevQuickStart &&
       !isOauthPostLogin &&
       (context.session.activeOrganizationId ||
         isAcceptInvitationRedirect(search.redirectTo ?? "/"))
@@ -95,9 +108,48 @@ export const Route = createFileRoute("/auth/organization")({
 });
 
 function Organization() {
+  const hydrated = useHydrated();
+  const { devQuickStart, redirectTo } = Route.useSearch({
+    select: (search) => ({
+      devQuickStart: search.devQuickStart,
+      redirectTo: search.redirectTo ?? "/",
+    }),
+  });
+
+  if (import.meta.env.DEV && devQuickStart && hydrated) {
+    if (DevQuickStartContinuation === null) {
+      return null;
+    }
+    return (
+      <React.Suspense fallback={<OrganizationSkeleton />}>
+        <DevQuickStartContinuation redirectTo={redirectTo} />
+      </React.Suspense>
+    );
+  }
+
+  if (!hydrated && import.meta.env.DEV && devQuickStart) {
+    return <OrganizationSkeleton />;
+  }
+
+  return <OrganizationFlow hydrated={hydrated} />;
+}
+
+const OrganizationSkeleton = () => (
+  <Frame className="w-full max-w-sm">
+    <FrameHeader>
+      <Skeleton className="h-5 w-48" />
+      <Skeleton className="mt-2 h-4 w-64" />
+    </FrameHeader>
+    <FramePanel className="flex flex-col gap-2">
+      <Skeleton className="h-16 w-full rounded-lg" />
+      <Skeleton className="h-16 w-full rounded-lg" />
+    </FramePanel>
+  </Frame>
+);
+
+const OrganizationFlow = ({ hydrated }: { hydrated: boolean }) => {
   const { data: organizations, isPending } = authClient.useListOrganizations();
   const hasOrganizations = (organizations?.length ?? 0) > 0;
-  const hydrated = useHydrated();
   const isOauthPostLoginFromSearch = Route.useRouteContext({
     select: (context) => context.isOauthPostLoginFromSearch,
   });
@@ -110,18 +162,7 @@ function Organization() {
   }
 
   if (!hydrated || isPending || (!hasOrganizations && !isOauthPostLogin)) {
-    return (
-      <Frame className="w-full max-w-sm">
-        <FrameHeader>
-          <Skeleton className="h-5 w-48" />
-          <Skeleton className="mt-2 h-4 w-64" />
-        </FrameHeader>
-        <FramePanel className="flex flex-col gap-2">
-          <Skeleton className="h-16 w-full rounded-lg" />
-          <Skeleton className="h-16 w-full rounded-lg" />
-        </FramePanel>
-      </Frame>
-    );
+    return <OrganizationSkeleton />;
   }
 
   return (
@@ -136,7 +177,7 @@ function Organization() {
       )}
     </div>
   );
-}
+};
 
 type OrganizationListProps = {
   isOauthPostLogin: boolean;

--- a/apps/web/src/routes/auth/two-factor.tsx
+++ b/apps/web/src/routes/auth/two-factor.tsx
@@ -5,6 +5,7 @@ import { TwoFactorPanel } from "@/components/auth/two-factor-panel";
 import { redirectToSchema } from "@/lib/redirect";
 
 const searchSchema = v.strictObject({
+  devQuickStart: v.optional(v.boolean()),
   redirectTo: redirectToSchema,
 });
 
@@ -14,7 +15,10 @@ export const Route = createFileRoute("/auth/two-factor")({
     if (context.session) {
       throw redirect({
         to: "/auth/organization",
-        search: { redirectTo: search.redirectTo },
+        search: {
+          devQuickStart: search.devQuickStart,
+          redirectTo: search.redirectTo,
+        },
         replace: true,
       });
     }

--- a/deploy/selfhost/.env.example
+++ b/deploy/selfhost/.env.example
@@ -32,6 +32,13 @@ STELLA_API_ENV_FILE="deploy/selfhost/.env"
 # [secret] Optional. Logs otlp token.
 # LOGS_OTLP_TOKEN=""
 
+# [internal] Optional with a default. Morphological expansion of case-law
+# search terms: "off" builds today's query, "shadow" runs the unexpanded query
+# and records leaf counts comparing it with the expanded one (never the query
+# text). "on" runs the expanded query and is currently refused at startup,
+# pending cursors that carry the dictionary version.
+# QUERY_EXPANSION_MODE="off"
+
 # [secret] Required. Valkey or Redis URL used for cross-instance broadcasts
 # and rate limits. Treated as secret because it may contain credentials.
 REDIS_URL="rediss://valkey.example.internal:6379"


### PR DESCRIPTION
## Summary

- add a development-only quick-start action that completes local OTP sign-in and creates a fresh Harvey LAB workspace
- install starter skills and launch a reproducibly randomized 10-matter Harvey LAB import
- keep serialized import state organization-scoped and pin background uploads to a short-lived job session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a development quick-start option on the sign-in page to authenticate, create an organisation, seed sample data, and resume interrupted setup.
  - Added progress feedback, success/error notifications, and protection against concurrent setup attempts.
  - Added configurable, repeatable matter selection and organisation-scoped setup status reporting.

- **Localisation**
  - Added translated quick-start content across supported languages.

- **Tests**
  - Added coverage for deterministic selection, workflow ordering, failure handling, and resumable setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->