### PR TITLE
fix: make mutation refresh policies exhaustive

### DIFF
--- a/.oxlint-plugins/README.md
+++ b/.oxlint-plugins/README.md
@@ -82,10 +82,12 @@ runtime validation, or integration tests.
 - [`no-detached-void`](./no-detached-void.ts) (`no-detached-void`): prevents `void promise` from hiding rejection ownership; use `await`, return the promise, or the monitored `detached()` helper.
 - [`no-disabled-tooltip-trigger`](./no-disabled-tooltip-trigger.ts) (`no-disabled-tooltip-trigger`): rejects tooltip triggers rendered as disabled buttons that cannot receive hover or focus events.
 - [`no-inline-endpoint-in-routes`](./no-inline-endpoint-in-routes.ts) (`no-inline-endpoint-in-routes`): requires route code to use owned API clients instead of declaring endpoints inline.
+- [`no-optional-mutation-command`](./no-optional-mutation-command.ts) (`no-optional-mutation-command`): rejects React Query mutation commands with multiple optional domain fields; use a discriminated union so empty, conflicting, and semantically ambiguous operations are unrepresentable.
 - [`no-inline-style-colors`](./no-inline-style-colors.ts) (`no-inline-style-colors`): rejects hardcoded color values only inside JSX `style={{ ... }}` objects; domain data objects are out of scope.
 - [`no-input-dir-auto`](./no-input-dir-auto.ts) (`no-input-dir-auto`): prevents `dir="auto"` on form inputs where direction changes can destabilize layout and value editing.
 - [`no-legacy-entity-route`](./no-legacy-entity-route.ts) (`no-legacy-entity-route`): prevents construction of the removed public entity detail route.
 - [`no-raw-route-query-client`](./no-raw-route-query-client.ts) (`no-raw-route-query-client`): requires route freshness wrappers in loaders and synchronous cache reads in pending components.
+- [`no-raw-router-invalidation`](./no-raw-router-invalidation.ts) (`no-raw-router-invalidation`): confines navigation-grade `router.invalidate()` calls to the owned session, locale, and exhaustively classified route-metadata boundaries.
 - [`no-raw-stored-json`](./no-raw-stored-json.ts) (`no-raw-stored-json`): requires persisted browser JSON to be parsed and schema-validated through `readStoredJson()`.
 - [`no-raw-use-effect`](./no-raw-use-effect.ts) (`no-raw-use-effect`): bans direct React `useEffect`; use the sanctioned lifecycle wrappers or a more precise primitive.
 - [`no-ref-mirror`](./no-ref-mirror.ts) (`no-ref-mirror`): rejects mirroring render values into refs during render, a stale-value and React Compiler hazard.
@@ -93,7 +95,7 @@ runtime validation, or integration tests.
 - [`no-static-catalogue-route-import`](./no-static-catalogue-route-import.ts) (`no-static-catalogue-route-import`): prevents static imports of large catalogue route modules that defeat route-level code splitting.
 - [`no-strict-route-read-in-chrome`](./no-strict-route-read-in-chrome.ts) (`no-strict-route-read-in-chrome`): prevents strict router reads in reusable chrome that can render outside the matching route.
 - [`require-cn-for-classname-composition`](./require-cn-for-classname-composition.ts) (`require-cn-for-classname-composition`): requires conditional, interpolated, concatenated, or helper-composed JSX class names to use `cn` from `@stll/ui/lib/utils`; static and pass-through values remain valid.
-- [`require-contained-handler`](./require-contained-handler.ts) (`require-contained-handler`): wraps handlers on ref-owned containers so portal-bubbled events do not trigger unrelated parent behavior.
+- [`require-contained-handler`](./require-contained-handler.ts) (`require-contained-handler`, `no-portal-under-interactive-ancestor`): wraps handlers on ref-owned containers and rejects portaled popups under interactive ancestors so portal-bubbled events cannot trigger unrelated parent behavior or navigation.
 - [`require-loader-prefetch`](./require-loader-prefetch.ts) (`require-loader-prefetch`): requires suspense query data to start in the route loader rather than after component mount.
 - [`require-query-key-factory`](./require-query-key-factory.ts) (`require-query-key-factory`): requires query keys to come from their feature-owned factory.
 - [`require-query-signal`](./require-query-signal.ts) (`require-query-signal`): requires query functions to pass TanStack Query's abort signal into fetch or Eden calls.

--- a/.oxlint-plugins/__fixtures__/no-optional-mutation-command.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-optional-mutation-command.fixture.ts
@@ -1,0 +1,43 @@
+// Passive regression fixture for
+// `no-optional-mutation-command/no-optional-mutation-command`.
+
+import { useMutation } from "@tanstack/react-query";
+
+import type { NonEmptyPatch } from "@/lib/mutation-command";
+
+const save = async (_value: unknown) => {
+  await Promise.resolve();
+};
+
+type OptionalUpdateBag = {
+  color?: string;
+  name?: string;
+};
+
+type ExplicitUpdate =
+  | { type: "color"; value: string }
+  | { type: "name"; value: string };
+
+export const useInlineOptionalBag = () =>
+  useMutation({
+    // oxlint-disable-next-line no-optional-mutation-command/no-optional-mutation-command -- fixture proves inline optional command bags are rejected
+    mutationFn: async (body: { color?: string; name?: string }) => save(body),
+  });
+
+export const useNamedOptionalBag = () =>
+  useMutation({
+    // oxlint-disable-next-line no-optional-mutation-command/no-optional-mutation-command -- fixture proves named optional command bags are rejected
+    mutationFn: async (body: OptionalUpdateBag) => save(body),
+  });
+
+export const useExplicitCommand = () =>
+  useMutation({
+    mutationFn: async (update: ExplicitUpdate) => save(update),
+  });
+
+export const useIntentionalBatchPatch = () =>
+  useMutation({
+    mutationFn: async (
+      patch: NonEmptyPatch<{ color: string; name: string }>,
+    ) => save(patch),
+  });

--- a/.oxlint-plugins/__fixtures__/no-optional-mutation-command.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-optional-mutation-command.fixture.ts
@@ -30,6 +30,17 @@ export const useNamedOptionalBag = () =>
     mutationFn: async (body: OptionalUpdateBag) => save(body),
   });
 
+export const useLaterDeclaredOptionalBag = () =>
+  useMutation({
+    // oxlint-disable-next-line no-optional-mutation-command/no-optional-mutation-command -- fixture proves declaration order cannot evade the rule
+    mutationFn: async (body: LaterDeclaredOptionalBag) => save(body),
+  });
+
+type LaterDeclaredOptionalBag = {
+  color?: string;
+  name?: string;
+};
+
 export const useExplicitCommand = () =>
   useMutation({
     mutationFn: async (update: ExplicitUpdate) => save(update),

--- a/.oxlint-plugins/__fixtures__/no-raw-router-invalidation.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-raw-router-invalidation.fixture.ts
@@ -1,0 +1,24 @@
+// Passive regression fixture for
+// `no-raw-router-invalidation/no-raw-router-invalidation`.
+
+import { useRouter } from "@tanstack/react-router";
+
+export const useRawRouterInvalidation = () => {
+  const router = useRouter();
+  return async () => {
+    // oxlint-disable-next-line no-raw-router-invalidation/no-raw-router-invalidation -- fixture proves raw router invalidation is confined to owned boundaries
+    await router.invalidate();
+  };
+};
+
+export const useDestructuredRouterInvalidation = () => {
+  const { invalidate } = useRouter();
+  return async () => {
+    // oxlint-disable-next-line no-raw-router-invalidation/no-raw-router-invalidation -- fixture proves destructuring cannot evade the boundary
+    await invalidate();
+  };
+};
+
+export const unrelatedInvalidation = (guard: { invalidate: () => void }) => {
+  guard.invalidate();
+};

--- a/.oxlint-plugins/__fixtures__/require-contained-handler.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/require-contained-handler.fixture.tsx
@@ -8,7 +8,11 @@
 
 import type { RefObject, SyntheticEvent } from "react";
 
-import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
+import {
+  containedEventHandler,
+  containedHandler,
+} from "@stll/ui/hooks/use-contained-handler";
+import { PopoverPopup } from "@stll/ui/components/popover";
 
 const noop = (_event?: SyntheticEvent) => undefined;
 
@@ -65,6 +69,22 @@ export const FlagWrongCall = () => (
   />
 );
 
+export const FlagBareContextMenu = () => (
+  <button
+    type="button"
+    ref={buttonRef}
+    // oxlint-disable-next-line require-contained-handler/require-contained-handler -- fixture proves context-menu events are contained too
+    onContextMenu={noop}
+  />
+);
+
+export const FlagPortalUnderInteractiveAncestor = () => (
+  <button type="button">
+    {/* oxlint-disable-next-line require-contained-handler/no-portal-under-interactive-ancestor -- fixture proves portaled popups cannot live under interactive ancestors */}
+    <PopoverPopup>Popup</PopoverPopup>
+  </button>
+);
+
 // --- Cases the rule MUST NOT flag ---
 
 export const Wrapped = () => (
@@ -83,11 +103,26 @@ export const ConditionalWrapped = ({ inline }: { inline: boolean }) => (
   />
 );
 
+export const WrappedWithCurrentTarget = () => (
+  <button
+    type="button"
+    ref={buttonRef}
+    onContextMenu={containedEventHandler(noop)}
+  />
+);
+
 export const UndefinedHandler = () => (
   <button type="button" ref={buttonRef} onMouseDown={undefined} />
 );
 
 export const NoRef = () => <button type="button" onMouseDown={noop} />;
+
+export const PortalBesideInteractiveTrigger = () => (
+  <>
+    <button type="button">Open</button>
+    <PopoverPopup>Popup</PopoverPopup>
+  </>
+);
 
 export const NoWatchedHandler = () => (
   <button type="button" ref={buttonRef} onChange={noop} />

--- a/.oxlint-plugins/no-optional-mutation-command.ts
+++ b/.oxlint-plugins/no-optional-mutation-command.ts
@@ -1,0 +1,169 @@
+// Require React Query mutation commands to preserve operation identity.
+//
+// A mutation parameter with multiple optional domain fields admits an empty
+// command and several unrelated operations at once. It also forces success
+// effects to infer intent from field presence, which allowed a workspace color
+// update to inherit rename-only route invalidation. Use a discriminated union;
+// one variant may still carry a compound payload when fields form one atomic
+// operation.
+//
+// Flagged:
+//   useMutation({
+//     mutationFn: async (body: { name?: string; color?: string }) => save(body),
+//   })
+//
+// Allowed:
+//   type Update =
+//     | { type: "name"; value: string }
+//     | { type: "color"; value: string };
+//   useMutation({ mutationFn: async (update: Update) => save(update) })
+
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import {
+  getImportLocalName,
+  getImportedName,
+  getPropertyName,
+  isAstNode,
+  isIdentifier,
+  isStringLiteral,
+} from "./utils.ts";
+
+const REACT_QUERY_MODULE = "@tanstack/react-query";
+
+const isIdentityProperty = (name: string | null) =>
+  name === "id" || name?.endsWith("Id") === true;
+
+const isAmbiguousOptionalBag = (typeNode: unknown): boolean => {
+  if (!isAstNode(typeNode)) {
+    return false;
+  }
+  if (typeNode.type === "TSTypeLiteral") {
+    const members = Array.isArray(typeNode.members) ? typeNode.members : [];
+    const propertyMembers = members.filter(
+      (member) =>
+        isAstNode(member) &&
+        member.type === "TSPropertySignature",
+    );
+    const optionalCount = propertyMembers.filter(
+      (member) => member.optional === true,
+    ).length;
+    const hasRequiredDomainField = propertyMembers.some(
+      (member) =>
+        member.optional !== true &&
+        !isIdentityProperty(getPropertyName(member.key)),
+    );
+    return optionalCount >= 2 && !hasRequiredDomainField;
+  }
+  return false;
+};
+
+const parameterType = (parameter: unknown) => {
+  if (!isAstNode(parameter)) {
+    return null;
+  }
+  const annotation = parameter.typeAnnotation;
+  if (!isAstNode(annotation) || annotation.type !== "TSTypeAnnotation") {
+    return null;
+  }
+  return isAstNode(annotation.typeAnnotation) ? annotation.typeAnnotation : null;
+};
+
+const mutationFunctionFromOptions = (options: unknown) => {
+  if (!isAstNode(options) || options.type !== "ObjectExpression") {
+    return null;
+  }
+  const properties = Array.isArray(options.properties) ? options.properties : [];
+  for (const property of properties) {
+    if (
+      !isAstNode(property) ||
+      property.type !== "Property" ||
+      getPropertyName(property.key) !== "mutationFn"
+    ) {
+      continue;
+    }
+    return isAstNode(property.value) ? property.value : null;
+  }
+  return null;
+};
+
+export default eslintCompatPlugin({
+  meta: { name: "no-optional-mutation-command" },
+  rules: {
+    "no-optional-mutation-command": {
+      meta: {
+        type: "problem",
+        messages: {
+          optionalBag:
+            "Mutation commands with multiple optional domain fields lose " +
+            "operation identity and admit empty or conflicting updates. Use " +
+            "a discriminated union with one explicit variant per operation.",
+        },
+      },
+      createOnce(context) {
+        const useMutationNames = new Set<string>();
+        const localTypeNodes = new Map<string, unknown>();
+
+        return {
+          ImportDeclaration(node) {
+            if (
+              !isStringLiteral(node.source) ||
+              node.source.value !== REACT_QUERY_MODULE
+            ) {
+              return;
+            }
+            const specifiers = Array.isArray(node.specifiers)
+              ? node.specifiers
+              : [];
+            for (const specifier of specifiers) {
+              if (getImportedName(specifier) !== "useMutation") {
+                continue;
+              }
+              const localName = getImportLocalName(specifier);
+              if (localName !== null) {
+                useMutationNames.add(localName);
+              }
+            }
+          },
+          TSTypeAliasDeclaration(node) {
+            if (isIdentifier(node.id) && isAstNode(node.typeAnnotation)) {
+              localTypeNodes.set(node.id.name, node.typeAnnotation);
+            }
+          },
+          CallExpression(node) {
+            if (
+              !isIdentifier(node.callee) ||
+              !useMutationNames.has(node.callee.name)
+            ) {
+              return;
+            }
+            const mutationFunction = mutationFunctionFromOptions(
+              node.arguments?.[0],
+            );
+            if (
+              !isAstNode(mutationFunction) ||
+              (mutationFunction.type !== "ArrowFunctionExpression" &&
+                mutationFunction.type !== "FunctionExpression")
+            ) {
+              return;
+            }
+            const parameter = mutationFunction.params?.[0];
+            const typeNode = parameterType(parameter);
+            if (typeNode === null) {
+              return;
+            }
+            const resolvedType =
+              typeNode.type === "TSTypeReference" &&
+              isIdentifier(typeNode.typeName)
+                ? localTypeNodes.get(typeNode.typeName.name)
+                : typeNode;
+            if (!isAmbiguousOptionalBag(resolvedType)) {
+              return;
+            }
+            context.report({ node: parameter, messageId: "optionalBag" });
+          },
+        };
+      },
+    },
+  },
+});

--- a/.oxlint-plugins/no-optional-mutation-command.ts
+++ b/.oxlint-plugins/no-optional-mutation-command.ts
@@ -103,6 +103,43 @@ export default eslintCompatPlugin({
       createOnce(context) {
         const useMutationNames = new Set<string>();
         const localTypeNodes = new Map<string, unknown>();
+        const callExpressions: unknown[] = [];
+
+        const reportAmbiguousMutation = (node: unknown) => {
+          if (!isAstNode(node) || node.type !== "CallExpression") {
+            return;
+          }
+          if (
+            !isIdentifier(node.callee) ||
+            !useMutationNames.has(node.callee.name)
+          ) {
+            return;
+          }
+          const mutationFunction = mutationFunctionFromOptions(
+            node.arguments?.[0],
+          );
+          if (
+            !isAstNode(mutationFunction) ||
+            (mutationFunction.type !== "ArrowFunctionExpression" &&
+              mutationFunction.type !== "FunctionExpression")
+          ) {
+            return;
+          }
+          const parameter = mutationFunction.params?.[0];
+          const typeNode = parameterType(parameter);
+          if (typeNode === null) {
+            return;
+          }
+          const resolvedType =
+            typeNode.type === "TSTypeReference" &&
+            isIdentifier(typeNode.typeName)
+              ? localTypeNodes.get(typeNode.typeName.name)
+              : typeNode;
+          if (!isAmbiguousOptionalBag(resolvedType)) {
+            return;
+          }
+          context.report({ node: parameter, messageId: "optionalBag" });
+        };
 
         return {
           ImportDeclaration(node) {
@@ -131,36 +168,12 @@ export default eslintCompatPlugin({
             }
           },
           CallExpression(node) {
-            if (
-              !isIdentifier(node.callee) ||
-              !useMutationNames.has(node.callee.name)
-            ) {
-              return;
+            callExpressions.push(node);
+          },
+          "Program:exit"() {
+            for (const callExpression of callExpressions) {
+              reportAmbiguousMutation(callExpression);
             }
-            const mutationFunction = mutationFunctionFromOptions(
-              node.arguments?.[0],
-            );
-            if (
-              !isAstNode(mutationFunction) ||
-              (mutationFunction.type !== "ArrowFunctionExpression" &&
-                mutationFunction.type !== "FunctionExpression")
-            ) {
-              return;
-            }
-            const parameter = mutationFunction.params?.[0];
-            const typeNode = parameterType(parameter);
-            if (typeNode === null) {
-              return;
-            }
-            const resolvedType =
-              typeNode.type === "TSTypeReference" &&
-              isIdentifier(typeNode.typeName)
-                ? localTypeNodes.get(typeNode.typeName.name)
-                : typeNode;
-            if (!isAmbiguousOptionalBag(resolvedType)) {
-              return;
-            }
-            context.report({ node: parameter, messageId: "optionalBag" });
           },
         };
       },

--- a/.oxlint-plugins/no-raw-router-invalidation.ts
+++ b/.oxlint-plugins/no-raw-router-invalidation.ts
@@ -1,0 +1,128 @@
+// Confine TanStack Router invalidation to its three owned lifecycle boundaries.
+//
+// `router.invalidate()` is navigation-grade work: it reruns route context,
+// beforeLoad, loaders, and head resolution. Query mutations must not use it as
+// a broad cache refresh. The workspace boundary is additionally constrained by
+// its total `WorkspaceUpdate["type"] -> refresh scope` policy.
+
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import {
+  filenameForContext,
+  getImportLocalName,
+  getImportedName,
+  getPropertyName,
+  isAstNode,
+  isIdentifier,
+  isStringLiteral,
+} from "./utils.ts";
+
+const ROUTER_MODULE = "@tanstack/react-router";
+
+const OWNED_INVALIDATION_FILES = new Set([
+  "apps/web/src/app-providers.tsx",
+  "apps/web/src/hooks/use-invalidate-session.ts",
+  "apps/web/src/lib/workspaces/mutations.ts",
+]);
+
+export default eslintCompatPlugin({
+  meta: { name: "no-raw-router-invalidation" },
+  rules: {
+    "no-raw-router-invalidation": {
+      meta: {
+        type: "problem",
+        messages: {
+          rawInvalidation:
+            "`router.invalidate()` reruns the active route and may remount " +
+            "local UI. Keep it inside an owned session, locale, or exhaustive " +
+            "route-metadata refresh boundary; use query invalidation for data.",
+        },
+      },
+      createOnce(context) {
+        const useRouterNames = new Set<string>();
+        const routerObjectNames = new Set<string>();
+        const invalidateFunctionNames = new Set<string>();
+        let isOwnedFile = false;
+
+        return {
+          before() {
+            const filename = filenameForContext(context);
+            isOwnedFile = [...OWNED_INVALIDATION_FILES].some((ownedFile) =>
+              filename.endsWith(ownedFile),
+            );
+          },
+          ImportDeclaration(node) {
+            if (
+              !isStringLiteral(node.source) ||
+              node.source.value !== ROUTER_MODULE
+            ) {
+              return;
+            }
+            const specifiers = Array.isArray(node.specifiers)
+              ? node.specifiers
+              : [];
+            for (const specifier of specifiers) {
+              if (getImportedName(specifier) !== "useRouter") {
+                continue;
+              }
+              const localName = getImportLocalName(specifier);
+              if (localName !== null) {
+                useRouterNames.add(localName);
+              }
+            }
+          },
+          VariableDeclarator(node) {
+            if (
+              !isAstNode(node.init) ||
+              node.init.type !== "CallExpression" ||
+              !isIdentifier(node.init.callee) ||
+              !useRouterNames.has(node.init.callee.name)
+            ) {
+              return;
+            }
+            if (isIdentifier(node.id)) {
+              routerObjectNames.add(node.id.name);
+              return;
+            }
+            if (!isAstNode(node.id) || node.id.type !== "ObjectPattern") {
+              return;
+            }
+            const properties = Array.isArray(node.id.properties)
+              ? node.id.properties
+              : [];
+            for (const property of properties) {
+              if (
+                !isAstNode(property) ||
+                property.type !== "Property" ||
+                getPropertyName(property.key) !== "invalidate" ||
+                !isIdentifier(property.value)
+              ) {
+                continue;
+              }
+              invalidateFunctionNames.add(property.value.name);
+            }
+          },
+          CallExpression(node) {
+            const callsDestructuredInvalidation =
+              isIdentifier(node.callee) &&
+              invalidateFunctionNames.has(node.callee.name);
+            const callsRouterInvalidation =
+              isAstNode(node.callee) &&
+              node.callee.type === "MemberExpression" &&
+              node.callee.computed === false &&
+              isIdentifier(node.callee.object) &&
+              routerObjectNames.has(node.callee.object.name) &&
+              getPropertyName(node.callee.property) === "invalidate";
+            if (
+              isOwnedFile ||
+              (!callsDestructuredInvalidation && !callsRouterInvalidation)
+            ) {
+              return;
+            }
+            context.report({ node, messageId: "rawInvalidation" });
+          },
+        };
+      },
+    },
+  },
+});

--- a/.oxlint-plugins/require-contained-handler.ts
+++ b/.oxlint-plugins/require-contained-handler.ts
@@ -1,7 +1,7 @@
 import { eslintCompatPlugin } from "@oxlint/plugins";
 
-// Require event handlers on ref-tracked containers to be wrapped in
-// `containedHandler` from `@stll/ui/hooks/use-contained-handler`.
+// Require event handlers on ref-tracked containers to be wrapped in a
+// containment helper from `@stll/ui/hooks/use-contained-handler`.
 //
 // React forwards synthetic events through the parent React tree even when
 // descendants are rendered via createPortal. A handler attached to a
@@ -15,9 +15,9 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 // This rule flags any JSX element that has both:
 //   - a `ref={<Identifier>}` attribute
 //   - one or more event-handler attributes from WATCHED_HANDLERS
-// where the handler value is not a direct `containedHandler(refIdent, …)`
-// call. The containedHandler helper short-circuits when the event target
-// is outside the ref's DOM subtree.
+// where the handler value is not a direct containment-helper call. Both
+// helpers short-circuit when the event target is outside the element's DOM
+// subtree; `containedEventHandler` uses `currentTarget` and needs no ref.
 //
 // Flagged:
 //   <div ref={barRef} onMouseDown={handleBarMouseDown}>...</div>
@@ -44,12 +44,26 @@ const WATCHED_HANDLERS = new Set([
   "onMouseDown",
   "onMouseUp",
   "onClick",
+  "onContextMenu",
   "onPointerDown",
   "onPointerUp",
   "onFocus",
   "onTouchStart",
   "onTouchEnd",
 ]);
+
+const PORTAL_POPUPS = new Set([
+  "ComboboxPopup",
+  "DialogContent",
+  "DialogPopup",
+  "MenuPopup",
+  "PopoverContent",
+  "PopoverPanel",
+  "PopoverPopup",
+  "TooltipPopup",
+]);
+
+const INTERACTIVE_ELEMENTS = new Set(["a", "button", "Button", "Link"]);
 
 // Void/leaf form elements cannot have React-tree descendants, so a
 // portaled popup can never bubble through them. Wrapping their handlers
@@ -73,14 +87,47 @@ const LEAF_ELEMENTS = new Set([
   "wbr",
 ]);
 
-const HELPER_NAME = "containedHandler";
+const HELPER_NAMES = new Set(["containedEventHandler", "containedHandler"]);
 
 const jsxAttrName = (attr) =>
   attr?.name?.type === "JSXIdentifier" && typeof attr.name.name === "string"
     ? attr.name.name
     : null;
 
-const isPlainIdentifier = (node, name) =>
+const jsxElementName = (node) =>
+  node?.type === "JSXIdentifier" && typeof node.name === "string"
+    ? node.name
+    : null;
+
+const openingHasInteractiveHandler = (opening) =>
+  (opening.attributes ?? []).some((attr) => {
+    const attrName = jsxAttrName(attr);
+    if (attrName === null || !WATCHED_HANDLERS.has(attrName)) {
+      return false;
+    }
+    return !isSafeHandlerValue(expressionFromAttribute(attr));
+  });
+
+const interactiveAncestorName = (opening) => {
+  let current = opening.parent?.parent;
+  while (current && typeof current === "object") {
+    if (current.type === "JSXElement") {
+      const ancestorOpening = current.openingElement;
+      const ancestorName = jsxElementName(ancestorOpening?.name);
+      if (
+        ancestorName !== null &&
+        (INTERACTIVE_ELEMENTS.has(ancestorName) ||
+          openingHasInteractiveHandler(ancestorOpening))
+      ) {
+        return ancestorName;
+      }
+    }
+    current = current.parent;
+  }
+  return null;
+};
+
+const isPlainIdentifier = (node, name?: string) =>
   node?.type === "Identifier" &&
   typeof node.name === "string" &&
   (name === undefined || node.name === name);
@@ -100,7 +147,7 @@ const expressionFromAttribute = (attr) => {
 // Callback refs (`ref={setRowRef}` where `setRowRef` forwards to a real
 // useRef) are common in this codebase, and the wrapping should be tied
 // to the underlying useRef, not the callback. The check still ensures the
-// handler is structurally a containedHandler call.
+// handler is structurally a recognized containment-helper call.
 const isSafeHandlerValue = (expr) => {
   if (!expr) {
     return true;
@@ -112,7 +159,7 @@ const isSafeHandlerValue = (expr) => {
     return true;
   }
   if (expr.type === "CallExpression") {
-    return isPlainIdentifier(expr.callee, HELPER_NAME);
+    return isPlainIdentifier(expr.callee) && HELPER_NAMES.has(expr.callee.name);
   }
   if (expr.type === "ConditionalExpression") {
     return (
@@ -170,6 +217,37 @@ const findRefDisplayName = (attributes) => {
 export default eslintCompatPlugin({
   meta: { name: "require-contained-handler" },
   rules: {
+    "no-portal-under-interactive-ancestor": {
+      meta: {
+        type: "problem",
+        messages: {
+          portalUnderInteractive:
+            "`<{{popup}}>` portals its events through the React tree but is " +
+            "nested under interactive `<{{ancestor}}>`. Hoist the popup/root " +
+            "outside that interactive subtree so popup events cannot trigger " +
+            "navigation or parent actions.",
+        },
+      },
+      createOnce(context) {
+        return {
+          JSXOpeningElement(opening) {
+            const popupName = jsxElementName(opening.name);
+            if (popupName === null || !PORTAL_POPUPS.has(popupName)) {
+              return;
+            }
+            const ancestorName = interactiveAncestorName(opening);
+            if (ancestorName === null) {
+              return;
+            }
+            context.report({
+              node: opening,
+              messageId: "portalUnderInteractive",
+              data: { ancestor: ancestorName, popup: popupName },
+            });
+          },
+        };
+      },
+    },
     "require-contained-handler": {
       meta: {
         type: "problem",

--- a/apps/web/e2e/specs/matter-color-picker.spec.ts
+++ b/apps/web/e2e/specs/matter-color-picker.spec.ts
@@ -45,7 +45,7 @@ test("sidebar color picker stays open when custom colors are expanded", async ({
 
     const colorUpdate = page.waitForResponse(
       (response) =>
-        response.request().method() === "PATCH" &&
+        response.request().method() === "POST" &&
         response.url().includes(`/workspaces/${workspace.id}`),
     );
     await customColorInput.fill("12AB34");

--- a/apps/web/e2e/specs/matter-color-picker.spec.ts
+++ b/apps/web/e2e/specs/matter-color-picker.spec.ts
@@ -38,9 +38,22 @@ test("sidebar color picker stays open when custom colors are expanded", async ({
     ).toHaveCount(1);
     await colorPicker.getByRole("button", { name: "Show more" }).click();
 
-    await expect(
-      page.getByRole("textbox", { name: "Custom hex color" }),
-    ).toBeVisible();
+    const customColorInput = page.getByRole("textbox", {
+      name: "Custom hex color",
+    });
+    await expect(customColorInput).toBeVisible();
+
+    const colorUpdate = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PATCH" &&
+        response.url().includes(`/workspaces/${workspace.id}`),
+    );
+    await customColorInput.fill("12AB34");
+    const colorUpdateResponse = await colorUpdate;
+    expect(colorUpdateResponse.ok()).toBe(true);
+
+    await expect(customColorInput).toHaveValue("12AB34");
+    await expect(customColorInput).toBeVisible();
     await expect(page).toHaveURL(
       new RegExp(`/workspaces/${workspace.id}/${workspace.viewId}$`, "u"),
     );

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -53,6 +53,7 @@ import {
   MenuTrigger,
 } from "@stll/ui/components/menu";
 import { stellaToast } from "@stll/ui/components/toast";
+import { containedEventHandler } from "@stll/ui/hooks/use-contained-handler";
 import { cn } from "@stll/ui/lib/utils";
 
 import {
@@ -804,7 +805,7 @@ const NavContextMenu = ({
   return (
     <div
       className="contents"
-      onContextMenu={(e) => {
+      onContextMenu={containedEventHandler((e) => {
         e.preventDefault();
         e.stopPropagation();
         const x = e.clientX;
@@ -813,7 +814,7 @@ const NavContextMenu = ({
           getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
         });
         setOpen(true);
-      }}
+      })}
     >
       {children}
       <Menu
@@ -1209,7 +1210,7 @@ const MatterItem = ({
           isEntityDropTarget &&
             "bg-primary/8 ring-primary rounded-md ring-2 ring-inset",
         )}
-        onContextMenu={(e) => {
+        onContextMenu={containedEventHandler((e) => {
           e.preventDefault();
           e.stopPropagation();
           const x = e.clientX;
@@ -1218,7 +1219,7 @@ const MatterItem = ({
             getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
           });
           setMenuOpen(true);
-        }}
+        })}
         ref={dropRef}
       >
         {activityIsKnownEmpty ? null : (
@@ -1583,7 +1584,7 @@ const SidebarContextArea = ({
   return (
     <div
       className="flex min-h-0 flex-1 flex-col"
-      onContextMenu={(e) => {
+      onContextMenu={containedEventHandler((e) => {
         e.preventDefault();
         const x = e.clientX;
         const y = e.clientY;
@@ -1591,7 +1592,7 @@ const SidebarContextArea = ({
           getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
         });
         setCtxOpen(true);
-      }}
+      })}
     >
       {children}
       <Menu

--- a/apps/web/src/components/inspector/inspector-rail.tsx
+++ b/apps/web/src/components/inspector/inspector-rail.tsx
@@ -11,7 +11,10 @@ import {
 import { useTranslations } from "use-intl";
 
 import { ScrollArea } from "@stll/ui/components/scroll-area";
-import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
+import {
+  containedEventHandler,
+  containedHandler,
+} from "@stll/ui/hooks/use-contained-handler";
 import { cn } from "@stll/ui/lib/utils";
 
 import { DocumentIcon } from "@/components/document-icon";
@@ -539,7 +542,7 @@ const VerticalTab = ({
             }}
             // eslint-disable-next-line react/react-compiler -- containedHandler reads tabRef.current only at event time, not during render; passing the ref here is the portal-safety pattern mandated by the require-contained-handler rule
             onClick={containedHandler(tabRef, onActivate)}
-            onContextMenu={contextMenu.openAt}
+            onContextMenu={containedEventHandler(contextMenu.openAt)}
             type="button"
           />
         }

--- a/apps/web/src/components/workspaces/tasks/task-detail-panel.logic.test.ts
+++ b/apps/web/src/components/workspaces/tasks/task-detail-panel.logic.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
+import { toSafeId } from "@/lib/safe-id";
+
 import {
   getTaskDetailInstanceKey,
   getTaskStatusUpdate,
+  taskUpdateBody,
+  workflowUpdateBody,
 } from "./task-detail-panel.logic";
 
 describe("task detail compatibility updates", () => {
@@ -11,12 +15,64 @@ describe("task detail compatibility updates", () => {
       getTaskStatusUpdate("task-1", "cancelled", "  No longer needed  "),
     ).toEqual({
       taskId: "task-1",
-      status: "cancelled",
-      workflowReason: "No longer needed",
+      type: "status",
+      value: {
+        status: "cancelled",
+        workflowReason: "No longer needed",
+      },
     });
     expect(
       getTaskStatusUpdate("task-1", "in_review", "Keep this draft"),
-    ).toEqual({ taskId: "task-1", status: "in_review" });
+    ).toEqual({
+      taskId: "task-1",
+      type: "status",
+      value: { status: "in_review" },
+    });
+  });
+
+  test("maps every task command to one API update", () => {
+    expect([
+      taskUpdateBody({ taskId: "task-1", type: "name", value: "Review" }),
+      taskUpdateBody({ taskId: "task-1", type: "priority", value: "high" }),
+      taskUpdateBody({ taskId: "task-1", type: "dueDate", value: null }),
+      taskUpdateBody({
+        taskId: "task-1",
+        type: "listItemType",
+        value: "task",
+      }),
+      taskUpdateBody({
+        taskId: "task-1",
+        type: "status",
+        value: { status: "cancelled", workflowReason: "Superseded" },
+      }),
+    ]).toEqual([
+      { name: "Review" },
+      { priority: "high" },
+      { dueDate: null },
+      { listItemType: "task" },
+      { status: "cancelled", workflowReason: "Superseded" },
+    ]);
+  });
+
+  test("maps every workflow command to one API update", () => {
+    const ownerUserId = toSafeId<"user">("user-1");
+    expect([
+      workflowUpdateBody({
+        type: "owner",
+        value: { ownerUserId, reason: "Delegated" },
+      }),
+      workflowUpdateBody({ type: "workingTargetDate", value: null }),
+      workflowUpdateBody({
+        type: "hardDeadline",
+        value: { hardDeadlineDate: "2026-08-20", reason: "Court order" },
+      }),
+      workflowUpdateBody({ type: "type", value: "deadline" }),
+    ]).toEqual([
+      { ownerUserId, reason: "Delegated" },
+      { workingTargetDate: null },
+      { hardDeadlineDate: "2026-08-20", reason: "Court order" },
+      { type: "deadline" },
+    ]);
   });
 });
 

--- a/apps/web/src/components/workspaces/tasks/task-detail-panel.logic.ts
+++ b/apps/web/src/components/workspaces/tasks/task-detail-panel.logic.ts
@@ -1,5 +1,10 @@
 import type { TaskStatus } from "@stll/api-contract";
 
+import { toSafeId } from "@/lib/safe-id";
+
+import type { ListItemType, TaskPriority } from "./task-detail-constants";
+import type { WorkType } from "./task-metadata";
+
 type TaskDetailIdentity = {
   workspaceId: string;
   taskId: string;
@@ -10,15 +15,110 @@ export const getTaskDetailInstanceKey = ({
   taskId,
 }: TaskDetailIdentity) => `${workspaceId}:${taskId}`;
 
+type TaskUpdateValueByType = {
+  dueDate: string | null;
+  listItemType: ListItemType;
+  name: string;
+  priority: TaskPriority;
+  status: {
+    status: TaskStatus;
+    workflowReason?: string;
+  };
+};
+
+type TaskUpdateType = keyof TaskUpdateValueByType;
+
+export type TaskUpdate = {
+  [Type in TaskUpdateType]: {
+    taskId: string;
+    type: Type;
+    value: TaskUpdateValueByType[Type];
+  };
+}[TaskUpdateType];
+
+export const taskUpdateBody = (update: TaskUpdate) => {
+  switch (update.type) {
+    case "dueDate":
+      return { dueDate: update.value };
+    case "listItemType":
+      return { listItemType: update.value };
+    case "name":
+      return { name: update.value };
+    case "priority":
+      return { priority: update.value };
+    case "status":
+      return update.value;
+    default: {
+      const unreachable: never = update;
+      return unreachable;
+    }
+  }
+};
+
+export const taskUpdateClearsWorkflowReason = (update: TaskUpdate) =>
+  update.type === "status" && update.value.workflowReason !== undefined;
+
+type WorkflowUpdateValueByType = {
+  hardDeadline: {
+    hardDeadlineDate: string | null;
+    reason?: string;
+  };
+  owner: {
+    ownerUserId: string | null;
+    reason?: string;
+  };
+  type: WorkType;
+  workingTargetDate: string | null;
+};
+
+type WorkflowUpdateType = keyof WorkflowUpdateValueByType;
+
+export type WorkflowUpdate = {
+  [Type in WorkflowUpdateType]: {
+    type: Type;
+    value: WorkflowUpdateValueByType[Type];
+  };
+}[WorkflowUpdateType];
+
+export const workflowUpdateBody = (update: WorkflowUpdate) => {
+  switch (update.type) {
+    case "hardDeadline":
+      return update.value;
+    case "owner":
+      return {
+        ...update.value,
+        ownerUserId:
+          update.value.ownerUserId === null
+            ? null
+            : toSafeId<"user">(update.value.ownerUserId),
+      };
+    case "type":
+      return { type: update.value };
+    case "workingTargetDate":
+      return { workingTargetDate: update.value };
+    default: {
+      const unreachable: never = update;
+      return unreachable;
+    }
+  }
+};
+
+export const workflowUpdateClearsReason = (update: WorkflowUpdate) =>
+  (update.type === "hardDeadline" || update.type === "owner") &&
+  update.value.reason !== undefined;
+
 export const getTaskStatusUpdate = (
   taskId: string,
   status: TaskStatus,
   workflowReason: string,
-) => {
+): TaskUpdate => {
   const reason = workflowReason.trim();
   return {
     taskId,
-    status,
-    ...(status === "cancelled" && reason ? { workflowReason: reason } : {}),
+    type: "status",
+    value: {
+      status,
+      ...(status === "cancelled" && reason ? { workflowReason: reason } : {}),
+    },
   };
 };

--- a/apps/web/src/components/workspaces/tasks/task-detail-panel.tsx
+++ b/apps/web/src/components/workspaces/tasks/task-detail-panel.tsx
@@ -34,6 +34,14 @@ import {
 import {
   getTaskDetailInstanceKey,
   getTaskStatusUpdate,
+  taskUpdateBody,
+  taskUpdateClearsWorkflowReason,
+  workflowUpdateBody,
+  workflowUpdateClearsReason,
+} from "@/components/workspaces/tasks/task-detail-panel.logic";
+import type {
+  TaskUpdate,
+  WorkflowUpdate,
 } from "@/components/workspaces/tasks/task-detail-panel.logic";
 import { LinksSection } from "@/components/workspaces/tasks/task-links";
 import {
@@ -124,25 +132,17 @@ const TaskDetailPanelContent = ({
   const name = task?.name ?? t("untitled");
 
   const updateMutation = useMutation({
-    mutationFn: async (body: {
-      taskId: string;
-      name?: string;
-      status?: string;
-      priority?: string;
-      dueDate?: string | null;
-      workflowReason?: string;
-      listItemType?: string;
-    }) => {
+    mutationFn: async (update: TaskUpdate) => {
       const response = await api
         .tasks({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .patch({
-          ...body,
-          taskId: toSafeId<"entity">(body.taskId),
+          ...taskUpdateBody(update),
+          taskId: toSafeId<"entity">(update.taskId),
         });
       return unwrapEden(response);
     },
     onSuccess: async (_data, variables) => {
-      if (variables.workflowReason) {
+      if (taskUpdateClearsWorkflowReason(variables)) {
         setWorkflowReason("");
       }
       await Promise.all([
@@ -185,29 +185,16 @@ const TaskDetailPanelContent = ({
   };
 
   const workflowMutation = useMutation({
-    mutationFn: async (body: {
-      ownerUserId?: string | null;
-      workingTargetDate?: string | null;
-      hardDeadlineDate?: string | null;
-      type?: "task" | "deadline";
-      reason?: string;
-    }) => {
-      const { ownerUserId, ...workflowBody } = body;
+    mutationFn: async (update: WorkflowUpdate) => {
       const response = await api["work-obligations"]({
         workspaceId: toSafeId<"workspace">(workspaceId),
       })({ entityId: toSafeId<"entity">(taskId) }).patch({
-        ...workflowBody,
-        ...(ownerUserId === undefined
-          ? {}
-          : {
-              ownerUserId:
-                ownerUserId === null ? null : toSafeId<"user">(ownerUserId),
-            }),
+        ...workflowUpdateBody(update),
       });
       return unwrapEden(response);
     },
     onSuccess: async (_data, variables) => {
-      if (variables.reason) {
+      if (workflowUpdateClearsReason(variables)) {
         setWorkflowReason("");
       }
       await invalidateWorkflow();
@@ -335,7 +322,7 @@ const TaskDetailPanelContent = ({
   const commitName = () => {
     const trimmed = editNameValue.trim();
     if (trimmed && trimmed !== (task?.name ?? "")) {
-      updateMutation.mutate({ taskId, name: trimmed });
+      updateMutation.mutate({ taskId, type: "name", value: trimmed });
     }
     setIsEditingName(false);
   };
@@ -351,22 +338,22 @@ const TaskDetailPanelContent = ({
     if (!value) {
       return;
     }
-    updateMutation.mutate({ taskId, priority: value });
+    updateMutation.mutate({ taskId, type: "priority", value });
   };
 
   const handleDueDateChange = (value: string | null) => {
     if (env.VITE_FEATURE_GOVERNED_WORKFLOW) {
-      workflowMutation.mutate({ workingTargetDate: value });
+      workflowMutation.mutate({ type: "workingTargetDate", value });
       return;
     }
-    updateMutation.mutate({ taskId, dueDate: value });
+    updateMutation.mutate({ taskId, type: "dueDate", value });
   };
 
   const handleItemTypeChange = (value: ListItemType | null) => {
     if (!value) {
       return;
     }
-    updateMutation.mutate({ taskId, listItemType: value });
+    updateMutation.mutate({ taskId, type: "listItemType", value });
   };
 
   const handleSubtaskToggle = (
@@ -376,7 +363,8 @@ const TaskDetailPanelContent = ({
     const newStatus = currentStatus === "done" ? "open" : "done";
     updateMutation.mutate({
       taskId: subtaskId,
-      status: newStatus,
+      type: "status",
+      value: { status: newStatus },
     });
   };
 
@@ -641,7 +629,7 @@ const TaskDetailPanelContent = ({
                 <WorkTypeSelect
                   onChange={(type) => {
                     if (type) {
-                      workflowMutation.mutate({ type });
+                      workflowMutation.mutate({ type: "type", value: type });
                     }
                   }}
                   value={workflow.type}
@@ -654,8 +642,11 @@ const TaskDetailPanelContent = ({
                   onChange={(ownerUserId) => {
                     const reason = workflowReason.trim();
                     workflowMutation.mutate({
-                      ownerUserId,
-                      ...(reason ? { reason } : {}),
+                      type: "owner",
+                      value: {
+                        ownerUserId,
+                        ...(reason ? { reason } : {}),
+                      },
                     });
                   }}
                   owner={workflow.owner}
@@ -670,10 +661,13 @@ const TaskDetailPanelContent = ({
                   onChange={(hardDeadline) => {
                     const reason = workflowReason.trim();
                     workflowMutation.mutate({
-                      hardDeadlineDate: hardDeadline,
-                      ...(workflow.hardDeadlineDate && reason
-                        ? { reason }
-                        : {}),
+                      type: "hardDeadline",
+                      value: {
+                        hardDeadlineDate: hardDeadline,
+                        ...(workflow.hardDeadlineDate && reason
+                          ? { reason }
+                          : {}),
+                      },
                     });
                   }}
                   value={workflow.hardDeadlineDate}

--- a/apps/web/src/lib/contacts/mutations.ts
+++ b/apps/web/src/lib/contacts/mutations.ts
@@ -5,6 +5,7 @@ import type { ContactType } from "@stll/api-contract";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { toAPIError, unwrapEden } from "@/lib/errors/api";
+import type { NonEmptyPatch } from "@/lib/mutation-command";
 import type { SafeId } from "@/lib/safe-id";
 
 type BankAccount = {
@@ -96,31 +97,36 @@ export const useCreateContact = () => {
   });
 };
 
+export type ContactUpdateFields = {
+  displayName: string;
+  type: ContactType;
+  firstName: string | null;
+  lastName: string | null;
+  organizationName: string | null;
+  prefix: string | null;
+  middleName: string | null;
+  suffix: string | null;
+  notes: string | null;
+  emails: ContactEmail[] | null;
+  phones: ContactPhone[] | null;
+  metadata: ContactMetadata | null;
+  color: string | null;
+  registrationNumber: string | null;
+  taxId: string | null;
+  bankAccounts: BankAccount[] | null;
+  billingAddress: BillingAddress | null;
+  defaultHourlyRate: number | null;
+  currency: string | null;
+  paymentTermDays: number | null;
+  originatingAttorneyId: SafeId<"user"> | null;
+  responsibleAttorneyId: SafeId<"user"> | null;
+};
+
+export type ContactUpdate = NonEmptyPatch<ContactUpdateFields>;
+
 type UpdateContactVars = {
   contactId: SafeId<"contact">;
-  displayName?: string;
-  type?: ContactType;
-  firstName?: string | null;
-  lastName?: string | null;
-  organizationName?: string | null;
-  prefix?: string | null;
-  middleName?: string | null;
-  suffix?: string | null;
-  notes?: string | null;
-  emails?: ContactEmail[] | null;
-  phones?: ContactPhone[] | null;
-  metadata?: ContactMetadata | null;
-  color?: string | null;
-  registrationNumber?: string | null;
-  taxId?: string | null;
-  bankAccounts?: BankAccount[] | null;
-  billingAddress?: BillingAddress | null;
-  defaultHourlyRate?: number | null;
-  currency?: string | null;
-  paymentTermDays?: number | null;
-  originatingAttorneyId?: SafeId<"user"> | null;
-  responsibleAttorneyId?: SafeId<"user"> | null;
-};
+} & ContactUpdate;
 
 export const useUpdateContact = () => {
   const analytics = useAnalytics();

--- a/apps/web/src/lib/contained-handler.test.ts
+++ b/apps/web/src/lib/contained-handler.test.ts
@@ -16,8 +16,7 @@ type SyntheticLike = { target: unknown };
 const makeRef = <T>(node: T | null) => ({ current: node });
 
 const makeContainer = (containsImpl: (other: unknown) => boolean) => {
-  const stub = Object.assign(new FakeNode(), { contains: containsImpl });
-  return stub as unknown as HTMLElement;
+  return Object.assign(new FakeNode(), { contains: containsImpl });
 };
 
 const node = (): object => new FakeNode();

--- a/apps/web/src/lib/contained-handler.test.ts
+++ b/apps/web/src/lib/contained-handler.test.ts
@@ -1,7 +1,3 @@
-/* oxlint-disable typescript/no-unsafe-type-assertion --
-   The helper is typed against real DOM interfaces. Bun's default test
-   runtime has no DOM, so the stubs here intentionally narrow to
-   `HTMLElement` to exercise the runtime branches. */
 import { describe, expect, it, mock } from "bun:test";
 
 // The helper does a runtime `instanceof Node` check; install a minimal
@@ -12,7 +8,7 @@ class FakeNode {
 }
 Object.assign(globalThis, { Node: FakeNode });
 
-const { containedHandler } =
+const { containedEventHandler, containedHandler } =
   await import("@stll/ui/hooks/use-contained-handler");
 
 type SyntheticLike = { target: unknown };
@@ -20,7 +16,7 @@ type SyntheticLike = { target: unknown };
 const makeRef = <T>(node: T | null) => ({ current: node });
 
 const makeContainer = (containsImpl: (other: unknown) => boolean) => {
-  const stub = { contains: containsImpl };
+  const stub = Object.assign(new FakeNode(), { contains: containsImpl });
   return stub as unknown as HTMLElement;
 };
 
@@ -83,6 +79,31 @@ describe("containedHandler", () => {
     const handler = mock<(e: SyntheticLike) => void>(() => {});
 
     containedHandler(makeRef(container), handler)({ target: { plain: true } });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("containedEventHandler", () => {
+  it("blocks targets outside the current target subtree", () => {
+    const currentTarget = makeContainer(() => false);
+    const handler = mock<
+      (event: SyntheticLike & { currentTarget: unknown }) => void
+    >(() => {});
+
+    containedEventHandler(handler)({ currentTarget, target: node() });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("invokes the handler for a contained target", () => {
+    const target = node();
+    const currentTarget = makeContainer((other) => other === target);
+    const handler = mock<
+      (event: SyntheticLike & { currentTarget: unknown }) => void
+    >(() => {});
+
+    containedEventHandler(handler)({ currentTarget, target });
 
     expect(handler).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/src/lib/contained-handler.test.ts
+++ b/apps/web/src/lib/contained-handler.test.ts
@@ -15,9 +15,8 @@ type SyntheticLike = { target: unknown };
 
 const makeRef = <T>(node: T | null) => ({ current: node });
 
-const makeContainer = (containsImpl: (other: unknown) => boolean) => {
-  return Object.assign(new FakeNode(), { contains: containsImpl });
-};
+const makeContainer = (containsImpl: (other: unknown) => boolean) =>
+  Object.assign(new FakeNode(), { contains: containsImpl });
 
 const node = (): object => new FakeNode();
 

--- a/apps/web/src/lib/mutation-command.ts
+++ b/apps/web/src/lib/mutation-command.ts
@@ -1,0 +1,7 @@
+/**
+ * An intentional multi-field PATCH with at least one supplied field.
+ * Single-operation mutations should use a discriminated union instead.
+ */
+export type NonEmptyPatch<Fields extends object> = {
+  [Key in keyof Fields]-?: Pick<Fields, Key> & Partial<Omit<Fields, Key>>;
+}[keyof Fields];

--- a/apps/web/src/lib/mutation-command.type-test.ts
+++ b/apps/web/src/lib/mutation-command.type-test.ts
@@ -1,0 +1,18 @@
+import type { NonEmptyPatch } from "@/lib/mutation-command";
+
+type ExamplePatchFields = {
+  color: string;
+  name: string;
+};
+
+export const singleFieldPatch: NonEmptyPatch<ExamplePatchFields> = {
+  color: "blue",
+};
+
+export const multiFieldPatch: NonEmptyPatch<ExamplePatchFields> = {
+  color: "blue",
+  name: "Appeal",
+};
+
+// @ts-expect-error -- an intentional PATCH must supply at least one field
+export const emptyPatch: NonEmptyPatch<ExamplePatchFields> = {};

--- a/apps/web/src/lib/mutation-command.type-test.ts
+++ b/apps/web/src/lib/mutation-command.type-test.ts
@@ -14,5 +14,8 @@ export const multiFieldPatch: NonEmptyPatch<ExamplePatchFields> = {
   name: "Appeal",
 };
 
-// @ts-expect-error -- an intentional PATCH must supply at least one field
-export const emptyPatch: NonEmptyPatch<ExamplePatchFields> = {};
+type Expect<Condition extends true> = Condition;
+
+export type EmptyPatchIsRejected = Expect<
+  Record<never, never> extends NonEmptyPatch<ExamplePatchFields> ? false : true
+>;

--- a/apps/web/src/lib/workspaces/mutations.test.ts
+++ b/apps/web/src/lib/workspaces/mutations.test.ts
@@ -43,33 +43,40 @@ describe("workspace update cache invalidation", () => {
     ]);
   });
 
-  test("only name updates invalidate the current route metadata", async () => {
-    const { workspaceUpdateInvalidatesRoute } =
+  test("assigns every update kind its exact refresh scope", async () => {
+    const { workspaceUpdateRefreshScope } =
       await import("@/lib/workspaces/mutations");
 
-    expect([
-      workspaceUpdateInvalidatesRoute({
-        type: "name",
-        value: "Renamed matter",
-      }),
-      workspaceUpdateInvalidatesRoute({
+    expect({
+      clientId: workspaceUpdateRefreshScope({
         type: "clientId",
         value: "contact_test",
       }),
-      workspaceUpdateInvalidatesRoute({ type: "color", value: "purple" }),
-      workspaceUpdateInvalidatesRoute({
+      color: workspaceUpdateRefreshScope({ type: "color", value: "purple" }),
+      leadUserId: workspaceUpdateRefreshScope({
         type: "leadUserId",
         value: "user_test",
       }),
-      workspaceUpdateInvalidatesRoute({
+      name: workspaceUpdateRefreshScope({
+        type: "name",
+        value: "Renamed matter",
+      }),
+      promote: workspaceUpdateRefreshScope({
         type: "promote",
         value: { clientId: "contact_test" },
       }),
-      workspaceUpdateInvalidatesRoute({
+      reference: workspaceUpdateRefreshScope({
         type: "reference",
         value: "REF-42",
       }),
-    ]).toEqual([true, false, false, false, false, false]);
+    }).toEqual({
+      clientId: "query-cache",
+      color: "query-cache",
+      leadUserId: "query-cache",
+      name: "route-metadata",
+      promote: "query-cache",
+      reference: "query-cache",
+    });
   });
 
   test("maps every workspace update variant to its API body", async () => {

--- a/apps/web/src/lib/workspaces/mutations.test.ts
+++ b/apps/web/src/lib/workspaces/mutations.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
+import type { WorkspaceUpdate } from "@/lib/workspaces/mutations";
+
 const previousApiUrl = process.env["VITE_API_URL"];
 
 beforeAll(() => {
@@ -47,29 +49,36 @@ describe("workspace update cache invalidation", () => {
     const { workspaceUpdateRefreshScope } =
       await import("@/lib/workspaces/mutations");
 
-    expect({
-      clientId: workspaceUpdateRefreshScope({
+    const updates = {
+      clientId: {
         type: "clientId",
         value: "contact_test",
-      }),
-      color: workspaceUpdateRefreshScope({ type: "color", value: "purple" }),
-      leadUserId: workspaceUpdateRefreshScope({
+      },
+      color: { type: "color", value: "purple" },
+      leadUserId: {
         type: "leadUserId",
         value: "user_test",
-      }),
-      name: workspaceUpdateRefreshScope({
-        type: "name",
-        value: "Renamed matter",
-      }),
-      promote: workspaceUpdateRefreshScope({
+      },
+      name: { type: "name", value: "Renamed matter" },
+      promote: {
         type: "promote",
         value: { clientId: "contact_test" },
-      }),
-      reference: workspaceUpdateRefreshScope({
-        type: "reference",
-        value: "REF-42",
-      }),
-    }).toEqual({
+      },
+      reference: { type: "reference", value: "REF-42" },
+    } as const satisfies {
+      [Type in WorkspaceUpdate["type"]]: Extract<
+        WorkspaceUpdate,
+        { type: Type }
+      >;
+    };
+    const scopes = Object.fromEntries(
+      Object.values(updates).map((update) => [
+        update.type,
+        workspaceUpdateRefreshScope(update),
+      ]),
+    );
+
+    expect(scopes).toEqual({
       clientId: "query-cache",
       color: "query-cache",
       leadUserId: "query-cache",

--- a/apps/web/src/lib/workspaces/mutations.ts
+++ b/apps/web/src/lib/workspaces/mutations.ts
@@ -86,27 +86,27 @@ export type WorkspaceUpdate = {
   };
 }[WorkspaceUpdateType];
 
+type WorkspaceUpdateRefreshScope = "query-cache" | "route-metadata";
+
+const WORKSPACE_UPDATE_REFRESH_SCOPE = {
+  clientId: "query-cache",
+  color: "query-cache",
+  leadUserId: "query-cache",
+  name: "route-metadata",
+  promote: "query-cache",
+  reference: "query-cache",
+} as const satisfies Record<
+  WorkspaceUpdate["type"],
+  WorkspaceUpdateRefreshScope
+>;
+
 type UpdateWorkspaceVars = {
   workspaceId: string;
   update: WorkspaceUpdate;
 };
 
-export const workspaceUpdateInvalidatesRoute = (update: WorkspaceUpdate) => {
-  switch (update.type) {
-    case "name":
-      return true;
-    case "clientId":
-    case "color":
-    case "leadUserId":
-    case "promote":
-    case "reference":
-      return false;
-    default: {
-      const unreachable: never = update;
-      return unreachable;
-    }
-  }
-};
+export const workspaceUpdateRefreshScope = (update: WorkspaceUpdate) =>
+  WORKSPACE_UPDATE_REFRESH_SCOPE[update.type];
 
 export const workspaceUpdateBody = (update: WorkspaceUpdate) => {
   switch (update.type) {
@@ -182,7 +182,7 @@ export const useUpdateWorkspace = () => {
           },
         ),
       );
-      if (workspaceUpdateInvalidatesRoute(variables.update)) {
+      if (workspaceUpdateRefreshScope(variables.update) === "route-metadata") {
         await router.invalidate();
       }
     },

--- a/apps/web/src/routes/_protected.contacts/-components/contact-owners-editor.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/contact-owners-editor.tsx
@@ -15,12 +15,27 @@ import { UserIdentity } from "@/components/user-avatar";
 import { useUpdateContact } from "@/lib/contacts/mutations";
 import { detached } from "@/lib/detached";
 import { organizationOptions } from "@/lib/organization/queries";
+import { toSafeId } from "@/lib/safe-id";
 import { invalidateContactCaches } from "@/routes/_protected.contacts/-components/contact-caches";
 import type { ContactData } from "@/routes/_protected.contacts/-components/types";
 
 const NO_OWNER_VALUE = "__none";
 
 const protectedRouteApi = getRouteApi("/_protected");
+
+type ContactOwnerField = "originatingAttorneyId" | "responsibleAttorneyId";
+
+const contactOwnerPatch = (field: ContactOwnerField, value: string | null) => {
+  const ownerUserId = value === null ? null : toSafeId<"user">(value);
+  switch (field) {
+    case "originatingAttorneyId":
+      return { originatingAttorneyId: ownerUserId };
+    case "responsibleAttorneyId":
+      return { responsibleAttorneyId: ownerUserId };
+    default:
+      return field satisfies never;
+  }
+};
 
 export const ContactOwnersEditor = ({ contact }: { contact: ContactData }) => {
   const t = useTranslations();
@@ -41,10 +56,7 @@ export const ContactOwnersEditor = ({ contact }: { contact: ContactData }) => {
     value: member.userId,
   }));
 
-  const updateOwner = (
-    field: "originatingAttorneyId" | "responsibleAttorneyId",
-    value: string | null,
-  ) => {
+  const updateOwner = (field: ContactOwnerField, value: string | null) => {
     const nextValue = value === NO_OWNER_VALUE ? null : value;
     if (contact[field] === nextValue) {
       return;
@@ -53,7 +65,7 @@ export const ContactOwnersEditor = ({ contact }: { contact: ContactData }) => {
     updateContact.mutate(
       {
         contactId: contact.id,
-        [field]: nextValue,
+        ...contactOwnerPatch(field, nextValue),
       },
       {
         onSuccess: () => {

--- a/apps/web/src/routes/_protected.contacts/-components/editable-row.logic.test.ts
+++ b/apps/web/src/routes/_protected.contacts/-components/editable-row.logic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   buildNumericContactPayload,
+  buildTextContactPayload,
   getEditableFieldInputAttributes,
 } from "@/routes/_protected.contacts/-components/editable-row.logic";
 
@@ -62,5 +63,61 @@ describe("contact numeric editable fields", () => {
       type: "text",
       inputMode: "numeric",
     });
+  });
+});
+
+describe("contact text editable fields", () => {
+  test("maps every field to its exact API property", () => {
+    expect([
+      buildTextContactPayload("prefix", "Dr"),
+      buildTextContactPayload("firstName", "Ada"),
+      buildTextContactPayload("middleName", "M"),
+      buildTextContactPayload("lastName", "Lovelace"),
+      buildTextContactPayload("suffix", "KC"),
+      buildTextContactPayload("organizationName", "Analytical Engines"),
+      buildTextContactPayload("displayName", "Ada Lovelace"),
+      buildTextContactPayload("notes", "Counsel"),
+      buildTextContactPayload("registrationNumber", "123"),
+      buildTextContactPayload("taxId", "GB123"),
+      buildTextContactPayload("currency", "GBP"),
+    ]).toEqual([
+      { prefix: "Dr" },
+      { firstName: "Ada" },
+      { middleName: "M" },
+      { lastName: "Lovelace" },
+      { suffix: "KC" },
+      { organizationName: "Analytical Engines" },
+      { displayName: "Ada Lovelace" },
+      { notes: "Counsel" },
+      { registrationNumber: "123" },
+      { taxId: "GB123" },
+      { currency: "GBP" },
+    ]);
+  });
+
+  test("clears every optional text field with null", () => {
+    expect([
+      buildTextContactPayload("prefix", ""),
+      buildTextContactPayload("firstName", ""),
+      buildTextContactPayload("middleName", ""),
+      buildTextContactPayload("lastName", ""),
+      buildTextContactPayload("suffix", ""),
+      buildTextContactPayload("organizationName", ""),
+      buildTextContactPayload("notes", ""),
+      buildTextContactPayload("registrationNumber", ""),
+      buildTextContactPayload("taxId", ""),
+      buildTextContactPayload("currency", ""),
+    ]).toEqual([
+      { prefix: null },
+      { firstName: null },
+      { middleName: null },
+      { lastName: null },
+      { suffix: null },
+      { organizationName: null },
+      { notes: null },
+      { registrationNumber: null },
+      { taxId: null },
+      { currency: null },
+    ]);
   });
 });

--- a/apps/web/src/routes/_protected.contacts/-components/editable-row.logic.ts
+++ b/apps/web/src/routes/_protected.contacts/-components/editable-row.logic.ts
@@ -1,3 +1,4 @@
+import type { ContactUpdate } from "@/lib/contacts/mutations";
 import type { EditableField } from "@/routes/_protected.contacts/-components/types";
 
 type EditableFieldPolicy =
@@ -25,6 +26,8 @@ type NumericEditableField = {
     ? Field
     : never;
 }[EditableField];
+
+type TextEditableField = Exclude<EditableField, NumericEditableField>;
 
 export const isNumericEditableField = (
   field: EditableField,
@@ -91,4 +94,36 @@ export const buildNumericContactPayload = (
     status: "valid",
     payload: buildNumericPayload(field, value),
   };
+};
+
+export const buildTextContactPayload = (
+  field: TextEditableField,
+  value: string,
+): ContactUpdate => {
+  switch (field) {
+    case "currency":
+      return { currency: value || null };
+    case "displayName":
+      return { displayName: value };
+    case "firstName":
+      return { firstName: value || null };
+    case "lastName":
+      return { lastName: value || null };
+    case "middleName":
+      return { middleName: value || null };
+    case "notes":
+      return { notes: value || null };
+    case "organizationName":
+      return { organizationName: value || null };
+    case "prefix":
+      return { prefix: value || null };
+    case "registrationNumber":
+      return { registrationNumber: value || null };
+    case "suffix":
+      return { suffix: value || null };
+    case "taxId":
+      return { taxId: value || null };
+    default:
+      return field satisfies never;
+  }
 };

--- a/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
@@ -7,10 +7,12 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { useInlineRename } from "@/hooks/use-inline-rename";
 import { useUpdateContact } from "@/lib/contacts/mutations";
+import type { ContactUpdate } from "@/lib/contacts/mutations";
 import { detached } from "@/lib/detached";
 import { invalidateContactCaches } from "@/routes/_protected.contacts/-components/contact-caches";
 import {
   buildNumericContactPayload,
+  buildTextContactPayload,
   EDITABLE_FIELD_POLICY,
   getEditableFieldInputAttributes,
   isNumericEditableField,
@@ -69,7 +71,7 @@ export const EditableRow = ({
         return;
       }
 
-      let payload: Record<string, unknown>;
+      let payload: ContactUpdate;
       if (isNumericEditableField(field)) {
         const result = buildNumericContactPayload(field, trimmed);
         if (result.status === "invalid") {
@@ -79,17 +81,15 @@ export const EditableRow = ({
           return;
         }
         payload = result.payload;
-      } else if (field === "displayName") {
-        if (!trimmed) {
+      } else {
+        if (field === "displayName" && !trimmed) {
           stellaToast.add({
             title: t("errors.actionFailed"),
             type: "error",
           });
           return;
         }
-        payload = { displayName: trimmed };
-      } else {
-        payload = { [field]: trimmed || null };
+        payload = buildTextContactPayload(field, trimmed);
       }
 
       updateContact.mutate(

--- a/apps/web/src/routes/_protected.contacts/-components/types.ts
+++ b/apps/web/src/routes/_protected.contacts/-components/types.ts
@@ -1,4 +1,6 @@
+import type { ContactUpdateFields } from "@/lib/contacts/mutations";
 import type { contactOptions } from "@/lib/contacts/queries";
+import type { NonEmptyPatch } from "@/lib/mutation-command";
 
 export type ContactData = NonNullable<
   Awaited<ReturnType<NonNullable<ReturnType<typeof contactOptions>["queryFn"]>>>
@@ -35,11 +37,9 @@ export type ContactMetadata = {
   customFields?: ContactCustomField[];
 };
 
-export type ContactPatch = {
-  emails?: ContactEmail[] | null;
-  phones?: ContactPhone[] | null;
-  metadata?: ContactMetadata | null;
-};
+export type ContactPatch = NonEmptyPatch<
+  Pick<ContactUpdateFields, "emails" | "metadata" | "phones">
+>;
 
 export type PartyMatter = ContactData["partyMatters"][number];
 

--- a/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
@@ -55,6 +55,7 @@ import { APIError, unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
 import { knowledgeKeys, skillDetailOptions } from "@/lib/knowledge/queries";
 import { catalogueKeys } from "@/lib/knowledge/queries/catalogue";
+import type { NonEmptyPatch } from "@/lib/mutation-command";
 import { toSafeId } from "@/lib/safe-id";
 
 import {
@@ -322,13 +323,15 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
   // gallery with nothing else to click first.
   // Mutations
   const patchMetadata = useMutation({
-    mutationFn: async (payload: {
-      name?: string;
-      description?: string;
-      version?: string | null;
-      enabled?: boolean;
-      command?: string | null;
-    }) => {
+    mutationFn: async (
+      payload: NonEmptyPatch<{
+        name: string;
+        description: string;
+        version: string | null;
+        enabled: boolean;
+        command: string | null;
+      }>,
+    ) => {
       const response = await api
         .skills({ skillId: safeSkillId })
         .patch({ ...payload });

--- a/apps/web/src/routes/_protected.settings/-components/organization/memory/memory-row.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/memory/memory-row.tsx
@@ -16,6 +16,7 @@ import { cn } from "@stll/ui/lib/utils";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { updateMemory as updateMemoryRequest } from "@/lib/memory-api";
+import type { NonEmptyPatch } from "@/lib/mutation-command";
 import { invalidateMemories } from "@/routes/_protected.settings/-queries/memories";
 import type { MemoryListItem } from "@/routes/_protected.settings/-queries/memories";
 
@@ -54,11 +55,13 @@ export const MemoryRow = ({
   const [draft, setDraft] = useState(memory.content);
 
   const updateMemory = useMutation({
-    mutationFn: async (body: {
-      content?: string;
-      pinned?: boolean;
-      status?: "active" | "archived";
-    }) => await updateMemoryRequest({ body, memoryId: memory.id }),
+    mutationFn: async (
+      body: NonEmptyPatch<{
+        content: string;
+        pinned: boolean;
+        status: "active" | "archived";
+      }>,
+    ) => await updateMemoryRequest({ body, memoryId: memory.id }),
     onSuccess: async (_data, variables) => {
       await invalidateMemories(queryClient, activeOrganizationId);
       if (variables.status === "archived") {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog.tsx
@@ -17,6 +17,7 @@ import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { detached } from "@/lib/detached";
 import { unwrapEden } from "@/lib/errors/api";
+import type { NonEmptyPatch } from "@/lib/mutation-command";
 import { toSafeId } from "@/lib/safe-id";
 import { billingCodesOptions } from "@/lib/workspaces/queries/billing-codes";
 
@@ -85,18 +86,18 @@ export const BillingCodesDialog = ({
       analytics.captureError(error);
     },
   });
+  type UpdateBillingCodeVars = {
+    workspaceId: string;
+    id: string;
+  } & NonEmptyPatch<{
+    code: string;
+    label: string;
+    active: boolean;
+    sortOrder: number;
+  }>;
+
   const updateCode = useMutation({
-    mutationFn: async ({
-      workspaceId: ws,
-      ...body
-    }: {
-      workspaceId: string;
-      id: string;
-      code?: string;
-      label?: string;
-      active?: boolean;
-      sortOrder?: number;
-    }) => {
+    mutationFn: async ({ workspaceId: ws, ...body }: UpdateBillingCodeVars) => {
       const response = await api["billing-codes"]({
         workspaceId: toSafeId<"workspace">(ws),
       }).patch({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog.tsx
@@ -27,6 +27,7 @@ import { api } from "@/lib/api";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
 import { detached } from "@/lib/detached";
 import { unwrapEden } from "@/lib/errors/api";
+import type { NonEmptyPatch } from "@/lib/mutation-command";
 import { organizationOptions } from "@/lib/organization/queries";
 import { toSafeId } from "@/lib/safe-id";
 import {
@@ -135,17 +136,17 @@ const RateTablesView = ({
       analytics.captureError(error);
     },
   });
+  type UpdateRateTableVars = {
+    workspaceId: string;
+    id: string;
+  } & NonEmptyPatch<{
+    name: string;
+    currency: string;
+    isDefault: boolean;
+  }>;
+
   const updateTable = useMutation({
-    mutationFn: async ({
-      workspaceId: ws,
-      ...body
-    }: {
-      workspaceId: string;
-      id: string;
-      name?: string;
-      currency?: string;
-      isDefault?: boolean;
-    }) => {
+    mutationFn: async ({ workspaceId: ws, ...body }: UpdateRateTableVars) => {
       const response = await api
         .rates({ workspaceId: toSafeId<"workspace">(ws) })
         .patch({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-day-cell.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-day-cell.tsx
@@ -10,6 +10,7 @@ import {
   MenuPopup,
   MenuTrigger,
 } from "@stll/ui/components/menu";
+import { containedEventHandler } from "@stll/ui/hooks/use-contained-handler";
 import { cn } from "@stll/ui/lib/utils";
 
 import { useExternalSyncEffect } from "@/hooks/use-effect";
@@ -121,7 +122,7 @@ export const CalendarDayCell = ({
         mode === "week" && "min-h-[300px]",
         isDropTarget && "bg-primary/10",
       )}
-      onContextMenu={handleContextMenu}
+      onContextMenu={containedEventHandler(handleContextMenu)}
     >
       {/* Current time indicator (week view, today only) */}
       {mode === "week" && day.isToday && <CurrentTimeIndicator />}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -37,6 +37,7 @@ import {
   MenuTrigger,
 } from "@stll/ui/components/menu";
 import { stellaToast } from "@stll/ui/components/toast";
+import { containedEventHandler } from "@stll/ui/hooks/use-contained-handler";
 import { cn } from "@stll/ui/lib/utils";
 
 import { DocumentIcon } from "@/components/document-icon";
@@ -1068,7 +1069,7 @@ const ColumnHeaderCell = ({
         "group/column relative flex min-w-0 items-center",
         align === "end" ? "justify-end" : "justify-start",
       )}
-      onContextMenu={handleContextMenu}
+      onContextMenu={containedEventHandler(handleContextMenu)}
       ref={containerRef}
     >
       <button
@@ -1607,7 +1608,7 @@ const FilesystemRow = ({
       <div
         className="group/row relative h-full"
         data-entity-row
-        onContextMenu={handleContextMenu}
+        onContextMenu={containedEventHandler(handleContextMenu)}
         ref={rowRef}
       >
         {isFolder ? (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
@@ -52,6 +52,7 @@ import {
   PopoverPopup,
   PopoverTrigger,
 } from "@stll/ui/components/popover";
+import { containedEventHandler } from "@stll/ui/hooks/use-contained-handler";
 import { cn } from "@stll/ui/lib/utils";
 
 import { InlineEdit } from "@/components/inline-edit";
@@ -489,7 +490,7 @@ export const KanbanColumn = ({
       </div>
       <div
         className="flex-1 overflow-y-auto p-2"
-        onContextMenu={handleContextMenu}
+        onContextMenu={containedEventHandler(handleContextMenu)}
         ref={scrollRef}
       >
         {isFileDragOver && (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
@@ -43,6 +43,7 @@ import {
   Tooltip as TooltipRoot,
   TooltipTrigger,
 } from "@stll/ui/components/tooltip";
+import { containedEventHandler } from "@stll/ui/hooks/use-contained-handler";
 import { cn } from "@stll/ui/lib/utils";
 
 import { EmptyScreen } from "@/components/empty-screen";
@@ -504,7 +505,7 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
         {/* Upcoming tasks */}
         <section
           className="flex flex-col"
-          onContextMenu={(e) => {
+          onContextMenu={containedEventHandler((e) => {
             e.preventDefault();
             e.stopPropagation();
             setUpcomingMenu({
@@ -515,7 +516,7 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
               },
               task: null,
             });
-          }}
+          })}
         >
           <div className="mb-3 flex items-center justify-between">
             <h2 className="text-muted-foreground text-sm font-medium">

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table/row-cells.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table/row-cells.tsx
@@ -14,7 +14,10 @@ import { useTranslations } from "use-intl";
 
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { DirectionalIcon } from "@stll/ui/components/directional-icon";
-import { containedHandler } from "@stll/ui/hooks/use-contained-handler";
+import {
+  containedEventHandler,
+  containedHandler,
+} from "@stll/ui/hooks/use-contained-handler";
 import { cn } from "@stll/ui/lib/utils";
 
 import { renderDragPreview } from "@/components/drag-preview";
@@ -435,7 +438,7 @@ export const DraggableRow = ({
         editingEntityId={editingEntityId}
         entity={entity}
         isMutedByExpandedCell={isMutedByExpandedCell}
-        onContextMenu={handleContextMenu}
+        onRowContextMenu={handleContextMenu}
         onRename={onRename}
         onStartEditing={onStartEditing}
         onStopEditing={onStopEditing}
@@ -468,7 +471,7 @@ export const DraggableRow = ({
         key={row.id}
         // eslint-disable-next-line react/react-compiler -- containedHandler house pattern; rowRef is handed to the helper, not read for rendered output
         onClick={containedHandler(rowRef, handleRowClick)}
-        onContextMenu={handleContextMenu}
+        onContextMenu={containedEventHandler(handleContextMenu)}
         ref={setRowRef}
       >
         <DataRowCells
@@ -512,7 +515,7 @@ type FolderTableRowProps = {
   editingEntityId: string | null;
   entity: TableTreeNode;
   isMutedByExpandedCell: boolean;
-  onContextMenu: (event: React.MouseEvent) => void;
+  onRowContextMenu: (event: React.MouseEvent) => void;
   onRename: (entityId: string, newName: string) => void;
   onStartEditing: (entityId: string) => void;
   onStopEditing: () => void;
@@ -530,7 +533,7 @@ const FolderTableRow = ({
   editingEntityId,
   entity,
   isMutedByExpandedCell,
-  onContextMenu,
+  onRowContextMenu,
   onRename,
   onStartEditing,
   onStopEditing,
@@ -560,7 +563,7 @@ const FolderTableRow = ({
       data-index={virtualIndex}
       data-state={row_getIsSelected(row) ? "selected" : undefined}
       key={row.id}
-      onContextMenu={onContextMenu}
+      onContextMenu={containedEventHandler(onRowContextMenu)}
       ref={ref}
     >
       <WorkspaceGridCell

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/expenses.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/expenses.ts
@@ -5,6 +5,7 @@ import type { ExpenseCategory } from "@stll/api-contract";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { unwrapEden } from "@/lib/errors/api";
+import type { NonEmptyPatch } from "@/lib/mutation-command";
 import { toSafeId } from "@/lib/safe-id";
 
 type CreateExpenseVars = {
@@ -44,17 +45,18 @@ export const useCreateExpense = () => {
 type UpdateExpenseVars = {
   workspaceId: string;
   id: string;
-  dateIncurred?: string;
-  amount?: number;
-  currency?: string;
-  category?: ExpenseCategory;
-  description?: string;
-  invoiceDescription?: string | null;
-  billable?: boolean;
-  markup?: number;
-  matterId?: string;
-  status?: "draft" | "approved";
-};
+} & NonEmptyPatch<{
+  dateIncurred: string;
+  amount: number;
+  currency: string;
+  category: ExpenseCategory;
+  description: string;
+  invoiceDescription: string | null;
+  billable: boolean;
+  markup: number;
+  matterId: string;
+  status: "draft" | "approved";
+}>;
 
 export const useUpdateExpense = () => {
   const analytics = useAnalytics();

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/time-entries.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/time-entries.ts
@@ -1,6 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 
 import { useAnalytics } from "@/lib/analytics/provider";
+import type { NonEmptyPatch } from "@/lib/mutation-command";
 import { timeEntriesKeys } from "@/lib/workspaces/queries/time-entries";
 import { sendTimeEntryMutation } from "@/lib/workspaces/time-entries-api";
 
@@ -46,17 +47,18 @@ export const useCreateTimeEntry = () => {
 type UpdateTimeEntryVars = {
   workspaceId: string;
   id: string;
-  dateWorked?: string;
-  timezoneId?: string;
-  durationMinutes?: number;
-  narrative?: string;
-  invoiceNarrative?: string | null;
-  billable?: boolean;
-  noCharge?: boolean;
-  workItemId?: string | null;
-  taskCode?: string | null;
-  activityCode?: string | null;
-};
+} & NonEmptyPatch<{
+  dateWorked: string;
+  timezoneId: string;
+  durationMinutes: number;
+  narrative: string;
+  invoiceNarrative: string | null;
+  billable: boolean;
+  noCharge: boolean;
+  workItemId: string | null;
+  taskCode: string | null;
+  activityCode: string | null;
+}>;
 
 export const useUpdateTimeEntry = () => {
   const analytics = useAnalytics();

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { unwrapEden } from "@/lib/errors/api";
+import type { NonEmptyPatch } from "@/lib/mutation-command";
 import { toSafeId } from "@/lib/safe-id";
 import type {
   ViewLayout,
@@ -58,9 +59,10 @@ export const useCreateView = (workspaceId: string) => {
 
 type UpdateViewVars = {
   viewId: string;
-  name?: string;
-  layout?: ViewLayout;
-};
+} & NonEmptyPatch<{
+  name: string;
+  layout: ViewLayout;
+}>;
 
 export const useUpdateView = (workspaceId: string) => {
   const analytics = useAnalytics();

--- a/apps/web/src/routes/_protected.workspaces/index.tsx
+++ b/apps/web/src/routes/_protected.workspaces/index.tsx
@@ -35,6 +35,7 @@ import {
   TableHeader,
   TableRow,
 } from "@stll/ui/components/table";
+import { containedEventHandler } from "@stll/ui/hooks/use-contained-handler";
 import { cn } from "@stll/ui/lib/utils";
 
 import { EmptyScreen } from "@/components/empty-screen";
@@ -576,7 +577,7 @@ const MattersPageContextMenu = ({
   return (
     <div
       className="contents"
-      onContextMenu={(event) => {
+      onContextMenu={containedEventHandler((event) => {
         if (event.defaultPrevented) {
           return;
         }
@@ -587,7 +588,7 @@ const MattersPageContextMenu = ({
           getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
         });
         setOpen(true);
-      }}
+      })}
     >
       {children}
       <Menu

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -147,6 +147,9 @@ const fixtureRuleOverrides = [
   fixtureRuleOverride("no-offset-pagination.fixture.ts", [
     "no-offset-pagination/no-offset-pagination",
   ]),
+  fixtureRuleOverride("no-optional-mutation-command.fixture.ts", [
+    "no-optional-mutation-command/no-optional-mutation-command",
+  ]),
   fixtureRuleOverride("no-physical-properties.fixture.ts", [
     "no-physical-properties/no-physical-properties",
   ]),
@@ -166,6 +169,9 @@ const fixtureRuleOverrides = [
   ]),
   fixtureRuleOverride("no-raw-public-law-seo.fixture.ts", [
     "no-raw-public-law-seo/no-raw-public-law-seo",
+  ]),
+  fixtureRuleOverride("no-raw-router-invalidation.fixture.ts", [
+    "no-raw-router-invalidation/no-raw-router-invalidation",
   ]),
   fixtureRuleOverride("no-raw-user-id-schema.fixture.ts", [
     "no-raw-user-id-schema/no-raw-user-id-schema",
@@ -202,6 +208,10 @@ const fixtureRuleOverrides = [
   ]),
   fixtureRuleOverride("require-router-select.fixture.ts", [
     "require-router-select/require-router-select",
+  ]),
+  fixtureRuleOverride("require-contained-handler.fixture.tsx", [
+    "require-contained-handler/no-portal-under-interactive-ancestor",
+    "require-contained-handler/require-contained-handler",
   ]),
   fixtureRuleOverride("require-safe-route-handlers.fixture.ts", [
     "require-safe-route-handlers/require-safe-route-handlers",
@@ -461,6 +471,7 @@ export default defineConfig({
     "no-partial-record-satisfies/no-partial-record-satisfies": "error",
     "no-raw-public-law-seo/no-raw-public-law-seo": "off",
     "public-case-law-db-boundary/public-case-law-db-boundary": "off",
+    "require-contained-handler/no-portal-under-interactive-ancestor": "error",
     "require-contained-handler/require-contained-handler": "error",
     "require-function-replacer/require-function-replacer": "error",
     "no-void": ["error", { allowAsStatement: true }],
@@ -673,6 +684,8 @@ export default defineConfig({
     "./.oxlint-plugins/require-loader-prefetch.ts",
     "./.oxlint-plugins/require-matter-affordance.ts",
     "./.oxlint-plugins/no-raw-route-query-client.ts",
+    "./.oxlint-plugins/no-raw-router-invalidation.ts",
+    "./.oxlint-plugins/no-optional-mutation-command.ts",
     "./.oxlint-plugins/no-beforeload-redirect.ts",
     "./.oxlint-plugins/require-safe-route-handlers.ts",
     "./.oxlint-plugins/no-inline-endpoint-in-routes.ts",
@@ -1672,6 +1685,8 @@ export default defineConfig({
           { allowedText: ["Anthropic", "Google AI", "OpenAI"] },
         ],
         "require-router-select/require-router-select": "error",
+        "no-optional-mutation-command/no-optional-mutation-command": "error",
+        "no-raw-router-invalidation/no-raw-router-invalidation": "error",
         "require-matter-affordance/require-matter-affordance": "error",
         "security-guards/no-unsanitized-href": "error",
         "stella-toast/stella-toast": "error",

--- a/packages/ui/src/hooks/use-contained-handler.ts
+++ b/packages/ui/src/hooks/use-contained-handler.ts
@@ -1,7 +1,7 @@
 import type * as React from "react";
 
 type ContainmentRoot = {
-  contains(target: Node): boolean;
+  contains: (target: Node) => boolean;
 };
 
 /**

--- a/packages/ui/src/hooks/use-contained-handler.ts
+++ b/packages/ui/src/hooks/use-contained-handler.ts
@@ -1,5 +1,9 @@
 import type * as React from "react";
 
+type ContainmentRoot = {
+  contains(target: Node): boolean;
+};
+
 /**
  * Wrap a React event handler so it only fires when the event target
  * is a DOM descendant of the given ref.
@@ -39,7 +43,7 @@ import type * as React from "react";
  */
 export const containedHandler =
   <E extends { target: unknown }>(
-    ref: React.RefObject<HTMLElement | null> | null | undefined,
+    ref: React.RefObject<ContainmentRoot | null> | null | undefined,
     handler: ((event: E) => void) | undefined,
   ) =>
   (event: E): void => {

--- a/packages/ui/src/hooks/use-contained-handler.ts
+++ b/packages/ui/src/hooks/use-contained-handler.ts
@@ -20,7 +20,8 @@ import type * as React from "react";
  * directly inside the handler.
  *
  * The `require-contained-handler` oxlint rule enforces this on any JSX
- * element carrying both `ref={…}` and one of the watched handler props.
+ * element carrying both `ref={…}` and one of the watched handler props;
+ * `containedEventHandler` covers elements that do not otherwise need a ref.
  *
  * @example
  *   const barRef = useRef<HTMLDivElement>(null);
@@ -50,6 +51,25 @@ export const containedHandler =
       container !== null &&
       event.target instanceof Node &&
       !container.contains(event.target)
+    ) {
+      return;
+    }
+    handler(event);
+  };
+
+/**
+ * Contain a synchronous JSX handler to its own DOM subtree without a ref.
+ * Prefer this form when the element does not otherwise need a ref.
+ */
+export const containedEventHandler =
+  <E extends { currentTarget: unknown; target: unknown }>(
+    handler: (event: E) => void,
+  ) =>
+  (event: E): void => {
+    if (
+      event.currentTarget instanceof Node &&
+      event.target instanceof Node &&
+      !event.currentTarget.contains(event.target)
     ) {
       return;
     }


### PR DESCRIPTION
## Summary

- make workspace refresh behavior a total policy over every update operation and model single-operation mutations as discriminated commands
- require intentional batch patches to contain at least one field; migrate existing update surfaces to the strict type
- confine route-wide invalidation and prevent portaled popup events from reaching unrelated interactive ancestors with enforced lint rules
- strengthen the matter-color regression test to verify the PATCH succeeds without closing the picker or refreshing the route

CC on behalf of sok0