### PR TITLE
fix: scope PDF pinch zoom to viewer

### DIFF
--- a/apps/web/src/components/inspector/file-tab-panel.tsx
+++ b/apps/web/src/components/inspector/file-tab-panel.tsx
@@ -122,12 +122,12 @@ type FileTabPanelProps = {
   handleOpenFullView: () => Promise<void>;
   handleResetZoom: (tabId: string) => void;
   handleStartDocxEdit: (tabId: string) => Promise<void>;
+  handleWheelZoom: (tabId: string, deltaY: number) => void;
   handleZoom: (tabId: string, direction: "in" | "out") => void;
   matterColor: string | null;
   matterOrigin: MatterOrigin | null;
   minimized: boolean;
   mountedPdfIds: ReadonlySet<string>;
-  pdfContentRef: RefObject<HTMLDivElement | null>;
   pdfRouteJustification: string | null;
   peekPdfViewId: string;
   ribbonLabelContextMenuOpenAt: (event: MouseEvent<HTMLElement>) => void;
@@ -173,12 +173,12 @@ export const FileTabPanel = ({
   handleOpenFullView,
   handleResetZoom,
   handleStartDocxEdit,
+  handleWheelZoom,
   handleZoom,
   matterColor,
   matterOrigin,
   minimized,
   mountedPdfIds,
-  pdfContentRef,
   pdfRouteJustification,
   peekPdfViewId,
   ribbonLabelContextMenuOpenAt,
@@ -1021,6 +1021,7 @@ export const FileTabPanel = ({
         onDocxScrollTopChange={handleDocxScrollTopChange}
         onError={handleViewerError}
         onPeekNavigate={closeAll}
+        onWheelZoom={(deltaY) => handleWheelZoom(tab.id, deltaY)}
         scaleOffset={scaleOffsets.get(tab.id) ?? 0}
         viewId={peekPdfViewId}
         workspaceId={tab.workspaceId}
@@ -1292,7 +1293,6 @@ export const FileTabPanel = ({
         !isActive && "hidden",
       )}
       key={tab.renderId ?? tab.id}
-      ref={isActive ? pdfContentRef : undefined}
     >
       {isNativeDocxDisplay || isOfficeDisplay ? (
         <>

--- a/apps/web/src/components/inspector/inspector-panel.tsx
+++ b/apps/web/src/components/inspector/inspector-panel.tsx
@@ -228,11 +228,11 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
 
   const {
     handleResetZoom,
+    handleWheelZoom,
     handleZoom,
-    pdfContentRef,
     scaleOffsets,
     setScaleOffsets,
-  } = usePdfTabZoom({ activeId, activeTabType: activeTab?.type });
+  } = usePdfTabZoom();
 
   // -- Inline rename --
   const {
@@ -616,13 +616,13 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
           handleOpenFullView={handleOpenFullView}
           handleResetZoom={handleResetZoom}
           handleStartDocxEdit={handleStartDocxEdit}
+          handleWheelZoom={handleWheelZoom}
           handleZoom={handleZoom}
           key={tab.renderId ?? tab.id}
           matterColor={matterColor}
           matterOrigin={matterOrigin}
           minimized={minimized}
           mountedPdfIds={mountedPdfIds}
-          pdfContentRef={pdfContentRef}
           pdfRouteJustification={pdfRouteJustification}
           peekPdfViewId={peekPdfViewId}
           ribbonLabelContextMenuOpenAt={ribbonContextMenu.openAt}

--- a/apps/web/src/components/inspector/use-pdf-tab-zoom.ts
+++ b/apps/web/src/components/inspector/use-pdf-tab-zoom.ts
@@ -1,36 +1,24 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 
-import { useExternalSyncEffect } from "@/hooks/use-effect";
 import {
-  consumePDFWheelZoomEvent,
+  getPDFScaleOffset,
   getPDFWheelZoomScaleOffset,
-  PDF_MAX_SCALE_OFFSET,
-  PDF_MIN_SCALE_OFFSET,
   PDF_SCALE_OFFSET_STEP,
 } from "@/lib/pdf/pdf-zoom.logic";
 
-type UsePdfTabZoomOptions = {
-  activeId: string | null;
-  activeTabType: string | undefined;
-};
-
-export const usePdfTabZoom = ({
-  activeId,
-  activeTabType,
-}: UsePdfTabZoomOptions) => {
+export const usePdfTabZoom = () => {
   const [scaleOffsets, setScaleOffsets] = useState<Map<string, number>>(
     () => new Map(),
   );
-  const pdfContentRef = useRef<HTMLDivElement>(null);
 
   const handleZoom = (tabId: string, direction: "in" | "out") => {
     setScaleOffsets((prev) => {
       const current = prev.get(tabId) ?? 0;
       const delta =
         direction === "in" ? PDF_SCALE_OFFSET_STEP : -PDF_SCALE_OFFSET_STEP;
-      const next = Math.round((current + delta) * 10) / 10;
+      const next = getPDFScaleOffset(current, delta);
 
-      if (next < PDF_MIN_SCALE_OFFSET || next > PDF_MAX_SCALE_OFFSET) {
+      if (next === current) {
         return prev;
       }
 
@@ -48,41 +36,25 @@ export const usePdfTabZoom = ({
     });
   };
 
-  useExternalSyncEffect(() => {
-    const el = pdfContentRef.current;
-    if (!el || activeTabType !== "pdf") {
-      return undefined;
-    }
+  const handleWheelZoom = (tabId: string, deltaY: number) => {
+    setScaleOffsets((prev) => {
+      const current = prev.get(tabId) ?? 0;
+      const next = getPDFWheelZoomScaleOffset(current, deltaY);
 
-    const onWheel = (event: WheelEvent) => {
-      if (!activeId) {
-        return;
+      if (next === current) {
+        return prev;
       }
 
-      consumePDFWheelZoomEvent(event, (deltaY) => {
-        setScaleOffsets((prev) => {
-          const current = prev.get(activeId) ?? 0;
-          const next = getPDFWheelZoomScaleOffset(current, deltaY);
-
-          if (next === current) {
-            return prev;
-          }
-
-          const updated = new Map(prev);
-          updated.set(activeId, next);
-          return updated;
-        });
-      });
-    };
-
-    el.addEventListener("wheel", onWheel, { passive: false });
-    return () => el.removeEventListener("wheel", onWheel);
-  }, [activeId, activeTabType]);
+      const updated = new Map(prev);
+      updated.set(tabId, next);
+      return updated;
+    });
+  };
 
   return {
     handleResetZoom,
+    handleWheelZoom,
     handleZoom,
-    pdfContentRef,
     scaleOffsets,
     setScaleOffsets,
   };

--- a/apps/web/src/components/inspector/use-pdf-tab-zoom.ts
+++ b/apps/web/src/components/inspector/use-pdf-tab-zoom.ts
@@ -1,11 +1,13 @@
 import { useRef, useState } from "react";
 
 import { useExternalSyncEffect } from "@/hooks/use-effect";
-
-const ZOOM_STEP = 0.2;
-const MIN_OFFSET = -0.8;
-const MAX_OFFSET = 2;
-const PINCH_ZOOM_SENSITIVITY = 0.005;
+import {
+  consumePDFWheelZoomEvent,
+  getPDFWheelZoomScaleOffset,
+  PDF_MAX_SCALE_OFFSET,
+  PDF_MIN_SCALE_OFFSET,
+  PDF_SCALE_OFFSET_STEP,
+} from "@/lib/pdf/pdf-zoom.logic";
 
 type UsePdfTabZoomOptions = {
   activeId: string | null;
@@ -24,10 +26,11 @@ export const usePdfTabZoom = ({
   const handleZoom = (tabId: string, direction: "in" | "out") => {
     setScaleOffsets((prev) => {
       const current = prev.get(tabId) ?? 0;
-      const delta = direction === "in" ? ZOOM_STEP : -ZOOM_STEP;
+      const delta =
+        direction === "in" ? PDF_SCALE_OFFSET_STEP : -PDF_SCALE_OFFSET_STEP;
       const next = Math.round((current + delta) * 10) / 10;
 
-      if (next < MIN_OFFSET || next > MAX_OFFSET) {
+      if (next < PDF_MIN_SCALE_OFFSET || next > PDF_MAX_SCALE_OFFSET) {
         return prev;
       }
 
@@ -52,26 +55,23 @@ export const usePdfTabZoom = ({
     }
 
     const onWheel = (event: WheelEvent) => {
-      if (!event.ctrlKey || !activeId) {
+      if (!activeId) {
         return;
       }
-      event.preventDefault();
 
-      setScaleOffsets((prev) => {
-        const current = prev.get(activeId) ?? 0;
-        const delta = -event.deltaY * PINCH_ZOOM_SENSITIVITY;
-        const next =
-          Math.round(
-            Math.max(MIN_OFFSET, Math.min(MAX_OFFSET, current + delta)) * 100,
-          ) / 100;
+      consumePDFWheelZoomEvent(event, (deltaY) => {
+        setScaleOffsets((prev) => {
+          const current = prev.get(activeId) ?? 0;
+          const next = getPDFWheelZoomScaleOffset(current, deltaY);
 
-        if (next === current) {
-          return prev;
-        }
+          if (next === current) {
+            return prev;
+          }
 
-        const updated = new Map(prev);
-        updated.set(activeId, next);
-        return updated;
+          const updated = new Map(prev);
+          updated.set(activeId, next);
+          return updated;
+        });
       });
     };
 

--- a/apps/web/src/components/pdf/pdf-viewer.tsx
+++ b/apps/web/src/components/pdf/pdf-viewer.tsx
@@ -13,6 +13,7 @@ import { fileOptions } from "@/lib/files/queries";
 import { usePDFStore } from "@/lib/pdf/pdf-context";
 import { PDFPage } from "@/lib/pdf/pdf-page";
 import { PDFViewport } from "@/lib/pdf/pdf-viewport";
+import { getPDFWheelZoomScaleOffset } from "@/lib/pdf/pdf-zoom.logic";
 import { entityOptions } from "@/lib/workspaces/queries/entities";
 import "@/components/pdf/peek/peek-docx.css";
 import { useWorkspaceStore } from "@/lib/workspaces/store";
@@ -29,6 +30,7 @@ const FullscreenPdfViewer = () => {
   const entityId = routeApi.useSearch({ select: (s) => s.entity ?? "" });
   const pageNumber = routeApi.useSearch({ select: (s) => s.pdfPage ?? 1 });
   const setPdfPageCount = useWorkspaceStore((s) => s.setPdfPageCount);
+  const setPdfScaleOffset = useWorkspaceStore((s) => s.setPdfScaleOffset);
   const scaleOffset = useWorkspaceStore((s) => s.pdfViewer.scaleOffset);
   const pageCount = usePDFStore((s) => s.pages.size);
 
@@ -77,6 +79,19 @@ const FullscreenPdfViewer = () => {
     );
   };
 
+  const handleWheelZoom = (deltaY: number) => {
+    const currentScaleOffset =
+      useWorkspaceStore.getState().pdfViewer.scaleOffset;
+    const nextScaleOffset = getPDFWheelZoomScaleOffset(
+      currentScaleOffset,
+      deltaY,
+    );
+
+    if (nextScaleOffset !== currentScaleOffset) {
+      setPdfScaleOffset(nextScaleOffset);
+    }
+  };
+
   return (
     <FileViewerWithAI
       activeFile={
@@ -94,6 +109,7 @@ const FullscreenPdfViewer = () => {
         fileId={fieldId}
         invertColors={isImageOrigin ? false : undefined}
         onPageChanged={handlePageChanged}
+        onWheelZoom={handleWheelZoom}
         page={pageNumber}
         scaleOffset={scaleOffset}
         renderPage={(props) => (

--- a/apps/web/src/components/pdf/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/components/pdf/peek/peek-pdf-viewer.tsx
@@ -116,6 +116,7 @@ type PeekPdfViewerProps = {
   onPeekNavigate?: (() => void) | undefined;
   docxPrintActionsRef?: RefObject<Map<string, () => void>> | undefined;
   onDocxScrollTopChange?: ((scrollTop: number) => void) | undefined;
+  onWheelZoom?: ((deltaY: number) => void) | undefined;
   errorFallback?: ((props: { reset: () => void }) => ReactNode) | undefined;
   onError?: ((error: Error) => void) | undefined;
 };
@@ -161,6 +162,7 @@ const PeekPdfViewerContent = ({
   onPeekNavigate,
   docxPrintActionsRef,
   onDocxScrollTopChange,
+  onWheelZoom,
 }: PeekPdfViewerProps) => {
   const isImageOrigin = mimeType?.startsWith("image/") ?? false;
 
@@ -221,6 +223,7 @@ const PeekPdfViewerContent = ({
       scaleOffset={scaleOffset}
       activeSearchMatchIndex={activeSearchMatchIndex}
       onSearchMatchSummaryChange={onSearchMatchSummaryChange}
+      onWheelZoom={onWheelZoom}
       searchText={searchText}
       renderPage={(props) => (
         <PDFPage {...props} renderOverlay={renderPageOverlay} />

--- a/apps/web/src/components/search-document-preview.tsx
+++ b/apps/web/src/components/search-document-preview.tsx
@@ -37,11 +37,8 @@ export const SearchDocumentPreview = ({
     useState<SearchMatchSummary>({ count: 0, truncated: false });
   const [nativeSearchStatus, setNativeSearchStatus] =
     useState<NativeSearchStatus>("pending");
-  const { handleResetZoom, handleZoom, pdfContentRef, scaleOffsets } =
-    usePdfTabZoom({
-      activeId: target.fieldId,
-      activeTabType: target.filePurpose === "display" ? "pdf" : "docx",
-    });
+  const { handleResetZoom, handleWheelZoom, handleZoom, scaleOffsets } =
+    usePdfTabZoom();
   const scaleOffset = scaleOffsets.get(target.fieldId) ?? 0;
   const handleSearchMatchSummaryChange = useCallback(
     (summary: SearchMatchSummary) => {
@@ -81,6 +78,7 @@ export const SearchDocumentPreview = ({
       mimeType={target.mimeType}
       onError={handlePreviewError}
       onSearchMatchSummaryChange={handleSearchMatchSummaryChange}
+      onWheelZoom={(deltaY) => handleWheelZoom(target.fieldId, deltaY)}
       scaleOffset={scaleOffset}
       searchText={searchText}
       viewId="all"
@@ -107,7 +105,7 @@ export const SearchDocumentPreview = ({
   });
 
   return (
-    <div className="relative h-full min-h-0" ref={pdfContentRef}>
+    <div className="relative h-full min-h-0">
       {content}
       {showNoMatchFallback && (
         <div className="bg-background absolute inset-0 z-10 flex min-h-0 flex-col">

--- a/apps/web/src/lib/pdf/hooks/use-pdf-wheel-zoom.ts
+++ b/apps/web/src/lib/pdf/hooks/use-pdf-wheel-zoom.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+
+import { useLatestCallback } from "@/hooks/use-latest-callback";
+import { consumePDFWheelZoomEvent } from "@/lib/pdf/pdf-zoom.logic";
+
+export const usePDFWheelZoom = (
+  onWheelZoom: ((deltaY: number) => void) | undefined,
+) => {
+  const handleWheel = useLatestCallback((event: WheelEvent) => {
+    if (!onWheelZoom) {
+      return;
+    }
+
+    consumePDFWheelZoomEvent(event, onWheelZoom);
+  });
+  const enabled = onWheelZoom !== undefined;
+
+  return useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node || !enabled) {
+        return undefined;
+      }
+
+      node.addEventListener("wheel", handleWheel, { passive: false });
+      return () => node.removeEventListener("wheel", handleWheel);
+    },
+    [enabled, handleWheel],
+  );
+};

--- a/apps/web/src/lib/pdf/pdf-viewport.tsx
+++ b/apps/web/src/lib/pdf/pdf-viewport.tsx
@@ -20,6 +20,7 @@ import { usePDFControlledScaleOffset } from "@/lib/pdf/hooks/use-pdf-controlled-
 import { usePDFDocument } from "@/lib/pdf/hooks/use-pdf-document";
 import { usePDFExternalPageSync } from "@/lib/pdf/hooks/use-pdf-external-page-sync";
 import { usePDFFitToWidth } from "@/lib/pdf/hooks/use-pdf-fit-to-width";
+import { usePDFWheelZoom } from "@/lib/pdf/hooks/use-pdf-wheel-zoom";
 import { useTextSelection } from "@/lib/pdf/hooks/use-text-selection";
 import { usePDFStore } from "@/lib/pdf/pdf-context";
 import type { PDFDocument } from "@/lib/pdf/pdf-loader";
@@ -42,6 +43,7 @@ type PDFViewportProps = {
   buffer: ArrayBuffer;
   page?: number | undefined;
   onPageChanged?: ((page: number) => void) | undefined;
+  onWheelZoom?: ((deltaY: number) => void) | undefined;
   password?: string | undefined;
   scaleOffset?: number | undefined;
   invertColors?: boolean | undefined;
@@ -130,6 +132,7 @@ const PDFViewerContent = ({
   password,
   page,
   onPageChanged,
+  onWheelZoom,
   scaleOffset = 0,
   invertColors,
   className,
@@ -196,6 +199,7 @@ const PDFViewerContent = ({
   };
 
   const containerRef = useRef<HTMLDivElement>(null);
+  const wheelZoomRef = usePDFWheelZoom(onWheelZoom);
 
   useExternalSyncEffect(() => {
     startTransition(() => {
@@ -273,7 +277,11 @@ const PDFViewerContent = ({
     // stack floats at z-50 over the bottom of the viewer. Without this
     // the scrollbar's bottom section painted underneath that glass veil
     // instead of on top of it.
-    <ScrollArea className={className} scrollbarClassName="z-[60]">
+    <ScrollArea
+      className={className}
+      scrollbarClassName="z-[60]"
+      viewportRef={wheelZoomRef}
+    >
       <div
         ref={pdfContentRef}
         className={contentClassName}

--- a/apps/web/src/lib/pdf/pdf-zoom.logic.test.ts
+++ b/apps/web/src/lib/pdf/pdf-zoom.logic.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "bun:test";
 
 import {
   consumePDFWheelZoomEvent,
+  getPDFScaleOffset,
   getPDFWheelZoomScaleOffset,
   PDF_MAX_SCALE_OFFSET,
   PDF_MIN_SCALE_OFFSET,
+  PDF_SCALE_OFFSET_STEP,
 } from "@/lib/pdf/pdf-zoom.logic";
 
-describe("PDF wheel zoom", () => {
+describe("PDF zoom", () => {
   it("keeps ordinary scrolling native", () => {
     let prevented = false;
     let receivedDelta: number | undefined;
@@ -62,6 +64,21 @@ describe("PDF wheel zoom", () => {
 
     for (const { current, deltaY, expected } of cases) {
       const offset = getPDFWheelZoomScaleOffset(current, deltaY);
+
+      expect(offset).toBe(expected);
+      expect(offset).toBeGreaterThanOrEqual(PDF_MIN_SCALE_OFFSET);
+      expect(offset).toBeLessThanOrEqual(PDF_MAX_SCALE_OFFSET);
+    }
+  });
+
+  it("clamps toolbar steps after fractional pinch offsets", () => {
+    const cases = [
+      { current: 1.99, delta: PDF_SCALE_OFFSET_STEP, expected: 2 },
+      { current: -0.79, delta: -PDF_SCALE_OFFSET_STEP, expected: -0.8 },
+    ];
+
+    for (const { current, delta, expected } of cases) {
+      const offset = getPDFScaleOffset(current, delta);
 
       expect(offset).toBe(expected);
       expect(offset).toBeGreaterThanOrEqual(PDF_MIN_SCALE_OFFSET);

--- a/apps/web/src/lib/pdf/pdf-zoom.logic.test.ts
+++ b/apps/web/src/lib/pdf/pdf-zoom.logic.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  consumePDFWheelZoomEvent,
+  getPDFWheelZoomScaleOffset,
+  PDF_MAX_SCALE_OFFSET,
+  PDF_MIN_SCALE_OFFSET,
+} from "@/lib/pdf/pdf-zoom.logic";
+
+describe("PDF wheel zoom", () => {
+  it("keeps ordinary scrolling native", () => {
+    let prevented = false;
+    let receivedDelta: number | undefined;
+
+    const consumed = consumePDFWheelZoomEvent(
+      {
+        ctrlKey: false,
+        deltaY: -20,
+        preventDefault: () => {
+          prevented = true;
+        },
+      },
+      (deltaY) => {
+        receivedDelta = deltaY;
+      },
+    );
+
+    expect(consumed).toBe(false);
+    expect(prevented).toBe(false);
+    expect(receivedDelta).toBeUndefined();
+  });
+
+  it("consumes trackpad pinch gestures before they reach browser zoom", () => {
+    let prevented = false;
+    let receivedDelta: number | undefined;
+
+    const consumed = consumePDFWheelZoomEvent(
+      {
+        ctrlKey: true,
+        deltaY: -20,
+        preventDefault: () => {
+          prevented = true;
+        },
+      },
+      (deltaY) => {
+        receivedDelta = deltaY;
+      },
+    );
+
+    expect(consumed).toBe(true);
+    expect(prevented).toBe(true);
+    expect(receivedDelta).toBe(-20);
+  });
+
+  it("keeps every wheel-derived offset within the viewer bounds", () => {
+    const cases = [
+      { current: 0, deltaY: -20, expected: 0.1 },
+      { current: 0, deltaY: 20, expected: -0.1 },
+      { current: PDF_MAX_SCALE_OFFSET, deltaY: -100, expected: 2 },
+      { current: PDF_MIN_SCALE_OFFSET, deltaY: 100, expected: -0.8 },
+    ];
+
+    for (const { current, deltaY, expected } of cases) {
+      const offset = getPDFWheelZoomScaleOffset(current, deltaY);
+
+      expect(offset).toBe(expected);
+      expect(offset).toBeGreaterThanOrEqual(PDF_MIN_SCALE_OFFSET);
+      expect(offset).toBeLessThanOrEqual(PDF_MAX_SCALE_OFFSET);
+    }
+  });
+});

--- a/apps/web/src/lib/pdf/pdf-zoom.logic.ts
+++ b/apps/web/src/lib/pdf/pdf-zoom.logic.ts
@@ -9,11 +9,10 @@ type PDFWheelZoomEvent = Pick<WheelEvent, "ctrlKey" | "deltaY"> & {
   preventDefault: () => void;
 };
 
-export const getPDFWheelZoomScaleOffset = (
+export const getPDFScaleOffset = (
   currentScaleOffset: number,
-  deltaY: number,
+  delta: number,
 ) => {
-  const delta = -deltaY * PDF_PINCH_ZOOM_SENSITIVITY;
   const boundedOffset = Math.max(
     PDF_MIN_SCALE_OFFSET,
     Math.min(PDF_MAX_SCALE_OFFSET, currentScaleOffset + delta),
@@ -23,6 +22,14 @@ export const getPDFWheelZoomScaleOffset = (
     Math.round(boundedOffset * PDF_SCALE_OFFSET_PRECISION) /
     PDF_SCALE_OFFSET_PRECISION
   );
+};
+
+export const getPDFWheelZoomScaleOffset = (
+  currentScaleOffset: number,
+  deltaY: number,
+) => {
+  const delta = -deltaY * PDF_PINCH_ZOOM_SENSITIVITY;
+  return getPDFScaleOffset(currentScaleOffset, delta);
 };
 
 export const consumePDFWheelZoomEvent = (

--- a/apps/web/src/lib/pdf/pdf-zoom.logic.ts
+++ b/apps/web/src/lib/pdf/pdf-zoom.logic.ts
@@ -1,0 +1,42 @@
+export const PDF_SCALE_OFFSET_STEP = 0.2;
+export const PDF_MIN_SCALE_OFFSET = -0.8;
+export const PDF_MAX_SCALE_OFFSET = 2;
+
+const PDF_PINCH_ZOOM_SENSITIVITY = 0.005;
+const PDF_SCALE_OFFSET_PRECISION = 100;
+
+type PDFWheelZoomEvent = Pick<WheelEvent, "ctrlKey" | "deltaY"> & {
+  preventDefault: () => void;
+};
+
+export const getPDFWheelZoomScaleOffset = (
+  currentScaleOffset: number,
+  deltaY: number,
+) => {
+  const delta = -deltaY * PDF_PINCH_ZOOM_SENSITIVITY;
+  const boundedOffset = Math.max(
+    PDF_MIN_SCALE_OFFSET,
+    Math.min(PDF_MAX_SCALE_OFFSET, currentScaleOffset + delta),
+  );
+
+  return (
+    Math.round(boundedOffset * PDF_SCALE_OFFSET_PRECISION) /
+    PDF_SCALE_OFFSET_PRECISION
+  );
+};
+
+export const consumePDFWheelZoomEvent = (
+  event: PDFWheelZoomEvent,
+  onWheelZoom: (deltaY: number) => void,
+) => {
+  if (!event.ctrlKey) {
+    return false;
+  }
+
+  // Chrome exposes a trackpad pinch as a ctrl+wheel event. Consume it even
+  // when the viewer is already at a zoom bound, otherwise the gesture leaks
+  // through and starts zooming the whole browser page.
+  event.preventDefault();
+  onWheelZoom(event.deltaY);
+  return true;
+};

--- a/apps/web/src/routes/_protected.workspaces/-components/pdf-viewer-controls.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/pdf-viewer-controls.tsx
@@ -30,10 +30,13 @@ import { unwrapEden } from "@/lib/errors/api";
 import { ClientOperationError } from "@/lib/errors/client";
 import { fetchWithTimeout } from "@/lib/fetch";
 import { fileMetadataOptions } from "@/lib/files/file-metadata-query";
+import {
+  PDF_MAX_SCALE_OFFSET,
+  PDF_MIN_SCALE_OFFSET,
+  PDF_SCALE_OFFSET_STEP,
+} from "@/lib/pdf/pdf-zoom.logic";
 import { downloadFile } from "@/lib/utils";
 import { useWorkspaceStore } from "@/lib/workspaces/store";
-
-const SCALE_OFFSET_STEP = 0.2;
 
 type PdfViewerControlsProps = {
   workspaceId: string;
@@ -163,14 +166,14 @@ export const PdfViewerControls = ({
           canResetZoom={scaleOffset !== 0}
           onResetZoom={() => navigateToScale(0)}
           onZoomIn={
-            scaleOffset >= 2
+            scaleOffset >= PDF_MAX_SCALE_OFFSET
               ? undefined
-              : () => navigateToScale(scaleOffset + SCALE_OFFSET_STEP)
+              : () => navigateToScale(scaleOffset + PDF_SCALE_OFFSET_STEP)
           }
           onZoomOut={
-            scaleOffset <= -0.8
+            scaleOffset <= PDF_MIN_SCALE_OFFSET
               ? undefined
-              : () => navigateToScale(scaleOffset - SCALE_OFFSET_STEP)
+              : () => navigateToScale(scaleOffset - PDF_SCALE_OFFSET_STEP)
           }
           scaleOffset={scaleOffset}
         />

--- a/apps/web/src/routes/_protected.workspaces/-components/pdf-viewer-controls.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/pdf-viewer-controls.tsx
@@ -31,6 +31,7 @@ import { ClientOperationError } from "@/lib/errors/client";
 import { fetchWithTimeout } from "@/lib/fetch";
 import { fileMetadataOptions } from "@/lib/files/file-metadata-query";
 import {
+  getPDFScaleOffset,
   PDF_MAX_SCALE_OFFSET,
   PDF_MIN_SCALE_OFFSET,
   PDF_SCALE_OFFSET_STEP,
@@ -168,12 +169,18 @@ export const PdfViewerControls = ({
           onZoomIn={
             scaleOffset >= PDF_MAX_SCALE_OFFSET
               ? undefined
-              : () => navigateToScale(scaleOffset + PDF_SCALE_OFFSET_STEP)
+              : () =>
+                  navigateToScale(
+                    getPDFScaleOffset(scaleOffset, PDF_SCALE_OFFSET_STEP),
+                  )
           }
           onZoomOut={
             scaleOffset <= PDF_MIN_SCALE_OFFSET
               ? undefined
-              : () => navigateToScale(scaleOffset - PDF_SCALE_OFFSET_STEP)
+              : () =>
+                  navigateToScale(
+                    getPDFScaleOffset(scaleOffset, -PDF_SCALE_OFFSET_STEP),
+                  )
           }
           scaleOffset={scaleOffset}
         />


### PR DESCRIPTION
## Summary

- consume trackpad pinch gestures inside the full-screen PDF viewport so they zoom the document instead of the browser page
- centralize PDF zoom bounds and calculations while keeping the toolbar state synchronized
- cover gesture consumption, ordinary scrolling, and zoom bounds with regression tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wheel-based zooming to PDF viewers, including previews, inspector panels and fullscreen viewing.
  * Ctrl/trackpad wheel gestures now zoom PDFs without triggering browser-level zoom.
  * Zoom controls now consistently respect shared minimum and maximum limits.

* **Bug Fixes**
  * Improved zoom handling and consistency across PDF viewing contexts.

* **Tests**
  * Added coverage for wheel zoom, pinch gestures, zoom limits and toolbar controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->