### PR TITLE
fix(search): key morphological expansion with the shared ASCII fold

### DIFF
--- a/apps/api/src/lib/legal-search/expansion.test.ts
+++ b/apps/api/src/lib/legal-search/expansion.test.ts
@@ -55,6 +55,22 @@ test("an unaccented spelling reaches the accented bucket", () => {
   ]);
 });
 
+// `ł` has no canonical decomposition, so a mark-stripping fold left the key
+// spelled `wyłaczenie`: unreachable from an ASCII keyboard, and spelled unlike
+// any lexeme the index stored. The key has to fold the way the index folded.
+test("a Polish term typed without ł reaches its bucket", () => {
+  const entries = dictionaryOf([
+    {
+      documentFrequency: 600,
+      forms: ["wyłączenie", "wyłączenia"],
+      stem: "wyłącz",
+    },
+  ]);
+  expect(entries.get("wylaczenie")).toBe("wyłączenie,wyłączenia");
+  expect(expandTermWith(entries, "wylaczenie")).toEqual(["wyłączenia"]);
+  expect(expandTermWith(entries, "wyłączenie")).toEqual(["wyłączenia"]);
+});
+
 // Pinned from corpus data: `veci` and `vek`/`veku` share a stem but not a
 // word. Three shared leading characters is what separates them.
 test("a term never expands to a bucket member it shares under three characters with", () => {

--- a/apps/api/src/lib/legal-search/expansion.ts
+++ b/apps/api/src/lib/legal-search/expansion.ts
@@ -439,10 +439,10 @@ export const expandTermWith = (
   entries: ReadonlyMap<string, string>,
   term: string,
 ): readonly string[] => {
-  // Fold first, then test the shape. The fold canonicalises and strips
-  // combining marks, so a decomposed `žalobě` (routine from extracted PDFs and
-  // from macOS keyboards) is judged as the word it is rather than rejected for
-  // the marks it carries. Digits and punctuation survive the fold, so the
+  // Fold first, then test the shape. The fold decomposes and removes the
+  // marks, so a decomposed `žalobě` (routine from extracted PDFs and from
+  // macOS keyboards) is judged as the word it is rather than rejected for the
+  // marks it carries. Digits and punctuation survive the fold, so the
   // letters-only rule still excludes every identifier it excluded before.
   const folded = foldExpansionKey(term);
   if (!isSurfaceForm(folded)) {

--- a/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
@@ -107,7 +107,7 @@ test("the cap is what the parser enforces", () => {
   ).toBe(MAX_FORMS_PER_BUCKET);
 });
 
-test("the fold is lowercase, NFC, and diacritic-free", () => {
+test("the fold is lowercase, form-independent, and ASCII", () => {
   expect(foldExpansionKey("ŠKODY")).toBe("skody");
   // The same word decomposed (routine from extracted PDFs and macOS
   // filesystems) must reach the same key, or half the corpus is unreachable
@@ -116,6 +116,15 @@ test("the fold is lowercase, NFC, and diacritic-free", () => {
   expect(foldExpansionKey("žalobě".normalize("NFD"))).toBe(
     foldExpansionKey("žalobě"),
   );
+  // `ł` has no canonical decomposition, so a mark strip leaves it standing
+  // while the engine's ascii folding and `unaccent()` both store `l`. A key
+  // spelled with `ł` is a key no indexed lexeme can be spelled as.
+  expect(foldExpansionKey("Łaska")).toBe("laska");
+  expect(foldExpansionKey("zażółć")).toBe("zazolc");
+  // Case folds after the ASCII fold, the order the index applies. Lowercasing
+  // first would key on `ɩ`, a character no fold rule reaches and no lexeme can
+  // be spelled with.
+  expect(foldExpansionKey("Ɩota")).toBe("iota");
 });
 
 // A combining mark is \p{M}, not \p{L}, so a letters-only test that ran before
@@ -151,6 +160,21 @@ test("a folded key two stems claim expands to nothing", () => {
   // Keys only one stem claims are unaffected.
   expect(parsed.entries.get("radu")).toBe("rada,rady,radu");
   expect(parsed.entries.get("rade")).toBe("řada,řady,řadě");
+});
+
+// Folding to ASCII widens the ambiguous set rather than narrowing it: `łaska`
+// and `laska` are distinct Polish words that the index stores under one
+// lexeme, so they are the same ambiguity as rada/řada and get the same answer.
+// Under a mark strip they kept separate keys and each expanded to the other
+// family's inflections, which the index could never have matched anyway.
+test("a Polish ł/l pair claims one key and expands to nothing", () => {
+  const parsed = parseExpansionDictionary(
+    ["łask\tłaska,łaski\t400", "lask\tlaska,laski\t300"].join("\n"),
+  );
+  expect(parsed.collidedKeys).toBe(2);
+  expect(parsed.entries.get("laska")).toBeUndefined();
+  expect(parsed.entries.get("laski")).toBeUndefined();
+  expect(parsed.entries.size).toBe(0);
 });
 
 // Order must not decide the answer: the same two buckets serialized either way

--- a/apps/api/src/lib/legal-search/morphology/dictionary.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.ts
@@ -13,7 +13,7 @@
  * what it emits. Neither layer is allowed to be the only one.
  */
 
-import { stripDiacritics } from "@stll/text-normalize";
+import { foldToAscii } from "@stll/text-normalize";
 
 import type { MorphologyLanguage } from "@/api/lib/legal-search/morphology/stem";
 
@@ -103,7 +103,7 @@ export const isMorphologyDictionaryContentHash = (value: string): boolean =>
   CONTENT_HASH_PATTERN.test(value);
 
 /**
- * Lookup key for a surface form: NFC, lowercased, then diacritics stripped.
+ * Lookup key for a surface form: folded to ASCII, then lowercased.
  *
  * Keys are folded, values are not. The corpus is written with diacritics and
  * queries frequently are not, so folding the key is what lets "skody" reach
@@ -111,12 +111,25 @@ export const isMorphologyDictionaryContentHash = (value: string): boolean =>
  * because the engine folds its own query terms and an accented form matches
  * strictly more index terms than its folded spelling would.
  *
+ * `foldToAscii` rather than a mark strip, because the engine's `ascii_folding`
+ * and PostgreSQL `unaccent()` fold letters that have no canonical
+ * decomposition: Polish `ł` survives NFD plus mark removal, so a key built
+ * that way is spelled differently from every lexeme the index stored for it.
+ * The fold decomposes internally, so the key is form-independent without a
+ * separate NFC pass.
+ *
+ * Case folding runs after, in the order the index applies it: `unaccent()`
+ * maps case for case, and the tokenizer lowercases what comes out. Reversing
+ * the two would key on whatever the source character's lowercase form happens
+ * to be, and that form is not always one the fold table reaches — `Ɩ` folds to
+ * `I`, but lowercases first to `ɩ`, which no lexeme can be spelled with.
+ *
  * The stemmer deliberately runs the other way round (fold after stemming),
  * which is why it is never called here: this fold destroys exactly the
  * characters the suffix tables are written over.
  */
 export const foldExpansionKey = (term: string): string =>
-  stripDiacritics(term.normalize("NFC").toLowerCase());
+  foldToAscii(term).toLowerCase();
 
 export type ExpansionBucket = {
   /** Corpus document frequency summed over the bucket's members. */
@@ -174,12 +187,12 @@ export type ParsedExpansionDictionary = {
  * line must cost one bucket rather than every query the language serves.
  *
  * Keys are folded and values are not, so two buckets whose stems differ only
- * by diacritics claim the same key: Czech `rada`/`řada` and Polish `sad`/`sąd`
- * are ordinary words, not edge cases. Letting the later line win would answer
- * a query for one family with the other family's inflections, and the
- * prefix guard cannot see it because the folded spellings agree. Such a key
- * expands to nothing instead — an ambiguous lookup is resolved by declining
- * to answer, never by serialization order.
+ * by what the fold removes claim the same key: Czech `rada`/`řada`, Polish
+ * `sad`/`sąd` and `łaska`/`laska` are ordinary words, not edge cases. Letting
+ * the later line win would answer a query for one family with the other
+ * family's inflections, and the prefix guard cannot see it because the folded
+ * spellings agree. Such a key expands to nothing instead: an ambiguous lookup
+ * is resolved by declining to answer, never by serialization order.
  */
 type ParseAccumulator = {
   collided: Set<string>;
@@ -268,9 +281,9 @@ const PARSE_BATCH_LINES = 2000;
  * The same parse, handing the event loop back between batches.
  *
  * Parsing is the CPU half of loading a dictionary and it is not cheap: every
- * line splits twice, and every form is NFC-normalised, lower-cased, decomposed
- * and stripped before it keys a Map. On a payload near the ceiling that is long
- * enough to stall an API replica, and detaching the fetch does not help —
+ * line splits twice, and every form is decomposed, folded and lower-cased
+ * before it keys a Map. On a payload near the ceiling that is long enough to
+ * stall an API replica, and detaching the fetch does not help —
  * a detached promise's continuation still runs on the same thread. A warm-up or
  * a rebuild should not pause the requests happening around it.
  */


### PR DESCRIPTION
## Problem

`foldExpansionKey` is the one definition the offline dictionary builder and the
query-time loader share: it turns a surface form into the key both sides look
up. It folded with `stripDiacritics`, which is NFD plus combining-mark removal,
and that can only fold a letter with a canonical decomposition.

Polish `ł` has none. So the key kept it (`wyłączenie` -> `wyłaczenie`) while the
corpus index's `ascii_folding` and PostgreSQL `unaccent()` both store `l`
(`wylaczenie`). Every Polish key carrying `ł` therefore addressed a spelling no
indexed lexeme has, and was unreachable from a reader typing ASCII.

`foldToAscii` (`packages/text-normalize/src/ascii-fold.ts`) is the fold already
used by the query and highlight paths, generated from the extension's own rules
and pinned against a live PostgreSQL by
`apps/api/src/lib/search/ascii-fold-unaccent-parity.db.test.ts`.

## Change

- `foldExpansionKey` now returns `foldToAscii(term.toLowerCase())`. The fold
  decomposes internally, so the separate NFC pass is gone; the existing
  NFD/NFC agreement test pins that the key stays form-independent.
- The case-then-fold order mirrors the tokenizer, which lists `lower_caser`
  before `ascii_folding`, and the builder's vocabulary arrives already
  lowercased from `to_tsvector('simple', ...)`. The orders are not
  interchangeable for a character whose lowercase form the fold table does not
  reach: `Ɩ` folds to `I` but lowercases to `ɩ`, so folding first would key an
  uppercase query on `iota` against a corpus form keyed `ɩota`. The agreement
  is now bound rather than documented: the test reads `FOLDED_TOKENIZER`'s own
  filter list, so reordering the filters fails there.
- Comments updated where they described the old mark-strip behaviour.

Call sites checked: the builder (`apps/api/src/scripts/build-expansion-dictionary.ts`)
imports `foldExpansionKey` rather than carrying its own copy, and the loader and
`expandTermWith` do the same, so builder and loader still fold identically by
construction. The stem path is unchanged: `morphology/stem.ts` performs no fold
at all (it only normalises to NFC and lowercases, because the suffix tables are
diacritic-bearing), and the fold-after-stem ordering is untouched.

## Ambiguity

Folding to ASCII widens the ambiguous-key set rather than narrowing it: `łaska`
and `laska` are distinct Polish words the index stores as one lexeme, so they
now claim one key. That is the same ambiguity as Czech `rada`/`řada`, and takes
the same established answer: the key expands to nothing, because an ambiguous
lookup is resolved by declining to answer, never by serialization order. Under
the mark strip the pair kept separate keys and each expanded to the other
family's inflections, which the index could not have matched anyway.

## Dictionaries

No dictionary has been published yet, so there is no re-key migration and no
stale payload to invalidate. Dictionaries must be built after this lands; a
payload built with the old fold would key Polish buckets in a spelling the
loader no longer produces.

## Tests

- `foldExpansionKey` fold test extended with the `ł`, `zażółć`, and `Straße`
  cases, plus a separate test binding the fold order to the tokenizer's
  filter list.
- New parser test pinning that the `łaska`/`laska` pair is detected as
  ambiguous and drops both keys.
- New `expandTermWith` test pinning that a Polish term typed without `ł`
  reaches its bucket. Both new tests fail against the previous fold.
- Round-trip and clause-safety properties are unchanged and still pass.

`apps/api` legal-search suites plus the module-mock guards: 248 tests, 0 fail.
`@stll/text-normalize`: 80 tests, 0 fail. tsc, type-aware oxlint, ratchet, and
oxfmt clean.
