### PR TITLE
fix(api): harden durable extraction timeout diagnostics

### DIFF
--- a/apps/api/src/lib/analytics/capture.test.ts
+++ b/apps/api/src/lib/analytics/capture.test.ts
@@ -7,6 +7,13 @@ import {
   test,
 } from "bun:test";
 
+import {
+  extractionWorkerErrorCode,
+  ExtractionWorkerError,
+  type ExtractionWorkerTermination,
+  SUBPROCESS_TERMINATION_REASON,
+} from "@/api/lib/errors/tagged-errors";
+
 const captured: { properties: Record<string, unknown> }[] = [];
 
 const realClient = await import("@/api/lib/analytics/client");
@@ -36,6 +43,24 @@ const captureFromSiteA = (context?: Record<string, string>): void => {
 const captureFromSiteB = (): void => {
   captureError(new Error("boom"));
 };
+
+const extractionError = ({
+  exitCode,
+  message,
+  termination,
+}: {
+  exitCode: number | null;
+  message: string;
+  termination: ExtractionWorkerTermination | null;
+}): ExtractionWorkerError =>
+  new ExtractionWorkerError({
+    code: extractionWorkerErrorCode(termination),
+    exitCode,
+    message,
+    mimeType: "application/pdf",
+    sizeBytes: 12_345,
+    termination,
+  });
 
 beforeEach(() => {
   captured.length = 0;
@@ -120,5 +145,61 @@ describe("captureError issue grouping", () => {
     const fingerprint = captured.at(0)?.properties["$exception_fingerprint"];
     expect(typeof fingerprint).toBe("string");
     expect(fingerprint).not.toContain("Privileged");
+  });
+});
+
+describe("captureError extraction diagnostics", () => {
+  test("attaches safe worker metadata without exposing the error message", () => {
+    captureError(
+      extractionError({
+        exitCode: null,
+        message: "Privileged document parser detail",
+        termination: {
+          reason: SUBPROCESS_TERMINATION_REASON.timeout,
+          signalCode: "SIGTERM",
+        },
+      }),
+      { runId: "run-1" },
+    );
+
+    const properties = captured.at(0)?.properties;
+    expect(properties).toMatchObject({
+      "error.code": "worker_timeout",
+      mimeType: "application/pdf",
+      runId: "run-1",
+      signalCode: "SIGTERM",
+      sizeBytes: "12345",
+      terminationReason: "timeout",
+    });
+    expect(JSON.stringify(properties)).not.toContain("Privileged");
+  });
+
+  test("fingerprints parser exits separately from worker termination", () => {
+    captureError(
+      extractionError({
+        exitCode: 1,
+        message: "parser failed",
+        termination: null,
+      }),
+    );
+    captureError(
+      extractionError({
+        exitCode: null,
+        message: "worker timed out",
+        termination: {
+          reason: SUBPROCESS_TERMINATION_REASON.timeout,
+          signalCode: "SIGTERM",
+        },
+      }),
+    );
+
+    expect(captured).toHaveLength(2);
+    expect(captured.at(0)?.properties).toMatchObject({
+      "error.code": "parser_failed",
+      exitCode: "1",
+    });
+    expect(captured.at(0)?.properties["$exception_fingerprint"]).not.toBe(
+      captured.at(1)?.properties["$exception_fingerprint"],
+    );
   });
 });

--- a/apps/api/src/lib/analytics/capture.ts
+++ b/apps/api/src/lib/analytics/capture.ts
@@ -5,6 +5,7 @@ import {
   errorFingerprint,
   errorTag,
   logDevError,
+  safeErrorTelemetryFields,
 } from "@/api/lib/errors/utils";
 import { getRequestContext } from "@/api/lib/observability/request-context";
 
@@ -171,6 +172,7 @@ const captureErrorWithOptions = (
     // the dashboard without violating it.
     ...fingerprint,
     ...options.context,
+    ...safeErrorTelemetryFields(error),
     ...(options.organizationId
       ? { organization_id: options.organizationId }
       : {}),

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -384,17 +384,50 @@ export class SubprocessError extends TaggedError("SubprocessError")<{
   cause?: unknown;
 }> {}
 
-type ExtractionWorkerTermination = {
+export type ExtractionWorkerTermination = {
   reason: SubprocessTerminationReason;
   signalCode: string;
 };
+
+export const EXTRACTION_WORKER_ERROR_CODE = {
+  cancelled: "worker_cancelled",
+  crashed: "worker_crashed",
+  external: "worker_externally_terminated",
+  parser: "parser_failed",
+  timeout: "worker_timeout",
+} as const;
+
+export type ExtractionWorkerErrorCode =
+  (typeof EXTRACTION_WORKER_ERROR_CODE)[keyof typeof EXTRACTION_WORKER_ERROR_CODE];
+
+const EXTRACTION_WORKER_TERMINATION_ERROR_CODE = {
+  [SUBPROCESS_TERMINATION_REASON.cancelled]:
+    EXTRACTION_WORKER_ERROR_CODE.cancelled,
+  [SUBPROCESS_TERMINATION_REASON.crashed]: EXTRACTION_WORKER_ERROR_CODE.crashed,
+  [SUBPROCESS_TERMINATION_REASON.external]:
+    EXTRACTION_WORKER_ERROR_CODE.external,
+  [SUBPROCESS_TERMINATION_REASON.timeout]: EXTRACTION_WORKER_ERROR_CODE.timeout,
+} as const satisfies Record<
+  SubprocessTerminationReason,
+  ExtractionWorkerErrorCode
+>;
+
+export const extractionWorkerErrorCode = (
+  termination: ExtractionWorkerTermination | null,
+): ExtractionWorkerErrorCode =>
+  termination === null
+    ? EXTRACTION_WORKER_ERROR_CODE.parser
+    : EXTRACTION_WORKER_TERMINATION_ERROR_CODE[termination.reason];
 
 /** File content extraction failure. */
 export class ExtractionWorkerError extends TaggedError(
   "ExtractionWorkerError",
 )<{
+  code: ExtractionWorkerErrorCode;
   message: string;
   exitCode: number | null;
+  mimeType: string;
+  sizeBytes: number;
   termination: ExtractionWorkerTermination | null;
 }> {}
 

--- a/apps/api/src/lib/errors/utils.ts
+++ b/apps/api/src/lib/errors/utils.ts
@@ -6,6 +6,7 @@ import { createDevErrorLogger } from "@stll/errors";
 
 import { envBase } from "@/api/env-base";
 import { errorClassName, errorTag } from "@/api/lib/errors/error-tag";
+import { ExtractionWorkerError } from "@/api/lib/errors/tagged-errors";
 import { pgErrorFields } from "@/api/lib/pg-error";
 
 // Re-exported so callers keep one import path, while modules that must not
@@ -81,6 +82,32 @@ export const connectionErrorFields = (
     }
   }
   return fields;
+};
+
+/**
+ * Typed, non-content diagnostics that every error capture may safely attach.
+ * Keep this exhaustive per supported error class so callers cannot forget
+ * fields on one execution path, while messages, names, and document bytes
+ * remain excluded by construction.
+ */
+export const safeErrorTelemetryFields = (
+  error: unknown,
+): Record<string, string> => {
+  if (!(error instanceof ExtractionWorkerError)) {
+    return {};
+  }
+  const fields = {
+    mimeType: error.mimeType,
+    sizeBytes: String(error.sizeBytes),
+  };
+  if (error.termination !== null) {
+    return {
+      ...fields,
+      signalCode: error.termination.signalCode,
+      terminationReason: error.termination.reason,
+    };
+  }
+  return { ...fields, exitCode: String(error.exitCode) };
 };
 
 const safeErrorStringProperty = (

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -275,6 +275,8 @@ export const LIMITS = {
   ocrPdfGenerationTimeoutMs: 2 * 60_000,
   /** Hard timeout (ms) for the sandboxed extraction subprocess. */
   extractionTimeoutMs: 30_000,
+  /** Hard timeout for durable background document extraction. */
+  documentProcessingExtractionTimeoutMs: 2 * 60_000,
   /** Wall-clock ceiling for one document-processing object-storage read. */
   documentProcessingObjectReadTimeoutMs: 30_000,
   /** Wall-clock ceiling (ms) for the live DOCX-to-Markdown read path in

--- a/apps/api/src/lib/search/extract-content.ts
+++ b/apps/api/src/lib/search/extract-content.ts
@@ -113,13 +113,17 @@ export const resolveExtractionMimeType = ({
 };
 
 type ExtractFileTextResultOptions = {
+  signal?: AbortSignal;
   timeoutMs?: number;
 };
 
 export const extractFileTextResult = async (
   buffer: ArrayBuffer,
   mimeType: string,
-  { timeoutMs = LIMITS.extractionTimeoutMs }: ExtractFileTextResultOptions = {},
+  {
+    signal,
+    timeoutMs = LIMITS.extractionTimeoutMs,
+  }: ExtractFileTextResultOptions = {},
 ): Promise<Result<string | null, ExtractionWorkerError>> => {
   const normalizedMimeType = normalizeMimeType(mimeType);
   if (!canExtractMimeType(normalizedMimeType)) {
@@ -129,6 +133,7 @@ export const extractFileTextResult = async (
   const result = await spawnWorker({
     workerPath: WORKER_PATH,
     args: [normalizedMimeType],
+    ...(signal ? { signal } : {}),
     stdin: new Blob([buffer]),
     timeoutMs,
   });

--- a/apps/api/src/lib/search/extract-content.ts
+++ b/apps/api/src/lib/search/extract-content.ts
@@ -13,6 +13,7 @@ import { Result } from "better-result";
 
 import { captureError } from "@/api/lib/analytics/capture";
 import {
+  extractionWorkerErrorCode,
   ExtractionWorkerError,
   SUBPROCESS_TERMINATION_REASON,
 } from "@/api/lib/errors/tagged-errors";
@@ -111,9 +112,14 @@ export const resolveExtractionMimeType = ({
   return EXTENSION_MIME_TYPES[extension] ?? normalized;
 };
 
+type ExtractFileTextResultOptions = {
+  timeoutMs?: number;
+};
+
 export const extractFileTextResult = async (
   buffer: ArrayBuffer,
   mimeType: string,
+  { timeoutMs = LIMITS.extractionTimeoutMs }: ExtractFileTextResultOptions = {},
 ): Promise<Result<string | null, ExtractionWorkerError>> => {
   const normalizedMimeType = normalizeMimeType(mimeType);
   if (!canExtractMimeType(normalizedMimeType)) {
@@ -124,20 +130,24 @@ export const extractFileTextResult = async (
     workerPath: WORKER_PATH,
     args: [normalizedMimeType],
     stdin: new Blob([buffer]),
-    timeoutMs: LIMITS.extractionTimeoutMs,
+    timeoutMs,
   });
 
   if (Result.isError(result)) {
+    const termination =
+      result.error.termination === null
+        ? null
+        : {
+            reason: result.error.termination.reason,
+            signalCode: result.error.termination.signalCode,
+          };
     const error = new ExtractionWorkerError({
+      code: extractionWorkerErrorCode(termination),
       message: result.error.message,
       exitCode: result.error.exitCode,
-      termination:
-        result.error.termination === null
-          ? null
-          : {
-              reason: result.error.termination.reason,
-              signalCode: result.error.termination.signalCode,
-            },
+      mimeType: normalizedMimeType,
+      sizeBytes: buffer.byteLength,
+      termination,
     });
     return Result.err(error);
   }
@@ -172,18 +182,6 @@ export const extractFileText = async (
     return result.value;
   }
 
-  const failureContext =
-    result.error.termination !== null
-      ? {
-          signalCode: result.error.termination.signalCode,
-          terminationReason: result.error.termination.reason,
-        }
-      : { exitCode: String(result.error.exitCode) };
-  captureError(result.error, {
-    mimeType: normalizeMimeType(mimeType),
-    sizeBytes: String(buffer.byteLength),
-    ...failureContext,
-    ...context,
-  });
+  captureError(result.error, context);
   return null;
 };

--- a/apps/api/src/lib/search/process-extraction.test.ts
+++ b/apps/api/src/lib/search/process-extraction.test.ts
@@ -321,10 +321,11 @@ describe("processExtraction", () => {
     extractFileTextResultMock.mockImplementationOnce(async () =>
       Result.err(workerError),
     );
+    const lifecycleSignal = new AbortController().signal;
 
     const rejection: unknown = await executeNativeExtraction({
       fileField: fileContent,
-      lifecycleSignal: new AbortController().signal,
+      lifecycleSignal,
       run: {
         entityId,
         entityVersionId,
@@ -343,7 +344,10 @@ describe("processExtraction", () => {
     expect(extractFileTextResultMock).toHaveBeenCalledWith(
       expect.any(ArrayBuffer),
       fileContent.mimeType,
-      { timeoutMs: LIMITS.documentProcessingExtractionTimeoutMs },
+      {
+        signal: lifecycleSignal,
+        timeoutMs: LIMITS.documentProcessingExtractionTimeoutMs,
+      },
     );
     expect(encryptContentMock).not.toHaveBeenCalled();
     expect(requestAutomaticDocumentOcrMock).not.toHaveBeenCalled();

--- a/apps/api/src/lib/search/process-extraction.test.ts
+++ b/apps/api/src/lib/search/process-extraction.test.ts
@@ -5,7 +5,11 @@ import { PgDialect } from "drizzle-orm/pg-core";
 
 import type { FieldContent } from "@/api/db/schema-validators";
 import { toSafeId } from "@/api/lib/branded-types";
-import { ExtractionWorkerError } from "@/api/lib/errors/tagged-errors";
+import {
+  EXTRACTION_WORKER_ERROR_CODE,
+  ExtractionWorkerError,
+} from "@/api/lib/errors/tagged-errors";
+import { LIMITS } from "@/api/lib/limits";
 import { DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
 
 // `processExtraction` reads through the `rootDb` module-level singleton
@@ -307,8 +311,11 @@ describe("processExtraction", () => {
 
   test("keeps a sandbox failure distinct from a valid empty document", async () => {
     const workerError = new ExtractionWorkerError({
+      code: EXTRACTION_WORKER_ERROR_CODE.parser,
       exitCode: 1,
       message: "sandbox crashed",
+      mimeType: fileContent.mimeType,
+      sizeBytes: fileContent.sizeBytes,
       termination: null,
     });
     extractFileTextResultMock.mockImplementationOnce(async () =>
@@ -333,6 +340,11 @@ describe("processExtraction", () => {
     );
 
     expect(rejection).toBe(workerError);
+    expect(extractFileTextResultMock).toHaveBeenCalledWith(
+      expect.any(ArrayBuffer),
+      fileContent.mimeType,
+      { timeoutMs: LIMITS.documentProcessingExtractionTimeoutMs },
+    );
     expect(encryptContentMock).not.toHaveBeenCalled();
     expect(requestAutomaticDocumentOcrMock).not.toHaveBeenCalled();
     expect(executeMock).not.toHaveBeenCalled();

--- a/apps/api/src/lib/search/process-extraction.ts
+++ b/apps/api/src/lib/search/process-extraction.ts
@@ -311,7 +311,10 @@ export const executeNativeExtraction = async ({
   const extraction = await extractFileTextResult(
     buffer,
     source.extractionMimeType,
-    { timeoutMs: LIMITS.documentProcessingExtractionTimeoutMs },
+    {
+      signal: lifecycleSignal,
+      timeoutMs: LIMITS.documentProcessingExtractionTimeoutMs,
+    },
   );
   if (Result.isError(extraction)) {
     throw extraction.error;

--- a/apps/api/src/lib/search/process-extraction.ts
+++ b/apps/api/src/lib/search/process-extraction.ts
@@ -311,6 +311,7 @@ export const executeNativeExtraction = async ({
   const extraction = await extractFileTextResult(
     buffer,
     source.extractionMimeType,
+    { timeoutMs: LIMITS.documentProcessingExtractionTimeoutMs },
   );
   if (Result.isError(extraction)) {
     throw extraction.error;


### PR DESCRIPTION
## Summary

- extend durable native extraction to a two-minute timeout while preserving the 30-second interactive default
- assign stable parser, timeout, crash, cancellation, and external-termination error codes for distinct fingerprints
- attach MIME type, byte size, and exit or signal state through the redacted error telemetry boundary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document text extraction reliability by handling cancellations, timeouts, crashes and parser failures more distinctly.
  * Added a two-minute limit for background document extraction to prevent stalled processing.
  * Preserved safer handling of extraction failures without exposing document content in diagnostic information.

* **Improvements**
  * Enhanced error reporting with sanitised technical details, helping support teams diagnose failed extractions while protecting sensitive data.
  * Improved cancellation handling so interrupted extraction jobs can stop more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->