### PR TITLE
fix(search): lowercase the expansion key before folding it

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -40,7 +40,7 @@ type CorpusIndexTokenizer = {
  * discards tokens past the default byte limit, keeping OCR runs out of the
  * term dictionary; `lower_caser` is what `default` already did.
  */
-const FOLDED_TOKENIZER = {
+export const FOLDED_TOKENIZER = {
   name: "folded",
   type: "simple",
   filters: ["lower_caser", "ascii_folding", "remove_long"],

--- a/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 
+import { FOLDED_TOKENIZER } from "@/api/lib/legal-search/corpus-index-config";
 import {
   foldExpansionKey,
   isMorphologyDictionaryContentHash,
@@ -109,6 +110,7 @@ test("the cap is what the parser enforces", () => {
 
 test("the fold is lowercase, form-independent, and ASCII", () => {
   expect(foldExpansionKey("ŠKODY")).toBe("skody");
+  expect(foldExpansionKey("Straße")).toBe("strasse");
   // The same word decomposed (routine from extracted PDFs and macOS
   // filesystems) must reach the same key, or half the corpus is unreachable
   // from half the keyboards.
@@ -121,10 +123,20 @@ test("the fold is lowercase, form-independent, and ASCII", () => {
   // spelled with `ł` is a key no indexed lexeme can be spelled as.
   expect(foldExpansionKey("Łaska")).toBe("laska");
   expect(foldExpansionKey("zażółć")).toBe("zazolc");
-  // Case folds after the ASCII fold, the order the index applies. Lowercasing
-  // first would key on `ɩ`, a character no fold rule reaches and no lexeme can
-  // be spelled with.
-  expect(foldExpansionKey("Ɩota")).toBe("iota");
+});
+
+// The key's two steps mirror the tokenizer's filter list, and the mirror is
+// asserted rather than trusted: the orders are not interchangeable for a
+// character whose lowercase form the fold table does not reach. `Ɩ` folds to
+// `I` but lowercases to `ɩ`, so folding first would key an uppercase query on
+// `iota` while the corpus form (already lowercased by `to_tsvector('simple')`,
+// which is what the builder reads) keys `ɩota`.
+test("the fold lowercases before it folds, the order the index applies", () => {
+  const filters: readonly string[] = FOLDED_TOKENIZER.filters;
+  expect(filters.indexOf("lower_caser")).toBeLessThan(
+    filters.indexOf("ascii_folding"),
+  );
+  expect(foldExpansionKey("Ɩota")).toBe(foldExpansionKey("ɩota"));
 });
 
 // A combining mark is \p{M}, not \p{L}, so a letters-only test that ran before

--- a/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.test.ts
@@ -132,7 +132,11 @@ test("the fold is lowercase, form-independent, and ASCII", () => {
 // `iota` while the corpus form (already lowercased by `to_tsvector('simple')`,
 // which is what the builder reads) keys `ɩota`.
 test("the fold lowercases before it folds, the order the index applies", () => {
-  const filters: readonly string[] = FOLDED_TOKENIZER.filters;
+  // Unannotated on purpose: the tuple keeps its literal element type, so
+  // dropping either filter from the tokenizer makes the argument below a
+  // compile error rather than an `indexOf` returning -1 that this comparison
+  // would read as an ordering. Only the ordering is left to assert at runtime.
+  const { filters } = FOLDED_TOKENIZER;
   expect(filters.indexOf("lower_caser")).toBeLessThan(
     filters.indexOf("ascii_folding"),
   );

--- a/apps/api/src/lib/legal-search/morphology/dictionary.ts
+++ b/apps/api/src/lib/legal-search/morphology/dictionary.ts
@@ -103,7 +103,7 @@ export const isMorphologyDictionaryContentHash = (value: string): boolean =>
   CONTENT_HASH_PATTERN.test(value);
 
 /**
- * Lookup key for a surface form: folded to ASCII, then lowercased.
+ * Lookup key for a surface form: lowercased, then folded to ASCII.
  *
  * Keys are folded, values are not. The corpus is written with diacritics and
  * queries frequently are not, so folding the key is what lets "skody" reach
@@ -118,18 +118,20 @@ export const isMorphologyDictionaryContentHash = (value: string): boolean =>
  * The fold decomposes internally, so the key is form-independent without a
  * separate NFC pass.
  *
- * Case folding runs after, in the order the index applies it: `unaccent()`
- * maps case for case, and the tokenizer lowercases what comes out. Reversing
- * the two would key on whatever the source character's lowercase form happens
- * to be, and that form is not always one the fold table reaches — `Ɩ` folds to
- * `I`, but lowercases first to `ɩ`, which no lexeme can be spelled with.
+ * Case folding runs first, the order the index applies: `FOLDED_TOKENIZER`
+ * lists `lower_caser` before `ascii_folding`, and the builder's vocabulary
+ * comes from `to_tsvector('simple', ...)`, which has already lowercased. The
+ * two orders are not interchangeable for a character whose lowercase form the
+ * fold table does not reach: `Ɩ` folds to `I` but lowercases to `ɩ`, so
+ * folding first would key an uppercase query on `iota` while the corpus form
+ * keys `ɩota`, and the bucket would be unreachable from that spelling.
  *
  * The stemmer deliberately runs the other way round (fold after stemming),
  * which is why it is never called here: this fold destroys exactly the
  * characters the suffix tables are written over.
  */
 export const foldExpansionKey = (term: string): string =>
-  foldToAscii(term).toLowerCase();
+  foldToAscii(term.toLowerCase());
 
 export type ExpansionBucket = {
   /** Corpus document frequency summed over the bucket's members. */
@@ -281,7 +283,7 @@ const PARSE_BATCH_LINES = 2000;
  * The same parse, handing the event loop back between batches.
  *
  * Parsing is the CPU half of loading a dictionary and it is not cheap: every
- * line splits twice, and every form is decomposed, folded and lower-cased
+ * line splits twice, and every form is lower-cased, decomposed and folded
  * before it keys a Map. On a payload near the ceiling that is long enough to
  * stall an API replica, and detaching the fetch does not help —
  * a detached promise's continuation still runs on the same thread. A warm-up or


### PR DESCRIPTION
Follow-up to #2124, which repointed `foldExpansionKey` at `foldToAscii` but
composed the two steps in the wrong order.

## Problem

`foldExpansionKey` ran `foldToAscii(term).toLowerCase()`: ASCII fold first,
case fold after. The index does the opposite. `FOLDED_TOKENIZER`
(`apps/api/src/lib/legal-search/corpus-index-config.ts`) lists its filters as
`["lower_caser", "ascii_folding", "remove_long"]`, and the builder's vocabulary
comes from `ts_stat` over `to_tsvector('simple', ...)`, which has already
lowercased every token before a dictionary form is ever written.

The two orders are not the same function. They agree on everything a Czech,
Polish, or Slovak corpus actually contains, and diverge for a character whose
lowercase form the fold table does not reach: `Ɩ` (U+0196) folds to `I`, but
lowercases to `ɩ` (U+0269), which no fold rule touches. Folding first keyed an
uppercase query on `iota` while the corpus form keys `ɩota`, so the bucket was
unreachable from that spelling. 56 fold-table characters lowercase to a form
outside the table, which is the size of the class.

## Change

- `foldExpansionKey` returns `foldToAscii(term.toLowerCase())`.
- `FOLDED_TOKENIZER` is exported so the test can read its filter list.

The fold order and the tokenizer's filter order have to mirror each other, so
the test asserts the mirror instead of trusting it: it reads
`FOLDED_TOKENIZER.filters` and requires `lower_caser` to precede
`ascii_folding`. Reordering the tokenizer's filters now fails there rather than
silently splitting the key from the lexemes it addresses.

## Tests

- New test binding the fold order to the tokenizer's filter list, plus
  `foldExpansionKey("Ɩota") === foldExpansionKey("ɩota")`. Both fail against the
  merged ordering.
- `Straße` -> `strasse` added to the fold test, pinning a multi-character fold
  output.

`apps/api` legal-search suites: 230 tests, 0 fail. tsc, type-aware oxlint,
ratchet, and oxfmt clean.

## Dictionaries

Still none published, so there is no re-key migration; dictionaries must be
built after this lands rather than after #2124.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legal search matching by applying consistent case handling when processing terms.
  * Searches now more reliably match equivalent spellings, including words containing German “ß”.
  * Corrected character-folding behaviour for certain Unicode characters, improving consistency across indexed content and search queries.
* **Tests**
  * Expanded coverage for case-insensitive matching, character equivalence, and tokenizer behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->