### PR TITLE
feat(lint): guard omitted props against the props respread

### DIFF
--- a/.oxlint-plugins/README.md
+++ b/.oxlint-plugins/README.md
@@ -86,6 +86,7 @@ runtime validation, or integration tests.
 - [`no-inline-style-colors`](./no-inline-style-colors.ts) (`no-inline-style-colors`): rejects hardcoded color values only inside JSX `style={{ ... }}` objects; domain data objects are out of scope.
 - [`no-input-dir-auto`](./no-input-dir-auto.ts) (`no-input-dir-auto`): prevents `dir="auto"` on form inputs where direction changes can destabilize layout and value editing.
 - [`no-legacy-entity-route`](./no-legacy-entity-route.ts) (`no-legacy-entity-route`): prevents construction of the removed public entity detail route.
+- [`no-omitted-prop-respread`](./no-omitted-prop-respread.ts) (`no-omitted-prop-respread`): requires a prop a component omits from its props type to be pinned after the last props spread, because width subtyping keeps the key on the spread value at runtime. It reads literal `Omit` keys and the component's own props binding only.
 - [`no-raw-route-query-client`](./no-raw-route-query-client.ts) (`no-raw-route-query-client`): requires route freshness wrappers in loaders and synchronous cache reads in pending components.
 - [`no-raw-router-invalidation`](./no-raw-router-invalidation.ts) (`no-raw-router-invalidation`): confines navigation-grade `router.invalidate()` calls to the owned session, locale, and exhaustively classified route-metadata boundaries.
 - [`no-raw-stored-json`](./no-raw-stored-json.ts) (`no-raw-stored-json`): requires persisted browser JSON to be parsed and schema-validated through `readStoredJson()`.

--- a/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
@@ -146,6 +146,19 @@ export const _ok_reTypedAlias = (props: RetypedPanelProps) => (
   <Panel {...props} />
 );
 
+// Allowed: an intersection has a key when any member has it, so each member
+// here supplies what the other omits and neither key is actually removed.
+export const _ok_intersectedOmissions = (
+  props: Omit<PanelProps, "orientation"> & Omit<PanelProps, "variant">,
+) => <Panel {...props} />;
+
+// Allowed: a generic alias means something different per use site, and the
+// argument here deliberately puts `orientation` back.
+type GenericShellProps<Extra> = Omit<PanelProps, "orientation"> & Extra;
+export const _ok_genericAliasArgument = (
+  props: GenericShellProps<{ orientation?: "vertical" }>,
+) => <Panel {...props} />;
+
 // Allowed: a union of props shapes keeps only the keys every branch omits, and
 // a value of the second branch may legitimately carry `orientation`.
 export const _ok_unionBranchOmit = (

--- a/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
@@ -225,6 +225,14 @@ export const _ok_reTypedUnderNestedOmit = (
   >,
 ) => <Panel {...props} orientation="horizontal" />;
 
+// Allowed: the annotation is a generic parameter shadowing the alias of the
+// same name, so the alias does not answer for it.
+export type ShadowedProps = Omit<PanelProps, "orientation">;
+export const _ok_typeParameterShadowsAlias = <ShadowedProps extends PanelProps>(
+  props: ShadowedProps,
+  _sibling: ShadowedProps,
+) => <Panel {...props} />;
+
 // Allowed: `SharedProps` is imported here and also declared in an unrelated
 // nested scope, so the name answers to neither rather than to the wrong one.
 export const _ok_importedNameCollision = (props: SharedProps) => (

--- a/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
@@ -156,6 +156,32 @@ export const _ok_shadowedBinding = ({
   </Panel>
 );
 
+// Allowed: the shadowing binding is a later parameter, not the first one.
+export const _ok_shadowedSecondParam = ({
+  ...props
+}: Omit<PanelProps, "orientation">) => (
+  <Panel {...props} orientation="horizontal">
+    {[<span key="a" />].map((_item, props: PanelProps) => (
+      <Panel {...props} />
+    ))}
+  </Panel>
+);
+
+// Allowed: the shadowing binding is a local, not a parameter at all.
+export const _ok_shadowedLocal = ({
+  ...props
+}: Omit<PanelProps, "orientation">) => {
+  const render = () => {
+    const props: PanelProps = { id: "inner" };
+    return <Panel {...props} />;
+  };
+  return (
+    <Panel {...props} orientation="horizontal">
+      {render()}
+    </Panel>
+  );
+};
+
 // Allowed: the trailing spread is a statically known object literal that does
 // not declare the omitted key, so it cannot override the pin.
 export const _ok_trailingLiteralSpread = (
@@ -176,6 +202,17 @@ export const _defaultedParam = (
 export const _defaultedDestructuring = ({
   ...props
 }: Omit<PanelProps, "orientation"> = {}) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...props} />
+);
+
+// A long alias chain still resolves: only a cycle stops the walk.
+type Shell1 = Omit<PanelProps, "orientation">;
+type Shell2 = Shell1;
+type Shell3 = Shell2;
+type Shell4 = Shell3;
+type Shell5 = Shell4;
+export const _deepAliasChain = (props: Shell5) => (
   // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
   <Panel {...props} />
 );

--- a/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
@@ -1,0 +1,138 @@
+// Passive regression fixture for
+// `no-omitted-prop-respread/no-omitted-prop-respread`.
+//
+// `oxlint-disable-next-line` directives suppress cases the rule MUST flag; if
+// the rule regresses the directive goes unused and
+// `--report-unused-disable-directives-severity=error` fails CI. Lines without a
+// directive cover the allow-list and must keep passing.
+
+import type * as React from "react";
+
+type PanelProps = React.ComponentProps<"section"> & {
+  orientation?: "horizontal" | "vertical";
+  variant?: "solid" | "underline";
+};
+
+const Panel = (props: PanelProps) => <section {...props} />;
+
+type ShellProps = Omit<PanelProps, "orientation">;
+type LabelledShellProps = ShellProps & { label?: string };
+
+const child = <span />;
+
+// --- Flagged: the omitted key cannot survive the props spread ---
+
+// Written before the spread, so the spread overwrites it.
+export const _pinnedBefore = (props: Omit<PanelProps, "orientation">) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel orientation="horizontal" {...props} />
+);
+
+// Never written, so the spread supplies whatever the caller's wider value
+// carried.
+export const _neverPinned = ({ ...props }: Omit<PanelProps, "variant">) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...props} />
+);
+
+// Both omitted keys are reported; `variant` is pinned before the spread and
+// `orientation` is not pinned at all.
+export const _multipleKeys = (
+  props: Omit<PanelProps, "orientation" | "variant">,
+) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel variant="underline" {...props} />
+);
+
+// A second spread after the pin can override it just as the first would.
+export const _lastSpreadWins = ({
+  ...props
+}: Omit<PanelProps, "orientation">) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...props} orientation="horizontal" {...props} />
+);
+
+// The omit is reached through a file-local alias.
+export const _viaAlias = ({ ...props }: ShellProps) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...props} />
+);
+
+// And through an alias that intersects the omitting one.
+export const _viaIntersectedAlias = ({
+  label: _label,
+  ...props
+}: LabelledShellProps) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...props} />
+);
+
+// The shape the portable inspector shell shipped with before the fix: forced
+// chrome props sat above the spread that could replace them.
+export const _inspectorTabsBeforeFix = ({
+  className,
+  ...props
+}: Omit<PanelProps, "orientation">) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel className={className} orientation="horizontal" {...props} />
+);
+
+// --- Allowed: the pin clears the last spread ---
+
+// The shape the portable inspector shell ships today.
+export const _ok_inspectorTabs = ({
+  className,
+  ...props
+}: Omit<PanelProps, "orientation">) => (
+  <Panel className={className} {...props} orientation="horizontal" />
+);
+export const _ok_pinnedAfter = (props: Omit<PanelProps, "variant">) => (
+  <Panel {...props} variant="underline" />
+);
+export const _ok_pinnedAfterEveryKey = (
+  props: Omit<PanelProps, "orientation" | "variant">,
+) => <Panel {...props} orientation="horizontal" variant="underline" />;
+
+// Allowed: nothing is spread, so no wider value reaches the element.
+export const _ok_noSpread = ({ id }: Omit<PanelProps, "orientation">) => (
+  <Panel id={id} />
+);
+
+// Allowed: the spread is not the omitting component's props binding.
+export const _ok_unrelatedSpread = (props: Omit<PanelProps, "orientation">) => (
+  <Panel {...{ id: props.id }} />
+);
+
+// Allowed: a non-literal key set is outside what this rule can read.
+export const _ok_genericKeys = <Key extends keyof PanelProps>(
+  props: Omit<PanelProps, Key>,
+) => <Panel {...props} />;
+
+// Allowed: JSX children are passed positionally and beat a spread `children`.
+export const _ok_children = (props: Omit<PanelProps, "children">) => (
+  <Panel {...props}>{child}</Panel>
+);
+
+// Allowed: the props type omits nothing.
+export const _ok_noOmit = (props: PanelProps) => <Panel {...props} />;
+
+// Allowed: the pattern destructures the omitted key, so the rest object
+// provably does not carry it and the pin before the spread survives.
+export const _ok_destructuredOut = ({
+  orientation,
+  ...props
+}: Omit<PanelProps, "orientation"> & { orientation?: "horizontal" }) => (
+  <Panel orientation={orientation} {...props} />
+);
+
+// Allowed: the omission re-types the key rather than forbidding it, so it is
+// meant to reach the element through the spread.
+export const _ok_reTyped = (
+  props: Omit<PanelProps, "variant"> & { variant?: "ghost" },
+) => <Panel {...props} />;
+
+// Same shape reached through a file-local alias.
+type RetypedPanelProps = Omit<PanelProps, "variant"> & { variant?: "ghost" };
+export const _ok_reTypedAlias = (props: RetypedPanelProps) => (
+  <Panel {...props} />
+);

--- a/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
@@ -224,6 +224,24 @@ export const _ok_reTypedUnderNestedOmit = (
   >,
 ) => <Panel {...props} orientation="horizontal" />;
 
+// A function-local alias resolves like a top-level one.
+export const _blockLocalAlias = () => {
+  type InnerProps = Omit<PanelProps, "orientation">;
+  const Inner = (props: InnerProps) => (
+    // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+    <Panel {...props} />
+  );
+  return <Inner />;
+};
+
+// A top-level alias declared after the component that annotates with it still
+// resolves: the walk finishes before anything is reported.
+export const _forwardDeclaredAlias = (props: LaterProps) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...props} />
+);
+type LaterProps = Omit<PanelProps, "orientation">;
+
 // A long alias chain still resolves: only a cycle stops the walk.
 type Shell1 = Omit<PanelProps, "orientation">;
 type Shell2 = Shell1;

--- a/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
@@ -7,6 +7,7 @@
 // directive cover the allow-list and must keep passing.
 
 import type * as React from "react";
+import type { AriaAttributes as SharedProps } from "react";
 
 type PanelProps = React.ComponentProps<"section"> & {
   orientation?: "horizontal" | "vertical";
@@ -223,6 +224,26 @@ export const _ok_reTypedUnderNestedOmit = (
     "orientation"
   >,
 ) => <Panel {...props} orientation="horizontal" />;
+
+// Allowed: `SharedProps` is imported here and also declared in an unrelated
+// nested scope, so the name answers to neither rather than to the wrong one.
+export const _ok_importedNameCollision = (props: SharedProps) => (
+  <Panel {...props} />
+);
+export const _ok_collidingNestedAlias = () => {
+  type SharedProps = Omit<PanelProps, "orientation">;
+  return (props: SharedProps) => <Panel {...props} />;
+};
+
+// An erased `this` parameter takes the first AST slot without carrying a
+// runtime argument, so the props parameter follows it.
+export function _thisParameter(
+  this: unknown,
+  props: Omit<PanelProps, "orientation">,
+) {
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  return <Panel {...props} />;
+}
 
 // A function-local alias resolves like a top-level one.
 export const _blockLocalAlias = () => {

--- a/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
@@ -136,3 +136,9 @@ type RetypedPanelProps = Omit<PanelProps, "variant"> & { variant?: "ghost" };
 export const _ok_reTypedAlias = (props: RetypedPanelProps) => (
   <Panel {...props} />
 );
+
+// Allowed: a union of props shapes keeps only the keys every branch omits, and
+// a value of the second branch may legitimately carry `orientation`.
+export const _ok_unionBranchOmit = (
+  props: Omit<PanelProps, "orientation"> | Omit<PanelProps, "variant">,
+) => <Panel {...props} />;

--- a/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
@@ -37,13 +37,20 @@ export const _neverPinned = ({ ...props }: Omit<PanelProps, "variant">) => (
   <Panel {...props} />
 );
 
-// Both omitted keys are reported; `variant` is pinned before the spread and
-// `orientation` is not pinned at all.
-export const _multipleKeys = (
+// Each member of a literal-key union is guarded on its own: the other key is
+// pinned after the spread, so only one diagnostic can keep each directive used
+// and dropping either member of the union leaves its directive unused.
+export const _unionKeyOrientation = (
   props: Omit<PanelProps, "orientation" | "variant">,
 ) => (
   // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
-  <Panel variant="underline" {...props} />
+  <Panel {...props} variant="underline" />
+);
+export const _unionKeyVariant = (
+  props: Omit<PanelProps, "orientation" | "variant">,
+) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...props} orientation="horizontal" />
 );
 
 // A second spread after the pin can override it just as the first would.

--- a/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
@@ -235,6 +235,20 @@ export const _ok_collidingNestedAlias = () => {
   return (props: SharedProps) => <Panel {...props} />;
 };
 
+// A type-only wrapper around the spread argument changes the type, not the
+// value, so the spread is runtime-identical to spreading the binding.
+export const _wrappedSpread = (props: Omit<PanelProps, "orientation">) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...(props satisfies Omit<PanelProps, "orientation">)} />
+);
+
+// Allowed: whitespace within one line is emitted as a child, so it overrides a
+// spread `children` the way any other child would.
+// The single space between the tags is the child under test.
+export const _ok_sameLineWhitespaceChild = (
+  props: Omit<PanelProps, "children">,
+) => <Panel {...props}> </Panel>;
+
 // An erased `this` parameter takes the first AST slot without carrying a
 // runtime argument, so the props parameter follows it.
 export function _thisParameter(

--- a/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
@@ -146,11 +146,21 @@ export const _ok_reTypedAlias = (props: RetypedPanelProps) => (
   <Panel {...props} />
 );
 
-// Allowed: an intersection has a key when any member has it, so each member
-// here supplies what the other omits and neither key is actually removed.
+// Allowed: an intersection has a key when any member has it, and here each
+// member draws from the same source and supplies what the other omits.
 export const _ok_intersectedOmissions = (
   props: Omit<PanelProps, "orientation"> & Omit<PanelProps, "variant">,
 ) => <Panel {...props} />;
+
+// A sibling that removes the same key supplies nothing back, so `orientation`
+// stands while `variant` is cancelled by the member that keeps it.
+export const _intersectedSameOmission = (
+  props: Omit<PanelProps, "orientation"> &
+    Omit<PanelProps, "orientation" | "variant">,
+) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...props} />
+);
 
 // Allowed: a generic alias means something different per use site, and the
 // argument here deliberately puts `orientation` back.

--- a/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
@@ -19,6 +19,7 @@ type ShellProps = Omit<PanelProps, "orientation">;
 type LabelledShellProps = ShellProps & { label?: string };
 
 const child = <span />;
+const VERTICAL = "vertical" as const;
 
 // --- Flagged: the omitted key cannot survive the props spread ---
 
@@ -142,3 +143,54 @@ export const _ok_reTypedAlias = (props: RetypedPanelProps) => (
 export const _ok_unionBranchOmit = (
   props: Omit<PanelProps, "orientation"> | Omit<PanelProps, "variant">,
 ) => <Panel {...props} />;
+
+// Allowed: a nested callback shadows `props`, so its spread is the callback's
+// value, not the component's omitting one.
+export const _ok_shadowedBinding = ({
+  ...props
+}: Omit<PanelProps, "orientation">) => (
+  <Panel {...props} orientation="horizontal">
+    {[<span key="a" />].map((props: PanelProps) => (
+      <Panel {...props} />
+    ))}
+  </Panel>
+);
+
+// Allowed: the trailing spread is a statically known object literal that does
+// not declare the omitted key, so it cannot override the pin.
+export const _ok_trailingLiteralSpread = (
+  props: Omit<PanelProps, "orientation">,
+) => <Panel {...props} orientation="horizontal" {...{ id: "panel" }} />;
+
+// --- Flagged through shapes the parameter can take ---
+
+// A defaulted props parameter parses as an assignment; the omission still binds.
+export const _defaultedParam = (
+  props: Omit<PanelProps, "orientation"> = {},
+) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...props} />
+);
+
+// Defaulted destructuring, same shape.
+export const _defaultedDestructuring = ({
+  ...props
+}: Omit<PanelProps, "orientation"> = {}) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...props} />
+);
+
+// A JSX comment emits no child, so it does not pin an omitted `children`.
+export const _commentOnlyChildren = (props: Omit<PanelProps, "children">) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...props}>{/* nothing rendered here */}</Panel>
+);
+
+// A trailing object-literal spread that does declare the key still overrides
+// the pin.
+export const _trailingLiteralCarriesKey = (
+  props: Omit<PanelProps, "orientation">,
+) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...props} orientation="horizontal" {...{ orientation: VERTICAL }} />
+);

--- a/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
@@ -206,6 +206,24 @@ export const _defaultedDestructuring = ({
   <Panel {...props} />
 );
 
+// A modifier utility changes property modifiers, not which keys exist, so the
+// omission underneath it still holds.
+export const _readonlyWrapper = (
+  props: Readonly<Omit<PanelProps, "orientation">>,
+) => (
+  // oxlint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread
+  <Panel {...props} />
+);
+
+// Allowed: the inner re-typing survives an outer omission of a different key,
+// so only `orientation` is forbidden and it is pinned after the spread.
+export const _ok_reTypedUnderNestedOmit = (
+  props: Omit<
+    Omit<PanelProps, "variant"> & { variant?: "ghost" },
+    "orientation"
+  >,
+) => <Panel {...props} orientation="horizontal" />;
+
 // A long alias chain still resolves: only a cycle stops the walk.
 type Shell1 = Omit<PanelProps, "orientation">;
 type Shell2 = Shell1;

--- a/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx
@@ -240,12 +240,17 @@ export const _ok_typeParameterShadowsAlias = <ShadowedProps extends PanelProps>(
   _sibling: ShadowedProps,
 ) => <Panel {...props} />;
 
-// Allowed: `SharedProps` is imported here and also declared in an unrelated
-// nested scope, so the name answers to neither rather than to the wrong one.
-export const _ok_importedNameCollision = (props: SharedProps) => (
+// Analysis boundary, not an accepted shape. `SharedProps` is imported here and
+// also declared in an unrelated nested scope. The plugin API exposes no type
+// scope, so the rule cannot tell which declaration a reference means; it answers
+// with neither. That keeps the imported half from being reported against the
+// wrong omission, and costs a report on the nested half. Both are pinned so the
+// trade is visible: if type-scope resolution ever lands, the second case gains a
+// directive and the first keeps none.
+export const _boundary_importedNameCollision = (props: SharedProps) => (
   <Panel {...props} />
 );
-export const _ok_collidingNestedAlias = () => {
+export const _boundary_collidingNestedAlias = () => {
   type SharedProps = Omit<PanelProps, "orientation">;
   return (props: SharedProps) => <Panel {...props} />;
 };

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -50,9 +50,9 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 //     of scope, as is an `Omit` reached through an imported type alias; only
 //     file-local type aliases and the modifier utilities `Partial`, `Readonly`,
 //     and `Required` are unwrapped. Aliases are indexed by name across the whole
-//     file, so a name shared by two declarations, or by a declaration and an
-//     import, resolves to nothing rather than guessing which one a reference
-//     meant.
+//     file, so a name claimed by more than one thing — two declarations, an
+//     import, or a type parameter — resolves to nothing rather than guessing
+//     which one a reference meant.
 //   - `Omit` is matched by name. A shadowed or re-exported `Omit` is not
 //     distinguished.
 //   - The omission must be written on the parameter. A props type inferred from
@@ -487,6 +487,14 @@ export default eslintCompatPlugin({
               if (typeof specifier.local?.name === "string") {
                 localTypes.set(specifier.local.name, null);
               }
+            }
+          },
+          // A type parameter binds its name inside the declaration that
+          // introduces it, shadowing any alias that shares it. Nothing concrete
+          // can be read from it, so claim the name as unresolvable too.
+          TSTypeParameter(node) {
+            if (typeof node.name?.name === "string") {
+              localTypes.set(node.name.name, null);
             }
           },
           TSTypeAliasDeclaration: declareLocalType,

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -114,6 +114,14 @@ const expandAlias = (name, localTypes, open) => {
   return localTypes.get(name)?.typeNode ?? null;
 };
 
+// Keys every set holds. No sets means no guarantee, so nothing survives.
+const intersectAll = (keySets): string[] => {
+  const first = keySets.at(0);
+  return first === undefined
+    ? []
+    : [...first].filter((key) => keySets.every((keys) => keys.has(key)));
+};
+
 // String keys from the second `Omit` argument: `"a"` or `"a" | "b"`.
 // A non-literal key set yields nothing, which is the documented boundary.
 const literalKeysOf = (keyTypeNode): string[] => {
@@ -142,19 +150,25 @@ const omittedKeysOf = (typeNode, localTypes, open = new Set()): string[] => {
   if (typeNode.type === "TSParenthesizedType") {
     return omittedKeysOf(typeNode.typeAnnotation, localTypes, open);
   }
+  // An intersection has a key when any member has it, so one member's omission
+  // is undone by another's: `Omit<P, "a"> & Omit<P, "b">` still carries both.
+  // Only keys every omitting member removes survive. Members that omit nothing
+  // (a literal, an unresolved reference) neither remove nor supply a key here;
+  // what they declare is subtracted separately, by `reintroducedKeysOf`.
   if (typeNode.type === "TSIntersectionType") {
-    return typeNode.types.flatMap((member) =>
-      omittedKeysOf(member, localTypes, open),
+    return intersectAll(
+      typeNode.types
+        .map((member) => new Set(omittedKeysOf(member, localTypes, open)))
+        .filter((keys) => keys.size > 0),
     );
   }
+  // A union only guarantees the omission its branches share.
   if (typeNode.type === "TSUnionType") {
-    const branches = typeNode.types.map(
-      (member) => new Set(omittedKeysOf(member, localTypes, open)),
+    return intersectAll(
+      typeNode.types.map(
+        (member) => new Set(omittedKeysOf(member, localTypes, open)),
+      ),
     );
-    const first = branches.at(0);
-    return first === undefined
-      ? []
-      : [...first].filter((key) => branches.every((branch) => branch.has(key)));
   }
   if (typeNode.type === "TSTypeReference") {
     const name = typeReferenceName(typeNode.typeName);
@@ -169,7 +183,6 @@ const omittedKeysOf = (typeNode, localTypes, open = new Set()): string[] => {
     if (MODIFIER_UTILITIES.has(name)) {
       return omittedKeysOf(args.at(0), localTypes, open);
     }
-    // A generic alias parameterized at the use site is not resolved here.
     const alias = expandAlias(name, localTypes, open);
     if (alias === null) {
       return [];
@@ -372,6 +385,12 @@ export default eslintCompatPlugin({
           }
           const name = declaration.id?.name;
           if (typeof name !== "string") {
+            return;
+          }
+          // A generic alias means something different per use site, and the
+          // arguments are not substituted here, so it stays unresolvable.
+          if ((declaration.typeParameters?.params?.length ?? 0) > 0) {
+            localTypes.set(name, null);
             return;
           }
           const start = declaration.range[0];

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -49,7 +49,9 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 //     position. A generic or computed key set (`Omit<P, K>`, `keyof Q`) is out
 //     of scope, as is an `Omit` reached through an imported type alias; only
 //     file-local type aliases and the modifier utilities `Partial`, `Readonly`,
-//     and `Required` are unwrapped.
+//     and `Required` are unwrapped. Aliases are indexed by name across the whole
+//     file, so a name two declarations share resolves to nothing rather than
+//     guessing which scope a reference meant.
 //   - `Omit` is matched by name. A shadowed or re-exported `Omit` is not
 //     distinguished.
 //   - The omission must be written on the parameter. A props type inferred from
@@ -94,14 +96,15 @@ const typeReferenceName = (typeName) => {
   return left === null || right === null ? null : `${left}.${right}`;
 };
 
-// The body of a file-local alias, unless it is already being expanded on this
-// path. `open` bounds cyclic aliases without capping how deep an honest chain
-// may go: a depth cutoff would silently stop reporting past the limit.
+// The body of a local alias, unless it is already being expanded on this path.
+// `open` bounds cyclic aliases without capping how deep an honest chain may go:
+// a depth cutoff would silently stop reporting past the limit. An entry of
+// `null` marks a name two declarations share, which resolves to nothing.
 const expandAlias = (name, localTypes, open) => {
   if (name === null || open.has(name)) {
     return null;
   }
-  return localTypes.get(name) ?? null;
+  return localTypes.get(name)?.typeNode ?? null;
 };
 
 // String keys from the second `Omit` argument: `"a"` or `"a" | "b"`.
@@ -320,37 +323,63 @@ export default eslintCompatPlugin({
         // binding identifier. Scope resolution maps a spread back to exactly one
         // binding, so any shadowing declaration wins over an enclosing one.
         const omittedByBinding = new Map<number, Set<string>>();
+        // Collected during traversal, evaluated once the file is fully walked.
+        const propsParams: { binding; param }[] = [];
+        const spreadElements: unknown[] = [];
 
         // Props types are aliases here: `typescript/consistent-type-definitions`
-        // keeps interfaces out of this codebase.
+        // keeps interfaces out of this codebase. Aliases are indexed by name
+        // across the whole file, including block- and function-local ones; a
+        // name two declarations share resolves to nothing rather than guessing
+        // which scope a reference meant.
         const declareLocalType = (declaration) => {
           if (declaration?.type !== "TSTypeAliasDeclaration") {
             return;
           }
           const name = declaration.id?.name;
-          if (typeof name === "string") {
-            localTypes.set(name, declaration.typeAnnotation);
+          if (typeof name !== "string") {
+            return;
+          }
+          const start = declaration.range[0];
+          const existing = localTypes.get(name);
+          if (existing === undefined) {
+            localTypes.set(name, {
+              start,
+              typeNode: declaration.typeAnnotation,
+            });
+            return;
+          }
+          if (existing !== null && existing.start !== start) {
+            localTypes.set(name, null);
           }
         };
 
-        const enterFunction = (node) => {
+        const collectPropsParam = (node) => {
           const param = patternOf(node.params?.at(0));
           const binding = propsBindingOf(param);
-          if (binding === null) {
-            return;
+          if (binding !== null) {
+            propsParams.push({ binding, param });
           }
-          const propsType = param.typeAnnotation?.typeAnnotation;
-          // A key the pattern destructures is absent from the rest object, and
-          // a key the props type re-declares is meant to pass through.
-          const carried = new Set([
-            ...destructuredKeysOf(param),
-            ...reintroducedKeysOf(propsType, localTypes),
-          ]);
-          const keys = omittedKeysOf(propsType, localTypes).filter(
-            (key) => !carried.has(key),
-          );
-          if (keys.length > 0) {
-            omittedByBinding.set(binding.range[0], new Set(keys));
+        };
+
+        // Deferred to `Program:exit` so every alias in the file is known first:
+        // a type alias may be declared after the component that annotates with
+        // it, in any scope.
+        const indexOmittedKeys = () => {
+          for (const { binding, param } of propsParams) {
+            const propsType = param.typeAnnotation?.typeAnnotation;
+            // A key the pattern destructures is absent from the rest object,
+            // and a key the props type re-declares is meant to pass through.
+            const carried = new Set([
+              ...destructuredKeysOf(param),
+              ...reintroducedKeysOf(propsType, localTypes),
+            ]);
+            const keys = omittedKeysOf(propsType, localTypes).filter(
+              (key) => !carried.has(key),
+            );
+            if (keys.length > 0) {
+              omittedByBinding.set(binding.range[0], new Set(keys));
+            }
           }
         };
 
@@ -373,65 +402,76 @@ export default eslintCompatPlugin({
           return undefined;
         };
 
+        const reportElement = (node) => {
+          const attributes = node.openingElement.attributes;
+          const omitted = new Set<string>();
+          for (const attribute of attributes) {
+            if (
+              attribute.type !== "JSXSpreadAttribute" ||
+              !isIdentifier(attribute.argument)
+            ) {
+              continue;
+            }
+            for (const key of omittedKeysForSpread(attribute.argument) ?? []) {
+              omitted.add(key);
+            }
+          }
+
+          for (const key of omitted) {
+            if (key === "children" && hasMeaningfulChildren(node)) {
+              continue;
+            }
+            // Only a spread that could carry this key can override the pin.
+            const lastOverrideIndex = attributes.findLastIndex(
+              (attribute) =>
+                attribute.type === "JSXSpreadAttribute" &&
+                spreadCanDeliver(attribute, key),
+            );
+            if (lastOverrideIndex === -1) {
+              continue;
+            }
+            const pin = attributes.find(
+              (attribute) => attributeName(attribute) === key,
+            );
+            if (
+              pin !== undefined &&
+              attributes.indexOf(pin) > lastOverrideIndex
+            ) {
+              continue;
+            }
+            context.report({
+              node: pin ?? node.openingElement,
+              messageId:
+                pin === undefined ? "suppliedBySpread" : "pinnedBeforeSpread",
+              data: { key },
+            });
+          }
+        };
+
         return {
-          Program(node) {
+          Program() {
             localTypes.clear();
             omittedByBinding.clear();
-            for (const statement of node.body) {
-              declareLocalType(
-                statement.type === "ExportNamedDeclaration"
-                  ? statement.declaration
-                  : statement,
-              );
+            propsParams.length = 0;
+            spreadElements.length = 0;
+          },
+          TSTypeAliasDeclaration: declareLocalType,
+          ArrowFunctionExpression: collectPropsParam,
+          FunctionDeclaration: collectPropsParam,
+          FunctionExpression: collectPropsParam,
+          JSXElement(node) {
+            if (
+              node.openingElement.attributes.some(
+                (attribute) => attribute.type === "JSXSpreadAttribute",
+              )
+            ) {
+              spreadElements.push(node);
             }
           },
-          ArrowFunctionExpression: enterFunction,
-          FunctionDeclaration: enterFunction,
-          FunctionExpression: enterFunction,
-          JSXElement(node) {
-            const attributes = node.openingElement.attributes;
-            const omitted = new Set<string>();
-            for (const attribute of attributes) {
-              if (
-                attribute.type !== "JSXSpreadAttribute" ||
-                !isIdentifier(attribute.argument)
-              ) {
-                continue;
-              }
-              for (const key of omittedKeysForSpread(attribute.argument) ??
-                []) {
-                omitted.add(key);
-              }
-            }
-
-            for (const key of omitted) {
-              if (key === "children" && hasMeaningfulChildren(node)) {
-                continue;
-              }
-              // Only a spread that could carry this key can override the pin.
-              const lastOverrideIndex = attributes.findLastIndex(
-                (attribute) =>
-                  attribute.type === "JSXSpreadAttribute" &&
-                  spreadCanDeliver(attribute, key),
-              );
-              if (lastOverrideIndex === -1) {
-                continue;
-              }
-              const pin = attributes.find(
-                (attribute) => attributeName(attribute) === key,
-              );
-              if (
-                pin !== undefined &&
-                attributes.indexOf(pin) > lastOverrideIndex
-              ) {
-                continue;
-              }
-              context.report({
-                node: pin ?? node.openingElement,
-                messageId:
-                  pin === undefined ? "suppliedBySpread" : "pinnedBeforeSpread",
-                data: { key },
-              });
+          "Program:exit"() {
+            indexOmittedKeys();
+            for (const element of spreadElements) {
+              reportElement(element);
             }
           },
         };

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -51,6 +51,8 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 //     file-local type aliases are followed.
 //   - `Omit` is matched by name. A shadowed or re-exported `Omit` is not
 //     distinguished.
+//   - The omission must be written on the parameter. A props type inferred from
+//     a generic wrapper (`forwardRef<Ref, Omit<P, "k">>`) is not read.
 //   - JSX children override a spread `children` prop, so an element with
 //     children satisfies an omitted `children` key.
 //
@@ -99,19 +101,27 @@ const literalKeysOf = (keyTypeNode) => {
 
 /**
  * Literal keys omitted anywhere inside a type position, following file-local
- * aliases. Intersections and nested `Omit`s accumulate.
+ * aliases. Intersections and nested `Omit`s accumulate; a union of props shapes
+ * keeps only the keys every branch omits, since a value of the other branch may
+ * legitimately carry the rest.
  */
 const omittedKeysOf = (typeNode, localTypes, depth = 0) => {
   if (typeNode === null || typeNode === undefined || depth > MAX_ALIAS_DEPTH) {
     return [];
   }
-  if (
-    typeNode.type === "TSIntersectionType" ||
-    typeNode.type === "TSUnionType"
-  ) {
+  if (typeNode.type === "TSIntersectionType") {
     return typeNode.types.flatMap((member) =>
       omittedKeysOf(member, localTypes, depth),
     );
+  }
+  if (typeNode.type === "TSUnionType") {
+    const branches = typeNode.types.map(
+      (member) => new Set(omittedKeysOf(member, localTypes, depth)),
+    );
+    const first = branches.at(0);
+    return first === undefined
+      ? []
+      : [...first].filter((key) => branches.every((branch) => branch.has(key)));
   }
   if (typeNode.type === "TSTypeReference") {
     const name = typeReferenceName(typeNode.typeName);

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -52,7 +52,10 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 //     and `Required` are unwrapped. Aliases are indexed by name across the whole
 //     file, so a name claimed by more than one thing — two declarations, an
 //     import, or a type parameter — resolves to nothing rather than guessing
-//     which one a reference meant.
+//     which one a reference meant. The plugin API exposes no type scope, so this
+//     cuts both ways: it avoids reporting one declaration's omission against
+//     another's reference, and it costs the report on whichever reference did
+//     mean an omitting alias.
 //   - `Omit` is matched by name. A shadowed or re-exported `Omit` is not
 //     distinguished.
 //   - The omission must be written on the parameter. A props type inferred from

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -53,8 +53,13 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 //     distinguished.
 //   - The omission must be written on the parameter. A props type inferred from
 //     a generic wrapper (`forwardRef<Ref, Omit<P, "k">>`) is not read.
-//   - JSX children override a spread `children` prop, so an element with
-//     children satisfies an omitted `children` key.
+//   - JSX children override a spread `children` prop, so an element with a
+//     rendered child satisfies an omitted `children` key. Whitespace and a JSX
+//     comment emit no child and do not count.
+//   - A spread of an object literal can only deliver what the literal declares,
+//     spreads in, or computes; anything else is opaque and assumed able to.
+//   - A nested function shadowing the props binding owns the name inside it, so
+//     spreading the inner value is not charged to the outer omission.
 //
 // When a key legitimately passes through by design, suppress the finding with
 // `// eslint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread`
@@ -182,6 +187,11 @@ const reintroducedKeysOf = (typeNode, localTypes, depth = 0): string[] => {
   return [];
 };
 
+// The pattern behind a default value: `(props: P = {})` parses the whole
+// parameter as an assignment, with the binding and its annotation on the left.
+const patternOf = (param) =>
+  param?.type === "AssignmentPattern" ? param.left : param;
+
 // The binding that carries the rest of the props: the parameter identifier, or
 // the rest element of a destructuring pattern.
 const propsBindingOf = (param) => {
@@ -217,11 +227,36 @@ const attributeName = (attribute) =>
     : null;
 
 // JSX children are passed positionally and override a spread `children` prop,
-// so anything other than insignificant whitespace counts as pinning the key.
-const hasMeaningfulChildren = (element) =>
-  (element.children ?? []).some(
-    (child) => child.type !== "JSXText" || child.value.trim() !== "",
+// so a real child counts as pinning the key. Whitespace-only text and a JSX
+// comment (`{/* … */}`, an expression container holding nothing) emit no child.
+const isRenderedChild = (child) => {
+  if (child.type === "JSXText") {
+    return child.value.trim() !== "";
+  }
+  return (
+    child.type !== "JSXExpressionContainer" ||
+    child.expression.type !== "JSXEmptyExpression"
   );
+};
+
+const hasMeaningfulChildren = (element) =>
+  element.children.some(isRenderedChild);
+
+// Whether a spread of this attribute could deliver `key`. An object literal is
+// statically known: it can only deliver what it declares, spreads in, or
+// computes. Anything else is opaque and assumed able to.
+const spreadCanDeliver = (attribute, key) => {
+  const argument = attribute.argument;
+  if (argument.type !== "ObjectExpression") {
+    return true;
+  }
+  return argument.properties.some(
+    (property) =>
+      property.type !== "Property" ||
+      property.computed === true ||
+      getPropertyName(property.key) === key,
+  );
+};
 
 export default eslintCompatPlugin({
   meta: { name: "no-omitted-prop-respread" },
@@ -256,7 +291,7 @@ export default eslintCompatPlugin({
         };
 
         const enterFunction = (node) => {
-          const param = node.params?.at(0);
+          const param = patternOf(node.params?.at(0));
           const binding = propsBindingOf(param);
           if (binding === null) {
             scopes.push({ binding, keys: new Set() });
@@ -299,34 +334,53 @@ export default eslintCompatPlugin({
           "FunctionExpression:exit": exitFunction,
           JSXElement(node) {
             const attributes = node.openingElement.attributes;
-            // Only a spread of a named value can smuggle a key; an object
-            // literal spread is statically known. Any spread can override an
-            // earlier attribute, so the pin has to clear the last one.
             const spreadNames = new Set<string>();
-            let lastSpreadIndex = -1;
-            for (const [index, attribute] of attributes.entries()) {
-              if (attribute.type !== "JSXSpreadAttribute") {
-                continue;
-              }
-              lastSpreadIndex = index;
-              if (isIdentifier(attribute.argument)) {
+            for (const attribute of attributes) {
+              if (
+                attribute.type === "JSXSpreadAttribute" &&
+                isIdentifier(attribute.argument)
+              ) {
                 spreadNames.add(attribute.argument.name);
               }
             }
-
-            // The innermost enclosing component whose props reach this element.
-            const scope = scopes.findLast(
-              (candidate) =>
-                candidate.binding !== null &&
-                candidate.keys.size > 0 &&
-                spreadNames.has(candidate.binding),
-            );
-            if (scope === undefined) {
+            if (spreadNames.size === 0) {
               return;
             }
 
-            for (const key of scope.keys) {
+            // Walk outwards, keeping only the innermost frame per binding name:
+            // a nested callback naming its parameter `props` shadows the
+            // component's `props`, and spreading the callback's value must not
+            // be charged to the component's omission.
+            const omitted = new Set<string>();
+            const resolved = new Set<string>();
+            for (let index = scopes.length - 1; index >= 0; index -= 1) {
+              const frame = scopes[index];
+              if (frame === undefined || frame.binding === null) {
+                continue;
+              }
+              if (resolved.has(frame.binding)) {
+                continue;
+              }
+              resolved.add(frame.binding);
+              if (!spreadNames.has(frame.binding)) {
+                continue;
+              }
+              for (const key of frame.keys) {
+                omitted.add(key);
+              }
+            }
+
+            for (const key of omitted) {
               if (key === "children" && hasMeaningfulChildren(node)) {
+                continue;
+              }
+              // Only a spread that could carry this key can override the pin.
+              const lastOverrideIndex = attributes.findLastIndex(
+                (attribute) =>
+                  attribute.type === "JSXSpreadAttribute" &&
+                  spreadCanDeliver(attribute, key),
+              );
+              if (lastOverrideIndex === -1) {
                 continue;
               }
               const pin = attributes.find(
@@ -334,7 +388,7 @@ export default eslintCompatPlugin({
               );
               if (
                 pin !== undefined &&
-                attributes.indexOf(pin) > lastSpreadIndex
+                attributes.indexOf(pin) > lastOverrideIndex
               ) {
                 continue;
               }

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -50,8 +50,9 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 //     of scope, as is an `Omit` reached through an imported type alias; only
 //     file-local type aliases and the modifier utilities `Partial`, `Readonly`,
 //     and `Required` are unwrapped. Aliases are indexed by name across the whole
-//     file, so a name two declarations share resolves to nothing rather than
-//     guessing which scope a reference meant.
+//     file, so a name shared by two declarations, or by a declaration and an
+//     import, resolves to nothing rather than guessing which one a reference
+//     meant.
 //   - `Omit` is matched by name. A shadowed or re-exported `Omit` is not
 //     distinguished.
 //   - The omission must be written on the parameter. A props type inferred from
@@ -230,6 +231,13 @@ const reintroducedKeysOf = (
 const patternOf = (param) =>
   param?.type === "AssignmentPattern" ? param.left : param;
 
+// The props parameter. An erased `this` parameter occupies the first slot in
+// the AST while contributing no runtime argument, so props follow it.
+const propsParamOf = (params = []) => {
+  const first = params.at(0);
+  return isIdentifier(first, "this") ? params.at(1) : first;
+};
+
 // The identifier that carries the rest of the props: the parameter itself, or
 // the rest element of a destructuring pattern.
 const propsBindingOf = (param) => {
@@ -355,7 +363,7 @@ export default eslintCompatPlugin({
         };
 
         const collectPropsParam = (node) => {
-          const param = patternOf(node.params?.at(0));
+          const param = patternOf(propsParamOf(node.params));
           const binding = propsBindingOf(param);
           if (binding !== null) {
             propsParams.push({ binding, param });
@@ -454,6 +462,16 @@ export default eslintCompatPlugin({
             omittedByBinding.clear();
             propsParams.length = 0;
             spreadElements.length = 0;
+          },
+          // An imported type is not followed, and its name must not be answered
+          // by an unrelated local alias that happens to match, so claim the name
+          // as unresolvable.
+          ImportDeclaration(node) {
+            for (const specifier of node.specifiers) {
+              if (typeof specifier.local?.name === "string") {
+                localTypes.set(specifier.local.name, null);
+              }
+            }
           },
           TSTypeAliasDeclaration: declareLocalType,
           ArrowFunctionExpression: collectPropsParam,

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -122,6 +122,78 @@ const intersectAll = (keySets): string[] => {
     : [...first].filter((key) => keySets.every((keys) => keys.has(key)));
 };
 
+// A stable spelling of a type node, enough to tell whether two `Omit`s remove
+// from the same source. Structural, not semantic: two spellings of one type are
+// two sources here.
+const typeSignature = (typeNode) => {
+  if (typeNode === null || typeNode === undefined) {
+    return "?";
+  }
+  if (typeNode.type === "TSParenthesizedType") {
+    return typeSignature(typeNode.typeAnnotation);
+  }
+  if (typeNode.type === "TSTypeReference") {
+    const args = typeArgumentsOf(typeNode);
+    const name = typeReferenceName(typeNode.typeName) ?? "?";
+    return args.length === 0
+      ? name
+      : `${name}<${args.map(typeSignature).join(",")}>`;
+  }
+  if (typeNode.type === "TSLiteralType") {
+    return JSON.stringify(typeNode.literal?.value ?? null);
+  }
+  if (
+    typeNode.type === "TSUnionType" ||
+    typeNode.type === "TSIntersectionType"
+  ) {
+    const separator = typeNode.type === "TSUnionType" ? "|" : "&";
+    return `(${typeNode.types.map(typeSignature).join(separator)})`;
+  }
+  return typeNode.type;
+};
+
+/**
+ * What each member of an intersection can supply, as the source it draws from
+ * and the keys it removes from that source. A bare reference supplies its whole
+ * source; `Omit<S, K>` supplies the rest of `S`. Anything else supplies only
+ * what it declares, which `reintroducedKeysOf` already subtracts.
+ */
+const suppliersOf = (typeNode, localTypes, open = new Set()) => {
+  if (typeNode === null || typeNode === undefined) {
+    return [];
+  }
+  if (typeNode.type === "TSParenthesizedType") {
+    return suppliersOf(typeNode.typeAnnotation, localTypes, open);
+  }
+  if (typeNode.type !== "TSTypeReference") {
+    return [];
+  }
+  const name = typeReferenceName(typeNode.typeName);
+  const args = typeArgumentsOf(typeNode);
+  if (name === OMIT_TYPE) {
+    const source = args.at(0);
+    return [
+      {
+        source: typeSignature(source),
+        removed: new Set(literalKeysOf(args.at(1))),
+      },
+      ...suppliersOf(source, localTypes, open),
+    ];
+  }
+  if (MODIFIER_UTILITIES.has(name)) {
+    return suppliersOf(args.at(0), localTypes, open);
+  }
+  const alias = expandAlias(name, localTypes, open);
+  if (alias === null) {
+    // An opaque reference supplies everything its own source has.
+    return [{ source: typeSignature(typeNode), removed: new Set() }];
+  }
+  open.add(name);
+  const suppliers = suppliersOf(alias, localTypes, open);
+  open.delete(name);
+  return suppliers;
+};
+
 // String keys from the second `Omit` argument: `"a"` or `"a" | "b"`.
 // A non-literal key set yields nothing, which is the documented boundary.
 const literalKeysOf = (keyTypeNode): string[] => {
@@ -150,16 +222,33 @@ const omittedKeysOf = (typeNode, localTypes, open = new Set()): string[] => {
   if (typeNode.type === "TSParenthesizedType") {
     return omittedKeysOf(typeNode.typeAnnotation, localTypes, open);
   }
-  // An intersection has a key when any member has it, so one member's omission
-  // is undone by another's: `Omit<P, "a"> & Omit<P, "b">` still carries both.
-  // Only keys every omitting member removes survive. Members that omit nothing
-  // (a literal, an unresolved reference) neither remove nor supply a key here;
-  // what they declare is subtracted separately, by `reintroducedKeysOf`.
+  // An intersection has a key when any member has it, so a member's omission
+  // survives only when no sibling can supply the key back. A sibling proves it
+  // can when it draws from the same source and does not remove the key itself:
+  // `Omit<P, "a"> & Omit<P, "b">` carries both, while `Omit<A, "a"> & Omit<B, "b">`
+  // carries neither. What a sibling merely declares is subtracted separately, by
+  // `reintroducedKeysOf`.
   if (typeNode.type === "TSIntersectionType") {
-    return intersectAll(
-      typeNode.types
-        .map((member) => new Set(omittedKeysOf(member, localTypes, open)))
-        .filter((keys) => keys.size > 0),
+    const members = typeNode.types.map((member) => ({
+      keys: omittedKeysOf(member, localTypes, open),
+      suppliers: suppliersOf(member, localTypes, open),
+    }));
+    return members.flatMap(({ keys }, index) =>
+      keys.filter(
+        (key) =>
+          !members.some(
+            (sibling, siblingIndex) =>
+              siblingIndex !== index &&
+              sibling.suppliers.some(
+                (supplier) =>
+                  !supplier.removed.has(key) &&
+                  members[index]?.suppliers.some(
+                    (own) =>
+                      own.removed.has(key) && own.source === supplier.source,
+                  ),
+              ),
+          ),
+      ),
     );
   }
   // A union only guarantees the omission its branches share.

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -58,8 +58,8 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 //     comment emit no child and do not count.
 //   - A spread of an object literal can only deliver what the literal declares,
 //     spreads in, or computes; anything else is opaque and assumed able to.
-//   - A nested function shadowing the props binding owns the name inside it, so
-//     spreading the inner value is not charged to the outer omission.
+//   - The spread identifier is resolved through the lexical scope chain, so a
+//     shadowing binding of the same name always wins over an enclosing one.
 //
 // When a key legitimately passes through by design, suppress the finding with
 // `// eslint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread`
@@ -71,9 +71,6 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 import { getPropertyName, isIdentifier } from "./utils.ts";
 
 const OMIT_TYPE = "Omit";
-
-// Local alias chains are short in practice; the cap only bounds a cycle.
-const MAX_ALIAS_DEPTH = 4;
 
 const typeArgumentsOf = (typeNode) =>
   typeNode?.typeArguments?.params ?? typeNode?.typeParameters?.params ?? [];
@@ -89,6 +86,16 @@ const typeReferenceName = (typeName) => {
   const left = typeReferenceName(typeName.left);
   const right = getPropertyName(typeName.right);
   return left === null || right === null ? null : `${left}.${right}`;
+};
+
+// The body of a file-local alias, unless it is already being expanded on this
+// path. `open` bounds cyclic aliases without capping how deep an honest chain
+// may go: a depth cutoff would silently stop reporting past the limit.
+const expandAlias = (name, localTypes, open) => {
+  if (name === null || open.has(name)) {
+    return null;
+  }
+  return localTypes.get(name) ?? null;
 };
 
 // String keys from the second `Omit` argument: `"a"` or `"a" | "b"`.
@@ -110,18 +117,18 @@ const literalKeysOf = (keyTypeNode): string[] => {
  * keeps only the keys every branch omits, since a value of the other branch may
  * legitimately carry the rest.
  */
-const omittedKeysOf = (typeNode, localTypes, depth = 0): string[] => {
-  if (typeNode === null || typeNode === undefined || depth > MAX_ALIAS_DEPTH) {
+const omittedKeysOf = (typeNode, localTypes, open = new Set()): string[] => {
+  if (typeNode === null || typeNode === undefined) {
     return [];
   }
   if (typeNode.type === "TSIntersectionType") {
     return typeNode.types.flatMap((member) =>
-      omittedKeysOf(member, localTypes, depth),
+      omittedKeysOf(member, localTypes, open),
     );
   }
   if (typeNode.type === "TSUnionType") {
     const branches = typeNode.types.map(
-      (member) => new Set(omittedKeysOf(member, localTypes, depth)),
+      (member) => new Set(omittedKeysOf(member, localTypes, open)),
     );
     const first = branches.at(0);
     return first === undefined
@@ -135,14 +142,18 @@ const omittedKeysOf = (typeNode, localTypes, depth = 0): string[] => {
       return [
         ...literalKeysOf(args.at(1)),
         // `Omit<Omit<P, "a">, "b">` omits both.
-        ...omittedKeysOf(args.at(0), localTypes, depth),
+        ...omittedKeysOf(args.at(0), localTypes, open),
       ];
     }
-    const alias = name === null ? undefined : localTypes.get(name);
     // A generic alias parameterized at the use site is not resolved here.
-    return alias === undefined
-      ? []
-      : omittedKeysOf(alias, localTypes, depth + 1);
+    const alias = expandAlias(name, localTypes, open);
+    if (alias === null) {
+      return [];
+    }
+    open.add(name);
+    const keys = omittedKeysOf(alias, localTypes, open);
+    open.delete(name);
+    return keys;
   }
   return [];
 };
@@ -152,8 +163,12 @@ const omittedKeysOf = (typeNode, localTypes, depth = 0): string[] => {
  * type. `Omit<P, "size"> & { size?: Local }` re-types `size` rather than
  * forbidding it, so the key is meant to reach the element.
  */
-const reintroducedKeysOf = (typeNode, localTypes, depth = 0): string[] => {
-  if (typeNode === null || typeNode === undefined || depth > MAX_ALIAS_DEPTH) {
+const reintroducedKeysOf = (
+  typeNode,
+  localTypes,
+  open = new Set(),
+): string[] => {
+  if (typeNode === null || typeNode === undefined) {
     return [];
   }
   if (
@@ -161,7 +176,7 @@ const reintroducedKeysOf = (typeNode, localTypes, depth = 0): string[] => {
     typeNode.type === "TSUnionType"
   ) {
     return typeNode.types.flatMap((member) =>
-      reintroducedKeysOf(member, localTypes, depth),
+      reintroducedKeysOf(member, localTypes, open),
     );
   }
   if (typeNode.type === "TSTypeLiteral") {
@@ -179,10 +194,14 @@ const reintroducedKeysOf = (typeNode, localTypes, depth = 0): string[] => {
     if (name === OMIT_TYPE) {
       return [];
     }
-    const alias = name === null ? undefined : localTypes.get(name);
-    return alias === undefined
-      ? []
-      : reintroducedKeysOf(alias, localTypes, depth + 1);
+    const alias = expandAlias(name, localTypes, open);
+    if (alias === null) {
+      return [];
+    }
+    open.add(name);
+    const keys = reintroducedKeysOf(alias, localTypes, open);
+    open.delete(name);
+    return keys;
   }
   return [];
 };
@@ -192,11 +211,11 @@ const reintroducedKeysOf = (typeNode, localTypes, depth = 0): string[] => {
 const patternOf = (param) =>
   param?.type === "AssignmentPattern" ? param.left : param;
 
-// The binding that carries the rest of the props: the parameter identifier, or
+// The identifier that carries the rest of the props: the parameter itself, or
 // the rest element of a destructuring pattern.
 const propsBindingOf = (param) => {
   if (isIdentifier(param)) {
-    return param.name;
+    return param;
   }
   if (param?.type !== "ObjectPattern") {
     return null;
@@ -204,7 +223,7 @@ const propsBindingOf = (param) => {
   const rest = param.properties?.find(
     (property) => property.type === "RestElement",
   );
-  return isIdentifier(rest?.argument) ? rest.argument.name : null;
+  return isIdentifier(rest?.argument) ? rest.argument : null;
 };
 
 // Keys a destructuring pattern names before its rest element. A rest object
@@ -258,6 +277,13 @@ const spreadCanDeliver = (attribute, key) => {
   );
 };
 
+// The slice of the scope manager this rule reads: names visible at a node, and
+// where each was bound. Oxlint does not publish these types.
+type Scope = {
+  set: Map<string, { defs: { name: { range: [number, number] } }[] }>;
+  upper: Scope | null;
+};
+
 export default eslintCompatPlugin({
   meta: { name: "no-omitted-prop-respread" },
   rules: {
@@ -274,9 +300,10 @@ export default eslintCompatPlugin({
       createOnce(context) {
         // Type aliases declared in this file, by name.
         const localTypes = new Map();
-        // One frame per enclosing function: the props binding it introduces and
-        // the literal keys its parameter type omits.
-        const scopes: { binding: string | null; keys: Set<string> }[] = [];
+        // Keys each props binding omits, keyed by the start offset of its
+        // binding identifier. Scope resolution maps a spread back to exactly one
+        // binding, so any shadowing declaration wins over an enclosing one.
+        const omittedByBinding = new Map<number, Set<string>>();
 
         // Props types are aliases here: `typescript/consistent-type-definitions`
         // keeps interfaces out of this codebase.
@@ -294,7 +321,6 @@ export default eslintCompatPlugin({
           const param = patternOf(node.params?.at(0));
           const binding = propsBindingOf(param);
           if (binding === null) {
-            scopes.push({ binding, keys: new Set() });
             return;
           }
           const propsType = param.typeAnnotation?.typeAnnotation;
@@ -307,17 +333,34 @@ export default eslintCompatPlugin({
           const keys = omittedKeysOf(propsType, localTypes).filter(
             (key) => !carried.has(key),
           );
-          scopes.push({ binding, keys: new Set(keys) });
+          if (keys.length > 0) {
+            omittedByBinding.set(binding.range[0], new Set(keys));
+          }
         };
 
-        const exitFunction = () => {
-          scopes.pop();
+        // What the value behind a spread identifier is declared to omit, read
+        // through the lexical scope chain: a nested binding of the same name, in
+        // any parameter position or as a local, shadows an enclosing one.
+        const omittedKeysForSpread = (identifier) => {
+          let scope: Scope | null = context.sourceCode.getScope(identifier);
+          while (scope !== null) {
+            const variable = scope.set.get(identifier.name);
+            if (variable !== undefined) {
+              return variable.defs
+                .map((definition) =>
+                  omittedByBinding.get(definition.name.range[0]),
+                )
+                .find((keys) => keys !== undefined);
+            }
+            scope = scope.upper;
+          }
+          return undefined;
         };
 
         return {
           Program(node) {
             localTypes.clear();
-            scopes.length = 0;
+            omittedByBinding.clear();
             for (const statement of node.body) {
               declareLocalType(
                 statement.type === "ExportNamedDeclaration"
@@ -327,45 +370,20 @@ export default eslintCompatPlugin({
             }
           },
           ArrowFunctionExpression: enterFunction,
-          "ArrowFunctionExpression:exit": exitFunction,
           FunctionDeclaration: enterFunction,
-          "FunctionDeclaration:exit": exitFunction,
           FunctionExpression: enterFunction,
-          "FunctionExpression:exit": exitFunction,
           JSXElement(node) {
             const attributes = node.openingElement.attributes;
-            const spreadNames = new Set<string>();
+            const omitted = new Set<string>();
             for (const attribute of attributes) {
               if (
-                attribute.type === "JSXSpreadAttribute" &&
-                isIdentifier(attribute.argument)
+                attribute.type !== "JSXSpreadAttribute" ||
+                !isIdentifier(attribute.argument)
               ) {
-                spreadNames.add(attribute.argument.name);
-              }
-            }
-            if (spreadNames.size === 0) {
-              return;
-            }
-
-            // Walk outwards, keeping only the innermost frame per binding name:
-            // a nested callback naming its parameter `props` shadows the
-            // component's `props`, and spreading the callback's value must not
-            // be charged to the component's omission.
-            const omitted = new Set<string>();
-            const resolved = new Set<string>();
-            for (let index = scopes.length - 1; index >= 0; index -= 1) {
-              const frame = scopes[index];
-              if (frame === undefined || frame.binding === null) {
                 continue;
               }
-              if (resolved.has(frame.binding)) {
-                continue;
-              }
-              resolved.add(frame.binding);
-              if (!spreadNames.has(frame.binding)) {
-                continue;
-              }
-              for (const key of frame.keys) {
+              for (const key of omittedKeysForSpread(attribute.argument) ??
+                []) {
                 omitted.add(key);
               }
             }

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -142,6 +142,13 @@ const typeSignature = (typeNode) => {
   if (typeNode.type === "TSLiteralType") {
     return JSON.stringify(typeNode.literal?.value ?? null);
   }
+  // Two inline objects are different sources when they declare different keys.
+  if (typeNode.type === "TSTypeLiteral") {
+    const names = (typeNode.members ?? [])
+      .map((member) => getPropertyName(member.key) ?? "?")
+      .sort();
+    return `{${names.join(",")}}`;
+  }
   if (
     typeNode.type === "TSUnionType" ||
     typeNode.type === "TSIntersectionType"
@@ -172,12 +179,15 @@ const suppliersOf = (typeNode, localTypes, open = new Set()) => {
   const args = typeArgumentsOf(typeNode);
   if (name === OMIT_TYPE) {
     const source = args.at(0);
+    const removed = new Set(literalKeysOf(args.at(1)));
+    // Removals compose down the chain: what this `Omit` takes away is gone from
+    // everything its source could otherwise have supplied.
     return [
-      {
-        source: typeSignature(source),
-        removed: new Set(literalKeysOf(args.at(1))),
-      },
-      ...suppliersOf(source, localTypes, open),
+      { source: typeSignature(source), removed },
+      ...suppliersOf(source, localTypes, open).map((supplier) => ({
+        source: supplier.source,
+        removed: new Set([...supplier.removed, ...removed]),
+      })),
     ];
   }
   if (MODIFIER_UTILITIES.has(name)) {
@@ -251,12 +261,13 @@ const omittedKeysOf = (typeNode, localTypes, open = new Set()): string[] => {
       ),
     );
   }
-  // A union only guarantees the omission its branches share.
+  // A union only guarantees the omission its branches share. A `never` branch
+  // is uninhabited, so it neither carries a key nor weakens the guarantee.
   if (typeNode.type === "TSUnionType") {
     return intersectAll(
-      typeNode.types.map(
-        (member) => new Set(omittedKeysOf(member, localTypes, open)),
-      ),
+      typeNode.types
+        .filter((member) => member.type !== "TSNeverKeyword")
+        .map((member) => new Set(omittedKeysOf(member, localTypes, open))),
     );
   }
   if (typeNode.type === "TSTypeReference") {

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -87,6 +87,15 @@ const OMIT_TYPE = "Omit";
 // underneath one is still a reintroduction.
 const MODIFIER_UTILITIES = new Set(["Partial", "Readonly", "Required"]);
 
+// Union branches that contribute no property to a spread: `never` is
+// uninhabited, and spreading a nullish value is a no-op.
+const EMPTY_SPREAD_KEYWORDS = new Set([
+  "TSNeverKeyword",
+  "TSNullKeyword",
+  "TSUndefinedKeyword",
+  "TSVoidKeyword",
+]);
+
 const typeArgumentsOf = (typeNode) =>
   typeNode?.typeArguments?.params ?? typeNode?.typeParameters?.params ?? [];
 
@@ -261,12 +270,13 @@ const omittedKeysOf = (typeNode, localTypes, open = new Set()): string[] => {
       ),
     );
   }
-  // A union only guarantees the omission its branches share. A `never` branch
-  // is uninhabited, so it neither carries a key nor weakens the guarantee.
+  // A union only guarantees the omission its branches share. A branch that
+  // cannot carry a property — uninhabited, or nullish, which spreads as a no-op
+  // — supplies nothing, so it must not weaken that guarantee either.
   if (typeNode.type === "TSUnionType") {
     return intersectAll(
       typeNode.types
-        .filter((member) => member.type !== "TSNeverKeyword")
+        .filter((member) => !EMPTY_SPREAD_KEYWORDS.has(member.type))
         .map((member) => new Set(omittedKeysOf(member, localTypes, open))),
     );
   }

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -58,12 +58,15 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 //   - The omission must be written on the parameter. A props type inferred from
 //     a generic wrapper (`forwardRef<Ref, Omit<P, "k">>`) is not read.
 //   - JSX children override a spread `children` prop, so an element with a
-//     rendered child satisfies an omitted `children` key. Whitespace and a JSX
-//     comment emit no child and do not count.
+//     rendered child satisfies an omitted `children` key. A JSX comment emits no
+//     child, and neither does whitespace-only text spanning lines; whitespace
+//     within one line does.
 //   - A spread of an object literal can only deliver what the literal declares,
 //     spreads in, or computes; anything else is opaque and assumed able to.
 //   - The spread identifier is resolved through the lexical scope chain, so a
 //     shadowing binding of the same name always wins over an enclosing one.
+//     Type-only wrappers around it (`as`, `satisfies`, `!`) are unwrapped first,
+//     since they change the type and not the value.
 //
 // When a key legitimately passes through by design, suppress the finding with
 // `// eslint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread`
@@ -273,11 +276,12 @@ const attributeName = (attribute) =>
     : null;
 
 // JSX children are passed positionally and override a spread `children` prop,
-// so a real child counts as pinning the key. Whitespace-only text and a JSX
-// comment (`{/* … */}`, an expression container holding nothing) emit no child.
+// so a real child counts as pinning the key. A JSX comment (`{/* … */}`, an
+// expression container holding nothing) emits no child, and JSX drops
+// whitespace-only text that spans lines; whitespace within one line survives.
 const isRenderedChild = (child) => {
   if (child.type === "JSXText") {
-    return child.value.trim() !== "";
+    return child.value.trim() !== "" || !child.value.includes("\n");
   }
   return (
     child.type !== "JSXExpressionContainer" ||
@@ -288,11 +292,22 @@ const isRenderedChild = (child) => {
 const hasMeaningfulChildren = (element) =>
   element.children.some(isRenderedChild);
 
+// Wrappers that change a spread argument's type, not its value: the spread is
+// runtime-identical to spreading what they wrap.
+const unwrapSpread = (node) =>
+  node?.type === "TSAsExpression" ||
+  node?.type === "TSSatisfiesExpression" ||
+  node?.type === "TSNonNullExpression" ||
+  node?.type === "TSInstantiationExpression" ||
+  node?.type === "ParenthesizedExpression"
+    ? unwrapSpread(node.expression)
+    : node;
+
 // Whether a spread of this attribute could deliver `key`. An object literal is
 // statically known: it can only deliver what it declares, spreads in, or
 // computes. Anything else is opaque and assumed able to.
 const spreadCanDeliver = (attribute, key) => {
-  const argument = attribute.argument;
+  const argument = unwrapSpread(attribute.argument);
   if (argument.type !== "ObjectExpression") {
     return true;
   }
@@ -414,13 +429,14 @@ export default eslintCompatPlugin({
           const attributes = node.openingElement.attributes;
           const omitted = new Set<string>();
           for (const attribute of attributes) {
-            if (
-              attribute.type !== "JSXSpreadAttribute" ||
-              !isIdentifier(attribute.argument)
-            ) {
+            if (attribute.type !== "JSXSpreadAttribute") {
               continue;
             }
-            for (const key of omittedKeysForSpread(attribute.argument) ?? []) {
+            const argument = unwrapSpread(attribute.argument);
+            if (!isIdentifier(argument)) {
+              continue;
+            }
+            for (const key of omittedKeysForSpread(argument) ?? []) {
               omitted.add(key);
             }
           }

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -48,7 +48,8 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 //   - Omitted keys must be string literals in the `Omit<..., "a" | "b">`
 //     position. A generic or computed key set (`Omit<P, K>`, `keyof Q`) is out
 //     of scope, as is an `Omit` reached through an imported type alias; only
-//     file-local type aliases are followed.
+//     file-local type aliases and the modifier utilities `Partial`, `Readonly`,
+//     and `Required` are unwrapped.
 //   - `Omit` is matched by name. A shadowed or re-exported `Omit` is not
 //     distinguished.
 //   - The omission must be written on the parameter. A props type inferred from
@@ -71,6 +72,11 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 import { getPropertyName, isIdentifier } from "./utils.ts";
 
 const OMIT_TYPE = "Omit";
+
+// Utility types that change property modifiers without changing which keys
+// exist, so an omission underneath one still holds and a member declared
+// underneath one is still a reintroduction.
+const MODIFIER_UTILITIES = new Set(["Partial", "Readonly", "Required"]);
 
 const typeArgumentsOf = (typeNode) =>
   typeNode?.typeArguments?.params ?? typeNode?.typeParameters?.params ?? [];
@@ -145,6 +151,9 @@ const omittedKeysOf = (typeNode, localTypes, open = new Set()): string[] => {
         ...omittedKeysOf(args.at(0), localTypes, open),
       ];
     }
+    if (MODIFIER_UTILITIES.has(name)) {
+      return omittedKeysOf(args.at(0), localTypes, open);
+    }
     // A generic alias parameterized at the use site is not resolved here.
     const alias = expandAlias(name, localTypes, open);
     if (alias === null) {
@@ -189,10 +198,17 @@ const reintroducedKeysOf = (
   }
   if (typeNode.type === "TSTypeReference") {
     const name = typeReferenceName(typeNode.typeName);
-    // `Omit`'s own source type is what the omission removes from, so its
-    // members are not a reintroduction.
+    const args = typeArgumentsOf(typeNode);
     if (name === OMIT_TYPE) {
-      return [];
+      // A member declared inside the source survives unless this `Omit` is the
+      // one removing it: `Omit<Omit<P, "x"> & { x?: T }, "y">` still re-adds x.
+      const removed = new Set(literalKeysOf(args.at(1)));
+      return reintroducedKeysOf(args.at(0), localTypes, open).filter(
+        (key) => !removed.has(key),
+      );
+    }
+    if (MODIFIER_UTILITIES.has(name)) {
+      return reintroducedKeysOf(args.at(0), localTypes, open);
     }
     const alias = expandAlias(name, localTypes, open);
     if (alias === null) {

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -134,6 +134,11 @@ const omittedKeysOf = (typeNode, localTypes, open = new Set()): string[] => {
   if (typeNode === null || typeNode === undefined) {
     return [];
   }
+  // Redundant type parentheses do not survive oxfmt, so no committed file can
+  // carry one; unwrapping keeps the walk right on unformatted input.
+  if (typeNode.type === "TSParenthesizedType") {
+    return omittedKeysOf(typeNode.typeAnnotation, localTypes, open);
+  }
   if (typeNode.type === "TSIntersectionType") {
     return typeNode.types.flatMap((member) =>
       omittedKeysOf(member, localTypes, open),
@@ -186,6 +191,9 @@ const reintroducedKeysOf = (
 ): string[] => {
   if (typeNode === null || typeNode === undefined) {
     return [];
+  }
+  if (typeNode.type === "TSParenthesizedType") {
+    return reintroducedKeysOf(typeNode.typeAnnotation, localTypes, open);
   }
   if (
     typeNode.type === "TSIntersectionType" ||

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -1,0 +1,339 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+// `Omit<Props, "k">` on a component does not keep `k` off the element.
+//
+// Omitting a key narrows what a caller may write *literally*. It does not
+// narrow what a value can carry: TypeScript is width-subtyping, so a props
+// object typed wider than the omitting component's parameter is still
+// assignable to it, and the rest object collected from a spread keeps every
+// runtime key the caller passed. `{...props}` in the body then re-applies `k`
+// to the element the omit was meant to protect.
+//
+// JSX attribute order decides the winner. React builds the props object left
+// to right, so an attribute written before the spread is overwritten by it,
+// and an attribute the component never writes is supplied by it. Only an
+// attribute to the right of the last spread survives. `Omit` therefore reads
+// as a guarantee while the layout, variant, or direction it was protecting
+// silently follows whatever reached the spread.
+//
+// Flagged, when a component's parameter type omits literal keys and the body
+// spreads that parameter's binding into a JSX element:
+//
+//   const Tabs = ({ ...props }: Omit<TabsProps, "orientation">) => (
+//     <Root orientation="horizontal" {...props} />   // spread wins
+//   );
+//   const Tabs = ({ ...props }: Omit<TabsProps, "orientation">) => (
+//     <Root {...props} />                            // spread supplies it
+//   );
+//
+// Allowed:
+//
+//   const Tabs = ({ ...props }: Omit<TabsProps, "orientation">) => (
+//     <Root {...props} orientation="horizontal" />   // pinned after
+//   );
+//
+// Two shapes are out of scope because the key is not actually removed:
+//
+//   - The pattern destructures the key (`({ size, ...props }: Omit<P, "size">)`).
+//     A rest object provably excludes what the pattern named, so no spread of
+//     it can carry the key.
+//   - The props type re-declares the key alongside the omission
+//     (`Omit<P, "size"> & { size?: Local }`). That is a re-typing, not a
+//     prohibition, and the key is meant to reach the element.
+//
+// Analysis boundary. This is a tripwire for the common shape, not a proof:
+//
+//   - Only the component's own props binding counts as the smuggling spread —
+//     an identifier or rest element annotated with the omitting type. A wider
+//     value spread from anywhere else is invisible here.
+//   - Omitted keys must be string literals in the `Omit<..., "a" | "b">`
+//     position. A generic or computed key set (`Omit<P, K>`, `keyof Q`) is out
+//     of scope, as is an `Omit` reached through an imported type alias; only
+//     file-local type aliases are followed.
+//   - `Omit` is matched by name. A shadowed or re-exported `Omit` is not
+//     distinguished.
+//   - JSX children override a spread `children` prop, so an element with
+//     children satisfies an omitted `children` key.
+//
+// When a key legitimately passes through by design, suppress the finding with
+// `// eslint-disable-next-line no-omitted-prop-respread/no-omitted-prop-respread`
+// and a reason. The rule is not in `TRACKED_SUPPRESSION_RULES`, so the
+// directive is charged to the residual suppression budget in `scripts/ratchet.ts`:
+// the exception is still countable and decrease-only, without claiming a tenancy,
+// capacity, or diagnosability tier it does not guard. The repo carries none today.
+
+import { getPropertyName, isIdentifier } from "./utils.ts";
+
+const OMIT_TYPE = "Omit";
+
+// Local alias chains are short in practice; the cap only bounds a cycle.
+const MAX_ALIAS_DEPTH = 4;
+
+const typeArgumentsOf = (typeNode) =>
+  typeNode?.typeArguments?.params ?? typeNode?.typeParameters?.params ?? [];
+
+// The dotted name of a type reference: `Props`, `React.ComponentProps`.
+const typeReferenceName = (typeName) => {
+  if (isIdentifier(typeName)) {
+    return typeName.name;
+  }
+  if (typeName?.type !== "TSQualifiedName") {
+    return null;
+  }
+  const left = typeReferenceName(typeName.left);
+  const right = getPropertyName(typeName.right);
+  return left === null || right === null ? null : `${left}.${right}`;
+};
+
+// String keys from the second `Omit` argument: `"a"` or `"a" | "b"`.
+// A non-literal key set yields nothing, which is the documented boundary.
+const literalKeysOf = (keyTypeNode) => {
+  if (keyTypeNode?.type === "TSLiteralType") {
+    const literal = keyTypeNode.literal;
+    return typeof literal?.value === "string" ? [literal.value] : [];
+  }
+  if (keyTypeNode?.type === "TSUnionType") {
+    return keyTypeNode.types.flatMap(literalKeysOf);
+  }
+  return [];
+};
+
+/**
+ * Literal keys omitted anywhere inside a type position, following file-local
+ * aliases. Intersections and nested `Omit`s accumulate.
+ */
+const omittedKeysOf = (typeNode, localTypes, depth = 0) => {
+  if (typeNode === null || typeNode === undefined || depth > MAX_ALIAS_DEPTH) {
+    return [];
+  }
+  if (
+    typeNode.type === "TSIntersectionType" ||
+    typeNode.type === "TSUnionType"
+  ) {
+    return typeNode.types.flatMap((member) =>
+      omittedKeysOf(member, localTypes, depth),
+    );
+  }
+  if (typeNode.type === "TSTypeReference") {
+    const name = typeReferenceName(typeNode.typeName);
+    const args = typeArgumentsOf(typeNode);
+    if (name === OMIT_TYPE) {
+      return [
+        ...literalKeysOf(args.at(1)),
+        // `Omit<Omit<P, "a">, "b">` omits both.
+        ...omittedKeysOf(args.at(0), localTypes, depth),
+      ];
+    }
+    const alias = name === null ? undefined : localTypes.get(name);
+    // A generic alias parameterized at the use site is not resolved here.
+    return alias === undefined
+      ? []
+      : omittedKeysOf(alias, localTypes, depth + 1);
+  }
+  return [];
+};
+
+/**
+ * Keys the props type declares in its own right, outside the removed source
+ * type. `Omit<P, "size"> & { size?: Local }` re-types `size` rather than
+ * forbidding it, so the key is meant to reach the element.
+ */
+const reintroducedKeysOf = (typeNode, localTypes, depth = 0) => {
+  if (typeNode === null || typeNode === undefined || depth > MAX_ALIAS_DEPTH) {
+    return [];
+  }
+  if (
+    typeNode.type === "TSIntersectionType" ||
+    typeNode.type === "TSUnionType"
+  ) {
+    return typeNode.types.flatMap((member) =>
+      reintroducedKeysOf(member, localTypes, depth),
+    );
+  }
+  if (typeNode.type === "TSTypeLiteral") {
+    return (typeNode.members ?? [])
+      .filter((member) => member.type === "TSPropertySignature")
+      .map((member) =>
+        member.computed === true ? null : getPropertyName(member.key),
+      )
+      .filter((name) => name !== null);
+  }
+  if (typeNode.type === "TSTypeReference") {
+    const name = typeReferenceName(typeNode.typeName);
+    // `Omit`'s own source type is what the omission removes from, so its
+    // members are not a reintroduction.
+    if (name === OMIT_TYPE) {
+      return [];
+    }
+    const alias = name === null ? undefined : localTypes.get(name);
+    return alias === undefined
+      ? []
+      : reintroducedKeysOf(alias, localTypes, depth + 1);
+  }
+  return [];
+};
+
+// The binding that carries the rest of the props: the parameter identifier, or
+// the rest element of a destructuring pattern.
+const propsBindingOf = (param) => {
+  if (isIdentifier(param)) {
+    return param.name;
+  }
+  if (param?.type !== "ObjectPattern") {
+    return null;
+  }
+  const rest = param.properties?.find(
+    (property) => property.type === "RestElement",
+  );
+  return isIdentifier(rest?.argument) ? rest.argument.name : null;
+};
+
+// Keys a destructuring pattern names before its rest element. A rest object
+// provably excludes them, so no spread of it can carry the key.
+const destructuredKeysOf = (param) => {
+  if (param?.type !== "ObjectPattern") {
+    return [];
+  }
+  return (param.properties ?? [])
+    .filter((property) => property.type === "Property" && !property.computed)
+    .map((property) => getPropertyName(property.key))
+    .filter((name) => name !== null);
+};
+
+// A plain attribute name. `JSXNamespacedName` (`xlink:href`) yields null: no
+// omitted key spells that way.
+const attributeName = (attribute) =>
+  attribute?.type === "JSXAttribute" && attribute.name?.type === "JSXIdentifier"
+    ? attribute.name.name
+    : null;
+
+// JSX children are passed positionally and override a spread `children` prop,
+// so anything other than insignificant whitespace counts as pinning the key.
+const hasMeaningfulChildren = (element) =>
+  (element.children ?? []).some(
+    (child) => child.type !== "JSXText" || child.value.trim() !== "",
+  );
+
+export default eslintCompatPlugin({
+  meta: { name: "no-omitted-prop-respread" },
+  rules: {
+    "no-omitted-prop-respread": {
+      meta: {
+        type: "problem",
+        messages: {
+          pinnedBeforeSpread:
+            "`{{key}}` is omitted from this component's props but written before the props spread, so the spread overwrites it. A value typed wider than the omitting parameter still carries `{{key}}` at runtime — `Omit` narrows what callers may write, not what a spread can deliver. Move the attribute after the last spread.",
+          suppliedBySpread:
+            "`{{key}}` is omitted from this component's props but the props spread can still deliver it: `Omit` narrows what callers may write literally, while a value typed wider stays assignable and keeps the key at runtime. Pin `{{key}}` after the last spread, or suppress with a reason if it is meant to pass through.",
+        },
+      },
+      createOnce(context) {
+        // Type aliases declared in this file, by name.
+        const localTypes = new Map();
+        // One frame per enclosing function: the props binding it introduces and
+        // the literal keys its parameter type omits.
+        const scopes = [];
+
+        // Props types are aliases here: `typescript/consistent-type-definitions`
+        // keeps interfaces out of this codebase.
+        const declareLocalType = (declaration) => {
+          if (declaration?.type !== "TSTypeAliasDeclaration") {
+            return;
+          }
+          const name = declaration.id?.name;
+          if (typeof name === "string") {
+            localTypes.set(name, declaration.typeAnnotation);
+          }
+        };
+
+        const enterFunction = (node) => {
+          const param = node.params?.at(0);
+          const binding = propsBindingOf(param);
+          if (binding === null) {
+            scopes.push({ binding, keys: new Set() });
+            return;
+          }
+          const propsType = param.typeAnnotation?.typeAnnotation;
+          // A key the pattern destructures is absent from the rest object, and
+          // a key the props type re-declares is meant to pass through.
+          const carried = new Set([
+            ...destructuredKeysOf(param),
+            ...reintroducedKeysOf(propsType, localTypes),
+          ]);
+          const keys = omittedKeysOf(propsType, localTypes).filter(
+            (key) => !carried.has(key),
+          );
+          scopes.push({ binding, keys: new Set(keys) });
+        };
+
+        const exitFunction = () => {
+          scopes.pop();
+        };
+
+        return {
+          Program(node) {
+            localTypes.clear();
+            scopes.length = 0;
+            for (const statement of node.body) {
+              declareLocalType(
+                statement.type === "ExportNamedDeclaration"
+                  ? statement.declaration
+                  : statement,
+              );
+            }
+          },
+          ArrowFunctionExpression: enterFunction,
+          "ArrowFunctionExpression:exit": exitFunction,
+          FunctionDeclaration: enterFunction,
+          "FunctionDeclaration:exit": exitFunction,
+          FunctionExpression: enterFunction,
+          "FunctionExpression:exit": exitFunction,
+          JSXElement(node) {
+            const attributes = node.openingElement.attributes ?? [];
+            // Only a spread of a named value can smuggle a key; an object
+            // literal spread is statically known.
+            const spreadNames = new Set(
+              attributes
+                .filter(
+                  (attribute) =>
+                    attribute.type === "JSXSpreadAttribute" &&
+                    isIdentifier(attribute.argument),
+                )
+                .map((attribute) => attribute.argument.name),
+            );
+            // The innermost enclosing component whose props reach this element.
+            const scope = scopes.findLast(
+              (candidate) =>
+                candidate.keys.size > 0 && spreadNames.has(candidate.binding),
+            );
+            if (scope === undefined) {
+              return;
+            }
+
+            // Any later spread can override, so the pin must clear the last one.
+            const lastSpreadIndex = attributes.findLastIndex(
+              (attribute) => attribute.type === "JSXSpreadAttribute",
+            );
+            for (const key of scope.keys) {
+              if (key === "children" && hasMeaningfulChildren(node)) {
+                continue;
+              }
+              const pinIndex = attributes.findIndex(
+                (attribute) => attributeName(attribute) === key,
+              );
+              if (pinIndex > lastSpreadIndex) {
+                continue;
+              }
+              context.report({
+                node:
+                  pinIndex === -1 ? node.openingElement : attributes[pinIndex],
+                messageId:
+                  pinIndex === -1 ? "suppliedBySpread" : "pinnedBeforeSpread",
+                data: { key },
+              });
+            }
+          },
+        };
+      },
+    },
+  },
+});

--- a/.oxlint-plugins/no-omitted-prop-respread.ts
+++ b/.oxlint-plugins/no-omitted-prop-respread.ts
@@ -88,7 +88,7 @@ const typeReferenceName = (typeName) => {
 
 // String keys from the second `Omit` argument: `"a"` or `"a" | "b"`.
 // A non-literal key set yields nothing, which is the documented boundary.
-const literalKeysOf = (keyTypeNode) => {
+const literalKeysOf = (keyTypeNode): string[] => {
   if (keyTypeNode?.type === "TSLiteralType") {
     const literal = keyTypeNode.literal;
     return typeof literal?.value === "string" ? [literal.value] : [];
@@ -105,7 +105,7 @@ const literalKeysOf = (keyTypeNode) => {
  * keeps only the keys every branch omits, since a value of the other branch may
  * legitimately carry the rest.
  */
-const omittedKeysOf = (typeNode, localTypes, depth = 0) => {
+const omittedKeysOf = (typeNode, localTypes, depth = 0): string[] => {
   if (typeNode === null || typeNode === undefined || depth > MAX_ALIAS_DEPTH) {
     return [];
   }
@@ -147,7 +147,7 @@ const omittedKeysOf = (typeNode, localTypes, depth = 0) => {
  * type. `Omit<P, "size"> & { size?: Local }` re-types `size` rather than
  * forbidding it, so the key is meant to reach the element.
  */
-const reintroducedKeysOf = (typeNode, localTypes, depth = 0) => {
+const reintroducedKeysOf = (typeNode, localTypes, depth = 0): string[] => {
   if (typeNode === null || typeNode === undefined || depth > MAX_ALIAS_DEPTH) {
     return [];
   }
@@ -199,7 +199,7 @@ const propsBindingOf = (param) => {
 
 // Keys a destructuring pattern names before its rest element. A rest object
 // provably excludes them, so no spread of it can carry the key.
-const destructuredKeysOf = (param) => {
+const destructuredKeysOf = (param): string[] => {
   if (param?.type !== "ObjectPattern") {
     return [];
   }
@@ -241,7 +241,7 @@ export default eslintCompatPlugin({
         const localTypes = new Map();
         // One frame per enclosing function: the props binding it introduces and
         // the literal keys its parameter type omits.
-        const scopes = [];
+        const scopes: { binding: string | null; keys: Set<string> }[] = [];
 
         // Props types are aliases here: `typescript/consistent-type-definitions`
         // keeps interfaces out of this codebase.
@@ -298,46 +298,50 @@ export default eslintCompatPlugin({
           FunctionExpression: enterFunction,
           "FunctionExpression:exit": exitFunction,
           JSXElement(node) {
-            const attributes = node.openingElement.attributes ?? [];
+            const attributes = node.openingElement.attributes;
             // Only a spread of a named value can smuggle a key; an object
-            // literal spread is statically known.
-            const spreadNames = new Set(
-              attributes
-                .filter(
-                  (attribute) =>
-                    attribute.type === "JSXSpreadAttribute" &&
-                    isIdentifier(attribute.argument),
-                )
-                .map((attribute) => attribute.argument.name),
-            );
+            // literal spread is statically known. Any spread can override an
+            // earlier attribute, so the pin has to clear the last one.
+            const spreadNames = new Set<string>();
+            let lastSpreadIndex = -1;
+            for (const [index, attribute] of attributes.entries()) {
+              if (attribute.type !== "JSXSpreadAttribute") {
+                continue;
+              }
+              lastSpreadIndex = index;
+              if (isIdentifier(attribute.argument)) {
+                spreadNames.add(attribute.argument.name);
+              }
+            }
+
             // The innermost enclosing component whose props reach this element.
             const scope = scopes.findLast(
               (candidate) =>
-                candidate.keys.size > 0 && spreadNames.has(candidate.binding),
+                candidate.binding !== null &&
+                candidate.keys.size > 0 &&
+                spreadNames.has(candidate.binding),
             );
             if (scope === undefined) {
               return;
             }
 
-            // Any later spread can override, so the pin must clear the last one.
-            const lastSpreadIndex = attributes.findLastIndex(
-              (attribute) => attribute.type === "JSXSpreadAttribute",
-            );
             for (const key of scope.keys) {
               if (key === "children" && hasMeaningfulChildren(node)) {
                 continue;
               }
-              const pinIndex = attributes.findIndex(
+              const pin = attributes.find(
                 (attribute) => attributeName(attribute) === key,
               );
-              if (pinIndex > lastSpreadIndex) {
+              if (
+                pin !== undefined &&
+                attributes.indexOf(pin) > lastSpreadIndex
+              ) {
                 continue;
               }
               context.report({
-                node:
-                  pinIndex === -1 ? node.openingElement : attributes[pinIndex],
+                node: pin ?? node.openingElement,
                 messageId:
-                  pinIndex === -1 ? "suppliedBySpread" : "pinnedBeforeSpread",
+                  pin === undefined ? "suppliedBySpread" : "pinnedBeforeSpread",
                 data: { key },
               });
             }

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -201,11 +201,15 @@ export const ConversationDownload = ({
         "inset-e-4 top-4 rounded-full",
         className,
       )}
-      onClick={handleDownload}
       size="icon"
       type="button"
       variant="outline"
       {...props}
+      // After the spread on purpose: the props type omits `onClick` so the
+      // button keeps its download action, but an omit only rejects a literal
+      // attribute. A props object typed wider stays assignable and carries a
+      // handler through the spread, silently replacing the download.
+      onClick={handleDownload}
     >
       {children ?? <DownloadIcon className="size-4" />}
     </Button>

--- a/apps/web/src/components/secret-input.tsx
+++ b/apps/web/src/components/secret-input.tsx
@@ -13,9 +13,13 @@ const SecretInput = (props: SecretInputProps) => {
 
   return (
     <SecretInputPrimitive
+      {...props}
+      // After the spread on purpose: this wrapper exists to own the translated
+      // labels, and the props type omits them so callers cannot. The omit only
+      // rejects a literal attribute, though — a props object typed wider stays
+      // assignable and carries an untranslated label through the spread.
       hideValueLabel={t("hideSecretValue")}
       showValueLabel={t("showSecretValue")}
-      {...props}
     />
   );
 };

--- a/apps/web/src/components/workspaces/tasks/task-metadata.tsx
+++ b/apps/web/src/components/workspaces/tasks/task-metadata.tsx
@@ -216,6 +216,7 @@ const hasDeletedAccount = (
 
 export const DatePickerPopover = (props: DatePickerPopoverProps) => {
   const t = useTranslations("tasks");
+  const tCommon = useTranslations("common");
   const locale = useLocale();
 
   return (
@@ -224,6 +225,13 @@ export const DatePickerPopover = (props: DatePickerPopoverProps) => {
       clearLabel={t("clearDate")}
       locale={locale}
       overdueLabel={t("overdue")}
+      // The props type omits all four labels so this wrapper owns them, but
+      // `todayLabel` was never supplied: the base fell back to its own
+      // Intl-derived string while its siblings came from the catalogue. An
+      // omit also only rejects a literal attribute — a props object typed
+      // wider stays assignable and carries a label through the spread — so
+      // every pinned label sits after it.
+      todayLabel={tCommon("today")}
     />
   );
 };

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -767,6 +767,7 @@ export default defineConfig({
     "./.oxlint-plugins/confine-redis-client.ts",
     "./.oxlint-plugins/require-coordination-key.ts",
     "./.oxlint-plugins/no-async-context-enter-with.ts",
+    "./.oxlint-plugins/no-omitted-prop-respread.ts",
   ],
 
   overrides: [
@@ -1467,6 +1468,20 @@ export default defineConfig({
       ],
       rules: {
         "no-disabled-tooltip-trigger/no-disabled-tooltip-trigger": "error",
+      },
+    },
+    {
+      // `Omit<Props, "k">` narrows what a caller may write, not what a value
+      // can carry: a wider props object stays assignable and the rest object
+      // keeps every runtime key, so `{...props}` re-applies the omitted key
+      // unless the component pins it after the last spread.
+      files: [
+        "apps/*/src/**/*.tsx",
+        "packages/*/src/**/*.tsx",
+        ".oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx",
+      ],
+      rules: {
+        "no-omitted-prop-respread/no-omitted-prop-respread": "error",
       },
     },
     {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1485,6 +1485,17 @@ export default defineConfig({
       },
     },
     {
+      // A nested callback naming its parameter `props` is the accepted case
+      // this fixture pins: the shadowed binding must not be charged to the
+      // enclosing component's omission. The shadowing is the test.
+      files: [
+        ".oxlint-plugins/__fixtures__/no-omitted-prop-respread.fixture.tsx",
+      ],
+      rules: {
+        "no-shadow": "off",
+      },
+    },
+    {
       files: ["apps/web/src/**/*.{ts,tsx}"],
       rules: {
         "no-ambient-hotkey-format/no-ambient-hotkey-format": "error",

--- a/packages/ui/src/components/destructive-action-confirmation.tsx
+++ b/packages/ui/src/components/destructive-action-confirmation.tsx
@@ -55,13 +55,18 @@ const DestructiveActionConfirmation = ({
         autoComplete="off"
         className={inputClassName}
         data-slot="destructive-action-confirmation-input"
+        spellCheck={false}
+        {...props}
+        // After the spread on purpose: the props type omits these three so the
+        // field stays controlled by `value`/`onValueChange`, but an omit only
+        // rejects a literal attribute. A props object typed wider stays
+        // assignable and carries them through the spread, which would replace
+        // the confirmation handler or the compared value.
         onChange={(event) => {
           onValueChange(event.currentTarget.value);
         }}
-        spellCheck={false}
         type="text"
         value={value}
-        {...props}
       />
     </Field>
   );

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -119,7 +119,17 @@ const SortableHead = ({
     sortIcon = <ArrowDownIcon className="size-3" />;
   }
   return (
-    <TableHead aria-sort={ariaSort} className={className} {...props}>
+    <TableHead
+      aria-sort={ariaSort}
+      className={className}
+      {...props}
+      // After the spread on purpose: the props type omits `onClick` because the
+      // sort button below owns activation, but omitting it only rejects a
+      // literal attribute. A props object typed wider stays assignable and
+      // carries the handler through the spread, giving the cell a click target
+      // that no keyboard user can reach.
+      onClick={undefined}
+    >
       <span className="inline-flex items-center gap-1">
         <button
           className="text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center gap-1 font-medium select-none"


### PR DESCRIPTION
## The bug class

`Omit<Props, "k">` on a component reads as a guarantee that `k` cannot reach the
element. It is not one. TypeScript is width-subtyping: a props object typed wider
than the omitting parameter stays assignable to it, and the rest object collected
from a spread keeps every runtime key the caller actually passed. `{...props}` in
the body then re-applies `k` to the element the omit was meant to protect.

JSX attribute order decides the outcome. React builds the props object left to
right, so an attribute written *before* the spread is overwritten by it, and an
attribute the component never writes is supplied by it. Only an attribute to the
right of the last spread survives. The failure is silent: the layout, variant,
handler, or label the omission was protecting quietly follows whatever reached the
spread.

#2049 closed one instance of this in the portable inspector shell; it took two
review rounds to get the forced chrome props (`variant`, `orientation`) pinned
*after* the rest spread. This lands the guard so the shape cannot come back, and
sweeps the rest of the tree.

## The rule

`no-omitted-prop-respread` (`.oxlint-plugins/no-omitted-prop-respread.ts`), scoped
to `apps/*/src/**/*.tsx` and `packages/*/src/**/*.tsx`.

**Contract.** When a component's first parameter type omits literal keys and the
body spreads that parameter's own binding into a JSX element, every omitted key
must be set as an attribute to the right of the last spread on that element.
Setting it earlier is flagged (the spread overwrites it); not setting it at all is
flagged (the spread supplies it).

**Deliberately out of scope**, because the key is not actually removed:

- The pattern destructures the key (`({ size, ...props }: Omit<P, "size"> & { size?: L })`).
  A rest object provably excludes what the pattern named, so no spread of it can
  carry the key.
- The props type re-declares the key alongside the omission
  (`Omit<P, "size"> & { size?: Local }`). That is a re-typing, not a prohibition,
  and the key is meant to reach the element. This covers the common
  widen-a-primitive-prop idiom in `input.tsx`, `combobox.tsx`, and `command.tsx`.

An intersection has a key when any member has it, so a member's omission survives
only when no sibling proves it can supply the key back (same source, and the
sibling does not remove it): `Omit<P, "a"> & Omit<P, "b">` carries both, while
`Omit<A, "a"> & Omit<B, "b">` carries neither. A union keeps only what every
branch omits, ignoring branches that can supply nothing (`never`, nullish). A
generic alias is left unresolved, since its use-site arguments are not
substituted.

**Analysis boundary** (documented in the rule header; this is a tripwire for the
common shape, not a proof):

- Only the component's own props binding counts as the smuggling spread. A wider
  value spread from anywhere else is invisible.
- Omitted keys must be string literals in the `Omit<..., "a" | "b">` position. A
  generic or computed key set (`Omit<P, K>`, `keyof Q`) is out of scope, as is an
  `Omit` reached through an imported alias; only file-local type aliases and the
  modifier utilities `Partial`, `Readonly`, and `Required` are unwrapped. Aliases
  are indexed by name across the whole file, so a name claimed by more than one
  thing (two declarations, an import, or a type parameter) resolves to nothing
  rather than guessing which one a reference meant. The plugin API exposes a value
  scope but no type scope, so this cuts both ways: it avoids reporting one
  declaration's omission against another's reference, and it costs the report on
  whichever reference did mean an omitting alias. The fixture pins both halves as
  a boundary rather than as an accepted shape.
- `Omit` is matched by name; a shadowed or re-exported `Omit` is not distinguished.
- JSX children are passed positionally and beat a spread `children`, so an element
  with a rendered child satisfies an omitted `children` key. A JSX comment emits no
  child, and neither does whitespace-only text spanning lines; whitespace within one
  line does.
- A spread of an object literal can only deliver what the literal declares, spreads
  in, or computes; anything else is opaque and assumed able to.
- The spread identifier is resolved through the lexical scope chain, so a
  shadowing binding of the same name always wins over an enclosing one. Type-only
  wrappers around it (`as`, `satisfies`, `!`) are unwrapped first, since they change
  the type and not the value.

**Escape hatch.** A key that passes through by design takes the standard
`eslint-disable-next-line` with a reason. The rule is not in
`TRACKED_SUPPRESSION_RULES`: it guards none of the three defined tiers (tenancy,
capacity, diagnosability), so directives are charged to the residual
decrease-only suppression budget in `scripts/ratchet.ts` instead of claiming a
tier it does not hold. The tree carries none today, so no baseline moves in this
PR.

## Sweep

19 raw findings across `apps/` and `packages/`; 12 were the re-typing idiom above
and became the two carve-outs. The remaining 7 are real and all fixed by pinning
after the spread:

| Site | Omitted | Was |
| --- | --- | --- |
| `packages/ui/src/components/table.tsx` | `onClick` | never pinned; the sort button owns activation, so a smuggled cell handler would be an unreachable click target |
| `packages/ui/src/components/destructive-action-confirmation.tsx` | `onChange`, `type`, `value` | pinned before the spread; a wider value could replace the confirmation handler or the compared value |
| `apps/web/src/components/secret-input.tsx` | `hideValueLabel`, `showValueLabel` | pinned before the spread; the wrapper exists to own the translated labels |
| `apps/web/src/components/ai-elements/conversation.tsx` | `onClick` | pinned before the spread; a smuggled handler silently replaces the download |
| `apps/web/src/components/workspaces/tasks/task-metadata.tsx` | `todayLabel` | never pinned |

The last one is a real defect rather than a latent one. `DatePickerPopover` omits
all four date-picker labels so the wrapper owns them, but supplied only three:
`todayLabel` fell through to the base's Intl-derived string while `clearLabel` and
`overdueLabel` came from the translation catalogue. It now pins `common.today`,
which is translated in every supported language.

`packages/ui/src/components/inspector.tsx` passes as it stands. Reconstructing its
pre-#2049 shape against the real file reproduces the report, and the fixture pins
both shapes.

## Gate

- `bun scripts/check-oxlint-plugin-registry.ts`
- `bash scripts/lint-oxlint-fixtures.sh` (type-aware, unused directives fatal)
- `oxlint -c oxlint.config.ts apps packages`: 0 findings for the new rule
- `bun scripts/ratchet.ts`: no baseline movement
- `oxfmt` on every touched file; `typecheck` on `@stll/ui` and `@stll/web`

The fixture covers pin-before-spread, spread-without-pin, multiple omitted keys,
multiple spreads (last one wins), the alias and intersected-alias paths, a
defaulted props parameter in both destructured and whole-object form, a
comment-only child, a trailing object literal that does declare the key, and the
pre-#2049 inspector shape; the accepted half covers pin-after-spread, no spread,
non-literal keys, a union of props shapes, a rendered child, three shadowed
bindings (nested first parameter, later parameter, local), a harmless trailing
literal spread, both carve-outs, and the shipping inspector shape. A five-hop
local alias chain is a must-fail case, pinning that alias resolution is bounded
by cycle detection rather than a depth cutoff, alongside a `Readonly`-wrapped
omission, a re-typing that survives an outer omission of a different key, a
function-local alias, an alias declared after the component that annotates with
it, a props parameter behind an erased `this`, and a spread behind a `satisfies`
wrapper.
