### PR TITLE
fix(api): hold a slice reconciliation cannot walk

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -813,6 +813,44 @@ test("a settled slice past the recheck window is re-walked, and a grown listing 
   });
 });
 
+test("a held recheck candidate yields to the next settled row, not to idle", async () => {
+  // The recheck read is `LIMIT 1` on the oldest settled row, so a held row
+  // filtered after the query is the whole candidate set and the source reports
+  // idle with a later settled row due. Unlike the sweep frontier, skipping one
+  // costs nothing: a settled slice keeps its ledger row and is selectable on a
+  // later turn, so the only thing the hold changes is which row this turn
+  // proves.
+  const sourceId = await seedSource();
+  const longSettled = new Date(
+    NOW.getTime() - RECONCILIATION_SETTLED_RECHECK_MS - DAY_IN_MS,
+  );
+  await seedSettledHistory(sourceId, longSettled);
+  const behind = stepDay(OWED_SLICE, 1);
+  await seedSlice({
+    sourceId,
+    slice: behind,
+    reported: 1,
+    collected: 1,
+    // Younger than the held row, so it is only reached once that one is out,
+    // and still the wrong side of the recheck cutoff so it is genuinely due.
+    checkedAt: new Date(longSettled.getTime() + DAY_IN_MS / 2),
+  });
+
+  const sliceRetries: SliceRetrySchedule = new Map([
+    [OWED_SLICE, NOW.getTime() + DAY_IN_MS],
+  ]);
+
+  expect(await runUnitWith({ sourceId, sliceRetries })).toMatchObject({
+    type: "worked",
+    summary: {
+      unit: "slice",
+      slice: behind,
+      reason: SLICE_WALK_REASON.RECHECK,
+    },
+  });
+  expect(listed.map(({ slice }) => slice)).toEqual([behind]);
+});
+
 test("a settled slice inside the recheck window is left alone", async () => {
   // Otherwise proved history is re-walked at nearly the tip's own cadence, and
   // the politeness budget spent on it is budget not spent on slices that are

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -15,6 +15,7 @@ import {
   RECONCILIATION_ITEM_STATUS,
   relations,
 } from "@/api/db/schema";
+import type { SliceRetrySchedule } from "@/api/handlers/case-law/ingestion/reconciliation-engine";
 import { runReconciliationWorkUnit } from "@/api/handlers/case-law/ingestion/reconciliation-engine";
 import {
   RECONCILIATION_SETTLED_RECHECK_MS,
@@ -171,6 +172,22 @@ const stubReconciliation: SourceReconciliation = {
   },
 };
 
+/** The same publisher, with one slice it will not serve. */
+const unwalkableSliceStub: SourceReconciliation = {
+  ...stubReconciliation,
+  listSlicePage: async (options): Promise<ReconciliationSlicePage> => {
+    listed.push(options);
+    if (options.slice === OWED_SLICE) {
+      throw new AdapterFetchError({
+        message: "listing refused",
+        adapterKey: "engine-fixture",
+        cursor: options.slice,
+      });
+    }
+    return await Promise.resolve({ items: [], totalPages: 1 });
+  },
+};
+
 /**
  * The same publisher, listing dockets instead of document ids: the other half
  * of the identity index, which is answered by its own held query.
@@ -267,10 +284,18 @@ const checkedAtBySlice = async (
     ).map(({ slice, checkedAt }) => [slice, checkedAt]),
   );
 
-const runUnit = async (
-  sourceId: SafeId<"caseLawSource">,
-  reconciliation: SourceReconciliation = stubReconciliation,
-) =>
+type RunUnitOptions = {
+  sourceId: SafeId<"caseLawSource">;
+  reconciliation?: SourceReconciliation;
+  /** Shared across turns only where a test is about what a failure leaves. */
+  sliceRetries?: SliceRetrySchedule;
+};
+
+const runUnitWith = async ({
+  reconciliation = stubReconciliation,
+  sliceRetries = new Map(),
+  sourceId,
+}: RunUnitOptions) =>
   await runReconciliationWorkUnit({
     adapterKey: "engine-fixture",
     sourceId,
@@ -281,7 +306,13 @@ const runUnit = async (
     sleep: async () => {
       await Promise.resolve();
     },
+    sliceRetries,
   });
+
+const runUnit = async (
+  sourceId: SafeId<"caseLawSource">,
+  reconciliation: SourceReconciliation = stubReconciliation,
+) => await runUnitWith({ sourceId, reconciliation });
 
 test("a settled slice is touched out of the window so the one behind it is reached", async () => {
   const sourceId = await seedSource();
@@ -632,6 +663,44 @@ test("a publisher claiming an absurd page count is refused, not walked", async (
     )
     .limit(1);
   expect(ledger).toEqual({ reported: 2, collected: 0 });
+});
+
+test("a slice the publisher will not serve does not hold the ones behind it", async () => {
+  // The other half of the test above. A failed walk writes nothing, so every
+  // input the selection reads is exactly what it was before — and the same
+  // slice comes back on the next turn, and on every turn after it, while the
+  // rest of the source's backlog is never reached. The loop's error backoff
+  // does not help: it paces the retries, it does not change what is retried.
+  const sourceId = await seedSource();
+  await seedFreshTip(sourceId);
+  const reachable = stepDay(OWED_SLICE, 1);
+  for (const [slice, checkedAt] of [
+    [OWED_SLICE, addUtcDays(NOW, -3)],
+    [reachable, addUtcDays(NOW, -2)],
+  ] as const) {
+    // oxlint-disable-next-line no-await-in-loop -- fixture seeding, sequential on one pglite handle
+    await seedSlice({ sourceId, slice, reported: 2, collected: 0, checkedAt });
+  }
+
+  // One schedule across both turns, as the runner holds one per source.
+  const sliceRetries: SliceRetrySchedule = new Map();
+  const options = {
+    sourceId,
+    reconciliation: unwalkableSliceStub,
+    sliceRetries,
+  };
+
+  const rejection = await runUnitWith(options).then(
+    () => null,
+    (error: unknown) => error,
+  );
+  expect(rejection).toBeInstanceOf(AdapterFetchError);
+  expect(listed.map(({ slice }) => slice)).toEqual([OWED_SLICE]);
+
+  // The next turn spends itself on the slice behind it rather than on the one
+  // that just refused.
+  expect(await runUnitWith(options)).toMatchObject({ type: "worked" });
+  expect(listed.map(({ slice }) => slice)).toEqual([OWED_SLICE, reachable]);
 });
 
 // ── Rechecking a settled slice ──────────────────────────

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -703,6 +703,42 @@ test("a slice the publisher will not serve does not hold the ones behind it", as
   expect(listed.map(({ slice }) => slice)).toEqual([OWED_SLICE, reachable]);
 });
 
+test("held slices are excluded from the backlog window, not filtered after it", async () => {
+  // The backlog read is a bounded oldest-first window. A held row filtered
+  // out afterwards still occupies a place in it, so a full window of held
+  // rows hides every short slice behind them — the same starvation the
+  // settled-row touch exists to prevent, arriving by a different route. The
+  // holds renew as they expire, so it does not clear on its own.
+  const sourceId = await seedSource();
+  await seedFreshTip(sourceId);
+  const sliceRetries: SliceRetrySchedule = new Map();
+  for (const [index, slice] of SETTLED_SLICES.entries()) {
+    sliceRetries.set(slice, NOW.getTime() + DAY_IN_MS);
+    // oxlint-disable-next-line no-await-in-loop -- fixture seeding, sequential on one pglite handle
+    await seedSlice({
+      sourceId,
+      slice,
+      reported: 2,
+      collected: 0,
+      // Oldest-checked, so these fill the window ahead of the one behind them.
+      checkedAt: addUtcDays(NOW, -10 - index),
+    });
+  }
+  await seedSlice({
+    sourceId,
+    slice: OWED_SLICE,
+    reported: 2,
+    collected: 0,
+    checkedAt: addUtcDays(NOW, -2),
+  });
+  expect(sliceRetries.size).toBe(SETTLED_SLICES.length);
+
+  expect(await runUnitWith({ sourceId, sliceRetries })).toMatchObject({
+    type: "worked",
+  });
+  expect(listed.map(({ slice }) => slice)).toEqual([OWED_SLICE]);
+});
+
 // ── Rechecking a settled slice ──────────────────────────
 
 /**

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
@@ -170,6 +170,28 @@ export type ReconciliationUnitOutcome =
   | { type: "idle" }
   | { type: "leased" };
 
+/**
+ * How long a slice whose walk threw is held out of the selection order.
+ *
+ * The walk writes nothing when it fails, so the slice is owed exactly as much
+ * afterwards as before and the selection would hand it back on the next turn
+ * forever. An hour is the trade: short against the tip's daily staleness, so a
+ * publisher that recovers is picked up within the same cadence the slice would
+ * have been walked on anyway, and long enough that a slice nothing can serve
+ * costs its source one turn an hour instead of one a minute.
+ */
+export const RECONCILIATION_SLICE_RETRY_MS = 60 * 60_000;
+
+/**
+ * When each slice whose walk threw may be tried again, by slice.
+ *
+ * Held by the caller, one map per source, for the same reason the loop holds
+ * its per-source failure deadlines: the state is about this process's recent
+ * attempts, not about the corpus, and a restart is entitled to try everything
+ * once more.
+ */
+export type SliceRetrySchedule = Map<string, number>;
+
 export type ReconciliationWorkUnitOptions = {
   adapterKey: string;
   sourceId: SafeId<"caseLawSource">;
@@ -179,6 +201,8 @@ export type ReconciliationWorkUnitOptions = {
   /** Gap between two document fetches; the loop's politeness contract. */
   fetchDelayMs: number;
   sleep: (ms: number) => Promise<void>;
+  /** Read and updated in place; see `SliceRetrySchedule`. */
+  sliceRetries: SliceRetrySchedule;
 };
 
 type KeyedListingItem = ReconciliationListingItem & {
@@ -885,6 +909,7 @@ export const runReconciliationWorkUnit = async ({
   reconciliation,
   scopedDb,
   sleep,
+  sliceRetries,
   sourceId,
 }: ReconciliationWorkUnitOptions): Promise<ReconciliationUnitOutcome> => {
   const startedAt = now();
@@ -953,6 +978,15 @@ export const runReconciliationWorkUnit = async ({
       ? tipStart
       : oldestLedgerSlice;
 
+  // Dropped as they come due rather than left to accumulate: the map is the
+  // process's memory of what it has just failed to walk, and an expired entry
+  // is a slice the selection is free to pick again.
+  for (const [slice, retryAtMs] of sliceRetries) {
+    if (retryAtMs <= startedAt.getTime()) {
+      sliceRetries.delete(slice);
+    }
+  }
+
   const unit = selectReconciliationWorkUnit({
     now: startedAt,
     hasDueParkedItems: dueParked,
@@ -963,6 +997,7 @@ export const runReconciliationWorkUnit = async ({
     unsettledShortSlices: unsettled,
     sweepSlice: reconciliation.previousSlice(frontier),
     recheckCandidate,
+    slicesHeldForRetry: new Set(sliceRetries.keys()),
     staleAfterMs: RECONCILIATION_SLICE_STALE_MS,
     recheckAfterMs: RECONCILIATION_SETTLED_RECHECK_MS,
   });
@@ -1009,6 +1044,25 @@ export const runReconciliationWorkUnit = async ({
             slice: unit.slice,
             sleep,
             sourceId,
+          }).catch((error: unknown) => {
+            // The walk is all-or-nothing by design: a listing that failed part
+            // way through writes no ledger row, so the slice is owed exactly
+            // as much as before and would be selected again immediately. Held
+            // for its retry instead, and named here because the loop's window
+            // tally reports how many turns threw without saying over what;
+            // the slice a source cannot walk is the one fact that turns a
+            // standing error rate into something an operator can reproduce.
+            sliceRetries.set(
+              unit.slice,
+              startedAt.getTime() + RECONCILIATION_SLICE_RETRY_MS,
+            );
+            logger.warn("case_law.reconciliation.slice_failed", {
+              adapterKey,
+              slice: unit.slice,
+              reason: unit.reason,
+              "error.type": errorTag(error),
+            });
+            throw error;
           }),
         };
       default: {

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
@@ -492,11 +492,23 @@ const selectStaleShortSlices = async (
  * `case_law_coverage_slices_source_slice_idx`; the short partial index is the
  * exact complement of this predicate and deliberately does not serve it.
  */
+type SelectRecheckCandidateOptions = {
+  sourceId: SafeId<"caseLawSource">;
+  /** The tip window's own start; slices at or above it are re-walked anyway. */
+  belowSlice: string;
+  /**
+   * Held slices, excluded here for the same reason the backlog query excludes
+   * them: this read is `LIMIT 1`, so a held row filtered afterwards is the
+   * whole candidate set and the source reports idle while a later settled row
+   * is due. Skipping one costs nothing, unlike the sweep — a settled slice
+   * keeps its ledger row and stays selectable on a later turn.
+   */
+  heldSlices: string[];
+};
+
 const selectRecheckCandidate = async (
   scopedDb: ScopedDb,
-  sourceId: SafeId<"caseLawSource">,
-  /** The tip window's own start; slices at or above it are re-walked anyway. */
-  belowSlice: string,
+  { belowSlice, heldSlices, sourceId }: SelectRecheckCandidateOptions,
 ): Promise<LedgerSlice | null> =>
   (
     await scopedDb(
@@ -517,6 +529,9 @@ const selectRecheckCandidate = async (
                 caseLawCoverageSlices.collected,
                 caseLawCoverageSlices.reported,
               ),
+              heldSlices.length === 0
+                ? undefined
+                : notInArray(caseLawCoverageSlices.slice, heldSlices),
             ),
           )
           .orderBy(caseLawCoverageSlices.checkedAt)
@@ -968,7 +983,11 @@ export const runReconciliationWorkUnit = async ({
       // empty: idle is the steady state of a surveyed source, so the branch
       // that skipped it would almost never be taken, and one more bounded read
       // in the batch already in flight costs no extra round trip.
-      selectRecheckCandidate(scopedDb, sourceId, tipStart),
+      selectRecheckCandidate(scopedDb, {
+        sourceId,
+        belowSlice: tipStart,
+        heldSlices,
+      }),
     ]);
 
   const terminalBySlice = await countTerminalReconciliationItemsBySlice(

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
@@ -25,7 +25,16 @@
 
 import { panic } from "better-result";
 import type { SQL } from "drizzle-orm";
-import { and, eq, gte, inArray, isNull, lt, min } from "drizzle-orm";
+import {
+  and,
+  eq,
+  gte,
+  inArray,
+  isNull,
+  lt,
+  min,
+  notInArray,
+} from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
@@ -410,14 +419,26 @@ const selectLedgerSlices = async (
   );
 };
 
+type SelectStaleShortSlicesOptions = {
+  sourceId: SafeId<"caseLawSource">;
+  staleBefore: Date;
+  /**
+   * Slices held for retry, excluded in the query rather than by the caller.
+   * The read is a bounded oldest-first window, so a held row filtered
+   * afterwards still occupies a place in it: enough of them fill the window
+   * and every short slice behind them becomes unreachable, which is the same
+   * starvation the settled-row touch exists to prevent.
+   */
+  heldSlices: string[];
+};
+
 /**
  * Slices the ledger records as short and has not re-checked recently, oldest
  * first. This is the first reader of the ledger's short-slice partial index.
  */
 const selectStaleShortSlices = async (
   scopedDb: ScopedDb,
-  sourceId: SafeId<"caseLawSource">,
-  staleBefore: Date,
+  { heldSlices, sourceId, staleBefore }: SelectStaleShortSlicesOptions,
 ): Promise<LedgerSlice[]> =>
   await scopedDb(
     async (tx) =>
@@ -435,6 +456,9 @@ const selectStaleShortSlices = async (
             lt(caseLawCoverageSlices.collected, caseLawCoverageSlices.reported),
             // eslint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- staleness cutoff derived from the clock, not a cursor boundary: a slice landing within a microsecond of it is walked one turn earlier or later, which the widening tip cadence already tolerates
             lt(caseLawCoverageSlices.checkedAt, staleBefore),
+            heldSlices.length === 0
+              ? undefined
+              : notInArray(caseLawCoverageSlices.slice, heldSlices),
           ),
         )
         .orderBy(caseLawCoverageSlices.checkedAt)
@@ -922,10 +946,22 @@ export const runReconciliationWorkUnit = async ({
   // cadence and needs neither.
   const tipStart = tipSlices.at(-1) ?? reconciliation.sliceOf(startedAt);
 
+  // Dropped as they come due rather than left to accumulate: the map is the
+  // process's memory of what it has just failed to walk, and an expired entry
+  // is a slice the selection is free to pick again. Before the reads, because
+  // the backlog query excludes the held ones and must not exclude a slice
+  // whose hold ended.
+  for (const [slice, retryAtMs] of sliceRetries) {
+    if (retryAtMs <= startedAt.getTime()) {
+      sliceRetries.delete(slice);
+    }
+  }
+  const heldSlices = [...sliceRetries.keys()];
+
   const [tipLedger, shortRows, oldestLedgerSlice, dueParked, recheckCandidate] =
     await Promise.all([
       selectLedgerSlices(scopedDb, sourceId, tipSlices),
-      selectStaleShortSlices(scopedDb, sourceId, staleBefore),
+      selectStaleShortSlices(scopedDb, { sourceId, staleBefore, heldSlices }),
       selectOldestLedgerSlice(scopedDb, sourceId),
       hasDueParkedItems(scopedDb, sourceId, startedAt),
       // Asked every turn rather than only once the higher priorities come up
@@ -978,15 +1014,6 @@ export const runReconciliationWorkUnit = async ({
       ? tipStart
       : oldestLedgerSlice;
 
-  // Dropped as they come due rather than left to accumulate: the map is the
-  // process's memory of what it has just failed to walk, and an expired entry
-  // is a slice the selection is free to pick again.
-  for (const [slice, retryAtMs] of sliceRetries) {
-    if (retryAtMs <= startedAt.getTime()) {
-      sliceRetries.delete(slice);
-    }
-  }
-
   const unit = selectReconciliationWorkUnit({
     now: startedAt,
     hasDueParkedItems: dueParked,
@@ -997,7 +1024,7 @@ export const runReconciliationWorkUnit = async ({
     unsettledShortSlices: unsettled,
     sweepSlice: reconciliation.previousSlice(frontier),
     recheckCandidate,
-    slicesHeldForRetry: new Set(sliceRetries.keys()),
+    slicesHeldForRetry: new Set(heldSlices),
     staleAfterMs: RECONCILIATION_SLICE_STALE_MS,
     recheckAfterMs: RECONCILIATION_SETTLED_RECHECK_MS,
   });
@@ -1052,9 +1079,13 @@ export const runReconciliationWorkUnit = async ({
             // tally reports how many turns threw without saying over what;
             // the slice a source cannot walk is the one fact that turns a
             // standing error rate into something an operator can reproduce.
+            // Measured from the failure, not from the unit's start: a slice
+            // is several paginated requests and a walk can spend most of the
+            // runner's deadline before it throws, which would leave the hold
+            // shorter than it says or already expired.
             sliceRetries.set(
               unit.slice,
-              startedAt.getTime() + RECONCILIATION_SLICE_RETRY_MS,
+              now().getTime() + RECONCILIATION_SLICE_RETRY_MS,
             );
             logger.warn("case_law.reconciliation.slice_failed", {
               adapterKey,

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.test.ts
@@ -56,6 +56,7 @@ const baseInput = (
   unsettledShortSlices: [],
   sweepSlice: null,
   recheckCandidate: null,
+  slicesHeldForRetry: new Set(),
   staleAfterMs: RECONCILIATION_SLICE_STALE_MS,
   recheckAfterMs: RECONCILIATION_SETTLED_RECHECK_MS,
   ...overrides,
@@ -385,6 +386,114 @@ describe("selectReconciliationWorkUnit", () => {
         reason,
       });
     }
+  });
+});
+
+describe("a slice held for retry", () => {
+  // A failed walk writes nothing, so every input this selection reads is
+  // unchanged by it. Without the hold the same slice comes back on the next
+  // turn and on every turn after it, and the source's other work — its tip,
+  // its backlog, its sweep — is never reached again. These assert the source
+  // keeps moving at each priority the hold can apply to.
+  const held = (slice: string) => ({ slicesHeldForRetry: new Set([slice]) });
+
+  test("a held tip slice yields to the rest of the tip window", () => {
+    expect(
+      selectReconciliationWorkUnit(
+        baseInput({
+          tipSlices: ["2026-08-11", "2026-08-10"],
+          ...held("2026-08-11"),
+        }),
+      ),
+    ).toEqual({
+      type: "slice",
+      slice: "2026-08-10",
+      reason: SLICE_WALK_REASON.TIP,
+    });
+  });
+
+  test("a tip window held end to end falls through to the backlog", () => {
+    expect(
+      selectReconciliationWorkUnit(
+        baseInput({
+          tipSlices: ["2026-08-11"],
+          unsettledShortSlices: [shortSlice({ slice: "2024-03-12" })],
+          sweepSlice: "2024-01-01",
+          ...held("2026-08-11"),
+        }),
+      ),
+    ).toEqual({
+      type: "slice",
+      slice: "2024-03-12",
+      reason: SLICE_WALK_REASON.SHORT,
+    });
+  });
+
+  test("a held backlog slice yields to the next one owed", () => {
+    // The backlog is read oldest-checked first and selection took the head,
+    // so one unwalkable row at the front stopped the whole queue.
+    expect(
+      selectReconciliationWorkUnit(
+        baseInput({
+          unsettledShortSlices: [
+            shortSlice({ slice: "2024-03-12" }),
+            shortSlice({ slice: "2024-05-02" }),
+          ],
+          ...held("2024-03-12"),
+        }),
+      ),
+    ).toEqual({
+      type: "slice",
+      slice: "2024-05-02",
+      reason: SLICE_WALK_REASON.SHORT,
+    });
+  });
+
+  test("a held sweep slice does not block the recheck behind it", () => {
+    expect(
+      selectReconciliationWorkUnit(
+        baseInput({
+          sweepSlice: "2023-06-01",
+          recheckCandidate: recheckCandidate(LONG_SETTLED),
+          ...held("2023-06-01"),
+        }),
+      ),
+    ).toMatchObject({ reason: SLICE_WALK_REASON.RECHECK });
+  });
+
+  test("a source whose every candidate is held reports idle, not the slice", () => {
+    // Idle is the honest answer: the loop's own pacing then backs the source
+    // off, where returning the slice again would spin it at the unit rate.
+    const recheck = recheckCandidate(LONG_SETTLED);
+    expect(
+      selectReconciliationWorkUnit(
+        baseInput({
+          tipSlices: ["2026-08-11"],
+          unsettledShortSlices: [shortSlice({ slice: "2024-03-12" })],
+          sweepSlice: "2024-01-01",
+          recheckCandidate: recheck,
+          slicesHeldForRetry: new Set([
+            "2026-08-11",
+            "2024-03-12",
+            "2024-01-01",
+            recheck.slice,
+          ]),
+        }),
+      ),
+    ).toEqual({ type: "idle" });
+  });
+
+  test("holding a slice never displaces work that outranks it", () => {
+    // The hold subtracts candidates; it must not reorder what is left.
+    expect(
+      selectReconciliationWorkUnit(
+        baseInput({
+          hasDueParkedItems: true,
+          tipSlices: ["2026-08-11"],
+          ...held("2026-08-11"),
+        }),
+      ),
+    ).toEqual({ type: "parked-retries" });
   });
 });
 

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.ts
@@ -194,6 +194,19 @@ export type SelectReconciliationWorkUnitInput = {
   /** The newest never-surveyed slice below the tip window, if any remain. */
   sweepSlice: string | null;
   /**
+   * Slices whose last walk threw and whose retry is not yet due.
+   *
+   * A walk that fails writes nothing, so nothing about the source's state
+   * changes and this selection would return the same slice on the next turn,
+   * and on every turn after it. One slice the publisher cannot serve would
+   * then hold every other slice the source owes, indefinitely: the tip stops
+   * being re-walked, the backlog stops draining and the sweep stops advancing,
+   * while the source still looks busy. Holding the failed slice out of the
+   * order until its retry comes due costs that slice its turns and nobody
+   * else's.
+   */
+  slicesHeldForRetry: ReadonlySet<string>;
+  /**
    * The oldest-checked settled slice below the tip window, if the source has
    * one. Which rows count as settled is the assembly's question, since only it
    * can read the ledger; whether this one is old enough to walk is decided
@@ -231,6 +244,7 @@ export const selectReconciliationWorkUnit = ({
   now,
   recheckAfterMs,
   recheckCandidate,
+  slicesHeldForRetry,
   staleAfterMs,
   sweepSlice,
   tipCheckedAt,
@@ -243,6 +257,9 @@ export const selectReconciliationWorkUnit = ({
 
   const staleBefore = now.getTime() - staleAfterMs;
   const dueTipSlices = tipSlices.filter((slice) => {
+    if (slicesHeldForRetry.has(slice)) {
+      return false;
+    }
     const checkedAt = tipCheckedAt.get(slice);
     return checkedAt === undefined || checkedAt.getTime() < staleBefore;
   });
@@ -271,7 +288,9 @@ export const selectReconciliationWorkUnit = ({
   // Already partitioned by the assembly, which had to look at settledness
   // anyway to know which rows to touch; re-deciding it here would be a second
   // copy of the rule free to drift from that one.
-  const owed = unsettledShortSlices.at(0);
+  const owed = unsettledShortSlices.find(
+    ({ slice }) => !slicesHeldForRetry.has(slice),
+  );
   if (owed !== undefined) {
     return {
       type: "slice",
@@ -280,7 +299,7 @@ export const selectReconciliationWorkUnit = ({
     };
   }
 
-  if (sweepSlice !== null) {
+  if (sweepSlice !== null && !slicesHeldForRetry.has(sweepSlice)) {
     return {
       type: "slice",
       slice: sweepSlice,
@@ -298,6 +317,7 @@ export const selectReconciliationWorkUnit = ({
   // without a database.
   if (
     recheckCandidate !== null &&
+    !slicesHeldForRetry.has(recheckCandidate.slice) &&
     recheckCandidate.checkedAt.getTime() < now.getTime() - recheckAfterMs
   ) {
     return {

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -38,6 +38,7 @@ import {
 } from "@/api/handlers/case-law/corpus-index";
 import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
 import { runIngestionPipeline } from "@/api/handlers/case-law/ingestion/pipeline";
+import type { SliceRetrySchedule } from "@/api/handlers/case-law/ingestion/reconciliation-engine";
 import { runReconciliationWorkUnit } from "@/api/handlers/case-law/ingestion/reconciliation-engine";
 import {
   readSourceReportedTotals,
@@ -1640,6 +1641,10 @@ export const runCaseLawIngest = async (
       }
       // oxlint-disable-next-line no-await-in-loop -- one bounded source lookup per configured source, at startup
       const source = await ensureSource(adapterKey, name, null);
+      // One schedule per source, living as long as this process: a slice whose
+      // walk threw is held out of that source's selection order until its
+      // retry comes due, so it cannot be handed back on every turn.
+      const sliceRetries: SliceRetrySchedule = new Map();
       reconcilable.push({
         adapterKey,
         runWorkUnit: async () => {
@@ -1657,6 +1662,7 @@ export const runCaseLawIngest = async (
                 sleep: async (ms) => {
                   await Bun.sleep(ms);
                 },
+                sliceRetries,
               }),
           );
           switch (outcome.type) {


### PR DESCRIPTION
## Proposed change

A reconciliation slice walk is all-or-nothing by design: a listing that fails part way through writes no ledger row, so the slice is owed exactly as much afterwards as before. `walkSlice` throws, `runReconciliationWorkUnit` lets the throw past (its only `finally` releases the lease), and nothing anywhere records that the attempt happened.

Every input `selectReconciliationWorkUnit` reads is therefore identical on the source's next turn, so it returns the same slice. And the turn after that. One slice a publisher will not serve holds the entire source: its tip stops being re-walked, its short-slice backlog stops draining, its sweep stops advancing, and the loop keeps counting turns and looks busy throughout. The loop's per-source failure backoff (#2064) does not help here, because it paces the retries rather than changing what is retried.

This is the same fixed-point problem the engine already solves for items. An item the publisher lists but never serves is parked on a widening schedule and finally retired, precisely so the hunt can end; a slice that cannot be walked had no equivalent and could pin its source indefinitely.

**The fix.** `selectReconciliationWorkUnit` takes `slicesHeldForRetry` and skips those slices at every priority it can apply to (tip, short, sweep, recheck), so the source keeps making progress on everything else. `runReconciliationWorkUnit` records the failed slice against a per-source retry deadline (`RECONCILIATION_SLICE_RETRY_MS`, one hour: short against the tip's daily staleness, long enough that an unservable slice costs one turn an hour instead of one a minute) and rethrows, leaving the loop's own error accounting exactly as it was.

The schedule lives with the caller, one `Map` per source, for the same reason the loop holds its per-source failure deadlines there: it records this process's recent attempts, not a fact about the corpus, so a restart is entitled to try everything once more.

**Observability.** A failed walk now logs `case_law.reconciliation.slice_failed` with `adapterKey`, `slice`, `reason` and the error tag, mirroring the existing `item_failed` line (tag only, no message, per the same reasoning the sweep summary renders a tag). The window summary can already say how many turns threw and which sources they belonged to; the slice is what turns that into something reproducible by hand.

**Tests.** Six cases in `reconciliation-plan.test.ts` covering each priority the hold applies to, plus that it subtracts candidates without reordering what is left and that a source with every candidate held reports `idle` rather than the slice. Reverting the plan hunk fails five of them. One case in `reconciliation-engine.db.test.ts` drives two turns against a publisher with one slice it will not serve and asserts the second turn walks the slice behind it; reverting the engine hunk fails it.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | `reconciliation-plan.test.ts` 32/32, `reconciliation-engine.db.test.ts` 11/11, `@stll/legal-atlas-runner` 87/87; `lint` and `typecheck` clean for `@stll/api` and `@stll/legal-atlas-runner`.
- [ ] DARK MODE SUPPORT | Not applicable: no user-facing surface.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable.

---
_Generated by [Claude Code](https://claude.ai/code/session_015nyxw4bgwGjiaZRttnzohD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Failed case-law reconciliation slices are now temporarily deferred and retried after a one-hour hold.
  - Deferred slices are excluded from processing until their retry time, preventing repeated immediate failures.
  - Other eligible reconciliation work continues in priority order, including lower-priority work when higher-priority slices are held.
  - Retry handling now applies consistently across tips, backlogs, sweeps and settled rechecks.
  - A failed slice no longer blocks subsequent reachable slices from being processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->