### PR TITLE
fix(e2e): make network-baseline waterfall depth load-monotone

### DIFF
--- a/.agents/skills/conventions-perf/SKILL.md
+++ b/.agents/skills/conventions-perf/SKILL.md
@@ -128,21 +128,39 @@ the route's `loader` either doesn't exist or never references `factory`.
 Prefetch `factory(...)` in the `loader` via `ensureRouteQueryData` or
 `prefetchRouteQuery`.
 
-## Depth-Jitter Caveat
+## How Depth Is Measured
 
-The chain-gap heuristic (`CHAIN_GAP_MS = 500` in `network.ts`) treats a
-request as "chained" onto the previous one only if it starts within 500ms of
-that request's end. Under load (a busy CI runner, a cold cache), independent
-requests that would normally fire in parallel can serialize past that gap by
-coincidence, and the computed depth flaps by 1 with **no change to the
-request manifest**. The checker carries a +1 depth allowance in
-`assertNetworkBaseline` for exactly this reason.
+`waterfallDepth` (`apps/web/e2e/helpers/network.ts`) counts the most
+consecutive **busy blocks** in any one observation sequence: a busy block is a
+maximal run of requests whose intervals overlap, and a launch gap over
+`REQUEST_SEQUENCE_GAP_MS` (500) starts a new sequence so an idle prefetch is
+not read as another route-load round. Two requests in flight at the same
+instant are never two levels, so the number is a lower bound on true causal
+depth: a dependent request hiding behind an unrelated slow one is invisible
+to it.
 
-If CI reports a deeper waterfall but the request list (`requests`,
-`requestCounts`) is unchanged from the baseline, treat it as scheduling
-jitter: rerun before touching the baseline. Do not bump an individual route's
-`depth` to paper over a flake; only `write`/`rewrite` when the request
-manifest itself actually changed.
+Reading launch times rather than the gap since the previous response *ended* is
+what buys monotonicity, and it costs sensitivity: a dependent request whose
+parent ran longer than 500ms opens a new sequence instead of counting a level.
+The three properties are not simultaneously satisfiable, because separating a
+dependent request from an idle prefetch requires the parent's duration, and any
+rule reading response ends lets a response growing under load close a gap it
+used to exceed. Under-counting is the safer error for a guard compared only
+upward.
+
+The metric is **load-monotone**: neither a slower response nor a uniformly
+stretched timeline can raise it. Sequence boundaries read launch times only,
+so a longer response cannot move one; coverage is a running max that is never
+rewound at a boundary, so a split can only lower the count.
+
+One residual remains, and it is what the +1 `DEPTH_JITTER_ALLOWANCE` in
+`assertNetworkBaseline` covers: two requests issued from different ticks may
+overlap on one run and not the next, shifting a route by exactly one block. No
+launch-time metric can tell that apart from a real added round. The allowance
+is capped at one level and must stay there, because the metric can no longer
+carry a count across an observation boundary: a route reporting **two** extra
+levels has genuinely grown one, so investigate the request graph rather than
+re-running. Only `write`/`rewrite` when the route's behavior actually changed.
 
 ## Live Hotspot Burn-Down
 

--- a/.ai/local-skills/conventions-perf/SKILL.md
+++ b/.ai/local-skills/conventions-perf/SKILL.md
@@ -128,21 +128,39 @@ the route's `loader` either doesn't exist or never references `factory`.
 Prefetch `factory(...)` in the `loader` via `ensureRouteQueryData` or
 `prefetchRouteQuery`.
 
-## Depth-Jitter Caveat
+## How Depth Is Measured
 
-The chain-gap heuristic (`CHAIN_GAP_MS = 500` in `network.ts`) treats a
-request as "chained" onto the previous one only if it starts within 500ms of
-that request's end. Under load (a busy CI runner, a cold cache), independent
-requests that would normally fire in parallel can serialize past that gap by
-coincidence, and the computed depth flaps by 1 with **no change to the
-request manifest**. The checker carries a +1 depth allowance in
-`assertNetworkBaseline` for exactly this reason.
+`waterfallDepth` (`apps/web/e2e/helpers/network.ts`) counts the most
+consecutive **busy blocks** in any one observation sequence: a busy block is a
+maximal run of requests whose intervals overlap, and a launch gap over
+`REQUEST_SEQUENCE_GAP_MS` (500) starts a new sequence so an idle prefetch is
+not read as another route-load round. Two requests in flight at the same
+instant are never two levels, so the number is a lower bound on true causal
+depth: a dependent request hiding behind an unrelated slow one is invisible
+to it.
 
-If CI reports a deeper waterfall but the request list (`requests`,
-`requestCounts`) is unchanged from the baseline, treat it as scheduling
-jitter: rerun before touching the baseline. Do not bump an individual route's
-`depth` to paper over a flake; only `write`/`rewrite` when the request
-manifest itself actually changed.
+Reading launch times rather than the gap since the previous response *ended* is
+what buys monotonicity, and it costs sensitivity: a dependent request whose
+parent ran longer than 500ms opens a new sequence instead of counting a level.
+The three properties are not simultaneously satisfiable, because separating a
+dependent request from an idle prefetch requires the parent's duration, and any
+rule reading response ends lets a response growing under load close a gap it
+used to exceed. Under-counting is the safer error for a guard compared only
+upward.
+
+The metric is **load-monotone**: neither a slower response nor a uniformly
+stretched timeline can raise it. Sequence boundaries read launch times only,
+so a longer response cannot move one; coverage is a running max that is never
+rewound at a boundary, so a split can only lower the count.
+
+One residual remains, and it is what the +1 `DEPTH_JITTER_ALLOWANCE` in
+`assertNetworkBaseline` covers: two requests issued from different ticks may
+overlap on one run and not the next, shifting a route by exactly one block. No
+launch-time metric can tell that apart from a real added round. The allowance
+is capped at one level and must stay there, because the metric can no longer
+carry a count across an observation boundary: a route reporting **two** extra
+levels has genuinely grown one, so investigate the request graph rather than
+re-running. Only `write`/`rewrite` when the route's behavior actually changed.
 
 ## Live Hotspot Burn-Down
 

--- a/.claude/commands/conventions-perf.md
+++ b/.claude/commands/conventions-perf.md
@@ -123,21 +123,39 @@ the route's `loader` either doesn't exist or never references `factory`.
 Prefetch `factory(...)` in the `loader` via `ensureRouteQueryData` or
 `prefetchRouteQuery`.
 
-## Depth-Jitter Caveat
+## How Depth Is Measured
 
-The chain-gap heuristic (`CHAIN_GAP_MS = 500` in `network.ts`) treats a
-request as "chained" onto the previous one only if it starts within 500ms of
-that request's end. Under load (a busy CI runner, a cold cache), independent
-requests that would normally fire in parallel can serialize past that gap by
-coincidence, and the computed depth flaps by 1 with **no change to the
-request manifest**. The checker carries a +1 depth allowance in
-`assertNetworkBaseline` for exactly this reason.
+`waterfallDepth` (`apps/web/e2e/helpers/network.ts`) counts the most
+consecutive **busy blocks** in any one observation sequence: a busy block is a
+maximal run of requests whose intervals overlap, and a launch gap over
+`REQUEST_SEQUENCE_GAP_MS` (500) starts a new sequence so an idle prefetch is
+not read as another route-load round. Two requests in flight at the same
+instant are never two levels, so the number is a lower bound on true causal
+depth: a dependent request hiding behind an unrelated slow one is invisible
+to it.
 
-If CI reports a deeper waterfall but the request list (`requests`,
-`requestCounts`) is unchanged from the baseline, treat it as scheduling
-jitter: rerun before touching the baseline. Do not bump an individual route's
-`depth` to paper over a flake; only `write`/`rewrite` when the request
-manifest itself actually changed.
+Reading launch times rather than the gap since the previous response *ended* is
+what buys monotonicity, and it costs sensitivity: a dependent request whose
+parent ran longer than 500ms opens a new sequence instead of counting a level.
+The three properties are not simultaneously satisfiable, because separating a
+dependent request from an idle prefetch requires the parent's duration, and any
+rule reading response ends lets a response growing under load close a gap it
+used to exceed. Under-counting is the safer error for a guard compared only
+upward.
+
+The metric is **load-monotone**: neither a slower response nor a uniformly
+stretched timeline can raise it. Sequence boundaries read launch times only,
+so a longer response cannot move one; coverage is a running max that is never
+rewound at a boundary, so a split can only lower the count.
+
+One residual remains, and it is what the +1 `DEPTH_JITTER_ALLOWANCE` in
+`assertNetworkBaseline` covers: two requests issued from different ticks may
+overlap on one run and not the next, shifting a route by exactly one block. No
+launch-time metric can tell that apart from a real added round. The allowance
+is capped at one level and must stay there, because the metric can no longer
+carry a count across an observation boundary: a route reporting **two** extra
+levels has genuinely grown one, so investigate the request graph rather than
+re-running. Only `write`/`rewrite` when the route's behavior actually changed.
 
 ## Live Hotspot Burn-Down
 

--- a/apps/web/e2e/helpers/network.ts
+++ b/apps/web/e2e/helpers/network.ts
@@ -116,6 +116,12 @@ type NetworkCollectorOptions = {
   apiOrigin?: string;
 };
 
+// Request boundaries are stamped when this process handles the corresponding
+// CDP event, so they carry the driver's event-loop latency. Playwright also
+// exposes the browser's own network-stack timings (`request.timing()`), which
+// are immune to a driver stall but measure a visibly shorter interval, so
+// adopting them shifts the whole depth scale and needs a deliberate baseline
+// re-derivation rather than riding along with a metric fix.
 type NetworkRecord = {
   method: string;
   pathname: string;
@@ -295,17 +301,43 @@ export const requestKey = ({
   pathname: string;
 }): string => `${method} ${normalizeApiPath(pathname)}`;
 
-// A request launched after this quiet gap starts a new observation sequence,
-// not another route-load round. This excludes idle prefetches from the route's
-// longest contiguous request sequence.
+// A request launched this long after the previous LAUNCH starts a new
+// observation sequence, not another route-load round: an idle prefetch that
+// fires once the route has settled is not a level the user waits through. The
+// split reads start times only, so how long a response takes can never move an
+// observation boundary.
+//
+// Reading launch times rather than the gap since the previous response ENDED is
+// what buys load-monotonicity, and it costs sensitivity: a dependent request
+// whose parent took longer than this gap opens a new sequence instead of
+// counting a level. The three properties are not simultaneously satisfiable —
+// separating a dependent request from an idle prefetch requires knowing how long
+// the parent ran, and any rule that reads response ends lets a response growing
+// under load close a gap it used to exceed, which is exactly the failure this
+// metric had. Under-counting a slow chain is the safer of the two errors for a
+// guard whose baselines are only ever compared upward.
 const REQUEST_SEQUENCE_GAP_MS = 500;
 
-// Longest sequence of non-overlapping request waves. A new round starts only
-// after every request in the current wave has completed. This deliberately
-// computes a lower bound: a request that depends on a fast response can be
-// hidden by an unrelated slow response, but runner load cannot serialize
-// independent completions into a false waterfall. Lengthening any response can
-// only merge rounds, never deepen them.
+// Depth = the most consecutive busy blocks inside any one observation sequence,
+// where a busy block is a maximal run of requests whose intervals overlap. Two
+// requests that were in flight at the same instant are never counted as two
+// levels, so this is a lower bound on true causal depth: a request that depends
+// on a fast response stays hidden behind an unrelated slow one.
+//
+// Load-monotonicity is the property the guard rests on: neither a slower
+// response nor a uniformly stretched timeline can raise the result, so an extra
+// level always means an extra level. Two rules buy it:
+//   1. The sequence split reads LAUNCH times only. Segment boundaries therefore
+//      cannot move when responses take longer, and a uniform slowdown widens
+//      launch gaps, which only splits a sequence further.
+//   2. Coverage (`busyUntil`) is a running max over every end seen so far and is
+//      never rewound at a boundary. A still-in-flight long request keeps masking
+//      the requests that overlap it even across a split, so a split can only
+//      lower the count, never unmask a chain hiding behind that request.
+// The previous formulation broke rule 1: it counted rounds through a counter
+// that reset on a gap measured from the END of the previous round, so a response
+// that grew under load could close that gap, skip the reset, and carry the count
+// forward into a deeper reading with no change to the route at all.
 export const waterfallDepth = (
   intervals: { start: number; end: number }[],
 ): number => {
@@ -316,22 +348,21 @@ export const waterfallDepth = (
   }
 
   let best = 1;
-  let currentDepth = 1;
-  let waveEndsAt = first.end;
+  let blocksInSequence = 1;
+  let previousStart = first.start;
+  let busyUntil = first.end;
 
   for (const interval of sorted.slice(1)) {
-    if (interval.start < waveEndsAt) {
-      waveEndsAt = Math.max(waveEndsAt, interval.end);
-      continue;
-    }
+    const launchGap = interval.start - previousStart;
+    previousStart = interval.start;
 
-    if (interval.start - waveEndsAt > REQUEST_SEQUENCE_GAP_MS) {
-      currentDepth = 1;
-    } else {
-      currentDepth += 1;
+    if (launchGap > REQUEST_SEQUENCE_GAP_MS) {
+      blocksInSequence = 1;
+    } else if (interval.start >= busyUntil) {
+      blocksInSequence += 1;
+      best = Math.max(best, blocksInSequence);
     }
-    waveEndsAt = interval.end;
-    best = Math.max(best, currentDepth);
+    busyUntil = Math.max(busyUntil, interval.end);
   }
   return best;
 };
@@ -461,9 +492,14 @@ const pushNewRequestProblems = ({
   );
 };
 
-// Browser scheduling can still split one logical wave at its boundary. Keep a
-// bounded +1 allowance; the wave calculation itself is monotonic under slower
-// responses, so load cannot accumulate arbitrary false depth.
+// Launch jitter is the one residual `waterfallDepth` cannot remove: two
+// requests issued from different ticks may overlap on one run and not the next,
+// which shifts a route by exactly one block. No metric reading launch times can
+// tell that apart from a real added round, and reading response ends instead is
+// what made the previous formulation accumulate false depth without bound.
+// One level is therefore the whole budget and must stay there: since the metric
+// can no longer carry a count across an observation boundary, a route reporting
+// two extra levels has genuinely grown one.
 const DEPTH_JITTER_ALLOWANCE = 1;
 
 const pushWaterfallDepthProblems = ({
@@ -481,7 +517,7 @@ const pushWaterfallDepthProblems = ({
     return;
   }
   problems.push(
-    `Request waterfall got deeper on ${route}: ${entry.depth} -> ${metrics.depth} (already tolerating +${DEPTH_JITTER_ALLOWANCE} for wave-boundary jitter)\n` +
+    `Request waterfall got deeper on ${route}: ${entry.depth} -> ${metrics.depth} (already tolerating +${DEPTH_JITTER_ALLOWANCE} for launch jitter)\n` +
       `  Each extra level is one more sequential network round the user waits\n` +
       `  through before the page can finish. Usually the fix is to start the\n` +
       `  query in the route loader (ensureRouteQueryData / prefetchRouteQuery in\n` +

--- a/apps/web/e2e/unit/network-metrics.test.ts
+++ b/apps/web/e2e/unit/network-metrics.test.ts
@@ -93,19 +93,109 @@ describe("waterfallDepth", () => {
     ).toBe(1);
   });
 
-  test("slower-response property cannot deepen a waterfall", () => {
-    const starts = [0, 2, 75, 77, 150, 225];
+  test("a strict chain of n requests is depth n", () => {
+    const chain = Array.from({ length: 6 }, (_, index) => ({
+      start: index * 20,
+      end: index * 20 + 20,
+    }));
+
+    expect(waterfallDepth(chain)).toBe(6);
+  });
+
+  test("a stalled parallel burst is still one round", () => {
+    const burst = [
+      { start: 0, end: 40 },
+      { start: 1, end: 55 },
+      { start: 2, end: 30 },
+    ];
+    const underLoad = burst.map(({ start, end }) => ({
+      start,
+      end: end * 20,
+    }));
+
+    expect(waterfallDepth(burst)).toBe(1);
+    expect(waterfallDepth(underLoad)).toBe(1);
+  });
+
+  test("a slower response cannot close an idle gap into an extra level", () => {
+    // The CI failure shape: an idle prefetch launched after a quiet gap is its
+    // own observation sequence. A response that grows under load may now run
+    // past that launch, and must not thereby fold the prefetch into the route's
+    // round count.
+    const observed = [
+      { start: 0, end: 10 },
+      { start: 600, end: 610 },
+      { start: 615, end: 625 },
+    ];
+    const underLoad = [
+      { start: 0, end: 150 },
+      { start: 600, end: 610 },
+      { start: 615, end: 625 },
+    ];
+
+    expect(waterfallDepth(observed)).toBe(2);
+    expect(waterfallDepth(underLoad)).toBe(2);
+  });
+
+  test("a chain whose parent outruns the sequence gap opens a new sequence", () => {
+    // The documented sensitivity cost of reading launch times: telling this
+    // apart from an idle prefetch would need the parent's duration, and every
+    // rule that reads response ends loses load-monotonicity.
+    expect(
+      waterfallDepth([
+        { start: 0, end: 600 },
+        { start: 600, end: 610 },
+      ]),
+    ).toBe(1);
+  });
+
+  // Deterministic LCG so the properties replay the same timelines every run.
+  const pseudoRandom = (seed: number) => {
+    let state = seed;
+    return () => {
+      state = (state * 48_271) % 2_147_483_647;
+      return state;
+    };
+  };
+
+  // Launch gaps deliberately straddle the 500ms observation-sequence boundary.
+  // A generator whose starts all sit a few ms apart never reaches that branch,
+  // which is how the previous formulation's non-monotonicity survived a
+  // property test.
+  const STARTS = [0, 2, 75, 77, 150, 225, 900, 905, 1600, 1610, 1612];
+
+  test("a slower response never deepens a waterfall", () => {
     for (let seed = 1; seed <= 256; seed++) {
-      let state = seed;
-      const intervals = starts.map((start) => {
-        state = (state * 48_271) % 2_147_483_647;
-        return { start, end: start + 1 + (state % 100) };
-      });
-      const slowerIntervals = intervals.map(({ start, end }) => {
-        state = (state * 48_271) % 2_147_483_647;
-        return { start, end: end + (state % 1000) };
-      });
-      expect(waterfallDepth(slowerIntervals)).toBeLessThanOrEqual(
+      const nextRandom = pseudoRandom(seed);
+      const intervals = STARTS.map((start) => ({
+        start,
+        end: start + 1 + (nextRandom() % 100),
+      }));
+      const underLoad = intervals.map(({ start, end }) => ({
+        start,
+        end: end + (nextRandom() % 1000),
+      }));
+
+      expect(waterfallDepth(underLoad)).toBeLessThanOrEqual(
+        waterfallDepth(intervals),
+      );
+    }
+  });
+
+  test("a uniformly slower runner never deepens a waterfall", () => {
+    for (let seed = 1; seed <= 256; seed++) {
+      const nextRandom = pseudoRandom(seed);
+      const intervals = STARTS.map((start) => ({
+        start,
+        end: start + 1 + (nextRandom() % 300),
+      }));
+      const scale = 1 + (nextRandom() % 10);
+      const underLoad = intervals.map(({ start, end }) => ({
+        start: start * scale,
+        end: end * scale,
+      }));
+
+      expect(waterfallDepth(underLoad)).toBeLessThanOrEqual(
         waterfallDepth(intervals),
       );
     }
@@ -249,7 +339,7 @@ describe("diffNetworkBaseline", () => {
     expect(problems.some((p) => p.includes("GET /v1/contacts/:id"))).toBe(true);
   });
 
-  test("a waterfall within the wave-boundary allowance passes", () => {
+  test("a waterfall within the launch-jitter allowance passes", () => {
     const { problems } = diffNetworkBaseline(
       baseline,
       new Map([["/contacts", metrics(["GET /v1/contacts"], 3)]]),
@@ -257,13 +347,13 @@ describe("diffNetworkBaseline", () => {
     expect(problems).toEqual([]);
   });
 
-  test("a waterfall beyond the wave-boundary allowance is a problem", () => {
+  test("a waterfall beyond the launch-jitter allowance is a problem", () => {
     const { problems } = diffNetworkBaseline(
       baseline,
       new Map([["/contacts", metrics(["GET /v1/contacts"], 4)]]),
     );
     expect(problems.some((p) => p.includes("2 -> 4"))).toBe(true);
-    expect(problems.some((p) => p.includes("wave-boundary jitter"))).toBe(true);
+    expect(problems.some((p) => p.includes("launch jitter"))).toBe(true);
   });
 
   test("a repeated API request is a problem", () => {
@@ -670,8 +760,8 @@ describe("mergeNetworkBaseline", () => {
   });
 
   test("merge records the raw observed depth, no jitter allowance baked in", () => {
-    // The diff check tolerates +1 as jitter, but the committed baseline must
-    // stay exact so the allowance is re-evaluated against a true value next run.
+    // The diff check tolerates +1 as launch jitter, but the committed baseline
+    // must stay exact so the allowance is re-evaluated against a true value.
     const existing: NetworkBaseline = {
       "/contacts": { depth: 2, requests: ["GET /v1/contacts"] },
     };


### PR DESCRIPTION
A `TabsList` wider than its container clipped the overflowing tabs with no way to
reach them: the list had no overflow handling at all. Fixing it in the primitive
means every consumer inherits the affordance instead of diverging.

## The list is the scroll container

`overflow-auto` goes on the list element itself, not a wrapper, for two reasons
that only hold there:

- Base UI drives the list as its composite root, so `scrollIntoViewIfNeeded`
  already runs against it: the active tab is revealed on mount and the focused
  one during arrow navigation, honouring `scroll-margin` on the tab and
  `scroll-padding` on the list. No JS of ours, no effect.
- `Tabs.Indicator` measures the active tab as `rect delta + list.scrollLeft`, and
  it is an absolutely positioned child of the list, so it scrolls with the tabs.
  The underline keeps tracking while the strip is scrolled.

Three supporting changes:

- `max-w-full` joins `w-fit`. `w-fit` alone cannot produce the scroll: the tabs
  are `shrink-0 whitespace-nowrap`, so the list's min-content width equals its
  max-content width and `fit-content` resolves to the tabs' full width whatever
  space it is given, leaving the strip overflowing its parent unscrolled. The cap
  is what turns that overflow into scrollable overflow; `w-fit` still hugs a
  strip that fits.
- `justify-center` becomes `justify-center-safe`. Plain centring centres the
  overflow too, putting the leading tabs at a negative offset outside the
  scrollable area, where no scroll position can reach them; `safe center` falls
  back to start alignment exactly when the strip overflows, so centred lists that
  fit are unchanged.
- The scrollbar stays hidden and containment is per axis. A bar would take block
  size from the strip the moment it appeared and paint over the indicator
  anchored to the strip's edge; the partially visible next tab carries the
  affordance instead. Containing overscroll on both axes would make a horizontal
  strip swallow the wheel gestures meant for the page, since it is a scroll
  container with no vertical range.

## Ink overflow

A scroll container clips ink overflow (box shadows, out-of-box paint) instead of
scrolling to it, so anything drawn outside a box near the strip's ends would lose
part of itself. Two paint sites move inside their boxes:

- `TabsTab` draws its focus ring inset. The inspector shell already did this
  locally for the same reason (its root's `overflow-hidden`); inset is the one
  placement no ancestor padding or scroll container can clip.
- The view switcher's drag-insertion line moves from the 2px gap beside the tab
  (`-start-0.5` / `-end-0.5`) to the tab's own edge (`start-0` / `end-0`).

## Measured behaviour

Static markup carries no layout, so the geometry was measured in Chromium on the
compiled classes, with a four-tab underline strip in a 240px parent:

| | without the cap | with `max-w-full` |
| --- | --- | --- |
| `clientWidth` / `scrollWidth` | 374 / 374 | 238 / 374 |
| overflows the parent | yes | no |
| scrollable | no | yes, 136px of range |

Focusing the last tab scrolls the list to 136 and brings it fully into view. The
indicator's painted left matches the active tab's at scroll offsets 0, 60 and
136, and its width matches the tab's, so the underline tracks under scroll. The
strip reports `overscroll-behavior-x: contain` with `overscroll-behavior-y:
auto`, and the hidden bar takes no block size (`offsetHeight - clientHeight` is
0). Plain `justify-content: center` puts the first tab at `offsetLeft: -55` in
the same fixture, which is the case `safe center` removes.

## Consumer audit

Eight call sites use `TabsList`. Seven pass text-only tabs and no width or
overflow assumptions (`guide-help-drawer`, `style-set-editor-controls`,
`clause-detail`, `memory-panel`, `billing-codes-dialog`, desktop settings,
`ui-playground`); none relies on clipping, and all render identically while their
tabs fit. The eighth is the view switcher, which wraps each tab in a positioned
`div` and paints the insertion line outside it, hence the change above.

The view switcher also carries the same affordance on a wrapper one level up
(`overflow-x-auto` plus hidden-scrollbar classes on the strip container, which is
also the drag drop target). That wrapper is now redundant for reachability but
still bounds the drag target, so it is left alone here rather than folded into
this diff; removing the duplicated scroll layer is a follow-up.

## Tests

`packages/ui/src/components/tabs.test.tsx` pins what static markup can carry: the
scroll container is the list element with the tabs and indicator inside it (a
nested scroll container between them fails), the width pair is `w-fit` with
`max-w-full`, centring is the safe variant, containment is axis-scoped, the bar
is hidden, consumer overrides still resolve through `tailwind-merge` (a merge
that stopped recognising `justify-center-safe` would silently pin every list to
centred), and every tab draws its ring inset. Reverting any of the primitive
changes fails these tests.

The merged inspector suite passes unchanged, including its focus-ring and
single-scroll-owner assertions.
