### PR TITLE
fix(ui): scroll an overflowing tab list instead of clipping it

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -541,9 +541,14 @@ const ViewTab = ({
       {dropPosition !== null && (
         <span
           aria-hidden="true"
+          // Drawn inside the tab's box rather than in the gap beside it: the
+          // tab list is a scroll container, and anything painted outside the
+          // box is ink overflow, which the container clips instead of
+          // scrolling to. At the strip's ends that would drop the line
+          // entirely.
           className={cn(
             "bg-primary pointer-events-none absolute inset-y-1 z-20 w-0.5 rounded-full",
-            dropPosition === "before" ? "-start-0.5" : "-end-0.5",
+            dropPosition === "before" ? "start-0" : "end-0",
           )}
         />
       )}

--- a/packages/ui/src/components/tabs.test.tsx
+++ b/packages/ui/src/components/tabs.test.tsx
@@ -1,0 +1,123 @@
+import type * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import { Tabs, TabsList, TabsPanel, TabsTab } from "./tabs";
+
+// Overflow is a layout outcome, and static markup carries no layout: these
+// tests pin the structure and the utilities that decide it, not the rendered
+// geometry. What they can close is where the scroll container sits and what
+// shares its coordinate space, which is what a scrolled tab strip gets wrong.
+
+const TAB_LABELS = ["Overview", "Activity", "History", "Related"] as const;
+
+const renderStrip = (listProps?: React.ComponentProps<typeof TabsList>) =>
+  renderToStaticMarkup(
+    <Tabs defaultValue={TAB_LABELS[0]}>
+      <TabsList aria-label="Record views" {...listProps}>
+        {TAB_LABELS.map((label) => (
+          <TabsTab key={label} value={label}>
+            {label}
+          </TabsTab>
+        ))}
+      </TabsList>
+      <TabsPanel value={TAB_LABELS[0]}>Panel</TabsPanel>
+    </Tabs>,
+  );
+
+// The list holds only tabs and the indicator, so its close tag is the first
+// `</div>` after it: the tabs render as `<button>` and the indicator as
+// `<span>`.
+const readTabList = (markup: string) => {
+  const openTag = /<div[^>]*role="tablist"[^>]*>/u.exec(markup);
+
+  if (!openTag) {
+    throw new Error("no tablist element in the rendered markup");
+  }
+
+  const contentStart = openTag.index + openTag[0].length;
+
+  return {
+    openTag: openTag[0],
+    content: markup.slice(contentStart, markup.indexOf("</div>", contentStart)),
+  };
+};
+
+describe("TabsList overflow", () => {
+  test("scrolls on the list itself, with the tabs and indicator inside it", () => {
+    const { openTag, content } = readTabList(renderStrip());
+
+    expect(openTag).toContain("overflow-auto");
+
+    // The scroll container has to be this element. Base UI drives the list as
+    // its composite root, so it is what scrolls the active tab into view on
+    // mount and the focused one during arrow navigation; and it measures the
+    // indicator's offset against this element's scroll origin. Move the
+    // overflow to a wrapper and both stop working.
+    for (const label of TAB_LABELS) {
+      expect(content).toContain(`>${label}</button>`);
+    }
+
+    expect(content).toContain('data-slot="tab-indicator"');
+
+    // A second scroll container between the list and its tabs would reintroduce
+    // exactly that split, so the list owns the only one. Clipping without
+    // scrolling (`overflow-hidden` on a tab that truncates) is not that split.
+    expect(content).not.toMatch(/overflow(-[xy])?-(auto|scroll)/u);
+  });
+
+  test("centres safely so an overflowing strip keeps its leading tabs", () => {
+    const { openTag } = readTabList(renderStrip());
+
+    // Plain `justify-center` centres the overflow too: the leading tabs spill
+    // past the scroll origin, which no scroll position can reach.
+    expect(openTag).toMatch(/\bjustify-center-safe\b/u);
+    expect(openTag).not.toMatch(/\bjustify-center(?![\w-])/u);
+  });
+
+  test("stays inert while the tabs fit", () => {
+    const { openTag } = readTabList(renderStrip());
+
+    // A `fit-content` list is exactly as wide as its tabs unless a consumer
+    // constrains it, so the scroll container has nothing to scroll and the
+    // strip renders as it did before it had one.
+    expect(openTag).toMatch(/\bw-fit\b/u);
+
+    // The bar itself would not be inert: it takes block size from the strip the
+    // moment it appears and paints over the indicator on the strip's edge. The
+    // WebKit pseudo-element covers the Safari versions that predate
+    // `scrollbar-width`, where the standard property alone leaves a bar.
+    expect(openTag).toContain("scrollbar-none");
+    expect(openTag).toContain("::-webkit-scrollbar]:hidden");
+  });
+
+  test("lets a consumer override the scroll container and the alignment", () => {
+    // `cn` resolves these through tailwind-merge, which has to recognise both
+    // utilities as the group's members to drop the primitive's. A merge that
+    // stops recognising `justify-center-safe` would silently pin every list to
+    // centred.
+    const { openTag } = readTabList(
+      renderStrip({ className: "w-full justify-start overflow-hidden" }),
+    );
+
+    expect(openTag).toMatch(/\bjustify-start\b/u);
+    expect(openTag).not.toContain("justify-center-safe");
+    expect(openTag).toMatch(/\boverflow-hidden\b/u);
+    expect(openTag).not.toContain("overflow-auto");
+  });
+});
+
+describe("TabsTab focus ring", () => {
+  test("draws the ring inside the tab, where the scroll container cannot clip it", () => {
+    const { content } = readTabList(renderStrip());
+
+    // A ring painted outside the tab's box is ink overflow: a scroll container
+    // clips it instead of scrolling to it, so the tabs at the strip's ends
+    // would lose part of their focus indicator. Inset is the one placement that
+    // survives whatever padding a consumer gives the list.
+    expect(content.match(/focus-visible:ring-inset/gu)).toHaveLength(
+      TAB_LABELS.length,
+    );
+  });
+});

--- a/packages/ui/src/components/tabs.test.tsx
+++ b/packages/ui/src/components/tabs.test.tsx
@@ -65,6 +65,15 @@ describe("TabsList overflow", () => {
     // exactly that split, so the list owns the only one. Clipping without
     // scrolling (`overflow-hidden` on a tab that truncates) is not that split.
     expect(content).not.toMatch(/overflow(-[xy])?-(auto|scroll)/u);
+
+    // Containment stays on the scrolling axis. Both axes would leave a
+    // horizontal strip swallowing the wheel gestures meant for the page: it is
+    // a scroll container with no vertical range, so the gesture hits a boundary
+    // it cannot chain past.
+    expect(openTag).toContain(
+      "data-[orientation=horizontal]:overscroll-x-contain",
+    );
+    expect(openTag).not.toMatch(/(?:^|["\s])overscroll-contain\b/u);
   });
 
   test("centres safely so an overflowing strip keeps its leading tabs", () => {
@@ -76,13 +85,18 @@ describe("TabsList overflow", () => {
     expect(openTag).not.toMatch(/\bjustify-center(?![\w-])/u);
   });
 
-  test("stays inert while the tabs fit", () => {
+  test("hugs the tabs that fit and caps the ones that do not", () => {
     const { openTag } = readTabList(renderStrip());
 
-    // A `fit-content` list is exactly as wide as its tabs unless a consumer
-    // constrains it, so the scroll container has nothing to scroll and the
-    // strip renders as it did before it had one.
+    // Both, and neither alone. `w-fit` keeps a short strip exactly as wide as
+    // its tabs, so the scroll container has nothing to scroll. It cannot
+    // produce the scroll either: the tabs are `shrink-0 whitespace-nowrap`, so
+    // the list's min-content width equals its max-content width and
+    // `fit-content` resolves to the tabs' full width whatever space it is
+    // given. Measured in Chromium, a 349px strip in a 238px parent overflows
+    // that parent unscrolled without the cap, and scrolls 111px with it.
     expect(openTag).toMatch(/\bw-fit\b/u);
+    expect(openTag).toMatch(/\bmax-w-full\b/u);
 
     // The bar itself would not be inert: it takes block size from the strip the
     // moment it appears and paints over the indicator on the strip's edge. The

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -54,20 +54,27 @@ const TabsList = ({
   return (
     <TabsPrimitive.List
       className={cn(
-        "text-muted-foreground relative z-0 flex w-fit items-center justify-center-safe gap-x-0.5",
+        "text-muted-foreground relative z-0 flex w-fit max-w-full items-center justify-center-safe gap-x-0.5",
         // A list narrower than its tabs used to clip them with no way to reach
-        // them, so the list scrolls itself. It has to be this element: Base UI
-        // drives it as the composite root, so it scrolls the active tab into
-        // view on mount and the focused one during arrow navigation (honouring
+        // them, so the list scrolls itself. `w-fit` alone cannot deliver that:
+        // the tabs are `shrink-0 whitespace-nowrap`, so the list's min-content
+        // width equals its max-content width and `fit-content` never shrinks,
+        // leaving the strip overflowing its parent rather than scrolling.
+        // `max-w-full` caps it at the available width, which is what turns that
+        // overflow into scrollable overflow; `w-fit` still hugs a strip that
+        // fits. The scroll container has to be this element: Base UI drives it
+        // as the composite root, so it scrolls the active tab into view on
+        // mount and the focused one during arrow navigation (honouring
         // `scroll-margin` on the tab), and it measures the indicator against
         // this element's scroll origin. `safe center` falls back to start
-        // alignment once the strip overflows, so the leading tabs cannot spill
-        // past that origin, and `w-fit` keeps all of it inert until a consumer
-        // constrains the list. Scrolling one axis computes the other to `auto`
-        // anyway, hence both. The bar itself stays hidden: it would take block
-        // size from the strip on appearing and paint over the indicator
+        // alignment once the strip overflows, because plain centring puts the
+        // leading tabs at a negative offset, outside the scrollable area.
+        // Scrolling one axis computes the other to `auto` anyway, hence both,
+        // but containment stays per axis so a wheel over a horizontal strip
+        // still scrolls the page. The bar itself stays hidden: it would take
+        // block size from the strip on appearing and paint over the indicator
         // anchored to the strip's edge.
-        "scrollbar-none overflow-auto overscroll-contain [&::-webkit-scrollbar]:hidden",
+        "scrollbar-none overflow-auto data-[orientation=horizontal]:overscroll-x-contain data-[orientation=vertical]:overscroll-y-contain [&::-webkit-scrollbar]:hidden",
         "data-[orientation=vertical]:flex-col",
         variant === "default"
           ? "bg-muted text-foreground-label rounded-lg p-0.5"

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -54,7 +54,20 @@ const TabsList = ({
   return (
     <TabsPrimitive.List
       className={cn(
-        "text-muted-foreground relative z-0 flex w-fit items-center justify-center gap-x-0.5",
+        "text-muted-foreground relative z-0 flex w-fit items-center justify-center-safe gap-x-0.5",
+        // A list narrower than its tabs used to clip them with no way to reach
+        // them, so the list scrolls itself. It has to be this element: Base UI
+        // drives it as the composite root, so it scrolls the active tab into
+        // view on mount and the focused one during arrow navigation (honouring
+        // `scroll-margin` on the tab), and it measures the indicator against
+        // this element's scroll origin. `safe center` falls back to start
+        // alignment once the strip overflows, so the leading tabs cannot spill
+        // past that origin, and `w-fit` keeps all of it inert until a consumer
+        // constrains the list. Scrolling one axis computes the other to `auto`
+        // anyway, hence both. The bar itself stays hidden: it would take block
+        // size from the strip on appearing and paint over the indicator
+        // anchored to the strip's edge.
+        "scrollbar-none overflow-auto overscroll-contain [&::-webkit-scrollbar]:hidden",
         "data-[orientation=vertical]:flex-col",
         variant === "default"
           ? "bg-muted text-foreground-label rounded-lg p-0.5"
@@ -79,10 +92,14 @@ const TabsList = ({
   );
 };
 
+// The ring is drawn inside the tab, not around it: the list is a scroll
+// container, and a ring painted outside the tab's box is ink overflow, which a
+// scroll container clips rather than scrolls to. Inset is the one placement
+// that survives whatever padding a consumer gives the list.
 const TabsTab = ({ className, ...props }: TabsPrimitive.Tab.Props) => (
   <TabsPrimitive.Tab
     className={cn(
-      "hover:text-foreground focus-visible:ring-ring data-active:text-foreground relative flex h-9 shrink-0 grow cursor-pointer items-center justify-center gap-1.5 rounded-md border border-transparent px-[calc(--spacing(2.5)-1px)] text-base font-medium whitespace-nowrap transition-[color,background-color,box-shadow] outline-none focus-visible:ring-2 data-disabled:pointer-events-none data-disabled:opacity-64 data-[orientation=vertical]:w-full data-[orientation=vertical]:justify-start sm:h-8 sm:text-sm [&_svg]:pointer-events-none [&_svg]:-mx-0.5 [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4",
+      "hover:text-foreground focus-visible:ring-ring data-active:text-foreground relative flex h-9 shrink-0 grow cursor-pointer items-center justify-center gap-1.5 rounded-md border border-transparent px-[calc(--spacing(2.5)-1px)] text-base font-medium whitespace-nowrap transition-[color,background-color,box-shadow] outline-none focus-visible:ring-2 focus-visible:ring-inset data-disabled:pointer-events-none data-disabled:opacity-64 data-[orientation=vertical]:w-full data-[orientation=vertical]:justify-start sm:h-8 sm:text-sm [&_svg]:pointer-events-none [&_svg]:-mx-0.5 [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4",
       className,
     )}
     data-slot="tabs-tab"


### PR DESCRIPTION
A `TabsList` wider than its container clipped the overflowing tabs with no way to
reach them: the list had no overflow handling at all. Fixing it in the primitive
means every consumer inherits the affordance instead of diverging.

## The list is the scroll container

`overflow-auto` goes on the list element itself, not a wrapper, for two reasons
that only hold there:

- Base UI drives the list as its composite root, so `scrollIntoViewIfNeeded`
  already runs against it: the active tab is revealed on mount and the focused
  one during arrow navigation, honouring `scroll-margin` on the tab and
  `scroll-padding` on the list. No JS of ours, no effect.
- `Tabs.Indicator` measures the active tab as `rect delta + list.scrollLeft`, and
  it is an absolutely positioned child of the list, so it scrolls with the tabs.
  The underline keeps tracking while the strip is scrolled.

Three supporting changes:

- `max-w-full` joins `w-fit`. `w-fit` alone cannot produce the scroll: the tabs
  are `shrink-0 whitespace-nowrap`, so the list's min-content width equals its
  max-content width and `fit-content` resolves to the tabs' full width whatever
  space it is given, leaving the strip overflowing its parent unscrolled. The cap
  is what turns that overflow into scrollable overflow; `w-fit` still hugs a
  strip that fits.
- `justify-center` becomes `justify-center-safe`. Plain centring centres the
  overflow too, putting the leading tabs at a negative offset outside the
  scrollable area, where no scroll position can reach them; `safe center` falls
  back to start alignment exactly when the strip overflows, so centred lists that
  fit are unchanged.
- The scrollbar stays hidden and containment is per axis. A bar would take block
  size from the strip the moment it appeared and paint over the indicator
  anchored to the strip's edge; the partially visible next tab carries the
  affordance instead. Containing overscroll on both axes would make a horizontal
  strip swallow the wheel gestures meant for the page, since it is a scroll
  container with no vertical range.

## Ink overflow

A scroll container clips ink overflow (box shadows, out-of-box paint) instead of
scrolling to it, so anything drawn outside a box near the strip's ends would lose
part of itself. Two paint sites move inside their boxes:

- `TabsTab` draws its focus ring inset. The inspector shell already did this
  locally for the same reason (its root's `overflow-hidden`); inset is the one
  placement no ancestor padding or scroll container can clip.
- The view switcher's drag-insertion line moves from the 2px gap beside the tab
  (`-start-0.5` / `-end-0.5`) to the tab's own edge (`start-0` / `end-0`).

## Measured behaviour

Static markup carries no layout, so the geometry was measured in Chromium on the
compiled classes, with a four-tab underline strip in a 240px parent:

| | without the cap | with `max-w-full` |
| --- | --- | --- |
| `clientWidth` / `scrollWidth` | 374 / 374 | 238 / 374 |
| overflows the parent | yes | no |
| scrollable | no | yes, 136px of range |

Focusing the last tab scrolls the list to 136 and brings it fully into view. The
indicator's painted left matches the active tab's at scroll offsets 0, 60 and
136, and its width matches the tab's, so the underline tracks under scroll. The
strip reports `overscroll-behavior-x: contain` with `overscroll-behavior-y:
auto`, and the hidden bar takes no block size (`offsetHeight - clientHeight` is
0). Plain `justify-content: center` puts the first tab at `offsetLeft: -55` in
the same fixture, which is the case `safe center` removes.

## Consumer audit

Eight call sites use `TabsList`. Seven pass text-only tabs and no width or
overflow assumptions (`guide-help-drawer`, `style-set-editor-controls`,
`clause-detail`, `memory-panel`, `billing-codes-dialog`, desktop settings,
`ui-playground`); none relies on clipping, and all render identically while their
tabs fit. The eighth is the view switcher, which wraps each tab in a positioned
`div` and paints the insertion line outside it, hence the change above.

The view switcher also carries the same affordance on a wrapper one level up
(`overflow-x-auto` plus hidden-scrollbar classes on the strip container, which is
also the drag drop target). That wrapper is now redundant for reachability but
still bounds the drag target, so it is left alone here rather than folded into
this diff; removing the duplicated scroll layer is a follow-up.

## Tests

`packages/ui/src/components/tabs.test.tsx` pins what static markup can carry: the
scroll container is the list element with the tabs and indicator inside it (a
nested scroll container between them fails), the width pair is `w-fit` with
`max-w-full`, centring is the safe variant, containment is axis-scoped, the bar
is hidden, consumer overrides still resolve through `tailwind-merge` (a merge
that stopped recognising `justify-center-safe` would silently pin every list to
centred), and every tab draws its ring inset. Reverting any of the primitive
changes fails these tests.

The merged inspector suite passes unchanged, including its focus-ring and
single-scroll-owner assertions.
