### PR TITLE
fix(api): citation polarity and citation-kind engine correctness

### DIFF
--- a/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
@@ -300,6 +300,22 @@ describe("rule precedence", () => {
     expect(forward).toEqual(reversed);
   });
 
+  test("a rule carrying a pipeline-only polarity never matches", () => {
+    // The CHECK constraint accepts `unknown` on a rule row, so this is
+    // reachable from a hand-written insert. It must not become a match: the
+    // citation would be labelled "classification did not happen" when the
+    // regex tier had in fact just classified it.
+    const rules = compileRules([
+      rule({ pattern: "viz", polarity: POLARITY.UNKNOWN }),
+      rule({ pattern: "viz", polarity: POLARITY.SUPPORTIVE }),
+    ]);
+
+    expect(rules).toHaveLength(1);
+    expect(selectRuleMatch(rules, "viz nález")?.polarity).toBe(
+      POLARITY.SUPPORTIVE,
+    );
+  });
+
   test("a rule that does not compile is dropped, not fatal", () => {
     const rules = compileRules([
       rule({ pattern: "(unclosed", polarity: POLARITY.NEGATIVE }),

--- a/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  CLASSIFIABLE_POLARITIES,
   isValidPolarity,
   phraseToPattern,
+  POLARITIES,
+  POLARITY,
+  POLARITY_PRECEDENCE,
 } from "@/api/handlers/case-law/polarity/consts";
+import type { Polarity } from "@/api/handlers/case-law/polarity/consts";
 import { extractContext } from "@/api/handlers/case-law/polarity/context";
+import {
+  compileRules,
+  selectRuleMatch,
+} from "@/api/handlers/case-law/polarity/rule-engine";
 import { SEED_RULES } from "@/api/handlers/case-law/polarity/seed-rules";
+import { createSafeId } from "@/api/lib/branded-types";
 
 describe("extractContext", () => {
   const sections = [
@@ -163,5 +173,160 @@ describe("seed rules", () => {
     const languages = [...new Set(SEED_RULES.map((r) => r.language))];
     expect(languages).toContain("cs");
     expect(languages).toContain("sk");
+  });
+});
+
+describe("the classifier codomain is one list", () => {
+  test("every polarity but the pipeline's own is classifiable", () => {
+    expect([...CLASSIFIABLE_POLARITIES]).toEqual(
+      POLARITIES.filter((polarity) => polarity !== POLARITY.UNKNOWN),
+    );
+  });
+
+  test("`unknown` is not something a classifier may emit", () => {
+    // It records that classification did not happen. A model returning it
+    // would be claiming the pipeline failed, which is not its to say.
+    expect([...CLASSIFIABLE_POLARITIES]).not.toContain(POLARITY.UNKNOWN);
+  });
+
+  test("both tiers label with the same set", () => {
+    // The drift this pins: the rule table has always emitted `supportive`
+    // (`srov.`, `viz`, `obdobně`), while the LLM schema offered only
+    // positive/neutral/negative, so the same phrase was labelled one way by
+    // a regex rule and another by the model. Declared set equals exercised
+    // set, in both directions.
+    const seeded = new Set<Polarity>(SEED_RULES.map((rule) => rule.polarity));
+
+    expect([...seeded].toSorted()).toEqual(
+      [...CLASSIFIABLE_POLARITIES].toSorted(),
+    );
+  });
+
+  test("precedence covers every polarity", () => {
+    expect(Object.keys(POLARITY_PRECEDENCE).toSorted()).toEqual(
+      [...POLARITIES].toSorted(),
+    );
+  });
+});
+
+describe("rule precedence", () => {
+  const rule = ({
+    pattern,
+    polarity,
+  }: {
+    pattern: string;
+    polarity: Polarity;
+  }) => ({
+    id: createSafeId<"caseLawPolarityRule">(),
+    pattern,
+    polarity,
+    confidence: 1,
+  });
+
+  test("a rare specific negative rule beats a popular generic positive one", () => {
+    // The rows are listed the way the old `ORDER BY match_count DESC` query
+    // returned them: the busy generic rule first. It used to win by arriving
+    // first, and every win raised its count further, so a negative rule that
+    // fired rarely could never overtake it. Nothing in the engine reads
+    // `match_count` any more, which is why this input cannot even express
+    // "popular" and the negative rule wins on severity alone.
+    const rules = compileRules([
+      rule({ pattern: "odkazuje\\s+na", polarity: POLARITY.POSITIVE }),
+      rule({ pattern: "na\\s+rozdíl\\s+od", polarity: POLARITY.NEGATIVE }),
+    ]);
+
+    const match = selectRuleMatch(
+      rules,
+      "Na rozdíl od věci sp. zn. 21 Cdo 1234/2020, na kterou žalobce " +
+        "odkazuje na podporu svého názoru, jde zde o jiný skutkový základ.",
+    );
+
+    expect(match?.polarity).toBe(POLARITY.NEGATIVE);
+  });
+
+  test("supportive does not outrank negative either", () => {
+    const rules = compileRules([
+      rule({ pattern: "srov\\.", polarity: POLARITY.SUPPORTIVE }),
+      rule({ pattern: "překonán[aouy]?", polarity: POLARITY.NEGATIVE }),
+    ]);
+
+    const match = selectRuleMatch(
+      rules,
+      "Tento závěr byl překonán; srov. rozsudek velkého senátu.",
+    );
+
+    expect(match?.polarity).toBe(POLARITY.NEGATIVE);
+  });
+
+  test("the more specific pattern wins within one severity", () => {
+    const rules = compileRules([
+      rule({ pattern: "viz", polarity: POLARITY.SUPPORTIVE }),
+      rule({
+        pattern: "viz\\s+rozsudek\\s+Nejvyššího",
+        polarity: POLARITY.SUPPORTIVE,
+      }),
+    ]);
+
+    expect(rules.at(0)?.pattern).toBe("viz\\s+rozsudek\\s+Nejvyššího");
+  });
+
+  test("neutral loses to positive", () => {
+    const rules = compileRules([
+      rule({ pattern: "proti\\s+rozsudku", polarity: POLARITY.NEUTRAL }),
+      rule({ pattern: "v\\s+souladu\\s+s", polarity: POLARITY.POSITIVE }),
+    ]);
+
+    const match = selectRuleMatch(
+      rules,
+      "V souladu s citovaným rozhodnutím, proti rozsudku odvolacího soudu.",
+    );
+
+    expect(match?.polarity).toBe(POLARITY.POSITIVE);
+  });
+
+  test("the order does not depend on the order rows arrived in", () => {
+    const rows = [
+      rule({ pattern: "aaa", polarity: POLARITY.NEUTRAL }),
+      rule({ pattern: "bbbb", polarity: POLARITY.NEUTRAL }),
+      rule({ pattern: "cc", polarity: POLARITY.NEGATIVE }),
+      rule({ pattern: "dddd", polarity: POLARITY.POSITIVE }),
+    ];
+
+    const forward = compileRules(rows).map((compiled) => compiled.id);
+    const reversed = compileRules([...rows].toReversed()).map(
+      (compiled) => compiled.id,
+    );
+
+    expect(forward).toEqual(reversed);
+  });
+
+  test("a rule that does not compile is dropped, not fatal", () => {
+    const rules = compileRules([
+      rule({ pattern: "(unclosed", polarity: POLARITY.NEGATIVE }),
+      rule({ pattern: "viz", polarity: POLARITY.SUPPORTIVE }),
+    ]);
+
+    expect(rules.map((compiled) => compiled.pattern)).toEqual(["viz"]);
+  });
+
+  test("a match carries the rule's stored confidence", () => {
+    const rules = compileRules([
+      {
+        id: createSafeId<"caseLawPolarityRule">(),
+        pattern: "viz",
+        polarity: POLARITY.SUPPORTIVE,
+        confidence: 0.8,
+      },
+    ]);
+
+    expect(selectRuleMatch(rules, "viz nález")?.confidence).toBe(0.8);
+  });
+
+  test("no match returns null", () => {
+    const rules = compileRules([
+      rule({ pattern: "viz", polarity: POLARITY.SUPPORTIVE }),
+    ]);
+
+    expect(selectRuleMatch(rules, "nothing to see here")).toBeNull();
   });
 });

--- a/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
@@ -317,6 +317,9 @@ describe("rule precedence", () => {
   });
 
   test("a rule that does not compile is dropped, not fatal", () => {
+    // Dropped, and reported: such a row can never fire, yet it still takes a
+    // slot in its tier's budget, so leaving it invisible subtracts from the
+    // working set forever.
     const rules = compileRules([
       rule({ pattern: "(unclosed", polarity: POLARITY.NEGATIVE }),
       rule({ pattern: "viz", polarity: POLARITY.SUPPORTIVE }),

--- a/apps/api/src/handlers/case-law/__tests__/polarity-rule-order.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/polarity-rule-order.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { lte } from "drizzle-orm";
 import { QueryBuilder } from "drizzle-orm/pg-core";
 
-import { CLASSIFIABLE_POLARITIES } from "@/api/handlers/case-law/polarity/consts";
+import {
+  CLASSIFIABLE_POLARITIES,
+  POLARITY,
+} from "@/api/handlers/case-law/polarity/consts";
 import {
   rankPolarityRulesByTier,
   RULES_PER_POLARITY,
@@ -40,6 +43,18 @@ describe("the polarity rule read caps each tier separately", () => {
   test("applies the per-tier budget", () => {
     expect(rendered.sql).toContain('"tier_rank" <=');
     expect(rendered.params).toContain(RULES_PER_POLARITY);
+  });
+
+  test("reads only the polarities a match may assign", () => {
+    // A rule carrying `unknown` would open a fifth partition, taking a share
+    // of a budget divided among four — and would then match, labelling a
+    // citation "classification did not happen" when nothing had tried.
+    expect(statement).toContain('"polarity" in (');
+    expect(rendered.params).not.toContain(POLARITY.UNKNOWN);
+
+    for (const polarity of CLASSIFIABLE_POLARITIES) {
+      expect(rendered.params).toContain(polarity);
+    }
   });
 
   test("no ordering reads match_count", () => {

--- a/apps/api/src/handlers/case-law/__tests__/polarity-rule-order.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/polarity-rule-order.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { QueryBuilder } from "drizzle-orm/pg-core";
+
+import { caseLawPolarityRules } from "@/api/db/schema";
+import {
+  POLARITIES,
+  POLARITY_PRECEDENCE,
+} from "@/api/handlers/case-law/polarity/consts";
+import { polarityRuleOrder } from "@/api/handlers/case-law/polarity/rule-engine";
+
+/**
+ * The rule query's ORDER BY is assembled from a const map rather than written
+ * out, so a mistake in the assembly produces SQL no type can reject. It runs
+ * in a background classifier, where a malformed clause would surface as rules
+ * quietly failing to load rather than as a failing request. Rendering the
+ * query through drizzle's dialect gives the exact string the driver would
+ * send, without standing up a database.
+ */
+const rendered = new QueryBuilder()
+  .select()
+  .from(caseLawPolarityRules)
+  .orderBy(...polarityRuleOrder)
+  .toSQL();
+
+/** Only the clause under test; the select list names every column. */
+const orderBy = rendered.sql.slice(rendered.sql.indexOf("order by"));
+
+describe("the polarity rule query orders by precedence", () => {
+  test("orders by severity, then pattern length, then id", () => {
+    expect(orderBy).toStartWith("order by CASE WHEN ");
+    expect(orderBy).toContain(
+      'END, length("case_law_polarity_rules"."pattern") desc, "case_law_polarity_rules"."id"',
+    );
+  });
+
+  test("scores every polarity, and none by match count", () => {
+    // Each arm binds the polarity as a parameter, so the names live in
+    // `params` while the scores are inlined into the CASE.
+    for (const polarity of POLARITIES) {
+      expect(rendered.params).toContain(polarity);
+      expect(orderBy).toContain(
+        `THEN ${String(POLARITY_PRECEDENCE[polarity])}`,
+      );
+    }
+
+    expect(orderBy).not.toContain("match_count");
+  });
+
+  test("negative outscores every other polarity", () => {
+    // The property the ORDER BY exists for: severity decides, and `negative`
+    // is the most severe, so it must sort ahead of everything else.
+    const negative = POLARITY_PRECEDENCE.negative;
+
+    for (const polarity of POLARITIES) {
+      if (polarity === "negative") {
+        continue;
+      }
+      expect(POLARITY_PRECEDENCE[polarity]).toBeGreaterThan(negative);
+    }
+  });
+});

--- a/apps/api/src/handlers/case-law/__tests__/polarity-rule-order.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/polarity-rule-order.test.ts
@@ -1,61 +1,57 @@
 import { describe, expect, test } from "bun:test";
+import { lte } from "drizzle-orm";
 import { QueryBuilder } from "drizzle-orm/pg-core";
 
-import { caseLawPolarityRules } from "@/api/db/schema";
+import { CLASSIFIABLE_POLARITIES } from "@/api/handlers/case-law/polarity/consts";
 import {
-  POLARITIES,
-  POLARITY_PRECEDENCE,
-} from "@/api/handlers/case-law/polarity/consts";
-import { polarityRuleOrder } from "@/api/handlers/case-law/polarity/rule-engine";
+  rankPolarityRulesByTier,
+  RULES_PER_POLARITY,
+} from "@/api/handlers/case-law/polarity/rule-engine";
+import { LIMITS } from "@/api/lib/limits";
 
 /**
- * The rule query's ORDER BY is assembled from a const map rather than written
- * out, so a mistake in the assembly produces SQL no type can reject. It runs
- * in a background classifier, where a malformed clause would surface as rules
- * quietly failing to load rather than as a failing request. Rendering the
- * query through drizzle's dialect gives the exact string the driver would
- * send, without standing up a database.
+ * The rule read is a window function assembled in code, so a mistake in it
+ * produces SQL no type can reject. It runs in a background classifier, where
+ * a malformed statement would surface as rules quietly failing to load rather
+ * than as a failing request. Rendering through drizzle's dialect gives the
+ * string the driver would send, without standing up a database.
  */
+const ranked = rankPolarityRulesByTier("cs");
 const rendered = new QueryBuilder()
-  .select()
-  .from(caseLawPolarityRules)
-  .orderBy(...polarityRuleOrder)
+  .select({ id: ranked.id })
+  .from(ranked)
+  .where(lte(ranked.tierRank, RULES_PER_POLARITY))
   .toSQL();
 
-/** Only the clause under test; the select list names every column. */
-const orderBy = rendered.sql.slice(rendered.sql.indexOf("order by"));
+/** The window clause is written across lines; compare it as one. */
+const statement = rendered.sql.replaceAll(/\s+/gu, " ");
 
-describe("the polarity rule query orders by precedence", () => {
-  test("orders by severity, then pattern length, then id", () => {
-    expect(orderBy).toStartWith("order by CASE WHEN ");
-    expect(orderBy).toContain(
-      'END, length("case_law_polarity_rules"."pattern") desc, "case_law_polarity_rules"."id"',
-    );
+describe("the polarity rule read caps each tier separately", () => {
+  test("ranks within a polarity, not across the table", () => {
+    // The partition is the whole point: without it the cap is a race between
+    // tiers, and whichever tier grows fastest evicts the others.
+    expect(statement).toContain('row_number() over ( partition by "polarity"');
   });
 
-  test("scores every polarity, and none by match count", () => {
-    // Each arm binds the polarity as a parameter, so the names live in
-    // `params` while the scores are inlined into the CASE.
-    for (const polarity of POLARITIES) {
-      expect(rendered.params).toContain(polarity);
-      expect(orderBy).toContain(
-        `THEN ${String(POLARITY_PRECEDENCE[polarity])}`,
-      );
-    }
-
-    expect(orderBy).not.toContain("match_count");
+  test("keeps the most specific rules of each tier, deterministically", () => {
+    expect(statement).toContain('order by length("pattern") desc, "id"');
   });
 
-  test("negative outscores every other polarity", () => {
-    // The property the ORDER BY exists for: severity decides, and `negative`
-    // is the most severe, so it must sort ahead of everything else.
-    const negative = POLARITY_PRECEDENCE.negative;
+  test("applies the per-tier budget", () => {
+    expect(rendered.sql).toContain('"tier_rank" <=');
+    expect(rendered.params).toContain(RULES_PER_POLARITY);
+  });
 
-    for (const polarity of POLARITIES) {
-      if (polarity === "negative") {
-        continue;
-      }
-      expect(POLARITY_PRECEDENCE[polarity]).toBeGreaterThan(negative);
-    }
+  test("no ordering reads match_count", () => {
+    // The self-reinforcing order this engine used to have. It must not come
+    // back through the cap, which is the subtler place for it to hide.
+    expect(rendered.sql).not.toContain("match_count");
+  });
+
+  test("every tier gets a budget, and together they cover the limit", () => {
+    expect(RULES_PER_POLARITY).toBeGreaterThan(0);
+    expect(
+      RULES_PER_POLARITY * CLASSIFIABLE_POLARITIES.length,
+    ).toBeGreaterThanOrEqual(LIMITS.caseLawPolarityRulesPerLanguage);
   });
 });

--- a/apps/api/src/handlers/case-law/citation-kind.test.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.test.ts
@@ -88,6 +88,55 @@ describe("the registry decides when context does not", () => {
     ).toBe(CITATION_KIND.PRECEDENT);
   });
 
+  test("a chamber-less kolegium opinion is precedent", () => {
+    // A "stanovisko" carries no chamber number, so the registry reader used
+    // to find no mark at all and every opinion fell through to procedural —
+    // the one document class issued specifically to unify practice. These
+    // are real file numbers: the registers use disjoint number ranges, so a
+    // shape invented from one would not stand in for the others.
+    for (const citationText of [
+      "Cpjn 203/2010",
+      "sp. zn. Cpjn 206/2010",
+      "Tpjn 300/2017",
+      "sp. zn. Opjn 8/2006",
+    ]) {
+      expect(classifyCitation({ citationText, context: null })).toBe(
+        CITATION_KIND.PRECEDENT,
+      );
+    }
+  });
+
+  test("a chamber-less first-instance mark is still procedural", () => {
+    // The bare-mark reader promotes nothing on its own: an unlisted registry
+    // falls through exactly as an unreadable one did.
+    expect(
+      classifyCitation({ citationText: "Nt 408/2023", context: null }),
+    ).toBe(CITATION_KIND.PROCEDURAL);
+  });
+
+  test("a grand-chamber citation is precedent", () => {
+    // Slovak grand-chamber numbers are senate-prefixed and slash-separated,
+    // with no space after the senate; the Supreme Administrative Court's
+    // spaces its mark instead. Both spellings have to reach the registry.
+    for (const citationText of [
+      "1VCdo/9/2025",
+      "1VObdo/2/2026",
+      "1 SVs 1/2021",
+    ]) {
+      expect(classifyCitation({ citationText, context: null })).toBe(
+        CITATION_KIND.PRECEDENT,
+      );
+    }
+  });
+
+  test("a Polish legal-question resolution is precedent", () => {
+    // The Roman chamber prefix drifts as chambers are reorganised, so the
+    // mark alone decides.
+    expect(
+      classifyCitation({ citationText: "III PZP 1/21", context: null }),
+    ).toBe(CITATION_KIND.PRECEDENT);
+  });
+
   test("context carrying both cues falls back to the registry", () => {
     // "srov." and an appeal recital in one window: the string alone cannot
     // arbitrate, so publication status decides rather than cue order.

--- a/apps/api/src/handlers/case-law/citation-kind.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.ts
@@ -136,16 +136,19 @@ const withoutPrefix = (text: string): string =>
  * the digits of the case number follow it directly, so it cannot pick a word
  * out of ordinary prose. It never promotes on its own either: an unlisted
  * mark still falls through to procedural, exactly as a null did.
+ *
+ * The mark is matched as `\p{L}`, the same class the citation extractor
+ * uses. The `Á-Ž`/`á-ž` ranges this used to spell out are code-point ranges,
+ * not letter ranges: they overlap each other and take in `×` and `÷`, which
+ * sit between the accented blocks. Whatever they match is looked up in a
+ * closed set, so the sloppiness never promoted anything, but there is no
+ * reason for two spellings of "a letter" in one file.
  */
 const registryOf = (citationText: string): string | null => {
-  const roman = /^\s*[IVX]+\.?\s*(?<reg>[A-Za-zÁ-Žá-ž]{1,5})/u.exec(
-    citationText,
-  );
-  const arabic = /^\s*\d{1,3}\s*(?<reg>[A-Za-zÁ-Žá-ž]{1,6})/u.exec(
-    citationText,
-  );
+  const roman = /^\s*[IVX]+\.?\s*(?<reg>\p{L}{1,5})/u.exec(citationText);
+  const arabic = /^\s*\d{1,3}\s*(?<reg>\p{L}{1,6})/u.exec(citationText);
   const us = /ÚS|US/u.exec(citationText);
-  const bare = /^\s*(?<reg>[A-Za-zÁ-Žá-ž]{2,6})\.?\s+\d/u.exec(citationText);
+  const bare = /^\s*(?<reg>\p{L}{2,6})\.?\s+\d/u.exec(citationText);
   const raw =
     roman?.groups?.["reg"] ??
     arabic?.groups?.["reg"] ??

--- a/apps/api/src/handlers/case-law/citation-kind.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.ts
@@ -47,6 +47,17 @@ const AUTHORITY_REGISTRIES = new Set([
   "tdo",
   "odo",
   "nd",
+  // Czech Supreme Court kolegium opinions ("stanoviska"): civil-and-
+  // commercial (Cpjn 203/2010) and criminal (Tpjn 300/2017). A stanovisko is
+  // issued to unify divergent practice, so it is authority by construction.
+  // The citation extractor already recognises the bare `Cpjn`/`Tpjn` forms;
+  // the registry reader below is what lets them reach this set.
+  "cpjn",
+  "tpjn",
+  // The commercial kolegium's own opinion register, from before that
+  // kolegium merged into the civil-and-commercial one. Historical: the
+  // published set is tiny (Opjn 8/2006), but those opinions are still cited.
+  "opjn",
   // Czech Supreme Administrative Court
   "as",
   "afs",
@@ -66,11 +77,25 @@ const AUTHORITY_REGISTRIES = new Set([
   "uzp",
   "kzp",
   "cskp",
-  // Slovak Supreme Court
+  // Polish Supreme Court legal-question resolutions ("uchwały") of the
+  // labour chamber, the sibling of the `uzp`/`czp`/`kzp` marks already
+  // listed. Cited with a Roman chamber prefix that drifts as chambers are
+  // reorganised ("III PZP 1/21"), so only the mark itself is keyed on.
+  "pzp",
+  // Slovak Supreme Court. `cdo` is shared with the Czech Supreme Court and
+  // is listed once, above.
   "sžo",
   "sž",
   "obdo",
-  "cdo",
+  // Slovak grand chambers ("veľký senát"), which sit precisely to depart
+  // from settled practice: the Supreme Court's civil and commercial ones
+  // ("1VCdo/9/2025", "1VObdo/2/2026"), and the Supreme Administrative
+  // Court's ("1 SVs 1/2021"). There is deliberately no criminal entry:
+  // Slovak criminal law has no veľký senát, and the unifying senates that
+  // stand in for it have published nothing to cite yet.
+  "vcdo",
+  "vobdo",
+  "svs",
 ]);
 
 /**
@@ -102,7 +127,16 @@ const withoutPrefix = (text: string): string =>
     .replace(/^\s*sygn\.\s*(?:akt\s+)?/iu, "")
     .trim();
 
-/** The registry token of a case number: `21 Cdo 1234/2020` -> `cdo`. */
+/**
+ * The registry token of a case number: `21 Cdo 1234/2020` -> `cdo`.
+ *
+ * Most marks are preceded by a chamber number, Roman or Arabic. Some are
+ * not: a Czech kolegium opinion is `Cpjn 203/2010`, with no chamber at all,
+ * because the whole kolegium issued it. That form is read last and only when
+ * the digits of the case number follow it directly, so it cannot pick a word
+ * out of ordinary prose. It never promotes on its own either: an unlisted
+ * mark still falls through to procedural, exactly as a null did.
+ */
 const registryOf = (citationText: string): string | null => {
   const roman = /^\s*[IVX]+\.?\s*(?<reg>[A-Za-zÁ-Žá-ž]{1,5})/u.exec(
     citationText,
@@ -111,7 +145,12 @@ const registryOf = (citationText: string): string | null => {
     citationText,
   );
   const us = /ÚS|US/u.exec(citationText);
-  const raw = roman?.groups?.["reg"] ?? arabic?.groups?.["reg"] ?? us?.[0];
+  const bare = /^\s*(?<reg>[A-Za-zÁ-Žá-ž]{2,6})\.?\s+\d/u.exec(citationText);
+  const raw =
+    roman?.groups?.["reg"] ??
+    arabic?.groups?.["reg"] ??
+    us?.[0] ??
+    bare?.groups?.["reg"];
   return raw === undefined ? null : raw.toLowerCase();
 };
 

--- a/apps/api/src/handlers/case-law/ingestion/pipeline-canonical.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline-canonical.test.ts
@@ -10,11 +10,7 @@ import {
 } from "@/api/db/schema";
 import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
 import { createSafeId } from "@/api/lib/branded-types";
-import {
-  ConcurrentModificationError,
-  DatabaseError,
-  TimeoutError,
-} from "@/api/lib/errors/tagged-errors";
+import { DatabaseError, TimeoutError } from "@/api/lib/errors/tagged-errors";
 import type { CaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
 import type { WriteCorpusResult } from "@/api/lib/legal-search/corpus-storage";
 import { caseLawSourceRow } from "@/api/tests/helpers/case-law-source-row";
@@ -81,7 +77,7 @@ void mock.module("@/api/lib/legal-search/corpus-storage", () => ({
 
 const { czNsAdapter } =
   await import("@/api/handlers/case-law/ingestion/adapters/cz-ns");
-const { processDecision, runIngestionPipeline, settleCaseLawCorpusMirror } =
+const { processDecision, runIngestionPipeline } =
   await import("@/api/handlers/case-law/ingestion/pipeline");
 
 const originalCzNsFetchPage = czNsAdapter.fetchPage;
@@ -243,31 +239,6 @@ const scopedDb: ScopedDb = async (callback) => {
   // eslint-disable-next-line typescript/no-unsafe-type-assertion
   return await callback(tx as unknown as Transaction);
 };
-
-describe("settleCaseLawCorpusMirror", () => {
-  const settle = async (): Promise<unknown> =>
-    await settleCaseLawCorpusMirror({
-      decisionId: createSafeId<"caseLawDecision">(),
-      persistedSourceHash: "source-hash",
-      observationOrder: 1n,
-      mirrorCarriesDocument: true,
-      scopedDb,
-      written: { ...CORPUS_KEYS, contentHash: "content-hash" },
-    }).then(
-      () => null,
-      (error: unknown) => error,
-    );
-
-  test("accepts the observation that still owns the pending mirror", async () => {
-    expect(await settle()).toBeNull();
-  });
-
-  test("makes a missed settlement compare-and-set retryable", async () => {
-    mirrorSettlementApplied = false;
-
-    expect(await settle()).toBeInstanceOf(ConcurrentModificationError);
-  });
-});
 
 describe("processDecision — canonical storage mode", () => {
   test("reserves before upload and publishes pointers only after it succeeds", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -370,22 +370,22 @@ type CorpusWritePayload = CorpusPayload & {
   jurisdiction: string;
 };
 
-type SettleCaseLawCorpusMirrorOptions = {
+type SettleCaseLawCorpusMirrorTxOptions = {
   decisionId: SafeId<"caseLawDecision">;
   persistedSourceHash: string | null;
   observationOrder: bigint;
   mirrorCarriesDocument: boolean;
-  scopedDb: ScopedDb;
   written: WriteCorpusResult;
-};
-
-type SettleCaseLawCorpusMirrorTxOptions = Omit<
-  SettleCaseLawCorpusMirrorOptions,
-  "scopedDb"
-> & {
   tx: Transaction;
 };
 
+/**
+ * Settle only the observation that owns the pending mirror.
+ *
+ * A missed compare-and-set is retryable, not terminal: another run may still
+ * leave the durable row pending, so the caller's page cursor must stay held
+ * until a replay proves the mirror settled.
+ */
 const settleCaseLawCorpusMirrorTx = async ({
   decisionId,
   persistedSourceHash,
@@ -427,38 +427,6 @@ const settleCaseLawCorpusMirrorTx = async ({
     )
     .returning({ id: caseLawDecisions.id });
   return settled.length > 0;
-};
-
-/**
- * Settle only the observation that owns the pending mirror. A missed CAS is
- * retryable, not terminal: another run may still leave the durable row
- * pending, so its page cursor must remain held until a replay proves the
- * mirror settled.
- */
-export const settleCaseLawCorpusMirror = async ({
-  decisionId,
-  persistedSourceHash,
-  observationOrder,
-  mirrorCarriesDocument,
-  scopedDb,
-  written,
-}: SettleCaseLawCorpusMirrorOptions): Promise<void> => {
-  const settled = await scopedDb(
-    async (tx) =>
-      await settleCaseLawCorpusMirrorTx({
-        decisionId,
-        persistedSourceHash,
-        observationOrder,
-        mirrorCarriesDocument,
-        tx,
-        written,
-      }),
-  );
-  if (!settled) {
-    throw new ConcurrentModificationError({
-      message: "Case-law corpus mirror owner changed before settlement",
-    });
-  }
 };
 
 /**

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill-corpus.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill-corpus.db.test.ts
@@ -31,9 +31,7 @@ import {
 } from "@/api/db/schema";
 import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
-import { settleCaseLawCorpusMirror } from "@/api/handlers/case-law/ingestion/pipeline";
 import type { SafeId } from "@/api/lib/branded-types";
-import { ConcurrentModificationError } from "@/api/lib/errors/tagged-errors";
 import type { WriteCorpusResult } from "@/api/lib/legal-search/corpus-storage";
 import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/lib/legal-search/corpus-storage";
 import {
@@ -641,61 +639,6 @@ if (!databaseUrl || !runPostgresTests) {
       ).toMatchObject({
         corpusMirrorStatus: CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED,
         contentHash: NEW_CONTENT_HASH,
-      });
-    });
-
-    test("a redaction tombstone rejects stale mirror settlement", async () => {
-      const caseNumber = `corpus-redaction-fence-${suffix}`;
-      const id = await insertDecision({
-        caseNumber,
-        mirrorStatus: CASE_LAW_CORPUS_MIRROR_STATUS.PENDING,
-      });
-      await db
-        .update(caseLawDecisions)
-        .set({
-          sourceHash: "redacted-source-hash",
-          sourceObservationOrder: 1n,
-        })
-        .where(eq(caseLawDecisions.id, id));
-      const redactedAt = new Date("2026-07-31T12:00:00.000Z");
-      await db
-        .update(caseLawDecisions)
-        .set({
-          redactedAt,
-          corpusMirrorStatus: CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED,
-          fulltext: null,
-          sections: null,
-          documentAst: null,
-          contentHash: null,
-        })
-        .where(eq(caseLawDecisions.id, id));
-
-      const rejection = await settleCaseLawCorpusMirror({
-        decisionId: id,
-        persistedSourceHash: "redacted-source-hash",
-        observationOrder: 1n,
-        mirrorCarriesDocument: true,
-        scopedDb,
-        written: { ...NEW_KEYS, contentHash: NEW_CONTENT_HASH },
-      }).then(
-        () => null,
-        (error: unknown) => error,
-      );
-
-      expect(rejection).toBeInstanceOf(ConcurrentModificationError);
-      expect(
-        await db.query.caseLawDecisions.findFirst({
-          where: { id: { eq: id } },
-          columns: {
-            redactedAt: true,
-            textS3Key: true,
-            contentHash: true,
-          },
-        }),
-      ).toMatchObject({
-        redactedAt,
-        textS3Key: null,
-        contentHash: null,
       });
     });
 

--- a/apps/api/src/handlers/case-law/polarity/classifier.ts
+++ b/apps/api/src/handlers/case-law/polarity/classifier.ts
@@ -35,6 +35,15 @@ type ClassifyResult = {
   polarity: Polarity;
   ruleId: SafeId<"caseLawPolarityRule"> | null;
   source: "regex" | "llm" | "fallback";
+  /**
+   * How much the deciding tier trusts this label: the rule's stored
+   * confidence for a regex match, the model's own for an LLM call, and null
+   * on the fallback, where nothing read the text.
+   *
+   * `case_law_citations` has no column for it yet, so `persistPolarity`
+   * drops it and only in-process callers see it.
+   */
+  confidence: number | null;
 };
 
 /**
@@ -88,6 +97,7 @@ export const classifyCitation = async ({
       polarity: ruleMatch.polarity,
       ruleId: ruleMatch.ruleId,
       source: "regex",
+      confidence: ruleMatch.confidence,
     };
   }
 
@@ -102,10 +112,15 @@ export const classifyCitation = async ({
   });
 
   if (llmResult.isErr()) {
+    // `unknown` here records that classification did not happen, not that the
+    // citation was read and found unclear. The two are not distinguishable
+    // once persisted, because the column has no value for "read it, could not
+    // decide"; adding one needs a CHECK-constraint migration.
     return {
       polarity: POLARITY.UNKNOWN,
       ruleId: null,
       source: "fallback",
+      confidence: null,
     };
   }
 
@@ -124,7 +139,7 @@ export const classifyCitation = async ({
     });
   }
 
-  return { polarity, ruleId: null, source: "llm" };
+  return { polarity, ruleId: null, source: "llm", confidence };
 };
 
 /**
@@ -231,6 +246,9 @@ const trackSurfaceForm = async ({
 
 /**
  * Persist a classification result to the citations table.
+ *
+ * `result.confidence` is deliberately not written: `case_law_citations` has
+ * no column for it. Adding one is a schema change, not a write-path change.
  */
 export const persistPolarity = async (
   citationId: SafeId<"caseLawCitation">,

--- a/apps/api/src/handlers/case-law/polarity/consts.ts
+++ b/apps/api/src/handlers/case-law/polarity/consts.ts
@@ -25,6 +25,52 @@ export const POLARITY = {
   UNKNOWN: "unknown",
 } as const satisfies ConstantMap<Polarity>;
 
+/**
+ * Polarities that record the pipeline's own state rather than a reading of
+ * the text. `unknown` means classification did not produce an answer — the
+ * LLM call failed, or the row predates the classifier — so no classifier
+ * may emit it and no rule may carry it.
+ */
+const PIPELINE_POLARITIES = [POLARITY.UNKNOWN] as const;
+
+/** A polarity a classifier is allowed to assign to a citation. */
+export type ClassifiablePolarity = Exclude<
+  Polarity,
+  (typeof PIPELINE_POLARITIES)[number]
+>;
+
+/**
+ * The classifier codomain, derived from `POLARITIES` so both tiers share one
+ * list. Deriving matters: the LLM's schema and the rule table used to be
+ * written out separately, and they disagreed about `supportive`, so the same
+ * phrase got one label from a regex rule and another from the model.
+ */
+export const CLASSIFIABLE_POLARITIES = POLARITIES.filter(
+  (polarity): polarity is ClassifiablePolarity =>
+    !includes(PIPELINE_POLARITIES, polarity),
+);
+
+/**
+ * Order in which competing rule matches are resolved: lower wins.
+ *
+ * Severity first. A court that distinguishes or overrules a decision has
+ * said something stronger than one that also happens to cite it approvingly,
+ * so a negative match must never lose to a positive or supportive one.
+ * `positive` and `supportive` are deliberately equal: they differ in how
+ * explicit the reliance is, not in how strong it is.
+ *
+ * `matchCount` must never enter this order. Ordering by it is
+ * self-reinforcing — every win raises the winner's precedence — so a common
+ * generic rule ends up permanently shadowing a rare specific one.
+ */
+export const POLARITY_PRECEDENCE = {
+  negative: 0,
+  positive: 1,
+  supportive: 1,
+  neutral: 2,
+  unknown: 3,
+} as const satisfies Record<Polarity, number>;
+
 /** Rule source types, declared as the list the CHECK constraint derives from. */
 export const RULE_SOURCES = ["manual", "llm-proposed", "llm-promoted"] as const;
 

--- a/apps/api/src/handlers/case-law/polarity/consts.ts
+++ b/apps/api/src/handlers/case-law/polarity/consts.ts
@@ -51,6 +51,17 @@ export const CLASSIFIABLE_POLARITIES = POLARITIES.filter(
 );
 
 /**
+ * Whether a stored value is one a classifier may assign.
+ *
+ * Stricter than `isValidPolarity`, and deliberately so at the read boundary:
+ * the CHECK constraint keeps values inside `POLARITIES`, but nothing stops a
+ * row carrying `unknown`, which is the pipeline's word about itself.
+ */
+export const isClassifiablePolarity = (
+  value: string,
+): value is ClassifiablePolarity => includes(CLASSIFIABLE_POLARITIES, value);
+
+/**
  * Order in which competing rule matches are resolved: lower wins.
  *
  * Severity first. A court that distinguishes or overrules a decision has

--- a/apps/api/src/handlers/case-law/polarity/llm-classifier.ts
+++ b/apps/api/src/handlers/case-law/polarity/llm-classifier.ts
@@ -35,9 +35,10 @@ const POLARITY_GUIDANCE = {
   agreement outright: a comparison or see-also pointer offered in support
   of what it is saying. Phrases like "srov.", "viz", "obdobně",
   "přiměřeně", "porov.", "pozri", "cf.", "see also".`,
-  neutral: `The court names the cited decision as part of the procedural
-  record, endorsing nothing. Phrases like "proti rozsudku", "vedené u",
-  "veden pod".`,
+  neutral: `The court names the cited decision without endorsing or
+  rejecting it, most often as part of the procedural record. Phrases like
+  "proti rozsudku", "vedené u", "veden pod". This is also the answer when
+  the excerpt does not settle the question.`,
   negative: `The court distinguishes, overrules, departs from, or
   criticizes the cited decision. Phrases like "na rozdíl od",
   "překonán", "zrušen", "odlišuje se", "overruled", "distinguished".`,
@@ -58,7 +59,9 @@ Extract the specific phrase (2-5 words) from the text that most
 strongly indicates the polarity. This phrase will be used to generate
 regex rules for future classification.
 
-If the context is ambiguous, classify as "neutral".`;
+Report confidence honestly. A high-confidence answer can be promoted into
+a regex rule that labels later citations without you, so an uncertain one
+must say so rather than round itself up.`;
 
 const classificationSchema = v.strictObject({
   polarity: v.picklist(CLASSIFIABLE_POLARITIES),

--- a/apps/api/src/handlers/case-law/polarity/llm-classifier.ts
+++ b/apps/api/src/handlers/case-law/polarity/llm-classifier.ts
@@ -15,7 +15,33 @@ import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack
 import { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
 import { generateTanStackObjectForRole } from "@/api/lib/tanstack-ai-generate";
 
-import type { Polarity } from "./consts";
+import { CLASSIFIABLE_POLARITIES } from "./consts";
+import type { ClassifiablePolarity } from "./consts";
+
+/**
+ * What each polarity means, one entry per value the classifier may return.
+ *
+ * Total over `ClassifiablePolarity` by construction, so a new polarity cannot
+ * be added to the canonical list without the model being told what it means.
+ * The examples are drawn from the same phrases the seed rules key on, because
+ * the two tiers label the same corpus and used to disagree: the regex tier has
+ * always called "srov." supportive, while this prompt called it neutral.
+ */
+const POLARITY_GUIDANCE = {
+  positive: `The court follows, agrees with, applies, or builds on the
+  cited decision, and says so. Phrases like "v souladu s", "odkazuje na",
+  "jak konstatoval", "following", "in line with", "as held in".`,
+  supportive: `The court relies on the cited decision without stating
+  agreement outright: a comparison or see-also pointer offered in support
+  of what it is saying. Phrases like "srov.", "viz", "obdobně",
+  "přiměřeně", "porov.", "pozri", "cf.", "see also".`,
+  neutral: `The court names the cited decision as part of the procedural
+  record, endorsing nothing. Phrases like "proti rozsudku", "vedené u",
+  "veden pod".`,
+  negative: `The court distinguishes, overrules, departs from, or
+  criticizes the cited decision. Phrases like "na rozdíl od",
+  "překonán", "zrušen", "odlišuje se", "overruled", "distinguished".`,
+} as const satisfies Record<ClassifiablePolarity, string>;
 
 const SYSTEM_PROMPT = `You are a legal citation polarity classifier.
 
@@ -24,15 +50,9 @@ reference, classify the relationship between the citing decision and
 the cited decision.
 
 Classifications:
-- "positive": The court follows, agrees with, applies, or builds on
-  the cited decision. Phrases like "v souladu s", "odkazuje na",
-  "jak konstatoval", "following", "in line with", "as held in".
-- "neutral": The court merely references or mentions the cited
-  decision without endorsing or rejecting it. Phrases like "srov.",
-  "viz", "cf.", "see", "compare".
-- "negative": The court distinguishes, overrules, departs from, or
-  criticizes the cited decision. Phrases like "na rozdíl od",
-  "překonán", "zrušen", "odlišuje se", "overruled", "distinguished".
+${CLASSIFIABLE_POLARITIES.map(
+  (polarity) => `- "${polarity}": ${POLARITY_GUIDANCE[polarity]}`,
+).join("\n")}
 
 Extract the specific phrase (2-5 words) from the text that most
 strongly indicates the polarity. This phrase will be used to generate
@@ -41,13 +61,13 @@ regex rules for future classification.
 If the context is ambiguous, classify as "neutral".`;
 
 const classificationSchema = v.strictObject({
-  polarity: v.picklist(["positive", "neutral", "negative"]),
+  polarity: v.picklist(CLASSIFIABLE_POLARITIES),
   keyPhrase: v.pipe(v.string(), v.minLength(2), v.maxLength(100)),
   confidence: v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
 });
 
 type ClassificationResult = {
-  polarity: Polarity;
+  polarity: ClassifiablePolarity;
   keyPhrase: string;
   confidence: number;
 };
@@ -112,9 +132,6 @@ ${context}`,
       });
 
       return {
-        // SAFETY: Valibot picklist at line 45 restricts to
-        // valid Polarity subset ("positive" | "neutral" | "negative").
-        // The picklist subset is assignable to Polarity without cast
         polarity: output.polarity,
         keyPhrase: output.keyPhrase,
         confidence: output.confidence,

--- a/apps/api/src/handlers/case-law/polarity/rule-engine.ts
+++ b/apps/api/src/handlers/case-law/polarity/rule-engine.ts
@@ -70,7 +70,7 @@ const compareRulePrecedence = (a: CompiledRule, b: CompiledRule): number => {
 };
 
 /**
- * The severity tier of `compareRulePrecedence`, in SQL.
+ * `compareRulePrecedence`, in SQL.
  *
  * This orders the truncation, not the matching: `loadRules` caps how many
  * rules it reads, and the cap has to drop the rules that would have lost
@@ -78,14 +78,21 @@ const compareRulePrecedence = (a: CompiledRule, b: CompiledRule): number => {
  * rule push a rare negative one out of the working set entirely, which is the
  * same shadowing bug one layer down. Match order is re-established in memory
  * by `compareRulePrecedence`, so only this cap depends on the clause below.
+ *
+ * The severity tier is built from `POLARITY_PRECEDENCE`, the map the
+ * in-memory comparator reads, so the two cannot disagree about severity.
  */
-const POLARITY_PRECEDENCE_SQL = sql`CASE ${sql.join(
-  POLARITIES.map(
-    (polarity) =>
-      sql`WHEN ${caseLawPolarityRules.polarity} = ${polarity} THEN ${sql.raw(String(POLARITY_PRECEDENCE[polarity]))}`,
-  ),
-  sql` `,
-)} END`;
+export const polarityRuleOrder = [
+  sql`CASE ${sql.join(
+    POLARITIES.map(
+      (polarity) =>
+        sql`WHEN ${caseLawPolarityRules.polarity} = ${polarity} THEN ${sql.raw(String(POLARITY_PRECEDENCE[polarity]))}`,
+    ),
+    sql` `,
+  )} END`,
+  sql`length(${caseLawPolarityRules.pattern}) desc`,
+  caseLawPolarityRules.id,
+];
 
 /** Optional caller-owned cache for batch scripts. */
 export type RuleCache = Map<string, CompiledRule[]>;
@@ -203,11 +210,7 @@ const loadRules = async (
           inArray(caseLawPolarityRules.source, ACTIVE_SOURCES),
         ),
       )
-      .orderBy(
-        POLARITY_PRECEDENCE_SQL,
-        sql`length(${caseLawPolarityRules.pattern}) desc`,
-        caseLawPolarityRules.id,
-      )
+      .orderBy(...polarityRuleOrder)
       .limit(LIMITS.caseLawPolarityRulesPerLanguage),
   );
 

--- a/apps/api/src/handlers/case-law/polarity/rule-engine.ts
+++ b/apps/api/src/handlers/case-law/polarity/rule-engine.ts
@@ -10,13 +10,14 @@
  * stateless (rules reload from DB on every call).
  */
 
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, lte, sql } from "drizzle-orm";
+import { QueryBuilder } from "drizzle-orm/pg-core";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawPolarityRules } from "@/api/db/schema";
 import {
+  CLASSIFIABLE_POLARITIES,
   isValidPolarity,
-  POLARITIES,
   POLARITY_PRECEDENCE,
   RULE_SOURCE,
 } from "@/api/handlers/case-law/polarity/consts";
@@ -70,29 +71,23 @@ const compareRulePrecedence = (a: CompiledRule, b: CompiledRule): number => {
 };
 
 /**
- * `compareRulePrecedence`, in SQL.
+ * How many rules one polarity may contribute to the working set.
  *
- * This orders the truncation, not the matching: `loadRules` caps how many
- * rules it reads, and the cap has to drop the rules that would have lost
- * anyway. Ordering that cap by `match_count` instead would let a busy generic
- * rule push a rare negative one out of the working set entirely, which is the
- * same shadowing bug one layer down. Match order is re-established in memory
- * by `compareRulePrecedence`, so only this cap depends on the clause below.
+ * The cap exists to bound the read, but which rules it drops is a
+ * classification decision. Ordering it by `match_count` let a busy generic
+ * rule push a rare negative one out of the working set entirely — the
+ * shadowing bug one layer down from the match order. Ordering it by severity
+ * instead would be no better: a language that accumulated a cap's worth of
+ * negative rules would load nothing else, and every context those rules
+ * missed would fall through to the LLM.
  *
- * The severity tier is built from `POLARITY_PRECEDENCE`, the map the
- * in-memory comparator reads, so the two cannot disagree about severity.
+ * So the budget is divided among the tiers rather than competed for. No tier
+ * can starve another, and severity stays a matching concern, expressed once,
+ * in `compareRulePrecedence`.
  */
-export const polarityRuleOrder = [
-  sql`CASE ${sql.join(
-    POLARITIES.map(
-      (polarity) =>
-        sql`WHEN ${caseLawPolarityRules.polarity} = ${polarity} THEN ${sql.raw(String(POLARITY_PRECEDENCE[polarity]))}`,
-    ),
-    sql` `,
-  )} END`,
-  sql`length(${caseLawPolarityRules.pattern}) desc`,
-  caseLawPolarityRules.id,
-];
+export const RULES_PER_POLARITY = Math.ceil(
+  LIMITS.caseLawPolarityRulesPerLanguage / CLASSIFIABLE_POLARITIES.length,
+);
 
 /** Optional caller-owned cache for batch scripts. */
 export type RuleCache = Map<string, CompiledRule[]>;
@@ -108,6 +103,35 @@ const compilePattern = (pattern: string): RegExp | null => {
 
 /** Active rule sources (proposed rules are excluded). */
 const ACTIVE_SOURCES = [RULE_SOURCE.MANUAL, RULE_SOURCE.LLM_PROMOTED];
+
+/**
+ * Active rules for one language, numbered within their own polarity.
+ *
+ * Ranking by pattern length keeps the most specific rules of each tier when
+ * the per-tier budget bites, which is the same axis `compareRulePrecedence`
+ * breaks ties on; the id makes the rank total, so a cap that bites lands on
+ * the same rules on every run.
+ */
+export const rankPolarityRulesByTier = (language: string) =>
+  new QueryBuilder()
+    .select({
+      id: caseLawPolarityRules.id,
+      pattern: caseLawPolarityRules.pattern,
+      polarity: caseLawPolarityRules.polarity,
+      confidence: caseLawPolarityRules.confidence,
+      tierRank: sql<number>`row_number() over (
+        partition by ${caseLawPolarityRules.polarity}
+        order by length(${caseLawPolarityRules.pattern}) desc, ${caseLawPolarityRules.id}
+      )`.as("tier_rank"),
+    })
+    .from(caseLawPolarityRules)
+    .where(
+      and(
+        eq(caseLawPolarityRules.language, language),
+        inArray(caseLawPolarityRules.source, ACTIVE_SOURCES),
+      ),
+    )
+    .as("ranked_polarity_rules");
 
 /** The columns `compileRules` reads; the DB read that produces them is the caller's. */
 type PolarityRuleRow = Pick<
@@ -200,18 +224,18 @@ const loadRules = async (
     }
   }
 
+  const ranked = rankPolarityRulesByTier(language);
+
   const rows = await scopedDb((tx) =>
     tx
-      .select()
-      .from(caseLawPolarityRules)
-      .where(
-        and(
-          eq(caseLawPolarityRules.language, language),
-          inArray(caseLawPolarityRules.source, ACTIVE_SOURCES),
-        ),
-      )
-      .orderBy(...polarityRuleOrder)
-      .limit(LIMITS.caseLawPolarityRulesPerLanguage),
+      .select({
+        id: ranked.id,
+        pattern: ranked.pattern,
+        polarity: ranked.polarity,
+        confidence: ranked.confidence,
+      })
+      .from(ranked)
+      .where(lte(ranked.tierRank, RULES_PER_POLARITY)),
   );
 
   const compiled = compileRules(rows);

--- a/apps/api/src/handlers/case-law/polarity/rule-engine.ts
+++ b/apps/api/src/handlers/case-law/polarity/rule-engine.ts
@@ -17,11 +17,11 @@ import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawPolarityRules } from "@/api/db/schema";
 import {
   CLASSIFIABLE_POLARITIES,
-  isValidPolarity,
+  isClassifiablePolarity,
   POLARITY_PRECEDENCE,
   RULE_SOURCE,
 } from "@/api/handlers/case-law/polarity/consts";
-import type { Polarity } from "@/api/handlers/case-law/polarity/consts";
+import type { ClassifiablePolarity } from "@/api/handlers/case-law/polarity/consts";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { TelemetryError } from "@/api/lib/errors/tagged-errors";
@@ -30,7 +30,12 @@ import { LIMITS } from "@/api/lib/limits";
 export type CompiledRule = {
   id: SafeId<"caseLawPolarityRule">;
   regex: RegExp;
-  polarity: Polarity;
+  /**
+   * Narrower than the column, which the CHECK constraint still lets carry any
+   * `Polarity`. A rule labelling a citation `unknown` would be asserting that
+   * classification did not happen, which is not something a match can mean.
+   */
+  polarity: ClassifiablePolarity;
   /** Kept for the specificity tiebreak; the compiled regex hides its length. */
   pattern: string;
   confidence: number;
@@ -38,7 +43,7 @@ export type CompiledRule = {
 
 export type RuleMatch = {
   ruleId: SafeId<"caseLawPolarityRule">;
-  polarity: Polarity;
+  polarity: ClassifiablePolarity;
   confidence: number;
 };
 
@@ -114,6 +119,12 @@ const ACTIVE_SOURCES = [RULE_SOURCE.MANUAL, RULE_SOURCE.LLM_PROMOTED];
  * the per-tier budget bites, which is the same axis `compareRulePrecedence`
  * breaks ties on; the id makes the rank total, so a cap that bites lands on
  * the same rules on every run.
+ *
+ * Only the classifiable polarities are read. The CHECK constraint still lets
+ * a row carry `unknown`, and one that did would otherwise open a fifth
+ * partition — taking a share of a budget divided among four, and, worse,
+ * matching: a citation would be labelled "classification did not happen"
+ * without anything having tried to classify it.
  */
 export const rankPolarityRulesByTier = (language: string) =>
   new QueryBuilder()
@@ -132,6 +143,7 @@ export const rankPolarityRulesByTier = (language: string) =>
       and(
         eq(caseLawPolarityRules.language, language),
         inArray(caseLawPolarityRules.source, ACTIVE_SOURCES),
+        inArray(caseLawPolarityRules.polarity, CLASSIFIABLE_POLARITIES),
       ),
     )
     .as("ranked_polarity_rules");
@@ -145,9 +157,13 @@ type PolarityRuleRow = Pick<
 /**
  * Compile stored rules into the order they are matched in.
  *
- * Rows whose pattern does not compile are dropped; rows carrying a polarity
- * outside `POLARITIES` are dropped and reported, because the CHECK constraint
- * should have made them impossible.
+ * Rows whose pattern does not compile are dropped silently: a bad regex is a
+ * rule that was never going to match. A row whose polarity a rule may not
+ * carry is dropped and reported, because it should not have reached storage:
+ * either it is outside `POLARITIES`, which the CHECK constraint forbids, or
+ * it is `unknown`, which the constraint permits but no match may mean. The
+ * query filters those out too; this is the guard that does not depend on the
+ * caller having done so.
  */
 export const compileRules = (
   rows: readonly PolarityRuleRow[],
@@ -160,12 +176,12 @@ export const compileRules = (
       continue;
     }
 
-    if (!isValidPolarity(row.polarity)) {
+    if (!isClassifiablePolarity(row.polarity)) {
       captureError(
         new TelemetryError({
-          message: "Invalid polarity value in rule",
+          message: "Polarity rule carries a polarity no match may assign",
         }),
-        { ruleId: row.id },
+        { polarity: row.polarity, ruleId: row.id },
       );
       continue;
     }

--- a/apps/api/src/handlers/case-law/polarity/rule-engine.ts
+++ b/apps/api/src/handlers/case-law/polarity/rule-engine.ts
@@ -10,12 +10,14 @@
  * stateless (rules reload from DB on every call).
  */
 
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawPolarityRules } from "@/api/db/schema";
 import {
   isValidPolarity,
+  POLARITIES,
+  POLARITY_PRECEDENCE,
   RULE_SOURCE,
 } from "@/api/handlers/case-law/polarity/consts";
 import type { Polarity } from "@/api/handlers/case-law/polarity/consts";
@@ -24,16 +26,66 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { TelemetryError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 
-type CompiledRule = {
+export type CompiledRule = {
   id: SafeId<"caseLawPolarityRule">;
   regex: RegExp;
   polarity: Polarity;
+  /** Kept for the specificity tiebreak; the compiled regex hides its length. */
+  pattern: string;
+  confidence: number;
 };
 
-type RuleMatch = {
+export type RuleMatch = {
   ruleId: SafeId<"caseLawPolarityRule">;
   polarity: Polarity;
+  confidence: number;
 };
+
+/**
+ * Order two rules that both match one context.
+ *
+ * Severity, then specificity, then id. Specificity is measured by pattern
+ * length, which is coarse but monotone in the usual case: `na\s+rozdíl\s+od`
+ * says more about a sentence than `viz`. The id tiebreak is what makes the
+ * order total, so two rules of equal severity and length resolve the same way
+ * on every run rather than following whatever order the rows arrived in.
+ */
+const compareRulePrecedence = (a: CompiledRule, b: CompiledRule): number => {
+  const severity =
+    POLARITY_PRECEDENCE[a.polarity] - POLARITY_PRECEDENCE[b.polarity];
+  if (severity !== 0) {
+    return severity;
+  }
+
+  const specificity = b.pattern.length - a.pattern.length;
+  if (specificity !== 0) {
+    return specificity;
+  }
+
+  if (a.id === b.id) {
+    return 0;
+  }
+
+  return a.id < b.id ? -1 : 1;
+};
+
+/**
+ * The severity tier of `compareRulePrecedence`, in SQL.
+ *
+ * This orders the truncation, not the matching: `loadRules` caps how many
+ * rules it reads, and the cap has to drop the rules that would have lost
+ * anyway. Ordering that cap by `match_count` instead would let a busy generic
+ * rule push a rare negative one out of the working set entirely, which is the
+ * same shadowing bug one layer down. Match order is re-established in memory
+ * by `compareRulePrecedence`, so only this cap depends on the clause below.
+ */
+const POLARITY_PRECEDENCE_SQL = sql`CASE ${sql.join(
+  POLARITIES.map(
+    (polarity) =>
+      sql`WHEN ${caseLawPolarityRules.polarity} = ${polarity} THEN ${sql.raw(String(POLARITY_PRECEDENCE[polarity]))}`,
+  ),
+  sql` `,
+)} END`;
 
 /** Optional caller-owned cache for batch scripts. */
 export type RuleCache = Map<string, CompiledRule[]>;
@@ -49,6 +101,75 @@ const compilePattern = (pattern: string): RegExp | null => {
 
 /** Active rule sources (proposed rules are excluded). */
 const ACTIVE_SOURCES = [RULE_SOURCE.MANUAL, RULE_SOURCE.LLM_PROMOTED];
+
+/** The columns `compileRules` reads; the DB read that produces them is the caller's. */
+type PolarityRuleRow = Pick<
+  typeof caseLawPolarityRules.$inferSelect,
+  "id" | "pattern" | "polarity" | "confidence"
+>;
+
+/**
+ * Compile stored rules into the order they are matched in.
+ *
+ * Rows whose pattern does not compile are dropped; rows carrying a polarity
+ * outside `POLARITIES` are dropped and reported, because the CHECK constraint
+ * should have made them impossible.
+ */
+export const compileRules = (
+  rows: readonly PolarityRuleRow[],
+): CompiledRule[] => {
+  const compiled: CompiledRule[] = [];
+
+  for (const row of rows) {
+    const regex = compilePattern(row.pattern);
+    if (!regex) {
+      continue;
+    }
+
+    if (!isValidPolarity(row.polarity)) {
+      captureError(
+        new TelemetryError({
+          message: "Invalid polarity value in rule",
+        }),
+        { ruleId: row.id },
+      );
+      continue;
+    }
+
+    compiled.push({
+      id: row.id,
+      regex,
+      polarity: row.polarity,
+      pattern: row.pattern,
+      confidence: row.confidence,
+    });
+  }
+
+  return compiled.sort(compareRulePrecedence);
+};
+
+/**
+ * The highest-precedence rule matching a context, or null.
+ *
+ * `rules` must be in `compileRules` order, which is what makes the first
+ * match the winning one.
+ */
+export const selectRuleMatch = (
+  rules: readonly CompiledRule[],
+  context: string,
+): RuleMatch | null => {
+  for (const rule of rules) {
+    if (rule.regex.test(context)) {
+      return {
+        ruleId: rule.id,
+        polarity: rule.polarity,
+        confidence: rule.confidence,
+      };
+    }
+  }
+
+  return null;
+};
 
 /**
  * Load and compile active rules for a language from the database.
@@ -82,61 +203,42 @@ const loadRules = async (
           inArray(caseLawPolarityRules.source, ACTIVE_SOURCES),
         ),
       )
-      .orderBy(desc(caseLawPolarityRules.matchCount))
+      .orderBy(
+        POLARITY_PRECEDENCE_SQL,
+        sql`length(${caseLawPolarityRules.pattern}) desc`,
+        caseLawPolarityRules.id,
+      )
       .limit(LIMITS.caseLawPolarityRulesPerLanguage),
   );
 
-  const compiled: CompiledRule[] = [];
-
-  for (const row of rows) {
-    const regex = compilePattern(row.pattern);
-    if (!regex) {
-      continue;
-    }
-
-    if (!isValidPolarity(row.polarity)) {
-      captureError(
-        new TelemetryError({
-          message: "Invalid polarity value in rule",
-        }),
-        { ruleId: row.id },
-      );
-      continue;
-    }
-
-    compiled.push({
-      id: row.id,
-      regex,
-      polarity: row.polarity,
-    });
-  }
+  const compiled = compileRules(rows);
 
   cache?.set(language, compiled);
   return compiled;
 };
 
 /**
- * Match a citation context against all active rules for a
- * language. Returns the first matching rule, or null.
+ * Match a citation context against all active rules for a language.
+ *
+ * Rules are held in `compareRulePrecedence` order, so the first match is the
+ * highest-precedence match rather than whichever rule happened to be read
+ * first. Returns null when nothing matches.
  */
 export const matchRule = async (
   context: string,
   language: string,
   scopedDb: ScopedDb,
   cache?: RuleCache,
-): Promise<RuleMatch | null> => {
-  const rules = await loadRules(language, scopedDb, cache);
+): Promise<RuleMatch | null> =>
+  selectRuleMatch(await loadRules(language, scopedDb, cache), context);
 
-  for (const rule of rules) {
-    if (rule.regex.test(context)) {
-      return { ruleId: rule.id, polarity: rule.polarity };
-    }
-  }
-
-  return null;
-};
-
-/** Increment the match count for a rule. */
+/**
+ * Record that a rule fired.
+ *
+ * Telemetry only: `match_count` reports how much work a rule is doing and
+ * feeds rule curation. It carries no authority over classification, and in
+ * particular must stay out of every ordering that decides which rule wins.
+ */
 type IncrementMatchCountArgs = {
   observedAt: Date;
   ruleId: SafeId<"caseLawPolarityRule">;

--- a/apps/api/src/handlers/case-law/polarity/rule-engine.ts
+++ b/apps/api/src/handlers/case-law/polarity/rule-engine.ts
@@ -84,6 +84,9 @@ const compareRulePrecedence = (a: CompiledRule, b: CompiledRule): number => {
  * So the budget is divided among the tiers rather than competed for. No tier
  * can starve another, and severity stays a matching concern, expressed once,
  * in `compareRulePrecedence`.
+ *
+ * The read stays bounded: at most this many rows per polarity present, so
+ * the language-wide total is within rounding of the limit it divides.
  */
 export const RULES_PER_POLARITY = Math.ceil(
   LIMITS.caseLawPolarityRulesPerLanguage / CLASSIFIABLE_POLARITIES.length,

--- a/apps/api/src/handlers/case-law/polarity/rule-engine.ts
+++ b/apps/api/src/handlers/case-law/polarity/rule-engine.ts
@@ -157,13 +157,16 @@ type PolarityRuleRow = Pick<
 /**
  * Compile stored rules into the order they are matched in.
  *
- * Rows whose pattern does not compile are dropped silently: a bad regex is a
- * rule that was never going to match. A row whose polarity a rule may not
- * carry is dropped and reported, because it should not have reached storage:
- * either it is outside `POLARITIES`, which the CHECK constraint forbids, or
- * it is `unknown`, which the constraint permits but no match may mean. The
- * query filters those out too; this is the guard that does not depend on the
- * caller having done so.
+ * A row is dropped, and reported, when it cannot take part in matching:
+ * either its pattern does not compile, or it carries a polarity no match may
+ * assign (outside `POLARITIES`, which the CHECK constraint forbids, or
+ * `unknown`, which the constraint permits but which means classification did
+ * not happen). Both are reported rather than dropped quietly, because such a
+ * row is a rule that can never fire and still occupies its tier's budget:
+ * left invisible, it is subtracted from the working set forever.
+ *
+ * The ranked query filters the polarity case out too. This is the guard that
+ * does not depend on the caller having done so.
  */
 export const compileRules = (
   rows: readonly PolarityRuleRow[],
@@ -173,6 +176,12 @@ export const compileRules = (
   for (const row of rows) {
     const regex = compilePattern(row.pattern);
     if (!regex) {
+      captureError(
+        new TelemetryError({
+          message: "Polarity rule pattern does not compile",
+        }),
+        { pattern: row.pattern, ruleId: row.id },
+      );
       continue;
     }
 

--- a/apps/api/src/mcp/tool-utils.test.ts
+++ b/apps/api/src/mcp/tool-utils.test.ts
@@ -94,9 +94,8 @@ describe("slugifyCaseLawPathSegment", () => {
   });
 
   test("agrees with the persisted slug generator", () => {
-    // These segments end up in public URLs the API has already persisted
-    // slugs for, so the two must fold identically. This used to be a
-    // hand-copied NFKD strip rather than a call to the shared helper.
+    // These segments address rows whose slug the API already generated, so
+    // the two folds must agree. This used to be a hand-copied NFKD strip.
     const segments = [
       "Nejvyšší soud",
       "Ústavní soud České republiky",
@@ -114,6 +113,18 @@ describe("slugifyCaseLawPathSegment", () => {
         createCaseLawDecisionSlug(segment),
       );
     }
+  });
+
+  test("truncates like the persisted slug on an expanding case number", () => {
+    // `case_number` and `slug` are both varchar(256), and NFKD expands the
+    // ligature threefold, so a full-width case number slugifies past the
+    // column its persisted slug was truncated to. A URL built without that
+    // truncation would address a slug nobody stored.
+    const caseNumber = "ﬃ".repeat(256);
+    const slug = slugifyCaseLawPathSegment(caseNumber);
+
+    expect(slug.length).toBeLessThanOrEqual(256);
+    expect(slug).toBe(createCaseLawDecisionSlug(caseNumber));
   });
 });
 

--- a/apps/api/src/mcp/tool-utils.test.ts
+++ b/apps/api/src/mcp/tool-utils.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as v from "valibot";
 
 import { env } from "@/api/env";
+import { createCaseLawDecisionSlug } from "@/api/handlers/case-law/decisions/slug";
 import { type SafeId, toSafeId } from "@/api/lib/branded-types";
 import { runWithRequestId } from "@/api/lib/observability/request-context";
 import { encodePaginationCursor } from "@/api/lib/pagination";
@@ -90,6 +91,29 @@ describe("slugifyCaseLawPathSegment", () => {
   test("falls back to 'unknown' when nothing alphanumeric remains", () => {
     expect(slugifyCaseLawPathSegment("///")).toBe("unknown");
     expect(slugifyCaseLawPathSegment("")).toBe("unknown");
+  });
+
+  test("agrees with the persisted slug generator", () => {
+    // These segments end up in public URLs the API has already persisted
+    // slugs for, so the two must fold identically. This used to be a
+    // hand-copied NFKD strip rather than a call to the shared helper.
+    const segments = [
+      "Nejvyšší soud",
+      "Ústavní soud České republiky",
+      "Najvyšší súd Slovenskej republiky",
+      "Sąd Najwyższy — Izba Cywilna",
+      "Oberster Gerichtshof (Österreich)",
+      "29 Cdo 123/2024",
+      "II. ÚS 251/04",
+      "ﬁnanční ročník²",
+      "  ---  ",
+    ];
+
+    for (const segment of segments) {
+      expect(slugifyCaseLawPathSegment(segment)).toBe(
+        createCaseLawDecisionSlug(segment),
+      );
+    }
   });
 });
 

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -2,6 +2,8 @@ import type { CallToolResult } from "@modelcontextprotocol/server";
 import { panic, TaggedError } from "better-result";
 import * as v from "valibot";
 
+import { stripDiacriticsForSlug } from "@stll/text-normalize";
+
 import { env } from "@/api/env";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { AuditEvent, AuditRecorder } from "@/api/lib/audit-log";
@@ -707,11 +709,12 @@ const trimSlugHyphens = (value: string): string => {
 };
 
 export const slugifyCaseLawPathSegment = (value: string): string => {
+  // Must reproduce the API's persisted case-law slugs byte-for-byte
+  // (apps/api/src/handlers/case-law/decisions/slug.ts): same NFKD strip,
+  // same op order.
   const slug = trimSlugHyphens(
-    value
-      .normalize("NFKD")
+    stripDiacriticsForSlug(value)
       .toLowerCase()
-      .replace(/\p{Diacritic}/gu, "")
       .replace(/[^a-z0-9]+/gu, "-"),
   );
 

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -2,9 +2,8 @@ import type { CallToolResult } from "@modelcontextprotocol/server";
 import { panic, TaggedError } from "better-result";
 import * as v from "valibot";
 
-import { stripDiacriticsForSlug } from "@stll/text-normalize";
-
 import { env } from "@/api/env";
+import { createCaseLawDecisionSlug } from "@/api/handlers/case-law/decisions/slug";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { AuditEvent, AuditRecorder } from "@/api/lib/audit-log";
 import type { AccessibleWorkspace } from "@/api/lib/auth";
@@ -694,32 +693,19 @@ const slugifyCaseNumber = (caseNumber: string) =>
 const UNKNOWN_COURT_SEGMENT = "unknown-court";
 const LANGUAGE_SEGMENT_REGEX = /^(?=.{2,8}$)[a-z]{2,3}(?:-[a-z0-9]{2,8})*$/u;
 
-const trimSlugHyphens = (value: string): string => {
-  let start = 0;
-  while (value.at(start) === "-") {
-    start += 1;
-  }
-
-  let end = value.length;
-  while (end > start && value.at(end - 1) === "-") {
-    end -= 1;
-  }
-
-  return value.slice(start, end);
-};
-
-export const slugifyCaseLawPathSegment = (value: string): string => {
-  // Must reproduce the API's persisted case-law slugs byte-for-byte
-  // (apps/api/src/handlers/case-law/decisions/slug.ts): same NFKD strip,
-  // same op order.
-  const slug = trimSlugHyphens(
-    stripDiacriticsForSlug(value)
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/gu, "-"),
-  );
-
-  return slug.length > 0 ? slug : "unknown";
-};
+/**
+ * A case-law URL segment, folded exactly as the persisted slug was.
+ *
+ * These segments address rows whose slug the API already generated, so the
+ * two folds have to agree on every step, length included: `case_number` and
+ * `slug` are both `varchar(256)`, and NFKD expansion can push a long case
+ * number's slug past the column the persisted one was truncated to. A
+ * segment folded without that truncation would address a slug nobody stored.
+ * Delegating leaves one implementation rather than two that must be kept
+ * equal by hand.
+ */
+export const slugifyCaseLawPathSegment = (value: string): string =>
+  createCaseLawDecisionSlug(value);
 
 const normalizeCaseLawStoredSlug = (
   slug: string | null | undefined,


### PR DESCRIPTION
Five correctness fixes in the citation polarity engine and the citation-kind
classifier, plus two removals. No schema changes.

## Polarity rule precedence was decided by popularity

`matchRule` returned the first hit over rules ordered `match_count DESC`, and
every hit incremented that count. The order was self-reinforcing: a generic
positive rule that fired often kept climbing and permanently shadowed a rare,
specific negative rule matching the same sentence, so a court distinguishing a
decision was recorded as following it.

Rules are now ordered by severity (negative, then positive/supportive, then
neutral), then pattern specificity, then id, which makes the order total and
reproducible. `match_count` stays as telemetry and enters no ordering.

The row cap in `loadRules` had the same defect one layer down, and ordering it
by severity would only have moved the starvation: a language that accumulated
a cap's worth of negative rules would load nothing else. Each polarity now
gets its own share of the budget, via a `row_number()` partitioned by
polarity, so no tier can evict another. Severity is therefore expressed once,
in the in-memory comparator, and not mirrored into SQL.

`compileRules` and `selectRuleMatch` are extracted as pure functions so the
precedence decision is testable without a database.

A rule row can also carry `unknown`, which the CHECK constraint permits: it
would have opened a fifth partition against a budget divided among four, and
it would have matched, labelling a citation "classification did not happen"
at the moment the regex tier had classified it. The ranked read and
`compileRules` both exclude it, and `CompiledRule.polarity` narrows to
`ClassifiablePolarity` so the two cannot drift.

## The two classifier tiers used different label sets

The rule table has always emitted `supportive` (`srov.`, `viz`, `obdobně`: 18
of the 45 seed rules). The LLM tier's Valibot picklist offered only
positive/neutral/negative, and its prompt described `srov.` as neutral. The
same phrase therefore got one label from a regex rule and another from the
model.

Both now derive from the canonical `POLARITIES` list, and the prompt's
per-polarity guidance is a map total over that list, so a new value cannot be
added without the model being told what it means. No data migration:
`supportive` was already a valid stored value, so keeping it first-class is
the option that touches no rows.

## LLM confidence was discarded

The model returns a confidence the pipeline dropped on the floor. It is now
carried on `ClassifyResult`, alongside the matched rule's stored confidence.
`case_law_citations` has no column for it, so it is not persisted yet; the
comment at `persistPolarity` records that.

## Unifying-court registries were classified as procedural

`AUTHORITY_REGISTRIES` was missing the registers whose whole purpose is to
unify divergent practice, so those decisions were kept out of the citation
graph: Czech Supreme Court kolegium opinions (`Cpjn`, `Tpjn`, and the
historical `Opjn`), Slovak grand chambers (`VCdo`, `VObdo`, and the Supreme
Administrative Court's `SVs`), and Polish legal-question resolutions of the
labour chamber (`PZP`).

Adding the marks alone would not have worked. `registryOf` read a mark only
after a Roman or Arabic chamber number, and a kolegium opinion has neither:
`Cpjn 203/2010` is the whole file number, because the kolegium sits as a
whole. The citation extractor already recognises that bare form, so those
citations reached the classifier and fell through to procedural every time.
`registryOf` now also reads a leading mark when the case number's digits
follow it directly. That form is tried last and promotes nothing by itself,
so an unlisted mark still falls through exactly as a null did; a test pins
that.

There is deliberately no Slovak criminal grand-chamber entry: Slovak criminal
law has no veľký senát, and the zjednocovacie senáty that stand in for it are
declared registers with nothing published to cite. Test fixtures use real file
numbers, since the registers use disjoint number ranges and an invented one
would not stand in for the others.

Also drops a duplicate `cdo`, shared by the Czech and Slovak Supreme Courts
and listed twice in the Set.

## Removals

- `slugifyCaseLawPathSegment` in the MCP tool utilities re-implemented the
  persisted slug fold inline, in a different order, and without its length
  finalisation. These segments address rows whose slug the API already
  generated, so the folds have to agree on every step: `case_number` and
  `slug` are both `varchar(256)` and NFKD expands threefold (`ﬃ` to `ffi`),
  so a long case number's persisted slug was truncated where the MCP one was
  not, and the URL addressed a slug nobody stored. It now delegates to
  `createCaseLawDecisionSlug`, leaving one implementation.

- `settleCaseLawCorpusMirror` has had no production caller since settlement
  moved inside `writeReservedCaseLawCorpusUpload`, which calls the
  transaction-scoped helper directly. The two tests still reaching it covered
  nothing the remaining suites do not: the unit pair asserted against a
  transaction double that ignores `.where()`, so it exercised no predicate
  arm, and the database test set `redactedAt` and a non-pending mirror status
  in one statement, so it would have passed with the redaction fence removed.
  That invariant is held by the `FOR UPDATE` redaction check in
  `writeReservedCaseLawCorpusUpload` and by the
  `case_law_decisions_redacted_payload_erased` constraint.

## Deliberately not in this PR

- Splitting `unknown` (classification did not happen) from a distinct
  "read it, could not decide" value. Both the citations and the rules tables
  derive a CHECK constraint from `POLARITIES`, so a new value needs a
  migration; the conflation is documented at the fallback return.
- A `polarity_confidence` column on `case_law_citations`, for the same reason.
- Re-classifying citations already labelled under the old precedence. Only
  rows with a null polarity are picked up from here; a sweep over the existing
  labels is a batch operation, not a deploy.
- A shape guard for the Slovak `Vs` mark. It is genuine but dormant
  (administrative kolégium grand chamber, 2018-2021, succeeded by `SVs`), and
  it is the highest false-positive risk of the set: a flat registry Set cannot
  express the strict `\d+\s*Vs\s*[/ ]\d+/\d{4}` shape it needs.

## Found while here, not fixed here

- `settleCaseLawCorpusMirrorTx`'s compare-and-set predicate (`pipeline.ts`)
  and the `ownerPredicate` built for the preflight a thousand lines below it
  are hand-mirrored copies of the same six-arm condition. Extracting one
  predicate builder would remove the drift; it is a separate change to the
  ingestion pipeline, which has other work in flight.
- No test reaches `settleCaseLawCorpusMirrorTx` against a real database: the
  db suites run with corpus storage off, so the mirror block never executes.
  A `processDecision` test under a mocked canonical storage mode would cover
  all six predicate arms and both SET shapes, which is more than the tests
  removed here ever did.

- `apps/web/src/lib/case-law-route.ts` folds the same segments with the same
  missing truncation. It is a different package with its own route matching,
  so this PR does not touch it. The durable fix is to move the whole fold,
  truncation included, into `@stll/text-normalize`, so API, MCP and web share
  one implementation instead of three that must be kept equal by hand.

## Verification

`tsc` clean across all four API projects, type-aware oxlint clean, `oxfmt`
applied, `scripts/ratchet.ts` and `scripts/lint-suppressions.ts` both at
baseline. The case-law and MCP suites pass. Two failures in
`replay-apply.db.test.ts` are environmental (a local object-storage bucket
belonging to a different dev stack) and reproduce independently of this diff.
