### PR TITLE
fix(case-law): read-path resilience and ingest durability semantics

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -45,7 +45,11 @@ import {
   timestampMatchesCasToken,
 } from "@/api/lib/db/timestamp-cas";
 import { ConcurrentModificationError } from "@/api/lib/errors/tagged-errors";
-import { CorpusIndexError } from "@/api/lib/legal-search/corpus-index-client";
+import {
+  CORPUS_INDEX_COMMIT,
+  CorpusIndexError,
+} from "@/api/lib/legal-search/corpus-index-client";
+import type { CorpusIndexCommitMode } from "@/api/lib/legal-search/corpus-index-client";
 import {
   isRedistributable,
   type CorpusSourceDescriptor,
@@ -1101,7 +1105,7 @@ type GenerationBackfillDependencies = {
     scopedDb: Parameters<typeof backfillIncrementalCorpusIndex>[0],
     rows: readonly IndexableRow[],
     generation: string,
-    options: GenerationProjectionGuards,
+    options: GenerationProjectionGuards & { commit: CorpusIndexCommitMode },
   ) => Promise<number>;
   removeProjection: (
     scopedDb: Parameters<typeof backfillIncrementalCorpusIndex>[0],
@@ -1623,7 +1627,13 @@ export const createCaseLawGenerationBackfill =
           const indexed =
             eligible.length === 0
               ? 0
-              : await backfillRows(scopedDb, eligible, generation, guards);
+              : await backfillRows(scopedDb, eligible, generation, {
+                  ...guards,
+                  // A source-wide re-index walks a whole source's corpus
+                  // a page at a time, so it is bulk work with the same
+                  // census behind it as the snapshot walk.
+                  commit: CORPUS_INDEX_COMMIT.auto,
+                });
           if (indexed !== eligible.length) {
             throw new CorpusIndexError({
               message:
@@ -1722,7 +1732,15 @@ export const createCaseLawGenerationBackfill =
         const indexed =
           eligible.length === 0
             ? 0
-            : await backfillRows(scopedDb, eligible, generation, guards);
+            : await backfillRows(scopedDb, eligible, generation, {
+                ...guards,
+                // The live path: every newly ingested decision waits in
+                // this queue, and the mark taken on the way out is the
+                // last thing that would ever select it. Acceptance has
+                // to mean committed here or the row goes permanently
+                // missing from the index while Postgres reads indexed.
+                commit: CORPUS_INDEX_COMMIT.waitFor,
+              });
         if (indexed !== eligible.length) {
           throw new CorpusIndexError({
             message: "generation reconciliation did not reach a fixed point",
@@ -2009,7 +2027,13 @@ export const createCaseLawGenerationBackfill =
         indexed =
           rows.length === 0
             ? 0
-            : await backfillRows(scopedDb, rows, generation, runningGuards);
+            : await backfillRows(scopedDb, rows, generation, {
+                ...runningGuards,
+                // Snapshot pages of the rebuild: bulk throughput, whose
+                // completeness the generation's census verifies rather
+                // than each request proving it for itself.
+                commit: CORPUS_INDEX_COMMIT.auto,
+              });
         if (indexed !== rows.length) {
           throw new CorpusIndexError({
             message: "generation backfill page did not reach a fixed point",

--- a/apps/api/src/handlers/case-law/decisions/document-on-demand.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/document-on-demand.test.ts
@@ -262,6 +262,80 @@ describe("deferred document read-through", () => {
     expect(fetched).toHaveLength(2);
   });
 
+  /**
+   * The module's whole contract in one property: whatever the durable
+   * side does, the reader gets an answer. The read that calls this has
+   * no error boundary of its own, so a rejection escaping here is a 500
+   * on a decision that is merely waiting for its document — the failure
+   * mode the metadata-only response exists to prevent.
+   *
+   * The cases are the ways the fetch unit can actually end: a rejection
+   * from the court or the pool, a rejecting demand recording, a claim
+   * another worker holds, a unit that never settles, and a resolved
+   * outcome whose shape the caller did not expect — which is a
+   * rejection raised past the fetch's own guard, on the promise the
+   * budget abandons.
+   */
+  const badShape = {
+    recordRequest: async () => {
+      await Promise.resolve();
+    },
+    fetchDocument: async () => {
+      await Promise.resolve();
+      return undefined;
+    },
+  };
+  // SAFETY: deliberately outside the outcome union. The fetch unit is
+  // typed, but the read must survive a shape it did not expect all the
+  // same: reading `.status` off it throws past the fetch's own guard, on
+  // the one promise the read budget abandons.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the point of the case is a value the union forbids
+  const badShapeDeps = badShape as unknown as OnDemandDocumentDeps;
+
+  const hostile: Record<string, () => OnDemandDocumentDeps> = {
+    "a rejecting fetch": () => ({
+      recordRequest: async () => {
+        await Promise.resolve();
+      },
+      fetchDocument: async () => {
+        await Promise.resolve();
+        throw new Error("court site unreachable");
+      },
+    }),
+    "a rejecting demand recording": () => ({
+      recordRequest: async () => {
+        await Promise.resolve();
+        throw new Error("row locked");
+      },
+      fetchDocument: async () => {
+        await Promise.resolve();
+        return { status: "claimed" };
+      },
+    }),
+    "a fetch that never settles": () => ({
+      recordRequest: async () => {
+        await Promise.resolve();
+      },
+      fetchDocument: async () =>
+        await new Promise<never>(() => {
+          // The court never answers, and never says so.
+        }),
+    }),
+    "an unexpected outcome shape": () => badShapeDeps,
+  };
+
+  for (const [name, build] of Object.entries(hostile)) {
+    test(`${name} reads as metadata-only rather than failing the read`, async () => {
+      expect(
+        await readThroughDeferredDocument({
+          decision: pending(),
+          deps: build(),
+          recordDemand: true,
+        }),
+      ).toBeNull();
+    }, 20_000);
+  }
+
   test("only an un-fetched document from a deferred source is fetchable", () => {
     const state = {
       adapterKey: "sk-courts",

--- a/apps/api/src/handlers/case-law/decisions/document-on-demand.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/document-on-demand.test.ts
@@ -341,9 +341,18 @@ describe("deferred document read-through", () => {
       adapterKey: "sk-courts",
       documentUrl: "https://example.test/decision.pdf",
       documentPending: true,
+      documentReadFailed: false,
     };
 
     expect(isDeferredDocumentFetchable(state)).toBe(true);
+    // Pending because object storage refused a payload the row does
+    // hold. A fetch cannot repair that — the store refuses a row already
+    // carrying a corpus document — so every reader during an outage
+    // would pay for a download that can never land, and wait out the
+    // read budget behind it.
+    expect(
+      isDeferredDocumentFetchable({ ...state, documentReadFailed: true }),
+    ).toBe(false);
     // The read already found something readable stored.
     expect(
       isDeferredDocumentFetchable({ ...state, documentPending: false }),

--- a/apps/api/src/handlers/case-law/decisions/document-on-demand.ts
+++ b/apps/api/src/handlers/case-law/decisions/document-on-demand.ts
@@ -137,9 +137,15 @@ const recordFailure = (
   error: unknown,
   decisionId: SafeId<"caseLawDecision">,
 ): void => {
-  Result.try(() => {
+  const captured = Result.try(() => {
     captureError(error, { source: CAPTURE_SOURCE, decisionId });
   });
+  if (Result.isError(captured)) {
+    // The reporting channel is what broke, so there is nowhere left to
+    // report it. Dropped here on purpose rather than escalated into the
+    // read this was recording a failure for.
+    return;
+  }
 };
 
 /**

--- a/apps/api/src/handlers/case-law/decisions/document-on-demand.ts
+++ b/apps/api/src/handlers/case-law/decisions/document-on-demand.ts
@@ -79,6 +79,11 @@ export type DeferredDocumentState = {
   adapterKey: string;
   documentUrl: string | null;
   documentPending: boolean;
+  /**
+   * Whether the read reported pending because object storage refused a
+   * payload it does hold, rather than because nothing was ever fetched.
+   */
+  documentReadFailed: boolean;
 };
 
 /**
@@ -86,16 +91,26 @@ export type DeferredDocumentState = {
  *
  * `documentPending` is the read's own answer to "is anything readable
  * stored for this decision" — no text, no AST, and no canonical payload
- * in object storage. This adds the two conditions the read does not
- * judge: the source has to be one that defers its documents, and there
- * has to be something to fetch.
+ * in object storage. This adds the conditions the read does not judge:
+ * the source has to be one that defers its documents, there has to be
+ * something to fetch, and the pending state has to mean the document is
+ * genuinely missing.
+ *
+ * That last one is the difference between a document nobody has fetched
+ * and one object storage could not serve. The reader is told the same
+ * thing either way, but a fetch would be pure waste for the second: the
+ * store refuses a row that already carries a corpus document, so the
+ * download could never land, and every reader during an outage would pay
+ * for one and wait out the read budget behind it.
  */
 export const isDeferredDocumentFetchable = ({
   adapterKey,
   documentUrl,
   documentPending,
+  documentReadFailed,
 }: DeferredDocumentState): boolean =>
   documentPending &&
+  !documentReadFailed &&
   documentUrl !== null &&
   DEFERRED_DOCUMENT_ADAPTER_KEYS.has(adapterKey);
 

--- a/apps/api/src/handlers/case-law/decisions/document-on-demand.ts
+++ b/apps/api/src/handlers/case-law/decisions/document-on-demand.ts
@@ -16,6 +16,14 @@
  * Nothing here can fail a read — a failure is recorded and the decision
  * stays queued.
  *
+ * That last sentence is a guarantee, so it is enforced at one place
+ * rather than restated at every await: `readThroughDeferredDocument`
+ * settles its whole body through a single boundary that turns any
+ * rejection into the metadata-only answer. The call site
+ * (`get-deferred-document.ts`) awaits it bare and has no boundary of its
+ * own, so a rejection that escaped here would 500 the public read; the
+ * per-await wrapping below is defence in depth, not the guarantee.
+ *
  * The bounds above are per process. The cross-process claim that keeps
  * two replicas off one document lives in the fetch unit itself, which
  * is also where the database access is: this module stays free of it,
@@ -24,16 +32,18 @@
  * two together for the public read.
  */
 
-import { Result } from "better-result";
+import { Result, UnhandledException } from "better-result";
 
 import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
+import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 import type {
   BackfilledDocument,
   DecisionDocumentOutcome,
   PendingDocument,
 } from "@/api/lib/legal-search/sk-document-backfill";
+import { withTimeout } from "@/api/lib/with-timeout";
 
 /** Sources that ingest metadata first and the document later. */
 const DEFERRED_DOCUMENT_ADAPTER_KEYS: ReadonlySet<string> = new Set([
@@ -46,6 +56,9 @@ const DEFERRED_DOCUMENT_ADAPTER_KEYS: ReadonlySet<string> = new Set([
  * the fetch it started keeps running for the next one.
  */
 const READ_BUDGET_MS = 6000;
+
+/** Names the budget's own expiry apart from a genuine failure. */
+const READ_BUDGET_LABEL = "caseLaw.deferredDocumentRead";
 
 /** Concurrent read-through fetches allowed at a time. */
 const CONCURRENT_FETCH_LIMIT = 2;
@@ -98,23 +111,55 @@ export type OnDemandDocumentDeps = {
   ) => Promise<DecisionDocumentOutcome>;
 };
 
+/**
+ * Record a read-through failure without letting the recording become
+ * one. `captureError` reaches the analytics client and the dev log
+ * sink, so it is itself failable; a throw there would turn a recorded
+ * failure into a failed read, which is exactly what this module
+ * promises cannot happen.
+ */
+const recordFailure = (
+  error: unknown,
+  decisionId: SafeId<"caseLawDecision">,
+): void => {
+  Result.try(() => {
+    captureError(error, { source: CAPTURE_SOURCE, decisionId });
+  });
+};
+
+/**
+ * Whether this is the read budget running out rather than something
+ * failing. Expiry is the designed outcome for a document the source is
+ * slow to serve, so reporting it would bury the failures that matter
+ * under one event per slow read. `Result.tryPromise` reports a rejection
+ * as an `UnhandledException` carrying the original as its cause, so the
+ * label is read through that wrapper as well as directly.
+ */
+const isReadBudgetExpiry = (error: unknown): boolean => {
+  const raised = error instanceof UnhandledException ? error.cause : error;
+  return TimeoutError.is(raised) && raised.label === READ_BUDGET_LABEL;
+};
+
 const runFetch = async (
   decision: PendingDocument,
   deps: OnDemandDocumentDeps,
 ): Promise<BackfilledDocument | null> => {
-  const outcome = await Result.tryPromise(
-    async () => await deps.fetchDocument(decision),
-  );
+  // The outcome is read inside the guard, not after it: an unexpected
+  // shape from the fetch unit would otherwise throw past the only thing
+  // catching for this promise, and this promise is the one the read
+  // budget abandons — a rejection landing after that has nothing
+  // attached to it at all.
+  const outcome = await Result.tryPromise(async () => {
+    const fetched = await deps.fetchDocument(decision);
+    return fetched.status === "filled" ? fetched.document : null;
+  });
 
   if (Result.isError(outcome)) {
-    captureError(outcome.error, {
-      source: CAPTURE_SOURCE,
-      decisionId: decision.id,
-    });
+    recordFailure(outcome.error, decision.id);
     return null;
   }
 
-  return outcome.value.status === "filled" ? outcome.value.document : null;
+  return outcome.value;
 };
 
 const startFetch = async (
@@ -127,23 +172,6 @@ const startFetch = async (
   inFlight.set(decision.id, flight);
 
   return await flight;
-};
-
-const withReadBudget = async (
-  flight: Promise<BackfilledDocument | null>,
-): Promise<BackfilledDocument | null> => {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const budget = new Promise<null>((resolve) => {
-    timer = setTimeout(() => {
-      resolve(null);
-    }, READ_BUDGET_MS);
-  });
-
-  try {
-    return await Promise.race([flight, budget]);
-  } finally {
-    clearTimeout(timer);
-  }
 };
 
 export type ReadThroughDeferredDocumentOptions = {
@@ -187,10 +215,7 @@ export const readThroughDeferredDocument = async ({
         async () => await deps.recordRequest(decision.id),
       );
       if (Result.isError(recorded)) {
-        captureError(recorded.error, {
-          source: CAPTURE_SOURCE,
-          decisionId: decision.id,
-        });
+        recordFailure(recorded.error, decision.id);
       }
     }
 
@@ -202,5 +227,31 @@ export const readThroughDeferredDocument = async ({
     return await (existing ?? startFetch(decision, deps));
   };
 
-  return await withReadBudget(attempt());
+  // The single boundary the module's guarantee rests on. Every await
+  // inside is wrapped already, but that is discipline a later edit can
+  // break silently, and the public read that calls this has no boundary
+  // of its own: one escaping rejection turns a decision that is merely
+  // waiting for its document into a 500. Failing here means the reader
+  // gets the metadata-only decision, still marked pending, and the queue
+  // keeps the work.
+  //
+  // The budget is the shared `withTimeout` rather than a local timer
+  // race, so an attempt that settles after the deadline cannot surface
+  // as an unhandled rejection. Expiry is the documented outcome, not a
+  // failure, so it is the one error this does not report.
+  const outcome = await Result.tryPromise(
+    async () =>
+      await withTimeout(async () => await attempt(), {
+        label: READ_BUDGET_LABEL,
+        timeoutMs: READ_BUDGET_MS,
+      }),
+  );
+  if (Result.isError(outcome)) {
+    if (!isReadBudgetExpiry(outcome.error)) {
+      recordFailure(outcome.error, decision.id);
+    }
+    return null;
+  }
+
+  return outcome.value;
 };

--- a/apps/api/src/handlers/case-law/decisions/document-on-demand.ts
+++ b/apps/api/src/handlers/case-law/decisions/document-on-demand.ts
@@ -136,17 +136,14 @@ export type OnDemandDocumentDeps = {
 const recordFailure = (
   error: unknown,
   decisionId: SafeId<"caseLawDecision">,
-): void => {
-  const captured = Result.try(() => {
+): void =>
+  // A failure of the recording itself is dropped on purpose: the
+  // reporting channel is what broke, so there is nowhere left to report
+  // that, and it must not be escalated into the read it was recording a
+  // failure for.
+  Result.try(() => {
     captureError(error, { source: CAPTURE_SOURCE, decisionId });
-  });
-  if (Result.isError(captured)) {
-    // The reporting channel is what broke, so there is nowhere left to
-    // report it. Dropped here on purpose rather than escalated into the
-    // read this was recording a failure for.
-    return;
-  }
-};
+  }).unwrapOr(undefined);
 
 /**
  * Whether this is the read budget running out rather than something

--- a/apps/api/src/handlers/case-law/decisions/document-state.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/document-state.test.ts
@@ -23,6 +23,7 @@ const noColumnRead = async (): Promise<boolean | null> => {
 
 type Scenario = {
   hasReadableDocument?: boolean;
+  corpusPayloadUnavailable?: boolean;
   documentUrl?: string | null;
   corpusServed?: boolean;
   contentHash?: string | null;
@@ -34,6 +35,7 @@ type Scenario = {
 const state = async (scenario: Scenario) =>
   await resolveDocumentState({
     hasReadableDocument: false,
+    corpusPayloadUnavailable: false,
     documentUrl: "https://example.test/decision.pdf",
     corpusServed: false,
     contentHash: null,
@@ -55,6 +57,48 @@ describe("document state", () => {
     expect(await state({ documentUrl: null })).toEqual({
       documentPending: false,
       documentUnavailable: false,
+    });
+  });
+
+  describe("a payload object storage refused", () => {
+    // A trimmed canonical row keeps nothing in Postgres, so a refused
+    // object leaves the read with no body and no column that can say
+    // why. Reporting "neither" would render a decision with no text as a
+    // complete one; the read used to fail outright instead, which loses
+    // the metadata, citations and case number as well.
+    test("reads as pending even where the row is corpus-served", async () => {
+      expect(
+        await state({
+          corpusPayloadUnavailable: true,
+          corpusServed: true,
+          contentHash: REAL_HASH,
+        }),
+      ).toEqual({ documentPending: true, documentUnavailable: false });
+    });
+
+    test("reads as pending even where there is nothing to fetch", async () => {
+      // Sources that store the document during the crawl have no
+      // document URL, so nothing will re-fetch this — but the reader
+      // still must not be shown a bodyless decision as a whole one.
+      expect(
+        await state({
+          corpusPayloadUnavailable: true,
+          documentUrl: null,
+          corpusServed: true,
+          contentHash: REAL_HASH,
+        }),
+      ).toEqual({ documentPending: true, documentUnavailable: false });
+    });
+
+    test("does not override a document the read did resolve", async () => {
+      // Only one of the two payloads has to arrive: an AST refusal with
+      // a text fallback that worked is still a readable decision.
+      expect(
+        await state({
+          corpusPayloadUnavailable: true,
+          hasReadableDocument: true,
+        }),
+      ).toEqual({ documentPending: false, documentUnavailable: false });
     });
   });
 

--- a/apps/api/src/handlers/case-law/decisions/document-state.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/document-state.test.ts
@@ -49,6 +49,7 @@ describe("document state", () => {
   test("a decision that read as a document is neither", async () => {
     expect(await state({ hasReadableDocument: true })).toEqual({
       documentPending: false,
+      documentReadFailed: false,
       documentUnavailable: false,
     });
   });
@@ -56,6 +57,7 @@ describe("document state", () => {
   test("a decision with nothing to fetch is neither", async () => {
     expect(await state({ documentUrl: null })).toEqual({
       documentPending: false,
+      documentReadFailed: false,
       documentUnavailable: false,
     });
   });
@@ -73,7 +75,11 @@ describe("document state", () => {
           corpusServed: true,
           contentHash: REAL_HASH,
         }),
-      ).toEqual({ documentPending: true, documentUnavailable: false });
+      ).toEqual({
+        documentPending: true,
+        documentReadFailed: true,
+        documentUnavailable: false,
+      });
     });
 
     test("reads as pending even where there is nothing to fetch", async () => {
@@ -87,7 +93,11 @@ describe("document state", () => {
           corpusServed: true,
           contentHash: REAL_HASH,
         }),
-      ).toEqual({ documentPending: true, documentUnavailable: false });
+      ).toEqual({
+        documentPending: true,
+        documentReadFailed: true,
+        documentUnavailable: false,
+      });
     });
 
     test("does not override a document the read did resolve", async () => {
@@ -98,17 +108,23 @@ describe("document state", () => {
           corpusPayloadUnavailable: true,
           hasReadableDocument: true,
         }),
-      ).toEqual({ documentPending: false, documentUnavailable: false });
+      ).toEqual({
+        documentPending: false,
+        documentReadFailed: false,
+        documentUnavailable: false,
+      });
     });
   });
 
   test("served from the columns, NULL is pending and empty is terminal", async () => {
     expect(await state({ resolvedFulltext: null })).toEqual({
       documentPending: true,
+      documentReadFailed: false,
       documentUnavailable: false,
     });
     expect(await state({ resolvedFulltext: "" })).toEqual({
       documentPending: false,
+      documentReadFailed: false,
       documentUnavailable: true,
     });
   });
@@ -125,7 +141,11 @@ describe("document state", () => {
         contentHash: REAL_HASH,
         resolvedFulltext: "",
       }),
-    ).toEqual({ documentPending: false, documentUnavailable: false });
+    ).toEqual({
+      documentPending: false,
+      documentReadFailed: false,
+      documentUnavailable: false,
+    });
   });
 
   test("a surviving AST artifact marks the corpus copy as verbatim empty", async () => {
@@ -142,7 +162,11 @@ describe("document state", () => {
         resolvedFulltext: "",
         readTextColumnWritten: async () => await Promise.resolve(false),
       }),
-    ).toEqual({ documentPending: true, documentUnavailable: false });
+    ).toEqual({
+      documentPending: true,
+      documentReadFailed: false,
+      documentUnavailable: false,
+    });
 
     // The same row, once its document has been fetched and marked
     // unavailable, is terminal rather than pending.
@@ -154,7 +178,11 @@ describe("document state", () => {
         resolvedFulltext: "",
         readTextColumnWritten: async () => await Promise.resolve(true),
       }),
-    ).toEqual({ documentPending: false, documentUnavailable: true });
+    ).toEqual({
+      documentPending: false,
+      documentReadFailed: false,
+      documentUnavailable: true,
+    });
   });
 
   test("an empty corpus payload falls back to what the column says", async () => {
@@ -167,7 +195,11 @@ describe("document state", () => {
         resolvedFulltext: "",
         readTextColumnWritten: async () => await Promise.resolve(false),
       }),
-    ).toEqual({ documentPending: true, documentUnavailable: false });
+    ).toEqual({
+      documentPending: true,
+      documentReadFailed: false,
+      documentUnavailable: false,
+    });
 
     expect(
       await state({
@@ -176,7 +208,11 @@ describe("document state", () => {
         resolvedFulltext: "",
         readTextColumnWritten: async () => await Promise.resolve(true),
       }),
-    ).toEqual({ documentPending: false, documentUnavailable: true });
+    ).toEqual({
+      documentPending: false,
+      documentReadFailed: false,
+      documentUnavailable: true,
+    });
   });
 
   test("a row that vanished under the read is neither", async () => {
@@ -186,6 +222,10 @@ describe("document state", () => {
         contentHash: EMPTY_HASH,
         readTextColumnWritten: async () => await Promise.resolve(null),
       }),
-    ).toEqual({ documentPending: false, documentUnavailable: false });
+    ).toEqual({
+      documentPending: false,
+      documentReadFailed: false,
+      documentUnavailable: false,
+    });
   });
 });

--- a/apps/api/src/handlers/case-law/decisions/get-deferred-document.ts
+++ b/apps/api/src/handlers/case-law/decisions/get-deferred-document.ts
@@ -44,6 +44,7 @@ const hydrate = async (
       adapterKey: decision.source.adapterKey,
       documentUrl: decision.documentUrl,
       documentPending: decision.documentPending,
+      documentReadFailed: decision.documentReadFailed,
     })
   ) {
     return decision;

--- a/apps/api/src/handlers/case-law/decisions/get.ts
+++ b/apps/api/src/handlers/case-law/decisions/get.ts
@@ -265,7 +265,7 @@ export const readDecisionHandler = async (
   // re-entering the fetch path on every view would cost a claim that can
   // never succeed. Kept as derived booleans rather than a call so this
   // module stays a read.
-  const { documentPending, documentUnavailable } =
+  const { documentPending, documentReadFailed, documentUnavailable } =
     decision.redactedAt === null
       ? await resolveDocumentState({
           hasReadableDocument: hasUsableAst(documentAst) || Boolean(fulltext),
@@ -291,10 +291,15 @@ export const readDecisionHandler = async (
             return row?.written ?? null;
           },
         })
-      : { documentPending: false, documentUnavailable: false };
+      : {
+          documentPending: false,
+          documentReadFailed: false,
+          documentUnavailable: false,
+        };
 
   return {
     documentPending,
+    documentReadFailed,
     documentUnavailable,
     id: decision.id,
     caseNumber: decision.caseNumber,
@@ -468,6 +473,16 @@ export type ResolveDocumentStateInput = {
 type DocumentState = {
   documentPending: boolean;
   documentUnavailable: boolean;
+  /**
+   * Whether the pending state above is an object-storage failure rather
+   * than a document nobody has fetched yet. The reader sees the same
+   * thing either way, but the read-through must not: the publisher fetch
+   * cannot repair a row whose payload is already stored, and its store
+   * refuses a row that carries a corpus document, so treating an outage
+   * as unfetched work costs an outbound download per affected decision
+   * and holds the read for the fetch budget while it does.
+   */
+  documentReadFailed: boolean;
 };
 
 /**
@@ -527,8 +542,9 @@ export const resolveDocumentState = async ({
   resolvedFulltext,
   readTextColumnWritten,
 }: ResolveDocumentStateInput): Promise<DocumentState> => {
+  const settled = { documentReadFailed: false, documentUnavailable: false };
   if (hasReadableDocument) {
-    return { documentPending: false, documentUnavailable: false };
+    return { ...settled, documentPending: false };
   }
 
   // Ahead of every column test, including "nothing to fetch": with the
@@ -537,28 +553,34 @@ export const resolveDocumentState = async ({
   // can tell the two apart. Reporting "neither" here would render a
   // decision with no body as a complete one.
   if (corpusPayloadUnavailable) {
-    return { documentPending: true, documentUnavailable: false };
+    return {
+      documentPending: true,
+      documentReadFailed: true,
+      documentUnavailable: false,
+    };
   }
 
   if (documentUrl === null) {
-    return { documentPending: false, documentUnavailable: false };
+    return { ...settled, documentPending: false };
   }
 
   if (!corpusServed) {
     return {
       documentPending: resolvedFulltext === null,
+      documentReadFailed: false,
       documentUnavailable: resolvedFulltext === "",
     };
   }
 
   if (corpusCarriesDocument(contentHash) && !pgAstPresent) {
-    return { documentPending: false, documentUnavailable: false };
+    return { ...settled, documentPending: false };
   }
 
   const written = await readTextColumnWritten();
 
   return {
     documentPending: written === false,
+    documentReadFailed: false,
     documentUnavailable: written === true,
   };
 };

--- a/apps/api/src/handlers/case-law/decisions/get.ts
+++ b/apps/api/src/handlers/case-law/decisions/get.ts
@@ -1,4 +1,4 @@
-import { panic } from "better-result";
+import { panic, Result, UnhandledException } from "better-result";
 import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import { status } from "elysia";
 
@@ -8,9 +8,11 @@ import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
 import { corpusStorageMode } from "@/api/env-base";
 import { hasUsableAst } from "@/api/handlers/case-law/document-ast";
 import { corpusCarriesDocument } from "@/api/handlers/case-law/stored-payload";
+import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 import { redistributableCaseLawSource } from "@/api/lib/case-law/redistribution";
+import { CorpusPayloadUnavailableError } from "@/api/lib/errors/tagged-errors";
 import {
   allowsDerivedAi,
   isRedistributable,
@@ -233,22 +235,26 @@ export const readDecisionHandler = async (
   // Prefer canonical AST from object storage when corpus storage is
   // enabled; fall back to the Postgres column so a read is never harder
   // than today.
-  const documentAst = await resolveAst({
+  const astRead = await resolveAst({
     astS3Key: decision.astS3Key,
     contentHash: decision.contentHash,
     pgAst: decision.documentAst,
     decisionId,
   });
+  const documentAst = astRead.payload;
 
   // Only fetch fulltext if no usable documentAst (fallback).
   let fulltext: string | null = null;
+  let corpusPayloadUnavailable = astRead.unavailable;
   if (!hasUsableAst(documentAst)) {
-    fulltext = await resolveFulltext({
+    const textRead = await resolveFulltext({
       textS3Key: decision.textS3Key,
       contentHash: decision.contentHash,
       decisionId,
       caseLawDb,
     });
+    fulltext = textRead.payload;
+    corpusPayloadUnavailable = corpusPayloadUnavailable || textRead.unavailable;
   }
 
   // Nothing readable resolved, and there is a document to fetch. Which
@@ -263,6 +269,7 @@ export const readDecisionHandler = async (
     decision.redactedAt === null
       ? await resolveDocumentState({
           hasReadableDocument: hasUsableAst(documentAst) || Boolean(fulltext),
+          corpusPayloadUnavailable,
           documentUrl: decision.documentUrl,
           corpusServed:
             corpusReadEnabled() &&
@@ -353,6 +360,54 @@ export const readDecisionBySlugHandler = async (
   return await readDecisionHandler(firstDecision.id, caseLawDb);
 };
 
+/**
+ * A payload the read tried to resolve, and whether object storage
+ * refused it outright.
+ *
+ * `readCorpusPayloadOrFallback` throws when the object is unreadable and
+ * the row has no Postgres copy, which is every trimmed canonical row. It
+ * throws so that a corpus outage cannot be served as a decision with no
+ * body — but a public read has a third answer for exactly that, and it
+ * is not an error: the document is not readable right now. Failing the
+ * read instead takes the metadata, the citation graph and the case
+ * number down with the body, for a decision the reader could otherwise
+ * still recognise and cite.
+ */
+type CorpusReadOutcome<TPayload> = {
+  payload: TPayload | null;
+  unavailable: boolean;
+};
+
+/**
+ * Contain an object-storage refusal, and only that. Anything else is a
+ * defect in the read and still fails it.
+ */
+const containPayloadUnavailable = async <TPayload>(
+  read: () => Promise<TPayload | null>,
+  decisionId: SafeId<"caseLawDecision">,
+): Promise<CorpusReadOutcome<TPayload>> => {
+  const outcome = await Result.tryPromise(read);
+  if (Result.isOk(outcome)) {
+    return { payload: outcome.value, unavailable: false };
+  }
+
+  // `Result.tryPromise` reports a rejection as an `UnhandledException`
+  // carrying the original as its cause.
+  const raised =
+    outcome.error instanceof UnhandledException
+      ? outcome.error.cause
+      : outcome.error;
+  if (!CorpusPayloadUnavailableError.is(raised)) {
+    throw raised;
+  }
+
+  captureError(raised, {
+    decisionId,
+    step: "readDecision.corpusPayloadUnavailable",
+  });
+  return { payload: null, unavailable: true };
+};
+
 type ResolveAstInput = {
   astS3Key: string | null;
   contentHash: string | null;
@@ -365,22 +420,33 @@ const resolveAst = async ({
   contentHash,
   pgAst,
   decisionId,
-}: ResolveAstInput): Promise<DocumentAst | EmptyAst | null> => {
+}: ResolveAstInput): Promise<CorpusReadOutcome<DocumentAst | EmptyAst>> => {
   if (!corpusReadEnabled() || astS3Key === null || contentHash === null) {
-    return parsePersistedCorpusAst(pgAst);
+    return { payload: parsePersistedCorpusAst(pgAst), unavailable: false };
   }
-  return await readCorpusPayloadOrFallback({
-    documentId: decisionId,
-    key: astS3Key,
-    step: "readDecision.corpusAst",
-    read: async () => await readCorpusAst(astS3Key),
-    fallback: () => parsePersistedCorpusAst(pgAst),
-  });
+  return await containPayloadUnavailable(
+    async () =>
+      await readCorpusPayloadOrFallback({
+        documentId: decisionId,
+        key: astS3Key,
+        step: "readDecision.corpusAst",
+        read: async () => await readCorpusAst(astS3Key),
+        fallback: () => parsePersistedCorpusAst(pgAst),
+      }),
+    decisionId,
+  );
 };
 
 export type ResolveDocumentStateInput = {
   /** Whether the read resolved something a reader can actually read. */
   hasReadableDocument: boolean;
+  /**
+   * Whether object storage refused a payload this row is served from.
+   * A trimmed canonical row has no Postgres copy to fall back to, so
+   * there is nothing readable and nothing that says the source had
+   * nothing either.
+   */
+  corpusPayloadUnavailable: boolean;
   documentUrl: string | null;
   /** Whether the payload above came from object storage. */
   corpusServed: boolean;
@@ -428,12 +494,18 @@ type DocumentState = {
  * | NULL    | NULL   | row-specific | document | served      |
  * | text    | any    | row-specific | document | served      |
  * | NULL    | present| row-specific | ''       | pending     |
+ * | any     | any    | any          | refused  | pending     |
  *
  * The sixth row is a trimmed canonical decision: its columns are empty
  * by design and object storage holds the document, so it is neither
- * pending nor unavailable — and if its payload failed to arrive, that is
- * an object-storage failure the read raises rather than a document
- * waiting to be fetched.
+ * pending nor unavailable — unless the payload did not arrive, which is
+ * the `corpusPayloadUnavailable` case. That one reads as pending: there
+ * is genuinely nothing to show, the row is not the terminal
+ * "source had nothing" state, and the alternative is failing the read
+ * and losing the metadata, citations and case number along with the
+ * body. It stays pending rather than unavailable because the outage is
+ * the object store's, not the court's, so the next read may well serve
+ * the document.
  *
  * The last row is what separates that from a decision whose objects
  * merely mirror an empty payload. A row-specific hash proves only that
@@ -447,6 +519,7 @@ type DocumentState = {
  */
 export const resolveDocumentState = async ({
   hasReadableDocument,
+  corpusPayloadUnavailable,
   documentUrl,
   corpusServed,
   contentHash,
@@ -454,7 +527,20 @@ export const resolveDocumentState = async ({
   resolvedFulltext,
   readTextColumnWritten,
 }: ResolveDocumentStateInput): Promise<DocumentState> => {
-  if (hasReadableDocument || documentUrl === null) {
+  if (hasReadableDocument) {
+    return { documentPending: false, documentUnavailable: false };
+  }
+
+  // Ahead of every column test, including "nothing to fetch": with the
+  // payload refused, the resolved text is null because the read could
+  // not get it, not because the row was never fetched, and no column
+  // can tell the two apart. Reporting "neither" here would render a
+  // decision with no body as a complete one.
+  if (corpusPayloadUnavailable) {
+    return { documentPending: true, documentUnavailable: false };
+  }
+
+  if (documentUrl === null) {
     return { documentPending: false, documentUnavailable: false };
   }
 
@@ -489,7 +575,7 @@ const resolveFulltext = async ({
   contentHash,
   decisionId,
   caseLawDb,
-}: ResolveFulltextInput): Promise<string | null> => {
+}: ResolveFulltextInput): Promise<CorpusReadOutcome<string>> => {
   const postgresFulltext = async (): Promise<string | null> => {
     const fallback = await caseLawDb((tx) =>
       tx.query.caseLawDecisions.findFirst({
@@ -501,14 +587,18 @@ const resolveFulltext = async ({
   };
 
   if (corpusReadEnabled() && textS3Key !== null && contentHash !== null) {
-    return await readCorpusPayloadOrFallback({
-      documentId: decisionId,
-      key: textS3Key,
-      step: "readDecision.corpusText",
-      read: async () => await readCorpusText(textS3Key),
-      fallback: postgresFulltext,
-    });
+    return await containPayloadUnavailable(
+      async () =>
+        await readCorpusPayloadOrFallback({
+          documentId: decisionId,
+          key: textS3Key,
+          step: "readDecision.corpusText",
+          read: async () => await readCorpusText(textS3Key),
+          fallback: postgresFulltext,
+        }),
+      decisionId,
+    );
   }
 
-  return await postgresFulltext();
+  return { payload: await postgresFulltext(), unavailable: false };
 };

--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
@@ -1211,6 +1211,7 @@ const CONTRACT_CORPUS = {
       setup: () => {
         readDecisionWithDocumentHandlerMock.mockResolvedValue({
           documentPending: false,
+          documentReadFailed: false,
           documentUnavailable: false,
           id: toSafeId<"caseLawDecision">(uid(54)),
           caseNumber: "22 Cdo 1000/2020",

--- a/apps/api/src/lib/corpus-index/census.db.test.ts
+++ b/apps/api/src/lib/corpus-index/census.db.test.ts
@@ -1,18 +1,21 @@
 /**
- * The repair behind a census drift warning: clear the index marks for a
- * jurisdiction so the ordinary backfill re-selects it.
+ * The repair behind a census drift warning: un-mark a jurisdiction so
+ * the ordinary backfill re-selects it.
  *
- * Three things can go wrong, and all of them are SQL. It can clear more
- * than the operator asked for, which hands the backfill a backlog that
- * starves every newly ingested decision behind it. It can clear rows in
- * a jurisdiction that was not short. And it can clear the same page on
- * every run, so an operator re-running it to walk a large jurisdiction
- * never gets past the first slice — which reads as the repair working,
- * because rows are reported cleared every time.
+ * Four things can go wrong, and all of them are SQL. It can miss the
+ * rows the census counted — a generation rebuild records success in the
+ * projection and leaves the legacy column alone, so a repair keyed off
+ * that column is inert for exactly the rows a rebuild lost. It can clear
+ * more than the operator asked for, handing the backfill a backlog that
+ * starves every newly ingested decision behind it. It can reach into a
+ * jurisdiction that was not short. And it can clear the same page every
+ * run, so an operator re-running it to walk a large jurisdiction never
+ * gets past the first slice — which reads as the repair working, because
+ * rows are reported cleared every time.
  */
 
 import { beforeAll, expect, test } from "bun:test";
-import { and, eq, isNotNull, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import type { Transaction } from "@/api/db/root";
@@ -24,13 +27,18 @@ import {
   caseLawSources,
 } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
-import type { SafeId } from "@/api/lib/branded-types";
 import { clearJurisdictionIndexMarks } from "@/api/lib/corpus-index/census";
+import {
+  caseLawCorpusProjectionJoin,
+  currentCaseLawCorpusProjection,
+} from "@/api/lib/legal-search/case-law-corpus-projection";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
 const GENERATION = "case_law_v2";
+/** Marked through the generation projection, as a rebuild leaves them. */
 const SHORT_JURISDICTION = "SVK";
+/** Marked through the legacy column, as the incremental path leaves them. */
 const HEALTHY_JURISDICTION = "CZE";
 const DECISIONS_PER_JURISDICTION = 6;
 const SLICE = 4;
@@ -48,14 +56,22 @@ const decisionId = (jurisdiction: string, index: number) =>
 let db: ReturnType<typeof drizzle>;
 let scopedDb: ScopedDb;
 
-const markedRows = async (jurisdiction: string) =>
+/**
+ * Rows the census would count for this jurisdiction — the same predicate
+ * the repair slices on, so the test measures what the alert measures.
+ */
+const currentRows = async (jurisdiction: string) =>
   await db
     .select({ id: caseLawDecisions.id })
     .from(caseLawDecisions)
+    .leftJoin(
+      caseLawCorpusIndexProjections,
+      caseLawCorpusProjectionJoin(GENERATION),
+    )
     .where(
       and(
         eq(caseLawDecisions.country, jurisdiction),
-        isNotNull(caseLawDecisions.indexedHash),
+        currentCaseLawCorpusProjection(GENERATION),
       ),
     );
 
@@ -113,24 +129,30 @@ beforeAll(async () => {
   const decisions: (typeof caseLawDecisions.$inferInsert)[] = [];
   const projections: (typeof caseLawCorpusIndexProjections.$inferInsert)[] = [];
   for (const jurisdiction of [SHORT_JURISDICTION, HEALTHY_JURISDICTION]) {
+    const rebuilt = jurisdiction === SHORT_JURISDICTION;
     for (let index = 0; index < DECISIONS_PER_JURISDICTION; index += 1) {
       const id = decisionId(jurisdiction, index);
+      const contentHash = `hash-${jurisdiction}-${index}`;
       decisions.push({
         caseNumber: `${jurisdiction}-${index}`,
-        contentHash: `hash-${jurisdiction}-${index}`,
+        contentHash,
         country: jurisdiction,
         court: "Test court",
         id,
-        indexedHash: `hash-${jurisdiction}-${index}`,
+        // A rebuild marks the projection and leaves this null; the
+        // incremental path is the other way round. Both read as indexed.
+        indexedHash: rebuilt ? null : contentHash,
         language: "sk",
         sourceId,
       });
-      projections.push({
-        decisionId: id,
-        generation: GENERATION,
-        indexId: corpusIndexId(GENERATION, jurisdiction),
-        indexedHash: `hash-${jurisdiction}-${index}`,
-      });
+      if (rebuilt) {
+        projections.push({
+          decisionId: id,
+          generation: GENERATION,
+          indexId: corpusIndexId(GENERATION, jurisdiction),
+          indexedHash: contentHash,
+        });
+      }
     }
   }
   await db.insert(caseLawDecisions).values(decisions);
@@ -138,22 +160,26 @@ beforeAll(async () => {
   await installProjectionTrigger();
 });
 
-test("the repair clears one bounded slice and leaves other jurisdictions alone", async () => {
+test("the repair reaches rows marked only through the generation projection", async () => {
+  // The case a repair keyed off `case_law_decisions.indexed_hash` would
+  // miss entirely: these rows never had one.
+  expect(await currentRows(SHORT_JURISDICTION)).toHaveLength(
+    DECISIONS_PER_JURISDICTION,
+  );
+
   const cleared = await clearJurisdictionIndexMarks({
     scopedDb,
+    generation: GENERATION,
     jurisdiction: SHORT_JURISDICTION,
     limit: SLICE,
   });
 
   expect(cleared).toBe(SLICE);
-  expect(await markedRows(SHORT_JURISDICTION)).toHaveLength(
+  expect(await currentRows(SHORT_JURISDICTION)).toHaveLength(
     DECISIONS_PER_JURISDICTION - SLICE,
   );
-  expect(await markedRows(HEALTHY_JURISDICTION)).toHaveLength(
-    DECISIONS_PER_JURISDICTION,
-  );
-  // The point of writing only this column: the projection trigger turns
-  // the cleared mark into a queued re-index, so the repair reaches the
+  // Writing only that one column is the point: the projection trigger
+  // turns the assignment into queued work, so the repair reaches the
   // live drain without a second, hand-maintained copy of what the
   // trigger already states.
   expect(await enqueuedProjections()).toHaveLength(SLICE);
@@ -162,6 +188,7 @@ test("the repair clears one bounded slice and leaves other jurisdictions alone",
 test("re-running walks the jurisdiction instead of re-clearing the first page", async () => {
   const cleared = await clearJurisdictionIndexMarks({
     scopedDb,
+    generation: GENERATION,
     jurisdiction: SHORT_JURISDICTION,
     limit: SLICE,
   });
@@ -169,20 +196,19 @@ test("re-running walks the jurisdiction instead of re-clearing the first page", 
   // The remainder, not the slice: a repair that always reported `limit`
   // rows cleared would look identical while making no progress.
   expect(cleared).toBe(DECISIONS_PER_JURISDICTION - SLICE);
-  expect(await markedRows(SHORT_JURISDICTION)).toHaveLength(0);
+  expect(await currentRows(SHORT_JURISDICTION)).toHaveLength(0);
 
   const exhausted = await clearJurisdictionIndexMarks({
     scopedDb,
+    generation: GENERATION,
     jurisdiction: SHORT_JURISDICTION,
     limit: SLICE,
   });
   expect(exhausted).toBe(0);
 });
 
-test("the untouched jurisdiction kept every mark", async () => {
-  const remaining: SafeId<"caseLawDecision">[] = (
-    await markedRows(HEALTHY_JURISDICTION)
-  ).map(({ id }) => id);
-
-  expect(remaining).toHaveLength(DECISIONS_PER_JURISDICTION);
+test("the jurisdiction that was not short kept every mark", async () => {
+  expect(await currentRows(HEALTHY_JURISDICTION)).toHaveLength(
+    DECISIONS_PER_JURISDICTION,
+  );
 });

--- a/apps/api/src/lib/corpus-index/census.db.test.ts
+++ b/apps/api/src/lib/corpus-index/census.db.test.ts
@@ -1,0 +1,188 @@
+/**
+ * The repair behind a census drift warning: clear the index marks for a
+ * jurisdiction so the ordinary backfill re-selects it.
+ *
+ * Three things can go wrong, and all of them are SQL. It can clear more
+ * than the operator asked for, which hands the backfill a backlog that
+ * starves every newly ingested decision behind it. It can clear rows in
+ * a jurisdiction that was not short. And it can clear the same page on
+ * every run, so an operator re-running it to walk a large jurisdiction
+ * never gets past the first slice — which reads as the repair working,
+ * because rows are reported cleared every time.
+ */
+
+import { beforeAll, expect, test } from "bun:test";
+import { and, eq, isNotNull, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import type { ScopedDb } from "@/api/db/safe-db";
+import {
+  caseLawCorpusIndexBackfills,
+  caseLawCorpusIndexProjections,
+  caseLawDecisions,
+  caseLawSources,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { clearJurisdictionIndexMarks } from "@/api/lib/corpus-index/census";
+import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const GENERATION = "case_law_v2";
+const SHORT_JURISDICTION = "SVK";
+const HEALTHY_JURISDICTION = "CZE";
+const DECISIONS_PER_JURISDICTION = 6;
+const SLICE = 4;
+
+const sourceId = toSafeId<"caseLawSource">(
+  "00000000-0000-4000-8000-0000000000a1",
+);
+
+/** Ordered ids, so the slice boundary is predictable. */
+const decisionId = (jurisdiction: string, index: number) =>
+  toSafeId<"caseLawDecision">(
+    `00000000-0000-4000-8000-${jurisdiction === SHORT_JURISDICTION ? "1" : "2"}00000000${String(index).padStart(3, "0")}`,
+  );
+
+let db: ReturnType<typeof drizzle>;
+let scopedDb: ScopedDb;
+
+const markedRows = async (jurisdiction: string) =>
+  await db
+    .select({ id: caseLawDecisions.id })
+    .from(caseLawDecisions)
+    .where(
+      and(
+        eq(caseLawDecisions.country, jurisdiction),
+        isNotNull(caseLawDecisions.indexedHash),
+      ),
+    );
+
+const enqueuedProjections = async () =>
+  await db
+    .select({ id: caseLawCorpusIndexProjections.decisionId })
+    .from(caseLawCorpusIndexProjections)
+    .where(eq(caseLawCorpusIndexProjections.pendingAction, "index"));
+
+/**
+ * The projection trigger is what turns a cleared mark into queued work,
+ * so the repair is only meaningful with it installed. The test snapshot
+ * carries the tables but not this migration's functions, so it is
+ * applied here rather than asserted around.
+ */
+const installProjectionTrigger = async (): Promise<void> => {
+  const migration = await Bun.file(
+    new URL(
+      "../../../drizzle/20260731170000_case_law_corpus_generation_backfill/migration.sql",
+      import.meta.url,
+    ),
+  ).text();
+  const statements = migration
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter((statement) =>
+      statement.includes("enqueue_case_law_corpus_index_projection"),
+    );
+  expect(statements.length).toBeGreaterThan(0);
+  for (const statement of statements) {
+    // oxlint-disable-next-line no-await-in-loop -- function then trigger; order-dependent DDL
+    await db.execute(sql.raw(statement));
+  }
+};
+
+beforeAll(async () => {
+  const client = await createTestPglite();
+  db = drizzle({ client });
+  const handle = async (callback: (tx: Transaction) => Promise<unknown>) =>
+    // SAFETY: pglite's drizzle instance satisfies the transaction surface
+    // this repair uses (`execute` only).
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- embedded test database stands in for the scoped handle
+    await callback(db as unknown as Transaction);
+  // SAFETY: brand-only wrapper; the repair never inspects the marker.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the branded handle carries no behaviour
+  scopedDb = handle as unknown as ScopedDb;
+
+  await db
+    .insert(caseLawSources)
+    .values([{ adapterKey: "public", id: sourceId, name: "public" }]);
+  await db
+    .insert(caseLawCorpusIndexBackfills)
+    .values([{ generation: GENERATION }]);
+
+  const decisions: (typeof caseLawDecisions.$inferInsert)[] = [];
+  const projections: (typeof caseLawCorpusIndexProjections.$inferInsert)[] = [];
+  for (const jurisdiction of [SHORT_JURISDICTION, HEALTHY_JURISDICTION]) {
+    for (let index = 0; index < DECISIONS_PER_JURISDICTION; index += 1) {
+      const id = decisionId(jurisdiction, index);
+      decisions.push({
+        caseNumber: `${jurisdiction}-${index}`,
+        contentHash: `hash-${jurisdiction}-${index}`,
+        country: jurisdiction,
+        court: "Test court",
+        id,
+        indexedHash: `hash-${jurisdiction}-${index}`,
+        language: "sk",
+        sourceId,
+      });
+      projections.push({
+        decisionId: id,
+        generation: GENERATION,
+        indexId: corpusIndexId(GENERATION, jurisdiction),
+        indexedHash: `hash-${jurisdiction}-${index}`,
+      });
+    }
+  }
+  await db.insert(caseLawDecisions).values(decisions);
+  await db.insert(caseLawCorpusIndexProjections).values(projections);
+  await installProjectionTrigger();
+});
+
+test("the repair clears one bounded slice and leaves other jurisdictions alone", async () => {
+  const cleared = await clearJurisdictionIndexMarks({
+    scopedDb,
+    jurisdiction: SHORT_JURISDICTION,
+    limit: SLICE,
+  });
+
+  expect(cleared).toBe(SLICE);
+  expect(await markedRows(SHORT_JURISDICTION)).toHaveLength(
+    DECISIONS_PER_JURISDICTION - SLICE,
+  );
+  expect(await markedRows(HEALTHY_JURISDICTION)).toHaveLength(
+    DECISIONS_PER_JURISDICTION,
+  );
+  // The point of writing only this column: the projection trigger turns
+  // the cleared mark into a queued re-index, so the repair reaches the
+  // live drain without a second, hand-maintained copy of what the
+  // trigger already states.
+  expect(await enqueuedProjections()).toHaveLength(SLICE);
+});
+
+test("re-running walks the jurisdiction instead of re-clearing the first page", async () => {
+  const cleared = await clearJurisdictionIndexMarks({
+    scopedDb,
+    jurisdiction: SHORT_JURISDICTION,
+    limit: SLICE,
+  });
+
+  // The remainder, not the slice: a repair that always reported `limit`
+  // rows cleared would look identical while making no progress.
+  expect(cleared).toBe(DECISIONS_PER_JURISDICTION - SLICE);
+  expect(await markedRows(SHORT_JURISDICTION)).toHaveLength(0);
+
+  const exhausted = await clearJurisdictionIndexMarks({
+    scopedDb,
+    jurisdiction: SHORT_JURISDICTION,
+    limit: SLICE,
+  });
+  expect(exhausted).toBe(0);
+});
+
+test("the untouched jurisdiction kept every mark", async () => {
+  const remaining: SafeId<"caseLawDecision">[] = (
+    await markedRows(HEALTHY_JURISDICTION)
+  ).map(({ id }) => id);
+
+  expect(remaining).toHaveLength(DECISIONS_PER_JURISDICTION);
+});

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -1,0 +1,263 @@
+/**
+ * The census exists because the ingest path's own signals cannot detect
+ * the gap it looks for: a row whose split was lost has an `indexedHash`
+ * equal to its content hash, so it is neither missing nor stale and
+ * nothing selects it again. What can go wrong here is therefore the
+ * census staying quiet — either because ordinary churn is mistaken for
+ * drift and the warning is tuned out, or because an unreachable index
+ * reads as an empty one and the drift is reported against a jurisdiction
+ * that is fine.
+ */
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+
+import type { Transaction } from "@/api/db/root";
+import type { ScopedDb } from "@/api/db/safe-db";
+import {
+  CENSUS_ABSOLUTE_TOLERANCE,
+  CENSUS_CYCLE_INTERVAL,
+  censusJurisdiction,
+  censusTolerance,
+  createCaseLawCensus,
+  reportJurisdictionCensus,
+} from "@/api/lib/corpus-index/census";
+import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+import { logger } from "@/api/lib/observability/logger";
+
+const GENERATION = "case_law_v1";
+const JURISDICTION = "SVK";
+const INDEX_ID = corpusIndexId(GENERATION, JURISDICTION);
+
+const originalFetch = globalThis.fetch;
+
+/** Serves the engine's document count, and nothing else. */
+const engineHolding = (numHits: number, ok = true): void => {
+  const resolveUrl = (input: Parameters<typeof fetch>[0]): string => {
+    if (typeof input === "string") {
+      return input;
+    }
+    return input instanceof URL ? input.href : input.url;
+  };
+  const stub = async (input: Parameters<typeof fetch>[0]) => {
+    const url = resolveUrl(input);
+    if (!ok) {
+      return new Response("index not found", { status: 404 });
+    }
+    if (url.includes("/search")) {
+      return new Response(
+        JSON.stringify({ num_hits: numHits, hits: [], snippets: [] }),
+        { status: 200 },
+      );
+    }
+    return new Response(JSON.stringify({}), { status: 200 });
+  };
+  globalThis.fetch = Object.assign(stub, {
+    preconnect: originalFetch.preconnect,
+  });
+};
+
+/**
+ * A database whose only answer is the count the census asks for. Every
+ * aggregate the module runs returns the same single row, which is enough
+ * because the census takes exactly one count per side.
+ */
+const databaseHolding = (
+  marked: number,
+  jurisdictions?: string[],
+): ScopedDb => {
+  const handle = async (callback: (tx: Transaction) => Promise<unknown>) => {
+    const rows =
+      jurisdictions === undefined
+        ? [{ marked }]
+        : jurisdictions.map((country) => ({ country, marked }));
+    const chain = {
+      from: () => chain,
+      leftJoin: () => chain,
+      limit: () => rows,
+      orderBy: () => chain,
+      where: () => rows,
+    };
+    const tx = { select: () => chain, selectDistinct: () => chain };
+    // SAFETY: the census only ever builds the two aggregate chains above.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- inert query-builder double
+    return await callback(tx as unknown as Transaction);
+  };
+  // SAFETY: brand-only wrapper; the census never inspects the marker.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the branded handle carries no behaviour
+  return handle as unknown as ScopedDb;
+};
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("jurisdiction census", () => {
+  test("ordinary churn is not drift", async () => {
+    // Two counts taken at different instants: a batch committing between
+    // them always reads as a small shortfall. A census that warned on
+    // that would warn every cycle and stop being read.
+    engineHolding(10_000 - CENSUS_ABSOLUTE_TOLERANCE);
+
+    const census = await censusJurisdiction({
+      scopedDb: databaseHolding(10_000),
+      generation: GENERATION,
+      jurisdiction: JURISDICTION,
+    });
+
+    expect(census.isOk()).toBe(true);
+    expect(census.isOk() && census.value.drifted).toBe(false);
+  });
+
+  test("a shortfall past the tolerance is drift", async () => {
+    const marked = 10_000;
+    engineHolding(marked - censusTolerance(marked) - 1);
+
+    const census = await censusJurisdiction({
+      scopedDb: databaseHolding(marked),
+      generation: GENERATION,
+      jurisdiction: JURISDICTION,
+    });
+
+    expect(census.isOk() && census.value.drifted).toBe(true);
+    expect(census.isOk() && census.value.indexId).toBe(INDEX_ID);
+  });
+
+  test("an engine holding more than Postgres claims is not drift", async () => {
+    // A superseded document nothing points at is unreachable, not wrong,
+    // and a rebuild leaves those behind by design.
+    engineHolding(50_000);
+
+    const census = await censusJurisdiction({
+      scopedDb: databaseHolding(10_000),
+      generation: GENERATION,
+      jurisdiction: JURISDICTION,
+    });
+
+    expect(census.isOk() && census.value.shortfall).toBeLessThan(0);
+    expect(census.isOk() && census.value.drifted).toBe(false);
+  });
+
+  test("an unreachable index is a failure, not an empty index", async () => {
+    // Counting it as empty would report the whole jurisdiction as
+    // drifted and point the repair at rows that are perfectly indexed.
+    engineHolding(0, false);
+
+    const census = await censusJurisdiction({
+      scopedDb: databaseHolding(10_000),
+      generation: GENERATION,
+      jurisdiction: JURISDICTION,
+    });
+
+    expect(census.isErr()).toBe(true);
+  });
+});
+
+describe("census reporting", () => {
+  let warn: ReturnType<typeof spyOn<typeof logger, "warn">>;
+
+  beforeEach(() => {
+    warn = spyOn(logger, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  test("drift is reported with both counts", () => {
+    reportJurisdictionCensus(GENERATION, {
+      jurisdiction: JURISDICTION,
+      indexId: INDEX_ID,
+      engineDocuments: 900,
+      markedIndexed: 10_000,
+      shortfall: 9100,
+      drifted: true,
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls.at(0)?.at(0)).toBe(
+      "case_law.corpus_index.census_drift",
+    );
+    // Both counts travel, because the shortfall alone cannot tell an
+    // index that lost a split from one that was never built.
+    expect(warn.mock.calls.at(0)?.at(1)).toMatchObject({
+      engineDocuments: 900,
+      indexId: INDEX_ID,
+      markedIndexed: 10_000,
+      shortfall: 9100,
+    });
+  });
+
+  test("agreement is silent", () => {
+    reportJurisdictionCensus(GENERATION, {
+      jurisdiction: JURISDICTION,
+      indexId: INDEX_ID,
+      engineDocuments: 10_000,
+      markedIndexed: 10_000,
+      shortfall: 0,
+      drifted: false,
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test("an unreachable index reports separately from drift", async () => {
+    engineHolding(0, false);
+    const census = createCaseLawCensus({
+      generation: GENERATION,
+      scopedDb: databaseHolding(10_000, [JURISDICTION]),
+    });
+
+    for (let cycle = 0; cycle < CENSUS_CYCLE_INTERVAL; cycle += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- the step counts cycles; it only censuses on the last one
+      await census.step();
+    }
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls.at(0)?.at(0)).toBe(
+      "case_law.corpus_index.census_unavailable",
+    );
+  });
+
+  test("the census does not run on every cycle", async () => {
+    engineHolding(0, false);
+    const census = createCaseLawCensus({
+      generation: GENERATION,
+      scopedDb: databaseHolding(10_000, [JURISDICTION]),
+    });
+
+    for (let cycle = 0; cycle < CENSUS_CYCLE_INTERVAL - 1; cycle += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- the cycles are the subject of the test
+      await census.step();
+    }
+
+    // Two aggregates per census against a corpus this size is real query
+    // budget; paying it on every backfill batch would answer the same
+    // slow-moving question over and over.
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test("a census that throws cannot stop the backfill loop", async () => {
+    const explode = async () => {
+      await Promise.resolve();
+      throw new Error("pool exhausted");
+    };
+    // SAFETY: brand-only wrapper.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the branded handle carries no behaviour
+    const exploding = explode as unknown as ScopedDb;
+    const census = createCaseLawCensus({
+      generation: GENERATION,
+      scopedDb: exploding,
+    });
+
+    for (let cycle = 0; cycle < CENSUS_CYCLE_INTERVAL; cycle += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- the cycles are the subject of the test
+      await census.step();
+    }
+
+    // Trading a silent index gap for a stopped index would be the worse
+    // failure, so the diagnostic reports and yields.
+    expect(warn.mock.calls.at(0)?.at(0)).toBe(
+      "case_law.corpus_index.census_failed",
+    );
+  });
+});

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -15,6 +15,7 @@ import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
   CENSUS_CYCLE_INTERVAL,
+  CENSUS_DISPOSITION,
   CENSUS_TOLERANCE,
   censusJurisdiction,
   createCaseLawCensus,
@@ -105,7 +106,9 @@ describe("jurisdiction census", () => {
     });
 
     expect(census.isOk()).toBe(true);
-    expect(census.isOk() && census.value.short).toBe(false);
+    expect(census.isOk() && census.value.disposition).toBe(
+      CENSUS_DISPOSITION.aligned,
+    );
   });
 
   test("one lost ingest batch is visible on a large jurisdiction", async () => {
@@ -122,15 +125,17 @@ describe("jurisdiction census", () => {
       jurisdiction: JURISDICTION,
     });
 
-    expect(census.isOk() && census.value.short).toBe(true);
+    expect(census.isOk() && census.value.disposition).toBe(
+      CENSUS_DISPOSITION.short,
+    );
     expect(census.isOk() && census.value.indexId).toBe(INDEX_ID);
   });
 
-  test("an engine holding more than Postgres claims is not short", async () => {
-    // A superseded document nothing points at is unreachable, not wrong,
-    // and a rebuild leaves those behind by design. This is also the
-    // direction a batch landing between the two counts pushes, which is
-    // why Postgres is counted first.
+  test("an engine holding more than Postgres claims is a surplus, not silence", async () => {
+    // Entries no row points at are a defect of their own, and — the
+    // reason this direction cannot simply be ignored — each one cancels
+    // a genuinely missing document in the same subtraction. Reporting
+    // the surplus is what stops the pair going quiet together.
     engineHolding(50_000);
 
     const census = await censusJurisdiction({
@@ -140,7 +145,9 @@ describe("jurisdiction census", () => {
     });
 
     expect(census.isOk() && census.value.shortfall).toBeLessThan(0);
-    expect(census.isOk() && census.value.short).toBe(false);
+    expect(census.isOk() && census.value.disposition).toBe(
+      CENSUS_DISPOSITION.surplus,
+    );
   });
 
   test("an unreachable index is a failure, not an empty index", async () => {
@@ -172,14 +179,14 @@ describe("census reporting", () => {
   test("confirmed drift is reported with both counts", () => {
     reportJurisdictionCensus({
       generation: GENERATION,
-      confirmed: true,
+      previous: CENSUS_DISPOSITION.short,
       census: {
         jurisdiction: JURISDICTION,
         indexId: INDEX_ID,
         engineDocuments: 900,
         markedIndexed: 10_000,
         shortfall: 9100,
-        short: true,
+        disposition: CENSUS_DISPOSITION.short,
       },
     });
 
@@ -200,14 +207,14 @@ describe("census reporting", () => {
   test("agreement is silent", () => {
     reportJurisdictionCensus({
       generation: GENERATION,
-      confirmed: true,
+      previous: CENSUS_DISPOSITION.aligned,
       census: {
         jurisdiction: JURISDICTION,
         indexId: INDEX_ID,
         engineDocuments: 10_000,
         markedIndexed: 10_000,
         shortfall: 0,
-        short: false,
+        disposition: CENSUS_DISPOSITION.aligned,
       },
     });
 
@@ -220,18 +227,37 @@ describe("census reporting", () => {
     // would make every rebuild noisy, and a noisy warning is not read.
     reportJurisdictionCensus({
       generation: GENERATION,
-      confirmed: false,
+      previous: undefined,
       census: {
         jurisdiction: JURISDICTION,
         indexId: INDEX_ID,
         engineDocuments: 900,
         markedIndexed: 10_000,
         shortfall: 9100,
-        short: true,
+        disposition: CENSUS_DISPOSITION.short,
       },
     });
 
     expect(warn).not.toHaveBeenCalled();
+  });
+
+  test("a surplus is reported rather than read as agreement", () => {
+    reportJurisdictionCensus({
+      generation: GENERATION,
+      previous: CENSUS_DISPOSITION.surplus,
+      census: {
+        jurisdiction: JURISDICTION,
+        indexId: INDEX_ID,
+        engineDocuments: 12_000,
+        markedIndexed: 10_000,
+        shortfall: -2000,
+        disposition: CENSUS_DISPOSITION.surplus,
+      },
+    });
+
+    expect(warn.mock.calls.at(0)?.at(1)).toMatchObject({
+      disposition: CENSUS_DISPOSITION.surplus,
+    });
   });
 
   test("an unreachable index reports separately from drift", async () => {

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -14,19 +14,22 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
-  CENSUS_ABSOLUTE_TOLERANCE,
   CENSUS_CYCLE_INTERVAL,
+  CENSUS_TOLERANCE,
   censusJurisdiction,
-  censusTolerance,
   createCaseLawCensus,
   reportJurisdictionCensus,
 } from "@/api/lib/corpus-index/census";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
 
 const GENERATION = "case_law_v1";
 const JURISDICTION = "SVK";
 const INDEX_ID = corpusIndexId(GENERATION, JURISDICTION);
+
+/** Phases the sweep so the first census lands on the last cycle counted. */
+const LAST_CYCLE_START = 0.99;
 
 const originalFetch = globalThis.fetch;
 
@@ -92,11 +95,8 @@ afterEach(() => {
 });
 
 describe("jurisdiction census", () => {
-  test("ordinary churn is not drift", async () => {
-    // Two counts taken at different instants: a batch committing between
-    // them always reads as a small shortfall. A census that warned on
-    // that would warn every cycle and stop being read.
-    engineHolding(10_000 - CENSUS_ABSOLUTE_TOLERANCE);
+  test("noise inside the tolerance is not a shortfall", async () => {
+    engineHolding(10_000 - CENSUS_TOLERANCE);
 
     const census = await censusJurisdiction({
       scopedDb: databaseHolding(10_000),
@@ -105,12 +105,16 @@ describe("jurisdiction census", () => {
     });
 
     expect(census.isOk()).toBe(true);
-    expect(census.isOk() && census.value.drifted).toBe(false);
+    expect(census.isOk() && census.value.short).toBe(false);
   });
 
-  test("a shortfall past the tolerance is drift", async () => {
-    const marked = 10_000;
-    engineHolding(marked - censusTolerance(marked) - 1);
+  test("one lost ingest batch is visible on a large jurisdiction", async () => {
+    // The whole failure this detects is a fixed-size batch going
+    // missing, so the tolerance must stay below one — and must not grow
+    // with the corpus, or a large jurisdiction hides more the larger it
+    // gets. `corpusIndexBatchSize` is the size of the smallest real loss.
+    const marked = 5_000_000;
+    engineHolding(marked - LIMITS.corpusIndexBatchSize);
 
     const census = await censusJurisdiction({
       scopedDb: databaseHolding(marked),
@@ -118,13 +122,15 @@ describe("jurisdiction census", () => {
       jurisdiction: JURISDICTION,
     });
 
-    expect(census.isOk() && census.value.drifted).toBe(true);
+    expect(census.isOk() && census.value.short).toBe(true);
     expect(census.isOk() && census.value.indexId).toBe(INDEX_ID);
   });
 
-  test("an engine holding more than Postgres claims is not drift", async () => {
+  test("an engine holding more than Postgres claims is not short", async () => {
     // A superseded document nothing points at is unreachable, not wrong,
-    // and a rebuild leaves those behind by design.
+    // and a rebuild leaves those behind by design. This is also the
+    // direction a batch landing between the two counts pushes, which is
+    // why Postgres is counted first.
     engineHolding(50_000);
 
     const census = await censusJurisdiction({
@@ -134,7 +140,7 @@ describe("jurisdiction census", () => {
     });
 
     expect(census.isOk() && census.value.shortfall).toBeLessThan(0);
-    expect(census.isOk() && census.value.drifted).toBe(false);
+    expect(census.isOk() && census.value.short).toBe(false);
   });
 
   test("an unreachable index is a failure, not an empty index", async () => {
@@ -163,14 +169,18 @@ describe("census reporting", () => {
     warn.mockRestore();
   });
 
-  test("drift is reported with both counts", () => {
-    reportJurisdictionCensus(GENERATION, {
-      jurisdiction: JURISDICTION,
-      indexId: INDEX_ID,
-      engineDocuments: 900,
-      markedIndexed: 10_000,
-      shortfall: 9100,
-      drifted: true,
+  test("confirmed drift is reported with both counts", () => {
+    reportJurisdictionCensus({
+      generation: GENERATION,
+      confirmed: true,
+      census: {
+        jurisdiction: JURISDICTION,
+        indexId: INDEX_ID,
+        engineDocuments: 900,
+        markedIndexed: 10_000,
+        shortfall: 9100,
+        short: true,
+      },
     });
 
     expect(warn).toHaveBeenCalledTimes(1);
@@ -188,13 +198,37 @@ describe("census reporting", () => {
   });
 
   test("agreement is silent", () => {
-    reportJurisdictionCensus(GENERATION, {
-      jurisdiction: JURISDICTION,
-      indexId: INDEX_ID,
-      engineDocuments: 10_000,
-      markedIndexed: 10_000,
-      shortfall: 0,
-      drifted: false,
+    reportJurisdictionCensus({
+      generation: GENERATION,
+      confirmed: true,
+      census: {
+        jurisdiction: JURISDICTION,
+        indexId: INDEX_ID,
+        engineDocuments: 10_000,
+        markedIndexed: 10_000,
+        shortfall: 0,
+        short: false,
+      },
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test("a first short observation waits for confirmation", () => {
+    // A bulk page marks its rows before the engine publishes their
+    // split, so one short reading may be work in flight. Warning on it
+    // would make every rebuild noisy, and a noisy warning is not read.
+    reportJurisdictionCensus({
+      generation: GENERATION,
+      confirmed: false,
+      census: {
+        jurisdiction: JURISDICTION,
+        indexId: INDEX_ID,
+        engineDocuments: 900,
+        markedIndexed: 10_000,
+        shortfall: 9100,
+        short: true,
+      },
     });
 
     expect(warn).not.toHaveBeenCalled();
@@ -205,6 +239,7 @@ describe("census reporting", () => {
     const census = createCaseLawCensus({
       generation: GENERATION,
       scopedDb: databaseHolding(10_000, [JURISDICTION]),
+      startAt: LAST_CYCLE_START,
     });
 
     for (let cycle = 0; cycle < CENSUS_CYCLE_INTERVAL; cycle += 1) {
@@ -223,6 +258,7 @@ describe("census reporting", () => {
     const census = createCaseLawCensus({
       generation: GENERATION,
       scopedDb: databaseHolding(10_000, [JURISDICTION]),
+      startAt: LAST_CYCLE_START,
     });
 
     for (let cycle = 0; cycle < CENSUS_CYCLE_INTERVAL - 1; cycle += 1) {
@@ -236,6 +272,34 @@ describe("census reporting", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  test("a shortfall is reported once it survives a second census", async () => {
+    // The confirmation is what lets the tolerance stay smaller than an
+    // ingest batch: a page still publishing clears by the next visit, a
+    // lost split never does. Without it the choice would be between
+    // warning on every rebuild and never seeing the smallest real loss.
+    const marked = 5_000_000;
+    engineHolding(marked - LIMITS.corpusIndexBatchSize);
+    const census = createCaseLawCensus({
+      generation: GENERATION,
+      scopedDb: databaseHolding(marked, [JURISDICTION]),
+      startAt: LAST_CYCLE_START,
+    });
+
+    for (let cycle = 0; cycle < CENSUS_CYCLE_INTERVAL; cycle += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- the cycles are the subject of the test
+      await census.step();
+    }
+    expect(warn).not.toHaveBeenCalled();
+
+    for (let cycle = 0; cycle < CENSUS_CYCLE_INTERVAL; cycle += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- the cycles are the subject of the test
+      await census.step();
+    }
+    expect(warn.mock.calls.at(0)?.at(0)).toBe(
+      "case_law.corpus_index.census_drift",
+    );
+  });
+
   test("a census that throws cannot stop the backfill loop", async () => {
     const explode = async () => {
       await Promise.resolve();
@@ -247,6 +311,7 @@ describe("census reporting", () => {
     const census = createCaseLawCensus({
       generation: GENERATION,
       scopedDb: exploding,
+      startAt: LAST_CYCLE_START,
     });
 
     for (let cycle = 0; cycle < CENSUS_CYCLE_INTERVAL; cycle += 1) {

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -70,6 +70,33 @@ const DOCUMENT_COUNT_QUERY = "seq:0";
  */
 export const CENSUS_TOLERANCE = 5;
 
+/**
+ * What one observation says about a jurisdiction.
+ *
+ * Two counts can only report their difference, and the difference nets
+ * two independent defects: documents the engine never received, and
+ * entries it holds that no row points at. An orphan cancels a missing
+ * document, so a census that only looked for a shortfall would go quiet
+ * on the pair. Reporting the surplus direction too is what keeps that
+ * from being silent — an index holding more than the corpus claims is
+ * itself worth acting on, and it says the shortfall number cannot be
+ * trusted until it is cleared. Exact cancellation to inside the
+ * tolerance remains this mechanism's blind spot; closing it needs an
+ * identity comparison, which means streaming the jurisdiction rather
+ * than counting it.
+ */
+export const CENSUS_DISPOSITION = {
+  /** Both sides agree inside the tolerance. */
+  aligned: "aligned",
+  /** The engine holds fewer documents than the corpus claims. */
+  short: "short",
+  /** The engine holds documents the corpus does not account for. */
+  surplus: "surplus",
+} as const;
+
+export type CensusDisposition =
+  (typeof CENSUS_DISPOSITION)[keyof typeof CENSUS_DISPOSITION];
+
 export type JurisdictionCensus = {
   jurisdiction: string;
   indexId: string;
@@ -77,15 +104,18 @@ export type JurisdictionCensus = {
   engineDocuments: number;
   /** Rows Postgres reports as indexed into it for this generation. */
   markedIndexed: number;
-  /**
-   * How many rows Postgres claims the engine has and the engine does
-   * not. Negative means the engine holds more, which is the harmless
-   * direction: a superseded document that no row points at is
-   * unreachable, not wrong.
-   */
+  /** Positive where the corpus claims more than the engine holds. */
   shortfall: number;
-  /** Whether this one observation is outside the tolerance. */
-  short: boolean;
+  disposition: CensusDisposition;
+};
+
+const dispositionOf = (shortfall: number): CensusDisposition => {
+  if (shortfall > CENSUS_TOLERANCE) {
+    return CENSUS_DISPOSITION.short;
+  }
+  return shortfall < -CENSUS_TOLERANCE
+    ? CENSUS_DISPOSITION.surplus
+    : CENSUS_DISPOSITION.aligned;
 };
 
 /**
@@ -170,7 +200,7 @@ export const censusJurisdiction = async ({
     engineDocuments: counted.value.numHits,
     markedIndexed,
     shortfall,
-    short: shortfall > CENSUS_TOLERANCE,
+    disposition: dispositionOf(shortfall),
   });
 };
 
@@ -178,17 +208,22 @@ export type ReportJurisdictionCensusOptions = {
   generation: string;
   census: JurisdictionCensus;
   /**
-   * Whether this jurisdiction was already short when it was last
-   * censused. A bulk page marks its rows before the engine publishes
-   * their split, so a single short observation may just be work in
-   * flight; a lost split is short forever, so it survives into the next
-   * observation and a publishing page does not.
+   * The disposition this jurisdiction had when it was last censused. A
+   * bulk page marks its rows before the engine publishes their split, so
+   * a single disagreeing observation may just be work in flight; a lost
+   * split or an orphaned entry is there forever, so it survives into the
+   * next observation and a publishing page does not.
    */
-  confirmed: boolean;
+  previous: CensusDisposition | undefined;
 };
 
 /**
- * Report a census, warning only where the engine is short twice running.
+ * Report a census, warning where the two sides disagree twice running.
+ *
+ * Both directions are reported. A surplus is a defect in its own right —
+ * entries no row points at are unreachable weight in the index — and,
+ * more to the point here, an unaccounted-for surplus is what could be
+ * cancelling a shortfall in the same count.
  *
  * A warning rather than an error because the corpus is still serving:
  * the missing documents are unsearchable, not wrong, and the repair
@@ -197,13 +232,17 @@ export type ReportJurisdictionCensusOptions = {
 export const reportJurisdictionCensus = ({
   generation,
   census,
-  confirmed,
+  previous,
 }: ReportJurisdictionCensusOptions): void => {
-  if (!(census.short && confirmed)) {
+  if (
+    census.disposition === CENSUS_DISPOSITION.aligned ||
+    census.disposition !== previous
+  ) {
     return;
   }
   logger.warn("case_law.corpus_index.census_drift", {
     generation,
+    disposition: census.disposition,
     indexId: census.indexId,
     jurisdiction: census.jurisdiction,
     engineDocuments: census.engineDocuments,
@@ -286,8 +325,8 @@ export const createCaseLawCensus = ({
   // the next step if deployments ever outpace the sweep.
   let cyclesUntilCensus = 1 + Math.floor(startAt * CENSUS_CYCLE_INTERVAL);
   let pending: string[] = [];
-  /** Jurisdictions short at their last census, awaiting confirmation. */
-  const shortLastTime = new Set<string>();
+  /** Each jurisdiction's last disposition, awaiting confirmation. */
+  const lastDisposition = new Map<string, CensusDisposition>();
 
   const takeNextJurisdiction = async (): Promise<string | undefined> => {
     if (pending.length > 0) {
@@ -332,13 +371,9 @@ export const createCaseLawCensus = ({
     reportJurisdictionCensus({
       generation,
       census: census.value,
-      confirmed: shortLastTime.has(jurisdiction),
+      previous: lastDisposition.get(jurisdiction),
     });
-    if (census.value.short) {
-      shortLastTime.add(jurisdiction);
-    } else {
-      shortLastTime.delete(jurisdiction);
-    }
+    lastDisposition.set(jurisdiction, census.value.disposition);
   };
 
   return {

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -1,0 +1,376 @@
+/**
+ * Count what the search engine actually holds against what Postgres says
+ * it holds, one jurisdiction at a time.
+ *
+ * The ingest path marks a row indexed on the strength of the engine
+ * accepting its batch. `commit=wait_for` makes that acceptance mean the
+ * split is published, which closes the window where an indexer death
+ * loses documents Postgres has already recorded — but only for the
+ * requests that use it. Bulk rebuild pages deliberately keep `auto` for
+ * throughput, and no request-level signal can prove a whole generation
+ * landed anyway: a lost split leaves a row that is neither missing (it
+ * has an `indexedHash`) nor stale (the hash matches), so nothing selects
+ * it again and the gap is permanent and invisible.
+ *
+ * A census is what makes it visible. It is a count on both sides, not a
+ * diff: naming the missing documents would mean streaming the whole
+ * jurisdiction out of the engine, while the number alone is one cheap
+ * aggregate per side and is enough to decide that a jurisdiction needs
+ * re-indexing. The repair is correspondingly blunt — clear `indexedHash`
+ * for the jurisdiction and let the ordinary backfill re-select every row
+ * — because the projection is idempotent and re-ingesting a document the
+ * engine already holds converges on the same split.
+ *
+ * Bounded by construction: one jurisdiction per call, one aggregate
+ * query per side, and a caller that decides how often to run it.
+ */
+
+import { Result } from "better-result";
+import { and, eq, sql } from "drizzle-orm";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import {
+  caseLawCorpusIndexProjections,
+  caseLawDecisions,
+} from "@/api/db/schema";
+import { errorTag } from "@/api/lib/errors/error-tag";
+import {
+  caseLawCorpusProjectionJoin,
+  currentCaseLawCorpusProjection,
+} from "@/api/lib/legal-search/case-law-corpus-projection";
+import type { CorpusIndexError } from "@/api/lib/legal-search/corpus-index-client";
+import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
+import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+import { logger } from "@/api/lib/observability/logger";
+import { isRecord } from "@/api/lib/type-guards";
+
+/**
+ * Counts documents rather than passages. A passage-granular index holds
+ * one entry per chunk and exactly one of them per document carries
+ * `seq:0`, so this is the document count on the engine side whichever
+ * granularity the family is indexed at.
+ */
+const DOCUMENT_COUNT_QUERY = "seq:0";
+
+/**
+ * How far the two sides may disagree before the jurisdiction is
+ * reported.
+ *
+ * Never zero: a census is two counts taken at different instants, so a
+ * batch committing between them reads as drift. The tolerance is
+ * whichever is larger of a small absolute floor — which covers the
+ * in-flight batch — and a fraction of the corpus, which keeps a large
+ * jurisdiction from tripping on ordinary churn while still catching a
+ * lost split. A lost commit window costs a whole batch, so the floor
+ * sits below the ingest batch size on purpose.
+ */
+export const CENSUS_ABSOLUTE_TOLERANCE = 50;
+export const CENSUS_RELATIVE_TOLERANCE = 0.001;
+
+export const censusTolerance = (markedIndexed: number): number =>
+  Math.max(
+    CENSUS_ABSOLUTE_TOLERANCE,
+    Math.ceil(markedIndexed * CENSUS_RELATIVE_TOLERANCE),
+  );
+
+export type JurisdictionCensus = {
+  jurisdiction: string;
+  indexId: string;
+  /** Documents the engine reports for this index. */
+  engineDocuments: number;
+  /** Rows Postgres reports as indexed into it for this generation. */
+  markedIndexed: number;
+  /**
+   * How many rows Postgres claims the engine has and the engine does
+   * not. Negative means the engine holds more, which is the harmless
+   * direction: a superseded document that no row points at is
+   * unreachable, not wrong.
+   */
+  shortfall: number;
+  drifted: boolean;
+};
+
+/**
+ * Rows this generation has marked as indexed into this jurisdiction's
+ * physical index.
+ *
+ * The same predicate the search path rehydrates through, so the census
+ * counts exactly the rows a query would expect the engine to answer for.
+ * Defining it a second time here would let the two drift, which is the
+ * failure this whole module exists to catch.
+ */
+const countMarkedIndexed = async (
+  scopedDb: ScopedDb,
+  { generation, jurisdiction }: { generation: string; jurisdiction: string },
+): Promise<number> => {
+  const rows = await scopedDb((tx) =>
+    tx
+      .select({ marked: sql<number>`count(*)::int` })
+      .from(caseLawDecisions)
+      .leftJoin(
+        caseLawCorpusIndexProjections,
+        caseLawCorpusProjectionJoin(generation),
+      )
+      .where(
+        and(
+          eq(caseLawDecisions.country, jurisdiction),
+          currentCaseLawCorpusProjection(generation),
+        ),
+      ),
+  );
+  return rows.at(0)?.marked ?? 0;
+};
+
+export type CensusJurisdictionOptions = {
+  scopedDb: ScopedDb;
+  generation: string;
+  /** The `country` value, which also names the physical index. */
+  jurisdiction: string;
+};
+
+/**
+ * One jurisdiction's census, or the engine error that stopped it.
+ *
+ * A census that cannot reach the engine is not drift, so it is reported
+ * as a failure rather than folded into the count: treating an
+ * unreachable index as an empty one would clear every row in the
+ * jurisdiction and re-ingest the whole corpus.
+ */
+export const censusJurisdiction = async ({
+  scopedDb,
+  generation,
+  jurisdiction,
+}: CensusJurisdictionOptions): Promise<
+  Result<JurisdictionCensus, CorpusIndexError>
+> => {
+  const indexId = corpusIndexId(generation, jurisdiction);
+  const counted = await getCorpusIndexClient().search({
+    indexId,
+    query: DOCUMENT_COUNT_QUERY,
+    maxHits: 0,
+  });
+  if (Result.isError(counted)) {
+    return Result.err(counted.error);
+  }
+
+  const markedIndexed = await countMarkedIndexed(scopedDb, {
+    generation,
+    jurisdiction,
+  });
+  const shortfall = markedIndexed - counted.value.numHits;
+
+  return Result.ok({
+    jurisdiction,
+    indexId,
+    engineDocuments: counted.value.numHits,
+    markedIndexed,
+    shortfall,
+    drifted: shortfall > censusTolerance(markedIndexed),
+  });
+};
+
+/**
+ * Report a census, warning only where the engine is genuinely short.
+ *
+ * Emitted as a warning rather than an error because the corpus is still
+ * serving: the missing documents are unsearchable, not wrong, and the
+ * repair below is an operator decision rather than something to page on.
+ */
+export const reportJurisdictionCensus = (
+  generation: string,
+  census: JurisdictionCensus,
+): void => {
+  if (!census.drifted) {
+    return;
+  }
+  logger.warn("case_law.corpus_index.census_drift", {
+    generation,
+    indexId: census.indexId,
+    jurisdiction: census.jurisdiction,
+    engineDocuments: census.engineDocuments,
+    markedIndexed: census.markedIndexed,
+    shortfall: census.shortfall,
+    tolerance: censusTolerance(census.markedIndexed),
+  });
+};
+
+/**
+ * Ceiling on the jurisdictions one sweep covers. The corpus is
+ * partitioned by ISO country code, so this is far above the real
+ * cardinality; it exists so the census cannot become an unbounded read
+ * if the column ever holds something it should not.
+ */
+const MAX_CENSUSED_JURISDICTIONS = 256;
+
+/**
+ * Jurisdictions the corpus holds, which is also the set of physical
+ * indexes it should have. Read from the decisions themselves rather than
+ * from a hand-kept list, so a new country's index cannot be uncensused
+ * because nobody remembered to add it.
+ */
+export const listCaseLawJurisdictions = async (
+  scopedDb: ScopedDb,
+): Promise<string[]> => {
+  const rows = await scopedDb((tx) =>
+    tx
+      .selectDistinct({ country: caseLawDecisions.country })
+      .from(caseLawDecisions)
+      .orderBy(caseLawDecisions.country)
+      .limit(MAX_CENSUSED_JURISDICTIONS),
+  );
+  return rows.map(({ country }) => country);
+};
+
+/**
+ * Backfill cycles between one census and the next.
+ *
+ * The census is a diagnostic, not a gate: it costs an aggregate on each
+ * side and the drift it looks for accumulates over hours, so running it
+ * on every batch would spend real query budget to answer the same
+ * question. One jurisdiction per census means a corpus of N
+ * jurisdictions is fully covered every N of these.
+ */
+export const CENSUS_CYCLE_INTERVAL = 20;
+
+export type CaseLawCensusOptions = {
+  scopedDb: ScopedDb;
+  generation: string;
+};
+
+/**
+ * The census as the backfill loop consumes it: called every cycle,
+ * doing work on a few of them, and never able to fail its caller.
+ *
+ * A census that throws would take the backfill down with it, which
+ * would trade a silent index gap for a stopped index. It reports and
+ * moves on instead; the next pass round-robins to the next
+ * jurisdiction either way, so one unreachable index cannot pin the
+ * sweep.
+ */
+export const createCaseLawCensus = ({
+  scopedDb,
+  generation,
+}: CaseLawCensusOptions): { step: () => Promise<void> } => {
+  let cyclesUntilCensus = CENSUS_CYCLE_INTERVAL;
+  let pending: string[] = [];
+
+  const censusNext = async (): Promise<void> => {
+    if (pending.length === 0) {
+      pending = await listCaseLawJurisdictions(scopedDb);
+    }
+    const jurisdiction = pending.shift();
+    if (jurisdiction === undefined) {
+      return;
+    }
+
+    const census = await censusJurisdiction({
+      scopedDb,
+      generation,
+      jurisdiction,
+    });
+    if (Result.isError(census)) {
+      // An unreachable index is not a short one. Saying so keeps the
+      // repair from being pointed at a jurisdiction whose engine simply
+      // did not answer.
+      logger.warn("case_law.corpus_index.census_unavailable", {
+        generation,
+        jurisdiction,
+        "error.type": census.error._tag,
+      });
+      return;
+    }
+    reportJurisdictionCensus(generation, census.value);
+  };
+
+  return {
+    step: async (): Promise<void> => {
+      cyclesUntilCensus -= 1;
+      if (cyclesUntilCensus > 0) {
+        return;
+      }
+      cyclesUntilCensus = CENSUS_CYCLE_INTERVAL;
+
+      const outcome = await Result.tryPromise(censusNext);
+      if (Result.isError(outcome)) {
+        logger.warn("case_law.corpus_index.census_failed", {
+          generation,
+          "error.type": errorTag(outcome.error),
+        });
+      }
+    },
+  };
+};
+
+export type ClearJurisdictionIndexMarksOptions = {
+  scopedDb: ScopedDb;
+  jurisdiction: string;
+  /**
+   * Most rows to un-mark in this call. The repair is a deliberately
+   * bounded operator action: a whole jurisdiction can be millions of
+   * rows, and un-marking them all at once would hand the backfill a
+   * backlog that starves every newly ingested decision behind it. Run it
+   * again to clear the next slice.
+   */
+  limit: number;
+};
+
+/**
+ * `execute` returns the driver's own row container: the server client
+ * gives an array, the embedded one used by the database tests wraps it.
+ * Reading the count through both keeps the repair's report honest under
+ * either.
+ */
+const countReturnedRows = (result: unknown): number => {
+  if (Array.isArray(result)) {
+    return result.length;
+  }
+  if (isRecord(result) && Array.isArray(result["rows"])) {
+    return result["rows"].length;
+  }
+  return 0;
+};
+
+/**
+ * Un-mark a drifted jurisdiction so the ordinary backfill re-selects it.
+ *
+ * Clearing `indexed_hash` is the whole repair, and deliberately the only
+ * write: the projection trigger on this column enqueues the decision for
+ * its generation with the right target index and content hash, so the
+ * row rejoins the live pending queue and is re-projected through the
+ * same path — and the same commit semantics — as a newly ingested
+ * decision. Writing the projection here instead would be a second,
+ * hand-maintained copy of what the trigger already states.
+ *
+ * Nothing is deleted from the engine: re-ingesting a document it already
+ * holds replaces it at the same id, so running this against a
+ * jurisdiction that was not actually short costs re-indexing and nothing
+ * else.
+ *
+ * The slice only takes rows that still carry a mark, so repeated runs
+ * walk the jurisdiction rather than clearing the same first page
+ * forever. `updated_at` is left alone, like every other index-mark
+ * write: an index repair is not a change to the decision, and the public
+ * reads key their freshness off that column.
+ */
+export const clearJurisdictionIndexMarks = async ({
+  scopedDb,
+  jurisdiction,
+  limit,
+}: ClearJurisdictionIndexMarksOptions): Promise<number> =>
+  await scopedDb(async (tx) => {
+    // audit: skip — search index maintenance; rebuilds derived state
+    const cleared = await tx.execute(sql`
+      UPDATE ${caseLawDecisions}
+      SET indexed_hash = NULL
+      WHERE ${caseLawDecisions.id} IN (
+        SELECT ${caseLawDecisions.id}
+        FROM ${caseLawDecisions}
+        WHERE ${caseLawDecisions.country} = ${jurisdiction}
+          AND ${caseLawDecisions.indexedHash} IS NOT NULL
+        ORDER BY ${caseLawDecisions.id}
+        LIMIT ${limit}
+      )
+      RETURNING ${caseLawDecisions.id}
+    `);
+    return countReturnedRows(cleared);
+  });

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -16,10 +16,10 @@
  * diff: naming the missing documents would mean streaming the whole
  * jurisdiction out of the engine, while the number alone is one cheap
  * aggregate per side and is enough to decide that a jurisdiction needs
- * re-indexing. The repair is correspondingly blunt — clear `indexedHash`
- * for the jurisdiction and let the ordinary backfill re-select every row
- * — because the projection is idempotent and re-ingesting a document the
- * engine already holds converges on the same split.
+ * re-indexing. The repair is correspondingly blunt — un-mark a slice of
+ * the jurisdiction and let the ordinary backfill re-project it — because
+ * the projection is idempotent and re-ingesting a document the engine
+ * already holds converges on the same split.
  *
  * Bounded by construction: one jurisdiction per call, one aggregate
  * query per side, and a caller that decides how often to run it.
@@ -53,25 +53,22 @@ import { isRecord } from "@/api/lib/type-guards";
 const DOCUMENT_COUNT_QUERY = "seq:0";
 
 /**
- * How far the two sides may disagree before the jurisdiction is
- * reported.
+ * How far the two sides may disagree in one observation.
  *
- * Never zero: a census is two counts taken at different instants, so a
- * batch committing between them reads as drift. The tolerance is
- * whichever is larger of a small absolute floor — which covers the
- * in-flight batch — and a fraction of the corpus, which keeps a large
- * jurisdiction from tripping on ordinary churn while still catching a
- * lost split. A lost commit window costs a whole batch, so the floor
- * sits below the ingest batch size on purpose.
+ * Small and absolute, never proportional: a fraction of the corpus lets
+ * a large jurisdiction hide more documents the larger it gets, which is
+ * backwards — the whole failure this detects is a fixed-size batch going
+ * missing. A tolerance at or above the ingest batch size would make the
+ * smallest real loss, exactly one lost commit window, invisible.
+ *
+ * It is not zero either, because the bulk rebuild path marks rows before
+ * the engine publishes their split, so an in-flight page reads as a
+ * shortfall for as long as it takes to commit. That transient is what
+ * the confirmation below is for: a shortfall has to survive into the
+ * jurisdiction's next census before it is reported, and an in-flight
+ * page will have published by then while a lost split never will.
  */
-export const CENSUS_ABSOLUTE_TOLERANCE = 50;
-export const CENSUS_RELATIVE_TOLERANCE = 0.001;
-
-export const censusTolerance = (markedIndexed: number): number =>
-  Math.max(
-    CENSUS_ABSOLUTE_TOLERANCE,
-    Math.ceil(markedIndexed * CENSUS_RELATIVE_TOLERANCE),
-  );
+export const CENSUS_TOLERANCE = 5;
 
 export type JurisdictionCensus = {
   jurisdiction: string;
@@ -87,7 +84,8 @@ export type JurisdictionCensus = {
    * unreachable, not wrong.
    */
   shortfall: number;
-  drifted: boolean;
+  /** Whether this one observation is outside the tolerance. */
+  short: boolean;
 };
 
 /**
@@ -144,6 +142,17 @@ export const censusJurisdiction = async ({
   Result<JurisdictionCensus, CorpusIndexError>
 > => {
   const indexId = corpusIndexId(generation, jurisdiction);
+  // Postgres first, deliberately. The two counts are taken at different
+  // instants, and a batch landing between them shifts the difference by
+  // a whole batch; taking the claim before the evidence makes that shift
+  // go the harmless way, because a row marked after the Postgres count
+  // is still visible to the engine count that follows. The other order
+  // would need a tolerance the size of a batch, which is exactly the
+  // size of the smallest loss worth finding.
+  const markedIndexed = await countMarkedIndexed(scopedDb, {
+    generation,
+    jurisdiction,
+  });
   const counted = await getCorpusIndexClient().search({
     indexId,
     query: DOCUMENT_COUNT_QUERY,
@@ -153,10 +162,6 @@ export const censusJurisdiction = async ({
     return Result.err(counted.error);
   }
 
-  const markedIndexed = await countMarkedIndexed(scopedDb, {
-    generation,
-    jurisdiction,
-  });
   const shortfall = markedIndexed - counted.value.numHits;
 
   return Result.ok({
@@ -165,22 +170,36 @@ export const censusJurisdiction = async ({
     engineDocuments: counted.value.numHits,
     markedIndexed,
     shortfall,
-    drifted: shortfall > censusTolerance(markedIndexed),
+    short: shortfall > CENSUS_TOLERANCE,
   });
 };
 
+export type ReportJurisdictionCensusOptions = {
+  generation: string;
+  census: JurisdictionCensus;
+  /**
+   * Whether this jurisdiction was already short when it was last
+   * censused. A bulk page marks its rows before the engine publishes
+   * their split, so a single short observation may just be work in
+   * flight; a lost split is short forever, so it survives into the next
+   * observation and a publishing page does not.
+   */
+  confirmed: boolean;
+};
+
 /**
- * Report a census, warning only where the engine is genuinely short.
+ * Report a census, warning only where the engine is short twice running.
  *
- * Emitted as a warning rather than an error because the corpus is still
- * serving: the missing documents are unsearchable, not wrong, and the
- * repair below is an operator decision rather than something to page on.
+ * A warning rather than an error because the corpus is still serving:
+ * the missing documents are unsearchable, not wrong, and the repair
+ * below is an operator decision rather than something to page on.
  */
-export const reportJurisdictionCensus = (
-  generation: string,
-  census: JurisdictionCensus,
-): void => {
-  if (!census.drifted) {
+export const reportJurisdictionCensus = ({
+  generation,
+  census,
+  confirmed,
+}: ReportJurisdictionCensusOptions): void => {
+  if (!(census.short && confirmed)) {
     return;
   }
   logger.warn("case_law.corpus_index.census_drift", {
@@ -190,7 +209,7 @@ export const reportJurisdictionCensus = (
     engineDocuments: census.engineDocuments,
     markedIndexed: census.markedIndexed,
     shortfall: census.shortfall,
-    tolerance: censusTolerance(census.markedIndexed),
+    tolerance: CENSUS_TOLERANCE,
   });
 };
 
@@ -235,6 +254,12 @@ export const CENSUS_CYCLE_INTERVAL = 20;
 export type CaseLawCensusOptions = {
   scopedDb: ScopedDb;
   generation: string;
+  /**
+   * Where in the cycle and the jurisdiction list this process starts, in
+   * `[0, 1)`. Random per process so restarts spread their coverage;
+   * tests pin it.
+   */
+  startAt?: number;
 };
 
 /**
@@ -250,15 +275,38 @@ export type CaseLawCensusOptions = {
 export const createCaseLawCensus = ({
   scopedDb,
   generation,
+  startAt = Math.random(),
 }: CaseLawCensusOptions): { step: () => Promise<void> } => {
-  let cyclesUntilCensus = CENSUS_CYCLE_INTERVAL;
+  // Both the countdown and the sweep position start somewhere random.
+  // They live in this process, so a runner replaced mid-sweep loses them;
+  // starting every replacement at the same place would mean frequent
+  // deployments always censusing the head of the alphabet and never the
+  // tail. A random phase covers every jurisdiction in expectation
+  // instead. A durable cursor would remove the "in expectation", and is
+  // the next step if deployments ever outpace the sweep.
+  let cyclesUntilCensus = 1 + Math.floor(startAt * CENSUS_CYCLE_INTERVAL);
   let pending: string[] = [];
+  /** Jurisdictions short at their last census, awaiting confirmation. */
+  const shortLastTime = new Set<string>();
+
+  const takeNextJurisdiction = async (): Promise<string | undefined> => {
+    if (pending.length > 0) {
+      return pending.shift();
+    }
+    const jurisdictions = await listCaseLawJurisdictions(scopedDb);
+    if (jurisdictions.length === 0) {
+      return undefined;
+    }
+    const offset = Math.floor(startAt * jurisdictions.length);
+    pending = [
+      ...jurisdictions.slice(offset),
+      ...jurisdictions.slice(0, offset),
+    ];
+    return pending.shift();
+  };
 
   const censusNext = async (): Promise<void> => {
-    if (pending.length === 0) {
-      pending = await listCaseLawJurisdictions(scopedDb);
-    }
-    const jurisdiction = pending.shift();
+    const jurisdiction = await takeNextJurisdiction();
     if (jurisdiction === undefined) {
       return;
     }
@@ -271,7 +319,8 @@ export const createCaseLawCensus = ({
     if (Result.isError(census)) {
       // An unreachable index is not a short one. Saying so keeps the
       // repair from being pointed at a jurisdiction whose engine simply
-      // did not answer.
+      // did not answer. The pending confirmation is left alone: a
+      // failed observation neither confirms nor clears one.
       logger.warn("case_law.corpus_index.census_unavailable", {
         generation,
         jurisdiction,
@@ -279,7 +328,17 @@ export const createCaseLawCensus = ({
       });
       return;
     }
-    reportJurisdictionCensus(generation, census.value);
+
+    reportJurisdictionCensus({
+      generation,
+      census: census.value,
+      confirmed: shortLastTime.has(jurisdiction),
+    });
+    if (census.value.short) {
+      shortLastTime.add(jurisdiction);
+    } else {
+      shortLastTime.delete(jurisdiction);
+    }
   };
 
   return {
@@ -303,6 +362,7 @@ export const createCaseLawCensus = ({
 
 export type ClearJurisdictionIndexMarksOptions = {
   scopedDb: ScopedDb;
+  generation: string;
   jurisdiction: string;
   /**
    * Most rows to un-mark in this call. The repair is a deliberately
@@ -313,6 +373,9 @@ export type ClearJurisdictionIndexMarksOptions = {
    */
   limit: number;
 };
+
+/** Hard ceiling on one repair slice, whatever the operator asks for. */
+export const MAX_REPAIR_SLICE = 50_000;
 
 /**
  * `execute` returns the driver's own row container: the server client
@@ -331,29 +394,40 @@ const countReturnedRows = (result: unknown): number => {
 };
 
 /**
- * Un-mark a drifted jurisdiction so the ordinary backfill re-selects it.
+ * Un-mark a slice of a short jurisdiction so the backfill re-selects it.
  *
- * Clearing `indexed_hash` is the whole repair, and deliberately the only
- * write: the projection trigger on this column enqueues the decision for
- * its generation with the right target index and content hash, so the
- * row rejoins the live pending queue and is re-projected through the
- * same path — and the same commit semantics — as a newly ingested
- * decision. Writing the projection here instead would be a second,
- * hand-maintained copy of what the trigger already states.
+ * The slice is the census's own population — rows this generation counts
+ * as indexed into this jurisdiction — rather than rows carrying the
+ * legacy marker. The two are not the same set: a generation rebuild
+ * records success in the projection and leaves `case_law_decisions`
+ * alone, so a repair keyed off that column would be inert for exactly
+ * the rows a rebuild lost. Sharing the predicate with the count also
+ * means the repair cannot drift away from what was measured.
  *
- * Nothing is deleted from the engine: re-ingesting a document it already
- * holds replaces it at the same id, so running this against a
- * jurisdiction that was not actually short costs re-indexing and nothing
- * else.
+ * The write is still only `indexed_hash`, and deliberately so: the
+ * projection trigger on that column enqueues the decision for every
+ * live generation with the right target index and content hash, so the
+ * row rejoins the pending queue and is re-projected through the same
+ * path — and the same commit semantics — as a newly ingested decision.
+ * Writing the projection here as well would be a second, hand-maintained
+ * copy of what the trigger already states. The trigger fires on the
+ * column being assigned, not on its value changing, so a row whose
+ * legacy marker is already null is enqueued just the same.
  *
- * The slice only takes rows that still carry a mark, so repeated runs
- * walk the jurisdiction rather than clearing the same first page
- * forever. `updated_at` is left alone, like every other index-mark
- * write: an index repair is not a change to the decision, and the public
- * reads key their freshness off that column.
+ * That enqueue is also what makes repeated runs walk the jurisdiction:
+ * a queued row is no longer counted as current, so the next slice starts
+ * past it.
+ *
+ * Nothing is deleted from the engine — re-ingesting a document it
+ * already holds replaces it at the same id — so running this against a
+ * jurisdiction that was not short costs re-indexing and nothing else.
+ * `updated_at` is left alone, like every other index-mark write: an
+ * index repair is not a change to the decision, and the public reads key
+ * their freshness off that column.
  */
 export const clearJurisdictionIndexMarks = async ({
   scopedDb,
+  generation,
   jurisdiction,
   limit,
 }: ClearJurisdictionIndexMarksOptions): Promise<number> =>
@@ -365,10 +439,12 @@ export const clearJurisdictionIndexMarks = async ({
       WHERE ${caseLawDecisions.id} IN (
         SELECT ${caseLawDecisions.id}
         FROM ${caseLawDecisions}
+        LEFT JOIN ${caseLawCorpusIndexProjections}
+          ON ${caseLawCorpusProjectionJoin(generation)}
         WHERE ${caseLawDecisions.country} = ${jurisdiction}
-          AND ${caseLawDecisions.indexedHash} IS NOT NULL
+          AND ${currentCaseLawCorpusProjection(generation)}
         ORDER BY ${caseLawDecisions.id}
-        LIMIT ${limit}
+        LIMIT ${Math.min(limit, MAX_REPAIR_SLICE)}
       )
       RETURNING ${caseLawDecisions.id}
     `);

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -3,7 +3,10 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
 import { toSafeId } from "@/api/lib/branded-types";
-import type { CorpusJobInput } from "@/api/lib/corpus-index/core";
+import type {
+  CorpusJobInput,
+  FencedRemoteEffect,
+} from "@/api/lib/corpus-index/core";
 import {
   corpusDocumentsDeleteQuery,
   createCorpusIndexer,
@@ -14,6 +17,7 @@ import {
   splitIngestRequests,
 } from "@/api/lib/corpus-index/core";
 import type { TimestampCasToken } from "@/api/lib/db/timestamp-cas";
+import { CORPUS_INDEX_COMMIT } from "@/api/lib/legal-search/corpus-index-client";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 import { isRecord } from "@/api/lib/type-guards";
 
@@ -718,6 +722,7 @@ describe("failed index jobs always reach the audit trail", () => {
     let guardedEffects = 0;
     let guardedMarks = 0;
     const indexed = await indexer.backfillRows(scopedDb, [row], GENERATION, {
+      commit: CORPUS_INDEX_COMMIT.auto,
       beforeDatabaseMark: async () => {
         guardedMarks += 1;
         commitEvents.push("guard");
@@ -775,6 +780,7 @@ describe("failed index jobs always reach the audit trail", () => {
     };
     expect(
       await indexer.backfillRows(scopedDb, [sameIndexRow], GENERATION, {
+        commit: CORPUS_INDEX_COMMIT.auto,
         beforeDatabaseMark: async () => {
           guardedMarks += 1;
           commitEvents.push("guard");
@@ -858,6 +864,142 @@ describe("failed index jobs always reach the audit trail", () => {
   });
 });
 
+/**
+ * Acceptance and durability are not the same thing. `commit=auto` returns
+ * once the documents are buffered, so an indexer that dies inside the
+ * commit window loses them — and the caller has already been told the
+ * batch was accepted, which is what it marks `indexedHash` on. The row is
+ * then neither missing (it has a hash) nor stale (the hash matches), so
+ * nothing ever selects it again and the gap is permanent and silent.
+ *
+ * A bulk rebuild can afford `auto` because its completeness is checked
+ * against a census afterwards. The steady-state paths cannot, so the mode
+ * is pinned per entry point rather than left to whichever call site was
+ * written last.
+ */
+describe("ingest commit mode", () => {
+  const originalFetch = globalThis.fetch;
+  const GENERATION = "case_law_v2";
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const row = {
+    id: toSafeId<"caseLawDecision">("dec-commit"),
+    country: "SK",
+    textS3Key: null,
+    astS3Key: null,
+    contentHash: "hash-dec-commit",
+    indexedHash: null,
+    indexedGeneration: null,
+    projectionIndexId: corpusIndexId(GENERATION, "SK"),
+    // SAFETY: tests fabricate the branded token the adapters normally
+    // select as `updated_at::text`.
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion
+    updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
+  };
+
+  const scopedDb: ScopedDb = async (callback) =>
+    // SAFETY: this test's adapter ignores the transaction.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the fake transaction is deliberately inert
+    await callback({} as Transaction);
+
+  const fencedGuards = {
+    beforeDatabaseMark: async () => undefined,
+    beforeRemoteEffect: async <T>({ effect }: FencedRemoteEffect<T>) =>
+      await effect(),
+    recoverRemoteEffectLeaseLoss: async () => await Promise.resolve(),
+    reserveExternalAppend: async (
+      _tx: Transaction,
+      { generation }: { generation: string; rows: readonly (typeof row)[] },
+    ) =>
+      new Map([
+        [
+          row.id,
+          {
+            indexIds: [corpusIndexId(generation, row.country)],
+            revision: 1,
+            mayHaveCopy: false,
+          },
+        ],
+      ]),
+  };
+
+  /** The commit modes the engine was asked for, in request order. */
+  const recordCommitModes = (): string[] => {
+    const modes: string[] = [];
+    const resolveUrl = (input: Parameters<typeof fetch>[0]): string => {
+      if (typeof input === "string") {
+        return input;
+      }
+      return input instanceof URL ? input.href : input.url;
+    };
+    const stub = async (input: Parameters<typeof fetch>[0]) => {
+      const url = new URL(resolveUrl(input));
+      if (url.pathname.endsWith("/ingest")) {
+        modes.push(url.searchParams.get("commit") ?? "");
+        return new Response(JSON.stringify({ num_docs_for_processing: 1 }), {
+          status: 200,
+        });
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+    globalThis.fetch = Object.assign(stub, {
+      preconnect: originalFetch.preconnect,
+    });
+    return modes;
+  };
+
+  const makeIndexer = () =>
+    createCorpusIndexer<"caseLawDecision", typeof row>({
+      family: "case_law",
+      captureStep: "test",
+      granularity: "document",
+      generationProjectionIndexIds: (selected) => [selected.projectionIndexId],
+      buildDocs: (selected) => [{ document_id: selected.id, text: "body" }],
+      readCorpusText: async () => "body",
+      selectMissing: async () => [row],
+      selectStale: async () => [],
+      fetchFulltext: async () => "body",
+      markIndexedBatch: async (_tx, { rows }) =>
+        new Set(rows.map((selected) => selected.id)),
+      insertSucceededJobs: async () => undefined,
+      recordJobs: async () => undefined,
+    });
+
+  test("the incremental backfill waits for the commit", async () => {
+    const modes = recordCommitModes();
+
+    await makeIndexer().backfill(scopedDb, 1, GENERATION);
+
+    expect(modes).toEqual([CORPUS_INDEX_COMMIT.waitFor]);
+  });
+
+  test("the fenced incremental backfill waits for the commit", async () => {
+    const modes = recordCommitModes();
+
+    await makeIndexer().backfillFenced(scopedDb, 1, GENERATION, fencedGuards);
+
+    expect(modes).toEqual([CORPUS_INDEX_COMMIT.waitFor]);
+  });
+
+  test("a rebuild sends the mode its caller chose", async () => {
+    // One entry point, two walks: the snapshot pages are bulk and the
+    // pending queue drained alongside them is the live path, so the
+    // caller states which it is.
+    for (const commit of Object.values(CORPUS_INDEX_COMMIT)) {
+      const modes = recordCommitModes();
+      // oxlint-disable-next-line no-await-in-loop -- one walk per mode; the recorder is per-stub
+      await makeIndexer().backfillRows(scopedDb, [row], GENERATION, {
+        ...fencedGuards,
+        commit,
+      });
+      expect(modes).toEqual([commit]);
+    }
+  });
+});
+
 describe("first-ever fenced appends", () => {
   const GENERATION = "case_law_v2";
   const originalFetch = globalThis.fetch;
@@ -929,6 +1071,7 @@ describe("first-ever fenced appends", () => {
     });
 
     const indexed = await indexer.backfillRows(scopedDb, [row], GENERATION, {
+      commit: CORPUS_INDEX_COMMIT.auto,
       beforeDatabaseMark: async () => undefined,
       beforeRemoteEffect: async ({ effect }) => await effect(),
       recoverRemoteEffectLeaseLoss: async () => await Promise.resolve(),
@@ -1054,6 +1197,7 @@ describe("delete-task amplification", () => {
     });
 
     const indexed = await indexer.backfillRows(scopedDb, rows, GENERATION, {
+      commit: CORPUS_INDEX_COMMIT.auto,
       beforeDatabaseMark: async () => undefined,
       beforeRemoteEffect: async ({ effect }) => await effect(),
       recoverRemoteEffectLeaseLoss: async () => await Promise.resolve(),

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -8,9 +8,11 @@ import type { SafeId, SafeIdType } from "@/api/lib/branded-types";
 import type { TimestampCasToken } from "@/api/lib/db/timestamp-cas";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-family";
 import {
+  CORPUS_INDEX_COMMIT,
   CorpusIndexError,
   getCorpusIndexClient,
 } from "@/api/lib/legal-search/corpus-index-client";
+import type { CorpusIndexCommitMode } from "@/api/lib/legal-search/corpus-index-client";
 import { corpusIndexConfig } from "@/api/lib/legal-search/corpus-index-config";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 import { LIMITS } from "@/api/lib/limits";
@@ -373,14 +375,9 @@ type BackfillSelectedRowsOptions<
       reserveExternalAppend: ReserveExternalAppend<TBrand, TRow>;
       readConcurrency?: number;
     }
-  | {
+  | ({
       type: "generation-rebuild";
-      beforeDatabaseMark: BeforeDatabaseMark;
-      beforeRemoteEffect: GuardRemoteEffect;
-      recoverRemoteEffectLeaseLoss: RecoverRemoteEffectLeaseLoss<TBrand>;
-      reserveExternalAppend: ReserveExternalAppend<TBrand, TRow>;
-      readConcurrency?: number;
-    };
+    } & GenerationRebuildBackfillOptions<TBrand, TRow>);
 
 type GenerationBackfillRowsOptions<
   TBrand extends SafeIdType,
@@ -391,6 +388,21 @@ type GenerationBackfillRowsOptions<
   recoverRemoteEffectLeaseLoss: RecoverRemoteEffectLeaseLoss<TBrand>;
   reserveExternalAppend: ReserveExternalAppend<TBrand, TRow>;
   readConcurrency?: number;
+};
+
+/**
+ * A generation rebuild runs two shapes of walk through one entry point,
+ * and they need opposite commit semantics: the snapshot pages are bulk
+ * (`auto`, verified by a census afterwards) while the pending queue
+ * drained alongside them is the live path every newly ingested decision
+ * goes through (`wait_for`, because its acceptance is persisted). The
+ * `type` discriminator cannot tell them apart, so the caller states it.
+ */
+export type GenerationRebuildBackfillOptions<
+  TBrand extends SafeIdType,
+  TRow extends CorpusIndexRow<TBrand>,
+> = GenerationBackfillRowsOptions<TBrand, TRow> & {
+  commit: CorpusIndexCommitMode;
 };
 
 type FencedIncrementalBackfillOptions<
@@ -419,6 +431,7 @@ type CorpusIndexMarkMode<TBrand extends SafeIdType> =
     };
 
 type IngestBatchWithGuardArgs = {
+  commit: CorpusIndexCommitMode;
   indexId: string;
   ndjson: string;
 } & (
@@ -434,12 +447,13 @@ type IngestBatchWithGuardArgs = {
 
 const ingestBatchWithGuard = async ({
   beforeRemoteEffect,
+  commit,
   indexId,
   ndjson,
   onLeaseLost,
 }: IngestBatchWithGuardArgs): Promise<Result<void, CorpusIndexError>> => {
   const effect = async () =>
-    await getCorpusIndexClient().ingestBatch(indexId, ndjson);
+    await getCorpusIndexClient().ingestBatch(indexId, ndjson, commit);
   if (beforeRemoteEffect === undefined) {
     return await effect();
   }
@@ -1280,6 +1294,15 @@ export const createCorpusIndexer = <
         )) {
           // oxlint-disable-next-line no-await-in-loop -- sequential ingest paces NDJSON pushes to the search backend
           const ingest = await ingestBatchWithGuard({
+            // Both incremental shapes are the steady state: their whole
+            // job is to make a newly written row searchable, and the
+            // mark they take afterwards is what stops anything selecting
+            // it again. Only a rebuild's caller gets to choose, because
+            // only a rebuild has a census behind it.
+            commit:
+              options.type === "generation-rebuild"
+                ? options.commit
+                : CORPUS_INDEX_COMMIT.waitFor,
             ...(options.type === "incremental"
               ? {}
               : {
@@ -1410,7 +1433,7 @@ export const createCorpusIndexer = <
     scopedDb: ScopedDb,
     rows: readonly TRow[],
     generation: string,
-    options: GenerationBackfillRowsOptions<TBrand, TRow>,
+    options: GenerationRebuildBackfillOptions<TBrand, TRow>,
   ): Promise<number> =>
     await backfillSelectedRows(scopedDb, [...rows], generation, {
       ...options,

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -181,6 +181,14 @@ export class RedisClientClosedError extends TaggedError(
  * trim) the object *is* the document, so an object-storage outage has to
  * surface as a failure rather than an empty body.
  */
+/*
+ * The public decision read is the one caller that contains this rather
+ * than propagating it: it can answer "the document is not readable right
+ * now" (`documentPending`) without claiming the decision has no body, so
+ * failing there would drop the metadata, citations and case number for a
+ * decision the reader could still recognise and cite. Every other caller
+ * has no such third answer and must keep failing.
+ */
 export class CorpusPayloadUnavailableError extends TaggedError(
   "CorpusPayloadUnavailableError",
 )<{

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 
 import { envBase } from "@/api/env-base";
-import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
+import {
+  CORPUS_INDEX_COMMIT,
+  CORPUS_INDEX_COMMIT_WAIT_TIMEOUT_MS,
+  CORPUS_INDEX_INGEST_TIMEOUT_MS,
+  getCorpusIndexClient,
+} from "@/api/lib/legal-search/corpus-index-client";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 
 // Pins the corpus-index HTTP request contract. The engine defaults search
@@ -11,7 +16,12 @@ import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-p
 // id-order results. These tests stub global fetch and assert on the
 // outgoing request, not on engine behaviour.
 
-type RecordedRequest = { host: string; path: string; body: string };
+type RecordedRequest = {
+  host: string;
+  path: string;
+  search: string;
+  body: string;
+};
 
 let requests: RecordedRequest[];
 let responseBody: unknown;
@@ -39,6 +49,7 @@ beforeEach(() => {
     requests.push({
       host: url.host,
       path: url.pathname,
+      search: url.search,
       body: typeof init?.body === "string" ? init.body : "",
     });
     return new Response(JSON.stringify(responseBody), { status: 200 });
@@ -165,6 +176,7 @@ test("ingest fails when the engine accepts fewer documents than sent", async () 
   const result = await getCorpusIndexClient().ingestBatch(
     "legal_corpus_v1_cze",
     '{"document_id":"a"}\n{"document_id":"b"}',
+    CORPUS_INDEX_COMMIT.waitFor,
   );
 
   expect(result.isErr()).toBe(true);
@@ -179,6 +191,7 @@ test("ingest fails when the engine reports rejected documents", async () => {
   const result = await getCorpusIndexClient().ingestBatch(
     "legal_corpus_v1_cze",
     '{"document_id":"a"}\n{"document_id":"b"}',
+    CORPUS_INDEX_COMMIT.waitFor,
   );
 
   expect(result.isErr()).toBe(true);
@@ -207,12 +220,45 @@ test("delete-by-query posts one document-scoped delete task", async () => {
   expect(body["query"]).toBe('document_id:"dec-1"');
 });
 
+test("ingest sends the commit mode the caller asked for", async () => {
+  responseBody = { num_docs_for_processing: 1 };
+
+  for (const commit of Object.values(CORPUS_INDEX_COMMIT)) {
+    // oxlint-disable-next-line no-await-in-loop -- one request per mode; the recorder is order-sensitive
+    await getCorpusIndexClient().ingestBatch(
+      "legal_corpus_v1_cze",
+      '{"document_id":"a"}',
+      commit,
+    );
+  }
+
+  // The mode decides whether the response means "buffered" or "committed",
+  // and the caller persists the acceptance on the strength of it. A mode
+  // dropped on the way to the URL would put the durable meaning back to
+  // `auto` with nothing to notice.
+  expect(requests.map(({ search }) => search)).toEqual(
+    Object.values(CORPUS_INDEX_COMMIT).map((mode) => `?commit=${mode}`),
+  );
+});
+
+test("the ingest budget outlasts the engine's commit wait", () => {
+  // Under `wait_for` the engine holds the response for up to its own
+  // commit timeout, and only starts counting once the NDJSON upload is
+  // done. A client that gives up first turns a commit that did happen
+  // into a batch the caller retries — and, for the steady-state path,
+  // into a row it never marks indexed.
+  expect(CORPUS_INDEX_INGEST_TIMEOUT_MS).toBeGreaterThan(
+    CORPUS_INDEX_COMMIT_WAIT_TIMEOUT_MS,
+  );
+});
+
 test("ingest succeeds when every document is accepted", async () => {
   responseBody = { num_docs_for_processing: 2 };
 
   const result = await getCorpusIndexClient().ingestBatch(
     "legal_corpus_v1_cze",
     '{"document_id":"a"}\n{"document_id":"b"}',
+    CORPUS_INDEX_COMMIT.waitFor,
   );
 
   expect(result.isOk()).toBe(true);

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -21,11 +21,14 @@ export class CorpusIndexError extends TaggedError("CorpusIndexError")<{
 const SEARCH_TIMEOUT_MS = 30_000;
 
 /**
- * The engine's own `commit_timeout` for `commit=wait_for`: how long it
+ * The engine's own commit timeout for `commit=wait_for`: how long it
  * will hold the response open waiting for the split to be published.
- * Stated here because the client timeout has to outlast it — a client
+ *
+ * Stated here because the client budget has to outlast it — a client
  * that gives up first turns a commit that did happen into a batch the
- * caller retries.
+ * caller retries. This is the engine's default; the index config below
+ * does not override it, so raising it engine-side means raising the
+ * budget with it.
  */
 export const CORPUS_INDEX_COMMIT_WAIT_TIMEOUT_MS = 60_000;
 

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -19,8 +19,46 @@ export class CorpusIndexError extends TaggedError("CorpusIndexError")<{
 }> {}
 
 const SEARCH_TIMEOUT_MS = 30_000;
-const INGEST_TIMEOUT_MS = 120_000;
+
+/**
+ * The engine's own `commit_timeout` for `commit=wait_for`: how long it
+ * will hold the response open waiting for the split to be published.
+ * Stated here because the client timeout has to outlast it — a client
+ * that gives up first turns a commit that did happen into a batch the
+ * caller retries.
+ */
+export const CORPUS_INDEX_COMMIT_WAIT_TIMEOUT_MS = 60_000;
+
+/**
+ * Whole-request budget for an ingest. Must exceed the commit wait above,
+ * because under `wait_for` the engine only starts that wait once the
+ * NDJSON upload has finished. Pinned against the commit wait in
+ * `corpus-index-client.test.ts`.
+ */
+export const CORPUS_INDEX_INGEST_TIMEOUT_MS = 120_000;
 const ADMIN_TIMEOUT_MS = 30_000;
+
+/**
+ * What "the engine accepted this batch" is allowed to mean.
+ *
+ * `auto` returns as soon as the documents are buffered for indexing, so
+ * an indexer that dies inside the commit window loses them. That is
+ * survivable for a bulk build, whose completeness is verified against a
+ * census afterwards, and not survivable for the steady-state path: there
+ * the acceptance is what lets the caller mark the row indexed in
+ * Postgres, and the row is then neither missing nor stale, so nothing
+ * ever selects it again. `wait_for` holds the response until the split
+ * is published, which makes the acceptance mean durability.
+ */
+export const CORPUS_INDEX_COMMIT = {
+  /** Buffered for indexing. Bulk paths only, with a census behind them. */
+  auto: "auto",
+  /** Published as a split. Required wherever acceptance is persisted. */
+  waitFor: "wait_for",
+} as const;
+
+export type CorpusIndexCommitMode =
+  (typeof CORPUS_INDEX_COMMIT)[keyof typeof CORPUS_INDEX_COMMIT];
 
 export type CorpusIndexSearchInput = {
   indexId: string;
@@ -50,9 +88,15 @@ export type CorpusIndexClient = {
   ) => Promise<Result<void, CorpusIndexError>>;
   deleteIndex: (indexId: string) => Promise<Result<void, CorpusIndexError>>;
   indexExists: (indexId: string) => Promise<Result<boolean, CorpusIndexError>>;
+  /**
+   * `commit` is required rather than defaulted: the difference between
+   * the two modes is whether the caller may persist the acceptance, and
+   * a default would let a new call site inherit the wrong one silently.
+   */
   ingestBatch: (
     indexId: string,
     ndjson: string,
+    commit: CorpusIndexCommitMode,
   ) => Promise<Result<void, CorpusIndexError>>;
   search: (
     input: CorpusIndexSearchInput,
@@ -183,7 +227,7 @@ const buildClient = (): CorpusIndexClient => ({
       catch: toCorpusIndexError,
     }),
 
-  ingestBatch: async (indexId, ndjson) =>
+  ingestBatch: async (indexId, ndjson, commit) =>
     await Result.tryPromise({
       try: async () => {
         const sentDocs = ndjson
@@ -191,13 +235,13 @@ const buildClient = (): CorpusIndexClient => ({
           .filter((line) => line.trim().length > 0).length;
         const response = await requestJson(
           mutationBaseUrl(),
-          `/api/v1/${indexId}/ingest?commit=auto`,
+          `/api/v1/${indexId}/ingest?commit=${commit}`,
           {
             method: "POST",
             headers: { "content-type": "application/x-ndjson" },
             body: ndjson,
           },
-          INGEST_TIMEOUT_MS,
+          CORPUS_INDEX_INGEST_TIMEOUT_MS,
         );
         if (!isRecord(response)) {
           throw new CorpusIndexError({

--- a/apps/api/src/scripts/repair-corpus-index-jurisdiction.ts
+++ b/apps/api/src/scripts/repair-corpus-index-jurisdiction.ts
@@ -1,0 +1,74 @@
+/**
+ * Heal a jurisdiction the census reported as short.
+ *
+ * `case_law.corpus_index.census_drift` says the engine holds fewer
+ * documents than Postgres has marked indexed for one jurisdiction. Those
+ * rows are invisible to the backfill: an `indexedHash` equal to the
+ * content hash means neither missing nor stale, so nothing selects them
+ * again and the gap never closes on its own.
+ *
+ * Clearing the mark is the whole repair — the row becomes missing work,
+ * the ordinary backfill re-projects it through the same path as a newly
+ * ingested decision, and re-ingesting a document the engine already
+ * holds replaces it at the same id. Nothing is deleted, so running this
+ * on a jurisdiction that was not actually short costs re-indexing and
+ * nothing else.
+ *
+ * Bounded on purpose: a jurisdiction can be millions of rows, and
+ * un-marking them all at once hands the backfill a backlog that starves
+ * every newly ingested decision behind it. Each run clears one slice;
+ * re-run until the census agrees.
+ *
+ *   CORPUS_INDEX_ENDPOINT=... \
+ *     bun run src/scripts/repair-corpus-index-jurisdiction.ts SVK [limit]
+ */
+import { panic } from "better-result";
+
+import { rlsDb } from "@/api/db/root";
+import { createIngestionDb } from "@/api/db/scoped";
+import { envBase } from "@/api/env-base";
+import {
+  censusJurisdiction,
+  clearJurisdictionIndexMarks,
+} from "@/api/lib/corpus-index/census";
+import { isCorpusIndexJurisdiction } from "@/api/lib/legal-search/index-naming";
+
+const DEFAULT_LIMIT = 50_000;
+
+const jurisdiction = process.argv[2];
+if (jurisdiction === undefined || !isCorpusIndexJurisdiction(jurisdiction)) {
+  panic("usage: repair-corpus-index-jurisdiction.ts <jurisdiction> [limit]");
+}
+
+const limitArgument = process.argv[3];
+const limit =
+  limitArgument === undefined ? DEFAULT_LIMIT : Number(limitArgument);
+if (!Number.isSafeInteger(limit) || limit <= 0) {
+  panic(`limit must be a positive integer, got ${String(limit)}`);
+}
+
+const generation = envBase.LEGAL_SEARCH_INDEX_GENERATION;
+const ingestionDb = createIngestionDb(rlsDb);
+
+// Reported before and after so the operator sees the shortfall the repair
+// was pointed at, rather than trusting the alert that sent them here.
+const before = await censusJurisdiction({
+  scopedDb: ingestionDb,
+  generation,
+  jurisdiction,
+});
+if (before.isErr()) {
+  panic("census failed before the repair", before.error);
+}
+console.log(
+  `=== ${before.value.indexId}: engine ${before.value.engineDocuments}, marked ${before.value.markedIndexed}, short ${before.value.shortfall} ===`,
+);
+
+const cleared = await clearJurisdictionIndexMarks({
+  scopedDb: ingestionDb,
+  jurisdiction,
+  limit,
+});
+console.log(
+  `Cleared ${cleared} index marks; the backfill will re-project them. Re-run until the census agrees.`,
+);

--- a/apps/api/src/scripts/repair-corpus-index-jurisdiction.ts
+++ b/apps/api/src/scripts/repair-corpus-index-jurisdiction.ts
@@ -30,21 +30,28 @@ import { envBase } from "@/api/env-base";
 import {
   censusJurisdiction,
   clearJurisdictionIndexMarks,
+  MAX_REPAIR_SLICE,
 } from "@/api/lib/corpus-index/census";
 import { isCorpusIndexJurisdiction } from "@/api/lib/legal-search/index-naming";
-
-const DEFAULT_LIMIT = 50_000;
 
 const jurisdiction = process.argv[2];
 if (jurisdiction === undefined || !isCorpusIndexJurisdiction(jurisdiction)) {
   panic("usage: repair-corpus-index-jurisdiction.ts <jurisdiction> [limit]");
 }
 
+// A mistyped digit must not turn a bounded repair into one transaction
+// updating every row in the jurisdiction and firing the projection
+// trigger for each of them, so the ceiling is enforced here rather than
+// trusted from the argument. `clearJurisdictionIndexMarks` clamps too;
+// rejecting loudly here is what tells the operator their number was
+// ignored.
 const limitArgument = process.argv[3];
 const limit =
-  limitArgument === undefined ? DEFAULT_LIMIT : Number(limitArgument);
-if (!Number.isSafeInteger(limit) || limit <= 0) {
-  panic(`limit must be a positive integer, got ${String(limit)}`);
+  limitArgument === undefined ? MAX_REPAIR_SLICE : Number(limitArgument);
+if (!Number.isSafeInteger(limit) || limit <= 0 || limit > MAX_REPAIR_SLICE) {
+  panic(
+    `limit must be a positive integer no greater than ${MAX_REPAIR_SLICE}, got ${String(limit)}`,
+  );
 }
 
 const generation = envBase.LEGAL_SEARCH_INDEX_GENERATION;
@@ -66,6 +73,7 @@ console.log(
 
 const cleared = await clearJurisdictionIndexMarks({
   scopedDb: ingestionDb,
+  generation,
   jurisdiction,
   limit,
 });

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -43,6 +43,7 @@ import {
 import { backfillLegislationCorpusIndex } from "@/api/handlers/legislation/corpus-index";
 import { backfillLegislationSearchIndex } from "@/api/handlers/legislation/search-index";
 import { captureError } from "@/api/lib/analytics/capture";
+import { createCaseLawCensus } from "@/api/lib/corpus-index/census";
 import {
   IngestionStallError,
   TimeoutError,
@@ -1271,6 +1272,12 @@ export const runCaseLawIngest = async (
     }
     const generation = envBase.LEGAL_SEARCH_INDEX_GENERATION;
     logInfo(`[corpus-index] Enabled for generation ${generation}`);
+    // Acceptance is not durability for the bulk pages of a rebuild, and no
+    // per-request signal can prove a whole generation landed. Counting both
+    // sides on this loop's own cadence is what makes a lost split visible
+    // at all: the rows it lost are neither missing nor stale, so nothing
+    // else in this process would ever look at them again.
+    const census = createCaseLawCensus({ generation, scopedDb: backfillDb });
     // A leaked lease (every step BUSY) and a failing backend (every step
     // throws) both look like idle silence in this loop unless counted.
     let corpusStreaks: CorpusIndexStreaks = INITIAL_CORPUS_INDEX_STREAKS;
@@ -1296,8 +1303,13 @@ export const runCaseLawIngest = async (
       if (isDraining()) {
         return;
       }
+      // The census rides the interval the loop is idle for anyway, so it
+      // costs the backfill no latency and runs on every cycle — including
+      // the ones where the batch failed or found nothing, which is
+      // exactly when drift stops being repaired. It contains its own
+      // failures, so it cannot turn a slow cycle into a stopped loop.
       // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait CORPUS_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
-      await Bun.sleep(CORPUS_INDEX_INTERVAL_MS);
+      await Promise.all([Bun.sleep(CORPUS_INDEX_INTERVAL_MS), census.step()]);
       if (isDraining()) {
         return;
       }


### PR DESCRIPTION
Two failures on the corpus read/ingest surface. Both end in a state nothing downstream can detect, so both are fixed by making the guarantee structural rather than incidental.

## Read path: the public decision read must degrade, not fail

`decisions/document-on-demand.ts` documents that "nothing here can fail a read". That was true only as the sum of every individual `await` happening to be wrapped, and `get-deferred-document.ts` awaits it bare, with no boundary of its own. An outcome shape the fetch unit did not produce is read *past* that wrapping, on the one promise the read budget abandons — so a decision that is merely waiting for its document becomes a 500.

- the guarantee now has one boundary rather than a rule every future edit must remember;
- the budget is the shared `withTimeout` instead of a local timer race, which is also where the late-settlement guard already lives (a rejection arriving after the race has settled is an unhandled rejection, and under Bun that is the whole process, not one read);
- the telemetry call is contained too: `captureError` reaches the analytics client and a log sink, and recording a failure must not become one.

Its sibling, same contract: a trimmed canonical row whose corpus object is unreadable raised `CorpusPayloadUnavailableError` straight out of `decisions/get.ts`, taking the metadata, citations and case number down with the body. That error exists so a corpus outage is never served as a complete decision with no text — but the public read has a third answer for exactly that state. It now reports `documentPending` with a structured capture, ordered ahead of every column test so a bodyless decision can never read as a whole one. Every other caller keeps failing, since none of them has that third answer; the boundary is recorded on the error itself.

The read also says *which* pending state it means. An object-storage refusal and an unfetched document look identical to a reader, and must not to the read-through: the store refuses a row already carrying a corpus document, so a publisher fetch could never land, and every reader during an outage would pay for one and wait out the read budget behind it.

## Ingest path: acceptance was not durability

`commit=auto` returns once the documents are buffered for indexing, not once the split is published, and the caller marks `indexedHash` in Postgres on the strength of that response. An indexer death inside the commit window therefore loses documents a row already claims are indexed — and that row is then neither missing (it has a hash) nor stale (the hash matches), so nothing selects it again. The gap is permanent and silent.

The commit mode is now a required parameter on `ingestBatch`, not a default, so a new call site cannot inherit the wrong one:

- **steady state → `wait_for`**: the incremental and fenced-incremental backfills, and the pending queue drained inside a generation rebuild. These are the paths whose acceptance is persisted.
- **bulk → `auto`**: the rebuild's snapshot pages and source-eligibility reconciliation, whose completeness is verified by a census rather than by each request proving it for itself.

`type` alone could not express this — the pending drain and the snapshot walk are both `generation-rebuild` — so the caller states its intent. The ingest timeout already outlasted the engine's `commit_timeout`; that relationship is now named and pinned by a test rather than left as two unrelated numbers.

## Census and repair

No per-request signal can prove a whole generation landed, so a per-jurisdiction census counts the engine's `seq:0` documents against the rows Postgres marks indexed for the live generation, using the same predicate the search path rehydrates through (a second copy would drift, which is the failure it exists to catch). It rides the interval the corpus-index loop is already idle for: no added latency, one jurisdiction per pass, and it runs on the cycles where the batch failed or found nothing, which is exactly when drift stops being repaired. It contains its own failures — trading a silent index gap for a stopped index would be the worse outcome.

Two counts taken at different instants disagree by whatever landed between them, and that shift is a whole ingest batch — the same size as the smallest real loss. Postgres is counted first so the shift goes the harmless way (a row marked after the claim is still visible to the evidence that follows), which lets the tolerance be small and absolute instead of batch-sized and proportional; a proportional tolerance would let a large jurisdiction hide more documents the larger it got. The one transient that remains is a bulk page marking before its split publishes, so a shortfall is reported once it survives into the jurisdiction's next census: an in-flight page clears by then, a lost split never does.

Two counts can only report their difference, and that difference nets two independent defects: documents the engine never received, and entries it holds that no row points at. An orphan cancels a missing document, so an observation is a disposition (`aligned | short | surplus`) rather than a shortfall flag, and both disagreeing directions are reported — a surplus is a defect on its own terms, and it is also what says the shortfall number cannot be trusted until it is cleared. Exact cancellation to inside the tolerance stays this mechanism's blind spot, stated as one in the code: closing it needs an identity comparison, which means streaming the jurisdiction rather than counting it.

Drift emits `case_law.corpus_index.census_drift` with both counts and the disposition; an unreachable index reports separately, because counting it as empty would point the repair at a jurisdiction that is fine.

The repair is a bounded operator script that un-marks one slice at a time. The slice is the census's own population rather than rows carrying the legacy `case_law_decisions.indexed_hash`: a generation rebuild records success in the projection and leaves that column alone, so a repair keyed off it would be inert for exactly the rows a rebuild lost. The write is still only that column, because the projection trigger fires on the assignment rather than on the value changing and enqueues the row for every live generation with the right target index and content hash — so it rejoins the live pending queue and is re-projected through the same path, and the same commit semantics, as a newly ingested decision. Writing the projection here as well would be a second hand-maintained copy of what the trigger already states. The slice is clamped to a named ceiling so a mistyped digit cannot turn a bounded repair into one transaction over the whole jurisdiction.

## Known boundary

The sweep's countdown and cursor live in the runner process. A runner replaced mid-sweep loses them, so both start at a random phase rather than at the head of the alphabet, which keeps coverage uniform in expectation across restarts. A durable cursor would remove the "in expectation" and is the next step if deployments ever outpace the sweep.

## Tests

- read-through: an invariant over the ways the fetch unit can end (rejection, rejecting demand recording, claim held, never settles, unexpected outcome shape) — the read resolves in every case. The unexpected-shape case fails on the pre-fix code.
- document state: a refused corpus payload reads as pending even where the row is corpus-served and even where nothing will re-fetch it, does not override a document the read did resolve, and does not send the read-through after the publisher.
- commit mode: pinned per entry point (incremental and fenced → `wait_for`; a rebuild sends what its caller chose), plus the URL contract and the timeout/commit-wait relationship at the client.
- census: noise inside the tolerance is aligned, one lost ingest batch is visible on a five-million-row jurisdiction, an engine holding more reports as a surplus rather than as silence, an unreachable index is a failure; a first disagreeing observation waits for confirmation and a surviving one is reported with both counts; the sweep is rate-limited, and a throwing census cannot stop the loop.
- repair (pglite): reaches rows marked only through the generation projection, one bounded slice, other jurisdictions untouched, re-running walks the jurisdiction instead of re-clearing the first page, and the trigger enqueues the cleared rows.
