### PR TITLE
chore: build deployable web images in repo

### DIFF
--- a/.github/actions/build-web-image/action.yml
+++ b/.github/actions/build-web-image/action.yml
@@ -1,0 +1,142 @@
+name: Build and publish Stella web image
+description: Build Stella's public web source with an allowlisted browser configuration and publish it by digest.
+
+inputs:
+  release-ref:
+    description: Release tag or synthetic main-<sha> reference embedded in the image.
+    required: true
+  release-sha:
+    description: Full source commit SHA checked out by the caller.
+    required: true
+  target-environment:
+    description: Public browser configuration to compile (production or staging).
+    required: true
+  posthog-key:
+    description: Browser-visible PostHog project key; passed separately so it is never committed.
+    required: false
+    default: ""
+  source-path:
+    description: Checkout containing the exact source commit to build.
+    required: false
+    default: .
+  tooling-path:
+    description: Checkout containing the current renderer and workflow policy.
+    required: false
+    default: .
+
+outputs:
+  digest:
+    description: Immutable GHCR manifest digest.
+    value: ${{ steps.build.outputs.digest }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate web image source and target
+      shell: bash
+      env:
+        RELEASE_REF: ${{ inputs.release-ref }}
+        RELEASE_SHA: ${{ inputs.release-sha }}
+        SOURCE_PATH: ${{ inputs.source-path }}
+        TARGET_ENV: ${{ inputs.target-environment }}
+      run: |
+        set -euo pipefail
+        if [[ ! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "::error::release-sha must be a full lowercase commit SHA."
+          exit 1
+        fi
+        case "$TARGET_ENV" in
+          production|staging) ;;
+          *)
+            echo "::error::target-environment must be production or staging."
+            exit 1
+            ;;
+        esac
+        if [[ "$RELEASE_REF" == main-* ]]; then
+          ref_sha="${RELEASE_REF#main-}"
+          if [[ "$TARGET_ENV" != "staging" || "${RELEASE_SHA:0:${#ref_sha}}" != "$ref_sha" ]]; then
+            echo "::error::synthetic release refs must match the source SHA and target staging."
+            exit 1
+          fi
+        elif [[ ! "$RELEASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)\.[0-9]+)?$ ]]; then
+          echo "::error::release-ref must be a release tag or main-<sha>."
+          exit 1
+        fi
+        checked_out_sha="$(git -C "$SOURCE_PATH" rev-parse HEAD)"
+        if [[ "$checked_out_sha" != "$RELEASE_SHA" ]]; then
+          echo "::error::source-path does not contain release-sha."
+          exit 1
+        fi
+        config="${SOURCE_PATH}/apps/web/build-env/${TARGET_ENV}.json"
+        if [[ "$(jq -r '.targetEnvironment' "$config")" != "$TARGET_ENV" ]]; then
+          echo "::error::web build configuration does not match the target environment."
+          exit 1
+        fi
+
+    - name: Resolve allowlisted web build arguments
+      id: args
+      shell: bash
+      env:
+        SOURCE_PATH: ${{ inputs.source-path }}
+        TARGET_ENV: ${{ inputs.target-environment }}
+        TOOLING_PATH: ${{ inputs.tooling-path }}
+      run: |
+        set -euo pipefail
+        rendered="$(
+          bash "${TOOLING_PATH}/scripts/render-web-build-args.sh" \
+            "${SOURCE_PATH}/apps/web/build-env-contract.json" \
+            "${SOURCE_PATH}/apps/web/build-env/${TARGET_ENV}.json" \
+            VITE_POSTHOG_KEY
+        )"
+        posthog_arg="$(jq -er '.variables.VITE_POSTHOG_KEY' "${SOURCE_PATH}/apps/web/build-env-contract.json")"
+        version="${{ inputs.release-ref }}"
+        if [[ "$version" == v* ]]; then
+          version="${version#v}"
+        fi
+        {
+          echo "values<<STELLA_WEB_BUILD_ARGS"
+          printf '%s\n' "$rendered"
+          echo "STELLA_WEB_BUILD_ARGS"
+          echo "posthog-name=$posthog_arg"
+          echo "version=$version"
+        } >>"$GITHUB_OUTPUT"
+
+    - name: Verify native x64 build host
+      shell: bash
+      run: |
+        if [[ "$(uname -m)" != "x86_64" ]]; then
+          echo "::error::Web compilation requires a native x64 build host."
+          exit 1
+        fi
+
+    - name: Set up ARM64 runtime emulation
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      with:
+        platforms: arm64
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+    - name: Login to GHCR
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Build and push web image
+      id: build
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      with:
+        context: ${{ inputs.source-path }}
+        file: ${{ inputs.source-path }}/apps/web/Dockerfile
+        platforms: linux/arm64
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/stella-web:candidate-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.target-environment }}
+        cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/stella-web:buildcache-${{ inputs.target-environment }}
+        cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/stella-web:buildcache-${{ inputs.target-environment }},mode=max
+        build-args: |
+          STELLA_VERSION=${{ steps.args.outputs.version }}
+          STELLA_COMMIT_SHA=${{ inputs.release-sha }}
+          ${{ steps.args.outputs.values }}
+          ${{ steps.args.outputs.posthog-name }}=${{ inputs.posthog-key }}

--- a/.github/actions/build-web-image/action.yml
+++ b/.github/actions/build-web-image/action.yml
@@ -67,7 +67,12 @@ runs:
           echo "::error::source-path does not contain release-sha."
           exit 1
         fi
+        contract="${SOURCE_PATH}/apps/web/build-env-contract.json"
         config="${SOURCE_PATH}/apps/web/build-env/${TARGET_ENV}.json"
+        if [[ ! -f "$contract" || ! -f "$config" ]]; then
+          echo "::error::Release source predates the public web build contract; rebuilding legacy release tags is unsupported."
+          exit 1
+        fi
         if [[ "$(jq -r '.targetEnvironment' "$config")" != "$TARGET_ENV" ]]; then
           echo "::error::web build configuration does not match the target environment."
           exit 1

--- a/.github/actions/promote-dispatch/action.yml
+++ b/.github/actions/promote-dispatch/action.yml
@@ -34,7 +34,7 @@ inputs:
     required: false
     default: "true"
   frontend:
-    description: Build and publish the frontend as part of the promotion
+    description: Deploy the prebuilt frontend image as part of the promotion
     required: false
     default: "true"
   image-digest:
@@ -45,7 +45,7 @@ inputs:
     default: ""
   web-image-digest:
     description: >
-      Prebuilt web image digest (sha256:...). Required when a tagged release
+      Prebuilt web image digest (sha256:...). Required when the promotion
       includes the frontend.
     required: false
     default: ""
@@ -158,8 +158,8 @@ runs:
           echo "::error::web-image-digest must look like sha256:<64 lowercase hex chars>." >&2
           exit 1
         fi
-        if [[ "$FRONTEND" == "true" && "$RELEASE_REF" != main-* && -z "$WEB_IMAGE_DIGEST" ]]; then
-          echo "::error::Tagged frontend promotions require a prebuilt web image digest." >&2
+        if [[ "$FRONTEND" == "true" && -z "$WEB_IMAGE_DIGEST" ]]; then
+          echo "::error::Frontend promotions require a prebuilt web image digest." >&2
           exit 1
         fi
         current_app_token=""

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -17,18 +17,10 @@ on:
     - cron: "*/30 * * * *"
   workflow_dispatch:
 
-# Queue rather than cancel: build-and-deploy dispatches a promotion to the
-# infra repo and then watches it to completion. A run cancelled mid-dispatch
-# would leave that promotion in flight with nothing watching it, racing
-# whatever the next run dispatches. A dispatched promotion must always be
-# watched, so a newer push waits for the current run instead of preempting it.
-concurrency:
-  group: deploy-staging
-  cancel-in-progress: false
-
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/stella-api
+  WEB_IMAGE_NAME: ${{ github.repository_owner }}/stella-web
 
 jobs:
   # Tie promotion and its dependent smoke job to the current health of the
@@ -218,8 +210,8 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::notice::Staging is not answering; deploy of ${GITHUB_SHA} deferred until it does."
 
-  build-and-deploy:
-    name: Build + deploy staging
+  build-api:
+    name: Build staging API image
     needs: staging-health
     if: >-
       github.ref == 'refs/heads/main' &&
@@ -232,7 +224,12 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-      deployments: write
+    concurrency:
+      group: staging-api-build
+      cancel-in-progress: true
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      release-ref: ${{ steps.ref.outputs.release_ref }}
 
     steps:
       - name: Resolve synthetic ref
@@ -277,20 +274,101 @@ jobs:
             STELLA_VERSION=${{ steps.ref.outputs.release_ref }}
             STELLA_COMMIT_SHA=${{ github.sha }}
 
-      # Best-effort on staging: the provenance action already retries
-      # transient Sigstore blips, but a sustained Rekor outage must not
-      # wedge continuous deploys (the image is built and pushed; only
-      # the transparency-log attestation is unavailable). The step still
-      # surfaces as failed in the UI. Production keeps attestation
-      # blocking in release.yml.
       - name: Attest image provenance
-        continue-on-error: true
         uses: ./.github/actions/provenance
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
 
+  build-web:
+    name: Build staging web image
+    needs: staging-health
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      needs.staging-health.outputs.deploy == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 55
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    concurrency:
+      group: staging-web-build
+      cancel-in-progress: true
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Resolve synthetic ref
+        id: ref
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          echo "release-ref=main-${SHA:0:7}" >>"$GITHUB_OUTPUT"
+
+      - name: Build and publish web image
+        id: build
+        uses: ./.github/actions/build-web-image
+        with:
+          release-ref: ${{ steps.ref.outputs.release-ref }}
+          release-sha: ${{ github.sha }}
+          target-environment: staging
+          posthog-key: ${{ secrets.VITE_POSTHOG_KEY }}
+
+      - name: Attest web image provenance
+        uses: ./.github/actions/provenance
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+
+  promote-staging:
+    name: Promote staging images
+    needs: [build-api, build-web]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
+    # Deployment and its smoke verification are one serialized side-effecting
+    # unit. Public builds may be cancelled; this job may not be interrupted
+    # after it dispatches Terraform work into the private repository.
+    concurrency:
+      group: deploy-staging
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Checkout workflow actions
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      # Builds are intentionally free to finish. Only the newest main SHA may
+      # cross the private-compute boundary; an obsolete queued build is a
+      # successful no-op, and the newer workflow converges staging afterward.
+      - name: Confirm this SHA is still main
+        id: current
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          current_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          if [[ "$current_sha" != "$GITHUB_SHA" ]]; then
+            echo "promoted=false" >>"$GITHUB_OUTPUT"
+            echo "Skipping private promotion of obsolete commit \`${GITHUB_SHA}\`; main is \`${current_sha}\`." >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "promoted=true" >>"$GITHUB_OUTPUT"
+
       - name: Check staging deployment target is configured
+        if: steps.current.outputs.promoted == 'true'
         env:
           DEPLOY_REPOSITORY: ${{ github.repository_owner }}/${{ vars.STAGING_DEPLOY_REPOSITORY }}
           DEPLOY_WORKFLOW: ${{ vars.STAGING_DEPLOY_WORKFLOW }}
@@ -305,21 +383,24 @@ jobs:
       # skipped by `needs` instead of blocking on a commit that will never
       # be served.
       - name: Deploy to staging
+        if: steps.current.outputs.promoted == 'true'
         uses: ./.github/actions/promote-dispatch
         with:
           app-client-id: ${{ vars.STELLA_RELEASE_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
           infra-repo: ${{ github.repository_owner }}/${{ vars.STAGING_DEPLOY_REPOSITORY }}
           workflow-file: ${{ vars.STAGING_DEPLOY_WORKFLOW }}
-          release-ref: ${{ steps.ref.outputs.release_ref }}
+          release-ref: ${{ needs.build-api.outputs.release-ref }}
           target-environment: staging
-          image-digest: ${{ steps.build.outputs.digest }}
+          image-digest: ${{ needs.build-api.outputs.digest }}
+          web-image-digest: ${{ needs.build-web.outputs.digest }}
           git-sha: ${{ github.sha }}
 
       # The commit staging is running, recorded where it outlives this run:
       # the health gate reads it to tell a deploy that is waiting from one
       # that is stuck.
       - name: Record staging deployment
+        if: steps.current.outputs.promoted == 'true'
         env:
           DEPLOY_ENVIRONMENT: staging
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -346,36 +427,32 @@ jobs:
             gh api "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
               --method POST --input - >/dev/null
 
-  # Post-deploy verification: authenticate via the secret-guarded
-  # /smoke/session endpoint and click through the deployed app so a
-  # render-breaking regression turns this workflow red instead of
-  # waiting for a human to stumble over it.
-  verify-staging:
-    name: Verify staging deploy
-    needs: build-and-deploy
-    runs-on: ubuntu-24.04
-    timeout-minutes: 60
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
+      # Post-deploy verification stays in the serialized promotion job. If it
+      # were a separate job, a newer promotion could start while this smoke
+      # still measures the previous commit.
+      - name: Checkout deployed source
+        if: steps.current.outputs.promoted == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Setup Bun
+        if: steps.current.outputs.promoted == 'true'
         uses: stella/.github/actions/setup-bun-cached@905280fd96d464a343fd3bf6be20af9ef3f399fb
 
       - name: Install dependencies
+        if: steps.current.outputs.promoted == 'true'
         run: bash scripts/bun-ci-retry.sh --ignore-scripts
         env:
           NPM_TOKEN: ""
 
       - name: Install Playwright browser
+        if: steps.current.outputs.promoted == 'true'
         run: cd apps/web && bunx playwright install --with-deps chromium
 
       - name: Run staging web smoke
+        if: steps.current.outputs.promoted == 'true'
         run: bun --filter @stll/web test:e2e:staging
         env:
           E2E_WEB_URL: https://staging.stll.app
@@ -386,7 +463,7 @@ jobs:
           EXPECTED_COMMIT: ${{ github.sha }}
 
       - name: Run staging API chat smoke
-        if: ${{ !cancelled() }}
+        if: ${{ steps.current.outputs.promoted == 'true' && !cancelled() }}
         run: bun apps/api/src/scripts/post-deploy-smoke.ts "$E2E_API_URL"
         env:
           E2E_API_URL: https://api-staging.stll.app
@@ -394,7 +471,7 @@ jobs:
           EXPECTED_COMMIT: ${{ github.sha }}
 
       - name: Upload Playwright report
-        if: failure()
+        if: ${{ steps.current.outputs.promoted == 'true' && failure() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: staging-smoke-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -531,9 +531,9 @@ jobs:
             echo "reused=true"
           } >> "$GITHUB_OUTPUT"
 
-      # Keep the current workflow tooling separate from the selected release
-      # source. A manual rerun may build a tag created before this action
-      # existed, but policy must still come from the workflow revision.
+      # Keep current workflow tooling separate from the selected release source.
+      # The action code comes from the workflow revision; the browser build
+      # contract remains bound to the release source and fails closed when absent.
       - name: Checkout workflow tooling
         if: steps.existing.outputs.reused != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -453,10 +453,7 @@ jobs:
           if [[ "$RELEASE_REF" == *-* ]]; then
             target_environment=staging
           fi
-          {
-            echo "environment=${target_environment}"
-            echo "request_id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          } >> "$GITHUB_OUTPUT"
+          echo "environment=${target_environment}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -534,176 +531,49 @@ jobs:
             echo "reused=true"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Mint App token for the web build workflow
+      # Keep the current workflow tooling separate from the selected release
+      # source. A manual rerun may build a tag created before this action
+      # existed, but policy must still come from the workflow revision.
+      - name: Checkout workflow tooling
         if: steps.existing.outputs.reused != 'true'
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          client-id: ${{ vars.STELLA_RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: stella-infra
-          permission-actions: write
+          ref: ${{ github.workflow_sha }}
+          path: .workflow-source
+          persist-credentials: false
 
-      - name: Dispatch and watch web image build
+      - name: Checkout release source
         if: steps.existing.outputs.reused != 'true'
-        id: build-run
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          INFRA_REPO: ${{ github.repository_owner }}/stella-infra
-          RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
-          RELEASE_SHA: ${{ needs.resolve.outputs.release_sha }}
-          REQUEST_ID: ${{ steps.target.outputs.request_id }}
-          TARGET_ENV: ${{ steps.target.outputs.environment }}
-        run: |
-          set -euo pipefail
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve.outputs.release_sha }}
+          path: .release-source
+          persist-credentials: false
 
-          dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          expected_title="Build web ${RELEASE_REF} → ${TARGET_ENV} [${REQUEST_ID}]"
-          gh api --method POST \
-            "/repos/${INFRA_REPO}/actions/workflows/build-release-web.yml/dispatches" \
-            -f "ref=main" \
-            -f "inputs[release_ref]=${RELEASE_REF}" \
-            -f "inputs[release_sha]=${RELEASE_SHA}" \
-            -f "inputs[request_id]=${REQUEST_ID}" \
-            -f "inputs[target_environment]=${TARGET_ENV}"
-
-          run_id=""
-          for _ in {1..30}; do
-            if ! run_id="$(
-              gh api \
-                "/repos/${INFRA_REPO}/actions/workflows/build-release-web.yml/runs?event=workflow_dispatch&per_page=10" \
-                --jq ".workflow_runs[] | select(.created_at >= \"${dispatched_at}\") | select(.display_title == \"${expected_title}\") | .id" \
-                | head -n 1
-            )"; then
-              run_id=""
-            fi
-            if [[ -n "$run_id" ]]; then
-              break
-            fi
-            sleep 2
-          done
-
-          if [[ -z "$run_id" ]]; then
-            echo "::error::Could not correlate the dispatched web image build."
-            exit 1
-          fi
-
-          while true; do
-            if ! run_state="$(
-              gh api "/repos/${INFRA_REPO}/actions/runs/${run_id}" \
-                --jq '[.status, .conclusion, .html_url] | @tsv'
-            )"; then
-              sleep 10
-              continue
-            fi
-            status="$(cut -f1 <<<"$run_state")"
-            conclusion="$(cut -f2 <<<"$run_state")"
-            run_url="$(cut -f3 <<<"$run_state")"
-            if [[ "$status" == "completed" ]]; then
-              break
-            fi
-            sleep 10
-          done
-
-          if [[ "$conclusion" != "success" ]]; then
-            echo "::error::Web image build concluded ${conclusion}: ${run_url}"
-            exit 1
-          fi
-          echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"
-
-      - name: Download web image archive
-        if: steps.existing.outputs.reused != 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          INFRA_REPO: ${{ github.repository_owner }}/stella-infra
-          RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
-          TARGET_ENV: ${{ steps.target.outputs.environment }}
-        run: |
-          gh run download "${{ steps.build-run.outputs.run_id }}" \
-            --repo "$INFRA_REPO" \
-            --name "release-web-image-${RELEASE_REF}-${TARGET_ENV}" \
-            --dir release-web-image
-
-      - name: Verify web image receipt
-        if: steps.existing.outputs.reused != 'true'
-        id: archive
-        env:
-          RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
-          RELEASE_SHA: ${{ needs.resolve.outputs.release_sha }}
-          TARGET_ENV: ${{ steps.target.outputs.environment }}
-        run: |
-          set -euo pipefail
-          if [[ ! -f release-web-image/stella-web.tar || -L release-web-image/stella-web.tar ]]; then
-            echo "::error::Web image archive must be a regular file."
-            exit 1
-          fi
-          if [[ ! -f release-web-image/source-receipt.json || -L release-web-image/source-receipt.json ]]; then
-            echo "::error::Web image source receipt must be a regular file."
-            exit 1
-          fi
-          if [[ ! -f release-web-image/stella-web.intoto.jsonl || -L release-web-image/stella-web.intoto.jsonl ]]; then
-            echo "::error::Web image build attestation must be a regular file."
-            exit 1
-          fi
-          jq -e \
-            --arg release_ref "$RELEASE_REF" \
-            --arg release_sha "$RELEASE_SHA" \
-            --arg target_environment "$TARGET_ENV" \
-            '.schemaVersion == 1
-              and .releaseRef == $release_ref
-              and .releaseSha == $release_sha
-              and .targetEnvironment == $target_environment' \
-            release-web-image/source-receipt.json >/dev/null
-          # The build was dispatched at ref=main above, so require the
-          # attestation's source ref to match: a same-path workflow on
-          # another branch of the infra repo must not pass.
-          gh attestation verify release-web-image/stella-web.tar \
-            --bundle release-web-image/stella-web.intoto.jsonl \
-            --repo "${GITHUB_REPOSITORY_OWNER}/stella-infra" \
-            --signer-workflow "${GITHUB_REPOSITORY_OWNER}/stella-infra/.github/workflows/build-release-web.yml" \
-            --source-ref refs/heads/main \
-            --deny-self-hosted-runners >/dev/null
-          archive_digest="$(sha256sum release-web-image/stella-web.tar | awk '{print $1}')"
-          echo "digest=sha256:${archive_digest}" >> "$GITHUB_OUTPUT"
-
-      - name: Publish web image
+      - name: Build and publish web image publicly
         if: steps.existing.outputs.reused != 'true'
         id: publish
-        env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.WEB_IMAGE_NAME }}
-          RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
-        run: |
-          set -euo pipefail
-          docker load --input release-web-image/stella-web.tar
-          source_image="stella-web-release:${RELEASE_REF}"
-          candidate_tag="candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          docker tag "$source_image" "${IMAGE}:${candidate_tag}"
-          docker push "${IMAGE}:${candidate_tag}"
-
-          digest="$(docker buildx imagetools inspect "${IMAGE}:${candidate_tag}" --format '{{.Manifest.Digest}}')"
-          if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
-            echo "::error::Registry returned an invalid web image digest."
-            exit 1
-          fi
-          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+        uses: ./.workflow-source/.github/actions/build-web-image
+        with:
+          release-ref: ${{ needs.resolve.outputs.release_ref }}
+          release-sha: ${{ needs.resolve.outputs.release_sha }}
+          target-environment: ${{ steps.target.outputs.environment }}
+          posthog-key: ${{ secrets.VITE_POSTHOG_KEY }}
+          source-path: .release-source
+          tooling-path: .workflow-source
 
       - name: Write web image publication predicate
         if: steps.existing.outputs.reused != 'true'
         env:
-          ARCHIVE_DIGEST: ${{ steps.archive.outputs.digest }}
-          BUILD_RUN_ID: ${{ steps.build-run.outputs.run_id }}
           RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
           RELEASE_SHA: ${{ needs.resolve.outputs.release_sha }}
           TARGET_ENV: ${{ steps.target.outputs.environment }}
         run: |
           jq -n \
-            --arg archive_digest "$ARCHIVE_DIGEST" \
-            --arg build_run_id "$BUILD_RUN_ID" \
             --arg release_ref "$RELEASE_REF" \
             --arg release_sha "$RELEASE_SHA" \
             --arg target_environment "$TARGET_ENV" \
-            '{archiveDigest: $archive_digest, buildRunId: $build_run_id, releaseRef: $release_ref, releaseSha: $release_sha, targetEnvironment: $target_environment}' \
+            '{releaseRef: $release_ref, releaseSha: $release_sha, targetEnvironment: $target_environment}' \
             > web-image-publication.json
 
       # The registry refused this upload on v0.6.22 with a 403 on the first

--- a/apps/web/build-env/production.json
+++ b/apps/web/build-env/production.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "targetEnvironment": "production",
+  "variables": {
+    "VITE_API_URL": "https://api.stll.app",
+    "VITE_AUTH_GOOGLE": "true",
+    "VITE_AUTH_MICROSOFT": "true",
+    "VITE_BETA_FEATURES_ENABLED": "true",
+    "VITE_BROWSER_API_URL": "https://my.stll.app/api",
+    "VITE_FEATURE_TIME_BILLING": "true",
+    "VITE_FEEDBACK_EMAIL_TO": "help@stll.app",
+    "VITE_POSTHOG_HOST": "https://eu.i.posthog.com",
+    "VITE_PUBLIC_APP_URL": "https://my.stll.app"
+  }
+}

--- a/apps/web/build-env/staging.json
+++ b/apps/web/build-env/staging.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "targetEnvironment": "staging",
+  "variables": {
+    "VITE_API_URL": "https://api-staging.stll.app",
+    "VITE_AUTH_GOOGLE": "true",
+    "VITE_AUTH_MICROSOFT": "true",
+    "VITE_BETA_FEATURES_ENABLED": "true",
+    "VITE_BROWSER_API_URL": "https://staging.stll.app/api",
+    "VITE_FEEDBACK_EMAIL_TO": "help@stll.app",
+    "VITE_POSTHOG_HOST": "https://eu.i.posthog.com",
+    "VITE_PUBLIC_APP_URL": "https://staging.stll.app"
+  }
+}

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -52,14 +52,18 @@ describe("API deployment health receipt", () => {
       new URL("../.github/workflows/deploy-staging.yml", import.meta.url),
     ).text();
     const healthJobStart = workflow.indexOf("\n  staging-health:\n");
-    const deployJobStart = workflow.indexOf("\n  build-and-deploy:\n");
-    const verifyJobStart = workflow.indexOf("\n  verify-staging:\n");
-    const healthJob = workflow.slice(healthJobStart, deployJobStart);
-    const deployJob = workflow.slice(deployJobStart, verifyJobStart);
+    const apiBuildStart = workflow.indexOf("\n  build-api:\n");
+    const webBuildStart = workflow.indexOf("\n  build-web:\n");
+    const promoteStart = workflow.indexOf("\n  promote-staging:\n");
+    const healthJob = workflow.slice(healthJobStart, apiBuildStart);
+    const apiBuild = workflow.slice(apiBuildStart, webBuildStart);
+    const webBuild = workflow.slice(webBuildStart, promoteStart);
+    const promoteJob = workflow.slice(promoteStart);
 
     expect(healthJobStart).toBeGreaterThanOrEqual(0);
-    expect(deployJobStart).toBeGreaterThan(healthJobStart);
-    expect(verifyJobStart).toBeGreaterThan(deployJobStart);
+    expect(apiBuildStart).toBeGreaterThan(healthJobStart);
+    expect(webBuildStart).toBeGreaterThan(apiBuildStart);
+    expect(promoteStart).toBeGreaterThan(webBuildStart);
     // The gate only reads: it decides whether to promote, never promotes.
     // Both delimiters are asserted so a missing block cannot slice to "" and
     // satisfy the write check by being empty.
@@ -85,10 +89,52 @@ describe("API deployment health receipt", () => {
     // An unreachable environment defers; only a wait past the budget fails.
     expect(healthJob).toContain("readonly MAX_DEFERRAL_HOURS=");
     expect(healthJob).toContain("the environment needs attention.");
-    expect(deployJob).toContain("needs: staging-health");
-    expect(deployJob).toContain(
-      "needs.staging-health.outputs.deploy == 'true'",
-    );
+    expect(apiBuild).toContain("needs: staging-health");
+    expect(apiBuild).toContain("needs.staging-health.outputs.deploy == 'true'");
+    expect(webBuild).toContain("needs: staging-health");
+    expect(webBuild).toContain("needs.staging-health.outputs.deploy == 'true'");
+    expect(apiBuild).toContain("cancel-in-progress: true");
+    expect(webBuild).toContain("cancel-in-progress: true");
+    expect(promoteJob).toContain("cancel-in-progress: false");
+    expect(promoteJob).toContain("Confirm this SHA is still main");
+    expect(promoteJob).toContain("web-image-digest:");
+    expect(promoteJob).toContain("Run staging web smoke");
+    expect(workflow).not.toContain("\n  verify-staging:\n");
+  });
+
+  test("builds web images publicly from an allowlisted browser contract", async () => {
+    const [action, contract, production, staging] = await Promise.all([
+      Bun.file(
+        new URL(
+          "../.github/actions/build-web-image/action.yml",
+          import.meta.url,
+        ),
+      ).text(),
+      Bun.file(
+        new URL("../apps/web/build-env-contract.json", import.meta.url),
+      ).text(),
+      Bun.file(
+        new URL("../apps/web/build-env/production.json", import.meta.url),
+      ).text(),
+      Bun.file(
+        new URL("../apps/web/build-env/staging.json", import.meta.url),
+      ).text(),
+    ]);
+
+    expect(action).toContain("scripts/render-web-build-args.sh");
+    expect(action).toContain("type=registry,ref=ghcr.io/");
+    expect(action).not.toContain("type=gha");
+    expect(action).not.toContain("toJSON(vars)");
+    expect(action).not.toContain("AWS_");
+
+    for (const configuration of [production, staging]) {
+      const configuredKeys = configuration.match(/"VITE_[A-Z0-9_]+"(?=:)/gu);
+      expect(configuredKeys?.length).toBeGreaterThan(0);
+      for (const quotedKey of configuredKeys ?? []) {
+        expect(contract).toContain(`${quotedKey}:`);
+      }
+      expect(configuration).not.toMatch(/AWS_|DB_|ECR_|SECRET|TOKEN/gu);
+    }
   });
 
   test("release promotion preserves the full online-migration window", async () => {
@@ -142,17 +188,20 @@ describe("API deployment health receipt", () => {
     expect(manifestJobStart).toBeGreaterThan(webBuildJobStart);
     expect(promoteJob).toContain("timeout-minutes: 360");
     expect(webBuildJob).toContain("timeout-minutes: 55");
-    expect(webBuildJob).toContain(`-f "inputs[release_sha]=\${RELEASE_SHA}"`);
-    expect(webBuildJob).toContain(`-f "inputs[request_id]=\${REQUEST_ID}"`);
+    expect(webBuildJob).toContain("Build and publish web image publicly");
+    expect(webBuildJob).toContain(
+      "uses: ./.workflow-source/.github/actions/build-web-image",
+    );
+    expect(webBuildJob).toContain("source-path: .release-source");
+    expect(webBuildJob).toContain("tooling-path: .workflow-source");
     expect(webBuildJob).toContain(".releaseSha == $release_sha");
-    expect(webBuildJob).toContain("stella-web.intoto.jsonl");
     expect(webBuildJob).toContain(
       "actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6",
     );
-    expect(webBuildJob).toContain(
-      `candidate_tag="candidate-\${GITHUB_RUN_ID}-\${GITHUB_RUN_ATTEMPT}"`,
-    );
     expect(webBuildJob).toContain(".targetEnvironment == $target_environment");
+    expect(webBuildJob).not.toContain("stella-infra");
+    expect(webBuildJob).not.toContain("gh run download");
+    expect(webBuildJob).not.toContain("build-release-web.yml");
     expect(webBuildJob).not.toContain(`tags+=("\${IMAGE}:latest")`);
     expect(manifestJob).toContain(
       "bash .workflow-source/scripts/create-release-manifest.sh",
@@ -198,7 +247,7 @@ describe("API deployment health receipt", () => {
       `-f "inputs[web_image_digest]=\${WEB_IMAGE_DIGEST}"`,
     );
     expect(promoteAction).toContain(
-      "Tagged frontend promotions require a prebuilt web image digest.",
+      "Frontend promotions require a prebuilt web image digest.",
     );
     expect(promoteJob).not.toContain("steps.app-token.outputs.token");
     expect(stagingWorkflow).not.toContain(

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -122,6 +122,9 @@ describe("API deployment health receipt", () => {
     ]);
 
     expect(action).toContain("scripts/render-web-build-args.sh");
+    expect(action).toContain(
+      "Release source predates the public web build contract",
+    );
     expect(action).toContain("type=registry,ref=ghcr.io/");
     expect(action).not.toContain("type=gha");
     expect(action).not.toContain("toJSON(vars)");

--- a/scripts/check-staging-deploy-decision.test.ts
+++ b/scripts/check-staging-deploy-decision.test.ts
@@ -24,7 +24,7 @@ const extractDecideScript = (workflow: string) => {
   const stepStart = workflow.indexOf(
     "      - name: Decide deploy, defer, or escalate\n",
   );
-  const jobEnd = workflow.indexOf("\n  build-and-deploy:\n", stepStart);
+  const jobEnd = workflow.indexOf("\n  build-api:\n", stepStart);
   const runStart = workflow.indexOf("run: |\n", stepStart);
   if (stepStart === -1 || jobEnd === -1 || runStart === -1) {
     throw new Error("deploy-staging.yml no longer exposes the decide step");
@@ -84,6 +84,7 @@ type Decision = { deploy: string; exitCode: number };
 let workspace = "";
 let scriptPath = "";
 let probeScriptPath = "";
+let currentScriptPath = "";
 
 const runDecision = async ({
   committedHoursAgo = 1,
@@ -175,10 +176,42 @@ const runProbe = async ({
   };
 };
 
+const runCurrentCheck = async (currentSha: string) => {
+  const outputPath = path.join(
+    workspace,
+    `current-output-${Bun.randomUUIDv7()}.txt`,
+  );
+  const summaryPath = path.join(
+    workspace,
+    `current-summary-${Bun.randomUUIDv7()}.md`,
+  );
+  await Promise.all([Bun.write(outputPath, ""), Bun.write(summaryPath, "")]);
+
+  const result = Bun.spawnSync(["bash", currentScriptPath], {
+    env: {
+      ...process.env,
+      GH_TOKEN: "stub",
+      GITHUB_OUTPUT: outputPath,
+      GITHUB_REPOSITORY: "stella/stella",
+      GITHUB_SHA: TIP_SHA,
+      GITHUB_STEP_SUMMARY: summaryPath,
+      PATH: `${workspace}:${process.env["PATH"] ?? ""}`,
+      STUB_CURRENT_SHA: currentSha,
+    },
+  });
+
+  return {
+    exitCode: result.exitCode,
+    output: await Bun.file(outputPath).text(),
+    summary: await Bun.file(summaryPath).text(),
+  };
+};
+
 beforeAll(async () => {
   workspace = await mkdtemp(path.join(tmpdir(), "staging-deploy-decision-"));
   scriptPath = path.join(workspace, "decide.sh");
   probeScriptPath = path.join(workspace, "probe.sh");
+  currentScriptPath = path.join(workspace, "current.sh");
 
   const workflow = await Bun.file(WORKFLOW_URL).text();
   const script = extractDecideScript(workflow);
@@ -193,6 +226,14 @@ beforeAll(async () => {
       "\n      # Absent staging defers",
     ),
   );
+  await Bun.write(
+    currentScriptPath,
+    extractStepScript(
+      workflow,
+      "Confirm this SHA is still main",
+      "\n      - name: Check staging deployment target",
+    ),
+  );
   // Stands in for the reads the script makes: the last recorded staging
   // deployment, the oldest commit staging has not taken, and the tip's own
   // timestamp.
@@ -202,6 +243,7 @@ beforeAll(async () => {
     `#!/usr/bin/env bash
 for arg in "$@"; do
   case "$arg" in
+    *"/git/ref/heads/main"*) echo "\${STUB_CURRENT_SHA:-${TIP_SHA}}"; exit 0 ;;
     *"/deployments?environment="*) echo "\${STUB_DEPLOYED_SHA}"; exit 0 ;;
     *"/compare/"*) echo "\${STUB_PENDING_SINCE_EPOCH}"; exit 0 ;;
     *"/commits/"*) echo "\${STUB_COMMITTED_EPOCH}"; exit 0 ;;
@@ -419,5 +461,24 @@ describe("staging readiness cutover", () => {
     expect(stagingSetup).toContain("const READINESS_STABLE_SAMPLES = 3;");
     expect(stagingSetup).toContain(`url: \`\${API_URL}/ready\`,`);
     expect(stagingSetup).not.toContain(`url: \`\${API_URL}/health\`,`);
+  });
+});
+
+describe("private promotion coalescing", () => {
+  test("allows the exact main tip to cross the private boundary", async () => {
+    expect(await runCurrentCheck(TIP_SHA)).toEqual({
+      exitCode: 0,
+      output: "promoted=true\n",
+      summary: "",
+    });
+  });
+
+  test("turns an obsolete completed build into a successful no-op", async () => {
+    const result = await runCurrentCheck(OTHER_SHA);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toBe("promoted=false\n");
+    expect(result.summary).toContain("Skipping private promotion");
+    expect(result.summary).toContain(OTHER_SHA);
   });
 });

--- a/scripts/render-web-build-args.sh
+++ b/scripts/render-web-build-args.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Render Docker build arguments from Stella's generated web environment contract.
+set -euo pipefail
+
+if (( $# < 2 || $# > 3 )); then
+  echo "Usage: $0 <contract.json> <configuration.json> [omitted-variable]" >&2
+  exit 2
+fi
+
+contract_path="$1"
+configuration_path="$2"
+omitted_variable="${3:-}"
+
+if [[ ! -f "$contract_path" ]]; then
+  echo "ERROR: web build contract not found: ${contract_path}" >&2
+  exit 1
+fi
+if [[ ! -f "$configuration_path" ]]; then
+  echo "ERROR: web build configuration not found: ${configuration_path}" >&2
+  exit 1
+fi
+
+if ! jq -e '
+  .version == 1 and
+  (.variables | type == "object") and
+  (.variables | length > 0) and
+  ([.variables | to_entries[] |
+    (.key | test("^VITE_[A-Z0-9_]+$")) and
+    (.value | test("^[A-Z][A-Z0-9_]*$"))
+  ] | all)
+' "$contract_path" >/dev/null; then
+  echo "ERROR: invalid web build contract: ${contract_path}" >&2
+  exit 1
+fi
+
+if ! jq -e '
+  .version == 1 and
+  (.targetEnvironment == "production" or .targetEnvironment == "staging") and
+  (.variables | type == "object") and
+  ([.variables | to_entries[] |
+    (.key | test("^VITE_[A-Z0-9_]+$")) and
+    (.value | type == "string") and
+    (.value | test("[\\r\\n]") | not)
+  ] | all)
+' "$configuration_path" >/dev/null; then
+  echo "ERROR: invalid web build configuration: ${configuration_path}" >&2
+  exit 1
+fi
+
+unknown_variables="$(
+  jq -nr \
+    --slurpfile configured "$configuration_path" \
+    --slurpfile contract "$contract_path" '
+      $configured[0].variables
+      | keys[]
+      | select($contract[0].variables[.] == null)
+    '
+)"
+if [[ -n "$unknown_variables" ]]; then
+  echo "ERROR: configured web variables are absent from Stella's build contract:" >&2
+  while IFS= read -r name; do
+    echo "  ${name}" >&2
+  done <<<"$unknown_variables"
+  exit 1
+fi
+
+if [[ -n "$omitted_variable" ]] &&
+  ! jq -e --arg name "$omitted_variable" '.variables[$name] | type == "string"' \
+    "$contract_path" >/dev/null; then
+  echo "ERROR: omitted web variable is not declared by the contract: ${omitted_variable}" >&2
+  exit 1
+fi
+
+jq -nr \
+  --arg omitted "$omitted_variable" \
+  --slurpfile configured "$configuration_path" \
+  --slurpfile contract "$contract_path" '
+    $contract[0].variables
+    | to_entries
+    | sort_by(.key)
+    | .[]
+    | select(.key != $omitted)
+    | ($configured[0].variables[.key] // "") as $value
+    | "\(.value)=\($value)"
+  '

--- a/scripts/render-web-build-args.test.sh
+++ b/scripts/render-web-build-args.test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RENDERER="$SCRIPT_DIR/render-web-build-args.sh"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+printf '%s\n' '{"version":1,"variables":{"VITE_ALPHA":"PUBLIC_ALPHA","VITE_BETA":"VITE_BETA"}}' >"$TEMP_DIR/contract.json"
+printf '%s\n' '{"version":1,"targetEnvironment":"staging","variables":{"VITE_ALPHA":"enabled"}}' >"$TEMP_DIR/configuration.json"
+
+actual="$(bash "$RENDERER" "$TEMP_DIR/contract.json" "$TEMP_DIR/configuration.json")"
+expected=$'PUBLIC_ALPHA=enabled\nVITE_BETA='
+if [[ "$actual" != "$expected" ]]; then
+  echo "ERROR: renderer did not follow the declared contract." >&2
+  diff -u <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") || true
+  exit 1
+fi
+
+omitted="$(bash "$RENDERER" "$TEMP_DIR/contract.json" "$TEMP_DIR/configuration.json" VITE_BETA)"
+if [[ "$omitted" != "PUBLIC_ALPHA=enabled" ]]; then
+  echo "ERROR: renderer did not omit the separately supplied variable." >&2
+  exit 1
+fi
+
+printf '%s\n' '{"version":1,"targetEnvironment":"staging","variables":{"VITE_RETIRED":"enabled"}}' >"$TEMP_DIR/unknown.json"
+if bash "$RENDERER" "$TEMP_DIR/contract.json" "$TEMP_DIR/unknown.json" \
+  >"$TEMP_DIR/unknown.stdout" 2>"$TEMP_DIR/unknown.stderr"; then
+  echo "ERROR: renderer accepted a variable absent from the contract." >&2
+  exit 1
+fi
+grep -Fq "VITE_RETIRED" "$TEMP_DIR/unknown.stderr"
+
+printf '%s\n' '{"version":1,"targetEnvironment":"staging","variables":{"VITE_ALPHA":"first\nsecond"}}' >"$TEMP_DIR/newline.json"
+if bash "$RENDERER" "$TEMP_DIR/contract.json" "$TEMP_DIR/newline.json" >/dev/null 2>&1; then
+  echo "ERROR: renderer accepted a multiline build argument." >&2
+  exit 1
+fi
+
+echo "ok - web build arguments follow the public contract"

--- a/scripts/selfhost-contract.test.ts
+++ b/scripts/selfhost-contract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -21,6 +21,8 @@ import {
   renderSelfhostEnvExample,
   workflowContractIssues,
 } from "./selfhost-tool";
+
+setDefaultTimeout(15_000);
 
 const repositoryCompose = async () =>
   await Bun.file(


### PR DESCRIPTION
## Summary

- build and attest staging and release web images in this repository
- compile browser configuration from a committed VITE-only allowlist
- pass immutable API and web digests into promotion
- cancel superseded public builds while keeping deployment and smoke verification serialized
- reject obsolete staging artifacts immediately before dispatch

The promotion boundary now receives prebuilt, source-bound images instead of requesting a separate web compilation.

CC on behalf of jan-kubica