### PR TITLE
fix(api): keep the extraction failure code in the failure log

### DIFF
--- a/apps/api/src/lib/document-processing-failure-fields.test.ts
+++ b/apps/api/src/lib/document-processing-failure-fields.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+
+import { documentProcessingFailureFields } from "@/api/lib/document-processing-failure-fields";
+import {
+  EXTRACTION_WORKER_ERROR_CODE,
+  type ExtractionWorkerErrorCode,
+  type ExtractionWorkerTermination,
+  ExtractionWorkerError,
+  extractionWorkerErrorCode,
+  SUBPROCESS_TERMINATION_REASON,
+  type SubprocessTerminationReason,
+} from "@/api/lib/errors/tagged-errors";
+
+/**
+ * The class these pin: every extraction failure shares one error class, so a
+ * sink that logs only the class collapses five distinct outcomes into one
+ * unactionable line. The discriminator has to survive into the fields, for
+ * every code, without carrying the message or any document bytes with it.
+ */
+
+const MESSAGE = "sandbox rejected 04-2019 rozsudek.pdf";
+
+const terminationFor = (
+  reason: SubprocessTerminationReason,
+): ExtractionWorkerTermination => ({ reason, signalCode: "SIGKILL" });
+
+const errorFor = (termination: ExtractionWorkerTermination | null) =>
+  new ExtractionWorkerError({
+    code: extractionWorkerErrorCode(termination),
+    exitCode: termination === null ? 1 : null,
+    message: MESSAGE,
+    mimeType: "application/pdf",
+    sizeBytes: 12_345,
+    termination,
+  });
+
+/**
+ * `null` is the parser branch: it is the one code with no termination, so it
+ * cannot be derived from the reason list and has to be named here.
+ */
+const TERMINATIONS = [
+  null,
+  ...Object.values(SUBPROCESS_TERMINATION_REASON).map(terminationFor),
+];
+
+describe("documentProcessingFailureFields", () => {
+  test("discriminates every extraction failure code", () => {
+    const exercised = new Set<ExtractionWorkerErrorCode>();
+    for (const termination of TERMINATIONS) {
+      const code = extractionWorkerErrorCode(termination);
+      expect(
+        documentProcessingFailureFields(errorFor(termination)),
+      ).toMatchObject({
+        "error.code": code,
+        "error.type": "ExtractionWorkerError",
+        mimeType: "application/pdf",
+        sizeBytes: "12345",
+      });
+      exercised.add(code);
+    }
+    // Both directions: a new code without a case here, or a case for a code
+    // the union dropped, fails rather than silently going unexercised.
+    expect([...exercised].toSorted()).toEqual(
+      Object.values(EXTRACTION_WORKER_ERROR_CODE).toSorted(),
+    );
+  });
+
+  test("carries the termination shape a code alone does not give", () => {
+    expect(
+      documentProcessingFailureFields(
+        errorFor(terminationFor(SUBPROCESS_TERMINATION_REASON.timeout)),
+      ),
+    ).toMatchObject({
+      signalCode: "SIGKILL",
+      terminationReason: SUBPROCESS_TERMINATION_REASON.timeout,
+    });
+    expect(documentProcessingFailureFields(errorFor(null))).toMatchObject({
+      exitCode: "1",
+    });
+  });
+
+  test("never carries the message", () => {
+    for (const termination of TERMINATIONS) {
+      const values = Object.values(
+        documentProcessingFailureFields(errorFor(termination)),
+      );
+      expect(values.some((value) => value.includes(MESSAGE))).toBe(false);
+    }
+  });
+
+  test("still names an error that is not an extraction failure", () => {
+    expect(documentProcessingFailureFields(new Error("boom"))).toMatchObject({
+      "error.type": "Error",
+    });
+  });
+});

--- a/apps/api/src/lib/document-processing-failure-fields.ts
+++ b/apps/api/src/lib/document-processing-failure-fields.ts
@@ -1,0 +1,26 @@
+import {
+  errorSystemFields,
+  safeErrorTelemetryFields,
+} from "@/api/lib/errors/utils";
+
+/**
+ * Log fields for a document-processing run that failed for good.
+ *
+ * `errorTag` alone names the class, and every extraction failure shares one
+ * class, so the tag cannot tell a parser rejection from a timeout, a crash,
+ * or an external kill: the run is unactionable from the log. Both helpers
+ * here are the sanctioned non-content sinks, and `captureError` already
+ * pairs them on the analytics path, so this only stops the log sink from
+ * being the poorer of the two.
+ *
+ * `errorSystemFields` carries the `code` discriminator (plus a wrapped
+ * cause's class and code); `safeErrorTelemetryFields` adds the extraction
+ * shape the code alone does not give: mime type, size, and either the
+ * termination reason and signal or the exit code.
+ */
+export const documentProcessingFailureFields = (
+  error: unknown,
+): Record<string, string> => ({
+  ...errorSystemFields(error),
+  ...safeErrorTelemetryFields(error),
+});

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -50,6 +50,7 @@ import {
   enqueueDocumentProcessingRun,
   type DocumentProcessingJobData,
 } from "@/api/lib/document-processing-enqueue";
+import { documentProcessingFailureFields } from "@/api/lib/document-processing-failure-fields";
 import { DocumentOcrError } from "@/api/lib/document-processing-ocr-result";
 import { startDocumentOcrWorkerReadiness } from "@/api/lib/document-processing-readiness";
 import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
@@ -2567,7 +2568,7 @@ const handleDocumentProcessingFailure = ({
 }): void => {
   captureError(error, { runId: job?.data.runId ?? "" });
   logger.error("document_processing.failed", {
-    "error.type": errorTag(error),
+    ...documentProcessingFailureFields(error),
     runId: job?.data.runId ?? "",
   });
 };


### PR DESCRIPTION
## Proposed change

`document_processing.failed` logged only `errorTag(error)`. Every extraction
failure is an `ExtractionWorkerError`, so that field reads the same string
whether the worker timed out, crashed, was cancelled, was killed externally, or
the parser rejected the file. `EXTRACTION_WORKER_ERROR_CODE` exists to separate
those five, and none of it reached the log line, so a permanently failed run
could not be told apart from any other by the record it leaves behind.

The error object already carries what was missing. `captureError`, called one
line above, pairs `errorSystemFields` and `safeErrorTelemetryFields` on the
analytics path; the log sink now uses the same two helpers, so the line carries
`error.code`, mime type, size, and either the termination reason and signal or
the exit code. Both helpers are this codebase's non-content sinks and exclude
messages and document bytes by construction, so the change adds no new exposure:
it stops the log from being the poorer of two sinks fed by the same error.

Field building moved into `document-processing-failure-fields.ts` so it can be
tested on its own; `handleDocumentProcessingFailure` keeps `runId`.

### Test

`document-processing-failure-fields.test.ts` asserts the discriminator survives
for every member of the code union, and that the exercised set equals the
declared set in both directions, so a new termination reason cannot land without
a case here. It also pins that the message never reaches a field value. Two of
its four tests fail against the previous shape.

## Checklist

- [x] **BUILD ASSURANCE** | Verified locally, since CI does not run on draft PRs:
  `bun test` on the new suite plus `document-processing-queue` and
  `analytics/capture` (73 pass, 0 fail), `bun --filter @stll/api typecheck`,
  `bun run format`, and the pre-push `code-check` workspace lint, all clean.
- [x] **TESTING** | Covered by the invariant test above.
- [ ] DARK MODE SUPPORT | Not applicable: no UI in this change.
- [ ] ISSUE LINKED | No tracking issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: log field change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhpKEax9WC1aJhLK9t9kkP)_