### PR TITLE
feat(api): pre-flight budget resolution

### DIFF
--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -14,6 +14,7 @@ import type { SkillMetadata } from "@stll/skills";
 
 import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
 import { chatMessages, chatThreads } from "@/api/db/schema";
+import type { UsageEventLane } from "@/api/db/schema";
 import { env } from "@/api/env";
 import {
   getActiveFileModelBinding,
@@ -251,7 +252,7 @@ const config = {
   permissions: { chat: ["create"] },
   mcp: { type: "internal", reason: "realtime_stream" },
   body: agUiSendMessageBodySchema,
-  requiresUsage: { actionType: "chat" },
+  requiresUsage: { actionType: "chat", laneRouting: true },
 } satisfies HandlerConfig;
 
 /** IDs of workspaces the chat may touch; deleting workspaces are excluded. */
@@ -859,44 +860,47 @@ const sendMessage = createSafeRootHandler(
 
       // Budget routing. Inside the included budget any selection
       // stands. When the pre-flight resolved the reduced-cost lane, an
-      // unselected turn is served on the lane's own model; an explicit
-      // selection instead falls through to the pool, which must be
-      // able to cover it — the same 402 a pool-only org would see.
+      // unselected turn is served on the lane's own model. Two cases
+      // instead fall through to the pool, which must be able to cover
+      // them — the same 402 a pool-only org would see: an explicit
+      // model selection, and an agent-mode send (machine work never
+      // settles an interactive budget).
       let chatModelOverride = selectedChatModel;
       let chatReasoningEffort = selectedReasoningEffort;
       let turnLane = usageLane ?? { lane: "pool" as const };
-      if (turnLane.lane === "fallback") {
-        if (
-          selectedChatModel === undefined ||
-          selectedChatModel === turnLane.forcedModelSelection
-        ) {
-          chatModelOverride = turnLane.forcedModelSelection;
-          chatReasoningEffort = undefined;
-        } else {
-          const poolCheck = yield* Result.await(
-            Result.tryPromise({
-              try: async () =>
-                await assertUsageAvailableForHandler({
-                  metering: { actionType: "chat" },
-                  organizationId: session.activeOrganizationId,
-                  orgAIConfig,
-                  workspaceId: null,
-                  userId: user.id,
-                  safeDb,
-                }),
-              catch: (cause) =>
-                new HandlerError({
-                  status: 500,
-                  message: "Usage check failed",
-                  cause,
-                }),
-            }),
-          );
-          if (poolCheck !== null) {
-            return Result.err(poolCheck);
-          }
-          turnLane = { lane: "pool" };
+      const explicitSelectionNeedsPool =
+        turnLane.lane === "fallback" &&
+        selectedChatModel !== undefined &&
+        selectedChatModel !== turnLane.forcedModelSelection;
+      const agentModeNeedsPool =
+        body.runMode === "agent" && turnLane.lane !== "pool";
+      if (explicitSelectionNeedsPool || agentModeNeedsPool) {
+        const poolCheck = yield* Result.await(
+          Result.tryPromise({
+            try: async () =>
+              await assertUsageAvailableForHandler({
+                metering: { actionType: "chat" },
+                organizationId: session.activeOrganizationId,
+                orgAIConfig,
+                workspaceId: null,
+                userId: user.id,
+                safeDb,
+              }),
+            catch: (cause) =>
+              new HandlerError({
+                status: 500,
+                message: "Usage check failed",
+                cause,
+              }),
+          }),
+        );
+        if (poolCheck !== null) {
+          return Result.err(poolCheck);
         }
+        turnLane = { lane: "pool" };
+      } else if (turnLane.lane === "fallback") {
+        chatModelOverride = turnLane.forcedModelSelection;
+        chatReasoningEffort = undefined;
       }
 
       // For an existing thread, accept a non-empty body update as
@@ -1366,6 +1370,7 @@ const sendMessage = createSafeRootHandler(
         safeDb,
         tenantWorkspaceIds: accessibleWorkspaceIds,
         threadId: body.threadId,
+        usageLane: turnLane.lane,
         userId: user.id,
         workspaceId,
       });
@@ -1873,6 +1878,8 @@ type CompactMessagesForContextProps = ChatCompactionModelProps & {
   safeDb: SafeDb;
   tenantWorkspaceIds: readonly SafeId<"workspace">[];
   threadId: SafeId<"chatThread">;
+  /** Budget lane of the turn this compaction serves. */
+  usageLane: UsageEventLane;
   userId: SafeId<"user">;
   workspaceId: SafeId<"workspace"> | null;
 };
@@ -1927,6 +1934,7 @@ const compactMessagesForContext = async ({
   safeDb,
   tenantWorkspaceIds,
   threadId,
+  usageLane,
   userId,
   workspaceId,
 }: CompactMessagesForContextProps): Promise<
@@ -1935,6 +1943,9 @@ const compactMessagesForContext = async ({
   const aiAnalytics = createTanStackAIAnalyticsCallbacks({
     usageMetering: {
       actionType: "chat",
+      // Pre-stream compaction is part of the same interactive turn,
+      // so it settles against the turn's resolved lane.
+      lane: usageLane,
       organizationId,
       safeDb,
       serviceTier: "standard",

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -154,7 +154,10 @@ import type { OrgAIConfig } from "@/api/lib/ai-config";
 import { captureError } from "@/api/lib/analytics/capture";
 import { createTanStackAIAnalyticsCallbacks } from "@/api/lib/analytics/tanstack-ai";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import {
+  assertUsageAvailableForHandler,
+  createSafeRootHandler,
+} from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AccessibleWorkspace } from "@/api/lib/auth";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -383,6 +386,7 @@ const sendMessage = createSafeRootHandler(
     safeDb,
     scopedDb,
     session,
+    usageLane,
     user,
   }) {
     const body = transportBody.forwardedProps;
@@ -844,14 +848,56 @@ const sendMessage = createSafeRootHandler(
       // a catalog bump that drops the model falls back to the org default
       // silently instead of failing the send.
       const {
-        modelId: chatModelOverride,
-        reasoningEffort: chatReasoningEffort,
+        modelId: selectedChatModel,
+        reasoningEffort: selectedReasoningEffort,
       } = resolveEffectiveChatModelSelection({
         devModelId: body.devModelId,
         threadChatModel: thread.data.chatModel,
         threadReasoningEffort: thread.data.chatReasoningEffort,
         orgAIConfig,
       });
+
+      // Budget routing. Inside the included budget any selection
+      // stands. When the pre-flight resolved the reduced-cost lane, an
+      // unselected turn is served on the lane's own model; an explicit
+      // selection instead falls through to the pool, which must be
+      // able to cover it — the same 402 a pool-only org would see.
+      let chatModelOverride = selectedChatModel;
+      let chatReasoningEffort = selectedReasoningEffort;
+      let turnLane = usageLane ?? { lane: "pool" as const };
+      if (turnLane.lane === "fallback") {
+        if (
+          selectedChatModel === undefined ||
+          selectedChatModel === turnLane.forcedModelSelection
+        ) {
+          chatModelOverride = turnLane.forcedModelSelection;
+          chatReasoningEffort = undefined;
+        } else {
+          const poolCheck = yield* Result.await(
+            Result.tryPromise({
+              try: async () =>
+                await assertUsageAvailableForHandler({
+                  metering: { actionType: "chat" },
+                  organizationId: session.activeOrganizationId,
+                  orgAIConfig,
+                  workspaceId: null,
+                  userId: user.id,
+                  safeDb,
+                }),
+              catch: (cause) =>
+                new HandlerError({
+                  status: 500,
+                  message: "Usage check failed",
+                  cause,
+                }),
+            }),
+          );
+          if (poolCheck !== null) {
+            return Result.err(poolCheck);
+          }
+          turnLane = { lane: "pool" };
+        }
+      }
 
       // For an existing thread, accept a non-empty body update as
       // "user changed scope, persist it"; an omitted/empty body keeps
@@ -1695,6 +1741,7 @@ const sendMessage = createSafeRootHandler(
                 promptCachingEnabled,
                 runMode: body.runMode,
                 sandboxRun,
+                usageLane: turnLane.lane,
                 resolveAssistantTextRefs: refRegistry.resolveAssistantTextRefs,
                 resolveAssistantToolInputRefs: ({ input, toolName }) =>
                   resolveRegistryToolInputRefs({

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -30,6 +30,7 @@ import {
 import type { ChatSendMode } from "@stll/anonymize-chat";
 
 import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
+import type { UsageEventLane } from "@/api/db/schema";
 import { modelAcceptsDocumentAttachment } from "@/api/handlers/chat/attachment-modality";
 import {
   applyChatPartPersistenceBudget,
@@ -196,6 +197,8 @@ type StreamChatProps = {
    */
   runMode: ChatRunMode | undefined;
   sandboxRun: StellaSandboxRunInput | undefined;
+  /** Budget lane the pre-flight resolved for this turn. */
+  usageLane: UsageEventLane;
   resolveAssistantTextRefs?: ((text: string) => string) | undefined;
   resolveAssistantToolInputRefs?: AssistantToolInputRefResolver | undefined;
   resolveAssistantToolOutputRefs?: AssistantToolOutputRefResolver | undefined;
@@ -307,6 +310,7 @@ export const streamChat = async ({
   reasoningEffort,
   runMode,
   sandboxRun,
+  usageLane,
   resolveAssistantTextRefs,
   resolveAssistantToolInputRefs,
   resolveAssistantToolOutputRefs,
@@ -468,6 +472,7 @@ export const streamChat = async ({
     promptCachingEnabled,
     runMode,
     sandboxRun,
+    usageLane,
     runId,
     parentRunId,
     resume: preparedResume,
@@ -752,6 +757,8 @@ type CreateChatAttemptAnalyticsProps = {
   safeDb: SafeDb;
   /** Explicit per-turn model selection; undefined = role default. */
   selectedModelId: string | undefined;
+  /** Budget lane this turn's consumption settles against. */
+  usageLane: UsageEventLane;
   threadId: SafeId<"chatThread">;
   userId: SafeId<"user">;
   workspaceId: SafeId<"workspace"> | null;
@@ -764,6 +771,7 @@ const createChatAttemptAnalytics = ({
   orgAIConfig,
   safeDb,
   selectedModelId,
+  usageLane,
   threadId,
   userId,
   workspaceId,
@@ -771,6 +779,7 @@ const createChatAttemptAnalytics = ({
   createTanStackAIAnalyticsCallbacks({
     usageMetering: {
       actionType: "chat",
+      lane: usageLane,
       organizationId,
       safeDb,
       serviceTier: "standard",
@@ -823,6 +832,8 @@ type RunChatAttemptsProps = {
   promptCachingEnabled: boolean;
   runMode: ChatRunMode | undefined;
   sandboxRun: StellaSandboxRunInput | undefined;
+  /** Budget lane the pre-flight resolved for this turn. */
+  usageLane: UsageEventLane;
   runId: string;
   parentRunId: string | undefined;
   resume: RunAgentResumeItem[] | undefined;
@@ -847,6 +858,7 @@ const runChatAttempts = async function* ({
   promptCachingEnabled,
   runMode,
   sandboxRun,
+  usageLane,
   runId,
   parentRunId,
   resume,
@@ -879,6 +891,7 @@ const runChatAttempts = async function* ({
     role: "chat",
     safeDb,
     sandboxRun,
+    usageLane,
     state: primaryState,
     surfaces,
     thirdPartyBoundary,
@@ -924,6 +937,9 @@ const runChatAttempts = async function* ({
     promptCachingEnabled,
     role: "reasoning",
     safeDb,
+    // The provider-fallback attempt serves the same user turn, so it
+    // settles against the same budget lane.
+    usageLane,
     state: fallbackState,
     surfaces,
     thirdPartyBoundary,
@@ -942,6 +958,8 @@ type RunChatAttemptProps = {
   abortController: AbortController;
   abortSignal: AbortSignal;
   compactionFeature: string;
+  /** Budget lane this turn's consumption settles against. */
+  usageLane: UsageEventLane;
   externalMcpToolSource: StellaMcpToolSource | undefined;
   feature: string;
   model: ResolvedTanStackTextModel;
@@ -989,6 +1007,7 @@ const runChatAttempt = async function* ({
   role,
   safeDb,
   sandboxRun,
+  usageLane,
   state,
   surfaces,
   thirdPartyBoundary,
@@ -1013,6 +1032,9 @@ const runChatAttempt = async function* ({
   // selection, so their consumption must rate against the role default
   // rather than a model that never served them.
   const servedModelId = sandboxRun ? undefined : modelId;
+  // Sandbox turns are machine work: they settle against the pool
+  // regardless of the interactive lane the pre-flight resolved.
+  const servedLane = sandboxRun ? "pool" : usageLane;
   const analytics = createChatAttemptAnalytics({
     feature,
     modelRole: role,
@@ -1020,6 +1042,7 @@ const runChatAttempt = async function* ({
     orgAIConfig,
     safeDb,
     selectedModelId: servedModelId,
+    usageLane: servedLane,
     threadId,
     userId,
     workspaceId,
@@ -1033,6 +1056,7 @@ const runChatAttempt = async function* ({
     // Compaction runs on the same adapter as the turn itself, so its
     // consumption rates against the same selection.
     selectedModelId: servedModelId,
+    usageLane: servedLane,
     threadId,
     userId,
     workspaceId,

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -45,6 +45,8 @@ import {
   resolveEffectiveServiceTierForProvider,
 } from "@/api/lib/tanstack-ai-models";
 import { computeUsageUnitCost } from "@/api/lib/usage/action-weights";
+import { decideChatUsageLane } from "@/api/lib/usage/lane-routing";
+import type { UsageLaneDecision } from "@/api/lib/usage/lane-routing";
 import { assertUsageAvailable } from "@/api/lib/usage/usage-ledger";
 // Type-only: derive the closed tool-name union from the single MCP registry
 // so `mcp: { type: "tool", name }` typechecks against the real tools. The
@@ -363,6 +365,13 @@ type BaseHandlerContext<TConfig extends HandlerConfig = HandlerConfig> =
     };
     orgAIConfig: OrgAIConfig | null;
     /**
+     * Budget lane the usage pre-flight resolved for this request.
+     * Set only when the handler declares `requiresUsage` and
+     * enforcement is on; handlers thread it into their metering so
+     * consumption settles against the decided budget.
+     */
+    usageLane?: UsageLaneDecision;
+    /**
      * Whether stella may annotate AI requests for this org with
      * prompt-cache markers. Threaded through to the model resolver;
      * provider adapters strip any markers when
@@ -654,9 +663,10 @@ const createSafeScopedHandler = <
         userId: ctx.user.id,
       });
       const preflight = await runUsagePreflight({ ctx, meteringContext });
-      if (preflight !== null) {
-        return preflight;
+      if (preflight.kind === "blocked") {
+        return preflight.response;
       }
+      ctx.usageLane = preflight.lane;
     }
 
     return await runSafeHandler(ctx, handler);
@@ -669,6 +679,7 @@ type ResolvedMeteringContext = {
   userId: SafeId<"user">;
   actionType: UsageActionType;
   serviceTier: UsageServiceTier;
+  isByok: boolean;
   cost: number;
 };
 
@@ -706,6 +717,7 @@ export const resolveMeteringContext = ({
     userId,
     actionType: metering.actionType,
     serviceTier,
+    isByok,
     cost,
   };
 };
@@ -716,24 +728,48 @@ type PreflightCtx = {
   safeDb: SafeDb;
 };
 
+type UsagePreflightOutcome =
+  | { kind: "blocked"; response: SafeStatusResponse<402 | 500> }
+  | { kind: "allowed"; lane: UsageLaneDecision };
+
 const runUsagePreflight = async ({
   ctx,
   meteringContext,
 }: {
   ctx: PreflightCtx;
   meteringContext: ResolvedMeteringContext;
-}): Promise<SafeStatusResponse<402 | 500> | null> => {
+}): Promise<UsagePreflightOutcome> => {
   if (meteringContext.cost <= 0) {
-    return null;
+    // BYOK (and other zero-cost) turns never draw a managed budget.
+    return { kind: "allowed", lane: { lane: "pool" } };
   }
-  const checkResult = await ctx.safeDb(
-    async (tx) =>
-      await assertUsageAvailable({
+  const checkResult = await ctx.safeDb(async (tx) => {
+    // Chat is the interactive lane surface: a chat turn inside the
+    // user's included budget settles there and skips the pool check
+    // entirely. Every other metered action stays pool until routing
+    // deliberately expands.
+    if (meteringContext.actionType === "chat" && !meteringContext.isByok) {
+      const lane = await decideChatUsageLane({
         tx,
         organizationId: meteringContext.organizationId,
-        required: meteringContext.cost,
-      }),
-  );
+        userId: meteringContext.userId,
+      });
+      if (lane.lane !== "pool") {
+        return { ok: true as const, lane };
+      }
+    }
+    const check = await assertUsageAvailable({
+      tx,
+      organizationId: meteringContext.organizationId,
+      required: meteringContext.cost,
+    });
+    return check.ok
+      ? {
+          ok: true as const,
+          lane: { lane: "pool" } satisfies UsageLaneDecision,
+        }
+      : { ok: false as const, error: check.error };
+  });
   if (Result.isError(checkResult)) {
     // DB error during pre-flight — surface generic 500 so the
     // user retries; we don't let it look like an over-limit
@@ -744,22 +780,28 @@ const runUsagePreflight = async ({
       error: checkResult.error,
       statusCode: 500,
     });
-    return toSafeStatusResponse(500, {
-      code: API_ERROR_CODE.internalServerError,
-      message: "Internal server error",
-    });
+    return {
+      kind: "blocked",
+      response: toSafeStatusResponse(500, {
+        code: API_ERROR_CODE.internalServerError,
+        message: "Internal server error",
+      }),
+    };
   }
   const check = checkResult.value;
   if (check.ok) {
-    return null;
+    return { kind: "allowed", lane: check.lane };
   }
-  return toSafeStatusResponse(402, {
-    code: API_ERROR_CODE.usageLimitExceeded,
-    message: check.error.message,
-    reason: check.error.reason,
-    required: check.error.required,
-    available: check.error.available,
-  });
+  return {
+    kind: "blocked",
+    response: toSafeStatusResponse(402, {
+      code: API_ERROR_CODE.usageLimitExceeded,
+      message: check.error.message,
+      reason: check.error.reason,
+      required: check.error.required,
+      available: check.error.available,
+    }),
+  };
 };
 
 type UsagePreflightInput = {

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -43,6 +43,7 @@ import type { AnyPermissiveRouteSchema } from "@/api/lib/permissive-route-schema
 import {
   getTanStackTextModelInfoForRole,
   resolveEffectiveServiceTierForProvider,
+  resolveFallbackChatSelection,
 } from "@/api/lib/tanstack-ai-models";
 import { computeUsageUnitCost } from "@/api/lib/usage/action-weights";
 import { decideChatUsageLane } from "@/api/lib/usage/lane-routing";
@@ -234,6 +235,12 @@ export type McpExposure =
 export type UsageMeteringConfig = {
   actionType: UsageActionType;
   serviceTier?: UsageServiceTier;
+  /**
+   * Opt this endpoint's pre-flight into per-user budget-lane routing.
+   * Only the interactive chat send declares it; pricing an action as
+   * "chat" is not by itself evidence the handler can honor a lane.
+   */
+  laneRouting?: true;
   /**
    * Logical model role recorded on the consumption ledger row.
    * Defaults to `"chat"`. Set to the role the handler will pass
@@ -680,6 +687,7 @@ type ResolvedMeteringContext = {
   actionType: UsageActionType;
   serviceTier: UsageServiceTier;
   isByok: boolean;
+  laneRouting: boolean;
   cost: number;
 };
 
@@ -718,6 +726,7 @@ export const resolveMeteringContext = ({
     actionType: metering.actionType,
     serviceTier,
     isByok,
+    laneRouting: metering.laneRouting === true,
     cost,
   };
 };
@@ -744,18 +753,34 @@ const runUsagePreflight = async ({
     return { kind: "allowed", lane: { lane: "pool" } };
   }
   const checkResult = await ctx.safeDb(async (tx) => {
-    // Chat is the interactive lane surface: a chat turn inside the
-    // user's included budget settles there and skips the pool check
-    // entirely. Every other metered action stays pool until routing
-    // deliberately expands.
-    if (meteringContext.actionType === "chat" && !meteringContext.isByok) {
-      const lane = await decideChatUsageLane({
+    // Only endpoints that opted into lane routing (the interactive
+    // chat send) resolve a per-user budget lane; a turn inside the
+    // included budget settles there and skips the pool check
+    // entirely. A fallback verdict must also be servable on this
+    // deployment, otherwise it degrades to the pool path.
+    if (meteringContext.laneRouting && !meteringContext.isByok) {
+      const verdict = await decideChatUsageLane({
         tx,
         organizationId: meteringContext.organizationId,
         userId: meteringContext.userId,
       });
-      if (lane.lane !== "pool") {
-        return { ok: true as const, lane };
+      if (verdict === "allowance") {
+        return {
+          ok: true as const,
+          lane: { lane: "allowance" } satisfies UsageLaneDecision,
+        };
+      }
+      if (verdict === "fallback") {
+        const forcedModelSelection = resolveFallbackChatSelection(null);
+        if (forcedModelSelection !== null) {
+          return {
+            ok: true as const,
+            lane: {
+              lane: "fallback",
+              forcedModelSelection,
+            } satisfies UsageLaneDecision,
+          };
+        }
       }
     }
     const check = await assertUsageAvailable({

--- a/apps/api/src/lib/tanstack-ai-models.ts
+++ b/apps/api/src/lib/tanstack-ai-models.ts
@@ -21,6 +21,7 @@ import {
   ANTHROPIC_ADAPTIVE_THINKING_MODELS,
   BYOK_MODEL_OPTIONS,
   DEFAULT_MODELS,
+  FALLBACK_CHAT_MODEL_BY_PROVIDER,
   isBYOKModelRoleSupported,
   isBYOKProviderRoleSupported,
   isChatPdfAttachmentModelSupported,
@@ -1670,6 +1671,26 @@ export const getTanStackTextModelInfoForRole = (
     modelId: MODEL_OVERRIDES[role] ?? DEFAULT_MODELS[provider][role],
     provider: supportedProvider,
   };
+};
+
+/**
+ * Selection string for the reduced-cost lane on this deployment, or
+ * null when the lane cannot be served: BYOK orgs settle on their own
+ * key, and instance deployments need a configured provider whose
+ * fallback model is adapter-servable.
+ */
+export const resolveFallbackChatSelection = (
+  orgConfig: OrgAIConfig | null | undefined,
+): string | null => {
+  if (orgConfig) {
+    return null;
+  }
+  if (!hasTanStackInstanceProvider()) {
+    return null;
+  }
+  const provider = getActiveProvider();
+  const modelId = FALLBACK_CHAT_MODEL_BY_PROVIDER[provider];
+  return modelId === null ? null : `${provider}::${modelId}`;
 };
 
 /**

--- a/apps/api/src/lib/usage/lane-routing.db.test.ts
+++ b/apps/api/src/lib/usage/lane-routing.db.test.ts
@@ -15,10 +15,7 @@ import type { UsageEntitlementStatus } from "@/api/db/schema";
 import { createSafeId, toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { incrementLaneCounter } from "@/api/lib/usage/lane-budget";
-import {
-  decideChatUsageLane,
-  FALLBACK_CHAT_MODEL_SELECTION,
-} from "@/api/lib/usage/lane-routing";
+import { decideChatUsageLane } from "@/api/lib/usage/lane-routing";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
 import type { TestDatabase } from "@/api/tests/security/test-utils";
@@ -130,9 +127,7 @@ describe("chat usage lane routing", () => {
     await withRolledBackTx(async (tx) => {
       const fx = await setupFixture(tx);
 
-      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
-        lane: "pool",
-      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe("pool");
     });
   });
 
@@ -149,9 +144,7 @@ describe("chat usage lane routing", () => {
         fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
       });
 
-      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
-        lane: "pool",
-      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe("pool");
     });
   });
 
@@ -166,9 +159,7 @@ describe("chat usage lane routing", () => {
         fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
       });
 
-      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
-        lane: "pool",
-      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe("pool");
     });
   });
 
@@ -185,9 +176,9 @@ describe("chat usage lane routing", () => {
 
       // An untouched bucket has no row; the missing row must read as
       // zero rather than skipping the lane.
-      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
-        lane: "allowance",
-      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe(
+        "allowance",
+      );
 
       await incrementLaneCounter({
         tx,
@@ -196,9 +187,9 @@ describe("chat usage lane routing", () => {
         microUnits: DAILY_ALLOWANCE - 1,
         asOf: ASOF,
       });
-      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
-        lane: "allowance",
-      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe(
+        "allowance",
+      );
     });
   });
 
@@ -221,10 +212,9 @@ describe("chat usage lane routing", () => {
         microUnits: DAILY_ALLOWANCE,
         asOf: ASOF,
       });
-      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
-        lane: "fallback",
-        forcedModelSelection: FALLBACK_CHAT_MODEL_SELECTION,
-      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe(
+        "fallback",
+      );
 
       // Overshooting the daily budget (a turn that crossed it) keeps the
       // same lane while the weekly budget still has room.
@@ -242,10 +232,9 @@ describe("chat usage lane routing", () => {
         microUnits: FALLBACK_WEEKLY - 1,
         asOf: ASOF,
       });
-      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
-        lane: "fallback",
-        forcedModelSelection: FALLBACK_CHAT_MODEL_SELECTION,
-      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe(
+        "fallback",
+      );
     });
   });
 
@@ -267,9 +256,7 @@ describe("chat usage lane routing", () => {
         microUnits: DAILY_ALLOWANCE,
         asOf: ASOF,
       });
-      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
-        lane: "pool",
-      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe("pool");
     });
   });
 
@@ -298,9 +285,7 @@ describe("chat usage lane routing", () => {
         microUnits: FALLBACK_WEEKLY,
         asOf: ASOF,
       });
-      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
-        lane: "pool",
-      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe("pool");
     });
   });
 });

--- a/apps/api/src/lib/usage/lane-routing.db.test.ts
+++ b/apps/api/src/lib/usage/lane-routing.db.test.ts
@@ -1,0 +1,306 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { TransactionRollbackError } from "drizzle-orm";
+
+import { organization, user } from "@/api/db/auth-schema";
+import type { Transaction } from "@/api/db/root";
+import { usageEntitlements, usagePolicies } from "@/api/db/schema";
+import type { UsageEntitlementStatus } from "@/api/db/schema";
+import { createSafeId, toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { incrementLaneCounter } from "@/api/lib/usage/lane-budget";
+import {
+  decideChatUsageLane,
+  FALLBACK_CHAT_MODEL_SELECTION,
+} from "@/api/lib/usage/lane-routing";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+setDefaultTimeout(120_000);
+
+let testDb: TestDatabase;
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+});
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+// 2026-07-10 is a Friday inside the seeded period: its daily bucket
+// (2026-07-10) and its ISO-week bucket (Monday 2026-07-06) differ, so a
+// daily/weekly kind mix-up cannot pass unnoticed.
+const ASOF = new Date("2026-07-10T12:00:00.000Z");
+const PERIOD_START = new Date("2026-07-01T00:00:00.000Z");
+const PERIOD_END = new Date("2026-08-01T00:00:00.000Z");
+
+const DAILY_ALLOWANCE = 1000;
+const FALLBACK_WEEKLY = 5000;
+
+type Fixture = {
+  organizationId: SafeId<"organization">;
+  userId: string;
+};
+
+const setupFixture = async (tx: Transaction): Promise<Fixture> => {
+  const organizationId = toSafeId<"organization">(`org_${Bun.randomUUIDv7()}`);
+  const userId = `user_${Bun.randomUUIDv7()}`;
+
+  await tx.insert(organization).values({
+    id: organizationId,
+    name: "Test Org",
+    slug: organizationId,
+    createdAt: ASOF,
+  });
+  await tx.insert(user).values({
+    id: userId,
+    name: "Test User",
+    email: `${userId}@test.local`,
+  });
+
+  return { organizationId, userId };
+};
+
+type SeedEntitlementOptions = {
+  tx: Transaction;
+  fx: Fixture;
+  status: UsageEntitlementStatus;
+  dailyAllowanceMicroUnits: number | null;
+  fallbackWeeklyMicroUnits: number | null;
+};
+
+const seedEntitlement = async ({
+  tx,
+  fx,
+  status,
+  dailyAllowanceMicroUnits,
+  fallbackWeeklyMicroUnits,
+}: SeedEntitlementOptions): Promise<void> => {
+  const usagePolicyId = createSafeId<"usagePolicy">();
+
+  await tx.insert(usagePolicies).values({
+    id: usagePolicyId,
+    policyKey: `test_${Bun.randomUUIDv7()}`,
+    displayName: "Test Policy",
+    monthlyUsageUnits: 10_000,
+    dailyAllowanceMicroUnits,
+    fallbackWeeklyMicroUnits,
+  });
+  await tx.insert(usageEntitlements).values({
+    id: createSafeId<"usageEntitlement">(),
+    organizationId: fx.organizationId,
+    usagePolicyId,
+    status,
+    seats: 1,
+    currentPeriodStart: PERIOD_START,
+    currentPeriodEnd: PERIOD_END,
+    source: "manual",
+  });
+};
+
+const withRolledBackTx = async (
+  fn: (tx: Transaction) => Promise<void>,
+): Promise<void> => {
+  try {
+    await testDb.transaction(async (rawTx) => {
+      // SAFETY: PGlite drizzle transaction is structurally compatible
+      // with prod BunSQL transaction for the queries we run here.
+      const tx = asTestRaw<Transaction>(rawTx);
+      await fn(tx);
+      rawTx.rollback();
+    });
+  } catch (error) {
+    if (error instanceof TransactionRollbackError) {
+      return;
+    }
+    throw error;
+  }
+};
+
+describe("chat usage lane routing", () => {
+  test("an org without an entitlement row draws from the pool", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
+        lane: "pool",
+      });
+    });
+  });
+
+  test("a policy that declares no daily allowance draws from the pool", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+      // A weekly fallback alone grants no lane: the daily allowance is
+      // the opt-in.
+      await seedEntitlement({
+        tx,
+        fx,
+        status: "active",
+        dailyAllowanceMicroUnits: null,
+        fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
+      });
+
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
+        lane: "pool",
+      });
+    });
+  });
+
+  test("a non-consumable entitlement draws from the pool despite seeded budgets", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+      await seedEntitlement({
+        tx,
+        fx,
+        status: "cancelled",
+        dailyAllowanceMicroUnits: DAILY_ALLOWANCE,
+        fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
+      });
+
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
+        lane: "pool",
+      });
+    });
+  });
+
+  test("a daily counter below the allowance draws from the allowance", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+      await seedEntitlement({
+        tx,
+        fx,
+        status: "active",
+        dailyAllowanceMicroUnits: DAILY_ALLOWANCE,
+        fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
+      });
+
+      // An untouched bucket has no row; the missing row must read as
+      // zero rather than skipping the lane.
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
+        lane: "allowance",
+      });
+
+      await incrementLaneCounter({
+        tx,
+        ...fx,
+        kind: "daily",
+        microUnits: DAILY_ALLOWANCE - 1,
+        asOf: ASOF,
+      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
+        lane: "allowance",
+      });
+    });
+  });
+
+  test("an exhausted daily budget with weekly room forces the fallback model", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+      await seedEntitlement({
+        tx,
+        fx,
+        status: "active",
+        dailyAllowanceMicroUnits: DAILY_ALLOWANCE,
+        fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
+      });
+
+      // The allowance is spent at equality, not only past it.
+      await incrementLaneCounter({
+        tx,
+        ...fx,
+        kind: "daily",
+        microUnits: DAILY_ALLOWANCE,
+        asOf: ASOF,
+      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
+        lane: "fallback",
+        forcedModelSelection: FALLBACK_CHAT_MODEL_SELECTION,
+      });
+
+      // Overshooting the daily budget (a turn that crossed it) keeps the
+      // same lane while the weekly budget still has room.
+      await incrementLaneCounter({
+        tx,
+        ...fx,
+        kind: "daily",
+        microUnits: DAILY_ALLOWANCE,
+        asOf: ASOF,
+      });
+      await incrementLaneCounter({
+        tx,
+        ...fx,
+        kind: "fallback_weekly",
+        microUnits: FALLBACK_WEEKLY - 1,
+        asOf: ASOF,
+      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
+        lane: "fallback",
+        forcedModelSelection: FALLBACK_CHAT_MODEL_SELECTION,
+      });
+    });
+  });
+
+  test("an exhausted daily budget draws from the pool when the policy grants no weekly fallback", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+      await seedEntitlement({
+        tx,
+        fx,
+        status: "active",
+        dailyAllowanceMicroUnits: DAILY_ALLOWANCE,
+        fallbackWeeklyMicroUnits: null,
+      });
+
+      await incrementLaneCounter({
+        tx,
+        ...fx,
+        kind: "daily",
+        microUnits: DAILY_ALLOWANCE,
+        asOf: ASOF,
+      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
+        lane: "pool",
+      });
+    });
+  });
+
+  test("both budgets exhausted draws from the pool", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+      await seedEntitlement({
+        tx,
+        fx,
+        status: "active",
+        dailyAllowanceMicroUnits: DAILY_ALLOWANCE,
+        fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
+      });
+
+      await incrementLaneCounter({
+        tx,
+        ...fx,
+        kind: "daily",
+        microUnits: DAILY_ALLOWANCE,
+        asOf: ASOF,
+      });
+      await incrementLaneCounter({
+        tx,
+        ...fx,
+        kind: "fallback_weekly",
+        microUnits: FALLBACK_WEEKLY,
+        asOf: ASOF,
+      });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toEqual({
+        lane: "pool",
+      });
+    });
+  });
+});

--- a/apps/api/src/lib/usage/lane-routing.ts
+++ b/apps/api/src/lib/usage/lane-routing.ts
@@ -1,0 +1,102 @@
+/**
+ * Budget lane decision for a metered chat turn.
+ *
+ * The decision reads the org's entitlement budgets and the user's lane
+ * counters, both as point lookups; consumption crossing a budget
+ * mid-turn is allowed (the turn that crosses completes) and the next
+ * decision lands on the other side of it.
+ */
+
+import { eq } from "drizzle-orm";
+
+import { FALLBACK_CHAT_MODEL } from "@stll/ai-catalog";
+
+import type { Transaction } from "@/api/db/root";
+import { usageEntitlements, usagePolicies } from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+import { encodeChatModelSelection } from "@/api/lib/chat-model-selection";
+import { getLaneCounterMicroUnits } from "@/api/lib/usage/lane-budget";
+import { isEntitlementConsumableAt } from "@/api/lib/usage/usage-ledger";
+
+export type UsageLaneDecision =
+  | { lane: "allowance" }
+  | { lane: "fallback"; forcedModelSelection: string }
+  | { lane: "pool" };
+
+export const FALLBACK_CHAT_MODEL_SELECTION =
+  encodeChatModelSelection(FALLBACK_CHAT_MODEL);
+
+type DecideChatUsageLaneInput = {
+  tx: Transaction;
+  organizationId: SafeId<"organization">;
+  userId: string;
+  asOf?: Date;
+};
+
+/**
+ * Decide which budget a chat turn draws from. `pool` reproduces the
+ * pre-lane behavior exactly and is the answer whenever the org's
+ * policy declares no budgets, so deployments that never seed them are
+ * untouched.
+ */
+export const decideChatUsageLane = async ({
+  tx,
+  organizationId,
+  userId,
+  asOf = new Date(),
+}: DecideChatUsageLaneInput): Promise<UsageLaneDecision> => {
+  const rows = await tx
+    .select({
+      status: usageEntitlements.status,
+      currentPeriodStart: usageEntitlements.currentPeriodStart,
+      currentPeriodEnd: usageEntitlements.currentPeriodEnd,
+      dailyAllowanceMicroUnits: usagePolicies.dailyAllowanceMicroUnits,
+      fallbackWeeklyMicroUnits: usagePolicies.fallbackWeeklyMicroUnits,
+    })
+    .from(usageEntitlements)
+    .innerJoin(
+      usagePolicies,
+      eq(usageEntitlements.usagePolicyId, usagePolicies.id),
+    )
+    .where(eq(usageEntitlements.organizationId, organizationId))
+    .limit(1);
+  const entitlement = rows.at(0);
+
+  if (
+    !entitlement ||
+    !isEntitlementConsumableAt(entitlement, asOf) ||
+    entitlement.dailyAllowanceMicroUnits === null
+  ) {
+    return { lane: "pool" };
+  }
+
+  const dailyUsed = await getLaneCounterMicroUnits({
+    tx,
+    organizationId,
+    userId,
+    kind: "daily",
+    asOf,
+  });
+  if (dailyUsed < entitlement.dailyAllowanceMicroUnits) {
+    return { lane: "allowance" };
+  }
+
+  if (entitlement.fallbackWeeklyMicroUnits === null) {
+    return { lane: "pool" };
+  }
+  const weeklyUsed = await getLaneCounterMicroUnits({
+    tx,
+    organizationId,
+    userId,
+    kind: "fallback_weekly",
+    asOf,
+  });
+  if (weeklyUsed < entitlement.fallbackWeeklyMicroUnits) {
+    return {
+      lane: "fallback",
+      forcedModelSelection: FALLBACK_CHAT_MODEL_SELECTION,
+    };
+  }
+
+  return { lane: "pool" };
+};

--- a/apps/api/src/lib/usage/lane-routing.ts
+++ b/apps/api/src/lib/usage/lane-routing.ts
@@ -9,12 +9,9 @@
 
 import { eq } from "drizzle-orm";
 
-import { FALLBACK_CHAT_MODEL } from "@stll/ai-catalog";
-
 import type { Transaction } from "@/api/db/root";
 import { usageEntitlements, usagePolicies } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
-import { encodeChatModelSelection } from "@/api/lib/chat-model-selection";
 import { getLaneCounterMicroUnits } from "@/api/lib/usage/lane-budget";
 import { isEntitlementConsumableAt } from "@/api/lib/usage/usage-ledger";
 
@@ -23,8 +20,12 @@ export type UsageLaneDecision =
   | { lane: "fallback"; forcedModelSelection: string }
   | { lane: "pool" };
 
-export const FALLBACK_CHAT_MODEL_SELECTION =
-  encodeChatModelSelection(FALLBACK_CHAT_MODEL);
+/**
+ * Budget verdict only: which lane the user's budgets admit. Whether a
+ * fallback verdict is actually servable (a fallback model exists on
+ * this deployment) is the pre-flight's composition concern.
+ */
+export type LaneBudgetVerdict = UsageLaneDecision["lane"];
 
 type DecideChatUsageLaneInput = {
   tx: Transaction;
@@ -44,7 +45,7 @@ export const decideChatUsageLane = async ({
   organizationId,
   userId,
   asOf = new Date(),
-}: DecideChatUsageLaneInput): Promise<UsageLaneDecision> => {
+}: DecideChatUsageLaneInput): Promise<LaneBudgetVerdict> => {
   const rows = await tx
     .select({
       status: usageEntitlements.status,
@@ -67,7 +68,7 @@ export const decideChatUsageLane = async ({
     !isEntitlementConsumableAt(entitlement, asOf) ||
     entitlement.dailyAllowanceMicroUnits === null
   ) {
-    return { lane: "pool" };
+    return "pool";
   }
 
   const dailyUsed = await getLaneCounterMicroUnits({
@@ -78,11 +79,11 @@ export const decideChatUsageLane = async ({
     asOf,
   });
   if (dailyUsed < entitlement.dailyAllowanceMicroUnits) {
-    return { lane: "allowance" };
+    return "allowance";
   }
 
   if (entitlement.fallbackWeeklyMicroUnits === null) {
-    return { lane: "pool" };
+    return "pool";
   }
   const weeklyUsed = await getLaneCounterMicroUnits({
     tx,
@@ -92,11 +93,8 @@ export const decideChatUsageLane = async ({
     asOf,
   });
   if (weeklyUsed < entitlement.fallbackWeeklyMicroUnits) {
-    return {
-      lane: "fallback",
-      forcedModelSelection: FALLBACK_CHAT_MODEL_SELECTION,
-    };
+    return "fallback";
   }
 
-  return { lane: "pool" };
+  return "pool";
 };

--- a/apps/api/src/tests/setup-env.ts
+++ b/apps/api/src/tests/setup-env.ts
@@ -45,9 +45,13 @@ process.env["SMTP_PORT"] ??= "1025";
 process.env["TRANSACTIONAL_EMAIL_FROM"] ??= "test@example.com";
 process.env["FRONTEND_URL"] ??= "http://localhost:3000";
 // Never reached by tests: corpus-index tests stub global fetch and only
-// assert on the request contract.
-process.env["CORPUS_INDEX_ENDPOINT"] ??= "http://localhost:7280";
-process.env["CORPUS_INDEX_SEARCH_ENDPOINT"] ??= "http://localhost:7281";
+// assert on the request contract. A developer .env that configures
+// CASE_LAW_DATABASE_URL forbids the endpoint (env-base invariant), so
+// only default it when that path is not configured.
+if (process.env["CASE_LAW_DATABASE_URL"] === undefined) {
+  process.env["CORPUS_INDEX_ENDPOINT"] ??= "http://localhost:7280";
+  process.env["CORPUS_INDEX_SEARCH_ENDPOINT"] ??= "http://localhost:7281";
+}
 process.env["GOTENBERG_URL"] ??= "http://localhost:3002";
 process.env["GOTENBERG_USERNAME"] ??= "test";
 process.env["GOTENBERG_PASSWORD"] ??= "test";

--- a/packages/ai-catalog/src/index.ts
+++ b/packages/ai-catalog/src/index.ts
@@ -792,14 +792,23 @@ type OfferedFirstPartyModelId =
  * bypass rates or capabilities and duplicated alias rows cannot drift apart.
  */
 /**
- * Model served when a user's included budget is exhausted and no
- * explicit selection overrides it. A first-party catalog entry so the
- * rate/display/context guards all apply.
+ * Per-provider model served when a user's included budget is exhausted
+ * and no explicit selection overrides it. Falls back to each
+ * provider's fast-role default; providers without a first-class
+ * adapter path cannot serve the lane. Total over providers so a new
+ * provider lands with an explicit decision.
  */
-export const FALLBACK_CHAT_MODEL = {
-  provider: "openai",
-  modelId: "gpt-5.6-luna",
-} as const;
+export const FALLBACK_CHAT_MODEL_BY_PROVIDER = {
+  google: DEFAULT_MODELS.google.fast,
+  openrouter: "openai/gpt-5.6-luna",
+  openai: "gpt-5.6-luna",
+  anthropic: DEFAULT_MODELS.anthropic.fast,
+  bedrock: DEFAULT_MODELS.bedrock.fast,
+  mistral: DEFAULT_MODELS.mistral.fast,
+  azure_foundry: null,
+  openai_compatible: null,
+  huggingface: null,
+} as const satisfies Record<AIProvider, string | null>;
 
 export const MODEL_CATALOG_ID_ALIASES = {
   "gpt-5.6-sol": "gpt-5.6",

--- a/packages/ai-catalog/src/index.ts
+++ b/packages/ai-catalog/src/index.ts
@@ -791,6 +791,16 @@ type OfferedFirstPartyModelId =
  * Every metadata lookup normalizes here, so instance/dev overrides cannot
  * bypass rates or capabilities and duplicated alias rows cannot drift apart.
  */
+/**
+ * Model served when a user's included budget is exhausted and no
+ * explicit selection overrides it. A first-party catalog entry so the
+ * rate/display/context guards all apply.
+ */
+export const FALLBACK_CHAT_MODEL = {
+  provider: "openai",
+  modelId: "gpt-5.6-luna",
+} as const;
+
 export const MODEL_CATALOG_ID_ALIASES = {
   "gpt-5.6-sol": "gpt-5.6",
 } as const satisfies Readonly<Record<string, OfferedFirstPartyModelId>>;


### PR DESCRIPTION
The usage pre-flight now resolves which budget a metered chat turn settles against instead of always checking the shared pool: turns inside the per-user included budget settle there directly, an exhausted budget serves unselected turns on the reduced-cost lane's configured model, and explicit selections fall through to the pool check unchanged. Machine-dispatched turns and every other metered action keep the existing pool path. The decision threads through the chat attempt into consumption metering, provider-fallback attempts included.

Also gates the corpus test-env defaults on the case-law path so the suite honors the env-base invariant under a developer .env, and adds decision coverage over entitlement state, budget opt-in, and both exhaustion boundaries.