### PR TITLE
feat: organization groups

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -270,10 +270,6 @@ POSTHOG_KEY="phc_"
 # when using a real project key.
 # POSTHOG_LOCAL_DEBUG="false"
 
-# [internal] Optional with a default. Include raw AI prompts and outputs in
-# local diagnostics. This may expose privileged content.
-# POSTHOG_LOCAL_DEBUG_AI_CONTENT="false"
-
 # [internal] Optional with a default. Debug unredacted errors.
 # DEBUG_UNREDACTED_ERRORS="false"
 

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -131,10 +131,6 @@ export const envBaseServerSchema = {
     v.pipe(v.string(), v.parseBoolean()),
     "false",
   ),
-  POSTHOG_LOCAL_DEBUG_AI_CONTENT: v.optional(
-    v.pipe(v.string(), v.parseBoolean()),
-    "false",
-  ),
   // Legal corpus + corpus index. Defaults keep the shipped pg-fts /
   // Postgres-text path active; flipping to corpus index is a config change.
   LEGAL_SEARCH_PROVIDER: v.optional(

--- a/apps/api/src/handlers/case-law/analysis/generate.ts
+++ b/apps/api/src/handlers/case-law/analysis/generate.ts
@@ -124,6 +124,7 @@ ${decisionText}`;
   const aiAnalytics = createTanStackAIAnalyticsCallbacks({
     feature: "case-law.analysis",
     modelRole: "fast",
+    organizationId,
     orgAIConfig,
     properties: {
       decision_id: decisionId,

--- a/apps/api/src/handlers/case-law/analysis/generate.ts
+++ b/apps/api/src/handlers/case-law/analysis/generate.ts
@@ -127,6 +127,9 @@ ${decisionText}`;
     orgAIConfig,
     properties: {
       decision_id: decisionId,
+      jurisdiction: decision.country,
+      language: decision.language,
+      organization_id: organizationId,
     },
     sessionId: decisionId,
     traceId: Bun.randomUUIDv7(),

--- a/apps/api/src/handlers/chat/get-suggested-prompts.ts
+++ b/apps/api/src/handlers/chat/get-suggested-prompts.ts
@@ -223,6 +223,7 @@ const getSuggestedPrompts = createSafeRootHandler(
     const aiAnalytics = createTanStackAIAnalyticsCallbacks({
       feature: "chat.suggested_prompts",
       modelRole: "fast",
+      organizationId: session.activeOrganizationId,
       orgAIConfig,
       properties: persistedWorkspaceId
         ? { workspace_id: persistedWorkspaceId }

--- a/apps/api/src/handlers/organization-settings/practice-jurisdictions.ts
+++ b/apps/api/src/handlers/organization-settings/practice-jurisdictions.ts
@@ -3,6 +3,7 @@ import { isCountryCode } from "@stll/country-codes";
 import type { Transaction } from "@/api/db/root";
 import { organizationSettings } from "@/api/db/schema";
 import type { PracticeJurisdiction } from "@/api/db/schema";
+import { getAnalytics } from "@/api/lib/analytics/client";
 import { arrayOrEmpty } from "@/api/lib/array";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
@@ -48,6 +49,27 @@ export const normalizePracticeJurisdictions = (
   }
 
   return [{ ...first, isPrimary: true }, ...normalized.slice(1)];
+};
+
+// Mirrors the persisted setting onto the PostHog organization group profile
+// so insights can break down usage by an organization's selected
+// jurisdictions. Called after the transaction commits, never inside it: a
+// rollback must not leave a phantom group profile.
+export const identifyOrganizationJurisdictions = (
+  organizationId: SafeId<"organization">,
+  practiceJurisdictions: readonly PracticeJurisdiction[],
+): void => {
+  getAnalytics().identifyOrganizationGroup({
+    organizationId,
+    properties: {
+      practice_jurisdictions: practiceJurisdictions.map(
+        (jurisdiction) => jurisdiction.countryCode,
+      ),
+      primary_jurisdiction:
+        practiceJurisdictions.find((jurisdiction) => jurisdiction.isPrimary)
+          ?.countryCode ?? null,
+    },
+  });
 };
 
 type UpsertPracticeJurisdictionsOptions = {

--- a/apps/api/src/handlers/organization-settings/update-practice-jurisdictions.ts
+++ b/apps/api/src/handlers/organization-settings/update-practice-jurisdictions.ts
@@ -2,6 +2,7 @@ import { Result } from "better-result";
 import { t } from "elysia";
 
 import {
+  identifyOrganizationJurisdictions,
   normalizePracticeJurisdictions,
   upsertPracticeJurisdictions,
 } from "@/api/handlers/organization-settings/practice-jurisdictions";
@@ -70,6 +71,11 @@ const updatePracticeJurisdictions = createSafeRootHandler(
           tx,
         });
       }),
+    );
+
+    identifyOrganizationJurisdictions(
+      session.activeOrganizationId,
+      practiceJurisdictions,
     );
 
     return Result.ok({ practiceJurisdictions });

--- a/apps/api/src/handlers/playbooks/derive-ask.ts
+++ b/apps/api/src/handlers/playbooks/derive-ask.ts
@@ -108,6 +108,7 @@ const defaultDeriveAskGenerate: DeriveAskGenerate = async (input) => {
   const aiAnalytics = createTanStackAIAnalyticsCallbacks({
     feature: "playbook.derive-ask",
     modelRole: DERIVE_ASK_ROLE,
+    organizationId,
     orgAIConfig,
     properties: { organization_id: organizationId },
     traceId: Bun.randomUUIDv7(),

--- a/apps/api/src/lib/analytics/capture.test.ts
+++ b/apps/api/src/lib/analytics/capture.test.ts
@@ -24,6 +24,7 @@ void mock.module("@/api/lib/analytics/client", () => ({
       captured.push(params);
     },
     flush: async () => undefined,
+    identifyOrganizationGroup: () => undefined,
   }),
 }));
 

--- a/apps/api/src/lib/analytics/capture.test.ts
+++ b/apps/api/src/lib/analytics/capture.test.ts
@@ -14,13 +14,19 @@ import {
   SUBPROCESS_TERMINATION_REASON,
 } from "@/api/lib/errors/tagged-errors";
 
-const captured: { properties: Record<string, unknown> }[] = [];
+const captured: {
+  groups?: Record<string, string>;
+  properties: Record<string, unknown>;
+}[] = [];
 
 const realClient = await import("@/api/lib/analytics/client");
 void mock.module("@/api/lib/analytics/client", () => ({
   ...realClient,
   getAnalytics: () => ({
-    capture: (params: { properties: Record<string, unknown> }) => {
+    capture: (params: {
+      groups?: Record<string, string>;
+      properties: Record<string, unknown>;
+    }) => {
       captured.push(params);
     },
     flush: async () => undefined,
@@ -28,8 +34,10 @@ void mock.module("@/api/lib/analytics/client", () => ({
   }),
 }));
 
-const { captureError, resetCaptureWindows } =
+const { captureError, captureRequestError, resetCaptureWindows } =
   await import("@/api/lib/analytics/capture");
+const { enrichRequestContext, initRequestContext } =
+  await import("@/api/lib/observability/request-context");
 
 /**
  * Both helpers construct their error on a single source line, so every
@@ -146,6 +154,30 @@ describe("captureError issue grouping", () => {
     const fingerprint = captured.at(0)?.properties["$exception_fingerprint"];
     expect(typeof fingerprint).toBe("string");
     expect(fingerprint).not.toContain("Privileged");
+  });
+});
+
+describe("captureRequestError organization attribution", () => {
+  test("attaches the organization group from the request context", () => {
+    const organizationId = "3f6e0a7e-9f6f-4a53-9a3e-2b8f6f0c9d41";
+    const request = new Request("https://api.test/internal");
+    initRequestContext(request);
+    enrichRequestContext(request, { organizationId });
+
+    captureRequestError(new Error("boom"), { request });
+
+    // The group is what PostHog's organization breakdown reads; losing it
+    // while organization_id survives as a plain property would go unnoticed.
+    expect(captured.at(0)?.groups).toEqual({ organization: organizationId });
+  });
+
+  test("stays ungrouped without an organization in the request context", () => {
+    const request = new Request("https://api.test/internal");
+    initRequestContext(request);
+
+    captureRequestError(new Error("boom"), { request });
+
+    expect(captured.at(0)?.groups).toBeUndefined();
   });
 });
 

--- a/apps/api/src/lib/analytics/capture.ts
+++ b/apps/api/src/lib/analytics/capture.ts
@@ -191,6 +191,9 @@ const captureErrorWithOptions = (
   getAnalytics().capture({
     distinctId: options.distinctId ?? SERVER_DISTINCT_ID,
     event: SERVER_ANALYTICS_EVENTS.exception,
+    ...(options.organizationId
+      ? { groups: { organization: options.organizationId } }
+      : {}),
     properties:
       suppressed > 0
         ? { ...properties, suppressed_repeats: String(suppressed) }

--- a/apps/api/src/lib/analytics/noop.ts
+++ b/apps/api/src/lib/analytics/noop.ts
@@ -5,5 +5,6 @@ const asyncNoop = async () => await Promise.resolve();
 
 export const noopAnalytics: Analytics = {
   capture: noop,
+  identifyOrganizationGroup: noop,
   flush: asyncNoop,
 };

--- a/apps/api/src/lib/analytics/posthog.ts
+++ b/apps/api/src/lib/analytics/posthog.ts
@@ -11,6 +11,10 @@ const ALLOWED_EVENTS = new Set<ServerAnalyticsCaptureParams["event"]>(
   Object.values(SERVER_ANALYTICS_EVENTS),
 );
 
+// Must match the browser adapter's `posthog.group` call so client and
+// server events aggregate under the same group.
+const ORGANIZATION_GROUP_TYPE = "organization";
+
 export const createPostHogAnalytics = (
   key: string,
   host: string,
@@ -39,6 +43,13 @@ export const createPostHogAnalytics = (
         ...(event === SERVER_ANALYTICS_EVENTS.exception
           ? { _originatedFromCaptureException: true }
           : {}),
+      });
+    },
+    identifyOrganizationGroup: (params) => {
+      client.groupIdentify({
+        groupType: ORGANIZATION_GROUP_TYPE,
+        groupKey: params.organizationId,
+        properties: params.properties,
       });
     },
     // eslint-disable-next-line promise-function-async -- forwards client.flush()'s promise directly; async would add a redundant wrapper

--- a/apps/api/src/lib/analytics/tanstack-ai.test.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.test.ts
@@ -191,6 +191,7 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
       feature: "case-law.analysis",
       organizationId: orgId,
       orgAIConfig: createOpenAIOrgAIConfig(),
+      properties: { jurisdiction: "CZE" },
       traceId: "trace_grouped",
     });
     const ctx = createMiddlewareContext();
@@ -209,6 +210,12 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
     for (const event of events) {
       expect(event.groups).toEqual({ organization: orgId });
     }
+    // `jurisdiction` is a newly allowlisted safe property and must survive
+    // into the completed event.
+    const completed = events.find(
+      (event) => event.event === SERVER_ANALYTICS_EVENTS.aiGenerationCompleted,
+    );
+    expect(completed?.properties).toMatchObject({ jurisdiction: "CZE" });
   });
 
   test("records usage through TanStack deferred side effects", async () => {

--- a/apps/api/src/lib/analytics/tanstack-ai.test.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.test.ts
@@ -106,6 +106,7 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
         events.push(event);
       },
       flush: async () => undefined,
+      identifyOrganizationGroup: () => undefined,
     };
     const callbacks = createTanStackAIAnalyticsCallbacks({
       analytics,
@@ -206,6 +207,7 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
     const analytics: Analytics = {
       capture: () => undefined,
       flush: async () => undefined,
+      identifyOrganizationGroup: () => undefined,
     };
     const callbacks = createTanStackAIAnalyticsCallbacks({
       analytics,
@@ -300,6 +302,7 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
         events.push(event);
       },
       flush: async () => undefined,
+      identifyOrganizationGroup: () => undefined,
     };
     const callbacks = createTanStackAIAnalyticsCallbacks({
       analytics,
@@ -391,6 +394,7 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
     const analytics: Analytics = {
       capture: () => undefined,
       flush: async () => undefined,
+      identifyOrganizationGroup: () => undefined,
     };
     const callbacks = createTanStackAIAnalyticsCallbacks({
       analytics,
@@ -434,6 +438,7 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
         events.push(event);
       },
       flush: async () => undefined,
+      identifyOrganizationGroup: () => undefined,
     };
     const callbacks = createTanStackAIAnalyticsCallbacks({
       analytics,
@@ -482,6 +487,7 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
         events.push(event);
       },
       flush: async () => undefined,
+      identifyOrganizationGroup: () => undefined,
     };
 
     try {
@@ -535,12 +541,20 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
 
     try {
       createTanStackAIAnalyticsCallbacks({
-        analytics: { capture: () => undefined, flush: async () => undefined },
+        analytics: {
+          capture: () => undefined,
+          flush: async () => undefined,
+          identifyOrganizationGroup: () => undefined,
+        },
         feature: "chat.suggested_prompts",
         traceId: "trace_provider_unavailable",
       }).captureError({ status: 503 });
       createTanStackAIAnalyticsCallbacks({
-        analytics: { capture: () => undefined, flush: async () => undefined },
+        analytics: {
+          capture: () => undefined,
+          flush: async () => undefined,
+          identifyOrganizationGroup: () => undefined,
+        },
         feature: "chat.suggested_prompts",
         traceId: "trace_unknown",
       }).captureError(new Error("boom"));
@@ -582,7 +596,11 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
 
     try {
       createTanStackAIAnalyticsCallbacks({
-        analytics: { capture: () => undefined, flush: async () => undefined },
+        analytics: {
+          capture: () => undefined,
+          flush: async () => undefined,
+          identifyOrganizationGroup: () => undefined,
+        },
         feature: "templates.suggestFields",
         traceId: "trace_byok_role",
       }).captureError(error);

--- a/apps/api/src/lib/analytics/tanstack-ai.test.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.test.ts
@@ -172,6 +172,45 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
     expect(completed?.properties).not.toHaveProperty("unsafe");
   });
 
+  test("groups events by the analytics organization without usage metering", async () => {
+    const { createTanStackAIAnalyticsCallbacks } =
+      await loadTanStackAIAnalytics();
+    const events: Parameters<Analytics["capture"]>[0][] = [];
+    const analytics: Analytics = {
+      capture: (event) => {
+        events.push(event);
+      },
+      flush: async () => undefined,
+      identifyOrganizationGroup: () => undefined,
+    };
+    // Org-scoped but unmetered (fixed-cost feature): the analytics-only
+    // organization id must group generation, completion, and failure events
+    // exactly like the metering-derived id does.
+    const callbacks = createTanStackAIAnalyticsCallbacks({
+      analytics,
+      feature: "case-law.analysis",
+      organizationId: orgId,
+      orgAIConfig: createOpenAIOrgAIConfig(),
+      traceId: "trace_grouped",
+    });
+    const ctx = createMiddlewareContext();
+
+    await callbacks.middleware.onFinish?.(ctx, {
+      content: "Done",
+      duration: 4200,
+      finishReason: "stop",
+      usage,
+    });
+    callbacks.captureError(new Error("boom"));
+
+    const eventNames = events.map((event) => event.event);
+    expect(eventNames).toContain(SERVER_ANALYTICS_EVENTS.aiGeneration);
+    expect(eventNames).toContain(SERVER_ANALYTICS_EVENTS.aiGenerationCompleted);
+    for (const event of events) {
+      expect(event.groups).toEqual({ organization: orgId });
+    }
+  });
+
   test("records usage through TanStack deferred side effects", async () => {
     const { createTanStackAIAnalyticsCallbacks } =
       await loadTanStackAIAnalytics();

--- a/apps/api/src/lib/analytics/tanstack-ai.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.ts
@@ -70,6 +70,12 @@ type TanStackAIAnalyticsProps = {
    */
   selectedModelId?: string | undefined;
   orgAIConfig?: OrgAIConfig | null;
+  /**
+   * Analytics-only organization identity for org-scoped calls that do not
+   * meter usage (fixed-cost or internal features). Metered calls derive the
+   * organization from `usageMetering` and may omit this.
+   */
+  organizationId?: SafeId<"organization"> | null;
   usageMetering?: TanStackAIUsageMetering;
 };
 
@@ -297,12 +303,15 @@ export const createTanStackAIAnalyticsCallbacks = ({
 }: TanStackAIAnalyticsProps): TanStackAIAnalyticsCallbacks => {
   const distinctId = config.distinctId ?? SERVER_DISTINCT_ID;
   const modelRole = config.modelRole ?? "chat";
-  // Group attachment is derived centrally from the metering context so call
-  // sites cannot forget it; events without metering stay ungrouped.
+  // Group attachment is derived centrally so call sites cannot forget it:
+  // from the metering context when present, else from the analytics-only
+  // organization identity. Events with neither stay ungrouped.
+  const analyticsOrganizationId =
+    config.usageMetering?.organizationId ?? config.organizationId ?? null;
   const groups =
-    config.usageMetering === undefined
+    analyticsOrganizationId === null
       ? {}
-      : { groups: { organization: config.usageMetering.organizationId } };
+      : { groups: { organization: analyticsOrganizationId } };
   const selectedModelId = config.selectedModelId;
   let modelInfo: ResolvedTanStackTextModelInfo | null | undefined;
   const startedAt = performance.now();
@@ -326,7 +335,7 @@ export const createTanStackAIAnalyticsCallbacks = ({
                 modelRole,
               )
             : getTanStackTextModelInfoForRole(modelRole, config.orgAIConfig, {
-                organizationId: config.usageMetering?.organizationId ?? null,
+                organizationId: analyticsOrganizationId,
               });
       } catch (error) {
         modelInfo = null;
@@ -374,7 +383,7 @@ export const createTanStackAIAnalyticsCallbacks = ({
     }
     captureTelemetryError(error, {
       feature: config.feature,
-      organization_id: config.usageMetering?.organizationId ?? "",
+      organization_id: analyticsOrganizationId ?? "",
       trace_id: config.traceId,
     });
 

--- a/apps/api/src/lib/analytics/tanstack-ai.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.ts
@@ -139,6 +139,9 @@ const pickSafeMetadata = (
       case "file_count":
         safeProperties.file_count = value;
         break;
+      case "jurisdiction":
+        safeProperties.jurisdiction = value;
+        break;
       case "language":
         safeProperties.language = value;
         break;
@@ -294,6 +297,12 @@ export const createTanStackAIAnalyticsCallbacks = ({
 }: TanStackAIAnalyticsProps): TanStackAIAnalyticsCallbacks => {
   const distinctId = config.distinctId ?? SERVER_DISTINCT_ID;
   const modelRole = config.modelRole ?? "chat";
+  // Group attachment is derived centrally from the metering context so call
+  // sites cannot forget it; events without metering stay ungrouped.
+  const groups =
+    config.usageMetering === undefined
+      ? {}
+      : { groups: { organization: config.usageMetering.organizationId } };
   const selectedModelId = config.selectedModelId;
   let modelInfo: ResolvedTanStackTextModelInfo | null | undefined;
   const startedAt = performance.now();
@@ -374,6 +383,7 @@ export const createTanStackAIAnalyticsCallbacks = ({
     // privacy contract.
     analytics.capture({
       distinctId,
+      ...groups,
       event: SERVER_ANALYTICS_EVENTS.aiGeneration,
       properties: {
         $ai_error: errorTag(error),
@@ -396,6 +406,7 @@ export const createTanStackAIAnalyticsCallbacks = ({
 
     analytics.capture({
       distinctId,
+      ...groups,
       event: SERVER_ANALYTICS_EVENTS.aiGenerationFailed,
       properties: {
         ...pickSafeMetadata(config.properties),
@@ -445,6 +456,7 @@ export const createTanStackAIAnalyticsCallbacks = ({
         // content never leave the service.
         analytics.capture({
           distinctId,
+          ...groups,
           event: SERVER_ANALYTICS_EVENTS.aiGeneration,
           properties: {
             $ai_input_tokens: usage.promptTokens,
@@ -459,6 +471,7 @@ export const createTanStackAIAnalyticsCallbacks = ({
 
         analytics.capture({
           distinctId,
+          ...groups,
           event: SERVER_ANALYTICS_EVENTS.aiGenerationCompleted,
           properties: {
             ...pickSafeMetadata(config.properties),

--- a/apps/api/src/lib/analytics/types.ts
+++ b/apps/api/src/lib/analytics/types.ts
@@ -1,10 +1,10 @@
+import type { SafeId } from "@/api/lib/branded-types";
 import type { ResolvedTanStackTextModelInfo } from "@/api/lib/tanstack-ai-models";
 
 export const SERVER_ANALYTICS_EVENTS = {
   aiGeneration: "$ai_generation",
   aiGenerationCompleted: "ai_generation_completed",
   aiGenerationFailed: "ai_generation_failed",
-  aiSpan: "$ai_span",
   exception: "$exception",
 } as const;
 
@@ -30,6 +30,10 @@ export type SafeAIAnalyticsMetadata = {
   content_type?: AnalyticsPrimitive;
   feature_area?: AnalyticsPrimitive;
   file_count?: AnalyticsPrimitive;
+  // Corpus jurisdiction of the underlying legal content (`CZE`, `EU`, ...);
+  // an event property rather than a group because it is a closed enum, not
+  // an entity with a profile.
+  jurisdiction?: AnalyticsPrimitive;
   language?: AnalyticsPrimitive;
   organization_id?: AnalyticsPrimitive;
   page_number?: AnalyticsPrimitive;
@@ -85,35 +89,54 @@ export type ExceptionProperties = {
 
 type DebugAIProperties = Record<string, unknown>;
 
-export type ServerAnalyticsCaptureParams =
-  | {
-      distinctId: string;
-      event: typeof SERVER_ANALYTICS_EVENTS.aiGeneration;
-      properties: DebugAIProperties;
-    }
-  | {
-      distinctId: string;
-      event: typeof SERVER_ANALYTICS_EVENTS.aiGenerationCompleted;
-      properties: AIGenerationCompletedProperties;
-    }
-  | {
-      distinctId: string;
-      event: typeof SERVER_ANALYTICS_EVENTS.aiGenerationFailed;
-      properties: AIGenerationFailedProperties;
-    }
-  | {
-      distinctId: string;
-      event: typeof SERVER_ANALYTICS_EVENTS.aiSpan;
-      properties: DebugAIProperties;
-    }
-  | {
-      distinctId: string;
-      event: typeof SERVER_ANALYTICS_EVENTS.exception;
-      properties: ExceptionProperties;
-    };
+// PostHog group attachment. `organization` is the only group type; it must
+// match the browser adapter's `posthog.group` call so client and server
+// events aggregate under the same group.
+export type ServerAnalyticsGroups = {
+  organization: string;
+};
+
+type ServerAnalyticsCaptureBase = {
+  distinctId: string;
+  groups?: ServerAnalyticsGroups;
+};
+
+export type ServerAnalyticsCaptureParams = ServerAnalyticsCaptureBase &
+  (
+    | {
+        event: typeof SERVER_ANALYTICS_EVENTS.aiGeneration;
+        properties: DebugAIProperties;
+      }
+    | {
+        event: typeof SERVER_ANALYTICS_EVENTS.aiGenerationCompleted;
+        properties: AIGenerationCompletedProperties;
+      }
+    | {
+        event: typeof SERVER_ANALYTICS_EVENTS.aiGenerationFailed;
+        properties: AIGenerationFailedProperties;
+      }
+    | {
+        event: typeof SERVER_ANALYTICS_EVENTS.exception;
+        properties: ExceptionProperties;
+      }
+  );
+
+// Group-profile properties for an organization; upserted whenever the
+// settings they mirror change.
+export type OrganizationGroupProperties = {
+  practice_jurisdictions: string[];
+  primary_jurisdiction: string | null;
+};
+
+export type OrganizationGroupIdentifyParams = {
+  organizationId: SafeId<"organization">;
+  properties: OrganizationGroupProperties;
+};
 
 export type Analytics = {
   capture: (params: ServerAnalyticsCaptureParams) => void;
+  /** Upsert the organization group profile in PostHog. */
+  identifyOrganizationGroup: (params: OrganizationGroupIdentifyParams) => void;
   /** Flush queued events. No-op for providers without a queue. */
   flush: () => Promise<void>;
 };

--- a/apps/api/src/lib/bbox/ai-generate-b-boxes.ts
+++ b/apps/api/src/lib/bbox/ai-generate-b-boxes.ts
@@ -52,6 +52,7 @@ export const generateBBoxData = async ({
   const aiAnalytics = createTanStackAIAnalyticsCallbacks({
     feature: "bbox.generate",
     modelRole: "pdf",
+    organizationId,
     orgAIConfig: orgAIConfig ?? null,
     properties: {
       justification_id: justificationId,

--- a/apps/api/src/lib/templates/suggest-template-fields-error.test.ts
+++ b/apps/api/src/lib/templates/suggest-template-fields-error.test.ts
@@ -56,7 +56,11 @@ describe("suggestTemplateFields", () => {
     // propagates the failure. Callers (suggest-fields.ts, prepare.ts,
     // template-tools.ts) are responsible for calling captureError.
     const aiAnalytics = createTanStackAIAnalyticsCallbacks({
-      analytics: { capture: () => undefined, flush: async () => undefined },
+      analytics: {
+        capture: () => undefined,
+        flush: async () => undefined,
+        identifyOrganizationGroup: () => undefined,
+      },
       feature: "templates.test",
       traceId: "trace_test",
     });
@@ -86,6 +90,7 @@ describe("suggestTemplateFieldsOrEmpty", () => {
           captured.push(params);
         },
         flush: async () => undefined,
+        identifyOrganizationGroup: () => undefined,
       },
       feature: "templates.test",
       traceId: "trace_test",

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -19,6 +19,7 @@ import { readDecisionWithDocumentHandler } from "@/api/handlers/case-law/decisio
 import { searchDecisionsHandler } from "@/api/handlers/case-law/decisions/search";
 import { parseUsableDocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
+  identifyOrganizationJurisdictions,
   normalizePracticeJurisdictions,
   upsertPracticeJurisdictions,
 } from "@/api/handlers/organization-settings/practice-jurisdictions";
@@ -1978,6 +1979,11 @@ const handleSetPracticeJurisdictionsTool: McpToolHandler = async ({
       tx,
     });
   });
+
+  identifyOrganizationJurisdictions(
+    context.organizationId,
+    practiceJurisdictions,
+  );
 
   return textResult({ practiceJurisdictions } satisfies v.InferInput<
     typeof SET_PRACTICE_JURISDICTIONS_PROJECTION

--- a/apps/web/src/app-providers.tsx
+++ b/apps/web/src/app-providers.tsx
@@ -127,7 +127,10 @@ const AnalyticsAuthIdentity = () => {
       return;
     }
 
-    analytics.identifyUser({ id: authStatus.user.id });
+    analytics.identifyUser({
+      id: authStatus.user.id,
+      activeOrganizationId: authStatus.user.activeOrganizationId,
+    });
   }, [analytics, authStatus]);
 
   return null;

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -166,10 +166,10 @@ describe("PostHog browser analytics adapter", () => {
   });
 
   test("scrubs SDK-stamped resolved URLs from navigation events", () => {
-    const { analytics } = createPostHogAnalytics(
-      "phc_test",
-      "https://posthog.test",
-    );
+    const { analytics } = createPostHogAnalytics({
+      host: "https://posthog.test",
+      key: "phc_test",
+    });
 
     Object.defineProperty(globalThis, "location", {
       configurable: true,
@@ -211,7 +211,7 @@ describe("PostHog browser analytics adapter", () => {
   });
 
   test("drops resolved URLs the route template history cannot map", () => {
-    createPostHogAnalytics("phc_test", "https://posthog.test");
+    createPostHogAnalytics({ host: "https://posthog.test", key: "phc_test" });
 
     const sanitized = initOptions?.before_send({
       event: WEB_ANALYTICS_EVENTS.pageLeft,
@@ -230,7 +230,7 @@ describe("PostHog browser analytics adapter", () => {
   });
 
   test("keeps the route template override on page views while scrubbing SDK context", () => {
-    createPostHogAnalytics("phc_test", "https://posthog.test");
+    createPostHogAnalytics({ host: "https://posthog.test", key: "phc_test" });
 
     const sanitized = initOptions?.before_send({
       event: WEB_ANALYTICS_EVENTS.pageViewed,
@@ -988,10 +988,10 @@ describe("PostHog browser analytics adapter", () => {
   });
 
   test("rebinds the organization group on a same-user organization switch", () => {
-    const { analytics } = createPostHogAnalytics(
-      "phc_test",
-      "https://posthog.test",
-    );
+    const { analytics } = createPostHogAnalytics({
+      host: "https://posthog.test",
+      key: "phc_test",
+    });
 
     analytics.identifyUser({ id: "user_123", activeOrganizationId: "org_1" });
     analytics.identifyUser({ id: "user_123", activeOrganizationId: "org_2" });

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -987,6 +987,22 @@ describe("PostHog browser analytics adapter", () => {
     expect(resetMock).not.toHaveBeenCalled();
   });
 
+  test("rebinds the organization group on a same-user organization switch", () => {
+    const { analytics } = createPostHogAnalytics(
+      "phc_test",
+      "https://posthog.test",
+    );
+
+    analytics.identifyUser({ id: "user_123", activeOrganizationId: "org_1" });
+    analytics.identifyUser({ id: "user_123", activeOrganizationId: "org_2" });
+
+    // The identity guard still suppresses the duplicate identify, but the
+    // group must follow the active organization or later events attribute
+    // to the previous organization across an ownership boundary.
+    expect(identifyMock).toHaveBeenCalledTimes(1);
+    expect(groupMock).toHaveBeenNthCalledWith(2, "organization", "org_2");
+  });
+
   test("resets before identifying a different user", () => {
     const { analytics } = createPostHogAnalytics({
       host: "https://posthog.test",

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -17,6 +17,7 @@ type PostHogInitOptions = {
   ) => CapturedBrowserEvent | null;
   capture_dead_clicks: boolean;
   capture_heatmaps: boolean;
+  capture_pageleave: boolean;
   capture_pageview: boolean;
   capture_performance:
     | boolean
@@ -55,11 +56,13 @@ const resetMock = mock(() => {
   distinctId = "anonymous_after_reset";
   identified = false;
 });
+const groupMock = mock((_type: string, _key: string) => undefined);
 
 const posthogMock = {
   capture: captureMock,
   captureException: captureExceptionMock,
   get_distinct_id: getDistinctIdMock,
+  group: groupMock,
   identify: identifyMock,
   init: initMock,
   _isIdentified: isIdentifiedMock,
@@ -97,6 +100,7 @@ describe("PostHog browser analytics adapter", () => {
     initMock.mockClear();
     registerMock.mockClear();
     resetMock.mockClear();
+    groupMock.mockClear();
   });
 
   test("structurally disables interaction tracking features", () => {
@@ -108,6 +112,7 @@ describe("PostHog browser analytics adapter", () => {
       autocapture: false,
       capture_dead_clicks: false,
       capture_heatmaps: false,
+      capture_pageleave: true,
       capture_pageview: false,
       capture_performance: { network_timing: false, web_vitals: true },
       disable_persistence: true,
@@ -145,15 +150,104 @@ describe("PostHog browser analytics adapter", () => {
       initOptions?.before_send({
         event: WEB_ANALYTICS_EVENTS.identify,
       }),
-    ).toEqual({ event: WEB_ANALYTICS_EVENTS.identify });
+    ).toEqual({ event: WEB_ANALYTICS_EVENTS.identify, properties: {} });
     expect(
       initOptions?.before_send({
         event: WEB_ANALYTICS_EVENTS.pageViewed,
       }),
-    ).toEqual({ event: WEB_ANALYTICS_EVENTS.pageViewed });
+    ).toEqual({ event: WEB_ANALYTICS_EVENTS.pageViewed, properties: {} });
+    expect(
+      initOptions?.before_send({
+        event: WEB_ANALYTICS_EVENTS.pageLeft,
+      }),
+    ).toEqual({ event: WEB_ANALYTICS_EVENTS.pageLeft, properties: {} });
     expect(initOptions?.before_send({ event: "$autocapture" })).toBeNull();
-    expect(initOptions?.before_send({ event: "$pageleave" })).toBeNull();
     expect(initOptions?.before_send({ event: "$heatmap" })).toBeNull();
+  });
+
+  test("scrubs SDK-stamped resolved URLs from navigation events", () => {
+    const { analytics } = createPostHogAnalytics(
+      "phc_test",
+      "https://posthog.test",
+    );
+
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: new URL("https://app.example.test/workspaces/ws_1"),
+    });
+    // Records resolved pathname -> route template in the history the
+    // scrubber maps through.
+    analytics.capturePageViewed({ path: "/workspaces/$workspaceId" });
+
+    const sanitized = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.pageLeft,
+      properties: {
+        $current_url: "https://app.example.test/workspaces/ws_1",
+        $pathname: "/workspaces/ws_1",
+        $host: "app.example.test",
+        $prev_pageview_pathname: "/workspaces/ws_1",
+        $session_entry_url: "https://app.example.test/workspaces/ws_1",
+        $session_entry_pathname: "/workspaces/ws_1",
+        $referrer: "https://app.example.test/workspaces/ws_1",
+        $session_entry_referrer: "https://www.google.com/",
+        $prev_pageview_duration: 12,
+        title: "Client Smith v Example",
+        $session_id: "session-1",
+      },
+    });
+
+    expect(sanitized?.properties).toEqual({
+      $current_url: "https://app.example.test/workspaces/$workspaceId",
+      $pathname: "/workspaces/$workspaceId",
+      $host: "app.example.test",
+      $prev_pageview_pathname: "/workspaces/$workspaceId",
+      $session_entry_url: "https://app.example.test/workspaces/$workspaceId",
+      $session_entry_pathname: "/workspaces/$workspaceId",
+      // Internal referrer dropped; external referrer kept.
+      $session_entry_referrer: "https://www.google.com/",
+      $prev_pageview_duration: 12,
+      $session_id: "session-1",
+    });
+  });
+
+  test("drops resolved URLs the route template history cannot map", () => {
+    createPostHogAnalytics("phc_test", "https://posthog.test");
+
+    const sanitized = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.pageLeft,
+      properties: {
+        $current_url: "https://app.example.test/workspaces/ws_unknown",
+        $pathname: "/workspaces/ws_unknown",
+        $prev_pageview_pathname: "/workspaces/ws_unknown",
+        $session_entry_url: "https://app.example.test/workspaces/ws_unknown",
+        $session_entry_pathname: "/workspaces/ws_unknown",
+        title: "Client Smith v Example",
+        $session_id: "session-1",
+      },
+    });
+
+    expect(sanitized?.properties).toEqual({ $session_id: "session-1" });
+  });
+
+  test("keeps the route template override on page views while scrubbing SDK context", () => {
+    createPostHogAnalytics("phc_test", "https://posthog.test");
+
+    const sanitized = initOptions?.before_send({
+      event: WEB_ANALYTICS_EVENTS.pageViewed,
+      properties: {
+        $current_url: "https://app.example.test/workspaces/$workspaceId",
+        $pathname: "/workspaces/$workspaceId",
+        path: "/workspaces/$workspaceId",
+        $prev_pageview_pathname: "/workspaces/ws_unmapped",
+        title: "Client Smith v Example",
+      },
+    });
+
+    expect(sanitized?.properties).toEqual({
+      $current_url: "https://app.example.test/workspaces/$workspaceId",
+      $pathname: "/workspaces/$workspaceId",
+      path: "/workspaces/$workspaceId",
+    });
   });
 
   test("drops known browser-noise exceptions", () => {
@@ -868,15 +962,16 @@ describe("PostHog browser analytics adapter", () => {
     });
   });
 
-  test("identifies users by stable id without person properties", () => {
+  test("identifies users by stable id and attaches the organization group", () => {
     const { analytics } = createPostHogAnalytics({
       host: "https://posthog.test",
       key: "phc_test",
     });
 
-    analytics.identifyUser({ id: "user_123" });
+    analytics.identifyUser({ id: "user_123", activeOrganizationId: "org_1" });
 
     expect(identifyMock).toHaveBeenCalledWith("user_123");
+    expect(groupMock).toHaveBeenCalledWith("organization", "org_1");
   });
 
   test("identifies the same user only once per browser app session", () => {
@@ -885,8 +980,8 @@ describe("PostHog browser analytics adapter", () => {
       key: "phc_test",
     });
 
-    analytics.identifyUser({ id: "user_123" });
-    analytics.identifyUser({ id: "user_123" });
+    analytics.identifyUser({ id: "user_123", activeOrganizationId: "org_1" });
+    analytics.identifyUser({ id: "user_123", activeOrganizationId: "org_1" });
 
     expect(identifyMock).toHaveBeenCalledTimes(1);
     expect(resetMock).not.toHaveBeenCalled();
@@ -898,11 +993,12 @@ describe("PostHog browser analytics adapter", () => {
       key: "phc_test",
     });
 
-    analytics.identifyUser({ id: "user_123" });
-    analytics.identifyUser({ id: "user_456" });
+    analytics.identifyUser({ id: "user_123", activeOrganizationId: "org_1" });
+    analytics.identifyUser({ id: "user_456", activeOrganizationId: "org_2" });
 
     expect(resetMock).toHaveBeenCalledTimes(1);
     expect(identifyMock).toHaveBeenNthCalledWith(2, "user_456");
+    expect(groupMock).toHaveBeenNthCalledWith(2, "organization", "org_2");
   });
 
   test("reset can be limited to identified sessions", () => {
@@ -915,7 +1011,7 @@ describe("PostHog browser analytics adapter", () => {
 
     expect(resetMock).not.toHaveBeenCalled();
 
-    analytics.identifyUser({ id: "user_123" });
+    analytics.identifyUser({ id: "user_123", activeOrganizationId: "org_1" });
     analytics.reset({ onlyIfIdentified: true });
 
     expect(resetMock).toHaveBeenCalledTimes(1);
@@ -938,9 +1034,9 @@ describe("PostHog browser analytics adapter", () => {
       key: "phc_test",
     });
 
-    analytics.identifyUser({ id: "user_123" });
+    analytics.identifyUser({ id: "user_123", activeOrganizationId: "org_1" });
     analytics.reset();
-    analytics.identifyUser({ id: "user_123" });
+    analytics.identifyUser({ id: "user_123", activeOrganizationId: "org_1" });
 
     expect(resetMock).toHaveBeenCalledTimes(1);
     expect(identifyMock).toHaveBeenCalledTimes(2);

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -635,6 +635,10 @@ export const createPostHogAnalytics = ({
       const distinctId = posthog.get_distinct_id();
 
       if (distinctId === user.id) {
+        // Same person, possibly a fresh active organization (SPA org
+        // switch): rebind the group so later events attribute to the
+        // current organization instead of the one bound at identify.
+        posthog.group(ORGANIZATION_GROUP_TYPE, user.activeOrganizationId);
         return;
       }
 

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -21,6 +21,10 @@ import { logDevError } from "@/lib/errors/utils";
 const isWebAnalyticsEvent = (event: string): event is WebAnalyticsEvent =>
   Object.values(WEB_ANALYTICS_EVENTS).some((value) => value === event);
 
+// PostHog group type for organization-level analytics; must match the
+// server-side capture wrapper's group key.
+const ORGANIZATION_GROUP_TYPE = "organization";
+
 // Browser-noise patterns we drop client-side before they hit
 // PostHog ingest. PostHog has no built-in `ignoreErrors` analogue
 // to Sentry's, so the canonical filter point is `before_send`.
@@ -346,6 +350,101 @@ const sanitizeWebVitalsEvent = (
   };
 };
 
+// The SDK stamps every capture with context from the live location beyond
+// the `$current_url`/`$pathname` pair `capturePageViewed` overrides: the
+// previous page's pathname, the session entry URL, the document title, and
+// referrers. Events whose payloads are not rebuilt from an allowlist
+// (`$pageview`, `$pageleave`, `$identify`, custom events) go through this
+// scrub so resolved resource ids still never leave the browser: each
+// resolved path is rewritten to its recorded route template or dropped.
+//
+// `route-template` marks events whose `$current_url`/`$pathname` already
+// carry the template (our own `$pageview` override); `resolved` events get
+// those fields mapped through the history like every other resolved path.
+type SdkUrlSource = "route-template" | "resolved";
+
+type TemplateUrl = { url: string; pathname: string };
+
+const templateUrl = (
+  history: RouteTemplateHistory,
+  value: unknown,
+): TemplateUrl | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return undefined;
+  }
+  const template = history.get(parsed.pathname);
+  if (template === undefined) {
+    return undefined;
+  }
+  return { url: `${parsed.origin}${template}`, pathname: template };
+};
+
+// Referrers on another host are marketing signal and carry no resource ids;
+// same-host referrers are resolved in-app paths, and `$referring_domain`
+// already covers them.
+const isExternalReferrer = (value: unknown, host: unknown): boolean => {
+  if (typeof value !== "string" || typeof host !== "string") {
+    return false;
+  }
+  try {
+    return new URL(value).host !== host;
+  } catch {
+    return false;
+  }
+};
+
+const sanitizeSdkUrlContext = (
+  event: CaptureResult,
+  history: RouteTemplateHistory,
+  urlSource: SdkUrlSource,
+): CaptureResult => {
+  const properties: Record<string, unknown> = { ...event.properties };
+  // `document.title` can carry document or matter names.
+  delete properties["title"];
+  if (urlSource === "resolved") {
+    const current = templateUrl(history, properties["$current_url"]);
+    delete properties["$current_url"];
+    delete properties["$pathname"];
+    if (current !== undefined) {
+      properties["$current_url"] = current.url;
+      properties["$pathname"] = current.pathname;
+    }
+  }
+  const previousPath = properties["$prev_pageview_pathname"];
+  delete properties["$prev_pageview_pathname"];
+  if (typeof previousPath === "string") {
+    const template = history.get(previousPath);
+    if (template !== undefined) {
+      properties["$prev_pageview_pathname"] = template;
+    }
+  }
+  const entry = templateUrl(history, properties["$session_entry_url"]);
+  delete properties["$session_entry_url"];
+  delete properties["$session_entry_pathname"];
+  if (entry !== undefined) {
+    properties["$session_entry_url"] = entry.url;
+    properties["$session_entry_pathname"] = entry.pathname;
+  }
+  if (!isExternalReferrer(properties["$referrer"], properties["$host"])) {
+    delete properties["$referrer"];
+  }
+  if (
+    !isExternalReferrer(
+      properties["$session_entry_referrer"],
+      properties["$host"],
+    )
+  ) {
+    delete properties["$session_entry_referrer"];
+  }
+  return { ...event, properties };
+};
+
 const errorContextProperties = (
   context: ErrorCaptureContext | undefined,
 ): Record<string, string> | undefined => {
@@ -431,6 +530,10 @@ export const createPostHogAnalytics = ({
     capture_heatmaps: false,
     capture_performance: { network_timing: false, web_vitals: true },
     capture_pageview: false,
+    // The SDK's pageleave is what web analytics derives bounce rate and page
+    // duration from; the default ties it to `capture_pageview`, which stays
+    // off because page views are captured manually with route templates.
+    capture_pageleave: true,
     before_send: (event) => {
       if (import.meta.env.DEV && !localDebugEnabled) {
         return null;
@@ -438,22 +541,28 @@ export const createPostHogAnalytics = ({
       if (!event || !isWebAnalyticsEvent(event.event)) {
         return null;
       }
-      if (
-        event.event === WEB_ANALYTICS_EVENTS.exception &&
-        isNoiseException(event)
-      ) {
-        return null;
+      switch (event.event) {
+        case WEB_ANALYTICS_EVENTS.exception:
+          return isNoiseException(event) ? null : sanitizeExceptionEvent(event);
+        case WEB_ANALYTICS_EVENTS.routeErrorRecovery:
+          return routeErrorLifecycleSanitizer?.(event) ?? null;
+        case WEB_ANALYTICS_EVENTS.webVitals:
+          return sanitizeWebVitalsEvent(event, routeTemplateHistory);
+        case WEB_ANALYTICS_EVENTS.pageViewed:
+          return sanitizeSdkUrlContext(
+            event,
+            routeTemplateHistory,
+            "route-template",
+          );
+        case WEB_ANALYTICS_EVENTS.pageLeft:
+        case WEB_ANALYTICS_EVENTS.identify:
+        case WEB_ANALYTICS_EVENTS.guideStepSkipped:
+          return sanitizeSdkUrlContext(event, routeTemplateHistory, "resolved");
+        default: {
+          const exhaustive: never = event.event;
+          return exhaustive;
+        }
       }
-      if (event.event === WEB_ANALYTICS_EVENTS.exception) {
-        return sanitizeExceptionEvent(event);
-      }
-      if (event.event === WEB_ANALYTICS_EVENTS.routeErrorRecovery) {
-        return routeErrorLifecycleSanitizer?.(event) ?? null;
-      }
-      if (event.event === WEB_ANALYTICS_EVENTS.webVitals) {
-        return sanitizeWebVitalsEvent(event, routeTemplateHistory);
-      }
-      return event;
     },
   });
 
@@ -538,6 +647,9 @@ export const createPostHogAnalytics = ({
       // duplicating them into PostHog person properties adds no analytical
       // value and only widens the person-property surface.
       posthog.identify(user.id);
+      // Group properties (name, practice jurisdictions) are set server-side
+      // via groupIdentify; the browser only attaches the opaque key.
+      posthog.group(ORGANIZATION_GROUP_TYPE, user.activeOrganizationId);
     },
     reset: ({ onlyIfIdentified } = {}) => {
       if (onlyIfIdentified && !posthog._isIdentified()) {

--- a/apps/web/src/lib/analytics/types.ts
+++ b/apps/web/src/lib/analytics/types.ts
@@ -6,6 +6,10 @@ export const WEB_ANALYTICS_EVENTS = {
   // The standard event name, so PostHog web analytics aggregates our page
   // views; the payload still carries route templates, never resolved URLs.
   pageViewed: "$pageview",
+  // SDK-emitted on tab hide and close; web analytics derives bounce rate
+  // and page duration from it. `before_send` maps its resolved URL back to
+  // the route template.
+  pageLeft: "$pageleave",
   // SDK-emitted performance metrics; `before_send` rebuilds the payload so
   // only metric values and coarse client context leave the browser.
   webVitals: "$web_vitals",
@@ -71,4 +75,7 @@ export type RouteErrorLifecycleProperties = RouteErrorLifecycleCommon & {
 
 export type AnalyticsUserIdentity = {
   id: string;
+  // Attached as the `organization` group so insights can aggregate and
+  // break down by organization, not just by person.
+  activeOrganizationId: string;
 };

--- a/deploy/selfhost/.env.example
+++ b/deploy/selfhost/.env.example
@@ -276,10 +276,6 @@ S3_REGION="us-east-1"
 # when using a real project key.
 # POSTHOG_LOCAL_DEBUG="false"
 
-# [internal] Optional with a default. Include raw AI prompts and outputs in
-# local diagnostics. This may expose privileged content.
-# POSTHOG_LOCAL_DEBUG_AI_CONTENT="false"
-
 # [internal] Optional with a default. Debug unredacted errors.
 # DEBUG_UNREDACTED_ERRORS="false"
 

--- a/scripts/env-catalog.ts
+++ b/scripts/env-catalog.ts
@@ -133,7 +133,6 @@ const INTERNAL_SERVER_KEYS = new Set([
   "POSTHOG_HOST",
   "POSTHOG_KEY",
   "POSTHOG_LOCAL_DEBUG",
-  "POSTHOG_LOCAL_DEBUG_AI_CONTENT",
   "PUBLIC_URL",
   "QUERY_EXPANSION_MODE",
   "REQUIRE_PERSONAL_AI_KEY",
@@ -311,8 +310,6 @@ const DESCRIPTION_OVERRIDES: Record<string, string> = {
     'PostHog project key. The placeholder "phc_" disables capture for local development.',
   POSTHOG_LOCAL_DEBUG:
     "Allow PostHog capture from localhost when using a real project key.",
-  POSTHOG_LOCAL_DEBUG_AI_CONTENT:
-    "Include raw AI prompts and outputs in local diagnostics. This may expose privileged content.",
   PUBLIC_URL:
     "Public API origin for verification links and OAuth callbacks. Defaults to BETTER_AUTH_URL.",
   QUERY_EXPANSION_MODE:


### PR DESCRIPTION
- Scrub SDK-stamped resolved URLs (prev pageview pathname, session entry, title, internal referrers) from allowlisted web events; capture `$pageleave` so web analytics gets bounce rate and page duration.
- Attach an `organization` group to client and server events; upsert practice jurisdictions as group properties; add a `jurisdiction` property to AI events (case-law analysis).
- Remove the emitter-less `$ai_span` event and the unread `POSTHOG_LOCAL_DEBUG_AI_CONTENT` env var.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved analytics attribution for active organisations, practice jurisdictions and AI generation activity.
  - Added organisation context to error reporting and usage events.
  - Enabled page-leave tracking and improved navigation URL sanitisation.
  - Analytics now better protects privacy by removing sensitive page context and retaining only relevant external referrers.

- **Configuration**
  - Removed the deprecated local AI content debugging setting from configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->