### PR TITLE
feat(api): organization member designations

### DIFF
--- a/apps/api/drizzle/20260817120000_usage_member_assignment/migration.sql
+++ b/apps/api/drizzle/20260817120000_usage_member_assignment/migration.sql
@@ -1,0 +1,29 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Which members occupy the organisation's purchased seats: assigned
+-- members draw the per-user included budgets, everyone else keeps the
+-- shared-pool path. Manager-managed; bounded by the entitlement's seat
+-- count at write time.
+CREATE TABLE IF NOT EXISTS "usage_seat_assignments" (
+  "id" uuid PRIMARY KEY,
+  "organization_id" varchar(128) NOT NULL REFERENCES "organization" ("id") ON DELETE CASCADE,
+  "user_id" text NOT NULL REFERENCES "user" ("id") ON DELETE CASCADE,
+  "assigned_by_user_id" text REFERENCES "user" ("id") ON DELETE SET NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL
+);--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "usage_seat_assignments_org_user_uidx"
+  ON "usage_seat_assignments" ("organization_id", "user_id");--> statement-breakpoint
+
+ALTER TABLE "usage_seat_assignments" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+
+CREATE POLICY "usage_seat_assignments_select" ON "usage_seat_assignments" AS PERMISSIVE FOR SELECT TO "stella" USING (organization_id = (SELECT current_setting('app.organization_id', true)));--> statement-breakpoint
+
+CREATE POLICY "usage_seat_assignments_insert" ON "usage_seat_assignments" AS PERMISSIVE FOR INSERT TO "stella" WITH CHECK (organization_id = (SELECT current_setting('app.organization_id', true)));--> statement-breakpoint
+
+CREATE POLICY "usage_seat_assignments_delete" ON "usage_seat_assignments" AS PERMISSIVE FOR DELETE TO "stella" USING (organization_id = (SELECT current_setting('app.organization_id', true)));--> statement-breakpoint
+
+CREATE POLICY "usage_seat_assignments_no_update" ON "usage_seat_assignments" AS RESTRICTIVE FOR UPDATE TO "stella" USING (false);--> statement-breakpoint
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "usage_seat_assignments" TO stella;

--- a/apps/api/drizzle/20260817120000_usage_member_assignment/migration.sql
+++ b/apps/api/drizzle/20260817120000_usage_member_assignment/migration.sql
@@ -1,16 +1,28 @@
 SET lock_timeout = '1s';--> statement-breakpoint
 SET statement_timeout = '5s';--> statement-breakpoint
 
+-- One membership per user per organization (the auth layer already
+-- guarantees this); makes the membership referenceable so dependent
+-- rows can cascade with it. "member" stays small, so an in-transaction
+-- build under the 1s lock_timeout is safe.
+-- squawk-ignore require-concurrent-index-creation
+CREATE UNIQUE INDEX IF NOT EXISTS "member_organization_id_user_id_uidx"
+  ON "member" ("organization_id", "user_id");--> statement-breakpoint
+
 -- Which members occupy the organisation's purchased seats: assigned
 -- members draw the per-user included budgets, everyone else keeps the
 -- shared-pool path. Manager-managed; bounded by the entitlement's seat
--- count at write time.
+-- count at write time. Bound to the membership (not the account) so
+-- removing a member removes the designation with it.
 CREATE TABLE IF NOT EXISTS "usage_seat_assignments" (
   "id" uuid PRIMARY KEY,
   "organization_id" varchar(128) NOT NULL REFERENCES "organization" ("id") ON DELETE CASCADE,
-  "user_id" text NOT NULL REFERENCES "user" ("id") ON DELETE CASCADE,
+  "user_id" text NOT NULL,
   "assigned_by_user_id" text REFERENCES "user" ("id") ON DELETE SET NULL,
-  "created_at" timestamptz DEFAULT now() NOT NULL
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "usage_seat_assignments_member_fk"
+    FOREIGN KEY ("organization_id", "user_id")
+    REFERENCES "member" ("organization_id", "user_id") ON DELETE CASCADE
 );--> statement-breakpoint
 
 CREATE UNIQUE INDEX IF NOT EXISTS "usage_seat_assignments_org_user_uidx"

--- a/apps/api/src/db/auth-schema.ts
+++ b/apps/api/src/db/auth-schema.ts
@@ -238,6 +238,13 @@ export const member = pgTable(
     index("member_organizationId_idx").on(table.organizationId),
     index("member_userId_idx").on(table.userId),
     index("member_lastActiveWorkspaceId_idx").on(table.lastActiveWorkspaceId),
+    // One membership per user per organization (the auth layer already
+    // guarantees this; the index makes it referenceable so dependent
+    // rows can bind to the membership and cascade with it).
+    uniqueIndex("member_organization_id_user_id_uidx").on(
+      table.organizationId,
+      table.userId,
+    ),
     ...authMemberPolicies(),
   ],
 );

--- a/apps/api/src/db/schema/common.ts
+++ b/apps/api/src/db/schema/common.ts
@@ -19,7 +19,7 @@ import type { CountryCode } from "@stll/country-codes";
 import type { PersistedDecisionAnalysis } from "@stll/legal-ast/analysis";
 import type { DocumentAst } from "@stll/legal-ast/document-ast";
 
-import { organization, user } from "@/api/db/auth-schema";
+import { member, organization, user } from "@/api/db/auth-schema";
 import { jsonb, timestamptz } from "@/api/db/columns";
 import {
   agentSkillPolicies,
@@ -448,6 +448,7 @@ export {
   isNotNull,
   isNull,
   jsonb,
+  member,
   organization,
   p,
   panic,

--- a/apps/api/src/db/schema/usage.ts
+++ b/apps/api/src/db/schema/usage.ts
@@ -1,6 +1,7 @@
 import {
   DESTRUCTIVE_EFFECT_CHUNK_STATUSES,
   jsonb,
+  member,
   organization,
   organizationCheck,
   p,
@@ -616,10 +617,7 @@ export const usageSeatAssignments = p.pgTable(
     organizationId: safeOrganizationId("organization_id")
       .notNull()
       .references(() => organization.id, { onDelete: "cascade" }),
-    userId: p
-      .text("user_id")
-      .notNull()
-      .references(() => user.id, { onDelete: "cascade" }),
+    userId: p.text("user_id").notNull(),
     assignedByUserId: p
       .text("assigned_by_user_id")
       .references(() => user.id, { onDelete: "set null" }),
@@ -629,6 +627,17 @@ export const usageSeatAssignments = p.pgTable(
     p
       .uniqueIndex("usage_seat_assignments_org_user_uidx")
       .on(table.organizationId, table.userId),
+    // Bound to the membership, not the account: removing a member from
+    // the organization removes the designation with it, so an orphan
+    // can neither hold capacity nor silently restore budgets on
+    // re-invite.
+    p
+      .foreignKey({
+        columns: [table.organizationId, table.userId],
+        foreignColumns: [member.organizationId, member.userId],
+        name: "usage_seat_assignments_member_fk",
+      })
+      .onDelete("cascade"),
     // Reads for any member (the lane decision runs for every user);
     // writes stay manager-gated at the handler layer on top of the
     // org check.

--- a/apps/api/src/db/schema/usage.ts
+++ b/apps/api/src/db/schema/usage.ts
@@ -603,6 +603,59 @@ export const usageEvents = p.pgTable(
  * `usage_events`. Buckets are UTC-aligned; a new bucket row starts the
  * count at zero, which is the reset.
  */
+/**
+ * Which members occupy the organisation's purchased seats. Only
+ * assigned members draw the per-user included budgets; everyone else
+ * keeps the shared-pool path. Assignment is manager-managed and
+ * bounded by the entitlement's seat count at write time.
+ */
+export const usageSeatAssignments = p.pgTable(
+  "usage_seat_assignments",
+  {
+    id: pUuid<"usageSeatAssignment">().primaryKey(),
+    organizationId: safeOrganizationId("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    userId: p
+      .text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    assignedByUserId: p
+      .text("assigned_by_user_id")
+      .references(() => user.id, { onDelete: "set null" }),
+    createdAt: timestamptz("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    p
+      .uniqueIndex("usage_seat_assignments_org_user_uidx")
+      .on(table.organizationId, table.userId),
+    // Reads for any member (the lane decision runs for every user);
+    // writes stay manager-gated at the handler layer on top of the
+    // org check.
+    p.pgPolicy("usage_seat_assignments_select", {
+      for: "select",
+      to: stella,
+      using: organizationCheck,
+    }),
+    p.pgPolicy("usage_seat_assignments_insert", {
+      for: "insert",
+      to: stella,
+      withCheck: organizationCheck,
+    }),
+    p.pgPolicy("usage_seat_assignments_delete", {
+      for: "delete",
+      to: stella,
+      using: organizationCheck,
+    }),
+    p.pgPolicy("usage_seat_assignments_no_update", {
+      as: "restrictive",
+      for: "update",
+      to: stella,
+      using: sql`false`,
+    }),
+  ],
+);
+
 export const usageLaneCounters = p.pgTable(
   "usage_lane_counters",
   {

--- a/apps/api/src/handlers/hosted-usage-webhook/dispatch.test.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/dispatch.test.ts
@@ -589,13 +589,13 @@ describe("dispatch — handleHostedEntitlementUpsert", () => {
       const designated = [fx.memberUserId];
       for (const _extra of [1, 2]) {
         const extraUserId = `user_${Bun.randomUUIDv7()}`;
-        // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop, no-await-in-loop -- two sequential seed rows in a test fixture
+        // oxlint-disable-next-line no-await-in-loop -- two sequential seed rows in a test fixture
         await tx.insert(user).values({
           id: extraUserId,
           name: "Extra Member",
           email: `${extraUserId}@test.local`,
         });
-        // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop, no-await-in-loop -- see above
+        // oxlint-disable-next-line no-await-in-loop -- see above
         await tx.insert(member).values({
           id: `member_${Bun.randomUUIDv7()}`,
           organizationId: fx.organizationId,

--- a/apps/api/src/handlers/hosted-usage-webhook/dispatch.test.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/dispatch.test.ts
@@ -574,6 +574,58 @@ describe("dispatch — handleHostedEntitlementUpsert", () => {
     });
   });
 
+  test("shrinking the quantity trims the roster to the oldest designations", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+      await handleHostedEntitlementUpsert({
+        tx,
+        payload: buildEntitlementPayload(fx),
+        eventId: "evt_shrink_create",
+      });
+
+      // Three designated members with distinct designation times; the
+      // handler-side default (now()) is the transaction timestamp, so
+      // explicit stamps are what make keep-oldest observable.
+      const designated = [fx.memberUserId];
+      for (const _extra of [1, 2]) {
+        const extraUserId = `user_${Bun.randomUUIDv7()}`;
+        // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop, no-await-in-loop -- two sequential seed rows in a test fixture
+        await tx.insert(user).values({
+          id: extraUserId,
+          name: "Extra Member",
+          email: `${extraUserId}@test.local`,
+        });
+        // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop, no-await-in-loop -- see above
+        await tx.insert(member).values({
+          id: `member_${Bun.randomUUIDv7()}`,
+          organizationId: fx.organizationId,
+          userId: extraUserId,
+          role: "member",
+          createdAt: PERIOD_START,
+        });
+        designated.push(extraUserId);
+      }
+      await tx.insert(usageSeatAssignments).values(
+        designated.map((userId, index) => ({
+          organizationId: fx.organizationId,
+          userId,
+          createdAt: new Date(PERIOD_START.getTime() + index * 3_600_000),
+        })),
+      );
+
+      const outcome = await handleHostedEntitlementUpsert({
+        tx,
+        payload: buildEntitlementPayload(fx, { quantity: 1 }),
+        eventId: "evt_shrink_update",
+      });
+      expect(outcome.kind).toBe("applied");
+      // Only the earliest designation survives a shrink to one.
+      expect(await readSeatAssignments(tx, fx)).toEqual([
+        { userId: fx.memberUserId },
+      ]);
+    });
+  });
+
   test("a seat_user_id outside the organization seats nobody", async () => {
     await withRolledBackTx(async (tx) => {
       const fx = await setupFixture(tx);

--- a/apps/api/src/handlers/hosted-usage-webhook/dispatch.test.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/dispatch.test.ts
@@ -8,9 +8,13 @@ import {
 } from "bun:test";
 import { eq, TransactionRollbackError } from "drizzle-orm";
 
-import { organization, user } from "@/api/db/auth-schema";
+import { member, organization, user } from "@/api/db/auth-schema";
 import type { Transaction } from "@/api/db/root";
-import { usageEntitlements, usagePolicies } from "@/api/db/schema";
+import {
+  usageEntitlements,
+  usagePolicies,
+  usageSeatAssignments,
+} from "@/api/db/schema";
 import {
   handleHostedAllocation,
   handleUsageEntitlementStatusChange,
@@ -46,6 +50,8 @@ const NEXT_PERIOD_END = new Date("2026-09-01T00:00:00.000Z");
 
 type Fixture = {
   organizationId: SafeId<"organization">;
+  /** A member of the fixture organization: a valid seat_user_id. */
+  memberUserId: string;
   usagePolicyId: SafeId<"usagePolicy">;
   hostedPolicyRef: string;
   hostedAddonPolicyRef: string;
@@ -69,6 +75,13 @@ const setupFixture = async (tx: Transaction): Promise<Fixture> => {
     id: userId,
     name: "Test User",
     email: `${userId}@test.local`,
+  });
+  await tx.insert(member).values({
+    id: `member_${Bun.randomUUIDv7()}`,
+    organizationId,
+    userId,
+    role: "owner",
+    createdAt: PERIOD_START,
   });
 
   const inserted = await tx
@@ -95,6 +108,7 @@ const setupFixture = async (tx: Transaction): Promise<Fixture> => {
 
   return {
     organizationId,
+    memberUserId: userId,
     usagePolicyId,
     hostedPolicyRef,
     hostedAddonPolicyRef,
@@ -148,6 +162,12 @@ const buildAllocationPayload = (
   metadata: { organization_id: fx.organizationId },
   ...overrides,
 });
+
+const readSeatAssignments = async (tx: Transaction, fx: Fixture) =>
+  await tx
+    .select({ userId: usageSeatAssignments.userId })
+    .from(usageSeatAssignments)
+    .where(eq(usageSeatAssignments.organizationId, fx.organizationId));
 
 describe("dispatch — handleHostedEntitlementUpsert", () => {
   test("creates entitlement and allocates policy units by seat count on a fresh event", async () => {
@@ -517,6 +537,67 @@ describe("dispatch — handleHostedEntitlementUpsert", () => {
         asOf: new Date(PERIOD_START.getTime() + 1000),
       });
       expect(balance).toBe(0);
+    });
+  });
+
+  test("a fresh entitlement seats the metadata seat_user_id exactly once", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+      const payload = buildEntitlementPayload(fx, {
+        metadata: {
+          organization_id: fx.organizationId,
+          seat_user_id: fx.memberUserId,
+        },
+      });
+
+      const created = await handleHostedEntitlementUpsert({
+        tx,
+        payload,
+        eventId: "evt_seat_scope_create",
+      });
+      expect(created.kind).toBe("applied");
+      expect(await readSeatAssignments(tx, fx)).toEqual([
+        { userId: fx.memberUserId },
+      ]);
+
+      // A re-delivery carries the same seat metadata; the purchaser must
+      // occupy one seat, not one per webhook delivery.
+      const redelivery = await handleHostedEntitlementUpsert({
+        tx,
+        payload,
+        eventId: "evt_seat_scope_redelivery",
+      });
+      expect(redelivery.kind).toBe("applied");
+      expect(await readSeatAssignments(tx, fx)).toEqual([
+        { userId: fx.memberUserId },
+      ]);
+    });
+  });
+
+  test("a seat_user_id outside the organization seats nobody", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+      // A real user row that is not a member here: membership, not the
+      // foreign key, has to be what rejects the value.
+      const outsiderUserId = `user_${Bun.randomUUIDv7()}`;
+      await tx.insert(user).values({
+        id: outsiderUserId,
+        name: "Outsider",
+        email: `${outsiderUserId}@test.local`,
+      });
+
+      const outcome = await handleHostedEntitlementUpsert({
+        tx,
+        payload: buildEntitlementPayload(fx, {
+          metadata: {
+            organization_id: fx.organizationId,
+            seat_user_id: outsiderUserId,
+          },
+        }),
+        eventId: "evt_seat_scope_outsider",
+      });
+      expect(outcome.kind).toBe("applied");
+      expect(await readSeatAssignments(tx, fx)).toEqual([]);
     });
   });
 });

--- a/apps/api/src/handlers/hosted-usage-webhook/dispatch.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/dispatch.ts
@@ -32,6 +32,10 @@ import type {
 } from "@/api/lib/hosted-usage-provider/event-schemas";
 import { recordWebhookAuditEvent } from "@/api/lib/hosted-usage-provider/webhook-store";
 import { parseExternalOrganizationId } from "@/api/lib/safe-id-boundaries";
+import {
+  lockAssignmentCapacity,
+  trimAssignmentsToCapacity,
+} from "@/api/lib/usage/assignment-capacity";
 import { allocateUsage } from "@/api/lib/usage/usage-ledger";
 
 export type DispatchOutcome =
@@ -484,6 +488,32 @@ export const handleHostedEntitlementUpsert = async ({
       }
       entitlementId = insertedId;
     }
+  }
+
+  // Capacity may have shrunk: drop designations beyond the recorded
+  // count, keeping the earliest-designated members, under the same
+  // per-organization lock the designation endpoints take so a racing
+  // designation cannot slip past the new bound.
+  await lockAssignmentCapacity(tx, ownerOrganizationId);
+  const trimmedAssignments = await trimAssignmentsToCapacity(
+    tx,
+    ownerOrganizationId,
+    seats,
+  );
+  if (trimmedAssignments > 0) {
+    await recordWebhookAuditEvent({
+      tx,
+      organizationId: ownerOrganizationId,
+      action: AUDIT_ACTION.UPDATE,
+      resourceType: AUDIT_RESOURCE_TYPE.ORGANIZATION_SETTINGS,
+      resourceId: ownerOrganizationId,
+      eventId,
+      changes: {
+        field: { old: null, new: "usageAssignment" },
+        removed: { old: null, new: trimmedAssignments },
+        seats: { old: null, new: seats },
+      },
+    });
   }
 
   // Allocate the period's usage units. Idempotent per entitlement period,

--- a/apps/api/src/handlers/hosted-usage-webhook/dispatch.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/dispatch.ts
@@ -18,7 +18,11 @@ import { and, eq } from "drizzle-orm";
 
 import { member } from "@/api/db/auth-schema";
 import type { Transaction } from "@/api/db/root";
-import { usagePolicies, usageEntitlements } from "@/api/db/schema";
+import {
+  usagePolicies,
+  usageEntitlements,
+  usageSeatAssignments,
+} from "@/api/db/schema";
 import type { UsageEntitlementStatus, UsagePolicyKind } from "@/api/db/schema";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -458,6 +462,26 @@ export const handleHostedEntitlementUpsert = async ({
         resourceId: insertedId,
         eventId,
       });
+      // First activation: assign the purchasing member to a seat so
+      // the per-user budgets work immediately; further assignments are
+      // manager-managed. Membership is validated the same way the
+      // add-on attribution is; a stale value simply assigns nobody.
+      const purchaserUserId = await resolveSeatScopeUserId(
+        tx,
+        organizationId,
+        payload.metadata?.seat_user_id,
+      );
+      if (purchaserUserId !== null) {
+        await tx
+          .insert(usageSeatAssignments)
+          .values({ organizationId, userId: purchaserUserId })
+          .onConflictDoNothing({
+            target: [
+              usageSeatAssignments.organizationId,
+              usageSeatAssignments.userId,
+            ],
+          });
+      }
       entitlementId = insertedId;
     }
   }

--- a/apps/api/src/handlers/usage/assign-seat.db.test.ts
+++ b/apps/api/src/handlers/usage/assign-seat.db.test.ts
@@ -7,8 +7,9 @@ import {
   setDefaultTimeout,
   test,
 } from "bun:test";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
+import { member, user } from "@/api/db/auth-schema";
 import type { SafeDb } from "@/api/db/safe-db";
 import {
   usageEntitlements,
@@ -142,5 +143,35 @@ describe("assign-seat capacity", () => {
 
     expect(result).toEqual({ assigned: true });
     expect(await assignedUserIds()).toEqual([ids.userA2]);
+  });
+
+  test("removing the membership removes the designation and frees the seat", async () => {
+    // Throwaway member so deleting the membership cannot disturb the
+    // shared fixture rows other tests rely on.
+    const leaverId = `user_${Bun.randomUUIDv7()}`;
+    await testDb.insert(user).values({
+      id: leaverId,
+      name: "Leaver",
+      email: `${leaverId}@test.local`,
+    });
+    await testDb.insert(member).values({
+      id: `member_${Bun.randomUUIDv7()}`,
+      organizationId: ids.orgA,
+      userId: leaverId,
+      role: "member",
+      createdAt: new Date(),
+    });
+    await assignSeat.handler(assignContextFor(leaverId));
+    expect(await assignedUserIds()).toEqual([leaverId]);
+
+    await testDb
+      .delete(member)
+      .where(
+        and(eq(member.organizationId, ids.orgA), eq(member.userId, leaverId)),
+      );
+
+    expect(await assignedUserIds()).toEqual([]);
+    const result = await assignSeat.handler(assignContextFor(ids.userA2));
+    expect(result).toEqual({ assigned: true });
   });
 });

--- a/apps/api/src/handlers/usage/assign-seat.db.test.ts
+++ b/apps/api/src/handlers/usage/assign-seat.db.test.ts
@@ -1,0 +1,146 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { eq } from "drizzle-orm";
+
+import type { SafeDb } from "@/api/db/safe-db";
+import {
+  usageEntitlements,
+  usagePolicies,
+  usageSeatAssignments,
+} from "@/api/db/schema";
+import { createSafeDb } from "@/api/db/scoped";
+import { toSafeId } from "@/api/lib/branded-types";
+import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import {
+  createTestIds,
+  setupRlsTestData,
+} from "@/api/tests/security/rls-helpers";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+import assignSeat from "./assign-seat";
+import unassignSeat from "./unassign-seat";
+
+setDefaultTimeout(120_000);
+
+const DAY_MS = 86_400_000;
+const PERIOD_START = new Date(Date.now() - 10 * DAY_MS);
+const PERIOD_END = new Date(Date.now() + 20 * DAY_MS);
+/** One purchased seat: the capacity boundary sits between two members. */
+const SEATS = 1;
+
+let testDb: TestDatabase;
+let ids: TestIds;
+
+beforeAll(async () => {
+  testDb = await getTestDb();
+  ids = createTestIds();
+  await setupRlsTestData(testDb, ids);
+
+  const policyId = toSafeId<"usagePolicy">(Bun.randomUUIDv7());
+  await testDb.insert(usagePolicies).values({
+    id: policyId,
+    policyKey: `test_policy_${Bun.randomUUIDv7()}`,
+    displayName: "Test policy",
+    monthlyUsageUnits: 1000,
+  });
+  await testDb.insert(usageEntitlements).values({
+    id: toSafeId<"usageEntitlement">(Bun.randomUUIDv7()),
+    organizationId: ids.orgA,
+    usagePolicyId: policyId,
+    status: "active",
+    seats: SEATS,
+    currentPeriodStart: PERIOD_START,
+    currentPeriodEnd: PERIOD_END,
+    source: "manual",
+  });
+});
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+// The handler persists; each case starts from an empty seat roster so
+// capacity is decided by the case's own assignments.
+beforeEach(async () => {
+  await testDb
+    .delete(usageSeatAssignments)
+    .where(eq(usageSeatAssignments.organizationId, ids.orgA));
+});
+
+type AssignSeatCtx = Parameters<typeof assignSeat.handler>[0];
+type UnassignSeatCtx = Parameters<typeof unassignSeat.handler>[0];
+
+const contextOverridesFor = (userId: string) => ({
+  body: { userId },
+  session: { activeOrganizationId: ids.orgA },
+  user: { id: ids.userAdmin },
+  safeDb: asTestRaw<SafeDb>(createSafeDb(testDb, [], ids.orgA, ids.userAdmin)),
+});
+
+const assignContextFor = (userId: string): AssignSeatCtx =>
+  createTestHandlerContext<AssignSeatCtx>(contextOverridesFor(userId));
+
+const unassignContextFor = (userId: string): UnassignSeatCtx =>
+  createTestHandlerContext<UnassignSeatCtx>(contextOverridesFor(userId));
+
+const assignedUserIds = async () => {
+  const rows = await testDb
+    .select({ userId: usageSeatAssignments.userId })
+    .from(usageSeatAssignments)
+    .where(eq(usageSeatAssignments.organizationId, ids.orgA));
+  return rows.map((row) => row.userId);
+};
+
+const CAPACITY_REJECTION = {
+  code: 409,
+  response: { message: "All included per-user limits are assigned" },
+} as const;
+
+describe("assign-seat capacity", () => {
+  test("assigns a member while the entitlement has a free seat", async () => {
+    const result = await assignSeat.handler(assignContextFor(ids.userA1));
+
+    expect(result).toEqual({ assigned: true });
+    expect(await assignedUserIds()).toEqual([ids.userA1]);
+  });
+
+  test("refuses the assignment that would exceed the entitlement's seats", async () => {
+    await assignSeat.handler(assignContextFor(ids.userA1));
+
+    const result = await assignSeat.handler(assignContextFor(ids.userA2));
+
+    expect(result).toMatchObject(CAPACITY_REJECTION);
+    expect(await assignedUserIds()).toEqual([ids.userA1]);
+  });
+
+  test("re-assigning an already seated member succeeds without taking a second seat", async () => {
+    await assignSeat.handler(assignContextFor(ids.userA1));
+
+    // Idempotence matters at the boundary: a retry on the last seat must
+    // not read its own row as the seat that fills the plan.
+    const result = await assignSeat.handler(assignContextFor(ids.userA1));
+
+    expect(result).toEqual({ assigned: true });
+    expect(await assignedUserIds()).toEqual([ids.userA1]);
+  });
+
+  test("unassigning releases the seat for another member", async () => {
+    await assignSeat.handler(assignContextFor(ids.userA1));
+    await unassignSeat.handler(unassignContextFor(ids.userA1));
+
+    const result = await assignSeat.handler(assignContextFor(ids.userA2));
+
+    expect(result).toEqual({ assigned: true });
+    expect(await assignedUserIds()).toEqual([ids.userA2]);
+  });
+});

--- a/apps/api/src/handlers/usage/assign-seat.ts
+++ b/apps/api/src/handlers/usage/assign-seat.ts
@@ -1,0 +1,171 @@
+import { Result } from "better-result";
+import { and, count, eq, sql } from "drizzle-orm";
+import { t } from "elysia";
+
+import { member } from "@/api/db/auth-schema";
+import { usageEntitlements, usageSeatAssignments } from "@/api/db/schema";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import { tUserId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+/**
+ * Assign a member to one of the organisation's per-user included
+ * limits. The count is bounded by the entitlement's capacity inside
+ * the same transaction, so concurrent assigns cannot exceed it past
+ * the last free slot.
+ */
+
+/**
+ * Namespace for the per-organization assignment-capacity lock.
+ * `pg_advisory_xact_lock` keys collide across unrelated advisory
+ * locks; the org-id hash is the second key. Row locks are not an
+ * option here: RLS restrictive `no_update` policies on
+ * `usage_entitlements` and `usage_seat_assignments` filter rows out
+ * of `SELECT ... FOR UPDATE` for the app role.
+ */
+const SEAT_CAPACITY_LOCK_NAMESPACE = 0x5e_a7_ca_9a;
+
+const config = {
+  permissions: { organizationSettings: ["update"] },
+  mcp: { type: "internal", reason: "hosted_billing" },
+  body: t.Object({
+    userId: tUserId,
+  }),
+} satisfies HandlerConfig;
+
+const assignSeat = createSafeRootHandler(
+  config,
+  async function* ({ body, session, safeDb, user, recordAuditEvent }) {
+    const outcome = yield* Result.await(
+      safeDb(async (tx) => {
+        const memberRows = await tx
+          .select({ userId: member.userId })
+          .from(member)
+          .where(
+            and(
+              eq(member.organizationId, session.activeOrganizationId),
+              eq(member.userId, body.userId),
+            ),
+          )
+          .limit(1);
+        if (memberRows.at(0) === undefined) {
+          return { kind: "not_a_member" as const };
+        }
+
+        // Serialize concurrent assigns per organization so two
+        // requests cannot both observe the last free slot.
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(${SEAT_CAPACITY_LOCK_NAMESPACE}, hashtext(${session.activeOrganizationId}))`,
+        );
+
+        const entitlementRows = await tx
+          .select({ seats: usageEntitlements.seats })
+          .from(usageEntitlements)
+          .where(
+            eq(usageEntitlements.organizationId, session.activeOrganizationId),
+          )
+          .limit(1);
+        const entitlement = entitlementRows.at(0);
+        if (!entitlement) {
+          return { kind: "no_entitlement" as const };
+        }
+
+        // Idempotent re-assign must succeed even when the plan is full,
+        // so check for an existing row before enforcing capacity.
+        const existingRows = await tx
+          .select({ id: usageSeatAssignments.id })
+          .from(usageSeatAssignments)
+          .where(
+            and(
+              eq(
+                usageSeatAssignments.organizationId,
+                session.activeOrganizationId,
+              ),
+              eq(usageSeatAssignments.userId, body.userId),
+            ),
+          )
+          .limit(1);
+        if (existingRows.at(0)) {
+          return { kind: "already_assigned" as const };
+        }
+
+        const assignedRows = await tx
+          .select({ value: count() })
+          .from(usageSeatAssignments)
+          .where(
+            eq(
+              usageSeatAssignments.organizationId,
+              session.activeOrganizationId,
+            ),
+          );
+        const assigned = assignedRows.at(0)?.value ?? 0;
+        if (assigned >= entitlement.seats) {
+          return { kind: "capacity_reached" as const };
+        }
+
+        const inserted = await tx
+          .insert(usageSeatAssignments)
+          .values({
+            organizationId: session.activeOrganizationId,
+            userId: body.userId,
+            assignedByUserId: user.id,
+          })
+          .onConflictDoNothing({
+            target: [
+              usageSeatAssignments.organizationId,
+              usageSeatAssignments.userId,
+            ],
+          })
+          .returning({ id: usageSeatAssignments.id });
+        if (inserted.at(0) === undefined) {
+          return { kind: "already_assigned" as const };
+        }
+
+        await recordAuditEvent(tx, {
+          action: AUDIT_ACTION.CREATE,
+          resourceType: AUDIT_RESOURCE_TYPE.ORGANIZATION_SETTINGS,
+          resourceId: session.activeOrganizationId,
+          metadata: {
+            field: "usageAssignment",
+            userId: body.userId,
+          },
+        });
+        return { kind: "assigned" as const };
+      }),
+    );
+
+    switch (outcome.kind) {
+      case "not_a_member":
+        return Result.err(
+          new HandlerError({
+            status: 404,
+            message: "User is not a member of this organization",
+          }),
+        );
+      case "no_entitlement":
+        return Result.err(
+          new HandlerError({
+            status: 409,
+            message: "No active plan to assign against",
+          }),
+        );
+      case "capacity_reached":
+        return Result.err(
+          new HandlerError({
+            status: 409,
+            message: "All included per-user limits are assigned",
+          }),
+        );
+      case "assigned":
+      case "already_assigned":
+        return Result.ok({ assigned: true });
+      default:
+        outcome satisfies never;
+        return Result.ok({ assigned: true });
+    }
+  },
+);
+
+export default assignSeat;

--- a/apps/api/src/handlers/usage/assign-seat.ts
+++ b/apps/api/src/handlers/usage/assign-seat.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, count, eq, sql } from "drizzle-orm";
+import { and, count, eq } from "drizzle-orm";
 import { t } from "elysia";
 
 import { member } from "@/api/db/auth-schema";
@@ -9,6 +9,7 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { tUserId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { lockAssignmentCapacity } from "@/api/lib/usage/assignment-capacity";
 
 /**
  * Assign a member to one of the organisation's per-user included
@@ -16,16 +17,6 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
  * the same transaction, so concurrent assigns cannot exceed it past
  * the last free slot.
  */
-
-/**
- * Namespace for the per-organization assignment-capacity lock.
- * `pg_advisory_xact_lock` keys collide across unrelated advisory
- * locks; the org-id hash is the second key. Row locks are not an
- * option here: RLS restrictive `no_update` policies on
- * `usage_entitlements` and `usage_seat_assignments` filter rows out
- * of `SELECT ... FOR UPDATE` for the app role.
- */
-const SEAT_CAPACITY_LOCK_NAMESPACE = 0x5e_a7_ca_9a;
 
 const config = {
   permissions: { organizationSettings: ["update"] },
@@ -54,11 +45,9 @@ const assignSeat = createSafeRootHandler(
           return { kind: "not_a_member" as const };
         }
 
-        // Serialize concurrent assigns per organization so two
+        // Serialize concurrent roster writes per organization so two
         // requests cannot both observe the last free slot.
-        await tx.execute(
-          sql`select pg_advisory_xact_lock(${SEAT_CAPACITY_LOCK_NAMESPACE}, hashtext(${session.activeOrganizationId}))`,
-        );
+        await lockAssignmentCapacity(tx, session.activeOrganizationId);
 
         const entitlementRows = await tx
           .select({ seats: usageEntitlements.seats })

--- a/apps/api/src/handlers/usage/list-seat-assignments.ts
+++ b/apps/api/src/handlers/usage/list-seat-assignments.ts
@@ -1,0 +1,66 @@
+import { Result } from "better-result";
+import { asc, eq } from "drizzle-orm";
+
+import { usageEntitlements, usageSeatAssignments } from "@/api/db/schema";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { LIMITS } from "@/api/lib/limits";
+
+/**
+ * List which members currently draw the per-user included budgets,
+ * alongside the entitlement's capacity. Bounded by the seat count, so
+ * a plain list (no cursor envelope) matches the catalog precedent.
+ */
+
+const config = {
+  description:
+    "List the members assigned to the organization's per-user included " +
+    "limits, with the total capacity. Requires organization-settings " +
+    "management access.",
+  permissions: { organizationSettings: ["update"] },
+  access: "read",
+  mcp: { type: "internal", reason: "hosted_billing" },
+} satisfies HandlerConfig;
+
+const listSeatAssignments = createSafeRootHandler(
+  config,
+  async function* ({ session, safeDb }) {
+    const result = yield* Result.await(
+      safeDb(async (tx) => {
+        const entitlementRows = await tx
+          .select({ seats: usageEntitlements.seats })
+          .from(usageEntitlements)
+          .where(
+            eq(usageEntitlements.organizationId, session.activeOrganizationId),
+          )
+          .limit(1);
+        const assignments = await tx
+          .select({
+            id: usageSeatAssignments.id,
+            userId: usageSeatAssignments.userId,
+            createdAt: usageSeatAssignments.createdAt,
+          })
+          .from(usageSeatAssignments)
+          .where(
+            eq(
+              usageSeatAssignments.organizationId,
+              session.activeOrganizationId,
+            ),
+          )
+          .orderBy(asc(usageSeatAssignments.createdAt))
+          .limit(LIMITS.usageAssignmentsMax);
+        return {
+          seats: entitlementRows.at(0)?.seats ?? null,
+          assignments: assignments.map((assignment) => ({
+            id: assignment.id,
+            userId: assignment.userId,
+            createdAt: assignment.createdAt.toISOString(),
+          })),
+        };
+      }),
+    );
+    return Result.ok(result);
+  },
+);
+
+export default listSeatAssignments;

--- a/apps/api/src/handlers/usage/routes.ts
+++ b/apps/api/src/handlers/usage/routes.ts
@@ -1,10 +1,13 @@
 import Elysia from "elysia";
 
+import assignSeat from "@/api/handlers/usage/assign-seat";
 import createHostedManagement from "@/api/handlers/usage/create-hosted-management";
 import createHostedSetup from "@/api/handlers/usage/create-hosted-setup";
 import getEntitlement from "@/api/handlers/usage/get-entitlement";
 import getLane from "@/api/handlers/usage/get-lane";
 import listPolicies from "@/api/handlers/usage/list-policies";
+import listSeatAssignments from "@/api/handlers/usage/list-seat-assignments";
+import unassignSeat from "@/api/handlers/usage/unassign-seat";
 import { authMacro, permissionMacro } from "@/api/lib/auth";
 
 // Operator-driven admin endpoints (manual entitlement upsert,
@@ -27,6 +30,17 @@ export const usageRoute = new Elysia({ prefix: "/usage" })
   })
   .get("/policies", listPolicies.handler, {
     permissions: listPolicies.config.permissions,
+  })
+  .get("/assignments", listSeatAssignments.handler, {
+    permissions: listSeatAssignments.config.permissions,
+  })
+  .post("/assignments", assignSeat.handler, {
+    body: assignSeat.config.body,
+    permissions: assignSeat.config.permissions,
+  })
+  .delete("/assignments", unassignSeat.handler, {
+    body: unassignSeat.config.body,
+    permissions: unassignSeat.config.permissions,
   })
   .post("/hosted/setup", createHostedSetup.handler, {
     body: createHostedSetup.config.body,

--- a/apps/api/src/handlers/usage/unassign-seat.ts
+++ b/apps/api/src/handlers/usage/unassign-seat.ts
@@ -1,0 +1,61 @@
+import { Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+import { t } from "elysia";
+
+import { usageSeatAssignments } from "@/api/db/schema";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import { tUserId } from "@/api/lib/custom-schema";
+
+/**
+ * Release a member's per-user included limit. Idempotent: releasing
+ * an unassigned member is a no-op success, so retries and races with
+ * member removal stay quiet.
+ */
+
+const config = {
+  permissions: { organizationSettings: ["update"] },
+  mcp: { type: "internal", reason: "hosted_billing" },
+  body: t.Object({
+    userId: tUserId,
+  }),
+} satisfies HandlerConfig;
+
+const unassignSeat = createSafeRootHandler(
+  config,
+  async function* ({ body, session, safeDb, recordAuditEvent }) {
+    yield* Result.await(
+      safeDb(async (tx) => {
+        const deleted = await tx
+          .delete(usageSeatAssignments)
+          .where(
+            and(
+              eq(
+                usageSeatAssignments.organizationId,
+                session.activeOrganizationId,
+              ),
+              eq(usageSeatAssignments.userId, body.userId),
+            ),
+          )
+          .returning({ id: usageSeatAssignments.id });
+        if (deleted.at(0) === undefined) {
+          return;
+        }
+
+        await recordAuditEvent(tx, {
+          action: AUDIT_ACTION.DELETE,
+          resourceType: AUDIT_RESOURCE_TYPE.ORGANIZATION_SETTINGS,
+          resourceId: session.activeOrganizationId,
+          metadata: {
+            field: "usageAssignment",
+            userId: body.userId,
+          },
+        });
+      }),
+    );
+    return Result.ok({ assigned: false });
+  },
+);
+
+export default unassignSeat;

--- a/apps/api/src/handlers/usage/unassign-seat.ts
+++ b/apps/api/src/handlers/usage/unassign-seat.ts
@@ -7,6 +7,7 @@ import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { tUserId } from "@/api/lib/custom-schema";
+import { lockAssignmentCapacity } from "@/api/lib/usage/assignment-capacity";
 
 /**
  * Release a member's per-user included limit. Idempotent: releasing
@@ -27,6 +28,10 @@ const unassignSeat = createSafeRootHandler(
   async function* ({ body, session, safeDb, recordAuditEvent }) {
     yield* Result.await(
       safeDb(async (tx) => {
+        // Serialize with designation so a racing capacity check cannot
+        // count a row that this release is about to remove.
+        await lockAssignmentCapacity(tx, session.activeOrganizationId);
+
         const deleted = await tx
           .delete(usageSeatAssignments)
           .where(

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -48,6 +48,7 @@ export type SafeIdType =
   | "contactRelationship"
   | "usageAllocation"
   | "usageLaneCounter"
+  | "usageSeatAssignment"
   | "usagePolicy"
   | "usageEntitlement"
   | "usageEvent"

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -73,6 +73,8 @@ export const LIMITS = {
   /** Max entity-link rows returned per direction for one task. */
   taskEntityLinksPerDirectionMax: 200,
   entitySummariesPageSize: 200,
+  /** Max per-user limit assignments returned for one organization. */
+  usageAssignmentsMax: 1000,
   viewsCount: 20,
   viewTemplatesPerUser: 50,
   /** Per-org cap on saved playbook definitions. Per-playbook size is bounded

--- a/apps/api/src/lib/resource-identity.ts
+++ b/apps/api/src/lib/resource-identity.ts
@@ -94,6 +94,7 @@ export const RESOURCE_IDENTITY_DISPOSITION = {
   contactRelationship: { type: "non_resource", reason: "association" },
   usageAllocation: { type: "non_resource", reason: "policy" },
   usageLaneCounter: { type: "non_resource", reason: "event" },
+  usageSeatAssignment: { type: "non_resource", reason: "policy" },
   usagePolicy: { type: "non_resource", reason: "policy" },
   usageEntitlement: { type: "non_resource", reason: "policy" },
   usageEvent: { type: "non_resource", reason: "event" },

--- a/apps/api/src/lib/usage/assignment-capacity.ts
+++ b/apps/api/src/lib/usage/assignment-capacity.ts
@@ -1,0 +1,65 @@
+/**
+ * Serialization and reconciliation for the member designation roster.
+ *
+ * Every writer that reads roster size before changing it — designation
+ * (capacity check), release (so a racing designation cannot count a row
+ * being released), and capacity reconciliation on configuration changes —
+ * takes the same per-organization advisory lock first, so each outcome
+ * describes the committed roster. Row locks are not an option: the
+ * restrictive `no_update` RLS policies on the usage tables silently
+ * filter rows out of `SELECT ... FOR UPDATE` for the app role.
+ */
+
+import { asc, eq, inArray, sql } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db/root";
+import { usageSeatAssignments } from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+import { LIMITS } from "@/api/lib/limits";
+
+/**
+ * Namespace for the per-organization roster lock. `pg_advisory_xact_lock`
+ * keys collide across unrelated advisory locks; the org-id hash is the
+ * second key.
+ */
+const ASSIGNMENT_CAPACITY_LOCK_NAMESPACE = 0x5e_a7_ca_9a;
+
+/** Held until the surrounding transaction commits. */
+export const lockAssignmentCapacity = async (
+  tx: Transaction,
+  organizationId: SafeId<"organization">,
+): Promise<void> => {
+  await tx.execute(
+    sql`select pg_advisory_xact_lock(${ASSIGNMENT_CAPACITY_LOCK_NAMESPACE}, hashtext(${organizationId}))`,
+  );
+};
+
+/**
+ * Drop designations beyond `capacity`, keeping the earliest-designated
+ * members (deterministic id tiebreak). Callers hold the capacity lock.
+ * Returns the number of rows removed.
+ */
+export const trimAssignmentsToCapacity = async (
+  tx: Transaction,
+  organizationId: SafeId<"organization">,
+  capacity: number,
+): Promise<number> => {
+  const excess = await tx
+    .select({ id: usageSeatAssignments.id })
+    .from(usageSeatAssignments)
+    .where(eq(usageSeatAssignments.organizationId, organizationId))
+    .orderBy(asc(usageSeatAssignments.createdAt), asc(usageSeatAssignments.id))
+    .offset(capacity)
+    .limit(LIMITS.usageAssignmentsMax);
+  if (excess.length === 0) {
+    return 0;
+  }
+
+  await tx.delete(usageSeatAssignments).where(
+    inArray(
+      usageSeatAssignments.id,
+      excess.map((row) => row.id),
+    ),
+  );
+  return excess.length;
+};

--- a/apps/api/src/lib/usage/lane-routing.db.test.ts
+++ b/apps/api/src/lib/usage/lane-routing.db.test.ts
@@ -10,7 +10,11 @@ import { TransactionRollbackError } from "drizzle-orm";
 
 import { organization, user } from "@/api/db/auth-schema";
 import type { Transaction } from "@/api/db/root";
-import { usageEntitlements, usagePolicies } from "@/api/db/schema";
+import {
+  usageEntitlements,
+  usagePolicies,
+  usageSeatAssignments,
+} from "@/api/db/schema";
 import type { UsageEntitlementStatus } from "@/api/db/schema";
 import { createSafeId, toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -103,6 +107,18 @@ const seedEntitlement = async ({
   });
 };
 
+/**
+ * Occupy one of the org's seats with the fixture's user. Per-user budgets
+ * only apply to assigned members, so every test that means to reach a
+ * budget decision must seed this row: without it the verdict is "pool"
+ * for a reason that has nothing to do with the budgets under test.
+ */
+const seedAssignment = async (tx: Transaction, fx: Fixture): Promise<void> => {
+  await tx
+    .insert(usageSeatAssignments)
+    .values({ organizationId: fx.organizationId, userId: fx.userId });
+};
+
 const withRolledBackTx = async (
   fn: (tx: Transaction) => Promise<void>,
 ): Promise<void> => {
@@ -143,6 +159,7 @@ describe("chat usage lane routing", () => {
         dailyAllowanceMicroUnits: null,
         fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
       });
+      await seedAssignment(tx, fx);
 
       expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe("pool");
     });
@@ -158,6 +175,7 @@ describe("chat usage lane routing", () => {
         dailyAllowanceMicroUnits: DAILY_ALLOWANCE,
         fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
       });
+      await seedAssignment(tx, fx);
 
       expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe("pool");
     });
@@ -173,6 +191,7 @@ describe("chat usage lane routing", () => {
         dailyAllowanceMicroUnits: DAILY_ALLOWANCE,
         fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
       });
+      await seedAssignment(tx, fx);
 
       // An untouched bucket has no row; the missing row must read as
       // zero rather than skipping the lane.
@@ -203,6 +222,7 @@ describe("chat usage lane routing", () => {
         dailyAllowanceMicroUnits: DAILY_ALLOWANCE,
         fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
       });
+      await seedAssignment(tx, fx);
 
       // The allowance is spent at equality, not only past it.
       await incrementLaneCounter({
@@ -248,6 +268,7 @@ describe("chat usage lane routing", () => {
         dailyAllowanceMicroUnits: DAILY_ALLOWANCE,
         fallbackWeeklyMicroUnits: null,
       });
+      await seedAssignment(tx, fx);
 
       await incrementLaneCounter({
         tx,
@@ -270,6 +291,7 @@ describe("chat usage lane routing", () => {
         dailyAllowanceMicroUnits: DAILY_ALLOWANCE,
         fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
       });
+      await seedAssignment(tx, fx);
 
       await incrementLaneCounter({
         tx,
@@ -285,6 +307,50 @@ describe("chat usage lane routing", () => {
         microUnits: FALLBACK_WEEKLY,
         asOf: ASOF,
       });
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe("pool");
+    });
+  });
+
+  test("an unassigned user draws from the pool despite fully funded budgets", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+      await seedEntitlement({
+        tx,
+        fx,
+        status: "active",
+        dailyAllowanceMicroUnits: DAILY_ALLOWANCE,
+        fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
+      });
+
+      // Identical to the allowance test apart from the missing seat row:
+      // the budgets alone must not open the per-user lane.
+      expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe("pool");
+    });
+  });
+
+  test("another member's assignment does not lend this user the budgets", async () => {
+    await withRolledBackTx(async (tx) => {
+      const fx = await setupFixture(tx);
+      await seedEntitlement({
+        tx,
+        fx,
+        status: "active",
+        dailyAllowanceMicroUnits: DAILY_ALLOWANCE,
+        fallbackWeeklyMicroUnits: FALLBACK_WEEKLY,
+      });
+
+      // A seat in the same organisation, held by somebody else: the
+      // lookup must match on (org, user), not on the org alone.
+      const otherUserId = `user_${Bun.randomUUIDv7()}`;
+      await tx.insert(user).values({
+        id: otherUserId,
+        name: "Other User",
+        email: `${otherUserId}@test.local`,
+      });
+      await tx
+        .insert(usageSeatAssignments)
+        .values({ organizationId: fx.organizationId, userId: otherUserId });
+
       expect(await decideChatUsageLane({ tx, ...fx, asOf: ASOF })).toBe("pool");
     });
   });

--- a/apps/api/src/lib/usage/lane-routing.db.test.ts
+++ b/apps/api/src/lib/usage/lane-routing.db.test.ts
@@ -8,7 +8,7 @@ import {
 } from "bun:test";
 import { TransactionRollbackError } from "drizzle-orm";
 
-import { organization, user } from "@/api/db/auth-schema";
+import { member, organization, user } from "@/api/db/auth-schema";
 import type { Transaction } from "@/api/db/root";
 import {
   usageEntitlements,
@@ -65,6 +65,15 @@ const setupFixture = async (tx: Transaction): Promise<Fixture> => {
     id: userId,
     name: "Test User",
     email: `${userId}@test.local`,
+  });
+  // Designations bind to the membership, so the fixture user must be a
+  // member for seedAssignment's row to exist.
+  await tx.insert(member).values({
+    id: `member_${Bun.randomUUIDv7()}`,
+    organizationId,
+    userId,
+    role: "member",
+    createdAt: ASOF,
   });
 
   return { organizationId, userId };
@@ -346,6 +355,13 @@ describe("chat usage lane routing", () => {
         id: otherUserId,
         name: "Other User",
         email: `${otherUserId}@test.local`,
+      });
+      await tx.insert(member).values({
+        id: `member_${Bun.randomUUIDv7()}`,
+        organizationId: fx.organizationId,
+        userId: otherUserId,
+        role: "member",
+        createdAt: ASOF,
       });
       await tx
         .insert(usageSeatAssignments)

--- a/apps/api/src/lib/usage/lane-routing.ts
+++ b/apps/api/src/lib/usage/lane-routing.ts
@@ -7,10 +7,14 @@
  * decision lands on the other side of it.
  */
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
-import { usageEntitlements, usagePolicies } from "@/api/db/schema";
+import {
+  usageEntitlements,
+  usagePolicies,
+  usageSeatAssignments,
+} from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import { getLaneCounterMicroUnits } from "@/api/lib/usage/lane-budget";
 import { isEntitlementConsumableAt } from "@/api/lib/usage/usage-ledger";
@@ -68,6 +72,23 @@ export const decideChatUsageLane = async ({
     !isEntitlementConsumableAt(entitlement, asOf) ||
     entitlement.dailyAllowanceMicroUnits === null
   ) {
+    return "pool";
+  }
+
+  // Per-user budgets belong to assigned members only; everyone else
+  // keeps the shared-pool path (never a hard block — the pool check
+  // still runs downstream exactly as before budgets existed).
+  const assignment = await tx
+    .select({ id: usageSeatAssignments.id })
+    .from(usageSeatAssignments)
+    .where(
+      and(
+        eq(usageSeatAssignments.organizationId, organizationId),
+        eq(usageSeatAssignments.userId, userId),
+      ),
+    )
+    .limit(1);
+  if (assignment.at(0) === undefined) {
     return "pool";
   }
 

--- a/docs/capability-coverage.md
+++ b/docs/capability-coverage.md
@@ -500,7 +500,7 @@ mechanics, and similar), not gaps in coverage.
 | deploy_mechanics       | 1     |
 | document_processing    | 17    |
 | health_infra           | 1     |
-| hosted_billing         | 3     |
+| hosted_billing         | 6     |
 | mcp_transport          | 11    |
 | native_tool_ui         | 3     |
 | provider_secret        | 20    |
@@ -511,4 +511,4 @@ mechanics, and similar), not gaps in coverage.
 | upload_mechanics       | 9     |
 | url_preview            | 2     |
 
-Total: 126
+Total: 129


### PR DESCRIPTION
Adds an organization-scoped member designation roster and wires per-user accounting to it.

- New designation table with RLS (select/insert/delete for the app role, no updates) and migration.
- `GET/POST/DELETE /usage/assignments`: list, designate, and undesignate members. Designation is capacity-bounded inside a single transaction, serialized by a namespaced advisory transaction lock (row locks are unavailable under the restrictive RLS policies), idempotent on retry, and audited.
- `decideChatUsageLane` applies per-user budgets only to designated members; everyone else settles against the shared organization pool.
- Webhook dispatch designates the initiating member automatically when a configuration first materializes.
- Tests cover the capacity boundary, idempotent re-designation, release and reuse, the routing gate, and the dispatch bootstrap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organisation usage seat assignment management.
  * Added APIs to list, assign and unassign seats.
  * Added validation for membership, permissions and available capacity.
  * Automatically assigns eligible members during hosted entitlement setup.
  * Usage budgets now apply only to members with assigned seats.
* **Bug Fixes**
  * Prevented duplicate assignments and safely handled seat reductions.
  * Released assignments when memberships are removed.
* **Tests**
  * Added coverage for assignment, capacity, reassignment and routing behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->