### PR TITLE
feat(guards): merge bar, merge-time migration ordering, vacuous-throw rule

### DIFF
--- a/.agents/skills/conventions-testing/SKILL.md
+++ b/.agents/skills/conventions-testing/SKILL.md
@@ -74,3 +74,40 @@ enforcement, branded types) live in
   transitions for lifecycle code, and round trips for serialization.
 - Keep time, randomness, network, filesystem, and database ownership explicit
   in tests. Pin or inject them rather than relying on ambient machine state.
+- Name the error a throw assertion expects. `expect(...).toThrow()` with no
+  argument passes for every error, so it keeps passing once the code fails for
+  an unrelated reason; pass a message substring, a regex, or the error class.
+  `no-vacuous-throw-assertion` enforces this.
+
+## Mutation check
+
+A test guarding behavior X is finished only once reverting X makes it fail.
+Until you have seen it go red against the known-bad behavior, it may be
+passing for an unrelated reason. When the test is the evidence for a fix,
+say in the PR that you ran the mutation and what it broke.
+
+The usual failure is a fixture the fault cannot reach. Assert the fixture
+DIFFERS before asserting the equivalence: check
+`expect(NFD(word)).not.toBe(NFC(word))` before asserting both normalize alike,
+so a fixture that is already normalized cannot make the test vacuous.
+
+## Cross-runtime contracts
+
+Where one rule lives in two runtimes at once (JavaScript, Postgres, the search
+engine), parity is proven only by DERIVING the other side's rules executably:
+query the live extension for its token output, render the SQL the query layer
+emits and assert on that, read the analyzer's configuration tuple.
+
+A hand-maintained list mirroring the other side's behavior is not evidence of
+parity. It is the drift, written down: it agrees with the other runtime exactly
+until that runtime changes, and nothing fails when it does.
+
+## Projection census
+
+Any "marked done" flag that mirrors state in an external system (search index,
+object store, queue) ships with a reconciler that compares both sides and
+reports the difference. Acceptance by the remote system is not durability, so
+the flag alone can never prove the projection landed.
+
+Treat the reconciler as part of the feature, not follow-up work: without it the
+first divergence is invisible until a user reports missing data.

--- a/.ai/local-skills/conventions-testing/SKILL.md
+++ b/.ai/local-skills/conventions-testing/SKILL.md
@@ -74,3 +74,40 @@ enforcement, branded types) live in
   transitions for lifecycle code, and round trips for serialization.
 - Keep time, randomness, network, filesystem, and database ownership explicit
   in tests. Pin or inject them rather than relying on ambient machine state.
+- Name the error a throw assertion expects. `expect(...).toThrow()` with no
+  argument passes for every error, so it keeps passing once the code fails for
+  an unrelated reason; pass a message substring, a regex, or the error class.
+  `no-vacuous-throw-assertion` enforces this.
+
+## Mutation check
+
+A test guarding behavior X is finished only once reverting X makes it fail.
+Until you have seen it go red against the known-bad behavior, it may be
+passing for an unrelated reason. When the test is the evidence for a fix,
+say in the PR that you ran the mutation and what it broke.
+
+The usual failure is a fixture the fault cannot reach. Assert the fixture
+DIFFERS before asserting the equivalence: check
+`expect(NFD(word)).not.toBe(NFC(word))` before asserting both normalize alike,
+so a fixture that is already normalized cannot make the test vacuous.
+
+## Cross-runtime contracts
+
+Where one rule lives in two runtimes at once (JavaScript, Postgres, the search
+engine), parity is proven only by DERIVING the other side's rules executably:
+query the live extension for its token output, render the SQL the query layer
+emits and assert on that, read the analyzer's configuration tuple.
+
+A hand-maintained list mirroring the other side's behavior is not evidence of
+parity. It is the drift, written down: it agrees with the other runtime exactly
+until that runtime changes, and nothing fails when it does.
+
+## Projection census
+
+Any "marked done" flag that mirrors state in an external system (search index,
+object store, queue) ships with a reconciler that compares both sides and
+reports the difference. Acceptance by the remote system is not durability, so
+the flag alone can never prove the projection landed.
+
+Treat the reconciler as part of the feature, not follow-up work: without it the
+first divergence is invisible until a user reports missing data.

--- a/.ai/local/agents.md
+++ b/.ai/local/agents.md
@@ -25,6 +25,13 @@ branch instead of hand-picking individual checks. Green here means
 green on the `ci-result` status. `--all` checks every package instead
 of only those affected vs `origin/main`.
 
+## Merging
+
+Merges go through `bun scripts/merge-bar.ts <pr>`: it re-reads PR state, the
+`ci-result` check run on the exact head SHA, and unresolved review threads in one
+invocation, then merges. Raw `gh pr merge` asserts nothing and reads an empty check
+list as green.
+
 ## Documentation Access
 
 The `stella-docs` MCP server provides on-demand access to library documentation via
@@ -66,6 +73,27 @@ only the non-obvious caveats for this environment.
   of the base checkout; run `git submodule update --init .ai/shared` first, otherwise
   the "AI skill sync" step errors out.
 - Optional demo data: `bun --filter @stll/api db:seed-test-user` and `db:seed-dev`.
+
+## Test Doctrine
+
+Full conventions in `/conventions-testing`; these three are the ones most often
+skipped.
+
+- **Mutation check.** A test guarding behavior X is finished only once reverting X
+  makes it fail; until then it may be passing for an unrelated reason. When the test
+  is the evidence for a fix, state in the PR that you ran the mutation. A test whose
+  fixture cannot express the fault is the common failure: assert the fixture DIFFERS
+  before asserting the equivalence, for example `expect(NFD(word)).not.toBe(NFC(word))`
+  before asserting both normalize alike.
+- **Cross-runtime contracts.** Where a rule lives in two runtimes at once
+  (JavaScript, Postgres, the search engine), prove parity by DERIVING the other
+  side's rules executably: query the live extension, render the SQL the query layer
+  emits, read the analyzer's configuration tuple. A hand-maintained mirror list of
+  the other side's behavior is not evidence of parity; it is the drift, written down.
+- **Projection census.** Any "marked done" flag that mirrors state in an external
+  system (search index, object store, queue) ships with a reconciler that compares
+  both sides and reports the difference. Acceptance by the remote system is not
+  durability, so the flag alone can never prove the projection landed.
 
 ## Convention & Type-Cost Guards
 

--- a/.changeset/vacuous-throw-sweep-no-release.md
+++ b/.changeset/vacuous-throw-sweep-no-release.md
@@ -1,0 +1,7 @@
+---
+---
+
+No release. The only published-package file this pull request touches is
+`packages/conditions/src/evaluate.test.ts`, where two throw assertions gained
+the error message they were always meant to pin. Tests are excluded from the
+build, so no shipped artifact changes.

--- a/.claude/commands/conventions-testing.md
+++ b/.claude/commands/conventions-testing.md
@@ -69,3 +69,40 @@ enforcement, branded types) live in
   transitions for lifecycle code, and round trips for serialization.
 - Keep time, randomness, network, filesystem, and database ownership explicit
   in tests. Pin or inject them rather than relying on ambient machine state.
+- Name the error a throw assertion expects. `expect(...).toThrow()` with no
+  argument passes for every error, so it keeps passing once the code fails for
+  an unrelated reason; pass a message substring, a regex, or the error class.
+  `no-vacuous-throw-assertion` enforces this.
+
+## Mutation check
+
+A test guarding behavior X is finished only once reverting X makes it fail.
+Until you have seen it go red against the known-bad behavior, it may be
+passing for an unrelated reason. When the test is the evidence for a fix,
+say in the PR that you ran the mutation and what it broke.
+
+The usual failure is a fixture the fault cannot reach. Assert the fixture
+DIFFERS before asserting the equivalence: check
+`expect(NFD(word)).not.toBe(NFC(word))` before asserting both normalize alike,
+so a fixture that is already normalized cannot make the test vacuous.
+
+## Cross-runtime contracts
+
+Where one rule lives in two runtimes at once (JavaScript, Postgres, the search
+engine), parity is proven only by DERIVING the other side's rules executably:
+query the live extension for its token output, render the SQL the query layer
+emits and assert on that, read the analyzer's configuration tuple.
+
+A hand-maintained list mirroring the other side's behavior is not evidence of
+parity. It is the drift, written down: it agrees with the other runtime exactly
+until that runtime changes, and nothing fails when it does.
+
+## Projection census
+
+Any "marked done" flag that mirrors state in an external system (search index,
+object store, queue) ships with a reconciler that compares both sides and
+reports the difference. Acceptance by the remote system is not durability, so
+the flag alone can never prove the projection landed.
+
+Treat the reconciler as part of the feature, not follow-up work: without it the
+first divergence is invisible until a user reports missing data.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -915,6 +915,16 @@ jobs:
       - name: Test bun ci retry script
         run: bash scripts/bun-ci-retry.test.sh
 
+      # Both guards decide whether a change may reach a live database or the
+      # default branch, and both fail open if their comparison logic breaks:
+      # a migration ordering check that always returns null passes every PR,
+      # and a merge gate that reads an empty check list as green merges
+      # unverified code. Neither test ran in CI before.
+      - name: Test migration ordering and merge gate logic
+        run: |
+          bun test scripts/check-migration-order.test.ts
+          bun test scripts/merge-bar.test.ts
+
       # Fail PRs that change the desktop bridge surface without
       # bumping BRIDGE_VERSION in apps/desktop/src-tauri/src/types.rs.
       # See scripts/check-bridge-version.sh for rationale.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -920,7 +920,10 @@ jobs:
       # a migration ordering check that always returns null passes every PR,
       # and a merge gate that reads an empty check list as green merges
       # unverified code. Neither test ran in CI before.
+      # Both scripts import `better-result`, so they need the dependency
+      # install above, which is itself conditional.
       - name: Test migration ordering and merge gate logic
+        if: needs.ci-plan.outputs.package_checks_required == 'true'
         run: |
           bun test scripts/check-migration-order.test.ts
           bun test scripts/merge-bar.test.ts

--- a/.oxlint-plugins/README.md
+++ b/.oxlint-plugins/README.md
@@ -152,6 +152,7 @@ runtime validation, or integration tests.
 - [`no-facade-imports`](./no-facade-imports.ts) (`no-facade-imports`): requires imports from the owning leaf module instead of broad facades that hide boundaries and side effects.
 - [`no-nanoid`](./no-nanoid.ts) (`no-nanoid`): prevents the removed Nano ID dependency from returning; use UUIDv7 or Web Crypto for custom alphabets.
 - [`no-partial-record-satisfies`](./no-partial-record-satisfies.ts) (`no-partial-record-satisfies`): rejects `satisfies Partial<Record<Union, T>>`, which defeats exhaustive companion-map checking.
+- [`no-vacuous-throw-assertion`](./no-vacuous-throw-assertion.ts) (`no-vacuous-throw-assertion`): requires `toThrow` and `toThrowError` in tests to name the expected error; an unargumented throw assertion is satisfied by every error, so it keeps passing once the code fails for an unrelated reason. `.not.toThrow()` stays valid.
 - [`no-static-devtools-import`](./no-static-devtools-import.ts) (`no-static-devtools-import`): prevents development-only modules from entering eager production dependency graphs.
 - [`require-function-replacer`](./require-function-replacer.ts) (`require-function-replacer`): requires function-valued state updates to use an explicit replacer wrapper so they are not invoked as updater callbacks.
 - [`suppression-hygiene`](./suppression-hygiene.ts) (`require-description`, `no-foreign-directive`): requires rule-specific, explained suppressions and rejects directives for another lint engine.

--- a/.oxlint-plugins/__fixtures__/no-vacuous-throw-assertion.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-vacuous-throw-assertion.fixture.ts
@@ -1,0 +1,64 @@
+// Passive regression fixture for
+// `no-vacuous-throw-assertion/no-vacuous-throw-assertion`.
+
+import { expect } from "bun:test";
+
+const corpusIndexId = (prefix: string, region: string): string => {
+  if (!/^[a-z][a-z0-9_]*$/u.test(prefix)) {
+    throw new TypeError(`corpus index prefix is not an identifier: ${prefix}`);
+  }
+  if (!/^[a-z]{3}$/u.test(region)) {
+    throw new TypeError(`corpus index region is not alpha-3: ${region}`);
+  }
+  return `${prefix}_${region}`;
+};
+
+const loadCorpus = async (indexId: string): Promise<string> => {
+  if (indexId === "") {
+    throw new RangeError("corpus index id is empty");
+  }
+  return await Promise.resolve(indexId);
+};
+
+export const vacuousAssertions = (): void => {
+  // MUST flag: any thrown value satisfies this, including an unrelated
+  // TypeError from a renamed argument.
+  // oxlint-disable-next-line no-vacuous-throw-assertion/no-vacuous-throw-assertion -- fixture: an unargumented toThrow pins no error
+  expect(() => corpusIndexId("1_case_law", "svk")).toThrow();
+
+  // MUST flag: the legacy alias is the same matcher.
+  // oxlint-disable-next-line no-vacuous-throw-assertion/no-vacuous-throw-assertion -- fixture: toThrowError is the same unargumented assertion
+  expect(() => corpusIndexId("", "svk")).toThrowError();
+};
+
+// bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+// type-aware lint; the assertion shape is what this fixture pins.
+export const vacuousRejection = (): void => {
+  // MUST flag: the `.rejects` chain is the same assertion over a promise.
+  // oxlint-disable-next-line no-vacuous-throw-assertion/no-vacuous-throw-assertion -- fixture: an unargumented rejects.toThrow pins no error
+  expect(loadCorpus("")).rejects.toThrow();
+};
+
+export const namedAssertions = (): void => {
+  // Allowed: a message substring discriminates between errors.
+  expect(() => corpusIndexId("1_case_law", "svk")).toThrow(
+    "corpus index prefix is not an identifier",
+  );
+
+  // Allowed: a regex pins the shape of the message.
+  expect(() => corpusIndexId("case_law_v1", "sk-1")).toThrow(
+    /region is not alpha-3/u,
+  );
+
+  // Allowed: an error class pins the constructor.
+  expect(loadCorpus("")).rejects.toThrow(RangeError);
+
+  // Allowed: `.not.toThrow()` asserts the absence of every error, so there is
+  // no error to name.
+  expect(() => corpusIndexId("case_law_v1", "svk")).not.toThrow();
+};
+
+// Allowed: an unrelated method that happens to share the name is not an
+// `expect(...)` assertion.
+const retryPolicy = { toThrow: (): string => "escalate" };
+export const unrelatedToThrow = retryPolicy.toThrow();

--- a/.oxlint-plugins/no-vacuous-throw-assertion.ts
+++ b/.oxlint-plugins/no-vacuous-throw-assertion.ts
@@ -1,0 +1,102 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { getPropertyName, isAstNode, isCallTo } from "./utils.ts";
+
+// Require throw assertions to name the error they expect.
+//
+// `expect(() => parse(bad)).toThrow()` passes for ANY thrown value. A test
+// written to pin "rejects an identifier containing a quote" keeps passing once
+// the function starts throwing a NOT NULL violation, a TypeError from a renamed
+// field, or an import-time failure: the assertion cannot tell those apart from
+// the error it was written for. The test then reports on the presence of a
+// throw rather than on the contract, and silently stops guarding the behavior
+// it was added for.
+//
+// Flagged: `.toThrow()` and `.toThrowError()` with no argument, on a chain
+// rooted at `expect(...)`, including the `.rejects` and `.resolves` forms.
+//
+// Accepted: any argument at all (message substring, regex, error class, error
+// instance, object carrying `message`), because each of them discriminates
+// between errors. `.not.toThrow()` is accepted and takes no argument by design:
+// it asserts the absence of every error, so there is nothing to name.
+//
+// Boundary: this is a syntax check on the assertion shape. It cannot prove the
+// supplied matcher is specific enough (`.toThrow("")` still matches
+// everything), only that the call site made a choice.
+
+const THROW_MATCHERS = new Set(["toThrow", "toThrowError"]);
+const NEGATION_PROPERTY = "not";
+const EXPECT_CALLEE = "expect";
+
+const staticPropertyName = (node: unknown): string | null => {
+  if (!isAstNode(node) || node.type !== "MemberExpression") {
+    return null;
+  }
+  if (node.computed !== false) {
+    return null;
+  }
+  return getPropertyName(node.property);
+};
+
+type ChainShape = { negated: boolean; rootedAtExpect: boolean };
+
+// Walk the member chain beneath the matcher. `expect(x).rejects.toThrow` has
+// `.rejects` under the matcher and the `expect(x)` call at the root.
+const describeChain = (start: unknown): ChainShape => {
+  let current = start;
+  let negated = false;
+
+  while (isAstNode(current) && current.type === "MemberExpression") {
+    if (staticPropertyName(current) === NEGATION_PROPERTY) {
+      negated = true;
+    }
+    current = current.object;
+  }
+
+  return { negated, rootedAtExpect: isCallTo(current, EXPECT_CALLEE) };
+};
+
+export default eslintCompatPlugin({
+  meta: { name: "no-vacuous-throw-assertion" },
+  rules: {
+    "no-vacuous-throw-assertion": {
+      meta: {
+        type: "problem",
+        messages: {
+          vacuousThrow:
+            "`{{matcher}}()` with no argument passes for any thrown value, " +
+            "so it stops guarding the failure it was written for. Name the " +
+            "expected error: a message substring, a regex, an error class, " +
+            "or an object with `message`.",
+        },
+      },
+      createOnce(context) {
+        return {
+          CallExpression(node) {
+            if (node.arguments.length > 0) {
+              return;
+            }
+            const matcher = staticPropertyName(node.callee);
+            if (matcher === null || !THROW_MATCHERS.has(matcher)) {
+              return;
+            }
+            if (!isAstNode(node.callee)) {
+              return;
+            }
+            const { negated, rootedAtExpect } = describeChain(
+              node.callee.object,
+            );
+            if (negated || !rootedAtExpect) {
+              return;
+            }
+            context.report({
+              node,
+              messageId: "vacuousThrow",
+              data: { matcher },
+            });
+          },
+        };
+      },
+    },
+  },
+});

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,6 +301,13 @@ branch instead of hand-picking individual checks. Green here means
 green on the `ci-result` status. `--all` checks every package instead
 of only those affected vs `origin/main`.
 
+## Merging
+
+Merges go through `bun scripts/merge-bar.ts <pr>`: it re-reads PR state, the
+`ci-result` check run on the exact head SHA, and unresolved review threads in one
+invocation, then merges. Raw `gh pr merge` asserts nothing and reads an empty check
+list as green.
+
 ## Documentation Access
 
 The `stella-docs` MCP server provides on-demand access to library documentation via
@@ -342,6 +349,27 @@ only the non-obvious caveats for this environment.
   of the base checkout; run `git submodule update --init .ai/shared` first, otherwise
   the "AI skill sync" step errors out.
 - Optional demo data: `bun --filter @stll/api db:seed-test-user` and `db:seed-dev`.
+
+## Test Doctrine
+
+Full conventions in `/conventions-testing`; these three are the ones most often
+skipped.
+
+- **Mutation check.** A test guarding behavior X is finished only once reverting X
+  makes it fail; until then it may be passing for an unrelated reason. When the test
+  is the evidence for a fix, state in the PR that you ran the mutation. A test whose
+  fixture cannot express the fault is the common failure: assert the fixture DIFFERS
+  before asserting the equivalence, for example `expect(NFD(word)).not.toBe(NFC(word))`
+  before asserting both normalize alike.
+- **Cross-runtime contracts.** Where a rule lives in two runtimes at once
+  (JavaScript, Postgres, the search engine), prove parity by DERIVING the other
+  side's rules executably: query the live extension, render the SQL the query layer
+  emits, read the analyzer's configuration tuple. A hand-maintained mirror list of
+  the other side's behavior is not evidence of parity; it is the drift, written down.
+- **Projection census.** Any "marked done" flag that mirrors state in an external
+  system (search index, object store, queue) ships with a reconciler that compares
+  both sides and reports the difference. Acceptance by the remote system is not
+  durability, so the flag alone can never prove the projection landed.
 
 ## Convention & Type-Cost Guards
 

--- a/apps/api/scripts/lib/capability-catalog.test.ts
+++ b/apps/api/scripts/lib/capability-catalog.test.ts
@@ -66,7 +66,7 @@ describe("deriveCapabilityId", () => {
         file: "apps/api/src/lib/x.ts",
         exportName: undefined,
       }),
-    ).toThrow();
+    ).toThrow("handler path is outside apps/api/src/handlers/");
   });
 });
 
@@ -759,7 +759,9 @@ describe("deriveHandlerImportPath", () => {
   });
 
   test("panics on a path outside apps/api/src", () => {
-    expect(() => deriveHandlerImportPath("packages/cli/src/x.ts")).toThrow();
+    expect(() => deriveHandlerImportPath("packages/cli/src/x.ts")).toThrow(
+      "handler path is outside apps/api/src/",
+    );
   });
 });
 

--- a/apps/api/src/db/json-utils.test.ts
+++ b/apps/api/src/db/json-utils.test.ts
@@ -44,7 +44,9 @@ describe("assertIdentifierLiteral", () => {
     "",
     "emoji-🙂",
   ])("rejects non-identifier value %p", (value) => {
-    expect(() => assertIdentifierLiteral(value)).toThrow();
+    expect(() => assertIdentifierLiteral(value)).toThrow(
+      "Raw SQL literal must be an identifier-like value",
+    );
   });
 });
 

--- a/apps/api/src/dev/register-mock-ai.test.ts
+++ b/apps/api/src/dev/register-mock-ai.test.ts
@@ -221,6 +221,6 @@ describe("mockStructuredData", () => {
         properties: { odd: {} },
         required: ["odd"],
       }),
-    ).toThrow();
+    ).toThrow("mock AI adapter cannot synthesise structured output");
   });
 });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
@@ -238,9 +238,15 @@ describe("cz-ns reconciliation slices", () => {
   });
 
   test("a slice that is not a UTC calendar day is refused", () => {
-    expect(() => reconciliation.nextSlice("2026-08")).toThrow();
-    expect(() => reconciliation.previousSlice("2026-02-30")).toThrow();
-    expect(() => reconciliation.nextSlice("11.08.2026")).toThrow();
+    expect(() => reconciliation.nextSlice("2026-08")).toThrow(
+      "cz-ns slice is not a UTC calendar day",
+    );
+    expect(() => reconciliation.previousSlice("2026-02-30")).toThrow(
+      "cz-ns slice is not a UTC calendar day",
+    );
+    expect(() => reconciliation.nextSlice("11.08.2026")).toThrow(
+      "cz-ns slice is not a UTC calendar day",
+    );
   });
 });
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -307,11 +307,15 @@ describe("cz-nss reconciliation slices", () => {
   });
 
   test("refuses a slice that is not a UTC calendar day", () => {
-    expect(() => reconciliation.nextSlice("2026-06")).toThrow();
-    expect(() =>
-      reconciliation.previousSlice("2026-06-10T00:00:00Z"),
-    ).toThrow();
-    expect(() => reconciliation.nextSlice("2026-02-30")).toThrow();
+    expect(() => reconciliation.nextSlice("2026-06")).toThrow(
+      "cz-nss slice is not a UTC calendar day",
+    );
+    expect(() => reconciliation.previousSlice("2026-06-10T00:00:00Z")).toThrow(
+      "cz-nss slice is not a UTC calendar day",
+    );
+    expect(() => reconciliation.nextSlice("2026-02-30")).toThrow(
+      "cz-nss slice is not a UTC calendar day",
+    );
   });
 
   test("walk order is the ledger's lexicographic order", () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us-reconciliation.test.ts
@@ -314,9 +314,15 @@ describe("cz-us reconciliation slices", () => {
   });
 
   test("refuses a slice that is not a decision year", () => {
-    expect(() => reconciliation.nextSlice("2026-08")).toThrow();
-    expect(() => reconciliation.previousSlice("")).toThrow();
-    expect(() => reconciliation.nextSlice("199")).toThrow();
+    expect(() => reconciliation.nextSlice("2026-08")).toThrow(
+      "cz-us slice is not a decision year",
+    );
+    expect(() => reconciliation.previousSlice("")).toThrow(
+      "cz-us slice is not a decision year",
+    );
+    expect(() => reconciliation.nextSlice("199")).toThrow(
+      "cz-us slice is not a decision year",
+    );
   });
 });
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -689,8 +689,12 @@ describe("euEcjAdapter.reconciliation slices", () => {
   });
 
   test("a slice that is not a year is refused rather than guessed at", () => {
-    expect(() => reconciliation.nextSlice("2024-01")).toThrow();
-    expect(() => reconciliation.previousSlice("202")).toThrow();
+    expect(() => reconciliation.nextSlice("2024-01")).toThrow(
+      "eu-ecj slice is not a four-digit year",
+    );
+    expect(() => reconciliation.previousSlice("202")).toThrow(
+      "eu-ecj slice is not a four-digit year",
+    );
   });
 });
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-reconciliation.test.ts
@@ -182,8 +182,12 @@ describe("pl-courts slice arithmetic", () => {
   });
 
   test("a slice that is not a UTC calendar day is refused", () => {
-    expect(() => reconciliation.nextSlice("2015-03")).toThrow();
-    expect(() => reconciliation.previousSlice("2015-02-30")).toThrow();
+    expect(() => reconciliation.nextSlice("2015-03")).toThrow(
+      "pl-courts slice is not a UTC calendar day",
+    );
+    expect(() => reconciliation.previousSlice("2015-02-30")).toThrow(
+      "pl-courts slice is not a UTC calendar day",
+    );
   });
 });
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts-reconciliation.test.ts
@@ -215,9 +215,15 @@ describe("sk-courts slice arithmetic", () => {
   });
 
   test("a slice that is not a UTC calendar day is refused", () => {
-    expect(() => reconciliation.nextSlice("2026-06")).toThrow();
-    expect(() => reconciliation.previousSlice("2026-02-30")).toThrow();
-    expect(() => reconciliation.nextSlice("10.06.2026")).toThrow();
+    expect(() => reconciliation.nextSlice("2026-06")).toThrow(
+      "sk-courts slice is not a UTC calendar day",
+    );
+    expect(() => reconciliation.previousSlice("2026-02-30")).toThrow(
+      "sk-courts slice is not a UTC calendar day",
+    );
+    expect(() => reconciliation.nextSlice("10.06.2026")).toThrow(
+      "sk-courts slice is not a UTC calendar day",
+    );
   });
 });
 

--- a/apps/api/src/handlers/chat/chat-message-parts.test.ts
+++ b/apps/api/src/handlers/chat/chat-message-parts.test.ts
@@ -205,7 +205,11 @@ describe("persisted chat message parts", () => {
     ];
 
     for (const part of malformedParts) {
-      expect(() => classifyChatPartForPersistence(part)).toThrow();
+      // Every fixture keeps type: "structured-output", so persistence
+      // rejects each the same way (see the invalidHandling !== "drop" panic).
+      expect(() => classifyChatPartForPersistence(part)).toThrow(
+        "Cannot persist malformed chat part type: structured-output",
+      );
     }
   });
 

--- a/apps/api/src/lib/brand-invariants.test.ts
+++ b/apps/api/src/lib/brand-invariants.test.ts
@@ -34,7 +34,9 @@ test("SafeId constructors return the requested brand", () => {
 });
 
 test("SafeId constructors reject empty identifiers", () => {
-  expect(() => toSafeId<"entity">("")).toThrow();
+  expect(() => toSafeId<"entity">("")).toThrow(
+    "Expected a non-empty identifier",
+  );
 });
 
 test("Secret is nominal and kinds do not cross", () => {

--- a/apps/api/src/lib/chat/model-ingress-guard.test.ts
+++ b/apps/api/src/lib/chat/model-ingress-guard.test.ts
@@ -88,7 +88,7 @@ describe("assertModelSurfaceFreeOfTenantIds", () => {
         surface: "system-prompt",
         workspaceIds: [WS_A],
       }),
-    ).toThrow();
+    ).toThrow("Model-bound system-prompt embeds a tenant workspace id");
     expect(captureErrorMock).toHaveBeenCalledTimes(1);
   });
 
@@ -281,7 +281,7 @@ describe("guarded model surfaces", () => {
         system: `Connected matter: ${WS_A}`,
         workspaceIds: [WS_A],
       }),
-    ).toThrow();
+    ).toThrow("Model-bound system-prompt embeds a tenant workspace id");
     expect(captureErrorMock).toHaveBeenCalledTimes(1);
 
     const clean = guardModelSystemPrompt({

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -1238,9 +1238,9 @@ describe("delete-task amplification", () => {
     // The terms are OR-joined, so one id that breaks out of its quotes
     // changes what the whole task deletes. Ids come from `uuid` columns; one
     // that reaches here in another shape is a defect upstream.
-    expect(() =>
-      corpusDocumentsDeleteQuery(['a" OR document_id:"b']),
-    ).toThrow();
+    expect(() => corpusDocumentsDeleteQuery(['a" OR document_id:"b'])).toThrow(
+      'corpus delete query received an unusable document id: a" OR document_id:"b',
+    );
     expect(corpusDocumentsDeleteQuery(["a1b2-c3", "d4e5_f6"])).toBe(
       'document_id:"a1b2-c3" OR document_id:"d4e5_f6"',
     );

--- a/apps/api/src/lib/files/email-attachment-token.test.ts
+++ b/apps/api/src/lib/files/email-attachment-token.test.ts
@@ -76,12 +76,12 @@ describe("email attachment descriptors", () => {
         ...source,
         attachmentIndex: -1,
       }),
-    ).toThrow();
+    ).toThrow("Email attachment index is out of bounds");
     expect(() =>
       createEmailAttachmentDescriptor({
         ...source,
         attachmentIndex: Number.MAX_SAFE_INTEGER + 1,
       }),
-    ).toThrow();
+    ).toThrow("Email attachment index is out of bounds");
   });
 });

--- a/apps/api/src/lib/legal-search/corpus-storage.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-storage.test.ts
@@ -155,12 +155,16 @@ describe("persisted corpus JSON validation", () => {
       parsePersistedCorpusSections([
         { index: "0", type: "header", title: null, text: "Rozsudok" },
       ]),
-    ).toThrow();
+    ).toThrow('Invalid type: Expected number but received "0"');
     expect(() =>
       parsePersistedCorpusAst({ version: 1, blocks: [{ type: "paragraph" }] }),
-    ).toThrow();
-    expect(() => parsePersistedCorpusAst([])).toThrow();
-    expect(() => parsePersistedCorpusAst({ unexpected: true })).toThrow();
+    ).toThrow("Invalid type: Expected (Object | unknown) but received Object");
+    expect(() => parsePersistedCorpusAst([])).toThrow(
+      "Invalid type: Expected (Object | unknown) but received Array",
+    );
+    expect(() => parsePersistedCorpusAst({ unexpected: true })).toThrow(
+      "Invalid type: Expected (Object | unknown) but received Object",
+    );
   });
 });
 

--- a/apps/api/src/lib/legal-search/index-naming.test.ts
+++ b/apps/api/src/lib/legal-search/index-naming.test.ts
@@ -25,18 +25,30 @@ test("pattern globs all jurisdiction indexes for a generation", () => {
 });
 
 test("rejects a non-alpha jurisdiction (guards against odd index ids)", () => {
-  expect(() => corpusIndexId("case_law_v1", "sk droptable")).toThrow();
-  expect(() => corpusIndexId("case_law_v1", "")).toThrow();
-  expect(() => corpusIndexId("case_law_v1", "sk-1")).toThrow();
+  expect(() => corpusIndexId("case_law_v1", "sk droptable")).toThrow(
+    "Invalid jurisdiction for corpus index index id: sk droptable",
+  );
+  expect(() => corpusIndexId("case_law_v1", "")).toThrow(
+    "Invalid jurisdiction for corpus index index id: ",
+  );
+  expect(() => corpusIndexId("case_law_v1", "sk-1")).toThrow(
+    "Invalid jurisdiction for corpus index index id: sk-1",
+  );
 });
 
 test("rejects generations outside the shared storage contract", () => {
-  expect(() => corpusIndexId("", "svk")).toThrow();
-  expect(() => corpusIndexId("1_case_law", "svk")).toThrow();
+  expect(() => corpusIndexId("", "svk")).toThrow(
+    "Invalid corpus index generation: ",
+  );
+  expect(() => corpusIndexId("1_case_law", "svk")).toThrow(
+    "Invalid corpus index generation: 1_case_law",
+  );
   expect(() =>
     corpusIndexId("x".repeat(CORPUS_INDEX_GENERATION_MAX_LENGTH + 1), "svk"),
-  ).toThrow();
-  expect(() => corpusIndexPattern("case law v1")).toThrow();
+  ).toThrow("Invalid corpus index generation:");
+  expect(() => corpusIndexPattern("case law v1")).toThrow(
+    "Invalid corpus index generation: case law v1",
+  );
 });
 
 test("case-law generation order is canonical and total over its domain", () => {
@@ -80,8 +92,12 @@ test("generation extraction is the inverse of index construction", () => {
 });
 
 test("rejects malformed physical index ids", () => {
-  expect(() => corpusIndexGeneration("case_law_v1_12")).toThrow();
-  expect(() => corpusIndexGeneration("svk")).toThrow();
+  expect(() => corpusIndexGeneration("case_law_v1_12")).toThrow(
+    "Invalid corpus index index id: case_law_v1_12",
+  );
+  expect(() => corpusIndexGeneration("svk")).toThrow(
+    "Invalid corpus index index id: svk",
+  );
   expect(tryCorpusIndexGeneration("case_law_v1")).toBeNull();
   expect(tryCorpusIndexGeneration("case_law_v1_svk")).toBe("case_law_v1");
 });

--- a/apps/api/src/lib/provider-safe-json-schema.test.ts
+++ b/apps/api/src/lib/provider-safe-json-schema.test.ts
@@ -242,7 +242,9 @@ describe("projectToProviderSafeJsonSchema", () => {
       expect(providerKeywords.has("maxItems")).toBe(false);
     }
 
-    expect(() => v.parse(sourceSchema, { entries: [] })).toThrow();
+    expect(() => v.parse(sourceSchema, { entries: [] })).toThrow(
+      "Invalid length: Expected >=1 but received 0",
+    );
 
     const tooManyEntries = {
       entries: Array.from({ length: 201 }, (_, index) => ({
@@ -254,7 +256,9 @@ describe("projectToProviderSafeJsonSchema", () => {
         suggestedRevision: null,
       })),
     };
-    expect(() => v.parse(sourceSchema, tooManyEntries)).toThrow();
+    expect(() => v.parse(sourceSchema, tooManyEntries)).toThrow(
+      "Invalid length: Expected <=200 but received 201",
+    );
   });
 
   test("drops propertyNames from the fill_template repro while keeping additionalProperties", () => {

--- a/apps/api/src/lib/subprocess.test.ts
+++ b/apps/api/src/lib/subprocess.test.ts
@@ -129,7 +129,7 @@ describe("spawnWorker", () => {
         timeoutMs: 600_000,
         signal: abort.signal,
       }),
-    ).rejects.toThrow();
+    ).rejects.toThrow("The operation was aborted.");
   });
 });
 

--- a/apps/api/src/lib/usage/unit-model.test.ts
+++ b/apps/api/src/lib/usage/unit-model.test.ts
@@ -145,7 +145,7 @@ describe("computeRawUsageMicroUnits", () => {
         outputTokens: 0,
         cacheReadTokens: 200,
       }),
-    ).toThrow();
+    ).toThrow("cached input tokens cannot exceed total input tokens");
   });
 
   test("rejects every token field outside the non-negative safe-integer domain", () => {
@@ -169,7 +169,7 @@ describe("computeRawUsageMicroUnits", () => {
             cacheReadTokens: 0,
             [field]: invalidCount,
           }),
-        ).toThrow();
+        ).toThrow("usage token counts must be non-negative safe integers");
       }
     }
   });
@@ -181,7 +181,7 @@ describe("computeRawUsageMicroUnits", () => {
         inputTokens: 0,
         outputTokens: Number.MAX_SAFE_INTEGER,
       }),
-    ).toThrow();
+    ).toThrow("computed usage component exceeds the safe integer range");
   });
 
   test("keeps rate scaling exact when the intermediate product is unsafe", () => {

--- a/apps/api/src/lib/user-shortcuts.test.ts
+++ b/apps/api/src/lib/user-shortcuts.test.ts
@@ -21,24 +21,34 @@ describe("normalizeUserShortcutsField", () => {
   });
 
   test("rejects non-JSON and non-object shapes", () => {
-    expect(() => normalizeUserShortcutsField("not json")).toThrow();
-    expect(() => normalizeUserShortcutsField("[]")).toThrow();
-    expect(() => normalizeUserShortcutsField("42")).toThrow();
-    expect(() => normalizeUserShortcutsField(42)).toThrow();
+    expect(() => normalizeUserShortcutsField("not json")).toThrow(
+      "Invalid keyboard shortcuts",
+    );
+    expect(() => normalizeUserShortcutsField("[]")).toThrow(
+      "Invalid keyboard shortcuts",
+    );
+    expect(() => normalizeUserShortcutsField("42")).toThrow(
+      "Invalid keyboard shortcuts",
+    );
+    expect(() => normalizeUserShortcutsField(42)).toThrow(
+      "Invalid keyboard shortcuts",
+    );
   });
 
   test("rejects non-string binding values", () => {
     expect(() =>
       normalizeUserShortcutsField(JSON.stringify({ search: 5 })),
-    ).toThrow();
+    ).toThrow("Invalid keyboard shortcuts");
     expect(() =>
       normalizeUserShortcutsField(JSON.stringify({ search: "" })),
-    ).toThrow();
+    ).toThrow("Invalid keyboard shortcuts");
   });
 
   test("rejects an oversized blob", () => {
     const huge = JSON.stringify({ search: "M".repeat(5000) });
-    expect(() => normalizeUserShortcutsField(huge)).toThrow();
+    expect(() => normalizeUserShortcutsField(huge)).toThrow(
+      "Invalid keyboard shortcuts",
+    );
   });
 
   test("rejects too many entries", () => {
@@ -46,6 +56,8 @@ describe("normalizeUserShortcutsField", () => {
     for (let i = 0; i < 100; i += 1) {
       many[`k${i}`] = "Mod+A";
     }
-    expect(() => normalizeUserShortcutsField(JSON.stringify(many))).toThrow();
+    expect(() => normalizeUserShortcutsField(JSON.stringify(many))).toThrow(
+      "Invalid keyboard shortcuts",
+    );
   });
 });

--- a/apps/api/src/lib/views-schema.test.ts
+++ b/apps/api/src/lib/views-schema.test.ts
@@ -41,7 +41,9 @@ describe("parseViewLayout", () => {
       mode: "month",
     };
 
-    expect(() => parseViewLayout(layout)).toThrow();
+    expect(() => parseViewLayout(layout)).toThrow(
+      'Invalid key: Expected "version" but received undefined',
+    );
   });
 });
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -737,6 +737,7 @@ export default defineConfig({
     "./.oxlint-plugins/no-spread-input-in-query-key.ts",
     "./.oxlint-plugins/require-query-key-factory.ts",
     "./.oxlint-plugins/no-unsafe-inner-html.ts",
+    "./.oxlint-plugins/no-vacuous-throw-assertion.ts",
     "./.oxlint-plugins/no-centered-scroll-column.ts",
     "./.oxlint-plugins/no-static-devtools-import.ts",
     "./.oxlint-plugins/no-static-catalogue-route-import.ts",
@@ -2558,6 +2559,22 @@ export default defineConfig({
       ],
       rules: {
         "no-eager-singleton/no-eager-singleton": "error",
+      },
+    },
+    {
+      // Throw assertions must name the error they expect. Scoped to test
+      // files (and the module-named fixture, which is not one) because
+      // `expect(...).toThrow()` only appears there.
+      files: [
+        "**/*.test.{ts,tsx}",
+        "**/*.property.test.{ts,tsx}",
+        "**/*.spec.{ts,tsx}",
+        "**/__tests__/**/*.{ts,tsx}",
+        "apps/api/src/tests/**/*.ts",
+        ".oxlint-plugins/__fixtures__/no-vacuous-throw-assertion.fixture.ts",
+      ],
+      rules: {
+        "no-vacuous-throw-assertion/no-vacuous-throw-assertion": "error",
       },
     },
     {

--- a/packages/api-contract/src/resource-ref.test.ts
+++ b/packages/api-contract/src/resource-ref.test.ts
@@ -106,8 +106,12 @@ describe("canonical resource identity", () => {
     expect(
       parseResourceRef({ type: RESOURCE_TYPE.ENTITY, id: "\uD800" }),
     ).toBeNull();
-    expect(() => toSafeId<"entity">("")).toThrow();
-    expect(() => toSafeId<"entity">("\uD800")).toThrow();
+    expect(() => toSafeId<"entity">("")).toThrow(
+      "Expected a non-empty, well-formed identifier",
+    );
+    expect(() => toSafeId<"entity">("\uD800")).toThrow(
+      "Expected a non-empty, well-formed identifier",
+    );
     expect(
       parseResourceRef({
         type: RESOURCE_TYPE.ENTITY,

--- a/packages/conditions/src/evaluate.test.ts
+++ b/packages/conditions/src/evaluate.test.ts
@@ -284,7 +284,7 @@ describe("schema", () => {
         op: "bogus",
         right: { type: "literal", value: "x" },
       }),
-    ).toThrow();
+    ).toThrow('but received "bogus"');
   });
 });
 
@@ -320,7 +320,7 @@ describe("formula operand", () => {
         op: "gte",
         right: { type: "literal", value: 1000 },
       }),
-    ).toThrow();
+    ).toThrow("Expected >=1 but received 0");
   });
 
   test("a formula-right ordered comparison is complete, not pruned", () => {

--- a/packages/skills/src/loader.test.ts
+++ b/packages/skills/src/loader.test.ts
@@ -51,7 +51,7 @@ description: Valid description.
 ---
 
 Body.`),
-    ).toThrow();
+    ).toThrow("Skill file frontmatter must include name and description");
     expect(() =>
       parseSkillFile(`---
 name: valid-name
@@ -59,7 +59,7 @@ description: "   "
 ---
 
 Body.`),
-    ).toThrow();
+    ).toThrow("Skill file frontmatter must include name and description");
   });
 
   test("parses skill files with CRLF line endings", () => {

--- a/scripts/check-migration-order.test.ts
+++ b/scripts/check-migration-order.test.ts
@@ -45,6 +45,53 @@ describe("migration ordering", () => {
     });
   });
 
+  // The motivating race: the branch is generated against an older tip, and a
+  // higher-timestamped migration lands on the base branch before it merges.
+  // Already-migrated databases record the higher timestamp and never apply the
+  // lower one, so the DDL silently never runs.
+  test("rejects a migration that the base branch overtook after it was generated", () => {
+    expect(
+      findMigrationOrderViolation({
+        baseDirectories: [
+          "20260816140000_branch_point",
+          "20260816200000_landed_meanwhile",
+        ],
+        newDirectories: ["apps/api/drizzle/20260816150000_generated_earlier"],
+      }),
+    ).toMatchObject({
+      type: "not-after-base",
+      timestamp: "20260816150000",
+      previousTimestamp: "20260816200000",
+    });
+  });
+
+  test("a pull request that adds no migrations has nothing to violate", () => {
+    expect(
+      findMigrationOrderViolation({
+        baseDirectories: ["20260816200000_landed_meanwhile"],
+        newDirectories: [],
+      }),
+    ).toBeNull();
+  });
+
+  test("the first migration in an empty tree is accepted", () => {
+    expect(
+      findMigrationOrderViolation({
+        baseDirectories: [],
+        newDirectories: ["apps/api/drizzle/20260801120000_initial"],
+      }),
+    ).toBeNull();
+  });
+
+  test("base directories without timestamps do not raise the floor", () => {
+    expect(
+      findMigrationOrderViolation({
+        baseDirectories: ["meta", "20260801120000_existing"],
+        newDirectories: ["apps/api/drizzle/20260801130000_next"],
+      }),
+    ).toBeNull();
+  });
+
   test("rejects migration directories without canonical timestamps", () => {
     expect(
       findMigrationOrderViolation({

--- a/scripts/check-migration-order.ts
+++ b/scripts/check-migration-order.ts
@@ -102,8 +102,11 @@ if (import.meta.main) {
   }
   if (violation?.type === "not-after-base") {
     panic(
-      `New migration ${violation.directory} has timestamp ${violation.timestamp}; ` +
-        `it must be later than ${violation.previousTimestamp} so already-migrated databases apply it.`,
+      `New migration ${violation.directory} has timestamp ${violation.timestamp}, ` +
+        `which is not above ${violation.previousTimestamp}. Rename the directory ` +
+        `(and its journal entry) to a timestamp above ${violation.previousTimestamp}: ` +
+        `a database that already recorded ${violation.previousTimestamp} skips this ` +
+        `migration silently, so its DDL never runs and nothing reports an error.`,
     );
   }
 }

--- a/scripts/env-tool.test.ts
+++ b/scripts/env-tool.test.ts
@@ -791,7 +791,7 @@ describe("web container build arguments", () => {
           exports: [["VITE_EXAMPLE", `prefix-${reference("EXAMPLE_INPUT")}`]],
         }),
       }),
-    ).toThrow();
+    ).toThrow("VITE_EXAMPLE must map directly to one build argument");
   });
 
   test("report a schema key the build command never exports", () => {
@@ -889,6 +889,6 @@ describe("web container build arguments", () => {
   test("fail loudly when the build command moves", () => {
     expect(() =>
       parseWebBuildContract("FROM oven/bun AS builder\nRUN bun run build\n"),
-    ).toThrow();
+    ).toThrow("no longer runs");
   });
 });

--- a/scripts/lint-suppressions.ts
+++ b/scripts/lint-suppressions.ts
@@ -39,10 +39,17 @@ import ts from "typescript";
 // `data-volume` and unlike `security`, it carries a per-rule budget but no
 // waiver ledger: the exceptions are numerous and individually cheap to read
 // from the baseline diff, and none of them stands down an authorization check.
+// A `test-integrity` rule guards the assertion itself rather than the product:
+// it rejects a test shape that keeps passing after the behavior it was written
+// for is gone. A suppression here means one guard has been downgraded to a
+// smoke check, which is a coverage decision readable from the baseline diff
+// alone. Like `data-volume` and `observability`, it carries a per-rule budget
+// and no waiver ledger.
 export const SUPPRESSION_TIERS = [
   "security",
   "data-volume",
   "observability",
+  "test-integrity",
 ] as const;
 
 export type SuppressionTier = (typeof SUPPRESSION_TIERS)[number];
@@ -181,6 +188,12 @@ export const TRACKED_SUPPRESSION_RULES = [
     tier: "observability",
     guards:
       "detached-promise labels that cannot correlate a captured rejection to a call site",
+  },
+  {
+    rule: "no-vacuous-throw-assertion/no-vacuous-throw-assertion",
+    tier: "test-integrity",
+    guards:
+      "throw assertions that pin no error, so any unrelated failure keeps them green",
   },
 ] as const satisfies readonly TrackedSuppressionRule[];
 

--- a/scripts/merge-bar.test.ts
+++ b/scripts/merge-bar.test.ts
@@ -4,6 +4,8 @@ import { evaluateMergeBar, type MergeBarSnapshot } from "./merge-bar";
 
 const HEAD_SHA = "1f0c3a7d9e5b4c2a8d6f0e1b3c5a7d9e5b4c2a8d";
 const OTHER_SHA = "9e5b4c2a8d6f0e1b3c5a7d9e5b4c2a8d6f0e1b3c";
+const BASE_SHA = "4c2a8d6f0e1b3c5a7d9e5b4c2a8d6f0e1b3c5a7d";
+const OTHER_BASE_SHA = "0e1b3c5a7d9e5b4c2a8d6f0e1b3c5a7d9e5b4c2a";
 
 const passingSnapshot = (
   overrides: Partial<MergeBarSnapshot> = {},
@@ -26,7 +28,9 @@ const passingSnapshot = (
   migrations: {
     baseDirectories: ["20260801120000_earlier", "20260812090000_latest"],
     addedDirectories: ["apps/api/drizzle/20260816200000_new_column"],
+    baseSha: BASE_SHA,
   },
+  baseShaBeforeMerge: BASE_SHA,
   headShaBeforeMerge: HEAD_SHA,
   ...overrides,
 });
@@ -210,6 +214,7 @@ describe("merge bar", () => {
           migrations: {
             baseDirectories: ["20260816200000_landed_meanwhile"],
             addedDirectories: ["apps/api/drizzle/20260816140000_branch"],
+            baseSha: BASE_SHA,
           },
         }),
       ),
@@ -223,6 +228,7 @@ describe("merge bar", () => {
           migrations: {
             baseDirectories: ["20260816200000_landed_meanwhile"],
             addedDirectories: ["apps/api/drizzle/20260816200000_branch"],
+            baseSha: BASE_SHA,
           },
         }),
       ),
@@ -236,7 +242,34 @@ describe("merge bar", () => {
           migrations: {
             baseDirectories: ["20260816200000_landed_meanwhile"],
             addedDirectories: [],
+            baseSha: BASE_SHA,
           },
+        }),
+      ).decision,
+    ).toBe("merge");
+  });
+
+  // The migration maximum was read from a commit that is no longer the tip, so
+  // another migration-bearing merge may have landed a higher timestamp since.
+  test("a base branch that moved under added migrations aborts", () => {
+    expect(
+      failedGate(passingSnapshot({ baseShaBeforeMerge: OTHER_BASE_SHA })),
+    ).toEqual({
+      decision: "abort",
+      reasons: ["BASE_MOVED_UNDER_ADDED_MIGRATIONS"],
+    });
+  });
+
+  test("base movement is irrelevant when the pull request adds no migrations", () => {
+    expect(
+      evaluateMergeBar(
+        passingSnapshot({
+          migrations: {
+            baseDirectories: ["20260816200000_landed_meanwhile"],
+            addedDirectories: [],
+            baseSha: BASE_SHA,
+          },
+          baseShaBeforeMerge: OTHER_BASE_SHA,
         }),
       ).decision,
     ).toBe("merge");
@@ -252,12 +285,13 @@ describe("merge bar", () => {
         },
         checkRuns: [],
         reviewThreads: [{ id: "PRRT_open", isResolved: false }],
+        baseShaBeforeMerge: OTHER_BASE_SHA,
         headShaBeforeMerge: OTHER_SHA,
       }),
     );
 
     expect(verdict.gates.filter((gate) => gate.status === "fail")).toHaveLength(
-      5,
+      6,
     );
   });
 
@@ -267,6 +301,7 @@ describe("merge bar", () => {
     );
 
     expect(gates.toSorted()).toEqual([
+      "base-stability",
       "head-stability",
       "mergeable",
       "migration-order",

--- a/scripts/merge-bar.test.ts
+++ b/scripts/merge-bar.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, test } from "bun:test";
+
+import { evaluateMergeBar, type MergeBarSnapshot } from "./merge-bar";
+
+const HEAD_SHA = "1f0c3a7d9e5b4c2a8d6f0e1b3c5a7d9e5b4c2a8d";
+const OTHER_SHA = "9e5b4c2a8d6f0e1b3c5a7d9e5b4c2a8d6f0e1b3c";
+
+const passingSnapshot = (
+  overrides: Partial<MergeBarSnapshot> = {},
+): MergeBarSnapshot => ({
+  pullRequest: {
+    number: 2137,
+    title: "feat(api): pre-flight budget resolution",
+    body: "Resolves the budget before the request runs.",
+    state: "OPEN",
+    isDraft: false,
+    mergeable: "MERGEABLE",
+    headSha: HEAD_SHA,
+  },
+  checkRunsHeadSha: HEAD_SHA,
+  checkRuns: [
+    { name: "ci-result", status: "completed", conclusion: "success" },
+    { name: "typecheck", status: "completed", conclusion: "success" },
+  ],
+  reviewThreads: [{ id: "PRRT_kwDOabcdef", isResolved: true }],
+  migrations: {
+    baseDirectories: ["20260801120000_earlier", "20260812090000_latest"],
+    addedDirectories: ["apps/api/drizzle/20260816200000_new_column"],
+  },
+  headShaBeforeMerge: HEAD_SHA,
+  ...overrides,
+});
+
+const failedGate = (snapshot: MergeBarSnapshot) => {
+  const verdict = evaluateMergeBar(snapshot);
+  return {
+    decision: verdict.decision,
+    reasons: verdict.gates.flatMap((gate) =>
+      gate.status === "fail" ? [gate.reason] : [],
+    ),
+  };
+};
+
+describe("merge bar", () => {
+  test("merges when every gate is positively satisfied", () => {
+    const verdict = evaluateMergeBar(passingSnapshot());
+
+    expect(verdict.decision).toBe("merge");
+    expect(verdict.gates.every((gate) => gate.status === "pass")).toBe(true);
+  });
+
+  // Failure class (a): a negative predicate over an empty list reads as green.
+  test("an empty check-run list fails rather than passing vacuously", () => {
+    expect(failedGate(passingSnapshot({ checkRuns: [] }))).toEqual({
+      decision: "abort",
+      reasons: ["REQUIRED_CHECK_MISSING"],
+    });
+  });
+
+  test("other checks succeeding does not substitute for ci-result", () => {
+    expect(
+      failedGate(
+        passingSnapshot({
+          checkRuns: [
+            { name: "typecheck", status: "completed", conclusion: "success" },
+            { name: "lint", status: "completed", conclusion: "success" },
+          ],
+        }),
+      ),
+    ).toEqual({ decision: "abort", reasons: ["REQUIRED_CHECK_MISSING"] });
+  });
+
+  test("a conflicting pull request fails on mergeability and on its empty check list", () => {
+    expect(
+      failedGate(
+        passingSnapshot({
+          pullRequest: {
+            ...passingSnapshot().pullRequest,
+            mergeable: "CONFLICTING",
+          },
+          checkRuns: [],
+        }),
+      ),
+    ).toEqual({
+      decision: "abort",
+      reasons: ["MERGEABLE_CONFLICTING", "REQUIRED_CHECK_MISSING"],
+    });
+  });
+
+  test("a draft fails before its empty check list can be misread", () => {
+    expect(
+      failedGate(
+        passingSnapshot({
+          pullRequest: { ...passingSnapshot().pullRequest, isDraft: true },
+          checkRuns: [],
+        }),
+      ),
+    ).toEqual({
+      decision: "abort",
+      reasons: ["PULL_REQUEST_IS_DRAFT", "REQUIRED_CHECK_MISSING"],
+    });
+  });
+
+  test("UNKNOWN mergeability is a refusal, not a pass", () => {
+    expect(
+      failedGate(
+        passingSnapshot({
+          pullRequest: {
+            ...passingSnapshot().pullRequest,
+            mergeable: "UNKNOWN",
+          },
+        }),
+      ),
+    ).toEqual({ decision: "abort", reasons: ["MERGEABLE_UNKNOWN"] });
+  });
+
+  test("a closed pull request is refused", () => {
+    expect(
+      failedGate(
+        passingSnapshot({
+          pullRequest: { ...passingSnapshot().pullRequest, state: "MERGED" },
+        }),
+      ),
+    ).toEqual({ decision: "abort", reasons: ["PULL_REQUEST_NOT_OPEN"] });
+  });
+
+  test("a still-running ci-result is not a success", () => {
+    expect(
+      failedGate(
+        passingSnapshot({
+          checkRuns: [
+            { name: "ci-result", status: "in_progress", conclusion: null },
+          ],
+        }),
+      ),
+    ).toEqual({ decision: "abort", reasons: ["REQUIRED_CHECK_INCOMPLETE"] });
+  });
+
+  test("a completed but unsuccessful ci-result is refused", () => {
+    expect(
+      failedGate(
+        passingSnapshot({
+          checkRuns: [
+            { name: "ci-result", status: "completed", conclusion: "failure" },
+          ],
+        }),
+      ),
+    ).toEqual({
+      decision: "abort",
+      reasons: ["REQUIRED_CHECK_NOT_SUCCESSFUL"],
+    });
+  });
+
+  test("a skipped ci-result is refused", () => {
+    expect(
+      failedGate(
+        passingSnapshot({
+          checkRuns: [
+            { name: "ci-result", status: "completed", conclusion: "skipped" },
+          ],
+        }),
+      ),
+    ).toEqual({
+      decision: "abort",
+      reasons: ["REQUIRED_CHECK_NOT_SUCCESSFUL"],
+    });
+  });
+
+  // Failure class (b): check runs that describe a commit that is no longer head.
+  test("check runs fetched for a different SHA cannot vouch for head", () => {
+    expect(
+      failedGate(passingSnapshot({ checkRunsHeadSha: OTHER_SHA })),
+    ).toEqual({
+      decision: "abort",
+      reasons: ["CHECK_RUNS_READ_FOR_STALE_SHA"],
+    });
+  });
+
+  test("a push between the checks and the merge aborts", () => {
+    expect(
+      failedGate(passingSnapshot({ headShaBeforeMerge: OTHER_SHA })),
+    ).toEqual({ decision: "abort", reasons: ["HEAD_MOVED_DURING_CHECKS"] });
+  });
+
+  test("an unresolved review thread aborts", () => {
+    expect(
+      failedGate(
+        passingSnapshot({
+          reviewThreads: [
+            { id: "PRRT_resolved", isResolved: true },
+            { id: "PRRT_open", isResolved: false },
+          ],
+        }),
+      ),
+    ).toEqual({ decision: "abort", reasons: ["UNRESOLVED_REVIEW_THREADS"] });
+  });
+
+  test("zero review threads is a pass, not a missing observation", () => {
+    expect(
+      evaluateMergeBar(passingSnapshot({ reviewThreads: [] })).decision,
+    ).toBe("merge");
+  });
+
+  // Failure class (b) across pull requests: the branch's own CI could not see
+  // a migration that landed on the default branch after that run finished.
+  test("a migration below the default branch's maximum aborts at merge time", () => {
+    expect(
+      failedGate(
+        passingSnapshot({
+          migrations: {
+            baseDirectories: ["20260816200000_landed_meanwhile"],
+            addedDirectories: ["apps/api/drizzle/20260816140000_branch"],
+          },
+        }),
+      ),
+    ).toEqual({ decision: "abort", reasons: ["MIGRATION_ORDER_VIOLATION"] });
+  });
+
+  test("a migration equal to the default branch's maximum aborts", () => {
+    expect(
+      failedGate(
+        passingSnapshot({
+          migrations: {
+            baseDirectories: ["20260816200000_landed_meanwhile"],
+            addedDirectories: ["apps/api/drizzle/20260816200000_branch"],
+          },
+        }),
+      ),
+    ).toEqual({ decision: "abort", reasons: ["MIGRATION_ORDER_VIOLATION"] });
+  });
+
+  test("a pull request that adds no migrations passes the ordering gate", () => {
+    expect(
+      evaluateMergeBar(
+        passingSnapshot({
+          migrations: {
+            baseDirectories: ["20260816200000_landed_meanwhile"],
+            addedDirectories: [],
+          },
+        }),
+      ).decision,
+    ).toBe("merge");
+  });
+
+  test("every failing gate is reported, not just the first", () => {
+    const verdict = evaluateMergeBar(
+      passingSnapshot({
+        pullRequest: {
+          ...passingSnapshot().pullRequest,
+          state: "CLOSED",
+          mergeable: "CONFLICTING",
+        },
+        checkRuns: [],
+        reviewThreads: [{ id: "PRRT_open", isResolved: false }],
+        headShaBeforeMerge: OTHER_SHA,
+      }),
+    );
+
+    expect(verdict.gates.filter((gate) => gate.status === "fail")).toHaveLength(
+      5,
+    );
+  });
+
+  test("the verdict covers every declared gate exactly once", () => {
+    const gates = evaluateMergeBar(passingSnapshot()).gates.map(
+      (gate) => gate.gate,
+    );
+
+    expect(gates.toSorted()).toEqual([
+      "head-stability",
+      "mergeable",
+      "migration-order",
+      "pull-request-state",
+      "required-check",
+      "review-threads",
+    ]);
+  });
+});

--- a/scripts/merge-bar.ts
+++ b/scripts/merge-bar.ts
@@ -1,0 +1,753 @@
+#!/usr/bin/env bun
+//
+// Merge bar: the sanctioned way to merge a pull request.
+//
+// `gh pr merge` is a single write with no state assertions, so the operator
+// supplies the safety argument from whatever they happened to read earlier.
+// This tool re-reads every input inside one invocation and asserts each gate
+// POSITIVELY before it writes. Three failure classes motivate it:
+//
+// (a) Negative-check misreads. "No failing checks" is not "checks passed".
+//     A CONFLICTING pull request produces ZERO check runs, a draft produces
+//     ZERO check runs, and a rollup filtered for failures over an empty list
+//     is empty — all three read as green to a negative predicate. Every gate
+//     here therefore demands a positive observation: the `ci-result` check run
+//     must EXIST on the exact current head SHA with conclusion `success`, and
+//     an empty check-run list fails rather than passes.
+//
+// (b) Time-of-check to time-of-use. Review threads, reviews, and pushes land
+//     between a state read and the merge call. Gate inputs read minutes ago
+//     describe a pull request that no longer exists. Everything below is
+//     fetched in THIS invocation, and the head SHA is re-read immediately
+//     before the merge so a push mid-flight aborts instead of merging code
+//     nothing verified. The same staleness applies across pull requests:
+//     migration ordering is re-checked against the live default branch,
+//     because a branch's own CI run cannot see a migration that landed on the
+//     default branch after that run finished.
+//
+// (c) Merge-body file clobbering. `gh pr merge --body-file path` reads the
+//     file at merge time, so a concurrent writer to that path silently
+//     rewrites the commit message. The body is read and inlined here at
+//     startup; the merge call never receives a path.
+//
+// What this tool deliberately does NOT gate: review depth. Automated review
+// requests are budgeted at two per pull request, because a third round buys
+// re-litigation of the same diff rather than new findings. Spend both, address
+// what they surface, resolve the threads, and let the gates below decide. A
+// green bar is the merge argument; another review request is not.
+//
+// Usage:
+//   bun scripts/merge-bar.ts <pr-number> [--repo owner/name] [--body-file path]
+//                                        [--admin] [--dry-run]
+//
+// Without --body-file the pull request body read in this invocation becomes
+// the squash body, so the commit message never degrades into a commit list.
+
+import { panic } from "better-result";
+import { readFileSync } from "node:fs";
+
+import { findMigrationOrderViolation } from "./check-migration-order";
+
+const DEFAULT_REPO = "stella/stella";
+const REQUIRED_CHECK_RUN = "ci-result";
+const MIGRATION_DIRECTORY = "apps/api/drizzle";
+const MERGEABLE_POLL_ATTEMPTS = 8;
+const MERGEABLE_POLL_INTERVAL_MS = 2000;
+
+// --- Gate model -------------------------------------------------------------
+
+const GATE_IDS = [
+  "pull-request-state",
+  "mergeable",
+  "required-check",
+  "review-threads",
+  "migration-order",
+  "head-stability",
+] as const;
+type GateId = (typeof GATE_IDS)[number];
+
+// Named reasons: a refusal must say which invariant failed, never just "no".
+const MERGE_BAR_REASONS = {
+  notOpen: "PULL_REQUEST_NOT_OPEN",
+  draft: "PULL_REQUEST_IS_DRAFT",
+  conflicting: "MERGEABLE_CONFLICTING",
+  mergeableUnknown: "MERGEABLE_UNKNOWN",
+  checkRunsStale: "CHECK_RUNS_READ_FOR_STALE_SHA",
+  requiredCheckMissing: "REQUIRED_CHECK_MISSING",
+  requiredCheckIncomplete: "REQUIRED_CHECK_INCOMPLETE",
+  requiredCheckNotSuccessful: "REQUIRED_CHECK_NOT_SUCCESSFUL",
+  unresolvedReviewThreads: "UNRESOLVED_REVIEW_THREADS",
+  migrationOrder: "MIGRATION_ORDER_VIOLATION",
+  headMoved: "HEAD_MOVED_DURING_CHECKS",
+} as const;
+type MergeBarReason =
+  (typeof MERGE_BAR_REASONS)[keyof typeof MERGE_BAR_REASONS];
+
+const PULL_REQUEST_STATES = ["OPEN", "CLOSED", "MERGED"] as const;
+const MERGEABLE_STATES = ["MERGEABLE", "CONFLICTING", "UNKNOWN"] as const;
+
+type PullRequestSnapshot = {
+  number: number;
+  title: string;
+  body: string;
+  state: (typeof PULL_REQUEST_STATES)[number];
+  isDraft: boolean;
+  mergeable: (typeof MERGEABLE_STATES)[number];
+  headSha: string;
+};
+
+type CheckRunSnapshot = {
+  name: string;
+  status: string;
+  conclusion: string | null;
+};
+
+type ReviewThreadSnapshot = { id: string; isResolved: boolean };
+
+type MigrationSnapshot = {
+  // Migration directories present on the default branch right now.
+  baseDirectories: readonly string[];
+  // Migration directories this pull request adds.
+  addedDirectories: readonly string[];
+};
+
+export type MergeBarSnapshot = {
+  pullRequest: PullRequestSnapshot;
+  // The SHA the check runs were actually fetched for. Kept separate from
+  // `pullRequest.headSha` so a read against a stale commit cannot masquerade
+  // as a read against the current one.
+  checkRunsHeadSha: string;
+  checkRuns: readonly CheckRunSnapshot[];
+  reviewThreads: readonly ReviewThreadSnapshot[];
+  migrations: MigrationSnapshot;
+  // Re-read immediately before the merge call.
+  headShaBeforeMerge: string;
+};
+
+type GateVerdict =
+  | { gate: GateId; status: "pass"; detail: string }
+  | { gate: GateId; status: "fail"; reason: MergeBarReason; detail: string };
+
+export type MergeBarVerdict = {
+  decision: "merge" | "abort";
+  gates: readonly GateVerdict[];
+};
+
+// --- Gates (pure) -----------------------------------------------------------
+
+const evaluatePullRequestState = (
+  pullRequest: PullRequestSnapshot,
+): GateVerdict => {
+  if (pullRequest.state !== "OPEN") {
+    return {
+      gate: "pull-request-state",
+      status: "fail",
+      reason: MERGE_BAR_REASONS.notOpen,
+      detail: `state is ${pullRequest.state}`,
+    };
+  }
+  // A draft runs zero required workflows, so its check-run list is empty for
+  // reasons that have nothing to do with the code being correct.
+  if (pullRequest.isDraft) {
+    return {
+      gate: "pull-request-state",
+      status: "fail",
+      reason: MERGE_BAR_REASONS.draft,
+      detail: "draft pull requests do not run the required workflows",
+    };
+  }
+  return { gate: "pull-request-state", status: "pass", detail: "OPEN" };
+};
+
+const evaluateMergeable = (pullRequest: PullRequestSnapshot): GateVerdict => {
+  if (pullRequest.mergeable === "CONFLICTING") {
+    return {
+      gate: "mergeable",
+      status: "fail",
+      reason: MERGE_BAR_REASONS.conflicting,
+      detail: "rebase onto the default branch; a conflicting PR runs no CI",
+    };
+  }
+  if (pullRequest.mergeable === "UNKNOWN") {
+    return {
+      gate: "mergeable",
+      status: "fail",
+      reason: MERGE_BAR_REASONS.mergeableUnknown,
+      detail: "GitHub has not finished computing mergeability",
+    };
+  }
+  return { gate: "mergeable", status: "pass", detail: "MERGEABLE" };
+};
+
+const evaluateRequiredCheck = ({
+  checkRuns,
+  checkRunsHeadSha,
+  headSha,
+}: {
+  checkRuns: readonly CheckRunSnapshot[];
+  checkRunsHeadSha: string;
+  headSha: string;
+}): GateVerdict => {
+  if (checkRunsHeadSha !== headSha) {
+    return {
+      gate: "required-check",
+      status: "fail",
+      reason: MERGE_BAR_REASONS.checkRunsStale,
+      detail: `check runs read for ${checkRunsHeadSha}, head is ${headSha}`,
+    };
+  }
+
+  const required = checkRuns.filter((run) => run.name === REQUIRED_CHECK_RUN);
+  // The load-bearing case: an empty list is an ABSENT verdict, not a passing
+  // one. Filtering a rollup for failures would report "none" here and merge.
+  if (required.length === 0) {
+    return {
+      gate: "required-check",
+      status: "fail",
+      reason: MERGE_BAR_REASONS.requiredCheckMissing,
+      detail:
+        `no \`${REQUIRED_CHECK_RUN}\` check run on ${headSha} ` +
+        `(${checkRuns.length} check run(s) present)`,
+    };
+  }
+
+  const incomplete = required.filter((run) => run.status !== "completed");
+  if (incomplete.length > 0) {
+    return {
+      gate: "required-check",
+      status: "fail",
+      reason: MERGE_BAR_REASONS.requiredCheckIncomplete,
+      detail: `\`${REQUIRED_CHECK_RUN}\` is ${incomplete.at(0)?.status ?? "pending"}`,
+    };
+  }
+
+  const unsuccessful = required.filter((run) => run.conclusion !== "success");
+  if (unsuccessful.length > 0) {
+    return {
+      gate: "required-check",
+      status: "fail",
+      reason: MERGE_BAR_REASONS.requiredCheckNotSuccessful,
+      detail: `\`${REQUIRED_CHECK_RUN}\` concluded ${unsuccessful.at(0)?.conclusion ?? "null"}`,
+    };
+  }
+
+  return {
+    gate: "required-check",
+    status: "pass",
+    detail: `\`${REQUIRED_CHECK_RUN}\` success on ${headSha}`,
+  };
+};
+
+const evaluateReviewThreads = (
+  reviewThreads: readonly ReviewThreadSnapshot[],
+): GateVerdict => {
+  const unresolved = reviewThreads.filter((thread) => !thread.isResolved);
+  if (unresolved.length > 0) {
+    return {
+      gate: "review-threads",
+      status: "fail",
+      reason: MERGE_BAR_REASONS.unresolvedReviewThreads,
+      detail: `${unresolved.length} unresolved thread(s): ${unresolved
+        .map((thread) => thread.id)
+        .join(", ")}`,
+    };
+  }
+  return {
+    gate: "review-threads",
+    status: "pass",
+    detail: `${reviewThreads.length} thread(s), all resolved`,
+  };
+};
+
+const evaluateMigrationOrder = (migrations: MigrationSnapshot): GateVerdict => {
+  const violation = findMigrationOrderViolation({
+    baseDirectories: migrations.baseDirectories,
+    newDirectories: migrations.addedDirectories,
+  });
+  if (violation?.type === "invalid-name") {
+    return {
+      gate: "migration-order",
+      status: "fail",
+      reason: MERGE_BAR_REASONS.migrationOrder,
+      detail: `${violation.directory} does not start with a 14-digit timestamp`,
+    };
+  }
+  if (violation?.type === "not-after-base") {
+    return {
+      gate: "migration-order",
+      status: "fail",
+      reason: MERGE_BAR_REASONS.migrationOrder,
+      detail:
+        `${violation.directory} (${violation.timestamp}) is not above ` +
+        `${violation.previousTimestamp}; rename it to a timestamp above ` +
+        `${violation.previousTimestamp} so already-migrated databases apply it`,
+    };
+  }
+  return {
+    gate: "migration-order",
+    status: "pass",
+    detail: `${migrations.addedDirectories.length} added migration(s) ordered above the default branch`,
+  };
+};
+
+const evaluateHeadStability = ({
+  headSha,
+  headShaBeforeMerge,
+}: {
+  headSha: string;
+  headShaBeforeMerge: string;
+}): GateVerdict => {
+  if (headSha !== headShaBeforeMerge) {
+    return {
+      gate: "head-stability",
+      status: "fail",
+      reason: MERGE_BAR_REASONS.headMoved,
+      detail: `head moved ${headSha} -> ${headShaBeforeMerge}; nothing verified that commit`,
+    };
+  }
+  return { gate: "head-stability", status: "pass", detail: headSha };
+};
+
+/**
+ * The whole merge bar as a pure function of one snapshot: every gate is
+ * evaluated so the operator sees the full picture, and any single failure
+ * aborts. Callers must build the snapshot from reads taken in one invocation.
+ */
+export const evaluateMergeBar = (
+  snapshot: MergeBarSnapshot,
+): MergeBarVerdict => {
+  const gates = [
+    evaluatePullRequestState(snapshot.pullRequest),
+    evaluateMergeable(snapshot.pullRequest),
+    evaluateRequiredCheck({
+      checkRuns: snapshot.checkRuns,
+      checkRunsHeadSha: snapshot.checkRunsHeadSha,
+      headSha: snapshot.pullRequest.headSha,
+    }),
+    evaluateReviewThreads(snapshot.reviewThreads),
+    evaluateMigrationOrder(snapshot.migrations),
+    evaluateHeadStability({
+      headSha: snapshot.pullRequest.headSha,
+      headShaBeforeMerge: snapshot.headShaBeforeMerge,
+    }),
+  ] as const;
+
+  return {
+    decision: gates.some((gate) => gate.status === "fail") ? "abort" : "merge",
+    gates,
+  };
+};
+
+// --- gh seam ----------------------------------------------------------------
+
+type GitHubGateway = {
+  readPullRequest: () => PullRequestSnapshot;
+  // Deliberately separate from `readPullRequest`: the pre-merge re-read only
+  // needs the SHA, and a narrow read makes the TOCTOU window smaller.
+  readHeadSha: () => string;
+  readCheckRuns: (headSha: string) => readonly CheckRunSnapshot[];
+  readReviewThreads: () => readonly ReviewThreadSnapshot[];
+  readMigrationDirectories: () => MigrationSnapshot;
+  merge: (input: { subject: string; body: string; admin: boolean }) => string;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const readRecord = (value: unknown, label: string): Record<string, unknown> => {
+  if (!isRecord(value)) {
+    panic(`Expected an object for ${label}`);
+  }
+  return value;
+};
+
+const readString = (record: Record<string, unknown>, key: string): string => {
+  const value = record[key];
+  if (typeof value !== "string") {
+    panic(`Expected string field \`${key}\` in gh response`);
+  }
+  return value;
+};
+
+const readBoolean = (record: Record<string, unknown>, key: string): boolean => {
+  const value = record[key];
+  if (typeof value !== "boolean") {
+    panic(`Expected boolean field \`${key}\` in gh response`);
+  }
+  return value;
+};
+
+const readMember = <T extends string>(
+  allowed: readonly T[],
+  value: string,
+  label: string,
+): T => {
+  const match = allowed.find((candidate) => candidate === value);
+  if (match === undefined) {
+    panic(`Unexpected ${label} from gh: ${value}`);
+  }
+  return match;
+};
+
+const runGh = (args: readonly string[]): string => {
+  const result = Bun.spawnSync(["gh", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (result.exitCode !== 0) {
+    panic(
+      `gh ${args.join(" ")} failed (${result.exitCode}): ${result.stderr.toString()}`,
+    );
+  }
+  return result.stdout.toString();
+};
+
+const runGhJson = (args: readonly string[]): unknown => JSON.parse(runGh(args));
+
+const REVIEW_THREADS_QUERY = `
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { id isResolved }
+      }
+    }
+  }
+}`;
+
+const createGhGateway = ({
+  repo,
+  pullNumber,
+}: {
+  repo: string;
+  pullNumber: number;
+}): GitHubGateway => {
+  const [owner, name] = repo.split("/");
+  if (owner === undefined || name === undefined || name === "") {
+    panic(`--repo must be owner/name, got: ${repo}`);
+  }
+  const prArgs = [String(pullNumber), "--repo", repo];
+
+  return {
+    readHeadSha: () =>
+      readString(
+        readRecord(
+          runGhJson(["pr", "view", ...prArgs, "--json", "headRefOid"]),
+          "pr view",
+        ),
+        "headRefOid",
+      ),
+
+    readPullRequest: () => {
+      const raw = readRecord(
+        runGhJson([
+          "pr",
+          "view",
+          ...prArgs,
+          "--json",
+          "number,title,body,state,isDraft,mergeable,headRefOid",
+        ]),
+        "pr view",
+      );
+      const number = raw["number"];
+      if (typeof number !== "number") {
+        panic("Expected numeric field `number` in gh response");
+      }
+      return {
+        number,
+        title: readString(raw, "title"),
+        body: readString(raw, "body"),
+        state: readMember(
+          PULL_REQUEST_STATES,
+          readString(raw, "state"),
+          "state",
+        ),
+        isDraft: readBoolean(raw, "isDraft"),
+        mergeable: readMember(
+          MERGEABLE_STATES,
+          readString(raw, "mergeable"),
+          "mergeable",
+        ),
+        headSha: readString(raw, "headRefOid"),
+      };
+    },
+
+    // Read the check runs recorded against one exact commit. `statusCheckRollup`
+    // is deliberately avoided: it is a summary whose emptiness is ambiguous.
+    readCheckRuns: (headSha) => {
+      const lines = runGh([
+        "api",
+        "--paginate",
+        `repos/${repo}/commits/${headSha}/check-runs`,
+        "--jq",
+        '.check_runs[] | [.name, .status, (.conclusion // "")] | @tsv',
+      ])
+        .split("\n")
+        .filter(Boolean);
+
+      const runs: CheckRunSnapshot[] = [];
+      for (const line of lines) {
+        const [runName, status, conclusion] = line.split("\t");
+        if (runName === undefined || status === undefined) {
+          panic(`Malformed check-run row from gh: ${line}`);
+        }
+        runs.push({
+          name: runName,
+          status,
+          conclusion:
+            conclusion === undefined || conclusion === "" ? null : conclusion,
+        });
+      }
+      return runs;
+    },
+
+    readReviewThreads: () => {
+      const threads: ReviewThreadSnapshot[] = [];
+      let cursor: string | null = null;
+
+      for (;;) {
+        const cursorArgs =
+          cursor === null ? ["-F", "cursor="] : ["-F", `cursor=${cursor}`];
+        const page = readRecord(
+          runGhJson([
+            "api",
+            "graphql",
+            "-f",
+            `query=${REVIEW_THREADS_QUERY}`,
+            "-f",
+            `owner=${owner}`,
+            "-f",
+            `name=${name}`,
+            "-F",
+            `number=${pullNumber}`,
+            ...cursorArgs,
+            "--jq",
+            ".data.repository.pullRequest.reviewThreads",
+          ]),
+          "reviewThreads",
+        );
+
+        const nodes = page["nodes"];
+        if (!Array.isArray(nodes)) {
+          panic("Expected `nodes` array in reviewThreads response");
+        }
+        for (const node of nodes) {
+          const thread = readRecord(node, "review thread");
+          threads.push({
+            id: readString(thread, "id"),
+            isResolved: readBoolean(thread, "isResolved"),
+          });
+        }
+
+        const pageInfo = readRecord(page["pageInfo"], "pageInfo");
+        if (!readBoolean(pageInfo, "hasNextPage")) {
+          return threads;
+        }
+        cursor = readString(pageInfo, "endCursor");
+      }
+    },
+
+    // Read both sides from the API rather than the local checkout: the local
+    // clone can be behind the default branch, which is the very staleness this
+    // gate exists to catch.
+    readMigrationDirectories: () => {
+      const defaultBranch = readString(
+        readRecord(
+          runGhJson([
+            "api",
+            `repos/${repo}`,
+            "--jq",
+            "{name: .default_branch}",
+          ]),
+          "repo",
+        ),
+        "name",
+      );
+      const baseDirectories = runGh([
+        "api",
+        `repos/${repo}/contents/${MIGRATION_DIRECTORY}?ref=${defaultBranch}`,
+        "--jq",
+        '.[] | select(.type == "dir") | .name',
+      ])
+        .split("\n")
+        .filter(Boolean);
+
+      const addedDirectories = runGh([
+        "api",
+        "--paginate",
+        `repos/${repo}/pulls/${pullNumber}/files`,
+        "--jq",
+        '.[] | select(.status == "added") | .filename',
+      ])
+        .split("\n")
+        .filter(
+          (file) =>
+            file.startsWith(`${MIGRATION_DIRECTORY}/`) &&
+            file.endsWith("/migration.sql"),
+        )
+        .map((file) => file.slice(0, file.lastIndexOf("/")));
+
+      return { baseDirectories, addedDirectories };
+    },
+
+    // The body arrives already inlined: no path is passed to gh, so no
+    // concurrent writer can rewrite the commit message between the check and
+    // the merge.
+    merge: ({ subject, body, admin }) => {
+      runGh([
+        "pr",
+        "merge",
+        ...prArgs,
+        "--squash",
+        "--subject",
+        subject,
+        "--body",
+        body,
+        ...(admin ? ["--admin"] : []),
+      ]);
+      return readString(
+        readRecord(
+          readRecord(
+            runGhJson(["pr", "view", ...prArgs, "--json", "mergeCommit"]),
+            "pr view",
+          )["mergeCommit"],
+          "mergeCommit",
+        ),
+        "oid",
+      );
+    },
+  };
+};
+
+// --- CLI --------------------------------------------------------------------
+
+type MergeBarOptions = {
+  pullNumber: number;
+  repo: string;
+  bodyFile: string | null;
+  admin: boolean;
+  dryRun: boolean;
+};
+
+const parseOptions = (argv: readonly string[]): MergeBarOptions => {
+  const positional: string[] = [];
+  let repo = DEFAULT_REPO;
+  let bodyFile: string | null = null;
+  let admin = false;
+  let dryRun = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--repo") {
+      index += 1;
+      repo = argv[index] ?? panic("--repo requires a value");
+      continue;
+    }
+    if (argument === "--body-file") {
+      index += 1;
+      bodyFile = argv[index] ?? panic("--body-file requires a value");
+      continue;
+    }
+    if (argument === "--admin") {
+      admin = true;
+      continue;
+    }
+    if (argument === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (argument === undefined || argument.startsWith("--")) {
+      panic(`Unknown argument: ${argument ?? "<empty>"}`);
+    }
+    positional.push(argument);
+  }
+
+  const rawNumber = positional.at(0);
+  if (rawNumber === undefined) {
+    panic(
+      "Usage: bun scripts/merge-bar.ts <pr-number> [--repo owner/name] " +
+        "[--body-file path] [--admin] [--dry-run]",
+    );
+  }
+  const pullNumber = Number.parseInt(rawNumber, 10);
+  if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+    panic(`PR number must be a positive integer, got: ${rawNumber}`);
+  }
+
+  return { pullNumber, repo, bodyFile, admin, dryRun };
+};
+
+const formatVerdict = (verdict: MergeBarVerdict): string =>
+  verdict.gates
+    .map((gate) =>
+      gate.status === "pass"
+        ? `  PASS ${gate.gate}: ${gate.detail}`
+        : `  FAIL ${gate.gate}: ${gate.reason} — ${gate.detail}`,
+    )
+    .join("\n");
+
+// Mergeability is computed asynchronously on GitHub's side, so UNKNOWN on the
+// first read means "not yet", not "no". Poll briefly, then let the gate refuse.
+// Blocking is correct here: the whole tool is one strictly ordered read
+// sequence, and it has nothing else to do while GitHub finishes.
+const readSettledPullRequest = (
+  gateway: GitHubGateway,
+): PullRequestSnapshot => {
+  let pullRequest = gateway.readPullRequest();
+  for (
+    let attempt = 1;
+    attempt < MERGEABLE_POLL_ATTEMPTS && pullRequest.mergeable === "UNKNOWN";
+    attempt += 1
+  ) {
+    Bun.sleepSync(MERGEABLE_POLL_INTERVAL_MS);
+    pullRequest = gateway.readPullRequest();
+  }
+  return pullRequest;
+};
+
+if (import.meta.main) {
+  const options = parseOptions(Bun.argv.slice(2));
+  // Read the body FIRST and keep only its contents: after this line the path
+  // is irrelevant, so a concurrent writer cannot reach the merge commit.
+  const bodyOverride =
+    options.bodyFile === null ? null : readFileSync(options.bodyFile, "utf-8");
+
+  const gateway = createGhGateway({
+    repo: options.repo,
+    pullNumber: options.pullNumber,
+  });
+
+  const pullRequest = readSettledPullRequest(gateway);
+  const snapshot: MergeBarSnapshot = {
+    pullRequest,
+    checkRunsHeadSha: pullRequest.headSha,
+    checkRuns: gateway.readCheckRuns(pullRequest.headSha),
+    reviewThreads: gateway.readReviewThreads(),
+    migrations: gateway.readMigrationDirectories(),
+    // Deliberately the LAST read before the verdict: everything above is now
+    // known to describe this exact commit, or the gate fails.
+    headShaBeforeMerge: gateway.readHeadSha(),
+  };
+
+  const verdict = evaluateMergeBar(snapshot);
+  console.log(`merge bar: ${options.repo}#${options.pullNumber}`);
+  console.log(formatVerdict(verdict));
+
+  if (verdict.decision === "abort") {
+    console.log("\nverdict: ABORT — not merging.");
+    process.exit(1);
+  }
+
+  if (options.dryRun) {
+    console.log("\nverdict: MERGE (dry run, nothing written).");
+    process.exit(0);
+  }
+
+  const mergeSha = gateway.merge({
+    subject: `${pullRequest.title} (#${pullRequest.number})`,
+    body: bodyOverride ?? pullRequest.body,
+    admin: options.admin,
+  });
+  console.log(`\nverdict: MERGE — squashed as ${mergeSha}`);
+}

--- a/scripts/merge-bar.ts
+++ b/scripts/merge-bar.ts
@@ -32,6 +32,14 @@
 //     rewrites the commit message. The body is read and inlined here at
 //     startup; the merge call never receives a path.
 //
+// Known boundary. `--match-head-commit` binds the pull request head and
+// nothing else, and `--admin` merges past branch protection by definition, so
+// the review-thread and base-branch gates are client-side assertions with no
+// server-side backstop. Reading them last shrinks their windows to the final
+// two calls; two migration-bearing merges issued simultaneously, or a thread
+// opened inside that window, still slip through. Closing those completely
+// needs a merge queue.
+//
 // What this tool deliberately does NOT gate: review depth. Automated review
 // requests are budgeted at two per pull request, because a third round buys
 // re-litigation of the same diff rather than new findings. Spend both, address
@@ -58,6 +66,7 @@ const MERGEABLE_POLL_INTERVAL_MS = 2000;
 const MERGE_COMMIT_POLL_ATTEMPTS = 5;
 // GitHub's REST contents listing silently truncates past this many entries.
 const CONTENTS_ENDPOINT_ENTRY_LIMIT = 1000;
+const PULL_NUMBER_PATTERN = /^\d+$/u;
 
 // --- Gate model -------------------------------------------------------------
 
@@ -67,6 +76,7 @@ const GATE_IDS = [
   "required-check",
   "review-threads",
   "migration-order",
+  "base-stability",
   "head-stability",
 ] as const;
 type GateId = (typeof GATE_IDS)[number];
@@ -83,6 +93,7 @@ const MERGE_BAR_REASONS = {
   requiredCheckNotSuccessful: "REQUIRED_CHECK_NOT_SUCCESSFUL",
   unresolvedReviewThreads: "UNRESOLVED_REVIEW_THREADS",
   migrationOrder: "MIGRATION_ORDER_VIOLATION",
+  baseMoved: "BASE_MOVED_UNDER_ADDED_MIGRATIONS",
   headMoved: "HEAD_MOVED_DURING_CHECKS",
 } as const;
 type MergeBarReason =
@@ -114,6 +125,8 @@ type MigrationSnapshot = {
   baseDirectories: readonly string[];
   // Migration directories this pull request adds.
   addedDirectories: readonly string[];
+  // The default-branch commit `baseDirectories` was read from.
+  baseSha: string;
 };
 
 export type MergeBarSnapshot = {
@@ -125,7 +138,8 @@ export type MergeBarSnapshot = {
   checkRuns: readonly CheckRunSnapshot[];
   reviewThreads: readonly ReviewThreadSnapshot[];
   migrations: MigrationSnapshot;
-  // Re-read immediately before the merge call.
+  // Both re-read immediately before the merge call.
+  baseShaBeforeMerge: string;
   headShaBeforeMerge: string;
 };
 
@@ -295,6 +309,47 @@ const evaluateMigrationOrder = (migrations: MigrationSnapshot): GateVerdict => {
   };
 };
 
+// `--match-head-commit` binds the pull request head, not the branch being
+// merged into, so nothing server-side notices that the base advanced while the
+// gates ran. That only matters when this pull request adds migrations: another
+// merge landing a higher timestamp in that window would silently put this
+// one's DDL below the maximum an already-migrated database has recorded.
+//
+// Residual boundary: this narrows the window to the merge call itself. Two
+// migration-bearing merges issued in the same instant can still interleave;
+// closing that completely needs a merge queue, not a client-side gate.
+const evaluateBaseStability = ({
+  migrations,
+  baseShaBeforeMerge,
+}: {
+  migrations: MigrationSnapshot;
+  baseShaBeforeMerge: string;
+}): GateVerdict => {
+  if (migrations.addedDirectories.length === 0) {
+    return {
+      gate: "base-stability",
+      status: "pass",
+      detail: "no added migrations; base movement cannot reorder anything",
+    };
+  }
+  if (migrations.baseSha !== baseShaBeforeMerge) {
+    return {
+      gate: "base-stability",
+      status: "fail",
+      reason: MERGE_BAR_REASONS.baseMoved,
+      detail:
+        `default branch moved ${migrations.baseSha} -> ${baseShaBeforeMerge} ` +
+        "while this pull request adds migrations; re-run so ordering is " +
+        "checked against what will actually be merged into",
+    };
+  }
+  return {
+    gate: "base-stability",
+    status: "pass",
+    detail: `default branch steady at ${migrations.baseSha}`,
+  };
+};
+
 const evaluateHeadStability = ({
   headSha,
   headShaBeforeMerge,
@@ -331,6 +386,10 @@ export const evaluateMergeBar = (
     }),
     evaluateReviewThreads(snapshot.reviewThreads),
     evaluateMigrationOrder(snapshot.migrations),
+    evaluateBaseStability({
+      migrations: snapshot.migrations,
+      baseShaBeforeMerge: snapshot.baseShaBeforeMerge,
+    }),
     evaluateHeadStability({
       headSha: snapshot.pullRequest.headSha,
       headShaBeforeMerge: snapshot.headShaBeforeMerge,
@@ -350,6 +409,8 @@ type GitHubGateway = {
   // Deliberately separate from `readPullRequest`: the pre-merge re-read only
   // needs the SHA, and a narrow read makes the TOCTOU window smaller.
   readHeadSha: () => string;
+  // Tip of the branch this pull request merges into.
+  readBaseSha: () => string;
   readCheckRuns: (headSha: string) => readonly CheckRunSnapshot[];
   readReviewThreads: () => readonly ReviewThreadSnapshot[];
   readMigrationDirectories: () => MigrationSnapshot;
@@ -451,6 +512,31 @@ const createGhGateway = ({
         ),
         "headRefOid",
       ),
+
+    // The live tip of the base branch, not `baseRefOid`: gh reports that as
+    // the commit the pull request was compared against, which is exactly the
+    // stale value this gate exists to detect.
+    readBaseSha: () => {
+      const baseRefName = readString(
+        readRecord(
+          runGhJson(["pr", "view", ...prArgs, "--json", "baseRefName"]),
+          "pr view",
+        ),
+        "baseRefName",
+      );
+      return readString(
+        readRecord(
+          runGhJson([
+            "api",
+            `repos/${repo}/commits/${baseRefName}`,
+            "--jq",
+            "{sha: .sha}",
+          ]),
+          "base commit",
+        ),
+        "sha",
+      );
+    },
 
     readPullRequest: () => {
       const raw = readRecord(
@@ -566,21 +652,31 @@ const createGhGateway = ({
     // clone can be behind the default branch, which is the very staleness this
     // gate exists to catch.
     readMigrationDirectories: () => {
-      const defaultBranch = readString(
+      const baseRefName = readString(
+        readRecord(
+          runGhJson(["pr", "view", ...prArgs, "--json", "baseRefName"]),
+          "pr view",
+        ),
+        "baseRefName",
+      );
+      // Pin the listing to one commit so `baseSha` provably describes the
+      // directories read below, rather than whatever the branch pointed at
+      // between two separate requests.
+      const baseSha = readString(
         readRecord(
           runGhJson([
             "api",
-            `repos/${repo}`,
+            `repos/${repo}/commits/${baseRefName}`,
             "--jq",
-            "{name: .default_branch}",
+            "{sha: .sha}",
           ]),
-          "repo",
+          "base commit",
         ),
-        "name",
+        "sha",
       );
       const baseDirectories = runGh([
         "api",
-        `repos/${repo}/contents/${MIGRATION_DIRECTORY}?ref=${defaultBranch}`,
+        `repos/${repo}/contents/${MIGRATION_DIRECTORY}?ref=${baseSha}`,
         "--jq",
         '.[] | select(.type == "dir") | .name',
       ])
@@ -591,8 +687,8 @@ const createGhGateway = ({
       // pass on the exact ordering it exists to catch, so refuse instead.
       if (baseDirectories.length >= CONTENTS_ENDPOINT_ENTRY_LIMIT) {
         panic(
-          `${MIGRATION_DIRECTORY} has ${baseDirectories.length} entries on ` +
-            `${defaultBranch}, at or past the contents endpoint's ` +
+          `${MIGRATION_DIRECTORY} has ${baseDirectories.length} entries at ` +
+            `${baseSha}, at or past the contents endpoint's ` +
             `${CONTENTS_ENDPOINT_ENTRY_LIMIT}-entry limit. The listing may be ` +
             "truncated; switch this gate to the git tree API before merging.",
         );
@@ -613,7 +709,7 @@ const createGhGateway = ({
         )
         .map((file) => file.slice(0, file.lastIndexOf("/")));
 
-      return { baseDirectories, addedDirectories };
+      return { baseDirectories, addedDirectories, baseSha };
     },
 
     // The body arrives already inlined: no path is passed to gh, so no
@@ -700,15 +796,22 @@ const parseOptions = (argv: readonly string[]): MergeBarOptions => {
     positional.push(argument);
   }
 
-  const rawNumber = positional.at(0);
-  if (rawNumber === undefined) {
+  // Exactly one, all digits. `Number.parseInt("2137oops", 10)` is 2137, so a
+  // mistyped suffix would silently merge a different real pull request; extra
+  // positionals would silently pick the first.
+  if (positional.length !== 1) {
     panic(
-      "Usage: bun scripts/merge-bar.ts <pr-number> [--repo owner/name] " +
+      `Expected exactly one PR number, got ${positional.length}. ` +
+        "Usage: bun scripts/merge-bar.ts <pr-number> [--repo owner/name] " +
         "[--body-file path] [--admin] [--dry-run]",
     );
   }
-  const pullNumber = Number.parseInt(rawNumber, 10);
-  if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+  const rawNumber = positional[0] ?? panic("unreachable: length checked above");
+  if (!PULL_NUMBER_PATTERN.test(rawNumber)) {
+    panic(`PR number must be digits only, got: ${rawNumber}`);
+  }
+  const pullNumber = Number(rawNumber);
+  if (!Number.isSafeInteger(pullNumber) || pullNumber <= 0) {
     panic(`PR number must be a positive integer, got: ${rawNumber}`);
   }
 
@@ -756,14 +859,21 @@ if (import.meta.main) {
   });
 
   const pullRequest = readSettledPullRequest(gateway);
+  // Read order is load-bearing. Each gate's window is the time between its own
+  // read and the merge, so the reads with no server-side enforcement behind
+  // them go LAST. Review threads have none at all: `--admin` merges past
+  // conversation protection by definition, so a thread opened after this read
+  // cannot block the write. Ordering it immediately before the two SHA reads
+  // shrinks that window to those two calls; it does not remove it.
   const snapshot: MergeBarSnapshot = {
     pullRequest,
     checkRunsHeadSha: pullRequest.headSha,
     checkRuns: gateway.readCheckRuns(pullRequest.headSha),
-    reviewThreads: gateway.readReviewThreads(),
     migrations: gateway.readMigrationDirectories(),
-    // Deliberately the LAST read before the verdict: everything above is now
-    // known to describe this exact commit, or the gate fails.
+    reviewThreads: gateway.readReviewThreads(),
+    baseShaBeforeMerge: gateway.readBaseSha(),
+    // Last, and the one the merge write itself re-asserts through
+    // `--match-head-commit`.
     headShaBeforeMerge: gateway.readHeadSha(),
   };
 

--- a/scripts/merge-bar.ts
+++ b/scripts/merge-bar.ts
@@ -18,9 +18,11 @@
 // (b) Time-of-check to time-of-use. Review threads, reviews, and pushes land
 //     between a state read and the merge call. Gate inputs read minutes ago
 //     describe a pull request that no longer exists. Everything below is
-//     fetched in THIS invocation, and the head SHA is re-read immediately
-//     before the merge so a push mid-flight aborts instead of merging code
-//     nothing verified. The same staleness applies across pull requests:
+//     fetched in THIS invocation, the head SHA is re-read immediately before
+//     the merge, and that SHA is passed to `--match-head-commit` so GitHub
+//     rejects the write server-side if head moved in the remaining gap: the
+//     assertion is enforced by the write, not merely checked before it. The
+//     same staleness applies across pull requests:
 //     migration ordering is re-checked against the live default branch,
 //     because a branch's own CI run cannot see a migration that landed on the
 //     default branch after that run finished.
@@ -351,7 +353,15 @@ type GitHubGateway = {
   readCheckRuns: (headSha: string) => readonly CheckRunSnapshot[];
   readReviewThreads: () => readonly ReviewThreadSnapshot[];
   readMigrationDirectories: () => MigrationSnapshot;
-  merge: (input: { subject: string; body: string; admin: boolean }) => string;
+  merge: (input: {
+    subject: string;
+    body: string;
+    admin: boolean;
+    // The SHA every gate above was evaluated against. GitHub rejects the merge
+    // if head has moved since, so the head-stability assertion is enforced by
+    // the write itself rather than by the gap between the last read and it.
+    expectedHeadSha: string;
+  }) => string;
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -609,12 +619,17 @@ const createGhGateway = ({
     // The body arrives already inlined: no path is passed to gh, so no
     // concurrent writer can rewrite the commit message between the check and
     // the merge.
-    merge: ({ subject, body, admin }) => {
+    merge: ({ subject, body, admin, expectedHeadSha }) => {
       runGh([
         "pr",
         "merge",
         ...prArgs,
         "--squash",
+        // Without this, the head-stability gate is only advisory: a push
+        // landing between the final SHA read and this call would merge a
+        // commit no gate ever saw. GitHub enforces the match server-side.
+        "--match-head-commit",
+        expectedHeadSha,
         "--subject",
         subject,
         "--body",
@@ -770,6 +785,7 @@ if (import.meta.main) {
     subject: `${pullRequest.title} (#${pullRequest.number})`,
     body: bodyOverride ?? pullRequest.body,
     admin: options.admin,
+    expectedHeadSha: snapshot.headShaBeforeMerge,
   });
   console.log(`\nverdict: MERGE — squashed as ${mergeSha}`);
 }

--- a/scripts/merge-bar.ts
+++ b/scripts/merge-bar.ts
@@ -53,6 +53,9 @@ const REQUIRED_CHECK_RUN = "ci-result";
 const MIGRATION_DIRECTORY = "apps/api/drizzle";
 const MERGEABLE_POLL_ATTEMPTS = 8;
 const MERGEABLE_POLL_INTERVAL_MS = 2000;
+const MERGE_COMMIT_POLL_ATTEMPTS = 5;
+// GitHub's REST contents listing silently truncates past this many entries.
+const CONTENTS_ENDPOINT_ENTRY_LIMIT = 1000;
 
 // --- Gate model -------------------------------------------------------------
 
@@ -507,8 +510,9 @@ const createGhGateway = ({
       let cursor: string | null = null;
 
       for (;;) {
-        const cursorArgs =
-          cursor === null ? ["-F", "cursor="] : ["-F", `cursor=${cursor}`];
+        // Omit the variable entirely on the first page: `after: ""` is not the
+        // same as `after: null` to the GraphQL connection.
+        const cursorArgs = cursor === null ? [] : ["-F", `cursor=${cursor}`];
         const page = readRecord(
           runGhJson([
             "api",
@@ -572,6 +576,17 @@ const createGhGateway = ({
       ])
         .split("\n")
         .filter(Boolean);
+      // The contents endpoint truncates at 1000 entries without saying so. A
+      // truncated listing would drop the newest migrations and let the gate
+      // pass on the exact ordering it exists to catch, so refuse instead.
+      if (baseDirectories.length >= CONTENTS_ENDPOINT_ENTRY_LIMIT) {
+        panic(
+          `${MIGRATION_DIRECTORY} has ${baseDirectories.length} entries on ` +
+            `${defaultBranch}, at or past the contents endpoint's ` +
+            `${CONTENTS_ENDPOINT_ENTRY_LIMIT}-entry limit. The listing may be ` +
+            "truncated; switch this gate to the git tree API before merging.",
+        );
+      }
 
       const addedDirectories = runGh([
         "api",
@@ -606,15 +621,22 @@ const createGhGateway = ({
         body,
         ...(admin ? ["--admin"] : []),
       ]);
-      return readString(
-        readRecord(
-          readRecord(
-            runGhJson(["pr", "view", ...prArgs, "--json", "mergeCommit"]),
-            "pr view",
-          )["mergeCommit"],
-          "mergeCommit",
-        ),
-        "oid",
+      // The merge already happened; the commit SHA just may not be attached to
+      // the pull request yet. Retry rather than fail on a reporting lag, which
+      // would read as a failed merge.
+      for (let attempt = 1; attempt <= MERGE_COMMIT_POLL_ATTEMPTS; attempt++) {
+        const mergeCommit = readRecord(
+          runGhJson(["pr", "view", ...prArgs, "--json", "mergeCommit"]),
+          "pr view",
+        )["mergeCommit"];
+        if (isRecord(mergeCommit)) {
+          return readString(mergeCommit, "oid");
+        }
+        Bun.sleepSync(MERGEABLE_POLL_INTERVAL_MS);
+      }
+      return panic(
+        "Merge succeeded but GitHub did not report a merge commit; " +
+          `check ${repo}#${pullNumber} manually.`,
       );
     },
   };

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -231,6 +231,10 @@
     "count": 0,
     "files": {}
   },
+  "no-vacuous-throw-assertion-suppressions": {
+    "count": 0,
+    "files": {}
+  },
   "lint-suppression-directives": {
     "count": 760,
     "files": {
@@ -403,6 +407,7 @@
       "apps/api/src/mcp/template-persistence.ts": 1,
       "apps/api/src/mcp/tool-utils.ts": 1,
       "apps/api/src/scripts/adapter-health.ts": 1,
+      "apps/api/src/scripts/backfill-citation-authority.ts": 1,
       "apps/api/src/scripts/backfill-citation-keys.ts": 2,
       "apps/api/src/scripts/backfill-corpus-storage.ts": 1,
       "apps/api/src/scripts/backfill-fulltext.ts": 6,
@@ -412,6 +417,7 @@
       "apps/api/src/scripts/cz-regional-repair.ts": 8,
       "apps/api/src/scripts/eu-ecj-census.ts": 3,
       "apps/api/src/scripts/eu-ecj-refetch.ts": 6,
+      "apps/api/src/scripts/normalize-case-numbers.ts": 1,
       "apps/api/src/scripts/post-deploy-smoke.ts": 3,
       "apps/api/src/scripts/redact-case-law-decision.ts": 1,
       "apps/api/src/scripts/repair-case-law-jsonb.ts": 1,
@@ -423,9 +429,9 @@
       "apps/landing/src/components/react/EditorLiveDemo.tsx": 1,
       "apps/landing/src/components/react/previews/CliMcpPreview.tsx": 1,
       "apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts": 10,
-      "apps/legal-atlas-runner/src/runners/case-law-ingest.ts": 20,
+      "apps/legal-atlas-runner/src/runners/case-law-ingest.ts": 19,
       "apps/legal-atlas-runner/src/runners/case-law-reconciliation.ts": 2,
-      "apps/legal-atlas-runner/src/runners/citation-resolution-drain.ts": 4,
+      "apps/legal-atlas-runner/src/runners/citation-resolution-drain.ts": 3,
       "apps/legal-atlas-runner/src/runners/sk-document-drain.ts": 3,
       "apps/legal-atlas-runner/src/runners/source-total-poll.ts": 2,
       "apps/mobile/src/app/_layout.tsx": 1,

--- a/scripts/ratchet.ts
+++ b/scripts/ratchet.ts
@@ -2062,6 +2062,7 @@ const EXPECTED_NAMED_FIXTURE_SUPPRESSIONS = {
   "no-detached-void/no-detached-void": 0,
   "require-detached-label-shape/require-detached-label-shape": 0,
   "no-awaited-builder-union/no-awaited-builder-union": 0,
+  "no-vacuous-throw-assertion/no-vacuous-throw-assertion": 0,
 } as const satisfies Record<TrackedRule, number>;
 
 const TS_SUPPRESSION_FIXTURE_LINES = [

--- a/scripts/ratchet.ts
+++ b/scripts/ratchet.ts
@@ -53,7 +53,11 @@ import {
   TRACKED_SUPPRESSION_RULES,
   type TrackedRule,
 } from "./lint-suppressions";
-import { ALL_SOURCE_GLOBS, isExcludedSource } from "./source-globs";
+import {
+  ALL_SOURCE_GLOBS,
+  isExcludedSource,
+  isExcludedTestInclusiveSource,
+} from "./source-globs";
 
 const SCRIPTS_DIR = import.meta.dir;
 const REPO_ROOT = path.resolve(SCRIPTS_DIR, "..");
@@ -1097,12 +1101,18 @@ type RatchetMetric = {
 // apps. A security waiver in an operational script stands down the same
 // invariant as one in a handler, and the rules are enabled well beyond
 // `apps/*/src` in `oxlint.config.ts`.
+// The `test-integrity` tier budgets rules oxlint enables only on tests, so its
+// scan has to keep test files; every other tier guards product code, where a
+// directive in a test is noise.
 const PER_RULE_SUPPRESSION_METRICS: readonly RatchetMetric[] =
   TRACKED_SUPPRESSION_RULES.map(({ rule, tier, guards }) => ({
     id: suppressionMetricId(rule),
     description: `${rule} disable directives, repo-wide (${tier} tier: ${guards}). Bare directives count, because they silence this rule too.`,
     include: ALL_SOURCE_GLOBS,
-    exclude: isExcludedSource,
+    exclude:
+      tier === "test-integrity"
+        ? isExcludedTestInclusiveSource
+        : isExcludedSource,
     count: countTrackedRuleSuppressions(rule),
   }));
 

--- a/scripts/source-globs.ts
+++ b/scripts/source-globs.ts
@@ -21,14 +21,25 @@ export const ALL_SOURCE_GLOBS = [
   ".oxlint-plugins/*.ts",
 ] as const;
 
+// Never hand-edited, so never budgeted: generated declarations, generated
+// modules, and the browser suite that no ratchet glob reaches anyway.
+const isGeneratedSource = (file: string): boolean =>
+  file.endsWith(".d.ts") || /\.gen\./u.test(file) || file.includes("/e2e/");
+
 export const isExcludedSource = (file: string): boolean =>
-  file.endsWith(".d.ts") ||
-  /\.gen\./u.test(file) ||
+  isGeneratedSource(file) ||
   /\.test\./u.test(file) ||
   /\.spec\./u.test(file) ||
   file.includes("/tests/") ||
-  file.includes("/e2e/") ||
   file.includes("/__tests__/");
+
+// The same surface with test files KEPT. A rule that oxlint enables only on
+// tests must be budgeted over tests: scanning it with `isExcludedSource` would
+// leave the budget structurally unable to count a single one of its
+// directives, so a committed zero would stay green no matter how many
+// suppressions land. Known boundary: `apps/*/e2e` sits outside
+// ALL_SOURCE_GLOBS, so no ratchet, this one included, sees directives there.
+export const isExcludedTestInclusiveSource = isGeneratedSource;
 
 // Repo-relative paths of every scannable source file under `root`.
 export const scanSourceFiles = (root: string): readonly string[] => {

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -226,6 +226,8 @@ run_step "Marketing content evidence" bun run marketing:check
 run_step "Marketing recording verification self-test" bun test \
   scripts/check-marketing-recordings.test.ts
 run_step "Environment tooling self-test" bun test scripts/env-tool.test.ts
+run_step "Migration ordering self-test" bun test scripts/check-migration-order.test.ts
+run_step "Merge-bar gate self-test" bun test scripts/merge-bar.test.ts
 run_step "Self-host production contract self-test" bun test \
   scripts/selfhost-contract.test.ts
 run_step "Self-host production contract" bun run selfhost:check


### PR DESCRIPTION
Four guards, each closing a class of defect that reaches `main` because a check
was read negatively, read too early, or never written at all.

## 1. `scripts/merge-bar.ts`: the merge gate

`gh pr merge` is a single write with no state assertions, so whoever runs it
supplies the safety argument from whatever they last read. Three failure
classes follow from that, and the tool's header documents each:

- **Negative-check misreads.** "No failing checks" is not "checks passed". A
  CONFLICTING pull request produces zero check runs; a draft produces zero
  check runs; a rollup filtered for failures over an empty list is empty. All
  three read as green to a negative predicate. Every gate here demands a
  positive observation instead: the `ci-result` check run must EXIST on the
  exact current head SHA with conclusion `success`, read via
  `commits/{sha}/check-runs` rather than by filtering `statusCheckRollup`.
- **Time-of-check to time-of-use.** Review threads, reviews, and pushes land
  between a state read and the merge call. Every input is fetched inside one
  invocation, the head SHA is re-read immediately before merging, and that SHA
  is passed to `gh pr merge --match-head-commit` so GitHub rejects the write
  server-side if head moved in the remaining gap. The assertion is enforced by
  the write, not merely checked before it.
- **Merge-body file clobbering.** `--body-file` is read by `gh` at merge time,
  so a concurrent writer to that path rewrites the commit message. The body is
  read and inlined at startup; the merge call never receives a path.

Gates: pull-request state (open, not draft), mergeability (MERGEABLE, polling
briefly through UNKNOWN because GitHub computes it asynchronously), the
required check run, unresolved review threads (GraphQL `isResolved`, fetched in
this invocation), migration ordering (below), base stability, and head
stability. Read order is load-bearing: the gates with no server-side backstop
run last, so their windows are the final two calls. Each gate
reports PASS or FAIL with a named reason; every gate is evaluated so the
operator sees the whole picture rather than the first refusal.

The gate logic is a pure function of one snapshot (`evaluateMergeBar`), with
the `gh` calls behind a thin gateway seam. `scripts/merge-bar.test.ts` covers
each failure class, including the load-bearing case that an empty check-run
list FAILS rather than passing vacuously.

`--dry-run` prints the verdict without writing. `--admin` passes through.

Known boundaries, recorded in the source rather than papered over:
`--match-head-commit` binds the pull request head and nothing else, and
`--admin` merges past branch protection by definition, so the review-thread and
base-branch gates are client-side assertions. Reading them last shrinks their
windows; two migration-bearing merges issued simultaneously, or a thread opened
inside that window, still slip through. Closing those needs a merge queue.

## 2. Migration ordering, re-checked at merge time

A branch generates migration `20260816140000` while `20260816200000` merges to
`main` first. The branch's migration is now below `main`'s maximum. Drizzle's
journal records it, but a database that already applied the higher timestamp
skips the lower one silently: DDL that never runs, and no error anywhere.

`scripts/check-migration-order.ts` already guards this, wired through
`scripts/check-migrations.sh` in the `db-migrations` workflow. The residual
hole is staleness, not detection: that check runs when the pull request last
changed, against `origin/main` as it stood then. Nothing re-evaluates it when
`main` advances afterwards, which is precisely the race. So rather than
duplicating the check, this PR:

- reuses `findMigrationOrderViolation` as a merge-bar gate that reads the
  default branch's migration directories and the pull request's added
  migrations from the API at merge time;
- adds cases to `scripts/check-migration-order.test.ts` for the overtake
  scenario, equal timestamps, an empty added set, an empty base tree, and base
  entries without timestamps;
- sharpens the failure message to name the fix (rename above `X`) and the
  consequence (already-migrated databases skip it silently).

`scripts/check-migration-order.test.ts` never ran in CI. Neither guard's
comparison logic was covered: a migration check that always returns null
passes every PR, and a merge gate that reads an empty list as green merges
unverified code. Both test files are now wired into the `ci-checks` job and
`scripts/verify.sh`.

## 3. `no-vacuous-throw-assertion` lint rule

`expect(() => parse(bad)).toThrow()` is satisfied by any thrown value. A test
written to pin "rejects an identifier containing a quote" keeps passing once
the code starts throwing a NOT NULL violation or a TypeError from a renamed
field. The assertion cannot tell those apart from the error it was written for,
so it reports on the presence of a throw rather than on the contract.

The rule flags `.toThrow()` and `.toThrowError()` with no argument on a chain
rooted at `expect(...)`, including `.rejects`. It accepts any argument, because
each of them discriminates between errors, and it accepts `.not.toThrow()`,
which takes no argument by design. Its boundary is stated in the source: this
is a syntax check on the assertion shape, and it cannot prove the supplied
matcher is specific enough.

Registered in `oxlint.config.ts`, scoped to test files plus its own fixture,
with a module-named fixture in `__fixtures__` and a catalogue entry in
`.oxlint-plugins/README.md`.

**Sweep: 63 sites, all fixed, 0 suppressions.** Every expectation was derived
by reading the implementation under test (a `panic(...)` message, a valibot
validator's output, or the error class) and verified by running each test file;
none were invented. A separate 42 `.not.toThrow()` sites were correctly left
alone.

The rule is registered in `TRACKED_SUPPRESSION_RULES` at count 0 under a new
`test-integrity` tier, so future suppressions are budgeted from zero. The tier
is documented alongside the existing three: it guards the assertion rather than
the product, and a suppression means one guard has been downgraded to a smoke
check.

That tier also needed its own scan policy. Every tracked-rule budget used
`isExcludedSource`, which drops `.test.`, `.spec.`, `/tests/`, and
`/__tests__/` paths, so a budget over a rule oxlint enables *only* on tests
could never count a single directive and its committed zero would have stayed
green regardless. `test-integrity` now scans with a test-inclusive exclusion.
Mutation-checked: one directive added to a test file moves the metric `0 -> 1`
and fails `--check`. Known boundary: `apps/*/e2e` is outside `ALL_SOURCE_GLOBS`,
so no ratchet sees directives there.

## 4. Doctrine

Three additions to `/conventions-testing` and the repo-local `AGENTS.md` tail:

- **Mutation check.** A test guarding behavior X is finished only once
  reverting X makes it fail. The usual failure is a fixture the fault cannot
  reach, so assert the fixture DIFFERS before asserting the equivalence.
- **Cross-runtime contracts.** Where a rule lives in two runtimes at once,
  parity is proven by DERIVING the other side's rules executably. A
  hand-maintained mirror list is not evidence of parity; it is the drift,
  written down.
- **Projection census.** Any "marked done" flag mirroring an external system
  ships with a reconciler comparing both sides. Acceptance is not durability.

## Changeset

An empty changeset records intentional no-release intent. The only
published-package file this PR touches is `packages/conditions/src/evaluate.test.ts`,
which the build excludes, so no shipped artifact changes.

## Baseline change

`scripts/ratchet-baseline.json` gains one metric,
`no-vacuous-throw-assertion-suppressions`, at count 0: the sweep left no
suppressions, so the budget starts closed and can only shrink. No budget count
rises. The diff also refreshes four entries in the `lint-suppression-directives`
file map (two scripts gained a directive, two runners lost one) that had already
drifted on `main`; the metric total is unchanged at 760, which is why the guard
was green through the drift.

Note on placement: `AGENTS.md`'s `## Testing` and `## Meta Preferences`
sections are generated from `.ai/shared/modules/`, which is a submodule of a
different repository. To keep this a single-repo change, the doctrine and the
merge-bar line live in `.ai/local/agents.md` (repo-local, rendered into
`AGENTS.md` by `bun run sync-ai`) and in `.ai/local-skills/conventions-testing/`.
Folding them into the shared modules is a follow-up in that repository.
