### PR TITLE
fix: error capture noise classes

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -37,7 +37,6 @@ import {
   toOptionalValue,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
 import { parseRegionalDecision } from "@/api/handlers/case-law/ingestion/parsers/cz-regional";
-import { captureError } from "@/api/lib/analytics/capture";
 import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
 import {
   AdapterFetchError,
@@ -328,14 +327,14 @@ const fetchFinaldoc = async (
     const sourceRaw = JSON.stringify(doc);
 
     if (!isCzRegionalFinaldoc(doc)) {
-      captureError(
-        new AdapterFetchError({
-          message: `CZ Regional finaldoc validation failed for ${item.caseNumber}`,
-          adapterKey: ADAPTER_KEYS.CZ_REGIONAL,
-          cursor: null,
-        }),
-        { docUrl: target.toString(), caseNumber: item.caseNumber },
-      );
+      // Per-document publisher-side shape drift is operational: the raw
+      // response is preserved for re-parsing, so the miss is logged rather
+      // than captured per document.
+      logger.warn("case_law.ingestion.finaldoc_validation_failed", {
+        adapterKey: ADAPTER_KEYS.CZ_REGIONAL,
+        caseNumber: item.caseNumber,
+        docUrl: target.toString(),
+      });
 
       return {
         fulltext: undefined,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -19,7 +19,6 @@ import {
   adapterCatch,
   isTimeoutError,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
-import { captureError } from "@/api/lib/analytics/capture";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 import { logger } from "@/api/lib/observability/logger";
 
@@ -314,16 +313,16 @@ export const createPagePaginatedFetch = <TResponse>(
           // adapter doesn't stall on a single slow page.
           // Network errors (DNS, connection refused) propagate
           // so a transient outage doesn't permanently skip pages.
+          // A slow publisher is an expected operational failure, so no
+          // per-page exception capture (see the pipeline's halt path):
+          // the skip is logged, and the coverage ledger records the
+          // shortfall the skipped page leaves behind.
           if (isTimeoutError(error)) {
-            captureError(
-              new AdapterFetchError({
-                message:
-                  `${opts.adapterKey}: page ${page} timed out after ` +
-                  `${SERVER_ERROR_RETRIES} retries, skipping`,
-                adapterKey: opts.adapterKey,
-                cursor,
-              }),
-            );
+            logger.warn("case_law.ingestion.page_skipped_timeout", {
+              adapterKey: opts.adapterKey,
+              page: String(page),
+              retries: String(SERVER_ERROR_RETRIES),
+            });
             return {
               decisions: [],
               nextCursor: encode(pageStartOffset + opts.pageSize),
@@ -338,16 +337,14 @@ export const createPagePaginatedFetch = <TResponse>(
           // a page error. The cursor stays put so the page is
           // retried in the next cycle.
           if (response.status >= 500) {
-            captureError(
-              new AdapterFetchError({
-                message:
-                  `${opts.adapterKey}: page ${page} returned ` +
-                  `${response.status} after retries, skipping`,
-                adapterKey: opts.adapterKey,
-                cursor,
-                httpStatus: response.status,
-              }),
-            );
+            // Same rule as the timeout skip above: a publisher-side 5xx
+            // is operational, logged per page, and aggregated by the
+            // coverage ledger rather than captured per attempt.
+            logger.warn("case_law.ingestion.page_skipped_server_error", {
+              adapterKey: opts.adapterKey,
+              httpStatus: String(response.status),
+              page: String(page),
+            });
             return {
               decisions: [],
               nextCursor: encode(pageStartOffset + opts.pageSize),

--- a/apps/api/src/handlers/chat/stream-chat-model-ingress.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat-model-ingress.test.ts
@@ -57,6 +57,11 @@ describe("mid-loop rewrites re-enter the model-ingress guard", () => {
     expect(captureErrorMock).not.toHaveBeenCalled();
     expect(loggerWarnMock).toHaveBeenCalledTimes(1);
     const [, attributes] = loggerWarnMock.mock.calls.at(0) ?? [];
+    expect(attributes).toEqual({
+      pathCount: "1",
+      paths: "$",
+      surface: "system-prompt-mixed",
+    });
     expect(JSON.stringify(attributes)).not.toContain(WS_A);
   });
 
@@ -107,6 +112,13 @@ describe("mid-loop rewrites re-enter the model-ingress guard", () => {
     expect(dispatched).toContain(PUBLIC_UUID);
     expect(captureErrorMock).not.toHaveBeenCalled();
     expect(loggerWarnMock).toHaveBeenCalledTimes(1);
+    const [, attributes] = loggerWarnMock.mock.calls.at(0) ?? [];
+    expect(attributes).toEqual({
+      pathCount: "1",
+      paths: "$[0].content",
+      surface: "messages",
+    });
+    expect(JSON.stringify(attributes)).not.toContain(WS_A);
   });
 
   test("keeps a clean summary intact and skips the patch when nothing compacted", () => {

--- a/apps/api/src/handlers/chat/stream-chat-model-ingress.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat-model-ingress.test.ts
@@ -11,6 +11,13 @@ void mock.module("@/api/lib/analytics/capture", () => ({
   captureRequestError: captureErrorMock,
 }));
 
+const loggerWarnMock = mock();
+const realLogger = await import("@/api/lib/observability/logger");
+void mock.module("@/api/lib/observability/logger", () => ({
+  ...realLogger,
+  logger: { ...realLogger.logger, warn: loggerWarnMock },
+}));
+
 const { guardModelSystemPrompt } =
   await import("@/api/lib/chat/model-ingress-guard");
 const { guardedCompactedMessages, guardedLoopRecoveryPrompts } =
@@ -45,13 +52,17 @@ describe("mid-loop rewrites re-enter the model-ingress guard", () => {
     expect(prompt).not.toContain(WS_A);
     // The base prompt survives: recovery still carries the turn's scaffold.
     expect(prompt).toContain("Matter scope: mat_1.");
-    expect(captureErrorMock).toHaveBeenCalledTimes(1);
-    const [, context] = captureErrorMock.mock.calls.at(0) ?? [];
-    expect(JSON.stringify(context)).not.toContain(WS_A);
+    // Redaction hits on rewrites are routine (the id arrived through an org
+    // tool name), so they log rather than capture.
+    expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
+    const [, attributes] = loggerWarnMock.mock.calls.at(0) ?? [];
+    expect(JSON.stringify(attributes)).not.toContain(WS_A);
   });
 
   test("passes a clean loop-recovery prompt through unchanged and silent", () => {
     captureErrorMock.mockClear();
+    loggerWarnMock.mockClear();
 
     const [prompt] = guardedLoopRecoveryPrompts({
       baseSystem: BASE_SYSTEM,
@@ -67,10 +78,12 @@ describe("mid-loop rewrites re-enter the model-ingress guard", () => {
     expect(prompt).toContain("search_case_law");
     expect(prompt).not.toContain("[internal-id-removed]");
     expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(loggerWarnMock).not.toHaveBeenCalled();
   });
 
   test("redacts a tenant id the compaction summary reintroduces", () => {
     captureErrorMock.mockClear();
+    loggerWarnMock.mockClear();
     const previous: ModelMessage[] = [
       { role: "user", content: "Earlier turn." },
     ];
@@ -92,11 +105,13 @@ describe("mid-loop rewrites re-enter the model-ingress guard", () => {
     expect(dispatched).toContain("[internal-id-removed]");
     // Membership-exact: the public decision id survives compaction.
     expect(dispatched).toContain(PUBLIC_UUID);
-    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
   });
 
   test("keeps a clean summary intact and skips the patch when nothing compacted", () => {
     captureErrorMock.mockClear();
+    loggerWarnMock.mockClear();
     const previous: ModelMessage[] = [
       { role: "user", content: "Earlier turn." },
     ];
@@ -120,5 +135,6 @@ describe("mid-loop rewrites re-enter the model-ingress guard", () => {
       }),
     ).toBeUndefined();
     expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(loggerWarnMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -371,8 +371,8 @@ export const streamChat = async ({
   // Messages carry user-authored and historical text (mention hrefs from
   // before ref hydration covered user text, pasted workspace URLs), so hits
   // are redacted rather than refused: old threads keep working, telemetry
-  // records the path of every residual ingress leak, and the model loses
-  // only an id it could not legitimately use.
+  // counts every residual ingress leak (recording the first 20 paths), and
+  // the model loses only an id it could not legitimately use.
   const preparedMessageList = guardModelMessages({
     messages: rawPreparedMessages.value,
     workspaceIds: tenantWorkspaceIds,

--- a/apps/api/src/lib/chat/model-ingress-guard.test.ts
+++ b/apps/api/src/lib/chat/model-ingress-guard.test.ts
@@ -16,6 +16,13 @@ void mock.module("@/api/lib/analytics/capture", () => ({
   captureRequestError: captureErrorMock,
 }));
 
+const loggerWarnMock = mock();
+const realLogger = await import("@/api/lib/observability/logger");
+void mock.module("@/api/lib/observability/logger", () => ({
+  ...realLogger,
+  logger: { ...realLogger.logger, warn: loggerWarnMock },
+}));
+
 const {
   assertModelSurfaceFreeOfTenantIds,
   guardMcpToolSource,
@@ -60,14 +67,17 @@ describe("redactTenantIdsDeep", () => {
     expect(value.createdAt).toEqual(createdAt);
     expect(value.count).toBe(2);
     expect(redactedPaths).toEqual(["$.parts[0].content"]);
-    expect(captureErrorMock).toHaveBeenCalledTimes(1);
-    // Telemetry carries paths, never the id value.
-    const [, context] = captureErrorMock.mock.calls.at(0) ?? [];
-    expect(JSON.stringify(context)).not.toContain(WS_A);
+    // Routine traffic (a pasted app URL) is logged, never captured as an
+    // exception; the log carries paths, never the id value.
+    expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
+    const [, attributes] = loggerWarnMock.mock.calls.at(0) ?? [];
+    expect(JSON.stringify(attributes)).not.toContain(WS_A);
   });
 
   test("clean input passes through without telemetry", () => {
     captureErrorMock.mockClear();
+    loggerWarnMock.mockClear();
     const input = { parts: [{ type: "text", content: "all refs: mat_1" }] };
     const { value, redactedPaths } = redactTenantIdsDeep({
       value: input,
@@ -76,6 +86,7 @@ describe("redactTenantIdsDeep", () => {
     expect(value).toEqual(input);
     expect(redactedPaths).toEqual([]);
     expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(loggerWarnMock).not.toHaveBeenCalled();
   });
 });
 
@@ -129,6 +140,7 @@ describe("guarded model surfaces", () => {
 
   test("branding messages redacts tenant ids and reports the path", () => {
     captureErrorMock.mockClear();
+    loggerWarnMock.mockClear();
     const messages = [
       {
         id: "user-1",
@@ -159,10 +171,11 @@ describe("guarded model surfaces", () => {
     expect(guarded[1]?.parts[0]?.content).toBe(`Public ${PUBLIC_UUID} stays`);
     // The caller's array is left untouched: the model gets the redacted copy.
     expect(messages[0]?.parts[0]?.content).toContain(WS_A);
-    expect(captureErrorMock).toHaveBeenCalledTimes(1);
-    const [, context] = captureErrorMock.mock.calls.at(0) ?? [];
-    expect(JSON.stringify(context)).toContain("$[0].parts[0].content");
-    expect(JSON.stringify(context)).not.toContain(WS_A);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
+    const [, attributes] = loggerWarnMock.mock.calls.at(0) ?? [];
+    expect(JSON.stringify(attributes)).toContain("$[0].parts[0].content");
+    expect(JSON.stringify(attributes)).not.toContain(WS_A);
 
     // @ts-expect-error unguarded messages must not reach the model dispatch
     acceptsGuardedMessages(messages);
@@ -248,6 +261,7 @@ describe("guarded model surfaces", () => {
 
   test("redact mode keeps a mixed-provenance system prompt alive", () => {
     captureErrorMock.mockClear();
+    loggerWarnMock.mockClear();
     const redacted = redactModelSystemPrompt({
       system: `Loop detected in tool mcp__crm__${WS_A}. Public: ${PUBLIC_UUID}`,
       workspaceIds: [WS_A, WS_B],
@@ -258,9 +272,10 @@ describe("guarded model surfaces", () => {
       `Loop detected in tool mcp__crm__${TENANT_ID_REDACTION_PLACEHOLDER}. Public: ${PUBLIC_UUID}`,
     );
     expect(acceptsGuardedSystemPrompt(redacted)).toBe(redacted);
-    expect(captureErrorMock).toHaveBeenCalledTimes(1);
-    const [, context] = captureErrorMock.mock.calls.at(0) ?? [];
-    expect(JSON.stringify(context)).not.toContain(WS_A);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
+    const [, attributes] = loggerWarnMock.mock.calls.at(0) ?? [];
+    expect(JSON.stringify(attributes)).not.toContain(WS_A);
   });
 
   test("redact mode leaves a clean system prompt untouched and silent", () => {

--- a/apps/api/src/lib/chat/model-ingress-guard.test.ts
+++ b/apps/api/src/lib/chat/model-ingress-guard.test.ts
@@ -275,6 +275,11 @@ describe("guarded model surfaces", () => {
     expect(captureErrorMock).not.toHaveBeenCalled();
     expect(loggerWarnMock).toHaveBeenCalledTimes(1);
     const [, attributes] = loggerWarnMock.mock.calls.at(0) ?? [];
+    expect(attributes).toEqual({
+      pathCount: "1",
+      paths: "$",
+      surface: "system-prompt-mixed",
+    });
     expect(JSON.stringify(attributes)).not.toContain(WS_A);
   });
 

--- a/apps/api/src/lib/chat/model-ingress-guard.ts
+++ b/apps/api/src/lib/chat/model-ingress-guard.ts
@@ -155,6 +155,7 @@ export const redactTenantIdsDeep = <T extends object>({
   }
   if (state.paths.length > 0) {
     logger.warn("chat.model_ingress_redacted", {
+      pathCount: String(state.paths.length),
       paths: state.paths.slice(0, 20).join(", "),
       surface: "messages",
     });
@@ -267,6 +268,7 @@ export const redactModelSystemPrompt = ({
     // output or user text, so the hit is routine and the redaction is the
     // enforcement — same treatment as the messages surface.
     logger.warn("chat.model_ingress_redacted", {
+      pathCount: String(state.paths.length),
       paths: state.paths.slice(0, 20).join(", "),
       surface: "system-prompt-mixed",
     });

--- a/apps/api/src/lib/chat/model-ingress-guard.ts
+++ b/apps/api/src/lib/chat/model-ingress-guard.ts
@@ -5,6 +5,7 @@ import * as v from "valibot";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { TelemetryError } from "@/api/lib/errors/tagged-errors";
+import { logger } from "@/api/lib/observability/logger";
 
 /**
  * Last-line guard for the "tenant workspace ids reach the model only as chat
@@ -21,9 +22,11 @@ import { TelemetryError } from "@/api/lib/errors/tagged-errors";
  *   panics (fail closed);
  * - tool schemas may include org-configured external MCP tools, so a hit is
  *   captured to telemetry rather than taking the org's chat down;
- * - messages carry user-authored and historical text, so hits are redacted
- *   in place (the model loses an id it could not use legitimately anyway)
- *   and captured to telemetry with the message path, never the value.
+ * - messages carry user-authored and historical text, where a workspace id
+ *   is routine (a pasted app URL contains one), so hits are redacted in
+ *   place (the model loses an id it could not use legitimately anyway) and
+ *   logged with the message path, never the value — the redaction is the
+ *   enforcement; an exception per hit would page on ordinary traffic.
  */
 
 export const TENANT_ID_REDACTION_PLACEHOLDER = "[internal-id-removed]";
@@ -134,9 +137,9 @@ export type RedactTenantIdsResult<T> = {
 
 /**
  * Deep-copy `value` with every occurrence of a tenant workspace id inside any
- * string replaced by `TENANT_ID_REDACTION_PLACEHOLDER`. Hits are captured to
- * telemetry by path so residual ingress leaks stay visible while chat keeps
- * working for threads whose history predates ref mediation.
+ * string replaced by `TENANT_ID_REDACTION_PLACEHOLDER`. Hits are logged by
+ * path so residual ingress leaks stay visible while chat keeps working for
+ * threads whose history predates ref mediation.
  */
 export const redactTenantIdsDeep = <T extends object>({
   value,
@@ -151,16 +154,10 @@ export const redactTenantIdsDeep = <T extends object>({
     redactContainerInPlace(redacted, workspaceIds, "$", state);
   }
   if (state.paths.length > 0) {
-    captureError(
-      new TelemetryError({
-        message: "Model-bound message content embedded tenant workspace ids",
-      }),
-      {
-        source: "model-ingress-guard",
-        surface: "messages",
-        paths: state.paths.slice(0, 20).join(", "),
-      },
-    );
+    logger.warn("chat.model_ingress_redacted", {
+      paths: state.paths.slice(0, 20).join(", "),
+      surface: "messages",
+    });
   }
   return { value: redacted, redactedPaths: state.paths };
 };
@@ -266,12 +263,13 @@ export const redactModelSystemPrompt = ({
   const state: RedactionState = { paths: [] };
   const redacted = redactString(system, workspaceIds, "$", state);
   if (state.paths.length > 0) {
-    captureError(
-      new TelemetryError({
-        message: "Model-bound system prompt embedded tenant workspace ids",
-      }),
-      { source: "model-ingress-guard", surface: "system-prompt" },
-    );
+    // Mixed-provenance prompt: the id arrived through interpolated model
+    // output or user text, so the hit is routine and the redaction is the
+    // enforcement — same treatment as the messages surface.
+    logger.warn("chat.model_ingress_redacted", {
+      paths: state.paths.slice(0, 20).join(", "),
+      surface: "system-prompt-mixed",
+    });
   }
   return v.parse(guardedSystemPromptSchema, redacted);
 };

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -64,6 +64,7 @@ import {
   createBullMqConnection,
   createLazyRedisClient,
   createRedisClient,
+  isTransientRedisConnectionError,
 } from "@/api/lib/redis-client";
 import { unboundedCoordinationKey } from "@/api/lib/redis-keys";
 import { broadcastWorkspaceResourceUpdated } from "@/api/lib/resource-realtime";
@@ -1316,6 +1317,11 @@ export const isRetryableOcrDerivativeFailure = ({
   failureCode === SEARCHABLE_PDF_FAILURE_CODE &&
   attemptCount < AUTOMATIC_OCR_MAX_ATTEMPTS;
 
+type MarkRunFailedOutcome = {
+  attemptCount: number;
+  retryScheduled: boolean;
+};
+
 const markRunFailed = async ({
   claimToken,
   error,
@@ -1326,59 +1332,85 @@ const markRunFailed = async ({
   run: typeof documentProcessingRuns.$inferSelect;
 }): Promise<void> => {
   const failureCode = errorCode(error);
-  await rootDb.transaction(async (tx) => {
-    const ownedRows = await tx
-      .select({
-        attemptCount: documentProcessingRuns.attemptCount,
-        requestSource: documentProcessingRuns.requestSource,
-      })
-      .from(documentProcessingRuns)
-      .where(
-        and(
-          eq(documentProcessingRuns.id, run.id),
-          eq(documentProcessingRuns.status, "running"),
-          eq(documentProcessingRuns.claimedBy, claimToken),
-        ),
-      )
-      .limit(1)
-      .for("update");
-    const owned = ownedRows.at(0);
-    if (!owned) {
-      return;
-    }
-    const retryable = isRetryableAutomaticOcrFailure({
-      attemptCount: owned.attemptCount,
-      errorCode: failureCode,
-      requestSource: owned.requestSource,
-    });
-    const retryableSearchIndex = isRetryableSearchIndexFailure(failureCode);
-    const retryableDerivative = isRetryableOcrDerivativeFailure({
-      attemptCount: owned.attemptCount,
-      errorCode: failureCode,
-    });
-    await tx
-      .update(documentProcessingRuns)
-      .set({
-        claimedAt: null,
-        claimedBy: null,
-        errorAt: new Date(),
+  const outcome = await rootDb.transaction(
+    async (tx): Promise<MarkRunFailedOutcome | null> => {
+      const ownedRows = await tx
+        .select({
+          attemptCount: documentProcessingRuns.attemptCount,
+          requestSource: documentProcessingRuns.requestSource,
+        })
+        .from(documentProcessingRuns)
+        .where(
+          and(
+            eq(documentProcessingRuns.id, run.id),
+            eq(documentProcessingRuns.status, "running"),
+            eq(documentProcessingRuns.claimedBy, claimToken),
+          ),
+        )
+        .limit(1)
+        .for("update");
+      const owned = ownedRows.at(0);
+      if (!owned) {
+        return null;
+      }
+      const retryable = isRetryableAutomaticOcrFailure({
+        attemptCount: owned.attemptCount,
         errorCode: failureCode,
-        nextAttemptAt:
-          retryable || retryableSearchIndex || retryableDerivative
+        requestSource: owned.requestSource,
+      });
+      const retryableSearchIndex = isRetryableSearchIndexFailure(failureCode);
+      const retryableDerivative = isRetryableOcrDerivativeFailure({
+        attemptCount: owned.attemptCount,
+        errorCode: failureCode,
+      });
+      const retryScheduled =
+        retryable || retryableSearchIndex || retryableDerivative;
+      await tx
+        .update(documentProcessingRuns)
+        .set({
+          claimedAt: null,
+          claimedBy: null,
+          errorAt: new Date(),
+          errorCode: failureCode,
+          nextAttemptAt: retryScheduled
             ? new Date(
                 Date.now() + automaticOcrRetryDelayMs(owned.attemptCount),
               )
             : null,
-        status: "failed",
-        updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(documentProcessingRuns.id, run.id),
-          eq(documentProcessingRuns.status, "running"),
-          eq(documentProcessingRuns.claimedBy, claimToken),
-        ),
-      );
+          status: "failed",
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(documentProcessingRuns.id, run.id),
+            eq(documentProcessingRuns.status, "running"),
+            eq(documentProcessingRuns.claimedBy, claimToken),
+          ),
+        );
+      return { attemptCount: owned.attemptCount, retryScheduled };
+    },
+  );
+  if (outcome === null) {
+    return;
+  }
+  // One exception per run, at its terminal transition. An attempt whose
+  // failure schedules a retry is expected churn of the durable retry model
+  // and stays a structured log; capturing every attempt reported the same
+  // defect up to AUTOMATIC_OCR_MAX_ATTEMPTS times.
+  if (outcome.retryScheduled) {
+    logger.warn("document_processing.attempt_failed", {
+      "error.type": errorTag(error),
+      attempt: String(outcome.attemptCount),
+      errorCode: failureCode,
+      runId: run.id,
+    });
+    return;
+  }
+  captureError(error, { runId: run.id });
+  logger.error("document_processing.run_failed", {
+    "error.type": errorTag(error),
+    errorCode: failureCode,
+    runId: run.id,
   });
 };
 
@@ -2565,7 +2597,17 @@ const handleDocumentProcessingFailure = ({
   error: unknown;
   job: { data: DocumentProcessingJobData } | undefined;
 }): void => {
-  captureError(error, { runId: job?.data.runId ?? "" });
+  // No capture here: run-scoped failures capture once at their terminal
+  // transition in `markRunFailed`, and a dropped Redis socket on the claim
+  // path heals on the job's own retry. Machinery failures stay visible
+  // through the ERROR log.
+  if (isTransientRedisConnectionError(error)) {
+    logger.warn("document_processing.job_disrupted", {
+      "error.type": errorTag(error),
+      runId: job?.data.runId ?? "",
+    });
+    return;
+  }
   logger.error("document_processing.failed", {
     "error.type": errorTag(error),
     runId: job?.data.runId ?? "",
@@ -2808,6 +2850,16 @@ const reconcileDocumentProcessing = async ({
       const results = await runDocumentProcessingReconciliationPhases({
         phases: DOCUMENT_PROCESSING_RECONCILIATION_PHASES,
         onPhaseError: (error, phase) => {
+          // A dropped Redis socket rejects the first command after an idle
+          // window; the next 30s tick retries the phase, so the transient
+          // stays a structured log instead of an exception.
+          if (isTransientRedisConnectionError(error)) {
+            logger.warn("document_processing.reconcile_phase_disrupted", {
+              "error.type": errorTag(error),
+              phase,
+            });
+            return;
+          }
           captureError(error, { phase });
           logger.error("document_processing.reconcile_phase_failed", {
             "error.type": errorTag(error),
@@ -2834,10 +2886,16 @@ const reconcileDocumentProcessing = async ({
     // The tick never reported, so the backlog stays unknown and
     // `runTick` leaves reconciliation marked unfinished. Same rule the
     // idle check applies to a failed sample: never exit on uncertainty.
-    captureError(error);
-    logger.error("document_processing.reconcile_failed", {
-      "error.type": errorTag(error),
-    });
+    if (isTransientRedisConnectionError(error)) {
+      logger.warn("document_processing.reconcile_disrupted", {
+        "error.type": errorTag(error),
+      });
+    } else {
+      captureError(error);
+      logger.error("document_processing.reconcile_failed", {
+        "error.type": errorTag(error),
+      });
+    }
   } finally {
     onComplete();
   }

--- a/apps/api/src/lib/document-processing-readiness.test.ts
+++ b/apps/api/src/lib/document-processing-readiness.test.ts
@@ -5,8 +5,32 @@ process.env["GOTENBERG_URL"] ??= "http://localhost:3002";
 process.env["GOTENBERG_USERNAME"] ??= "test";
 process.env["GOTENBERG_PASSWORD"] ??= "test";
 
-const { readDocumentOcrWorkerAvailability, refreshDocumentOcrWorkerReadiness } =
-  await import("@/api/lib/document-processing-readiness");
+const captureErrorMock = mock();
+const realCapture = await import("@/api/lib/analytics/capture");
+void mock.module("@/api/lib/analytics/capture", () => ({
+  ...realCapture,
+  captureError: captureErrorMock,
+}));
+
+const loggerWarnMock = mock();
+const realLogger = await import("@/api/lib/observability/logger");
+void mock.module("@/api/lib/observability/logger", () => ({
+  ...realLogger,
+  logger: { ...realLogger.logger, warn: loggerWarnMock },
+}));
+
+const readinessGetMock = mock(async (): Promise<string | null> => null);
+const realRedisClient = await import("@/api/lib/redis-client");
+void mock.module("@/api/lib/redis-client", () => ({
+  ...realRedisClient,
+  createRedisClient: () => ({ get: readinessGetMock }),
+}));
+
+const {
+  isDocumentOcrWorkerAvailable,
+  readDocumentOcrWorkerAvailability,
+  refreshDocumentOcrWorkerReadiness,
+} = await import("@/api/lib/document-processing-readiness");
 
 describe("document OCR worker readiness", () => {
   test("configures readiness clients to fail fast during Redis outages", async () => {
@@ -33,6 +57,37 @@ describe("document OCR worker readiness", () => {
     expect(await readDocumentOcrWorkerAvailability(async () => "stale")).toBe(
       false,
     );
+  });
+
+  test("degrades to unavailable on a dropped socket without capturing", async () => {
+    captureErrorMock.mockClear();
+    loggerWarnMock.mockClear();
+    // The transient and non-transient fixtures must classify differently,
+    // or both assertions below would pass through the same branch.
+    const transient = Object.assign(new Error("Connection closed"), {
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+    });
+    const defect = Object.assign(new Error("WRONGTYPE"), {
+      code: "ERR_REDIS_INVALID_TYPE",
+    });
+    expect(realRedisClient.isTransientRedisConnectionError(transient)).toBe(
+      true,
+    );
+    expect(realRedisClient.isTransientRedisConnectionError(defect)).toBe(false);
+
+    readinessGetMock.mockImplementationOnce(async () => {
+      throw transient;
+    });
+    expect(await isDocumentOcrWorkerAvailable()).toBe(false);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
+
+    readinessGetMock.mockImplementationOnce(async () => {
+      throw defect;
+    });
+    expect(await isDocumentOcrWorkerAvailable()).toBe(false);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
   });
 
   test("bounds readiness reads", async () => {

--- a/apps/api/src/lib/document-processing-readiness.ts
+++ b/apps/api/src/lib/document-processing-readiness.ts
@@ -2,7 +2,12 @@ import { Result } from "better-result";
 
 import { captureError } from "@/api/lib/analytics/capture";
 import { detached } from "@/api/lib/detached";
-import { createRedisClient } from "@/api/lib/redis-client";
+import { errorTag } from "@/api/lib/errors/utils";
+import { logger } from "@/api/lib/observability/logger";
+import {
+  createRedisClient,
+  isTransientRedisConnectionError,
+} from "@/api/lib/redis-client";
 import {
   coordinationKey,
   coordinationSetArguments,
@@ -53,7 +58,16 @@ export const isDocumentOcrWorkerAvailable = async (): Promise<boolean> => {
     catch: (cause) => cause,
   });
   if (Result.isError(availability)) {
-    captureError(availability.error);
+    // A dropped Redis socket rejects the first read after an idle window;
+    // the caller already degrades to "worker unavailable", and the next
+    // read retries on a reconnected socket.
+    if (isTransientRedisConnectionError(availability.error)) {
+      logger.warn("document_processing.readiness_read_disrupted", {
+        "error.type": errorTag(availability.error),
+      });
+    } else {
+      captureError(availability.error);
+    }
     return false;
   }
   return availability.value;
@@ -111,7 +125,21 @@ export const startDocumentOcrWorkerReadiness = () => {
     if (writeInFlight !== null) {
       return;
     }
-    detached(refresh(), "document-processing.readiness-heartbeat");
+    // A dropped Redis socket rejects the first write after an idle window;
+    // the 90s lease outlives one missed 30s beat, and the next beat writes
+    // on a reconnected socket. Other failures keep flowing to `detached`'s
+    // exception capture.
+    detached(
+      refresh().catch((error: unknown) => {
+        if (!isTransientRedisConnectionError(error)) {
+          throw error;
+        }
+        logger.warn("document_processing.readiness_heartbeat_disrupted", {
+          "error.type": errorTag(error),
+        });
+      }),
+      "document-processing.readiness-heartbeat",
+    );
   };
 
   heartbeat();

--- a/apps/api/src/lib/document-processing-reconciliation-feeds.db.test.ts
+++ b/apps/api/src/lib/document-processing-reconciliation-feeds.db.test.ts
@@ -15,6 +15,7 @@ import type {
   DOCUMENT_PROCESSING_RECONCILIATION_PHASES as Phases,
   runDocumentProcessingReconciliationPhases as RunPhases,
 } from "@/api/lib/document-processing-queue";
+import type * as RedisClientModule from "@/api/lib/redis-client";
 import {
   createTestIds,
   setupRlsTestData,
@@ -71,30 +72,35 @@ beforeAll(async () => {
   // this test never reaches, so a module that grows one does not quietly
   // lose it here. Spreading the real module instead would import it, and
   // these are the modules being kept out of the process.
-  void mock.module("@/api/lib/redis-client", () => ({
-    connectWithColdStartRetries: async (connect: () => Promise<void>) =>
-      await connect(),
-    createBullMqConnection: () => ({}),
-    createLazyRedisClient: () => ({
-      close: () => undefined,
-      ready: async () => {
-        if (!redisAvailable) {
-          throw new Error("redis unavailable");
-        }
-        return await Promise.resolve({
+  void mock.module(
+    "@/api/lib/redis-client",
+    () =>
+      ({
+        connectWithColdStartRetries: async (connect: () => Promise<void>) =>
+          await connect(),
+        createBullMqConnection: () => ({}),
+        createLazyRedisClient: () => ({
+          close: () => undefined,
+          ready: async () => {
+            if (!redisAvailable) {
+              throw new Error("redis unavailable");
+            }
+            return await Promise.resolve({
+              get: async () => null,
+              send: async () => 1,
+            });
+          },
+        }),
+        createRedisClient: () => ({
+          close: () => undefined,
+          connect: async () => undefined,
           get: async () => null,
           send: async () => 1,
-        });
-      },
-    }),
-    createRedisClient: () => ({
-      close: () => undefined,
-      connect: async () => undefined,
-      get: async () => null,
-      send: async () => 1,
-    }),
-    isRecoverableRedisPollError: () => false,
-  }));
+        }),
+        isRecoverableRedisPollError: () => false,
+        isTransientRedisConnectionError: () => false,
+      }) satisfies Record<keyof typeof RedisClientModule, unknown>,
+  );
   void mock.module("@/api/lib/document-processing-enqueue", () => ({
     countPendingDocumentProcessingJobs: async () => 0,
     DOCUMENT_PROCESSING_OCR_JOB_NAME: "ocr",

--- a/apps/api/src/lib/redis-client.test.ts
+++ b/apps/api/src/lib/redis-client.test.ts
@@ -18,6 +18,7 @@ const {
   createBullMqConnection,
   createLazyRedisClient,
   isRecoverableRedisPollError,
+  isTransientRedisConnectionError,
 } = await import("@/api/lib/redis-client");
 
 describe("BullMQ Redis connection", () => {
@@ -98,6 +99,33 @@ describe("isRecoverableRedisPollError", () => {
     expect(
       isRecoverableRedisPollError({ code: "ERR_REDIS_INVALID_RESPONSE" }),
     ).toBe(false);
+  });
+});
+
+describe("isTransientRedisConnectionError", () => {
+  const withCode = (code: string): Error =>
+    Object.assign(new Error(code), { code });
+
+  // The classifier gates whether a periodic loop logs a Redis failure as an
+  // expected transient or captures it as an exception; a drifted code string
+  // would silently disable it, so the exact Bun error code is pinned.
+  test("classifies a closed-connection rejection as transient", () => {
+    expect(
+      isTransientRedisConnectionError(withCode("ERR_REDIS_CONNECTION_CLOSED")),
+    ).toBe(true);
+  });
+
+  test("leaves other failures and the poll blip unclassified", () => {
+    expect(isTransientRedisConnectionError(withCode("ECONNREFUSED"))).toBe(
+      false,
+    );
+    expect(
+      isTransientRedisConnectionError(withCode("ERR_REDIS_INVALID_RESPONSE")),
+    ).toBe(false);
+    expect(isTransientRedisConnectionError(new Error("plain"))).toBe(false);
+    expect(isTransientRedisConnectionError("ERR_REDIS_CONNECTION_CLOSED")).toBe(
+      false,
+    );
   });
 });
 

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -20,6 +20,20 @@ export const isRecoverableRedisPollError = (error: unknown): boolean =>
   error instanceof Error &&
   safeErrorCode(error) === RECOVERABLE_REDIS_POLL_ERROR_CODE;
 
+// Bun's RedisClient auto-reconnects a dropped socket, but a command issued
+// against the dead connection — the first touch after an idle window, or a
+// command in flight when the drop happens — rejects with
+// ERR_REDIS_CONNECTION_CLOSED instead of waiting for the reconnect. For a
+// periodic loop whose next tick retries anyway, that rejection is an
+// expected operational transient, not a defect; a persistent outage keeps
+// failing and stays visible through the loop's own error logging and the
+// worker/broadcast error paths.
+const TRANSIENT_REDIS_CONNECTION_ERROR_CODE = "ERR_REDIS_CONNECTION_CLOSED";
+
+export const isTransientRedisConnectionError = (error: unknown): boolean =>
+  error instanceof Error &&
+  safeErrorCode(error) === TRANSIENT_REDIS_CONNECTION_ERROR_CODE;
+
 class ConfiguredRedisClient extends RedisClient implements BunRedisRawClient {
   readonly #connectHandlers = new Set<() => void>();
 

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -55,6 +55,13 @@ void mock.module("@/api/lib/analytics/capture", () => ({
   captureRequestError: captureErrorMock,
 }));
 
+const loggerWarnMock = mock();
+const realLogger = await import("@/api/lib/observability/logger");
+void mock.module("@/api/lib/observability/logger", () => ({
+  ...realLogger,
+  logger: { ...realLogger.logger, warn: loggerWarnMock },
+}));
+
 void mock.module("@/api/lib/tanstack-ai-models", () => ({
   ...realTanStackAIModels,
   getTanStackTextModelById: () => testModel,
@@ -482,6 +489,7 @@ describe("TanStack AI model-ingress guard", () => {
   test("redacts tenant ids out of the dispatched messages", async () => {
     capturedChatOptions.length = 0;
     captureErrorMock.mockClear();
+    loggerWarnMock.mockClear();
     nextChatResult = createTextStream(["ok"]);
 
     await generateTanStackTextForRole({
@@ -499,7 +507,9 @@ describe("TanStack AI model-ingress guard", () => {
     expect(dispatched).toContain("[internal-id-removed]");
     // Membership-exact: a public decision id is not a tenant id.
     expect(dispatched).toContain(publicDecisionId);
-    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    // Routine redaction hits log; only server-built surfaces still capture.
+    expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
   });
 
   test("leaves a request without tenant ids untouched and silent", async () => {
@@ -530,6 +540,7 @@ describe("TanStack AI model-ingress guard", () => {
   test("redacts an untrusted-embedding system prompt, fails closed on a server-built one", async () => {
     capturedChatOptions.length = 0;
     captureErrorMock.mockClear();
+    loggerWarnMock.mockClear();
     nextChatResult = createTextStream(["ok"]);
 
     await generateTanStackTextForRole({
@@ -546,7 +557,9 @@ describe("TanStack AI model-ingress guard", () => {
     expect(getOnlyCapturedChatOptions().systemPrompts).toEqual([
       "Document context: workspace [internal-id-removed]",
     ]);
-    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    // Routine redaction hits log; only server-built surfaces still capture.
+    expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1);
 
     capturedChatOptions.length = 0;
     nextChatResult = createTextStream(["ok"]);

--- a/apps/web/src/lib/sse.ts
+++ b/apps/web/src/lib/sse.ts
@@ -92,6 +92,10 @@ export const useWorkspaceSSE = (
     let source: EventSource | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let consecutiveFailures = 0;
+    // Offline failures back off but never count toward the outage capture:
+    // they would either trip it on the first failure after coming back
+    // online, or overshoot the threshold so a real outage never equals it.
+    let consecutiveOnlineFailures = 0;
     let disposed = false;
 
     const handleMessage = (event: MessageEvent) => {
@@ -112,6 +116,7 @@ export const useWorkspaceSSE = (
 
       const handleOpen = () => {
         consecutiveFailures = 0;
+        consecutiveOnlineFailures = 0;
       };
 
       const handleError = () => {
@@ -122,11 +127,13 @@ export const useWorkspaceSSE = (
         }
         stream.close();
         consecutiveFailures += 1;
-        if (
-          consecutiveFailures === SSE_ESCALATE_AFTER_FAILURES &&
-          navigator.onLine
-        ) {
-          captureConnectionOutage();
+        if (navigator.onLine) {
+          consecutiveOnlineFailures += 1;
+          if (consecutiveOnlineFailures === SSE_ESCALATE_AFTER_FAILURES) {
+            captureConnectionOutage();
+          }
+        } else {
+          consecutiveOnlineFailures = 0;
         }
         reconnectTimer = setTimeout(() => {
           reconnectTimer = null;

--- a/apps/web/src/lib/sse.ts
+++ b/apps/web/src/lib/sse.ts
@@ -17,6 +17,22 @@ const WORKSPACE_SSE_EVENT_SOURCE_INIT = {
   withCredentials: true,
 } satisfies EventSourceInit;
 
+// The browser stops reconnecting (readyState CLOSED) on a non-2xx response,
+// a wrong content type, or a network change — states a fresh EventSource
+// usually recovers from. Re-establish with capped exponential backoff and
+// escalate to telemetry once per outage episode, only after several
+// consecutive failures while the browser reports itself online: a laptop
+// waking from sleep should reconnect quietly, not page.
+const SSE_RECONNECT_BASE_DELAY_MS = 1000;
+const SSE_RECONNECT_MAX_DELAY_MS = 30_000;
+const SSE_ESCALATE_AFTER_FAILURES = 5;
+
+const sseReconnectDelayMs = (failures: number): number =>
+  Math.min(
+    SSE_RECONNECT_BASE_DELAY_MS * 2 ** Math.max(0, failures - 1),
+    SSE_RECONNECT_MAX_DELAY_MS,
+  );
+
 type UseWorkspaceSSEOptions = {
   onEvent?: (event: WorkspaceRealtimeEvent) => void;
 };
@@ -28,8 +44,9 @@ const getWorkspaceSSEUrl = (workspaceId: string) =>
  * Subscribe to workspace-scoped SSE events and apply their validated React
  * Query cache actions.
  *
- * Auto-reconnects via the native EventSource reconnection
- * behaviour. Cleans up on unmount or when workspaceId changes.
+ * The native EventSource retry covers transient drops; once the browser
+ * gives up (readyState CLOSED) a new source is created with capped backoff.
+ * Cleans up on unmount or when workspaceId changes.
  */
 export const useWorkspaceSSE = (
   workspaceId: string,
@@ -63,17 +80,19 @@ export const useWorkspaceSSE = (
       }
     },
   );
-  const captureClosedConnection = useLatestCallback(() => {
+  const captureConnectionOutage = useLatestCallback(() => {
     analytics.captureError(
-      new Error(`SSE connection closed for workspace ${workspaceId}`),
+      // Stable message: the workspace id adds nothing to grouping and the
+      // failure is the same defect regardless of workspace.
+      new Error("SSE connection failed to re-establish"),
     );
   });
 
   useExternalSyncEffect(() => {
-    const source = new EventSource(
-      getWorkspaceSSEUrl(workspaceId),
-      WORKSPACE_SSE_EVENT_SOURCE_INIT,
-    );
+    let source: EventSource | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let consecutiveFailures = 0;
+    let disposed = false;
 
     const handleMessage = (event: MessageEvent) => {
       const parsed = parseWorkspaceRealtimeMessage(String(event.data));
@@ -84,21 +103,50 @@ export const useWorkspaceSSE = (
       handleParsedEvent(parsed);
     };
 
-    const handleError = () => {
-      // EventSource auto-reconnects; capture for observability
-      // only if the connection is fully closed.
-      if (source.readyState === EventSource.CLOSED) {
-        captureClosedConnection();
-      }
+    const connect = () => {
+      const stream = new EventSource(
+        getWorkspaceSSEUrl(workspaceId),
+        WORKSPACE_SSE_EVENT_SOURCE_INIT,
+      );
+      source = stream;
+
+      const handleOpen = () => {
+        consecutiveFailures = 0;
+      };
+
+      const handleError = () => {
+        // readyState CONNECTING means the browser is retrying on its own;
+        // only a fully closed source needs our reconnect loop.
+        if (stream.readyState !== EventSource.CLOSED || disposed) {
+          return;
+        }
+        stream.close();
+        consecutiveFailures += 1;
+        if (
+          consecutiveFailures === SSE_ESCALATE_AFTER_FAILURES &&
+          navigator.onLine
+        ) {
+          captureConnectionOutage();
+        }
+        reconnectTimer = setTimeout(() => {
+          reconnectTimer = null;
+          connect();
+        }, sseReconnectDelayMs(consecutiveFailures));
+      };
+
+      stream.addEventListener("open", handleOpen);
+      stream.addEventListener("message", handleMessage);
+      stream.addEventListener("error", handleError);
     };
 
-    source.addEventListener("message", handleMessage);
-    source.addEventListener("error", handleError);
+    connect();
 
     return () => {
-      source.removeEventListener("message", handleMessage);
-      source.removeEventListener("error", handleError);
-      source.close();
+      disposed = true;
+      if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer);
+      }
+      source?.close();
     };
-  }, [workspaceId, captureClosedConnection, handleParsedEvent]);
+  }, [workspaceId, captureConnectionOutage, handleParsedEvent]);
 };


### PR DESCRIPTION
- Classify Bun's `ERR_REDIS_CONNECTION_CLOSED` as an expected transient in the periodic loops (reconciliation, OCR readiness heartbeat/read, job claim): the socket auto-reconnects and the next tick retries, so the rejection logs at WARN instead of capturing an exception per drop.
- Capture a document-processing run once, at its terminal transition in `markRunFailed`; retry-scheduled attempts log at WARN instead of re-reporting the same defect up to the attempt cap.
- Model-ingress redactions on user-authored surfaces (messages, mixed-provenance prompts) log paths at WARN: a pasted app URL contains a workspace id, so hits are routine and the redaction is the enforcement. Server-built surfaces keep capture/panic.
- Crawl adapters: skipped-page timeouts/5xx and per-document finaldoc validation misses log at WARN; the coverage ledger and the runner's stall latch own the durable signal.
- Web SSE: a fully closed EventSource now re-establishes with capped backoff (1s..30s) instead of staying dead until remount, escalating one stable-message exception per outage episode after five consecutive failures while online.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resilience when temporary service or connection issues affect document processing and readiness checks.
  - Reduced unnecessary error reporting for expected validation, retry, and recovery scenarios.
  - Improved chat input safeguards while maintaining strict handling of potentially unsafe system or tool content.
  - Added more reliable automatic reconnection for live updates after connection closures, using increasing retry delays.
  - Prevented duplicate reconnect attempts and ensured connections are cleaned up correctly when no longer needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->