### PR TITLE
feat(api): size confirmation for queued runs

### DIFF
--- a/apps/api/src/handlers/document-reviews/create-run.ts
+++ b/apps/api/src/handlers/document-reviews/create-run.ts
@@ -206,7 +206,8 @@ const createDocumentReviewRun = createSafeHandler(
       metering: { actionType: "doc_review", modelRole: "pdf" },
       estimatedUnits: estimateDocumentRunUnits({
         modelId: reviewModel.modelId,
-        inputBytes,
+        actionType: "doc_review",
+        storedInputBytes: inputBytes,
         plannedOutputs: plan.expectedFindingCount,
         serviceTier: "standard",
       }),

--- a/apps/api/src/handlers/document-reviews/create-run.ts
+++ b/apps/api/src/handlers/document-reviews/create-run.ts
@@ -16,7 +16,10 @@ import { resolveReviewSelection } from "@/api/handlers/document-reviews/review-s
 import { validateReviewTopics } from "@/api/handlers/document-reviews/review-topics";
 import { createDocumentReviewRunBodySchema } from "@/api/handlers/document-reviews/schemas";
 import type { DocumentReviewTopic } from "@/api/handlers/document-reviews/schemas";
-import { createSafeHandler } from "@/api/lib/api-handlers";
+import {
+  assertRunSizeConfirmedForHandler,
+  createSafeHandler,
+} from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
@@ -32,6 +35,8 @@ import type {
 import { planReviewRun } from "@/api/lib/document-review/run-plan";
 import { enqueueDocumentReviewRun } from "@/api/lib/document-review/run-queue";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { getTanStackTextModelInfoForRole } from "@/api/lib/tanstack-ai-models";
+import { estimateDocumentRunUnits } from "@/api/lib/usage/run-estimate";
 
 const config = {
   description:
@@ -67,6 +72,7 @@ const createDocumentReviewRun = createSafeHandler(
   config,
   async function* ({
     body,
+    orgAIConfig,
     recordAuditEvent,
     safeDb,
     session,
@@ -182,6 +188,37 @@ const createDocumentReviewRun = createSafeHandler(
           message: "None of the confirmed topics can be reviewed.",
         }),
       );
+    }
+
+    // Size the whole run before pinning it: every reviewed file's bytes
+    // through the review model's rate, one output budget per planned
+    // finding. Large runs need the client to restate the estimate.
+    const reviewModel = getTanStackTextModelInfoForRole("pdf", orgAIConfig, {
+      organizationId,
+    });
+    const inputBytes =
+      selection.value.target.fileSizeBytes +
+      selection.value.references.reduce(
+        (total, reference) => total + reference.fileSizeBytes,
+        0,
+      );
+    const sizeError = await assertRunSizeConfirmedForHandler({
+      metering: { actionType: "doc_review", modelRole: "pdf" },
+      estimatedUnits: estimateDocumentRunUnits({
+        modelId: reviewModel.modelId,
+        inputBytes,
+        plannedOutputs: plan.expectedFindingCount,
+        serviceTier: "standard",
+      }),
+      confirmedUnits: body.confirmedUnits,
+      organizationId,
+      orgAIConfig,
+      workspaceId,
+      userId: user.id,
+      safeDb,
+    });
+    if (sizeError) {
+      return Result.err(sizeError);
     }
 
     const target = selection.value.target;

--- a/apps/api/src/handlers/document-reviews/review-selection.ts
+++ b/apps/api/src/handlers/document-reviews/review-selection.ts
@@ -22,6 +22,8 @@ export type ResolvedReviewDocument = {
   entityId: SafeId<"entity">;
   entityVersionId: SafeId<"entityVersion">;
   file: ResolvedFile;
+  /** Pinned file's stored size, for pre-flight run sizing. */
+  fileSizeBytes: number;
 };
 
 type ResolveReviewSelectionArgs = {
@@ -64,6 +66,7 @@ const resolveOne = (
   return Result.ok({
     entityId: entity.id,
     entityVersionId: currentVersion.id,
+    fileSizeBytes: field.content.sizeBytes,
     file: {
       fileFieldId: field.id,
       fileId: field.content.id,

--- a/apps/api/src/handlers/document-reviews/schemas.ts
+++ b/apps/api/src/handlers/document-reviews/schemas.ts
@@ -89,4 +89,9 @@ export const createDocumentReviewRunBodySchema = t.Object({
     minItems: 1,
     maxItems: DOCUMENT_REVIEW_LIMITS.topicsMax,
   }),
+  /**
+   * Restated size estimate from a prior 409 `usage_confirmation_required`
+   * answer; the run starts only when it covers the current estimate.
+   */
+  confirmedUnits: t.Optional(t.Integer({ minimum: 0 })),
 });

--- a/apps/api/src/handlers/document-reviews/schemas.ts
+++ b/apps/api/src/handlers/document-reviews/schemas.ts
@@ -90,7 +90,7 @@ export const createDocumentReviewRunBodySchema = t.Object({
     maxItems: DOCUMENT_REVIEW_LIMITS.topicsMax,
   }),
   /**
-   * Restated size estimate from a prior 409 `usage_confirmation_required`
+   * Restated size estimate from a prior 428 `usage_confirmation_required`
    * answer; the run starts only when it covers the current estimate.
    */
   confirmedUnits: t.Optional(t.Integer({ minimum: 0 })),

--- a/apps/api/src/handlers/uploads/agent-skill.ts
+++ b/apps/api/src/handlers/uploads/agent-skill.ts
@@ -170,6 +170,7 @@ export const finalizeAgentSkill = async function* ({
         case 402:
         case 403:
         case 413:
+        case 428:
         case 429:
         case 502:
         case 503:

--- a/apps/api/src/lib/ai-error.test.ts
+++ b/apps/api/src/lib/ai-error.test.ts
@@ -124,7 +124,7 @@ describe("classifyAIError", () => {
 // Split so the exhaustiveness alias below fails to compile when a status is
 // added to `HandlerErrorStatusCode` without deciding which side it falls on.
 const CLIENT_STATUS_CODES = [
-  400, 401, 402, 403, 404, 409, 413, 422, 429,
+  400, 401, 402, 403, 404, 409, 413, 422, 428, 429,
 ] as const satisfies readonly HandlerErrorStatusCode[];
 
 const SERVER_STATUS_CODES = [

--- a/apps/api/src/lib/api-handlers.test.ts
+++ b/apps/api/src/lib/api-handlers.test.ts
@@ -489,7 +489,7 @@ describe("assertRunSizeConfirmedForHandler", () => {
     });
   });
 
-  test("a large unconfirmed run answers 409 carrying the estimate", async () => {
+  test("a large unconfirmed run answers 428 carrying the estimate", async () => {
     await withInstanceEnforcement(async () => {
       const outcome = await assertRunSizeConfirmedForHandler({
         ...baseInput,
@@ -498,7 +498,7 @@ describe("assertRunSizeConfirmedForHandler", () => {
         safeDb: availableDb(500),
       });
       expect(outcome).toMatchObject({
-        status: 409,
+        status: 428,
         code: "usage_confirmation_required",
         confirmation: { estimatedUnits: 120, availableUnits: 500 },
       });
@@ -513,7 +513,7 @@ describe("assertRunSizeConfirmedForHandler", () => {
         confirmedUnits: 60,
         safeDb: availableDb(500),
       });
-      expect(outcome).toMatchObject({ status: 409 });
+      expect(outcome).toMatchObject({ status: 428 });
     });
   });
 

--- a/apps/api/src/lib/api-handlers.test.ts
+++ b/apps/api/src/lib/api-handlers.test.ts
@@ -5,6 +5,7 @@ import type { SafeDb, SafeDbError } from "@/api/db/safe-db";
 import { env } from "@/api/env";
 import type { OrgAIConfig } from "@/api/lib/ai-config";
 import {
+  assertRunSizeConfirmedForHandler,
   createSafeHandler,
   createSafeRootHandler,
   errorCauseChainAttributes,
@@ -12,7 +13,11 @@ import {
 } from "@/api/lib/api-handlers";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
-import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  DatabaseError,
+  HandlerError,
+  UsageLimitExceededError,
+} from "@/api/lib/errors/tagged-errors";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 const noopAuditRecorder: AuditRecorder = async () => undefined;
@@ -360,6 +365,167 @@ describe("errorCauseChainAttributes", () => {
 
     expect(errorCauseChainAttributes(first)).toEqual({
       "error.cause.type": "Error",
+    });
+  });
+});
+
+describe("assertRunSizeConfirmedForHandler", () => {
+  const organizationId = toSafeId<"organization">(
+    "019e7000-0000-7000-8000-000000000002",
+  );
+  const userId = toSafeId<"user">("019e7000-0000-7000-8000-000000000001");
+
+  const baseInput = {
+    metering: { actionType: "doc_review", modelRole: "pdf" },
+    organizationId,
+    orgAIConfig: null,
+    workspaceId: null,
+    userId,
+  } as const;
+
+  const untouchableDb: SafeDb = asTestRaw<SafeDb>(async () => {
+    throw new DatabaseError({ message: "ledger must not be touched" });
+  });
+
+  const availableDb = (available: number): SafeDb =>
+    asTestRaw<SafeDb>(async () => Result.ok({ ok: true, available }));
+
+  const overLimitDb = (required: number, available: number): SafeDb =>
+    asTestRaw<SafeDb>(async () =>
+      Result.ok({
+        ok: false,
+        error: new UsageLimitExceededError({
+          message: `Usage limit exceeded: need ${required}, have ${available}`,
+          required,
+          available,
+          reason: "usage_limit_exceeded",
+        }),
+      }),
+    );
+
+  const withInstanceEnforcement = async (
+    fn: () => Promise<void>,
+  ): Promise<void> => {
+    const previous = {
+      enforcement: env.USAGE_ENFORCEMENT_ENABLED,
+      provider: env.AI_PROVIDER,
+      openaiKey: env.OPENAI_API_KEY,
+    };
+    env.USAGE_ENFORCEMENT_ENABLED = true;
+    env.AI_PROVIDER = "openai";
+    env.OPENAI_API_KEY = "test-openai-instance-key";
+    try {
+      await fn();
+    } finally {
+      env.USAGE_ENFORCEMENT_ENABLED = previous.enforcement;
+      env.AI_PROVIDER = previous.provider;
+      env.OPENAI_API_KEY = previous.openaiKey;
+    }
+  };
+
+  test("no-op while enforcement is off", async () => {
+    const previous = env.USAGE_ENFORCEMENT_ENABLED;
+    env.USAGE_ENFORCEMENT_ENABLED = false;
+    try {
+      const outcome = await assertRunSizeConfirmedForHandler({
+        ...baseInput,
+        estimatedUnits: 10_000,
+        confirmedUnits: undefined,
+        safeDb: untouchableDb,
+      });
+      expect(outcome).toBeNull();
+    } finally {
+      env.USAGE_ENFORCEMENT_ENABLED = previous;
+    }
+  });
+
+  test("no-op for BYOK settlements", async () => {
+    await withInstanceEnforcement(async () => {
+      const byokConfig: OrgAIConfig = {
+        providers: [{ provider: "openai", apiKey: "test-api-key" }],
+        overrideModels: {
+          chat: { provider: "openai", modelId: "gpt-5.6" },
+          fast: { provider: "openai", modelId: "gpt-5.4-mini" },
+          pdf: { provider: "openai", modelId: "gpt-5.6" },
+          reasoning: { provider: "openai", modelId: "gpt-5.6" },
+        },
+      };
+      const outcome = await assertRunSizeConfirmedForHandler({
+        ...baseInput,
+        orgAIConfig: byokConfig,
+        estimatedUnits: 10_000,
+        confirmedUnits: undefined,
+        safeDb: untouchableDb,
+      });
+      expect(outcome).toBeNull();
+    });
+  });
+
+  test("small runs pass once the whole estimate is affordable", async () => {
+    await withInstanceEnforcement(async () => {
+      const outcome = await assertRunSizeConfirmedForHandler({
+        ...baseInput,
+        estimatedUnits: 10,
+        confirmedUnits: undefined,
+        safeDb: availableDb(500),
+      });
+      expect(outcome).toBeNull();
+    });
+  });
+
+  test("an unaffordable estimate answers the over-limit shape, not a confirmation", async () => {
+    await withInstanceEnforcement(async () => {
+      const outcome = await assertRunSizeConfirmedForHandler({
+        ...baseInput,
+        estimatedUnits: 800,
+        confirmedUnits: undefined,
+        safeDb: overLimitDb(800, 30),
+      });
+      expect(outcome).toMatchObject({
+        status: 402,
+        code: "usage_limit_exceeded",
+        usage: { required: 800, available: 30 },
+      });
+    });
+  });
+
+  test("a large unconfirmed run answers 409 carrying the estimate", async () => {
+    await withInstanceEnforcement(async () => {
+      const outcome = await assertRunSizeConfirmedForHandler({
+        ...baseInput,
+        estimatedUnits: 120,
+        confirmedUnits: undefined,
+        safeDb: availableDb(500),
+      });
+      expect(outcome).toMatchObject({
+        status: 409,
+        code: "usage_confirmation_required",
+        confirmation: { estimatedUnits: 120, availableUnits: 500 },
+      });
+    });
+  });
+
+  test("a stale lower confirmation does not cover a grown estimate", async () => {
+    await withInstanceEnforcement(async () => {
+      const outcome = await assertRunSizeConfirmedForHandler({
+        ...baseInput,
+        estimatedUnits: 120,
+        confirmedUnits: 60,
+        safeDb: availableDb(500),
+      });
+      expect(outcome).toMatchObject({ status: 409 });
+    });
+  });
+
+  test("restating the estimate lets the run proceed", async () => {
+    await withInstanceEnforcement(async () => {
+      const outcome = await assertRunSizeConfirmedForHandler({
+        ...baseInput,
+        estimatedUnits: 120,
+        confirmedUnits: 120,
+        safeDb: availableDb(500),
+      });
+      expect(outcome).toBeNull();
     });
   });
 });

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -935,7 +935,7 @@ type RunSizePreflightInput = UsagePreflightInput & {
  * for the WHOLE estimate — the per-action preflight would admit a run
  * whose tail cannot settle — and above {@link RUN_CONFIRMATION_UNITS}
  * additionally requires the request to restate the estimate via
- * `confirmedUnits`, else answers a 409 carrying the estimate for the
+ * `confirmedUnits`, else answers a 428 carrying the estimate for the
  * client to confirm. No-op for BYOK settlements (the organization's own
  * key pays) and while `USAGE_ENFORCEMENT_ENABLED` is off.
  */
@@ -948,7 +948,7 @@ export const assertRunSizeConfirmedForHandler = async ({
   workspaceId,
   userId,
   safeDb,
-}: RunSizePreflightInput): Promise<HandlerError<402 | 409 | 500> | null> => {
+}: RunSizePreflightInput): Promise<HandlerError<402 | 428 | 500> | null> => {
   if (!env.USAGE_ENFORCEMENT_ENABLED) {
     return null;
   }
@@ -999,7 +999,7 @@ export const assertRunSizeConfirmedForHandler = async ({
   }
   return new HandlerError({
     code: API_ERROR_CODE.usageConfirmationRequired,
-    status: 409,
+    status: 428,
     message:
       "This run's estimated size needs an explicit confirmation to start.",
     confirmation: {

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -28,6 +28,7 @@ import {
 import type {
   HandlerErrorClaim,
   HandlerErrorCode,
+  HandlerErrorConfirmationDetail,
   HandlerErrorStatusCode,
 } from "@/api/lib/errors/tagged-errors";
 import {
@@ -432,6 +433,11 @@ type SafeErrorBody = {
   required?: number;
   available?: number;
   /**
+   * Structured 409 detail when a queued run's estimated consumption
+   * needs an explicit go-ahead (see HandlerErrorConfirmationDetail).
+   */
+  confirmation?: HandlerErrorConfirmationDetail;
+  /**
    * OAuth-style machine-readable error identifier surfaced on the
    * agent-auth ID-JAG path (e.g. `login_required`,
    * `interaction_required`, `issuer_not_enabled`). Optional everywhere.
@@ -515,6 +521,7 @@ const API_ERROR_CODE = {
   forbidden: "forbidden",
   internalServerError: "internal_server_error",
   usageLimitExceeded: "usage_limit_exceeded",
+  usageConfirmationRequired: "usage_confirmation_required",
 } as const satisfies Record<string, HandlerErrorCode>;
 
 // This needs function overloads. A generic arrow returning `status(statusCode)`
@@ -909,6 +916,99 @@ export const assertUsageAvailableForHandler = async ({
   });
 };
 
+/**
+ * Above this many estimated units, a queued run must carry an explicit
+ * `confirmedUnits` restating its size before it may start.
+ */
+export const RUN_CONFIRMATION_UNITS = 50;
+
+type RunSizePreflightInput = UsagePreflightInput & {
+  /** Units the initiator expects the whole run to consume. */
+  estimatedUnits: number;
+  /** The client's restated estimate; `undefined` when not confirming. */
+  confirmedUnits: number | undefined;
+};
+
+/**
+ * Pre-flight for batch initiators (document reviews, flows) that
+ * enqueue work whose total size is known up front. Checks availability
+ * for the WHOLE estimate — the per-action preflight would admit a run
+ * whose tail cannot settle — and above {@link RUN_CONFIRMATION_UNITS}
+ * additionally requires the request to restate the estimate via
+ * `confirmedUnits`, else answers a 409 carrying the estimate for the
+ * client to confirm. No-op for BYOK settlements (the organization's own
+ * key pays) and while `USAGE_ENFORCEMENT_ENABLED` is off.
+ */
+export const assertRunSizeConfirmedForHandler = async ({
+  metering,
+  estimatedUnits,
+  confirmedUnits,
+  organizationId,
+  orgAIConfig,
+  workspaceId,
+  userId,
+  safeDb,
+}: RunSizePreflightInput): Promise<HandlerError<402 | 409 | 500> | null> => {
+  if (!env.USAGE_ENFORCEMENT_ENABLED) {
+    return null;
+  }
+  const meteringContext = resolveMeteringContext({
+    metering,
+    organizationId,
+    orgAIConfig,
+    workspaceId,
+    userId,
+  });
+  if (meteringContext.isByok) {
+    return null;
+  }
+  const checkResult = await safeDb(
+    async (tx) =>
+      await assertUsageAvailable({
+        tx,
+        organizationId: meteringContext.organizationId,
+        required: Math.max(estimatedUnits, meteringContext.cost),
+      }),
+  );
+  if (Result.isError(checkResult)) {
+    return new HandlerError({
+      code: API_ERROR_CODE.internalServerError,
+      status: 500,
+      message: "Internal server error",
+      cause: checkResult.error,
+    });
+  }
+  const check = checkResult.value;
+  if (!check.ok) {
+    return new HandlerError({
+      code: API_ERROR_CODE.usageLimitExceeded,
+      status: 402,
+      message: check.error.message,
+      usage: {
+        reason: check.error.reason,
+        required: check.error.required,
+        available: check.error.available,
+      },
+    });
+  }
+  if (estimatedUnits <= RUN_CONFIRMATION_UNITS) {
+    return null;
+  }
+  if (confirmedUnits !== undefined && confirmedUnits >= estimatedUnits) {
+    return null;
+  }
+  return new HandlerError({
+    code: API_ERROR_CODE.usageConfirmationRequired,
+    status: 409,
+    message:
+      "This run's estimated size needs an explicit confirmation to start.",
+    confirmation: {
+      estimatedUnits,
+      availableUnits: check.available,
+    },
+  });
+};
+
 const createSafeDirectHandler = <
   TConfig extends InputSchema,
   TContext extends SafeHandlerLogContext,
@@ -934,6 +1034,7 @@ const safeErrorBody = (error: HandlerError): SafeErrorBody => ({
         available: error.usage.available,
       }
     : {}),
+  ...(error.confirmation ? { confirmation: error.confirmation } : {}),
   ...(error.error ? { error: error.error } : {}),
   ...(error.claim ? { claim: error.claim } : {}),
   ...error.stepUp,

--- a/apps/api/src/lib/document-review/run-queue.ts
+++ b/apps/api/src/lib/document-review/run-queue.ts
@@ -560,7 +560,9 @@ const executeRun = async (
     promptCachingEnabled: config.value.promptCachingEnabled,
     serviceTier: SERVICE_TIER,
     usageMetering: {
-      actionType: "chat",
+      // Settles under the same action type the create-run pre-flight
+      // estimates with, so the estimate and the ledger agree.
+      actionType: "doc_review",
       organizationId: actor.organizationId,
       safeDb: actor.safeDb,
       serviceTier: SERVICE_TIER,

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -11,6 +11,7 @@ export type HandlerErrorStatusCode =
   | 409
   | 413
   | 422
+  | 428
   | 429
   | 500
   | 502
@@ -35,7 +36,9 @@ export type HandlerErrorUsageDetail = {
  * crosses the confirmation threshold: the client re-submits the same
  * request with `confirmedUnits >= estimatedUnits` to proceed. Distinct
  * from `usage` (the 402 over-limit detail) — this is not an over-limit
- * state, and the run may well be affordable.
+ * state, and the run may well be affordable. Answered as a 428, never a
+ * 409: run initiators already use 409 for "a run is active on this
+ * document", and clients resolve that by attaching the existing run.
  */
 export type HandlerErrorConfirmationDetail = {
   estimatedUnits: number;

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -31,6 +31,18 @@ export type HandlerErrorUsageDetail = {
 };
 
 /**
+ * Structured 409 detail for a queued run whose estimated consumption
+ * crosses the confirmation threshold: the client re-submits the same
+ * request with `confirmedUnits >= estimatedUnits` to proceed. Distinct
+ * from `usage` (the 402 over-limit detail) — this is not an over-limit
+ * state, and the run may well be affordable.
+ */
+export type HandlerErrorConfirmationDetail = {
+  estimatedUnits: number;
+  availableUnits: number;
+};
+
+/**
  * Ceremony fields of an agent-auth ID-JAG `interaction_required` step-up: a
  * human must complete the RFC 8628-style claim ceremony before a first
  * `(iss, sub)` delegation is written. The pinned guide reserves `claim` for
@@ -80,6 +92,7 @@ export type HandlerErrorProps<
   stepUp?: HandlerErrorStepUp | undefined;
   cause?: unknown;
   usage?: HandlerErrorUsageDetail | undefined;
+  confirmation?: HandlerErrorConfirmationDetail | undefined;
 };
 
 // TaggedError(...) cannot reference the class type parameter in the base
@@ -91,6 +104,7 @@ export class HandlerError<
   declare code?: HandlerErrorCode | undefined;
   declare status: TStatus;
   declare usage?: HandlerErrorUsageDetail | undefined;
+  declare confirmation?: HandlerErrorConfirmationDetail | undefined;
   declare error?: string | undefined;
   declare claim?: HandlerErrorClaim | undefined;
   declare stepUp?: HandlerErrorStepUp | undefined;
@@ -100,6 +114,7 @@ export class HandlerError<
     this.code = props.code;
     this.status = props.status;
     this.usage = props.usage;
+    this.confirmation = props.confirmation;
     this.error = props.error;
     this.claim = props.claim;
     this.stepUp = props.stepUp;

--- a/apps/api/src/lib/usage/run-estimate.test.ts
+++ b/apps/api/src/lib/usage/run-estimate.test.ts
@@ -3,45 +3,65 @@ import { describe, expect, test } from "bun:test";
 import { estimateDocumentRunUnits } from "./run-estimate";
 
 describe("estimateDocumentRunUnits", () => {
-  test("converts bytes and planned outputs through the model's rate", () => {
-    // 1 MiB -> 262144 tokens at 20_000/MTok = 5243 micro-units;
-    // 10 outputs -> 2500 tokens at 120_000/MTok = 300; standard tier
-    // multiplies by 1.5 before the 100 micro-unit -> unit conversion.
+  test("converts stored bytes and planned outputs through the model's rate", () => {
+    // 1 MiB stored inflates 4x into 4 MiB of prompt -> 1048576 tokens
+    // at 20_000/MTok = 20972 micro-units; 10 outputs -> 2500 tokens at
+    // 120_000/MTok = 300; standard tier multiplies by 1.5 before the
+    // 100 micro-unit -> unit conversion (320 units), then 11 planned
+    // calls x the doc_review floor of 8 add 88.
     expect(
       estimateDocumentRunUnits({
         modelId: "gpt-5.6-luna",
-        inputBytes: 1_048_576,
+        actionType: "doc_review",
+        storedInputBytes: 1_048_576,
         plannedOutputs: 10,
         serviceTier: "standard",
       }),
-    ).toBe(84);
+    ).toBe(408);
   });
 
   test("small documents stay under the confirmation threshold", () => {
     expect(
       estimateDocumentRunUnits({
         modelId: "gpt-5.6-luna",
-        inputBytes: 20_000,
+        actionType: "doc_review",
+        storedInputBytes: 20_000,
         plannedOutputs: 3,
         serviceTier: "standard",
       }),
-    ).toBe(3);
+    ).toBe(40);
   });
 
   test("scales with the model's rate, not a flat per-run constant", () => {
     const luna = estimateDocumentRunUnits({
       modelId: "gpt-5.6-luna",
-      inputBytes: 1_048_576,
+      actionType: "doc_review",
+      storedInputBytes: 1_048_576,
       plannedOutputs: 10,
       serviceTier: "standard",
     });
     const sonnet = estimateDocumentRunUnits({
       modelId: "claude-sonnet-5",
-      inputBytes: 1_048_576,
+      actionType: "doc_review",
+      storedInputBytes: 1_048_576,
       plannedOutputs: 10,
       serviceTier: "standard",
     });
-    expect(sonnet).toBe(824);
+    expect(sonnet).toBe(3272);
     expect(sonnet).toBeGreaterThan(luna);
+  });
+
+  test("floors every planned call even when tokens are negligible", () => {
+    // A tiny document with many planned findings settles at least the
+    // per-call floor for each generation; the estimate must not admit
+    // it on token volume alone.
+    const estimate = estimateDocumentRunUnits({
+      modelId: "gpt-5.6-luna",
+      actionType: "doc_review",
+      storedInputBytes: 100,
+      plannedOutputs: 10,
+      serviceTier: "standard",
+    });
+    expect(estimate).toBeGreaterThanOrEqual(88);
   });
 });

--- a/apps/api/src/lib/usage/run-estimate.test.ts
+++ b/apps/api/src/lib/usage/run-estimate.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import { estimateDocumentRunUnits } from "./run-estimate";
+
+describe("estimateDocumentRunUnits", () => {
+  test("converts bytes and planned outputs through the model's rate", () => {
+    // 1 MiB -> 262144 tokens at 20_000/MTok = 5243 micro-units;
+    // 10 outputs -> 2500 tokens at 120_000/MTok = 300; standard tier
+    // multiplies by 1.5 before the 100 micro-unit -> unit conversion.
+    expect(
+      estimateDocumentRunUnits({
+        modelId: "gpt-5.6-luna",
+        inputBytes: 1_048_576,
+        plannedOutputs: 10,
+        serviceTier: "standard",
+      }),
+    ).toBe(84);
+  });
+
+  test("small documents stay under the confirmation threshold", () => {
+    expect(
+      estimateDocumentRunUnits({
+        modelId: "gpt-5.6-luna",
+        inputBytes: 20_000,
+        plannedOutputs: 3,
+        serviceTier: "standard",
+      }),
+    ).toBe(3);
+  });
+
+  test("scales with the model's rate, not a flat per-run constant", () => {
+    const luna = estimateDocumentRunUnits({
+      modelId: "gpt-5.6-luna",
+      inputBytes: 1_048_576,
+      plannedOutputs: 10,
+      serviceTier: "standard",
+    });
+    const sonnet = estimateDocumentRunUnits({
+      modelId: "claude-sonnet-5",
+      inputBytes: 1_048_576,
+      plannedOutputs: 10,
+      serviceTier: "standard",
+    });
+    expect(sonnet).toBe(824);
+    expect(sonnet).toBeGreaterThan(luna);
+  });
+});

--- a/apps/api/src/lib/usage/run-estimate.ts
+++ b/apps/api/src/lib/usage/run-estimate.ts
@@ -1,21 +1,34 @@
 /**
  * Pre-flight sizing for document-scale runs.
  *
- * The initiator knows the pinned files' byte sizes and the planned
- * output count before any model call, so the estimate converts those
- * through the same rate table settlement uses. The heuristics are
- * deliberately coarse (bytes to tokens, a flat output budget per
- * planned item): the number gates a confirmation, it is not a charge.
+ * The initiator knows the pinned files' stored byte sizes and the
+ * planned output count before any model call, so the estimate converts
+ * those through the same rate table settlement uses, and adds the
+ * per-call settlement floor for every planned generation. Each
+ * heuristic is deliberately coarse and errs high — stored archives
+ * inflate into larger prompts, and token units plus full floors bound
+ * the per-call `max(tokens, floor)` settlement from above — because
+ * the number gates a confirmation, it is not a charge.
  */
 
-import type { UsageServiceTier } from "@/api/db/schema";
-import { SERVICE_TIER_MULTIPLIERS } from "@/api/lib/usage/action-weights";
+import type { UsageActionType, UsageServiceTier } from "@/api/db/schema";
+import {
+  computeUsageUnitCost,
+  SERVICE_TIER_MULTIPLIERS,
+} from "@/api/lib/usage/action-weights";
 import {
   computeRawUsageMicroUnits,
   MICRO_UNITS_PER_USAGE_UNIT,
 } from "@/api/lib/usage/unit-model";
 
-/** Rough document bytes per model token (DOCX/PDF extracted text). */
+/**
+ * Prompt bytes assumed per stored byte. Stored documents are
+ * compressed archives that inflate into serialized prompt blocks, so
+ * the stored size understates what the model reads.
+ */
+const PROMPT_BYTES_PER_STORED_BYTE = 4;
+
+/** Rough prompt bytes per model token. */
 const BYTES_PER_TOKEN = 4;
 
 /** Flat output budget assumed per planned item (finding, step result). */
@@ -23,26 +36,37 @@ const OUTPUT_TOKENS_PER_PLANNED_ITEM = 250;
 
 type EstimateDocumentRunUnitsInput = {
   modelId: string;
-  inputBytes: number;
+  actionType: UsageActionType;
+  storedInputBytes: number;
   plannedOutputs: number;
   serviceTier: UsageServiceTier;
 };
 
 export const estimateDocumentRunUnits = ({
   modelId,
-  inputBytes,
+  actionType,
+  storedInputBytes,
   plannedOutputs,
   serviceTier,
 }: EstimateDocumentRunUnitsInput): number => {
-  const inputTokens = Math.ceil(inputBytes / BYTES_PER_TOKEN);
+  const inputTokens = Math.ceil(
+    (storedInputBytes * PROMPT_BYTES_PER_STORED_BYTE) / BYTES_PER_TOKEN,
+  );
   const outputTokens = plannedOutputs * OUTPUT_TOKENS_PER_PLANNED_ITEM;
   const rawMicroUnits = computeRawUsageMicroUnits({
     modelId,
     inputTokens,
     outputTokens,
   });
-  return Math.ceil(
+  const tokenUnits = Math.ceil(
     (rawMicroUnits * SERVICE_TIER_MULTIPLIERS[serviceTier]) /
       MICRO_UNITS_PER_USAGE_UNIT,
   );
+  // Settlement floors each generation separately; one shared pass plus
+  // one generation per planned item bounds the call count.
+  const plannedCalls = plannedOutputs + 1;
+  const floorUnits =
+    plannedCalls *
+    computeUsageUnitCost({ actionType, serviceTier, isByok: false });
+  return tokenUnits + floorUnits;
 };

--- a/apps/api/src/lib/usage/run-estimate.ts
+++ b/apps/api/src/lib/usage/run-estimate.ts
@@ -1,0 +1,48 @@
+/**
+ * Pre-flight sizing for document-scale runs.
+ *
+ * The initiator knows the pinned files' byte sizes and the planned
+ * output count before any model call, so the estimate converts those
+ * through the same rate table settlement uses. The heuristics are
+ * deliberately coarse (bytes to tokens, a flat output budget per
+ * planned item): the number gates a confirmation, it is not a charge.
+ */
+
+import type { UsageServiceTier } from "@/api/db/schema";
+import { SERVICE_TIER_MULTIPLIERS } from "@/api/lib/usage/action-weights";
+import {
+  computeRawUsageMicroUnits,
+  MICRO_UNITS_PER_USAGE_UNIT,
+} from "@/api/lib/usage/unit-model";
+
+/** Rough document bytes per model token (DOCX/PDF extracted text). */
+const BYTES_PER_TOKEN = 4;
+
+/** Flat output budget assumed per planned item (finding, step result). */
+const OUTPUT_TOKENS_PER_PLANNED_ITEM = 250;
+
+type EstimateDocumentRunUnitsInput = {
+  modelId: string;
+  inputBytes: number;
+  plannedOutputs: number;
+  serviceTier: UsageServiceTier;
+};
+
+export const estimateDocumentRunUnits = ({
+  modelId,
+  inputBytes,
+  plannedOutputs,
+  serviceTier,
+}: EstimateDocumentRunUnitsInput): number => {
+  const inputTokens = Math.ceil(inputBytes / BYTES_PER_TOKEN);
+  const outputTokens = plannedOutputs * OUTPUT_TOKENS_PER_PLANNED_ITEM;
+  const rawMicroUnits = computeRawUsageMicroUnits({
+    modelId,
+    inputTokens,
+    outputTokens,
+  });
+  return Math.ceil(
+    (rawMicroUnits * SERVICE_TIER_MULTIPLIERS[serviceTier]) /
+      MICRO_UNITS_PER_USAGE_UNIT,
+  );
+};


### PR DESCRIPTION
Batch initiators previously enqueued metered work with no pre-flight at all: the per-action check covers a single call, so a run whose tail cannot settle was admitted anyway, and arbitrarily large runs started without any explicit go-ahead.

- `assertRunSizeConfirmedForHandler` (api-handlers): checks availability for the whole estimated run; above `RUN_CONFIRMATION_UNITS` the request must restate the estimate via `confirmedUnits`, else it is answered `409 usage_confirmation_required` carrying `confirmation: { estimatedUnits, availableUnits }`. No-op for BYOK settlements and while enforcement is off.
- `estimateDocumentRunUnits`: pinned file bytes and planned outputs through the model's catalog rate and tier multiplier; deliberately coarse (it gates a confirmation, it is not a charge).
- Wired into `document-reviews/create-run` (new optional `confirmedUnits` body field; `fileSizeBytes` exposed on the resolved selection). The review worker's settlement moves from `chat` to `doc_review` so the estimate and the ledger use the same action type.
- `HandlerErrorConfirmationDetail` on `HandlerError`/`SafeErrorBody`, following the existing structured-detail pattern.

Follow-ups (separate PRs): the flows initiator needs file sizes at start time; the client-side confirmation flow lands with the rest of that surface. Both are inert until enforcement is enabled.

Tests: gate matrix (enforcement off, BYOK, small run, over-limit 402, unconfirmed 409, stale confirmation, restated estimate), pinned estimator arithmetic, and the document-review suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added usage estimates for document review runs based on document size, planned outputs, model pricing and service tier.
  - Large runs now require confirmation before they can be queued, with estimated and available usage displayed when applicable.
  - Added support for submitting a previously confirmed usage estimate.

- **Bug Fixes**
  - Document review usage is now recorded under the correct activity type.
  - Improved handling of usage-limit and confirmation errors with clearer response details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->