### PR TITLE
feat(analytics): set organization group name on create and rename

### DIFF
--- a/apps/api/src/lib/analytics/posthog.test.ts
+++ b/apps/api/src/lib/analytics/posthog.test.ts
@@ -20,6 +20,11 @@ void mock.module("posthog-node", () => ({
 
 const { createPostHogAnalytics } = await import("./posthog");
 
+// Pinned as a literal on purpose: it must equal the browser adapter's group
+// type so client and server events land on one profile. Importing the
+// adapter's constant would make the assertion tautological.
+const EXPECTED_ORGANIZATION_GROUP_TYPE = "organization";
+
 describe("PostHog server analytics adapter", () => {
   beforeEach(() => {
     clientCaptureMock.mockClear();
@@ -41,10 +46,8 @@ describe("PostHog server analytics adapter", () => {
       properties: { name: "Acme Legal" },
     });
 
-    // `organization` must equal the browser adapter's group type; the id is
-    // the group key so client and server events land on one profile.
     expect(clientGroupIdentifyMock).toHaveBeenCalledWith({
-      groupType: "organization",
+      groupType: EXPECTED_ORGANIZATION_GROUP_TYPE,
       groupKey: organizationId,
       properties: { name: "Acme Legal" },
     });

--- a/apps/api/src/lib/analytics/posthog.test.ts
+++ b/apps/api/src/lib/analytics/posthog.test.ts
@@ -2,12 +2,15 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { ServerAnalyticsCaptureParams } from "@/api/lib/analytics/types";
 import { SERVER_ANALYTICS_EVENTS } from "@/api/lib/analytics/types";
+import { toSafeId } from "@/api/lib/branded-types";
 
 const clientCaptureMock = mock((_event: unknown) => undefined);
+const clientGroupIdentifyMock = mock((_params: unknown) => undefined);
 const clientFlushMock = mock(async () => undefined);
 
 class MockPostHog {
   capture = clientCaptureMock;
+  groupIdentify = clientGroupIdentifyMock;
   flush = clientFlushMock;
 }
 
@@ -20,7 +23,31 @@ const { createPostHogAnalytics } = await import("./posthog");
 describe("PostHog server analytics adapter", () => {
   beforeEach(() => {
     clientCaptureMock.mockClear();
+    clientGroupIdentifyMock.mockClear();
     clientFlushMock.mockClear();
+  });
+
+  test("upserts the organization group under the shared group type", () => {
+    const analytics = createPostHogAnalytics(
+      "phc_test",
+      "https://posthog.test",
+    );
+    const organizationId = toSafeId<"organization">(
+      "3f6e0a7e-9f6f-4a53-9a3e-2b8f6f0c9d41",
+    );
+
+    analytics.identifyOrganizationGroup({
+      organizationId,
+      properties: { name: "Acme Legal" },
+    });
+
+    // `organization` must equal the browser adapter's group type; the id is
+    // the group key so client and server events land on one profile.
+    expect(clientGroupIdentifyMock).toHaveBeenCalledWith({
+      groupType: "organization",
+      groupKey: organizationId,
+      properties: { name: "Acme Legal" },
+    });
   });
 
   test("captures only explicitly allowed server telemetry events", () => {

--- a/apps/api/src/lib/analytics/types.ts
+++ b/apps/api/src/lib/analytics/types.ts
@@ -121,16 +121,19 @@ export type ServerAnalyticsCaptureParams = ServerAnalyticsCaptureBase &
       }
   );
 
-// Group-profile properties for an organization; upserted whenever the
-// settings they mirror change.
+// Group-profile properties for an organization; each is upserted by the
+// code path that owns the state it mirrors (creation/rename for `name`,
+// settings for jurisdictions). `groupIdentify` merges properties into the
+// existing profile, so a caller sends only the keys it owns.
 export type OrganizationGroupProperties = {
+  name: string;
   practice_jurisdictions: string[];
   primary_jurisdiction: string | null;
 };
 
 export type OrganizationGroupIdentifyParams = {
   organizationId: SafeId<"organization">;
-  properties: OrganizationGroupProperties;
+  properties: Partial<OrganizationGroupProperties>;
 };
 
 export type Analytics = {

--- a/apps/api/src/lib/auth.test.ts
+++ b/apps/api/src/lib/auth.test.ts
@@ -5,11 +5,13 @@ import {
   describe,
   expect,
   setDefaultTimeout,
+  spyOn,
   test,
 } from "bun:test";
 
 import { member, organization, user } from "@/api/db/auth-schema";
 import { contacts, workspaceMembers, workspaces } from "@/api/db/schema";
+import { getAnalytics } from "@/api/lib/analytics/client";
 import {
   AUTHORITATIVE_SESSION_PATHS,
   assertNewAccountEmailAllowedForCreation,
@@ -814,5 +816,37 @@ describe("session freshness", () => {
       maxAge: SESSION_COOKIE_CACHE_MAX_AGE_SECONDS,
     });
     expect(SESSION_COOKIE_CACHE_MAX_AGE_SECONDS).toBe(60);
+  });
+});
+
+describe("organization lifecycle hook wiring", () => {
+  test("the organization plugin runs the lifecycle hooks against the live analytics sink", async () => {
+    // Pins the `...organizationLifecycleHooks` spread inside the plugin
+    // config: the hooks themselves are unit-tested in
+    // organization-lifecycle-hooks.test.ts; this checks the plugin actually
+    // received them and that they reach the analytics singleton.
+    const orgPlugin = getAuth().options.plugins.find(
+      (plugin) => plugin.id === "organization",
+    );
+    if (!orgPlugin || !("options" in orgPlugin)) {
+      throw new Error("organization plugin missing from auth config");
+    }
+    const hooks = orgPlugin.options.organizationHooks;
+    expect(hooks.afterCreateOrganization).toBeFunction();
+    expect(hooks.afterUpdateOrganization).toBeFunction();
+
+    const identify = spyOn(getAnalytics(), "identifyOrganizationGroup");
+    try {
+      const organizationId = orgId();
+      await hooks.afterUpdateOrganization({
+        organization: { id: organizationId, name: "Renamed Org" },
+      });
+      expect(identify).toHaveBeenCalledWith({
+        organizationId,
+        properties: { name: "Renamed Org" },
+      });
+    } finally {
+      identify.mockRestore();
+    }
   });
 });

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -36,6 +36,7 @@ import {
 import { env } from "@/api/env";
 import { loadOrgSettingsForAuth } from "@/api/lib/ai-config-loader";
 import { captureError } from "@/api/lib/analytics/capture";
+import { getAnalytics } from "@/api/lib/analytics/client";
 import { createAuditRecorder } from "@/api/lib/audit-log";
 import type { AuditExecutionContext } from "@/api/lib/audit-log";
 import { revokeOrganizationMemberAuthArtifacts } from "@/api/lib/auth-artifacts";
@@ -468,6 +469,19 @@ const SESSION_LIFETIME_SECONDS = 60 * 60 * 24 * 7;
 
 /** How often the session expiry is refreshed, in seconds (1 day). */
 const SESSION_UPDATE_AGE_SECONDS = 60 * 60 * 24;
+
+// Mirrors the organization's display name onto its PostHog group profile so
+// insights and group pages show a name instead of an opaque id. Called from
+// the organization hooks after the plugin has persisted the row.
+const identifyOrganizationName = (
+  organizationId: SafeId<"organization">,
+  name: string,
+): void => {
+  getAnalytics().identifyOrganizationGroup({
+    organizationId,
+    properties: { name },
+  });
+};
 
 /**
  * How long the signed session-cookie snapshot may satisfy `getSession`
@@ -1102,10 +1116,23 @@ const createAuth = () => {
             // here. Idempotent via the (organization_id, key) unique. Runs on
             // the owner connection (`rootDb`), which bypasses RLS the same way
             // the org row's own creation did.
-            await ensureDefaultDocumentTypes(
+            const organizationId = brandPersistedOrganizationId(org.id);
+            await ensureDefaultDocumentTypes(organizationId, rootDb);
+            identifyOrganizationName(organizationId, org.name);
+          },
+          async afterUpdateOrganization({ organization: org }) {
+            // The plugin passes `null` when the adapter returns no updated row.
+            if (!org) {
+              return;
+            }
+            // Fires for every organization update, not just renames; the
+            // group upsert is idempotent so re-sending an unchanged name is
+            // harmless.
+            identifyOrganizationName(
               brandPersistedOrganizationId(org.id),
-              rootDb,
+              org.name,
             );
+            await Promise.resolve();
           },
           async beforeDeleteOrganization({ organization: org }) {
             // Complete the deletion here, before the plugin's adapter runs.

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -86,6 +86,7 @@ import {
   enrichRequestContext,
   getRequestContext,
 } from "@/api/lib/observability/request-context";
+import { createOrganizationLifecycleHooks } from "@/api/lib/organization-lifecycle-hooks";
 import {
   completeOrganizationDeletion,
   OrganizationStorageTeardownBoundError,
@@ -470,19 +471,6 @@ const SESSION_LIFETIME_SECONDS = 60 * 60 * 24 * 7;
 /** How often the session expiry is refreshed, in seconds (1 day). */
 const SESSION_UPDATE_AGE_SECONDS = 60 * 60 * 24;
 
-// Mirrors the organization's display name onto its PostHog group profile so
-// insights and group pages show a name instead of an opaque id. Called from
-// the organization hooks after the plugin has persisted the row.
-const identifyOrganizationName = (
-  organizationId: SafeId<"organization">,
-  name: string,
-): void => {
-  getAnalytics().identifyOrganizationGroup({
-    organizationId,
-    properties: { name },
-  });
-};
-
 /**
  * How long the signed session-cookie snapshot may satisfy `getSession`
  * without touching the database. Bounds revocation latency: a revoked
@@ -760,6 +748,15 @@ const createAuth = () => {
   const twoFactorWithSignInGate = withStellaTwoFactorSignInGate(
     twoFactorPlugin,
   ) satisfies BetterAuthPlugin;
+
+  const organizationLifecycleHooks = createOrganizationLifecycleHooks({
+    analytics: getAnalytics(),
+    // Idempotent via the (organization_id, key) unique. Runs on the owner
+    // connection (`rootDb`), which bypasses RLS the same way the org row's
+    // own creation did.
+    seedDefaultDocumentTypes: async (organizationId: SafeId<"organization">) =>
+      await ensureDefaultDocumentTypes(organizationId, rootDb),
+  });
 
   const auth = betterAuth({
     trustedOrigins: [
@@ -1108,32 +1105,7 @@ const createAuth = () => {
         // valid. Single-use is enforced by the plugin's invitation status.
         invitationExpiresIn: 60 * 60 * 48,
         organizationHooks: {
-          async afterCreateOrganization({ organization: org }) {
-            // Seed the org's starter document-type taxonomy at creation so
-            // listing it stays a pure read: a read-only credential must not be
-            // able to mint document types by listing them. `org.id` is read off
-            // the row the plugin just created, so it becomes the ownership id
-            // here. Idempotent via the (organization_id, key) unique. Runs on
-            // the owner connection (`rootDb`), which bypasses RLS the same way
-            // the org row's own creation did.
-            const organizationId = brandPersistedOrganizationId(org.id);
-            await ensureDefaultDocumentTypes(organizationId, rootDb);
-            identifyOrganizationName(organizationId, org.name);
-          },
-          async afterUpdateOrganization({ organization: org }) {
-            // The plugin passes `null` when the adapter returns no updated row.
-            if (!org) {
-              return;
-            }
-            // Fires for every organization update, not just renames; the
-            // group upsert is idempotent so re-sending an unchanged name is
-            // harmless.
-            identifyOrganizationName(
-              brandPersistedOrganizationId(org.id),
-              org.name,
-            );
-            await Promise.resolve();
-          },
+          ...organizationLifecycleHooks,
           async beforeDeleteOrganization({ organization: org }) {
             // Complete the deletion here, before the plugin's adapter runs.
             // Everything that names the organization cascades away with it, and

--- a/apps/api/src/lib/organization-lifecycle-hooks.test.ts
+++ b/apps/api/src/lib/organization-lifecycle-hooks.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { Analytics } from "@/api/lib/analytics/types";
+import { toSafeId } from "@/api/lib/branded-types";
+import { createOrganizationLifecycleHooks } from "@/api/lib/organization-lifecycle-hooks";
+
+const identifyOrganizationGroup =
+  mock<Analytics["identifyOrganizationGroup"]>();
+const seedDefaultDocumentTypes = mock(async () => await Promise.resolve());
+const analytics: Analytics = {
+  capture: () => undefined,
+  identifyOrganizationGroup,
+  flush: async () => await Promise.resolve(),
+};
+
+const orgId = toSafeId<"organization">("3f6e0a7e-9f6f-4a53-9a3e-2b8f6f0c9d41");
+
+const hooks = createOrganizationLifecycleHooks({
+  analytics,
+  seedDefaultDocumentTypes,
+});
+
+describe("organization lifecycle hooks", () => {
+  beforeEach(() => {
+    identifyOrganizationGroup.mockClear();
+    seedDefaultDocumentTypes.mockClear();
+  });
+
+  test("afterCreateOrganization seeds document types, then names the group", async () => {
+    await hooks.afterCreateOrganization({
+      organization: { id: orgId, name: "Acme Legal" },
+    });
+
+    expect(seedDefaultDocumentTypes).toHaveBeenCalledWith(orgId);
+    expect(identifyOrganizationGroup).toHaveBeenCalledTimes(1);
+    expect(identifyOrganizationGroup).toHaveBeenCalledWith({
+      organizationId: orgId,
+      properties: { name: "Acme Legal" },
+    });
+  });
+
+  test("afterUpdateOrganization re-sends the current name", async () => {
+    await hooks.afterUpdateOrganization({
+      organization: { id: orgId, name: "Acme Legal LLP" },
+    });
+
+    expect(seedDefaultDocumentTypes).not.toHaveBeenCalled();
+    expect(identifyOrganizationGroup).toHaveBeenCalledTimes(1);
+    expect(identifyOrganizationGroup).toHaveBeenCalledWith({
+      organizationId: orgId,
+      properties: { name: "Acme Legal LLP" },
+    });
+  });
+
+  test("afterUpdateOrganization skips a missing updated row", async () => {
+    await hooks.afterUpdateOrganization({ organization: null });
+
+    expect(identifyOrganizationGroup).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/lib/organization-lifecycle-hooks.ts
+++ b/apps/api/src/lib/organization-lifecycle-hooks.ts
@@ -1,0 +1,66 @@
+import type { Analytics } from "@/api/lib/analytics/types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { brandPersistedOrganizationId } from "@/api/lib/safe-id-boundaries";
+
+// The subset of the plugin's organization row the hooks read. Declared
+// narrower than better-auth's hook payload so tests can call the hooks with a
+// minimal fixture; parameter contravariance keeps the hooks assignable to the
+// plugin's `organizationHooks`.
+type PersistedOrganization = {
+  id: string;
+  name: string;
+};
+
+type OrganizationLifecycleHooksOptions = {
+  analytics: Analytics;
+  seedDefaultDocumentTypes: (
+    organizationId: SafeId<"organization">,
+  ) => Promise<void>;
+};
+
+// Mirrors the organization's display name onto its PostHog group profile so
+// insights and group pages show a name instead of an opaque id.
+const identifyOrganizationName = (
+  analytics: Analytics,
+  { id, name }: PersistedOrganization,
+): void => {
+  analytics.identifyOrganizationGroup({
+    organizationId: brandPersistedOrganizationId(id),
+    properties: { name },
+  });
+};
+
+// Organization create/update hooks for the better-auth organization plugin,
+// built as a factory so the seeding step and analytics sink can be
+// substituted in tests. `org.id` is read off the row the plugin persisted, so
+// it becomes the ownership id here.
+export const createOrganizationLifecycleHooks = ({
+  analytics,
+  seedDefaultDocumentTypes,
+}: OrganizationLifecycleHooksOptions) => ({
+  afterCreateOrganization: async ({
+    organization: org,
+  }: {
+    organization: PersistedOrganization;
+  }): Promise<void> => {
+    // Seed the org's starter document-type taxonomy at creation so listing it
+    // stays a pure read: a read-only credential must not be able to mint
+    // document types by listing them.
+    await seedDefaultDocumentTypes(brandPersistedOrganizationId(org.id));
+    identifyOrganizationName(analytics, org);
+  },
+  afterUpdateOrganization: async ({
+    organization: org,
+  }: {
+    organization: PersistedOrganization | null;
+  }): Promise<void> => {
+    // The plugin passes `null` when the adapter returns no updated row.
+    if (!org) {
+      return;
+    }
+    // Fires for every organization update, not just renames; the group
+    // upsert is idempotent so re-sending an unchanged name is harmless.
+    identifyOrganizationName(analytics, org);
+    await Promise.resolve();
+  },
+});


### PR DESCRIPTION
## Summary

- Upsert the organization group's `name` from the auth plugin's `afterCreateOrganization` and `afterUpdateOrganization` hooks. Until now only a one-off backfill set it, so organizations created or renamed afterwards had a nameless or stale-named group profile.
- `identifyOrganizationGroup` now takes `Partial<OrganizationGroupProperties>`: `groupIdentify` merges into the existing profile, so each caller sends only the keys it owns (name here, jurisdictions in the settings handler).
- Adapter test asserting the group upsert lands on the `organization` group type keyed by the organization id.

`afterUpdateOrganization` fires for any organization update, not only renames; the upsert is idempotent so re-sending an unchanged name is harmless.

## Verification

- `bun --filter @stll/api test src/lib/analytics/ src/handlers/organization-settings/` green
- `bun --filter @stll/api typecheck` green
- pre-push `code-check` (type-aware lint + typecheck for api/web/legal-atlas-runner) green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Organisation names are now synchronised with their analytics group profiles when organisations are created or updated.
  - Analytics group information now supports partial updates, allowing existing properties to be retained when only selected details change.

- **Bug Fixes**
  - Improved organisation analytics handling when update data is unavailable, preventing unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->