### PR TITLE
feat(api): serve case-law browse facets from the corpus index

### DIFF
--- a/apps/api/src/handlers/case-law/decisions/facets.ts
+++ b/apps/api/src/handlers/case-law/decisions/facets.ts
@@ -2,6 +2,7 @@ import { Result } from "better-result";
 import { status, t } from "elysia";
 import type { Static } from "elysia";
 
+import { readNonRedistributableCaseLawSourceIds } from "@/api/lib/case-law/non-redistributable-sources";
 import { createBrowseFacetsCache } from "@/api/lib/legal-search/browse-facets-cache";
 import { isCorpusIndexJurisdiction } from "@/api/lib/legal-search/index-naming";
 import { getLegalSearchProvider } from "@/api/lib/legal-search/provider";
@@ -40,6 +41,18 @@ export const listDecisionFacetsHandler = async ({
     return status(400, { message: "Invalid country" });
   }
 
+  // Read ahead of the cache, not inside it: source policy is an input to the
+  // answer, so a revocation has to change the cache key. Reading it behind the
+  // cache would keep a revoked source's buckets public for a whole window.
+  // Failing closed here is deliberate — no facets beats stale ones.
+  const excludedSourceIds = await readNonRedistributableCaseLawSourceIds();
+  if (Result.isError(excludedSourceIds)) {
+    logger.warn("case_law.browse_facets.unavailable", {
+      message: excludedSourceIds.error.message,
+    });
+    return EMPTY_FACETS;
+  }
+
   // The accepted code is case-insensitive, but the providers are not equally
   // so: the corpus index lowercases it into an index name while the Postgres
   // path compares it to the stored column, which is upper-case. Canonicalising
@@ -47,6 +60,7 @@ export const listDecisionFacetsHandler = async ({
   // one jurisdiction to one cache entry.
   const result = await browseFacets({
     ...(country === undefined ? {} : { jurisdiction: country.toUpperCase() }),
+    excludedSourceIds: excludedSourceIds.value,
     limit: LIMITS.caseLawFacetLimit,
   });
   if (Result.isError(result)) {

--- a/apps/api/src/handlers/case-law/decisions/facets.ts
+++ b/apps/api/src/handlers/case-law/decisions/facets.ts
@@ -40,8 +40,13 @@ export const listDecisionFacetsHandler = async ({
     return status(400, { message: "Invalid country" });
   }
 
+  // The accepted code is case-insensitive, but the providers are not equally
+  // so: the corpus index lowercases it into an index name while the Postgres
+  // path compares it to the stored column, which is upper-case. Canonicalising
+  // once here is what keeps the two answering the same question — and keeps
+  // one jurisdiction to one cache entry.
   const result = await browseFacets({
-    ...(country === undefined ? {} : { jurisdiction: country }),
+    ...(country === undefined ? {} : { jurisdiction: country.toUpperCase() }),
     limit: LIMITS.caseLawFacetLimit,
   });
   if (Result.isError(result)) {

--- a/apps/api/src/handlers/case-law/decisions/facets.ts
+++ b/apps/api/src/handlers/case-law/decisions/facets.ts
@@ -1,80 +1,57 @@
-import { and, desc, eq, isNotNull, sql } from "drizzle-orm";
+import { Result } from "better-result";
+import { status, t } from "elysia";
+import type { Static } from "elysia";
 
-import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
-import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
-import { redistributableCaseLawSource } from "@/api/lib/case-law/redistribution";
+import { createBrowseFacetsCache } from "@/api/lib/legal-search/browse-facets-cache";
+import { isCorpusIndexJurisdiction } from "@/api/lib/legal-search/index-naming";
+import { getLegalSearchProvider } from "@/api/lib/legal-search/provider";
+import type { LegalBrowseFacets } from "@/api/lib/legal-search/types";
 import { LIMITS } from "@/api/lib/limits";
+import { logger } from "@/api/lib/observability/logger";
 
-type FacetBucket = {
-  count: number;
-  value: string;
-};
+/**
+ * Facet counts for the public browse page: which countries, courts and years
+ * the corpus holds, and how many decisions each has. Provider-dispatched, so a
+ * deployment with a corpus index answers from engine aggregations while one
+ * without still answers from Postgres.
+ */
 
-const toFacetBuckets = (rows: readonly FacetBucket[]): FacetBucket[] =>
-  rows.map((row) => ({
-    count: row.count,
-    value: row.value,
-  }));
+export const listDecisionFacetsQuerySchema = t.Object({
+  country: t.Optional(t.String({ maxLength: 3 })),
+});
 
-export const listDecisionFacetsHandler = async (
-  caseLawDb: CaseLawPublicReadDb,
-) => {
-  const [countryRows, courtRows, yearRows] = await caseLawDb(async (tx) => {
-    const countries = await tx
-      .select({
-        value: caseLawDecisions.country,
-        count: sql<number>`count(*)::int`,
-      })
-      .from(caseLawDecisions)
-      .innerJoin(
-        caseLawSources,
-        eq(caseLawSources.id, caseLawDecisions.sourceId),
-      )
-      .where(redistributableCaseLawSource)
-      .groupBy(caseLawDecisions.country)
-      .orderBy(desc(sql`count(*)`), desc(caseLawDecisions.country))
-      .limit(LIMITS.caseLawFacetLimit);
+type ListDecisionFacetsQuery = Static<typeof listDecisionFacetsQuerySchema>;
 
-    const courts = await tx
-      .select({
-        value: caseLawDecisions.court,
-        count: sql<number>`count(*)::int`,
-      })
-      .from(caseLawDecisions)
-      .innerJoin(
-        caseLawSources,
-        eq(caseLawSources.id, caseLawDecisions.sourceId),
-      )
-      .where(redistributableCaseLawSource)
-      .groupBy(caseLawDecisions.court)
-      .orderBy(desc(sql`count(*)`), desc(caseLawDecisions.court))
-      .limit(LIMITS.caseLawFacetLimit);
-    const years = await tx
-      .select({
-        value: sql<string>`to_char(${caseLawDecisions.decisionDate}, 'YYYY')`,
-        count: sql<number>`count(*)::int`,
-      })
-      .from(caseLawDecisions)
-      .innerJoin(
-        caseLawSources,
-        eq(caseLawSources.id, caseLawDecisions.sourceId),
-      )
-      .where(
-        and(
-          isNotNull(caseLawDecisions.decisionDate),
-          redistributableCaseLawSource,
-        ),
-      )
-      .groupBy(sql`to_char(${caseLawDecisions.decisionDate}, 'YYYY')`)
-      .orderBy(desc(sql`to_char(${caseLawDecisions.decisionDate}, 'YYYY')`))
-      .limit(LIMITS.caseLawFacetLimit);
+const FACETS_CACHE_TTL_MS = 5 * 60 * 1000;
+const FACETS_CACHE_MAX_ENTRIES = 32;
 
-    return [countries, courts, years] as const;
+const EMPTY_FACETS: LegalBrowseFacets = { country: [], court: [], year: [] };
+
+const browseFacets = createBrowseFacetsCache({
+  load: async (query) => await getLegalSearchProvider().browseFacets(query),
+  ttlMs: FACETS_CACHE_TTL_MS,
+  maxEntries: FACETS_CACHE_MAX_ENTRIES,
+});
+
+export const listDecisionFacetsHandler = async ({
+  country,
+}: ListDecisionFacetsQuery) => {
+  if (country !== undefined && !isCorpusIndexJurisdiction(country)) {
+    return status(400, { message: "Invalid country" });
+  }
+
+  const result = await browseFacets({
+    ...(country === undefined ? {} : { jurisdiction: country }),
+    limit: LIMITS.caseLawFacetLimit,
   });
+  if (Result.isError(result)) {
+    // Facets are navigation chrome: an empty set collapses the selects into
+    // free-text filters, which is a degraded page, not a broken one.
+    logger.warn("case_law.browse_facets.unavailable", {
+      message: result.error.message,
+    });
+    return EMPTY_FACETS;
+  }
 
-  return {
-    country: toFacetBuckets(countryRows),
-    court: toFacetBuckets(courtRows),
-    year: toFacetBuckets(yearRows),
-  };
+  return result.value;
 };

--- a/apps/api/src/handlers/case-law/public-routes.ts
+++ b/apps/api/src/handlers/case-law/public-routes.ts
@@ -2,7 +2,10 @@ import { Result } from "better-result";
 import Elysia, { t } from "elysia";
 
 import { env } from "@/api/env";
-import { listDecisionFacetsHandler } from "@/api/handlers/case-law/decisions/facets";
+import {
+  listDecisionFacetsHandler,
+  listDecisionFacetsQuerySchema,
+} from "@/api/handlers/case-law/decisions/facets";
 import {
   readDecisionBySlugWithDocumentHandler,
   readDecisionWithDocumentHandler,
@@ -39,12 +42,13 @@ const listDecisions = createSafePublicHandler(
 );
 
 const listDecisionFacets = createSafePublicHandler(
-  { mcp: { type: "internal", reason: "public_indexing" } },
-  async function* () {
+  {
+    mcp: { type: "internal", reason: "public_indexing" },
+    query: listDecisionFacetsQuerySchema,
+  },
+  async function* ({ query }) {
     const response = yield* Result.await(
-      Result.tryPromise(
-        async () => await listDecisionFacetsHandler(caseLawPublicReadDb),
-      ),
+      Result.tryPromise(async () => await listDecisionFacetsHandler(query)),
     );
 
     return Result.ok(response);
@@ -163,7 +167,9 @@ export const publicCaseLawRoute = new Elysia({
   .get("/decisions", listDecisions.handler, {
     query: listDecisions.config.query,
   })
-  .get("/decisions/facets", listDecisionFacets.handler)
+  .get("/decisions/facets", listDecisionFacets.handler, {
+    query: listDecisionFacets.config.query,
+  })
   .get("/decisions/by-slug/:slug", readDecisionBySlug.handler, {
     params: readDecisionBySlug.config.params,
     query: readDecisionBySlug.config.query,

--- a/apps/api/src/lib/case-law/non-redistributable-sources.ts
+++ b/apps/api/src/lib/case-law/non-redistributable-sources.ts
@@ -1,0 +1,47 @@
+import { Result, TaggedError } from "better-result";
+import { not } from "drizzle-orm";
+
+import { caseLawSources } from "@/api/db/schema";
+import { caseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
+import { redistributableCaseLawSource } from "@/api/lib/case-law/redistribution";
+
+export class NonRedistributableSourcesError extends TaggedError(
+  "NonRedistributableSourcesError",
+)<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+/**
+ * The sources a public surface may not count or serve, read from the same
+ * predicate the SQL surfaces filter with, so the two cannot drift.
+ *
+ * This exists for surfaces that aggregate the corpus index rather than the
+ * table. Projection is a write-time gate: revoking a source's redistribution
+ * only queues its documents for removal, so between the flip and the
+ * reconciliation the index still holds them. Reading the ineligible set here
+ * makes the gate query-time, the way the search path re-applies it when it
+ * rehydrates index candidates.
+ *
+ * The table holds one row per court feed, so this is a few dozen ids at most.
+ */
+export const readNonRedistributableCaseLawSourceIds = async () =>
+  await Result.tryPromise({
+    try: async () =>
+      await caseLawPublicReadDb(async (tx) => {
+        const rows = await tx
+          .select({ id: caseLawSources.id })
+          .from(caseLawSources)
+          .where(not(redistributableCaseLawSource));
+
+        return rows.map(({ id }) => id);
+      }),
+    catch: (cause) =>
+      new NonRedistributableSourcesError({
+        message:
+          cause instanceof Error
+            ? cause.message
+            : "reading non-redistributable case-law sources failed",
+        cause,
+      }),
+  });

--- a/apps/api/src/lib/legal-search/browse-facets-cache.test.ts
+++ b/apps/api/src/lib/legal-search/browse-facets-cache.test.ts
@@ -1,0 +1,140 @@
+import { Result } from "better-result";
+import { expect, test } from "bun:test";
+
+import { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
+import { createBrowseFacetsCache } from "@/api/lib/legal-search/browse-facets-cache";
+import type {
+  LegalBrowseFacets,
+  LegalBrowseFacetsQuery,
+} from "@/api/lib/legal-search/types";
+
+/**
+ * The cache is what keeps the browse page off a multi-million-row aggregation
+ * on every request, so what it must not do is serve one jurisdiction's counts
+ * for another, pin a failure for the whole window, or let a burst of cold
+ * requests each fire their own provider call.
+ */
+
+const facets = (country: string): LegalBrowseFacets => ({
+  country: [{ value: country, count: 1 }],
+  court: [],
+  year: [],
+});
+
+const cacheOf = (
+  load: (
+    query: LegalBrowseFacetsQuery,
+  ) => Promise<Result<LegalBrowseFacets, LegalBrowseFacetsError>>,
+) => createBrowseFacetsCache({ load, ttlMs: 60_000, maxEntries: 3 });
+
+test("serves a repeat request from cache", async () => {
+  let calls = 0;
+  const browseFacets = cacheOf(async () => {
+    calls += 1;
+    return Result.ok(facets("CZE"));
+  });
+
+  await browseFacets({ limit: 20 });
+  const second = await browseFacets({ limit: 20 });
+
+  expect(calls).toBe(1);
+  if (Result.isError(second)) {
+    throw second.error;
+  }
+  expect(second.value.country).toEqual([{ value: "CZE", count: 1 }]);
+});
+
+test("keys on every input that changes the answer", async () => {
+  const seen: LegalBrowseFacetsQuery[] = [];
+  const browseFacets = cacheOf(async (query) => {
+    seen.push(query);
+    return Result.ok(facets(query.jurisdiction ?? "*"));
+  });
+
+  await browseFacets({ limit: 20 });
+  await browseFacets({ jurisdiction: "CZE", limit: 20 });
+  const scoped = await browseFacets({ jurisdiction: "SVK", limit: 20 });
+  await browseFacets({ limit: 10 });
+
+  expect(seen.length).toBe(4);
+  if (Result.isError(scoped)) {
+    throw scoped.error;
+  }
+  expect(scoped.value.country).toEqual([{ value: "SVK", count: 1 }]);
+});
+
+test("concurrent misses share one provider call", async () => {
+  let calls = 0;
+  let release = (): void => undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const browseFacets = cacheOf(async () => {
+    calls += 1;
+    await gate;
+    return Result.ok(facets("CZE"));
+  });
+
+  const inFlight = [
+    browseFacets({ limit: 20 }),
+    browseFacets({ limit: 20 }),
+    browseFacets({ limit: 20 }),
+  ];
+  release();
+  await Promise.all(inFlight);
+
+  expect(calls).toBe(1);
+});
+
+test("a failure is not cached, so the next request retries", async () => {
+  let calls = 0;
+  const browseFacets = cacheOf(async () => {
+    calls += 1;
+    return calls === 1
+      ? Result.err(new LegalBrowseFacetsError({ message: "engine down" }))
+      : Result.ok(facets("CZE"));
+  });
+
+  const failed = await browseFacets({ limit: 20 });
+  const recovered = await browseFacets({ limit: 20 });
+
+  expect(Result.isError(failed)).toBe(true);
+  expect(calls).toBe(2);
+  expect(Result.isError(recovered)).toBe(false);
+});
+
+test("bounds the key space a caller can grow", async () => {
+  let calls = 0;
+  const browseFacets = cacheOf(async () => {
+    calls += 1;
+    return Result.ok(facets("CZE"));
+  });
+
+  // maxEntries is 3, and the entries must be filled in order, so the fourth
+  // jurisdiction evicts the first: a caller probing distinct jurisdictions
+  // cannot grow the map without bound.
+  await browseFacets({ jurisdiction: "cze", limit: 20 });
+  await browseFacets({ jurisdiction: "svk", limit: 20 });
+  await browseFacets({ jurisdiction: "pol", limit: 20 });
+  await browseFacets({ jurisdiction: "eu", limit: 20 });
+  await browseFacets({ jurisdiction: "cze", limit: 20 });
+
+  expect(calls).toBe(5);
+});
+
+test("expires an entry once its window closes", async () => {
+  let calls = 0;
+  const browseFacets = createBrowseFacetsCache({
+    load: async () => {
+      calls += 1;
+      return Result.ok(facets("CZE"));
+    },
+    ttlMs: 0,
+    maxEntries: 3,
+  });
+
+  await browseFacets({ limit: 20 });
+  await browseFacets({ limit: 20 });
+
+  expect(calls).toBe(2);
+});

--- a/apps/api/src/lib/legal-search/browse-facets-cache.test.ts
+++ b/apps/api/src/lib/legal-search/browse-facets-cache.test.ts
@@ -34,8 +34,8 @@ test("serves a repeat request from cache", async () => {
     return Result.ok(facets("CZE"));
   });
 
-  await browseFacets({ limit: 20 });
-  const second = await browseFacets({ limit: 20 });
+  await browseFacets({ excludedSourceIds: [], limit: 20 });
+  const second = await browseFacets({ excludedSourceIds: [], limit: 20 });
 
   expect(calls).toBe(1);
   if (Result.isError(second)) {
@@ -51,16 +51,51 @@ test("keys on every input that changes the answer", async () => {
     return Result.ok(facets(query.jurisdiction ?? "*"));
   });
 
-  await browseFacets({ limit: 20 });
-  await browseFacets({ jurisdiction: "CZE", limit: 20 });
-  const scoped = await browseFacets({ jurisdiction: "SVK", limit: 20 });
-  await browseFacets({ limit: 10 });
+  await browseFacets({ excludedSourceIds: [], limit: 20 });
+  await browseFacets({ excludedSourceIds: [], jurisdiction: "CZE", limit: 20 });
+  const scoped = await browseFacets({
+    excludedSourceIds: [],
+    jurisdiction: "SVK",
+    limit: 20,
+  });
+  await browseFacets({ excludedSourceIds: [], limit: 10 });
 
   expect(seen.length).toBe(4);
   if (Result.isError(scoped)) {
     throw scoped.error;
   }
   expect(scoped.value.country).toEqual([{ value: "SVK", count: 1 }]);
+});
+
+test("a revoked source invalidates the entry instead of waiting out its window", async () => {
+  let calls = 0;
+  const browseFacets = cacheOf(async () => {
+    calls += 1;
+    return Result.ok(facets("CZE"));
+  });
+
+  await browseFacets({ excludedSourceIds: [], limit: 20 });
+  await browseFacets({ excludedSourceIds: ["src-1"], limit: 20 });
+
+  // Source policy is an input to the answer, so it belongs in the key: a
+  // revocation that only changed the loader's behaviour would keep the
+  // revoked source's buckets public for the rest of the window.
+  expect(calls).toBe(2);
+});
+
+test("reads one source policy under either order it arrives in", async () => {
+  let calls = 0;
+  const browseFacets = cacheOf(async () => {
+    calls += 1;
+    return Result.ok(facets("CZE"));
+  });
+
+  // The ineligible set is a set; the row order it was read in is not part of
+  // the policy and must not split it across two entries.
+  await browseFacets({ excludedSourceIds: ["src-1", "src-2"], limit: 20 });
+  await browseFacets({ excludedSourceIds: ["src-2", "src-1"], limit: 20 });
+
+  expect(calls).toBe(1);
 });
 
 test("concurrent misses share one provider call", async () => {
@@ -76,9 +111,9 @@ test("concurrent misses share one provider call", async () => {
   });
 
   const inFlight = [
-    browseFacets({ limit: 20 }),
-    browseFacets({ limit: 20 }),
-    browseFacets({ limit: 20 }),
+    browseFacets({ excludedSourceIds: [], limit: 20 }),
+    browseFacets({ excludedSourceIds: [], limit: 20 }),
+    browseFacets({ excludedSourceIds: [], limit: 20 }),
   ];
   release();
   await Promise.all(inFlight);
@@ -95,8 +130,8 @@ test("a failure is not cached, so the next request retries", async () => {
       : Result.ok(facets("CZE"));
   });
 
-  const failed = await browseFacets({ limit: 20 });
-  const recovered = await browseFacets({ limit: 20 });
+  const failed = await browseFacets({ excludedSourceIds: [], limit: 20 });
+  const recovered = await browseFacets({ excludedSourceIds: [], limit: 20 });
 
   expect(Result.isError(failed)).toBe(true);
   expect(calls).toBe(2);
@@ -113,11 +148,11 @@ test("bounds the key space a caller can grow", async () => {
   // maxEntries is 3, and the entries must be filled in order, so the fourth
   // jurisdiction evicts the first: a caller probing distinct jurisdictions
   // cannot grow the map without bound.
-  await browseFacets({ jurisdiction: "cze", limit: 20 });
-  await browseFacets({ jurisdiction: "svk", limit: 20 });
-  await browseFacets({ jurisdiction: "pol", limit: 20 });
-  await browseFacets({ jurisdiction: "eu", limit: 20 });
-  await browseFacets({ jurisdiction: "cze", limit: 20 });
+  await browseFacets({ excludedSourceIds: [], jurisdiction: "cze", limit: 20 });
+  await browseFacets({ excludedSourceIds: [], jurisdiction: "svk", limit: 20 });
+  await browseFacets({ excludedSourceIds: [], jurisdiction: "pol", limit: 20 });
+  await browseFacets({ excludedSourceIds: [], jurisdiction: "eu", limit: 20 });
+  await browseFacets({ excludedSourceIds: [], jurisdiction: "cze", limit: 20 });
 
   expect(calls).toBe(5);
 });
@@ -133,8 +168,8 @@ test("expires an entry once its window closes", async () => {
     maxEntries: 3,
   });
 
-  await browseFacets({ limit: 20 });
-  await browseFacets({ limit: 20 });
+  await browseFacets({ excludedSourceIds: [], limit: 20 });
+  await browseFacets({ excludedSourceIds: [], limit: 20 });
 
   expect(calls).toBe(2);
 });

--- a/apps/api/src/lib/legal-search/browse-facets-cache.ts
+++ b/apps/api/src/lib/legal-search/browse-facets-cache.ts
@@ -1,0 +1,90 @@
+import { Result } from "better-result";
+
+import type { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
+import type {
+  LegalBrowseFacets,
+  LegalBrowseFacetsQuery,
+} from "@/api/lib/legal-search/types";
+
+/**
+ * In-process TTL cache for browse facets. Facet counts describe the whole
+ * corpus and move only as it is ingested, so a window of minutes is
+ * indistinguishable from live to a reader, and it is what keeps the browse
+ * page off the provider on all but the first request of each window.
+ *
+ * No new infrastructure on purpose: per-process is enough because every
+ * process converges on the same counts, and a cold process pays one call.
+ */
+
+type BrowseFacetsResult = Result<LegalBrowseFacets, LegalBrowseFacetsError>;
+
+type BrowseFacetsCacheOptions = {
+  load: (query: LegalBrowseFacetsQuery) => Promise<BrowseFacetsResult>;
+  ttlMs: number;
+  /**
+   * The jurisdiction is caller-influenced (validated against a pattern, not a
+   * closed list), so the key space is bounded here rather than left to grow.
+   * The corpus has a handful of jurisdictions, so eviction only ever touches
+   * probing traffic.
+   */
+  maxEntries: number;
+};
+
+type CacheEntry = {
+  expiresAt: number;
+  /**
+   * The in-flight call, not its value: concurrent misses share one provider
+   * round-trip instead of stampeding it.
+   */
+  pending: Promise<BrowseFacetsResult>;
+};
+
+/**
+ * Every input that changes the answer, in a fixed order — never a serialized
+ * object, whose key order would follow construction rather than the contract.
+ */
+const cacheKey = ({
+  documentFamily,
+  jurisdiction,
+  limit,
+}: LegalBrowseFacetsQuery): string =>
+  `${documentFamily ?? ""}:${jurisdiction ?? ""}:${limit}`;
+
+export const createBrowseFacetsCache = ({
+  load,
+  ttlMs,
+  maxEntries,
+}: BrowseFacetsCacheOptions) => {
+  const entries = new Map<string, CacheEntry>();
+
+  return async (query: LegalBrowseFacetsQuery): Promise<BrowseFacetsResult> => {
+    const key = cacheKey(query);
+    const now = Date.now();
+
+    const cached = entries.get(key);
+    if (cached && cached.expiresAt > now) {
+      return await cached.pending;
+    }
+
+    const entry: CacheEntry = { expiresAt: now + ttlMs, pending: load(query) };
+    // Re-insert so Map iteration order tracks recency: refreshing a hot key
+    // must not leave it first in line for eviction.
+    entries.delete(key);
+    entries.set(key, entry);
+
+    if (entries.size > maxEntries) {
+      const oldest = entries.keys().next();
+      if (!oldest.done) {
+        entries.delete(oldest.value);
+      }
+    }
+
+    const result = await entry.pending;
+    // A failure must not pin an empty facet set for the whole window. Drop it
+    // only while this call still owns the entry, so a newer one survives.
+    if (Result.isError(result) && entries.get(key) === entry) {
+      entries.delete(key);
+    }
+    return result;
+  };
+};

--- a/apps/api/src/lib/legal-search/browse-facets-cache.ts
+++ b/apps/api/src/lib/legal-search/browse-facets-cache.ts
@@ -25,7 +25,8 @@ type BrowseFacetsCacheOptions = {
    * The jurisdiction is caller-influenced (validated against a pattern, not a
    * closed list), so the key space is bounded here rather than left to grow.
    * The corpus has a handful of jurisdictions, so eviction only ever touches
-   * probing traffic.
+   * probing traffic. Source policy is not caller-influenced and changes rarely,
+   * so it adds a generation to the key space rather than a dimension.
    */
   maxEntries: number;
 };
@@ -45,10 +46,13 @@ type CacheEntry = {
  */
 const cacheKey = ({
   documentFamily,
+  excludedSourceIds,
   jurisdiction,
   limit,
 }: LegalBrowseFacetsQuery): string =>
-  `${documentFamily ?? ""}:${jurisdiction ?? ""}:${limit}`;
+  // Sorted, because the ineligible set is a set: the order it was read in
+  // must not split one source policy across two entries.
+  `${documentFamily ?? ""}:${jurisdiction ?? ""}:${limit}:${excludedSourceIds.toSorted().join(",")}`;
 
 export const createBrowseFacetsCache = ({
   load,

--- a/apps/api/src/lib/legal-search/browse-facets.ts
+++ b/apps/api/src/lib/legal-search/browse-facets.ts
@@ -1,0 +1,14 @@
+import { TaggedError } from "better-result";
+
+/**
+ * A provider could not produce browse facets. Facet counts are a navigation
+ * aid, not the page's content, so callers are expected to degrade to an empty
+ * facet set rather than fail the request — the error carries the reason so the
+ * degradation is logged instead of silent.
+ */
+export class LegalBrowseFacetsError extends TaggedError(
+  "LegalBrowseFacetsError",
+)<{
+  message: string;
+  cause?: unknown;
+}> {}

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -40,6 +40,12 @@ export const CORPUS_INDEX_COMMIT_WAIT_TIMEOUT_MS = 60_000;
  */
 export const CORPUS_INDEX_INGEST_TIMEOUT_MS = 120_000;
 const ADMIN_TIMEOUT_MS = 30_000;
+/**
+ * Tighter than search: aggregations serve page chrome (facet counts), so a
+ * slow engine must give up well inside the page's own budget rather than
+ * hold the request open for the full search timeout.
+ */
+const AGGREGATION_TIMEOUT_MS = 10_000;
 
 /**
  * What "the engine accepted this batch" is allowed to mean.
@@ -77,6 +83,21 @@ export type CorpusIndexSearchInput = {
   snippetFields?: string[] | undefined;
 };
 
+export type CorpusIndexAggregateInput = {
+  indexId: string;
+  /** Full corpus index query string the aggregation runs over. */
+  query: string;
+  /** Engine-native aggregation request, keyed by aggregation name. */
+  aggs: Record<string, unknown>;
+};
+
+/**
+ * The engine's `aggregations` object, one entry per requested name. Left
+ * unparsed here: bucket shape is per aggregation kind, so the caller that
+ * asked for a shape is the one that can validate it.
+ */
+export type CorpusIndexAggregations = Record<string, unknown>;
+
 export type CorpusIndexHit = Record<string, unknown>;
 
 export type CorpusIndexSearchResponse = {
@@ -104,6 +125,9 @@ export type CorpusIndexClient = {
   search: (
     input: CorpusIndexSearchInput,
   ) => Promise<Result<CorpusIndexSearchResponse, CorpusIndexError>>;
+  aggregate: (
+    input: CorpusIndexAggregateInput,
+  ) => Promise<Result<CorpusIndexAggregations, CorpusIndexError>>;
   deleteByQuery: (
     indexId: string,
     query: string,
@@ -335,6 +359,31 @@ const buildClient = (): CorpusIndexClient => ({
           hits,
           snippets,
         };
+      },
+      catch: toCorpusIndexError,
+    }),
+
+  aggregate: async ({ indexId, query, aggs }) =>
+    await Result.tryPromise({
+      try: async () => {
+        const response = await requestJson(
+          searchBaseUrl(),
+          `/api/v1/${indexId}/search`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            // Aggregations only: hits are the expensive part of the
+            // response and the caller wants counts, not documents.
+            body: JSON.stringify({ query, max_hits: 0, aggs }),
+          },
+          AGGREGATION_TIMEOUT_MS,
+        );
+        if (!isRecord(response) || !isRecord(response["aggregations"])) {
+          throw new CorpusIndexError({
+            message: "corpus index aggregation returned an invalid response",
+          });
+        }
+        return response["aggregations"];
       },
       catch: toCorpusIndexError,
     }),

--- a/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
@@ -93,7 +93,10 @@ const requestedAggregations = (): Record<string, unknown> =>
 test("aggregates over opening passages only, so buckets count decisions", async () => {
   responseBody = engineResponse();
 
-  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
+  const result = await corpusIndexBrowseFacets({
+    excludedSourceIds: [],
+    limit: 20,
+  });
 
   expect(Result.isError(result)).toBe(false);
   // Every passage of a decision carries the decision's court and country, so
@@ -105,7 +108,10 @@ test("aggregates over opening passages only, so buckets count decisions", async 
 test("requests exactly the aggregations the response is read from", async () => {
   responseBody = engineResponse();
 
-  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
+  const result = await corpusIndexBrowseFacets({
+    excludedSourceIds: [],
+    limit: 20,
+  });
   if (Result.isError(result)) {
     throw result.error;
   }
@@ -123,7 +129,10 @@ test("requests exactly the aggregations the response is read from", async () => 
 test("reads string and numeric bucket keys into the same bucket shape", async () => {
   responseBody = engineResponse();
 
-  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
+  const result = await corpusIndexBrowseFacets({
+    excludedSourceIds: [],
+    limit: 20,
+  });
   if (Result.isError(result)) {
     throw result.error;
   }
@@ -141,8 +150,12 @@ test("scopes to one jurisdiction index, and to the generation glob without one",
   responseBody = engineResponse();
   const generation = corpusGeneration("case_law");
 
-  await corpusIndexBrowseFacets({ jurisdiction: "CZE", limit: 20 }, []);
-  await corpusIndexBrowseFacets({ limit: 20 }, []);
+  await corpusIndexBrowseFacets({
+    excludedSourceIds: [],
+    jurisdiction: "CZE",
+    limit: 20,
+  });
+  await corpusIndexBrowseFacets({ excludedSourceIds: [], limit: 20 });
 
   expect(requests.at(0)?.url).toContain(`/${generation}_cze/search`);
   expect(requests.at(1)?.url).toContain(`/${generation}_*/search`);
@@ -151,7 +164,7 @@ test("scopes to one jurisdiction index, and to the generation glob without one",
 test("asks for bucket depth beyond the requested size", async () => {
   responseBody = engineResponse();
 
-  await corpusIndexBrowseFacets({ limit: 20 }, []);
+  await corpusIndexBrowseFacets({ excludedSourceIds: [], limit: 20 });
 
   // Terms aggregations merge per-split top-k lists: at a depth of `size` the
   // merged counts are approximate, which would show wrong numbers next to
@@ -166,10 +179,13 @@ test("asks for bucket depth beyond the requested size", async () => {
 test("excludes sources that may no longer be redistributed", async () => {
   responseBody = engineResponse();
 
-  await corpusIndexBrowseFacets({ limit: 20 }, [
-    "018f0a2b-0000-7000-8000-000000000001",
-    "018f0a2b-0000-7000-8000-000000000002",
-  ]);
+  await corpusIndexBrowseFacets({
+    excludedSourceIds: [
+      "018f0a2b-0000-7000-8000-000000000001",
+      "018f0a2b-0000-7000-8000-000000000002",
+    ],
+    limit: 20,
+  });
 
   // Projection keeps ineligible sources out of the index, but a revocation
   // only queues their documents for removal: without this clause the buckets
@@ -191,7 +207,10 @@ test("an approximate aggregation fails rather than serving wrong counts", async 
     },
   };
 
-  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
+  const result = await corpusIndexBrowseFacets({
+    excludedSourceIds: [],
+    limit: 20,
+  });
 
   expect(Result.isError(result)).toBe(true);
 });
@@ -209,7 +228,10 @@ test("an unreadable aggregation fails rather than reporting an empty corpus", as
     },
   };
 
-  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
+  const result = await corpusIndexBrowseFacets({
+    excludedSourceIds: [],
+    limit: 20,
+  });
 
   expect(Result.isError(result)).toBe(true);
 });
@@ -217,7 +239,10 @@ test("an unreadable aggregation fails rather than reporting an empty corpus", as
 test("a missing aggregation fails rather than reporting an empty corpus", async () => {
   responseBody = { aggregations: { country: termsAggregation([]) } };
 
-  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
+  const result = await corpusIndexBrowseFacets({
+    excludedSourceIds: [],
+    limit: 20,
+  });
 
   expect(Result.isError(result)).toBe(true);
 });
@@ -226,7 +251,10 @@ test("an engine failure returns a typed error, not a throw", async () => {
   responseStatus = 503;
   responseBody = { message: "service unavailable" };
 
-  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
+  const result = await corpusIndexBrowseFacets({
+    excludedSourceIds: [],
+    limit: 20,
+  });
 
   expect(Result.isError(result)).toBe(true);
   if (Result.isError(result)) {

--- a/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
@@ -1,0 +1,197 @@
+import { Result } from "better-result";
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import * as v from "valibot";
+
+import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
+import {
+  browseFacetNames,
+  corpusIndexBrowseFacets,
+} from "@/api/lib/legal-search/corpus-index-facets";
+
+const segmentSizeSchema = v.pipe(
+  v.object({ terms: v.object({ segment_size: v.number() }) }),
+  v.transform(({ terms }) => terms.segment_size),
+);
+
+/**
+ * The facet path reads the engine's aggregation response, so what can go wrong
+ * is the reading: counting passages instead of decisions, mistaking a numeric
+ * bucket key for a missing one, and — the one that would be invisible —
+ * turning an unreadable response into an empty facet set, which renders as a
+ * corpus with no courts in it.
+ *
+ * These stub the engine's HTTP response rather than mock the client module, so
+ * the request body the engine would receive is asserted too.
+ */
+
+const requestUrl = (input: Parameters<typeof fetch>[0]): string => {
+  if (typeof input === "string") {
+    return input;
+  }
+  return input instanceof URL ? input.href : input.url;
+};
+
+const originalFetch = globalThis.fetch;
+
+let requests: { url: string; body: Record<string, unknown> }[];
+let responseBody: unknown;
+let responseStatus: number;
+
+beforeEach(() => {
+  requests = [];
+  responseStatus = 200;
+  responseBody = { aggregations: {} };
+  const stub = async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ): Promise<Response> => {
+    requests.push({
+      url: requestUrl(input),
+      body: v.parse(
+        v.pipe(
+          v.string(),
+          v.transform((body: string) => JSON.parse(body)),
+          v.record(v.string(), v.unknown()),
+        ),
+        init?.body,
+      ),
+    });
+    return new Response(JSON.stringify(responseBody), {
+      status: responseStatus,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  globalThis.fetch = Object.assign(stub, {
+    preconnect: originalFetch.preconnect,
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const termsAggregation = (
+  buckets: { key: string | number; count: number }[],
+) => ({
+  buckets: buckets.map(({ key, count }) => ({ key, doc_count: count })),
+  doc_count_error_upper_bound: 0,
+  sum_other_doc_count: 0,
+});
+
+const engineResponse = () => ({
+  aggregations: {
+    country: termsAggregation([{ key: "CZE", count: 1_271_387 }]),
+    court: termsAggregation([{ key: "Nejvyšší soud", count: 203_722 }]),
+    // A u64 fast field comes back as a JSON float.
+    year: termsAggregation([{ key: 2024, count: 1_425_310 }]),
+  },
+});
+
+const requestedAggregations = (): Record<string, unknown> =>
+  v.parse(v.record(v.string(), v.unknown()), requests.at(0)?.body["aggs"]);
+
+test("aggregates over opening passages only, so buckets count decisions", async () => {
+  responseBody = engineResponse();
+
+  const result = await corpusIndexBrowseFacets({ limit: 20 });
+
+  expect(Result.isError(result)).toBe(false);
+  // Every passage of a decision carries the decision's court and country, so
+  // an unrestricted aggregation would count a long judgment once per passage.
+  expect(requests.at(0)?.body["query"]).toBe("seq:0");
+  expect(requests.at(0)?.body["max_hits"]).toBe(0);
+});
+
+test("requests exactly the aggregations the response is read from", async () => {
+  responseBody = engineResponse();
+
+  const result = await corpusIndexBrowseFacets({ limit: 20 });
+  if (Result.isError(result)) {
+    throw result.error;
+  }
+
+  // Both directions: an aggregation nobody reads is dead engine work, and a
+  // facet nobody requested can only ever come back empty.
+  expect(Object.keys(requestedAggregations()).toSorted()).toEqual(
+    browseFacetNames.toSorted(),
+  );
+  expect(Object.keys(result.value).toSorted()).toEqual(
+    browseFacetNames.toSorted(),
+  );
+});
+
+test("reads string and numeric bucket keys into the same bucket shape", async () => {
+  responseBody = engineResponse();
+
+  const result = await corpusIndexBrowseFacets({ limit: 20 });
+  if (Result.isError(result)) {
+    throw result.error;
+  }
+
+  expect(result.value.country).toEqual([{ value: "CZE", count: 1_271_387 }]);
+  expect(result.value.court).toEqual([
+    { value: "Nejvyšší soud", count: 203_722 },
+  ]);
+  // The year facet's contract is a string bucket value, as the Postgres path
+  // produced with to_char; "2024", never "2024.0".
+  expect(result.value.year).toEqual([{ value: "2024", count: 1_425_310 }]);
+});
+
+test("scopes to one jurisdiction index, and to the generation glob without one", async () => {
+  responseBody = engineResponse();
+  const generation = corpusGeneration("case_law");
+
+  await corpusIndexBrowseFacets({ jurisdiction: "CZE", limit: 20 });
+  await corpusIndexBrowseFacets({ limit: 20 });
+
+  expect(requests.at(0)?.url).toContain(`/${generation}_cze/search`);
+  expect(requests.at(1)?.url).toContain(`/${generation}_*/search`);
+});
+
+test("asks for bucket depth beyond the requested size", async () => {
+  responseBody = engineResponse();
+
+  await corpusIndexBrowseFacets({ limit: 20 });
+
+  // Terms aggregations merge per-split top-k lists: at a depth of `size` the
+  // merged counts are approximate, which would show wrong numbers next to
+  // every court in the filter.
+  const country = requestedAggregations()["country"];
+  expect(country).toMatchObject({
+    terms: { field: "jurisdiction", size: 20 },
+  });
+  expect(v.parse(segmentSizeSchema, country)).toBeGreaterThan(20);
+});
+
+test("an unreadable aggregation fails rather than reporting an empty corpus", async () => {
+  responseBody = {
+    aggregations: {
+      ...engineResponse().aggregations,
+      court: { buckets: [{ key: "Nejvyšší soud" }] },
+    },
+  };
+
+  const result = await corpusIndexBrowseFacets({ limit: 20 });
+
+  expect(Result.isError(result)).toBe(true);
+});
+
+test("a missing aggregation fails rather than reporting an empty corpus", async () => {
+  responseBody = { aggregations: { country: termsAggregation([]) } };
+
+  const result = await corpusIndexBrowseFacets({ limit: 20 });
+
+  expect(Result.isError(result)).toBe(true);
+});
+
+test("an engine failure returns a typed error, not a throw", async () => {
+  responseStatus = 503;
+  responseBody = { message: "service unavailable" };
+
+  const result = await corpusIndexBrowseFacets({ limit: 20 });
+
+  expect(Result.isError(result)).toBe(true);
+  if (Result.isError(result)) {
+    expect(result.error._tag).toBe("LegalBrowseFacetsError");
+  }
+});

--- a/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
@@ -93,7 +93,7 @@ const requestedAggregations = (): Record<string, unknown> =>
 test("aggregates over opening passages only, so buckets count decisions", async () => {
   responseBody = engineResponse();
 
-  const result = await corpusIndexBrowseFacets({ limit: 20 });
+  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
 
   expect(Result.isError(result)).toBe(false);
   // Every passage of a decision carries the decision's court and country, so
@@ -105,7 +105,7 @@ test("aggregates over opening passages only, so buckets count decisions", async 
 test("requests exactly the aggregations the response is read from", async () => {
   responseBody = engineResponse();
 
-  const result = await corpusIndexBrowseFacets({ limit: 20 });
+  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
   if (Result.isError(result)) {
     throw result.error;
   }
@@ -123,7 +123,7 @@ test("requests exactly the aggregations the response is read from", async () => 
 test("reads string and numeric bucket keys into the same bucket shape", async () => {
   responseBody = engineResponse();
 
-  const result = await corpusIndexBrowseFacets({ limit: 20 });
+  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
   if (Result.isError(result)) {
     throw result.error;
   }
@@ -141,8 +141,8 @@ test("scopes to one jurisdiction index, and to the generation glob without one",
   responseBody = engineResponse();
   const generation = corpusGeneration("case_law");
 
-  await corpusIndexBrowseFacets({ jurisdiction: "CZE", limit: 20 });
-  await corpusIndexBrowseFacets({ limit: 20 });
+  await corpusIndexBrowseFacets({ jurisdiction: "CZE", limit: 20 }, []);
+  await corpusIndexBrowseFacets({ limit: 20 }, []);
 
   expect(requests.at(0)?.url).toContain(`/${generation}_cze/search`);
   expect(requests.at(1)?.url).toContain(`/${generation}_*/search`);
@@ -151,7 +151,7 @@ test("scopes to one jurisdiction index, and to the generation glob without one",
 test("asks for bucket depth beyond the requested size", async () => {
   responseBody = engineResponse();
 
-  await corpusIndexBrowseFacets({ limit: 20 });
+  await corpusIndexBrowseFacets({ limit: 20 }, []);
 
   // Terms aggregations merge per-split top-k lists: at a depth of `size` the
   // merged counts are approximate, which would show wrong numbers next to
@@ -163,15 +163,53 @@ test("asks for bucket depth beyond the requested size", async () => {
   expect(v.parse(segmentSizeSchema, country)).toBeGreaterThan(20);
 });
 
+test("excludes sources that may no longer be redistributed", async () => {
+  responseBody = engineResponse();
+
+  await corpusIndexBrowseFacets({ limit: 20 }, [
+    "018f0a2b-0000-7000-8000-000000000001",
+    "018f0a2b-0000-7000-8000-000000000002",
+  ]);
+
+  // Projection keeps ineligible sources out of the index, but a revocation
+  // only queues their documents for removal: without this clause the buckets
+  // keep counting them until reconciliation catches up.
+  expect(requests.at(0)?.body["query"]).toBe(
+    'seq:0 AND NOT (source:"018f0a2b-0000-7000-8000-000000000001" OR source:"018f0a2b-0000-7000-8000-000000000002")',
+  );
+});
+
+test("an approximate aggregation fails rather than serving wrong counts", async () => {
+  responseBody = {
+    aggregations: {
+      ...engineResponse().aggregations,
+      court: {
+        ...termsAggregation([{ key: "Nejvyšší soud", count: 203_722 }]),
+        // The engine's own statement that the merged top-k is not exact.
+        doc_count_error_upper_bound: 17,
+      },
+    },
+  };
+
+  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
+
+  expect(Result.isError(result)).toBe(true);
+});
+
 test("an unreadable aggregation fails rather than reporting an empty corpus", async () => {
   responseBody = {
     aggregations: {
       ...engineResponse().aggregations,
-      court: { buckets: [{ key: "Nejvyšší soud" }] },
+      // A bucket with no `doc_count` is the shape under test; the exactness
+      // bound is stated so this fails on the bucket rather than on it.
+      court: {
+        buckets: [{ key: "Nejvyšší soud" }],
+        doc_count_error_upper_bound: 0,
+      },
     },
   };
 
-  const result = await corpusIndexBrowseFacets({ limit: 20 });
+  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
 
   expect(Result.isError(result)).toBe(true);
 });
@@ -179,7 +217,7 @@ test("an unreadable aggregation fails rather than reporting an empty corpus", as
 test("a missing aggregation fails rather than reporting an empty corpus", async () => {
   responseBody = { aggregations: { country: termsAggregation([]) } };
 
-  const result = await corpusIndexBrowseFacets({ limit: 20 });
+  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
 
   expect(Result.isError(result)).toBe(true);
 });
@@ -188,7 +226,7 @@ test("an engine failure returns a typed error, not a throw", async () => {
   responseStatus = 503;
   responseBody = { message: "service unavailable" };
 
-  const result = await corpusIndexBrowseFacets({ limit: 20 });
+  const result = await corpusIndexBrowseFacets({ limit: 20 }, []);
 
   expect(Result.isError(result)).toBe(true);
   if (Result.isError(result)) {

--- a/apps/api/src/lib/legal-search/corpus-index-facets.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.ts
@@ -29,10 +29,11 @@ import { isRecord } from "@/api/lib/type-guards";
  *
  * Projection is only the first half of the redistribution gate: it keeps
  * ineligible sources out of the index, but revoking a source's redistribution
- * merely queues its documents for removal, so the caller passes the currently
+ * merely queues its documents for removal, so the query carries the currently
  * ineligible source ids and they are excluded here. That is the same posture
  * the search path takes when it re-applies the predicate while rehydrating
- * index candidates.
+ * index candidates. The caller resolves them per request, ahead of its cache,
+ * so a revocation changes the key rather than waiting out a window.
  *
  * What the index does NOT hold is also visible in these counts: a decision
  * with no canonical payload is never projected, so it is browseable in the
@@ -148,7 +149,6 @@ const parseTermsBuckets = (aggregation: unknown): FacetBucket[] | null => {
 
 export const corpusIndexBrowseFacets = async (
   query: LegalBrowseFacetsQuery,
-  excludedSourceIds: readonly string[],
 ): Promise<Result<LegalBrowseFacets, LegalBrowseFacetsError>> => {
   const generation = corpusGeneration(query.documentFamily ?? "case_law");
   // Scoped query → that jurisdiction's index; unscoped → the generation glob
@@ -159,7 +159,7 @@ export const corpusIndexBrowseFacets = async (
 
   const aggregated = await getCorpusIndexClient().aggregate({
     indexId,
-    query: browseFacetsQuery(excludedSourceIds),
+    query: browseFacetsQuery(query.excludedSourceIds),
     aggs: buildAggregations(query.limit),
   });
   if (Result.isError(aggregated)) {

--- a/apps/api/src/lib/legal-search/corpus-index-facets.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.ts
@@ -44,13 +44,11 @@ const OPENING_PASSAGE_QUERY = "seq:0";
 
 /**
  * Opening passages, minus every source that may no longer be redistributed.
- * Exported for the test that pins the clause: an aggregation that silently
- * dropped it would keep counting revoked decisions for a reconciliation
- * window plus a cache window.
+ * An aggregation that dropped this clause would keep counting revoked
+ * decisions for a reconciliation window plus a cache window, so the test
+ * asserts it on the request the engine would receive.
  */
-export const browseFacetsQuery = (
-  excludedSourceIds: readonly string[],
-): string => {
+const browseFacetsQuery = (excludedSourceIds: readonly string[]): string => {
   if (excludedSourceIds.length === 0) {
     return OPENING_PASSAGE_QUERY;
   }

--- a/apps/api/src/lib/legal-search/corpus-index-facets.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.ts
@@ -3,6 +3,7 @@ import { Result } from "better-result";
 import { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
+import { quoteCorpusValue } from "@/api/lib/legal-search/corpus-query";
 import {
   corpusIndexId,
   corpusIndexPattern,
@@ -26,12 +27,38 @@ import { isRecord } from "@/api/lib/type-guards";
  * numbers passages from zero and always emits at least one, so exactly one
  * document per decision matches — and every bucket then counts decisions.
  *
- * Source policy needs no clause here: only redistributable, unredacted
- * decisions are ever projected into the index (see `corpus-index.ts`), so the
- * index is already the gated set the public endpoint may count.
+ * Projection is only the first half of the redistribution gate: it keeps
+ * ineligible sources out of the index, but revoking a source's redistribution
+ * merely queues its documents for removal, so the caller passes the currently
+ * ineligible source ids and they are excluded here. That is the same posture
+ * the search path takes when it re-applies the predicate while rehydrating
+ * index candidates.
+ *
+ * What the index does NOT hold is also visible in these counts: a decision
+ * with no canonical payload is never projected, so it is browseable in the
+ * list yet absent from a bucket. That is the same set search can find, which
+ * is the set these filters exist to narrow.
  */
 
 const OPENING_PASSAGE_QUERY = "seq:0";
+
+/**
+ * Opening passages, minus every source that may no longer be redistributed.
+ * Exported for the test that pins the clause: an aggregation that silently
+ * dropped it would keep counting revoked decisions for a reconciliation
+ * window plus a cache window.
+ */
+export const browseFacetsQuery = (
+  excludedSourceIds: readonly string[],
+): string => {
+  if (excludedSourceIds.length === 0) {
+    return OPENING_PASSAGE_QUERY;
+  }
+  const excluded = excludedSourceIds
+    .map((id) => `source:${quoteCorpusValue(id)}`)
+    .join(" OR ");
+  return `${OPENING_PASSAGE_QUERY} AND NOT (${excluded})`;
+};
 
 /**
  * Per-split candidate depth behind each bucket. Terms aggregations merge
@@ -79,11 +106,21 @@ const buildAggregations = (limit: number): Record<string, unknown> =>
 
 /**
  * Terms buckets, or null when the engine returned a shape this facet cannot
- * be read from. Null is a hard parse failure, never an empty facet: silently
- * reporting "no courts" would look like a corpus with no decisions.
+ * be read from, or counts it will not vouch for. Null is a hard failure,
+ * never an empty facet: silently reporting "no courts" would look like a
+ * corpus with no decisions.
  */
 const parseTermsBuckets = (aggregation: unknown): FacetBucket[] | null => {
   if (!isRecord(aggregation) || !Array.isArray(aggregation["buckets"])) {
+    return null;
+  }
+
+  // `FACET_SEGMENT_SIZE` is a claim about the corpus, not a property of the
+  // engine, and corpus growth or a split-topology change can outgrow it. The
+  // engine states when it has: anything but a reported zero means the counts
+  // are approximate, and serving them would put wrong numbers next to every
+  // court with nothing to notice.
+  if (aggregation["doc_count_error_upper_bound"] !== 0) {
     return null;
   }
 
@@ -113,6 +150,7 @@ const parseTermsBuckets = (aggregation: unknown): FacetBucket[] | null => {
 
 export const corpusIndexBrowseFacets = async (
   query: LegalBrowseFacetsQuery,
+  excludedSourceIds: readonly string[],
 ): Promise<Result<LegalBrowseFacets, LegalBrowseFacetsError>> => {
   const generation = corpusGeneration(query.documentFamily ?? "case_law");
   // Scoped query → that jurisdiction's index; unscoped → the generation glob
@@ -123,7 +161,7 @@ export const corpusIndexBrowseFacets = async (
 
   const aggregated = await getCorpusIndexClient().aggregate({
     indexId,
-    query: OPENING_PASSAGE_QUERY,
+    query: browseFacetsQuery(excludedSourceIds),
     aggs: buildAggregations(query.limit),
   });
   if (Result.isError(aggregated)) {
@@ -141,7 +179,8 @@ export const corpusIndexBrowseFacets = async (
   if (country === null || court === null || year === null) {
     return Result.err(
       new LegalBrowseFacetsError({
-        message: "corpus index returned an unreadable facet aggregation",
+        message:
+          "corpus index returned an unreadable or approximate facet aggregation",
       }),
     );
   }

--- a/apps/api/src/lib/legal-search/corpus-index-facets.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.ts
@@ -1,0 +1,150 @@
+import { Result } from "better-result";
+
+import { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
+import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
+import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
+import {
+  corpusIndexId,
+  corpusIndexPattern,
+} from "@/api/lib/legal-search/index-naming";
+import type {
+  LegalBrowseFacets,
+  LegalBrowseFacetsQuery,
+} from "@/api/lib/legal-search/types";
+import type { FacetBucket } from "@/api/lib/search/types";
+import { isRecord } from "@/api/lib/type-guards";
+
+/**
+ * Browse-page facet counts served by corpus index aggregations instead of a
+ * `GROUP BY` over the whole decisions table. The counts describe the corpus,
+ * not a result set, so there is no text query to honour and the engine reads
+ * only fast fields.
+ *
+ * The index is passage-granular: every passage carries its decision's shared
+ * fields, so an unrestricted terms aggregation counts passages, not decisions.
+ * `seq:0` restricts it to each decision's opening passage — `chunkDocument`
+ * numbers passages from zero and always emits at least one, so exactly one
+ * document per decision matches — and every bucket then counts decisions.
+ *
+ * Source policy needs no clause here: only redistributable, unredacted
+ * decisions are ever projected into the index (see `corpus-index.ts`), so the
+ * index is already the gated set the public endpoint may count.
+ */
+
+const OPENING_PASSAGE_QUERY = "seq:0";
+
+/**
+ * Per-split candidate depth behind each bucket. Terms aggregations merge
+ * per-split top-k lists, so a depth at `size` alone makes counts approximate
+ * across many splits; at this depth the engine reports a
+ * `doc_count_error_upper_bound` of 0 for every browse facet at current corpus
+ * size, i.e. the counts are exact.
+ */
+const FACET_SEGMENT_SIZE = 5000;
+
+type BrowseFacetSpec = {
+  /** Index field the terms aggregation runs over. */
+  field: string;
+  /** Bucket order; mirrors the ORDER BY the Postgres facets use. */
+  order: { _count: "desc" } | { _key: "desc" };
+};
+
+/**
+ * One aggregation per response facet, named after the facet so the request
+ * and the parse cannot drift. `country` reads `jurisdiction` because that is
+ * the index's name for the decision's country.
+ */
+const BROWSE_FACETS = {
+  country: { field: "jurisdiction", order: { _count: "desc" } },
+  court: { field: "court", order: { _count: "desc" } },
+  year: { field: "year", order: { _key: "desc" } },
+} as const satisfies Record<keyof LegalBrowseFacets, BrowseFacetSpec>;
+
+export const browseFacetNames = Object.keys(BROWSE_FACETS);
+
+const buildAggregations = (limit: number): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(BROWSE_FACETS).map(([name, { field, order }]) => [
+      name,
+      {
+        terms: {
+          field,
+          size: limit,
+          segment_size: FACET_SEGMENT_SIZE,
+          order,
+        },
+      },
+    ]),
+  );
+
+/**
+ * Terms buckets, or null when the engine returned a shape this facet cannot
+ * be read from. Null is a hard parse failure, never an empty facet: silently
+ * reporting "no courts" would look like a corpus with no decisions.
+ */
+const parseTermsBuckets = (aggregation: unknown): FacetBucket[] | null => {
+  if (!isRecord(aggregation) || !Array.isArray(aggregation["buckets"])) {
+    return null;
+  }
+
+  const buckets: FacetBucket[] = [];
+  for (const bucket of aggregation["buckets"]) {
+    if (!isRecord(bucket)) {
+      return null;
+    }
+    const count = bucket["doc_count"];
+    const key = bucket["key"];
+    if (typeof count !== "number" || !Number.isFinite(count)) {
+      return null;
+    }
+    if (typeof key === "string") {
+      buckets.push({ value: key, count });
+      continue;
+    }
+    // `year` is a u64 fast field and comes back as a JSON float (2024.0);
+    // a non-integer key cannot come from one, so it is a parse failure.
+    if (typeof key !== "number" || !Number.isInteger(key)) {
+      return null;
+    }
+    buckets.push({ value: String(key), count });
+  }
+  return buckets;
+};
+
+export const corpusIndexBrowseFacets = async (
+  query: LegalBrowseFacetsQuery,
+): Promise<Result<LegalBrowseFacets, LegalBrowseFacetsError>> => {
+  const generation = corpusGeneration(query.documentFamily ?? "case_law");
+  // Scoped query → that jurisdiction's index; unscoped → the generation glob
+  // (one multi-index aggregation across every jurisdiction).
+  const indexId = query.jurisdiction
+    ? corpusIndexId(generation, query.jurisdiction)
+    : corpusIndexPattern(generation);
+
+  const aggregated = await getCorpusIndexClient().aggregate({
+    indexId,
+    query: OPENING_PASSAGE_QUERY,
+    aggs: buildAggregations(query.limit),
+  });
+  if (Result.isError(aggregated)) {
+    return Result.err(
+      new LegalBrowseFacetsError({
+        message: aggregated.error.message,
+        cause: aggregated.error,
+      }),
+    );
+  }
+
+  const country = parseTermsBuckets(aggregated.value["country"]);
+  const court = parseTermsBuckets(aggregated.value["court"]);
+  const year = parseTermsBuckets(aggregated.value["year"]);
+  if (country === null || court === null || year === null) {
+    return Result.err(
+      new LegalBrowseFacetsError({
+        message: "corpus index returned an unreadable facet aggregation",
+      }),
+    );
+  }
+
+  return Result.ok({ country, court, year });
+};

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -1,3 +1,4 @@
+import { Result } from "better-result";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
 import {
@@ -9,8 +10,10 @@ import { envBase } from "@/api/env-base";
 // eslint-disable-next-line no-restricted-imports -- search boundary: brands document ids returned by the corpus index before re-hydrating from Postgres
 import { toSafeId } from "@/api/lib/branded-types";
 import { caseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
+import { readNonRedistributableCaseLawSourceIds } from "@/api/lib/case-law/non-redistributable-sources";
 import { redistributableCaseLawSource } from "@/api/lib/case-law/redistribution";
 import { isUuid } from "@/api/lib/custom-schema";
+import { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
 import {
   caseLawCorpusProjectionJoin,
   currentCaseLawCorpusProjection,
@@ -30,6 +33,7 @@ import {
   stableBlendUpperBound,
 } from "@/api/lib/legal-search/rerank";
 import type {
+  LegalBrowseFacetsQuery,
   LegalSearchHit,
   LegalSearchProvider,
   LegalSearchQuery,
@@ -239,8 +243,28 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
   return { hits, facets: null, nextCursor, limit };
 };
 
+/**
+ * The aggregation counts the index, so the source-policy predicate cannot ride
+ * along in its query the way it does in SQL. It is read here instead and
+ * excluded in the corpus query, which keeps the gate query-time rather than
+ * leaving it to whenever reconciliation removes a revoked source's documents.
+ */
+const browseFacets = async (query: LegalBrowseFacetsQuery) => {
+  const excludedSourceIds = await readNonRedistributableCaseLawSourceIds();
+  if (Result.isError(excludedSourceIds)) {
+    return Result.err(
+      new LegalBrowseFacetsError({
+        message: excludedSourceIds.error.message,
+        cause: excludedSourceIds.error,
+      }),
+    );
+  }
+
+  return await corpusIndexBrowseFacets(query, excludedSourceIds.value);
+};
+
 export const corpusIndexProvider: LegalSearchProvider = {
   search,
-  browseFacets: corpusIndexBrowseFacets,
+  browseFacets,
   getDocumentContext: loadDocumentContext,
 };

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -16,6 +16,7 @@ import {
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
+import { corpusIndexBrowseFacets } from "@/api/lib/legal-search/corpus-index-facets";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
 import { loadDocumentContext } from "@/api/lib/legal-search/document-context";
@@ -240,5 +241,6 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
 
 export const corpusIndexProvider: LegalSearchProvider = {
   search,
+  browseFacets: corpusIndexBrowseFacets,
   getDocumentContext: loadDocumentContext,
 };

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -1,4 +1,3 @@
-import { Result } from "better-result";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
 import {
@@ -10,10 +9,8 @@ import { envBase } from "@/api/env-base";
 // eslint-disable-next-line no-restricted-imports -- search boundary: brands document ids returned by the corpus index before re-hydrating from Postgres
 import { toSafeId } from "@/api/lib/branded-types";
 import { caseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
-import { readNonRedistributableCaseLawSourceIds } from "@/api/lib/case-law/non-redistributable-sources";
 import { redistributableCaseLawSource } from "@/api/lib/case-law/redistribution";
 import { isUuid } from "@/api/lib/custom-schema";
-import { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
 import {
   caseLawCorpusProjectionJoin,
   currentCaseLawCorpusProjection,
@@ -33,7 +30,6 @@ import {
   stableBlendUpperBound,
 } from "@/api/lib/legal-search/rerank";
 import type {
-  LegalBrowseFacetsQuery,
   LegalSearchHit,
   LegalSearchProvider,
   LegalSearchQuery,
@@ -243,28 +239,8 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
   return { hits, facets: null, nextCursor, limit };
 };
 
-/**
- * The aggregation counts the index, so the source-policy predicate cannot ride
- * along in its query the way it does in SQL. It is read here instead and
- * excluded in the corpus query, which keeps the gate query-time rather than
- * leaving it to whenever reconciliation removes a revoked source's documents.
- */
-const browseFacets = async (query: LegalBrowseFacetsQuery) => {
-  const excludedSourceIds = await readNonRedistributableCaseLawSourceIds();
-  if (Result.isError(excludedSourceIds)) {
-    return Result.err(
-      new LegalBrowseFacetsError({
-        message: excludedSourceIds.error.message,
-        cause: excludedSourceIds.error,
-      }),
-    );
-  }
-
-  return await corpusIndexBrowseFacets(query, excludedSourceIds.value);
-};
-
 export const corpusIndexProvider: LegalSearchProvider = {
   search,
-  browseFacets,
+  browseFacets: corpusIndexBrowseFacets,
   getDocumentContext: loadDocumentContext,
 };

--- a/apps/api/src/lib/legal-search/pg-fts-browse-facets.ts
+++ b/apps/api/src/lib/legal-search/pg-fts-browse-facets.ts
@@ -1,0 +1,106 @@
+import { Result } from "better-result";
+import { and, desc, eq, isNotNull, sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+
+import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import { caseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
+import { redistributableCaseLawSource } from "@/api/lib/case-law/redistribution";
+import { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
+import type {
+  LegalBrowseFacets,
+  LegalBrowseFacetsQuery,
+} from "@/api/lib/legal-search/types";
+import type { FacetBucket } from "@/api/lib/search/types";
+
+/**
+ * Browse-page facets for a deployment without a corpus index: three grouped
+ * scans of `case_law_decisions`. This is the self-host path and the reason the
+ * capability is provider-dispatched rather than corpus-index-only. It is slow
+ * on a large corpus (the aggregation path exists because of that), so the
+ * caller is expected to keep it behind its TTL cache.
+ */
+
+const decisionYear = sql<string>`to_char(${caseLawDecisions.decisionDate}, 'YYYY')`;
+
+const toFacetBuckets = (
+  rows: readonly { count: number; value: string }[],
+): FacetBucket[] => rows.map((row) => ({ count: row.count, value: row.value }));
+
+const pgFtsBrowseFacetsUnsafe = async (
+  query: LegalBrowseFacetsQuery,
+): Promise<LegalBrowseFacets> => {
+  const scope: SQL[] = [redistributableCaseLawSource];
+  if (query.jurisdiction) {
+    scope.push(eq(caseLawDecisions.country, query.jurisdiction));
+  }
+
+  const [countryRows, courtRows, yearRows] = await caseLawPublicReadDb(
+    async (tx) => {
+      const countries = await tx
+        .select({
+          value: caseLawDecisions.country,
+          count: sql<number>`count(*)::int`,
+        })
+        .from(caseLawDecisions)
+        .innerJoin(
+          caseLawSources,
+          eq(caseLawSources.id, caseLawDecisions.sourceId),
+        )
+        .where(and(...scope))
+        .groupBy(caseLawDecisions.country)
+        .orderBy(desc(sql`count(*)`), desc(caseLawDecisions.country))
+        .limit(query.limit);
+
+      const courts = await tx
+        .select({
+          value: caseLawDecisions.court,
+          count: sql<number>`count(*)::int`,
+        })
+        .from(caseLawDecisions)
+        .innerJoin(
+          caseLawSources,
+          eq(caseLawSources.id, caseLawDecisions.sourceId),
+        )
+        .where(and(...scope))
+        .groupBy(caseLawDecisions.court)
+        .orderBy(desc(sql`count(*)`), desc(caseLawDecisions.court))
+        .limit(query.limit);
+
+      const years = await tx
+        .select({
+          value: decisionYear,
+          count: sql<number>`count(*)::int`,
+        })
+        .from(caseLawDecisions)
+        .innerJoin(
+          caseLawSources,
+          eq(caseLawSources.id, caseLawDecisions.sourceId),
+        )
+        .where(and(isNotNull(caseLawDecisions.decisionDate), ...scope))
+        .groupBy(decisionYear)
+        .orderBy(desc(decisionYear))
+        .limit(query.limit);
+
+      return [countries, courts, years] as const;
+    },
+  );
+
+  return {
+    country: toFacetBuckets(countryRows),
+    court: toFacetBuckets(courtRows),
+    year: toFacetBuckets(yearRows),
+  };
+};
+
+export const pgFtsBrowseFacets = async (query: LegalBrowseFacetsQuery) =>
+  await Result.tryPromise({
+    try: async () => await pgFtsBrowseFacetsUnsafe(query),
+    catch: (cause) =>
+      new LegalBrowseFacetsError({
+        message:
+          cause instanceof Error
+            ? cause.message
+            : "postgres browse facets failed",
+        cause,
+      }),
+  });

--- a/apps/api/src/lib/legal-search/pg-fts-legal-provider.ts
+++ b/apps/api/src/lib/legal-search/pg-fts-legal-provider.ts
@@ -7,6 +7,7 @@ import {
 } from "@/api/lib/case-law/search-sql";
 import { loadDocumentContext } from "@/api/lib/legal-search/document-context";
 import { loadFtsSearchConfigs } from "@/api/lib/legal-search/fts-config";
+import { pgFtsBrowseFacets } from "@/api/lib/legal-search/pg-fts-browse-facets";
 import { buildPgFtsSearchSql } from "@/api/lib/legal-search/pg-fts-query";
 import type {
   LegalSearchHit,
@@ -208,5 +209,6 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
 
 export const pgFtsLegalProvider: LegalSearchProvider = {
   search,
+  browseFacets: pgFtsBrowseFacets,
   getDocumentContext: loadDocumentContext,
 };

--- a/apps/api/src/lib/legal-search/types.ts
+++ b/apps/api/src/lib/legal-search/types.ts
@@ -1,6 +1,9 @@
+import type { Result } from "better-result";
+
 import type { DocumentAst } from "@stll/legal-ast/document-ast";
 
 import type { SafeId } from "@/api/lib/branded-types";
+import type { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-family";
 import type { EmptyAst } from "@/api/lib/legal-search/document-types";
 import type { FacetBucket } from "@/api/lib/search/types";
@@ -92,6 +95,27 @@ export type LegalDocumentContext = {
 };
 
 /**
+ * Facets for the *unsearched* browse page. Separate from `LegalSearchFacets`
+ * because it answers a different question: those describe one result set, these
+ * describe the whole corpus, so they are computed without a text query and are
+ * cacheable for minutes.
+ */
+export type LegalBrowseFacetsQuery = {
+  /** Document family to facet; selects the index family. Default case_law. */
+  documentFamily?: CorpusFamily | undefined;
+  /** Maps from the decision's `country`; scopes every facet to it. */
+  jurisdiction?: string | undefined;
+  /** Maximum buckets per facet. */
+  limit: number;
+};
+
+export type LegalBrowseFacets = {
+  country: FacetBucket[];
+  court: FacetBucket[];
+  year: FacetBucket[];
+};
+
+/**
  * Read-side abstraction the app calls for legal-corpus search. Indexing,
  * deletion, and redaction are NOT here: like the shipped case-law FTS,
  * those are daemon-loop / dedicated-module concerns (search-index.ts,
@@ -99,6 +123,14 @@ export type LegalDocumentContext = {
  */
 export type LegalSearchProvider = {
   search: (query: LegalSearchQuery) => Promise<LegalSearchResult>;
+  /**
+   * Corpus-wide facet counts for the browse page. Returns a Result rather
+   * than throwing: facets are navigational, and the caller degrades to an
+   * empty set instead of failing the page.
+   */
+  browseFacets: (
+    query: LegalBrowseFacetsQuery,
+  ) => Promise<Result<LegalBrowseFacets, LegalBrowseFacetsError>>;
   /** Canonical text/AST for the AI reader; served from object storage. */
   getDocumentContext: (
     decisionId: SafeId<"caseLawDecision">,

--- a/apps/api/src/lib/legal-search/types.ts
+++ b/apps/api/src/lib/legal-search/types.ts
@@ -105,6 +105,15 @@ export type LegalBrowseFacetsQuery = {
   documentFamily?: CorpusFamily | undefined;
   /** Maps from the decision's `country`; scopes every facet to it. */
   jurisdiction?: string | undefined;
+  /**
+   * Sources whose redistribution is currently revoked. Resolved by the caller
+   * on every request rather than inside a provider, because it is an input
+   * that changes the answer: a cache keyed without it would keep serving a
+   * revoked source's buckets for a whole window. Providers that re-evaluate
+   * the policy in their own query (pg-fts) need not read it; its presence in
+   * the key is what makes their cached answer expire with the policy too.
+   */
+  excludedSourceIds: readonly string[];
   /** Maximum buckets per facet. */
   limit: number;
 };

--- a/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
+++ b/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
@@ -22,6 +22,12 @@ const DEFERRED_DOCUMENT_FILE =
   "apps/api/src/handlers/case-law/decisions/get-deferred-document.ts";
 const FACETS_DECISIONS_FILE =
   "apps/api/src/handlers/case-law/decisions/facets.ts";
+const PG_FTS_FACETS_FILE =
+  "apps/api/src/lib/legal-search/pg-fts-browse-facets.ts";
+const CORPUS_INDEX_FACETS_FILE =
+  "apps/api/src/lib/legal-search/corpus-index-facets.ts";
+const CORPUS_INDEX_PROJECTION_FILE =
+  "apps/api/src/handlers/case-law/corpus-index.ts";
 const SEARCH_DECISIONS_FILE =
   "apps/api/src/handlers/case-law/decisions/search.ts";
 const SEARCH_DECISIONS_SCHEMA_FILE =
@@ -42,6 +48,11 @@ const readDecisionSource = async () => await readSource(READ_DECISION_FILE);
 const readDeferredDocumentSource = async () =>
   await readSource(DEFERRED_DOCUMENT_FILE);
 const readFacetsSource = async () => await readSource(FACETS_DECISIONS_FILE);
+const readPgFtsFacetsSource = async () => await readSource(PG_FTS_FACETS_FILE);
+const readCorpusIndexFacetsSource = async () =>
+  await readSource(CORPUS_INDEX_FACETS_FILE);
+const readCorpusIndexProjectionSource = async () =>
+  await readSource(CORPUS_INDEX_PROJECTION_FILE);
 const readSearchSource = async () => await readSource(SEARCH_DECISIONS_FILE);
 const readSearchSchemaSource = async () =>
   await readSource(SEARCH_DECISIONS_SCHEMA_FILE);
@@ -191,16 +202,28 @@ describe("public case-law route boundary", () => {
   });
 
   test("public facets payload is aggregate public data only", async () => {
-    const source = await readFacetsSource();
+    // Facets are provider-dispatched, so the invariant has to hold on the
+    // handler and on both implementations behind it.
+    const [handlerSource, pgFtsSource, corpusIndexSource] = await Promise.all([
+      readFacetsSource(),
+      readPgFtsFacetsSource(),
+      readCorpusIndexFacetsSource(),
+    ]);
 
-    expect(source).not.toContain("analysis");
-    expect(source).not.toContain("workspace");
-    expect(source).not.toContain("organization");
-    expect(source).not.toContain("matter");
-    expect(source).toContain("caseLawDecisions.country");
-    expect(source).toContain("caseLawDecisions.court");
-    expect(source).toContain("caseLawDecisions.decisionDate");
-    expect(source).toContain("LIMITS.caseLawFacetLimit");
+    for (const source of [handlerSource, pgFtsSource, corpusIndexSource]) {
+      expect(source).not.toContain("analysis");
+      expect(source).not.toContain("workspace");
+      expect(source).not.toContain("organization");
+      expect(source).not.toContain("matter");
+    }
+
+    expect(handlerSource).toContain("LIMITS.caseLawFacetLimit");
+    expect(pgFtsSource).toContain("caseLawDecisions.country");
+    expect(pgFtsSource).toContain("caseLawDecisions.court");
+    expect(pgFtsSource).toContain("caseLawDecisions.decisionDate");
+    expect(corpusIndexSource).toContain('field: "jurisdiction"');
+    expect(corpusIndexSource).toContain('field: "court"');
+    expect(corpusIndexSource).toContain('field: "year"');
   });
 
   test("public search payload is aggregate public data only", async () => {
@@ -284,14 +307,21 @@ describe("public case-law route boundary", () => {
   test("every public decision surface enforces the redistribution gate", async () => {
     const listSource = await readListSource();
     const decisionSource = await readDecisionSource();
-    const facetsSource = await readFacetsSource();
+    const pgFtsFacetsSource = await readPgFtsFacetsSource();
+    const corpusIndexProjectionSource = await readCorpusIndexProjectionSource();
     const searchSource = await readSearchSource();
     const sitemapSource = await readSitemapSource();
 
     expect(listSource).toContain("redistributableCaseLawSource");
     expect(decisionSource).toContain("redistributableCaseLawSource");
     expect(decisionSource).toContain("isRedistributable");
-    expect(facetsSource).toContain("redistributableCaseLawSource");
+    expect(pgFtsFacetsSource).toContain("redistributableCaseLawSource");
+    // The corpus-index facets aggregate the index rather than the table, so
+    // their gate is the projection's: only redistributable decisions are ever
+    // indexed, which is what makes counting the index safe to serve publicly.
+    expect(corpusIndexProjectionSource).toContain(
+      "redistributableCaseLawSource",
+    );
     expect(searchSource).toContain("redistributableSourceJoin");
     expect(searchSource).toContain("redistributableCaseLawSource");
     expect(sitemapSource).toContain("redistributableCaseLawSource");

--- a/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
+++ b/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
@@ -28,8 +28,8 @@ const CORPUS_INDEX_FACETS_FILE =
   "apps/api/src/lib/legal-search/corpus-index-facets.ts";
 const CORPUS_INDEX_PROJECTION_FILE =
   "apps/api/src/handlers/case-law/corpus-index.ts";
-const CORPUS_INDEX_PROVIDER_FILE =
-  "apps/api/src/lib/legal-search/corpus-index-provider.ts";
+const BROWSE_FACETS_CACHE_FILE =
+  "apps/api/src/lib/legal-search/browse-facets-cache.ts";
 const NON_REDISTRIBUTABLE_SOURCES_FILE =
   "apps/api/src/lib/case-law/non-redistributable-sources.ts";
 const SEARCH_DECISIONS_FILE =
@@ -57,8 +57,8 @@ const readCorpusIndexFacetsSource = async () =>
   await readSource(CORPUS_INDEX_FACETS_FILE);
 const readCorpusIndexProjectionSource = async () =>
   await readSource(CORPUS_INDEX_PROJECTION_FILE);
-const readCorpusIndexProviderSource = async () =>
-  await readSource(CORPUS_INDEX_PROVIDER_FILE);
+const readBrowseFacetsCacheSource = async () =>
+  await readSource(BROWSE_FACETS_CACHE_FILE);
 const readNonRedistributableSourcesSource = async () =>
   await readSource(NON_REDISTRIBUTABLE_SOURCES_FILE);
 const readSearchSource = async () => await readSource(SEARCH_DECISIONS_FILE);
@@ -315,10 +315,11 @@ describe("public case-law route boundary", () => {
   test("every public decision surface enforces the redistribution gate", async () => {
     const listSource = await readListSource();
     const decisionSource = await readDecisionSource();
+    const facetsHandlerSource = await readFacetsSource();
     const pgFtsFacetsSource = await readPgFtsFacetsSource();
     const corpusIndexFacetsSource = await readCorpusIndexFacetsSource();
     const corpusIndexProjectionSource = await readCorpusIndexProjectionSource();
-    const corpusIndexProviderSource = await readCorpusIndexProviderSource();
+    const browseFacetsCacheSource = await readBrowseFacetsCacheSource();
     const nonRedistributableSourcesSource =
       await readNonRedistributableSourcesSource();
     const searchSource = await readSearchSource();
@@ -338,10 +339,16 @@ describe("public case-law route boundary", () => {
     expect(nonRedistributableSourcesSource).toContain(
       "redistributableCaseLawSource",
     );
-    expect(corpusIndexProviderSource).toContain(
+    expect(nonRedistributableSourcesSource).toContain(
       "readNonRedistributableCaseLawSourceIds",
     );
-    expect(corpusIndexFacetsSource).toContain("excludedSourceIds");
+    expect(corpusIndexFacetsSource).toContain("query.excludedSourceIds");
+    // Resolved ahead of the cache, so a revocation changes the key. Behind it,
+    // the revoked source's buckets would stay public for a whole window.
+    expect(facetsHandlerSource).toContain(
+      "readNonRedistributableCaseLawSourceIds",
+    );
+    expect(browseFacetsCacheSource).toContain("excludedSourceIds");
     expect(searchSource).toContain("redistributableSourceJoin");
     expect(searchSource).toContain("redistributableCaseLawSource");
     expect(sitemapSource).toContain("redistributableCaseLawSource");

--- a/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
+++ b/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
@@ -28,6 +28,10 @@ const CORPUS_INDEX_FACETS_FILE =
   "apps/api/src/lib/legal-search/corpus-index-facets.ts";
 const CORPUS_INDEX_PROJECTION_FILE =
   "apps/api/src/handlers/case-law/corpus-index.ts";
+const CORPUS_INDEX_PROVIDER_FILE =
+  "apps/api/src/lib/legal-search/corpus-index-provider.ts";
+const NON_REDISTRIBUTABLE_SOURCES_FILE =
+  "apps/api/src/lib/case-law/non-redistributable-sources.ts";
 const SEARCH_DECISIONS_FILE =
   "apps/api/src/handlers/case-law/decisions/search.ts";
 const SEARCH_DECISIONS_SCHEMA_FILE =
@@ -53,6 +57,10 @@ const readCorpusIndexFacetsSource = async () =>
   await readSource(CORPUS_INDEX_FACETS_FILE);
 const readCorpusIndexProjectionSource = async () =>
   await readSource(CORPUS_INDEX_PROJECTION_FILE);
+const readCorpusIndexProviderSource = async () =>
+  await readSource(CORPUS_INDEX_PROVIDER_FILE);
+const readNonRedistributableSourcesSource = async () =>
+  await readSource(NON_REDISTRIBUTABLE_SOURCES_FILE);
 const readSearchSource = async () => await readSource(SEARCH_DECISIONS_FILE);
 const readSearchSchemaSource = async () =>
   await readSource(SEARCH_DECISIONS_SCHEMA_FILE);
@@ -308,7 +316,11 @@ describe("public case-law route boundary", () => {
     const listSource = await readListSource();
     const decisionSource = await readDecisionSource();
     const pgFtsFacetsSource = await readPgFtsFacetsSource();
+    const corpusIndexFacetsSource = await readCorpusIndexFacetsSource();
     const corpusIndexProjectionSource = await readCorpusIndexProjectionSource();
+    const corpusIndexProviderSource = await readCorpusIndexProviderSource();
+    const nonRedistributableSourcesSource =
+      await readNonRedistributableSourcesSource();
     const searchSource = await readSearchSource();
     const sitemapSource = await readSitemapSource();
 
@@ -317,11 +329,19 @@ describe("public case-law route boundary", () => {
     expect(decisionSource).toContain("isRedistributable");
     expect(pgFtsFacetsSource).toContain("redistributableCaseLawSource");
     // The corpus-index facets aggregate the index rather than the table, so
-    // their gate is the projection's: only redistributable decisions are ever
-    // indexed, which is what makes counting the index safe to serve publicly.
+    // the gate is two-sided. Projection keeps ineligible sources out of the
+    // index; because a revocation only queues their removal, the aggregation
+    // additionally excludes whatever is ineligible at query time.
     expect(corpusIndexProjectionSource).toContain(
       "redistributableCaseLawSource",
     );
+    expect(nonRedistributableSourcesSource).toContain(
+      "redistributableCaseLawSource",
+    );
+    expect(corpusIndexProviderSource).toContain(
+      "readNonRedistributableCaseLawSourceIds",
+    );
+    expect(corpusIndexFacetsSource).toContain("excludedSourceIds");
     expect(searchSource).toContain("redistributableSourceJoin");
     expect(searchSource).toContain("redistributableCaseLawSource");
     expect(sitemapSource).toContain("redistributableCaseLawSource");


### PR DESCRIPTION
## Why

`GET /case/decisions/facets` is a public, uncached route that grouped the whole
`case_law_decisions` table three times per request (country, court, year). On the
deployed corpus that endpoint alone accounts for roughly a quarter of all database
disk-read load, and each of the three aggregations now runs long enough that the
request can hit the statement timeout: the browse page waits on a query that may
never return.

The counts describe the corpus, not a result set. Nothing about that requires a
`GROUP BY` over the source table on every page view.

## What

- `browseFacets` joins `search` and `getDocumentContext` on the `LegalSearchProvider`
  contract, so the capability is dispatched the same way search already is.
- The corpus-index provider answers with terms aggregations over fast fields
  (`jurisdiction`, `court`, `year`), no hits requested.
- The pg-fts provider keeps the existing SQL, moved verbatim into
  `pg-fts-browse-facets.ts`. A deployment without a corpus index is unaffected, which
  is the point of dispatching rather than replacing.
- The handler keeps the answer behind a 5-minute in-process TTL cache that collapses
  concurrent misses into one provider call, refuses to cache a failure, and bounds its
  key space at 32 entries.
- A provider failure degrades to an empty facet set plus a structured warning instead
  of a 500: the filters fall back to free-text inputs, which is a degraded page rather
  than a broken one.
- Response shape is unchanged. The endpoint additionally accepts an optional `country`,
  scoping counts the way the decisions list scopes its rows. The code is canonicalised
  once at the boundary so both providers answer the same question and one jurisdiction
  maps to one cache entry.

### Two details worth reviewing

The index is passage-granular: every passage carries its decision's shared fields, so
an unrestricted terms aggregation would count passages. `seq:0` restricts it to each
decision's opening passage, of which every decision has exactly one, so each bucket
counts decisions.

Terms aggregations merge per-split top-k lists, so a candidate depth at `size` alone
makes counts approximate across many splits. `segment_size: 5000` was chosen because
at that depth the engine reports `doc_count_error_upper_bound: 0` for every browse
facet at current corpus size, i.e. the counts are exact rather than nearly right.
That is a claim about the corpus, not a property of the engine, so the parser
requires the reported zero: a merged top-k that outgrows the candidate depth takes
the degraded-facets path with a structured warning instead of serving approximate
counts as exact.

## Redistribution gate

The pg-fts path keeps its explicit `redistributableCaseLawSource` predicate. The
corpus-index path aggregates the index rather than the table, so the gate is
two-sided:

- **Write time.** Only redistributable, unredacted decisions are ever projected into
  the index.
- **Query time.** Projection alone is not enough, because revoking a source's
  redistribution only *queues* its documents for removal: until reconciliation
  catches up, the index still holds them. So the aggregation excludes whatever is
  ineligible right now (`seq:0 AND NOT (source:"…" OR …)`), read from the same
  `redistributableCaseLawSource` predicate the SQL surfaces filter with. That is the
  posture the search path already takes when it re-applies the predicate while
  rehydrating index candidates.
- **Ahead of the cache.** The ineligible set is resolved per request and is part of
  the cache key (sorted, so read order cannot split one policy across two entries).
  Consulting it inside the loader instead would have kept a revoked source's buckets
  public for the rest of the window, and would have left the pg-fts answer stale for
  the same reason. A failed policy read returns empty facets rather than stale ones.
  Cost is one indexed lookup over a table of court feeds.

The security invariants test pins the gate at the projection, the ineligible-source
reader, and the aggregation, and asserts the no-analysis/no-workspace/no-matter
payload rule against the handler and both implementations.

## Known boundary

An unprojected decision (no canonical payload yet) is browseable in the list but
absent from a facet bucket. That is stated in the module doc comment rather than
worked around: the set the facets describe is the set search can find, and widening
them to cover rows the index cannot serve would restore the full-corpus `GROUP BY`
this change exists to remove.

## Measured

| Request | Before | After |
| --- | --- | --- |
| Cold (unscoped, cache miss) | statement timeout | 828 ms |
| Warm (unscoped, cache hit) | statement timeout | ~300 ms |
| Scoped to one jurisdiction | statement timeout | ~130 ms |

## Verification

- `tsc` across all four API projects, type-aware `oxlint` on `apps/api`, `oxfmt`,
  `scripts/ratchet.ts`, `scripts/typecheck-baseline.ts`, `mcp-coverage-guard`.
- Suites: `src/lib/legal-search/`, `src/handlers/case-law/`, `src/tests/security/`.
  All green.

`mcp-coverage-guard` needed no allowlist change: `public-routes.ts` gains no inline
handler here, it only adds a query schema to the existing facets handler.
