### PR TITLE
fix(api): report deferred rows in the corpus backfill outcome

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
@@ -188,6 +188,13 @@ const ignoreProjectionRemoval = async () => {
   await Promise.resolve();
 };
 
+/** A batch where every selected row settled, with nothing deferred. */
+const indexedOutcome = (indexed: number) => ({
+  indexed,
+  refreshed: 0,
+  unread: 0,
+});
+
 const completeRemoteEffect = async (): Promise<void> => {
   await Promise.resolve();
 };
@@ -252,7 +259,7 @@ test(
     const backfill = createCaseLawGenerationBackfill({
       backfillRows: async () => {
         backfillCalls += 1;
-        return 0;
+        return indexedOutcome(0);
       },
       newLeaseToken: () =>
         `00000000-0000-4000-8000-${String(++lease).padStart(12, "0")}`,
@@ -369,7 +376,7 @@ test(
           onLeaseLost: noRemoteEffectCompensation,
         });
         writes += 1;
-        return rows.length;
+        return indexedOutcome(rows.length);
       },
       newLeaseToken: () => "00000000-0000-4000-8000-000000000060",
       removeProjection: ignoreProjectionRemoval,
@@ -399,7 +406,7 @@ test(
 test("rejects an invalid generation before creating durable state", async () => {
   const generation = "invalid generation";
   const backfill = createCaseLawGenerationBackfill({
-    backfillRows: async () => 0,
+    backfillRows: async () => indexedOutcome(0),
     newLeaseToken: () => "00000000-0000-4000-8000-000000000099",
     removeProjection: ignoreProjectionRemoval,
   });
@@ -610,7 +617,7 @@ test(
               eq(caseLawCorpusIndexProjections.generation, rebuildGeneration),
             );
         });
-        return rows.length;
+        return indexedOutcome(rows.length);
       },
       newLeaseToken: () =>
         `00000000-0000-4000-8000-${String(++lease).padStart(12, "0")}`,
@@ -678,7 +685,7 @@ test(
           effect: completeRemoteEffect,
           onLeaseLost: noRemoteEffectCompensation,
         });
-        return rows.length;
+        return indexedOutcome(rows.length);
       },
       newLeaseToken: () => "00000000-0000-4000-8000-000000000070",
       removeProjection: async (
@@ -767,7 +774,7 @@ test(
           });
           const row = rows.at(0);
           if (!row) {
-            return 0;
+            return indexedOutcome(0);
           }
           let indexed = 0;
           await runnerDb(async (tx) => {
@@ -796,7 +803,7 @@ test(
             );
             indexed = marked.size;
           });
-          return indexed;
+          return indexedOutcome(indexed);
         },
         newLeaseToken: () => "00000000-0000-4000-8000-000000000050",
         removeProjection: ignoreProjectionRemoval,
@@ -1122,7 +1129,7 @@ test(
               );
           });
         }
-        return rows.length;
+        return indexedOutcome(rows.length);
       },
       newLeaseToken: () =>
         `00000000-0000-4000-8000-${String(++lease).padStart(12, "0")}`,
@@ -1350,7 +1357,7 @@ test(
           effect: completeRemoteEffect,
           onLeaseLost: noRemoteEffectCompensation,
         });
-        return 0;
+        return { indexed: 0, refreshed: 1, unread: 0 };
       },
       newLeaseToken: () => "00000000-0000-4000-8000-000000000101",
       removeProjection: ignoreProjectionRemoval,
@@ -1363,8 +1370,13 @@ test(
       () => null,
       (error: unknown) => error,
     );
+    // The shortfall reason is the point: a page that deferred a row to a
+    // concurrent refresh has to say so, or the log cannot tell that apart
+    // from an unreadable object or a lost update.
     expect(incompleteRejection).toMatchObject({
-      message: "generation backfill page did not reach a fixed point",
+      message: expect.stringMatching(
+        /^generation backfill page did not reach a fixed point \(selected=\d+ indexed=0 refreshed=1 unread=0\)$/u,
+      ),
     });
     expect(await readCheckpoint(retryGeneration)).toMatchObject({
       cursorCreatedAt: null,
@@ -1382,7 +1394,7 @@ test(
           onLeaseLost: noRemoteEffectCompensation,
         });
         replayed.push(rows.map((row) => row.id));
-        return rows.length;
+        return indexedOutcome(rows.length);
       },
       newLeaseToken: () => "00000000-0000-4000-8000-000000000102",
       removeProjection: ignoreProjectionRemoval,
@@ -1408,7 +1420,7 @@ test(
           onLeaseLost: noRemoteEffectCompensation,
         });
         winningRemoteEffects += 1;
-        return rows.length;
+        return indexedOutcome(rows.length);
       },
       newLeaseToken: () => "00000000-0000-4000-8000-000000000201",
       removeProjection: ignoreProjectionRemoval,
@@ -1432,7 +1444,7 @@ test(
           onLeaseLost: noRemoteEffectCompensation,
         });
         staleRemoteEffects += 1;
-        return rows.length;
+        return indexedOutcome(rows.length);
       },
       newLeaseToken: () => "00000000-0000-4000-8000-000000000200",
       removeProjection: ignoreProjectionRemoval,
@@ -1511,7 +1523,7 @@ test(
               ),
             );
         });
-        return rows.length;
+        return indexedOutcome(rows.length);
       },
       newLeaseToken: () => "00000000-0000-4000-8000-000000000401",
       removeProjection: ignoreProjectionRemoval,
@@ -1557,7 +1569,7 @@ test(
         });
         await runnerDb(options.beforeDatabaseMark);
         staleDatabaseMarks += 1;
-        return rows.length;
+        return indexedOutcome(rows.length);
       },
       newLeaseToken: () => "00000000-0000-4000-8000-000000000400",
       removeProjection: ignoreProjectionRemoval,
@@ -1916,7 +1928,7 @@ test(
           onLeaseLost: noRemoteEffectCompensation,
         });
         sent.push(...rows.map(({ id }) => id));
-        return rows.length;
+        return indexedOutcome(rows.length);
       },
       newLeaseToken: () => "00000000-0000-4000-8000-000000000300",
       removeProjection: ignoreProjectionRemoval,
@@ -2054,7 +2066,7 @@ test(
         indexed.push(...rows.map(({ id }) => id));
         const row = rows.at(0);
         if (!row) {
-          return 0;
+          return indexedOutcome(0);
         }
         let markedCount = 0;
         await runnerDb(async (tx) => {
@@ -2080,7 +2092,7 @@ test(
           });
           markedCount = marked.size;
         });
-        return markedCount;
+        return indexedOutcome(markedCount);
       },
       newLeaseToken: () => "00000000-0000-4000-8000-000000000900",
       removeProjection: async (runnerDb, { options, row }) => {
@@ -2223,7 +2235,7 @@ test(
           onLeaseLost: noRemoteEffectCompensation,
         });
         indexed.push(...rows.map(({ id }) => id));
-        return rows.length;
+        return indexedOutcome(rows.length);
       },
       newLeaseToken: () => "00000000-0000-4000-8000-000000000901",
       removeProjection: async () => {
@@ -2429,7 +2441,7 @@ test(
             onLeaseLost: noRemoteEffectCompensation,
           });
           indexed.push(...rows.map(({ id }) => id));
-          return rows.length;
+          return indexedOutcome(rows.length);
         },
         newLeaseToken: () => "00000000-0000-4000-8000-000000000940",
         removeProjection: ignoreProjectionRemoval,
@@ -2675,7 +2687,7 @@ test(
               eq(caseLawCorpusIndexProjections.generation, rebuildGeneration),
             );
         });
-        return rows.length;
+        return indexedOutcome(rows.length);
       },
       newLeaseToken: () => "00000000-0000-4000-8000-000000000640",
       removeProjection: ignoreProjectionRemoval,

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -27,6 +27,7 @@ import {
   formatHeadingPath,
 } from "@/api/lib/corpus-index/chunking";
 import type {
+  CorpusBackfillOutcome,
   CorpusDocumentPayload,
   CorpusIndexAdapter,
   FencedRemoteEffect,
@@ -1106,7 +1107,7 @@ type GenerationBackfillDependencies = {
     rows: readonly IndexableRow[],
     generation: string,
     options: GenerationProjectionGuards & { commit: CorpusIndexCommitMode },
-  ) => Promise<number>;
+  ) => Promise<CorpusBackfillOutcome>;
   removeProjection: (
     scopedDb: Parameters<typeof backfillIncrementalCorpusIndex>[0],
     args: {
@@ -1117,6 +1118,37 @@ type GenerationBackfillDependencies = {
   ) => Promise<void>;
   newLeaseToken: () => string;
 };
+
+const EMPTY_BACKFILL_OUTCOME = {
+  indexed: 0,
+  refreshed: 0,
+  unread: 0,
+} as const satisfies CorpusBackfillOutcome;
+
+const FIXED_POINT_STAGE = {
+  generationBackfillPage: "generation backfill page",
+  generationReconciliation: "generation reconciliation",
+  sourceEligibilityReconciliation: "source eligibility reconciliation",
+} as const;
+
+type FixedPointShortfall = {
+  outcome: CorpusBackfillOutcome;
+  selected: number;
+  stage: (typeof FIXED_POINT_STAGE)[keyof typeof FIXED_POINT_STAGE];
+};
+
+/**
+ * A page that indexed fewer rows than it selected has not settled, but the
+ * count alone does not say why, and the reasons need different answers: a
+ * concurrent refresh leaves the row queued for the next cycle, an unreadable
+ * corpus object is already recorded as a failed job, and a shortfall neither
+ * accounts for is a lost update. Carry the split so the next occurrence is
+ * readable from the log rather than only from the analytics sink.
+ */
+const fixedPointError = ({ outcome, selected, stage }: FixedPointShortfall) =>
+  new CorpusIndexError({
+    message: `${stage} did not reach a fixed point (selected=${selected} indexed=${outcome.indexed} refreshed=${outcome.refreshed} unread=${outcome.unread})`,
+  });
 
 const backfillGenerationRows: GenerationBackfillDependencies["backfillRows"] =
   async (scopedDb, rows, generation, options) =>
@@ -1624,9 +1656,9 @@ export const createCaseLawGenerationBackfill =
           const eligible = sourcePage
             .filter(isCorpusEligible)
             .map(withoutSourceDescriptor);
-          const indexed =
+          const outcome =
             eligible.length === 0
-              ? 0
+              ? EMPTY_BACKFILL_OUTCOME
               : await backfillRows(scopedDb, eligible, generation, {
                   ...guards,
                   // A source-wide re-index walks a whole source's corpus
@@ -1634,12 +1666,14 @@ export const createCaseLawGenerationBackfill =
                   // census behind it as the snapshot walk.
                   commit: CORPUS_INDEX_COMMIT.auto,
                 });
-          if (indexed !== eligible.length) {
-            throw new CorpusIndexError({
-              message:
-                "source eligibility reconciliation did not reach a fixed point",
+          if (outcome.indexed !== eligible.length) {
+            throw fixedPointError({
+              outcome,
+              selected: eligible.length,
+              stage: FIXED_POINT_STAGE.sourceEligibilityReconciliation,
             });
           }
+          const { indexed } = outcome;
           const removals = sourcePage.filter(
             (row) =>
               !isCorpusEligible(row) &&
@@ -1729,9 +1763,9 @@ export const createCaseLawGenerationBackfill =
             !isCorpusEligible(row) &&
             hasGenerationProjectionTargets({ generation, row }),
         );
-        const indexed =
+        const outcome =
           eligible.length === 0
-            ? 0
+            ? EMPTY_BACKFILL_OUTCOME
             : await backfillRows(scopedDb, eligible, generation, {
                 ...guards,
                 // The live path: every newly ingested decision waits in
@@ -1741,11 +1775,14 @@ export const createCaseLawGenerationBackfill =
                 // missing from the index while Postgres reads indexed.
                 commit: CORPUS_INDEX_COMMIT.waitFor,
               });
-        if (indexed !== eligible.length) {
-          throw new CorpusIndexError({
-            message: "generation reconciliation did not reach a fixed point",
+        if (outcome.indexed !== eligible.length) {
+          throw fixedPointError({
+            outcome,
+            selected: eligible.length,
+            stage: FIXED_POINT_STAGE.generationReconciliation,
           });
         }
+        const { indexed } = outcome;
         if (terminal.length > 0) {
           const cleared = await scopedDb(async (tx) => {
             await guards.beforeDatabaseMark(tx);
@@ -2024,9 +2061,9 @@ export const createCaseLawGenerationBackfill =
       try {
         // The drain above may have brought every row on this page current, so
         // skip the indexer rather than hand it an empty batch.
-        indexed =
+        const outcome =
           rows.length === 0
-            ? 0
+            ? EMPTY_BACKFILL_OUTCOME
             : await backfillRows(scopedDb, rows, generation, {
                 ...runningGuards,
                 // Snapshot pages of the rebuild: bulk throughput, whose
@@ -2034,11 +2071,14 @@ export const createCaseLawGenerationBackfill =
                 // than each request proving it for itself.
                 commit: CORPUS_INDEX_COMMIT.auto,
               });
-        if (indexed !== rows.length) {
-          throw new CorpusIndexError({
-            message: "generation backfill page did not reach a fixed point",
+        if (outcome.indexed !== rows.length) {
+          throw fixedPointError({
+            outcome,
+            selected: rows.length,
+            stage: FIXED_POINT_STAGE.generationBackfillPage,
           });
         }
+        indexed = outcome.indexed;
         await settleAll(
           removals.map(async (row) => {
             await removeProjection(scopedDb, {

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -47,6 +47,16 @@ const ingestedIds = (requests: ReturnType<typeof splitIngestRequests>) =>
     }),
   );
 
+const requestUrl = (input: Parameters<typeof fetch>[0]): string => {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+};
+
 describe("splitIngestRequests", () => {
   test("a group that fits stays one request", () => {
     const group = [builtRow("a", 3, "x"), builtRow("b", 2, "x")];
@@ -721,7 +731,7 @@ describe("failed index jobs always reach the audit trail", () => {
 
     let guardedEffects = 0;
     let guardedMarks = 0;
-    const indexed = await indexer.backfillRows(scopedDb, [row], GENERATION, {
+    const outcome = await indexer.backfillRows(scopedDb, [row], GENERATION, {
       commit: CORPUS_INDEX_COMMIT.auto,
       beforeDatabaseMark: async () => {
         guardedMarks += 1;
@@ -748,7 +758,7 @@ describe("failed index jobs always reach the audit trail", () => {
         ),
     });
 
-    expect(indexed).toBe(1);
+    expect(outcome).toEqual({ indexed: 1, refreshed: 0, unread: 0 });
     const deleteCalls = calls
       .map(({ url, body }, index) => ({ url, body, index }))
       .filter(({ url }) => url.includes("/delete-tasks"));
@@ -805,7 +815,7 @@ describe("failed index jobs always reach the audit trail", () => {
             ]),
           ),
       }),
-    ).toBe(1);
+    ).toEqual({ indexed: 1, refreshed: 0, unread: 0 });
     expect(
       calls.filter(({ url }) => url.includes("/delete-tasks")),
     ).toHaveLength(1);
@@ -1070,7 +1080,7 @@ describe("first-ever fenced appends", () => {
       recordJobs: async () => undefined,
     });
 
-    const indexed = await indexer.backfillRows(scopedDb, [row], GENERATION, {
+    const outcome = await indexer.backfillRows(scopedDb, [row], GENERATION, {
       commit: CORPUS_INDEX_COMMIT.auto,
       beforeDatabaseMark: async () => undefined,
       beforeRemoteEffect: async ({ effect }) => await effect(),
@@ -1088,11 +1098,96 @@ describe("first-ever fenced appends", () => {
         ),
     });
 
-    expect(indexed).toBe(1);
+    expect(outcome).toEqual({ indexed: 1, refreshed: 0, unread: 0 });
     expect(calls.filter(({ url }) => url.includes("/delete-tasks"))).toEqual(
       [],
     );
     expect(calls.some(({ url }) => url.includes("/ingest"))).toBe(true);
+  });
+
+  // A caller comparing `indexed` against the rows it selected reads a lost
+  // compare-and-set as a lost update. It is neither: the refreshed row is
+  // queued for the next cycle and its unrecorded copies are deleted here.
+  // Reporting the split is what lets the caller tell the two apart, and the
+  // sum is what proves no row went unaccounted for.
+  test("a lost compare-and-set is reported as refreshed, not as a missing row", async () => {
+    globalThis.fetch = Object.assign(
+      async (input: Parameters<typeof fetch>[0]) => {
+        const url = requestUrl(input);
+        return url.includes("/ingest")
+          ? new Response(JSON.stringify({ num_docs_for_processing: 2 }), {
+              status: 200,
+            })
+          : new Response(JSON.stringify({}), { status: 200 });
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+
+    const makeRow = (id: string) => ({
+      id: toSafeId<"caseLawDecision">(id),
+      country: "CZ",
+      textS3Key: null,
+      astS3Key: null,
+      contentHash: `hash-${id}`,
+      indexedHash: null,
+      indexedGeneration: null,
+      // SAFETY: tests fabricate the branded token the adapters normally
+      // select as `updated_at::text`.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
+      projectionIndexId: corpusIndexId(GENERATION, "CZ"),
+    });
+    const settled = makeRow("dec-settled");
+    const refreshed = makeRow("dec-refreshed");
+    const scopedDb: ScopedDb = async (callback) =>
+      // SAFETY: this test's adapter ignores the transaction.
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the fake transaction is deliberately inert
+      await callback({} as Transaction);
+    const indexer = createCorpusIndexer<"caseLawDecision", typeof settled>({
+      family: "case_law",
+      captureStep: "test",
+      granularity: "document",
+      generationProjectionIndexIds: (selected) => [selected.projectionIndexId],
+      buildDocs: (selected) => [{ document_id: selected.id, text: "body" }],
+      readCorpusText: async () => "body",
+      selectMissing: async () => [],
+      selectStale: async () => [],
+      fetchFulltext: async () => "body",
+      // The refreshed row's mark loses: another writer bumped it between
+      // selection and this transaction.
+      markIndexedBatch: async () => new Set([settled.id]),
+      insertSucceededJobs: async () => undefined,
+      recordJobs: async () => undefined,
+    });
+
+    const outcome = await indexer.backfillRows(
+      scopedDb,
+      [settled, refreshed],
+      GENERATION,
+      {
+        commit: CORPUS_INDEX_COMMIT.auto,
+        beforeDatabaseMark: async () => undefined,
+        beforeRemoteEffect: async ({ effect }) => await effect(),
+        recoverRemoteEffectLeaseLoss: async () => await Promise.resolve(),
+        reserveExternalAppend: async (
+          _tx,
+          { generation, rows: reservedRows },
+        ) =>
+          new Map(
+            reservedRows.map((selected) => [
+              selected.id,
+              {
+                indexIds: [corpusIndexId(generation, selected.country)],
+                revision: 1,
+                mayHaveCopy: false,
+              },
+            ]),
+          ),
+      },
+    );
+
+    expect(outcome).toEqual({ indexed: 1, refreshed: 1, unread: 0 });
+    expect(outcome.indexed + outcome.refreshed + outcome.unread).toBe(2);
   });
 });
 
@@ -1196,7 +1291,7 @@ describe("delete-task amplification", () => {
       recordJobs: async () => undefined,
     });
 
-    const indexed = await indexer.backfillRows(scopedDb, rows, GENERATION, {
+    const { indexed } = await indexer.backfillRows(scopedDb, rows, GENERATION, {
       commit: CORPUS_INDEX_COMMIT.auto,
       beforeDatabaseMark: async () => undefined,
       beforeRemoteEffect: async ({ effect }) => await effect(),

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
+import type { SafeId } from "@/api/lib/branded-types";
 import { toSafeId } from "@/api/lib/branded-types";
 import type {
   CorpusJobInput,
@@ -1105,70 +1106,119 @@ describe("first-ever fenced appends", () => {
     expect(calls.some(({ url }) => url.includes("/ingest"))).toBe(true);
   });
 
+  // Reports back exactly as many documents as the request carried, so a test
+  // that varies how many rows survive to the ingest does not also have to
+  // restate the count the engine is expected to accept.
+  const acceptEveryIngest = async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ) => {
+    if (!requestUrl(input).includes("/ingest")) {
+      return new Response(JSON.stringify({}), { status: 200 });
+    }
+    const body = typeof init?.body === "string" ? init.body : "";
+    return new Response(
+      JSON.stringify({
+        num_docs_for_processing: body.split("\n").filter(Boolean).length,
+      }),
+      { status: 200 },
+    );
+  };
+
+  // Shared by the three outcome-accounting tests below. Each varies exactly
+  // one adapter behaviour, so the bucket a row lands in is the only thing
+  // that differs between them.
+  const outcomeRow = (id: string) => ({
+    id: toSafeId<"caseLawDecision">(id),
+    country: "CZ",
+    textS3Key: null,
+    astS3Key: null,
+    contentHash: `hash-${id}`,
+    indexedHash: null,
+    indexedGeneration: null,
+    // SAFETY: tests fabricate the branded token the adapters normally
+    // select as `updated_at::text`.
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion
+    updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
+    projectionIndexId: corpusIndexId(GENERATION, "CZ"),
+  });
+
+  const outcomeScopedDb: ScopedDb = async (callback) =>
+    // SAFETY: these tests' adapter ignores the transaction.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the fake transaction is deliberately inert
+    await callback({} as Transaction);
+
+  const outcomeGuards = {
+    commit: CORPUS_INDEX_COMMIT.auto,
+    beforeDatabaseMark: async () => undefined,
+    beforeRemoteEffect: async <T>({ effect }: FencedRemoteEffect<T>) =>
+      await effect(),
+    recoverRemoteEffectLeaseLoss: async () => await Promise.resolve(),
+  };
+
+  const outcomeAdapterBase = {
+    family: "case_law" as const,
+    captureStep: "test",
+    // Pinned outside the overrides below: it is the adapter union's
+    // discriminator, so letting a test widen it would erase the branch.
+    granularity: "document" as const,
+    generationProjectionIndexIds: (selected: ReturnType<typeof outcomeRow>) => [
+      selected.projectionIndexId,
+    ],
+    buildDocs: (selected: ReturnType<typeof outcomeRow>) => [
+      { document_id: selected.id, text: "body" },
+    ],
+    readCorpusText: async () => "body",
+    selectMissing: async () => [],
+    selectStale: async () => [],
+    fetchFulltext: async (
+      _db: ScopedDb,
+      _id: SafeId<"caseLawDecision">,
+    ): Promise<string | null> => "body",
+    markIndexedBatch: async (
+      _tx: Transaction,
+      { rows }: { rows: readonly ReturnType<typeof outcomeRow>[] },
+    ) => new Set(rows.map((selected) => selected.id)),
+    insertSucceededJobs: async () => undefined,
+    recordJobs: async (
+      _db: ScopedDb,
+      _jobs: readonly CorpusJobInput<"caseLawDecision">[],
+      _indexId: string,
+    ): Promise<void> => undefined,
+  };
+
+  const outcomeIndexer = (
+    overrides: Partial<Omit<typeof outcomeAdapterBase, "granularity">>,
+  ) =>
+    createCorpusIndexer<"caseLawDecision", ReturnType<typeof outcomeRow>>({
+      ...outcomeAdapterBase,
+      ...overrides,
+    });
+
   // A caller comparing `indexed` against the rows it selected reads a lost
   // compare-and-set as a lost update. It is neither: the refreshed row is
   // queued for the next cycle and its unrecorded copies are deleted here.
   // Reporting the split is what lets the caller tell the two apart, and the
   // sum is what proves no row went unaccounted for.
   test("a lost compare-and-set is reported as refreshed, not as a missing row", async () => {
-    globalThis.fetch = Object.assign(
-      async (input: Parameters<typeof fetch>[0]) => {
-        const url = requestUrl(input);
-        return url.includes("/ingest")
-          ? new Response(JSON.stringify({ num_docs_for_processing: 2 }), {
-              status: 200,
-            })
-          : new Response(JSON.stringify({}), { status: 200 });
-      },
-      { preconnect: originalFetch.preconnect },
-    );
-
-    const makeRow = (id: string) => ({
-      id: toSafeId<"caseLawDecision">(id),
-      country: "CZ",
-      textS3Key: null,
-      astS3Key: null,
-      contentHash: `hash-${id}`,
-      indexedHash: null,
-      indexedGeneration: null,
-      // SAFETY: tests fabricate the branded token the adapters normally
-      // select as `updated_at::text`.
-      // eslint-disable-next-line typescript/no-unsafe-type-assertion
-      updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
-      projectionIndexId: corpusIndexId(GENERATION, "CZ"),
+    globalThis.fetch = Object.assign(acceptEveryIngest, {
+      preconnect: originalFetch.preconnect,
     });
-    const settled = makeRow("dec-settled");
-    const refreshed = makeRow("dec-refreshed");
-    const scopedDb: ScopedDb = async (callback) =>
-      // SAFETY: this test's adapter ignores the transaction.
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the fake transaction is deliberately inert
-      await callback({} as Transaction);
-    const indexer = createCorpusIndexer<"caseLawDecision", typeof settled>({
-      family: "case_law",
-      captureStep: "test",
-      granularity: "document",
-      generationProjectionIndexIds: (selected) => [selected.projectionIndexId],
-      buildDocs: (selected) => [{ document_id: selected.id, text: "body" }],
-      readCorpusText: async () => "body",
-      selectMissing: async () => [],
-      selectStale: async () => [],
-      fetchFulltext: async () => "body",
+
+    const settled = outcomeRow("dec-settled");
+    const refreshed = outcomeRow("dec-refreshed");
+    const indexer = outcomeIndexer({
       // The refreshed row's mark loses: another writer bumped it between
       // selection and this transaction.
       markIndexedBatch: async () => new Set([settled.id]),
-      insertSucceededJobs: async () => undefined,
-      recordJobs: async () => undefined,
     });
 
     const outcome = await indexer.backfillRows(
-      scopedDb,
+      outcomeScopedDb,
       [settled, refreshed],
       GENERATION,
       {
-        commit: CORPUS_INDEX_COMMIT.auto,
-        beforeDatabaseMark: async () => undefined,
-        beforeRemoteEffect: async ({ effect }) => await effect(),
-        recoverRemoteEffectLeaseLoss: async () => await Promise.resolve(),
+        ...outcomeGuards,
         reserveExternalAppend: async (
           _tx,
           { generation, rows: reservedRows },
@@ -1188,6 +1238,105 @@ describe("first-ever fenced appends", () => {
 
     expect(outcome).toEqual({ indexed: 1, refreshed: 1, unread: 0 });
     expect(outcome.indexed + outcome.refreshed + outcome.unread).toBe(2);
+  });
+
+  // The reservation is the earlier of the two places a concurrent refresh can
+  // take a row out of the batch, and it drops the row before the external
+  // append rather than after it. It lands in the same bucket, so the two sites
+  // are covered separately or one of them can stop counting unnoticed.
+  test("a row the append reservation drops is reported as refreshed", async () => {
+    globalThis.fetch = Object.assign(acceptEveryIngest, {
+      preconnect: originalFetch.preconnect,
+    });
+
+    const reserved = outcomeRow("dec-reserved");
+    const dropped = outcomeRow("dec-dropped");
+    const indexer = outcomeIndexer({
+      markIndexedBatch: async (_tx, { rows: markedRows }) =>
+        new Set(markedRows.map((selected) => selected.id)),
+    });
+
+    const outcome = await indexer.backfillRows(
+      outcomeScopedDb,
+      [reserved, dropped],
+      GENERATION,
+      {
+        ...outcomeGuards,
+        // Only one of the two rows gets an epoch: the other moved after the
+        // batch read, so its old payload must not cross the append boundary.
+        reserveExternalAppend: async (_tx, { generation }) =>
+          new Map([
+            [
+              reserved.id,
+              {
+                indexIds: [corpusIndexId(generation, reserved.country)],
+                revision: 1,
+                mayHaveCopy: false,
+              },
+            ],
+          ]),
+      },
+    );
+
+    expect(outcome).toEqual({ indexed: 1, refreshed: 1, unread: 0 });
+    expect(outcome.indexed + outcome.refreshed + outcome.unread).toBe(2);
+  });
+
+  // An unreadable corpus object is the one shortfall that is a real failure.
+  // It is already recorded as a failed job, so it must be reported apart from
+  // a refresh: the two want opposite responses from whoever reads the count.
+  test("a row whose corpus text cannot be read is reported as unread", async () => {
+    globalThis.fetch = Object.assign(acceptEveryIngest, {
+      preconnect: originalFetch.preconnect,
+    });
+
+    const readable = outcomeRow("dec-readable");
+    const unreadable = outcomeRow("dec-unreadable");
+    const recorded: CorpusJobInput<"caseLawDecision">[] = [];
+    const indexer = outcomeIndexer({
+      fetchFulltext: async (_db, id) => {
+        if (id === unreadable.id) {
+          throw new Error("corpus object unavailable");
+        }
+        return "body";
+      },
+      markIndexedBatch: async (_tx, { rows: markedRows }) =>
+        new Set(markedRows.map((selected) => selected.id)),
+      recordJobs: async (_db, jobs) => {
+        recorded.push(...jobs);
+      },
+    });
+
+    const outcome = await indexer.backfillRows(
+      outcomeScopedDb,
+      [readable, unreadable],
+      GENERATION,
+      {
+        ...outcomeGuards,
+        reserveExternalAppend: async (
+          _tx,
+          { generation, rows: reservedRows },
+        ) =>
+          new Map(
+            reservedRows.map((selected) => [
+              selected.id,
+              {
+                indexIds: [corpusIndexId(generation, selected.country)],
+                revision: 1,
+                mayHaveCopy: false,
+              },
+            ]),
+          ),
+      },
+    );
+
+    expect(outcome).toEqual({ indexed: 1, refreshed: 0, unread: 1 });
+    expect(outcome.indexed + outcome.refreshed + outcome.unread).toBe(2);
+    // The audit row is what makes an unread shortfall actionable; without it
+    // the row would be invisible rather than merely uncounted.
+    expect(recorded).toMatchObject([
+      { entityId: unreadable.id, operation: "index", status: "failed" },
+    ]);
   });
 });
 

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -54,6 +54,29 @@ export type FencedBackfillBatchResult =
         | typeof FENCED_BACKFILL_BATCH_STATUS.RETRY;
     };
 
+/**
+ * What became of every row handed to one backfill call.
+ *
+ * A batch can settle fewer rows than it selected without anything having
+ * failed: a row whose compare-and-set lost to a concurrent refresh is left
+ * for a later cycle, and a row whose corpus text could not be read is
+ * recorded as a failed job. Both are deferrals, not lost updates, so the
+ * indexed count alone cannot tell a caller whether its selection was fully
+ * accounted for. Reporting the split makes that readable — and makes the
+ * accounting itself checkable, because `indexed + refreshed + unread` is
+ * always the number of rows passed in.
+ */
+export type CorpusBackfillOutcome = {
+  indexed: number;
+  /**
+   * Moved by a concurrent refresh, at the append reservation or at the mark;
+   * left in the pending set for a later cycle.
+   */
+  refreshed: number;
+  /** Corpus text could not be read; recorded as a failed job. */
+  unread: number;
+};
+
 const corpusIndexErrorFromThrown = (error: unknown): CorpusIndexError =>
   error instanceof CorpusIndexError
     ? error
@@ -1047,7 +1070,7 @@ export const createCorpusIndexer = <
       return { indexed: 0, status: FENCED_BACKFILL_BATCH_STATUS.COMPLETE };
     }
 
-    const indexed = await backfillSelectedRows(
+    const { indexed } = await backfillSelectedRows(
       scopedDb,
       rows,
       generation,
@@ -1064,11 +1087,13 @@ export const createCorpusIndexer = <
     generation: string,
     options: { readConcurrency?: number } = {},
   ): Promise<number> => {
-    const result = await backfillWithOptions(scopedDb, batchSize, generation, {
-      ...options,
-      type: "incremental",
-    });
-    return result.indexed;
+    const { indexed } = await backfillWithOptions(
+      scopedDb,
+      batchSize,
+      generation,
+      { ...options, type: "incremental" },
+    );
+    return indexed;
   };
 
   const backfillFenced = async (
@@ -1087,9 +1112,9 @@ export const createCorpusIndexer = <
     rows: TRow[],
     generation: string,
     options: BackfillSelectedRowsOptions<TBrand, TRow>,
-  ): Promise<number> => {
+  ): Promise<CorpusBackfillOutcome> => {
     if (rows.length === 0) {
-      return 0;
+      return { indexed: 0, refreshed: 0, unread: 0 };
     }
 
     // Load text (S3) with bounded concurrency, then ingest one NDJSON batch.
@@ -1125,6 +1150,7 @@ export const createCorpusIndexer = <
 
     const now = new Date();
     let indexed = 0;
+    let refreshed = 0;
     let firstError: CorpusIndexError | null = null;
 
     const reserveAndEnsureGroup = async (
@@ -1178,6 +1204,10 @@ export const createCorpusIndexer = <
         // oxlint-disable-next-line no-await-in-loop -- each jurisdiction reserves and ensures its durable target immediately before sequential remote writes
         const reservation = await reserveAndEnsureGroup(indexId, group);
         const { ensured, reservedGroup, reservedTargets } = reservation;
+        // A row the reservation dropped was moved by a concurrent refresh
+        // before this batch reached the append boundary — the same deferral
+        // the mark's compare-and-set reports below, just caught earlier.
+        refreshed += group.length - reservedGroup.length;
         if (ensured === null) {
           continue;
         }
@@ -1407,6 +1437,7 @@ export const createCorpusIndexer = <
             }
           }
           indexed += entries.length - casMissed.size;
+          refreshed += casMissed.size;
         }
       } finally {
         // Always lands, including when the code above threw. The audit
@@ -1426,7 +1457,14 @@ export const createCorpusIndexer = <
       throw firstError;
     }
 
-    return indexed;
+    // Reached only when every group was attempted, so the three counters
+    // partition the selection. Anything else is an accounting bug in this
+    // function, not a condition a caller could act on.
+    const unread = readFailures.length;
+    if (indexed + refreshed + unread !== rows.length) {
+      panic("corpus backfill outcome does not account for every selected row");
+    }
+    return { indexed, refreshed, unread };
   };
 
   const backfillRows = async (
@@ -1434,7 +1472,7 @@ export const createCorpusIndexer = <
     rows: readonly TRow[],
     generation: string,
     options: GenerationRebuildBackfillOptions<TBrand, TRow>,
-  ): Promise<number> =>
+  ): Promise<CorpusBackfillOutcome> =>
     await backfillSelectedRows(scopedDb, [...rows], generation, {
       ...options,
       type: "generation-rebuild",


### PR DESCRIPTION
## Proposed change

`backfillSelectedRows` (`apps/api/src/lib/corpus-index/core.ts`) returned only the number of rows it indexed. Three kinds of row leave a batch settled by something other than an index write, none of which is an error and none of which was counted:

- the append reservation lost its compare-and-set, so the row was filtered out of the group before the external append (`reserveAndEnsureGroup`);
- the mark lost the same race, so the row landed in `casMissed` and its unrecorded copies were deleted again;
- the corpus text could not be read, so the row never entered `built` and was recorded as a failed job by `recordReadFailures`.

The first two leave the row in the pending set for a later cycle; the third is already in the audit trail. The function's own comments say as much ("the refreshed row is re-indexed by a later cycle").

Every caller of `backfillRows` in `apps/api/src/handlers/case-law/corpus-index.ts` compares the returned count against the rows it selected and throws `... did not reach a fixed point` when they differ — at the source-eligibility page, at the pending drain, and at the snapshot page. With only the indexed count in hand, that error cannot say whether a row was deferred or genuinely lost, and the three reasons need different answers: a refreshed row wants nothing, an unreadable object wants investigating, and a shortfall neither accounts for is a real lost update.

The count is also the only thing that reaches a log sink; the reasons currently reach analytics or nothing at all, so a shortfall is unactionable from the log alone.

This returns the split instead. `CorpusBackfillOutcome` is `{ indexed, refreshed, unread }`, the sum is checked against the rows passed in (a `panic`, since anything else is an accounting bug in that function rather than a condition a caller could act on), and the three call sites carry the breakdown into the error they raise.

**Control flow is unchanged.** A page that indexed fewer rows than it selected still throws; it now says why. Whether the equality check should tolerate a refreshed row is a separate question, and this change is what produces the evidence to answer it.

## Testing

- `bun test src/lib/corpus-index/core.test.ts` — 28/28 pass, including a new case where the mark grants one row of two and the outcome reports `{ indexed: 1, refreshed: 1, unread: 0 }`.
- Mutation-checked: reverting the `refreshed` counter to `+= 0` fails that new test and only that test.
- `tsc --noEmit -p apps/api/tsconfig.json` clean; type-aware `oxlint` clean on the four touched files; `oxfmt` clean.
- The `.db.test.ts` fakes were updated to the new return shape and are covered by the typecheck above, but the Postgres-backed suites were not run locally.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeF9BKbT9EB5TdSNoLUpvZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of case-law indexing when records are updated concurrently.
  - Ensured indexing results accurately account for processed, refreshed and unreadable records.
  - Added clearer error details when an indexing batch cannot process all selected records.
  - Improved handling of temporary read or update failures so indexing status remains accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->