### PR TITLE
fix: show OCR actions across matter views

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -119,6 +119,7 @@ import {
   getDesktopEditLockState,
   getOcrExportFileName,
   getOcrExportFormats,
+  getOcrSources,
   getPdfDownloadFileName,
   hasOcrExport,
   type OcrExportFormat,
@@ -132,12 +133,9 @@ export type VirtualAnchor = {
   getBoundingClientRect: () => DOMRect;
 };
 
-const EMPTY_OCR_SOURCES: readonly OcrSource[] = [];
-
 type RowActionsProps = {
   entity: WorkspaceEntity;
   ocrSource?: OcrSource | undefined;
-  ocrSources?: readonly OcrSource[] | undefined;
   workspaceId: string;
   open?: boolean | undefined;
   onOpenChange?: ((open: boolean) => void) | undefined;
@@ -207,7 +205,6 @@ export const RowActions = ({
   getAncestorIds,
   cellMetadataTarget,
   ocrSource,
-  ocrSources = EMPTY_OCR_SOURCES,
 }: RowActionsProps) => {
   const t = useTranslations();
   const analytics = useAnalytics();
@@ -232,6 +229,7 @@ export const RowActions = ({
   const bulkTargets = isBulk ? selectedEntities : [entity];
   const isCellContext =
     !isBulk && cellMetadataTarget !== null && cellMetadataTarget !== undefined;
+  const ocrSources = getOcrSources(entity.fields);
   let rowActionContext: RowActionContext = "row";
   if (isBulk) {
     rowActionContext = "bulk";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table/row-cells.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table/row-cells.tsx
@@ -43,10 +43,7 @@ import type { PropertyId } from "@/lib/types";
 import { ENTITY_DRAG_TYPE } from "@/lib/workspaces/drag-constants";
 import { RowActions } from "@/routes/_protected.workspaces/$workspaceId/-components/row-actions";
 import type { VirtualAnchor } from "@/routes/_protected.workspaces/$workspaceId/-components/row-actions";
-import {
-  getOcrSource,
-  getOcrSources,
-} from "@/routes/_protected.workspaces/$workspaceId/-components/row-actions.logic";
+import { getOcrSource } from "@/routes/_protected.workspaces/$workspaceId/-components/row-actions.logic";
 import {
   WorkspaceGridCell,
   WorkspaceGridRow,
@@ -349,7 +346,6 @@ export const DraggableRow = ({
           propertyId: contextPropertyId,
         }) ?? undefined
       }
-      ocrSources={getOcrSources(entity.fields)}
       onOpenChange={(open) => {
         if (open) {
           setBulkEntities(getBulkSelectedEntities());


### PR DESCRIPTION
## Summary

- derive OCR source candidates inside the shared row-actions menu
- expose OCR queue and export actions consistently wherever that menu is used
- remove per-view OCR source plumbing so new views cannot omit the capability

CC on behalf of jan-kubica