### PR TITLE
feat(api): court tag, timestamp field and merge policy

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.test.ts
@@ -9,15 +9,25 @@ import { toSafeId } from "@/api/lib/branded-types";
 import { corpusDocumentDeleteQuery } from "@/api/lib/corpus-index/core";
 import type { TimestampCasToken } from "@/api/lib/db/timestamp-cas";
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
+import {
+  DECISION_TIMESTAMP_FIELD,
+  UNDATED_DECISION_TIMESTAMP,
+} from "@/api/lib/legal-search/corpus-index-config";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 
 type MakeRowOptions = {
   id: string;
   contentHash: string;
   textS3Key?: string | null;
+  decisionDate?: string | null;
 };
 
-const makeRow = ({ id, contentHash, textS3Key }: MakeRowOptions) => ({
+const makeRow = ({
+  id,
+  contentHash,
+  textS3Key,
+  decisionDate = "2024-01-01",
+}: MakeRowOptions) => ({
   id: toSafeId<"caseLawDecision">(id),
   sourceId: toSafeId<"caseLawSource">("src_1"),
   caseNumber: `case-${id}`,
@@ -25,7 +35,7 @@ const makeRow = ({ id, contentHash, textS3Key }: MakeRowOptions) => ({
   court: "Test Court",
   country: "CZ",
   language: "cs",
-  decisionDate: "2024-01-01",
+  decisionDate,
   decisionType: null,
   citationAuthority: 0,
   citationCount: 0,
@@ -260,6 +270,45 @@ describe("case-law passage projection", () => {
     expect(
       docs.filter((doc) => String(doc["text"]).includes("Odůvodnění")),
     ).toHaveLength(1);
+  });
+
+  test("every passage carries the timestamp field, dated decision or not", async () => {
+    const dated = makeRow({ id: "dec_dated", contentHash: "hash_dated" });
+    const undated = makeRow({
+      id: "dec_undated",
+      contentHash: "hash_undated",
+      decisionDate: null,
+    });
+
+    const { built } = await loadDocsForBatch([dated, undated], {
+      generation: "case_law_v2",
+      fetchFulltext: async () => null,
+      readPayload: async () => ({
+        text: `${"slovo ".repeat(400)}\n\n${"jinak ".repeat(400)}`,
+        ast: {},
+      }),
+    });
+
+    const docsOf = (id: string) =>
+      built.find((entry) => entry.row.id === id)?.docs ?? [];
+    expect(docsOf(dated.id).length).toBeGreaterThan(1);
+    expect(docsOf(undated.id).length).toBeGreaterThan(1);
+
+    // The engine rejects a document missing the timestamp field, and a
+    // decision is split across passages, so "every document" means every
+    // passage of every row — not one per decision.
+    for (const doc of docsOf(dated.id)) {
+      expect(doc[DECISION_TIMESTAMP_FIELD]).toBe("2024-01-01");
+      expect(doc["decision_date"]).toBe("2024-01-01");
+    }
+    for (const doc of docsOf(undated.id)) {
+      expect(doc[DECISION_TIMESTAMP_FIELD]).toBe(UNDATED_DECISION_TIMESTAMP);
+      // The sentinel stands in for the timestamp field alone. What the court
+      // published is still nothing, so the fields the reader and the year
+      // facet show stay absent rather than claiming a date of 1800.
+      expect(doc["decision_date"]).toBeUndefined();
+      expect(doc["year"]).toBeUndefined();
+    }
   });
 
   test("a row with no usable AST still emits passages, unanchored", async () => {

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -52,6 +52,10 @@ import {
 } from "@/api/lib/legal-search/corpus-index-client";
 import type { CorpusIndexCommitMode } from "@/api/lib/legal-search/corpus-index-client";
 import {
+  DECISION_TIMESTAMP_FIELD,
+  UNDATED_DECISION_TIMESTAMP,
+} from "@/api/lib/legal-search/corpus-index-config";
+import {
   isRedistributable,
   type CorpusSourceDescriptor,
 } from "@/api/lib/legal-search/corpus-source";
@@ -588,6 +592,13 @@ const buildSharedFields = (row: IndexableRow): Record<string, unknown> => {
   if (row.decisionType !== null) {
     doc["document_type"] = row.decisionType;
   }
+  // The index's timestamp field, written on every document because the engine
+  // requires it on every document: a decision the source published without a
+  // date is still indexed, standing in at the sentinel. `decision_date` and
+  // `year` stay absent for it, so display and the year facet keep telling the
+  // truth about what the court published.
+  doc[DECISION_TIMESTAMP_FIELD] =
+    row.decisionDate ?? UNDATED_DECISION_TIMESTAMP;
   if (row.decisionDate !== null) {
     doc["decision_date"] = row.decisionDate;
     doc["year"] = Number(row.decisionDate.slice(0, 4));

--- a/apps/api/src/lib/legal-search/corpus-index-config.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.test.ts
@@ -32,10 +32,17 @@ test("jurisdiction/document_type/source/court are tag fields for split pruning",
 });
 
 /**
- * The courts one jurisdiction's index can name, bounded by the court system
- * each source draws from. Deliberately upper bounds rather than observed
- * counts: the corpus grows toward its sources, and the question a tag field
- * asks is what the domain can hold, not what it holds today.
+ * The courts one jurisdiction's index may name, declared per jurisdiction
+ * against the court system its sources draw from. Upper bounds rather than
+ * observed counts: the corpus grows toward its sources, and what a tag field
+ * has to survive is what the domain can hold, not what it holds today.
+ *
+ * This is the decision, not the measurement. The other side is a court
+ * registry in a foreign jurisdiction, which nothing here can bind at compile
+ * time, so the value of the table is that the bound is written down per
+ * jurisdiction and cannot be inherited silently by the next one. Observing the
+ * live distinct-value count belongs to the generation that carries the tag,
+ * where it can be read off the index itself.
  *
  * - AUT: RIS publishes for OGH, VwGH and VfGH, 4 Oberlandesgerichte, the
  *   Landesgerichte, and the Bezirksgerichte.

--- a/apps/api/src/lib/legal-search/corpus-index-config.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.test.ts
@@ -3,7 +3,13 @@ import { expect, test } from "bun:test";
 import {
   caseLawIndexConfig,
   corpusIndexConfig,
+  DECISION_TIMESTAMP_FIELD,
+  TAG_FIELD_VALUE_LIMIT,
 } from "@/api/lib/legal-search/corpus-index-config";
+import {
+  CASE_LAW_JURISDICTIONS,
+  type CaseLawJurisdiction,
+} from "@/api/lib/legal-search/ingestion-constants";
 
 test("searchable text fields enable fieldnorms so BM25 scoring works", () => {
   const fields = new Map(
@@ -16,12 +22,62 @@ test("searchable text fields enable fieldnorms so BM25 scoring works", () => {
   expect(fields.get("title")?.fieldnorms).toBe(true);
 });
 
-test("jurisdiction/document_type/source are tag fields for split pruning", () => {
+test("jurisdiction/document_type/source/court are tag fields for split pruning", () => {
   expect(caseLawIndexConfig("case_law_v1").doc_mapping.tag_fields).toEqual([
     "jurisdiction",
     "document_type",
     "source",
+    "court",
   ]);
+});
+
+/**
+ * The courts one jurisdiction's index can name, bounded by the court system
+ * each source draws from. Deliberately upper bounds rather than observed
+ * counts: the corpus grows toward its sources, and the question a tag field
+ * asks is what the domain can hold, not what it holds today.
+ *
+ * - AUT: RIS publishes for OGH, VwGH and VfGH, 4 Oberlandesgerichte, the
+ *   Landesgerichte, and the Bezirksgerichte.
+ * - CZE: Ústavní soud, NS, NSS, 2 vrchní, 8 krajské (Městský soud v Praze
+ *   among them), and the okresní courts.
+ * - EU: Court of Justice, General Court, and the dissolved Civil Service
+ *   Tribunal.
+ * - POL: the SAOS `commonCourts` registry the adapter takes court names from
+ *   enumerates 374 (318 rejonowy, 45 okręgowy, 11 apelacyjny), plus Sąd
+ *   Najwyższy, NSA, Trybunał Konstytucyjny and the voivodeship
+ *   administrative courts.
+ * - SVK: Ústavný súd, NS, NSS, the krajské courts, and the okresné courts.
+ */
+const COURT_DOMAIN_BOUND = {
+  AUT: 200,
+  CZE: 200,
+  EU: 10,
+  POL: 400,
+  SVK: 200,
+} as const satisfies Record<CaseLawJurisdiction, number>;
+
+// A tag field whose values outgrow the engine's per-split limit stops being
+// recorded, and the only symptom is that every query opens every split. Court
+// is the one tag field whose domain is neither a short closed list
+// (document_type, status) nor an operator-curated catalogue (source,
+// jurisdiction), so it is the one that has to be argued.
+test("court stays a viable tag field in every jurisdiction's index", () => {
+  // Indexes are per generation and jurisdiction, so a split holds one
+  // country's courts. A bound at half the limit leaves room for court renames
+  // and reorganizations, which add values without retiring the old ones.
+  for (const bound of Object.values(COURT_DOMAIN_BOUND)) {
+    expect(bound).toBeLessThan(TAG_FIELD_VALUE_LIMIT / 2);
+  }
+
+  // Total over the jurisdictions the corpus ships, so onboarding one is a
+  // decision about its court registry rather than a silent inheritance.
+  expect(Object.keys(COURT_DOMAIN_BOUND).sort()).toEqual([
+    ...CASE_LAW_JURISDICTIONS,
+  ]);
+  expect(
+    caseLawIndexConfig("case_law_v3_pol").doc_mapping.tag_fields,
+  ).toContain("court");
 });
 
 test("index_id is the generation; citation_authority is a fast f64", () => {
@@ -125,6 +181,73 @@ test("every full-text field uses a declared tokenizer, and every declared one is
     for (const field of fullText) {
       expect(field.tokenizer).toBe("folded");
     }
+  }
+});
+
+// Same reason the tokenizer block is pinned: the engine never diffs an
+// existing index, so this shape is only ever read at creation time, and the
+// block a reviewer sees is the block the engine is asked to accept.
+test("the merge policy is declared whole, verbatim", () => {
+  for (const family of ["case_law", "legislation"] as const) {
+    expect(
+      corpusIndexConfig(family, `${family}_v3_cze`).indexing_settings,
+    ).toEqual({
+      merge_policy: {
+        type: "stable_log",
+        maturation_period: "7days",
+        merge_factor: 10,
+        max_merge_factor: 12,
+        min_level_num_docs: 100_000,
+      },
+    });
+  }
+});
+
+test("case law names decision_date_ts as its timestamp field, mapped verbatim", () => {
+  const config = caseLawIndexConfig("case_law_v3_cze");
+  expect(config.doc_mapping.timestamp_field).toBe(DECISION_TIMESTAMP_FIELD);
+  expect(
+    config.doc_mapping.field_mappings.find(
+      (f) => f.name === DECISION_TIMESTAMP_FIELD,
+    ),
+  ).toEqual({
+    name: "decision_date_ts",
+    type: "datetime",
+    fast: true,
+    fast_precision: "seconds",
+    input_formats: ["%Y-%m-%d", "rfc3339", "unix_timestamp"],
+  });
+
+  // The field it stands in for keeps its own mapping: nullable, so it is
+  // absent from an undated decision's document, and never the timestamp field.
+  const decisionDate = config.doc_mapping.field_mappings.find(
+    (f) => f.name === "decision_date",
+  );
+  expect(decisionDate?.type).toBe("datetime");
+  expect(decisionDate?.fast).toBe(true);
+});
+
+// The engine rejects an index whose timestamp field it cannot find in the doc
+// mapping, and rejects a document that omits the field. A family therefore
+// either maps a field every one of its documents carries, or declares none.
+test("a declared timestamp field is a mapped fast datetime; a family without one declares none", () => {
+  const declared = new Map(
+    (["case_law", "legislation"] as const).map((family) => [
+      family,
+      corpusIndexConfig(family, `${family}_v3_cze`).doc_mapping,
+    ]),
+  );
+
+  expect(declared.get("legislation")?.timestamp_field).toBeUndefined();
+
+  for (const mapping of declared.values()) {
+    const { timestamp_field: timestampField } = mapping;
+    if (timestampField === undefined) {
+      continue;
+    }
+    const field = mapping.field_mappings.find((f) => f.name === timestampField);
+    expect(field?.type).toBe("datetime");
+    expect(field?.fast).toBe(true);
   }
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -204,8 +204,15 @@ export const DECISION_TIMESTAMP_FIELD = "decision_date_ts";
  * Far enough before any decision the corpus can hold that it cannot collide
  * with a real one, and readable as what it is in a raw document. A timestamp
  * range query therefore never returns an undated decision unless it asks for a
- * window this old, and split pruning still works: a split of undated documents
- * has a min/max nowhere near a real query window.
+ * window this old, which is the property that matters: the field decides what
+ * a date filter matches.
+ *
+ * It does not, on its own, make split pruning tight. A split's timestamp range
+ * spans everything written into it, and the generation walk writes in
+ * `(created_at, id)` order, so a split already mixes decisions from across the
+ * corpus' date range; one undated row widens its low end to here. Pruning
+ * tightens only for a generation whose splits are built date-contiguous, which
+ * is a property of the backfill's walk order rather than of this constant.
  */
 export const UNDATED_DECISION_TIMESTAMP = "1800-01-01";
 

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -10,11 +10,11 @@ import type { CorpusFamily } from "@/api/lib/legal-search/corpus-family";
  *   (corpus index disables BM25 by default for latency).
  * - full-text fields use the custom `folded` tokenizer so a query typed
  *   without diacritics reaches text that carries them.
- * - jurisdiction / document_type / source (+ status for legislation) are
- *   `tag_fields` so queries prune irrelevant splits.
- * - date fields are fast datetime for range filtering, not the
- *   timestamp_field (dates can be null; a timestamp_field must be present
- *   on every doc).
+ * - jurisdiction / document_type / source (+ court for case law, status for
+ *   legislation) are `tag_fields` so queries prune irrelevant splits.
+ * - a family's own date field stays nullable, fast, and range-filterable, and
+ *   is never the timestamp_field. Case law carries a second, always-present
+ *   `decision_date_ts` for that role.
  */
 
 type CorpusIndexFieldType =
@@ -61,9 +61,32 @@ type CorpusIndexFieldMapping = {
   record?: "basic" | "freq" | "position";
   fieldnorms?: boolean;
   fast?: boolean;
+  /** Fast-field resolution for a datetime; coarser truncates harder. */
+  fast_precision?: "seconds" | "milliseconds" | "microseconds" | "nanoseconds";
   stored?: boolean;
   input_formats?: string[];
 };
+
+/**
+ * Split merging. The engine's default `stable_log` policy matures a split
+ * after one day, and a matured split is never merged again: a backfill that
+ * writes for longer than that leaves its early splits frozen small and
+ * numerous. That is a query-time cost, not a storage one — a cold query pays
+ * one object-store round trip per split it cannot prune, so split count
+ * multiplies cold latency for as long as the generation lives.
+ *
+ * The period is therefore set past the length of a full-corpus backfill, so
+ * splits written during one still consolidate before they mature. The rest are
+ * the engine's defaults, restated: a merge policy declared by halves is harder
+ * to reason about than one declared whole.
+ */
+const MERGE_POLICY = {
+  type: "stable_log",
+  maturation_period: "7days",
+  merge_factor: 10,
+  max_merge_factor: 12,
+  min_level_num_docs: 100_000,
+} as const;
 
 export type CorpusIndexConfig = {
   version: string;
@@ -73,7 +96,16 @@ export type CorpusIndexConfig = {
     field_mappings: CorpusIndexFieldMapping[];
     tokenizers: readonly CorpusIndexTokenizer[];
     tag_fields: string[];
+    /**
+     * Present only for a family that maps an always-present datetime. The
+     * engine stores its min/max per split and prunes on it, and it is what
+     * `start_timestamp` / `end_timestamp` search parameters address.
+     */
+    timestamp_field?: string;
     store_source: boolean;
+  };
+  indexing_settings: {
+    merge_policy: typeof MERGE_POLICY;
   };
   search_settings: {
     default_search_fields: string[];
@@ -153,6 +185,30 @@ const CORE_FIELDS: CorpusIndexFieldMapping[] = [
   },
 ];
 
+/**
+ * The timestamp field for case law, and the reason `decision_date` cannot be
+ * it: a decision whose date the source never published still has to be
+ * indexed, and the engine requires the timestamp field on every document it
+ * accepts. `decision_date` therefore stays nullable and keeps answering for
+ * display and range filters, while this field is written unconditionally,
+ * standing in for the missing date with `UNDATED_DECISION_TIMESTAMP`.
+ *
+ * Seconds precision because the source data is a calendar date. A finer fast
+ * field would spend bits encoding zeros.
+ */
+export const DECISION_TIMESTAMP_FIELD = "decision_date_ts";
+
+/**
+ * What `decision_date_ts` carries when the decision has no published date.
+ *
+ * Far enough before any decision the corpus can hold that it cannot collide
+ * with a real one, and readable as what it is in a raw document. A timestamp
+ * range query therefore never returns an undated decision unless it asks for a
+ * window this old, and split pruning still works: a split of undated documents
+ * has a min/max nowhere near a real query window.
+ */
+export const UNDATED_DECISION_TIMESTAMP = "1800-01-01";
+
 const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
   case_law: [
     { name: "court", type: "text", tokenizer: "raw", fast: true },
@@ -160,6 +216,13 @@ const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
       name: "decision_date",
       type: "datetime",
       fast: true,
+      input_formats: DATE_INPUT_FORMATS,
+    },
+    {
+      name: DECISION_TIMESTAMP_FIELD,
+      type: "datetime",
+      fast: true,
+      fast_precision: "seconds",
       input_formats: DATE_INPUT_FORMATS,
     },
     { name: "ecli", type: "text", tokenizer: "raw" },
@@ -178,36 +241,72 @@ const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
   ],
 };
 
+/**
+ * Distinct values a split may hold for a tag field before the engine stops
+ * recording that field's values in the split's metadata.
+ *
+ * Crossing it costs pruning, not correctness: a split whose tag values were
+ * dropped is opened by every query instead of only the matching ones. Silent,
+ * and visible only as latency, which is why a field joins `tag_fields` on an
+ * argument about its value domain rather than on hope. `court` per
+ * jurisdiction is the case the corpus-index config test states.
+ */
+export const TAG_FIELD_VALUE_LIMIT = 1000;
+
+/**
+ * Fields whose values a split records so a query can skip splits that cannot
+ * match. Every one of them is a filter the browse and search paths apply, and
+ * every one has a value domain bounded well under `TAG_FIELD_VALUE_LIMIT`
+ * within a single index (indexes are per jurisdiction, so `court` is bounded
+ * by one country's court registry, not by every country's at once).
+ */
 const FAMILY_TAG_FIELDS: Record<CorpusFamily, string[]> = {
-  case_law: ["jurisdiction", "document_type", "source"],
+  case_law: ["jurisdiction", "document_type", "source", "court"],
   legislation: ["jurisdiction", "document_type", "source", "status"],
 };
+
+/**
+ * The datetime every document of a family carries, or null for a family that
+ * has none. Total so a new family has to answer the question: the engine takes
+ * the timestamp field as a promise about every document, and a family whose
+ * date is nullable can only keep that promise by mapping a second field for it
+ * (see `DECISION_TIMESTAMP_FIELD`).
+ */
+const FAMILY_TIMESTAMP_FIELD = {
+  case_law: DECISION_TIMESTAMP_FIELD,
+  legislation: null,
+} as const satisfies Record<CorpusFamily, string | null>;
 
 export const corpusIndexConfig = (
   family: CorpusFamily,
   indexId: string,
-): CorpusIndexConfig => ({
-  version: CORPUS_INDEX_CONFIG_VERSION,
-  index_id: indexId,
-  doc_mapping: {
-    mode: "lenient",
-    field_mappings: [...CORE_FIELDS, ...FAMILY_FIELDS[family]],
-    tokenizers: CUSTOM_TOKENIZERS,
-    tag_fields: FAMILY_TAG_FIELDS[family],
-    store_source: false,
-  },
-  search_settings: {
-    // The rule under a passage layout: no field that repeats across a
-    // document's passages may be a default search field. One free-text term
-    // hitting such a field lets a single document answer with as many hits as
-    // it has passages and crowd everything else out of the capped scan window.
-    // `text` is the only per-passage field here, and it is per-passage
-    // *content* — each passage matches on its own words, which is the point.
-    // Everything else document-level is raw-tokenized, numeric, or (like
-    // `title`) written to one passage only.
-    default_search_fields: ["title", "text"],
-  },
-});
+): CorpusIndexConfig => {
+  const timestampField = FAMILY_TIMESTAMP_FIELD[family];
+  return {
+    version: CORPUS_INDEX_CONFIG_VERSION,
+    index_id: indexId,
+    doc_mapping: {
+      mode: "lenient",
+      field_mappings: [...CORE_FIELDS, ...FAMILY_FIELDS[family]],
+      tokenizers: CUSTOM_TOKENIZERS,
+      tag_fields: FAMILY_TAG_FIELDS[family],
+      ...(timestampField === null ? {} : { timestamp_field: timestampField }),
+      store_source: false,
+    },
+    indexing_settings: { merge_policy: MERGE_POLICY },
+    search_settings: {
+      // The rule under a passage layout: no field that repeats across a
+      // document's passages may be a default search field. One free-text term
+      // hitting such a field lets a single document answer with as many hits
+      // as it has passages and crowd everything else out of the capped scan
+      // window. `text` is the only per-passage field here, and it is
+      // per-passage *content* — each passage matches on its own words, which
+      // is the point. Everything else document-level is raw-tokenized,
+      // numeric, or (like `title`) written to one passage only.
+      default_search_fields: ["title", "text"],
+    },
+  };
+};
 
 export const caseLawIndexConfig = (indexId: string): CorpusIndexConfig =>
   corpusIndexConfig("case_law", indexId);


### PR DESCRIPTION
Three doc-mapping and indexing decisions the next corpus-index generation needs.

## Inert until the next generation exists

`ensureIndex` creates an index only when it is absent, and never diffs or updates the config of one that already exists. Every deployed index therefore keeps the mapping it was built with, and nothing here reaches a document until a fresh generation is created and backfilled. This is the same property the diacritics-folding change relied on.

The one part that is not config is the projection writer, which now sets `decision_date_ts` on every document it builds. Existing mappings are lenient, so that field is dropped on ingest rather than rejected; verified below.

## The three riders

**`court` joins `tag_fields`.** Tag values let a query skip splits that cannot match. An index is per generation and jurisdiction, so `court`'s value domain within one index is one country's court registry, not every country's at once. The largest of them is Poland's, where the adapter takes court names from the SAOS `commonCourts` registry: 374 courts (318 rejonowy, 45 okręgowy, 11 apelacyjny), plus the Supreme Court, NSA, Constitutional Tribunal and the voivodeship administrative courts. That is an order of magnitude under the engine's per-split limit of 1000 distinct values, past which a split silently stops recording that field and every query opens it. The config test declares a per-jurisdiction bound with headroom, total over the declared jurisdiction list, so onboarding a jurisdiction is a decision about its court registry rather than a silent inheritance. That table is the decision, not a measurement: the other side is a foreign court registry, and the adapters read a court name off each decision rather than enumerating courts, so there is nothing in the repo to derive it from. Reading the live distinct-value count belongs to the generation that carries the tag, since no deployed index has the field yet.

**`decision_date_ts`, a new always-present fast datetime, becomes the doc mapping's `timestamp_field`.** The engine requires the timestamp field on every document it accepts, and a decision the source published without a date still has to be indexed. `decision_date` therefore stays nullable and keeps answering for display and the year facet, while the projection writes `decision_date_ts` unconditionally: the decision's date, or a named sentinel (`1800-01-01`) when there is none. The sentinel is far enough before any decision the corpus can hold that a real query window never reaches it, which is the property that matters: the field decides what a date filter matches. It does not make split pruning tight on its own. The generation walk is keyset-ordered by `(created_at, id)`, so a split already mixes decisions from across the corpus' date range; an undated row widens its low end to 1800 on top of that. Tight pruning waits on a backfill whose splits are date-contiguous, which is a walk-order decision and belongs with the flip, not with this field.

**`indexing_settings.merge_policy` is declared whole**, with a maturation period past the length of a full backfill. The engine's default `stable_log` policy matures a split after a day and never merges a matured split again, so a backfill that runs longer leaves its early splits frozen small and numerous. That is a query cost rather than a storage one: a cold query pays an object-store round trip per split it cannot prune, and it pays it for as long as the generation lives. The other parameters are the engine's defaults restated, because a merge policy declared by halves is harder to review than one declared whole.

## Read path

Unaffected. No query sends `start_timestamp` or `end_timestamp` today, and none can before the flip: an index without a timestamp field rejects those parameters outright. They ship with, or after, the generation that has one.

## Verification

Against a throwaway `quickwit:0.8.2` container (the deployed engine version, same digest as the compose service), driven with the config this module emits:

- index creation accepted; the engine stores `timestamp_field: decision_date_ts`, `court` among the tag fields, and the merge policy exactly as declared;
- two documents ingested, one with `decision_date` and one without, both accepted, both searchable;
- the resulting split carries `court:` tag values, and a timestamp range spanning the sentinel era;
- a search windowed on the modern era returns only the dated document; one windowed on the sentinel era returns only the undated one;
- the same two documents ingest into a mapping without `decision_date_ts` (the shape existing indexes have): accepted, the unmapped field dropped, everything else searchable; that index rejects a `start_timestamp` query with an explicit error.

Container removed afterwards.

Tests: the emitted merge policy and `decision_date_ts` mapping are pinned verbatim, the timestamp-field invariant is asserted per family in both directions, the projection is covered for a dated and an undated decision, and the tag-cardinality bound is asserted per jurisdiction. Each new assertion was mutation-checked: dropping the court tag, dropping the emitted `timestamp_field`, restoring the default maturation period, writing the timestamp field only when a date exists, and letting the sentinel leak into `decision_date` each fail the suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved case-law search support with consistent date handling, including records without a known decision date.
  - Enhanced filtering by court and decision date.
  - Added support for more reliable, precise date-based search results.

- **Bug Fixes**
  - Undated decisions now remain searchable without displaying misleading dates or years.
  - Improved consistency across case-law indexing and search configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->