### PR TITLE
fix(case-law): repair legacy decision dates no publisher could have issued

### DIFF
--- a/apps/api/src/lib/dates.ts
+++ b/apps/api/src/lib/dates.ts
@@ -82,8 +82,12 @@ const ISO_DATE_LENGTH = 10;
  * transcription or parsing artifact rather than a real date. The ceiling is
  * relative to the current year because a publisher may date a decision
  * slightly ahead; a fixed upper year would go stale.
+ *
+ * Exported because the same bounds have to hold in SQL: rows written before
+ * the guard existed are found by `repair-decision-dates-sql.ts`, which derives
+ * its predicate from this declaration rather than restating the numbers.
  */
-const DECISION_YEAR_BOUNDS = {
+export const DECISION_YEAR_BOUNDS = {
   min: 1800,
   yearsAhead: 1,
 } as const;

--- a/apps/api/src/lib/dates.ts
+++ b/apps/api/src/lib/dates.ts
@@ -84,7 +84,7 @@ const ISO_DATE_LENGTH = 10;
  * slightly ahead; a fixed upper year would go stale.
  *
  * Exported because the same bounds have to hold in SQL: rows written before
- * the guard existed are found by `repair-decision-dates-sql.ts`, which derives
+ * the guard existed are found by `repair-decision-dates-plan.ts`, which derives
  * its predicate from this declaration rather than restating the numbers.
  */
 export const DECISION_YEAR_BOUNDS = {

--- a/apps/api/src/scripts/repair-decision-dates-plan.db.test.ts
+++ b/apps/api/src/scripts/repair-decision-dates-plan.db.test.ts
@@ -7,10 +7,14 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { createSafeId } from "@/api/lib/branded-types";
 import { canonicalDecisionDate } from "@/api/lib/dates";
 import { isRecord } from "@/api/lib/type-guards";
-import type { CorruptDecisionDateRow } from "@/api/scripts/repair-decision-dates-plan";
+import type {
+  CorruptDecisionDateRow,
+  DecisionDateRowLock,
+} from "@/api/scripts/repair-decision-dates-plan";
 import {
   applyDecisionDateRepairsStatement,
   DECISION_DATE_REPAIR_OUTCOMES,
+  DECISION_DATE_ROW_LOCKS,
   decideDecisionDateRepair,
   decisionDateSourceSurveyStatement,
   decisionDateYearSurveyStatement,
@@ -200,9 +204,12 @@ const executedRows = (result: unknown): unknown[] => {
   return [];
 };
 
-const corruptRows = async (limit: number): Promise<CorruptDecisionDateRow[]> =>
+const corruptRows = async (
+  limit: number,
+  lock: DecisionDateRowLock = DECISION_DATE_ROW_LOCKS.NONE,
+): Promise<CorruptDecisionDateRow[]> =>
   executedRows(
-    await db.execute(selectCorruptDecisionDatesStatement(limit)),
+    await db.execute(selectCorruptDecisionDatesStatement({ limit, lock })),
   ).map(parseCorruptDecisionDateRow);
 
 test("the selection is exactly what the write-path guard rejects", async () => {
@@ -213,6 +220,14 @@ test("the selection is exactly what the write-path guard rejects", async () => {
   const rejected = new Set(rejectedByGuard.map(({ id }) => id));
 
   expect([...selected].toSorted()).toEqual([...rejected].toSorted());
+  // The repairing variant claims its rows before the citation-graph lock, in
+  // the ingestion pipeline's lock order. `FOR UPDATE OF d` over a join is only
+  // valid SQL against the right alias, and it must not change what is selected.
+  expect(
+    (await corruptRows(100, DECISION_DATE_ROW_LOCKS.FOR_UPDATE))
+      .map(({ id }) => id)
+      .toSorted(),
+  ).toEqual([...rejected].toSorted());
   // Guards the assertion above against a fixture set that made it vacuous.
   expect(selected.size).toBeGreaterThan(0);
   expect(selected.size).toBeLessThan(fixtures.length);

--- a/apps/api/src/scripts/repair-decision-dates-plan.db.test.ts
+++ b/apps/api/src/scripts/repair-decision-dates-plan.db.test.ts
@@ -1,0 +1,342 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { inArray } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+import { createSafeId } from "@/api/lib/branded-types";
+import { canonicalDecisionDate } from "@/api/lib/dates";
+import { isRecord } from "@/api/lib/type-guards";
+import type { CorruptDecisionDateRow } from "@/api/scripts/repair-decision-dates-plan";
+import {
+  applyDecisionDateRepairsStatement,
+  DECISION_DATE_REPAIR_OUTCOMES,
+  decideDecisionDateRepair,
+  decisionDateSourceSurveyStatement,
+  decisionDateYearSurveyStatement,
+  parseCorruptDecisionDateRow,
+  selectCorruptDecisionDatesStatement,
+} from "@/api/scripts/repair-decision-dates-plan";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+/**
+ * The repair's two halves are each other's blind spot: the predicate decides
+ * which rows are touched at all, and the per-row decision decides what a
+ * touched row becomes. Both run here against a real PostgreSQL, over fixtures
+ * shaped like the rows production actually holds — a corrupt `decision_date`
+ * whose `metadata.decisionDate` carries the byte-identical corrupt string,
+ * which is what makes re-derivation from the row worthless for that source.
+ */
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const czSourceId = createSafeId<"caseLawSource">();
+const plSourceId = createSafeId<"caseLawSource">();
+
+const currentYear = new Date().getUTCFullYear();
+
+type Fixture = {
+  adapterKey: string;
+  id: SafeId<"caseLawDecision">;
+  /** What `decision_date` holds. `null` rows must never be selected. */
+  decisionDate: string | null;
+  label: string;
+  metadata: Record<string, unknown>;
+  sourceId: SafeId<"caseLawSource">;
+};
+
+/**
+ * `metadata.decisionDate` mirroring the stored value is the production shape:
+ * the adapters that normalize a date write the normalized value into metadata,
+ * and cz-regional copies the publisher's string into both places unchanged.
+ */
+const mirrored = (date: string, publishedDate: string) => ({
+  decisionDate: date,
+  publishedDate,
+});
+
+const fixtures: readonly Fixture[] = [
+  {
+    adapterKey: "cz-regional",
+    id: createSafeId<"caseLawDecision">(),
+    decisionDate: "2944-04-30",
+    label: "far-future year",
+    metadata: mirrored("2944-04-30", "2024-01-23"),
+    sourceId: czSourceId,
+  },
+  {
+    adapterKey: "cz-regional",
+    id: createSafeId<"caseLawDecision">(),
+    decisionDate: "1168-10-28",
+    label: "medieval year",
+    metadata: mirrored("1168-10-28", "2022-10-25"),
+    sourceId: czSourceId,
+  },
+  {
+    adapterKey: "cz-regional",
+    id: createSafeId<"caseLawDecision">(),
+    decisionDate: "0001-01-01",
+    label: "year one",
+    metadata: mirrored("0001-01-01", "2024-01-23"),
+    sourceId: czSourceId,
+  },
+  {
+    adapterKey: "pl-courts",
+    id: createSafeId<"caseLawDecision">(),
+    decisionDate: "3013-12-04",
+    label: "fourth-millennium year",
+    metadata: mirrored("3013-12-04", "2021-05-05"),
+    sourceId: plSourceId,
+  },
+  {
+    // Synthetic on purpose: no adapter stores a raw date under this key today
+    // that differs from the column, which is exactly the claim the run has to
+    // keep proving per row rather than assuming. Without a fixture the
+    // re-derivation branch can reach, "nothing was re-derived" would be a
+    // result the test could not tell apart from a broken branch.
+    adapterKey: "cz-regional",
+    id: createSafeId<"caseLawDecision">(),
+    decisionDate: "2417-05-05",
+    label: "metadata keeps a usable date",
+    metadata: { decisionDate: "2017-05-05", publishedDate: "2017-06-01" },
+    sourceId: czSourceId,
+  },
+  {
+    adapterKey: "cz-regional",
+    id: createSafeId<"caseLawDecision">(),
+    decisionDate: "1799-12-31",
+    label: "day before the floor",
+    metadata: mirrored("1799-12-31", "2023-02-23"),
+    sourceId: czSourceId,
+  },
+  {
+    adapterKey: "cz-regional",
+    id: createSafeId<"caseLawDecision">(),
+    decisionDate: "1800-01-01",
+    label: "the floor itself",
+    metadata: mirrored("1800-01-01", "2023-02-23"),
+    sourceId: czSourceId,
+  },
+  {
+    adapterKey: "cz-regional",
+    id: createSafeId<"caseLawDecision">(),
+    decisionDate: `${String(currentYear + 1)}-12-31`,
+    label: "last day the guard still accepts",
+    metadata: {},
+    sourceId: czSourceId,
+  },
+  {
+    adapterKey: "cz-regional",
+    id: createSafeId<"caseLawDecision">(),
+    decisionDate: `${String(currentYear + 2)}-01-01`,
+    label: "first day past the ceiling",
+    metadata: {},
+    sourceId: czSourceId,
+  },
+  {
+    adapterKey: "cz-regional",
+    id: createSafeId<"caseLawDecision">(),
+    decisionDate: null,
+    label: "already absent",
+    metadata: {},
+    sourceId: czSourceId,
+  },
+];
+
+const fixtureById = new Map(fixtures.map((fixture) => [fixture.id, fixture]));
+
+/** The rows the write-path guard would refuse to store today. */
+const rejectedByGuard = fixtures.filter(
+  (fixture) =>
+    fixture.decisionDate !== null &&
+    canonicalDecisionDate(fixture.decisionDate) === null,
+);
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    db = drizzle({ client });
+
+    await db.insert(caseLawSources).values([
+      { id: czSourceId, adapterKey: "cz-regional", name: "cz source" },
+      { id: plSourceId, adapterKey: "pl-courts", name: "pl source" },
+    ]);
+
+    await db.insert(caseLawDecisions).values(
+      fixtures.map((fixture, index) => ({
+        id: fixture.id,
+        sourceId: fixture.sourceId,
+        caseNumber: `${String(index)} C ${String(index)}/2020`,
+        court: "Krajský soud",
+        country: fixture.adapterKey === "pl-courts" ? "POL" : "CZE",
+        language: fixture.adapterKey === "pl-courts" ? "pl" : "cs",
+        decisionDate: fixture.decisionDate,
+        metadata: fixture.metadata,
+        // Both hashes present and equal: the row reads as projected and
+        // up to date, which is the state a date-only change has to disturb.
+        contentHash: "a".repeat(64),
+        indexedHash: "a".repeat(64),
+        slug: `fixture-${String(index)}`,
+        languageGroupKey: `fixture-${String(index)}`,
+      })),
+    );
+  },
+  { timeout: 120_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+/** Rows from `execute` under either driver shape (bare array or `{ rows }`). */
+const executedRows = (result: unknown): unknown[] => {
+  if (Array.isArray(result)) {
+    return result;
+  }
+  if (isRecord(result) && Array.isArray(result["rows"])) {
+    return result["rows"];
+  }
+  return [];
+};
+
+const corruptRows = async (limit: number): Promise<CorruptDecisionDateRow[]> =>
+  executedRows(
+    await db.execute(selectCorruptDecisionDatesStatement(limit)),
+  ).map(parseCorruptDecisionDateRow);
+
+test("the selection is exactly what the write-path guard rejects", async () => {
+  // Both directions, so neither a predicate that over-selects nor one that
+  // silently misses a boundary can pass. The fixtures straddle both bounds, so
+  // the sets differ from "everything" and from "nothing" in each direction.
+  const selected = new Set((await corruptRows(100)).map(({ id }) => id));
+  const rejected = new Set(rejectedByGuard.map(({ id }) => id));
+
+  expect([...selected].toSorted()).toEqual([...rejected].toSorted());
+  // Guards the assertion above against a fixture set that made it vacuous.
+  expect(selected.size).toBeGreaterThan(0);
+  expect(selected.size).toBeLessThan(fixtures.length);
+  for (const fixture of fixtures) {
+    if (!selected.has(fixture.id)) {
+      continue;
+    }
+    expect(fixture.decisionDate).not.toBeNull();
+  }
+});
+
+test("the surveys count the same population without writing", async () => {
+  const bySource = executedRows(
+    await db.execute(decisionDateSourceSurveyStatement(50)),
+  );
+  const byYear = executedRows(
+    await db.execute(decisionDateYearSurveyStatement(50)),
+  );
+
+  const countRows = (rows: readonly unknown[]): number => {
+    let sum = 0;
+    for (const row of rows) {
+      if (isRecord(row) && typeof row["rows"] === "number") {
+        sum += row["rows"];
+      }
+    }
+    return sum;
+  };
+  expect(countRows(bySource)).toBe(rejectedByGuard.length);
+  expect(countRows(byYear)).toBe(rejectedByGuard.length);
+  expect(
+    bySource.map((row) => (isRecord(row) ? row["adapterKey"] : null)),
+  ).toEqual(["cz-regional", "pl-courts"]);
+
+  // A dry run reads; it must leave the population exactly as it found it.
+  expect((await corruptRows(100)).length).toBe(rejectedByGuard.length);
+});
+
+test("a row keeps a re-derivable date and loses an unrecoverable one", async () => {
+  const decided = (await corruptRows(100)).map(decideDecisionDateRepair);
+  const labelOf = (id: SafeId<"caseLawDecision">): string =>
+    fixtureById.get(id)?.label ?? id;
+
+  const rederived = decided.filter(
+    ({ outcome }) => outcome === DECISION_DATE_REPAIR_OUTCOMES.REDERIVED,
+  );
+  expect(
+    rederived.map(({ decisionDate, id }) => ({
+      decisionDate,
+      label: labelOf(id),
+    })),
+  ).toEqual([
+    { decisionDate: "2017-05-05", label: "metadata keeps a usable date" },
+  ]);
+
+  // Every other row is cleared, including the ones whose metadata carries a
+  // plausible `publishedDate`: publication is not decision.
+  for (const { decisionDate, outcome } of decided) {
+    if (outcome === DECISION_DATE_REPAIR_OUTCOMES.CLEARED) {
+      expect(decisionDate).toBeNull();
+    }
+  }
+  expect(decided.length - rederived.length).toBe(rejectedByGuard.length - 1);
+});
+
+test("applying writes the decisions, re-enqueues them, and converges", async () => {
+  const before = await corruptRows(100);
+  expect(before.length).toBeGreaterThan(0);
+  const repairs = before.map(decideDecisionDateRepair);
+
+  // A crawl that re-observed one of these rows between the selection and the
+  // write already stored whatever the write-path guard allowed. The statement
+  // re-checks the predicate, so this run's older decision must not undo it.
+  const raced = before[0];
+  if (raced === undefined) {
+    throw new Error("no corrupt row to race");
+  }
+  await db
+    .update(caseLawDecisions)
+    .set({ decisionDate: "2020-02-02" })
+    .where(inArray(caseLawDecisions.id, [raced.id]));
+
+  const written = new Set(
+    executedRows(await db.execute(applyDecisionDateRepairsStatement(repairs)))
+      .filter(isRecord)
+      .map((row) => String(row["id"])),
+  );
+  expect(written.has(raced.id)).toBe(false);
+  expect(written.size).toBe(repairs.length - 1);
+
+  // Selecting again finds nothing: every repaired row left the predicate, which
+  // is what lets the batch loop terminate without a cursor.
+  expect(await corruptRows(100)).toEqual([]);
+
+  const stored = await db
+    .select({
+      id: caseLawDecisions.id,
+      decisionDate: caseLawDecisions.decisionDate,
+      indexedHash: caseLawDecisions.indexedHash,
+    })
+    .from(caseLawDecisions);
+  const byId = new Map(stored.map((row) => [String(row.id), row]));
+
+  expect(byId.get(raced.id)?.decisionDate).toBe("2020-02-02");
+  // Untouched by this statement, so still carrying the hash the fixture set.
+  expect(byId.get(raced.id)?.indexedHash).toBe("a".repeat(64));
+
+  for (const { decisionDate, id } of repairs) {
+    if (!written.has(id)) {
+      continue;
+    }
+    expect(byId.get(id)?.decisionDate).toBe(decisionDate);
+    // A date-only change leaves `content_hash` alone, so clearing this is the
+    // only thing that puts the row back in front of the search projection.
+    expect(byId.get(id)?.indexedHash).toBeNull();
+  }
+
+  // Rows the predicate never selected keep both their date and their
+  // projection state: a run cannot widen into dates the guard accepts.
+  for (const fixture of fixtures) {
+    if (before.some(({ id }) => id === fixture.id)) {
+      continue;
+    }
+    expect(byId.get(fixture.id)?.decisionDate).toBe(fixture.decisionDate);
+    expect(byId.get(fixture.id)?.indexedHash).toBe("a".repeat(64));
+  }
+});

--- a/apps/api/src/scripts/repair-decision-dates-plan.ts
+++ b/apps/api/src/scripts/repair-decision-dates-plan.ts
@@ -1,0 +1,274 @@
+/**
+ * What `repair-decision-dates.ts` selects and how it decides each row,
+ * separated from the script that runs it.
+ *
+ * An operator script is a module with a side effect at the top level, so
+ * nothing can import it and nothing in CI ever executes its SQL. Keeping the
+ * statements and the per-row decision here, where a database test can run them
+ * against a real PostgreSQL, is what makes them reviewable: a predicate that
+ * selects the wrong rows is a data loss the first invocation commits, and a
+ * syntax error is one no test would otherwise see.
+ */
+
+import { panic } from "better-result";
+import type { SQL } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+
+import type { SafeId } from "@/api/lib/branded-types";
+import { canonicalDecisionDate, DECISION_YEAR_BOUNDS } from "@/api/lib/dates";
+import { brandPersistedCaseLawDecisionId } from "@/api/lib/safe-id-boundaries";
+import { isRecord } from "@/api/lib/type-guards";
+
+/**
+ * `canonicalDecisionDate`'s year bounds, in SQL.
+ *
+ * Both halves are derived from `DECISION_YEAR_BOUNDS`, the same declaration
+ * the write-path guard reads, so the two runtimes cannot drift into disagreeing
+ * about which stored dates are impossible. `repair-decision-dates-plan.db.test.ts`
+ * proves the agreement executably rather than by inspection.
+ *
+ * The ceiling is expressed as the first excluded day (1 January of
+ * `currentYear + yearsAhead + 1`) rather than a year comparison, so the
+ * predicate stays a pair of range scans over `case_law_decisions_date_idx`
+ * instead of a sequential scan behind `extract(...)`.
+ *
+ * `now()` is read in UTC to match the guard's `getUTCFullYear()`: a session
+ * time zone must not decide whether a stored date is corrupt.
+ *
+ * Written with `sql.raw` for the two integers so the fragment is literal SQL
+ * with no bind parameters, which is what lets the same text be reused verbatim
+ * in DDL (a CHECK constraint takes no parameters). The values are integers from
+ * an `as const` declaration, never input.
+ */
+export const decisionDateOutOfBoundsSql = (column: SQL): SQL => sql`(
+  ${column} < make_date(${sql.raw(String(DECISION_YEAR_BOUNDS.min))}, 1, 1)
+  OR ${column} >= make_date(
+       extract(year from (now() AT TIME ZONE 'UTC'))::int
+         + ${sql.raw(String(DECISION_YEAR_BOUNDS.yearsAhead + 1))},
+       1, 1)
+)`;
+
+const OUT_OF_BOUNDS = decisionDateOutOfBoundsSql(sql.raw("d.decision_date"));
+
+/**
+ * How many out-of-bounds dates each source holds, and the range they span.
+ *
+ * Bounded by `limit` like any other read: the source registry is small, but a
+ * survey that silently truncates is worse than one that says it did, and the
+ * script reports a full result set as suspect.
+ */
+export const decisionDateSourceSurveyStatement = (limit: number): SQL => sql`
+  SELECT s.adapter_key AS "adapterKey",
+         count(*)::int AS "rows",
+         min(d.decision_date)::text AS "minDate",
+         max(d.decision_date)::text AS "maxDate"
+    FROM case_law_decisions d
+    JOIN case_law_sources s ON s.id = d.source_id
+   WHERE ${OUT_OF_BOUNDS}
+   GROUP BY 1
+   ORDER BY 2 DESC, 1
+   LIMIT ${limit}
+`;
+
+/**
+ * The same population by source and year. The year is what identifies the
+ * fault: a run of rows sharing one impossible year is a publisher's repeated
+ * data-entry error, while a scatter of unrelated years is a parse fallback.
+ */
+export const decisionDateYearSurveyStatement = (limit: number): SQL => sql`
+  SELECT s.adapter_key AS "adapterKey",
+         extract(year from d.decision_date)::int AS "year",
+         count(*)::int AS "rows"
+    FROM case_law_decisions d
+    JOIN case_law_sources s ON s.id = d.source_id
+   WHERE ${OUT_OF_BOUNDS}
+   GROUP BY 1, 2
+   ORDER BY 3 DESC, 1, 2
+   LIMIT ${limit}
+`;
+
+/**
+ * One bounded batch of corrupt rows, with the only cheap re-derivation source
+ * the row itself carries.
+ *
+ * `metadata->>'decisionDate'` is the key every adapter that stores a date in
+ * metadata uses (`at-courts` stores none). It is read so the run can *prove*
+ * per row whether a better value survives rather than assume it does not: the
+ * adapters that normalize the date write the normalized value into metadata,
+ * and `cz-regional`, whose rows dominate this population, copies the
+ * publisher's string into both places unchanged. The dry-run report prints the
+ * re-derived count, so a source that does keep a usable raw value shows up as a
+ * number instead of being silently nulled.
+ *
+ * `sourceRaw` is deliberately not consulted. It lives in object storage
+ * (`source_raw_s3_key`), so reading it is a network round-trip per row, and it
+ * holds the same publisher payload the corrupt value was taken from — the cost
+ * buys a copy of what metadata already showed.
+ */
+export const selectCorruptDecisionDatesStatement = (limit: number): SQL => sql`
+  SELECT d.id AS "id",
+         s.adapter_key AS "adapterKey",
+         d.decision_date::text AS "storedDate",
+         d.metadata->>'decisionDate' AS "metadataDate",
+         d.citation_key AS "citationKey",
+         d.country AS "country"
+    FROM case_law_decisions d
+    JOIN case_law_sources s ON s.id = d.source_id
+   WHERE ${OUT_OF_BOUNDS}
+   ORDER BY d.id
+   LIMIT ${limit}
+`;
+
+/** One corrupt row as `selectCorruptDecisionDatesStatement` returns it. */
+export type CorruptDecisionDateRow = {
+  adapterKey: string;
+  /** The resolver's key and policy filters, carried so the run can reopen the
+   * edges its date change invalidates without a second read. */
+  citationKey: string | null;
+  country: string;
+  id: SafeId<"caseLawDecision">;
+  metadataDate: string | null;
+  storedDate: string;
+};
+
+const optionalString = (value: unknown): string | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    panic("Corrupt-date selection returned a non-string where text was read");
+  }
+  return value;
+};
+
+const requiredString = (value: unknown): string => {
+  const text = optionalString(value);
+  if (text === null) {
+    panic("Corrupt-date selection returned null in a NOT NULL column");
+  }
+  return text;
+};
+
+/**
+ * One selected row, narrowed.
+ *
+ * `execute` returns untyped rows, and a repair that mis-reads a column would
+ * write a decision made from the wrong field. A shape the query cannot produce
+ * is a programmer error in the statement above it, so it panics rather than
+ * being skipped: a run that quietly dropped rows would report a repair it did
+ * not make.
+ */
+export const parseCorruptDecisionDateRow = (
+  row: unknown,
+): CorruptDecisionDateRow => {
+  if (!isRecord(row)) {
+    panic("Corrupt-date selection returned a non-row");
+  }
+  return {
+    adapterKey: requiredString(row["adapterKey"]),
+    citationKey: optionalString(row["citationKey"]),
+    country: requiredString(row["country"]),
+    id: brandPersistedCaseLawDecisionId(requiredString(row["id"])),
+    metadataDate: optionalString(row["metadataDate"]),
+    storedDate: requiredString(row["storedDate"]),
+  };
+};
+
+export const DECISION_DATE_REPAIR_OUTCOMES = {
+  /** Metadata carried a usable date the stored column had lost. */
+  REDERIVED: "rederived",
+  /** No source in the row survives; the column is set to NULL. */
+  CLEARED: "cleared",
+} as const;
+
+export type DecisionDateRepairOutcome =
+  (typeof DECISION_DATE_REPAIR_OUTCOMES)[keyof typeof DECISION_DATE_REPAIR_OUTCOMES];
+
+export type DecisionDateRepair = {
+  id: SafeId<"caseLawDecision">;
+  /** The re-derived date, or `null` where none survives. */
+  decisionDate: string | null;
+  outcome: DecisionDateRepairOutcome;
+};
+
+/**
+ * What one corrupt row becomes.
+ *
+ * Re-derivation runs the row's own metadata date through the same
+ * `canonicalDecisionDate` the ingest writes through, so a value this accepts is
+ * a value the write path would have stored. Nothing else in the row is
+ * consulted: `metadata.publishedDate` is when the court published the document,
+ * not when it decided the case, and substituting it would replace a visibly
+ * wrong date with a plausibly wrong one.
+ *
+ * Everything else is cleared. Nulling is the designed fallback, not a
+ * concession: the column is nullable, every reader already renders a decision
+ * with no date, and an absent date is a fact a search facet, a sort, and a
+ * citation can all handle correctly, while a year of 1168 is one none of them
+ * can.
+ */
+export const decideDecisionDateRepair = ({
+  id,
+  metadataDate,
+}: CorruptDecisionDateRow): DecisionDateRepair => {
+  const rederived =
+    metadataDate === null ? null : canonicalDecisionDate(metadataDate);
+  if (rederived === null) {
+    return {
+      id,
+      decisionDate: null,
+      outcome: DECISION_DATE_REPAIR_OUTCOMES.CLEARED,
+    };
+  }
+  return {
+    id,
+    decisionDate: rederived,
+    outcome: DECISION_DATE_REPAIR_OUTCOMES.REDERIVED,
+  };
+};
+
+/**
+ * Write one batch of decided repairs.
+ *
+ * Every decision leaves the selection predicate, because both outcomes are
+ * values the predicate does not match: the batch walk converges on an empty
+ * batch without a cursor, and a keyset cursor over a self-consuming predicate
+ * would only add a way to skip rows.
+ *
+ * `indexed_hash` is cleared in the same statement. The search projection
+ * carries `decision_date` and its derived year, but `content_hash` covers only
+ * the text payload, so a date-only change is invisible to the
+ * `indexed_hash IS DISTINCT FROM content_hash` staleness test and the index
+ * would keep serving the corrupt year forever. The projection trigger fires on
+ * `indexed_hash` being assigned rather than on its value changing, which is the
+ * same mechanism the ingestion pipeline uses for its own metadata-only updates.
+ *
+ * The predicate is re-checked here, against the row as it stands now rather
+ * than as the selection read it: the crawl keeps running, and a decision it
+ * re-observed in between already carries whatever date the write-path guard
+ * allowed. Overwriting that with this run's decision would undo a repair with
+ * a stale one. The returned ids are therefore the rows actually changed, which
+ * is also what the citation graph has to be told about.
+ */
+export const applyDecisionDateRepairsStatement = (
+  repairs: readonly DecisionDateRepair[],
+): SQL => {
+  if (repairs.length === 0) {
+    panic("applyDecisionDateRepairsStatement called with no repairs");
+  }
+  // Cast every VALUES row rather than only the first: PostgreSQL infers the
+  // column types from the first row, and a batch whose first date is NULL
+  // would otherwise resolve to `text` and fail the assignment.
+  const rows = repairs.map(
+    ({ decisionDate, id }) => sql`(${id}::uuid, ${decisionDate}::date)`,
+  );
+  return sql`
+    UPDATE case_law_decisions AS d
+       SET decision_date = v.decision_date,
+           indexed_hash = NULL
+      FROM (VALUES ${sql.join(rows, sql`, `)}) AS v(id, decision_date)
+     WHERE d.id = v.id
+       AND ${decisionDateOutOfBoundsSql(sql.raw("d.decision_date"))}
+    RETURNING d.id
+  `;
+};

--- a/apps/api/src/scripts/repair-decision-dates-plan.ts
+++ b/apps/api/src/scripts/repair-decision-dates-plan.ts
@@ -104,8 +104,35 @@ export const decisionDateYearSurveyStatement = (limit: number): SQL => sql`
  * (`source_raw_s3_key`), so reading it is a network round-trip per row, and it
  * holds the same publisher payload the corrupt value was taken from — the cost
  * buys a copy of what metadata already showed.
+ *
+ * `lock` decides whether the read claims its rows. A repairing batch takes
+ * `FOR UPDATE` on the decisions alone, before the citation-graph lock, because
+ * that is the order the ingestion pipeline takes them in: it locks the row it
+ * is about to overwrite, then reopens the edges its identity change
+ * invalidates. Taking them the other way round here would let one transaction
+ * hold the row while waiting for the graph and the other hold the graph while
+ * waiting for the row, which PostgreSQL resolves by aborting one of them. A
+ * report-only read claims nothing.
  */
-export const selectCorruptDecisionDatesStatement = (limit: number): SQL => sql`
+export const DECISION_DATE_ROW_LOCKS = {
+  /** Claim the decision rows, in the pipeline's lock order. */
+  FOR_UPDATE: "for-update",
+  /** Read without claiming anything. */
+  NONE: "none",
+} as const;
+
+export type DecisionDateRowLock =
+  (typeof DECISION_DATE_ROW_LOCKS)[keyof typeof DECISION_DATE_ROW_LOCKS];
+
+type SelectCorruptDecisionDatesOptions = {
+  limit: number;
+  lock: DecisionDateRowLock;
+};
+
+export const selectCorruptDecisionDatesStatement = ({
+  limit,
+  lock,
+}: SelectCorruptDecisionDatesOptions): SQL => sql`
   SELECT d.id AS "id",
          s.adapter_key AS "adapterKey",
          d.decision_date::text AS "storedDate",
@@ -117,6 +144,7 @@ export const selectCorruptDecisionDatesStatement = (limit: number): SQL => sql`
    WHERE ${OUT_OF_BOUNDS}
    ORDER BY d.id
    LIMIT ${limit}
+   ${lock === DECISION_DATE_ROW_LOCKS.FOR_UPDATE ? sql`FOR UPDATE OF d` : sql``}
 `;
 
 /** One corrupt row as `selectCorruptDecisionDatesStatement` returns it. */

--- a/apps/api/src/scripts/repair-decision-dates.ts
+++ b/apps/api/src/scripts/repair-decision-dates.ts
@@ -1,0 +1,371 @@
+/**
+ * Repair `case_law_decisions.decision_date` values no publisher could have
+ * meant.
+ *
+ * Rows written before the ingest bounded the field carry dates a court cannot
+ * have issued: years in the twelfth century, years in the fourth millennium.
+ * They sort, facet and filter as if they were real, and the corpus index seeds
+ * its date field from this column, so every projection built on top of them
+ * inherits the fault.
+ *
+ * **What a repair can recover.** Almost nothing, and the run proves it per row
+ * rather than assuming it. The only cheap alternative source a row carries is
+ * its own `metadata.decisionDate`, which is put through the same
+ * `canonicalDecisionDate` the ingest writes through. For every adapter that
+ * normalizes a date, metadata holds the normalized value, and `cz-regional` —
+ * whose rows are almost all of this population — copies the publisher's string
+ * into the column and into metadata unchanged. `sourceRaw` is not consulted: it
+ * lives in object storage, so reading it costs a network round-trip per row,
+ * and it holds the same publisher payload the corrupt value was taken from.
+ *
+ * **Nulling is the designed outcome, not a concession.** The column is
+ * nullable, readers already render a decision with no date, and an absent date
+ * is something a sort, a facet and the citation resolver can each handle
+ * correctly. A year of 1168 is something none of them can. `metadata.publishedDate`
+ * is deliberately not substituted: publication is not decision, and replacing a
+ * visibly wrong date with a plausibly wrong one is worse than an honest gap.
+ *
+ * **What a date change costs elsewhere.** Two things, both handled per batch:
+ * the search projection is re-enqueued by clearing `indexed_hash` in the same
+ * statement, and the citation graph is told, because the resolver filters
+ * candidates on `decision_date` and treats NULL on either side as permissive.
+ * Edges decided under the old date are retracted and requeued through the same
+ * helpers the ingestion pipeline uses when a stored decision's resolution
+ * identity changes, under the citation-graph lock.
+ *
+ * **Why the bounds are not a CHECK constraint yet.** They should be, and the
+ * predicate above is written so the same text can become one. It cannot land
+ * before this run has: `ADD CONSTRAINT … NOT VALID` skips the scan of existing
+ * rows but still enforces the constraint on every later INSERT and UPDATE, so
+ * while a corrupt row survives, any unrelated write touching it — a citation
+ * authority refresh, a corpus mirror update, an index hash — fails on a column
+ * it never mentioned. `VALIDATE CONSTRAINT` fails outright. A report-only run
+ * finding zero rows is the precondition; until then the write path's own
+ * `canonicalDecisionDate` is the guard, and `dates.test.ts` pins its bounds.
+ *
+ * Without `--apply` nothing is written: the run reports the population per
+ * source and per year and exits. Idempotent either way — a repaired row leaves
+ * the selection predicate, so a second pass finds nothing.
+ *
+ *   # what the repair would touch, writing nothing
+ *   bun run src/scripts/repair-decision-dates.ts
+ *
+ *   # repair, bounded and resumable by re-running
+ *   bun run src/scripts/repair-decision-dates.ts --apply [--limit 5000]
+ *
+ * Not a scheduled job: the write path has bounded new dates since the guard
+ * landed, so this is a one-shot operation on the rows that predate it, run by
+ * an operator who reads the report first.
+ */
+
+import { panic } from "better-result";
+
+import { rootDb } from "@/api/db/root";
+import {
+  lockCitationGraph,
+  reopenCitationsForDecisionKey,
+  reopenCitationsForKeys,
+  reopenCitationsFrom,
+  reopenCitationsResolvedTo,
+} from "@/api/handlers/case-law/citation-resolution";
+import { isCaseLawJurisdiction } from "@/api/lib/legal-search/ingestion-constants";
+import { isRecord } from "@/api/lib/type-guards";
+import type {
+  CorruptDecisionDateRow,
+  DecisionDateRepair,
+} from "@/api/scripts/repair-decision-dates-plan";
+import {
+  applyDecisionDateRepairsStatement,
+  DECISION_DATE_REPAIR_OUTCOMES,
+  decideDecisionDateRepair,
+  decisionDateSourceSurveyStatement,
+  decisionDateYearSurveyStatement,
+  parseCorruptDecisionDateRow,
+  selectCorruptDecisionDatesStatement,
+} from "@/api/scripts/repair-decision-dates-plan";
+
+/**
+ * Rows per transaction. Small on purpose: the batch holds the citation-graph
+ * advisory lock while it reopens edges, and the standing resolver waits on it.
+ */
+const BATCH = 50;
+/**
+ * Rows this run may repair. The population is bounded by construction, but an
+ * operator run that discovers otherwise should stop and report rather than walk
+ * a table for an hour.
+ */
+const DEFAULT_LIMIT = 5000;
+/** Survey rows printed. A result at the cap is reported as truncated. */
+const SURVEY_LIMIT = 200;
+
+const USAGE = `Usage: bun run src/scripts/repair-decision-dates.ts [options]
+
+  --apply        Write the repairs. Omitted, the run only reports.
+  --dry-run      Report only, the default. Accepted so it cannot be mistaken
+                 for a flag this script ignores; contradicts --apply.
+  --limit <n>    Rows this run may repair (default ${String(DEFAULT_LIMIT)}).`;
+
+const hasFlag = (name: string): boolean => process.argv.includes(`--${name}`);
+
+const DECIMAL_INTEGER = /^\d+$/u;
+
+const flagInteger = (name: string, fallback: number): number => {
+  const index = process.argv.indexOf(`--${name}`);
+  if (index === -1) {
+    return fallback;
+  }
+  const raw = process.argv[index + 1];
+  const parsed =
+    raw !== undefined && DECIMAL_INTEGER.test(raw)
+      ? Number.parseInt(raw, 10)
+      : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    console.error(
+      `--${name} must be a positive integer, got: ${raw ?? "(none)"}`,
+    );
+    console.error(USAGE);
+    process.exit(1);
+  }
+  return parsed;
+};
+
+const apply = hasFlag("apply");
+if (apply && hasFlag("dry-run")) {
+  console.error("--apply and --dry-run contradict each other; pass one.");
+  console.error(USAGE);
+  process.exit(1);
+}
+const limit = flagInteger("limit", DEFAULT_LIMIT);
+
+/** Rows from `execute` under either driver shape (bare array or `{ rows }`). */
+const executedRows = (result: unknown): unknown[] => {
+  if (Array.isArray(result)) {
+    return result;
+  }
+  if (isRecord(result) && Array.isArray(result["rows"])) {
+    return result["rows"];
+  }
+  return [];
+};
+
+const surveyNumber = (row: Record<string, unknown>, key: string): number => {
+  const value = row[key];
+  if (typeof value !== "number") {
+    panic(`Survey column ${key} is not a number`);
+  }
+  return value;
+};
+
+const surveyText = (row: Record<string, unknown>, key: string): string => {
+  const value = row[key];
+  if (value === null) {
+    return "—";
+  }
+  if (typeof value !== "string") {
+    panic(`Survey column ${key} is not text`);
+  }
+  return value;
+};
+
+const printSurvey = async (): Promise<number> => {
+  const bySource = executedRows(
+    await rootDb.execute(decisionDateSourceSurveyStatement(SURVEY_LIMIT)),
+  ).filter(isRecord);
+  const byYear = executedRows(
+    await rootDb.execute(decisionDateYearSurveyStatement(SURVEY_LIMIT)),
+  ).filter(isRecord);
+
+  console.info("--- out-of-bounds decision dates, per source ---");
+  let total = 0;
+  for (const row of bySource) {
+    const rows = surveyNumber(row, "rows");
+    total += rows;
+    console.info(
+      `${surveyText(row, "adapterKey").padEnd(14)} ${String(rows).padStart(7)}  ` +
+        `${surveyText(row, "minDate")} … ${surveyText(row, "maxDate")}`,
+    );
+  }
+  console.info(`${"total".padEnd(14)} ${String(total).padStart(7)}`);
+
+  console.info("--- and per year ---");
+  for (const row of byYear) {
+    console.info(
+      `${surveyText(row, "adapterKey").padEnd(14)} ${String(surveyNumber(row, "year")).padStart(6)}  ${String(surveyNumber(row, "rows")).padStart(7)}`,
+    );
+  }
+  if (bySource.length >= SURVEY_LIMIT || byYear.length >= SURVEY_LIMIT) {
+    console.info(
+      `survey truncated at ${String(SURVEY_LIMIT)} rows; the counts above are a floor`,
+    );
+  }
+  return total;
+};
+
+/**
+ * Tell the citation graph that this decision's date is no longer what it was.
+ *
+ * The resolver filters candidates on `decision_date` and reads NULL on either
+ * side as permissive, so clearing a date both revives citations that were time
+ * filtered away from this decision and contests edges that were drawn while it
+ * was excluded. Neither is discoverable from the citing side, and the standing
+ * walk only revisits unsettled rows, so an edge left alone here stays wrong
+ * forever. Same four steps, in the same order, as the ingestion pipeline's own
+ * resolution-identity change.
+ */
+const reopenAffectedCitations = async (
+  tx: Parameters<typeof lockCitationGraph>[0],
+  row: CorruptDecisionDateRow,
+  repaired: DecisionDateRepair,
+): Promise<void> => {
+  await reopenCitationsResolvedTo(tx, row.id);
+  await reopenCitationsFrom(tx, row.id);
+  if (row.citationKey === null) {
+    return;
+  }
+  await reopenCitationsForKeys(tx, [row.citationKey]);
+  if (!isCaseLawJurisdiction(row.country)) {
+    // A stored country nobody declares a resolution policy for. Loud rather
+    // than defaulted, matching the pipeline: guessing a reach would write
+    // cross-border edges on an assumption.
+    console.error(
+      `${row.id}: country ${row.country} declares no resolution policy; key not re-announced`,
+    );
+    return;
+  }
+  await reopenCitationsForDecisionKey(tx, {
+    citationKey: row.citationKey,
+    decisionId: row.id,
+    jurisdiction: row.country,
+    decisionDate: repaired.decisionDate,
+  });
+};
+
+type BatchResult = {
+  cleared: number;
+  rederived: number;
+  /** Rows a concurrent observation had already repaired; skipped, not undone. */
+  skipped: number;
+};
+
+/**
+ * Announce each written row to the citation graph, one after another.
+ *
+ * Recursive rather than a loop with an awaited body: the reopen statements are
+ * graph mutations under one lock, so they must not fan out, and expressing that
+ * as a walk keeps the sequencing structural instead of a suppressed lint.
+ */
+const reopenWrittenAt = async (
+  tx: Parameters<typeof lockCitationGraph>[0],
+  rows: readonly CorruptDecisionDateRow[],
+  repairs: readonly DecisionDateRepair[],
+  written: ReadonlySet<string>,
+  counts: { cleared: number; rederived: number },
+  offset = 0,
+): Promise<void> => {
+  const row = rows.at(offset);
+  if (row === undefined) {
+    return;
+  }
+  const repaired = repairs.at(offset);
+  if (repaired === undefined) {
+    panic("Repair decisions and selected rows fell out of step");
+  }
+  if (written.has(row.id)) {
+    if (repaired.outcome === DECISION_DATE_REPAIR_OUTCOMES.REDERIVED) {
+      counts.rederived += 1;
+    } else {
+      counts.cleared += 1;
+    }
+    await reopenAffectedCitations(tx, row, repaired);
+  }
+  await reopenWrittenAt(tx, rows, repairs, written, counts, offset + 1);
+};
+
+const repairBatch = async (size: number): Promise<BatchResult> =>
+  await rootDb.transaction(async (tx) => {
+    // The lock first, then the read: this changes what decisions are citable,
+    // so a resolver batch holding a snapshot from before the date moved must
+    // not commit an edge against it.
+    await lockCitationGraph(tx);
+    const rows = executedRows(
+      await tx.execute(selectCorruptDecisionDatesStatement(size)),
+    ).map(parseCorruptDecisionDateRow);
+    if (rows.length === 0) {
+      return { cleared: 0, rederived: 0, skipped: 0 };
+    }
+
+    const repairs = rows.map(decideDecisionDateRepair);
+    const written = new Set(
+      executedRows(await tx.execute(applyDecisionDateRepairsStatement(repairs)))
+        .filter(isRecord)
+        .map((row) => String(row["id"])),
+    );
+
+    const counts = { cleared: 0, rederived: 0 };
+    await reopenWrittenAt(tx, rows, repairs, written, counts);
+    return { ...counts, skipped: rows.length - written.size };
+  });
+
+/**
+ * Repair batches until the population is empty or `--limit` is reached.
+ *
+ * Each batch depends on the previous one having committed, which is what makes
+ * this a walk rather than a fan-out.
+ */
+const repairUntilDone = async (counts: {
+  cleared: number;
+  rederived: number;
+  skipped: number;
+}): Promise<void> => {
+  const done = counts.cleared + counts.rederived + counts.skipped;
+  if (done >= limit) {
+    return;
+  }
+  const batch = await repairBatch(Math.min(BATCH, limit - done));
+  if (batch.cleared + batch.rederived + batch.skipped === 0) {
+    return;
+  }
+  counts.cleared += batch.cleared;
+  counts.rederived += batch.rederived;
+  counts.skipped += batch.skipped;
+  console.info(
+    `${String(counts.cleared + counts.rederived)} repaired (${String(counts.rederived)} re-derived)`,
+  );
+  await repairUntilDone(counts);
+};
+
+const total = await printSurvey();
+
+if (!apply) {
+  console.info(
+    "Report only: nothing written. Re-run with --apply to repair, and note " +
+      "that a run reporting zero rows is the precondition for adding the " +
+      "bounds CHECK constraint.",
+  );
+  process.exit(0);
+}
+
+const counts = { cleared: 0, rederived: 0, skipped: 0 };
+await repairUntilDone(counts);
+
+console.info(
+  `done: ${String(counts.cleared)} cleared, ${String(counts.rederived)} re-derived, ` +
+    `${String(counts.skipped)} already repaired by a concurrent observation ` +
+    `(survey reported ${String(total)} before the run).`,
+);
+console.info(
+  "The search projection is re-enqueued and the affected citations are back " +
+    "in the resolver's queue; both settle on their own schedules.",
+);
+
+// Re-surveyed rather than inferred from the counts above: what the constraint
+// needs is that the population is empty now, and a run that hit `--limit`, or
+// raced a crawl still writing unbounded dates, has counts that say otherwise.
+const remaining = await printSurvey();
+console.info(
+  remaining === 0
+    ? "population empty: the bounds CHECK constraint can now be added."
+    : `${String(remaining)} rows remain; re-run before adding the bounds CHECK constraint.`,
+);
+
+process.exit(0);

--- a/apps/api/src/scripts/repair-decision-dates.ts
+++ b/apps/api/src/scripts/repair-decision-dates.ts
@@ -31,7 +31,9 @@
  * candidates on `decision_date` and treats NULL on either side as permissive.
  * Edges decided under the old date are retracted and requeued through the same
  * helpers the ingestion pipeline uses when a stored decision's resolution
- * identity changes, under the citation-graph lock.
+ * identity changes, under the citation-graph lock — and in the pipeline's lock
+ * order, decision rows before the graph, so a refresh of one of these decisions
+ * running at the same time cannot deadlock against the repair.
  *
  * **Why the bounds are not a CHECK constraint yet.** They should be, and the
  * predicate above is written so the same text can become one. It cannot land
@@ -43,9 +45,12 @@
  * finding zero rows is the precondition; until then the write path's own
  * `canonicalDecisionDate` is the guard, and `dates.test.ts` pins its bounds.
  *
- * Without `--apply` nothing is written: the run reports the population per
- * source and per year and exits. Idempotent either way — a repaired row leaves
- * the selection predicate, so a second pass finds nothing.
+ * Without `--apply` nothing is written and nothing is locked: the run reports
+ * the population per source and per year, then how many of those rows a repair
+ * would re-derive and how many it would clear, and exits. Those last two are
+ * what an operator authorises on, because a cleared row loses its date for
+ * good. Idempotent either way — a repaired row leaves the selection predicate,
+ * so a second pass finds nothing.
  *
  *   # what the repair would touch, writing nothing
  *   bun run src/scripts/repair-decision-dates.ts
@@ -77,6 +82,7 @@ import type {
 import {
   applyDecisionDateRepairsStatement,
   DECISION_DATE_REPAIR_OUTCOMES,
+  DECISION_DATE_ROW_LOCKS,
   decideDecisionDateRepair,
   decisionDateSourceSurveyStatement,
   decisionDateYearSurveyStatement,
@@ -283,16 +289,23 @@ const reopenWrittenAt = async (
 
 const repairBatch = async (size: number): Promise<BatchResult> =>
   await rootDb.transaction(async (tx) => {
-    // The lock first, then the read: this changes what decisions are citable,
-    // so a resolver batch holding a snapshot from before the date moved must
-    // not commit an edge against it.
-    await lockCitationGraph(tx);
+    // Decision rows first, citation graph second — the order the ingestion
+    // pipeline takes them in, which is the only thing that keeps a concurrent
+    // refresh of one of these decisions from deadlocking against this batch.
+    // Holding the rows is also what makes the graph work below sound: nothing
+    // can move a claimed row's date between the reopen and the commit.
     const rows = executedRows(
-      await tx.execute(selectCorruptDecisionDatesStatement(size)),
+      await tx.execute(
+        selectCorruptDecisionDatesStatement({
+          limit: size,
+          lock: DECISION_DATE_ROW_LOCKS.FOR_UPDATE,
+        }),
+      ),
     ).map(parseCorruptDecisionDateRow);
     if (rows.length === 0) {
       return { cleared: 0, rederived: 0, skipped: 0 };
     }
+    await lockCitationGraph(tx);
 
     const repairs = rows.map(decideDecisionDateRepair);
     const written = new Set(
@@ -334,9 +347,42 @@ const repairUntilDone = async (counts: {
   await repairUntilDone(counts);
 };
 
+/**
+ * What the repair would decide, without writing or claiming anything.
+ *
+ * The counts an operator authorises on are these, not the population size: a
+ * cleared row loses its date for good, so how many rows that is has to be on
+ * the report rather than discovered afterwards.
+ */
+const printDecisions = async (): Promise<void> => {
+  const rows = executedRows(
+    await rootDb.execute(
+      selectCorruptDecisionDatesStatement({
+        limit,
+        lock: DECISION_DATE_ROW_LOCKS.NONE,
+      }),
+    ),
+  ).map(parseCorruptDecisionDateRow);
+  const decided = rows.map(decideDecisionDateRepair);
+  const rederived = decided.filter(
+    ({ outcome }) => outcome === DECISION_DATE_REPAIR_OUTCOMES.REDERIVED,
+  ).length;
+  console.info("--- what a repair would decide ---");
+  console.info(`re-derived from metadata: ${String(rederived)}`);
+  console.info(
+    `cleared to NULL:          ${String(decided.length - rederived)}`,
+  );
+  if (rows.length >= limit) {
+    console.info(
+      `decisions capped at --limit ${String(limit)}; the counts above are a floor`,
+    );
+  }
+};
+
 const total = await printSurvey();
 
 if (!apply) {
+  await printDecisions();
   console.info(
     "Report only: nothing written. Re-run with --apply to repair, and note " +
       "that a run reporting zero rows is the precondition for adding the " +


### PR DESCRIPTION
`case_law_decisions.decision_date` rows written before the ingest bounded the
field carry years outside `[1800, currentYear + 1]`: dates in the twelfth
century, dates in the fourth millennium. They sort, facet and filter as if they
were real, and the corpus index seeds its date field from this column, so every
projection built on top of them inherits the fault. `canonicalDecisionDate` has
guarded the write path since it landed; these rows predate it.

## What lands

A one-shot operator script, `apps/api/src/scripts/repair-decision-dates.ts`,
report-only unless `--apply` is passed. The statements and the per-row decision
live in `repair-decision-dates-plan.ts` so a database test can execute them: an
operator script is a module with a top-level side effect, so nothing else ever
runs its SQL, and a predicate that selects the wrong rows is a data loss the
first invocation commits.

**Selection is derived, not restated.** `DECISION_YEAR_BOUNDS` — the declaration
`canonicalDecisionDate` reads — is now exported and the SQL predicate is built
from it, expressed as a pair of range scans over `case_law_decisions_date_idx`
rather than a comparison behind `extract(...)`. `now()` is read in UTC to match
the guard's `getUTCFullYear()`, so a session time zone cannot decide whether a
stored date is corrupt. The database test asserts in both directions that the
rows the predicate selects are exactly the rows `canonicalDecisionDate` rejects,
over fixtures straddling both bounds.

**Re-derivation is proved per row, not assumed.** The only alternative source a
row carries cheaply is its own `metadata.decisionDate`, which is put through the
same `canonicalDecisionDate` the ingest writes through. For adapters that
normalize the date, metadata holds the normalized value; `cz-regional` copies
the publisher's string into the column and into metadata unchanged. The report
prints the re-derived count, so a source that does keep a usable raw value shows
up as a number instead of being silently cleared. `sourceRaw` is not consulted:
it lives in object storage, so reading it costs a round-trip per row, and it
holds the same publisher payload the corrupt value came from.

**Clearing is the designed outcome.** The column is nullable, readers already
render a decision with no date, and an absent date is something a sort, a facet
and the citation resolver each handle correctly. `metadata.publishedDate` is
deliberately not substituted: publication is not decision, and a plausibly wrong
date is worse than an honest gap.

## A date change is not local

Two couplings, both handled inside the batch transaction:

- **Search projection.** `content_hash` covers only the text payload, so a
  date-only change is invisible to the `indexed_hash IS DISTINCT FROM
  content_hash` staleness test while `decision_date` and its derived year *are*
  projected. The batch clears `indexed_hash` in the same `UPDATE`; the
  projection trigger fires on the column being assigned, which is the mechanism
  the ingestion pipeline already uses for its own metadata-only updates.
- **Citation graph.** The resolver filters candidates on `decision_date` and
  reads NULL on either side as permissive, so clearing a date both revives
  citations that were time-filtered away from a decision and contests edges
  drawn while it was excluded. Neither is reachable from the citing side and the
  standing walk only revisits unsettled rows, so the run calls the same four
  reopen helpers, in the same order, that the pipeline calls on a
  resolution-identity change, under the citation-graph lock.

The write statement re-checks the predicate against the row as it stands rather
than as the selection read it, so a decision the crawl re-observed in between
keeps whatever date the write-path guard allowed instead of being overwritten
with this run's older decision. Its `RETURNING` ids are what the citation graph
is told about.

## Why no CHECK constraint yet

The bounds belong in a `CHECK`, and the predicate is written so the same text
can become one, but it cannot land in this change. `ADD CONSTRAINT … NOT VALID`
skips the scan of existing rows and still enforces the constraint on every later
INSERT and UPDATE, so while a corrupt row survives, any unrelated write touching
it — a citation-authority refresh, a corpus-mirror update, an index hash — fails
on a column it never mentioned; `VALIDATE CONSTRAINT` fails outright. A
report-only run finding zero rows is the constraint's precondition, and the
script's module doc says so. Until then `canonicalDecisionDate` is the guard and
`dates.test.ts` pins its bounds (1799 rejected, 1800 accepted, `currentYear + 1`
accepted, `currentYear + 2` rejected).

## Tests

`repair-decision-dates-plan.db.test.ts` runs the real statements against
PostgreSQL over fixtures shaped like the rows this repairs — a corrupt
`decision_date` whose `metadata.decisionDate` carries the byte-identical corrupt
string — and covers the guard-parity assertion above, report-only leaving the
population untouched, the re-derived and cleared branches, `indexed_hash` being
cleared for written rows only, the concurrent-repair skip, and convergence on a
second pass. Mutation-checked: loosening the ceiling by one year fails three of
the four tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an operational tool to detect and repair invalid decision dates.
  * Supports report-only and apply modes, bounded processing, progress reporting, and safe handling of concurrent updates.
  * Repairs can restore dates from available metadata or clear them when no reliable value exists.
  * Affected search and citation information is refreshed automatically.

* **Tests**
  * Added comprehensive integration coverage for date detection, repair outcomes, validation, concurrency, and repeatability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->