### PR TITLE
feat(api): walk the corpus-index generation rebuild in decision-date order

### DIFF
--- a/apps/api/drizzle/20260817150000_corpus_generation_date_walk/migration.sql
+++ b/apps/api/drizzle/20260817150000_corpus_generation_date_walk/migration.sql
@@ -1,0 +1,225 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- The corpus-index generation rebuild walked its snapshot in creation order.
+-- A split's timestamp range spans everything written into it, so that order
+-- gave every split the corpus' whole date range and left a date-filtered query
+-- nothing to skip. The walk now goes in decision-date order, so a split holds a
+-- contiguous span of dates.
+--
+-- The cursor changes with it: `(decision_date, id)` instead of
+-- `(created_at, id)`, with undated decisions coalesced to `-infinity` so they
+-- form the first band and one row comparison expresses the whole cursor.
+
+ALTER TABLE "case_law_corpus_index_backfills"
+  ADD COLUMN "cursor_walk_date" date;--> statement-breakpoint
+
+-- The pair check follows the cursor to its new column. Dropping it first is
+-- required, not cosmetic: it asserts the legacy column and the id are set
+-- together, which the new writer, leaving the legacy column null, would
+-- violate on its first advance.
+-- stella-migration-safety: reviewed destructive-change - drops a check
+-- constraint over the cursor columns and replaces it below with the same
+-- invariant over the column the cursor now uses. No row data is touched.
+ALTER TABLE "case_law_corpus_index_backfills"
+  DROP CONSTRAINT IF EXISTS "case_law_corpus_index_backfills_cursor_pair";--> statement-breakpoint
+
+-- A position in creation order is not a position in date order, so every
+-- stored cursor is cleared rather than translated. A rebuild still running
+-- restarts, which costs a re-scan and re-indexes nothing: a row already
+-- rebuilt into the generation is current and is skipped. A finished rebuild
+-- keeps its `complete` status, which is what routes it; its cursor only ever
+-- served as the compare-and-set token its reconciliation lease claims against,
+-- and the new writer compares against the cleared value.
+-- stella-migration-safety: reviewed destructive-change - clears a derived
+-- rebuild cursor whose ordering this release replaces; the rebuild it belongs
+-- to reaches the same fixed point by re-walking.
+-- stella-migration-safety: reviewed bulk-backfill - the table holds one row
+-- per corpus-index generation, so the whole of it is a handful of rows.
+UPDATE "case_law_corpus_index_backfills"
+  SET "cursor_created_at" = NULL, "cursor_id" = NULL;--> statement-breakpoint
+
+ALTER TABLE "case_law_corpus_index_backfills"
+  ADD CONSTRAINT "case_law_corpus_index_backfills_cursor_pair"
+  CHECK (("cursor_walk_date" IS NULL) = ("cursor_id" IS NULL)) NOT VALID;--> statement-breakpoint
+
+-- `cursor_created_at` stays for now. A migration runs before the tasks of the
+-- release that stops selecting it have finished rolling out, and dropping it
+-- here would fail their checkpoint read, which the live pending drain shares.
+-- Drop it in the next release.
+
+-- A decision date is now part of two things it was not before: the document
+-- the projection writes (its timestamp field) and the walk's position. A
+-- correction to it therefore has to reach the pending queue. Without this, a
+-- date moving behind the cursor takes its row out of the walk's remaining
+-- range, and nothing else would notice.
+CREATE OR REPLACE FUNCTION enqueue_case_law_corpus_index_projection()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.content_hash IS NULL THEN
+      INSERT INTO case_law_corpus_index_projections (
+        generation,
+        decision_id,
+        pending_action,
+        pending_hash,
+        pending_index_ids,
+        pending_revision,
+        updated_at
+      )
+      SELECT checkpoint.generation, NEW.id, 'delete', null, '{}', 1, clock_timestamp()
+      FROM case_law_corpus_index_backfills AS checkpoint
+      WHERE EXISTS (
+        SELECT 1
+        FROM case_law_corpus_index_projections AS existing
+        WHERE existing.generation = checkpoint.generation
+          AND existing.decision_id = NEW.id
+      ) OR NOT EXISTS (
+        SELECT 1
+        FROM case_law_corpus_index_backfills AS newer
+        WHERE (newer.generation_order, newer.generation) >
+          (checkpoint.generation_order, checkpoint.generation)
+      )
+      ON CONFLICT ON CONSTRAINT case_law_corpus_index_projections_pk DO UPDATE
+      SET pending_action = EXCLUDED.pending_action,
+          pending_hash = EXCLUDED.pending_hash,
+          pending_index_ids = ARRAY(
+            SELECT DISTINCT target
+            FROM unnest(
+              case_law_corpus_index_projections.pending_index_ids || CASE
+                WHEN case_law_corpus_index_projections.index_id IS NULL THEN '{}'
+                ELSE ARRAY[case_law_corpus_index_projections.index_id]
+              END
+            ) AS target
+          ),
+          pending_revision = case_law_corpus_index_projections.pending_revision + 1,
+          updated_at = EXCLUDED.updated_at;
+      RETURN NEW;
+    END IF;
+
+    IF NEW.indexed_hash IS NOT NULL
+      AND NEW.content_hash IS NOT DISTINCT FROM OLD.content_hash
+      AND NEW.country IS NOT DISTINCT FROM OLD.country
+      AND NEW.decision_date IS NOT DISTINCT FROM OLD.decision_date
+    THEN
+      -- The ordinary incremental writer owns the serving generation while a
+      -- newer generation may be rebuilding. Its successful database mark is
+      -- also the authoritative projection commit for that serving generation;
+      -- the newer generation's independently queued action remains untouched.
+      -- The decision date joins this guard because it reaches the document:
+      -- an update that changes it is a content change for the index, however
+      -- unchanged the text is.
+      UPDATE case_law_corpus_index_projections AS projection
+      SET index_id = NEW.indexed_generation,
+          indexed_hash = NEW.indexed_hash,
+          updated_at = clock_timestamp()
+      WHERE projection.decision_id = NEW.id
+        AND NEW.indexed_generation =
+          (projection.generation || '_' || lower(NEW.country));
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  IF NEW.content_hash IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO case_law_corpus_index_projections (
+    generation,
+    decision_id,
+    pending_action,
+    pending_hash,
+    pending_index_ids,
+    pending_revision,
+    updated_at
+  )
+  SELECT checkpoint.generation,
+         NEW.id,
+         'index',
+         NEW.content_hash,
+         ARRAY[checkpoint.generation || '_' || lower(NEW.country)],
+         1,
+         clock_timestamp()
+  FROM case_law_corpus_index_backfills AS checkpoint
+  WHERE EXISTS (
+    SELECT 1
+    FROM case_law_corpus_index_projections AS existing
+    WHERE existing.generation = checkpoint.generation
+      AND existing.decision_id = NEW.id
+  ) OR NOT EXISTS (
+      SELECT 1
+      FROM case_law_corpus_index_backfills AS newer
+      WHERE (newer.generation_order, newer.generation) >
+        (checkpoint.generation_order, checkpoint.generation)
+    )
+  ON CONFLICT ON CONSTRAINT case_law_corpus_index_projections_pk DO UPDATE
+  SET pending_action = EXCLUDED.pending_action,
+      pending_hash = EXCLUDED.pending_hash,
+      pending_index_ids = ARRAY(
+        SELECT DISTINCT target
+        FROM unnest(
+          case_law_corpus_index_projections.pending_index_ids || EXCLUDED.pending_index_ids
+        ) AS target
+      ),
+      pending_revision = case_law_corpus_index_projections.pending_revision + 1,
+      updated_at = EXCLUDED.updated_at;
+
+  RETURN NEW;
+END
+$function$;--> statement-breakpoint
+
+-- stella-migration-safety: reviewed destructive-change - replaces only this
+-- trigger, to widen the column list it fires on; table data is unchanged.
+DROP TRIGGER IF EXISTS case_law_decisions_enqueue_corpus_index_projection
+  ON "case_law_decisions";--> statement-breakpoint
+CREATE TRIGGER case_law_decisions_enqueue_corpus_index_projection
+AFTER INSERT OR UPDATE OF content_hash, indexed_hash, country, decision_date
+ON "case_law_decisions"
+FOR EACH ROW
+EXECUTE FUNCTION enqueue_case_law_corpus_index_projection();--> statement-breakpoint
+
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block. Split
+-- the migrator transaction, lift the timeouts for the concurrent build, then
+-- restore and reopen a transaction for Drizzle's migration row. Same shape as
+-- 20260816210000_citation_authority_due_index.
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+
+-- Validated outside the transaction that added it, so the scan cannot hold
+-- reads for the rest of the migration. The rows it reads are the handful of
+-- generation checkpoints, all of them cleared above.
+ALTER TABLE "case_law_corpus_index_backfills"
+  VALIDATE CONSTRAINT "case_law_corpus_index_backfills_cursor_pair";--> statement-breakpoint
+
+-- The walk's page is an index range only if the index matches its ORDER BY
+-- expression for expression, direction and tiebreaker. Apply this before the
+-- next generation's rebuild starts; without it every page sorts the corpus.
+-- stella-migration-safety: reviewed destructive-change - drops only this
+-- migration's own index by name before recreating it. A cancelled concurrent
+-- build leaves an INVALID index behind, and IF NOT EXISTS would then skip
+-- recreating it.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_corpus_generation_date_cursor_idx";--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "case_law_decisions_corpus_generation_date_cursor_idx" ON "case_law_decisions" ((coalesce("decision_date", '-infinity'::date)),"id");--> statement-breakpoint
+
+-- The creation-ordered cursor index existed for this walk and has no other
+-- reader: the source-eligibility pass keys on (source_id, created_at, id) and
+-- the incremental scan on its own partial index.
+-- stella-migration-safety: reviewed destructive-change - drops the index the
+-- walk this migration re-orders was its only user.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_decisions_corpus_generation_cursor_idx";--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/drizzle/20260817150000_corpus_generation_date_walk/migration.sql
+++ b/apps/api/drizzle/20260817150000_corpus_generation_date_walk/migration.sql
@@ -11,6 +11,21 @@ SET statement_timeout = '5s';--> statement-breakpoint
 -- `(created_at, id)`, with undated decisions coalesced to `-infinity` so they
 -- form the first band and one row comparison expresses the whole cursor.
 
+-- The two orders cannot share one cursor slot, so this refuses to apply while
+-- a rebuild is in flight rather than reasoning about which release's worker
+-- wrote the position it finds. A release that stops here is recoverable: let
+-- the rebuild finish, or clear its checkpoint, and deploy again.
+DO $precondition$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM "case_law_corpus_index_backfills" WHERE "status" <> 'complete'
+  ) THEN
+    RAISE EXCEPTION
+      'corpus-index generation rebuild in flight; apply this migration between rebuilds';
+  END IF;
+END
+$precondition$;--> statement-breakpoint
+
 ALTER TABLE "case_law_corpus_index_backfills"
   ADD COLUMN "cursor_walk_date" date;--> statement-breakpoint
 

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -75,6 +75,11 @@ const APPROVED_PROCEDURAL_STATEMENTS = new Set([
   // Adds the chat reasoning-effort CHECK only when it is absent. The body is
   // static DDL; the conditional makes a partially applied migration retryable.
   "20260808003000_chat_reasoning_effort/migration.sql:871dd7588123b5ea2a092acac856c0427e4cf8673b8494bc94cf0a6dbd6cfd0f",
+  // Refuses to re-order the corpus-index rebuild's cursor while a rebuild is
+  // in flight. Reads one small checkpoint table and raises; it writes nothing,
+  // takes no lock beyond the read, and stopping the release is the intended
+  // outcome, since the two orders cannot share one cursor slot.
+  "20260817150000_corpus_generation_date_walk/migration.sql:06821016b65f9c0e7ab643794da37f29616a0ccbef91df3df8b1806197f5ac8c",
 ]);
 
 type TimeoutState = "bounded" | "unbounded" | "unset";

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -397,9 +397,16 @@ export const caseLawDecisions = p.pgTable(
       .on(t.languageGroupKey)
       .where(isNotNull(t.languageGroupKey)),
     p.index("case_law_decisions_created_at_idx").on(t.createdAt),
+    // The generation rebuild walks its snapshot in decision-date order, so the
+    // documents one split receives cover a contiguous span of dates and a
+    // timestamp-filtered query can skip the splits outside its window. The
+    // expression, direction and tiebreaker mirror the walk's ORDER BY exactly,
+    // so a page is an index range rather than a sort of the corpus. Undated
+    // decisions coalesce to `-infinity`: they sort first, as one band, matching
+    // the earliest-possible timestamp their documents carry.
     p
-      .index("case_law_decisions_corpus_generation_cursor_idx")
-      .on(t.createdAt, t.id),
+      .index("case_law_decisions_corpus_generation_date_cursor_idx")
+      .on(sql`coalesce(${t.decisionDate}, '-infinity'::date)`, t.id),
     p
       .index("case_law_decisions_source_generation_cursor_idx")
       .on(t.sourceId, t.createdAt, t.id),
@@ -1136,7 +1143,21 @@ export const caseLawCorpusIndexBackfills = p.pgTable(
         sql`substring("generation" from '^case_law_v([1-9][0-9]*)$')::integer`,
       ),
     snapshotAt: timestamptz("snapshot_at").defaultNow().notNull(),
+    /**
+     * The walk's previous, creation-ordered cursor. Nothing reads or writes it:
+     * it stays only because a migration runs before the tasks of the release
+     * that stops selecting it have finished rolling out, and a dropped column
+     * would fail their checkpoint read. Drop it in the release after
+     * `cursor_walk_date` ships.
+     */
     cursorCreatedAt: timestamptz("cursor_created_at"),
+    /**
+     * Keyset position in the walk's own order: the decision date the last
+     * indexed page ended on, `-infinity` while the walk is still in the undated
+     * band. Paired with `cursor_id`, which carries the ties a day-granular date
+     * leaves behind.
+     */
+    cursorWalkDate: p.date("cursor_walk_date"),
     cursorId: safeUuid<"caseLawDecision">("cursor_id"),
     status: p
       .text({ enum: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUSES })
@@ -1166,7 +1187,7 @@ export const caseLawCorpusIndexBackfills = p.pgTable(
     ),
     p.check(
       "case_law_corpus_index_backfills_cursor_pair",
-      sql`(${t.cursorCreatedAt} IS NULL) = (${t.cursorId} IS NULL)`,
+      sql`(${t.cursorWalkDate} IS NULL) = (${t.cursorId} IS NULL)`,
     ),
     p.check(
       "case_law_corpus_index_backfills_lease_pair",

--- a/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
@@ -36,15 +36,35 @@ const generationMigrationSource = new URL(
   "../../../drizzle/20260731170000_case_law_corpus_generation_backfill/migration.sql",
   import.meta.url,
 );
+const PROJECTION_TRIGGER_FUNCTION =
+  "CREATE OR REPLACE FUNCTION enqueue_case_law_corpus_index_projection()";
+
 /**
  * The projection trigger's current definition. `db:push` builds the test
  * database from the schema, which carries no triggers, so a test that needs
- * one installs it from the migration that last defined it.
+ * one installs it from a migration. Which migration is derived, not named:
+ * migrations apply in directory order, so the last one that redefines the
+ * function is the definition a database ends up with, and a later migration
+ * replacing it moves this with it.
  */
-const projectionTriggerSource = new URL(
-  "../../../drizzle/20260817150000_corpus_generation_date_walk/migration.sql",
-  import.meta.url,
-);
+const latestProjectionTriggerMigration = async (): Promise<string> => {
+  const drizzleDir = new URL("../../../drizzle/", import.meta.url);
+  const migrations = [
+    ...new Bun.Glob("*/migration.sql").scanSync(Bun.fileURLToPath(drizzleDir)),
+  ].sort();
+  let latest: string | undefined;
+  for (const migration of migrations) {
+    // oxlint-disable-next-line no-await-in-loop -- ordered scan over a directory listing
+    const source = await Bun.file(new URL(migration, drizzleDir)).text();
+    if (source.includes(PROJECTION_TRIGGER_FUNCTION)) {
+      latest = source;
+    }
+  }
+  if (latest === undefined) {
+    throw new Error("no migration defines the corpus projection trigger");
+  }
+  return latest;
+};
 const CREATED_AT = new Date("2026-07-30T12:00:00.000Z");
 const GENERATION = "case_law_v2";
 /**
@@ -219,15 +239,16 @@ const completeRemoteEffect = async (): Promise<void> => {
  * against the deployed definition rather than a paraphrase of it.
  */
 const installProjectionTrigger = async (): Promise<void> => {
-  const migration = await Bun.file(projectionTriggerSource).text();
-  const triggerStart = migration.indexOf(
-    "CREATE OR REPLACE FUNCTION enqueue_case_law_corpus_index_projection()",
+  const migration = await latestProjectionTriggerMigration();
+  const triggerStart = migration.indexOf(PROJECTION_TRIGGER_FUNCTION);
+  const triggerEnd = migration.indexOf(
+    "CREATE TRIGGER case_law_decisions_enqueue_corpus_index_projection",
   );
-  const triggerEnd = migration.indexOf("-- Drizzle wraps pending migrations");
   expect(triggerStart).toBeGreaterThanOrEqual(0);
   expect(triggerEnd).toBeGreaterThan(triggerStart);
+  const createTriggerEnd = migration.indexOf(";", triggerEnd);
   const statements = migration
-    .slice(triggerStart, triggerEnd)
+    .slice(triggerStart, createTriggerEnd + 1)
     .split("--> statement-breakpoint")
     .map((statement) => statement.trim())
     .filter((statement) => statement.length > 0);

--- a/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
@@ -36,8 +36,23 @@ const generationMigrationSource = new URL(
   "../../../drizzle/20260731170000_case_law_corpus_generation_backfill/migration.sql",
   import.meta.url,
 );
+/**
+ * The projection trigger's current definition. `db:push` builds the test
+ * database from the schema, which carries no triggers, so a test that needs
+ * one installs it from the migration that last defined it.
+ */
+const projectionTriggerSource = new URL(
+  "../../../drizzle/20260817150000_corpus_generation_date_walk/migration.sql",
+  import.meta.url,
+);
 const CREATED_AT = new Date("2026-07-30T12:00:00.000Z");
 const GENERATION = "case_law_v2";
+/**
+ * The walk's order, restated here so the fixtures read in it. Undated rows
+ * carry `-infinity`, which is the cursor value the runner stores for them.
+ */
+const UNDATED_WALK_DATE = "-infinity";
+const WALK_DATE = sql`coalesce(${caseLawDecisions.decisionDate}, '-infinity'::date)`;
 const noRemoteEffectCompensation = async (): Promise<void> => {
   await Promise.resolve();
 };
@@ -197,6 +212,35 @@ const indexedOutcome = (indexed: number) => ({
 
 const completeRemoteEffect = async (): Promise<void> => {
   await Promise.resolve();
+};
+
+/**
+ * Install the projection trigger as the migration defines it, so a test runs
+ * against the deployed definition rather than a paraphrase of it.
+ */
+const installProjectionTrigger = async (): Promise<void> => {
+  const migration = await Bun.file(projectionTriggerSource).text();
+  const triggerStart = migration.indexOf(
+    "CREATE OR REPLACE FUNCTION enqueue_case_law_corpus_index_projection()",
+  );
+  const triggerEnd = migration.indexOf("-- Drizzle wraps pending migrations");
+  expect(triggerStart).toBeGreaterThanOrEqual(0);
+  expect(triggerEnd).toBeGreaterThan(triggerStart);
+  const statements = migration
+    .slice(triggerStart, triggerEnd)
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
+  expect(statements).toHaveLength(3);
+  // The trigger fires on the columns that reach the document or the walk's
+  // position. A decision date now does both, so it has to be in this list.
+  expect(statements.at(-1)).toContain(
+    "UPDATE OF content_hash, indexed_hash, country, decision_date",
+  );
+  for (const statement of statements) {
+    // oxlint-disable-next-line no-await-in-loop -- function, replacement drop, and trigger creation are order-dependent DDL
+    await db.execute(sql.raw(statement));
+  }
 };
 
 const queueSourceReconciliation = async (
@@ -538,25 +582,7 @@ test("contentless inserts never create deletion projection work", async () => {
   });
 
   try {
-    const migration = await Bun.file(generationMigrationSource).text();
-    const triggerStart = migration.indexOf(
-      "CREATE OR REPLACE FUNCTION enqueue_case_law_corpus_index_projection()",
-    );
-    const triggerEnd = migration.indexOf(
-      "CREATE OR REPLACE FUNCTION enqueue_case_law_corpus_source_reconciliation()",
-    );
-    expect(triggerStart).toBeGreaterThanOrEqual(0);
-    expect(triggerEnd).toBeGreaterThan(triggerStart);
-    const triggerStatements = migration
-      .slice(triggerStart, triggerEnd)
-      .split("--> statement-breakpoint")
-      .map((statement) => statement.trim())
-      .filter((statement) => statement.length > 0);
-    expect(triggerStatements).toHaveLength(3);
-    for (const statement of triggerStatements) {
-      // oxlint-disable-next-line no-await-in-loop -- function, replacement drop, and trigger creation are order-dependent DDL
-      await db.execute(sql.raw(statement));
-    }
+    await installProjectionTrigger();
 
     await db.insert(caseLawDecisions).values({
       caseNumber: "63 T 63/2026",
@@ -659,8 +685,8 @@ test(
     expect(guardedPages).toBe(3);
     const checkpoint = await readCheckpoint(GENERATION);
     expect(checkpoint).toMatchObject({
-      cursorCreatedAt: CREATED_AT,
       cursorId: publicLastId,
+      cursorWalkDate: "2026-01-01",
       leaseExpiresAt: null,
       leaseToken: null,
       status: "complete",
@@ -1344,8 +1370,8 @@ test(
 
     const failed = await readCheckpoint(retryGeneration);
     expect(failed).toMatchObject({
-      cursorCreatedAt: null,
       cursorId: null,
+      cursorWalkDate: null,
       leaseExpiresAt: null,
       leaseToken: null,
       status: "running",
@@ -1379,8 +1405,8 @@ test(
       ),
     });
     expect(await readCheckpoint(retryGeneration)).toMatchObject({
-      cursorCreatedAt: null,
       cursorId: null,
+      cursorWalkDate: null,
       leaseExpiresAt: null,
       leaseToken: null,
       status: "running",
@@ -1460,8 +1486,8 @@ test(
     expect(winningRemoteEffects).toBe(1);
     expect(staleRemoteEffects).toBe(0);
     expect(await readCheckpoint(generation)).toMatchObject({
-      cursorCreatedAt: CREATED_AT,
       cursorId: publicFirstId,
+      cursorWalkDate: "2026-01-01",
       leaseExpiresAt: null,
       leaseToken: null,
       status: "running",
@@ -1611,8 +1637,8 @@ test(
         expect.arrayContaining([staleIndexId, successorIndexId]),
       );
       expect(await readCheckpoint(generation)).toMatchObject({
-        cursorCreatedAt: CREATED_AT,
         cursorId: staleDecisionId,
+        cursorWalkDate: "2026-01-01",
         leaseExpiresAt: null,
         leaseToken: null,
         status: "running",
@@ -2610,19 +2636,19 @@ test(
     const boundary = (
       await db
         .select({
-          createdAtToken: timestampCasToken(caseLawDecisions.createdAt),
+          decisionDate: caseLawDecisions.decisionDate,
           id: caseLawDecisions.id,
         })
         .from(caseLawDecisions)
-        .orderBy(desc(caseLawDecisions.createdAt), desc(caseLawDecisions.id))
+        .orderBy(sql`${WALK_DATE} DESC`, desc(caseLawDecisions.id))
         .limit(1)
     ).at(0);
     if (!boundary) {
       throw new Error("expected seeded decisions");
     }
     await db.insert(caseLawCorpusIndexBackfills).values({
-      cursorCreatedAt: sql`${boundary.createdAtToken}::timestamptz`,
       cursorId: boundary.id,
+      cursorWalkDate: boundary.decisionDate ?? UNDATED_WALK_DATE,
       generation,
       snapshotAt: await nextBackfillSnapshotAt(),
       status: "running",
@@ -2645,6 +2671,207 @@ test(
       await db
         .delete(caseLawCorpusIndexBackfills)
         .where(eq(caseLawCorpusIndexBackfills.generation, generation));
+    }
+  },
+  { timeout: 30_000 },
+);
+
+/**
+ * A walk fixture built to break a keyset: one date carried by many rows (the
+ * tie group a day-granular key leaves behind), dates out of insertion order,
+ * and undated rows, whose walk position is the `-infinity` band.
+ */
+const walkFixtureRows = (sourceId: SafeId<"caseLawSource">) =>
+  [
+    { date: "2026-03-04", suffix: "01" },
+    { date: null, suffix: "02" },
+    { date: "1994-11-30", suffix: "03" },
+    { date: "2026-03-04", suffix: "04" },
+    { date: "2026-03-04", suffix: "05" },
+    { date: null, suffix: "06" },
+    { date: "1994-11-30", suffix: "07" },
+    { date: "2011-07-19", suffix: "08" },
+    { date: "2026-03-04", suffix: "09" },
+    { date: "1994-11-30", suffix: "10" },
+  ].map(({ date, suffix }) => ({
+    caseNumber: `walk ${suffix}`,
+    contentHash: `walk-${suffix}`,
+    country: "CZE",
+    court: "Walk court",
+    createdAt: CREATED_AT,
+    decisionDate: date,
+    id: toSafeId<"caseLawDecision">(
+      `00000000-0000-4000-8000-0000000009${suffix}`,
+    ),
+    language: "cs",
+    languageGroupKey: `walk-${suffix}`,
+    slug: `walk-${suffix}`,
+    sourceId,
+  }));
+
+test(
+  "the walk covers its snapshot exactly once at any page size, in date order",
+  async () => {
+    // The rebuild's page boundaries are wherever the batch size and the
+    // scheduler put them, and the cursor is all that carries the walk across
+    // them. Ties and the undated band are where a keyset drops or repeats a
+    // row, so the same fixture is walked at several page sizes: a page size
+    // that divides the tie group and one that splits it mid-way both have to
+    // reach the same set.
+    const sourceId = toSafeId<"caseLawSource">(
+      "00000000-0000-4000-8000-000000000901",
+    );
+    const rows = walkFixtureRows(sourceId);
+    await db
+      .insert(caseLawSources)
+      .values({ adapterKey: "walk", id: sourceId, name: "walk" });
+    await db.insert(caseLawDecisions).values(rows);
+    const fixtureIds = new Set(rows.map((row) => row.id));
+
+    try {
+      for (const [index, batchSize] of [1, 2, 3, 7].entries()) {
+        const generation = `case_law_v7${index}`;
+        const seen: {
+          decisionDate: string | null;
+          id: SafeId<"caseLawDecision">;
+        }[] = [];
+        let lease = 0;
+        const backfill = createCaseLawGenerationBackfill({
+          backfillRows: async (_runnerDb, batch) => {
+            for (const row of batch) {
+              seen.push({ decisionDate: row.decisionDate, id: row.id });
+            }
+            return indexedOutcome(batch.length);
+          },
+          newLeaseToken: () =>
+            `00000000-0000-4000-8000-${String(++lease).padStart(12, "0")}`,
+          removeProjection: ignoreProjectionRemoval,
+        });
+
+        // Bounded so a cursor that stops advancing fails here rather than
+        // hanging: every page either moves the cursor or ends the walk.
+        let pages = 0;
+        let status = "";
+        while (status !== "complete" && pages < 200) {
+          pages += 1;
+          // oxlint-disable-next-line no-await-in-loop -- the walk is sequential by construction
+          status = (await backfill(scopedDb, batchSize, generation)).status;
+        }
+        expect(status).toBe("complete");
+
+        const fixtureSeen = seen.filter((row) => fixtureIds.has(row.id));
+        // Exactly once: no row skipped over a page boundary, none repeated.
+        expect(fixtureSeen.map((row) => row.id).sort()).toEqual(
+          [...fixtureIds].sort(),
+        );
+        // And in the order the documents will carry: undated first, then by
+        // date. Asserted over every row the walk handed out, not just the
+        // fixture's, because a break in the order anywhere is a break.
+        const walkKeys = seen.map((row) => ({
+          date: row.decisionDate ?? "",
+          id: row.id,
+        }));
+        const ordered = [...walkKeys].sort((left, right) => {
+          if (left.date !== right.date) {
+            return left.date < right.date ? -1 : 1;
+          }
+          if (left.id === right.id) {
+            return 0;
+          }
+          return left.id < right.id ? -1 : 1;
+        });
+        expect(walkKeys).toEqual(ordered);
+      }
+    } finally {
+      await db
+        .delete(caseLawCorpusIndexBackfills)
+        .where(
+          inArray(caseLawCorpusIndexBackfills.generation, [
+            "case_law_v70",
+            "case_law_v71",
+            "case_law_v72",
+            "case_law_v73",
+          ]),
+        );
+      await db
+        .delete(caseLawDecisions)
+        .where(inArray(caseLawDecisions.id, [...fixtureIds]));
+      await db.delete(caseLawSources).where(eq(caseLawSources.id, sourceId));
+    }
+  },
+  { timeout: 60_000 },
+);
+
+test(
+  "a corrected decision date reaches the pending queue",
+  async () => {
+    // The walk's position is the decision date, so a correction to it can move
+    // a row behind the cursor, out of the range the walk has left. Nothing
+    // else would notice: the text is unchanged, so the content hash is too.
+    const generation = "case_law_v74";
+    const sourceId = toSafeId<"caseLawSource">(
+      "00000000-0000-4000-8000-000000000902",
+    );
+    const decisionId = toSafeId<"caseLawDecision">(
+      "00000000-0000-4000-8000-000000000903",
+    );
+    await db
+      .insert(caseLawSources)
+      .values({ adapterKey: "redate", id: sourceId, name: "redate" });
+    await db.insert(caseLawCorpusIndexBackfills).values({
+      generation,
+      snapshotAt: await nextBackfillSnapshotAt(),
+      status: "running",
+    });
+
+    try {
+      await installProjectionTrigger();
+      await db.insert(caseLawDecisions).values({
+        caseNumber: "74 T 74/2026",
+        contentHash: "redate",
+        country: "CZE",
+        court: "Redate court",
+        createdAt: CREATED_AT,
+        decisionDate: "2026-02-02",
+        id: decisionId,
+        indexedGeneration: corpusIndexId(generation, "CZE"),
+        indexedHash: "redate",
+        language: "cs",
+        languageGroupKey: "redate",
+        slug: "redate",
+        sourceId,
+      });
+      // The insert enqueues; clearing that is what makes the update the only
+      // thing the assertion can be reading.
+      await db
+        .delete(caseLawCorpusIndexProjections)
+        .where(eq(caseLawCorpusIndexProjections.decisionId, decisionId));
+
+      await db
+        .update(caseLawDecisions)
+        .set({ decisionDate: "1998-05-06" })
+        .where(eq(caseLawDecisions.id, decisionId));
+
+      expect(
+        await db
+          .select({
+            pendingAction: caseLawCorpusIndexProjections.pendingAction,
+            pendingHash: caseLawCorpusIndexProjections.pendingHash,
+          })
+          .from(caseLawCorpusIndexProjections)
+          .where(eq(caseLawCorpusIndexProjections.decisionId, decisionId)),
+      ).toEqual([{ pendingAction: "index", pendingHash: "redate" }]);
+    } finally {
+      await db
+        .delete(caseLawCorpusIndexProjections)
+        .where(eq(caseLawCorpusIndexProjections.decisionId, decisionId));
+      await db
+        .delete(caseLawDecisions)
+        .where(eq(caseLawDecisions.id, decisionId));
+      await db
+        .delete(caseLawCorpusIndexBackfills)
+        .where(eq(caseLawCorpusIndexBackfills.generation, generation));
+      await db.delete(caseLawSources).where(eq(caseLawSources.id, sourceId));
     }
   },
   { timeout: 30_000 },

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -1077,6 +1077,14 @@ const backfillIncrementalCorpusIndex = async (
  * page stays a single index range. Undated decisions sort first, which is
  * where the documents written for them belong — they carry the earliest
  * timestamp the mapping can hold.
+ *
+ * What this orders is the snapshot walk, which is the whole corpus. It does
+ * not order the pending queue: that drains before each page, in decision-id
+ * order, and its documents carry whatever dates live traffic corrected or
+ * ingested. Those widen the split they land in, bounded by the commit that
+ * publishes them. Holding them back until the rebuild finished is the wedge
+ * the drain exists to prevent, so the banding is a property of the rebuild's
+ * own pages, not of every document the generation ever receives.
  */
 const NEGATIVE_INFINITY_DATE = "-infinity";
 

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -1064,28 +1064,106 @@ const backfillIncrementalCorpusIndex = async (
 };
 
 /**
- * Keyset and snapshot timestamps travel as exact-precision text tokens, never
- * as `Date`: Postgres keeps microseconds, a `Date` keeps milliseconds, and a
- * truncated cursor re-selects the row it was written from forever.
+ * The order the snapshot walk visits its rows in, and the order the engine
+ * receives their documents in: by decision date, undated decisions first.
+ *
+ * A split's timestamp range spans everything written into it, so the walk's
+ * order is what decides whether a date-filtered query can skip a split or has
+ * to open it. Walking by decision date gives each split a contiguous span of
+ * dates; walking by anything else gives every split the corpus' whole range.
+ *
+ * `coalesce(..., '-infinity')` rather than a null-placement rule: the walk key
+ * is then never null, so one row comparison expresses the whole cursor and the
+ * page stays a single index range. Undated decisions sort first, which is
+ * where the documents written for them belong — they carry the earliest
+ * timestamp the mapping can hold.
+ */
+const NEGATIVE_INFINITY_DATE = "-infinity";
+
+// Inlined rather than bound: the planner matches an expression index by the
+// expression, and a bind parameter is not the constant the index was built on.
+const walkDate = sql`coalesce(${caseLawDecisions.decisionDate}, ${sql.raw(
+  `'${NEGATIVE_INFINITY_DATE}'`,
+)}::date)`;
+
+/**
+ * Where the walk stopped. A `date` is day-granular and round-trips exactly, so
+ * unlike a timestamp cursor it cannot be truncated into re-selecting its own
+ * row; what it does leave is large tie groups, which `id` orders.
+ */
+type GenerationWalkCursor = {
+  id: SafeId<"caseLawDecision">;
+  walkDate: string;
+};
+
+/**
+ * Snapshot timestamps travel as exact-precision text tokens, never as `Date`:
+ * Postgres keeps microseconds, a `Date` keeps milliseconds, and a truncated
+ * boundary re-selects the row it was written from forever.
  */
 type GenerationBackfillCheckpoint = {
-  cursorCreatedAt: TimestampCasToken | null;
-  cursorId: SafeId<"caseLawDecision"> | null;
+  cursor: GenerationWalkCursor | null;
   generation: string;
   generationOrder: number;
   snapshotAt: TimestampCasToken;
 };
 
 const GENERATION_CHECKPOINT_COLUMNS = {
-  cursorCreatedAt: timestampCasToken(
-    caseLawCorpusIndexBackfills.cursorCreatedAt,
-  ),
   cursorId: caseLawCorpusIndexBackfills.cursorId,
+  cursorWalkDate: caseLawCorpusIndexBackfills.cursorWalkDate,
   generation: caseLawCorpusIndexBackfills.generation,
   generationOrder: caseLawCorpusIndexBackfills.generationOrder,
   snapshotAt: timestampCasToken(caseLawCorpusIndexBackfills.snapshotAt),
   status: caseLawCorpusIndexBackfills.status,
 };
+
+type GenerationCheckpointRow = {
+  cursorId: SafeId<"caseLawDecision"> | null;
+  cursorWalkDate: string | null;
+  generation: string;
+  generationOrder: number;
+  snapshotAt: TimestampCasToken;
+};
+
+/**
+ * Read a checkpoint row as a checkpoint. The date and the id are stored
+ * together or not at all (`case_law_corpus_index_backfills_cursor_pair`), so a
+ * half-set cursor is a database invariant violation rather than a state to
+ * handle.
+ */
+const toGenerationCheckpoint = ({
+  cursorId,
+  cursorWalkDate,
+  generation,
+  generationOrder,
+  snapshotAt,
+}: GenerationCheckpointRow): GenerationBackfillCheckpoint => {
+  if (cursorWalkDate === null || cursorId === null) {
+    if (cursorWalkDate !== null || cursorId !== null) {
+      panic("case-law corpus generation cursor is half set");
+    }
+    return { cursor: null, generation, generationOrder, snapshotAt };
+  }
+  return {
+    cursor: { id: cursorId, walkDate: cursorWalkDate },
+    generation,
+    generationOrder,
+    snapshotAt,
+  };
+};
+
+/**
+ * The walk key of the row a page ended on, as checkpoint columns. An undated
+ * row stores the same `-infinity` the walk ordered it by, so the cursor is
+ * exactly the position the next page resumes from.
+ */
+const nextGenerationWalkCursorColumns = (row: {
+  decisionDate: string | null;
+  id: SafeId<"caseLawDecision">;
+}) => ({
+  cursorId: row.id,
+  cursorWalkDate: row.decisionDate ?? NEGATIVE_INFINITY_DATE,
+});
 
 type GenerationBackfillRow = IndexableRow & {
   createdAtToken: TimestampCasToken;
@@ -1246,11 +1324,8 @@ const sameCursor = ({
   checkpoint: GenerationBackfillCheckpoint;
 }) =>
   and(
-    timestampMatchesCasToken(
-      caseLawCorpusIndexBackfills.cursorCreatedAt,
-      checkpoint.cursorCreatedAt,
-    ),
-    sql`${caseLawCorpusIndexBackfills.cursorId} IS NOT DISTINCT FROM ${checkpoint.cursorId}`,
+    sql`${caseLawCorpusIndexBackfills.cursorWalkDate} IS NOT DISTINCT FROM ${checkpoint.cursor?.walkDate ?? null}::date`,
+    sql`${caseLawCorpusIndexBackfills.cursorId} IS NOT DISTINCT FROM ${checkpoint.cursor?.id ?? null}`,
   );
 
 const nextLeaseExpiry = () =>
@@ -1296,13 +1371,18 @@ const selectGenerationBackfillPage = async (
       )
       .where(
         and(
+          // The set is fixed by creation time, which no update moves; the
+          // cursor orders that set by decision date, which one can. A date
+          // correction therefore enqueues the row on the pending queue (see
+          // the projection trigger), because a row whose key moved behind the
+          // cursor is a row this walk will not reach again.
           sql`${caseLawDecisions.createdAt} <= ${checkpoint.snapshotAt}::timestamptz`,
-          checkpoint.cursorCreatedAt === null
+          checkpoint.cursor === null
             ? undefined
-            : sql`(${caseLawDecisions.createdAt}, ${caseLawDecisions.id}) > (${checkpoint.cursorCreatedAt}::timestamptz, ${checkpoint.cursorId})`,
+            : sql`(${walkDate}, ${caseLawDecisions.id}) > (${checkpoint.cursor.walkDate}::date, ${checkpoint.cursor.id})`,
         ),
       )
-      .orderBy(asc(caseLawDecisions.createdAt), asc(caseLawDecisions.id))
+      .orderBy(walkDate, asc(caseLawDecisions.id))
       .limit(batchSize),
   );
 
@@ -1508,7 +1588,7 @@ export const createCaseLawGenerationBackfill =
       return { indexed: 0, status: BACKFILL_STATUS.BUSY };
     }
     try {
-      const checkpoint = await scopedDb(async (tx) => {
+      const checkpointRow = await scopedDb(async (tx) => {
         // audit: skip — the checkpoint is the durable audit trail for this derived projection rebuild
         const existing = (
           await tx
@@ -1524,7 +1604,7 @@ export const createCaseLawGenerationBackfill =
         // Wait for decision writes that already acquired their table lock, then
         // capture statement time while new writers are held out. Together with
         // the decision column's clock_timestamp() default, no later commit can
-        // appear behind this rebuild's (created_at,id) cursor.
+        // land inside the snapshot this rebuild walks.
         await tx.execute(
           sql`LOCK TABLE ${caseLawDecisions}, ${caseLawSources} IN SHARE MODE`,
         );
@@ -1550,6 +1630,7 @@ export const createCaseLawGenerationBackfill =
         }
         return concurrent;
       });
+      const checkpoint = toGenerationCheckpoint(checkpointRow);
 
       type LeaseGuardOptions = {
         checkpoint: GenerationBackfillCheckpoint;
@@ -1853,7 +1934,7 @@ export const createCaseLawGenerationBackfill =
       };
 
       if (
-        checkpoint.status === CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE
+        checkpointRow.status === CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE
       ) {
         const reconciliationToken = newLeaseToken();
         const claimedReconciliation = await scopedDb(async (tx) => {
@@ -1884,13 +1965,9 @@ export const createCaseLawGenerationBackfill =
         if (!claimedReconciliation) {
           return { indexed: 0, status: BACKFILL_STATUS.BUSY };
         }
-        const reconciliationCheckpoint: GenerationBackfillCheckpoint = {
-          cursorCreatedAt: claimedReconciliation.cursorCreatedAt,
-          cursorId: claimedReconciliation.cursorId,
-          generation: claimedReconciliation.generation,
-          generationOrder: claimedReconciliation.generationOrder,
-          snapshotAt: claimedReconciliation.snapshotAt,
-        };
+        const reconciliationCheckpoint = toGenerationCheckpoint(
+          claimedReconciliation,
+        );
         try {
           return await reconcilePending({
             checkpoint: reconciliationCheckpoint,
@@ -1932,13 +2009,7 @@ export const createCaseLawGenerationBackfill =
         return { indexed: 0, status: BACKFILL_STATUS.BUSY };
       }
 
-      const claimedCheckpoint: GenerationBackfillCheckpoint = {
-        cursorCreatedAt: claimed.cursorCreatedAt,
-        cursorId: claimed.cursorId,
-        generation: claimed.generation,
-        generationOrder: claimed.generationOrder,
-        snapshotAt: claimed.snapshotAt,
-      };
+      const claimedCheckpoint = toGenerationCheckpoint(claimed);
       const runningGuards = createLeaseGuards({
         checkpoint: claimedCheckpoint,
         leaseToken,
@@ -2037,13 +2108,7 @@ export const createCaseLawGenerationBackfill =
         if (!completed) {
           return withDrained({ indexed: 0, status: BACKFILL_STATUS.BUSY });
         }
-        const completedCheckpoint: GenerationBackfillCheckpoint = {
-          cursorCreatedAt: completed.cursorCreatedAt,
-          cursorId: completed.cursorId,
-          generation: completed.generation,
-          generationOrder: completed.generationOrder,
-          snapshotAt: completed.snapshotAt,
-        };
+        const completedCheckpoint = toGenerationCheckpoint(completed);
         try {
           return withDrained(
             await reconcilePending({
@@ -2111,8 +2176,7 @@ export const createCaseLawGenerationBackfill =
         const advancedRows = await tx
           .update(caseLawCorpusIndexBackfills)
           .set({
-            cursorCreatedAt: sql`${last.createdAtToken}::timestamptz`,
-            cursorId: last.id,
+            ...nextGenerationWalkCursorColumns(last),
             leaseExpiresAt: null,
             leaseToken: null,
           })
@@ -2141,7 +2205,7 @@ export const createCaseLawGenerationBackfill =
 
 /**
  * Advance one durable generation-rebuild page. The page is bounded by the
- * `(created_at,id)` cursor before any generation comparison is made, so a
+ * `(decision_date,id)` cursor before any generation comparison is made, so a
  * cutover never turns into a table scan.
  */
 export const backfillCorpusIndexGenerationPage =


### PR DESCRIPTION
The corpus-index generation rebuild walked its snapshot in creation order. A split's timestamp range spans everything written into it, so that order gave every split the corpus' whole date range, and a date-filtered query had nothing to skip. The walk now goes in decision-date order, so a split holds a contiguous span of dates.

## The cursor

`(decision_date, id)` replaces `(created_at, id)`.

Undated decisions coalesce to `-infinity`, which puts them in the first band, where the documents written for them belong. It also keeps the walk key non-null, so one row comparison expresses the whole cursor and a page stays a single index range rather than a filter over a scan.

A `date` is day-granular and round-trips exactly, so it cannot be truncated into re-selecting the row it was written from, the way a timestamp cursor can. What day granularity does leave is large tie groups; `id` orders them.

## Completeness

The set the walk covers is fixed by `created_at <= snapshot_at`, and no update moves a row's creation time. Its *ordering* key is not immutable: a corrected decision date can move a row behind the cursor, out of the range the walk has left to visit.

So the projection trigger now also fires on `decision_date`, and its serving-generation fast path no longer swallows a date-only update. That path exists for the incremental writer's own index marks, and it required the content hash and country to be unchanged; the decision date joins them because it reaches the document (the date, the year facet, and the timestamp field are all written from it). A date-only correction on an already-indexed row previously left a stale date in the index; it now enqueues, which is also what keeps the walk complete.

## Migration

It refuses to apply while any generation checkpoint is not `complete`: the two orders cannot share one cursor slot, so a rebuild in flight has to finish (or have its checkpoint cleared) before this lands. Between rebuilds there is no cursor for a worker of either release to advance.

- adds `case_law_decisions (coalesce(decision_date, '-infinity'), id)` CONCURRENTLY, matching the walk's ORDER BY expression, direction and tiebreaker;
- drops the creation-ordered cursor index, whose only reader was this walk;
- adds `cursor_walk_date` and moves the cursor pair check to it;
- clears every stored cursor, because a position in creation order is not a position in date order. A rebuild still running restarts: it re-scans and re-indexes nothing, since a row already rebuilt into the generation is current and is skipped. A finished rebuild keeps the `complete` status that routes it.

`cursor_created_at` stays for one release. A migration runs before the tasks of the release that stops selecting it have finished rolling out, and dropping it now would fail their checkpoint read, which the live pending drain shares.

**Apply the migration before the next generation's rebuild starts**; without the index every page sorts the corpus instead of scanning a range.

## What this does not order

The pending queue. It drains before each page, in decision-id order, carrying whatever dates live traffic ingested or corrected, and those documents widen the split they land in, bounded by the commit that publishes them. Holding them until the rebuild finished is the wedge the drain exists to prevent, so the banding is a property of the rebuild's own pages, not of every document the generation receives.

## Verification

Every committed migration applied to a fresh PostgreSQL 18 database, then, with 200k synthetic decisions (5% undated, dates clustered onto ~2000 days so tie groups are large), `EXPLAIN (ANALYZE)` of the walk's own statement:

- first page, resumed page inside the dated band, and resumed page inside the undated band are all `Index Scan using case_law_decisions_corpus_generation_date_cursor_idx`, one index search, `Index Cond: ROW(COALESCE(decision_date, '-infinity'), id) > ROW(...)`, no Sort node, ~506 buffers for a 500-row page;
- `drizzle-kit push` against the migrated database reports nothing to change for these objects;
- the precondition guard raises when a `running` checkpoint is present, and the chain applies when none is.

Tests (PGlite, against the real schema and the migration's own trigger text): the walk is driven end to end at page sizes 1, 2, 3 and 7 over a fixture built to break a keyset (a tie group of four on one date, dates out of insertion order, undated rows), asserting every row is handed out exactly once and that the order the engine would receive is non-decreasing in `(date, id)`. A second test drives a date-only correction through the trigger and asserts the pending queue picks it up.

Mutation-checked: reverting the ORDER BY to creation order, comparing the cursor on creation time while the order stays by date, removing `decision_date` from the trigger's column list, and restoring the fast path that ignored a date change each fail the suite.
