### PR TITLE
fix(api): skip corpus writes for unchanged or empty content

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/pipeline-canonical.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline-canonical.test.ts
@@ -12,7 +12,7 @@ import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter"
 import { createSafeId } from "@/api/lib/branded-types";
 import { DatabaseError, TimeoutError } from "@/api/lib/errors/tagged-errors";
 import type { CaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
-import type { WriteCorpusResult } from "@/api/lib/legal-search/corpus-storage";
+import type { CorpusWriteOutcome } from "@/api/lib/legal-search/corpus-storage";
 import { caseLawSourceRow } from "@/api/tests/helpers/case-law-source-row";
 
 /**
@@ -30,19 +30,20 @@ const events: string[] = [];
 const insertedRows: Record<string, unknown>[] = [];
 const updatedDecisionRows: Record<string, unknown>[] = [];
 
-const CORPUS_KEYS = {
-  textKey: "corpus/text.zst",
-  sectionsKey: "corpus/sections.json.zst",
-  astKey: "corpus/ast.json.zst",
-} as const;
-
+// The double runs the real redundancy decision and fakes only the S3 I/O,
+// so a payload the planner refuses is refused here for the same reason it
+// would be in production, not because a fixture said so.
 const writeCorpusDocumentMock = mock(
-  async (input: { documentId: string }): Promise<WriteCorpusResult> => {
+  async (
+    input: Parameters<typeof realCorpusStorage.writeCorpusDocument>[0],
+  ): Promise<CorpusWriteOutcome> => {
+    const plan = realCorpusStorage.planCorpusDocumentWrite(input);
+    if (plan.type !== "put") {
+      events.push(`corpus-skip:${plan.type}`);
+      return await Promise.resolve(plan);
+    }
     events.push(`corpus-write:${input.documentId}`);
-    return await Promise.resolve({
-      ...CORPUS_KEYS,
-      contentHash: "content-hash",
-    });
+    return await Promise.resolve({ type: "written", written: plan.written });
   },
 );
 
@@ -77,8 +78,12 @@ void mock.module("@/api/lib/legal-search/corpus-storage", () => ({
 
 const { czNsAdapter } =
   await import("@/api/handlers/case-law/ingestion/adapters/cz-ns");
-const { processDecision, runIngestionPipeline } =
-  await import("@/api/handlers/case-law/ingestion/pipeline");
+const {
+  caseLawCanonicalPayload,
+  processDecision,
+  runIngestionPipeline,
+  sanitizeResult,
+} = await import("@/api/handlers/case-law/ingestion/pipeline");
 
 const originalCzNsFetchPage = czNsAdapter.fetchPage;
 
@@ -129,6 +134,25 @@ const decision: IngestionResult = {
   metadata: {},
   rawHash: "raw-hash",
   documentAst: {},
+};
+
+/**
+ * The write the settle path records for `decision`'s canonical payload,
+ * derived with the same functions the pipeline uses so the fixture cannot
+ * drift from what production would store.
+ */
+const recordedCorpusWrite = (documentId: string) => {
+  const contentHash = realCorpusStorage.corpusContentHash(
+    caseLawCanonicalPayload(sanitizeResult(decision)),
+  );
+  return {
+    ...realCorpusStorage.corpusKeys({
+      documentId,
+      jurisdiction: decision.country,
+      contentHash,
+    }),
+    contentHash,
+  };
 };
 
 /**
@@ -276,14 +300,15 @@ describe("processDecision — canonical storage mode", () => {
       astS3Key: null,
       contentHash: null,
     });
+    const written = recordedCorpusWrite(String(row?.["id"]));
     expect(updatedDecisionRows.at(-1)).toMatchObject({
       fulltext: null,
       sections: null,
       documentAst: null,
-      textS3Key: "corpus/text.zst",
-      normalizedS3Key: "corpus/sections.json.zst",
-      astS3Key: "corpus/ast.json.zst",
-      contentHash: "content-hash",
+      textS3Key: written.textKey,
+      normalizedS3Key: written.sectionsKey,
+      astS3Key: written.astKey,
+      contentHash: written.contentHash,
       corpusMirrorStatus: "settled",
     });
     expect(events.at(-1)).toBe("intent-delete");
@@ -328,6 +353,10 @@ describe("processDecision — canonical storage mode", () => {
       sourceObservationHash: "first-listing-hash",
       sourceObservationOrder: 1n,
       corpusMirrorStatus: "pending",
+      contentHash: null,
+      textS3Key: null,
+      normalizedS3Key: null,
+      astS3Key: null,
       redactedAt: null,
       sourceRawS3Key: "raw/recovered-detail.html",
       sourceRawContentType: "text/html",
@@ -383,6 +412,10 @@ describe("processDecision — canonical storage mode", () => {
       id: createSafeId<"caseLawDecision">(),
       metadata: {},
       sourceHash: "older-hash",
+      contentHash: null,
+      textS3Key: null,
+      normalizedS3Key: null,
+      astS3Key: null,
       sourceRawS3Key: null,
       sourceRawContentType: null,
     };
@@ -436,6 +469,157 @@ describe("processDecision — canonical storage mode", () => {
       reason: "corpus-write",
     });
     expect(writeCorpusDocumentMock).not.toHaveBeenCalled();
+  });
+
+  test("stores nothing and settles null pointers for a metadata-only decision", async () => {
+    const outcome = await processDecision({
+      // A metadata-first observation: identity fields only, the empty-AST
+      // placeholder, no fulltext — the shape a deferred-document adapter
+      // returns for every listing row.
+      input: { ...decision, fulltext: undefined },
+      observationOrder: 1n,
+      sourceId: createSafeId<"caseLawSource">(),
+      scopedDb,
+      observedAt: new Date("2026-07-31T12:00:00.000Z"),
+    });
+
+    expect(outcome).toEqual({
+      status: "complete",
+      inserted: true,
+      searchVectorFailed: false,
+    });
+    expect(events).toContain("corpus-skip:skipped-empty");
+    expect(events.filter((e) => e.startsWith("corpus-write:"))).toHaveLength(0);
+    const settled = updatedDecisionRows.at(-1);
+    expect(settled).toMatchObject({
+      corpusMirrorStatus: "settled",
+      textS3Key: null,
+      normalizedS3Key: null,
+      astS3Key: null,
+      contentHash: null,
+    });
+    // Nothing in object storage backs this row, so the settle must not
+    // trim the Postgres payload columns.
+    expect(settled).not.toHaveProperty("fulltext");
+    expect(events.at(-1)).toBe("intent-delete");
+  });
+
+  test("skips the corpus PUT when a settled row already records the payload", async () => {
+    const decisionId = createSafeId<"caseLawDecision">();
+    const recorded = recordedCorpusWrite(decisionId);
+    existingDecision = {
+      id: decisionId,
+      metadata: {},
+      // The publisher's raw hash moved (a metadata change) …
+      sourceHash: "older-hash",
+      sourceObservedAt: new Date("2026-07-31T11:00:00.000Z"),
+      sourceObservationHash: "older-hash",
+      sourceObservationOrder: 0n,
+      // … while the canonical payload the row settled did not.
+      corpusMirrorStatus: "settled",
+      contentHash: recorded.contentHash,
+      textS3Key: recorded.textKey,
+      normalizedS3Key: recorded.sectionsKey,
+      astS3Key: recorded.astKey,
+      redactedAt: null,
+      sourceRawS3Key: null,
+      sourceRawContentType: null,
+    };
+
+    const outcome = await processDecision({
+      input: decision,
+      observationOrder: 1n,
+      sourceId: createSafeId<"caseLawSource">(),
+      scopedDb,
+      observedAt: new Date("2026-07-31T12:00:00.000Z"),
+    });
+
+    expect(outcome).toEqual({
+      status: "complete",
+      inserted: true,
+      searchVectorFailed: false,
+    });
+    expect(events).toContain("corpus-skip:skipped-unchanged");
+    expect(events.filter((e) => e.startsWith("corpus-write:"))).toHaveLength(0);
+    // The mirror settles back onto the pointers it already held.
+    expect(updatedDecisionRows.at(-1)).toMatchObject({
+      corpusMirrorStatus: "settled",
+      textS3Key: recorded.textKey,
+      normalizedS3Key: recorded.sectionsKey,
+      astS3Key: recorded.astKey,
+      contentHash: recorded.contentHash,
+    });
+    expect(events.at(-1)).toBe("intent-delete");
+  });
+
+  test("a pending mirror settles once and then stops writing", async () => {
+    const decisionId = createSafeId<"caseLawDecision">();
+    existingDecision = {
+      id: decisionId,
+      metadata: {},
+      // The publisher did not move; only the mirror is stuck pending, so
+      // the source-hash skip must not swallow the settlement.
+      sourceHash: decision.rawHash,
+      sourceObservedAt: new Date("2026-07-31T11:00:00.000Z"),
+      sourceObservationHash: decision.rawHash,
+      sourceObservationOrder: 0n,
+      corpusMirrorStatus: "pending",
+      contentHash: null,
+      textS3Key: null,
+      normalizedS3Key: null,
+      astS3Key: null,
+      redactedAt: null,
+      sourceRawS3Key: null,
+      sourceRawContentType: null,
+    };
+
+    const first = await processDecision({
+      input: decision,
+      observationOrder: 1n,
+      sourceId: createSafeId<"caseLawSource">(),
+      scopedDb,
+      observedAt: new Date("2026-07-31T12:00:00.000Z"),
+    });
+
+    expect(first).toEqual({
+      status: "complete",
+      inserted: true,
+      searchVectorFailed: false,
+    });
+    // A pending row records no write, so this pass must upload and settle.
+    expect(events.filter((e) => e.startsWith("corpus-write:"))).toHaveLength(1);
+    expect(updatedDecisionRows.at(-1)).toMatchObject({
+      corpusMirrorStatus: "settled",
+    });
+
+    // The next crawl pass sees the row the settle produced; with the source
+    // unchanged it advances the watermark and touches no corpus state.
+    const recorded = recordedCorpusWrite(decisionId);
+    existingDecision = {
+      ...existingDecision,
+      corpusMirrorStatus: "settled",
+      contentHash: recorded.contentHash,
+      textS3Key: recorded.textKey,
+      normalizedS3Key: recorded.sectionsKey,
+      astS3Key: recorded.astKey,
+    };
+    events.length = 0;
+
+    const second = await processDecision({
+      input: decision,
+      observationOrder: 2n,
+      sourceId: createSafeId<"caseLawSource">(),
+      scopedDb,
+      observedAt: new Date("2026-07-31T13:00:00.000Z"),
+    });
+
+    expect(second).toEqual({
+      status: "complete",
+      inserted: false,
+      searchVectorFailed: false,
+    });
+    expect(events.filter((e) => e.startsWith("corpus-"))).toHaveLength(0);
+    expect(events).not.toContain("intent-reserve");
   });
 
   // bun-types declares `.rejects.toBe` as void, so awaiting it trips

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -75,6 +75,7 @@ import {
   corpusContentHash,
   corpusPayloadDisposition,
   EMPTY_CORPUS_CONTENT_HASHES,
+  storedCorpusWrite,
   TRIMMED_CORPUS_PAYLOAD_COLUMNS,
   writeCorpusDocument,
 } from "@/api/lib/legal-search/corpus-storage";
@@ -297,6 +298,16 @@ export const allocateSourceObservationOrder = async ({
     return allocated.order;
   });
 
+type UploadSourceRawOptions = {
+  sourceId: SafeId<"caseLawSource">;
+  data: Uint8Array | string;
+  contentType: string;
+  /** The raw-payload key the row already records, or null for none. */
+  storedKey: string | null;
+  /** The content type recorded with that key. */
+  storedContentType: string | null;
+};
+
 /**
  * Upload sourceRaw to S3 under a content-addressable key.
  * Returns the S3 object key.
@@ -304,17 +315,25 @@ export const allocateSourceObservationOrder = async ({
  * The write is retried: failing here holds the page cursor (see the caller),
  * so letting one transient transport failure through stalls the whole source
  * until the next attempt happens to succeed. The key is the payload's own
- * hash, so a retry that duplicates an attempt which landed late is a no-op.
+ * hash, so a retry that duplicates an attempt which landed late is a no-op —
+ * and a key the row already records names an object with these exact bytes,
+ * so that PUT is skipped outright. A changed content type still re-uploads:
+ * it is stored on the object, not derivable from the key.
  */
-const uploadSourceRaw = async (
-  sourceId: SafeId<"caseLawSource">,
-  data: Uint8Array | string,
-  contentType: string,
-): Promise<string> => {
+const uploadSourceRaw = async ({
+  sourceId,
+  data,
+  contentType,
+  storedKey,
+  storedContentType,
+}: UploadSourceRawOptions): Promise<string> => {
   const hasher = new Bun.CryptoHasher("sha256");
   hasher.update(data);
   const blobHash = hasher.digest("hex");
   const key = `case-law/raw/${sourceId}/${blobHash}`;
+  if (key === storedKey && contentType === storedContentType) {
+    return key;
+  }
   await writeS3ObjectWithRetry({ contentType, data, key });
   return key;
 };
@@ -376,7 +395,8 @@ type SettleCaseLawCorpusMirrorTxOptions = {
   persistedSourceHash: string | null;
   observationOrder: bigint;
   mirrorCarriesDocument: boolean;
-  written: WriteCorpusResult;
+  /** Null when the payload carried no document and nothing was stored. */
+  written: WriteCorpusResult | null;
   tx: Transaction;
 };
 
@@ -703,6 +723,12 @@ const processDecisionAttempt = async ({
       sourceObservationHash: true,
       redactedAt: true,
       corpusMirrorStatus: true,
+      // The write the row records for its canonical payload, so the corpus
+      // upload can refuse re-PUTting objects a settled row already proved.
+      contentHash: true,
+      textS3Key: true,
+      normalizedS3Key: true,
+      astS3Key: true,
       sourceRawS3Key: true,
       sourceRawContentType: true,
       sourceUrl: true,
@@ -1133,11 +1159,13 @@ const processDecisionAttempt = async ({
     sourceRawContentType = existing.sourceRawContentType;
   } else if (rawPayload !== undefined) {
     try {
-      sourceRawS3Key = await uploadSourceRaw(
+      sourceRawS3Key = await uploadSourceRaw({
         sourceId,
-        rawPayload,
-        rawContentType,
-      );
+        data: rawPayload,
+        contentType: rawContentType,
+        storedKey: existing?.sourceRawS3Key ?? null,
+        storedContentType: existing?.sourceRawContentType ?? null,
+      });
       sourceRawContentType = rawContentType;
     } catch (error) {
       if (!existing) {
@@ -1871,7 +1899,18 @@ const processDecisionAttempt = async ({
           ),
         scopedDb,
         write: async ({ signal: uploadSignal }) =>
-          await writeCorpusDocument(corpusPayload, { signal: uploadSignal }),
+          await writeCorpusDocument(
+            {
+              ...corpusPayload,
+              // From the pre-write snapshot: the row update above moved the
+              // mirror to pending, but a settled record in that snapshot
+              // still proves these content-addressed objects were confirmed,
+              // so an identical payload need not re-PUT them.
+              stored:
+                existing === undefined ? null : storedCorpusWrite(existing),
+            },
+            { signal: uploadSignal },
+          ),
       });
       if (upload.type === "redacted-or-missing") {
         return {

--- a/apps/api/src/handlers/case-law/ingestion/replay.ts
+++ b/apps/api/src/handlers/case-law/ingestion/replay.ts
@@ -60,9 +60,9 @@ import type { CorpusPayload } from "@/api/lib/legal-search/corpus-storage";
  *
  * Together these make a re-run converge rather than accumulate: the second
  * pass derives the payload the row already holds, reports it unchanged, and
- * lets the pipeline advance the observation watermark alone. The stored
- * payload is uploaded again under its own content hash, so that write lands
- * on the key it already occupies.
+ * lets the pipeline advance the observation watermark alone. Where a write
+ * does run, the corpus writer compares the derived keys against the ones
+ * the row records and skips re-uploading a payload the row already holds.
  */
 
 export const REPLAY_ROW_OUTCOME = {
@@ -504,8 +504,8 @@ const replayRow = async ({
     // result it is handed, so a result that carried no payload would clear
     // the stored key and leave the row unreplayable — it would destroy the
     // one thing that makes this local. These are the bytes this run read,
-    // and the pipeline keys the object on their own hash, so re-uploading
-    // them lands on the key the row already holds.
+    // and the pipeline keys the object on their own hash, so it recognises
+    // the key the row already holds and skips the re-upload.
     input: {
       ...reparsed.result,
       sourceRawBytes: raw,

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill-corpus.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill-corpus.db.test.ts
@@ -32,7 +32,7 @@ import {
 import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import type { SafeId } from "@/api/lib/branded-types";
-import type { WriteCorpusResult } from "@/api/lib/legal-search/corpus-storage";
+import type { CorpusWriteOutcome } from "@/api/lib/legal-search/corpus-storage";
 import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/lib/legal-search/corpus-storage";
 import {
   markDocumentUnavailable,
@@ -78,6 +78,10 @@ const NEW_KEYS = {
   astKey: "legal-corpus/new/ast.json.zst",
 } as const;
 const NEW_CONTENT_HASH = "new-content-hash";
+const NEW_WRITE_OUTCOME = {
+  type: "written",
+  written: { ...NEW_KEYS, contentHash: NEW_CONTENT_HASH },
+} as const satisfies CorpusWriteOutcome;
 
 if (!databaseUrl || !runPostgresTests) {
   describe.skip("sk-courts document backfill — corpus storage", () => {
@@ -208,7 +212,7 @@ if (!databaseUrl || !runPostgresTests) {
         decision: decisionFor(id, caseNumber),
         document: parsedDocument,
         scopedDb,
-        writeCorpus: async (input): Promise<WriteCorpusResult> => {
+        writeCorpus: async (input): Promise<CorpusWriteOutcome> => {
           corpusWrites.push({
             documentId: input.documentId,
             jurisdiction: input.jurisdiction,
@@ -219,7 +223,7 @@ if (!databaseUrl || !runPostgresTests) {
             columns: { contentHash: true },
           });
           hashesDuringWrite.push(during?.contentHash ?? null);
-          return { ...NEW_KEYS, contentHash: NEW_CONTENT_HASH };
+          return NEW_WRITE_OUTCOME;
         },
       });
 
@@ -301,10 +305,7 @@ if (!databaseUrl || !runPostgresTests) {
         decision: decisionFor(id, caseNumber),
         document: parsedDocument,
         scopedDb,
-        writeCorpus: async () => ({
-          ...NEW_KEYS,
-          contentHash: NEW_CONTENT_HASH,
-        }),
+        writeCorpus: async () => NEW_WRITE_OUTCOME,
       });
 
       const stored = await db.query.caseLawDecisions.findFirst({
@@ -348,10 +349,7 @@ if (!databaseUrl || !runPostgresTests) {
         document: parsedDocument,
         mode: "canonical",
         scopedDb,
-        writeCorpus: async () => ({
-          ...NEW_KEYS,
-          contentHash: NEW_CONTENT_HASH,
-        }),
+        writeCorpus: async () => NEW_WRITE_OUTCOME,
       });
 
       expect(outcome).toBe("stored");
@@ -402,10 +400,7 @@ if (!databaseUrl || !runPostgresTests) {
         document: parsedDocument,
         mode: "canonical",
         scopedDb,
-        writeCorpus: async () => ({
-          ...NEW_KEYS,
-          contentHash: NEW_CONTENT_HASH,
-        }),
+        writeCorpus: async () => NEW_WRITE_OUTCOME,
       });
 
       // The attempt that was overtaken, finishing with nothing to store.
@@ -447,10 +442,7 @@ if (!databaseUrl || !runPostgresTests) {
           document: parsedDocument,
           mode: "canonical",
           scopedDb,
-          writeCorpus: async () => ({
-            ...NEW_KEYS,
-            contentHash: NEW_CONTENT_HASH,
-          }),
+          writeCorpus: async () => NEW_WRITE_OUTCOME,
         });
 
       expect(await store()).toBe("stored");
@@ -487,10 +479,7 @@ if (!databaseUrl || !runPostgresTests) {
         document: parsedDocument,
         mode: "canonical",
         scopedDb,
-        writeCorpus: async () => ({
-          ...NEW_KEYS,
-          contentHash: NEW_CONTENT_HASH,
-        }),
+        writeCorpus: async () => NEW_WRITE_OUTCOME,
       });
 
       expect(await stillPending()).toBe(false);
@@ -508,10 +497,7 @@ if (!databaseUrl || !runPostgresTests) {
         document: parsedDocument,
         mode: "dual-write",
         scopedDb,
-        writeCorpus: async () => ({
-          ...NEW_KEYS,
-          contentHash: NEW_CONTENT_HASH,
-        }),
+        writeCorpus: async () => NEW_WRITE_OUTCOME,
       });
 
       expect(

--- a/apps/api/src/handlers/legislation/ingestion.ts
+++ b/apps/api/src/handlers/legislation/ingestion.ts
@@ -17,7 +17,10 @@ import {
   sanitizeMetadata,
   stripDangerousChars,
 } from "@/api/lib/legal-search/corpus-sanitize";
-import { writeCorpusDocument } from "@/api/lib/legal-search/corpus-storage";
+import {
+  storedCorpusWrite,
+  writeCorpusDocument,
+} from "@/api/lib/legal-search/corpus-storage";
 import type {
   DecisionSection,
   EmptyAst,
@@ -195,6 +198,12 @@ export const processLegislationDocument = async (
       .select({
         id: legislationDocuments.id,
         sourceHash: legislationDocuments.sourceHash,
+        // The write the row records for its corpus payload, so the corpus
+        // write below can refuse re-PUTting objects it already proved.
+        contentHash: legislationDocuments.contentHash,
+        textS3Key: legislationDocuments.textS3Key,
+        normalizedS3Key: legislationDocuments.normalizedS3Key,
+        astS3Key: legislationDocuments.astS3Key,
       })
       .from(legislationDocuments)
       .where(
@@ -268,35 +277,48 @@ export const processLegislationDocument = async (
   // decision, not an oversight.
   if (corpusStorageMode !== "off") {
     try {
-      const written = await writeCorpusDocument({
+      const outcome = await writeCorpusDocument({
         documentId: id,
         jurisdiction: input.country,
         text,
         sections,
         ast,
+        stored: existing === undefined ? null : storedCorpusWrite(existing),
       });
-      // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-      await scopedDb((tx) => {
-        // audit: skip — background corpus storage; derived state
-        return (
-          tx
-            .update(legislationDocuments)
-            .set({
-              textS3Key: written.textKey,
-              normalizedS3Key: written.sectionsKey,
-              astS3Key: written.astKey,
-              contentHash: written.contentHash,
-            })
-            // Only while the row still carries this run's sourceHash: a
-            // slower run must not overwrite a concurrent newer refresh.
-            .where(
-              and(
-                eq(legislationDocuments.id, id),
-                sql`${legislationDocuments.sourceHash} IS NOT DISTINCT FROM ${sourceHash}`,
-              ),
-            )
-        );
-      });
+      // An unchanged outcome means the row already records exactly these
+      // pointers; a written or skipped-empty outcome records the keys, or
+      // null pointers where the payload carried no document. The empty
+      // payload's hash is still recorded: the corpus indexer's missing and
+      // stale scans require a non-null content hash, so a row whose indexed
+      // document refreshed to empty must stay visible to them — with a null
+      // hash the previously indexed text would remain searchable forever.
+      if (outcome.type !== "skipped-unchanged") {
+        // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+        await scopedDb((tx) => {
+          // audit: skip — background corpus storage; derived state
+          return (
+            tx
+              .update(legislationDocuments)
+              .set({
+                textS3Key: outcome.written?.textKey ?? null,
+                normalizedS3Key: outcome.written?.sectionsKey ?? null,
+                astS3Key: outcome.written?.astKey ?? null,
+                contentHash:
+                  outcome.type === "skipped-empty"
+                    ? outcome.contentHash
+                    : outcome.written.contentHash,
+              })
+              // Only while the row still carries this run's sourceHash: a
+              // slower run must not overwrite a concurrent newer refresh.
+              .where(
+                and(
+                  eq(legislationDocuments.id, id),
+                  sql`${legislationDocuments.sourceHash} IS NOT DISTINCT FROM ${sourceHash}`,
+                ),
+              )
+          );
+        });
+      }
     } catch (error) {
       corpusWriteFailed = true;
       captureError(error, {

--- a/apps/api/src/lib/legal-search/case-law-corpus-upload-intents.ts
+++ b/apps/api/src/lib/legal-search/case-law-corpus-upload-intents.ts
@@ -17,7 +17,10 @@ import {
   corpusKeys,
   deleteCorpusDocument,
 } from "@/api/lib/legal-search/corpus-storage";
-import type { WriteCorpusResult } from "@/api/lib/legal-search/corpus-storage";
+import type {
+  CorpusWriteOutcome,
+  WriteCorpusResult,
+} from "@/api/lib/legal-search/corpus-storage";
 
 const CLEANUP_RETRY_MAX_DELAY_MS = DAY_IN_MS;
 const CLEANUP_RETRY_UNIT_MS = 60 * 1000;
@@ -198,16 +201,21 @@ export type CaseLawCorpusUploadApplyResult =
   | { type: "superseded" };
 
 type WriteReservedCaseLawCorpusUploadOptions = {
+  /**
+   * Row CAS for the settled state. `written` is null when the write
+   * concluded the payload carries no document, in which case the CAS
+   * settles the mirror with null pointers instead of keys.
+   */
   apply: (args: {
     tx: Transaction;
-    written: WriteCorpusResult;
+    written: WriteCorpusResult | null;
   }) => Promise<CaseLawCorpusUploadApplyResult>;
   decisionId: SafeId<"caseLawDecision">;
   intentId: SafeId<"caseLawCorpusUploadIntent">;
   preflight: (tx: Transaction) => Promise<boolean>;
   scopedDb: ScopedDb;
   signal?: AbortSignal;
-  write: (args: { signal: AbortSignal }) => Promise<WriteCorpusResult>;
+  write: (args: { signal: AbortSignal }) => Promise<CorpusWriteOutcome>;
 };
 
 class CorpusUploadWriteError extends TaggedError("CorpusUploadWriteError")<{
@@ -293,9 +301,9 @@ export const writeReservedCaseLawCorpusUpload = async ({
         return { type: "superseded" };
       }
 
-      let written: WriteCorpusResult;
+      let writeOutcome: CorpusWriteOutcome;
       try {
-        written = await write({
+        writeOutcome = await write({
           signal: signal ?? new AbortController().signal,
         });
       } catch (error) {
@@ -304,7 +312,7 @@ export const writeReservedCaseLawCorpusUpload = async ({
           message: "Reserved corpus upload failed",
         });
       }
-      const outcome = await apply({ tx, written });
+      const outcome = await apply({ tx, written: writeOutcome.written });
       if (outcome.type === "superseded") {
         await tx
           .update(caseLawCorpusUploadIntents)

--- a/apps/api/src/lib/legal-search/corpus-storage-cancellation.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-storage-cancellation.test.ts
@@ -46,8 +46,13 @@ void mock.module("@/api/lib/s3", () => ({
   putCorpusS3ObjectWithSignal: putCorpusObjectMock,
 }));
 
-const { deleteCorpusDocument, writeCorpusDocument } =
-  await import("@/api/lib/legal-search/corpus-storage");
+const {
+  corpusContentHash,
+  corpusKeys,
+  deleteCorpusDocument,
+  writeCorpusDocument,
+} = await import("@/api/lib/legal-search/corpus-storage");
+const { EMPTY_AST } = await import("@/api/lib/legal-search/document-types");
 
 const waitForCallCount = async (
   callCount: () => number,
@@ -73,6 +78,7 @@ const writeRejection = async (signal: AbortSignal): Promise<unknown> =>
       text: "decision text",
       sections: null,
       ast: null,
+      stored: null,
     },
     { signal },
   ).then(
@@ -255,5 +261,87 @@ describe("corpus object cancellation", () => {
 
     releaseSiblings.resolve(undefined);
     expect(await pending).toBe(deleteFailure);
+  });
+});
+
+describe("corpus write redundancy refusal", () => {
+  const documentId = "7f9b1c34-52ad-4c8e-b1f0-6a2d9e4c8b21";
+  const jurisdiction = "SVK";
+  const payload = {
+    text: "Rozsudok v mene Slovenskej republiky. Súd rozhodol o veci samej.",
+    sections: null,
+    ast: null,
+  };
+
+  test("an empty payload issues no corpus PUTs", async () => {
+    putCorpusObjectMock.mockClear();
+
+    const outcome = await writeCorpusDocument({
+      documentId,
+      jurisdiction,
+      // The metadata-first shape: no text, no sections, the empty-AST
+      // placeholder an adapter without a document emits.
+      text: null,
+      sections: null,
+      ast: EMPTY_AST,
+      stored: null,
+    });
+
+    expect(outcome).toEqual({
+      type: "skipped-empty",
+      written: null,
+      contentHash: corpusContentHash({
+        text: null,
+        sections: null,
+        ast: EMPTY_AST,
+      }),
+    });
+    expect(putCorpusObjectMock).not.toHaveBeenCalled();
+  });
+
+  test("a payload the row already records issues no corpus PUTs", async () => {
+    putCorpusObjectMock.mockClear();
+    const contentHash = corpusContentHash(payload);
+    const stored = {
+      ...corpusKeys({ documentId, jurisdiction, contentHash }),
+      contentHash,
+    };
+
+    const outcome = await writeCorpusDocument({
+      documentId,
+      jurisdiction,
+      ...payload,
+      stored,
+    });
+
+    expect(outcome).toEqual({ type: "skipped-unchanged", written: stored });
+    expect(putCorpusObjectMock).not.toHaveBeenCalled();
+  });
+
+  test("a changed payload still issues all three PUTs", async () => {
+    putCorpusObjectMock.mockClear();
+    putCorpusObjectMock.mockImplementation(async () => {
+      await Promise.resolve();
+    });
+    const previousHash = corpusContentHash(payload);
+    const stored = {
+      ...corpusKeys({ documentId, jurisdiction, contentHash: previousHash }),
+      contentHash: previousHash,
+    };
+    const changed = { ...payload, text: `${payload.text} Opravené znenie.` };
+    expect(corpusContentHash(changed)).not.toBe(previousHash);
+
+    const outcome = await writeCorpusDocument({
+      documentId,
+      jurisdiction,
+      ...changed,
+      stored,
+    });
+
+    expect(outcome).toMatchObject({
+      type: "written",
+      written: { contentHash: corpusContentHash(changed) },
+    });
+    expect(putCorpusObjectMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/api/src/lib/legal-search/corpus-storage.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-storage.test.ts
@@ -9,16 +9,22 @@ import {
 } from "@/api/lib/errors/tagged-errors";
 import {
   corpusContentHash,
+  corpusKeys,
   corpusMirrorColumns,
   corpusPayloadDisposition,
   EMPTY_CORPUS_CONTENT_HASHES,
   parsePersistedCorpusAst,
   parsePersistedCorpusSections,
+  planCorpusDocumentWrite,
   readCorpusPayloadOrFallback,
   readCorpusText,
+  storedCorpusWrite,
   TRIMMED_CORPUS_PAYLOAD_COLUMNS,
 } from "@/api/lib/legal-search/corpus-storage";
-import type { WriteCorpusResult } from "@/api/lib/legal-search/corpus-storage";
+import type {
+  CorpusPayload,
+  WriteCorpusResult,
+} from "@/api/lib/legal-search/corpus-storage";
 import { EMPTY_AST } from "@/api/lib/legal-search/document-types";
 
 describe("corpus mirror state columns", () => {
@@ -302,5 +308,120 @@ describe("empty corpus payload hashes", () => {
         ast: EMPTY_AST,
       }),
     ).toBe("9d69e9cdfe9a15179939cc74ac6af324d03b6dc049bf4fe010971b56767bab2b");
+  });
+});
+
+describe("planCorpusDocumentWrite", () => {
+  const documentId = "0d2f4a5e-9c1b-4c62-8b1a-3f6f2f8f9e10";
+  const jurisdiction = "SVK";
+  const documentPayload: CorpusPayload = {
+    text: "Rozsudok v mene Slovenskej republiky. Súd rozhodol o veci samej.",
+    sections: [
+      {
+        index: 0,
+        type: "header",
+        title: null,
+        text: "Rozsudok v mene Slovenskej republiky.",
+      },
+    ],
+    ast: EMPTY_AST,
+  };
+  /** The write the settle path would record for `documentPayload`. */
+  const recordedWrite = (id: string, partition: string) => {
+    const contentHash = corpusContentHash(documentPayload);
+    return {
+      ...corpusKeys({ documentId: id, jurisdiction: partition, contentHash }),
+      contentHash,
+    };
+  };
+
+  test("refuses every payload shape that carries no document", () => {
+    const texts = [null, ""];
+    const sectionShapes = [null, []];
+    const astShapes = [EMPTY_AST, null];
+    for (const text of texts) {
+      for (const sections of sectionShapes) {
+        for (const ast of astShapes) {
+          expect(
+            planCorpusDocumentWrite({
+              documentId,
+              jurisdiction,
+              text,
+              sections,
+              ast,
+              stored: null,
+            }),
+          ).toEqual({
+            type: "skipped-empty",
+            written: null,
+            contentHash: corpusContentHash({ text, sections, ast }),
+          });
+        }
+      }
+    }
+  });
+
+  test("refuses re-writing the exact write the row records", () => {
+    const stored = recordedWrite(documentId, jurisdiction);
+    expect(
+      planCorpusDocumentWrite({
+        documentId,
+        jurisdiction,
+        ...documentPayload,
+        stored,
+      }),
+    ).toEqual({ type: "skipped-unchanged", written: stored });
+  });
+
+  test("writes when the payload differs from the recorded write", () => {
+    const stored = recordedWrite(documentId, jurisdiction);
+    const changed = {
+      ...documentPayload,
+      text: `${documentPayload.text} Opravené znenie.`,
+    };
+    // The fixture must express the fault: an unchanged hash would make the
+    // equality guard the thing under test trivially pass.
+    expect(corpusContentHash(changed)).not.toBe(stored.contentHash);
+
+    expect(
+      planCorpusDocumentWrite({ documentId, jurisdiction, ...changed, stored }),
+    ).toMatchObject({
+      type: "put",
+      written: { contentHash: corpusContentHash(changed) },
+    });
+  });
+
+  test("writes when the recorded write lives under another jurisdiction", () => {
+    // Same payload, same hash, different partition: the keys must move, so
+    // hash equality alone may not skip the write.
+    const stored = recordedWrite(documentId, "CZE");
+    const plan = planCorpusDocumentWrite({
+      documentId,
+      jurisdiction,
+      ...documentPayload,
+      stored,
+    });
+    expect(stored.contentHash).toBe(corpusContentHash(documentPayload));
+    expect(plan.type).toBe("put");
+  });
+
+  test("a row without all four pointer columns records no write", () => {
+    expect(
+      storedCorpusWrite({
+        textS3Key: "legal-corpus/documents/jurisdiction=SVK/x/hash/text.zst",
+        normalizedS3Key: null,
+        astS3Key: null,
+        contentHash: null,
+      }),
+    ).toBeNull();
+    const stored = recordedWrite(documentId, jurisdiction);
+    expect(
+      storedCorpusWrite({
+        textS3Key: stored.textKey,
+        normalizedS3Key: stored.sectionsKey,
+        astS3Key: stored.astKey,
+        contentHash: stored.contentHash,
+      }),
+    ).toEqual(stored);
   });
 });

--- a/apps/api/src/lib/legal-search/corpus-storage.ts
+++ b/apps/api/src/lib/legal-search/corpus-storage.ts
@@ -173,6 +173,15 @@ export const EMPTY_CORPUS_CONTENT_HASHES: readonly string[] =
 type WriteCorpusInput = CorpusPayload & {
   documentId: string;
   jurisdiction: string;
+  /**
+   * The corpus write the row currently records ({@link storedCorpusWrite}),
+   * or null when it records none. A write whose derived keys and hash equal
+   * this record is refused: the objects are content-addressed and a settled
+   * record proves they were confirmed, so re-PUTting them buys nothing.
+   * Required rather than optional so no call site can forget to state what
+   * the row knows.
+   */
+  stored: WriteCorpusResult | null;
 };
 
 type CorpusIoOptions = { signal?: AbortSignal };
@@ -237,6 +246,96 @@ const settleCancellableCorpusIoGroup = async ({
 };
 
 export type WriteCorpusResult = CorpusKeys & { contentHash: string };
+
+/** The corpus pointer columns as a decision or legislation row stores them. */
+type StoredCorpusWriteColumns = {
+  textS3Key: string | null;
+  normalizedS3Key: string | null;
+  astS3Key: string | null;
+  contentHash: string | null;
+};
+
+/**
+ * The corpus write a row records, in the shape {@link writeCorpusDocument}
+ * compares against, or null when the row records none. All four columns
+ * travel together — the mirror settles them in one statement — so a partial
+ * set means no confirmed write.
+ */
+export const storedCorpusWrite = (
+  row: StoredCorpusWriteColumns,
+): WriteCorpusResult | null =>
+  row.textS3Key !== null &&
+  row.normalizedS3Key !== null &&
+  row.astS3Key !== null &&
+  row.contentHash !== null
+    ? {
+        textKey: row.textS3Key,
+        sectionsKey: row.normalizedS3Key,
+        astKey: row.astS3Key,
+        contentHash: row.contentHash,
+      }
+    : null;
+
+export type CorpusWriteOutcome =
+  /** All three objects were PUT under the derived keys. */
+  | { type: "written"; written: WriteCorpusResult }
+  /** The row already records this exact write; nothing was PUT. */
+  | { type: "skipped-unchanged"; written: WriteCorpusResult }
+  /**
+   * The payload carries no document; nothing was PUT, and the caller
+   * settles the row's mirror with null pointers to say so. The payload's
+   * hash still travels, for a caller whose index staleness tracking keys
+   * off a non-null content hash and must converge on the empty payload
+   * rather than skip the row.
+   */
+  | { type: "skipped-empty"; written: null; contentHash: string };
+
+type PlannedCorpusWrite =
+  | { type: "put"; written: WriteCorpusResult }
+  | Extract<
+      CorpusWriteOutcome,
+      { type: "skipped-unchanged" | "skipped-empty" }
+    >;
+
+/**
+ * The redundancy decision behind {@link writeCorpusDocument}, separated
+ * from the S3 I/O so it stays a pure unit and a test double can fake only
+ * the PUTs while keeping the real decision.
+ *
+ * A payload whose hash is one of the empty shapes stores nothing: a
+ * metadata-first ingest would otherwise PUT the same constant
+ * zero-information objects under a fresh key per row. A payload whose
+ * derived keys and hash equal the write the row already records stores
+ * nothing either — a settled record proves those exact objects were
+ * confirmed. The comparison is over the keys, not the hash alone, because
+ * the keys also carry the jurisdiction partition: an equal payload under a
+ * moved jurisdiction must still land at its new keys.
+ */
+export const planCorpusDocumentWrite = ({
+  documentId,
+  jurisdiction,
+  text,
+  sections,
+  ast,
+  stored,
+}: WriteCorpusInput): PlannedCorpusWrite => {
+  const contentHash = corpusContentHash({ text, sections, ast });
+  if (EMPTY_CORPUS_CONTENT_HASHES.includes(contentHash)) {
+    return { type: "skipped-empty", written: null, contentHash };
+  }
+  const written = {
+    ...corpusKeys({ documentId, jurisdiction, contentHash }),
+    contentHash,
+  };
+  const unchanged =
+    stored?.contentHash === contentHash &&
+    stored.textKey === written.textKey &&
+    stored.sectionsKey === written.sectionsKey &&
+    stored.astKey === written.astKey;
+  return unchanged
+    ? { type: "skipped-unchanged", written }
+    : { type: "put", written };
+};
 
 type CorpusMirrorState =
   | { status: typeof CASE_LAW_CORPUS_MIRROR_STATUS.PENDING }
@@ -368,11 +467,20 @@ export const corpusPayloadDisposition = ({
 };
 
 export const writeCorpusDocument = async (
-  { documentId, jurisdiction, text, sections, ast }: WriteCorpusInput,
+  input: WriteCorpusInput,
   { signal }: CorpusIoOptions = {},
-): Promise<WriteCorpusResult> => {
-  const contentHash = corpusContentHash({ text, sections, ast });
-  const keys = corpusKeys({ documentId, jurisdiction, contentHash });
+): Promise<CorpusWriteOutcome> => {
+  const plan = planCorpusDocumentWrite(input);
+  if (plan.type !== "put") {
+    return plan;
+  }
+  const { text, sections, ast } = input;
+  const { written } = plan;
+  const keys = {
+    textKey: written.textKey,
+    sectionsKey: written.sectionsKey,
+    astKey: written.astKey,
+  };
   const writeController = new AbortController();
   const groupSignal =
     signal === undefined
@@ -421,7 +529,7 @@ export const writeCorpusDocument = async (
     operations: writes,
   });
 
-  return { ...keys, contentHash };
+  return { type: "written", written };
 };
 
 type ReadCorpusTextOptions = {

--- a/apps/api/src/lib/legal-search/sk-document-backfill.ts
+++ b/apps/api/src/lib/legal-search/sk-document-backfill.ts
@@ -691,7 +691,17 @@ export const storeBackfilledDocument = async ({
           ).at(0),
         ),
       scopedDb,
-      write: async ({ signal }) => await writeCorpus(payload, { signal }),
+      write: async ({ signal }) =>
+        await writeCorpus(
+          {
+            ...payload,
+            // The queue admits only rows whose corpus stores no document
+            // (`storesNoCorpusDocument`), so no recorded write can match
+            // the fetched document's payload; there is nothing to compare.
+            stored: null,
+          },
+          { signal },
+        ),
     });
     stored = outcome.type === "applied";
   }

--- a/apps/api/src/scripts/backfill-corpus-storage.ts
+++ b/apps/api/src/scripts/backfill-corpus-storage.ts
@@ -56,6 +56,7 @@ import {
   corpusContentHash,
   corpusMirrorColumns,
   EMPTY_CORPUS_CONTENT_HASHES,
+  storedCorpusWrite,
   writeCorpusDocument,
 } from "@/api/lib/legal-search/corpus-storage";
 import type {
@@ -76,6 +77,9 @@ type BackfillRow = {
   sections: DecisionSection[] | null;
   documentAst: DocumentAst | EmptyAst | null;
   contentHash: string | null;
+  textS3Key: string | null;
+  normalizedS3Key: string | null;
+  astS3Key: string | null;
   updatedAtToken: TimestampCasToken;
 };
 
@@ -124,6 +128,7 @@ const backfillRow = async (row: BackfillRow): Promise<void> => {
       text: row.fulltext,
       sections: row.sections,
       ast: row.documentAst,
+      stored: storedCorpusWrite(row),
     };
     const intent = await reserveCaseLawCorpusUploadIntent({
       contentHash: corpusContentHash(payload),
@@ -204,6 +209,9 @@ while (true) {
         sections: caseLawDecisions.sections,
         documentAst: caseLawDecisions.documentAst,
         contentHash: caseLawDecisions.contentHash,
+        textS3Key: caseLawDecisions.textS3Key,
+        normalizedS3Key: caseLawDecisions.normalizedS3Key,
+        astS3Key: caseLawDecisions.astS3Key,
         updatedAtToken: timestampCasToken(caseLawDecisions.updatedAt),
       })
       .from(caseLawDecisions)

--- a/apps/api/src/scripts/corpus-column-trim-plan.ts
+++ b/apps/api/src/scripts/corpus-column-trim-plan.ts
@@ -74,16 +74,17 @@ type ColumnTrimInput = {
  * Nulling the Postgres columns destroys the only other copy, so every
  * object the trim relies on must be proven present first — sections
  * included, since `sections` is nulled alongside `fulltext` and
- * `document_ast`. `writeCorpusDocument` always writes all three objects
- * (a null payload is stored as the JSON literal `null`), so a row backed
- * by object storage carries all three keys; a missing one means the row
- * was never written by the corpus writer. Keys are content-addressed,
- * which makes an existence check a sufficient verification.
+ * `document_ast`. For any payload it stores, `writeCorpusDocument` writes
+ * all three objects (a null payload field is stored as the JSON literal
+ * `null`), so a row backed by object storage carries all three keys; a
+ * missing one means the row was never written by the corpus writer. Keys
+ * are content-addressed, which makes an existence check a sufficient
+ * verification.
  *
  * Present is not the same as holding this row's document. A
- * metadata-first ingest writes all three objects before the document
- * exists, so a row can pass every existence check while object storage
- * holds nothing; and the shapes it writes are not all constants — a
+ * metadata-first ingest used to write all three objects before the
+ * document existed, so a row can pass every existence check while object
+ * storage holds nothing; and the shapes it wrote are not all constants — a
  * DocumentAst envelope with no blocks carries the decision's own
  * metadata, so no fixed hash can name it. Enumerating the empty shapes
  * therefore cannot close this: what the trim needs is the positive

--- a/apps/api/src/scripts/corpus-column-trim.ts
+++ b/apps/api/src/scripts/corpus-column-trim.ts
@@ -232,9 +232,10 @@ const trimRow = async (row: TrimRow): Promise<void> => {
       ast: row.documentAst,
     };
     // Every object whose column this run nulls has to be checked,
-    // sections included: `writeCorpusDocument` always writes a sections
-    // object, so its absence means the row is not actually backed by
-    // object storage. Where the columns hold a document, presence is not
+    // sections included: `writeCorpusDocument` writes a sections object
+    // for every payload it stores, so its absence means the row is not
+    // actually backed by object storage. Where the columns hold a document,
+    // presence is not
     // enough and the object's content is compared with the column's;
     // `Bun.deepEquals` rather than a serialization, because the columns
     // come back through jsonb with their keys reordered.

--- a/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
@@ -178,13 +178,43 @@ const backfillRow = async (
   row: BackfillRow,
 ): Promise<"written" | "skipped" | "failed"> => {
   try {
-    const result = await writeCorpusDocument({
+    // The batch snapshot can go stale while earlier rows in it write.
+    // Re-check the compare-and-set precondition first, so a row whose
+    // recording below would be refused does not pay the object PUTs.
+    const fresh = await ingestionDb((tx) =>
+      tx
+        .select({ id: caseLawDecisions.id })
+        .from(caseLawDecisions)
+        .where(
+          and(
+            eq(caseLawDecisions.id, row.id),
+            isNull(caseLawDecisions.textS3Key),
+            timestampMatchesCasToken(
+              caseLawDecisions.updatedAt,
+              row.updatedAtToken,
+            ),
+          ),
+        )
+        .limit(1),
+    );
+    if (fresh.length === 0) {
+      return "skipped";
+    }
+
+    const outcome = await writeCorpusDocument({
       documentId: row.id,
       jurisdiction: row.country,
       text: row.fulltext,
       sections: row.sections,
       ast: row.documentAst,
+      // The scan admits only rows with no recorded corpus write.
+      stored: null,
     });
+    if (outcome.type === "skipped-empty") {
+      // Nothing readable to store; null pointers already represent it.
+      return "skipped";
+    }
+    const result = outcome.written;
 
     const recorded = await ingestionDb((tx) =>
       tx
@@ -228,13 +258,42 @@ const backfillLegislationRow = async (
   row: LegislationBackfillRow,
 ): Promise<"written" | "skipped" | "failed"> => {
   try {
-    const result = await writeCorpusDocument({
+    // Same shape as the case-law pass: refuse the PUTs when the recording
+    // compare-and-set below would already refuse the row.
+    const fresh = await ingestionDb((tx) =>
+      tx
+        .select({ id: legislationDocuments.id })
+        .from(legislationDocuments)
+        .where(
+          and(
+            eq(legislationDocuments.id, row.id),
+            isNull(legislationDocuments.textS3Key),
+            timestampMatchesCasToken(
+              legislationDocuments.updatedAt,
+              row.updatedAtToken,
+            ),
+          ),
+        )
+        .limit(1),
+    );
+    if (fresh.length === 0) {
+      return "skipped";
+    }
+
+    const outcome = await writeCorpusDocument({
       documentId: row.id,
       jurisdiction: row.country,
       text: row.fulltext,
       sections: row.sections,
       ast: row.documentAst,
+      // The scan admits only rows with no recorded corpus write.
+      stored: null,
     });
+    if (outcome.type === "skipped-empty") {
+      // Nothing readable to store; null pointers already represent it.
+      return "skipped";
+    }
+    const result = outcome.written;
 
     const recorded = await ingestionDb((tx) =>
       tx


### PR DESCRIPTION
`writeCorpusDocument` PUT three objects per call even when the call could prove the write redundant. Four defects, one mechanism: the writer itself now refuses writes it can prove redundant, so no call site can forget the guard.

- **Empty payloads.** `corpusContentHash({ text: null, sections: null, ast: EMPTY_AST })` is a member of `EMPTY_CORPUS_CONTENT_HASHES`, yet metadata-only ingestion (the sk-courts listing phase stores `EMPTY_AST` with no fulltext) still wrote the constant empty payload under a fresh content-addressed key per decision. The writer now returns `skipped-empty` for any payload whose hash is one of the empty shapes, and callers settle the mirror with null pointers (`corpusMirrorColumns({ status: SETTLED, written: null })`), the representation `markDocumentUnavailable` already uses. Readers and the mirror CHECK already treat null keys as "no corpus content" (`storesNoCorpusDocument`, `rowHoldsDocument`), and the Postgres payload columns are retained because nothing in object storage backs them. Legislation is the one caller that records the empty payload's hash (with null keys): its corpus indexer's missing/stale scans require a non-null `content_hash`, so a row whose indexed document refreshed to empty must stay visible to them instead of leaving the old text searchable.
- **No payload-equality guard on the ingest path.** The refresh skip predicate (`shouldSkipRefresh`) compares the publisher raw hash only, so a metadata-only refresh re-PUT all three objects of an unchanged document. Call sites now pass the row's recorded write (`stored`, a required input built by `storedCorpusWrite`); when the derived keys and hash equal it, the writer returns `skipped-unchanged` without PUTs. The comparison is over the keys, not the hash alone, so an equal payload under a moved jurisdiction still lands at its new partition. A row stuck at `corpusMirrorStatus='pending'` records no write, so it still uploads and settles.
- **`uploadSourceRaw`** never compared the computed content-addressed key to `existing.sourceRawS3Key`; it now skips the PUT when the key and recorded content type both match.
- **CAS-after-PUT in the corpus-storage backfill runner.** A row whose recording compare-and-set would be refused still paid the PUTs first, and the next pass repeated them. The runner re-checks the CAS precondition before writing. (`backfill-corpus-storage.ts` already preflights the same predicate inside the reserved-upload fence; it now also passes the row's recorded write.)

The decision lives in `planCorpusDocumentWrite`, a pure function; `writeCorpusDocument` only adds the I/O. The pipeline test double reuses the real planner and fakes only the PUTs, so its fixtures cannot drift from the real guard. `stored` is required rather than optional so a future call site cannot omit what the row knows.

Tests: planner unit tests over the real hash function and empty shapes (all empty variants, hash-equal recorded write, changed payload, jurisdiction move); writer-level tests assert zero PUTs on both skip branches and three on a real write; pipeline tests assert a metadata-only decision settles with null pointers and no corpus write, a settled row whose payload is unchanged re-settles onto its existing pointers without PUTs, and a pending mirror settles once and then stops writing.
