### PR TITLE
feat(api): case_number field, language tag, and a strict doc mapping

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.test.ts
@@ -10,6 +10,7 @@ import { corpusDocumentDeleteQuery } from "@/api/lib/corpus-index/core";
 import type { TimestampCasToken } from "@/api/lib/db/timestamp-cas";
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
 import {
+  caseLawIndexConfig,
   DECISION_TIMESTAMP_FIELD,
   UNDATED_DECISION_TIMESTAMP,
 } from "@/api/lib/legal-search/corpus-index-config";
@@ -19,29 +20,35 @@ type MakeRowOptions = {
   id: string;
   contentHash: string;
   textS3Key?: string | null;
+  astS3Key?: string | null;
   decisionDate?: string | null;
+  decisionType?: string | null;
+  ecli?: string | null;
 };
 
 const makeRow = ({
   id,
   contentHash,
   textS3Key,
+  astS3Key = null,
   decisionDate = "2024-01-01",
+  decisionType = null,
+  ecli = null,
 }: MakeRowOptions) => ({
   id: toSafeId<"caseLawDecision">(id),
   sourceId: toSafeId<"caseLawSource">("src_1"),
   caseNumber: `case-${id}`,
-  ecli: null,
+  ecli,
   court: "Test Court",
   country: "CZ",
   language: "cs",
   decisionDate,
-  decisionType: null,
+  decisionType,
   citationAuthority: 0,
   citationCount: 0,
   textS3Key:
     textS3Key === undefined ? `legal-corpus/${id}/text.zst` : textS3Key,
-  astS3Key: null,
+  astS3Key,
   contentHash,
   indexedHash: null,
   indexedGeneration: null,
@@ -309,6 +316,73 @@ describe("case-law passage projection", () => {
       expect(doc["decision_date"]).toBeUndefined();
       expect(doc["year"]).toBeUndefined();
     }
+  });
+
+  test("every field the projection writes is one the doc mapping declares", async () => {
+    // A generation created from the current config maps in `strict` mode: a
+    // document carrying a field the mapping does not declare is rejected at
+    // ingest. This is the guard for that — the writer and the mapping are two
+    // halves of one shape, and the half that fails is the one nothing checks.
+    const rows = [
+      makeRow({
+        id: "dec_full",
+        contentHash: "hash_full",
+        astS3Key: "legal-corpus/dec_full/ast.zst",
+        decisionType: "rozsudek",
+        ecli: "ECLI:CZ:NS:2024:1.T.1.2024.1",
+      }),
+      makeRow({
+        id: "dec_sparse",
+        contentHash: "hash_sparse",
+        decisionDate: null,
+        textS3Key: null,
+      }),
+    ];
+
+    const { built } = await loadDocsForBatch(rows, {
+      generation: "case_law_v3",
+      fetchFulltext: async () => "slovo ".repeat(400),
+      readPayload: async (row) => ({
+        text: `${"slovo ".repeat(400)}\n\n${"jinak ".repeat(400)}`,
+        // The anchored layout on one row and the unanchored fallback on the
+        // other, so both passage shapes are in the assertion's input.
+        ast:
+          row.id === rows.at(0)?.id
+            ? astOf([heading(0, "Odůvodnění"), paragraph(1, 200)])
+            : {},
+      }),
+    });
+
+    const docs = built.flatMap((entry) => entry.docs);
+    const emitted = new Set(docs.flatMap((doc) => Object.keys(doc)));
+    const mapped = new Set(
+      caseLawIndexConfig("case_law_v3_cze").doc_mapping.field_mappings.map(
+        (field) => field.name,
+      ),
+    );
+    expect([...emitted].filter((name) => !mapped.has(name)).sort()).toEqual([]);
+
+    // The fixtures have to reach the conditional fields, or the assertion is
+    // over a shape narrower than the writer's: the rich row carries every
+    // optional field, the sparse one carries none of them, and both layouts of
+    // a passage (opening, continuation) appear.
+    for (const field of [
+      "anchor_id",
+      "canonical_ast_key",
+      "canonical_text_key",
+      "case_number",
+      "decision_date",
+      "document_type",
+      "ecli",
+      "title",
+      "year",
+      DECISION_TIMESTAMP_FIELD,
+    ]) {
+      expect(emitted.has(field)).toBe(true);
+    }
+    expect(
+      docs.filter((doc) => doc["title"] === undefined).length,
+    ).toBeGreaterThan(0);
   });
 
   test("a row with no usable AST still emits passages, unanchored", async () => {

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -584,6 +584,9 @@ const buildSharedFields = (row: IndexableRow): Record<string, unknown> => {
     document_id: row.id,
     jurisdiction: row.country,
     source: row.sourceId,
+    // The docket as its own field, so an exact lookup does not have to go
+    // through `title`, where it is folded and tokenized with the court name.
+    case_number: row.caseNumber,
     court: row.court,
     language: row.language,
     citation_authority: row.citationAuthority,

--- a/apps/api/src/handlers/legislation/corpus-index.test.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.test.ts
@@ -4,30 +4,41 @@ import { loadDocsForBatch } from "@/api/handlers/legislation/corpus-index";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { TimestampCasToken } from "@/api/lib/db/timestamp-cas";
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
+import { corpusIndexConfig } from "@/api/lib/legal-search/corpus-index-config";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 
 type MakeRowOptions = {
   id: string;
   contentHash: string;
   textS3Key?: string | null;
+  astS3Key?: string | null;
+  documentType?: string | null;
+  effectiveDate?: string | null;
 };
 
-const makeRow = ({ id, contentHash, textS3Key }: MakeRowOptions) => ({
+const makeRow = ({
+  id,
+  contentHash,
+  textS3Key,
+  astS3Key = null,
+  documentType = null,
+  effectiveDate = "2024-01-01",
+}: MakeRowOptions) => ({
   id: toSafeId<"legislationDocument">(id),
   sourceId: toSafeId<"legislationSource">("src_1"),
   eli: `/eli/cz/act/2024/${id}`,
   title: `Act ${id}`,
   country: "CZ",
   language: "cs",
-  documentType: null,
+  documentType,
   status: "in_force",
-  effectiveDate: "2024-01-01",
-  versionValidFrom: null,
+  effectiveDate,
+  versionValidFrom: "2024-02-02",
   citationAuthority: 0,
   citationCount: 0,
   textS3Key:
     textS3Key === undefined ? `legal-corpus/${id}/text.zst` : textS3Key,
-  astS3Key: null,
+  astS3Key,
   contentHash,
   indexedHash: null,
   indexedGeneration: null,
@@ -102,5 +113,56 @@ describe("legislation loadDocsForBatch read-failure isolation", () => {
     expect(built.at(0)?.docs.at(0)?.["text"]).toBe("stored fulltext");
     // The lazy fallback runs only for the S3-less row, keyed by its id.
     expect(fetchedIds).toEqual([legacyRow.id]);
+  });
+
+  test("every field the projection writes is one the doc mapping declares", async () => {
+    // A generation created from the current config maps in `strict` mode: a
+    // document carrying a field the mapping does not declare is rejected at
+    // ingest. The writer and the mapping are two halves of one shape, and this
+    // is the half nothing else checks.
+    const rows = [
+      makeRow({
+        id: "leg_full",
+        astS3Key: "legal-corpus/leg_full/ast.zst",
+        contentHash: "hash_full",
+        documentType: "zákon",
+      }),
+      makeRow({
+        id: "leg_sparse",
+        contentHash: "hash_sparse",
+        effectiveDate: null,
+        textS3Key: null,
+      }),
+    ];
+
+    const { built } = await loadDocsForBatch(rows, {
+      generation: "legislation_v2",
+      fetchFulltext: async () => "stored fulltext",
+      readPayload: async () => ({ text: "text", ast: null }),
+    });
+
+    const docs = built.flatMap((entry) => entry.docs);
+    const emitted = new Set(docs.flatMap((doc) => Object.keys(doc)));
+    const mapped = new Set(
+      corpusIndexConfig(
+        "legislation",
+        "legislation_v2_svk",
+      ).doc_mapping.field_mappings.map((field) => field.name),
+    );
+    expect([...emitted].filter((name) => !mapped.has(name)).sort()).toEqual([]);
+
+    // The fixtures reach the conditional fields, so the assertion is over the
+    // writer's whole shape rather than its required half.
+    for (const field of [
+      "canonical_ast_key",
+      "canonical_text_key",
+      "document_type",
+      "effective_date",
+      "eli",
+      "status",
+      "year",
+    ]) {
+      expect(emitted.has(field)).toBe(true);
+    }
   });
 });

--- a/apps/api/src/lib/legal-search/corpus-index-config.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.test.ts
@@ -22,13 +22,51 @@ test("searchable text fields enable fieldnorms so BM25 scoring works", () => {
   expect(fields.get("title")?.fieldnorms).toBe(true);
 });
 
-test("jurisdiction/document_type/source/court are tag fields for split pruning", () => {
+test("case-law tag fields are the filters a query prunes splits by", () => {
   expect(caseLawIndexConfig("case_law_v1").doc_mapping.tag_fields).toEqual([
     "jurisdiction",
     "document_type",
     "source",
     "court",
+    "language",
   ]);
+});
+
+// The engine never diffs an existing index, so the mode change reaches
+// documents only through a generation created from this config. An existing
+// generation keeps `lenient`, which is what makes a writer field it does not
+// map land harmlessly there rather than failing its ingest.
+test("a newly created index maps in strict mode", () => {
+  for (const family of ["case_law", "legislation"] as const) {
+    expect(corpusIndexConfig(family, `${family}_v3_cze`).doc_mapping.mode).toBe(
+      "strict",
+    );
+  }
+});
+
+test("the docket is its own raw field, reachable only by an exact query", () => {
+  const config = caseLawIndexConfig("case_law_v3_cze");
+  const caseNumber = config.doc_mapping.field_mappings.find(
+    (field) => field.name === "case_number",
+  );
+  expect(caseNumber).toEqual({
+    name: "case_number",
+    type: "text",
+    tokenizer: "raw",
+  });
+  // Raw and not a default search field: a docket answers `case_number:"..."`,
+  // and no free-text term reaches it. It repeats across a decision's passages,
+  // which is the fan-out rule that keeps it out of the default fields.
+  expect(config.search_settings.default_search_fields).not.toContain(
+    "case_number",
+  );
+  // Case law only: legislation identifies a document by ELI.
+  expect(
+    corpusIndexConfig(
+      "legislation",
+      "legislation_v2_svk",
+    ).doc_mapping.field_mappings.some((field) => field.name === "case_number"),
+  ).toBe(false);
 });
 
 /**

--- a/apps/api/src/lib/legal-search/corpus-index-config.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.test.ts
@@ -32,16 +32,19 @@ test("case-law tag fields are the filters a query prunes splits by", () => {
   ]);
 });
 
-// The engine never diffs an existing index, so the mode change reaches
-// documents only through a generation created from this config. An existing
-// generation keeps `lenient`, which is what makes a writer field it does not
-// map land harmlessly there rather than failing its ingest.
-test("a newly created index maps in strict mode", () => {
-  for (const family of ["case_law", "legislation"] as const) {
-    expect(corpusIndexConfig(family, `${family}_v3_cze`).doc_mapping.mode).toBe(
-      "strict",
-    );
-  }
+// The engine never diffs an existing index, so a mode change reaches documents
+// only through a generation created from this config; an existing generation
+// keeps the mode it was made with.
+//
+// `strict` costs the whole document when a field is undeclared, and says so
+// only in the engine's log, so a family may only take it where something
+// counts the documents that should be there. Case law has the rebuild census;
+// legislation does not, and stays lenient until it does.
+test("only a family with a census maps in strict mode", () => {
+  expect(caseLawIndexConfig("case_law_v3_cze").doc_mapping.mode).toBe("strict");
+  expect(
+    corpusIndexConfig("legislation", "legislation_v2_svk").doc_mapping.mode,
+  ).toBe("lenient");
 });
 
 test("the docket is its own raw field, reachable only by an exact query", () => {

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -207,17 +207,22 @@ export const DECISION_TIMESTAMP_FIELD = "decision_date_ts";
  * window this old, which is the property that matters: the field decides what
  * a date filter matches.
  *
- * It does not, on its own, make split pruning tight. A split's timestamp range
- * spans everything written into it, and the generation walk writes in
- * `(created_at, id)` order, so a split already mixes decisions from across the
- * corpus' date range; one undated row widens its low end to here. Pruning
- * tightens only for a generation whose splits are built date-contiguous, which
- * is a property of the backfill's walk order rather than of this constant.
+ * A split's timestamp range spans everything written into it, so pruning is
+ * tight only where the walk that filled the split was ordered by date. The
+ * generation walk is (see the case-law rebuild's cursor), and it puts undated
+ * decisions in their own band, at this value.
  */
 export const UNDATED_DECISION_TIMESTAMP = "1800-01-01";
 
 const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
   case_law: [
+    // The docket, exactly as the court wrote it. Raw-tokenized, so it answers
+    // an exact lookup and no free-text term reaches it; it repeats on every
+    // passage, which is what makes an exact lookup return the whole decision
+    // rather than one passage of it. Until now the number reached the index
+    // only inside `title`, where it is folded and tokenized with everything
+    // else on that line.
+    { name: "case_number", type: "text", tokenizer: "raw" },
     { name: "court", type: "text", tokenizer: "raw", fast: true },
     {
       name: "decision_date",
@@ -268,7 +273,10 @@ export const TAG_FIELD_VALUE_LIMIT = 1000;
  * by one country's court registry, not by every country's at once).
  */
 const FAMILY_TAG_FIELDS: Record<CorpusFamily, string[]> = {
-  case_law: ["jurisdiction", "document_type", "source", "court"],
+  // `language` is bounded by the languages a jurisdiction's courts publish in,
+  // which is one or a few; a jurisdiction that publishes in several is exactly
+  // where tagging it lets a language-filtered query skip splits.
+  case_law: ["jurisdiction", "document_type", "source", "court", "language"],
   legislation: ["jurisdiction", "document_type", "source", "status"],
 };
 
@@ -293,7 +301,26 @@ export const corpusIndexConfig = (
     version: CORPUS_INDEX_CONFIG_VERSION,
     index_id: indexId,
     doc_mapping: {
-      mode: "lenient",
+      // A document may only carry fields this mapping declares.
+      //
+      // What each mode does with a writer field the mapping does not have,
+      // measured against the engine: `lenient` indexes the document and drops
+      // the field, so a filter on it matches nothing, forever, with nothing to
+      // notice. `strict` drops the whole document — and not loudly: the ingest
+      // still answers 200 with the document counted as accepted, and the only
+      // direct trace is a warning in the engine's own log. The rebuild's
+      // census is what turns that into a signal, because a dropped document is
+      // a count the corpus side does not match.
+      //
+      // Losing a document the census reports beats losing a field nothing
+      // reports, but only because the writer and this mapping are checked
+      // against each other per family (see each family's projection test).
+      //
+      // Generation-scoped, like everything else here: an index already created
+      // keeps the `lenient` mapping it was made with, which is what lets the
+      // writer emit a field that generation never mapped (`decision_date_ts`
+      // against a v2 index) without losing that document.
+      mode: "strict",
       field_mappings: [...CORE_FIELDS, ...FAMILY_FIELDS[family]],
       tokenizers: CUSTOM_TOKENIZERS,
       tag_fields: FAMILY_TAG_FIELDS[family],

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -88,11 +88,13 @@ const MERGE_POLICY = {
   min_level_num_docs: 100_000,
 } as const;
 
+type CorpusIndexDocMappingMode = "lenient" | "strict" | "dynamic";
+
 export type CorpusIndexConfig = {
   version: string;
   index_id: string;
   doc_mapping: {
-    mode: "lenient" | "strict" | "dynamic";
+    mode: CorpusIndexDocMappingMode;
     field_mappings: CorpusIndexFieldMapping[];
     tokenizers: readonly CorpusIndexTokenizer[];
     tag_fields: string[];
@@ -222,6 +224,11 @@ const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
     // rather than one passage of it. Until now the number reached the index
     // only inside `title`, where it is folded and tokenized with everything
     // else on that line.
+    //
+    // Nothing queries it yet, and nothing can before the generation that maps
+    // it exists: the query layer builds its filters explicitly and strips
+    // engine field syntax out of free text, so a docket filter is added there
+    // with, or after, the flip.
     { name: "case_number", type: "text", tokenizer: "raw" },
     { name: "court", type: "text", tokenizer: "raw", fast: true },
     {
@@ -281,6 +288,31 @@ const FAMILY_TAG_FIELDS: Record<CorpusFamily, string[]> = {
 };
 
 /**
+ * How the engine treats a document field the mapping does not declare.
+ *
+ * `lenient` indexes the document and drops the field, so a filter on it
+ * matches nothing, forever, with nothing to notice. `strict` drops the whole
+ * document — and not loudly: the ingest still answers 200 with the document
+ * counted as accepted, and the only direct trace is a warning in the engine's
+ * own log.
+ *
+ * So `strict` is worth its failure mode only where something counts the
+ * documents that should be there. Case law has that: the rebuild's census
+ * compares the engine's count against the corpus' per jurisdiction, and a
+ * dropped document is a difference it reports. Legislation has no census yet
+ * and stays `lenient` until it does, because a silently dropped document
+ * there would be marked indexed with nothing to find it. Both families are
+ * covered on the other side by a test that every field their writer emits is
+ * one their mapping declares.
+ *
+ * Total, so a new family answers this rather than inheriting an answer.
+ */
+const FAMILY_DOC_MAPPING_MODE = {
+  case_law: "strict",
+  legislation: "lenient",
+} as const satisfies Record<CorpusFamily, CorpusIndexDocMappingMode>;
+
+/**
  * The datetime every document of a family carries, or null for a family that
  * has none. Total so a new family has to answer the question: the engine takes
  * the timestamp field as a promise about every document, and a family whose
@@ -301,26 +333,11 @@ export const corpusIndexConfig = (
     version: CORPUS_INDEX_CONFIG_VERSION,
     index_id: indexId,
     doc_mapping: {
-      // A document may only carry fields this mapping declares.
-      //
-      // What each mode does with a writer field the mapping does not have,
-      // measured against the engine: `lenient` indexes the document and drops
-      // the field, so a filter on it matches nothing, forever, with nothing to
-      // notice. `strict` drops the whole document — and not loudly: the ingest
-      // still answers 200 with the document counted as accepted, and the only
-      // direct trace is a warning in the engine's own log. The rebuild's
-      // census is what turns that into a signal, because a dropped document is
-      // a count the corpus side does not match.
-      //
-      // Losing a document the census reports beats losing a field nothing
-      // reports, but only because the writer and this mapping are checked
-      // against each other per family (see each family's projection test).
-      //
-      // Generation-scoped, like everything else here: an index already created
-      // keeps the `lenient` mapping it was made with, which is what lets the
-      // writer emit a field that generation never mapped (`decision_date_ts`
-      // against a v2 index) without losing that document.
-      mode: "strict",
+      // Per family, and generation-scoped like everything else here: an index
+      // already created keeps the mode it was made with, which is what lets
+      // the writer emit a field that generation never mapped
+      // (`decision_date_ts` against a v2 index) without losing that document.
+      mode: FAMILY_DOC_MAPPING_MODE[family],
       field_mappings: [...CORE_FIELDS, ...FAMILY_FIELDS[family]],
       tokenizers: CUSTOM_TOKENIZERS,
       tag_fields: FAMILY_TAG_FIELDS[family],


### PR DESCRIPTION
Three corpus-index doc-mapping changes.

- **`case_number`**, a raw-tokenized case-law field, written by the projection from the decision's docket. It reached the index only inside `title` before, folded and tokenized with the court name; as its own raw field it is reachable by an exact query and by no free-text term. Nothing queries it yet: the query layer builds its filters explicitly, so the docket filter is added there with, or after, the generation that maps the field.
- **`language`** joins the case-law tag fields, so a language filter prunes splits. It is already a raw fast field.
- **`mode`** is `strict` for case law rather than `lenient`: a document may only carry fields the mapping declares. Legislation stays `lenient` (see below).

Inert for existing indexes. The engine creates an index only when it is absent and never diffs the config of one that exists, so every deployed generation keeps the mapping it was built with; these take effect for the next generation created and backfilled.

## Verification

Against a throwaway `quickwit:0.8.2` container, the deployed engine version, using the configs this module emits and documents from the projection writers themselves:

- the index creates under `strict`; the stored mapping carries `case_number` as a raw field and `language` among the tag fields;
- every document shape the case-law writer emits ingests and stays searchable: dated and undated, opening passage and continuation, with and without `ecli`, `document_type`, and the canonical object keys;
- the legislation writer's shapes ingest the same way, with and without `effective_date`, `document_type` and the AST key;
- `case_number:"1 T 42/2024"` matches the decision's passages;
- the split records `language:` and `court:` tag values.

One thing to know about `strict` on this ingest path: a document carrying an undeclared field is dropped, and the ingest still answers 200 with the document counted as accepted. The only direct trace is a warning in the engine's log (`the document contains a field that is not declared in the schema`). `lenient` indexes the same document and drops just the field.

So the mode is a per-family decision, total over the families. Case law takes `strict` because the rebuild census counts the engine's documents against the corpus' per jurisdiction and reports the difference. Legislation has no census, so a dropped document there would be marked indexed with nothing to find it: it stays `lenient` until it has one.

Because of that, each family's projection test now asserts that every field its writer emits is one the mapping declares, over fixtures that reach the conditional fields rather than only the required ones.

Mutation-checked: unmapping `case_number`, removing it from the writer, reverting the mode to `lenient`, and dropping `language` from the tag fields each fail the suite.

(The container run predates the per-family mode split, and covered both families under `strict`; every writer shape of both families ingested cleanly there.)
