### PR TITLE
fix(api): normalize provider token counts in usage metering instead of panicking

### DIFF
--- a/apps/api/src/lib/usage/unit-model.test.ts
+++ b/apps/api/src/lib/usage/unit-model.test.ts
@@ -137,18 +137,53 @@ describe("computeRawUsageMicroUnits", () => {
     ).toBe(0);
   });
 
-  test("panics on inconsistent token counts (cache > input)", () => {
-    expect(() =>
+  test("clamps cache reads above input tokens to the fully-cached result", () => {
+    const uncached = computeRawUsageMicroUnits({
+      modelId: "gemini-2.5-flash",
+      inputTokens: 100,
+      outputTokens: 0,
+    });
+    const fullyCached = computeRawUsageMicroUnits({
+      modelId: "gemini-2.5-flash",
+      inputTokens: 100,
+      outputTokens: 0,
+      cacheReadTokens: 100,
+    });
+    // Mutation guard: the cached rate is cheaper, so the clamp target is
+    // distinguishable from both the uncached cost and zero.
+    expect(fullyCached).toBeLessThan(uncached);
+    expect(fullyCached).toBeGreaterThan(0);
+
+    // Cache reads beyond the input count clamp down to the input count
+    // instead of throwing or driving billed input negative.
+    expect(
       computeRawUsageMicroUnits({
         modelId: "gemini-2.5-flash",
         inputTokens: 100,
         outputTokens: 0,
         cacheReadTokens: 200,
       }),
-    ).toThrow("cached input tokens cannot exceed total input tokens");
+    ).toBe(fullyCached);
   });
 
-  test("rejects every token field outside the non-negative safe-integer domain", () => {
+  test("reports telemetry once when a provider count is out of domain", () => {
+    const modelId = "unit-model-test-count-anomaly";
+    computeRawUsageMicroUnits({
+      modelId,
+      inputTokens: 100,
+      outputTokens: 0,
+      cacheReadTokens: 500,
+    });
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        source: "usage-unit-model",
+        field: "cacheReadTokens",
+      }),
+    );
+  });
+
+  test("normalizes token fields outside the non-negative safe-integer domain to zero", () => {
     const invalidCounts = [
       -1,
       0.5,
@@ -161,15 +196,26 @@ describe("computeRawUsageMicroUnits", () => {
 
     for (const field of fields) {
       for (const invalidCount of invalidCounts) {
-        expect(() =>
+        const units = computeRawUsageMicroUnits({
+          modelId: "gemini-2.5-flash",
+          inputTokens: 100,
+          outputTokens: 100,
+          cacheReadTokens: 0,
+          [field]: invalidCount,
+        });
+        // The bad field floors to zero: the call still returns a finite,
+        // safe result and matches the same input with that field set to 0,
+        // rather than aborting the metering path.
+        expect(Number.isSafeInteger(units)).toBe(true);
+        expect(units).toBe(
           computeRawUsageMicroUnits({
             modelId: "gemini-2.5-flash",
             inputTokens: 100,
             outputTokens: 100,
             cacheReadTokens: 0,
-            [field]: invalidCount,
+            [field]: 0,
           }),
-        ).toThrow("usage token counts must be non-negative safe integers");
+        );
       }
     }
   });

--- a/apps/api/src/lib/usage/unit-model.ts
+++ b/apps/api/src/lib/usage/unit-model.ts
@@ -103,10 +103,61 @@ type UsageInput = {
   cacheReadTokens?: number;
 };
 
+// Model id + field pairs already reported for a count anomaly this process,
+// so a hot billing path can't spam telemetry.
+const reportedCountAnomalyKeys = new Set<string>();
+
+/**
+ * Provider token counts are external input, not an internal invariant, so an
+ * inconsistent count normalizes into the valid domain and is reported once per
+ * model + field instead of aborting the metering path. Mirrors the catalog-miss
+ * handling above (capture + safe fallback) rather than `panic`.
+ */
+const reportUsageCountAnomaly = ({
+  modelId,
+  field,
+  value,
+}: {
+  modelId: string;
+  field: string;
+  value: number;
+}): void => {
+  const key = `${modelId}:${field}`;
+  if (reportedCountAnomalyKeys.has(key)) {
+    return;
+  }
+  reportedCountAnomalyKeys.add(key);
+  captureError(
+    new TelemetryError({
+      message: "Provider usage count outside the valid domain; normalized",
+    }),
+    { source: "usage-unit-model", modelId, field, value: String(value) },
+  );
+};
+
+/**
+ * Floor a provider-reported token count into the non-negative safe-integer
+ * domain. Anything outside it (negative, fractional, non-finite, or above the
+ * safe-integer ceiling) becomes zero so a single malformed payload cannot
+ * distort or abort settlement.
+ */
+const normalizeTokenCount = (
+  value: number,
+  field: string,
+  modelId: string,
+): number => {
+  if (isNonNegativeSafeInteger(value)) {
+    return value;
+  }
+  reportUsageCountAnomaly({ modelId, field, value });
+  return 0;
+};
+
 /**
  * Convert token usage into normalized micro-units using the
- * model's public rate table. Provider token counts are validated here because
- * this helper is the shared boundary before usage reaches the ledger.
+ * model's public rate table. Provider token counts are external input, so this
+ * shared boundary normalizes them before they reach the ledger rather than
+ * aborting the process on a malformed or inconsistent payload.
  */
 export const computeRawUsageMicroUnits = ({
   modelId,
@@ -114,22 +165,44 @@ export const computeRawUsageMicroUnits = ({
   outputTokens,
   cacheReadTokens = 0,
 }: UsageInput): number => {
-  if (
-    !isNonNegativeSafeInteger(inputTokens) ||
-    !isNonNegativeSafeInteger(outputTokens) ||
-    !isNonNegativeSafeInteger(cacheReadTokens)
-  ) {
-    panic("usage token counts must be non-negative safe integers");
+  const safeInputTokens = normalizeTokenCount(
+    inputTokens,
+    "inputTokens",
+    modelId,
+  );
+  const safeOutputTokens = normalizeTokenCount(
+    outputTokens,
+    "outputTokens",
+    modelId,
+  );
+  const reportedCacheReadTokens = normalizeTokenCount(
+    cacheReadTokens,
+    "cacheReadTokens",
+    modelId,
+  );
+  // Cache reads are a subset of the input tokens. A provider that reports more
+  // cache reads than input tokens is clamped so billed input never goes
+  // negative; the overlap is billed at the (cheaper) cached rate.
+  const safeCacheReadTokens = Math.min(
+    reportedCacheReadTokens,
+    safeInputTokens,
+  );
+  if (safeCacheReadTokens !== reportedCacheReadTokens) {
+    reportUsageCountAnomaly({
+      modelId,
+      field: "cacheReadTokens",
+      value: cacheReadTokens,
+    });
   }
-  if (cacheReadTokens > inputTokens) {
-    panic("cached input tokens cannot exceed total input tokens");
-  }
-  const rate = resolveModelRate(getModelRateOrFallback(modelId), inputTokens);
-  const billedInputTokens = inputTokens - cacheReadTokens;
+  const rate = resolveModelRate(
+    getModelRateOrFallback(modelId),
+    safeInputTokens,
+  );
+  const billedInputTokens = safeInputTokens - safeCacheReadTokens;
   const cachedRate = rate.cachedInputPerMTok ?? rate.inputPerMTok;
   const inputCost = scaleTokenCost(billedInputTokens, rate.inputPerMTok);
-  const cacheCost = scaleTokenCost(cacheReadTokens, cachedRate);
-  const outputCost = scaleTokenCost(outputTokens, rate.outputPerMTok);
+  const cacheCost = scaleTokenCost(safeCacheReadTokens, cachedRate);
+  const outputCost = scaleTokenCost(safeOutputTokens, rate.outputPerMTok);
   const rawUsageMicroUnits = inputCost + cacheCost + outputCost;
   if (!Number.isSafeInteger(rawUsageMicroUnits)) {
     panic("computed raw usage exceeds the safe integer range");


### PR DESCRIPTION
## Proposed change

`computeRawUsageMicroUnits` (`apps/api/src/lib/usage/unit-model.ts`) is the shared boundary that turns provider-reported token usage into ledger micro-units. It treated an out-of-domain or inconsistent count as an internal invariant and called `panic()`, which aborts the whole process. Those counts are external input, so a single malformed or unusual payload can bring the process down:

- `cacheReadTokens` is only a subset of `inputTokens` by convention. A provider that reports more cache-read tokens than input tokens trips the `cache > input` panic, and also drives `billedInputTokens = inputTokens - cacheReadTokens` negative.
- A non-integer, negative, non-finite, or above-safe-integer value in any token field trips the non-negative-safe-integer panic.

Normalize at the boundary instead, mirroring the module's existing catalog-miss handling (capture telemetry + safe fallback rather than `panic`):

- Floor each token field into the non-negative safe-integer domain; out-of-domain values become `0`.
- Clamp `cacheReadTokens` to `inputTokens`, so billed input is never negative and the overlap bills at the cached rate.
- Report each anomaly once per model + field through `captureError` (deduped per process like the catalog-miss path, so a hot billing path can't spam telemetry).

Internal arithmetic-overflow guards stay as `panic()`; they protect our own rate arithmetic, not external counts.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings. (`bun --filter @stll/api typecheck`, oxlint, and oxfmt are clean.)
- [x] **TESTING** | Added coverage for the cache clamp, per-field domain normalization, and the once-per-key telemetry. Mutation-checked: reverting the clamp or the floor fails the new tests.
- [ ] DARK MODE SUPPORT | N/A, backend metering change.
- [ ] ISSUE LINKED | No linked issue.
- [ ] SCREENSHOT INCLUDED | N/A, no UI change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Knc4tyLPR5symhSb9QHMWf)_