### PR TITLE
fix(api): clamp provider usage token counts instead of panicking

### DIFF
--- a/apps/api/src/lib/usage/unit-model.test.ts
+++ b/apps/api/src/lib/usage/unit-model.test.ts
@@ -137,18 +137,28 @@ describe("computeRawUsageMicroUnits", () => {
     ).toBe(0);
   });
 
-  test("panics on inconsistent token counts (cache > input)", () => {
-    expect(() =>
+  test("clamps a cache-read count above the input count and reports it", () => {
+    // Providers that report cache reads separately from (not as a subset
+    // of) input tokens can send cacheReadTokens > inputTokens; metering
+    // must clamp to the range the arithmetic assumes, not abort.
+    const clamped = computeRawUsageMicroUnits({
+      modelId: "gpt-5.4",
+      inputTokens: 100,
+      outputTokens: 0,
+      cacheReadTokens: 200,
+    });
+    expect(clamped).toBe(
       computeRawUsageMicroUnits({
-        modelId: "gemini-2.5-flash",
+        modelId: "gpt-5.4",
         inputTokens: 100,
         outputTokens: 0,
-        cacheReadTokens: 200,
+        cacheReadTokens: 100,
       }),
-    ).toThrow("cached input tokens cannot exceed total input tokens");
+    );
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
   });
 
-  test("rejects every token field outside the non-negative safe-integer domain", () => {
+  test("never throws on token fields outside the non-negative safe-integer domain", () => {
     const invalidCounts = [
       -1,
       0.5,
@@ -159,19 +169,35 @@ describe("computeRawUsageMicroUnits", () => {
     ];
     const fields = ["inputTokens", "outputTokens", "cacheReadTokens"] as const;
 
+    // The metering boundary must degrade to a clamped, non-negative safe
+    // integer for any malformed provider payload rather than crashing the
+    // process, since it runs in the nonterminal onUsage callback.
     for (const field of fields) {
       for (const invalidCount of invalidCounts) {
-        expect(() =>
-          computeRawUsageMicroUnits({
+        let units = -1;
+        expect(() => {
+          units = computeRawUsageMicroUnits({
             modelId: "gemini-2.5-flash",
             inputTokens: 100,
             outputTokens: 100,
             cacheReadTokens: 0,
             [field]: invalidCount,
-          }),
-        ).toThrow("usage token counts must be non-negative safe integers");
+          });
+        }).not.toThrow();
+        expect(Number.isSafeInteger(units)).toBe(true);
+        expect(units).toBeGreaterThanOrEqual(0);
       }
     }
+  });
+
+  test("reports a clamped token anomaly through telemetry", () => {
+    computeRawUsageMicroUnits({
+      modelId: "gpt-5.5",
+      inputTokens: 100,
+      outputTokens: -5,
+      cacheReadTokens: 0,
+    });
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
   });
 
   test("rejects a computed amount outside the safe-integer domain", () => {

--- a/apps/api/src/lib/usage/unit-model.ts
+++ b/apps/api/src/lib/usage/unit-model.ts
@@ -77,6 +77,70 @@ const getModelRateOrFallback = (modelId: string): ModelRate => {
 const isNonNegativeSafeInteger = (value: number): boolean =>
   Number.isSafeInteger(value) && value >= 0;
 
+const toTokenCount = (value: number): number =>
+  isNonNegativeSafeInteger(value) ? value : 0;
+
+// Model ids already reported for a token-count anomaly this process, so a
+// hot billing path can't spam telemetry when a provider reports usage
+// consistently outside the expected range.
+const reportedTokenAnomalyModelIds = new Set<string>();
+
+/**
+ * Provider-reported token counts are external boundary data, not an
+ * internal invariant: a malformed or differently-normalized usage payload
+ * (negative, fractional, or a cache-read count that is not a subset of the
+ * input count) must be metered at clamped values and reported, never abort
+ * the process. This helper runs in the analytics `onUsage` callback, which
+ * the chat lifecycle declares nonterminal, so a panic here would escalate a
+ * data-quality problem into a process crash.
+ */
+const sanitizeProviderTokenCounts = ({
+  modelId,
+  inputTokens,
+  outputTokens,
+  cacheReadTokens,
+}: {
+  modelId: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+}): { inputTokens: number; outputTokens: number; cacheReadTokens: number } => {
+  const safeInputTokens = toTokenCount(inputTokens);
+  const safeOutputTokens = toTokenCount(outputTokens);
+  // `cacheReadTokens` is a subset of `inputTokens` (see `billedInputTokens`),
+  // so clamp into range to keep that arithmetic invariant non-negative.
+  const safeCacheReadTokens = Math.min(
+    toTokenCount(cacheReadTokens),
+    safeInputTokens,
+  );
+
+  const clamped =
+    safeInputTokens !== inputTokens ||
+    safeOutputTokens !== outputTokens ||
+    safeCacheReadTokens !== cacheReadTokens;
+  if (clamped && !reportedTokenAnomalyModelIds.has(modelId)) {
+    reportedTokenAnomalyModelIds.add(modelId);
+    captureError(
+      new TelemetryError({
+        message: "Usage token counts out of range; metering at clamped values",
+      }),
+      {
+        source: "usage-unit-model",
+        modelId,
+        inputTokens: String(inputTokens),
+        outputTokens: String(outputTokens),
+        cacheReadTokens: String(cacheReadTokens),
+      },
+    );
+  }
+
+  return {
+    inputTokens: safeInputTokens,
+    outputTokens: safeOutputTokens,
+    cacheReadTokens: safeCacheReadTokens,
+  };
+};
+
 const scaleTokenCost = (tokens: number, ratePerMTok: number): number => {
   if (!isNonNegativeSafeInteger(ratePerMTok)) {
     panic("usage rates must be non-negative safe integers");
@@ -105,8 +169,9 @@ type UsageInput = {
 
 /**
  * Convert token usage into normalized micro-units using the
- * model's public rate table. Provider token counts are validated here because
- * this helper is the shared boundary before usage reaches the ledger.
+ * model's public rate table. Provider token counts are sanitized here
+ * (see `sanitizeProviderTokenCounts`) because this helper is the shared
+ * boundary before usage reaches the ledger.
  */
 export const computeRawUsageMicroUnits = ({
   modelId,
@@ -114,22 +179,25 @@ export const computeRawUsageMicroUnits = ({
   outputTokens,
   cacheReadTokens = 0,
 }: UsageInput): number => {
-  if (
-    !isNonNegativeSafeInteger(inputTokens) ||
-    !isNonNegativeSafeInteger(outputTokens) ||
-    !isNonNegativeSafeInteger(cacheReadTokens)
-  ) {
-    panic("usage token counts must be non-negative safe integers");
-  }
-  if (cacheReadTokens > inputTokens) {
-    panic("cached input tokens cannot exceed total input tokens");
-  }
-  const rate = resolveModelRate(getModelRateOrFallback(modelId), inputTokens);
-  const billedInputTokens = inputTokens - cacheReadTokens;
+  const {
+    inputTokens: safeInputTokens,
+    outputTokens: safeOutputTokens,
+    cacheReadTokens: safeCacheReadTokens,
+  } = sanitizeProviderTokenCounts({
+    modelId,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+  });
+  const rate = resolveModelRate(
+    getModelRateOrFallback(modelId),
+    safeInputTokens,
+  );
+  const billedInputTokens = safeInputTokens - safeCacheReadTokens;
   const cachedRate = rate.cachedInputPerMTok ?? rate.inputPerMTok;
   const inputCost = scaleTokenCost(billedInputTokens, rate.inputPerMTok);
-  const cacheCost = scaleTokenCost(cacheReadTokens, cachedRate);
-  const outputCost = scaleTokenCost(outputTokens, rate.outputPerMTok);
+  const cacheCost = scaleTokenCost(safeCacheReadTokens, cachedRate);
+  const outputCost = scaleTokenCost(safeOutputTokens, rate.outputPerMTok);
   const rawUsageMicroUnits = inputCost + cacheCost + outputCost;
   if (!Number.isSafeInteger(rawUsageMicroUnits)) {
     panic("computed raw usage exceeds the safe integer range");


### PR DESCRIPTION
## Proposed change

`computeRawUsageMicroUnits` (`apps/api/src/lib/usage/unit-model.ts`) is the post-flight metering boundary that turns provider-reported token counts into ledger micro-units. It runs inside the analytics `onUsage` callback, which `tanstack-chat-lifecycle` declares nonterminal.

The helper called `panic()` when a provider reported:

- a cache-read count larger than the input count, or
- a negative / fractional / non-finite token count.

`panic()` is reserved for impossible internal invariants and programmer misuse. Provider-reported token counts are external boundary data: some providers report cache-read tokens separately from (not as a subset of) the input count, so `cacheReadTokens > inputTokens` is a shape the code can actually receive. Because the panic runs in a nonterminal callback, an out-of-range usage payload would abort the whole process instead of degrading.

This change sanitizes the counts at the boundary:

- coerce each count to a non-negative safe integer (invalid → `0`);
- clamp cache reads to at most the input count — the range `billedInputTokens = inputTokens - cacheReadTokens` already assumes;
- report the anomaly once per model through the existing `captureError(TelemetryError)` channel (same dedup approach used for the catalog-rate miss just above), then meter at the clamped values.

Genuine overflow of the computed micro-units stays a `panic()` — that is a real internal arithmetic invariant, not external data.

Tests are updated to assert the boundary now degrades instead of throwing: an over-range cache-read count clamps to the input count and is reported, and no malformed token field (negative, fractional, `NaN`, `±Infinity`, above `MAX_SAFE_INTEGER`) can throw — the helper always returns a non-negative safe integer.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings. (`typecheck` and `oxlint` clean on the changed files.)
- [x] **TESTING** | `bun test apps/api/src/lib/usage/unit-model.test.ts` passes (22 tests). Mutation-checked: reintroducing the panic fails the new tests.
- [ ] DARK MODE SUPPORT | N/A (backend metering logic, no UI).
- [ ] ISSUE LINKED | N/A.
- [ ] SCREENSHOT INCLUDED | N/A (no UI change).

---
_Generated by [Claude Code](https://claude.ai/code/session_016KboQvWVU6eQ7XAdZwo92J)_