### PR TITLE
fix(ci): gate the staging chat smoke on installed dependencies

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -452,6 +452,7 @@ jobs:
         uses: stella/.github/actions/setup-bun-cached@2b8697f04b39187c934afc04f7b04ad1a18bd827
 
       - name: Install dependencies
+        id: smoke-deps
         if: steps.current.outputs.promoted == 'true'
         run: bash scripts/bun-ci-retry.sh --ignore-scripts
         env:
@@ -474,8 +475,12 @@ jobs:
           # so it doesn't race the ECS task rollover.
           EXPECTED_COMMIT: ${{ github.sha }}
 
+      # `!cancelled()` keeps this signal when the web smoke fails, but it
+      # also suppresses the implicit success() gate, so without the explicit
+      # deps condition this step ran after a failed deploy with no toolchain
+      # installed and died with `bun: command not found`.
       - name: Run staging API chat smoke
-        if: ${{ steps.current.outputs.promoted == 'true' && !cancelled() }}
+        if: ${{ steps.current.outputs.promoted == 'true' && !cancelled() && steps.smoke-deps.conclusion == 'success' }}
         run: bun apps/api/src/scripts/post-deploy-smoke.ts "$E2E_API_URL"
         env:
           E2E_API_URL: https://api-staging.stll.app


### PR DESCRIPTION
In `deploy-staging.yml`'s promote job, `Run staging API chat smoke` uses `!cancelled()` so a failed web smoke does not hide chat-smoke signal. Because any status-check function suppresses the implicit `success()` gate, the step also ran when the deploy itself failed, with `Setup Bun`/`Install dependencies` skipped, and died with `bun: command not found` (run 32037193621) instead of being skipped.

Gate it on `steps.smoke-deps.conclusion == 'success'` (id added to Install dependencies): after a failed deploy every setup step is skipped, so the chat smoke now skips too; after a failed web smoke it still runs.