### PR TITLE
fix(api): meter cached input tokens correctly across provider usage shapes

### DIFF
--- a/apps/api/src/lib/analytics/tanstack-ai.test.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.test.ts
@@ -45,6 +45,21 @@ const createOpenAIOrgAIConfig = (): OrgAIConfig => ({
   },
 });
 
+const createAnthropicOrgAIConfig = (): OrgAIConfig => ({
+  providers: [
+    {
+      apiKey: "test-anthropic-org-key",
+      provider: "anthropic",
+    },
+  ],
+  overrideModels: {
+    chat: { provider: "anthropic", modelId: "claude-sonnet-5" },
+    fast: { provider: "anthropic", modelId: "claude-sonnet-5" },
+    pdf: { provider: "anthropic", modelId: "claude-sonnet-5" },
+    reasoning: { provider: "anthropic", modelId: "claude-sonnet-5" },
+  },
+});
+
 const createMiddlewareContext = ({
   deferred = [],
   iteration = 0,
@@ -309,6 +324,139 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
     });
   });
 
+  test("meters an Anthropic warm cache where cached reads exceed input tokens", async () => {
+    const { createTanStackAIAnalyticsCallbacks } =
+      await loadTanStackAIAnalytics();
+    const insertedRows: unknown[] = [];
+    const tx = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [
+              {
+                currentPeriodEnd: new Date("2026-07-01T00:00:00.000Z"),
+                currentPeriodStart: new Date("2026-06-01T00:00:00.000Z"),
+                status: "active",
+              },
+            ],
+          }),
+        }),
+      }),
+      insert: () => ({
+        values: (values: unknown) => {
+          insertedRows.push(values);
+          return {
+            onConflictDoNothing: () => ({
+              returning: async () => [{ id: "usage_event_1" }],
+            }),
+          };
+        },
+      }),
+    };
+    const { safeDb } = createScopedDbMock(tx);
+    const callbacks = createTanStackAIAnalyticsCallbacks({
+      analytics: {
+        capture: () => undefined,
+        flush: async () => undefined,
+        identifyOrganizationGroup: () => undefined,
+      },
+      feature: "chat.stream",
+      modelRole: "chat",
+      orgAIConfig: createAnthropicOrgAIConfig(),
+      traceId: "trace_anthropic_warm_cache",
+      usageMetering: {
+        actionType: "chat",
+        organizationId: orgId,
+        safeDb,
+        serviceTier: "standard",
+        userId,
+        workspaceId,
+      },
+    });
+    const deferred: Promise<unknown>[] = [];
+
+    // Production-shaped Anthropic usage on a warm cache: `input_tokens`
+    // excludes cache reads and writes, so the cached count dwarfs it.
+    await callbacks.middleware.onUsage?.(
+      createMiddlewareContext({ deferred }),
+      {
+        completionTokens: 1538,
+        promptTokens: 217,
+        promptTokensDetails: { cachedTokens: 45_082, cacheWriteTokens: 1204 },
+        totalTokens: 1755,
+      },
+    );
+    await Promise.all(deferred);
+
+    expect(insertedRows).toHaveLength(1);
+    // (217 + 1204 write) uncached at 200_000/MTok = 285, 45_082 cached at
+    // 20_000/MTok = 902, 1538 output at 1_000_000/MTok = 1538.
+    expect(insertedRows[0]).toMatchObject({
+      isByok: true,
+      rawUsageMicroUnits: 285 + 902 + 1538,
+    });
+  });
+
+  test("survives a faulty usage payload without rejecting the stream hook", async () => {
+    const { createTanStackAIAnalyticsCallbacks } =
+      await loadTanStackAIAnalytics();
+    const insertedRows: unknown[] = [];
+    const tx = {
+      insert: () => ({
+        values: (values: unknown) => {
+          insertedRows.push(values);
+          return {
+            onConflictDoNothing: () => ({
+              returning: async () => [{ id: "usage_event_1" }],
+            }),
+          };
+        },
+      }),
+    };
+    const { safeDb } = createScopedDbMock(tx);
+    const callbacks = createTanStackAIAnalyticsCallbacks({
+      analytics: {
+        capture: () => undefined,
+        flush: async () => undefined,
+        identifyOrganizationGroup: () => undefined,
+      },
+      feature: "chat.stream",
+      modelRole: "chat",
+      orgAIConfig: createOpenAIOrgAIConfig(),
+      traceId: "trace_poisoned_usage",
+      usageMetering: {
+        actionType: "chat",
+        organizationId: orgId,
+        safeDb,
+        serviceTier: "standard",
+        userId,
+        workspaceId,
+      },
+    });
+    const deferred: Promise<unknown>[] = [];
+    // Stands in for any future metering bug: reading the payload throws.
+    const poisonedUsage = Object.defineProperty(
+      { completionTokens: 0, promptTokens: 0, totalTokens: 0 },
+      "promptTokens",
+      {
+        get: (): number => {
+          throw new Error("poisoned usage payload");
+        },
+      },
+    ) satisfies TokenUsage;
+
+    // The hook is called from inside the provider stream: a metering
+    // fault must be swallowed and reported, never propagated.
+    expect(() => {
+      void callbacks.middleware.onUsage?.(
+        createMiddlewareContext({ deferred }),
+        poisonedUsage,
+      );
+    }).not.toThrow();
+    await Promise.all(deferred);
+    expect(insertedRows).toHaveLength(0);
+  });
+
   test("rates consumption against the explicitly selected model", async () => {
     const { createTanStackAIAnalyticsCallbacks } =
       await loadTanStackAIAnalytics();
@@ -383,11 +531,11 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
     const ratedMicroUnits = (modelId: string) =>
       usageUnitsFromTokens({
         actionType: "chat",
-        inputTokens: usage.promptTokens,
         isByok: true,
         modelId,
         outputTokens: usage.completionTokens,
         serviceTier: "standard",
+        uncachedInputTokens: usage.promptTokens,
       }).rawUsageMicroUnits;
 
     // The org config's chat role default is gpt-5.4-mini: metering and

--- a/apps/api/src/lib/analytics/tanstack-ai.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.ts
@@ -23,7 +23,10 @@ import {
   type ResolvedTanStackTextModelInfo,
 } from "@/api/lib/tanstack-ai-models";
 import { incrementLaneCounter } from "@/api/lib/usage/lane-budget";
-import { usageUnitsFromTokens } from "@/api/lib/usage/unit-model";
+import {
+  normalizeProviderPromptTokens,
+  usageUnitsFromTokens,
+} from "@/api/lib/usage/unit-model";
 import { recordUsageEvent } from "@/api/lib/usage/usage-ledger";
 
 import { getAnalytics } from "./client";
@@ -186,10 +189,6 @@ const resolveTanStackEffectiveServiceTier = ({
     serviceTier,
   });
 
-const getUsageCacheReadTokens = (usage: {
-  promptTokensDetails?: { cachedTokens?: number | undefined } | undefined;
-}): number => usage.promptTokensDetails?.cachedTokens ?? 0;
-
 const usageServiceTierFromModelOptions = ({
   fallback,
   modelOptions,
@@ -223,18 +222,18 @@ const recordTanStackConsumption = async ({
   config,
   iteration,
   modelInfo,
-  promptTokens,
   runId,
   serviceTier,
+  uncachedInputTokens,
 }: {
   cacheReadTokens: number;
   completionTokens: number;
   config: TanStackAIAnalyticsProps;
   iteration: number;
   modelInfo: ResolvedTanStackTextModelInfo;
-  promptTokens: number;
   runId: string;
   serviceTier: UsageServiceTier;
+  uncachedInputTokens: number;
 }): Promise<void> => {
   const metering = config.usageMetering;
   if (!metering) {
@@ -248,11 +247,11 @@ const recordTanStackConsumption = async ({
   const { unitsConsumed, rawUsageMicroUnits } = usageUnitsFromTokens({
     actionType: metering.actionType,
     cacheReadTokens,
-    inputTokens: promptTokens,
     isByok: modelInfo.keySource === "byok",
     modelId: modelInfo.modelId,
     outputTokens: completionTokens,
     serviceTier: effectiveServiceTier,
+    uncachedInputTokens,
   });
 
   const lane = metering.lane ?? "pool";
@@ -499,31 +498,60 @@ export const createTanStackAIAnalyticsCallbacks = ({
           },
         });
       },
+      // Framework-hook boundary (the one place try-catch is allowed): a
+      // metering fault must never propagate into the provider stream and
+      // take the process down with it. A bug here loses one metering
+      // event and reports it; it never loses the server.
       onUsage: (ctx, usage) => {
-        const metering = config.usageMetering;
-        if (!metering) {
-          return;
-        }
+        try {
+          const metering = config.usageMetering;
+          if (!metering) {
+            return;
+          }
 
-        const resolvedModelInfo = resolveAnalyticsModelInfo();
-        if (!resolvedModelInfo) {
-          return;
-        }
+          const resolvedModelInfo = resolveAnalyticsModelInfo();
+          if (!resolvedModelInfo) {
+            return;
+          }
 
-        const consumption = recordTanStackConsumption({
-          cacheReadTokens: getUsageCacheReadTokens(usage),
-          completionTokens: usage.completionTokens,
-          config,
-          iteration: ctx.iteration,
-          modelInfo: resolvedModelInfo,
-          promptTokens: usage.promptTokens,
-          runId: ctx.runId,
-          serviceTier: usageServiceTierFromModelOptions({
-            fallback: metering.serviceTier,
-            modelOptions: ctx.modelOptions,
-          }),
-        });
-        ctx.defer(consumption);
+          const { uncachedInputTokens, cacheReadTokens } =
+            normalizeProviderPromptTokens({
+              provider: resolvedModelInfo.provider,
+              modelId: resolvedModelInfo.modelId,
+              promptTokens: usage.promptTokens,
+              cacheReadTokens: usage.promptTokensDetails?.cachedTokens ?? 0,
+              cacheWriteTokens:
+                usage.promptTokensDetails?.cacheWriteTokens ?? 0,
+            });
+          const consumption = recordTanStackConsumption({
+            cacheReadTokens,
+            completionTokens: usage.completionTokens,
+            config,
+            iteration: ctx.iteration,
+            modelInfo: resolvedModelInfo,
+            runId: ctx.runId,
+            serviceTier: usageServiceTierFromModelOptions({
+              fallback: metering.serviceTier,
+              modelOptions: ctx.modelOptions,
+            }),
+            uncachedInputTokens,
+          }).catch((error: unknown) => {
+            // A rejected deferred settles inside the stream lifecycle;
+            // capture it here so it cannot surface as an unhandled
+            // rejection there.
+            captureTelemetryError(error, {
+              organization_id: metering.organizationId,
+              source: "usage.tanstack_ai",
+              trace_id: config.traceId,
+            });
+          });
+          ctx.defer(consumption);
+        } catch (error) {
+          captureTelemetryError(error, {
+            source: "usage.tanstack_ai",
+            trace_id: config.traceId,
+          });
+        }
       },
     },
   };

--- a/apps/api/src/lib/usage/provider-cache-accounting-canary.test.ts
+++ b/apps/api/src/lib/usage/provider-cache-accounting-canary.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Canary tests binding PROVIDER_CACHE_READ_ACCOUNTING (unit-model.ts) to the
+ * REAL adapter usage builders, not to hand-written fixtures that restate the
+ * map's own assumptions. Each test feeds a production-shaped provider usage
+ * payload through the adapter code that ships to production and asserts the
+ * relationship between `promptTokens` and `promptTokensDetails.cachedTokens`
+ * that the accounting map encodes for that provider.
+ *
+ * The usage builders are internal modules, deliberately imported by dist file
+ * path because the packages' exports maps do not expose them. That fragility
+ * is the point of a canary: an adapter upgrade that moves or reshapes the
+ * builder fails these imports loudly, forcing the accounting map to be
+ * re-verified against the new adapter behavior instead of drifting silently.
+ *
+ * Providers not exercised here: the bedrock and openai adapters currently
+ * emit no `cachedTokens` at all (verified against their dist output), so
+ * their map entries cannot mis-meter today; if an upgrade adds cache fields,
+ * the anomaly telemetry (`cache-read-exceeds-included-prompt`) is the runtime
+ * backstop until a canary is added for them.
+ */
+// eslint-disable-next-line import/no-relative-packages -- deliberate deep import: the usage builder is not in the package exports map; breaking on adapter upgrade is this canary's purpose
+import { buildAnthropicUsage } from "../../../../../node_modules/@tanstack/ai-anthropic/dist/esm/usage.js";
+// eslint-disable-next-line import/no-relative-packages -- deliberate deep import: the usage builder is not in the package exports map; breaking on adapter upgrade is this canary's purpose
+import { buildGeminiUsage } from "../../../../../node_modules/@tanstack/ai-gemini/dist/esm/usage.js";
+
+describe("provider cache accounting canaries", () => {
+  test("anthropic adapter reports cache reads SEPARATE from input_tokens", () => {
+    // Production-shaped Anthropic usage on a warm cache: input_tokens
+    // excludes cache reads, so the cached count legitimately dwarfs it.
+    const usage = buildAnthropicUsage({
+      input_tokens: 5,
+      output_tokens: 421,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 18_874,
+    });
+    if (usage === undefined) {
+      throw new Error("adapter returned no usage for a present usage object");
+    }
+    // separate-from-input: promptTokens stays the uncached count and the
+    // cache reads ride promptTokensDetails without being folded in.
+    expect(usage.promptTokens).toBe(5);
+    expect(usage.promptTokensDetails?.cachedTokens).toBe(18_874);
+  });
+
+  test("anthropic adapter keeps cache writes out of promptTokens too", () => {
+    const usage = buildAnthropicUsage({
+      input_tokens: 12,
+      output_tokens: 50,
+      cache_creation_input_tokens: 9502,
+      cache_read_input_tokens: 0,
+    });
+    if (usage === undefined) {
+      throw new Error("adapter returned no usage for a present usage object");
+    }
+    expect(usage.promptTokens).toBe(12);
+    expect(usage.promptTokensDetails?.cacheWriteTokens).toBe(9502);
+  });
+
+  test("gemini adapter reports cache reads INCLUDED in promptTokenCount", () => {
+    // Production-shaped Gemini usageMetadata: promptTokenCount is the total
+    // prompt INCLUDING cachedContentTokenCount.
+    const usage = buildGeminiUsage({
+      promptTokenCount: 21_000,
+      candidatesTokenCount: 300,
+      totalTokenCount: 21_300,
+      cachedContentTokenCount: 18_874,
+    });
+    if (usage === undefined) {
+      throw new Error("adapter returned no usage for a present usage object");
+    }
+    // included-in-input: the cached count is a subset of promptTokens.
+    expect(usage.promptTokens).toBe(21_000);
+    expect(usage.promptTokensDetails?.cachedTokens).toBe(18_874);
+    const cached = usage.promptTokensDetails?.cachedTokens ?? 0;
+    expect(cached).toBeLessThanOrEqual(usage.promptTokens);
+  });
+});

--- a/apps/api/src/lib/usage/run-estimate.ts
+++ b/apps/api/src/lib/usage/run-estimate.ts
@@ -55,8 +55,8 @@ export const estimateDocumentRunUnits = ({
   const outputTokens = plannedOutputs * OUTPUT_TOKENS_PER_PLANNED_ITEM;
   const rawMicroUnits = computeRawUsageMicroUnits({
     modelId,
-    inputTokens,
     outputTokens,
+    uncachedInputTokens: inputTokens,
   });
   const tokenUnits = Math.ceil(
     (rawMicroUnits * SERVICE_TIER_MULTIPLIERS[serviceTier]) /

--- a/apps/api/src/lib/usage/unit-model.test.ts
+++ b/apps/api/src/lib/usage/unit-model.test.ts
@@ -143,12 +143,7 @@ describe("computeRawUsageMicroUnits", () => {
   test("meters malformed token counts conservatively without throwing", () => {
     // Each malformed field must coerce (never throw), report the shape,
     // and leave the well-formed fields metered normally.
-    const invalidCounts = [
-      -1,
-      Number.NaN,
-      Number.POSITIVE_INFINITY,
-      Number.NEGATIVE_INFINITY,
-    ];
+    const invalidCounts = [-1, Number.NaN, Number.NEGATIVE_INFINITY];
     const fields = [
       "uncachedInputTokens",
       "outputTokens",
@@ -176,6 +171,19 @@ describe("computeRawUsageMicroUnits", () => {
       }
     }
     expect(captureErrorMock).toHaveBeenCalled();
+
+    // +Infinity is an oversized positive count, not an absent one: it must
+    // clamp to the ceiling (over-metering), never coerce to zero.
+    for (const field of fields) {
+      const units = computeRawUsageMicroUnits({
+        modelId: "gemini-2.5-flash",
+        uncachedInputTokens: 100,
+        outputTokens: 100,
+        cacheReadTokens: 0,
+        [field]: Number.POSITIVE_INFINITY,
+      });
+      expect(units).toBeGreaterThan(baseline);
+    }
   });
 
   test("rounds fractional token counts up", () => {
@@ -293,9 +301,12 @@ describe("normalizeProviderPromptTokens", () => {
       cacheWriteTokens: 0,
     });
 
+    // Shape disagreement falls back to separate accounting: full prompt at
+    // the input rate AND the reported cache reads at the cache rate, so the
+    // larger reported amount is never discarded (conservative direction).
     expect(normalized).toEqual({
       uncachedInputTokens: 1024,
-      cacheReadTokens: 0,
+      cacheReadTokens: 2048,
     });
     expect(captureErrorMock).toHaveBeenCalledWith(
       expect.any(Error),

--- a/apps/api/src/lib/usage/unit-model.test.ts
+++ b/apps/api/src/lib/usage/unit-model.test.ts
@@ -11,6 +11,7 @@ void mock.module("@/api/lib/analytics/capture", () => ({
 
 const {
   computeRawUsageMicroUnits,
+  normalizeProviderPromptTokens,
   usageUnitsFromTokens,
   MICRO_UNITS_PER_USAGE_UNIT,
 } = await import("@/api/lib/usage/unit-model");
@@ -30,12 +31,12 @@ describe("computeRawUsageMicroUnits", () => {
   test("scales linearly in input + output tokens", () => {
     const small = computeRawUsageMicroUnits({
       modelId: "gemini-2.5-flash",
-      inputTokens: 1000,
+      uncachedInputTokens: 1000,
       outputTokens: 1000,
     });
     const large = computeRawUsageMicroUnits({
       modelId: "gemini-2.5-flash",
-      inputTokens: 100_000,
+      uncachedInputTokens: 100_000,
       outputTokens: 100_000,
     });
     expect(large).toBeGreaterThan(small);
@@ -46,12 +47,12 @@ describe("computeRawUsageMicroUnits", () => {
   test("cached input tokens use the adjusted rate", () => {
     const noCache = computeRawUsageMicroUnits({
       modelId: "gemini-2.5-flash",
-      inputTokens: 100_000,
+      uncachedInputTokens: 100_000,
       outputTokens: 0,
     });
     const withCache = computeRawUsageMicroUnits({
       modelId: "gemini-2.5-flash",
-      inputTokens: 100_000,
+      uncachedInputTokens: 10_000,
       outputTokens: 0,
       cacheReadTokens: 90_000,
     });
@@ -66,12 +67,12 @@ describe("computeRawUsageMicroUnits", () => {
     test(`${modelId} switches the entire request above 272K input tokens`, () => {
       const atThreshold = computeRawUsageMicroUnits({
         modelId,
-        inputTokens: 272_000,
+        uncachedInputTokens: 272_000,
         outputTokens: 1000,
       });
       const aboveThreshold = computeRawUsageMicroUnits({
         modelId,
-        inputTokens: 272_001,
+        uncachedInputTokens: 272_001,
         outputTokens: 1000,
       });
 
@@ -84,24 +85,26 @@ describe("computeRawUsageMicroUnits", () => {
     expect(
       computeRawUsageMicroUnits({
         modelId: "gemini-3.1-pro-preview",
-        inputTokens: 200_000,
+        uncachedInputTokens: 200_000,
         outputTokens: 1000,
       }),
     ).toBe(41_200);
     expect(
       computeRawUsageMicroUnits({
         modelId: "gemini-3.1-pro-preview",
-        inputTokens: 200_001,
+        uncachedInputTokens: 200_001,
         outputTokens: 1000,
       }),
     ).toBe(81_801);
   });
 
   test("GPT-5.6 applies its long-context multiplier to cached input", () => {
+    // Tier resolution counts cached prompt tokens too: 300K cached reads
+    // alone push the request over the 272K threshold.
     expect(
       computeRawUsageMicroUnits({
         modelId: "gpt-5.6",
-        inputTokens: 300_000,
+        uncachedInputTokens: 0,
         outputTokens: 0,
         cacheReadTokens: 300_000,
       }),
@@ -110,7 +113,7 @@ describe("computeRawUsageMicroUnits", () => {
 
   test("GPT-5.6 Sol canonical ID shares the alias rate schedule", () => {
     const usage = {
-      inputTokens: 300_000,
+      uncachedInputTokens: 300_000,
       outputTokens: 10_000,
     };
     expect(
@@ -121,7 +124,7 @@ describe("computeRawUsageMicroUnits", () => {
   test("unknown models use the conservative fallback rate", () => {
     const units = computeRawUsageMicroUnits({
       modelId: "unknown-model-name",
-      inputTokens: 10_000,
+      uncachedInputTokens: 10_000,
       outputTokens: 10_000,
     });
     expect(units).toBeGreaterThan(0);
@@ -131,67 +134,209 @@ describe("computeRawUsageMicroUnits", () => {
     expect(
       computeRawUsageMicroUnits({
         modelId: "gemini-2.5-flash",
-        inputTokens: 0,
+        uncachedInputTokens: 0,
         outputTokens: 0,
       }),
     ).toBe(0);
   });
 
-  test("panics on inconsistent token counts (cache > input)", () => {
-    expect(() =>
-      computeRawUsageMicroUnits({
-        modelId: "gemini-2.5-flash",
-        inputTokens: 100,
-        outputTokens: 0,
-        cacheReadTokens: 200,
-      }),
-    ).toThrow("cached input tokens cannot exceed total input tokens");
-  });
-
-  test("rejects every token field outside the non-negative safe-integer domain", () => {
+  test("meters malformed token counts conservatively without throwing", () => {
+    // Each malformed field must coerce (never throw), report the shape,
+    // and leave the well-formed fields metered normally.
     const invalidCounts = [
       -1,
-      0.5,
       Number.NaN,
       Number.POSITIVE_INFINITY,
       Number.NEGATIVE_INFINITY,
-      Number.MAX_SAFE_INTEGER + 1,
     ];
-    const fields = ["inputTokens", "outputTokens", "cacheReadTokens"] as const;
+    const fields = [
+      "uncachedInputTokens",
+      "outputTokens",
+      "cacheReadTokens",
+    ] as const;
+    const baseline = computeRawUsageMicroUnits({
+      modelId: "gemini-2.5-flash",
+      uncachedInputTokens: 100,
+      outputTokens: 100,
+      cacheReadTokens: 0,
+    });
 
     for (const field of fields) {
       for (const invalidCount of invalidCounts) {
-        expect(() =>
-          computeRawUsageMicroUnits({
-            modelId: "gemini-2.5-flash",
-            inputTokens: 100,
-            outputTokens: 100,
-            cacheReadTokens: 0,
-            [field]: invalidCount,
-          }),
-        ).toThrow("usage token counts must be non-negative safe integers");
+        const units = computeRawUsageMicroUnits({
+          modelId: "gemini-2.5-flash",
+          uncachedInputTokens: 100,
+          outputTokens: 100,
+          cacheReadTokens: 0,
+          [field]: invalidCount,
+        });
+        // The malformed field meters as 0; the others stay billed.
+        expect(units).toBeGreaterThanOrEqual(0);
+        expect(units).toBeLessThanOrEqual(baseline);
       }
     }
+    expect(captureErrorMock).toHaveBeenCalled();
   });
 
-  test("rejects a computed amount outside the safe-integer domain", () => {
-    expect(() =>
+  test("rounds fractional token counts up", () => {
+    // Anomaly telemetry dedupes per model id, so this test uses a model
+    // the malformed-count test above did not touch.
+    expect(
       computeRawUsageMicroUnits({
-        modelId: "unknown-model-name",
-        inputTokens: 0,
-        outputTokens: Number.MAX_SAFE_INTEGER,
+        modelId: "gemini-2.5-pro",
+        uncachedInputTokens: 0.5,
+        outputTokens: 0,
       }),
-    ).toThrow("computed usage component exceeds the safe integer range");
+    ).toBe(
+      computeRawUsageMicroUnits({
+        modelId: "gemini-2.5-pro",
+        uncachedInputTokens: 1,
+        outputTokens: 0,
+      }),
+    );
+    expect(captureErrorMock).toHaveBeenCalled();
+  });
+
+  test("clamps absurdly large counts instead of overflowing", () => {
+    // 2^40 caps every component, so even MAX_SAFE_INTEGER tokens meter
+    // to a finite conservative amount with telemetry, never a crash.
+    const units = computeRawUsageMicroUnits({
+      modelId: "unknown-model-name",
+      uncachedInputTokens: 0,
+      outputTokens: Number.MAX_SAFE_INTEGER,
+    });
+    expect(Number.isSafeInteger(units)).toBe(true);
+    expect(units).toBe(2 ** 41);
+    expect(captureErrorMock).toHaveBeenCalled();
   });
 
   test("keeps rate scaling exact when the intermediate product is unsafe", () => {
+    // (2^40 - 2) * 500_000 exceeds 2^53, so float math would round;
+    // the bigint path must stay exact.
     expect(
       computeRawUsageMicroUnits({
         modelId: "unknown-model-name",
-        inputTokens: 9_007_199_254_740_938,
+        uncachedInputTokens: 2 ** 40 - 2,
         outputTokens: 0,
       }),
-    ).toBe(4_503_599_627_370_469);
+    ).toBe(2 ** 39 - 1);
+  });
+});
+
+describe("normalizeProviderPromptTokens", () => {
+  test("Anthropic warm cache: cache reads exceed input tokens legitimately", () => {
+    // Production-shaped Anthropic usage on a warm cache: `input_tokens`
+    // excludes cache reads and cache writes, so cached >> input.
+    const normalized = normalizeProviderPromptTokens({
+      provider: "anthropic",
+      modelId: "claude-sonnet-5",
+      promptTokens: 217,
+      cacheReadTokens: 45_082,
+      cacheWriteTokens: 1204,
+    });
+
+    expect(normalized).toEqual({
+      // Cache writes are billable prompt tokens outside `input_tokens`.
+      uncachedInputTokens: 217 + 1204,
+      cacheReadTokens: 45_082,
+    });
+    expect(captureErrorMock).not.toHaveBeenCalled();
+
+    // End to end: 1421 uncached at 200_000/MTok (285) + 45_082 cached at
+    // 20_000/MTok (902) + 1538 output at 1_000_000/MTok (1538).
+    expect(
+      computeRawUsageMicroUnits({
+        modelId: "claude-sonnet-5",
+        outputTokens: 1538,
+        ...normalized,
+      }),
+    ).toBe(285 + 902 + 1538);
+  });
+
+  test("OpenAI subset semantics: cached tokens split out of the prompt total", () => {
+    // Production-shaped OpenAI usage: `prompt_tokens` includes
+    // `prompt_tokens_details.cached_tokens` (1024-boundary multiples).
+    const normalized = normalizeProviderPromptTokens({
+      provider: "openai",
+      modelId: "gpt-5.6",
+      promptTokens: 32_512,
+      cacheReadTokens: 31_744,
+      cacheWriteTokens: 0,
+    });
+
+    expect(normalized).toEqual({
+      uncachedInputTokens: 768,
+      cacheReadTokens: 31_744,
+    });
+    expect(captureErrorMock).not.toHaveBeenCalled();
+
+    // 768 uncached at 500_000/MTok (384) + 31_744 cached at 50_000/MTok
+    // (1588) + 2048 output at 3_000_000/MTok (6144).
+    expect(
+      computeRawUsageMicroUnits({
+        modelId: "gpt-5.6",
+        outputTokens: 2048,
+        ...normalized,
+      }),
+    ).toBe(384 + 1588 + 6144);
+  });
+
+  test("subset-semantics disagreement meters the full prompt and reports", () => {
+    // An included-in-input provider claiming more cached than prompt
+    // tokens is a shape disagreement: bill everything at the input rate,
+    // never throw.
+    const normalized = normalizeProviderPromptTokens({
+      provider: "openai",
+      modelId: "gpt-5.6-shape-disagreement",
+      promptTokens: 1024,
+      cacheReadTokens: 2048,
+      cacheWriteTokens: 0,
+    });
+
+    expect(normalized).toEqual({
+      uncachedInputTokens: 1024,
+      cacheReadTokens: 0,
+    });
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        anomaly: "cache-read-exceeds-included-prompt",
+        source: "usage-unit-model",
+      }),
+    );
+  });
+
+  test("malformed provider counts coerce conservatively and report", () => {
+    const normalized = normalizeProviderPromptTokens({
+      provider: "anthropic",
+      modelId: "claude-sonnet-5-malformed-shape",
+      promptTokens: Number.NaN,
+      cacheReadTokens: -512,
+      cacheWriteTokens: 96.4,
+    });
+
+    // NaN and negative meter as 0; fractional rounds up.
+    expect(normalized).toEqual({
+      uncachedInputTokens: 97,
+      cacheReadTokens: 0,
+    });
+    expect(captureErrorMock).toHaveBeenCalled();
+  });
+
+  test("anomaly telemetry dedupes per model id and anomaly", () => {
+    const modelId = "claude-sonnet-5-anomaly-dedupe";
+    const usage = {
+      provider: "anthropic",
+      modelId,
+      promptTokens: -1,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    } as const;
+
+    normalizeProviderPromptTokens(usage);
+    normalizeProviderPromptTokens(usage);
+
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -199,7 +344,7 @@ describe("usageUnitsFromTokens", () => {
   test("BYOK actions consume zero units but still report raw attribution", () => {
     const result = usageUnitsFromTokens({
       modelId: "gemini-2.5-flash",
-      inputTokens: 10_000,
+      uncachedInputTokens: 10_000,
       outputTokens: 10_000,
       actionType: "chat",
       serviceTier: "standard",
@@ -212,7 +357,7 @@ describe("usageUnitsFromTokens", () => {
   test("trivial calls floor at the action weight", () => {
     const result = usageUnitsFromTokens({
       modelId: "gemini-2.5-flash",
-      inputTokens: 10,
+      uncachedInputTokens: 10,
       outputTokens: 10,
       actionType: "case_law",
       serviceTier: "flex",
@@ -226,7 +371,7 @@ describe("usageUnitsFromTokens", () => {
   test("large calls consume more than the action floor", () => {
     const result = usageUnitsFromTokens({
       modelId: "gemini-2.5-pro",
-      inputTokens: 500_000,
+      uncachedInputTokens: 500_000,
       outputTokens: 50_000,
       actionType: "chat",
       serviceTier: "standard",
@@ -240,7 +385,7 @@ describe("usageUnitsFromTokens", () => {
   test("standard tier consumes more than flex tier for identical usage", () => {
     const usage = {
       modelId: "gemini-2.5-pro",
-      inputTokens: 100_000,
+      uncachedInputTokens: 100_000,
       outputTokens: 10_000,
       actionType: "doc_review" as const,
       isByok: false,
@@ -256,7 +401,7 @@ describe("usageUnitsFromTokens", () => {
   test("units derive from raw micro-units via the documented denomination", () => {
     const result = usageUnitsFromTokens({
       modelId: "gemini-2.5-pro",
-      inputTokens: 100_000,
+      uncachedInputTokens: 100_000,
       outputTokens: 10_000,
       actionType: "chat",
       serviceTier: "flex",
@@ -275,8 +420,16 @@ describe("catalog-miss telemetry", () => {
   test("reports a telemetry error once per unknown model id", () => {
     const modelId = "unit-model-test-unknown-model-once";
 
-    computeRawUsageMicroUnits({ modelId, inputTokens: 100, outputTokens: 100 });
-    computeRawUsageMicroUnits({ modelId, inputTokens: 200, outputTokens: 200 });
+    computeRawUsageMicroUnits({
+      modelId,
+      outputTokens: 100,
+      uncachedInputTokens: 100,
+    });
+    computeRawUsageMicroUnits({
+      modelId,
+      outputTokens: 200,
+      uncachedInputTokens: 200,
+    });
 
     // Deduped per process by model id: the second miss for the same id
     // must not capture again.
@@ -290,7 +443,7 @@ describe("catalog-miss telemetry", () => {
   test("does not report telemetry for a model already in the rate catalog", () => {
     computeRawUsageMicroUnits({
       modelId: "gemini-2.5-flash",
-      inputTokens: 100,
+      uncachedInputTokens: 100,
       outputTokens: 100,
     });
 

--- a/apps/api/src/lib/usage/unit-model.ts
+++ b/apps/api/src/lib/usage/unit-model.ts
@@ -139,9 +139,11 @@ const sanitizeTokenCount = ({
     anomaly: `invalid-${field}`,
     context: { value: String(value) },
   });
-  if (!Number.isFinite(value) || value <= 0) {
+  if (Number.isNaN(value) || value <= 0) {
     return 0;
   }
+  // Oversized positive values (finite or +Infinity) clamp to the ceiling
+  // rather than zeroing: a too-large count must never under-meter.
   return Math.min(Math.ceil(value), MAX_TOKEN_COUNT);
 };
 
@@ -241,8 +243,11 @@ export const normalizeProviderPromptTokens = ({
       if (cacheRead > prompt) {
         // Under subset semantics the cached count can never exceed the
         // prompt count: a shape disagreement with the provider, not an
-        // internal invariant. Bill the full prompt at the input rate
-        // (never under-meters) and record the raw shape.
+        // internal invariant. Fall back to separate accounting — bill the
+        // full prompt at the input rate AND the reported cache reads at
+        // the cache rate. That over-meters relative to either consistent
+        // reading, which is the conservative direction; discarding the
+        // larger cache-read count would under-meter.
         reportUsageShapeAnomaly({
           modelId,
           anomaly: "cache-read-exceeds-included-prompt",
@@ -252,7 +257,7 @@ export const normalizeProviderPromptTokens = ({
             cacheReadTokens: String(cacheRead),
           },
         });
-        return { uncachedInputTokens: prompt, cacheReadTokens: 0 };
+        return { uncachedInputTokens: prompt, cacheReadTokens: cacheRead };
       }
       return {
         uncachedInputTokens: prompt - cacheRead,

--- a/apps/api/src/lib/usage/unit-model.ts
+++ b/apps/api/src/lib/usage/unit-model.ts
@@ -11,7 +11,7 @@
 import { panic } from "better-result";
 
 import { getModelRate, resolveModelRate } from "@stll/ai-catalog";
-import type { ModelRate } from "@stll/ai-catalog";
+import type { AIProvider, ModelRate } from "@stll/ai-catalog";
 
 import type { UsageActionType, UsageServiceTier } from "@/api/db/schema";
 import { captureError } from "@/api/lib/analytics/capture";
@@ -77,6 +77,74 @@ const getModelRateOrFallback = (modelId: string): ModelRate => {
 const isNonNegativeSafeInteger = (value: number): boolean =>
   Number.isSafeInteger(value) && value >= 0;
 
+/**
+ * Highest token count the meter accepts per component: far above any real
+ * context window, and low enough that every downstream product with a
+ * catalog rate stays inside the safe-integer range.
+ */
+const MAX_TOKEN_COUNT = 2 ** 40;
+
+// Usage shape anomalies already reported this process, keyed by model id
+// and anomaly, so a systematically malformed provider response cannot spam
+// telemetry on the hot metering path.
+const reportedUsageShapeAnomalies = new Set<string>();
+
+type UsageShapeAnomalyOptions = {
+  modelId: string;
+  anomaly: string;
+  context: Record<string, string>;
+};
+
+const reportUsageShapeAnomaly = ({
+  modelId,
+  anomaly,
+  context,
+}: UsageShapeAnomalyOptions): void => {
+  const key = `${modelId}:${anomaly}`;
+  if (reportedUsageShapeAnomalies.has(key)) {
+    return;
+  }
+  reportedUsageShapeAnomalies.add(key);
+  captureError(
+    new TelemetryError({
+      message: `Provider usage shape anomaly (${anomaly}); metering fell back to a conservative value`,
+    }),
+    { source: "usage-unit-model", modelId, anomaly, ...context },
+  );
+};
+
+type SanitizeTokenCountOptions = {
+  modelId: string;
+  field: string;
+  value: number;
+};
+
+/**
+ * Provider-reported token counts are external input, so a malformed count
+ * is an expected runtime failure, never a process-fatal invariant. Coerce
+ * out-of-domain values to the nearest conservative in-domain value and
+ * report the raw shape: non-finite and negative counts meter as 0,
+ * fractional counts round up, oversized counts clamp to `MAX_TOKEN_COUNT`.
+ */
+const sanitizeTokenCount = ({
+  modelId,
+  field,
+  value,
+}: SanitizeTokenCountOptions): number => {
+  if (isNonNegativeSafeInteger(value) && value <= MAX_TOKEN_COUNT) {
+    return value;
+  }
+  reportUsageShapeAnomaly({
+    modelId,
+    anomaly: `invalid-${field}`,
+    context: { value: String(value) },
+  });
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.min(Math.ceil(value), MAX_TOKEN_COUNT);
+};
+
 const scaleTokenCost = (tokens: number, ratePerMTok: number): number => {
   if (!isNonNegativeSafeInteger(ratePerMTok)) {
     panic("usage rates must be non-negative safe integers");
@@ -90,46 +158,171 @@ const scaleTokenCost = (tokens: number, ratePerMTok: number): number => {
   return Number(scaled);
 };
 
+type CacheReadAccounting = "included-in-input" | "separate-from-input";
+
+/**
+ * How each provider's reported input/prompt token count relates to its
+ * cache-read count. OpenAI-style usage reports cached tokens as a subset
+ * of the prompt count (`prompt_tokens_details.cached_tokens` within
+ * `prompt_tokens`); Gemini's `promptTokenCount` likewise includes
+ * `cachedContentTokenCount`. Anthropic-style usage reports `input_tokens`
+ * EXCLUDING `cache_read_input_tokens` and `cache_creation_input_tokens`,
+ * so on a warm cache the cached count legitimately exceeds the input
+ * count; Bedrock's Converse usage follows the same split.
+ */
+const PROVIDER_CACHE_READ_ACCOUNTING = {
+  anthropic: "separate-from-input",
+  azure_foundry: "included-in-input",
+  bedrock: "separate-from-input",
+  google: "included-in-input",
+  huggingface: "included-in-input",
+  mistral: "included-in-input",
+  openai: "included-in-input",
+  openai_compatible: "included-in-input",
+  openrouter: "included-in-input",
+} as const satisfies Record<AIProvider, CacheReadAccounting>;
+
+type NormalizeProviderPromptTokensOptions = {
+  provider: AIProvider;
+  modelId: string;
+  /** The provider's own input/prompt token count, in its native semantics. */
+  promptTokens: number;
+  /** The provider's cache-read count, in its native semantics. */
+  cacheReadTokens: number;
+  /** Cache-write (cache creation) count for providers that report one. */
+  cacheWriteTokens: number;
+};
+
+type NormalizedPromptTokens = {
+  uncachedInputTokens: number;
+  cacheReadTokens: number;
+};
+
+/**
+ * Normalize a provider's native prompt-token accounting into the
+ * non-overlapping components the unit model bills: uncached input at the
+ * full input rate, cache reads at the cache-read rate. This is the only
+ * place provider cache semantics may be interpreted; downstream code
+ * never subtracts one provider-reported count from another.
+ */
+export const normalizeProviderPromptTokens = ({
+  provider,
+  modelId,
+  promptTokens,
+  cacheReadTokens,
+  cacheWriteTokens,
+}: NormalizeProviderPromptTokensOptions): NormalizedPromptTokens => {
+  const prompt = sanitizeTokenCount({
+    modelId,
+    field: "promptTokens",
+    value: promptTokens,
+  });
+  const cacheRead = sanitizeTokenCount({
+    modelId,
+    field: "cacheReadTokens",
+    value: cacheReadTokens,
+  });
+  const cacheWrite = sanitizeTokenCount({
+    modelId,
+    field: "cacheWriteTokens",
+    value: cacheWriteTokens,
+  });
+  const accounting = PROVIDER_CACHE_READ_ACCOUNTING[provider];
+  switch (accounting) {
+    case "separate-from-input":
+      // Cache writes are billable prompt tokens the provider excludes
+      // from its input count. The rate table carries no write-premium
+      // rate, so they meter at the full input rate.
+      return {
+        uncachedInputTokens: prompt + cacheWrite,
+        cacheReadTokens: cacheRead,
+      };
+    case "included-in-input": {
+      if (cacheRead > prompt) {
+        // Under subset semantics the cached count can never exceed the
+        // prompt count: a shape disagreement with the provider, not an
+        // internal invariant. Bill the full prompt at the input rate
+        // (never under-meters) and record the raw shape.
+        reportUsageShapeAnomaly({
+          modelId,
+          anomaly: "cache-read-exceeds-included-prompt",
+          context: {
+            provider,
+            promptTokens: String(prompt),
+            cacheReadTokens: String(cacheRead),
+          },
+        });
+        return { uncachedInputTokens: prompt, cacheReadTokens: 0 };
+      }
+      return {
+        uncachedInputTokens: prompt - cacheRead,
+        cacheReadTokens: cacheRead,
+      };
+    }
+    default: {
+      const _exhaustive: never = accounting;
+      return _exhaustive;
+    }
+  }
+};
+
 type UsageInput = {
   modelId: string;
-  inputTokens: number;
+  /**
+   * Input tokens billed at the full input rate. Excludes cache reads:
+   * provider usage must pass through `normalizeProviderPromptTokens`
+   * first, never a raw provider prompt total.
+   */
+  uncachedInputTokens: number;
   outputTokens: number;
   /**
-   * Tokens that were served from the provider's prompt cache.
-   * Where the model offers a cache adjustment we count these at
-   * `cachedInputPerMTok`; otherwise they're treated as normal
-   * input tokens. Defaults to 0.
+   * Tokens that were served from the provider's prompt cache, disjoint
+   * from `uncachedInputTokens`. Where the model offers a cache adjustment
+   * we count these at `cachedInputPerMTok`; otherwise they're treated as
+   * normal input tokens. Defaults to 0.
    */
   cacheReadTokens?: number;
 };
 
 /**
  * Convert token usage into normalized micro-units using the
- * model's public rate table. Provider token counts are validated here because
- * this helper is the shared boundary before usage reaches the ledger.
+ * model's public rate table. Provider token counts are sanitized here
+ * because this helper is the shared boundary before usage reaches the
+ * ledger; a malformed count meters conservatively and reports telemetry
+ * instead of failing.
  */
 export const computeRawUsageMicroUnits = ({
   modelId,
-  inputTokens,
+  uncachedInputTokens,
   outputTokens,
   cacheReadTokens = 0,
 }: UsageInput): number => {
-  if (
-    !isNonNegativeSafeInteger(inputTokens) ||
-    !isNonNegativeSafeInteger(outputTokens) ||
-    !isNonNegativeSafeInteger(cacheReadTokens)
-  ) {
-    panic("usage token counts must be non-negative safe integers");
-  }
-  if (cacheReadTokens > inputTokens) {
-    panic("cached input tokens cannot exceed total input tokens");
-  }
-  const rate = resolveModelRate(getModelRateOrFallback(modelId), inputTokens);
-  const billedInputTokens = inputTokens - cacheReadTokens;
+  const uncachedInput = sanitizeTokenCount({
+    modelId,
+    field: "uncachedInputTokens",
+    value: uncachedInputTokens,
+  });
+  const output = sanitizeTokenCount({
+    modelId,
+    field: "outputTokens",
+    value: outputTokens,
+  });
+  const cacheRead = sanitizeTokenCount({
+    modelId,
+    field: "cacheReadTokens",
+    value: cacheReadTokens,
+  });
+  // Long-context rate tiers key on what the model actually read, so tier
+  // resolution counts cached prompt tokens too.
+  const totalInputTokens = uncachedInput + cacheRead;
+  const rate = resolveModelRate(
+    getModelRateOrFallback(modelId),
+    totalInputTokens,
+  );
   const cachedRate = rate.cachedInputPerMTok ?? rate.inputPerMTok;
-  const inputCost = scaleTokenCost(billedInputTokens, rate.inputPerMTok);
-  const cacheCost = scaleTokenCost(cacheReadTokens, cachedRate);
-  const outputCost = scaleTokenCost(outputTokens, rate.outputPerMTok);
+  const inputCost = scaleTokenCost(uncachedInput, rate.inputPerMTok);
+  const cacheCost = scaleTokenCost(cacheRead, cachedRate);
+  const outputCost = scaleTokenCost(output, rate.outputPerMTok);
   const rawUsageMicroUnits = inputCost + cacheCost + outputCost;
   if (!Number.isSafeInteger(rawUsageMicroUnits)) {
     panic("computed raw usage exceeds the safe integer range");
@@ -159,7 +352,7 @@ type UsageUnitsFromTokensResult = {
  */
 export const usageUnitsFromTokens = ({
   modelId,
-  inputTokens,
+  uncachedInputTokens,
   outputTokens,
   cacheReadTokens = 0,
   actionType,
@@ -168,7 +361,7 @@ export const usageUnitsFromTokens = ({
 }: UsageUnitsFromTokensInput): UsageUnitsFromTokensResult => {
   const rawUsageMicroUnits = computeRawUsageMicroUnits({
     modelId,
-    inputTokens,
+    uncachedInputTokens,
     outputTokens,
     cacheReadTokens,
   });


### PR DESCRIPTION
## Problem

`computeRawUsageMicroUnits` assumed OpenAI-style cache accounting: the prompt
count includes cached reads as a subset, so it derived billable input as
`inputTokens - cacheReadTokens` and asserted `cacheReadTokens <= inputTokens`
with a `panic()`.

Anthropic-style usage has the opposite semantics: `input_tokens` EXCLUDES
`cache_read_input_tokens` and `cache_creation_input_tokens`, and the TanStack
Anthropic adapter passes those counts through unchanged
(`promptTokens = input_tokens`, `promptTokensDetails.cachedTokens =
cache_read_input_tokens`). On a warm cache the cached count legitimately
exceeds the prompt count, so the invariant tripped, and because it tripped
inside the streaming `onUsage` callback the panic propagated through the
stream lifecycle. Bedrock's Converse usage follows the same split. Anthropic
`cache_creation_input_tokens` were also dropped entirely (never metered), and
long-context tier resolution undercounted input for separate-accounting
providers.

## Fix

- **Normalize provider cache semantics at the adapter boundary.**
  `normalizeProviderPromptTokens` (new, in `unit-model.ts`) maps each
  provider's native accounting onto non-overlapping components: uncached
  input billed at the input rate, cache reads billed at the cache-read rate.
  A total `Record<AIProvider, CacheReadAccounting>` companion map declares
  the semantics per provider (`anthropic`/`bedrock` separate-from-input,
  the rest included-in-input), so a new provider cannot land without a
  decision. Cache-write tokens now meter at the input rate for
  separate-accounting providers (the rate table carries no write-premium
  rate). Tier resolution uses uncached + cached, so long-context premiums
  count cached prompt tokens too.
- **The unit model takes disjoint components.** `computeRawUsageMicroUnits`
  now accepts `uncachedInputTokens` + `cacheReadTokens` and never subtracts
  one provider-reported count from another; the crashing cross-field
  invariant no longer exists to violate.
- **Usage-shape problems are expected runtime failures, not panics.**
  Malformed counts (negative, NaN, infinite, fractional, absurdly large) are
  coerced to a conservative in-domain value and reported through
  `captureError` as a `TelemetryError` with the raw shape, deduplicated per
  model id and anomaly. A subset-semantics disagreement (cached > prompt on
  an included-in-input provider) bills the full prompt at the input rate and
  reports.
- **Streaming-callback boundary.** The `onUsage` middleware hook now wraps
  its body in a framework-hook try/catch and attaches a `.catch` to the
  deferred consumption promise: any future metering fault loses one metering
  event (and reports it), never the stream or the process.

## Tests

- Anthropic warm cache with cached reads far exceeding input tokens
  (production-shaped counts), asserting exact micro-unit billing end to end
  through the `onUsage` hook, including cache-write metering.
- OpenAI subset shape asserting the cached split and exact billing.
- Malformed shapes (negative, NaN, infinite, fractional, oversized) proving
  no-throw, conservative metering, and captured telemetry, plus anomaly
  dedupe.
- A poisoned usage payload (throwing getter) proving the hook boundary
  swallows and reports instead of propagating.
- Mutation check: the exact-value assertions fail against the previous
  subtraction-based computation, and the warm-cache fixture is the shape the
  removed invariant rejected.
