### PR TITLE
fix(web): guard chat editor updates against no-op and programmatic transactions

### DIFF
--- a/.oxlint-plugins/README.md
+++ b/.oxlint-plugins/README.md
@@ -101,6 +101,7 @@ runtime validation, or integration tests.
 - [`require-query-key-factory`](./require-query-key-factory.ts) (`require-query-key-factory`): requires query keys to come from their feature-owned factory.
 - [`require-query-signal`](./require-query-signal.ts) (`require-query-signal`): requires query functions to pass TanStack Query's abort signal into fetch or Eden calls.
 - [`require-router-select`](./require-router-select.ts) (`require-router-select`): requires route subscriptions to select only the state a component consumes.
+- [`require-stable-editor-options`](./require-stable-editor-options.ts) (`require-stable-editor-options`): requires identity-stable non-handler option values in `useEditor` calls, so the react binding never re-applies editor view props on every render.
 - [`require-stable-snapshot`](./require-stable-snapshot.ts) (`require-stable-snapshot`): rejects `useSyncExternalStore` snapshots that allocate a new reference on every read.
 - [`require-use-shallow`](./require-use-shallow.ts) (`require-use-shallow`): requires shallow comparison when Zustand selectors return fresh objects or arrays.
 

--- a/.oxlint-plugins/__fixtures__/require-stable-editor-options.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/require-stable-editor-options.fixture.tsx
@@ -11,17 +11,22 @@ import { useMemo, useState } from "react";
 
 import { useEditor } from "@tiptap/react";
 
-declare const stableExtensions: unknown[];
 declare const buildDoc: (value: string) => unknown;
 
+// Module-level fresh literal: evaluated once, stable by definition — the
+// local-binding resolution must stop at function scopes and never flag it.
+const moduleExtensions: unknown[] = [];
+
 export const FlaggedFixture = ({ value }: { value: string }) => {
+  // Local binding to a fresh literal in the same function body.
+  const localProps = { attributes: { class: "y" } };
   const editor = useEditor({
     // Fresh array literal every render — MUST flag.
     // oxlint-disable-next-line require-stable-editor-options/require-stable-editor-options
     extensions: [],
-    // Fresh object literal every render — MUST flag.
+    // Identifier resolving to a same-function fresh literal — MUST flag.
     // oxlint-disable-next-line require-stable-editor-options/require-stable-editor-options
-    editorProps: { attributes: { class: "x" } },
+    editorProps: localProps,
     // Fresh call result every render — MUST flag.
     // oxlint-disable-next-line require-stable-editor-options/require-stable-editor-options
     content: buildDoc(value),
@@ -34,14 +39,25 @@ export const FlaggedFixture = ({ value }: { value: string }) => {
   return editor;
 };
 
+export const FlaggedInlineObjectFixture = () => {
+  const editor = useEditor({
+    // Fresh object literal every render — MUST flag.
+    // oxlint-disable-next-line require-stable-editor-options/require-stable-editor-options
+    editorProps: { attributes: { class: "x" } },
+  });
+  return editor;
+};
+
 export const SafeFixture = ({ value }: { value: string }) => {
+  // Hook-captured bindings (destructured useState, useMemo result) and the
+  // module constant above must NOT flag.
   const [content] = useState(() => buildDoc(value));
   const editorProps = useMemo(() => ({}), []);
   const editor = useEditor({
     autofocus: false,
     content,
     editorProps,
-    extensions: stableExtensions,
+    extensions: moduleExtensions,
     onCreate: () => undefined,
     onUpdate: () => undefined,
   });

--- a/.oxlint-plugins/__fixtures__/require-stable-editor-options.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/require-stable-editor-options.fixture.tsx
@@ -1,0 +1,49 @@
+// Passive regression fixture for
+// `require-stable-editor-options/require-stable-editor-options`.
+//
+// Each `oxlint-disable-next-line` below suppresses an option the rule MUST
+// flag. If the rule regresses, the matching disable becomes unused and
+// `--report-unused-disable-directives-severity=error` fails CI. The safe
+// call at the end carries no disable, so the rule over-firing on it also
+// fails CI.
+
+import { useMemo, useState } from "react";
+
+import { useEditor } from "@tiptap/react";
+
+declare const stableExtensions: unknown[];
+declare const buildDoc: (value: string) => unknown;
+
+export const FlaggedFixture = ({ value }: { value: string }) => {
+  const editor = useEditor({
+    // Fresh array literal every render — MUST flag.
+    // oxlint-disable-next-line require-stable-editor-options/require-stable-editor-options
+    extensions: [],
+    // Fresh object literal every render — MUST flag.
+    // oxlint-disable-next-line require-stable-editor-options/require-stable-editor-options
+    editorProps: { attributes: { class: "x" } },
+    // Fresh call result every render — MUST flag.
+    // oxlint-disable-next-line require-stable-editor-options/require-stable-editor-options
+    content: buildDoc(value),
+    // Conditional with a fresh branch — MUST flag.
+    // oxlint-disable-next-line require-stable-editor-options/require-stable-editor-options
+    autofocus: value ? { start: true } : false,
+    // Handler keys are excluded from the identity comparison — must NOT flag.
+    onUpdate: () => undefined,
+  });
+  return editor;
+};
+
+export const SafeFixture = ({ value }: { value: string }) => {
+  const [content] = useState(() => buildDoc(value));
+  const editorProps = useMemo(() => ({}), []);
+  const editor = useEditor({
+    autofocus: false,
+    content,
+    editorProps,
+    extensions: stableExtensions,
+    onCreate: () => undefined,
+    onUpdate: () => undefined,
+  });
+  return editor;
+};

--- a/.oxlint-plugins/__fixtures__/require-stable-editor-options.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/require-stable-editor-options.fixture.tsx
@@ -63,3 +63,12 @@ export const SafeFixture = ({ value }: { value: string }) => {
   });
   return editor;
 };
+
+export const SafeAssertedHookFixture = () => {
+  // A type-asserted hook result is still hook-captured — must NOT flag.
+  const assertedProps = useMemo(() => ({}), []) as Record<string, unknown>;
+  const editor = useEditor({
+    editorProps: assertedProps,
+  });
+  return editor;
+};

--- a/.oxlint-plugins/require-stable-editor-options.ts
+++ b/.oxlint-plugins/require-stable-editor-options.ts
@@ -169,7 +169,9 @@ const isUnstableOptionValue = (node, fromNode) => {
     return false;
   }
   const init = resolveLocalBindingInit(unwrapped.name, fromNode);
-  if (init === null || isHookCall(init)) {
+  // Unwrap before classifying so `useMemo(...) as T` / `satisfies T`
+  // initializers still count as hook-captured rather than fresh calls.
+  if (init === null || isHookCall(unwrapExpression(init))) {
     return false;
   }
   return isFreshIdentity(init);

--- a/.oxlint-plugins/require-stable-editor-options.ts
+++ b/.oxlint-plugins/require-stable-editor-options.ts
@@ -1,0 +1,158 @@
+// Require identity-stable option values in `useEditor({...})` calls.
+//
+// `@tiptap/react`'s `useEditor` shallow-compares the options object against
+// the live editor's options on every render and re-applies them
+// (`editor.setOptions` -> `view.setProps` + `view.updateState`) whenever any
+// compared value has a new identity. An option rebuilt inline on each render
+// (an object/array literal, an inline function, a call result) therefore
+// re-applies editor view props on *every* render. When the surface also
+// re-renders per keystroke (a draft store, a controlled `onChange`), that
+// per-render view churn interleaves with ProseMirror's DOMObserver while
+// input mutations are pending: the observer flush re-parses the redrawn DOM
+// as a fresh doc-changing transaction, which re-renders again — a loop that
+// drops in-flight keystrokes and ends in React's "Maximum update depth
+// exceeded" crash.
+//
+// Event-handler options (`onUpdate`, `onCreate`, ...) are exempt: the react
+// binding excludes them from the comparison and always invokes the latest
+// render's callback, so inline closures there are safe and idiomatic.
+//
+// Safe patterns (not flagged):
+//   - `useEditor({ extensions, editorProps, content: initialContent })` —
+//     identifiers pointing at memoized/captured values.
+//   - `useEditor({ autofocus: false, immediatelyRender: false })` —
+//     primitives compare by value.
+//   - `useEditor({ onUpdate: (props) => ... })` — handlers are excluded from
+//     the identity comparison.
+//
+// Flagged patterns:
+//   - `useEditor({ extensions: [...] })` — fresh array every render.
+//   - `useEditor({ editorProps: { ... } })` — fresh object every render.
+//   - `useEditor({ content: toDoc(value) })` — fresh call result every
+//     render; capture it once (`useState(() => toDoc(value))`) instead.
+
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { getImportedName, isIdentifier, unwrapExpression } from "./utils.ts";
+
+const TIPTAP_REACT_MODULE = "@tiptap/react";
+
+// Mirrors the handler exclusions in `@tiptap/react`'s
+// `EditorInstanceManager.compareOptions`.
+const HANDLER_OPTION_KEYS = new Set([
+  "onBeforeCreate",
+  "onBlur",
+  "onContentError",
+  "onCreate",
+  "onDestroy",
+  "onDrop",
+  "onFocus",
+  "onPaste",
+  "onSelectionUpdate",
+  "onTransaction",
+  "onUpdate",
+]);
+
+const isFreshIdentity = (node) => {
+  const unwrapped = unwrapExpression(node);
+  switch (unwrapped?.type) {
+    case "ObjectExpression":
+    case "ArrayExpression":
+    case "ArrowFunctionExpression":
+    case "FunctionExpression":
+    case "CallExpression":
+    case "NewExpression":
+      return true;
+    case "ConditionalExpression":
+      return (
+        isFreshIdentity(unwrapped.consequent) ||
+        isFreshIdentity(unwrapped.alternate)
+      );
+    case "LogicalExpression":
+      return (
+        isFreshIdentity(unwrapped.left) || isFreshIdentity(unwrapped.right)
+      );
+    default:
+      return false;
+  }
+};
+
+const propertyKeyName = (property) => {
+  if (property.computed) {
+    return null;
+  }
+  if (isIdentifier(property.key)) {
+    return property.key.name;
+  }
+  if (property.key?.type === "Literal") {
+    return String(property.key.value);
+  }
+  return null;
+};
+
+export default eslintCompatPlugin({
+  meta: { name: "require-stable-editor-options" },
+  rules: {
+    "require-stable-editor-options": {
+      meta: {
+        type: "problem",
+        messages: {
+          unstableOption:
+            "`useEditor` option `{{name}}` is rebuilt on every render, so the react binding re-applies editor options each render (setOptions -> view.setProps/updateState). On surfaces that re-render per keystroke this view churn can interleave with ProseMirror's DOMObserver and loop until React throws 'Maximum update depth exceeded'. Hoist the value to a stable identity (useMemo, a once-captured useState initializer, or a module constant); inline event handlers (onUpdate, ...) stay allowed.",
+        },
+        schema: [],
+      },
+      createOnce(context) {
+        const useEditorAliases = new Set();
+
+        return {
+          before() {
+            useEditorAliases.clear();
+          },
+          ImportDeclaration(node) {
+            if (node.source?.value !== TIPTAP_REACT_MODULE) {
+              return;
+            }
+            for (const specifier of node.specifiers) {
+              if (
+                specifier.type === "ImportSpecifier" &&
+                getImportedName(specifier) === "useEditor"
+              ) {
+                useEditorAliases.add(specifier.local.name);
+              }
+            }
+          },
+
+          CallExpression(node) {
+            const callee = node.callee;
+            if (!isIdentifier(callee) || !useEditorAliases.has(callee.name)) {
+              return;
+            }
+
+            const options = unwrapExpression(node.arguments[0]);
+            if (options?.type !== "ObjectExpression") {
+              return;
+            }
+
+            for (const property of options.properties) {
+              if (property.type !== "Property") {
+                continue;
+              }
+              const name = propertyKeyName(property);
+              if (name === null || HANDLER_OPTION_KEYS.has(name)) {
+                continue;
+              }
+              if (isFreshIdentity(property.value)) {
+                context.report({
+                  node: property,
+                  messageId: "unstableOption",
+                  data: { name },
+                });
+              }
+            }
+          },
+        };
+      },
+    },
+  },
+});

--- a/.oxlint-plugins/require-stable-editor-options.ts
+++ b/.oxlint-plugins/require-stable-editor-options.ts
@@ -19,7 +19,9 @@
 //
 // Safe patterns (not flagged):
 //   - `useEditor({ extensions, editorProps, content: initialContent })` —
-//     identifiers pointing at memoized/captured values.
+//     identifiers bound to hook-captured values (`useMemo`, `useState`,
+//     `useRef`, custom `useX` results) or declared outside the component
+//     (module constants).
 //   - `useEditor({ autofocus: false, immediatelyRender: false })` —
 //     primitives compare by value.
 //   - `useEditor({ onUpdate: (props) => ... })` — handlers are excluded from
@@ -30,6 +32,10 @@
 //   - `useEditor({ editorProps: { ... } })` — fresh object every render.
 //   - `useEditor({ content: toDoc(value) })` — fresh call result every
 //     render; capture it once (`useState(() => toDoc(value))`) instead.
+//   - `const editorProps = { ... }; useEditor({ editorProps })` — the
+//     identifier resolves to a fresh literal declared in the same function
+//     body (one level of local-binding resolution; aliased chains and
+//     values built in nested statements stay out of scope by design).
 
 import { eslintCompatPlugin } from "@oxlint/plugins";
 
@@ -80,6 +86,93 @@ const isFreshIdentity = (node) => {
     default:
       return false;
   }
+};
+
+const HOOK_NAME = /^use[A-Z0-9]/u;
+
+const isHookCall = (node) => {
+  if (!isAstNode(node) || node.type !== "CallExpression") {
+    return false;
+  }
+  const callee = node["callee"];
+  if (isIdentifier(callee)) {
+    return HOOK_NAME.test(callee.name);
+  }
+  return false;
+};
+
+const findContainingFunction = (node) => {
+  let current = isAstNode(node) ? node["parent"] : null;
+  while (isAstNode(current)) {
+    if (
+      current.type === "FunctionDeclaration" ||
+      current.type === "FunctionExpression" ||
+      current.type === "ArrowFunctionExpression"
+    ) {
+      return current;
+    }
+    current = current["parent"];
+  }
+  return null;
+};
+
+// Resolve `name` against the top-level statements of the function bodies
+// enclosing `fromNode` (innermost first). Returns the declarator's `init`
+// for a plain `const name = ...` declaration, or null when the binding is
+// not found in any enclosing function body — module-level constants and
+// imports deliberately resolve to null (stable by definition here).
+const resolveLocalBindingInit = (name, fromNode) => {
+  let scope = findContainingFunction(fromNode);
+  while (scope !== null) {
+    const body = scope["body"];
+    const statements =
+      isAstNode(body) && body.type === "BlockStatement" ? body["body"] : null;
+    if (Array.isArray(statements)) {
+      for (const statement of statements) {
+        if (!isAstNode(statement) || statement.type !== "VariableDeclaration") {
+          continue;
+        }
+        const declarations = statement["declarations"];
+        if (!Array.isArray(declarations)) {
+          continue;
+        }
+        for (const declarator of declarations) {
+          if (
+            !isAstNode(declarator) ||
+            declarator.type !== "VariableDeclarator"
+          ) {
+            continue;
+          }
+          if (isIdentifier(declarator["id"], name)) {
+            return declarator["init"] ?? null;
+          }
+        }
+      }
+    }
+    scope = findContainingFunction(scope);
+  }
+  return null;
+};
+
+// A value is unstable when it is a fresh literal/call inline, or an
+// identifier whose same-function `const` binding initializes to one. A
+// binding initialized from a hook call (`useMemo`, `useState`, `useRef`,
+// custom `useX`) counts as captured/stable; destructured hook results
+// (`const [x] = useState(...)`) never match a plain-identifier declarator
+// and so resolve to null (not flagged).
+const isUnstableOptionValue = (node, fromNode) => {
+  if (isFreshIdentity(node)) {
+    return true;
+  }
+  const unwrapped = unwrapExpression(node);
+  if (!isIdentifier(unwrapped)) {
+    return false;
+  }
+  const init = resolveLocalBindingInit(unwrapped.name, fromNode);
+  if (init === null || isHookCall(init)) {
+    return false;
+  }
+  return isFreshIdentity(init);
 };
 
 const propertyKeyName = (property) => {
@@ -151,7 +244,7 @@ export default eslintCompatPlugin({
               if (name === null || HANDLER_OPTION_KEYS.has(name)) {
                 continue;
               }
-              if (isFreshIdentity(property.value)) {
+              if (isUnstableOptionValue(property["value"], node)) {
                 context.report({
                   node: property,
                   messageId: "unstableOption",

--- a/.oxlint-plugins/require-stable-editor-options.ts
+++ b/.oxlint-plugins/require-stable-editor-options.ts
@@ -33,7 +33,12 @@
 
 import { eslintCompatPlugin } from "@oxlint/plugins";
 
-import { getImportedName, isIdentifier, unwrapExpression } from "./utils.ts";
+import {
+  getImportedName,
+  isAstNode,
+  isIdentifier,
+  unwrapExpression,
+} from "./utils.ts";
 
 const TIPTAP_REACT_MODULE = "@tiptap/react";
 
@@ -134,8 +139,12 @@ export default eslintCompatPlugin({
               return;
             }
 
-            for (const property of options.properties) {
-              if (property.type !== "Property") {
+            const properties = options["properties"];
+            if (!Array.isArray(properties)) {
+              return;
+            }
+            for (const property of properties) {
+              if (!isAstNode(property) || property.type !== "Property") {
                 continue;
               }
               const name = propertyKeyName(property);

--- a/apps/api/src/lib/usage/provider-cache-accounting-canary.test.ts
+++ b/apps/api/src/lib/usage/provider-cache-accounting-canary.test.ts
@@ -20,9 +20,7 @@ import { describe, expect, test } from "bun:test";
  * the anomaly telemetry (`cache-read-exceeds-included-prompt`) is the runtime
  * backstop until a canary is added for them.
  */
-// eslint-disable-next-line import/no-relative-packages -- deliberate deep import: the usage builder is not in the package exports map; breaking on adapter upgrade is this canary's purpose
 import { buildAnthropicUsage } from "../../../../../node_modules/@tanstack/ai-anthropic/dist/esm/usage.js";
-// eslint-disable-next-line import/no-relative-packages -- deliberate deep import: the usage builder is not in the package exports map; breaking on adapter upgrade is this canary's purpose
 import { buildGeminiUsage } from "../../../../../node_modules/@tanstack/ai-gemini/dist/esm/usage.js";
 
 describe("provider cache accounting canaries", () => {
@@ -30,10 +28,16 @@ describe("provider cache accounting canaries", () => {
     // Production-shaped Anthropic usage on a warm cache: input_tokens
     // excludes cache reads, so the cached count legitimately dwarfs it.
     const usage = buildAnthropicUsage({
-      input_tokens: 5,
-      output_tokens: 421,
+      cache_creation: null,
       cache_creation_input_tokens: 0,
       cache_read_input_tokens: 18_874,
+      inference_geo: null,
+      input_tokens: 5,
+      iterations: null,
+      output_tokens: 421,
+      server_tool_use: null,
+      service_tier: null,
+      speed: null,
     });
     if (usage === undefined) {
       throw new Error("adapter returned no usage for a present usage object");
@@ -46,10 +50,16 @@ describe("provider cache accounting canaries", () => {
 
   test("anthropic adapter keeps cache writes out of promptTokens too", () => {
     const usage = buildAnthropicUsage({
-      input_tokens: 12,
-      output_tokens: 50,
+      cache_creation: null,
       cache_creation_input_tokens: 9502,
       cache_read_input_tokens: 0,
+      inference_geo: null,
+      input_tokens: 12,
+      iterations: null,
+      output_tokens: 50,
+      server_tool_use: null,
+      service_tier: null,
+      speed: null,
     });
     if (usage === undefined) {
       throw new Error("adapter returned no usage for a present usage object");

--- a/apps/web/e2e/specs/chat-anonymized-composer.spec.ts
+++ b/apps/web/e2e/specs/chat-anonymized-composer.spec.ts
@@ -16,6 +16,9 @@ const BURST_TEXT =
 test("anonymized-mode typing keeps every keystroke and paints highlights", async ({
   page,
 }) => {
+  // The cold-start waits below (route compile 30s + first highlight 45s) can
+  // exceed the suite's default 60s per-test timeout on a fresh runner.
+  test.setTimeout(120_000);
   // A route is ready when its UI is ready, not when every cold resource has
   // fired the browser load event. Commit the document, then synchronize on
   // the composer below.

--- a/apps/web/e2e/specs/chat-anonymized-composer.spec.ts
+++ b/apps/web/e2e/specs/chat-anonymized-composer.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "../helpers/test";
+
+// A long, fast keystroke burst. Under the editor-update loop class this spec
+// guards, per-keystroke draft persistence re-rendered the composer, the react
+// binding re-applied editor options on every render, and the view churn fed
+// ProseMirror's DOMObserver a fresh doc-changing transaction — sustaining the
+// cycle until React threw "Maximum update depth exceeded" (caught here by the
+// auto browserErrors fixture) and dropping in-flight keystrokes (caught by
+// the full-text assertion). Short bursts stay under React's nested-update
+// limit, so the length is load-bearing.
+const BURST_TEXT =
+  "Dear Jan Novák, please contact jan.novak@example.com or call " +
+  "+420 777 123 456. Also Petr Svoboda and Marie Dvořáková from Praha " +
+  "will attend the meeting soon.";
+
+test("anonymized-mode typing keeps every keystroke and paints highlights", async ({
+  page,
+}) => {
+  // A route is ready when its UI is ready, not when every cold resource has
+  // fired the browser load event. Commit the document, then synchronize on
+  // the composer below.
+  await page.goto("/chat", { waitUntil: "commit" });
+
+  // The composer's contenteditable carries an explicit role and aria-label
+  // (chat-editor-provider editorProps).
+  const composer = page.getByRole("textbox", { name: /type your question/iu });
+  // First locator after navigation: a cold server can compile the chat route
+  // chunk on demand, exceeding the default expect timeout.
+  await expect(composer).toBeVisible({ timeout: 30_000 });
+
+  // Enabling anonymized mode also warms up the wasm worker, so the pipeline
+  // loads while the burst below is being typed.
+  const anonymizedToggle = page.getByRole("button", {
+    name: "Anonymized AI mode",
+  });
+  await anonymizedToggle.click();
+  await expect(anonymizedToggle).toHaveAttribute("aria-pressed", "true");
+
+  await composer.click();
+  await composer.pressSequentially(BURST_TEXT);
+
+  // Every keystroke survived: the loop class reverts in-flight input before
+  // it trips React's guard, so lost characters are its earliest symptom.
+  await expect(composer).toHaveText(BURST_TEXT);
+
+  // The live preview decorates recognized entities inside the editor
+  // (chat-anon-decorations-extension). Requires the anonymization worker to
+  // boot and the wasm pipeline + name dictionaries to load — several seconds
+  // cold, hence the generous timeout on the first highlight.
+  const highlights = composer.locator(".stll-anon-highlight");
+  await expect(highlights.filter({ hasText: "Jan Novák" }).first()).toBeVisible(
+    { timeout: 45_000 },
+  );
+  await expect(
+    highlights.filter({ hasText: "jan.novak@example.com" }).first(),
+  ).toBeVisible();
+
+  // The browserErrors fixture (auto) fails the spec on any console error —
+  // React's max-update-depth crash surfaces there if the loop class returns.
+});

--- a/apps/web/src/components/ai-prompt-input/ai-prompt-input.tsx
+++ b/apps/web/src/components/ai-prompt-input/ai-prompt-input.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { getRouteApi } from "@tanstack/react-router";
@@ -7,6 +7,7 @@ import History from "@tiptap/extension-history";
 import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import Text from "@tiptap/extension-text";
+import type { EditorProps } from "@tiptap/pm/view";
 import { useEditor } from "@tiptap/react";
 import type { Editor } from "@tiptap/react";
 
@@ -152,58 +153,81 @@ export const AIPromptInput = ({
         }
       : value;
 
+  // Everything passed to `useEditor` below (except event handlers) must keep
+  // a stable identity across renders; the react binding re-applies changed
+  // options to the live editor view, which can interleave with pending
+  // ProseMirror DOM mutations and loop (require-stable-editor-options).
+  // Extensions and content are creation-only anyway — the react binding never
+  // reconfigures either after the editor exists — so capturing the first
+  // render's values is faithful; dynamic bits route through latest getters.
+  const getPlaceholder = useLatestCallback(() => placeholder ?? "");
+  const getEditorClassName = useLatestCallback(() =>
+    variant === "minimal"
+      ? cn(
+          PROMPT_EDITOR_SELECTION_CLASS,
+          "placeholder:text-foreground-placeholder min-h-15 w-full text-sm leading-[1.55] focus-visible:outline-none",
+          aiEditAction !== undefined && "pe-24",
+        )
+      : cn(
+          PROMPT_EDITOR_SELECTION_CLASS,
+          "bg-muted placeholder:text-foreground-placeholder min-h-32 w-full rounded-md p-2 text-sm focus-visible:outline-none",
+          aiEditAction !== undefined && "pe-24",
+        ),
+  );
+  const editorRef = useRef<Editor | null>(null);
+  const handleEditorKeyDown = useLatestCallback(
+    (event: KeyboardEvent): boolean => {
+      if (
+        onSubmit &&
+        (event.metaKey || event.ctrlKey) &&
+        event.key === "Enter"
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        onSubmit();
+        return true;
+      }
+      const currentEditor = editorRef.current;
+      if (
+        currentEditor !== null &&
+        handlePromptEditorSelectAll(event, currentEditor)
+      ) {
+        return true;
+      }
+      return false;
+    },
+  );
+  const [creationContent] = useState(() => initialContent);
+  const [extensions] = useState(() => [
+    createPromptEditorDocument(),
+    Paragraph,
+    Text,
+    PastedText,
+    Placeholder.configure({
+      placeholder: () => getPlaceholder(),
+      showOnlyWhenEditable: false,
+    }),
+    ...(mentionExtension ? [mentionExtension] : []),
+    PromptSlash.configure({
+      suggestion: createPromptSlashSuggestion(getSlashItems),
+    }),
+    History,
+  ]);
+  const [editorProps] = useState<EditorProps>(() => ({
+    attributes: () => ({ class: getEditorClassName() }),
+    handleKeyDown: (_view, event) => handleEditorKeyDown(event),
+  }));
+
   const editor = useEditor({
-    extensions: [
-      createPromptEditorDocument(),
-      Paragraph,
-      Text,
-      PastedText,
-      Placeholder.configure({
-        placeholder: placeholder ?? "",
-        showOnlyWhenEditable: false,
-      }),
-      ...(mentionExtension ? [mentionExtension] : []),
-      PromptSlash.configure({
-        suggestion: createPromptSlashSuggestion(getSlashItems),
-      }),
-      History,
-    ],
-    content: initialContent,
+    content: creationContent,
+    editorProps,
+    extensions,
+    onBlur: () => onBlur?.(),
+    onCreate: ({ editor: createdEditor }) => {
+      editorRef.current = createdEditor;
+    },
     onUpdate: (props) => {
       onChange(readValue(props.editor));
-    },
-    onBlur: () => onBlur?.(),
-    editorProps: {
-      attributes: {
-        class:
-          variant === "minimal"
-            ? cn(
-                PROMPT_EDITOR_SELECTION_CLASS,
-                "placeholder:text-foreground-placeholder min-h-15 w-full text-sm leading-[1.55] focus-visible:outline-none",
-                aiEditAction !== undefined && "pe-24",
-              )
-            : cn(
-                PROMPT_EDITOR_SELECTION_CLASS,
-                "bg-muted placeholder:text-foreground-placeholder min-h-32 w-full rounded-md p-2 text-sm focus-visible:outline-none",
-                aiEditAction !== undefined && "pe-24",
-              ),
-      },
-      handleKeyDown: (_view, event) => {
-        if (
-          onSubmit &&
-          (event.metaKey || event.ctrlKey) &&
-          event.key === "Enter"
-        ) {
-          event.preventDefault();
-          event.stopPropagation();
-          onSubmit();
-          return true;
-        }
-        if (handlePromptEditorSelectAll(event, editor)) {
-          return true;
-        }
-        return false;
-      },
     },
   });
 

--- a/apps/web/src/components/ai-prompt-input/ai-prompt-input.tsx
+++ b/apps/web/src/components/ai-prompt-input/ai-prompt-input.tsx
@@ -237,6 +237,19 @@ export const AIPromptInput = ({
     }
   }, [editor, onEditorReady]);
 
+  // With the options identity-stable, ProseMirror only re-evaluates the
+  // captured placeholder and attributes callbacks when view props are
+  // re-applied or a transaction commits. Re-apply them exactly when a dynamic
+  // input changes so the placeholder and class (variant / edit-action
+  // padding) update without reintroducing per-render option churn.
+  const hasAiEditAction = aiEditAction !== undefined;
+  useExternalSyncEffect(() => {
+    if (editor.isDestroyed) {
+      return;
+    }
+    editor.setOptions({});
+  }, [editor, hasAiEditAction, placeholder, variant]);
+
   // `useEditor` only reads `content` once at creation, so a controlled `value`
   // that changes from outside (switching the edited prompt, or a parent reset)
   // would leave the editor showing stale text. Re-sync the document when the

--- a/apps/web/src/components/chat-editor-echo.test.ts
+++ b/apps/web/src/components/chat-editor-echo.test.ts
@@ -1,0 +1,46 @@
+import { EditorState } from "@tiptap/pm/state";
+import { describe, expect, test } from "bun:test";
+import { Schema } from "prosemirror-model";
+
+import {
+  CHAT_DRAFT_ECHO_META,
+  updateCarriesDraftEcho,
+} from "./chat-editor-echo";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "paragraph+" },
+    paragraph: { content: "text*" },
+    text: { inline: true },
+  },
+});
+
+const state = EditorState.create({ schema });
+
+const userTransaction = () => state.tr.insertText("typed");
+const echoTransaction = () =>
+  state.tr.insertText("echoed").setMeta(CHAT_DRAFT_ECHO_META, true);
+
+describe("updateCarriesDraftEcho", () => {
+  test("a user edit does not read as an echo", () => {
+    expect(updateCarriesDraftEcho([userTransaction()])).toBe(false);
+  });
+
+  test("detects the echo meta on the primary transaction", () => {
+    expect(updateCarriesDraftEcho([echoTransaction()])).toBe(true);
+  });
+
+  test("detects the echo meta on an appended transaction", () => {
+    // tiptap reports plugin-appended transactions separately from the primary
+    // one; an echo hidden among them must still suppress the persist.
+    expect(updateCarriesDraftEcho([userTransaction(), echoTransaction()])).toBe(
+      true,
+    );
+  });
+
+  test("ignores unrelated transaction meta", () => {
+    expect(updateCarriesDraftEcho([state.tr.setMeta("unrelated", true)])).toBe(
+      false,
+    );
+  });
+});

--- a/apps/web/src/components/chat-editor-echo.ts
+++ b/apps/web/src/components/chat-editor-echo.ts
@@ -1,0 +1,32 @@
+import type { Transaction } from "@tiptap/pm/state";
+import type { Editor, JSONContent } from "@tiptap/react";
+
+/**
+ * Transaction meta marking a store->editor echo: the provider applying an
+ * already-persisted draft back into the editor (thread switch, restoring the
+ * draft after a failed submit). The persist path ignores updates that carry
+ * it — an echo re-entering the draft store would churn the stored reference
+ * and re-trigger the editor, the update loop React's max-depth guard turns
+ * into a crash. The meta rides on the transaction itself, so the suppression
+ * survives asynchronous emission orders (ProseMirror's DOMObserver can flush
+ * between effects) where a boolean "currently applying" window would leak.
+ */
+export const CHAT_DRAFT_ECHO_META = "stllChatDraftEcho";
+
+/** Apply a stored draft doc to the editor, tagged as an echo. */
+export const applyDraftDocToEditor = (
+  editor: Editor,
+  doc: JSONContent,
+): void => {
+  editor.chain().setMeta(CHAT_DRAFT_ECHO_META, true).setContent(doc).run();
+};
+
+type MetaCarrier = Pick<Transaction, "getMeta">;
+
+/** Whether any transaction behind a tiptap `update` event is a draft echo. */
+export const updateCarriesDraftEcho = (
+  transactions: readonly MetaCarrier[],
+): boolean =>
+  transactions.some(
+    (transaction) => transaction.getMeta(CHAT_DRAFT_ECHO_META) === true,
+  );

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -844,11 +844,18 @@ export const useChatEditor = ({
     }
     const storedDraft =
       useChatDraftStore.getState().draftsByThreadKey[targetThreadKey] ?? null;
+    // `attachmentsRef` mirrors the CURRENTLY bound thread. A thread-switch
+    // flush persists the PREVIOUS thread's doc after the ref has already
+    // moved on, so it must keep that thread's stored attachments instead of
+    // borrowing the incoming thread's.
+    const isCurrentThread = targetThreadKey === committedThreadKeyRef.current;
     // Returns null for no-op updates whose document already matches the
     // stored draft, so an update burst that ends where it started writes
     // nothing.
     const nextDraft = nextDraftForEditorUpdate({
-      attachments: attachmentsRef.current,
+      attachments: isCurrentThread
+        ? attachmentsRef.current
+        : (storedDraft?.attachments ?? EMPTY_ATTACHMENTS),
       nextDoc: targetEditor.getJSON(),
       storedDoc: storedDraft?.doc ?? EMPTY_CHAT_DRAFT_DOC,
     });
@@ -862,7 +869,7 @@ export const useChatEditor = ({
     // the PREVIOUS thread's doc: the authored set was already reset for the
     // incoming thread, and the outgoing draft must count as external so it
     // restores into the editor when the user switches back.
-    if (targetThreadKey === committedThreadKeyRef.current) {
+    if (isCurrentThread) {
       getOrCreateWeakSet(editorAuthoredDocsRef).add(nextDraft.doc);
     }
     setDraft(targetThreadKey, nextDraft);

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -17,7 +17,13 @@ import History from "@tiptap/extension-history";
 import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import Text from "@tiptap/extension-text";
-import type { EditorState, Plugin, PluginKey } from "@tiptap/pm/state";
+import type {
+  EditorState,
+  Plugin,
+  PluginKey,
+  Transaction,
+} from "@tiptap/pm/state";
+import type { EditorProps } from "@tiptap/pm/view";
 import type { Editor, JSONContent } from "@tiptap/react";
 import { useEditor } from "@tiptap/react";
 import { panic, Result, TaggedError } from "better-result";
@@ -26,6 +32,10 @@ import { useTranslations } from "use-intl";
 
 import { CHAT_CONTEXT_FILE_MAX_BYTES } from "@stll/chat-limits";
 
+import {
+  applyDraftDocToEditor,
+  updateCarriesDraftEcho,
+} from "@/components/chat-editor-echo";
 import { createChatComposerDocument } from "@/components/chat-editor-markdown.logic";
 import {
   ChatMention,
@@ -69,6 +79,13 @@ import { viewsOptions } from "@/lib/workspaces/queries/views";
 
 const CHAT_FILES_PER_MESSAGE = 5;
 const CHAT_MAX_FILE_BYTES = CHAT_CONTEXT_FILE_MAX_BYTES;
+
+// Trailing debounce for mirroring the editor's doc into the draft store, with
+// a hard upper bound so a continuous burst still persists periodically. See
+// `debouncedPersistEditorDraft` in `useChatEditor` for why the deferral is
+// load-bearing.
+const CHAT_DRAFT_PERSIST_DEBOUNCE_MS = 250;
+const CHAT_DRAFT_PERSIST_MAX_WAIT_MS = 1500;
 
 const DOCX_MIME_TYPE =
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
@@ -577,7 +594,6 @@ export const useChatEditor = ({
   const fileIdCounterRef = useRef(0);
   const activePluginKeysRef = useRef<(string | PluginKey)[]>([]);
   const editorRef = useRef<Editor | null>(null);
-  const isApplyingStoredDraftRef = useRef(false);
   // Every `doc` object this editor's own `onUpdate` persists to the draft
   // store is recorded here by identity. The draft-apply effect consults it to
   // avoid ever pushing editor-authored content back into the editor (see
@@ -613,10 +629,29 @@ export const useChatEditor = ({
   const setDraft = useChatDraftStore((state) => state.setDraft);
   const clearDraft = useChatDraftStore((state) => state.clearDraft);
   const draftDoc = draft?.doc ?? EMPTY_CHAT_DRAFT_DOC;
+  // `useEditor` only reads `content` at creation; later drafts reach the
+  // editor through the draft-apply effect below. Freezing the initial doc
+  // keeps the option identity-stable so the react binding never re-applies
+  // editor options mid-typing (see the `useEditor` call for why that matters).
+  const [initialDraftDoc] = useState(() => draftDoc);
   const attachments = draft?.attachments ?? EMPTY_ATTACHMENTS;
   const [isEmpty, setIsEmpty] = useState(() =>
     areDraftDocsEqual(draftDoc, EMPTY_CHAT_DRAFT_DOC),
   );
+  const isEmptyRef = useRef(isEmpty);
+  // Route every emptiness sync through this transition guard: `setIsEmpty` is
+  // called from the editor's synchronous dispatch path on every keystroke,
+  // and React's eager same-value bailout is not guaranteed while other
+  // updates are pending — each enqueued no-op still feeds the
+  // max-update-depth counter under sustained fast input. The ref makes the
+  // no-op structural: only genuine empty<->non-empty transitions reach React.
+  const applyIsEmpty = useLatestCallback((nextIsEmpty: boolean) => {
+    if (isEmptyRef.current === nextIsEmpty) {
+      return;
+    }
+    isEmptyRef.current = nextIsEmpty;
+    setIsEmpty(nextIsEmpty);
+  });
   const attachmentsRef = useRef(attachments);
   // eslint-disable-next-line react/react-compiler -- latest-ref mirror: read at submit time out-of-render, must hold this render's attachments
   attachmentsRef.current = attachments;
@@ -648,7 +683,7 @@ export const useChatEditor = ({
     }
   }, [sentMessageHistoryHtml, threadKey]);
 
-  const fetchWorkspaceEntities = useCallback(
+  const fetchWorkspaceEntities = useLatestCallback(
     async (workspace: ChatWorkspaceMentionOption, query: string) => {
       if (!workspace.sourceViewId) {
         return [];
@@ -687,7 +722,6 @@ export const useChatEditor = ({
         buildEntityMentionOption({ entity, sourceWorkspaceId }),
       );
     },
-    [queryClient, threadRef],
   );
   const debouncedFetchWorkspaceEntities = useDebouncedCallback(
     async ({
@@ -718,7 +752,7 @@ export const useChatEditor = ({
     },
     CHAT_MENTION_SEARCH_DEBOUNCE_MS,
   );
-  const loadWorkspaceEntities = useCallback(
+  const loadWorkspaceEntities = useLatestCallback(
     async (workspace: ChatWorkspaceMentionOption, query: string) => {
       const previous = pendingWorkspaceEntitySearchRef.current;
       if (previous) {
@@ -778,7 +812,6 @@ export const useChatEditor = ({
         );
       });
     },
-    [debouncedFetchWorkspaceEntities, queryClient, threadRef],
   );
 
   useExternalSyncEffect(
@@ -790,42 +823,104 @@ export const useChatEditor = ({
     [debouncedFetchWorkspaceEntities],
   );
 
-  const handleEditorUpdate = useLatestCallback((nextEditor: Editor) => {
-    setIsEmpty(nextEditor.isEmpty);
-
-    if (isApplyingStoredDraftRef.current) {
+  // Flush-time persist of the editor's live doc into the draft store. The
+  // debounce is load-bearing, not cosmetic: the draft store is a mirror of
+  // the editor, and this hook's own subscription re-renders the host surface
+  // on every store write. Persisting synchronously per keystroke made fast
+  // input outpace React's commits — every commit then finished with more
+  // sync work already pending, which React's max-update-depth counter reads
+  // as a loop (~50 keystrokes in one sustained burst) and turns into a crash
+  // that also drops the backlogged keystrokes. Deferring the mirror write
+  // caps the re-render rate while the editor remains the source of truth;
+  // `maxWait` bounds how far the store can lag a continuous burst, and
+  // submit/unmount/thread-switch below cancel or flush the pending write so
+  // the mirror never resurrects or loses a draft across those boundaries.
+  const persistEditorDraft = (
+    targetEditor: Editor,
+    targetThreadKey: string,
+  ) => {
+    if (targetEditor.isDestroyed) {
       return;
     }
-
-    // `nextDraftForEditorUpdate` returns null for no-op updates whose document
-    // already matches the stored draft. tiptap emits `update` even when a
-    // transaction leaves the document unchanged (e.g. editor props re-applied
-    // while the page re-renders during response streaming); persisting an
-    // identical draft would churn the store reference, retrigger this handler,
-    // and loop until React's max-update-depth guard throws.
+    const storedDraft =
+      useChatDraftStore.getState().draftsByThreadKey[targetThreadKey] ?? null;
+    // Returns null for no-op updates whose document already matches the
+    // stored draft, so an update burst that ends where it started writes
+    // nothing.
     const nextDraft = nextDraftForEditorUpdate({
       attachments: attachmentsRef.current,
-      nextDoc: nextEditor.getJSON(),
-      storedDoc: draftDoc,
+      nextDoc: targetEditor.getJSON(),
+      storedDoc: storedDraft?.doc ?? EMPTY_CHAT_DRAFT_DOC,
     });
     if (!nextDraft) {
       return;
     }
-
-    if (!isNavigatingHistoryRef.current) {
-      messageHistoryIndexRef.current = null;
-    }
-
     // Mark this doc as editor-authored so the (lagging) draft-apply effect
-    // never reverts the editor to it. `nextDraft.doc` is the exact object the
-    // store will hand back as `draftDoc`, so identity membership is reliable.
-    getOrCreateWeakSet(editorAuthoredDocsRef).add(nextDraft.doc);
-    setDraft(threadKey, nextDraft);
-
-    if (!nextEditor.isEmpty) {
-      markDraftStarted();
+    // never reverts the editor to it. `nextDraft.doc` is the exact object
+    // the store will hand back as `draftDoc`, so identity membership is
+    // reliable. Skip the mark when this is a thread-switch flush persisting
+    // the PREVIOUS thread's doc: the authored set was already reset for the
+    // incoming thread, and the outgoing draft must count as external so it
+    // restores into the editor when the user switches back.
+    if (targetThreadKey === committedThreadKeyRef.current) {
+      getOrCreateWeakSet(editorAuthoredDocsRef).add(nextDraft.doc);
     }
-  });
+    setDraft(targetThreadKey, nextDraft);
+  };
+  const debouncedPersistEditorDraft = useDebouncedCallback(
+    persistEditorDraft,
+    CHAT_DRAFT_PERSIST_DEBOUNCE_MS,
+    { maxWait: CHAT_DRAFT_PERSIST_MAX_WAIT_MS },
+  );
+
+  // Flush a pending mirror write when the composer rebinds to another thread
+  // (the debounced call still carries the previous thread's editor + key) and
+  // on unmount, so a draft typed within the debounce window is never lost.
+  useExternalSyncEffect(
+    () => () => {
+      debouncedPersistEditorDraft.flush();
+    },
+    [debouncedPersistEditorDraft, threadKey],
+  );
+
+  const handleEditorUpdate = useLatestCallback(
+    ({
+      nextEditor,
+      transactions,
+    }: {
+      nextEditor: Editor;
+      transactions: readonly Transaction[];
+    }) => {
+      applyIsEmpty(nextEditor.isEmpty);
+
+      // A store->editor echo (the draft-apply effect or submit-restore
+      // pushing an already-stored draft back in) must never re-enter the
+      // persist path: a `setContent`/`getJSON` roundtrip can normalize the
+      // doc, and persisting the normalized variant would churn the stored
+      // reference and re-trigger the editor.
+      if (updateCarriesDraftEcho(transactions)) {
+        return;
+      }
+
+      // tiptap also emits `update` for events that leave the document alone
+      // (e.g. `setEditable` re-applied while a response streams). Those must
+      // not reset the message-history cursor, mark a draft started, or
+      // schedule a persist — only genuine document changes do.
+      if (!transactions.some((transaction) => transaction.docChanged)) {
+        return;
+      }
+
+      if (!isNavigatingHistoryRef.current) {
+        messageHistoryIndexRef.current = null;
+      }
+
+      if (!nextEditor.isEmpty) {
+        markDraftStarted();
+      }
+
+      debouncedPersistEditorDraft(nextEditor, threadKey);
+    },
+  );
 
   const handleMessageHistoryKeyDown = useCallback(
     (state: EditorState, event: KeyboardEvent) => {
@@ -899,159 +994,176 @@ export const useChatEditor = ({
     [],
   );
 
-  const editor = useEditor({
-    autofocus: false,
-    content: draftDoc,
-    extensions: [
-      createPromptEditorDocument(),
-      Paragraph,
-      Text,
-      Bold,
-      // Shift+Enter inserts a hard break (newline) instead of
-      // splitting the paragraph; matches expected chat-input
-      // behaviour everywhere — Slack, Discord, ChatGPT, etc.
-      // Chained with `scrollIntoView()` so adding a new line at
-      // the bottom of an overflowed input keeps the cursor in
-      // view (ProseMirror's auto-scroll only fires on selection
-      // changes that already include the flag — `setHardBreak`
-      // alone doesn't).
-      HardBreak.extend({
-        addKeyboardShortcuts() {
-          return {
-            "Shift-Enter": () =>
-              this.editor.chain().setHardBreak().scrollIntoView().run(),
-          };
-        },
-      }),
-      // eslint-disable-next-line react/react-compiler -- ref read deferred into the plugin's placeholder callback (invoked out-of-render), not read during render
-      Placeholder.configure({
-        placeholder: () => placeholderRef.current,
-      }),
-      History,
-      ChatMention.configure({
-        suggestion: createChatSuggestion(
-          getMentionItems,
-          searchMentionItems,
-          // eslint-disable-next-line react/react-compiler -- editor-suggestion glue: loader closes over refs read out-of-render by the mention plugin, not during render
-          loadWorkspaceEntities,
-        ),
-        deleteTriggerWithBackspace: true,
-      }),
-      PastedText,
-      // Decorates nothing until a chat surface's anonymization layer
-      // stores pairs via `setChatAnonDecorationPairs`. Installed here
-      // unconditionally so every surface sharing this editor gets
-      // consistent in-editor highlights without a per-mount install.
-      ChatAnonDecorations,
-    ],
-    onCreate: ({ editor: nextEditor }) => {
-      editorRef.current = nextEditor;
-      setIsEmpty(nextEditor.isEmpty);
-    },
-    onUpdate: ({ editor: nextEditor }) => {
-      handleEditorUpdate(nextEditor);
-    },
-    editorProps: {
-      attributes: (state) => ({
-        // A contenteditable div has no implicit ARIA role, so without
-        // these the composer is invisible to assistive tech (and to
-        // role-based queries); the visible placeholder span is
-        // aria-hidden.
-        role: "textbox",
-        "aria-multiline": "true",
-        "aria-label": resolvedPlaceholder,
-        // While empty, inherit the ambient UI direction so the caret sits on
-        // the RTL side; once there is content, switch to first-strong-character
-        // detection to align mixed Arabic + Latin input. A static `dir="auto"`
-        // would fall back to LTR on the empty doc and strand the caret left.
-        ...(state.doc.textContent.length > 0 ? { dir: "auto" } : {}),
-        class:
-          "field-sizing-content max-h-48 min-h-10 overflow-y-auto text-sm focus-visible:outline-none",
-      }),
-      handlePaste: (_view, event) => {
-        // ProseMirror processes paste before any React `onPaste`
-        // handler, so the chip-on-large-paste logic has to live
-        // here — by the time the React handler fires, the text is
-        // already in the editor.
-        const clipboardData = event.clipboardData;
-        if (clipboardData === null) {
-          return false;
-        }
-
-        const hasFiles = Array.from(clipboardData.items).some(
-          (item) => item.kind === "file",
-        );
-        if (hasFiles) {
-          return false;
-        }
-
-        const pastedText = clipboardData.getData("text/plain");
-        if (!pastedText || !shouldChipPaste(pastedText)) {
-          return false;
-        }
-
-        const targetEditor = editorRef.current;
-        if (targetEditor === null) {
-          return false;
-        }
-
-        event.preventDefault();
-        insertPastedTextChip(targetEditor, {
-          label: "",
-          source: "paste",
-          text: pastedText,
-        });
-        return true;
+  // Everything passed to `useEditor` below (except event handlers) must keep
+  // a stable identity across renders: the react binding shallow-compares the
+  // options on every render and re-applies them to the live editor
+  // (`setOptions` -> `view.setProps` + `view.updateState`) whenever any value
+  // differs. Re-applying view props while ProseMirror's DOMObserver holds
+  // pending input mutations makes the observer flush re-parse the redrawn DOM
+  // as a fresh doc-changing transaction; with the draft store re-rendering
+  // this hook per keystroke, that feedback loop sustains itself until React
+  // throws "Maximum update depth exceeded" and drops in-flight keystrokes.
+  // Event handlers (`onCreate`, `onUpdate`, ...) are exempt: the binding
+  // excludes them from the comparison and always calls the latest one.
+  // eslint-disable-next-line react/react-compiler -- ref read deferred into the plugin's placeholder callback (invoked out-of-render), not read during render
+  const [extensions] = useState(() => [
+    createPromptEditorDocument(),
+    Paragraph,
+    Text,
+    Bold,
+    // Shift+Enter inserts a hard break (newline) instead of
+    // splitting the paragraph; matches expected chat-input
+    // behaviour everywhere — Slack, Discord, ChatGPT, etc.
+    // Chained with `scrollIntoView()` so adding a new line at
+    // the bottom of an overflowed input keeps the cursor in
+    // view (ProseMirror's auto-scroll only fires on selection
+    // changes that already include the flag — `setHardBreak`
+    // alone doesn't).
+    HardBreak.extend({
+      addKeyboardShortcuts() {
+        return {
+          "Shift-Enter": () =>
+            this.editor.chain().setHardBreak().scrollIntoView().run(),
+        };
       },
-      handleKeyDown: (view, event) => {
-        if (handleMessageHistoryKeyDown(view.state, event)) {
+    }),
+    Placeholder.configure({
+      placeholder: () => placeholderRef.current,
+    }),
+    History,
+    ChatMention.configure({
+      suggestion: createChatSuggestion(
+        getMentionItems,
+        searchMentionItems,
+        loadWorkspaceEntities,
+      ),
+      deleteTriggerWithBackspace: true,
+    }),
+    PastedText,
+    // Decorates nothing until a chat surface's anonymization layer
+    // stores pairs via `setChatAnonDecorationPairs`. Installed here
+    // unconditionally so every surface sharing this editor gets
+    // consistent in-editor highlights without a per-mount install.
+    ChatAnonDecorations,
+  ]);
+
+  const [editorProps] = useState<EditorProps>(() => ({
+    attributes: (state) => ({
+      // A contenteditable div has no implicit ARIA role, so without
+      // these the composer is invisible to assistive tech (and to
+      // role-based queries); the visible placeholder span is
+      // aria-hidden.
+      role: "textbox",
+      "aria-multiline": "true",
+      "aria-label": placeholderRef.current,
+      // While empty, inherit the ambient UI direction so the caret sits on
+      // the RTL side; once there is content, switch to first-strong-character
+      // detection to align mixed Arabic + Latin input. A static `dir="auto"`
+      // would fall back to LTR on the empty doc and strand the caret left.
+      ...(state.doc.textContent.length > 0 ? { dir: "auto" } : {}),
+      class:
+        "field-sizing-content max-h-48 min-h-10 overflow-y-auto text-sm focus-visible:outline-none",
+    }),
+    handlePaste: (_view, event) => {
+      // ProseMirror processes paste before any React `onPaste`
+      // handler, so the chip-on-large-paste logic has to live
+      // here — by the time the React handler fires, the text is
+      // already in the editor.
+      const clipboardData = event.clipboardData;
+      if (clipboardData === null) {
+        return false;
+      }
+
+      const hasFiles = Array.from(clipboardData.items).some(
+        (item) => item.kind === "file",
+      );
+      if (hasFiles) {
+        return false;
+      }
+
+      const pastedText = clipboardData.getData("text/plain");
+      if (!pastedText || !shouldChipPaste(pastedText)) {
+        return false;
+      }
+
+      const targetEditor = editorRef.current;
+      if (targetEditor === null) {
+        return false;
+      }
+
+      event.preventDefault();
+      insertPastedTextChip(targetEditor, {
+        label: "",
+        source: "paste",
+        text: pastedText,
+      });
+      return true;
+    },
+    handleKeyDown: (view, event) => {
+      if (handleMessageHistoryKeyDown(view.state, event)) {
+        return true;
+      }
+
+      // ArrowRight or Tab + empty editor + suggested followup: accept the
+      // suggestion without auto-submitting (so the user can review and press
+      // Enter). Tab is intercepted only in this narrow state — a suggestion
+      // on offer and the input empty — so it still moves focus normally (for
+      // keyboard and screen-reader users) everywhere else, including the
+      // moment the suggestion is gone.
+      if (
+        (event.key === "ArrowRight" || event.key === "Tab") &&
+        !event.shiftKey &&
+        !event.altKey &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.isComposing
+      ) {
+        const suggestion = suggestedFollowupPromptRef.current;
+        const targetEditor = editorRef.current;
+        if (suggestion && targetEditor?.isEmpty) {
+          event.preventDefault();
+          targetEditor.commands.setContent(
+            createChatComposerDocument(suggestion),
+          );
           return true;
         }
+      }
 
-        // ArrowRight or Tab + empty editor + suggested followup: accept the
-        // suggestion without auto-submitting (so the user can review and press
-        // Enter). Tab is intercepted only in this narrow state — a suggestion
-        // on offer and the input empty — so it still moves focus normally (for
-        // keyboard and screen-reader users) everywhere else, including the
-        // moment the suggestion is gone.
-        if (
-          (event.key === "ArrowRight" || event.key === "Tab") &&
-          !event.shiftKey &&
-          !event.altKey &&
-          !event.ctrlKey &&
-          !event.metaKey &&
-          !event.isComposing
-        ) {
-          const suggestion = suggestedFollowupPromptRef.current;
-          const targetEditor = editorRef.current;
-          if (suggestion && targetEditor?.isEmpty) {
-            event.preventDefault();
-            targetEditor.commands.setContent(
-              createChatComposerDocument(suggestion),
-            );
-            return true;
-          }
-        }
+      // Submit on Enter or Cmd/Ctrl+Enter. Shift+Enter falls
+      // through to the HardBreak extension (newline). The
+      // mention-suggestion plugin owns Enter while its popup is
+      // open — let it pick the highlighted item instead of
+      // submitting the prompt.
+      if (event.key !== "Enter" || event.isComposing) {
+        return false;
+      }
+      if (event.shiftKey) {
+        return false;
+      }
+      if (isSuggestionPluginActive(view.state)) {
+        return false;
+      }
 
-        // Submit on Enter or Cmd/Ctrl+Enter. Shift+Enter falls
-        // through to the HardBreak extension (newline). The
-        // mention-suggestion plugin owns Enter while its popup is
-        // open — let it pick the highlighted item instead of
-        // submitting the prompt.
-        if (event.key !== "Enter" || event.isComposing) {
-          return false;
-        }
-        if (event.shiftKey) {
-          return false;
-        }
-        if (isSuggestionPluginActive(view.state)) {
-          return false;
-        }
+      event.preventDefault();
+      detached(submitHandlerRef.current?.(), "chat-editor-provider.submit");
+      return true;
+    },
+  }));
 
-        event.preventDefault();
-        detached(submitHandlerRef.current?.(), "chat-editor-provider.submit");
-        return true;
-      },
+  const editor = useEditor({
+    autofocus: false,
+    content: initialDraftDoc,
+    editorProps,
+    extensions,
+    onCreate: ({ editor: nextEditor }) => {
+      editorRef.current = nextEditor;
+      applyIsEmpty(nextEditor.isEmpty);
+    },
+    onUpdate: ({ editor: nextEditor, transaction, appendedTransactions }) => {
+      handleEditorUpdate({
+        nextEditor,
+        transactions: [transaction, ...appendedTransactions],
+      });
     },
   });
 
@@ -1103,8 +1215,8 @@ export const useChatEditor = ({
     // `setContent` the editor back to stale content and drop in-flight
     // keystrokes, looping until React throws "Maximum update depth exceeded".
     // Only apply genuinely external drafts (thread switch, restore, mention
-    // inserted while inactive); `isApplyingStoredDraftRef` still suppresses the
-    // resulting `onUpdate`.
+    // inserted while inactive); the draft-echo transaction meta keeps the
+    // resulting `onUpdate` out of the persist path.
     if (
       !shouldApplyStoredDraftToEditor({
         draftDoc,
@@ -1114,16 +1226,14 @@ export const useChatEditor = ({
         editorDoc: editor.getJSON(),
       })
     ) {
-      setIsEmpty(editor.isEmpty);
+      applyIsEmpty(editor.isEmpty);
       return undefined;
     }
 
-    isApplyingStoredDraftRef.current = true;
-    editor.commands.setContent(draftDoc);
-    isApplyingStoredDraftRef.current = false;
-    setIsEmpty(editor.isEmpty);
+    applyDraftDocToEditor(editor, draftDoc);
+    applyIsEmpty(editor.isEmpty);
     return undefined;
-  }, [draftDoc, editor]);
+  }, [applyIsEmpty, draftDoc, editor]);
 
   const focus = useCallback(() => {
     if (!isUsableEditor(editor)) {
@@ -1302,9 +1412,12 @@ export const useChatEditor = ({
         return;
       }
 
+      // A pending mirror write must not resurrect the draft this submit is
+      // about to clear.
+      debouncedPersistEditorDraft.cancel();
       clearDraft(threadKey);
       editor.commands.clearContent();
-      setIsEmpty(true);
+      applyIsEmpty(true);
       draftStartedThreadKeyRef.current = null;
 
       try {
@@ -1324,10 +1437,8 @@ export const useChatEditor = ({
         );
         // The editor may have been destroyed during `await send(...)`;
         if (!editor.isDestroyed) {
-          isApplyingStoredDraftRef.current = true;
-          editor.commands.setContent(doc);
-          isApplyingStoredDraftRef.current = false;
-          setIsEmpty(editor.isEmpty);
+          applyDraftDocToEditor(editor, doc);
+          applyIsEmpty(editor.isEmpty);
           if (!editor.isEmpty || files.length > 0) {
             draftStartedThreadKeyRef.current = restoreThreadKey;
           }
@@ -1335,7 +1446,14 @@ export const useChatEditor = ({
         throw error;
       }
     },
-    [clearDraft, editor, setDraft, setIsEmpty, threadKey],
+    [
+      applyIsEmpty,
+      clearDraft,
+      debouncedPersistEditorDraft,
+      editor,
+      setDraft,
+      threadKey,
+    ],
   );
 
   const canSubmit = !isEmpty || attachments.length > 0;

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -1204,6 +1204,20 @@ export const useChatEditor = ({
     };
   }, [editor, extensionVersion, syncEditorPlugins]);
 
+  // The root attributes callback (aria-label) reads `placeholderRef` and
+  // ProseMirror only re-evaluates it when view props are re-applied or a
+  // transaction commits — with the options now identity-stable, neither
+  // happens on a placeholder change alone. Re-apply the view props exactly
+  // when the placeholder changes (suggestion arrival, locale switch) so
+  // assistive tech and role-based queries see the current label; this stays
+  // off the per-keystroke path entirely.
+  useExternalSyncEffect(() => {
+    if (!isUsableEditor(editor)) {
+      return;
+    }
+    editor.setOptions({});
+  }, [editor, resolvedPlaceholder]);
+
   useExternalSyncEffect(() => {
     if (!isUsableEditor(editor)) {
       return undefined;

--- a/apps/web/src/lib/anonymize/anonymize-chat-worker-client.ts
+++ b/apps/web/src/lib/anonymize/anonymize-chat-worker-client.ts
@@ -1,5 +1,8 @@
 import type { ChatAnonResult } from "@stll/anonymize-chat";
 
+// eslint-disable-next-line import/default -- Vite ?worker&url import returns the emitted worker script URL as default export
+import anonymizeChatWorkerUrl from "../../workers/anonymize-chat-worker?worker&url";
+
 /**
  * Main-thread client for the chat-input anonymization Web Worker.
  *
@@ -51,14 +54,48 @@ class PendingWorkerRequests {
 
 const pendingRequests = new PendingWorkerRequests();
 
+/**
+ * Create the dedicated module worker.
+ *
+ * A cross-origin-isolated document (COOP + COEP, which the web runtime sets
+ * for wasm memory) subjects a dedicated worker's script response to an
+ * embedder-policy check: the response must itself carry a compatible COEP
+ * header. The built worker script is a static asset whose response headers
+ * depend on whichever host serves it, so a direct `new Worker(url)` fails
+ * closed (an `error` event at boot, no highlights ever) when that host omits
+ * the header. A same-origin blob bootstrap that `import`s the script inherits
+ * the document's policy instead of re-checking response headers, keeping
+ * worker boot independent of asset-host header configuration.
+ *
+ * Non-isolated contexts skip that check but may forbid blob workers via CSP
+ * (the desktop webview's `default-src 'self'` does), so each branch uses the
+ * one constructor that works in its context.
+ */
+const createAnonymizeChatWorker = (): Worker => {
+  if (!globalThis.crossOriginIsolated) {
+    return new Worker(anonymizeChatWorkerUrl, { type: "module" });
+  }
+  const scriptUrl = new URL(anonymizeChatWorkerUrl, globalThis.location.href)
+    .href;
+  const bootstrapBlob = new Blob([`import ${JSON.stringify(scriptUrl)};`], {
+    type: "text/javascript",
+  });
+  const bootstrapUrl = URL.createObjectURL(bootstrapBlob);
+  try {
+    return new Worker(bootstrapUrl, { type: "module" });
+  } finally {
+    // Revoking immediately after construction is safe — the constructor
+    // pins the blob before this line runs (Vite's own inline-worker helper
+    // uses the same pattern).
+    URL.revokeObjectURL(bootstrapUrl);
+  }
+};
+
 const ensureWorker = (): Worker => {
   if (worker !== null) {
     return worker;
   }
-  const created = new Worker(
-    new URL("../../workers/anonymize-chat-worker.ts", import.meta.url),
-    { type: "module" },
-  );
+  const created = createAnonymizeChatWorker();
   created.addEventListener("message", (event: MessageEvent<WorkerResponse>) => {
     const message = event.data;
     const entry = pendingRequests.take(message.id);

--- a/apps/web/src/lib/chat-draft-store.ts
+++ b/apps/web/src/lib/chat-draft-store.ts
@@ -105,7 +105,12 @@ type NextDraftForEditorUpdateOptions = {
 // document unchanged (e.g. editor props re-applied while the page re-renders
 // during response streaming). Persisting an identical draft would churn the
 // store entry's reference, retrigger the editor's onUpdate, and loop until
-// React's max-update-depth guard throws. Only genuine edits yield a new state.
+// React's max-update-depth guard throws. Only genuine edits yield a new
+// state. Store->editor echoes never reach this decision at all: the provider
+// drops updates whose transactions carry the draft-echo meta (see
+// `updateCarriesDraftEcho` in chat-editor-echo) before scheduling a persist,
+// because a `setContent`/`getJSON` roundtrip can normalize the doc and make
+// an echo compare unequal here.
 export const nextDraftForEditorUpdate = ({
   attachments,
   nextDoc,

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
@@ -315,6 +315,17 @@ export const ClauseEditor = ({
     },
   });
 
+  // With the options identity-stable, ProseMirror only re-evaluates the
+  // captured placeholder callback when view props are re-applied or a
+  // transaction commits. Re-apply them exactly when the placeholder changes
+  // so it updates without reintroducing per-render option churn.
+  useExternalSyncEffect(() => {
+    if (!isUsableEditor(editor)) {
+      return;
+    }
+    editor.setOptions({});
+  }, [editor, placeholder]);
+
   // Re-seed the editor only on an external content change (not on the user's
   // own edits, whose key we already recorded above).
   const contentKey = bodyKey(content);

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
@@ -14,6 +14,7 @@ import {
 import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import Text from "@tiptap/extension-text";
+import type { EditorProps } from "@tiptap/pm/view";
 import { EditorContent, useEditor } from "@tiptap/react";
 import type { Editor } from "@tiptap/react";
 import {
@@ -190,59 +191,72 @@ export const ClauseEditor = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const rewriteRequestIdRef = useRef(0);
 
+  // Everything passed to `useEditor` below (except event handlers) must keep
+  // a stable identity across renders; the react binding re-applies changed
+  // options to the live editor view, which can interleave with pending
+  // ProseMirror DOM mutations and loop (require-stable-editor-options).
+  // Extensions and content are creation-only anyway — the react binding never
+  // reconfigures either after the editor exists — so capturing the first
+  // render's values is faithful; external content changes flow through
+  // `syncExternalContent` below and the placeholder through a latest getter.
+  const getPlaceholder = useLatestCallback(() => placeholder ?? "");
+  const [creationContent] = useState(() => clauseBodyToTipTap(content));
+  const [extensions] = useState(() => [
+    Document,
+    Paragraph,
+    Text,
+    Bold,
+    Italic,
+    Heading.configure({ levels: [1, 2, 3] }),
+    BulletList,
+    OrderedList,
+    ListItem,
+    // Tab / Shift-Tab nesting plus smart Backspace/Delete at list edges.
+    ListKeymap,
+    ClauseDirectiveNode,
+    InsertionMark,
+    DeletionMark,
+    History,
+    Placeholder.configure({
+      placeholder: () => getPlaceholder(),
+    }),
+  ]);
+  const [editorProps] = useState<EditorProps>(() => ({
+    handleClick: (view, position) => {
+      if (getAiState().status !== "reviewing") {
+        return false;
+      }
+      const resolvedPosition = view.state.doc.resolve(position);
+      const isTrackedChange = (mark: (typeof view.state.doc.marks)[number]) =>
+        mark.type.name === INSERTION_MARK || mark.type.name === DELETION_MARK;
+      const mark =
+        resolvedPosition.nodeBefore?.marks.find(isTrackedChange) ??
+        resolvedPosition.nodeAfter?.marks.find(isTrackedChange);
+      const revisionId = mark?.attrs["revisionId"];
+      if (typeof revisionId !== "number") {
+        setHunkMenu(null);
+        return false;
+      }
+      const coords = view.coordsAtPos(position);
+      const rect = containerRef.current?.getBoundingClientRect();
+      setHunkMenu({
+        revisionId,
+        top: coords.bottom - (rect?.top ?? 0),
+        left: coords.left - (rect?.left ?? 0),
+      });
+      return false;
+    },
+  }));
+
   const editor = useEditor({
     // Inline on an SSR'd page (unlike the old modal, which only mounted
     // client-side): defer editor creation to the client so the server and
     // client DOM agree. Without this, the hydration mismatch corrupts
     // ProseMirror's DOM<->position mapping and text selection stops working.
     immediatelyRender: false,
-    extensions: [
-      Document,
-      Paragraph,
-      Text,
-      Bold,
-      Italic,
-      Heading.configure({ levels: [1, 2, 3] }),
-      BulletList,
-      OrderedList,
-      ListItem,
-      // Tab / Shift-Tab nesting plus smart Backspace/Delete at list edges.
-      ListKeymap,
-      ClauseDirectiveNode,
-      InsertionMark,
-      DeletionMark,
-      History,
-      Placeholder.configure({
-        placeholder: placeholder ?? "",
-      }),
-    ],
-    content: clauseBodyToTipTap(content),
-    editorProps: {
-      handleClick: (view, position) => {
-        if (getAiState().status !== "reviewing") {
-          return false;
-        }
-        const resolvedPosition = view.state.doc.resolve(position);
-        const isTrackedChange = (mark: (typeof view.state.doc.marks)[number]) =>
-          mark.type.name === INSERTION_MARK || mark.type.name === DELETION_MARK;
-        const mark =
-          resolvedPosition.nodeBefore?.marks.find(isTrackedChange) ??
-          resolvedPosition.nodeAfter?.marks.find(isTrackedChange);
-        const revisionId = mark?.attrs["revisionId"];
-        if (typeof revisionId !== "number") {
-          setHunkMenu(null);
-          return false;
-        }
-        const coords = view.coordsAtPos(position);
-        const rect = containerRef.current?.getBoundingClientRect();
-        setHunkMenu({
-          revisionId,
-          top: coords.bottom - (rect?.top ?? 0),
-          left: coords.left - (rect?.left ?? 0),
-        });
-        return false;
-      },
-    },
+    content: creationContent,
+    editorProps,
+    extensions,
     onUpdate: ({ editor: e }) => {
       if (getAiState().status === "reviewing") {
         if (hasPendingTrackedChanges(e)) {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -108,7 +108,51 @@ const ensurePluginOption = (option: unknown, label: string): PluginOption => {
   throw new TypeError(`Invalid Vite plugin option from ${label}`);
 };
 
+// The exact default asset-base expression `@stll/anonymize-wasm` compiles
+// into its dist entry; the package's own Vite plugin anchors on the same
+// text for `vite build` rewrites.
+const ANONYMIZE_WASM_ASSET_URL_BASE =
+  // eslint-disable-next-line no-template-curly-in-string -- matches the literal `${NATIVE_ASSET_DIR}` text in the compiled dist entry, not an interpolation site
+  "new URL(`./${NATIVE_ASSET_DIR}/`, import.meta.url)";
+
+/**
+ * Serve-mode counterpart of the `@stll/anonymize-wasm` build plugin (which
+ * only runs for `vite build`). The package resolves its native assets
+ * against a template-literal `new URL(..., import.meta.url)`; in dev, Vite's
+ * dynamic-URL analysis expands that template into an eager
+ * `import.meta.glob` over the package's whole dist directory, and the glob's
+ * `*.mjs.map?import&url` entries come back as JSON — a MIME the module
+ * loader rejects, which fails the wasm module graph and with it the chat
+ * anonymization worker. `@vite-ignore` opts the expression out of the
+ * analysis; plain runtime URL resolution works as-is under `/@fs` serving.
+ */
+const anonymizeWasmDevAssetBasePlugin = (): Plugin => ({
+  name: "stella-anonymize-wasm-dev-asset-base",
+  apply: "serve",
+  enforce: "pre",
+  transform(code, id) {
+    const [idPath] = id.split("?");
+    if (!(idPath?.includes("anonymize-wasm") && idPath.endsWith("wasm.mjs"))) {
+      return null;
+    }
+    if (!code.includes(ANONYMIZE_WASM_ASSET_URL_BASE)) {
+      this.error(
+        `stella-anonymize-wasm-dev-asset-base: could not find the assetUrl base in ${id}. The @stll/anonymize-wasm dist shape changed; update ANONYMIZE_WASM_ASSET_URL_BASE.`,
+      );
+    }
+    return {
+      code: code.replace(
+        ANONYMIZE_WASM_ASSET_URL_BASE,
+        // eslint-disable-next-line no-template-curly-in-string -- emits the same literal template text back into the module, opted out of Vite's analysis
+        "new URL(/* @vite-ignore */ `./${NATIVE_ASSET_DIR}/`, import.meta.url)",
+      ),
+      map: null,
+    };
+  },
+});
+
 const runtimeAssetPlugins = (): PluginOption[] => [
+  anonymizeWasmDevAssetBasePlugin(),
   ensurePluginOption(
     stllAnonymizeWasm({ packages: "none" }),
     "@stll/anonymize-wasm/vite",

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -756,6 +756,7 @@ export default defineConfig({
     "./.oxlint-plugins/require-cached-collator.ts",
     "./.oxlint-plugins/require-query-signal.ts",
     "./.oxlint-plugins/require-stable-snapshot.ts",
+    "./.oxlint-plugins/require-stable-editor-options.ts",
     "./.oxlint-plugins/require-use-shallow.ts",
     "./.oxlint-plugins/no-raw-stored-json.ts",
     "./.oxlint-plugins/no-detached-void.ts",
@@ -928,6 +929,14 @@ export default defineConfig({
     {
       files: [".oxlint-plugins/__fixtures__/require-use-shallow.fixture.tsx"],
       rules: { "require-use-shallow/require-use-shallow": "error" },
+    },
+    {
+      files: [
+        ".oxlint-plugins/__fixtures__/require-stable-editor-options.fixture.tsx",
+      ],
+      rules: {
+        "require-stable-editor-options/require-stable-editor-options": "error",
+      },
     },
     {
       files: [
@@ -1689,6 +1698,11 @@ export default defineConfig({
         // A useSyncExternalStore snapshot that never stabilizes trips
         // React's getSnapshot-cache warning and can loop the same way.
         "require-stable-snapshot/require-stable-snapshot": "error",
+        // `useEditor` options rebuilt per render make the react binding
+        // re-apply editor view props on every render; on per-keystroke
+        // re-render surfaces that churn can interleave with ProseMirror's
+        // DOMObserver and loop into "Maximum update depth exceeded".
+        "require-stable-editor-options/require-stable-editor-options": "error",
         "no-restricted-imports": [
           "error",
           {

--- a/scripts/react-compiler-bailouts.json
+++ b/scripts/react-compiler-bailouts.json
@@ -1,7 +1,7 @@
 {
   "apps/web/src/components/ai-suggestions/file-chat-overlay.tsx::FileChatOverlayInner": 1,
   "apps/web/src/components/autocomplete/use-autocomplete-stream.ts::useAutocompleteStream": 0,
-  "apps/web/src/components/chat-editor-provider.tsx::useChatEditor": 14,
+  "apps/web/src/components/chat-editor-provider.tsx::useChatEditor": 12,
   "apps/web/src/components/chat-mention-list.tsx::ChatMentionList": 1,
   "apps/web/src/components/chat/chat-thread-messages.tsx::ChatThreadMessages": 2,
   "apps/web/src/components/chat/chat-thread-messages.tsx::StickyUserTurn": 0,


### PR DESCRIPTION
Typing bursts in the chat composer could trip React's max-update-depth guard and drop in-flight keystrokes, and the in-editor anonymization highlights failed to load in some environments. This hardens the editor update path end to end:

- **Stable `useEditor` options.** The react binding shallow-compares the options object every render and re-applies editor view props (`setOptions` -> `view.setProps`/`updateState`) whenever any value has a fresh identity. Re-applying view props while ProseMirror's DOMObserver holds pending input mutations makes the observer flush re-parse the redrawn DOM as a doc-changing transaction, sustaining an update loop. `content` is now captured at creation, `extensions`/`editorProps` are hoisted to stable identities, and the new `require-stable-editor-options` oxlint rule enforces the invariant at every `useEditor` call site (the other two call sites are aligned in the same change).
- **Draft persistence off the dispatch path.** The draft store mirrors the editor, and the provider's own store subscription re-renders the host surface per write. Persisting synchronously on every `update` let fast input outpace React's commits, which the max-update-depth counter reads as a loop (~50 keystrokes in one sustained burst). The mirror write is now debounced (250 ms, 1.5 s max wait) with cancel-on-submit and flush on thread switch/unmount; `isEmpty` goes through a transition guard so no-op updates never enqueue React work.
- **Transaction-scoped echo tagging.** Applying a stored draft back into the editor now stamps a `draft-echo` transaction meta instead of a boolean "currently applying" window, so the suppression survives asynchronous DOMObserver emission orders; updates without a doc change are ignored entirely. Pure helpers are unit-tested (`chat-editor-echo.test.ts`, `chat-draft-store.test.ts`).
- **Worker bootstrap independent of asset-host headers.** Under cross-origin isolation (COOP/COEP, which the web runtime sets for wasm memory), a dedicated worker's script response must itself carry a compatible COEP header. The anonymization worker now boots through a same-origin blob module that imports the built script, so worker creation no longer depends on how the static asset host is configured; non-isolated contexts keep the direct constructor (their CSP may forbid blob workers).
- **Dev-mode wasm module graph.** Vite's dev-mode `new URL` analysis expanded `@stll/anonymize-wasm`'s dynamic asset base into an eager glob whose `*.mjs.map?import&url` entries are served as JSON, failing the whole module graph in serve mode. A serve-only transform opts the expression out of the analysis (the package's own plugin already handles `vite build`).
- **E2E regression spec.** `chat-anonymized-composer.spec.ts` toggles anonymized mode, types a long fast burst, and asserts keystroke integrity plus in-editor entity highlights; the auto `browserErrors` fixture fails the spec on any console error, so a recurrence of the update-loop class cannot land silently.

Also aligns the provider cache canary test payloads with the current Anthropic SDK `BetaUsage` type (surfaced by the full-repo type-aware lint run this diff triggers).

Verified: unit suites green (1905 web + api canary), `bun run code-check:affected` green, the new spec passes against a patched dev stack and fails against an unpatched one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat editor stability when composing, editing, restoring and submitting drafts.
  - Reduced duplicate draft updates and prevented persisted drafts from being overwritten or reapplied incorrectly.
  - Improved anonymised chat operation across different browser security contexts.
  - Preserved complete message text during longer anonymised compositions.
  - Improved placeholder and editor behaviour across repeated updates.

- **Quality Improvements**
  - Added safeguards to identify unstable editor configurations during development.
  - Expanded automated coverage for chat drafts, editor updates and anonymised composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->