### PR TITLE
feat(web): group client exceptions by structural fingerprint

### DIFF
--- a/apps/web/src/lib/analytics/exception-fingerprint.test.ts
+++ b/apps/web/src/lib/analytics/exception-fingerprint.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+
+import { fingerprintExceptionEvent } from "@/lib/analytics/exception-fingerprint";
+
+// Production-shaped frames: bundled asset URLs as posthog-js reports them,
+// crash frame last (caller-first ordering).
+const matterViewFrames = [
+  {
+    filename: "https://my.stll.app/assets/root-BOq2mF3k.js",
+    function: "dispatchEvent",
+    in_app: true,
+    lineno: 1,
+    colno: 51_204,
+  },
+  {
+    filename: "https://my.stll.app/assets/matter-view-D3kfQx9a.js",
+    function: "renderMatter",
+    in_app: true,
+    lineno: 4,
+    colno: 18_733,
+  },
+] as const;
+
+const documentPanelFrames = [
+  {
+    filename: "https://my.stll.app/assets/root-BOq2mF3k.js",
+    function: "dispatchEvent",
+    in_app: true,
+    lineno: 1,
+    colno: 51_204,
+  },
+  {
+    filename: "https://my.stll.app/assets/document-panel-Ck2pW7dm.js",
+    function: "openDocument",
+    in_app: true,
+    lineno: 2,
+    colno: 9812,
+  },
+] as const;
+
+describe("fingerprintExceptionEvent", () => {
+  test("distinct defects in distinct components produce distinct fingerprints", () => {
+    const matterView = fingerprintExceptionEvent({
+      entries: [
+        { type: "TypeError", stacktrace: { frames: matterViewFrames } },
+      ],
+    });
+    const documentPanel = fingerprintExceptionEvent({
+      entries: [
+        { type: "TypeError", stacktrace: { frames: documentPanelFrames } },
+      ],
+    });
+    expect(matterView).not.toBe(documentPanel);
+  });
+
+  test("the same error fingerprints identically on every occurrence", () => {
+    const entry = {
+      type: "RangeError",
+      stacktrace: { frames: matterViewFrames },
+    };
+    expect(
+      fingerprintExceptionEvent({ area: "pdf-viewer", entries: [entry] }),
+    ).toBe(fingerprintExceptionEvent({ area: "pdf-viewer", entries: [entry] }));
+  });
+
+  test("keeps only asset basename and symbol name from each frame", () => {
+    expect(
+      fingerprintExceptionEvent({
+        entries: [
+          { type: "TypeError", stacktrace: { frames: matterViewFrames } },
+        ],
+      }),
+    ).toBe(
+      "TypeError||root-BOq2mF3k.js:dispatchEvent;matter-view-D3kfQx9a.js:renderMatter|",
+    );
+  });
+
+  test("the area slug and cause-chain classes separate otherwise identical errors", () => {
+    const wrapper = {
+      type: "ClientTelemetryError",
+      stacktrace: { frames: matterViewFrames },
+    };
+    const entries = [wrapper, { type: "RangeError" }];
+    const fingerprint = fingerprintExceptionEvent({
+      area: "pdf-viewer",
+      entries,
+    });
+    expect(fingerprint).toBe(
+      "ClientTelemetryError|pdf-viewer|root-BOq2mF3k.js:dispatchEvent;matter-view-D3kfQx9a.js:renderMatter|RangeError",
+    );
+    expect(fingerprint).not.toBe(fingerprintExceptionEvent({ entries }));
+    expect(fingerprint).not.toBe(
+      fingerprintExceptionEvent({
+        area: "pdf-viewer",
+        entries: [wrapper, { type: "AbortError" }],
+      }),
+    );
+  });
+
+  test("strips query strings and fragments before taking the basename", () => {
+    const fingerprint = fingerprintExceptionEvent({
+      entries: [
+        {
+          type: "TypeError",
+          stacktrace: {
+            frames: [
+              {
+                filename:
+                  "https://my.stll.app/assets/matter-view-D3kfQx9a.js?token=phx_9f3b2c&email=jana.novakova@example.com#L4",
+                function: "renderMatter",
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(fingerprint).toBe(
+      "TypeError||matter-view-D3kfQx9a.js:renderMatter|",
+    );
+    expect(fingerprint).not.toContain("?");
+    expect(fingerprint).not.toContain("@");
+  });
+
+  test("caps the frame identities at the crash-site end of the stack", () => {
+    const deepStack = [
+      ...Array.from({ length: 8 }, (_, index) => ({
+        filename: "https://my.stll.app/assets/root-BOq2mF3k.js",
+        function: `frame${index}`,
+      })),
+      ...matterViewFrames,
+    ];
+    expect(
+      fingerprintExceptionEvent({
+        entries: [{ type: "TypeError", stacktrace: { frames: deepStack } }],
+      }),
+    ).toBe(
+      "TypeError||root-BOq2mF3k.js:frame7;root-BOq2mF3k.js:dispatchEvent;matter-view-D3kfQx9a.js:renderMatter|",
+    );
+  });
+
+  test("frameless and entryless events still yield a stable class-level identity", () => {
+    expect(fingerprintExceptionEvent({ entries: [] })).toBe("UnknownError|||");
+    expect(
+      fingerprintExceptionEvent({
+        entries: [{ type: "UnhandledRejection" }],
+      }),
+    ).toBe("UnhandledRejection|||");
+  });
+});

--- a/apps/web/src/lib/analytics/exception-fingerprint.test.ts
+++ b/apps/web/src/lib/analytics/exception-fingerprint.test.ts
@@ -70,9 +70,7 @@ describe("fingerprintExceptionEvent", () => {
           { type: "TypeError", stacktrace: { frames: matterViewFrames } },
         ],
       }),
-    ).toBe(
-      "TypeError||root-BOq2mF3k.js:dispatchEvent;matter-view-D3kfQx9a.js:renderMatter|",
-    );
+    ).toBe("TypeError||root.js:dispatchEvent;matter-view.js:renderMatter|");
   });
 
   test("the area slug and cause-chain classes separate otherwise identical errors", () => {
@@ -86,7 +84,7 @@ describe("fingerprintExceptionEvent", () => {
       entries,
     });
     expect(fingerprint).toBe(
-      "ClientTelemetryError|pdf-viewer|root-BOq2mF3k.js:dispatchEvent;matter-view-D3kfQx9a.js:renderMatter|RangeError",
+      "ClientTelemetryError|pdf-viewer|root.js:dispatchEvent;matter-view.js:renderMatter|RangeError",
     );
     expect(fingerprint).not.toBe(fingerprintExceptionEvent({ entries }));
     expect(fingerprint).not.toBe(
@@ -114,9 +112,7 @@ describe("fingerprintExceptionEvent", () => {
         },
       ],
     });
-    expect(fingerprint).toBe(
-      "TypeError||matter-view-D3kfQx9a.js:renderMatter|",
-    );
+    expect(fingerprint).toBe("TypeError||matter-view.js:renderMatter|");
     expect(fingerprint).not.toContain("?");
     expect(fingerprint).not.toContain("@");
   });
@@ -134,7 +130,7 @@ describe("fingerprintExceptionEvent", () => {
         entries: [{ type: "TypeError", stacktrace: { frames: deepStack } }],
       }),
     ).toBe(
-      "TypeError||root-BOq2mF3k.js:frame7;root-BOq2mF3k.js:dispatchEvent;matter-view-D3kfQx9a.js:renderMatter|",
+      "TypeError||root.js:frame7;root.js:dispatchEvent;matter-view.js:renderMatter|",
     );
   });
 
@@ -146,4 +142,31 @@ describe("fingerprintExceptionEvent", () => {
       }),
     ).toBe("UnhandledRejection|||");
   });
+});
+
+test("fingerprint is stable across content-hashed chunk renames", () => {
+  const input = (filename: string) => ({
+    entries: [
+      {
+        type: "TypeError",
+        stacktrace: {
+          frames: [{ filename, function: "renderMatter" }],
+        },
+      },
+    ],
+  });
+  const a = fingerprintExceptionEvent(
+    input("https://app.example/assets/matter-view-D3kfQx9a.js"),
+  );
+  const b = fingerprintExceptionEvent(
+    input("https://app.example/assets/matter-view-Bx91kQwe.js"),
+  );
+  // Different content hashes must not split the issue; the fixture differs
+  // before the equivalence is asserted.
+  expect("matter-view-D3kfQx9a.js").not.toBe("matter-view-Bx91kQwe.js");
+  expect(a).toBe(b);
+  const c = fingerprintExceptionEvent(
+    input("https://app.example/assets/other-view-D3kfQx9a.js"),
+  );
+  expect(a).not.toBe(c);
 });

--- a/apps/web/src/lib/analytics/exception-fingerprint.ts
+++ b/apps/web/src/lib/analytics/exception-fingerprint.ts
@@ -1,0 +1,76 @@
+// Grouping identity for `$exception` events. PostHog derives issues from
+// `$exception_list` content; with messages and stacks redacted by the
+// exception sanitizer, that default collapses to roughly one issue per
+// error class. `$exception_fingerprint` overrides it with a structural
+// identity built only from components the sanitizer already keeps, so
+// distinct defects create distinct issues without weakening redaction.
+
+// Frames beyond the crash site describe generic dispatch (schedulers,
+// event loops) and dilute identity more than they sharpen it.
+const FRAME_IDENTITY_LIMIT = 3;
+
+type FingerprintFrame = {
+  filename?: string;
+  function?: string;
+};
+
+type FingerprintEntry = {
+  type: string;
+  stacktrace?: { frames: readonly FingerprintFrame[] };
+};
+
+type ExceptionFingerprintInput = {
+  /**
+   * Sanitized `$exception_list`: the first entry is the thrown error, later
+   * entries its cause chain.
+   */
+  entries: readonly FingerprintEntry[];
+  /** Validated telemetry area slug, when an error boundary declared one. */
+  area?: string | undefined;
+};
+
+// The asset path up to the basename is deployment layout, not defect
+// identity, and query strings or fragments can carry tokens. Keep only
+// the final path segment.
+const assetBasename = (filename: string): string => {
+  const terminator = filename.search(/[?#]/u);
+  const path = terminator === -1 ? filename : filename.slice(0, terminator);
+  return path.slice(path.lastIndexOf("/") + 1);
+};
+
+const frameIdentity = (frame: FingerprintFrame): string => {
+  const basename =
+    frame.filename === undefined ? "" : assetBasename(frame.filename);
+  const symbol = frame.function ?? "";
+  return basename === "" && symbol === "" ? "" : `${basename}:${symbol}`;
+};
+
+// Frames are ordered caller-first, so the tail of the list is the crash
+// site. A frameless error legitimately yields no identities.
+const frameIdentities = (entry: FingerprintEntry | undefined): string[] => {
+  if (entry?.stacktrace === undefined) {
+    return [];
+  }
+  return entry.stacktrace.frames
+    .map(frameIdentity)
+    .filter((identity) => identity !== "")
+    .slice(-FRAME_IDENTITY_LIMIT);
+};
+
+/**
+ * Positions are fixed (an empty component stays empty) so one component can
+ * never collide with another — the same shape the server-side capture
+ * wrapper uses for its `$exception_fingerprint`.
+ */
+export const fingerprintExceptionEvent = ({
+  area,
+  entries,
+}: ExceptionFingerprintInput): string => {
+  const classes = entries.map((entry) => entry.type);
+  return [
+    classes.at(0) ?? "UnknownError",
+    area ?? "",
+    frameIdentities(entries.at(0)).join(";"),
+    classes.slice(1).join(";"),
+  ].join("|");
+};

--- a/apps/web/src/lib/analytics/exception-fingerprint.ts
+++ b/apps/web/src/lib/analytics/exception-fingerprint.ts
@@ -38,9 +38,19 @@ const assetBasename = (filename: string): string => {
   return path.slice(path.lastIndexOf("/") + 1);
 };
 
+// Vite content-hashes chunk basenames (`matter-view-D3kfQx9a.js`), so a
+// rebuild renames the chunk without the defect changing. Strip the hash
+// segment so a fingerprint survives deployments; a basename with no hash
+// passes through unchanged.
+const CHUNK_HASH_SUFFIX = /-[A-Za-z0-9_-]{8}(?=\.[a-z]+$)/u;
+const stableBasename = (basename: string): string =>
+  basename.replace(CHUNK_HASH_SUFFIX, "");
+
 const frameIdentity = (frame: FingerprintFrame): string => {
   const basename =
-    frame.filename === undefined ? "" : assetBasename(frame.filename);
+    frame.filename === undefined
+      ? ""
+      : stableBasename(assetBasename(frame.filename));
   const symbol = frame.function ?? "";
   return basename === "" && symbol === "" ? "" : `${basename}:${symbol}`;
 };

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -560,7 +560,7 @@ describe("PostHog browser analytics adapter", () => {
         "$exception_fingerprint"
       ];
     expect(fingerprint).toBe(
-      "ClientTelemetryError|pdf-viewer|matter-view-D3kfQx9a.js:renderMatter|RangeError",
+      "ClientTelemetryError|pdf-viewer|matter-view.js:renderMatter|RangeError",
     );
 
     // Deterministic: the same defect groups into the same issue.

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -287,6 +287,7 @@ describe("PostHog browser analytics adapter", () => {
     expect(initOptions?.before_send(event)).toEqual({
       event: WEB_ANALYTICS_EVENTS.exception,
       properties: {
+        $exception_fingerprint: "UnhandledRejection|||",
         $exception_list: [{ type: "UnhandledRejection", value: "" }],
         $exception_type: "UnhandledRejection",
       },
@@ -311,6 +312,7 @@ describe("PostHog browser analytics adapter", () => {
     expect(initOptions?.before_send(event)).toEqual({
       event: WEB_ANALYTICS_EVENTS.exception,
       properties: {
+        $exception_fingerprint: "TypeError||app.js:|",
         $exception_list: [
           {
             type: "TypeError",
@@ -519,6 +521,84 @@ describe("PostHog browser analytics adapter", () => {
     expect(sanitizedFreeForm?.properties).not.toContainKey("area");
   });
 
+  test("fingerprints exceptions from structure, never from message content", () => {
+    createPostHogAnalytics({ host: "https://posthog.test", key: "phc_test" });
+
+    // Production-shaped event: PII in the message, a token-bearing query
+    // string on the asset URL, and a wrapped cause.
+    const crashInMatterView = {
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
+        area: "pdf-viewer",
+        $exception_list: [
+          {
+            type: "ClientTelemetryError",
+            value:
+              "Cannot render brief for jana.novakova@example.com in Client Smith v Example",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "https://my.stll.app/assets/matter-view-D3kfQx9a.js?token=phx_9f3b2c&email=jana.novakova@example.com",
+                  function: "renderMatter",
+                  in_app: true,
+                  lineno: 4,
+                  colno: 18_733,
+                },
+              ],
+            },
+          },
+          {
+            type: "RangeError",
+            value: "Privileged cause detail for jana.novakova@example.com",
+          },
+        ],
+      },
+    };
+    const fingerprint =
+      initOptions?.before_send(crashInMatterView)?.properties?.[
+        "$exception_fingerprint"
+      ];
+    expect(fingerprint).toBe(
+      "ClientTelemetryError|pdf-viewer|matter-view-D3kfQx9a.js:renderMatter|RangeError",
+    );
+
+    // Deterministic: the same defect groups into the same issue.
+    expect(
+      initOptions?.before_send(crashInMatterView)?.properties?.[
+        "$exception_fingerprint"
+      ],
+    ).toBe(fingerprint);
+
+    // A different defect in a different component groups separately even
+    // though the error class matches.
+    expect(
+      initOptions?.before_send({
+        event: WEB_ANALYTICS_EVENTS.exception,
+        properties: {
+          $exception_list: [
+            {
+              type: "ClientTelemetryError",
+              value: "Different failure, same class",
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      "https://my.stll.app/assets/document-panel-Ck2pW7dm.js",
+                    function: "openDocument",
+                    in_app: true,
+                    lineno: 2,
+                    colno: 9812,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      })?.properties?.["$exception_fingerprint"],
+    ).not.toBe(fingerprint);
+  });
+
   test("captureError correlates a recovery reference without error details", () => {
     const { analytics } = createPostHogAnalytics({
       host: "https://posthog.test",
@@ -689,6 +769,7 @@ describe("PostHog browser analytics adapter", () => {
       properties: {
         token: "phc_test",
         distinct_id: "018f9f0e-7b42-7cc8-9a5d-42db46f6842d",
+        $exception_fingerprint: "TypeError||app.js:|",
         $exception_list: [
           {
             type: "TypeError",
@@ -788,6 +869,7 @@ describe("PostHog browser analytics adapter", () => {
       event: WEB_ANALYTICS_EVENTS.exception,
       properties: {
         error_reference: "ERR-DEAD-BEEF-1234",
+        $exception_fingerprint: "TypeError|||",
         $exception_list: [{ type: "TypeError", value: "" }],
         $exception_type: "TypeError",
       },
@@ -803,6 +885,7 @@ describe("PostHog browser analytics adapter", () => {
     expect(rejected).toEqual({
       event: WEB_ANALYTICS_EVENTS.exception,
       properties: {
+        $exception_fingerprint: "TypeError|||",
         $exception_list: [{ type: "TypeError", value: "" }],
         $exception_type: "TypeError",
       },

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -8,6 +8,7 @@ import {
   telemetryErrorType,
 } from "@/lib/analytics/error-diagnostics";
 import { isErrorReference } from "@/lib/analytics/error-reference";
+import { fingerprintExceptionEvent } from "@/lib/analytics/exception-fingerprint";
 import { pickIngestionRequired } from "@/lib/analytics/posthog-ingestion";
 import type { sanitizeRouteErrorLifecycleEvent } from "@/lib/analytics/posthog-route-error";
 import { WEB_ANALYTICS_EVENTS } from "@/lib/analytics/types";
@@ -205,17 +206,23 @@ const sanitizeExceptionEvent = (event: CaptureResult): CaptureResult => {
       ? entries.map(sanitizeExceptionEntry)
       : [sanitizeExceptionEntry(undefined)];
   const type = sanitizedList.at(0)?.type ?? normalizeTelemetryErrorTypeName("");
+  const safeArea =
+    typeof area === "string" && TELEMETRY_AREA.test(area) ? area : undefined;
   return {
     ...event,
     properties: {
       ...pickIngestionRequired(properties),
+      // Grouping identity derived from the sanitized list, so nothing the
+      // redaction removed can reach it.
+      $exception_fingerprint: fingerprintExceptionEvent({
+        area: safeArea,
+        entries: sanitizedList,
+      }),
       $exception_list: sanitizedList,
       $exception_type: type,
       ...(typeof appCommit === "string" ? { app_commit: appCommit } : {}),
       ...(typeof appVersion === "string" ? { app_version: appVersion } : {}),
-      ...(typeof area === "string" && TELEMETRY_AREA.test(area)
-        ? { area }
-        : {}),
+      ...(safeArea === undefined ? {} : { area: safeArea }),
       ...(isErrorReference(errorReference)
         ? { error_reference: errorReference }
         : {}),

--- a/deploy/selfhost/.env.example
+++ b/deploy/selfhost/.env.example
@@ -264,6 +264,29 @@ S3_REGION="us-east-1"
 # [internal] Optional with a default. Corpus index read concurrency.
 # CORPUS_INDEX_READ_CONCURRENCY="4"
 
+# [internal] Optional. CloudWatch metric name the corpus-index build loop
+# samples to pace itself. Unset disables pacing.
+# CORPUS_INDEX_BACKPRESSURE_METRIC=""
+
+# [internal] Optional. CloudWatch namespace of the pacing metric.
+# CORPUS_INDEX_BACKPRESSURE_NAMESPACE=""
+
+# [internal] Optional. Name=Value[,Name=Value...] dimensions of the pacing
+# metric.
+# CORPUS_INDEX_BACKPRESSURE_DIMENSIONS=""
+
+# [internal] Optional with a default. Metric value below which the
+# corpus-index build loop pauses.
+# CORPUS_INDEX_BACKPRESSURE_LOW_WATERMARK="30"
+
+# [internal] Optional with a default. Metric value above which a paused
+# corpus-index build resumes.
+# CORPUS_INDEX_BACKPRESSURE_HIGH_WATERMARK="50"
+
+# [internal] Optional with a default. Minimum interval between pacing-metric
+# samples.
+# CORPUS_INDEX_BACKPRESSURE_SAMPLE_INTERVAL_MS="60000"
+
 # --- Observability -----------------------------------------------------
 # [internal] Optional. PostHog project key. The placeholder "phc_" disables
 # capture for local development.


### PR DESCRIPTION
## Summary

The web exception sanitizer redacts messages and stacks before `$exception` events leave the browser, which collapses PostHog's default issue grouping to roughly one issue per error class. This PR sets `$exception_fingerprint` from structure the sanitizer already keeps, so distinct defects create distinct issues:

- `fingerprintExceptionEvent` (`apps/web/src/lib/analytics/exception-fingerprint.ts`): a pure function over the sanitized `$exception_list` plus the validated `area` slug. Components: primary error class, area, the last three frame identities (asset basename + symbol name, query strings and fragments stripped), and cause-chain class names. Positions are fixed and pipe-joined, matching the shape the server-side capture wrapper uses.
- Wired inside `sanitizeExceptionEvent` and computed from the sanitizer's own output, so nothing the redaction removes can reach the fingerprint; all existing redaction is unchanged.
- The `route_error_recovery` lifecycle event keeps its existing structural `error_fingerprint`: it is not a `$exception` event, so error tracking never groups it and `$exception_fingerprint` would be inert there.

## Repairs picked up along the way

- `fix(api)`: the cache-accounting canary literals no longer typecheck against the current `BetaUsage` shape (its nullable usage fields are required); filled them with production-shaped values and dropped two disable directives that now report as unused.
- `chore(selfhost)`: `deploy/selfhost/.env.example` regenerated; the corpus-index pacing variables landed without regenerating it, so the self-host contract check fails on a clean tree.

## Tests

- `exception-fingerprint.test.ts`: distinctness across components, determinism, basename/symbol-only frame identities, query-string and fragment stripping, crash-site frame cap, frameless fallback.
- `posthog.test.ts`: end-to-end through `before_send` with a production-shaped payload embedding an email in the message and a token-bearing query string on the asset URL; asserts the exact structural fingerprint and that a same-class error in a different component groups separately. Mutation check: replacing the fingerprint call with a static string fails 5 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stable exception fingerprints to improve identification of recurring errors.
  - Fingerprints use structured error details while excluding message content and sanitising URLs.
  - Similar errors remain recognisable across bundle renames and varying stack traces.
- **Bug Fixes**
  - Improved exception telemetry consistency by validating and reusing the reported analytics area.
- **Configuration**
  - Added optional settings for controlling CloudWatch metric backpressure during corpus-index builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->