### PR TITLE
fix(chat): persist and resume client-executed tool turns

### DIFF
--- a/apps/api/drizzle/20260817220000_chat_turn_client_tool_interaction/migration.sql
+++ b/apps/api/drizzle/20260817220000_chat_turn_client_tool_interaction/migration.sql
@@ -1,0 +1,10 @@
+-- stella-migration-safety: reviewed destructive-change - Replaces only the interaction-type value CHECK to admit 'client-tool'; every existing row satisfies the widened set, and rollback can restore the prior CHECK once no row carries the new value.
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+ALTER TABLE "chat_turns"
+  DROP CONSTRAINT "chat_turns_interaction_values_check";--> statement-breakpoint
+
+ALTER TABLE "chat_turns"
+  ADD CONSTRAINT "chat_turns_interaction_values_check"
+  CHECK ("interaction_type" IS NULL OR "interaction_type" IN ('ask-user', 'approval', 'client-tool'));

--- a/apps/api/drizzle/20260817220000_chat_turn_client_tool_interaction/migration.sql
+++ b/apps/api/drizzle/20260817220000_chat_turn_client_tool_interaction/migration.sql
@@ -7,4 +7,17 @@ ALTER TABLE "chat_turns"
 
 ALTER TABLE "chat_turns"
   ADD CONSTRAINT "chat_turns_interaction_values_check"
-  CHECK ("interaction_type" IS NULL OR "interaction_type" IN ('ask-user', 'approval', 'client-tool'));
+  CHECK ("interaction_type" IS NULL OR "interaction_type" IN ('ask-user', 'approval', 'client-tool')) NOT VALID;--> statement-breakpoint
+
+-- Validate outside Drizzle's migration transaction so PostgreSQL does not
+-- hold the ADD CONSTRAINT lock for the duration of the table scan.
+-- squawk-ignore transaction-nesting
+COMMIT;--> statement-breakpoint
+SET statement_timeout = 0;--> statement-breakpoint
+SET lock_timeout = 0;--> statement-breakpoint
+ALTER TABLE "chat_turns"
+  VALIDATE CONSTRAINT "chat_turns_interaction_values_check";--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+SET lock_timeout = '1s';--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/dev/register-mock-ai.ts
+++ b/apps/api/src/dev/register-mock-ai.ts
@@ -46,6 +46,28 @@ const E2E_EMPTY_COMPLETION_MARKER = "Return an empty completion please";
 
 const EMPTY_COMPLETION_DELAY_MS = 1500;
 
+// A user message containing this marker makes the mock adapter answer with a
+// `create-document` tool call (a client-executed tool), the shape of a real
+// drafting turn: the run pauses at TanStack's native interrupt boundary, the
+// chat client compiles the draft and posts the result back, and only the
+// continuation run answers with text. This exercises the whole client-tool
+// round trip (server persistence of the paused turn, the durable-turn claim,
+// the resume continuation, and the inspector draft) deterministically.
+const E2E_CREATE_DOCUMENT_MARKER = "Draft it as a document please";
+
+const E2E_CREATE_DOCUMENT_TOOL_NAME = "create-document";
+const E2E_CREATE_DOCUMENT_NAME = "Mutual NDA";
+const E2E_CREATE_DOCUMENT_SOURCE =
+  "@doc kind=agreement locale=en page=A4\n" +
+  "@title MUTUAL NON-DISCLOSURE AGREEMENT\n" +
+  "@clause Definition of Confidential Information\n" +
+  "Confidential Information means any information disclosed by " +
+  "[[Disclosing Party]] to [[Receiving Party]].\n" +
+  "@signatures\nparty: [[Party A]]\nparty: [[Party B]]\n";
+const E2E_CREATE_DOCUMENT_REPLY =
+  "The draft is open in the panel. Placeholders left to fill: the parties " +
+  "and the effective date.";
+
 const SLOW_STREAM_REPLY =
   "This mock reply streams back in many small pieces instead of arriving all " +
   "at once, so an end to end test has a real window while the assistant is " +
@@ -100,6 +122,21 @@ const getLatestUserText = (messages: ModelMessage[]): string => {
   return textParts.join("");
 };
 
+type MockCreateDocumentPhase = "call" | "reply" | null;
+
+const resolveCreateDocumentPhase = ({
+  latestUserText,
+  messages,
+}: {
+  latestUserText: string;
+  messages: ModelMessage[];
+}): MockCreateDocumentPhase => {
+  if (!latestUserText.includes(E2E_CREATE_DOCUMENT_MARKER)) {
+    return null;
+  }
+  return messages.at(-1)?.role === "tool" ? "reply" : "call";
+};
+
 const createMockTextAdapter = (modelId: string): AnyTextAdapter => ({
   kind: "text",
   name: "mock",
@@ -119,6 +156,12 @@ const createMockTextAdapter = (modelId: string): AnyTextAdapter => ({
     const timestamp = Date.now();
     const latestUserText = getLatestUserText(messages);
     const slowStream = latestUserText.includes(E2E_SLOW_STREAM_MARKER);
+    // The continuation after the client posted the draft result ends with a
+    // tool message; only the first turn of the marker prompt calls the tool.
+    const createDocumentPhase = resolveCreateDocumentPhase({
+      latestUserText,
+      messages,
+    });
 
     yield {
       type: EventType.RUN_STARTED,
@@ -127,6 +170,52 @@ const createMockTextAdapter = (modelId: string): AnyTextAdapter => ({
       model,
       timestamp,
     } satisfies StreamChunk;
+
+    if (createDocumentPhase === "call") {
+      yield {
+        type: EventType.TEXT_MESSAGE_START,
+        messageId,
+        role: "assistant",
+        model,
+        timestamp,
+      } satisfies StreamChunk;
+      yield {
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "mock-create-document-call",
+        toolCallName: E2E_CREATE_DOCUMENT_TOOL_NAME,
+        // eslint-disable-next-line typescript/no-deprecated -- AG-UI still requires the compatibility field.
+        toolName: E2E_CREATE_DOCUMENT_TOOL_NAME,
+        parentMessageId: messageId,
+        model,
+        timestamp,
+      } satisfies StreamChunk;
+      yield {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId: "mock-create-document-call",
+        delta: JSON.stringify({
+          name: E2E_CREATE_DOCUMENT_NAME,
+          source: E2E_CREATE_DOCUMENT_SOURCE,
+        }),
+        model,
+        timestamp,
+      } satisfies StreamChunk;
+      yield {
+        type: EventType.TOOL_CALL_END,
+        toolCallId: "mock-create-document-call",
+        model,
+        timestamp,
+      } satisfies StreamChunk;
+      yield {
+        type: EventType.RUN_FINISHED,
+        runId: resolvedRunId,
+        threadId: resolvedThreadId,
+        model,
+        timestamp,
+        finishReason: "tool_calls",
+        usage: mockUsage,
+      } satisfies StreamChunk;
+      return;
+    }
 
     if (latestUserText.includes(E2E_EMPTY_COMPLETION_MARKER)) {
       // Real providers return an empty completion only after a round-trip;
@@ -170,7 +259,10 @@ const createMockTextAdapter = (modelId: string): AnyTextAdapter => ({
       yield {
         type: EventType.TEXT_MESSAGE_CONTENT,
         messageId,
-        delta: MOCK_REPLY,
+        delta:
+          createDocumentPhase === "reply"
+            ? E2E_CREATE_DOCUMENT_REPLY
+            : MOCK_REPLY,
         model,
         timestamp,
       } satisfies StreamChunk;

--- a/apps/api/src/handlers/chat/chat-message-parts.test.ts
+++ b/apps/api/src/handlers/chat/chat-message-parts.test.ts
@@ -154,8 +154,92 @@ describe("persisted chat message parts", () => {
       getAwaitingUserInteractions({ parts: [...parts], role: "assistant" }),
     ).toEqual([{ toolCallId: "ask-1", type: "ask-user" }]);
     expect(
-      getResumedUserInteraction({ parts: [...parts], role: "assistant" }),
+      getResumedUserInteraction({
+        awaited: [
+          { toolCallId: "ask-1", type: "ask-user" },
+          { toolCallId: "approval-1", type: "approval" },
+        ],
+        message: { parts: [...parts], role: "assistant" },
+      }),
     ).toEqual({ toolCallId: "approval-1", type: "approval" });
+  });
+
+  test("awaits a client-executed tool call whose input is complete", () => {
+    const parts = [
+      {
+        arguments: '{"query":"nda"}',
+        id: "search-1",
+        input: { query: "nda" },
+        name: "mcp__external__search",
+        output: { matters: [] },
+        state: "complete",
+        type: "tool-call",
+      },
+      {
+        arguments: '{"name":"NDA","source":"@title NDA"}',
+        id: "draft-1",
+        input: { name: "NDA", source: "@title NDA" },
+        name: "create-document",
+        state: "input-complete",
+        type: "tool-call",
+      },
+    ] as const satisfies ChatPart[];
+
+    expect(
+      getAwaitingUserInteractions({ parts: [...parts], role: "assistant" }),
+    ).toEqual([{ toolCallId: "draft-1", type: "client-tool" }]);
+  });
+
+  test("resolves a client-tool interaction only through its awaited call", () => {
+    const awaited = [
+      { toolCallId: "draft-1", type: "client-tool" },
+    ] as const satisfies Parameters<
+      typeof getResumedUserInteraction
+    >[0]["awaited"];
+    const resolvedDraft = {
+      arguments: '{"name":"NDA","source":"@title NDA"}',
+      id: "draft-1",
+      input: { name: "NDA", source: "@title NDA" },
+      name: "create-document",
+      output: { destination: "draft", fileName: "NDA.docx", success: true },
+      state: "complete",
+      type: "tool-call",
+    } as const satisfies ChatPart;
+    // A completed server tool after the awaited call is not an answer.
+    const completedServerCall = {
+      arguments: '{"query":"nda"}',
+      id: "search-1",
+      input: { query: "nda" },
+      name: "mcp__external__search",
+      output: { matters: [] },
+      state: "complete",
+      type: "tool-call",
+    } as const satisfies ChatPart;
+
+    expect(
+      getResumedUserInteraction({
+        awaited,
+        message: {
+          parts: [resolvedDraft, completedServerCall],
+          role: "assistant",
+        },
+      }),
+    ).toEqual({ toolCallId: "draft-1", type: "client-tool" });
+    expect(
+      getResumedUserInteraction({
+        awaited,
+        message: {
+          parts: [{ ...resolvedDraft, state: "input-complete" }],
+          role: "assistant",
+        },
+      }),
+    ).toBeNull();
+    expect(
+      getResumedUserInteraction({
+        awaited: [],
+        message: { parts: [resolvedDraft], role: "assistant" },
+      }),
+    ).toBeNull();
   });
 
   test("persists every structured-output terminal and streaming state", () => {

--- a/apps/api/src/handlers/chat/chat-message-parts.test.ts
+++ b/apps/api/src/handlers/chat/chat-message-parts.test.ts
@@ -225,15 +225,18 @@ describe("persisted chat message parts", () => {
         },
       }),
     ).toEqual({ toolCallId: "draft-1", type: "client-tool" });
+    // A cancelled native resume leaves the awaited call untouched; the turn
+    // still names its owner so the execution claim can proceed.
+    const { output: _output, ...untouchedDraft } = resolvedDraft;
     expect(
       getResumedUserInteraction({
         awaited,
         message: {
-          parts: [{ ...resolvedDraft, state: "input-complete" }],
+          parts: [{ ...untouchedDraft, state: "input-complete" }],
           role: "assistant",
         },
       }),
-    ).toBeNull();
+    ).toEqual({ toolCallId: "draft-1", type: "client-tool" });
     expect(
       getResumedUserInteraction({
         awaited: [],

--- a/apps/api/src/handlers/chat/chat-message-parts.ts
+++ b/apps/api/src/handlers/chat/chat-message-parts.ts
@@ -546,8 +546,8 @@ export const getAwaitingUserInteraction = (
 /**
  * Whether an incoming tool-call state answers an awaited interaction:
  * `resolved` carries the client's answer, `unchanged` leaves the call as it
- * was awaited (the legacy ask-user fallback while a later approval in the
- * same message is answered), and `null` is not an answer.
+ * was awaited (an untouched call while a later interaction in the same
+ * message is answered, or a cancelled resume), and `null` is not an answer.
  */
 const CLIENT_INTERACTION_RESOLUTION = {
   approval: {
@@ -608,10 +608,10 @@ export const getResumedUserInteraction = ({
       (interaction) => [interaction.toolCallId, interaction] as const,
     ),
   );
-  let unchangedAskUser: AwaitingUserInteraction | null = null;
+  let unchangedInteraction: AwaitingUserInteraction | null = null;
   for (let index = message.parts.length - 1; index >= 0; index -= 1) {
     const part = message.parts[index];
-    if (part === undefined || part.type !== "tool-call") {
+    if (part?.type !== "tool-call") {
       continue;
     }
     const interaction = awaitedByToolCallId.get(part.id);
@@ -623,13 +623,15 @@ export const getResumedUserInteraction = ({
     if (resolution === "resolved") {
       return interaction;
     }
-    // Prefer an explicit answer elsewhere in the message; retain the untouched
-    // ask-user call only as the legacy fallback.
-    if (resolution === "unchanged" && interaction.type === "ask-user") {
-      unchangedAskUser = interaction;
+    // Prefer an explicit answer elsewhere in the message. An awaited call the
+    // continuation leaves untouched still names the turn it belongs to: a
+    // cancelled native resume keeps the call as awaited, and the turn must
+    // still find its owner.
+    if (resolution === "unchanged") {
+      unchangedInteraction = interaction;
     }
   }
-  return unchangedAskUser;
+  return unchangedInteraction;
 };
 
 export const toProviderVisibleMessages = (

--- a/apps/api/src/handlers/chat/chat-message-parts.ts
+++ b/apps/api/src/handlers/chat/chat-message-parts.ts
@@ -13,6 +13,7 @@ import {
   TANSTACK_TOOL_CALL_STATE_LIFECYCLE,
   TANSTACK_TOOL_RESULT_STATE_LIFECYCLE,
 } from "@/api/handlers/chat/tanstack-chat-lifecycle";
+import { ASK_USER_TOOL_NAME } from "@/api/handlers/chat/tools/native-chat-tool-names";
 import type {
   ChatAttachmentMetadata,
   ChatAttachmentPart,
@@ -383,12 +384,19 @@ export const toProviderVisibleMessage = (
     : { ...message, parts };
 };
 
-const ASK_USER_STATE_AWAITS_USER = {
+/**
+ * Whether a client-executed tool call (ask-user, or any tool without a server
+ * `execute`) still awaits its client resolution. A server-executed call never
+ * ends a run in `input-complete`: the agent loop executes every tool of a
+ * model turn before it decides whether to call the model again, so at run end
+ * an `input-complete` call is by construction one the client must resolve.
+ */
+const CLIENT_TOOL_STATE_AWAITS_RESOLUTION = {
   "approval-requested": false,
   "approval-responded": false,
   // A terminal stream can end while the provider has only announced a call or
-  // is still emitting its JSON arguments. The card cannot render a usable
-  // question in either state, so neither may take durable user-turn ownership.
+  // is still emitting its JSON arguments. Neither state carries usable input,
+  // so neither may take durable turn ownership.
   "awaiting-input": false,
   complete: false,
   error: false,
@@ -396,18 +404,8 @@ const ASK_USER_STATE_AWAITS_USER = {
   "input-streaming": false,
 } as const satisfies Record<TanStackToolCallState, boolean>;
 
-const RESUMED_INTERACTION_TYPE_BY_TOOL_STATE = {
-  "approval-requested": null,
-  "approval-responded": "approval",
-  "awaiting-input": null,
-  complete: "ask-user",
-  error: null,
-  "input-complete": "ask-user",
-  "input-streaming": null,
-} as const satisfies Record<
-  TanStackToolCallState,
-  "approval" | "ask-user" | null
->;
+const clientToolInteractionType = (name: string): "ask-user" | "client-tool" =>
+  name === ASK_USER_TOOL_NAME ? "ask-user" : "client-tool";
 
 type AwaitingUserInteraction = Extract<
   NonNullable<ChatMessageMetadata["turnOutcome"]>,
@@ -530,8 +528,11 @@ export const getAwaitingUserInteractions = (
       interactions.push({ type: "approval", toolCallId: part.id });
       continue;
     }
-    if (part.name === "ask-user" && ASK_USER_STATE_AWAITS_USER[part.state]) {
-      interactions.push({ type: "ask-user", toolCallId: part.id });
+    if (CLIENT_TOOL_STATE_AWAITS_RESOLUTION[part.state]) {
+      interactions.push({
+        type: clientToolInteractionType(part.name),
+        toolCallId: part.id,
+      });
     }
   }
   return interactions;
@@ -543,42 +544,92 @@ export const getAwaitingUserInteraction = (
   getAwaitingUserInteractions(message).at(0) ?? null;
 
 /**
- * Return the durable interaction a client continuation is attempting to
- * resolve. The turn store compares this identity with its canonical awaited
- * interaction before any client-supplied assistant parts replace history.
+ * Whether an incoming tool-call state answers an awaited interaction:
+ * `resolved` carries the client's answer, `unchanged` leaves the call as it
+ * was awaited (the legacy ask-user fallback while a later approval in the
+ * same message is answered), and `null` is not an answer.
  */
-export const getResumedUserInteraction = (
-  message: Pick<ChatMessage, "parts" | "role">,
-): AwaitingUserInteraction | null => {
-  if (message.role !== "assistant") {
+const CLIENT_INTERACTION_RESOLUTION = {
+  approval: {
+    "approval-requested": "unchanged",
+    "approval-responded": "resolved",
+    "awaiting-input": null,
+    complete: null,
+    error: null,
+    "input-complete": null,
+    "input-streaming": null,
+  },
+  "ask-user": {
+    "approval-requested": null,
+    "approval-responded": null,
+    "awaiting-input": null,
+    complete: "resolved",
+    // A client-executed failure round-trips as an error result.
+    error: "resolved",
+    "input-complete": "unchanged",
+    "input-streaming": null,
+  },
+  "client-tool": {
+    "approval-requested": null,
+    "approval-responded": null,
+    "awaiting-input": null,
+    complete: "resolved",
+    error: "resolved",
+    "input-complete": "unchanged",
+    "input-streaming": null,
+  },
+} as const satisfies Record<
+  AwaitingUserInteraction["type"],
+  Record<TanStackToolCallState, "resolved" | "unchanged" | null>
+>;
+
+type GetResumedUserInteractionOptions = {
+  /** Interactions the persisted turn awaits (`getAwaitingUserInteractions`). */
+  awaited: readonly AwaitingUserInteraction[];
+  message: Pick<ChatMessage, "parts" | "role">;
+};
+
+/**
+ * Return the awaited interaction a client continuation is resolving. The turn
+ * store compares this identity with its canonical awaited interaction before
+ * any client-supplied assistant parts replace history. Resolution is defined
+ * against the awaited set, never by tool name or state alone: a completed
+ * server tool in the same message is not an answer to anything.
+ */
+export const getResumedUserInteraction = ({
+  awaited,
+  message,
+}: GetResumedUserInteractionOptions): AwaitingUserInteraction | null => {
+  if (message.role !== "assistant" || awaited.length === 0) {
     return null;
   }
-  let inputCompleteAskUser: AwaitingUserInteraction | null = null;
+  const awaitedByToolCallId = new Map(
+    awaited.map(
+      (interaction) => [interaction.toolCallId, interaction] as const,
+    ),
+  );
+  let unchangedAskUser: AwaitingUserInteraction | null = null;
   for (let index = message.parts.length - 1; index >= 0; index -= 1) {
     const part = message.parts[index];
-    if (part === undefined) {
+    if (part === undefined || part.type !== "tool-call") {
       continue;
     }
-    if (part.type !== "tool-call") {
+    const interaction = awaitedByToolCallId.get(part.id);
+    if (interaction === undefined) {
       continue;
     }
-    const interactionType = RESUMED_INTERACTION_TYPE_BY_TOOL_STATE[part.state];
-    if (interactionType === null) {
-      continue;
+    const resolution =
+      CLIENT_INTERACTION_RESOLUTION[interaction.type][part.state];
+    if (resolution === "resolved") {
+      return interaction;
     }
-    if (interactionType === "ask-user" && part.name !== "ask-user") {
-      continue;
+    // Prefer an explicit answer elsewhere in the message; retain the untouched
+    // ask-user call only as the legacy fallback.
+    if (resolution === "unchanged" && interaction.type === "ask-user") {
+      unchangedAskUser = interaction;
     }
-    // An unchanged ask-user call remains input-complete while the user acts
-    // on a later approval in the same message. Prefer the explicit approval
-    // response; retain input-complete only as the legacy ask-user fallback.
-    if (part.state === "input-complete") {
-      inputCompleteAskUser = { type: interactionType, toolCallId: part.id };
-      continue;
-    }
-    return { type: interactionType, toolCallId: part.id };
   }
-  return inputCompleteAskUser;
+  return unchangedAskUser;
 };
 
 export const toProviderVisibleMessages = (

--- a/apps/api/src/handlers/chat/chat-schema.ts
+++ b/apps/api/src/handlers/chat/chat-schema.ts
@@ -714,10 +714,6 @@ const validateContinuationToolCallIntegrity = ({
     }
   }
 
-  const resumedInteraction = getResumedUserInteraction({
-    parts: [...incomingParts],
-    role: "assistant",
-  });
   const awaitedInteractions = getAwaitingUserInteractions({
     parts: [...persistedParts],
     role: "assistant",
@@ -755,8 +751,8 @@ const validateContinuationToolCallIntegrity = ({
         return [];
       }
       const resumed = getResumedUserInteraction({
-        parts: [call],
-        role: "assistant",
+        awaited: awaitedInteractions,
+        message: { parts: [call], role: "assistant" },
       });
       return resumed === null ? [] : [{ call, interaction: resumed }];
     });
@@ -794,17 +790,6 @@ const validateContinuationToolCallIntegrity = ({
     ) {
       return invalidContinuationToolCall();
     }
-  }
-  if (resumedInteraction === null) {
-    return Result.ok();
-  }
-  const interaction = awaitedInteractions.find(
-    (candidate) =>
-      candidate.toolCallId === resumedInteraction.toolCallId &&
-      candidate.type === resumedInteraction.type,
-  );
-  if (interaction === undefined) {
-    return invalidContinuationToolCall();
   }
   return Result.ok();
 };

--- a/apps/api/src/handlers/chat/chat-turn-state.ts
+++ b/apps/api/src/handlers/chat/chat-turn-state.ts
@@ -11,7 +11,11 @@ export const CHAT_TURN_STATUSES = [
 ] as const;
 export type ChatTurnStatus = (typeof CHAT_TURN_STATUSES)[number];
 
-export const CHAT_TURN_INTERACTION_TYPES = ["ask-user", "approval"] as const;
+export const CHAT_TURN_INTERACTION_TYPES = [
+  "ask-user",
+  "approval",
+  "client-tool",
+] as const;
 export type ChatTurnInteractionType =
   (typeof CHAT_TURN_INTERACTION_TYPES)[number];
 

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -22,6 +22,8 @@ import {
   type ActiveFileSourceForModel,
 } from "@/api/handlers/chat/active-file-model-source";
 import {
+  chatMessageFromPersisted,
+  getAwaitingUserInteractions,
   getResumedUserInteraction,
   isChatPart,
   toPersistableChatMessage,
@@ -1216,7 +1218,18 @@ const sendMessage = createSafeRootHandler(
           claim: {
             acceptedTurnId: null,
             continuationInteraction:
-              getResumedUserInteraction(parsedMessage.message) ?? undefined,
+              getResumedUserInteraction({
+                awaited: getAwaitingUserInteractions(
+                  validationThreadState.persistedMessage === null
+                    ? null
+                    : chatMessageFromPersisted({
+                        content: validationThreadState.persistedMessage.content,
+                        id: parsedMessage.message.id,
+                        role: validationThreadState.persistedMessage.role,
+                      }),
+                ),
+                message: parsedMessage.message,
+              }) ?? undefined,
             incomingMessageId: parsedMessage.message.id,
             incomingMessageRole: parsedMessage.message.role,
             organizationId: session.activeOrganizationId,

--- a/apps/api/src/handlers/chat/stream-chat.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.test.ts
@@ -1,7 +1,19 @@
-import { EventType, StreamProcessor } from "@tanstack/ai";
-import type { ModelMessage, StreamChunk, ToolCallPart } from "@tanstack/ai";
+import {
+  chat,
+  EventType,
+  maxIterations,
+  StreamProcessor,
+  toolDefinition,
+} from "@tanstack/ai";
+import type {
+  AnyTextAdapter,
+  ModelMessage,
+  StreamChunk,
+  ToolCallPart,
+} from "@tanstack/ai";
 import { Result } from "better-result";
 import { describe, expect, spyOn, test } from "bun:test";
+import * as v from "valibot";
 
 import {
   CHAT_SEND_MODE,
@@ -18,6 +30,7 @@ import { CHAT_RUN_MODE } from "@/api/handlers/chat/chat-schema";
 import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
 import { resolveRegistryToolInputRefs } from "@/api/handlers/chat/tools/registry-adapter/input-ref-hydration";
 import { resolveRegistryToolOutputRefs } from "@/api/handlers/chat/tools/registry-adapter/output-ref-resolution";
+import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
 import type {
   ChatAnonRestoration,
   ChatMessage,
@@ -149,6 +162,317 @@ describe("agent sandbox third-party boundary", () => {
         runMode: CHAT_RUN_MODE.agent,
       }),
     ).toBeNull();
+  });
+});
+
+/**
+ * A text adapter that answers every model turn with one tool call. Driving the
+ * real `chat()` loop with it derives TanStack's interrupt boundary emission
+ * (MESSAGES_SNAPSHOT, then RUN_FINISHED with an `interrupt` outcome) instead of
+ * hand-writing the sequence, so the persistence path is checked against what
+ * the loop actually emits.
+ */
+const createSingleToolCallAdapter = ({
+  arguments: argumentsText,
+  toolName,
+}: {
+  arguments: string;
+  toolName: string;
+}): AnyTextAdapter =>
+  createToolCallSequenceAdapter([{ arguments: argumentsText, toolName }]);
+
+/**
+ * Answers the n-th model turn with the n-th tool call, so a run can execute a
+ * server tool first and pause for a client tool on the next iteration.
+ */
+const createToolCallSequenceAdapter = (
+  turns: readonly { arguments: string; toolName: string }[],
+): AnyTextAdapter => {
+  let turnIndex = 0;
+  return createScriptedAdapter(turns, () => {
+    const index = turnIndex;
+    turnIndex += 1;
+    return index;
+  });
+};
+
+const createScriptedAdapter = (
+  turns: readonly { arguments: string; toolName: string }[],
+  nextTurnIndex: () => number,
+): AnyTextAdapter => ({
+  kind: "text",
+  name: "single-tool-call",
+  model: "single-tool-call",
+  "~types": {
+    providerOptions: {},
+    inputModalities: ["text"],
+    messageMetadataByModality: {},
+    toolCapabilities: [],
+    toolCallMetadata: {},
+    systemPromptMetadata: undefined,
+  },
+  async *chatStream({ model, runId, threadId }) {
+    const turnIndex = nextTurnIndex();
+    const turn = turns.at(turnIndex);
+    if (turn === undefined) {
+      throw new Error("The fixture adapter ran out of scripted turns");
+    }
+    const { arguments: argumentsText, toolName } = turn;
+    const callId = `call-${String(turnIndex + 1)}`;
+    const resolvedRunId = runId ?? "run-1";
+    const resolvedThreadId = threadId ?? "thread-1";
+    const messageId = `provider-message-${String(turnIndex + 1)}`;
+    const timestamp = Date.now();
+    yield {
+      type: EventType.RUN_STARTED,
+      runId: resolvedRunId,
+      threadId: resolvedThreadId,
+      model,
+      timestamp,
+    } satisfies StreamChunk;
+    // Provider adapters open a text message only when text arrives; a
+    // tool-only iteration (Gemini, OpenAI Responses) carries no
+    // TEXT_MESSAGE_START, so only the first scripted turn emits one.
+    if (turnIndex === 0) {
+      yield {
+        type: EventType.TEXT_MESSAGE_START,
+        messageId,
+        role: "assistant",
+        model,
+        timestamp,
+      } satisfies StreamChunk;
+    }
+    yield {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: callId,
+      toolCallName: toolName,
+      // eslint-disable-next-line typescript/no-deprecated -- AG-UI still requires the compatibility field.
+      toolName,
+      parentMessageId: messageId,
+      model,
+      timestamp,
+    } satisfies StreamChunk;
+    yield {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: callId,
+      delta: argumentsText,
+      model,
+      timestamp,
+    } satisfies StreamChunk;
+    yield {
+      type: EventType.TOOL_CALL_END,
+      toolCallId: callId,
+      model,
+      timestamp,
+    } satisfies StreamChunk;
+    yield {
+      type: EventType.RUN_FINISHED,
+      runId: resolvedRunId,
+      threadId: resolvedThreadId,
+      finishReason: "tool_calls",
+      model,
+      timestamp,
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    } satisfies StreamChunk;
+  },
+  structuredOutput: () => {
+    throw new Error("Structured output is not part of this fixture");
+  },
+});
+
+const draftToolInputSchema = toTanStackToolSchema(
+  v.object({ name: v.string(), source: v.string() }),
+);
+
+type ProcessedStreamFinishEvent = Parameters<
+  Parameters<typeof processServerChatStream>[0]["onFinish"]
+>[0];
+
+/** Run the loop's emission through the same persistence path as `streamChat`. */
+const persistNativeInterruptTurn = async (
+  chunks: AsyncIterable<StreamChunk>,
+) => {
+  const messageId = toSafeId<"chatMessage">(
+    "11111111-1111-4111-8111-111111111111",
+  );
+  const mapMessageId = createChatMessageIdMapper(() => messageId);
+  let responseMessage: ChatMessage | null = null;
+  const processor = new StreamProcessor({
+    events: {
+      onStreamEnd: (message) => {
+        responseMessage = toChatMessage(message);
+      },
+    },
+  });
+  const terminal: { finish: ProcessedStreamFinishEvent | null } = {
+    finish: null,
+  };
+  const source: StreamChunk[] = [];
+  const observed = async function* (): AsyncIterable<StreamChunk> {
+    for await (const chunk of chunks) {
+      source.push(chunk);
+      yield chunk;
+    }
+  };
+  const emitted = await collectChunks(
+    processServerChatStream({
+      abortSignal: new AbortController().signal,
+      getResponseMessage: () => responseMessage,
+      mapMessageId,
+      onFinish: (event) => {
+        terminal.finish = event;
+      },
+      processor,
+      source: observed(),
+    }),
+  );
+  return { emitted, finish: terminal.finish, source };
+};
+
+describe("native interrupt boundary persistence", () => {
+  test("persists a client-tool turn the loop pauses for, and awaits the client", async () => {
+    const draftTool = toolDefinition({
+      name: "create-document",
+      description: "Client-executed draft",
+      inputSchema: draftToolInputSchema,
+    });
+    const { emitted, finish, source } = await persistNativeInterruptTurn(
+      chat({
+        adapter: createSingleToolCallAdapter({
+          arguments: '{"name":"NDA","source":"@title NDA"}',
+          toolName: "create-document",
+        }),
+        agentLoopStrategy: maxIterations(3),
+        messages: [{ role: "user", content: "Draft an NDA" }],
+        threadId: "thread-1",
+        tools: [draftTool],
+      }),
+    );
+
+    // The fixture must express the fault: the loop emits a snapshot before the
+    // interrupted run's finish. Without this the assertion below is vacuous.
+    const types = source.map((chunk) => chunk.type);
+    expect(types.indexOf(EventType.MESSAGES_SNAPSHOT)).toBeGreaterThan(-1);
+    expect(types.indexOf(EventType.MESSAGES_SNAPSHOT)).toBeLessThan(
+      types.lastIndexOf(EventType.RUN_FINISHED),
+    );
+
+    expect(emitted.some((chunk) => chunk.type === EventType.RUN_ERROR)).toBe(
+      false,
+    );
+    expect(finish?.outcome).toEqual({
+      type: "awaiting-user",
+      interaction: { type: "client-tool", toolCallId: "call-1" },
+    });
+    expect(finish?.responseMessage.parts).toEqual([
+      {
+        arguments: '{"name":"NDA","source":"@title NDA"}',
+        id: "call-1",
+        input: { name: "NDA", source: "@title NDA" },
+        name: "create-document",
+        state: "input-complete",
+        type: "tool-call",
+      },
+    ]);
+  });
+
+  test("persists an approval-gated turn the loop pauses for, and awaits the approval", async () => {
+    const approvalTool = toolDefinition({
+      name: "mcp__external__delete",
+      description: "Server tool behind an approval",
+      inputSchema: draftToolInputSchema,
+      needsApproval: true,
+    }).server(async () => "deleted");
+    const { emitted, finish, source } = await persistNativeInterruptTurn(
+      chat({
+        adapter: createSingleToolCallAdapter({
+          arguments: '{"name":"NDA","source":"@title NDA"}',
+          toolName: "mcp__external__delete",
+        }),
+        agentLoopStrategy: maxIterations(3),
+        messages: [{ role: "user", content: "Delete the NDA" }],
+        threadId: "thread-1",
+        tools: [approvalTool],
+      }),
+    );
+
+    expect(source.map((chunk) => chunk.type)).toContain(
+      EventType.MESSAGES_SNAPSHOT,
+    );
+    expect(emitted.some((chunk) => chunk.type === EventType.RUN_ERROR)).toBe(
+      false,
+    );
+    expect(finish?.outcome).toMatchObject({
+      type: "awaiting-user",
+      interaction: { type: "approval", toolCallId: "call-1" },
+    });
+    expect(finish?.responseMessage.parts).toMatchObject([
+      {
+        id: "call-1",
+        name: "mcp__external__delete",
+        state: "approval-requested",
+        type: "tool-call",
+      },
+    ]);
+  });
+
+  test("keeps a server tool's iteration in the same persisted turn as the client tool it precedes", async () => {
+    const lookupTool = toolDefinition({
+      name: "mcp__external__lookup",
+      description: "Server tool that runs before the draft",
+      inputSchema: draftToolInputSchema,
+    }).server(async () => ({ templates: [] }));
+    const draftTool = toolDefinition({
+      name: "create-document",
+      description: "Client-executed draft",
+      inputSchema: draftToolInputSchema,
+    });
+    const { emitted, finish } = await persistNativeInterruptTurn(
+      chat({
+        adapter: createToolCallSequenceAdapter([
+          {
+            arguments: '{"name":"NDA","source":"@title NDA"}',
+            toolName: "mcp__external__lookup",
+          },
+          {
+            arguments: '{"name":"NDA","source":"@title NDA"}',
+            toolName: "create-document",
+          },
+        ]),
+        agentLoopStrategy: maxIterations(3),
+        messages: [{ role: "user", content: "Draft an NDA" }],
+        threadId: "thread-1",
+        tools: [lookupTool, draftTool],
+      }),
+    );
+
+    expect(emitted.some((chunk) => chunk.type === EventType.RUN_ERROR)).toBe(
+      false,
+    );
+    expect(finish?.outcome).toEqual({
+      type: "awaiting-user",
+      interaction: { type: "client-tool", toolCallId: "call-2" },
+    });
+    expect(finish?.responseMessage.parts).toMatchObject([
+      { id: "call-1", name: "mcp__external__lookup", state: "complete" },
+      { toolCallId: "call-1", type: "tool-result" },
+      { id: "call-2", name: "create-document", state: "input-complete" },
+    ]);
+    // The client-facing snapshot presents the same single assistant message,
+    // under the persisted id, so the continuation targets the persisted turn.
+    const snapshot = emitted.find(
+      (chunk) => chunk.type === EventType.MESSAGES_SNAPSHOT,
+    );
+    if (snapshot?.type !== EventType.MESSAGES_SNAPSHOT) {
+      throw new Error("Expected the loop to emit a snapshot");
+    }
+    const assistantSnapshotMessages = snapshot.messages.filter(
+      (message) => message.role === "assistant",
+    );
+    expect(assistantSnapshotMessages).toHaveLength(1);
+    expect(assistantSnapshotMessages.at(0)?.id).toBe(
+      finish?.responseMessage.id,
+    );
   });
 });
 
@@ -348,7 +672,7 @@ describe("outgoing chat stream message ids", () => {
     expect(index).toBe(1);
   });
 
-  test("normalizes only new assistant ids in native AG-UI snapshots", async () => {
+  test("folds the run's assistant snapshot messages into the one persisted assistant message", async () => {
     const messageId = toSafeId<"chatMessage">(
       "11111111-1111-4111-8111-111111111111",
     );
@@ -376,11 +700,34 @@ describe("outgoing chat stream message ids", () => {
                 id: "provider-message-1",
                 role: "assistant",
                 content: "Checking the request",
+                toolCalls: [
+                  {
+                    id: "tool-lookup",
+                    type: "function",
+                    function: { name: "list_templates", arguments: "{}" },
+                  },
+                ],
+              },
+              {
+                id: "tool-lookup-result",
+                role: "tool",
+                toolCallId: "tool-lookup",
+                content: '{"templates":[]}',
               },
               {
                 id: "provider-message-2",
                 role: "assistant",
                 content: "Waiting for approval",
+                toolCalls: [
+                  {
+                    id: "tool-draft",
+                    type: "function",
+                    function: {
+                      name: "create-document",
+                      arguments: '{"name":"NDA","source":"@title NDA"}',
+                    },
+                  },
+                ],
               },
             ],
           },
@@ -420,15 +767,34 @@ describe("outgoing chat stream message ids", () => {
             role: "assistant",
             content: "Earlier answer",
           },
-          {
-            id: expect.any(String),
-            role: "assistant",
-            content: "Checking the request",
-          },
+          // One assistant message per persisted turn: both iterations' text and
+          // tool calls, under the turn's stable id, tool messages anchoring by
+          // toolCallId behind it.
           {
             id: messageId,
             role: "assistant",
-            content: "Waiting for approval",
+            content: "Checking the request\n\nWaiting for approval",
+            toolCalls: [
+              {
+                id: "tool-lookup",
+                type: "function",
+                function: { name: "list_templates", arguments: "{}" },
+              },
+              {
+                id: "tool-draft",
+                type: "function",
+                function: {
+                  name: "create-document",
+                  arguments: '{"name":"NDA","source":"@title NDA"}',
+                },
+              },
+            ],
+          },
+          {
+            id: "tool-lookup-result",
+            role: "tool",
+            toolCallId: "tool-lookup",
+            content: '{"templates":[]}',
           },
         ],
       },
@@ -452,12 +818,6 @@ describe("outgoing chat stream message ids", () => {
         value: { messageId: "assistant-previous" },
       },
     ]);
-    const snapshot = chunks.at(0);
-    expect(snapshot?.type).toBe(EventType.MESSAGES_SNAPSHOT);
-    if (snapshot?.type !== EventType.MESSAGES_SNAPSHOT) {
-      throw new Error("Expected a native message snapshot");
-    }
-    expect(snapshot.messages.at(2)?.id).not.toBe(snapshot.messages.at(3)?.id);
   });
 
   test("normalizes tanstack generated final assistant ids before persistence", () => {

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -1414,6 +1414,23 @@ const normalizeRunErrorChunk = (chunk: RunErrorChunk): RunErrorChunk => {
   };
 };
 
+type AwaitingInteraction = Extract<
+  ChatTurnOutcome,
+  { type: "awaiting-user" }
+>["interaction"];
+
+const awaitsCompleteInput = (interaction: AwaitingInteraction): boolean => {
+  switch (interaction.type) {
+    case "approval":
+      return false;
+    case "ask-user":
+    case "client-tool":
+      return true;
+    default:
+      return interaction satisfies never;
+  }
+};
+
 export const processServerChatStream = async function* ({
   abortSignal,
   existingMessageIds = new Set(),
@@ -1444,6 +1461,20 @@ export const processServerChatStream = async function* ({
     if (flushProcessor) {
       finalizeResponseProcessor(processor);
     }
+    // An empty completion is a provider outcome: the model produced no
+    // persistable part. A run that carried a complete tool call cannot be
+    // one; losing that call between the stream and the persistence
+    // processor is a defect in this pipeline, so it must not be graded as
+    // an anticipated provider state.
+    if (
+      (outcome.type === "completed" || outcome.type === "awaiting-user") &&
+      toolCallsWithCompleteInput.size > 0 &&
+      (getResponseMessage()?.parts.length ?? 0) === 0
+    ) {
+      panic(
+        "Persistence processor dropped an assistant turn that carried a complete tool call",
+      );
+    }
     const responseMessage = createTerminalResponseMessage({
       getResponseMessage,
       mapMessageId,
@@ -1473,19 +1504,34 @@ export const processServerChatStream = async function* ({
         sourceChunk.type === EventType.RUN_STARTED &&
         deferredRunFinishedChunks.length > 0
       ) {
-        // Continuation events such as `approval-requested` belong before the
-        // run's finish, but a later run does not. Register the later run with
-        // the server-side processor before closing the prior run so the
-        // processor keeps the shared assistant message active across a
-        // server-tool continuation. The client still receives the canonical
-        // FINISH(A), START(B) order. Without this internal overlap, TanStack
-        // finalizes after A and a tool-only B has no message-start event to
-        // reactivate, so its client-tool call is visible live but omitted from
-        // the persisted assistant turn.
-        processor.processChunk(sourceChunk);
+        // A later run in the same turn. The client always receives the
+        // canonical FINISH(A), START(B) order; what the persistence processor
+        // sees depends on whether B is a new run or another iteration of A.
+        //
+        // TanStack reuses one runId across the model iterations of a request
+        // (server tool executed, model called again). An intermediate finish
+        // with that same id would empty the processor's active-run set,
+        // finalize the shared assistant message, and leave a tool-only B (no
+        // TEXT_MESSAGE_START to reactivate it) appended to an inactive message
+        // that `onStreamEnd` never reports: the client-tool call is visible
+        // live but missing from the persisted turn. An intermediate finish
+        // never carries an interrupt (an interrupt ends the run), so the
+        // processor loses nothing by seeing only the terminal finish.
+        //
+        // A run with a different id (a fallback model attempt) must close the
+        // prior run for the processor, but only after B is registered, so the
+        // shared assistant message stays active across the attempts.
         const priorRunFinishedChunks = deferredRunFinishedChunks.splice(0);
-        for (const chunk of priorRunFinishedChunks) {
-          processor.processChunk(chunk);
+        const isSameRunIteration = priorRunFinishedChunks.every(
+          (chunk) =>
+            chunk.type === EventType.RUN_FINISHED &&
+            chunk.runId === sourceChunk.runId,
+        );
+        processor.processChunk(sourceChunk);
+        if (!isSameRunIteration) {
+          for (const chunk of priorRunFinishedChunks) {
+            processor.processChunk(chunk);
+          }
         }
         for (const chunk of priorRunFinishedChunks) {
           yield chunk;
@@ -1516,7 +1562,17 @@ export const processServerChatStream = async function* ({
         deferredRunFinishedChunks.push(chunk);
         continue;
       }
-      processor.processChunk(chunk);
+      // TanStack emits MESSAGES_SNAPSHOT before RUN_FINISHED at every
+      // interrupt boundary (client tool, approval) so the client can rehydrate.
+      // The persistence processor derives the assistant turn from the event
+      // stream itself; feeding it the snapshot resets its stream state, and the
+      // deferred RUN_FINISHED then finalizes with no active message, so
+      // `onStreamEnd` never fires and a turn that carries a complete tool call
+      // is persisted as an empty completion. Forward the snapshot; never
+      // process it.
+      if (chunk.type !== EventType.MESSAGES_SNAPSHOT) {
+        processor.processChunk(chunk);
+      }
       if (lifecycle === "failed") {
         if (chunk.type !== EventType.RUN_ERROR) {
           panic("Unhandled TanStack failed stream event");
@@ -1537,11 +1593,14 @@ export const processServerChatStream = async function* ({
     }
     const awaitingUserInteraction =
       getAwaitingUserInteraction(getResponseMessage());
-    const incompleteAskUserInteraction =
-      awaitingUserInteraction?.type === "ask-user" &&
+    // A client-resolved call whose input never finished (no TOOL_CALL_END)
+    // cannot be answered by any client, so the turn fails instead of waiting.
+    const incompleteClientInteraction =
+      awaitingUserInteraction !== null &&
+      awaitsCompleteInput(awaitingUserInteraction) &&
       !toolCallsWithCompleteInput.has(awaitingUserInteraction.toolCallId);
     let outcome: ChatTurnOutcome;
-    if (incompleteAskUserInteraction) {
+    if (incompleteClientInteraction) {
       outcome = { type: "failed", error: "unknown" };
     } else if (awaitingUserInteraction === null) {
       outcome = { type: "completed" };
@@ -1697,16 +1756,13 @@ export const remapOutgoingMessageIds = async function* ({
   source,
 }: RemapOutgoingMessageIdsProps): AsyncIterable<StreamChunk> {
   const snapshotMessageIds = new Map<string, SafeId<"chatMessage">>();
-  let primarySnapshotMessageIdAssigned = false;
   for await (const chunk of source) {
     yield remapChunkMessageId({
       chunk,
       existingMessageIds,
       mapMessageId,
       snapshotMessageIds,
-      primarySnapshotMessageIdAssigned,
     });
-    primarySnapshotMessageIdAssigned ||= snapshotMessageIds.size > 0;
   }
 };
 
@@ -1777,50 +1833,93 @@ type StreamChunkWithMessageId = StreamChunk & { messageId: string };
 const hasMessageId = (chunk: StreamChunk): chunk is StreamChunkWithMessageId =>
   "messageId" in chunk && typeof chunk.messageId === "string";
 
+type SnapshotMessage = Extract<
+  StreamChunk,
+  { type: EventType.MESSAGES_SNAPSHOT }
+>["messages"][number];
+
+/**
+ * A native snapshot carries one assistant message per model iteration, but the
+ * turn is persisted as ONE assistant message (every text and tool-call part of
+ * every iteration, under the id `mapMessageId` fixes for the turn). The client
+ * continues the persisted message, so the snapshot must present the same
+ * shape: the run's new assistant messages fold into that one message, and
+ * their tool messages keep anchoring by `toolCallId`.
+ */
+const mergeSnapshotAssistantMessages = ({
+  existingMessageIds,
+  mapMessageId,
+  messages,
+  snapshotMessageIds,
+}: {
+  existingMessageIds: ReadonlySet<string>;
+  mapMessageId: MessageIdMapper;
+  messages: readonly SnapshotMessage[];
+  snapshotMessageIds: Map<string, SafeId<"chatMessage">>;
+}): SnapshotMessage[] => {
+  const isNewAssistant = (
+    message: SnapshotMessage,
+  ): message is Extract<SnapshotMessage, { role: "assistant" }> =>
+    message.role === "assistant" && !existingMessageIds.has(message.id);
+  const newAssistantMessages = messages.filter(isNewAssistant);
+  const first = newAssistantMessages.at(0);
+  if (first === undefined) {
+    return [...messages];
+  }
+  const mergedId = mapMessageId(first.id);
+  const contents: string[] = [];
+  const toolCalls: NonNullable<
+    Extract<SnapshotMessage, { role: "assistant" }>["toolCalls"]
+  > = [];
+  for (const message of newAssistantMessages) {
+    snapshotMessageIds.set(message.id, mergedId);
+    if (typeof message.content === "string" && message.content.length > 0) {
+      contents.push(message.content);
+    }
+    if (message.toolCalls !== undefined) {
+      toolCalls.push(...message.toolCalls);
+    }
+  }
+  const { content: _content, toolCalls: _toolCalls, ...identity } = first;
+  const merged: SnapshotMessage = {
+    ...identity,
+    id: mergedId,
+    ...(contents.length === 0 ? {} : { content: contents.join("\n\n") }),
+    ...(toolCalls.length === 0 ? {} : { toolCalls }),
+  };
+  const result: SnapshotMessage[] = [];
+  for (const message of messages) {
+    if (message === first) {
+      result.push(merged);
+      continue;
+    }
+    if (!isNewAssistant(message)) {
+      result.push(message);
+    }
+  }
+  return result;
+};
+
 const remapChunkMessageId = ({
   chunk,
   existingMessageIds,
   mapMessageId,
-  primarySnapshotMessageIdAssigned,
   snapshotMessageIds,
 }: {
   chunk: StreamChunk;
   existingMessageIds: ReadonlySet<string>;
   mapMessageId: MessageIdMapper;
-  primarySnapshotMessageIdAssigned: boolean;
   snapshotMessageIds: Map<string, SafeId<"chatMessage">>;
 }): StreamChunk => {
   if (chunk.type === EventType.MESSAGES_SNAPSHOT) {
-    const newAssistantIds = chunk.messages
-      .filter(
-        (message) =>
-          message.role === "assistant" &&
-          !existingMessageIds.has(message.id) &&
-          !snapshotMessageIds.has(message.id),
-      )
-      .map(({ id }) => id);
-    const primarySourceId = primarySnapshotMessageIdAssigned
-      ? undefined
-      : newAssistantIds.at(-1);
     return {
       ...chunk,
-      messages: chunk.messages.map((message) =>
-        message.role !== "assistant" || existingMessageIds.has(message.id)
-          ? message
-          : {
-              ...message,
-              id:
-                snapshotMessageIds.get(message.id) ??
-                (() => {
-                  const id =
-                    message.id === primarySourceId
-                      ? mapMessageId(message.id)
-                      : createSafeId<"chatMessage">();
-                  snapshotMessageIds.set(message.id, id);
-                  return id;
-                })(),
-            },
-      ),
+      messages: mergeSnapshotAssistantMessages({
+        existingMessageIds,
+        mapMessageId,
+        messages: chunk.messages,
+        snapshotMessageIds,
+      }),
     };
   }
   const remapMessageId = (messageId: string): string =>

--- a/apps/api/src/handlers/chat/tools/native-chat-tool-names.ts
+++ b/apps/api/src/handlers/chat/tools/native-chat-tool-names.ts
@@ -1,3 +1,4 @@
+export const ASK_USER_TOOL_NAME = "ask-user";
 export const CREATE_DOCUMENT_TOOL_NAME = "create-document";
 export const CREATE_WORKSPACE_DOCUMENT_TOOL_NAME = "create_workspace_document";
 export const UPDATE_ENTITY_FIELDS_TOOL_NAME = "update-entity-fields";

--- a/apps/api/src/handlers/chat/tools/org-tools.ts
+++ b/apps/api/src/handlers/chat/tools/org-tools.ts
@@ -2,6 +2,7 @@ import { toolDefinition } from "@tanstack/ai";
 import * as v from "valibot";
 
 import type { ScopedDb } from "@/api/db/safe-db";
+import { ASK_USER_TOOL_NAME } from "@/api/handlers/chat/tools/native-chat-tool-names";
 import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
 import type { SafeId } from "@/api/lib/branded-types";
 
@@ -16,8 +17,8 @@ type OrgToolsContext = {
 };
 
 export const createOrgTools = (_context: OrgToolsContext) => ({
-  "ask-user": toolDefinition({
-    name: "ask-user",
+  [ASK_USER_TOOL_NAME]: toolDefinition({
+    name: ASK_USER_TOOL_NAME,
     description:
       "Ask the user clarifying questions before executing " +
       "a complex task. Use this when the request is " +

--- a/apps/api/src/handlers/chat/types.ts
+++ b/apps/api/src/handlers/chat/types.ts
@@ -90,7 +90,13 @@ export type ChatTurnOutcome =
       type: "awaiting-user";
       interaction:
         | { type: "approval"; toolCallId: string }
-        | { type: "ask-user"; toolCallId: string };
+        | { type: "ask-user"; toolCallId: string }
+        /**
+         * A client-executed tool (no server `execute`, e.g. create-document)
+         * whose input is complete and whose result the chat client posts back
+         * as a native interrupt resolution.
+         */
+        | { type: "client-tool"; toolCallId: string };
     }
   | { type: "completed" }
   | { type: "cancelled"; reason: "superseded" | "user-stop" }

--- a/apps/web/e2e/specs/chat.spec.ts
+++ b/apps/web/e2e/specs/chat.spec.ts
@@ -270,3 +270,48 @@ test("chat composer sends a message and renders the assistant reply", async ({
     1,
   );
 });
+
+// The mock model answers this marker with a `create-document` tool call (see
+// apps/api/src/dev/register-mock-ai.ts). That tool is client-executed, so the
+// run pauses at TanStack's native interrupt boundary, the client compiles the
+// draft into the inspector and posts the result back, and the continuation
+// answers with text. Every hop is asserted: the paused turn must persist, the
+// durable-turn claim must accept the resume, and no run error may surface.
+test("a client-executed draft tool pauses the turn, opens the draft, and resumes", async ({
+  page,
+}) => {
+  await page.goto("/chat", { waitUntil: "commit" });
+  const composer = page.getByRole("textbox", { name: /type your question/iu });
+  await expect(composer).toBeVisible({ timeout: 30_000 });
+  await composer.fill("Draft it as a document please: a mutual NDA.");
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect(page).toHaveURL(/\/chat\/[0-9a-f-]+$/u, { timeout: 30_000 });
+
+  // The compiled draft opens in the inspector with its own file composer.
+  await expect(
+    page.getByRole("textbox", { name: /chat about or edit Mutual NDA/iu }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // The continuation run answered with text: the transcript carries the reply
+  // and no error bubble ("Resend" renders on every ChatErrorMessage variant).
+  const transcript = page.getByRole("log");
+  await expect(
+    transcript.getByText("The draft is open in the panel"),
+  ).toBeVisible({ timeout: 30_000 });
+  await expect(transcript.getByRole("button", { name: "Retry" })).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(transcript.getByRole("button", { name: "Resend" })).toHaveCount(
+    0,
+  );
+
+  // The paused turn and its resumption survive a reload: the draft is
+  // re-settled from the persisted tool call, and the reply is still there.
+  await page.reload({ waitUntil: "commit" });
+  await expect(
+    transcript.getByText("The draft is open in the panel"),
+  ).toBeVisible({ timeout: 30_000 });
+  await expect(transcript.getByRole("button", { name: "Resend" })).toHaveCount(
+    0,
+  );
+});

--- a/apps/web/e2e/specs/chat.spec.ts
+++ b/apps/web/e2e/specs/chat.spec.ts
@@ -309,6 +309,9 @@ test("a client-executed draft tool pauses the turn, opens the draft, and resumes
   // re-settled from the persisted tool call, and the reply is still there.
   await page.reload({ waitUntil: "commit" });
   await expect(
+    page.getByRole("textbox", { name: /chat about or edit Mutual NDA/iu }),
+  ).toBeVisible({ timeout: 30_000 });
+  await expect(
     transcript.getByText("The draft is open in the panel"),
   ).toBeVisible({ timeout: 30_000 });
   await expect(transcript.getByRole("button", { name: "Resend" })).toHaveCount(

--- a/apps/web/src/components/chat-editor-markdown.logic.test.ts
+++ b/apps/web/src/components/chat-editor-markdown.logic.test.ts
@@ -50,7 +50,27 @@ describe("chat composer Markdown", () => {
     ).toEqual([
       {
         type: "paragraph",
-        content: [{ type: "text", text: "\\**doslova** a `**kód**`" }],
+        content: [{ type: "text", text: "**doslova** a `**kód**`" }],
+      },
+    ]);
+  });
+
+  test("resolves backslash escapes so model-written prompts hold plain text", () => {
+    // The submit boundary escapes `[` again, so a literal backslash in the
+    // editor would reach the transcript doubled: `\\[Party Name\\]`.
+    const source = String.raw`Use placeholders (e.g., \[Party Name\], \[Effective Date\]) and \*not bold\*.`;
+    expect(source).not.toBe(
+      "Use placeholders (e.g., [Party Name], [Effective Date]) and *not bold*.",
+    );
+    expect(createChatComposerDocument(source).content).toEqual([
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "Use placeholders (e.g., [Party Name], [Effective Date]) and *not bold*.",
+          },
+        ],
       },
     ]);
   });

--- a/apps/web/src/components/chat-editor-markdown.logic.test.ts
+++ b/apps/web/src/components/chat-editor-markdown.logic.test.ts
@@ -76,8 +76,7 @@ describe("chat composer Markdown", () => {
   });
 
   test("resolves escapes inside bold text and keeps code spans literal", () => {
-    const source =
-      `${String.raw`**\[Party Name\]** matches `  }\`\\(\\d+\\)\` and \`\`a\`\\*b\`\``;
+    const source = "**\\[Party Name\\]** matches `\\(\\d+\\)` and ``a`\\*b``";
     expect(createChatComposerDocument(source).content).toEqual([
       {
         type: "paragraph",

--- a/apps/web/src/components/chat-editor-markdown.logic.test.ts
+++ b/apps/web/src/components/chat-editor-markdown.logic.test.ts
@@ -74,4 +74,18 @@ describe("chat composer Markdown", () => {
       },
     ]);
   });
+
+  test("resolves escapes inside bold text and keeps code spans literal", () => {
+    const source =
+      `${String.raw`**\[Party Name\]** matches `  }\`\\(\\d+\\)\` and \`\`a\`\\*b\`\``;
+    expect(createChatComposerDocument(source).content).toEqual([
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "[Party Name]", marks: [{ type: "bold" }] },
+          { type: "text", text: " matches `\\(\\d+\\)` and ``a`\\*b``" },
+        ],
+      },
+    ]);
+  });
 });

--- a/apps/web/src/components/chat-editor-markdown.logic.ts
+++ b/apps/web/src/components/chat-editor-markdown.logic.ts
@@ -37,8 +37,24 @@ const collectStrongMatches = (
 const BACKSLASH_ESCAPE =
   /\\(?<punctuation>[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/gu;
 
-const unescapeMarkdownPunctuation = (text: string): string =>
-  text.replace(BACKSLASH_ESCAPE, "$<punctuation>");
+// A code span (a backtick run closed by a run of the same length) is literal in
+// CommonMark: `\*` inside one stays a backslash and a star.
+const CODE_SPAN = /(?<fence>`+)[\s\S]*?\k<fence>(?!`)/gu;
+
+const unescapeMarkdownPunctuation = (text: string): string => {
+  let result = "";
+  let cursor = 0;
+  for (const match of text.matchAll(CODE_SPAN)) {
+    result += text
+      .slice(cursor, match.index)
+      .replace(BACKSLASH_ESCAPE, "$<punctuation>");
+    result += match[0];
+    cursor = match.index + match[0].length;
+  }
+  return (
+    result + text.slice(cursor).replace(BACKSLASH_ESCAPE, "$<punctuation>")
+  );
+};
 
 const parseInlineStrong = (source: string): InlineNode[] => {
   const nodes: InlineNode[] = [];

--- a/apps/web/src/components/chat-editor-markdown.logic.ts
+++ b/apps/web/src/components/chat-editor-markdown.logic.ts
@@ -29,6 +29,17 @@ const collectStrongMatches = (
   return matches;
 };
 
+// CommonMark backslash escapes: a backslash before ASCII punctuation stands
+// for that character. Model-written prompts escape brackets and asterisks
+// (`\[Party Name\]`); the composer holds resolved text, and the submit
+// boundary re-escapes whatever it needs, so a literal backslash never leaks
+// into the sent prompt.
+const BACKSLASH_ESCAPE =
+  /\\(?<punctuation>[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/gu;
+
+const unescapeMarkdownPunctuation = (text: string): string =>
+  text.replace(BACKSLASH_ESCAPE, "$<punctuation>");
+
 const parseInlineStrong = (source: string): InlineNode[] => {
   const nodes: InlineNode[] = [];
   const matches = [
@@ -42,18 +53,24 @@ const parseInlineStrong = (source: string): InlineNode[] => {
       continue;
     }
     if (match.from > cursor) {
-      nodes.push({ type: "text", text: source.slice(cursor, match.from) });
+      nodes.push({
+        type: "text",
+        text: unescapeMarkdownPunctuation(source.slice(cursor, match.from)),
+      });
     }
     nodes.push({
       type: "text",
-      text: match.text,
+      text: unescapeMarkdownPunctuation(match.text),
       marks: [{ type: "bold" }],
     });
     cursor = match.to;
   }
 
   if (cursor < source.length) {
-    nodes.push({ type: "text", text: source.slice(cursor) });
+    nodes.push({
+      type: "text",
+      text: unescapeMarkdownPunctuation(source.slice(cursor)),
+    });
   }
   return nodes;
 };

--- a/apps/web/src/components/chat-editor-markdown.logic.ts
+++ b/apps/web/src/components/chat-editor-markdown.logic.ts
@@ -37,23 +37,56 @@ const collectStrongMatches = (
 const BACKSLASH_ESCAPE =
   /\\(?<punctuation>[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/gu;
 
-// A code span (a backtick run closed by a run of the same length) is literal in
-// CommonMark: `\*` inside one stays a backslash and a star.
-const CODE_SPAN = /(?<fence>`+)[\s\S]*?\k<fence>(?!`)/gu;
+const unescapeOutsideCodeSpans = (text: string): string =>
+  text.replace(BACKSLASH_ESCAPE, "$<punctuation>");
 
+const backtickRunLength = (text: string, index: number): number => {
+  let end = index;
+  while (text.charAt(end) === "`") {
+    end += 1;
+  }
+  return end - index;
+};
+
+/**
+ * Resolve escapes outside code spans only. A code span (a backtick run closed
+ * by a run of the same length) is literal in CommonMark: `\*` inside one stays
+ * a backslash and a star. Linear scan; an unclosed run is ordinary text.
+ */
 const unescapeMarkdownPunctuation = (text: string): string => {
   let result = "";
   let cursor = 0;
-  for (const match of text.matchAll(CODE_SPAN)) {
-    result += text
-      .slice(cursor, match.index)
-      .replace(BACKSLASH_ESCAPE, "$<punctuation>");
-    result += match[0];
-    cursor = match.index + match[0].length;
+  let index = 0;
+  while (index < text.length) {
+    if (text.charAt(index) !== "`") {
+      index += 1;
+      continue;
+    }
+    const fence = backtickRunLength(text, index);
+    let closeIndex = -1;
+    let scan = index + fence;
+    while (scan < text.length) {
+      if (text.charAt(scan) !== "`") {
+        scan += 1;
+        continue;
+      }
+      const run = backtickRunLength(text, scan);
+      if (run === fence) {
+        closeIndex = scan;
+        break;
+      }
+      scan += run;
+    }
+    if (closeIndex === -1) {
+      index += fence;
+      continue;
+    }
+    result += unescapeOutsideCodeSpans(text.slice(cursor, index));
+    result += text.slice(index, closeIndex + fence);
+    cursor = closeIndex + fence;
+    index = cursor;
   }
-  return (
-    result + text.slice(cursor).replace(BACKSLASH_ESCAPE, "$<punctuation>")
-  );
+  return result + unescapeOutsideCodeSpans(text.slice(cursor));
 };
 
 const parseInlineStrong = (source: string): InlineNode[] => {

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -236,7 +236,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 763,
+    "count": 764,
     "files": {
       "apps/api/scripts/ai-provider-canary-config.ts": 1,
       "apps/api/scripts/ai-provider-canary.ts": 4,
@@ -260,7 +260,7 @@
       "apps/api/src/db/schema.ts": 1,
       "apps/api/src/db/schema/case-law.ts": 1,
       "apps/api/src/db/schema/chat.ts": 2,
-      "apps/api/src/dev/register-mock-ai.ts": 1,
+      "apps/api/src/dev/register-mock-ai.ts": 2,
       "apps/api/src/handlers/agent-auth/events.ts": 1,
       "apps/api/src/handlers/ai-autocomplete/stream.ts": 1,
       "apps/api/src/handlers/audit-logs/query.ts": 3,
@@ -444,7 +444,7 @@
       "apps/web/src/components/ai-suggestions/host.tsx": 1,
       "apps/web/src/components/ai-suggestions/review-panel.impl.tsx": 1,
       "apps/web/src/components/autocomplete/use-autocomplete-stream.ts": 1,
-      "apps/web/src/components/chat-editor-provider.tsx": 8,
+      "apps/web/src/components/chat-editor-provider.tsx": 7,
       "apps/web/src/components/chat-mention-list.tsx": 2,
       "apps/web/src/components/chat/chat-anon-decorations-extension.ts": 1,
       "apps/web/src/components/chat/chat-thread-messages.tsx": 5,
@@ -484,7 +484,7 @@
       "apps/web/src/hooks/external-file-drop.logic.ts": 5,
       "apps/web/src/hooks/use-effect.ts": 2,
       "apps/web/src/lib/analytics/posthog.ts": 1,
-      "apps/web/src/lib/anonymize/anonymize-chat-worker-client.ts": 2,
+      "apps/web/src/lib/anonymize/anonymize-chat-worker-client.ts": 3,
       "apps/web/src/lib/anonymize/use-overlay-rects.ts": 1,
       "apps/web/src/lib/desktop-bridge.ts": 6,
       "apps/web/src/lib/dev-canary.ts": 1,


### PR DESCRIPTION
## Summary

A client-executed chat tool (`create-document`, `apply-active-docx-edits`, the folio doc tools) could not complete a turn: the paused turn was persisted as an empty completion (the user saw "The AI returned an empty reply", and the generated draft was lost on reload), and even a persisted turn could not be continued. Four defects, fixed end to end:

- **Snapshot resets the persistence processor.** TanStack emits `MESSAGES_SNAPSHOT` before `RUN_FINISHED` at every interrupt boundary (client tool, approval). The server-side `StreamProcessor` consumed it, which resets its stream state; the deferred finish then finalized with no active message, `onStreamEnd` never fired, and the turn was persisted with zero parts. The snapshot is now forwarded to the client only. Losing a complete tool call between the stream and the processor is a `panic`, not an anticipated provider outcome, so triage grades it as a defect.
- **Intermediate run finish drops a tool-only iteration.** TanStack reuses one `runId` across the model iterations of a request (server tool executed, model called again). Feeding the processor the intermediate `RUN_FINISHED` emptied its active-run set, finalized the shared assistant message, and a tool-only next iteration landed on an inactive message the processor never reported. Only a finish from a different run (fallback attempt) closes the prior run for the processor.
- **The durable-turn model knew only `ask-user` and `approval` pauses.** A native `client_tool_*` resume of any other client tool failed continuation validation ("does not match its awaited interaction") and the execution claim. This adds the `client-tool` interaction to `ChatTurnOutcome`, `CHAT_TURN_INTERACTION_TYPES`, and the `chat_turns` CHECK (migration `20260817220000`). Awaited interactions are derived from tool-call state (an `input-complete` call at run end is by construction one the client must resolve); resumed interactions are derived against the awaited set, never by tool name or state alone, so a completed server tool in the same message is not an answer.
- **Snapshot ids diverged from persistence.** The client-facing snapshot carried one assistant message per iteration under distinct ids while the turn persists as one message, so a server tool followed by a client tool could not be continued (the client echoed only the second message). The run's assistant snapshot messages now fold into the one persisted message; tool messages keep anchoring by `toolCallId`.

Also: prompts loaded into the composer (improve prompt, suggestions) keep CommonMark backslash escapes as literal text, and the submit boundary escaped them again (`\[Party Name\]` in the transcript). The composer document now resolves backslash escapes.

## Verification

- New tests drive the real `@tanstack/ai` chat loop with a scripted adapter through `processServerChatStream` (client tool, approval, server tool then client tool), so the interrupt boundary sequence is derived from the loop instead of hand-written; each fixture asserts it contains the snapshot before the finish. Mutation run: re-enabling snapshot processing fails all three.
- The mock model gains a `create-document` scenario; a new e2e spec covers draft, resume, reply, and reload without run errors. Passes locally against a `USE_MOCK_AI=true` stack.
- Live against a real provider: single-iteration and server-tool-then-client-tool drafting turns complete with the reply streamed and the draft open.
- Migration only widens the value CHECK; every existing row satisfies it.

## Follow-ups (not in this PR)

- TanStack calls no terminal middleware hook for a run that ends in an interrupt (contrary to its docs), so `$ai_generation` is not captured for those turns; metering (`onUsage`) is unaffected.
- Main chat composer and the inspector/file composers use different shells (`ChatInputSurface` vs `PromptBar`); unification is a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for client-executed tools in chat, including draft creation and resumed replies.
  * Improved persistence across multi-step tool interactions and page reloads.
  * Added clearer handling for approvals, completed tools, and tool errors.

* **Bug Fixes**
  * Fixed chat state and tool-call associations across streamed responses.
  * Markdown composer now correctly displays escaped punctuation as plain text.

* **Tests**
  * Added coverage for client tools, approvals, persistence, resumed chats, and Markdown escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->