### PR TITLE
chore: cover every fc.assert workspace with test:property

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "i18n:check": "bun ../../packages/scripts/src/i18n-typegen.ts src/i18n/langs --check && bun ../../packages/scripts/src/i18n-check.ts src/i18n/langs && bun ../../packages/scripts/src/glossary-gen.ts src/i18n --check && bun ../../packages/scripts/src/i18n-lint.ts src/i18n/langs && bun scripts/sync-prepaint-locales.ts --check",
     "i18n:sync": "bun ../../packages/scripts/src/i18n-check.ts src/i18n/langs --sync && bun ../../packages/scripts/src/i18n-typegen.ts src/i18n/langs && bun ../../packages/scripts/src/glossary-gen.ts src/i18n && bun scripts/sync-prepaint-locales.ts",
     "test": "bun test --path-ignore-patterns='e2e/**' && bun test e2e/unit",
+    "test:property": "bun test $(grep -rlF 'fc.assert' src --include='*.test.ts' --include='*.test.tsx')",
     "test:e2e": "playwright test --config e2e/playwright.config.ts",
     "test:e2e:marketing": "playwright test --config e2e/playwright.marketing.config.ts --project app",
     "test:e2e:marketing:update": "playwright test --config e2e/playwright.marketing.config.ts --project app --update-snapshots=all",

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "clean": "git clean -xdf .cache .turbo node_modules",
     "test": "bun test src",
+    "test:property": "bun test $(grep -rlF 'fc.assert' src --include='*.test.ts')",
     "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/api-contract",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/api-contract",

--- a/packages/boe/package.json
+++ b/packages/boe/package.json
@@ -45,6 +45,7 @@
     "build": "rm -rf dist && bun ../../packages/scripts/src/tsc-native.ts -p tsconfig.build.json",
     "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test src",
+    "test:property": "bun test $(grep -rlF 'fc.assert' src --include='*.test.ts')",
     "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/boe",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/boe",

--- a/packages/property-testing/src/convention.test.ts
+++ b/packages/property-testing/src/convention.test.ts
@@ -4,6 +4,34 @@ import path from "node:path";
 // Repo root, four levels up from this file (packages/property-testing/src).
 const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
 
+const TEST_FILE_GLOB = "{apps,packages}/**/*.test.{ts,tsx}";
+const PACKAGE_JSON_GLOB = "{apps,packages}/*/package.json";
+
+// The content marker every property runner selects files by: the api runner's
+// PROPERTY_TEST_MARKER and each package's `grep -rlF 'fc.assert'` script.
+const PROPERTY_MARKER = "fc.assert";
+const PROPERTY_SCRIPT = "test:property";
+
+// This guard names the marker in its own source and is not a property test.
+const SELF_PATH = "packages/property-testing/src/convention.test.ts";
+
+type PropertyTestFile = { relativePath: string; source: string };
+
+const collectPropertyTestFiles = async (): Promise<PropertyTestFile[]> => {
+  const glob = new Bun.Glob(TEST_FILE_GLOB);
+  const files: PropertyTestFile[] = [];
+  for await (const relativePath of glob.scan({ cwd: REPO_ROOT })) {
+    if (relativePath.includes("node_modules") || relativePath === SELF_PATH) {
+      continue;
+    }
+    const source = await Bun.file(path.resolve(REPO_ROOT, relativePath)).text();
+    if (source.includes(PROPERTY_MARKER)) {
+      files.push({ relativePath, source });
+    }
+  }
+  return files;
+};
+
 /**
  * Guard: every test that uses fast-check's `fc.assert` must route its
  * parameters through `propertyConfig` (from this package). That is what wires a
@@ -12,26 +40,50 @@ const REPO_ROOT = path.resolve(import.meta.dir, "../../..");
  * by their `fc.assert` content, so a missing `propertyConfig` import means a
  * property test that runs at a fixed budget forever. Catch it at the source.
  */
-const collectViolations = async (): Promise<string[]> => {
-  const glob = new Bun.Glob("{apps,packages}/**/*.test.{ts,tsx}");
-  const violations: string[] = [];
+const collectViolations = async (): Promise<string[]> =>
+  (await collectPropertyTestFiles())
+    .filter(({ source }) => !source.includes("@stll/property-testing"))
+    .map(({ relativePath }) => relativePath);
+
+// Workspace directory ("apps/web", "packages/boe") of a repo-relative path.
+const workspaceOf = (relativePath: string): string =>
+  relativePath.split("/").slice(0, 2).join("/");
+
+const collectPropertyScriptWorkspaces = async (): Promise<Set<string>> => {
+  const glob = new Bun.Glob(PACKAGE_JSON_GLOB);
+  const workspaces = new Set<string>();
   for await (const relativePath of glob.scan({ cwd: REPO_ROOT })) {
-    if (relativePath.includes("node_modules")) {
-      continue;
-    }
-    const source = await Bun.file(path.resolve(REPO_ROOT, relativePath)).text();
-    if (
-      source.includes("fc.assert") &&
-      !source.includes("@stll/property-testing")
-    ) {
-      violations.push(relativePath);
+    const manifest: { scripts?: Record<string, string> } = await Bun.file(
+      path.resolve(REPO_ROOT, relativePath),
+    ).json();
+    if (manifest.scripts?.[PROPERTY_SCRIPT] !== undefined) {
+      workspaces.add(workspaceOf(relativePath));
     }
   }
-  return violations;
+  return workspaces;
 };
 
 describe("property-test convention", () => {
   test("every fc.assert test imports propertyConfig", async () => {
     expect(await collectViolations()).toEqual([]);
+  });
+
+  /**
+   * Guard: the nightly property job runs `turbo run test:property`, so a
+   * property test in a workspace without that script never gets the scaled
+   * numRuns budget; it runs at its PR budget forever while looking covered.
+   * Conversely a workspace with the script but no property file would run
+   * its whole suite (`bun test` with an empty selection). Assert the two sets
+   * match in both directions.
+   */
+  test("workspaces with fc.assert tests and test:property scripts coincide", async () => {
+    const withPropertyTests = new Set(
+      (await collectPropertyTestFiles()).map(({ relativePath }) =>
+        workspaceOf(relativePath),
+      ),
+    );
+    const withScript = await collectPropertyScriptWorkspaces();
+    expect(withPropertyTests.size).toBeGreaterThan(0);
+    expect([...withPropertyTests].sort()).toEqual([...withScript].sort());
   });
 });


### PR DESCRIPTION
## Summary

- \`packages/boe\`, \`packages/api-contract\`, and \`apps/web\` contain fast-check property tests but had no \`test:property\` script, so the nightly property job (\`turbo run test:property\`) never scaled their \`numRuns\`. Add the same content-selected script the other packages use.
- Add a census to \`@stll/property-testing\`'s convention test: the set of workspaces containing \`fc.assert\` test files must equal the set declaring \`test:property\`, in both directions (a script with no property file would run the whole suite through an empty selection).

Mutation check: removing one of the new scripts fails the census with the workspace named in the diff.