### PR TITLE
feat(api): corpus pack format and range reader

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
@@ -191,6 +191,33 @@ test("redaction fences uploads before inspecting or deleting object keys", async
   expect(objectDelete).toBeGreaterThan(intentFence);
 });
 
+test("pointer columns and the success audit depend on every corpus object being gone", async () => {
+  const source = await Bun.file(caseLawErasureSource).text();
+  const erasure = source.indexOf("corpusErasure = await eraseCorpusObjects({");
+  const incompleteAudit = source.indexOf(
+    "await recordFailedRedactionAudit({",
+    erasure,
+  );
+  const pointerClear = source.indexOf(
+    ".set({ textS3Key: null, normalizedS3Key: null, astS3Key: null })",
+  );
+  const pointerGuard = source.lastIndexOf(
+    'if (corpusErasure.type === "deleted") {',
+    pointerClear,
+  );
+  const incompleteReturn = source.indexOf(
+    'return { type: "corpus-objects-remain", error: corpusErasure.error };',
+  );
+  const successAudit = source.indexOf('status: "succeeded"');
+
+  expect(erasure).toBeGreaterThan(-1);
+  expect(incompleteAudit).toBeGreaterThan(erasure);
+  expect(pointerGuard).toBeGreaterThan(incompleteAudit);
+  expect(pointerClear).toBeGreaterThan(pointerGuard);
+  expect(incompleteReturn).toBeGreaterThan(pointerClear);
+  expect(successAudit).toBeGreaterThan(incompleteReturn);
+});
+
 test("lease acquisition failures are audited after local redaction", async () => {
   const source = await Bun.file(caseLawErasureSource).text();
   const firstIrreversibleMutation = source.indexOf(

--- a/apps/api/src/handlers/case-law/erasure.test.ts
+++ b/apps/api/src/handlers/case-law/erasure.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CorpusObjectRetainedError,
+  eraseCorpusObjects,
+} from "@/api/handlers/case-law/erasure";
+import { formatCorpusLocation } from "@/api/lib/legal-search/corpus-location";
+import type { PackedCorpusLocation } from "@/api/lib/legal-search/corpus-location";
+import type { CorpusDeleteOutcome } from "@/api/lib/legal-search/corpus-storage";
+
+const objectKey =
+  "legal-corpus/documents/jurisdiction=SVK/d/h/sections.json.zst";
+const packedLocation: PackedCorpusLocation = {
+  type: "packed",
+  packKey: "legal-corpus/packs/jurisdiction=SVK/01912f6a.pack",
+  offset: 128,
+  length: 64,
+};
+const packedAddress = formatCorpusLocation(packedLocation);
+const keys = { textKey: packedAddress, sectionsKey: objectKey, astKey: null };
+
+const deleteReporting =
+  (outcome: CorpusDeleteOutcome) => async (): Promise<CorpusDeleteOutcome> =>
+    await Promise.resolve(outcome);
+
+describe("eraseCorpusObjects", () => {
+  test("a pointer into an object that holds other members is not reported erased", async () => {
+    // The delete itself resolves: the standalone sibling went, the shared
+    // object stayed. That resolution must not read as a complete erasure.
+    const erasure = await eraseCorpusObjects({
+      keys,
+      deleteCorpus: deleteReporting({
+        type: "shared-object-retained",
+        deletedKeys: [objectKey],
+        retained: [packedLocation],
+      }),
+    });
+
+    expect(erasure.type).toBe("incomplete");
+    if (erasure.type !== "incomplete") {
+      throw new Error("expected an incomplete erasure");
+    }
+    expect(erasure.error).toBeInstanceOf(CorpusObjectRetainedError);
+    expect(erasure.error).toMatchObject({
+      retained: [packedAddress],
+      message: expect.stringContaining(packedAddress),
+    });
+  });
+
+  test("a delete that resolves with every object gone is reported deleted", async () => {
+    expect(
+      await eraseCorpusObjects({
+        keys,
+        deleteCorpus: deleteReporting({ type: "deleted", keys: [objectKey] }),
+      }),
+    ).toEqual({ type: "deleted" });
+  });
+
+  test("a failed delete carries its cause", async () => {
+    const cause = new Error("bucket unreachable");
+    expect(
+      await eraseCorpusObjects({
+        keys,
+        deleteCorpus: async () => await Promise.reject(cause),
+      }),
+    ).toEqual({ type: "incomplete", error: cause });
+  });
+});

--- a/apps/api/src/handlers/case-law/erasure.ts
+++ b/apps/api/src/handlers/case-law/erasure.ts
@@ -1,3 +1,4 @@
+import { Result, TaggedError } from "better-result";
 import { and, eq, isNotNull, isNull, or } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
@@ -23,6 +24,7 @@ import {
 } from "@/api/lib/legal-search/case-law-corpus-upload-intents";
 import { removeDecisionFromIndex } from "@/api/lib/legal-search/case-law-search-index";
 import { CorpusIndexError } from "@/api/lib/legal-search/corpus-index-client";
+import { formatCorpusLocation } from "@/api/lib/legal-search/corpus-location";
 import { deleteCorpusDocument } from "@/api/lib/legal-search/corpus-storage";
 import {
   corpusIndexId,
@@ -44,13 +46,84 @@ import {
  * The decision row itself is kept (citation-graph node) but stripped of
  * personal text. `content_hash` is nulled so neither backfill loop
  * re-indexes the body. The erasure is recorded in case_law_index_jobs.
- *
- * Returns false if the decision does not exist.
  */
 type RedactInput = {
   decisionId: SafeId<"caseLawDecision">;
   scopedDb: ScopedDb;
   generation?: string;
+  /** Test seam; production deletes through the corpus bucket client. */
+  deleteCorpus?: typeof deleteCorpusDocument;
+};
+
+export type RedactCaseLawDecisionOutcome =
+  | { type: "not-found" }
+  /** Every store was scrubbed. */
+  | { type: "redacted" }
+  /**
+   * The row is redacted and every index copy removed, but at least one
+   * corpus object still holds the payload. Its pointer columns are kept as
+   * retry targets and a failed audit row records the cause.
+   */
+  | { type: "corpus-objects-remain"; error: unknown };
+
+/** A pointer named a range inside an object that holds other members. */
+export class CorpusObjectRetainedError extends TaggedError(
+  "CorpusObjectRetainedError",
+)<{
+  message: string;
+  retained: string[];
+}> {}
+
+type CorpusObjectErasure =
+  | { type: "deleted" }
+  /**
+   * At least one object still holds the payload, whether its DELETE failed
+   * or it holds other members and was left in place. Either way the pointer
+   * columns must stay as retry targets.
+   */
+  | { type: "incomplete"; error: unknown };
+
+type EraseCorpusObjectsOptions = {
+  keys: Parameters<typeof deleteCorpusDocument>[0];
+  deleteCorpus?: typeof deleteCorpusDocument;
+};
+
+/**
+ * Delete a decision's corpus objects and say whether every payload is gone.
+ * A pointer into an object that holds other members leaves that object in
+ * place, so its payload is not erased; that is reported the same way as a
+ * failed DELETE rather than as success.
+ */
+export const eraseCorpusObjects = async ({
+  keys,
+  deleteCorpus = deleteCorpusDocument,
+}: EraseCorpusObjectsOptions): Promise<CorpusObjectErasure> => {
+  const outcome = await Result.tryPromise({
+    try: async () => await deleteCorpus(keys),
+    // The cause travels unchanged into the audit row and telemetry.
+    catch: (cause) => cause,
+  });
+  if (Result.isError(outcome)) {
+    return { type: "incomplete", error: outcome.error };
+  }
+  switch (outcome.value.type) {
+    case "deleted":
+      return { type: "deleted" };
+    case "shared-object-retained": {
+      const retained = outcome.value.retained.map(formatCorpusLocation);
+      return {
+        type: "incomplete",
+        error: new CorpusObjectRetainedError({
+          message: `Corpus objects hold other members and are left in place: ${retained.join(", ")}`,
+          retained,
+        }),
+      };
+    }
+    default: {
+      const unhandled: never = outcome.value;
+      return unhandled;
+    }
+  }
 };
 
 type FailedRedactionAuditOptions = {
@@ -86,7 +159,8 @@ export const redactCaseLawDecision = async ({
   decisionId,
   scopedDb,
   generation = envBase.LEGAL_SEARCH_INDEX_GENERATION,
-}: RedactInput): Promise<boolean> => {
+  deleteCorpus = deleteCorpusDocument,
+}: RedactInput): Promise<RedactCaseLawDecisionOutcome> => {
   if (!isCaseLawCorpusGeneration(generation)) {
     const error = new CorpusIndexError({
       message: "Invalid corpus index generation",
@@ -140,7 +214,7 @@ export const redactCaseLawDecision = async ({
   });
 
   if (!fenced) {
-    return false;
+    return { type: "not-found" };
   }
   const { cancelledIntents, decision } = fenced;
 
@@ -173,24 +247,33 @@ export const redactCaseLawDecision = async ({
 
   // 2. Object-storage corpus payloads. Delete if ANY key is present: a
   // partially ingested decision (e.g. text written but AST not yet) must
-  // still have its personal data erased, not skipped.
-  let corpusObjectsDeleted = true;
+  // still have its personal data erased, not skipped. An incomplete erasure
+  // (a failed DELETE, or an object left in place because it holds other
+  // members) is recorded as a failed audit row so the outcome is visible.
+  let corpusErasure: CorpusObjectErasure = { type: "deleted" };
   if (
     decision.textS3Key !== null ||
     decision.normalizedS3Key !== null ||
     decision.astS3Key !== null
   ) {
-    try {
-      await deleteCorpusDocument({
+    corpusErasure = await eraseCorpusObjects({
+      keys: {
         textKey: decision.textS3Key,
         sectionsKey: decision.normalizedS3Key,
         astKey: decision.astS3Key,
-      });
-    } catch (error) {
-      corpusObjectsDeleted = false;
-      captureError(error, {
+      },
+      deleteCorpus,
+    });
+    if (corpusErasure.type === "incomplete") {
+      captureError(corpusErasure.error, {
         decisionId,
         step: "redactCaseLawDecision.deleteCorpusDocument",
+      });
+      await recordFailedRedactionAudit({
+        decisionId,
+        error: corpusErasure.error,
+        generation,
+        scopedDb,
       });
     }
   }
@@ -217,9 +300,10 @@ export const redactCaseLawDecision = async ({
     }
   }
 
-  // Clear pointers only after their delete succeeds; failed deletes retain
-  // exact retry targets while the tombstone already blocks every reader.
-  if (corpusObjectsDeleted) {
+  // Clear pointers only once every object is gone; an incomplete erasure
+  // retains exact retry targets while the tombstone already blocks every
+  // reader.
+  if (corpusErasure.type === "deleted") {
     // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
     await scopedDb((tx) => {
       // audit: skip — GDPR redaction; recorded in case_law_index_jobs below
@@ -456,6 +540,11 @@ export const redactCaseLawDecision = async ({
     auditedViaCorpusIndex = targets.size > 0;
   }
 
+  if (corpusErasure.type === "incomplete") {
+    // The failed audit row recorded above is the record of this erasure.
+    return { type: "corpus-objects-remain", error: corpusErasure.error };
+  }
+
   // Ensure the erasure is auditable even when corpus index isn't configured.
   if (!auditedViaCorpusIndex) {
     // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
@@ -471,5 +560,5 @@ export const redactCaseLawDecision = async ({
     });
   }
 
-  return true;
+  return { type: "redacted" };
 };

--- a/apps/api/src/lib/compression.test.ts
+++ b/apps/api/src/lib/compression.test.ts
@@ -1,11 +1,41 @@
 import { describe, expect, test } from "bun:test";
+import { randomFillSync } from "node:crypto";
 
 import {
   PayloadBudgetError,
   zstdCompress,
   zstdCompressAsync,
+  zstdCompressBound,
   zstdDecompressToStringBounded,
 } from "@/api/lib/compression";
+
+describe("zstdCompressBound", () => {
+  test("bounds the frame of incompressible input at every block regime", () => {
+    // Random bytes do not compress, so the frame carries the input plus
+    // frame and block overhead: larger than the input, never past the bound.
+    // Sizes straddle the 128 KiB point where zstd's own margin changes.
+    for (const size of [1, 17, 4096, 131_071, 131_072, 262_144, 1_000_003]) {
+      const input = new Uint8Array(size);
+      randomFillSync(input);
+      const frame = zstdCompress(input);
+      expect(frame.byteLength).toBeGreaterThan(size);
+      expect(frame.byteLength).toBeLessThanOrEqual(zstdCompressBound(size));
+    }
+    expect(zstdCompress(new Uint8Array()).byteLength).toBeLessThanOrEqual(
+      zstdCompressBound(0),
+    );
+  });
+
+  test("is monotonic and never below its input", () => {
+    let previous = zstdCompressBound(0);
+    for (let size = 1; size <= 4096; size += 1) {
+      const bound = zstdCompressBound(size);
+      expect(bound).toBeGreaterThan(size);
+      expect(bound).toBeGreaterThanOrEqual(previous);
+      previous = bound;
+    }
+  });
+});
 
 describe("bounded corpus compression", () => {
   test("async round-trip preserves the payload", async () => {

--- a/apps/api/src/lib/compression.ts
+++ b/apps/api/src/lib/compression.ts
@@ -12,7 +12,7 @@ import { zstdDecompress } from "node:zlib";
  * event-loop latency is irrelevant.
  */
 
-/** A corpus payload exceeded the decompressed-size ceiling. */
+/** A corpus payload exceeded a size ceiling (transfer or decompressed). */
 export class PayloadBudgetError extends TaggedError("PayloadBudgetError")<{
   message: string;
 }> {}

--- a/apps/api/src/lib/compression.ts
+++ b/apps/api/src/lib/compression.ts
@@ -17,6 +17,17 @@ export class PayloadBudgetError extends TaggedError("PayloadBudgetError")<{
   message: string;
 }> {}
 
+/**
+ * Upper bound on the size of a zstd frame that decodes to `inputBytes`
+ * bytes: a frame can exceed its input by frame and block overhead, so a
+ * ceiling on the transferred frame must sit above the ceiling on its
+ * decoded output. Follows `ZSTD_COMPRESSBOUND`, which adds one part in 256
+ * plus a margin that peaks at 64 bytes; the margin is applied at every size
+ * so the bound is monotonic and never below zstd's own.
+ */
+export const zstdCompressBound = (inputBytes: number): number =>
+  inputBytes + Math.ceil(inputBytes / 256) + 64;
+
 export const zstdCompress = (data: string | Uint8Array): Uint8Array => {
   const bytes = typeof data === "string" ? Buffer.from(data, "utf-8") : data;
   return Bun.zstdCompressSync(bytes);

--- a/apps/api/src/lib/legal-search/case-law-corpus-upload-intents.ts
+++ b/apps/api/src/lib/legal-search/case-law-corpus-upload-intents.ts
@@ -18,6 +18,7 @@ import {
   deleteCorpusDocument,
 } from "@/api/lib/legal-search/corpus-storage";
 import type {
+  CorpusDeleteOutcome,
   CorpusWriteOutcome,
   WriteCorpusResult,
 } from "@/api/lib/legal-search/corpus-storage";
@@ -454,7 +455,7 @@ type ReconcileCaseLawCorpusUploadIntentsOptions = {
       textKey: string | null;
     },
     options?: { signal?: AbortSignal },
-  ) => Promise<void>;
+  ) => Promise<CorpusDeleteOutcome>;
   limit: number;
   safeDb: SafeDb;
   signal?: AbortSignal;

--- a/apps/api/src/lib/legal-search/corpus-location.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-location.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { propertyConfig } from "@stll/property-testing";
+
+import {
+  formatCorpusLocation,
+  isPackedLocation,
+  parseCorpusLocation,
+} from "@/api/lib/legal-search/corpus-location";
+import type { PackedCorpusLocation } from "@/api/lib/legal-search/corpus-location";
+import { packKey } from "@/api/lib/legal-search/corpus-pack";
+
+// The row's key column is varchar(512); an address that does not fit is
+// unrepresentable, so the grammar is checked against that ceiling.
+const KEY_COLUMN_MAX_CHARS = 512;
+
+const jurisdiction = fc.stringMatching(/^[A-Z]{2,4}$/u);
+
+// UUIDv7 text: what `newCorpusPackId` produces.
+const packId = fc.uuid({ version: 7 });
+
+const packedLocation: fc.Arbitrary<PackedCorpusLocation> = fc
+  .record({
+    jurisdiction,
+    packId,
+    offset: fc.nat({ max: Number.MAX_SAFE_INTEGER }),
+    length: fc.nat({ max: Number.MAX_SAFE_INTEGER }),
+  })
+  .map(({ jurisdiction: j, packId: id, offset, length }) => ({
+    type: "packed",
+    packKey: packKey({ jurisdiction: j, packId: id }),
+    offset,
+    length,
+  }));
+
+describe("corpus location grammar", () => {
+  test("format then parse is the identity over packed addresses", () => {
+    fc.assert(
+      fc.property(packedLocation, (location) => {
+        const address = formatCorpusLocation(location);
+        expect(parseCorpusLocation(address)).toEqual(location);
+        expect(address.length).toBeLessThan(KEY_COLUMN_MAX_CHARS);
+      }),
+      propertyConfig({ numRuns: 300 }),
+    );
+  });
+
+  test("a value without the pack prefix is a plain object key", () => {
+    const key = "legal-corpus/documents/jurisdiction=SVK/doc/hash/text.zst";
+    const location = parseCorpusLocation(key);
+
+    expect(location).toEqual({ type: "object", key });
+    expect(isPackedLocation(location)).toBe(false);
+    expect(formatCorpusLocation(location)).toBe(key);
+  });
+
+  test("a pack key containing the address separators still round-trips", () => {
+    // `@` and `+` are legal in object keys; the anchored digit groups at
+    // the end decide where the address suffix begins.
+    const location: PackedCorpusLocation = {
+      type: "packed",
+      packKey: "legal-corpus/packs/jurisdiction=CZE/a@b+c.pack",
+      offset: 7,
+      length: 9,
+    };
+
+    expect(parseCorpusLocation(formatCorpusLocation(location))).toEqual(
+      location,
+    );
+  });
+
+  test("a value with the pack prefix that breaks the grammar panics", () => {
+    for (const malformed of [
+      "pack:",
+      "pack:legal-corpus/packs/x.pack",
+      "pack:legal-corpus/packs/x.pack@12",
+      "pack:legal-corpus/packs/x.pack@-1+4",
+      "pack:legal-corpus/packs/x.pack@1+4.5",
+      "pack:@1+4",
+    ]) {
+      expect(() => parseCorpusLocation(malformed)).toThrow(
+        "Malformed packed corpus address",
+      );
+    }
+  });
+
+  test("an integer beyond the safe range panics", () => {
+    expect(() =>
+      parseCorpusLocation("pack:legal-corpus/packs/x.pack@9007199254740993+1"),
+    ).toThrow("unrepresentable integer");
+  });
+});

--- a/apps/api/src/lib/legal-search/corpus-location.ts
+++ b/apps/api/src/lib/legal-search/corpus-location.ts
@@ -1,0 +1,84 @@
+import { panic } from "better-result";
+
+/**
+ * Where a corpus payload's bytes live.
+ *
+ * A row's key column (`text_s3_key`, `normalized_s3_key`, `ast_s3_key`)
+ * stores either a plain object key or a packed address: a byte range inside
+ * a larger immutable pack object (see corpus-pack.ts). Every reader goes
+ * through {@link parseCorpusLocation}, so a stored value of either form
+ * reads the same way.
+ *
+ * Textual form of a packed address: `pack:<packKey>@<offset>+<length>`, with
+ * offset and length as non-negative decimal safe integers. Anything that does
+ * not start with `pack:` is a plain object key.
+ */
+export type ObjectCorpusLocation = { type: "object"; key: string };
+
+export type PackedCorpusLocation = {
+  type: "packed";
+  packKey: string;
+  offset: number;
+  length: number;
+};
+
+export type CorpusLocation = ObjectCorpusLocation | PackedCorpusLocation;
+
+const PACKED_LOCATION_PREFIX = "pack:";
+
+// The pack key may itself contain `@` or `+`; the anchored digit groups at
+// the end make the last `@<digits>+<digits>` the address suffix regardless.
+const PACKED_LOCATION_PATTERN =
+  /^pack:(?<packKey>.+)@(?<offset>\d+)\+(?<length>\d+)$/u;
+
+const parseSafeInteger = (digits: string, address: string): number => {
+  const value = Number(digits);
+  if (!Number.isSafeInteger(value)) {
+    return panic(
+      `Packed corpus address carries an unrepresentable integer: ${address}`,
+    );
+  }
+  return value;
+};
+
+/**
+ * Decode a stored key column. A value that announces itself as packed but
+ * does not match the grammar is corruption of a stored pointer, not an
+ * expected runtime failure, so it panics rather than degrading to an
+ * object read of a nonsensical key.
+ */
+export const parseCorpusLocation = (value: string): CorpusLocation => {
+  if (!value.startsWith(PACKED_LOCATION_PREFIX)) {
+    return { type: "object", key: value };
+  }
+  const match = PACKED_LOCATION_PATTERN.exec(value);
+  const packKey = match?.groups?.["packKey"];
+  const offset = match?.groups?.["offset"];
+  const length = match?.groups?.["length"];
+  if (packKey === undefined || offset === undefined || length === undefined) {
+    return panic(`Malformed packed corpus address: ${value}`);
+  }
+  return {
+    type: "packed",
+    packKey,
+    offset: parseSafeInteger(offset, value),
+    length: parseSafeInteger(length, value),
+  };
+};
+
+export const formatCorpusLocation = (location: CorpusLocation): string => {
+  switch (location.type) {
+    case "object":
+      return location.key;
+    case "packed":
+      return `${PACKED_LOCATION_PREFIX}${location.packKey}@${location.offset}+${location.length}`;
+    default: {
+      const unhandled: never = location;
+      return panic(`Unhandled corpus location: ${String(unhandled)}`);
+    }
+  }
+};
+
+export const isPackedLocation = (
+  location: CorpusLocation,
+): location is PackedCorpusLocation => location.type === "packed";

--- a/apps/api/src/lib/legal-search/corpus-pack.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-pack.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test } from "bun:test";
+
+import { zstdCompress, zstdDecompressToString } from "@/api/lib/compression";
+import { formatCorpusLocation } from "@/api/lib/legal-search/corpus-location";
+import {
+  CorpusPackError,
+  decodePackFooter,
+  encodePack,
+  newCorpusPackId,
+  PACK_FORMAT_VERSION,
+  PACK_MAGIC,
+  packKey,
+  writeCorpusPack,
+} from "@/api/lib/legal-search/corpus-pack";
+import type { PackMemberInput } from "@/api/lib/legal-search/corpus-pack";
+
+const sha256 = (bytes: Uint8Array): string => {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(bytes);
+  return hasher.digest("hex");
+};
+
+const PACK_KEY = packKey({
+  jurisdiction: "SVK",
+  packId: "01912f6a-4b0c-7d3e-9a1b-2c3d4e5f6a7b",
+});
+
+const payloads = {
+  text: "Rozsudok v mene Slovenskej republiky.",
+  sections: JSON.stringify([
+    { index: 0, type: "header", title: null, text: "Rozsudok" },
+  ]),
+  ast: JSON.stringify(null),
+} as const;
+
+const members: PackMemberInput[] = [
+  {
+    kind: "text",
+    documentId: "0d2f4a5e-9c1b-4c62-8b1a-3f6f2f8f9e10",
+    contentHash: "a".repeat(64),
+    bytes: zstdCompress(payloads.text),
+  },
+  {
+    kind: "sections",
+    documentId: "0d2f4a5e-9c1b-4c62-8b1a-3f6f2f8f9e10",
+    contentHash: "a".repeat(64),
+    bytes: zstdCompress(payloads.sections),
+  },
+  {
+    kind: "ast",
+    documentId: "0d2f4a5e-9c1b-4c62-8b1a-3f6f2f8f9e10",
+    contentHash: "a".repeat(64),
+    bytes: zstdCompress(payloads.ast),
+  },
+];
+
+const trailerOf = (bytes: Uint8Array) => ({
+  magic: new TextDecoder().decode(bytes.subarray(bytes.byteLength - 8)),
+  footerLength: new DataView(
+    bytes.buffer,
+    bytes.byteOffset + bytes.byteLength - 16,
+    8,
+  ).getBigUint64(0, true),
+});
+
+describe("corpus pack round-trip", () => {
+  test("each member's range slice is the standalone object's bytes", async () => {
+    const { bytes, entries } = await encodePack({
+      packKey: PACK_KEY,
+      members,
+    });
+
+    expect(entries).toHaveLength(members.length);
+    for (const [index, entry] of entries.entries()) {
+      const input = members[index];
+      if (input === undefined) {
+        throw new Error("member index out of range");
+      }
+      const { offset, length } = entry.location;
+      const slice = bytes.subarray(offset, offset + length);
+      expect(entry.location.packKey).toBe(PACK_KEY);
+      expect(entry.member).toEqual({
+        offset,
+        length,
+        kind: input.kind,
+        documentId: input.documentId,
+        contentHash: input.contentHash,
+        sha256: sha256(input.bytes),
+      });
+      expect([...slice]).toEqual([...input.bytes]);
+      expect(zstdDecompressToString(slice)).toBe(payloads[input.kind]);
+    }
+    // Members are laid out contiguously from byte zero.
+    const expectedOffsets: number[] = [];
+    let cursor = 0;
+    for (const { bytes: memberBytes } of members) {
+      expectedOffsets.push(cursor);
+      cursor += memberBytes.byteLength;
+    }
+    expect(entries.map(({ location }) => location.offset)).toEqual(
+      expectedOffsets,
+    );
+  });
+
+  test("the footer decodes to the entries the encoder reported", async () => {
+    const { bytes, entries } = await encodePack({
+      packKey: PACK_KEY,
+      members,
+    });
+
+    const { magic, footerLength } = trailerOf(bytes);
+    expect(magic).toBe(PACK_MAGIC);
+    expect(footerLength).toBeGreaterThan(0n);
+
+    const footer = await decodePackFooter(bytes);
+    expect(footer.version).toBe(PACK_FORMAT_VERSION);
+    expect(footer.members).toEqual(entries.map(({ member }) => member));
+  });
+
+  test("an address formatted from an entry names the member's range", async () => {
+    const { entries } = await encodePack({ packKey: PACK_KEY, members });
+    const first = entries.at(0);
+    if (first === undefined) {
+      throw new Error("pack has no entries");
+    }
+
+    expect(formatCorpusLocation(first.location)).toBe(
+      `pack:${PACK_KEY}@0+${first.member.length}`,
+    );
+  });
+
+  test("an empty member list is refused", async () => {
+    let captured: unknown;
+    try {
+      await encodePack({ packKey: PACK_KEY, members: [] });
+    } catch (error) {
+      captured = error;
+    }
+    expect(captured).toBeInstanceOf(Error);
+  });
+});
+
+describe("decodePackFooter refuses malformed packs", () => {
+  const rejection = async (bytes: Uint8Array): Promise<unknown> =>
+    await decodePackFooter(bytes).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+  test("wrong magic", async () => {
+    const { bytes } = await encodePack({ packKey: PACK_KEY, members });
+    const corrupt = bytes.slice();
+    corrupt.set(new TextEncoder().encode("NOTAPACK"), corrupt.byteLength - 8);
+
+    const error = await rejection(corrupt);
+    expect(error).toBeInstanceOf(CorpusPackError);
+    expect(error).toMatchObject({ message: expect.stringContaining("magic") });
+  });
+
+  test("a footer length that does not fit the object", async () => {
+    const { bytes } = await encodePack({ packKey: PACK_KEY, members });
+    const corrupt = bytes.slice();
+    new DataView(
+      corrupt.buffer,
+      corrupt.byteOffset + corrupt.byteLength - 16,
+      8,
+    ).setBigUint64(0, BigInt(corrupt.byteLength), true);
+
+    const error = await rejection(corrupt);
+    expect(error).toBeInstanceOf(CorpusPackError);
+    expect(error).toMatchObject({
+      message: expect.stringContaining("footer length"),
+    });
+  });
+
+  test("a zero footer length", async () => {
+    const { bytes } = await encodePack({ packKey: PACK_KEY, members });
+    const corrupt = bytes.slice();
+    new DataView(
+      corrupt.buffer,
+      corrupt.byteOffset + corrupt.byteLength - 16,
+      8,
+    ).setBigUint64(0, 0n, true);
+
+    expect(await rejection(corrupt)).toBeInstanceOf(CorpusPackError);
+  });
+
+  test("an unsupported footer version", async () => {
+    const footer = zstdCompress(
+      JSON.stringify({ version: PACK_FORMAT_VERSION + 1, members: [] }),
+    );
+    const bytes = new Uint8Array(footer.byteLength + 16);
+    bytes.set(footer, 0);
+    new DataView(bytes.buffer, footer.byteLength, 8).setBigUint64(
+      0,
+      BigInt(footer.byteLength),
+      true,
+    );
+    bytes.set(new TextEncoder().encode(PACK_MAGIC), footer.byteLength + 8);
+
+    const error = await rejection(bytes);
+    expect(error).toBeInstanceOf(CorpusPackError);
+    expect(error).toMatchObject({
+      message: expect.stringContaining("malformed"),
+    });
+  });
+
+  test("a footer that is not zstd-compressed JSON", async () => {
+    const footer = new TextEncoder().encode("not zstd");
+    const bytes = new Uint8Array(footer.byteLength + 16);
+    bytes.set(footer, 0);
+    new DataView(bytes.buffer, footer.byteLength, 8).setBigUint64(
+      0,
+      BigInt(footer.byteLength),
+      true,
+    );
+    bytes.set(new TextEncoder().encode(PACK_MAGIC), footer.byteLength + 8);
+
+    expect(await rejection(bytes)).toBeInstanceOf(CorpusPackError);
+  });
+
+  test("a member that points outside the payload region", async () => {
+    const footer = zstdCompress(
+      JSON.stringify({
+        version: PACK_FORMAT_VERSION,
+        members: [
+          {
+            offset: 0,
+            length: 1,
+            kind: "text",
+            documentId: "d",
+            contentHash: "h",
+            sha256: "0".repeat(64),
+          },
+        ],
+      }),
+    );
+    // No payload bytes at all, so a member of length 1 cannot fit.
+    const bytes = new Uint8Array(footer.byteLength + 16);
+    bytes.set(footer, 0);
+    new DataView(bytes.buffer, footer.byteLength, 8).setBigUint64(
+      0,
+      BigInt(footer.byteLength),
+      true,
+    );
+    bytes.set(new TextEncoder().encode(PACK_MAGIC), footer.byteLength + 8);
+
+    const error = await rejection(bytes);
+    expect(error).toBeInstanceOf(CorpusPackError);
+    expect(error).toMatchObject({
+      message: expect.stringContaining("outside the payload region"),
+    });
+  });
+
+  test("a buffer shorter than the trailer", async () => {
+    expect(await rejection(new Uint8Array(3))).toBeInstanceOf(CorpusPackError);
+  });
+});
+
+describe("writeCorpusPack", () => {
+  test("PUTs the encoded pack once under the derived key", async () => {
+    const puts: { key: string; bytes: Uint8Array }[] = [];
+    const packId = newCorpusPackId();
+
+    const { packKey: key, entries } = await writeCorpusPack({
+      jurisdiction: "CZE",
+      packId,
+      members,
+      put: async (putKey, bytes) => {
+        puts.push({ key: putKey, bytes });
+        await Promise.resolve();
+      },
+    });
+
+    expect(key).toBe(`legal-corpus/packs/jurisdiction=CZE/${packId}.pack`);
+    expect(puts).toHaveLength(1);
+    const put = puts.at(0);
+    if (put === undefined) {
+      throw new Error("no PUT recorded");
+    }
+    expect(put.key).toBe(key);
+    expect((await decodePackFooter(put.bytes)).members).toEqual(
+      entries.map(({ member }) => member),
+    );
+    expect(entries.every(({ location }) => location.packKey === key)).toBe(
+      true,
+    );
+  });
+});

--- a/apps/api/src/lib/legal-search/corpus-pack.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-pack.test.ts
@@ -138,6 +138,26 @@ describe("corpus pack round-trip", () => {
     }
     expect(captured).toBeInstanceOf(Error);
   });
+
+  test("a zero-byte member is refused before any entry is generated", async () => {
+    // A zero-length range has no address a range read can express, so an
+    // encoder that accepted it would hand out an unreadable location.
+    const first = members.at(0);
+    if (first === undefined) {
+      throw new Error("fixture has no members");
+    }
+    const captured: unknown = await encodePack({
+      packKey: PACK_KEY,
+      members: [first, { ...first, kind: "ast", bytes: new Uint8Array() }],
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured).toMatchObject({
+      message: expect.stringContaining("carries no bytes"),
+    });
+  });
 });
 
 describe("decodePackFooter refuses malformed packs", () => {
@@ -254,6 +274,64 @@ describe("decodePackFooter refuses malformed packs", () => {
 
   test("a buffer shorter than the trailer", async () => {
     expect(await rejection(new Uint8Array(3))).toBeInstanceOf(CorpusPackError);
+  });
+
+  test("a buffer shorter than the trailer that still ends with the magic", async () => {
+    // 8 to 15 bytes: long enough to carry the magic, too short for the
+    // footer length field in front of it. Every length in the window must
+    // fail with the decoder's error, not a raw buffer-range error.
+    const magic = new TextEncoder().encode(PACK_MAGIC);
+    const window = Array.from(
+      { length: 16 - magic.byteLength },
+      (_, index) => magic.byteLength + index,
+    );
+    const errors = await Promise.all(
+      window.map(async (length) => {
+        const bytes = new Uint8Array(length);
+        bytes.set(magic, length - magic.byteLength);
+        return await rejection(bytes);
+      }),
+    );
+
+    expect(errors).toHaveLength(8);
+    for (const error of errors) {
+      expect(error).toBeInstanceOf(CorpusPackError);
+      expect(error).toMatchObject({
+        message: expect.stringContaining("shorter than"),
+      });
+    }
+  });
+
+  test("a footer member of zero length", async () => {
+    const footer = zstdCompress(
+      JSON.stringify({
+        version: PACK_FORMAT_VERSION,
+        members: [
+          {
+            offset: 0,
+            length: 0,
+            kind: "text",
+            documentId: "d",
+            contentHash: "h",
+            sha256: "0".repeat(64),
+          },
+        ],
+      }),
+    );
+    const bytes = new Uint8Array(footer.byteLength + 16);
+    bytes.set(footer, 0);
+    new DataView(bytes.buffer, footer.byteLength, 8).setBigUint64(
+      0,
+      BigInt(footer.byteLength),
+      true,
+    );
+    bytes.set(new TextEncoder().encode(PACK_MAGIC), footer.byteLength + 8);
+
+    const error = await rejection(bytes);
+    expect(error).toBeInstanceOf(CorpusPackError);
+    expect(error).toMatchObject({
+      message: expect.stringContaining("malformed"),
+    });
   });
 });
 

--- a/apps/api/src/lib/legal-search/corpus-pack.ts
+++ b/apps/api/src/lib/legal-search/corpus-pack.ts
@@ -1,0 +1,256 @@
+import { panic, Result, TaggedError } from "better-result";
+import * as v from "valibot";
+
+import {
+  zstdCompressAsync,
+  zstdDecompressToStringBounded,
+} from "@/api/lib/compression";
+import type { PackedCorpusLocation } from "@/api/lib/legal-search/corpus-location";
+import { LIMITS } from "@/api/lib/limits";
+import { putCorpusS3ObjectWithSignal } from "@/api/lib/s3";
+import { withTimeout } from "@/api/lib/with-timeout";
+
+/**
+ * Corpus pack format.
+ *
+ * A pack is one immutable object that concatenates corpus payloads, each
+ * addressed by byte range (see corpus-location.ts). Layout:
+ *
+ *   member₀ bytes | member₁ bytes | … | footer | footer length | magic
+ *
+ * Each member is exactly the bytes of the standalone object it stands for
+ * (the zstd frame), so a range read of a member decompresses through the
+ * same path as an object read. The footer is zstd-compressed JSON
+ * `{ version: 1, members: [{ offset, length, kind, documentId, contentHash,
+ * sha256 }] }`, followed by its own byte length as an 8-byte little-endian
+ * integer and the 8-byte magic `STLPACK1`. A reader that holds an address
+ * never needs the footer; the footer lists the members for a reader that
+ * holds only the pack.
+ */
+
+export const PACK_MAGIC = "STLPACK1";
+const PACK_MAGIC_BYTES = new TextEncoder().encode(PACK_MAGIC);
+const MAGIC_LENGTH = PACK_MAGIC_BYTES.byteLength;
+const FOOTER_LENGTH_FIELD_BYTES = 8;
+const TRAILER_LENGTH = FOOTER_LENGTH_FIELD_BYTES + MAGIC_LENGTH;
+export const PACK_FORMAT_VERSION = 1;
+const PACK_CONTENT_TYPE = "application/octet-stream";
+
+// Ceiling on the decoded footer, so a corrupt length field cannot ask for
+// an unbounded decode.
+const FOOTER_MAX_DECOMPRESSED_BYTES = 64 * 1024 * 1024;
+
+const PACK_MEMBER_KINDS = ["text", "sections", "ast"] as const;
+export type PackMemberKind = (typeof PACK_MEMBER_KINDS)[number];
+
+export class CorpusPackError extends TaggedError("CorpusPackError")<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+const packMemberSchema = v.object({
+  offset: v.pipe(v.number(), v.safeInteger(), v.minValue(0)),
+  length: v.pipe(v.number(), v.safeInteger(), v.minValue(0)),
+  kind: v.picklist(PACK_MEMBER_KINDS),
+  documentId: v.string(),
+  contentHash: v.string(),
+  sha256: v.pipe(v.string(), v.regex(/^[0-9a-f]{64}$/u)),
+});
+
+// Unknown keys are ignored: the version field, not the key set, decides
+// what a footer means.
+const packFooterSchema = v.object({
+  version: v.literal(PACK_FORMAT_VERSION),
+  members: v.array(packMemberSchema),
+});
+
+export type PackFooterMember = v.InferOutput<typeof packMemberSchema>;
+export type PackFooter = v.InferOutput<typeof packFooterSchema>;
+
+export type PackMemberInput = {
+  kind: PackMemberKind;
+  documentId: string;
+  contentHash: string;
+  /** The standalone object's bytes: the zstd frame, unchanged. */
+  bytes: Uint8Array;
+};
+
+export type PackedEntry = {
+  member: PackFooterMember;
+  location: PackedCorpusLocation;
+};
+
+type PackKeyInput = { jurisdiction: string; packId: string };
+
+/** Pack ids are UUIDv7. */
+export const newCorpusPackId = (): string => Bun.randomUUIDv7();
+
+export const packKey = ({ jurisdiction, packId }: PackKeyInput): string =>
+  `legal-corpus/packs/jurisdiction=${jurisdiction}/${packId}.pack`;
+
+const sha256Hex = (bytes: Uint8Array): string => {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(bytes);
+  return hasher.digest("hex");
+};
+
+type EncodePackInput = { packKey: string; members: PackMemberInput[] };
+
+type EncodedPack = { bytes: Uint8Array; entries: PackedEntry[] };
+
+export const encodePack = async ({
+  packKey: key,
+  members,
+}: EncodePackInput): Promise<EncodedPack> => {
+  if (members.length === 0) {
+    return panic("A corpus pack must carry at least one member");
+  }
+  const entries: PackedEntry[] = [];
+  let offset = 0;
+  for (const { kind, documentId, contentHash, bytes } of members) {
+    const member = {
+      offset,
+      length: bytes.byteLength,
+      kind,
+      documentId,
+      contentHash,
+      sha256: sha256Hex(bytes),
+    };
+    entries.push({
+      member,
+      location: {
+        type: "packed",
+        packKey: key,
+        offset,
+        length: bytes.byteLength,
+      },
+    });
+    offset += bytes.byteLength;
+  }
+  const footer = await zstdCompressAsync(
+    JSON.stringify({
+      version: PACK_FORMAT_VERSION,
+      members: entries.map(({ member }) => member),
+    } satisfies PackFooter),
+  );
+
+  const bytes = new Uint8Array(offset + footer.byteLength + TRAILER_LENGTH);
+  let cursor = 0;
+  for (const { bytes: memberBytes } of members) {
+    bytes.set(memberBytes, cursor);
+    cursor += memberBytes.byteLength;
+  }
+  bytes.set(footer, cursor);
+  cursor += footer.byteLength;
+  new DataView(bytes.buffer, bytes.byteOffset + cursor).setBigUint64(
+    0,
+    BigInt(footer.byteLength),
+    true,
+  );
+  cursor += FOOTER_LENGTH_FIELD_BYTES;
+  bytes.set(PACK_MAGIC_BYTES, cursor);
+  return { bytes, entries };
+};
+
+const magicMatches = (bytes: Uint8Array): boolean =>
+  bytes.byteLength >= MAGIC_LENGTH &&
+  PACK_MAGIC_BYTES.every(
+    (byte, index) => bytes[bytes.byteLength - MAGIC_LENGTH + index] === byte,
+  );
+
+/**
+ * Decode a whole pack's footer, refusing anything that does not read as a
+ * version-1 pack: wrong magic, a footer length that does not fit inside the
+ * object, or a member that points outside the payload region.
+ */
+export const decodePackFooter = async (
+  bytes: Uint8Array,
+): Promise<PackFooter> => {
+  if (!magicMatches(bytes)) {
+    throw new CorpusPackError({
+      message: "Corpus pack does not end with the pack magic",
+    });
+  }
+  const lengthField = new DataView(
+    bytes.buffer,
+    bytes.byteOffset + bytes.byteLength - TRAILER_LENGTH,
+    FOOTER_LENGTH_FIELD_BYTES,
+  ).getBigUint64(0, true);
+  const payloadEnd = bytes.byteLength - TRAILER_LENGTH;
+  if (lengthField === 0n || lengthField > BigInt(payloadEnd)) {
+    throw new CorpusPackError({
+      message: `Corpus pack footer length ${lengthField} does not fit a ${bytes.byteLength}-byte pack`,
+    });
+  }
+  const footerLength = Number(lengthField);
+  const footerStart = payloadEnd - footerLength;
+  const decoded = await Result.tryPromise({
+    try: async (): Promise<unknown> =>
+      JSON.parse(
+        await zstdDecompressToStringBounded(
+          bytes.subarray(footerStart, payloadEnd),
+          FOOTER_MAX_DECOMPRESSED_BYTES,
+        ),
+      ),
+    catch: (cause) =>
+      new CorpusPackError({
+        message: "Corpus pack footer does not decode as zstd-compressed JSON",
+        cause,
+      }),
+  });
+  if (Result.isError(decoded)) {
+    throw decoded.error;
+  }
+  const footer = v.safeParse(packFooterSchema, decoded.value);
+  if (!footer.success) {
+    throw new CorpusPackError({
+      message: `Corpus pack footer is malformed: ${footer.issues.map((issue) => issue.message).join("; ")}`,
+    });
+  }
+  for (const member of footer.output.members) {
+    if (member.offset + member.length > footerStart) {
+      throw new CorpusPackError({
+        message: `Corpus pack member at ${member.offset}+${member.length} lies outside the payload region`,
+      });
+    }
+  }
+  return footer.output;
+};
+
+type WriteCorpusPackInput = {
+  jurisdiction: string;
+  packId: string;
+  members: PackMemberInput[];
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  /** Test seam; production always PUTs through the corpus bucket client. */
+  put?: (key: string, bytes: Uint8Array, signal: AbortSignal) => Promise<void>;
+};
+
+type WriteCorpusPackResult = { packKey: string; entries: PackedEntry[] };
+
+const putPack = async (
+  key: string,
+  bytes: Uint8Array,
+  signal: AbortSignal,
+): Promise<void> =>
+  await putCorpusS3ObjectWithSignal(key, bytes, PACK_CONTENT_TYPE, signal);
+
+/** Encode the members and PUT the pack once under its derived key. */
+export const writeCorpusPack = async ({
+  jurisdiction,
+  packId,
+  members,
+  signal,
+  timeoutMs = LIMITS.corpusObjectIoTimeoutMs,
+  put = putPack,
+}: WriteCorpusPackInput): Promise<WriteCorpusPackResult> => {
+  const key = packKey({ jurisdiction, packId });
+  const { bytes, entries } = await encodePack({ packKey: key, members });
+  await withTimeout(async (writeSignal) => await put(key, bytes, writeSignal), {
+    label: "corpus-write-pack",
+    signal,
+    timeoutMs,
+  });
+  return { packKey: key, entries };
+};

--- a/apps/api/src/lib/legal-search/corpus-pack.ts
+++ b/apps/api/src/lib/legal-search/corpus-pack.ts
@@ -50,7 +50,8 @@ export class CorpusPackError extends TaggedError("CorpusPackError")<{
 
 const packMemberSchema = v.object({
   offset: v.pipe(v.number(), v.safeInteger(), v.minValue(0)),
-  length: v.pipe(v.number(), v.safeInteger(), v.minValue(0)),
+  // A member is a zstd frame, which is never empty; see encodePack.
+  length: v.pipe(v.number(), v.safeInteger(), v.minValue(1)),
   kind: v.picklist(PACK_MEMBER_KINDS),
   documentId: v.string(),
   contentHash: v.string(),
@@ -108,6 +109,14 @@ export const encodePack = async ({
   const entries: PackedEntry[] = [];
   let offset = 0;
   for (const { kind, documentId, contentHash, bytes } of members) {
+    // A zstd frame is never empty, and a zero-length range has no address
+    // a range read can express, so an empty member is refused before any
+    // entry is generated for it.
+    if (bytes.byteLength === 0) {
+      return panic(
+        `Corpus pack member ${kind} for ${documentId} carries no bytes`,
+      );
+    }
     const member = {
       offset,
       length: bytes.byteLength,
@@ -153,19 +162,26 @@ export const encodePack = async ({
 };
 
 const magicMatches = (bytes: Uint8Array): boolean =>
-  bytes.byteLength >= MAGIC_LENGTH &&
   PACK_MAGIC_BYTES.every(
     (byte, index) => bytes[bytes.byteLength - MAGIC_LENGTH + index] === byte,
   );
 
 /**
  * Decode a whole pack's footer, refusing anything that does not read as a
- * version-1 pack: wrong magic, a footer length that does not fit inside the
- * object, or a member that points outside the payload region.
+ * version-1 pack: an object shorter than the trailer, wrong magic, a footer
+ * length that does not fit inside the object, or a member that points
+ * outside the payload region. Every refusal is a {@link CorpusPackError}.
  */
 export const decodePackFooter = async (
   bytes: Uint8Array,
 ): Promise<PackFooter> => {
+  // The trailer (footer length + magic) is read as a whole; checking the
+  // full length first keeps the magic and length reads inside the buffer.
+  if (bytes.byteLength < TRAILER_LENGTH) {
+    throw new CorpusPackError({
+      message: `Corpus pack of ${bytes.byteLength} bytes is shorter than the ${TRAILER_LENGTH}-byte trailer`,
+    });
+  }
   if (!magicMatches(bytes)) {
     throw new CorpusPackError({
       message: "Corpus pack does not end with the pack magic",

--- a/apps/api/src/lib/legal-search/corpus-storage.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-storage.test.ts
@@ -1,21 +1,28 @@
 import { describe, expect, test } from "bun:test";
 
 import { CASE_LAW_CORPUS_MIRROR_STATUS } from "@/api/db/schema";
-import { zstdCompress } from "@/api/lib/compression";
+import { PayloadBudgetError, zstdCompress } from "@/api/lib/compression";
 import { CORPUS_STORAGE_MODES } from "@/api/lib/corpus-storage-mode";
 import {
   CorpusPayloadUnavailableError,
   TimeoutError,
 } from "@/api/lib/errors/tagged-errors";
 import {
+  formatCorpusLocation,
+  parseCorpusLocation,
+} from "@/api/lib/legal-search/corpus-location";
+import type { PackedCorpusLocation } from "@/api/lib/legal-search/corpus-location";
+import {
   corpusContentHash,
   corpusKeys,
   corpusMirrorColumns,
   corpusPayloadDisposition,
+  deleteCorpusDocument,
   EMPTY_CORPUS_CONTENT_HASHES,
   parsePersistedCorpusAst,
   parsePersistedCorpusSections,
   planCorpusDocumentWrite,
+  readCorpusBytesAt,
   readCorpusPayloadOrFallback,
   readCorpusText,
   storedCorpusWrite,
@@ -423,5 +430,146 @@ describe("planCorpusDocumentWrite", () => {
         contentHash: stored.contentHash,
       }),
     ).toEqual(stored);
+  });
+});
+
+describe("readCorpusBytesAt", () => {
+  const packKey = "legal-corpus/packs/jurisdiction=SVK/01912f6a.pack";
+  const pack = new Uint8Array(64).map((_, index) => index);
+  const fakeRange = async ({
+    key,
+    offset,
+    length,
+  }: {
+    key: string;
+    offset: number;
+    length: number;
+  }): Promise<Uint8Array> => {
+    expect(key).toBe(packKey);
+    return await Promise.resolve(pack.subarray(offset, offset + length));
+  };
+  const neverObject = async (): Promise<Uint8Array> =>
+    await Promise.reject(new Error("object read must not run"));
+  const neverRange = async (): Promise<Uint8Array> =>
+    await Promise.reject(new Error("range read must not run"));
+
+  test("a packed address reads exactly its range through the range reader", async () => {
+    const bytes = await readCorpusBytesAt({
+      location: { type: "packed", packKey, offset: 10, length: 5 },
+      maxBytes: 1024,
+      signal: new AbortController().signal,
+      readObject: neverObject,
+      readRange: fakeRange,
+    });
+
+    expect([...bytes]).toEqual([10, 11, 12, 13, 14]);
+  });
+
+  test("a packed address whose length exceeds the ceiling is refused before any read", async () => {
+    let ranges = 0;
+    const rejection: unknown = await readCorpusBytesAt({
+      location: { type: "packed", packKey, offset: 0, length: 1025 },
+      maxBytes: 1024,
+      signal: new AbortController().signal,
+      readObject: neverObject,
+      readRange: async (options) => {
+        ranges += 1;
+        return await fakeRange(options);
+      },
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBeInstanceOf(PayloadBudgetError);
+    expect(ranges).toBe(0);
+  });
+
+  test("an object key reads through the bounded object reader", async () => {
+    const seen: { key: string; maxBytes: number }[] = [];
+    const bytes = await readCorpusBytesAt({
+      location: { type: "object", key: "legal-corpus/x/text.zst" },
+      maxBytes: 77,
+      signal: new AbortController().signal,
+      readObject: async ({ key, maxBytes }) => {
+        seen.push({ key, maxBytes });
+        return await Promise.resolve(new Uint8Array([1, 2, 3]));
+      },
+      readRange: neverRange,
+    });
+
+    expect([...bytes]).toEqual([1, 2, 3]);
+    expect(seen).toEqual([{ key: "legal-corpus/x/text.zst", maxBytes: 77 }]);
+  });
+
+  test("readCorpusText accepts a packed address as its stored key", async () => {
+    // The member bytes are the same zstd frame a standalone object holds.
+    const member = zstdCompress("packed corpus text");
+    const address = formatCorpusLocation({
+      type: "packed",
+      packKey,
+      offset: 3,
+      length: member.byteLength,
+    });
+    expect(parseCorpusLocation(address)).toMatchObject({ type: "packed" });
+
+    const text = await readCorpusText(address, {
+      read: async () => await Promise.resolve(member),
+      timeoutMs: 1000,
+    });
+
+    expect(text).toBe("packed corpus text");
+  });
+});
+
+describe("deleteCorpusDocument", () => {
+  const objectKey =
+    "legal-corpus/documents/jurisdiction=SVK/d/h/sections.json.zst";
+  const packedLocation: PackedCorpusLocation = {
+    type: "packed",
+    packKey: "legal-corpus/packs/jurisdiction=SVK/01912f6a.pack",
+    offset: 128,
+    length: 64,
+  };
+  const packedAddress = formatCorpusLocation(packedLocation);
+
+  test("a packed address issues no DELETE and reports the shared object retained", async () => {
+    const deleted: string[] = [];
+    const outcome = await deleteCorpusDocument(
+      { textKey: packedAddress, sectionsKey: objectKey, astKey: null },
+      {
+        deleteObject: async (key) => {
+          deleted.push(key);
+          await Promise.resolve();
+        },
+      },
+    );
+
+    expect(deleted).toEqual([objectKey]);
+    expect(outcome).toEqual({
+      type: "shared-object-retained",
+      deletedKeys: [objectKey],
+      retained: [packedLocation],
+    });
+  });
+
+  test("plain object keys are deleted and reported as such", async () => {
+    const deleted: string[] = [];
+    const outcome = await deleteCorpusDocument(
+      {
+        textKey: "legal-corpus/documents/jurisdiction=SVK/d/h/text.zst",
+        sectionsKey: null,
+        astKey: "legal-corpus/documents/jurisdiction=SVK/d/h/ast.json.zst",
+      },
+      {
+        deleteObject: async (key) => {
+          deleted.push(key);
+          await Promise.resolve();
+        },
+      },
+    );
+
+    expect(deleted).toHaveLength(2);
+    expect(outcome).toEqual({ type: "deleted", keys: deleted });
   });
 });

--- a/apps/api/src/lib/legal-search/corpus-storage.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-storage.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { randomFillSync } from "node:crypto";
 
 import { CASE_LAW_CORPUS_MIRROR_STATUS } from "@/api/db/schema";
-import { PayloadBudgetError, zstdCompress } from "@/api/lib/compression";
+import {
+  PayloadBudgetError,
+  zstdCompress,
+  zstdCompressBound,
+} from "@/api/lib/compression";
 import { CORPUS_STORAGE_MODES } from "@/api/lib/corpus-storage-mode";
 import {
   CorpusPayloadUnavailableError,
@@ -17,6 +22,7 @@ import {
   corpusKeys,
   corpusMirrorColumns,
   corpusPayloadDisposition,
+  CORPUS_TRANSFER_MAX_BYTES,
   deleteCorpusDocument,
   EMPTY_CORPUS_CONTENT_HASHES,
   parsePersistedCorpusAst,
@@ -33,6 +39,7 @@ import type {
   WriteCorpusResult,
 } from "@/api/lib/legal-search/corpus-storage";
 import { EMPTY_AST } from "@/api/lib/legal-search/document-types";
+import { LIMITS } from "@/api/lib/limits";
 
 describe("corpus mirror state columns", () => {
   test("partition pending and settled pointer states", () => {
@@ -127,7 +134,7 @@ describe("readCorpusText bounded corpus read", () => {
         // Intentionally never calls resolve/reject.
       });
       await readCorpusText("legal-corpus/never/text.zst", {
-        read: async () => await neverSettles,
+        readObject: async () => await neverSettles,
         timeoutMs: 25,
       });
     } catch (error) {
@@ -139,12 +146,39 @@ describe("readCorpusText bounded corpus read", () => {
   });
 
   test("returns the decompressed text when the read settles in time", async () => {
+    const seen: { key: string; maxBytes: number }[] = [];
     const text = await readCorpusText("legal-corpus/ok/text.zst", {
-      read: async () => zstdCompress("hello corpus"),
+      readObject: async ({ key, maxBytes }) => {
+        seen.push({ key, maxBytes });
+        return await Promise.resolve(zstdCompress("hello corpus"));
+      },
       timeoutMs: 1000,
     });
 
     expect(text).toBe("hello corpus");
+    expect(seen).toEqual([
+      { key: "legal-corpus/ok/text.zst", maxBytes: CORPUS_TRANSFER_MAX_BYTES },
+    ]);
+  });
+
+  test("the transfer ceiling admits a frame at zstd's bound over the decompressed ceiling", () => {
+    // Incompressible input yields a frame larger than the input; the
+    // transfer ceiling must therefore sit above the decompressed one by at
+    // least that overhead, or a valid payload at the decompressed ceiling
+    // could be refused before decoding.
+    const random = new Uint8Array(4096);
+    randomFillSync(random);
+    const frame = zstdCompress(random);
+    expect(frame.byteLength).toBeGreaterThan(random.byteLength);
+    expect(frame.byteLength).toBeLessThanOrEqual(
+      zstdCompressBound(random.byteLength),
+    );
+    expect(CORPUS_TRANSFER_MAX_BYTES).toBe(
+      zstdCompressBound(LIMITS.corpusPayloadMaxDecompressedBytes),
+    );
+    expect(CORPUS_TRANSFER_MAX_BYTES).toBeGreaterThan(
+      LIMITS.corpusPayloadMaxDecompressedBytes,
+    );
   });
 });
 
@@ -513,12 +547,64 @@ describe("readCorpusBytesAt", () => {
     });
     expect(parseCorpusLocation(address)).toMatchObject({ type: "packed" });
 
+    // Only the byte sources are stubbed; the stored value still travels
+    // through the reader's own parsing and routing, so the range reader is
+    // what must serve it, with the offset and length the address carries.
+    const seen: { key: string; offset: number; length: number }[] = [];
     const text = await readCorpusText(address, {
-      read: async () => await Promise.resolve(member),
+      readObject: neverObject,
+      readRange: async ({ key, offset, length }) => {
+        seen.push({ key, offset, length });
+        return await Promise.resolve(member);
+      },
       timeoutMs: 1000,
     });
 
     expect(text).toBe("packed corpus text");
+    expect(seen).toEqual([
+      { key: packKey, offset: 3, length: member.byteLength },
+    ]);
+  });
+
+  test("the packed length check and the object ceiling share the transfer bound", async () => {
+    const seen: number[] = [];
+    await readCorpusText("legal-corpus/x/text.zst", {
+      readObject: async ({ maxBytes }) => {
+        seen.push(maxBytes);
+        return await Promise.resolve(zstdCompress("x"));
+      },
+      timeoutMs: 1000,
+    });
+    const atBound = formatCorpusLocation({
+      type: "packed",
+      packKey,
+      offset: 0,
+      length: CORPUS_TRANSFER_MAX_BYTES,
+    });
+    const pastBound = formatCorpusLocation({
+      type: "packed",
+      packKey,
+      offset: 0,
+      length: CORPUS_TRANSFER_MAX_BYTES + 1,
+    });
+    const rangeReads: number[] = [];
+    const readRange = async ({ length }: { length: number }) => {
+      rangeReads.push(length);
+      return await Promise.resolve(zstdCompress("x"));
+    };
+
+    await readCorpusText(atBound, { readObject: neverObject, readRange });
+    const rejection: unknown = await readCorpusText(pastBound, {
+      readObject: neverObject,
+      readRange,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(seen).toEqual([CORPUS_TRANSFER_MAX_BYTES]);
+    expect(rangeReads).toEqual([CORPUS_TRANSFER_MAX_BYTES]);
+    expect(rejection).toBeInstanceOf(PayloadBudgetError);
   });
 });
 

--- a/apps/api/src/lib/legal-search/corpus-storage.ts
+++ b/apps/api/src/lib/legal-search/corpus-storage.ts
@@ -9,11 +9,17 @@ import {
 import { CASE_LAW_CORPUS_MIRROR_STATUS } from "@/api/db/schema";
 import { captureError } from "@/api/lib/analytics/capture";
 import {
+  PayloadBudgetError,
   zstdCompressAsync,
   zstdDecompressToStringBounded,
 } from "@/api/lib/compression";
 import type { CorpusStorageMode } from "@/api/lib/corpus-storage-mode";
 import { CorpusPayloadUnavailableError } from "@/api/lib/errors/tagged-errors";
+import { parseCorpusLocation } from "@/api/lib/legal-search/corpus-location";
+import type {
+  CorpusLocation,
+  PackedCorpusLocation,
+} from "@/api/lib/legal-search/corpus-location";
 import {
   emptyAstSchema,
   EMPTY_AST,
@@ -27,7 +33,8 @@ import { LIMITS } from "@/api/lib/limits";
 import {
   deleteCorpusS3ObjectWithSignal,
   putCorpusS3ObjectWithSignal,
-  readCorpusS3Bytes,
+  readCorpusS3BytesBounded,
+  readCorpusS3Range,
 } from "@/api/lib/s3";
 import { withTimeout } from "@/api/lib/with-timeout";
 
@@ -37,6 +44,11 @@ import { withTimeout } from "@/api/lib/with-timeout";
  * jurisdiction partition so a re-parse produces a new immutable object
  * and the row's key columns point at the current version. Payloads are
  * zstd-compressed JSON.
+ *
+ * A row's key column may also hold a packed address (corpus-location.ts):
+ * the same bytes as a member of a larger pack object (corpus-pack.ts),
+ * read by byte range. Every reader below parses the stored value, so
+ * callers pass the column through unchanged whichever form it holds.
  */
 
 const CONTENT_TYPE = "application/zstd";
@@ -44,6 +56,10 @@ const CONTENT_TYPE = "application/zstd";
 const CORPUS_IO_TIMEOUT_MS = LIMITS.corpusObjectIoTimeoutMs;
 
 const PAYLOAD_MAX_BYTES = LIMITS.corpusPayloadMaxDecompressedBytes;
+
+// A zstd frame is at most a few bytes larger than what it decodes to, so
+// the decompressed ceiling also bounds the transfer.
+const TRANSFER_MAX_BYTES = PAYLOAD_MAX_BYTES;
 
 const persistedCorpusAstSchema = v.nullable(
   v.union([persistedDocumentAstSchema, emptyAstSchema]),
@@ -532,6 +548,76 @@ export const writeCorpusDocument = async (
   return { type: "written", written };
 };
 
+type BoundedObjectReader = (options: {
+  key: string;
+  maxBytes: number;
+  signal: AbortSignal;
+}) => Promise<Uint8Array>;
+
+type RangeReader = (options: {
+  key: string;
+  offset: number;
+  length: number;
+  signal: AbortSignal;
+}) => Promise<Uint8Array>;
+
+type ReadCorpusBytesAtOptions = {
+  location: CorpusLocation;
+  /** Ceiling on the transferred (still-compressed) bytes. */
+  maxBytes: number;
+  signal: AbortSignal;
+  /** Test seams; production reads through the corpus bucket client. */
+  readObject?: BoundedObjectReader;
+  readRange?: RangeReader;
+};
+
+/**
+ * The bytes a corpus location names, transferred under `maxBytes`.
+ *
+ * An object location is a bounded whole-object GET. A packed location is a
+ * range GET of exactly the member; its declared length is checked against
+ * the ceiling before any request is made.
+ */
+export const readCorpusBytesAt = async ({
+  location,
+  maxBytes,
+  signal,
+  readObject = readCorpusS3BytesBounded,
+  readRange = readCorpusS3Range,
+}: ReadCorpusBytesAtOptions): Promise<Uint8Array> => {
+  switch (location.type) {
+    case "object":
+      return await readObject({ key: location.key, maxBytes, signal });
+    case "packed": {
+      if (location.length > maxBytes) {
+        throw new PayloadBudgetError({
+          message: `Packed corpus member declares ${location.length} bytes, past the ${maxBytes}-byte ceiling`,
+        });
+      }
+      return await readRange({
+        key: location.packKey,
+        offset: location.offset,
+        length: location.length,
+        signal,
+      });
+    }
+    default: {
+      const unhandled: never = location;
+      return panic(`Unhandled corpus location: ${String(unhandled)}`);
+    }
+  }
+};
+
+const readStoredCorpusBytes = async (
+  storedKey: string,
+  signal: AbortSignal,
+): Promise<Uint8Array> =>
+  await readCorpusBytesAt({
+    location: parseCorpusLocation(storedKey),
+    maxBytes: TRANSFER_MAX_BYTES,
+    signal,
+  });
+
 type ReadCorpusTextOptions = {
   /**
    * Override the bounded corpus GET. Defaults to the corpus bucket read; a
@@ -542,24 +628,28 @@ type ReadCorpusTextOptions = {
   timeoutMs?: number;
 };
 
+/**
+ * Every reader takes the row's key column as stored: a plain object key or a
+ * packed address (see {@link parseCorpusLocation}).
+ */
 export const readCorpusText = async (
-  key: string,
+  storedKey: string,
   { read, timeoutMs = CORPUS_IO_TIMEOUT_MS }: ReadCorpusTextOptions = {},
 ): Promise<string> => {
   const bytes = await boundedCorpusIo(
     "corpus-read-text",
-    read ?? (async (signal) => await readCorpusS3Bytes(key, signal)),
+    read ?? (async (signal) => await readStoredCorpusBytes(storedKey, signal)),
     { timeoutMs },
   );
   return await zstdDecompressToStringBounded(bytes, PAYLOAD_MAX_BYTES);
 };
 
 export const readCorpusSections = async (
-  key: string,
+  storedKey: string,
 ): Promise<DecisionSection[] | null> => {
   const bytes = await boundedCorpusIo(
     "corpus-read-sections",
-    async (signal) => await readCorpusS3Bytes(key, signal),
+    async (signal) => await readStoredCorpusBytes(storedKey, signal),
   );
   const parsed: unknown = JSON.parse(
     await zstdDecompressToStringBounded(bytes, PAYLOAD_MAX_BYTES),
@@ -568,11 +658,11 @@ export const readCorpusSections = async (
 };
 
 export const readCorpusAst = async (
-  key: string,
+  storedKey: string,
 ): Promise<DocumentAst | EmptyAst | null> => {
   const bytes = await boundedCorpusIo(
     "corpus-read-ast",
-    async (signal) => await readCorpusS3Bytes(key, signal),
+    async (signal) => await readStoredCorpusBytes(storedKey, signal),
   );
   const parsed: unknown = JSON.parse(
     await zstdDecompressToStringBounded(bytes, PAYLOAD_MAX_BYTES),
@@ -582,6 +672,7 @@ export const readCorpusAst = async (
 
 type CorpusReadWithFallbackInput<T> = {
   documentId: string;
+  /** The row's key column as stored (object key or packed address). */
   key: string;
   /** Telemetry label for the degraded (fallback-served) path. */
   step: string;
@@ -627,6 +718,24 @@ export const readCorpusPayloadOrFallback = async <T>({
   return postgresCopy;
 };
 
+export type CorpusDeleteOutcome =
+  /** Every present pointer named a standalone object; each DELETE settled. */
+  | { type: "deleted"; keys: string[] }
+  /**
+   * At least one pointer addresses a range inside a shared object; that
+   * object is left in place. Standalone siblings were deleted.
+   */
+  | {
+      type: "shared-object-retained";
+      deletedKeys: string[];
+      retained: PackedCorpusLocation[];
+    };
+
+type DeleteCorpusDocumentOptions = CorpusIoOptions & {
+  /** Test seam; production deletes through the corpus bucket client. */
+  deleteObject?: (key: string, signal: AbortSignal) => Promise<void>;
+};
+
 /**
  * Delete all corpus objects for a decision version (GDPR erasure).
  * Keys are individually nullable: a partially ingested decision may have
@@ -638,21 +747,33 @@ export const deleteCorpusDocument = async (
     sectionsKey: string | null;
     astKey: string | null;
   },
-  { signal }: CorpusIoOptions = {},
-): Promise<void> => {
-  const present = [keys.textKey, keys.sectionsKey, keys.astKey].filter(
-    (key): key is string => key !== null,
-  );
+  {
+    signal,
+    deleteObject = deleteCorpusS3ObjectWithSignal,
+  }: DeleteCorpusDocumentOptions = {},
+): Promise<CorpusDeleteOutcome> => {
+  const objectKeys: string[] = [];
+  const retained: PackedCorpusLocation[] = [];
+  for (const storedKey of [keys.textKey, keys.sectionsKey, keys.astKey]) {
+    if (storedKey === null) {
+      continue;
+    }
+    const location = parseCorpusLocation(storedKey);
+    if (location.type === "packed") {
+      retained.push(location);
+    } else {
+      objectKeys.push(location.key);
+    }
+  }
   const deleteController = new AbortController();
   const groupSignal =
     signal === undefined
       ? deleteController.signal
       : AbortSignal.any([deleteController.signal, signal]);
-  const operations = present.map((key) =>
+  const operations = objectKeys.map((key) =>
     startCancellableCorpusIo(
       "corpus-delete",
-      async (deleteSignal) =>
-        await deleteCorpusS3ObjectWithSignal(key, deleteSignal),
+      async (deleteSignal) => await deleteObject(key, deleteSignal),
       { signal: groupSignal },
     ),
   );
@@ -660,4 +781,7 @@ export const deleteCorpusDocument = async (
     controller: deleteController,
     operations,
   });
+  return retained.length === 0
+    ? { type: "deleted", keys: objectKeys }
+    : { type: "shared-object-retained", deletedKeys: objectKeys, retained };
 };

--- a/apps/api/src/lib/legal-search/corpus-storage.ts
+++ b/apps/api/src/lib/legal-search/corpus-storage.ts
@@ -11,6 +11,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import {
   PayloadBudgetError,
   zstdCompressAsync,
+  zstdCompressBound,
   zstdDecompressToStringBounded,
 } from "@/api/lib/compression";
 import type { CorpusStorageMode } from "@/api/lib/corpus-storage-mode";
@@ -57,9 +58,14 @@ const CORPUS_IO_TIMEOUT_MS = LIMITS.corpusObjectIoTimeoutMs;
 
 const PAYLOAD_MAX_BYTES = LIMITS.corpusPayloadMaxDecompressedBytes;
 
-// A zstd frame is at most a few bytes larger than what it decodes to, so
-// the decompressed ceiling also bounds the transfer.
-const TRANSFER_MAX_BYTES = PAYLOAD_MAX_BYTES;
+/**
+ * Ceiling on the transferred (still-compressed) bytes of one payload. A
+ * zstd frame can exceed what it decodes to by frame and block overhead, so
+ * a frame whose output sits at the decompressed ceiling must still fit the
+ * transfer; the bound is zstd's worst case over that ceiling. Both the
+ * whole-object read and the packed range read are checked against it.
+ */
+export const CORPUS_TRANSFER_MAX_BYTES = zstdCompressBound(PAYLOAD_MAX_BYTES);
 
 const persistedCorpusAstSchema = v.nullable(
   v.union([persistedDocumentAstSchema, emptyAstSchema]),
@@ -608,37 +614,47 @@ export const readCorpusBytesAt = async ({
   }
 };
 
-const readStoredCorpusBytes = async (
-  storedKey: string,
-  signal: AbortSignal,
-): Promise<Uint8Array> =>
+/** Test seams for the two byte sources; production reads through the corpus bucket client. */
+type CorpusByteSourceSeams = {
+  readObject?: BoundedObjectReader;
+  readRange?: RangeReader;
+};
+
+type ReadStoredCorpusBytesOptions = CorpusByteSourceSeams & {
+  storedKey: string;
+  signal: AbortSignal;
+};
+
+const readStoredCorpusBytes = async ({
+  storedKey,
+  signal,
+  ...seams
+}: ReadStoredCorpusBytesOptions): Promise<Uint8Array> =>
   await readCorpusBytesAt({
     location: parseCorpusLocation(storedKey),
-    maxBytes: TRANSFER_MAX_BYTES,
+    maxBytes: CORPUS_TRANSFER_MAX_BYTES,
     signal,
+    ...seams,
   });
 
-type ReadCorpusTextOptions = {
-  /**
-   * Override the bounded corpus GET. Defaults to the corpus bucket read; a
-   * caller (or a test proving the ceiling fires) can supply a different byte
-   * source without bypassing the wall-clock bound.
-   */
-  read?: () => Promise<Uint8Array>;
+type ReadCorpusTextOptions = CorpusByteSourceSeams & {
   timeoutMs?: number;
 };
 
 /**
  * Every reader takes the row's key column as stored: a plain object key or a
- * packed address (see {@link parseCorpusLocation}).
+ * packed address (see {@link parseCorpusLocation}). The seams replace only
+ * the byte source behind that routing, never the routing or the wall-clock
+ * bound.
  */
 export const readCorpusText = async (
   storedKey: string,
-  { read, timeoutMs = CORPUS_IO_TIMEOUT_MS }: ReadCorpusTextOptions = {},
+  { timeoutMs = CORPUS_IO_TIMEOUT_MS, ...seams }: ReadCorpusTextOptions = {},
 ): Promise<string> => {
   const bytes = await boundedCorpusIo(
     "corpus-read-text",
-    read ?? (async (signal) => await readStoredCorpusBytes(storedKey, signal)),
+    async (signal) =>
+      await readStoredCorpusBytes({ storedKey, signal, ...seams }),
     { timeoutMs },
   );
   return await zstdDecompressToStringBounded(bytes, PAYLOAD_MAX_BYTES);
@@ -649,7 +665,7 @@ export const readCorpusSections = async (
 ): Promise<DecisionSection[] | null> => {
   const bytes = await boundedCorpusIo(
     "corpus-read-sections",
-    async (signal) => await readStoredCorpusBytes(storedKey, signal),
+    async (signal) => await readStoredCorpusBytes({ storedKey, signal }),
   );
   const parsed: unknown = JSON.parse(
     await zstdDecompressToStringBounded(bytes, PAYLOAD_MAX_BYTES),
@@ -662,7 +678,7 @@ export const readCorpusAst = async (
 ): Promise<DocumentAst | EmptyAst | null> => {
   const bytes = await boundedCorpusIo(
     "corpus-read-ast",
-    async (signal) => await readStoredCorpusBytes(storedKey, signal),
+    async (signal) => await readStoredCorpusBytes({ storedKey, signal }),
   );
   const parsed: unknown = JSON.parse(
     await zstdDecompressToStringBounded(bytes, PAYLOAD_MAX_BYTES),

--- a/apps/api/src/lib/s3.test.ts
+++ b/apps/api/src/lib/s3.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import {
   getS3,
   isMissingS3ObjectError,
   isS3Stale,
+  readCorpusS3Range,
   resolveS3Credentials,
   writeS3ObjectWithRetry,
 } from "@/api/lib/s3";
@@ -369,5 +370,157 @@ describe("isMissingS3ObjectError", () => {
     expect(unanswered.map(isMissingS3ObjectError)).toEqual(
       unanswered.map(() => false),
     );
+  });
+});
+
+/**
+ * The range reader is the only path that hands a caller a slice of a larger
+ * object, so it is exercised against a fake store that serves exactly what
+ * the request header names. A one-byte error in the header end would surface
+ * as a body of the wrong length here.
+ */
+describe("readCorpusS3Range", () => {
+  const originalFetch = globalThis.fetch;
+  const object = new Uint8Array(256).map((_, index) => index);
+  const seenRangeHeaders: string[] = [];
+
+  // Serves the byte range the header names, the way an object store does.
+  const rangeServingFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const headers = new Headers(
+      init?.headers ?? (input instanceof Request ? input.headers : undefined),
+    );
+    const range = headers.get("range");
+    if (range === null) {
+      return await Promise.resolve(new Response(object, { status: 200 }));
+    }
+    seenRangeHeaders.push(range);
+    const match = /^bytes=(?<first>\d+)-(?<last>\d+)$/u.exec(range);
+    const first = Number(match?.groups?.["first"]);
+    const last = Number(match?.groups?.["last"]);
+    const body = object.slice(first, last + 1);
+    return await Promise.resolve(
+      new Response(body, {
+        status: 206,
+        headers: {
+          "content-range": `bytes ${first}-${last}/${object.byteLength}`,
+          "content-length": String(body.byteLength),
+        },
+      }),
+    );
+  };
+
+  const installFetch = (
+    stub: (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => Promise<Response>,
+  ) => {
+    globalThis.fetch = Object.assign(stub, {
+      preconnect: originalFetch.preconnect,
+    });
+  };
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    seenRangeHeaders.length = 0;
+  });
+
+  test("asks for the inclusive range and returns exactly those bytes", async () => {
+    installFetch(rangeServingFetch);
+
+    const bytes = await readCorpusS3Range({
+      key: "legal-corpus/packs/jurisdiction=SVK/p.pack",
+      offset: 100,
+      length: 7,
+      signal: new AbortController().signal,
+    });
+
+    expect(seenRangeHeaders).toEqual(["bytes=100-106"]);
+    expect([...bytes]).toEqual([100, 101, 102, 103, 104, 105, 106]);
+  });
+
+  test("refuses a store that ignores the range and answers 200", async () => {
+    installFetch(async (input, init) => {
+      const full = await rangeServingFetch(input, {
+        ...init,
+        headers: undefined,
+      });
+      return full;
+    });
+
+    const rejection: unknown = await readCorpusS3Range({
+      key: "legal-corpus/packs/jurisdiction=SVK/p.pack",
+      offset: 0,
+      length: 8,
+      signal: new AbortController().signal,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toMatchObject({
+      message: expect.stringContaining("not 206"),
+    });
+  });
+
+  test("refuses a 206 whose Content-Range is not the requested range", async () => {
+    installFetch(
+      async () =>
+        await Promise.resolve(
+          new Response(object.slice(0, 8), {
+            status: 206,
+            headers: {
+              "content-range": `bytes 1-8/${object.byteLength}`,
+              "content-length": "8",
+            },
+          }),
+        ),
+    );
+
+    const rejection: unknown = await readCorpusS3Range({
+      key: "legal-corpus/packs/jurisdiction=SVK/p.pack",
+      offset: 0,
+      length: 8,
+      signal: new AbortController().signal,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toMatchObject({
+      message: expect.stringContaining("different range"),
+    });
+  });
+
+  test("refuses a body whose length differs from the range", async () => {
+    installFetch(
+      async () =>
+        await Promise.resolve(
+          new Response(object.slice(0, 9), {
+            status: 206,
+            headers: {
+              "content-range": `bytes 0-7/${object.byteLength}`,
+              "content-length": "9",
+            },
+          }),
+        ),
+    );
+
+    const rejection: unknown = await readCorpusS3Range({
+      key: "legal-corpus/packs/jurisdiction=SVK/p.pack",
+      offset: 0,
+      length: 8,
+      signal: new AbortController().signal,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toMatchObject({
+      message: expect.stringContaining("expected 8"),
+    });
   });
 });

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -5,7 +5,7 @@ import {
   PutObjectCommand,
   S3Client as AwsS3Client,
 } from "@aws-sdk/client-s3";
-import { Result, TaggedError } from "better-result";
+import { panic, Result, TaggedError } from "better-result";
 import { S3Client } from "bun";
 
 import { envBase } from "@/api/env-base";
@@ -751,6 +751,91 @@ export const readCorpusS3BytesBounded = async ({
     });
   }
   return await response.bytes();
+};
+
+type CorpusRangeReadOptions = {
+  key: string;
+  /** First byte of the range, inclusive. */
+  offset: number;
+  /** Byte count; must be positive, a range GET cannot express zero bytes. */
+  length: number;
+  signal: AbortSignal;
+};
+
+// `Content-Range: bytes <first>-<last>/<complete-length>`; the complete
+// length may be `*` when the store does not know it (RFC 9110 §14.4).
+const CONTENT_RANGE_PATTERN = /^bytes (?<first>\d+)-(?<last>\d+)\/(?:\d+|\*)$/u;
+
+/**
+ * Read `length` bytes of a legal-corpus object starting at `offset` with a
+ * range GET, so a member of a pack transfers without the pack around it.
+ *
+ * The response is accepted only as a 206 whose `Content-Range` names exactly
+ * the requested range and whose `Content-Length` equals `length`. A store
+ * that ignores the header answers 200 with the whole object; taking that
+ * body would silently hand the caller the wrong bytes (and an unbounded
+ * transfer), so anything but the exact partial response is refused. The
+ * transfer is bounded by `length`, which the caller checks against its
+ * ceiling before asking.
+ */
+export const readCorpusS3Range = async ({
+  key,
+  offset,
+  length,
+  signal,
+}: CorpusRangeReadOptions): Promise<Uint8Array> => {
+  if (!Number.isSafeInteger(offset) || offset < 0) {
+    return panic(
+      `Corpus range read offset must be a non-negative integer, got ${offset}`,
+    );
+  }
+  if (!Number.isSafeInteger(length) || length < 1) {
+    return panic(
+      `Corpus range read length must be a positive integer, got ${length}`,
+    );
+  }
+  const last = offset + length - 1;
+  const response = await fetchWithTimeout(
+    getCorpusS3().presign(key, { expiresIn: OBJECT_READ_PRESIGN_TTL_SECONDS }),
+    {
+      headers: { Range: `bytes=${offset}-${last}` },
+      signal,
+      timeoutMs: OBJECT_READ_TIMEOUT_MS,
+    },
+  );
+  if (response.status !== 206) {
+    throw new S3ObjectReadError({
+      message: `Range read for ${key} answered ${response.status}, not 206`,
+    });
+  }
+  const contentRange = CONTENT_RANGE_PATTERN.exec(
+    response.headers.get("content-range") ?? "",
+  );
+  const first = contentRange?.groups?.["first"];
+  const servedLast = contentRange?.groups?.["last"];
+  if (
+    first === undefined ||
+    servedLast === undefined ||
+    Number(first) !== offset ||
+    Number(servedLast) !== last
+  ) {
+    throw new S3ObjectReadError({
+      message: `Range read for ${key} served a different range than bytes=${offset}-${last}`,
+    });
+  }
+  const contentLength = response.headers.get("content-length");
+  if (contentLength === null || Number(contentLength.trim()) !== length) {
+    throw new S3ObjectReadError({
+      message: `Range read for ${key} declared ${contentLength ?? "no"} bytes, expected ${length}`,
+    });
+  }
+  const bytes = await response.bytes();
+  if (bytes.byteLength !== length) {
+    throw new S3ObjectReadError({
+      message: `Range read for ${key} returned ${bytes.byteLength} bytes, expected ${length}`,
+    });
+  }
+  return bytes;
 };
 
 /** Read a documents-bucket object. See `fetchObject`. */

--- a/apps/api/src/scripts/redact-case-law-decision.ts
+++ b/apps/api/src/scripts/redact-case-law-decision.ts
@@ -1,3 +1,5 @@
+import { panic } from "better-result";
+
 import { rlsDb } from "@/api/db/root";
 /**
  * GDPR redaction / takedown for a single case-law decision: strips
@@ -24,15 +26,40 @@ const ingestionDb = createIngestionDb(rlsDb);
 await refreshS3();
 await refreshCorpusS3();
 
-const found = await redactCaseLawDecision({
+const outcome = await redactCaseLawDecision({
   decisionId: toSafeId<"caseLawDecision">(decisionIdArg),
   scopedDb: ingestionDb,
 });
 
-console.log(
-  found
-    ? `Redacted decision ${decisionIdArg} across all stores.`
-    : `Decision ${decisionIdArg} not found.`,
-);
+const report = ((): { exitCode: 0 | 1; message: string } => {
+  switch (outcome.type) {
+    case "redacted":
+      return {
+        exitCode: 0,
+        message: `Redacted decision ${decisionIdArg} across all stores.`,
+      };
+    case "not-found":
+      return { exitCode: 1, message: `Decision ${decisionIdArg} not found.` };
+    case "corpus-objects-remain": {
+      const cause =
+        outcome.error instanceof Error
+          ? outcome.error.message
+          : String(outcome.error);
+      return {
+        exitCode: 1,
+        message: `Redacted decision ${decisionIdArg}, but corpus objects remain; pointer columns are kept for a retry: ${cause}`,
+      };
+    }
+    default: {
+      const unhandled: never = outcome;
+      return panic(`Unhandled redaction outcome: ${String(unhandled)}`);
+    }
+  }
+})();
 
-process.exit(found ? 0 : 1);
+if (report.exitCode === 0) {
+  console.log(report.message);
+} else {
+  console.error(report.message);
+}
+process.exit(report.exitCode);


### PR DESCRIPTION
Adds a pack format for corpus payloads and makes the corpus readers address-agnostic.

- `corpus-pack.ts`: a pack concatenates payload members (each the zstd frame a standalone object holds), followed by a zstd-compressed JSON footer listing offset, length, kind, documentId, contentHash and sha256 per member, an 8-byte little-endian footer length, and the magic `STLPACK1`. `encodePack`, `decodePackFooter` (refuses wrong magic/version, footer lengths that do not fit, members outside the payload region), `packKey`, `writeCorpusPack` (one PUT).
- `corpus-location.ts`: a row's key column holds either a plain object key or a packed address `pack:<packKey>@<offset>+<length>`; `parseCorpusLocation` / `formatCorpusLocation` (property test: format∘parse identity, addresses stay under the column width).
- Readers: `readCorpusText/Sections/Ast` take the stored column value and route an object key to the bounded whole-object GET and a packed address to a range GET (`readCorpusS3Range`), which accepts only a 206 whose `Content-Range` and `Content-Length` name exactly the requested range; a packed length over the payload ceiling is refused before any request.
- `deleteCorpusDocument` returns a discriminated outcome: `deleted`, or `shared-object-retained` when a pointer addresses a range inside a shared object (that object is left in place).

No change to what the ingestion pipeline writes, to the schema, or to env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for storing and reading legal corpus documents from packed storage locations.
  * Added bounded range reads with transfer and decompression-size safeguards.
  * Added structured deletion outcomes, including retention of shared packed data.
  * Added validation for packed corpus metadata, locations and storage integrity.

* **Bug Fixes**
  * Improved handling and reporting of incomplete or failed corpus deletion.

* **Tests**
  * Added comprehensive coverage for packed storage, range reads, location parsing, deletion behaviour and malformed data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->