### PR TITLE
fix(ai): tiered long-context rates for gpt-5.6-luna and gpt-5.6-terra

### DIFF
--- a/apps/api/src/lib/usage/run-estimate.test.ts
+++ b/apps/api/src/lib/usage/run-estimate.test.ts
@@ -4,10 +4,11 @@ import { estimateDocumentRunUnits } from "./run-estimate";
 
 describe("estimateDocumentRunUnits", () => {
   test("converts stored bytes and planned outputs through the model's rate", () => {
-    // 1 MiB stored inflates 4x into 4 MiB of prompt -> 1048576 tokens
-    // at 20_000/MTok = 20972 micro-units; 10 outputs -> 2500 tokens at
-    // 120_000/MTok = 300; standard tier multiplies by 1.5 before the
-    // 100 micro-unit -> unit conversion (320 units), then 11 planned
+    // 1 MiB stored inflates 4x into 4 MiB of prompt -> 1048576 tokens,
+    // past the model's 272K long-context threshold, so the above-threshold
+    // rate applies: 40_000/MTok = 41944 micro-units; 10 outputs -> 2500
+    // tokens at 180_000/MTok = 450; standard tier multiplies by 1.5 before
+    // the 100 micro-unit -> unit conversion (636 units), then 11 planned
     // calls x the doc_review floor of 8 add 88.
     expect(
       estimateDocumentRunUnits({
@@ -17,7 +18,7 @@ describe("estimateDocumentRunUnits", () => {
         plannedOutputs: 10,
         serviceTier: "standard",
       }),
-    ).toBe(408);
+    ).toBe(724);
   });
 
   test("small documents stay under the confirmation threshold", () => {

--- a/apps/api/src/lib/usage/unit-model.test.ts
+++ b/apps/api/src/lib/usage/unit-model.test.ts
@@ -15,6 +15,7 @@ const {
   usageUnitsFromTokens,
   MICRO_UNITS_PER_USAGE_UNIT,
 } = await import("@/api/lib/usage/unit-model");
+const { MODEL_RATES } = await import("@stll/ai-catalog");
 
 beforeEach(() => {
   captureErrorMock.mockReset();
@@ -59,20 +60,43 @@ describe("computeRawUsageMicroUnits", () => {
     expect(withCache).toBeLessThan(noCache);
   });
 
-  for (const [modelId, atThresholdUnits, aboveThresholdUnits] of [
-    ["gpt-5.4", 69_500, 138_251],
-    ["gpt-5.5", 139_000, 276_501],
-    ["gpt-5.6", 139_000, 276_501],
-  ] as const) {
-    test(`${modelId} switches the entire request above 272K input tokens`, () => {
+  // Every tiered schedule, pinned at and just past its threshold: exactly at
+  // the threshold stays on the standard rate, one token past it reprices the
+  // whole request.
+  const TIER_BOUNDARY_UNITS = {
+    "gemini-3.1-pro-preview": [200_000, 41_200, 81_801],
+    "gpt-5.4": [272_000, 69_500, 138_251],
+    "gpt-5.5": [272_000, 139_000, 276_501],
+    "gpt-5.6": [272_000, 139_000, 276_501],
+    "gpt-5.6-luna": [272_000, 5560, 11_061],
+    "gpt-5.6-terra": [272_000, 55_600, 110_601],
+  } as const;
+
+  test("the tier boundary table covers exactly the tiered rate schedules", () => {
+    const tiered = Object.entries(MODEL_RATES).flatMap(([modelId, rate]) =>
+      rate.kind === "input-token-tiered"
+        ? [[modelId, rate.inputTokenThreshold] as const]
+        : [],
+    );
+    const pinned = Object.entries(TIER_BOUNDARY_UNITS).map(
+      ([modelId, [threshold]]) => [modelId, threshold] as const,
+    );
+    expect(new Map(tiered)).toEqual(new Map(pinned));
+  });
+
+  for (const [
+    modelId,
+    [threshold, atThresholdUnits, aboveThresholdUnits],
+  ] of Object.entries(TIER_BOUNDARY_UNITS)) {
+    test(`${modelId} switches the entire request above ${String(threshold)} input tokens`, () => {
       const atThreshold = computeRawUsageMicroUnits({
         modelId,
-        uncachedInputTokens: 272_000,
+        uncachedInputTokens: threshold,
         outputTokens: 1000,
       });
       const aboveThreshold = computeRawUsageMicroUnits({
         modelId,
-        uncachedInputTokens: 272_001,
+        uncachedInputTokens: threshold + 1,
         outputTokens: 1000,
       });
 
@@ -80,23 +104,6 @@ describe("computeRawUsageMicroUnits", () => {
       expect(aboveThreshold).toBe(aboveThresholdUnits);
     });
   }
-
-  test("Gemini 3.1 Pro switches the entire request above 200K input tokens", () => {
-    expect(
-      computeRawUsageMicroUnits({
-        modelId: "gemini-3.1-pro-preview",
-        uncachedInputTokens: 200_000,
-        outputTokens: 1000,
-      }),
-    ).toBe(41_200);
-    expect(
-      computeRawUsageMicroUnits({
-        modelId: "gemini-3.1-pro-preview",
-        uncachedInputTokens: 200_001,
-        outputTokens: 1000,
-      }),
-    ).toBe(81_801);
-  });
 
   test("GPT-5.6 applies its long-context multiplier to cached input", () => {
     // Tier resolution counts cached prompt tokens too: 300K cached reads

--- a/packages/ai-catalog/src/index.ts
+++ b/packages/ai-catalog/src/index.ts
@@ -1160,16 +1160,33 @@ export const MODEL_RATES = {
   // Luna/Terra verified against the published price list 2026-08-16
   // (Luna's 2026-07-30 price cut).
   "gpt-5.6-luna": {
-    kind: "flat",
-    inputPerMTok: 20_000,
-    outputPerMTok: 120_000,
-    cachedInputPerMTok: 2000,
+    kind: "input-token-tiered",
+    inputTokenThreshold: 272_000,
+    standard: {
+      inputPerMTok: 20_000,
+      outputPerMTok: 120_000,
+      cachedInputPerMTok: 2000,
+    },
+    aboveThreshold: {
+      // OpenAI prices the entire >272K request at 2x input and 1.5x output.
+      inputPerMTok: 40_000,
+      outputPerMTok: 180_000,
+      cachedInputPerMTok: 4000,
+    },
   },
   "gpt-5.6-terra": {
-    kind: "flat",
-    inputPerMTok: 200_000,
-    outputPerMTok: 1_200_000,
-    cachedInputPerMTok: 20_000,
+    kind: "input-token-tiered",
+    inputTokenThreshold: 272_000,
+    standard: {
+      inputPerMTok: 200_000,
+      outputPerMTok: 1_200_000,
+      cachedInputPerMTok: 20_000,
+    },
+    aboveThreshold: {
+      inputPerMTok: 400_000,
+      outputPerMTok: 1_800_000,
+      cachedInputPerMTok: 40_000,
+    },
   },
   "claude-haiku-4-5-20251001": {
     kind: "flat",


### PR DESCRIPTION
## Summary

- `gpt-5.6-luna` and `gpt-5.6-terra` were priced flat in `MODEL_RATES`; upstream publishes a 272K long-context tier for both (2x input, 1.5x output, 2x cached input). Convert both entries to `input-token-tiered`, matching the shape of the other `gpt-5.x` entries.
- The scheduled model-catalog check has failed since Luna entered the offered set (`[NO TIERED RATE] openai / gpt-5.6-luna`); usage estimation and settlement resolve rates tier-aware, so requests past the threshold were under-priced.
- `run-estimate.test.ts`: the 1 MiB case sits past the threshold, so its expectation moves to the above-threshold rate (mutation-checked: reverting the catalog change restores the old value).

Terra is not offered yet; it is fixed now so the same check does not fail the day it is.

`bun run check:model-catalog` passes; `@stll/ai-catalog`, `model-catalog-rates`, and `run-estimate` tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tiered pricing for `gpt-5.6-luna` and `gpt-5.6-terra`, with rates changing for requests above 272,000 input tokens.
  - Terra and Luna now apply distinct standard and higher-volume rates, including input, output and cached-input pricing.

- **Bug Fixes**
  - Updated large-document usage estimates to accurately reflect the revised model pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->