### PR TITLE
test(api): bound PGlite property-test memory across numRuns

### DIFF
--- a/apps/api/src/handlers/rates/resolve.test.ts
+++ b/apps/api/src/handlers/rates/resolve.test.ts
@@ -24,6 +24,7 @@ import { validateOrgUserId } from "@/api/lib/validated-org-user-id";
 import type { ValidatedOrgUserId } from "@/api/lib/validated-org-user-id";
 import { createTestHandlerContext } from "@/api/tests/helpers/handler-context";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createPropertyRunReclaimer } from "@/api/tests/property-run-reclaim";
 import {
   createTestIds,
   setupRlsTestData,
@@ -61,9 +62,11 @@ const isoDate = (dayOffset: number): string =>
 let testDb: TestDatabase;
 let ids: TestIds;
 let defaultTableId: SafeId<"rateTable">;
+let reclaimRun: () => Promise<void>;
 
 beforeAll(async () => {
   testDb = await getTestDb();
+  reclaimRun = createPropertyRunReclaimer(testDb, [rateEntries]);
   ids = createTestIds();
   await setupRlsTestData(testDb, ids);
 
@@ -217,6 +220,8 @@ describe("effective-dated rate resolution", () => {
             await testDb
               .delete(rateEntries)
               .where(eq(rateEntries.rateTableId, defaultTableId));
+            // Otherwise the process grows with numRuns, not with the input.
+            await reclaimRun();
             if (rows.length > 0) {
               await testDb.insert(rateEntries).values(
                 rows.map((row) => ({

--- a/apps/api/src/lib/entity-filters.differential.test.ts
+++ b/apps/api/src/lib/entity-filters.differential.test.ts
@@ -14,6 +14,7 @@ import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
 import { toSafeId } from "@/api/lib/branded-types";
 import { applyFilters, buildFilterConditions } from "@/api/lib/entity-filters";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
+import { createPropertyRunReclaimer } from "@/api/tests/property-run-reclaim";
 
 // ── Differential property test ──────────────────────────────
 //
@@ -29,6 +30,7 @@ type RawDb = ReturnType<typeof drizzle>;
 
 let client: Awaited<ReturnType<typeof createTestPglite>> | undefined;
 let db: RawDb;
+let reclaimRun: () => Promise<void>;
 
 const ORG_ID = toSafeId<"organization">(Bun.randomUUIDv7());
 const WS_ID = toSafeId<"workspace">(Bun.randomUUIDv7());
@@ -84,6 +86,11 @@ beforeAll(
   async () => {
     client = await createTestPglite();
     db = drizzle({ client });
+    reclaimRun = createPropertyRunReclaimer(db, [
+      entities,
+      entityVersions,
+      fields,
+    ]);
 
     await db.insert(authSchema.user).values({
       id: "user_diff_test",
@@ -464,6 +471,8 @@ const clearRows = async () => {
     .where(eq(entities.workspaceId, WS_ID));
   await db.delete(entityVersions).where(eq(entityVersions.workspaceId, WS_ID));
   await db.delete(entities).where(eq(entities.workspaceId, WS_ID));
+  // Otherwise the process grows with numRuns, not with the generated input.
+  await reclaimRun();
 };
 
 const sqlMatchIds = async (condition: ConditionNode): Promise<Set<string>> => {

--- a/apps/api/src/tests/property-run-reclaim.ts
+++ b/apps/api/src/tests/property-run-reclaim.ts
@@ -1,0 +1,60 @@
+import { getTableName, sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import type { AnyPgTable } from "drizzle-orm/pg-core";
+
+/**
+ * A DB-backed property test is only memory-bounded if each run gives back what
+ * it took. Two things in this stack do not do that on their own, so both grow
+ * with `numRuns` rather than with the generated input, and the nightly
+ * `PROPERTY_TEST_NUM_RUNS_FACTOR` sweep is what makes them visible as a DB test
+ * batch over its peak-RSS budget:
+ *
+ *  1. PGlite runs Postgres with `max_worker_processes = 0`, so the autovacuum
+ *     launcher never starts and the rows a run deletes stay as dead tuples for
+ *     the life of the process. Measured on the entity-filter differential
+ *     property, 15,000 runs: data dir 20 MB -> 149 MB, `entities` heap
+ *     160 KB -> 27 MB, and the property itself 4.5x slower end to end.
+ *  2. Under `bun --smol` the collector does not keep up with a long
+ *     allocation-heavy async loop: most of the heap is the typed-array backing
+ *     stores behind PGlite's wire buffers, and JSC grows the heap instead of
+ *     collecting them. Same property, 3,000 runs: `extraMemorySize`
+ *     551 MB -> 1200 MB and peak RSS 1248 MB -> 1833 MB, with a flat data dir.
+ *     Collecting on the same interval holds it at ~560 MB / 1320 MB.
+ *
+ * Both are reclaimed on an interval rather than per run: a per-run VACUUM costs
+ * about 3x the run itself, while at this interval neither reclaim is
+ * measurable. What is retained is then bounded by the interval, a constant,
+ * instead of by `numRuns`.
+ */
+const RECLAIM_INTERVAL_RUNS = 100;
+
+/** Structural: raw and relations-aware drizzle instances both satisfy it. */
+type ExecutingDb = { execute: (query: SQL) => Promise<unknown> };
+
+/**
+ * Build the per-run cleanup hook that keeps a property test's memory bounded.
+ * Call the returned function once per property run, after the run's rows are
+ * deleted, passing the tables that run wrote to.
+ */
+export const createPropertyRunReclaimer = (
+  db: ExecutingDb,
+  tables: readonly AnyPgTable[],
+): (() => Promise<void>) => {
+  const vacuum = sql`vacuum ${sql.join(
+    tables.map((table) => sql.identifier(getTableName(table))),
+    sql`, `,
+  )}`;
+  // Reclaim on the first call too, so a factor-1 PR run exercises this path
+  // even for a property whose `numRuns` is below the interval.
+  let runsSinceReclaim = RECLAIM_INTERVAL_RUNS - 1;
+
+  return async () => {
+    runsSinceReclaim += 1;
+    if (runsSinceReclaim < RECLAIM_INTERVAL_RUNS) {
+      return;
+    }
+    runsSinceReclaim = 0;
+    await db.execute(vacuum);
+    Bun.gc(true);
+  };
+};


### PR DESCRIPTION
## Summary

Two DB-backed property tests (`entity-filters.differential.test.ts`, `rates/resolve.test.ts`) grew with `numRuns` rather than with the generated input, so a `PROPERTY_TEST_NUM_RUNS_FACTOR=50` sweep pushed the shared DB test batch to 3.0–4.5 GB peak RSS and tripped the 2560 MB budget in `run-tests.ts` while every assertion passed. Two causes, both measured:

- PGlite runs Postgres with `max_worker_processes = 0`, so the autovacuum launcher never starts and every row a run deletes stays as a dead tuple for the process lifetime (15,000 runs: data dir 20 → 157 MB, `entities` heap 160 KB → 27 MB, 111k dead tuples).
- Under `bun --smol` the collector does not keep up with a long allocation-heavy async loop; the typed-array backing stores behind PGlite's wire buffers accumulate (`extraMemorySize` 551 → 1200 MB over 3,000 runs with a flat data dir; the WASM heap itself stays constant).

Fix: `createPropertyRunReclaimer(db, tables)` returns a per-run hook that runs `VACUUM <tables>` and `Bun.gc(true)` every 100 runs (a per-run VACUUM costs ~3x the run; at this interval neither reclaim is measurable), and reclaims on its first call so a factor-1 run exercises the path. Wired into both properties after their per-run delete.

Batch peak RSS (`entity-filters.differential` + `rates/resolve` + `replay.db`): factor 50 3015 MB → ~1300 MB, 817 s → 91 s; factor 1 2157 MB → 1813 MB. Budget and `numRuns` unchanged. `replay.db.test.ts` inserts without deleting and holds a few MB of live rows at factor 50; left alone.