### PR TITLE
fix(api): classify canary credential rejection and abort the run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -877,16 +877,17 @@ jobs:
         if: needs.ci-plan.outputs.package_checks_required == 'true'
         run: bun test scripts/prepare-maintenance-release.property.test.ts
 
-      # The api test runner only globs `src/**`, so this seed-side regression
-      # guard (it imports `createMockDocx` and the Export Review citation
-      # seeds) needs an explicit invocation to run in CI, like the scripts
-      # tests above. Gated on workspace checks so it is skipped on
-      # workflow-only PRs where dependencies are not installed.
-      - name: Test seed citation-anchor guard
+      # The api test runner only globs `src/**`, so the tests beside the api
+      # scripts (seed guards, AI provider canary, MCP coverage) need an
+      # explicit invocation to run in CI, like the scripts tests above. The
+      # glob keeps a new scripts test from landing unrun. Gated on workspace
+      # checks so it is skipped on workflow-only PRs where dependencies are
+      # not installed.
+      - name: Test api scripts
         if: needs.ci-plan.outputs.package_checks_required == 'true'
         run: >-
           bun test --preload ./apps/api/src/tests/setup-env.ts
-          apps/api/scripts/seed-dev.test.ts
+          apps/api/scripts/*.test.ts
 
       - name: Test API and CLI contract invariants
         if: needs.ci-plan.outputs.package_checks_required == 'true'

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -10,6 +10,7 @@ import {
 import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
 
 import {
+  CanaryCredentialRejectedError,
   CanaryProviderRunError,
   createPdfCanaryMessages,
   errorSummary,
@@ -18,6 +19,7 @@ import {
   pdfCanarySelection,
   requireWeeklyToolExecution,
   runCanaryProbe,
+  runCanaryProbeSequence,
   toolRoundTripInputSchema,
   toolRoundTripInputSchemaForProvider,
   toolRoundTripPromptForProvider,
@@ -475,6 +477,188 @@ describe("AI provider canary retry contract", () => {
     expect(
       cases.map(({ error }) => isRetryableCanaryError(error, signal)),
     ).toEqual(cases.map(({ retryable }) => retryable));
+  });
+});
+
+// The shared generate path rethrows a provider RUN_ERROR as HTTP 502 while
+// keeping the provider's message, so this is the exact shape an expired key
+// reached the canary as.
+class ProviderAuthError extends Error {
+  readonly status = 502;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ProviderAuthError";
+  }
+}
+
+const runProbeWithoutBackoff = async ({
+  run,
+  timeoutMs,
+}: {
+  run: (signal: AbortSignal) => Promise<void>;
+  timeoutMs: number;
+}) =>
+  await runCanaryProbe({
+    retryDelayMs: 0,
+    run,
+    timeoutMs,
+    wait: async () => {},
+  });
+
+describe("AI provider canary credential rejection", () => {
+  test("summarizes auth statuses and adapter auth signatures as credential rejection", () => {
+    const signal = new AbortController().signal;
+    const credentialFailures = [
+      // bedrock-converse: bearer-key rejection relayed as a RUN_ERROR message.
+      new CanaryProviderRunError(
+        {
+          error: {
+            message:
+              "Authentication failed: Please make sure your API Key is valid.",
+          },
+        },
+        "before-tool-call",
+      ),
+      // openai-base: 401 response body forwarded as rawEvent.
+      new CanaryProviderRunError(
+        {
+          rawEvent: {
+            error: {
+              code: "invalid_api_key",
+              message: "Incorrect API key provided: sk-***",
+            },
+          },
+        },
+        "before-tool-call",
+      ),
+      // ai-anthropic: SDK message carrying the error body.
+      new CanaryProviderRunError(
+        {
+          message:
+            '401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}',
+        },
+        "before-tool-call",
+      ),
+      new CanaryProviderRunError(
+        { rawEvent: { statusCode: 401 } },
+        "after-tool-call",
+      ),
+      // ai-gemini: rejection body rethrown by the shared generate path.
+      new ProviderAuthError(
+        '{"error":{"code":400,"message":"API key not valid. Please pass a valid API key.","status":"INVALID_ARGUMENT"}}',
+      ),
+      { status: 403 },
+    ];
+
+    expect(
+      credentialFailures.map((error) => errorSummary(error, signal)),
+    ).toEqual(credentialFailures.map(() => "credential rejected"));
+  });
+
+  test("keeps capability failures out of the credential class", () => {
+    const signal = new AbortController().signal;
+
+    expect(
+      errorSummary(
+        new CanaryProviderRunError(
+          { error: { code: "provider_error" } },
+          "after-tool-result",
+        ),
+        signal,
+      ),
+    ).toBe("provider stream error after tool result (provider_error)");
+    expect(
+      errorSummary(
+        new ProviderAuthError("Upstream model is overloaded."),
+        signal,
+      ),
+    ).toBe("provider HTTP 502");
+  });
+
+  test("does not retry a credential rejection wrapped in a retryable status", async () => {
+    let calls = 0;
+    const result = await runCanaryProbe({
+      retryDelayMs: 0,
+      run: async () => {
+        calls += 1;
+        throw new ProviderAuthError(
+          "Authentication failed: Please make sure your API Key is valid.",
+        );
+      },
+      timeoutMs: 1000,
+      wait: async () => {},
+    });
+
+    expect(result.attempts).toBe(1);
+    expect(result.status).toBe("failed");
+    expect(calls).toBe(1);
+  });
+
+  test("aborts the remaining probes after a first-probe credential rejection", async () => {
+    const invoked: string[] = [];
+    const probeRuns = [
+      "role-fast:model",
+      "role-chat:model",
+      "prompt-caching",
+    ].map((label) => ({
+      label,
+      run: async () => {
+        invoked.push(label);
+        throw new ProviderAuthError(
+          "Authentication failed: Please make sure your API Key is valid.",
+        );
+      },
+      timeoutMs: 1000,
+    }));
+
+    const failure = await runCanaryProbeSequence({
+      probeRuns,
+      provider: "bedrock",
+      runProbe: runProbeWithoutBackoff,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(CanaryCredentialRejectedError);
+    expect(failure).toHaveProperty(
+      "message",
+      "bedrock: credential rejected (role-fast:model, authentication failed); " +
+        "rotate AI_CANARY_API_KEY for this provider",
+    );
+    expect(invoked).toEqual(["role-fast:model"]);
+  });
+
+  test("runs the remaining probes when the first probe fails for another reason", async () => {
+    const invoked: string[] = [];
+    const probeRuns = [
+      "role-fast:model",
+      "role-chat:model",
+      "prompt-caching",
+    ].map((label, index) => ({
+      label,
+      run: async () => {
+        invoked.push(label);
+        if (index === 0) {
+          throw new TypeError("Provider returned no text.");
+        }
+      },
+      timeoutMs: 1000,
+    }));
+
+    const failures = await runCanaryProbeSequence({
+      probeRuns,
+      provider: "bedrock",
+      runProbe: runProbeWithoutBackoff,
+    });
+
+    expect(failures).toBe(1);
+    expect(invoked).toEqual([
+      "role-fast:model",
+      "role-chat:model",
+      "prompt-caching",
+    ]);
   });
 });
 

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -12,7 +12,10 @@ import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-sc
 import {
   CanaryCredentialRejectedError,
   CanaryProviderRunError,
+  classifyCanaryFailure,
   createPdfCanaryMessages,
+  CREDENTIAL_REJECTION_SIGNATURES,
+  CREDENTIAL_REJECTION_STATUSES,
   errorSummary,
   isRetryableCanaryError,
   PDF_CANARY_TOKEN,
@@ -480,17 +483,50 @@ describe("AI provider canary retry contract", () => {
   });
 });
 
-// The shared generate path rethrows a provider RUN_ERROR as HTTP 502 while
-// keeping the provider's message, so this is the exact shape an expired key
-// reached the canary as.
+// The shared generate path rethrows a provider RUN_ERROR as HTTP 502, keeping
+// the provider message or the raw error body, so this is the exact shape an
+// expired key reached the canary as.
 class ProviderAuthError extends Error {
   readonly status = 502;
+  readonly rawEvent: Record<string, unknown> | undefined;
 
-  constructor(message: string) {
+  constructor(message: string, rawEvent?: Record<string, unknown>) {
     super(message);
     this.name = "ProviderAuthError";
+    this.rawEvent = rawEvent;
   }
 }
+
+type CredentialSignatureField = "code" | "message" | "type";
+
+// The adapter field each declared signature actually arrives on. One standalone
+// fixture per signature keeps a removed matcher from being masked by a sibling
+// match on the same error.
+const CREDENTIAL_SIGNATURE_FIELDS = {
+  "authentication failed": "message",
+  authentication_error: "type",
+  "invalid x-api-key": "message",
+  invalid_api_key: "code",
+  "incorrect api key": "message",
+  "api key not valid": "message",
+  permission_denied: "message",
+  unauthenticated: "message",
+  "no auth credentials found": "message",
+  unauthorized: "message",
+} as const satisfies Record<
+  (typeof CREDENTIAL_REJECTION_SIGNATURES)[number],
+  CredentialSignatureField
+>;
+
+const credentialFixture = (
+  signature: string,
+  field: CredentialSignatureField,
+): ProviderAuthError =>
+  field === "message"
+    ? new ProviderAuthError(signature)
+    : new ProviderAuthError("Provider request failed.", {
+        error: { [field]: signature },
+      });
 
 const runProbeWithoutBackoff = async ({
   run,
@@ -507,6 +543,40 @@ const runProbeWithoutBackoff = async ({
   });
 
 describe("AI provider canary credential rejection", () => {
+  test("classifies every declared signature on its own", () => {
+    const exercised = Object.keys(CREDENTIAL_SIGNATURE_FIELDS);
+    expect(new Set(exercised)).toEqual(
+      new Set(CREDENTIAL_REJECTION_SIGNATURES),
+    );
+
+    for (const signature of CREDENTIAL_REJECTION_SIGNATURES) {
+      const fixture = credentialFixture(
+        signature,
+        CREDENTIAL_SIGNATURE_FIELDS[signature],
+      );
+      expect(classifyCanaryFailure(fixture)).toEqual({
+        kind: "credential-rejected",
+        reason: signature,
+      });
+    }
+  });
+
+  test("treats a bare 403 as a provider failure, a bare 401 as a rejection", () => {
+    // A valid key without entitlement to a model also answers 403.
+    expect(classifyCanaryFailure({ status: 403 })).toEqual({
+      kind: "provider-failure",
+    });
+    expect(
+      classifyCanaryFailure({ status: 403, message: "PERMISSION_DENIED" }),
+    ).toEqual({ kind: "credential-rejected", reason: "permission_denied" });
+    for (const status of CREDENTIAL_REJECTION_STATUSES) {
+      expect(classifyCanaryFailure({ status })).toEqual({
+        kind: "credential-rejected",
+        reason: `HTTP ${status}`,
+      });
+    }
+  });
+
   test("summarizes auth statuses and adapter auth signatures as credential rejection", () => {
     const signal = new AbortController().signal;
     const credentialFailures = [
@@ -548,7 +618,8 @@ describe("AI provider canary credential rejection", () => {
       new ProviderAuthError(
         '{"error":{"code":400,"message":"API key not valid. Please pass a valid API key.","status":"INVALID_ARGUMENT"}}',
       ),
-      { status: 403 },
+      // ai-gemini: restricted key, 403 alongside an auth signature.
+      { status: 403, message: "PERMISSION_DENIED" },
     ];
 
     expect(

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -363,7 +363,7 @@ const terminalProviderCode = (error: unknown, depth = 0): string | null => {
 // indistinguishable from a capability regression by status alone. Each signature
 // is matched case-insensitively against the message, code, and type fields on
 // the error chain.
-const CREDENTIAL_REJECTION_SIGNATURES = [
+export const CREDENTIAL_REJECTION_SIGNATURES = [
   "authentication failed", // bedrock-converse: bearer-key rejection body
   "authentication_error", // ai-anthropic: error body type
   "invalid x-api-key", // ai-anthropic: error body message
@@ -376,7 +376,10 @@ const CREDENTIAL_REJECTION_SIGNATURES = [
   "unauthorized", // ai-mistral: 401 body message
 ] as const;
 
-const CREDENTIAL_REJECTION_STATUSES = [401, 403] as const;
+// Only 401 rejects a credential on status alone: a 403 is also how a provider
+// answers a valid key that lacks entitlement to a model, so it must carry an
+// auth signature as well.
+export const CREDENTIAL_REJECTION_STATUSES = [401] as const;
 
 type CredentialRejectionReason =
   | (typeof CREDENTIAL_REJECTION_SIGNATURES)[number]

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -357,8 +357,110 @@ const terminalProviderCode = (error: unknown, depth = 0): string | null => {
   return null;
 };
 
+// Every adapter collapses a provider failure into a RUN_ERROR carrying only the
+// provider's message and code (@tanstack/ai `toRunErrorPayload`), and the shared
+// generate path rethrows that event as HTTP 502, so a rejected key is
+// indistinguishable from a capability regression by status alone. Each signature
+// is matched case-insensitively against the message, code, and type fields on
+// the error chain.
+const CREDENTIAL_REJECTION_SIGNATURES = [
+  "authentication failed", // bedrock-converse: bearer-key rejection body
+  "authentication_error", // ai-anthropic: error body type
+  "invalid x-api-key", // ai-anthropic: error body message
+  "invalid_api_key", // ai-openai, openrouter: error body code
+  "incorrect api key", // ai-openai: error body message
+  "api key not valid", // ai-gemini: rejection message
+  "permission_denied", // ai-gemini: status for a revoked or restricted key
+  "unauthenticated", // ai-gemini: status for a missing or expired key
+  "no auth credentials found", // openrouter: 401 body message
+  "unauthorized", // ai-mistral: 401 body message
+] as const;
+
+const CREDENTIAL_REJECTION_STATUSES = [401, 403] as const;
+
+type CredentialRejectionReason =
+  | (typeof CREDENTIAL_REJECTION_SIGNATURES)[number]
+  | `HTTP ${(typeof CREDENTIAL_REJECTION_STATUSES)[number]}`;
+
+export type CanaryFailure =
+  | { kind: "credential-rejected"; reason: CredentialRejectionReason }
+  | { kind: "provider-failure" };
+
+const PROVIDER_FAILURE = {
+  kind: "provider-failure",
+} as const satisfies CanaryFailure;
+
+const CREDENTIAL_SIGNATURE_KEYS = ["message", "code", "type"] as const;
+
+const credentialSignature = (
+  value: unknown,
+): CredentialRejectionReason | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.toLowerCase();
+  return (
+    CREDENTIAL_REJECTION_SIGNATURES.find((signature) =>
+      normalized.includes(signature),
+    ) ?? null
+  );
+};
+
+const credentialRejectionSignature = (
+  error: unknown,
+  depth = 0,
+): CredentialRejectionReason | null => {
+  const direct = credentialSignature(error);
+  if (direct !== null) {
+    return direct;
+  }
+  if (!isRecord(error)) {
+    return null;
+  }
+
+  for (const key of CREDENTIAL_SIGNATURE_KEYS) {
+    const signature = credentialSignature(error[key]);
+    if (signature !== null) {
+      return signature;
+    }
+  }
+  if (depth >= 3) {
+    return null;
+  }
+  for (const key of PROVIDER_ERROR_NESTED_KEYS) {
+    const nested = credentialRejectionSignature(error[key], depth + 1);
+    if (nested !== null) {
+      return nested;
+    }
+  }
+  return null;
+};
+
+const credentialRejectionStatus = (
+  status: number | null,
+): CredentialRejectionReason | null => {
+  const match = CREDENTIAL_REJECTION_STATUSES.find(
+    (candidate) => candidate === status,
+  );
+  return match === undefined ? null : `HTTP ${match}`;
+};
+
+const canaryEventFailure = (event: unknown): CanaryFailure => {
+  const statusReason = credentialRejectionStatus(providerStatus(event));
+  if (statusReason !== null) {
+    return { kind: "credential-rejected", reason: statusReason };
+  }
+
+  const signature = credentialRejectionSignature(event);
+  return signature === null
+    ? PROVIDER_FAILURE
+    : { kind: "credential-rejected", reason: signature };
+};
+
 export class CanaryProviderRunError extends TypeError {
   readonly code: string | null;
+  readonly failure: CanaryFailure;
   readonly retryCode: string | null;
   readonly retryable: boolean | null;
   readonly stage: CanaryRunStage;
@@ -371,9 +473,33 @@ export class CanaryProviderRunError extends TypeError {
     this.retryCode = rawProviderCode(event);
     this.retryable = explicitRetryability(event);
     this.code = safeProviderCode(this.retryCode);
+    this.failure = canaryEventFailure(event);
     this.stage = stage;
     this.status = providerStatus(event);
     this.terminalCode = terminalProviderCode(event);
+  }
+}
+
+export const classifyCanaryFailure = (error: unknown): CanaryFailure =>
+  error instanceof CanaryProviderRunError
+    ? error.failure
+    : canaryEventFailure(error);
+
+type CanaryCredentialRejectedOptions = {
+  label: string;
+  provider: CanaryProvider;
+  reason: CredentialRejectionReason;
+};
+
+// A TypeError so the top-level handler prints this bounded message; every part
+// of it is either a canary literal or a canary-built label.
+export class CanaryCredentialRejectedError extends TypeError {
+  constructor({ label, provider, reason }: CanaryCredentialRejectedOptions) {
+    super(
+      `${provider}: credential rejected (${label}, ${reason}); ` +
+        "rotate AI_CANARY_API_KEY for this provider",
+    );
+    this.name = "CanaryCredentialRejectedError";
   }
 }
 
@@ -383,6 +509,11 @@ export const isRetryableCanaryError = (
 ): boolean => {
   if (signal.aborted) {
     return true;
+  }
+
+  // A rejected credential fails every remaining attempt identically.
+  if (classifyCanaryFailure(error).kind === "credential-rejected") {
+    return false;
   }
 
   if (error instanceof CanaryProviderRunError) {
@@ -1156,6 +1287,10 @@ export const errorSummary = (error: unknown, signal: AbortSignal): string => {
     return "timeout";
   }
 
+  if (classifyCanaryFailure(error).kind === "credential-rejected") {
+    return "credential rejected";
+  }
+
   if (error instanceof CanaryProviderRunError) {
     if (error.status !== null) {
       return `provider HTTP ${error.status}`;
@@ -1218,6 +1353,55 @@ const recordProbeResult = ({
   return 1;
 };
 
+type CanaryProbeRun = {
+  label: string;
+  run: (signal: AbortSignal) => Promise<void>;
+  timeoutMs: number;
+};
+
+type RunCanaryProbeSequenceOptions = {
+  index?: number;
+  probeRuns: readonly CanaryProbeRun[];
+  provider: CanaryProvider;
+  runProbe?: (options: RunCanaryProbeOptions) => Promise<CanaryProbeResult>;
+};
+
+// A credential rejected by the very first probe rejects every later probe too:
+// abort so the run reports a rotation task instead of a capability regression.
+export const runCanaryProbeSequence = async ({
+  index = 0,
+  probeRuns,
+  provider,
+  runProbe = runCanaryProbe,
+}: RunCanaryProbeSequenceOptions): Promise<number> => {
+  const probeRun = probeRuns.at(index);
+  if (!probeRun) {
+    return 0;
+  }
+
+  const { label, run, timeoutMs } = probeRun;
+  const result = await runProbe({ run, timeoutMs });
+  const failures = recordProbeResult({ label, provider, result });
+  if (index === 0 && result.status === "failed") {
+    const failure = classifyCanaryFailure(result.error);
+    if (failure.kind === "credential-rejected") {
+      throw new CanaryCredentialRejectedError({
+        label,
+        provider,
+        reason: failure.reason,
+      });
+    }
+  }
+
+  const remaining = await runCanaryProbeSequence({
+    index: index + 1,
+    probeRuns,
+    provider,
+    runProbe,
+  });
+  return failures + remaining;
+};
+
 const run = async (): Promise<void> => {
   const args = parseCanaryRunArgs(Bun.argv.slice(2));
   const { provider } = args;
@@ -1230,7 +1414,10 @@ const run = async (): Promise<void> => {
     config: createCanaryConfig({ apiKey, provider }),
     provider,
   } satisfies CanaryContext;
-  let failures = await runProbes(context, 0, 0);
+  let failures = await runCanaryProbeSequence({
+    probeRuns: canaryProbeRuns(context),
+    provider,
+  });
 
   if (args.tier === "weekly") {
     const rotation = weeklyCanaryRotation({
@@ -1261,44 +1448,38 @@ const run = async (): Promise<void> => {
   }
 };
 
-const runProbes = async (
-  context: CanaryContext,
-  index: number,
-  failures: number,
-): Promise<number> => {
-  const probe = probes.at(index);
-  if (!probe) {
-    return failures;
+const isSkippedProbe = (context: CanaryContext, probe: Probe): boolean => {
+  if (probe.type === "capability") {
+    return false;
   }
 
-  const label = probeLabel(context, probe);
-  if (
-    probe.type !== "capability" &&
-    (probe.type === "model-role" && probe.role === "pdf"
-      ? pdfCanarySelection(context.provider) === null
-      : !isBYOKProviderRoleSupported({
-          provider: context.provider,
-          role: probe.role,
-        }))
-  ) {
-    console.log(
-      `[ai-canary] ${context.provider}/${label}: skipped (unsupported role)`,
-    );
-    return await runProbes(context, index + 1, failures);
-  }
+  return probe.type === "model-role" && probe.role === "pdf"
+    ? pdfCanarySelection(context.provider) === null
+    : !isBYOKProviderRoleSupported({
+        provider: context.provider,
+        role: probe.role,
+      });
+};
 
-  const result = await runCanaryProbe({
-    run: async (signal) => {
-      await probe.run(context, signal);
-    },
-    timeoutMs: probe.timeoutMs,
-  });
-  const failureDelta = recordProbeResult({
-    label,
-    provider: context.provider,
-    result,
-  });
-  return await runProbes(context, index + 1, failures + failureDelta);
+const canaryProbeRuns = (context: CanaryContext): CanaryProbeRun[] => {
+  const probeRuns: CanaryProbeRun[] = [];
+  for (const probe of probes) {
+    const label = probeLabel(context, probe);
+    if (isSkippedProbe(context, probe)) {
+      console.log(
+        `[ai-canary] ${context.provider}/${label}: skipped (unsupported role)`,
+      );
+      continue;
+    }
+    probeRuns.push({
+      label,
+      run: async (signal) => {
+        await probe.run(context, signal);
+      },
+      timeoutMs: probe.timeoutMs,
+    });
+  }
+  return probeRuns;
 };
 
 const runWeeklyCanaryProbes = async (


### PR DESCRIPTION
## Summary

When a provider rejects the canary's API key, every adapter collapses the failure into a RUN_ERROR carrying only the provider's message and code, and the shared generate path rethrows it as HTTP 502. The scheduled canary therefore reported a dead key as 13 capability-probe failures (`provider HTTP 502`), each retried, which reads like a provider regression rather than a rotation task.

- `classifyCanaryFailure` returns a discriminated `CanaryFailure`: `credential-rejected` when the provider status is 401/403 or when a message/code/type field on the error chain carries one of the adapter auth signatures (`CREDENTIAL_REJECTION_SIGNATURES`, each annotated with the adapter that emits it), else `provider-failure`.
- A credential rejection is never retried, and `errorSummary` reports `credential rejected` instead of the synthetic status.
- The probe loop (`runCanaryProbeSequence`, now over a prebuilt probe list) aborts when the first probe is rejected and exits with one line: `<provider>: credential rejected (<probe>, <reason>); rotate AI_CANARY_API_KEY for this provider`. Non-credential first-probe failures still run the rest; weekly probes are unchanged; the coverage job still sees the provider as failed.
- Tests in `ai-provider-canary.test.ts` cover the classification (statuses and per-adapter signatures), no-retry, the first-probe abort, and the non-abort path; each was mutation-checked against its behavior.
- CI: the api test runner globs `src/**` only, so the canary/coverage/guard tests beside `apps/api/scripts` never ran; the existing seed-dev step now globs `apps/api/scripts/*.test.ts` (8 files, 76 tests, ~2 s).

The Mistral and OpenRouter 401 body wordings are not asserted anywhere in the SDK sources, so those two signatures are the least certain; a miss degrades to today's `provider-failure` reporting, never to a false rotation alarm, and 401/403 are caught structurally.