### PR TITLE
feat(db): bound case_law_decisions.decision_date at the table

### DIFF
--- a/apps/api/drizzle/20260818090000_case_law_decision_date_bounds/migration.sql
+++ b/apps/api/drizzle/20260818090000_case_law_decision_date_bounds/migration.sql
@@ -1,6 +1,21 @@
 SET lock_timeout = '1s';--> statement-breakpoint
 SET statement_timeout = '5s';--> statement-breakpoint
 
+-- Rows still holding a date outside the bounds cannot survive the
+-- constraint: NOT VALID is enforced on every later UPDATE of such a row,
+-- whatever column it touches, and VALIDATE fails while one remains. Clear
+-- them first, the way `repair-decision-dates.ts` does (`decision_date` to
+-- NULL, `indexed_hash` cleared so the search projection is rebuilt); the
+-- script additionally reopens the citation edges decided under the old
+-- date and is the intended pre-step, this statement is the floor. Bounded
+-- by the date index; the population is what the script's report counts.
+UPDATE "case_law_decisions"
+   SET "decision_date" = NULL,
+       "indexed_hash" = NULL
+ WHERE "decision_date" < make_date(1800, 1, 1)
+    OR "decision_date" >= make_date(
+         extract(year from (now() AT TIME ZONE 'UTC'))::int + 2, 1, 1);--> statement-breakpoint
+
 -- The year bounds the write path enforces through `canonicalDecisionDate`
 -- (`DECISION_YEAR_BOUNDS` in apps/api/src/lib/dates.ts), enforced at the
 -- table. A NULL date is allowed. The ceiling is the first excluded day rather

--- a/apps/api/drizzle/20260818090000_case_law_decision_date_bounds/migration.sql
+++ b/apps/api/drizzle/20260818090000_case_law_decision_date_bounds/migration.sql
@@ -1,0 +1,55 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- The year bounds the write path enforces through `canonicalDecisionDate`
+-- (`DECISION_YEAR_BOUNDS` in apps/api/src/lib/dates.ts), enforced at the
+-- table. A NULL date is allowed. The ceiling is the first excluded day rather
+-- than a year comparison so the same text stays a range predicate over
+-- "case_law_decisions_date_idx"; `now()` is read in UTC so the session time
+-- zone cannot move the boundary.
+--
+-- NOT VALID here, VALIDATE below: adding a validating CHECK scans every row
+-- while holding ACCESS EXCLUSIVE. NOT VALID takes the lock only long enough to
+-- record the constraint, which then applies to every later INSERT and UPDATE.
+--
+-- Guarded so the file can be re-run: the ADD commits below before the
+-- VALIDATE, and a VALIDATE that fails would otherwise leave a second run
+-- failing on a constraint that already exists.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'case_law_decisions_decision_date_bounds'
+      AND conrelid = 'case_law_decisions'::regclass
+  ) THEN
+    ALTER TABLE "case_law_decisions"
+      ADD CONSTRAINT "case_law_decisions_decision_date_bounds"
+      CHECK (
+        "decision_date" IS NULL
+        OR (
+          "decision_date" >= make_date(1800, 1, 1)
+          AND "decision_date" < make_date(
+            extract(year from (now() AT TIME ZONE 'UTC'))::int + 2, 1, 1)
+        )
+      ) NOT VALID;
+  END IF;
+END
+$$;--> statement-breakpoint
+
+-- Validate outside Drizzle's migration transaction so PostgreSQL does not
+-- hold the ADD CONSTRAINT lock for the duration of the table scan. VALIDATE
+-- takes SHARE UPDATE EXCLUSIVE, which concurrent readers and writers do not
+-- wait on, and is a no-op on an already validated constraint. Same shape as
+-- 20260817220000_chat_turn_client_tool_interaction.
+-- squawk-ignore transaction-nesting
+COMMIT;--> statement-breakpoint
+SET statement_timeout = 0;--> statement-breakpoint
+SET lock_timeout = 0;--> statement-breakpoint
+-- Re-runnable as it stands: the guarded ADD above is skipped once the
+-- constraint exists, and validating a validated constraint changes nothing.
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE "case_law_decisions" VALIDATE CONSTRAINT "case_law_decisions_decision_date_bounds";--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+SET lock_timeout = '1s';--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/scripts/seed-case-law.ts
+++ b/apps/api/scripts/seed-case-law.ts
@@ -29,6 +29,7 @@ import { rootDb, rlsDb } from "@/api/db/root";
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
 import { createIngestionDb } from "@/api/db/scoped";
 import { backfillCaseLawSlugs } from "@/api/handlers/case-law/decisions/slug-backfill";
+import { canonicalDecisionDate } from "@/api/lib/dates";
 import { indexDecision } from "@/api/lib/legal-search/case-law-search-index";
 import type {
   DecisionSection,
@@ -229,7 +230,13 @@ export async function seedCaseLaw() {
           country: d.country,
           language: d.language,
           languageGroupKey: d.language_group_key,
-          decisionDate: d.decision_date,
+          // Fixtures are verbatim rows, some of them older than the write-path
+          // guard; the same guard runs here so the table's bounds CHECK sees
+          // what the ingest would have stored.
+          decisionDate:
+            d.decision_date === null
+              ? null
+              : canonicalDecisionDate(d.decision_date),
           decisionType: d.decision_type,
           fulltext,
           sections: d.sections,

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -80,6 +80,10 @@ const APPROVED_PROCEDURAL_STATEMENTS = new Set([
   // takes no lock beyond the read, and stopping the release is the intended
   // outcome, since the two orders cannot share one cursor slot.
   "20260817150000_corpus_generation_date_walk/migration.sql:06821016b65f9c0e7ab643794da37f29616a0ccbef91df3df8b1806197f5ac8c",
+  // Adds the decision-date bounds CHECK NOT VALID only when it is absent. The
+  // body is static DDL; the conditional makes the file retryable after the
+  // VALIDATE that follows it outside the migrator transaction.
+  "20260818090000_case_law_decision_date_bounds/migration.sql:31f2786a7f7aed2d2e55bd3161acad6ad49e606ec1bc75e9235de07cdadd96e0",
 ]);
 
 type TimeoutState = "bounded" | "unbounded" | "unset";

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -18,6 +18,10 @@ import type {
   RuleSource,
 } from "@/api/handlers/case-law/polarity/consts";
 import type { ConstantMap } from "@/api/lib/constant-map";
+import {
+  CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT,
+  decisionDateWithinBoundsSql,
+} from "@/api/lib/decision-date-bounds-sql";
 
 import {
   caseLawIngestionOnlyPolicies,
@@ -370,6 +374,14 @@ export const caseLawDecisions = p.pgTable(
     p.check(
       "case_law_decisions_redacted_payload_erased",
       sql`${t.redactedAt} IS NULL OR (${t.fulltext} IS NULL AND ${t.sections} IS NULL AND ${t.documentAst} IS NULL AND ${t.contentHash} IS NULL)`,
+    ),
+    // The year bounds `canonicalDecisionDate` enforces on the write path,
+    // enforced at the table as well; both derive from `DECISION_YEAR_BOUNDS`.
+    // A NULL date is allowed: it is how a decision without a usable date is
+    // stored.
+    p.check(
+      CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT,
+      sql`${t.decisionDate} IS NULL OR ${decisionDateWithinBoundsSql(t.decisionDate)}`,
     ),
     // Identity, in two halves that together cover every row exactly once.
     // Where the publisher states an id, that is the key. Where it does not,

--- a/apps/api/src/lib/dates.ts
+++ b/apps/api/src/lib/dates.ts
@@ -83,9 +83,9 @@ const ISO_DATE_LENGTH = 10;
  * relative to the current year because a publisher may date a decision
  * slightly ahead; a fixed upper year would go stale.
  *
- * Exported because the same bounds have to hold in SQL: rows written before
- * the guard existed are found by `repair-decision-dates-plan.ts`, which derives
- * its predicate from this declaration rather than restating the numbers.
+ * Exported because the same bounds have to hold in SQL:
+ * `decision-date-bounds-sql.ts` derives the table's CHECK constraint and the
+ * repair predicate from this declaration rather than restating the numbers.
  */
 export const DECISION_YEAR_BOUNDS = {
   min: 1800,

--- a/apps/api/src/lib/decision-date-bounds-sql.db.test.ts
+++ b/apps/api/src/lib/decision-date-bounds-sql.db.test.ts
@@ -1,0 +1,226 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { PgDialect, getTableConfig } from "drizzle-orm/pg-core";
+import { drizzle } from "drizzle-orm/pglite";
+import { readFileSync } from "node:fs";
+import nodePath from "node:path";
+
+import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import { createSafeId } from "@/api/lib/branded-types";
+import { canonicalDecisionDate } from "@/api/lib/dates";
+import {
+  CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT,
+  decisionDateOutOfBoundsSql,
+  decisionDateWithinBoundsSql,
+} from "@/api/lib/decision-date-bounds-sql";
+import { isRecord } from "@/api/lib/type-guards";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+/**
+ * The bounds live in three runtimes: the write-path guard in TypeScript, the
+ * repair predicate in SQL, and the table's CHECK in DDL. Each pair is proved
+ * equal here against a real PostgreSQL rather than by reading the numbers.
+ */
+
+const MIGRATION_PATH = nodePath.resolve(
+  import.meta.dir,
+  "../../drizzle/20260818090000_case_law_decision_date_bounds/migration.sql",
+);
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const sourceId = createSafeId<"caseLawSource">();
+const currentYear = new Date().getUTCFullYear();
+
+/** Both sides of both bounds, plus dates far outside them. */
+const BOUNDARY_DATES: readonly string[] = [
+  "0001-01-01",
+  "1168-10-28",
+  "1799-12-31",
+  "1800-01-01",
+  "1800-01-02",
+  "2000-06-15",
+  `${String(currentYear)}-12-31`,
+  `${String(currentYear + 1)}-01-01`,
+  `${String(currentYear + 1)}-12-31`,
+  `${String(currentYear + 2)}-01-01`,
+  "2944-04-30",
+  "9999-12-31",
+];
+
+const acceptedByGuard = (date: string): boolean =>
+  canonicalDecisionDate(date) !== null;
+
+/** Rows from `execute` under either driver shape (bare array or `{ rows }`). */
+const executedRows = (result: unknown): unknown[] => {
+  if (Array.isArray(result)) {
+    return result;
+  }
+  if (isRecord(result) && Array.isArray(result["rows"])) {
+    return result["rows"];
+  }
+  return [];
+};
+
+/**
+ * Every message down the `cause` chain of a rejection, or `""` when the
+ * promise settled. The driver wraps a constraint violation in a query error
+ * whose own message names the statement, not the constraint.
+ */
+const rejectionOf = async (run: Promise<void>): Promise<string> => {
+  const messages: string[] = [];
+  try {
+    await run;
+  } catch (error: unknown) {
+    let current: unknown = error;
+    while (current instanceof Error) {
+      messages.push(current.message);
+      current = current.cause;
+    }
+  }
+  return messages.join("\n");
+};
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    db = drizzle({ client });
+    await db
+      .insert(caseLawSources)
+      .values([{ id: sourceId, adapterKey: "cz-regional", name: "cz source" }]);
+  },
+  { timeout: 120_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("the SQL fragments are each other's negation and agree with the guard", async () => {
+  const rows = executedRows(
+    await db.execute(sql`
+      SELECT v.date::text AS "date",
+             ${decisionDateWithinBoundsSql(sql.raw("v.date"))} AS "within",
+             ${decisionDateOutOfBoundsSql(sql.raw("v.date"))} AS "out"
+        FROM (VALUES ${sql.join(
+          BOUNDARY_DATES.map((date) => sql`(${date}::date)`),
+          sql`, `,
+        )}) AS v(date)
+    `),
+  );
+  expect(rows.length).toBe(BOUNDARY_DATES.length);
+
+  const verdicts = new Map<string, boolean>();
+  for (const row of rows) {
+    if (!isRecord(row)) {
+      throw new Error("non-row from VALUES");
+    }
+    const { date, within, out } = row;
+    if (typeof date !== "string") {
+      throw new TypeError("date did not render as text");
+    }
+    expect(typeof within).toBe("boolean");
+    expect(within).toBe(!out);
+    verdicts.set(date, within === true);
+  }
+  for (const date of BOUNDARY_DATES) {
+    expect([date, verdicts.get(date)]).toEqual([date, acceptedByGuard(date)]);
+  }
+  // Guards the loop above against a fixture set that made it vacuous.
+  expect(BOUNDARY_DATES.some(acceptedByGuard)).toBe(true);
+  expect(BOUNDARY_DATES.some((date) => !acceptedByGuard(date))).toBe(true);
+});
+
+test("a NULL date is neither within nor out of bounds", async () => {
+  const rows = executedRows(
+    await db.execute(sql`
+      SELECT ${decisionDateWithinBoundsSql(sql.raw("NULL::date"))} AS "within",
+             ${decisionDateOutOfBoundsSql(sql.raw("NULL::date"))} AS "out"
+    `),
+  );
+  expect(rows).toEqual([{ within: null, out: null }]);
+});
+
+test("the table refuses exactly the dates the guard refuses, and takes NULL", async () => {
+  const insertWithDate = async (
+    decisionDate: string | null,
+    index: number,
+  ): Promise<void> => {
+    await db.insert(caseLawDecisions).values({
+      id: createSafeId<"caseLawDecision">(),
+      sourceId,
+      caseNumber: `${String(index)} C ${String(index)}/2020`,
+      court: "Krajský soud",
+      country: "CZE",
+      language: "cs",
+      decisionDate,
+    });
+  };
+
+  await insertWithDate(null, 0);
+
+  const outcomes: { date: string; stored: boolean }[] = [];
+  for (const [index, date] of BOUNDARY_DATES.entries()) {
+    if (acceptedByGuard(date)) {
+      // oxlint-disable-next-line no-await-in-loop -- one insert per fixture on a single test DB connection
+      await insertWithDate(date, index + 1);
+      outcomes.push({ date, stored: true });
+      continue;
+    }
+    // oxlint-disable-next-line no-await-in-loop -- one insert per fixture on a single test DB connection
+    const rejection = await rejectionOf(insertWithDate(date, index + 1));
+    // Refused by this constraint, not by some other check on the row.
+    expect(rejection).toContain(CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT);
+    outcomes.push({ date, stored: false });
+  }
+  expect(outcomes).toEqual(
+    BOUNDARY_DATES.map((date) => ({ date, stored: acceptedByGuard(date) })),
+  );
+
+  const stored = await db
+    .select({ decisionDate: caseLawDecisions.decisionDate })
+    .from(caseLawDecisions);
+  // ISO dates and "null" order correctly bytewise; no locale is involved.
+  const byDate = (left: string | null, right: string | null) => {
+    const l = String(left);
+    const r = String(right);
+    if (l === r) {
+      return 0;
+    }
+    return l < r ? -1 : 1;
+  };
+  expect(
+    stored.map(({ decisionDate }) => decisionDate).toSorted(byDate),
+  ).toEqual([null, ...BOUNDARY_DATES.filter(acceptedByGuard)].toSorted(byDate));
+});
+
+test("the migration adds the expression the schema declares", () => {
+  const check = getTableConfig(caseLawDecisions).checks.find(
+    ({ name }) => name === CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT,
+  );
+  if (check === undefined) {
+    throw new Error("schema declares no decision-date bounds CHECK");
+  }
+  const { sql: declared, params } = new PgDialect().sqlToQuery(check.value);
+  // DDL takes no bind parameters, so the fragment must carry none.
+  expect(params).toEqual([]);
+
+  const migration = readFileSync(MIGRATION_PATH, "utf-8");
+  const added =
+    /ADD CONSTRAINT "case_law_decisions_decision_date_bounds"\s+CHECK \((?<body>[\s\S]*?)\) NOT VALID;/u.exec(
+      migration,
+    )?.groups?.["body"];
+  if (added === undefined) {
+    throw new Error("migration does not add the constraint NOT VALID");
+  }
+  expect(migration).toContain(
+    `VALIDATE CONSTRAINT "${CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT}"`,
+  );
+
+  // The dialect qualifies the column with its table; DDL inside ALTER TABLE
+  // does not. Whitespace is layout, not meaning, on both sides.
+  const normalize = (text: string) =>
+    text.replaceAll('"case_law_decisions".', "").replaceAll(/\s+/gu, "");
+  expect(normalize(added)).toBe(normalize(declared));
+});

--- a/apps/api/src/lib/decision-date-bounds-sql.ts
+++ b/apps/api/src/lib/decision-date-bounds-sql.ts
@@ -1,0 +1,56 @@
+/**
+ * `canonicalDecisionDate`'s year bounds, in SQL.
+ *
+ * Both fragments are derived from `DECISION_YEAR_BOUNDS`, the same declaration
+ * the write-path guard reads, so the runtimes cannot drift into disagreeing
+ * about which stored dates are impossible. `decision-date-bounds-sql.db.test.ts`
+ * proves the agreement executably rather than by inspection, and proves the two
+ * fragments are each other's negation.
+ *
+ * The ceiling is expressed as the first excluded day (1 January of
+ * `currentYear + yearsAhead + 1`) rather than a year comparison, so a predicate
+ * built from it stays a pair of range scans over `case_law_decisions_date_idx`
+ * instead of a sequential scan behind `extract(...)`.
+ *
+ * `now()` is read in UTC to match the guard's `getUTCFullYear()`: a session
+ * time zone must not decide whether a stored date is corrupt.
+ *
+ * Written with `sql.raw` for the two integers so the fragment is literal SQL
+ * with no bind parameters, which is what lets the same text serve in DDL (a
+ * CHECK constraint takes no parameters). The values are integers from an
+ * `as const` declaration, never input.
+ */
+
+import type { SQL, SQLWrapper } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+
+import { DECISION_YEAR_BOUNDS } from "@/api/lib/dates";
+
+/** The `case_law_decisions` CHECK that holds `decisionDateWithinBoundsSql`. */
+export const CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT =
+  "case_law_decisions_decision_date_bounds";
+
+/** First day the bounds admit. */
+const floorSql = sql`make_date(${sql.raw(String(DECISION_YEAR_BOUNDS.min))}, 1, 1)`;
+
+/** First day past the ceiling, relative to the current UTC year. */
+const ceilingSql = sql`make_date(
+       extract(year from (now() AT TIME ZONE 'UTC'))::int
+         + ${sql.raw(String(DECISION_YEAR_BOUNDS.yearsAhead + 1))},
+       1, 1)`;
+
+/** True for a date the write-path guard would refuse; NULL for a NULL date. */
+export const decisionDateOutOfBoundsSql = (column: SQLWrapper): SQL => sql`(
+  ${column} < ${floorSql}
+  OR ${column} >= ${ceilingSql}
+)`;
+
+/**
+ * True for a date the write-path guard accepts; NULL for a NULL date. The
+ * negation of `decisionDateOutOfBoundsSql`, spelled out so a CHECK reads as
+ * the range it enforces.
+ */
+export const decisionDateWithinBoundsSql = (column: SQLWrapper): SQL => sql`(
+  ${column} >= ${floorSql}
+  AND ${column} < ${ceilingSql}
+)`;

--- a/apps/api/src/scripts/repair-decision-dates-plan.db.test.ts
+++ b/apps/api/src/scripts/repair-decision-dates-plan.db.test.ts
@@ -1,11 +1,12 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { inArray } from "drizzle-orm";
+import { inArray, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createSafeId } from "@/api/lib/branded-types";
 import { canonicalDecisionDate } from "@/api/lib/dates";
+import { CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT } from "@/api/lib/decision-date-bounds-sql";
 import { isRecord } from "@/api/lib/type-guards";
 import type {
   CorruptDecisionDateRow,
@@ -161,6 +162,13 @@ beforeAll(
   async () => {
     client = await createTestPglite();
     db = drizzle({ client });
+
+    // The fixtures are rows the table's bounds CHECK refuses: they model what
+    // was stored before the constraint existed, which is the population the
+    // repair walks. `decision-date-bounds-sql.db.test.ts` covers the CHECK.
+    await db.execute(
+      sql`ALTER TABLE case_law_decisions DROP CONSTRAINT ${sql.identifier(CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT)}`,
+    );
 
     await db.insert(caseLawSources).values([
       { id: czSourceId, adapterKey: "cz-regional", name: "cz source" },

--- a/apps/api/src/scripts/repair-decision-dates-plan.ts
+++ b/apps/api/src/scripts/repair-decision-dates-plan.ts
@@ -96,6 +96,9 @@ export const DECISION_DATE_ROW_LOCKS = {
 export type DecisionDateRowLock =
   (typeof DECISION_DATE_ROW_LOCKS)[keyof typeof DECISION_DATE_ROW_LOCKS];
 
+/** Pages of ids the corrupt-id collection may hold before it is paged. */
+const CORRUPT_SCAN_PAGES = 100;
+
 type SelectCorruptDecisionDatesOptions = {
   limit: number;
   lock: DecisionDateRowLock;
@@ -103,7 +106,10 @@ type SelectCorruptDecisionDatesOptions = {
 
 /*
  * The corrupt ids are collected in one materialized CTE and paged in a
- * second on purpose. Written as one statement over the join, the planner
+ * second on purpose. The collection is capped at a multiple of the page
+ * (unordered, so the date index still answers it) rather than materializing
+ * an unexpectedly large population; a page drawn from a capped set is still
+ * a page of corrupt rows, and the caller loops until a page is empty. Written as one statement over the join, the planner
  * estimates the date bounds to match a large share of the table and either
  * merge-joins over a full primary-key scan or walks the primary key in order
  * filtering every row; both outrun the statement timeout while the bounds
@@ -121,6 +127,7 @@ export const selectCorruptDecisionDatesStatement = ({
     SELECT d.id
       FROM case_law_decisions d
      WHERE ${OUT_OF_BOUNDS}
+     LIMIT ${limit * CORRUPT_SCAN_PAGES}
   ),
   page AS MATERIALIZED (
     SELECT c.id

--- a/apps/api/src/scripts/repair-decision-dates-plan.ts
+++ b/apps/api/src/scripts/repair-decision-dates-plan.ts
@@ -15,38 +15,10 @@ import type { SQL } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 
 import type { SafeId } from "@/api/lib/branded-types";
-import { canonicalDecisionDate, DECISION_YEAR_BOUNDS } from "@/api/lib/dates";
+import { canonicalDecisionDate } from "@/api/lib/dates";
+import { decisionDateOutOfBoundsSql } from "@/api/lib/decision-date-bounds-sql";
 import { brandPersistedCaseLawDecisionId } from "@/api/lib/safe-id-boundaries";
 import { isRecord } from "@/api/lib/type-guards";
-
-/**
- * `canonicalDecisionDate`'s year bounds, in SQL.
- *
- * Both halves are derived from `DECISION_YEAR_BOUNDS`, the same declaration
- * the write-path guard reads, so the two runtimes cannot drift into disagreeing
- * about which stored dates are impossible. `repair-decision-dates-plan.db.test.ts`
- * proves the agreement executably rather than by inspection.
- *
- * The ceiling is expressed as the first excluded day (1 January of
- * `currentYear + yearsAhead + 1`) rather than a year comparison, so the
- * predicate stays a pair of range scans over `case_law_decisions_date_idx`
- * instead of a sequential scan behind `extract(...)`.
- *
- * `now()` is read in UTC to match the guard's `getUTCFullYear()`: a session
- * time zone must not decide whether a stored date is corrupt.
- *
- * Written with `sql.raw` for the two integers so the fragment is literal SQL
- * with no bind parameters, which is what lets the same text be reused verbatim
- * in DDL (a CHECK constraint takes no parameters). The values are integers from
- * an `as const` declaration, never input.
- */
-export const decisionDateOutOfBoundsSql = (column: SQL): SQL => sql`(
-  ${column} < make_date(${sql.raw(String(DECISION_YEAR_BOUNDS.min))}, 1, 1)
-  OR ${column} >= make_date(
-       extract(year from (now() AT TIME ZONE 'UTC'))::int
-         + ${sql.raw(String(DECISION_YEAR_BOUNDS.yearsAhead + 1))},
-       1, 1)
-)`;
 
 const OUT_OF_BOUNDS = decisionDateOutOfBoundsSql(sql.raw("d.decision_date"));
 

--- a/apps/api/src/scripts/repair-decision-dates-plan.ts
+++ b/apps/api/src/scripts/repair-decision-dates-plan.ts
@@ -129,19 +129,42 @@ type SelectCorruptDecisionDatesOptions = {
   lock: DecisionDateRowLock;
 };
 
+/*
+ * The corrupt ids are collected in one materialized CTE and paged in a
+ * second on purpose. Written as one statement over the join, the planner
+ * estimates the date bounds to match a large share of the table and either
+ * merge-joins over a full primary-key scan or walks the primary key in order
+ * filtering every row; both outrun the statement timeout while the bounds
+ * actually match a handful of rows. The first CTE keeps the predicate on its
+ * own, where the date index answers it; the second applies the ordering and
+ * the page limit to that set, so the join and the lock cost one primary-key
+ * lookup per id.
+ */
+
 export const selectCorruptDecisionDatesStatement = ({
   limit,
   lock,
 }: SelectCorruptDecisionDatesOptions): SQL => sql`
+  WITH corrupt AS MATERIALIZED (
+    SELECT d.id
+      FROM case_law_decisions d
+     WHERE ${OUT_OF_BOUNDS}
+  ),
+  page AS MATERIALIZED (
+    SELECT c.id
+      FROM corrupt c
+     ORDER BY c.id
+     LIMIT ${limit}
+  )
   SELECT d.id AS "id",
          s.adapter_key AS "adapterKey",
          d.decision_date::text AS "storedDate",
          d.metadata->>'decisionDate' AS "metadataDate",
          d.citation_key AS "citationKey",
          d.country AS "country"
-    FROM case_law_decisions d
+    FROM page c
+    JOIN case_law_decisions d ON d.id = c.id
     JOIN case_law_sources s ON s.id = d.source_id
-   WHERE ${OUT_OF_BOUNDS}
    ORDER BY d.id
    LIMIT ${limit}
    ${lock === DECISION_DATE_ROW_LOCKS.FOR_UPDATE ? sql`FOR UPDATE OF d` : sql``}

--- a/apps/api/src/scripts/repair-decision-dates.ts
+++ b/apps/api/src/scripts/repair-decision-dates.ts
@@ -35,15 +35,15 @@
  * order, decision rows before the graph, so a refresh of one of these decisions
  * running at the same time cannot deadlock against the repair.
  *
- * **Why the bounds are not a CHECK constraint yet.** They should be, and the
- * predicate above is written so the same text can become one. It cannot land
- * before this run has: `ADD CONSTRAINT … NOT VALID` skips the scan of existing
- * rows but still enforces the constraint on every later INSERT and UPDATE, so
- * while a corrupt row survives, any unrelated write touching it — a citation
- * authority refresh, a corpus mirror update, an index hash — fails on a column
- * it never mentioned. `VALIDATE CONSTRAINT` fails outright. A report-only run
- * finding zero rows is the precondition; until then the write path's own
- * `canonicalDecisionDate` is the guard, and `dates.test.ts` pins its bounds.
+ * **The bounds are also a CHECK constraint.** `case_law_decisions_decision_date_bounds`
+ * (migration 20260818090000) holds the same predicate, derived from the same
+ * `DECISION_YEAR_BOUNDS`. Its `VALIDATE CONSTRAINT` fails while a corrupt row
+ * survives, and until then `ADD CONSTRAINT … NOT VALID` makes any unrelated
+ * write touching such a row — a citation authority refresh, a corpus mirror
+ * update, an index hash — fail on a column it never mentioned. So this runs
+ * against a database before that migration is applied to it; a report finding
+ * zero rows is the precondition, and once the constraint is validated the
+ * selection is empty by construction.
  *
  * Without `--apply` nothing is written and nothing is locked: the run reports
  * the population per source and per year, then how many of those rows a repair


### PR DESCRIPTION
Two commits.

1. `fix(api): page corrupt decision dates through the date index`: `selectCorruptDecisionDatesStatement` collects the out-of-bounds ids in a materialized CTE and pages them in a second one; written as one statement over the join, the planner estimated the bounds to match a large share of the table and either merge-joined over a full primary-key scan or walked the primary key filtering every row, past the statement timeout, while the bounds match a handful of rows.

2. `feat(db): bound case_law_decisions.decision_date at the table`: the bounds the write path enforces (`canonicalDecisionDate`, `DECISION_YEAR_BOUNDS`) are now also a table constraint, `case_law_decisions_decision_date_bounds`, `CHECK (decision_date IS NULL OR (decision_date >= make_date(1800,1,1) AND decision_date < make_date(extract(year from (now() AT TIME ZONE 'UTC'))::int + 2, 1, 1)))`. Both the schema check and the repair predicate render from one module (`decision-date-bounds-sql.ts`); a PGlite test asserts the two are complementary on boundary dates and that the migration's CHECK body equals the schema's. Migration adds the constraint `NOT VALID` (guarded) and validates it in a separate statement. The seed fixture routes its dates through `canonicalDecisionDate`.

Precondition: the repair script's report finds zero out-of-bounds rows.