### PR TITLE
feat(api): group case-law corpus indexes by language from generation 3

### DIFF
--- a/apps/api/drizzle/20260818120000_case_law_corpus_index_groups/migration.sql
+++ b/apps/api/drizzle/20260818120000_case_law_corpus_index_groups/migration.sql
@@ -1,0 +1,159 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- The physical corpus-index id of a case-law decision, derived in one place.
+--
+-- Up to generation `case_law_v2` the id is `<generation>_<country>`, one
+-- index per jurisdiction. From `case_law_v3` on it is `<generation>_<group>`,
+-- where the group is the jurisdiction's entry in `CASE_LAW_INDEX_GROUPS`
+-- (apps/api/src/lib/legal-search/case-law-index-groups.ts): CZE and SVK share
+-- `cs_sk`, AUT and DEU share `de`, POL is `pl`, EU is `eu`, and any other
+-- country is its own lowercase code. The body below is the rendering of that
+-- declaration; `case-law-index-groups.db.test.ts` checks the function, the
+-- query fragment, and `corpusIndexId` against each other. Ids already stored
+-- for `case_law_v1` and `case_law_v2` are unchanged by this rule.
+--
+-- IMMUTABLE and STRICT: the result depends on its two arguments alone, and a
+-- NULL argument yields NULL, the same as the concatenation it replaces.
+CREATE OR REPLACE FUNCTION case_law_corpus_index_id(generation text, country text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE STRICT
+AS $function$
+  SELECT CASE
+  WHEN substring(generation from '^case_law_v([1-9][0-9]*)$')::integer
+       >= 3
+  THEN generation || '_' || CASE upper(country)
+    WHEN 'CZE' THEN 'cs_sk'
+    WHEN 'SVK' THEN 'cs_sk'
+    WHEN 'POL' THEN 'pl'
+    WHEN 'EU' THEN 'eu'
+    WHEN 'AUT' THEN 'de'
+    WHEN 'DEU' THEN 'de'
+    ELSE lower(country)
+  END
+  ELSE generation || '_' || lower(country)
+END
+$function$;--> statement-breakpoint
+
+-- The projection trigger derives a decision's target index at two points: the
+-- serving-generation mark it accepts, and the pending target it enqueues. Both
+-- now go through the function above; everything else in the body is as
+-- 20260817150000_corpus_generation_date_walk left it. The trigger itself is
+-- unchanged and keeps pointing at this function.
+CREATE OR REPLACE FUNCTION enqueue_case_law_corpus_index_projection()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.content_hash IS NULL THEN
+      INSERT INTO case_law_corpus_index_projections (
+        generation,
+        decision_id,
+        pending_action,
+        pending_hash,
+        pending_index_ids,
+        pending_revision,
+        updated_at
+      )
+      SELECT checkpoint.generation, NEW.id, 'delete', null, '{}', 1, clock_timestamp()
+      FROM case_law_corpus_index_backfills AS checkpoint
+      WHERE EXISTS (
+        SELECT 1
+        FROM case_law_corpus_index_projections AS existing
+        WHERE existing.generation = checkpoint.generation
+          AND existing.decision_id = NEW.id
+      ) OR NOT EXISTS (
+        SELECT 1
+        FROM case_law_corpus_index_backfills AS newer
+        WHERE (newer.generation_order, newer.generation) >
+          (checkpoint.generation_order, checkpoint.generation)
+      )
+      ON CONFLICT ON CONSTRAINT case_law_corpus_index_projections_pk DO UPDATE
+      SET pending_action = EXCLUDED.pending_action,
+          pending_hash = EXCLUDED.pending_hash,
+          pending_index_ids = ARRAY(
+            SELECT DISTINCT target
+            FROM unnest(
+              case_law_corpus_index_projections.pending_index_ids || CASE
+                WHEN case_law_corpus_index_projections.index_id IS NULL THEN '{}'
+                ELSE ARRAY[case_law_corpus_index_projections.index_id]
+              END
+            ) AS target
+          ),
+          pending_revision = case_law_corpus_index_projections.pending_revision + 1,
+          updated_at = EXCLUDED.updated_at;
+      RETURN NEW;
+    END IF;
+
+    IF NEW.indexed_hash IS NOT NULL
+      AND NEW.content_hash IS NOT DISTINCT FROM OLD.content_hash
+      AND NEW.country IS NOT DISTINCT FROM OLD.country
+      AND NEW.decision_date IS NOT DISTINCT FROM OLD.decision_date
+    THEN
+      -- The ordinary incremental writer owns the serving generation while a
+      -- newer generation may be rebuilding. Its successful database mark is
+      -- also the authoritative projection commit for that serving generation;
+      -- the newer generation's independently queued action remains untouched.
+      -- The decision date joins this guard because it reaches the document:
+      -- an update that changes it is a content change for the index, however
+      -- unchanged the text is.
+      UPDATE case_law_corpus_index_projections AS projection
+      SET index_id = NEW.indexed_generation,
+          indexed_hash = NEW.indexed_hash,
+          updated_at = clock_timestamp()
+      WHERE projection.decision_id = NEW.id
+        AND NEW.indexed_generation =
+          case_law_corpus_index_id(projection.generation, NEW.country);
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  IF NEW.content_hash IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO case_law_corpus_index_projections (
+    generation,
+    decision_id,
+    pending_action,
+    pending_hash,
+    pending_index_ids,
+    pending_revision,
+    updated_at
+  )
+  SELECT checkpoint.generation,
+         NEW.id,
+         'index',
+         NEW.content_hash,
+         ARRAY[case_law_corpus_index_id(checkpoint.generation, NEW.country)],
+         1,
+         clock_timestamp()
+  FROM case_law_corpus_index_backfills AS checkpoint
+  WHERE EXISTS (
+    SELECT 1
+    FROM case_law_corpus_index_projections AS existing
+    WHERE existing.generation = checkpoint.generation
+      AND existing.decision_id = NEW.id
+  ) OR NOT EXISTS (
+      SELECT 1
+      FROM case_law_corpus_index_backfills AS newer
+      WHERE (newer.generation_order, newer.generation) >
+        (checkpoint.generation_order, checkpoint.generation)
+    )
+  ON CONFLICT ON CONSTRAINT case_law_corpus_index_projections_pk DO UPDATE
+  SET pending_action = EXCLUDED.pending_action,
+      pending_hash = EXCLUDED.pending_hash,
+      pending_index_ids = ARRAY(
+        SELECT DISTINCT target
+        FROM unnest(
+          case_law_corpus_index_projections.pending_index_ids || EXCLUDED.pending_index_ids
+        ) AS target
+      ),
+      pending_revision = case_law_corpus_index_projections.pending_revision + 1,
+      updated_at = EXCLUDED.updated_at;
+
+  RETURN NEW;
+END
+$function$;

--- a/apps/api/drizzle/20260818120000_case_law_corpus_index_groups/migration.sql
+++ b/apps/api/drizzle/20260818120000_case_law_corpus_index_groups/migration.sql
@@ -5,13 +5,20 @@ SET statement_timeout = '5s';--> statement-breakpoint
 --
 -- Up to generation `case_law_v2` the id is `<generation>_<country>`, one
 -- index per jurisdiction. From `case_law_v3` on it is `<generation>_<group>`,
--- where the group is the jurisdiction's entry in `CASE_LAW_INDEX_GROUPS`
+-- where the group is the jurisdiction's entry in `CASE_LAW_INDEX_GROUP_OF`
 -- (apps/api/src/lib/legal-search/case-law-index-groups.ts): CZE and SVK share
--- `cs_sk`, AUT and DEU share `de`, POL is `pl`, EU is `eu`, and any other
--- country is its own lowercase code. The body below is the rendering of that
--- declaration; `case-law-index-groups.db.test.ts` checks the function, the
--- query fragment, and `corpusIndexId` against each other. Ids already stored
--- for `case_law_v1` and `case_law_v2` are unchanged by this rule.
+-- `cs_sk`; AUT, EU, and POL each keep an index named by their own lowercase
+-- code, and so does any other country. Every declared jurisdiction is listed,
+-- an index of its own included, so the function reads as the declaration. A
+-- shared group's name contains an underscore and a country code holds letters
+-- only, so a country outside the list never lands in a shared group. The
+-- generation order is compared in numeric within the integer range of the
+-- backfill checkpoint's `generation_order` column; a longer digit run is not a
+-- case-law generation and stays per country rather than failing a cast. The
+-- body below is the rendering of that declaration;
+-- `case-law-index-groups.db.test.ts` checks the function, the query fragment,
+-- and `corpusIndexId` against each other. Ids already stored for `case_law_v1`
+-- and `case_law_v2` are unchanged by this rule.
 --
 -- IMMUTABLE and STRICT: the result depends on its two arguments alone, and a
 -- NULL argument yields NULL, the same as the concatenation it replaces.
@@ -21,15 +28,15 @@ LANGUAGE sql
 IMMUTABLE STRICT
 AS $function$
   SELECT CASE
-  WHEN substring(generation from '^case_law_v([1-9][0-9]*)$')::integer
-       >= 3
+  WHEN substring(generation from '^case_law_v([1-9][0-9]*)$')::numeric
+       BETWEEN 3
+       AND 2147483647
   THEN generation || '_' || CASE upper(country)
+    WHEN 'AUT' THEN 'aut'
     WHEN 'CZE' THEN 'cs_sk'
-    WHEN 'SVK' THEN 'cs_sk'
-    WHEN 'POL' THEN 'pl'
     WHEN 'EU' THEN 'eu'
-    WHEN 'AUT' THEN 'de'
-    WHEN 'DEU' THEN 'de'
+    WHEN 'POL' THEN 'pol'
+    WHEN 'SVK' THEN 'cs_sk'
     ELSE lower(country)
   END
   ELSE generation || '_' || lower(country)

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -147,8 +147,9 @@ export const envBaseServerSchema = {
     "pg-fts",
   ),
   // Blue-green generation prefix. Each jurisdiction gets its own index
-  // (`<generation>_<country>`, e.g. case_law_v1_svk); bump the prefix to
-  // rebuild all jurisdictions and flip to it.
+  // (`<generation>_<country>`, e.g. case_law_v1_svk) up to generation 2, and
+  // each index group from generation 3 on (`corpusIndexId`); bump the prefix
+  // to rebuild all jurisdictions and flip to it.
   LEGAL_SEARCH_INDEX_GENERATION: v.optional(v.string(), "case_law_v1"),
   // Local-development-only search endpoint for consuming a shared corpus.
   // Request-path searches use it while mutations remain bound to the separate

--- a/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
@@ -36,18 +36,24 @@ const generationMigrationSource = new URL(
   "../../../drizzle/20260731170000_case_law_corpus_generation_backfill/migration.sql",
   import.meta.url,
 );
+const INDEX_ID_FUNCTION =
+  "CREATE OR REPLACE FUNCTION case_law_corpus_index_id(generation text, country text)";
 const PROJECTION_TRIGGER_FUNCTION =
   "CREATE OR REPLACE FUNCTION enqueue_case_law_corpus_index_projection()";
+const PROJECTION_TRIGGER =
+  "CREATE TRIGGER case_law_decisions_enqueue_corpus_index_projection";
+const PROJECTION_TRIGGER_STATEMENT =
+  /\b(?:CREATE|DROP) TRIGGER (?:IF EXISTS )?case_law_decisions_enqueue_corpus_index_projection\b/u;
 
 /**
- * The projection trigger's current definition. `db:push` builds the test
- * database from the schema, which carries no triggers, so a test that needs
- * one installs it from a migration. Which migration is derived, not named:
- * migrations apply in directory order, so the last one that redefines the
- * function is the definition a database ends up with, and a later migration
- * replacing it moves this with it.
+ * The statements of the last migration containing `marker`. `db:push` builds
+ * the test database from the schema, which carries no triggers or functions,
+ * so a test that needs them installs them from a migration. Which migration
+ * is derived, not named: migrations apply in directory order, so the last one
+ * that redefines an object is the definition a database ends up with, and a
+ * later migration replacing it moves this with it.
  */
-const latestProjectionTriggerMigration = async (): Promise<string> => {
+const latestMigrationStatements = async (marker: string): Promise<string[]> => {
   const drizzleDir = new URL("../../../drizzle/", import.meta.url);
   const migrations = [
     ...new Bun.Glob("*/migration.sql").scanSync(Bun.fileURLToPath(drizzleDir)),
@@ -56,14 +62,17 @@ const latestProjectionTriggerMigration = async (): Promise<string> => {
   for (const migration of migrations) {
     // oxlint-disable-next-line no-await-in-loop -- ordered scan over a directory listing
     const source = await Bun.file(new URL(migration, drizzleDir)).text();
-    if (source.includes(PROJECTION_TRIGGER_FUNCTION)) {
+    if (source.includes(marker)) {
       latest = source;
     }
   }
   if (latest === undefined) {
-    throw new Error("no migration defines the corpus projection trigger");
+    throw new Error(`no migration contains ${marker}`);
   }
-  return latest;
+  return latest
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
 };
 const CREATED_AT = new Date("2026-07-30T12:00:00.000Z");
 const GENERATION = "case_law_v2";
@@ -235,31 +244,32 @@ const completeRemoteEffect = async (): Promise<void> => {
 };
 
 /**
- * Install the projection trigger as the migration defines it, so a test runs
- * against the deployed definition rather than a paraphrase of it.
+ * Install the projection trigger as the migrations define it, so a test runs
+ * against the deployed definition rather than a paraphrase of it: the index
+ * id function the trigger calls, the trigger function, then the trigger, each
+ * from the last migration defining it.
  */
 const installProjectionTrigger = async (): Promise<void> => {
-  const migration = await latestProjectionTriggerMigration();
-  const triggerStart = migration.indexOf(PROJECTION_TRIGGER_FUNCTION);
-  const triggerEnd = migration.indexOf(
-    "CREATE TRIGGER case_law_decisions_enqueue_corpus_index_projection",
-  );
-  expect(triggerStart).toBeGreaterThanOrEqual(0);
-  expect(triggerEnd).toBeGreaterThan(triggerStart);
-  const createTriggerEnd = migration.indexOf(";", triggerEnd);
-  const statements = migration
-    .slice(triggerStart, createTriggerEnd + 1)
-    .split("--> statement-breakpoint")
-    .map((statement) => statement.trim())
-    .filter((statement) => statement.length > 0);
-  expect(statements).toHaveLength(3);
+  const functionStatements = [
+    ...(await latestMigrationStatements(INDEX_ID_FUNCTION)).filter(
+      (statement) => statement.includes(INDEX_ID_FUNCTION),
+    ),
+    ...(await latestMigrationStatements(PROJECTION_TRIGGER_FUNCTION)).filter(
+      (statement) => statement.includes(PROJECTION_TRIGGER_FUNCTION),
+    ),
+  ];
+  expect(functionStatements).toHaveLength(2);
+  // The replacement drop (`DROP TRIGGER IF EXISTS ...`) and the creation.
+  const triggerStatements = (
+    await latestMigrationStatements(PROJECTION_TRIGGER)
+  ).filter((statement) => PROJECTION_TRIGGER_STATEMENT.test(statement));
   // The trigger fires on the columns that reach the document or the walk's
   // position. A decision date now does both, so it has to be in this list.
-  expect(statements.at(-1)).toContain(
+  expect(triggerStatements.at(-1)).toContain(
     "UPDATE OF content_hash, indexed_hash, country, decision_date",
   );
-  for (const statement of statements) {
-    // oxlint-disable-next-line no-await-in-loop -- function, replacement drop, and trigger creation are order-dependent DDL
+  for (const statement of [...functionStatements, ...triggerStatements]) {
+    // oxlint-disable-next-line no-await-in-loop -- functions, replacement drop, and trigger creation are order-dependent DDL
     await db.execute(sql.raw(statement));
   }
 };
@@ -900,14 +910,14 @@ test(
       });
       await db
         .update(caseLawDecisions)
-        .set({ country: "SVK" })
+        .set({ country: "POL" })
         .where(eq(caseLawDecisions.id, publicFirstId));
       await db
         .update(caseLawCorpusIndexProjections)
         .set({
           pendingAction: "index",
           pendingHash: "first",
-          pendingIndexIds: [corpusIndexId(generation, "SVK")],
+          pendingIndexIds: [corpusIndexId(generation, "POL")],
         })
         .where(eq(caseLawCorpusIndexProjections.generation, generation));
       expect(await backfill(scopedDb, 10, generation)).toEqual({
@@ -924,7 +934,7 @@ test(
           .where(eq(caseLawCorpusIndexProjections.generation, generation))
           .limit(1)
       ).at(0);
-      expect(movedProjection?.indexId).toBe(corpusIndexId(generation, "SVK"));
+      expect(movedProjection?.indexId).toBe(corpusIndexId(generation, "POL"));
     } finally {
       await db
         .update(caseLawDecisions)
@@ -1525,7 +1535,8 @@ test(
       "00000000-0000-4000-8000-000000000010",
     );
     const staleIndexId = corpusIndexId(generation, "CZE");
-    const successorIndexId = corpusIndexId(generation, "SVK");
+    // POL sits in another index group, so this is a different physical index.
+    const successorIndexId = corpusIndexId(generation, "POL");
     await db.insert(caseLawDecisions).values({
       caseNumber: "stale fence",
       contentHash: "stale",
@@ -1604,7 +1615,7 @@ test(
               .where(eq(caseLawCorpusIndexWriterLeases.generation, generation));
             await db
               .update(caseLawDecisions)
-              .set({ country: "SVK", indexedHash: null })
+              .set({ country: "POL", indexedHash: null })
               .where(eq(caseLawDecisions.id, staleDecisionId));
             winnerResult = await winner(scopedDb, 1, generation);
           },
@@ -1878,7 +1889,7 @@ test(
     const decisionId = toSafeId<"caseLawDecision">(
       "00000000-0000-4000-8000-000000000097",
     );
-    const staleIndexId = corpusIndexId(generation, "SVK");
+    const staleIndexId = corpusIndexId(generation, "POL");
     await db.insert(caseLawCorpusIndexBackfills).values({
       generation,
       snapshotAt: await nextBackfillSnapshotAt(),
@@ -2059,10 +2070,13 @@ test(
         .where(eq(caseLawCorpusIndexProjections.generation, generation));
       expect(await visible()).toBe(false);
 
+      // A country from another index group: under this generation CZE and
+      // SVK share one physical index, so only a different group is a
+      // different index.
       await db
         .update(caseLawCorpusIndexProjections)
         .set({
-          indexId: corpusIndexId(generation, "SVK"),
+          indexId: corpusIndexId(generation, "POL"),
           pendingAction: null,
           pendingHash: null,
           pendingIndexIds: [],

--- a/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
@@ -19,6 +19,10 @@ const sharedSearchProviderSource = new URL(
   "../../lib/legal-search/corpus-index-provider.ts",
   import.meta.url,
 );
+const caseLawCorpusProjectionSource = new URL(
+  "../../lib/legal-search/case-law-corpus-projection.ts",
+  import.meta.url,
+);
 const generationMigrationSource = new URL(
   "../../../drizzle/20260731170000_case_law_corpus_generation_backfill/migration.sql",
   import.meta.url,
@@ -510,6 +514,43 @@ test("every case-law corpus query is assembled by the shared builder", async () 
     // the expander made reachable.
     expect(source).not.toMatch(/"\s+OR\s+"/u);
   }
+});
+
+// The physical index id has one SQL derivation, `caseLawIndexIdSql`, and its
+// migration twin `case_law_corpus_index_id`. A hand-written concatenation in
+// a query or the trigger would be a second answer to which index a decision
+// belongs to, and from generation 3 on a wrong one.
+test("no case-law SQL derives the physical index id by hand", async () => {
+  const consumers = await Promise.all(
+    [caseLawCorpusIndexSource, caseLawCorpusProjectionSource].map(
+      async (source) => await Bun.file(source).text(),
+    ),
+  );
+  for (const source of consumers) {
+    expect(source).not.toMatch(/\|\|\s*'_'\s*\|\|/u);
+  }
+  const triggerMigrations = readdirSync(DRIZZLE_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => nodePath.join(DRIZZLE_DIR, entry.name, "migration.sql"))
+    .filter((file) => existsSync(file))
+    .sort()
+    .filter((file) =>
+      readFileSync(file, "utf-8").includes(
+        "CREATE OR REPLACE FUNCTION enqueue_case_law_corpus_index_projection()",
+      ),
+    );
+  const latestTrigger = triggerMigrations.at(-1);
+  if (latestTrigger === undefined) {
+    throw new Error("no migration defines the projection trigger");
+  }
+  const trigger = readFileSync(latestTrigger, "utf-8");
+  expect(trigger).toContain(
+    "NEW.indexed_generation =\n          case_law_corpus_index_id(projection.generation, NEW.country)",
+  );
+  expect(trigger).toContain(
+    "ARRAY[case_law_corpus_index_id(checkpoint.generation, NEW.country)]",
+  );
+  expect(trigger).not.toContain("|| '_' || lower(NEW.country)");
 });
 
 test("every case-law corpus search boundary uses generation projection state", async () => {

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -46,6 +46,8 @@ import {
   timestampMatchesCasToken,
 } from "@/api/lib/db/timestamp-cas";
 import { ConcurrentModificationError } from "@/api/lib/errors/tagged-errors";
+import { caseLawDecisionCorpusIndexIdSql } from "@/api/lib/legal-search/case-law-corpus-projection";
+import { caseLawIndexIdSql } from "@/api/lib/legal-search/case-law-index-groups";
 import {
   CORPUS_INDEX_COMMIT,
   CorpusIndexError,
@@ -76,9 +78,9 @@ import {
  * Domain adapter over the shared core (lib/corpus-index/core.ts): supplies the
  * case-law tables, batch queries, and per-decision document shape; the core
  * owns the S3-chunked load, per-group ingest, compare-and-set commit, and audit
- * trail (case_law_index_jobs). Per-jurisdiction indexes (`case_law_v1_<country>`)
- * with the license gate in SQL so non-redistributable sources never enter the
- * scan.
+ * trail (case_law_index_jobs). Physical indexes are named by `corpusIndexId`
+ * (per jurisdiction, or per index group from generation 3 on), with the
+ * license gate in SQL so non-redistributable sources never enter the scan.
  *
  * Case law is indexed at passage granularity: a decision projects to one
  * search document per passage of its AST, all carrying the same doc-level
@@ -431,7 +433,7 @@ const recoverLostGenerationProjectionEffect = async (
                SELECT DISTINCT target
                FROM unnest(ARRAY[
                  ${indexId},
-               ${generation} || '_' || lower(decision.country)
+                 ${caseLawIndexIdSql(sql`${generation}`, sql.raw("decision.country"))}
                ]) AS target
              ), 1, now()
       FROM ${caseLawDecisions} AS decision
@@ -751,7 +753,7 @@ export const caseLawCorpusIndexAdapter = {
             hasCorpusJurisdiction,
             redistributableCaseLawSource,
             isNotNull(caseLawDecisions.indexedHash),
-            sql`${caseLawDecisions.indexedGeneration} = (${generation} || '_' || lower(${caseLawDecisions.country}))`,
+            sql`${caseLawDecisions.indexedGeneration} = (${caseLawDecisionCorpusIndexIdSql(generation)})`,
             sql`${caseLawDecisions.indexedHash} IS DISTINCT FROM ${caseLawDecisions.contentHash}`,
           ),
         )

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -39,8 +39,7 @@ import {
 import { resolveExpandedCorpusQuery } from "@/api/lib/legal-search/expansion";
 import { loadFtsSearchConfigs } from "@/api/lib/legal-search/fts-config";
 import {
-  corpusIndexId,
-  corpusIndexPattern,
+  corpusIndexRoute,
   isCorpusIndexJurisdiction,
 } from "@/api/lib/legal-search/index-naming";
 import { buildPgFtsSearchSql } from "@/api/lib/legal-search/pg-fts-query";
@@ -438,6 +437,7 @@ const searchPostgresDecisions = async (
 // expander is resolved from it here rather than inside the query builder.
 const buildCorpusIndexQuery = (
   body: SearchDecisionsBody,
+  jurisdictionClause: string | undefined,
   expand?: CorpusTermExpander,
 ): string | null =>
   caseLawCorpusQuery(
@@ -447,6 +447,7 @@ const buildCorpusIndexQuery = (
       dateFrom: body.dateFrom,
       dateTo: body.dateTo,
       documentType: body.decisionType,
+      jurisdiction: jurisdictionClause,
       language: body.language,
       source: body.sourceId,
     },
@@ -456,9 +457,10 @@ const buildCorpusIndexQuery = (
 /** Mode, dictionary, and shadow accounting are the shared resolver's. */
 const resolveCorpusIndexQuery = async (
   body: SearchDecisionsBody,
+  jurisdictionClause: string | undefined,
 ): Promise<string | null> =>
   await resolveExpandedCorpusQuery({
-    build: (expand) => buildCorpusIndexQuery(body, expand),
+    build: (expand) => buildCorpusIndexQuery(body, jurisdictionClause, expand),
     jurisdiction: body.country,
     mode: envBase.QUERY_EXPANSION_MODE,
     text: body.query,
@@ -494,11 +496,14 @@ const searchCorpusIndexDecisions = async (
   }
 
   const generation = corpusGeneration("case_law");
-  const indexId = body.country
-    ? corpusIndexId(generation, body.country)
-    : corpusIndexPattern(generation);
+  // Scoped query → that country's index, plus a jurisdiction clause when that
+  // index holds other countries; unscoped → the generation glob.
+  const { indexId, jurisdictionClause } = corpusIndexRoute(
+    generation,
+    body.country,
+  );
 
-  const query = await resolveCorpusIndexQuery(body);
+  const query = await resolveCorpusIndexQuery(body, jurisdictionClause);
   if (query === null) {
     return { hits: [], facets: null, totalCount: null, nextCursor: null };
   }

--- a/apps/api/src/lib/corpus-index/census.db.test.ts
+++ b/apps/api/src/lib/corpus-index/census.db.test.ts
@@ -1,6 +1,7 @@
 /**
- * The repair behind a census drift warning: un-mark a jurisdiction so
- * the ordinary backfill re-selects it.
+ * The repair behind a census drift warning: un-mark an index so the
+ * ordinary backfill re-selects it. Under this generation every index is
+ * one jurisdiction's, so the two are named interchangeably below.
  *
  * Four things can go wrong, and all of them are SQL. It can miss the
  * rows the census counted — a generation rebuild records success in the
@@ -27,7 +28,7 @@ import {
   caseLawSources,
 } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
-import { clearJurisdictionIndexMarks } from "@/api/lib/corpus-index/census";
+import { clearIndexMarks } from "@/api/lib/corpus-index/census";
 import {
   caseLawCorpusProjectionJoin,
   currentCaseLawCorpusProjection,
@@ -167,10 +168,10 @@ test("the repair reaches rows marked only through the generation projection", as
     DECISIONS_PER_JURISDICTION,
   );
 
-  const cleared = await clearJurisdictionIndexMarks({
+  const cleared = await clearIndexMarks({
     scopedDb,
     generation: GENERATION,
-    jurisdiction: SHORT_JURISDICTION,
+    indexId: corpusIndexId(GENERATION, SHORT_JURISDICTION),
     limit: SLICE,
   });
 
@@ -186,10 +187,10 @@ test("the repair reaches rows marked only through the generation projection", as
 });
 
 test("re-running walks the jurisdiction instead of re-clearing the first page", async () => {
-  const cleared = await clearJurisdictionIndexMarks({
+  const cleared = await clearIndexMarks({
     scopedDb,
     generation: GENERATION,
-    jurisdiction: SHORT_JURISDICTION,
+    indexId: corpusIndexId(GENERATION, SHORT_JURISDICTION),
     limit: SLICE,
   });
 
@@ -198,10 +199,10 @@ test("re-running walks the jurisdiction instead of re-clearing the first page", 
   expect(cleared).toBe(DECISIONS_PER_JURISDICTION - SLICE);
   expect(await currentRows(SHORT_JURISDICTION)).toHaveLength(0);
 
-  const exhausted = await clearJurisdictionIndexMarks({
+  const exhausted = await clearIndexMarks({
     scopedDb,
     generation: GENERATION,
-    jurisdiction: SHORT_JURISDICTION,
+    indexId: corpusIndexId(GENERATION, SHORT_JURISDICTION),
     limit: SLICE,
   });
   expect(exhausted).toBe(0);

--- a/apps/api/src/lib/corpus-index/census.db.test.ts
+++ b/apps/api/src/lib/corpus-index/census.db.test.ts
@@ -1,22 +1,25 @@
 /**
  * The repair behind a census drift warning: un-mark an index so the
- * ordinary backfill re-selects it. Under this generation every index is
- * one jurisdiction's, so the two are named interchangeably below.
+ * ordinary backfill re-selects it. Up to generation 2 every index is one
+ * jurisdiction's, so the two are named interchangeably below; from
+ * generation 3 on an index may hold several, and the repair has to reach
+ * all of them and no other index's.
  *
- * Four things can go wrong, and all of them are SQL. It can miss the
+ * Five things can go wrong, and all of them are SQL. It can miss the
  * rows the census counted — a generation rebuild records success in the
  * projection and leaves the legacy column alone, so a repair keyed off
  * that column is inert for exactly the rows a rebuild lost. It can clear
  * more than the operator asked for, handing the backfill a backlog that
  * starves every newly ingested decision behind it. It can reach into a
- * jurisdiction that was not short. And it can clear the same page every
+ * jurisdiction that was not short. It can clear the same page every
  * run, so an operator re-running it to walk a large jurisdiction never
  * gets past the first slice — which reads as the repair working, because
- * rows are reported cleared every time.
+ * rows are reported cleared every time. And on a shared index it can
+ * address one member's rows and leave the others marked.
  */
 
-import { beforeAll, expect, test } from "bun:test";
-import { and, eq, sql } from "drizzle-orm";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import type { Transaction } from "@/api/db/root";
@@ -28,51 +31,71 @@ import {
   caseLawSources,
 } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
-import { clearIndexMarks } from "@/api/lib/corpus-index/census";
+import {
+  clearIndexMarks,
+  MAX_REPAIR_SLICE,
+} from "@/api/lib/corpus-index/census";
 import {
   caseLawCorpusProjectionJoin,
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+import { installCaseLawProjectionTrigger } from "@/api/tests/helpers/case-law-projection-trigger";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
 const GENERATION = "case_law_v2";
 /** Marked through the generation projection, as a rebuild leaves them. */
 const SHORT_JURISDICTION = "SVK";
 /** Marked through the legacy column, as the incremental path leaves them. */
-const HEALTHY_JURISDICTION = "CZE";
+const HEALTHY_JURISDICTION = "POL";
 const DECISIONS_PER_JURISDICTION = 6;
 const SLICE = 4;
+
+/** From generation 3 on these two share one physical index. */
+const GROUPED_GENERATION = "case_law_v3";
+const GROUPED_JURISDICTIONS = ["CZE", "SVK"] as const;
+const DECISIONS_PER_GROUPED_JURISDICTION = 3;
 
 const sourceId = toSafeId<"caseLawSource">(
   "00000000-0000-4000-8000-0000000000a1",
 );
 
-/** Ordered ids, so the slice boundary is predictable. */
-const decisionId = (jurisdiction: string, index: number) =>
+/** Ids ordered by fixture then jurisdiction, so a slice boundary is predictable. */
+const ID_PREFIX = {
+  [SHORT_JURISDICTION]: "1",
+  [HEALTHY_JURISDICTION]: "2",
+  [`${GROUPED_GENERATION}:CZE`]: "3",
+  [`${GROUPED_GENERATION}:SVK`]: "4",
+} as const;
+
+const decisionId = (fixture: keyof typeof ID_PREFIX, index: number) =>
   toSafeId<"caseLawDecision">(
-    `00000000-0000-4000-8000-${jurisdiction === SHORT_JURISDICTION ? "1" : "2"}00000000${String(index).padStart(3, "0")}`,
+    `00000000-0000-4000-8000-${ID_PREFIX[fixture]}00000000${String(index).padStart(3, "0")}`,
   );
 
 let db: ReturnType<typeof drizzle>;
 let scopedDb: ScopedDb;
 
 /**
- * Rows the census would count for this jurisdiction — the same predicate
- * the repair slices on, so the test measures what the alert measures.
+ * Rows the census would count for this jurisdiction under this generation
+ * — the same predicate the repair slices on, so the test measures what
+ * the alert measures.
  */
-const currentRows = async (jurisdiction: string) =>
+const currentRows = async (
+  jurisdiction: string,
+  generation: string = GENERATION,
+) =>
   await db
     .select({ id: caseLawDecisions.id })
     .from(caseLawDecisions)
     .leftJoin(
       caseLawCorpusIndexProjections,
-      caseLawCorpusProjectionJoin(GENERATION),
+      caseLawCorpusProjectionJoin(generation),
     )
     .where(
       and(
         eq(caseLawDecisions.country, jurisdiction),
-        currentCaseLawCorpusProjection(GENERATION),
+        currentCaseLawCorpusProjection(generation),
       ),
     );
 
@@ -81,32 +104,6 @@ const enqueuedProjections = async () =>
     .select({ id: caseLawCorpusIndexProjections.decisionId })
     .from(caseLawCorpusIndexProjections)
     .where(eq(caseLawCorpusIndexProjections.pendingAction, "index"));
-
-/**
- * The projection trigger is what turns a cleared mark into queued work,
- * so the repair is only meaningful with it installed. The test snapshot
- * carries the tables but not this migration's functions, so it is
- * applied here rather than asserted around.
- */
-const installProjectionTrigger = async (): Promise<void> => {
-  const migration = await Bun.file(
-    new URL(
-      "../../../drizzle/20260731170000_case_law_corpus_generation_backfill/migration.sql",
-      import.meta.url,
-    ),
-  ).text();
-  const statements = migration
-    .split("--> statement-breakpoint")
-    .map((statement) => statement.trim())
-    .filter((statement) =>
-      statement.includes("enqueue_case_law_corpus_index_projection"),
-    );
-  expect(statements.length).toBeGreaterThan(0);
-  for (const statement of statements) {
-    // oxlint-disable-next-line no-await-in-loop -- function then trigger; order-dependent DDL
-    await db.execute(sql.raw(statement));
-  }
-};
 
 beforeAll(async () => {
   const client = await createTestPglite();
@@ -129,7 +126,10 @@ beforeAll(async () => {
 
   const decisions: (typeof caseLawDecisions.$inferInsert)[] = [];
   const projections: (typeof caseLawCorpusIndexProjections.$inferInsert)[] = [];
-  for (const jurisdiction of [SHORT_JURISDICTION, HEALTHY_JURISDICTION]) {
+  for (const jurisdiction of [
+    SHORT_JURISDICTION,
+    HEALTHY_JURISDICTION,
+  ] as const) {
     const rebuilt = jurisdiction === SHORT_JURISDICTION;
     for (let index = 0; index < DECISIONS_PER_JURISDICTION; index += 1) {
       const id = decisionId(jurisdiction, index);
@@ -158,7 +158,10 @@ beforeAll(async () => {
   }
   await db.insert(caseLawDecisions).values(decisions);
   await db.insert(caseLawCorpusIndexProjections).values(projections);
-  await installProjectionTrigger();
+  // The projection trigger is what turns a cleared mark into queued work,
+  // so the repair is only meaningful with it installed. The test snapshot
+  // carries the tables but not the migrations' functions.
+  await installCaseLawProjectionTrigger(db);
 });
 
 test("the repair reaches rows marked only through the generation projection", async () => {
@@ -212,4 +215,96 @@ test("the jurisdiction that was not short kept every mark", async () => {
   expect(await currentRows(HEALTHY_JURISDICTION)).toHaveLength(
     DECISIONS_PER_JURISDICTION,
   );
+});
+
+describe("an index shared by several jurisdictions", () => {
+  const sharedIndexId = corpusIndexId(GROUPED_GENERATION, "CZE");
+
+  /** Current row counts under the grouped generation, per jurisdiction. */
+  const currentRowsOfEach = async (jurisdictions: readonly string[]) =>
+    await Promise.all(
+      jurisdictions.map(
+        async (jurisdiction) =>
+          (await currentRows(jurisdiction, GROUPED_GENERATION)).length,
+      ),
+    );
+
+  beforeAll(async () => {
+    const decisions: (typeof caseLawDecisions.$inferInsert)[] = [];
+    const projections: (typeof caseLawCorpusIndexProjections.$inferInsert)[] =
+      [];
+    for (const jurisdiction of GROUPED_JURISDICTIONS) {
+      expect(corpusIndexId(GROUPED_GENERATION, jurisdiction)).toBe(
+        sharedIndexId,
+      );
+      for (
+        let index = 0;
+        index < DECISIONS_PER_GROUPED_JURISDICTION;
+        index += 1
+      ) {
+        const id = decisionId(`${GROUPED_GENERATION}:${jurisdiction}`, index);
+        const contentHash = `hash-${GROUPED_GENERATION}-${jurisdiction}-${index}`;
+        decisions.push({
+          caseNumber: `${GROUPED_GENERATION}-${jurisdiction}-${index}`,
+          contentHash,
+          country: jurisdiction,
+          court: "Test court",
+          id,
+          indexedHash: null,
+          language: "cs",
+          sourceId,
+        });
+        projections.push({
+          decisionId: id,
+          generation: GROUPED_GENERATION,
+          indexId: sharedIndexId,
+          indexedHash: contentHash,
+        });
+      }
+    }
+    // The decisions land before the generation is registered, so the
+    // installed trigger queues them for the earlier generation only; the
+    // grouped generation then marks them through the projection alone, as
+    // a rebuild leaves them.
+    await db.insert(caseLawDecisions).values(decisions);
+    await db
+      .insert(caseLawCorpusIndexBackfills)
+      .values([{ generation: GROUPED_GENERATION }]);
+    await db.insert(caseLawCorpusIndexProjections).values(projections);
+  });
+
+  test("one repair reaches every jurisdiction the index holds and no other index", async () => {
+    // Every member's rows are current, and so are the legacy-marked rows of
+    // a jurisdiction whose index is its own; the earlier repairs left the
+    // rebuilt generation-2 rows out of every generation.
+    expect(await currentRowsOfEach(GROUPED_JURISDICTIONS)).toEqual([
+      DECISIONS_PER_GROUPED_JURISDICTION,
+      DECISIONS_PER_GROUPED_JURISDICTION,
+    ]);
+    expect(
+      await currentRows(HEALTHY_JURISDICTION, GROUPED_GENERATION),
+    ).toHaveLength(DECISIONS_PER_JURISDICTION);
+    // The index the healthy rows derive to is another one; the repair below
+    // must not reach it.
+    expect(corpusIndexId(GROUPED_GENERATION, HEALTHY_JURISDICTION)).not.toBe(
+      sharedIndexId,
+    );
+
+    const cleared = await clearIndexMarks({
+      scopedDb,
+      generation: GROUPED_GENERATION,
+      indexId: sharedIndexId,
+      limit: MAX_REPAIR_SLICE,
+    });
+
+    // Both members, in one repair: a repair addressing the rows by one
+    // member's country would leave the other's marked.
+    expect(cleared).toBe(
+      GROUPED_JURISDICTIONS.length * DECISIONS_PER_GROUPED_JURISDICTION,
+    );
+    expect(await currentRowsOfEach(GROUPED_JURISDICTIONS)).toEqual([0, 0]);
+    expect(
+      await currentRows(HEALTHY_JURISDICTION, GROUPED_GENERATION),
+    ).toHaveLength(DECISIONS_PER_JURISDICTION);
+  });
 });

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -5,8 +5,9 @@
  * nothing selects it again. What can go wrong here is therefore the
  * census staying quiet — either because ordinary churn is mistaken for
  * drift and the warning is tuned out, or because an unreachable index
- * reads as an empty one and the drift is reported against a jurisdiction
- * that is fine.
+ * reads as an empty one and the drift is reported against an index that
+ * is fine — and, since generation 3 shares one index between several
+ * countries, the sweep counting the same index once per country.
  */
 
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
@@ -17,9 +18,9 @@ import {
   CENSUS_CYCLE_INTERVAL,
   CENSUS_DISPOSITION,
   CENSUS_TOLERANCE,
-  censusJurisdiction,
+  censusIndex,
   createCaseLawCensus,
-  reportJurisdictionCensus,
+  reportIndexCensus,
 } from "@/api/lib/corpus-index/census";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 import { LIMITS } from "@/api/lib/limits";
@@ -33,6 +34,12 @@ const INDEX_ID = corpusIndexId(GENERATION, JURISDICTION);
 const LAST_CYCLE_START = 0.99;
 
 const originalFetch = globalThis.fetch;
+
+/** Index ids the engine was asked to count, in request order. */
+let countedIndexIds: string[];
+
+const indexIdOfCountRequest = (url: string): string | undefined =>
+  /\/api\/v1\/(?<indexId>[^/]+)\/search/u.exec(url)?.groups?.["indexId"];
 
 /** Serves the engine's document count, and nothing else. */
 const engineHolding = (numHits: number, ok = true): void => {
@@ -48,6 +55,10 @@ const engineHolding = (numHits: number, ok = true): void => {
       return new Response("index not found", { status: 404 });
     }
     if (url.includes("/search")) {
+      const indexId = indexIdOfCountRequest(url);
+      if (indexId !== undefined) {
+        countedIndexIds.push(indexId);
+      }
       return new Response(
         JSON.stringify({ num_hits: numHits, hits: [], snippets: [] }),
         { status: 200 },
@@ -91,18 +102,22 @@ const databaseHolding = (
   return handle as unknown as ScopedDb;
 };
 
+beforeEach(() => {
+  countedIndexIds = [];
+});
+
 afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
-describe("jurisdiction census", () => {
+describe("index census", () => {
   test("noise inside the tolerance is not a shortfall", async () => {
     engineHolding(10_000 - CENSUS_TOLERANCE);
 
-    const census = await censusJurisdiction({
+    const census = await censusIndex({
       scopedDb: databaseHolding(10_000),
       generation: GENERATION,
-      jurisdiction: JURISDICTION,
+      indexId: INDEX_ID,
     });
 
     expect(census.isOk()).toBe(true);
@@ -111,24 +126,25 @@ describe("jurisdiction census", () => {
     );
   });
 
-  test("one lost ingest batch is visible on a large jurisdiction", async () => {
+  test("one lost ingest batch is visible on a large index", async () => {
     // The whole failure this detects is a fixed-size batch going
     // missing, so the tolerance must stay below one — and must not grow
-    // with the corpus, or a large jurisdiction hides more the larger it
-    // gets. `corpusIndexBatchSize` is the size of the smallest real loss.
+    // with the corpus, or a large index hides more the larger it gets.
+    // `corpusIndexBatchSize` is the size of the smallest real loss.
     const marked = 5_000_000;
     engineHolding(marked - LIMITS.corpusIndexBatchSize);
 
-    const census = await censusJurisdiction({
+    const census = await censusIndex({
       scopedDb: databaseHolding(marked),
       generation: GENERATION,
-      jurisdiction: JURISDICTION,
+      indexId: INDEX_ID,
     });
 
     expect(census.isOk() && census.value.disposition).toBe(
       CENSUS_DISPOSITION.short,
     );
     expect(census.isOk() && census.value.indexId).toBe(INDEX_ID);
+    expect(countedIndexIds).toEqual([INDEX_ID]);
   });
 
   test("an engine holding more than Postgres claims is a surplus, not silence", async () => {
@@ -138,10 +154,10 @@ describe("jurisdiction census", () => {
     // the surplus is what stops the pair going quiet together.
     engineHolding(50_000);
 
-    const census = await censusJurisdiction({
+    const census = await censusIndex({
       scopedDb: databaseHolding(10_000),
       generation: GENERATION,
-      jurisdiction: JURISDICTION,
+      indexId: INDEX_ID,
     });
 
     expect(census.isOk() && census.value.shortfall).toBeLessThan(0);
@@ -151,14 +167,14 @@ describe("jurisdiction census", () => {
   });
 
   test("an unreachable index is a failure, not an empty index", async () => {
-    // Counting it as empty would report the whole jurisdiction as
-    // drifted and point the repair at rows that are perfectly indexed.
+    // Counting it as empty would report the whole index as drifted and
+    // point the repair at rows that are perfectly indexed.
     engineHolding(0, false);
 
-    const census = await censusJurisdiction({
+    const census = await censusIndex({
       scopedDb: databaseHolding(10_000),
       generation: GENERATION,
-      jurisdiction: JURISDICTION,
+      indexId: INDEX_ID,
     });
 
     expect(census.isErr()).toBe(true);
@@ -177,11 +193,10 @@ describe("census reporting", () => {
   });
 
   test("confirmed drift is reported with both counts", () => {
-    reportJurisdictionCensus({
+    reportIndexCensus({
       generation: GENERATION,
       previous: CENSUS_DISPOSITION.short,
       census: {
-        jurisdiction: JURISDICTION,
         indexId: INDEX_ID,
         engineDocuments: 900,
         markedIndexed: 10_000,
@@ -205,11 +220,10 @@ describe("census reporting", () => {
   });
 
   test("agreement is silent", () => {
-    reportJurisdictionCensus({
+    reportIndexCensus({
       generation: GENERATION,
       previous: CENSUS_DISPOSITION.aligned,
       census: {
-        jurisdiction: JURISDICTION,
         indexId: INDEX_ID,
         engineDocuments: 10_000,
         markedIndexed: 10_000,
@@ -225,11 +239,10 @@ describe("census reporting", () => {
     // A bulk page marks its rows before the engine publishes their
     // split, so one short reading may be work in flight. Warning on it
     // would make every rebuild noisy, and a noisy warning is not read.
-    reportJurisdictionCensus({
+    reportIndexCensus({
       generation: GENERATION,
       previous: undefined,
       census: {
-        jurisdiction: JURISDICTION,
         indexId: INDEX_ID,
         engineDocuments: 900,
         markedIndexed: 10_000,
@@ -242,11 +255,10 @@ describe("census reporting", () => {
   });
 
   test("a surplus is reported rather than read as agreement", () => {
-    reportJurisdictionCensus({
+    reportIndexCensus({
       generation: GENERATION,
       previous: CENSUS_DISPOSITION.surplus,
       census: {
-        jurisdiction: JURISDICTION,
         indexId: INDEX_ID,
         engineDocuments: 12_000,
         markedIndexed: 10_000,
@@ -277,6 +289,7 @@ describe("census reporting", () => {
     expect(warn.mock.calls.at(0)?.at(0)).toBe(
       "case_law.corpus_index.census_unavailable",
     );
+    expect(warn.mock.calls.at(0)?.at(1)).toMatchObject({ indexId: INDEX_ID });
   });
 
   test("the census does not run on every cycle", async () => {
@@ -350,5 +363,40 @@ describe("census reporting", () => {
     expect(warn.mock.calls.at(0)?.at(0)).toBe(
       "case_law.corpus_index.census_failed",
     );
+  });
+});
+
+describe("census sweep unit", () => {
+  /** Runs the sweep long enough to census `count` indexes. */
+  const sweep = async (
+    generation: string,
+    jurisdictions: string[],
+    count: number,
+  ): Promise<string[]> => {
+    engineHolding(10_000);
+    const census = createCaseLawCensus({
+      generation,
+      scopedDb: databaseHolding(10_000, jurisdictions),
+      startAt: 0,
+    });
+    for (let cycle = 0; cycle < CENSUS_CYCLE_INTERVAL * count; cycle += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- the cycles are the subject of the test
+      await census.step();
+    }
+    return countedIndexIds;
+  };
+
+  test("countries sharing an index are one observation from generation 3", async () => {
+    // Two countries, one physical index: censusing it once per country
+    // would count the same engine index twice and compare it against half
+    // its rows each time. Two censuses' worth of cycles must visit the
+    // same index twice, not two indexes once.
+    const counted = await sweep("case_law_v3", ["CZE", "SVK"], 2);
+    expect(counted).toEqual(["case_law_v3_cs_sk", "case_law_v3_cs_sk"]);
+  });
+
+  test("countries keep their own observation before generation 3", async () => {
+    const counted = await sweep("case_law_v2", ["CZE", "SVK"], 2);
+    expect(counted).toEqual(["case_law_v2_cze", "case_law_v2_svk"]);
   });
 });

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -389,14 +389,24 @@ describe("census sweep unit", () => {
   test("countries sharing an index are one observation from generation 3", async () => {
     // Two countries, one physical index: censusing it once per country
     // would count the same engine index twice and compare it against half
-    // its rows each time. Two censuses' worth of cycles must visit the
-    // same index twice, not two indexes once.
-    const counted = await sweep("case_law_v3", ["CZE", "SVK"], 2);
-    expect(counted).toEqual(["case_law_v3_cs_sk", "case_law_v3_cs_sk"]);
+    // its rows each time. Three censuses' worth of cycles must visit the
+    // shared index, then the other index, then wrap round to the shared
+    // one; a per-country sweep would visit the shared index twice before
+    // reaching the other.
+    const counted = await sweep("case_law_v3", ["CZE", "SVK", "POL"], 3);
+    expect(counted).toEqual([
+      "case_law_v3_cs_sk",
+      "case_law_v3_pol",
+      "case_law_v3_cs_sk",
+    ]);
   });
 
   test("countries keep their own observation before generation 3", async () => {
-    const counted = await sweep("case_law_v2", ["CZE", "SVK"], 2);
-    expect(counted).toEqual(["case_law_v2_cze", "case_law_v2_svk"]);
+    const counted = await sweep("case_law_v2", ["CZE", "SVK", "POL"], 3);
+    expect(counted).toEqual([
+      "case_law_v2_cze",
+      "case_law_v2_svk",
+      "case_law_v2_pol",
+    ]);
   });
 });

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -1,6 +1,6 @@
 /**
  * Count what the search engine actually holds against what Postgres says
- * it holds, one jurisdiction at a time.
+ * it holds, one physical index at a time.
  *
  * The ingest path marks a row indexed on the strength of the engine
  * accepting its batch. `commit=wait_for` makes that acceptance mean the
@@ -14,19 +14,25 @@
  *
  * A census is what makes it visible. It is a count on both sides, not a
  * diff: naming the missing documents would mean streaming the whole
- * jurisdiction out of the engine, while the number alone is one cheap
- * aggregate per side and is enough to decide that a jurisdiction needs
+ * index out of the engine, while the number alone is one cheap
+ * aggregate per side and is enough to decide that an index needs
  * re-indexing. The repair is correspondingly blunt — un-mark a slice of
- * the jurisdiction and let the ordinary backfill re-project it — because
+ * the index's rows and let the ordinary backfill re-project it — because
  * the projection is idempotent and re-ingesting a document the engine
  * already holds converges on the same split.
  *
- * Bounded by construction: one jurisdiction per call, one aggregate
- * query per side, and a caller that decides how often to run it.
+ * The unit is the physical index, not the country: from generation 3 on
+ * several countries share one index (`corpusIndexId`), and the engine
+ * count is per index either way. The rows an index answers for are the
+ * ones whose derived index id is that index, the same derivation the
+ * search path rehydrates through.
+ *
+ * Bounded by construction: one index per call, one aggregate query per
+ * side, and a caller that decides how often to run it.
  */
 
 import { Result } from "better-result";
-import { and, eq, sql } from "drizzle-orm";
+import { and, sql } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
@@ -36,11 +42,12 @@ import {
 import { errorTag } from "@/api/lib/errors/error-tag";
 import {
   caseLawCorpusProjectionJoin,
+  caseLawDecisionCorpusIndexIdSql,
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import type { CorpusIndexError } from "@/api/lib/legal-search/corpus-index-client";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
-import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+import { corpusIndexIdsFor } from "@/api/lib/legal-search/index-naming";
 import { logger } from "@/api/lib/observability/logger";
 import { isRecord } from "@/api/lib/type-guards";
 
@@ -56,7 +63,7 @@ const DOCUMENT_COUNT_QUERY = "seq:0";
  * How far the two sides may disagree in one observation.
  *
  * Small and absolute, never proportional: a fraction of the corpus lets
- * a large jurisdiction hide more documents the larger it gets, which is
+ * a large index hide more documents the larger it gets, which is
  * backwards — the whole failure this detects is a fixed-size batch going
  * missing. A tolerance at or above the ingest batch size would make the
  * smallest real loss, exactly one lost commit window, invisible.
@@ -65,13 +72,13 @@ const DOCUMENT_COUNT_QUERY = "seq:0";
  * the engine publishes their split, so an in-flight page reads as a
  * shortfall for as long as it takes to commit. That transient is what
  * the confirmation below is for: a shortfall has to survive into the
- * jurisdiction's next census before it is reported, and an in-flight
- * page will have published by then while a lost split never will.
+ * index's next census before it is reported, and an in-flight page will
+ * have published by then while a lost split never will.
  */
 export const CENSUS_TOLERANCE = 5;
 
 /**
- * What one observation says about a jurisdiction.
+ * What one observation says about an index.
  *
  * Two counts can only report their difference, and the difference nets
  * two independent defects: documents the engine never received, and
@@ -82,8 +89,8 @@ export const CENSUS_TOLERANCE = 5;
  * itself worth acting on, and it says the shortfall number cannot be
  * trusted until it is cleared. Exact cancellation to inside the
  * tolerance remains this mechanism's blind spot; closing it needs an
- * identity comparison, which means streaming the jurisdiction rather
- * than counting it.
+ * identity comparison, which means streaming the index rather than
+ * counting it.
  */
 export const CENSUS_DISPOSITION = {
   /** Both sides agree inside the tolerance. */
@@ -97,8 +104,7 @@ export const CENSUS_DISPOSITION = {
 export type CensusDisposition =
   (typeof CENSUS_DISPOSITION)[keyof typeof CENSUS_DISPOSITION];
 
-export type JurisdictionCensus = {
-  jurisdiction: string;
+export type IndexCensus = {
   indexId: string;
   /** Documents the engine reports for this index. */
   engineDocuments: number;
@@ -119,17 +125,18 @@ const dispositionOf = (shortfall: number): CensusDisposition => {
 };
 
 /**
- * Rows this generation has marked as indexed into this jurisdiction's
- * physical index.
+ * Rows this generation has marked as indexed into this physical index:
+ * every row whose country derives to it, in the state the search path
+ * accepts.
  *
- * The same predicate the search path rehydrates through, so the census
+ * The same predicates the search path rehydrates through, so the census
  * counts exactly the rows a query would expect the engine to answer for.
- * Defining it a second time here would let the two drift, which is the
+ * Defining them a second time here would let the two drift, which is the
  * failure this whole module exists to catch.
  */
 const countMarkedIndexed = async (
   scopedDb: ScopedDb,
-  { generation, jurisdiction }: { generation: string; jurisdiction: string },
+  { generation, indexId }: { generation: string; indexId: string },
 ): Promise<number> => {
   const rows = await scopedDb((tx) =>
     tx
@@ -141,7 +148,7 @@ const countMarkedIndexed = async (
       )
       .where(
         and(
-          eq(caseLawDecisions.country, jurisdiction),
+          sql`(${caseLawDecisionCorpusIndexIdSql(generation)}) = ${indexId}`,
           currentCaseLawCorpusProjection(generation),
         ),
       ),
@@ -149,29 +156,26 @@ const countMarkedIndexed = async (
   return rows.at(0)?.marked ?? 0;
 };
 
-export type CensusJurisdictionOptions = {
+export type CensusIndexOptions = {
   scopedDb: ScopedDb;
   generation: string;
-  /** The `country` value, which also names the physical index. */
-  jurisdiction: string;
+  /** The physical index id, as `corpusIndexId` derives it. */
+  indexId: string;
 };
 
 /**
- * One jurisdiction's census, or the engine error that stopped it.
+ * One index's census, or the engine error that stopped it.
  *
  * A census that cannot reach the engine is not drift, so it is reported
  * as a failure rather than folded into the count: treating an
- * unreachable index as an empty one would clear every row in the
- * jurisdiction and re-ingest the whole corpus.
+ * unreachable index as an empty one would clear every row in the index
+ * and re-ingest the whole corpus.
  */
-export const censusJurisdiction = async ({
+export const censusIndex = async ({
   scopedDb,
   generation,
-  jurisdiction,
-}: CensusJurisdictionOptions): Promise<
-  Result<JurisdictionCensus, CorpusIndexError>
-> => {
-  const indexId = corpusIndexId(generation, jurisdiction);
+  indexId,
+}: CensusIndexOptions): Promise<Result<IndexCensus, CorpusIndexError>> => {
   // Postgres first, deliberately. The two counts are taken at different
   // instants, and a batch landing between them shifts the difference by
   // a whole batch; taking the claim before the evidence makes that shift
@@ -181,7 +185,7 @@ export const censusJurisdiction = async ({
   // size of the smallest loss worth finding.
   const markedIndexed = await countMarkedIndexed(scopedDb, {
     generation,
-    jurisdiction,
+    indexId,
   });
   const counted = await getCorpusIndexClient().search({
     indexId,
@@ -195,7 +199,6 @@ export const censusJurisdiction = async ({
   const shortfall = markedIndexed - counted.value.numHits;
 
   return Result.ok({
-    jurisdiction,
     indexId,
     engineDocuments: counted.value.numHits,
     markedIndexed,
@@ -204,13 +207,13 @@ export const censusJurisdiction = async ({
   });
 };
 
-export type ReportJurisdictionCensusOptions = {
+export type ReportIndexCensusOptions = {
   generation: string;
-  census: JurisdictionCensus;
+  census: IndexCensus;
   /**
-   * The disposition this jurisdiction had when it was last censused. A
-   * bulk page marks its rows before the engine publishes their split, so
-   * a single disagreeing observation may just be work in flight; a lost
+   * The disposition this index had when it was last censused. A bulk
+   * page marks its rows before the engine publishes their split, so a
+   * single disagreeing observation may just be work in flight; a lost
    * split or an orphaned entry is there forever, so it survives into the
    * next observation and a publishing page does not.
    */
@@ -229,11 +232,11 @@ export type ReportJurisdictionCensusOptions = {
  * the missing documents are unsearchable, not wrong, and the repair
  * below is an operator decision rather than something to page on.
  */
-export const reportJurisdictionCensus = ({
+export const reportIndexCensus = ({
   generation,
   census,
   previous,
-}: ReportJurisdictionCensusOptions): void => {
+}: ReportIndexCensusOptions): void => {
   if (
     census.disposition === CENSUS_DISPOSITION.aligned ||
     census.disposition !== previous
@@ -244,7 +247,6 @@ export const reportJurisdictionCensus = ({
     generation,
     disposition: census.disposition,
     indexId: census.indexId,
-    jurisdiction: census.jurisdiction,
     engineDocuments: census.engineDocuments,
     markedIndexed: census.markedIndexed,
     shortfall: census.shortfall,
@@ -261,10 +263,9 @@ export const reportJurisdictionCensus = ({
 const MAX_CENSUSED_JURISDICTIONS = 256;
 
 /**
- * Jurisdictions the corpus holds, which is also the set of physical
- * indexes it should have. Read from the decisions themselves rather than
- * from a hand-kept list, so a new country's index cannot be uncensused
- * because nobody remembered to add it.
+ * Jurisdictions the corpus holds. Read from the decisions themselves
+ * rather than from a hand-kept list, so a new country's index cannot be
+ * uncensused because nobody remembered to add it.
  */
 export const listCaseLawJurisdictions = async (
   scopedDb: ScopedDb,
@@ -280,13 +281,24 @@ export const listCaseLawJurisdictions = async (
 };
 
 /**
+ * Physical indexes the corpus should have for this generation: the
+ * distinct ids its jurisdictions derive to, one per country up to
+ * generation 2 and one per index group from generation 3 on.
+ */
+export const listCaseLawIndexIds = async (
+  scopedDb: ScopedDb,
+  generation: string,
+): Promise<string[]> =>
+  corpusIndexIdsFor(generation, await listCaseLawJurisdictions(scopedDb));
+
+/**
  * Backfill cycles between one census and the next.
  *
  * The census is a diagnostic, not a gate: it costs an aggregate on each
  * side and the drift it looks for accumulates over hours, so running it
  * on every batch would spend real query budget to answer the same
- * question. One jurisdiction per census means a corpus of N
- * jurisdictions is fully covered every N of these.
+ * question. One index per census means a corpus of N indexes is fully
+ * covered every N of these.
  */
 export const CENSUS_CYCLE_INTERVAL = 20;
 
@@ -294,7 +306,7 @@ export type CaseLawCensusOptions = {
   scopedDb: ScopedDb;
   generation: string;
   /**
-   * Where in the cycle and the jurisdiction list this process starts, in
+   * Where in the cycle and the index list this process starts, in
    * `[0, 1)`. Random per process so restarts spread their coverage;
    * tests pin it.
    */
@@ -307,9 +319,8 @@ export type CaseLawCensusOptions = {
  *
  * A census that throws would take the backfill down with it, which
  * would trade a silent index gap for a stopped index. It reports and
- * moves on instead; the next pass round-robins to the next
- * jurisdiction either way, so one unreachable index cannot pin the
- * sweep.
+ * moves on instead; the next pass round-robins to the next index either
+ * way, so one unreachable index cannot pin the sweep.
  */
 export const createCaseLawCensus = ({
   scopedDb,
@@ -320,60 +331,53 @@ export const createCaseLawCensus = ({
   // They live in this process, so a runner replaced mid-sweep loses them;
   // starting every replacement at the same place would mean frequent
   // deployments always censusing the head of the alphabet and never the
-  // tail. A random phase covers every jurisdiction in expectation
-  // instead. A durable cursor would remove the "in expectation", and is
-  // the next step if deployments ever outpace the sweep.
+  // tail. A random phase covers every index in expectation instead. A
+  // durable cursor would remove the "in expectation", and is the next
+  // step if deployments ever outpace the sweep.
   let cyclesUntilCensus = 1 + Math.floor(startAt * CENSUS_CYCLE_INTERVAL);
   let pending: string[] = [];
-  /** Each jurisdiction's last disposition, awaiting confirmation. */
+  /** Each index's last disposition, awaiting confirmation. */
   const lastDisposition = new Map<string, CensusDisposition>();
 
-  const takeNextJurisdiction = async (): Promise<string | undefined> => {
+  const takeNextIndexId = async (): Promise<string | undefined> => {
     if (pending.length > 0) {
       return pending.shift();
     }
-    const jurisdictions = await listCaseLawJurisdictions(scopedDb);
-    if (jurisdictions.length === 0) {
+    const indexIds = await listCaseLawIndexIds(scopedDb, generation);
+    if (indexIds.length === 0) {
       return undefined;
     }
-    const offset = Math.floor(startAt * jurisdictions.length);
-    pending = [
-      ...jurisdictions.slice(offset),
-      ...jurisdictions.slice(0, offset),
-    ];
+    const offset = Math.floor(startAt * indexIds.length);
+    pending = [...indexIds.slice(offset), ...indexIds.slice(0, offset)];
     return pending.shift();
   };
 
   const censusNext = async (): Promise<void> => {
-    const jurisdiction = await takeNextJurisdiction();
-    if (jurisdiction === undefined) {
+    const indexId = await takeNextIndexId();
+    if (indexId === undefined) {
       return;
     }
 
-    const census = await censusJurisdiction({
-      scopedDb,
-      generation,
-      jurisdiction,
-    });
+    const census = await censusIndex({ scopedDb, generation, indexId });
     if (Result.isError(census)) {
       // An unreachable index is not a short one. Saying so keeps the
-      // repair from being pointed at a jurisdiction whose engine simply
-      // did not answer. The pending confirmation is left alone: a
-      // failed observation neither confirms nor clears one.
+      // repair from being pointed at an index whose engine simply did
+      // not answer. The pending confirmation is left alone: a failed
+      // observation neither confirms nor clears one.
       logger.warn("case_law.corpus_index.census_unavailable", {
         generation,
-        jurisdiction,
+        indexId,
         "error.type": census.error._tag,
       });
       return;
     }
 
-    reportJurisdictionCensus({
+    reportIndexCensus({
       generation,
       census: census.value,
-      previous: lastDisposition.get(jurisdiction),
+      previous: lastDisposition.get(indexId),
     });
-    lastDisposition.set(jurisdiction, census.value.disposition);
+    lastDisposition.set(indexId, census.value.disposition);
   };
 
   return {
@@ -395,16 +399,17 @@ export const createCaseLawCensus = ({
   };
 };
 
-export type ClearJurisdictionIndexMarksOptions = {
+export type ClearIndexMarksOptions = {
   scopedDb: ScopedDb;
   generation: string;
-  jurisdiction: string;
+  /** The physical index id, as `corpusIndexId` derives it. */
+  indexId: string;
   /**
    * Most rows to un-mark in this call. The repair is a deliberately
-   * bounded operator action: a whole jurisdiction can be millions of
-   * rows, and un-marking them all at once would hand the backfill a
-   * backlog that starves every newly ingested decision behind it. Run it
-   * again to clear the next slice.
+   * bounded operator action: a whole index can be millions of rows, and
+   * un-marking them all at once would hand the backfill a backlog that
+   * starves every newly ingested decision behind it. Run it again to
+   * clear the next slice.
    */
   limit: number;
 };
@@ -429,15 +434,15 @@ const countReturnedRows = (result: unknown): number => {
 };
 
 /**
- * Un-mark a slice of a short jurisdiction so the backfill re-selects it.
+ * Un-mark a slice of a short index so the backfill re-selects it.
  *
  * The slice is the census's own population — rows this generation counts
- * as indexed into this jurisdiction — rather than rows carrying the
- * legacy marker. The two are not the same set: a generation rebuild
- * records success in the projection and leaves `case_law_decisions`
- * alone, so a repair keyed off that column would be inert for exactly
- * the rows a rebuild lost. Sharing the predicate with the count also
- * means the repair cannot drift away from what was measured.
+ * as indexed into this index — rather than rows carrying the legacy
+ * marker. The two are not the same set: a generation rebuild records
+ * success in the projection and leaves `case_law_decisions` alone, so a
+ * repair keyed off that column would be inert for exactly the rows a
+ * rebuild lost. Sharing the predicate with the count also means the
+ * repair cannot drift away from what was measured.
  *
  * The write is still only `indexed_hash`, and deliberately so: the
  * projection trigger on that column enqueues the decision for every
@@ -449,23 +454,22 @@ const countReturnedRows = (result: unknown): number => {
  * column being assigned, not on its value changing, so a row whose
  * legacy marker is already null is enqueued just the same.
  *
- * That enqueue is also what makes repeated runs walk the jurisdiction:
- * a queued row is no longer counted as current, so the next slice starts
- * past it.
+ * That enqueue is also what makes repeated runs walk the index: a queued
+ * row is no longer counted as current, so the next slice starts past it.
  *
  * Nothing is deleted from the engine — re-ingesting a document it
- * already holds replaces it at the same id — so running this against a
- * jurisdiction that was not short costs re-indexing and nothing else.
+ * already holds replaces it at the same id — so running this against an
+ * index that was not short costs re-indexing and nothing else.
  * `updated_at` is left alone, like every other index-mark write: an
  * index repair is not a change to the decision, and the public reads key
  * their freshness off that column.
  */
-export const clearJurisdictionIndexMarks = async ({
+export const clearIndexMarks = async ({
   scopedDb,
   generation,
-  jurisdiction,
+  indexId,
   limit,
-}: ClearJurisdictionIndexMarksOptions): Promise<number> =>
+}: ClearIndexMarksOptions): Promise<number> =>
   await scopedDb(async (tx) => {
     // audit: skip — search index maintenance; rebuilds derived state
     const cleared = await tx.execute(sql`
@@ -476,7 +480,7 @@ export const clearJurisdictionIndexMarks = async ({
         FROM ${caseLawDecisions}
         LEFT JOIN ${caseLawCorpusIndexProjections}
           ON ${caseLawCorpusProjectionJoin(generation)}
-        WHERE ${caseLawDecisions.country} = ${jurisdiction}
+        WHERE (${caseLawDecisionCorpusIndexIdSql(generation)}) = ${indexId}
           AND ${currentCaseLawCorpusProjection(generation)}
         ORDER BY ${caseLawDecisions.id}
         LIMIT ${Math.min(limit, MAX_REPAIR_SLICE)}

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -24,15 +24,15 @@
  * The unit is the physical index, not the country: from generation 3 on
  * several countries share one index (`corpusIndexId`), and the engine
  * count is per index either way. The rows an index answers for are the
- * ones whose derived index id is that index, the same derivation the
- * search path rehydrates through.
+ * ones whose country the index holds (`corpusIndexJurisdictions`, the
+ * inverse of that derivation), in the state the search path accepts.
  *
  * Bounded by construction: one index per call, one aggregate query per
  * side, and a caller that decides how often to run it.
  */
 
 import { Result } from "better-result";
-import { and, sql } from "drizzle-orm";
+import { inArray, type SQL, sql } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
@@ -42,12 +42,14 @@ import {
 import { errorTag } from "@/api/lib/errors/error-tag";
 import {
   caseLawCorpusProjectionJoin,
-  caseLawDecisionCorpusIndexIdSql,
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import type { CorpusIndexError } from "@/api/lib/legal-search/corpus-index-client";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
-import { corpusIndexIdsFor } from "@/api/lib/legal-search/index-naming";
+import {
+  corpusIndexIdsFor,
+  corpusIndexJurisdictions,
+} from "@/api/lib/legal-search/index-naming";
 import { logger } from "@/api/lib/observability/logger";
 import { isRecord } from "@/api/lib/type-guards";
 
@@ -126,14 +128,21 @@ const dispositionOf = (shortfall: number): CensusDisposition => {
 
 /**
  * Rows this generation has marked as indexed into this physical index:
- * every row whose country derives to it, in the state the search path
+ * every row whose country the index holds, in the state the search path
  * accepts.
  *
- * The same predicates the search path rehydrates through, so the census
- * counts exactly the rows a query would expect the engine to answer for.
- * Defining them a second time here would let the two drift, which is the
- * failure this whole module exists to catch.
+ * The country list is the inverse of the id derivation, so the census
+ * counts exactly the rows a query would expect the engine to answer for,
+ * and `country` is a plain column predicate the country index serves. The
+ * projection state is the same predicate the search path rehydrates
+ * through; defining it a second time here would let the two drift, which
+ * is the failure this whole module exists to catch.
  */
+const censusPopulation = (generation: string, indexId: string): SQL =>
+  sql`${inArray(caseLawDecisions.country, [
+    ...corpusIndexJurisdictions(generation, indexId),
+  ])} AND ${currentCaseLawCorpusProjection(generation)}`;
+
 const countMarkedIndexed = async (
   scopedDb: ScopedDb,
   { generation, indexId }: { generation: string; indexId: string },
@@ -146,12 +155,7 @@ const countMarkedIndexed = async (
         caseLawCorpusIndexProjections,
         caseLawCorpusProjectionJoin(generation),
       )
-      .where(
-        and(
-          sql`(${caseLawDecisionCorpusIndexIdSql(generation)}) = ${indexId}`,
-          currentCaseLawCorpusProjection(generation),
-        ),
-      ),
+      .where(censusPopulation(generation, indexId)),
   );
   return rows.at(0)?.marked ?? 0;
 };
@@ -480,8 +484,7 @@ export const clearIndexMarks = async ({
         FROM ${caseLawDecisions}
         LEFT JOIN ${caseLawCorpusIndexProjections}
           ON ${caseLawCorpusProjectionJoin(generation)}
-        WHERE (${caseLawDecisionCorpusIndexIdSql(generation)}) = ${indexId}
-          AND ${currentCaseLawCorpusProjection(generation)}
+        WHERE ${censusPopulation(generation, indexId)}
         ORDER BY ${caseLawDecisions.id}
         LIMIT ${Math.min(limit, MAX_REPAIR_SLICE)}
       )

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -1131,8 +1131,9 @@ export const createCorpusIndexer = <
     });
     await recordReadFailures(scopedDb, readFailures, generation);
 
-    // Route each row's documents to its jurisdiction's index
-    // (<family>_v1_<country>), grouping so each index gets one NDJSON ingest.
+    // Route each row's documents to its physical index (`corpusIndexId`: per
+    // jurisdiction, or per index group), grouping so each index gets one
+    // NDJSON ingest.
     // A group that fails to ensure/ingest is recorded and retried next cycle;
     // other groups still commit. The group's unit stays the row, so counting,
     // marking, and auditing below are unaffected by how many documents a row

--- a/apps/api/src/lib/legal-search/case-law-corpus-projection.ts
+++ b/apps/api/src/lib/legal-search/case-law-corpus-projection.ts
@@ -4,11 +4,16 @@ import {
   caseLawCorpusIndexProjections,
   caseLawDecisions,
 } from "@/api/db/schema";
+import { caseLawIndexIdSql } from "@/api/lib/legal-search/case-law-index-groups";
 
 /** Join one decision to its durable state for the selected generation. */
 export const caseLawCorpusProjectionJoin = (generation: string) =>
   sql`${caseLawCorpusIndexProjections.decisionId} = ${caseLawDecisions.id}
     AND ${caseLawCorpusIndexProjections.generation} = ${generation}`;
+
+/** The physical index this generation projects a decision's current country into. */
+export const caseLawDecisionCorpusIndexIdSql = (generation: string) =>
+  caseLawIndexIdSql(sql`${generation}`, caseLawDecisions.country);
 
 /**
  * Accept a physical hit only when this generation recorded the current
@@ -19,7 +24,7 @@ export const currentCaseLawCorpusProjection = (generation: string) =>
   sql`(
     (
       ${caseLawCorpusIndexProjections.indexedHash} = ${caseLawDecisions.contentHash}
-      AND ${caseLawCorpusIndexProjections.indexId} = (${generation} || '_' || lower(${caseLawDecisions.country}))
+      AND ${caseLawCorpusIndexProjections.indexId} = (${caseLawDecisionCorpusIndexIdSql(generation)})
       AND ${caseLawCorpusIndexProjections.pendingAction} IS NULL
     )
     OR (

--- a/apps/api/src/lib/legal-search/case-law-index-groups.db.test.ts
+++ b/apps/api/src/lib/legal-search/case-law-index-groups.db.test.ts
@@ -3,7 +3,6 @@ import { sql } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/pglite";
 import { readFileSync } from "node:fs";
-import nodePath from "node:path";
 
 import {
   caseLawCorpusIndexBackfills,
@@ -13,35 +12,34 @@ import {
 } from "@/api/db/schema";
 import { createSafeId } from "@/api/lib/branded-types";
 import {
-  CASE_LAW_INDEX_GROUPS,
+  CASE_LAW_INDEX_GROUP_OF,
   caseLawIndexIdSql,
 } from "@/api/lib/legal-search/case-law-index-groups";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 import { isRecord } from "@/api/lib/type-guards";
+import {
+  INDEX_ID_FUNCTION,
+  installCaseLawProjectionTrigger,
+  latestMigrationContaining,
+} from "@/api/tests/helpers/case-law-projection-trigger";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
 /**
  * The physical index id is derived in three runtimes: `corpusIndexId` in
  * TypeScript, `caseLawIndexIdSql` in the queries, and
  * `case_law_corpus_index_id` in the projection trigger. Each is proved equal
- * to the others here against a real PostgreSQL, over every group member in
- * both letter cases, countries outside every group, and generations on both
- * sides of the grouping threshold plus one from another family.
+ * to the others here against a real PostgreSQL, over every declared
+ * jurisdiction in both letter cases, countries outside the declaration, and
+ * generations on both sides of the grouping threshold, at and past the
+ * integer bound, plus one from another family.
  */
 
-const DRIZZLE_DIR = nodePath.resolve(import.meta.dir, "../../../drizzle");
-const INDEX_ID_FUNCTION =
-  "CREATE OR REPLACE FUNCTION case_law_corpus_index_id(generation text, country text)";
-const PROJECTION_TRIGGER_FUNCTION =
-  "CREATE OR REPLACE FUNCTION enqueue_case_law_corpus_index_projection()";
-const PROJECTION_TRIGGER =
-  "CREATE TRIGGER case_law_decisions_enqueue_corpus_index_projection";
-
+const DECLARED: readonly string[] = Object.keys(CASE_LAW_INDEX_GROUP_OF);
 const COUNTRIES: readonly string[] = [
-  ...Object.values(CASE_LAW_INDEX_GROUPS).flat(),
-  ...Object.values(CASE_LAW_INDEX_GROUPS)
-    .flat()
-    .map((country) => country.toLowerCase()),
+  ...DECLARED,
+  ...DECLARED.map((country) => country.toLowerCase()),
+  // A code that spells a language tag derives an index of its own.
+  "PL",
   "HUN",
   "ROU",
   "xyz",
@@ -51,45 +49,16 @@ const GENERATIONS: readonly string[] = [
   "case_law_v2",
   "case_law_v3",
   "case_law_v12",
+  // The last order the checkpoint column holds, and the first past it: the
+  // former is grouped, the latter is not a case-law generation and stays per
+  // country rather than failing an integer cast.
+  "case_law_v2147483647",
+  "case_law_v2147483648",
   "legislation_v1",
 ];
 
 let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
-
-/** Statements of a migration file, in order, comments included. */
-const statementsOf = (path: string): string[] =>
-  readFileSync(path, "utf-8")
-    .split("--> statement-breakpoint")
-    .map((statement) => statement.trim())
-    .filter((statement) => statement.length > 0);
-
-/**
- * The last migration whose text contains `marker`. Migrations apply in
- * directory order, so that is the definition a database ends up with.
- */
-const latestMigrationContaining = (marker: string): string => {
-  const path = [...new Bun.Glob("*/migration.sql").scanSync(DRIZZLE_DIR)]
-    .sort()
-    .map((file) => nodePath.join(DRIZZLE_DIR, file))
-    .findLast((file) => readFileSync(file, "utf-8").includes(marker));
-  if (path === undefined) {
-    throw new Error(`no migration contains ${marker}`);
-  }
-  return path;
-};
-
-/** Statements matching `statementMarker` from the last migration containing `marker`. */
-const latestStatements = (
-  marker: string,
-  statementMarker: RegExp,
-): string[] => {
-  const statements = statementsOf(latestMigrationContaining(marker)).filter(
-    (statement) => statementMarker.test(statement),
-  );
-  expect(statements.length).toBeGreaterThan(0);
-  return statements;
-};
 
 /** Rows from `execute` under either driver shape (bare array or `{ rows }`). */
 const executedRows = (result: unknown): unknown[] => {
@@ -116,25 +85,7 @@ beforeAll(
     db = drizzle({ client });
     // The function under test, and the trigger that calls it, come from the
     // last migrations that define them, so the test runs the deployed text.
-    const statements = [
-      ...latestStatements(
-        INDEX_ID_FUNCTION,
-        /FUNCTION case_law_corpus_index_id\(/u,
-      ),
-      ...latestStatements(
-        PROJECTION_TRIGGER_FUNCTION,
-        /enqueue_case_law_corpus_index_projection\(\)\s+RETURNS trigger/u,
-      ),
-      // The replacement drop (`DROP TRIGGER IF EXISTS ...`) and the creation.
-      ...latestStatements(
-        PROJECTION_TRIGGER,
-        /\b(?:CREATE|DROP) TRIGGER (?:IF EXISTS )?case_law_decisions_enqueue_corpus_index_projection\b/u,
-      ),
-    ];
-    for (const statement of statements) {
-      // oxlint-disable-next-line no-await-in-loop -- order-dependent DDL
-      await db.execute(sql.raw(statement));
-    }
+    await installCaseLawProjectionTrigger(db);
   },
   { timeout: 120_000 },
 );
@@ -181,6 +132,15 @@ test("the SQL function, the query fragment, and corpusIndexId derive the same id
   expect(corpusIndexId("case_law_v3", "CZE")).not.toBe("case_law_v3_cze");
   expect(corpusIndexId("case_law_v2", "CZE")).toBe("case_law_v2_cze");
   expect(corpusIndexId("legislation_v1", "CZE")).toBe("legislation_v1_cze");
+  expect(corpusIndexId("case_law_v2147483647", "CZE")).toBe(
+    "case_law_v2147483647_cs_sk",
+  );
+  expect(corpusIndexId("case_law_v2147483648", "CZE")).toBe(
+    "case_law_v2147483648_cze",
+  );
+  expect(corpusIndexId("case_law_v3", "PL")).not.toBe(
+    corpusIndexId("case_law_v3", "POL"),
+  );
 });
 
 test("the migration's function body is the rendered query fragment", () => {

--- a/apps/api/src/lib/legal-search/case-law-index-groups.db.test.ts
+++ b/apps/api/src/lib/legal-search/case-law-index-groups.db.test.ts
@@ -1,0 +1,278 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { drizzle } from "drizzle-orm/pglite";
+import { readFileSync } from "node:fs";
+import nodePath from "node:path";
+
+import {
+  caseLawCorpusIndexBackfills,
+  caseLawCorpusIndexProjections,
+  caseLawDecisions,
+  caseLawSources,
+} from "@/api/db/schema";
+import { createSafeId } from "@/api/lib/branded-types";
+import {
+  CASE_LAW_INDEX_GROUPS,
+  caseLawIndexIdSql,
+} from "@/api/lib/legal-search/case-law-index-groups";
+import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+import { isRecord } from "@/api/lib/type-guards";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+/**
+ * The physical index id is derived in three runtimes: `corpusIndexId` in
+ * TypeScript, `caseLawIndexIdSql` in the queries, and
+ * `case_law_corpus_index_id` in the projection trigger. Each is proved equal
+ * to the others here against a real PostgreSQL, over every group member in
+ * both letter cases, countries outside every group, and generations on both
+ * sides of the grouping threshold plus one from another family.
+ */
+
+const DRIZZLE_DIR = nodePath.resolve(import.meta.dir, "../../../drizzle");
+const INDEX_ID_FUNCTION =
+  "CREATE OR REPLACE FUNCTION case_law_corpus_index_id(generation text, country text)";
+const PROJECTION_TRIGGER_FUNCTION =
+  "CREATE OR REPLACE FUNCTION enqueue_case_law_corpus_index_projection()";
+const PROJECTION_TRIGGER =
+  "CREATE TRIGGER case_law_decisions_enqueue_corpus_index_projection";
+
+const COUNTRIES: readonly string[] = [
+  ...Object.values(CASE_LAW_INDEX_GROUPS).flat(),
+  ...Object.values(CASE_LAW_INDEX_GROUPS)
+    .flat()
+    .map((country) => country.toLowerCase()),
+  "HUN",
+  "ROU",
+  "xyz",
+];
+const GENERATIONS: readonly string[] = [
+  "case_law_v1",
+  "case_law_v2",
+  "case_law_v3",
+  "case_law_v12",
+  "legislation_v1",
+];
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+/** Statements of a migration file, in order, comments included. */
+const statementsOf = (path: string): string[] =>
+  readFileSync(path, "utf-8")
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
+
+/**
+ * The last migration whose text contains `marker`. Migrations apply in
+ * directory order, so that is the definition a database ends up with.
+ */
+const latestMigrationContaining = (marker: string): string => {
+  const path = [...new Bun.Glob("*/migration.sql").scanSync(DRIZZLE_DIR)]
+    .sort()
+    .map((file) => nodePath.join(DRIZZLE_DIR, file))
+    .findLast((file) => readFileSync(file, "utf-8").includes(marker));
+  if (path === undefined) {
+    throw new Error(`no migration contains ${marker}`);
+  }
+  return path;
+};
+
+/** Statements matching `statementMarker` from the last migration containing `marker`. */
+const latestStatements = (
+  marker: string,
+  statementMarker: RegExp,
+): string[] => {
+  const statements = statementsOf(latestMigrationContaining(marker)).filter(
+    (statement) => statementMarker.test(statement),
+  );
+  expect(statements.length).toBeGreaterThan(0);
+  return statements;
+};
+
+/** Rows from `execute` under either driver shape (bare array or `{ rows }`). */
+const executedRows = (result: unknown): unknown[] => {
+  if (Array.isArray(result)) {
+    return result;
+  }
+  if (isRecord(result) && Array.isArray(result["rows"])) {
+    return result["rows"];
+  }
+  return [];
+};
+
+const readString = (row: unknown, key: string): string => {
+  const value = isRecord(row) ? row[key] : undefined;
+  if (typeof value !== "string") {
+    throw new TypeError(`${key} did not render as text`);
+  }
+  return value;
+};
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    db = drizzle({ client });
+    // The function under test, and the trigger that calls it, come from the
+    // last migrations that define them, so the test runs the deployed text.
+    const statements = [
+      ...latestStatements(
+        INDEX_ID_FUNCTION,
+        /FUNCTION case_law_corpus_index_id\(/u,
+      ),
+      ...latestStatements(
+        PROJECTION_TRIGGER_FUNCTION,
+        /enqueue_case_law_corpus_index_projection\(\)\s+RETURNS trigger/u,
+      ),
+      // The replacement drop (`DROP TRIGGER IF EXISTS ...`) and the creation.
+      ...latestStatements(
+        PROJECTION_TRIGGER,
+        /\b(?:CREATE|DROP) TRIGGER (?:IF EXISTS )?case_law_decisions_enqueue_corpus_index_projection\b/u,
+      ),
+    ];
+    for (const statement of statements) {
+      // oxlint-disable-next-line no-await-in-loop -- order-dependent DDL
+      await db.execute(sql.raw(statement));
+    }
+  },
+  { timeout: 120_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("the SQL function, the query fragment, and corpusIndexId derive the same id", async () => {
+  const countryValues = sql.join(
+    COUNTRIES.map((country) => sql`(${country}::varchar(3))`),
+    sql`, `,
+  );
+  for (const generation of GENERATIONS) {
+    // The generation is a bound parameter and the country a column, the
+    // shapes the query layer feeds the fragment.
+    // oxlint-disable-next-line no-await-in-loop -- one round trip per generation on a single test DB
+    const result = await db.execute(sql`
+      SELECT c.country AS "country",
+             case_law_corpus_index_id(${generation}, c.country) AS "fn",
+             (${caseLawIndexIdSql(sql`${generation}`, sql.raw("c.country"))}) AS "fragment"
+        FROM (VALUES ${countryValues}) AS c(country)
+    `);
+    const rows = executedRows(result);
+    expect(rows.length).toBe(COUNTRIES.length);
+    for (const row of rows) {
+      const country = readString(row, "country");
+      const expected = corpusIndexId(generation, country);
+      expect([generation, country, readString(row, "fn")]).toEqual([
+        generation,
+        country,
+        expected,
+      ]);
+      expect([generation, country, readString(row, "fragment")]).toEqual([
+        generation,
+        country,
+        expected,
+      ]);
+    }
+  }
+  // Non-vacuity: the grouped form differs from the per-country one where a
+  // group holds several countries, and the ungrouped generations keep it.
+  expect(corpusIndexId("case_law_v3", "CZE")).toBe("case_law_v3_cs_sk");
+  expect(corpusIndexId("case_law_v3", "CZE")).not.toBe("case_law_v3_cze");
+  expect(corpusIndexId("case_law_v2", "CZE")).toBe("case_law_v2_cze");
+  expect(corpusIndexId("legislation_v1", "CZE")).toBe("legislation_v1_cze");
+});
+
+test("the migration's function body is the rendered query fragment", () => {
+  const { sql: rendered, params } = new PgDialect().sqlToQuery(
+    caseLawIndexIdSql(sql.raw("generation"), sql.raw("country")),
+  );
+  // DDL takes no bind parameters, so the fragment must carry none.
+  expect(params).toEqual([]);
+
+  const migration = readFileSync(
+    latestMigrationContaining(INDEX_ID_FUNCTION),
+    "utf-8",
+  );
+  const body =
+    /RETURNS text\s+LANGUAGE sql\s+IMMUTABLE STRICT\s+AS \$function\$\s+SELECT (?<body>[\s\S]*?)\s+\$function\$;/u.exec(
+      migration,
+    )?.groups?.["body"];
+  if (body === undefined) {
+    throw new Error("migration does not define the function as expected");
+  }
+  const normalize = (text: string) => text.replaceAll(/\s+/gu, " ").trim();
+  expect(normalize(body)).toBe(normalize(rendered));
+});
+
+test("the function is immutable and strict", async () => {
+  const rows = executedRows(
+    await db.execute(sql`
+      SELECT provolatile::text AS "volatility", proisstrict AS "strict"
+        FROM pg_proc
+       WHERE proname = 'case_law_corpus_index_id'
+    `),
+  );
+  expect(rows).toEqual([{ volatility: "i", strict: true }]);
+  const nulls = executedRows(
+    await db.execute(sql`
+      SELECT case_law_corpus_index_id(NULL, 'CZE') AS "a",
+             case_law_corpus_index_id('case_law_v3', NULL) AS "b"
+    `),
+  );
+  expect(nulls).toEqual([{ a: null, b: null }]);
+});
+
+test("the projection trigger enqueues and accepts the grouped id", async () => {
+  const generation = "case_law_v3";
+  const sourceId = createSafeId<"caseLawSource">();
+  const decisionId = createSafeId<"caseLawDecision">();
+  const contentHash = "hash-1";
+  await db
+    .insert(caseLawSources)
+    .values({ adapterKey: "public", id: sourceId, name: "public" });
+  await db.insert(caseLawCorpusIndexBackfills).values({ generation });
+
+  await db.insert(caseLawDecisions).values({
+    caseNumber: "1 C 1/2024",
+    contentHash,
+    country: "CZE",
+    court: "Test court",
+    id: decisionId,
+    language: "cs",
+    sourceId,
+  });
+  const queued = await db
+    .select({
+      indexId: caseLawCorpusIndexProjections.indexId,
+      pendingAction: caseLawCorpusIndexProjections.pendingAction,
+      pendingIndexIds: caseLawCorpusIndexProjections.pendingIndexIds,
+    })
+    .from(caseLawCorpusIndexProjections);
+  expect(queued).toEqual([
+    {
+      indexId: null,
+      pendingAction: "index",
+      pendingIndexIds: [corpusIndexId(generation, "CZE")],
+    },
+  ]);
+
+  // The serving-generation mark is accepted only where it names the index
+  // the generation derives for the row's country.
+  await db
+    .update(caseLawDecisions)
+    .set({
+      indexedGeneration: corpusIndexId(generation, "CZE"),
+      indexedHash: contentHash,
+    })
+    .where(sql`${caseLawDecisions.id} = ${decisionId}`);
+  const marked = await db
+    .select({
+      indexId: caseLawCorpusIndexProjections.indexId,
+      indexedHash: caseLawCorpusIndexProjections.indexedHash,
+    })
+    .from(caseLawCorpusIndexProjections);
+  expect(marked).toEqual([
+    { indexId: "case_law_v3_cs_sk", indexedHash: contentHash },
+  ]);
+});

--- a/apps/api/src/lib/legal-search/case-law-index-groups.ts
+++ b/apps/api/src/lib/legal-search/case-law-index-groups.ts
@@ -1,0 +1,99 @@
+/**
+ * Which case-law jurisdictions share one physical corpus index.
+ *
+ * From generation `CASE_LAW_INDEX_GROUPING_FROM_GENERATION` on, a case-law
+ * index id is `<generation>_<group>` rather than `<generation>_<country>`:
+ * every country of a group projects into, and is queried from, the same
+ * index. Earlier generations keep one index per country.
+ *
+ * The mapping is declared once here and rendered into SQL by
+ * `caseLawIndexIdSql`, so the TypeScript id and the id Postgres derives in
+ * queries and in the projection trigger come from the same declaration.
+ * `case-law-index-groups.db.test.ts` proves the three renderings (TypeScript,
+ * this fragment, and the migration's `case_law_corpus_index_id` function)
+ * agree executably.
+ */
+
+import type { SQL, SQLWrapper } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+
+/**
+ * Group name to the countries it holds. A country absent from every group
+ * forms its own group, named by its lowercase code, so an unlisted
+ * jurisdiction still gets a deterministic index of its own.
+ */
+export const CASE_LAW_INDEX_GROUPS = {
+  cs_sk: ["CZE", "SVK"],
+  pl: ["POL"],
+  eu: ["EU"],
+  de: ["AUT", "DEU"],
+} as const satisfies Record<string, readonly string[]>;
+
+export type CaseLawIndexGroup = keyof typeof CASE_LAW_INDEX_GROUPS;
+
+/** First case-law generation whose physical indexes are per group. */
+export const CASE_LAW_INDEX_GROUPING_FROM_GENERATION = 3;
+
+const isCaseLawIndexGroup = (value: string): value is CaseLawIndexGroup =>
+  Object.hasOwn(CASE_LAW_INDEX_GROUPS, value);
+
+/** Group names in declaration order. */
+export const CASE_LAW_INDEX_GROUP_NAMES: readonly CaseLawIndexGroup[] =
+  Object.keys(CASE_LAW_INDEX_GROUPS).filter(isCaseLawIndexGroup);
+
+const GROUP_BY_COUNTRY: ReadonlyMap<string, CaseLawIndexGroup> = new Map(
+  CASE_LAW_INDEX_GROUP_NAMES.flatMap((group) =>
+    CASE_LAW_INDEX_GROUPS[group].map(
+      (country) => [country, group] satisfies [string, CaseLawIndexGroup],
+    ),
+  ),
+);
+
+/** Lowercase index group of a country; its own code when unlisted. */
+export const caseLawIndexGroup = (country: string): string =>
+  GROUP_BY_COUNTRY.get(country.toUpperCase()) ?? country.toLowerCase();
+
+/** Countries an index group holds; the group's own code when unlisted. */
+export const caseLawIndexGroupCountries = (group: string): readonly string[] =>
+  isCaseLawIndexGroup(group)
+    ? CASE_LAW_INDEX_GROUPS[group]
+    : [group.toUpperCase()];
+
+/**
+ * The generation-order match the backfill checkpoint's `generation_order`
+ * column uses; a generation outside the canonical case-law form yields NULL,
+ * and NULL never satisfies the threshold, so such a generation stays per
+ * country.
+ */
+const CASE_LAW_GENERATION_ORDER_PATTERN = "^case_law_v([1-9][0-9]*)$";
+
+/**
+ * The index id as a SQL expression over a generation and a country, the same
+ * mapping `corpusIndexId` applies. Constants are inlined with `sql.raw` (they
+ * come from the declaration above, never from input) so the same text serves
+ * as a function body in DDL, where bind parameters do not exist.
+ */
+export const caseLawIndexIdSql = (
+  generation: SQLWrapper,
+  country: SQLWrapper,
+): SQL => {
+  const groupArms = sql.join(
+    CASE_LAW_INDEX_GROUP_NAMES.flatMap((group) =>
+      CASE_LAW_INDEX_GROUPS[group].map(
+        (member) =>
+          sql`WHEN ${sql.raw(`'${member}'`)} THEN ${sql.raw(`'${group}'`)}`,
+      ),
+    ),
+    sql`
+    `,
+  );
+  return sql`CASE
+  WHEN substring(${generation} from ${sql.raw(`'${CASE_LAW_GENERATION_ORDER_PATTERN}'`)})::integer
+       >= ${sql.raw(String(CASE_LAW_INDEX_GROUPING_FROM_GENERATION))}
+  THEN ${generation} || '_' || CASE upper(${country})
+    ${groupArms}
+    ELSE lower(${country})
+  END
+  ELSE ${generation} || '_' || lower(${country})
+END`;
+};

--- a/apps/api/src/lib/legal-search/case-law-index-groups.ts
+++ b/apps/api/src/lib/legal-search/case-law-index-groups.ts
@@ -14,58 +14,112 @@
  * agree executably.
  */
 
+import { panic } from "better-result";
 import type { SQL, SQLWrapper } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 
-/**
- * Group name to the countries it holds. A country absent from every group
- * forms its own group, named by its lowercase code, so an unlisted
- * jurisdiction still gets a deterministic index of its own.
- */
-export const CASE_LAW_INDEX_GROUPS = {
-  cs_sk: ["CZE", "SVK"],
-  pl: ["POL"],
-  eu: ["EU"],
-  de: ["AUT", "DEU"],
-} as const satisfies Record<string, readonly string[]>;
+import type { CaseLawJurisdiction } from "@/api/lib/legal-search/ingestion-constants";
 
-export type CaseLawIndexGroup = keyof typeof CASE_LAW_INDEX_GROUPS;
+/**
+ * Index group of every declared jurisdiction. Total over
+ * `CaseLawJurisdiction`: a new jurisdiction does not compile until it is
+ * placed here.
+ *
+ * A group name is either the jurisdiction's own lowercase code (an index of
+ * its own) or contains an underscore (an index shared by several
+ * jurisdictions). A country outside this map falls back to its own lowercase
+ * code, and a country code holds letters only, so a fallback can never name
+ * a declared group: the two kinds of id share one namespace by construction.
+ */
+export const CASE_LAW_INDEX_GROUP_OF = {
+  AUT: "aut",
+  CZE: "cs_sk",
+  EU: "eu",
+  POL: "pol",
+  SVK: "cs_sk",
+} as const satisfies {
+  [J in CaseLawJurisdiction]: Lowercase<J> | `${string}_${string}`;
+};
+
+export type CaseLawIndexGroup =
+  (typeof CASE_LAW_INDEX_GROUP_OF)[CaseLawJurisdiction];
 
 /** First case-law generation whose physical indexes are per group. */
 export const CASE_LAW_INDEX_GROUPING_FROM_GENERATION = 3;
 
-const isCaseLawIndexGroup = (value: string): value is CaseLawIndexGroup =>
-  Object.hasOwn(CASE_LAW_INDEX_GROUPS, value);
+const isCaseLawJurisdictionKey = (
+  value: string,
+): value is CaseLawJurisdiction =>
+  Object.hasOwn(CASE_LAW_INDEX_GROUP_OF, value);
 
-/** Group names in declaration order. */
-export const CASE_LAW_INDEX_GROUP_NAMES: readonly CaseLawIndexGroup[] =
-  Object.keys(CASE_LAW_INDEX_GROUPS).filter(isCaseLawIndexGroup);
+const DECLARED_JURISDICTIONS: readonly CaseLawJurisdiction[] = Object.keys(
+  CASE_LAW_INDEX_GROUP_OF,
+).filter(isCaseLawJurisdictionKey);
 
-const GROUP_BY_COUNTRY: ReadonlyMap<string, CaseLawIndexGroup> = new Map(
-  CASE_LAW_INDEX_GROUP_NAMES.flatMap((group) =>
-    CASE_LAW_INDEX_GROUPS[group].map(
-      (country) => [country, group] satisfies [string, CaseLawIndexGroup],
+/** Group names in declaration order, each once. */
+export const CASE_LAW_INDEX_GROUP_NAMES: readonly CaseLawIndexGroup[] = [
+  ...new Set(
+    DECLARED_JURISDICTIONS.map(
+      (jurisdiction) => CASE_LAW_INDEX_GROUP_OF[jurisdiction],
     ),
   ),
+];
+
+export const isCaseLawIndexGroup = (
+  value: string,
+): value is CaseLawIndexGroup =>
+  CASE_LAW_INDEX_GROUP_NAMES.some((group) => group === value);
+
+/** Group name to the jurisdictions it holds, in declaration order. */
+export const CASE_LAW_INDEX_GROUPS: ReadonlyMap<
+  CaseLawIndexGroup,
+  readonly CaseLawJurisdiction[]
+> = new Map(
+  CASE_LAW_INDEX_GROUP_NAMES.map((group) => [
+    group,
+    DECLARED_JURISDICTIONS.filter(
+      (jurisdiction) => CASE_LAW_INDEX_GROUP_OF[jurisdiction] === group,
+    ),
+  ]),
 );
 
 /** Lowercase index group of a country; its own code when unlisted. */
-export const caseLawIndexGroup = (country: string): string =>
-  GROUP_BY_COUNTRY.get(country.toUpperCase()) ?? country.toLowerCase();
+export const caseLawIndexGroup = (country: string): string => {
+  const upper = country.toUpperCase();
+  return isCaseLawJurisdictionKey(upper)
+    ? CASE_LAW_INDEX_GROUP_OF[upper]
+    : country.toLowerCase();
+};
 
 /** Countries an index group holds; the group's own code when unlisted. */
-export const caseLawIndexGroupCountries = (group: string): readonly string[] =>
-  isCaseLawIndexGroup(group)
-    ? CASE_LAW_INDEX_GROUPS[group]
-    : [group.toUpperCase()];
+export const caseLawIndexGroupCountries = (
+  group: string,
+): readonly string[] => {
+  if (!isCaseLawIndexGroup(group)) {
+    return [group.toUpperCase()];
+  }
+  return (
+    CASE_LAW_INDEX_GROUPS.get(group) ??
+    panic(`Index group without members: ${group}`)
+  );
+};
 
 /**
  * The generation-order match the backfill checkpoint's `generation_order`
  * column uses; a generation outside the canonical case-law form yields NULL,
- * and NULL never satisfies the threshold, so such a generation stays per
+ * and NULL never satisfies the range, so such a generation stays per
  * country.
  */
 const CASE_LAW_GENERATION_ORDER_PATTERN = "^case_law_v([1-9][0-9]*)$";
+
+/**
+ * Largest generation order the checkpoint's integer column can hold. Past
+ * it a digit run is not a case-law generation, for
+ * `caseLawCorpusGenerationOrder` and for the fragment below alike; the
+ * fragment compares in `numeric`, so a longer run is out of range rather
+ * than a cast error.
+ */
+export const POSTGRES_INTEGER_MAX = 2_147_483_647;
 
 /**
  * The index id as a SQL expression over a generation and a country, the same
@@ -78,18 +132,17 @@ export const caseLawIndexIdSql = (
   country: SQLWrapper,
 ): SQL => {
   const groupArms = sql.join(
-    CASE_LAW_INDEX_GROUP_NAMES.flatMap((group) =>
-      CASE_LAW_INDEX_GROUPS[group].map(
-        (member) =>
-          sql`WHEN ${sql.raw(`'${member}'`)} THEN ${sql.raw(`'${group}'`)}`,
-      ),
+    DECLARED_JURISDICTIONS.map(
+      (jurisdiction) =>
+        sql`WHEN ${sql.raw(`'${jurisdiction}'`)} THEN ${sql.raw(`'${CASE_LAW_INDEX_GROUP_OF[jurisdiction]}'`)}`,
     ),
     sql`
     `,
   );
   return sql`CASE
-  WHEN substring(${generation} from ${sql.raw(`'${CASE_LAW_GENERATION_ORDER_PATTERN}'`)})::integer
-       >= ${sql.raw(String(CASE_LAW_INDEX_GROUPING_FROM_GENERATION))}
+  WHEN substring(${generation} from ${sql.raw(`'${CASE_LAW_GENERATION_ORDER_PATTERN}'`)})::numeric
+       BETWEEN ${sql.raw(String(CASE_LAW_INDEX_GROUPING_FROM_GENERATION))}
+       AND ${sql.raw(String(POSTGRES_INTEGER_MAX))}
   THEN ${generation} || '_' || CASE upper(${country})
     ${groupArms}
     ELSE lower(${country})

--- a/apps/api/src/lib/legal-search/corpus-family.ts
+++ b/apps/api/src/lib/legal-search/corpus-family.ts
@@ -17,8 +17,9 @@ export const parseCorpusFamily = (value: unknown): CorpusFamily | null =>
 /**
  * Blue-green generation prefix per family. Index ids are
  * `<generation>_<jurisdiction>` (e.g. `case_law_v1_svk`,
- * `legislation_v1_svk`). Bumping a prefix rebuilds that family across all
- * jurisdictions, then you flip to it. case_law keeps its existing env
+ * `legislation_v1_svk`), or `<generation>_<group>` for case-law generations
+ * from 3 on (`corpusIndexId`). Bumping a prefix rebuilds that family across
+ * all jurisdictions, then you flip to it. case_law keeps its existing env
  * override for back-compat; other families default to `<family>_v1`.
  */
 export const corpusGeneration = (family: CorpusFamily): string => {

--- a/apps/api/src/lib/legal-search/corpus-index-config.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 
+import { CASE_LAW_INDEX_GROUPS } from "@/api/lib/legal-search/case-law-index-groups";
 import {
   caseLawIndexConfig,
   corpusIndexConfig,
@@ -9,6 +10,7 @@ import {
 import {
   CASE_LAW_JURISDICTIONS,
   type CaseLawJurisdiction,
+  isCaseLawJurisdiction,
 } from "@/api/lib/legal-search/ingestion-constants";
 
 test("searchable text fields enable fieldnorms so BM25 scoring works", () => {
@@ -110,12 +112,24 @@ const COURT_DOMAIN_BOUND = {
 // is the one tag field whose domain is neither a short closed list
 // (document_type, status) nor an operator-curated catalogue (source,
 // jurisdiction), so it is the one that has to be argued.
-test("court stays a viable tag field in every jurisdiction's index", () => {
-  // Indexes are per generation and jurisdiction, so a split holds one
-  // country's courts. A bound at half the limit leaves room for court renames
-  // and reorganizations, which add values without retiring the old ones.
+test("court stays a viable tag field in every index", () => {
+  // Indexes are per generation and jurisdiction up to generation 2, and per
+  // index group from generation 3 on, so a split holds the courts of one
+  // group's countries. A bound at half the limit leaves room for court
+  // renames and reorganizations, which add values without retiring the old
+  // ones. Summing per group is what makes adding a country to a group a
+  // decision about the group's court domain rather than a silent inheritance.
   for (const bound of Object.values(COURT_DOMAIN_BOUND)) {
     expect(bound).toBeLessThan(TAG_FIELD_VALUE_LIMIT / 2);
+  }
+  for (const [group, countries] of Object.entries(CASE_LAW_INDEX_GROUPS)) {
+    const groupBound = countries
+      .filter(isCaseLawJurisdiction)
+      .reduce((total, country) => total + COURT_DOMAIN_BOUND[country], 0);
+    expect([group, groupBound < TAG_FIELD_VALUE_LIMIT / 2]).toEqual([
+      group,
+      true,
+    ]);
   }
 
   // Total over the jurisdictions the corpus ships, so onboarding one is a

--- a/apps/api/src/lib/legal-search/corpus-index-config.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.test.ts
@@ -10,7 +10,6 @@ import {
 import {
   CASE_LAW_JURISDICTIONS,
   type CaseLawJurisdiction,
-  isCaseLawJurisdiction,
 } from "@/api/lib/legal-search/ingestion-constants";
 
 test("searchable text fields enable fieldnorms so BM25 scoring works", () => {
@@ -122,10 +121,12 @@ test("court stays a viable tag field in every index", () => {
   for (const bound of Object.values(COURT_DOMAIN_BOUND)) {
     expect(bound).toBeLessThan(TAG_FIELD_VALUE_LIMIT / 2);
   }
-  for (const [group, countries] of Object.entries(CASE_LAW_INDEX_GROUPS)) {
-    const groupBound = countries
-      .filter(isCaseLawJurisdiction)
-      .reduce((total, country) => total + COURT_DOMAIN_BOUND[country], 0);
+  // Group members are declared jurisdictions, so every member has a bound.
+  for (const [group, countries] of CASE_LAW_INDEX_GROUPS) {
+    const groupBound = countries.reduce(
+      (total, country) => total + COURT_DOMAIN_BOUND[country],
+      0,
+    );
     expect([group, groupBound < TAG_FIELD_VALUE_LIMIT / 2]).toEqual([
       group,
       true,

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -276,8 +276,9 @@ export const TAG_FIELD_VALUE_LIMIT = 1000;
  * Fields whose values a split records so a query can skip splits that cannot
  * match. Every one of them is a filter the browse and search paths apply, and
  * every one has a value domain bounded well under `TAG_FIELD_VALUE_LIMIT`
- * within a single index (indexes are per jurisdiction, so `court` is bounded
- * by one country's court registry, not by every country's at once).
+ * within a single index (indexes are per jurisdiction, or per index group
+ * from case-law generation 3 on, so `court` is bounded by one group's court
+ * registries, not by every country's at once).
  */
 const FAMILY_TAG_FIELDS: Record<CorpusFamily, string[]> = {
   // `language` is bounded by the languages a jurisdiction's courts publish in,

--- a/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
@@ -1,7 +1,8 @@
 import { Result } from "better-result";
-import { afterEach, beforeEach, expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, spyOn, test } from "bun:test";
 import * as v from "valibot";
 
+import * as corpusFamily from "@/api/lib/legal-search/corpus-family";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import {
   browseFacetNames,
@@ -159,6 +160,37 @@ test("scopes to one jurisdiction index, and to the generation glob without one",
 
   expect(requests.at(0)?.url).toContain(`/${generation}_cze/search`);
   expect(requests.at(1)?.url).toContain(`/${generation}_*/search`);
+});
+
+test("a scoped query on a shared index carries its jurisdiction as a clause", async () => {
+  responseBody = engineResponse();
+  // From generation 3 on CZE and SVK share one physical index, so selecting
+  // the index alone would aggregate over both countries.
+  const generation = spyOn(corpusFamily, "corpusGeneration").mockReturnValue(
+    "case_law_v3",
+  );
+  try {
+    await corpusIndexBrowseFacets({
+      excludedSourceIds: [],
+      jurisdiction: "CZE",
+      limit: 20,
+    });
+    await corpusIndexBrowseFacets({
+      excludedSourceIds: ["018f0a2b-0000-7000-8000-000000000001"],
+      jurisdiction: "POL",
+      limit: 20,
+    });
+  } finally {
+    generation.mockRestore();
+  }
+
+  expect(requests.at(0)?.url).toContain("/case_law_v3_cs_sk/search");
+  expect(requests.at(0)?.body["query"]).toBe('seq:0 AND jurisdiction:"CZE"');
+  // A single-country index needs no clause; the source exclusion still lands.
+  expect(requests.at(1)?.url).toContain("/case_law_v3_pl/search");
+  expect(requests.at(1)?.body["query"]).toBe(
+    'seq:0 AND NOT (source:"018f0a2b-0000-7000-8000-000000000001")',
+  );
 });
 
 test("asks for bucket depth beyond the requested size", async () => {

--- a/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
@@ -187,7 +187,7 @@ test("a scoped query on a shared index carries its jurisdiction as a clause", as
   expect(requests.at(0)?.url).toContain("/case_law_v3_cs_sk/search");
   expect(requests.at(0)?.body["query"]).toBe('seq:0 AND jurisdiction:"CZE"');
   // A single-country index needs no clause; the source exclusion still lands.
-  expect(requests.at(1)?.url).toContain("/case_law_v3_pl/search");
+  expect(requests.at(1)?.url).toContain("/case_law_v3_pol/search");
   expect(requests.at(1)?.body["query"]).toBe(
     'seq:0 AND NOT (source:"018f0a2b-0000-7000-8000-000000000001")',
   );

--- a/apps/api/src/lib/legal-search/corpus-index-facets.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.ts
@@ -4,10 +4,7 @@ import { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
 import { quoteCorpusValue } from "@/api/lib/legal-search/corpus-query";
-import {
-  corpusIndexId,
-  corpusIndexPattern,
-} from "@/api/lib/legal-search/index-naming";
+import { corpusIndexRoute } from "@/api/lib/legal-search/index-naming";
 import type {
   LegalBrowseFacets,
   LegalBrowseFacetsQuery,
@@ -43,20 +40,34 @@ import { isRecord } from "@/api/lib/type-guards";
 
 const OPENING_PASSAGE_QUERY = "seq:0";
 
+type BrowseFacetsQueryOptions = {
+  excludedSourceIds: readonly string[];
+  /** Set when the selected index holds other jurisdictions too. */
+  jurisdictionClause: string | undefined;
+};
+
 /**
- * Opening passages, minus every source that may no longer be redistributed.
- * An aggregation that dropped this clause would keep counting revoked
- * decisions for a reconciliation window plus a cache window, so the test
- * asserts it on the request the engine would receive.
+ * Opening passages, minus every source that may no longer be redistributed,
+ * within the scoped jurisdiction where its index is shared. An aggregation
+ * that dropped the source clause would keep counting revoked decisions for a
+ * reconciliation window plus a cache window, so the test asserts it on the
+ * request the engine would receive.
  */
-const browseFacetsQuery = (excludedSourceIds: readonly string[]): string => {
-  if (excludedSourceIds.length === 0) {
-    return OPENING_PASSAGE_QUERY;
+const browseFacetsQuery = ({
+  excludedSourceIds,
+  jurisdictionClause,
+}: BrowseFacetsQueryOptions): string => {
+  const clauses = [OPENING_PASSAGE_QUERY];
+  if (jurisdictionClause !== undefined) {
+    clauses.push(`jurisdiction:${quoteCorpusValue(jurisdictionClause)}`);
   }
-  const excluded = excludedSourceIds
-    .map((id) => `source:${quoteCorpusValue(id)}`)
-    .join(" OR ");
-  return `${OPENING_PASSAGE_QUERY} AND NOT (${excluded})`;
+  if (excludedSourceIds.length > 0) {
+    const excluded = excludedSourceIds
+      .map((id) => `source:${quoteCorpusValue(id)}`)
+      .join(" OR ");
+    clauses.push(`NOT (${excluded})`);
+  }
+  return clauses.join(" AND ");
 };
 
 /**
@@ -151,15 +162,20 @@ export const corpusIndexBrowseFacets = async (
   query: LegalBrowseFacetsQuery,
 ): Promise<Result<LegalBrowseFacets, LegalBrowseFacetsError>> => {
   const generation = corpusGeneration(query.documentFamily ?? "case_law");
-  // Scoped query → that jurisdiction's index; unscoped → the generation glob
-  // (one multi-index aggregation across every jurisdiction).
-  const indexId = query.jurisdiction
-    ? corpusIndexId(generation, query.jurisdiction)
-    : corpusIndexPattern(generation);
+  // Scoped query → that jurisdiction's index, plus a jurisdiction clause when
+  // that index holds other jurisdictions; unscoped → the generation glob (one
+  // multi-index aggregation across every index of the generation).
+  const { indexId, jurisdictionClause } = corpusIndexRoute(
+    generation,
+    query.jurisdiction,
+  );
 
   const aggregated = await getCorpusIndexClient().aggregate({
     indexId,
-    query: browseFacetsQuery(query.excludedSourceIds),
+    query: browseFacetsQuery({
+      excludedSourceIds: query.excludedSourceIds,
+      jurisdictionClause,
+    }),
     aggs: buildAggregations(query.limit),
   });
   if (Result.isError(aggregated)) {

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -21,10 +21,7 @@ import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-p
 import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
 import { loadDocumentContext } from "@/api/lib/legal-search/document-context";
 import { resolveExpandedCorpusQuery } from "@/api/lib/legal-search/expansion";
-import {
-  corpusIndexId,
-  corpusIndexPattern,
-} from "@/api/lib/legal-search/index-naming";
+import { corpusIndexRoute } from "@/api/lib/legal-search/index-naming";
 import {
   blendStableCitationAuthority,
   stableBlendUpperBound,
@@ -74,17 +71,18 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
   const limit = query.limit;
   const generation = corpusGeneration(query.documentFamily ?? "case_law");
 
-  // Scoped query → that jurisdiction's index; unscoped → the generation
-  // glob (corpus index multi-index search across all jurisdiction indexes).
-  const indexId = query.jurisdiction
-    ? corpusIndexId(generation, query.jurisdiction)
-    : corpusIndexPattern(generation);
+  // Scoped query → that jurisdiction's index, plus a jurisdiction clause when
+  // that index holds other jurisdictions; unscoped → the generation glob
+  // (corpus index multi-index search across all of the generation's indexes).
+  const { indexId, jurisdictionClause } = corpusIndexRoute(
+    generation,
+    query.jurisdiction,
+  );
 
   const parsedCursor = query.cursor ? decodeCursor(query.cursor) : null;
 
-  // jurisdiction is deliberately absent from the filters: it selected the
-  // index above, so a scoped query never needs a clause for it. It does select
-  // the expansion dictionary, which is why the resolver takes it separately.
+  // The jurisdiction also selects the expansion dictionary, which is why the
+  // resolver takes it separately from the clause.
   const engineQuery = await resolveExpandedCorpusQuery({
     build: (expand) =>
       caseLawCorpusQuery(
@@ -94,6 +92,7 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
           dateFrom: query.dateFrom,
           dateTo: query.dateTo,
           documentType: query.documentType,
+          jurisdiction: jurisdictionClause,
           language: query.language,
           source: query.source,
         },

--- a/apps/api/src/lib/legal-search/corpus-query.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-query.test.ts
@@ -205,11 +205,13 @@ test("the assembler ANDs filter clauses onto the free-text clause", () => {
       dateFrom: "2020-01-01",
       dateTo: "2024-12-31",
       documentType: "rozsudek",
+      jurisdiction: "CZE",
       language: "cs",
       source: "7449df27-2067-4827-b22f-3091f564ae50",
     }),
   ).toBe(
     '("náhrada škody")' +
+      ' AND jurisdiction:"CZE"' +
       ' AND document_type:"rozsudek"' +
       ' AND source:"7449df27-2067-4827-b22f-3091f564ae50"' +
       ' AND language:"cs"' +

--- a/apps/api/src/lib/legal-search/corpus-query.ts
+++ b/apps/api/src/lib/legal-search/corpus-query.ts
@@ -210,14 +210,18 @@ export const corpusFreeTextClause = (
 
 /**
  * Filters a case-law corpus query may carry, named after the index fields
- * rather than after either caller's request shape. `jurisdiction` is absent by
- * design: it selects the index, so a scoped query never needs a clause for it.
+ * rather than after either caller's request shape. `jurisdiction` selects the
+ * index first; it is a clause here only when that index holds other
+ * jurisdictions too (`corpusIndexRoute` decides), so a scoped query stays
+ * exact without every scoped query paying for a clause its index already
+ * implies.
  */
 export type CaseLawCorpusFilters = {
   court?: string | undefined;
   dateFrom?: string | undefined;
   dateTo?: string | undefined;
   documentType?: string | undefined;
+  jurisdiction?: string | undefined;
   language?: string | undefined;
   source?: string | undefined;
 };
@@ -240,6 +244,9 @@ export const caseLawCorpusQuery = (
   }
 
   const clauses: string[] = [freeText];
+  if (filters.jurisdiction) {
+    clauses.push(`jurisdiction:${quoteCorpusValue(filters.jurisdiction)}`);
+  }
   if (filters.documentType) {
     clauses.push(`document_type:${quoteCorpusValue(filters.documentType)}`);
   }

--- a/apps/api/src/lib/legal-search/index-naming.test.ts
+++ b/apps/api/src/lib/legal-search/index-naming.test.ts
@@ -4,8 +4,10 @@ import fc from "fast-check";
 import { propertyConfig } from "@stll/property-testing";
 
 import {
-  CASE_LAW_INDEX_GROUPS,
+  CASE_LAW_INDEX_GROUP_NAMES,
+  CASE_LAW_INDEX_GROUP_OF,
   CASE_LAW_INDEX_GROUPING_FROM_GENERATION,
+  CASE_LAW_INDEX_GROUPS,
 } from "@/api/lib/legal-search/case-law-index-groups";
 import {
   CORPUS_INDEX_GENERATION_MAX_LENGTH,
@@ -14,6 +16,7 @@ import {
   corpusIndexGeneration,
   corpusIndexId,
   corpusIndexIdsFor,
+  corpusIndexJurisdictions,
   corpusIndexPattern,
   corpusIndexRoute,
   isCaseLawCorpusGeneration,
@@ -28,31 +31,104 @@ test("index id is the generation prefix + lowercased jurisdiction", () => {
 
 test("case-law ids are per index group from the grouping generation on", () => {
   expect(CASE_LAW_INDEX_GROUPING_FROM_GENERATION).toBe(3);
-  for (const [group, countries] of Object.entries(CASE_LAW_INDEX_GROUPS)) {
-    for (const country of countries) {
-      expect(corpusIndexId("case_law_v3", country)).toBe(
-        `case_law_v3_${group}`,
-      );
-      expect(corpusIndexId("case_law_v12", country.toLowerCase())).toBe(
-        `case_law_v12_${group}`,
-      );
-      // Grouping is a rule about the case-law family's generations only.
-      expect(corpusIndexId("case_law_v2", country)).toBe(
-        `case_law_v2_${country.toLowerCase()}`,
-      );
-      expect(corpusIndexId("legislation_v3", country)).toBe(
-        `legislation_v3_${country.toLowerCase()}`,
-      );
-    }
+  for (const [country, group] of Object.entries(CASE_LAW_INDEX_GROUP_OF)) {
+    expect(corpusIndexId("case_law_v3", country)).toBe(`case_law_v3_${group}`);
+    expect(corpusIndexId("case_law_v12", country.toLowerCase())).toBe(
+      `case_law_v12_${group}`,
+    );
+    // Grouping is a rule about the case-law family's generations only.
+    expect(corpusIndexId("case_law_v2", country)).toBe(
+      `case_law_v2_${country.toLowerCase()}`,
+    );
+    expect(corpusIndexId("legislation_v3", country)).toBe(
+      `legislation_v3_${country.toLowerCase()}`,
+    );
   }
+  // Non-vacuity: at least one group is shared, and it is named apart from
+  // any one member's code.
+  expect(corpusIndexId("case_law_v3", "CZE")).toBe("case_law_v3_cs_sk");
+  expect(corpusIndexId("case_law_v3", "SVK")).toBe("case_law_v3_cs_sk");
   // A country outside every group is its own group.
   expect(corpusIndexId("case_law_v3", "HUN")).toBe("case_law_v3_hun");
+});
+
+test("a country outside the declaration never lands in a declared group", () => {
+  // The DB accepts any 2-8 letter code, so a code whose lowercase form is a
+  // group name would share that group's index without being a member. Group
+  // names are a member's own code or contain a separator no code holds, so
+  // every code outside the declaration derives an index that is its own.
+  for (const group of CASE_LAW_INDEX_GROUP_NAMES) {
+    const members = CASE_LAW_INDEX_GROUPS.get(group) ?? [];
+    expect(members.length).toBeGreaterThan(0);
+    const selfNamed = members.some((member) => member.toLowerCase() === group);
+    expect([group, selfNamed || group.includes("_")]).toEqual([group, true]);
+  }
+  fc.assert(
+    fc.property(fc.stringMatching(/^[A-Za-z]{2,8}$/u), (code) => {
+      const indexId = corpusIndexId("case_law_v3", code);
+      const declared = Object.hasOwn(
+        CASE_LAW_INDEX_GROUP_OF,
+        code.toUpperCase(),
+      );
+      // Codes off the declaration derive their own index, one no declared
+      // group answers for.
+      if (!declared) {
+        expect(indexId).toBe(`case_law_v3_${code.toLowerCase()}`);
+        expect(corpusIndexJurisdictions("case_law_v3", indexId)).toEqual([
+          code.toUpperCase(),
+        ]);
+      }
+    }),
+    propertyConfig({ numRuns: 300 }),
+  );
+  // The concrete near-miss: a two-letter code equal to a language tag.
+  expect(corpusIndexId("case_law_v3", "PL")).toBe("case_law_v3_pl");
+  expect(corpusIndexId("case_law_v3", "PL")).not.toBe(
+    corpusIndexId("case_law_v3", "POL"),
+  );
+});
+
+test("the jurisdictions of an index are the inverse of its derivation", () => {
+  const generationPattern = new RegExp(
+    `^[a-z][a-z0-9_]{0,${CORPUS_INDEX_GENERATION_MAX_LENGTH - 1}}$`,
+    "u",
+  );
+  fc.assert(
+    fc.property(
+      fc.oneof(
+        fc.constantFrom("case_law_v2", "case_law_v3", "legislation_v1"),
+        fc.stringMatching(generationPattern),
+      ),
+      fc.stringMatching(/^[A-Za-z]{2,8}$/u),
+      (generation, jurisdiction) => {
+        const indexId = corpusIndexId(generation, jurisdiction);
+        const held = corpusIndexJurisdictions(generation, indexId);
+        // Every jurisdiction the index is said to hold derives to it, and the
+        // one it was derived from is among them.
+        expect(held).toContain(jurisdiction.toUpperCase());
+        for (const country of held) {
+          expect(corpusIndexId(generation, country)).toBe(indexId);
+        }
+      },
+    ),
+    propertyConfig({ numRuns: 300 }),
+  );
+  expect(corpusIndexJurisdictions("case_law_v3", "case_law_v3_cs_sk")).toEqual([
+    "CZE",
+    "SVK",
+  ]);
+  expect(corpusIndexJurisdictions("case_law_v2", "case_law_v2_cze")).toEqual([
+    "CZE",
+  ]);
+  expect(() =>
+    corpusIndexJurisdictions("case_law_v2", "case_law_v3_cze"),
+  ).toThrow("is not of generation case_law_v2");
 });
 
 test("distinct physical ids for a jurisdiction list", () => {
   expect(corpusIndexIdsFor("case_law_v3", ["CZE", "POL", "SVK"])).toEqual([
     "case_law_v3_cs_sk",
-    "case_law_v3_pl",
+    "case_law_v3_pol",
   ]);
   expect(corpusIndexIdsFor("case_law_v2", ["CZE", "POL", "SVK"])).toEqual([
     "case_law_v2_cze",
@@ -67,9 +143,15 @@ test("a scoped query names its index, and a clause only where the index is share
     indexId: "case_law_v3_cs_sk",
     jurisdictionClause: "CZE",
   });
+  // The clause is the canonical code indexed documents carry, whatever
+  // case the scope arrived in.
+  expect(corpusIndexRoute("case_law_v3", "cze")).toEqual({
+    indexId: "case_law_v3_cs_sk",
+    jurisdictionClause: "CZE",
+  });
   // A single-country group is bounded by its index alone.
   expect(corpusIndexRoute("case_law_v3", "POL")).toEqual({
-    indexId: "case_law_v3_pl",
+    indexId: "case_law_v3_pol",
     jurisdictionClause: undefined,
   });
   // Before grouping every index is one jurisdiction's.
@@ -168,7 +250,7 @@ test("rejects malformed physical index ids", () => {
 
 test("generation extraction reads a group suffix that contains the separator", () => {
   for (const generation of ["case_law_v3", "case_law_v12"]) {
-    for (const group of Object.keys(CASE_LAW_INDEX_GROUPS)) {
+    for (const group of CASE_LAW_INDEX_GROUP_NAMES) {
       expect(corpusIndexGeneration(`${generation}_${group}`)).toBe(generation);
     }
     expect(corpusIndexGeneration(`${generation}_hun`)).toBe(generation);

--- a/apps/api/src/lib/legal-search/index-naming.test.ts
+++ b/apps/api/src/lib/legal-search/index-naming.test.ts
@@ -4,19 +4,83 @@ import fc from "fast-check";
 import { propertyConfig } from "@stll/property-testing";
 
 import {
+  CASE_LAW_INDEX_GROUPS,
+  CASE_LAW_INDEX_GROUPING_FROM_GENERATION,
+} from "@/api/lib/legal-search/case-law-index-groups";
+import {
   CORPUS_INDEX_GENERATION_MAX_LENGTH,
   CORPUS_INDEX_ID_MAX_LENGTH,
   caseLawCorpusGenerationOrder,
   corpusIndexGeneration,
   corpusIndexId,
+  corpusIndexIdsFor,
   corpusIndexPattern,
+  corpusIndexRoute,
   isCaseLawCorpusGeneration,
   tryCorpusIndexGeneration,
 } from "@/api/lib/legal-search/index-naming";
 
 test("index id is the generation prefix + lowercased jurisdiction", () => {
   expect(corpusIndexId("case_law_v1", "SVK")).toBe("case_law_v1_svk");
+  expect(corpusIndexId("case_law_v2", "CZE")).toBe("case_law_v2_cze");
   expect(corpusIndexId("legislation_v1", "cze")).toBe("legislation_v1_cze");
+});
+
+test("case-law ids are per index group from the grouping generation on", () => {
+  expect(CASE_LAW_INDEX_GROUPING_FROM_GENERATION).toBe(3);
+  for (const [group, countries] of Object.entries(CASE_LAW_INDEX_GROUPS)) {
+    for (const country of countries) {
+      expect(corpusIndexId("case_law_v3", country)).toBe(
+        `case_law_v3_${group}`,
+      );
+      expect(corpusIndexId("case_law_v12", country.toLowerCase())).toBe(
+        `case_law_v12_${group}`,
+      );
+      // Grouping is a rule about the case-law family's generations only.
+      expect(corpusIndexId("case_law_v2", country)).toBe(
+        `case_law_v2_${country.toLowerCase()}`,
+      );
+      expect(corpusIndexId("legislation_v3", country)).toBe(
+        `legislation_v3_${country.toLowerCase()}`,
+      );
+    }
+  }
+  // A country outside every group is its own group.
+  expect(corpusIndexId("case_law_v3", "HUN")).toBe("case_law_v3_hun");
+});
+
+test("distinct physical ids for a jurisdiction list", () => {
+  expect(corpusIndexIdsFor("case_law_v3", ["CZE", "POL", "SVK"])).toEqual([
+    "case_law_v3_cs_sk",
+    "case_law_v3_pl",
+  ]);
+  expect(corpusIndexIdsFor("case_law_v2", ["CZE", "POL", "SVK"])).toEqual([
+    "case_law_v2_cze",
+    "case_law_v2_pol",
+    "case_law_v2_svk",
+  ]);
+});
+
+test("a scoped query names its index, and a clause only where the index is shared", () => {
+  // Shared index: the clause keeps the query to the scoped jurisdiction.
+  expect(corpusIndexRoute("case_law_v3", "CZE")).toEqual({
+    indexId: "case_law_v3_cs_sk",
+    jurisdictionClause: "CZE",
+  });
+  // A single-country group is bounded by its index alone.
+  expect(corpusIndexRoute("case_law_v3", "POL")).toEqual({
+    indexId: "case_law_v3_pl",
+    jurisdictionClause: undefined,
+  });
+  // Before grouping every index is one jurisdiction's.
+  expect(corpusIndexRoute("case_law_v2", "CZE")).toEqual({
+    indexId: "case_law_v2_cze",
+    jurisdictionClause: undefined,
+  });
+  expect(corpusIndexRoute("case_law_v3", undefined)).toEqual({
+    indexId: "case_law_v3_*",
+    jurisdictionClause: undefined,
+  });
 });
 
 test("pattern globs all jurisdiction indexes for a generation", () => {
@@ -100,4 +164,13 @@ test("rejects malformed physical index ids", () => {
   );
   expect(tryCorpusIndexGeneration("case_law_v1")).toBeNull();
   expect(tryCorpusIndexGeneration("case_law_v1_svk")).toBe("case_law_v1");
+});
+
+test("generation extraction reads a group suffix that contains the separator", () => {
+  for (const generation of ["case_law_v3", "case_law_v12"]) {
+    for (const group of Object.keys(CASE_LAW_INDEX_GROUPS)) {
+      expect(corpusIndexGeneration(`${generation}_${group}`)).toBe(generation);
+    }
+    expect(corpusIndexGeneration(`${generation}_hun`)).toBe(generation);
+  }
 });

--- a/apps/api/src/lib/legal-search/index-naming.ts
+++ b/apps/api/src/lib/legal-search/index-naming.ts
@@ -1,14 +1,24 @@
 import { panic } from "better-result";
 
+import {
+  CASE_LAW_INDEX_GROUP_NAMES,
+  CASE_LAW_INDEX_GROUPING_FROM_GENERATION,
+  caseLawIndexGroup,
+  caseLawIndexGroupCountries,
+} from "@/api/lib/legal-search/case-law-index-groups";
+
 /**
  * corpus index index naming, generic over document family. The `generation`
- * is a family-scoped blue-green prefix (`case_law_v1`, `legislation_v1`),
- * and each jurisdiction gets its own physical index
- * (`<generation>_<jurisdiction>`, e.g. `case_law_v1_svk`). So reindex,
- * retention, and query scope are isolated per family AND per jurisdiction,
- * and a scoped query only touches that one index. A single shared
- * searcher pool serves them all (corpus index routes splits to searchers by
- * consistent hashing) — index-level isolation, not per-family compute.
+ * is a family-scoped blue-green prefix (`case_law_v1`, `legislation_v1`).
+ * The physical index is `<generation>_<jurisdiction>` (e.g. `case_law_v1_svk`),
+ * except that case-law generations from
+ * `CASE_LAW_INDEX_GROUPING_FROM_GENERATION` on use `<generation>_<group>`
+ * (e.g. `case_law_v3_cs_sk`), where the group is the jurisdiction's entry in
+ * `CASE_LAW_INDEX_GROUPS`. So reindex, retention, and query scope are
+ * isolated per family AND per index, and a scoped query only touches that
+ * one index. A single shared searcher pool serves them all (corpus index
+ * routes splits to searchers by consistent hashing) — index-level isolation,
+ * not per-family compute.
  */
 
 // Corpus index ids must match ^[a-zA-Z][a-zA-Z0-9._-]{2,254}$. Database
@@ -46,6 +56,12 @@ export const caseLawCorpusGenerationOrder = (value: string): number | null => {
 export const isCaseLawCorpusGeneration = (value: string): boolean =>
   caseLawCorpusGenerationOrder(value) !== null;
 
+/** Whether this generation's case-law indexes are per group, not per country. */
+const isGroupedCaseLawGeneration = (generation: string): boolean => {
+  const order = caseLawCorpusGenerationOrder(generation);
+  return order !== null && order >= CASE_LAW_INDEX_GROUPING_FROM_GENERATION;
+};
+
 // The jurisdiction segment comes from the trusted `country` column (always
 // alpha), but we guard so a malformed value cannot craft an odd id.
 const JURISDICTION_PATTERN = /^[a-z]{2,8}$/u;
@@ -64,15 +80,91 @@ export const corpusIndexId = (
   if (!isCorpusIndexJurisdiction(jur)) {
     panic(`Invalid jurisdiction for corpus index index id: ${jurisdiction}`);
   }
-  const indexId = `${generation}_${jur}`;
+  const suffix = isGroupedCaseLawGeneration(generation)
+    ? caseLawIndexGroup(jur)
+    : jur;
+  const indexId = `${generation}_${suffix}`;
   if (indexId.length > CORPUS_INDEX_ID_MAX_LENGTH) {
     panic(`Corpus index id exceeds storage limit: ${indexId}`);
   }
   return indexId;
 };
 
-/** Recovers the generation prefix from a validated physical index id. */
+/** Distinct physical index ids the jurisdictions map to, in first-seen order. */
+export const corpusIndexIdsFor = (
+  generation: string,
+  jurisdictions: readonly string[],
+): string[] => [
+  ...new Set(
+    jurisdictions.map((jurisdiction) =>
+      corpusIndexId(generation, jurisdiction),
+    ),
+  ),
+];
+
+/**
+ * Whether the physical index a scoped query selects for this jurisdiction
+ * also holds other jurisdictions, so the query needs a jurisdiction clause
+ * of its own to stay exact.
+ */
+const corpusIndexHoldsOtherJurisdictions = (
+  generation: string,
+  jurisdiction: string,
+): boolean =>
+  isGroupedCaseLawGeneration(generation) &&
+  caseLawIndexGroupCountries(caseLawIndexGroup(jurisdiction)).length > 1;
+
+export type CorpusIndexRoute = {
+  /** Physical index, or the generation glob when the query is unscoped. */
+  indexId: string;
+  /**
+   * Jurisdiction the engine query must carry as a clause: the scoped one
+   * when its physical index holds other jurisdictions, otherwise undefined
+   * because the index itself already bounds the query.
+   */
+  jurisdictionClause: string | undefined;
+};
+
+/** Index selection for a query, scoped to one jurisdiction or unscoped. */
+export const corpusIndexRoute = (
+  generation: string,
+  jurisdiction: string | undefined,
+): CorpusIndexRoute => {
+  if (jurisdiction === undefined) {
+    return {
+      indexId: corpusIndexPattern(generation),
+      jurisdictionClause: undefined,
+    };
+  }
+  return {
+    indexId: corpusIndexId(generation, jurisdiction),
+    jurisdictionClause: corpusIndexHoldsOtherJurisdictions(
+      generation,
+      jurisdiction,
+    )
+      ? jurisdiction
+      : undefined,
+  };
+};
+
+/**
+ * Recovers the generation prefix from a validated physical index id.
+ *
+ * A grouped case-law id ends in a group name, which may itself contain the
+ * separator (`case_law_v3_cs_sk`), so those suffixes are tried first; every
+ * other id ends in a single jurisdiction segment.
+ */
 export const tryCorpusIndexGeneration = (indexId: string): string | null => {
+  for (const group of CASE_LAW_INDEX_GROUP_NAMES) {
+    const suffix = `_${group}`;
+    if (!indexId.endsWith(suffix)) {
+      continue;
+    }
+    const generation = indexId.slice(0, -suffix.length);
+    if (isGroupedCaseLawGeneration(generation)) {
+      return generation;
+    }
+  }
   const separator = indexId.lastIndexOf("_");
   const generation = indexId.slice(0, separator);
   const jurisdiction = indexId.slice(separator + 1);
@@ -95,7 +187,7 @@ export const corpusIndexGeneration = (indexId: string): string => {
   return generation;
 };
 
-/** Glob matching every jurisdiction index for a generation (multi-index search). */
+/** Glob matching every index of a generation (multi-index search). */
 export const corpusIndexPattern = (generation: string): string => {
   if (!isCorpusIndexGeneration(generation)) {
     panic(`Invalid corpus index generation: ${generation}`);

--- a/apps/api/src/lib/legal-search/index-naming.ts
+++ b/apps/api/src/lib/legal-search/index-naming.ts
@@ -5,6 +5,8 @@ import {
   CASE_LAW_INDEX_GROUPING_FROM_GENERATION,
   caseLawIndexGroup,
   caseLawIndexGroupCountries,
+  isCaseLawIndexGroup,
+  POSTGRES_INTEGER_MAX,
 } from "@/api/lib/legal-search/case-law-index-groups";
 
 /**
@@ -14,7 +16,7 @@ import {
  * except that case-law generations from
  * `CASE_LAW_INDEX_GROUPING_FROM_GENERATION` on use `<generation>_<group>`
  * (e.g. `case_law_v3_cs_sk`), where the group is the jurisdiction's entry in
- * `CASE_LAW_INDEX_GROUPS`. So reindex, retention, and query scope are
+ * `CASE_LAW_INDEX_GROUP_OF`. So reindex, retention, and query scope are
  * isolated per family AND per index, and a scoped query only touches that
  * one index. A single shared searcher pool serves them all (corpus index
  * routes splits to searchers by consistent hashing) — index-level isolation,
@@ -36,7 +38,6 @@ export const isCorpusIndexGeneration = (value: string): boolean =>
   GENERATION_PATTERN.test(value);
 
 const CASE_LAW_CORPUS_GENERATION_PATTERN = /^case_law_v([1-9][0-9]*)$/u;
-const POSTGRES_INTEGER_MAX = 2_147_483_647;
 
 /** Numeric precedence for the one canonical case-law generation form. */
 export const caseLawCorpusGenerationOrder = (value: string): number | null => {
@@ -103,6 +104,30 @@ export const corpusIndexIdsFor = (
 ];
 
 /**
+ * Jurisdictions whose rows `corpusIndexId` places in this physical index of
+ * this generation, in canonical (uppercase) form: the inverse of
+ * `corpusIndexId`, so a predicate over `country` can address exactly the
+ * rows an index answers for.
+ */
+export const corpusIndexJurisdictions = (
+  generation: string,
+  indexId: string,
+): readonly string[] => {
+  const prefix = `${generation}_`;
+  if (!indexId.startsWith(prefix)) {
+    panic(`Corpus index id ${indexId} is not of generation ${generation}`);
+  }
+  const suffix = indexId.slice(prefix.length);
+  if (isGroupedCaseLawGeneration(generation) && isCaseLawIndexGroup(suffix)) {
+    return caseLawIndexGroupCountries(suffix);
+  }
+  if (!isCorpusIndexJurisdiction(suffix)) {
+    panic(`Invalid corpus index index id: ${indexId}`);
+  }
+  return [suffix.toUpperCase()];
+};
+
+/**
  * Whether the physical index a scoped query selects for this jurisdiction
  * also holds other jurisdictions, so the query needs a jurisdiction clause
  * of its own to stay exact.
@@ -118,9 +143,10 @@ export type CorpusIndexRoute = {
   /** Physical index, or the generation glob when the query is unscoped. */
   indexId: string;
   /**
-   * Jurisdiction the engine query must carry as a clause: the scoped one
-   * when its physical index holds other jurisdictions, otherwise undefined
-   * because the index itself already bounds the query.
+   * Jurisdiction the engine query must carry as a clause, in the canonical
+   * uppercase form indexed documents carry: the scoped one when its physical
+   * index holds other jurisdictions, otherwise undefined because the index
+   * itself already bounds the query.
    */
   jurisdictionClause: string | undefined;
 };
@@ -136,13 +162,14 @@ export const corpusIndexRoute = (
       jurisdictionClause: undefined,
     };
   }
+  const canonical = jurisdiction.toUpperCase();
   return {
-    indexId: corpusIndexId(generation, jurisdiction),
+    indexId: corpusIndexId(generation, canonical),
     jurisdictionClause: corpusIndexHoldsOtherJurisdictions(
       generation,
-      jurisdiction,
+      canonical,
     )
-      ? jurisdiction
+      ? canonical
       : undefined,
   };
 };

--- a/apps/api/src/scripts/corpus-index-query-diff-report.test.ts
+++ b/apps/api/src/scripts/corpus-index-query-diff-report.test.ts
@@ -8,7 +8,9 @@ import { tokenizeCorpusFreeText } from "@/api/lib/legal-search/corpus-query";
 import {
   diffRankedDocuments,
   divergedQueries,
+  type GoldenQuery,
   type GoldenQueryDiffRow,
+  goldenQueryRequest,
   parseGoldenQueryFile,
   type QueryRunOutcome,
   rankDocumentHits,
@@ -120,6 +122,40 @@ describe("parseGoldenQueryFile", () => {
     expect(
       Result.isError(parseGoldenQueryFile(query("2015-12-31", "2016-01-01"))),
     ).toBe(false);
+  });
+});
+
+describe("goldenQueryRequest", () => {
+  const query: GoldenQuery = {
+    id: "q",
+    jurisdiction: "cze",
+    text: "náhrada škody",
+    filters: { court: "Nejvyšší soud" },
+  };
+
+  test("a generation whose index is shared carries the jurisdiction clause", () => {
+    // Base and candidate are routed separately: comparing a per-country
+    // index against a shared one without the clause would set one
+    // jurisdiction's hits against several jurisdictions' hits.
+    const perCountry = goldenQueryRequest("case_law_v2", query);
+    const shared = goldenQueryRequest("case_law_v3", query);
+    expect(perCountry).toEqual({
+      indexId: "case_law_v2_cze",
+      engineQuery: '("náhrada" AND "škody") AND court:"Nejvyšší soud"',
+    });
+    expect(shared).toEqual({
+      indexId: "case_law_v3_cs_sk",
+      engineQuery:
+        '("náhrada" AND "škody") AND jurisdiction:"CZE" AND court:"Nejvyšší soud"',
+    });
+    // Non-vacuity: the two requests differ only by index and clause.
+    expect(perCountry?.engineQuery).not.toBe(shared?.engineQuery);
+  });
+
+  test("a query without a searchable term has no request", () => {
+    expect(goldenQueryRequest("case_law_v3", { ...query, text: "..." })).toBe(
+      null,
+    );
   });
 });
 

--- a/apps/api/src/scripts/corpus-index-query-diff-report.ts
+++ b/apps/api/src/scripts/corpus-index-query-diff-report.ts
@@ -2,7 +2,11 @@ import { Result, TaggedError } from "better-result";
 import * as v from "valibot";
 
 import type { CorpusIndexHit } from "@/api/lib/legal-search/corpus-index-client";
-import { isCorpusIndexJurisdiction } from "@/api/lib/legal-search/index-naming";
+import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
+import {
+  corpusIndexRoute,
+  isCorpusIndexJurisdiction,
+} from "@/api/lib/legal-search/index-naming";
 
 /**
  * Pure half of the golden-query diff harness: query-file parsing, top-N
@@ -85,6 +89,34 @@ export const parseGoldenQueryFile = (
     );
   }
   return Result.ok(parsed.output);
+};
+
+export type GoldenQueryRequest = {
+  /** Physical index the query is sent to. */
+  indexId: string;
+  /** The engine query, jurisdiction clause included where the index needs one. */
+  engineQuery: string;
+};
+
+/**
+ * What one golden query asks one generation's engine for: the same route and
+ * the same query assembly the search paths use, so a generation whose index
+ * holds several jurisdictions is compared on the query's jurisdiction alone.
+ * Null when the query text carries no searchable term.
+ */
+export const goldenQueryRequest = (
+  generation: string,
+  query: GoldenQuery,
+): GoldenQueryRequest | null => {
+  const { indexId, jurisdictionClause } = corpusIndexRoute(
+    generation,
+    query.jurisdiction,
+  );
+  const engineQuery = caseLawCorpusQuery(query.text, {
+    ...query.filters,
+    jurisdiction: jurisdictionClause,
+  });
+  return engineQuery === null ? null : { indexId, engineQuery };
 };
 
 export type QueryRunOutcome = {

--- a/apps/api/src/scripts/corpus-index-query-diff.ts
+++ b/apps/api/src/scripts/corpus-index-query-diff.ts
@@ -4,16 +4,14 @@ import {
   type CorpusIndexHit,
   getCorpusIndexClient,
 } from "@/api/lib/legal-search/corpus-index-client";
-import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
-import {
-  corpusIndexId,
-  isCorpusIndexGeneration,
-} from "@/api/lib/legal-search/index-naming";
+import { isCorpusIndexGeneration } from "@/api/lib/legal-search/index-naming";
 import { LIMITS } from "@/api/lib/limits";
 import {
   divergedQueries,
+  type GoldenQuery,
   type GoldenQueryDiffRow,
   diffRankedDocuments,
+  goldenQueryRequest,
   parseGoldenQueryFile,
   type QueryRunOutcome,
   rankDocumentHits,
@@ -163,25 +161,25 @@ if (Result.isError(queries)) {
 
 const client = getCorpusIndexClient();
 
-type RunQueryOptions = {
-  generation: string;
-  jurisdiction: string;
-  engineQuery: string;
-};
-
 /**
  * Bounded offset scan until the top-N distinct documents are collected.
  * A passage-granularity index can put hundreds of one judgment's passages
  * ahead of the next document, so a single fixed-size page cannot promise
  * N distinct documents; the scan widens page by page (the production
  * reader's shape) up to the shared scan limit.
+ *
+ * Each generation gets its own route: from generation 3 on a physical
+ * index may hold several jurisdictions, and the query then carries the
+ * jurisdiction clause the search paths carry.
  */
-const runQuery = async ({
-  engineQuery,
-  generation,
-  jurisdiction,
-}: RunQueryOptions): Promise<QueryRunOutcome> => {
-  const indexId = corpusIndexId(generation, jurisdiction);
+const runQuery = async (
+  generation: string,
+  query: GoldenQuery,
+): Promise<QueryRunOutcome> => {
+  const request =
+    goldenQueryRequest(generation, query) ??
+    fail(`query ${query.id} holds no searchable term: ${query.text}`);
+  const { indexId, engineQuery } = request;
   const scanned: CorpusIndexHit[] = [];
   let totalHits = 0;
   let startOffset = 0;
@@ -219,22 +217,10 @@ const runQuery = async ({
 
 const rows: GoldenQueryDiffRow[] = [];
 for (const query of queries.value) {
-  const engineQuery = caseLawCorpusQuery(query.text, query.filters ?? {});
-  if (engineQuery === null) {
-    fail(`query ${query.id} holds no searchable term: ${query.text}`);
-  }
   // oxlint-disable-next-line no-await-in-loop -- one query at a time keeps the load on the engine bounded
   const [base, candidate] = await Promise.all([
-    runQuery({
-      generation: baseGeneration,
-      jurisdiction: query.jurisdiction,
-      engineQuery,
-    }),
-    runQuery({
-      generation: candidateGeneration,
-      jurisdiction: query.jurisdiction,
-      engineQuery,
-    }),
+    runQuery(baseGeneration, query),
+    runQuery(candidateGeneration, query),
   ]);
   rows.push({
     query,

--- a/apps/api/src/scripts/repair-corpus-index-jurisdiction.ts
+++ b/apps/api/src/scripts/repair-corpus-index-jurisdiction.ts
@@ -1,9 +1,9 @@
 /**
- * Heal a jurisdiction the census reported as short.
+ * Heal an index the census reported as short.
  *
  * `case_law.corpus_index.census_drift` says the engine holds fewer
- * documents than Postgres has marked indexed for one jurisdiction. Those
- * rows are invisible to the backfill: an `indexedHash` equal to the
+ * documents than Postgres has marked indexed for one physical index.
+ * Those rows are invisible to the backfill: an `indexedHash` equal to the
  * content hash means neither missing nor stale, so nothing selects them
  * again and the gap never closes on its own.
  *
@@ -11,13 +11,17 @@
  * the ordinary backfill re-projects it through the same path as a newly
  * ingested decision, and re-ingesting a document the engine already
  * holds replaces it at the same id. Nothing is deleted, so running this
- * on a jurisdiction that was not actually short costs re-indexing and
- * nothing else.
+ * on an index that was not actually short costs re-indexing and nothing
+ * else.
  *
- * Bounded on purpose: a jurisdiction can be millions of rows, and
- * un-marking them all at once hands the backfill a backlog that starves
- * every newly ingested decision behind it. Each run clears one slice;
- * re-run until the census agrees.
+ * Bounded on purpose: an index can be millions of rows, and un-marking
+ * them all at once hands the backfill a backlog that starves every newly
+ * ingested decision behind it. Each run clears one slice; re-run until
+ * the census agrees.
+ *
+ * The argument is a jurisdiction; the index repaired is the one that
+ * jurisdiction derives to under the serving generation (`corpusIndexId`),
+ * which from generation 3 on may hold other jurisdictions as well.
  *
  *   CORPUS_INDEX_ENDPOINT=... \
  *     bun run src/scripts/repair-corpus-index-jurisdiction.ts SVK [limit]
@@ -28,11 +32,14 @@ import { rlsDb } from "@/api/db/root";
 import { createIngestionDb } from "@/api/db/scoped";
 import { envBase } from "@/api/env-base";
 import {
-  censusJurisdiction,
-  clearJurisdictionIndexMarks,
+  censusIndex,
+  clearIndexMarks,
   MAX_REPAIR_SLICE,
 } from "@/api/lib/corpus-index/census";
-import { isCorpusIndexJurisdiction } from "@/api/lib/legal-search/index-naming";
+import {
+  corpusIndexId,
+  isCorpusIndexJurisdiction,
+} from "@/api/lib/legal-search/index-naming";
 
 const jurisdiction = process.argv[2];
 if (jurisdiction === undefined || !isCorpusIndexJurisdiction(jurisdiction)) {
@@ -40,11 +47,10 @@ if (jurisdiction === undefined || !isCorpusIndexJurisdiction(jurisdiction)) {
 }
 
 // A mistyped digit must not turn a bounded repair into one transaction
-// updating every row in the jurisdiction and firing the projection
-// trigger for each of them, so the ceiling is enforced here rather than
-// trusted from the argument. `clearJurisdictionIndexMarks` clamps too;
-// rejecting loudly here is what tells the operator their number was
-// ignored.
+// updating every row in the index and firing the projection trigger for
+// each of them, so the ceiling is enforced here rather than trusted from
+// the argument. `clearIndexMarks` clamps too; rejecting loudly here is
+// what tells the operator their number was ignored.
 const limitArgument = process.argv[3];
 const limit =
   limitArgument === undefined ? MAX_REPAIR_SLICE : Number(limitArgument);
@@ -55,14 +61,15 @@ if (!Number.isSafeInteger(limit) || limit <= 0 || limit > MAX_REPAIR_SLICE) {
 }
 
 const generation = envBase.LEGAL_SEARCH_INDEX_GENERATION;
+const indexId = corpusIndexId(generation, jurisdiction);
 const ingestionDb = createIngestionDb(rlsDb);
 
 // Reported before and after so the operator sees the shortfall the repair
 // was pointed at, rather than trusting the alert that sent them here.
-const before = await censusJurisdiction({
+const before = await censusIndex({
   scopedDb: ingestionDb,
   generation,
-  jurisdiction,
+  indexId,
 });
 if (before.isErr()) {
   panic("census failed before the repair", before.error);
@@ -71,10 +78,10 @@ console.log(
   `=== ${before.value.indexId}: engine ${before.value.engineDocuments}, marked ${before.value.markedIndexed}, short ${before.value.shortfall} ===`,
 );
 
-const cleared = await clearJurisdictionIndexMarks({
+const cleared = await clearIndexMarks({
   scopedDb: ingestionDb,
   generation,
-  jurisdiction,
+  indexId,
   limit,
 });
 console.log(

--- a/apps/api/src/tests/helpers/case-law-projection-trigger.ts
+++ b/apps/api/src/tests/helpers/case-law-projection-trigger.ts
@@ -1,0 +1,84 @@
+import { panic } from "better-result";
+import { sql } from "drizzle-orm";
+import { readFileSync } from "node:fs";
+import nodePath from "node:path";
+
+/**
+ * The test database is built from the schema, which carries no functions or
+ * triggers, so a test that exercises the case-law projection trigger installs
+ * it from the migrations: the index id function the trigger calls, the
+ * trigger function, then the trigger, each from the last migration defining
+ * it. Which migration is derived, not named: migrations apply in directory
+ * order, so the last one that redefines an object is the definition a
+ * database ends up with, and a later migration replacing it moves this with
+ * it.
+ */
+
+const DRIZZLE_DIR = nodePath.resolve(import.meta.dir, "../../../drizzle");
+
+export const INDEX_ID_FUNCTION =
+  "CREATE OR REPLACE FUNCTION case_law_corpus_index_id(generation text, country text)";
+const PROJECTION_TRIGGER_FUNCTION =
+  "CREATE OR REPLACE FUNCTION enqueue_case_law_corpus_index_projection()";
+const PROJECTION_TRIGGER =
+  "CREATE TRIGGER case_law_decisions_enqueue_corpus_index_projection";
+const PROJECTION_TRIGGER_STATEMENT =
+  /\b(?:CREATE|DROP) TRIGGER (?:IF EXISTS )?case_law_decisions_enqueue_corpus_index_projection\b/u;
+
+/** Statements of a migration file, in order, comments included. */
+export const migrationStatements = (path: string): string[] =>
+  readFileSync(path, "utf-8")
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
+
+/** Path of the last migration whose text contains `marker`. */
+export const latestMigrationContaining = (marker: string): string => {
+  const path = [...new Bun.Glob("*/migration.sql").scanSync(DRIZZLE_DIR)]
+    .sort()
+    .map((file) => nodePath.join(DRIZZLE_DIR, file))
+    .findLast((file) => readFileSync(file, "utf-8").includes(marker));
+  return path ?? panic(`no migration contains ${marker}`);
+};
+
+/** Statements matching `statementMarker` from the last migration containing `marker`. */
+const latestStatements = (
+  marker: string,
+  statementMarker: RegExp,
+): string[] => {
+  const statements = migrationStatements(
+    latestMigrationContaining(marker),
+  ).filter((statement) => statementMarker.test(statement));
+  if (statements.length === 0) {
+    panic(`no statement matches ${statementMarker} for ${marker}`);
+  }
+  return statements;
+};
+
+/** The DDL that installs the projection trigger as the migrations define it. */
+export const caseLawProjectionTriggerStatements = (): string[] => [
+  ...latestStatements(
+    INDEX_ID_FUNCTION,
+    /FUNCTION case_law_corpus_index_id\(/u,
+  ),
+  ...latestStatements(
+    PROJECTION_TRIGGER_FUNCTION,
+    /enqueue_case_law_corpus_index_projection\(\)\s+RETURNS trigger/u,
+  ),
+  // The replacement drop (`DROP TRIGGER IF EXISTS ...`) and the creation.
+  ...latestStatements(PROJECTION_TRIGGER, PROJECTION_TRIGGER_STATEMENT),
+];
+
+type Executor = {
+  execute: (query: ReturnType<typeof sql.raw>) => Promise<unknown>;
+};
+
+/** Install the projection trigger and the functions it calls. */
+export const installCaseLawProjectionTrigger = async (
+  db: Executor,
+): Promise<void> => {
+  for (const statement of caseLawProjectionTriggerStatements()) {
+    // oxlint-disable-next-line no-await-in-loop -- functions, replacement drop, and trigger creation are order-dependent DDL
+    await db.execute(sql.raw(statement));
+  }
+};


### PR DESCRIPTION
From generation `case_law_v3` on, a case-law physical index id is `<generation>_<group>` instead of `<generation>_<country>`; generations 1 and 2 and the legislation family are unchanged. Groups: `cs_sk` (CZE, SVK); AUT, EU, and POL each keep an index named by their own lowercase code (`aut`, `eu`, `pol`), and so does any country outside the declaration. The declaration (`CASE_LAW_INDEX_GROUP_OF`) is total over `CaseLawJurisdiction`; a group name is a jurisdiction's own lowercase code or contains an underscore, so a code outside the declaration never names a declared group.

- `case-law-index-groups.ts` declares the mapping once; `caseLawIndexIdSql` renders it as a SQL fragment, and a new migration defines `case_law_corpus_index_id(generation, country)` (IMMUTABLE, STRICT) and replaces the projection trigger function so it derives ids the same way. A PGlite test proves the TypeScript function, the fragment, and the migration's function agree over a matrix of countries and generations, and pins the migration text against the rendered fragment.
- Routing: a scoped query still selects the jurisdiction's index; when that index holds several countries the query carries a `jurisdiction:"<code>"` clause. `corpusIndexRoute` returns both.
- Census keyed by physical index id (`corpusIndexIdsFor`); the count and the repair select rows by `country IN (...)` from `corpusIndexJurisdictions`, the inverse of the id derivation. The repair maps its jurisdiction argument to the index id.
- The golden-query diff (`corpus-index-query-diff.ts`) routes each generation through `corpusIndexRoute` and `caseLawCorpusQuery`, so a shared index is queried with the jurisdiction clause.
- The inline `generation || '_' || lower(country)` derivations in the projection predicate and the corpus-index handler are replaced by the shared fragment.

Migration lint, migration order/safety checks, and the affected test suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case-law indexes from generation 3 onwards can group related jurisdictions, improving search index efficiency.
  * Scoped searches and facet queries now apply the correct jurisdiction filter when using shared indexes.
  * Index routing and naming now consistently support both legacy and grouped case-law indexes.

* **Bug Fixes**
  * Improved index projection, census, repair and incremental update handling for grouped jurisdictions.
  * Preserved legacy country-specific index behaviour for earlier generations.

* **Tests**
  * Added coverage for grouped index routing, naming, filtering and projection behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
