### PR TITLE
feat(chat): one composer shell for the chat bar and the docked bar

### DIFF
--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -45,6 +45,7 @@ import type {
 } from "@stll/folio-react";
 import { BidiText } from "@stll/ui/components/bidi-text";
 import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import { resolveDocxSuggestionRequest } from "@/components/ai-suggestions/docx-suggestion-persistence";
 import { resolveFileReviewSessionId } from "@/components/ai-suggestions/file-review-session";
@@ -92,6 +93,7 @@ import type {
   UnresolvedActiveDocxEditToolCallPart,
   UnresolvedFolioAgentDocToolCallPart,
 } from "@/components/chat/chat-ui-tools";
+import { COMPOSER_TEXT_CLASS } from "@/components/chat/composer-control-style";
 import {
   getCreateDocumentDraftPersistence,
   type CreateDocumentDraftPersistence,
@@ -2422,7 +2424,12 @@ const FileChatOverlayInner = ({
           emptyPlaceholder={
             (activeFile || activeDraft || activeExternal) &&
             filePlaceholderAction ? (
-              <span className="text-foreground-ghost flex min-w-0 items-center gap-1.5 text-[13px] leading-5">
+              <span
+                className={cn(
+                  "text-foreground-ghost flex min-w-0 items-center gap-1.5",
+                  COMPOSER_TEXT_CLASS,
+                )}
+              >
                 <span className="shrink-0">{filePlaceholderAction}</span>
                 <BidiText
                   as="span"

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -58,7 +58,17 @@ import { ChatComposerActionButton } from "@/components/chat/chat-composer-action
 import { resolveChatComposerAction } from "@/components/chat/chat-composer-action-button.logic";
 import { ChatDraftAttachmentChips } from "@/components/chat/chat-draft-attachment-chips";
 import type { ComposerModelsMenuProps } from "@/components/chat/chat-model-options-menu";
-import { COMPOSER_CONTROL_BUTTON_SIZE } from "@/components/chat/composer-control-style";
+import {
+  COMPOSER_BOX_ANONYMIZED_CLASS,
+  COMPOSER_BOX_CLASS,
+  COMPOSER_BOX_FOCUS_CLASS,
+  COMPOSER_COMPACT_CONTROL_SLOT_CLASS,
+  COMPOSER_COMPACT_ROW_CLASS,
+  COMPOSER_COMPACT_TEXT_CELL_CLASS,
+  COMPOSER_CONTROL_BUTTON_SIZE,
+  COMPOSER_PLACEHOLDER_CLASS,
+  COMPOSER_TEXT_CLASS,
+} from "@/components/chat/composer-control-style";
 import { ComposerPlusMenu } from "@/components/chat/composer-plus-menu";
 import type { ComposerContextMenuProps } from "@/components/chat/composer-plus-menu";
 import { ComposerVeil } from "@/components/chat/composer-veil";
@@ -288,7 +298,12 @@ export const PromptBarPlaceholderContent = ({
 }: {
   children: ReactNode;
 }) => (
-  <span className="text-foreground-muted block min-w-0 truncate text-[13px] leading-5">
+  <span
+    className={cn(
+      "text-foreground-placeholder block min-w-0 truncate",
+      COMPOSER_TEXT_CLASS,
+    )}
+  >
     {children}
   </span>
 );
@@ -311,12 +326,13 @@ const DOC_FLOAT_SURFACE_CLASS =
   "[--doc-float-surface:var(--color-white)] dark:[--doc-float-surface:var(--popover)] bg-(--doc-float-surface)";
 
 /**
- * The bar box itself — border, shadow, and the doc-anchored
- * surface — with no positioning or sizing of its own. `DockedComposer`
- * owns where the bar sits and how wide it is; this shell just paints the
- * box and fills the width it is given (`w-full`). Both the live
- * `PromptBar` and the loading `PromptBarPlaceholder` render through it so
- * they can never drift apart.
+ * The bar box itself — the shared composer box (same radius, border, focus
+ * ring and compact row stature as the main chat bar), plus the shadow and
+ * doc-anchored surface a bar floating over a document needs — with no
+ * positioning or sizing of its own. `DockedComposer` owns where the bar sits
+ * and how wide it is; this shell just paints the box and fills the width it
+ * is given (`w-full`). Both the live `PromptBar` and the loading
+ * `PromptBarPlaceholder` render through it so they can never drift apart.
  *
  * The surface is solid on purpose: the separate pane veil softens document
  * content around the stack while the controls themselves remain crisp.
@@ -329,12 +345,10 @@ export const PromptBarShell = ({
   <div
     {...rest}
     className={cn(
-      "group/bar border-foreground/15 relative flex w-full items-end gap-1 rounded-2xl border transition-[box-shadow,border-color]",
+      COMPOSER_BOX_CLASS,
+      "group/bar relative flex w-full transition-[box-shadow,border-color]",
+      COMPOSER_COMPACT_ROW_CLASS,
       "shadow-[0_0_0_1px_rgb(0_0_0/0.02),0_1px_2px_rgb(0_0_0/0.03),0_8px_20px_rgb(0_0_0/0.05)]",
-      // py-0.5 keeps the single-line pill slim (the inner editor cell's
-      // min-h-8 sets the line height; the shell adds only a hairline of
-      // breathing room) so the bar reads lighter than the transcript.
-      "py-0.5 ps-1.5 pe-1",
       DOC_FLOAT_SURFACE_CLASS,
       className,
     )}
@@ -354,12 +368,12 @@ export const PromptBarShell = ({
  *
  * Stack, measured from the pane's bottom edge: 14px column offset +
  * ~24px status row (icon-xs controls) + 6px bar-to-row gap (`mt-1.5`) +
- * ~38px bar (min-h-8 cell + py-0.5 + border) ⇒ the bar's TOP sits ~82px
- * up. `bottom-24` (96px) drops the card ~14px above that, matching the
- * transcript's rhythm. (Both floating surfaces render a status row; a
- * bar-only stack would clear this offset with room to spare.)
+ * ~46px bar (the shared compact row, `min-h-11` + border) ⇒ the bar's TOP
+ * sits ~90px up. `bottom-26` (104px) drops the card ~14px above that,
+ * matching the transcript's rhythm. (Both floating surfaces render a status
+ * row; a bar-only stack would clear this offset with room to spare.)
  */
-const FLOATING_THREAD_CARD_OFFSET_CLASS = "bottom-24";
+const FLOATING_THREAD_CARD_OFFSET_CLASS = "bottom-26";
 
 /**
  * Taller bottom offset for the thread card when the floating DOCX
@@ -821,9 +835,8 @@ export const PromptBar = (props: PromptBarProps) => {
       onFocusCapture={handleShellFocus}
       onKeyDownCapture={handleShellKeyDown}
       className={cn(
-        !inputDisabled && !anonymized && "focus-within:border-foreground/30",
-        anonymized &&
-          "ring-info/40 border-info/40 focus-within:border-info/60 shadow-[0_0_0_4px_rgb(from_var(--color-info)_r_g_b_/_0.08)] ring-1",
+        !inputDisabled && !anonymized && COMPOSER_BOX_FOCUS_CLASS,
+        anonymized && COMPOSER_BOX_ANONYMIZED_CLASS,
         // Attention pulse — kicked by the inspector chip click to
         // close the panel→producer loop visually. Stronger ring
         // than the busy state because it's transient and meant to
@@ -927,11 +940,11 @@ export const PromptBar = (props: PromptBarProps) => {
           />
           {/* Shared (+) affordance on the left, identical to the main chat
               composer; opens the attach-file picker via the same controller.
-              The h-8 wrapper (same pattern the pending badge below uses)
-              centers the size-7 circle on the editor cell's single-line
-              height: the shell is items-end, so the bare 28px button would
-              otherwise ride 2px below the placeholder's center line. */}
-          <span className="flex h-8 shrink-0 items-center">
+              The control slot (same pattern the pending badge below uses)
+              seats the circle on the editor cell's single text line: the
+              shell is items-end, so a bare button would otherwise ride
+              below the placeholder's center line. */}
+          <span className={COMPOSER_COMPACT_CONTROL_SLOT_CLASS}>
             {minimizedThreadAction ? (
               <Button
                 aria-label={minimizedThreadAction.label}
@@ -978,15 +991,25 @@ export const PromptBar = (props: PromptBarProps) => {
         </>
       )}
       {layout === "floating" && pendingCount > 0 && (
-        <span className="flex h-8 shrink-0 items-center ps-0.5">
+        <span className={cn(COMPOSER_COMPACT_CONTROL_SLOT_CLASS, "ps-0.5")}>
           <span className="bg-muted text-foreground inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full px-1.5 text-[11px] font-semibold tabular-nums">
             {format.number(pendingCount)}
           </span>
         </span>
       )}
-      <div className="relative flex min-h-8 min-w-0 flex-1 items-center gap-1.5 px-1.5">
+      <div
+        className={cn(
+          COMPOSER_COMPACT_TEXT_CELL_CLASS,
+          "flex flex-1 items-center gap-1.5 px-1.5",
+        )}
+      >
         {showBusyPlaceholder && (
-          <div className="text-muted-foreground pointer-events-none absolute inset-x-1.5 top-1/2 z-10 flex min-w-0 -translate-y-1/2 items-center gap-2 text-[13px]">
+          <div
+            className={cn(
+              COMPOSER_PLACEHOLDER_CLASS,
+              "inset-x-1.5 top-1/2 z-10 flex min-w-0 -translate-y-1/2 items-center gap-2",
+            )}
+          >
             <LoaderCircleIcon
               aria-hidden="true"
               className="size-3.5 shrink-0 animate-spin"
@@ -995,7 +1018,12 @@ export const PromptBar = (props: PromptBarProps) => {
           </div>
         )}
         {isEmpty && !busy && isSendBlocked && (
-          <div className="text-muted-foreground pointer-events-none absolute inset-x-1.5 top-1/2 z-10 flex min-w-0 -translate-y-1/2 items-center gap-2 text-[13px]">
+          <div
+            className={cn(
+              COMPOSER_PLACEHOLDER_CLASS,
+              "inset-x-1.5 top-1/2 z-10 flex min-w-0 -translate-y-1/2 items-center gap-2",
+            )}
+          >
             <LoaderCircleIcon
               aria-hidden="true"
               className="size-3.5 shrink-0 animate-spin"
@@ -1016,15 +1044,13 @@ export const PromptBar = (props: PromptBarProps) => {
             </div>
           )}
         <PromptEditorContent
-          // Height is content-driven: a single line of 13px text
-          // is ~20px tall (`leading-5`) and the cell's `min-h-8`
-          // (2rem) + `items-center` centres it vertically;
-          // multiple wrapped lines stay tight. The cell grows up
-          // to `max-h-32` before scrolling, and `min-h-0`
-          // overrides the provider's `min-h-10` so it shrinks
+          // Height is content-driven: the shared compact text cell seats
+          // one `text-sm` line at `leading-5`; multiple wrapped lines stay
+          // tight. The cell grows up to `max-h-32` before scrolling, and
+          // `min-h-0` overrides the provider's `min-h-10` so it shrinks
           // back as the user deletes content.
           className={cn(
-            "folio-ai-bar-editor text-foreground min-w-0 flex-1 [&_.ProseMirror]:field-sizing-fixed [&_.ProseMirror]:max-h-32 [&_.ProseMirror]:min-h-0 [&_.ProseMirror]:overflow-y-auto [&_.ProseMirror]:py-1.5 [&_.ProseMirror]:text-[13px] [&_.ProseMirror]:leading-5 [&_.ProseMirror]:select-text [&_.ProseMirror]:focus-visible:outline-none [&_.ProseMirror_p]:my-0",
+            "folio-ai-bar-editor text-foreground min-w-0 flex-1 [&_.ProseMirror]:field-sizing-fixed [&_.ProseMirror]:max-h-32 [&_.ProseMirror]:min-h-0 [&_.ProseMirror]:overflow-y-auto [&_.ProseMirror]:leading-5 [&_.ProseMirror]:select-text [&_.ProseMirror]:focus-visible:outline-none [&_.ProseMirror_p]:my-0",
             // Suppress the composer's own placeholder whenever the host
             // renders an overlay in the same cell (custom placeholder, the
             // busy "working" label, or the editor-loading label) — otherwise
@@ -1043,13 +1069,10 @@ export const PromptBar = (props: PromptBarProps) => {
       <Tooltip>
         <TooltipTrigger
           render={
-            // The h-8 wrapper mirrors the (+) menu's centering: the shell
-            // is items-end, so a bare size-7 circle would sit 2px below
-            // the editor cell's single-line center. Bottom-aligned at the
-            // cell's min-h-8, the wrapper centers the circle on the
-            // placeholder line and rides the bottom text line as the
+            // The control slot mirrors the (+) menu's seating: the shell
+            // is items-end, so the slot rides the bottom text line as the
             // editor grows.
-            <span className="flex h-8 shrink-0 items-center">
+            <span className={COMPOSER_COMPACT_CONTROL_SLOT_CLASS}>
               <ChatComposerActionButton
                 canSend={!composerSubmitDisabled && canSubmit}
                 isGenerating={isGenerating}

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -20,6 +20,17 @@ import { ChatDraftAttachmentChips } from "@/components/chat/chat-draft-attachmen
 import type { ComposerModelsMenuProps } from "@/components/chat/chat-model-options-menu";
 import { ChatPromptImproveButton } from "@/components/chat/chat-prompt-improve-button";
 import {
+  COMPOSER_BOX_ANONYMIZED_CLASS,
+  COMPOSER_BOX_CLASS,
+  COMPOSER_BOX_FOCUS_CLASS,
+  COMPOSER_COMPACT_ROW_CLASS,
+  COMPOSER_COMPACT_TEXT_CELL_CLASS,
+  COMPOSER_LARGE_ACTION_ROW_CLASS,
+  COMPOSER_LARGE_TEXT_WELL_CLASS,
+  COMPOSER_LEADING_GROUP_CLASS,
+  COMPOSER_PLACEHOLDER_CLASS,
+} from "@/components/chat/composer-control-style";
+import {
   ComposerPlusMenu,
   type ComposerContextMenuProps,
 } from "@/components/chat/composer-plus-menu";
@@ -201,14 +212,12 @@ export const ChatInputSurface = ({
         <div
           {...guideAnchor(GUIDE_ANCHORS.chatComposer, guideAnchorsEnabled)}
           className={cn(
-            "bg-background rounded-lg border",
-            "transition-colors",
+            COMPOSER_BOX_CLASS,
             // Default focus border (gray) only when not in anonymized
             // mode — otherwise the gray border landed on top of the
             // blue ring and read as a double-ring on click.
-            !inputDisabled && !anonymized && "focus-within:border-ring",
-            anonymized &&
-              "ring-info/40 border-info/40 focus-within:border-info/60 shadow-[0_0_0_4px_rgb(from_var(--color-info)_r_g_b_/_0.08)] ring-1",
+            !inputDisabled && !anonymized && COMPOSER_BOX_FOCUS_CLASS,
+            anonymized && COMPOSER_BOX_ANONYMIZED_CLASS,
           )}
           onBlurCapture={handleBlur}
           onDragOver={inputDisabled ? undefined : handleDragOver}
@@ -220,16 +229,21 @@ export const ChatInputSurface = ({
           <ChatDraftAttachmentChips files={attachments} onRemove={removeFile} />
           <div
             className={cn(
-              variant === "compact" &&
-                "grid min-h-11 grid-cols-[auto_minmax(0,1fr)_auto] items-end gap-1 px-1.5 py-px",
+              variant === "compact" && [
+                "grid grid-cols-[auto_minmax(0,1fr)_auto]",
+                COMPOSER_COMPACT_ROW_CLASS,
+              ],
             )}
           >
             <div
               className={cn(
-                "chat-editor relative min-w-0 overflow-hidden",
+                "chat-editor overflow-hidden",
                 variant === "compact"
-                  ? "col-start-2 row-start-1 py-1"
-                  : "ps-3 pe-3 pt-2 pb-1",
+                  ? [
+                      "col-start-2 row-start-1",
+                      COMPOSER_COMPACT_TEXT_CELL_CLASS,
+                    ]
+                  : ["relative min-w-0", COMPOSER_LARGE_TEXT_WELL_CLASS],
               )}
               onKeyDown={(event) => {
                 event.stopPropagation();
@@ -254,7 +268,7 @@ export const ChatInputSurface = ({
                 <span
                   aria-hidden="true"
                   className={cn(
-                    "text-foreground-placeholder pointer-events-none absolute truncate text-sm",
+                    COMPOSER_PLACEHOLDER_CLASS,
                     variant === "compact"
                       ? "start-0 end-0 top-1"
                       : "start-3 end-3 top-2",
@@ -268,12 +282,12 @@ export const ChatInputSurface = ({
               className={cn(
                 variant === "compact"
                   ? "contents"
-                  : "flex items-center justify-end gap-0.5 px-1.5 pb-1.5",
+                  : COMPOSER_LARGE_ACTION_ROW_CLASS,
               )}
             >
               <div
                 className={cn(
-                  "flex min-w-0 items-center gap-0.5",
+                  COMPOSER_LEADING_GROUP_CLASS,
                   variant === "compact"
                     ? "col-start-1 row-start-1 self-end"
                     : "me-auto",

--- a/apps/web/src/components/chat/composer-control-style.ts
+++ b/apps/web/src/components/chat/composer-control-style.ts
@@ -1,2 +1,73 @@
+/**
+ * The tokens every composer box shares: the chat hero, the chat follow-up
+ * bar, and the docked bar over documents (inspector chat, file overlay,
+ * Template Studio) all render one shell from these, so they restyle
+ * together. A surface that needs the look imports these rather than copying
+ * the classes; a copy is how the boxes drifted apart the first time (44px /
+ * `rounded-lg` / 14px in the chat, 38px / `rounded-2xl` / 13px in the
+ * inspector).
+ */
+
 /** Shared responsive size for the two round controls flanking a composer. */
 export const COMPOSER_CONTROL_BUTTON_SIZE = "icon-sm" as const;
+
+/** The bordered box: background, radius, border, colour transition. */
+export const COMPOSER_BOX_CLASS =
+  "bg-background rounded-lg border transition-colors";
+
+/** The box's focus ring in its default (non-anonymized) treatment. */
+export const COMPOSER_BOX_FOCUS_CLASS = "focus-within:border-ring";
+
+/**
+ * The box's "shield active" treatment when the next send is anonymized: a
+ * blue ring replaces the default focus border (both together read as a
+ * double ring on click).
+ */
+export const COMPOSER_BOX_ANONYMIZED_CLASS =
+  "ring-info/40 border-info/40 focus-within:border-info/60 shadow-[0_0_0_4px_rgb(from_var(--color-info)_r_g_b_/_0.08)] ring-1";
+
+/**
+ * The compact (one-line) bar row: its stature, end alignment, control gap
+ * and inset. The surface supplies the layout (`grid` for the chat bar's
+ * three fixed columns, `flex` for the docked bar's variable leading
+ * controls); the row grows with the editor.
+ */
+export const COMPOSER_COMPACT_ROW_CLASS =
+  "min-h-11 items-end gap-1 px-1.5 py-px";
+
+/**
+ * The compact text cell: one `text-sm` line at `leading-5` plus the
+ * vertical inset that seats it on the row's controls. The editable element
+ * itself takes `min-h-0` so an empty composer collapses to this one line.
+ */
+export const COMPOSER_COMPACT_TEXT_CELL_CLASS = "relative min-w-0 py-1";
+
+/** Text stature of the editor and every placeholder painted over it. */
+export const COMPOSER_TEXT_CLASS = "text-sm leading-5";
+
+/**
+ * A round control's slot in the compact row: as tall as the control
+ * (`icon-sm`), bottom-aligned by the row, so the control rides the last
+ * text line as the editor grows.
+ */
+export const COMPOSER_COMPACT_CONTROL_SLOT_CLASS =
+  "flex h-8 shrink-0 items-center";
+
+/**
+ * The `large` (hero) text well: the padding around the editor. The editor's
+ * own stature is `min-h-15` (~3 lines of `text-sm` at `leading-5`), applied
+ * on the editable element by each surface because the chat editor targets its
+ * `.ProseMirror` node while a plain textarea takes it directly.
+ */
+export const COMPOSER_LARGE_TEXT_WELL_CLASS = "ps-3 pe-3 pt-2 pb-1";
+
+/** The placeholder painted over an empty editor, in either stature. */
+export const COMPOSER_PLACEHOLDER_CLASS =
+  "text-foreground-placeholder pointer-events-none absolute truncate text-sm";
+
+/** The `large` action row under the text well: leading controls, trailing send. */
+export const COMPOSER_LARGE_ACTION_ROW_CLASS =
+  "flex items-center justify-end gap-0.5 px-1.5 pb-1.5";
+
+/** The leading group of the action row (the (+) menu, or a scope control). */
+export const COMPOSER_LEADING_GROUP_CLASS = "flex min-w-0 items-center gap-0.5";

--- a/apps/web/src/components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/components/inspector/chat-tab-panel.tsx
@@ -31,6 +31,7 @@ import { useShallow } from "zustand/react/shallow";
 import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
 import { Button } from "@stll/ui/components/button";
 import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import {
   Conversation,
@@ -54,6 +55,10 @@ import { ChatComposerDock } from "@/components/chat/chat-composer-dock";
 import { ChatMatterPicker } from "@/components/chat/chat-matter-picker";
 import { ChatMattersContext } from "@/components/chat/chat-matters-context";
 import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
+import {
+  COMPOSER_COMPACT_CONTROL_SLOT_CLASS,
+  COMPOSER_COMPACT_TEXT_CELL_CLASS,
+} from "@/components/chat/composer-control-style";
 import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
 import { useInspectorCommandStore } from "@/components/inspector/inspector-command-store";
 import { InspectorTabHeader } from "@/components/inspector/inspector-tab-header";
@@ -888,15 +893,20 @@ const PromptBarPlaceholder = ({ tab }: { tab: ChatTab }) => {
   const chatContextLabel = useChatContextLabel(tab, activeOrganizationId);
   return (
     <PromptBarShell aria-hidden="true">
-      <div className="flex min-h-8 min-w-0 flex-1 items-center px-1.5">
+      <div
+        className={cn(
+          COMPOSER_COMPACT_TEXT_CELL_CLASS,
+          "flex flex-1 items-center px-1.5",
+        )}
+      >
         <PromptBarPlaceholderContent>
           {t("chat.contextPlaceholder", { context: chatContextLabel })}
         </PromptBarPlaceholderContent>
       </div>
-      {/* Same h-8 centering wrapper the live send button uses, so the
-          placeholder stays pixel-identical; the disabled action button
-          renders the canonical Send look without re-copying its styling. */}
-      <span className="flex h-8 shrink-0 items-center">
+      {/* Same control slot the live send button uses, so the placeholder
+          stays pixel-identical; the disabled action button renders the
+          canonical Send look without re-copying its styling. */}
+      <span className={COMPOSER_COMPACT_CONTROL_SLOT_CLASS}>
         <ChatComposerActionButton
           canSend={false}
           isGenerating={false}

--- a/apps/web/src/routes/_protected.knowledge/-components/template-studio-chat.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-studio-chat.tsx
@@ -38,6 +38,7 @@ import type {
 import { BidiText } from "@stll/ui/components/bidi-text";
 import { Button } from "@stll/ui/components/button";
 import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import {
   ChatThreadCard,
@@ -63,6 +64,7 @@ import type {
   PersistedChatMessage,
   UnresolvedActiveDocxEditToolCallPart,
 } from "@/components/chat/chat-ui-tools";
+import { COMPOSER_TEXT_CLASS } from "@/components/chat/composer-control-style";
 import { useAIKeyGate } from "@/components/require-ai-key";
 import { isInputType } from "@/components/templates/template-field-manifest";
 import { useChatSession } from "@/features/chat/hooks/use-chat-session";
@@ -1347,7 +1349,12 @@ const TemplateStudioChatInner = ({
           canSubmitNow={canSubmitWithCurrentSnapshot}
           editorController={editorController}
           emptyPlaceholder={
-            <span className="text-foreground-ghost flex min-w-0 items-center gap-1.5 text-[13px] leading-5">
+            <span
+              className={cn(
+                "text-foreground-ghost flex min-w-0 items-center gap-1.5",
+                COMPOSER_TEXT_CLASS,
+              )}
+            >
               <span className="shrink-0">
                 {t("chat.editableFilePlaceholderAction")}
               </span>


### PR DESCRIPTION
## Summary

The main chat bar (`ChatInputSurface`, 44px / `rounded-lg` / 14px, `focus-within:border-ring`) and the docked bar over documents (`PromptBar` in the inspector chat, file overlay and Template Studio: 38px / `rounded-2xl` / 13px, `border-foreground/15`, `focus-within:border-foreground/30`) had drifted into two shells.

- `composer-control-style.ts` now holds the shared shell tokens: box, focus ring, anonymized ring, compact row stature (`min-h-11 items-end gap-1 px-1.5 py-px`), compact text cell, control slot, text size (`text-sm leading-5`) and placeholder colour. Both surfaces render from them, so they can only restyle together; the large (hero) tokens are the same ones the case-law composer branch introduces, so that branch rebases onto these.
- `PromptBarShell` keeps only what floating over a document needs (shadow, doc-anchored surface). Its placeholders (`PromptBarPlaceholderContent`, busy/loading labels, the file placeholders in the overlay and Template Studio) take the shared text size and placeholder colour; the loading `PromptBarPlaceholder` mirror uses the same cell and slot tokens.
- The floating thread card offset moves from `bottom-24` to `bottom-26` to clear the taller bar with the same 14px gap.

## Verification

Type-aware lint and web typecheck green. Visual: inspector chat, file-overlay chat and Template Studio bars now match the main chat follow-up bar (height, radius, text, focus).