### PR TITLE
fix(analytics): capture $ai_generation per model call, not per finished run

### DIFF
--- a/apps/api/src/lib/analytics/tanstack-ai.test.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.test.ts
@@ -865,6 +865,97 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
     });
   });
 
+  test("keeps concurrent runs on one callbacks instance apart", async () => {
+    const { createTanStackAIAnalyticsCallbacks } =
+      await loadTanStackAIAnalytics();
+    const events: Parameters<Analytics["capture"]>[0][] = [];
+    const analytics: Analytics = {
+      capture: (event) => {
+        events.push(event);
+      },
+      flush: async () => undefined,
+      identifyOrganizationGroup: () => undefined,
+    };
+    // Template filling shares one callbacks instance across concurrent
+    // field resolutions: each run's totals and tool count must stay its own.
+    const callbacks = createTanStackAIAnalyticsCallbacks({
+      analytics,
+      feature: "templates.fill",
+      orgAIConfig: createOpenAIOrgAIConfig(),
+      traceId: "trace_shared",
+    });
+    const runA = createMiddlewareContext({ runId: "run_a" });
+    const runB = createMiddlewareContext({ runId: "run_b" });
+    const small = {
+      promptTokens: 300,
+      completionTokens: 50,
+      totalTokens: 350,
+    } satisfies TokenUsage;
+    const large = {
+      promptTokens: 30_000,
+      completionTokens: 2000,
+      totalTokens: 32_000,
+    } satisfies TokenUsage;
+    const toolCall = {
+      duration: 1,
+      ok: true,
+      result: {},
+      tool: undefined,
+      toolCall: {
+        id: "tool_1",
+        type: "function" as const,
+        function: { name: "search", arguments: "{}" },
+      },
+      toolCallId: "tool_1",
+      toolName: "search",
+    };
+
+    // Interleaved: A reports usage, B reports usage and calls two tools, A
+    // finishes, B finishes.
+    await callbacks.middleware.onUsage?.(runA, small);
+    await callbacks.middleware.onUsage?.(runB, large);
+    await callbacks.middleware.onAfterToolCall?.(runB, toolCall);
+    await callbacks.middleware.onAfterToolCall?.(runB, toolCall);
+    await callbacks.middleware.onFinish?.(runA, {
+      content: "",
+      duration: 100,
+      finishReason: "stop",
+      usage: small,
+    });
+    await callbacks.middleware.onFinish?.(runB, {
+      content: "",
+      duration: 100,
+      finishReason: "stop",
+      usage: large,
+    });
+
+    const completedProperties = () =>
+      events
+        .filter(
+          (event) =>
+            event.event === SERVER_ANALYTICS_EVENTS.aiGenerationCompleted,
+        )
+        .map((event) => event.properties);
+    expect(completedProperties()).toMatchObject([
+      { input_tokens_bucket: "0_1k", tool_count_bucket: "0" },
+      { input_tokens_bucket: "20k_plus", tool_count_bucket: "2_3" },
+    ]);
+
+    // A finished run leaves no state behind: a later run under the same id
+    // starts from zero rather than inheriting the earlier totals.
+    await callbacks.middleware.onUsage?.(runA, small);
+    await callbacks.middleware.onFinish?.(runA, {
+      content: "",
+      duration: 100,
+      finishReason: "stop",
+      usage: small,
+    });
+    expect(completedProperties().at(-1)).toMatchObject({
+      input_tokens_bucket: "0_1k",
+      tool_count_bucket: "0",
+    });
+  });
+
   test("an interrupted run still reports its generation", async () => {
     const { createTanStackAIAnalyticsCallbacks } =
       await loadTanStackAIAnalytics();

--- a/apps/api/src/lib/analytics/tanstack-ai.test.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.test.ts
@@ -133,6 +133,11 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
     });
     const ctx = createMiddlewareContext();
 
+    await callbacks.middleware.onIteration?.(ctx, {
+      iteration: 0,
+      messageId: "msg_1",
+    });
+    await callbacks.middleware.onUsage?.(ctx, usage);
     await callbacks.middleware.onAfterToolCall?.(ctx, {
       duration: 10,
       ok: true,
@@ -146,6 +151,13 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
       toolCallId: "tool_1",
       toolName: "search",
     });
+    // The generation event belongs to the model call, not the run: it is
+    // already captured before the terminal hook.
+    expect(
+      events.filter(
+        (event) => event.event === SERVER_ANALYTICS_EVENTS.aiGeneration,
+      ),
+    ).toHaveLength(1);
     await callbacks.middleware.onFinish?.(ctx, {
       content: "Done",
       duration: 4200,
@@ -160,8 +172,12 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
     expect(generation).toMatchObject({
       distinctId: "user_123",
       properties: {
+        $ai_input_tokens: usage.promptTokens,
         $ai_model: "gpt-5.4-mini",
+        $ai_output_tokens: usage.completionTokens,
         $ai_provider: "openai",
+        $ai_span_id: "run_1:0",
+        $ai_trace_id: "trace_complete",
         feature: "chat.stream",
       },
     });
@@ -211,6 +227,8 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
     });
     const ctx = createMiddlewareContext();
 
+    // No metering: the generation event still fires from usage.
+    await callbacks.middleware.onUsage?.(ctx, usage);
     await callbacks.middleware.onFinish?.(ctx, {
       content: "Done",
       duration: 4200,
@@ -767,6 +785,118 @@ describe("createTanStackAIAnalyticsCallbacks", () => {
       errorSpy.mockRestore();
       warnSpy.mockRestore();
     }
+  });
+
+  test("captures one generation per model call and sums the run's usage", async () => {
+    const { createTanStackAIAnalyticsCallbacks } =
+      await loadTanStackAIAnalytics();
+    const events: Parameters<Analytics["capture"]>[0][] = [];
+    const analytics: Analytics = {
+      capture: (event) => {
+        events.push(event);
+      },
+      flush: async () => undefined,
+      identifyOrganizationGroup: () => undefined,
+    };
+    const callbacks = createTanStackAIAnalyticsCallbacks({
+      analytics,
+      feature: "chat.stream",
+      orgAIConfig: createOpenAIOrgAIConfig(),
+      traceId: "trace_iterations",
+    });
+    // A tool-calling turn: two model calls, each reporting its own usage;
+    // TanStack hands `onFinish` only the second one.
+    // Chosen so the run total lands in a different bucket than the last
+    // iteration alone: prompt 1200 + 4300 = 5500 (5k_20k, not 1k_5k) and
+    // completion 200 + 900 = 1100 (1k_5k, not 0_1k).
+    const first = {
+      promptTokens: 1200,
+      completionTokens: 200,
+      totalTokens: 1400,
+    } satisfies TokenUsage;
+    const second = {
+      promptTokens: 4300,
+      completionTokens: 900,
+      totalTokens: 5200,
+    } satisfies TokenUsage;
+
+    const ctx0 = createMiddlewareContext({ iteration: 0 });
+    const ctx1 = createMiddlewareContext({ iteration: 1 });
+    await callbacks.middleware.onIteration?.(ctx0, {
+      iteration: 0,
+      messageId: "msg_1",
+    });
+    await callbacks.middleware.onUsage?.(ctx0, first);
+    await callbacks.middleware.onIteration?.(ctx1, {
+      iteration: 1,
+      messageId: "msg_2",
+    });
+    await callbacks.middleware.onUsage?.(ctx1, second);
+    await callbacks.middleware.onFinish?.(ctx1, {
+      content: "Done",
+      duration: 4200,
+      finishReason: "stop",
+      usage: second,
+    });
+
+    const generations = events.filter(
+      (event) => event.event === SERVER_ANALYTICS_EVENTS.aiGeneration,
+    );
+    expect(generations.map((event) => event.properties)).toMatchObject([
+      {
+        $ai_input_tokens: first.promptTokens,
+        $ai_output_tokens: first.completionTokens,
+        $ai_span_id: "run_1:0",
+        $ai_trace_id: "trace_iterations",
+      },
+      {
+        $ai_input_tokens: second.promptTokens,
+        $ai_output_tokens: second.completionTokens,
+        $ai_span_id: "run_1:1",
+        $ai_trace_id: "trace_iterations",
+      },
+    ]);
+    const completed = events.find(
+      (event) => event.event === SERVER_ANALYTICS_EVENTS.aiGenerationCompleted,
+    );
+    expect(completed?.properties).toMatchObject({
+      input_tokens_bucket: "5k_20k",
+      output_tokens_bucket: "1k_5k",
+    });
+  });
+
+  test("an interrupted run still reports its generation", async () => {
+    const { createTanStackAIAnalyticsCallbacks } =
+      await loadTanStackAIAnalytics();
+    const events: Parameters<Analytics["capture"]>[0][] = [];
+    const analytics: Analytics = {
+      capture: (event) => {
+        events.push(event);
+      },
+      flush: async () => undefined,
+      identifyOrganizationGroup: () => undefined,
+    };
+    const callbacks = createTanStackAIAnalyticsCallbacks({
+      analytics,
+      feature: "chat.stream",
+      orgAIConfig: createOpenAIOrgAIConfig(),
+      traceId: "trace_interrupted",
+    });
+    const ctx = createMiddlewareContext();
+
+    // A run that pauses at a client-tool or approval interrupt reports usage
+    // for the model call and then reaches no terminal hook at all
+    // (onFinish/onAbort/onError never fire; see the TanStack chat engine's
+    // `toolPhase !== "wait"` guard).
+    await callbacks.middleware.onIteration?.(ctx, {
+      iteration: 0,
+      messageId: "msg_1",
+    });
+    await callbacks.middleware.onUsage?.(ctx, usage);
+
+    expect(events.map((event) => event.event)).toEqual([
+      SERVER_ANALYTICS_EVENTS.aiGeneration,
+    ]);
   });
 
   test("logs a configuration refusal at WARN with its status", async () => {

--- a/apps/api/src/lib/analytics/tanstack-ai.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.ts
@@ -1,4 +1,8 @@
-import type { ChatMiddleware, ChatMiddlewareContext } from "@tanstack/ai";
+import type {
+  ChatMiddleware,
+  ChatMiddlewareContext,
+  TokenUsage,
+} from "@tanstack/ai";
 import { Result } from "better-result";
 
 import type { ModelRole } from "@stll/ai-catalog";
@@ -314,6 +318,15 @@ export const createTanStackAIAnalyticsCallbacks = ({
   const selectedModelId = config.selectedModelId;
   let modelInfo: ResolvedTanStackTextModelInfo | null | undefined;
   const startedAt = performance.now();
+  // Each agent-loop iteration is one model call: `onIteration` marks its
+  // start and `onUsage` closes it, so per-generation latency covers only
+  // that call (the run-level `duration` spans every iteration and tool).
+  let iterationStartedAt = startedAt;
+  // Token totals across every iteration that reported usage. TanStack's
+  // `onFinish` usage is the LAST iteration's only (`finishedEvent` resets per
+  // iteration), so the run-level completion event sums these instead.
+  const runUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+  let runUsageReported = false;
   let hasCapturedGenerationError = false;
   let toolCount = 0;
 
@@ -439,10 +452,47 @@ export const createTanStackAIAnalyticsCallbacks = ({
     });
   };
 
+  // The standard $ai_* schema feeds the analytics platform's LLM
+  // observability product: one `$ai_generation` per model call, correlated
+  // by `$ai_trace_id`. Captured from `onUsage` (once per iteration that
+  // reports usage) rather than from `onFinish`: a run that pauses at an
+  // interrupt (client tool, approval) reaches no terminal hook at all, and
+  // `onFinish` only carries the last iteration's usage. Privacy mode by
+  // construction: model, token counts, latency, and trace correlation only —
+  // prompt and completion content never leave the service.
+  const captureGeneration = ({
+    ctx,
+    modelInfo: resolvedModelInfo,
+    usage,
+  }: {
+    ctx: ChatMiddlewareContext;
+    modelInfo: ResolvedTanStackTextModelInfo;
+    usage: TokenUsage;
+  }) => {
+    analytics.capture({
+      distinctId,
+      ...groups,
+      event: SERVER_ANALYTICS_EVENTS.aiGeneration,
+      properties: {
+        $ai_input_tokens: usage.promptTokens,
+        $ai_latency: (performance.now() - iterationStartedAt) / ONE_SECOND_MS,
+        $ai_model: resolvedModelInfo.modelId,
+        $ai_output_tokens: usage.completionTokens,
+        $ai_provider: resolvedModelInfo.provider,
+        $ai_span_id: `${ctx.runId}:${ctx.iteration}`,
+        $ai_trace_id: config.traceId,
+        feature: config.feature,
+      },
+    });
+  };
+
   return {
     captureError: captureGenerationError,
     middleware: {
       name: "stella-tanstack-analytics",
+      onIteration: () => {
+        iterationStartedAt = performance.now();
+      },
       onAfterToolCall: () => {
         toolCount += 1;
       },
@@ -450,32 +500,17 @@ export const createTanStackAIAnalyticsCallbacks = ({
         captureGenerationError(error, duration);
       },
       onFinish: (_ctx, { duration, usage }) => {
-        if (!usage) {
+        // Sum of every iteration's reported usage; the hook's own `usage`
+        // (last iteration only) is the fallback for a run whose provider
+        // never reached `onUsage`.
+        const totals = runUsageReported ? runUsage : usage;
+        if (!totals) {
           return;
         }
         const resolvedModelInfo = resolveAnalyticsModelInfo();
         if (!resolvedModelInfo) {
           return;
         }
-
-        // The standard $ai_* schema feeds the analytics platform's LLM
-        // observability product. Privacy mode by construction: model, token
-        // counts, latency, and trace correlation only — prompt and completion
-        // content never leave the service.
-        analytics.capture({
-          distinctId,
-          ...groups,
-          event: SERVER_ANALYTICS_EVENTS.aiGeneration,
-          properties: {
-            $ai_input_tokens: usage.promptTokens,
-            $ai_latency: duration / ONE_SECOND_MS,
-            $ai_model: resolvedModelInfo.modelId,
-            $ai_output_tokens: usage.completionTokens,
-            $ai_provider: resolvedModelInfo.provider,
-            $ai_trace_id: config.traceId,
-            feature: config.feature,
-          },
-        });
 
         analytics.capture({
           distinctId,
@@ -484,17 +519,17 @@ export const createTanStackAIAnalyticsCallbacks = ({
           properties: {
             ...pickSafeMetadata(config.properties),
             feature: config.feature,
-            input_tokens_bucket: bucketTokenCount(usage.promptTokens),
+            input_tokens_bucket: bucketTokenCount(totals.promptTokens),
             latency_bucket: bucketLatency(duration / ONE_SECOND_MS),
             model: resolvedModelInfo.modelId,
             model_key_source: resolvedModelInfo.keySource,
-            output_tokens_bucket: bucketTokenCount(usage.completionTokens),
+            output_tokens_bucket: bucketTokenCount(totals.completionTokens),
             provider: resolvedModelInfo.provider,
             ...(resolvedModelInfo.region
               ? { region: resolvedModelInfo.region }
               : {}),
             tool_count_bucket: bucketCount(toolCount),
-            total_tokens_bucket: bucketTokenCount(usage.totalTokens),
+            total_tokens_bucket: bucketTokenCount(totals.totalTokens),
           },
         });
       },
@@ -504,13 +539,19 @@ export const createTanStackAIAnalyticsCallbacks = ({
       // event and reports it; it never loses the server.
       onUsage: (ctx, usage) => {
         try {
-          const metering = config.usageMetering;
-          if (!metering) {
+          const resolvedModelInfo = resolveAnalyticsModelInfo();
+          if (!resolvedModelInfo) {
             return;
           }
 
-          const resolvedModelInfo = resolveAnalyticsModelInfo();
-          if (!resolvedModelInfo) {
+          runUsage.promptTokens += usage.promptTokens;
+          runUsage.completionTokens += usage.completionTokens;
+          runUsage.totalTokens += usage.totalTokens;
+          runUsageReported = true;
+          captureGeneration({ ctx, modelInfo: resolvedModelInfo, usage });
+
+          const metering = config.usageMetering;
+          if (!metering) {
             return;
           }
 

--- a/apps/api/src/lib/analytics/tanstack-ai.ts
+++ b/apps/api/src/lib/analytics/tanstack-ai.ts
@@ -46,6 +46,20 @@ import {
 
 type AnalyticsMetadata = Record<string, AnalyticsPrimitive>;
 
+/** What one run accumulates across its middleware hooks. */
+type RunAnalyticsState = {
+  /** Start of the current agent-loop iteration (one model call). */
+  iterationStartedAt: number;
+  toolCount: number;
+  /** Sum of every iteration's reported usage. */
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  usageReported: boolean;
+};
+
 export type TanStackAIUsageMetering = {
   actionType: UsageActionType;
   /**
@@ -318,17 +332,28 @@ export const createTanStackAIAnalyticsCallbacks = ({
   const selectedModelId = config.selectedModelId;
   let modelInfo: ResolvedTanStackTextModelInfo | null | undefined;
   const startedAt = performance.now();
-  // Each agent-loop iteration is one model call: `onIteration` marks its
-  // start and `onUsage` closes it, so per-generation latency covers only
-  // that call (the run-level `duration` spans every iteration and tool).
-  let iterationStartedAt = startedAt;
-  // Token totals across every iteration that reported usage. TanStack's
-  // `onFinish` usage is the LAST iteration's only (`finishedEvent` resets per
-  // iteration), so the run-level completion event sums these instead.
-  const runUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
-  let runUsageReported = false;
+  // Per-run state, keyed by `ctx.runId`: one callbacks instance may serve
+  // several `chat()` requests (template filling shares one across up to
+  // four concurrent field resolutions), so nothing a hook accumulates may
+  // live on the closure. Entries are dropped by the terminal hooks; a run
+  // that parks at an interrupt keeps its entry for the instance's lifetime.
+  const runs = new Map<string, RunAnalyticsState>();
+  const runState = (ctx: ChatMiddlewareContext): RunAnalyticsState => {
+    const existing = runs.get(ctx.runId);
+    if (existing) {
+      return existing;
+    }
+    const now = performance.now();
+    const created: RunAnalyticsState = {
+      iterationStartedAt: now,
+      toolCount: 0,
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      usageReported: false,
+    };
+    runs.set(ctx.runId, created);
+    return created;
+  };
   let hasCapturedGenerationError = false;
-  let toolCount = 0;
 
   const resolveAnalyticsModelInfo =
     (): ResolvedTanStackTextModelInfo | null => {
@@ -462,10 +487,12 @@ export const createTanStackAIAnalyticsCallbacks = ({
   // prompt and completion content never leave the service.
   const captureGeneration = ({
     ctx,
+    iterationStartedAt,
     modelInfo: resolvedModelInfo,
     usage,
   }: {
     ctx: ChatMiddlewareContext;
+    iterationStartedAt: number;
     modelInfo: ResolvedTanStackTextModelInfo;
     usage: TokenUsage;
   }) => {
@@ -490,20 +517,30 @@ export const createTanStackAIAnalyticsCallbacks = ({
     captureError: captureGenerationError,
     middleware: {
       name: "stella-tanstack-analytics",
-      onIteration: () => {
-        iterationStartedAt = performance.now();
+      // Each agent-loop iteration is one model call: `onIteration` marks its
+      // start and `onUsage` closes it, so per-generation latency covers only
+      // that call (the run-level `duration` spans every iteration and tool).
+      onIteration: (ctx) => {
+        runState(ctx).iterationStartedAt = performance.now();
       },
-      onAfterToolCall: () => {
-        toolCount += 1;
+      onAfterToolCall: (ctx) => {
+        runState(ctx).toolCount += 1;
       },
-      onError: (_ctx, { duration, error }) => {
+      onAbort: (ctx) => {
+        runs.delete(ctx.runId);
+      },
+      onError: (ctx, { duration, error }) => {
+        runs.delete(ctx.runId);
         captureGenerationError(error, duration);
       },
-      onFinish: (_ctx, { duration, usage }) => {
-        // Sum of every iteration's reported usage; the hook's own `usage`
-        // (last iteration only) is the fallback for a run whose provider
-        // never reached `onUsage`.
-        const totals = runUsageReported ? runUsage : usage;
+      onFinish: (ctx, { duration, usage }) => {
+        const run = runs.get(ctx.runId);
+        runs.delete(ctx.runId);
+        // Sum of every iteration's reported usage. TanStack's `onFinish`
+        // usage is the LAST iteration's only (`finishedEvent` resets per
+        // iteration); it is the fallback for a run whose provider never
+        // reached `onUsage`.
+        const totals = run?.usageReported ? run.usage : usage;
         if (!totals) {
           return;
         }
@@ -528,68 +565,90 @@ export const createTanStackAIAnalyticsCallbacks = ({
             ...(resolvedModelInfo.region
               ? { region: resolvedModelInfo.region }
               : {}),
-            tool_count_bucket: bucketCount(toolCount),
+            tool_count_bucket: bucketCount(run?.toolCount ?? 0),
             total_tokens_bucket: bucketTokenCount(totals.totalTokens),
           },
         });
       },
-      // Framework-hook boundary (the one place try-catch is allowed): a
-      // metering fault must never propagate into the provider stream and
-      // take the process down with it. A bug here loses one metering
-      // event and reports it; it never loses the server.
+      // Framework-hook boundaries (the one place try-catch is allowed): a
+      // fault here must never propagate into the provider stream and take
+      // the process down with it, and metering and observability are
+      // isolated from each other so an analytics fault cannot drop a
+      // billable usage event. A bug loses that one event and reports it; it
+      // never loses the server.
       onUsage: (ctx, usage) => {
+        const resolvedModelInfo = resolveAnalyticsModelInfo();
+        if (!resolvedModelInfo) {
+          return;
+        }
+        const run = runState(ctx);
         try {
-          const resolvedModelInfo = resolveAnalyticsModelInfo();
-          if (!resolvedModelInfo) {
-            return;
-          }
+          run.usage.promptTokens += usage.promptTokens;
+          run.usage.completionTokens += usage.completionTokens;
+          run.usage.totalTokens += usage.totalTokens;
+          run.usageReported = true;
+        } catch (error) {
+          // The payload itself is unreadable: neither side effect can use it.
+          captureTelemetryError(error, {
+            source: "usage.tanstack_ai",
+            trace_id: config.traceId,
+          });
+          return;
+        }
 
-          runUsage.promptTokens += usage.promptTokens;
-          runUsage.completionTokens += usage.completionTokens;
-          runUsage.totalTokens += usage.totalTokens;
-          runUsageReported = true;
-          captureGeneration({ ctx, modelInfo: resolvedModelInfo, usage });
-
-          const metering = config.usageMetering;
-          if (!metering) {
-            return;
-          }
-
-          const { uncachedInputTokens, cacheReadTokens } =
-            normalizeProviderPromptTokens({
-              provider: resolvedModelInfo.provider,
-              modelId: resolvedModelInfo.modelId,
-              promptTokens: usage.promptTokens,
-              cacheReadTokens: usage.promptTokensDetails?.cachedTokens ?? 0,
-              cacheWriteTokens:
-                usage.promptTokensDetails?.cacheWriteTokens ?? 0,
+        const metering = config.usageMetering;
+        if (metering) {
+          try {
+            const { uncachedInputTokens, cacheReadTokens } =
+              normalizeProviderPromptTokens({
+                provider: resolvedModelInfo.provider,
+                modelId: resolvedModelInfo.modelId,
+                promptTokens: usage.promptTokens,
+                cacheReadTokens: usage.promptTokensDetails?.cachedTokens ?? 0,
+                cacheWriteTokens:
+                  usage.promptTokensDetails?.cacheWriteTokens ?? 0,
+              });
+            const consumption = recordTanStackConsumption({
+              cacheReadTokens,
+              completionTokens: usage.completionTokens,
+              config,
+              iteration: ctx.iteration,
+              modelInfo: resolvedModelInfo,
+              runId: ctx.runId,
+              serviceTier: usageServiceTierFromModelOptions({
+                fallback: metering.serviceTier,
+                modelOptions: ctx.modelOptions,
+              }),
+              uncachedInputTokens,
+            }).catch((error: unknown) => {
+              // A rejected deferred settles inside the stream lifecycle;
+              // capture it here so it cannot surface as an unhandled
+              // rejection there.
+              captureTelemetryError(error, {
+                organization_id: metering.organizationId,
+                source: "usage.tanstack_ai",
+                trace_id: config.traceId,
+              });
             });
-          const consumption = recordTanStackConsumption({
-            cacheReadTokens,
-            completionTokens: usage.completionTokens,
-            config,
-            iteration: ctx.iteration,
-            modelInfo: resolvedModelInfo,
-            runId: ctx.runId,
-            serviceTier: usageServiceTierFromModelOptions({
-              fallback: metering.serviceTier,
-              modelOptions: ctx.modelOptions,
-            }),
-            uncachedInputTokens,
-          }).catch((error: unknown) => {
-            // A rejected deferred settles inside the stream lifecycle;
-            // capture it here so it cannot surface as an unhandled
-            // rejection there.
+            ctx.defer(consumption);
+          } catch (error) {
             captureTelemetryError(error, {
-              organization_id: metering.organizationId,
               source: "usage.tanstack_ai",
               trace_id: config.traceId,
             });
+          }
+        }
+
+        try {
+          captureGeneration({
+            ctx,
+            iterationStartedAt: run.iterationStartedAt,
+            modelInfo: resolvedModelInfo,
+            usage,
           });
-          ctx.defer(consumption);
         } catch (error) {
           captureTelemetryError(error, {
-            source: "usage.tanstack_ai",
+            source: "analytics.tanstack_ai",
             trace_id: config.traceId,
           });
         }


### PR DESCRIPTION
## Summary

TanStack's chat engine calls a terminal hook only when `toolPhase !== "wait"`, so a run that pauses at a client-tool or approval interrupt reaches neither `onFinish` nor `onError` and produced no `$ai_generation`. `onFinish`'s `usage` is also only the last iteration's (`finishedEvent` resets per iteration), so tool-calling runs under-reported tokens.

- `$ai_generation` is now captured from `onUsage`, once per model call: tokens of that call, `$ai_span_id = <runId>:<iteration>`, `$ai_latency` measured from `onIteration` to `onUsage`, `$ai_trace_id` unchanged. Fires with or without usage metering.
- `onFinish` keeps only the run-level `ai_generation_completed` and buckets the sum of every iteration's usage (falls back to the hook's own usage when no iteration reported any).
- Error path unchanged (`$ai_is_error` generation + `ai_generation_failed`).

## Tests

`tanstack-ai.test.ts`: one generation per iteration with span ids and per-call tokens; the completed event buckets the run total (fixture chosen so the last-iteration-only bucket differs, reverting the sum fails the test); an interrupted run (usage, no terminal hook) still yields its generation; existing tests moved to drive `onUsage` where they asserted the generation event.