### PR TITLE
chore(ci): mint the release App token only in the release-app environment

### DIFF
--- a/.github/actions/marketing-capture/action.yml
+++ b/.github/actions/marketing-capture/action.yml
@@ -1,0 +1,151 @@
+name: Capture marketing screenshots
+description: Seed the app on the CI runner and either compare or rewrite the committed product screenshots
+
+# The one body behind both directions of the baselines. `check` and `update`
+# are separate jobs in marketing-screenshots.yml because only `update` may
+# declare the release-app environment, so "what CI compares" and "what CI
+# regenerates" have to meet here instead of in two drifting job bodies.
+#
+# The checkout stays with the caller: check captures the triggering ref,
+# update captures the branch it was told to regenerate.
+
+inputs:
+  mode:
+    description: check compares committed baselines; update rewrites them in the workspace
+    required: true
+  dockerhub-username:
+    description: Docker Hub username for authenticated infrastructure image pulls
+    required: false
+    default: ""
+  dockerhub-token:
+    description: Docker Hub token for authenticated infrastructure image pulls
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Validate mode
+      # Both callers gate on the mode, but only one of them can see an
+      # unrecognised value: the check job runs on anything that is not
+      # `update`, so a typo fails here instead of skipping both jobs green.
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+      run: |
+        case "$MODE" in
+          check|update) ;;
+          *)
+            echo "::error::Unknown marketing screenshot mode: $MODE"
+            exit 1
+            ;;
+        esac
+
+    - name: Setup Bun
+      uses: stella/.github/actions/setup-bun-cached@2b8697f04b39187c934afc04f7b04ad1a18bd827
+
+    - name: Install dependencies
+      shell: bash
+      run: bash scripts/bun-ci-retry.sh --ignore-scripts
+      env:
+        NPM_TOKEN: ""
+
+    - name: Prepare environment
+      shell: bash
+      run: |
+        cd ./apps/api
+        cp .env.example .env
+        cd ../web
+        cp .env.example .env
+
+    - name: Start docker stack and API server
+      id: e2e-stack
+      uses: ./.github/actions/setup-e2e-stack
+      with:
+        dockerhub-username: ${{ inputs.dockerhub-username }}
+        dockerhub-token: ${{ inputs.dockerhub-token }}
+        # Document conversion backs the seeded product scenes the captures
+        # render.
+        extra-services: gotenberg
+
+    - name: Require the stack
+      # The action exits 0 with `status=rate-limited` when Docker Hub throttles
+      # the image pulls. The e2e suites accept that skip; this capture cannot: it
+      # is the only guard on assets that ship on the marketing site, so a skipped
+      # run would report success without comparing a single PNG. Every later
+      # `status == 'ready'` condition is therefore unreachable-if-false, and only
+      # the `always()` cleanup steps still test it.
+      if: steps.e2e-stack.outputs.status != 'ready'
+      shell: bash
+      env:
+        STATUS: ${{ steps.e2e-stack.outputs.status }}
+      run: |
+        echo "::error::E2E stack status is '$STATUS', not 'ready'; marketing screenshots were neither compared nor regenerated"
+        exit 1
+
+    - name: Start web dev server
+      shell: bash
+      run: |
+        cd apps/web
+        nohup bun --bun vite --port 3000 > /tmp/web.log 2>&1 &
+        echo $! > /tmp/web.pid
+
+    - name: Wait for web dev server
+      shell: bash
+      run: |
+        for i in {1..60}; do
+          if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3000 > /dev/null 2>&1; then
+            echo "Web up after ${i}s"
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "::error::Web never came up"
+        tail -200 /tmp/web.log || true
+        exit 1
+
+    - name: Install Playwright browsers
+      uses: ./.github/actions/setup-playwright
+      with:
+        dependency-mode: full
+
+    - name: Seed deterministic marketing content
+      shell: bash
+      run: bun --filter @stll/api db:seed-dev
+
+    - name: Capture marketing screenshots
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+      run: |
+        # The `--update-snapshots` flag lives in the package script alone, so
+        # there is one place that knows how a baseline is rewritten.
+        if [[ "$MODE" == "update" ]]; then
+          bun --filter @stll/web test:e2e:marketing:update
+        else
+          bun --filter @stll/web test:e2e:marketing
+        fi
+
+    - name: Guard against mid-test Vite re-optimize
+      # Before the update-mode commit in the caller: a mid-session reload
+      # produces torn frames, which must never be pushed as a baseline. Also
+      # runs after a failed capture, so a reload is reported as the cause
+      # rather than as a pixel diff.
+      if: always() && steps.e2e-stack.outputs.status == 'ready'
+      shell: bash
+      run: |
+        if grep -q "optimized dependencies changed. reloading" /tmp/web.log; then
+          echo "::error::Vite re-optimized dependencies mid-session and forced a reload. Add the lazy/runtime dependency named below to optimizeDeps.include in apps/web/vite.config.ts."
+          grep -nE "new dependencies optimized|optimized dependencies changed" /tmp/web.log || true
+          exit 1
+        fi
+        echo "No mid-session dep re-optimize detected."
+
+    - name: Stop web dev server
+      if: always() && steps.e2e-stack.outputs.status == 'ready'
+      shell: bash
+      run: |
+        if [[ -f /tmp/web.pid ]]; then
+          kill "$(cat /tmp/web.pid)" || true
+          rm -f /tmp/web.pid
+        fi

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -30,6 +30,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    # Release App key lives in this environment (main and v* tags only).
+    environment: release-app
     steps:
       - name: Mint App token for the private workflows repo
         id: app-token

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -355,6 +355,8 @@ jobs:
     permissions:
       contents: read
       deployments: write
+    # Release App key lives in this environment (main and v* tags only).
+    environment: release-app
     steps:
       - name: Checkout workflow actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/marketing-screenshots.yml
+++ b/.github/workflows/marketing-screenshots.yml
@@ -1,14 +1,19 @@
 name: Marketing screenshots
 
-# One runner definition for both directions of the marketing screenshot
-# baselines, so "what CI compares" and "what CI regenerates" can never be
-# produced by two drifting job bodies:
+# Both directions of the marketing screenshot baselines, driven by one
+# capture body (`.github/actions/marketing-capture`) so "what CI compares" and
+# "what CI regenerates" can never be produced by two drifting definitions:
 #
 #   check  — PR CI and the nightly run compare the committed PNGs against a
 #            freshly seeded app.
 #   update — dispatched on main against the branch whose UI legitimately
 #            changed; rewrites every baseline on the runner and pushes the
 #            result to that branch.
+#
+# They are separate jobs because only update may hold the release App key:
+# update runs in the `release-app` environment, whose deployment policy
+# allows main and release tags only, so the key is structurally unavailable
+# to a run on any other ref.
 #
 # Both render on the same runner image, which is why the baselines can be
 # treated as reproducible artifacts rather than a developer's local output.
@@ -39,7 +44,44 @@ on:
 permissions: {}
 
 jobs:
-  marketing-screenshots:
+  check:
+    # Anything that is not update, so an unrecognised mode reaches the
+    # capture action's validation instead of skipping both jobs green.
+    if: inputs.mode != 'update'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          submodules: true
+
+      - name: Capture marketing screenshots
+        uses: ./.github/actions/marketing-capture
+        with:
+          mode: ${{ inputs.mode }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          # Mode and run keep the nightly, PR, and dispatched artifacts apart.
+          name: marketing-screenshots-${{ inputs.mode }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            /tmp/api.log
+            /tmp/web.log
+            apps/web/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  update:
+    if: inputs.mode == 'update'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -47,22 +89,15 @@ jobs:
       # with GITHUB_TOKEN does not re-trigger the PR's checks, so the branch
       # would sit on a failed marketing check with the fix already committed.
       contents: read
+    # Release App key lives in this environment (main and v* tags only).
+    environment: release-app
 
     steps:
       - name: Validate inputs
         env:
           BRANCH: ${{ inputs.ref }}
-          MODE: ${{ inputs.mode }}
           WORKFLOW_REF: ${{ github.ref_name }}
         run: |
-          case "$MODE" in
-            check|update) ;;
-            *)
-              echo "::error::Unknown marketing screenshot mode: $MODE"
-              exit 1
-              ;;
-          esac
-
           # `ref` reaches a checkout and a push refspec, so it has to be a
           # plain branch name and nothing that reads as an option or a path
           # traversal.
@@ -75,10 +110,6 @@ jobs:
               echo "::error::Not a plain branch name: $BRANCH"
               exit 1
             fi
-          fi
-
-          if [[ "$MODE" != "update" ]]; then
-            exit 0
           fi
 
           # The release App key must only ever run workflow code from main
@@ -99,7 +130,6 @@ jobs:
         # Before the token is minted: a typo must not reach the App, and a
         # fork PR's branch does not exist here at all (its baselines travel as
         # the artifact uploaded below).
-        if: inputs.ref != ''
         env:
           BRANCH: ${{ inputs.ref }}
           GH_TOKEN: ${{ github.token }}
@@ -110,7 +140,6 @@ jobs:
           fi
 
       - name: Mint App token
-        if: inputs.mode == 'update'
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -127,113 +156,20 @@ jobs:
           # so it never reaches disk as a persisted git credential, and the
           # code checked out here never sees it.
           persist-credentials: false
-          # Empty in check mode, which resolves to the triggering ref.
           ref: ${{ inputs.ref }}
           submodules: true
 
-      - name: Setup Bun
-        uses: stella/.github/actions/setup-bun-cached@2b8697f04b39187c934afc04f7b04ad1a18bd827
-
-      - name: Install dependencies
-        run: bash scripts/bun-ci-retry.sh --ignore-scripts
-        env:
-          NPM_TOKEN: ""
-
-      - name: Prepare environment
-        run: |
-          cd ./apps/api
-          cp .env.example .env
-          cd ../web
-          cp .env.example .env
-
-      - name: Start docker stack and API server
-        id: e2e-stack
-        uses: ./.github/actions/setup-e2e-stack
+      - name: Capture marketing screenshots
+        uses: ./.github/actions/marketing-capture
         with:
+          mode: ${{ inputs.mode }}
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
-          # Document conversion backs the seeded product scenes the captures
-          # render.
-          extra-services: gotenberg
-
-      - name: Require the stack
-        # The action exits 0 with `status=rate-limited` when Docker Hub throttles
-        # the image pulls. The e2e suites accept that skip; this job cannot: it is
-        # the only guard on assets that ship on the marketing site, so a skipped
-        # run would report success without comparing a single PNG. Every later
-        # `status == 'ready'` condition is therefore unreachable-if-false, and
-        # only the `always()` cleanup steps still test it.
-        if: steps.e2e-stack.outputs.status != 'ready'
-        env:
-          STATUS: ${{ steps.e2e-stack.outputs.status }}
-        run: |
-          echo "::error::E2E stack status is '$STATUS', not 'ready'; marketing screenshots were neither compared nor regenerated"
-          exit 1
-
-      - name: Start web dev server
-        run: |
-          cd apps/web
-          nohup bun --bun vite --port 3000 > /tmp/web.log 2>&1 &
-          echo $! > /tmp/web.pid
-
-      - name: Wait for web dev server
-        run: |
-          for i in {1..60}; do
-            if curl --connect-timeout 2 --max-time 5 -sf http://localhost:3000 > /dev/null 2>&1; then
-              echo "Web up after ${i}s"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "::error::Web never came up"
-          tail -200 /tmp/web.log || true
-          exit 1
-
-      - name: Install Playwright browsers
-        uses: ./.github/actions/setup-playwright
-        with:
-          dependency-mode: full
-
-      - name: Seed deterministic marketing content
-        run: bun --filter @stll/api db:seed-dev
-
-      - name: Capture marketing screenshots
-        env:
-          MODE: ${{ inputs.mode }}
-        run: |
-          # The `--update-snapshots` flag lives in the package script alone, so
-          # there is one place that knows how a baseline is rewritten.
-          if [[ "$MODE" == "update" ]]; then
-            bun --filter @stll/web test:e2e:marketing:update
-          else
-            bun --filter @stll/web test:e2e:marketing
-          fi
-
-      - name: Guard against mid-test Vite re-optimize
-        # Before the update-mode commit below: a mid-session reload produces
-        # torn frames, which must never be pushed as a baseline.
-        if: always() && steps.e2e-stack.outputs.status == 'ready'
-        run: |
-          if grep -q "optimized dependencies changed. reloading" /tmp/web.log; then
-            echo "::error::Vite re-optimized dependencies mid-session and forced a reload. Add the lazy/runtime dependency named below to optimizeDeps.include in apps/web/vite.config.ts."
-            grep -nE "new dependencies optimized|optimized dependencies changed" /tmp/web.log || true
-            exit 1
-          fi
-          echo "No mid-session dep re-optimize detected."
-
-      - name: Stop web dev server
-        if: always() && steps.e2e-stack.outputs.status == 'ready'
-        run: |
-          if [[ -f /tmp/web.pid ]]; then
-            kill "$(cat /tmp/web.pid)" || true
-            rm -f /tmp/web.pid
-          fi
 
       - name: Upload regenerated baselines
         # The App token can only push to a branch of this repository, so the
         # PNGs are published unconditionally: a pull request from a fork takes
         # them from here.
-        if: inputs.mode == 'update'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: marketing-screenshots-${{ github.run_id }}
@@ -242,7 +178,6 @@ jobs:
           retention-days: 7
 
       - name: Note the artifact for fork pull requests
-        if: inputs.mode == 'update'
         env:
           ARTIFACT: marketing-screenshots-${{ github.run_id }}
         run: |
@@ -253,7 +188,6 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Push regenerated baselines
-        if: inputs.mode == 'update'
         env:
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
           BRANCH: ${{ inputs.ref || github.ref_name }}
@@ -282,7 +216,7 @@ jobs:
           git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/${BRANCH}"
 
       - name: Upload failure diagnostics
-        if: failure() && steps.e2e-stack.outputs.status == 'ready'
+        if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Mode and run keep the nightly, PR, and dispatched artifacts apart.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -359,8 +359,11 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # Exchange a short-lived npm trusted-publishing credential.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@2b8697f04b39187c934afc04f7b04ad1a18bd827 # package latest-pointer policy
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@48aacae31829ce15216a6b766b03a92fd2e84da3 # release job environment input
     with:
+      # The release App key is an environment secret; the shared job runs in
+      # this environment so only main and release tags can mint the token.
+      environment: release-app
       artifact-pattern: npm-tarball-*
       package-files: ${{ needs.pack.outputs.package_files }}
       source-ref: ${{ needs.pack.outputs.source_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -929,6 +929,8 @@ jobs:
     if: ${{ !contains(needs.resolve.outputs.release_ref, '-') }}
     permissions:
       contents: read
+    # Release App key lives in this environment (main and v* tags only).
+    environment: release-app
     steps:
       # The dispatch runs from a local composite action, so the workspace has
       # to hold the workflow's own revision rather than the release's. This
@@ -992,6 +994,7 @@ jobs:
     if: ${{ contains(needs.resolve.outputs.release_ref, '-rc.') }}
     permissions:
       contents: read
+    environment: release-app
     steps:
       # The workflow's own revision, not the release's: this job can be
       # dispatched manually against a tag cut before the composite action

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -30,6 +30,8 @@ jobs:
     # through the merge-to-main review path.
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # Release App key lives in this environment (main and v* tags only).
+    environment: release-app
     timeout-minutes: 15
     steps:
       - name: Mint App token

--- a/apps/landing/public/media/products/README.md
+++ b/apps/landing/public/media/products/README.md
@@ -21,6 +21,10 @@ Dispatching on `main` is what keeps the release App key on workflow code from
 `main`: only the app and spec code checked out from `branch` is
 branch-controlled, and the token never leaves the push step.
 
+The capture body is the composite action `.github/actions/marketing-capture`
+resolved from the branch, so a branch created before that action existed
+must be rebased onto `main` first.
+
 It regenerates every baseline on the CI runner and pushes them to the branch,
 which re-runs the PR's checks against the new head. Because baselines and
 comparison render on the same runner image, the pixel tolerance only has to

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -42,8 +42,10 @@ describe("API deployment health receipt", () => {
       new URL("../.github/workflows/publish-npm.yml", import.meta.url),
     ).text();
 
+    // Descends from the latest-pointer policy fix and adds the release job
+    // environment input.
     expect(workflow).toContain(
-      "stella/.github/.github/workflows/npm-independent-release.yml@2b8697f04b39187c934afc04f7b04ad1a18bd827 # package latest-pointer policy",
+      "stella/.github/.github/workflows/npm-independent-release.yml@48aacae31829ce15216a6b766b03a92fd2e84da3 # release job environment input",
     );
   });
 

--- a/scripts/detect-e2e-changes.sh
+++ b/scripts/detect-e2e-changes.sh
@@ -11,7 +11,7 @@ fi
 
 for file in "$@"; do
   case "$file" in
-    .github/actions/setup-e2e-stack/*|.github/actions/setup-playwright/*|.github/workflows/ci.yml|.github/workflows/marketing-screenshots.yml|scripts/detect-e2e-changes.sh|bun.lock|package.json|patches/*)
+    .github/actions/setup-e2e-stack/*|.github/actions/setup-playwright/*|.github/actions/marketing-capture/*|.github/workflows/ci.yml|.github/workflows/marketing-screenshots.yml|scripts/detect-e2e-changes.sh|bun.lock|package.json|patches/*)
       echo true
       exit 0
       ;;

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -623,6 +623,9 @@ describe("detect-e2e-changes", () => {
       }
       const jobs = source.slice(jobsStart + "\njobs:".length);
       for (const [, jobId] of jobs.matchAll(/\n {2}([A-Za-z0-9_-]+):\n/gu)) {
+        if (jobId === undefined) {
+          continue;
+        }
         const body = jobOf(jobs, jobId);
         if (!/(?:STELLA_)?RELEASE_APP_PRIVATE_KEY/u.test(body)) {
           continue;

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -604,7 +604,9 @@ describe("detect-e2e-changes", () => {
 
     // A job that calls a reusable workflow cannot declare an environment:
     // GitHub allows only name, uses, with, secrets, needs, if, and
-    // permissions there. Pinned so each exception stays a listed decision.
+    // permissions there. A local reusable declares it on its own job (walked
+    // below); a remote one must be handed the environment name. Pinned so
+    // each caller stays a listed decision.
     const forwardingCallers = new Set([
       "marketing-screenshots-update.yml#update",
       "publish-npm.yml#release",
@@ -633,6 +635,11 @@ describe("detect-e2e-changes", () => {
         const location = `${file}#${jobId}`;
         if (/(?:^|\n) {4}uses: /u.test(body)) {
           seenCallers.add(location);
+          if (!/(?:^|\n) {4}uses: \.\//u.test(body)) {
+            expect(`${location}: ${body}`).toContain(
+              "environment: release-app",
+            );
+          }
           continue;
         }
         expect(`${location}: ${body}`).toContain("environment: release-app");

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 const script = path.join(import.meta.dirname, "detect-e2e-changes.sh");
@@ -43,34 +43,52 @@ const marketingUpdateWorkflow = readFileSync(
   ),
   "utf-8",
 );
+const marketingCapture = readFileSync(
+  path.join(
+    import.meta.dirname,
+    "../.github/actions/marketing-capture/action.yml",
+  ),
+  "utf-8",
+);
 
-const workflowJob = (jobId: string): string => {
+const jobOf = (source: string, jobId: string): string => {
   const marker = `\n  ${jobId}:\n`;
-  const start = workflow.indexOf(marker);
+  const start = source.indexOf(marker);
   if (start === -1) {
-    throw new Error(`CI workflow is missing ${jobId}`);
+    throw new Error(`Workflow is missing job ${jobId}`);
   }
   const bodyStart = start + marker.length;
-  const nextJob = workflow.slice(bodyStart).search(/\n {2}[a-z][\w-]*:\n/u);
+  const nextJob = source.slice(bodyStart).search(/\n {2}[a-z][\w-]*:\n/u);
   return nextJob === -1
-    ? workflow.slice(bodyStart)
-    : workflow.slice(bodyStart, bodyStart + nextJob);
+    ? source.slice(bodyStart)
+    : source.slice(bodyStart, bodyStart + nextJob);
 };
 
-const workflowStep = (job: string, stepName: string): string => {
-  const marker = `\n      - name: ${stepName}\n`;
-  const start = job.indexOf(marker);
+const workflowJob = (jobId: string): string => jobOf(workflow, jobId);
+
+// Workflow steps sit two levels deeper than composite-action steps, so the
+// marker indent is what tells the two apart.
+const stepOf = (source: string, stepName: string, indent: number): string => {
+  const pad = " ".repeat(indent);
+  const marker = `\n${pad}- name: ${stepName}\n`;
+  const start = source.indexOf(marker);
   if (start === -1) {
-    throw new Error(`CI job is missing step ${stepName}`);
+    throw new Error(`Missing step ${stepName}`);
   }
   const bodyStart = start + marker.length;
-  const nextStep = job.slice(bodyStart).search(/\n {6}- name:/u);
-  const step =
-    nextStep === -1
-      ? job.slice(bodyStart)
-      : job.slice(bodyStart, bodyStart + nextStep);
-  return step;
+  const nextStep = source
+    .slice(bodyStart)
+    .search(new RegExp(`\\n {${indent}}- name:`, "u"));
+  return nextStep === -1
+    ? source.slice(bodyStart)
+    : source.slice(bodyStart, bodyStart + nextStep);
 };
+
+const workflowStep = (job: string, stepName: string): string =>
+  stepOf(job, stepName, 6);
+
+const actionStep = (action: string, stepName: string): string =>
+  stepOf(action, stepName, 4);
 
 const workflowStepRun = (job: string, stepName: string): string => {
   const step = workflowStep(job, stepName);
@@ -159,6 +177,7 @@ describe("detect-e2e-changes", () => {
       "packages/locales/src/en.ts",
       "apps/landing/public/media/products/editor.png",
       ".github/workflows/marketing-screenshots.yml",
+      ".github/actions/marketing-capture/action.yml",
     ]) {
       expect(detects("marketing", [file])).toBe("true");
     }
@@ -257,7 +276,8 @@ describe("detect-e2e-changes", () => {
     // what it exercises, so a new consumer cannot quietly widen the stack the
     // PR jobs pay for.
     expect(e2eStackSetup).not.toContain("gotenberg");
-    expect(marketingWorkflow).toContain("extra-services: gotenberg");
+    expect(marketingWorkflow).not.toContain("gotenberg");
+    expect(marketingCapture).toContain("extra-services: gotenberg");
   });
 
   test("skips browser execution only for an explicit Docker Hub pull rate limit", () => {
@@ -408,25 +428,30 @@ describe("detect-e2e-changes", () => {
     );
     expect(marketingUpdateWorkflow).not.toContain("--ref");
 
-    const validate = workflowStep(marketingWorkflow, "Validate inputs");
+    const update = jobOf(marketingWorkflow, "update");
+    const validate = workflowStep(update, "Validate inputs");
     expect(validate).toContain('if [[ "$WORKFLOW_REF" != "main" ]]');
     expect(validate).toContain('if [[ "$BRANCH" == "main" ]]');
     expect(validate).toContain('"$BRANCH" =~ ^[A-Za-z0-9._/-]+$');
     expect(validate).toContain('"$BRANCH" == *".."*');
     expect(validate).toContain('"$BRANCH" == -*');
     // Nothing is minted for a branch that does not exist here.
-    expect(
-      marketingWorkflow.indexOf("- name: Verify the branch exists"),
-    ).toBeLessThan(marketingWorkflow.indexOf("- name: Mint App token"));
+    expect(update.indexOf("- name: Verify the branch exists")).toBeLessThan(
+      update.indexOf("- name: Mint App token"),
+    );
 
     // The checked-out code and the push target are the named branch, never
-    // the ref the workflow itself runs from.
-    expect(workflowStep(marketingWorkflow, "Checkout")).toContain(
+    // the ref the workflow itself runs from. The check job takes no ref and
+    // stays on its triggering one.
+    expect(workflowStep(update, "Checkout")).toContain(
       `ref: ${githubExpression("inputs.ref")}`,
     );
     expect(
-      workflowStep(marketingWorkflow, "Push regenerated baselines"),
-    ).toContain(`BRANCH: ${githubExpression("inputs.ref || github.ref_name")}`);
+      workflowStep(jobOf(marketingWorkflow, "check"), "Checkout"),
+    ).not.toContain("ref:");
+    expect(workflowStep(update, "Push regenerated baselines")).toContain(
+      `BRANCH: ${githubExpression("inputs.ref || github.ref_name")}`,
+    );
 
     // Check-mode callers pass no ref and stay on their own triggering ref.
     expect(workflowJob("marketing-screenshots")).not.toContain("ref:");
@@ -435,7 +460,7 @@ describe("detect-e2e-changes", () => {
 
   test("publishes regenerated baselines a fork pull request can commit itself", () => {
     const upload = workflowStep(
-      marketingWorkflow,
+      jobOf(marketingWorkflow, "update"),
       "Upload regenerated baselines",
     );
     expect(upload).toContain(
@@ -459,17 +484,47 @@ describe("detect-e2e-changes", () => {
     // setup-e2e-stack exits 0 with `status=rate-limited`, which the e2e suites
     // treat as a skip. Here it would report success on assets nothing looked
     // at, so the stack is mandatory.
-    const requireStack = workflowStep(marketingWorkflow, "Require the stack");
+    const requireStack = actionStep(marketingCapture, "Require the stack");
     expect(requireStack).toContain("steps.e2e-stack.outputs.status != 'ready'");
     expect(requireStack).toContain("::error::");
     expect(requireStack).toContain("exit 1");
-    expect(marketingWorkflow.indexOf("- name: Require the stack")).toBeLessThan(
-      marketingWorkflow.indexOf("- name: Start web dev server"),
+    expect(marketingCapture.indexOf("- name: Require the stack")).toBeLessThan(
+      marketingCapture.indexOf("- name: Start web dev server"),
     );
     // No capture, upload, or push step may still carry the skip that step
     // makes fatal; only `always()` cleanup and `failure()` diagnostics test it.
-    expect(marketingWorkflow).not.toContain(
+    expect(marketingCapture).not.toContain(
       "if: steps.e2e-stack.outputs.status == 'ready'",
+    );
+    expect(marketingWorkflow).not.toContain("steps.e2e-stack");
+  });
+
+  test("keeps one capture body behind both screenshot directions", () => {
+    // The shared body is a composite action so check and update cannot drift;
+    // only the checkout differs, because update captures a named branch.
+    expect(
+      marketingWorkflow.match(
+        /uses: \.\/\.github\/actions\/marketing-capture/gu,
+      ),
+    ).toHaveLength(2);
+    expect(marketingWorkflow).not.toContain("test:e2e:marketing");
+    expect(marketingCapture).toContain("test:e2e:marketing:update");
+    // Cleanup and the torn-frame guard stay inside the action so a failed
+    // capture still reports a mid-session reload as the cause.
+    for (const stepName of [
+      "Guard against mid-test Vite re-optimize",
+      "Stop web dev server",
+    ]) {
+      expect(actionStep(marketingCapture, stepName)).toContain("if: always()");
+    }
+    // An unrecognised mode must fail loudly: the check job runs on anything
+    // that is not update, so it reaches this validation instead of leaving
+    // both jobs skipped and green.
+    expect(jobOf(marketingWorkflow, "check")).toContain(
+      "if: inputs.mode != 'update'",
+    );
+    expect(actionStep(marketingCapture, "Validate mode")).toContain(
+      "Unknown marketing screenshot mode",
     );
   });
 
@@ -493,11 +548,11 @@ describe("detect-e2e-changes", () => {
     expect(
       workflow.match(/uses: \.\/\.github\/actions\/setup-playwright/gu),
     ).toHaveLength(3);
-    expect(marketingWorkflow).toContain(
+    expect(marketingCapture).toContain(
       [
         "uses: ./.github/actions/setup-playwright",
-        "        with:",
-        "          dependency-mode: full",
+        "      with:",
+        "        dependency-mode: full",
       ].join("\n"),
     );
     // The nightly and PR checks share that one definition instead of
@@ -535,6 +590,55 @@ describe("detect-e2e-changes", () => {
     );
     expect(playwrightSetup).toContain("if verify_chromium; then");
     expect(playwrightSetup).toContain("bunx playwright install-deps chromium");
+  });
+
+  test("mints the release App token only inside its deployment environment", () => {
+    // The key is an environment secret of `release-app`, whose deployment
+    // policy is main and release tags. A job that reads it without declaring
+    // the environment would be a job the policy never sees, so the census
+    // below covers every workflow rather than the two edited here.
+    expect(jobOf(marketingWorkflow, "update")).toContain(
+      "environment: release-app",
+    );
+    expect(jobOf(marketingWorkflow, "check")).not.toContain("environment:");
+
+    // A job that calls a reusable workflow cannot declare an environment:
+    // GitHub allows only name, uses, with, secrets, needs, if, and
+    // permissions there. Pinned so each exception stays a listed decision.
+    const forwardingCallers = new Set([
+      "marketing-screenshots-update.yml#update",
+      "publish-npm.yml#release",
+    ]);
+    const seenCallers = new Set<string>();
+
+    const workflowsDir = path.join(import.meta.dirname, "../.github/workflows");
+    for (const file of readdirSync(workflowsDir)) {
+      if (!file.endsWith(".yml")) {
+        continue;
+      }
+      const source = readFileSync(path.join(workflowsDir, file), "utf-8");
+      const jobsStart = source.indexOf("\njobs:\n");
+      if (jobsStart === -1) {
+        continue;
+      }
+      const jobs = source.slice(jobsStart + "\njobs:".length);
+      for (const [, jobId] of jobs.matchAll(/\n {2}([A-Za-z0-9_-]+):\n/gu)) {
+        const body = jobOf(jobs, jobId);
+        if (!/(?:STELLA_)?RELEASE_APP_PRIVATE_KEY/u.test(body)) {
+          continue;
+        }
+        const location = `${file}#${jobId}`;
+        if (/(?:^|\n) {4}uses: /u.test(body)) {
+          seenCallers.add(location);
+          continue;
+        }
+        expect(`${location}: ${body}`).toContain("environment: release-app");
+      }
+    }
+
+    // Both directions: an exception that stops existing must be deleted, and
+    // a new caller job must be a deliberate entry rather than a silent skip.
+    expect([...seenCallers].sort()).toEqual([...forwardingCallers].sort());
   });
 
   test("uploads blob reports from the configured Playwright output directory", () => {

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -615,7 +615,7 @@ describe("detect-e2e-changes", () => {
 
     const workflowsDir = path.join(import.meta.dirname, "../.github/workflows");
     for (const file of readdirSync(workflowsDir)) {
-      if (!file.endsWith(".yml")) {
+      if (!(file.endsWith(".yml") || file.endsWith(".yaml"))) {
         continue;
       }
       const source = readFileSync(path.join(workflowsDir, file), "utf-8");


### PR DESCRIPTION
## Summary

The release App private key is now an environment secret of `release-app`, whose deployment policy allows only `main` and `v*` tags. Every job that mints a token from it declares `environment: release-app`, so the key is structurally unavailable to workflow code running on any other ref (previously the runtime `github.ref` gates in each workflow were the only guard).

- `environment: release-app` on the token-minting jobs in `deploy-staging.yml`, `deploy-landing.yml`, `release.yml` (promote, promote-staging), `tag-on-version-bump.yml`.
- `marketing-screenshots.yml` split into `check` (no environment; PR refs) and `update` (`release-app`) jobs sharing a new composite action `marketing-capture` (one capture body for both directions; a mistyped mode fails closed in the check job).
- `publish-npm.yml` forwards the key to the shared reusable in `stella/.github`, which cannot take an environment on the caller; the reusable gained an `environment` input (stella/.github#78) and the pin moves to that commit with `environment: release-app`.
- `detect-e2e-changes.test.ts`: a census over every workflow asserts that each job referencing the key declares the environment, that local-reusable callers are covered by their callee's job, and that remote callers pass the environment name; the caller set is pinned in both directions.

Manual `release.yml` dispatches must now run from `main` or a `v*` tag; the repository-level copy of the key is removed after this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated marketing screenshot checks and baseline updates.
  * Added diagnostics upload when screenshot checks fail.
* **Bug Fixes**
  * Improved detection of changes requiring end-to-end validation.
  * Added safeguards against invalid screenshot update branches and session re-optimisation.
* **Documentation**
  * Documented branch requirements for updating marketing screenshots.
* **Chores**
  * Strengthened release workflows with environment-scoped credentials and updated publishing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->