### PR TITLE
fix(api): accept a corpus-index search response without snippets

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -111,6 +111,19 @@ test("search accepts a response without snippets", async () => {
   }
 });
 
+test("search rejects a response without snippets when snippet fields were requested", async () => {
+  responseBody = { num_hits: 1, hits: [{ id: "a" }] };
+
+  const result = await getCorpusIndexClient().search({
+    indexId: "legal_corpus_v1_cze",
+    query: "text:smlouva",
+    maxHits: 10,
+    snippetFields: ["text"],
+  });
+
+  expect(result.isErr()).toBe(true);
+});
+
 test("search rejects a malformed snippets value", async () => {
   responseBody = { num_hits: 1, hits: [], snippets: "no" };
 

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -88,6 +88,41 @@ test("search sends the documented sort_by parameter", async () => {
   expect(body).not.toHaveProperty("sort_by_field");
 });
 
+test("search accepts a response without snippets", async () => {
+  // A count-only search (`maxHits: 0`, no snippet fields) is answered
+  // without a `snippets` key.
+  responseBody = {
+    num_hits: 1_197_000,
+    hits: [],
+    elapsed_time_micros: 4,
+    errors: [],
+  };
+
+  const result = await getCorpusIndexClient().search({
+    indexId: "legal_corpus_v1_cze",
+    query: "seq:0",
+    maxHits: 0,
+  });
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value.numHits).toBe(1_197_000);
+    expect(result.value.snippets).toEqual([]);
+  }
+});
+
+test("search rejects a malformed snippets value", async () => {
+  responseBody = { num_hits: 1, hits: [], snippets: "no" };
+
+  const result = await getCorpusIndexClient().search({
+    indexId: "legal_corpus_v1_cze",
+    query: "seq:0",
+    maxHits: 0,
+  });
+
+  expect(result.isErr()).toBe(true);
+});
+
 test("search falls back to the shared corpus index endpoint", async () => {
   responseBody = { num_hits: 0, hits: [], snippets: [] };
   Object.assign(envBase, {

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -342,7 +342,12 @@ const buildClient = (): CorpusIndexClient => ({
         }
         const numHits = response["num_hits"];
         const hits = parseRecordArray(response["hits"]);
-        const snippets = parseRecordArray(response["snippets"]);
+        // The engine includes `snippets` only when snippet fields were
+        // requested; a response without the key carries no snippets.
+        const snippets =
+          response["snippets"] === undefined
+            ? []
+            : parseRecordArray(response["snippets"]);
         if (
           typeof numHits !== "number" ||
           !Number.isFinite(numHits) ||

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -343,9 +343,12 @@ const buildClient = (): CorpusIndexClient => ({
         const numHits = response["num_hits"];
         const hits = parseRecordArray(response["hits"]);
         // The engine includes `snippets` only when snippet fields were
-        // requested; a response without the key carries no snippets.
+        // requested: without them a missing key carries no snippets, with
+        // them a missing key is a malformed response.
+        const snippetsRequested =
+          snippetFields !== undefined && snippetFields.length > 0;
         const snippets =
-          response["snippets"] === undefined
+          response["snippets"] === undefined && !snippetsRequested
             ? []
             : parseRecordArray(response["snippets"]);
         if (


### PR DESCRIPTION
The engine includes the `snippets` array only when snippet fields were requested; a count-only search (`max_hits: 0`) is answered without the key, and the parser reported that as an invalid response. A missing key now reads as no snippets; a present non-array value is still refused. Tests cover both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search response handling when snippet data is omitted.
  * Count-only searches now complete successfully without snippet results.
  * Searches requesting snippets continue to report invalid or missing snippet data clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->