### PR TITLE
feat(api): make the reconciliation slice ingest budget a unit option

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -287,12 +287,14 @@ const checkedAtBySlice = async (
 type RunUnitOptions = {
   sourceId: SafeId<"caseLawSource">;
   reconciliation?: SourceReconciliation;
+  sliceIngestBudget?: number;
   /** Shared across turns only where a test is about what a failure leaves. */
   sliceRetries?: SliceRetrySchedule;
 };
 
 const runUnitWith = async ({
   reconciliation = stubReconciliation,
+  sliceIngestBudget,
   sliceRetries = new Map(),
   sourceId,
 }: RunUnitOptions) =>
@@ -306,6 +308,7 @@ const runUnitWith = async ({
     sleep: async () => {
       await Promise.resolve();
     },
+    sliceIngestBudget,
     sliceRetries,
   });
 
@@ -401,6 +404,37 @@ test("a settled slice is touched out of the window so the one behind it is reach
     },
   });
   expect(listed.map(({ slice }) => slice)).toEqual([OWED_SLICE]);
+});
+
+test("a walk ingests no more than the unit's slice budget and defers the rest", async () => {
+  // Two listed misses, a budget of one: the walk fetches one and records the
+  // other as deferred, so the slice stays short and is selected again.
+  const sourceId = await seedSource();
+  await seedSlice({
+    sourceId,
+    slice: OWED_SLICE,
+    reported: 2,
+    collected: 0,
+    checkedAt: addUtcDays(NOW, -2),
+  });
+  for (const offset of [0, -1]) {
+    // oxlint-disable-next-line no-await-in-loop -- fixture seeding, sequential on one pglite handle
+    await seedSlice({
+      sourceId,
+      slice: day(offset),
+      reported: 0,
+      collected: 0,
+      checkedAt: NOW,
+    });
+  }
+
+  const outcome = await runUnitWith({ sourceId, sliceIngestBudget: 1 });
+
+  expect(outcome).toMatchObject({
+    type: "worked",
+    summary: { slice: OWED_SLICE, keyable: 2, parked: 1, deferred: 1 },
+  });
+  expect(builds).toHaveLength(1);
 });
 
 test("a slice the publisher will not serve parks its items rather than storing them", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -16,7 +16,10 @@ import {
   relations,
 } from "@/api/db/schema";
 import type { SliceRetrySchedule } from "@/api/handlers/case-law/ingestion/reconciliation-engine";
-import { runReconciliationWorkUnit } from "@/api/handlers/case-law/ingestion/reconciliation-engine";
+import {
+  MAX_SLICE_INGEST_BUDGET,
+  runReconciliationWorkUnit,
+} from "@/api/handlers/case-law/ingestion/reconciliation-engine";
 import {
   RECONCILIATION_SETTLED_RECHECK_MS,
   SLICE_WALK_REASON,
@@ -435,6 +438,17 @@ test("a walk ingests no more than the unit's slice budget and defers the rest", 
     summary: { slice: OWED_SLICE, keyable: 2, parked: 1, deferred: 1 },
   });
   expect(builds).toHaveLength(1);
+});
+
+test("a slice budget outside 1..MAX is refused before any work", async () => {
+  const sourceId = await seedSource();
+  for (const sliceIngestBudget of [0, MAX_SLICE_INGEST_BUDGET + 1, 1.5]) {
+    // oxlint-disable-next-line no-await-in-loop -- each refusal is asserted in turn
+    await expect(runUnitWith({ sourceId, sliceIngestBudget })).rejects.toThrow(
+      /slice ingest budget/u,
+    );
+  }
+  expect(listed).toHaveLength(0);
 });
 
 test("a slice the publisher will not serve parks its items rather than storing them", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -443,10 +443,20 @@ test("a walk ingests no more than the unit's slice budget and defers the rest", 
 test("a slice budget outside 1..MAX is refused before any work", async () => {
   const sourceId = await seedSource();
   for (const sliceIngestBudget of [0, MAX_SLICE_INGEST_BUDGET + 1, 1.5]) {
+    // Bun's matcher type declares `.rejects.toThrow` as void; capture the
+    // rejection explicitly so type-aware lint and the runtime agree.
     // oxlint-disable-next-line no-await-in-loop -- each refusal is asserted in turn
-    await expect(runUnitWith({ sourceId, sliceIngestBudget })).rejects.toThrow(
-      /slice ingest budget/u,
+    const rejection: unknown = await runUnitWith({
+      sourceId,
+      sliceIngestBudget,
+    }).then(
+      () => null,
+      (error: unknown) => error,
     );
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection).toMatchObject({
+      message: expect.stringContaining("slice ingest budget"),
+    });
   }
   expect(listed).toHaveLength(0);
 });

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
@@ -90,11 +90,12 @@ import { logger } from "@/api/lib/observability/logger";
 /** Parked items rebuilt in one unit; each costs a publisher fetch. */
 const PARKED_RETRY_BATCH = 25;
 /**
- * Decisions ingested per slice walk. A slice the source barely stored can be
- * missing hundreds; the cap keeps one unit finite, and the slice records short
- * afterwards, so it is selected again rather than forgotten.
+ * Decisions ingested per slice walk unless the unit says otherwise. A slice
+ * the source barely stored can be missing hundreds; the cap keeps one unit
+ * finite, and the slice records short afterwards, so it is selected again
+ * rather than forgotten.
  */
-const SLICE_INGEST_BUDGET = 50;
+export const DEFAULT_SLICE_INGEST_BUDGET = 50;
 /** Identity lookups per query, matching the publishers' own page size. */
 const HELD_LOOKUP_CHUNK = 100;
 /** Short ledger rows examined per unit when looking for an unsettled one. */
@@ -209,6 +210,13 @@ export type ReconciliationWorkUnitOptions = {
   now: () => Date;
   /** Gap between two document fetches; the loop's politeness contract. */
   fetchDelayMs: number;
+  /**
+   * Decisions one slice walk may ingest; `DEFAULT_SLICE_INGEST_BUDGET` when
+   * absent. Deployment configuration like the fetch delay: a walk lists the
+   * whole slice whatever the budget, so the budget sets how much of one
+   * listing a unit turns into writes before its deadline.
+   */
+  sliceIngestBudget?: number | undefined;
   sleep: (ms: number) => Promise<void>;
   /** Read and updated in place; see `SliceRetrySchedule`. */
   sliceRetries: SliceRetrySchedule;
@@ -695,6 +703,7 @@ const ingestListedItem = async ({
 type WalkSliceOptions = {
   adapterKey: string;
   fetchDelayMs: number;
+  ingestBudget: number;
   lease: CaseLawSourceIngestionLease;
   now: () => Date;
   reason: SliceWalkReason;
@@ -716,6 +725,7 @@ type WalkSliceOptions = {
 const walkSlice = async ({
   adapterKey,
   fetchDelayMs,
+  ingestBudget,
   lease,
   now,
   reason,
@@ -798,7 +808,7 @@ const walkSlice = async ({
   );
   summary.scheduled = missing.length - untracked.length;
 
-  const fillable = untracked.slice(0, SLICE_INGEST_BUDGET);
+  const fillable = untracked.slice(0, ingestBudget);
   summary.deferred = untracked.length - fillable.length;
   for (const [index, item] of fillable.entries()) {
     if (index > 0) {
@@ -948,9 +958,15 @@ export const runReconciliationWorkUnit = async ({
   reconciliation,
   scopedDb,
   sleep,
+  sliceIngestBudget = DEFAULT_SLICE_INGEST_BUDGET,
   sliceRetries,
   sourceId,
 }: ReconciliationWorkUnitOptions): Promise<ReconciliationUnitOutcome> => {
+  if (!Number.isInteger(sliceIngestBudget) || sliceIngestBudget < 1) {
+    panic(
+      `reconciliation slice ingest budget must be a positive integer: ${sliceIngestBudget}`,
+    );
+  }
   const startedAt = now();
   const tipSlices = tipWindowSlices(reconciliation, startedAt);
   const staleBefore = new Date(
@@ -1082,6 +1098,7 @@ export const runReconciliationWorkUnit = async ({
           summary: await walkSlice({
             adapterKey,
             fetchDelayMs,
+            ingestBudget: sliceIngestBudget,
             lease,
             now,
             reason: unit.reason,

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
@@ -96,6 +96,14 @@ const PARKED_RETRY_BATCH = 25;
  * rather than forgotten.
  */
 export const DEFAULT_SLICE_INGEST_BUDGET = 50;
+/**
+ * The most a unit may be asked to ingest. One walk holds the source lease
+ * for its whole run and the runner's hard deadline ends an overrun by
+ * exiting the process, so the option is bounded here rather than trusted:
+ * a thousand sequential fetches at the loop's politeness gap stay well
+ * inside that deadline.
+ */
+export const MAX_SLICE_INGEST_BUDGET = 1000;
 /** Identity lookups per query, matching the publishers' own page size. */
 const HELD_LOOKUP_CHUNK = 100;
 /** Short ledger rows examined per unit when looking for an unsettled one. */
@@ -211,8 +219,8 @@ export type ReconciliationWorkUnitOptions = {
   /** Gap between two document fetches; the loop's politeness contract. */
   fetchDelayMs: number;
   /**
-   * Decisions one slice walk may ingest; `DEFAULT_SLICE_INGEST_BUDGET` when
-   * absent. Deployment configuration like the fetch delay: a walk lists the
+   * Decisions one slice walk may ingest, at most `MAX_SLICE_INGEST_BUDGET`;
+   * `DEFAULT_SLICE_INGEST_BUDGET` when absent. Deployment configuration like the fetch delay: a walk lists the
    * whole slice whatever the budget, so the budget sets how much of one
    * listing a unit turns into writes before its deadline.
    */
@@ -962,9 +970,13 @@ export const runReconciliationWorkUnit = async ({
   sliceRetries,
   sourceId,
 }: ReconciliationWorkUnitOptions): Promise<ReconciliationUnitOutcome> => {
-  if (!Number.isInteger(sliceIngestBudget) || sliceIngestBudget < 1) {
+  if (
+    !Number.isInteger(sliceIngestBudget) ||
+    sliceIngestBudget < 1 ||
+    sliceIngestBudget > MAX_SLICE_INGEST_BUDGET
+  ) {
     panic(
-      `reconciliation slice ingest budget must be a positive integer: ${sliceIngestBudget}`,
+      `reconciliation slice ingest budget must be an integer in 1..${MAX_SLICE_INGEST_BUDGET}: ${sliceIngestBudget}`,
     );
   }
   const startedAt = now();


### PR DESCRIPTION
## Summary

- \`runReconciliationWorkUnit\` accepts \`sliceIngestBudget\` (positive integer; \`DEFAULT_SLICE_INGEST_BUDGET\` = 50 when absent), threaded into the slice walk.
- A walk lists the whole slice whatever the budget, so the budget only decides how much of one listing a unit turns into writes before its deadline; deployment configuration in the same sense as the fetch delay.
- Test: two listed misses with a budget of one fetch one and defer one (mutation: reading the constant instead of the option fails it).

## Test plan

- [x] \`reconciliation-engine.db.test.ts\` (14 pass, mutation checked)
- [x] lint