### PR TITLE
fix(api): a slice the publisher cannot list no longer stalls the reconciliation sweep

### DIFF
--- a/apps/api/drizzle/20260818150000_case_law_coverage_slice_walk_error/migration.sql
+++ b/apps/api/drizzle/20260818150000_case_law_coverage_slice_walk_error/migration.sql
@@ -16,17 +16,28 @@ SET statement_timeout = '5s';--> statement-breakpoint
 ALTER TABLE "case_law_coverage_slices" ALTER COLUMN "reported" DROP NOT NULL;--> statement-breakpoint
 -- squawk-ignore ban-drop-not-null
 ALTER TABLE "case_law_coverage_slices" ALTER COLUMN "collected" DROP NOT NULL;--> statement-breakpoint
-ALTER TABLE "case_law_coverage_slices" ADD COLUMN "walk_error" text;--> statement-breakpoint
+ALTER TABLE "case_law_coverage_slices" ADD COLUMN IF NOT EXISTS "walk_error" text;--> statement-breakpoint
 
 -- NOT VALID here, VALIDATE below: adding a validating CHECK scans every row
 -- while holding ACCESS EXCLUSIVE. NOT VALID takes the lock only long enough
 -- to record the constraint, which then applies to every later INSERT and
 -- UPDATE. Every existing row has both counts and no error, so both checks
 -- validate without a repair step.
+--
+-- Re-runnable as it stands: everything up to the COMMIT below is committed
+-- before the VALIDATEs and the index build, so a failure after it leaves the
+-- file to run again without Drizzle's migration row. The column add is
+-- guarded, and each constraint is dropped by name and re-added in one
+-- statement, so a second run re-records the same NOT VALID constraint.
+-- stella-migration-safety: reviewed destructive-change - drops only this
+-- migration's own two check constraints by name immediately before
+-- re-adding them; no row data is touched.
 ALTER TABLE "case_law_coverage_slices"
+  DROP CONSTRAINT IF EXISTS "case_law_coverage_slices_counts_pair",
   ADD CONSTRAINT "case_law_coverage_slices_counts_pair"
   CHECK (("reported" IS NULL) = ("collected" IS NULL)) NOT VALID;--> statement-breakpoint
 ALTER TABLE "case_law_coverage_slices"
+  DROP CONSTRAINT IF EXISTS "case_law_coverage_slices_counted_or_failed",
   ADD CONSTRAINT "case_law_coverage_slices_counted_or_failed"
   CHECK ("reported" IS NOT NULL OR "walk_error" IS NOT NULL) NOT VALID;--> statement-breakpoint
 

--- a/apps/api/drizzle/20260818150000_case_law_coverage_slice_walk_error/migration.sql
+++ b/apps/api/drizzle/20260818150000_case_law_coverage_slice_walk_error/migration.sql
@@ -1,0 +1,58 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- A coverage slice whose listing walk fails is now recorded rather than left
+-- without a row: `walk_error` carries the reason, and the counts stay null
+-- until a walk lists it. Recording it is what lets the historical sweep move
+-- past a slice the publisher cannot serve, while the failed rows are retried
+-- on their own cadence.
+-- stella-migration-safety: reviewed destructive-change - drops NOT NULL on the
+-- two count columns so a failed walk can be recorded without counts; the pair
+-- and counted-or-failed checks below keep every existing row's shape valid.
+-- Rollback: delete rows where walk_error is not null, then restore NOT NULL.
+-- The only readers of these columns are the ingestion status endpoint and
+-- the reconciliation engine, both of which read null as "not counted".
+-- squawk-ignore ban-drop-not-null
+ALTER TABLE "case_law_coverage_slices" ALTER COLUMN "reported" DROP NOT NULL;--> statement-breakpoint
+-- squawk-ignore ban-drop-not-null
+ALTER TABLE "case_law_coverage_slices" ALTER COLUMN "collected" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "case_law_coverage_slices" ADD COLUMN "walk_error" text;--> statement-breakpoint
+
+-- NOT VALID here, VALIDATE below: adding a validating CHECK scans every row
+-- while holding ACCESS EXCLUSIVE. NOT VALID takes the lock only long enough
+-- to record the constraint, which then applies to every later INSERT and
+-- UPDATE. Every existing row has both counts and no error, so both checks
+-- validate without a repair step.
+ALTER TABLE "case_law_coverage_slices"
+  ADD CONSTRAINT "case_law_coverage_slices_counts_pair"
+  CHECK (("reported" IS NULL) = ("collected" IS NULL)) NOT VALID;--> statement-breakpoint
+ALTER TABLE "case_law_coverage_slices"
+  ADD CONSTRAINT "case_law_coverage_slices_counted_or_failed"
+  CHECK ("reported" IS NOT NULL OR "walk_error" IS NOT NULL) NOT VALID;--> statement-breakpoint
+
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block, and
+-- a VALIDATE outside the transaction that added the constraint does not hold
+-- the ADD lock for the scan. Split the migrator transaction, lift the
+-- timeouts, then restore and reopen a transaction for Drizzle's migration
+-- row. Same shape as 20260818090000_case_law_decision_date_bounds.
+-- squawk-ignore transaction-nesting
+COMMIT;--> statement-breakpoint
+SET statement_timeout = 0;--> statement-breakpoint
+SET lock_timeout = 0;--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE "case_law_coverage_slices" VALIDATE CONSTRAINT "case_law_coverage_slices_counts_pair";--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE "case_law_coverage_slices" VALIDATE CONSTRAINT "case_law_coverage_slices_counted_or_failed";--> statement-breakpoint
+-- The retry arm reads a source's failed rows oldest-checked first.
+-- stella-migration-safety: reviewed destructive-change - drops only this
+-- migration's own index by name before creating it. A cancelled concurrent
+-- build leaves an INVALID index behind, and IF NOT EXISTS would then skip
+-- recreating it.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_coverage_slices_failed_idx";--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "case_law_coverage_slices_failed_idx" ON "case_law_coverage_slices" ("source_id", "checked_at") WHERE "walk_error" IS NOT NULL;--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+SET lock_timeout = '1s';--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -617,11 +617,21 @@ export const caseLawCoverageSlices = p.pgTable(
       .references(() => caseLawSources.id, { onDelete: "cascade" }),
     /** The crawl slice, e.g. an ISO day for date-cursor adapters. */
     slice: p.varchar({ length: 64 }).notNull(),
-    /** The source's own count for this slice. */
-    reported: p.integer().notNull(),
-    /** What the crawl produced for it. */
-    collected: p.integer().notNull(),
+    /**
+     * The source's own count for this slice; null while the slice has never
+     * been listed successfully (see `walkError`).
+     */
+    reported: p.integer(),
+    /** What the crawl produced for it; null with `reported`. */
+    collected: p.integer(),
     checkedAt: timestamptz("checked_at").defaultNow().notNull(),
+    /**
+     * Why the last listing walk of this slice failed, null when it listed.
+     * A row is either counted or failed, never neither: a slice the publisher
+     * cannot list is still recorded, so the historical sweep moves past it
+     * and the retry arm owns it instead.
+     */
+    walkError: p.text("walk_error"),
   },
   (t) => [
     p
@@ -633,6 +643,19 @@ export const caseLawCoverageSlices = p.pgTable(
       .index("case_law_coverage_slices_short_idx")
       .on(t.sourceId, t.slice)
       .where(sql`${t.collected} < ${t.reported}`),
+    // The retry arm reads failed rows oldest-checked first.
+    p
+      .index("case_law_coverage_slices_failed_idx")
+      .on(t.sourceId, t.checkedAt)
+      .where(sql`${t.walkError} IS NOT NULL`),
+    p.check(
+      "case_law_coverage_slices_counts_pair",
+      sql`(${t.reported} IS NULL) = (${t.collected} IS NULL)`,
+    ),
+    p.check(
+      "case_law_coverage_slices_counted_or_failed",
+      sql`${t.reported} IS NOT NULL OR ${t.walkError} IS NOT NULL`,
+    ),
     ...globalCaseLawPolicies(),
   ],
 );

--- a/apps/api/src/handlers/case-law/ingestion/coverage-ledger.ts
+++ b/apps/api/src/handlers/case-law/ingestion/coverage-ledger.ts
@@ -46,7 +46,49 @@ export const recordSliceCoverage = async (
           reported: coverage.reported,
           collected: coverage.collected,
           checkedAt: sql`now()`,
+          // A slice that lists again is no longer failed, whatever it was.
+          walkError: null,
         },
+      });
+  });
+};
+
+export type RecordSliceWalkFailureInput = {
+  sourceId: SafeId<"caseLawSource">;
+  slice: string;
+  /** Why the walk failed, as the retry arm and an operator will read it. */
+  walkError: string;
+};
+
+/**
+ * Record that a slice's listing walk failed.
+ *
+ * Without a row a failed slice is indistinguishable from one never surveyed,
+ * and the historical sweep, which fills downward from the newest surveyed
+ * slice, would hand it back on every turn and never move past it. The row
+ * keeps whatever counts an earlier walk recorded and stamps `checkedAt`, so
+ * the failed slice leaves the sweep's frontier and the short backlog's stale
+ * window alike and is owned by the retry arm until a walk lists it again.
+ */
+export const recordSliceWalkFailure = async (
+  scopedDb: ScopedDb,
+  { slice, sourceId, walkError }: RecordSliceWalkFailureInput,
+): Promise<void> => {
+  await scopedDb(async (tx) => {
+    // audit: skip — crawl bookkeeping, not a user action
+    await tx
+      .insert(caseLawCoverageSlices)
+      .values({
+        id: createSafeId<"caseLawCoverageSlice">(),
+        sourceId,
+        slice,
+        reported: null,
+        collected: null,
+        walkError,
+      })
+      .onConflictDoUpdate({
+        target: [caseLawCoverageSlices.sourceId, caseLawCoverageSlices.slice],
+        set: { walkError, checkedAt: sql`now()` },
       });
   });
 };

--- a/apps/api/src/handlers/case-law/ingestion/coverage-ledger.ts
+++ b/apps/api/src/handlers/case-law/ingestion/coverage-ledger.ts
@@ -12,7 +12,7 @@
  * describes the latest attempt.
  */
 
-import { sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawCoverageSlices } from "@/api/db/schema";
@@ -50,6 +50,38 @@ export const recordSliceCoverage = async (
           walkError: null,
         },
       });
+  });
+};
+
+export type TouchSliceCoverageInput = {
+  sourceId: SafeId<"caseLawSource">;
+  slice: string;
+};
+
+/**
+ * Re-stamp a counted row's `checkedAt` without touching what it says.
+ *
+ * Bookkeeping outside the source lease, so it must not overwrite what a
+ * leased walk on another replica may have recorded since the row was read:
+ * the counts stay, and a row that has meanwhile failed is left to the retry
+ * arm rather than quietly restored to counted.
+ */
+export const touchSliceCoverage = async (
+  scopedDb: ScopedDb,
+  { slice, sourceId }: TouchSliceCoverageInput,
+): Promise<void> => {
+  await scopedDb(async (tx) => {
+    // audit: skip — crawl bookkeeping, not a user action
+    await tx
+      .update(caseLawCoverageSlices)
+      .set({ checkedAt: sql`now()` })
+      .where(
+        and(
+          eq(caseLawCoverageSlices.sourceId, sourceId),
+          eq(caseLawCoverageSlices.slice, slice),
+          isNull(caseLawCoverageSlices.walkError),
+        ),
+      );
   });
 };
 

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -813,6 +813,45 @@ test("a slice the publisher will not list is recorded, and the sweep moves past 
   expect(listed.map(({ slice }) => slice)).toEqual([refused, behind]);
 });
 
+test("a failed walk of a counted slice keeps its counts and marks it failed", async () => {
+  // A short row the backlog owes, whose publisher then refuses it: the row
+  // must not lose what the last successful listing said, and it must leave
+  // the backlog's window for the retry arm's.
+  const sourceId = await seedSource();
+  await seedFreshTip(sourceId);
+  await seedSlice({
+    sourceId,
+    slice: OWED_SLICE,
+    reported: 2,
+    collected: 0,
+    checkedAt: addUtcDays(NOW, -2),
+  });
+
+  const rejection = await runUnitWith({
+    sourceId,
+    reconciliation: unwalkableSliceStub,
+  }).then(
+    () => null,
+    (error: unknown) => error,
+  );
+  expect(rejection).toBeInstanceOf(AdapterFetchError);
+  expect(await ledgerRow(sourceId, OWED_SLICE)).toEqual({
+    reported: 2,
+    collected: 0,
+    walkError: "AdapterFetchError: listing refused",
+  });
+
+  // A fresh process (no hold) with the same publisher: the failed row is
+  // resting, the backlog no longer offers it, and the source is idle.
+  expect(
+    await runUnitWith({
+      sourceId,
+      reconciliation: unwalkableSliceStub,
+      sliceRetries: new Map(),
+    }),
+  ).toEqual({ type: "idle" });
+});
+
 test("a failed slice is walked again once it has rested, and a listing clears it", async () => {
   const sourceId = await seedSource();
   await seedFreshTip(sourceId);

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -21,6 +21,7 @@ import {
   runReconciliationWorkUnit,
 } from "@/api/handlers/case-law/ingestion/reconciliation-engine";
 import {
+  RECONCILIATION_FAILED_SLICE_RETRY_MS,
   RECONCILIATION_SETTLED_RECHECK_MS,
   SLICE_WALK_REASON,
 } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
@@ -761,6 +762,103 @@ test("a slice the publisher will not serve does not hold the ones behind it", as
   expect(listed.map(({ slice }) => slice)).toEqual([OWED_SLICE, reachable]);
 });
 
+/** The stub publisher, refusing to list exactly one slice. */
+const refusingSlice = (refused: string): SourceReconciliation => ({
+  ...stubReconciliation,
+  listSlicePage: async (options): Promise<ReconciliationSlicePage> => {
+    listed.push(options);
+    if (options.slice === refused) {
+      throw new AdapterFetchError({
+        message: "listing refused",
+        adapterKey: "engine-fixture",
+        cursor: options.slice,
+      });
+    }
+    return await Promise.resolve({ items: [], totalPages: 1 });
+  },
+});
+
+test("a slice the publisher will not list is recorded, and the sweep moves past it", async () => {
+  // The sweep fills downward from the newest surveyed slice. Without a row
+  // for the refused slice it stays the frontier, and the sweep offers it on
+  // every turn its hold allows and nothing else in between: one slice the
+  // publisher cannot serve ends the survey of everything older. Recording
+  // the failure moves the frontier past it.
+  const sourceId = await seedSource();
+  await seedFreshTip(sourceId);
+  const refused = day(-TIP_WINDOW_DAYS);
+  const behind = stepDay(refused, -1);
+  const options = {
+    sourceId,
+    reconciliation: refusingSlice(refused),
+    sliceRetries: new Map(),
+  };
+
+  const rejection = await runUnitWith(options).then(
+    () => null,
+    (error: unknown) => error,
+  );
+  expect(rejection).toBeInstanceOf(AdapterFetchError);
+  expect(await ledgerRow(sourceId, refused)).toEqual({
+    reported: null,
+    collected: null,
+    walkError: "AdapterFetchError: listing refused",
+  });
+
+  // The next turn sweeps the slice behind the refused one.
+  expect(await runUnitWith(options)).toMatchObject({
+    type: "worked",
+    summary: { slice: behind, reason: SLICE_WALK_REASON.SWEEP },
+  });
+  expect(listed.map(({ slice }) => slice)).toEqual([refused, behind]);
+});
+
+test("a failed slice is walked again once it has rested, and a listing clears it", async () => {
+  const sourceId = await seedSource();
+  await seedFreshTip(sourceId);
+  // The feed's first slice, so the sweep has nothing left to offer and the
+  // retry arm is what answers the turn.
+  await db.insert(caseLawCoverageSlices).values({
+    id: createSafeId<"caseLawCoverageSlice">(),
+    sourceId,
+    slice: OWED_SLICE,
+    reported: null,
+    collected: null,
+    walkError: "AdapterFetchError: listing refused",
+    checkedAt: new Date(
+      NOW.getTime() - RECONCILIATION_FAILED_SLICE_RETRY_MS - DAY_IN_MS,
+    ),
+  });
+
+  expect(await runUnit(sourceId)).toMatchObject({
+    type: "worked",
+    summary: { slice: OWED_SLICE, reason: SLICE_WALK_REASON.RETRY, keyable: 2 },
+  });
+  // Listed again: counted, no longer failed.
+  expect(await ledgerRow(sourceId, OWED_SLICE)).toEqual({
+    reported: 2,
+    collected: 0,
+    walkError: null,
+  });
+});
+
+test("a failed slice still resting is left alone", async () => {
+  const sourceId = await seedSource();
+  await seedFreshTip(sourceId);
+  await db.insert(caseLawCoverageSlices).values({
+    id: createSafeId<"caseLawCoverageSlice">(),
+    sourceId,
+    slice: OWED_SLICE,
+    reported: null,
+    collected: null,
+    walkError: "AdapterFetchError: listing refused",
+    checkedAt: addUtcDays(NOW, 0),
+  });
+
+  expect(await runUnit(sourceId)).toEqual({ type: "idle" });
+  expect(listed).toHaveLength(0);
+});
+
 test("held slices are excluded from the backlog window, not filtered after it", async () => {
   // The backlog read is a bounded oldest-first window. A held row filtered
   // out afterwards still occupies a place in it, so a full window of held
@@ -823,15 +921,22 @@ const seedSettledHistory = async (
   });
 };
 
+type LedgerRowRead = {
+  reported: number | null;
+  collected: number | null;
+  walkError: string | null;
+};
+
 const ledgerRow = async (
   sourceId: SafeId<"caseLawSource">,
   slice: string,
-): Promise<{ reported: number; collected: number } | undefined> =>
+): Promise<LedgerRowRead | undefined> =>
   (
     await db
       .select({
         reported: caseLawCoverageSlices.reported,
         collected: caseLawCoverageSlices.collected,
+        walkError: caseLawCoverageSlices.walkError,
       })
       .from(caseLawCoverageSlices)
       .where(
@@ -868,6 +973,7 @@ test("a settled slice past the recheck window is re-walked, and a grown listing 
   expect(await ledgerRow(sourceId, OWED_SLICE)).toEqual({
     reported: 2,
     collected: 0,
+    walkError: null,
   });
 });
 

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
@@ -46,6 +46,7 @@ import {
 import {
   recordSliceCoverage,
   recordSliceWalkFailure,
+  touchSliceCoverage,
 } from "@/api/handlers/case-law/ingestion/coverage-ledger";
 import {
   allocateSourceObservationOrder,
@@ -195,17 +196,14 @@ export type ReconciliationUnitOutcome =
   | { type: "leased" };
 
 /**
- * How long a slice whose walk threw is held out of the selection order.
- *
  * How long this process holds a slice whose walk threw before offering it
  * again. The ledger records the failure durably and re-tests it on its own
- * cadence (`RECONCILIATION_FAILED_SLICE_RETRY_MS`); this hold is for the tip,
- * which is re-derived from the clock each turn and would otherwise be handed
- * straight back. An hour is the trade: short against the tip's daily
- * staleness, so a publisher that recovers is picked up within the same
- * cadence the slice would have been walked on anyway, and long enough that a
- * tip slice nothing can serve costs its source one turn an hour instead of
- * one a minute.
+ * cadence (`RECONCILIATION_FAILED_SLICE_RETRY_MS`, and the tip's own
+ * staleness for tip slices); this hold is the process's short memory of a
+ * failure it has just seen, so a walk whose ledger write itself failed is not
+ * handed straight back. An hour: short against the daily cadences, long
+ * enough that a slice nothing can serve costs its source one turn an hour
+ * instead of one a minute.
  */
 export const RECONCILIATION_SLICE_RETRY_MS = 60 * 60_000;
 
@@ -449,26 +447,28 @@ const countedLedgerSlice = ({
   return { slice, reported, collected, checkedAt };
 };
 
+type TipCheckedAt = { slice: string; checkedAt: Date };
+
 /**
- * Counted ledger rows for the named slices. Bounded by the tip window. A tip
- * slice whose last walk failed is absent here on purpose: absent is what the
- * tip arm walks, and the retry hold is what keeps it from walking it at once.
+ * When each of the named slices was last walked, counted or failed alike.
+ * Bounded by the tip window. A failed tip row keeps its `checkedAt` here on
+ * purpose: the tip arm walks a slice once it is stale, so a tip slice whose
+ * walk failed rests the tip's own day, on every replica and across restarts,
+ * rather than being taken for never walked and offered straight back.
  */
-const selectLedgerSlices = async (
+const selectTipCheckedAt = async (
   scopedDb: ScopedDb,
   sourceId: SafeId<"caseLawSource">,
   slices: readonly string[],
-): Promise<LedgerSlice[]> => {
+): Promise<TipCheckedAt[]> => {
   if (slices.length === 0) {
     return [];
   }
-  const rows = await scopedDb(
+  return await scopedDb(
     async (tx) =>
       await tx
         .select({
           slice: caseLawCoverageSlices.slice,
-          reported: caseLawCoverageSlices.reported,
-          collected: caseLawCoverageSlices.collected,
           checkedAt: caseLawCoverageSlices.checkedAt,
         })
         .from(caseLawCoverageSlices)
@@ -476,12 +476,10 @@ const selectLedgerSlices = async (
           and(
             eq(caseLawCoverageSlices.sourceId, sourceId),
             inArray(caseLawCoverageSlices.slice, [...slices]),
-            isNull(caseLawCoverageSlices.walkError),
           ),
         )
         .limit(slices.length),
   );
-  return rows.map(countedLedgerSlice);
 };
 
 type SelectStaleShortSlicesOptions = {
@@ -1096,14 +1094,14 @@ export const runReconciliationWorkUnit = async ({
   const heldSlices = [...sliceRetries.keys()];
 
   const [
-    tipLedger,
+    tipCheckedAt,
     shortRows,
     oldestLedgerSlice,
     dueParked,
     recheckCandidate,
     failedCandidate,
   ] = await Promise.all([
-    selectLedgerSlices(scopedDb, sourceId, tipSlices),
+    selectTipCheckedAt(scopedDb, sourceId, tipSlices),
     selectStaleShortSlices(scopedDb, { sourceId, staleBefore, heldSlices }),
     selectOldestLedgerSlice(scopedDb, sourceId),
     hasDueParkedItems(scopedDb, sourceId, startedAt),
@@ -1147,12 +1145,9 @@ export const runReconciliationWorkUnit = async ({
   // Not a work unit: touching is bookkeeping, and selection continues over
   // whatever is genuinely owed in the same iteration. Outside the lease, like
   // the crawl's own ledger writes.
-  for (const { collected, reported, slice } of settled) {
-    // oxlint-disable-next-line no-await-in-loop -- bounded by the candidate window; sequential upserts on one scoped connection rather than a fan-out
-    await recordSliceCoverage(scopedDb, {
-      sourceId,
-      coverage: { slice, reported, collected },
-    });
+  for (const { slice } of settled) {
+    // oxlint-disable-next-line no-await-in-loop -- bounded by the candidate window; sequential updates on one scoped connection rather than a fan-out
+    await touchSliceCoverage(scopedDb, { sourceId, slice });
   }
 
   // The sweep frontier: the oldest slice with any row, bounded above by the
@@ -1167,7 +1162,7 @@ export const runReconciliationWorkUnit = async ({
     hasDueParkedItems: dueParked,
     tipSlices,
     tipCheckedAt: new Map(
-      tipLedger.map(({ slice, checkedAt }) => [slice, checkedAt]),
+      tipCheckedAt.map(({ slice, checkedAt }) => [slice, checkedAt]),
     ),
     unsettledShortSlices: unsettled,
     failedCandidate,

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
@@ -30,6 +30,7 @@ import {
   eq,
   gte,
   inArray,
+  isNotNull,
   isNull,
   lt,
   min,
@@ -42,18 +43,23 @@ import {
   caseLawDecisions,
   RECONCILIATION_ITEM_STATUS,
 } from "@/api/db/schema";
-import { recordSliceCoverage } from "@/api/handlers/case-law/ingestion/coverage-ledger";
+import {
+  recordSliceCoverage,
+  recordSliceWalkFailure,
+} from "@/api/handlers/case-law/ingestion/coverage-ledger";
 import {
   allocateSourceObservationOrder,
   PROCESS_DECISION_STATUS,
   processDecision,
 } from "@/api/handlers/case-law/ingestion/pipeline";
 import type {
+  FailedSliceCandidate,
   LedgerSlice,
   ReconciliationWorkUnit,
   SliceWalkReason,
 } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import {
+  RECONCILIATION_FAILED_SLICE_RETRY_MS,
   RECONCILIATION_SETTLED_RECHECK_MS,
   RECONCILIATION_SLICE_STALE_MS,
   partitionShortSliceCandidates,
@@ -191,14 +197,26 @@ export type ReconciliationUnitOutcome =
 /**
  * How long a slice whose walk threw is held out of the selection order.
  *
- * The walk writes nothing when it fails, so the slice is owed exactly as much
- * afterwards as before and the selection would hand it back on the next turn
- * forever. An hour is the trade: short against the tip's daily staleness, so a
- * publisher that recovers is picked up within the same cadence the slice would
- * have been walked on anyway, and long enough that a slice nothing can serve
- * costs its source one turn an hour instead of one a minute.
+ * How long this process holds a slice whose walk threw before offering it
+ * again. The ledger records the failure durably and re-tests it on its own
+ * cadence (`RECONCILIATION_FAILED_SLICE_RETRY_MS`); this hold is for the tip,
+ * which is re-derived from the clock each turn and would otherwise be handed
+ * straight back. An hour is the trade: short against the tip's daily
+ * staleness, so a publisher that recovers is picked up within the same
+ * cadence the slice would have been walked on anyway, and long enough that a
+ * tip slice nothing can serve costs its source one turn an hour instead of
+ * one a minute.
  */
 export const RECONCILIATION_SLICE_RETRY_MS = 60 * 60_000;
+
+/** Longest `walk_error` text recorded; the ledger is a note, not a log. */
+const WALK_ERROR_MAX_LENGTH = 500;
+
+/** The failure as the ledger records it: its tag, then its message. */
+const describeWalkError = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error);
+  return `${errorTag(error)}: ${message}`.slice(0, WALK_ERROR_MAX_LENGTH);
+};
 
 /**
  * When each slice whose walk threw may be tried again, by slice.
@@ -406,7 +424,36 @@ const selectHeldIdentityKeys = async (
   return held;
 };
 
-/** Ledger rows for the named slices. Bounded by the tip window. */
+type LedgerRow = {
+  slice: string;
+  reported: number | null;
+  collected: number | null;
+  checkedAt: Date;
+};
+
+/**
+ * The counted shape of a ledger row. Every read below that hands rows to the
+ * selection filters on `walk_error IS NULL`, and the table's counted-or-failed
+ * check makes both counts present on such a row; a null here is a violated
+ * invariant, not a case.
+ */
+const countedLedgerSlice = ({
+  checkedAt,
+  collected,
+  reported,
+  slice,
+}: LedgerRow): LedgerSlice => {
+  if (reported === null || collected === null) {
+    panic(`coverage slice ${slice} is neither counted nor failed`);
+  }
+  return { slice, reported, collected, checkedAt };
+};
+
+/**
+ * Counted ledger rows for the named slices. Bounded by the tip window. A tip
+ * slice whose last walk failed is absent here on purpose: absent is what the
+ * tip arm walks, and the retry hold is what keeps it from walking it at once.
+ */
 const selectLedgerSlices = async (
   scopedDb: ScopedDb,
   sourceId: SafeId<"caseLawSource">,
@@ -415,7 +462,7 @@ const selectLedgerSlices = async (
   if (slices.length === 0) {
     return [];
   }
-  return await scopedDb(
+  const rows = await scopedDb(
     async (tx) =>
       await tx
         .select({
@@ -429,10 +476,12 @@ const selectLedgerSlices = async (
           and(
             eq(caseLawCoverageSlices.sourceId, sourceId),
             inArray(caseLawCoverageSlices.slice, [...slices]),
+            isNull(caseLawCoverageSlices.walkError),
           ),
         )
         .limit(slices.length),
   );
+  return rows.map(countedLedgerSlice);
 };
 
 type SelectStaleShortSlicesOptions = {
@@ -455,8 +504,8 @@ type SelectStaleShortSlicesOptions = {
 const selectStaleShortSlices = async (
   scopedDb: ScopedDb,
   { heldSlices, sourceId, staleBefore }: SelectStaleShortSlicesOptions,
-): Promise<LedgerSlice[]> =>
-  await scopedDb(
+): Promise<LedgerSlice[]> => {
+  const rows = await scopedDb(
     async (tx) =>
       await tx
         .select({
@@ -470,6 +519,8 @@ const selectStaleShortSlices = async (
           and(
             eq(caseLawCoverageSlices.sourceId, sourceId),
             lt(caseLawCoverageSlices.collected, caseLawCoverageSlices.reported),
+            // A short row whose later walk failed belongs to the retry arm.
+            isNull(caseLawCoverageSlices.walkError),
             // eslint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- staleness cutoff derived from the clock, not a cursor boundary: a slice landing within a microsecond of it is walked one turn earlier or later, which the widening tip cadence already tolerates
             lt(caseLawCoverageSlices.checkedAt, staleBefore),
             heldSlices.length === 0
@@ -480,6 +531,8 @@ const selectStaleShortSlices = async (
         .orderBy(caseLawCoverageSlices.checkedAt)
         .limit(SHORT_SLICE_CANDIDATES),
   );
+  return rows.map(countedLedgerSlice);
+};
 
 /**
  * The oldest-checked settled slice below the tip window, or null. Whether it
@@ -525,8 +578,8 @@ type SelectRecheckCandidateOptions = {
 const selectRecheckCandidate = async (
   scopedDb: ScopedDb,
   { belowSlice, heldSlices, sourceId }: SelectRecheckCandidateOptions,
-): Promise<LedgerSlice | null> =>
-  (
+): Promise<LedgerSlice | null> => {
+  const row = (
     await scopedDb(
       async (tx) =>
         await tx
@@ -545,6 +598,47 @@ const selectRecheckCandidate = async (
                 caseLawCoverageSlices.collected,
                 caseLawCoverageSlices.reported,
               ),
+              isNull(caseLawCoverageSlices.walkError),
+              heldSlices.length === 0
+                ? undefined
+                : notInArray(caseLawCoverageSlices.slice, heldSlices),
+            ),
+          )
+          .orderBy(caseLawCoverageSlices.checkedAt)
+          .limit(1),
+    )
+  ).at(0);
+  return row === undefined ? null : countedLedgerSlice(row);
+};
+
+type SelectFailedSliceCandidateOptions = {
+  sourceId: SafeId<"caseLawSource">;
+  /** Held slices, excluded for the same reason the recheck excludes them. */
+  heldSlices: string[];
+};
+
+/**
+ * The oldest-checked slice whose last walk failed, or null. Whether it has
+ * rested long enough is the selection's decision, not this query's. Served by
+ * the ledger's failed partial index.
+ */
+const selectFailedSliceCandidate = async (
+  scopedDb: ScopedDb,
+  { heldSlices, sourceId }: SelectFailedSliceCandidateOptions,
+): Promise<FailedSliceCandidate | null> =>
+  (
+    await scopedDb(
+      async (tx) =>
+        await tx
+          .select({
+            slice: caseLawCoverageSlices.slice,
+            checkedAt: caseLawCoverageSlices.checkedAt,
+          })
+          .from(caseLawCoverageSlices)
+          .where(
+            and(
+              eq(caseLawCoverageSlices.sourceId, sourceId),
+              isNotNull(caseLawCoverageSlices.walkError),
               heldSlices.length === 0
                 ? undefined
                 : notInArray(caseLawCoverageSlices.slice, heldSlices),
@@ -1001,22 +1095,29 @@ export const runReconciliationWorkUnit = async ({
   }
   const heldSlices = [...sliceRetries.keys()];
 
-  const [tipLedger, shortRows, oldestLedgerSlice, dueParked, recheckCandidate] =
-    await Promise.all([
-      selectLedgerSlices(scopedDb, sourceId, tipSlices),
-      selectStaleShortSlices(scopedDb, { sourceId, staleBefore, heldSlices }),
-      selectOldestLedgerSlice(scopedDb, sourceId),
-      hasDueParkedItems(scopedDb, sourceId, startedAt),
-      // Asked every turn rather than only once the higher priorities come up
-      // empty: idle is the steady state of a surveyed source, so the branch
-      // that skipped it would almost never be taken, and one more bounded read
-      // in the batch already in flight costs no extra round trip.
-      selectRecheckCandidate(scopedDb, {
-        sourceId,
-        belowSlice: tipStart,
-        heldSlices,
-      }),
-    ]);
+  const [
+    tipLedger,
+    shortRows,
+    oldestLedgerSlice,
+    dueParked,
+    recheckCandidate,
+    failedCandidate,
+  ] = await Promise.all([
+    selectLedgerSlices(scopedDb, sourceId, tipSlices),
+    selectStaleShortSlices(scopedDb, { sourceId, staleBefore, heldSlices }),
+    selectOldestLedgerSlice(scopedDb, sourceId),
+    hasDueParkedItems(scopedDb, sourceId, startedAt),
+    // Asked every turn rather than only once the higher priorities come up
+    // empty: idle is the steady state of a surveyed source, so the branch
+    // that skipped it would almost never be taken, and one more bounded read
+    // in the batch already in flight costs no extra round trip.
+    selectRecheckCandidate(scopedDb, {
+      sourceId,
+      belowSlice: tipStart,
+      heldSlices,
+    }),
+    selectFailedSliceCandidate(scopedDb, { sourceId, heldSlices }),
+  ]);
 
   const terminalBySlice = await countTerminalReconciliationItemsBySlice(
     scopedDb,
@@ -1069,11 +1170,13 @@ export const runReconciliationWorkUnit = async ({
       tipLedger.map(({ slice, checkedAt }) => [slice, checkedAt]),
     ),
     unsettledShortSlices: unsettled,
+    failedCandidate,
     sweepSlice: reconciliation.previousSlice(frontier),
     recheckCandidate,
     slicesHeldForRetry: new Set(heldSlices),
     staleAfterMs: RECONCILIATION_SLICE_STALE_MS,
     recheckAfterMs: RECONCILIATION_SETTLED_RECHECK_MS,
+    failedRetryAfterMs: RECONCILIATION_FAILED_SLICE_RETRY_MS,
   });
 
   if (unit.type === "idle") {
@@ -1119,22 +1222,30 @@ export const runReconciliationWorkUnit = async ({
             slice: unit.slice,
             sleep,
             sourceId,
-          }).catch((error: unknown) => {
+          }).catch(async (error: unknown) => {
             // The walk is all-or-nothing by design: a listing that failed part
-            // way through writes no ledger row, so the slice is owed exactly
-            // as much as before and would be selected again immediately. Held
-            // for its retry instead, and named here because the loop's window
-            // tally reports how many turns threw without saying over what;
-            // the slice a source cannot walk is the one fact that turns a
-            // standing error rate into something an operator can reproduce.
-            // Measured from the failure, not from the unit's start: a slice
-            // is several paginated requests and a walk can spend most of the
-            // runner's deadline before it throws, which would leave the hold
-            // shorter than it says or already expired.
+            // way through writes no counts, so the slice is owed exactly as
+            // much as before. Recorded as failed, so the sweep's frontier and
+            // the backlog move past it and the retry arm owns it; and held in
+            // this process for its retry, because the tip is re-derived from
+            // the clock and would otherwise be handed straight back. Named
+            // here because the loop's window tally reports how many turns
+            // threw without saying over what; the slice a source cannot walk
+            // is the one fact that turns a standing error rate into something
+            // an operator can reproduce. Measured from the failure, not from
+            // the unit's start: a slice is several paginated requests and a
+            // walk can spend most of the runner's deadline before it throws,
+            // which would leave the hold shorter than it says or already
+            // expired.
             sliceRetries.set(
               unit.slice,
               now().getTime() + RECONCILIATION_SLICE_RETRY_MS,
             );
+            await recordSliceWalkFailure(scopedDb, {
+              sourceId,
+              slice: unit.slice,
+              walkError: describeWalkError(error),
+            });
             logger.warn("case_law.reconciliation.slice_failed", {
               adapterKey,
               slice: unit.slice,

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.test.ts
@@ -20,12 +20,14 @@ import { DAY_IN_MS } from "@stll/time";
 import { czRegionalAdapter } from "@/api/handlers/case-law/ingestion/adapters/cz-regional";
 import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
 import type {
+  FailedSliceCandidate,
   LedgerSlice,
   ShortSliceCandidate,
   SelectReconciliationWorkUnitInput,
   SliceWalkReason,
 } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import {
+  RECONCILIATION_FAILED_SLICE_RETRY_MS,
   RECONCILIATION_SETTLED_RECHECK_MS,
   RECONCILIATION_SLICE_STALE_MS,
   SLICE_WALK_REASON,
@@ -54,13 +56,25 @@ const baseInput = (
   tipSlices: [],
   tipCheckedAt: new Map(),
   unsettledShortSlices: [],
+  failedCandidate: null,
   sweepSlice: null,
   recheckCandidate: null,
   slicesHeldForRetry: new Set(),
   staleAfterMs: RECONCILIATION_SLICE_STALE_MS,
   recheckAfterMs: RECONCILIATION_SETTLED_RECHECK_MS,
+  failedRetryAfterMs: RECONCILIATION_FAILED_SLICE_RETRY_MS,
   ...overrides,
 });
+
+/** A ledger row whose last walk failed at `checkedAt`. */
+const failedCandidate = (checkedAt: Date): FailedSliceCandidate => ({
+  slice: "2024-02-02",
+  checkedAt,
+});
+
+const RESTED = new Date(
+  NOW.getTime() - RECONCILIATION_FAILED_SLICE_RETRY_MS - 60_000,
+);
 
 /** A settled ledger row, checked long enough ago to be worth proving again. */
 const recheckCandidate = (checkedAt: Date): LedgerSlice => ({
@@ -346,6 +360,7 @@ describe("selectReconciliationWorkUnit", () => {
       { hasDueParkedItems: true },
       { tipSlices: ["2026-08-11"], tipCheckedAt: new Map<string, Date>() },
       { unsettledShortSlices: [shortSlice()] },
+      { failedCandidate: failedCandidate(RESTED) },
       { sweepSlice: "2023-06-01" },
     ] as const satisfies readonly Partial<SelectReconciliationWorkUnitInput>[];
 
@@ -371,6 +386,9 @@ describe("selectReconciliationWorkUnit", () => {
       [SLICE_WALK_REASON.SHORT]: baseInput({
         unsettledShortSlices: [shortSlice()],
       }),
+      [SLICE_WALK_REASON.RETRY]: baseInput({
+        failedCandidate: failedCandidate(RESTED),
+      }),
       [SLICE_WALK_REASON.SWEEP]: baseInput({ sweepSlice: "2023-06-01" }),
       [SLICE_WALK_REASON.RECHECK]: baseInput({
         recheckCandidate: recheckCandidate(LONG_SETTLED),
@@ -386,6 +404,56 @@ describe("selectReconciliationWorkUnit", () => {
         reason,
       });
     }
+  });
+});
+
+describe("a slice whose last walk failed", () => {
+  // The failure is recorded in the ledger, so the sweep and the backlog move
+  // on around it; what remains to decide is when it is tried again, and that
+  // it is tried ahead of new history but never ahead of work something owes.
+  test("is walked again once it has rested, ahead of the sweep", () => {
+    expect(
+      selectReconciliationWorkUnit(
+        baseInput({
+          failedCandidate: failedCandidate(RESTED),
+          sweepSlice: "2023-06-01",
+        }),
+      ),
+    ).toEqual({
+      type: "slice",
+      slice: "2024-02-02",
+      reason: SLICE_WALK_REASON.RETRY,
+    });
+  });
+
+  test("still resting, it yields to the sweep", () => {
+    expect(
+      selectReconciliationWorkUnit(
+        baseInput({
+          failedCandidate: failedCandidate(
+            new Date(
+              NOW.getTime() - RECONCILIATION_FAILED_SLICE_RETRY_MS + 60_000,
+            ),
+          ),
+          sweepSlice: "2023-06-01",
+        }),
+      ),
+    ).toEqual({
+      type: "slice",
+      slice: "2023-06-01",
+      reason: SLICE_WALK_REASON.SWEEP,
+    });
+  });
+
+  test("held in this process, it yields even when rested", () => {
+    expect(
+      selectReconciliationWorkUnit(
+        baseInput({
+          failedCandidate: failedCandidate(RESTED),
+          slicesHeldForRetry: new Set(["2024-02-02"]),
+        }),
+      ),
+    ).toEqual({ type: "idle" });
   });
 });
 

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-plan.ts
@@ -43,12 +43,25 @@ export const RECONCILIATION_SLICE_STALE_MS = DAY_IN_MS;
  */
 export const RECONCILIATION_SETTLED_RECHECK_MS = 30 * DAY_IN_MS;
 
+/**
+ * How long a slice whose last walk failed rests before it is walked again.
+ *
+ * A failed walk records its slice, so the source's other work goes on around
+ * it; this decides only how soon the failure is re-tested. A day: the tip's
+ * own cadence, and long enough that a slice nothing can list costs one turn a
+ * day rather than one an hour, while a publisher fix or an adapter release
+ * is picked up within the same day.
+ */
+export const RECONCILIATION_FAILED_SLICE_RETRY_MS = DAY_IN_MS;
+
 /** Why a slice was chosen, for the summary and nothing else. */
 export const SLICE_WALK_REASON = {
   /** Inside the tip window, where the publisher is still filling in. */
   TIP: "tip",
   /** Held fewer identities than were listed, and the row has gone stale. */
   SHORT: "short",
+  /** Its last walk failed and the retry has come due. */
+  RETRY: "retry",
   /** Never surveyed at all; the sweep works backward through history. */
   SWEEP: "sweep",
   /** Settled long ago; walked again to prove the ledger still describes it. */
@@ -191,19 +204,23 @@ export type SelectReconciliationWorkUnitInput = {
    * touch the row.
    */
   unsettledShortSlices: readonly ShortSliceCandidate[];
+  /**
+   * The oldest-checked slice whose last walk failed, if the source has one.
+   * Whether it has rested long enough is decided here, against
+   * `failedRetryAfterMs`.
+   */
+  failedCandidate: FailedSliceCandidate | null;
   /** The newest never-surveyed slice below the tip window, if any remain. */
   sweepSlice: string | null;
   /**
-   * Slices whose last walk threw and whose retry is not yet due.
+   * Slices whose last walk threw in this process and whose retry is not yet
+   * due.
    *
-   * A walk that fails writes nothing, so nothing about the source's state
-   * changes and this selection would return the same slice on the next turn,
-   * and on every turn after it. One slice the publisher cannot serve would
-   * then hold every other slice the source owes, indefinitely: the tip stops
-   * being re-walked, the backlog stops draining and the sweep stops advancing,
-   * while the source still looks busy. Holding the failed slice out of the
-   * order until its retry comes due costs that slice its turns and nobody
-   * else's.
+   * A failed walk is recorded in the ledger, so the sweep and the backlog
+   * move on around it; but the tip is re-derived from the clock each turn
+   * and a failed tip slice would be handed straight back. Holding the failed
+   * slice out of the order until its retry comes due costs that slice its
+   * turns and nobody else's.
    */
   slicesHeldForRetry: ReadonlySet<string>;
   /**
@@ -215,6 +232,13 @@ export type SelectReconciliationWorkUnitInput = {
   recheckCandidate: LedgerSlice | null;
   staleAfterMs: number;
   recheckAfterMs: number;
+  failedRetryAfterMs: number;
+};
+
+/** A ledger row whose last walk failed, as the selection reads it. */
+export type FailedSliceCandidate = {
+  slice: string;
+  checkedAt: Date;
 };
 
 /**
@@ -225,8 +249,12 @@ export type SelectReconciliationWorkUnitInput = {
  *  2. the tip, where the publisher is still adding to slices and a miss is
  *     both most likely and most visible;
  *  3. slices known to be short and gone stale — the ledger's own backlog;
- *  4. history never surveyed at all, newest first;
- *  5. a slice that settled long enough ago that its ledger row is no longer
+ *  4. a slice whose last walk failed and has rested its day: ahead of new
+ *     history because it is history already reached, and a publisher fix or
+ *     an adapter release should show within a day rather than after the
+ *     sweep;
+ *  5. history never surveyed at all, newest first;
+ *  6. a slice that settled long enough ago that its ledger row is no longer
  *     evidence of anything — the only work that re-does work.
  *
  * Anything else is idle. The order is deliberately not round-robin between
@@ -240,6 +268,8 @@ export type SelectReconciliationWorkUnitInput = {
  * verification, and a source with real work never spends a turn on it.
  */
 export const selectReconciliationWorkUnit = ({
+  failedCandidate,
+  failedRetryAfterMs,
   hasDueParkedItems,
   now,
   recheckAfterMs,
@@ -296,6 +326,21 @@ export const selectReconciliationWorkUnit = ({
       type: "slice",
       slice: owed.slice,
       reason: SLICE_WALK_REASON.SHORT,
+    };
+  }
+
+  // The rest, like the recheck's, is decided here rather than in the query
+  // that reads the row: same clock arithmetic as the tip's staleness, kept
+  // where a test can reach it without a database.
+  if (
+    failedCandidate !== null &&
+    !slicesHeldForRetry.has(failedCandidate.slice) &&
+    failedCandidate.checkedAt.getTime() < now.getTime() - failedRetryAfterMs
+  ) {
+    return {
+      type: "slice",
+      slice: failedCandidate.slice,
+      reason: SLICE_WALK_REASON.RETRY,
     };
   }
 

--- a/apps/api/src/handlers/case-law/ingestion/status.ts
+++ b/apps/api/src/handlers/case-law/ingestion/status.ts
@@ -194,7 +194,9 @@ export const getIngestionStatus = async (
       // oxlint-disable-next-line no-db-await-in-loop/no-db-await-in-loop, no-await-in-loop -- sequential per-source aggregation reads on a single scoped connection
       const [sliceRow] = await db
         .select({
-          slices: count(),
+          // Surveyed means listed at least once; a row that only ever failed
+          // is counted under `failedSlices` alone.
+          slices: sql<number>`coalesce(sum(case when ${caseLawCoverageSlices.reported} is not null then 1 else 0 end), 0)::int`,
           shortSlices: sql<number>`coalesce(sum(case when ${caseLawCoverageSlices.collected} < ${caseLawCoverageSlices.reported} then 1 else 0 end), 0)::int`,
           failedSlices: sql<number>`coalesce(sum(case when ${caseLawCoverageSlices.walkError} is not null then 1 else 0 end), 0)::int`,
           lastCheckedAt: sql<Date | null>`max(${caseLawCoverageSlices.checkedAt})`,

--- a/apps/api/src/handlers/case-law/ingestion/status.ts
+++ b/apps/api/src/handlers/case-law/ingestion/status.ts
@@ -39,6 +39,8 @@ type SourceReconciliationStatus = {
   slices: number;
   /** Of those, slices holding fewer identities than the publisher listed. */
   shortSlices: number;
+  /** Of those, slices whose last listing walk failed; retried daily. */
+  failedSlices: number;
   /** Listed decisions awaiting another attempt. */
   parked: number;
   /** Listed decisions the retry schedule gave up on; accounted for, not held. */
@@ -194,6 +196,7 @@ export const getIngestionStatus = async (
         .select({
           slices: count(),
           shortSlices: sql<number>`coalesce(sum(case when ${caseLawCoverageSlices.collected} < ${caseLawCoverageSlices.reported} then 1 else 0 end), 0)::int`,
+          failedSlices: sql<number>`coalesce(sum(case when ${caseLawCoverageSlices.walkError} is not null then 1 else 0 end), 0)::int`,
           lastCheckedAt: sql<Date | null>`max(${caseLawCoverageSlices.checkedAt})`,
         })
         .from(caseLawCoverageSlices)
@@ -217,6 +220,7 @@ export const getIngestionStatus = async (
           : {
               slices,
               shortSlices: sliceRow?.shortSlices ?? 0,
+              failedSlices: sliceRow?.failedSlices ?? 0,
               parked,
               terminal,
               lastCheckedAt: sliceRow?.lastCheckedAt?.toISOString() ?? null,


### PR DESCRIPTION
## Summary

The historical sweep fills downward from the newest surveyed slice. A slice whose listing walk failed wrote nothing, so it stayed the frontier: held for an hour, offered again, failed again, and nothing older was ever surveyed. Four sources were stuck this way on one slice each.

- A failed walk is now recorded in the coverage ledger: `walk_error` carries the reason, the counts stay null until a walk lists it (`reported`/`collected` become nullable; a row is either counted or failed, enforced by two checks). The sweep's frontier and the short backlog move past it.
- New retry arm between the backlog and the sweep: the oldest-checked failed slice is walked again once it has rested `RECONCILIATION_FAILED_SLICE_RETRY_MS` (a day); a listing that succeeds clears `walk_error`. Reason `retry` in the summary; the in-process hour hold stays for the tip.
- Ingestion status reports `failedSlices` per source.
- Migration `20260818150000_case_law_coverage_slice_walk_error` (nullable counts, `walk_error`, checks validated outside the migrator transaction, partial index for the retry arm).

## Test plan

- [x] `reconciliation-plan.test.ts`: retry reason reachable and total, priority order (ahead of the sweep, behind the backlog), resting/held cases
- [x] `reconciliation-engine.db.test.ts`: a refused slice is recorded and the next turn sweeps the slice behind it (mutation: skipping the record → fails), a rested failed slice is walked with reason `retry` and clears, a resting one is left alone
- [x] `bun scripts/check-migrations.sh` against main (order, safety, squawk)
- [x] api typecheck, lint on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Failed case-law coverage listings are now recorded with error details and automatically retried after a delay.
  - Ingestion status now reports the number of coverage slices with failed latest checks.
- **Bug Fixes**
  - Successful rechecks clear previous failure information.
  - Failed slices no longer block other reconciliation work and are retried according to priority.
- **Tests**
  - Added coverage for failure recording, retry timing, recovery, and reconciliation progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->