### PR TITLE
fix(api): individual listing court defects

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns-reconciliation.test.ts
@@ -37,12 +37,18 @@ const UNID = {
   FIRST: "05D11F4FB3ACC585C1258E27004D2F09",
   SECOND: "137FECBC92321C61C1258E27004D2ECB",
   THIRD: "2E70B2C9AF8044CFC1258E27004D2EF8",
+  /** The decision that settles two dockets in one anchor, from 2025-09-03. */
+  CO_SETTLED: "EB8B51F4C8354470C1258CFA004D3FC3",
 } as const;
 
 const DOCKET = {
   FIRST: "30 Cdo 3000/2025",
   SECOND: "29 ICdo 83/2026",
   SUFFIXED: "21 Cdo 288/2026- III.",
+  /** Two dockets in one anchor, with the publisher's own separator markup. */
+  CO_SETTLED: "22 Cdo 807/2025<br />22 ND 148/2025",
+  /** Those two dockets as the single case number the store holds. */
+  CO_SETTLED_JOINED: "22 Cdo 807/2025, 22 ND 148/2025",
 } as const;
 
 /** The anchor the search view prints for one result row. */
@@ -378,6 +384,35 @@ describe("cz-ns listSlicePage", () => {
     const parked = JSON.stringify(listed.items.at(0)?.payload);
     const replayed: unknown = JSON.parse(parked);
     expect(replayed).toEqual({ unid: UNID.FIRST, caseNumber: DOCKET.SUFFIXED });
+  });
+
+  test("an anchor settling two dockets is one row carrying both", async () => {
+    // The fault this guards needs markup inside the anchor; without it the
+    // row parses either way and the test proves nothing.
+    expect(DOCKET.CO_SETTLED).toContain("<br />");
+
+    mockFetch({
+      listing: {
+        body: listingPageHtml({
+          rows: [
+            [UNID.FIRST, DOCKET.FIRST],
+            [UNID.CO_SETTLED, DOCKET.CO_SETTLED],
+          ],
+          shown: 2,
+        }),
+      },
+    });
+
+    const listed = await listSlice("2025-09-03");
+
+    expect(listed.items.map(({ payload }) => payload)).toEqual([
+      { unid: UNID.FIRST, caseNumber: DOCKET.FIRST },
+      { unid: UNID.CO_SETTLED, caseNumber: DOCKET.CO_SETTLED_JOINED },
+    ]);
+    expect(listed.items.map(({ identity }) => identity)).toEqual([
+      { type: "document", sourceDocumentId: UNID.FIRST },
+      { type: "document", sourceDocumentId: UNID.CO_SETTLED },
+    ]);
   });
 
   test("a lone hit, which the publisher states no count for, still lists", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -527,9 +527,35 @@ const czNsSliceDate = (slice: string): string => {
  * A result row. The docket and the universal id come out of the same anchor,
  * so a row that names one names the other, and a row that names neither is
  * not a row at all.
+ *
+ * The docket runs to the anchor's close rather than to the first tag inside
+ * it: one decision can settle several dockets, and the publisher prints those
+ * inside the one anchor separated by `<br />`. A group that stopped at markup
+ * skipped such a row entirely, and the day it fell in then counted one more
+ * decision than it listed and could never settle.
  */
 const LISTING_ROW_PATTERN =
-  /<a\s+class="odk"\s+href="[^"]*\/WebSearch\/(?<unid>[0-9A-Fa-f]{32})\?openDocument"[^>]*>(?<caseNumber>[^<]*)<\/a>/gu;
+  /<a\s+class="odk"\s+href="[^"]*\/WebSearch\/(?<unid>[0-9A-Fa-f]{32})\?openDocument"[^>]*>(?<caseNumber>[\s\S]*?)<\/a>/gu;
+
+/** What several dockets settled by one decision are joined with. */
+const CASE_NUMBER_SEPARATOR = ", ";
+
+/**
+ * The docket an anchor names, as one field.
+ *
+ * `stripHtml` turns the publisher's `<br />` between co-settled dockets into
+ * a line break; the store holds one case number per decision, so the parts
+ * are joined into a single number. Identity is unaffected: this adapter keys
+ * a decision on its universal id, and the docket is descriptive.
+ */
+const parseListingCaseNumber = (raw: string): string =>
+  stripHtml(raw)
+    .split("\n")
+    .flatMap((part) => {
+      const trimmed = part.trim();
+      return trimmed.length === 0 ? [] : [trimmed];
+    })
+    .join(CASE_NUMBER_SEPARATOR);
 
 /**
  * The two counts the publisher may state about a listing, both captured under
@@ -560,7 +586,7 @@ const parseListingCount = (
 const parseListingRows = (html: string): CzNsListingRow[] =>
   [...html.matchAll(LISTING_ROW_PATTERN)].map((match) => ({
     unid: match.groups?.["unid"] ?? "",
-    caseNumber: stripHtml(match.groups?.["caseNumber"] ?? ""),
+    caseNumber: parseListingCaseNumber(match.groups?.["caseNumber"] ?? ""),
   }));
 
 /**

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -7,6 +7,7 @@
  * predecessor came to assert a citation pattern the adapter no longer had.
  */
 
+import { Result } from "better-result";
 import {
   afterAll,
   afterEach,
@@ -20,9 +21,12 @@ import {
 import {
   buildCzNssDecision,
   czNssAdapter,
+  czNssExpectedRows,
   czNssListingIdentity,
+  czNssTotalPages,
+  CZ_NSS_CONTINUATION_PAGE_ROWS,
   CZ_NSS_FIRST_SLICE,
-  CZ_NSS_RESULTS_PER_PAGE,
+  CZ_NSS_FIRST_PAGE_ROWS,
   parseResultRows,
 } from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
 import type { ParsedRow } from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
@@ -446,6 +450,38 @@ describe("cz-nss listing rows", () => {
   });
 });
 
+// ── Page arithmetic ──────────────────────────────────────
+
+describe("cz-nss page arithmetic", () => {
+  test("the two page sizes the portal serves are not the same size", () => {
+    // Every case below is vacuous under one size for both.
+    expect(CZ_NSS_CONTINUATION_PAGE_ROWS).not.toBe(CZ_NSS_FIRST_PAGE_ROWS);
+  });
+
+  const cases = [
+    { statedCount: 0, pages: 0, rows: [] },
+    { statedCount: 1, pages: 1, rows: [1] },
+    { statedCount: 40, pages: 1, rows: [40] },
+    { statedCount: 41, pages: 2, rows: [40, 1] },
+    { statedCount: 60, pages: 2, rows: [40, 20] },
+    { statedCount: 61, pages: 3, rows: [40, 20, 1] },
+    { statedCount: 68, pages: 3, rows: [40, 20, 8] },
+  ] as const;
+
+  for (const { pages, rows, statedCount } of cases) {
+    test(`a day of ${statedCount} records spans ${pages} pages`, () => {
+      expect(czNssTotalPages(statedCount)).toBe(pages);
+      expect(
+        rows.map((_, page) => czNssExpectedRows({ page, statedCount })),
+      ).toEqual([...rows]);
+      // Every stated record lands on exactly one page, and no page expects a
+      // row past the day's end.
+      expect(rows.reduce((sum, count) => sum + count, 0)).toBe(statedCount);
+      expect(czNssExpectedRows({ page: pages, statedCount })).toBe(0);
+    });
+  }
+});
+
 // ── Listing walk ─────────────────────────────────────────
 
 describe("cz-nss listSlicePage", () => {
@@ -546,13 +582,13 @@ describe("cz-nss listSlicePage", () => {
   });
 
   test("derives the page count from the court's own record count", async () => {
-    const statedCount = CZ_NSS_RESULTS_PER_PAGE + 10;
+    const statedCount = CZ_NSS_FIRST_PAGE_ROWS + 10;
     installStub({
       search: [
         htmlResponse(
           searchPage({
             statedCount,
-            rows: fullPageRows(CZ_NSS_RESULTS_PER_PAGE),
+            rows: fullPageRows(CZ_NSS_FIRST_PAGE_ROWS),
           }),
         ),
       ],
@@ -563,6 +599,53 @@ describe("cz-nss listSlicePage", () => {
       (await reconciliation.listSlicePage({ slice: SLICE, page: 0 }))
         .totalPages,
     ).toBe(2);
+  });
+
+  test("pages a day of 68 records as 40 inline then 20 and 8", async () => {
+    // The day that exposed this: 68 decisions, of which the inline page
+    // carries 40 and the continuation endpoint serves 20 at a time.
+    const statedCount = 68;
+    const { requests } = installStub({
+      search: [
+        htmlResponse(
+          searchPage({
+            statedCount,
+            rows: fullPageRows(CZ_NSS_FIRST_PAGE_ROWS),
+          }),
+        ),
+        htmlResponse(
+          searchPage({
+            statedCount,
+            rows: fullPageRows(CZ_NSS_FIRST_PAGE_ROWS),
+          }),
+        ),
+      ],
+      continuation: [
+        htmlResponse(
+          fullPageRows(CZ_NSS_CONTINUATION_PAGE_ROWS).map(rowBlock).join("\n"),
+        ),
+        htmlResponse(fullPageRows(8).map(rowBlock).join("\n")),
+      ],
+    });
+
+    const second = await reconciliation.listSlicePage({
+      slice: SLICE,
+      page: 1,
+    });
+    const third = await reconciliation.listSlicePage({ slice: SLICE, page: 2 });
+
+    expect(second.totalPages).toBe(3);
+    expect(second.items).toHaveLength(CZ_NSS_CONTINUATION_PAGE_ROWS);
+    expect(third.totalPages).toBe(3);
+    expect(third.items).toHaveLength(8);
+
+    // The engine's page index is the portal's own `pageNum`.
+    const paginated = requests.filter(({ url }) =>
+      url.endsWith("/Home/MyResTRowsCont"),
+    );
+    expect(
+      paginated.map(({ body }) => new URLSearchParams(body).get("pageNum")),
+    ).toEqual(["1", "2"]);
   });
 
   test("refuses a first page shorter than the stated count requires", async () => {
@@ -592,8 +675,8 @@ describe("cz-nss listSlicePage", () => {
       search: [
         htmlResponse(
           searchPage({
-            statedCount: CZ_NSS_RESULTS_PER_PAGE + 10,
-            rows: fullPageRows(CZ_NSS_RESULTS_PER_PAGE),
+            statedCount: CZ_NSS_FIRST_PAGE_ROWS + 10,
+            rows: fullPageRows(CZ_NSS_FIRST_PAGE_ROWS),
           }),
         ),
       ],
@@ -612,8 +695,8 @@ describe("cz-nss listSlicePage", () => {
       search: [
         htmlResponse(
           searchPage({
-            statedCount: CZ_NSS_RESULTS_PER_PAGE + 1,
-            rows: fullPageRows(CZ_NSS_RESULTS_PER_PAGE),
+            statedCount: CZ_NSS_FIRST_PAGE_ROWS + 1,
+            rows: fullPageRows(CZ_NSS_FIRST_PAGE_ROWS),
           }),
         ),
       ],
@@ -719,6 +802,52 @@ describe("cz-nss listSlicePage", () => {
       ),
     ).toBeInstanceOf(Error);
   });
+});
+
+// ── Crawl cursor ─────────────────────────────────────────
+
+describe("cz-nss fetchPage", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    setSystemTime(new Date("2026-08-11T09:30:00.000Z"));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    setSystemTime();
+  });
+
+  test("a full continuation page moves the cursor on within the day", async () => {
+    // A continuation page is full at half the inline page's size, so a crawl
+    // measuring it against the inline size ends the day here and never asks
+    // for the records past it.
+    installStub({
+      search: [
+        htmlResponse(
+          searchPage({
+            statedCount: 68,
+            rows: fullPageRows(CZ_NSS_FIRST_PAGE_ROWS),
+          }),
+        ),
+      ],
+      continuation: [
+        htmlResponse(
+          fullPageRows(CZ_NSS_CONTINUATION_PAGE_ROWS).map(rowBlock).join("\n"),
+        ),
+      ],
+    });
+
+    const page = await czNssAdapter.fetchPage(`${SLICE}:1`, {});
+
+    expect(Result.isError(page)).toBe(false);
+    expect(Result.isError(page) ? null : page.value.nextCursor).toBe(
+      `${SLICE}:2`,
+    );
+  }, 30_000);
 });
 
 // ── Per-item build ───────────────────────────────────────

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -81,12 +81,62 @@ const CZ_NSS_LANGUAGE = "cs";
 const CZ_NSS_COURT = "Nejvyšší správní soud";
 
 /**
- * Results the portal renders per page, matching the page size its own
- * infinite-scroll script requests. Read from the live search rather than
- * assumed: a day-filtered search stating 50 records renders 40 rows inline and
- * serves the remaining 10 as the next page.
+ * Rows the portal renders inline on the results page a search returns.
  */
-export const CZ_NSS_RESULTS_PER_PAGE = 40;
+export const CZ_NSS_FIRST_PAGE_ROWS = 40;
+
+/**
+ * Rows `/Home/MyResTRowsCont` serves for one `pageNum`, which is half what
+ * the inline page carries.
+ *
+ * The two sizes are separate because the portal's are: a day stating 68
+ * records renders 40 inline, then answers `pageNum` 1 with 20 and `pageNum` 2
+ * with the last 8. One size for both made every page after the first expect
+ * twice the rows it can hold, so every day above 40 decisions failed its own
+ * count check and held its slice out of the sweep.
+ */
+export const CZ_NSS_CONTINUATION_PAGE_ROWS = 20;
+
+/** Rows page `page` of a day carries when the day is larger than it. */
+const czNssRowsOnPage = (page: number): number =>
+  page === 0 ? CZ_NSS_FIRST_PAGE_ROWS : CZ_NSS_CONTINUATION_PAGE_ROWS;
+
+/** Rows of a day preceding page `page`. */
+const czNssRowsBeforePage = (page: number): number =>
+  page === 0
+    ? 0
+    : CZ_NSS_FIRST_PAGE_ROWS + (page - 1) * CZ_NSS_CONTINUATION_PAGE_ROWS;
+
+/**
+ * Pages the walk must ask for to see a day of `statedCount` records: the
+ * inline one, plus one continuation page per {@link
+ * CZ_NSS_CONTINUATION_PAGE_ROWS} beyond it.
+ */
+export const czNssTotalPages = (statedCount: number): number =>
+  statedCount <= 0
+    ? 0
+    : 1 +
+      Math.ceil(
+        Math.max(0, statedCount - CZ_NSS_FIRST_PAGE_ROWS) /
+          CZ_NSS_CONTINUATION_PAGE_ROWS,
+      );
+
+type CzNssExpectedRowsOptions = {
+  /** 0-indexed page within the day. */
+  page: number;
+  /** What the portal says the day holds. */
+  statedCount: number;
+};
+
+/** Rows page `page` must carry for a day of `statedCount` records. */
+export const czNssExpectedRows = ({
+  page,
+  statedCount,
+}: CzNssExpectedRowsOptions): number =>
+  Math.max(
+    0,
+    Math.min(czNssRowsOnPage(page), statedCount - czNssRowsBeforePage(page)),
+  );
 
 /**
  * How many records the court says its own search matched, as the results page
@@ -1189,10 +1239,10 @@ const listCzNssSlicePage = async ({
   // `reported` reads as a fully collected day and settles it forever. Left
   // unwritten, the day keeps its previous row and the failure surfaces in the
   // loop's tally.
-  const expectedRows = Math.min(
-    CZ_NSS_RESULTS_PER_PAGE,
-    search.statedCount - page * CZ_NSS_RESULTS_PER_PAGE,
-  );
+  const expectedRows = czNssExpectedRows({
+    page,
+    statedCount: search.statedCount,
+  });
   if (rows.length < expectedRows) {
     throw new AdapterFetchError({
       message: `NSS page ${page} of ${slice} carried ${rows.length} of the ${expectedRows} rows its stated count of ${search.statedCount} requires`,
@@ -1206,7 +1256,7 @@ const listCzNssSlicePage = async ({
       identity: czNssListingIdentity(row),
       payload: row,
     })),
-    totalPages: Math.ceil(search.statedCount / CZ_NSS_RESULTS_PER_PAGE),
+    totalPages: czNssTotalPages(search.statedCount),
   };
 };
 
@@ -1436,8 +1486,11 @@ export const czNssAdapter = defineSourceAdapter({
           decisions.push(built.decision);
         }
 
-        // Determine next cursor
-        if (rows.length >= CZ_NSS_RESULTS_PER_PAGE) {
+        // Determine next cursor. Against the size this page can hold, not the
+        // inline one: a continuation page tops out at half of it, so measuring
+        // every page against the inline size ended the day at the first
+        // continuation page and skipped everything past record 60.
+        if (rows.length >= czNssRowsOnPage(page)) {
           // More pages for this date
           return {
             decisions,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-reconciliation.test.ts
@@ -385,6 +385,42 @@ describe("pl-courts listSlicePage", () => {
     expect(error).toBeInstanceOf(AdapterFetchError);
     expect(String(error)).toContain("text/html");
   });
+
+  test("the media type is read whole, not searched for", async () => {
+    // Both of these carry the JSON media type as a substring and neither is
+    // it, so a `Content-Type` containing it is not a `Content-Type` naming it.
+    for (const contentType of [
+      "application/jsonp",
+      "text/html; note=application/json",
+    ]) {
+      expect(contentType).toContain("application/json");
+      mockFetchWithBodies([
+        {
+          pattern: SEARCH_PATTERN,
+          body: searchBody([COMMON_COURT_ITEM], 1),
+          contentType,
+        },
+      ]);
+      // oxlint-disable-next-line no-await-in-loop -- one mocked response at a time; the mock is process-global
+      expect(await sliceRejection(SLICE)).toBeInstanceOf(AdapterFetchError);
+    }
+  });
+
+  test("the JSON media type is read past its parameters", async () => {
+    // What SAOS actually labels a listing with; the charset must not make it
+    // a different media type.
+    mockFetchWithBodies([
+      {
+        pattern: SEARCH_PATTERN,
+        body: searchBody([COMMON_COURT_ITEM], 1),
+        contentType: "Application/JSON; charset=utf-8",
+      },
+    ]);
+
+    const page = await reconciliation.listSlicePage({ slice: SLICE, page: 0 });
+
+    expect(page.items).toHaveLength(1);
+  });
 });
 
 describe("pl-courts buildDecision", () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-reconciliation.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts-reconciliation.test.ts
@@ -17,6 +17,7 @@ import type { SaosItem } from "@/api/handlers/case-law/ingestion/adapters/pl-cou
 import {
   PL_COURTS_FIRST_SLICE,
   PL_COURTS_LANGUAGE,
+  PL_COURTS_SLICE_PAGE_SIZE,
   plCourtsAdapter,
   plCourtsListingIdentity,
 } from "@/api/handlers/case-law/ingestion/adapters/pl-courts";
@@ -64,6 +65,8 @@ type MockRoute = {
   pattern: string;
   body: string;
   status?: number | undefined;
+  /** What the publisher labels the body; JSON unless a route says otherwise. */
+  contentType?: string | undefined;
 };
 
 const originalFetch = globalThis.fetch;
@@ -93,7 +96,9 @@ const mockFetchWithBodies = (routes: MockRoute[]) => {
       }
       return new Response(match.body, {
         status: match.status ?? 200,
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": match.contentType ?? "application/json;charset=UTF-8",
+        },
       });
     },
     { preconnect: originalFetch.preconnect.bind(originalFetch) },
@@ -252,7 +257,12 @@ describe("pl-courts listSlicePage", () => {
     expect(requested.searchParams.get("judgmentDateFrom")).toBe(SLICE);
     expect(requested.searchParams.get("judgmentDateTo")).toBe(SLICE);
     expect(requested.searchParams.get("pageNumber")).toBe("2");
-    expect(requested.searchParams.get("pageSize")).toBe("100");
+    // Half the crawl's dump page: the date-filtered search is a scan, and at
+    // 100 its later pages time out into the publisher's maintenance page.
+    expect(requested.searchParams.get("pageSize")).toBe(
+      String(PL_COURTS_SLICE_PAGE_SIZE),
+    );
+    expect(PL_COURTS_SLICE_PAGE_SIZE).toBe(50);
     // Ids are assigned once, so a judgment published mid-walk appends past the
     // last page instead of shifting items onto pages already read.
     expect(requested.searchParams.get("sortingField")).toBe("DATABASE_ID");
@@ -269,9 +279,9 @@ describe("pl-courts listSlicePage", () => {
 
     const page = await reconciliation.listSlicePage({ slice: SLICE, page: 0 });
 
-    // 283 filtered results at 100 a page is three pages; the API states no
-    // page count of its own.
-    expect(page.totalPages).toBe(3);
+    // 283 filtered results at 50 a page is six pages; the API states no page
+    // count of its own.
+    expect(page.totalPages).toBe(6);
     expect(page.items.map(({ identity }) => identity)).toEqual([
       { type: "document", sourceDocumentId: "130600" },
       { type: "document", sourceDocumentId: "168472" },
@@ -331,13 +341,49 @@ describe("pl-courts listSlicePage", () => {
     // The last page of a day is genuinely empty when the total divides evenly;
     // only a page the total still covers is a contradiction.
     mockFetchWithBodies([
-      { pattern: SEARCH_PATTERN, body: searchBody([], 200) },
+      {
+        pattern: SEARCH_PATTERN,
+        body: searchBody([], PL_COURTS_SLICE_PAGE_SIZE * 2),
+      },
     ]);
 
     const page = await reconciliation.listSlicePage({ slice: SLICE, page: 2 });
 
     expect(page.items).toEqual([]);
     expect(page.totalPages).toBe(2);
+  });
+
+  test("pages a day of 149 judgments at the slice listing's own size", async () => {
+    // The day that exposed this: 149 judgments, whose second page at 100 the
+    // publisher answered with a maintenance page after a minute.
+    mockFetchWithBodies([
+      { pattern: SEARCH_PATTERN, body: searchBody([COMMON_COURT_ITEM], 149) },
+    ]);
+
+    const page = await reconciliation.listSlicePage({
+      slice: "2019-05-20",
+      page: 0,
+    });
+
+    expect(page.totalPages).toBe(3);
+  });
+
+  test("an answer that is not JSON is a tagged failure naming its type", async () => {
+    // What SAOS serves under load: a 200 carrying its maintenance page. Left
+    // to `response.json()` this is a bare SyntaxError, which names neither the
+    // adapter nor the slice it held.
+    mockFetchWithBodies([
+      {
+        pattern: SEARCH_PATTERN,
+        body: "<html><body><h1>Przerwa techniczna</h1></body></html>",
+        contentType: "text/html;charset=UTF-8",
+      },
+    ]);
+
+    const error = await sliceRejection("2019-05-20");
+
+    expect(error).toBeInstanceOf(AdapterFetchError);
+    expect(String(error)).toContain("text/html");
   });
 });
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -61,6 +61,34 @@ const LEGACY_PAGE_SIZE = 100;
 const ITEM_CONCURRENCY = 10;
 
 /**
+ * Judgments the slice listing asks the search endpoint for at a time, which
+ * is half what the crawl asks the dump for.
+ *
+ * The dump serves an id-ordered window and is fast at 100. The search filters
+ * by judgment date over the whole corpus and is not: on a date holding 149
+ * judgments, its second page at 100 took a minute and then answered with the
+ * publisher's maintenance page, while at 50 it answered JSON. The size the
+ * crawl uses is therefore not the size this listing can use, so it is stated
+ * separately rather than shared.
+ */
+export const PL_COURTS_SLICE_PAGE_SIZE = 50;
+
+/**
+ * How long the slice listing waits for one search page.
+ *
+ * Longer than {@link ADAPTER_TIMEOUT.LIST}, and for the same reason the crawl
+ * gives its dump 60 s: a date-filtered search is a scan, and repeated
+ * sampling of one 149-judgment date measured its later pages between 1 s and
+ * 44 s. Aborting such a page raises a bare DOMException that holds the slice
+ * for an hour, which is a worse answer than waiting for the one the publisher
+ * is still producing.
+ */
+const SLICE_LIST_TIMEOUT_MS = 60_000;
+
+/** What a listing answer must be, before it is read as one. */
+const JSON_MEDIA_TYPE = "application/json";
+
+/**
  * SAOS numbers `pageNumber` from zero, on both the dump the crawl walks and
  * the search the slice listing walks: the listing asks for the slice's page
  * number unchanged, and the crawl derives the same number from its offset.
@@ -956,7 +984,7 @@ export const listPlCourtsDayPage = async ({
   signal,
 }: ListPlCourtsDayPageOptions): Promise<PlCourtsDayPage> => {
   const url = `${SEARCH_URL}?${new URLSearchParams({
-    pageSize: String(PAGE_SIZE),
+    pageSize: String(PL_COURTS_SLICE_PAGE_SIZE),
     pageNumber: String(page + FIRST_PAGE),
     sortingField: SLICE_SORTING_FIELD,
     sortingDirection: SLICE_SORTING_DIRECTION,
@@ -966,7 +994,7 @@ export const listPlCourtsDayPage = async ({
 
   const response = await fetchWithTimeout(url, {
     signal,
-    timeoutMs: ADAPTER_TIMEOUT.LIST,
+    timeoutMs: SLICE_LIST_TIMEOUT_MS,
     headers: {
       Accept: "application/json",
       "User-Agent": INGESTION_USER_AGENT,
@@ -976,6 +1004,21 @@ export const listPlCourtsDayPage = async ({
   if (!response.ok) {
     throw new AdapterFetchError({
       message: `SAOS search API error: ${response.status}`,
+      adapterKey: ADAPTER_KEYS.PL_COURTS,
+      cursor: date,
+      httpStatus: response.status,
+    });
+  }
+
+  // The publisher answers a 200 carrying an HTML maintenance page when the
+  // search is under load, and `response.json()` meets that with a raw
+  // SyntaxError: no adapter, no cursor, nothing naming the publisher as the
+  // cause. Refused here instead, as the tagged failure every other answer
+  // this function will not read is.
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes(JSON_MEDIA_TYPE)) {
+    throw new AdapterFetchError({
+      message: `SAOS search API answered ${contentType.length === 0 ? "no content type" : contentType} rather than ${JSON_MEDIA_TYPE}`,
       adapterKey: ADAPTER_KEYS.PL_COURTS,
       cursor: date,
       httpStatus: response.status,
@@ -1001,7 +1044,7 @@ export const listPlCourtsDayPage = async ({
   }
 
   const items = normalizeOptionalArray(json.items).map(normalizeSaosDumpItem);
-  const totalPages = Math.ceil(totalResults / PAGE_SIZE);
+  const totalPages = Math.ceil(totalResults / PL_COURTS_SLICE_PAGE_SIZE);
 
   // A page the publisher's own total says holds judgments has to return them.
   // Checked against the total rather than against the key's presence, because

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -89,6 +89,16 @@ const SLICE_LIST_TIMEOUT_MS = 60_000;
 const JSON_MEDIA_TYPE = "application/json";
 
 /**
+ * The media type a `Content-Type` names, without its parameters.
+ *
+ * Compared whole rather than searched for: `application/jsonp` contains the
+ * JSON media type and is not it, and a parameter can carry the string into a
+ * header that names something else entirely (`text/html; note=application/json`).
+ */
+const mediaTypeOf = (contentType: string): string =>
+  (contentType.split(";").at(0) ?? "").trim().toLowerCase();
+
+/**
  * SAOS numbers `pageNumber` from zero, on both the dump the crawl walks and
  * the search the slice listing walks: the listing asks for the slice's page
  * number unchanged, and the crawl derives the same number from its offset.
@@ -1015,10 +1025,10 @@ export const listPlCourtsDayPage = async ({
   // SyntaxError: no adapter, no cursor, nothing naming the publisher as the
   // cause. Refused here instead, as the tagged failure every other answer
   // this function will not read is.
-  const contentType = response.headers.get("content-type") ?? "";
-  if (!contentType.toLowerCase().includes(JSON_MEDIA_TYPE)) {
+  const mediaType = mediaTypeOf(response.headers.get("content-type") ?? "");
+  if (mediaType !== JSON_MEDIA_TYPE) {
     throw new AdapterFetchError({
-      message: `SAOS search API answered ${contentType.length === 0 ? "no content type" : contentType} rather than ${JSON_MEDIA_TYPE}`,
+      message: `SAOS search API answered ${mediaType.length === 0 ? "no content type" : mediaType} rather than ${JSON_MEDIA_TYPE}`,
       adapterKey: ADAPTER_KEYS.PL_COURTS,
       cursor: date,
       httpStatus: response.status,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
@@ -111,6 +111,8 @@ type DownloadStub =
 type MockOptions = {
   /** Search responses, one per request, in order. */
   search: readonly SearchStub[];
+  /** Answers derived from the window asked for; takes precedence over `search`. */
+  searchFor?: (body: SearchBody) => SearchStub;
   download?: DownloadStub;
   onSearch?: (body: SearchBody, headers: Headers) => void;
 };
@@ -176,14 +178,18 @@ const mockFetch = ({
   download = { type: "pdf" },
   onSearch,
   search,
+  searchFor,
 }: MockOptions): { calls: () => number } => {
   let searchCall = 0;
   globalThis.fetch = asFetchMock(
     (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(input instanceof Request ? input.url : String(input));
       if (url.pathname === SEARCH_PATH) {
-        onSearch?.(parseSearchBody(init), new Headers(init?.headers));
-        const next = search.at(Math.min(searchCall, search.length - 1));
+        const body = parseSearchBody(init);
+        onSearch?.(body, new Headers(init?.headers));
+        const next =
+          searchFor?.(body) ??
+          search.at(Math.min(searchCall, search.length - 1));
         searchCall += 1;
         return Promise.resolve(
           next === undefined
@@ -425,8 +431,56 @@ describe("sk-us listSlicePage", () => {
     expect(stub.calls()).toBe(2);
   });
 
+  // ── A record the DMS will not serialise ──────────────────
+  //
+  // 2025-04 states 278 decisions, and every window containing result index
+  // 194 answers 204 with an empty body: start=193&pageSize=1 answers 200,
+  // start=194&pageSize=1 answers 204, start=195&pageSize=1 answers 200.
+
+  /** Result index the stubbed DMS refuses, exactly as 2025-04's does. */
+  const UNSERVED_INDEX = 194;
+  const POISONED_NUM_FOUND = 278;
+
+  /**
+   * What one refused page may cost: two requests per halving of the adapter's
+   * 100-record listing page, plus the refused request that started it.
+   */
+  const SPLIT_REQUEST_BOUND = 2 * Math.ceil(Math.log2(100)) + 1;
+
+  /**
+   * What a window that serves nothing costs: one halving per level down the
+   * spine, plus the two one-record windows at the bottom that establish it.
+   */
+  const OUTAGE_REQUEST_COUNT = Math.ceil(Math.log2(100)) + 2;
+
+  /** A DMS document for result index `index`, keyed the way the real ones are. */
+  const documentAt = (index: number): Record<string, unknown> => ({
+    ...PLENARY_OPINION,
+    documentId: `7964d54e-6708-48e9-92cc-5cc4${String(index).padStart(8, "0")}`,
+    mkRSAPNumberOfFile: `III. ÚS ${index}/2025`,
+    mkDateOfDecision: "04/15/2025 00:00:00",
+  });
+
+  /** The DMS as 2025-04's is: 204 for any window covering `UNSERVED_INDEX`. */
+  const poisonedDms = ({
+    pageSize,
+    start,
+  }: Pick<SearchBody, "start" | "pageSize">): SearchStub => {
+    if (start <= UNSERVED_INDEX && UNSERVED_INDEX < start + pageSize) {
+      return { type: "status", status: 204 };
+    }
+    const end = Math.min(start + pageSize, POISONED_NUM_FOUND);
+    return {
+      type: "page",
+      documents: Array.from({ length: Math.max(0, end - start) }, (_, offset) =>
+        documentAt(start + offset),
+      ),
+      numFound: POISONED_NUM_FOUND,
+    };
+  };
+
   test("an empty 204 throws rather than settling the slice", async () => {
-    mockFetch({ search: [{ type: "status", status: 204 }] });
+    const stub = mockFetch({ search: [{ type: "status", status: 204 }] });
 
     const rejection = await rejectionOf(
       reconciliation.listSlicePage({ slice: "2026-06", page: 0 }),
@@ -435,6 +489,58 @@ describe("sk-us listSlicePage", () => {
     expect(rejection instanceof Error ? rejection.message : "").toContain(
       "no body",
     );
+    // A window that serves nothing however narrowly it is cut is the endpoint
+    // being down, and is established by walking one spine of the halving
+    // rather than by subdividing the whole page.
+    expect(stub.calls()).toBe(OUTAGE_REQUEST_COUNT);
+  }, 30_000);
+
+  test("a record the DMS refuses is isolated, not allowed to refuse its page", async () => {
+    // Without a split this page answers 204 whole and the month is held.
+    expect(poisonedDms({ start: 100, pageSize: 100 })).toEqual({
+      type: "status",
+      status: 204,
+    });
+
+    const stub = mockFetch({ search: [], searchFor: poisonedDms });
+
+    const page = await reconciliation.listSlicePage({
+      slice: "2025-04",
+      page: 1,
+    });
+
+    // The page is whole: 99 keyed records plus the one that cannot be keyed,
+    // which the engine counts as unidentifiable and leaves out of both
+    // `reported` and `collected`.
+    expect(page.items).toHaveLength(100);
+    expect(page.totalPages).toBe(3);
+    const unkeyableAt = page.items.findIndex(
+      ({ identity }) => listingIdentityKey(identity) === null,
+    );
+    // In place, not appended: the walk must not reorder what the publisher
+    // lists, or a replay would key the wrong payloads.
+    expect(unkeyableAt).toBe(UNSERVED_INDEX - 100);
+    expect(page.items.at(unkeyableAt)?.identity).toEqual({
+      type: "unidentifiable",
+    });
+    expect(
+      page.items.filter(
+        ({ identity }) => listingIdentityKey(identity) === null,
+      ),
+    ).toHaveLength(1);
+    expect(stub.calls()).toBe(SPLIT_REQUEST_BOUND);
+  }, 30_000);
+
+  test("a page of a poisoned month that carries no refused record costs one request", async () => {
+    const stub = mockFetch({ search: [], searchFor: poisonedDms });
+
+    const page = await reconciliation.listSlicePage({
+      slice: "2025-04",
+      page: 0,
+    });
+
+    expect(page.items).toHaveLength(100);
+    expect(stub.calls()).toBe(1);
   });
 
   test("a payload without a count throws rather than reporting zero pages", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@/api/handlers/case-law/ingestion/adapters/sk-us";
 import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
+import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 import {
   listingIdentityKey,
   SOURCE_DOCUMENT_ID_MAX_LENGTH,
@@ -443,18 +444,20 @@ describe("sk-us listSlicePage", () => {
 
   /**
    * What one refused page may cost: two requests per halving of the adapter's
-   * 100-record listing page, plus the refused request that started it.
+   * 100-record listing page, the refused request that started it, and the one
+   * that confirms the isolated record is refused rather than unlucky.
    */
-  const SPLIT_REQUEST_BOUND = 2 * Math.ceil(Math.log2(100)) + 1;
+  const SPLIT_REQUEST_BOUND = 2 * Math.ceil(Math.log2(100)) + 1 + 1;
 
   /**
    * What a window that serves nothing costs: one halving per level down the
-   * spine, plus the two one-record windows at the bottom that establish it.
+   * spine, plus the two one-record windows at the bottom that establish it,
+   * each of which is asked twice before it counts as refused.
    */
-  const OUTAGE_REQUEST_COUNT = Math.ceil(Math.log2(100)) + 2;
+  const OUTAGE_REQUEST_COUNT = Math.ceil(Math.log2(100)) + 2 * 2;
 
   /** A DMS document for result index `index`, keyed the way the real ones are. */
-  const documentAt = (index: number): Record<string, unknown> => ({
+  const documentAt = (index: number) => ({
     ...PLENARY_OPINION,
     documentId: `7964d54e-6708-48e9-92cc-5cc4${String(index).padStart(8, "0")}`,
     mkRSAPNumberOfFile: `III. ÚS ${index}/2025`,
@@ -542,6 +545,73 @@ describe("sk-us listSlicePage", () => {
     expect(page.items).toHaveLength(100);
     expect(stub.calls()).toBe(1);
   });
+
+  test("a one-record 204 that does not repeat lists the record it named", async () => {
+    // An unidentifiable item is excluded from the slice rather than parked, so
+    // nothing retries it: a 204 the endpoint answered once under load and not
+    // again would drop a real decision out of `reported` for good.
+    let singletonCalls = 0;
+    const transientDms = (
+      body: Pick<SearchBody, "start" | "pageSize">,
+    ): SearchStub => {
+      const isTheRecord = body.start === UNSERVED_INDEX && body.pageSize === 1;
+      if (!isTheRecord) {
+        return poisonedDms(body);
+      }
+      singletonCalls += 1;
+      return singletonCalls === 1
+        ? { type: "status", status: 204 }
+        : {
+            type: "page",
+            documents: [documentAt(UNSERVED_INDEX)],
+            numFound: POISONED_NUM_FOUND,
+          };
+    };
+
+    const stub = mockFetch({ search: [], searchFor: transientDms });
+
+    const page = await reconciliation.listSlicePage({
+      slice: "2025-04",
+      page: 1,
+    });
+
+    // The record is asked for twice and served the second time, so it is a
+    // listed decision like any other and nothing is unidentifiable.
+    expect(singletonCalls).toBe(2);
+    expect(page.items).toHaveLength(100);
+    expect(
+      page.items.filter(
+        ({ identity }) => listingIdentityKey(identity) === null,
+      ),
+    ).toHaveLength(0);
+    expect(page.items.at(UNSERVED_INDEX - 100)?.identity).toEqual({
+      type: "document",
+      sourceDocumentId: documentAt(UNSERVED_INDEX).documentId,
+    });
+    expect(stub.calls()).toBe(SPLIT_REQUEST_BOUND);
+  }, 30_000);
+
+  test("halves that disagree on the month's size throw rather than bank a page", async () => {
+    // Both halves size the same month, so two counts mean the page cannot be
+    // sized; keeping either would write a `reported` the slice never reaches.
+    const stub = mockFetch({
+      search: [
+        { type: "status", status: 204 },
+        { type: "page", documents: [PLENARY_OPINION], numFound: 200 },
+        { type: "page", documents: [CHAMBER_RESOLUTION], numFound: 201 },
+      ],
+    });
+
+    const rejection = await rejectionOf(
+      reconciliation.listSlicePage({ slice: "2025-04", page: 0 }),
+    );
+
+    expect(rejection).toBeInstanceOf(AdapterFetchError);
+    expect(rejection instanceof Error ? rejection.message : "").toContain(
+      "200 and 201",
+    );
+    expect(stub.calls()).toBe(3);
+  }, 30_000);
 
   test("a payload without a count throws rather than reporting zero pages", async () => {
     mockFetch({

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -50,6 +50,7 @@ import type {
   IngestionResult,
   ListingIdentity,
   ReconciliationBuildOutcome,
+  ReconciliationListingItem,
   ReconciliationSlicePage,
   ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
@@ -76,6 +77,12 @@ const DOC_DOWNLOAD_URL = `${BASE_URL}/docDownload`;
 
 const PAGE_SIZE = 10;
 const SEARCH_RETRY_DELAY_MS = 500;
+
+/**
+ * Shortest gap between two requests this adapter makes to the court, both as
+ * the pipeline's pacing and as the pause it takes between requests of its own.
+ */
+const MIN_REQUEST_INTERVAL_MS = 500;
 
 /**
  * Page size for a listing walk. The crawl takes ten at a time because every
@@ -664,15 +671,104 @@ const sliceDateRange = (slice: string): SearchDateRange => {
  * observed answering 500 and 524 under load), a 204, a body the validator
  * rejects — is an error the engine retries on a later pass.
  */
-const listSkUsSlicePage = async ({
-  page,
+/**
+ * One listed item for a result the DMS will not serve.
+ *
+ * With no body there is no document id and no docket, so there is nothing to
+ * key the decision on and nothing that could be invented: an identity guessed
+ * from the offset would name a row the ingest can never write. The engine
+ * counts an item like this as unidentifiable and leaves it out of both
+ * `reported` and `collected`, which is what lets the month settle on the
+ * records that do exist instead of standing one short of a number no walk can
+ * reach.
+ */
+const unservedListingItem = (offset: number): ReconciliationListingItem => ({
+  identity: { type: "unidentifiable" },
+  payload: { unservedResultIndex: offset },
+});
+
+/** What one window of a month's results answered. */
+type ListedWindow = {
+  items: ReconciliationListingItem[];
+  /** The month's size, from whichever sub-window stated it; null if none did. */
+  numFound: number | null;
+};
+
+/**
+ * Requests one unservable record costs to isolate: the endpoint answers each
+ * halving twice, once for the half that carries the record and once for the
+ * half that does not.
+ */
+const SPLIT_REQUESTS_PER_UNSERVED_RECORD =
+  2 * Math.ceil(Math.log2(LISTING_PAGE_SIZE));
+
+/**
+ * Extra requests one page may spend isolating what the DMS refuses.
+ *
+ * Two records' worth. A page needing more than that is not a page with a
+ * poisoned record on it, and spending a full binary subdivision (2·pageSize-1
+ * requests) to establish that would be a worse answer than leaving the slice
+ * its previous ledger row.
+ */
+const SPLIT_REQUEST_BUDGET = 2 * SPLIT_REQUESTS_PER_UNSERVED_RECORD;
+
+/** Extra requests a page's splitting may still spend. */
+type SplitBudget = { remaining: number };
+
+type ListSkUsWindowOptions = {
+  budget: SplitBudget;
+  /** 0-indexed result offset within the month. */
+  offset: number;
+  pageSize: number;
+  slice: string;
+  signal?: AbortSignal | undefined;
+};
+
+const unservedWindowError = (
+  slice: string,
+  detail: string,
+): AdapterFetchError =>
+  new AdapterFetchError({
+    message: `SK ÚS search returned no body for ${slice}: ${detail}`,
+    adapterKey: ADAPTER_KEYS.SK_US,
+    cursor: slice,
+  });
+
+/**
+ * List one window of a month, splitting it around whatever the DMS refuses.
+ *
+ * The endpoint answers 204 with an empty body for any window containing a
+ * record it cannot serialise, and it does so deterministically: for 2025-04,
+ * `start=194&pageSize=1` answered 204 while 193 and 195 answered 200, and
+ * every wider window covering 194 answered 204 too. One such record therefore
+ * refuses the whole page it falls on, and a page read as an outage held the
+ * slice for an hour, every hour, with no pass ever able to get past it.
+ *
+ * So a refused window is halved until the refusal is one record wide. What
+ * surrounds it lists normally, the record itself is reported with nothing to
+ * key on, and the month settles honestly: 277 reported, 277 collected, one
+ * unidentifiable. The halving terminates at a window of one record, costs
+ * {@link SPLIT_REQUESTS_PER_UNSERVED_RECORD} per such record, and each of
+ * those requests waits the same pause as every other request here.
+ *
+ * A refusal that survives the halving with nothing served on either side is
+ * the endpoint being down for that window rather than a record it cannot
+ * serialise, and is thrown: reporting the window as that many unidentifiable
+ * items would settle the month over an outage. Two unservable records lying
+ * side by side read the same way and are refused with it, which is the safe
+ * direction to be wrong in.
+ */
+const listSkUsWindow = async ({
+  budget,
+  offset,
+  pageSize,
   signal,
   slice,
-}: ReconciliationSlicePageOptions): Promise<ReconciliationSlicePage> => {
+}: ListSkUsWindowOptions): Promise<ListedWindow> => {
   const searchResult = await executeSearchWithRetry({
     cursor: slice,
-    offset: page * LISTING_PAGE_SIZE,
-    pageSize: LISTING_PAGE_SIZE,
+    offset,
+    pageSize,
     range: sliceDateRange(slice),
     signal,
   });
@@ -681,21 +777,78 @@ const listSkUsSlicePage = async ({
   }
 
   const data = searchResult.value;
-  if (data === null) {
-    throw new AdapterFetchError({
-      message: `SK ÚS search returned no body for ${slice}`,
-      adapterKey: ADAPTER_KEYS.SK_US,
-      cursor: slice,
-    });
+  if (data !== null) {
+    return {
+      items: data.documents.map((doc) => ({
+        identity: skUsListingIdentity(doc),
+        payload: doc,
+      })),
+      numFound: data.numFound,
+    };
   }
 
-  return {
-    items: data.documents.map((doc) => ({
-      identity: skUsListingIdentity(doc),
-      payload: doc,
-    })),
-    totalPages: Math.ceil(data.numFound / LISTING_PAGE_SIZE),
-  };
+  if (pageSize <= 1) {
+    return { items: [unservedListingItem(offset)], numFound: null };
+  }
+
+  if (budget.remaining < 2) {
+    throw unservedWindowError(
+      slice,
+      `splitting a refused window at offset ${offset} spent its ${SPLIT_REQUEST_BUDGET}-request budget`,
+    );
+  }
+  budget.remaining -= 2;
+
+  const half = Math.ceil(pageSize / 2);
+  await Bun.sleep(MIN_REQUEST_INTERVAL_MS);
+  const lower = await listSkUsWindow({
+    budget,
+    offset,
+    pageSize: half,
+    signal,
+    slice,
+  });
+  await Bun.sleep(MIN_REQUEST_INTERVAL_MS);
+  const upper = await listSkUsWindow({
+    budget,
+    offset: offset + half,
+    pageSize: pageSize - half,
+    signal,
+    slice,
+  });
+
+  // Either half that answered states the same month-wide count.
+  const numFound = lower.numFound ?? upper.numFound;
+  if (numFound === null) {
+    throw unservedWindowError(
+      slice,
+      `${pageSize} records from offset ${offset} served nothing`,
+    );
+  }
+
+  return { items: [...lower.items, ...upper.items], numFound };
+};
+
+const listSkUsSlicePage = async ({
+  page,
+  signal,
+  slice,
+}: ReconciliationSlicePageOptions): Promise<ReconciliationSlicePage> => {
+  const { items, numFound } = await listSkUsWindow({
+    budget: { remaining: SPLIT_REQUEST_BUDGET },
+    offset: page * LISTING_PAGE_SIZE,
+    pageSize: LISTING_PAGE_SIZE,
+    signal,
+    slice,
+  });
+
+  if (numFound === null) {
+    // Only reachable where a page is one record wide: the split refuses a
+    // wider window that served nothing before it can answer with one.
+    throw unservedWindowError(slice, `offset ${page * LISTING_PAGE_SIZE}`);
+  }
+
+  return { items, totalPages: Math.ceil(numFound / LISTING_PAGE_SIZE) };
 };
 
 /**
@@ -745,7 +898,7 @@ export const skUsAdapter = defineSourceAdapter({
   name: "ustavnysud.sk",
   country: "SVK",
   language: "sk",
-  minRequestIntervalMs: 500,
+  minRequestIntervalMs: MIN_REQUEST_INTERVAL_MS,
   pageTimeoutMs: 120_000,
   maxSyncPages: 10,
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -734,6 +734,36 @@ const unservedWindowError = (
     cursor: slice,
   });
 
+type SearchWindowOptions = Omit<ListSkUsWindowOptions, "budget">;
+
+/** One search request for a window: its body, or null where it answered 204. */
+const searchWindow = async ({
+  offset,
+  pageSize,
+  signal,
+  slice,
+}: SearchWindowOptions): Promise<SearchResponse | null> => {
+  const searchResult = await executeSearchWithRetry({
+    cursor: slice,
+    offset,
+    pageSize,
+    range: sliceDateRange(slice),
+    signal,
+  });
+  if (Result.isError(searchResult)) {
+    throw searchResult.error;
+  }
+  return searchResult.value;
+};
+
+const listedWindow = (data: SearchResponse): ListedWindow => ({
+  items: data.documents.map((doc) => ({
+    identity: skUsListingIdentity(doc),
+    payload: doc,
+  })),
+  numFound: data.numFound,
+});
+
 /**
  * List one window of a month, splitting it around whatever the DMS refuses.
  *
@@ -748,8 +778,9 @@ const unservedWindowError = (
  * surrounds it lists normally, the record itself is reported with nothing to
  * key on, and the month settles honestly: 277 reported, 277 collected, one
  * unidentifiable. The halving terminates at a window of one record, costs
- * {@link SPLIT_REQUESTS_PER_UNSERVED_RECORD} per such record, and each of
- * those requests waits the same pause as every other request here.
+ * {@link SPLIT_REQUESTS_PER_UNSERVED_RECORD} plus the one confirming request
+ * below per such record, and each of those requests waits the same pause as
+ * every other request here.
  *
  * A refusal that survives the halving with nothing served on either side is
  * the endpoint being down for that window rather than a record it cannot
@@ -757,6 +788,13 @@ const unservedWindowError = (
  * items would settle the month over an outage. Two unservable records lying
  * side by side read the same way and are refused with it, which is the safe
  * direction to be wrong in.
+ *
+ * A one-record refusal is confirmed by a second request before it is reported
+ * unserved. An unidentifiable item is excluded from the slice rather than
+ * parked, so nothing retries it later: a single 204 taken at face value would
+ * drop a real decision out of `reported` permanently, and this endpoint is
+ * known to answer badly under load. One request is a reading; two agreeing
+ * requests are a property of the record.
  */
 const listSkUsWindow = async ({
   budget,
@@ -765,30 +803,22 @@ const listSkUsWindow = async ({
   signal,
   slice,
 }: ListSkUsWindowOptions): Promise<ListedWindow> => {
-  const searchResult = await executeSearchWithRetry({
-    cursor: slice,
-    offset,
-    pageSize,
-    range: sliceDateRange(slice),
-    signal,
-  });
-  if (Result.isError(searchResult)) {
-    throw searchResult.error;
-  }
-
-  const data = searchResult.value;
+  const data = await searchWindow({ offset, pageSize, signal, slice });
   if (data !== null) {
-    return {
-      items: data.documents.map((doc) => ({
-        identity: skUsListingIdentity(doc),
-        payload: doc,
-      })),
-      numFound: data.numFound,
-    };
+    return listedWindow(data);
   }
 
   if (pageSize <= 1) {
-    return { items: [unservedListingItem(offset)], numFound: null };
+    await Bun.sleep(MIN_REQUEST_INTERVAL_MS);
+    const confirmation = await searchWindow({
+      offset,
+      pageSize,
+      signal,
+      slice,
+    });
+    return confirmation === null
+      ? { items: [unservedListingItem(offset)], numFound: null }
+      : listedWindow(confirmation);
   }
 
   if (budget.remaining < 2) {
@@ -817,7 +847,22 @@ const listSkUsWindow = async ({
     slice,
   });
 
-  // Either half that answered states the same month-wide count.
+  // Both halves state the size of the same month, so two different counts mean
+  // the month changed under the walk or the endpoint answered about something
+  // else. Either way the page cannot be sized, and banking it would write a
+  // `reported` the slice can never reach.
+  if (
+    lower.numFound !== null &&
+    upper.numFound !== null &&
+    lower.numFound !== upper.numFound
+  ) {
+    throw new AdapterFetchError({
+      message: `SK ÚS search sized ${slice} as ${lower.numFound} and ${upper.numFound} while splitting ${pageSize} records from offset ${offset}`,
+      adapterKey: ADAPTER_KEYS.SK_US,
+      cursor: slice,
+    });
+  }
+
   const numFound = lower.numFound ?? upper.numFound;
   if (numFound === null) {
     throw unservedWindowError(


### PR DESCRIPTION
## Summary

Each of these was reproduced against the publisher; each held that source's historical sweep on the one slice it could not list.

- **cz-ns**: a listing anchor naming two dockets (`22 Cdo 807/2025<br />22 ND 148/2025`) was dropped by the row pattern, so the slice stated 32 and carried 31. The case-number group now spans to `</a>`; tags stripped, line breaks joined with `, `.
- **cz-nss**: the inline first results page carries 40 rows but the continuation endpoint serves 20 per `pageNum`; one constant drove both, so every day with more than 40 decisions failed the carried-vs-stated check. Split into first-page and continuation sizes with the page arithmetic derived from the pair; the crawl's day-termination had the same bug class (a full 20-row continuation page ended the day) and is fixed alongside.
- **pl-courts**: page 1 of a busy day at `pageSize=100` hangs and then answers an HTML maintenance page; the slice listing now uses its own page size (50) and timeout (60 s, the crawl's dump timeout), and refuses a non-JSON content type as a tagged error instead of a raw parse failure.
- **sk-us**: the DMS answers HTTP 204 for any window containing one record it cannot serialise. A 204/empty window is halved recursively down to one record; the rest is listed and the unserved index is reported as an item with no keyable identity (the engine's `unidentifiable` bucket), so the month settles honestly. Bounded requests (poisoned page = 15), politeness gap before every extra request; a window that serves nothing on either side is still an outage.

## Test plan

- [x] adapter tests: 336 pass; each fix mutation-checked (pattern revert, single page size, page size back to 100 / check disabled, split disabled)
- [x] api typecheck; oxlint type-aware and oxfmt on touched files
- [x] cz-ns, pl-courts and sk-us re-verified live at ≤ 1 request/s; cz-nss arithmetic verified against the observed 40/20/8 pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Czech Supreme Court pagination to process continuation pages correctly, including larger result sets.
  - Normalised Czech case numbers when listings contain multiple docket numbers.
  - Improved Polish Courts handling of paginated results and non-JSON maintenance responses.
  - Strengthened Slovak Supreme Court reconciliation for unavailable, refused, or ambiguous records, with controlled retries and clearer failure handling.
- **Reliability**
  - Added safeguards to prevent incomplete or inconsistent case-law ingestion during temporary service issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->