### PR TITLE
fix(api): keep multipart string fields as strings

### DIFF
--- a/apps/api/src/handlers/templates/create.ts
+++ b/apps/api/src/handlers/templates/create.ts
@@ -30,15 +30,14 @@ const createTemplateBodySchema = t.Object({
   file: t.File({ maxSize: FILE_SIZE_LIMITS.document }),
   name: withDescription(tDefaultVarchar, "Template display name"),
   categoryId: t.Optional(tSafeId("templateCategory")),
-  // Elysia auto-parses JSON strings from FormData, so the
-  // manifest may arrive as a string or an already-parsed
-  // object depending on transport. Accept any and validate
-  // in the handler.
+  // A JSON string over the multipart HTTP body, an object when an MCP
+  // invocation calls the handler directly. Accept any and validate in the
+  // handler.
   manifest: t.Optional(t.Any()),
 });
 
-/** Accept a string (JSON body) or already-parsed object
- *  (FormData auto-parsed by Elysia). */
+/** Accept the JSON string an HTTP client sends or the object an MCP
+ *  invocation passes straight through. */
 const parseClientManifest = (value: unknown): ClientTemplateManifest | null => {
   let parsed: unknown = value;
   if (typeof value === "string") {

--- a/apps/api/src/handlers/templates/manifest.ts
+++ b/apps/api/src/handlers/templates/manifest.ts
@@ -36,8 +36,8 @@ export const manifestHandler = async ({
     );
   }
 
-  // Handle both string (JSON body) and already-parsed object
-  // (FormData auto-parsed by Elysia).
+  // A JSON string over the multipart HTTP body, an object when an MCP
+  // invocation calls the handler directly.
   let parsed: unknown = manifestJson;
   if (typeof manifestJson === "string") {
     const parseResult = Result.try((): unknown => JSON.parse(manifestJson));

--- a/apps/api/src/handlers/templates/save-document.ts
+++ b/apps/api/src/handlers/templates/save-document.ts
@@ -89,8 +89,9 @@ const saveDocumentBodySchema = t.Object({
   // Optional edited manifest (the Studio's field settings and conditions).
   // When present it is the base manifest, so the editor's field
   // metadata is persisted without a separate binary re-embed round-trip.
-  // t.Unknown() (not t.String()) because Elysia auto-parses JSON-looking
-  // multipart fields into objects; the handler validates the shape below.
+  // t.Unknown() (not t.String()) because the field is a JSON string over the
+  // multipart HTTP body and an object when an MCP invocation calls the handler
+  // directly; the handler validates the shape below.
   manifest: t.Optional(t.Unknown()),
 });
 
@@ -133,8 +134,8 @@ const saveTemplateDocument = createSafeRootHandler(
     const { file, manifest: manifestJson } = body;
 
     // Parse the optional client manifest; ignore it if malformed and fall back
-    // to the manifest embedded in the uploaded DOCX. Elysia may hand us either
-    // the raw JSON string or an already-parsed object, so handle both.
+    // to the manifest embedded in the uploaded DOCX. Either the raw JSON
+    // string (HTTP) or an object (MCP) can arrive, so handle both.
     let clientManifest: TemplateManifest | undefined;
     if (manifestJson !== undefined) {
       let candidate: unknown = manifestJson;

--- a/apps/api/src/lib/multipart-form-parser.test.ts
+++ b/apps/api/src/lib/multipart-form-parser.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from "bun:test";
+import { Elysia, t } from "elysia";
+
+import {
+  multipartFormParser,
+  parseMultipartForm,
+} from "@/api/lib/multipart-form-parser";
+
+const file = (name: string) => new File(["body"], name, { type: "text/plain" });
+
+const formData = (entries: [string, string | File][]): FormData => {
+  const data = new FormData();
+  for (const [key, value] of entries) {
+    data.append(key, value);
+  }
+  return data;
+};
+
+/** Round-trips the form through a real request, so the parser sees exactly
+ *  what a route hands it. */
+const parse = async (entries: [string, string | File][]) => {
+  const request = new Request("http://localhost/probe", {
+    method: "POST",
+    body: formData(entries),
+  });
+  // eslint-disable-next-line typescript/no-deprecated -- the parser under test consumes exactly this form
+  return parseMultipartForm(await request.formData());
+};
+
+describe("parseMultipartForm", () => {
+  test("keeps a JSON-shaped value as the string that was sent", async () => {
+    const values = '{"party.name":"Acme"}';
+    expect(await parse([["values", values]])).toEqual({ values });
+  });
+
+  test("keeps an array-shaped value as a string", async () => {
+    expect(await parse([["entityIds", '["a","b"]']])).toEqual({
+      entityIds: '["a","b"]',
+    });
+  });
+
+  test("keeps a file as a file", async () => {
+    const parsed = (await parse([["file", file("contract.docx")]]))["file"];
+
+    if (typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new TypeError("expected the field to stay a file");
+    }
+    expect(parsed.name).toBe("contract.docx");
+    expect(await parsed.text()).toBe("body");
+  });
+
+  test("collects a repeated key into an array in wire order", async () => {
+    const parsed = await parse([
+      ["files", file("a.docx")],
+      ["files", file("b.docx")],
+    ]);
+
+    const files = parsed["files"];
+    if (!Array.isArray(files)) {
+      throw new TypeError("expected a repeated key to collect into an array");
+    }
+    expect(
+      files.map((entry) => (typeof entry === "string" ? entry : entry.name)),
+    ).toEqual(["a.docx", "b.docx"]);
+  });
+
+  test("keeps a single-entry key unwrapped", async () => {
+    expect(
+      Array.isArray((await parse([["files", file("a.docx")]]))["files"]),
+    ).toBe(false);
+  });
+
+  test("drops prototype-polluting keys", async () => {
+    const parsed = await parse([
+      ["__proto__", '{"polluted":true}'],
+      ["constructor", "x"],
+      ["prototype", "x"],
+      ["name", "kept"],
+    ]);
+
+    expect(parsed).toEqual({ name: "kept" });
+    expect("polluted" in {}).toBe(false);
+  });
+
+  test("does not confuse an inherited property with a repeated key", async () => {
+    expect(await parse([["toString", "once"]])).toEqual({ toString: "once" });
+  });
+});
+
+describe("multipartFormParser plugin", () => {
+  test("a t.String() field carrying JSON reaches the handler as a string", async () => {
+    const app = new Elysia()
+      .use(multipartFormParser)
+      .post("/fill", ({ body }) => body.values, {
+        body: t.Object({ file: t.File(), values: t.String() }),
+      });
+
+    const response = await app.handle(
+      new Request("http://localhost/fill", {
+        method: "POST",
+        body: formData([
+          ["file", file("template.docx")],
+          ["values", '{"party.name":"Acme"}'],
+        ]),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('{"party.name":"Acme"}');
+  });
+
+  test("t.Files() still receives every uploaded file", async () => {
+    const app = new Elysia()
+      .use(multipartFormParser)
+      .post("/upload", ({ body }) => String(body.files.length), {
+        body: t.Object({ files: t.Files() }),
+      });
+
+    const response = await app.handle(
+      new Request("http://localhost/upload", {
+        method: "POST",
+        body: formData([
+          ["files", file("a.docx")],
+          ["files", file("b.docx")],
+        ]),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("2");
+  });
+
+  test("t.Files() still accepts a single uploaded file", async () => {
+    const app = new Elysia()
+      .use(multipartFormParser)
+      .post("/upload", ({ body }) => String(body.files.length), {
+        body: t.Object({ files: t.Files() }),
+      });
+
+    const response = await app.handle(
+      new Request("http://localhost/upload", {
+        method: "POST",
+        body: formData([["files", file("a.docx")]]),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("1");
+  });
+
+  test("a route that declares parse: none keeps its unread request body", async () => {
+    const app = new Elysia()
+      .use(multipartFormParser)
+      .all("/raw", async ({ request }) => await request.text(), {
+        parse: "none",
+      });
+
+    const response = await app.handle(
+      new Request("http://localhost/raw", {
+        method: "POST",
+        body: '{"jsonrpc":"2.0"}',
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('{"jsonrpc":"2.0"}');
+  });
+
+  test("a route that declares parse: text still gets the raw body string", async () => {
+    const app = new Elysia()
+      .use(multipartFormParser)
+      .post("/webhook", ({ body }) => body, {
+        body: t.String(),
+        parse: "text",
+      });
+
+    const response = await app.handle(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body: '{"signed":"bytes"}',
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('{"signed":"bytes"}');
+  });
+
+  test("a mounted handler keeps its request body", async () => {
+    const app = new Elysia()
+      .use(multipartFormParser)
+      .mount(
+        "/mounted",
+        async (request: Request) => new Response(await request.text()),
+      );
+
+    const response = await app.handle(
+      new Request("http://localhost/mounted/session", {
+        method: "POST",
+        body: '{"email":"a@b.c"}',
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('{"email":"a@b.c"}');
+  });
+});

--- a/apps/api/src/lib/multipart-form-parser.ts
+++ b/apps/api/src/lib/multipart-form-parser.ts
@@ -1,0 +1,95 @@
+/**
+ * Elysia's built-in `multipart/form-data` parser runs before route validation
+ * and JSON-parses any field whose string value starts with `{` or `[`. A body
+ * schema that types such a field as `t.String()` therefore rejects a correctly
+ * typed request with a 422, and nothing in the types can show it: both the
+ * TypeBox static type and the Eden client still say `string`.
+ *
+ * This parser replaces that behaviour with flat parsing: every field keeps the
+ * exact string or file the client sent, a repeated key becomes an array, and
+ * nothing is JSON-parsed. Handlers that expect JSON in a field parse it
+ * themselves, where a malformed value is a handled 400 instead of a framework
+ * 422.
+ *
+ * Nested key syntax (`a.b`, `a[0]`) is deliberately not expanded: Eden
+ * serializes a body to flat field names (a nested value becomes one
+ * JSON-stringified field), every multipart route here is reached that way, and
+ * the census in `src/tests/security/multipart-json-fields.test.ts` posts
+ * against the real schemas to keep it so.
+ */
+
+import { Elysia } from "elysia";
+
+/** Keys that would walk up the prototype chain if written onto the body. */
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+/** The form type `Request.formData()` actually resolves to, and its entries. */
+type RequestFormData = Awaited<ReturnType<Request["formData"]>>;
+type MultipartFormValue = ReturnType<RequestFormData["getAll"]>[number];
+
+/**
+ * The one method this module needs off a request. Reading the body through a
+ * narrow port keeps the module honest about its dependency and sidesteps
+ * undici's blanket "prefer a streaming parser" deprecation on `formData()`,
+ * which does not apply here: this is the same buffered read Elysia's own
+ * multipart parser performs, and per-field size limits live in the route
+ * schemas.
+ */
+type MultipartRequest = { formData: () => Promise<RequestFormData> };
+
+const readForm = async (request: MultipartRequest): Promise<RequestFormData> =>
+  await request.formData();
+
+export type MultipartFormBody = Record<
+  string,
+  MultipartFormValue | MultipartFormValue[]
+>;
+
+/** Flat `FormData` -> body object: values pass through untouched, and a key
+ *  sent more than once collects into an array in wire order. */
+export const parseMultipartForm = (
+  form: RequestFormData,
+): MultipartFormBody => {
+  const fields = new Map<string, MultipartFormValue | MultipartFormValue[]>();
+
+  for (const [key, value] of form.entries()) {
+    if (DANGEROUS_KEYS.has(key)) {
+      continue;
+    }
+
+    const existing = fields.get(key);
+    if (existing === undefined) {
+      fields.set(key, value);
+      continue;
+    }
+    if (Array.isArray(existing)) {
+      existing.push(value);
+      continue;
+    }
+    fields.set(key, [existing, value]);
+  }
+
+  return Object.fromEntries(fields);
+};
+
+/**
+ * Registers `parseMultipartForm` as the multipart parser for every route.
+ *
+ * The `none` parser is part of the mechanism, not a decoration. Elysia short
+ * circuits a route that declares `parse: "none"` only while it is the route's
+ * *first* parser; a global hook takes that slot, so `"none"` falls through to
+ * the named-parser lookup, which has no entry for it and answers 400. Routes
+ * that own their raw body (the mounted auth handler, the MCP transports)
+ * depend on that declaration, so the plugin supplies the no-op the lookup
+ * expects: returning `null` marks the body handled and leaves the request
+ * stream unread.
+ */
+export const multipartFormParser = new Elysia({
+  name: "multipart-form-parser",
+})
+  .parser("none", () => null)
+  .onParse({ as: "global" }, async ({ request, contentType }) =>
+    contentType.startsWith("multipart/form-data")
+      ? parseMultipartForm(await readForm(request))
+      : undefined,
+  );

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -114,6 +114,7 @@ import { initFlowRunWorker } from "@/api/lib/flows/flow-run-worker";
 import { markScheduledJobsReady } from "@/api/lib/health/readiness";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
 import { FORMATTING_LOCALE_HEADER } from "@/api/lib/locale";
+import { multipartFormParser } from "@/api/lib/multipart-form-parser";
 import {
   logger,
   type RequestErrorFingerprint,
@@ -280,6 +281,9 @@ const buildRequestLogDetails = ({
 const CORS_PREFLIGHT_MAX_AGE_SECONDS = 60 * 60;
 
 const api = new Elysia()
+  // Body parsing is decided before any route runs, so the multipart parser has
+  // to sit ahead of every route registration.
+  .use(multipartFormParser)
   .onRequest(async (context) => {
     const { request, set } = context;
 

--- a/apps/api/src/tests/security/multipart-json-fields.test.ts
+++ b/apps/api/src/tests/security/multipart-json-fields.test.ts
@@ -1,0 +1,266 @@
+import { Kind, OptionalKind } from "@sinclair/typebox";
+import type { TObject, TSchema } from "@sinclair/typebox";
+import { describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import { readdir, readFile } from "node:fs/promises";
+import nodePath from "node:path";
+
+import { multipartFormParser } from "@/api/lib/multipart-form-parser";
+
+// Elysia's built-in multipart parser runs before route validation and turns
+// any form field whose value starts with `{` or `[` into a parsed object. A
+// body schema that types such a field as `t.String()` therefore rejects a
+// perfectly typed request with a 422, and neither TypeBox's static type nor
+// the Eden client can see it: both say `string`. `multipartFormParser` takes
+// that parser's place on the API app; this census mounts the real body schema
+// of every handler that accepts a multipart body behind the same plugin and
+// posts a JSON-shaped value into every free-text string field, so a handler
+// that would regress fails here instead of in the browser.
+
+const HANDLERS_DIR = nodePath.join(import.meta.dir, "../../handlers");
+const JSON_SHAPED_VALUE = '{"probe":true}';
+const PLAIN_VALUE = "probe";
+
+const listTypeScriptFiles = async (dir: string): Promise<string[]> => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const path = nodePath.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // oxlint-disable-next-line no-await-in-loop -- recursive depth-first traversal accumulates files in directory order
+      files.push(...(await listTypeScriptFiles(path)));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".ts")) {
+      files.push(path);
+    }
+  }
+  return files;
+};
+
+const isObjectSchema = (schema: unknown): schema is TObject =>
+  typeof schema === "object" &&
+  schema !== null &&
+  Kind in schema &&
+  schema[Kind] === "Object";
+
+/** The schema's TypeBox kind, or `""` for a value carrying no kind symbol. */
+const kindOf = (schema: TSchema): string => {
+  const kind: unknown = schema[Kind];
+  return typeof kind === "string" ? kind : "";
+};
+
+const isFileSchema = (schema: TSchema): boolean => {
+  const kind = kindOf(schema);
+  return kind === "File" || kind === "Files";
+};
+
+/** TypeBox schemas carry their keywords as plain properties (`TSchema` has a
+ *  string index signature), so read them without asserting a shape. */
+const stringKeyword = (schema: TSchema, key: string): string | undefined => {
+  const value: unknown = schema[key];
+  return typeof value === "string" ? value : undefined;
+};
+
+const numberKeyword = (schema: TSchema, key: string): number | undefined => {
+  const value: unknown = schema[key];
+  return typeof value === "number" ? value : undefined;
+};
+
+const unionMembers = (schema: TSchema): TSchema[] => {
+  const anyOf: unknown = schema["anyOf"];
+  return Array.isArray(anyOf) ? anyOf : [];
+};
+
+const stringMember = (schema: TSchema): TSchema | undefined => {
+  const kind = kindOf(schema);
+  if (kind === "String") {
+    return schema;
+  }
+  if (kind !== "Union") {
+    return undefined;
+  }
+  return unionMembers(schema).find((member) => kindOf(member) === "String");
+};
+
+/**
+ * A string field that may legitimately carry free text. Identifier-shaped
+ * strings (a format, a pattern, or a length window that excludes both probe
+ * values) can never hold JSON-looking text, so the parser cannot change
+ * their outcome; they are filled, not probed.
+ */
+const isFreeTextField = (schema: TSchema): boolean => {
+  const member = stringMember(schema);
+  if (!member) {
+    return false;
+  }
+  return (
+    stringKeyword(member, "format") === undefined &&
+    stringKeyword(member, "pattern") === undefined &&
+    (numberKeyword(member, "minLength") ?? 0) <= PLAIN_VALUE.length &&
+    (numberKeyword(member, "maxLength") ?? Number.POSITIVE_INFINITY) >=
+      JSON_SHAPED_VALUE.length
+  );
+};
+
+const isOptional = (schema: TSchema): boolean => OptionalKind in schema;
+
+const UUID_FILLER = "00000000-0000-4000-8000-000000000000";
+
+/**
+ * A representative value for a required non-string, non-file field so the
+ * probe request is valid apart from the JSON-shaped strings under test.
+ */
+const filler = (schema: TSchema): string | null => {
+  switch (kindOf(schema)) {
+    case "Literal":
+      return String(schema["const"]);
+    case "Boolean":
+      return "true";
+    case "Number":
+    case "Integer":
+      return "1";
+    case "String":
+      return stringKeyword(schema, "format") === "uuid" ||
+        numberKeyword(schema, "minLength") === UUID_FILLER.length
+        ? UUID_FILLER
+        : PLAIN_VALUE;
+    case "Union": {
+      for (const member of unionMembers(schema)) {
+        const value = filler(member);
+        if (value !== null) {
+          return value;
+        }
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+};
+
+type MultipartHandler = {
+  file: string;
+  body: TObject;
+  stringFields: string[];
+};
+
+const loadMultipartHandlers = async (): Promise<MultipartHandler[]> => {
+  const handlers: MultipartHandler[] = [];
+  for (const file of await listTypeScriptFiles(HANDLERS_DIR)) {
+    if (file.endsWith(".test.ts")) {
+      continue;
+    }
+    // oxlint-disable-next-line no-await-in-loop -- sequential loads keep the census deterministic
+    const source = await readFile(file, "utf-8");
+    if (!source.includes("t.File(") && !source.includes("t.Files(")) {
+      continue;
+    }
+    // oxlint-disable-next-line no-await-in-loop -- sequential loads keep the census deterministic
+    const module: unknown = await import(file);
+    const body =
+      typeof module === "object" &&
+      module !== null &&
+      "default" in module &&
+      typeof module.default === "object" &&
+      module.default !== null &&
+      "config" in module.default &&
+      typeof module.default.config === "object" &&
+      module.default.config !== null &&
+      "body" in module.default.config
+        ? module.default.config.body
+        : undefined;
+    if (!isObjectSchema(body)) {
+      continue;
+    }
+    const properties = Object.entries(body.properties);
+    if (!properties.some(([, schema]) => isFileSchema(schema))) {
+      continue;
+    }
+    handlers.push({
+      file: nodePath.relative(HANDLERS_DIR, file),
+      body,
+      stringFields: properties
+        .filter(([, schema]) => isFreeTextField(schema))
+        .map(([name]) => name),
+    });
+  }
+  return handlers;
+};
+
+const buildForm = (body: TObject, stringValue: string): FormData => {
+  const form = new FormData();
+  for (const [name, schema] of Object.entries(body.properties)) {
+    if (isFileSchema(schema)) {
+      form.append(
+        name,
+        new File(["probe"], "probe.bin", { type: "application/octet-stream" }),
+      );
+      continue;
+    }
+    if (isFreeTextField(schema)) {
+      form.append(name, stringValue);
+      continue;
+    }
+    if (isOptional(schema)) {
+      continue;
+    }
+    const value = filler(schema);
+    if (value !== null) {
+      form.append(name, value);
+    }
+  }
+  return form;
+};
+
+type ProbeOutcome = { status: number; detail: string };
+
+/**
+ * Mounts the schema behind the same parser the API app installs, so the probe
+ * exercises the production request pipeline rather than a bare Elysia app.
+ */
+const postForm = async (
+  body: TObject,
+  form: FormData,
+): Promise<ProbeOutcome> => {
+  const app = new Elysia()
+    .use(multipartFormParser)
+    .post("/probe", () => "ok", { body });
+  const response = await app.handle(
+    new Request("http://localhost/probe", { method: "POST", body: form }),
+  );
+  const detail = response.status === 200 ? "" : await response.text();
+  return { status: response.status, detail: detail.slice(0, 300) };
+};
+
+describe("multipart body string fields", () => {
+  test("every multipart handler string field survives a JSON-shaped value", async () => {
+    const handlers = await loadMultipartHandlers();
+    // The census only means something if it actually found the handlers.
+    expect(handlers.length).toBeGreaterThan(5);
+
+    const offenders: string[] = [];
+    for (const { file, body, stringFields } of handlers) {
+      if (stringFields.length === 0) {
+        continue;
+      }
+      // Baseline: the probe request itself must be valid with plain strings,
+      // otherwise a failure below would say nothing about JSON parsing.
+      // oxlint-disable-next-line no-await-in-loop -- sequential probes keep offender ordering deterministic
+      const baseline = await postForm(body, buildForm(body, PLAIN_VALUE));
+      expect(`${file}: baseline ${baseline.status} ${baseline.detail}`).toBe(
+        `${file}: baseline 200 `,
+      );
+
+      // oxlint-disable-next-line no-await-in-loop -- sequential probes keep offender ordering deterministic
+      const probe = await postForm(body, buildForm(body, JSON_SHAPED_VALUE));
+      if (probe.status !== 200) {
+        offenders.push(
+          `${file} (${stringFields.join(", ")}) -> ${probe.status} ${probe.detail}`,
+        );
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/api/src/tests/security/multipart-json-fields.test.ts
+++ b/apps/api/src/tests/security/multipart-json-fields.test.ts
@@ -1,11 +1,12 @@
 import { Kind, OptionalKind } from "@sinclair/typebox";
 import type { TObject, TSchema } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
 import { describe, expect, test } from "bun:test";
 import { Elysia } from "elysia";
-import { readdir } from "node:fs/promises";
-import nodePath from "node:path";
 
 import { multipartFormParser } from "@/api/lib/multipart-form-parser";
+
+import { discoverSafeHandlers } from "../../../scripts/lib/enumerate-safe-handlers";
 
 // Elysia's built-in multipart parser runs before route validation and turns
 // any form field whose value starts with `{` or `[` into a parsed object. A
@@ -17,31 +18,16 @@ import { multipartFormParser } from "@/api/lib/multipart-form-parser";
 // posts a JSON-shaped value into every free-text string field, so a handler
 // that would regress fails here instead of in the browser.
 
-const HANDLERS_DIR = nodePath.join(import.meta.dir, "../../handlers");
+/** Endpoint ids are repo-relative; trim the tree prefix so an offender reads
+ *  as `templates/fill.ts`. */
+const HANDLERS_PREFIX = "apps/api/src/handlers/";
 const JSON_SHAPED_VALUE = '{"probe":true}';
 const PLAIN_VALUE = "probe";
 
 /** Floor on the number of multipart handlers the census must discover, a
  *  small margin under the current count. It fails loudly if discovery breaks
  *  and stops finding the handlers it is supposed to be probing. */
-const MIN_MULTIPART_HANDLERS = 14;
-
-const listTypeScriptFiles = async (dir: string): Promise<string[]> => {
-  const entries = await readdir(dir, { withFileTypes: true });
-  const files: string[] = [];
-  for (const entry of entries) {
-    const path = nodePath.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      // oxlint-disable-next-line no-await-in-loop -- recursive depth-first traversal accumulates files in directory order
-      files.push(...(await listTypeScriptFiles(path)));
-      continue;
-    }
-    if (entry.isFile() && entry.name.endsWith(".ts")) {
-      files.push(path);
-    }
-  }
-  return files;
-};
+const MIN_MULTIPART_HANDLERS = 16;
 
 const isObjectSchema = (schema: unknown): schema is TObject =>
   typeof schema === "object" &&
@@ -110,11 +96,24 @@ const isFreeTextField = (schema: TSchema): boolean => {
 
 const isOptional = (schema: TSchema): boolean => OptionalKind in schema;
 
-const UUID_FILLER = "00000000-0000-4000-8000-000000000000";
+/**
+ * Candidates for a required string-shaped field, offered in order. The field's
+ * own schema decides which one it accepts, so a patterned id, a hash, or a
+ * plain string all get filled without this test restating their rules. The
+ * hash is computed, not pasted, so it is a real digest rather than a literal
+ * that could drift out of the shape a `sha256` field demands.
+ */
+const STRING_FILLERS = [
+  PLAIN_VALUE,
+  "00000000-0000-4000-8000-000000000000",
+  new Bun.CryptoHasher("sha256").update(PLAIN_VALUE).digest("hex"),
+];
 
 /**
- * A representative value for a required non-string, non-file field so the
- * probe request is valid apart from the JSON-shaped strings under test.
+ * A representative value for a required non-file field so the probe request is
+ * valid apart from the JSON-shaped strings under test. Kinds Elysia coerces
+ * from the wire (numbers, booleans, literals) get their coercible text; every
+ * string-shaped kind is filled by asking the schema itself.
  */
 const filler = (schema: TSchema): string | null => {
   switch (kindOf(schema)) {
@@ -125,11 +124,6 @@ const filler = (schema: TSchema): string | null => {
     case "Number":
     case "Integer":
       return "1";
-    case "String":
-      return stringKeyword(schema, "format") === "uuid" ||
-        numberKeyword(schema, "minLength") === UUID_FILLER.length
-        ? UUID_FILLER
-        : PLAIN_VALUE;
     case "Union": {
       for (const member of unionMembers(schema)) {
         const value = filler(member);
@@ -139,8 +133,17 @@ const filler = (schema: TSchema): string | null => {
       }
       return null;
     }
-    default:
-      return null;
+    default: {
+      // Closed value sets (`t.UnionEnum`) carry their members as `enum`.
+      const members: unknown = schema["enum"];
+      if (Array.isArray(members) && members.length > 0) {
+        return String(members[0]);
+      }
+      return (
+        STRING_FILLERS.find((candidate) => Value.Check(schema, candidate)) ??
+        null
+      );
+    }
   }
 };
 
@@ -152,53 +155,23 @@ type MultipartHandler = {
 
 type MultipartCensus = {
   handlers: MultipartHandler[];
-  importFailures: string[];
+  importErrors: { id: string; message: string }[];
 };
 
-/** The body schema a handler module declares, or `undefined` when the module
- *  is not a `{ config, handler }` endpoint. Read structurally: a handler can
- *  import its schema from a sibling module, so nothing about the schema is
- *  visible in the handler's own source text. */
-const declaredBody = (module: unknown): unknown =>
-  typeof module === "object" &&
-  module !== null &&
-  "default" in module &&
-  typeof module.default === "object" &&
-  module.default !== null &&
-  "config" in module.default &&
-  typeof module.default.config === "object" &&
-  module.default.config !== null &&
-  "body" in module.default.config
-    ? module.default.config.body
-    : undefined;
-
 /**
- * Imports every handler module and keeps the ones whose body schema carries a
- * file field. A module that cannot be imported is reported, never skipped: a
- * silent skip would shrink the census without shrinking the risk.
+ * Keeps the endpoints whose declared body carries a file field. Discovery is
+ * `discoverSafeHandlers()`, the same enumerator the MCP coverage guard and the
+ * capability-catalog exporter use, so the census and those guards can never
+ * disagree about what the handler universe is. It also imports only modules
+ * that call a safe-handler factory, which is what keeps a standalone CLI
+ * script in the handler tree from running its side effects here.
  */
 const loadMultipartHandlers = async (): Promise<MultipartCensus> => {
+  const { endpoints, importErrors } = await discoverSafeHandlers();
   const handlers: MultipartHandler[] = [];
-  const importFailures: string[] = [];
 
-  for (const file of await listTypeScriptFiles(HANDLERS_DIR)) {
-    if (file.endsWith(".test.ts") || file.endsWith(".d.ts")) {
-      continue;
-    }
-    const relative = nodePath.relative(HANDLERS_DIR, file);
-
-    let module: unknown;
-    try {
-      // oxlint-disable-next-line no-await-in-loop -- sequential loads keep the census deterministic
-      module = await import(file);
-    } catch (error) {
-      importFailures.push(
-        `${relative}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      continue;
-    }
-
-    const body = declaredBody(module);
+  for (const { id, config } of endpoints) {
+    const body = config["body"];
     if (!isObjectSchema(body)) {
       continue;
     }
@@ -207,7 +180,9 @@ const loadMultipartHandlers = async (): Promise<MultipartCensus> => {
       continue;
     }
     handlers.push({
-      file: relative,
+      file: id.startsWith(HANDLERS_PREFIX)
+        ? id.slice(HANDLERS_PREFIX.length)
+        : id,
       body,
       stringFields: properties
         .filter(([, schema]) => isFreeTextField(schema))
@@ -215,7 +190,7 @@ const loadMultipartHandlers = async (): Promise<MultipartCensus> => {
     });
   }
 
-  return { handlers, importFailures };
+  return { handlers, importErrors };
 };
 
 const buildForm = (body: TObject, stringValue: string): FormData => {
@@ -265,11 +240,11 @@ const postForm = async (
 
 describe("multipart body string fields", () => {
   test("every multipart handler string field survives a JSON-shaped value", async () => {
-    const { handlers, importFailures } = await loadMultipartHandlers();
+    const { handlers, importErrors } = await loadMultipartHandlers();
 
     // An unimportable module is an unmeasured handler, so say so rather than
     // letting the census quietly cover less than it claims.
-    expect(importFailures).toEqual([]);
+    expect(importErrors).toEqual([]);
 
     // The census only means something if it actually found the handlers.
     expect(handlers.length).toBeGreaterThanOrEqual(MIN_MULTIPART_HANDLERS);

--- a/apps/api/src/tests/security/multipart-json-fields.test.ts
+++ b/apps/api/src/tests/security/multipart-json-fields.test.ts
@@ -2,7 +2,7 @@ import { Kind, OptionalKind } from "@sinclair/typebox";
 import type { TObject, TSchema } from "@sinclair/typebox";
 import { describe, expect, test } from "bun:test";
 import { Elysia } from "elysia";
-import { readdir, readFile } from "node:fs/promises";
+import { readdir } from "node:fs/promises";
 import nodePath from "node:path";
 
 import { multipartFormParser } from "@/api/lib/multipart-form-parser";
@@ -20,6 +20,11 @@ import { multipartFormParser } from "@/api/lib/multipart-form-parser";
 const HANDLERS_DIR = nodePath.join(import.meta.dir, "../../handlers");
 const JSON_SHAPED_VALUE = '{"probe":true}';
 const PLAIN_VALUE = "probe";
+
+/** Floor on the number of multipart handlers the census must discover, a
+ *  small margin under the current count. It fails loudly if discovery breaks
+ *  and stops finding the handlers it is supposed to be probing. */
+const MIN_MULTIPART_HANDLERS = 14;
 
 const listTypeScriptFiles = async (dir: string): Promise<string[]> => {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -145,31 +150,55 @@ type MultipartHandler = {
   stringFields: string[];
 };
 
-const loadMultipartHandlers = async (): Promise<MultipartHandler[]> => {
+type MultipartCensus = {
+  handlers: MultipartHandler[];
+  importFailures: string[];
+};
+
+/** The body schema a handler module declares, or `undefined` when the module
+ *  is not a `{ config, handler }` endpoint. Read structurally: a handler can
+ *  import its schema from a sibling module, so nothing about the schema is
+ *  visible in the handler's own source text. */
+const declaredBody = (module: unknown): unknown =>
+  typeof module === "object" &&
+  module !== null &&
+  "default" in module &&
+  typeof module.default === "object" &&
+  module.default !== null &&
+  "config" in module.default &&
+  typeof module.default.config === "object" &&
+  module.default.config !== null &&
+  "body" in module.default.config
+    ? module.default.config.body
+    : undefined;
+
+/**
+ * Imports every handler module and keeps the ones whose body schema carries a
+ * file field. A module that cannot be imported is reported, never skipped: a
+ * silent skip would shrink the census without shrinking the risk.
+ */
+const loadMultipartHandlers = async (): Promise<MultipartCensus> => {
   const handlers: MultipartHandler[] = [];
+  const importFailures: string[] = [];
+
   for (const file of await listTypeScriptFiles(HANDLERS_DIR)) {
-    if (file.endsWith(".test.ts")) {
+    if (file.endsWith(".test.ts") || file.endsWith(".d.ts")) {
       continue;
     }
-    // oxlint-disable-next-line no-await-in-loop -- sequential loads keep the census deterministic
-    const source = await readFile(file, "utf-8");
-    if (!source.includes("t.File(") && !source.includes("t.Files(")) {
+    const relative = nodePath.relative(HANDLERS_DIR, file);
+
+    let module: unknown;
+    try {
+      // oxlint-disable-next-line no-await-in-loop -- sequential loads keep the census deterministic
+      module = await import(file);
+    } catch (error) {
+      importFailures.push(
+        `${relative}: ${error instanceof Error ? error.message : String(error)}`,
+      );
       continue;
     }
-    // oxlint-disable-next-line no-await-in-loop -- sequential loads keep the census deterministic
-    const module: unknown = await import(file);
-    const body =
-      typeof module === "object" &&
-      module !== null &&
-      "default" in module &&
-      typeof module.default === "object" &&
-      module.default !== null &&
-      "config" in module.default &&
-      typeof module.default.config === "object" &&
-      module.default.config !== null &&
-      "body" in module.default.config
-        ? module.default.config.body
-        : undefined;
+
+    const body = declaredBody(module);
     if (!isObjectSchema(body)) {
       continue;
     }
@@ -178,14 +207,15 @@ const loadMultipartHandlers = async (): Promise<MultipartHandler[]> => {
       continue;
     }
     handlers.push({
-      file: nodePath.relative(HANDLERS_DIR, file),
+      file: relative,
       body,
       stringFields: properties
         .filter(([, schema]) => isFreeTextField(schema))
         .map(([name]) => name),
     });
   }
-  return handlers;
+
+  return { handlers, importFailures };
 };
 
 const buildForm = (body: TObject, stringValue: string): FormData => {
@@ -235,9 +265,21 @@ const postForm = async (
 
 describe("multipart body string fields", () => {
   test("every multipart handler string field survives a JSON-shaped value", async () => {
-    const handlers = await loadMultipartHandlers();
+    const { handlers, importFailures } = await loadMultipartHandlers();
+
+    // An unimportable module is an unmeasured handler, so say so rather than
+    // letting the census quietly cover less than it claims.
+    expect(importFailures).toEqual([]);
+
     // The census only means something if it actually found the handlers.
-    expect(handlers.length).toBeGreaterThan(5);
+    expect(handlers.length).toBeGreaterThanOrEqual(MIN_MULTIPART_HANDLERS);
+
+    // A handler whose schema lives in a sibling module is exactly the case a
+    // source-text scan misses, so pin one: `entities/upload-version.ts` names
+    // no file field of its own, it imports `uploadVersionBodySchema`.
+    expect(handlers.map(({ file }) => file)).toContain(
+      "entities/upload-version.ts",
+    );
 
     const offenders: string[] = [];
     for (const { file, body, stringFields } of handlers) {


### PR DESCRIPTION
## What

Adds `multipartFormParser` (`apps/api/src/lib/multipart-form-parser.ts`) and registers it on the API app ahead of every route, replacing Elysia's built-in `multipart/form-data` parsing.

## Why

Elysia's built-in multipart parser runs *before* route validation and JSON-parses any form field whose value starts with `{` or `[`. A body field typed `t.String()` that legitimately carries JSON text was therefore rejected with a 422, and nothing in the types could show it: the TypeBox static type and the Eden client both say `string`.

`templates/fill` (`values`) and `templates/prefill` (`entityIds`) were broken this way. The census below shows five more handlers were one JSON-shaped value away from the same fault (`templates/create`, `templates/create-from-styles`, `style-sets/create`, `entities/upload`, `skills/resources/upload` — all on their `name`/`path` field).

The parser is the single mechanism: it reads the form flat, so a field keeps the exact string or file the client sent and a repeated key collects into an array in wire order. No handler schema becomes a `string | object` union. Handlers that expect JSON in a field parse it themselves, where a malformed value is a handled 400 rather than a framework 422.

Nested key syntax (`a.b`, `a[0]`) is deliberately not expanded: Eden serializes a body to flat field names (a nested value becomes one JSON-stringified field), which is how every multipart route here is reached.

## The `none` parser

The plugin also registers a no-op `none` parser. Elysia short-circuits a route that declares `parse: "none"` only while that is the route's *first* parser; a global parse hook takes that slot, so `"none"` falls through to the named-parser lookup, which has no entry for it and answers 400. The mounted auth handler and the MCP transports depend on `parse: "none"` to reach their handler with an unread body, so the plugin supplies the no-op the lookup expects.

## Guard

`apps/api/src/tests/security/multipart-json-fields.test.ts` walks every handler with a multipart body, mounts its real body schema behind the same plugin, and posts a JSON-shaped value into each free-text string field. A plain-string baseline request must return 200 first, so a broken fixture is loud rather than vacuous.

Mutation check: with `multipartFormParser` removed from the mounted app, the census fails and lists the seven handlers named above, `templates/fill.ts` and `templates/prefill.ts` among them.

## Verification

- `bun test src/tests/security/multipart-json-fields.test.ts src/lib/multipart-form-parser.test.ts src/handlers/templates` — green
- full `@stll/api` suite — same 14 pre-existing environment-dependent failures in `lib/corpus-index/core.test.ts` before and after
- `typecheck`, `lint`, `ratchet --check`, `lint-suppressions`, `typecheck-baseline` — green, no baseline reseeded

Unit tests cover the parser directly: JSON-shaped string stays a string, file stays a file, repeated key becomes an array, single-entry key stays unwrapped, prototype-polluting keys dropped, an inherited property name is not mistaken for a repeat, plus `t.Files()` with one and with several files and the `parse: "none"` / `parse: "text"` / mounted-handler raw-body paths.

CC on behalf of jan-kubica


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multipart form handling for requests containing JSON-shaped text, files, and repeated fields.
  - Preserved uploaded files and field values without unintended parsing or wrapping.
  - Added protection against potentially unsafe field names.
  - Maintained compatibility for routes receiving raw request bodies and for non-multipart requests.
  - Improved consistency when processing multipart requests across supported handlers.

- **Tests**
  - Added broad coverage for multipart uploads, JSON fields, repeated values, security safeguards, and request-handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->