### PR TITLE
fix(api): citation authority without the decision-age divisor; bounded in the blend

### DIFF
--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -319,7 +319,7 @@ export const caseLawDecisions = p.pgTable(
       .notNull(),
     /**
      * Materialized citation-authority ranking signal: the
-     * ln(1 + weighted-citation-density) value that `citationScore()`
+     * ln(1 + weighted-citation-sum) value that `citationScore()`
      * computes. Precomputed by the post-ingestion citation pass so
      * search reads it instead of recomputing the citation-graph
      * aggregate per query. Decays slowly with time; refreshed on a

--- a/apps/api/src/handlers/case-law/__tests__/citation-score.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/citation-score.test.ts
@@ -4,9 +4,15 @@ import {
   citationScore,
   courtWeight,
   courtWeightSql,
+  polarityWeightSql,
   recencyFactor,
   weightedCitationSum,
 } from "@/api/handlers/case-law/citation-score";
+import {
+  POLARITIES,
+  POLARITY,
+  POLARITY_AUTHORITY_WEIGHT,
+} from "@/api/handlers/case-law/polarity/consts";
 
 describe("courtWeight", () => {
   test("constitutional court → tier 4", () => {
@@ -241,6 +247,66 @@ describe("citationScore", () => {
       withDecisionAgeDivisor(weightedCitationSum(landmarkCitations, now), 20),
     ).toBeLessThan(
       withDecisionAgeDivisor(weightedCitationSum(recentCitations, now), 2),
+    );
+  });
+});
+
+describe("polarity weighting", () => {
+  const now = new Date("2025-01-01");
+  const citation = {
+    citingCourt: "Nejvyšší soud",
+    citingDate: "2024-01-01",
+  };
+
+  test("a negative treatment adds exactly nothing to the sum", () => {
+    const followed = weightedCitationSum(
+      [citation, { ...citation, polarity: POLARITY.POSITIVE }],
+      now,
+    );
+    const overruled = weightedCitationSum(
+      [citation, { ...citation, polarity: POLARITY.NEGATIVE }],
+      now,
+    );
+
+    // The two sets differ in one citation's polarity and nothing else, so the
+    // gap is that citation's whole contribution: court weight times decay.
+    const contribution = weightedCitationSum([citation], now);
+    expect(followed - overruled).toBeCloseTo(contribution, 12);
+    expect(overruled).toBeCloseTo(contribution, 12);
+    expect(
+      citationScore([{ ...citation, polarity: POLARITY.NEGATIVE }], now),
+    ).toBe(0);
+  });
+
+  test("an unclassified citation weighs the same as a classified neutral one", () => {
+    // The corpus is mostly unclassified; scoring null below `neutral` would
+    // rank classification coverage instead of case law.
+    const unclassified = weightedCitationSum([citation], now);
+    for (const polarity of POLARITIES) {
+      if (polarity !== POLARITY.NEGATIVE) {
+        expect(
+          weightedCitationSum([{ ...citation, polarity }], now),
+        ).toBeCloseTo(unclassified, 12);
+      }
+    }
+  });
+});
+
+describe("polarityWeightSql", () => {
+  test("renders one branch per non-default polarity, from the shared map", () => {
+    const generated = polarityWeightSql("c.polarity");
+    for (const polarity of POLARITIES) {
+      if (polarity === POLARITY.UNKNOWN) {
+        // `unknown` is the ELSE branch, which is also where NULL lands.
+        expect(generated).not.toContain(`= '${polarity}'`);
+      } else {
+        expect(generated).toContain(
+          `WHEN c.polarity = '${polarity}' THEN ${POLARITY_AUTHORITY_WEIGHT[polarity]}`,
+        );
+      }
+    }
+    expect(generated).toContain(
+      `ELSE ${POLARITY_AUTHORITY_WEIGHT[POLARITY.UNKNOWN]} END`,
     );
   });
 });

--- a/apps/api/src/handlers/case-law/__tests__/citation-score.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/citation-score.test.ts
@@ -134,7 +134,7 @@ describe("citationScore", () => {
   const now = new Date("2025-01-01");
 
   test("no citations → 0", () => {
-    expect(citationScore([], "2020-01-01", now)).toBe(0);
+    expect(citationScore([], now)).toBe(0);
   });
 
   test("positive with citations", () => {
@@ -145,7 +145,6 @@ describe("citationScore", () => {
           citingDate: "2024-06-01",
         },
       ],
-      "2020-01-01",
       now,
     );
     expect(score).toBeGreaterThan(0);
@@ -158,49 +157,91 @@ describe("citationScore", () => {
         citingDate: "2024-06-01",
       }));
 
-    const ten = citationScore(makeCitations(10), "2015-01-01", now);
-    const hundred = citationScore(makeCitations(100), "2015-01-01", now);
+    const ten = citationScore(makeCitations(10), now);
+    const hundred = citationScore(makeCitations(100), now);
 
     expect(hundred).toBeGreaterThan(ten);
     expect(hundred / ten).toBeLessThan(4);
   });
 
-  test("density: recent few citations beat old many", () => {
-    // 2024 decision with 5 recent supreme citations
-    const recent = citationScore(
+  test("a decision still being cited beats one whose citations went stale", () => {
+    // The citing side carries recency on its own, which is why the cited
+    // decision's own age is not part of the score: 5 citations from this year
+    // outweigh 20 from twenty years ago.
+    const stillCited = citationScore(
       Array.from({ length: 5 }, () => ({
         citingCourt: "Nejvyšší soud",
-        citingDate: "2025-06-01",
+        citingDate: "2024-11-01",
       })),
-      "2024-01-01",
       now,
     );
 
-    // 2000 decision with 20 old district citations
-    const old = citationScore(
+    const stale = citationScore(
       Array.from({ length: 20 }, () => ({
         citingCourt: "Okresní soud v Ostravě",
         citingDate: "2005-01-01",
       })),
-      "2000-01-01",
       now,
     );
 
-    expect(recent).toBeGreaterThan(old);
+    expect(stillCited).toBeGreaterThan(stale);
   });
 
-  test("null decision date → yearsOld defaults to 1", () => {
-    const score = citationScore(
-      [
-        {
-          citingCourt: "Nejvyšší soud",
-          citingDate: "2024-06-01",
-        },
-      ],
-      null,
-      now,
+  test("a landmark decision is no longer buried under a recent one", () => {
+    // 200 citations, ten a year across the twenty years since publication.
+    const landmarkCitations = Array.from({ length: 20 }, (_, year) =>
+      Array.from({ length: 10 }, () => ({
+        citingCourt: "Okresní soud v Ostravě",
+        citingDate: `${2006 + year}-01-01`,
+      })),
+    ).flat();
+    // 8 citations, all from today, on a decision two years old.
+    const recentCitations = Array.from({ length: 8 }, () => ({
+      citingCourt: "Okresní soud v Ostravě",
+      citingDate: "2025-01-01",
+    }));
+
+    // Expected sums derived from the fixture, not from the implementation: a
+    // district court weighs 1 and a citation k years old contributes
+    // 1/(1 + k), so the landmark's sum is ten harmonic terms a year and the
+    // recent decision's is 8 citations at full weight. The harmonic form
+    // holds to a decimal rather than exactly, because the decay counts Julian
+    // years while the fixture's dates are calendar years.
+    const harmonic = Array.from({ length: 20 }, (_, k) => 1 / (1 + k)).reduce(
+      (a, b) => a + b,
+      0,
     );
-    expect(score).toBeGreaterThan(0);
+    expect(weightedCitationSum(landmarkCitations, now)).toBeCloseTo(
+      10 * harmonic,
+      1,
+    );
+    expect(weightedCitationSum(recentCitations, now)).toBe(8);
+
+    const landmark = citationScore(landmarkCitations, now);
+    const recent = citationScore(recentCitations, now);
+
+    expect(landmark).toBeCloseTo(Math.log(1 + 10 * harmonic), 3);
+    expect(recent).toBeCloseTo(Math.log(9), 12);
+    // The two numbers the module doc quotes, so the doc cannot drift.
+    expect(landmark).toBeCloseTo(3.61, 2);
+    expect(recent).toBeCloseTo(2.2, 2);
+    expect(landmark).toBeGreaterThan(recent);
+
+    // Under the removed divisor this ordering was inverted: the landmark's
+    // sum was charged for all twenty years it had been available to be cited.
+    const withDecisionAgeDivisor = (sum: number, yearsOld: number): number =>
+      Math.log(1 + sum / Math.max(yearsOld, 1));
+    expect(
+      withDecisionAgeDivisor(weightedCitationSum(landmarkCitations, now), 20),
+    ).toBeCloseTo(1.03, 2);
+    expect(
+      withDecisionAgeDivisor(weightedCitationSum(recentCitations, now), 2),
+    ).toBeCloseTo(1.61, 2);
+    expect(
+      withDecisionAgeDivisor(weightedCitationSum(landmarkCitations, now), 20),
+    ).toBeLessThan(
+      withDecisionAgeDivisor(weightedCitationSum(recentCitations, now), 2),
+    );
   });
 });
 

--- a/apps/api/src/handlers/case-law/citation-authority.test.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { eq, sql } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import {
@@ -215,7 +215,6 @@ test("materialized authority equals citationScore() at the same instant", async 
       { citingCourt: "Nejvyšší soud", citingDate: "2025-01-01" },
       { citingCourt: "Krajský soud", citingDate: "2018-01-01" },
     ],
-    "2020-01-01",
     NOW,
   );
 
@@ -236,12 +235,10 @@ test("a more authoritative citing court yields higher authority", async () => {
   // controlling for date so only court weight differs.
   const supreme = citationScore(
     [{ citingCourt: "Nejvyšší soud", citingDate: "2024-01-01" }],
-    "2020-01-01",
     NOW,
   );
   const regional = citationScore(
     [{ citingCourt: "Krajský soud", citingDate: "2024-01-01" }],
-    "2020-01-01",
     NOW,
   );
   expect(supreme).toBeGreaterThan(regional);
@@ -414,7 +411,6 @@ test("the contribution weight is a seam the aggregate reads through", async () =
       { citingCourt: "Nejvyšší soud", citingDate: "2025-01-01" },
       { citingCourt: "Krajský soud", citingDate: "2018-01-01" },
     ],
-    "2020-01-01",
     NOW,
   );
   // score = ln(1 + sum/age), so doubling the sum is ln(1 + 2*(e^score - 1)).
@@ -479,7 +475,6 @@ test("courtWeightEntries option drives the SQL instead of the legacy tiers", asy
   expect(await authorityOf(customCitedId)).toBeCloseTo(
     citationScore(
       [{ citingCourt: "Custom Seeded Court", citingDate: "2025-01-01" }],
-      "2020-01-01",
       NOW,
       new Map([["CZE", CUSTOM_ENTRIES]]),
     ),
@@ -491,7 +486,6 @@ test("courtWeightEntries option drives the SQL instead of the legacy tiers", asy
   expect(await authorityOf(customCitedId)).not.toBeCloseTo(
     citationScore(
       [{ citingCourt: "Custom Seeded Court", citingDate: "2025-01-01" }],
-      "2020-01-01",
       NOW,
     ),
     2,
@@ -500,4 +494,70 @@ test("courtWeightEntries option drives the SQL instead of the legacy tiers", asy
 
 test("an unrankable corpus is detected before a sweep walks it", async () => {
   expect(await db.transaction(hasResolvedCitations)).toBe(true);
+});
+
+test("the cited decision's own age does not change its authority", async () => {
+  // Two decisions with identical citation sets, published twenty-nine years
+  // apart. Authority reads the citing side only, so they have to score the
+  // same value: the removed divisor — the cited decision's own age — put the
+  // older one far below the newer for nothing but having existed longer.
+  const oldId = createSafeId<"caseLawDecision">();
+  const youngId = createSafeId<"caseLawDecision">();
+  await db.insert(caseLawDecisions).values([
+    {
+      id: oldId,
+      sourceId,
+      caseNumber: "7 Cdo 7/1995",
+      court: "Okresní soud",
+      country: "CZE",
+      language: "cs",
+      decisionDate: "1995-01-01",
+    },
+    {
+      id: youngId,
+      sourceId,
+      caseNumber: "8 Cdo 8/2024",
+      court: "Okresní soud",
+      country: "CZE",
+      language: "cs",
+      decisionDate: "2024-01-01",
+    },
+  ]);
+  await db.insert(caseLawCitations).values([
+    {
+      citingDecisionId: supremeCitingId,
+      citedDecisionId: oldId,
+      citationText: "7 Cdo 7/1995",
+    },
+    {
+      citingDecisionId: regionalCitingId,
+      citedDecisionId: oldId,
+      citationText: "7 Cdo 7/1995",
+    },
+    {
+      citingDecisionId: supremeCitingId,
+      citedDecisionId: youngId,
+      citationText: "8 Cdo 8/2024",
+    },
+    {
+      citingDecisionId: regionalCitingId,
+      citedDecisionId: youngId,
+      citationText: "8 Cdo 8/2024",
+    },
+  ]);
+
+  await markAllDue();
+  await sweep(1000);
+
+  // Not vacuous: the fixture differs precisely where the removed term read.
+  const dates = await db
+    .select({ id: caseLawDecisions.id, date: caseLawDecisions.decisionDate })
+    .from(caseLawDecisions)
+    .where(inArray(caseLawDecisions.id, [oldId, youngId]));
+  expect(new Set(dates.map((row) => row.date)).size).toBe(2);
+
+  const older = await authorityOf(oldId);
+  expect(older).toBe(await authorityOf(youngId));
+  expect(older).toBeGreaterThan(0);
+  expect(await countOf(oldId)).toBe(await countOf(youngId));
 });

--- a/apps/api/src/handlers/case-law/citation-authority.test.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.test.ts
@@ -9,13 +9,17 @@ import {
 } from "@/api/db/schema";
 import {
   type CitationContributionWeight,
-  courtRecencyContributionWeight,
+  citationContributionWeight,
   hasResolvedCitations,
   oldestCitationAuthorityRecomputeAt,
   recomputeCitationAuthorityBatch,
 } from "@/api/handlers/case-law/citation-authority";
-import { citationScore } from "@/api/handlers/case-law/citation-score";
+import {
+  citationScore,
+  type CitationInput,
+} from "@/api/handlers/case-law/citation-score";
 import type { CourtWeightEntry } from "@/api/handlers/case-law/court-weights";
+import { POLARITY } from "@/api/handlers/case-law/polarity/consts";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
@@ -32,6 +36,23 @@ import { createTestPglite } from "@/api/tests/pglite-test-db";
 
 const NOW = new Date("2026-06-05T00:00:00.000Z");
 
+/**
+ * What cites the fixture's cited decision, as `citationScore` sees it.
+ *
+ * Two unclassified citations and one negative treatment: the corpus is mostly
+ * unclassified, so the fixture has to carry both cases or the SQL could weigh
+ * NULL polarity any way it liked and still match.
+ */
+const CITED_CITATIONS = [
+  { citingCourt: "Nejvyšší soud", citingDate: "2025-01-01" },
+  { citingCourt: "Krajský soud", citingDate: "2018-01-01" },
+  {
+    citingCourt: "Nejvyšší soud",
+    citingDate: "2024-01-01",
+    polarity: POLARITY.NEGATIVE,
+  },
+] as const satisfies readonly CitationInput[];
+
 let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
 
@@ -39,6 +60,7 @@ const sourceId = createSafeId<"caseLawSource">();
 const citedId = createSafeId<"caseLawDecision">();
 const supremeCitingId = createSafeId<"caseLawDecision">();
 const regionalCitingId = createSafeId<"caseLawDecision">();
+const overrulingCitingId = createSafeId<"caseLawDecision">();
 const orphanId = createSafeId<"caseLawDecision">();
 
 type SweepOptions = {
@@ -157,6 +179,15 @@ beforeAll(
         language: "cs",
         decisionDate: "2021-01-01",
       },
+      {
+        id: overrulingCitingId,
+        sourceId,
+        caseNumber: "5 Cdo 5/2024",
+        court: "Nejvyšší soud",
+        country: "CZE",
+        language: "cs",
+        decisionDate: "2024-01-01",
+      },
     ]);
 
     await db.insert(caseLawCitations).values([
@@ -169,6 +200,12 @@ beforeAll(
         citingDecisionId: regionalCitingId,
         citedDecisionId: citedId,
         citationText: "1 Cdo 1/2020",
+      },
+      {
+        citingDecisionId: overrulingCitingId,
+        citedDecisionId: citedId,
+        citationText: "1 Cdo 1/2020",
+        polarity: POLARITY.NEGATIVE,
       },
     ]);
 
@@ -210,16 +247,24 @@ const snapshot = async (): Promise<
     .orderBy(caseLawDecisions.id);
 
 test("materialized authority equals citationScore() at the same instant", async () => {
-  const expected = citationScore(
-    [
-      { citingCourt: "Nejvyšší soud", citingDate: "2025-01-01" },
-      { citingCourt: "Krajský soud", citingDate: "2018-01-01" },
-    ],
+  const expected = citationScore([...CITED_CITATIONS], NOW);
+
+  // Not vacuous: the negative treatment is a citation the sum has to drop.
+  // Ignoring polarity would score the same fixture higher, so a SQL twin that
+  // forgot the polarity CASE could not pass the equality below.
+  const ignoringPolarity = citationScore(
+    CITED_CITATIONS.map(({ citingCourt, citingDate }) => ({
+      citingCourt,
+      citingDate,
+    })),
     NOW,
   );
+  expect(ignoringPolarity).toBeGreaterThan(expected);
 
   expect(await authorityOf(citedId)).toBeCloseTo(expected, 9);
-  expect(await countOf(citedId)).toBe(2);
+  // The overruling citation still counts: it is a citation, and the citator
+  // exists to surface exactly that one.
+  expect(await countOf(citedId)).toBe(3);
 });
 
 test("a decision with no incoming citations has zero authority", async () => {
@@ -402,23 +447,17 @@ test("the contribution weight is a seam the aggregate reads through", async () =
   // this expression alone. Doubling it must double the weighted sum and touch
   // nothing else, including the citation count.
   const doubled: CitationContributionWeight = (options) =>
-    sql`2 * (${courtRecencyContributionWeight(options)})`;
+    sql`2 * (${citationContributionWeight(options)})`;
   await markAllDue();
   await sweep(1000, { contributionWeight: doubled });
 
-  const expected = citationScore(
-    [
-      { citingCourt: "Nejvyšší soud", citingDate: "2025-01-01" },
-      { citingCourt: "Krajský soud", citingDate: "2018-01-01" },
-    ],
-    NOW,
-  );
-  // score = ln(1 + sum/age), so doubling the sum is ln(1 + 2*(e^score - 1)).
+  const expected = citationScore([...CITED_CITATIONS], NOW);
+  // score = ln(1 + sum), so doubling the sum is ln(1 + 2*(e^score - 1)).
   expect(await authorityOf(citedId)).toBeCloseTo(
     Math.log(1 + 2 * (Math.E ** expected - 1)),
     9,
   );
-  expect(await countOf(citedId)).toBe(2);
+  expect(await countOf(citedId)).toBe(3);
 
   await markAllDue();
   await sweep(1000);

--- a/apps/api/src/handlers/case-law/citation-authority.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.ts
@@ -9,9 +9,9 @@
  *   authority = ln(1 + weightedCitationSum)
  *
  * where each incoming citation contributes
- * `courtWeight(citingCourt) * 1/(1 + ageYears(citing))`. See citation-score.ts
- * for the reference TS implementation; this SQL must stay equal to
- * `citationScore(...)` evaluated at the same instant.
+ * `polarityWeight(polarity) * courtWeight(citingCourt) * 1/(1 + ageYears(citing))`.
+ * See citation-score.ts for the reference TS implementation; this SQL must
+ * stay equal to `citationScore(...)` evaluated at the same instant.
  *
  * Because the value decays with time (the citing decision's age references
  * "now"), it is a point-in-time snapshot refreshed on a schedule — the search

--- a/apps/api/src/handlers/case-law/citation-authority.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.ts
@@ -47,7 +47,10 @@ import { panic } from "better-result";
 import type { SQL } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 
-import { courtWeightSql } from "@/api/handlers/case-law/citation-score";
+import {
+  courtWeightSql,
+  polarityWeightSql,
+} from "@/api/handlers/case-law/citation-score";
 import type { CourtWeightEntry } from "@/api/handlers/case-law/court-weights";
 import { redistributableCaseLawSourceSqlFor } from "@/api/lib/case-law/redistribution";
 import { setCorpusBackfillStatementTimeout } from "@/api/lib/legal-search/backfill-statement-timeout";
@@ -97,34 +100,33 @@ export type CitationContributionOptions = {
 /**
  * What one incoming citation adds to a decision's weighted sum.
  *
- * A seam, not an abstraction for its own sake. The ranking's open question is
- * whether a citation that distinguishes or overrules a decision should count
- * for less than one that follows it, and answering it must not mean rewriting
- * the aggregate, the batching and the equality test against `citationScore` at
- * the same time. Everything outside this expression is arithmetic that would
- * not change; a polarity multiplier is a change to this expression alone.
+ * A seam, not an abstraction for its own sake: the polarity term below landed
+ * as a change to this expression alone, leaving the aggregate, the batching
+ * and the equality test against `citationScore` untouched.
  *
- * No polarity term today, deliberately. `case_law_citations.polarity` is
- * populated for almost nothing, so a discount keyed on it would not express
- * "endorsements rank above criticism" — it would express "classified citations
- * rank below unclassified ones", which misranks the corpus in proportion to
- * how little of it has been classified.
+ * The polarity weighting is binary for the reason a graded one was rejected.
+ * `case_law_citations.polarity` is populated for almost nothing, so any scheme
+ * that moved unclassified citations off full weight would express "classified
+ * citations rank below unclassified ones" rather than "endorsements rank above
+ * criticism". Zeroing negative treatments alone leaves every unclassified
+ * citation exactly where it was.
  */
 export type CitationContributionWeight = (
   options: CitationContributionOptions,
 ) => SQL;
 
 /**
- * Court authority multiplied by a hyperbolic decay on the citing decision's
- * age. Mirrors `courtWeight(...) * recencyFactor(...)` in citation-score.ts,
- * which is the equality the tests assert.
+ * Polarity, court authority, and a hyperbolic decay on the citing decision's
+ * age. Mirrors `polarityWeight(...) * courtWeight(...) * recencyFactor(...)`
+ * in citation-score.ts, which is the equality the tests assert.
  */
-export const courtRecencyContributionWeight: CitationContributionWeight = ({
+export const citationContributionWeight: CitationContributionWeight = ({
   aliases,
   courtWeightEntries,
   now,
 }) =>
-  sql`(${sql.raw(courtWeightSql(`${aliases.citing}.court`, courtWeightEntries))})
+  sql`(${sql.raw(polarityWeightSql(`${aliases.citation}.polarity`))})
+      * (${sql.raw(courtWeightSql(`${aliases.citing}.court`, courtWeightEntries))})
       * (1.0 / (1 + COALESCE(
           extract(
             epoch FROM (
@@ -186,7 +188,7 @@ export type CitationAuthorityBatchOptions = {
    */
   window: CitationAuthoritySweepWindow;
   courtWeightEntries?: CourtWeightEntry[] | undefined;
-  /** Defaults to `courtRecencyContributionWeight`. */
+  /** Defaults to `citationContributionWeight`. */
   contributionWeight?: CitationContributionWeight | undefined;
 };
 
@@ -298,7 +300,7 @@ export const oldestCitationAuthorityRecomputeAt = async (
 export const recomputeCitationAuthorityBatch = async (
   tx: CitationAuthorityTx,
   {
-    contributionWeight = courtRecencyContributionWeight,
+    contributionWeight = citationContributionWeight,
     courtWeightEntries,
     limit,
     window,

--- a/apps/api/src/handlers/case-law/citation-authority.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.ts
@@ -6,18 +6,18 @@
  * value the search SQL used to compute inline per query with a LATERAL over
  * the citation graph:
  *
- *   authority = ln(1 + weightedCitationSum / max(ageYears(decision), 1))
+ *   authority = ln(1 + weightedCitationSum)
  *
  * where each incoming citation contributes
  * `courtWeight(citingCourt) * 1/(1 + ageYears(citing))`. See citation-score.ts
  * for the reference TS implementation; this SQL must stay equal to
  * `citationScore(...)` evaluated at the same instant.
  *
- * Because the value decays with time (both age terms reference "now"), it is a
- * point-in-time snapshot refreshed on a schedule — the search blend tolerates
- * being stale by up to one refresh interval. Pass a fixed `now` to make the
- * computation deterministic (used by tests to assert equality against
- * `citationScore`).
+ * Because the value decays with time (the citing decision's age references
+ * "now"), it is a point-in-time snapshot refreshed on a schedule — the search
+ * blend tolerates being stale by up to one refresh interval. Pass a fixed
+ * `now` to make the computation deterministic (used by tests to assert
+ * equality against `citationScore`).
  *
  * **It runs in bounded batches, and it has to.** The whole-corpus form was one
  * UPDATE over every decision, which on a corpus of this size outruns the
@@ -314,7 +314,7 @@ export const recomputeCitationAuthorityBatch = async (
   await setCorpusBackfillStatementTimeout(tx);
   const result: unknown = await tx.execute(sql`
     WITH batch AS (
-      SELECT d.id, d.decision_date
+      SELECT d.id
         FROM case_law_decisions d
        WHERE d.citation_authority_computed_at IS NULL
           OR d.citation_authority_computed_at < ${staleBefore}::timestamptz
@@ -323,7 +323,6 @@ export const recomputeCitationAuthorityBatch = async (
     ),
     agg AS (
       SELECT b.id AS decision_id,
-             b.decision_date,
              coalesce(sum(
                CASE WHEN c.id IS NULL THEN 0 ELSE ${contribution} END
              ), 0) AS raw_sum,
@@ -341,24 +340,11 @@ export const recomputeCitationAuthorityBatch = async (
            -- authority being invoked; counting them would rank a decision by
            -- how often it was appealed.
            AND c.kind = 'precedent'
-       GROUP BY b.id, b.decision_date
+       GROUP BY b.id
     ),
     updated AS (
       UPDATE case_law_decisions d
-         SET citation_authority = ln(1 + (
-               agg.raw_sum / GREATEST(
-                 COALESCE(
-                   extract(
-                     epoch FROM (
-                       ${nowExpr}
-                       - (agg.decision_date::timestamp AT TIME ZONE 'UTC')
-                     )
-                   ) / ${SECONDS_PER_YEAR},
-                   1.0
-                 ),
-                 1.0
-               )
-             )),
+         SET citation_authority = ln(1 + agg.raw_sum),
              citation_count = agg.cnt,
              citation_authority_computed_at = ${nowExpr}
         FROM agg

--- a/apps/api/src/handlers/case-law/citation-score.ts
+++ b/apps/api/src/handlers/case-law/citation-score.ts
@@ -1,13 +1,21 @@
 /**
  * Citation authority scoring for case law decisions.
  *
- * Combines three signals:
- * 1. Citation density — citations per year since publication
- * 2. Court-level weight — Supreme Court citations count more
- * 3. Recency decay — recent citations are stronger evidence
+ * Every incoming citation is weighted by two signals:
+ * 1. Court-level weight — Supreme Court citations count more
+ * 2. Recency decay — recent citations are stronger evidence
  *
- * The final score is log-scaled to prevent outliers from
- * dominating search results.
+ * Their sum is log-scaled to prevent outliers from dominating search results.
+ *
+ * The cited decision's own age is deliberately not part of this. The score
+ * used to be a density — the weighted sum divided by the years since
+ * publication — which charged recency twice: the citing-side decay already
+ * says whether a decision is still being cited, and a decision nobody cites
+ * any more decays through that term alone. Dividing again only penalized
+ * decisions for having been available to be cited, so the divisor buried
+ * landmark decisions under recent ones. Under the density, 200 citations
+ * spread over 20 years scored 1.03 while 8 citations from the past year
+ * scored 1.61; on the weighted sum alone the same two score 3.61 and 2.20.
  */
 
 import { DAY_IN_MS } from "@stll/time";
@@ -150,32 +158,15 @@ export const weightedCitationSum = (
 /**
  * Full citation authority score for a decision.
  *
- *   density = weightedSum / max(yearsSinceDecision, 1)
- *   score   = ln(1 + density)
+ *   score = ln(1 + weightedSum)
  *
  * Returns a non-negative float. Zero means no citations.
  */
 export const citationScore = (
   citations: CitationInput[],
-  decisionDate: Date | string | null,
   now: Date = new Date(),
   weightMap?: CourtWeightMap,
-): number => {
-  if (citations.length === 0) {
-    return 0;
-  }
-
-  const wSum = weightedCitationSum(citations, now, weightMap);
-
-  let yearsOld = 1;
-  if (decisionDate !== null) {
-    const d =
-      typeof decisionDate === "string" ? new Date(decisionDate) : decisionDate;
-    yearsOld = Math.max((now.getTime() - d.getTime()) / MS_PER_YEAR, 1);
-  }
-
-  return Math.log(1 + wSum / yearsOld);
-};
+): number => Math.log(1 + weightedCitationSum(citations, now, weightMap));
 
 // -- SQL fragments -------------------------------------------------------
 

--- a/apps/api/src/handlers/case-law/citation-score.ts
+++ b/apps/api/src/handlers/case-law/citation-score.ts
@@ -24,6 +24,11 @@ import type {
   CourtWeightEntry,
   CourtWeightMap,
 } from "@/api/handlers/case-law/court-weights";
+import {
+  POLARITY,
+  POLARITY_AUTHORITY_WEIGHT,
+} from "@/api/handlers/case-law/polarity/consts";
+import type { Polarity } from "@/api/handlers/case-law/polarity/consts";
 
 /** Average (Julian) year, used for citation-age decay. A duration. */
 const MS_PER_YEAR = 365.25 * DAY_IN_MS;
@@ -131,16 +136,33 @@ export const recencyFactor = (
 
 // -- Combined score ------------------------------------------------------
 
-type CitationInput = {
+/**
+ * Authority weight for a citation's polarity. An unclassified citation (null)
+ * weighs the same as `unknown`, which is what keeps the score from moving as
+ * classification coverage grows rather than as the case law changes.
+ */
+export const polarityWeight = (polarity: Polarity | null): number =>
+  POLARITY_AUTHORITY_WEIGHT[polarity ?? POLARITY.UNKNOWN];
+
+/** One incoming citation, as the score reads it. */
+export type CitationInput = {
   citingCourt: string;
   citingDate: Date | string | null;
+  /** Null while the citation has not been classified. */
+  polarity?: Polarity | null;
 };
 
 /**
  * Compute the weighted citation sum for a single decision.
  * Each citation contributes:
  *
- *   courtWeight(citingCourt) * recencyFactor(citingDate)
+ *   polarityWeight(polarity)
+ *     * courtWeight(citingCourt)
+ *     * recencyFactor(citingDate)
+ *
+ * A negative treatment therefore adds nothing: the court that overruled or
+ * distinguished the decision is not vouching for it. It is still a citation
+ * everywhere else — `citation_count` and the citator both keep it.
  */
 export const weightedCitationSum = (
   citations: CitationInput[],
@@ -150,7 +172,9 @@ export const weightedCitationSum = (
   let sum = 0;
   for (const c of citations) {
     sum +=
-      courtWeight(c.citingCourt, weightMap) * recencyFactor(c.citingDate, now);
+      polarityWeight(c.polarity ?? null) *
+      courtWeight(c.citingCourt, weightMap) *
+      recencyFactor(c.citingDate, now);
   }
   return sum;
 };
@@ -169,6 +193,23 @@ export const citationScore = (
 ): number => Math.log(1 + weightedCitationSum(citations, now, weightMap));
 
 // -- SQL fragments -------------------------------------------------------
+
+/**
+ * The SQL twin of `polarityWeight()`, rendered from the same map so a new
+ * polarity cannot reach the database with no weight decided for it. NULL
+ * falls to the ELSE branch, which is `unknown`'s weight by construction.
+ */
+export const polarityWeightSql = (polarityColumn: string): string => {
+  const cases = Object.entries(POLARITY_AUTHORITY_WEIGHT)
+    .filter(([polarity]) => polarity !== POLARITY.UNKNOWN)
+    .map(
+      ([polarity, weight]) =>
+        `WHEN ${polarityColumn} = '${polarity}' THEN ${weight}`,
+    )
+    .join("\n      ");
+
+  return `CASE ${cases}\n      ELSE ${POLARITY_AUTHORITY_WEIGHT[POLARITY.UNKNOWN]} END`;
+};
 
 /**
  * Build a SQL CASE expression for court weights.

--- a/apps/api/src/handlers/case-law/citation-score.ts
+++ b/apps/api/src/handlers/case-law/citation-score.ts
@@ -1,9 +1,12 @@
 /**
  * Citation authority scoring for case law decisions.
  *
- * Every incoming citation is weighted by two signals:
- * 1. Court-level weight — Supreme Court citations count more
- * 2. Recency decay — recent citations are stronger evidence
+ * Every incoming citation is weighted by three signals:
+ * 1. Polarity — a citation classified as negative treatment confers no
+ *    authority (weight 0); every other reading, including unclassified,
+ *    counts in full
+ * 2. Court-level weight — Supreme Court citations count more
+ * 3. Recency decay — recent citations are stronger evidence
  *
  * Their sum is log-scaled to prevent outliers from dominating search results.
  *

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -505,17 +505,6 @@ const searchCorpusIndexDecisions = async (
     return { hits: [], facets: null, totalCount: null, nextCursor: null };
   }
 
-  // Upper bound for the pagination early-stop: scanning may end only
-  // once no unseen candidate could out-blend the page cursor.
-  const [authorityBound] = await caseLawDb((tx) =>
-    tx
-      .select({
-        max: sql<number>`coalesce(max(${caseLawDecisions.citationAuthority}), 0)`,
-      })
-      .from(caseLawDecisions),
-  );
-  const maxAuthority = authorityBound?.max ?? 0;
-
   const searchPage = await readCorpusIndexSearchPage({
     indexId,
     query,
@@ -527,8 +516,10 @@ const searchCorpusIndexDecisions = async (
       return typeof id === "string" && isUuid(id) ? id : null;
     },
     extractSnippet: extractCorpusSnippet,
-    unseenScoreUpperBound: (nextLexicalScore) =>
-      stableBlendUpperBound(nextLexicalScore, maxAuthority),
+    // Upper bound for the pagination early-stop: scanning may end only once
+    // no unseen candidate could out-blend the page cursor. Saturated
+    // authority is bounded by 1, so the bound reads nothing from the corpus.
+    unseenScoreUpperBound: stableBlendUpperBound,
     rankCandidates: async (candidates) => {
       const ids = candidates.map((candidate) =>
         toSafeId<"caseLawDecision">(candidate.id),

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -172,9 +172,6 @@ const searchPostgresDecisions = async (
           * (1.0 / (1 + COALESCE(extract(epoch FROM (now() - citing_d.decision_date)) / (365.25 * 86400), 1.0)))
         ),
         0
-      ) / GREATEST(
-        extract(epoch FROM (now() - d.decision_date)) / (365.25 * 86400),
-        1.0
       ) AS boost,
       count(*)::int AS cnt
       FROM case_law_citations c

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -26,6 +26,7 @@ import {
   redistributableSourceJoin,
 } from "@/api/lib/case-law/search-sql";
 import { isUuid } from "@/api/lib/custom-schema";
+import { blendedRankSql } from "@/api/lib/legal-search/authority-sql";
 import {
   caseLawCorpusProjectionJoin,
   currentCaseLawCorpusProjection,
@@ -137,10 +138,13 @@ const searchPostgresDecisions = async (
     ? sql`AND d.language = ${body.language}`
     : sql``;
 
+  // One fragment for the ORDER BY and the cursor predicate alike: keyset
+  // pagination is only stable while the two are the same expression.
+  const scoreExpr = blendedRankSql(ftsSearch.rank, sql`cb.authority`);
+
   const cursorFilter = parsedCursor
     ? sql`AND (
-        (${ftsSearch.rank}
-          + 0.3 * ln(1 + cb.boost)),
+        ${scoreExpr},
         sd.decision_id
       ) < (
         ${parsedCursor.score}::float8,
@@ -164,15 +168,15 @@ const searchPostgresDecisions = async (
   const courtWeightEntries = await loadCourtWeightEntriesForSql();
   const courtWeightExpr = courtWeightSql("citing_d.court", courtWeightEntries);
 
-  const citationBoost = sql.raw(`
+  const citationAuthorityLateral = sql.raw(`
     LATERAL (
-      SELECT coalesce(
+      SELECT ln(1 + coalesce(
         sum(
           (${courtWeightExpr})
           * (1.0 / (1 + COALESCE(extract(epoch FROM (now() - citing_d.decision_date)) / (365.25 * 86400), 1.0)))
         ),
         0
-      ) AS boost,
+      )) AS authority,
       count(*)::int AS cnt
       FROM case_law_citations c
       JOIN case_law_decisions citing_d
@@ -203,9 +207,7 @@ const searchPostgresDecisions = async (
         ${ftsSearch.headlineQuery},
         ${TS_HEADLINE_CONFIG}
       ) AS headline,
-      (${ftsSearch.rank}
-        + 0.3 * ln(1 + cb.boost)
-      ) AS score,
+      ${scoreExpr} AS score,
       cb.cnt AS citation_count,
       d.created_at
     FROM case_law_search_documents sd
@@ -213,7 +215,7 @@ const searchPostgresDecisions = async (
       ON d.id = sd.decision_id
     ${redistributableSourceJoin}
     ${bodyPreviewJoin}
-    LEFT JOIN ${citationBoost} ON true
+    LEFT JOIN ${citationAuthorityLateral} ON true
     WHERE ${ftsSearch.predicate}
       ${allFilters}
       ${cursorFilter}

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -9,7 +9,10 @@ import {
   caseLawSources,
 } from "@/api/db/schema";
 import { envBase } from "@/api/env-base";
-import { courtWeightSql } from "@/api/handlers/case-law/citation-score";
+import {
+  courtWeightSql,
+  polarityWeightSql,
+} from "@/api/handlers/case-law/citation-score";
 import { loadCourtWeightEntriesForSql } from "@/api/handlers/case-law/court-weights";
 import { validCaseLawLanguageAlternateCountSql } from "@/api/handlers/case-law/decisions/language";
 import type { searchDecisionsBodySchema } from "@/api/handlers/case-law/decisions/search-schema";
@@ -172,7 +175,8 @@ const searchPostgresDecisions = async (
     LATERAL (
       SELECT ln(1 + coalesce(
         sum(
-          (${courtWeightExpr})
+          (${polarityWeightSql("c.polarity")})
+          * (${courtWeightExpr})
           * (1.0 / (1 + COALESCE(extract(epoch FROM (now() - citing_d.decision_date)) / (365.25 * 86400), 1.0)))
         ),
         0

--- a/apps/api/src/handlers/case-law/polarity/consts.ts
+++ b/apps/api/src/handlers/case-law/polarity/consts.ts
@@ -99,13 +99,29 @@ export const RULE_SOURCE = {
  */
 export const PROMOTION_THRESHOLD = 5;
 
-/** Polarity weights for citation scoring. */
-export const POLARITY_WEIGHT = {
+/**
+ * What each polarity contributes to citation authority.
+ *
+ * Binary on purpose. A court that overrules or distinguishes a decision is
+ * not vouching for it, so a negative treatment confers no authority; every
+ * other reading does, in full. Grading the middle (neutral below supportive
+ * below positive) would rank a decision by how enthusiastically it happens to
+ * have been cited, and it would make the score move as classification
+ * coverage grows rather than as the case law changes.
+ *
+ * A citation with no polarity yet weighs the same as `unknown`: the corpus is
+ * mostly unclassified, and anything else would rank unclassified citations
+ * against classified ones instead of ranking decisions.
+ *
+ * This governs authority only. A negative treatment is still a citation: it
+ * counts in `citation_count` and it is exactly what the citator must surface.
+ */
+export const POLARITY_AUTHORITY_WEIGHT = {
   positive: 1,
-  supportive: 0.8,
-  neutral: 0.5,
+  supportive: 1,
+  neutral: 1,
   negative: 0,
-  unknown: 0.5,
+  unknown: 1,
 } as const satisfies Record<Polarity, number>;
 
 /**

--- a/apps/api/src/handlers/legislation/search.ts
+++ b/apps/api/src/handlers/legislation/search.ts
@@ -247,17 +247,6 @@ const corpusIndexSearch = async (
     return { hits: [], nextCursor: null };
   }
 
-  // Upper bound for the pagination early-stop: scanning may end only
-  // once no unseen candidate could out-blend the page cursor.
-  const [authorityBound] = await scopedDb((tx) =>
-    tx
-      .select({
-        max: sql<number>`coalesce(max(${legislationDocuments.citationAuthority}), 0)`,
-      })
-      .from(legislationDocuments),
-  );
-  const maxAuthority = authorityBound?.max ?? 0;
-
   const searchPage = await readCorpusIndexSearchPage({
     indexId,
     query,
@@ -269,8 +258,10 @@ const corpusIndexSearch = async (
       return typeof id === "string" && isUuid(id) ? id : null;
     },
     extractSnippet: extractCorpusSnippet,
-    unseenScoreUpperBound: (nextLexicalScore) =>
-      stableBlendUpperBound(nextLexicalScore, maxAuthority),
+    // Upper bound for the pagination early-stop: scanning may end only once
+    // no unseen candidate could out-blend the page cursor. Saturated
+    // authority is bounded by 1, so the bound reads nothing from the corpus.
+    unseenScoreUpperBound: stableBlendUpperBound,
     rankCandidates: async (candidates) => {
       const ids = candidates.map((candidate) =>
         toSafeId<"legislationDocument">(candidate.id),

--- a/apps/api/src/handlers/legislation/search.ts
+++ b/apps/api/src/handlers/legislation/search.ts
@@ -18,6 +18,7 @@ import {
   tPaginationLimit,
   tSafeId,
 } from "@/api/lib/custom-schema";
+import { blendedRankSql } from "@/api/lib/legal-search/authority-sql";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 import {
@@ -127,7 +128,9 @@ const pgSearch = async (
     ${body.dateTo ? sql`AND d.effective_date <= ${body.dateTo}` : sql``}
   `;
 
-  const scoreExpr = sql`(${ftsSearch.rank} + 0.3 * d.citation_authority)`;
+  // One fragment for the ORDER BY and the cursor predicate alike: keyset
+  // pagination is only stable while the two are the same expression.
+  const scoreExpr = blendedRankSql(ftsSearch.rank, sql`d.citation_authority`);
   const cursorFilter = parsedCursor
     ? sql`AND (${scoreExpr}, sd.document_id) < (${parsedCursor.score}::float8, ${parsedCursor.id})`
     : sql``;

--- a/apps/api/src/lib/legal-search/authority-sql.test.ts
+++ b/apps/api/src/lib/legal-search/authority-sql.test.ts
@@ -1,0 +1,127 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import {
+  authorityBlendSql,
+  blendedRankSql,
+  saturatedAuthoritySql,
+} from "@/api/lib/legal-search/authority-sql";
+import {
+  AUTHORITY_PIVOT,
+  DEFAULT_AUTHORITY_WEIGHT,
+  saturateAuthority,
+} from "@/api/lib/legal-search/rerank";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+// The authority blend runs in two runtimes: TypeScript on the corpus-index
+// path, SQL on the Postgres paths, which have to score inside the statement
+// so the cursor predicate can be the same expression as the ORDER BY. Parity
+// is therefore asserted by *executing* the SQL and comparing it to
+// `saturateAuthority()`, not by reading the fragment and believing it.
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    db = drizzle({ client });
+  },
+  { timeout: 30_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+/** Evaluate a scalar fragment in Postgres. */
+const evaluate = async (
+  expression: ReturnType<typeof sql>,
+): Promise<number> => {
+  const [row] = await db
+    .select({ v: sql<number>`(${expression})::float8` })
+    .from(sql`(SELECT 1) AS one`);
+  return Number(row?.v);
+};
+
+const authorityLiteral = (value: number): ReturnType<typeof sql> =>
+  sql`${sql.raw(value.toString())}::float8`;
+
+test("the SQL saturation equals saturateAuthority(), value for value", async () => {
+  for (const authority of [0, 0.25, AUTHORITY_PIVOT, 5, 40, 1000]) {
+    // oxlint-disable-next-line no-await-in-loop -- one round-trip per sampled value against an in-process database
+    const inPostgres = await evaluate(
+      saturatedAuthoritySql(authorityLiteral(authority)),
+    );
+    expect(inPostgres).toBeCloseTo(saturateAuthority(authority), 12);
+  }
+});
+
+test("the SQL saturation half-saturates at the pivot and stays below 1", async () => {
+  expect(await evaluate(saturatedAuthoritySql(authorityLiteral(0)))).toBe(0);
+  expect(
+    await evaluate(saturatedAuthoritySql(authorityLiteral(AUTHORITY_PIVOT))),
+  ).toBe(0.5);
+  expect(
+    await evaluate(saturatedAuthoritySql(authorityLiteral(1e6))),
+  ).toBeLessThan(1);
+  // A corrupt negative column cannot invert the signal in SQL either.
+  expect(await evaluate(saturatedAuthoritySql(authorityLiteral(-5)))).toBe(0);
+});
+
+test("an authority of 5 adds less than the whole weight", async () => {
+  const gained = await evaluate(authorityBlendSql(authorityLiteral(5)));
+  // Raw authority would add 1.5 here and swamp the lexical score.
+  expect(gained).toBeLessThan(DEFAULT_AUTHORITY_WEIGHT);
+  expect(gained).toBeCloseTo(DEFAULT_AUTHORITY_WEIGHT * (5 / 6), 12);
+});
+
+test("the blended rank is the lexical score plus the bounded term", async () => {
+  const blended = await evaluate(
+    blendedRankSql(sql`0.5::float8`, authorityLiteral(5)),
+  );
+  expect(blended).toBeCloseTo(0.5 + DEFAULT_AUTHORITY_WEIGHT * (5 / 6), 12);
+  // Same arithmetic the TypeScript blend does for the same inputs.
+  expect(blended).toBeCloseTo(
+    0.5 + DEFAULT_AUTHORITY_WEIGHT * saturateAuthority(5),
+    12,
+  );
+});
+
+// Every Postgres ranking path, and what it feeds the blend. A path that scores
+// authority any other way is the drift this whole module exists to prevent, so
+// the set is asserted rather than trusted: `blendedRankSql` present, and no
+// weight multiplied straight into an authority expression.
+const RANKING_SQL_PATHS = {
+  "../../handlers/case-law/decisions/search.ts": "cb.authority",
+  "../../handlers/legislation/search.ts": "d.citation_authority",
+  "./pg-fts-legal-provider.ts": "d.citation_authority",
+} as const satisfies Record<string, string>;
+
+const RAW_AUTHORITY_BLEND =
+  /[\d.]+\s*\*\s*(?:ln\(|d\.citation_authority|cb\.authority)/u;
+
+test("every Postgres ranking path scores authority through the shared fragment", async () => {
+  const audited = await Promise.all(
+    Object.entries(RANKING_SQL_PATHS).map(async ([path, authority]) => {
+      const source = await Bun.file(`${import.meta.dir}/${path}`).text();
+      return {
+        path,
+        blendedThrough: source.includes(
+          `blendedRankSql(ftsSearch.rank, sql\`${authority}\`)`,
+        ),
+        // The whole match, not a boolean, so a failure names the offender.
+        rawAuthorityBlend: RAW_AUTHORITY_BLEND.exec(source)?.[0] ?? null,
+      };
+    }),
+  );
+
+  expect(audited).toEqual(
+    Object.keys(RANKING_SQL_PATHS).map((path) => ({
+      path,
+      blendedThrough: true,
+      rawAuthorityBlend: null,
+    })),
+  );
+});

--- a/apps/api/src/lib/legal-search/authority-sql.ts
+++ b/apps/api/src/lib/legal-search/authority-sql.ts
@@ -1,0 +1,45 @@
+/**
+ * The SQL twin of the citation-authority blend in rerank.ts.
+ *
+ * Only the corpus-index path blends in TypeScript. The Postgres paths have to
+ * score inside the statement, because the keyset cursor predicate must be the
+ * *same* expression as the ORDER BY or pagination skips or repeats rows. That
+ * leaves one piece of arithmetic living in two runtimes, which is exactly the
+ * shape ranking drift takes: authority saturated on one provider and raw on
+ * another means the same decision ranks differently depending on which
+ * provider served the query.
+ *
+ * So the constants are imported rather than retyped, every SQL ranking site
+ * builds its score here instead of spelling out `+ 0.3 * authority`, and
+ * `authority-sql.test.ts` executes these fragments against Postgres and
+ * compares them to `saturateAuthority()` value by value.
+ */
+
+import { sql, type SQL } from "drizzle-orm";
+
+import {
+  AUTHORITY_PIVOT,
+  DEFAULT_AUTHORITY_WEIGHT,
+} from "@/api/lib/legal-search/rerank";
+
+/**
+ * `saturateAuthority()` in SQL: `a / (a + pivot)`, clamped at zero.
+ *
+ * The authority expression is interpolated twice, so pass a column reference
+ * or a LATERAL output rather than something that costs anything to evaluate.
+ */
+export const saturatedAuthoritySql = (authority: SQL): SQL =>
+  sql`(GREATEST(${authority}, 0) / (GREATEST(${authority}, 0) + ${sql.raw(String(AUTHORITY_PIVOT))}))`;
+
+/** What authority adds to a lexical score: `weight * saturate(authority)`. */
+export const authorityBlendSql = (authority: SQL): SQL =>
+  sql`(${sql.raw(String(DEFAULT_AUTHORITY_WEIGHT))} * ${saturatedAuthoritySql(authority)})`;
+
+/**
+ * The blended ranking score: lexical relevance plus the bounded authority
+ * term. Both the ORDER BY and the cursor predicate must interpolate this same
+ * value, which is why every Postgres ranking path builds it once per
+ * statement and reuses the fragment.
+ */
+export const blendedRankSql = (lexicalRank: SQL, authority: SQL): SQL =>
+  sql`(${lexicalRank} + ${authorityBlendSql(authority)})`;

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import {
   caseLawCorpusIndexProjections,
@@ -106,17 +106,6 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
     return { hits: [], facets: null, nextCursor: null, limit };
   }
 
-  // Upper bound for the pagination early-stop: scanning may end only
-  // once no unseen candidate could out-blend the page cursor.
-  const [authorityBound] = await caseLawPublicReadDb((tx) =>
-    tx
-      .select({
-        max: sql<number>`coalesce(max(${caseLawDecisions.citationAuthority}), 0)`,
-      })
-      .from(caseLawDecisions),
-  );
-  const maxAuthority = authorityBound?.max ?? 0;
-
   const searchPage = await readCorpusIndexSearchPage({
     indexId,
     query: engineQuery,
@@ -128,8 +117,10 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
       return typeof id === "string" && isUuid(id) ? id : null;
     },
     extractSnippet,
-    unseenScoreUpperBound: (nextLexicalScore) =>
-      stableBlendUpperBound(nextLexicalScore, maxAuthority),
+    // Upper bound for the pagination early-stop: scanning may end only once
+    // no unseen candidate could out-blend the page cursor. Saturated
+    // authority is bounded by 1, so the bound reads nothing from the corpus.
+    unseenScoreUpperBound: stableBlendUpperBound,
     rankCandidates: async (candidates) => {
       const ids = candidates.map((candidate) =>
         toSafeId<"caseLawDecision">(candidate.id),

--- a/apps/api/src/lib/legal-search/pg-fts-legal-provider.ts
+++ b/apps/api/src/lib/legal-search/pg-fts-legal-provider.ts
@@ -5,6 +5,7 @@ import {
   bodyPreviewJoin,
   redistributableSourceJoin,
 } from "@/api/lib/case-law/search-sql";
+import { blendedRankSql } from "@/api/lib/legal-search/authority-sql";
 import { loadDocumentContext } from "@/api/lib/legal-search/document-context";
 import { loadFtsSearchConfigs } from "@/api/lib/legal-search/fts-config";
 import { pgFtsBrowseFacets } from "@/api/lib/legal-search/pg-fts-browse-facets";
@@ -72,7 +73,9 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
     ? sql`AND d.language = ${query.language}`
     : sql``;
 
-  const scoreExpr = sql`(${ftsSearch.rank} + 0.3 * d.citation_authority)`;
+  // One fragment for the ORDER BY and the cursor predicate alike: keyset
+  // pagination is only stable while the two are the same expression.
+  const scoreExpr = blendedRankSql(ftsSearch.rank, sql`d.citation_authority`);
 
   const cursorFilter = parsedCursor
     ? sql`AND (${scoreExpr}, sd.decision_id) < (${parsedCursor.score}::float8, ${parsedCursor.id})`

--- a/apps/api/src/lib/legal-search/rerank.test.ts
+++ b/apps/api/src/lib/legal-search/rerank.test.ts
@@ -1,9 +1,12 @@
 import { expect, test } from "bun:test";
 
 import {
+  AUTHORITY_PIVOT,
   blendCitationAuthority,
   blendStableCitationAuthority,
   rrfMerge,
+  saturateAuthority,
+  stableBlendUpperBound,
   type ScoredCandidate,
 } from "@/api/lib/legal-search/rerank";
 
@@ -138,4 +141,72 @@ test("rrfMerge feeds blendCitationAuthority as the lexical signal", () => {
   });
   // y is fused from both lists, so it must outrank x on lexical alone.
   expect(ranked.at(0)?.id).toBe("y");
+});
+
+test("saturation is bounded, monotone, and half-saturated at the pivot", () => {
+  expect(saturateAuthority(0)).toBe(0);
+  expect(saturateAuthority(AUTHORITY_PIVOT)).toBe(0.5);
+  // Bounded below 1 however authoritative the decision, which is what lets the
+  // pagination bound be `weight` alone.
+  expect(saturateAuthority(1e6)).toBeLessThan(1);
+  expect(saturateAuthority(1e6)).toBeGreaterThan(0.999);
+  // A corrupt negative value cannot invert the signal.
+  expect(saturateAuthority(-5)).toBe(0);
+
+  const sampled = [0, 0.25, 0.5, 1, 2, 5, 12, 40].map(saturateAuthority);
+  for (const [i, value] of sampled.entries()) {
+    if (i > 0) {
+      expect(value).toBeGreaterThan(sampled[i - 1] ?? 0);
+    }
+  }
+});
+
+test("the stable blend adds the saturated authority, not the raw value", () => {
+  const [hit] = blendStableCitationAuthority({
+    candidates: [{ id: "a", score: 2 }],
+    authorityById: authority({ a: 5 }),
+    weight: 0.3,
+  });
+  // 5 / (5 + 1) = 0.8333…, so the blend adds 0.25 — the raw value would add
+  // 1.5 and swamp the lexical score it is meant to nudge.
+  expect(hit?.score).toBeCloseTo(2 + 0.3 * (5 / 6), 12);
+  // The hit still reports the raw column value.
+  expect(hit?.citationAuthority).toBe(5);
+});
+
+test("a candidate's authority contribution does not depend on the page it lands on", () => {
+  // Equal lexical scores, so min-max collapses the lexical side to 0 and what
+  // is left is the authority contribution alone.
+  const contributionOf = (candidates: ScoredCandidate[]): number =>
+    blendCitationAuthority({
+      candidates,
+      authorityById: authority({ a: 1, b: 0.2, c: 40 }),
+      weight: 0.3,
+    }).find((hit) => hit.id === "a")?.score ?? Number.NaN;
+
+  const alone = contributionOf([
+    { id: "a", score: 5 },
+    { id: "b", score: 5 },
+  ]);
+  const besideALandmark = contributionOf([
+    { id: "a", score: 5 },
+    { id: "b", score: 5 },
+    { id: "c", score: 5 },
+  ]);
+
+  expect(alone).toBeCloseTo(0.3 * saturateAuthority(1), 12);
+  expect(besideALandmark).toBe(alone);
+});
+
+test("the pagination bound is the next lexical score plus the whole weight", () => {
+  expect(stableBlendUpperBound(1.5, 0.3)).toBeCloseTo(1.8, 12);
+  // No unseen candidate can reach past it: saturation is strictly below 1.
+  const blended = blendStableCitationAuthority({
+    candidates: [{ id: "a", score: 1.5 }],
+    authorityById: authority({ a: 1e9 }),
+    weight: 0.3,
+  });
+  expect(blended.at(0)?.score).toBeLessThan(stableBlendUpperBound(1.5, 0.3));
+  // And it defaults to the same weight the blends default to.
+  expect(stableBlendUpperBound(1.5)).toBe(stableBlendUpperBound(1.5, 0.3));
 });

--- a/apps/api/src/lib/legal-search/rerank.ts
+++ b/apps/api/src/lib/legal-search/rerank.ts
@@ -26,6 +26,32 @@ export type RankedHit = {
 const DEFAULT_RRF_K = 60;
 const DEFAULT_AUTHORITY_WEIGHT = 0.3;
 
+/**
+ * Half-saturation point of the log-scaled citation authority: the authority
+ * value at which the signal contributes half of `weight`, i.e. half of all it
+ * can ever contribute. Authority is already `ln(1 + weightedCitationSum)`, so
+ * 1 is roughly a decision with a couple of recent higher-court citations.
+ *
+ * A tuning constant, not a law: move it with relevance judgments, which is
+ * also the only thing that can say whether it is in the right place.
+ */
+export const AUTHORITY_PIVOT = 1;
+
+/**
+ * Map citation authority onto [0, 1) on an absolute scale:
+ *
+ *   saturate(a) = a / (a + AUTHORITY_PIVOT)
+ *
+ * Monotone, bounded, and independent of every other candidate — a decision's
+ * authority contribution is a property of the decision, not of the page it
+ * lands on. Negative authority is not representable in the corpus; clamping
+ * keeps a corrupt row from inverting the signal.
+ */
+export const saturateAuthority = (authority: number): number => {
+  const bounded = Math.max(authority, 0);
+  return bounded / (bounded + AUTHORITY_PIVOT);
+};
+
 /** Larger id first — deterministic, keyset-cursor-stable tiebreak. */
 const byScoreThenId = (
   a: { id: string; score: number },
@@ -80,10 +106,16 @@ type BlendOptions = {
 /**
  * Blend lexical relevance with citation authority:
  *
- *   blended = norm(lexical) + weight * norm(authority)
+ *   blended = minMax(lexical) + weight * saturate(authority)
  *
- * Normalizing both sides keeps the weight meaningful regardless of
- * BM25's unbounded scale. Equal lexical scores let authority decide;
+ * The lexical side is min-max normalized because BM25's scale is unbounded
+ * and query-dependent, so it is only comparable within one result set.
+ * Authority is not: it is a static, log-scaled property of the decision, and
+ * min-max normalizing it made a decision's contribution depend on which other
+ * candidates happened to share its page — the same decision scoring 1.0 next
+ * to unremarkable neighbours and 0.01 next to one landmark. Search engines
+ * bound static signals on an absolute scale for exactly this reason, which is
+ * what `saturateAuthority` is. Equal lexical scores let authority decide;
  * ties break deterministically by id for cursor stability.
  */
 export const blendCitationAuthority = ({
@@ -101,11 +133,10 @@ export const blendCitationAuthority = ({
     authority: authorityById.get(c.id) ?? 0,
   }));
   const lexicalNorm = normalize(scored.map((s) => s.lexical));
-  const authorityNorm = normalize(scored.map((s) => s.authority));
 
   const hits = scored.map((s, i) => ({
     id: s.id,
-    score: (lexicalNorm[i] ?? 0) + weight * (authorityNorm[i] ?? 0),
+    score: (lexicalNorm[i] ?? 0) + weight * saturateAuthority(s.authority),
     lexicalScore: s.lexical,
     citationAuthority: s.authority,
   }));
@@ -116,21 +147,25 @@ export const blendCitationAuthority = ({
 
 /**
  * Highest blended score any not-yet-scanned candidate could reach under
- * blendStableCitationAuthority, given the next rank's lexical score and
- * an upper bound on citation authority. Pagination scans until this
- * drops below the page cursor so reranking cannot promote an unseen
- * candidate past an already-emitted page.
+ * blendStableCitationAuthority, given the next rank's lexical score.
+ * Pagination scans until this drops below the page cursor so reranking cannot
+ * promote an unseen candidate past an already-emitted page.
+ *
+ * Saturated authority is strictly below 1, so `weight` is the whole of what
+ * authority can add and the bound needs nothing from the corpus. That is why
+ * search no longer pays for a `max(citation_authority)` aggregate per query.
  */
 export const stableBlendUpperBound = (
   nextLexicalScore: number,
-  maxAuthority: number,
   weight: number = DEFAULT_AUTHORITY_WEIGHT,
-): number => nextLexicalScore + weight * Math.max(0, maxAuthority);
+): number => nextLexicalScore + weight;
 
 /**
  * Stable cursor score for corpus-index pagination. Callers provide a lexical
  * score already normalized against the index-wide hit count, so adding later
  * candidate windows does not change scores for earlier hits.
+ *
+ * `citationAuthority` stays the raw column value; only the blend saturates.
  */
 export const blendStableCitationAuthority = ({
   candidates,
@@ -141,7 +176,7 @@ export const blendStableCitationAuthority = ({
     const authority = authorityById.get(candidate.id) ?? 0;
     return {
       id: candidate.id,
-      score: candidate.score + weight * authority,
+      score: candidate.score + weight * saturateAuthority(authority),
       lexicalScore: candidate.score,
       citationAuthority: authority,
     };

--- a/apps/api/src/lib/legal-search/rerank.ts
+++ b/apps/api/src/lib/legal-search/rerank.ts
@@ -24,7 +24,11 @@ export type RankedHit = {
 };
 
 const DEFAULT_RRF_K = 60;
-const DEFAULT_AUTHORITY_WEIGHT = 0.3;
+/**
+ * Default weight on the authority term. Exported because the Postgres
+ * ranking paths blend in SQL and must not retype it.
+ */
+export const DEFAULT_AUTHORITY_WEIGHT = 0.3;
 
 /**
  * Half-saturation point of the log-scaled citation authority: the authority


### PR DESCRIPTION
## Summary

- **Formula**: `authority = ln(1 + Σ polarityWeight(c) · courtWeight(citing) / (1 + ageYears(citing)))`. The division by the cited decision's own age is gone from the TS reference, the materialised SQL twin, and the pg-fts LATERAL. The citing-side decay already expresses whether a decision is still being cited; dividing by the decision's own age charged that twice and buried landmark decisions under recent ones (200 citations over 20 years scored 1.03, 8 citations last year 1.61; now 3.61 vs 2.20).
- **Polarity**: a citation classified `negative` confers no authority (weight 0; positive/supportive/neutral/unknown/unclassified 1, so the score does not move with classifier coverage). `citation_count` still counts it. One total map over `Polarity`; the unused contradictory `POLARITY_WEIGHT` map is removed.
- **Blend**: authority enters every rank and cursor expression, TypeScript and SQL, as `a/(a+1)` (`AUTHORITY_PIVOT`), so a decision's contribution is bounded and independent of the page and of the provider; the per-query `max(citation_authority)` aggregate that existed only for the pagination bound is removed from three search paths.
- Stored `citation_authority` values are recomputed by the standing sweep; the index does not change.

## Test plan

- [x] citation-score (32), citation-authority TS/SQL equality (14, fixture now carries a negative and a null-polarity citation and asserts it differs), authority-sql fragments executed in pglite (5), rerank (13), polarity (23), decisions; each change mutation-checked (divisor restored, raw authority in blends, pivot drift, negative→1, CASE dropped from SQL)
- [x] api typecheck; type-aware oxlint on touched dirs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Legal search rankings now blend text relevance with citation authority more consistently.
  * Citation authority accounts for whether citations support or negatively treat a decision.
  * Search pagination and ordering now use aligned ranking calculations across legal content.
* **Bug Fixes**
  * Removed cited-decision age from authority scoring, preventing older decisions from being unfairly penalised.
  * Improved ranking stability and consistency between database and indexed search results.
* **Documentation**
  * Clarified that authority is based on weighted citation totals rather than citation density.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->