### PR TITLE
feat(api): legislation corpus documents carry the validity window as fast fields

### DIFF
--- a/apps/api/src/handlers/legislation/corpus-index.test.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.test.ts
@@ -14,6 +14,8 @@ type MakeRowOptions = {
   astS3Key?: string | null;
   documentType?: string | null;
   effectiveDate?: string | null;
+  versionValidFrom?: string | null;
+  versionValidTo?: string | null;
 };
 
 const makeRow = ({
@@ -23,6 +25,8 @@ const makeRow = ({
   astS3Key = null,
   documentType = null,
   effectiveDate = "2024-01-01",
+  versionValidFrom = "2024-02-02",
+  versionValidTo = null,
 }: MakeRowOptions) => ({
   id: toSafeId<"legislationDocument">(id),
   sourceId: toSafeId<"legislationSource">("src_1"),
@@ -33,7 +37,8 @@ const makeRow = ({
   documentType,
   status: "in_force",
   effectiveDate,
-  versionValidFrom: "2024-02-02",
+  versionValidFrom,
+  versionValidTo,
   citationAuthority: 0,
   citationCount: 0,
   textS3Key:
@@ -126,12 +131,14 @@ describe("legislation loadDocsForBatch read-failure isolation", () => {
         astS3Key: "legal-corpus/leg_full/ast.zst",
         contentHash: "hash_full",
         documentType: "zákon",
+        versionValidTo: "2025-01-01",
       }),
       makeRow({
         id: "leg_sparse",
         contentHash: "hash_sparse",
         effectiveDate: null,
         textS3Key: null,
+        versionValidFrom: null,
       }),
     ];
 
@@ -160,9 +167,68 @@ describe("legislation loadDocsForBatch read-failure isolation", () => {
       "effective_date",
       "eli",
       "status",
+      "version_valid_from",
+      "version_valid_to",
       "year",
     ]) {
       expect(emitted.has(field)).toBe(true);
+    }
+  });
+
+  test("the validity window is written verbatim, open where the source left it open", async () => {
+    const superseded = makeRow({
+      id: "leg_superseded",
+      contentHash: "hash_superseded",
+      versionValidFrom: "2020-01-01",
+      versionValidTo: "2024-07-01",
+    });
+    const current = makeRow({
+      id: "leg_current",
+      contentHash: "hash_current",
+      versionValidFrom: "2024-07-01",
+      versionValidTo: null,
+    });
+
+    const { built } = await loadDocsForBatch([superseded, current], {
+      generation: "legislation_v2",
+      fetchFulltext: async () => null,
+      readPayload: async () => ({ text: "text", ast: null }),
+    });
+
+    const docById = new Map(
+      built.map((entry) => [String(entry.row.id), entry.docs.at(0) ?? {}]),
+    );
+
+    // Half-open `[from, to)`: a superseded consolidation carries both bounds,
+    // and both reach the engine as the source published them.
+    expect(docById.get(superseded.id)?.["version_valid_from"]).toBe(
+      "2020-01-01",
+    );
+    expect(docById.get(superseded.id)?.["version_valid_to"]).toBe("2024-07-01");
+
+    // The current consolidation is open-ended, and absence is what marks it: a
+    // stand-in upper bound would make it expire on a date the source never set.
+    const currentDoc = docById.get(current.id) ?? {};
+    expect(currentDoc["version_valid_from"]).toBe("2024-07-01");
+    expect(
+      Object.keys(currentDoc).filter((name) => name.startsWith("version_")),
+    ).toEqual(["version_valid_from"]);
+
+    // The window exists to be filtered on in the engine, so both bounds have to
+    // be fast datetimes in the mapping this writer is paired with. Read off the
+    // config rather than restated, or the two halves can drift apart.
+    const mapped = new Map(
+      corpusIndexConfig(
+        "legislation",
+        "legislation_v2_svk",
+      ).doc_mapping.field_mappings.map((field) => [field.name, field]),
+    );
+    for (const name of ["version_valid_from", "version_valid_to"]) {
+      expect([name, mapped.get(name)?.type, mapped.get(name)?.fast]).toEqual([
+        name,
+        "datetime",
+        true,
+      ]);
     }
   });
 });

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -44,6 +44,7 @@ type IndexableRow = {
   status: string;
   effectiveDate: string | null;
   versionValidFrom: string | null;
+  versionValidTo: string | null;
   citationAuthority: number;
   citationCount: number;
   textS3Key: string | null;
@@ -68,6 +69,7 @@ const SELECT_COLUMNS = {
   status: legislationDocuments.status,
   effectiveDate: legislationDocuments.effectiveDate,
   versionValidFrom: legislationDocuments.versionValidFrom,
+  versionValidTo: legislationDocuments.versionValidTo,
   citationAuthority: legislationDocuments.citationAuthority,
   citationCount: legislationDocuments.citationCount,
   textS3Key: legislationDocuments.textS3Key,
@@ -102,6 +104,16 @@ const buildDoc = (
   const dateForYear = row.effectiveDate ?? row.versionValidFrom;
   if (row.effectiveDate !== null) {
     doc["effective_date"] = row.effectiveDate;
+  }
+  // The validity window, verbatim and half-open `[from, to)`. Each bound is
+  // written only when the source published it: an absent `version_valid_to` is
+  // what marks the current consolidation, so writing a stand-in date would
+  // close a window the source left open.
+  if (row.versionValidFrom !== null) {
+    doc["version_valid_from"] = row.versionValidFrom;
+  }
+  if (row.versionValidTo !== null) {
+    doc["version_valid_to"] = row.versionValidTo;
   }
   if (dateForYear !== null) {
     doc["year"] = Number(dateForYear.slice(0, 4));

--- a/apps/api/src/lib/legal-search/corpus-index-config.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.test.ts
@@ -329,3 +329,31 @@ test("the legislation family gets its own fields + status tag, sharing the core"
   // status joins the tag fields for split pruning
   expect(config.doc_mapping.tag_fields).toContain("status");
 });
+
+// The point-in-time question — which consolidation was in force on date D — is
+// answered off these two fields, so they are fast: the engine evaluates the
+// window during the scan instead of the API re-deriving it per hit. Both stay
+// out of `tag_fields`, whose values a split records: a date's domain is
+// unbounded, and a tag field past the engine's per-split limit stops being
+// recorded, costing pruning everywhere.
+test("the legislation validity window is a pair of fast datetimes", () => {
+  const config = corpusIndexConfig("legislation", "legislation_v1_svk");
+  const window = ["version_valid_from", "version_valid_to"] as const;
+
+  for (const name of window) {
+    expect(
+      config.doc_mapping.field_mappings.find((f) => f.name === name),
+    ).toEqual({
+      name,
+      type: "datetime",
+      fast: true,
+      input_formats: ["%Y-%m-%d", "rfc3339", "unix_timestamp"],
+    });
+    expect(config.doc_mapping.tag_fields).not.toContain(name);
+  }
+
+  // Nullable on both ends, and neither is the timestamp field: a source that
+  // publishes no window still has to be indexed, and an open-ended
+  // `version_valid_to` is how the current consolidation says it has no end.
+  expect(config.doc_mapping.timestamp_field).toBeUndefined();
+});

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -4,7 +4,8 @@ import type { CorpusFamily } from "@/api/lib/legal-search/corpus-family";
  * corpus index index configuration, generic over document family. Shared
  * core fields apply to every family; each family adds its own
  * (case_law: court/decision_date/ecli/citation_*; legislation:
- * status/effective_date/eli). Notes that matter:
+ * status/effective_date/version_valid_from/version_valid_to/eli). Notes that
+ * matter:
  *
  * - `text` and `title` enable `fieldnorms` so BM25 scoring works
  *   (corpus index disables BM25 by default for latency).
@@ -251,6 +252,35 @@ const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
     { name: "status", type: "text", tokenizer: "raw", fast: true },
     {
       name: "effective_date",
+      type: "datetime",
+      fast: true,
+      input_formats: DATE_INPUT_FORMATS,
+    },
+    // The consolidation's point-in-time validity window, half-open
+    // `[version_valid_from, version_valid_to)`: the text in force on date D is
+    // the version with `version_valid_from <= D` and `version_valid_to > D`.
+    // A missing `version_valid_to` is the current consolidation, open-ended,
+    // so the upper half of that test is asked as a negation — a document
+    // without the field cannot match a range over it.
+    //
+    // Fast so an as-of filter is pushed into the engine and evaluated off the
+    // fast field, instead of being re-derived per hit after the scan. Both
+    // stay nullable (a source that publishes no window still has to be
+    // indexed) and neither is the timestamp field, for the same reason.
+    //
+    // Like every mapping here, these reach only indexes created after this
+    // change: the engine never diffs the mapping of an index that exists, and
+    // in `lenient` mode it would take the fields and drop them. An existing
+    // legislation index would therefore need a generation bump to serve an
+    // as-of filter — `corpusGeneration("legislation")` is the flip.
+    {
+      name: "version_valid_from",
+      type: "datetime",
+      fast: true,
+      input_formats: DATE_INPUT_FORMATS,
+    },
+    {
+      name: "version_valid_to",
       type: "datetime",
       fast: true,
       input_formats: DATE_INPUT_FORMATS,


### PR DESCRIPTION
## Summary

- Legislation index documents gain `version_valid_from` and `version_valid_to` (fast datetime fields; half-open `[from, to)`, a missing `version_valid_to` = the current consolidation), so an as-of-date filter can be pushed into the engine later. Neither is a tag field (unbounded domain) nor the family timestamp field (both nullable).
- Projection selects and emits both bounds when non-null, next to `effective_date`.
- No legislation index exists yet on the repo's evidence (`legislation_documents` has no production writer), so the mapping change needs no generation bump; the mapping comment records that the fields reach indexes created after this change.

## Test plan

- [x] projection emits both bounds verbatim / only `version_valid_from` for the current row (key-set assertion); mapping asserted from the config; the emitted-vs-declared census exercises both fields (mutation: dropping the `version_valid_to` emission fails 2 tests)
- [x] api typecheck, type-aware lint, oxfmt