### PR TITLE
feat: notification center backend and thin test ui

### DIFF
--- a/apps/api/drizzle/20260831120000_notifications_workspace_pointer/migration.sql
+++ b/apps/api/drizzle/20260831120000_notifications_workspace_pointer/migration.sql
@@ -1,0 +1,6 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5s';--> statement-breakpoint
+
+ALTER TABLE "notifications" ADD COLUMN "workspace_id" uuid;--> statement-breakpoint
+
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE SET NULL ON UPDATE NO ACTION NOT VALID;

--- a/apps/api/drizzle/20260831120010_validate_notifications_workspace_pointer/migration.sql
+++ b/apps/api/drizzle/20260831120010_validate_notifications_workspace_pointer/migration.sql
@@ -1,0 +1,5 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5s';--> statement-breakpoint
+
+ALTER TABLE "notifications"
+  VALIDATE CONSTRAINT "notifications_workspace_id_workspaces_id_fk";

--- a/apps/api/src/db/schema/notifications.ts
+++ b/apps/api/src/db/schema/notifications.ts
@@ -10,11 +10,13 @@ import {
   p,
   pUuid,
   safeOrganizationId,
+  safeWorkspaceId,
   sql,
   timestamptz,
   user,
   userOrganizationPolicies,
 } from "./common";
+import { workspaces } from "./contacts";
 
 const NOTIFICATION_KIND_SQL_VALUES = NOTIFICATION_KINDS.map((kind) =>
   sql.raw(`'${kind}'`),
@@ -50,6 +52,19 @@ export const notifications = p.pgTable(
     organizationId: safeOrganizationId("organization_id")
       .notNull()
       .references(() => organization.id, { onDelete: "cascade" }),
+    /**
+     * The matter the entity pointer lives in, so the client can build the
+     * `/workspaces/:workspaceId/...` link a bare entity id cannot address.
+     * Null for a kind that points at nothing, and null again once the matter
+     * is deleted: `ON DELETE SET NULL` keeps matter deletion unblocked and
+     * leaves the row as a linkless message rather than removing the history.
+     * Authorization is unaffected — the recipient and organization pins are
+     * what admit the row, and this column is never read as a permission.
+     */
+    workspaceId: safeWorkspaceId("workspace_id").references(
+      () => workspaces.id,
+      { onDelete: "set null" },
+    ),
     kind: p.text({ enum: NOTIFICATION_KINDS }).notNull(),
     /** Exactly the ICU parameters this kind's message renders. */
     metadata: jsonb().$type<NotificationMetadataValue>().notNull(),

--- a/apps/api/src/handlers/lists/items/comments/create.ts
+++ b/apps/api/src/handlers/lists/items/comments/create.ts
@@ -93,6 +93,9 @@ const createItemComment = createSafeHandler(
           metadata: { actorName: result.mentions.actorName },
           entityType: "entity",
           entityId: body.itemEntityId,
+          // The handler's validated matter, the same one the mention was
+          // resolved against, so the recipient's link cannot point outside it.
+          workspaceId,
           organizationId: session.activeOrganizationId,
           userId: mentioned,
           idempotencyKey: `mention:${result.id}`,

--- a/apps/api/src/handlers/notifications/announce.ts
+++ b/apps/api/src/handlers/notifications/announce.ts
@@ -143,6 +143,7 @@ export const createPublishAnnouncementEndpoint = ({
           metadata: { title: body.title },
           entityType: null,
           entityId: null,
+          workspaceId: null,
           organizationId,
           userId: brandPersistedUserId(recipient.userId),
           idempotencyKey,

--- a/apps/api/src/handlers/notifications/list.ts
+++ b/apps/api/src/handlers/notifications/list.ts
@@ -78,6 +78,7 @@ const listNotifications = createSafeRootHandler(
             metadata: notifications.metadata,
             entityType: notifications.entityType,
             entityId: notifications.entityId,
+            workspaceId: notifications.workspaceId,
             readAt: notifications.readAt,
             createdAt: notifications.createdAt,
             createdAtCursor:

--- a/apps/api/src/handlers/notifications/notifications.integration.test.ts
+++ b/apps/api/src/handlers/notifications/notifications.integration.test.ts
@@ -76,6 +76,7 @@ const seedNotification = async ({
     metadata: kind === NOTIFICATION_KIND.MENTION ? { actorName: "Ada" } : {},
     entityType: kind === NOTIFICATION_KIND.MENTION ? "entity" : null,
     entityId: kind === NOTIFICATION_KIND.MENTION ? ids.entityA1 : null,
+    workspaceId: kind === NOTIFICATION_KIND.MENTION ? ids.wsA1 : null,
     idempotencyKey,
     readAt,
   });
@@ -182,6 +183,22 @@ describe("notification list scoping", () => {
     expect(returned).toContain(readA1);
     expect(returned).not.toContain(otherOrgA1);
     expect(returned).not.toContain(otherUser);
+  });
+
+  test("answers with the matter a pointer lives in, and none without one", async () => {
+    const page = await listAs({
+      userId: ids.userA1,
+      organizationId: ids.orgA,
+    });
+    const mention = page.items.find(({ id }) => id === unreadA1);
+    const pointerless = page.items.find(({ id }) => id === readA1);
+
+    // Every target route is /workspaces/:workspaceId/..., so the entity id
+    // alone is not addressable: without this the client can render no link.
+    expect(mention?.entityType).toBe("entity");
+    expect(mention?.entityId).toBe(ids.entityA1);
+    expect(mention?.workspaceId).toBe(ids.wsA1);
+    expect(pointerless?.workspaceId).toBeNull();
   });
 
   test("switching organizations switches the feed", async () => {
@@ -380,12 +397,42 @@ describe("unread count", () => {
 });
 
 describe("fanOutNotifications", () => {
+  test("a mention filed for somebody else keeps the comment's matter", async () => {
+    // The producer writes the matter it validated the mention against, and it
+    // survives the fan-out to the recipient's feed unchanged: this is the
+    // whole deep link, and it names a matter the recipient is a member of.
+    const row: NewNotification = {
+      kind: NOTIFICATION_KIND.MENTION,
+      metadata: { actorName: "Ada" },
+      entityType: "entity",
+      entityId: ids.entityA1,
+      workspaceId: ids.wsA1,
+      organizationId: ids.orgA,
+      userId: ids.userA1,
+      idempotencyKey: "test:mention-workspace",
+    };
+
+    await fanOutNotifications([row], fanOutDb());
+
+    const written = await testDb
+      .select({ id: notifications.id, workspaceId: notifications.workspaceId })
+      .from(notifications)
+      .where(eq(notifications.idempotencyKey, "test:mention-workspace"));
+    seeded.push(...written.map(({ id }) => id));
+    expect(written.map(({ workspaceId }) => workspaceId)).toEqual([ids.wsA1]);
+
+    const page = await listAs({ userId: ids.userA1, organizationId: ids.orgA });
+    const listed = page.items.find(({ id }) => id === written.at(0)?.id);
+    expect(listed?.workspaceId).toBe(ids.wsA1);
+  });
+
   test("an idempotency key replayed for the same user writes one row", async () => {
     const row: NewNotification = {
       kind: NOTIFICATION_KIND.FLOW_RUN_COMPLETED,
       metadata: { flowName: "Intake" },
       entityType: "flow_run",
       entityId: createSafeId<"flowRun">(),
+      workspaceId: ids.wsA1,
       organizationId: ids.orgA,
       userId: ids.userA1,
       idempotencyKey: "test:dedupe",
@@ -408,6 +455,7 @@ describe("fanOutNotifications", () => {
       metadata: { title: "Maintenance window" },
       entityType: null,
       entityId: null,
+      workspaceId: null,
       organizationId: ids.orgA,
       idempotencyKey: "test:shared-announcement",
     } as const;
@@ -439,6 +487,7 @@ describe("fanOutNotifications", () => {
         metadata: { title: "Batched" },
         entityType: null,
         entityId: null,
+        workspaceId: null,
         organizationId: ids.orgA,
         userId: index % 2 === 0 ? ids.userA1 : ids.userA2,
         idempotencyKey: `test:batch:${index}`,

--- a/apps/api/src/handlers/notifications/read-model.ts
+++ b/apps/api/src/handlers/notifications/read-model.ts
@@ -29,6 +29,13 @@ export type NotificationListItem = {
   metadata: NotificationMetadataValue;
   entityType: NotificationEntityType | null;
   entityId: string | null;
+  /**
+   * The matter the pointer lives in, or null for a kind that points at nothing
+   * and for a pointer whose matter has since been deleted. The client renders a
+   * link only when it has all three, so a stale pointer degrades to plain text
+   * rather than to a route that cannot resolve.
+   */
+  workspaceId: SafeId<"workspace"> | null;
   readAt: string | null;
   createdAt: string;
 };
@@ -39,6 +46,7 @@ export const toNotificationListItem = (row: {
   metadata: NotificationMetadataValue;
   entityType: NotificationEntityType | null;
   entityId: string | null;
+  workspaceId: SafeId<"workspace"> | null;
   readAt: Date | null;
   createdAt: Date;
 }): NotificationListItem => ({
@@ -47,6 +55,7 @@ export const toNotificationListItem = (row: {
   metadata: row.metadata,
   entityType: row.entityType,
   entityId: row.entityId,
+  workspaceId: row.workspaceId,
   readAt: row.readAt?.toISOString() ?? null,
   createdAt: row.createdAt.toISOString(),
 });

--- a/apps/api/src/handlers/reports/report-export-notification.ts
+++ b/apps/api/src/handlers/reports/report-export-notification.ts
@@ -112,6 +112,7 @@ export const notifyReportExportStatus = async ({
                   metadata: {},
                   entityType: "report_export",
                   entityId: exportId,
+                  workspaceId,
                   organizationId,
                   userId,
                   idempotencyKey: `report-export:${exportId}`,

--- a/apps/api/src/lib/flows/flow-executor.ts
+++ b/apps/api/src/lib/flows/flow-executor.ts
@@ -733,6 +733,7 @@ const completeStepAndAdvance = async ({
           flowName,
           organizationId,
           runId,
+          workspaceId,
         }),
       ],
       tx,
@@ -753,6 +754,7 @@ type FlowRunCompletedNotificationArgs = {
   flowName: string;
   organizationId: SafeId<"organization">;
   runId: SafeId<"flowRun">;
+  workspaceId: SafeId<"workspace">;
 };
 
 /**
@@ -767,11 +769,13 @@ const flowRunCompletedNotification = ({
   flowName,
   organizationId,
   runId,
+  workspaceId,
 }: FlowRunCompletedNotificationArgs): NewNotification => ({
   kind: NOTIFICATION_KIND.FLOW_RUN_COMPLETED,
   metadata: { flowName },
   entityType: "flow_run",
   entityId: runId,
+  workspaceId,
   organizationId,
   userId: actorUserId,
   idempotencyKey: `flow-run-completed:${runId}`,
@@ -814,6 +818,7 @@ const pauseAtReviewGate = async ({
           metadata: { flowName },
           entityType: "flow_run",
           entityId: runId,
+          workspaceId,
           organizationId,
           userId: actorUserId,
           idempotencyKey: `flow-run-review-gate:${runId}:${stepIndex}`,
@@ -904,6 +909,7 @@ export const failFlowRunFromWorker = async (
                 metadata: { flowName: run.definitionSnapshot.name },
                 entityType: "flow_run",
                 entityId: runId,
+                workspaceId: run.workspaceId,
                 organizationId: scope.organizationId,
                 userId: actorUserId,
                 idempotencyKey: `flow-run-failed:${runId}`,
@@ -1129,6 +1135,7 @@ export const resolveFlowReviewGate = async (
                     flowName: run.definitionSnapshot.name,
                     organizationId,
                     runId,
+                    workspaceId,
                   }),
                 ],
                 database,

--- a/apps/api/src/lib/notifications.ts
+++ b/apps/api/src/lib/notifications.ts
@@ -26,7 +26,11 @@ import { broadcastToUser } from "@/api/lib/sse";
 type TotalEntityRefMap<
   T extends Record<
     NotificationKind,
-    { entityType: NotificationEntityType | null; entityId: string | null }
+    {
+      entityType: NotificationEntityType | null;
+      entityId: string | null;
+      workspaceId: SafeId<"workspace"> | null;
+    }
   >,
 > = T;
 
@@ -34,33 +38,47 @@ type TotalEntityRefMap<
  * What each kind points at. The pointer is derived from the kind, not chosen
  * per call, so a producer cannot file a flow-run notification against a report
  * export id.
+ *
+ * `workspaceId` travels with the pointer because every target route is
+ * `/workspaces/:workspaceId/...`: an entity id alone is not addressable. It is
+ * the matter the producer already validated, never a value off a request body.
  */
 type NotificationEntityRefByKind = TotalEntityRefMap<{
   [NOTIFICATION_KIND.MENTION]: {
     entityType: "entity";
     entityId: SafeId<"entity">;
+    workspaceId: SafeId<"workspace">;
   };
   [NOTIFICATION_KIND.REPORT_EXPORT_SUCCEEDED]: {
     entityType: "report_export";
     entityId: SafeId<"reportExport">;
+    workspaceId: SafeId<"workspace">;
   };
   [NOTIFICATION_KIND.REPORT_EXPORT_FAILED]: {
     entityType: "report_export";
     entityId: SafeId<"reportExport">;
+    workspaceId: SafeId<"workspace">;
   };
   [NOTIFICATION_KIND.FLOW_RUN_COMPLETED]: {
     entityType: "flow_run";
     entityId: SafeId<"flowRun">;
+    workspaceId: SafeId<"workspace">;
   };
   [NOTIFICATION_KIND.FLOW_RUN_FAILED]: {
     entityType: "flow_run";
     entityId: SafeId<"flowRun">;
+    workspaceId: SafeId<"workspace">;
   };
   [NOTIFICATION_KIND.FLOW_RUN_AWAITING_APPROVAL]: {
     entityType: "flow_run";
     entityId: SafeId<"flowRun">;
+    workspaceId: SafeId<"workspace">;
   };
-  [NOTIFICATION_KIND.ANNOUNCEMENT]: { entityType: null; entityId: null };
+  [NOTIFICATION_KIND.ANNOUNCEMENT]: {
+    entityType: null;
+    entityId: null;
+    workspaceId: null;
+  };
 }>;
 
 /**
@@ -144,6 +162,7 @@ const insertNotifications = async (
     metadata: row.metadata,
     entityType: row.entityType,
     entityId: row.entityId,
+    workspaceId: row.workspaceId,
     idempotencyKey: row.idempotencyKey,
   }));
 

--- a/apps/api/src/lib/workspace-deletion-coverage.test.ts
+++ b/apps/api/src/lib/workspace-deletion-coverage.test.ts
@@ -62,10 +62,11 @@ describe("workspace deletion coverage", () => {
         .filter((edge) => edge.parent === workspaces)
         .map((edge) => getTableConfig(edge.child).name),
     );
-    expect(directChildren.size).toBe(50);
+    expect(directChildren.size).toBe(51);
     expect(directChildren.has("chat_threads")).toBe(true);
     expect(directChildren.has("desktop_edit_sessions")).toBe(true);
     expect(directChildren.has("signals")).toBe(true);
+    expect(directChildren.has("notifications")).toBe(true);
   });
 
   test("every restrictive edge into the deletion closure is manually or transitively covered", () => {

--- a/apps/api/src/tests/security/rls-coverage.test.ts
+++ b/apps/api/src/tests/security/rls-coverage.test.ts
@@ -87,6 +87,13 @@ describe("policy coverage", () => {
     // not tenant-scoped — it has a deny-all RLS policy plus REVOKE ALL from
     // stella, so the org-policy coverage requirement does not apply.
     "agent_delegation",
+    // A notification is addressed to a person, not to a matter: recipient and
+    // organization are what admit the row, and its nullable workspace_id is a
+    // link pointer the client resolves through the ordinary authorized routes,
+    // never a permission. Workspace policies would additionally hide the rows
+    // whose matter has since been deleted, which are exactly the rows whose
+    // message the recipient still needs to read.
+    "notifications",
     // AI memory is multi-scope (org OR user OR workspace in one table)
     // and archive-only (no permissive DELETE). The generic workspace /
     // org loops can't express either shape; the dedicated test below
@@ -312,6 +319,10 @@ describe("policy coverage", () => {
     [
       "entity_deletion_cleanup_requests",
       "storage-erasure outbox: references no ancestor so cleanup survives owner deletion (apps/api/src/db/schema/entities.test.ts)",
+    ],
+    [
+      "notifications",
+      "awareness pointer whose nullable workspace_id is a deep link surviving matter deletion; the pair needs ON DELETE SET NULL (workspace_id), which drizzle cannot declare",
     ],
     [
       "usage_events",

--- a/apps/web/src/components/notification-bell.tsx
+++ b/apps/web/src/components/notification-bell.tsx
@@ -1,15 +1,27 @@
 import type { ReactNode } from "react";
 
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
 import { BellIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import type { REALTIME_EVENT_TYPE } from "@stll/api-contract";
-import { NOTIFICATION_KIND } from "@stll/api-contract/notifications";
-import type { NotificationKind } from "@stll/api-contract/notifications";
+import {
+  NOTIFICATION_ENTITY_TYPE,
+  NOTIFICATION_KIND,
+} from "@stll/api-contract/notifications";
+import type {
+  NotificationEntityType,
+  NotificationKind,
+} from "@stll/api-contract/notifications";
 import { BidiText } from "@stll/ui/bidi-text";
 import { Button } from "@stll/ui/button";
-import { Popover, PopoverPopup, PopoverTrigger } from "@stll/ui/popover";
+import {
+  Popover,
+  PopoverClose,
+  PopoverPopup,
+  PopoverTrigger,
+} from "@stll/ui/popover";
 import { Separator } from "@stll/ui/separator";
 import { stellaToast } from "@stll/ui/toast";
 import { cn } from "@stll/ui/utils";
@@ -252,30 +264,143 @@ type NotificationRowProps = {
 
 const NotificationRow = ({ notification, onRead }: NotificationRowProps) => {
   const unread = notification.readAt === null;
+  const rowClassName = cn(
+    "hover:bg-muted flex w-full items-start gap-2 px-3 py-2 text-start text-sm",
+    unread && "font-medium",
+  );
+  const body = (
+    <>
+      <span
+        aria-hidden
+        className={cn(
+          "mt-1.5 size-1.5 shrink-0 rounded-full",
+          unread ? "bg-primary" : "bg-transparent",
+        )}
+      />
+      <span className="min-w-0 flex-1">
+        <NotificationMessage notification={notification} />
+      </span>
+    </>
+  );
+  const target = notificationTarget(notification);
 
   return (
     <li>
-      <button
-        className={cn(
-          "hover:bg-muted flex w-full items-start gap-2 px-3 py-2 text-start text-sm",
-          unread && "font-medium",
-        )}
-        onClick={onRead}
-        type="button"
-      >
-        <span
-          aria-hidden
-          className={cn(
-            "mt-1.5 size-1.5 shrink-0 rounded-full",
-            unread ? "bg-primary" : "bg-transparent",
-          )}
-        />
-        <span className="min-w-0 flex-1">
-          <NotificationMessage notification={notification} />
-        </span>
-      </button>
+      {target === null ? (
+        <button className={rowClassName} onClick={onRead} type="button">
+          {body}
+        </button>
+      ) : (
+        <NotificationLink
+          className={rowClassName}
+          onRead={onRead}
+          target={target}
+        >
+          {body}
+        </NotificationLink>
+      )}
     </li>
   );
+};
+
+type NotificationTarget = {
+  entityId: string;
+  entityType: NotificationEntityType;
+  workspaceId: string;
+};
+
+/**
+ * The deep link this row can offer, or `null` when it cannot: an announcement
+ * points at nothing, and a pointer whose matter has been deleted keeps its
+ * message but loses its workspace. Every target route is
+ * `/workspaces/$workspaceId/...`, so all three parts are required — a row
+ * missing any of them renders as text rather than as a link that dead-ends.
+ */
+const notificationTarget = ({
+  entityId,
+  entityType,
+  workspaceId,
+}: Notification): NotificationTarget | null =>
+  entityType === null || entityId === null || workspaceId === null
+    ? null
+    : { entityId, entityType, workspaceId };
+
+type NotificationLinkProps = {
+  children: ReactNode;
+  className: string;
+  onRead: () => void;
+  target: NotificationTarget;
+};
+
+/**
+ * Where each entity type opens. The switch is exhaustive over
+ * `NotificationEntityType`, so a pointer shape added on the backend fails to
+ * compile here instead of rendering an unclickable row.
+ *
+ * `PopoverClose` closes the panel as it navigates: the reader lands on the
+ * target rather than on the target behind an open panel. Marking the row read
+ * rides the same click, so following a notification is one gesture.
+ */
+const NotificationLink = ({
+  children,
+  className,
+  onRead,
+  target: { entityId, entityType, workspaceId },
+}: NotificationLinkProps) => {
+  switch (entityType) {
+    // Today's only producer is a mention on a list item, and the item's own
+    // id addresses no route: Lists is the surface the comment lives on.
+    case NOTIFICATION_ENTITY_TYPE.ENTITY:
+      return (
+        <PopoverClose
+          render={
+            <Link
+              className={className}
+              onClick={onRead}
+              params={{ workspaceId }}
+              to="/workspaces/$workspaceId/lists"
+            />
+          }
+        >
+          {children}
+        </PopoverClose>
+      );
+    case NOTIFICATION_ENTITY_TYPE.REPORT_EXPORT:
+      return (
+        <PopoverClose
+          render={
+            <Link
+              className={className}
+              onClick={onRead}
+              params={{ exportId: entityId, workspaceId }}
+              to="/workspaces/$workspaceId/reports/$exportId"
+            />
+          }
+        >
+          {children}
+        </PopoverClose>
+      );
+    // The run detail is panel state rather than a route parameter, so the run
+    // id has nowhere to go; Workflows is the page that holds it.
+    case NOTIFICATION_ENTITY_TYPE.FLOW_RUN:
+      return (
+        <PopoverClose
+          render={
+            <Link
+              className={className}
+              onClick={onRead}
+              params={{ workspaceId }}
+              to="/workspaces/$workspaceId/workflows"
+            />
+          }
+        >
+          {children}
+        </PopoverClose>
+      );
+    default:
+      entityType satisfies never;
+      return null;
+  }
 };
 
 /**


### PR DESCRIPTION
## Proposed change

This PR implements the notification center, focusing on a comprehensive backend schema, integration triggers, and SSE delivery channels, along with a thin frontend UI popover for developer testing.

### Backend & Storage
- Created the `notifications` table schema with index mapping, user-scoped RLS policies, and branded identity boundary types.
- Implemented `/notifications` API endpoints for cursor-paginated retrieval, marking a notification as read, marking all notifications as read, and broadcasting announcements.
- Added the `createNotification` transaction wrapper to record notifications and trigger real-time SSE broadcasts.
- Created `detectAndNotifyMentions` to detect username mentions in comments and notify target users.
- Integrated notification creation triggers for async report exports and workflow run state updates.
- Added a daily cron task (`check-deadlines`) that queries tasks due tomorrow and sends alerts to assignees.

### Realtime Delivery
- Added the `new-notification` event type to the SSE schema.
- Added user-scoped Redis Pub/Sub routing to target active SSE connections.

### Frontend (Thin Testing UI)
- Implemented a minimalist `<NotificationBell />` popover in the header layout to view notifications and execute read updates.
- Configured dynamic favicon overlays to display an unread notification badge indicator.
- Wired workspace SSE event listeners to invalidate the React Query notifications cache in real time.
- Synced notification keys across all 13 translation locales.

### Verification
- Added backend integration tests in `list.db.test.ts` covering list retrieval, single/bulk read actions, and announcement broadcasting.
- Verified all integration tests pass successfully and the workspace compiles cleanly.

Closes #1611

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [x] **DARK MODE SUPPORT** | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [x] **ISSUE LINKED** | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] **SCREENSHOT INCLUDED** | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an in-app notification centre with unread counts, favicon badges, pagination, and mark-as-read controls.
  - Notifications now cover mentions, report exports, workflow updates, failures, product announcements, and upcoming deadlines.
  - Added real-time notification delivery and authorised product announcements.
  - Added daily deadline reminders with duplicate prevention and recipient fallbacks.

- **Bug Fixes**
  - Prevented duplicate notifications through user-scoped idempotency.

- **Tests**
  - Added coverage for notification creation, listing, visibility, read states, announcements, and deadline reminders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->