### PR TITLE
feat(legal-ast): headings to depth six

### DIFF
--- a/apps/api/src/handlers/case-law/document-ast.ts
+++ b/apps/api/src/handlers/case-law/document-ast.ts
@@ -4,6 +4,7 @@ export type {
   DocumentAstMetadata,
   DocumentAstSource,
   HeadingBlock,
+  HeadingLevel,
   Inline,
   InlineBold,
   InlineItalic,

--- a/apps/api/src/lib/case-law/document-ast.ts
+++ b/apps/api/src/lib/case-law/document-ast.ts
@@ -4,6 +4,7 @@ export type {
   DocumentAstMetadata,
   DocumentAstSource,
   HeadingBlock,
+  HeadingLevel,
   Inline,
   InlineBold,
   InlineItalic,

--- a/apps/api/src/lib/corpus-index/chunking.test.ts
+++ b/apps/api/src/lib/corpus-index/chunking.test.ts
@@ -474,7 +474,7 @@ describe("structural budget", () => {
             id: "h0",
             anchorId: "h0-anchor",
             type: "heading",
-            level: 4,
+            level: 7,
             inlines: [],
             plainText: "Invalid heading",
           },

--- a/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
@@ -3,7 +3,12 @@ import type { ReactNode } from "react";
 
 import { useTranslations } from "use-intl";
 
-import type { Block, DocumentAst, Inline } from "@stll/legal-ast/document-ast";
+import type {
+  Block,
+  DocumentAst,
+  HeadingLevel,
+  Inline,
+} from "@stll/legal-ast/document-ast";
 import { parseDocumentAst } from "@stll/legal-ast/document-ast";
 import { cn } from "@stll/ui/lib/utils";
 
@@ -413,6 +418,19 @@ const EditorialSupplement = ({
   );
 };
 
+/**
+ * Class per heading depth. Total over `HeadingLevel`, so a depth the AST can
+ * carry cannot reach the reader with no styling of its own.
+ */
+const HEADING_CLASS = {
+  1: "mt-4 mb-5 text-center text-lg leading-tight font-bold tracking-widest first:mt-0",
+  2: "mt-[var(--reader-section-gap-top)] mb-[var(--reader-section-gap-bottom)] text-center text-[0.95rem] leading-snug font-bold tracking-wider",
+  3: "mt-[var(--reader-section-gap-top)] mb-[var(--reader-section-gap-bottom)] text-center text-sm leading-snug font-semibold",
+  4: "mt-[var(--reader-section-gap-top)] mb-[var(--reader-section-gap-bottom)] text-center text-sm leading-snug font-medium",
+  5: "mt-[var(--reader-section-gap-top)] mb-[var(--reader-section-gap-bottom)] text-sm leading-snug font-semibold",
+  6: "mt-[var(--reader-section-gap-top)] mb-[var(--reader-section-gap-bottom)] text-sm leading-snug font-medium",
+} as const satisfies Record<HeadingLevel, string>;
+
 const BlockRenderer = ({
   activeMatchIndex,
   block,
@@ -428,12 +446,7 @@ const BlockRenderer = ({
       <Tag
         className={cn(
           "scroll-mt-[var(--reader-anchor-offset)]",
-          block.level === 1 &&
-            "mt-4 mb-5 text-center text-lg leading-tight font-bold tracking-widest first:mt-0",
-          block.level === 2 &&
-            "mt-[var(--reader-section-gap-top)] mb-[var(--reader-section-gap-bottom)] text-center text-[0.95rem] leading-snug font-bold tracking-wider",
-          block.level === 3 &&
-            "mt-[var(--reader-section-gap-top)] mb-[var(--reader-section-gap-bottom)] text-center text-sm leading-snug font-semibold",
+          HEADING_CLASS[block.level],
         )}
         id={block.anchorId}
       >

--- a/packages/legal-ast/src/document-ast.ts
+++ b/packages/legal-ast/src/document-ast.ts
@@ -16,11 +16,19 @@ export type {
   InlineText,
 } from "./inline.js";
 
+/**
+ * Heading depth, one to six.
+ *
+ * A depth a document reaches has to be expressible: a level clamped away
+ * turns a real container into a sibling of its parent.
+ */
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
 export type HeadingBlock = {
   id: string;
   anchorId: string;
   type: "heading";
-  level: 1 | 2 | 3;
+  level: HeadingLevel;
   role?: "decision-title" | "section-heading" | undefined;
   inlines: Inline[];
   plainText: string;
@@ -102,7 +110,7 @@ const blockSchema: v.GenericSchema<Block> = v.variant("type", [
     id: v.string(),
     anchorId: v.string(),
     type: v.literal("heading"),
-    level: v.picklist([1, 2, 3]),
+    level: v.picklist([1, 2, 3, 4, 5, 6]),
     role: v.optional(v.picklist(["decision-title", "section-heading"])),
     inlines: inlineArraySchema,
     plainText: v.string(),

--- a/packages/legal-ast/src/index.ts
+++ b/packages/legal-ast/src/index.ts
@@ -29,6 +29,7 @@ export type {
   DocumentAstMetadata,
   DocumentAstSource,
   HeadingBlock,
+  HeadingLevel,
   ParagraphBlock,
   ParagraphRole,
   TableBlock,


### PR DESCRIPTION
Heading levels 1..6 in the document AST (type + schema) and the reader's heading class map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Legal documents now support heading levels 4–6, enabling richer document structure and formatting.
  * Heading styles are applied consistently across all supported levels.

* **Bug Fixes**
  * Documents containing deeper-level headings are now accepted and rendered correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->