### PR TITLE
fix(case-law): empty AST is loss only when the source had text

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
@@ -46,6 +46,16 @@ const makeHeading = (text: string, level: 1 | 2 | 3 = 2): HeadingBlock => {
 const wrapInHtml = (text: string): string =>
   `<html><body><p>${text}</p></body></html>`;
 
+/**
+ * A source that publishes no decision text, in the shape courts actually
+ * serve it: the document endpoint answers with a placeholder in the body
+ * rather than an error, so the fetch succeeds and the parser is handed a
+ * page with nothing to parse.
+ */
+const TEXTLESS_SOURCE =
+  `<!DOCTYPE html><html lang="cs"><head><title>39 A 1/2026-35 - text` +
+  `</title></head><body>N/A</body></html>`;
+
 // ── Content completeness ────────────────────────────────────
 
 describe("validateAst", () => {
@@ -246,6 +256,19 @@ describe("validateAst", () => {
 
       expect(result.ok).toBe(false);
       expect(result.issues.some((i) => i.code === "EMPTY_AST")).toBe(true);
+    });
+
+    test("empty AST over a text-less source is not content loss", () => {
+      const result = validateAst(TEXTLESS_SOURCE, []);
+
+      // The fixture has to reach the text-less branch for the rest to
+      // mean anything: bare body text sits outside the content selector,
+      // so nothing is extracted and there is nothing an AST could drop.
+      expect(result.stats.originalLength).toBe(0);
+      expect(result.stats.retainedPct).toBe(100);
+
+      expect(result.issues.some((i) => i.code === "EMPTY_AST")).toBe(true);
+      expect(result.ok).toBe(true);
     });
 
     test("warns when no headings present", () => {
@@ -502,6 +525,17 @@ describe("validationSignal", () => {
     // it must not compete with real loss for attention.
     const text = "Alpha bravo charlie delta echo foxtrot golf hotel india.";
     expect(signalFor(body(text), [makeBlock({ plainText: text })])).toEqual({
+      event: AST_STRUCTURE_DEGRADED,
+      level: "warn",
+    });
+  });
+
+  test("a text-less source parsed to nothing is a warning", () => {
+    // Both signals fire on the same document otherwise: the pipeline
+    // already reports the emptiness as `decision_empty`, so reporting it
+    // again as loss would put a parser defect on an operator's sweep for
+    // a document the parser handled correctly.
+    expect(signalFor(TEXTLESS_SOURCE, [])).toEqual({
       event: AST_STRUCTURE_DEGRADED,
       level: "warn",
     });

--- a/apps/api/src/lib/legal-search/parsers/validate-ast.ts
+++ b/apps/api/src/lib/legal-search/parsers/validate-ast.ts
@@ -248,10 +248,17 @@ export const validateAst = (
   // ── 2. Structural checks ──────────────────────────────
 
   if (blocks.length === 0) {
+    // No blocks is loss only when there was something to lose. A source
+    // carrying no extractable text is represented faithfully by no
+    // blocks, and `retainedPct` already reads 100 for it; calling that an
+    // error reports content loss against a document whose emptiness the
+    // pipeline separately reports as `decision_empty`, sending whoever
+    // sweeps these logs after a parser bug that is not there. It stays an
+    // issue, so the parse still surfaces as structurally degraded.
     issues.push({
       code: "EMPTY_AST",
       message: "AST has no blocks",
-      severity: "error",
+      severity: originalText.length > 0 ? "error" : "warning",
     });
   }
 


### PR DESCRIPTION
## Proposed change

`validateAst` raised `EMPTY_AST` at error severity whenever a parse produced no blocks, without consulting whether the source carried any extractable text.

A source that publishes no text is represented faithfully by no blocks. The validator already knows this: `retainedPct` is computed as `originalText.length > 0 ? … : 100`, so it reads 100 for such a document, and `missingWords` is empty. The parse is correct and nothing was lost, yet `EMPTY_AST` fired at error severity anyway.

Because a single error-severity issue makes the whole result not `ok`, `validationSignal` mapped these parses to `ast_content_lost` at error level. That event means a parser dropped text it was given. Its sibling case, a stored decision that holds no text, is already reported separately by the pipeline as `decision_empty` (`storedDecisionSignal`, `pipeline.ts`) — so a single text-less document raised both events, and whoever swept the content-loss signal was sent after a parser defect that is not there.

The fix keeps `EMPTY_AST` at error severity only when there was source text to represent:

```ts
severity: originalText.length > 0 ? "error" : "warning",
```

It deliberately stays an issue rather than being dropped, so the parse still surfaces as `ast_structure_degraded` instead of going quiet.

The detector is unweakened in the direction that matters. A source that *does* carry text and yields no blocks is unchanged: it keeps `EMPTY_AST` at error severity, and independently trips `CONTENT_LOSS` at 0% retained. The pre-existing `flags empty AST` test covers exactly that case and still passes.

### Tests

Two regression tests, one at each level:

- `validateAst` — an empty AST over a text-less source is not content loss (`ok: true`).
- `validationSignal` — the same input maps to `ast_structure_degraded` / `warn`, not `ast_content_lost` / `error`.

The fixture is production-shaped rather than a minimal stand-in: a document endpoint that answers `200` with a placeholder in the body (`<body>N/A</body>`) rather than an error, which is how the text-less case actually reaches a parser. Bare body text sits outside the `p, li, td, th, div` content selector, so nothing is extracted. Both tests assert the fixture reaches that branch (`originalLength === 0`, `retainedPct === 100`) before asserting the behaviour, so neither can pass vacuously.

**Mutation check run:** reverting the severity expression to the unconditional `"error"` fails both new tests, with the signal test reporting exactly the swapped event and level. The pre-existing empty-AST test passes in both states, confirming the two cases are separated rather than merged.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

Dark mode and screenshot are not applicable: the change is server-side parser validation with no UI surface.

Verified locally on the API package: `lint` (oxlint, type-aware), `typecheck`, `format`, and the `validate-ast` suite (30 pass).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jf7xR8HTGGgf9x2LwiVgHz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for sources with no extractable decision text.
  - These sources are now reported as warnings rather than errors when the resulting content is empty.
  - Sources containing extractable text continue to be reported as errors if no content is produced.

- **Tests**
  - Added coverage confirming correct retention, validity, and signal classification for text-less sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->