### PR TITLE
fix(web): left click on a collapsed-rail matter navigates

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1250,16 +1250,18 @@ const MatterItem = ({
             />
           </Tooltip>
         )}
-        <MatterColorContextPicker
-          className="absolute start-2 top-2 z-10 size-4"
-          label={t("common.changeColor")}
-          matter={ws}
-        >
-          <MatterIcon
-            className="size-4 shrink-0"
-            matter={{ id: ws.id, color: ws.color }}
-          />
-        </MatterColorContextPicker>
+        {!isCollapsed && (
+          <MatterColorContextPicker
+            className="absolute start-2 top-2 z-10 size-4"
+            label={t("common.changeColor")}
+            matter={ws}
+          >
+            <MatterIcon
+              className="size-4 shrink-0"
+              matter={{ id: ws.id, color: ws.color }}
+            />
+          </MatterColorContextPicker>
+        )}
         <SidebarMenuButton
           asChild
           className={cn(
@@ -1275,6 +1277,21 @@ const MatterItem = ({
             .join(" — ")}
         >
           <Link data-active={isActive || undefined} {...navigationTarget}>
+            {/* Collapsed rail: the icon is the whole item, so it stays
+                inside the link (left click navigates) and only right
+                click opens the colour picker. */}
+            {isCollapsed && (
+              <MatterColorContextPicker
+                className="size-4"
+                matter={ws}
+                trigger="contextmenu"
+              >
+                <MatterIcon
+                  className="size-4 shrink-0"
+                  matter={{ id: ws.id, color: ws.color }}
+                />
+              </MatterColorContextPicker>
+            )}
             <span className="flex min-w-0 flex-col">
               <BidiText as="span" className="truncate">
                 {ws.name}

--- a/apps/web/src/components/workspaces/matter-color-picker.tsx
+++ b/apps/web/src/components/workspaces/matter-color-picker.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { ReactNode } from "react";
+import type { ReactNode, SyntheticEvent } from "react";
 
 import { useTranslations } from "use-intl";
 
@@ -53,8 +53,21 @@ type MatterColorPickerProps = {
 
 type MatterColorContextPickerProps = MatterColorPickerProps & {
   className?: string;
-  label: string;
-};
+} & (
+    | {
+        /** Focusable button: click, right-click, or keyboard opens the picker. */
+        trigger?: "button";
+        label: string;
+      }
+    | {
+        /**
+         * Right-click only. Renders an inert span so a parent link keeps
+         * left click (used where the icon is the whole clickable item).
+         */
+        trigger: "contextmenu";
+        label?: never;
+      }
+  );
 
 const MatterColorPicker = ({ children, matter }: MatterColorPickerProps) => {
   const { moreLabel, selectColor } = useMatterColorPicker(matter);
@@ -74,48 +87,60 @@ const MatterColorPicker = ({ children, matter }: MatterColorPickerProps) => {
 const MatterColorContextPicker = ({
   children,
   className,
-  label,
   matter,
+  ...trigger
 }: MatterColorContextPickerProps) => {
   const [open, setOpen] = useState(false);
   const [anchor, setAnchor] = useState<HTMLSpanElement | null>(null);
 
-  const openPicker = () => setOpen(true);
+  const openPicker = (event: SyntheticEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setOpen(true);
+  };
+
+  const triggerClassName = cn(
+    "relative flex shrink-0 items-center justify-center rounded",
+    className,
+  );
+  const content = (
+    <>
+      <span
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute -inset-1 rounded-md opacity-0 motion-reduce:animate-none",
+          open && "animate-attention-flash",
+        )}
+        style={{
+          backgroundColor: `color-mix(in srgb, ${resolveMatterColor(matter.id, matter.color)} 18%, transparent)`,
+        }}
+      />
+      <span className="relative flex" ref={setAnchor}>
+        {children}
+      </span>
+    </>
+  );
 
   return (
     <>
-      <button
-        aria-label={label}
-        className={cn(
-          "relative flex shrink-0 items-center justify-center rounded outline-hidden focus-visible:ring-2",
-          className,
-        )}
-        onClick={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          openPicker();
-        }}
-        onContextMenu={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          openPicker();
-        }}
-        type="button"
-      >
-        <span
-          aria-hidden
-          className={cn(
-            "pointer-events-none absolute -inset-1 rounded-md opacity-0 motion-reduce:animate-none",
-            open && "animate-attention-flash",
-          )}
-          style={{
-            backgroundColor: `color-mix(in srgb, ${resolveMatterColor(matter.id, matter.color)} 18%, transparent)`,
-          }}
-        />
-        <span className="relative flex" ref={setAnchor}>
-          {children}
+      {trigger.trigger === "contextmenu" ? (
+        <span className={triggerClassName} onContextMenu={openPicker}>
+          {content}
         </span>
-      </button>
+      ) : (
+        <button
+          aria-label={trigger.label}
+          className={cn(
+            triggerClassName,
+            "outline-hidden focus-visible:ring-2",
+          )}
+          onClick={openPicker}
+          onContextMenu={openPicker}
+          type="button"
+        >
+          {content}
+        </button>
+      )}
       <Popover onOpenChange={setOpen} open={open}>
         <PopoverPopup
           align="start"


### PR DESCRIPTION
In the collapsed icon rail the matter colour-picker button covered the whole item, so a left click opened the picker instead of navigating to the matter.

- \`MatterColorContextPicker\` gains a \`trigger\` discriminator: \`"button"\` (default, unchanged: click, right-click, keyboard, focusable) or \`"contextmenu"\` (inert span, right-click only).
- In the collapsed rail the icon stays inside the link wrapped in the \`"contextmenu"\` picker; the overlay button renders only when the sidebar is expanded.

Result: left click on a collapsed matter navigates; right click on its icon opens the colour picker; the expanded sidebar and breadcrumb are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved matter colour picker behaviour when sidebar rows are expanded, collapsed, or shown in the compact rail.
  - Prevented colour-picker interactions from interfering with navigation.
  - Added context-menu access to the picker in the compact sidebar while keeping matter icons usable for navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->