### PR TITLE
fix(api): recital cues for constitutional-complaint headers

### DIFF
--- a/apps/api/src/handlers/case-law/citation-kind.test.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.test.ts
@@ -48,14 +48,47 @@ describe("context decides when it speaks", () => {
     ).toBe(CITATION_KIND.PRECEDENT);
   });
 
-  test("a constitutional-complaint recital is procedural even for a supreme-court registry", () => {
+  // One cue per test, so removing any single alternative fails its test.
+  test("a complaint against a court's conduct is procedural even for a supreme-court registry", () => {
     expect(
       classifyCitation({
         citationText: "sp. zn. 1 Tdo 4/2008",
         context:
-          "postupom Najvyššieho súdu Slovenskej republiky v konaní vedenom pod sp. zn. 1 Tdo 4/2008 a jeho uznesením z 20. februára 2008 a takto",
+          "postupom Najvyššieho súdu Slovenskej republiky sp. zn. 1 Tdo 4/2008 a jeho uznesením z 20. februára 2008",
       }),
     ).toBe(CITATION_KIND.PROCEDURAL);
+  });
+
+  test("the proceedings a complaint names are procedural", () => {
+    expect(
+      classifyCitation({
+        citationText: "sp. zn. 1 Tdo 4/2008",
+        context:
+          "Najvyššieho súdu Slovenskej republiky v konaní vedenom pod sp. zn. 1 Tdo 4/2008 a jeho uznesením z 20. februára 2008",
+      }),
+    ).toBe(CITATION_KIND.PROCEDURAL);
+  });
+
+  test("the operative-part lead-in marks the recitals", () => {
+    expect(
+      classifyCitation({
+        citationText: "sp. zn. 3 Tdo 48/2015",
+        context:
+          "a uznesením Najvyššieho súdu Slovenskej republiky sp. zn. 3 Tdo 48/2015 z 11. novembra 2015 a takto rozhodol:",
+      }),
+    ).toBe(CITATION_KIND.PROCEDURAL);
+  });
+
+  test("a precedent invoked by the ordinary Slovak formula stays precedent", () => {
+    // `v konaní vedenom` alone would read as a recital; the Slovak
+    // precedent verb makes it a tie, and the registry settles it.
+    expect(
+      classifyCitation({
+        citationText: "sp. zn. II. ÚS 251/04",
+        context:
+          "Ústavný súd v konaní vedenom pod sp. zn. II. ÚS 251/04 konštatoval, že",
+      }),
+    ).toBe(CITATION_KIND.PRECEDENT);
   });
 
   test("a file kept by the court below is procedural on context, not registry", () => {

--- a/apps/api/src/handlers/case-law/citation-kind.test.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 
 import {
   CITATION_KIND,
+  CITATION_KIND_EVIDENCE,
   classifyCitation,
+  classifyCitationVerdict,
   proceduralKeysFromMetadata,
 } from "@/api/handlers/case-law/citation-kind";
 
@@ -44,6 +46,29 @@ describe("context decides when it speaks", () => {
           "srov. shodně např. usnesení Nejvyššího soudu ze dne 29. 8. 2013, sp. zn. 29 Cdo 1983/2013",
       }),
     ).toBe(CITATION_KIND.PRECEDENT);
+  });
+
+  test("a constitutional-complaint recital is procedural even for a supreme-court registry", () => {
+    expect(
+      classifyCitation({
+        citationText: "sp. zn. 1 Tdo 4/2008",
+        context:
+          "postupom Najvyššieho súdu Slovenskej republiky v konaní vedenom pod sp. zn. 1 Tdo 4/2008 a jeho uznesením z 20. februára 2008 a takto",
+      }),
+    ).toBe(CITATION_KIND.PROCEDURAL);
+  });
+
+  test("a file kept by the court below is procedural on context, not registry", () => {
+    expect(
+      classifyCitationVerdict({
+        citationText: "sp. zn. 2 T 31/2006",
+        context:
+          "v trestnej veci vedenej okresným súdom pod sp. zn. 2 T 31/2006 (v nej bol sťažovateľovi uložený trest odňatia slobody)",
+      }),
+    ).toEqual({
+      kind: CITATION_KIND.PROCEDURAL,
+      evidence: CITATION_KIND_EVIDENCE.CONTEXT,
+    });
   });
 
   test("first-instance file references are procedural", () => {

--- a/apps/api/src/handlers/case-law/citation-kind.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.ts
@@ -105,7 +105,7 @@ const AUTHORITY_REGISTRIES = new Set([
  * list working across cases.
  */
 const PROCEDURAL_CUE =
-  /napaden|proti\s+(?:rozsudk|usnesen)|odvol[áa]n|dovol[áa]n[íi]\s+(?:žalovan|žalobc)|soud[ue]?\s+prvn[íi]ho\s+stupn|prvostupňov|potvrdil|zrušil\s+a\s+vr[áa]til|vedl[ei]?\s+u\s+|pobočka\s+v/iu;
+  /napaden|proti\s+(?:rozsudk|usnesen)|odvol[áa]n|dovol[áa]n[íi]\s+(?:žalovan|žalobc)|soud[ue]?\s+prvn[íi]ho\s+stupn|prvostupňov|potvrdil|zrušil\s+a\s+vr[áa]til|vedl[ei]?\s+u\s+|pobočka\s+v|v\s+konan[íi]\s+veden[oe]m|veden[eé]j\s+\p{L}+\s+s[úu]dom\s+pod|postupom\s+(?:okresn|krajsk|najvyšš)|a\s+takto\s+rozhodol/iu;
 
 /**
  * Phrases that mark an authority being invoked. `srov.` (compare) and

--- a/apps/api/src/handlers/case-law/citation-kind.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.ts
@@ -110,9 +110,12 @@ const PROCEDURAL_CUE =
 /**
  * Phrases that mark an authority being invoked. `srov.` (compare) and
  * `viz` (see) are the strongest: they exist only to point at precedent.
+ * Slovak spells its verbs with `š` (`konštatoval`), so the stems are listed
+ * per language; a recital cue next to one of these is a tie, and the
+ * registry decides.
  */
 const PRECEDENT_CUE =
-  /srov\.|srovnej|viz\s|judikat|ust[áa]len|pr[áa]vn[íi]\s+n[áa]zor|dovodil|vyslovil|konstatoval|st[áa]l[áa]\s+praxe|ve\s+sv[ée]m\s+rozhodnut/iu;
+  /srov\.|srovnej|viz\s|judikat|ust[áa]len|pr[áa]vn[íi]\s+n[áa]zor|dovodil|vyslovil|kon[sš]tatoval|st[áa]l[áa]\s+praxe|ve\s+sv[ée]m\s+rozhodnut|porov\.|pozri|obdobne|vo\s+svojom\s+rozhodnut|v\s+s[úu]lade\s+s/iu;
 
 /**
  * Drop the citation prefix so the registry token is first. Spelled out


### PR DESCRIPTION
A constitutional complaint names the proceedings it challenges in its header (`postupom ... v konaní vedenom pod sp. zn. ...`). Those references read as the case's own history, not as authority, so the recital cue list now covers that form. Tests fail on the previous cues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classification of legal citations involving constitutional complaints and proceedings before lower courts.
  * Added recognition for references to district and regional court proceedings, as well as decisions by lower courts.
  * Enhanced citation results with supporting contextual evidence where applicable.

* **Tests**
  * Added coverage for the updated procedural citation classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->