### PR TITLE
fix(api): retire a polarity cue

### DIFF
--- a/apps/api/drizzle/20260819100000_polarity_rule_retired_source/migration.sql
+++ b/apps/api/drizzle/20260819100000_polarity_rule_retired_source/migration.sql
@@ -20,4 +20,19 @@ ALTER TABLE "case_law_polarity_rules"
 SET statement_timeout = '5s';--> statement-breakpoint
 SET lock_timeout = '1s';--> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
-BEGIN;
+BEGIN;--> statement-breakpoint
+
+-- Retire the withdrawn cues in place, and hand the citations they labelled
+-- back to the classifier. "byl zrušen" names the fate of the judgment under
+-- review, not of the authority cited next to it. Bounded by the rules'
+-- own match counts; deployments that never seeded rules touch no row.
+UPDATE "case_law_polarity_rules"
+   SET "source" = 'retired', "updated_at" = now()
+ WHERE ("pattern", "language") IN (('byl[aoyi]?\s+zrušen[aouy]?', 'cs'), ('bol[aoi]?\s+zrušen[áéý]?', 'sk'))
+   AND "source" <> 'retired';--> statement-breakpoint
+
+UPDATE "case_law_citations"
+   SET "polarity" = NULL, "polarity_rule_id" = NULL
+ WHERE "polarity_rule_id" IN (
+   SELECT "id" FROM "case_law_polarity_rules" WHERE "source" = 'retired'
+ );

--- a/apps/api/drizzle/20260819100000_polarity_rule_retired_source/migration.sql
+++ b/apps/api/drizzle/20260819100000_polarity_rule_retired_source/migration.sql
@@ -1,0 +1,23 @@
+-- stella-migration-safety: reviewed destructive-change - Replaces only the rule-source value CHECK to admit 'retired'; every existing row satisfies the widened set, and rollback can restore the prior CHECK once no row carries the new value.
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+ALTER TABLE "case_law_polarity_rules"
+  DROP CONSTRAINT "polarity_rules_source_values";--> statement-breakpoint
+
+ALTER TABLE "case_law_polarity_rules"
+  ADD CONSTRAINT "polarity_rules_source_values"
+  CHECK ("source" IN ('manual', 'llm-proposed', 'llm-promoted', 'retired')) NOT VALID;--> statement-breakpoint
+
+-- Validate outside Drizzle's migration transaction so PostgreSQL does not
+-- hold the ADD CONSTRAINT lock for the duration of the table scan.
+-- squawk-ignore transaction-nesting
+COMMIT;--> statement-breakpoint
+SET statement_timeout = 0;--> statement-breakpoint
+SET lock_timeout = 0;--> statement-breakpoint
+ALTER TABLE "case_law_polarity_rules"
+  VALIDATE CONSTRAINT "polarity_rules_source_values";--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+SET lock_timeout = '1s';--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
@@ -14,7 +14,10 @@ import {
   compileRules,
   selectRuleMatch,
 } from "@/api/handlers/case-law/polarity/rule-engine";
-import { SEED_RULES } from "@/api/handlers/case-law/polarity/seed-rules";
+import {
+  RETIRED_SEED_RULES,
+  SEED_RULES,
+} from "@/api/handlers/case-law/polarity/seed-rules";
 import { createSafeId } from "@/api/lib/branded-types";
 
 describe("extractContext", () => {
@@ -114,7 +117,6 @@ describe("seed rules", () => {
     const testCases = [
       "na rozdíl od předchozího rozhodnutí",
       "tento závěr byl překonán",
-      "nález byl zrušen",
     ];
 
     for (const text of testCases) {
@@ -166,6 +168,13 @@ describe("seed rules", () => {
         new RegExp(r.pattern, "iu").test(text),
       );
       expect(matched).toBe(true);
+    }
+  });
+
+  test("a retired rule is not also seeded", () => {
+    const seeded = new Set(SEED_RULES.map((r) => `${r.language}:${r.pattern}`));
+    for (const retired of RETIRED_SEED_RULES) {
+      expect(seeded.has(`${retired.language}:${retired.pattern}`)).toBe(false);
     }
   });
 
@@ -221,6 +230,26 @@ describe("rule precedence", () => {
     pattern,
     polarity,
     confidence: 1,
+  });
+
+  test("a quashed judgment under review does not turn a compare-cue negative", () => {
+    // The sentence reports what happened to the order below and points at
+    // authority for it. The withdrawn "byl zrušen" cue read the first half
+    // as the fate of the authority.
+    const context =
+      "Není totiž povolán rušit to, co již bylo zrušeno či změněno " +
+      "(srov. např. usnesení sp. zn. IV. ÚS 138/25).";
+    const rules = compileRules(
+      SEED_RULES.filter((r) => r.language === "cs").map((r) => rule(r)),
+    );
+    const retired = compileRules(
+      RETIRED_SEED_RULES.filter((r) => r.language === "cs").map((r) =>
+        rule({ pattern: r.pattern, polarity: POLARITY.NEGATIVE }),
+      ),
+    );
+
+    expect(selectRuleMatch(retired, context)?.polarity).toBe(POLARITY.NEGATIVE);
+    expect(selectRuleMatch(rules, context)?.polarity).toBe(POLARITY.SUPPORTIVE);
   });
 
   test("a rare specific negative rule beats a popular generic positive one", () => {

--- a/apps/api/src/handlers/case-law/__tests__/polarity-rule-order.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/polarity-rule-order.test.ts
@@ -5,6 +5,7 @@ import { QueryBuilder } from "drizzle-orm/pg-core";
 import {
   CLASSIFIABLE_POLARITIES,
   POLARITY,
+  RULE_SOURCE,
 } from "@/api/handlers/case-law/polarity/consts";
 import {
   rankPolarityRulesByTier,
@@ -55,6 +56,16 @@ describe("the polarity rule read caps each tier separately", () => {
     for (const polarity of CLASSIFIABLE_POLARITIES) {
       expect(rendered.params).toContain(polarity);
     }
+  });
+
+  test("reads hand-written and promoted rules, never proposed or retired ones", () => {
+    // A retired rule keeps its row for its telemetry; loading it would
+    // bring the withdrawn cue straight back.
+    expect(statement).toContain('"source" in (');
+    expect(rendered.params).toContain(RULE_SOURCE.MANUAL);
+    expect(rendered.params).toContain(RULE_SOURCE.LLM_PROMOTED);
+    expect(rendered.params).not.toContain(RULE_SOURCE.LLM_PROPOSED);
+    expect(rendered.params).not.toContain(RULE_SOURCE.RETIRED);
   });
 
   test("no ordering reads match_count", () => {

--- a/apps/api/src/handlers/case-law/polarity/consts.ts
+++ b/apps/api/src/handlers/case-law/polarity/consts.ts
@@ -82,8 +82,17 @@ export const POLARITY_PRECEDENCE = {
   unknown: 3,
 } as const satisfies Record<Polarity, number>;
 
-/** Rule source types, declared as the list the CHECK constraint derives from. */
-export const RULE_SOURCES = ["manual", "llm-proposed", "llm-promoted"] as const;
+/**
+ * Rule source types, declared as the list the CHECK constraint derives from.
+ * `retired` keeps a withdrawn rule's row (and its match telemetry) without
+ * the loader ever compiling it again.
+ */
+export const RULE_SOURCES = [
+  "manual",
+  "llm-proposed",
+  "llm-promoted",
+  "retired",
+] as const;
 
 export type RuleSource = (typeof RULE_SOURCES)[number];
 
@@ -91,6 +100,7 @@ export const RULE_SOURCE = {
   MANUAL: "manual",
   LLM_PROPOSED: "llm-proposed",
   LLM_PROMOTED: "llm-promoted",
+  RETIRED: "retired",
 } as const satisfies ConstantMap<RuleSource>;
 
 /**

--- a/apps/api/src/handlers/case-law/polarity/rule-engine.ts
+++ b/apps/api/src/handlers/case-law/polarity/rule-engine.ts
@@ -109,7 +109,7 @@ const compilePattern = (pattern: string): RegExp | null => {
   }
 };
 
-/** Active rule sources (proposed rules are excluded). */
+/** Active rule sources (proposed and retired rules are excluded). */
 const ACTIVE_SOURCES = [RULE_SOURCE.MANUAL, RULE_SOURCE.LLM_PROMOTED];
 
 /**

--- a/apps/api/src/handlers/case-law/polarity/seed-rules.ts
+++ b/apps/api/src/handlers/case-law/polarity/seed-rules.ts
@@ -14,6 +14,8 @@ type SeedRule = {
   language: string;
 };
 
+type RetiredSeedRule = Pick<SeedRule, "pattern" | "language">;
+
 export const SEED_RULES: readonly SeedRule[] = [
   // -- Czech: positive -------------------------------------------
   { pattern: "v\\s+souladu\\s+s", polarity: "positive", language: "cs" },
@@ -58,11 +60,6 @@ export const SEED_RULES: readonly SeedRule[] = [
   // -- Czech: negative -------------------------------------------
   { pattern: "na\\s+rozdíl\\s+od", polarity: "negative", language: "cs" },
   { pattern: "překonán[aouy]?", polarity: "negative", language: "cs" },
-  {
-    pattern: "byl[aoyi]?\\s+zrušen[aouy]?",
-    polarity: "negative",
-    language: "cs",
-  },
   { pattern: "odchyluje\\s+se", polarity: "negative", language: "cs" },
   { pattern: "nelze\\s+aplikovat", polarity: "negative", language: "cs" },
   { pattern: "odlišuje\\s+se\\s+od", polarity: "negative", language: "cs" },
@@ -83,10 +80,18 @@ export const SEED_RULES: readonly SeedRule[] = [
   // -- Slovak: negative ------------------------------------------
   { pattern: "na\\s+rozdiel\\s+od", polarity: "negative", language: "sk" },
   { pattern: "prekonan[áéý]?", polarity: "negative", language: "sk" },
-  {
-    pattern: "bol[aoi]?\\s+zrušen[áéý]?",
-    polarity: "negative",
-    language: "sk",
-  },
   { pattern: "odlišuje\\s+sa\\s+od", polarity: "negative", language: "sk" },
+];
+
+/**
+ * Rules withdrawn from the seed. Seeding marks their rows `retired` rather
+ * than deleting them, so the match counts they accumulated stay readable.
+ *
+ * "byl zrušen" names the fate of a judgment under review far more often than
+ * a precedent being overruled, and it sits next to the citations of whatever
+ * quashed it, so as a negative cue it mislabelled the authority it invoked.
+ */
+export const RETIRED_SEED_RULES: readonly RetiredSeedRule[] = [
+  { pattern: "byl[aoyi]?\\s+zrušen[aouy]?", language: "cs" },
+  { pattern: "bol[aoi]?\\s+zrušen[áéý]?", language: "sk" },
 ];

--- a/apps/api/src/scripts/seed-polarity-rules.ts
+++ b/apps/api/src/scripts/seed-polarity-rules.ts
@@ -3,15 +3,22 @@
  *
  * Idempotent: each rule is keyed on `(pattern, language)`, so re-running
  * updates the polarity a rule asserts rather than accumulating duplicates of
- * it. Run after changing `polarity/seed-rules.ts`; nothing else writes rows
- * with `source = 'manual'`.
+ * it, and rules listed as retired are marked so rather than deleted. Run after
+ * changing `polarity/seed-rules.ts`; nothing else writes rows with
+ * `source = 'manual'`.
  *
  *   bun apps/api/src/scripts/seed-polarity-rules.ts
  */
 
+import { and, eq } from "drizzle-orm";
+
 import { rootDb } from "@/api/db/root";
 import { caseLawPolarityRules } from "@/api/db/schema";
-import { SEED_RULES } from "@/api/handlers/case-law/polarity/seed-rules";
+import { RULE_SOURCE } from "@/api/handlers/case-law/polarity/consts";
+import {
+  RETIRED_SEED_RULES,
+  SEED_RULES,
+} from "@/api/handlers/case-law/polarity/seed-rules";
 
 console.log(`Seeding ${SEED_RULES.length} polarity rules...`);
 
@@ -38,6 +45,21 @@ for (const rule of SEED_RULES) {
     });
 }
 
-console.log(`Done. ${SEED_RULES.length} rules upserted.`);
+for (const rule of RETIRED_SEED_RULES) {
+  // oxlint-disable-next-line no-await-in-loop -- sequential, same as the upsert above
+  await rootDb
+    .update(caseLawPolarityRules)
+    .set({ source: RULE_SOURCE.RETIRED })
+    .where(
+      and(
+        eq(caseLawPolarityRules.pattern, rule.pattern),
+        eq(caseLawPolarityRules.language, rule.language),
+      ),
+    );
+}
+
+console.log(
+  `Done. ${SEED_RULES.length} rules upserted, ${RETIRED_SEED_RULES.length} retired.`,
+);
 
 process.exit(0);

--- a/apps/api/src/scripts/seed-polarity-rules.ts
+++ b/apps/api/src/scripts/seed-polarity-rules.ts
@@ -10,7 +10,7 @@
  *   bun apps/api/src/scripts/seed-polarity-rules.ts
  */
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, or } from "drizzle-orm";
 
 import { rootDb } from "@/api/db/root";
 import { caseLawPolarityRules } from "@/api/db/schema";
@@ -45,15 +45,18 @@ for (const rule of SEED_RULES) {
     });
 }
 
-for (const rule of RETIRED_SEED_RULES) {
-  // oxlint-disable-next-line no-await-in-loop -- sequential, same as the upsert above
+if (RETIRED_SEED_RULES.length > 0) {
   await rootDb
     .update(caseLawPolarityRules)
     .set({ source: RULE_SOURCE.RETIRED })
     .where(
-      and(
-        eq(caseLawPolarityRules.pattern, rule.pattern),
-        eq(caseLawPolarityRules.language, rule.language),
+      or(
+        ...RETIRED_SEED_RULES.map((rule) =>
+          and(
+            eq(caseLawPolarityRules.pattern, rule.pattern),
+            eq(caseLawPolarityRules.language, rule.language),
+          ),
+        ),
       ),
     );
 }


### PR DESCRIPTION
"byl zrušen" describes the judgment under review far more often than an overruled precedent, and it sits in the same sentence as the authority for quashing it, so as a negative cue it mislabelled that authority. The cue leaves the seed; seeding now marks withdrawn rules `retired` (new source value, migration widens the CHECK) so their rows and match telemetry stay and the loader never compiles them again. Regression test uses the sentence that surfaced it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retired polarity rules in case-law classification.
  - Retired Czech and Slovak patterns are now tracked separately from active rules.
  - Rule updates now report both active and retired rule counts.

- **Bug Fixes**
  - Prevented retired rules from being seeded as active.
  - Improved classification of contexts involving quashed or annulled judgments by keeping withdrawn negative rules separate from active classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->