### PR TITLE
fix(api): cz-nss stores the deciding court from the ECLI

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -21,6 +21,7 @@ import {
 import {
   buildCzNssDecision,
   courtFromEcli,
+  CZ_ECLI_COURTS,
   czNssAdapter,
   czNssExpectedRows,
   czNssListingIdentity,
@@ -181,6 +182,8 @@ type StubOptions = {
   continuation?: readonly Response[];
   /** Status for both document endpoints; 200 serves the fixture. */
   documentStatus?: number;
+  /** Status for the detail page alone; defaults to `documentStatus`. */
+  detailStatus?: number;
 };
 
 const htmlResponse = (body: string, status = 200): Response =>
@@ -192,6 +195,7 @@ const htmlResponse = (body: string, status = 200): Response =>
 const installStub = ({
   continuation = [],
   documentStatus = 200,
+  detailStatus = documentStatus,
   search = [],
 }: StubOptions): { requests: RecordedRequest[] } => {
   const requests: RecordedRequest[] = [];
@@ -222,9 +226,9 @@ const installStub = ({
           return next ?? htmlResponse("", 200);
         }
         if (url.pathname.startsWith("/DokumentDetail/Index/")) {
-          return documentStatus === 200
+          return detailStatus === 200
             ? htmlResponse(detailPage("ECLI:CZ:MSPH:2026:1.Az.4.2026.79"))
-            : htmlResponse("", documentStatus);
+            : htmlResponse("", detailStatus);
         }
         if (url.pathname.startsWith("/DokumentOriginal/Html/")) {
           return documentStatus === 200
@@ -854,15 +858,25 @@ describe("cz-nss fetchPage", () => {
 // ── Per-item build ───────────────────────────────────────
 
 describe("cz-nss court from ECLI", () => {
-  test("each published court code names its court", () => {
-    expect(courtFromEcli("ECLI:CZ:NSS:2020:1.As.1.2020.20")).toBe(
-      "Nejvyšší správní soud",
-    );
+  test("every declared court code resolves to its court, and nothing else does", () => {
+    // Driven from the map, so a code added to it is exercised here without
+    // anyone remembering to; the one non-member proves the lookup is closed.
+    for (const [code, court] of Object.entries(CZ_ECLI_COURTS)) {
+      expect(courtFromEcli(`ECLI:CZ:${code}:2021:52.Af.4.2020.66`)).toBe(court);
+    }
+    expect(Object.keys(CZ_ECLI_COURTS).toSorted()).toEqual([
+      "KSBR",
+      "KSCB",
+      "KSHK",
+      "KSOS",
+      "KSPH",
+      "KSPL",
+      "KSUL",
+      "MSPH",
+      "NSS",
+    ]);
     expect(courtFromEcli("ECLI:CZ:KSHK:2021:52.Af.4.2020.66")).toBe(
       "Krajský soud v Hradci Králové",
-    );
-    expect(courtFromEcli("ECLI:CZ:MSPH:2026:1.Az.4.2026.79")).toBe(
-      "Městský soud v Praze",
     );
   });
 
@@ -942,6 +956,32 @@ describe("cz-nss buildDecision", () => {
     expect((await reconciliation.buildDecision(payload)).type).toBe(
       "detail-unavailable",
     );
+  });
+
+  test("a detail page the portal failed to serve is not a row without metadata", async () => {
+    // The document came back but the metadata did not. Built as is, the row
+    // would carry the fallback court and no ECLI for good, since the refresh
+    // hashes only listing fields; reported unavailable, the walk comes back
+    // for it.
+    const payload = await listedRow();
+    installStub({ search: [], detailStatus: 503 });
+
+    expect((await reconciliation.buildDecision(payload)).type).toBe(
+      "detail-unavailable",
+    );
+  });
+
+  test("a detail page the portal has none of still builds the row", async () => {
+    const payload = await listedRow();
+    installStub({ search: [], detailStatus: 404 });
+
+    const built = await reconciliation.buildDecision(payload);
+    expect(built.type).toBe("built");
+    if (built.type !== "built") {
+      return;
+    }
+    expect(built.decision.ecli).toBeUndefined();
+    expect(built.decision.court).toBe("Nejvyšší správní soud");
   });
 
   test("refuses a row that names no document at all", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -20,6 +20,7 @@ import {
 
 import {
   buildCzNssDecision,
+  courtFromEcli,
   czNssAdapter,
   czNssExpectedRows,
   czNssListingIdentity,
@@ -222,7 +223,7 @@ const installStub = ({
         }
         if (url.pathname.startsWith("/DokumentDetail/Index/")) {
           return documentStatus === 200
-            ? htmlResponse(detailPage("ECLI:CZ:NSS:2026:1.Az.4.2026.79"))
+            ? htmlResponse(detailPage("ECLI:CZ:MSPH:2026:1.Az.4.2026.79"))
             : htmlResponse("", documentStatus);
         }
         if (url.pathname.startsWith("/DokumentOriginal/Html/")) {
@@ -852,6 +853,27 @@ describe("cz-nss fetchPage", () => {
 
 // ── Per-item build ───────────────────────────────────────
 
+describe("cz-nss court from ECLI", () => {
+  test("each published court code names its court", () => {
+    expect(courtFromEcli("ECLI:CZ:NSS:2020:1.As.1.2020.20")).toBe(
+      "Nejvyšší správní soud",
+    );
+    expect(courtFromEcli("ECLI:CZ:KSHK:2021:52.Af.4.2020.66")).toBe(
+      "Krajský soud v Hradci Králové",
+    );
+    expect(courtFromEcli("ECLI:CZ:MSPH:2026:1.Az.4.2026.79")).toBe(
+      "Městský soud v Praze",
+    );
+  });
+
+  test("no ECLI, or a code the map does not know, keeps the portal's label", () => {
+    expect(courtFromEcli(undefined)).toBe("Nejvyšší správní soud");
+    expect(courtFromEcli("ECLI:CZ:XXXX:2026:1.Az.4.2026.79")).toBe(
+      "Nejvyšší správní soud",
+    );
+  });
+});
+
 describe("cz-nss buildDecision", () => {
   const originalFetch = globalThis.fetch;
 
@@ -886,8 +908,10 @@ describe("cz-nss buildDecision", () => {
     }
     expect(built.decision.caseNumber).toBe("1 Az 4/2026");
     expect(built.decision.language).toBe("cs");
-    expect(built.decision.court).toBe("Nejvyšší správní soud");
-    expect(built.decision.ecli).toBe("ECLI:CZ:NSS:2026:1.Az.4.2026.79");
+    // The portal lists the city court's decision; the ECLI names the court,
+    // so the row is stored under it rather than under the portal's own.
+    expect(built.decision.court).toBe("Městský soud v Praze");
+    expect(built.decision.ecli).toBe("ECLI:CZ:MSPH:2026:1.Az.4.2026.79");
     expect(built.decision.fulltext ?? "").not.toBe("");
     // Silent drift here is the whole failure mode: a walk that keys a row one
     // way and a build that stores it another leaves the slice permanently

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -858,26 +858,25 @@ describe("cz-nss fetchPage", () => {
 // ── Per-item build ───────────────────────────────────────
 
 describe("cz-nss court from ECLI", () => {
+  // Stated here independently of the adapter's map, so a wrong name in the
+  // map fails this rather than being read back as the expectation.
+  const EXPECTED_COURTS = {
+    NSS: "Nejvyšší správní soud",
+    MSPH: "Městský soud v Praze",
+    KSBR: "Krajský soud v Brně",
+    KSCB: "Krajský soud v Českých Budějovicích",
+    KSHK: "Krajský soud v Hradci Králové",
+    KSOS: "Krajský soud v Ostravě",
+    KSPH: "Krajský soud v Praze",
+    KSPL: "Krajský soud v Plzni",
+    KSUL: "Krajský soud v Ústí nad Labem",
+  } as const;
+
   test("every declared court code resolves to its court, and nothing else does", () => {
-    // Driven from the map, so a code added to it is exercised here without
-    // anyone remembering to; the one non-member proves the lookup is closed.
-    for (const [code, court] of Object.entries(CZ_ECLI_COURTS)) {
+    expect(CZ_ECLI_COURTS).toEqual(EXPECTED_COURTS);
+    for (const [code, court] of Object.entries(EXPECTED_COURTS)) {
       expect(courtFromEcli(`ECLI:CZ:${code}:2021:52.Af.4.2020.66`)).toBe(court);
     }
-    expect(Object.keys(CZ_ECLI_COURTS).toSorted()).toEqual([
-      "KSBR",
-      "KSCB",
-      "KSHK",
-      "KSOS",
-      "KSPH",
-      "KSPL",
-      "KSUL",
-      "MSPH",
-      "NSS",
-    ]);
-    expect(courtFromEcli("ECLI:CZ:KSHK:2021:52.Af.4.2020.66")).toBe(
-      "Krajský soud v Hradci Králové",
-    );
   });
 
   test("no ECLI, or a code the map does not know, keeps the portal's label", () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -96,7 +96,8 @@ export const CZ_ECLI_COURTS = {
   KSUL: "Krajský soud v Ústí nad Labem",
 } as const satisfies Record<string, string>;
 
-const ECLI_COURT_CODE = /^ECLI:CZ:(?<code>[A-Z]+):/u;
+/** Codes are four letters at most; the bound keeps an odd ECLI out of the log. */
+const ECLI_COURT_CODE = /^ECLI:CZ:(?<code>[A-Z]{1,8}):/u;
 
 const isEcliCourtCode = (code: string): code is keyof typeof CZ_ECLI_COURTS =>
   Object.hasOwn(CZ_ECLI_COURTS, code);
@@ -113,7 +114,7 @@ export const courtFromEcli = (ecli: string | undefined): string => {
   if (isEcliCourtCode(code)) {
     return CZ_ECLI_COURTS[code];
   }
-  logger.warn("case_law.ingestion.cz_nss.unknown_ecli_court", { ecli, code });
+  logger.warn("case_law.ingestion.cz_nss.unknown_ecli_court", { code });
   return CZ_NSS_COURT;
 };
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -84,7 +84,7 @@ const CZ_NSS_COURT = "Nejvyšší správní soud";
  * reported rather than mapped, and the row keeps the fallback label so the
  * document is still stored.
  */
-const CZ_ECLI_COURTS = {
+export const CZ_ECLI_COURTS = {
   NSS: CZ_NSS_COURT,
   MSPH: "Městský soud v Praze",
   KSBR: "Krajský soud v Brně",
@@ -687,13 +687,25 @@ const EMPTY_DETAIL: DetailMetadata = {
   citation: undefined,
 };
 
+/**
+ * The detail page, or the fact that it could not be read.
+ *
+ * A portal that answers 404 has no metadata for the document, and the row is
+ * built without it. A timeout or a server error is not that: the metadata
+ * exists and was not read, and a row built from it would carry the fallback
+ * court and no ECLI for good, since the refresh hashes only listing fields.
+ * Such a row is reported as unavailable, which the reconciliation treats as
+ * a document not yet read and comes back for.
+ */
+type DetailFetch =
+  | { type: "fetched"; detail: DetailMetadata }
+  | { type: "unavailable" };
+
 const fetchDetailMetadata = async (
   documentId: string,
   session: SessionState,
   signal: AbortSignal,
-): Promise<DetailMetadata> => {
-  const empty = EMPTY_DETAIL;
-
+): Promise<DetailFetch> => {
   try {
     const response = await fetchWithTimeout(
       `${BASE_URL}/DokumentDetail/Index/${documentId}`,
@@ -706,28 +718,34 @@ const fetchDetailMetadata = async (
         timeoutMs: ADAPTER_TIMEOUT.REQUEST,
       },
     );
+    if (response.status === 404) {
+      return { type: "fetched", detail: EMPTY_DETAIL };
+    }
     if (!response.ok) {
-      return empty;
+      return { type: "unavailable" };
     }
 
     const html = await response.text();
 
     return {
-      ecli: extractDivText(html, "ecli"),
-      judge: extractDivText(html, "soudcezpravodaj"),
-      senate: extractDivText(html, "soudsenat"),
-      legalArea: extractDivText(html, "oblastupravy"),
-      decisionType: extractDivText(html, "druhdokumentuavyrokrozhodnuti"),
-      decisionDate: extractDivText(html, "datumvydanirozhodnuti"),
-      outcome: extractDivText(html, "vyrokrozhodnuti"),
-      caseType: extractDivText(html, "typrizeni"),
-      parties: extractDivText(html, "ucastnicirizeniz"),
-      caseStatus: extractDivText(html, "stavrizeni"),
-      administrativeAuthority: extractDivText(html, "nazevspravnihoorganu"),
-      citation: extractDivText(html, "citace"),
+      type: "fetched",
+      detail: {
+        ecli: extractDivText(html, "ecli"),
+        judge: extractDivText(html, "soudcezpravodaj"),
+        senate: extractDivText(html, "soudsenat"),
+        legalArea: extractDivText(html, "oblastupravy"),
+        decisionType: extractDivText(html, "druhdokumentuavyrokrozhodnuti"),
+        decisionDate: extractDivText(html, "datumvydanirozhodnuti"),
+        outcome: extractDivText(html, "vyrokrozhodnuti"),
+        caseType: extractDivText(html, "typrizeni"),
+        parties: extractDivText(html, "ucastnicirizeniz"),
+        caseStatus: extractDivText(html, "stavrizeni"),
+        administrativeAuthority: extractDivText(html, "nazevspravnihoorganu"),
+        citation: extractDivText(html, "citace"),
+      },
     };
   } catch {
-    return empty;
+    return { type: "unavailable" };
   }
 };
 
@@ -1068,7 +1086,14 @@ export const buildCzNssDecision = async ({
     };
   }
 
-  const detail = await fetchDetailMetadata(documentId, session, signal);
+  const detailFetch = await fetchDetailMetadata(documentId, session, signal);
+  if (detailFetch.type === "unavailable") {
+    return {
+      type: "detail-unavailable",
+      decision: rowToResult(row, EMPTY_CONTENT, EMPTY_DETAIL),
+    };
+  }
+  const { detail } = detailFetch;
   const content = await fetchDecisionContent(
     documentId,
     row,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -66,19 +66,56 @@ const BASE_URL = "https://vyhledavac.nssoud.cz";
 const CZ_NSS_LANGUAGE = "cs";
 
 /**
- * The court every row is stored under.
+ * The court a row is stored under when nothing states a finer one.
  *
- * Coarser than the portal, which also carries the regional and city
- * administrative courts whose judgments the NSS reviews (a single day's
- * listing mixes `1 Az 4/2026` of the Městský soud v Praze with `52 Af 4/2026`
- * of the Krajský soud v Hradci Králové). Their decisions no longer share a row
- * — the identity is the portal's document id, see `czNssListingIdentity` — but
- * they are still all labelled with this court. Recording the deciding court is
- * a separate metadata migration: the row and the detail fields this adapter
- * reads state no court, so it would have to come from another field (the ECLI
- * carries a court code) and be rewritten across the rows already stored.
+ * The portal also carries the regional and city administrative courts whose
+ * judgments the NSS reviews (a single day's listing mixes `1 Az 4/2026` of the
+ * Městský soud v Praze with `52 Af 4/2026` of the Krajský soud v Hradci
+ * Králové). Neither the row nor the detail fields name the deciding court; the
+ * ECLI does, in its court code, so `courtFromEcli` reads it from there and this
+ * label covers only documents that carry no ECLI.
  */
 const CZ_NSS_COURT = "Nejvyšší správní soud";
+
+/**
+ * ECLI court codes the portal publishes under, to the court's name.
+ *
+ * The list is the one the corpus has shown so far; an unlisted code is
+ * reported rather than mapped, and the row keeps the fallback label so the
+ * document is still stored.
+ */
+const CZ_ECLI_COURTS = {
+  NSS: CZ_NSS_COURT,
+  MSPH: "Městský soud v Praze",
+  KSBR: "Krajský soud v Brně",
+  KSCB: "Krajský soud v Českých Budějovicích",
+  KSHK: "Krajský soud v Hradci Králové",
+  KSOS: "Krajský soud v Ostravě",
+  KSPH: "Krajský soud v Praze",
+  KSPL: "Krajský soud v Plzni",
+  KSUL: "Krajský soud v Ústí nad Labem",
+} as const satisfies Record<string, string>;
+
+const ECLI_COURT_CODE = /^ECLI:CZ:(?<code>[A-Z]+):/u;
+
+const isEcliCourtCode = (code: string): code is keyof typeof CZ_ECLI_COURTS =>
+  Object.hasOwn(CZ_ECLI_COURTS, code);
+
+/** The deciding court named by an ECLI, or the fallback label. */
+export const courtFromEcli = (ecli: string | undefined): string => {
+  const code =
+    ecli === undefined
+      ? undefined
+      : ECLI_COURT_CODE.exec(ecli)?.groups?.["code"];
+  if (code === undefined) {
+    return CZ_NSS_COURT;
+  }
+  if (isEcliCourtCode(code)) {
+    return CZ_ECLI_COURTS[code];
+  }
+  logger.warn("case_law.ingestion.cz_nss.unknown_ecli_court", { ecli, code });
+  return CZ_NSS_COURT;
+};
 
 /**
  * Rows the portal renders inline on the results page a search returns.
@@ -520,7 +557,7 @@ const fetchDecisionContent = async (
         const parsed = parseNssDecisionHtml({
           caseNumber: row.caseNumber,
           ecli: detail.ecli,
-          court: CZ_NSS_COURT,
+          court: courtFromEcli(detail.ecli),
           decisionDate: (() => {
             if (detail.decisionDate) {
               return parseCeDate(detail.decisionDate);
@@ -704,6 +741,7 @@ const rowToResult = (
   // network failures — never include fulltext in the hash.
   const raw = `${row.caseNumber}|${row.decisionDate ?? ""}|${row.decisionType ?? ""}`;
   const sourceDocumentId = czNssSourceDocumentId(row);
+  const court = courtFromEcli(detail.ecli);
 
   return {
     caseNumber: row.caseNumber,
@@ -720,7 +758,7 @@ const rowToResult = (
       ? {}
       : { legacySourceUrls: [detailUrl(sourceDocumentId)] }),
     ecli: detail.ecli,
-    court: CZ_NSS_COURT,
+    court,
     country: "CZE",
     language: CZ_NSS_LANGUAGE,
     decisionDate: (() => {
@@ -740,7 +778,7 @@ const rowToResult = (
     documentUrl: row.documentUrl,
     metadata: {
       caseNumber: row.caseNumber,
-      court: CZ_NSS_COURT,
+      court,
       ecli: detail.ecli,
       judge: detail.judge,
       senate: detail.senate,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -103,10 +103,10 @@ const isEcliCourtCode = (code: string): code is keyof typeof CZ_ECLI_COURTS =>
 
 /** The deciding court named by an ECLI, or the fallback label. */
 export const courtFromEcli = (ecli: string | undefined): string => {
-  const code =
-    ecli === undefined
-      ? undefined
-      : ECLI_COURT_CODE.exec(ecli)?.groups?.["code"];
+  if (ecli === undefined) {
+    return CZ_NSS_COURT;
+  }
+  const code = ECLI_COURT_CODE.exec(ecli)?.groups?.["code"];
   if (code === undefined) {
     return CZ_NSS_COURT;
   }


### PR DESCRIPTION
The portal lists the regional and city administrative courts alongside the NSS; every row was stored under the NSS label. The ECLI's court code names the deciding court, so the adapter reads it from there (eight codes; an unknown code is reported and keeps the fallback). Already-stored rows are a separate backfill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identification of Czech courts from ECLI codes.
  * Correctly distinguishes unavailable decision details from pages that genuinely do not exist.
  * Preserves decisions with fallback court information when detail pages return a 404.
  * Prevents temporarily unavailable or failed detail metadata from being treated as empty data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->