### PR TITLE
fix(api): the generation walk reads at the caller's concurrency

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
@@ -444,6 +444,7 @@ test(
       },
     ]);
     let writes = 0;
+    const readConcurrencies: (number | undefined)[] = [];
     const backfill = createCaseLawGenerationBackfill({
       backfillRows: async (_runnerDb, rows, _generation, options) => {
         await options.beforeRemoteEffect({
@@ -451,6 +452,7 @@ test(
           onLeaseLost: noRemoteEffectCompensation,
         });
         writes += 1;
+        readConcurrencies.push(options.readConcurrency);
         return indexedOutcome(rows.length);
       },
       newLeaseToken: () => "00000000-0000-4000-8000-000000000060",
@@ -458,7 +460,9 @@ test(
     });
 
     try {
-      expect(await backfill(scopedDb, 1, rebuildGeneration)).toEqual({
+      expect(
+        await backfill(scopedDb, 1, rebuildGeneration, { readConcurrency: 32 }),
+      ).toEqual({
         indexed: 1,
         status: "advanced",
       });
@@ -467,6 +471,9 @@ test(
         status: "advanced",
       });
       expect(writes).toBe(2);
+      // The caller's read concurrency reaches the rows; unset stays unset so
+      // the indexer's default applies.
+      expect(readConcurrencies).toEqual([32, undefined]);
     } finally {
       await db
         .delete(caseLawCorpusIndexBackfills)

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -2272,6 +2272,7 @@ export const backfillCorpusIndex = async (
       scopedDb,
       batchSize,
       generation,
+      options,
     );
     return result;
   }

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -1208,7 +1208,10 @@ type GenerationBackfillDependencies = {
     scopedDb: Parameters<typeof backfillIncrementalCorpusIndex>[0],
     rows: readonly IndexableRow[],
     generation: string,
-    options: GenerationProjectionGuards & { commit: CorpusIndexCommitMode },
+    options: GenerationProjectionGuards & {
+      commit: CorpusIndexCommitMode;
+      readConcurrency?: number;
+    },
   ) => Promise<CorpusBackfillOutcome>;
   removeProjection: (
     scopedDb: Parameters<typeof backfillIncrementalCorpusIndex>[0],
@@ -1590,8 +1593,16 @@ export const createCaseLawGenerationBackfill =
     scopedDb: Parameters<typeof backfillIncrementalCorpusIndex>[0],
     batchSize: number,
     generation: string,
+    // How many corpus objects a page reads at once. The generation walk is
+    // bound by object reads, so the caller's setting has to reach the rows
+    // here; left unset, the indexer's own default applies.
+    options: { readConcurrency?: number } = {},
   ): Promise<CorpusIndexBackfillResult> => {
     validateGenerationBoundary(generation);
+    const readConcurrencyOption =
+      options.readConcurrency === undefined
+        ? {}
+        : { readConcurrency: options.readConcurrency };
     const writerLease = await acquireCaseLawCorpusGenerationLease({
       generation,
       newLeaseToken,
@@ -1766,6 +1777,7 @@ export const createCaseLawGenerationBackfill =
               ? EMPTY_BACKFILL_OUTCOME
               : await backfillRows(scopedDb, eligible, generation, {
                   ...guards,
+                  ...readConcurrencyOption,
                   // A source-wide re-index walks a whole source's corpus
                   // a page at a time, so it is bulk work with the same
                   // census behind it as the snapshot walk.
@@ -1873,6 +1885,7 @@ export const createCaseLawGenerationBackfill =
             ? EMPTY_BACKFILL_OUTCOME
             : await backfillRows(scopedDb, eligible, generation, {
                 ...guards,
+                ...readConcurrencyOption,
                 // The live path: every newly ingested decision waits in
                 // this queue, and the mark taken on the way out is the
                 // last thing that would ever select it. Acceptance has
@@ -2155,6 +2168,7 @@ export const createCaseLawGenerationBackfill =
             ? EMPTY_BACKFILL_OUTCOME
             : await backfillRows(scopedDb, rows, generation, {
                 ...runningGuards,
+                ...readConcurrencyOption,
                 // Snapshot pages of the rebuild: bulk throughput, whose
                 // completeness the generation's census verifies rather
                 // than each request proving it for itself.


### PR DESCRIPTION
`backfillCorpusIndexGenerationPage` never forwarded a read concurrency to its rows, so the generation rebuild always read corpus objects four at a time whatever the caller configured. The page now takes the same `readConcurrency` option as the incremental path and threads it to every `backfillRows` call; unset keeps the indexer's default. Test asserts both.