### PR TITLE
fix(db): rule walks an index

### DIFF
--- a/apps/api/drizzle/20260819100000_polarity_rule_retired_source/migration.sql
+++ b/apps/api/drizzle/20260819100000_polarity_rule_retired_source/migration.sql
@@ -17,8 +17,24 @@ SET statement_timeout = 0;--> statement-breakpoint
 SET lock_timeout = 0;--> statement-breakpoint
 ALTER TABLE "case_law_polarity_rules"
   VALIDATE CONSTRAINT "polarity_rules_source_values";--> statement-breakpoint
-SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Rule -> citations. The repair below and every later retirement walk this
+-- edge; without it each is a scan of the whole citation table, which on a
+-- corpus of millions does not finish inside a migration's statement budget.
+-- Partial: most citations carry no rule.
+-- stella-migration-safety: reviewed destructive-change - this retry cleanup
+-- targets only this migration's index; a cancelled concurrent build can leave
+-- an INVALID index that would otherwise block recreation by name.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_citations_polarity_rule_idx";--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "case_law_citations_polarity_rule_idx"
+  ON "case_law_citations" ("polarity_rule_id")
+  WHERE "polarity_rule_id" IS NOT NULL;--> statement-breakpoint
+
 SET lock_timeout = '1s';--> statement-breakpoint
+-- The repair touches as many rows as the retired rules matched; the index
+-- above makes that proportional to the matches, not to the table.
+SET statement_timeout = '10min';--> statement-breakpoint
 -- squawk-ignore transaction-nesting, ban-uncommitted-transaction
 BEGIN;--> statement-breakpoint
 
@@ -35,4 +51,5 @@ UPDATE "case_law_citations"
    SET "polarity" = NULL, "polarity_rule_id" = NULL
  WHERE "polarity_rule_id" IN (
    SELECT "id" FROM "case_law_polarity_rules" WHERE "source" = 'retired'
- );
+ );--> statement-breakpoint
+SET statement_timeout = '5s';

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -822,6 +822,11 @@ export const caseLawCitations = p.pgTable(
       .index("case_law_citations_polarity_null_idx")
       .on(t.polarity)
       .where(isNull(t.polarity)),
+    // Rule -> citations, for retiring a rule and for its telemetry.
+    p
+      .index("case_law_citations_polarity_rule_idx")
+      .on(t.polarityRuleId)
+      .where(isNotNull(t.polarityRuleId)),
     // The burn-down index: the walk's keyset axis, restricted to the rows it
     // still has to examine. Ordered by citing decision because both id
     // families are uuidv7, so walking citations in that order reads the

--- a/apps/api/src/lib/db/migration-history.ts
+++ b/apps/api/src/lib/db/migration-history.ts
@@ -283,6 +283,27 @@ const rewrittenMigrationHistories = {
     ],
     requiredIndexes: [],
   },
+  // 0.7.12 repaired the citations of retired rules with a scan of the whole
+  // citation table, which exceeded the statement budget on a large corpus.
+  // 0.7.13 builds a partial index on the rule id concurrently first and runs
+  // the repair under its own budget. A database that applied the 0.7.12 file
+  // completed the repair within budget, so only the index is owed to it.
+  "20260819100000_polarity_rule_retired_source": {
+    currentHash:
+      "f75c91e75a1536e3bc2ba0f748684e67d01c79d2561651f1144d2f7323d1ca75",
+    priorHashes: [
+      "6924ba9c25cd6957c052479ceb73a9a1ae0252e086b8202c72c6b04a84279b97",
+    ],
+    requiredIndexes: [
+      {
+        definitionBody:
+          "ON public.case_law_citations USING btree (polarity_rule_id) WHERE (polarity_rule_id IS NOT NULL)",
+        isUnique: false,
+        name: "case_law_citations_polarity_rule_idx",
+        tableName: "case_law_citations",
+      },
+    ],
+  },
 } as const satisfies Readonly<Record<string, RewrittenMigrationHistory>>;
 
 export const REWRITTEN_MIGRATION_HISTORIES: Readonly<


### PR DESCRIPTION
The file (unapplied anywhere it failed) now builds a partial index on `polarity_rule_id` concurrently first and runs the repair under its own budget; the index is declared in the schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved the speed and reliability of case law citation lookups associated with polarity rules.
  * Optimised database maintenance for citation records, including safer handling of large updates.
* **Bug Fixes**
  * Improved consistency when applying citation-related database updates, reducing the risk of incomplete or interrupted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->