### PR TITLE
feat: read a statute at a date, and a provision's drafting history

### DIFF
--- a/apps/api/drizzle/20260819140000_legislation_expression_by_eli_idx/migration.sql
+++ b/apps/api/drizzle/20260819140000_legislation_expression_by_eli_idx/migration.sql
@@ -1,0 +1,37 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Access path for the point-in-time statute read. It seeks a Work by its
+-- identifier and takes the latest window that opened on or before the
+-- requested date; the existing identifier index stops at the identifier, so
+-- every consolidation of a long-lived code would be fetched and sorted on an
+-- unauthenticated path.
+--
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block.
+-- Split the migrator transaction, lift the timeouts for the concurrent
+-- build, then restore and reopen a transaction for Drizzle's migration row.
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+
+-- stella-migration-safety: reviewed destructive-change - this retry cleanup
+-- targets only this migration's index; a cancelled concurrent build can leave
+-- an INVALID index that would otherwise block recreation by name.
+DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_eli_lang_valid_from_idx";
+--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "legislation_documents_eli_lang_valid_from_idx"
+  ON "legislation_documents" ("eli", "language", "version_valid_from");
+--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/scripts/mcp-coverage-guard.ts
+++ b/apps/api/scripts/mcp-coverage-guard.ts
@@ -83,7 +83,7 @@ type ExposureType = (typeof EXPOSURE_TYPES)[number];
 const INLINE_ENDPOINT_ALLOWLIST: Record<string, number> = {
   "apps/api/src/handlers/case-law/public-routes.ts": 9,
   "apps/api/src/handlers/files/routes.ts": 4,
-  "apps/api/src/handlers/legislation/public-routes.ts": 3,
+  "apps/api/src/handlers/legislation/public-routes.ts": 5,
   "apps/api/src/handlers/search/routes.ts": 5,
   "apps/api/src/handlers/tasks/my-tasks-route.ts": 1,
   "apps/api/src/handlers/workspaces/routes.ts": 4,

--- a/apps/api/src/db/schema/legislation.ts
+++ b/apps/api/src/db/schema/legislation.ts
@@ -122,6 +122,12 @@ export const legislationDocuments = p.pgTable(
       .on(t.sourceId, t.eli, t.language)
       .where(isNull(t.versionValidFrom)),
     p.index("legislation_documents_eli_idx").on(t.eli),
+    // The point-in-time read seeks a Work by its identifier and takes the
+    // latest window that opened on or before the requested date, so the
+    // access path has to carry the language and the opening as well.
+    p
+      .index("legislation_documents_eli_lang_valid_from_idx")
+      .on(t.eli, t.language, t.versionValidFrom),
     p.index("legislation_documents_country_idx").on(t.country),
     // The public statute list, in its own order: the country seeks, the
     // title/id pair is both the sort and the cursor.

--- a/apps/api/src/handlers/legislation/by-eli.ts
+++ b/apps/api/src/handlers/legislation/by-eli.ts
@@ -1,0 +1,108 @@
+import { and, asc, desc, eq, sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import { status, t } from "elysia";
+import type { Static } from "elysia";
+
+import { legislationDocuments, legislationSources } from "@/api/db/schema";
+import { readPublicLegislationHandler } from "@/api/handlers/legislation/get";
+import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
+import {
+  inForceOn,
+  versionSortKey,
+} from "@/api/handlers/legislation/validity-window";
+import type { LegislationReadDb } from "@/api/lib/legislation-public-read-db";
+
+export const readStatuteByEliQuerySchema = t.Object({
+  eli: t.String({ minLength: 1, maxLength: 512 }),
+  language: t.Optional(t.String({ minLength: 2, maxLength: 8 })),
+  /** Absent means "the text in force today". */
+  asOf: t.Optional(t.String({ format: "date" })),
+});
+
+type ReadStatuteByEliQuery = Static<typeof readStatuteByEliQuerySchema>;
+
+/**
+ * Point-in-time read: the Expression of a Work that applied on a given date.
+ *
+ * The identifier addresses the Work, the date picks the Expression. When more
+ * than one window covers the date (an older open-ended consolidation the
+ * publisher never closed), the latest opening wins, which is the same rule
+ * the listing's current-version anti-join applies. Language is part of the
+ * Work key, so it is ordered on rather than left to the planner when the
+ * caller does not name one.
+ */
+export const readStatuteByEliHandler = async (
+  query: ReadStatuteByEliQuery,
+  legislationDb: LegislationReadDb,
+) => {
+  const asOf =
+    query.asOf === undefined ? sql`CURRENT_DATE` : sql`${query.asOf}::date`;
+
+  const workConditions: SQL[] = [
+    eq(legislationDocuments.eli, query.eli),
+    redistributableLegislationSource,
+  ];
+
+  if (query.language !== undefined) {
+    workConditions.push(eq(legislationDocuments.language, query.language));
+  }
+
+  const resolved = await legislationDb(async (tx) => {
+    const [expression] = await tx
+      .select({ id: legislationDocuments.id })
+      .from(legislationDocuments)
+      .innerJoin(
+        legislationSources,
+        eq(legislationSources.id, legislationDocuments.sourceId),
+      )
+      .where(
+        and(
+          ...workConditions,
+          inForceOn(
+            legislationDocuments.versionValidFrom,
+            legislationDocuments.versionValidTo,
+            asOf,
+          ),
+        ),
+      )
+      .orderBy(
+        desc(versionSortKey(legislationDocuments.versionValidFrom)),
+        asc(legislationDocuments.language),
+        desc(legislationDocuments.id),
+      )
+      .limit(1);
+
+    if (expression !== undefined) {
+      return { type: "expression", id: expression.id } as const;
+    }
+
+    // Separating "no such work" from "no window covers that date" is the
+    // whole answer for a caller who asked for a date before the corpus
+    // covers the act.
+    const [work] = await tx
+      .select({ id: legislationDocuments.id })
+      .from(legislationDocuments)
+      .innerJoin(
+        legislationSources,
+        eq(legislationSources.id, legislationDocuments.sourceId),
+      )
+      .where(and(...workConditions))
+      .limit(1);
+
+    return work === undefined
+      ? ({ type: "unknown-work" } as const)
+      : ({ type: "uncovered-date" } as const);
+  });
+
+  if (resolved.type === "unknown-work") {
+    return status(404, { message: "Legislation document not found" });
+  }
+
+  if (resolved.type === "uncovered-date") {
+    return status(404, {
+      message: "No version of this legislation was in force on the given date",
+    });
+  }
+
+  return await readPublicLegislationHandler(resolved.id, legislationDb);
+};

--- a/apps/api/src/handlers/legislation/list.ts
+++ b/apps/api/src/handlers/legislation/list.ts
@@ -1,10 +1,14 @@
 import { and, asc, eq, gt, ilike, or, sql } from "drizzle-orm";
-import type { SQL, SQLWrapper } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
 import { status, t } from "elysia";
 import type { Static } from "elysia";
 
 import { legislationDocuments, legislationSources } from "@/api/db/schema";
 import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
+import {
+  inForceToday,
+  versionSortKey,
+} from "@/api/handlers/legislation/validity-window";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tPaginationCursor, tPaginationLimit } from "@/api/lib/custom-schema";
 import { escapeLike } from "@/api/lib/escape-like";
@@ -49,21 +53,6 @@ const decodeTitleIdCursor = (cursor: string): TitleIdCursor | null => {
   return { title, id: brandPersistedLegislationDocumentId(id) };
 };
 
-/** Works with no version window sort below every dated consolidation. */
-const UNVERSIONED_SORT_DATE = "0001-01-01";
-
-/**
- * A version window that has opened and has not closed. The window is the
- * corpus half-open interval `[version_valid_from, version_valid_to)`, so a
- * version whose successor opens today ends today and is already historical.
- * A null `version_valid_from` marks a work kept as a single unversioned text.
- */
-const inForceToday = (validFrom: SQLWrapper, validTo: SQLWrapper): SQL => sql`(
-  ${validFrom} IS NULL OR ${validFrom} <= CURRENT_DATE
-) AND (
-  ${validTo} IS NULL OR ${validTo} > CURRENT_DATE
-)`;
-
 /**
  * Keeps only the version in force for its work: no other in-force row of the
  * same work (source, ELI and language, the key the unique indexes use) has a
@@ -79,10 +68,10 @@ const isCurrentVersionOfWork = sql`NOT EXISTS (
     AND newer.id <> ${legislationDocuments.id}
     AND (${inForceToday(sql`newer.version_valid_from`, sql`newer.version_valid_to`)})
     AND (
-      coalesce(newer.version_valid_from, DATE '${sql.raw(UNVERSIONED_SORT_DATE)}'),
+      ${versionSortKey(sql`newer.version_valid_from`)},
       newer.id
     ) > (
-      coalesce(${legislationDocuments.versionValidFrom}, DATE '${sql.raw(UNVERSIONED_SORT_DATE)}'),
+      ${versionSortKey(legislationDocuments.versionValidFrom)},
       ${legislationDocuments.id}
     )
 )`;

--- a/apps/api/src/handlers/legislation/provision-history.ts
+++ b/apps/api/src/handlers/legislation/provision-history.ts
@@ -1,0 +1,229 @@
+import { and, eq, sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import { status, t } from "elysia";
+import type { Static } from "elysia";
+
+import type { Block } from "@stll/legal-ast/document-ast";
+
+import { legislationDocuments } from "@/api/db/schema";
+import { corpusStorageMode } from "@/api/env-base";
+import { extractProvisionText } from "@/api/handlers/legislation/provision-text";
+import {
+  UNVERSIONED_SORT_DATE,
+  versionSortKey,
+} from "@/api/handlers/legislation/validity-window";
+import {
+  selectWorkKey,
+  workKeyConditions,
+} from "@/api/handlers/legislation/work-key";
+import type { SafeId } from "@/api/lib/branded-types";
+import {
+  tPaginationCursor,
+  tPaginationLimit,
+  tSafeId,
+} from "@/api/lib/custom-schema";
+import {
+  parsePersistedCorpusAst,
+  readCorpusAst,
+  readCorpusPayloadOrFallback,
+} from "@/api/lib/legal-search/corpus-storage";
+import type { LegislationReadDb } from "@/api/lib/legislation-public-read-db";
+import { LIMITS } from "@/api/lib/limits";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+  isDateOnlyPaginationCursorPart,
+  isUuidPaginationCursorPart,
+} from "@/api/lib/pagination";
+import { brandPersistedLegislationDocumentId } from "@/api/lib/safe-id-boundaries";
+
+export const provisionHistoryParamsSchema = t.Object({
+  documentId: tSafeId("legislationDocument"),
+  anchor: t.String({ minLength: 1, maxLength: 256 }),
+});
+
+export const provisionHistoryQuerySchema = t.Object({
+  limit: t.Optional(
+    tPaginationLimit(LIMITS.legislationProvisionHistoryPageSizeMax),
+  ),
+  cursor: t.Optional(tPaginationCursor()),
+});
+
+type ProvisionHistoryQuery = Static<typeof provisionHistoryQuerySchema>;
+
+type ProvisionHistoryOptions = {
+  documentId: SafeId<"legislationDocument">;
+  anchor: string;
+  query: ProvisionHistoryQuery;
+  legislationDb: LegislationReadDb;
+};
+
+type VersionCursor = {
+  validFrom: string;
+  id: SafeId<"legislationDocument">;
+};
+
+type VersionRow = {
+  id: SafeId<"legislationDocument">;
+  versionValidFrom: string | null;
+  versionValidTo: string | null;
+  astS3Key: string | null;
+  documentAst: unknown;
+};
+
+const decodeVersionCursor = (cursor: string): VersionCursor | null => {
+  const parts = decodePaginationCursor(cursor);
+
+  if (parts?.length !== 2) {
+    return null;
+  }
+
+  const [validFrom, id] = parts;
+
+  if (
+    !isDateOnlyPaginationCursorPart(validFrom) ||
+    !isUuidPaginationCursorPart(id)
+  ) {
+    return null;
+  }
+
+  return { validFrom, id: brandPersistedLegislationDocumentId(id) };
+};
+
+const versionColumns = {
+  id: legislationDocuments.id,
+  versionValidFrom: legislationDocuments.versionValidFrom,
+  versionValidTo: legislationDocuments.versionValidTo,
+  astS3Key: legislationDocuments.astS3Key,
+  documentAst: legislationDocuments.documentAst,
+};
+
+/**
+ * One version's parsed blocks, from object storage when the corpus keeps them
+ * there and from the Postgres copy otherwise (the same order the document
+ * read uses).
+ */
+const readVersionBlocks = async (
+  row: VersionRow,
+): Promise<readonly Block[]> => {
+  const { astS3Key } = row;
+
+  const ast =
+    corpusStorageMode !== "off" && astS3Key !== null
+      ? await readCorpusPayloadOrFallback({
+          documentId: row.id,
+          key: astS3Key,
+          step: "provisionHistory.corpusAst",
+          read: async () => await readCorpusAst(astS3Key),
+          fallback: () => parsePersistedCorpusAst(row.documentAst),
+        })
+      : parsePersistedCorpusAst(row.documentAst);
+
+  return ast !== null && "blocks" in ast ? ast.blocks : [];
+};
+
+/**
+ * One provision's text across the consolidations of its Work, newest window
+ * first, so a reader can diff a section without downloading whole statutes.
+ *
+ * The page walks versions, not occurrences: a version in which the anchor is
+ * absent is dropped from `items` while still counting against the page, so
+ * the cursor stays a plain keyset over the version order.
+ */
+export const readProvisionHistoryHandler = async ({
+  documentId,
+  anchor,
+  query,
+  legislationDb,
+}: ProvisionHistoryOptions) => {
+  const limit =
+    query.limit ?? LIMITS.legislationProvisionHistoryPageSizeDefault;
+  let cursor: VersionCursor | null = null;
+
+  if (query.cursor !== undefined) {
+    cursor = decodeVersionCursor(query.cursor);
+
+    if (cursor === null) {
+      return status(400, { message: "Invalid cursor" });
+    }
+  }
+
+  const resolved = await legislationDb(async (tx) => {
+    const work = await selectWorkKey(tx, documentId);
+
+    if (work === null) {
+      return null;
+    }
+
+    const [origin] = await tx
+      .select(versionColumns)
+      .from(legislationDocuments)
+      .where(eq(legislationDocuments.id, documentId))
+      .limit(1);
+
+    const conditions: SQL[] = workKeyConditions(work);
+
+    if (cursor !== null) {
+      conditions.push(
+        sql`(${versionSortKey(legislationDocuments.versionValidFrom)}, ${legislationDocuments.id}) < (${cursor.validFrom}::date, ${cursor.id}::uuid)`,
+      );
+    }
+
+    const versions = await tx
+      .select(versionColumns)
+      .from(legislationDocuments)
+      .where(and(...conditions))
+      .orderBy(
+        sql`${versionSortKey(legislationDocuments.versionValidFrom)} desc`,
+        sql`${legislationDocuments.id} desc`,
+      )
+      .limit(limit + 1);
+
+    return { origin, versions };
+  });
+
+  if (resolved?.origin === undefined) {
+    return status(404, { message: "Legislation document not found" });
+  }
+
+  const { origin, versions } = resolved;
+  const originText = extractProvisionText(
+    await readVersionBlocks(origin),
+    anchor,
+  );
+
+  if (originText === null) {
+    return status(404, { message: "Provision not found" });
+  }
+
+  const texts = await Promise.all(
+    versions.map(async (version) =>
+      version.id === origin.id
+        ? originText
+        : extractProvisionText(await readVersionBlocks(version), anchor),
+    ),
+  );
+
+  const page = createCursorPage({
+    rows: versions.map((version, index) => ({
+      documentId: version.id,
+      versionValidFrom: version.versionValidFrom,
+      versionValidTo: version.versionValidTo,
+      text: texts.at(index) ?? null,
+    })),
+    limit,
+    cursorForItem: (item) =>
+      encodePaginationCursor([
+        item.versionValidFrom ?? UNVERSIONED_SORT_DATE,
+        item.documentId,
+      ]),
+  });
+
+  return {
+    ...page,
+    items: page.items.flatMap(({ text, ...item }) =>
+      text === null ? [] : [{ ...item, text }],
+    ),
+  };
+};

--- a/apps/api/src/handlers/legislation/provision-text.test.ts
+++ b/apps/api/src/handlers/legislation/provision-text.test.ts
@@ -30,6 +30,8 @@ const blocks: Block[] = [
   paragraph("sec-1-a-1", "Nested rule."),
   heading("sec-2", 2, "Section 2"),
   paragraph("sec-2-1", "Second rule."),
+  heading("chapter-2", 1, "Chapter II"),
+  paragraph("chapter-2-1", "Rule of the next chapter."),
 ];
 
 describe("extractProvisionText", () => {
@@ -44,13 +46,18 @@ describe("extractProvisionText", () => {
   });
 
   test("stops at a shallower heading", () => {
+    // The fixture closes with a level-1 heading, so a rule that only stopped
+    // at same-level headings would swallow the next chapter.
     expect(extractProvisionText(blocks, "sec-2")).toBe(
       ["Section 2", "Second rule."].join("\n"),
     );
   });
 
   test("takes everything under a top-level heading", () => {
-    expect(extractProvisionText(blocks, "chapter-1")).toContain("Second rule.");
+    const chapter = extractProvisionText(blocks, "chapter-1");
+
+    expect(chapter).toContain("Second rule.");
+    expect(chapter).not.toContain("Rule of the next chapter.");
   });
 
   test("reads an unknown anchor as absent, not as empty", () => {

--- a/apps/api/src/handlers/legislation/provision-text.test.ts
+++ b/apps/api/src/handlers/legislation/provision-text.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Block } from "@stll/legal-ast/document-ast";
+
+import { extractProvisionText } from "@/api/handlers/legislation/provision-text";
+
+const heading = (anchorId: string, level: 1 | 2 | 3, text: string): Block => ({
+  id: `h-${anchorId}`,
+  anchorId,
+  type: "heading",
+  level,
+  inlines: [{ type: "text", text }],
+  plainText: text,
+});
+
+const paragraph = (anchorId: string, text: string): Block => ({
+  id: `p-${anchorId}`,
+  anchorId,
+  type: "paragraph",
+  inlines: [{ type: "text", text }],
+  plainText: text,
+});
+
+const blocks: Block[] = [
+  heading("chapter-1", 1, "Chapter I"),
+  paragraph("intro", "Introductory note."),
+  heading("sec-1", 2, "Section 1"),
+  paragraph("sec-1-1", "First rule."),
+  heading("sec-1-a", 3, "Section 1a"),
+  paragraph("sec-1-a-1", "Nested rule."),
+  heading("sec-2", 2, "Section 2"),
+  paragraph("sec-2-1", "Second rule."),
+];
+
+describe("extractProvisionText", () => {
+  test("keeps the provision's own blocks and its nested subdivisions", () => {
+    expect(extractProvisionText(blocks, "sec-1")).toBe(
+      ["Section 1", "First rule.", "Section 1a", "Nested rule."].join("\n"),
+    );
+  });
+
+  test("stops at the next heading of the same level", () => {
+    expect(extractProvisionText(blocks, "sec-1")).not.toContain("Second rule.");
+  });
+
+  test("stops at a shallower heading", () => {
+    expect(extractProvisionText(blocks, "sec-2")).toBe(
+      ["Section 2", "Second rule."].join("\n"),
+    );
+  });
+
+  test("takes everything under a top-level heading", () => {
+    expect(extractProvisionText(blocks, "chapter-1")).toContain("Second rule.");
+  });
+
+  test("reads an unknown anchor as absent, not as empty", () => {
+    expect(extractProvisionText(blocks, "sec-404")).toBeNull();
+  });
+
+  test("ignores an anchor that belongs to a paragraph, not a heading", () => {
+    // Only a heading opens a provision; a paragraph anchor is a deep-link
+    // target inside one.
+    expect(extractProvisionText(blocks, "sec-1-1")).toBeNull();
+  });
+});

--- a/apps/api/src/handlers/legislation/provision-text.ts
+++ b/apps/api/src/handlers/legislation/provision-text.ts
@@ -1,0 +1,44 @@
+import type { Block } from "@stll/legal-ast/document-ast";
+
+/**
+ * The text one provision owns: its heading, plus every block that follows
+ * until a heading at the same or a shallower level opens the next provision.
+ * Nested subdivisions stay inside, which is what a reader comparing two
+ * consolidations of a section expects to see.
+ *
+ * Returns null when no heading carries the anchor, which is how an unknown
+ * anchor is told apart from a provision that exists and is empty.
+ */
+export const extractProvisionText = (
+  blocks: readonly Block[],
+  anchorId: string,
+): string | null => {
+  const start = blocks.findIndex(
+    (block) => block.type === "heading" && block.anchorId === anchorId,
+  );
+
+  if (start === -1) {
+    return null;
+  }
+
+  const heading = blocks.at(start);
+
+  if (heading?.type !== "heading") {
+    return null;
+  }
+
+  const parts: string[] = [heading.plainText];
+
+  for (const block of blocks.slice(start + 1)) {
+    if (block.type === "heading" && block.level <= heading.level) {
+      break;
+    }
+
+    parts.push(block.plainText);
+  }
+
+  return parts
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .join("\n");
+};

--- a/apps/api/src/handlers/legislation/public-reads.db.test.ts
+++ b/apps/api/src/handlers/legislation/public-reads.db.test.ts
@@ -1,12 +1,16 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { drizzle } from "drizzle-orm/pglite";
 
+import type { Block, DocumentAst } from "@stll/legal-ast/document-ast";
+
 import { legislationDocuments, legislationSources } from "@/api/db/schema";
+import { readStatuteByEliHandler } from "@/api/handlers/legislation/by-eli";
 import {
   readLegislationHandler,
   readPublicLegislationHandler,
 } from "@/api/handlers/legislation/get";
 import { listStatutesHandler } from "@/api/handlers/legislation/list";
+import { readProvisionHistoryHandler } from "@/api/handlers/legislation/provision-history";
 import { listStatuteVersionsHandler } from "@/api/handlers/legislation/versions";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -43,6 +47,7 @@ type DocumentSeed = {
   title: string;
   language?: string;
   metadata?: Record<string, unknown>;
+  documentAst?: DocumentAst;
   versionValidFrom: string | null;
   versionValidTo: string | null;
 };
@@ -54,6 +59,7 @@ const seedDocument = ({
   title,
   language = "cs",
   metadata,
+  documentAst,
   versionValidFrom,
   versionValidTo,
 }: DocumentSeed) => ({
@@ -68,7 +74,72 @@ const seedDocument = ({
   versionValidFrom,
   versionValidTo,
   ...(metadata === undefined ? {} : { metadata }),
+  ...(documentAst === undefined ? {} : { documentAst }),
 });
+
+const DELIVERY_ANCHOR = "sec-2079";
+const UNKNOWN_ANCHOR = "sec-9999";
+const SECTION_SIGN = "\u00a7";
+
+/**
+ * One consolidation's structure: the provision under test, a paragraph that
+ * belongs to it, and a sibling section that has to stay out of the extracted
+ * text. Passing null repeals the provision, leaving the anchor absent.
+ */
+const statuteAst = (deliveryText: string | null): DocumentAst => {
+  const provision: Block[] =
+    deliveryText === null
+      ? []
+      : [
+          {
+            id: "b-1",
+            anchorId: DELIVERY_ANCHOR,
+            type: "heading",
+            level: 2,
+            inlines: [{ type: "text", text: `${SECTION_SIGN} 2079` }],
+            plainText: `${SECTION_SIGN} 2079`,
+          },
+          {
+            id: "b-2",
+            anchorId: "p-2079-1",
+            type: "paragraph",
+            inlines: [{ type: "text", text: deliveryText }],
+            plainText: deliveryText,
+          },
+        ];
+
+  return {
+    version: 1,
+    source: { system: "test", documentId: "", webUrl: "", printUrl: "" },
+    metadata: {
+      caseNumber: null,
+      ecli: null,
+      court: null,
+      decisionDate: null,
+      decisionType: null,
+      keywords: [],
+      statutes: [],
+    },
+    blocks: [
+      ...provision,
+      {
+        id: "b-3",
+        anchorId: "sec-2080",
+        type: "heading",
+        level: 2,
+        inlines: [{ type: "text", text: `${SECTION_SIGN} 2080` }],
+        plainText: `${SECTION_SIGN} 2080`,
+      },
+      {
+        id: "b-4",
+        anchorId: "p-2080-1",
+        type: "paragraph",
+        inlines: [{ type: "text", text: "Unrelated neighbouring rule." }],
+        plainText: "Unrelated neighbouring rule.",
+      },
+    ],
+  };
+};
 
 beforeAll(
   async () => {
@@ -100,6 +171,7 @@ beforeAll(
         sourceId: openSourceId,
         eli: "CZ/2012/89",
         title: "Civil Code",
+        documentAst: statuteAst("The seller shall deliver within thirty days."),
         versionValidFrom: "2014-01-01",
         versionValidTo: "2019-12-31",
       }),
@@ -110,6 +182,9 @@ beforeAll(
         sourceId: openSourceId,
         eli: "CZ/2012/89",
         title: "Civil Code",
+        // Same provision text as its predecessor: a reader has to be able to
+        // tell "another consolidation" from "another wording".
+        documentAst: statuteAst("The seller shall deliver within thirty days."),
         versionValidFrom: "2016-01-01",
         versionValidTo: null,
       }),
@@ -119,6 +194,9 @@ beforeAll(
         eli: "CZ/2012/89",
         title: "Civil Code",
         metadata: { publisherNote: "not for public display" },
+        documentAst: statuteAst(
+          "The seller shall deliver within fourteen days.",
+        ),
         versionValidFrom: "2020-01-01",
         versionValidTo: null,
       }),
@@ -138,6 +216,9 @@ beforeAll(
         sourceId: openSourceId,
         eli: "CZ/2012/89",
         title: "Civil Code",
+        // The provision is repealed in this consolidation, so its anchor is
+        // simply not there.
+        documentAst: statuteAst(null),
         versionValidFrom: "2999-01-01",
         versionValidTo: null,
       }),
@@ -204,6 +285,53 @@ const expectPage = (result: unknown): StatutePage => {
   // eslint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by the guard above
   return result as StatutePage;
 };
+
+type ProvisionHistoryPage = {
+  items: {
+    documentId: string;
+    versionValidFrom: string | null;
+    versionValidTo: string | null;
+    text: string;
+  }[];
+  nextCursor: string | null;
+};
+
+const expectHistoryPage = (result: unknown): ProvisionHistoryPage => {
+  if (typeof result !== "object" || result === null || !("items" in result)) {
+    throw new Error(`expected a page, got ${JSON.stringify(result)}`);
+  }
+
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed by the guard above
+  return result as ProvisionHistoryPage;
+};
+
+const expectDocumentId = (result: unknown): string => {
+  if (typeof result !== "object" || result === null || !("id" in result)) {
+    throw new Error(`expected a document, got ${JSON.stringify(result)}`);
+  }
+
+  return String(result.id);
+};
+
+const readEliAsOf = async (
+  eli: string,
+  asOf: string | undefined,
+  language?: string,
+) =>
+  await readStatuteByEliHandler(
+    {
+      eli,
+      ...(asOf === undefined ? {} : { asOf }),
+      ...(language === undefined ? {} : { language }),
+    },
+    legislationDb,
+  );
+
+const readAsOf = async (asOf: string | undefined, language?: string) =>
+  await readEliAsOf("CZ/2012/89", asOf, language);
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const yesterday = new Date(Date.now() - DAY_MS).toISOString().slice(0, 10);
 
 describe("public statute list", () => {
   test("returns the version in force, not the superseded or future one", async () => {
@@ -428,5 +556,194 @@ describe("public statute read", () => {
       code: 404,
       response: { message: "Legislation document not found" },
     });
+  });
+});
+
+describe("point-in-time statute read", () => {
+  test("returns the version whose window covers the date", async () => {
+    expect(expectDocumentId(await readAsOf("2015-06-01"))).toBe(
+      civilCodeSuperseded,
+    );
+  });
+
+  test("counts the opening boundary as covered", async () => {
+    expect(expectDocumentId(await readAsOf("2014-01-01"))).toBe(
+      civilCodeSuperseded,
+    );
+  });
+
+  test("counts the closing boundary as already elapsed", async () => {
+    // Half-open validity: the closing date is the first day the version no
+    // longer applies. The Sunset Act has no successor, so nothing else can
+    // answer for it and the boundary alone decides.
+    expect(expectDocumentId(await readEliAsOf("CZ/1998/222", yesterday))).toBe(
+      sunsetAct,
+    );
+    expect(await readEliAsOf("CZ/1998/222", today)).toMatchObject({
+      code: 404,
+      response: {
+        message:
+          "No version of this legislation was in force on the given date",
+      },
+    });
+  });
+
+  test("prefers the latest opening when several windows cover the date", async () => {
+    // Both the 2016 and the 2020 consolidation are open-ended.
+    expect(expectDocumentId(await readAsOf("2021-01-01"))).toBe(
+      civilCodeCurrent,
+    );
+  });
+
+  test("reads the text in force today without a date", async () => {
+    expect(expectDocumentId(await readAsOf(undefined))).toBe(civilCodeCurrent);
+  });
+
+  test("reads as not found before the corpus covers the work", async () => {
+    expect(await readAsOf("2013-01-01")).toMatchObject({
+      code: 404,
+      response: {
+        message:
+          "No version of this legislation was in force on the given date",
+      },
+    });
+  });
+
+  test("narrows to one language", async () => {
+    expect(expectDocumentId(await readAsOf("2021-01-01", "en"))).toBe(
+      civilCodeEnglish,
+    );
+  });
+
+  test("reads as not found for an unknown identifier", async () => {
+    const result = await readStatuteByEliHandler(
+      { eli: "CZ/1900/1" },
+      legislationDb,
+    );
+
+    expect(result).toMatchObject({
+      code: 404,
+      response: { message: "Legislation document not found" },
+    });
+  });
+
+  test("reads as not found for a source not cleared for redistribution", async () => {
+    const result = await readStatuteByEliHandler(
+      { eli: "CZ/1999/111" },
+      legislationDb,
+    );
+
+    expect(result).toMatchObject({
+      code: 404,
+      response: { message: "Legislation document not found" },
+    });
+  });
+
+  test("keeps the stored publisher metadata off the response", async () => {
+    const result = await readAsOf("2021-01-01");
+
+    expect(expectDocumentId(result)).toBe(civilCodeCurrent);
+    expect(result).not.toHaveProperty("metadata");
+  });
+});
+
+describe("provision history", () => {
+  test("returns the provision's own text per version, newest window first", async () => {
+    const page = expectHistoryPage(
+      await readProvisionHistoryHandler({
+        documentId: civilCodeCurrent,
+        anchor: DELIVERY_ANCHOR,
+        query: {},
+        legislationDb,
+      }),
+    );
+
+    expect(page.items.map((item) => item.documentId)).toEqual([
+      civilCodeCurrent,
+      civilCodeOpenOlder,
+      civilCodeSuperseded,
+    ]);
+    // The neighbouring section is a sibling heading, so it ends the provision.
+    expect(page.items.map((item) => item.text)).toEqual([
+      `${SECTION_SIGN} 2079\nThe seller shall deliver within fourteen days.`,
+      `${SECTION_SIGN} 2079\nThe seller shall deliver within thirty days.`,
+      `${SECTION_SIGN} 2079\nThe seller shall deliver within thirty days.`,
+    ]);
+  });
+
+  test("drops the version in which the provision is repealed", async () => {
+    const page = expectHistoryPage(
+      await readProvisionHistoryHandler({
+        documentId: civilCodeCurrent,
+        anchor: DELIVERY_ANCHOR,
+        query: {},
+        legislationDb,
+      }),
+    );
+
+    // The future consolidation is in the walked version range and still has
+    // to be absent from the answer.
+    expect(page.items.map((item) => item.documentId)).not.toContain(
+      civilCodeFuture,
+    );
+  });
+
+  test("reads as not found for an anchor no version carries", async () => {
+    const result = await readProvisionHistoryHandler({
+      documentId: civilCodeCurrent,
+      anchor: UNKNOWN_ANCHOR,
+      query: {},
+      legislationDb,
+    });
+
+    expect(result).toMatchObject({
+      code: 404,
+      response: { message: "Provision not found" },
+    });
+  });
+
+  test("reads as not found for a source not cleared for redistribution", async () => {
+    const result = await readProvisionHistoryHandler({
+      documentId: withheldAct,
+      anchor: DELIVERY_ANCHOR,
+      query: {},
+      legislationDb,
+    });
+
+    expect(result).toMatchObject({
+      code: 404,
+      response: { message: "Legislation document not found" },
+    });
+  });
+
+  test("walks every carrying version exactly once across cursor pages", async () => {
+    const seen: string[] = [];
+    let cursor: string | null = null;
+
+    for (let request = 0; request < 6; request += 1) {
+      const page: ProvisionHistoryPage = expectHistoryPage(
+        // eslint-disable-next-line eslint/no-await-in-loop -- keyset walk
+        await readProvisionHistoryHandler({
+          documentId: civilCodeCurrent,
+          anchor: DELIVERY_ANCHOR,
+          query: { limit: 1, ...(cursor === null ? {} : { cursor }) },
+          legislationDb,
+        }),
+      );
+
+      seen.push(...page.items.map((item) => item.documentId));
+      cursor = page.nextCursor;
+
+      if (cursor === null) {
+        break;
+      }
+    }
+
+    expect(cursor).toBeNull();
+    expect(seen).toEqual([
+      civilCodeCurrent,
+      civilCodeOpenOlder,
+      civilCodeSuperseded,
+    ]);
   });
 });

--- a/apps/api/src/handlers/legislation/public-routes.test.ts
+++ b/apps/api/src/handlers/legislation/public-routes.test.ts
@@ -38,6 +38,34 @@ describe("public statute routes", () => {
     expect(response.status).toBe(422);
   });
 
+  test("rejects a point-in-time read with no identifier", async () => {
+    const response = await publicLegislationRoute.handle(
+      new Request("http://localhost/law/statutes/by-eli"),
+    );
+
+    expect(response.status).toBe(422);
+  });
+
+  test("rejects an asOf that is not a calendar date", async () => {
+    const response = await publicLegislationRoute.handle(
+      new Request(
+        "http://localhost/law/statutes/by-eli?eli=CZ%2F2012%2F89&asOf=yesterday",
+      ),
+    );
+
+    expect(response.status).toBe(422);
+  });
+
+  test("rejects a provision-history anchor on a non-UUID document", async () => {
+    const response = await publicLegislationRoute.handle(
+      new Request(
+        "http://localhost/law/statutes/not-a-uuid/provisions/p-1/history",
+      ),
+    );
+
+    expect(response.status).toBe(422);
+  });
+
   test("rejects a list cursor that is not a title/id pair", async () => {
     const response = await publicLegislationRoute.handle(
       new Request(

--- a/apps/api/src/handlers/legislation/public-routes.ts
+++ b/apps/api/src/handlers/legislation/public-routes.ts
@@ -2,11 +2,20 @@ import { Result } from "better-result";
 import Elysia, { t } from "elysia";
 
 import { env } from "@/api/env";
+import {
+  readStatuteByEliHandler,
+  readStatuteByEliQuerySchema,
+} from "@/api/handlers/legislation/by-eli";
 import { readPublicLegislationHandler } from "@/api/handlers/legislation/get";
 import {
   listStatutesHandler,
   listStatutesQuerySchema,
 } from "@/api/handlers/legislation/list";
+import {
+  provisionHistoryParamsSchema,
+  provisionHistoryQuerySchema,
+  readProvisionHistoryHandler,
+} from "@/api/handlers/legislation/provision-history";
 import {
   listStatuteVersionsHandler,
   listStatuteVersionsParamsSchema,
@@ -25,6 +34,23 @@ const listStatutes = createSafePublicHandler(
     const response = yield* Result.await(
       Result.tryPromise(
         async () => await listStatutesHandler(query, legislationPublicReadDb),
+      ),
+    );
+
+    return Result.ok(response);
+  },
+);
+
+const readStatuteByEli = createSafePublicHandler(
+  {
+    mcp: { type: "internal", reason: "public_indexing" },
+    query: readStatuteByEliQuerySchema,
+  },
+  async function* ({ query }) {
+    const response = yield* Result.await(
+      Result.tryPromise(
+        async () =>
+          await readStatuteByEliHandler(query, legislationPublicReadDb),
       ),
     );
 
@@ -74,6 +100,29 @@ const listStatuteVersions = createSafePublicHandler(
   },
 );
 
+const readProvisionHistory = createSafePublicHandler(
+  {
+    mcp: { type: "internal", reason: "public_indexing" },
+    params: provisionHistoryParamsSchema,
+    query: provisionHistoryQuerySchema,
+  },
+  async function* ({ params: { documentId, anchor }, query }) {
+    const response = yield* Result.await(
+      Result.tryPromise(
+        async () =>
+          await readProvisionHistoryHandler({
+            documentId,
+            anchor,
+            query,
+            legislationDb: legislationPublicReadDb,
+          }),
+      ),
+    );
+
+    return Result.ok(response);
+  },
+);
+
 /**
  * Public-read routes: no auth, no session, no organization context.
  * Only sources cleared for redistribution are readable.
@@ -92,10 +141,23 @@ export const publicLegislationRoute = new Elysia({
   .get("/statutes", listStatutes.handler, {
     query: listStatutes.config.query,
   })
+  // Ahead of `/statutes/:documentId`, or the literal segment would be read as
+  // a document id and rejected by the UUID schema.
+  .get("/statutes/by-eli", readStatuteByEli.handler, {
+    query: readStatuteByEli.config.query,
+  })
   .get("/statutes/:documentId", readStatute.handler, {
     params: readStatute.config.params,
   })
   .get("/statutes/:documentId/versions", listStatuteVersions.handler, {
     params: listStatuteVersions.config.params,
     query: listStatuteVersions.config.query,
-  });
+  })
+  .get(
+    "/statutes/:documentId/provisions/:anchor/history",
+    readProvisionHistory.handler,
+    {
+      params: readProvisionHistory.config.params,
+      query: readProvisionHistory.config.query,
+    },
+  );

--- a/apps/api/src/handlers/legislation/validity-window.ts
+++ b/apps/api/src/handlers/legislation/validity-window.ts
@@ -1,0 +1,37 @@
+import { sql } from "drizzle-orm";
+import type { SQL, SQLWrapper } from "drizzle-orm";
+
+/** Works with no version window sort below every dated consolidation. */
+export const UNVERSIONED_SORT_DATE = "0001-01-01";
+
+/**
+ * A version window that covers the given date. The window is the corpus
+ * half-open interval `[version_valid_from, version_valid_to)`, so a version
+ * whose successor opens on that date has already ended on it. A null
+ * `version_valid_from` marks a work kept as a single unversioned text, which
+ * covers every date.
+ *
+ * Every read that answers "which text applied then" builds on this one
+ * predicate: the listing (at `CURRENT_DATE`) and the point-in-time read (at a
+ * caller-supplied date) must not be able to disagree about a boundary.
+ */
+export const inForceOn = (
+  validFrom: SQLWrapper,
+  validTo: SQLWrapper,
+  asOf: SQLWrapper,
+): SQL => sql`(
+  ${validFrom} IS NULL OR ${validFrom} <= ${asOf}
+) AND (
+  ${validTo} IS NULL OR ${validTo} > ${asOf}
+)`;
+
+/** `inForceOn` evaluated at the database's current date. */
+export const inForceToday = (validFrom: SQLWrapper, validTo: SQLWrapper): SQL =>
+  inForceOn(validFrom, validTo, sql`CURRENT_DATE`);
+
+/**
+ * The sort key versions are ordered and keyset-paged by: the window opening,
+ * with unversioned works below every dated consolidation.
+ */
+export const versionSortKey = (validFrom: SQLWrapper): SQL =>
+  sql`coalesce(${validFrom}, DATE '${sql.raw(UNVERSIONED_SORT_DATE)}')`;

--- a/apps/api/src/handlers/legislation/versions.ts
+++ b/apps/api/src/handlers/legislation/versions.ts
@@ -1,10 +1,17 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { status, t } from "elysia";
 import type { Static } from "elysia";
 
-import { legislationDocuments, legislationSources } from "@/api/db/schema";
-import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
+import { legislationDocuments } from "@/api/db/schema";
+import {
+  UNVERSIONED_SORT_DATE,
+  versionSortKey,
+} from "@/api/handlers/legislation/validity-window";
+import {
+  selectWorkKey,
+  workKeyConditions,
+} from "@/api/handlers/legislation/work-key";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
   tPaginationCursor,
@@ -43,14 +50,6 @@ type VersionCursor = {
   validFrom: string;
   id: SafeId<"legislationDocument">;
 };
-
-/** Works with no version window sort below every dated consolidation. */
-const UNVERSIONED_SORT_DATE = "0001-01-01";
-
-const versionSortKey = sql`coalesce(
-  ${legislationDocuments.versionValidFrom},
-  DATE '${sql.raw(UNVERSIONED_SORT_DATE)}'
-)`;
 
 const decodeVersionCursor = (cursor: string): VersionCursor | null => {
   const parts = decodePaginationCursor(cursor);
@@ -93,38 +92,17 @@ export const listStatuteVersionsHandler = async ({
   }
 
   const rows = await legislationDb(async (tx) => {
-    const [work] = await tx
-      .select({
-        sourceId: legislationDocuments.sourceId,
-        eli: legislationDocuments.eli,
-        language: legislationDocuments.language,
-      })
-      .from(legislationDocuments)
-      .innerJoin(
-        legislationSources,
-        eq(legislationSources.id, legislationDocuments.sourceId),
-      )
-      .where(
-        and(
-          eq(legislationDocuments.id, documentId),
-          redistributableLegislationSource,
-        ),
-      )
-      .limit(1);
+    const work = await selectWorkKey(tx, documentId);
 
-    if (work === undefined) {
+    if (work === null) {
       return null;
     }
 
-    const conditions: SQL[] = [
-      eq(legislationDocuments.sourceId, work.sourceId),
-      eq(legislationDocuments.eli, work.eli),
-      eq(legislationDocuments.language, work.language),
-    ];
+    const conditions: SQL[] = workKeyConditions(work);
 
     if (cursor !== null) {
       conditions.push(
-        sql`(${versionSortKey}, ${legislationDocuments.id}) < (${cursor.validFrom}::date, ${cursor.id}::uuid)`,
+        sql`(${versionSortKey(legislationDocuments.versionValidFrom)}, ${legislationDocuments.id}) < (${cursor.validFrom}::date, ${cursor.id}::uuid)`,
       );
     }
 
@@ -146,7 +124,7 @@ export const listStatuteVersionsHandler = async ({
       .from(legislationDocuments)
       .where(and(...conditions))
       .orderBy(
-        sql`${versionSortKey} desc`,
+        sql`${versionSortKey(legislationDocuments.versionValidFrom)} desc`,
         sql`${legislationDocuments.id} desc`,
       )
       .limit(limit + 1);

--- a/apps/api/src/handlers/legislation/work-key.ts
+++ b/apps/api/src/handlers/legislation/work-key.ts
@@ -1,0 +1,57 @@
+import { and, eq } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+
+import { legislationDocuments, legislationSources } from "@/api/db/schema";
+import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
+import type { SafeId } from "@/api/lib/branded-types";
+import type { LegislationReadTransaction } from "@/api/lib/legislation-public-read-db";
+
+/**
+ * What identifies a Work across its consolidations: the source, ELI and
+ * language triple the unique indexes are built on. Two Expressions share a
+ * Work exactly when these three match.
+ */
+export type LegislationWorkKey = {
+  sourceId: SafeId<"legislationSource">;
+  eli: string;
+  language: string;
+};
+
+/**
+ * The Work one Expression belongs to, or null when the document does not
+ * exist or its source is not cleared for redistribution. Every read that
+ * walks a Work's versions starts here, so "not found" means the same thing
+ * on all of them.
+ */
+export const selectWorkKey = async (
+  tx: LegislationReadTransaction,
+  documentId: SafeId<"legislationDocument">,
+): Promise<LegislationWorkKey | null> => {
+  const [work] = await tx
+    .select({
+      sourceId: legislationDocuments.sourceId,
+      eli: legislationDocuments.eli,
+      language: legislationDocuments.language,
+    })
+    .from(legislationDocuments)
+    .innerJoin(
+      legislationSources,
+      eq(legislationSources.id, legislationDocuments.sourceId),
+    )
+    .where(
+      and(
+        eq(legislationDocuments.id, documentId),
+        redistributableLegislationSource,
+      ),
+    )
+    .limit(1);
+
+  return work ?? null;
+};
+
+/** Restricts a `legislation_documents` scan to one Work. */
+export const workKeyConditions = (work: LegislationWorkKey): SQL[] => [
+  eq(legislationDocuments.sourceId, work.sourceId),
+  eq(legislationDocuments.eli, work.eli),
+  eq(legislationDocuments.language, work.language),
+];

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -315,6 +315,12 @@ export const LIMITS = {
   /** Consolidated versions of one work returned per page. */
   legislationVersionsPageSizeDefault: 50,
   legislationVersionsPageSizeMax: 200,
+  /**
+   * Versions inspected per page of one provision's history. Each one costs a
+   * document-AST read, so the page stays far below the version page size.
+   */
+  legislationProvisionHistoryPageSizeDefault: 5,
+  legislationProvisionHistoryPageSizeMax: 20,
   caseLawPolarityRulesPerLanguage: 500,
   // corpus index two-stage search: lexical candidates fetched per index window
   // before the citation-authority rerank.

--- a/apps/api/src/tests/setup-env.ts
+++ b/apps/api/src/tests/setup-env.ts
@@ -35,6 +35,13 @@ delete process.env["GOOGLE_AUTH_CLIENT_SECRET"];
 delete process.env["MICROSOFT_AUTH_CLIENT_ID"];
 delete process.env["MICROSOFT_AUTH_CLIENT_SECRET"];
 delete process.env["MICROSOFT_AUTH_TENANT_ID"];
+// Same leak, different blast radius: a developer .env that turns corpus
+// object storage on sends ingestion tests down the real S3 write path, where
+// they fail against a bucket the test runner has never created. Tests assert
+// on the Postgres copy, so force the mode off rather than leaving hermeticity
+// to whatever each machine happens to have configured.
+delete process.env["CORPUS_STORAGE_MODE"];
+delete process.env["CORPUS_STORAGE_ENABLED"];
 
 process.env["REDIS_URL"] ??= "redis://localhost:6379";
 process.env["BETTER_AUTH_SECRET"] ??= "x".repeat(32);

--- a/apps/web/src/components/versions/version-list.tsx
+++ b/apps/web/src/components/versions/version-list.tsx
@@ -28,6 +28,10 @@ import Tooltip from "@/components/tooltip";
 import { UserAvatar } from "@/components/user-avatar";
 import { detached } from "@/lib/detached";
 import { formatFullTimestamp, formatRelativeTime } from "@/lib/relative-time";
+import {
+  TRACKED_DELETION_STYLE,
+  TRACKED_INSERTION_STYLE,
+} from "@/lib/track-changes-style";
 
 export const VersionList = ({ children }: React.PropsWithChildren) => (
   <div className="flex flex-col gap-px p-1">{children}</div>
@@ -353,31 +357,6 @@ export const VersionDiffBlock = ({
   );
 };
 
-// Track-changes styling, matched to folio's suggestion preview
-// (.folio-ai-suggestion--focused-original/-replacement): deletions
-// read as dimmed muted strikethrough with a faint destructive tint,
-// insertions as a low-saturation success wash with an inset ring.
-// color-mix over semantic tokens keeps both theme-aware without
-// importing folio's stylesheet.
-const DEL_STYLE: React.CSSProperties = {
-  color: "color-mix(in oklch, var(--destructive) 35%, var(--muted-foreground))",
-  textDecorationLine: "line-through",
-  textDecorationThickness: "1px",
-  textDecorationColor:
-    "color-mix(in oklch, var(--destructive) 30%, var(--muted-foreground))",
-};
-
-const INS_STYLE: React.CSSProperties = {
-  borderRadius: "3px",
-  padding: "0 2px",
-  backgroundColor: "color-mix(in oklch, var(--success) 14%, transparent)",
-  boxShadow:
-    "inset 0 0 0 1px color-mix(in oklch, var(--success) 28%, transparent)",
-  textDecorationLine: "none",
-  boxDecorationBreak: "clone",
-  WebkitBoxDecorationBreak: "clone",
-};
-
 const DiffSegmentParagraph = ({ segment }: { segment: VersionDiffSegment }) => {
   if (segment.kind === "gap") {
     // The API elides long unchanged runs server-side and sends only the
@@ -404,14 +383,14 @@ const DiffSegmentParagraph = ({ segment }: { segment: VersionDiffSegment }) => {
   }
   if (segment.kind === "added") {
     return (
-      <ins style={INS_STYLE}>
+      <ins style={TRACKED_INSERTION_STYLE}>
         <MarkerAwareText text={segment.text} />
       </ins>
     );
   }
   if (segment.kind === "removed") {
     return (
-      <del style={DEL_STYLE}>
+      <del style={TRACKED_DELETION_STYLE}>
         <MarkerAwareText text={segment.text} />
       </del>
     );
@@ -426,14 +405,14 @@ const DiffSegmentParagraph = ({ segment }: { segment: VersionDiffSegment }) => {
 const DiffRunSpan = ({ run }: { run: VersionDiffRun }) => {
   if (run.kind === "del") {
     return (
-      <del style={DEL_STYLE}>
+      <del style={TRACKED_DELETION_STYLE}>
         <MarkerAwareText text={run.text} />
       </del>
     );
   }
   if (run.kind === "ins") {
     return (
-      <ins style={INS_STYLE}>
+      <ins style={TRACKED_INSERTION_STYLE}>
         <MarkerAwareText text={run.text} />
       </ins>
     );

--- a/apps/web/src/features/statutes/components/provision-history.tsx
+++ b/apps/web/src/features/statutes/components/provision-history.tsx
@@ -1,0 +1,266 @@
+import { useState } from "react";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { HistoryIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import {
+  Sheet,
+  SheetHeader,
+  SheetPanel,
+  SheetPopup,
+  SheetTitle,
+  SheetTrigger,
+} from "@stll/ui/components/sheet";
+import { Skeleton } from "@stll/ui/components/skeleton";
+import { cn } from "@stll/ui/lib/utils";
+
+import {
+  diffProvisionText,
+  selectChangedVersions,
+} from "@/features/statutes/provision-diff";
+import type { ProvisionDiffSegment } from "@/features/statutes/provision-diff";
+import { provisionHistoryOptions } from "@/features/statutes/queries/provision-history";
+import {
+  EM_DASH,
+  formatValidityDate,
+} from "@/features/statutes/statute-format";
+import { useFormatter } from "@/i18n/formatting-context";
+import { detached } from "@/lib/detached";
+import {
+  TRACKED_DELETION_STYLE,
+  TRACKED_INSERTION_STYLE,
+} from "@/lib/track-changes-style";
+
+type ProvisionHistoryProps = {
+  /** The provision heading's anchor, the id the history is filed under. */
+  anchorId: string;
+  /** The consolidation on screen; the read resolves its Work from this. */
+  documentId: string;
+  /** The heading's own text, so the panel names the provision it is about. */
+  provision: string;
+};
+
+/**
+ * Opens one provision's drafting history: the consolidations in which it was
+ * rewritten, and the word-level difference each rewrite made.
+ */
+export const ProvisionHistory = ({
+  anchorId,
+  documentId,
+  provision,
+}: ProvisionHistoryProps) => {
+  const t = useTranslations();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Sheet onOpenChange={setOpen} open={open}>
+      <SheetTrigger
+        render={
+          <Button
+            aria-label={t("statutes.provisionHistoryFor", { provision })}
+            className="text-muted-foreground hover:text-foreground -mt-1 mb-2 h-auto px-1 py-0.5 text-xs font-normal"
+            size="sm"
+            variant="ghost"
+          />
+        }
+      >
+        <HistoryIcon aria-hidden="true" className="size-3" />
+        {t("common.history")}
+      </SheetTrigger>
+      <SheetPopup side="inline-end" variant="inset">
+        <SheetHeader>
+          <SheetTitle>
+            {t("statutes.provisionHistoryFor", { provision })}
+          </SheetTitle>
+        </SheetHeader>
+        <SheetPanel className="flex flex-col gap-4">
+          {open && (
+            <ProvisionHistoryBody anchorId={anchorId} documentId={documentId} />
+          )}
+        </SheetPanel>
+      </SheetPopup>
+    </Sheet>
+  );
+};
+
+type ProvisionHistoryBodyProps = {
+  anchorId: string;
+  documentId: string;
+};
+
+/**
+ * Rendered only while the panel is open, so a page of provisions costs no
+ * requests until a reader asks about one of them.
+ */
+const ProvisionHistoryBody = ({
+  anchorId,
+  documentId,
+}: ProvisionHistoryBodyProps) => {
+  const t = useTranslations();
+  const format = useFormatter();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const { data, fetchNextPage, hasNextPage, isError, isFetchingNextPage } =
+    useInfiniteQuery(provisionHistoryOptions({ anchor: anchorId, documentId }));
+
+  if (isError) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        {t("statutes.provisionHistoryUnavailable")}
+      </p>
+    );
+  }
+
+  if (data === undefined) {
+    return (
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-6 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    );
+  }
+
+  const versions = selectChangedVersions(
+    data.pages.flatMap((page) => page.items),
+  );
+  const selectedIndex = Math.max(
+    0,
+    versions.findIndex((version) => version.documentId === selectedId),
+  );
+  const selected = versions.at(selectedIndex);
+
+  if (selected === undefined) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        {t("statutes.provisionHistoryEmpty")}
+      </p>
+    );
+  }
+
+  const previous = versions.at(selectedIndex + 1);
+  const label = (validFrom: string | null): string =>
+    formatValidityDate(validFrom, format) ?? EM_DASH;
+
+  return (
+    <>
+      <ul className="flex flex-col gap-1" aria-label={t("common.version")}>
+        {versions.map((version) => (
+          <li key={version.documentId}>
+            <Button
+              aria-current={
+                version.documentId === selected.documentId ? "true" : undefined
+              }
+              className={cn(
+                "h-auto w-full justify-start px-2 py-1.5 text-xs font-normal",
+                version.documentId === selected.documentId && "bg-accent",
+              )}
+              onClick={() => {
+                setSelectedId(version.documentId);
+              }}
+              variant="ghost"
+            >
+              {t("statutes.inForceSince", {
+                date: label(version.versionValidFrom),
+              })}
+            </Button>
+          </li>
+        ))}
+      </ul>
+
+      {hasNextPage && (
+        <Button
+          className="w-full"
+          disabled={isFetchingNextPage}
+          onClick={() => {
+            detached(fetchNextPage(), "statutes.provision-history-page");
+          }}
+          size="sm"
+          variant="outline"
+        >
+          {t("common.loadMore")}
+        </Button>
+      )}
+
+      {/* With no older wording loaded there is nothing to diff against, so
+          the panel shows the wording itself and says why. */}
+      <ProvisionDiff after={selected.text} before={previous?.text ?? null} />
+      {previous === undefined && (
+        <p className="text-muted-foreground text-xs">
+          {hasNextPage
+            ? t("statutes.provisionHistoryLoadOlder")
+            : t("statutes.provisionHistoryEarliest")}
+        </p>
+      )}
+    </>
+  );
+};
+
+type ProvisionDiffProps = {
+  /** The older wording, or null when this is the earliest one on record. */
+  before: string | null;
+  after: string;
+};
+
+const ProvisionDiff = ({ after, before }: ProvisionDiffProps) => {
+  if (before === null) {
+    return <p className="text-sm leading-6 whitespace-pre-wrap">{after}</p>;
+  }
+
+  return (
+    <p className="text-sm leading-6 whitespace-pre-wrap">
+      {withOffsets(diffProvisionText(before, after)).map(
+        ({ offset, segment }) => (
+          <ProvisionDiffRun key={offset} segment={segment} />
+        ),
+      )}
+    </p>
+  );
+};
+
+type OffsetSegment = {
+  offset: number;
+  segment: ProvisionDiffSegment;
+};
+
+/**
+ * Segments carry no identity of their own, but their position in the
+ * concatenated text is unique and stable for a given pair of wordings.
+ */
+const withOffsets = (
+  segments: readonly ProvisionDiffSegment[],
+): OffsetSegment[] => {
+  const positioned: OffsetSegment[] = [];
+  let offset = 0;
+
+  for (const segment of segments) {
+    positioned.push({ offset, segment });
+    offset += segment.text.length;
+  }
+
+  return positioned;
+};
+
+const ProvisionDiffRun = ({ segment }: { segment: ProvisionDiffSegment }) => {
+  const t = useTranslations();
+
+  if (segment.kind === "inserted") {
+    return (
+      <ins style={TRACKED_INSERTION_STYLE}>
+        <span className="sr-only">{t("statutes.diffInserted")}</span>
+        {segment.text}
+      </ins>
+    );
+  }
+
+  if (segment.kind === "removed") {
+    return (
+      <del style={TRACKED_DELETION_STYLE}>
+        <span className="sr-only">{t("statutes.diffRemoved")}</span>
+        {segment.text}
+      </del>
+    );
+  }
+
+  return <span>{segment.text}</span>;
+};

--- a/apps/web/src/features/statutes/components/provision-history.tsx
+++ b/apps/web/src/features/statutes/components/provision-history.tsx
@@ -18,6 +18,7 @@ import { cn } from "@stll/ui/lib/utils";
 
 import {
   diffProvisionText,
+  resolveSelectedVersion,
   selectChangedVersions,
 } from "@/features/statutes/provision-diff";
 import type { ProvisionDiffSegment } from "@/features/statutes/provision-diff";
@@ -121,14 +122,13 @@ const ProvisionHistoryBody = ({
     );
   }
 
-  const versions = selectChangedVersions(
-    data.pages.flatMap((page) => page.items),
-  );
-  const selectedIndex = Math.max(
-    0,
-    versions.findIndex((version) => version.documentId === selectedId),
-  );
-  const selected = versions.at(selectedIndex);
+  const consolidations = data.pages.flatMap((page) => page.items);
+  const versions = selectChangedVersions(consolidations);
+  const selected = resolveSelectedVersion({
+    changed: versions,
+    consolidations,
+    selectedId,
+  });
 
   if (selected === undefined) {
     return (
@@ -138,7 +138,7 @@ const ProvisionHistoryBody = ({
     );
   }
 
-  const previous = versions.at(selectedIndex + 1);
+  const previous = versions.at(versions.indexOf(selected) + 1);
   const label = (validFrom: string | null): string =>
     formatValidityDate(validFrom, format) ?? EM_DASH;
 

--- a/apps/web/src/features/statutes/components/statute-text.test.tsx
+++ b/apps/web/src/features/statutes/components/statute-text.test.tsx
@@ -25,6 +25,8 @@ const renderWithIntl = (children: ReactNode) =>
 
 const inlineText = (text: string) => [{ type: "text" as const, text }];
 
+const DOCUMENT_ID = "0198f4c1-2b3d-7a41-9c88-4a1c0e2f5d6b";
+
 const blocks = [
   // The publisher states a division's designation and its title as two
   // lines of one heading, joined by a line break.
@@ -91,8 +93,10 @@ describe("StatuteText", () => {
       <StatuteText
         blocks={blocks}
         citationWork={null}
+        documentId={DOCUMENT_ID}
         fulltext={null}
         language="cs"
+        versionCount={1}
       />,
     );
 
@@ -110,8 +114,10 @@ describe("StatuteText", () => {
       <StatuteText
         blocks={blocks}
         citationWork={null}
+        documentId={DOCUMENT_ID}
         fulltext={null}
         language="cs"
+        versionCount={1}
       />,
     );
 
@@ -124,8 +130,10 @@ describe("StatuteText", () => {
       <StatuteText
         blocks={blocks}
         citationWork={null}
+        documentId={DOCUMENT_ID}
         fulltext={null}
         language="cs"
+        versionCount={1}
       />,
     );
 
@@ -140,8 +148,10 @@ describe("StatuteText", () => {
       <StatuteText
         blocks={blocks}
         citationWork={null}
+        documentId={DOCUMENT_ID}
         fulltext={null}
         language="cs"
+        versionCount={1}
       />,
     );
 
@@ -159,8 +169,10 @@ describe("StatuteText", () => {
       <StatuteText
         blocks={blocks}
         citationWork={null}
+        documentId={DOCUMENT_ID}
         fulltext={null}
         language="cs"
+        versionCount={1}
       />,
     );
 
@@ -177,8 +189,10 @@ describe("StatuteText", () => {
       <StatuteText
         blocks={[]}
         citationWork={null}
+        documentId={DOCUMENT_ID}
         fulltext={"First paragraph.\n\nSecond paragraph."}
         language="cs"
+        versionCount={1}
       />,
     );
 
@@ -186,13 +200,47 @@ describe("StatuteText", () => {
     expect(markup).toContain("Second paragraph.");
   });
 
+  test("offers no drafting history while the work has one consolidation", () => {
+    const markup = renderWithIntl(
+      <StatuteText
+        blocks={blocks}
+        documentId={DOCUMENT_ID}
+        fulltext={null}
+        language="cs"
+        versionCount={1}
+      />,
+    );
+
+    expect(markup).not.toContain(messages.common.history);
+  });
+
+  test("offers a drafting history per provision, not per container", () => {
+    const markup = renderWithIntl(
+      <StatuteText
+        blocks={blocks}
+        documentId={DOCUMENT_ID}
+        fulltext={null}
+        language="cs"
+        versionCount={3}
+      />,
+    );
+
+    // Same rule as the citation affordance: of the fixture's four headings
+    // only `§ 47` opens a provision, and a container heading has no drafting
+    // history of its own.
+    expect(blocks.filter((block) => block.type === "heading")).toHaveLength(4);
+    expect(markup.split(messages.common.history)).toHaveLength(2);
+  });
+
   test("says so when neither a parsed document nor plain text exists", () => {
     const markup = renderWithIntl(
       <StatuteText
         blocks={[]}
         citationWork={null}
+        documentId={DOCUMENT_ID}
         fulltext={null}
         language="cs"
+        versionCount={1}
       />,
     );
 
@@ -207,8 +255,10 @@ describe("StatuteText", () => {
           <StatuteText
             blocks={blocks}
             citationWork={{ eli: "/eli/cz/sb/2012/89", jurisdiction: "CZE" }}
+            documentId={DOCUMENT_ID}
             fulltext={null}
             language="cs"
+            versionCount={1}
           />
         </FormattingProvider>
       </QueryClientProvider>,
@@ -229,8 +279,10 @@ describe("StatuteText", () => {
           <StatuteText
             blocks={blocks}
             citationWork={{ eli: "/eli/cz/sb/2012/89", jurisdiction: "CZE" }}
+            documentId={DOCUMENT_ID}
             fulltext={null}
             language="cs"
+            versionCount={1}
           />
         </FormattingProvider>
       </QueryClientProvider>,

--- a/apps/web/src/features/statutes/components/statute-text.test.tsx
+++ b/apps/web/src/features/statutes/components/statute-text.test.tsx
@@ -204,6 +204,7 @@ describe("StatuteText", () => {
     const markup = renderWithIntl(
       <StatuteText
         blocks={blocks}
+        citationWork={null}
         documentId={DOCUMENT_ID}
         fulltext={null}
         language="cs"
@@ -218,6 +219,7 @@ describe("StatuteText", () => {
     const markup = renderWithIntl(
       <StatuteText
         blocks={blocks}
+        citationWork={null}
         documentId={DOCUMENT_ID}
         fulltext={null}
         language="cs"

--- a/apps/web/src/features/statutes/components/statute-text.tsx
+++ b/apps/web/src/features/statutes/components/statute-text.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/legal-reader/document-ast-text";
 import { parseProvisionDesignation } from "@/components/legal-reader/reader-outline";
 import { ProvisionCitingDecisions } from "@/features/statutes/components/provision-citing-decisions";
+import { ProvisionHistory } from "@/features/statutes/components/provision-history";
 
 /**
  * What a provision's incoming citations are filed under: the work's own
@@ -26,9 +27,22 @@ type StatuteTextProps = {
   /** Parsed blocks. The route owns the parse: it also builds the outline. */
   blocks: readonly Block[];
   citationWork: StatuteCitationWork | null;
+  /** The consolidation on screen; a provision's history is read from it. */
+  documentId: string;
   fulltext: string | null;
   language: string;
+  /** A Work with a single consolidation has no history to offer. */
+  versionCount: number;
 };
+
+/**
+ * A heading that opens a provision. It is the unit case law cites and the
+ * unit a drafting history is about, so both affordances key off the one
+ * designation parser rather than each guessing at the shape of a heading.
+ */
+const isProvisionHeading = (block: Block): boolean =>
+  block.type === "heading" &&
+  parseProvisionDesignation(block.plainText) !== null;
 
 const READER_STYLE = {
   fontFamily: "var(--reader-body-font)",
@@ -49,15 +63,12 @@ const NO_ACTIVE_MATCH = -1;
 export const StatuteText = ({
   blocks,
   citationWork,
+  documentId,
   fulltext,
   language,
+  versionCount,
 }: StatuteTextProps) => {
   const t = useTranslations();
-
-  /** A heading that opens a provision is the unit case law cites. */
-  const isProvisionHeading = (block: Block): boolean =>
-    block.type === "heading" &&
-    parseProvisionDesignation(block.plainText) !== null;
 
   if (blocks.length > 0) {
     return (
@@ -74,7 +85,14 @@ export const StatuteText = ({
               rangesByPieceId={NO_RANGES}
               variant="statute"
             />
-            {citationWork !== null && isProvisionHeading(block) && (
+            {isProvisionHeading(block) && versionCount > 1 && (
+              <ProvisionHistory
+                anchorId={block.anchorId}
+                documentId={documentId}
+                provision={block.plainText}
+              />
+            )}
+            {isProvisionHeading(block) && citationWork !== null && (
               <ProvisionCitingDecisions
                 anchorId={block.anchorId}
                 eli={citationWork.eli}

--- a/apps/web/src/features/statutes/provision-diff.test.ts
+++ b/apps/web/src/features/statutes/provision-diff.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   diffProvisionText,
+  resolveSelectedVersion,
   selectChangedVersions,
 } from "@/features/statutes/provision-diff";
 import type { ProvisionDiffSegment } from "@/features/statutes/provision-diff";
@@ -126,5 +127,77 @@ describe("selectChangedVersions", () => {
     ];
 
     expect(selectChangedVersions(versions)).toEqual(versions);
+  });
+});
+
+describe("resolveSelectedVersion", () => {
+  // What one page of the history looks like, and what the next page turns it
+  // into: the reissue only becomes a repetition once its predecessor loads.
+  const firstPage = [
+    { documentId: "current", text: "new wording" },
+    { documentId: "reissue", text: "old wording" },
+  ];
+  const bothPages = [
+    ...firstPage,
+    { documentId: "original", text: "old wording" },
+  ];
+
+  test("keeps the reader on the same wording when the next page folds it away", () => {
+    // The fixture must actually fold, or the reconciliation proves nothing.
+    expect(selectChangedVersions(firstPage).map((v) => v.documentId)).toContain(
+      "reissue",
+    );
+    expect(
+      selectChangedVersions(bothPages).map((v) => v.documentId),
+    ).not.toContain("reissue");
+
+    const selected = resolveSelectedVersion({
+      changed: selectChangedVersions(bothPages),
+      consolidations: bothPages,
+      selectedId: "reissue",
+    });
+
+    expect(selected?.documentId).toBe("original");
+    expect(selected?.text).toBe("old wording");
+  });
+
+  test("leaves a still-listed selection alone", () => {
+    expect(
+      resolveSelectedVersion({
+        changed: selectChangedVersions(bothPages),
+        consolidations: bothPages,
+        selectedId: "original",
+      })?.documentId,
+    ).toBe("original");
+  });
+
+  test("defaults to the newest wording with nothing selected", () => {
+    expect(
+      resolveSelectedVersion({
+        changed: selectChangedVersions(bothPages),
+        consolidations: bothPages,
+        selectedId: null,
+      })?.documentId,
+    ).toBe("current");
+  });
+
+  test("falls back to the newest wording for an unknown selection", () => {
+    expect(
+      resolveSelectedVersion({
+        changed: selectChangedVersions(bothPages),
+        consolidations: bothPages,
+        selectedId: "not-in-this-work",
+      })?.documentId,
+    ).toBe("current");
+  });
+
+  test("has nothing to resolve to on an empty history", () => {
+    expect(
+      resolveSelectedVersion({
+        changed: [],
+        consolidations: [],
+        selectedId: "current",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/apps/web/src/features/statutes/provision-diff.test.ts
+++ b/apps/web/src/features/statutes/provision-diff.test.ts
@@ -192,10 +192,14 @@ describe("resolveSelectedVersion", () => {
   });
 
   test("has nothing to resolve to on an empty history", () => {
+    // Sliced from the fixture so the element type is the real one; empty
+    // literals would infer away the return type this asserts on.
+    const empty = bothPages.slice(0, 0);
+
     expect(
       resolveSelectedVersion({
-        changed: [],
-        consolidations: [],
+        changed: empty,
+        consolidations: empty,
         selectedId: "current",
       }),
     ).toBeUndefined();

--- a/apps/web/src/features/statutes/provision-diff.test.ts
+++ b/apps/web/src/features/statutes/provision-diff.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  diffProvisionText,
+  selectChangedVersions,
+} from "@/features/statutes/provision-diff";
+import type { ProvisionDiffSegment } from "@/features/statutes/provision-diff";
+
+const rebuild = (
+  segments: readonly ProvisionDiffSegment[],
+  side: "before" | "after",
+): string =>
+  segments
+    .filter(
+      (segment) =>
+        segment.kind === "equal" ||
+        segment.kind === (side === "before" ? "removed" : "inserted"),
+    )
+    .map((segment) => segment.text)
+    .join("");
+
+describe("diffProvisionText", () => {
+  test("marks only the words that changed", () => {
+    const segments = diffProvisionText(
+      "The seller shall deliver within thirty days.",
+      "The seller shall deliver within fourteen days.",
+    );
+
+    expect(segments.filter((segment) => segment.kind !== "equal")).toEqual([
+      { kind: "removed", text: "thirty" },
+      { kind: "inserted", text: "fourteen" },
+    ]);
+  });
+
+  test("rebuilds both wordings exactly", () => {
+    const before = "A party may withdraw from the contract within ten days.";
+    const after = "A party may, in writing, withdraw from the contract.";
+    const segments = diffProvisionText(before, after);
+
+    expect(rebuild(segments, "before")).toBe(before);
+    expect(rebuild(segments, "after")).toBe(after);
+  });
+
+  test("keeps identical wordings as a single unchanged run", () => {
+    const text = "The obligation expires on performance.";
+
+    expect(diffProvisionText(text, text)).toEqual([{ kind: "equal", text }]);
+  });
+
+  test("reports a repeal as a removal with nothing inserted", () => {
+    const segments = diffProvisionText("The rule applies.", "");
+
+    expect(segments).toEqual([{ kind: "removed", text: "The rule applies." }]);
+  });
+
+  test("reports a new provision as an insertion with nothing removed", () => {
+    const segments = diffProvisionText("", "The rule applies.");
+
+    expect(segments).toEqual([{ kind: "inserted", text: "The rule applies." }]);
+  });
+
+  test("never emits two adjacent segments of the same kind", () => {
+    const segments = diffProvisionText(
+      "one two three four five six",
+      "one nine three ten five eleven",
+    );
+
+    for (const [index, segment] of segments.entries()) {
+      expect(segments.at(index + 1)?.kind).not.toBe(segment.kind);
+    }
+  });
+
+  test("falls back to a wholesale replacement past the alignment limit", () => {
+    // Long enough that a quadratic alignment is the wrong tool; the fixture
+    // must exceed the limit or the assertion proves nothing.
+    const before = Array.from({ length: 2000 }, (_, i) => `a${i}`).join(" ");
+    const after = Array.from({ length: 2000 }, (_, i) => `b${i}`).join(" ");
+    const segments = diffProvisionText(before, after);
+
+    expect(segments).toEqual([
+      { kind: "removed", text: before },
+      { kind: "inserted", text: after },
+    ]);
+  });
+
+  test("still aligns a long provision with a shared prefix and suffix", () => {
+    // The same length, but only one word differs, so trimming the common ends
+    // leaves an alignment well inside the limit.
+    const words = Array.from({ length: 2000 }, (_, i) => `w${i}`);
+    const before = words.join(" ");
+    const after = words.with(1000, "changed").join(" ");
+    const segments = diffProvisionText(before, after);
+
+    expect(segments.filter((segment) => segment.kind !== "equal")).toEqual([
+      { kind: "removed", text: "w1000" },
+      { kind: "inserted", text: "changed" },
+    ]);
+  });
+});
+
+describe("selectChangedVersions", () => {
+  test("folds away a consolidation that reissues the wording unchanged", () => {
+    const versions = [
+      { documentId: "c", text: "new wording" },
+      { documentId: "b", text: "old wording" },
+      { documentId: "a", text: "old wording" },
+    ];
+
+    expect(selectChangedVersions(versions).map((v) => v.documentId)).toEqual([
+      "c",
+      "a",
+    ]);
+  });
+
+  test("keeps the earliest wording on record", () => {
+    const versions = [{ documentId: "a", text: "only wording" }];
+
+    expect(selectChangedVersions(versions)).toEqual(versions);
+  });
+
+  test("keeps every version when each one rewrote the provision", () => {
+    const versions = [
+      { documentId: "c", text: "third" },
+      { documentId: "b", text: "second" },
+      { documentId: "a", text: "first" },
+    ];
+
+    expect(selectChangedVersions(versions)).toEqual(versions);
+  });
+});

--- a/apps/web/src/features/statutes/provision-diff.ts
+++ b/apps/web/src/features/statutes/provision-diff.ts
@@ -1,0 +1,186 @@
+import { panic } from "better-result";
+
+export type ProvisionDiffSegmentKind = "equal" | "inserted" | "removed";
+
+export type ProvisionDiffSegment = {
+  kind: ProvisionDiffSegmentKind;
+  text: string;
+};
+
+/**
+ * Alignment is quadratic in the token count, so a provision longer than this
+ * is reported as a wholesale replacement rather than a word-level edit. A
+ * consolidated section is a few hundred tokens; anything past the limit is
+ * a whole chapter, where a word diff would be unreadable anyway.
+ */
+const ALIGNMENT_TOKEN_LIMIT = 1200;
+
+/** Whitespace is kept as its own token so the output rebuilds the input. */
+const TOKEN_BOUNDARY = /(\s+)/u;
+
+const tokenize = (text: string): string[] =>
+  text.split(TOKEN_BOUNDARY).filter((token) => token.length > 0);
+
+const tokenAt = (tokens: readonly string[], index: number): string =>
+  tokens[index] ??
+  panic("Provision diff read a token outside the aligned range");
+
+/**
+ * Longest-common-subsequence alignment over tokens, walked forwards so the
+ * segments come out in reading order.
+ */
+const alignTokens = (
+  before: readonly string[],
+  after: readonly string[],
+): ProvisionDiffSegment[] => {
+  const columns = after.length + 1;
+  const lengths = new Uint32Array((before.length + 1) * columns);
+  const commonAt = (row: number, column: number): number =>
+    lengths[row * columns + column] ??
+    panic("Provision diff read outside its alignment matrix");
+
+  for (let row = before.length - 1; row >= 0; row -= 1) {
+    for (let column = after.length - 1; column >= 0; column -= 1) {
+      lengths[row * columns + column] =
+        tokenAt(before, row) === tokenAt(after, column)
+          ? commonAt(row + 1, column + 1) + 1
+          : Math.max(commonAt(row + 1, column), commonAt(row, column + 1));
+    }
+  }
+
+  const segments: ProvisionDiffSegment[] = [];
+  let row = 0;
+  let column = 0;
+
+  while (row < before.length && column < after.length) {
+    if (tokenAt(before, row) === tokenAt(after, column)) {
+      segments.push({ kind: "equal", text: tokenAt(before, row) });
+      row += 1;
+      column += 1;
+      continue;
+    }
+
+    if (commonAt(row + 1, column) >= commonAt(row, column + 1)) {
+      segments.push({ kind: "removed", text: tokenAt(before, row) });
+      row += 1;
+      continue;
+    }
+
+    segments.push({ kind: "inserted", text: tokenAt(after, column) });
+    column += 1;
+  }
+
+  for (; row < before.length; row += 1) {
+    segments.push({ kind: "removed", text: tokenAt(before, row) });
+  }
+
+  for (; column < after.length; column += 1) {
+    segments.push({ kind: "inserted", text: tokenAt(after, column) });
+  }
+
+  return segments;
+};
+
+/** Adjacent segments of one kind read as one run of changed text. */
+const mergeRuns = (
+  segments: readonly ProvisionDiffSegment[],
+): ProvisionDiffSegment[] => {
+  const merged: ProvisionDiffSegment[] = [];
+
+  for (const segment of segments) {
+    if (segment.text.length === 0) {
+      continue;
+    }
+
+    const previous = merged.at(-1);
+
+    if (previous?.kind === segment.kind) {
+      merged[merged.length - 1] = {
+        kind: previous.kind,
+        text: previous.text + segment.text,
+      };
+      continue;
+    }
+
+    merged.push(segment);
+  }
+
+  return merged;
+};
+
+const replacement = (
+  before: readonly string[],
+  after: readonly string[],
+): ProvisionDiffSegment[] => [
+  { kind: "removed", text: before.join("") },
+  { kind: "inserted", text: after.join("") },
+];
+
+/**
+ * Word-level difference between two wordings of the same provision, as a flat
+ * run of segments a reader can render in order. Common leading and trailing
+ * tokens are matched before the alignment runs, which is what keeps a
+ * one-word amendment to a long section cheap.
+ */
+export const diffProvisionText = (
+  before: string,
+  after: string,
+): ProvisionDiffSegment[] => {
+  const beforeTokens = tokenize(before);
+  const afterTokens = tokenize(after);
+
+  let prefix = 0;
+
+  while (
+    prefix < beforeTokens.length &&
+    prefix < afterTokens.length &&
+    tokenAt(beforeTokens, prefix) === tokenAt(afterTokens, prefix)
+  ) {
+    prefix += 1;
+  }
+
+  let suffix = 0;
+
+  while (
+    suffix < beforeTokens.length - prefix &&
+    suffix < afterTokens.length - prefix &&
+    tokenAt(beforeTokens, beforeTokens.length - 1 - suffix) ===
+      tokenAt(afterTokens, afterTokens.length - 1 - suffix)
+  ) {
+    suffix += 1;
+  }
+
+  const beforeMiddle = beforeTokens.slice(prefix, beforeTokens.length - suffix);
+  const afterMiddle = afterTokens.slice(prefix, afterTokens.length - suffix);
+  const oversized =
+    beforeMiddle.length > ALIGNMENT_TOKEN_LIMIT ||
+    afterMiddle.length > ALIGNMENT_TOKEN_LIMIT;
+
+  return mergeRuns([
+    { kind: "equal", text: beforeTokens.slice(0, prefix).join("") },
+    ...(oversized
+      ? replacement(beforeMiddle, afterMiddle)
+      : alignTokens(beforeMiddle, afterMiddle)),
+    {
+      kind: "equal",
+      text: beforeTokens.slice(beforeTokens.length - suffix).join(""),
+    },
+  ]);
+};
+
+/**
+ * The versions in which a provision was actually rewritten, from a
+ * newest-first run of its wording per consolidation.
+ *
+ * A consolidation that reissues a provision unchanged is not part of its
+ * history, so it is folded away. The oldest wording in the run is always
+ * kept: it is the earliest wording on record, not a repetition of anything.
+ */
+export const selectChangedVersions = <T extends { text: string }>(
+  versions: readonly T[],
+): T[] =>
+  versions.filter((version, index) => {
+    const older = versions.at(index + 1);
+
+    return older === undefined || older.text !== version.text;
+  });

--- a/apps/web/src/features/statutes/provision-diff.ts
+++ b/apps/web/src/features/statutes/provision-diff.ts
@@ -168,6 +168,12 @@ export const diffProvisionText = (
   ]);
 };
 
+/** One consolidation's wording of a provision, as the history read returns it. */
+type ProvisionVersion = {
+  documentId: string;
+  text: string;
+};
+
 /**
  * The versions in which a provision was actually rewritten, from a
  * newest-first run of its wording per consolidation.
@@ -176,7 +182,7 @@ export const diffProvisionText = (
  * history, so it is folded away. The oldest wording in the run is always
  * kept: it is the earliest wording on record, not a repetition of anything.
  */
-export const selectChangedVersions = <T extends { text: string }>(
+export const selectChangedVersions = <T extends ProvisionVersion>(
   versions: readonly T[],
 ): T[] =>
   versions.filter((version, index) => {
@@ -184,3 +190,54 @@ export const selectChangedVersions = <T extends { text: string }>(
 
     return older === undefined || older.text !== version.text;
   });
+
+type ResolveSelectedVersionOptions<T extends ProvisionVersion> = {
+  /** Every consolidation read so far, newest first, nothing folded away. */
+  consolidations: readonly T[];
+  /** The result of `selectChangedVersions` over them. */
+  changed: readonly T[];
+  selectedId: string | null;
+};
+
+/**
+ * Which entry of the history a selection points at.
+ *
+ * The folded list is not stable across pages: loading older consolidations
+ * can reveal that the selected one merely reissued the wording its
+ * predecessor introduced, at which point folding drops it. Reading the
+ * selection back by position would then silently jump to the newest entry, so
+ * a dropped selection is resolved to the entry that represents its wording:
+ * folding keeps the oldest consolidation of an equal-wording run, which is
+ * the first kept entry at or below the selected one.
+ */
+export const resolveSelectedVersion = <T extends ProvisionVersion>({
+  changed,
+  consolidations,
+  selectedId,
+}: ResolveSelectedVersionOptions<T>): T | undefined => {
+  const newest = changed.at(0);
+
+  if (selectedId === null) {
+    return newest;
+  }
+
+  const kept = new Set(changed.map((version) => version.documentId));
+
+  if (kept.has(selectedId)) {
+    return changed.find((version) => version.documentId === selectedId);
+  }
+
+  const selectedIndex = consolidations.findIndex(
+    (version) => version.documentId === selectedId,
+  );
+
+  if (selectedIndex === -1) {
+    return newest;
+  }
+
+  return (
+    consolidations
+      .slice(selectedIndex)
+      .find((version) => kept.has(version.documentId)) ?? newest
+  );
+};

--- a/apps/web/src/features/statutes/queries/provision-history.ts
+++ b/apps/web/src/features/statutes/queries/provision-history.ts
@@ -1,0 +1,56 @@
+import { infiniteQueryOptions } from "@tanstack/react-query";
+
+import { api } from "@/lib/api";
+import { unwrapEden } from "@/lib/errors/api";
+import { nullableStringCursorSeed } from "@/lib/infinite-query";
+import { assertPublicLawApiData } from "@/lib/public-law-api";
+import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
+import { toSafeId } from "@/lib/safe-id";
+
+/**
+ * A consolidated code carries thousands of provisions, so one provision's
+ * history is read on demand, a few consolidations at a time: each one costs a
+ * document-AST read on the server.
+ */
+const PAGE_SIZE = 5;
+
+export type ProvisionHistoryKey = {
+  anchor: string;
+  documentId: string;
+};
+
+export const provisionHistoryKeys = {
+  all: ["statutes", "provision-history"],
+  byAnchor: (key: ProvisionHistoryKey) => [
+    ...provisionHistoryKeys.all,
+    { anchor: key.anchor, documentId: key.documentId },
+  ],
+};
+
+/** One provision's wording per consolidation of its Work, newest first. */
+export const provisionHistoryOptions = (key: ProvisionHistoryKey) =>
+  infiniteQueryOptions({
+    queryKey: provisionHistoryKeys.byAnchor(key),
+    queryFn: async ({ pageParam, signal }) => {
+      const response = await api.law
+        .statutes({
+          documentId: toSafeId<"legislationDocument">(key.documentId),
+        })
+        .provisions({ anchor: key.anchor })
+        .history.get({
+          query: {
+            limit: PAGE_SIZE,
+            ...(pageParam === null ? {} : { cursor: pageParam }),
+          },
+          fetch: { signal },
+        });
+
+      const data = unwrapEden(response);
+      assertPublicLawApiData(data, "readPublicProvisionHistory");
+
+      return data;
+    },
+    initialPageParam: nullableStringCursorSeed(),
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    staleTime: ROUTE_QUERY_STALE_TIME_MS,
+  });

--- a/apps/web/src/features/statutes/queries/statutes.ts
+++ b/apps/web/src/features/statutes/queries/statutes.ts
@@ -2,7 +2,7 @@ import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { unwrapEden } from "@/lib/errors/api";
+import { toAPIError, unwrapEden } from "@/lib/errors/api";
 import { ClientOperationError } from "@/lib/errors/client";
 import { nullableStringCursorSeed } from "@/lib/infinite-query";
 import { assertPublicLawApiData } from "@/lib/public-law-api";
@@ -10,6 +10,7 @@ import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 
 const DEFAULT_PAGE_SIZE = 50;
+const NOT_FOUND_STATUS = 404;
 const VERSIONS_PAGE_SIZE = 200;
 /**
  * Consolidated versions are read as a whole, because the switcher offers the
@@ -24,6 +25,16 @@ export type StatuteListFilters = {
   query?: string;
 };
 
+/**
+ * A Work plus the date to read it at. The identifier addresses the Work and
+ * the date picks the consolidation, so the trio is the cache identity.
+ */
+export type StatuteAsOfKey = {
+  asOf: string;
+  eli: string;
+  language: string;
+};
+
 export const statuteKeys = {
   all: ["statutes"],
   list: (filters: StatuteListFilters) => [
@@ -36,6 +47,11 @@ export const statuteKeys = {
     },
   ],
   byId: (documentId: string) => [...statuteKeys.all, "detail", documentId],
+  asOf: (key: StatuteAsOfKey) => [
+    ...statuteKeys.all,
+    "asOf",
+    { asOf: key.asOf, eli: key.eli, language: key.language },
+  ],
   versions: (documentId: string) => [
     ...statuteKeys.all,
     "detail",
@@ -69,16 +85,53 @@ export const statutesInfiniteOptions = (filters: StatuteListFilters) =>
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });
 
+const readStatute = async (documentId: string, signal: AbortSignal) => {
+  const response = await api.law
+    .statutes({ documentId: toSafeId<"legislationDocument">(documentId) })
+    .get({ fetch: { signal } });
+
+  const data = unwrapEden(response);
+  assertPublicLawApiData(data, "readPublicStatute");
+
+  return data;
+};
+
+/** One consolidation of a statute, as the public reader sees it. */
+export type PublicStatute = Awaited<ReturnType<typeof readStatute>>;
+
 export const statuteOptions = (documentId: string) =>
   queryOptions({
     queryKey: statuteKeys.byId(documentId),
-    queryFn: async ({ signal }) => {
-      const response = await api.law
-        .statutes({ documentId: toSafeId<"legislationDocument">(documentId) })
-        .get({ fetch: { signal } });
+    queryFn: async ({ signal }) => await readStatute(documentId, signal),
+    staleTime: ROUTE_QUERY_STALE_TIME_MS,
+  });
 
-      const data = unwrapEden(response);
-      assertPublicLawApiData(data, "readPublicStatute");
+/**
+ * The consolidation of a Work that applied on a given date, or null when the
+ * corpus covers no version on it. A date outside the covered range is a real
+ * answer the reader shows, not a failed request.
+ */
+export const statuteAsOfOptions = (key: StatuteAsOfKey) =>
+  queryOptions({
+    queryKey: statuteKeys.asOf(key),
+    queryFn: async ({ signal }) => {
+      const response = await api.law.statutes["by-eli"].get({
+        query: { asOf: key.asOf, eli: key.eli, language: key.language },
+        fetch: { signal },
+      });
+
+      if (response.error) {
+        const error = toAPIError(response.error);
+
+        if (error.status === NOT_FOUND_STATUS) {
+          return null;
+        }
+
+        throw error;
+      }
+
+      const { data } = response;
+      assertPublicLawApiData(data, "readPublicStatuteAsOf");
 
       return data;
     },
@@ -157,6 +210,9 @@ const readStatuteVersionsFrom = async ({
     signal,
   });
 };
+
+/** One entry of a Work's version list. */
+export type PublicStatuteVersion = StatuteVersionsPage["items"][number];
 
 /** Every consolidated version of the work, newest window first. */
 export const statuteVersionsOptions = (documentId: string) =>

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -3263,14 +3263,23 @@
     }
   },
   "statutes": {
+    "asOf": "النص النافذ في",
     "backToList": "جميع التشريعات",
+    "diffInserted": "مُضاف:",
+    "diffRemoved": "محذوف:",
     "emptyDocument": "لا يتوفر نص لهذه النسخة.",
     "emptyState": "لم يُعثر على تشريعات.",
     "inForceSince": "نافذ منذ {date}",
+    "noVersionInForce": "لم تكن أي نسخة من هذا النص نافذة في التاريخ المحدد.",
     "openEnded": "الآن",
     "outline": "المحتويات",
     "outlineJumpLabel": "الانتقال إلى حكم",
     "outlineJumpPlaceholder": "§ 10 أو عنوان",
+    "provisionHistoryEarliest": "أقدم صيغة متاحة.",
+    "provisionHistoryEmpty": "لا توجد أي صيغة مسجَّلة لهذه المادة.",
+    "provisionHistoryFor": "سجل التعديلات: {provision}",
+    "provisionHistoryLoadOlder": "حمّل صيغًا أقدم للمقارنة.",
+    "provisionHistoryUnavailable": "تعذّر تحميل سجل هذه المادة.",
     "searchLabel": "البحث في التشريعات",
     "searchPlaceholder": "ابحث بالعنوان أو الرقم...",
     "status": {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -3263,14 +3263,23 @@
     }
   },
   "statutes": {
+    "asOf": "Znění účinné k",
     "backToList": "Všechny předpisy",
+    "diffInserted": "Vloženo:",
+    "diffRemoved": "Vypuštěno:",
     "emptyDocument": "Toto znění nemá dostupný text.",
     "emptyState": "Nenalezeny žádné předpisy.",
     "inForceSince": "Účinné od {date}",
+    "noVersionInForce": "K vybranému dni nebylo účinné žádné znění tohoto předpisu.",
     "openEnded": "současnost",
     "outline": "Obsah",
     "outlineJumpLabel": "Přejít na ustanovení",
     "outlineJumpPlaceholder": "§ 10 nebo název",
+    "provisionHistoryEarliest": "Nejstarší dochované znění.",
+    "provisionHistoryEmpty": "K tomuto ustanovení není dochováno žádné znění.",
+    "provisionHistoryFor": "Historie změn: {provision}",
+    "provisionHistoryLoadOlder": "Načtěte starší znění a porovnejte je.",
+    "provisionHistoryUnavailable": "Historii tohoto ustanovení se nepodařilo načíst.",
     "searchLabel": "Hledat v právních předpisech",
     "searchPlaceholder": "Hledat podle názvu nebo čísla...",
     "status": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -3263,14 +3263,23 @@
     }
   },
   "statutes": {
+    "asOf": "Fassung gültig am",
     "backToList": "Alle Rechtsvorschriften",
+    "diffInserted": "Eingefügt:",
+    "diffRemoved": "Gestrichen:",
     "emptyDocument": "Für diese Fassung ist kein Text verfügbar.",
     "emptyState": "Keine Rechtsvorschriften gefunden.",
     "inForceSince": "In Kraft seit {date}",
+    "noVersionInForce": "Am gewählten Tag galt keine Fassung dieses Gesetzes.",
     "openEnded": "heute",
     "outline": "Inhalt",
     "outlineJumpLabel": "Zu einer Vorschrift springen",
     "outlineJumpPlaceholder": "§ 10 oder Überschrift",
+    "provisionHistoryEarliest": "Älteste überlieferte Fassung.",
+    "provisionHistoryEmpty": "Zu dieser Vorschrift liegt keine Fassung vor.",
+    "provisionHistoryFor": "Änderungsverlauf: {provision}",
+    "provisionHistoryLoadOlder": "Ältere Fassungen laden und vergleichen.",
+    "provisionHistoryUnavailable": "Der Verlauf dieser Vorschrift konnte nicht geladen werden.",
     "searchLabel": "Rechtsvorschriften durchsuchen",
     "searchPlaceholder": "Nach Titel oder Nummer suchen...",
     "status": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -3263,14 +3263,23 @@
     }
   },
   "statutes": {
+    "asOf": "Text in force on",
     "backToList": "All statutes",
+    "diffInserted": "Inserted:",
+    "diffRemoved": "Deleted:",
     "emptyDocument": "This version has no text available.",
     "emptyState": "No statutes found.",
     "inForceSince": "In force since {date}",
+    "noVersionInForce": "No version of this act was in force on the selected date.",
     "openEnded": "present",
     "outline": "Contents",
     "outlineJumpLabel": "Jump to a provision",
     "outlineJumpPlaceholder": "§ 10 or a heading",
+    "provisionHistoryEarliest": "Earliest wording on record.",
+    "provisionHistoryEmpty": "No wording of this provision is on record.",
+    "provisionHistoryFor": "Change history: {provision}",
+    "provisionHistoryLoadOlder": "Load older versions to compare wordings.",
+    "provisionHistoryUnavailable": "This provision's history could not be loaded.",
     "searchLabel": "Search statutes",
     "searchPlaceholder": "Search by title or number...",
     "status": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -3263,14 +3263,23 @@
     }
   },
   "statutes": {
+    "asOf": "Texto vigente el",
     "backToList": "Todas las normas",
+    "diffInserted": "Añadido:",
+    "diffRemoved": "Suprimido:",
     "emptyDocument": "Esta versión no tiene texto disponible.",
     "emptyState": "No se han encontrado normas.",
     "inForceSince": "En vigor desde el {date}",
+    "noVersionInForce": "Ninguna versión de esta norma estaba vigente en la fecha elegida.",
     "openEnded": "actualidad",
     "outline": "Índice",
     "outlineJumpLabel": "Ir a una disposición",
     "outlineJumpPlaceholder": "§ 10 o un título",
+    "provisionHistoryEarliest": "Versión más antigua disponible.",
+    "provisionHistoryEmpty": "No consta ninguna versión de este precepto.",
+    "provisionHistoryFor": "Historial de cambios: {provision}",
+    "provisionHistoryLoadOlder": "Cargue versiones anteriores para compararlas.",
+    "provisionHistoryUnavailable": "No se ha podido cargar el historial de este precepto.",
     "searchLabel": "Buscar en la legislación",
     "searchPlaceholder": "Buscar por título o número...",
     "status": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -3263,14 +3263,23 @@
     }
   },
   "statutes": {
+    "asOf": "Kehtinud tekst kuupäeval",
     "backToList": "Kõik õigusaktid",
+    "diffInserted": "Lisatud:",
+    "diffRemoved": "Välja jäetud:",
     "emptyDocument": "Sellel redaktsioonil puudub tekst.",
     "emptyState": "Õigusakte ei leitud.",
     "inForceSince": "Kehtib alates {date}",
+    "noVersionInForce": "Valitud kuupäeval ei kehtinud ükski selle õigusakti redaktsioon.",
     "openEnded": "praeguseni",
     "outline": "Sisukord",
     "outlineJumpLabel": "Liigu sättele",
     "outlineJumpPlaceholder": "§ 10 või pealkiri",
+    "provisionHistoryEarliest": "Varaseim teadaolev redaktsioon.",
+    "provisionHistoryEmpty": "Selle sätte kohta ei ole ühtegi redaktsiooni.",
+    "provisionHistoryFor": "Muudatuste ajalugu: {provision}",
+    "provisionHistoryLoadOlder": "Laadi vanemad redaktsioonid võrdlemiseks.",
+    "provisionHistoryUnavailable": "Selle sätte ajalugu ei õnnestunud laadida.",
     "searchLabel": "Otsi õigusaktidest",
     "searchPlaceholder": "Otsi pealkirja või numbri järgi...",
     "status": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -3263,14 +3263,23 @@
     }
   },
   "statutes": {
+    "asOf": "Version en vigueur au",
     "backToList": "Tous les textes",
+    "diffInserted": "Ajouté :",
+    "diffRemoved": "Supprimé :",
     "emptyDocument": "Aucun texte disponible pour cette version.",
     "emptyState": "Aucun texte trouvé.",
     "inForceSince": "En vigueur depuis le {date}",
+    "noVersionInForce": "Aucune version de ce texte n'était en vigueur à la date choisie.",
     "openEnded": "aujourd’hui",
     "outline": "Sommaire",
     "outlineJumpLabel": "Aller à une disposition",
     "outlineJumpPlaceholder": "§ 10 ou un intitulé",
+    "provisionHistoryEarliest": "Version la plus ancienne disponible.",
+    "provisionHistoryEmpty": "Aucune version de cette disposition n'est disponible.",
+    "provisionHistoryFor": "Historique des modifications : {provision}",
+    "provisionHistoryLoadOlder": "Charger des versions antérieures pour les comparer.",
+    "provisionHistoryUnavailable": "Impossible de charger l'historique de cette disposition.",
     "searchLabel": "Rechercher dans la législation",
     "searchPlaceholder": "Rechercher par titre ou numéro...",
     "status": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -3263,14 +3263,23 @@
     }
   },
   "statutes": {
+    "asOf": "Ezen a napon hatályos szöveg",
     "backToList": "Összes jogszabály",
+    "diffInserted": "Beszúrva:",
+    "diffRemoved": "Törölve:",
     "emptyDocument": "Ehhez a változathoz nem érhető el szöveg.",
     "emptyState": "Nem található jogszabály.",
     "inForceSince": "Hatályos {date} óta",
+    "noVersionInForce": "A kiválasztott napon a jogszabály egyetlen változata sem volt hatályban.",
     "openEnded": "jelenleg is",
     "outline": "Tartalom",
     "outlineJumpLabel": "Ugrás rendelkezéshez",
     "outlineJumpPlaceholder": "§ 10 vagy cím",
+    "provisionHistoryEarliest": "A legkorábbi ismert szövegváltozat.",
+    "provisionHistoryEmpty": "Ehhez a rendelkezéshez nincs nyilvántartott szövegváltozat.",
+    "provisionHistoryFor": "Módosítások története: {provision}",
+    "provisionHistoryLoadOlder": "Töltsön be korábbi változatokat az összehasonlításhoz.",
+    "provisionHistoryUnavailable": "A rendelkezés története nem tölthető be.",
     "searchLabel": "Keresés a jogszabályok között",
     "searchPlaceholder": "Keresés cím vagy szám alapján...",
     "status": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -3263,14 +3263,23 @@
     }
   },
   "statutes": {
+    "asOf": "Tekstas, galiojęs",
     "backToList": "Visi teisės aktai",
+    "diffInserted": "Įterpta:",
+    "diffRemoved": "Išbraukta:",
     "emptyDocument": "Ši redakcija neturi teksto.",
     "emptyState": "Teisės aktų nerasta.",
     "inForceSince": "Galioja nuo {date}",
+    "noVersionInForce": "Pasirinktą dieną negaliojo nė viena šio akto redakcija.",
     "openEnded": "dabar",
     "outline": "Turinys",
     "outlineJumpLabel": "Pereiti prie nuostatos",
     "outlineJumpPlaceholder": "§ 10 arba pavadinimas",
+    "provisionHistoryEarliest": "Seniausia žinoma redakcija.",
+    "provisionHistoryEmpty": "Šios nuostatos redakcijų nėra.",
+    "provisionHistoryFor": "Pakeitimų istorija: {provision}",
+    "provisionHistoryLoadOlder": "Įkelkite senesnes redakcijas palyginimui.",
+    "provisionHistoryUnavailable": "Nepavyko įkelti šios nuostatos istorijos.",
     "searchLabel": "Ieškoti teisės aktų",
     "searchPlaceholder": "Ieškoti pagal pavadinimą arba numerį...",
     "status": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -3263,14 +3263,23 @@
     }
   },
   "statutes": {
+    "asOf": "Teksts, kas bija spēkā",
     "backToList": "Visi tiesību akti",
+    "diffInserted": "Pievienots:",
+    "diffRemoved": "Svītrots:",
     "emptyDocument": "Šai redakcijai nav pieejams teksts.",
     "emptyState": "Tiesību akti nav atrasti.",
     "inForceSince": "Spēkā no {date}",
+    "noVersionInForce": "Izvēlētajā dienā neviena šā akta redakcija nebija spēkā.",
     "openEnded": "šobrīd",
     "outline": "Saturs",
     "outlineJumpLabel": "Pāriet uz normu",
     "outlineJumpPlaceholder": "§ 10 vai virsraksts",
+    "provisionHistoryEarliest": "Senākā zināmā redakcija.",
+    "provisionHistoryEmpty": "Šai normai nav nevienas redakcijas.",
+    "provisionHistoryFor": "Grozījumu vēsture: {provision}",
+    "provisionHistoryLoadOlder": "Ielādējiet vecākas redakcijas, lai tās salīdzinātu.",
+    "provisionHistoryUnavailable": "Neizdevās ielādēt šīs normas vēsturi.",
     "searchLabel": "Meklēt tiesību aktos",
     "searchPlaceholder": "Meklēt pēc nosaukuma vai numura...",
     "status": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -3266,14 +3266,23 @@ type Messages = {
     };
   };
   "statutes": {
+    "asOf": "Text in force on";
     "backToList": "All statutes";
+    "diffInserted": "Inserted:";
+    "diffRemoved": "Deleted:";
     "emptyDocument": "This version has no text available.";
     "emptyState": "No statutes found.";
     "inForceSince": "In force since {date}";
+    "noVersionInForce": "No version of this act was in force on the selected date.";
     "openEnded": "present";
     "outline": "Contents";
     "outlineJumpLabel": "Jump to a provision";
     "outlineJumpPlaceholder": "§ 10 or a heading";
+    "provisionHistoryEarliest": "Earliest wording on record.";
+    "provisionHistoryEmpty": "No wording of this provision is on record.";
+    "provisionHistoryFor": "Change history: {provision}";
+    "provisionHistoryLoadOlder": "Load older versions to compare wordings.";
+    "provisionHistoryUnavailable": "This provision's history could not be loaded.";
     "searchLabel": "Search statutes";
     "searchPlaceholder": "Search by title or number...";
     "status": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -3263,14 +3263,23 @@
     }
   },
   "statutes": {
+    "asOf": "Tekst obowiązujący na dzień",
     "backToList": "Wszystkie akty prawne",
+    "diffInserted": "Dodano:",
+    "diffRemoved": "Usunięto:",
     "emptyDocument": "Ta wersja nie ma dostępnego tekstu.",
     "emptyState": "Nie znaleziono aktów prawnych.",
     "inForceSince": "Obowiązuje od {date}",
+    "noVersionInForce": "W wybranym dniu nie obowiązywała żadna wersja tego aktu.",
     "openEnded": "nadal",
     "outline": "Spis treści",
     "outlineJumpLabel": "Przejdź do przepisu",
     "outlineJumpPlaceholder": "§ 10 lub tytuł",
+    "provisionHistoryEarliest": "Najstarsza dostępna wersja.",
+    "provisionHistoryEmpty": "Brak zapisanych wersji tego przepisu.",
+    "provisionHistoryFor": "Historia zmian: {provision}",
+    "provisionHistoryLoadOlder": "Wczytaj starsze wersje, aby je porównać.",
+    "provisionHistoryUnavailable": "Nie udało się wczytać historii tego przepisu.",
     "searchLabel": "Szukaj w aktach prawnych",
     "searchPlaceholder": "Szukaj według tytułu lub numeru...",
     "status": {

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -3263,14 +3263,23 @@
     }
   },
   "statutes": {
+    "asOf": "Texto em vigor em",
     "backToList": "Todas as normas",
+    "diffInserted": "Inserido:",
+    "diffRemoved": "Suprimido:",
     "emptyDocument": "Esta versão não tem texto disponível.",
     "emptyState": "Nenhuma norma encontrada.",
     "inForceSince": "Em vigor desde {date}",
+    "noVersionInForce": "Nenhuma versão desta norma estava em vigor na data escolhida.",
     "openEnded": "hoje",
     "outline": "Sumário",
     "outlineJumpLabel": "Ir para um dispositivo",
     "outlineJumpPlaceholder": "§ 10 ou um título",
+    "provisionHistoryEarliest": "Versão mais antiga disponível.",
+    "provisionHistoryEmpty": "Não há nenhuma versão deste dispositivo.",
+    "provisionHistoryFor": "Histórico de alterações: {provision}",
+    "provisionHistoryLoadOlder": "Carregue versões anteriores para comparar.",
+    "provisionHistoryUnavailable": "Não foi possível carregar o histórico deste dispositivo.",
     "searchLabel": "Buscar na legislação",
     "searchPlaceholder": "Buscar por título ou número...",
     "status": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -3263,14 +3263,23 @@
     }
   },
   "statutes": {
+    "asOf": "Znenie účinné k",
     "backToList": "Všetky predpisy",
+    "diffInserted": "Vložené:",
+    "diffRemoved": "Vypustené:",
     "emptyDocument": "Toto znenie nemá dostupný text.",
     "emptyState": "Nenašli sa žiadne predpisy.",
     "inForceSince": "Účinné od {date}",
+    "noVersionInForce": "K vybranému dňu nebolo účinné žiadne znenie tohto predpisu.",
     "openEnded": "súčasnosť",
     "outline": "Obsah",
     "outlineJumpLabel": "Prejsť na ustanovenie",
     "outlineJumpPlaceholder": "§ 10 alebo názov",
+    "provisionHistoryEarliest": "Najstaršie zachované znenie.",
+    "provisionHistoryEmpty": "K tomuto ustanoveniu nie je zachované žiadne znenie.",
+    "provisionHistoryFor": "História zmien: {provision}",
+    "provisionHistoryLoadOlder": "Načítajte staršie znenia a porovnajte ich.",
+    "provisionHistoryUnavailable": "Históriu tohto ustanovenia sa nepodarilo načítať.",
     "searchLabel": "Hľadať v právnych predpisoch",
     "searchPlaceholder": "Hľadať podľa názvu alebo čísla...",
     "status": {

--- a/apps/web/src/lib/track-changes-style.ts
+++ b/apps/web/src/lib/track-changes-style.ts
@@ -1,0 +1,30 @@
+import type { CSSProperties } from "react";
+
+// Track-changes styling, matched to folio's suggestion preview
+// (.folio-ai-suggestion--focused-original/-replacement): deletions read as
+// dimmed muted strikethrough with a faint destructive tint, insertions as a
+// low-saturation success wash with an inset ring. color-mix over semantic
+// tokens keeps both theme-aware without importing folio's stylesheet.
+//
+// One definition for the whole product: every surface that shows a text
+// difference (document versions, statute provisions) has to read as the same
+// visual language, and a second copy would drift from this one silently.
+
+export const TRACKED_DELETION_STYLE: CSSProperties = {
+  color: "color-mix(in oklch, var(--destructive) 35%, var(--muted-foreground))",
+  textDecorationLine: "line-through",
+  textDecorationThickness: "1px",
+  textDecorationColor:
+    "color-mix(in oklch, var(--destructive) 30%, var(--muted-foreground))",
+};
+
+export const TRACKED_INSERTION_STYLE: CSSProperties = {
+  borderRadius: "3px",
+  padding: "0 2px",
+  backgroundColor: "color-mix(in oklch, var(--success) 14%, transparent)",
+  boxShadow:
+    "inset 0 0 0 1px color-mix(in oklch, var(--success) 28%, transparent)",
+  textDecorationLine: "none",
+  boxDecorationBreak: "clone",
+  WebkitBoxDecorationBreak: "clone",
+};

--- a/apps/web/src/routes/law/$country/statutes/$documentId.tsx
+++ b/apps/web/src/routes/law/$country/statutes/$documentId.tsx
@@ -369,7 +369,10 @@ const StatuteReader = ({
                 onVersionChange={handleVersionChange}
                 versions={versions}
               />
-              {versions.length > 1 && (
+              {/* Reachable whenever a date is set, or a single-version act
+                  opened with one would strand the reader on an empty text
+                  with no way to clear it. */}
+              {(versions.length > 1 || asOf !== undefined) && (
                 <div className="flex items-center gap-2">
                   <span
                     className="text-muted-foreground text-xs"

--- a/apps/web/src/routes/law/$country/statutes/$documentId.tsx
+++ b/apps/web/src/routes/law/$country/statutes/$documentId.tsx
@@ -1,12 +1,14 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
+import * as v from "valibot";
 
 import { parseDocumentAst } from "@stll/legal-ast/document-ast";
 import { OutlineRail } from "@stll/ui/components/outline-rail";
 
+import { DatePickerPopover } from "@/components/date-picker-popover";
 import { OutlineJumpField } from "@/components/legal-reader/outline-jump-field";
 import {
   filterOutlineItems,
@@ -22,8 +24,13 @@ import { StatuteStatusPill } from "@/features/statutes/components/statute-status
 import { StatuteText } from "@/features/statutes/components/statute-text";
 import { StatuteVersionSwitcher } from "@/features/statutes/components/statute-version-switcher";
 import {
+  statuteAsOfOptions,
   statuteOptions,
   statuteVersionsOptions,
+} from "@/features/statutes/queries/statutes";
+import type {
+  PublicStatute,
+  PublicStatuteVersion,
 } from "@/features/statutes/queries/statutes";
 import {
   EM_DASH,
@@ -44,27 +51,74 @@ import {
   toStatuteCountrySegment,
 } from "@/lib/statute-route";
 
-export const Route = createFileRoute("/law/$country/statutes/$documentId")({
-  loader: async ({ context: { queryClient }, params }) => {
-    // Both reads start here so the version list never waits on the document.
-    const [statute] = await Promise.all([
-      ensureRouteQueryData(queryClient, statuteOptions(params.documentId)),
-      ensureRouteQueryData(
-        queryClient,
-        statuteVersionsOptions(params.documentId),
-      ),
-    ]);
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
 
-    return statute;
+/**
+ * A calendar day, not merely a date-shaped string: `2026-02-30` matches the
+ * pattern and is not a day, and the reader must not ask the corpus for it.
+ */
+const isCalendarDate = (value: string): boolean =>
+  ISO_DATE_PATTERN.test(value) &&
+  new Date(`${value}T00:00:00Z`).toISOString().startsWith(value);
+
+/**
+ * `asOf` names the day whose law the reader wants. Anything else is dropped
+ * rather than rejected: a mistyped link should still open the act.
+ */
+const searchSchema = v.object({
+  asOf: v.optional(
+    v.pipe(
+      v.string(),
+      v.trim(),
+      v.transform((value) => (isCalendarDate(value) ? value : undefined)),
+    ),
+  ),
+});
+
+export const Route = createFileRoute("/law/$country/statutes/$documentId")({
+  validateSearch: searchSchema,
+  loaderDeps: ({ search: { asOf } }) => ({ asOf }),
+  loader: async ({ context: { queryClient }, deps: { asOf }, params }) => {
+    // The version list is needed either way, and it carries the work key the
+    // point-in-time read is addressed by.
+    const versions = ensureRouteQueryData(
+      queryClient,
+      statuteVersionsOptions(params.documentId),
+    );
+
+    if (asOf === undefined) {
+      const [statute] = await Promise.all([
+        ensureRouteQueryData(queryClient, statuteOptions(params.documentId)),
+        versions,
+      ]);
+
+      return statute;
+    }
+
+    const work = (await versions).at(0);
+
+    // One document read either way: with a date it is the point-in-time read
+    // that runs, not an extra one.
+    return work === undefined
+      ? await ensureRouteQueryData(
+          queryClient,
+          statuteOptions(params.documentId),
+        )
+      : await ensureRouteQueryData(
+          queryClient,
+          statuteAsOfOptions({ asOf, eli: work.eli, language: work.language }),
+        );
   },
-  head: ({ loaderData, params }) => {
+  head: ({ loaderData }) => {
     if (!loaderData) {
       return { meta: [] };
     }
 
+    // The canonical URL names the consolidation on screen, which a dated
+    // request need not be the one the path was entered with.
     const path = createStatutePath({
       country: loaderData.country,
-      documentId: params.documentId,
+      documentId: loaderData.id,
     });
     const canonicalUrl = createPublicLawCanonicalUrl(path);
 
@@ -89,37 +143,144 @@ export const Route = createFileRoute("/law/$country/statutes/$documentId")({
 });
 
 function PublicStatuteRoute() {
-  const t = useTranslations();
-  const format = useFormatter();
   const documentId = Route.useParams({ select: (params) => params.documentId });
-  const navigate = Route.useNavigate();
-
-  const { data: statute } = useSuspenseQuery(statuteOptions(documentId));
+  const asOf = Route.useSearch({ select: (search) => search.asOf });
   const { data: versions } = useSuspenseQuery(
     statuteVersionsOptions(documentId),
+  );
+  const work = versions.at(0);
+
+  if (asOf === undefined || work === undefined) {
+    return <StatuteAtVersion documentId={documentId} versions={versions} />;
+  }
+
+  return (
+    <StatuteAtDate
+      asOf={asOf}
+      documentId={documentId}
+      eli={work.eli}
+      language={work.language}
+      work={work}
+      versions={versions}
+    />
+  );
+}
+
+type StatuteAtVersionProps = {
+  documentId: string;
+  versions: readonly PublicStatuteVersion[];
+};
+
+/** The consolidation the path names. */
+const StatuteAtVersion = ({ documentId, versions }: StatuteAtVersionProps) => {
+  const { data: statute } = useSuspenseQuery(statuteOptions(documentId));
+
+  return (
+    <StatuteReader
+      documentId={documentId}
+      statute={statute}
+      versions={versions}
+      work={statute}
+    />
+  );
+};
+
+type StatuteAtDateProps = StatuteAtVersionProps & {
+  asOf: string;
+  eli: string;
+  language: string;
+  work: PublicStatuteVersion;
+};
+
+/** The consolidation that applied on the requested day. */
+const StatuteAtDate = ({
+  asOf,
+  documentId,
+  eli,
+  language,
+  versions,
+  work,
+}: StatuteAtDateProps) => {
+  const { data: statute } = useSuspenseQuery(
+    statuteAsOfOptions({ asOf, eli, language }),
+  );
+
+  return (
+    <StatuteReader
+      documentId={documentId}
+      statute={statute}
+      versions={versions}
+      work={work}
+    />
+  );
+};
+
+type StatuteReaderProps = {
+  documentId: string;
+  /** Null when no consolidation of the Work covers the requested day. */
+  statute: PublicStatute | null;
+  versions: readonly PublicStatuteVersion[];
+  /**
+   * What the Work is known by. It carries the chrome (title, identifier,
+   * jurisdiction) while no text is resolved, and is the consolidation itself
+   * whenever one is.
+   */
+  work: PublicStatute | PublicStatuteVersion;
+};
+
+const StatuteReader = ({
+  documentId,
+  statute,
+  versions,
+  work,
+}: StatuteReaderProps) => {
+  const t = useTranslations();
+  const format = useFormatter();
+  const navigate = Route.useNavigate();
+  const asOfLabelId = useId();
+  const asOf = Route.useSearch({ select: (search) => search.asOf });
+  const readerRef = useRef<HTMLDivElement>(null);
+
+  const header = statute ?? work;
+
+  const goTo = useCallback(
+    (nextDocumentId: string, nextAsOf: string | undefined) => {
+      detached(
+        navigate({
+          params: {
+            country: toStatuteCountrySegment(header.country),
+            documentId: nextDocumentId,
+          },
+          search: nextAsOf === undefined ? {} : { asOf: nextAsOf },
+          to: "/law/$country/statutes/$documentId",
+        }),
+        "statutes.reader-navigate",
+      );
+    },
+    [header.country, navigate],
   );
 
   const handleVersionChange = useCallback(
     (nextDocumentId: string) => {
-      detached(
-        navigate({
-          params: {
-            country: toStatuteCountrySegment(statute.country),
-            documentId: nextDocumentId,
-          },
-          to: "/law/$country/statutes/$documentId",
-        }),
-        "statutes.version-change",
-      );
+      const next = versions.find((version) => version.id === nextDocumentId);
+
+      // Picking a version is also picking a day: its window opening.
+      goTo(nextDocumentId, next?.versionValidFrom ?? undefined);
     },
-    [navigate, statute.country],
+    [goTo, versions],
   );
 
-  const readerRef = useRef<HTMLDivElement>(null);
+  const handleAsOfChange = useCallback(
+    (value: string | null) => {
+      goTo(documentId, value === null || value === "" ? undefined : value);
+    },
+    [documentId, goTo],
+  );
+
   const [jumpValue, setJumpValue] = useState("");
   // An unparseable or absent AST is a real state: the reader then renders
   // the plain fulltext instead of blocks.
-  const ast = parseDocumentAst(statute.documentAst);
+  const ast = statute ? parseDocumentAst(statute.documentAst) : null;
   const blocks = ast ? ast.blocks : [];
   const outline = withProvisionRanges(outlineFromHeadings(blocks));
   const jump = parseOutlineJump(jumpValue);
@@ -128,14 +289,19 @@ function PublicStatuteRoute() {
 
   // The keys a provision's incoming citations are filed under. Both come off
   // the document itself: nothing about the work is inferred here.
-  const eli = statute.eli.trim();
-  const jurisdiction = statute.country.trim().toUpperCase();
+  const eli = statute?.eli.trim() ?? "";
+  const jurisdiction = statute?.country.trim().toUpperCase() ?? "";
   const citationWork =
     eli === "" || jurisdiction === "" ? null : { eli, jurisdiction };
 
-  const validFrom = formatValidityDate(statute.versionValidFrom, format);
-  const validTo = formatValidityDate(statute.versionValidTo, format);
-  const sourceHref = statute.documentUrl ?? statute.sourceUrl;
+  const validFrom = formatValidityDate(
+    statute?.versionValidFrom ?? null,
+    format,
+  );
+  const validTo = formatValidityDate(statute?.versionValidTo ?? null, format);
+  const sourceHref = statute
+    ? (statute.documentUrl ?? statute.sourceUrl)
+    : null;
 
   return (
     <main className="relative min-h-0 flex-1">
@@ -172,16 +338,20 @@ function PublicStatuteRoute() {
       <div className="reader-scroll h-full overflow-y-auto" ref={readerRef}>
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-4 py-6">
           <header className="flex flex-col gap-3 border-b pb-4">
-            <h1 className="text-xl font-semibold">{statute.title}</h1>
+            <h1 className="text-xl font-semibold">{header.title}</h1>
             <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-2 text-xs">
-              <span>{statute.eli}</span>
-              <StatuteStatusPill status={statute.status} />
-              <span>
-                {t("statutes.validity", {
-                  from: validFrom ?? EM_DASH,
-                  to: validTo ?? t("statutes.openEnded"),
-                })}
-              </span>
+              <span>{header.eli}</span>
+              {statute !== null && (
+                <StatuteStatusPill status={statute.status} />
+              )}
+              {statute !== null && (
+                <span>
+                  {t("statutes.validity", {
+                    from: validFrom ?? EM_DASH,
+                    to: validTo ?? t("statutes.openEnded"),
+                  })}
+                </span>
+              )}
               {sanitizeHref(sourceHref) !== undefined && (
                 <a
                   className="underline underline-offset-2"
@@ -193,28 +363,54 @@ function PublicStatuteRoute() {
                 </a>
               )}
             </div>
-            <StatuteVersionSwitcher
-              currentVersionId={statute.id}
-              onVersionChange={handleVersionChange}
-              versions={versions}
-            />
+            <div className="flex flex-wrap items-center gap-2">
+              <StatuteVersionSwitcher
+                currentVersionId={statute?.id ?? ""}
+                onVersionChange={handleVersionChange}
+                versions={versions}
+              />
+              {versions.length > 1 && (
+                <div className="flex items-center gap-2">
+                  <span
+                    className="text-muted-foreground text-xs"
+                    id={asOfLabelId}
+                  >
+                    {t("statutes.asOf")}
+                  </span>
+                  <DatePickerPopover
+                    labelledBy={asOfLabelId}
+                    onChange={handleAsOfChange}
+                    placeholderLabel={t("statutes.asOfToday")}
+                    value={asOf ?? null}
+                  />
+                </div>
+              )}
+            </div>
             <Link
               className="text-muted-foreground hover:text-foreground w-fit text-xs underline underline-offset-2"
-              params={{ country: toStatuteCountrySegment(statute.country) }}
+              params={{ country: toStatuteCountrySegment(header.country) }}
               to="/law/$country/statutes"
             >
               {t("statutes.backToList")}
             </Link>
           </header>
 
-          <StatuteText
-            blocks={blocks}
-            citationWork={citationWork}
-            fulltext={statute.fulltext}
-            language={statute.language}
-          />
+          {statute === null ? (
+            <p className="text-muted-foreground py-16 text-center text-sm">
+              {t("statutes.noVersionInForce")}
+            </p>
+          ) : (
+            <StatuteText
+              blocks={blocks}
+              citationWork={citationWork}
+              documentId={statute.id}
+              fulltext={statute.fulltext}
+              language={statute.language}
+              versionCount={versions.length}
+            />
+          )}
         </div>
       </div>
     </main>
   );
-}
+};

--- a/apps/web/src/routes/law/$country/statutes/$documentId.tsx
+++ b/apps/web/src/routes/law/$country/statutes/$documentId.tsx
@@ -380,7 +380,7 @@ const StatuteReader = ({
                   <DatePickerPopover
                     labelledBy={asOfLabelId}
                     onChange={handleAsOfChange}
-                    placeholderLabel={t("statutes.asOfToday")}
+                    placeholderLabel={t("common.today")}
                     value={asOf ?? null}
                   />
                 </div>

--- a/apps/web/src/routes/tools/-components/public-tools-shell.tsx
+++ b/apps/web/src/routes/tools/-components/public-tools-shell.tsx
@@ -18,6 +18,7 @@ function PublicToolsTopBar() {
       const loaderData = state.matches.at(-1)?.loaderData;
       if (
         typeof loaderData === "object" &&
+        loaderData !== null &&
         "displayName" in loaderData &&
         typeof loaderData.displayName === "string"
       ) {


### PR DESCRIPTION
Reading a statute at a date, and comparing one provision across the versions of its act.

**API**

- `GET /v1/law/statutes/by-eli?eli=&language=&asOf=` returns the version whose validity window covers `asOf`, the one in force today when the date is omitted, and 404 with a distinct message when the corpus covers the act but not that day.
- `GET /v1/law/statutes/:documentId/provisions/:anchor/history` returns one provision's text per version of the same act, extracted server-side from each version's parsed structure, cursor-paged.
- The validity predicate and the work key move to shared modules the listing and the versions read now use, so the reads cannot disagree about a window boundary.
- Forward migration adds the access path the point-in-time seek needs, built concurrently.

**Web**

- The reader takes an `asOf` search param (calendar date, invalid values dropped), resolved through the new read in the route loader. One document read either way. The version switcher and the date control stay in step: picking a version sets the date to its window opening.
- Each provision offers its drafting history: the versions in which its wording changed, newest first, with a word-level diff against the previous one. Dependency-free LCS alignment with common-affix trimming and a size cap; `ins`/`del` with screen-reader labels.
- Track-changes colours move to one shared definition so the document-version and statute surfaces stay one visual language.

Tests: unit for the diff and the provision extraction, DB tests for both reads (window interior, exclusive closing boundary, uncovered date, unknown identifier, redistribution, cursor walk), route-contract tests for the new validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added legislation lookup by ELI, language and effective date.
  - Added date-based statute viewing, including clear messaging when no version was in force.
  - Added provision history with pagination and selectable versions.
  - Added word-level highlighting for inserted and removed statutory text.

- **Bug Fixes**
  - Improved version selection and ordering across consolidated legislation.

- **Accessibility & Localisation**
  - Added translated labels and messages for version comparisons and provision history across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->