### PR TITLE
fix(api): Polish authority registries and cues

### DIFF
--- a/apps/api/src/handlers/case-law/citation-kind.test.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.test.ts
@@ -267,3 +267,237 @@ describe("proceduralKeysFromMetadata", () => {
     ).toBe(0);
   });
 });
+
+/**
+ * Polish, where the registry prior used to be wrong for a whole court tier.
+ *
+ * Every test here asserts the evidence tier as well as the kind, which is
+ * what makes one cue per test mean something: `CONTEXT` is only returned
+ * when exactly one of the two cue lists matched, so a sentence that
+ * accidentally carried a second cue would report `REGISTRY` and fail rather
+ * than pass for the wrong reason. The cue tests all cite an unlisted
+ * register (`I C`, a district civil number) or a listed one (`II CSK`), so
+ * removing the cue under test flips the answer to the registry's default.
+ */
+describe("Polish cues and registries", () => {
+  /** Falls back to procedural: the district registers are not authority. */
+  const DISTRICT = "sygn. akt I C 1234/19";
+  /** Falls back to precedent: the Supreme Court's civil cassation register. */
+  const SUPREME = "sygn. akt II CSK 123/20";
+
+  const contextVerdict = (citationText: string, context: string) =>
+    classifyCitationVerdict({ citationText, context });
+
+  test("por. points at an authority", () => {
+    expect(
+      contextVerdict(
+        DISTRICT,
+        "Por. stanowisko Sądu Najwyższego przyjęte w sprawie sygn. akt I C 1234/19.",
+      ),
+    ).toEqual({
+      kind: CITATION_KIND.PRECEDENT,
+      evidence: CITATION_KIND_EVIDENCE.CONTEXT,
+    });
+  });
+
+  test("zob. points at an authority", () => {
+    expect(
+      contextVerdict(
+        DISTRICT,
+        "Zob. stanowisko Sądu Najwyższego przyjęte w sprawie sygn. akt I C 1234/19.",
+      ),
+    ).toEqual({
+      kind: CITATION_KIND.PRECEDENT,
+      evidence: CITATION_KIND_EVIDENCE.CONTEXT,
+    });
+  });
+
+  test("tak też marks agreement with a cited holding", () => {
+    expect(
+      contextVerdict(
+        DISTRICT,
+        "Tak też Sąd Najwyższy w sprawie sygn. akt I C 1234/19.",
+      ),
+    ).toEqual({
+      kind: CITATION_KIND.PRECEDENT,
+      evidence: CITATION_KIND_EVIDENCE.CONTEXT,
+    });
+  });
+
+  test("podobnie marks agreement with a cited holding", () => {
+    expect(
+      contextVerdict(
+        DISTRICT,
+        "Podobnie Sąd Najwyższy w sprawie sygn. akt I C 1234/19.",
+      ),
+    ).toEqual({
+      kind: CITATION_KIND.PRECEDENT,
+      evidence: CITATION_KIND_EVIDENCE.CONTEXT,
+    });
+  });
+
+  test("zgodnie z marks reliance on a cited holding", () => {
+    expect(
+      contextVerdict(
+        DISTRICT,
+        "Zgodnie z poglądem przyjętym w sprawie sygn. akt I C 1234/19 roszczenie nie wygasło.",
+      ),
+    ).toEqual({
+      kind: CITATION_KIND.PRECEDENT,
+      evidence: CITATION_KIND_EVIDENCE.CONTEXT,
+    });
+  });
+
+  test("w wyroku z dnia introduces a cited holding", () => {
+    expect(
+      contextVerdict(
+        DISTRICT,
+        "Sąd Najwyższy w wyroku z dnia 5 maja 2019 r., sygn. akt I C 1234/19, przyjął odmienne stanowisko.",
+      ),
+    ).toEqual({
+      kind: CITATION_KIND.PRECEDENT,
+      evidence: CITATION_KIND_EVIDENCE.CONTEXT,
+    });
+  });
+
+  test("w uchwale introduces a cited resolution", () => {
+    expect(
+      contextVerdict(
+        DISTRICT,
+        "Sąd Najwyższy w uchwale sygn. akt I C 1234/19 rozstrzygnął tę rozbieżność.",
+      ),
+    ).toEqual({
+      kind: CITATION_KIND.PRECEDENT,
+      evidence: CITATION_KIND_EVIDENCE.CONTEXT,
+    });
+  });
+
+  test("ugruntowan marks settled case law", () => {
+    expect(
+      contextVerdict(
+        DISTRICT,
+        "Pogląd ten jest ugruntowany w orzecznictwie, sygn. akt I C 1234/19.",
+      ),
+    ).toEqual({
+      kind: CITATION_KIND.PRECEDENT,
+      evidence: CITATION_KIND_EVIDENCE.CONTEXT,
+    });
+  });
+
+  test("utrwalon marks settled case law", () => {
+    expect(
+      contextVerdict(
+        DISTRICT,
+        "Utrwalona linia orzecznicza, sygn. akt I C 1234/19, przyjmuje inaczej.",
+      ),
+    ).toEqual({
+      kind: CITATION_KIND.PRECEDENT,
+      evidence: CITATION_KIND_EVIDENCE.CONTEXT,
+    });
+  });
+
+  test("zaskarżon names the judgment under appeal", () => {
+    expect(
+      contextVerdict(
+        SUPREME,
+        "Sąd oddalił apelację od zaskarżonego wyroku, sygn. akt II CSK 123/20.",
+      ),
+    ).toEqual({
+      kind: CITATION_KIND.PROCEDURAL,
+      evidence: CITATION_KIND_EVIDENCE.CONTEXT,
+    });
+  });
+
+  test("od wyroku names what the appeal was brought from", () => {
+    expect(
+      contextVerdict(
+        SUPREME,
+        "Skarga kasacyjna od wyroku Sądu Apelacyjnego, sygn. akt II CSK 123/20.",
+      ),
+    ).toEqual({
+      kind: CITATION_KIND.PROCEDURAL,
+      evidence: CITATION_KIND_EVIDENCE.CONTEXT,
+    });
+  });
+
+  test("sygn. akt alone decides nothing", () => {
+    // The citation prefix is not a cue and must never become one: it stands
+    // in front of an authority and a recital alike, so a list carrying it
+    // would push every Polish citation onto whichever side it was added to.
+    expect(
+      contextVerdict(
+        "sygn. akt I ACa 1234/20",
+        "wyrok Sądu Apelacyjnego w Warszawie, sygn. akt I ACa 1234/20",
+      ),
+    ).toEqual({
+      kind: CITATION_KIND.PRECEDENT,
+      evidence: CITATION_KIND_EVIDENCE.REGISTRY,
+    });
+  });
+
+  test("an appellate mark is authority on the registry alone", () => {
+    // One assertion per register, so dropping any single entry fails here.
+    // The `z` marks are the interlocutory register of the same courts.
+    for (const citationText of [
+      "sygn. akt I ACa 1234/20",
+      "sygn. akt II AKa 210/19",
+      "sygn. akt III AUa 55/21",
+      "sygn. akt I AGa 88/22",
+      "sygn. akt III APa 12/18",
+      "sygn. akt I ACz 431/17",
+      "sygn. akt II AKz 902/20",
+      "sygn. akt III AUz 71/21",
+      "sygn. akt I AGz 64/22",
+      "sygn. akt III APz 9/19",
+    ]) {
+      expect(classifyCitationVerdict({ citationText, context: null })).toEqual({
+        kind: CITATION_KIND.PRECEDENT,
+        evidence: CITATION_KIND_EVIDENCE.REGISTRY,
+      });
+    }
+  });
+
+  test("a supreme-administrative mark is authority on the registry alone", () => {
+    for (const citationText of [
+      "sygn. akt II OSK 1234/19",
+      "sygn. akt I FSK 456/18",
+      "sygn. akt II GSK 789/20",
+      "sygn. akt I OPS 3/19",
+      "sygn. akt I FPS 2/18",
+      "sygn. akt II GPS 1/17",
+      "sygn. akt I ONP 4/06",
+    ]) {
+      expect(classifyCitationVerdict({ citationText, context: null })).toEqual({
+        kind: CITATION_KIND.PRECEDENT,
+        evidence: CITATION_KIND_EVIDENCE.REGISTRY,
+      });
+    }
+  });
+
+  test("a regional administrative mark is still not authority", () => {
+    // WSA is knowingly absent: `registryOf` stops at the slash and would key
+    // on the bare `sa`, the seat that identifies the court dropped. This
+    // pins the gap so that adding WSA is a deliberate edit here, not a
+    // silent side effect of loosening the reader.
+    expect(
+      classifyCitationVerdict({
+        citationText: "sygn. akt I SA/Wa 123/20",
+        context: null,
+      }),
+    ).toEqual({
+      kind: CITATION_KIND.PROCEDURAL,
+      evidence: CITATION_KIND_EVIDENCE.REGISTRY,
+    });
+  });
+
+  test("a district mark is not authority", () => {
+    // The other half of the appellate entries: what a Polish appellate
+    // judgment names as its own history stays procedural.
+    expect(
+      classifyCitationVerdict({ citationText: DISTRICT, context: null }),
+    ).toEqual({
+      kind: CITATION_KIND.PROCEDURAL,
+      evidence: CITATION_KIND_EVIDENCE.REGISTRY,
+    });
+  });
+});

--- a/apps/api/src/handlers/case-law/citation-kind.ts
+++ b/apps/api/src/handlers/case-law/citation-kind.ts
@@ -82,6 +82,49 @@ const AUTHORITY_REGISTRIES = new Set([
   // listed. Cited with a Roman chamber prefix that drifts as chambers are
   // reorganised ("III PZP 1/21"), so only the mark itself is keyed on.
   "pzp",
+  // Polish appellate courts ("sąd apelacyjny"), whose marks all carry the
+  // `A` prefix: civil (`ACa`), criminal (`AKa`), social-insurance (`AUa`),
+  // commercial (`AGa`) and labour (`APa`), each with a `z` sibling for the
+  // interlocutory register ("zażalenie"). Second instance, so the paragraph
+  // above would put them outside this set — but they are published in full
+  // and cited as authority, which is what the prior is asking about. Their
+  // own procedural history is the district and regional registers (`C`, `K`,
+  // `U`, `GC`, `P`), which stay unlisted and so still fall through.
+  //
+  // The cost of listing them is the supreme-court decision that names the
+  // appellate judgment it is reviewing: on the registry tier that now reads
+  // as authority. The Polish recital cues below are what catch it one tier
+  // earlier, which is where a statement about the case belongs.
+  "aca",
+  "aka",
+  "aua",
+  "aga",
+  "apa",
+  "acz",
+  "akz",
+  "auz",
+  "agz",
+  "apz",
+  // Polish Supreme Administrative Court (NSA): the cassation registers of
+  // its three chambers (`OSK` general-administrative, `FSK` financial, `GSK`
+  // commercial), the resolution registers those chambers use to unify
+  // practice (`OPS`, `FPS`, `GPS`), and `ONP` for the legal questions
+  // referred to it.
+  //
+  // The regional administrative courts (WSA) are deliberately absent. Their
+  // mark is two tokens, a register and a seat ("I SA/Wa 123/20"), and the
+  // reader below stops at the slash: what it would key on is the bare `sa`,
+  // the seat dropped, which is no longer the WSA mark at all. A two-letter
+  // token keyed without the half that identifies it is what this set cannot
+  // carry, because a wrong entry promotes silently and in bulk. WSA belongs
+  // here once `registryOf` reads the slash form.
+  "osk",
+  "fsk",
+  "gsk",
+  "ops",
+  "fps",
+  "gps",
+  "onp",
   // Slovak Supreme Court. `cdo` is shared with the Czech Supreme Court and
   // is listed once, above.
   "sžo",
@@ -101,11 +144,18 @@ const AUTHORITY_REGISTRIES = new Set([
 /**
  * Phrases that mark the recitals: the appeal, the judgment under review,
  * the court below. Deliberately morphological stems rather than whole
- * words — Czech and Slovak inflect heavily, and matching stems keeps one
- * list working across cases.
+ * words — Czech, Slovak and Polish all inflect heavily, and matching stems
+ * keeps one list working across cases.
+ *
+ * The Polish pair is `zaskarżon` (the judgment "under appeal", in whatever
+ * case the sentence puts it) and `od\s+wyroku` (what an appeal or a
+ * cassation is brought *from*). `sygn. akt` is not here and should not be:
+ * it is the citation prefix itself and appears on authority and recital
+ * alike, so it would push every Polish citation with a spelled-out prefix
+ * onto this side of the tie.
  */
 const PROCEDURAL_CUE =
-  /napaden|proti\s+(?:rozsudk|usnesen)|odvol[áa]n|dovol[áa]n[íi]\s+(?:žalovan|žalobc)|soud[ue]?\s+prvn[íi]ho\s+stupn|prvostupňov|potvrdil|zrušil\s+a\s+vr[áa]til|vedl[ei]?\s+u\s+|pobočka\s+v|v\s+konan[íi]\s+veden[oe]m|veden[eé]j\s+\p{L}+\s+s[úu]dom\s+pod|postupom\s+(?:okresn|krajsk|najvyšš)|a\s+takto\s+rozhodol/iu;
+  /napaden|proti\s+(?:rozsudk|usnesen)|odvol[áa]n|dovol[áa]n[íi]\s+(?:žalovan|žalobc)|soud[ue]?\s+prvn[íi]ho\s+stupn|prvostupňov|potvrdil|zrušil\s+a\s+vr[áa]til|vedl[ei]?\s+u\s+|pobočka\s+v|v\s+konan[íi]\s+veden[oe]m|veden[eé]j\s+\p{L}+\s+s[úu]dom\s+pod|postupom\s+(?:okresn|krajsk|najvyšš)|a\s+takto\s+rozhodol|zaskarżon|od\s+wyroku/iu;
 
 /**
  * Phrases that mark an authority being invoked. `srov.` (compare) and
@@ -113,9 +163,16 @@ const PROCEDURAL_CUE =
  * Slovak spells its verbs with `š` (`konštatoval`), so the stems are listed
  * per language; a recital cue next to one of these is a tie, and the
  * registry decides.
+ *
+ * Polish contributes its own two pointing abbreviations (`por.`, `zob.`),
+ * the three ways it says "likewise" (`tak też`, `podobnie`, `zgodnie z`),
+ * the coordinate that introduces a cited holding (`w wyroku z dnia`,
+ * `w uchwale`), and the two stems the settled-case-law formula is built on
+ * (`ugruntowan`, `utrwalon` — "ugruntowane orzecznictwo", "utrwalona linia
+ * orzecznicza"), the counterpart of the `ustálen` already listed for Czech.
  */
 const PRECEDENT_CUE =
-  /srov\.|srovnej|viz\s|judikat|ust[áa]len|pr[áa]vn[íi]\s+n[áa]zor|dovodil|vyslovil|kon[sš]tatoval|st[áa]l[áa]\s+praxe|ve\s+sv[ée]m\s+rozhodnut|porov\.|pozri|obdobne|vo\s+svojom\s+rozhodnut|v\s+s[úu]lade\s+s/iu;
+  /srov\.|srovnej|viz\s|judikat|ust[áa]len|pr[áa]vn[íi]\s+n[áa]zor|dovodil|vyslovil|kon[sš]tatoval|st[áa]l[áa]\s+praxe|ve\s+sv[ée]m\s+rozhodnut|porov\.|pozri|obdobne|vo\s+svojom\s+rozhodnut|v\s+s[úu]lade\s+s|por\.|zob\.|tak\s+też|podobnie|zgodnie\s+z|w\s+wyroku\s+z\s+dnia|w\s+uchwale|ugruntowan|utrwalon/iu;
 
 /**
  * Drop the citation prefix so the registry token is first. Spelled out


### PR DESCRIPTION
Appellate (A-prefixed) and NSA registry marks join the authority set; Polish precedent and recital cues join the two cue lists. WSA marks are deliberately left out until the registry reader handles the slash form. One cue per test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved classification of Polish legal citations, including appellate and Supreme Administrative Court registry references.
  - Added recognition of Polish procedural wording related to appeals and judgments under review.
  - Expanded detection of precedent references and settled case-law phrasing.

- **Tests**
  - Added comprehensive coverage for Polish citation contexts, court registries, procedural cues, and classification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->