### PR TITLE
chore(api): corpus index reporting

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -1641,6 +1641,41 @@ export const createCaseLawGenerationBackfill =
     const totalOf = (read: (timing: CorpusBackfillTiming) => number): number =>
       batchTimings.reduce((total, timing) => total + read(timing), 0);
     const stageMs = { drain: 0, select: 0, index: 0 };
+    // One line per page, on the walking arm: the stage times say which
+    // stage the page is in, and the batch totals say what that stage was
+    // waiting on. Emitted however the page ends, so a failing page still
+    // says where its time went. Counts only, never document content.
+    const reportPage = ({
+      outcome,
+      selected,
+      indexed,
+      drainedIndexed,
+    }: {
+      outcome: "advanced" | "busy" | "failed";
+      selected: number;
+      indexed: number;
+      drainedIndexed: number;
+    }): void => {
+      logger.info("case_law.corpus_index.generation_page", {
+        generation,
+        batchSize,
+        outcome,
+        selected,
+        indexed,
+        drainedIndexed,
+        pageMs: sinceMs(pageStartedAt),
+        drainMs: stageMs.drain,
+        selectMs: stageMs.select,
+        indexMs: stageMs.index,
+        readMs: totalOf(({ readMs }) => readMs),
+        reserveMs: totalOf(({ reserveMs }) => reserveMs),
+        removeMs: totalOf(({ removeMs }) => removeMs),
+        ingestMs: totalOf(({ ingestMs }) => ingestMs),
+        markMs: totalOf(({ markMs }) => markMs),
+        engineRequests: totalOf(({ engineRequests }) => engineRequests),
+        documents: totalOf(({ documents }) => documents),
+      });
+    };
     const writerLease = await acquireCaseLawCorpusGenerationLease({
       generation,
       newLeaseToken,
@@ -2115,12 +2150,16 @@ export const createCaseLawGenerationBackfill =
       let drainedIndexed = 0;
       try {
         const drainStartedAt = performance.now();
-        const drained = await drainPendingProjections({
-          checkpoint: claimedCheckpoint,
-          leaseToken,
-          status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,
-        });
-        stageMs.drain = sinceMs(drainStartedAt);
+        let drained: CorpusIndexBackfillResult;
+        try {
+          drained = await drainPendingProjections({
+            checkpoint: claimedCheckpoint,
+            leaseToken,
+            status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,
+          });
+        } finally {
+          stageMs.drain = sinceMs(drainStartedAt);
+        }
         if (drained.status === BACKFILL_STATUS.BUSY) {
           await releaseRunningLease();
           return drained;
@@ -2128,6 +2167,12 @@ export const createCaseLawGenerationBackfill =
         drainedIndexed = drained.indexed;
       } catch (error) {
         await releaseRunningLease();
+        reportPage({
+          outcome: "failed",
+          selected: 0,
+          indexed: 0,
+          drainedIndexed: 0,
+        });
         throw error;
       }
       // Reports this invocation's total durable movement: rows the drain
@@ -2240,9 +2285,16 @@ export const createCaseLawGenerationBackfill =
         // Keep the cursor intact, but do not make a transient search/S3 failure
         // wait for a stale lease before its durable retry.
         await releaseRunningLease();
+        reportPage({
+          outcome: "failed",
+          selected: rows.length,
+          indexed: 0,
+          drainedIndexed,
+        });
         throw error;
+      } finally {
+        stageMs.index = sinceMs(indexStartedAt);
       }
-      stageMs.index = sinceMs(indexStartedAt);
 
       const advanced = await scopedDb(async (tx) => {
         // audit: skip — cursor advancement is the durable audit trail for this derived rebuild
@@ -2266,26 +2318,11 @@ export const createCaseLawGenerationBackfill =
           .returning({ generation: caseLawCorpusIndexBackfills.generation });
         return advancedRows.at(0);
       });
-      // One line per page, on the walking arm: the stage times say which
-      // stage the page is in, and the batch totals say what that stage was
-      // waiting on. Counts only, never document content.
-      logger.info("case_law.corpus_index.generation_page", {
-        generation,
-        batchSize,
+      reportPage({
+        outcome: advanced ? "advanced" : "busy",
         selected: rows.length,
         indexed,
         drainedIndexed,
-        pageMs: sinceMs(pageStartedAt),
-        drainMs: stageMs.drain,
-        selectMs: stageMs.select,
-        indexMs: stageMs.index,
-        readMs: totalOf(({ readMs }) => readMs),
-        reserveMs: totalOf(({ reserveMs }) => reserveMs),
-        removeMs: totalOf(({ removeMs }) => removeMs),
-        ingestMs: totalOf(({ ingestMs }) => ingestMs),
-        markMs: totalOf(({ markMs }) => markMs),
-        engineRequests: totalOf(({ engineRequests }) => engineRequests),
-        documents: totalOf(({ documents }) => documents),
       });
       return withDrained(
         advanced

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -2162,6 +2162,12 @@ export const createCaseLawGenerationBackfill =
         }
         if (drained.status === BACKFILL_STATUS.BUSY) {
           await releaseRunningLease();
+          reportPage({
+            outcome: "busy",
+            selected: 0,
+            indexed: 0,
+            drainedIndexed: 0,
+          });
           return drained;
         }
         drainedIndexed = drained.indexed;

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -28,6 +28,7 @@ import {
 } from "@/api/lib/corpus-index/chunking";
 import type {
   CorpusBackfillOutcome,
+  CorpusBackfillTiming,
   CorpusDocumentPayload,
   CorpusIndexAdapter,
   FencedRemoteEffect,
@@ -72,6 +73,7 @@ import {
   isCorpusIndexJurisdiction,
   tryCorpusIndexGeneration,
 } from "@/api/lib/legal-search/index-naming";
+import { logger } from "@/api/lib/observability/logger";
 
 /**
  * corpus index search-projection maintenance for the `case_law` family.
@@ -1211,6 +1213,7 @@ type GenerationBackfillDependencies = {
     options: GenerationProjectionGuards & {
       commit: CorpusIndexCommitMode;
       readConcurrency?: number;
+      onTiming?: (timing: CorpusBackfillTiming) => void;
     },
   ) => Promise<CorpusBackfillOutcome>;
   removeProjection: (
@@ -1623,6 +1626,21 @@ export const createCaseLawGenerationBackfill =
       options.readConcurrency === undefined
         ? {}
         : { readConcurrency: options.readConcurrency };
+    // Where the page spends its wall clock. A page is a chain of object
+    // reads, engine requests and short transactions, and which one it is
+    // waiting on is not visible from the indexed count or from timing the
+    // page as a whole. Every batch the page runs reports its own split; the
+    // page reports the sum next to its stage times, once, at the end.
+    const pageStartedAt = performance.now();
+    const sinceMs = (startedAt: number) =>
+      Math.round(performance.now() - startedAt);
+    const batchTimings: CorpusBackfillTiming[] = [];
+    const collectTiming = (timing: CorpusBackfillTiming): void => {
+      batchTimings.push(timing);
+    };
+    const totalOf = (read: (timing: CorpusBackfillTiming) => number): number =>
+      batchTimings.reduce((total, timing) => total + read(timing), 0);
+    const stageMs = { drain: 0, select: 0, index: 0 };
     const writerLease = await acquireCaseLawCorpusGenerationLease({
       generation,
       newLeaseToken,
@@ -1798,6 +1816,7 @@ export const createCaseLawGenerationBackfill =
               : await backfillRows(scopedDb, eligible, generation, {
                   ...guards,
                   ...readConcurrencyOption,
+                  onTiming: collectTiming,
                   // A source-wide re-index walks a whole source's corpus
                   // a page at a time, so it is bulk work with the same
                   // census behind it as the snapshot walk.
@@ -1910,6 +1929,7 @@ export const createCaseLawGenerationBackfill =
             : await backfillRows(scopedDb, eligible, generation, {
                 ...guards,
                 ...readConcurrencyOption,
+                onTiming: collectTiming,
                 commit: PENDING_DRAIN_COMMIT[status],
               });
         if (outcome.indexed !== eligible.length) {
@@ -2094,11 +2114,13 @@ export const createCaseLawGenerationBackfill =
       // walk pages that later reach the same rows.
       let drainedIndexed = 0;
       try {
+        const drainStartedAt = performance.now();
         const drained = await drainPendingProjections({
           checkpoint: claimedCheckpoint,
           leaseToken,
           status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,
         });
+        stageMs.drain = sinceMs(drainStartedAt);
         if (drained.status === BACKFILL_STATUS.BUSY) {
           await releaseRunningLease();
           return drained;
@@ -2124,10 +2146,12 @@ export const createCaseLawGenerationBackfill =
           : { indexed: drainedIndexed, status: BACKFILL_STATUS.ADVANCED };
       };
 
+      const selectStartedAt = performance.now();
       const page = await selectGenerationBackfillPage(scopedDb, {
         batchSize,
         checkpoint: claimedCheckpoint,
       });
+      stageMs.select = sinceMs(selectStartedAt);
       const last = page.at(-1);
       if (!last) {
         const completed = await scopedDb(async (tx) => {
@@ -2179,6 +2203,7 @@ export const createCaseLawGenerationBackfill =
           hasGenerationProjectionTargets({ generation, row }),
       );
       let indexed: number;
+      const indexStartedAt = performance.now();
       try {
         // The drain above may have brought every row on this page current, so
         // skip the indexer rather than hand it an empty batch.
@@ -2188,6 +2213,7 @@ export const createCaseLawGenerationBackfill =
             : await backfillRows(scopedDb, rows, generation, {
                 ...runningGuards,
                 ...readConcurrencyOption,
+                onTiming: collectTiming,
                 // Snapshot pages of the rebuild: bulk throughput, whose
                 // completeness the generation's census verifies rather
                 // than each request proving it for itself.
@@ -2216,6 +2242,7 @@ export const createCaseLawGenerationBackfill =
         await releaseRunningLease();
         throw error;
       }
+      stageMs.index = sinceMs(indexStartedAt);
 
       const advanced = await scopedDb(async (tx) => {
         // audit: skip — cursor advancement is the durable audit trail for this derived rebuild
@@ -2238,6 +2265,27 @@ export const createCaseLawGenerationBackfill =
           )
           .returning({ generation: caseLawCorpusIndexBackfills.generation });
         return advancedRows.at(0);
+      });
+      // One line per page, on the walking arm: the stage times say which
+      // stage the page is in, and the batch totals say what that stage was
+      // waiting on. Counts only, never document content.
+      logger.info("case_law.corpus_index.generation_page", {
+        generation,
+        batchSize,
+        selected: rows.length,
+        indexed,
+        drainedIndexed,
+        pageMs: sinceMs(pageStartedAt),
+        drainMs: stageMs.drain,
+        selectMs: stageMs.select,
+        indexMs: stageMs.index,
+        readMs: totalOf(({ readMs }) => readMs),
+        reserveMs: totalOf(({ reserveMs }) => reserveMs),
+        removeMs: totalOf(({ removeMs }) => removeMs),
+        ingestMs: totalOf(({ ingestMs }) => ingestMs),
+        markMs: totalOf(({ markMs }) => markMs),
+        engineRequests: totalOf(({ engineRequests }) => engineRequests),
+        documents: totalOf(({ documents }) => documents),
       });
       return withDrained(
         advanced

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -1145,12 +1145,6 @@ export const createCorpusIndexer = <
     if (rows.length === 0) {
       return { indexed: 0, refreshed: 0, unread: 0 };
     }
-
-    // Load text (S3) with bounded concurrency, then ingest one NDJSON batch.
-    // A per-document read failure fails only that document; record it and let
-    // the rest still commit.
-    const fetchFulltext: FetchFulltext<TBrand> = async (id) =>
-      await adapter.fetchFulltext(scopedDb, id);
     const timing: CorpusBackfillTiming = {
       readMs: 0,
       reserveMs: 0,
@@ -1160,6 +1154,36 @@ export const createCorpusIndexer = <
       engineRequests: 0,
       documents: 0,
     };
+    try {
+      return await backfillSelectedRowsTimed(
+        scopedDb,
+        rows,
+        generation,
+        options,
+        timing,
+      );
+    } finally {
+      // Reported however the batch ends, so a batch that fails still says
+      // where its time went — a page that gets slow and a page that starts
+      // failing are often the same page.
+      if (options.type === "generation-rebuild") {
+        options.onTiming?.(timing);
+      }
+    }
+  };
+
+  const backfillSelectedRowsTimed = async (
+    scopedDb: ScopedDb,
+    rows: TRow[],
+    generation: string,
+    options: BackfillSelectedRowsOptions<TBrand, TRow>,
+    timing: CorpusBackfillTiming,
+  ): Promise<CorpusBackfillOutcome> => {
+    // Load text (S3) with bounded concurrency, then ingest one NDJSON batch.
+    // A per-document read failure fails only that document; record it and let
+    // the rest still commit.
+    const fetchFulltext: FetchFulltext<TBrand> = async (id) =>
+      await adapter.fetchFulltext(scopedDb, id);
     // Monotonic: a wall-clock step backwards would make a phase read
     // negative, and the whole point of the split is that it is comparable
     // across pages.
@@ -1335,6 +1359,7 @@ export const createCorpusIndexer = <
         let staleError: CorpusIndexError | null = null;
         const removeStartedAt = performance.now();
         for (const unit of deleteUnits) {
+          timing.engineRequests += 1;
           // oxlint-disable-next-line no-await-in-loop -- one task per (index, chunk): bounded by the batch's distinct indexes, not by its rows; sequential so the first failure stops before the ingest below
           const removed = await removeManyWithOptions({
             ...(options.type === "incremental"
@@ -1358,7 +1383,6 @@ export const createCorpusIndexer = <
           }
         }
         timing.removeMs += elapsedSince(removeStartedAt);
-        timing.engineRequests += deleteUnits.length;
         if (staleError) {
           firstError ??= staleError;
           continue;
@@ -1512,13 +1536,6 @@ export const createCorpusIndexer = <
           await adapter.recordJobs(scopedDb, groupFailures, indexId);
         }
       }
-    }
-
-    // Reported before the failure below, so a batch that ends in a retry
-    // still says where its time went — a page that gets slow and a page
-    // that starts failing are often the same page.
-    if (options.type === "generation-rebuild") {
-      options.onTiming?.(timing);
     }
 
     // Surface a failure so the daemon retries the un-indexed groups.

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -426,6 +426,35 @@ export type GenerationRebuildBackfillOptions<
   TRow extends CorpusIndexRow<TBrand>,
 > = GenerationBackfillRowsOptions<TBrand, TRow> & {
   commit: CorpusIndexCommitMode;
+  /**
+   * Where a batch spent its wall clock, reported once per call. A rebuild
+   * page is a chain of object reads, engine requests and short
+   * transactions; which of them dominates is not derivable from the
+   * indexed count, and reading it from the outside means timing the whole
+   * page and guessing. Optional, so only the paths that report it pay for
+   * it.
+   */
+  onTiming?: (timing: CorpusBackfillTiming) => void;
+};
+
+/**
+ * Wall-clock split of one backfill call, in milliseconds. Phases are
+ * sequential, so they sum to roughly the call's own duration; `documents`
+ * and `engineRequests` are the units behind the ingest figure.
+ */
+export type CorpusBackfillTiming = {
+  /** Canonical object reads for the batch (bounded concurrency). */
+  readMs: number;
+  /** Durable append reservations and index existence checks. */
+  reserveMs: number;
+  /** Engine removal tasks: replay cleanup and unrecorded-copy cleanup. */
+  removeMs: number;
+  /** Engine ingest requests, including any wait the commit mode implies. */
+  ingestMs: number;
+  /** Compare-and-set marks and their audit rows. */
+  markMs: number;
+  engineRequests: number;
+  documents: number;
 };
 
 type FencedIncrementalBackfillOptions<
@@ -1122,6 +1151,21 @@ export const createCorpusIndexer = <
     // the rest still commit.
     const fetchFulltext: FetchFulltext<TBrand> = async (id) =>
       await adapter.fetchFulltext(scopedDb, id);
+    const timing: CorpusBackfillTiming = {
+      readMs: 0,
+      reserveMs: 0,
+      removeMs: 0,
+      ingestMs: 0,
+      markMs: 0,
+      engineRequests: 0,
+      documents: 0,
+    };
+    // Monotonic: a wall-clock step backwards would make a phase read
+    // negative, and the whole point of the split is that it is comparable
+    // across pages.
+    const elapsedSince = (startedAt: number) =>
+      Math.round(performance.now() - startedAt);
+    const readStartedAt = performance.now();
     const { built, readFailures } = await loadDocsForBatch(rows, {
       generation,
       fetchFulltext,
@@ -1129,6 +1173,7 @@ export const createCorpusIndexer = <
         ? {}
         : { readConcurrency: options.readConcurrency }),
     });
+    timing.readMs = elapsedSince(readStartedAt);
     await recordReadFailures(scopedDb, readFailures, generation);
 
     // Route each row's documents to its physical index (`corpusIndexId`: per
@@ -1158,6 +1203,7 @@ export const createCorpusIndexer = <
       indexId: string,
       group: typeof built,
     ) => {
+      const reserveStartedAt = performance.now();
       const reservedTargets =
         options.type === "incremental"
           ? null
@@ -1176,6 +1222,7 @@ export const createCorpusIndexer = <
           ? group
           : group.filter(({ row }) => reservedTargets.has(row.id));
       if (reservedGroup.length === 0) {
+        timing.reserveMs += elapsedSince(reserveStartedAt);
         return { ensured: null, reservedGroup, reservedTargets };
       }
       // A new generation may not have an index for this jurisdiction yet.
@@ -1187,6 +1234,7 @@ export const createCorpusIndexer = <
           : { beforeRemoteEffect: options.beforeRemoteEffect }),
         indexId,
       });
+      timing.reserveMs += elapsedSince(reserveStartedAt);
       return { ensured, reservedGroup, reservedTargets };
     };
 
@@ -1285,6 +1333,7 @@ export const createCorpusIndexer = <
           }
         }
         let staleError: CorpusIndexError | null = null;
+        const removeStartedAt = performance.now();
         for (const unit of deleteUnits) {
           // oxlint-disable-next-line no-await-in-loop -- one task per (index, chunk): bounded by the batch's distinct indexes, not by its rows; sequential so the first failure stops before the ingest below
           const removed = await removeManyWithOptions({
@@ -1308,6 +1357,8 @@ export const createCorpusIndexer = <
             break;
           }
         }
+        timing.removeMs += elapsedSince(removeStartedAt);
+        timing.engineRequests += deleteUnits.length;
         if (staleError) {
           firstError ??= staleError;
           continue;
@@ -1323,6 +1374,7 @@ export const createCorpusIndexer = <
           reservedGroup,
           LIMITS.corpusIndexIngestMaxBytes,
         )) {
+          const ingestStartedAt = performance.now();
           // oxlint-disable-next-line no-await-in-loop -- sequential ingest paces NDJSON pushes to the search backend
           const ingest = await ingestBatchWithGuard({
             // Both incremental shapes are the steady state: their whole
@@ -1347,6 +1399,11 @@ export const createCorpusIndexer = <
             indexId,
             ndjson,
           });
+          timing.ingestMs += elapsedSince(ingestStartedAt);
+          timing.engineRequests += 1;
+          for (const { docs } of entries) {
+            timing.documents += docs.length;
+          }
 
           if (ingest.isErr()) {
             firstError ??= ingest.error;
@@ -1358,6 +1415,7 @@ export const createCorpusIndexer = <
           }
 
           const casMissed = new Set<SafeId<TBrand>>();
+          const markStartedAt = performance.now();
           // oxlint-disable-next-line no-await-in-loop -- one CAS transaction per ingest request; sequential to keep index writes and audit rows consistent
           await scopedDb(async (tx) => {
             // audit: skip — search index maintenance; rebuilds derived state
@@ -1411,10 +1469,12 @@ export const createCorpusIndexer = <
               });
             }
           });
+          timing.markMs += elapsedSince(markStartedAt);
           // A missed CAS means a refresh outpaced this batch after the ingest
           // appended its documents: the row carries no generation pointer to
           // them, so delete the unrecorded copies now; the refreshed row is
           // re-indexed by a later cycle.
+          const missedStartedAt = performance.now();
           for (const missedId of casMissed) {
             // oxlint-disable-next-line no-await-in-loop -- sequential cleanup deletes of the unrecorded copies; matches this file's established sequential-vs-search-backend design (see ensureIndex/ingestBatch above)
             const removed = await removeWithOptions({
@@ -1437,6 +1497,8 @@ export const createCorpusIndexer = <
               firstError ??= removed.error;
             }
           }
+          timing.removeMs += elapsedSince(missedStartedAt);
+          timing.engineRequests += casMissed.size;
           indexed += entries.length - casMissed.size;
           refreshed += casMissed.size;
         }
@@ -1450,6 +1512,13 @@ export const createCorpusIndexer = <
           await adapter.recordJobs(scopedDb, groupFailures, indexId);
         }
       }
+    }
+
+    // Reported before the failure below, so a batch that ends in a retry
+    // still says where its time went — a page that gets slow and a page
+    // that starts failing are often the same page.
+    if (options.type === "generation-rebuild") {
+      options.onTiming?.(timing);
     }
 
     // Surface a failure so the daemon retries the un-indexed groups.


### PR DESCRIPTION
A corpus-index rebuild page is a chain of object reads, engine requests and
short transactions. When a page is slow, the indexed count does not say which
of them it was waiting on, and timing the page from the outside only confirms
that it was slow.

This adds the split, behind the existing logger:

- The rebuild backfill reports its own wall-clock breakdown — reads,
  reservations, removals, ingest, marks, plus the request and document counts
  behind them — through an optional callback, so only the paths that ask for it
  pay for it. It is reported before a failing batch surfaces its error, so a
  page that starts failing still says where its time went.
- The generation page logs that sum once per page, next to its own stage times
  (drain, select, index) and the page total.

Counts only; no document content crosses the log boundary, and the log line
carries the same shape whatever the page did.

No behaviour change: no query, request, commit mode or ordering moves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Monitoring & Diagnostics**
  * Added detailed performance tracking for case-law corpus generation and rebuild operations.
  * Processing stages now report timing, request, document, and batch-operation metrics, including when processing fails.
  * Added structured per-page processing events to improve visibility into indexing performance and failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->