### PR TITLE
perf(api): running-generation pending drain commits with auto

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
@@ -28,7 +28,11 @@ import {
   caseLawCorpusProjectionJoin,
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
-import { CorpusIndexError } from "@/api/lib/legal-search/corpus-index-client";
+import {
+  CORPUS_INDEX_COMMIT,
+  CorpusIndexError,
+} from "@/api/lib/legal-search/corpus-index-client";
+import type { CorpusIndexCommitMode } from "@/api/lib/legal-search/corpus-index-client";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
@@ -663,6 +667,7 @@ test(
   "replays the snapshot once and reconciles pending rows after completion",
   async () => {
     const sent: SafeId<"caseLawDecision">[][] = [];
+    const commits: CorpusIndexCommitMode[] = [];
     let guardedPages = 0;
     let lease = 0;
     const backfill = createCaseLawGenerationBackfill({
@@ -672,6 +677,7 @@ test(
           onLeaseLost: noRemoteEffectCompensation,
         });
         sent.push(rows.map((row) => row.id));
+        commits.push(options.commit);
         guardedPages += 1;
         await runnerDb(async (tx) => {
           await options.beforeDatabaseMark(tx);
@@ -715,12 +721,38 @@ test(
       indexed: 0,
       status: "complete",
     });
+    // A row queued after completion drains through the completed path.
+    await db.insert(caseLawCorpusIndexProjections).values({
+      decisionId: publicLastId,
+      generation: GENERATION,
+      pendingAction: "index",
+      pendingHash: "last",
+      pendingIndexIds: [corpusIndexId(GENERATION, "CZE")],
+    });
+    expect(await backfill(scopedDb, 2, GENERATION)).toEqual({
+      indexed: 1,
+      status: "advanced",
+    });
 
     // Same-timestamp rows are visited in UUID order, exactly once. Restricted
     // and incomplete records advance the keyset cursor as terminal skips but
     // never cross the index boundary.
-    expect(sent).toEqual([[publicFirstId], [publicLastId], [publicFirstId]]);
-    expect(guardedPages).toBe(3);
+    expect(sent).toEqual([
+      [publicFirstId],
+      [publicLastId],
+      [publicFirstId],
+      [publicLastId],
+    ]);
+    expect(guardedPages).toBe(4);
+    // Snapshot pages and the running drain are bulk, verified by the census;
+    // the completed generation's drain is the live path and must not be
+    // marked on acceptance alone.
+    expect(commits).toEqual([
+      CORPUS_INDEX_COMMIT.auto,
+      CORPUS_INDEX_COMMIT.auto,
+      CORPUS_INDEX_COMMIT.auto,
+      CORPUS_INDEX_COMMIT.waitFor,
+    ]);
     const checkpoint = await readCheckpoint(GENERATION);
     expect(checkpoint).toMatchObject({
       cursorId: publicLastId,
@@ -2941,6 +2973,7 @@ test(
     });
 
     const sent: SafeId<"caseLawDecision">[][] = [];
+    const commits: CorpusIndexCommitMode[] = [];
     const backfill = createCaseLawGenerationBackfill({
       backfillRows: async (runnerDb, rows, rebuildGeneration, options) => {
         await options.beforeRemoteEffect({
@@ -2948,6 +2981,7 @@ test(
           onLeaseLost: noRemoteEffectCompensation,
         });
         sent.push(rows.map((row) => row.id));
+        commits.push(options.commit);
         await runnerDb(async (tx) => {
           await options.beforeDatabaseMark(tx);
           await tx
@@ -2970,6 +3004,12 @@ test(
         status: "advanced",
       });
       expect(sent.at(0)).toEqual([publicLastId]);
+      // A running generation's census is the backstop for the drain as much
+      // as for the walk, so neither page waits for the engine's commit.
+      expect(commits).toEqual([
+        CORPUS_INDEX_COMMIT.auto,
+        CORPUS_INDEX_COMMIT.auto,
+      ]);
       expect(await readCheckpoint(generation)).toMatchObject({
         leaseExpiresAt: null,
         leaseToken: null,

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -1230,6 +1230,26 @@ const EMPTY_BACKFILL_OUTCOME = {
   unread: 0,
 } as const satisfies CorpusBackfillOutcome;
 
+/**
+ * Commit mode for the pending-queue drain, by the generation's status.
+ *
+ * A completed generation's drain is the live path: every newly ingested
+ * decision waits in that queue, and the mark taken on the way out is the
+ * last thing that would ever select it, so acceptance has to mean
+ * committed or the row goes permanently missing while Postgres reads
+ * indexed. A running generation is still being built: a shortfall there
+ * is what its census reports and the repair re-projects, the same
+ * backstop that already licenses `auto` on its snapshot pages, while
+ * `wait_for` would hold every page for the engine's commit interval.
+ */
+const PENDING_DRAIN_COMMIT = {
+  [CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE]: CORPUS_INDEX_COMMIT.waitFor,
+  [CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING]: CORPUS_INDEX_COMMIT.auto,
+} as const satisfies Record<
+  CaseLawCorpusIndexBackfillStatus,
+  CorpusIndexCommitMode
+>;
+
 const FIXED_POINT_STAGE = {
   generationBackfillPage: "generation backfill page",
   generationReconciliation: "generation reconciliation",
@@ -1827,7 +1847,7 @@ export const createCaseLawGenerationBackfill =
             : { indexed: 0, status: BACKFILL_STATUS.BUSY };
         }
 
-        return await reconcilePendingPage(guards);
+        return await reconcilePendingPage({ guards, status });
       };
 
       // The pending queue is the live path: every newly ingested decision
@@ -1836,9 +1856,13 @@ export const createCaseLawGenerationBackfill =
       // walk. A queued source repair can span the whole corpus of a source;
       // routing the live drain behind it would recreate the wedge this
       // ordering exists to prevent.
-      const reconcilePendingPage = async (
-        guards: ReturnType<typeof createLeaseGuards>,
-      ): Promise<CorpusIndexBackfillResult> => {
+      const reconcilePendingPage = async ({
+        guards,
+        status,
+      }: {
+        guards: ReturnType<typeof createLeaseGuards>;
+        status: CaseLawCorpusIndexBackfillStatus;
+      }): Promise<CorpusIndexBackfillResult> => {
         const pendingPage = await selectGenerationPendingPage(scopedDb, {
           generation,
           limit: batchSize,
@@ -1886,12 +1910,7 @@ export const createCaseLawGenerationBackfill =
             : await backfillRows(scopedDb, eligible, generation, {
                 ...guards,
                 ...readConcurrencyOption,
-                // The live path: every newly ingested decision waits in
-                // this queue, and the mark taken on the way out is the
-                // last thing that would ever select it. Acceptance has
-                // to mean committed here or the row goes permanently
-                // missing from the index while Postgres reads indexed.
-                commit: CORPUS_INDEX_COMMIT.waitFor,
+                commit: PENDING_DRAIN_COMMIT[status],
               });
         if (outcome.indexed !== eligible.length) {
           throw fixedPointError({
@@ -1956,7 +1975,7 @@ export const createCaseLawGenerationBackfill =
           effect: completeRemoteEffect,
           onLeaseLost: async () => await Promise.resolve(),
         });
-        return await reconcilePendingPage(guards);
+        return await reconcilePendingPage({ guards, status });
       };
 
       if (

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -415,9 +415,9 @@ type GenerationBackfillRowsOptions<
 
 /**
  * A generation rebuild runs two shapes of walk through one entry point,
- * and they need opposite commit semantics: the snapshot pages are bulk
- * (`auto`, verified by a census afterwards) while the pending queue
- * drained alongside them is the live path every newly ingested decision
+ * and they need different commit semantics: the snapshot pages are bulk
+ * (`auto`, verified by a census afterwards) while the pending queue of a
+ * completed generation is the live path every newly ingested decision
  * goes through (`wait_for`, because its acceptance is persisted). The
  * `type` discriminator cannot tell them apart, so the caller states it.
  */


### PR DESCRIPTION
The pending-queue drain used `wait_for` under both generation statuses, so every rebuild page waited for the engine's commit interval before its snapshot work began.

- A completed generation's drain is the live path and keeps `wait_for`.
- A running generation's drain has the same census behind it as its snapshot pages and uses `auto`.

Commit mode is a total map over the backfill status (`PENDING_DRAIN_COMMIT`). Tests assert the mode per page for both statuses; reverting the map fails both.
