### PR TITLE
fix(ui): outline rail keeps the toggled row where it was

### DIFF
--- a/.changeset/outline-rail-toggle.md
+++ b/.changeset/outline-rail-toggle.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": patch
+---
+
+Toggling an outline rail branch keeps the toggled row where it was instead of re-pinning it to its sticky offset.

--- a/packages/ui/src/components/outline-rail.tsx
+++ b/packages/ui/src/components/outline-rail.tsx
@@ -363,7 +363,12 @@ export const OutlineRail = ({
   );
 
   const toggleCollapse = useCallback(
-    (id: string, level: number, rowEl: HTMLElement | null) => {
+    (id: string, rowEl: HTMLElement | null) => {
+      // Where the toggled row sits now. Content changes only below it, so the
+      // row moves only when the panel has to clamp its scroll offset (a branch
+      // folding away above the fold); compensate exactly that, and nothing
+      // when nothing moved.
+      const rowTop = rowEl?.getBoundingClientRect().top;
       setToggled((prev) => new Set(prev).add(id));
       setCollapsed((prev) => {
         const next = new Set(prev);
@@ -374,15 +379,12 @@ export const OutlineRail = ({
         }
         return next;
       });
-      // Keep the toggled header pinned at its sticky position so it doesn't
-      // jump out of view when the content below it grows or shrinks.
       requestAnimationFrame(() => {
         const panel = panelRef.current;
-        if (!panel || !rowEl) {
+        if (!panel || !rowEl || rowTop === undefined) {
           return;
         }
-        const target = panel.getBoundingClientRect().top + level * ROW_H;
-        panel.scrollTop += rowEl.getBoundingClientRect().top - target;
+        panel.scrollTop += rowEl.getBoundingClientRect().top - rowTop;
       });
     },
     [],
@@ -470,11 +472,7 @@ export const OutlineRail = ({
               aria-label={isCollapsed ? "Expand" : "Collapse"}
               className="text-muted-foreground hover:text-foreground flex size-5 shrink-0 items-center justify-center"
               onClick={(event) =>
-                toggleCollapse(
-                  node.item.id,
-                  node.item.level,
-                  event.currentTarget.parentElement,
-                )
+                toggleCollapse(node.item.id, event.currentTarget.parentElement)
               }
               style={{ marginInlineStart: indent - 4 }}
               type="button"


### PR DESCRIPTION
Toggling a branch re-pinned its row to `level * ROW_H` from the panel top, which moved the whole list whenever the row was not already at that offset (a top-level entry under the jump field, for one). The row is measured before the toggle and only its actual displacement is compensated, so a toggle that moves nothing scrolls nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved outline rail collapsing and expanding so the toggled row stays in the same position in the viewport.
  - Removed unwanted page movement when changing row visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->