### PR TITLE
fix(web): statute outline rows lead with the unit, then the title, range at the edge

### DIFF
--- a/.changeset/outline-rail-title.md
+++ b/.changeset/outline-rail-title.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": patch
+---
+
+Outline rail entries take an optional `title`, rendered after a non-truncating label; `meta` stays right-pinned. The tooltip shows both.

--- a/apps/web/src/components/legal-reader/reader-outline.test.ts
+++ b/apps/web/src/components/legal-reader/reader-outline.test.ts
@@ -6,6 +6,7 @@ import type { AnchorScrollContainer } from "@/components/legal-reader/reader-out
 import {
   filterOutlineItems,
   findProvisionAnchorId,
+  headingCase,
   jumpToAnchor,
   outlineFromHeadings,
   parseOutlineJump,
@@ -88,20 +89,27 @@ describe("outlineFromHeadings", () => {
     expect(outline.map((item) => item.level)).toEqual([0, 1, 2, 3, 3, 1]);
   });
 
-  test("leads with the designation and annotates with the title", () => {
+  test("leads with the designation and annotates with the title, in sentence case", () => {
     const [part] = outlineFromHeadings(blocks);
 
-    expect(part?.label).toBe("ČÁST PRVNÍ");
-    expect(part?.meta).toBe("OBECNÁ ČÁST");
+    expect(part?.label).toBe("Část první");
+    expect(part?.title).toBe("Obecná část");
   });
 
-  test("a single-line heading carries no annotation", () => {
+  test("a single-line heading carries no title", () => {
     const section = outlineFromHeadings(blocks).find(
       (item) => item.id === "paragraf-47",
     );
 
     expect(section?.label).toBe("§ 47");
-    expect(section?.meta).toBeUndefined();
+    expect(section?.title).toBeUndefined();
+  });
+
+  test("sentence case keeps Roman numerals and mixed-case headings", () => {
+    expect(headingCase("HLAVA II")).toBe("Hlava II");
+    expect(headingCase("OBECNÁ ČÁST")).toBe("Obecná část");
+    expect(headingCase("Díl 4")).toBe("Díl 4");
+    expect(headingCase("§ 47")).toBe("§ 47");
   });
 
   test("a document with no headings yields no outline", () => {
@@ -205,12 +213,20 @@ const outlineItem = ({
   label,
   level,
   meta,
+  title,
 }: {
   id: string;
   label: string;
   level: number;
   meta?: string;
-}) => ({ id, label, level, ...(meta === undefined ? {} : { meta }) });
+  title?: string;
+}) => ({
+  id,
+  label,
+  level,
+  ...(meta === undefined ? {} : { meta }),
+  ...(title === undefined ? {} : { title }),
+});
 
 describe("parseProvisionDesignation", () => {
   test("reads the designation a publisher prints, spacing and all", () => {
@@ -265,17 +281,19 @@ describe("withProvisionRanges", () => {
   test("states the span of provisions a container holds", () => {
     const [, hlava] = withProvisionRanges(items);
 
-    expect(hlava?.label).toBe("HLAVA I (§ 976–978)");
+    expect(hlava?.label).toBe("HLAVA I");
+    expect(hlava?.meta).toBe("§ 976–978");
   });
 
   test("a container reaches past its own children to the last provision under it", () => {
     const [cast] = withProvisionRanges(items);
 
-    expect(cast?.label).toBe("ČÁST PRVNÍ (§ 976–979)");
+    expect(cast?.label).toBe("ČÁST PRVNÍ");
+    expect(cast?.meta).toBe("§ 976–979");
   });
 
   test("a container holding one provision states it once, not as a range", () => {
-    expect(withProvisionRanges(items).at(-2)?.label).toBe("HLAVA II (§ 979)");
+    expect(withProvisionRanges(items).at(-2)?.meta).toBe("§ 979");
   });
 
   test("orders by the act, not by the number, so a suffix stays in place", () => {
@@ -286,7 +304,7 @@ describe("withProvisionRanges", () => {
       outlineItem({ id: "c", label: "§ 265b", level: 1 }),
     ]);
 
-    expect(suffixed.at(0)?.label).toBe("HLAVA I (§ 265–265b)");
+    expect(suffixed.at(0)?.meta).toBe("§ 265–265b");
   });
 
   test("a provision is not a range of itself", () => {
@@ -301,7 +319,7 @@ describe("withProvisionRanges", () => {
     ]);
 
     // `§ 1–2` would state the article as a section, which it is not.
-    expect(mixed.at(0)?.label).toBe("HLAVA I (§ 1–Čl. 2)");
+    expect(mixed.at(0)?.meta).toBe("§ 1–Čl. 2");
   });
 
   test("a container with no provisions under it is left as the act states it", () => {
@@ -313,18 +331,19 @@ describe("withProvisionRanges", () => {
     expect(ranged.map((item) => item.label)).toEqual(["ČÁST PRVNÍ", "HLAVA I"]);
   });
 
-  test("carries the annotation through untouched", () => {
+  test("carries the title through and states the range beside it", () => {
     const [cast] = withProvisionRanges([
       outlineItem({
         id: "cast",
-        label: "ČÁST PRVNÍ",
+        label: "Část první",
         level: 0,
-        meta: "OBECNÁ ČÁST",
+        title: "Obecná část",
       }),
       outlineItem({ id: "p", label: "§ 1", level: 1 }),
     ]);
 
-    expect(cast?.meta).toBe("OBECNÁ ČÁST");
+    expect(cast?.title).toBe("Obecná část");
+    expect(cast?.meta).toBe("§ 1");
   });
 });
 

--- a/apps/web/src/components/legal-reader/reader-outline.ts
+++ b/apps/web/src/components/legal-reader/reader-outline.ts
@@ -32,6 +32,36 @@ type HeadingLines = {
   secondary: string | undefined;
 };
 
+const ROMAN_NUMERAL_RE = /^[IVXLCDM]+$/u;
+
+/**
+ * A heading the publisher set in capitals, in sentence case: the outline
+ * lists hundreds of these in a narrow column, where capitals read heavier
+ * than the hierarchy they mark and truncate sooner. Mixed-case headings pass
+ * through untouched, and a Roman numeral keeps its capitals because it is
+ * a number, not a word.
+ */
+export const headingCase = (text: string): string => {
+  if (text !== text.toLocaleUpperCase() || !/\p{L}/u.test(text)) {
+    return text;
+  }
+
+  return text
+    .split(" ")
+    .map((word, index) => {
+      if (ROMAN_NUMERAL_RE.test(word)) {
+        return word;
+      }
+
+      const lower = word.toLocaleLowerCase();
+
+      return index === 0
+        ? lower.charAt(0).toLocaleUpperCase() + lower.slice(1)
+        : lower;
+    })
+    .join(" ");
+};
+
 const headingLines = (block: HeadingBlock): HeadingLines | null => {
   const lines = inlinesToPlainText(block.inlines)
     .split("\n")
@@ -69,9 +99,11 @@ export const outlineFromHeadings = (
 
     items.push({
       id: heading.anchorId,
-      label: lines.label,
+      label: headingCase(lines.label),
       level: depth,
-      ...(lines.secondary === undefined ? {} : { meta: lines.secondary }),
+      ...(lines.secondary === undefined
+        ? {}
+        : { title: headingCase(lines.secondary) }),
     });
   }
 
@@ -201,7 +233,7 @@ export const withProvisionRanges = (
       return item;
     }
 
-    return { ...item, label: `${item.label} (${spanOf(first, last)})` };
+    return { ...item, meta: spanOf(first, last) };
   });
 
 /**
@@ -294,7 +326,9 @@ export const filterOutlineItems = (
   const kept = new Set<number>();
 
   for (const [index, item] of items.entries()) {
-    const haystack = foldForMatch(`${item.label} ${item.meta ?? ""}`);
+    const haystack = foldForMatch(
+      `${item.label} ${item.title ?? ""} ${item.meta ?? ""}`,
+    );
 
     if (!haystack.includes(needle)) {
       continue;

--- a/packages/ui/src/components/outline-rail.tsx
+++ b/packages/ui/src/components/outline-rail.tsx
@@ -32,9 +32,13 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "./tooltip";
 export type OutlineItem = {
   id: string;
   label: string;
+  /** What the entry contains, after the label that names it. The label
+   *  stays whole; the title is what truncates when the row is narrow. */
+  title?: string;
   /** Nesting depth among included items; drives indent + tick taper. */
   level: number;
-  /** Optional trailing annotation in the panel (e.g. a page number). */
+  /** Optional trailing annotation in the panel (e.g. a page number or a
+   *  provision range); never truncated. */
   meta?: string;
   /** Optional CSS custom-property name colouring this entry's tick + chip
    *  (e.g. "--option-blue"). Defaults to the neutral foreground. */
@@ -78,6 +82,10 @@ const TICK_LEVEL_STEP = 2;
 const TICK_MAX_LEVEL = 5;
 // Cap visible ticks by pruning deeper levels; the popover still lists everything.
 const RAIL_MAX_TICKS = 40;
+
+/** The entry as one line of text: label, then its title when it has one. */
+const entryText = (item: OutlineItem): string =>
+  item.title === undefined ? item.label : `${item.label} ${item.title}`;
 
 const tickWidth = (level: number): number => {
   const clamped = Math.min(Math.max(level, 0), TICK_MAX_LEVEL);
@@ -500,7 +508,7 @@ export const OutlineRail = ({
               render={
                 <button
                   className={cn(
-                    "min-w-0 flex-1 truncate py-1.5 text-start text-[13px] leading-snug",
+                    "flex min-w-0 flex-1 items-baseline gap-1.5 py-1.5 text-start text-[13px] leading-snug",
                     rowTextClass(isActive, hasChildren),
                   )}
                   onClick={() => jumpTo(node.item.id)}
@@ -508,9 +516,20 @@ export const OutlineRail = ({
                 />
               }
             >
-              {node.item.label}
+              {node.item.title === undefined ? (
+                <span className="min-w-0 truncate">{node.item.label}</span>
+              ) : (
+                <>
+                  <span className="shrink-0 font-medium">
+                    {node.item.label}
+                  </span>
+                  <span className="min-w-0 truncate font-normal">
+                    {node.item.title}
+                  </span>
+                </>
+              )}
             </TooltipTrigger>
-            <TooltipPopup>{node.item.label}</TooltipPopup>
+            <TooltipPopup>{entryText(node.item)}</TooltipPopup>
           </Tooltip>
           {node.item.meta !== undefined && (
             <span className="text-foreground-placeholder shrink-0 ps-2 text-[11px] tabular-nums">


### PR DESCRIPTION
In the statute outline the title sat in the non-truncating trailing slot and the designation in the truncating one, so a long title squeezed the designation (the part the jump field keys on) to nothing.

- `OutlineItem` gains an optional `title`; the rail renders label (never truncated) · title (truncates) and keeps `meta` right-pinned in tabular numerals.
- Statute outline: designation → label, heading title → title, provision range → meta (`§ 1–654`), filter matches all three.
- Headings the publisher set in capitals are shown in sentence case; Roman numerals and mixed-case headings pass through.

Case-law outlines (label only) are unchanged.