### PR TITLE
chore: reseed the typecheck cost baseline

### DIFF
--- a/scripts/typecheck-baseline.json
+++ b/scripts/typecheck-baseline.json
@@ -1,14 +1,14 @@
 {
   "api": {
-    "types": 1086584,
-    "instantiations": 5850873
+    "types": 1138206,
+    "instantiations": 6109017
   },
   "web": {
-    "types": 1393624,
-    "instantiations": 10512726
+    "types": 1447880,
+    "instantiations": 10992290
   },
   "web-e2e": {
-    "types": 28479,
-    "instantiations": 35706
+    "types": 28709,
+    "instantiations": 35901
   }
 }


### PR DESCRIPTION
Reseeds `scripts/typecheck-baseline.json`. Nothing else is in the diff.

## Measurement

Taken on this branch, whose tree is `main` plus the baseline file itself:

| project | counter | committed baseline | measured | delta |
| --- | --- | ---: | ---: | ---: |
| api | types | 1,086,584 | 1,138,206 | +4.8% |
| api | instantiations | 5,850,873 | 6,109,017 | +4.4% |
| web | types | 1,393,624 | 1,447,880 | +3.9% |
| web | instantiations | 10,512,726 | 10,992,290 | +4.6% |
| web-e2e | types | 28,479 | 28,709 | +0.8% |
| web-e2e | instantiations | 35,706 | 35,901 | +0.5% |

Allowed headroom is 5% over baseline.

## Why now

The drift predates this change and belongs to no single commit: it accumulated
across merges, and `main` alone now sits 0.2 points under the ceiling on api
types. That leaves the guard measuring the backlog rather than the branch in
front of it — the next feature of any size trips it whatever its own cost, and
the fix would get folded into that feature's PR, which is exactly how a
whole-repo cost guard stops being readable.

Reseeding on its own commit records the drift as its own change, and leaves the
guard measuring new work again. It is a reseed, not a reduction: the burn-down
in `/conventions-perf` is unaffected and still worth doing.

Verified with `bun scripts/typecheck-baseline.ts --self-test` and `--check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated type-checking baseline metrics for API, web, and end-to-end web projects.
  * No user-facing functionality or behaviour has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->