### PR TITLE
fix(api): treat a decorative marker as a word boundary in AST validation

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
@@ -199,8 +199,10 @@ describe("validateAst", () => {
     test("keeps a mid-word anonymization marker joined", () => {
       // "[o]rganizace" anonymizes one letter inside a word: the
       // brackets are removed, not treated as a boundary, or the
-      // remainder ("rganizace") becomes a phantom missing word.
-      const html = wrapInHtml("[o]rganizace podala kasační stížnost");
+      // remainder ("rganizace") becomes a phantom missing word. The
+      // leading decorative marker puts both kinds of group in one
+      // token, so only the skippable one may become a boundary.
+      const html = wrapInHtml("[OBRÁZEK][o]rganizace podala kasační stížnost");
       const blocks: Block[] = [
         makeHeading("H"),
         makeBlock({ plainText: "podala kasační stížnost" }),

--- a/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
@@ -178,6 +178,40 @@ describe("validateAst", () => {
       }
     });
 
+    test("treats a decorative marker as a word boundary, not glue", () => {
+      // Real NSS pattern: image placeholders run flush against the
+      // heading text and against each other, with no whitespace
+      // between them. The space-separated form above cannot reach this
+      // path, because splitting on whitespace already separates it.
+      const html = wrapInHtml(
+        "[OBRÁZEK]ČESKÁ REPUBLIKA [OBRÁZEK][OBRÁZEK] rozsudek",
+      );
+      const blocks: Block[] = [
+        makeHeading("H"),
+        makeBlock({ plainText: "rozsudek" }),
+      ];
+
+      const result = validateAst(html, blocks);
+
+      expect(result.stats.missingWords).toEqual([]);
+    });
+
+    test("keeps a mid-word anonymization marker joined", () => {
+      // "[o]rganizace" anonymizes one letter inside a word: the
+      // brackets are removed, not treated as a boundary, or the
+      // remainder ("rganizace") becomes a phantom missing word.
+      const html = wrapInHtml("[o]rganizace podala kasační stížnost");
+      const blocks: Block[] = [
+        makeHeading("H"),
+        makeBlock({ plainText: "podala kasační stížnost" }),
+      ];
+
+      const result = validateAst(html, blocks);
+
+      expect(result.stats.missingWords).toContain("organizace");
+      expect(result.stats.missingWords).not.toContain("rganizace");
+    });
+
     test("respects custom maxMissingWords threshold", () => {
       const words = Array.from(
         { length: 30 },

--- a/apps/api/src/lib/legal-search/parsers/validate-ast.ts
+++ b/apps/api/src/lib/legal-search/parsers/validate-ast.ts
@@ -80,9 +80,24 @@ const trimNonLetters = (word: string): string => {
   return word.slice(start, end);
 };
 
+// A decorative marker sits flush against its neighbour in some source
+// HTML ("[OBRÁZEK]ČESKÁ", "[OBRÁZEK][OBRÁZEK]"). Deleting the brackets
+// alone fuses the marker to that neighbour, and the fused token
+// ("obrázekčeská") matches no SKIP_WORDS entry, so a marker the AST is
+// right to drop is reported missing. Same failure as the <br> gluing
+// handled in validateAst: make the boundary a separator. Only a group
+// whose content is itself skippable becomes one, because anonymization
+// markers are mid-word ("[o]rganizace") and must stay joined.
+const BRACKET_GROUP = /\[([^\]]*)\]/gu;
+
+const separateSkipMarkers = (text: string): string =>
+  text.replace(BRACKET_GROUP, (group, inner: string) =>
+    SKIP_WORDS.has(trimNonLetters(inner.toLowerCase())) ? " " : group,
+  );
+
 const extractWords = (text: string): Set<string> => {
   const words = new Set<string>();
-  for (const w of text.split(/\s+/u)) {
+  for (const w of separateSkipMarkers(text).split(/\s+/u)) {
     // Strip brackets first (anonymization markers like
     // "[o]rganizace" or "[OBRÁZEK]"), then trim remaining
     // non-letter chars from edges.

--- a/apps/api/src/lib/legal-search/parsers/validate-ast.ts
+++ b/apps/api/src/lib/legal-search/parsers/validate-ast.ts
@@ -88,12 +88,29 @@ const trimNonLetters = (word: string): string => {
 // handled in validateAst: make the boundary a separator. Only a group
 // whose content is itself skippable becomes one, because anonymization
 // markers are mid-word ("[o]rganizace") and must stay joined.
-const BRACKET_GROUP = /\[([^\]]*)\]/gu;
-
-const separateSkipMarkers = (text: string): string =>
-  text.replace(BRACKET_GROUP, (group, inner: string) =>
-    SKIP_WORDS.has(trimNonLetters(inner.toLowerCase())) ? " " : group,
-  );
+//
+// Scanned rather than matched with `/\[([^\]]*)\]/gu`: that literal is
+// super-linear under scslre (the `super-linear-regexes` ratchet is at 0
+// and stays there), and a court document is exactly the oversized input
+// that turns the backtracking into blocking CPU. Both indexOf cursors
+// only ever advance, so this is one pass over the text.
+const separateSkipMarkers = (text: string): string => {
+  let separated = "";
+  let index = 0;
+  while (index < text.length) {
+    const open = text.indexOf("[", index);
+    const close = open === -1 ? -1 : text.indexOf("]", open + 1);
+    if (close === -1) {
+      return separated + text.slice(index);
+    }
+    const marker = trimNonLetters(text.slice(open + 1, close).toLowerCase());
+    separated +=
+      text.slice(index, open) +
+      (SKIP_WORDS.has(marker) ? " " : text.slice(open, close + 1));
+    index = close + 1;
+  }
+  return separated;
+};
 
 const extractWords = (text: string): Set<string> => {
   const words = new Set<string>();


### PR DESCRIPTION
## Proposed change

`extractWords` in `apps/api/src/lib/legal-search/parsers/validate-ast.ts` deletes every bracket from a token before testing it against `SKIP_WORDS`. When a decorative marker sits flush against its neighbour, which is how NSS HTML emits it, the two fuse into a single token:

| source | token produced | in `SKIP_WORDS`? |
| --- | --- | --- |
| `[OBRÁZEK] ČESKÁ` | `obrázek`, `česká` | yes, both |
| `[OBRÁZEK]ČESKÁ` | `obrázekčeská` | no |
| `[OBRÁZEK][OBRÁZEK]` | `obrázekobrázek` | no |

`obrázek` and `česká` are both skip words, but fused neither is, so a marker the AST is correct to drop gets counted as a missing word. Enough of them push a complete AST past the `maxMissingWords` threshold and `validateAst` reports `MISSING_WORDS` against a parse that lost nothing.

The fix separates a bracket group only when its content is itself skippable. Other groups stay joined on purpose: anonymization markers are mid-word (`[o]rganizace`), and splitting those would leave a phantom `rganizace` that is genuinely absent from the AST. This mirrors the `$("br").replaceWith(" ")` handling already in `validateAst`, which makes the same boundary explicit for the same reason.

### Why the existing test did not catch it

`skips decorative skip words` uses `"[OBRÁZEK] ČESKÁ republika jménem republiky"` — with a space. Splitting on whitespace already separates that form, so the fixture cannot reach the code path where the fusing happens. The added test uses the flush form.

### Verification

- `bun test src/handlers/case-law/ingestion/parsers/validate-ast.test.ts` — 32 pass
- `bun test src/handlers/case-law/ingestion/parsers/ src/lib/legal-search/parsers/` — 201 pass across 9 files, covering every parser that calls `validateAst`
- Mutation check run: reverting the call site to `text.split(...)` fails the new test with exactly `["obrázekčeská", "obrázekobrázek"]`, so it is the fix the test is pinned to
- `oxlint --deny-warnings --type-aware --type-check` on both touched files, clean
- `tsc --noEmit -p apps/api/tsconfig.json`, clean
- `bun run format`, no changes

`retainedPct` and `CONTENT_LOSS` are computed from string lengths, not the word sets, so they are unaffected.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no UI surface.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrbKzLVLJyxwdZAandYfRd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved legal text parsing around bracketed markers for more reliable search results.
  - Prevented decorative markers from merging adjacent words or creating missing words.
  - Ensured mid-word anonymisation markers remain part of surrounding text without producing phantom remainder words.
  - Improved processing efficiency when handling multiple bracketed markers.

- **Tests**
  - Added coverage for adjacent decorative markers and mid-word anonymisation markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->