### PR TITLE
perf: tighten TypeScript type boundaries

### DIFF
--- a/packages/permissions/src/index.ts
+++ b/packages/permissions/src/index.ts
@@ -40,11 +40,11 @@ type PermissionMap = {
   [K in keyof typeof statements]: (typeof statements)[K][number][];
 };
 
-type RequireAtLeastOne<T> = {
-  [K in keyof T]-?: Required<Pick<T, K>> & Partial<Omit<T, K>>;
+type RequireAtLeastOne<T> = Partial<T> & {
+  [K in keyof T]-?: Pick<T, K>;
 }[keyof T];
 
-export type PermissionInput = RequireAtLeastOne<Partial<PermissionMap>>;
+export type PermissionInput = RequireAtLeastOne<PermissionMap>;
 
 export const ac = createAccessControl(statements);
 


### PR DESCRIPTION
## Summary

- factor the shared optional permission shape out of the non-empty permission union
- preserve the structural requirement that every permission input names at least one resource
- measure TypeScript type and instantiation cost before retaining further boundary changes

This pull request remains draft while the isolated type-cost experiments are measured.