### PR TITLE
feat(ui): export resource calendar

### DIFF
--- a/.changeset/calm-calendars-share.md
+++ b/.changeset/calm-calendars-share.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": minor
+---
+
+Export entity-agnostic calendar primitives and a resource calendar with half-open date-range placement.

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-day-cell.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-day-cell.tsx
@@ -4,6 +4,7 @@ import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/adapter
 import { PlusIcon, SquareCheckIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { CalendarCell } from "@stll/ui/calendar";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@stll/ui/menu";
 import { containedEventHandler } from "@stll/ui/use-contained-handler";
 import { cn } from "@stll/ui/utils";
@@ -117,11 +118,11 @@ export const CalendarDayCell = ({
   }, [announcementDate, isEditable, handleEntityDrop]);
 
   return (
-    <div
+    <CalendarCell
       ref={dropRef}
       className={cn(
         "group/day relative flex flex-col gap-0.5",
-        "overflow-hidden border-e border-b p-1",
+        "overflow-hidden p-1",
         !day.isCurrentMonth && "bg-muted/30",
         day.monthTone === "muted" && "bg-muted/10",
         day.isWeekend && day.isCurrentMonth && "bg-muted/15",
@@ -218,6 +219,6 @@ export const CalendarDayCell = ({
           </MenuPopup>
         </Menu>
       )}
-    </div>
+    </CalendarCell>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-entity-chip.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-entity-chip.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "use-intl";
 
 import { isTaskStatus } from "@stll/api-contract";
 import type { TaskStatus } from "@stll/api-contract";
+import { CalendarEntryButton } from "@stll/ui/calendar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "@stll/ui/tooltip";
 import { containedHandler } from "@stll/ui/use-contained-handler";
 import { cn } from "@stll/ui/utils";
@@ -102,7 +103,7 @@ export const CalendarEntityChip = ({
   });
 
   const card = (
-    <button
+    <CalendarEntryButton
       ref={dragRef}
       className={cn(
         "bg-card w-full rounded border border-s-2 px-1.5 py-0.5",
@@ -115,12 +116,11 @@ export const CalendarEntityChip = ({
       )}
       // eslint-disable-next-line react/react-compiler -- containedHandler house pattern; dragRef is handed to the helper, not read for rendered output
       onClick={containedHandler(dragRef, handleClick)}
-      type="button"
     >
       <span className="flex min-w-0 items-center gap-1">
         <span className="truncate">{name}</span>
       </span>
-    </button>
+    </CalendarEntryButton>
   );
 
   return (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-week-header.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-week-header.tsx
@@ -1,3 +1,4 @@
+import { CalendarHeaderCell, CalendarHeaderRow } from "@stll/ui/calendar";
 import { cn } from "@stll/ui/utils";
 
 type CalendarWeekHeaderProps = {
@@ -11,22 +12,18 @@ export const CalendarWeekHeader = ({
   firstWeekday,
   weekend,
 }: CalendarWeekHeaderProps) => (
-  <div className="grid grid-cols-7 border-b">
+  <CalendarHeaderRow className="grid-cols-7">
     {weekdayLabels.map((label, i) => {
       const dayOfWeek = (firstWeekday + i) % 7;
       const isWeekend = weekend.has(dayOfWeek);
       return (
-        <div
-          className={cn(
-            "px-2 py-1 text-center text-xs font-medium",
-            "text-muted-foreground",
-            isWeekend && "bg-muted/20",
-          )}
+        <CalendarHeaderCell
+          className={cn("border-e-0 py-1", isWeekend && "bg-muted/20")}
           key={label}
         >
           {label}
-        </div>
+        </CalendarHeaderCell>
       );
     })}
-  </div>
+  </CalendarHeaderRow>
 );

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,6 +43,7 @@
     "./color-picker": "./src/components/color-picker.tsx",
     "./combobox": "./src/components/combobox.tsx",
     "./command": "./src/components/command.tsx",
+    "./calendar": "./src/calendar/index.ts",
     "./data-table": "./src/data-table/index.ts",
     "./date-picker-popover": "./src/components/date-picker-popover.tsx",
     "./destructive-action-confirmation": "./src/components/destructive-action-confirmation.tsx",

--- a/packages/ui/src/calendar/index.ts
+++ b/packages/ui/src/calendar/index.ts
@@ -1,0 +1,24 @@
+export {
+  CalendarCell,
+  CalendarEntryButton,
+  CalendarEntrySurface,
+  CalendarGrid,
+  CalendarHeaderCell,
+  CalendarHeaderRow,
+} from "./primitives";
+export type {
+  CalendarDateRange,
+  ResourceCalendarPlacement,
+} from "./resource-calendar.logic";
+export {
+  assertConsecutiveCalendarDates,
+  getResourceCalendarPlacement,
+  nextCalendarDate,
+} from "./resource-calendar.logic";
+export type {
+  ResourceCalendarColumn,
+  ResourceCalendarEntry,
+  ResourceCalendarEntryTone,
+  ResourceCalendarResource,
+} from "./resource-calendar";
+export { ResourceCalendar } from "./resource-calendar";

--- a/packages/ui/src/calendar/index.ts
+++ b/packages/ui/src/calendar/index.ts
@@ -8,11 +8,14 @@ export {
 } from "./primitives";
 export type {
   CalendarDateRange,
+  ResourceCalendarLaneLayout,
+  ResourceCalendarLanePlacement,
   ResourceCalendarPlacement,
 } from "./resource-calendar.logic";
 export {
   assertConsecutiveCalendarDates,
   getResourceCalendarPlacement,
+  layoutResourceCalendarEntries,
   nextCalendarDate,
 } from "./resource-calendar.logic";
 export type {

--- a/packages/ui/src/calendar/primitives.tsx
+++ b/packages/ui/src/calendar/primitives.tsx
@@ -51,7 +51,7 @@ export const CalendarEntryButton = ({
 }: React.ComponentProps<"button">) => (
   <button
     className={cn(
-      "focus-visible:ring-ring min-w-0 rounded-md text-start text-xs outline-none focus-visible:ring-2",
+      "focus-visible:ring-ring min-w-0 rounded-md text-start text-xs outline-none focus-visible:ring-2 focus-visible:ring-offset-1",
       className,
     )}
     data-slot="calendar-entry"

--- a/packages/ui/src/calendar/primitives.tsx
+++ b/packages/ui/src/calendar/primitives.tsx
@@ -1,0 +1,72 @@
+import type * as React from "react";
+
+import { cn } from "../lib/utils";
+
+export const CalendarGrid = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div className={cn("grid", className)} data-slot="calendar-grid" {...props} />
+);
+
+export const CalendarHeaderRow = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn("grid border-b", className)}
+    data-slot="calendar-header-row"
+    {...props}
+  />
+);
+
+export const CalendarHeaderCell = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn(
+      "text-muted-foreground border-e px-2 py-2 text-center text-xs font-medium last:border-e-0",
+      className,
+    )}
+    data-slot="calendar-header-cell"
+    {...props}
+  />
+);
+
+export const CalendarCell = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn("border-e border-b", className)}
+    data-slot="calendar-cell"
+    {...props}
+  />
+);
+
+export const CalendarEntryButton = ({
+  className,
+  ...props
+}: React.ComponentProps<"button">) => (
+  <button
+    className={cn(
+      "focus-visible:ring-ring min-w-0 rounded-md text-start text-xs outline-none focus-visible:ring-2",
+      className,
+    )}
+    data-slot="calendar-entry"
+    type="button"
+    {...props}
+  />
+);
+
+export const CalendarEntrySurface = ({
+  className,
+  ...props
+}: React.ComponentProps<"article">) => (
+  <article
+    className={cn("min-w-0 rounded-md text-start text-xs", className)}
+    data-slot="calendar-entry"
+    {...props}
+  />
+);

--- a/packages/ui/src/calendar/resource-calendar.logic.test.ts
+++ b/packages/ui/src/calendar/resource-calendar.logic.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  assertConsecutiveCalendarDates,
+  getResourceCalendarPlacement,
+} from "./resource-calendar.logic";
+
+describe("resource calendar placement", () => {
+  const visibleRange = {
+    endDateExclusive: "2026-08-08",
+    startDate: "2026-08-01",
+  };
+
+  test("clips half-open entries to the visible columns", () => {
+    expect(
+      getResourceCalendarPlacement({
+        entry: {
+          endDateExclusive: "2026-08-04",
+          startDate: "2026-07-30",
+        },
+        visibleRange,
+      }),
+    ).toEqual({ columnStart: 2, span: 3 });
+    expect(
+      getResourceCalendarPlacement({
+        entry: {
+          endDateExclusive: "2026-08-10",
+          startDate: "2026-08-06",
+        },
+        visibleRange,
+      }),
+    ).toEqual({ columnStart: 7, span: 2 });
+  });
+
+  test("does not place adjacent or disjoint entries", () => {
+    expect(
+      getResourceCalendarPlacement({
+        entry: {
+          endDateExclusive: visibleRange.startDate,
+          startDate: "2026-07-30",
+        },
+        visibleRange,
+      }),
+    ).toBeNull();
+    expect(
+      getResourceCalendarPlacement({
+        entry: {
+          endDateExclusive: "2026-08-10",
+          startDate: visibleRange.endDateExclusive,
+        },
+        visibleRange,
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects empty ranges and nonconsecutive columns", () => {
+    expect(() =>
+      getResourceCalendarPlacement({
+        entry: {
+          endDateExclusive: "2026-08-02",
+          startDate: "2026-08-02",
+        },
+        visibleRange,
+      }),
+    ).toThrow("Calendar date ranges must be non-empty and half-open");
+    expect(() =>
+      assertConsecutiveCalendarDates(["2026-08-01", "2026-08-03"]),
+    ).toThrow(
+      "Resource calendar date columns must be consecutive normalized dates",
+    );
+    expect(() => assertConsecutiveCalendarDates(["2026-02-30"])).toThrow(
+      "Resource calendar date columns must be consecutive normalized dates",
+    );
+  });
+});

--- a/packages/ui/src/calendar/resource-calendar.logic.test.ts
+++ b/packages/ui/src/calendar/resource-calendar.logic.test.ts
@@ -88,26 +88,24 @@ describe("resource calendar placement", () => {
   });
 
   test("puts overlapping entries in separate lanes and reuses adjacent lanes", () => {
-    const layout = layoutResourceCalendarEntries(
-      [
-        {
-          endDateExclusive: "2026-08-04",
-          id: "first",
-          startDate: "2026-08-01",
-        },
-        {
-          endDateExclusive: "2026-08-03",
-          id: "overlap",
-          startDate: "2026-08-02",
-        },
-        {
-          endDateExclusive: "2026-08-05",
-          id: "adjacent",
-          startDate: "2026-08-04",
-        },
-      ],
-      visibleRange,
-    );
+    const entries = [
+      {
+        endDateExclusive: "2026-08-04",
+        id: "first",
+        startDate: "2026-08-01",
+      },
+      {
+        endDateExclusive: "2026-08-03",
+        id: "overlap",
+        startDate: "2026-08-02",
+      },
+      {
+        endDateExclusive: "2026-08-05",
+        id: "adjacent",
+        startDate: "2026-08-04",
+      },
+    ] as const;
+    const layout = layoutResourceCalendarEntries(entries, visibleRange);
 
     expect(layout.rowCount).toBe(2);
     expect(layout.placements).toEqual([
@@ -115,5 +113,8 @@ describe("resource calendar placement", () => {
       { columnStart: 3, entryId: "overlap", rowStart: 2, span: 1 },
       { columnStart: 5, entryId: "adjacent", rowStart: 1, span: 1 },
     ]);
+    expect(
+      layoutResourceCalendarEntries(entries.toReversed(), visibleRange),
+    ).toEqual(layout);
   });
 });

--- a/packages/ui/src/calendar/resource-calendar.logic.test.ts
+++ b/packages/ui/src/calendar/resource-calendar.logic.test.ts
@@ -4,6 +4,7 @@ import {
   assertConsecutiveCalendarDates,
   getResourceCalendarPlacement,
   layoutResourceCalendarEntries,
+  nextCalendarDate,
 } from "./resource-calendar.logic";
 
 describe("resource calendar placement", () => {
@@ -85,6 +86,12 @@ describe("resource calendar placement", () => {
     expect(() =>
       assertConsecutiveCalendarDates(["2026-12-31", "2027-01-01"]),
     ).not.toThrow();
+  });
+
+  test("rejects a date whose following day exceeds the normalized range", () => {
+    expect(() => nextCalendarDate("9999-12-31")).toThrow(
+      "Calendar dates must have a following normalized YYYY-MM-DD value",
+    );
   });
 
   test("puts overlapping entries in separate lanes and reuses adjacent lanes", () => {

--- a/packages/ui/src/calendar/resource-calendar.logic.test.ts
+++ b/packages/ui/src/calendar/resource-calendar.logic.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   assertConsecutiveCalendarDates,
   getResourceCalendarPlacement,
+  layoutResourceCalendarEntries,
 } from "./resource-calendar.logic";
 
 describe("resource calendar placement", () => {
@@ -84,5 +85,35 @@ describe("resource calendar placement", () => {
     expect(() =>
       assertConsecutiveCalendarDates(["2026-12-31", "2027-01-01"]),
     ).not.toThrow();
+  });
+
+  test("puts overlapping entries in separate lanes and reuses adjacent lanes", () => {
+    const layout = layoutResourceCalendarEntries(
+      [
+        {
+          endDateExclusive: "2026-08-04",
+          id: "first",
+          startDate: "2026-08-01",
+        },
+        {
+          endDateExclusive: "2026-08-03",
+          id: "overlap",
+          startDate: "2026-08-02",
+        },
+        {
+          endDateExclusive: "2026-08-05",
+          id: "adjacent",
+          startDate: "2026-08-04",
+        },
+      ],
+      visibleRange,
+    );
+
+    expect(layout.rowCount).toBe(2);
+    expect(layout.placements).toEqual([
+      { columnStart: 2, entryId: "first", rowStart: 1, span: 3 },
+      { columnStart: 3, entryId: "overlap", rowStart: 2, span: 1 },
+      { columnStart: 5, entryId: "adjacent", rowStart: 1, span: 1 },
+    ]);
   });
 });

--- a/packages/ui/src/calendar/resource-calendar.logic.test.ts
+++ b/packages/ui/src/calendar/resource-calendar.logic.test.ts
@@ -72,4 +72,17 @@ describe("resource calendar placement", () => {
       "Resource calendar date columns must be consecutive normalized dates",
     );
   });
+
+  test("keeps leap-day and year boundaries consecutive in UTC", () => {
+    expect(() =>
+      assertConsecutiveCalendarDates([
+        "2024-02-28",
+        "2024-02-29",
+        "2024-03-01",
+      ]),
+    ).not.toThrow();
+    expect(() =>
+      assertConsecutiveCalendarDates(["2026-12-31", "2027-01-01"]),
+    ).not.toThrow();
+  });
 });

--- a/packages/ui/src/calendar/resource-calendar.logic.ts
+++ b/packages/ui/src/calendar/resource-calendar.logic.ts
@@ -8,6 +8,16 @@ export type ResourceCalendarPlacement = {
   span: number;
 };
 
+export type ResourceCalendarLanePlacement = ResourceCalendarPlacement & {
+  entryId: string;
+  rowStart: number;
+};
+
+export type ResourceCalendarLaneLayout = {
+  placements: ResourceCalendarLanePlacement[];
+  rowCount: number;
+};
+
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
 const DAY_IN_MS = 86_400_000;
 
@@ -111,4 +121,60 @@ export const nextCalendarDate = (value: string): string => {
   }
   date.setUTCDate(date.getUTCDate() + 1);
   return date.toISOString().slice(0, 10);
+};
+
+export const layoutResourceCalendarEntries = (
+  entries: readonly (CalendarDateRange & { id: string })[],
+  visibleRange: CalendarDateRange,
+): ResourceCalendarLaneLayout => {
+  const visibleEntries: (ResourceCalendarPlacement & {
+    entryId: string;
+    inputOrder: number;
+  })[] = [];
+  const entryIds = new Set<string>();
+  for (const [inputOrder, entry] of entries.entries()) {
+    if (entryIds.has(entry.id)) {
+      throw new TypeError("Resource calendar entry ids must be unique");
+    }
+    entryIds.add(entry.id);
+    const placement = getResourceCalendarPlacement({ entry, visibleRange });
+    if (placement === null) {
+      continue;
+    }
+    visibleEntries.push({
+      columnStart: placement.columnStart,
+      entryId: entry.id,
+      inputOrder,
+      span: placement.span,
+    });
+  }
+  visibleEntries.sort((left, right) => {
+    const startDifference = left.columnStart - right.columnStart;
+    if (startDifference !== 0) {
+      return startDifference;
+    }
+    return left.inputOrder - right.inputOrder;
+  });
+
+  const laneEnds: number[] = [];
+  const placements: ResourceCalendarLanePlacement[] = [];
+  for (const entry of visibleEntries) {
+    const firstAvailableLane = laneEnds.findIndex(
+      (laneEnd) => laneEnd <= entry.columnStart,
+    );
+    const lane =
+      firstAvailableLane === -1 ? laneEnds.length : firstAvailableLane;
+    laneEnds[lane] = entry.columnStart + entry.span;
+    placements.push({
+      columnStart: entry.columnStart,
+      entryId: entry.entryId,
+      rowStart: lane + 1,
+      span: entry.span,
+    });
+  }
+
+  return {
+    placements,
+    rowCount: Math.max(1, laneEnds.length),
+  };
 };

--- a/packages/ui/src/calendar/resource-calendar.logic.ts
+++ b/packages/ui/src/calendar/resource-calendar.logic.ts
@@ -1,0 +1,114 @@
+export type CalendarDateRange = {
+  endDateExclusive: string;
+  startDate: string;
+};
+
+export type ResourceCalendarPlacement = {
+  columnStart: number;
+  span: number;
+};
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
+const DAY_IN_MS = 86_400_000;
+
+const toUTCDate = (value: string): Date | null => {
+  if (!ISO_DATE_PATTERN.test(value)) {
+    return null;
+  }
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return date.toISOString().slice(0, 10) === value ? date : null;
+};
+
+const differenceInCalendarDays = (later: string, earlier: string): number => {
+  const laterDate = toUTCDate(later);
+  const earlierDate = toUTCDate(earlier);
+  if (laterDate === null || earlierDate === null) {
+    throw new RangeError(
+      "Calendar dates must use normalized YYYY-MM-DD values",
+    );
+  }
+  return (laterDate.getTime() - earlierDate.getTime()) / DAY_IN_MS;
+};
+
+export const getResourceCalendarPlacement = ({
+  entry,
+  visibleRange,
+}: {
+  entry: CalendarDateRange;
+  visibleRange: CalendarDateRange;
+}): ResourceCalendarPlacement | null => {
+  const visibleDayCount = differenceInCalendarDays(
+    visibleRange.endDateExclusive,
+    visibleRange.startDate,
+  );
+  const entryDayCount = differenceInCalendarDays(
+    entry.endDateExclusive,
+    entry.startDate,
+  );
+  if (visibleDayCount <= 0 || entryDayCount <= 0) {
+    throw new RangeError(
+      "Calendar date ranges must be non-empty and half-open",
+    );
+  }
+  if (
+    entry.startDate >= visibleRange.endDateExclusive ||
+    entry.endDateExclusive <= visibleRange.startDate
+  ) {
+    return null;
+  }
+
+  const clippedStart =
+    entry.startDate < visibleRange.startDate
+      ? visibleRange.startDate
+      : entry.startDate;
+  const clippedEnd =
+    entry.endDateExclusive > visibleRange.endDateExclusive
+      ? visibleRange.endDateExclusive
+      : entry.endDateExclusive;
+
+  return {
+    columnStart:
+      differenceInCalendarDays(clippedStart, visibleRange.startDate) + 2,
+    span: differenceInCalendarDays(clippedEnd, clippedStart),
+  };
+};
+
+export const assertConsecutiveCalendarDates = (
+  dates: readonly string[],
+): void => {
+  if (dates.length === 0) {
+    throw new RangeError("A resource calendar needs at least one date column");
+  }
+
+  const first = dates.at(0);
+  if (first === undefined || toUTCDate(first) === null) {
+    throw new RangeError(
+      "Resource calendar date columns must be consecutive normalized dates",
+    );
+  }
+
+  for (let index = 1; index < dates.length; index += 1) {
+    const previous = dates.at(index - 1);
+    const current = dates.at(index);
+    if (
+      previous === undefined ||
+      current === undefined ||
+      differenceInCalendarDays(current, previous) !== 1
+    ) {
+      throw new RangeError(
+        "Resource calendar date columns must be consecutive normalized dates",
+      );
+    }
+  }
+};
+
+export const nextCalendarDate = (value: string): string => {
+  const date = toUTCDate(value);
+  if (date === null) {
+    throw new RangeError(
+      "Calendar dates must use normalized YYYY-MM-DD values",
+    );
+  }
+  date.setUTCDate(date.getUTCDate() + 1);
+  return date.toISOString().slice(0, 10);
+};

--- a/packages/ui/src/calendar/resource-calendar.logic.ts
+++ b/packages/ui/src/calendar/resource-calendar.logic.ts
@@ -120,7 +120,13 @@ export const nextCalendarDate = (value: string): string => {
     );
   }
   date.setUTCDate(date.getUTCDate() + 1);
-  return date.toISOString().slice(0, 10);
+  const nextDate = date.toISOString().slice(0, 10);
+  if (toUTCDate(nextDate) === null) {
+    throw new RangeError(
+      "Calendar dates must have a following normalized YYYY-MM-DD value",
+    );
+  }
+  return nextDate;
 };
 
 export const layoutResourceCalendarEntries = (

--- a/packages/ui/src/calendar/resource-calendar.logic.ts
+++ b/packages/ui/src/calendar/resource-calendar.logic.ts
@@ -129,10 +129,9 @@ export const layoutResourceCalendarEntries = (
 ): ResourceCalendarLaneLayout => {
   const visibleEntries: (ResourceCalendarPlacement & {
     entryId: string;
-    inputOrder: number;
   })[] = [];
   const entryIds = new Set<string>();
-  for (const [inputOrder, entry] of entries.entries()) {
+  for (const entry of entries) {
     if (entryIds.has(entry.id)) {
       throw new TypeError("Resource calendar entry ids must be unique");
     }
@@ -144,7 +143,6 @@ export const layoutResourceCalendarEntries = (
     visibleEntries.push({
       columnStart: placement.columnStart,
       entryId: entry.id,
-      inputOrder,
       span: placement.span,
     });
   }
@@ -153,7 +151,13 @@ export const layoutResourceCalendarEntries = (
     if (startDifference !== 0) {
       return startDifference;
     }
-    return left.inputOrder - right.inputOrder;
+    if (left.entryId < right.entryId) {
+      return -1;
+    }
+    if (left.entryId > right.entryId) {
+      return 1;
+    }
+    return 0;
   });
 
   const laneEnds: number[] = [];

--- a/packages/ui/src/calendar/resource-calendar.test.tsx
+++ b/packages/ui/src/calendar/resource-calendar.test.tsx
@@ -88,6 +88,7 @@ describe("ResourceCalendar", () => {
             label: "First hearing",
             resourceId: "room-a",
             startDate: "2026-08-01",
+            tone: "warning",
           },
           {
             accessibleLabel: "Second hearing in Room A",
@@ -96,6 +97,7 @@ describe("ResourceCalendar", () => {
             label: "Second hearing",
             resourceId: "room-a",
             startDate: "2026-08-01",
+            tone: "destructive",
           },
         ]}
         onSelectEntry={() => undefined}
@@ -108,6 +110,8 @@ describe("ResourceCalendar", () => {
     expect(markup.match(/block-size:50%/gu)).toHaveLength(2);
     expect(markup.match(/role="gridcell"/gu)).toHaveLength(columns.length);
     expect(markup.match(/<button/gu)).toHaveLength(2);
+    expect(markup).toContain("bg-warning/15 text-warning-foreground");
+    expect(markup).toContain("bg-destructive/12 text-destructive");
   });
 
   test("rejects entries whose resource is absent", () => {

--- a/packages/ui/src/calendar/resource-calendar.test.tsx
+++ b/packages/ui/src/calendar/resource-calendar.test.tsx
@@ -35,8 +35,37 @@ describe("ResourceCalendar", () => {
     expect(markup).toContain("Room A");
     expect(markup).toContain("Hearing");
     expect(markup).toContain("grid-column:2 / span 2");
+    expect(markup).toContain("min-width:28rem");
+    expect(markup).toContain("sticky start-0 z-20");
     expect(markup).toContain("<article");
     expect(markup).not.toContain("disabled");
+  });
+
+  test("renders selectable entries as non-submitting keyboard controls", () => {
+    const markup = renderToStaticMarkup(
+      <ResourceCalendar
+        ariaLabel="Room schedule"
+        columns={columns}
+        entries={[
+          {
+            accessibleLabel: "Hearing in Room A",
+            endDateExclusive: "2026-08-02",
+            id: "hearing-1",
+            label: "Hearing",
+            resourceId: "room-a",
+            startDate: "2026-08-01",
+          },
+        ]}
+        onSelectEntry={() => undefined}
+        resourceHeader="Room"
+        resources={resources}
+      />,
+    );
+
+    expect(markup).toContain("<button");
+    expect(markup).toContain('aria-label="Hearing in Room A"');
+    expect(markup).toContain('type="button"');
+    expect(markup).toContain("focus-visible:ring-2");
   });
 
   test("rejects entries whose resource is absent", () => {

--- a/packages/ui/src/calendar/resource-calendar.test.tsx
+++ b/packages/ui/src/calendar/resource-calendar.test.tsx
@@ -1,0 +1,66 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import { ResourceCalendar } from "./resource-calendar";
+
+const columns = [
+  { date: "2026-08-01", label: "Saturday" },
+  { date: "2026-08-02", label: "Sunday" },
+] as const;
+const resources = [{ id: "room-a", label: "Room A" }] as const;
+
+describe("ResourceCalendar", () => {
+  test("renders a complete read-only resource row and clips its entry", () => {
+    const markup = renderToStaticMarkup(
+      <ResourceCalendar
+        ariaLabel="Room schedule"
+        columns={columns}
+        entries={[
+          {
+            accessibleLabel: "Hearing in Room A",
+            endDateExclusive: "2026-08-03",
+            id: "hearing-1",
+            label: "Hearing",
+            resourceId: "room-a",
+            startDate: "2026-07-31",
+          },
+        ]}
+        resourceHeader="Room"
+        resources={resources}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Room schedule"');
+    expect(markup).toContain("Room A");
+    expect(markup).toContain("Hearing");
+    expect(markup).toContain("grid-column:2 / span 2");
+    expect(markup).toContain("<article");
+    expect(markup).not.toContain("disabled");
+  });
+
+  test("rejects entries whose resource is absent", () => {
+    expect(() =>
+      renderToStaticMarkup(
+        <ResourceCalendar
+          ariaLabel="Room schedule"
+          columns={columns}
+          entries={[
+            {
+              accessibleLabel: "Orphan hearing",
+              endDateExclusive: "2026-08-02",
+              id: "hearing-1",
+              label: "Hearing",
+              resourceId: "missing-room",
+              startDate: "2026-08-01",
+            },
+          ]}
+          resourceHeader="Room"
+          resources={resources}
+        />,
+      ),
+    ).toThrow(
+      "Resource calendar entry hearing-1 references an unknown resource",
+    );
+  });
+});

--- a/packages/ui/src/calendar/resource-calendar.test.tsx
+++ b/packages/ui/src/calendar/resource-calendar.test.tsx
@@ -37,6 +37,11 @@ describe("ResourceCalendar", () => {
     expect(markup).toContain("grid-column:2 / span 2");
     expect(markup).toContain("min-width:28rem");
     expect(markup).toContain("sticky start-0 z-20");
+    expect(markup).toContain('role="table"');
+    expect(markup).toContain('role="columnheader"');
+    expect(markup).toContain('role="rowheader"');
+    expect(markup).toContain('role="gridcell"');
+    expect(markup).toContain("aria-labelledby");
     expect(markup).toContain("<article");
     expect(markup).not.toContain("disabled");
   });

--- a/packages/ui/src/calendar/resource-calendar.test.tsx
+++ b/packages/ui/src/calendar/resource-calendar.test.tsx
@@ -110,8 +110,8 @@ describe("ResourceCalendar", () => {
     expect(markup.match(/block-size:50%/gu)).toHaveLength(2);
     expect(markup.match(/role="gridcell"/gu)).toHaveLength(columns.length);
     expect(markup.match(/<button/gu)).toHaveLength(2);
-    expect(markup).toContain("bg-warning/15 text-warning-foreground");
-    expect(markup).toContain("bg-destructive/12 text-destructive");
+    expect(markup).toContain("bg-warning/15 text-foreground");
+    expect(markup).toContain("bg-destructive/12 text-foreground");
   });
 
   test("rejects entries whose resource is absent", () => {

--- a/packages/ui/src/calendar/resource-calendar.test.tsx
+++ b/packages/ui/src/calendar/resource-calendar.test.tsx
@@ -34,14 +34,15 @@ describe("ResourceCalendar", () => {
     expect(markup).toContain('aria-label="Room schedule"');
     expect(markup).toContain("Room A");
     expect(markup).toContain("Hearing");
-    expect(markup).toContain("grid-column:2 / span 2");
+    expect(markup).toContain("inline-size:calc(2 * 100%)");
     expect(markup).toContain("min-width:28rem");
     expect(markup).toContain("sticky start-0 z-20");
     expect(markup).toContain('role="table"');
     expect(markup).toContain('role="columnheader"');
     expect(markup).toContain('role="rowheader"');
     expect(markup).toContain('role="gridcell"');
-    expect(markup).toContain("aria-labelledby");
+    expect(markup.match(/role="gridcell"/gu)).toHaveLength(columns.length);
+    expect(markup).toContain("aria-describedby");
     expect(markup).toContain("<article");
     expect(markup).not.toContain("disabled");
   });
@@ -70,7 +71,43 @@ describe("ResourceCalendar", () => {
     expect(markup).toContain("<button");
     expect(markup).toContain('aria-label="Hearing in Room A"');
     expect(markup).toContain('type="button"');
+    expect(markup).toContain("min-height:5rem");
     expect(markup).toContain("focus-visible:ring-2");
+  });
+
+  test("grows collision lanes without adding logical table cells", () => {
+    const markup = renderToStaticMarkup(
+      <ResourceCalendar
+        ariaLabel="Room schedule"
+        columns={columns}
+        entries={[
+          {
+            accessibleLabel: "First hearing in Room A",
+            endDateExclusive: "2026-08-02",
+            id: "hearing-1",
+            label: "First hearing",
+            resourceId: "room-a",
+            startDate: "2026-08-01",
+          },
+          {
+            accessibleLabel: "Second hearing in Room A",
+            endDateExclusive: "2026-08-02",
+            id: "hearing-2",
+            label: "Second hearing",
+            resourceId: "room-a",
+            startDate: "2026-08-01",
+          },
+        ]}
+        onSelectEntry={() => undefined}
+        resourceHeader="Room"
+        resources={resources}
+      />,
+    );
+
+    expect(markup).toContain("min-height:7.5rem");
+    expect(markup.match(/block-size:50%/gu)).toHaveLength(2);
+    expect(markup.match(/role="gridcell"/gu)).toHaveLength(columns.length);
+    expect(markup.match(/<button/gu)).toHaveLength(2);
   });
 
   test("rejects entries whose resource is absent", () => {

--- a/packages/ui/src/calendar/resource-calendar.tsx
+++ b/packages/ui/src/calendar/resource-calendar.tsx
@@ -238,10 +238,9 @@ export const ResourceCalendar = ({
 
 const RESOURCE_CALENDAR_ENTRY_TONES = {
   accent: "bg-primary text-primary-foreground",
-  destructive:
-    "border-destructive/32 bg-destructive/12 text-destructive border",
+  destructive: "border-destructive/32 bg-destructive/12 text-foreground border",
   neutral: "border-border bg-muted text-foreground border",
-  warning: "border-warning/30 bg-warning/15 text-warning-foreground border",
+  warning: "border-warning/30 bg-warning/15 text-foreground border",
 } as const satisfies Record<ResourceCalendarEntryTone, string>;
 
 const ResourceCalendarEntryView = ({

--- a/packages/ui/src/calendar/resource-calendar.tsx
+++ b/packages/ui/src/calendar/resource-calendar.tsx
@@ -238,9 +238,10 @@ export const ResourceCalendar = ({
 
 const RESOURCE_CALENDAR_ENTRY_TONES = {
   accent: "bg-primary text-primary-foreground",
-  destructive: "bg-destructive text-destructive-foreground",
+  destructive:
+    "border-destructive/32 bg-destructive/12 text-destructive border",
   neutral: "border-border bg-muted text-foreground border",
-  warning: "bg-warning text-warning-foreground",
+  warning: "border-warning/30 bg-warning/15 text-warning-foreground border",
 } as const satisfies Record<ResourceCalendarEntryTone, string>;
 
 const ResourceCalendarEntryView = ({

--- a/packages/ui/src/calendar/resource-calendar.tsx
+++ b/packages/ui/src/calendar/resource-calendar.tsx
@@ -14,6 +14,7 @@ import {
   layoutResourceCalendarEntries,
   nextCalendarDate,
 } from "./resource-calendar.logic";
+import type { ResourceCalendarLanePlacement } from "./resource-calendar.logic";
 
 export type ResourceCalendarColumn = {
   date: string;
@@ -52,6 +53,11 @@ type ResourceCalendarProps = {
   onSelectEntry?: (entry: ResourceCalendarEntry) => void;
   resourceHeader: ReactNode;
   resources: readonly ResourceCalendarResource[];
+};
+
+type PlacedResourceCalendarEntry = {
+  entry: ResourceCalendarEntry;
+  placement: ResourceCalendarLanePlacement;
 };
 
 export const ResourceCalendar = ({
@@ -133,15 +139,33 @@ export const ResourceCalendar = ({
             resourceEntries,
             visibleRange,
           );
-          const placementsByEntryId = new Map(
-            layout.placements.map((placement) => [
-              placement.entryId,
-              placement,
-            ]),
+          const resourceEntryById = new Map(
+            resourceEntries.map((entry) => [entry.id, entry]),
           );
+          const visibleEntriesByColumn = new Map<
+            number,
+            PlacedResourceCalendarEntry[]
+          >();
+          for (const placement of layout.placements) {
+            const entry = resourceEntryById.get(placement.entryId);
+            if (entry === undefined) {
+              throw new TypeError(
+                `Resource calendar layout references unknown entry ${placement.entryId}`,
+              );
+            }
+            const existing = visibleEntriesByColumn.get(placement.columnStart);
+            if (existing === undefined) {
+              visibleEntriesByColumn.set(placement.columnStart, [
+                { entry, placement },
+              ]);
+              continue;
+            }
+            existing.push({ entry, placement });
+          }
           const resourceHeaderId = `${calendarId}-resource-${String(resourceIndex)}`;
-          const spanningCellStyle = {
-            gridRow: `1 / span ${String(layout.rowCount)}`,
+          const resourceRowStyle = {
+            ...gridStyle,
+            minHeight: `${String(Math.max(5, layout.rowCount * 3.75))}rem`,
           } satisfies CSSProperties;
 
           return (
@@ -150,7 +174,7 @@ export const ResourceCalendar = ({
               data-slot="resource-calendar-row"
               key={resource.id}
               role="row"
-              style={gridStyle}
+              style={resourceRowStyle}
             >
               <CalendarCell
                 aria-colindex={1}
@@ -158,7 +182,6 @@ export const ResourceCalendar = ({
                 className="bg-card sticky start-0 z-20 border-b-0 px-4 py-3"
                 id={resourceHeaderId}
                 role="rowheader"
-                style={spanningCellStyle}
               >
                 <span className="block truncate text-sm font-semibold">
                   {resource.label}
@@ -169,38 +192,40 @@ export const ResourceCalendar = ({
                   </span>
                 )}
               </CalendarCell>
-              {columns.map((column, columnIndex) => (
-                <CalendarCell
-                  aria-colindex={columnIndex + 2}
-                  aria-labelledby={`${resourceHeaderId} ${getColumnHeaderId(columnIndex)}`}
-                  aria-rowindex={resourceIndex + 2}
-                  className="bg-background/40 border-b-0 last:border-e-0"
-                  key={column.date}
-                  role="gridcell"
-                  style={spanningCellStyle}
-                />
-              ))}
-              {resourceEntries.map((entry) => {
-                const placement = placementsByEntryId.get(entry.id);
-                if (placement === undefined) {
-                  return null;
-                }
-                const firstColumnIndex = placement.columnStart - 2;
-                const labelledBy = [
-                  resourceHeaderId,
-                  ...Array.from({ length: placement.span }, (_, index) =>
-                    getColumnHeaderId(firstColumnIndex + index),
-                  ),
-                ].join(" ");
+              {columns.map((column, columnIndex) => {
+                const columnStart = columnIndex + 2;
+                const visibleEntries =
+                  visibleEntriesByColumn.get(columnStart) ?? [];
 
                 return (
-                  <ResourceCalendarEntryView
-                    entry={entry}
-                    key={entry.id}
-                    labelledBy={labelledBy}
-                    onSelectEntry={onSelectEntry}
-                    placement={placement}
-                  />
+                  <CalendarCell
+                    aria-colindex={columnStart}
+                    aria-labelledby={`${resourceHeaderId} ${getColumnHeaderId(columnIndex)}`}
+                    aria-rowindex={resourceIndex + 2}
+                    className="bg-background/40 relative border-b-0 last:border-e-0"
+                    key={column.date}
+                    role="gridcell"
+                  >
+                    {visibleEntries.map(({ entry, placement }) => {
+                      const labelledBy = [
+                        resourceHeaderId,
+                        ...Array.from({ length: placement.span }, (_, index) =>
+                          getColumnHeaderId(columnIndex + index),
+                        ),
+                      ].join(" ");
+
+                      return (
+                        <ResourceCalendarEntryView
+                          entry={entry}
+                          key={entry.id}
+                          labelledBy={labelledBy}
+                          onSelectEntry={onSelectEntry}
+                          placement={placement}
+                          rowCount={layout.rowCount}
+                        />
+                      );
+                    })}
+                  </CalendarCell>
                 );
               })}
             </div>
@@ -223,19 +248,23 @@ const ResourceCalendarEntryView = ({
   labelledBy,
   onSelectEntry,
   placement,
+  rowCount,
 }: {
   entry: ResourceCalendarEntry;
   labelledBy: string;
   onSelectEntry: ResourceCalendarProps["onSelectEntry"];
-  placement: { columnStart: number; rowStart: number; span: number };
+  placement: ResourceCalendarLanePlacement;
+  rowCount: number;
 }) => {
   const className = cn(
     "h-full w-full px-3 py-2 font-medium shadow-sm",
     RESOURCE_CALENDAR_ENTRY_TONES[entry.tone ?? "accent"],
   );
   const style = {
-    gridColumn: `${String(placement.columnStart)} / span ${String(placement.span)}`,
-    gridRow: placement.rowStart,
+    blockSize: `${String(100 / rowCount)}%`,
+    insetBlockStart: `${String(((placement.rowStart - 1) * 100) / rowCount)}%`,
+    insetInlineStart: 0,
+    inlineSize: `calc(${String(placement.span)} * 100%)`,
   } satisfies CSSProperties;
   const content = (
     <>
@@ -247,14 +276,10 @@ const ResourceCalendarEntryView = ({
   );
 
   return (
-    <div
-      aria-labelledby={labelledBy}
-      className="z-10 m-2 min-w-0"
-      role="gridcell"
-      style={style}
-    >
+    <div className="absolute z-10 min-w-0 p-2" style={style}>
       {onSelectEntry === undefined ? (
         <CalendarEntrySurface
+          aria-describedby={labelledBy}
           aria-label={entry.accessibleLabel}
           className={className}
         >
@@ -262,6 +287,7 @@ const ResourceCalendarEntryView = ({
         </CalendarEntrySurface>
       ) : (
         <CalendarEntryButton
+          aria-describedby={labelledBy}
           aria-label={entry.accessibleLabel}
           className={className}
           onClick={() => onSelectEntry(entry)}

--- a/packages/ui/src/calendar/resource-calendar.tsx
+++ b/packages/ui/src/calendar/resource-calendar.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import type { CSSProperties, ReactElement, ReactNode } from "react";
 
 import { cn } from "../lib/utils";
@@ -10,7 +11,7 @@ import {
 } from "./primitives";
 import {
   assertConsecutiveCalendarDates,
-  getResourceCalendarPlacement,
+  layoutResourceCalendarEntries,
   nextCalendarDate,
 } from "./resource-calendar.logic";
 
@@ -63,6 +64,7 @@ export const ResourceCalendar = ({
   resources,
 }: ResourceCalendarProps): ReactElement => {
   assertResourceCalendarContract({ columns, entries, resources });
+  const calendarId = useId();
 
   if (resources.length === 0) {
     return <div data-slot="resource-calendar-empty">{empty}</div>;
@@ -87,20 +89,34 @@ export const ResourceCalendar = ({
     }
     existing.push(entry);
   }
+  const getColumnHeaderId = (index: number) =>
+    `${calendarId}-column-${String(index)}`;
 
   return (
     <section
+      aria-colcount={columns.length + 1}
       aria-label={ariaLabel}
+      aria-rowcount={resources.length + 1}
       className="border-border bg-card overflow-x-auto rounded-xl border"
       data-slot="resource-calendar"
+      role="table"
     >
       <div className="w-full" style={calendarWidthStyle}>
-        <CalendarHeaderRow style={gridStyle}>
-          <CalendarHeaderCell className="bg-card sticky start-0 z-20 text-start font-semibold tracking-wide uppercase">
+        <CalendarHeaderRow role="row" style={gridStyle}>
+          <CalendarHeaderCell
+            aria-colindex={1}
+            className="bg-card sticky start-0 z-30 text-start font-semibold tracking-wide uppercase"
+            role="columnheader"
+          >
             {resourceHeader}
           </CalendarHeaderCell>
-          {columns.map((column) => (
-            <CalendarHeaderCell key={column.date}>
+          {columns.map((column, index) => (
+            <CalendarHeaderCell
+              aria-colindex={index + 2}
+              id={getColumnHeaderId(index)}
+              key={column.date}
+              role="columnheader"
+            >
               <span className="block">{column.label}</span>
               {column.meta === undefined ? null : (
                 <span className="text-foreground mt-0.5 block font-semibold">
@@ -111,17 +127,39 @@ export const ResourceCalendar = ({
           ))}
         </CalendarHeaderRow>
 
-        {resources.map((resource) => {
+        {resources.map((resource, resourceIndex) => {
           const resourceEntries = entriesByResource.get(resource.id) ?? [];
+          const layout = layoutResourceCalendarEntries(
+            resourceEntries,
+            visibleRange,
+          );
+          const placementsByEntryId = new Map(
+            layout.placements.map((placement) => [
+              placement.entryId,
+              placement,
+            ]),
+          );
+          const resourceHeaderId = `${calendarId}-resource-${String(resourceIndex)}`;
+          const spanningCellStyle = {
+            gridRow: `1 / span ${String(layout.rowCount)}`,
+          } satisfies CSSProperties;
 
           return (
             <div
               className="border-border relative grid min-h-20 border-b last:border-b-0"
               data-slot="resource-calendar-row"
               key={resource.id}
+              role="row"
               style={gridStyle}
             >
-              <CalendarCell className="bg-card sticky start-0 z-10 border-b-0 px-4 py-3">
+              <CalendarCell
+                aria-colindex={1}
+                aria-rowindex={resourceIndex + 2}
+                className="bg-card sticky start-0 z-20 border-b-0 px-4 py-3"
+                id={resourceHeaderId}
+                role="rowheader"
+                style={spanningCellStyle}
+              >
                 <span className="block truncate text-sm font-semibold">
                   {resource.label}
                 </span>
@@ -131,25 +169,35 @@ export const ResourceCalendar = ({
                   </span>
                 )}
               </CalendarCell>
-              {columns.map((column) => (
+              {columns.map((column, columnIndex) => (
                 <CalendarCell
+                  aria-colindex={columnIndex + 2}
+                  aria-labelledby={`${resourceHeaderId} ${getColumnHeaderId(columnIndex)}`}
+                  aria-rowindex={resourceIndex + 2}
                   className="bg-background/40 border-b-0 last:border-e-0"
                   key={column.date}
+                  role="gridcell"
+                  style={spanningCellStyle}
                 />
               ))}
               {resourceEntries.map((entry) => {
-                const placement = getResourceCalendarPlacement({
-                  entry,
-                  visibleRange,
-                });
-                if (placement === null) {
+                const placement = placementsByEntryId.get(entry.id);
+                if (placement === undefined) {
                   return null;
                 }
+                const firstColumnIndex = placement.columnStart - 2;
+                const labelledBy = [
+                  resourceHeaderId,
+                  ...Array.from({ length: placement.span }, (_, index) =>
+                    getColumnHeaderId(firstColumnIndex + index),
+                  ),
+                ].join(" ");
 
                 return (
                   <ResourceCalendarEntryView
                     entry={entry}
                     key={entry.id}
+                    labelledBy={labelledBy}
                     onSelectEntry={onSelectEntry}
                     placement={placement}
                   />
@@ -172,20 +220,22 @@ const RESOURCE_CALENDAR_ENTRY_TONES = {
 
 const ResourceCalendarEntryView = ({
   entry,
+  labelledBy,
   onSelectEntry,
   placement,
 }: {
   entry: ResourceCalendarEntry;
+  labelledBy: string;
   onSelectEntry: ResourceCalendarProps["onSelectEntry"];
-  placement: { columnStart: number; span: number };
+  placement: { columnStart: number; rowStart: number; span: number };
 }) => {
   const className = cn(
-    "z-10 m-2 px-3 py-2 font-medium shadow-sm",
+    "h-full w-full px-3 py-2 font-medium shadow-sm",
     RESOURCE_CALENDAR_ENTRY_TONES[entry.tone ?? "accent"],
   );
   const style = {
     gridColumn: `${String(placement.columnStart)} / span ${String(placement.span)}`,
-    gridRow: 1,
+    gridRow: placement.rowStart,
   } satisfies CSSProperties;
   const content = (
     <>
@@ -196,27 +246,30 @@ const ResourceCalendarEntryView = ({
     </>
   );
 
-  if (onSelectEntry === undefined) {
-    return (
-      <CalendarEntrySurface
-        aria-label={entry.accessibleLabel}
-        className={className}
-        style={style}
-      >
-        {content}
-      </CalendarEntrySurface>
-    );
-  }
-
   return (
-    <CalendarEntryButton
-      aria-label={entry.accessibleLabel}
-      className={className}
-      onClick={() => onSelectEntry(entry)}
+    <div
+      aria-labelledby={labelledBy}
+      className="z-10 m-2 min-w-0"
+      role="gridcell"
       style={style}
     >
-      {content}
-    </CalendarEntryButton>
+      {onSelectEntry === undefined ? (
+        <CalendarEntrySurface
+          aria-label={entry.accessibleLabel}
+          className={className}
+        >
+          {content}
+        </CalendarEntrySurface>
+      ) : (
+        <CalendarEntryButton
+          aria-label={entry.accessibleLabel}
+          className={className}
+          onClick={() => onSelectEntry(entry)}
+        >
+          {content}
+        </CalendarEntryButton>
+      )}
+    </div>
   );
 };
 

--- a/packages/ui/src/calendar/resource-calendar.tsx
+++ b/packages/ui/src/calendar/resource-calendar.tsx
@@ -71,6 +71,9 @@ export const ResourceCalendar = ({
   const gridStyle = {
     gridTemplateColumns: `14rem repeat(${String(columns.length)}, minmax(7rem, 1fr))`,
   } satisfies CSSProperties;
+  const calendarWidthStyle = {
+    minWidth: `${String(14 + columns.length * 7)}rem`,
+  } satisfies CSSProperties;
   const visibleRange = {
     endDateExclusive: nextCalendarDate(columns.at(-1)?.date ?? ""),
     startDate: columns.at(0)?.date ?? "",
@@ -91,9 +94,9 @@ export const ResourceCalendar = ({
       className="border-border bg-card overflow-x-auto rounded-xl border"
       data-slot="resource-calendar"
     >
-      <div className="min-w-max">
+      <div className="w-full" style={calendarWidthStyle}>
         <CalendarHeaderRow style={gridStyle}>
-          <CalendarHeaderCell className="text-start font-semibold tracking-wide uppercase">
+          <CalendarHeaderCell className="bg-card sticky start-0 z-20 text-start font-semibold tracking-wide uppercase">
             {resourceHeader}
           </CalendarHeaderCell>
           {columns.map((column) => (

--- a/packages/ui/src/calendar/resource-calendar.tsx
+++ b/packages/ui/src/calendar/resource-calendar.tsx
@@ -1,0 +1,247 @@
+import type { CSSProperties, ReactElement, ReactNode } from "react";
+
+import { cn } from "../lib/utils";
+import {
+  CalendarCell,
+  CalendarEntryButton,
+  CalendarEntrySurface,
+  CalendarHeaderCell,
+  CalendarHeaderRow,
+} from "./primitives";
+import {
+  assertConsecutiveCalendarDates,
+  getResourceCalendarPlacement,
+  nextCalendarDate,
+} from "./resource-calendar.logic";
+
+export type ResourceCalendarColumn = {
+  date: string;
+  label: ReactNode;
+  meta?: ReactNode;
+};
+
+export type ResourceCalendarResource = {
+  id: string;
+  label: ReactNode;
+  meta?: ReactNode;
+};
+
+export type ResourceCalendarEntryTone =
+  | "accent"
+  | "neutral"
+  | "warning"
+  | "destructive";
+
+export type ResourceCalendarEntry = {
+  accessibleLabel: string;
+  endDateExclusive: string;
+  id: string;
+  label: ReactNode;
+  meta?: ReactNode;
+  resourceId: string;
+  startDate: string;
+  tone?: ResourceCalendarEntryTone;
+};
+
+type ResourceCalendarProps = {
+  ariaLabel: string;
+  columns: readonly ResourceCalendarColumn[];
+  empty?: ReactNode;
+  entries: readonly ResourceCalendarEntry[];
+  onSelectEntry?: (entry: ResourceCalendarEntry) => void;
+  resourceHeader: ReactNode;
+  resources: readonly ResourceCalendarResource[];
+};
+
+export const ResourceCalendar = ({
+  ariaLabel,
+  columns,
+  empty,
+  entries,
+  onSelectEntry,
+  resourceHeader,
+  resources,
+}: ResourceCalendarProps): ReactElement => {
+  assertResourceCalendarContract({ columns, entries, resources });
+
+  if (resources.length === 0) {
+    return <div data-slot="resource-calendar-empty">{empty}</div>;
+  }
+
+  const gridStyle = {
+    gridTemplateColumns: `14rem repeat(${String(columns.length)}, minmax(7rem, 1fr))`,
+  } satisfies CSSProperties;
+  const visibleRange = {
+    endDateExclusive: nextCalendarDate(columns.at(-1)?.date ?? ""),
+    startDate: columns.at(0)?.date ?? "",
+  };
+  const entriesByResource = new Map<string, ResourceCalendarEntry[]>();
+  for (const entry of entries) {
+    const existing = entriesByResource.get(entry.resourceId);
+    if (existing === undefined) {
+      entriesByResource.set(entry.resourceId, [entry]);
+      continue;
+    }
+    existing.push(entry);
+  }
+
+  return (
+    <section
+      aria-label={ariaLabel}
+      className="border-border bg-card overflow-x-auto rounded-xl border"
+      data-slot="resource-calendar"
+    >
+      <div className="min-w-max">
+        <CalendarHeaderRow style={gridStyle}>
+          <CalendarHeaderCell className="text-start font-semibold tracking-wide uppercase">
+            {resourceHeader}
+          </CalendarHeaderCell>
+          {columns.map((column) => (
+            <CalendarHeaderCell key={column.date}>
+              <span className="block">{column.label}</span>
+              {column.meta === undefined ? null : (
+                <span className="text-foreground mt-0.5 block font-semibold">
+                  {column.meta}
+                </span>
+              )}
+            </CalendarHeaderCell>
+          ))}
+        </CalendarHeaderRow>
+
+        {resources.map((resource) => {
+          const resourceEntries = entriesByResource.get(resource.id) ?? [];
+
+          return (
+            <div
+              className="border-border relative grid min-h-20 border-b last:border-b-0"
+              data-slot="resource-calendar-row"
+              key={resource.id}
+              style={gridStyle}
+            >
+              <CalendarCell className="bg-card sticky start-0 z-10 border-b-0 px-4 py-3">
+                <span className="block truncate text-sm font-semibold">
+                  {resource.label}
+                </span>
+                {resource.meta === undefined ? null : (
+                  <span className="text-muted-foreground mt-1 block truncate text-xs">
+                    {resource.meta}
+                  </span>
+                )}
+              </CalendarCell>
+              {columns.map((column) => (
+                <CalendarCell
+                  className="bg-background/40 border-b-0 last:border-e-0"
+                  key={column.date}
+                />
+              ))}
+              {resourceEntries.map((entry) => {
+                const placement = getResourceCalendarPlacement({
+                  entry,
+                  visibleRange,
+                });
+                if (placement === null) {
+                  return null;
+                }
+
+                return (
+                  <ResourceCalendarEntryView
+                    entry={entry}
+                    key={entry.id}
+                    onSelectEntry={onSelectEntry}
+                    placement={placement}
+                  />
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+const RESOURCE_CALENDAR_ENTRY_TONES = {
+  accent: "bg-primary text-primary-foreground",
+  destructive: "bg-destructive text-destructive-foreground",
+  neutral: "border-border bg-muted text-foreground border",
+  warning: "bg-warning text-warning-foreground",
+} as const satisfies Record<ResourceCalendarEntryTone, string>;
+
+const ResourceCalendarEntryView = ({
+  entry,
+  onSelectEntry,
+  placement,
+}: {
+  entry: ResourceCalendarEntry;
+  onSelectEntry: ResourceCalendarProps["onSelectEntry"];
+  placement: { columnStart: number; span: number };
+}) => {
+  const className = cn(
+    "z-10 m-2 px-3 py-2 font-medium shadow-sm",
+    RESOURCE_CALENDAR_ENTRY_TONES[entry.tone ?? "accent"],
+  );
+  const style = {
+    gridColumn: `${String(placement.columnStart)} / span ${String(placement.span)}`,
+    gridRow: 1,
+  } satisfies CSSProperties;
+  const content = (
+    <>
+      <span className="block truncate">{entry.label}</span>
+      {entry.meta === undefined ? null : (
+        <span className="block truncate opacity-75">{entry.meta}</span>
+      )}
+    </>
+  );
+
+  if (onSelectEntry === undefined) {
+    return (
+      <CalendarEntrySurface
+        aria-label={entry.accessibleLabel}
+        className={className}
+        style={style}
+      >
+        {content}
+      </CalendarEntrySurface>
+    );
+  }
+
+  return (
+    <CalendarEntryButton
+      aria-label={entry.accessibleLabel}
+      className={className}
+      onClick={() => onSelectEntry(entry)}
+      style={style}
+    >
+      {content}
+    </CalendarEntryButton>
+  );
+};
+
+const assertUniqueIds = (ids: readonly string[], label: string): void => {
+  if (new Set(ids).size !== ids.length) {
+    throw new TypeError(`${label} ids must be unique`);
+  }
+};
+
+const assertResourceCalendarContract = ({
+  columns,
+  entries,
+  resources,
+}: Pick<ResourceCalendarProps, "columns" | "entries" | "resources">): void => {
+  assertConsecutiveCalendarDates(columns.map(({ date }) => date));
+  assertUniqueIds(
+    resources.map(({ id }) => id),
+    "Resource calendar resource",
+  );
+  assertUniqueIds(
+    entries.map(({ id }) => id),
+    "Resource calendar entry",
+  );
+  const resourceIds = new Set(resources.map(({ id }) => id));
+  const orphan = entries.find(({ resourceId }) => !resourceIds.has(resourceId));
+  if (orphan !== undefined) {
+    throw new TypeError(
+      `Resource calendar entry ${orphan.id} references an unknown resource`,
+    );
+  }
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -18,6 +18,7 @@ export * from "./components/checkbox";
 export * from "./components/color-picker";
 export * from "./components/combobox";
 export * from "./components/command";
+export * from "./calendar";
 export * from "./components/date-picker-popover";
 export * from "./components/destructive-action-confirmation";
 export * from "./components/destructive-confirm-dialog";


### PR DESCRIPTION
Extracts entity-agnostic calendar primitives from the existing web calendar into `@stll/ui` and adds a resource calendar with validated consecutive date columns and half-open range clipping.

The existing Stella calendar now consumes the shared cell, header, and entry primitives so the published surface stays exercised in product code. Includes a minor changeset for the new `@stll/ui/calendar` export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a resource calendar for displaying scheduled entries across resources and date ranges.
  * Added reusable calendar building blocks, including headers, cells, grids and entry controls.
  * Added support for selectable entries, accessible markup and configurable entry styles.
  * Calendar components are now available through the main UI package exports.

* **Improvements**
  * Updated workspace calendar views to use the shared calendar components for consistent presentation and behaviour.

* **Tests**
  * Added coverage for date ranges, overlapping entries, accessibility, validation and calendar layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->