### PR TITLE
fix(api): request one hit for corpus census

### DIFF
--- a/apps/api/src/lib/corpus-index/census.db.test.ts
+++ b/apps/api/src/lib/corpus-index/census.db.test.ts
@@ -18,7 +18,7 @@
  * address one member's rows and leave the others marked.
  */
 
-import { beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
@@ -73,6 +73,7 @@ const decisionId = (fixture: keyof typeof ID_PREFIX, index: number) =>
     `00000000-0000-4000-8000-${ID_PREFIX[fixture]}00000000${String(index).padStart(3, "0")}`,
   );
 
+let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
 let scopedDb: ScopedDb;
 
@@ -106,7 +107,7 @@ const enqueuedProjections = async () =>
     .where(eq(caseLawCorpusIndexProjections.pendingAction, "index"));
 
 beforeAll(async () => {
-  const client = await createTestPglite();
+  client = await createTestPglite();
   db = drizzle({ client });
   const handle = async (callback: (tx: Transaction) => Promise<unknown>) =>
     // SAFETY: pglite's drizzle instance satisfies the transaction surface
@@ -162,6 +163,10 @@ beforeAll(async () => {
   // so the repair is only meaningful with it installed. The test snapshot
   // carries the tables but not the migrations' functions.
   await installCaseLawProjectionTrigger(db);
+});
+
+afterAll(async () => {
+  await client.close();
 });
 
 test("the repair reaches rows marked only through the generation projection", async () => {

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -37,6 +37,7 @@ const originalFetch = globalThis.fetch;
 
 /** Index ids the engine was asked to count, in request order. */
 let countedIndexIds: string[];
+let countedMaxHits: unknown[];
 
 const indexIdOfCountRequest = (url: string): string | undefined =>
   /\/api\/v1\/(?<indexId>[^/]+)\/search/u.exec(url)?.groups?.["indexId"];
@@ -49,7 +50,10 @@ const engineHolding = (numHits: number, ok = true): void => {
     }
     return input instanceof URL ? input.href : input.url;
   };
-  const stub = async (input: Parameters<typeof fetch>[0]) => {
+  const stub = async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ) => {
     const url = resolveUrl(input);
     if (!ok) {
       return new Response("index not found", { status: 404 });
@@ -59,8 +63,15 @@ const engineHolding = (numHits: number, ok = true): void => {
       if (indexId !== undefined) {
         countedIndexIds.push(indexId);
       }
+      const body: Record<string, unknown> = JSON.parse(
+        typeof init?.body === "string" ? init.body : "{}",
+      );
+      countedMaxHits.push(body["max_hits"]);
       return new Response(
-        JSON.stringify({ num_hits: numHits, hits: [], snippets: [] }),
+        JSON.stringify({
+          num_hits: numHits,
+          hits: [{ document_id: "count-hit" }],
+        }),
         { status: 200 },
       );
     }
@@ -104,6 +115,7 @@ const databaseHolding = (
 
 beforeEach(() => {
   countedIndexIds = [];
+  countedMaxHits = [];
 });
 
 afterEach(() => {
@@ -145,6 +157,7 @@ describe("index census", () => {
     );
     expect(census.isOk() && census.value.indexId).toBe(INDEX_ID);
     expect(countedIndexIds).toEqual([INDEX_ID]);
+    expect(countedMaxHits).toEqual([1]);
   });
 
   test("an engine holding more than Postgres claims is a surplus, not silence", async () => {

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -194,7 +194,7 @@ export const censusIndex = async ({
   const counted = await getCorpusIndexClient().search({
     indexId,
     query: DOCUMENT_COUNT_QUERY,
-    maxHits: 0,
+    maxHits: 1,
   });
   if (Result.isError(counted)) {
     return Result.err(counted.error);


### PR DESCRIPTION
## Summary

- request one Quickwit hit for corpus census queries while continuing to count num_hits
- cover the one-hit response shape and outgoing max_hits contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of indexed document counts by ensuring counting requests return a representative search result.
  - Large-index census operations now correctly verify document availability while calculating totals.

- **Tests**
  - Added coverage to confirm that census counting requests use the appropriate result limit and handle search responses correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->