### PR TITLE
feat(workspace): publish property model

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -3,8 +3,9 @@
 Pull requests that change the shipped source of `@stll/cli`,
 `@stll/business-registries`, `@stll/calculations`, `@stll/conditions`,
 `@stll/country-codes`, `@stll/docx-utils`, `@stll/money`,
-`@stll/template-conditions`, `@stll/ui`, or `@stll/workspace-ui` must include a
-Changeset describing the user-visible change and its semver impact.
+`@stll/template-conditions`, `@stll/ui`, `@stll/workspace-model`, or
+`@stll/workspace-ui` must include a Changeset describing the user-visible change
+and its semver impact.
 
 Run `bun run changeset`, select the affected package(s), and commit the generated
 Markdown file. Changes that do not alter a published package do not need one.

--- a/.changeset/publish-workspace-property-model.md
+++ b/.changeset/publish-workspace-property-model.md
@@ -1,0 +1,5 @@
+---
+"@stll/workspace-model": minor
+---
+
+Publish portable typed property definitions, options, and values for entity workspaces.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -861,6 +861,7 @@ jobs:
           bun scripts/check-published-exports.ts packages/ui
           bun scripts/check-published-exports.ts packages/money
           bun scripts/check-published-exports.ts packages/calculations
+          bun scripts/check-published-exports.ts packages/workspace-model
           bun scripts/check-published-exports.ts packages/workspace-ui
 
       # Release ordering is a safety property. This test has no workspace

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -28,6 +28,7 @@ on:
       - packages/template-conditions/CHANGELOG.md
       - packages/docx-utils/CHANGELOG.md
       - packages/ui/CHANGELOG.md
+      - packages/workspace-model/CHANGELOG.md
       - packages/workspace-ui/CHANGELOG.md
   workflow_run: # zizmor: ignore[dangerous-triggers] the release tag and SHA are revalidated before the release job receives id-token
     workflows: ["Release Artifacts"]
@@ -47,6 +48,7 @@ on:
           - template-conditions
           - docx-utils
           - ui
+          - workspace-model
           - workspace-ui
           - cli
         default: all
@@ -184,10 +186,10 @@ jobs:
           if [[ "$EVENT_NAME" == "workflow_run" ]]; then
             pkgs=(cli)
           elif [[ "$EVENT_NAME" == "push" ]]; then
-            pkgs=(country-codes business-registries conditions template-conditions docx-utils ui money calculations workspace-ui)
+            pkgs=(country-codes business-registries conditions template-conditions docx-utils ui money calculations workspace-model workspace-ui)
           else
             case "$MANUAL_PACKAGE" in
-              all) pkgs=(country-codes business-registries conditions template-conditions docx-utils ui money calculations workspace-ui cli) ;;
+              all) pkgs=(country-codes business-registries conditions template-conditions docx-utils ui money calculations workspace-model workspace-ui cli) ;;
               *) pkgs=("$MANUAL_PACKAGE") ;;
             esac
           fi
@@ -378,6 +380,15 @@ jobs:
         with:
           name: npm-tarball-workspace-ui
           path: release-artifacts/workspace-ui/
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload workspace-model tarball
+        if: contains(fromJSON(steps.pack.outputs.packages), 'workspace-model')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-tarball-workspace-model
+          path: release-artifacts/workspace-model/
           retention-days: 1
           if-no-files-found: error
 

--- a/bun.lock
+++ b/bun.lock
@@ -798,6 +798,15 @@
         "tailwindcss": "^4.3.0",
       },
     },
+    "packages/workspace-model": {
+      "name": "@stll/workspace-model",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@stll/typescript-config": "workspace:*",
+        "@types/bun": "catalog:",
+        "tsdown": "catalog:",
+      },
+    },
     "packages/workspace-ui": {
       "name": "@stll/workspace-ui",
       "version": "0.0.0",
@@ -2360,6 +2369,8 @@
     "@stll/ui": ["@stll/ui@workspace:packages/ui"],
 
     "@stll/web": ["@stll/web@workspace:apps/web"],
+
+    "@stll/workspace-model": ["@stll/workspace-model@workspace:packages/workspace-model"],
 
     "@stll/workspace-ui": ["@stll/workspace-ui@workspace:packages/workspace-ui"],
 

--- a/packages/workspace-model/README.md
+++ b/packages/workspace-model/README.md
@@ -1,0 +1,33 @@
+# `@stll/workspace-model`
+
+Portable entity-property definitions and values for workspace-style products.
+The package has no UI, database, or framework dependency: hosts own storage,
+authorization, validation bounds, translations, and rendering.
+
+Definitions use stable keys and identifiers. Select option labels and colours
+remain presentation metadata, while stored values reference option identifiers;
+renaming a label therefore does not rewrite entity data.
+
+```ts
+import type {
+  WorkspacePropertyDefinition,
+  WorkspacePropertyValue,
+} from "@stll/workspace-model/properties";
+
+const labels = {
+  id: "labels",
+  key: "labels",
+  label: "Labels",
+  revision: 1,
+  status: "active",
+  type: "multi-select",
+  fallbackOptionId: null,
+  options: [],
+} satisfies WorkspacePropertyDefinition;
+
+const value = {
+  propertyId: labels.id,
+  type: "multi-select",
+  optionIds: [],
+} satisfies WorkspacePropertyValue;
+```

--- a/packages/workspace-model/package.json
+++ b/packages/workspace-model/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@stll/workspace-model",
+  "version": "0.0.0",
+  "description": "Portable typed property definitions and values for entity workspaces.",
+  "keywords": [
+    "entities",
+    "metadata",
+    "properties",
+    "typescript",
+    "workspace"
+  ],
+  "homepage": "https://github.com/stella/stella/tree/main/packages/workspace-model",
+  "bugs": {
+    "url": "https://github.com/stella/stella/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stella/stella.git",
+    "directory": "packages/workspace-model"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/properties.ts",
+    "./properties": "./src/properties.ts"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "clean": "git clean -xdf dist .cache .turbo node_modules",
+    "build": "tsdown",
+    "pack:dry-run": "bun pm pack --dry-run",
+    "test": "bun test src",
+    "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/workspace-model",
+    "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/workspace-model",
+    "format": "oxfmt .",
+    "prepack": "bun run build"
+  },
+  "devDependencies": {
+    "@stll/typescript-config": "workspace:*",
+    "@types/bun": "catalog:",
+    "tsdown": "catalog:"
+  }
+}

--- a/packages/workspace-model/src/properties.test.ts
+++ b/packages/workspace-model/src/properties.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isWorkspacePropertyType,
+  workspacePropertyDefinitionStatuses,
+  workspacePropertyTypes,
+} from "./properties";
+
+describe("workspace property model", () => {
+  test("publishes each property discriminator exactly once", () => {
+    expect(new Set(workspacePropertyTypes).size).toBe(
+      workspacePropertyTypes.length,
+    );
+    expect(workspacePropertyTypes).toEqual([
+      "file",
+      "text",
+      "single-select",
+      "multi-select",
+      "date",
+      "int",
+      "money",
+      "person",
+    ]);
+  });
+
+  test("recognizes only declared property types", () => {
+    for (const type of workspacePropertyTypes) {
+      expect(isWorkspacePropertyType(type)).toBe(true);
+    }
+    expect(isWorkspacePropertyType("checkbox")).toBe(false);
+  });
+
+  test("keeps lifecycle status explicit", () => {
+    expect(workspacePropertyDefinitionStatuses).toEqual(["active", "archived"]);
+  });
+});

--- a/packages/workspace-model/src/properties.ts
+++ b/packages/workspace-model/src/properties.ts
@@ -1,0 +1,141 @@
+export const workspacePropertyDefinitionStatuses = [
+  "active",
+  "archived",
+] as const;
+
+export type WorkspacePropertyDefinitionStatus =
+  (typeof workspacePropertyDefinitionStatuses)[number];
+
+export const workspacePropertyTypes = [
+  "file",
+  "text",
+  "single-select",
+  "multi-select",
+  "date",
+  "int",
+  "money",
+  "person",
+] as const;
+
+export type WorkspacePropertyType = (typeof workspacePropertyTypes)[number];
+
+export type WorkspacePropertyIdentifier = string | number;
+
+export type WorkspacePropertyOption<
+  OptionId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+  Color extends string = string,
+> = {
+  color: Color;
+  id: OptionId;
+  key: string;
+  label: string;
+  sortOrder: number;
+  status: WorkspacePropertyDefinitionStatus;
+};
+
+type WorkspacePropertyDefinitionBase<
+  PropertyId extends WorkspacePropertyIdentifier,
+> = {
+  id: PropertyId;
+  key: string;
+  label: string;
+  revision: number;
+  status: WorkspacePropertyDefinitionStatus;
+};
+
+type WorkspaceSelectPropertyDefinition<
+  PropertyId extends WorkspacePropertyIdentifier,
+  OptionId extends WorkspacePropertyIdentifier,
+  Color extends string,
+> = WorkspacePropertyDefinitionBase<PropertyId> & {
+  fallbackOptionId: OptionId | null;
+  options: readonly WorkspacePropertyOption<OptionId, Color>[];
+  type: "multi-select" | "single-select";
+};
+
+/**
+ * Host-neutral property definition. Stable identifiers, rather than labels,
+ * are the persisted relationship between definitions, options, and values.
+ */
+export type WorkspacePropertyDefinition<
+  PropertyId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+  OptionId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+  Color extends string = string,
+> =
+  | (WorkspacePropertyDefinitionBase<PropertyId> & {
+      type: "file" | "text" | "date" | "int" | "person";
+    })
+  | (WorkspacePropertyDefinitionBase<PropertyId> & {
+      currency: string | null;
+      type: "money";
+    })
+  | WorkspaceSelectPropertyDefinition<PropertyId, OptionId, Color>;
+
+export type WorkspaceFileValue = {
+  encrypted: boolean;
+  fileName: string;
+  id: string;
+  mimeType: string;
+  pdfFileId: string | null;
+  sha256Hex: string;
+  sizeBytes: number;
+};
+
+type WorkspacePropertyValueBase<
+  PropertyId extends WorkspacePropertyIdentifier,
+> = {
+  propertyId: PropertyId;
+};
+
+/**
+ * Persisted property value. The discriminator carries the cardinality rule:
+ * a single select can reference at most one option, while a multi-select owns
+ * an explicit list.
+ */
+export type WorkspacePropertyValue<
+  PropertyId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+  OptionId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+> =
+  | (WorkspacePropertyValueBase<PropertyId> & {
+      type: "file";
+      value: WorkspaceFileValue;
+    })
+  | (WorkspacePropertyValueBase<PropertyId> & {
+      type: "text";
+      value: string;
+    })
+  | (WorkspacePropertyValueBase<PropertyId> & {
+      optionId: OptionId | null;
+      type: "single-select";
+    })
+  | (WorkspacePropertyValueBase<PropertyId> & {
+      optionIds: readonly OptionId[];
+      type: "multi-select";
+    })
+  | (WorkspacePropertyValueBase<PropertyId> & {
+      type: "date";
+      value: string | null;
+    })
+  | (WorkspacePropertyValueBase<PropertyId> & {
+      type: "int";
+      value: number;
+    })
+  | (WorkspacePropertyValueBase<PropertyId> & {
+      amountCents: number;
+      currency: string;
+      type: "money";
+    })
+  | (WorkspacePropertyValueBase<PropertyId> & {
+      image: string | null;
+      name: string;
+      type: "person";
+      userId: string | null;
+    });
+
+const workspacePropertyTypeSet: ReadonlySet<string> = new Set(
+  workspacePropertyTypes,
+);
+
+export const isWorkspacePropertyType = (
+  value: string,
+): value is WorkspacePropertyType => workspacePropertyTypeSet.has(value);

--- a/packages/workspace-model/tsconfig.json
+++ b/packages/workspace-model/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@stll/typescript-config/base.json",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "types": ["bun"]
+  },
+  "include": ["."],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/workspace-model/tsdown.config.ts
+++ b/packages/workspace-model/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/properties.ts"],
+  format: ["esm"],
+  platform: "neutral",
+  dts: true,
+  outDir: "dist",
+  clean: true,
+});

--- a/scripts/changeset-policy.json
+++ b/scripts/changeset-policy.json
@@ -43,6 +43,11 @@
     "packages/ui/src/**",
     "packages/ui/tsconfig.json",
     "packages/ui/tsdown.config.ts",
+    "packages/workspace-model/README.md",
+    "packages/workspace-model/package.json",
+    "packages/workspace-model/src/**",
+    "packages/workspace-model/tsconfig.json",
+    "packages/workspace-model/tsdown.config.ts",
     "packages/workspace-ui/README.md",
     "packages/workspace-ui/package.json",
     "packages/workspace-ui/src/**",
@@ -70,6 +75,8 @@
     "packages/docx-utils/package.json",
     "packages/ui/CHANGELOG.md",
     "packages/ui/package.json",
+    "packages/workspace-model/CHANGELOG.md",
+    "packages/workspace-model/package.json",
     "packages/workspace-ui/CHANGELOG.md",
     "packages/workspace-ui/package.json"
   ],
@@ -83,6 +90,7 @@
     "packages/template-conditions/package.json",
     "packages/docx-utils/package.json",
     "packages/ui/package.json",
+    "packages/workspace-model/package.json",
     "packages/workspace-ui/package.json"
   ]
 }

--- a/scripts/check-api-cli-contract.test.ts
+++ b/scripts/check-api-cli-contract.test.ts
@@ -26,6 +26,7 @@ const SHARED_NPM_PACKAGES = [
   "docx-utils",
   "money",
   "template-conditions",
+  "workspace-model",
   "workspace-ui",
 ] as const;
 


### PR DESCRIPTION
## Summary

- publish `@stll/workspace-model` as a framework-neutral property contract
- model definitions and values as discriminated unions with stable property and option identities
- wire the package into Changesets, packed-export checks, and trusted npm publishing

## Validation

- package build, tests, typecheck, lint, and formatting
- packed export resolution and tarball contents
- shared-package release contract and changeset guard
- focused security review: no runtime dependencies, I/O, credentials, or host-owned authorization behavior

## Stack

Depends on #2296 for the shared workspace-package publication foundation.