### PR TITLE
feat(workspace): model saved entity views

### DIFF
--- a/.changeset/publish-workspace-view-model.md
+++ b/.changeset/publish-workspace-view-model.md
@@ -1,0 +1,5 @@
+---
+"@stll/workspace-model": minor
+---
+
+Add saved table, kanban, calendar, and timeline view contracts over one entity collection.

--- a/bun.lock
+++ b/bun.lock
@@ -801,6 +801,10 @@
     "packages/workspace-model": {
       "name": "@stll/workspace-model",
       "version": "0.0.0",
+      "dependencies": {
+        "@stll/calculations": "workspace:^",
+        "@stll/conditions": "workspace:^",
+      },
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@types/bun": "catalog:",

--- a/packages/workspace-model/README.md
+++ b/packages/workspace-model/README.md
@@ -8,6 +8,11 @@ Definitions use stable keys and identifiers. Select option labels and colours
 remain presentation metadata, while stored values reference option identifiers;
 renaming a label therefore does not rewrite entity data.
 
+Saved views hold presentation state only: filters, sorting, grouping, visible
+properties, and layout-specific configuration all refer back to the same
+entity collection. Switching layout therefore never creates a second copy of
+entity state.
+
 ```ts
 import type {
   WorkspacePropertyDefinition,
@@ -30,4 +35,25 @@ const value = {
   type: "multi-select",
   optionIds: [],
 } satisfies WorkspacePropertyValue;
+```
+
+```ts
+import type { WorkspaceSavedView } from "@stll/workspace-model/views";
+
+const board = {
+  id: "open-work",
+  name: "Open work",
+  position: 0,
+  version: 1,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  layout: {
+    calculations: [],
+    filters: [],
+    groupByPropertyId: "workflow",
+    hiddenProperties: [],
+    sorts: [],
+    type: "kanban",
+    version: 1,
+  },
+} satisfies WorkspaceSavedView;
 ```

--- a/packages/workspace-model/package.json
+++ b/packages/workspace-model/package.json
@@ -28,7 +28,8 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/properties.ts",
-    "./properties": "./src/properties.ts"
+    "./properties": "./src/properties.ts",
+    "./views": "./src/views.ts"
   },
   "publishConfig": {
     "access": "public"
@@ -43,6 +44,10 @@
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/workspace-model",
     "format": "oxfmt .",
     "prepack": "bun run build"
+  },
+  "dependencies": {
+    "@stll/calculations": "workspace:^",
+    "@stll/conditions": "workspace:^"
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",

--- a/packages/workspace-model/src/properties.ts
+++ b/packages/workspace-model/src/properties.ts
@@ -19,7 +19,8 @@ export const workspacePropertyTypes = [
 
 export type WorkspacePropertyType = (typeof workspacePropertyTypes)[number];
 
-export type WorkspacePropertyIdentifier = string | number;
+export type WorkspaceIdentifier = string | number;
+export type WorkspacePropertyIdentifier = WorkspaceIdentifier;
 
 export type WorkspacePropertyOption<
   OptionId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,

--- a/packages/workspace-model/src/views.test.ts
+++ b/packages/workspace-model/src/views.test.ts
@@ -3,9 +3,10 @@ import { describe, expect, test } from "bun:test";
 import {
   isWorkspaceViewLayoutType,
   workspaceCalendarModes,
-  workspaceTimelineTableModes,
   workspaceTimelineZoomLevels,
   workspaceViewLayoutTypes,
+  type WorkspaceSavedView,
+  type WorkspaceTimelineViewLayout,
 } from "./views";
 
 describe("workspace saved-view model", () => {
@@ -37,6 +38,54 @@ describe("workspace saved-view model", () => {
       "month",
       "quarter",
     ]);
-    expect(workspaceTimelineTableModes).toEqual(["hidden", "visible"]);
+  });
+
+  test("uses the persisted timeline table contract", () => {
+    const timeline = {
+      calculations: [],
+      endDatePropertyId: "end",
+      filters: [],
+      hiddenProperties: [],
+      showTable: true,
+      sorts: [],
+      startDatePropertyId: "start",
+      type: "timeline",
+      version: 1,
+      zoom: "month",
+    } satisfies WorkspaceTimelineViewLayout;
+
+    expect(timeline.showTable).toBe(true);
+  });
+
+  test("threads numeric property identifiers through every view reference", () => {
+    const view = {
+      createdAt: "2026-01-01T00:00:00.000Z",
+      id: 1,
+      layout: {
+        calculations: [{ kind: "count", propertyId: 11 }],
+        columnOrder: [11, 12],
+        columnPinning: [11],
+        filters: [
+          {
+            operand: { propertyId: 12, type: "property" },
+            op: "is_not_empty",
+            type: "predicate",
+          },
+        ],
+        groupByPropertyId: 13,
+        hiddenProperties: [14],
+        sorts: [{ desc: false, propertyId: 15 }],
+        type: "table",
+        version: 1,
+      },
+      name: "Numeric property identifiers",
+      position: 0,
+      version: 1,
+    } satisfies WorkspaceSavedView<number, number>;
+
+    expect(view.layout.filters.at(0)?.operand).toEqual({
+      propertyId: 12,
+      type: "property",
+    });
   });
 });

--- a/packages/workspace-model/src/views.test.ts
+++ b/packages/workspace-model/src/views.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isWorkspaceViewLayoutType,
+  workspaceCalendarModes,
+  workspaceTimelineTableModes,
+  workspaceTimelineZoomLevels,
+  workspaceViewLayoutTypes,
+} from "./views";
+
+describe("workspace saved-view model", () => {
+  test("publishes each shared layout discriminator exactly once", () => {
+    expect(new Set(workspaceViewLayoutTypes).size).toBe(
+      workspaceViewLayoutTypes.length,
+    );
+    expect(workspaceViewLayoutTypes).toEqual([
+      "table",
+      "kanban",
+      "calendar",
+      "timeline",
+    ]);
+  });
+
+  test("recognizes only shared entity layouts", () => {
+    for (const type of workspaceViewLayoutTypes) {
+      expect(isWorkspaceViewLayoutType(type)).toBe(true);
+    }
+    expect(isWorkspaceViewLayoutType("overview")).toBe(false);
+    expect(isWorkspaceViewLayoutType("filesystem")).toBe(false);
+  });
+
+  test("keeps calendar and timeline modes finite", () => {
+    expect(workspaceCalendarModes).toEqual(["month", "week", "year"]);
+    expect(workspaceTimelineZoomLevels).toEqual([
+      "day",
+      "week",
+      "month",
+      "quarter",
+    ]);
+    expect(workspaceTimelineTableModes).toEqual(["hidden", "visible"]);
+  });
+});

--- a/packages/workspace-model/src/views.ts
+++ b/packages/workspace-model/src/views.ts
@@ -1,7 +1,16 @@
 import type { CalculationKind } from "@stll/calculations";
-import type { ConditionNode } from "@stll/conditions";
+import type {
+  CompareNode,
+  ConditionNode,
+  GroupNode,
+  Operand,
+  PredicateNode,
+} from "@stll/conditions";
 
-import type { WorkspaceIdentifier } from "./properties";
+import type {
+  WorkspaceIdentifier,
+  WorkspacePropertyIdentifier,
+} from "./properties";
 
 export const workspaceViewLayoutTypes = [
   "table",
@@ -24,53 +33,88 @@ export const workspaceTimelineZoomLevels = [
 export type WorkspaceTimelineZoomLevel =
   (typeof workspaceTimelineZoomLevels)[number];
 
-export const workspaceTimelineTableModes = ["hidden", "visible"] as const;
-export type WorkspaceTimelineTableMode =
-  (typeof workspaceTimelineTableModes)[number];
+type WorkspaceViewOperand<PropertyId extends WorkspacePropertyIdentifier> =
+  | Exclude<Operand, { type: "property" }>
+  | { propertyId: PropertyId; type: "property" };
 
-export type WorkspaceViewSort = {
+export type WorkspaceViewConditionNode<
+  PropertyId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+> =
+  | (Omit<CompareNode, "left" | "right"> & {
+      left: WorkspaceViewOperand<PropertyId>;
+      right: WorkspaceViewOperand<PropertyId>;
+    })
+  | (Omit<PredicateNode, "operand"> & {
+      operand: WorkspaceViewOperand<PropertyId>;
+    })
+  | (Omit<GroupNode, "children"> & {
+      children: WorkspaceViewConditionNode<PropertyId>[];
+    });
+
+true satisfies Exclude<
+  ConditionNode["type"],
+  WorkspaceViewConditionNode["type"]
+> extends never
+  ? true
+  : never;
+
+export type WorkspaceViewSort<
+  PropertyId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+> = {
   desc: boolean;
-  propertyId: string;
+  propertyId: PropertyId;
 };
 
-export type WorkspaceViewCalculation = {
+export type WorkspaceViewCalculation<
+  PropertyId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+> = {
   kind: CalculationKind;
-  propertyId: string;
+  propertyId: PropertyId;
 };
 
-export type WorkspaceViewLayoutBase = {
-  calculations: readonly WorkspaceViewCalculation[];
-  filters: readonly ConditionNode[];
-  hiddenProperties: readonly string[];
-  sorts: readonly WorkspaceViewSort[];
+export type WorkspaceViewLayoutBase<
+  PropertyId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+> = {
+  calculations: readonly WorkspaceViewCalculation<PropertyId>[];
+  filters: readonly WorkspaceViewConditionNode<PropertyId>[];
+  hiddenProperties: readonly PropertyId[];
+  sorts: readonly WorkspaceViewSort<PropertyId>[];
   version: 1;
 };
 
-export type WorkspaceTableViewLayout = WorkspaceViewLayoutBase & {
-  columnOrder: readonly string[];
-  columnPinning: readonly string[];
-  groupByPropertyId?: string | undefined;
+export type WorkspaceTableViewLayout<
+  PropertyId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+> = WorkspaceViewLayoutBase<PropertyId> & {
+  columnOrder: readonly PropertyId[];
+  columnPinning: readonly PropertyId[];
+  groupByPropertyId?: PropertyId | undefined;
   type: "table";
 };
 
-export type WorkspaceKanbanViewLayout = WorkspaceViewLayoutBase & {
-  groupByPropertyId?: string | undefined;
+export type WorkspaceKanbanViewLayout<
+  PropertyId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+> = WorkspaceViewLayoutBase<PropertyId> & {
+  groupByPropertyId?: PropertyId | undefined;
   type: "kanban";
 };
 
-export type WorkspaceCalendarViewLayout = WorkspaceViewLayoutBase & {
-  additionalDatePropertyIds?: readonly string[] | undefined;
-  datePropertyId: string;
-  endDatePropertyId?: string | undefined;
+export type WorkspaceCalendarViewLayout<
+  PropertyId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+> = WorkspaceViewLayoutBase<PropertyId> & {
+  additionalDatePropertyIds?: readonly PropertyId[] | undefined;
+  datePropertyId: PropertyId;
+  endDatePropertyId?: PropertyId | undefined;
   mode: WorkspaceCalendarMode;
   type: "calendar";
 };
 
-export type WorkspaceTimelineViewLayout = WorkspaceViewLayoutBase & {
-  endDatePropertyId: string;
-  groupByPropertyId?: string | undefined;
-  startDatePropertyId: string;
-  tableMode: WorkspaceTimelineTableMode;
+export type WorkspaceTimelineViewLayout<
+  PropertyId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+> = WorkspaceViewLayoutBase<PropertyId> & {
+  endDatePropertyId: PropertyId;
+  groupByPropertyId?: PropertyId | undefined;
+  showTable: boolean;
+  startDatePropertyId: PropertyId;
   type: "timeline";
   zoom: WorkspaceTimelineZoomLevel;
 };
@@ -79,15 +123,19 @@ export type WorkspaceTimelineViewLayout = WorkspaceViewLayoutBase & {
  * Presentation over one canonical entity collection. Layout arms own only
  * display and query configuration; entity values never belong to a view.
  */
-export type WorkspaceViewLayout =
-  | WorkspaceTableViewLayout
-  | WorkspaceKanbanViewLayout
-  | WorkspaceCalendarViewLayout
-  | WorkspaceTimelineViewLayout;
+export type WorkspaceViewLayout<
+  PropertyId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+> =
+  | WorkspaceTableViewLayout<PropertyId>
+  | WorkspaceKanbanViewLayout<PropertyId>
+  | WorkspaceCalendarViewLayout<PropertyId>
+  | WorkspaceTimelineViewLayout<PropertyId>;
 
 export type WorkspaceSavedView<
   ViewId extends WorkspaceIdentifier = WorkspaceIdentifier,
-  Layout extends WorkspaceViewLayout = WorkspaceViewLayout,
+  PropertyId extends WorkspacePropertyIdentifier = WorkspacePropertyIdentifier,
+  Layout extends WorkspaceViewLayout<PropertyId> =
+    WorkspaceViewLayout<PropertyId>,
 > = {
   createdAt: string;
   id: ViewId;

--- a/packages/workspace-model/src/views.ts
+++ b/packages/workspace-model/src/views.ts
@@ -1,0 +1,106 @@
+import type { CalculationKind } from "@stll/calculations";
+import type { ConditionNode } from "@stll/conditions";
+
+import type { WorkspaceIdentifier } from "./properties";
+
+export const workspaceViewLayoutTypes = [
+  "table",
+  "kanban",
+  "calendar",
+  "timeline",
+] as const;
+
+export type WorkspaceViewLayoutType = (typeof workspaceViewLayoutTypes)[number];
+
+export const workspaceCalendarModes = ["month", "week", "year"] as const;
+export type WorkspaceCalendarMode = (typeof workspaceCalendarModes)[number];
+
+export const workspaceTimelineZoomLevels = [
+  "day",
+  "week",
+  "month",
+  "quarter",
+] as const;
+export type WorkspaceTimelineZoomLevel =
+  (typeof workspaceTimelineZoomLevels)[number];
+
+export const workspaceTimelineTableModes = ["hidden", "visible"] as const;
+export type WorkspaceTimelineTableMode =
+  (typeof workspaceTimelineTableModes)[number];
+
+export type WorkspaceViewSort = {
+  desc: boolean;
+  propertyId: string;
+};
+
+export type WorkspaceViewCalculation = {
+  kind: CalculationKind;
+  propertyId: string;
+};
+
+export type WorkspaceViewLayoutBase = {
+  calculations: readonly WorkspaceViewCalculation[];
+  filters: readonly ConditionNode[];
+  hiddenProperties: readonly string[];
+  sorts: readonly WorkspaceViewSort[];
+  version: 1;
+};
+
+export type WorkspaceTableViewLayout = WorkspaceViewLayoutBase & {
+  columnOrder: readonly string[];
+  columnPinning: readonly string[];
+  groupByPropertyId?: string | undefined;
+  type: "table";
+};
+
+export type WorkspaceKanbanViewLayout = WorkspaceViewLayoutBase & {
+  groupByPropertyId?: string | undefined;
+  type: "kanban";
+};
+
+export type WorkspaceCalendarViewLayout = WorkspaceViewLayoutBase & {
+  additionalDatePropertyIds?: readonly string[] | undefined;
+  datePropertyId: string;
+  endDatePropertyId?: string | undefined;
+  mode: WorkspaceCalendarMode;
+  type: "calendar";
+};
+
+export type WorkspaceTimelineViewLayout = WorkspaceViewLayoutBase & {
+  endDatePropertyId: string;
+  groupByPropertyId?: string | undefined;
+  startDatePropertyId: string;
+  tableMode: WorkspaceTimelineTableMode;
+  type: "timeline";
+  zoom: WorkspaceTimelineZoomLevel;
+};
+
+/**
+ * Presentation over one canonical entity collection. Layout arms own only
+ * display and query configuration; entity values never belong to a view.
+ */
+export type WorkspaceViewLayout =
+  | WorkspaceTableViewLayout
+  | WorkspaceKanbanViewLayout
+  | WorkspaceCalendarViewLayout
+  | WorkspaceTimelineViewLayout;
+
+export type WorkspaceSavedView<
+  ViewId extends WorkspaceIdentifier = WorkspaceIdentifier,
+  Layout extends WorkspaceViewLayout = WorkspaceViewLayout,
+> = {
+  createdAt: string;
+  id: ViewId;
+  layout: Layout;
+  name: string;
+  position: number;
+  version: 1;
+};
+
+const workspaceViewLayoutTypeSet: ReadonlySet<string> = new Set(
+  workspaceViewLayoutTypes,
+);
+
+export const isWorkspaceViewLayoutType = (
+  value: string,
+): value is WorkspaceViewLayoutType => workspaceViewLayoutTypeSet.has(value);

--- a/packages/workspace-model/tsdown.config.ts
+++ b/packages/workspace-model/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/properties.ts"],
+  entry: ["src/properties.ts", "src/views.ts"],
   format: ["esm"],
   platform: "neutral",
   dts: true,


### PR DESCRIPTION
## Summary

- add saved table, kanban, calendar, and timeline layout contracts to `@stll/workspace-model`
- keep filters on the canonical conditions AST and calculations on the shared calculation kinds
- make views presentation-only so every layout references one canonical entity collection

## Validation

- package build, tests, typecheck, lint, and formatting
- packed export resolution and tarball contents
- changeset guard
- focused security review: type-only shared dependencies, bounded runtime discriminators, no I/O or authorization behavior

## Stack

Depends on #2302 for the workspace model package.