### PR TITLE
fix: rebuild statute search from canonical corpus text

### DIFF
--- a/apps/api/drizzle/20260820120000_legislation_updated_trail_index/migration.sql
+++ b/apps/api/drizzle/20260820120000_legislation_updated_trail_index/migration.sql
@@ -1,0 +1,29 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- The bounded updated-row walk keysets and orders by (updated_at, id).
+-- Build its matching access path without blocking writes.
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+
+-- stella-migration-safety: reviewed destructive-change - this retry cleanup
+-- targets only this migration's index; a cancelled concurrent build can leave
+-- an INVALID index that would otherwise block recreation by name.
+DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_updated_id_idx";
+--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "legislation_documents_updated_id_idx"
+  ON "legislation_documents" ("updated_at", "id");
+--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/drizzle/20260820130000_legislation_search_retry/migration.sql
+++ b/apps/api/drizzle/20260820130000_legislation_search_retry/migration.sql
@@ -1,0 +1,25 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+ALTER TABLE "legislation_search_documents"
+  ADD COLUMN IF NOT EXISTS "retry_after" timestamptz;--> statement-breakpoint
+
+-- Drizzle wraps migrations in a transaction, while PostgreSQL requires the
+-- retry index to build concurrently on the existing projection table.
+-- squawk-ignore transaction-nesting
+COMMIT;--> statement-breakpoint
+SET statement_timeout = 0;--> statement-breakpoint
+SET lock_timeout = 0;--> statement-breakpoint
+
+-- stella-migration-safety: reviewed destructive-change - removes only this
+-- migration's index so a cancelled INVALID build can be retried.
+DROP INDEX CONCURRENTLY IF EXISTS "legislation_search_docs_retry_idx";--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "legislation_search_docs_retry_idx"
+  ON "legislation_search_documents" ("retry_after", "document_id")
+  WHERE "retry_after" IS NOT NULL;--> statement-breakpoint
+
+SET statement_timeout = '5s';--> statement-breakpoint
+SET lock_timeout = '1s';--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/db/schema/legislation-search-retry.test.ts
+++ b/apps/api/src/db/schema/legislation-search-retry.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { getTableConfig } from "drizzle-orm/pg-core";
+import { getTableConfig, PgDialect } from "drizzle-orm/pg-core";
 import { readFileSync } from "node:fs";
 import nodePath from "node:path";
 
@@ -13,9 +13,10 @@ const MIGRATION = nodePath.resolve(
 
 test("the legislation search retry trail matches its migration", () => {
   const config = getTableConfig(legislationSearchDocuments);
-  expect(config.columns.some((column) => column.name === "retry_after")).toBe(
-    true,
+  const retryAfter = config.columns.find(
+    (column) => column.name === "retry_after",
   );
+  expect(retryAfter?.notNull).toBe(false);
   const index = config.indexes.find(
     (candidate) => candidate.config.name === INDEX_NAME,
   );
@@ -24,6 +25,11 @@ test("the legislation search retry trail matches its migration", () => {
       "name" in column ? column.name : undefined,
     ),
   ).toEqual(["retry_after", "document_id"]);
+  expect(
+    index?.config.where === undefined
+      ? undefined
+      : new PgDialect().sqlToQuery(index.config.where).sql,
+  ).toBe('("legislation_search_documents"."retry_after" is not null)');
 
   const migration = readFileSync(MIGRATION, "utf-8").replaceAll(/\s+/gu, " ");
   expect(migration).toContain(

--- a/apps/api/src/db/schema/legislation-search-retry.test.ts
+++ b/apps/api/src/db/schema/legislation-search-retry.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { readFileSync } from "node:fs";
+import nodePath from "node:path";
+
+import { legislationSearchDocuments } from "@/api/db/schema";
+
+const INDEX_NAME = "legislation_search_docs_retry_idx";
+const MIGRATION = nodePath.resolve(
+  import.meta.dir,
+  "../../../drizzle/20260820130000_legislation_search_retry/migration.sql",
+);
+
+test("the legislation search retry trail matches its migration", () => {
+  const config = getTableConfig(legislationSearchDocuments);
+  expect(config.columns.some((column) => column.name === "retry_after")).toBe(
+    true,
+  );
+  const index = config.indexes.find(
+    (candidate) => candidate.config.name === INDEX_NAME,
+  );
+  expect(
+    index?.config.columns.map((column) =>
+      "name" in column ? column.name : undefined,
+    ),
+  ).toEqual(["retry_after", "document_id"]);
+
+  const migration = readFileSync(MIGRATION, "utf-8").replaceAll(/\s+/gu, " ");
+  expect(migration).toContain(
+    'ADD COLUMN IF NOT EXISTS "retry_after" timestamptz;',
+  );
+  expect(migration).toContain(
+    `CREATE INDEX CONCURRENTLY "${INDEX_NAME}" ON "legislation_search_documents" ("retry_after", "document_id") WHERE "retry_after" IS NOT NULL;`,
+  );
+});

--- a/apps/api/src/db/schema/legislation-updated-trail-index.test.ts
+++ b/apps/api/src/db/schema/legislation-updated-trail-index.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { readFileSync } from "node:fs";
+import nodePath from "node:path";
+
+import { legislationDocuments } from "@/api/db/schema";
+
+const INDEX_NAME = "legislation_documents_updated_id_idx";
+const MIGRATION = nodePath.resolve(
+  import.meta.dir,
+  "../../../drizzle/20260820120000_legislation_updated_trail_index/migration.sql",
+);
+
+test("the legislation update trail has the same key order in schema and migration", () => {
+  const index = getTableConfig(legislationDocuments).indexes.find(
+    (candidate) => candidate.config.name === INDEX_NAME,
+  );
+  expect(
+    index?.config.columns.map((column) =>
+      "name" in column ? column.name : undefined,
+    ),
+  ).toEqual(["updated_at", "id"]);
+
+  const createStatement = /CREATE INDEX CONCURRENTLY[^;]+;/u
+    .exec(readFileSync(MIGRATION, "utf-8"))
+    ?.at(0)
+    ?.replaceAll(/\s+/gu, " ")
+    .trim();
+  expect(createStatement).toBe(
+    `CREATE INDEX CONCURRENTLY "${INDEX_NAME}" ON "legislation_documents" ("updated_at", "id");`,
+  );
+});

--- a/apps/api/src/db/schema/legislation.ts
+++ b/apps/api/src/db/schema/legislation.ts
@@ -184,9 +184,14 @@ export const legislationSearchDocuments = p.pgTable(
     regconfig: p.varchar({ length: 64 }).notNull().default("simple"),
     tsv: tsvector(),
     updatedAt: timestamptz("updated_at").notNull().defaultNow(),
+    retryAfter: timestamptz("retry_after"),
   },
   (table) => [
     p.index("legislation_search_docs_tsv_idx").using("gin", table.tsv),
+    p
+      .index("legislation_search_docs_retry_idx")
+      .on(table.retryAfter, table.documentId)
+      .where(isNotNull(table.retryAfter)),
     ...globalCaseLawPolicies(),
   ],
 );

--- a/apps/api/src/db/schema/legislation.ts
+++ b/apps/api/src/db/schema/legislation.ts
@@ -145,6 +145,7 @@ export const legislationDocuments = p.pgTable(
     p.index("legislation_documents_status_idx").on(t.status),
     p.index("legislation_documents_effective_date_idx").on(t.effectiveDate),
     p.index("legislation_documents_created_at_idx").on(t.createdAt),
+    p.index("legislation_documents_updated_id_idx").on(t.updatedAt, t.id),
     p
       .index("legislation_documents_citation_authority_idx")
       .on(t.citationAuthority),

--- a/apps/api/src/handlers/legislation/search-index.db.test.ts
+++ b/apps/api/src/handlers/legislation/search-index.db.test.ts
@@ -3,6 +3,7 @@ import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import type { Transaction } from "@/api/db/root";
+import type { ScopedDb } from "@/api/db/safe-db";
 import {
   legislationDocuments,
   legislationSearchDocuments,
@@ -19,6 +20,25 @@ import { packKey } from "@/api/lib/legal-search/corpus-pack";
 import type { DecisionSection } from "@/api/lib/legal-search/document-types";
 import { brandPersistedLegislationDocumentId } from "@/api/lib/safe-id-boundaries";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+process.env["REDIS_URL"] ??= "redis://localhost:6379";
+process.env["GOTENBERG_URL"] ??= "http://localhost:3003";
+process.env["GOTENBERG_USERNAME"] ??= "test";
+process.env["GOTENBERG_PASSWORD"] ??= "test";
+
+const { searchLegislationHandler } =
+  await import("@/api/handlers/legislation/search");
+
+const searchDependencies = {
+  loadSearchConfigs: async () => [
+    {
+      regconfig: "simple",
+      useUnaccent: false,
+      includeDefault: true,
+      languages: [],
+    },
+  ],
+} satisfies NonNullable<Parameters<typeof searchLegislationHandler>[2]>;
 
 let client: Awaited<ReturnType<typeof createTestPglite>> | undefined;
 let db: ReturnType<typeof drizzle>;
@@ -57,6 +77,22 @@ const scopedDb: Parameters<typeof indexLegislationDocument>[1] = async (
   // eslint-disable-next-line typescript/no-unsafe-type-assertion -- test transaction shim
   await callback(db as unknown as Transaction);
 
+const searchScopedDb: ScopedDb = async (callback) => {
+  const tx = new Proxy(db, {
+    get: (target, property, receiver) => {
+      if (property !== "execute") {
+        return Reflect.get(target, property, receiver);
+      }
+      return async (...args: Parameters<typeof db.execute>) =>
+        (await db.execute(...args)).rows;
+    },
+  });
+  // SAFETY: the proxy preserves the PGlite DB and adapts only execute's result
+  // shape to match the production driver used by this search boundary.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- test transaction shim
+  return await callback(tx as unknown as Transaction);
+};
+
 const seedDocument = ({
   id,
   fulltext,
@@ -89,6 +125,12 @@ beforeAll(
   async () => {
     client = await createTestPglite();
     db = drizzle({ client });
+    await db.execute(
+      sql`CREATE FUNCTION public.unaccent(input text) RETURNS text LANGUAGE sql IMMUTABLE STRICT AS 'SELECT input'`,
+    );
+    await db.execute(
+      sql`CREATE TEXT SEARCH CONFIGURATION public.stella_unaccent (COPY = pg_catalog.simple)`,
+    );
 
     await db.insert(legislationSources).values({
       id: sourceId,
@@ -183,12 +225,14 @@ test("the FTS rebuild reads canonical text only when inline payloads are absent"
     "canonical corpus sentinel",
   );
 
-  const [match] = await db
-    .select({
-      matches: sql<boolean>`${legislationSearchDocuments.tsv} @@ plainto_tsquery('simple', 'canonical corpus sentinel')`,
-    })
-    .from(legislationSearchDocuments)
-    .where(eq(legislationSearchDocuments.documentId, corpusId));
+  const match = (
+    await db
+      .select({
+        matches: sql<boolean>`${legislationSearchDocuments.tsv} @@ plainto_tsquery('simple', 'canonical corpus sentinel')`,
+      })
+      .from(legislationSearchDocuments)
+      .where(eq(legislationSearchDocuments.documentId, corpusId))
+  ).at(0);
   expect(match?.matches).toBe(true);
 });
 
@@ -225,15 +269,31 @@ test("an unreadable corpus row does not block the bounded missing scan", async (
   expect(readKeys).toEqual([unavailableKey, laterKey]);
   expect(unavailableCorpusId < laterCorpusId).toBe(true);
 
-  const [failedProjection] = await db
-    .select({
-      searchableText: legislationSearchDocuments.searchableText,
-      retryAfter: legislationSearchDocuments.retryAfter,
-    })
-    .from(legislationSearchDocuments)
-    .where(eq(legislationSearchDocuments.documentId, unavailableCorpusId));
+  const failedProjection = (
+    await db
+      .select({
+        searchableText: legislationSearchDocuments.searchableText,
+        retryAfter: legislationSearchDocuments.retryAfter,
+      })
+      .from(legislationSearchDocuments)
+      .where(eq(legislationSearchDocuments.documentId, unavailableCorpusId))
+  ).at(0);
   expect(failedProjection?.searchableText).not.toContain("corpus sentinel");
   expect(failedProjection?.retryAfter).not.toBeNull();
+  await db
+    .update(legislationSearchDocuments)
+    .set({
+      searchableText: "retry pending sentinel",
+      tsv: sql`to_tsvector('simple', 'retry pending sentinel')`,
+    })
+    .where(eq(legislationSearchDocuments.documentId, unavailableCorpusId));
+  expect(
+    await searchLegislationHandler(
+      { query: "retry pending sentinel" },
+      searchScopedDb,
+      searchDependencies,
+    ),
+  ).toMatchObject({ hits: [] });
 
   await db
     .update(legislationSearchDocuments)
@@ -244,15 +304,24 @@ test("an unreadable corpus row does not block the bounded missing scan", async (
   ).toEqual({ found: 1, indexed: 1 });
   expect(readKeys).toEqual([unavailableKey, laterKey, unavailableKey]);
 
-  const [repaired] = await db
-    .select({
-      searchableText: legislationSearchDocuments.searchableText,
-      retryAfter: legislationSearchDocuments.retryAfter,
-    })
-    .from(legislationSearchDocuments)
-    .where(eq(legislationSearchDocuments.documentId, unavailableCorpusId));
+  const repaired = (
+    await db
+      .select({
+        searchableText: legislationSearchDocuments.searchableText,
+        retryAfter: legislationSearchDocuments.retryAfter,
+      })
+      .from(legislationSearchDocuments)
+      .where(eq(legislationSearchDocuments.documentId, unavailableCorpusId))
+  ).at(0);
   expect(repaired?.searchableText).toContain("repaired corpus sentinel");
   expect(repaired?.retryAfter).toBeNull();
+  expect(
+    await searchLegislationHandler(
+      { query: "repaired corpus sentinel" },
+      searchScopedDb,
+      searchDependencies,
+    ),
+  ).toMatchObject({ hits: [{ documentId: unavailableCorpusId }] });
 });
 
 test("the stale scan breaks equal update timestamps by document id", async () => {

--- a/apps/api/src/handlers/legislation/search-index.db.test.ts
+++ b/apps/api/src/handlers/legislation/search-index.db.test.ts
@@ -1,0 +1,155 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  legislationDocuments,
+  legislationSearchDocuments,
+  legislationSources,
+} from "@/api/db/schema";
+import { indexLegislationDocument } from "@/api/handlers/legislation/search-index";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { formatCorpusLocation } from "@/api/lib/legal-search/corpus-location";
+import { packKey } from "@/api/lib/legal-search/corpus-pack";
+import type { DecisionSection } from "@/api/lib/legal-search/document-types";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+let client: Awaited<ReturnType<typeof createTestPglite>> | undefined;
+let db: ReturnType<typeof drizzle>;
+
+const sourceId = createSafeId<"legislationSource">();
+const fulltextId = createSafeId<"legislationDocument">();
+const sectionsId = createSafeId<"legislationDocument">();
+const corpusId = createSafeId<"legislationDocument">();
+const corpusKey = formatCorpusLocation({
+  type: "packed",
+  packKey: packKey({
+    jurisdiction: "CZE",
+    packId: "0198cb55-8e8b-7b95-83bf-c9e219c70db2",
+  }),
+  offset: 4096,
+  length: 512,
+});
+
+const scopedDb: Parameters<typeof indexLegislationDocument>[1] = async (
+  callback,
+) =>
+  // SAFETY: pglite stands in for the transaction used by this projection;
+  // the test exercises only the statements issued by the callback.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion -- test transaction shim
+  await callback(db as unknown as Transaction);
+
+const seedDocument = ({
+  id,
+  fulltext,
+  sections,
+  textS3Key,
+}: {
+  id: SafeId<"legislationDocument">;
+  fulltext: string | null;
+  sections: DecisionSection[] | null;
+  textS3Key: string;
+}) => ({
+  id,
+  sourceId,
+  eli: `CZ/2026/${id}`,
+  title: "Corpus reader search fixture",
+  country: "CZE",
+  language: "cs",
+  fulltext,
+  sections,
+  textS3Key,
+});
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    db = drizzle({ client });
+
+    await db.insert(legislationSources).values({
+      id: sourceId,
+      adapterKey: "fts-canonical-corpus",
+      name: "FTS canonical corpus fixture",
+    });
+    await db.insert(legislationDocuments).values([
+      seedDocument({
+        id: fulltextId,
+        fulltext: "inline fulltext sentinel",
+        sections: null,
+        textS3Key: "legal-corpus/documents/fulltext/text.zst",
+      }),
+      seedDocument({
+        id: sectionsId,
+        fulltext: null,
+        sections: [
+          {
+            index: 0,
+            type: "unknown",
+            title: null,
+            text: "inline sections sentinel",
+          },
+        ],
+        textS3Key: "legal-corpus/documents/sections/text.zst",
+      }),
+      seedDocument({
+        id: corpusId,
+        fulltext: null,
+        sections: null,
+        textS3Key: corpusKey,
+      }),
+    ]);
+  },
+  { timeout: 30_000 },
+);
+
+afterAll(async () => {
+  if (client !== undefined) {
+    await client.close();
+  }
+});
+
+test("the FTS rebuild reads canonical text only when inline payloads are absent", async () => {
+  const readKeys: string[] = [];
+  const dependencies: Parameters<typeof indexLegislationDocument>[2] = {
+    readText: async (storedKey) => {
+      readKeys.push(storedKey);
+      return "canonical corpus sentinel";
+    },
+    resolveConfig: async () => ({ regconfig: "simple", useUnaccent: false }),
+  };
+
+  await indexLegislationDocument(fulltextId, scopedDb, dependencies);
+  await indexLegislationDocument(sectionsId, scopedDb, dependencies);
+  await indexLegislationDocument(corpusId, scopedDb, dependencies);
+
+  expect(readKeys).toEqual([corpusKey]);
+
+  const rows = await db
+    .select({
+      documentId: legislationSearchDocuments.documentId,
+      searchableText: legislationSearchDocuments.searchableText,
+    })
+    .from(legislationSearchDocuments);
+  const searchableTextById = new Map(
+    rows.map((row) => [row.documentId, row.searchableText]),
+  );
+  expect(searchableTextById.get(fulltextId)).toContain(
+    "inline fulltext sentinel",
+  );
+  expect(searchableTextById.get(sectionsId)).toContain(
+    "inline sections sentinel",
+  );
+  expect(searchableTextById.get(corpusId)).toContain(
+    "canonical corpus sentinel",
+  );
+
+  const [match] = await db
+    .select({
+      matches: sql<boolean>`${legislationSearchDocuments.tsv} @@ plainto_tsquery('simple', 'canonical corpus sentinel')`,
+    })
+    .from(legislationSearchDocuments)
+    .where(eq(legislationSearchDocuments.documentId, corpusId));
+  expect(match?.matches).toBe(true);
+});

--- a/apps/api/src/handlers/legislation/search-index.db.test.ts
+++ b/apps/api/src/handlers/legislation/search-index.db.test.ts
@@ -11,13 +11,13 @@ import {
 import {
   backfillLegislationSearchIndex,
   indexLegislationDocument,
-  removeLegislationFromIndex,
 } from "@/api/handlers/legislation/search-index";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { formatCorpusLocation } from "@/api/lib/legal-search/corpus-location";
 import { packKey } from "@/api/lib/legal-search/corpus-pack";
 import type { DecisionSection } from "@/api/lib/legal-search/document-types";
+import { brandPersistedLegislationDocumentId } from "@/api/lib/safe-id-boundaries";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
 let client: Awaited<ReturnType<typeof createTestPglite>> | undefined;
@@ -27,8 +27,18 @@ const sourceId = createSafeId<"legislationSource">();
 const fulltextId = createSafeId<"legislationDocument">();
 const sectionsId = createSafeId<"legislationDocument">();
 const corpusId = createSafeId<"legislationDocument">();
-const unavailableCorpusId = createSafeId<"legislationDocument">();
-const laterCorpusId = createSafeId<"legislationDocument">();
+const unavailableCorpusId = brandPersistedLegislationDocumentId(
+  "0198cb55-8e8b-7b95-83bf-c9e219c70001",
+);
+const laterCorpusId = brandPersistedLegislationDocumentId(
+  "0198cb55-8e8b-7b95-83bf-c9e219c70002",
+);
+const firstStaleCorpusId = brandPersistedLegislationDocumentId(
+  "0198cb55-8e8b-7b95-83bf-c9e219c70003",
+);
+const laterStaleCorpusId = brandPersistedLegislationDocumentId(
+  "0198cb55-8e8b-7b95-83bf-c9e219c70004",
+);
 const corpusKey = formatCorpusLocation({
   type: "packed",
   packKey: packKey({
@@ -117,7 +127,7 @@ beforeAll(
         sections: null,
         textS3Key: "legal-corpus/documents/later/text.zst",
         createdAt: new Date("2026-01-01T00:00:00.000Z"),
-        updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       }),
       seedDocument({
         id: unavailableCorpusId,
@@ -186,16 +196,25 @@ test("an unreadable corpus row does not block the bounded missing scan", async (
   const unavailableKey = "legal-corpus/documents/unavailable/text.zst";
   const laterKey = "legal-corpus/documents/later/text.zst";
   const readKeys: string[] = [];
+  let unavailableAttempts = 0;
   const dependencies: Parameters<typeof backfillLegislationSearchIndex>[2] = {
     readText: async (storedKey) => {
       readKeys.push(storedKey);
       if (storedKey === unavailableKey) {
-        throw new Error("unavailable corpus fixture");
+        unavailableAttempts += 1;
+        if (unavailableAttempts === 1) {
+          throw new Error("unavailable corpus fixture");
+        }
+        return "repaired corpus sentinel";
       }
       return "later corpus sentinel";
     },
     resolveConfig: async () => ({ regconfig: "simple", useUnaccent: false }),
   };
+  await indexLegislationDocument(fulltextId, scopedDb, dependencies);
+  await indexLegislationDocument(sectionsId, scopedDb, dependencies);
+  await indexLegislationDocument(corpusId, scopedDb, dependencies);
+  readKeys.length = 0;
 
   expect(
     await backfillLegislationSearchIndex(scopedDb, 1, dependencies),
@@ -204,27 +223,84 @@ test("an unreadable corpus row does not block the bounded missing scan", async (
     await backfillLegislationSearchIndex(scopedDb, 1, dependencies),
   ).toEqual({ found: 1, indexed: 1 });
   expect(readKeys).toEqual([unavailableKey, laterKey]);
+  expect(unavailableCorpusId < laterCorpusId).toBe(true);
 
-  const projected = await db
+  const [failedProjection] = await db
     .select({
-      documentId: legislationSearchDocuments.documentId,
       searchableText: legislationSearchDocuments.searchableText,
+      retryAfter: legislationSearchDocuments.retryAfter,
     })
     .from(legislationSearchDocuments)
     .where(eq(legislationSearchDocuments.documentId, unavailableCorpusId));
-  expect(projected.at(0)?.searchableText).not.toContain(
-    "later corpus sentinel",
-  );
+  expect(failedProjection?.searchableText).not.toContain("corpus sentinel");
+  expect(failedProjection?.retryAfter).not.toBeNull();
 
-  await removeLegislationFromIndex(unavailableCorpusId, scopedDb);
-  await backfillLegislationSearchIndex(scopedDb, 1, {
-    readText: async () => "repaired corpus sentinel",
-    resolveConfig: dependencies.resolveConfig,
-  });
+  await db
+    .update(legislationSearchDocuments)
+    .set({ retryAfter: new Date("2025-01-01T00:00:00.000Z") })
+    .where(eq(legislationSearchDocuments.documentId, unavailableCorpusId));
+  expect(
+    await backfillLegislationSearchIndex(scopedDb, 1, dependencies),
+  ).toEqual({ found: 1, indexed: 1 });
+  expect(readKeys).toEqual([unavailableKey, laterKey, unavailableKey]);
 
   const [repaired] = await db
-    .select({ searchableText: legislationSearchDocuments.searchableText })
+    .select({
+      searchableText: legislationSearchDocuments.searchableText,
+      retryAfter: legislationSearchDocuments.retryAfter,
+    })
     .from(legislationSearchDocuments)
     .where(eq(legislationSearchDocuments.documentId, unavailableCorpusId));
   expect(repaired?.searchableText).toContain("repaired corpus sentinel");
+  expect(repaired?.retryAfter).toBeNull();
+});
+
+test("the stale scan breaks equal update timestamps by document id", async () => {
+  const firstKey = "legal-corpus/documents/stale-first/text.zst";
+  const laterKey = "legal-corpus/documents/stale-later/text.zst";
+  await db.insert(legislationDocuments).values([
+    seedDocument({
+      id: laterStaleCorpusId,
+      fulltext: null,
+      sections: null,
+      textS3Key: laterKey,
+    }),
+    seedDocument({
+      id: firstStaleCorpusId,
+      fulltext: null,
+      sections: null,
+      textS3Key: firstKey,
+    }),
+  ]);
+
+  const readKeys: string[] = [];
+  const dependencies: Parameters<typeof backfillLegislationSearchIndex>[2] = {
+    readText: async (storedKey) => {
+      readKeys.push(storedKey);
+      return "stale corpus sentinel";
+    },
+    resolveConfig: async () => ({ regconfig: "simple", useUnaccent: false }),
+  };
+  await indexLegislationDocument(fulltextId, scopedDb, dependencies);
+  await indexLegislationDocument(sectionsId, scopedDb, dependencies);
+  await indexLegislationDocument(corpusId, scopedDb, dependencies);
+  await indexLegislationDocument(unavailableCorpusId, scopedDb, dependencies);
+  await indexLegislationDocument(laterCorpusId, scopedDb, dependencies);
+  await indexLegislationDocument(laterStaleCorpusId, scopedDb, dependencies);
+  await indexLegislationDocument(firstStaleCorpusId, scopedDb, dependencies);
+  readKeys.length = 0;
+
+  const staleAt = new Date("2027-01-01T00:00:00.000Z");
+  await db
+    .update(legislationDocuments)
+    .set({ updatedAt: staleAt })
+    .where(
+      sql`${legislationDocuments.id} IN (${firstStaleCorpusId}, ${laterStaleCorpusId})`,
+    );
+
+  expect(
+    await backfillLegislationSearchIndex(scopedDb, 1, dependencies),
+  ).toEqual({ found: 1, indexed: 1 });
+  expect(firstStaleCorpusId < laterStaleCorpusId).toBe(true);
+  expect(readKeys).toEqual([firstKey]);
 });

--- a/apps/api/src/handlers/legislation/search-index.db.test.ts
+++ b/apps/api/src/handlers/legislation/search-index.db.test.ts
@@ -8,7 +8,11 @@ import {
   legislationSearchDocuments,
   legislationSources,
 } from "@/api/db/schema";
-import { indexLegislationDocument } from "@/api/handlers/legislation/search-index";
+import {
+  backfillLegislationSearchIndex,
+  indexLegislationDocument,
+  removeLegislationFromIndex,
+} from "@/api/handlers/legislation/search-index";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { formatCorpusLocation } from "@/api/lib/legal-search/corpus-location";
@@ -23,6 +27,8 @@ const sourceId = createSafeId<"legislationSource">();
 const fulltextId = createSafeId<"legislationDocument">();
 const sectionsId = createSafeId<"legislationDocument">();
 const corpusId = createSafeId<"legislationDocument">();
+const unavailableCorpusId = createSafeId<"legislationDocument">();
+const laterCorpusId = createSafeId<"legislationDocument">();
 const corpusKey = formatCorpusLocation({
   type: "packed",
   packKey: packKey({
@@ -46,11 +52,15 @@ const seedDocument = ({
   fulltext,
   sections,
   textS3Key,
+  createdAt,
+  updatedAt,
 }: {
   id: SafeId<"legislationDocument">;
   fulltext: string | null;
   sections: DecisionSection[] | null;
   textS3Key: string;
+  createdAt?: Date;
+  updatedAt?: Date;
 }) => ({
   id,
   sourceId,
@@ -61,6 +71,8 @@ const seedDocument = ({
   fulltext,
   sections,
   textS3Key,
+  createdAt,
+  updatedAt,
 });
 
 beforeAll(
@@ -98,6 +110,22 @@ beforeAll(
         fulltext: null,
         sections: null,
         textS3Key: corpusKey,
+      }),
+      seedDocument({
+        id: laterCorpusId,
+        fulltext: null,
+        sections: null,
+        textS3Key: "legal-corpus/documents/later/text.zst",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+      }),
+      seedDocument({
+        id: unavailableCorpusId,
+        fulltext: null,
+        sections: null,
+        textS3Key: "legal-corpus/documents/unavailable/text.zst",
+        createdAt: new Date("2026-01-02T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       }),
     ]);
   },
@@ -152,4 +180,51 @@ test("the FTS rebuild reads canonical text only when inline payloads are absent"
     .from(legislationSearchDocuments)
     .where(eq(legislationSearchDocuments.documentId, corpusId));
   expect(match?.matches).toBe(true);
+});
+
+test("an unreadable corpus row does not block the bounded missing scan", async () => {
+  const unavailableKey = "legal-corpus/documents/unavailable/text.zst";
+  const laterKey = "legal-corpus/documents/later/text.zst";
+  const readKeys: string[] = [];
+  const dependencies: Parameters<typeof backfillLegislationSearchIndex>[2] = {
+    readText: async (storedKey) => {
+      readKeys.push(storedKey);
+      if (storedKey === unavailableKey) {
+        throw new Error("unavailable corpus fixture");
+      }
+      return "later corpus sentinel";
+    },
+    resolveConfig: async () => ({ regconfig: "simple", useUnaccent: false }),
+  };
+
+  expect(
+    await backfillLegislationSearchIndex(scopedDb, 1, dependencies),
+  ).toEqual({ found: 1, indexed: 0 });
+  expect(
+    await backfillLegislationSearchIndex(scopedDb, 1, dependencies),
+  ).toEqual({ found: 1, indexed: 1 });
+  expect(readKeys).toEqual([unavailableKey, laterKey]);
+
+  const projected = await db
+    .select({
+      documentId: legislationSearchDocuments.documentId,
+      searchableText: legislationSearchDocuments.searchableText,
+    })
+    .from(legislationSearchDocuments)
+    .where(eq(legislationSearchDocuments.documentId, unavailableCorpusId));
+  expect(projected.at(0)?.searchableText).not.toContain(
+    "later corpus sentinel",
+  );
+
+  await removeLegislationFromIndex(unavailableCorpusId, scopedDb);
+  await backfillLegislationSearchIndex(scopedDb, 1, {
+    readText: async () => "repaired corpus sentinel",
+    resolveConfig: dependencies.resolveConfig,
+  });
+
+  const [repaired] = await db
+    .select({ searchableText: legislationSearchDocuments.searchableText })
+    .from(legislationSearchDocuments)
+    .where(eq(legislationSearchDocuments.documentId, unavailableCorpusId));
+  expect(repaired?.searchableText).toContain("repaired corpus sentinel");
 });

--- a/apps/api/src/handlers/legislation/search-index.ts
+++ b/apps/api/src/handlers/legislation/search-index.ts
@@ -10,6 +10,7 @@ import { redistributableLegislationSource } from "@/api/handlers/legislation/red
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { setCorpusBackfillStatementTimeout } from "@/api/lib/legal-search/backfill-statement-timeout";
+import { readCorpusText } from "@/api/lib/legal-search/corpus-storage";
 import type { DecisionSection } from "@/api/lib/legal-search/document-types";
 import { resolveFtsConfig } from "@/api/lib/legal-search/fts-config";
 import { logger } from "@/api/lib/observability/logger";
@@ -27,9 +28,23 @@ const sectionsToPlainText = (
   sections: readonly DecisionSection[] | null,
 ): string => sections?.map((s) => s.text).join(" ") ?? "";
 
+type LegislationSearchIndexDependencies = {
+  readText: typeof readCorpusText;
+  resolveConfig: typeof resolveFtsConfig;
+};
+
+const DEFAULT_DEPENDENCIES: LegislationSearchIndexDependencies = {
+  readText: readCorpusText,
+  resolveConfig: resolveFtsConfig,
+};
+
 export const indexLegislationDocument = async (
   documentId: SafeId<"legislationDocument">,
   scopedDb: ScopedDb,
+  {
+    readText,
+    resolveConfig,
+  }: LegislationSearchIndexDependencies = DEFAULT_DEPENDENCIES,
 ): Promise<void> => {
   const [document] = await scopedDb((tx) =>
     tx
@@ -40,6 +55,7 @@ export const indexLegislationDocument = async (
         language: legislationDocuments.language,
         fulltext: legislationDocuments.fulltext,
         sections: legislationDocuments.sections,
+        textS3Key: legislationDocuments.textS3Key,
       })
       .from(legislationDocuments)
       .innerJoin(
@@ -60,17 +76,22 @@ export const indexLegislationDocument = async (
     return;
   }
 
-  const bodyText =
-    document.fulltext ??
-    // SAFETY: sections is typed unknown in Drizzle's JSONB column but is
-    // always DecisionSection[] | null when set by ingestion.
-    sectionsToPlainText(document.sections);
+  let bodyText: string;
+  if (document.fulltext !== null) {
+    bodyText = document.fulltext;
+  } else if (document.sections !== null) {
+    bodyText = sectionsToPlainText(document.sections);
+  } else if (document.textS3Key !== null) {
+    bodyText = await readText(document.textS3Key);
+  } else {
+    bodyText = "";
+  }
 
   const searchableText = [document.eli, document.title, bodyText]
     .filter(Boolean)
     .join(" ");
 
-  const fts = await resolveFtsConfig(document.language);
+  const fts = await resolveConfig(document.language);
 
   const textExpr = fts.useUnaccent
     ? sql`unaccent(arabic_normalize(coalesce(${document.title}, '') || ' ' || coalesce(${searchableText}, '')))`

--- a/apps/api/src/handlers/legislation/search-index.ts
+++ b/apps/api/src/handlers/legislation/search-index.ts
@@ -1,3 +1,4 @@
+import { Result, TaggedError, UnhandledException } from "better-result";
 import { and, asc, eq, gt, notExists, sql } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
@@ -23,6 +24,13 @@ import { logger } from "@/api/lib/observability/logger";
  */
 
 const SEARCH_INDEX_CONCURRENCY = 4;
+
+class LegislationCorpusReadError extends TaggedError(
+  "LegislationCorpusReadError",
+)<{
+  message: string;
+  cause: unknown;
+}> {}
 
 const sectionsToPlainText = (
   sections: readonly DecisionSection[] | null,
@@ -77,12 +85,26 @@ export const indexLegislationDocument = async (
   }
 
   let bodyText: string;
+  let corpusReadFailure: { cause: unknown } | undefined;
   if (document.fulltext !== null) {
     bodyText = document.fulltext;
   } else if (document.sections !== null) {
     bodyText = sectionsToPlainText(document.sections);
   } else if (document.textS3Key !== null) {
-    bodyText = await readText(document.textS3Key);
+    const textS3Key = document.textS3Key;
+    const corpusRead = await Result.tryPromise(
+      async () => await readText(textS3Key),
+    );
+    if (Result.isOk(corpusRead)) {
+      bodyText = corpusRead.value;
+    } else {
+      bodyText = "";
+      const cause =
+        corpusRead.error instanceof UnhandledException
+          ? corpusRead.error.cause
+          : corpusRead.error;
+      corpusReadFailure = { cause };
+    }
   } else {
     bodyText = "";
   }
@@ -122,6 +144,13 @@ export const indexLegislationDocument = async (
       tsv = EXCLUDED.tsv
   `);
   });
+
+  if (corpusReadFailure !== undefined) {
+    throw new LegislationCorpusReadError({
+      message: "Canonical legislation corpus payload is unavailable",
+      cause: corpusReadFailure.cause,
+    });
+  }
 };
 
 type LegislationSearchIndexBackfillResult = { found: number; indexed: number };
@@ -129,6 +158,7 @@ type LegislationSearchIndexBackfillResult = { found: number; indexed: number };
 export const backfillLegislationSearchIndex = async (
   scopedDb: ScopedDb,
   batchSize: number,
+  dependencies: LegislationSearchIndexDependencies = DEFAULT_DEPENDENCIES,
 ): Promise<LegislationSearchIndexBackfillResult> => {
   const staleReserved = Math.max(1, Math.floor(batchSize / 4));
   const missingLimit = Math.max(1, batchSize - staleReserved);
@@ -157,7 +187,10 @@ export const backfillLegislationSearchIndex = async (
           ),
         ),
       )
-      .orderBy(asc(legislationDocuments.createdAt))
+      .orderBy(
+        asc(legislationDocuments.updatedAt),
+        asc(legislationDocuments.id),
+      )
       .limit(missingLimit),
   );
 
@@ -184,7 +217,10 @@ export const backfillLegislationSearchIndex = async (
           ),
         ),
       )
-      .orderBy(asc(legislationDocuments.createdAt))
+      .orderBy(
+        asc(legislationDocuments.updatedAt),
+        asc(legislationDocuments.id),
+      )
       .limit(staleLimit),
   );
 
@@ -194,7 +230,7 @@ export const backfillLegislationSearchIndex = async (
     id: SafeId<"legislationDocument">;
   }): Promise<number> => {
     try {
-      await indexLegislationDocument(row.id, scopedDb);
+      await indexLegislationDocument(row.id, scopedDb, dependencies);
       return 1;
     } catch (error) {
       captureError(error, {

--- a/apps/api/src/handlers/legislation/search-index.ts
+++ b/apps/api/src/handlers/legislation/search-index.ts
@@ -1,5 +1,16 @@
 import { Result, TaggedError, UnhandledException } from "better-result";
-import { and, asc, eq, gt, notExists, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  gt,
+  isNotNull,
+  isNull,
+  lte,
+  notExists,
+  or,
+  sql,
+} from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
@@ -24,6 +35,7 @@ import { logger } from "@/api/lib/observability/logger";
  */
 
 const SEARCH_INDEX_CONCURRENCY = 4;
+const CORPUS_READ_RETRY_DELAY_MS = 5 * 60_000;
 
 class LegislationCorpusReadError extends TaggedError(
   "LegislationCorpusReadError",
@@ -119,13 +131,17 @@ export const indexLegislationDocument = async (
     ? sql`unaccent(arabic_normalize(coalesce(${document.title}, '') || ' ' || coalesce(${searchableText}, '')))`
     : sql`arabic_normalize(coalesce(${document.title}, '') || ' ' || coalesce(${searchableText}, ''))`;
   const tsvExpr = sql`to_tsvector(${fts.regconfig}, ${textExpr})`;
+  const retryAfterExpr =
+    corpusReadFailure === undefined
+      ? sql`NULL`
+      : sql`now() + (${CORPUS_READ_RETRY_DELAY_MS} * interval '1 millisecond')`;
 
   await scopedDb(async (tx) => {
     await setCorpusBackfillStatementTimeout(tx);
     await tx.execute(sql`
     INSERT INTO legislation_search_documents (
       document_id, title, searchable_text,
-      language, regconfig, updated_at, tsv
+      language, regconfig, updated_at, retry_after, tsv
     ) VALUES (
       ${document.id},
       ${document.title},
@@ -133,6 +149,7 @@ export const indexLegislationDocument = async (
       ${document.language},
       ${fts.regconfig},
       now(),
+      ${retryAfterExpr},
       ${tsvExpr}
     )
     ON CONFLICT (document_id) DO UPDATE SET
@@ -141,6 +158,7 @@ export const indexLegislationDocument = async (
       language = EXCLUDED.language,
       regconfig = EXCLUDED.regconfig,
       updated_at = EXCLUDED.updated_at,
+      retry_after = EXCLUDED.retry_after,
       tsv = EXCLUDED.tsv
   `);
   });
@@ -210,10 +228,19 @@ export const backfillLegislationSearchIndex = async (
       .where(
         and(
           redistributableLegislationSource,
-          gt(
-            legislationDocuments.updatedAt,
-            // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- column-to-column comparison evaluated in Postgres; no JS Date is bound
-            legislationSearchDocuments.updatedAt,
+          or(
+            and(
+              isNull(legislationSearchDocuments.retryAfter),
+              gt(
+                legislationDocuments.updatedAt,
+                // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- column-to-column comparison evaluated in Postgres; no JS Date is bound
+                legislationSearchDocuments.updatedAt,
+              ),
+            ),
+            and(
+              isNotNull(legislationSearchDocuments.retryAfter),
+              lte(legislationSearchDocuments.retryAfter, sql`now()`),
+            ),
           ),
         ),
       )

--- a/apps/api/src/handlers/legislation/search.ts
+++ b/apps/api/src/handlers/legislation/search.ts
@@ -160,6 +160,7 @@ const pgSearch = async (
       ON legislation_sources.id = d.source_id
      AND ${redistributableLegislationSource}
     WHERE ${ftsSearch.predicate}
+      AND sd.retry_after IS NULL
       ${filters}
       ${cursorFilter}
     ORDER BY score DESC, sd.document_id DESC

--- a/apps/api/src/handlers/legislation/search.ts
+++ b/apps/api/src/handlers/legislation/search.ts
@@ -80,6 +80,14 @@ type LegislationHit = {
 
 type RawRow = Record<string, unknown>;
 
+type SearchLegislationDependencies = {
+  loadSearchConfigs: typeof loadFtsSearchConfigs;
+};
+
+const defaultSearchLegislationDependencies: SearchLegislationDependencies = {
+  loadSearchConfigs: loadFtsSearchConfigs,
+};
+
 const toNullableString = (x: unknown): string | null => {
   if (x === null || x === undefined) {
     return null;
@@ -106,10 +114,11 @@ const pgSearch = async (
   body: SearchLegislationBody,
   parsedCursor: { score: number; id: string } | null,
   scopedDb: ScopedDb,
+  dependencies: SearchLegislationDependencies,
 ): Promise<{ hits: LegislationHit[]; nextCursor: string | null }> => {
   const limit = body.limit ?? LIMITS.caseLawSearchPageSizeDefault;
   const ftsSearch = buildPgFtsSearchSql({
-    configs: await loadFtsSearchConfigs(),
+    configs: await dependencies.loadSearchConfigs(),
     query: body.query,
     refs: {
       language: sql`sd.language`,
@@ -395,6 +404,7 @@ const corpusIndexSearch = async (
 export const searchLegislationHandler = async (
   body: SearchLegislationBody,
   scopedDb: ScopedDb,
+  dependencies = defaultSearchLegislationDependencies,
 ) => {
   // source_id and the cursor id reach Postgres as UUID comparisons in the
   // pg-fts path; reject malformed values at the boundary so a bad filter
@@ -421,7 +431,7 @@ export const searchLegislationHandler = async (
   const { hits, nextCursor } =
     envBase.LEGAL_SEARCH_PROVIDER === "corpus-index"
       ? await corpusIndexSearch(body, parsedCursor, scopedDb)
-      : await pgSearch(body, parsedCursor, scopedDb);
+      : await pgSearch(body, parsedCursor, scopedDb, dependencies);
 
   return { hits, nextCursor, totalCount: null };
 };


### PR DESCRIPTION
## Summary

- read canonical corpus text when statute search projection rows have no inline payload
- add the `(updated_at, id)` access path with an online index build
- bind the projection fallback and schema/migration index shape with database-backed tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Search Improvements**
  * Improved legislation search indexing for inline content and canonical corpus text.
  * Backfills now process missing, outdated, and retryable entries in update order.
  * Unavailable corpus content is flagged for automatic retry and recovery.

* **Bug Fixes**
  * Corrected handling of corpus read failures and repaired documents during reindexing.
  * Prevented documents awaiting retry from appearing in search results.

* **Performance**
  * Added database indexes to improve legislation update tracking and retry processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->