### PR TITLE
fix: avoid duplicate statute reader payloads

### DIFF
--- a/apps/api/src/handlers/legislation/get.ts
+++ b/apps/api/src/handlers/legislation/get.ts
@@ -21,18 +21,24 @@ import {
 import type { EmptyAst } from "@/api/lib/legal-search/document-types";
 import type { LegislationReadDb } from "@/api/lib/legislation-public-read-db";
 
-type LegislationTextMode = "always" | "fallback";
+const LEGISLATION_TEXT_MODE = {
+  ALWAYS: "always",
+  FALLBACK: "fallback",
+} as const;
+
+type LegislationTextMode =
+  (typeof LEGISLATION_TEXT_MODE)[keyof typeof LEGISLATION_TEXT_MODE];
 
 type ReadLegislationOptions = {
   textMode: LegislationTextMode;
 };
 
 const DEFAULT_READ_OPTIONS = {
-  textMode: "always",
+  textMode: LEGISLATION_TEXT_MODE.ALWAYS,
 } as const satisfies ReadLegislationOptions;
 
 const PUBLIC_READ_OPTIONS = {
-  textMode: "fallback",
+  textMode: LEGISLATION_TEXT_MODE.FALLBACK,
 } as const satisfies ReadLegislationOptions;
 
 /**
@@ -112,7 +118,10 @@ export const readLegislationHandler = async (
       : parsePersistedCorpusAst(pgAst);
 
   let fulltext: string | null = null;
-  if (options.textMode === "always" || !hasUsableAst(documentAst)) {
+  if (
+    options.textMode === LEGISLATION_TEXT_MODE.ALWAYS ||
+    !hasUsableAst(documentAst)
+  ) {
     fulltext = pgText;
     if (corpus && textS3Key !== null) {
       fulltext = await readCorpusPayloadOrFallback({

--- a/apps/api/src/handlers/legislation/get.ts
+++ b/apps/api/src/handlers/legislation/get.ts
@@ -2,6 +2,7 @@ import { Result } from "better-result";
 import { and, eq } from "drizzle-orm";
 import { status, t } from "elysia";
 
+import { hasUsableAst } from "@stll/legal-ast/document-ast";
 import type { DocumentAst } from "@stll/legal-ast/document-ast";
 
 import { legislationDocuments, legislationSources } from "@/api/db/schema";
@@ -20,6 +21,20 @@ import {
 import type { EmptyAst } from "@/api/lib/legal-search/document-types";
 import type { LegislationReadDb } from "@/api/lib/legislation-public-read-db";
 
+type LegislationTextMode = "always" | "fallback";
+
+type ReadLegislationOptions = {
+  textMode: LegislationTextMode;
+};
+
+const DEFAULT_READ_OPTIONS = {
+  textMode: "always",
+} as const satisfies ReadLegislationOptions;
+
+const PUBLIC_READ_OPTIONS = {
+  textMode: "fallback",
+} as const satisfies ReadLegislationOptions;
+
 /**
  * Read one legislation document for display. Prefers canonical text/AST
  * from object storage when enabled, falling back to the Postgres columns
@@ -30,6 +45,7 @@ import type { LegislationReadDb } from "@/api/lib/legislation-public-read-db";
 export const readLegislationHandler = async (
   documentId: SafeId<"legislationDocument">,
   legislationDb: LegislationReadDb,
+  options: ReadLegislationOptions = DEFAULT_READ_OPTIONS,
 ) => {
   const [document] = await legislationDb(
     async (tx) =>
@@ -95,16 +111,19 @@ export const readLegislationHandler = async (
         })
       : parsePersistedCorpusAst(pgAst);
 
-  const fulltext =
-    corpus && textS3Key !== null
-      ? await readCorpusPayloadOrFallback({
-          documentId,
-          key: textS3Key,
-          step: "readLegislation.corpusText",
-          read: async () => await readCorpusText(textS3Key),
-          fallback: () => pgText,
-        })
-      : pgText;
+  let fulltext: string | null = null;
+  if (options.textMode === "always" || !hasUsableAst(documentAst)) {
+    fulltext = pgText;
+    if (corpus && textS3Key !== null) {
+      fulltext = await readCorpusPayloadOrFallback({
+        documentId,
+        key: textS3Key,
+        step: "readLegislation.corpusText",
+        read: async () => await readCorpusText(textS3Key),
+        fallback: () => pgText,
+      });
+    }
+  }
 
   return { ...rest, documentAst, fulltext };
 };
@@ -118,7 +137,11 @@ export const readPublicLegislationHandler = async (
   documentId: SafeId<"legislationDocument">,
   legislationDb: LegislationReadDb,
 ) => {
-  const document = await readLegislationHandler(documentId, legislationDb);
+  const document = await readLegislationHandler(
+    documentId,
+    legislationDb,
+    PUBLIC_READ_OPTIONS,
+  );
 
   if (!("metadata" in document)) {
     return document;

--- a/apps/api/src/handlers/legislation/public-reads.db.test.ts
+++ b/apps/api/src/handlers/legislation/public-reads.db.test.ts
@@ -48,6 +48,7 @@ type DocumentSeed = {
   language?: string;
   metadata?: Record<string, unknown>;
   documentAst?: DocumentAst;
+  fulltext?: string;
   versionValidFrom: string | null;
   versionValidTo: string | null;
 };
@@ -60,6 +61,7 @@ const seedDocument = ({
   language = "cs",
   metadata,
   documentAst,
+  fulltext,
   versionValidFrom,
   versionValidTo,
 }: DocumentSeed) => ({
@@ -75,6 +77,7 @@ const seedDocument = ({
   versionValidTo,
   ...(metadata === undefined ? {} : { metadata }),
   ...(documentAst === undefined ? {} : { documentAst }),
+  ...(fulltext === undefined ? {} : { fulltext }),
 });
 
 const DELIVERY_ANCHOR = "sec-2079";
@@ -194,6 +197,7 @@ beforeAll(
         eli: "CZ/2012/89",
         title: "Civil Code",
         metadata: { publisherNote: "not for public display" },
+        fulltext: "The duplicate plain-text consolidation.",
         documentAst: statuteAst(
           "The seller shall deliver within fourteen days.",
         ),
@@ -208,6 +212,7 @@ beforeAll(
         eli: "CZ/2012/89",
         title: "Civil Code (English)",
         language: "en",
+        fulltext: "The English plain-text consolidation.",
         versionValidFrom: "2020-01-01",
         versionValidTo: null,
       }),
@@ -544,6 +549,31 @@ describe("public statute read", () => {
     });
     expect(publicRead).not.toHaveProperty("metadata");
     expect(publicRead).toHaveProperty("title", "Civil Code");
+  });
+
+  test("returns full text only as the AST fallback", async () => {
+    const workspaceRead = await readLegislationHandler(
+      civilCodeCurrent,
+      legislationDb,
+    );
+    const structuredPublicRead = await readPublicLegislationHandler(
+      civilCodeCurrent,
+      legislationDb,
+    );
+    const plainPublicRead = await readPublicLegislationHandler(
+      civilCodeEnglish,
+      legislationDb,
+    );
+
+    expect(workspaceRead).toHaveProperty(
+      "fulltext",
+      "The duplicate plain-text consolidation.",
+    );
+    expect(structuredPublicRead).toHaveProperty("fulltext", null);
+    expect(plainPublicRead).toHaveProperty(
+      "fulltext",
+      "The English plain-text consolidation.",
+    );
   });
 
   test("reads as not found for a source not cleared for redistribution", async () => {


### PR DESCRIPTION
- Keep workspace statute reads unchanged while public reads omit redundant full text when a usable document AST is available.
- Preserve full-text fallback for documents without a renderable AST.
- Cover structured and plain-text public reads with a database-backed invariant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Public legislation reading now uses stored full text when structured document data is unavailable.
  - Structured legislation continues to prioritise parsed content and returns no unnecessary fallback text.

- **Bug Fixes**
  - Improved legislation text retrieval with a reliable fallback when the primary document structure cannot be used.

- **Tests**
  - Added coverage for full-text fallback behaviour across Czech and English legislation, including structured and unstructured documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->