### PR TITLE
fix: bound case-law citation reads

### DIFF
--- a/apps/api/drizzle/20260820140000_case_law_citation_pages/migration.sql
+++ b/apps/api/drizzle/20260820140000_case_law_citation_pages/migration.sql
@@ -26,6 +26,13 @@ CREATE INDEX CONCURRENTLY "case_law_citations_cited_page_idx"
   WHERE "cited_decision_id" IS NOT NULL;
 --> statement-breakpoint
 
+-- stella-migration-safety: reviewed destructive-change - the composite index above replaces this prefix index.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_citations_citing_idx";
+--> statement-breakpoint
+-- stella-migration-safety: reviewed destructive-change - the partial composite index above replaces this partial prefix index.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_citations_cited_idx";
+--> statement-breakpoint
+
 SET statement_timeout = '5s';
 --> statement-breakpoint
 SET lock_timeout = '1s';

--- a/apps/api/drizzle/20260820140000_case_law_citation_pages/migration.sql
+++ b/apps/api/drizzle/20260820140000_case_law_citation_pages/migration.sql
@@ -1,0 +1,34 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+
+-- stella-migration-safety: reviewed destructive-change - retry cleanup removes only invalid remnants from this migration's concurrent build.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_citations_citing_page_idx";
+--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "case_law_citations_citing_page_idx"
+  ON "case_law_citations" ("citing_decision_id", "id");
+--> statement-breakpoint
+
+-- stella-migration-safety: reviewed destructive-change - retry cleanup removes only invalid remnants from this migration's concurrent build.
+DROP INDEX CONCURRENTLY IF EXISTS "case_law_citations_cited_page_idx";
+--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "case_law_citations_cited_page_idx"
+  ON "case_law_citations" ("cited_decision_id", "id")
+  WHERE "cited_decision_id" IS NOT NULL;
+--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/db/schema/case-law-citation-page-index.db.test.ts
+++ b/apps/api/src/db/schema/case-law-citation-page-index.db.test.ts
@@ -20,6 +20,9 @@ const pageIndexNames = new Set([
 const pageIndexes = getTableConfig(caseLawCitations).indexes.filter(
   ({ config }) => config.name !== undefined && pageIndexNames.has(config.name),
 );
+const citationIndexNames = getTableConfig(caseLawCitations).indexes.map(
+  ({ config }) => config.name,
+);
 
 test("citation page indexes match the migration", () => {
   expect(
@@ -49,5 +52,13 @@ test("citation page indexes match the migration", () => {
   );
   expect(migration).toContain(
     '"case_law_citations_cited_page_idx"\n  ON "case_law_citations" ("cited_decision_id", "id")\n  WHERE "cited_decision_id" IS NOT NULL',
+  );
+  expect(citationIndexNames).not.toContain("case_law_citations_citing_idx");
+  expect(citationIndexNames).not.toContain("case_law_citations_cited_idx");
+  expect(migration).toContain(
+    'DROP INDEX CONCURRENTLY IF EXISTS "case_law_citations_citing_idx"',
+  );
+  expect(migration).toContain(
+    'DROP INDEX CONCURRENTLY IF EXISTS "case_law_citations_cited_idx"',
   );
 });

--- a/apps/api/src/db/schema/case-law-citation-page-index.db.test.ts
+++ b/apps/api/src/db/schema/case-law-citation-page-index.db.test.ts
@@ -48,6 +48,6 @@ test("citation page indexes match the migration", () => {
     '"case_law_citations_citing_page_idx"\n  ON "case_law_citations" ("citing_decision_id", "id")',
   );
   expect(migration).toContain(
-    '"case_law_citations_cited_page_idx"\n  ON "case_law_citations" ("cited_decision_id", "id")',
+    '"case_law_citations_cited_page_idx"\n  ON "case_law_citations" ("cited_decision_id", "id")\n  WHERE "cited_decision_id" IS NOT NULL',
   );
 });

--- a/apps/api/src/db/schema/case-law-citation-page-index.db.test.ts
+++ b/apps/api/src/db/schema/case-law-citation-page-index.db.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test";
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { readFileSync } from "node:fs";
+import nodePath from "node:path";
+
+import { caseLawCitations } from "@/api/db/schema";
+
+const migration = readFileSync(
+  nodePath.resolve(
+    import.meta.dir,
+    "../../../drizzle/20260820140000_case_law_citation_pages/migration.sql",
+  ),
+  "utf-8",
+);
+
+const pageIndexNames = new Set([
+  "case_law_citations_citing_page_idx",
+  "case_law_citations_cited_page_idx",
+]);
+const pageIndexes = getTableConfig(caseLawCitations).indexes.filter(
+  ({ config }) => config.name !== undefined && pageIndexNames.has(config.name),
+);
+
+test("citation page indexes match the migration", () => {
+  expect(
+    pageIndexes.map(({ config }) => ({
+      columns: config.columns.map((column) =>
+        "name" in column && typeof column.name === "string"
+          ? column.name
+          : null,
+      ),
+      name: config.name,
+      partial: config.where !== undefined,
+    })),
+  ).toEqual([
+    {
+      columns: ["citing_decision_id", "id"],
+      name: "case_law_citations_citing_page_idx",
+      partial: false,
+    },
+    {
+      columns: ["cited_decision_id", "id"],
+      name: "case_law_citations_cited_page_idx",
+      partial: true,
+    },
+  ]);
+  expect(migration).toContain(
+    '"case_law_citations_citing_page_idx"\n  ON "case_law_citations" ("citing_decision_id", "id")',
+  );
+  expect(migration).toContain(
+    '"case_law_citations_cited_page_idx"\n  ON "case_law_citations" ("cited_decision_id", "id")',
+  );
+});

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -813,12 +813,7 @@ export const caseLawCitations = p.pgTable(
     createdAt: timestamptz("created_at").defaultNow().notNull(),
   },
   (t) => [
-    p.index("case_law_citations_citing_idx").on(t.citingDecisionId),
     p.index("case_law_citations_citing_page_idx").on(t.citingDecisionId, t.id),
-    p
-      .index("case_law_citations_cited_idx")
-      .on(t.citedDecisionId)
-      .where(isNotNull(t.citedDecisionId)),
     p
       .index("case_law_citations_cited_page_idx")
       .on(t.citedDecisionId, t.id)

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -814,9 +814,14 @@ export const caseLawCitations = p.pgTable(
   },
   (t) => [
     p.index("case_law_citations_citing_idx").on(t.citingDecisionId),
+    p.index("case_law_citations_citing_page_idx").on(t.citingDecisionId, t.id),
     p
       .index("case_law_citations_cited_idx")
       .on(t.citedDecisionId)
+      .where(isNotNull(t.citedDecisionId)),
+    p
+      .index("case_law_citations_cited_page_idx")
+      .on(t.citedDecisionId, t.id)
       .where(isNotNull(t.citedDecisionId)),
     p
       .index("case_law_citations_polarity_null_idx")

--- a/apps/api/src/handlers/case-law/decisions/citations.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/citations.db.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { drizzle } from "drizzle-orm/pglite";
+
+import {
+  caseLawCitations,
+  caseLawDecisions,
+  caseLawSources,
+} from "@/api/db/schema";
+import {
+  listIncomingDecisionCitations,
+  listOutgoingDecisionCitations,
+} from "@/api/handlers/case-law/decisions/citations";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import type {
+  CaseLawPublicReadDb,
+  CaseLawPublicReadTransaction,
+} from "@/api/lib/case-law-public-read-db";
+import { caseLawSourceRow } from "@/api/tests/helpers/case-law-source-row";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const openSourceId = createSafeId<"caseLawSource">();
+const closedSourceId = createSafeId<"caseLawSource">();
+const subjectId = createSafeId<"caseLawDecision">();
+const openRelatedId = createSafeId<"caseLawDecision">();
+const closedRelatedId = createSafeId<"caseLawDecision">();
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+let caseLawDb: CaseLawPublicReadDb;
+
+const decisionRow = ({
+  caseNumber,
+  id,
+  sourceId,
+}: {
+  caseNumber: string;
+  id: SafeId<"caseLawDecision">;
+  sourceId: SafeId<"caseLawSource">;
+}): typeof caseLawDecisions.$inferInsert => ({
+  caseNumber,
+  country: "CZE",
+  court: "Court",
+  id,
+  language: "cs",
+  sourceId,
+});
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    db = drizzle({ client });
+    const readDb = async <T>(
+      fn: (tx: CaseLawPublicReadTransaction) => Promise<T>,
+    ) =>
+      // SAFETY: pglite's drizzle instance satisfies the select-only read surface.
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- embedded test database stands in for the read handle
+      await fn(db as unknown as CaseLawPublicReadTransaction);
+    // SAFETY: brand-only wrapper; the reads never inspect the marker.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the branded handle carries no behaviour
+    caseLawDb = readDb as unknown as CaseLawPublicReadDb;
+
+    await db.insert(caseLawSources).values([
+      caseLawSourceRow({ adapterKey: "open", id: openSourceId, name: "open" }),
+      caseLawSourceRow({
+        adapterKey: "closed",
+        descriptor: {
+          allowsDerivedAi: false,
+          allowsRedistribution: false,
+          attribution: null,
+          license: "restricted",
+        },
+        id: closedSourceId,
+        name: "closed",
+      }),
+    ]);
+    await db.insert(caseLawDecisions).values([
+      decisionRow({
+        caseNumber: "subject",
+        id: subjectId,
+        sourceId: openSourceId,
+      }),
+      decisionRow({
+        caseNumber: "open-related",
+        id: openRelatedId,
+        sourceId: openSourceId,
+      }),
+      decisionRow({
+        caseNumber: "closed-related",
+        id: closedRelatedId,
+        sourceId: closedSourceId,
+      }),
+    ]);
+
+    const outgoing = Array.from({ length: 55 }, (_unused, index) => ({
+      citedDecisionId: openRelatedId,
+      citingDecisionId: subjectId,
+      citationText: `outgoing-${String(index)}`,
+      id: createSafeId<"caseLawCitation">(),
+    }));
+    const incoming = Array.from({ length: 55 }, (_unused, index) => ({
+      citedDecisionId: subjectId,
+      citingDecisionId: openRelatedId,
+      citationText: `incoming-${String(index)}`,
+      id: createSafeId<"caseLawCitation">(),
+    }));
+    await db.insert(caseLawCitations).values([
+      ...outgoing,
+      ...incoming,
+      {
+        citedDecisionId: null,
+        citingDecisionId: subjectId,
+        citationText: "unresolved",
+        id: createSafeId<"caseLawCitation">(),
+      },
+      {
+        citedDecisionId: closedRelatedId,
+        citingDecisionId: subjectId,
+        citationText: "restricted-target",
+        id: createSafeId<"caseLawCitation">(),
+      },
+      {
+        citedDecisionId: subjectId,
+        citingDecisionId: closedRelatedId,
+        citationText: "restricted-source",
+        id: createSafeId<"caseLawCitation">(),
+      },
+    ]);
+  },
+  { timeout: 120_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+const collect = async (
+  readPage: (cursor: string | undefined) => Promise<{
+    items: { citationText: string }[];
+    nextCursor: string | null;
+  }>,
+) => {
+  const items: string[] = [];
+  let cursor: string | undefined;
+
+  for (let request = 0; request < 3; request += 1) {
+    // oxlint-disable-next-line no-await-in-loop -- cursor pages are sequential
+    const page = await readPage(cursor);
+    items.push(...page.items.map((item) => item.citationText));
+    cursor = page.nextCursor ?? undefined;
+    if (cursor === undefined) {
+      break;
+    }
+  }
+
+  return { cursor, items };
+};
+
+test("citation reads traverse bounded pages without leaking restricted decisions", async () => {
+  const outgoing = await collect(async (cursor) => {
+    const page = await listOutgoingDecisionCitations({
+      caseLawDb,
+      cursor,
+      decisionId: subjectId,
+    });
+    if (!("items" in page)) {
+      throw new Error("expected outgoing page");
+    }
+    expect(page.items.length).toBeLessThanOrEqual(50);
+    return page;
+  });
+  const incoming = await collect(async (cursor) => {
+    const page = await listIncomingDecisionCitations({
+      caseLawDb,
+      cursor,
+      decisionId: subjectId,
+    });
+    if (!("items" in page)) {
+      throw new Error("expected incoming page");
+    }
+    expect(page.items.length).toBeLessThanOrEqual(50);
+    return page;
+  });
+
+  expect(outgoing.items).toHaveLength(56);
+  expect(new Set(outgoing.items).size).toBe(56);
+  expect(outgoing.items).toContain("unresolved");
+  expect(outgoing.items).not.toContain("restricted-target");
+  expect(outgoing.cursor).toBeUndefined();
+  expect(incoming.items).toHaveLength(55);
+  expect(new Set(incoming.items).size).toBe(55);
+  expect(incoming.items).not.toContain("restricted-source");
+  expect(incoming.cursor).toBeUndefined();
+});
+
+test("citation reads reject malformed cursors", async () => {
+  const page = await listOutgoingDecisionCitations({
+    caseLawDb,
+    cursor: "not-a-cursor",
+    decisionId: subjectId,
+  });
+
+  expect("items" in page).toBe(false);
+});

--- a/apps/api/src/handlers/case-law/decisions/citations.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/citations.db.test.ts
@@ -10,7 +10,7 @@ import {
   listIncomingDecisionCitations,
   listOutgoingDecisionCitations,
 } from "@/api/handlers/case-law/decisions/citations";
-import { createSafeId } from "@/api/lib/branded-types";
+import { createSafeId, toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import type {
   CaseLawPublicReadDb,
@@ -24,6 +24,11 @@ const closedSourceId = createSafeId<"caseLawSource">();
 const subjectId = createSafeId<"caseLawDecision">();
 const openRelatedId = createSafeId<"caseLawDecision">();
 const closedRelatedId = createSafeId<"caseLawDecision">();
+
+const citationId = (value: number): SafeId<"caseLawCitation"> =>
+  toSafeId<"caseLawCitation">(
+    `00000000-0000-7000-8000-${String(value).padStart(12, "0")}`,
+  );
 
 let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
@@ -92,38 +97,40 @@ beforeAll(
       }),
     ]);
 
+    const restrictedOutgoing = Array.from({ length: 55 }, (_unused, index) => ({
+      citedDecisionId: closedRelatedId,
+      citingDecisionId: subjectId,
+      citationText: `restricted-outgoing-${String(index)}`,
+      id: citationId(index),
+    }));
     const outgoing = Array.from({ length: 55 }, (_unused, index) => ({
       citedDecisionId: openRelatedId,
       citingDecisionId: subjectId,
       citationText: `outgoing-${String(index)}`,
-      id: createSafeId<"caseLawCitation">(),
+      id: citationId(100 + index),
+    }));
+    const restrictedIncoming = Array.from({ length: 55 }, (_unused, index) => ({
+      citedDecisionId: subjectId,
+      citingDecisionId: closedRelatedId,
+      citationText: `restricted-incoming-${String(index)}`,
+      id: citationId(200 + index),
     }));
     const incoming = Array.from({ length: 55 }, (_unused, index) => ({
       citedDecisionId: subjectId,
       citingDecisionId: openRelatedId,
       citationText: `incoming-${String(index)}`,
-      id: createSafeId<"caseLawCitation">(),
+      id: citationId(300 + index),
     }));
     await db.insert(caseLawCitations).values([
+      ...restrictedOutgoing,
       ...outgoing,
+      ...restrictedIncoming,
       ...incoming,
       {
         citedDecisionId: null,
         citingDecisionId: subjectId,
         citationText: "unresolved",
-        id: createSafeId<"caseLawCitation">(),
-      },
-      {
-        citedDecisionId: closedRelatedId,
-        citingDecisionId: subjectId,
-        citationText: "restricted-target",
-        id: createSafeId<"caseLawCitation">(),
-      },
-      {
-        citedDecisionId: subjectId,
-        citingDecisionId: closedRelatedId,
-        citationText: "restricted-source",
-        id: createSafeId<"caseLawCitation">(),
+        id: citationId(155),
       },
     ]);
   },
@@ -157,6 +164,24 @@ const collect = async (
 };
 
 test("citation reads traverse bounded pages without leaking restricted decisions", async () => {
+  const firstOutgoing = await listOutgoingDecisionCitations({
+    caseLawDb,
+    cursor: undefined,
+    decisionId: subjectId,
+  });
+  const firstIncoming = await listIncomingDecisionCitations({
+    caseLawDb,
+    cursor: undefined,
+    decisionId: subjectId,
+  });
+  if (!("items" in firstOutgoing) || !("items" in firstIncoming)) {
+    throw new Error("expected first citation pages");
+  }
+  expect(firstOutgoing.items).toEqual([]);
+  expect(firstOutgoing.nextCursor).not.toBeNull();
+  expect(firstIncoming.items).toEqual([]);
+  expect(firstIncoming.nextCursor).not.toBeNull();
+
   const outgoing = await collect(async (cursor) => {
     const page = await listOutgoingDecisionCitations({
       caseLawDb,
@@ -185,11 +210,15 @@ test("citation reads traverse bounded pages without leaking restricted decisions
   expect(outgoing.items).toHaveLength(56);
   expect(new Set(outgoing.items).size).toBe(56);
   expect(outgoing.items).toContain("unresolved");
-  expect(outgoing.items).not.toContain("restricted-target");
+  expect(
+    outgoing.items.some((item) => item.startsWith("restricted-outgoing-")),
+  ).toBe(false);
   expect(outgoing.cursor).toBeUndefined();
   expect(incoming.items).toHaveLength(55);
   expect(new Set(incoming.items).size).toBe(55);
-  expect(incoming.items).not.toContain("restricted-source");
+  expect(
+    incoming.items.some((item) => item.startsWith("restricted-incoming-")),
+  ).toBe(false);
   expect(incoming.cursor).toBeUndefined();
 });
 

--- a/apps/api/src/handlers/case-law/decisions/citations.ts
+++ b/apps/api/src/handlers/case-law/decisions/citations.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, isNotNull, isNull, or, sql } from "drizzle-orm";
+import { and, asc, eq, gt, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { status } from "elysia";
 
@@ -9,12 +9,13 @@ import {
 } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
+import { redistributableCaseLawSourceFor } from "@/api/lib/case-law/redistribution";
 import { LIMITS } from "@/api/lib/limits";
 import {
-  createCursorPage,
   decodePaginationCursor,
   encodePaginationCursor,
   isUuidPaginationCursorPart,
+  type Page,
 } from "@/api/lib/pagination";
 import { brandPersistedCaseLawCitationId } from "@/api/lib/safe-id-boundaries";
 
@@ -22,15 +23,6 @@ const citedDecision = alias(caseLawDecisions, "cited_case_law_decision");
 const citedSource = alias(caseLawSources, "cited_case_law_source");
 const citingDecision = alias(caseLawDecisions, "citing_case_law_decision");
 const citingSource = alias(caseLawSources, "citing_case_law_source");
-
-const redistributableCitedSource = sql`(
-  ${citedSource.descriptor} IS NULL
-  OR (${citedSource.descriptor} ->> 'allowsRedistribution') = 'true'
-)`;
-const redistributableCitingSource = sql`(
-  ${citingSource.descriptor} IS NULL
-  OR (${citingSource.descriptor} ->> 'allowsRedistribution') = 'true'
-)`;
 
 const decodeCitationCursor = (
   cursor: string | undefined,
@@ -54,6 +46,35 @@ type CitationPageOptions = {
   decisionId: SafeId<"caseLawDecision">;
 };
 
+type ScannedCitation<T> = {
+  item: T;
+  scanId: SafeId<"caseLawCitation">;
+  visible: boolean;
+};
+
+const createScannedCitationPage = <T>(
+  rows: readonly ScannedCitation<T>[],
+): Page<T> => {
+  const limit = LIMITS.caseLawDecisionCitationPageSize;
+  const scanned = rows.slice(0, limit);
+  const items: T[] = [];
+  for (const row of scanned) {
+    if (row.visible) {
+      items.push(row.item);
+    }
+  }
+  const lastScanned = scanned.at(-1);
+
+  return {
+    items,
+    limit,
+    nextCursor:
+      rows.length > limit && lastScanned !== undefined
+        ? encodePaginationCursor([lastScanned.scanId])
+        : null,
+  };
+};
+
 export const listOutgoingDecisionCitations = async ({
   caseLawDb,
   cursor,
@@ -64,8 +85,8 @@ export const listOutgoingDecisionCitations = async ({
     return status(400, { message: "Invalid cursor" });
   }
 
-  const rows = await caseLawDb((tx) =>
-    tx
+  const rows = await caseLawDb((tx) => {
+    const candidates = tx
       .select({
         id: caseLawCitations.id,
         citationText: caseLawCitations.citationText,
@@ -73,32 +94,43 @@ export const listOutgoingDecisionCitations = async ({
         sectionIndex: caseLawCitations.sectionIndex,
       })
       .from(caseLawCitations)
-      .leftJoin(
-        citedDecision,
-        eq(citedDecision.id, caseLawCitations.citedDecisionId),
-      )
-      .leftJoin(citedSource, eq(citedSource.id, citedDecision.sourceId))
       .where(
         and(
           eq(caseLawCitations.citingDecisionId, decisionId),
           cursorId === undefined
             ? undefined
             : gt(caseLawCitations.id, cursorId),
-          or(
-            isNull(caseLawCitations.citedDecisionId),
-            and(isNotNull(citedSource.id), redistributableCitedSource),
-          ),
         ),
       )
       .orderBy(asc(caseLawCitations.id))
-      .limit(LIMITS.caseLawDecisionCitationPageSize + 1),
-  );
+      .limit(LIMITS.caseLawDecisionCitationPageSize + 1)
+      .as("outgoing_citation_candidates");
 
-  return createCursorPage({
-    rows,
-    limit: LIMITS.caseLawDecisionCitationPageSize,
-    cursorForItem: (item) => encodePaginationCursor([item.id]),
+    return tx
+      .select({
+        item: {
+          id: candidates.id,
+          citationText: candidates.citationText,
+          citedDecisionId: candidates.citedDecisionId,
+          sectionIndex: candidates.sectionIndex,
+        },
+        scanId: candidates.id,
+        visible: sql<boolean>`(
+            ${candidates.citedDecisionId} IS NULL
+          OR (
+            ${citedSource.id} IS NOT NULL
+            AND ${redistributableCaseLawSourceFor(citedSource.descriptor)}
+          )
+        )`,
+      })
+      .from(candidates)
+      .leftJoin(citedDecision, eq(citedDecision.id, candidates.citedDecisionId))
+      .leftJoin(citedSource, eq(citedSource.id, citedDecision.sourceId))
+      .orderBy(asc(candidates.id))
+      .limit(LIMITS.caseLawDecisionCitationPageSize + 1);
   });
+
+  return createScannedCitationPage(rows);
 };
 
 export const listIncomingDecisionCitations = async ({
@@ -111,8 +143,8 @@ export const listIncomingDecisionCitations = async ({
     return status(400, { message: "Invalid cursor" });
   }
 
-  const rows = await caseLawDb((tx) =>
-    tx
+  const rows = await caseLawDb((tx) => {
+    const candidates = tx
       .select({
         id: caseLawCitations.id,
         citationText: caseLawCitations.citationText,
@@ -120,27 +152,41 @@ export const listIncomingDecisionCitations = async ({
         sectionIndex: caseLawCitations.sectionIndex,
       })
       .from(caseLawCitations)
-      .innerJoin(
-        citingDecision,
-        eq(citingDecision.id, caseLawCitations.citingDecisionId),
-      )
-      .innerJoin(citingSource, eq(citingSource.id, citingDecision.sourceId))
       .where(
         and(
           eq(caseLawCitations.citedDecisionId, decisionId),
-          redistributableCitingSource,
           cursorId === undefined
             ? undefined
             : gt(caseLawCitations.id, cursorId),
         ),
       )
       .orderBy(asc(caseLawCitations.id))
-      .limit(LIMITS.caseLawDecisionCitationPageSize + 1),
-  );
+      .limit(LIMITS.caseLawDecisionCitationPageSize + 1)
+      .as("incoming_citation_candidates");
 
-  return createCursorPage({
-    rows,
-    limit: LIMITS.caseLawDecisionCitationPageSize,
-    cursorForItem: (item) => encodePaginationCursor([item.id]),
+    return tx
+      .select({
+        item: {
+          id: candidates.id,
+          citationText: candidates.citationText,
+          citingDecisionId: candidates.citingDecisionId,
+          sectionIndex: candidates.sectionIndex,
+        },
+        scanId: candidates.id,
+        visible: sql<boolean>`(
+          ${citingSource.id} IS NOT NULL
+          AND ${redistributableCaseLawSourceFor(citingSource.descriptor)}
+        )`,
+      })
+      .from(candidates)
+      .leftJoin(
+        citingDecision,
+        eq(citingDecision.id, candidates.citingDecisionId),
+      )
+      .leftJoin(citingSource, eq(citingSource.id, citingDecision.sourceId))
+      .orderBy(asc(candidates.id))
+      .limit(LIMITS.caseLawDecisionCitationPageSize + 1);
   });
+
+  return createScannedCitationPage(rows);
 };

--- a/apps/api/src/handlers/case-law/decisions/citations.ts
+++ b/apps/api/src/handlers/case-law/decisions/citations.ts
@@ -1,0 +1,146 @@
+import { and, asc, eq, gt, isNotNull, isNull, or, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+import { status } from "elysia";
+
+import {
+  caseLawCitations,
+  caseLawDecisions,
+  caseLawSources,
+} from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
+import { LIMITS } from "@/api/lib/limits";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+  isUuidPaginationCursorPart,
+} from "@/api/lib/pagination";
+import { brandPersistedCaseLawCitationId } from "@/api/lib/safe-id-boundaries";
+
+const citedDecision = alias(caseLawDecisions, "cited_case_law_decision");
+const citedSource = alias(caseLawSources, "cited_case_law_source");
+const citingDecision = alias(caseLawDecisions, "citing_case_law_decision");
+const citingSource = alias(caseLawSources, "citing_case_law_source");
+
+const redistributableCitedSource = sql`(
+  ${citedSource.descriptor} IS NULL
+  OR (${citedSource.descriptor} ->> 'allowsRedistribution') = 'true'
+)`;
+const redistributableCitingSource = sql`(
+  ${citingSource.descriptor} IS NULL
+  OR (${citingSource.descriptor} ->> 'allowsRedistribution') = 'true'
+)`;
+
+const decodeCitationCursor = (
+  cursor: string | undefined,
+): SafeId<"caseLawCitation"> | null | undefined => {
+  if (cursor === undefined) {
+    return undefined;
+  }
+
+  const parts = decodePaginationCursor(cursor);
+  const id = parts?.at(0);
+  if (parts?.length !== 1 || !isUuidPaginationCursorPart(id)) {
+    return null;
+  }
+
+  return brandPersistedCaseLawCitationId(id);
+};
+
+type CitationPageOptions = {
+  caseLawDb: CaseLawPublicReadDb;
+  cursor: string | undefined;
+  decisionId: SafeId<"caseLawDecision">;
+};
+
+export const listOutgoingDecisionCitations = async ({
+  caseLawDb,
+  cursor,
+  decisionId,
+}: CitationPageOptions) => {
+  const cursorId = decodeCitationCursor(cursor);
+  if (cursorId === null) {
+    return status(400, { message: "Invalid cursor" });
+  }
+
+  const rows = await caseLawDb((tx) =>
+    tx
+      .select({
+        id: caseLawCitations.id,
+        citationText: caseLawCitations.citationText,
+        citedDecisionId: caseLawCitations.citedDecisionId,
+        sectionIndex: caseLawCitations.sectionIndex,
+      })
+      .from(caseLawCitations)
+      .leftJoin(
+        citedDecision,
+        eq(citedDecision.id, caseLawCitations.citedDecisionId),
+      )
+      .leftJoin(citedSource, eq(citedSource.id, citedDecision.sourceId))
+      .where(
+        and(
+          eq(caseLawCitations.citingDecisionId, decisionId),
+          cursorId === undefined
+            ? undefined
+            : gt(caseLawCitations.id, cursorId),
+          or(
+            isNull(caseLawCitations.citedDecisionId),
+            and(isNotNull(citedSource.id), redistributableCitedSource),
+          ),
+        ),
+      )
+      .orderBy(asc(caseLawCitations.id))
+      .limit(LIMITS.caseLawDecisionCitationPageSize + 1),
+  );
+
+  return createCursorPage({
+    rows,
+    limit: LIMITS.caseLawDecisionCitationPageSize,
+    cursorForItem: (item) => encodePaginationCursor([item.id]),
+  });
+};
+
+export const listIncomingDecisionCitations = async ({
+  caseLawDb,
+  cursor,
+  decisionId,
+}: CitationPageOptions) => {
+  const cursorId = decodeCitationCursor(cursor);
+  if (cursorId === null) {
+    return status(400, { message: "Invalid cursor" });
+  }
+
+  const rows = await caseLawDb((tx) =>
+    tx
+      .select({
+        id: caseLawCitations.id,
+        citationText: caseLawCitations.citationText,
+        citingDecisionId: caseLawCitations.citingDecisionId,
+        sectionIndex: caseLawCitations.sectionIndex,
+      })
+      .from(caseLawCitations)
+      .innerJoin(
+        citingDecision,
+        eq(citingDecision.id, caseLawCitations.citingDecisionId),
+      )
+      .innerJoin(citingSource, eq(citingSource.id, citingDecision.sourceId))
+      .where(
+        and(
+          eq(caseLawCitations.citedDecisionId, decisionId),
+          redistributableCitingSource,
+          cursorId === undefined
+            ? undefined
+            : gt(caseLawCitations.id, cursorId),
+        ),
+      )
+      .orderBy(asc(caseLawCitations.id))
+      .limit(LIMITS.caseLawDecisionCitationPageSize + 1),
+  );
+
+  return createCursorPage({
+    rows,
+    limit: LIMITS.caseLawDecisionCitationPageSize,
+    cursorForItem: (item) => encodePaginationCursor([item.id]),
+  });
+};

--- a/apps/api/src/handlers/case-law/decisions/get-citation-cursor.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/get-citation-cursor.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  decodeDecisionCitationCursor,
+  encodeDecisionCitationCursor,
+} from "@/api/handlers/case-law/decisions/get";
+
+describe("decision citation cursor", () => {
+  test("preserves an exhausted stream while the other stream continues", () => {
+    const cursor = encodeDecisionCitationCursor({
+      from: null,
+      to: "incoming-next",
+    });
+
+    expect(cursor).not.toBeNull();
+    expect(decodeDecisionCitationCursor(cursor)).toEqual({
+      from: null,
+      to: "incoming-next",
+    });
+  });
+
+  test("ends only after both streams are exhausted", () => {
+    expect(encodeDecisionCitationCursor({ from: null, to: null })).toBeNull();
+  });
+
+  test("rejects malformed compound state", () => {
+    expect(decodeDecisionCitationCursor("not-a-cursor")).toBeNull();
+  });
+});

--- a/apps/api/src/handlers/case-law/decisions/get-citation-cursor.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/get-citation-cursor.test.ts
@@ -4,6 +4,7 @@ import {
   decodeDecisionCitationCursor,
   encodeDecisionCitationCursor,
 } from "@/api/handlers/case-law/decisions/get";
+import { encodePaginationCursor } from "@/api/lib/pagination";
 
 describe("decision citation cursor", () => {
   test("preserves an exhausted stream while the other stream continues", () => {
@@ -25,5 +26,23 @@ describe("decision citation cursor", () => {
 
   test("rejects malformed compound state", () => {
     expect(decodeDecisionCitationCursor("not-a-cursor")).toBeNull();
+    expect(
+      decodeDecisionCitationCursor(encodePaginationCursor(["only-one"])),
+    ).toBeNull();
+    expect(
+      decodeDecisionCitationCursor(
+        encodePaginationCursor(["from", "to", "extra"]),
+      ),
+    ).toBeNull();
+    expect(
+      decodeDecisionCitationCursor(encodePaginationCursor([1, 2])),
+    ).toBeNull();
+  });
+
+  test("seeds both streams when no cursor is supplied", () => {
+    expect(decodeDecisionCitationCursor(undefined)).toEqual({
+      from: undefined,
+      to: undefined,
+    });
   });
 });

--- a/apps/api/src/handlers/case-law/decisions/get-citation-cursor.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/get-citation-cursor.test.ts
@@ -9,19 +9,24 @@ import { encodePaginationCursor } from "@/api/lib/pagination";
 describe("decision citation cursor", () => {
   test("preserves an exhausted stream while the other stream continues", () => {
     const cursor = encodeDecisionCitationCursor({
-      from: null,
-      to: "incoming-next",
+      from: { status: "exhausted" },
+      to: { after: "incoming-next", status: "continue" },
     });
 
     expect(cursor).not.toBeNull();
     expect(decodeDecisionCitationCursor(cursor)).toEqual({
-      from: null,
-      to: "incoming-next",
+      from: { status: "exhausted" },
+      to: { after: "incoming-next", status: "continue" },
     });
   });
 
   test("ends only after both streams are exhausted", () => {
-    expect(encodeDecisionCitationCursor({ from: null, to: null })).toBeNull();
+    expect(
+      encodeDecisionCitationCursor({
+        from: { status: "exhausted" },
+        to: { status: "exhausted" },
+      }),
+    ).toBeNull();
   });
 
   test("rejects malformed compound state", () => {
@@ -41,8 +46,8 @@ describe("decision citation cursor", () => {
 
   test("seeds both streams when no cursor is supplied", () => {
     expect(decodeDecisionCitationCursor(undefined)).toEqual({
-      from: undefined,
-      to: undefined,
+      from: { status: "start" },
+      to: { status: "start" },
     });
   });
 });

--- a/apps/api/src/handlers/case-law/decisions/get-deferred-document.ts
+++ b/apps/api/src/handlers/case-law/decisions/get-deferred-document.ts
@@ -99,14 +99,14 @@ export type ReadDecisionWithDocumentOptions = {
   decisionId: SafeId<"caseLawDecision">;
   caseLawDb: CaseLawPublicReadDb;
   caller: DecisionReadCaller;
-  citationsFromCursor?: string | null | undefined;
-  citationsToCursor?: string | null | undefined;
+  citationsCursor?: string | null | undefined;
 };
 
 export type ReadDecisionBySlugWithDocumentOptions = {
   slug: string;
   caseLawDb: CaseLawPublicReadDb;
   caller: DecisionReadCaller;
+  citationsCursor?: string | null | undefined;
   language: string | undefined;
 };
 
@@ -114,14 +114,12 @@ export const readDecisionWithDocumentHandler = async ({
   decisionId,
   caseLawDb,
   caller,
-  citationsFromCursor,
-  citationsToCursor,
+  citationsCursor,
 }: ReadDecisionWithDocumentOptions): Promise<DecisionRead> =>
   await withDeferredDocument(
     await readDecisionHandler({
       caseLawDb,
-      citationsFromCursor,
-      citationsToCursor,
+      citationsCursor,
       decisionId,
     }),
     caller === "attributed",
@@ -131,9 +129,15 @@ export const readDecisionBySlugWithDocumentHandler = async ({
   slug,
   caseLawDb,
   caller,
+  citationsCursor,
   language,
 }: ReadDecisionBySlugWithDocumentOptions): Promise<DecisionRead> =>
   await withDeferredDocument(
-    await readDecisionBySlugHandler(slug, caseLawDb, language),
+    await readDecisionBySlugHandler({
+      caseLawDb,
+      citationsCursor,
+      language,
+      slug,
+    }),
     caller === "attributed",
   );

--- a/apps/api/src/handlers/case-law/decisions/get-deferred-document.ts
+++ b/apps/api/src/handlers/case-law/decisions/get-deferred-document.ts
@@ -99,6 +99,8 @@ export type ReadDecisionWithDocumentOptions = {
   decisionId: SafeId<"caseLawDecision">;
   caseLawDb: CaseLawPublicReadDb;
   caller: DecisionReadCaller;
+  citationsFromCursor?: string | null | undefined;
+  citationsToCursor?: string | null | undefined;
 };
 
 export type ReadDecisionBySlugWithDocumentOptions = {
@@ -112,9 +114,16 @@ export const readDecisionWithDocumentHandler = async ({
   decisionId,
   caseLawDb,
   caller,
+  citationsFromCursor,
+  citationsToCursor,
 }: ReadDecisionWithDocumentOptions): Promise<DecisionRead> =>
   await withDeferredDocument(
-    await readDecisionHandler(decisionId, caseLawDb),
+    await readDecisionHandler({
+      caseLawDb,
+      citationsFromCursor,
+      citationsToCursor,
+      decisionId,
+    }),
     caller === "attributed",
   );
 

--- a/apps/api/src/handlers/case-law/decisions/get-document-state.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/get-document-state.db.test.ts
@@ -60,7 +60,10 @@ if (!databaseUrl || !runPostgresTests) {
     };
 
     const readState = async (id: SafeId<"caseLawDecision">) => {
-      const decision = await readDecisionHandler(id, caseLawPublicReadDb);
+      const decision = await readDecisionHandler({
+        caseLawDb: caseLawPublicReadDb,
+        decisionId: id,
+      });
       if (!("documentPending" in decision)) {
         throw new Error("expected a readable decision");
       }

--- a/apps/api/src/handlers/case-law/decisions/get.ts
+++ b/apps/api/src/handlers/case-law/decisions/get.ts
@@ -30,6 +30,10 @@ import {
 } from "@/api/lib/legal-search/corpus-storage";
 import type { EmptyAst } from "@/api/lib/legal-search/document-types";
 import { LIMITS } from "@/api/lib/limits";
+import {
+  decodePaginationCursor,
+  encodePaginationCursor,
+} from "@/api/lib/pagination";
 
 type PublicDecisionLanguageAlternate = {
   caseNumber: string;
@@ -125,16 +129,54 @@ const listPublicDecisionLanguageAlternates = async ({
 const corpusReadEnabled = (): boolean => corpusStorageMode !== "off";
 
 export const readDecisionQuerySchema = t.Object({
-  citationsFromCursor: t.Optional(tPaginationCursor()),
-  citationsToCursor: t.Optional(tPaginationCursor()),
+  citationsCursor: t.Optional(tPaginationCursor()),
 });
 
 export type ReadDecisionOptions = {
   caseLawDb: CaseLawPublicReadDb;
-  citationsFromCursor?: string | null | undefined;
-  citationsToCursor?: string | null | undefined;
+  citationsCursor?: string | null | undefined;
   decisionId: SafeId<"caseLawDecision">;
 };
+
+type DecisionCitationCursorState = {
+  from: string | null | undefined;
+  to: string | null | undefined;
+};
+
+type DecisionCitationNextCursorState = {
+  from: string | null;
+  to: string | null;
+};
+
+export const decodeDecisionCitationCursor = (
+  cursor: string | null | undefined,
+): DecisionCitationCursorState | null => {
+  if (cursor === undefined) {
+    return { from: undefined, to: undefined };
+  }
+  if (cursor === null) {
+    return { from: null, to: null };
+  }
+
+  const parts = decodePaginationCursor(cursor);
+  const from = parts?.at(0);
+  const to = parts?.at(1);
+  if (
+    parts?.length !== 2 ||
+    (from !== null && typeof from !== "string") ||
+    (to !== null && typeof to !== "string")
+  ) {
+    return null;
+  }
+
+  return { from, to };
+};
+
+export const encodeDecisionCitationCursor = ({
+  from,
+  to,
+}: DecisionCitationNextCursorState): string | null =>
+  from === null && to === null ? null : encodePaginationCursor([from, to]);
 
 const emptyCitationPage = () => ({
   items: [],
@@ -144,10 +186,14 @@ const emptyCitationPage = () => ({
 
 export const readDecisionHandler = async ({
   caseLawDb,
-  citationsFromCursor,
-  citationsToCursor,
+  citationsCursor,
   decisionId,
 }: ReadDecisionOptions) => {
+  const citationCursors = decodeDecisionCitationCursor(citationsCursor);
+  if (citationCursors === null) {
+    return status(400, { message: "Invalid cursor" });
+  }
+
   const decision = await caseLawDb((tx) =>
     tx.query.caseLawDecisions.findFirst({
       where: { id: { eq: decisionId } },
@@ -203,18 +249,18 @@ export const readDecisionHandler = async ({
         caseLawDb,
         languageGroupKey: decision.languageGroupKey,
       }),
-      citationsFromCursor === null
+      citationCursors.from === null
         ? emptyCitationPage()
         : listOutgoingDecisionCitations({
             caseLawDb,
-            cursor: citationsFromCursor,
+            cursor: citationCursors.from,
             decisionId,
           }),
-      citationsToCursor === null
+      citationCursors.to === null
         ? emptyCitationPage()
         : listIncomingDecisionCitations({
             caseLawDb,
-            cursor: citationsToCursor,
+            cursor: citationCursors.to,
             decisionId,
           }),
     ]);
@@ -225,6 +271,10 @@ export const readDecisionHandler = async ({
   if (!("items" in citationsToPage)) {
     return citationsToPage;
   }
+  const citationsNextCursor = encodeDecisionCitationCursor({
+    from: citationsFromPage.nextCursor,
+    to: citationsToPage.nextCursor,
+  });
 
   // Prefer canonical AST from object storage when corpus storage is
   // enabled; fall back to the Postgres column so a read is never harder
@@ -320,19 +370,26 @@ export const readDecisionHandler = async ({
       allowsDerivedAi: allowsDerivedAi(source.descriptor),
     },
     citationsFrom: citationsFromPage.items,
-    citationsFromNextCursor: citationsFromPage.nextCursor,
     citationsTo: citationsToPage.items,
-    citationsToNextCursor: citationsToPage.nextCursor,
+    citationsNextCursor,
     languageAlternates,
     fulltext,
   };
 };
 
-export const readDecisionBySlugHandler = async (
-  slug: string,
-  caseLawDb: CaseLawPublicReadDb,
-  language?: string,
-) => {
+type ReadDecisionBySlugOptions = {
+  caseLawDb: CaseLawPublicReadDb;
+  citationsCursor?: string | null | undefined;
+  language?: string | undefined;
+  slug: string;
+};
+
+export const readDecisionBySlugHandler = async ({
+  caseLawDb,
+  citationsCursor,
+  language,
+  slug,
+}: ReadDecisionBySlugOptions) => {
   const normalizedLanguage = normalizePublicDecisionLanguage(language);
   if (language !== undefined && normalizedLanguage === null) {
     return status(404, { message: "Decision not found" });
@@ -360,6 +417,7 @@ export const readDecisionBySlugHandler = async (
 
   return await readDecisionHandler({
     caseLawDb,
+    citationsCursor,
     decisionId: firstDecision.id,
   });
 };

--- a/apps/api/src/handlers/case-law/decisions/get.ts
+++ b/apps/api/src/handlers/case-law/decisions/get.ts
@@ -132,51 +132,126 @@ export const readDecisionQuerySchema = t.Object({
   citationsCursor: t.Optional(tPaginationCursor()),
 });
 
-export type ReadDecisionOptions = {
+type ReadDecisionOptions = {
   caseLawDb: CaseLawPublicReadDb;
   citationsCursor?: string | null | undefined;
   decisionId: SafeId<"caseLawDecision">;
 };
 
+const CITATION_STREAM_CURSOR_STATUS = {
+  CONTINUE: "continue",
+  EXHAUSTED: "exhausted",
+  START: "start",
+} as const;
+
+type CitationStreamCursor =
+  | { status: typeof CITATION_STREAM_CURSOR_STATUS.START }
+  | { status: typeof CITATION_STREAM_CURSOR_STATUS.EXHAUSTED }
+  | {
+      after: string;
+      status: typeof CITATION_STREAM_CURSOR_STATUS.CONTINUE;
+    };
+
 type DecisionCitationCursorState = {
-  from: string | null | undefined;
-  to: string | null | undefined;
+  from: CitationStreamCursor;
+  to: CitationStreamCursor;
 };
 
+type CitationStreamNextCursor = Exclude<
+  CitationStreamCursor,
+  { status: typeof CITATION_STREAM_CURSOR_STATUS.START }
+>;
+
 type DecisionCitationNextCursorState = {
-  from: string | null;
-  to: string | null;
+  from: CitationStreamNextCursor;
+  to: CitationStreamNextCursor;
+};
+
+const decodeCitationStreamCursor = (
+  value: unknown,
+): CitationStreamNextCursor | null => {
+  if (value === null) {
+    return { status: CITATION_STREAM_CURSOR_STATUS.EXHAUSTED };
+  }
+  if (typeof value === "string") {
+    return { after: value, status: CITATION_STREAM_CURSOR_STATUS.CONTINUE };
+  }
+  return null;
 };
 
 export const decodeDecisionCitationCursor = (
   cursor: string | null | undefined,
 ): DecisionCitationCursorState | null => {
   if (cursor === undefined) {
-    return { from: undefined, to: undefined };
+    return {
+      from: { status: CITATION_STREAM_CURSOR_STATUS.START },
+      to: { status: CITATION_STREAM_CURSOR_STATUS.START },
+    };
   }
   if (cursor === null) {
-    return { from: null, to: null };
+    return {
+      from: { status: CITATION_STREAM_CURSOR_STATUS.EXHAUSTED },
+      to: { status: CITATION_STREAM_CURSOR_STATUS.EXHAUSTED },
+    };
   }
 
   const parts = decodePaginationCursor(cursor);
-  const from = parts?.at(0);
-  const to = parts?.at(1);
-  if (
-    parts?.length !== 2 ||
-    (from !== null && typeof from !== "string") ||
-    (to !== null && typeof to !== "string")
-  ) {
+  if (parts?.length !== 2) {
     return null;
   }
 
+  const from = decodeCitationStreamCursor(parts.at(0));
+  const to = decodeCitationStreamCursor(parts.at(1));
+  if (from === null || to === null) {
+    return null;
+  }
   return { from, to };
 };
+
+const encodeCitationStreamCursor = (
+  cursor: CitationStreamNextCursor,
+): string | null => {
+  switch (cursor.status) {
+    case CITATION_STREAM_CURSOR_STATUS.CONTINUE:
+      return cursor.after;
+    case CITATION_STREAM_CURSOR_STATUS.EXHAUSTED:
+      return null;
+    default: {
+      const exhaustive: never = cursor;
+      return exhaustive;
+    }
+  }
+};
+
+const citationStreamCursorFromNext = (
+  cursor: string | null,
+): CitationStreamNextCursor =>
+  cursor === null
+    ? { status: CITATION_STREAM_CURSOR_STATUS.EXHAUSTED }
+    : { after: cursor, status: CITATION_STREAM_CURSOR_STATUS.CONTINUE };
+
+const citationPageCursor = (
+  cursor: CitationStreamCursor,
+): string | undefined =>
+  cursor.status === CITATION_STREAM_CURSOR_STATUS.CONTINUE
+    ? cursor.after
+    : undefined;
 
 export const encodeDecisionCitationCursor = ({
   from,
   to,
-}: DecisionCitationNextCursorState): string | null =>
-  from === null && to === null ? null : encodePaginationCursor([from, to]);
+}: DecisionCitationNextCursorState): string | null => {
+  if (
+    from.status === CITATION_STREAM_CURSOR_STATUS.EXHAUSTED &&
+    to.status === CITATION_STREAM_CURSOR_STATUS.EXHAUSTED
+  ) {
+    return null;
+  }
+  return encodePaginationCursor([
+    encodeCitationStreamCursor(from),
+    encodeCitationStreamCursor(to),
+  ]);
+};
 
 const emptyCitationPage = () => ({
   items: [],
@@ -249,18 +324,18 @@ export const readDecisionHandler = async ({
         caseLawDb,
         languageGroupKey: decision.languageGroupKey,
       }),
-      citationCursors.from === null
+      citationCursors.from.status === CITATION_STREAM_CURSOR_STATUS.EXHAUSTED
         ? emptyCitationPage()
         : listOutgoingDecisionCitations({
             caseLawDb,
-            cursor: citationCursors.from,
+            cursor: citationPageCursor(citationCursors.from),
             decisionId,
           }),
-      citationCursors.to === null
+      citationCursors.to.status === CITATION_STREAM_CURSOR_STATUS.EXHAUSTED
         ? emptyCitationPage()
         : listIncomingDecisionCitations({
             caseLawDb,
-            cursor: citationCursors.to,
+            cursor: citationPageCursor(citationCursors.to),
             decisionId,
           }),
     ]);
@@ -272,8 +347,8 @@ export const readDecisionHandler = async ({
     return citationsToPage;
   }
   const citationsNextCursor = encodeDecisionCitationCursor({
-    from: citationsFromPage.nextCursor,
-    to: citationsToPage.nextCursor,
+    from: citationStreamCursorFromNext(citationsFromPage.nextCursor),
+    to: citationStreamCursorFromNext(citationsToPage.nextCursor),
   });
 
   // Prefer canonical AST from object storage when corpus storage is

--- a/apps/api/src/handlers/case-law/decisions/get.ts
+++ b/apps/api/src/handlers/case-law/decisions/get.ts
@@ -1,17 +1,22 @@
 import { panic, Result, UnhandledException } from "better-result";
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
-import { status } from "elysia";
+import { and, asc, eq, sql } from "drizzle-orm";
+import { status, t } from "elysia";
 
 import type { DocumentAst } from "@stll/legal-ast/document-ast";
 
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
 import { corpusStorageMode } from "@/api/env-base";
+import {
+  listIncomingDecisionCitations,
+  listOutgoingDecisionCitations,
+} from "@/api/handlers/case-law/decisions/citations";
 import { hasUsableAst } from "@/api/handlers/case-law/document-ast";
 import { corpusCarriesDocument } from "@/api/handlers/case-law/stored-payload";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 import { redistributableCaseLawSource } from "@/api/lib/case-law/redistribution";
+import { tPaginationCursor } from "@/api/lib/custom-schema";
 import { CorpusPayloadUnavailableError } from "@/api/lib/errors/tagged-errors";
 import {
   allowsDerivedAi,
@@ -119,10 +124,30 @@ const listPublicDecisionLanguageAlternates = async ({
 
 const corpusReadEnabled = (): boolean => corpusStorageMode !== "off";
 
-export const readDecisionHandler = async (
-  decisionId: SafeId<"caseLawDecision">,
-  caseLawDb: CaseLawPublicReadDb,
-) => {
+export const readDecisionQuerySchema = t.Object({
+  citationsFromCursor: t.Optional(tPaginationCursor()),
+  citationsToCursor: t.Optional(tPaginationCursor()),
+});
+
+export type ReadDecisionOptions = {
+  caseLawDb: CaseLawPublicReadDb;
+  citationsFromCursor?: string | null | undefined;
+  citationsToCursor?: string | null | undefined;
+  decisionId: SafeId<"caseLawDecision">;
+};
+
+const emptyCitationPage = () => ({
+  items: [],
+  limit: LIMITS.caseLawDecisionCitationPageSize,
+  nextCursor: null,
+});
+
+export const readDecisionHandler = async ({
+  caseLawDb,
+  citationsFromCursor,
+  citationsToCursor,
+  decisionId,
+}: ReadDecisionOptions) => {
   const decision = await caseLawDb((tx) =>
     tx.query.caseLawDecisions.findFirst({
       where: { id: { eq: decisionId } },
@@ -158,22 +183,6 @@ export const readDecisionHandler = async (
           // never returned to the client.
           columns: { id: true, name: true, adapterKey: true, descriptor: true },
         },
-        citationsFrom: {
-          columns: {
-            id: true,
-            citationText: true,
-            citedDecisionId: true,
-            sectionIndex: true,
-          },
-        },
-        citationsTo: {
-          columns: {
-            id: true,
-            citationText: true,
-            citingDecisionId: true,
-            sectionIndex: true,
-          },
-        },
       },
     }),
   );
@@ -188,49 +197,34 @@ export const readDecisionHandler = async (
     return status(404, { message: "Decision not found" });
   }
 
-  const languageAlternates = await listPublicDecisionLanguageAlternates({
-    caseLawDb,
-    languageGroupKey: decision.languageGroupKey,
-  });
+  const [languageAlternates, citationsFromPage, citationsToPage] =
+    await Promise.all([
+      listPublicDecisionLanguageAlternates({
+        caseLawDb,
+        languageGroupKey: decision.languageGroupKey,
+      }),
+      citationsFromCursor === null
+        ? emptyCitationPage()
+        : listOutgoingDecisionCitations({
+            caseLawDb,
+            cursor: citationsFromCursor,
+            decisionId,
+          }),
+      citationsToCursor === null
+        ? emptyCitationPage()
+        : listIncomingDecisionCitations({
+            caseLawDb,
+            cursor: citationsToCursor,
+            decisionId,
+          }),
+    ]);
 
-  // Citations may point at decisions from non-redistributable sources;
-  // drop those so the response cannot leak restricted decisions' ids.
-  // Unresolved citations (null citedDecisionId) carry only text and stay.
-  const relatedIdCandidates = decision.citationsFrom
-    .map((citation) => citation.citedDecisionId)
-    .concat(decision.citationsTo.map((citation) => citation.citingDecisionId));
-  const relatedDecisionIds = [
-    ...new Set(relatedIdCandidates.filter((value) => value !== null)),
-  ];
-  const redistributableRelatedIds = new Set(
-    relatedDecisionIds.length === 0
-      ? []
-      : (
-          await caseLawDb((tx) =>
-            tx
-              .select({ id: caseLawDecisions.id })
-              .from(caseLawDecisions)
-              .innerJoin(
-                caseLawSources,
-                eq(caseLawSources.id, caseLawDecisions.sourceId),
-              )
-              .where(
-                and(
-                  inArray(caseLawDecisions.id, relatedDecisionIds),
-                  redistributableCaseLawSource,
-                ),
-              ),
-          )
-        ).map((row) => row.id),
-  );
-  const citationsFrom = decision.citationsFrom.filter(
-    (citation) =>
-      citation.citedDecisionId === null ||
-      redistributableRelatedIds.has(citation.citedDecisionId),
-  );
-  const citationsTo = decision.citationsTo.filter((citation) =>
-    redistributableRelatedIds.has(citation.citingDecisionId),
-  );
+  if (!("items" in citationsFromPage)) {
+    return citationsFromPage;
+  }
+  if (!("items" in citationsToPage)) {
+    return citationsToPage;
+  }
 
   // Prefer canonical AST from object storage when corpus storage is
   // enabled; fall back to the Postgres column so a read is never harder
@@ -325,8 +319,10 @@ export const readDecisionHandler = async (
       // must not feed the full text to a model when this is false.
       allowsDerivedAi: allowsDerivedAi(source.descriptor),
     },
-    citationsFrom,
-    citationsTo,
+    citationsFrom: citationsFromPage.items,
+    citationsFromNextCursor: citationsFromPage.nextCursor,
+    citationsTo: citationsToPage.items,
+    citationsToNextCursor: citationsToPage.nextCursor,
     languageAlternates,
     fulltext,
   };
@@ -362,7 +358,10 @@ export const readDecisionBySlugHandler = async (
     return status(404, { message: "Decision not found" });
   }
 
-  return await readDecisionHandler(firstDecision.id, caseLawDb);
+  return await readDecisionHandler({
+    caseLawDb,
+    decisionId: firstDecision.id,
+  });
 };
 
 /**

--- a/apps/api/src/handlers/case-law/public-routes.ts
+++ b/apps/api/src/handlers/case-law/public-routes.ts
@@ -70,18 +70,14 @@ const readDecision = createSafePublicHandler(
     params: t.Object({ decisionId: tSafeId("caseLawDecision") }),
     query: readDecisionQuerySchema,
   },
-  async function* ({
-    params: { decisionId },
-    query: { citationsFromCursor, citationsToCursor },
-  }) {
+  async function* ({ params: { decisionId }, query: { citationsCursor } }) {
     const response = yield* Result.await(
       Result.tryPromise(
         async () =>
           await readDecisionWithDocumentHandler({
             decisionId,
             caseLawDb: caseLawPublicReadDb,
-            citationsFromCursor,
-            citationsToCursor,
+            citationsCursor,
             // Unauthenticated: hydrates when a slot is free, but never
             // persists demand — see `recordDemand`.
             caller: "anonymous",
@@ -97,17 +93,21 @@ const readDecisionBySlug = createSafePublicHandler(
   {
     mcp: { type: "covered", by: "read_case_law_decision" },
     params: t.Object({ slug: t.String({ minLength: 1, maxLength: 256 }) }),
-    query: t.Object({
-      language: t.Optional(t.String({ minLength: 2, maxLength: 8 })),
-    }),
+    query: t.Composite([
+      readDecisionQuerySchema,
+      t.Object({
+        language: t.Optional(t.String({ minLength: 2, maxLength: 8 })),
+      }),
+    ]),
   },
-  async function* ({ params: { slug }, query: { language } }) {
+  async function* ({ params: { slug }, query: { citationsCursor, language } }) {
     const response = yield* Result.await(
       Result.tryPromise(
         async () =>
           await readDecisionBySlugWithDocumentHandler({
             slug,
             caseLawDb: caseLawPublicReadDb,
+            citationsCursor,
             language,
             caller: "anonymous",
           }),

--- a/apps/api/src/handlers/case-law/public-routes.ts
+++ b/apps/api/src/handlers/case-law/public-routes.ts
@@ -6,6 +6,7 @@ import {
   listDecisionFacetsHandler,
   listDecisionFacetsQuerySchema,
 } from "@/api/handlers/case-law/decisions/facets";
+import { readDecisionQuerySchema } from "@/api/handlers/case-law/decisions/get";
 import {
   readDecisionBySlugWithDocumentHandler,
   readDecisionWithDocumentHandler,
@@ -67,14 +68,20 @@ const readDecision = createSafePublicHandler(
   {
     mcp: { type: "tool", name: "read_case_law_decision" },
     params: t.Object({ decisionId: tSafeId("caseLawDecision") }),
+    query: readDecisionQuerySchema,
   },
-  async function* ({ params: { decisionId } }) {
+  async function* ({
+    params: { decisionId },
+    query: { citationsFromCursor, citationsToCursor },
+  }) {
     const response = yield* Result.await(
       Result.tryPromise(
         async () =>
           await readDecisionWithDocumentHandler({
             decisionId,
             caseLawDb: caseLawPublicReadDb,
+            citationsFromCursor,
+            citationsToCursor,
             // Unauthenticated: hydrates when a slot is free, but never
             // persists demand — see `recordDemand`.
             caller: "anonymous",
@@ -225,6 +232,7 @@ export const publicCaseLawRoute = new Elysia({
   })
   .get("/decisions/:decisionId", readDecision.handler, {
     params: readDecision.config.params,
+    query: readDecision.config.query,
   })
   .get("/decisions/:decisionId/provisions", listDecisionProvisions.handler, {
     params: listDecisionProvisions.config.params,

--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
@@ -1223,7 +1223,6 @@ const CONTRACT_CORPUS = {
               sectionIndex: 0,
             },
           ],
-          citationsFromNextCursor: null,
           citationsTo: [
             {
               id: toSafeId<"caseLawCitation">(uid(57)),
@@ -1232,7 +1231,7 @@ const CONTRACT_CORPUS = {
               sectionIndex: 1,
             },
           ],
-          citationsToNextCursor: null,
+          citationsNextCursor: null,
           country: "CZ",
           court: "Nejvyšší soud",
           // `decisionDate` is a plain `date`-mode column (a "YYYY-MM-DD"

--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
@@ -1223,6 +1223,7 @@ const CONTRACT_CORPUS = {
               sectionIndex: 0,
             },
           ],
+          citationsFromNextCursor: null,
           citationsTo: [
             {
               id: toSafeId<"caseLawCitation">(uid(57)),
@@ -1231,6 +1232,7 @@ const CONTRACT_CORPUS = {
               sectionIndex: 1,
             },
           ],
+          citationsToNextCursor: null,
           country: "CZ",
           court: "Nejvyšší soud",
           // `decisionDate` is a plain `date`-mode column (a "YYYY-MM-DD"

--- a/apps/api/src/lib/case-law/redistribution.ts
+++ b/apps/api/src/lib/case-law/redistribution.ts
@@ -1,12 +1,16 @@
-import { sql } from "drizzle-orm";
+import { sql, type SQLWrapper } from "drizzle-orm";
 
 import { caseLawSources } from "@/api/db/schema";
 
 // null descriptor = legacy public-record source, treated as redistributable.
-export const redistributableCaseLawSource = sql`(
-  ${caseLawSources.descriptor} IS NULL
-  OR (${caseLawSources.descriptor} ->> 'allowsRedistribution') = 'true'
+export const redistributableCaseLawSourceFor = (descriptor: SQLWrapper) => sql`(
+  ${descriptor} IS NULL
+  OR (${descriptor} ->> 'allowsRedistribution') = 'true'
 )`;
+
+export const redistributableCaseLawSource = redistributableCaseLawSourceFor(
+  caseLawSources.descriptor,
+);
 
 /**
  * The same predicate as raw SQL for sites that join `case_law_sources`

--- a/apps/api/src/lib/chat/projections.ts
+++ b/apps/api/src/lib/chat/projections.ts
@@ -1201,7 +1201,7 @@ export const SEARCH_CASE_LAW_PROJECTION = v.strictObject({
  * while the UUID backstop still guards every string inside, unlicensed.
  */
 export const READ_CASE_LAW_DECISION_PROJECTION = v.strictObject({
-  // Opaque compound `[textOffset, fromOffset, toOffset]` cursor.
+  // Opaque compound `[textOffset, fromCursor, toCursor]` cursor.
   nextCursor: v.nullable(passthroughId()),
   decision: v.strictObject({
     // Nullable for the same reason as search_case_law's `results[].appUrl`.
@@ -1215,7 +1215,6 @@ export const READ_CASE_LAW_DECISION_PROJECTION = v.strictObject({
         sectionIndex: v.nullable(v.number()),
       }),
     ),
-    citationsFromTotal: v.number(),
     citationsTo: v.array(
       v.strictObject({
         id: passthroughId(),
@@ -1224,7 +1223,6 @@ export const READ_CASE_LAW_DECISION_PROJECTION = v.strictObject({
         sectionIndex: v.nullable(v.number()),
       }),
     ),
-    citationsToTotal: v.number(),
     country: v.string(),
     court: v.string(),
     decisionDate: v.nullable(v.string()),

--- a/apps/api/src/lib/chat/projections.ts
+++ b/apps/api/src/lib/chat/projections.ts
@@ -1201,7 +1201,7 @@ export const SEARCH_CASE_LAW_PROJECTION = v.strictObject({
  * while the UUID backstop still guards every string inside, unlicensed.
  */
 export const READ_CASE_LAW_DECISION_PROJECTION = v.strictObject({
-  // Opaque compound `[textOffset, fromCursor, toCursor]` cursor.
+  // Opaque compound `[textOffset, citationsCursor]` cursor.
   nextCursor: v.nullable(passthroughId()),
   decision: v.strictObject({
     // Nullable for the same reason as search_case_law's `results[].appUrl`.

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -313,6 +313,7 @@ export const LIMITS = {
   clauseImportBatchLimit: 200,
   templateFillsRetentionDays: 365,
   caseLawMatterLinksPerWorkspace: 1000,
+  caseLawDecisionCitationPageSize: 50,
   caseLawSearchPageSizeDefault: 20,
   caseLawSearchPageSizeMax: 100,
   /** Max language variants for one decision's languageGroupKey. Bounds the

--- a/apps/api/src/lib/safe-id-boundaries.ts
+++ b/apps/api/src/lib/safe-id-boundaries.ts
@@ -133,6 +133,10 @@ export const brandPersistedCaseLawDecisionId = (
   caseLawDecisionId: string,
 ): SafeId<"caseLawDecision"> => toSafeId<"caseLawDecision">(caseLawDecisionId);
 
+export const brandPersistedCaseLawCitationId = (
+  caseLawCitationId: string,
+): SafeId<"caseLawCitation"> => toSafeId<"caseLawCitation">(caseLawCitationId);
+
 export const brandPersistedCaseLawSourceId = (
   caseLawSourceId: string,
 ): SafeId<"caseLawSource"> => toSafeId<"caseLawSource">(caseLawSourceId);

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -1712,34 +1712,32 @@ const handleSearchCaseLawTool: McpToolHandler = async ({ args, context }) => {
 };
 
 type DecisionCursorState = {
+  citations: string | null | undefined;
   text: number;
-  from: string | null | undefined;
-  to: string | null | undefined;
 };
 
 // read_case_law_decision pages the decision text and both citation lists with
-// a single compound cursor encoding [textOffset, fromCursor, toCursor].
+// a single compound cursor encoding [textOffset, citationsCursor].
 const decodeDecisionCursor = (
   cursor: string | undefined,
 ): DecisionCursorState | null => {
   if (cursor === undefined) {
-    return { text: 0, from: undefined, to: undefined };
+    return { citations: undefined, text: 0 };
   }
   const parts = decodePaginationCursor(cursor);
-  if (!parts || parts.length !== 3) {
+  if (!parts || parts.length !== 2) {
     return null;
   }
-  const [text, from, to] = parts;
+  const [text, citations] = parts;
   if (
     typeof text !== "number" ||
     !Number.isInteger(text) ||
     text < 0 ||
-    (from !== null && typeof from !== "string") ||
-    (to !== null && typeof to !== "string")
+    (citations !== null && typeof citations !== "string")
   ) {
     return null;
   }
-  return { text, from, to };
+  return { citations, text };
 };
 
 const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
@@ -1765,8 +1763,7 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
   const result = await readDecisionWithDocumentHandler({
     decisionId: brandPersistedCaseLawDecisionId(decisionId),
     caseLawDb: caseLawPublicReadDb,
-    citationsFromCursor: offsets.from,
-    citationsToCursor: offsets.to,
+    citationsCursor: offsets.citations,
     // An agent holding a token is a reader we can attribute, so its
     // interest counts as demand.
     caller: "attributed",
@@ -1802,15 +1799,9 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
     MCP_CONTENT_MAX_CHARS,
   );
   const hasMore =
-    textBounds.nextOffset !== null ||
-    result.citationsFromNextCursor !== null ||
-    result.citationsToNextCursor !== null;
+    textBounds.nextOffset !== null || result.citationsNextCursor !== null;
   const nextCursor = hasMore
-    ? encodePaginationCursor([
-        textBounds.end,
-        result.citationsFromNextCursor,
-        result.citationsToNextCursor,
-      ])
+    ? encodePaginationCursor([textBounds.end, result.citationsNextCursor])
     : null;
 
   return textResult({

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -105,9 +105,6 @@ import {
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
 const MCP_CONTENT_MAX_CHARS = 8000;
-// Page size for each citation list on read_case_law_decision. The decision
-// text and both citation lists are paged together by a single compound cursor.
-const MCP_CASE_LAW_CITATIONS_PER_DECISION = 50;
 type StellaToolName =
   | "list_matters"
   | "read_case_law_decision"
@@ -1714,15 +1711,19 @@ const handleSearchCaseLawTool: McpToolHandler = async ({ args, context }) => {
   });
 };
 
-type DecisionCursorOffsets = { text: number; from: number; to: number };
+type DecisionCursorState = {
+  text: number;
+  from: string | null | undefined;
+  to: string | null | undefined;
+};
 
 // read_case_law_decision pages the decision text and both citation lists with
-// a single compound cursor encoding [textOffset, fromOffset, toOffset].
+// a single compound cursor encoding [textOffset, fromCursor, toCursor].
 const decodeDecisionCursor = (
   cursor: string | undefined,
-): DecisionCursorOffsets | null => {
+): DecisionCursorState | null => {
   if (cursor === undefined) {
-    return { text: 0, from: 0, to: 0 };
+    return { text: 0, from: undefined, to: undefined };
   }
   const parts = decodePaginationCursor(cursor);
   if (!parts || parts.length !== 3) {
@@ -1733,12 +1734,8 @@ const decodeDecisionCursor = (
     typeof text !== "number" ||
     !Number.isInteger(text) ||
     text < 0 ||
-    typeof from !== "number" ||
-    !Number.isInteger(from) ||
-    from < 0 ||
-    typeof to !== "number" ||
-    !Number.isInteger(to) ||
-    to < 0
+    (from !== null && typeof from !== "string") ||
+    (to !== null && typeof to !== "string")
   ) {
     return null;
   }
@@ -1768,6 +1765,8 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
   const result = await readDecisionWithDocumentHandler({
     decisionId: brandPersistedCaseLawDecisionId(decisionId),
     caseLawDb: caseLawPublicReadDb,
+    citationsFromCursor: offsets.from,
+    citationsToCursor: offsets.to,
     // An agent holding a token is a reader we can attribute, so its
     // interest counts as demand.
     caller: "attributed",
@@ -1802,25 +1801,16 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
     offsets.text,
     MCP_CONTENT_MAX_CHARS,
   );
-  const fromBounds = resolveWindowBounds(
-    result.citationsFrom.length,
-    offsets.from,
-    MCP_CASE_LAW_CITATIONS_PER_DECISION,
-  );
-  const toBounds = resolveWindowBounds(
-    result.citationsTo.length,
-    offsets.to,
-    MCP_CASE_LAW_CITATIONS_PER_DECISION,
-  );
-
-  // One compound cursor advances all three streams together; it resolves to
-  // null only once the text and both citation lists are fully consumed.
   const hasMore =
     textBounds.nextOffset !== null ||
-    fromBounds.nextOffset !== null ||
-    toBounds.nextOffset !== null;
+    result.citationsFromNextCursor !== null ||
+    result.citationsToNextCursor !== null;
   const nextCursor = hasMore
-    ? encodePaginationCursor([textBounds.end, fromBounds.end, toBounds.end])
+    ? encodePaginationCursor([
+        textBounds.end,
+        result.citationsFromNextCursor,
+        result.citationsToNextCursor,
+      ])
     : null;
 
   return textResult({
@@ -1835,13 +1825,8 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
         slug: result.slug,
       }),
       caseNumber: result.caseNumber,
-      citationsFrom: result.citationsFrom.slice(
-        fromBounds.start,
-        fromBounds.end,
-      ),
-      citationsFromTotal: result.citationsFrom.length,
-      citationsTo: result.citationsTo.slice(toBounds.start, toBounds.end),
-      citationsToTotal: result.citationsTo.length,
+      citationsFrom: result.citationsFrom,
+      citationsTo: result.citationsTo,
       country: result.country,
       court: result.court,
       decisionDate: toIsoDateString(result.decisionDate),

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -1831,7 +1831,7 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
       source: result.source,
       sourceUrl: result.sourceUrl,
       text:
-        plainText === null
+        plainText === null || textBounds.start >= textBounds.end
           ? null
           : plainText.slice(textBounds.start, textBounds.end),
       charCount: plainText === null ? null : textLength,

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -1576,6 +1576,7 @@ describe("OpenAI-compatible MCP tools", () => {
       decision: {
         citationsFrom: { id: string }[];
         citationsTo: { id: string }[];
+        text: string | null;
       };
     };
 
@@ -1605,6 +1606,7 @@ describe("OpenAI-compatible MCP tools", () => {
     expect(page2.decision.citationsTo).toHaveLength(20);
     expect(page2.decision.citationsFrom.at(0)?.id).toBe("cf_50");
     expect(page2.decision.citationsTo.at(0)?.id).toBe("ct_50");
+    expect(page2.decision.text).toBeNull();
     expect(page2.nextCursor).toBeNull();
     expect(readDecisionHandlerMock).toHaveBeenLastCalledWith({
       decisionId: "dec_123",

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -324,9 +324,8 @@ const createReadDecisionResult = () => ({
   analysis: null,
   caseNumber: "29 Cdo 123/2024",
   citationsFrom: [{ citationText: "29 Odo 1/2001", id: "c_1" }],
-  citationsFromNextCursor: null,
   citationsTo: [{ citationText: "31 Cdo 2/2025", id: "c_2" }],
-  citationsToNextCursor: null,
+  citationsNextCursor: null,
   country: "CZE",
   court: "Nejvyšší soud",
   decisionDate: new Date("2024-02-01T00:00:00.000Z"),
@@ -1446,8 +1445,7 @@ describe("OpenAI-compatible MCP tools", () => {
       decisionId: "dec_123",
       caseLawDb: caseLawPublicReadDb,
       caller: "attributed",
-      citationsFromCursor: undefined,
-      citationsToCursor: undefined,
+      citationsCursor: undefined,
     });
 
     expect(parseToolPayload(result)).toEqual({
@@ -1548,8 +1546,8 @@ describe("OpenAI-compatible MCP tools", () => {
   test("read_case_law_decision pages citation lists via the compound cursor", async () => {
     const base = createReadDecisionResult();
     readDecisionHandlerMock.mockImplementation(
-      async ({ citationsFromCursor }: { citationsFromCursor?: string }) => {
-        const page = citationsFromCursor === undefined ? 0 : 1;
+      async ({ citationsCursor }: { citationsCursor?: string }) => {
+        const page = citationsCursor === undefined ? 0 : 1;
         const fromStart = page * 50;
         const toStart = page * 50;
         return {
@@ -1561,7 +1559,6 @@ describe("OpenAI-compatible MCP tools", () => {
               id: `cf_${String(fromStart + i)}`,
             }),
           ),
-          citationsFromNextCursor: page === 0 ? "from-next" : null,
           citationsTo: Array.from(
             { length: page === 0 ? 50 : 20 },
             (_unused, i) => ({
@@ -1569,7 +1566,7 @@ describe("OpenAI-compatible MCP tools", () => {
               id: `ct_${String(toStart + i)}`,
             }),
           ),
-          citationsToNextCursor: page === 0 ? "to-next" : null,
+          citationsNextCursor: page === 0 ? "citations-next" : null,
         };
       },
     );
@@ -1613,8 +1610,7 @@ describe("OpenAI-compatible MCP tools", () => {
       decisionId: "dec_123",
       caseLawDb: caseLawPublicReadDb,
       caller: "attributed",
-      citationsFromCursor: "from-next",
-      citationsToCursor: "to-next",
+      citationsCursor: "citations-next",
     });
   });
 

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -324,7 +324,9 @@ const createReadDecisionResult = () => ({
   analysis: null,
   caseNumber: "29 Cdo 123/2024",
   citationsFrom: [{ citationText: "29 Odo 1/2001", id: "c_1" }],
+  citationsFromNextCursor: null,
   citationsTo: [{ citationText: "31 Cdo 2/2025", id: "c_2" }],
+  citationsToNextCursor: null,
   country: "CZE",
   court: "Nejvyšší soud",
   decisionDate: new Date("2024-02-01T00:00:00.000Z"),
@@ -1444,6 +1446,8 @@ describe("OpenAI-compatible MCP tools", () => {
       decisionId: "dec_123",
       caseLawDb: caseLawPublicReadDb,
       caller: "attributed",
+      citationsFromCursor: undefined,
+      citationsToCursor: undefined,
     });
 
     expect(parseToolPayload(result)).toEqual({
@@ -1452,9 +1456,7 @@ describe("OpenAI-compatible MCP tools", () => {
         appUrl: `${APP_BASE_URL}/law/cze/cases/nejvyssi-soud/stable-official-slug`,
         caseNumber: "29 Cdo 123/2024",
         citationsFrom: [{ citationText: "29 Odo 1/2001", id: "c_1" }],
-        citationsFromTotal: 1,
         citationsTo: [{ citationText: "31 Cdo 2/2025", id: "c_2" }],
-        citationsToTotal: 1,
         country: "CZE",
         court: "Nejvyšší soud",
         decisionDate: "2024-02-01",
@@ -1517,9 +1519,7 @@ describe("OpenAI-compatible MCP tools", () => {
         appUrl: `${APP_BASE_URL}/law/cze/cases/nejvyssi-soud/stable-official-slug`,
         caseNumber: "29 Cdo 123/2024",
         citationsFrom: [{ citationText: "29 Odo 1/2001", id: "c_1" }],
-        citationsFromTotal: 1,
         citationsTo: [{ citationText: "31 Cdo 2/2025", id: "c_2" }],
-        citationsToTotal: 1,
         country: "CZE",
         court: "Nejvyšší soud",
         decisionDate: "2024-02-01",
@@ -1547,25 +1547,38 @@ describe("OpenAI-compatible MCP tools", () => {
 
   test("read_case_law_decision pages citation lists via the compound cursor", async () => {
     const base = createReadDecisionResult();
-    readDecisionHandlerMock.mockResolvedValue({
-      ...base,
-      citationsFrom: Array.from({ length: 60 }, (_unused, i) => ({
-        citationText: `from-${i}`,
-        id: `cf_${i}`,
-      })),
-      citationsTo: Array.from({ length: 70 }, (_unused, i) => ({
-        citationText: `to-${i}`,
-        id: `ct_${i}`,
-      })),
-    });
+    readDecisionHandlerMock.mockImplementation(
+      async ({ citationsFromCursor }: { citationsFromCursor?: string }) => {
+        const page = citationsFromCursor === undefined ? 0 : 1;
+        const fromStart = page * 50;
+        const toStart = page * 50;
+        return {
+          ...base,
+          citationsFrom: Array.from(
+            { length: page === 0 ? 50 : 10 },
+            (_unused, i) => ({
+              citationText: `from-${String(fromStart + i)}`,
+              id: `cf_${String(fromStart + i)}`,
+            }),
+          ),
+          citationsFromNextCursor: page === 0 ? "from-next" : null,
+          citationsTo: Array.from(
+            { length: page === 0 ? 50 : 20 },
+            (_unused, i) => ({
+              citationText: `to-${String(toStart + i)}`,
+              id: `ct_${String(toStart + i)}`,
+            }),
+          ),
+          citationsToNextCursor: page === 0 ? "to-next" : null,
+        };
+      },
+    );
 
     type DecisionPage = {
       nextCursor: string | null;
       decision: {
         citationsFrom: { id: string }[];
-        citationsFromTotal: number;
         citationsTo: { id: string }[];
-        citationsToTotal: number;
       };
     };
 
@@ -1579,9 +1592,7 @@ describe("OpenAI-compatible MCP tools", () => {
       ),
     );
     expect(page1.decision.citationsFrom).toHaveLength(50);
-    expect(page1.decision.citationsFromTotal).toBe(60);
     expect(page1.decision.citationsTo).toHaveLength(50);
-    expect(page1.decision.citationsToTotal).toBe(70);
     expect(page1.nextCursor).not.toBeNull();
 
     const page2 = asTestRaw<DecisionPage>(
@@ -1598,6 +1609,13 @@ describe("OpenAI-compatible MCP tools", () => {
     expect(page2.decision.citationsFrom.at(0)?.id).toBe("cf_50");
     expect(page2.decision.citationsTo.at(0)?.id).toBe("ct_50");
     expect(page2.nextCursor).toBeNull();
+    expect(readDecisionHandlerMock).toHaveBeenLastCalledWith({
+      decisionId: "dec_123",
+      caseLawDb: caseLawPublicReadDb,
+      caller: "attributed",
+      citationsFromCursor: "from-next",
+      citationsToCursor: "to-next",
+    });
   });
 
   test("fetch rejects documents outside the MCP workspace allowlist", async () => {


### PR DESCRIPTION
## Summary
- page incoming and outgoing decision citations with stable UUID cursors
- filter redistribution eligibility inside bounded joins and add matching concurrent indexes
- drive MCP citation windows from database cursors

## Testing
- `bun run verify`
- `BASE_REF=origin/main bash scripts/check-migrations.sh`
- mutation: removing the lookahead row stopped traversal at 50 instead of 56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated incoming and outgoing citations to case-law decision responses.
  * Added cursor-based navigation for citation lists, including support for invalid-cursor error handling.
  * Citation results now respect source redistribution and visibility rules while retaining unresolved citations.
  * Increased citation page size to 50 items.

* **Bug Fixes**
  * Restricted decisions are excluded from citation results where appropriate.

* **Tests**
  * Added coverage for citation pagination, visibility filtering, cursor validation and database indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->