### PR TITLE
fix: allow slow NSS listing responses

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -15,6 +15,7 @@ import {
   describe,
   expect,
   setSystemTime,
+  spyOn,
   test,
 } from "bun:test";
 
@@ -273,6 +274,46 @@ const throughJsonb = (value: unknown): unknown =>
   JSON.parse(JSON.stringify(value));
 
 const SLICE = "2026-06-10";
+
+test("allows the NSS listing endpoints to use their source-specific budget", async () => {
+  installStub({ search: [htmlResponse("", 503)] });
+  const invalidation = await czNssAdapter.fetchPage("2026-08-20:0", {});
+  expect(invalidation.isErr()).toBe(true);
+
+  const originalTimeout = AbortSignal.timeout;
+  const timeouts: number[] = [];
+  const timeoutSpy = spyOn(AbortSignal, "timeout").mockImplementation(
+    (milliseconds) => {
+      timeouts.push(milliseconds);
+      return originalTimeout(milliseconds);
+    },
+  );
+  try {
+    installStub({ search: [htmlResponse("", 503)] });
+    const failed = await czNssAdapter.fetchPage("2026-08-20:0", {});
+    expect(failed.isErr()).toBe(true);
+    expect(timeouts).toEqual([120_000, 60_000, 60_000]);
+    timeouts.length = 0;
+
+    installStub({
+      search: [
+        htmlResponse(
+          searchPage({
+            statedCount: CZ_NSS_FIRST_PAGE_ROWS + 1,
+            rows: fullPageRows(CZ_NSS_FIRST_PAGE_ROWS),
+          }),
+        ),
+      ],
+      continuation: [htmlResponse(rowBlock(REGIONAL_ROW))],
+    });
+    const page = await czNssAdapter.fetchPage(`${SLICE}:1`, {});
+
+    expect(page.isOk()).toBe(true);
+    expect(timeouts.slice(0, 4)).toEqual([120_000, 60_000, 60_000, 60_000]);
+  } finally {
+    timeoutSpy.mockRestore();
+  }
+});
 
 // ── Slice arithmetic ─────────────────────────────────────
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -852,7 +852,7 @@ const initSession = async (signal: AbortSignal): Promise<SessionState> => {
     signal,
     redirect: "follow",
     headers: COMMON_HEADERS,
-    timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+    timeoutMs: CZ_NSS_LISTING_TIMEOUT_MS,
   });
 
   if (!response.ok) {
@@ -952,7 +952,7 @@ const executeSearch = async (
     },
     body: formData.toString(),
     redirect: "follow",
-    timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+    timeoutMs: CZ_NSS_LISTING_TIMEOUT_MS,
   });
 
   if (!response.ok) {
@@ -1020,7 +1020,7 @@ const fetchResultPage = async ({
       "X-Requested-With": "XMLHttpRequest",
     },
     body: formData.toString(),
-    timeoutMs: ADAPTER_TIMEOUT.REQUEST,
+    timeoutMs: CZ_NSS_LISTING_TIMEOUT_MS,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
- Use the NSS adapter's existing listing timeout for session, search, and pagination requests.
- Keep document fetches on the shared request timeout and cover the listing budget with a runtime regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when retrieving Czech Supreme Administrative Court case-law listings.
  - Initial listing requests now have up to 120 seconds to complete, while subsequent requests use a 60-second timeout.
  - Search and pagination requests now apply consistent timeout handling, including when earlier requests fail.
  - Improved handling of longer-running listing operations to reduce premature timeout failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->