### PR TITLE
chore: cache code checks across worktrees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -969,6 +969,12 @@ jobs:
       - name: Setup Bun
         uses: stella/.github/actions/setup-bun-cached@48aacae31829ce15216a6b766b03a92fd2e84da3
 
+      - name: Turbo remote cache
+        # code-quality runs cacheable workspace and root checks. Restore the
+        # same artifact store as ci-checks instead of rebuilding on every
+        # ephemeral runner; the job is restricted to trusted code above.
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
+
       - name: Install dependencies
         run: bash scripts/bun-ci-retry.sh --ignore-scripts
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,11 @@ jobs:
           package_checks_required=false
           for file in "${changed_files[@]}"; do
             case "$file" in
+              .github/workflows/ci.yml)
+                # This workflow owns package-check scheduling and the
+                # code-quality job itself, so its changes must exercise both.
+                package_checks_required=true
+                ;;
               .github/*|.provenance.yml|provenance/*)
                 ;;
               *)

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -366,6 +366,10 @@ describe("Turbo cache input contract", () => {
       typecheckStart,
       rootTypecheckStart,
     );
+    const rootTypecheckConfig = turboConfig.slice(
+      rootTypecheckStart,
+      lintStart,
+    );
     const lintConfig = turboConfig.slice(lintStart, lintFixStart);
     const rootInputs = (taskConfig: string) =>
       [...taskConfig.matchAll(/"(\$TURBO_ROOT\$\/[^"\n]+)"/gu)]
@@ -375,6 +379,23 @@ describe("Turbo cache input contract", () => {
 
     expect(rootInputs(typecheckConfig)).toEqual(
       [...ALL_WORKSPACE_TYPECHECK_CACHE_INPUTS].sort(),
+    );
+    expect(rootInputs(rootTypecheckConfig)).toEqual(
+      [
+        "$TURBO_ROOT$/.claude/mcp/**",
+        "$TURBO_ROOT$/.npmrc",
+        "$TURBO_ROOT$/.oxlint-plugins/**",
+        "$TURBO_ROOT$/apps/**",
+        "$TURBO_ROOT$/bun.lock",
+        "$TURBO_ROOT$/bunfig.toml",
+        "$TURBO_ROOT$/oxlint.config.ts",
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/packages/**",
+        "$TURBO_ROOT$/patches/**",
+        "$TURBO_ROOT$/scripts/**",
+        "$TURBO_ROOT$/tsconfig*.json",
+        "$TURBO_ROOT$/types/**",
+      ].sort(),
     );
     expect(rootInputs(lintConfig)).toEqual(
       [...ALL_WORKSPACE_CACHE_INPUTS, ...LINT_ONLY_CACHE_INPUTS].sort(),

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -160,6 +160,16 @@ describe("affected code-check planning", () => {
     },
   );
 
+  test("the shared tooling config invalidates only workspace lint", () => {
+    expect(plan(["tsconfig.tooling.json"], [])).toEqual({
+      type: "scoped",
+      lint: { type: "all" },
+      typecheck: { type: "targets", targets: [] },
+      rootLintPaths: [],
+      rootChecks: ["env", "repo-typecheck"],
+    });
+  });
+
   test.each([
     ["scripts/check-oxlint-plugin-registry.ts", "plugin-registry"],
     ["scripts/lint-oxlint-fixtures.sh", "plugin-fixtures"],
@@ -334,6 +344,12 @@ describe("Turbo cache input contract", () => {
     for (const input of TYPECHECK_ONLY_CACHE_INPUTS) {
       expect(ALL_WORKSPACE_TYPECHECK_CACHE_INPUTS).toContain(input);
     }
+  });
+
+  test("workspace lint covers the shared tooling config", () => {
+    expect(LINT_ONLY_CACHE_INPUTS).toContain(
+      "$TURBO_ROOT$/tsconfig.tooling.json",
+    );
   });
 
   test("keeps planner-wide inputs exactly aligned with their Turbo tasks", () => {

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -3,8 +3,11 @@ import { readFileSync } from "node:fs";
 
 import {
   ALL_WORKSPACE_CACHE_INPUTS,
+  DEPENDENCY_CACHE_INPUTS,
   LINT_ONLY_CACHE_INPUTS,
   planCheck,
+  PLUGIN_FIXTURE_INPUTS,
+  PLUGIN_REGISTRY_INPUTS,
   ROOT_SCRIPT_LINT_INPUTS,
   scopedCommands,
 } from "./code-check-affected";
@@ -155,6 +158,7 @@ describe("affected code-check planning", () => {
   );
 
   test.each([
+    ["scripts/check-oxlint-plugin-registry.ts", "plugin-registry"],
     ["scripts/lint-oxlint-fixtures.sh", "plugin-fixtures"],
     ["scripts/lint-root-scripts.sh", "root-script-lint"],
     ["scripts/tsconfig.json", "root-script-lint"],
@@ -283,6 +287,21 @@ describe("changed lint path selection", () => {
 });
 
 describe("Turbo cache input contract", () => {
+  test("each plugin check invalidates on its own implementation", () => {
+    expect(PLUGIN_REGISTRY_INPUTS).toContain(
+      "$TURBO_ROOT$/scripts/check-oxlint-plugin-registry.ts",
+    );
+    expect(PLUGIN_FIXTURE_INPUTS).toContain(
+      "$TURBO_ROOT$/scripts/lint-oxlint-fixtures.sh",
+    );
+  });
+
+  test("plugin fixtures cover every dependency-resolution input", () => {
+    for (const input of DEPENDENCY_CACHE_INPUTS) {
+      expect(PLUGIN_FIXTURE_INPUTS).toContain(input);
+    }
+  });
+
   test("root script lint covers every shared workspace input", () => {
     for (const input of ALL_WORKSPACE_CACHE_INPUTS) {
       expect(ROOT_SCRIPT_LINT_INPUTS).toContain(input);

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -175,6 +175,7 @@ describe("affected code-check planning", () => {
     ["scripts/lint-oxlint-fixtures.sh", "plugin-fixtures"],
     ["scripts/lint-root-scripts.sh", "root-script-lint"],
     ["scripts/tsconfig.json", "root-script-lint"],
+    ["tsconfig.json", "plugin-fixtures"],
     ["tsconfig.scripts.json", "root-script-lint"],
   ] as const)(
     "runs only the owning root check for %s",
@@ -329,6 +330,10 @@ describe("Turbo cache input contract", () => {
     for (const input of DEPENDENCY_CACHE_INPUTS) {
       expect(PLUGIN_FIXTURE_INPUTS).toContain(input);
     }
+  });
+
+  test("plugin fixtures cover the root config discovered by Oxc", () => {
+    expect(PLUGIN_FIXTURE_INPUTS).toContain("$TURBO_ROOT$/tsconfig.json");
   });
 
   test("root script lint covers every shared workspace input", () => {

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -10,6 +10,7 @@ import {
   PLUGIN_FIXTURE_INPUTS,
   PLUGIN_REGISTRY_INPUTS,
   ROOT_SCRIPT_LINT_INPUTS,
+  SHARED_COMPILER_CACHE_INPUTS,
   TYPECHECK_ONLY_CACHE_INPUTS,
   scopedCommands,
 } from "./code-check-affected";
@@ -139,6 +140,15 @@ describe("affected code-check planning", () => {
     }
     expect(planned.lint).toEqual({ type: "all" });
     expect(planned.typecheck).toEqual({ type: "all" });
+  });
+
+  test("shared compiler changes also invalidate plugin fixtures", () => {
+    const planned = plan(["packages/typescript-config/base.json"], []);
+    expect(planned.type).toBe("scoped");
+    if (planned.type !== "scoped") {
+      throw new Error("Expected a scoped code-check plan");
+    }
+    expect(planned.rootChecks).toContain("plugin-fixtures");
   });
 
   test.each(["oxlint.config.ts", ".oxlint-plugins/no-raw-use-effect.ts"])(
@@ -328,6 +338,12 @@ describe("Turbo cache input contract", () => {
 
   test("plugin fixtures cover every dependency-resolution input", () => {
     for (const input of DEPENDENCY_CACHE_INPUTS) {
+      expect(PLUGIN_FIXTURE_INPUTS).toContain(input);
+    }
+  });
+
+  test("plugin fixtures cover every shared compiler input", () => {
+    for (const input of SHARED_COMPILER_CACHE_INPUTS) {
       expect(PLUGIN_FIXTURE_INPUTS).toContain(input);
     }
   });

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -5,6 +5,7 @@ import {
   ALL_WORKSPACE_CACHE_INPUTS,
   LINT_ONLY_CACHE_INPUTS,
   planCheck,
+  ROOT_SCRIPT_LINT_INPUTS,
   scopedCommands,
 } from "./code-check-affected";
 import { isChangedLintPath } from "./lint-paths";
@@ -223,6 +224,19 @@ describe("affected code-check planning", () => {
     ]);
   });
 
+  test.each(
+    ROOT_SCRIPT_LINT_INPUTS.map((input) =>
+      input.slice("$TURBO_ROOT$/".length).replace(/\/\*\*$/u, "/fixture.ts"),
+    ),
+  )("shared root-script input %s schedules full root lint", (changedPath) => {
+    const planned = plan([changedPath], []);
+    expect(planned.type).toBe("scoped");
+    if (planned.type !== "scoped") {
+      throw new Error("Expected a scoped code-check plan");
+    }
+    expect(planned.rootChecks).toContain("root-script-lint");
+  });
+
   test("falls back when Turbo omits the directly changed workspace", () => {
     expect(plan(["apps/api/src/server.ts"], ["apps/web"])).toEqual({
       type: "fallback",
@@ -269,6 +283,12 @@ describe("changed lint path selection", () => {
 });
 
 describe("Turbo cache input contract", () => {
+  test("root script lint covers every shared workspace input", () => {
+    for (const input of ALL_WORKSPACE_CACHE_INPUTS) {
+      expect(ROOT_SCRIPT_LINT_INPUTS).toContain(input);
+    }
+  });
+
   test("keeps planner-wide inputs exactly aligned with their Turbo tasks", () => {
     const turboConfig = readFileSync("turbo.json", "utf-8");
     const typecheckStart = turboConfig.indexOf('    "typecheck":');

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 
-import { affectedCommands, planCheck } from "./code-check-affected";
+import {
+  ALL_WORKSPACE_CACHE_INPUTS,
+  LINT_ONLY_CACHE_INPUTS,
+  planCheck,
+  scopedCommands,
+} from "./code-check-affected";
 import { isChangedLintPath } from "./lint-paths";
 
 const WORKSPACES = new Set([
@@ -8,6 +14,7 @@ const WORKSPACES = new Set([
   "apps/landing",
   "apps/web",
   "packages/errors",
+  "packages/typescript-config",
   "packages/ui",
 ]);
 
@@ -31,26 +38,39 @@ describe("affected code-check planning", () => {
         ["packages/ui", "apps/web", "apps/landing"],
       ),
     ).toEqual({
-      type: "affected",
-      targets: ["apps/landing", "apps/web", "packages/ui"],
+      type: "scoped",
+      lint: {
+        type: "targets",
+        targets: ["apps/landing", "apps/web", "packages/ui"],
+      },
+      typecheck: {
+        type: "targets",
+        targets: ["apps/landing", "apps/web", "packages/ui"],
+      },
       rootLintPaths: [],
+      rootChecks: ["env", "repo-typecheck"],
     });
   });
 
   test("does not run workspace analysis for documentation-only changes", () => {
     expect(plan(["README.md"], [])).toEqual({
-      type: "affected",
-      targets: [],
+      type: "scoped",
+      lint: { type: "targets", targets: [] },
+      typecheck: { type: "targets", targets: [] },
       rootLintPaths: [],
+      rootChecks: ["env", "repo-typecheck"],
     });
   });
 
   test("caches lint and typecheck per affected workspace", () => {
-    const commands = affectedCommands({
-      type: "affected",
-      targets: ["apps/web", "packages/ui"],
-      rootLintPaths: [],
-    });
+    const planned = plan(
+      ["packages/ui/src/button.tsx"],
+      ["apps/web", "packages/ui"],
+    );
+    if (planned.type !== "scoped") {
+      throw new Error("Expected a scoped code-check plan");
+    }
+    const commands = scopedCommands(planned);
     expect(commands).toContainEqual(["bun", "run", "env:check"]);
     expect(commands).toContainEqual([
       "bun",
@@ -63,14 +83,22 @@ describe("affected code-check planning", () => {
       "--filter=./apps/web",
       "--filter=./packages/ui",
     ]);
+    expect(commands).toContainEqual([
+      "bun",
+      "--bun",
+      "turbo",
+      "run",
+      "typecheck:repo",
+      "--concurrency=2",
+    ]);
   });
 
   test("lints changed root scripts outside Turbo workspaces", () => {
-    const commands = affectedCommands({
-      type: "affected",
-      targets: [],
-      rootLintPaths: ["scripts/guard.ts"],
-    });
+    const planned = plan(["scripts/guard.ts"], []);
+    if (planned.type !== "scoped") {
+      throw new Error("Expected a scoped code-check plan");
+    }
+    const commands = scopedCommands(planned);
 
     const oxc = commands.find((command) => command.includes("oxlint"));
     expect(oxc).toContain("--type-aware");
@@ -79,49 +107,139 @@ describe("affected code-check planning", () => {
 
   test("typechecks dependants without trying to lint a deleted source", () => {
     expect(plan(["packages/ui/src/removed.ts"], ["packages/ui"], [])).toEqual({
-      type: "affected",
-      targets: ["packages/ui"],
+      type: "scoped",
+      lint: { type: "targets", targets: ["packages/ui"] },
+      typecheck: { type: "targets", targets: ["packages/ui"] },
       rootLintPaths: [],
+      rootChecks: ["env", "repo-typecheck"],
     });
   });
 
   test.each([
-    "package.json",
+    ".npmrc",
     "bun.lock",
     "bunfig.toml",
-    "scripts/code-check-affected.ts",
-    "scripts/lint-paths.ts",
-    "scripts/lint-oxlint-fixtures.sh",
-    "scripts/lint-root-scripts.sh",
-    "scripts/tsconfig.json",
+    "package.json",
     "turbo.json",
-    "oxlint.config.ts",
-    "tsconfig.json",
-    ".oxlint-plugins/no-raw-use-effect.ts",
     "packages/typescript-config/base.json",
     "patches/vite.patch",
     "types/react-css-properties.d.ts",
-  ])("falls back to the full repository for global input %s", (changedPath) => {
-    expect(plan([changedPath], [])).toEqual({ type: "full", changedPath });
+  ])("checks all workspaces for dependency input %s", (changedPath) => {
+    const planned = plan([changedPath], []);
+    expect(planned.type).toBe("scoped");
+    if (planned.type !== "scoped") {
+      throw new Error("Expected a scoped code-check plan");
+    }
+    expect(planned.lint).toEqual({ type: "all" });
+    expect(planned.typecheck).toEqual({ type: "all" });
+  });
+
+  test.each(["oxlint.config.ts", ".oxlint-plugins/no-raw-use-effect.ts"])(
+    "invalidates lint without discarding typecheck cache for %s",
+    (changedPath) => {
+      expect(plan([changedPath], [])).toEqual({
+        type: "scoped",
+        lint: { type: "all" },
+        typecheck: { type: "targets", targets: [] },
+        rootLintPaths: [changedPath],
+        rootChecks: [
+          "env",
+          "plugin-registry",
+          "plugin-fixtures",
+          "root-script-lint",
+          "repo-typecheck",
+        ],
+      });
+    },
+  );
+
+  test.each([
+    ["scripts/lint-oxlint-fixtures.sh", "plugin-fixtures"],
+    ["scripts/lint-root-scripts.sh", "root-script-lint"],
+    ["scripts/tsconfig.json", "root-script-lint"],
+    ["tsconfig.scripts.json", "root-script-lint"],
+  ] as const)(
+    "runs only the owning root check for %s",
+    (changedPath, rootCheck) => {
+      const planned = plan([changedPath], []);
+      expect(planned.type).toBe("scoped");
+      if (planned.type !== "scoped") {
+        throw new Error("Expected a scoped code-check plan");
+      }
+      expect(planned.lint).toEqual({ type: "targets", targets: [] });
+      expect(planned.typecheck).toEqual({ type: "targets", targets: [] });
+      expect(planned.rootChecks).toEqual(["env", rootCheck, "repo-typecheck"]);
+    },
+  );
+
+  test("a lint-global input does not widen affected typechecks", () => {
+    const planned = plan(
+      ["oxlint.config.ts", "apps/web/src/route.tsx"],
+      ["apps/web"],
+    );
+    expect(planned.type).toBe("scoped");
+    if (planned.type !== "scoped") {
+      throw new Error("Expected a scoped code-check plan");
+    }
+    expect(planned.lint).toEqual({ type: "all" });
+    expect(planned.typecheck).toEqual({
+      type: "targets",
+      targets: ["apps/web"],
+    });
+
+    const commands = scopedCommands(planned);
+    expect(commands).toContainEqual([
+      "bun",
+      "--bun",
+      "turbo",
+      "run",
+      "lint",
+      "--concurrency=2",
+    ]);
+    expect(commands).toContainEqual([
+      "bun",
+      "--bun",
+      "turbo",
+      "run",
+      "typecheck",
+      "--concurrency=2",
+      "--filter=./apps/web",
+    ]);
+  });
+
+  test("global dependency inputs use cacheable Turbo tasks", () => {
+    const planned = plan(["bunfig.toml"], []);
+    if (planned.type !== "scoped") {
+      throw new Error("Expected a scoped code-check plan");
+    }
+    expect(scopedCommands(planned)).toContainEqual([
+      "bun",
+      "--bun",
+      "turbo",
+      "run",
+      "lint",
+      "typecheck",
+      "--concurrency=2",
+    ]);
   });
 
   test("falls back when Turbo omits the directly changed workspace", () => {
     expect(plan(["apps/api/src/server.ts"], ["apps/web"])).toEqual({
-      type: "full",
+      type: "fallback",
       changedPath: "apps/api/src/server.ts",
     });
   });
 
   test("falls back for an unknown workspace directory", () => {
     expect(plan(["apps/unknown/src/main.ts"], [])).toEqual({
-      type: "full",
+      type: "fallback",
       changedPath: "apps/unknown/src/main.ts",
     });
   });
 
   test("falls back when Turbo returns a non-workspace target", () => {
     expect(plan(["README.md"], ["tools/unknown"])).toEqual({
-      type: "full",
+      type: "fallback",
       changedPath: "invalid Turbo workspace output",
     });
   });
@@ -147,5 +265,36 @@ describe("changed lint path selection", () => {
     "packages/ui/node_modules/library/index.js",
   ])("excludes non-source or generated path %s", (changedPath) => {
     expect(isChangedLintPath(changedPath)).toBe(false);
+  });
+});
+
+describe("Turbo cache input contract", () => {
+  test("keeps planner-wide inputs exactly aligned with their Turbo tasks", () => {
+    const turboConfig = readFileSync("turbo.json", "utf-8");
+    const typecheckStart = turboConfig.indexOf('    "typecheck":');
+    const rootTypecheckStart = turboConfig.indexOf('    "//#typecheck:repo":');
+    const lintStart = turboConfig.indexOf('    "lint":');
+    const lintFixStart = turboConfig.indexOf('    "lint:fix":');
+    expect(typecheckStart).toBeGreaterThan(-1);
+    expect(rootTypecheckStart).toBeGreaterThan(typecheckStart);
+    expect(lintStart).toBeGreaterThan(rootTypecheckStart);
+    expect(lintFixStart).toBeGreaterThan(lintStart);
+    const typecheckConfig = turboConfig.slice(
+      typecheckStart,
+      rootTypecheckStart,
+    );
+    const lintConfig = turboConfig.slice(lintStart, lintFixStart);
+    const rootInputs = (taskConfig: string) =>
+      [...taskConfig.matchAll(/"(\$TURBO_ROOT\$\/[^"\n]+)"/gu)]
+        .map((match) => match.at(1))
+        .filter((input) => input !== undefined)
+        .sort();
+
+    expect(rootInputs(typecheckConfig)).toEqual(
+      [...ALL_WORKSPACE_CACHE_INPUTS].sort(),
+    );
+    expect(rootInputs(lintConfig)).toEqual(
+      [...ALL_WORKSPACE_CACHE_INPUTS, ...LINT_ONLY_CACHE_INPUTS].sort(),
+    );
   });
 });

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -3,12 +3,14 @@ import { readFileSync } from "node:fs";
 
 import {
   ALL_WORKSPACE_CACHE_INPUTS,
+  ALL_WORKSPACE_TYPECHECK_CACHE_INPUTS,
   DEPENDENCY_CACHE_INPUTS,
   LINT_ONLY_CACHE_INPUTS,
   planCheck,
   PLUGIN_FIXTURE_INPUTS,
   PLUGIN_REGISTRY_INPUTS,
   ROOT_SCRIPT_LINT_INPUTS,
+  TYPECHECK_ONLY_CACHE_INPUTS,
   scopedCommands,
 } from "./code-check-affected";
 import { isChangedLintPath } from "./lint-paths";
@@ -18,6 +20,7 @@ const WORKSPACES = new Set([
   "apps/landing",
   "apps/web",
   "packages/errors",
+  "packages/scripts",
   "packages/typescript-config",
   "packages/ui",
 ]);
@@ -212,6 +215,22 @@ describe("affected code-check planning", () => {
     ]);
   });
 
+  test("the shared TypeScript runner invalidates only workspace typechecks", () => {
+    const planned = plan(
+      ["packages/scripts/src/tsc-native.ts"],
+      ["packages/scripts"],
+    );
+    expect(planned.type).toBe("scoped");
+    if (planned.type !== "scoped") {
+      throw new Error("Expected a scoped code-check plan");
+    }
+    expect(planned.lint).toEqual({
+      type: "targets",
+      targets: ["packages/scripts"],
+    });
+    expect(planned.typecheck).toEqual({ type: "all" });
+  });
+
   test("global dependency inputs use cacheable Turbo tasks", () => {
     const planned = plan(["bunfig.toml"], []);
     if (planned.type !== "scoped") {
@@ -308,6 +327,15 @@ describe("Turbo cache input contract", () => {
     }
   });
 
+  test("workspace typechecks cover every typecheck-only input", () => {
+    expect(TYPECHECK_ONLY_CACHE_INPUTS).toContain(
+      "$TURBO_ROOT$/packages/scripts/src/tsc-native.ts",
+    );
+    for (const input of TYPECHECK_ONLY_CACHE_INPUTS) {
+      expect(ALL_WORKSPACE_TYPECHECK_CACHE_INPUTS).toContain(input);
+    }
+  });
+
   test("keeps planner-wide inputs exactly aligned with their Turbo tasks", () => {
     const turboConfig = readFileSync("turbo.json", "utf-8");
     const typecheckStart = turboConfig.indexOf('    "typecheck":');
@@ -330,7 +358,7 @@ describe("Turbo cache input contract", () => {
         .sort();
 
     expect(rootInputs(typecheckConfig)).toEqual(
-      [...ALL_WORKSPACE_CACHE_INPUTS].sort(),
+      [...ALL_WORKSPACE_TYPECHECK_CACHE_INPUTS].sort(),
     );
     expect(rootInputs(lintConfig)).toEqual(
       [...ALL_WORKSPACE_CACHE_INPUTS, ...LINT_ONLY_CACHE_INPUTS].sort(),

--- a/scripts/code-check-affected.ts
+++ b/scripts/code-check-affected.ts
@@ -35,6 +35,13 @@ export const ALL_WORKSPACE_CACHE_INPUTS = [
   ...DEPENDENCY_CACHE_INPUTS,
   ...SHARED_COMPILER_CACHE_INPUTS,
 ] as const;
+export const TYPECHECK_ONLY_CACHE_INPUTS = [
+  "$TURBO_ROOT$/packages/scripts/src/tsc-native.ts",
+] as const;
+export const ALL_WORKSPACE_TYPECHECK_CACHE_INPUTS = [
+  ...ALL_WORKSPACE_CACHE_INPUTS,
+  ...TYPECHECK_ONLY_CACHE_INPUTS,
+] as const;
 export const LINT_ONLY_CACHE_INPUTS = [
   "$TURBO_ROOT$/oxlint.config.ts",
   "$TURBO_ROOT$/.oxlint-plugins/**",
@@ -125,6 +132,10 @@ const invalidatesAllWorkspaceChecks = (file: string): boolean =>
   file === TURBO_CONFIG_PATH ||
   ALL_WORKSPACE_CACHE_INPUTS.some((input) => matchesTurboInput(file, input));
 
+const invalidatesAllWorkspaceTypecheck = (file: string): boolean =>
+  invalidatesAllWorkspaceChecks(file) ||
+  TYPECHECK_ONLY_CACHE_INPUTS.some((input) => matchesTurboInput(file, input));
+
 const invalidatesRootScriptLint = (file: string): boolean =>
   ROOT_SCRIPT_LINT_INPUTS.some((input) => matchesTurboInput(file, input));
 
@@ -164,13 +175,16 @@ export const planCheck = ({
     }
     if (
       !workspacePaths.has(owner) ||
-      (!targetSet.has(owner) && !invalidatesAllWorkspaceChecks(changedPath))
+      (!targetSet.has(owner) && !invalidatesAllWorkspaceTypecheck(changedPath))
     ) {
       return { type: "fallback", changedPath };
     }
   }
 
   const allWorkspaceChecks = changedPaths.some(invalidatesAllWorkspaceChecks);
+  const allWorkspaceTypecheck = changedPaths.some(
+    invalidatesAllWorkspaceTypecheck,
+  );
   const allWorkspaceLint =
     allWorkspaceChecks ||
     changedPaths.some((changedPath) =>
@@ -195,7 +209,7 @@ export const planCheck = ({
   return {
     type: "scoped",
     lint: allWorkspaceLint ? { type: "all" } : { type: "targets", targets },
-    typecheck: allWorkspaceChecks
+    typecheck: allWorkspaceTypecheck
       ? { type: "all" }
       : { type: "targets", targets },
     rootLintPaths: [

--- a/scripts/code-check-affected.ts
+++ b/scripts/code-check-affected.ts
@@ -52,6 +52,7 @@ export const LINT_ONLY_CACHE_INPUTS = [
 ] as const;
 export const PLUGIN_FIXTURE_INPUTS = [
   ...DEPENDENCY_CACHE_INPUTS,
+  ...SHARED_COMPILER_CACHE_INPUTS,
   ...OXLINT_CONFIGURATION_CACHE_INPUTS,
   "$TURBO_ROOT$/scripts/lint-oxlint-fixtures.sh",
   "$TURBO_ROOT$/tsconfig.json",

--- a/scripts/code-check-affected.ts
+++ b/scripts/code-check-affected.ts
@@ -42,23 +42,27 @@ export const ALL_WORKSPACE_TYPECHECK_CACHE_INPUTS = [
   ...ALL_WORKSPACE_CACHE_INPUTS,
   ...TYPECHECK_ONLY_CACHE_INPUTS,
 ] as const;
-export const LINT_ONLY_CACHE_INPUTS = [
+const OXLINT_CONFIGURATION_CACHE_INPUTS = [
   "$TURBO_ROOT$/oxlint.config.ts",
   "$TURBO_ROOT$/.oxlint-plugins/**",
 ] as const;
+export const LINT_ONLY_CACHE_INPUTS = [
+  ...OXLINT_CONFIGURATION_CACHE_INPUTS,
+  "$TURBO_ROOT$/tsconfig.tooling.json",
+] as const;
 export const PLUGIN_FIXTURE_INPUTS = [
   ...DEPENDENCY_CACHE_INPUTS,
-  ...LINT_ONLY_CACHE_INPUTS,
+  ...OXLINT_CONFIGURATION_CACHE_INPUTS,
   "$TURBO_ROOT$/scripts/lint-oxlint-fixtures.sh",
   "$TURBO_ROOT$/tsconfig.oxlint-plugins.json",
 ] as const;
 export const PLUGIN_REGISTRY_INPUTS = [
-  ...LINT_ONLY_CACHE_INPUTS,
+  ...OXLINT_CONFIGURATION_CACHE_INPUTS,
   "$TURBO_ROOT$/scripts/check-oxlint-plugin-registry.ts",
 ] as const;
 export const ROOT_SCRIPT_LINT_INPUTS = [
   ...ALL_WORKSPACE_CACHE_INPUTS,
-  ...LINT_ONLY_CACHE_INPUTS,
+  ...OXLINT_CONFIGURATION_CACHE_INPUTS,
   "$TURBO_ROOT$/scripts/lint-root-scripts.sh",
   "$TURBO_ROOT$/scripts/tsconfig.json",
   "$TURBO_ROOT$/tsconfig.scripts.json",

--- a/scripts/code-check-affected.ts
+++ b/scripts/code-check-affected.ts
@@ -33,6 +33,13 @@ export const LINT_ONLY_CACHE_INPUTS = [
   "$TURBO_ROOT$/oxlint.config.ts",
   "$TURBO_ROOT$/.oxlint-plugins/**",
 ] as const;
+export const ROOT_SCRIPT_LINT_INPUTS = [
+  ...ALL_WORKSPACE_CACHE_INPUTS,
+  ...LINT_ONLY_CACHE_INPUTS,
+  "$TURBO_ROOT$/scripts/lint-root-scripts.sh",
+  "$TURBO_ROOT$/scripts/tsconfig.json",
+  "$TURBO_ROOT$/tsconfig.scripts.json",
+] as const;
 const TURBO_CONFIG_PATH = "turbo.json";
 const TURBO_ROOT_INPUT_PREFIX = "$TURBO_ROOT$/";
 const RECURSIVE_GLOB_SUFFIX = "/**";
@@ -102,35 +109,29 @@ const invalidatesAllWorkspaceChecks = (file: string): boolean =>
   file === TURBO_CONFIG_PATH ||
   ALL_WORKSPACE_CACHE_INPUTS.some((input) => matchesTurboInput(file, input));
 
+const invalidatesRootScriptLint = (file: string): boolean =>
+  ROOT_SCRIPT_LINT_INPUTS.some((input) => matchesTurboInput(file, input));
+
 const rootChecksForPath = (file: string): readonly RootCheck[] => {
+  const rootChecks: RootCheck[] = [];
   if (file === "package.json") {
-    return [
-      ROOT_CHECKS.pluginRegistry,
-      ROOT_CHECKS.pluginFixtures,
-      ROOT_CHECKS.rootScriptLint,
-    ];
-  }
-  if (file === "oxlint.config.ts" || file.startsWith(".oxlint-plugins/")) {
-    return [
-      ROOT_CHECKS.pluginRegistry,
-      ROOT_CHECKS.pluginFixtures,
-      ROOT_CHECKS.rootScriptLint,
-    ];
+    rootChecks.push(ROOT_CHECKS.pluginRegistry, ROOT_CHECKS.pluginFixtures);
+  } else if (
+    file === "oxlint.config.ts" ||
+    file.startsWith(".oxlint-plugins/")
+  ) {
+    rootChecks.push(ROOT_CHECKS.pluginRegistry, ROOT_CHECKS.pluginFixtures);
   }
   if (file === "scripts/lint-oxlint-fixtures.sh") {
-    return [ROOT_CHECKS.pluginFixtures];
-  }
-  if (
-    file === "scripts/lint-root-scripts.sh" ||
-    file === "scripts/tsconfig.json" ||
-    file === "tsconfig.scripts.json"
-  ) {
-    return [ROOT_CHECKS.rootScriptLint];
+    rootChecks.push(ROOT_CHECKS.pluginFixtures);
   }
   if (file === "tsconfig.oxlint-plugins.json") {
-    return [ROOT_CHECKS.pluginRegistry, ROOT_CHECKS.pluginFixtures];
+    rootChecks.push(ROOT_CHECKS.pluginRegistry, ROOT_CHECKS.pluginFixtures);
   }
-  return [];
+  if (invalidatesRootScriptLint(file)) {
+    rootChecks.push(ROOT_CHECKS.rootScriptLint);
+  }
+  return rootChecks;
 };
 
 export const planCheck = ({

--- a/scripts/code-check-affected.ts
+++ b/scripts/code-check-affected.ts
@@ -20,18 +20,34 @@ const REPO_ROOT = path.resolve(import.meta.dirname, "..");
 const DEFAULT_BASE = "origin/main";
 const WORKSPACE_PARENTS = ["apps", "packages"] as const;
 
-export const ALL_WORKSPACE_CACHE_INPUTS = [
+export const DEPENDENCY_CACHE_INPUTS = [
   "$TURBO_ROOT$/.npmrc",
   "$TURBO_ROOT$/bun.lock",
   "$TURBO_ROOT$/bunfig.toml",
   "$TURBO_ROOT$/package.json",
-  "$TURBO_ROOT$/packages/typescript-config/**",
   "$TURBO_ROOT$/patches/**",
+] as const;
+export const SHARED_COMPILER_CACHE_INPUTS = [
+  "$TURBO_ROOT$/packages/typescript-config/**",
   "$TURBO_ROOT$/types/**",
+] as const;
+export const ALL_WORKSPACE_CACHE_INPUTS = [
+  ...DEPENDENCY_CACHE_INPUTS,
+  ...SHARED_COMPILER_CACHE_INPUTS,
 ] as const;
 export const LINT_ONLY_CACHE_INPUTS = [
   "$TURBO_ROOT$/oxlint.config.ts",
   "$TURBO_ROOT$/.oxlint-plugins/**",
+] as const;
+export const PLUGIN_FIXTURE_INPUTS = [
+  ...DEPENDENCY_CACHE_INPUTS,
+  ...LINT_ONLY_CACHE_INPUTS,
+  "$TURBO_ROOT$/scripts/lint-oxlint-fixtures.sh",
+  "$TURBO_ROOT$/tsconfig.oxlint-plugins.json",
+] as const;
+export const PLUGIN_REGISTRY_INPUTS = [
+  ...LINT_ONLY_CACHE_INPUTS,
+  "$TURBO_ROOT$/scripts/check-oxlint-plugin-registry.ts",
 ] as const;
 export const ROOT_SCRIPT_LINT_INPUTS = [
   ...ALL_WORKSPACE_CACHE_INPUTS,
@@ -114,19 +130,11 @@ const invalidatesRootScriptLint = (file: string): boolean =>
 
 const rootChecksForPath = (file: string): readonly RootCheck[] => {
   const rootChecks: RootCheck[] = [];
-  if (file === "package.json") {
-    rootChecks.push(ROOT_CHECKS.pluginRegistry, ROOT_CHECKS.pluginFixtures);
-  } else if (
-    file === "oxlint.config.ts" ||
-    file.startsWith(".oxlint-plugins/")
-  ) {
-    rootChecks.push(ROOT_CHECKS.pluginRegistry, ROOT_CHECKS.pluginFixtures);
+  if (PLUGIN_REGISTRY_INPUTS.some((input) => matchesTurboInput(file, input))) {
+    rootChecks.push(ROOT_CHECKS.pluginRegistry);
   }
-  if (file === "scripts/lint-oxlint-fixtures.sh") {
+  if (PLUGIN_FIXTURE_INPUTS.some((input) => matchesTurboInput(file, input))) {
     rootChecks.push(ROOT_CHECKS.pluginFixtures);
-  }
-  if (file === "tsconfig.oxlint-plugins.json") {
-    rootChecks.push(ROOT_CHECKS.pluginRegistry, ROOT_CHECKS.pluginFixtures);
   }
   if (invalidatesRootScriptLint(file)) {
     rootChecks.push(ROOT_CHECKS.rootScriptLint);

--- a/scripts/code-check-affected.ts
+++ b/scripts/code-check-affected.ts
@@ -54,6 +54,7 @@ export const PLUGIN_FIXTURE_INPUTS = [
   ...DEPENDENCY_CACHE_INPUTS,
   ...OXLINT_CONFIGURATION_CACHE_INPUTS,
   "$TURBO_ROOT$/scripts/lint-oxlint-fixtures.sh",
+  "$TURBO_ROOT$/tsconfig.json",
   "$TURBO_ROOT$/tsconfig.oxlint-plugins.json",
 ] as const;
 export const PLUGIN_REGISTRY_INPUTS = [

--- a/scripts/code-check-affected.ts
+++ b/scripts/code-check-affected.ts
@@ -2,11 +2,13 @@
 
 // Fast local code-quality gate.
 //
-// CI keeps the full repository-wide `code-check`. Pre-push uses this wrapper
-// to ask Turbo for changed workspaces plus reverse dependants, then caches each
-// workspace's complete lint and typecheck independently with bounded
-// concurrency. Root scripts sit outside Turbo, so only changed root sources are
-// linted directly. Global inputs conservatively fall back to the full check.
+// Pre-push and pull-request CI use this wrapper to ask Turbo for changed
+// workspaces plus reverse dependants. Known global inputs widen only the check
+// family they can affect, preserving independent lint and typecheck cache hits.
+// Root scripts sit outside workspace tasks, so changed root sources are linted
+// directly and root TypeScript projects run through a cacheable Turbo root task.
+// Inconsistent affected-workspace output still fails safe to the monolithic
+// repository check.
 
 import { panic } from "better-result";
 import { existsSync, readdirSync } from "node:fs";
@@ -18,38 +20,50 @@ const REPO_ROOT = path.resolve(import.meta.dirname, "..");
 const DEFAULT_BASE = "origin/main";
 const WORKSPACE_PARENTS = ["apps", "packages"] as const;
 
-const FULL_CHECK_FILES = new Set([
-  ".npmrc",
-  "bun.lock",
-  "bunfig.toml",
-  "oxlint.config.ts",
-  "package.json",
-  "scripts/code-check-affected.ts",
-  "scripts/lint-paths.ts",
-  "scripts/lint-oxlint-fixtures.sh",
-  "scripts/lint-root-scripts.sh",
-  "scripts/tsconfig.json",
-  "turbo.json",
-  "tsconfig.json",
-  "tsconfig.oxlint-plugins.json",
-  "tsconfig.scripts.json",
-  "tsconfig.tooling.json",
-]);
-
-const FULL_CHECK_PREFIXES = [
-  ".oxlint-plugins/",
-  "packages/typescript-config/",
-  "patches/",
-  "types/",
+export const ALL_WORKSPACE_CACHE_INPUTS = [
+  "$TURBO_ROOT$/.npmrc",
+  "$TURBO_ROOT$/bun.lock",
+  "$TURBO_ROOT$/bunfig.toml",
+  "$TURBO_ROOT$/package.json",
+  "$TURBO_ROOT$/packages/typescript-config/**",
+  "$TURBO_ROOT$/patches/**",
+  "$TURBO_ROOT$/types/**",
 ] as const;
+export const LINT_ONLY_CACHE_INPUTS = [
+  "$TURBO_ROOT$/oxlint.config.ts",
+  "$TURBO_ROOT$/.oxlint-plugins/**",
+] as const;
+const TURBO_CONFIG_PATH = "turbo.json";
+const TURBO_ROOT_INPUT_PREFIX = "$TURBO_ROOT$/";
+const RECURSIVE_GLOB_SUFFIX = "/**";
 
-type CheckPlan =
-  | { type: "full"; changedPath: string }
-  | {
-      type: "affected";
-      targets: string[];
-      rootLintPaths: string[];
-    };
+const ROOT_CHECKS = {
+  env: "env",
+  pluginFixtures: "plugin-fixtures",
+  pluginRegistry: "plugin-registry",
+  repoTypecheck: "repo-typecheck",
+  rootScriptLint: "root-script-lint",
+} as const;
+type RootCheck = (typeof ROOT_CHECKS)[keyof typeof ROOT_CHECKS];
+const ROOT_CHECK_ORDER: readonly RootCheck[] = [
+  ROOT_CHECKS.env,
+  ROOT_CHECKS.pluginRegistry,
+  ROOT_CHECKS.pluginFixtures,
+  ROOT_CHECKS.rootScriptLint,
+  ROOT_CHECKS.repoTypecheck,
+];
+
+type TaskScope = { type: "all" } | { type: "targets"; targets: string[] };
+
+type ScopedCheckPlan = {
+  type: "scoped";
+  lint: TaskScope;
+  typecheck: TaskScope;
+  rootLintPaths: string[];
+  rootChecks: RootCheck[];
+};
+
+type CheckPlan = { type: "fallback"; changedPath: string } | ScopedCheckPlan;
 
 type PlanCheckOptions = {
   changedPaths: readonly string[];
@@ -72,9 +86,52 @@ const workspaceForPath = (file: string): string | null => {
   return `${parent}/${name}`;
 };
 
-const requiresFullCheck = (file: string): boolean =>
-  FULL_CHECK_FILES.has(file) ||
-  FULL_CHECK_PREFIXES.some((prefix) => file.startsWith(prefix));
+const matchesTurboInput = (file: string, input: string): boolean => {
+  if (!input.startsWith(TURBO_ROOT_INPUT_PREFIX)) {
+    return false;
+  }
+  const relativeInput = input.slice(TURBO_ROOT_INPUT_PREFIX.length);
+  if (!relativeInput.endsWith(RECURSIVE_GLOB_SUFFIX)) {
+    return file === relativeInput;
+  }
+  const directory = relativeInput.slice(0, -RECURSIVE_GLOB_SUFFIX.length);
+  return file.startsWith(`${directory}/`);
+};
+
+const invalidatesAllWorkspaceChecks = (file: string): boolean =>
+  file === TURBO_CONFIG_PATH ||
+  ALL_WORKSPACE_CACHE_INPUTS.some((input) => matchesTurboInput(file, input));
+
+const rootChecksForPath = (file: string): readonly RootCheck[] => {
+  if (file === "package.json") {
+    return [
+      ROOT_CHECKS.pluginRegistry,
+      ROOT_CHECKS.pluginFixtures,
+      ROOT_CHECKS.rootScriptLint,
+    ];
+  }
+  if (file === "oxlint.config.ts" || file.startsWith(".oxlint-plugins/")) {
+    return [
+      ROOT_CHECKS.pluginRegistry,
+      ROOT_CHECKS.pluginFixtures,
+      ROOT_CHECKS.rootScriptLint,
+    ];
+  }
+  if (file === "scripts/lint-oxlint-fixtures.sh") {
+    return [ROOT_CHECKS.pluginFixtures];
+  }
+  if (
+    file === "scripts/lint-root-scripts.sh" ||
+    file === "scripts/tsconfig.json" ||
+    file === "tsconfig.scripts.json"
+  ) {
+    return [ROOT_CHECKS.rootScriptLint];
+  }
+  if (file === "tsconfig.oxlint-plugins.json") {
+    return [ROOT_CHECKS.pluginRegistry, ROOT_CHECKS.pluginFixtures];
+  }
+  return [];
+};
 
 export const planCheck = ({
   changedPaths,
@@ -82,15 +139,12 @@ export const planCheck = ({
   affectedWorkspacePaths,
   workspacePaths,
 }: PlanCheckOptions): CheckPlan => {
-  for (const changedPath of changedPaths) {
-    if (requiresFullCheck(changedPath)) {
-      return { type: "full", changedPath };
-    }
-  }
-
   const targets = [...new Set(affectedWorkspacePaths)].sort();
   if (targets.some((target) => !workspacePaths.has(target))) {
-    return { type: "full", changedPath: "invalid Turbo workspace output" };
+    return {
+      type: "fallback",
+      changedPath: "invalid Turbo workspace output",
+    };
   }
 
   const targetSet = new Set(targets);
@@ -99,23 +153,53 @@ export const planCheck = ({
     if (owner === null) {
       continue;
     }
-    if (!workspacePaths.has(owner) || !targetSet.has(owner)) {
-      return { type: "full", changedPath };
+    if (
+      !workspacePaths.has(owner) ||
+      (!targetSet.has(owner) && !invalidatesAllWorkspaceChecks(changedPath))
+    ) {
+      return { type: "fallback", changedPath };
     }
   }
 
+  const allWorkspaceChecks = changedPaths.some(invalidatesAllWorkspaceChecks);
+  const allWorkspaceLint =
+    allWorkspaceChecks ||
+    changedPaths.some((changedPath) =>
+      LINT_ONLY_CACHE_INPUTS.some((input) =>
+        matchesTurboInput(changedPath, input),
+      ),
+    );
+  const rootCheckSet = new Set<RootCheck>([
+    ROOT_CHECKS.env,
+    ROOT_CHECKS.repoTypecheck,
+  ]);
+  for (const changedPath of changedPaths) {
+    for (const rootCheck of rootChecksForPath(changedPath)) {
+      rootCheckSet.add(rootCheck);
+    }
+  }
+  const rootChecks = ROOT_CHECK_ORDER.filter((rootCheck) =>
+    rootCheckSet.has(rootCheck),
+  );
+  const rootScriptLintRuns = rootCheckSet.has(ROOT_CHECKS.rootScriptLint);
+
   return {
-    type: "affected",
-    targets,
+    type: "scoped",
+    lint: allWorkspaceLint ? { type: "all" } : { type: "targets", targets },
+    typecheck: allWorkspaceChecks
+      ? { type: "all" }
+      : { type: "targets", targets },
     rootLintPaths: [
       ...new Set(
         presentChangedPaths.filter(
           (changedPath) =>
             workspaceForPath(changedPath) === null &&
-            isChangedLintPath(changedPath),
+            isChangedLintPath(changedPath) &&
+            !(rootScriptLintRuns && changedPath.startsWith("scripts/")),
         ),
       ),
     ].sort(),
+    rootChecks,
   };
 };
 
@@ -238,10 +322,49 @@ const affectedWorkspacePaths = (mergeBase: string): string[] => {
   });
 };
 
-export const affectedCommands = (
-  plan: Extract<CheckPlan, { type: "affected" }>,
-) => {
-  const commands: string[][] = [["bun", "run", "env:check"]];
+const turboCommand = (tasks: readonly string[], scope: TaskScope): string[] => [
+  "bun",
+  "--bun",
+  "turbo",
+  "run",
+  ...tasks,
+  "--concurrency=2",
+  ...(scope.type === "all"
+    ? []
+    : scope.targets.map((target) => `--filter=./${target}`)),
+];
+
+const sameScope = (left: TaskScope, right: TaskScope): boolean => {
+  if (left.type !== right.type) {
+    return false;
+  }
+  if (left.type === "all" || right.type === "all") {
+    return true;
+  }
+  return (
+    left.targets.length === right.targets.length &&
+    left.targets.every((target, index) => target === right.targets[index])
+  );
+};
+
+const hasTargets = (scope: TaskScope): boolean =>
+  scope.type === "all" || scope.targets.length > 0;
+
+export const scopedCommands = (plan: ScopedCheckPlan): string[][] => {
+  const commands: string[][] = [];
+  const rootChecks = new Set(plan.rootChecks);
+  if (rootChecks.has(ROOT_CHECKS.env)) {
+    commands.push(["bun", "run", "env:check"]);
+  }
+  if (rootChecks.has(ROOT_CHECKS.pluginRegistry)) {
+    commands.push(["bun", "scripts/check-oxlint-plugin-registry.ts"]);
+  }
+  if (rootChecks.has(ROOT_CHECKS.pluginFixtures)) {
+    commands.push(["bash", "scripts/lint-oxlint-fixtures.sh"]);
+  }
+  if (rootChecks.has(ROOT_CHECKS.rootScriptLint)) {
+    commands.push(["bash", "scripts/lint-root-scripts.sh"]);
+  }
   if (plan.rootLintPaths.length > 0) {
     commands.push([
       "bun",
@@ -255,19 +378,28 @@ export const affectedCommands = (
       ...plan.rootLintPaths,
     ]);
   }
-  if (plan.targets.length > 0) {
+  const lintRuns = hasTargets(plan.lint);
+  const typecheckRuns = hasTargets(plan.typecheck);
+  if (lintRuns && typecheckRuns && sameScope(plan.lint, plan.typecheck)) {
+    commands.push(turboCommand(["lint", "typecheck"], plan.lint));
+  } else {
+    if (lintRuns) {
+      commands.push(turboCommand(["lint"], plan.lint));
+    }
+    if (typecheckRuns) {
+      commands.push(turboCommand(["typecheck"], plan.typecheck));
+    }
+  }
+  if (rootChecks.has(ROOT_CHECKS.repoTypecheck)) {
     commands.push([
       "bun",
       "--bun",
       "turbo",
       "run",
-      "lint",
-      "typecheck",
+      "typecheck:repo",
       "--concurrency=2",
-      ...plan.targets.map((target) => `--filter=./${target}`),
     ]);
   }
-  commands.push(["bun", "run", "typecheck:repo"]);
   return commands;
 };
 
@@ -283,7 +415,7 @@ const main = () => {
     workspacePaths: workspacePaths(),
   });
 
-  if (plan.type === "full") {
+  if (plan.type === "fallback") {
     process.stdout.write(
       `code-check: full repository (${plan.changedPath} requires fallback)\n`,
     );
@@ -293,10 +425,19 @@ const main = () => {
     return;
   }
 
-  const targetLabel =
-    plan.targets.length === 0 ? "root projects only" : plan.targets.join(", ");
-  process.stdout.write(`code-check: affected ${targetLabel}\n`);
-  const commands = affectedCommands(plan);
+  const scopeLabel = (scope: TaskScope): string => {
+    if (scope.type === "all") {
+      return "all";
+    }
+    if (scope.targets.length === 0) {
+      return "none";
+    }
+    return scope.targets.join(", ");
+  };
+  process.stdout.write(
+    `code-check: lint ${scopeLabel(plan.lint)}; typecheck ${scopeLabel(plan.typecheck)}\n`,
+  );
+  const commands = scopedCommands(plan);
   if (options.dryRun) {
     for (const command of commands) {
       process.stdout.write(`  ${command.join(" ")}\n`);

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -333,7 +333,11 @@ describe("detect-e2e-changes", () => {
   });
 
   test("keeps full code quality for manual sweeps and scopes pull requests", () => {
+    const plan = workflowJob("ci-plan");
     const codeQuality = workflowJob("code-quality");
+    expect(plan).toContain(
+      ".github/workflows/ci.yml)\n                # This workflow owns package-check scheduling and the\n                # code-quality job itself, so its changes must exercise both.\n                package_checks_required=true",
+    );
     expect(codeQuality).toContain(
       `EVENT_NAME: ${githubExpression("github.event_name")}`,
     );

--- a/turbo.json
+++ b/turbo.json
@@ -81,6 +81,7 @@
         "$TURBO_ROOT$/.oxlint-plugins/**",
         "$TURBO_ROOT$/packages/typescript-config/**",
         "$TURBO_ROOT$/patches/**",
+        "$TURBO_ROOT$/tsconfig.tooling.json",
         "$TURBO_ROOT$/types/**"
       ]
     },

--- a/turbo.json
+++ b/turbo.json
@@ -25,7 +25,42 @@
     },
     "typecheck": {
       "dependsOn": ["transit"],
+      // These files live outside each workspace but can change dependency
+      // resolution or the shared compiler program. Hash them explicitly so a
+      // linked worktree never restores a stale lint or TypeScript result.
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/.npmrc",
+        "$TURBO_ROOT$/bunfig.toml",
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/bun.lock",
+        "$TURBO_ROOT$/packages/typescript-config/**",
+        "$TURBO_ROOT$/patches/**",
+        "$TURBO_ROOT$/types/**"
+      ],
       "outputs": [".cache/tsbuildinfo*.json", "**/.cache/tsbuildinfo*.json"]
+    },
+    "//#typecheck:repo": {
+      // Root projects can import workspace source. The broad workspace inputs
+      // trade some misses for correctness while still sharing exact results
+      // and compiler state between linked worktrees and CI runners.
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/.claude/mcp/**",
+        "$TURBO_ROOT$/.npmrc",
+        "$TURBO_ROOT$/.oxlint-plugins/**",
+        "$TURBO_ROOT$/apps/**",
+        "$TURBO_ROOT$/bunfig.toml",
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/bun.lock",
+        "$TURBO_ROOT$/packages/**",
+        "$TURBO_ROOT$/patches/**",
+        "$TURBO_ROOT$/scripts/**",
+        "$TURBO_ROOT$/types/**",
+        "$TURBO_ROOT$/oxlint.config.ts",
+        "$TURBO_ROOT$/tsconfig*.json"
+      ],
+      "outputs": [".cache/tsbuildinfo*.json"]
     },
     "@stll/landing#typecheck": {
       "dependsOn": ["transit"],
@@ -33,10 +68,19 @@
     },
     "lint": {
       "dependsOn": ["transit"],
+      // Type-aware lint reads the same external install and compiler inputs as
+      // TypeScript, in addition to Oxlint's root config and plugins.
       "inputs": [
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/.npmrc",
+        "$TURBO_ROOT$/bunfig.toml",
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/bun.lock",
         "$TURBO_ROOT$/oxlint.config.ts",
-        "$TURBO_ROOT$/.oxlint-plugins/**"
+        "$TURBO_ROOT$/.oxlint-plugins/**",
+        "$TURBO_ROOT$/packages/typescript-config/**",
+        "$TURBO_ROOT$/patches/**",
+        "$TURBO_ROOT$/types/**"
       ]
     },
     "lint:fix": {

--- a/turbo.json
+++ b/turbo.json
@@ -34,6 +34,7 @@
         "$TURBO_ROOT$/bunfig.toml",
         "$TURBO_ROOT$/package.json",
         "$TURBO_ROOT$/bun.lock",
+        "$TURBO_ROOT$/packages/scripts/src/tsc-native.ts",
         "$TURBO_ROOT$/packages/typescript-config/**",
         "$TURBO_ROOT$/patches/**",
         "$TURBO_ROOT$/types/**"


### PR DESCRIPTION
## Summary

- split affected code checks into independent lint, workspace typecheck, and root-check scopes
- declare repository inputs in Turbo so hash-matched results and TypeScript build state are safe to share across linked worktrees
- restore the Turbo artifact cache in the trusted code-quality CI job
- keep the monolithic full check as a fail-safe for invalid affected-workspace output

## Rationale

Known repository-wide inputs previously sent pre-push and pull-request checks through the monolithic code-quality command. That bypassed Turbo task caching, so another linked worktree could not reuse a valid lint or typecheck result.

The new planner widens only the affected check family. Dependency and compiler inputs run all workspace tasks through Turbo; Oxlint-only inputs invalidate lint without discarding typecheck hits. Root TypeScript projects run as a conservative Turbo root task because they can import workspace source. Explicit task inputs prevent stale artifacts, and an exact two-way contract test keeps the planner and Turbo configuration aligned.

This primarily improves repeated checks: a cold run still performs the required work, while matching worktrees and CI runners restore task results and incremental compiler outputs. In a local sample, the root TypeScript task fell from 5.6 seconds cold to 2.1 seconds from the shared worktree cache.

## Validation

- 36 planner and cache-contract tests pass
- scripts TypeScript compilation passes
- strict type-aware Oxlint passes
- mutation check proves lint-only changes do not widen typecheck scope
- formatting and diff integrity checks pass

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added remote caching to code-quality checks, helping CI complete faster.
  * Improved cache tracking for linting and repository-wide type checks to keep results accurate.

* **Bug Fixes**
  * Affected checks now independently identify required linting, type checking and root-level checks.
  * Added safer fallback handling when affected workspace information is incomplete or invalid.
  * Workflow changes now correctly trigger the relevant package checks.

* **Tests**
  * Expanded coverage for affected-check planning, cache inputs and scoped command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->