### PR TITLE
feat(ui): add generic data table renderer

### DIFF
--- a/.changeset/tidy-tables-render.md
+++ b/.changeset/tidy-tables-render.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": minor
+---
+
+Add an entity-agnostic data-table renderer with empty, loading, and accessible row-action states.

--- a/packages/ui/src/data-table/index.ts
+++ b/packages/ui/src/data-table/index.ts
@@ -20,3 +20,10 @@ export {
   tableColumnSizing,
   visibleColumnIds,
 } from "./schema";
+export { DataTable } from "./table";
+export type {
+  DataTableAriaSort,
+  DataTableColumn,
+  DataTableProps,
+  DataTableRowAction,
+} from "./table";

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -2,7 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { describe, expect, test } from "bun:test";
 
-import { DataTable } from "./table";
+import { DataTable, isDataTableRowActionTarget } from "./table";
 
 const columns = [
   {
@@ -19,12 +19,7 @@ describe("DataTable", () => {
       <DataTable
         columns={columns}
         emptyLabel="No matters"
-        getRowProps={() => ({
-          "aria-label": "Caller label",
-          className: "caller-row",
-          role: "row",
-          tabIndex: -1,
-        })}
+        getRowProps={() => ({ className: "caller-row" })}
         loadingLabel="Loading"
         rowAction={{
           getAriaLabel: (row) => `Open ${row.name}`,
@@ -36,11 +31,11 @@ describe("DataTable", () => {
     );
 
     expect(markup).toContain('aria-sort="ascending"');
-    expect(markup).toContain('aria-label="Open Northwind"');
-    expect(markup).toContain('role="button"');
-    expect(markup).toContain('tabindex="0"');
+    expect(markup).toContain('<button class="sr-only" type="button">');
+    expect(markup).toContain("Open Northwind</button>");
     expect(markup).toContain("caller-row");
-    expect(markup).not.toContain("Caller label");
+    expect(markup).not.toContain('role="button"');
+    expect(markup).not.toContain('tabindex="0"');
     expect(markup).toContain("Northwind");
   });
 
@@ -70,4 +65,34 @@ describe("DataTable", () => {
     expect(loading).toContain("Loading");
     expect(loading).not.toContain("No matters");
   });
+
+  test("row selection ignores every nested interactive target", () => {
+    const row = new EventTarget();
+    const cell = new ClosestTarget(null);
+    const nestedControl = new ClosestTarget({});
+
+    expect(isDataTableRowActionTarget(row, row)).toBe(true);
+    expect(isDataTableRowActionTarget(row, cell)).toBe(true);
+    expect(isDataTableRowActionTarget(row, nestedControl)).toBe(false);
+    expect(nestedControl.seenSelector).toContain("button");
+    expect(nestedControl.seenSelector).toContain(
+      "[data-data-table-stop-row-action]",
+    );
+  });
 });
+
+class ClosestTarget extends EventTarget {
+  private readonly match: unknown;
+
+  seenSelector = "";
+
+  constructor(match: unknown) {
+    super();
+    this.match = match;
+  }
+
+  closest(selector: string) {
+    this.seenSelector = selector;
+    return this.match;
+  }
+}

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -73,6 +73,7 @@ describe("DataTable", () => {
     expect(empty).toContain('colSpan="1"');
     expect(empty).toContain("No matters");
     expect(loading).toContain('aria-busy="true"');
+    expect(loading).toContain('role="status"');
     expect(loading).toContain("Loading");
     expect(loading.match(/data-slot="skeleton"/gu)).toHaveLength(4);
     expect(loading).not.toContain("colSpan");

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -75,10 +75,14 @@ describe("DataTable", () => {
     expect(empty).toContain("No matters");
     expect(loading).toContain('aria-busy="true"');
     expect(loading).toContain('role="status"');
+    expect(loading.indexOf('role="status"')).toBeLessThan(
+      loading.indexOf('data-slot="table"'),
+    );
     expect(loading).toContain("Loading");
     expect(loading.match(/data-slot="skeleton"/gu)).toHaveLength(4);
     expect(loading).not.toContain("colSpan");
     expect(loading).not.toContain("No matters");
+    expect(empty).toContain('role="status"');
   });
 
   test("keeps at least one loading row after rounding", () => {

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -33,6 +33,7 @@ describe("DataTable", () => {
     expect(markup).toContain('aria-sort="ascending"');
     expect(markup).toContain("focus-visible:not-sr-only");
     expect(markup).toContain("focus-visible:ring-2");
+    expect(markup).toContain('data-slot="button"');
     expect(markup).toContain("Open Northwind</button>");
     expect(markup).toContain("caller-row");
     expect(markup).not.toContain('role="button"');
@@ -76,6 +77,23 @@ describe("DataTable", () => {
     expect(loading.match(/data-slot="skeleton"/gu)).toHaveLength(4);
     expect(loading).not.toContain("colSpan");
     expect(loading).not.toContain("No matters");
+  });
+
+  test("keeps at least one loading row after rounding", () => {
+    const loading = renderToStaticMarkup(
+      <DataTable
+        columns={columns}
+        emptyLabel="No matters"
+        isLoading
+        loadingLabel="Loading"
+        loadingRowCount={0.5}
+        rowKey={(row: { id: string }) => row.id}
+        rows={[]}
+      />,
+    );
+
+    expect(loading.match(/data-slot="skeleton"/gu)).toHaveLength(1);
+    expect(loading).toContain("Loading");
   });
 
   test("row selection ignores every nested interactive target", () => {

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -96,6 +96,16 @@ describe("DataTable", () => {
     expect(loading).toContain("Loading");
   });
 
+  test("bounds invalid and extreme loading row counts", () => {
+    for (const rowCount of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const loading = renderLoadingTable(rowCount);
+      expect(loading.match(/data-slot="skeleton"/gu)).toHaveLength(3);
+    }
+
+    const extreme = renderLoadingTable(10_000);
+    expect(extreme.match(/data-slot="skeleton"/gu)).toHaveLength(20);
+  });
+
   test("row selection ignores every nested interactive target", () => {
     const cell = new ClosestTarget("[role='presentation']");
     const row = new ContainmentTarget([cell]);
@@ -128,6 +138,19 @@ describe("DataTable", () => {
     expect(isDataTableRowActionTarget(row, portaledPopup)).toBe(false);
   });
 });
+
+const renderLoadingTable = (loadingRowCount: number) =>
+  renderToStaticMarkup(
+    <DataTable
+      columns={columns}
+      emptyLabel="No matters"
+      isLoading
+      loadingLabel="Loading"
+      loadingRowCount={loadingRowCount}
+      rowKey={(row: { id: string }) => row.id}
+      rows={[]}
+    />,
+  );
 
 class ContainmentTarget extends EventTarget {
   private readonly targets: Set<EventTarget>;

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -40,7 +40,7 @@ describe("DataTable", () => {
     expect(markup).toContain("Northwind");
   });
 
-  test("renders one spanning empty or loading row", () => {
+  test("renders a spanning empty row and column-aligned loading skeletons", () => {
     const empty = renderToStaticMarkup(
       <DataTable
         columns={columns}
@@ -52,10 +52,18 @@ describe("DataTable", () => {
     );
     const loading = renderToStaticMarkup(
       <DataTable
-        columns={columns}
+        columns={[
+          ...columns,
+          {
+            header: "Status",
+            id: "status",
+            render: () => "Open",
+          },
+        ]}
         emptyLabel="No matters"
         isLoading
         loadingLabel="Loading"
+        loadingRowCount={2}
         rowKey={(row: { id: string }) => row.id}
         rows={[]}
       />,
@@ -63,7 +71,10 @@ describe("DataTable", () => {
 
     expect(empty).toContain('colSpan="1"');
     expect(empty).toContain("No matters");
+    expect(loading).toContain('aria-busy="true"');
     expect(loading).toContain("Loading");
+    expect(loading.match(/data-slot="skeleton"/gu)).toHaveLength(4);
+    expect(loading).not.toContain("colSpan");
     expect(loading).not.toContain("No matters");
   });
 

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -116,6 +116,7 @@ describe("DataTable", () => {
     const cell = new ClosestTarget("[role='presentation']");
     const row = new ContainmentTarget([cell]);
     const interactiveSelectors = [
+      "audio[controls]",
       "button",
       "label",
       "[contenteditable]:not([contenteditable='false'])",
@@ -126,6 +127,7 @@ describe("DataTable", () => {
       "[role='switch']",
       "[role='tab']",
       "[data-data-table-stop-row-action]",
+      "video[controls]",
     ];
 
     expect(isDataTableRowActionTarget(row, row)).toBe(true);

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -68,8 +68,8 @@ describe("DataTable", () => {
   });
 
   test("row selection ignores every nested interactive target", () => {
-    const row = new EventTarget();
     const cell = new ClosestTarget("[role='presentation']");
+    const row = new ContainmentTarget([cell]);
     const interactiveSelectors = [
       "button",
       "label",
@@ -86,12 +86,36 @@ describe("DataTable", () => {
     expect(isDataTableRowActionTarget(row, row)).toBe(true);
     expect(isDataTableRowActionTarget(row, cell)).toBe(true);
     for (const selector of interactiveSelectors) {
-      expect(isDataTableRowActionTarget(row, new ClosestTarget(selector))).toBe(
-        false,
-      );
+      const target = new ClosestTarget(selector);
+      row.add(target);
+      expect(isDataTableRowActionTarget(row, target)).toBe(false);
     }
   });
+
+  test("row selection ignores React-bubbled targets outside the row", () => {
+    const row = new ContainmentTarget([]);
+    const portaledPopup = new ClosestTarget("[role='presentation']");
+
+    expect(isDataTableRowActionTarget(row, portaledPopup)).toBe(false);
+  });
 });
+
+class ContainmentTarget extends EventTarget {
+  private readonly targets: Set<EventTarget>;
+
+  constructor(targets: readonly EventTarget[]) {
+    super();
+    this.targets = new Set(targets);
+  }
+
+  add(target: EventTarget) {
+    this.targets.add(target);
+  }
+
+  contains(target: EventTarget | null) {
+    return target !== null && this.targets.has(target);
+  }
+}
 
 class ClosestTarget extends EventTarget {
   private readonly matchingSelector: string;

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -73,6 +73,7 @@ describe("DataTable", () => {
     const interactiveSelectors = [
       "button",
       "label",
+      "[contenteditable]:not([contenteditable='false'])",
       "[role='checkbox']",
       "[role='combobox']",
       "[role='menuitem']",

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -33,6 +33,7 @@ describe("DataTable", () => {
     expect(markup).toContain('aria-sort="ascending"');
     expect(markup).toContain("focus-visible:not-sr-only");
     expect(markup).toContain("focus-visible:ring-2");
+    expect(markup).toContain("pointer-coarse:h-11");
     expect(markup).toContain('data-slot="button"');
     expect(markup).toContain("Open Northwind</button>");
     expect(markup).toContain("caller-row");

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -1,0 +1,73 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import { DataTable } from "./table";
+
+const columns = [
+  {
+    ariaSort: "ascending",
+    header: "Matter",
+    id: "name",
+    render: (row: { id: string; name: string }) => row.name,
+  },
+] as const;
+
+describe("DataTable", () => {
+  test("renders entity-agnostic columns and accessible row actions", () => {
+    const markup = renderToStaticMarkup(
+      <DataTable
+        columns={columns}
+        emptyLabel="No matters"
+        getRowProps={() => ({
+          "aria-label": "Caller label",
+          className: "caller-row",
+          role: "row",
+          tabIndex: -1,
+        })}
+        loadingLabel="Loading"
+        rowAction={{
+          getAriaLabel: (row) => `Open ${row.name}`,
+          onSelect: () => undefined,
+        }}
+        rowKey={(row) => row.id}
+        rows={[{ id: "matter-1", name: "Northwind" }]}
+      />,
+    );
+
+    expect(markup).toContain('aria-sort="ascending"');
+    expect(markup).toContain('aria-label="Open Northwind"');
+    expect(markup).toContain('role="button"');
+    expect(markup).toContain('tabindex="0"');
+    expect(markup).toContain("caller-row");
+    expect(markup).not.toContain("Caller label");
+    expect(markup).toContain("Northwind");
+  });
+
+  test("renders one spanning empty or loading row", () => {
+    const empty = renderToStaticMarkup(
+      <DataTable
+        columns={columns}
+        emptyLabel="No matters"
+        loadingLabel="Loading"
+        rowKey={(row: { id: string }) => row.id}
+        rows={[]}
+      />,
+    );
+    const loading = renderToStaticMarkup(
+      <DataTable
+        columns={columns}
+        emptyLabel="No matters"
+        isLoading
+        loadingLabel="Loading"
+        rowKey={(row: { id: string }) => row.id}
+        rows={[]}
+      />,
+    );
+
+    expect(empty).toContain('colSpan="1"');
+    expect(empty).toContain("No matters");
+    expect(loading).toContain("Loading");
+    expect(loading).not.toContain("No matters");
+  });
+});

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -2,7 +2,43 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { describe, expect, test } from "bun:test";
 
-import { DataTable, isDataTableRowActionTarget } from "./table";
+import {
+  DATA_TABLE_INTERACTIVE_DESCENDANT_SELECTORS,
+  DataTable,
+  isDataTableRowActionTarget,
+} from "./table";
+
+const expectedInteractiveDescendantSelectors = [
+  "a[href]",
+  "audio[controls]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "video[controls]",
+  "summary",
+  "label",
+  "[contenteditable]:not([contenteditable='false'])",
+  "[role='button']",
+  "[role='checkbox']",
+  "[role='combobox']",
+  "[role='link']",
+  "[role='listbox']",
+  "[role='menuitem']",
+  "[role='menuitemcheckbox']",
+  "[role='menuitemradio']",
+  "[role='option']",
+  "[role='radio']",
+  "[role='searchbox']",
+  "[role='slider']",
+  "[role='spinbutton']",
+  "[role='switch']",
+  "[role='tab']",
+  "[role='textbox']",
+  "[role='treeitem']",
+  "[tabindex]:not([tabindex='-1'])",
+  "[data-data-table-stop-row-action]",
+] as const;
 
 const columns = [
   {
@@ -57,6 +93,7 @@ describe("DataTable", () => {
         columns={[
           ...columns,
           {
+            cellClassName: "text-right",
             header: "Status",
             id: "status",
             render: () => "Open",
@@ -79,6 +116,7 @@ describe("DataTable", () => {
       loading.indexOf('data-slot="table"'),
     );
     expect(loading).toContain("Loading");
+    expect(loading).toContain("text-right");
     expect(loading.match(/data-slot="skeleton"/gu)).toHaveLength(4);
     expect(loading).not.toContain("colSpan");
     expect(loading).not.toContain("No matters");
@@ -115,24 +153,14 @@ describe("DataTable", () => {
   test("row selection ignores every nested interactive target", () => {
     const cell = new ClosestTarget("[role='presentation']");
     const row = new ContainmentTarget([cell]);
-    const interactiveSelectors = [
-      "audio[controls]",
-      "button",
-      "label",
-      "[contenteditable]:not([contenteditable='false'])",
-      "[role='checkbox']",
-      "[role='combobox']",
-      "[role='menuitem']",
-      "[role='radio']",
-      "[role='switch']",
-      "[role='tab']",
-      "[data-data-table-stop-row-action]",
-      "video[controls]",
-    ];
+
+    expect(DATA_TABLE_INTERACTIVE_DESCENDANT_SELECTORS).toEqual(
+      expectedInteractiveDescendantSelectors,
+    );
 
     expect(isDataTableRowActionTarget(row, row)).toBe(true);
     expect(isDataTableRowActionTarget(row, cell)).toBe(true);
-    for (const selector of interactiveSelectors) {
+    for (const selector of expectedInteractiveDescendantSelectors) {
       const target = new ClosestTarget(selector);
       row.add(target);
       expect(isDataTableRowActionTarget(row, target)).toBe(false);
@@ -189,6 +217,6 @@ class ClosestTarget extends EventTarget {
 
   closest(selector: string) {
     this.seenSelector = selector;
-    return selector.includes(this.matchingSelector) ? {} : null;
+    return selector.split(",").includes(this.matchingSelector) ? {} : null;
   }
 }

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -31,7 +31,8 @@ describe("DataTable", () => {
     );
 
     expect(markup).toContain('aria-sort="ascending"');
-    expect(markup).toContain('<button class="sr-only" type="button">');
+    expect(markup).toContain("focus-visible:not-sr-only");
+    expect(markup).toContain("focus-visible:ring-2");
     expect(markup).toContain("Open Northwind</button>");
     expect(markup).toContain("caller-row");
     expect(markup).not.toContain('role="button"');
@@ -68,31 +69,41 @@ describe("DataTable", () => {
 
   test("row selection ignores every nested interactive target", () => {
     const row = new EventTarget();
-    const cell = new ClosestTarget(null);
-    const nestedControl = new ClosestTarget({});
+    const cell = new ClosestTarget("[role='presentation']");
+    const interactiveSelectors = [
+      "button",
+      "label",
+      "[role='checkbox']",
+      "[role='combobox']",
+      "[role='menuitem']",
+      "[role='radio']",
+      "[role='switch']",
+      "[role='tab']",
+      "[data-data-table-stop-row-action]",
+    ];
 
     expect(isDataTableRowActionTarget(row, row)).toBe(true);
     expect(isDataTableRowActionTarget(row, cell)).toBe(true);
-    expect(isDataTableRowActionTarget(row, nestedControl)).toBe(false);
-    expect(nestedControl.seenSelector).toContain("button");
-    expect(nestedControl.seenSelector).toContain(
-      "[data-data-table-stop-row-action]",
-    );
+    for (const selector of interactiveSelectors) {
+      expect(isDataTableRowActionTarget(row, new ClosestTarget(selector))).toBe(
+        false,
+      );
+    }
   });
 });
 
 class ClosestTarget extends EventTarget {
-  private readonly match: unknown;
+  private readonly matchingSelector: string;
 
   seenSelector = "";
 
-  constructor(match: unknown) {
+  constructor(matchingSelector: string) {
     super();
-    this.match = match;
+    this.matchingSelector = matchingSelector;
   }
 
   closest(selector: string) {
     this.seenSelector = selector;
-    return this.match;
+    return selector.includes(this.matchingSelector) ? {} : null;
   }
 }

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -180,14 +180,15 @@ describe("DataTable", () => {
   });
 
   test("row selection stops interactive matching at the row boundary", () => {
+    const selector = "[tabindex]:not([tabindex='-1'])";
     const focusableWrapper = new EventTarget();
-    const cell = new ClosestTarget(
-      "[tabindex]:not([tabindex='-1'])",
-      focusableWrapper,
-    );
+    const cell = new ClosestTarget(selector, focusableWrapper);
     const row = new ContainmentTarget([cell]);
+    const cellInsideFocusableRow = new ClosestTarget(selector, row);
+    row.add(cellInsideFocusableRow);
 
     expect(isDataTableRowActionTarget(row, cell)).toBe(true);
+    expect(isDataTableRowActionTarget(row, cellInsideFocusableRow)).toBe(true);
   });
 });
 
@@ -217,7 +218,7 @@ class ContainmentTarget extends EventTarget {
   }
 
   contains(target: EventTarget | null) {
-    return target !== null && this.targets.has(target);
+    return target === this || (target !== null && this.targets.has(target));
   }
 }
 

--- a/packages/ui/src/data-table/table.test.tsx
+++ b/packages/ui/src/data-table/table.test.tsx
@@ -103,6 +103,10 @@ describe("DataTable", () => {
         isLoading
         loadingLabel="Loading"
         loadingRowCount={2}
+        rowAction={{
+          getAriaLabel: (row) => `Open ${row.name}`,
+          onSelect: () => undefined,
+        }}
         rowKey={(row: { id: string }) => row.id}
         rows={[]}
       />,
@@ -117,6 +121,7 @@ describe("DataTable", () => {
     );
     expect(loading).toContain("Loading");
     expect(loading).toContain("text-right");
+    expect(loading).toContain("pointer-coarse:h-11");
     expect(loading.match(/data-slot="skeleton"/gu)).toHaveLength(4);
     expect(loading).not.toContain("colSpan");
     expect(loading).not.toContain("No matters");
@@ -173,6 +178,17 @@ describe("DataTable", () => {
 
     expect(isDataTableRowActionTarget(row, portaledPopup)).toBe(false);
   });
+
+  test("row selection stops interactive matching at the row boundary", () => {
+    const focusableWrapper = new EventTarget();
+    const cell = new ClosestTarget(
+      "[tabindex]:not([tabindex='-1'])",
+      focusableWrapper,
+    );
+    const row = new ContainmentTarget([cell]);
+
+    expect(isDataTableRowActionTarget(row, cell)).toBe(true);
+  });
 });
 
 const renderLoadingTable = (loadingRowCount: number) =>
@@ -207,16 +223,20 @@ class ContainmentTarget extends EventTarget {
 
 class ClosestTarget extends EventTarget {
   private readonly matchingSelector: string;
+  private readonly matchTarget: EventTarget;
 
   seenSelector = "";
 
-  constructor(matchingSelector: string) {
+  constructor(matchingSelector: string, matchTarget?: EventTarget) {
     super();
     this.matchingSelector = matchingSelector;
+    this.matchTarget = matchTarget ?? this;
   }
 
   closest(selector: string) {
     this.seenSelector = selector;
-    return selector.split(",").includes(this.matchingSelector) ? {} : null;
+    return selector.split(",").includes(this.matchingSelector)
+      ? this.matchTarget
+      : null;
   }
 }

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -25,7 +25,15 @@ export const DataTable = <TItem,>({
 }: DataTableProps<TItem>) => {
   let content: ReactNode;
   if (isLoading) {
-    content = <LoadingRows columns={columns} rowCount={loadingRowCount} />;
+    content = (
+      <LoadingRows
+        columns={columns}
+        rowClassName={
+          rowAction === undefined ? undefined : COARSE_POINTER_ROW_CLASS_NAME
+        }
+        rowCount={loadingRowCount}
+      />
+    );
   } else if (rows.length === 0) {
     content = <StatusRow colSpan={columns.length} label={emptyLabel} />;
   } else {
@@ -101,6 +109,7 @@ type RowProps = Omit<HTMLAttributes<HTMLTableRowElement>, "children">;
 
 const DEFAULT_LOADING_ROW_COUNT = 3;
 const MAX_LOADING_ROW_COUNT = 20;
+const COARSE_POINTER_ROW_CLASS_NAME = "pointer-coarse:h-11";
 
 export const DATA_TABLE_INTERACTIVE_DESCENDANT_SELECTORS = [
   "a[href]",
@@ -168,13 +177,15 @@ export type DataTableProps<TItem> = {
 
 const LoadingRows = <TItem,>({
   columns,
+  rowClassName,
   rowCount,
 }: {
   columns: readonly DataTableColumn<TItem>[];
+  rowClassName: string | undefined;
   rowCount: number;
 }) =>
   Array.from({ length: resolveLoadingRowCount(rowCount) }, (_, rowIndex) => (
-    <TableRow key={rowIndex}>
+    <TableRow className={rowClassName} key={rowIndex}>
       {columns.map((column) => (
         <TableCell
           className={
@@ -216,7 +227,8 @@ const interactiveRowProps = <TItem,>(
   rowAction: DataTableRowAction<TItem>,
 ): RowProps => ({
   className: cn(
-    "cursor-pointer pointer-coarse:h-11",
+    "cursor-pointer",
+    COARSE_POINTER_ROW_CLASS_NAME,
     rowAction.getClassName?.(item),
   ),
   onClick: (event) => {
@@ -228,7 +240,7 @@ const interactiveRowProps = <TItem,>(
 });
 
 type ClosestEventTarget = EventTarget & {
-  closest: (selector: string) => unknown;
+  closest: (selector: string) => EventTarget | null;
 };
 
 type ContainsEventTarget = EventTarget & {
@@ -254,7 +266,8 @@ export const isDataTableRowActionTarget = (
   if (!hasClosest(target)) {
     return true;
   }
-  return target.closest(INTERACTIVE_DESCENDANT_SELECTOR) === null;
+  const interactiveTarget = target.closest(INTERACTIVE_DESCENDANT_SELECTOR);
+  return interactiveTarget === null || !row.contains(interactiveTarget);
 };
 
 const mergeHandlers = <TElement,>(

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -20,7 +20,7 @@ const INTERACTIVE_DESCENDANT_SELECTOR = [
   "textarea",
   "summary",
   "label",
-  "[contenteditable='true']",
+  "[contenteditable]:not([contenteditable='false'])",
   "[role='button']",
   "[role='checkbox']",
   "[role='combobox']",

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -101,6 +101,7 @@ export const DataTable = <TItem,>({
 type RowProps = Omit<HTMLAttributes<HTMLTableRowElement>, "children">;
 
 const DEFAULT_LOADING_ROW_COUNT = 3;
+const MAX_LOADING_ROW_COUNT = 20;
 
 const INTERACTIVE_DESCENDANT_SELECTOR = [
   "a[href]",
@@ -185,7 +186,7 @@ const LoadingRows = <TItem,>({
 
 const resolveLoadingRowCount = (rowCount: number) =>
   Number.isFinite(rowCount) && rowCount > 0
-    ? Math.max(1, Math.floor(rowCount))
+    ? Math.min(MAX_LOADING_ROW_COUNT, Math.max(1, Math.floor(rowCount)))
     : DEFAULT_LOADING_ROW_COUNT;
 
 const StatusRow = ({ colSpan, label }: { colSpan: number; label: string }) => (

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -102,7 +102,7 @@ type RowProps = Omit<HTMLAttributes<HTMLTableRowElement>, "children">;
 const DEFAULT_LOADING_ROW_COUNT = 3;
 const MAX_LOADING_ROW_COUNT = 20;
 
-const INTERACTIVE_DESCENDANT_SELECTOR = [
+export const DATA_TABLE_INTERACTIVE_DESCENDANT_SELECTORS = [
   "a[href]",
   "audio[controls]",
   "button",
@@ -132,7 +132,10 @@ const INTERACTIVE_DESCENDANT_SELECTOR = [
   "[role='treeitem']",
   "[tabindex]:not([tabindex='-1'])",
   "[data-data-table-stop-row-action]",
-].join(",");
+] as const;
+
+const INTERACTIVE_DESCENDANT_SELECTOR =
+  DATA_TABLE_INTERACTIVE_DESCENDANT_SELECTORS.join(",");
 
 export type DataTableAriaSort = "ascending" | "descending" | "none";
 
@@ -173,7 +176,14 @@ const LoadingRows = <TItem,>({
   Array.from({ length: resolveLoadingRowCount(rowCount) }, (_, rowIndex) => (
     <TableRow key={rowIndex}>
       {columns.map((column) => (
-        <TableCell key={column.id}>
+        <TableCell
+          className={
+            typeof column.cellClassName === "string"
+              ? column.cellClassName
+              : undefined
+          }
+          key={column.id}
+        >
           <Skeleton aria-hidden="true" className="h-4 w-full" />
         </TableCell>
       ))}

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -1,5 +1,6 @@
 import type { HTMLAttributes, ReactNode } from "react";
 
+import { Button } from "../components/button";
 import { Skeleton } from "../components/skeleton";
 import {
   Table,
@@ -60,13 +61,14 @@ export const DataTable = <TItem,>({
               key={column.id}
             >
               {rowAction !== undefined && columnIndex === 0 ? (
-                <button
+                <Button
                   className="focus-visible:bg-background focus-visible:ring-ring sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:inset-2 focus-visible:z-10 focus-visible:flex focus-visible:items-center focus-visible:rounded-md focus-visible:px-2 focus-visible:text-sm focus-visible:ring-2"
                   onClick={() => rowAction.onSelect(item)}
-                  type="button"
+                  size="xs"
+                  variant="ghost"
                 >
                   {rowAction.getAriaLabel(item)}
-                </button>
+                </Button>
               ) : null}
               {column.render(item)}
             </TableCell>
@@ -148,7 +150,7 @@ export type DataTableRowAction<TItem> = {
 };
 
 export type DataTableProps<TItem> = {
-  columns: readonly DataTableColumn<TItem>[];
+  columns: readonly [DataTableColumn<TItem>, ...DataTableColumn<TItem>[]];
   emptyLabel: string;
   getRowProps?: (item: TItem) => RowProps;
   isLoading?: boolean;
@@ -183,7 +185,7 @@ const LoadingRows = <TItem,>({
 
 const resolveLoadingRowCount = (rowCount: number) =>
   Number.isFinite(rowCount) && rowCount > 0
-    ? Math.floor(rowCount)
+    ? Math.max(1, Math.floor(rowCount))
     : DEFAULT_LOADING_ROW_COUNT;
 
 const StatusRow = ({ colSpan, label }: { colSpan: number; label: string }) => (

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -267,7 +267,11 @@ export const isDataTableRowActionTarget = (
     return true;
   }
   const interactiveTarget = target.closest(INTERACTIVE_DESCENDANT_SELECTOR);
-  return interactiveTarget === null || !row.contains(interactiveTarget);
+  return (
+    interactiveTarget === null ||
+    interactiveTarget === row ||
+    !row.contains(interactiveTarget)
+  );
 };
 
 const mergeHandlers = <TElement,>(

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -19,9 +19,25 @@ const INTERACTIVE_DESCENDANT_SELECTOR = [
   "select",
   "textarea",
   "summary",
+  "label",
   "[contenteditable='true']",
   "[role='button']",
+  "[role='checkbox']",
+  "[role='combobox']",
   "[role='link']",
+  "[role='listbox']",
+  "[role='menuitem']",
+  "[role='menuitemcheckbox']",
+  "[role='menuitemradio']",
+  "[role='option']",
+  "[role='radio']",
+  "[role='searchbox']",
+  "[role='slider']",
+  "[role='spinbutton']",
+  "[role='switch']",
+  "[role='tab']",
+  "[role='textbox']",
+  "[role='treeitem']",
   "[tabindex]:not([tabindex='-1'])",
   "[data-data-table-stop-row-action]",
 ].join(",");
@@ -87,12 +103,17 @@ export const DataTable = <TItem,>({
         >
           {columns.map((column, columnIndex) => (
             <TableCell
-              className={resolveClassName(column.cellClassName, item)}
+              className={cn(
+                rowAction !== undefined && columnIndex === 0
+                  ? "relative"
+                  : undefined,
+                resolveClassName(column.cellClassName, item),
+              )}
               key={column.id}
             >
               {rowAction !== undefined && columnIndex === 0 ? (
                 <button
-                  className="sr-only"
+                  className="focus-visible:bg-background focus-visible:ring-ring sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:inset-2 focus-visible:z-10 focus-visible:flex focus-visible:items-center focus-visible:rounded-md focus-visible:px-2 focus-visible:text-sm focus-visible:ring-2"
                   onClick={() => rowAction.onSelect(item)}
                   type="button"
                 >

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -181,14 +181,27 @@ type ClosestEventTarget = EventTarget & {
   closest: (selector: string) => unknown;
 };
 
+type ContainsEventTarget = EventTarget & {
+  contains: (target: EventTarget | null) => boolean;
+};
+
 const hasClosest = (target: EventTarget): target is ClosestEventTarget =>
   "closest" in target && typeof target.closest === "function";
+
+const hasContains = (target: EventTarget): target is ContainsEventTarget =>
+  "contains" in target && typeof target.contains === "function";
 
 export const isDataTableRowActionTarget = (
   row: EventTarget,
   target: EventTarget | null,
 ) => {
-  if (target === row || target === null || !hasClosest(target)) {
+  if (target === row) {
+    return true;
+  }
+  if (target === null || !hasContains(row) || !row.contains(target)) {
+    return false;
+  }
+  if (!hasClosest(target)) {
     return true;
   }
   return target.closest(INTERACTIVE_DESCENDANT_SELECTOR) === null;

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -1,5 +1,6 @@
 import type { HTMLAttributes, ReactNode } from "react";
 
+import { Skeleton } from "../components/skeleton";
 import {
   Table,
   TableBody,
@@ -10,7 +11,94 @@ import {
 } from "../components/table";
 import { cn } from "../lib/utils";
 
+export const DataTable = <TItem,>({
+  columns,
+  emptyLabel,
+  getRowProps,
+  isLoading = false,
+  loadingLabel,
+  loadingRowCount = DEFAULT_LOADING_ROW_COUNT,
+  rowAction,
+  rowKey,
+  rows,
+}: DataTableProps<TItem>) => {
+  let content: ReactNode;
+  if (isLoading) {
+    content = (
+      <LoadingRows
+        columns={columns}
+        label={loadingLabel}
+        rowCount={loadingRowCount}
+      />
+    );
+  } else if (rows.length === 0) {
+    content = <StatusRow colSpan={columns.length} label={emptyLabel} />;
+  } else {
+    content = rows.map((item) => {
+      const rowProps = getRowProps?.(item);
+      const interactiveProps =
+        rowAction === undefined
+          ? undefined
+          : interactiveRowProps(item, rowAction);
+
+      return (
+        <TableRow
+          key={rowKey(item)}
+          {...rowProps}
+          {...interactiveProps}
+          className={cn(interactiveProps?.className, rowProps?.className)}
+          onClick={mergeHandlers(interactiveProps?.onClick, rowProps?.onClick)}
+        >
+          {columns.map((column, columnIndex) => (
+            <TableCell
+              className={cn(
+                rowAction !== undefined && columnIndex === 0
+                  ? "relative"
+                  : undefined,
+                resolveClassName(column.cellClassName, item),
+              )}
+              key={column.id}
+            >
+              {rowAction !== undefined && columnIndex === 0 ? (
+                <button
+                  className="focus-visible:bg-background focus-visible:ring-ring sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:inset-2 focus-visible:z-10 focus-visible:flex focus-visible:items-center focus-visible:rounded-md focus-visible:px-2 focus-visible:text-sm focus-visible:ring-2"
+                  onClick={() => rowAction.onSelect(item)}
+                  type="button"
+                >
+                  {rowAction.getAriaLabel(item)}
+                </button>
+              ) : null}
+              {column.render(item)}
+            </TableCell>
+          ))}
+        </TableRow>
+      );
+    });
+  }
+
+  return (
+    <Table aria-busy={isLoading}>
+      <TableHeader>
+        <TableRow>
+          {columns.map((column) => (
+            <TableHead
+              aria-sort={column.ariaSort}
+              className={column.headClassName}
+              key={column.id}
+            >
+              {column.header}
+            </TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>{content}</TableBody>
+    </Table>
+  );
+};
+
 type RowProps = Omit<HTMLAttributes<HTMLTableRowElement>, "children">;
+
+const DEFAULT_LOADING_ROW_COUNT = 3;
 
 const INTERACTIVE_DESCENDANT_SELECTOR = [
   "a[href]",
@@ -65,88 +153,38 @@ export type DataTableProps<TItem> = {
   getRowProps?: (item: TItem) => RowProps;
   isLoading?: boolean;
   loadingLabel: string;
+  loadingRowCount?: number;
   rowAction?: DataTableRowAction<TItem>;
   rowKey: (item: TItem) => string | number;
   rows: readonly TItem[];
 };
 
-export const DataTable = <TItem,>({
+const LoadingRows = <TItem,>({
   columns,
-  emptyLabel,
-  getRowProps,
-  isLoading = false,
-  loadingLabel,
-  rowAction,
-  rowKey,
-  rows,
-}: DataTableProps<TItem>) => {
-  let content: ReactNode;
-  if (isLoading) {
-    content = <StatusRow colSpan={columns.length} label={loadingLabel} />;
-  } else if (rows.length === 0) {
-    content = <StatusRow colSpan={columns.length} label={emptyLabel} />;
-  } else {
-    content = rows.map((item) => {
-      const rowProps = getRowProps?.(item);
-      const interactiveProps =
-        rowAction === undefined
-          ? undefined
-          : interactiveRowProps(item, rowAction);
+  label,
+  rowCount,
+}: {
+  columns: readonly DataTableColumn<TItem>[];
+  label: string;
+  rowCount: number;
+}) =>
+  Array.from({ length: resolveLoadingRowCount(rowCount) }, (_, rowIndex) => (
+    <TableRow key={rowIndex}>
+      {columns.map((column, columnIndex) => (
+        <TableCell key={column.id}>
+          {rowIndex === 0 && columnIndex === 0 ? (
+            <span className="sr-only">{label}</span>
+          ) : null}
+          <Skeleton aria-hidden="true" className="h-4 w-full" />
+        </TableCell>
+      ))}
+    </TableRow>
+  ));
 
-      return (
-        <TableRow
-          key={rowKey(item)}
-          {...rowProps}
-          {...interactiveProps}
-          className={cn(interactiveProps?.className, rowProps?.className)}
-          onClick={mergeHandlers(interactiveProps?.onClick, rowProps?.onClick)}
-        >
-          {columns.map((column, columnIndex) => (
-            <TableCell
-              className={cn(
-                rowAction !== undefined && columnIndex === 0
-                  ? "relative"
-                  : undefined,
-                resolveClassName(column.cellClassName, item),
-              )}
-              key={column.id}
-            >
-              {rowAction !== undefined && columnIndex === 0 ? (
-                <button
-                  className="focus-visible:bg-background focus-visible:ring-ring sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:inset-2 focus-visible:z-10 focus-visible:flex focus-visible:items-center focus-visible:rounded-md focus-visible:px-2 focus-visible:text-sm focus-visible:ring-2"
-                  onClick={() => rowAction.onSelect(item)}
-                  type="button"
-                >
-                  {rowAction.getAriaLabel(item)}
-                </button>
-              ) : null}
-              {column.render(item)}
-            </TableCell>
-          ))}
-        </TableRow>
-      );
-    });
-  }
-
-  return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          {columns.map((column) => (
-            <TableHead
-              aria-sort={column.ariaSort}
-              className={column.headClassName}
-              key={column.id}
-            >
-              {column.header}
-            </TableHead>
-          ))}
-        </TableRow>
-      </TableHeader>
-      <TableBody>{content}</TableBody>
-    </Table>
-  );
-};
+const resolveLoadingRowCount = (rowCount: number) =>
+  Number.isFinite(rowCount) && rowCount > 0
+    ? Math.floor(rowCount)
+    : DEFAULT_LOADING_ROW_COUNT;
 
 const StatusRow = ({ colSpan, label }: { colSpan: number; label: string }) => (
   <TableRow>

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -211,7 +211,10 @@ const interactiveRowProps = <TItem,>(
   item: TItem,
   rowAction: DataTableRowAction<TItem>,
 ): RowProps => ({
-  className: cn("cursor-pointer", rowAction.getClassName?.(item)),
+  className: cn(
+    "cursor-pointer pointer-coarse:h-11",
+    rowAction.getClassName?.(item),
+  ),
   onClick: (event) => {
     if (!isDataTableRowActionTarget(event.currentTarget, event.target)) {
       return;

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -12,6 +12,20 @@ import { cn } from "../lib/utils";
 
 type RowProps = Omit<HTMLAttributes<HTMLTableRowElement>, "children">;
 
+const INTERACTIVE_DESCENDANT_SELECTOR = [
+  "a[href]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "summary",
+  "[contenteditable='true']",
+  "[role='button']",
+  "[role='link']",
+  "[tabindex]:not([tabindex='-1'])",
+  "[data-data-table-stop-row-action]",
+].join(",");
+
 export type DataTableAriaSort = "ascending" | "descending" | "none";
 
 export type DataTableColumn<TItem> = {
@@ -70,16 +84,21 @@ export const DataTable = <TItem,>({
           {...interactiveProps}
           className={cn(interactiveProps?.className, rowProps?.className)}
           onClick={mergeHandlers(interactiveProps?.onClick, rowProps?.onClick)}
-          onKeyDown={mergeHandlers(
-            interactiveProps?.onKeyDown,
-            rowProps?.onKeyDown,
-          )}
         >
-          {columns.map((column) => (
+          {columns.map((column, columnIndex) => (
             <TableCell
               className={resolveClassName(column.cellClassName, item)}
               key={column.id}
             >
+              {rowAction !== undefined && columnIndex === 0 ? (
+                <button
+                  className="sr-only"
+                  onClick={() => rowAction.onSelect(item)}
+                  type="button"
+                >
+                  {rowAction.getAriaLabel(item)}
+                </button>
+              ) : null}
               {column.render(item)}
             </TableCell>
           ))}
@@ -128,22 +147,31 @@ const interactiveRowProps = <TItem,>(
   item: TItem,
   rowAction: DataTableRowAction<TItem>,
 ): RowProps => ({
-  "aria-label": rowAction.getAriaLabel(item),
-  className: cn(
-    "focus-visible:outline-ring cursor-pointer focus-visible:outline focus-visible:outline-2",
-    rowAction.getClassName?.(item),
-  ),
-  onClick: () => rowAction.onSelect(item),
-  onKeyDown: (event) => {
-    if (event.key !== "Enter" && event.key !== " ") {
+  className: cn("cursor-pointer", rowAction.getClassName?.(item)),
+  onClick: (event) => {
+    if (!isDataTableRowActionTarget(event.currentTarget, event.target)) {
       return;
     }
-    event.preventDefault();
     rowAction.onSelect(item);
   },
-  role: "button",
-  tabIndex: 0,
 });
+
+type ClosestEventTarget = EventTarget & {
+  closest: (selector: string) => unknown;
+};
+
+const hasClosest = (target: EventTarget): target is ClosestEventTarget =>
+  "closest" in target && typeof target.closest === "function";
+
+export const isDataTableRowActionTarget = (
+  row: EventTarget,
+  target: EventTarget | null,
+) => {
+  if (target === row || target === null || !hasClosest(target)) {
+    return true;
+  }
+  return target.closest(INTERACTIVE_DESCENDANT_SELECTOR) === null;
+};
 
 const mergeHandlers = <TElement,>(
   first: ((event: TElement) => void) | undefined,

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -104,10 +104,12 @@ const MAX_LOADING_ROW_COUNT = 20;
 
 const INTERACTIVE_DESCENDANT_SELECTOR = [
   "a[href]",
+  "audio[controls]",
   "button",
   "input",
   "select",
   "textarea",
+  "video[controls]",
   "summary",
   "label",
   "[contenteditable]:not([contenteditable='false'])",

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -25,13 +25,7 @@ export const DataTable = <TItem,>({
 }: DataTableProps<TItem>) => {
   let content: ReactNode;
   if (isLoading) {
-    content = (
-      <LoadingRows
-        columns={columns}
-        label={loadingLabel}
-        rowCount={loadingRowCount}
-      />
-    );
+    content = <LoadingRows columns={columns} rowCount={loadingRowCount} />;
   } else if (rows.length === 0) {
     content = <StatusRow colSpan={columns.length} label={emptyLabel} />;
   } else {
@@ -79,22 +73,27 @@ export const DataTable = <TItem,>({
   }
 
   return (
-    <Table aria-busy={isLoading}>
-      <TableHeader>
-        <TableRow>
-          {columns.map((column) => (
-            <TableHead
-              aria-sort={column.ariaSort}
-              className={column.headClassName}
-              key={column.id}
-            >
-              {column.header}
-            </TableHead>
-          ))}
-        </TableRow>
-      </TableHeader>
-      <TableBody>{content}</TableBody>
-    </Table>
+    <>
+      <span className="sr-only" role="status">
+        {isLoading ? loadingLabel : ""}
+      </span>
+      <Table aria-busy={isLoading}>
+        <TableHeader>
+          <TableRow>
+            {columns.map((column) => (
+              <TableHead
+                aria-sort={column.ariaSort}
+                className={column.headClassName}
+                key={column.id}
+              >
+                {column.header}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>{content}</TableBody>
+      </Table>
+    </>
   );
 };
 
@@ -164,22 +163,15 @@ export type DataTableProps<TItem> = {
 
 const LoadingRows = <TItem,>({
   columns,
-  label,
   rowCount,
 }: {
   columns: readonly DataTableColumn<TItem>[];
-  label: string;
   rowCount: number;
 }) =>
   Array.from({ length: resolveLoadingRowCount(rowCount) }, (_, rowIndex) => (
     <TableRow key={rowIndex}>
-      {columns.map((column, columnIndex) => (
+      {columns.map((column) => (
         <TableCell key={column.id}>
-          {rowIndex === 0 && columnIndex === 0 ? (
-            <span className="sr-only" role="status">
-              {label}
-            </span>
-          ) : null}
           <Skeleton aria-hidden="true" className="h-4 w-full" />
         </TableCell>
       ))}

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -176,7 +176,9 @@ const LoadingRows = <TItem,>({
       {columns.map((column, columnIndex) => (
         <TableCell key={column.id}>
           {rowIndex === 0 && columnIndex === 0 ? (
-            <span className="sr-only">{label}</span>
+            <span className="sr-only" role="status">
+              {label}
+            </span>
           ) : null}
           <Skeleton aria-hidden="true" className="h-4 w-full" />
         </TableCell>

--- a/packages/ui/src/data-table/table.tsx
+++ b/packages/ui/src/data-table/table.tsx
@@ -1,0 +1,162 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../components/table";
+import { cn } from "../lib/utils";
+
+type RowProps = Omit<HTMLAttributes<HTMLTableRowElement>, "children">;
+
+export type DataTableAriaSort = "ascending" | "descending" | "none";
+
+export type DataTableColumn<TItem> = {
+  ariaSort?: DataTableAriaSort;
+  cellClassName?: string | ((item: TItem) => string | undefined);
+  header: ReactNode;
+  headClassName?: string;
+  id: string;
+  render: (item: TItem) => ReactNode;
+};
+
+export type DataTableRowAction<TItem> = {
+  getAriaLabel: (item: TItem) => string;
+  getClassName?: (item: TItem) => string | undefined;
+  onSelect: (item: TItem) => void;
+};
+
+export type DataTableProps<TItem> = {
+  columns: readonly DataTableColumn<TItem>[];
+  emptyLabel: string;
+  getRowProps?: (item: TItem) => RowProps;
+  isLoading?: boolean;
+  loadingLabel: string;
+  rowAction?: DataTableRowAction<TItem>;
+  rowKey: (item: TItem) => string | number;
+  rows: readonly TItem[];
+};
+
+export const DataTable = <TItem,>({
+  columns,
+  emptyLabel,
+  getRowProps,
+  isLoading = false,
+  loadingLabel,
+  rowAction,
+  rowKey,
+  rows,
+}: DataTableProps<TItem>) => {
+  let content: ReactNode;
+  if (isLoading) {
+    content = <StatusRow colSpan={columns.length} label={loadingLabel} />;
+  } else if (rows.length === 0) {
+    content = <StatusRow colSpan={columns.length} label={emptyLabel} />;
+  } else {
+    content = rows.map((item) => {
+      const rowProps = getRowProps?.(item);
+      const interactiveProps =
+        rowAction === undefined
+          ? undefined
+          : interactiveRowProps(item, rowAction);
+
+      return (
+        <TableRow
+          key={rowKey(item)}
+          {...rowProps}
+          {...interactiveProps}
+          className={cn(interactiveProps?.className, rowProps?.className)}
+          onClick={mergeHandlers(interactiveProps?.onClick, rowProps?.onClick)}
+          onKeyDown={mergeHandlers(
+            interactiveProps?.onKeyDown,
+            rowProps?.onKeyDown,
+          )}
+        >
+          {columns.map((column) => (
+            <TableCell
+              className={resolveClassName(column.cellClassName, item)}
+              key={column.id}
+            >
+              {column.render(item)}
+            </TableCell>
+          ))}
+        </TableRow>
+      );
+    });
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          {columns.map((column) => (
+            <TableHead
+              aria-sort={column.ariaSort}
+              className={column.headClassName}
+              key={column.id}
+            >
+              {column.header}
+            </TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>{content}</TableBody>
+    </Table>
+  );
+};
+
+const StatusRow = ({ colSpan, label }: { colSpan: number; label: string }) => (
+  <TableRow>
+    <TableCell
+      className="text-muted-foreground h-24 text-center"
+      colSpan={colSpan}
+    >
+      {label}
+    </TableCell>
+  </TableRow>
+);
+
+const resolveClassName = <TItem,>(
+  value: string | ((item: TItem) => string | undefined) | undefined,
+  item: TItem,
+) => (typeof value === "function" ? value(item) : value);
+
+const interactiveRowProps = <TItem,>(
+  item: TItem,
+  rowAction: DataTableRowAction<TItem>,
+): RowProps => ({
+  "aria-label": rowAction.getAriaLabel(item),
+  className: cn(
+    "focus-visible:outline-ring cursor-pointer focus-visible:outline focus-visible:outline-2",
+    rowAction.getClassName?.(item),
+  ),
+  onClick: () => rowAction.onSelect(item),
+  onKeyDown: (event) => {
+    if (event.key !== "Enter" && event.key !== " ") {
+      return;
+    }
+    event.preventDefault();
+    rowAction.onSelect(item);
+  },
+  role: "button",
+  tabIndex: 0,
+});
+
+const mergeHandlers = <TElement,>(
+  first: ((event: TElement) => void) | undefined,
+  second: ((event: TElement) => void) | undefined,
+) => {
+  if (first === undefined) {
+    return second;
+  }
+  if (second === undefined) {
+    return first;
+  }
+  return (event: TElement) => {
+    first(event);
+    second(event);
+  };
+};


### PR DESCRIPTION
Adds an entity-agnostic renderer to the existing `@stll/ui/data-table` subpath. It composes the shared table primitives, keeps cell rendering caller-owned, and provides explicit loading, empty, and accessible row-action states.

The interactive-row contract requires an accessible label and prevents caller row props from weakening its role, tab order, or label. Focused tests, package typecheck, type-aware lint, build, and pack dry-run pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a flexible, accessible data table for displaying different types of records.
  * Supports configurable columns, sorting metadata, custom row properties, styling, and optional row actions.
  * Added loading and empty states, including configurable skeleton loading rows and busy-state accessibility indicators.
  * Row actions are keyboard accessible and prevent unintended activation from nested controls.

* **Tests**
  * Added coverage for rendering, accessibility attributes, loading and empty states, and row-action behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->