### PR TITLE
fix(api): name errors by their declared name, not the constructor identifier

### DIFF
--- a/apps/api/src/lib/errors/error-tag.test.ts
+++ b/apps/api/src/lib/errors/error-tag.test.ts
@@ -1,0 +1,87 @@
+import { panic, Panic, TaggedError, UnhandledException } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import { errorClassName, errorTag } from "@/api/lib/errors/error-tag";
+
+class ExampleTaggedError extends TaggedError("ExampleTaggedError")<{
+  message: string;
+}> {}
+
+// These two fixtures exist to break the convention `custom-error-definition`
+// enforces — a class whose identifier and declared name disagree, and a class
+// that declares no name at all. `errorClassName` has to name both, so the
+// fixtures cannot be made rule-compliant without erasing what they test.
+/* eslint-disable unicorn/custom-error-definition */
+
+// The shape a bundler emits when a class expression collides with the outer
+// binding it is assigned to: a distinct, suffixed identifier over a `name`
+// that keeps the source spelling.
+const BundlerRenamedError = class BundlerRenamedError2 extends Error {
+  constructor() {
+    super("query failed");
+    this.name = "BundlerRenamedError";
+  }
+};
+
+class SilentError extends Error {}
+
+/* eslint-enable unicorn/custom-error-definition */
+
+describe("errorClassName", () => {
+  // `better-result` ships minified, so `Panic` is bound to a single letter
+  // and `UnhandledException` is an anonymous class expression named after
+  // the binding it was assigned to. Both write the real name onto the
+  // instance, which is the only spelling that identifies the class.
+  test("names a minified dependency's error classes", () => {
+    expect(errorClassName(new Panic({ message: "invariant broken" }))).toBe(
+      "Panic",
+    );
+    expect(
+      errorClassName(new UnhandledException({ cause: new Error("boom") })),
+    ).toBe("UnhandledException");
+  });
+
+  test("names a bundler-suffixed class by its declared name", () => {
+    const error = new BundlerRenamedError();
+
+    // Guard the fixture: without a divergence there is nothing to prefer.
+    expect(error.constructor.name).toBe("BundlerRenamedError2");
+    expect(errorClassName(error)).toBe("BundlerRenamedError");
+  });
+
+  test("falls back to the constructor for a class that declares no name", () => {
+    const error = new SilentError("boom");
+
+    // Guard the fixture: `name` is inherited here, not declared.
+    expect(error.name).toBe("Error");
+    expect(errorClassName(error)).toBe("SilentError");
+  });
+
+  test("names built-in and tagged errors", () => {
+    expect(errorClassName(new TypeError("bad access"))).toBe("TypeError");
+    expect(errorClassName(new Error("plain"))).toBe("Error");
+    expect(errorClassName(new ExampleTaggedError({ message: "nope" }))).toBe(
+      "ExampleTaggedError",
+    );
+  });
+
+  test("never throws on hostile accessors", () => {
+    const error = new Error("boom");
+    Object.defineProperties(error, {
+      constructor: { get: () => panic("constructor getter failed") },
+      name: { get: () => panic("name getter failed") },
+    });
+
+    expect(errorClassName(error)).toBe("Error");
+  });
+});
+
+describe("errorTag", () => {
+  test("prefers the tag, then the class name", () => {
+    expect(errorTag(new ExampleTaggedError({ message: "nope" }))).toBe(
+      "ExampleTaggedError",
+    );
+    expect(errorTag(new TypeError("bad access"))).toBe("TypeError");
+    expect(errorTag("boom")).toBe("UnknownError");
+  });
+});

--- a/apps/api/src/lib/errors/error-tag.test.ts
+++ b/apps/api/src/lib/errors/error-tag.test.ts
@@ -65,6 +65,14 @@ describe("errorClassName", () => {
     );
   });
 
+  test("rejects writable names that are not tied to the constructor", () => {
+    const error = new Error("upstream failure");
+    error.name = "PrivilegedClientNameError";
+
+    expect(errorClassName(error)).toBe("Error");
+    expect(errorTag(error)).toBe("Error");
+  });
+
   test("never throws on hostile accessors", () => {
     const error = new Error("boom");
     Object.defineProperties(error, {

--- a/apps/api/src/lib/errors/error-tag.ts
+++ b/apps/api/src/lib/errors/error-tag.ts
@@ -8,9 +8,17 @@
  * `errors/utils` re-exports these, so existing callers are unaffected.
  */
 
-import { isTaggedError } from "better-result";
+import { isTaggedError, Result } from "better-result";
 
 const GENERIC_ERROR_NAME = "Error";
+
+const safeReflectGet = (target: object, key: PropertyKey): unknown =>
+  Result.try((): unknown => Reflect.get(target, key)).unwrapOr(undefined);
+
+const taggedErrorName = (error: unknown): string | undefined =>
+  Result.try(() => (isTaggedError(error) ? error._tag : undefined)).unwrapOr(
+    undefined,
+  );
 
 /**
  * The name an error class assigns to itself, when it assigns one.
@@ -21,31 +29,30 @@ const GENERIC_ERROR_NAME = "Error";
  * the more specific of the two.
  */
 const declaredErrorName = (error: Error): string | undefined => {
-  try {
-    const name: unknown = Reflect.get(error, "name");
-    if (typeof name === "string" && name && name !== GENERIC_ERROR_NAME) {
-      return name;
-    }
-  } catch {
-    return undefined;
-  }
-  return undefined;
+  const name = safeReflectGet(error, "name");
+  return typeof name === "string" && name && name !== GENERIC_ERROR_NAME
+    ? name
+    : undefined;
 };
 
 const constructorIdentifier = (error: Error): string => {
-  try {
-    const constructorValue: unknown = Reflect.get(error, "constructor");
-    if (typeof constructorValue !== "function") {
-      return GENERIC_ERROR_NAME;
-    }
-    const name: unknown = Reflect.get(constructorValue, "name");
-    if (typeof name === "string" && name) {
-      return name;
-    }
-  } catch {
+  const constructorValue = safeReflectGet(error, "constructor");
+  if (typeof constructorValue !== "function") {
     return GENERIC_ERROR_NAME;
   }
-  return GENERIC_ERROR_NAME;
+  const name = safeReflectGet(constructorValue, "name");
+  return typeof name === "string" && name ? name : GENERIC_ERROR_NAME;
+};
+
+const hasNumericSuffix = (value: string, prefix: string): boolean => {
+  if (!value.startsWith(prefix)) {
+    return false;
+  }
+  const suffix = value.slice(prefix.length);
+  return (
+    suffix.length > 0 &&
+    Array.from(suffix).every((char) => char >= "0" && char <= "9")
+  );
 };
 
 /**
@@ -64,10 +71,29 @@ const constructorIdentifier = (error: Error): string => {
  *
  * Every such name is local to one build of one bundle, so none of them
  * identifies the class across builds, and none of them can be grepped for.
- * The declared name survives all three.
+ * The declared name survives all three. Because `Error.name` is writable, a
+ * declared name is used only when a tagged error vouches for it or the
+ * constructor identifier proves the same name, optionally with the numeric
+ * suffix emitted by the bundler. This keeps caller-controlled values out of
+ * telemetry and persisted error codes.
  */
-export const errorClassName = (error: Error): string =>
-  declaredErrorName(error) ?? constructorIdentifier(error);
+export const errorClassName = (error: Error): string => {
+  const taggedName = taggedErrorName(error);
+  if (taggedName !== undefined) {
+    return taggedName;
+  }
+
+  const declaredName = declaredErrorName(error);
+  const constructorName = constructorIdentifier(error);
+  if (
+    declaredName !== undefined &&
+    (declaredName === constructorName ||
+      hasNumericSuffix(constructorName, declaredName))
+  ) {
+    return declaredName;
+  }
+  return constructorName;
+};
 
 /**
  * Extract a safe, structural error identifier for observability.
@@ -78,8 +104,9 @@ export const errorClassName = (error: Error): string =>
  * names, or client data that must not reach analytics dashboards.
  */
 export const errorTag = (error: unknown): string => {
-  if (isTaggedError(error)) {
-    return error._tag;
+  const taggedName = taggedErrorName(error);
+  if (taggedName !== undefined) {
+    return taggedName;
   }
   if (error instanceof Error) {
     return errorClassName(error);

--- a/apps/api/src/lib/errors/error-tag.ts
+++ b/apps/api/src/lib/errors/error-tag.ts
@@ -10,26 +10,69 @@
 
 import { isTaggedError } from "better-result";
 
-export const errorClassName = (error: Error): string => {
+const GENERIC_ERROR_NAME = "Error";
+
+/**
+ * The name an error class assigns to itself, when it assigns one.
+ *
+ * `Error.prototype.name` is `"Error"`, so a class that never writes `name`
+ * reports that generic value. Treat it as "declares nothing" and let the
+ * caller fall back to the constructor identifier, which for such a class is
+ * the more specific of the two.
+ */
+const declaredErrorName = (error: Error): string | undefined => {
+  try {
+    const name: unknown = Reflect.get(error, "name");
+    if (typeof name === "string" && name && name !== GENERIC_ERROR_NAME) {
+      return name;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+};
+
+const constructorIdentifier = (error: Error): string => {
   try {
     const constructorValue: unknown = Reflect.get(error, "constructor");
     if (typeof constructorValue !== "function") {
-      return "Error";
+      return GENERIC_ERROR_NAME;
     }
     const name: unknown = Reflect.get(constructorValue, "name");
     if (typeof name === "string" && name) {
       return name;
     }
   } catch {
-    return "Error";
+    return GENERIC_ERROR_NAME;
   }
-  return "Error";
+  return GENERIC_ERROR_NAME;
 };
+
+/**
+ * Name an error class.
+ *
+ * Prefers the `name` the class declares over its constructor's identifier: an
+ * identifier is a build artifact, `name` is a string literal the class writes
+ * onto every instance. The two diverge silently in three ways, each of which
+ * renames the class without touching `name`:
+ *  - a minifier rewrites the binding, so a dependency ships
+ *    `class e extends Error { … this.name = "Panic" }`;
+ *  - an anonymous class expression is named after whatever it is assigned to,
+ *    so `var x = class extends Error {}` reports `"x"`;
+ *  - a bundler flattens modules into one scope and suffixes the loser of a
+ *    name collision, turning `DrizzleQueryError` into `DrizzleQueryError2`.
+ *
+ * Every such name is local to one build of one bundle, so none of them
+ * identifies the class across builds, and none of them can be grepped for.
+ * The declared name survives all three.
+ */
+export const errorClassName = (error: Error): string =>
+  declaredErrorName(error) ?? constructorIdentifier(error);
 
 /**
  * Extract a safe, structural error identifier for observability.
  *
- * Returns the TaggedError `_tag`, the Error constructor name, or
+ * Returns the TaggedError `_tag`, the error's class name, or
  * "UnknownError". Never includes messages, causes, or stack
  * traces; those may contain privileged document content, file
  * names, or client data that must not reach analytics dashboards.

--- a/apps/api/src/lib/errors/utils.ts
+++ b/apps/api/src/lib/errors/utils.ts
@@ -189,7 +189,7 @@ export const unredactedErrorFields = (
 /**
  * Non-PII structural fingerprint for diagnosing 5xx without shipping
  * any user data. Three signals, all code-level, never content:
- *  - `error.class`: the constructor name (e.g. "Panic", "TypeError").
+ *  - `error.class`: the class name (e.g. "Panic", "TypeError").
  *  - `error.code`: a stable code — a `.code` string when present
  *    (HandlerError code, ECONNRESET, …), otherwise the structural tag.
  *  - `error.frame`: the top stack frame as `file:line:col`, plus the


### PR DESCRIPTION
## Proposed change

`errorClassName` in `apps/api/src/lib/errors/error-tag.ts` reads the constructor's
identifier. An identifier is a build artifact, and three transforms rewrite it
without touching the `name` a class writes onto every instance:

- a minifier renames the binding: `better-result` ships `Panic` as `class e`, and
  `UnhandledException` as an anonymous class expression named after the `x` it is
  assigned to;
- a bundler flattens modules into one scope and suffixes the loser of a name
  collision: drizzle's `var DrizzleQueryError = class DrizzleQueryError extends Error`
  comes out as `class DrizzleQueryError2`;
- the two compose. Checked against the shipped dependencies through
  `bun build --target bun`, which is how `apps/api/Dockerfile` builds the server:

  | class | constructor identifier | `errorClassName` before | after |
  | --- | --- | --- | --- |
  | `DrizzleQueryError` | `DrizzleQueryError2` | `DrizzleQueryError2` | `DrizzleQueryError` |
  | `Panic` | `e2` | `e2` | `Panic` |
  | `UnhandledException` | `x` | `x` | `UnhandledException` |

Each of those names is local to one build of one bundle, identifies the class in no
other build, and cannot be grepped for. `error.class` leads both the fingerprint
`captureError` builds and the key it throttles repeats on, so it is the last field
that should carry a build-local value.

This prefers the `name` a class declares, and falls back to the constructor
identifier for a class that assigns none and so inherits the generic `"Error"`
(without that fallback, `class SilentError extends Error {}` would report `Error`).
Every error class in this repository already sets `name` to its own class name,
which `unicorn/custom-error-definition` enforces, so the two agree for all of them:
the change is a no-op there and a correction where they disagree.

`errorTag` is unchanged for tagged errors, which answer from `_tag` before reaching
this path.

### Tests

New `error-tag.test.ts` covers the three divergences, the fallback, and the hostile
accessors. Both divergence cases fail against the previous implementation. The two
fixtures that must break `unicorn/custom-error-definition` (a class whose identifier
and declared name disagree; a class that declares no name) carry a scoped disable
with the reason, since making them rule-compliant would erase what they test.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | `bun scripts/run-tests.ts src/lib/errors src/lib/analytics src/lib/observability`, `tsc --noEmit`, type-aware oxlint, oxfmt, `ratchet --check`, `suppression-waivers --check`.
- [ ] DARK MODE SUPPORT | Not applicable: no user-facing surface.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no user-facing surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification so meaningful error names are retained, including for minified or renamed errors.
  * Added safer handling when error properties cannot be accessed.
  * Preserved consistent fallback behaviour for unnamed and built-in errors.

* **Documentation**
  * Clarified that an error’s class value represents its class name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review follow-up

- Mutation check: replacing the constructor-proof rule with unconditional `Error.name` acceptance made `rejects writable names that are not tied to the constructor` fail (`PrivilegedClientNameError` instead of `Error`); restoring the rule made the focused suite pass.
