### PR TITLE
fix(api): stage native runtime assets through the resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1937,6 +1937,14 @@ jobs:
             --target bun \
             --outfile /tmp/image-smoke \
             apps/api/src/scripts/image-smoke.ts
+          # Stage the native runtime assets the way the image builder does:
+          # every asset resolves through Bun's resolver from this install, or
+          # the step fails here instead of in the release image smoke.
+          rm -rf /tmp/runtime-native
+          bun apps/api/src/scripts/stage-runtime-assets.ts /tmp/runtime-native
+          test -d /tmp/runtime-native/bin
+          test -d /tmp/runtime-native/node_modules/@img
+          test -z "$(find /tmp/runtime-native -type l | head -n 1)"
         env:
           NPM_TOKEN: ""
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -78,7 +78,10 @@ RUN bun build \
 # native addon, which the bundler emits as a sidecar `.node` asset next to the
 # entry point and references relatively. `--outfile` refuses to write more than
 # one output. The whole directory is copied into the runtime image below, so the
-# sidecar travels with the bundle.
+# sidecar travels with the bundle. The same-stage `cp` calls below copy regular
+# files whose path may traverse a package symlink under an isolated install;
+# cp follows it. Only a cross-stage COPY of a symlink breaks, and those assets
+# go through stage-runtime-assets.ts instead.
 RUN mkdir -p /app/runtime-workers && \
     bun build \
       --target bun \
@@ -112,6 +115,12 @@ RUN mkdir -p /app/runtime-workers && \
 # native binding, which the bundled worker resolves relative to its own
 # location (`../bin/...`), so the directory must sit beside the workers.
 RUN cd apps/api && bun src/scripts/fetch-ocr-models.ts /app/ocr-models
+# Native runtime assets (onnxruntime binding, sharp platform packages,
+# anonymize native glue, quickjs wasm) are located through Bun's resolver and
+# copied with symlinks dereferenced, so the runner stage never reads
+# node_modules and the install's layout (hoisted or isolated) cannot leak into
+# the image. A package that does not resolve fails the build here.
+RUN bun apps/api/src/scripts/stage-runtime-assets.ts /app/runtime-native
 RUN bun --filter @stll/legal-atlas-runner build
 # Runtime-asset smoke probe: initializes every lazily loaded asset the runner
 # stage copies by hand (anonymize engine, quickjs wasm, yara rules, worker
@@ -163,15 +172,15 @@ COPY --chown=stella:stella --from=builder /app/apps/api/src/db/migrate.js /app/a
 COPY --chown=stella:stella --from=builder /app/apps/api/drizzle /app/apps/api/drizzle
 RUN mkdir -p '/$bunfs/root'
 COPY --chown=stella:stella --from=builder /app/runtime-workers /\$bunfs/root/workers
-# The bundled OCR worker dlopens onnxruntime from `../bin` relative to the
-# workers directory; the models are read from DOCUMENT_OCR_MODEL_DIR.
-COPY --chown=stella:stella --from=builder /app/node_modules/onnxruntime-node/bin /\$bunfs/root/bin
+# Native runtime assets come from the resolver-staged directory, never from
+# node_modules (see stage-runtime-assets.ts). The bundled OCR worker dlopens
+# onnxruntime from `../bin` relative to the workers directory; sharp's platform
+# packages resolve through bare `@img/...` requires against a node_modules
+# directory beside the worker bundles. The image smoke spawns the worker, so a
+# missing binding fails the build, not the first run.
+COPY --chown=stella:stella --from=builder /app/runtime-native/bin /\$bunfs/root/bin
+COPY --chown=stella:stella --from=builder /app/runtime-native/node_modules/@img /\$bunfs/root/workers/node_modules/@img
 COPY --chown=stella:stella --from=builder /app/ocr-models /app/ocr-models
-# sharp's platform binding and libvips resolve at runtime through bare
-# `@img/...` requires the bundler cannot rewrite; a node_modules directory
-# beside the worker bundles satisfies that lookup. The image smoke spawns
-# the worker, so a missing binding fails the build, not the first run.
-COPY --chown=stella:stella --from=builder /app/node_modules/@img /\$bunfs/root/workers/node_modules/@img
 COPY --chown=stella:stella --from=install-inputs \
     /app/apps/landing/public/fonts/CabinetGrotesk-Regular.otf \
     /\$bunfs/root/fonts/CabinetGrotesk-Regular.otf
@@ -180,9 +189,7 @@ COPY --chown=stella:stella --from=builder /app/apps/api/src/lib/file-scan/yara /
 # compiled binary resolves against its embedded filesystem only — fs APIs
 # fall back to disk, import() does not. STLL_ANONYMIZE_ASSET_DIR points the
 # loader at a real directory instead.
-COPY --chown=stella:stella --from=deps \
-    /app/node_modules/@stll/anonymize-wasm/dist/native/ \
-    /app/anonymize-native/
+COPY --chown=stella:stella --from=builder /app/runtime-native/anonymize-native/ /app/anonymize-native/
 # Bundled template packs: the manifest is compiled into the binary, the DOCX
 # bytes are read from TEMPLATE_PACKS_CONTENT_DIR when a pack is installed.
 # Copied from the unpruned context stage. A build whose context has no content
@@ -192,9 +199,7 @@ COPY --chown=stella:stella --from=install-inputs \
     /app/template-packs-content/
 # quickjs-emscripten loads this WASM file at runtime from the
 # compiled Bun binary's `$bunfs/root` asset directory.
-COPY --chown=stella:stella --from=deps \
-    /app/node_modules/@jitl/quickjs-wasmfile-release-asyncify/dist/emscripten-module.wasm \
-    /\$bunfs/root/
+COPY --chown=stella:stella --from=builder /app/runtime-native/quickjs/emscripten-module.wasm /\$bunfs/root/
 WORKDIR /app/apps/api
 
 USER stella

--- a/apps/api/src/scripts/runtime-asset-manifest.test.ts
+++ b/apps/api/src/scripts/runtime-asset-manifest.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import path from "node:path";
+
+import {
+  RUNTIME_ASSET_DESTINATIONS,
+  STATIC_RUNTIME_ASSETS,
+  readPackageManifest,
+  sharpPlatformAssets,
+  sharpRuntimePackageCandidates,
+} from "./runtime-asset-manifest";
+
+const workspaceRoot = path.resolve(import.meta.dir, "../../../..");
+const dockerfile = path.join(workspaceRoot, "apps/api/Dockerfile");
+
+const resolvePackageDir = (specifier: string): string | null => {
+  try {
+    return path.dirname(
+      realpathSync(Bun.resolveSync(`${specifier}/package.json`, workspaceRoot)),
+    );
+  } catch {
+    return null;
+  }
+};
+
+describe("runtime asset manifest", () => {
+  // Runs under whatever layout the repo install uses, so an asset the image
+  // needs but the lockfile no longer provides fails here, before a release.
+  test("every static asset resolves and its selection exists", () => {
+    for (const asset of STATIC_RUNTIME_ASSETS) {
+      const dir = resolvePackageDir(asset.specifier);
+      expect(dir, asset.specifier).not.toBeNull();
+      expect(
+        existsSync(path.join(dir ?? "", asset.select)),
+        asset.specifier,
+      ).toBe(true);
+    }
+  });
+
+  test("sharp's runtime package and its libvips resolve for this platform", () => {
+    const { packages } = sharpPlatformAssets({
+      platform: process.platform,
+      arch: process.arch,
+      resolvePackageDir,
+    });
+    const runtimeCandidates = sharpRuntimePackageCandidates(
+      process.platform,
+      process.arch,
+    );
+    const runtime = packages.find((asset) =>
+      runtimeCandidates.includes(asset.specifier),
+    );
+    expect(runtime).toBeDefined();
+    // The runtime package declares its own libvips where one exists (the
+    // win32 bindings bundle it); the staged set must equal that declaration.
+    const runtimeDir = resolvePackageDir(runtime?.specifier ?? "");
+    expect(runtimeDir).not.toBeNull();
+    const declared = Object.keys(
+      readPackageManifest(path.join(runtimeDir ?? "", "package.json"))
+        .optionalDependencies ?? {},
+    );
+    expect(packages.map((asset) => asset.specifier).sort()).toEqual(
+      [runtime?.specifier ?? "", ...declared].sort(),
+    );
+    for (const asset of packages) {
+      expect(asset.destination.startsWith("node_modules/@img/")).toBe(true);
+    }
+  });
+
+  test("a platform with no installed runtime package is rejected", () => {
+    expect(() =>
+      sharpPlatformAssets({
+        platform: "plan9",
+        arch: "mips",
+        resolvePackageDir,
+      }),
+    ).toThrow(/not installed for plan9-mips/u);
+  });
+
+  // The Dockerfile copies each staged destination by hand; both sides must
+  // name the same set or an asset is staged and never shipped (or shipped
+  // from a path nothing stages).
+  test("Dockerfile copies exactly the declared destinations", () => {
+    const copied = new Set<string>();
+    for (const match of readFileSync(dockerfile, "utf-8").matchAll(
+      /--from=builder\s+\/app\/runtime-native\/([^\s]+)/gu,
+    )) {
+      copied.add((match[1] ?? "").replace(/\/$/u, ""));
+    }
+    expect([...copied].sort()).toEqual([...RUNTIME_ASSET_DESTINATIONS].sort());
+  });
+});

--- a/apps/api/src/scripts/runtime-asset-manifest.ts
+++ b/apps/api/src/scripts/runtime-asset-manifest.ts
@@ -1,0 +1,138 @@
+import { panic } from "better-result";
+/**
+ * Native and binary assets the runtime image ships outside any node_modules.
+ *
+ * The runner stage carries compiled bundles only, so every file a bundle
+ * loads at runtime by path (native addons, wasm, platform bindings) has to be
+ * placed by hand. Each entry here is resolved through Bun's module resolver at
+ * build time and copied with symlinks dereferenced, so the image never depends
+ * on how the install laid node_modules out (hoisted, isolated, global store).
+ *
+ * `destination` is relative to the staging root; the Dockerfile copies each
+ * staged directory from there. The manifest test asserts the two sets match.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+export type RuntimeAsset = {
+  /** Package whose files are staged; resolved via `<specifier>/package.json`. */
+  specifier: string;
+  /** Path inside the resolved package to copy; `.` copies the whole package. */
+  select: string;
+  /** Path under the staging root. */
+  destination: string;
+};
+
+/** Assets with a fixed package and path. */
+export const STATIC_RUNTIME_ASSETS = [
+  // The bundled OCR worker dlopens onnxruntime from `../bin` relative to the
+  // workers directory.
+  { specifier: "onnxruntime-node", select: "bin", destination: "bin" },
+  // @stll/anonymize-wasm loads its native glue via ESM import(), which a
+  // compiled binary resolves against its embedded filesystem only; the
+  // loader is pointed at this directory instead.
+  {
+    specifier: "@stll/anonymize-wasm",
+    select: "dist/native",
+    destination: "anonymize-native",
+  },
+  // quickjs-emscripten reads this wasm file from the compiled binary's
+  // `$bunfs/root` asset directory.
+  {
+    specifier: "@jitl/quickjs-wasmfile-release-asyncify",
+    select: "dist/emscripten-module.wasm",
+    destination: "quickjs/emscripten-module.wasm",
+  },
+] as const satisfies readonly RuntimeAsset[];
+
+/**
+ * Where sharp's platform packages are staged. The worker bundle requires
+ * `@img/...` bare, so a node_modules directory beside the worker bundles has
+ * to satisfy that lookup.
+ */
+export const SHARP_PLATFORM_DESTINATION = "node_modules/@img";
+
+/** Every destination the Dockerfile must copy out of the staging root. */
+export const RUNTIME_ASSET_DESTINATIONS = [
+  ...STATIC_RUNTIME_ASSETS.map((asset) => asset.destination),
+  SHARP_PLATFORM_DESTINATION,
+] as const;
+
+type PackageManifest = {
+  optionalDependencies?: Record<string, string>;
+};
+
+export const readPackageManifest = (file: string): PackageManifest => {
+  const parsed: unknown = JSON.parse(readFileSync(file, "utf-8"));
+  if (typeof parsed !== "object" || parsed === null) {
+    panic(`${file} is not a package manifest`);
+  }
+  return parsed;
+};
+
+/**
+ * sharp's runtime package for this platform and libc, as sharp names them:
+ * `@img/sharp-<os>-<arch>` on glibc, `@img/sharp-<os>musl-<arch>` on musl.
+ * Both spellings are tried; the installer only materializes the one that
+ * matches the build image, so exactly one resolves.
+ */
+export const sharpRuntimePackageCandidates = (
+  platform: string,
+  arch: string,
+): readonly string[] => [
+  `@img/sharp-${platform}-${arch}`,
+  `@img/sharp-${platform}musl-${arch}`,
+];
+
+export type SharpPlatformAssets = {
+  /** Resolved runtime package and everything it declares optional. */
+  packages: readonly { specifier: string; select: "."; destination: string }[];
+};
+
+export type ResolvePackageDir = (specifier: string) => string | null;
+
+/**
+ * The sharp packages this platform needs: the runtime binding plus its own
+ * optional dependencies (libvips). Derived from the manifests, not from a
+ * hand list, so a sharp upgrade that moves libvips does not need a code change.
+ */
+export const sharpPlatformAssets = ({
+  platform,
+  arch,
+  resolvePackageDir,
+}: {
+  platform: string;
+  arch: string;
+  resolvePackageDir: ResolvePackageDir;
+}): SharpPlatformAssets => {
+  const candidates = sharpRuntimePackageCandidates(platform, arch);
+  const runtime = candidates
+    .map((specifier) => {
+      const dir = resolvePackageDir(specifier);
+      return dir === null ? null : { specifier, dir };
+    })
+    .find((entry) => entry !== null);
+  if (runtime === undefined) {
+    panic(
+      `sharp runtime package not installed for ${platform}-${arch}; tried ${candidates.join(", ")}`,
+    );
+  }
+  const manifest = readPackageManifest(path.join(runtime.dir, "package.json"));
+  const optional = Object.keys(manifest.optionalDependencies ?? {});
+  const packages = [runtime.specifier, ...optional].map((specifier) => {
+    if (resolvePackageDir(specifier) === null) {
+      panic(
+        `${specifier} is declared by ${runtime.specifier} but is not installed`,
+      );
+    }
+    return {
+      specifier,
+      select: "." as const,
+      destination: path.posix.join(
+        SHARP_PLATFORM_DESTINATION,
+        specifier.replace(/^@img\//u, ""),
+      ),
+    };
+  });
+  return { packages };
+};

--- a/apps/api/src/scripts/stage-runtime-assets.ts
+++ b/apps/api/src/scripts/stage-runtime-assets.ts
@@ -1,0 +1,85 @@
+import { panic } from "better-result";
+/**
+ * Stage the runtime image's native assets into one directory.
+ *
+ * Run in the image builder stage:
+ *   bun apps/api/src/scripts/stage-runtime-assets.ts /app/runtime-native
+ *
+ * Every asset is located through Bun's resolver from the workspace root and
+ * copied with symlinks dereferenced, so the result is the same whether the
+ * install was hoisted or isolated. A package that does not resolve, or a
+ * selection that is missing or empty, fails the build here rather than the
+ * first request that needs it.
+ */
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import path from "node:path";
+
+import {
+  type ResolvePackageDir,
+  type RuntimeAsset,
+  STATIC_RUNTIME_ASSETS,
+  sharpPlatformAssets,
+} from "./runtime-asset-manifest";
+
+const stagingRoot = process.argv[2];
+if (stagingRoot === undefined || stagingRoot.length === 0) {
+  console.error(
+    "usage: bun apps/api/src/scripts/stage-runtime-assets.ts <staging-root>",
+  );
+  process.exit(2);
+}
+
+// Resolve from the workspace root: that is where the image installs.
+const workspaceRoot = path.resolve(import.meta.dir, "../../../..");
+
+const resolvePackageDir: ResolvePackageDir = (specifier) => {
+  try {
+    const manifest = Bun.resolveSync(
+      `${specifier}/package.json`,
+      workspaceRoot,
+    );
+    return path.dirname(realpathSync(manifest));
+  } catch {
+    return null;
+  }
+};
+
+const stage = (asset: RuntimeAsset): string => {
+  const packageDir = resolvePackageDir(asset.specifier);
+  if (packageDir === null) {
+    panic(`cannot resolve ${asset.specifier} from ${workspaceRoot}`);
+  }
+  const source = path.join(packageDir, asset.select);
+  if (!existsSync(source)) {
+    panic(`${asset.specifier}: ${asset.select} does not exist`);
+  }
+  const target = path.join(stagingRoot, asset.destination);
+  mkdirSync(path.dirname(target), { recursive: true });
+  cpSync(source, target, { recursive: true, dereference: true });
+  const staged = statSync(target);
+  if (staged.isDirectory() && readdirSync(target).length === 0) {
+    panic(`${asset.specifier}: ${asset.select} copied empty`);
+  }
+  return `${asset.specifier}/${asset.select} -> ${asset.destination}`;
+};
+
+const assets: RuntimeAsset[] = [
+  ...STATIC_RUNTIME_ASSETS,
+  ...sharpPlatformAssets({
+    platform: process.platform,
+    arch: process.arch,
+    resolvePackageDir,
+  }).packages,
+];
+
+for (const asset of assets) {
+  console.log(`staged ${stage(asset)}`);
+}
+console.log(`staged ${assets.length} runtime assets under ${stagingRoot}`);


### PR DESCRIPTION
## Summary

The release image smoke failed to load `sharp`: with the isolated linker, `/app/node_modules/@img` is a scope directory of symlinks into `node_modules/.bun`, and `COPY --from` ships them dangling.

Resolve every runtime asset through Bun's resolver at build time (`stage-runtime-assets.ts`), realpath it and copy it with symlinks dereferenced into `/app/runtime-native`; the runner stage copies only from there. sharp's platform packages are discovered from its own `optionalDependencies`, so the set follows the build platform. The manifest test binds declared destinations to the Dockerfile's copies in both directions, and the `api-image-deps` job runs the staging step so a missing asset fails at PR time rather than at release.

## Testing

- `bun test apps/api/src/scripts` (manifest and staging)
- `docker build -f apps/api/Dockerfile --target runtime-asset-smoke .` on linux/arm64: staged onnxruntime, anonymize native glue, quickjs wasm, `@img/sharp-linux-arm64` and libvips; image smoke passed
