### PR TITLE
fix(api): read the SQLSTATE from the error cause chain

### DIFF
--- a/apps/api/src/db/scoped.test.ts
+++ b/apps/api/src/db/scoped.test.ts
@@ -1,0 +1,94 @@
+import { Result, UnhandledException } from "better-result";
+import { describe, expect, it } from "bun:test";
+import { DrizzleQueryError } from "drizzle-orm";
+
+import { createSafeDb, markRlsDatabase } from "@/api/db/scoped";
+import { createSafeId } from "@/api/lib/branded-types";
+import {
+  DatabaseError,
+  DatabaseRlsError,
+} from "@/api/lib/errors/tagged-errors";
+import { PG_ERROR } from "@/api/lib/pg-error";
+
+/**
+ * A transaction that fails before its callback runs.
+ *
+ * Only a failure raised during prepared-query execution reaches the caller
+ * inside a `DrizzleQueryError`; the transaction lifecycle surfaces the bare
+ * driver error. `COMMIT` is part of that lifecycle, and it is where Postgres
+ * reports deferred constraint violations and serialization failures.
+ */
+const rejectingTransaction = (error: unknown) => (): never => {
+  throw error;
+};
+
+const rejectingDb = (error: unknown) =>
+  markRlsDatabase({ transaction: rejectingTransaction(error) });
+
+/** Runtime shape of a driver error, with no wrapper around it. */
+const driverError = (fields: Record<string, string>): Error =>
+  Object.assign(new Error("database error"), fields);
+
+/** The transaction fails before the callback can run. */
+const unreachableCallback = (): never => {
+  throw new TypeError("The transaction callback must not run");
+};
+
+const failedTransaction = async (error: unknown) => {
+  const outcome = await createSafeDb(
+    rejectingDb(error),
+    [createSafeId<"workspace">()],
+    createSafeId<"organization">(),
+    createSafeId<"user">(),
+  )(unreachableCallback);
+
+  if (!Result.isError(outcome)) {
+    throw new TypeError("Expected the transaction to fail");
+  }
+  return outcome.error;
+};
+
+describe("createSafeDb failure classification", () => {
+  it("classifies an unwrapped driver error by its SQLSTATE", async () => {
+    const error = await failedTransaction(
+      driverError({
+        errno: PG_ERROR.SERIALIZATION_FAILURE,
+        code: "ERR_POSTGRES_SERVER_ERROR",
+      }),
+    );
+
+    // `defaultDatabaseRetry` retries a serialization failure, and can only see
+    // one that arrives as a `DatabaseError` carrying its SQLSTATE.
+    expect(DatabaseError.is(error)).toBe(true);
+    if (!DatabaseError.is(error)) {
+      throw new TypeError("Expected a DatabaseError");
+    }
+    expect(error.code).toBe(PG_ERROR.SERIALIZATION_FAILURE);
+  });
+
+  it("classifies an unwrapped privilege rejection as an RLS failure", async () => {
+    const error = await failedTransaction(
+      driverError({ errno: PG_ERROR.INSUFFICIENT_PRIVILEGE }),
+    );
+
+    expect(DatabaseRlsError.is(error)).toBe(true);
+  });
+
+  it("classifies a query failure that carries no SQLSTATE", async () => {
+    const error = await failedTransaction(
+      new DrizzleQueryError("query failed", [], new Error("socket closed")),
+    );
+
+    expect(DatabaseError.is(error)).toBe(true);
+    if (!DatabaseError.is(error)) {
+      throw new TypeError("Expected a DatabaseError");
+    }
+    expect(error.code).toBeUndefined();
+  });
+
+  it("leaves a non-database failure unhandled", async () => {
+    const error = await failedTransaction(new Error("not a database failure"));
+
+    expect(UnhandledException.is(error)).toBe(true);
+  });
+});

--- a/apps/api/src/db/scoped.ts
+++ b/apps/api/src/db/scoped.ts
@@ -206,7 +206,15 @@ const toSafeDbError = (cause: unknown): SafeDbError => {
     });
   }
 
-  if (cause instanceof DrizzleQueryError) {
+  // A SQLSTATE is proof the database rejected the work, whether or not the
+  // driver error reached here inside a `DrizzleQueryError`: only failures
+  // raised during prepared-query execution are wrapped, while the transaction
+  // lifecycle rejects with the bare driver error. Classifying on the wrapper
+  // alone files a `COMMIT`-time serialization failure or deadlock as an
+  // unhandled exception, which then never matches the retry predicate in
+  // `safe-db.ts` that exists for exactly those codes. The wrapper still
+  // classifies a query failure that carries no SQLSTATE.
+  if (code !== undefined || cause instanceof DrizzleQueryError) {
     return new DatabaseError({
       message: "Database query failed",
       cause,

--- a/apps/api/src/lib/pg-error.test.ts
+++ b/apps/api/src/lib/pg-error.test.ts
@@ -38,7 +38,7 @@ describe("getPgErrorCode", () => {
     expect(getPgErrorCode(drizzleError({}))).toBeUndefined();
   });
 
-  it("returns undefined when error is not a DrizzleQueryError", () => {
+  it("returns undefined when the cause chain carries no SQLSTATE", () => {
     expect(getPgErrorCode(new Error("plain"))).toBeUndefined();
   });
 });
@@ -96,6 +96,62 @@ describe("isPgError", () => {
 // Structural object mirroring the runtime shape of a Bun/pg PostgresError.
 const pgCause = (fields: Record<string, string>): Error =>
   Object.assign(new Error("database error"), fields);
+
+// The transaction lifecycle runs through the client's own `begin`, so a
+// failure acquiring a connection or running BEGIN/COMMIT/ROLLBACK never
+// passes through the prepared-query wrapper and arrives in this shape.
+describe("driver errors that reached the caller unwrapped", () => {
+  it("reads the SQLSTATE Bun reports in `errno`", () => {
+    const error = pgCause({
+      errno: PG_ERROR.SERIALIZATION_FAILURE,
+      code: "ERR_POSTGRES_SERVER_ERROR",
+    });
+
+    expect(getPgErrorCode(error)).toBe(PG_ERROR.SERIALIZATION_FAILURE);
+    expect(isPgError(error, PG_ERROR.SERIALIZATION_FAILURE)).toBe(true);
+  });
+
+  it("matches a constraint alongside the SQLSTATE", () => {
+    const error = pgCause({
+      errno: PG_ERROR.UNIQUE_VIOLATION,
+      constraint: "case_law_decisions_slug_uidx",
+    });
+
+    expect(
+      isPgConstraintError(
+        error,
+        PG_ERROR.UNIQUE_VIOLATION,
+        "case_law_decisions_slug_uidx",
+      ),
+    ).toBe(true);
+    expect(
+      isPgConstraintError(
+        error,
+        PG_ERROR.UNIQUE_VIOLATION,
+        "case_law_decisions_source_document_idx",
+      ),
+    ).toBe(false);
+  });
+
+  it("reads through a wrapper that is not a DrizzleQueryError", () => {
+    const error = Object.assign(new Error("transaction failed"), {
+      cause: pgCause({ code: PG_ERROR.DEADLOCK_DETECTED }),
+    });
+
+    expect(getPgErrorCode(error)).toBe(PG_ERROR.DEADLOCK_DETECTED);
+  });
+
+  it("still ignores a connection error carrying no SQLSTATE", () => {
+    const error = Object.assign(new Error("socket"), {
+      code: "ECONNRESET",
+      errno: -54,
+      syscall: "read",
+    });
+
+    expect(getPgErrorCode(error)).toBeUndefined();
+    expect(isPgError(error, PG_ERROR.UNIQUE_VIOLATION)).toBe(false);
+  });
+});
 
 describe("pgErrorFields", () => {
   it("surfaces the SQLSTATE from a DrizzleQueryError-wrapped PostgresError", () => {

--- a/apps/api/src/lib/pg-error.test.ts
+++ b/apps/api/src/lib/pg-error.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { DrizzleQueryError } from "drizzle-orm";
 
+import { DatabaseError } from "./errors/tagged-errors";
 import {
   getPgErrorCode,
   isPgConstraintError,
@@ -63,6 +64,23 @@ describe("isPgConstraintError", () => {
         PG_ERROR.UNIQUE_VIOLATION,
         "case_law_decisions_source_document_idx",
       ),
+    ).toBe(true);
+  });
+
+  it("matches the constraint on an inner driver error", () => {
+    const constraint = "case_law_decisions_slug_uidx";
+    const driver = Object.assign(new Error("database error"), {
+      errno: PG_ERROR.UNIQUE_VIOLATION,
+      constraint,
+    });
+    const error = new DatabaseError({
+      message: "Database query failed",
+      code: PG_ERROR.UNIQUE_VIOLATION,
+      cause: driver,
+    });
+
+    expect(
+      isPgConstraintError(error, PG_ERROR.UNIQUE_VIOLATION, constraint),
     ).toBe(true);
   });
 });

--- a/apps/api/src/lib/pg-error.ts
+++ b/apps/api/src/lib/pg-error.ts
@@ -106,13 +106,12 @@ export const isPgConstraintError = (
   error: unknown,
   code: string,
   constraint: string,
-): boolean => {
-  const found = pgErrorNodes(error).at(0);
-  if (found === undefined || found.sqlState !== code) {
-    return false;
-  }
-  return readNonEmptyString(found.node, "constraint") === constraint;
-};
+): boolean =>
+  pgErrorNodes(error).some(
+    ({ node, sqlState }) =>
+      sqlState === code &&
+      readNonEmptyString(node, "constraint") === constraint,
+  );
 
 export const PG_ERROR = {
   DEADLOCK_DETECTED: "40P01",

--- a/apps/api/src/lib/pg-error.ts
+++ b/apps/api/src/lib/pg-error.ts
@@ -1,71 +1,3 @@
-import { DrizzleQueryError } from "drizzle-orm";
-
-type PgCause = { code?: unknown; constraint?: unknown; errno?: unknown };
-
-const hasPgCause = (cause: unknown): cause is PgCause =>
-  cause !== null &&
-  typeof cause === "object" &&
-  ("code" in cause || "errno" in cause);
-
-/**
- * Extracts the PostgreSQL SQLSTATE from a driver error. Bun's native
- * `Bun.sql` puts the SQLSTATE in `errno` and uses `code` for a generic
- * category like "ERR_POSTGRES_SERVER_ERROR"; pg/PGlite put the SQLSTATE
- * in `code` and leave `errno` undefined. Prefer `errno` so Bun-thrown
- * errors are recognized; fall back to `code` for pg/PGlite.
- */
-const sqlStateFromCause = (cause: PgCause): string | undefined => {
-  if (typeof cause.errno === "string") {
-    return cause.errno;
-  }
-  if (typeof cause.code === "string") {
-    return cause.code;
-  }
-  return undefined;
-};
-
-/**
- * Returns true when `error` is a Postgres error with the
- * given error code. Drizzle wraps the original driver
- * error (Bun `Bun.sql`, pg, or PGlite) as `.cause`.
- *
- * Common codes: see `PG_ERROR` below.
- */
-export const isPgError = (error: unknown, code: string): boolean =>
-  error instanceof DrizzleQueryError &&
-  hasPgCause(error.cause) &&
-  sqlStateFromCause(error.cause) === code;
-
-/**
- * Returns true only when Postgres identified both the SQLSTATE and the
- * database constraint/index which rejected the query.  A 23505 alone is not
- * enough to retry a different value: an identity conflict and a slug conflict
- * have different replay semantics.
- */
-export const isPgConstraintError = (
-  error: unknown,
-  code: string,
-  constraint: string,
-): boolean =>
-  error instanceof DrizzleQueryError &&
-  hasPgCause(error.cause) &&
-  sqlStateFromCause(error.cause) === code &&
-  error.cause.constraint === constraint;
-
-export const getPgErrorCode = (error: unknown): string | undefined =>
-  error instanceof DrizzleQueryError && hasPgCause(error.cause)
-    ? sqlStateFromCause(error.cause)
-    : undefined;
-
-export const PG_ERROR = {
-  DEADLOCK_DETECTED: "40P01",
-  FOREIGN_KEY_VIOLATION: "23503",
-  SERIALIZATION_FAILURE: "40001",
-  UNIQUE_VIOLATION: "23505",
-  INSUFFICIENT_PRIVILEGE: "42501",
-  READ_ONLY_SQL_TRANSACTION: "25006",
-} as const;
-
 // A SQLSTATE is exactly five characters from the class/subclass alphabet
 // (`0`-`9`, `A`-`Z`). Shape alone is not enough: five-letter Node system
 // codes (`EPIPE`, `EPERM`) fit it too, so the check also requires at least
@@ -73,19 +5,6 @@ export const PG_ERROR = {
 // letters) and `sqlStateOf` skips nodes carrying `syscall`, which every Node
 // system error has and no Postgres driver error does.
 const PG_SQLSTATE_PATTERN = /^(?=.*[0-9])[0-9A-Z]{5}$/u;
-
-// Schema identifiers Postgres attaches to a server error. These name database
-// objects, never row data, so they are safe to ship to a log sink. `detail`,
-// `hint`, `where`, `internalQuery`, and `query` are deliberately excluded:
-// they can embed the offending row's column values.
-const PG_SAFE_STRING_FIELDS = [
-  { key: "error.cause.pg_severity", property: "severity" },
-  { key: "error.cause.pg_constraint", property: "constraint" },
-  { key: "error.cause.pg_table", property: "table" },
-  { key: "error.cause.pg_column", property: "column" },
-  { key: "error.cause.pg_schema", property: "schema" },
-  { key: "error.cause.pg_routine", property: "routine" },
-] as const;
 
 const MAX_CAUSE_DEPTH = 6;
 
@@ -103,9 +22,10 @@ const readNonEmptyString = (value: object, key: string): string | undefined => {
 };
 
 // Returns a node's SQLSTATE when it is shaped like a Postgres driver error.
-// Bun's `Bun.sql` puts the SQLSTATE in `errno` (`code` is a generic category);
-// pg/PGlite put it in `code`. Prefer `errno`, fall back to `code`, and require
-// the SQLSTATE shape so non-Postgres codes are ignored.
+// Bun's `Bun.sql` puts the SQLSTATE in `errno` (`code` is a generic category
+// like "ERR_POSTGRES_SERVER_ERROR"); pg/PGlite put it in `code`. Prefer
+// `errno`, fall back to `code`, and require the SQLSTATE shape so
+// non-Postgres codes are ignored.
 const sqlStateOf = (node: object): string | undefined => {
   if (readProperty(node, "syscall") !== undefined) {
     return undefined;
@@ -121,6 +41,101 @@ const sqlStateOf = (node: object): string | undefined => {
   return undefined;
 };
 
+type PgErrorNode = { node: object; sqlState: string };
+
+/**
+ * Every node in `error`'s `.cause` chain, outermost first, that is shaped like
+ * a Postgres driver error.
+ *
+ * Matching walks the chain rather than testing for a `DrizzleQueryError`
+ * wrapper because only failures raised inside prepared-query execution are
+ * wrapped. The transaction lifecycle runs through the client's own `begin`,
+ * so a failure while acquiring a connection or running `BEGIN`, `COMMIT`, or
+ * `ROLLBACK` arrives as the bare driver error. `COMMIT` is where Postgres
+ * reports deferred constraint violations and serialization failures, so a
+ * reader gated on the wrapper misses exactly the codes worth acting on.
+ *
+ * Every helper below reads the chain through this one walk, so a SQLSTATE the
+ * observability fields can see is also one the predicates can match. Never
+ * throws: property access is fully guarded.
+ */
+const pgErrorNodes = (error: unknown): PgErrorNode[] => {
+  const nodes: PgErrorNode[] = [];
+  const seen = new WeakSet<object>();
+  let current: unknown = error;
+  let depth = 0;
+
+  while (
+    current !== null &&
+    typeof current === "object" &&
+    depth < MAX_CAUSE_DEPTH &&
+    !seen.has(current)
+  ) {
+    seen.add(current);
+    const sqlState = sqlStateOf(current);
+    if (sqlState !== undefined) {
+      nodes.push({ node: current, sqlState });
+    }
+    current = readProperty(current, "cause");
+    depth += 1;
+  }
+
+  return nodes;
+};
+
+/**
+ * The SQLSTATE of the outermost Postgres driver error in `error`'s cause
+ * chain, or undefined when the chain holds none.
+ *
+ * Common codes: see `PG_ERROR` below.
+ */
+export const getPgErrorCode = (error: unknown): string | undefined =>
+  pgErrorNodes(error).at(0)?.sqlState;
+
+/** Returns true when `error` is a Postgres error with the given SQLSTATE. */
+export const isPgError = (error: unknown, code: string): boolean =>
+  getPgErrorCode(error) === code;
+
+/**
+ * Returns true only when Postgres identified both the SQLSTATE and the
+ * database constraint/index which rejected the query.  A 23505 alone is not
+ * enough to retry a different value: an identity conflict and a slug conflict
+ * have different replay semantics.
+ */
+export const isPgConstraintError = (
+  error: unknown,
+  code: string,
+  constraint: string,
+): boolean => {
+  const found = pgErrorNodes(error).at(0);
+  if (found === undefined || found.sqlState !== code) {
+    return false;
+  }
+  return readNonEmptyString(found.node, "constraint") === constraint;
+};
+
+export const PG_ERROR = {
+  DEADLOCK_DETECTED: "40P01",
+  FOREIGN_KEY_VIOLATION: "23503",
+  SERIALIZATION_FAILURE: "40001",
+  UNIQUE_VIOLATION: "23505",
+  INSUFFICIENT_PRIVILEGE: "42501",
+  READ_ONLY_SQL_TRANSACTION: "25006",
+} as const;
+
+// Schema identifiers Postgres attaches to a server error. These name database
+// objects, never row data, so they are safe to ship to a log sink. `detail`,
+// `hint`, `where`, `internalQuery`, and `query` are deliberately excluded:
+// they can embed the offending row's column values.
+const PG_SAFE_STRING_FIELDS = [
+  { key: "error.cause.pg_severity", property: "severity" },
+  { key: "error.cause.pg_constraint", property: "constraint" },
+  { key: "error.cause.pg_table", property: "table" },
+  { key: "error.cause.pg_column", property: "column" },
+  { key: "error.cause.pg_schema", property: "schema" },
+  { key: "error.cause.pg_routine", property: "routine" },
+] as const;
+
 const readSafePgStringFields = (node: object): Record<string, string> => {
   const fields: Record<string, string> = {};
   for (const { key, property } of PG_SAFE_STRING_FIELDS) {
@@ -132,41 +147,11 @@ const readSafePgStringFields = (node: object): Record<string, string> => {
   return fields;
 };
 
-const collectPgErrorFields = (error: unknown): Record<string, string> => {
-  const seen = new WeakSet<object>();
-  let current: unknown = error;
-  let depth = 0;
-  let sqlState: string | undefined;
-  const fields: Record<string, string> = {};
-
-  while (
-    current !== null &&
-    typeof current === "object" &&
-    depth < MAX_CAUSE_DEPTH &&
-    !seen.has(current)
-  ) {
-    seen.add(current);
-    const currentSqlState = sqlStateOf(current);
-    sqlState ??= currentSqlState;
-    if (currentSqlState !== undefined) {
-      Object.assign(fields, readSafePgStringFields(current));
-    }
-    current = readProperty(current, "cause");
-    depth += 1;
-  }
-
-  if (sqlState === undefined) {
-    return {};
-  }
-
-  return { "error.cause.pg_code": sqlState, ...fields };
-};
-
 /**
  * Extract safe, structured fields from a Postgres driver error anywhere in an
- * error's `.cause` chain, for observability. Drizzle wraps the driver error
- * (`DrizzleQueryError`), so on a failed query the SQLSTATE lives one or more
- * `.cause` hops down and would otherwise never reach the log sink.
+ * error's `.cause` chain, for observability. A failed query wraps the driver
+ * error (`DrizzleQueryError`), so its SQLSTATE lives one or more `.cause` hops
+ * down and would otherwise never reach the log sink.
  *
  * Returns the SQLSTATE under `error.cause.pg_code` plus any present schema
  * identifiers (severity, constraint, table, column, schema, routine). Every
@@ -174,5 +159,18 @@ const collectPgErrorFields = (error: unknown): Record<string, string> => {
  * survive `sanitizeLogAttributes`. Returns `{}` when no Postgres error is
  * found. Never throws: property access is fully guarded.
  */
-export const pgErrorFields = (error: unknown): Record<string, string> =>
-  collectPgErrorFields(error);
+export const pgErrorFields = (error: unknown): Record<string, string> => {
+  const nodes = pgErrorNodes(error);
+  const outermost = nodes.at(0);
+  if (outermost === undefined) {
+    return {};
+  }
+
+  const fields: Record<string, string> = {
+    "error.cause.pg_code": outermost.sqlState,
+  };
+  for (const { node } of nodes) {
+    Object.assign(fields, readSafePgStringFields(node));
+  }
+  return fields;
+};


### PR DESCRIPTION
## Proposed change

`isPgError`, `isPgConstraintError`, and `getPgErrorCode` required the error to be a `DrizzleQueryError` before reading its SQLSTATE. Only a failure raised during prepared-query execution is wrapped in one: `BunSQLSession.transaction` delegates to the client's own `begin`, so acquiring a connection and running `BEGIN`, `COMMIT`, and `ROLLBACK` surface the bare driver error. `COMMIT` is where Postgres reports deferred constraint violations and serialization failures, so the predicates could not see the codes their callers act on.

The same module's `pgErrorFields` already walked the `.cause` chain and matched an unwrapped driver error, with shape and `syscall` guards that keep `ECONNRESET`/`EPIPE`-style codes out. Two readers of the same fact, one strictly weaker. Every helper now shares that one walk, so a SQLSTATE the observability fields can see is one the predicates can match.

`toSafeDbError` classified on the wrapper too, filing an unwrapped driver error as `UnhandledException`. `defaultDatabaseRetry` matches a `DatabaseError` carrying `40001` or `40P01`, so a `COMMIT`-time serialization failure or deadlock never reached the retry policy written for it. It now classifies on the SQLSTATE, keeping the wrapper branch for a query failure that carries none.

A wrapped driver error behaves exactly as before.

### Tests

- `pg-error.test.ts`: SQLSTATE and constraint matching on an unwrapped driver error, one behind a non-Drizzle wrapper, and the negative case for a connection error carrying no SQLSTATE.
- `scoped.test.ts` (new): `createSafeDb` classification for an unwrapped driver error (`DatabaseError` with its code), an unwrapped `42501` (`DatabaseRlsError`), a wrapped failure with no SQLSTATE (`DatabaseError`, no code), and a non-database failure (`UnhandledException`).

Reverting either source file fails the new tests.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

Server-side error handling only, so the dark mode and screenshot items do not apply.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TkhyT3oiBt9fjsRF7oyJBR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of database errors occurring during transaction setup, execution, commits, and rollbacks.
  * PostgreSQL errors are now recognised more reliably, including errors wrapped by other systems or missing expected query wrappers.
  * Improved classification of permission, serialization, deadlock, query, and non-database failures.

* **Observability**
  * Enhanced safe error details and constraint detection to support more accurate troubleshooting without exposing sensitive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->