### PR TITLE
fix(api): serialize case-law maintenance scripts on one lane

### DIFF
--- a/apps/api/src/lib/case-law/maintenance-lane.db.test.ts
+++ b/apps/api/src/lib/case-law/maintenance-lane.db.test.ts
@@ -1,0 +1,78 @@
+import { SQL } from "bun";
+/**
+ * Two sessions contend for the maintenance lane on a real Postgres: the
+ * second may not start until the first releases. PGlite cannot stand in here
+ * because it serves one session, and a session-level advisory lock is only
+ * meaningful across sessions. The read-only door is proved the same way: a
+ * write through it must be refused by the server, not by a convention.
+ */
+import { describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+
+import {
+  holdCaseLawMaintenanceLane,
+  openCaseLawReadOnlySession,
+} from "@/api/lib/case-law/maintenance-lane";
+import { PG_ERROR, getPgErrorCode } from "@/api/lib/pg-error";
+
+const databaseUrl = process.env["DATABASE_URL"];
+const runPostgresTests = process.env["STELLA_RUN_POSTGRES_TESTS"] === "true";
+
+if (!databaseUrl || !runPostgresTests) {
+  describe.skip("case-law maintenance lane (postgres)", () => {
+    test("requires STELLA_RUN_POSTGRES_TESTS=true and DATABASE_URL", () => {
+      expect(true).toBe(true);
+    });
+  });
+} else {
+  describe("case-law maintenance lane (postgres)", () => {
+    test("a second pass waits until the first releases", async () => {
+      const first = await holdCaseLawMaintenanceLane({
+        sql: new SQL({ url: databaseUrl, max: 1 }),
+      });
+      const order: string[] = [];
+      const second = holdCaseLawMaintenanceLane({
+        sql: new SQL({ url: databaseUrl, max: 1 }),
+      }).then((hold) => {
+        order.push("second-entered");
+        return hold;
+      });
+      // Give the second session time to block on the lock.
+      await Bun.sleep(300);
+      order.push("first-releasing");
+      await first.release();
+      const secondHold = await second;
+      expect(order).toEqual(["first-releasing", "second-entered"]);
+      expect(secondHold.waitedMs).toBeGreaterThanOrEqual(250);
+      await secondHold.release();
+    });
+
+    test("the read-only door refuses a write with 25006", async () => {
+      const { rootDb, ingestionDb } = await openCaseLawReadOnlySession();
+      const codes: (string | undefined)[] = [];
+      for (const run of [
+        async () =>
+          await rootDb.execute(
+            sql`UPDATE case_law_sources SET last_sync_at = now() WHERE false`,
+          ),
+        async () =>
+          await ingestionDb(
+            async (tx) =>
+              await tx.execute(
+                sql`UPDATE case_law_sources SET last_sync_at = now() WHERE false`,
+              ),
+          ),
+      ]) {
+        // oxlint-disable-next-line no-await-in-loop -- two independent doors, checked in turn
+        await run().then(
+          () => codes.push(undefined),
+          (error: unknown) => codes.push(getPgErrorCode(error)),
+        );
+      }
+      expect(codes).toEqual([
+        PG_ERROR.READ_ONLY_SQL_TRANSACTION,
+        PG_ERROR.READ_ONLY_SQL_TRANSACTION,
+      ]);
+    });
+  });
+}

--- a/apps/api/src/lib/case-law/maintenance-lane.test.ts
+++ b/apps/api/src/lib/case-law/maintenance-lane.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+import {
+  CASE_LAW_MAINTENANCE_LANE,
+  holdCaseLawMaintenanceLane,
+} from "@/api/lib/case-law/maintenance-lane";
+
+const API_SRC = path.resolve(import.meta.dir, "../..");
+const SCRIPTS_DIR = path.join(API_SRC, "scripts");
+
+/** The two doors; a case-law script imports at least one, and nothing else. */
+const LANE_MODULE = "@/api/lib/case-law/maintenance-lane";
+const DOORS = [
+  "enterCaseLawMaintenanceLane",
+  "openCaseLawReadOnlySession",
+] as const;
+
+/** The handles a script must not reach for directly: the "third way". */
+const DIRECT_HANDLE_IMPORTS = [
+  /import\s*\{[^}]*\b(?:rootDb|rlsDb)\b[^}]*\}\s*from\s*"@\/api\/db\/root"/u,
+  /import\s*\{[^}]*\b(?:createIngestionDb|createScopedDb)\b[^}]*\}\s*from\s*"@\/api\/db\/scoped"/u,
+] as const;
+
+/**
+ * Modules whose direct import marks a script as a case-law script. Direct,
+ * not transitive: shared libraries reach these from almost anywhere, and a
+ * script that writes through a helper imports that helper itself.
+ */
+const CASE_LAW_MODULE_PREFIXES = [
+  "@/api/handlers/case-law/",
+  "@/api/lib/case-law/",
+  "@/api/lib/legal-search/",
+] as const;
+
+/** Direct references that mark a script as a case-law script. */
+const CASE_LAW_TABLE_MARKERS = ["case_law_", "caseLaw"] as const;
+
+/**
+ * Modules through which a script can reach the database at all. Followed
+ * transitively: a script that never imports one, directly or through a
+ * helper, issues no statements and needs no door.
+ */
+const DATABASE_MODULES = ["@/api/db/root", "@/api/db/scoped"] as const;
+
+/** How far the resolver follows imports when looking for database reach. */
+const IMPORT_DEPTH_LIMIT = 6;
+
+/**
+ * Runtime import edges only: `import type` and `export type` carry no code,
+ * so a planner that borrows a type from a storage module reaches no storage.
+ */
+const IMPORT_SPECIFIER =
+  /(?:import|export)\s+(?!type\b)[^;]*?from\s*"([^"]+)"|import\s*\(\s*"([^"]+)"\s*\)/gu;
+
+const scriptFiles = (): string[] =>
+  readdirSync(SCRIPTS_DIR)
+    .filter((name) => name.endsWith(".ts") && !name.includes(".test."))
+    .sort();
+
+const readSource = (name: string): string =>
+  readFileSync(path.join(SCRIPTS_DIR, name), "utf-8");
+
+const importBase = (fromFile: string, specifier: string): string | null => {
+  if (specifier.startsWith("@/api/")) {
+    return path.join(API_SRC, specifier.slice("@/api/".length));
+  }
+  if (specifier.startsWith(".")) {
+    return path.resolve(path.dirname(fromFile), specifier);
+  }
+  return null;
+};
+
+const resolveImport = (fromFile: string, specifier: string): string | null => {
+  const base = importBase(fromFile, specifier);
+  if (base === null) {
+    return null;
+  }
+  return (
+    [`${base}.ts`, `${base}.tsx`, path.join(base, "index.ts")].find((file) =>
+      existsSync(file),
+    ) ?? null
+  );
+};
+
+const importSpecifiers = (source: string): string[] => {
+  const found: string[] = [];
+  for (const match of source.matchAll(IMPORT_SPECIFIER)) {
+    const specifier = match[1] ?? match[2];
+    if (specifier !== undefined) {
+      found.push(specifier);
+    }
+  }
+  return found;
+};
+
+/** Every specifier reachable from a file through relative and alias imports. */
+const transitiveSpecifiers = (entry: string): Set<string> => {
+  const seen = new Set<string>();
+  const specifiers = new Set<string>();
+  const walk = (file: string, depth: number): void => {
+    if (depth > IMPORT_DEPTH_LIMIT || seen.has(file)) {
+      return;
+    }
+    seen.add(file);
+    for (const specifier of importSpecifiers(readFileSync(file, "utf-8"))) {
+      specifiers.add(specifier);
+      const resolved = resolveImport(file, specifier);
+      if (resolved !== null) {
+        walk(resolved, depth + 1);
+      }
+    }
+  };
+  walk(entry, 0);
+  return specifiers;
+};
+
+const isCaseLawScript = (name: string): boolean => {
+  const source = readSource(name);
+  return (
+    CASE_LAW_TABLE_MARKERS.some((marker) => source.includes(marker)) ||
+    importSpecifiers(source).some((specifier) =>
+      CASE_LAW_MODULE_PREFIXES.some((prefix) => specifier.startsWith(prefix)),
+    )
+  );
+};
+
+/** Whether a script can issue a statement: it imports a database module or opens a door. */
+const reachesDatabase = (name: string): boolean => {
+  const file = path.join(SCRIPTS_DIR, name);
+  const specifiers = transitiveSpecifiers(file);
+  return (
+    specifiers.has(LANE_MODULE) ||
+    DATABASE_MODULES.some((module) => specifiers.has(module))
+  );
+};
+
+const doorsImported = (source: string): string[] =>
+  source.includes(`from "${LANE_MODULE}"`)
+    ? DOORS.filter((door) => new RegExp(`\\b${door}\\b`, "u").test(source))
+    : [];
+
+describe("case-law maintenance lane", () => {
+  // The structural rule: a case-law script that can reach the database does
+  // so through one of the two doors and nothing else. A script that imports
+  // a handle directly has found a third way and fails here; one that opens
+  // no door yet reaches the database has found another, which is the same
+  // finding from the other side. Pure planners and formatters reach nothing
+  // and need nothing.
+  test("every case-law script uses a door and never a direct handle", () => {
+    const findings: string[] = [];
+    let caseLawScripts = 0;
+    for (const name of scriptFiles()) {
+      if (!isCaseLawScript(name) || !reachesDatabase(name)) {
+        continue;
+      }
+      caseLawScripts += 1;
+      const source = readSource(name);
+      if (doorsImported(source).length === 0) {
+        findings.push(`${name}: opens no door`);
+      }
+      if (DIRECT_HANDLE_IMPORTS.some((pattern) => pattern.test(source))) {
+        findings.push(`${name}: imports a database handle directly`);
+      }
+    }
+    expect(caseLawScripts).toBeGreaterThan(0);
+    expect(findings).toEqual([]);
+  });
+
+  // The inverse: a door only belongs in a case-law script, so the census
+  // cannot be padded by a tool that took the lane for no reason.
+  test("only case-law scripts open a door", () => {
+    const strays = scriptFiles().filter(
+      (name) =>
+        doorsImported(readSource(name)).length > 0 && !isCaseLawScript(name),
+    );
+    expect(strays).toEqual([]);
+  });
+
+  // The resolver must actually follow imports, or the census above is a
+  // grep in disguise: a script that writes only through an imported helper
+  // is still a case-law script.
+  test("the census follows helper imports, not only the script body", () => {
+    const source = readSource("case-law-source-total.ts");
+    expect(
+      CASE_LAW_TABLE_MARKERS.some((marker) => source.includes(marker)),
+    ).toBe(false);
+    expect(isCaseLawScript("case-law-source-total.ts")).toBe(true);
+  });
+
+  test("the lane key names its domain and lane apart from the graph lock", () => {
+    expect(CASE_LAW_MAINTENANCE_LANE).toEqual({
+      domain: "case_law",
+      lane: "maintenance",
+    });
+  });
+
+  // Session semantics on a fake lock connection: the lock statement is issued
+  // before the hold is returned, release unlocks then closes, and a release
+  // the server does not confirm is an invariant failure.
+  test("hold locks, release unlocks and closes", async () => {
+    const calls: string[] = [];
+    const fake = {
+      unsafe: async (statement: string, values?: readonly string[]) => {
+        calls.push(`${statement} ${JSON.stringify(values)}`);
+        return await Promise.resolve([{ released: true }]);
+      },
+      end: async () => {
+        calls.push("end");
+        await Promise.resolve();
+      },
+    };
+    const hold = await holdCaseLawMaintenanceLane({ sql: fake, now: () => 0 });
+    expect(hold.waitedMs).toBe(0);
+    expect(calls).toEqual([
+      'SELECT pg_advisory_lock(hashtext($1), hashtext($2)) ["case_law","maintenance"]',
+    ]);
+    await hold.release();
+    expect(calls.at(-2)).toBe(
+      'SELECT pg_advisory_unlock(hashtext($1), hashtext($2)) AS released ["case_law","maintenance"]',
+    );
+    expect(calls.at(-1)).toBe("end");
+  });
+
+  test("a release the server does not confirm panics", async () => {
+    const fake = {
+      unsafe: async (statement: string) =>
+        await Promise.resolve(
+          statement.includes("unlock") ? [{ released: false }] : [],
+        ),
+      end: async () => {
+        await Promise.resolve();
+      },
+    };
+    const hold = await holdCaseLawMaintenanceLane({ sql: fake, now: () => 0 });
+    expect(hold.release()).rejects.toThrow("Maintenance lane was not held");
+  });
+});

--- a/apps/api/src/lib/case-law/maintenance-lane.ts
+++ b/apps/api/src/lib/case-law/maintenance-lane.ts
@@ -1,0 +1,243 @@
+/**
+ * The only two doors through which an operator script reaches the case-law
+ * tables.
+ *
+ * Two passes that each behave on their own can still deadlock together: a
+ * row-by-row backfill holds row locks on `case_law_decisions` while a citation
+ * pass takes `FOR KEY SHARE` on the same rows for its foreign keys. Neither
+ * script can know the other is running, so the guarantee lives in the
+ * database: every writing pass takes one session-level advisory lock before
+ * its first statement, and a second pass waits at the door instead of
+ * interleaving.
+ *
+ * A script does not import a database handle; it asks one of these two
+ * functions for one, so there is no third way to reach the tables:
+ *
+ * - `enterCaseLawMaintenanceLane()` holds the lane and hands out the
+ *   write-capable handles.
+ * - `openCaseLawReadOnlySession()` hands out handles whose every transaction
+ *   is `READ ONLY`. A helper that writes through one fails with SQLSTATE
+ *   25006 at the first statement, so a script that claims to only read
+ *   cannot quietly become a writer that skipped the lane.
+ *
+ * Both return the same shape, so a script with a plan mode and an apply mode
+ * picks its door after parsing arguments and runs one body against either.
+ *
+ * This is a different lock from `lockCitationGraph` in the resolver. That one
+ * is transaction-scoped and serializes the standing walk's batches against
+ * ingestion; this one is session-scoped and serializes whole operator runs
+ * against each other. A pass that also writes the graph still takes the graph
+ * lock inside its transactions.
+ *
+ * The lane holds its own single connection for the life of the process, so
+ * the lock cannot be lost to pool recycling. Postgres releases a session
+ * advisory lock when that session ends, and every script ends with
+ * `process.exit`, so there is nothing to unlock by hand.
+ */
+
+import { panic } from "better-result";
+import { SQL } from "bun";
+import { sql } from "drizzle-orm";
+import type { SQLWrapper } from "drizzle-orm";
+
+import type { rootDb as rootDatabase, Transaction } from "@/api/db/root";
+import { logger } from "@/api/lib/observability/logger";
+
+/**
+ * The lane's advisory-lock key, as the `(int, int)` form of
+ * `pg_advisory_lock`. The two halves name the domain and the lane so a reader
+ * of `pg_locks` can tell it from the resolver's graph lock.
+ */
+export const CASE_LAW_MAINTENANCE_LANE = {
+  domain: "case_law",
+  lane: "maintenance",
+} as const;
+
+/** Waits longer than this are logged so a stuck pass is visible. */
+export const MAINTENANCE_LANE_WAIT_LOG_MS = 30_000;
+
+/** What `execute` resolves to for a row shape, as the drizzle instance types it. */
+type ExecuteResult<TRow extends Record<string, unknown>> = Awaited<
+  ReturnType<typeof rootDatabase.execute<TRow>>
+>;
+
+/** A root-connection handle: the subset scripts use of the drizzle instance. */
+export type CaseLawRootHandle = {
+  execute: <TRow extends Record<string, unknown> = Record<string, unknown>>(
+    query: SQLWrapper | string,
+  ) => PromiseLike<ExecuteResult<TRow>>;
+  transaction: <T>(fn: (tx: Transaction) => Promise<T>) => Promise<T>;
+};
+
+/** A transaction runner that sets the ingestion role, as the pipeline uses. */
+export type CaseLawIngestionHandle = <T>(
+  fn: (tx: Transaction) => Promise<T>,
+) => Promise<T>;
+
+/**
+ * What either door hands a script. The lane's `rootDb` is the full drizzle
+ * instance; the read-only door's is the narrow handle. A script with both a
+ * plan and an apply mode writes its body against the narrow shape, which
+ * both satisfy.
+ */
+export type CaseLawScriptHandles = {
+  rootDb: CaseLawRootHandle;
+  ingestionDb: CaseLawIngestionHandle;
+};
+
+export type CaseLawWriteHandles = {
+  rootDb: typeof rootDatabase;
+  ingestionDb: CaseLawIngestionHandle;
+};
+
+/** The held lane: what `holdCaseLawMaintenanceLane` returns. */
+export type MaintenanceLaneHold = {
+  /** Releases the lane and closes its connection. */
+  release: () => Promise<void>;
+  /** How long the lane was contended before this session held it. */
+  waitedMs: number;
+};
+
+export type MaintenanceLaneSession = CaseLawWriteHandles & MaintenanceLaneHold;
+
+/**
+ * The two members the lane needs from its lock connection. Structural, so a
+ * test can hand in a fake without importing Bun's client type.
+ */
+export type MaintenanceLaneSql = {
+  unsafe: (
+    statement: string,
+    values?: readonly string[],
+  ) => PromiseLike<readonly Record<string, unknown>[]>;
+  end: () => Promise<void>;
+};
+
+type HoldLaneOptions = {
+  /** Lock connection override for tests; scripts open one on DATABASE_URL. */
+  sql?: MaintenanceLaneSql;
+  /** Clock override for tests. */
+  now?: () => number;
+};
+
+// Read lazily, not at import: the env and root modules connect on load, and a
+// test that only exercises the session logic must import this module without
+// an environment.
+const openLaneConnection = async (): Promise<MaintenanceLaneSql> => {
+  const { envBase } = await import("@/api/env-base");
+  return new SQL({ url: envBase.DATABASE_URL, max: 1 });
+};
+
+const loadWriteHandles = async (): Promise<CaseLawWriteHandles> => {
+  const { rlsDb, rootDb } = await import("@/api/db/root");
+  const { createIngestionDb } = await import("@/api/db/scoped");
+  return { rootDb, ingestionDb: createIngestionDb(rlsDb) };
+};
+
+/**
+ * Take the lane on a dedicated connection and hold it until released or the
+ * process ends. The lock half of `enterCaseLawMaintenanceLane`, separate so
+ * its session semantics can be exercised without a database.
+ */
+export const holdCaseLawMaintenanceLane = async ({
+  sql: providedSql,
+  now = Date.now,
+}: HoldLaneOptions = {}): Promise<MaintenanceLaneHold> => {
+  const lock = providedSql ?? (await openLaneConnection());
+  const startedAt = now();
+  // One warning while still waiting, so an operator watching the log learns
+  // the pass is queued behind another rather than hung.
+  const warnTimer = setTimeout(() => {
+    logger.warn("case_law.maintenance_lane.waiting", {
+      "maintenanceLane.waitMs": now() - startedAt,
+    });
+  }, MAINTENANCE_LANE_WAIT_LOG_MS);
+  try {
+    await lock.unsafe("SELECT pg_advisory_lock(hashtext($1), hashtext($2))", [
+      CASE_LAW_MAINTENANCE_LANE.domain,
+      CASE_LAW_MAINTENANCE_LANE.lane,
+    ]);
+  } finally {
+    clearTimeout(warnTimer);
+  }
+  const waitedMs = now() - startedAt;
+  if (waitedMs >= MAINTENANCE_LANE_WAIT_LOG_MS) {
+    logger.info("case_law.maintenance_lane.acquired", {
+      "maintenanceLane.waitMs": waitedMs,
+    });
+  }
+  return {
+    waitedMs,
+    release: async () => {
+      const rows = await lock.unsafe(
+        "SELECT pg_advisory_unlock(hashtext($1), hashtext($2)) AS released",
+        [CASE_LAW_MAINTENANCE_LANE.domain, CASE_LAW_MAINTENANCE_LANE.lane],
+      );
+      const released = rows.at(0)?.["released"];
+      if (released !== true) {
+        panic("Maintenance lane was not held by this session at release");
+      }
+      await lock.end();
+    },
+  };
+};
+
+/**
+ * Hold the maintenance lane for the rest of this process and receive the
+ * write-capable handles.
+ *
+ * Call it before the script's first database statement. It blocks until any
+ * other pass has finished. Release is only needed by tests; a script's
+ * `process.exit` ends the session and the lock with it.
+ */
+export const enterCaseLawMaintenanceLane =
+  async (): Promise<MaintenanceLaneSession> => {
+    const hold = await holdCaseLawMaintenanceLane();
+    const handles = await loadWriteHandles();
+    return { ...handles, ...hold };
+  };
+
+type ReadOnlySessionOptions = {
+  /** Handle override for tests. */
+  handles?: CaseLawScriptHandles;
+};
+
+/**
+ * Wrap both handles so every transaction is `READ ONLY`. `execute` outside a
+ * transaction runs inside one, so there is no path around the setting.
+ */
+export const readOnlyHandles = ({
+  rootDb,
+  ingestionDb,
+}: CaseLawScriptHandles): CaseLawScriptHandles => {
+  const readOnlyTransaction = async <T>(
+    fn: (tx: Transaction) => Promise<T>,
+  ): Promise<T> =>
+    await rootDb.transaction(async (tx) => {
+      await tx.execute(sql`SET TRANSACTION READ ONLY`);
+      return await fn(tx);
+    });
+  return {
+    rootDb: {
+      transaction: readOnlyTransaction,
+      execute: async <TRow extends Record<string, unknown>>(
+        query: SQLWrapper | string,
+      ) =>
+        await readOnlyTransaction(async (tx) => await tx.execute<TRow>(query)),
+    },
+    ingestionDb: async (fn) =>
+      await ingestionDb(async (tx) => {
+        await tx.execute(sql`SET TRANSACTION READ ONLY`);
+        return await fn(tx);
+      }),
+  };
+};
+
+/**
+ * Handles for a pass that only reads. No lane is taken, so a long report or
+ * planning run never blocks a writer; the `READ ONLY` transactions are what
+ * make that claim true rather than trusted.
+ */
+export const openCaseLawReadOnlySession = async ({
+  handles,
+}: ReadOnlySessionOptions = {}): Promise<CaseLawScriptHandles> =>
+  readOnlyHandles(handles ?? (await loadWriteHandles()));

--- a/apps/api/src/lib/pg-error.ts
+++ b/apps/api/src/lib/pg-error.ts
@@ -63,6 +63,7 @@ export const PG_ERROR = {
   SERIALIZATION_FAILURE: "40001",
   UNIQUE_VIOLATION: "23505",
   INSUFFICIENT_PRIVILEGE: "42501",
+  READ_ONLY_SQL_TRANSACTION: "25006",
 } as const;
 
 // A SQLSTATE is exactly five characters from the class/subclass alphabet

--- a/apps/api/src/scripts/adapter-health.ts
+++ b/apps/api/src/scripts/adapter-health.ts
@@ -17,7 +17,6 @@
 import { panic } from "better-result";
 import { count, eq, gt, sql } from "drizzle-orm";
 
-import { rootDb } from "@/api/db/root";
 import {
   caseLawCitations,
   caseLawDecisions,
@@ -28,6 +27,7 @@ import {
   listAdapterKeys,
   loadAdapterByKey,
 } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry-lazy";
+import { openCaseLawReadOnlySession } from "@/api/lib/case-law/maintenance-lane";
 import { boundedAll } from "@/api/lib/db/bounded-all";
 import {
   CASE_LAW_SOURCE_ROWS_BOUND,
@@ -40,6 +40,9 @@ import {
 } from "@/api/lib/legal-search/source-registry-membership";
 import { isRecord } from "@/api/lib/type-guards";
 
+// This tool only reads; the read-only session makes that a property of every
+// transaction rather than a promise, and takes no maintenance lane.
+const { rootDb } = await openCaseLawReadOnlySession();
 // ── Types ───────────────────────────────────────────────
 
 type FieldCoverage = {
@@ -259,83 +262,93 @@ const getSources = async () =>
     invariant: CASE_LAW_SOURCE_ROWS_INVARIANT,
     max: CASE_LAW_SOURCE_ROWS_BOUND,
     table: "case_law_sources",
-    query: (limit) =>
-      rootDb
-        .select({
-          id: caseLawSources.id,
-          adapterKey: caseLawSources.adapterKey,
-          name: caseLawSources.name,
-          enabled: caseLawSources.enabled,
-          syncCursor: caseLawSources.syncCursor,
-          lastSyncAt: caseLawSources.lastSyncAt,
-        })
-        .from(caseLawSources)
-        .orderBy(caseLawSources.adapterKey)
-        .limit(limit),
+    query: async (limit) =>
+      await rootDb.transaction(async (tx) =>
+        tx
+          .select({
+            id: caseLawSources.id,
+            adapterKey: caseLawSources.adapterKey,
+            name: caseLawSources.name,
+            enabled: caseLawSources.enabled,
+            syncCursor: caseLawSources.syncCursor,
+            lastSyncAt: caseLawSources.lastSyncAt,
+          })
+          .from(caseLawSources)
+          .orderBy(caseLawSources.adapterKey)
+          .limit(limit),
+      ),
   });
 
-const getDecisionCounts = () =>
-  rootDb
-    .select({
-      sourceId: caseLawDecisions.sourceId,
-      total: count(),
-    })
-    .from(caseLawDecisions)
-    .groupBy(caseLawDecisions.sourceId);
+const getDecisionCounts = async () =>
+  await rootDb.transaction(async (tx) =>
+    tx
+      .select({
+        sourceId: caseLawDecisions.sourceId,
+        total: count(),
+      })
+      .from(caseLawDecisions)
+      .groupBy(caseLawDecisions.sourceId),
+  );
 
-const getGrowthCounts = (sinceDate: Date) =>
-  rootDb
-    .select({
-      sourceId: caseLawDecisions.sourceId,
-      inserted: count(),
-    })
-    .from(caseLawDecisions)
-    // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- caller-supplied filter bound, never round-tripped through the database
-    .where(gt(caseLawDecisions.createdAt, sinceDate))
-    .groupBy(caseLawDecisions.sourceId);
+const getGrowthCounts = async (sinceDate: Date) =>
+  await rootDb.transaction(async (tx) =>
+    tx
+      .select({
+        sourceId: caseLawDecisions.sourceId,
+        inserted: count(),
+      })
+      .from(caseLawDecisions)
+      // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- caller-supplied filter bound, never round-tripped through the database
+      .where(gt(caseLawDecisions.createdAt, sinceDate))
+      .groupBy(caseLawDecisions.sourceId),
+  );
 
-const getSearchIndexCoverage = () =>
-  rootDb
-    .select({
-      sourceId: caseLawDecisions.sourceId,
-      isIndexed:
-        sql<boolean>`${caseLawSearchDocuments.decisionId} IS NOT NULL`.as(
-          "is_indexed",
-        ),
-      cnt: count(),
-    })
-    .from(caseLawDecisions)
-    .leftJoin(
-      caseLawSearchDocuments,
-      eq(caseLawDecisions.id, caseLawSearchDocuments.decisionId),
-    )
-    .groupBy(
-      caseLawDecisions.sourceId,
-      sql`${caseLawSearchDocuments.decisionId} IS NOT NULL`,
-    );
+const getSearchIndexCoverage = async () =>
+  await rootDb.transaction(async (tx) =>
+    tx
+      .select({
+        sourceId: caseLawDecisions.sourceId,
+        isIndexed:
+          sql<boolean>`${caseLawSearchDocuments.decisionId} IS NOT NULL`.as(
+            "is_indexed",
+          ),
+        cnt: count(),
+      })
+      .from(caseLawDecisions)
+      .leftJoin(
+        caseLawSearchDocuments,
+        eq(caseLawDecisions.id, caseLawSearchDocuments.decisionId),
+      )
+      .groupBy(
+        caseLawDecisions.sourceId,
+        sql`${caseLawSearchDocuments.decisionId} IS NOT NULL`,
+      ),
+  );
 
-const getCitationStats = () =>
-  rootDb
-    .select({
-      sourceId: caseLawDecisions.sourceId,
-      total: count(),
-      resolved:
-        sql<number>`COUNT(*) FILTER (WHERE ${caseLawCitations.citedDecisionId} IS NOT NULL)`.as(
-          "resolved",
-        ),
-    })
-    .from(caseLawCitations)
-    .innerJoin(
-      caseLawDecisions,
-      eq(caseLawCitations.citingDecisionId, caseLawDecisions.id),
-    )
-    .groupBy(caseLawDecisions.sourceId);
+const getCitationStats = async () =>
+  await rootDb.transaction(async (tx) =>
+    tx
+      .select({
+        sourceId: caseLawDecisions.sourceId,
+        total: count(),
+        resolved:
+          sql<number>`COUNT(*) FILTER (WHERE ${caseLawCitations.citedDecisionId} IS NOT NULL)`.as(
+            "resolved",
+          ),
+      })
+      .from(caseLawCitations)
+      .innerJoin(
+        caseLawDecisions,
+        eq(caseLawCitations.citingDecisionId, caseLawDecisions.id),
+      )
+      .groupBy(caseLawDecisions.sourceId),
+  );
 
 /**
  * Single query: counts non-null/non-empty values for all
  * checked fields per source, avoiding N+1 per-field queries.
  */
-const getAllFieldCoverage = () => {
+const getAllFieldCoverage = async () => {
   const fieldColumns = Object.fromEntries(
     CHECKED_FIELDS.map((field) => {
       const col = FIELD_COLUMN_MAP[field];
@@ -348,14 +361,16 @@ const getAllFieldCoverage = () => {
     }),
   );
 
-  return rootDb
-    .select({
-      sourceId: caseLawDecisions.sourceId,
-      total: count(),
-      ...fieldColumns,
-    })
-    .from(caseLawDecisions)
-    .groupBy(caseLawDecisions.sourceId);
+  return await rootDb.transaction(async (tx) =>
+    tx
+      .select({
+        sourceId: caseLawDecisions.sourceId,
+        total: count(),
+        ...fieldColumns,
+      })
+      .from(caseLawDecisions)
+      .groupBy(caseLawDecisions.sourceId),
+  );
 };
 
 const parseFieldCoverage = (

--- a/apps/api/src/scripts/backfill-case-law-slugs.ts
+++ b/apps/api/src/scripts/backfill-case-law-slugs.ts
@@ -1,4 +1,3 @@
-import { rlsDb } from "@/api/db/root";
 /**
  * Backfill: assign a unique public slug to every case_law_decisions row
  * that predates slug-at-ingest. Run once before launching the public
@@ -10,12 +9,15 @@ import { rlsDb } from "@/api/db/root";
  * Slug assignment reuses the same helper the ingestion pipeline and the
  * dev seed use, so there is a single source of truth for the slug algorithm.
  */
-import { createIngestionDb } from "@/api/db/scoped";
 import { backfillCaseLawSlugs } from "@/api/handlers/case-law/decisions/slug-backfill";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { ingestionDb } = await enterCaseLawMaintenanceLane();
 
 console.log("=== BACKFILL CASE-LAW SLUGS ===");
 
-const ingestionDb = createIngestionDb(rlsDb);
 const { written, failed } = await backfillCaseLawSlugs(ingestionDb);
 
 console.log(`Done. Wrote ${written} slugs, ${failed} failed.`);

--- a/apps/api/src/scripts/backfill-citation-authority.ts
+++ b/apps/api/src/scripts/backfill-citation-authority.ts
@@ -26,9 +26,13 @@
  */
 import { panic } from "better-result";
 
-import { rootDb } from "@/api/db/root";
 import { recomputeCitationAuthorityBatch } from "@/api/handlers/case-law/citation-authority";
 import { loadCourtWeightEntriesForSql } from "@/api/handlers/case-law/court-weights";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { rootDb } = await enterCaseLawMaintenanceLane();
 
 /**
  * A flag's value, or undefined when the flag is absent.

--- a/apps/api/src/scripts/backfill-citation-keys.ts
+++ b/apps/api/src/scripts/backfill-citation-keys.ts
@@ -18,10 +18,14 @@
 
 import { sql } from "drizzle-orm";
 
-import { rootDb } from "@/api/db/root";
 import { reopenCitationsForKeys } from "@/api/handlers/case-law/citation-resolution";
 import { citationKeyOf } from "@/api/handlers/case-law/ingestion/citation-extractor";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
 import { isRecord } from "@/api/lib/type-guards";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { rootDb } = await enterCaseLawMaintenanceLane();
 
 const BATCH = 5000;
 

--- a/apps/api/src/scripts/backfill-corpus-storage.ts
+++ b/apps/api/src/scripts/backfill-corpus-storage.ts
@@ -35,14 +35,13 @@ import type { SQL } from "drizzle-orm";
  */
 import type { DocumentAst } from "@stll/legal-ast/document-ast";
 
-import { rlsDb } from "@/api/db/root";
 import {
   CASE_LAW_CORPUS_MIRROR_STATUS,
   caseLawDecisions,
 } from "@/api/db/schema";
-import { createIngestionDb } from "@/api/db/scoped";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
 import {
   timestampCasToken,
   type TimestampCasToken,
@@ -64,6 +63,10 @@ import type {
   EmptyAst,
 } from "@/api/lib/legal-search/document-types";
 import { refreshCorpusS3, refreshS3 } from "@/api/lib/s3";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { ingestionDb } = await enterCaseLawMaintenanceLane();
 
 const BATCH_SIZE = 50;
 const CONCURRENCY = 4;
@@ -105,8 +108,6 @@ const eligibleForBackfill = and(
   rowsToBackfill,
   isNull(caseLawDecisions.redactedAt),
 );
-
-const ingestionDb = createIngestionDb(rlsDb);
 
 await refreshS3();
 await refreshCorpusS3();

--- a/apps/api/src/scripts/backfill-fulltext.ts
+++ b/apps/api/src/scripts/backfill-fulltext.ts
@@ -11,12 +11,16 @@
 
 import { eq, sql } from "drizzle-orm";
 
-import { rootDb } from "@/api/db/root";
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
 import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
 import { stripHtml } from "@/api/handlers/case-law/ingestion/adapters/utils";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { restrictOutboundUrl } from "@/api/lib/restrict-outbound-url";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { rootDb } = await enterCaseLawMaintenanceLane();
 
 const BATCH_SIZE = 50;
 

--- a/apps/api/src/scripts/backfill-source-document-ids.ts
+++ b/apps/api/src/scripts/backfill-source-document-ids.ts
@@ -23,8 +23,12 @@
 
 import { sql } from "drizzle-orm";
 
-import { rootDb } from "@/api/db/root";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
 import { isRecord } from "@/api/lib/type-guards";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { rootDb } = await enterCaseLawMaintenanceLane();
 
 const BATCH = 2000;
 

--- a/apps/api/src/scripts/build-corpus-index.ts
+++ b/apps/api/src/scripts/build-corpus-index.ts
@@ -1,4 +1,3 @@
-import { rlsDb } from "@/api/db/root";
 /**
  * Full backfill of the legal corpus into corpus index. Per-jurisdiction
  * indexes (`case_law_v1_<country>`) are created on demand by the indexer,
@@ -24,9 +23,9 @@ import { rlsDb } from "@/api/db/root";
  *   CORPUS_INDEX_ENDPOINT=... CORPUS_STORAGE_MODE=dual-write \
  *     bun run src/scripts/build-corpus-index.ts [generation]
  */
-import { createIngestionDb } from "@/api/db/scoped";
 import { envBase } from "@/api/env-base";
 import { backfillCorpusIndexGenerationPage } from "@/api/handlers/case-law/corpus-index";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
 import {
   createBackfillPacer,
   createCloudWatchBackpressureSampler,
@@ -36,8 +35,11 @@ import { CorpusIndexError } from "@/api/lib/legal-search/corpus-index-client";
 import { LIMITS } from "@/api/lib/limits";
 import { refreshCorpusS3, refreshS3 } from "@/api/lib/s3";
 
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { ingestionDb } = await enterCaseLawMaintenanceLane();
+
 const generation = process.argv[2] ?? envBase.LEGAL_SEARCH_INDEX_GENERATION;
-const ingestionDb = createIngestionDb(rlsDb);
 
 await refreshS3();
 await refreshCorpusS3();

--- a/apps/api/src/scripts/build-expansion-dictionary.ts
+++ b/apps/api/src/scripts/build-expansion-dictionary.ts
@@ -24,8 +24,7 @@
  */
 import { sql } from "drizzle-orm";
 
-import { rlsDb } from "@/api/db/root";
-import { createIngestionDb } from "@/api/db/scoped";
+import { openCaseLawReadOnlySession } from "@/api/lib/case-law/maintenance-lane";
 import { zstdCompress } from "@/api/lib/compression";
 import {
   type ExpansionBucket,
@@ -144,7 +143,9 @@ const maxVocabulary = positiveInteger(
   "max-vocabulary",
 );
 
-const ingestionDb = createIngestionDb(rlsDb);
+// This tool only reads; the read-only session makes that a property of every
+// transaction rather than a promise, and takes no maintenance lane.
+const { ingestionDb } = await openCaseLawReadOnlySession();
 
 /** The keyset floor: uuids order lexically, so the nil uuid precedes them all. */
 const NIL_UUID = "00000000-0000-0000-0000-000000000000";

--- a/apps/api/src/scripts/case-law-reconciliation-items.ts
+++ b/apps/api/src/scripts/case-law-reconciliation-items.ts
@@ -1,6 +1,5 @@
 import { eq } from "drizzle-orm";
 
-import { rlsDb } from "@/api/db/root";
 import { caseLawSources } from "@/api/db/schema";
 /**
  * Read and un-retire the items the standing reconciliation loop is carrying.
@@ -39,13 +38,17 @@ import { caseLawSources } from "@/api/db/schema";
  * documents already proved unservable, so it runs under an operator who read
  * the listing and fixed the cause.
  */
-import { createIngestionDb } from "@/api/db/scoped";
 import { listAdapterKeys } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
 import {
   countReconciliationItems,
   listReconciliationItems,
   resetTerminalReconciliationItems,
 } from "@/api/lib/legal-search/reconciliation-store";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { ingestionDb } = await enterCaseLawMaintenanceLane();
 
 /** Bounded by default: both modes read, and neither should scan a corpus. */
 const DEFAULT_LIMIT = 50;
@@ -136,8 +139,6 @@ const limit = (() => {
   }
   return parsed;
 })();
-
-const ingestionDb = createIngestionDb(rlsDb);
 
 const source = (
   await ingestionDb((tx) =>

--- a/apps/api/src/scripts/case-law-source-total.ts
+++ b/apps/api/src/scripts/case-law-source-total.ts
@@ -1,8 +1,6 @@
 import { panic } from "better-result";
 
-import { rlsDb } from "@/api/db/root";
 import { SOURCE_TOTAL_ORIGIN } from "@/api/db/schema";
-import { createIngestionDb } from "@/api/db/scoped";
 import {
   getAdapter,
   listAdapterKeys,
@@ -11,6 +9,10 @@ import {
   readSourceReportedTotals,
   setSourceReportedTotal,
 } from "@/api/handlers/case-law/ingestion/source-totals";
+import {
+  enterCaseLawMaintenanceLane,
+  openCaseLawReadOnlySession,
+} from "@/api/lib/case-law/maintenance-lane";
 import { isoCalendarDay } from "@/api/lib/dates";
 
 /**
@@ -125,7 +127,11 @@ const asOf = (() => {
   return new Date(`${day}T00:00:00.000Z`);
 })();
 
-const ingestionDb = createIngestionDb(rlsDb);
+// --list only reads, so it takes no lane; --total and --poll record a figure
+// and serialize with every other writing pass.
+const { ingestionDb } = list
+  ? await openCaseLawReadOnlySession()
+  : await enterCaseLawMaintenanceLane();
 
 if (list) {
   const rows = await readSourceReportedTotals(ingestionDb);

--- a/apps/api/src/scripts/corpus-column-trim.ts
+++ b/apps/api/src/scripts/corpus-column-trim.ts
@@ -51,13 +51,15 @@ import type { SQL } from "drizzle-orm";
  */
 import type { DocumentAst } from "@stll/legal-ast/document-ast";
 
-import { rlsDb } from "@/api/db/root";
 import { caseLawDecisions, caseLawSearchDocuments } from "@/api/db/schema";
-import { createIngestionDb } from "@/api/db/scoped";
 import { corpusStorageMode } from "@/api/env-base";
 import { payloadCarriesDocument } from "@/api/handlers/case-law/stored-payload";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
+import {
+  enterCaseLawMaintenanceLane,
+  openCaseLawReadOnlySession,
+} from "@/api/lib/case-law/maintenance-lane";
 import {
   timestampCasToken,
   type TimestampCasToken,
@@ -143,7 +145,11 @@ if (gate.type === "refused") {
   process.exit(2);
 }
 
-const ingestionDb = createIngestionDb(rlsDb);
+// A dry run only reads, so it takes no lane and cannot block a writer; the
+// read-only session makes that a property of the connection, not a promise.
+const { ingestionDb } = dryRun
+  ? await openCaseLawReadOnlySession()
+  : await enterCaseLawMaintenanceLane();
 
 await refreshS3();
 await refreshCorpusS3();

--- a/apps/api/src/scripts/cz-regional-repair.ts
+++ b/apps/api/src/scripts/cz-regional-repair.ts
@@ -1,9 +1,7 @@
 import { panic } from "better-result";
 import { and, eq, inArray, isNull } from "drizzle-orm";
 
-import { rlsDb } from "@/api/db/root";
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
-import { createIngestionDb } from "@/api/db/scoped";
 import type {
   CzRegionalApiItem,
   CzRegionalDayPage,
@@ -18,6 +16,10 @@ import {
   PROCESS_DECISION_STATUS,
   processDecision,
 } from "@/api/handlers/case-law/ingestion/pipeline";
+import {
+  enterCaseLawMaintenanceLane,
+  openCaseLawReadOnlySession,
+} from "@/api/lib/case-law/maintenance-lane";
 import { acquireCaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
 import type { CaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
 import { ADAPTER_KEYS } from "@/api/lib/legal-search/ingestion-constants";
@@ -251,7 +253,11 @@ if (suppliedItems === null) {
   console.log(`items file:  ${itemsFilePath} (${suppliedItems.length} items)`);
 }
 
-const ingestionDb = createIngestionDb(rlsDb);
+// A plan run only reads, so it takes no lane and cannot block a writer; the
+// read-only session makes that a property of the connection, not a promise.
+const { ingestionDb } = apply
+  ? await enterCaseLawMaintenanceLane()
+  : await openCaseLawReadOnlySession();
 
 const source = (
   await ingestionDb((tx) =>

--- a/apps/api/src/scripts/eu-ecj-census.ts
+++ b/apps/api/src/scripts/eu-ecj-census.ts
@@ -1,14 +1,13 @@
 import { and, eq, gt, sql } from "drizzle-orm";
 
-import { rlsDb } from "@/api/db/root";
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
-import { createIngestionDb } from "@/api/db/scoped";
 import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
 import {
   ECJ_LISTING_TIMEOUT_MS,
   listCelexVariants,
 } from "@/api/handlers/case-law/ingestion/adapters/eu-ecj";
 import type { SafeId } from "@/api/lib/branded-types";
+import { openCaseLawReadOnlySession } from "@/api/lib/case-law/maintenance-lane";
 
 /**
  * Classify every stored eu-ecj decision against Cellar's own listing.
@@ -101,7 +100,9 @@ const sparqlChunk = Math.min(
   MAX_SPARQL_CHUNK,
 );
 
-const ingestionDb = createIngestionDb(rlsDb);
+// This tool only reads; the read-only session makes that a property of every
+// transaction rather than a promise, and takes no maintenance lane.
+const { ingestionDb } = await openCaseLawReadOnlySession();
 
 const source = (
   await ingestionDb((tx) =>

--- a/apps/api/src/scripts/eu-ecj-refetch.ts
+++ b/apps/api/src/scripts/eu-ecj-refetch.ts
@@ -1,8 +1,6 @@
 import { eq } from "drizzle-orm";
 
-import { rlsDb } from "@/api/db/root";
 import { caseLawSources } from "@/api/db/schema";
-import { createIngestionDb } from "@/api/db/scoped";
 import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
 import {
   ECJ_LISTING_TIMEOUT_MS,
@@ -16,8 +14,13 @@ import {
   PROCESS_DECISION_STATUS,
   processDecision,
 } from "@/api/handlers/case-law/ingestion/pipeline";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
 import { acquireCaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
 import { refreshCorpusS3, refreshS3 } from "@/api/lib/s3";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { ingestionDb } = await enterCaseLawMaintenanceLane();
 
 /**
  * Re-fetch named CJEU decisions from Cellar and run them through the
@@ -200,7 +203,6 @@ if (!apply) {
   process.exit(0);
 }
 
-const ingestionDb = createIngestionDb(rlsDb);
 await refreshS3();
 await refreshCorpusS3();
 

--- a/apps/api/src/scripts/normalize-case-numbers.ts
+++ b/apps/api/src/scripts/normalize-case-numbers.ts
@@ -22,13 +22,17 @@
  *   bun apps/api/src/scripts/normalize-case-numbers.ts --dry-run
  */
 
-import { rootDb } from "@/api/db/root";
 import { lockCitationGraph } from "@/api/handlers/case-law/citation-resolution";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
 import { isRecord } from "@/api/lib/type-guards";
 import {
   normalizeSheetNumbersStatement,
   sheetNumberSurveyStatement,
 } from "@/api/scripts/normalize-case-numbers-sql";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { rootDb } = await enterCaseLawMaintenanceLane();
 
 const BATCH = 2000;
 const DRY_RUN = process.argv.includes("--dry-run");

--- a/apps/api/src/scripts/readjudicate-ambiguous-citations.ts
+++ b/apps/api/src/scripts/readjudicate-ambiguous-citations.ts
@@ -15,13 +15,17 @@
 
 import { panic } from "better-result";
 
-import { rootDb } from "@/api/db/root";
 import {
   type CitationResolutionCursor,
   readjudicateAmbiguousCitations,
 } from "@/api/handlers/case-law/citation-resolution";
 import { CITATION_RESOLUTION_RULE } from "@/api/handlers/case-law/citation-resolution-status";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
 import { isUuid } from "@/api/lib/custom-schema";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { rootDb } = await enterCaseLawMaintenanceLane();
 
 const BATCH = 2000;
 

--- a/apps/api/src/scripts/redact-case-law-decision.ts
+++ b/apps/api/src/scripts/redact-case-law-decision.ts
@@ -1,6 +1,5 @@
 import { panic } from "better-result";
 
-import { rlsDb } from "@/api/db/root";
 /**
  * GDPR redaction / takedown for a single case-law decision: strips
  * personal text from corpus index, the pg-fts index, object storage, and the
@@ -8,11 +7,15 @@ import { rlsDb } from "@/api/db/root";
  *
  *   bun run src/scripts/redact-case-law-decision.ts <decisionId>
  */
-import { createIngestionDb } from "@/api/db/scoped";
 import { redactCaseLawDecision } from "@/api/handlers/case-law/erasure";
 // eslint-disable-next-line no-restricted-imports -- CLI boundary: brands the decision id parsed from argv
 import { toSafeId } from "@/api/lib/branded-types";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
 import { refreshCorpusS3, refreshS3 } from "@/api/lib/s3";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { ingestionDb } = await enterCaseLawMaintenanceLane();
 
 const decisionIdArg = process.argv[2];
 if (decisionIdArg === undefined || decisionIdArg.length === 0) {
@@ -22,7 +25,6 @@ if (decisionIdArg === undefined || decisionIdArg.length === 0) {
   process.exit(1);
 }
 
-const ingestionDb = createIngestionDb(rlsDb);
 await refreshS3();
 await refreshCorpusS3();
 

--- a/apps/api/src/scripts/repair-case-law-jsonb.ts
+++ b/apps/api/src/scripts/repair-case-law-jsonb.ts
@@ -34,7 +34,11 @@
 
 import { sql } from "drizzle-orm";
 
-import { rootDb } from "@/api/db/root";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { rootDb } = await enterCaseLawMaintenanceLane();
 
 const BATCH_SIZE = 2000;
 const STATEMENT_TIMEOUT_MS = 120_000;

--- a/apps/api/src/scripts/repair-corpus-index-jurisdiction.ts
+++ b/apps/api/src/scripts/repair-corpus-index-jurisdiction.ts
@@ -28,9 +28,8 @@
  */
 import { panic } from "better-result";
 
-import { rlsDb } from "@/api/db/root";
-import { createIngestionDb } from "@/api/db/scoped";
 import { envBase } from "@/api/env-base";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
 import {
   censusIndex,
   clearIndexMarks,
@@ -40,6 +39,10 @@ import {
   corpusIndexId,
   isCorpusIndexJurisdiction,
 } from "@/api/lib/legal-search/index-naming";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { ingestionDb } = await enterCaseLawMaintenanceLane();
 
 const jurisdiction = process.argv[2];
 if (jurisdiction === undefined || !isCorpusIndexJurisdiction(jurisdiction)) {
@@ -62,7 +65,6 @@ if (!Number.isSafeInteger(limit) || limit <= 0 || limit > MAX_REPAIR_SLICE) {
 
 const generation = envBase.LEGAL_SEARCH_INDEX_GENERATION;
 const indexId = corpusIndexId(generation, jurisdiction);
-const ingestionDb = createIngestionDb(rlsDb);
 
 // Reported before and after so the operator sees the shortfall the repair
 // was pointed at, rather than trusting the alert that sent them here.

--- a/apps/api/src/scripts/repair-decision-dates.ts
+++ b/apps/api/src/scripts/repair-decision-dates.ts
@@ -65,7 +65,6 @@
 
 import { panic } from "better-result";
 
-import { rootDb } from "@/api/db/root";
 import {
   lockCitationGraph,
   reopenCitationsForDecisionKey,
@@ -73,6 +72,10 @@ import {
   reopenCitationsFrom,
   reopenCitationsResolvedTo,
 } from "@/api/handlers/case-law/citation-resolution";
+import {
+  enterCaseLawMaintenanceLane,
+  openCaseLawReadOnlySession,
+} from "@/api/lib/case-law/maintenance-lane";
 import { isCaseLawJurisdiction } from "@/api/lib/legal-search/ingestion-constants";
 import { isRecord } from "@/api/lib/type-guards";
 import type {
@@ -141,6 +144,12 @@ if (apply && hasFlag("dry-run")) {
   console.error(USAGE);
   process.exit(1);
 }
+
+// A report run only reads, so it takes no lane and cannot block a writer; the
+// read-only session makes that a property of the connection, not a promise.
+const { rootDb } = apply
+  ? await enterCaseLawMaintenanceLane()
+  : await openCaseLawReadOnlySession();
 const limit = flagInteger("limit", DEFAULT_LIMIT);
 
 /** Rows from `execute` under either driver shape (bare array or `{ rows }`). */

--- a/apps/api/src/scripts/replay-case-law-source.ts
+++ b/apps/api/src/scripts/replay-case-law-source.ts
@@ -1,7 +1,6 @@
 import { Result } from "better-result";
 import { eq } from "drizzle-orm";
 
-import { rlsDb } from "@/api/db/root";
 import { caseLawSources } from "@/api/db/schema";
 /**
  * Re-parse decisions a source already ingested, from the raw payload stored
@@ -29,7 +28,6 @@ import { caseLawSources } from "@/api/db/schema";
  * Not a scheduled job: it runs when a parser changes, under an operator who
  * reads the report.
  */
-import { createIngestionDb } from "@/api/db/scoped";
 import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
 import {
   countReplayability,
@@ -38,6 +36,7 @@ import {
   replayCaseLawSource,
 } from "@/api/handlers/case-law/ingestion/replay";
 import type { StoredRawReader } from "@/api/handlers/case-law/ingestion/replay";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
 import { acquireCaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
 import {
   readS3ObjectIfPresent,
@@ -45,6 +44,10 @@ import {
   refreshS3,
 } from "@/api/lib/s3";
 import { brandPersistedCaseLawDecisionId } from "@/api/lib/safe-id-boundaries";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { ingestionDb } = await enterCaseLawMaintenanceLane();
 
 const DEFAULT_LIMIT = 100;
 const DEFAULT_PAGE_SIZE = 25;
@@ -135,7 +138,6 @@ if (capability.type === "unsupported") {
   process.exit(1);
 }
 
-const ingestionDb = createIngestionDb(rlsDb);
 await refreshS3();
 await refreshCorpusS3();
 

--- a/apps/api/src/scripts/seed-polarity-rules.ts
+++ b/apps/api/src/scripts/seed-polarity-rules.ts
@@ -12,13 +12,17 @@
 
 import { and, eq, or } from "drizzle-orm";
 
-import { rootDb } from "@/api/db/root";
 import { caseLawPolarityRules } from "@/api/db/schema";
 import { RULE_SOURCE } from "@/api/handlers/case-law/polarity/consts";
 import {
   RETIRED_SEED_RULES,
   SEED_RULES,
 } from "@/api/handlers/case-law/polarity/seed-rules";
+import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
+
+// Hold the maintenance lane before the first statement: operator passes over
+// the case-law tables serialize here instead of deadlocking on row locks.
+const { rootDb } = await enterCaseLawMaintenanceLane();
 
 console.log(`Seeding ${SEED_RULES.length} polarity rules...`);
 


### PR DESCRIPTION
## Summary

Two operator passes over the case-law tables can deadlock: a row-by-row backfill holds row locks on `case_law_decisions` while a citation pass takes `FOR KEY SHARE` on the same rows for its foreign keys (`40P01`). Nothing structural prevented two maintenance scripts from overlapping.

A script no longer imports a database handle. It opens one of two doors in `apps/api/src/lib/case-law/maintenance-lane.ts`:

- `enterCaseLawMaintenanceLane()` takes a session-level `pg_advisory_lock` on a dedicated single connection, holds it for the life of the process, and hands out the write handles (`rootDb`, `ingestionDb`). A second pass waits at the door instead of interleaving; waits over 30 s are logged.
- `openCaseLawReadOnlySession()` hands out handles whose every transaction is `READ ONLY`, so a helper-mediated write fails with SQLSTATE 25006 rather than slipping past the lane. No lane is taken, so a report or planning run never blocks a writer.

Both return the same shape. Scripts with a plan mode (`cz-regional-repair`, `corpus-column-trim`, `repair-decision-dates`, `case-law-source-total`) parse arguments first and pick the door afterwards. 19 scripts take the lane, 3 use the read-only door, 4 choose per mode. It is a different lock from the resolver's transaction-scoped `lockCitationGraph`, which serializes the standing walk's batches; the relationship is documented in the module.

## Guards

- `maintenance-lane.test.ts`: a case-law script (direct case-law import or table reference) that can reach the database (runtime imports of a database module, followed transitively; `import type` edges ignored) must open a door and must not import `rootDb`, `rlsDb`, `createIngestionDb` or `createScopedDb` directly, in both directions; a helper-only writer (`case-law-source-total`) is pinned as in the census; hold/release semantics on a fake lock connection.
- `maintenance-lane.db.test.ts` (Postgres-gated): two sessions contend and the second enters only after the first releases; the read-only door refuses an `UPDATE` on both handles with 25006.

## Testing

- Lane suites 8 pass (Postgres-gated tests run against the local docker database); `bun test apps/api/src/scripts` 127 pass; tsc, type-aware oxlint, ratchet clean.
- Mutations: importing `rootDb` directly in a script fails the census (two findings); replacing `SET TRANSACTION READ ONLY` fails the 25006 test; removing `pg_advisory_lock` fails the serialization test.
