### PR TITLE
feat: publish reusable AI primitives

### DIFF
--- a/.changeset/publish-ai-primitives.md
+++ b/.changeset/publish-ai-primitives.md
@@ -1,0 +1,9 @@
+---
+"@stll/ai-catalog": minor
+"@stll/anonymize-chat": minor
+---
+
+Publish the provider-neutral model catalogue and placeholder-safe reversible
+anonymization pipeline as supported packages. Add exact sensitive-value inputs
+to the anonymization pipeline so callers can protect identifiers in the same
+redaction allocation as detected entities.

--- a/.changeset/publish-ai-primitives.md
+++ b/.changeset/publish-ai-primitives.md
@@ -6,4 +6,5 @@
 Publish the provider-neutral model catalogue and placeholder-safe reversible
 anonymization pipeline as supported packages. Add exact sensitive-value inputs
 to the anonymization pipeline so callers can protect identifiers in the same
-redaction allocation as detected entities.
+redaction allocation as detected entities, and expose placeholder scanning so
+hosts can reject unknown response tokens before restoration.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -859,6 +859,8 @@ jobs:
         if: needs.ci-plan.outputs.package_checks_required == 'true'
         run: |
           bun scripts/check-published-exports.ts packages/auth-model
+          bun scripts/check-published-exports.ts packages/ai-catalog
+          bun scripts/check-published-exports.ts packages/anonymize-chat
           bun scripts/check-published-exports.ts packages/ui
           bun scripts/check-published-exports.ts packages/money
           bun scripts/check-published-exports.ts packages/calculations

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,6 +22,8 @@ on:
       # accidentally start a release transaction.
       - packages/auth-model/CHANGELOG.md
       - packages/business-registries/CHANGELOG.md
+      - packages/ai-catalog/CHANGELOG.md
+      - packages/anonymize-chat/CHANGELOG.md
       - packages/country-codes/CHANGELOG.md
       - packages/conditions/CHANGELOG.md
       - packages/money/CHANGELOG.md
@@ -38,10 +40,12 @@ on:
     inputs:
       package:
         description: Package(s) to publish (dependency order is resolved centrally)
-        type: choice
-        options:
-          - all
-          - auth-model
+          type: choice
+          options:
+            - all
+            - auth-model
+            - ai-catalog
+            - anonymize-chat
           - business-registries
           - country-codes
           - conditions
@@ -188,10 +192,10 @@ jobs:
           if [[ "$EVENT_NAME" == "workflow_run" ]]; then
             pkgs=(cli)
           elif [[ "$EVENT_NAME" == "push" ]]; then
-            pkgs=(auth-model country-codes business-registries conditions template-conditions docx-utils ui money calculations workspace-model workspace-ui)
+            pkgs=(auth-model ai-catalog anonymize-chat country-codes business-registries conditions template-conditions docx-utils ui money calculations workspace-model workspace-ui)
           else
             case "$MANUAL_PACKAGE" in
-              all) pkgs=(auth-model country-codes business-registries conditions template-conditions docx-utils ui money calculations workspace-model workspace-ui cli) ;;
+              all) pkgs=(auth-model ai-catalog anonymize-chat country-codes business-registries conditions template-conditions docx-utils ui money calculations workspace-model workspace-ui cli) ;;
               *) pkgs=("$MANUAL_PACKAGE") ;;
             esac
           fi
@@ -319,6 +323,22 @@ jobs:
         with:
           name: npm-tarball-auth-model
           path: release-artifacts/auth-model/
+
+      - name: Upload ai-catalog tarball
+        if: contains(fromJSON(steps.pack.outputs.packages), 'ai-catalog')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-tarball-ai-catalog
+          path: release-artifacts/ai-catalog/
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload anonymize-chat tarball
+        if: contains(fromJSON(steps.pack.outputs.packages), 'anonymize-chat')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-tarball-anonymize-chat
+          path: release-artifacts/anonymize-chat/
           retention-days: 1
           if-no-files-found: error
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -40,12 +40,12 @@ on:
     inputs:
       package:
         description: Package(s) to publish (dependency order is resolved centrally)
-          type: choice
-          options:
-            - all
-            - auth-model
-            - ai-catalog
-            - anonymize-chat
+        type: choice
+        options:
+          - all
+          - auth-model
+          - ai-catalog
+          - anonymize-chat
           - business-registries
           - country-codes
           - conditions

--- a/apps/api/src/handlers/chat/stream-chat.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.test.ts
@@ -2159,6 +2159,7 @@ const createBoundary = (
   organizationId: toSafeId<"organization">("org_test"),
   pipelineContext: createPipelineContext(),
   placeholderOffsets: new Map<string, number>(),
+  literalPlaceholderAliases: new Map<string, string>(),
   redactionMap: new Map(pairs),
   scopedDb,
   sourcePlaceholders: new Set<string>(),

--- a/apps/api/src/handlers/chat/stream-chat.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.test.ts
@@ -2161,6 +2161,7 @@ const createBoundary = (
   placeholderOffsets: new Map<string, number>(),
   redactionMap: new Map(pairs),
   scopedDb,
+  sourcePlaceholders: new Set<string>(),
   type: "anonymized",
 });
 

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -337,7 +337,7 @@ export const streamChat = async ({
   }
   reserveThirdPartyBoundarySourcePlaceholders({
     boundary: thirdPartyBoundary,
-    value: [systemSafe, systemUntrusted, messages, resume],
+    value: [systemSafe, systemUntrusted, messages, resume, tools],
   });
   const preparedUntrusted = await prepareTextForThirdParty({
     boundary: thirdPartyBoundary,

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -68,11 +68,12 @@ import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-bou
 import {
   deanonymizeFromBoundary,
   deanonymizeUnknownStringsFromBoundary,
-  prepareMessagesForThirdParty,
   prepareMcpToolSourceForThirdParty,
+  prepareMessagesForThirdParty,
   prepareTextForThirdParty,
   prepareToolsForThirdParty,
   prepareUnknownForThirdParty,
+  reserveThirdPartyBoundarySourcePlaceholders,
 } from "@/api/handlers/chat/third-party-boundary";
 import type { StellaMcpToolSource } from "@/api/handlers/chat/tools/external-mcp-tools";
 import type {
@@ -334,6 +335,10 @@ export const streamChat = async ({
   if (agentBoundaryError !== null) {
     return thirdPartyBoundaryRefusalResponse(agentBoundaryError);
   }
+  reserveThirdPartyBoundarySourcePlaceholders({
+    boundary: thirdPartyBoundary,
+    value: [systemSafe, systemUntrusted, messages, resume],
+  });
   const preparedUntrusted = await prepareTextForThirdParty({
     boundary: thirdPartyBoundary,
     text: systemUntrusted,

--- a/apps/api/src/handlers/chat/subagent-runner.ts
+++ b/apps/api/src/handlers/chat/subagent-runner.ts
@@ -11,6 +11,7 @@ import {
   prepareMessagesForThirdParty,
   prepareTextForThirdParty,
   prepareToolsForThirdParty,
+  reserveThirdPartyBoundarySourcePlaceholders,
 } from "@/api/handlers/chat/third-party-boundary";
 import type { ChatMessage } from "@/api/handlers/chat/types";
 import type { AIRequestServiceTier, OrgAIConfig } from "@/api/lib/ai-config";
@@ -149,6 +150,11 @@ export const runSubagent = async (
     promptCachingEnabled: false,
     role: options.role,
     scopeKey: null,
+  });
+
+  reserveThirdPartyBoundarySourcePlaceholders({
+    boundary: options.thirdPartyBoundary,
+    value: [options.system, options.messages],
   });
 
   const preparedSystem = await prepareTextForThirdParty({

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -221,24 +221,27 @@ describe("chat third-party anonymization boundary", () => {
 
     const prepared = await prepareUnknownForThirdParty({
       boundary,
-      value: { [`tenant:${organizationId}`]: 7 },
+      value: {
+        [`tenant:${organizationId}`]: 7,
+        "[MISC_1]": 8,
+      },
     });
 
     expect(Result.isOk(prepared)).toBe(true);
     if (Result.isError(prepared)) {
       throw prepared.error;
     }
-    expect(prepared.value).toEqual({ "[MISC_1]": 7 });
+    expect(prepared.value).toEqual({ "[MISC_2]": 7, "[MISC_1]": 8 });
     expect(
       deanonymizeUnknownStringsFromBoundary(boundary, prepared.value),
-    ).toEqual({ [`tenant:${organizationId}`]: 7 });
+    ).toEqual({ [`tenant:${organizationId}`]: 7, "[MISC_1]": 8 });
     expect(
       deanonymizeUnknownStringsFromBoundary(
         boundary,
-        { MISC_1: 7 },
+        { MISC_2: 7, "[MISC_1]": 8 },
         "lenient",
       ),
-    ).toEqual({ [`tenant:${organizationId}`]: 7 });
+    ).toEqual({ [`tenant:${organizationId}`]: 7, "[MISC_1]": 8 });
     expect(anonymizeIds.mock.calls.at(0)?.[0].fields).toEqual([
       `tenant:${organizationId}`,
     ]);
@@ -814,6 +817,86 @@ describe("chat third-party anonymization boundary", () => {
       documentId: "doc_123",
       participants: ["[PERSON_1]", "[CUSTOM_1]"],
       text: "[CUSTOM_1] notes for [PERSON_1]",
+    });
+  });
+
+  test("reserves literal placeholders in static tool metadata", async () => {
+    const boundary = createBoundary();
+    prepareToolsForThirdParty({
+      boundary,
+      tools: asTestToolSet({
+        literal_metadata: toolDefinition({
+          name: "literal_metadata",
+          description: "Preserve literal [PERSON_1].",
+        }).server(async () => undefined),
+      }),
+    });
+
+    const prepared = await prepareTextForThirdParty({
+      boundary,
+      text: "Jan Novák prepared the memo.",
+    });
+
+    expect(Result.isOk(prepared)).toBe(true);
+    if (Result.isError(prepared)) {
+      throw prepared.error;
+    }
+    expect(prepared.value).toBe("[PERSON_2] prepared the memo.");
+  });
+
+  test("aliases claimed placeholders in late MCP tool metadata", async () => {
+    const boundary = createBoundary();
+    await prepareTextForThirdParty({
+      boundary,
+      text: "Jan Novák prepared the memo.",
+    });
+    const sourceTool = toolDefinition({
+      name: "mcp__test__literal_metadata",
+      description: "Preserve literal [PERSON_1].",
+    }).server(async () => undefined);
+    Reflect.set(sourceTool, "inputSchema", {
+      type: "object",
+      properties: {
+        "[PERSON_1]": {
+          description: "Enter literal [PERSON_1].",
+          type: "string",
+        },
+      },
+    });
+    const source = prepareMcpToolSourceForThirdParty({
+      boundary,
+      source: {
+        close: async () => {},
+        tools: async () => [sourceTool],
+      },
+    });
+
+    const [preparedTool] = await source.tools();
+    const description: unknown = Reflect.get(preparedTool, "description");
+    const inputSchema: unknown = Reflect.get(preparedTool, "inputSchema");
+
+    expect(description).toBe(
+      "Preserve literal [LITERAL_PLACEHOLDER_1].",
+    );
+    expect(inputSchema).toEqual({
+      type: "object",
+      properties: {
+        "[LITERAL_PLACEHOLDER_2]": {
+          description: "Enter literal [LITERAL_PLACEHOLDER_3].",
+          type: "string",
+        },
+      },
+    });
+    expect(
+      deanonymizeUnknownStringsFromBoundary(boundary, inputSchema),
+    ).toEqual({
+      type: "object",
+      properties: {
+        "[PERSON_1]": {
+          description: "Enter literal [PERSON_1].",
+          type: "string",
+        },
+      },
     });
   });
 

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -532,6 +532,135 @@ describe("chat third-party anonymization boundary", () => {
     });
   });
 
+  test("anonymizes every rich tool-result source before provider replay", async () => {
+    const organizationId = toSafeId<"organization">(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    const anonymizeIds = mock(async ({ fields }: { fields: string[] }) => ({
+      entityCount: 1,
+      fields: fields.map((field) =>
+        field.replaceAll(organizationId, () => "[MISC_1]"),
+      ),
+      redactionMap: new Map([["[MISC_1]", organizationId]]),
+    }));
+    const { scopedDb } = createScopedDbMock({});
+    const boundary = createChatThirdPartyBoundary({
+      anonymizeFields: anonymizeIds,
+      anonymizationScopeId: "workspace-A",
+      organizationId,
+      scopedDb,
+      sendMode: CHAT_SEND_MODE.anonymized,
+    });
+    const messages: ChatMessage[] = [
+      {
+        id: "msg_1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-call",
+            id: "call_1",
+            name: "mcp__test__read_rich_result",
+            arguments: "{}",
+            state: "complete",
+          },
+          {
+            type: "tool-result",
+            toolCallId: "call_1",
+            content: [
+              {
+                type: "image",
+                source: {
+                  type: "url",
+                  value: `https://example.test/${organizationId}/image.png`,
+                  mimeType: "image/png",
+                },
+              },
+              {
+                type: "audio",
+                source: {
+                  type: "url",
+                  value: `https://example.test/${organizationId}/audio.mp3`,
+                  mimeType: "audio/mpeg",
+                },
+              },
+              {
+                type: "video",
+                source: {
+                  type: "url",
+                  value: `https://example.test/${organizationId}/video.mp4`,
+                  mimeType: "video/mp4",
+                },
+              },
+              {
+                type: "document",
+                source: {
+                  type: "url",
+                  value: `https://example.test/${organizationId}/document.pdf`,
+                  mimeType: "application/pdf",
+                },
+              },
+            ],
+            state: "complete",
+          },
+        ],
+      },
+    ];
+
+    const prepared = await prepareMessagesForThirdParty({
+      boundary,
+      messages,
+    });
+
+    expect(Result.isOk(prepared)).toBe(true);
+    if (Result.isError(prepared)) {
+      throw prepared.error;
+    }
+    const resultPart = prepared.value.at(0)?.parts.at(1);
+    if (!resultPart || resultPart.type !== "tool-result") {
+      throw new TypeError("Expected prepared tool-result part");
+    }
+    expect(resultPart.content).toEqual([
+      {
+        type: "image",
+        source: {
+          type: "url",
+          value: "https://example.test/[MISC_1]/image.png",
+          mimeType: "image/png",
+        },
+      },
+      {
+        type: "audio",
+        source: {
+          type: "url",
+          value: "https://example.test/[MISC_1]/audio.mp3",
+          mimeType: "audio/mpeg",
+        },
+      },
+      {
+        type: "video",
+        source: {
+          type: "url",
+          value: "https://example.test/[MISC_1]/video.mp4",
+          mimeType: "video/mp4",
+        },
+      },
+      {
+        type: "document",
+        source: {
+          type: "url",
+          value: "https://example.test/[MISC_1]/document.pdf",
+          mimeType: "application/pdf",
+        },
+      },
+    ]);
+    expect(anonymizeIds.mock.calls.at(0)?.[0].fields).toEqual([
+      `https://example.test/${organizationId}/image.png`,
+      `https://example.test/${organizationId}/audio.mp3`,
+      `https://example.test/${organizationId}/video.mp4`,
+      `https://example.test/${organizationId}/document.pdf`,
+    ]);
+  });
+
   test("returns anonymized live tool output values", async () => {
     const boundary = createBoundary();
     const tools = {

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -815,6 +815,48 @@ describe("chat third-party anonymization boundary", () => {
     );
   });
 
+  test("does not let extreme literal indices collapse new placeholders", async () => {
+    const anonymizeSecrets = mock(async ({ fields }: { fields: string[] }) => ({
+      entityCount: 2,
+      fields: fields.map((field) =>
+        field
+          .replaceAll("First", () => "[MISC_1]")
+          .replaceAll("Second", () => "[MISC_2]"),
+      ),
+      redactionMap: new Map([
+        ["[MISC_1]", "First"],
+        ["[MISC_2]", "Second"],
+      ]),
+    }));
+    const { deanonymizeFromBoundary } =
+      await import("@/api/handlers/chat/third-party-boundary");
+    const { scopedDb } = createScopedDbMock({});
+    const boundary = createChatThirdPartyBoundary({
+      anonymizeFields: anonymizeSecrets,
+      anonymizationScopeId: "workspace-A",
+      organizationId: toSafeId<"organization">(
+        "11111111-1111-4111-8111-111111111111",
+      ),
+      scopedDb,
+      sendMode: CHAT_SEND_MODE.anonymized,
+    });
+    const literal = "[MISC_9007199254740991]";
+
+    const prepared = await prepareTextForThirdParty({
+      boundary,
+      text: `${literal} First Second`,
+    });
+
+    expect(Result.isOk(prepared)).toBe(true);
+    if (Result.isError(prepared)) {
+      throw prepared.error;
+    }
+    expect(prepared.value).toBe(`${literal} [MISC_1] [MISC_2]`);
+    expect(deanonymizeFromBoundary({ boundary, text: prepared.value })).toBe(
+      `${literal} First Second`,
+    );
+  });
+
   test("round-trip helpers are no-ops on raw boundaries", async () => {
     const { deanonymizeFromBoundary } =
       await import("@/api/handlers/chat/third-party-boundary");

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -164,7 +164,12 @@ describe("chat third-party anonymization boundary", () => {
 
     const prepared = await prepareUnknownForThirdParty({
       boundary,
-      value: { organizationId, id: scopeId, documentId: "doc_123" },
+      value: {
+        organizationId,
+        id: `ref_${organizationId}`,
+        scopeId: `scope:${scopeId}`,
+        documentId: "doc_123",
+      },
     });
 
     expect(Result.isOk(prepared)).toBe(true);
@@ -174,11 +179,13 @@ describe("chat third-party anonymization boundary", () => {
     expect(prepared.value).toEqual({
       organizationId: "[MISC_1]",
       id: "[MISC_2]",
+      scopeId: "[MISC_3]",
       documentId: "doc_123",
     });
     expect(anonymizeIds.mock.calls.at(0)?.[0].fields).toEqual([
       organizationId,
-      scopeId,
+      `ref_${organizationId}`,
+      `scope:${scopeId}`,
     ]);
   });
 

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -28,7 +28,13 @@ import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 import { richChatParts } from "./__fixtures__/rich-chat-parts";
 
 const anonymizeTextFieldsMock = mock(
-  async ({ fields }: { fields: string[]; workspaceId: string }) => {
+  async ({
+    fields,
+  }: {
+    fields: string[];
+    forcedSensitiveValues?: readonly string[];
+    workspaceId: string;
+  }) => {
     const swaps: [string, string][] = [
       ["[PERSON_1]", "Jan Novák"],
       ["[CUSTOM_1]", "Secret"],
@@ -122,6 +128,9 @@ describe("chat third-party anonymization boundary", () => {
     expect(anonymizeTextFieldsMock.mock.calls.at(0)?.[0].workspaceId).toBe(
       scopeId,
     );
+    expect(
+      anonymizeTextFieldsMock.mock.calls.at(0)?.[0].forcedSensitiveValues,
+    ).toEqual(["11111111-1111-4111-8111-111111111111", scopeId]);
   });
 
   test("omits UI-only rich output before every provider boundary", async () => {

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -628,7 +628,7 @@ describe("chat third-party anonymization boundary", () => {
           value: "https://example.test/[MISC_1]/image.png",
           mimeType: "image/png",
         },
-        metadata: { traceId: "[MISC_1]" },
+        metadata: { traceId: "ref_[MISC_1]" },
       },
       {
         type: "audio",

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -874,6 +874,10 @@ describe("chat third-party anonymization boundary", () => {
             "Enter Jan Novák or preserve literal [PERSON_1] in the example.",
           type: "string",
         },
+        "Jan Novák": {
+          description: "A sensitive schema property name.",
+          type: "string",
+        },
       },
     });
     const source = prepareMcpToolSourceForThirdParty({
@@ -902,6 +906,10 @@ describe("chat third-party anonymization boundary", () => {
             "Enter [PERSON_1] or preserve literal [LITERAL_PLACEHOLDER_3] in the example.",
           type: "string",
         },
+        "[PERSON_1]": {
+          description: "A sensitive schema property name.",
+          type: "string",
+        },
       },
     });
     expect(
@@ -914,8 +922,48 @@ describe("chat third-party anonymization boundary", () => {
             "Enter Jan Novák or preserve literal [PERSON_1] in the example.",
           type: "string",
         },
+        "Jan Novák": {
+          description: "A sensitive schema property name.",
+          type: "string",
+        },
       },
     });
+  });
+
+  test("rejects sensitive MCP tool names instead of corrupting identifiers", () => {
+    const organizationId = toSafeId<"organization">(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    const anonymizeIds = mock(async ({ fields }: { fields: string[] }) => ({
+      entityCount: 1,
+      fields: fields.map((field) =>
+        field.replaceAll(organizationId, () => "[MISC_1]"),
+      ),
+      redactionMap: new Map([["[MISC_1]", organizationId]]),
+    }));
+    const { scopedDb } = createScopedDbMock({});
+    const boundary = createChatThirdPartyBoundary({
+      anonymizeFields: anonymizeIds,
+      anonymizationScopeId: "workspace-A",
+      organizationId,
+      scopedDb,
+      sendMode: CHAT_SEND_MODE.anonymized,
+    });
+    const sourceTool = toolDefinition({
+      name: `mcp__crm__${organizationId}`,
+      description: "Read a record.",
+    }).server(async () => undefined);
+    const source = prepareMcpToolSourceForThirdParty({
+      boundary,
+      source: {
+        close: async () => {},
+        tools: async () => [sourceTool],
+      },
+    });
+
+    expect(source.tools()).rejects.toThrow(
+      "MCP tool names that contain sensitive data cannot cross an anonymized third-party boundary.",
+    );
   });
 
   test("aliases late literal placeholders in runtime tool output", async () => {

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -68,6 +68,7 @@ const {
   prepareMessagesForThirdParty,
   prepareTextForThirdParty,
   prepareToolsForThirdParty,
+  reserveThirdPartyBoundarySourcePlaceholders,
 } = await import("@/api/handlers/chat/third-party-boundary");
 
 const createBoundary = () => {
@@ -777,6 +778,45 @@ describe("chat third-party anonymization boundary", () => {
         ["[PERSON_2]", "Alice"],
       ]),
     );
+  });
+
+  test("reserves later source placeholders before an earlier allocation", async () => {
+    const { deanonymizeFromBoundary } =
+      await import("@/api/handlers/chat/third-party-boundary");
+    const boundary = createBoundary();
+    reserveThirdPartyBoundarySourcePlaceholders({
+      boundary,
+      value: ["Jan Novák", "Keep [PERSON_1] literal"],
+    });
+
+    const first = await prepareTextForThirdParty({
+      boundary,
+      text: "Jan Novák prepared the memo.",
+    });
+    const second = await prepareTextForThirdParty({
+      boundary,
+      text: "Keep [PERSON_1] literal",
+    });
+
+    expect(Result.isOk(first)).toBe(true);
+    expect(Result.isOk(second)).toBe(true);
+    if (Result.isError(first) || Result.isError(second)) {
+      throw new TypeError("Expected anonymization to succeed");
+    }
+    expect(first.value).toBe("[PERSON_2] prepared the memo.");
+    expect(second.value).toBe("Keep [PERSON_1] literal");
+    if (boundary.type !== "anonymized") {
+      throw new TypeError("Expected anonymized boundary");
+    }
+    expect(boundary.redactionMap).toEqual(
+      new Map([["[PERSON_2]", "Jan Novák"]]),
+    );
+    expect(
+      deanonymizeFromBoundary({
+        boundary,
+        text: `${first.value} Keep [PERSON_1] literal`,
+      }),
+    ).toBe("Jan Novák prepared the memo. Keep [PERSON_1] literal");
   });
 
   test("keeps literal source placeholders distinct from new redactions", async () => {

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -779,6 +779,42 @@ describe("chat third-party anonymization boundary", () => {
     );
   });
 
+  test("keeps literal source placeholders distinct from new redactions", async () => {
+    const anonymizeSecret = mock(async ({ fields }: { fields: string[] }) => ({
+      entityCount: 1,
+      fields: fields.map((field) =>
+        field.replaceAll("Secret", () => "[MISC_2]"),
+      ),
+      redactionMap: new Map([["[MISC_2]", "Secret"]]),
+    }));
+    const { deanonymizeFromBoundary } =
+      await import("@/api/handlers/chat/third-party-boundary");
+    const { scopedDb } = createScopedDbMock({});
+    const boundary = createChatThirdPartyBoundary({
+      anonymizeFields: anonymizeSecret,
+      anonymizationScopeId: "workspace-A",
+      organizationId: toSafeId<"organization">(
+        "11111111-1111-4111-8111-111111111111",
+      ),
+      scopedDb,
+      sendMode: CHAT_SEND_MODE.anonymized,
+    });
+
+    const prepared = await prepareTextForThirdParty({
+      boundary,
+      text: "Keep [MISC_1] literal; redact Secret.",
+    });
+
+    expect(Result.isOk(prepared)).toBe(true);
+    if (Result.isError(prepared)) {
+      throw prepared.error;
+    }
+    expect(prepared.value).toBe("Keep [MISC_1] literal; redact [MISC_2].");
+    expect(deanonymizeFromBoundary({ boundary, text: prepared.value })).toBe(
+      "Keep [MISC_1] literal; redact Secret.",
+    );
+  });
+
   test("round-trip helpers are no-ops on raw boundaries", async () => {
     const { deanonymizeFromBoundary } =
       await import("@/api/handlers/chat/third-party-boundary");

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -626,6 +626,52 @@ describe("chat third-party anonymization boundary", () => {
     ).toBe("Jan Novák; Keep [PERSON_1] literal");
   });
 
+  test("chooses late aliases absent from the complete runtime output", async () => {
+    const { deanonymizeUnknownStringsFromBoundary } =
+      await import("@/api/handlers/chat/third-party-boundary");
+    const boundary = createBoundary();
+    await prepareTextForThirdParty({
+      boundary,
+      text: "Jan Novák prepared the memo.",
+    });
+    const outputs = [
+      "[PERSON_1] [LITERAL_PLACEHOLDER_1]",
+      "[PERSON_1] [LITERAL_PLACEHOLDER_2]",
+    ];
+    const tools = {
+      literal_output: applyChatToolPolicy(
+        toolDefinition({
+          name: "literal_output",
+          description: "Return colliding literal placeholder fixtures.",
+        }).server(async () => ({ text: outputs.shift() })),
+        CHAT_TOOL_POLICY_KIND.internal,
+      ),
+    };
+    const prepared = prepareToolsForThirdParty({
+      boundary,
+      tools: asTestToolSet(tools),
+    });
+    const executable = asTestExecutable<unknown, unknown>(
+      prepared["literal_output"],
+    );
+
+    const first = await executable?.execute?.(undefined);
+    const second = await executable?.execute?.(undefined);
+
+    expect(first).toEqual({
+      text: "[LITERAL_PLACEHOLDER_2] [LITERAL_PLACEHOLDER_1]",
+    });
+    expect(second).toEqual({
+      text: "[LITERAL_PLACEHOLDER_3] [LITERAL_PLACEHOLDER_4]",
+    });
+    expect(deanonymizeUnknownStringsFromBoundary(boundary, first)).toEqual({
+      text: "[PERSON_1] [LITERAL_PLACEHOLDER_1]",
+    });
+    expect(deanonymizeUnknownStringsFromBoundary(boundary, second)).toEqual({
+      text: "[PERSON_1] [LITERAL_PLACEHOLDER_2]",
+    });
+  });
+
   test("allows approved external tools to inherit raw mode", async () => {
     const boundary = createRawBoundary();
     const tools = {

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -32,7 +32,7 @@ const anonymizeTextFieldsMock = mock(
     fields,
   }: {
     fields: string[];
-    forcedSensitiveValues?: readonly string[];
+    forcedSensitiveValues?: readonly string[] | undefined;
     workspaceId: string;
   }) => {
     const swaps: [string, string][] = [

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -166,6 +166,7 @@ describe("chat third-party anonymization boundary", () => {
       boundary,
       value: {
         organizationId,
+        legacyId: organizationId.toUpperCase(),
         id: `ref_${organizationId}`,
         scopeId: `scope:${scopeId}`,
         documentId: "doc_123",
@@ -178,12 +179,14 @@ describe("chat third-party anonymization boundary", () => {
     }
     expect(prepared.value).toEqual({
       organizationId: "[MISC_1]",
-      id: "[MISC_2]",
-      scopeId: "[MISC_3]",
+      legacyId: "[MISC_2]",
+      id: "[MISC_3]",
+      scopeId: "[MISC_4]",
       documentId: "doc_123",
     });
     expect(anonymizeIds.mock.calls.at(0)?.[0].fields).toEqual([
       organizationId,
+      organizationId.toUpperCase(),
       `ref_${organizationId}`,
       `scope:${scopeId}`,
     ]);

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -137,7 +137,7 @@ describe("chat third-party anonymization boundary", () => {
 
   test("forces boundary IDs through structured technical keys", async () => {
     const organizationId = toSafeId<"organization">(
-      "11111111-1111-4111-8111-111111111111",
+      "0198f3e8-75f2-7c11-8af0-111111111111",
     );
     const scopeId = "22222222-2222-4222-8222-222222222222";
     const anonymizeIds = mock(async ({ fields }: { fields: string[] }) => {
@@ -189,6 +189,37 @@ describe("chat third-party anonymization boundary", () => {
       organizationId.toUpperCase(),
       `ref_${organizationId}`,
       `scope:${scopeId}`,
+    ]);
+  });
+
+  test("forces boundary IDs through structured object keys", async () => {
+    const organizationId = "11111111-1111-4111-8111-111111111111";
+    const anonymizeIds = mock(async ({ fields }: { fields: string[] }) => ({
+      entityCount: fields.length,
+      fields: fields.map(() => "[MISC_1]"),
+      redactionMap: new Map([["[MISC_1]", fields.at(0) ?? ""]]),
+    }));
+    const { scopedDb } = createScopedDbMock({});
+    const boundary = createChatThirdPartyBoundary({
+      anonymizeFields: anonymizeIds,
+      anonymizationScopeId: "workspace-A",
+      organizationId: toSafeId<"organization">(organizationId),
+      scopedDb,
+      sendMode: CHAT_SEND_MODE.anonymized,
+    });
+
+    const prepared = await prepareUnknownForThirdParty({
+      boundary,
+      value: { [`tenant:${organizationId}`]: 7 },
+    });
+
+    expect(Result.isOk(prepared)).toBe(true);
+    if (Result.isError(prepared)) {
+      throw prepared.error;
+    }
+    expect(prepared.value).toEqual({ "[MISC_1]": 7 });
+    expect(anonymizeIds.mock.calls.at(0)?.[0].fields).toEqual([
+      `tenant:${organizationId}`,
     ]);
   });
 

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -64,6 +64,7 @@ const anonymizeTextFieldsMock = mock(
 
 const {
   createChatThirdPartyBoundary,
+  deanonymizeFromBoundary,
   deanonymizeUnknownStringsFromBoundary,
   prepareMcpToolSourceForThirdParty,
   prepareMessagesForThirdParty,
@@ -590,7 +591,7 @@ describe("chat third-party anonymization boundary", () => {
     });
   });
 
-  test("anonymizes every rich tool-result source before provider replay", async () => {
+  test("refuses rich-media URLs that require redaction", async () => {
     const organizationId = toSafeId<"organization">(
       "11111111-1111-4111-8111-111111111111",
     );
@@ -670,49 +671,11 @@ describe("chat third-party anonymization boundary", () => {
       messages,
     });
 
-    expect(Result.isOk(prepared)).toBe(true);
-    if (Result.isError(prepared)) {
-      throw prepared.error;
+    expect(Result.isError(prepared)).toBe(true);
+    if (Result.isOk(prepared)) {
+      throw new TypeError("Expected sensitive rich-media URL refusal");
     }
-    const resultPart = prepared.value.at(0)?.parts.at(1);
-    if (!resultPart || resultPart.type !== "tool-result") {
-      throw new TypeError("Expected prepared tool-result part");
-    }
-    expect(resultPart.content).toEqual([
-      {
-        type: "image",
-        source: {
-          type: "url",
-          value: "https://example.test/[MISC_1]/image.png",
-          mimeType: "image/png",
-        },
-        metadata: { traceId: "ref_[MISC_1]" },
-      },
-      {
-        type: "audio",
-        source: {
-          type: "url",
-          value: "https://example.test/[MISC_1]/audio.mp3",
-          mimeType: "audio/mpeg",
-        },
-      },
-      {
-        type: "video",
-        source: {
-          type: "url",
-          value: "https://example.test/[MISC_1]/video.mp4",
-          mimeType: "video/mp4",
-        },
-      },
-      {
-        type: "document",
-        source: {
-          type: "url",
-          value: "https://example.test/[MISC_1]/document.pdf",
-          mimeType: "application/pdf",
-        },
-      },
-    ]);
+    expect(prepared.error.status).toBe(422);
     expect(anonymizeIds.mock.calls.at(0)?.[0].fields).toEqual([
       `https://example.test/${organizationId}/image.png`,
       `https://example.test/${organizationId}/audio.mp3`,
@@ -720,6 +683,50 @@ describe("chat third-party anonymization boundary", () => {
       `https://example.test/${organizationId}/document.pdf`,
       `ref_${organizationId}`,
     ]);
+  });
+
+  test("preserves safe rich-media URLs while anonymizing metadata", async () => {
+    const boundary = createBoundary();
+    const prepared = await prepareMessagesForThirdParty({
+      boundary,
+      messages: [
+        {
+          id: "msg_1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-result",
+              toolCallId: "call_1",
+              content: [
+                {
+                  type: "image",
+                  source: {
+                    type: "url",
+                    value: "https://example.test/image.png",
+                    mimeType: "image/png",
+                  },
+                  metadata: { caption: "Jan Novák" },
+                },
+              ],
+              state: "complete",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(Result.isOk(prepared)).toBe(true);
+    if (Result.isError(prepared)) {
+      throw prepared.error;
+    }
+    expect(prepared.value.at(0)?.parts.at(0)).toMatchObject({
+      content: [
+        {
+          source: { value: "https://example.test/image.png" },
+          metadata: { caption: "[PERSON_1]" },
+        },
+      ],
+    });
   });
 
   test("refuses opaque inline rich-media tool results", async () => {
@@ -820,16 +827,20 @@ describe("chat third-party anonymization boundary", () => {
     });
   });
 
-  test("reserves literal placeholders in static tool metadata", async () => {
+  test("reserves static tool metadata in the initial source prepass", async () => {
     const boundary = createBoundary();
-    prepareToolsForThirdParty({
-      boundary,
-      tools: asTestToolSet({
-        literal_metadata: toolDefinition({
+    const tools = asTestToolSet({
+      literal_metadata: applyChatToolPolicy(
+        toolDefinition({
           name: "literal_metadata",
           description: "Preserve literal [PERSON_1].",
         }).server(async () => undefined),
-      }),
+        CHAT_TOOL_POLICY_KIND.internal,
+      ),
+    });
+    reserveThirdPartyBoundarySourcePlaceholders({
+      boundary,
+      value: ["System prompt", tools],
     });
 
     const prepared = await prepareTextForThirdParty({
@@ -852,13 +863,15 @@ describe("chat third-party anonymization boundary", () => {
     });
     const sourceTool = toolDefinition({
       name: "mcp__test__literal_metadata",
-      description: "Preserve literal [PERSON_1].",
+      description:
+        "Read Jan Novák; preserve literal [PERSON_1] in the description.",
     }).server(async () => undefined);
     Reflect.set(sourceTool, "inputSchema", {
       type: "object",
       properties: {
         "[PERSON_1]": {
-          description: "Enter literal [PERSON_1].",
+          description:
+            "Enter Jan Novák or preserve literal [PERSON_1] in the example.",
           type: "string",
         },
       },
@@ -878,12 +891,15 @@ describe("chat third-party anonymization boundary", () => {
     const description: unknown = Reflect.get(preparedTool, "description");
     const inputSchema: unknown = Reflect.get(preparedTool, "inputSchema");
 
-    expect(description).toBe("Preserve literal [LITERAL_PLACEHOLDER_1].");
+    expect(description).toBe(
+      "Read [PERSON_1]; preserve literal [LITERAL_PLACEHOLDER_1] in the description.",
+    );
     expect(inputSchema).toEqual({
       type: "object",
       properties: {
         "[LITERAL_PLACEHOLDER_2]": {
-          description: "Enter literal [LITERAL_PLACEHOLDER_3].",
+          description:
+            "Enter [PERSON_1] or preserve literal [LITERAL_PLACEHOLDER_3] in the example.",
           type: "string",
         },
       },
@@ -894,7 +910,8 @@ describe("chat third-party anonymization boundary", () => {
       type: "object",
       properties: {
         "[PERSON_1]": {
-          description: "Enter literal [PERSON_1].",
+          description:
+            "Enter Jan Novák or preserve literal [PERSON_1] in the example.",
           type: "string",
         },
       },
@@ -902,8 +919,6 @@ describe("chat third-party anonymization boundary", () => {
   });
 
   test("aliases late literal placeholders in runtime tool output", async () => {
-    const { deanonymizeFromBoundary, deanonymizeUnknownStringsFromBoundary } =
-      await import("@/api/handlers/chat/third-party-boundary");
     const boundary = createBoundary();
     await prepareTextForThirdParty({
       boundary,
@@ -942,8 +957,6 @@ describe("chat third-party anonymization boundary", () => {
   });
 
   test("chooses late aliases absent from the complete runtime output", async () => {
-    const { deanonymizeUnknownStringsFromBoundary } =
-      await import("@/api/handlers/chat/third-party-boundary");
     const boundary = createBoundary();
     await prepareTextForThirdParty({
       boundary,
@@ -988,8 +1001,6 @@ describe("chat third-party anonymization boundary", () => {
   });
 
   test("reserves aliases across a structured runtime output", async () => {
-    const { deanonymizeUnknownStringsFromBoundary } =
-      await import("@/api/handlers/chat/third-party-boundary");
     const boundary = createBoundary();
     await prepareTextForThirdParty({
       boundary,
@@ -1114,8 +1125,6 @@ describe("chat third-party anonymization boundary", () => {
   });
 
   test("round-trips placeholders so outgoing text is restored to originals", async () => {
-    const { deanonymizeFromBoundary, deanonymizeUnknownStringsFromBoundary } =
-      await import("@/api/handlers/chat/third-party-boundary");
     const boundary = createBoundary();
 
     // Anonymize on the inbound path so the boundary accumulates a map.
@@ -1270,8 +1279,6 @@ describe("chat third-party anonymization boundary", () => {
   });
 
   test("reserves later source placeholders before an earlier allocation", async () => {
-    const { deanonymizeFromBoundary } =
-      await import("@/api/handlers/chat/third-party-boundary");
     const boundary = createBoundary();
     reserveThirdPartyBoundarySourcePlaceholders({
       boundary,
@@ -1316,8 +1323,6 @@ describe("chat third-party anonymization boundary", () => {
       ),
       redactionMap: new Map([["[MISC_2]", "Secret"]]),
     }));
-    const { deanonymizeFromBoundary } =
-      await import("@/api/handlers/chat/third-party-boundary");
     const { scopedDb } = createScopedDbMock({});
     const boundary = createChatThirdPartyBoundary({
       anonymizeFields: anonymizeSecret,
@@ -1357,8 +1362,6 @@ describe("chat third-party anonymization boundary", () => {
         ["[MISC_2]", "Second"],
       ]),
     }));
-    const { deanonymizeFromBoundary } =
-      await import("@/api/handlers/chat/third-party-boundary");
     const { scopedDb } = createScopedDbMock({});
     const boundary = createChatThirdPartyBoundary({
       anonymizeFields: anonymizeSecrets,
@@ -1386,9 +1389,7 @@ describe("chat third-party anonymization boundary", () => {
     );
   });
 
-  test("round-trip helpers are no-ops on raw boundaries", async () => {
-    const { deanonymizeFromBoundary } =
-      await import("@/api/handlers/chat/third-party-boundary");
+  test("round-trip helpers are no-ops on raw boundaries", () => {
     const boundary = createRawBoundary();
     expect(
       deanonymizeFromBoundary({ boundary, text: "[PERSON_1] is here" }),

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -930,6 +930,76 @@ describe("chat third-party anonymization boundary", () => {
     });
   });
 
+  test("keeps MCP metadata envelope keys stable and restores only schema argument keys", async () => {
+    const anonymizeMetadata = mock(
+      async ({ fields }: { fields: string[] }) => ({
+        entityCount: fields.length,
+        fields: fields.map((field) =>
+          field
+            .replaceAll("description", "[FIELD_1]")
+            .replaceAll("Jan Novák", "[PERSON_1]")
+            .replaceAll("Secret", "[CUSTOM_1]"),
+        ),
+        redactionMap: new Map([
+          ["[CUSTOM_1]", "Secret"],
+          ["[FIELD_1]", "description"],
+          ["[PERSON_1]", "Jan Novák"],
+        ]),
+      }),
+    );
+    const { scopedDb } = createScopedDbMock({});
+    const boundary = createChatThirdPartyBoundary({
+      anonymizeFields: anonymizeMetadata,
+      anonymizationScopeId: "workspace-A",
+      organizationId: toSafeId<"organization">(
+        "11111111-1111-4111-8111-111111111111",
+      ),
+      scopedDb,
+      sendMode: CHAT_SEND_MODE.anonymized,
+    });
+    let executedInput: unknown;
+    const sourceTool = toolDefinition({
+      name: "mcp__test__sensitive_schema_key",
+      description: "Secret",
+    }).server(async (input) => {
+      executedInput = input;
+      return { status: "ok" };
+    });
+    Reflect.set(sourceTool, "inputSchema", {
+      properties: {
+        "Jan Novák": { type: "string" },
+      },
+      type: "object",
+    });
+    const source = prepareMcpToolSourceForThirdParty({
+      boundary,
+      source: {
+        close: async () => {},
+        tools: async () => [sourceTool],
+      },
+    });
+
+    const [preparedTool] = await source.tools();
+    if (!preparedTool) {
+      throw new TypeError("Expected an MCP tool");
+    }
+    const executable = asTestExecutable<unknown, unknown>(preparedTool);
+
+    expect(Reflect.get(preparedTool, "description")).toBe("[CUSTOM_1]");
+    expect(Reflect.get(preparedTool, "inputSchema")).toEqual({
+      properties: {
+        "[PERSON_1]": { type: "string" },
+      },
+      type: "object",
+    });
+    await executable?.execute?.({
+      "[PERSON_1]": "Keep [PERSON_1] anonymized",
+    });
+    expect(executedInput).toEqual({
+      "Jan Novák": "Keep [PERSON_1] anonymized",
+    });
+  });
+
   test("rejects sensitive MCP tool names instead of corrupting identifiers", () => {
     const organizationId = toSafeId<"organization">(
       "11111111-1111-4111-8111-111111111111",

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -574,6 +574,7 @@ describe("chat third-party anonymization boundary", () => {
                   value: `https://example.test/${organizationId}/image.png`,
                   mimeType: "image/png",
                 },
+                metadata: { traceId: `ref_${organizationId}` },
               },
               {
                 type: "audio",
@@ -627,6 +628,7 @@ describe("chat third-party anonymization boundary", () => {
           value: "https://example.test/[MISC_1]/image.png",
           mimeType: "image/png",
         },
+        metadata: { traceId: "[MISC_1]" },
       },
       {
         type: "audio",
@@ -658,6 +660,7 @@ describe("chat third-party anonymization boundary", () => {
       `https://example.test/${organizationId}/audio.mp3`,
       `https://example.test/${organizationId}/video.mp4`,
       `https://example.test/${organizationId}/document.pdf`,
+      `ref_${organizationId}`,
     ]);
   });
 

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -68,6 +68,7 @@ const {
   prepareMessagesForThirdParty,
   prepareTextForThirdParty,
   prepareToolsForThirdParty,
+  prepareUnknownForThirdParty,
   reserveThirdPartyBoundarySourcePlaceholders,
 } = await import("@/api/handlers/chat/third-party-boundary");
 
@@ -132,6 +133,53 @@ describe("chat third-party anonymization boundary", () => {
     expect(
       anonymizeTextFieldsMock.mock.calls.at(0)?.[0].forcedSensitiveValues,
     ).toEqual(["11111111-1111-4111-8111-111111111111", scopeId]);
+  });
+
+  test("forces boundary IDs through structured technical keys", async () => {
+    const organizationId = toSafeId<"organization">(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    const scopeId = "22222222-2222-4222-8222-222222222222";
+    const anonymizeIds = mock(async ({ fields }: { fields: string[] }) => {
+      const redactionMap = new Map<string, string>();
+      const anonymized = fields.map((field, index) => {
+        const placeholder = `[MISC_${String(index + 1)}]`;
+        redactionMap.set(placeholder, field);
+        return placeholder;
+      });
+      return {
+        entityCount: fields.length,
+        fields: anonymized,
+        redactionMap,
+      };
+    });
+    const { scopedDb } = createScopedDbMock({});
+    const boundary = createChatThirdPartyBoundary({
+      anonymizeFields: anonymizeIds,
+      anonymizationScopeId: scopeId,
+      organizationId,
+      scopedDb,
+      sendMode: CHAT_SEND_MODE.anonymized,
+    });
+
+    const prepared = await prepareUnknownForThirdParty({
+      boundary,
+      value: { organizationId, id: scopeId, documentId: "doc_123" },
+    });
+
+    expect(Result.isOk(prepared)).toBe(true);
+    if (Result.isError(prepared)) {
+      throw prepared.error;
+    }
+    expect(prepared.value).toEqual({
+      organizationId: "[MISC_1]",
+      id: "[MISC_2]",
+      documentId: "doc_123",
+    });
+    expect(anonymizeIds.mock.calls.at(0)?.[0].fields).toEqual([
+      organizationId,
+      scopeId,
+    ]);
   });
 
   test("omits UI-only rich output before every provider boundary", async () => {
@@ -536,6 +584,46 @@ describe("chat third-party anonymization boundary", () => {
       participants: ["[PERSON_1]", "[CUSTOM_1]"],
       text: "[CUSTOM_1] notes for [PERSON_1]",
     });
+  });
+
+  test("aliases late literal placeholders in runtime tool output", async () => {
+    const { deanonymizeFromBoundary, deanonymizeUnknownStringsFromBoundary } =
+      await import("@/api/handlers/chat/third-party-boundary");
+    const boundary = createBoundary();
+    await prepareTextForThirdParty({
+      boundary,
+      text: "Jan Novák prepared the memo.",
+    });
+    const tools = {
+      literal_output: applyChatToolPolicy(
+        toolDefinition({
+          name: "literal_output",
+          description: "Return a literal placeholder fixture.",
+        }).server(async () => ({ text: "Keep [PERSON_1] literal" })),
+        CHAT_TOOL_POLICY_KIND.internal,
+      ),
+    };
+    const prepared = prepareToolsForThirdParty({
+      boundary,
+      tools: asTestToolSet(tools),
+    });
+    const executable = asTestExecutable<unknown, unknown>(
+      prepared["literal_output"],
+    );
+    const output = await executable?.execute?.(undefined);
+
+    expect(output).toEqual({
+      text: "Keep [LITERAL_PLACEHOLDER_1] literal",
+    });
+    expect(deanonymizeUnknownStringsFromBoundary(boundary, output)).toEqual({
+      text: "Keep [PERSON_1] literal",
+    });
+    expect(
+      deanonymizeFromBoundary({
+        boundary,
+        text: "[PERSON_1]; Keep [LITERAL_PLACEHOLDER_1] literal",
+      }),
+    ).toBe("Jan Novák; Keep [PERSON_1] literal");
   });
 
   test("allows approved external tools to inherit raw mode", async () => {

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -198,9 +198,9 @@ describe("chat third-party anonymization boundary", () => {
       `ref_${organizationId}`,
       `scope:${scopeId}`,
     ]);
-    expect(
-      anonymizeIds.mock.calls.at(0)?.[0].forcedSensitiveValues,
-    ).toContain(organizationId.toUpperCase());
+    expect(anonymizeIds.mock.calls.at(0)?.[0].forcedSensitiveValues).toContain(
+      organizationId.toUpperCase(),
+    );
   });
 
   test("forces boundary IDs through structured object keys", async () => {
@@ -872,12 +872,13 @@ describe("chat third-party anonymization boundary", () => {
     });
 
     const [preparedTool] = await source.tools();
+    if (!preparedTool) {
+      throw new TypeError("Expected an MCP tool");
+    }
     const description: unknown = Reflect.get(preparedTool, "description");
     const inputSchema: unknown = Reflect.get(preparedTool, "inputSchema");
 
-    expect(description).toBe(
-      "Preserve literal [LITERAL_PLACEHOLDER_1].",
-    );
+    expect(description).toBe("Preserve literal [LITERAL_PLACEHOLDER_1].");
     expect(inputSchema).toEqual({
       type: "object",
       properties: {

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -672,6 +672,46 @@ describe("chat third-party anonymization boundary", () => {
     });
   });
 
+  test("reserves aliases across a structured runtime output", async () => {
+    const { deanonymizeUnknownStringsFromBoundary } =
+      await import("@/api/handlers/chat/third-party-boundary");
+    const boundary = createBoundary();
+    await prepareTextForThirdParty({
+      boundary,
+      text: "Jan Novák prepared the memo.",
+    });
+    const tools = {
+      literal_output: applyChatToolPolicy(
+        toolDefinition({
+          name: "literal_output",
+          description: "Return a structured placeholder collision fixture.",
+        }).server(async () => ({
+          literal: "[LITERAL_PLACEHOLDER_1]",
+          claimed: "[PERSON_1]",
+        })),
+        CHAT_TOOL_POLICY_KIND.internal,
+      ),
+    };
+    const prepared = prepareToolsForThirdParty({
+      boundary,
+      tools: asTestToolSet(tools),
+    });
+    const executable = asTestExecutable<unknown, unknown>(
+      prepared["literal_output"],
+    );
+
+    const output = await executable?.execute?.(undefined);
+
+    expect(output).toEqual({
+      literal: "[LITERAL_PLACEHOLDER_1]",
+      claimed: "[LITERAL_PLACEHOLDER_2]",
+    });
+    expect(deanonymizeUnknownStringsFromBoundary(boundary, output)).toEqual({
+      literal: "[LITERAL_PLACEHOLDER_1]",
+      claimed: "[PERSON_1]",
+    });
+  });
+
   test("allows approved external tools to inherit raw mode", async () => {
     const boundary = createRawBoundary();
     const tools = {

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -64,6 +64,7 @@ const anonymizeTextFieldsMock = mock(
 
 const {
   createChatThirdPartyBoundary,
+  deanonymizeUnknownStringsFromBoundary,
   prepareMcpToolSourceForThirdParty,
   prepareMessagesForThirdParty,
   prepareTextForThirdParty,
@@ -140,19 +141,26 @@ describe("chat third-party anonymization boundary", () => {
       "0198f3e8-75f2-7c11-8af0-111111111111",
     );
     const scopeId = "22222222-2222-4222-8222-222222222222";
-    const anonymizeIds = mock(async ({ fields }: { fields: string[] }) => {
-      const redactionMap = new Map<string, string>();
-      const anonymized = fields.map((field, index) => {
-        const placeholder = `[MISC_${String(index + 1)}]`;
-        redactionMap.set(placeholder, field);
-        return placeholder;
-      });
-      return {
-        entityCount: fields.length,
-        fields: anonymized,
-        redactionMap,
-      };
-    });
+    const anonymizeIds = mock(
+      async ({
+        fields,
+      }: {
+        fields: string[];
+        forcedSensitiveValues?: readonly string[] | undefined;
+      }) => {
+        const redactionMap = new Map<string, string>();
+        const anonymized = fields.map((field, index) => {
+          const placeholder = `[MISC_${String(index + 1)}]`;
+          redactionMap.set(placeholder, field);
+          return placeholder;
+        });
+        return {
+          entityCount: fields.length,
+          fields: anonymized,
+          redactionMap,
+        };
+      },
+    );
     const { scopedDb } = createScopedDbMock({});
     const boundary = createChatThirdPartyBoundary({
       anonymizeFields: anonymizeIds,
@@ -190,6 +198,9 @@ describe("chat third-party anonymization boundary", () => {
       `ref_${organizationId}`,
       `scope:${scopeId}`,
     ]);
+    expect(
+      anonymizeIds.mock.calls.at(0)?.[0].forcedSensitiveValues,
+    ).toContain(organizationId.toUpperCase());
   });
 
   test("forces boundary IDs through structured object keys", async () => {
@@ -218,6 +229,16 @@ describe("chat third-party anonymization boundary", () => {
       throw prepared.error;
     }
     expect(prepared.value).toEqual({ "[MISC_1]": 7 });
+    expect(
+      deanonymizeUnknownStringsFromBoundary(boundary, prepared.value),
+    ).toEqual({ [`tenant:${organizationId}`]: 7 });
+    expect(
+      deanonymizeUnknownStringsFromBoundary(
+        boundary,
+        { MISC_1: 7 },
+        "lenient",
+      ),
+    ).toEqual({ [`tenant:${organizationId}`]: 7 });
     expect(anonymizeIds.mock.calls.at(0)?.[0].fields).toEqual([
       `tenant:${organizationId}`,
     ]);
@@ -696,6 +717,43 @@ describe("chat third-party anonymization boundary", () => {
       `https://example.test/${organizationId}/document.pdf`,
       `ref_${organizationId}`,
     ]);
+  });
+
+  test("refuses opaque inline rich-media tool results", async () => {
+    const boundary = createBoundary();
+    const prepared = await prepareMessagesForThirdParty({
+      boundary,
+      messages: [
+        {
+          id: "msg_1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-result",
+              toolCallId: "call_1",
+              content: [
+                {
+                  type: "image",
+                  source: {
+                    type: "data",
+                    value: "AliceAAA",
+                    mimeType: "image/png",
+                  },
+                },
+              ],
+              state: "complete",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(Result.isError(prepared)).toBe(true);
+    if (Result.isOk(prepared)) {
+      throw new TypeError("Expected inline rich-media refusal");
+    }
+    expect(prepared.error.status).toBe(422);
+    expect(anonymizeTextFieldsMock).not.toHaveBeenCalled();
   });
 
   test("returns anonymized live tool output values", async () => {

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -1118,13 +1118,18 @@ const anonymizeToolResultContent = ({
   }
 
   const prepared = content.map((part) => {
-    if (part.type !== "text") {
-      return part;
+    if (part.type === "text") {
+      const preparedPart = { ...part };
+      queueTextReplacement(replacements, part.content, (value) => {
+        preparedPart.content = value;
+        apply(prepared);
+      });
+      return preparedPart;
     }
 
-    const preparedPart = { ...part };
-    queueTextReplacement(replacements, part.content, (value) => {
-      preparedPart.content = value;
+    const preparedPart = { ...part, source: { ...part.source } };
+    queueTextReplacement(replacements, part.source.value, (value) => {
+      preparedPart.source.value = value;
       apply(prepared);
     });
     return preparedPart;

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -1135,6 +1135,25 @@ const anonymizeToolResultContent = ({
     return preparedPart;
   });
 
+  for (const preparedPart of prepared) {
+    if (preparedPart.type === "text" || preparedPart.metadata === undefined) {
+      continue;
+    }
+    const metadata = anonymizeUnknownStrings({
+      apply: (value) => {
+        preparedPart.metadata = value;
+        apply(prepared);
+      },
+      boundary,
+      replacements,
+      value: preparedPart.metadata,
+    });
+    if (Result.isError(metadata)) {
+      return Result.err(metadata.error);
+    }
+    preparedPart.metadata = metadata.value;
+  }
+
   return Result.ok(prepared);
 };
 

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -1556,7 +1556,11 @@ const collectMcpInputKeyRestorations = ({
     if (preparedEntry === undefined) {
       throw new TypeError("MCP input schema preparation lost a property");
     }
-    const [preparedKey, preparedValue] = preparedEntry;
+    const preparedKey = preparedEntry.at(0);
+    const preparedValue: unknown = preparedEntry.at(1);
+    if (preparedKey === undefined) {
+      throw new TypeError("MCP input schema preparation lost a property key");
+    }
     if (preparedKey !== originalKey) {
       restorations.set(preparedKey, originalKey);
     }
@@ -1640,6 +1644,9 @@ const prepareMcpServerToolForThirdParty = async (
     if (providerValue === undefined) {
       continue;
     }
+    // The boundary assigns placeholders globally, so fields must retain their
+    // deterministic order instead of racing their transformations.
+    // oxlint-disable-next-line no-await-in-loop -- placeholder allocation is order-dependent
     const preparedMetadata = await prepareUnknownForThirdParty({
       anonymizeStructuredKeys: true,
       boundary,

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -182,6 +182,40 @@ const reserveSourcePlaceholders = (
   }
 };
 
+export const reserveThirdPartyBoundarySourcePlaceholders = ({
+  boundary,
+  value,
+}: {
+  boundary: ChatThirdPartyBoundary;
+  value: unknown;
+}) => {
+  if (boundary.type === "raw") {
+    return;
+  }
+
+  const pending: unknown[] = [value];
+  const seen = new WeakSet<object>();
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (typeof current === "string") {
+      reserveSourcePlaceholders(boundary, [current]);
+      continue;
+    }
+    if (
+      typeof current !== "object" ||
+      current === null ||
+      ArrayBuffer.isView(current) ||
+      seen.has(current)
+    ) {
+      continue;
+    }
+    seen.add(current);
+    for (const nested of Object.values(current)) {
+      pending.push(nested);
+    }
+  }
+};
+
 const rewritePlaceholders = (
   text: string,
   replacements: Map<string, string>,

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -66,7 +66,7 @@ export type ChatThirdPartyBoundary =
       pipelineContext: PipelineContext;
       /** Highest placeholder index seen per label after boundary-local rewrites. */
       placeholderOffsets: Map<string, number>;
-      /** Claimed generated token → provider-visible alias for late literal input. */
+      /** Provider-visible alias → late literal token restored at the boundary. */
       literalPlaceholderAliases: Map<string, string>;
       /** Indexed placeholder tokens present literally in provider-bound source text. */
       sourcePlaceholders: Set<string>;
@@ -190,27 +190,30 @@ const encodeLateLiteralPlaceholders = (
   text: string,
 ): string => {
   const replacements = new Map<string, string>();
-  const claimedPlaceholders = [...boundary.redactionMap.keys()];
-  for (const placeholder of claimedPlaceholders) {
-    if (!text.includes(placeholder)) {
+  const restorableTokens = [
+    ...boundary.redactionMap.keys(),
+    ...boundary.literalPlaceholderAliases.keys(),
+  ];
+  for (const token of restorableTokens) {
+    if (!text.includes(token)) {
       continue;
     }
-    let alias = boundary.literalPlaceholderAliases.get(placeholder);
-    if (alias === undefined) {
-      let index = boundary.literalPlaceholderAliases.size + 1;
+
+    let index = boundary.literalPlaceholderAliases.size + 1;
+    let alias = `[LITERAL_PLACEHOLDER_${String(index)}]`;
+    while (
+      text.includes(alias) ||
+      boundary.redactionMap.has(alias) ||
+      boundary.literalPlaceholderAliases.has(alias) ||
+      boundary.sourcePlaceholders.has(alias)
+    ) {
+      index += 1;
       alias = `[LITERAL_PLACEHOLDER_${String(index)}]`;
-      while (
-        boundary.redactionMap.has(alias) ||
-        boundary.sourcePlaceholders.has(alias)
-      ) {
-        index += 1;
-        alias = `[LITERAL_PLACEHOLDER_${String(index)}]`;
-      }
-      boundary.literalPlaceholderAliases.set(placeholder, alias);
-      boundary.sourcePlaceholders.add(alias);
     }
-    replacements.set(placeholder, alias);
-    boundary.sourcePlaceholders.add(placeholder);
+    boundary.literalPlaceholderAliases.set(alias, token);
+    replacements.set(token, alias);
+    boundary.sourcePlaceholders.add(token);
+    boundary.sourcePlaceholders.add(alias);
   }
   return rewritePlaceholders(text, replacements);
 };
@@ -374,13 +377,7 @@ const mergeRedactionMap = (
 
 const literalPlaceholderRestoreMap = (
   boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
-): Map<string, string> =>
-  new Map(
-    [...boundary.literalPlaceholderAliases].map(([placeholder, alias]) => [
-      alias,
-      placeholder,
-    ]),
-  );
+): Map<string, string> => new Map(boundary.literalPlaceholderAliases);
 
 /**
  * Reverse the anonymization for outgoing assistant content. No-op

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -66,6 +66,8 @@ export type ChatThirdPartyBoundary =
       pipelineContext: PipelineContext;
       /** Highest placeholder index seen per label after boundary-local rewrites. */
       placeholderOffsets: Map<string, number>;
+      /** Claimed generated token → provider-visible alias for late literal input. */
+      literalPlaceholderAliases: Map<string, string>;
       /** Indexed placeholder tokens present literally in provider-bound source text. */
       sourcePlaceholders: Set<string>;
       /**
@@ -124,6 +126,7 @@ export const createChatThirdPartyBoundary = ({
         organizationId,
         pipelineContext: createPipelineContext(),
         placeholderOffsets: new Map<string, number>(),
+        literalPlaceholderAliases: new Map<string, string>(),
         redactionMap: new Map<string, string>(),
         scopedDb,
         sourcePlaceholders: new Set<string>(),
@@ -180,6 +183,36 @@ const reserveSourcePlaceholders = (
       boundary.sourcePlaceholders.add(match[0]);
     }
   }
+};
+
+const encodeLateLiteralPlaceholders = (
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
+  text: string,
+): string => {
+  const replacements = new Map<string, string>();
+  const claimedPlaceholders = [...boundary.redactionMap.keys()];
+  for (const placeholder of claimedPlaceholders) {
+    if (!text.includes(placeholder)) {
+      continue;
+    }
+    let alias = boundary.literalPlaceholderAliases.get(placeholder);
+    if (alias === undefined) {
+      let index = boundary.literalPlaceholderAliases.size + 1;
+      alias = `[LITERAL_PLACEHOLDER_${String(index)}]`;
+      while (
+        boundary.redactionMap.has(alias) ||
+        boundary.sourcePlaceholders.has(alias)
+      ) {
+        index += 1;
+        alias = `[LITERAL_PLACEHOLDER_${String(index)}]`;
+      }
+      boundary.literalPlaceholderAliases.set(placeholder, alias);
+      boundary.sourcePlaceholders.add(alias);
+    }
+    replacements.set(placeholder, alias);
+    boundary.sourcePlaceholders.add(placeholder);
+  }
+  return rewritePlaceholders(text, replacements);
 };
 
 export const reserveThirdPartyBoundarySourcePlaceholders = ({
@@ -339,6 +372,16 @@ const mergeRedactionMap = (
   }
 };
 
+const literalPlaceholderRestoreMap = (
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
+): Map<string, string> =>
+  new Map(
+    [...boundary.literalPlaceholderAliases].map(([placeholder, alias]) => [
+      alias,
+      placeholder,
+    ]),
+  );
+
 /**
  * Reverse the anonymization for outgoing assistant content. No-op
  * for raw boundaries and for placeholders not seen on the way in
@@ -352,10 +395,17 @@ export const deanonymizeFromBoundary = ({
   boundary: ChatThirdPartyBoundary;
   text: string;
 }): string => {
-  if (boundary.type === "raw" || boundary.redactionMap.size === 0) {
+  if (boundary.type === "raw") {
     return text;
   }
-  return deanonymise(text, boundary.redactionMap);
+  const deanonymized =
+    boundary.redactionMap.size === 0
+      ? text
+      : deanonymise(text, boundary.redactionMap);
+  return rewritePlaceholders(
+    deanonymized,
+    literalPlaceholderRestoreMap(boundary),
+  );
 };
 
 const PLACEHOLDER_LIKE = /\[[A-Z][A-Z0-9_]*\]/u;
@@ -382,17 +432,20 @@ export const deanonymizeUnknownStringsFromBoundary = (
   value: unknown,
   mode: "strict" | "lenient" = "strict",
 ): unknown => {
-  if (boundary.type === "raw" || boundary.redactionMap.size === 0) {
+  if (boundary.type === "raw") {
     return value;
   }
+  const literalRestorations = literalPlaceholderRestoreMap(boundary);
   if (mode === "strict") {
-    return walkStrict(value, boundary.redactionMap);
+    const deanonymized = walkStrict(value, boundary.redactionMap);
+    return walkStrict(deanonymized, literalRestorations);
   }
   const lenient = buildLenientReplacer(boundary.redactionMap);
-  if (lenient === null) {
-    return value;
-  }
-  return walkLenient(value, lenient);
+  const deanonymized = lenient === null ? value : walkLenient(value, lenient);
+  const literalLenient = buildLenientReplacer(literalRestorations);
+  return literalLenient === null
+    ? deanonymized
+    : walkLenient(deanonymized, literalLenient);
 };
 
 const walkStrict = (value: unknown, map: Map<string, string>): unknown => {
@@ -692,7 +745,7 @@ const preparePartForThirdParty = ({
   }
 
   if (part.type === "tool-call" || part.type === "tool-result") {
-    return anonymizeToolPart({ part, replacements });
+    return anonymizeToolPart({ boundary, part, replacements });
   }
 
   return Result.ok(part);
@@ -822,22 +875,36 @@ const shouldPreserveStructuredString = (
 
 const anonymizeUnknownStrings = ({
   apply,
+  boundary,
+  encodeClaimedPlaceholders = false,
   key,
   replacements,
   value,
 }: {
   apply?: ((value: unknown) => void) | undefined;
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>;
+  encodeClaimedPlaceholders?: boolean | undefined;
   key?: string | undefined;
   replacements: TextReplacement[];
   value: unknown;
 }): Result<unknown, BoundaryRefusal> => {
   if (typeof value === "string") {
-    if (key && shouldPreserveStructuredString(key, value)) {
-      return Result.ok(value);
+    const sourceValue = encodeClaimedPlaceholders
+      ? encodeLateLiteralPlaceholders(boundary, value)
+      : value;
+    const isForcedBoundaryValue =
+      value === boundary.organizationId ||
+      value === boundary.anonymizationScopeId;
+    if (
+      key &&
+      shouldPreserveStructuredString(key, value) &&
+      !isForcedBoundaryValue
+    ) {
+      return Result.ok(sourceValue);
     }
 
-    let prepared = value;
-    queueTextReplacement(replacements, value, (next) => {
+    let prepared = sourceValue;
+    queueTextReplacement(replacements, sourceValue, (next) => {
       prepared = next;
       apply?.(prepared);
     });
@@ -856,6 +923,8 @@ const anonymizeUnknownStrings = ({
             output[index] = next;
             apply?.(output);
           },
+          boundary,
+          encodeClaimedPlaceholders,
           key,
           replacements,
           value: item,
@@ -879,6 +948,8 @@ const anonymizeUnknownStrings = ({
           Object.assign(output, { [nestedKey]: next });
           apply?.(output);
         },
+        boundary,
+        encodeClaimedPlaceholders,
         key: nestedKey,
         replacements,
         value: nestedValue,
@@ -912,6 +983,7 @@ export const prepareUnknownForThirdParty = async ({
     apply: (next) => {
       preparedValue = next;
     },
+    boundary,
     replacements,
     value,
   });
@@ -936,9 +1008,11 @@ type ToolResultPart = Extract<
   { type: "tool-result" }
 >;
 const anonymizeToolPart = ({
+  boundary,
   part,
   replacements,
 }: {
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>;
   part: ToolLikePart;
   replacements: TextReplacement[];
 }): Result<ToolLikePart, BoundaryRefusal> =>
@@ -951,6 +1025,7 @@ const anonymizeToolPart = ({
         apply: (value) => {
           Reflect.set(prepared, "arguments", safeStringifyToolArguments(value));
         },
+        boundary,
         replacements,
         value: parsedArguments,
       });
@@ -966,6 +1041,7 @@ const anonymizeToolPart = ({
         apply: (value) => {
           Reflect.set(prepared, "content", value);
         },
+        boundary,
         content: part.content,
         replacements,
       });
@@ -977,6 +1053,7 @@ const anonymizeToolPart = ({
         apply: (value) => {
           Reflect.set(prepared, "input", value);
         },
+        boundary,
         replacements,
         value: part.input,
       });
@@ -988,6 +1065,7 @@ const anonymizeToolPart = ({
         apply: (value) => {
           Reflect.set(prepared, "output", value);
         },
+        boundary,
         replacements,
         value: part.output,
       });
@@ -1026,15 +1104,22 @@ const anonymizeToolPart = ({
 
 const anonymizeToolResultContent = ({
   apply,
+  boundary,
   content,
   replacements,
 }: {
   apply: (value: ToolResultPart["content"]) => void;
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>;
   content: ToolResultPart["content"];
   replacements: TextReplacement[];
 }): Result<ToolResultPart["content"], BoundaryRefusal> => {
   if (typeof content === "string") {
-    return anonymizeToolResultTextContent({ apply, content, replacements });
+    return anonymizeToolResultTextContent({
+      apply,
+      boundary,
+      content,
+      replacements,
+    });
   }
 
   const prepared = content.map((part) => {
@@ -1055,10 +1140,12 @@ const anonymizeToolResultContent = ({
 
 const anonymizeToolResultTextContent = ({
   apply,
+  boundary,
   content,
   replacements,
 }: {
   apply: (value: string) => void;
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>;
   content: string;
   replacements: TextReplacement[];
 }): Result<string, BoundaryRefusal> => {
@@ -1082,6 +1169,7 @@ const anonymizeToolResultTextContent = ({
       prepared = safeStringifyToolResultContent({ fallback: content, value });
       apply(prepared);
     },
+    boundary,
     replacements,
     value: parsed.value,
   });
@@ -1277,6 +1365,8 @@ const anonymizeToolOutputForThirdParty = async ({
     apply: (value) => {
       preparedOutput = value;
     },
+    boundary,
+    encodeClaimedPlaceholders: true,
     replacements,
     value: outputValue,
   });

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -1070,9 +1070,11 @@ const anonymizeUnknownStrings = ({
  */
 export const prepareUnknownForThirdParty = async ({
   boundary,
+  encodeClaimedPlaceholders = false,
   value,
 }: {
   boundary: ChatThirdPartyBoundary;
+  encodeClaimedPlaceholders?: boolean;
   value: unknown;
 }): Promise<Result<unknown, BoundaryRefusal>> => {
   if (boundary.type === "raw") {
@@ -1088,6 +1090,7 @@ export const prepareUnknownForThirdParty = async ({
       preparedValue = next;
     },
     boundary,
+    encodeClaimedPlaceholders,
     replacements,
     value,
   });
@@ -1466,11 +1469,41 @@ export const prepareMcpToolSourceForThirdParty = ({
     ...source,
     tools: async (options) => {
       const tools = await source.tools(options);
-      return await Promise.all(
-        tools.map((tool) => prepareMcpServerToolForThirdParty(boundary, tool)),
-      );
+      return await prepareMcpServerToolsForThirdParty({ boundary, tools });
     },
   };
+};
+
+const MCP_PROVIDER_METADATA_FIELDS = [
+  "name",
+  "description",
+  "inputSchema",
+  "outputSchema",
+] as const;
+
+const prepareMcpServerToolsForThirdParty = async ({
+  boundary,
+  index = 0,
+  prepared = [],
+  tools,
+}: {
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>;
+  index?: number;
+  prepared?: AnyServerTool[];
+  tools: AnyServerTool[];
+}): Promise<AnyServerTool[]> => {
+  const tool = tools.at(index);
+  if (tool === undefined) {
+    return prepared;
+  }
+
+  prepared.push(await prepareMcpServerToolForThirdParty(boundary, tool));
+  return await prepareMcpServerToolsForThirdParty({
+    boundary,
+    index: index + 1,
+    prepared,
+    tools,
+  });
 };
 
 const prepareMcpServerToolForThirdParty = async (
@@ -1479,24 +1512,31 @@ const prepareMcpServerToolForThirdParty = async (
 ): Promise<AnyServerTool> => {
   reserveThirdPartyBoundarySourcePlaceholders({ boundary, value: tool });
   const prepared = { ...tool };
-  for (const field of [
-    "name",
-    "description",
-    "inputSchema",
-    "outputSchema",
-  ] as const) {
+  const providerMetadata: Record<string, unknown> = {};
+  for (const field of MCP_PROVIDER_METADATA_FIELDS) {
     const providerValue: unknown = Reflect.get(prepared, field);
-    if (providerValue === undefined) {
-      continue;
+    if (providerValue !== undefined) {
+      Reflect.set(providerMetadata, field, providerValue);
     }
-    const preparedValue = await prepareUnknownForThirdParty({
-      boundary,
-      value: providerValue,
-    });
-    if (Result.isError(preparedValue)) {
-      throw preparedValue.error;
+  }
+  const preparedMetadata = await prepareUnknownForThirdParty({
+    boundary,
+    encodeClaimedPlaceholders: true,
+    value: providerMetadata,
+  });
+  if (Result.isError(preparedMetadata)) {
+    throw preparedMetadata.error;
+  }
+  if (
+    typeof preparedMetadata.value !== "object" ||
+    preparedMetadata.value === null
+  ) {
+    throw new TypeError("MCP provider metadata preparation changed its shape");
+  }
+  for (const field of MCP_PROVIDER_METADATA_FIELDS) {
+    if (Reflect.has(preparedMetadata.value, field)) {
+      Reflect.set(prepared, field, Reflect.get(preparedMetadata.value, field));
     }
-    Reflect.set(prepared, field, preparedValue.value);
   }
 
   const execute = prepared.execute;

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -1504,6 +1504,93 @@ const MCP_PROVIDER_METADATA_FIELDS = [
   "outputSchema",
 ] as const;
 
+const collectMcpInputKeyRestorations = ({
+  original,
+  prepared,
+  restorations,
+}: {
+  original: unknown;
+  prepared: unknown;
+  restorations: Map<string, string>;
+}): void => {
+  if (Array.isArray(original) && Array.isArray(prepared)) {
+    if (original.length !== prepared.length) {
+      throw new TypeError(
+        "MCP input schema preparation changed its array shape",
+      );
+    }
+    for (let index = 0; index < original.length; index += 1) {
+      collectMcpInputKeyRestorations({
+        original: original.at(index),
+        prepared: prepared.at(index),
+        restorations,
+      });
+    }
+    return;
+  }
+
+  if (
+    typeof original !== "object" ||
+    original === null ||
+    Array.isArray(original) ||
+    typeof prepared !== "object" ||
+    prepared === null ||
+    Array.isArray(prepared)
+  ) {
+    return;
+  }
+
+  const originalEntries = Object.entries(original);
+  const preparedEntries = Object.entries(prepared);
+  if (originalEntries.length !== preparedEntries.length) {
+    throw new TypeError(
+      "MCP input schema preparation changed its object shape",
+    );
+  }
+
+  for (const [
+    index,
+    [originalKey, originalValue],
+  ] of originalEntries.entries()) {
+    const preparedEntry = preparedEntries.at(index);
+    if (preparedEntry === undefined) {
+      throw new TypeError("MCP input schema preparation lost a property");
+    }
+    const [preparedKey, preparedValue] = preparedEntry;
+    if (preparedKey !== originalKey) {
+      restorations.set(preparedKey, originalKey);
+    }
+    collectMcpInputKeyRestorations({
+      original: originalValue,
+      prepared: preparedValue,
+      restorations,
+    });
+  }
+};
+
+const restoreMcpInputSchemaKeys = ({
+  restorations,
+  value,
+}: {
+  restorations: ReadonlyMap<string, string>;
+  value: unknown;
+}): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      restoreMcpInputSchemaKeys({ restorations, value: item }),
+    );
+  }
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nested]) => [
+      restorations.get(key) ?? key,
+      restoreMcpInputSchemaKeys({ restorations, value: nested }),
+    ]),
+  );
+};
+
 const prepareMcpServerToolsForThirdParty = async ({
   boundary,
   index = 0,
@@ -1547,32 +1634,29 @@ const prepareMcpServerToolForThirdParty = async (
       throw nameCheck.error;
     }
   }
-  const providerMetadata: Record<string, unknown> = {};
+  const inputKeyRestorations = new Map<string, string>();
   for (const field of MCP_PROVIDER_METADATA_FIELDS) {
     const providerValue: unknown = Reflect.get(prepared, field);
-    if (providerValue !== undefined) {
-      Reflect.set(providerMetadata, field, providerValue);
+    if (providerValue === undefined) {
+      continue;
     }
-  }
-  const preparedMetadata = await prepareUnknownForThirdParty({
-    anonymizeStructuredKeys: true,
-    boundary,
-    encodeClaimedPlaceholders: true,
-    value: providerMetadata,
-  });
-  if (Result.isError(preparedMetadata)) {
-    throw preparedMetadata.error;
-  }
-  if (
-    typeof preparedMetadata.value !== "object" ||
-    preparedMetadata.value === null
-  ) {
-    throw new TypeError("MCP provider metadata preparation changed its shape");
-  }
-  for (const field of MCP_PROVIDER_METADATA_FIELDS) {
-    if (Reflect.has(preparedMetadata.value, field)) {
-      Reflect.set(prepared, field, Reflect.get(preparedMetadata.value, field));
+    const preparedMetadata = await prepareUnknownForThirdParty({
+      anonymizeStructuredKeys: true,
+      boundary,
+      encodeClaimedPlaceholders: true,
+      value: providerValue,
+    });
+    if (Result.isError(preparedMetadata)) {
+      throw preparedMetadata.error;
     }
+    if (field === "inputSchema") {
+      collectMcpInputKeyRestorations({
+        original: providerValue,
+        prepared: preparedMetadata.value,
+        restorations: inputKeyRestorations,
+      });
+    }
+    Reflect.set(prepared, field, preparedMetadata.value);
   }
 
   const execute = prepared.execute;
@@ -1583,7 +1667,13 @@ const prepareMcpServerToolForThirdParty = async (
   return {
     ...prepared,
     execute: async (input, context) => {
-      const outputValue: unknown = await execute(input, context);
+      const outputValue: unknown = await execute(
+        restoreMcpInputSchemaKeys({
+          restorations: inputKeyRestorations,
+          value: input,
+        }),
+        context,
+      );
       return await anonymizeToolOutputForThirdParty({
         boundary,
         outputValue,

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -948,17 +948,18 @@ const anonymizeUnknownStrings = ({
       let preparedKey = encodeClaimedPlaceholders
         ? encodeLateLiteralPlaceholders(boundary, nestedKey)
         : nestedKey;
+      let preparedValue: unknown;
       if (containsForcedBoundaryValue(boundary, nestedKey)) {
         queueTextReplacement(replacements, preparedKey, (next) => {
-          const currentValue = Reflect.get(output, preparedKey);
           Reflect.deleteProperty(output, preparedKey);
           preparedKey = next;
-          Object.assign(output, { [preparedKey]: currentValue });
+          Object.assign(output, { [preparedKey]: preparedValue });
           apply?.(output);
         });
       }
       const nestedPrepared = yield* anonymizeUnknownStrings({
         apply: (next) => {
+          preparedValue = next;
           Object.assign(output, { [preparedKey]: next });
           apply?.(output);
         },
@@ -968,6 +969,7 @@ const anonymizeUnknownStrings = ({
         replacements,
         value: nestedValue,
       });
+      preparedValue = nestedPrepared;
       Object.assign(output, { [preparedKey]: nestedPrepared });
     }
 

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -1595,6 +1595,49 @@ const restoreMcpInputSchemaKeys = ({
   );
 };
 
+const prepareMcpProviderMetadataForThirdParty = async ({
+  boundary,
+  index = 0,
+  inputKeyRestorations,
+  prepared,
+}: {
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>;
+  index?: number;
+  inputKeyRestorations: Map<string, string>;
+  prepared: AnyServerTool;
+}): Promise<void> => {
+  const field = MCP_PROVIDER_METADATA_FIELDS.at(index);
+  if (field === undefined) {
+    return;
+  }
+  const providerValue: unknown = Reflect.get(prepared, field);
+  if (providerValue !== undefined) {
+    const preparedMetadata = await prepareUnknownForThirdParty({
+      anonymizeStructuredKeys: true,
+      boundary,
+      encodeClaimedPlaceholders: true,
+      value: providerValue,
+    });
+    if (Result.isError(preparedMetadata)) {
+      throw preparedMetadata.error;
+    }
+    if (field === "inputSchema") {
+      collectMcpInputKeyRestorations({
+        original: providerValue,
+        prepared: preparedMetadata.value,
+        restorations: inputKeyRestorations,
+      });
+    }
+    Reflect.set(prepared, field, preparedMetadata.value);
+  }
+  return await prepareMcpProviderMetadataForThirdParty({
+    boundary,
+    index: index + 1,
+    inputKeyRestorations,
+    prepared,
+  });
+};
+
 const prepareMcpServerToolsForThirdParty = async ({
   boundary,
   index = 0,
@@ -1639,32 +1682,11 @@ const prepareMcpServerToolForThirdParty = async (
     }
   }
   const inputKeyRestorations = new Map<string, string>();
-  for (const field of MCP_PROVIDER_METADATA_FIELDS) {
-    const providerValue: unknown = Reflect.get(prepared, field);
-    if (providerValue === undefined) {
-      continue;
-    }
-    // The boundary assigns placeholders globally, so fields must retain their
-    // deterministic order instead of racing their transformations.
-    // oxlint-disable-next-line no-await-in-loop -- placeholder allocation is order-dependent
-    const preparedMetadata = await prepareUnknownForThirdParty({
-      anonymizeStructuredKeys: true,
-      boundary,
-      encodeClaimedPlaceholders: true,
-      value: providerValue,
-    });
-    if (Result.isError(preparedMetadata)) {
-      throw preparedMetadata.error;
-    }
-    if (field === "inputSchema") {
-      collectMcpInputKeyRestorations({
-        original: providerValue,
-        prepared: preparedMetadata.value,
-        restorations: inputKeyRestorations,
-      });
-    }
-    Reflect.set(prepared, field, preparedMetadata.value);
-  }
+  await prepareMcpProviderMetadataForThirdParty({
+    boundary,
+    inputKeyRestorations,
+    prepared,
+  });
 
   const execute = prepared.execute;
   if (!execute) {

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -839,8 +839,6 @@ const TECHNICAL_IDENTIFIER_KEYS = new Set([
 
 const TECHNICAL_IDENTIFIER_PATTERN =
   /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|[a-z][a-z0-9]*_[A-Za-z0-9-]+)$/iu;
-const UUID_IDENTIFIER_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 
 const containsForcedBoundaryValue = (
   boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
@@ -849,8 +847,7 @@ const containsForcedBoundaryValue = (
   boundaryForcedSensitiveValues(boundary).some(
     (forcedValue) =>
       value.includes(forcedValue) ||
-      (UUID_IDENTIFIER_PATTERN.test(forcedValue) &&
-        value.toLowerCase().includes(forcedValue.toLowerCase())),
+      value.toLowerCase().includes(forcedValue.toLowerCase()),
   );
 
 const shouldPreserveStructuredString = (
@@ -948,9 +945,21 @@ const anonymizeUnknownStrings = ({
     const output = {};
 
     for (const [nestedKey, nestedValue] of Object.entries(value)) {
+      let preparedKey = encodeClaimedPlaceholders
+        ? encodeLateLiteralPlaceholders(boundary, nestedKey)
+        : nestedKey;
+      if (containsForcedBoundaryValue(boundary, nestedKey)) {
+        queueTextReplacement(replacements, preparedKey, (next) => {
+          const currentValue = Reflect.get(output, preparedKey);
+          Reflect.deleteProperty(output, preparedKey);
+          preparedKey = next;
+          Object.assign(output, { [preparedKey]: currentValue });
+          apply?.(output);
+        });
+      }
       const nestedPrepared = yield* anonymizeUnknownStrings({
         apply: (next) => {
-          Object.assign(output, { [nestedKey]: next });
+          Object.assign(output, { [preparedKey]: next });
           apply?.(output);
         },
         boundary,
@@ -959,7 +968,7 @@ const anonymizeUnknownStrings = ({
         replacements,
         value: nestedValue,
       });
-      Object.assign(output, { [nestedKey]: nestedPrepared });
+      Object.assign(output, { [preparedKey]: nestedPrepared });
     }
 
     return Result.ok(output);

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -66,6 +66,8 @@ export type ChatThirdPartyBoundary =
       pipelineContext: PipelineContext;
       /** Highest placeholder index seen per label after boundary-local rewrites. */
       placeholderOffsets: Map<string, number>;
+      /** Indexed placeholder tokens present literally in provider-bound source text. */
+      sourcePlaceholders: Set<string>;
       /**
        * Cumulative placeholder → original map across every
        * anonymization call on this boundary. Mutated as the request
@@ -124,6 +126,7 @@ export const createChatThirdPartyBoundary = ({
         placeholderOffsets: new Map<string, number>(),
         redactionMap: new Map<string, string>(),
         scopedDb,
+        sourcePlaceholders: new Set<string>(),
       }
     : { type: "raw" };
 
@@ -174,14 +177,7 @@ const reserveSourcePlaceholders = (
 ) => {
   for (const field of fields) {
     for (const match of field.matchAll(INDEXED_PLACEHOLDER_OCCURRENCE)) {
-      const parsed = parseIndexedPlaceholder(match[0]);
-      if (parsed === null) {
-        continue;
-      }
-      const currentOffset = boundary.placeholderOffsets.get(parsed.label) ?? 0;
-      if (parsed.index > currentOffset) {
-        boundary.placeholderOffsets.set(parsed.label, parsed.index);
-      }
+      boundary.sourcePlaceholders.add(match[0]);
     }
   }
 };
@@ -262,10 +258,21 @@ const rewriteBoundaryPlaceholders = (
       continue;
     }
 
-    const nextIndex =
+    let nextIndex =
       nextIndexByLabel.get(parsed.label) ??
       (boundary.placeholderOffsets.get(parsed.label) ?? 0) + 1;
-    const nextPlaceholder = `[${parsed.label}_${nextIndex}]`;
+    let nextPlaceholder = `[${parsed.label}_${String(nextIndex)}]`;
+    while (
+      boundary.sourcePlaceholders.has(nextPlaceholder) ||
+      boundary.redactionMap.has(nextPlaceholder) ||
+      redactionMap.has(nextPlaceholder)
+    ) {
+      nextIndex += 1;
+      if (!Number.isSafeInteger(nextIndex)) {
+        throw new TypeError("placeholder index exceeds the safe integer range");
+      }
+      nextPlaceholder = `[${parsed.label}_${String(nextIndex)}]`;
+    }
     replacements.set(placeholder, nextPlaceholder);
     redactionMap.set(nextPlaceholder, original);
     nextIndexByLabel.set(parsed.label, nextIndex + 1);

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -839,6 +839,19 @@ const TECHNICAL_IDENTIFIER_KEYS = new Set([
 
 const TECHNICAL_IDENTIFIER_PATTERN =
   /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|[a-z][a-z0-9]*_[A-Za-z0-9-]+)$/iu;
+const UUID_IDENTIFIER_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+
+const containsForcedBoundaryValue = (
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
+  value: string,
+): boolean =>
+  boundaryForcedSensitiveValues(boundary).some(
+    (forcedValue) =>
+      value.includes(forcedValue) ||
+      (UUID_IDENTIFIER_PATTERN.test(forcedValue) &&
+        value.toLowerCase().includes(forcedValue.toLowerCase())),
+  );
 
 const shouldPreserveStructuredString = (
   key: string,
@@ -887,13 +900,10 @@ const anonymizeUnknownStrings = ({
     const sourceValue = encodeClaimedPlaceholders
       ? encodeLateLiteralPlaceholders(boundary, value)
       : value;
-    const containsForcedBoundaryValue = boundaryForcedSensitiveValues(
-      boundary,
-    ).some((forcedValue) => value.includes(forcedValue));
     if (
       key &&
       shouldPreserveStructuredString(key, value) &&
-      !containsForcedBoundaryValue
+      !containsForcedBoundaryValue(boundary, value)
     ) {
       return Result.ok(sourceValue);
     }

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -256,6 +256,42 @@ const boundaryForcedSensitiveValues = (
   boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
 ): string[] => [boundary.organizationId, boundary.anonymizationScopeId];
 
+const boundarySensitiveSurfaces = (
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
+  text: string,
+): string[] => {
+  const normalizedText = text.toLowerCase();
+  const surfaces = new Set<string>();
+  for (const forcedValue of boundaryForcedSensitiveValues(boundary)) {
+    if (forcedValue.length === 0) {
+      continue;
+    }
+    const normalizedForcedValue = forcedValue.toLowerCase();
+    let offset = normalizedText.indexOf(normalizedForcedValue);
+    while (offset !== -1) {
+      surfaces.add(text.slice(offset, offset + forcedValue.length));
+      offset = normalizedText.indexOf(
+        normalizedForcedValue,
+        offset + forcedValue.length,
+      );
+    }
+  }
+  return [...surfaces];
+};
+
+const forcedSensitiveValuesForFields = (
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
+  fields: readonly string[],
+): string[] => {
+  const values = new Set(boundaryForcedSensitiveValues(boundary));
+  for (const field of fields) {
+    for (const surface of boundarySensitiveSurfaces(boundary, field)) {
+      values.add(surface);
+    }
+  }
+  return [...values];
+};
+
 const rewritePlaceholders = (
   text: string,
   replacements: Map<string, string>,
@@ -460,7 +496,11 @@ const walkStrict = (value: unknown, map: Map<string, string>): unknown => {
     return value;
   }
   const entries = Object.entries(value).map(
-    ([key, nested]) => [key, walkStrict(nested, map)] as const,
+    ([key, nested]) =>
+      [
+        PLACEHOLDER_LIKE.test(key) ? deanonymise(key, map) : key,
+        walkStrict(nested, map),
+      ] as const,
   );
   return Object.fromEntries(entries);
 };
@@ -511,12 +551,15 @@ const buildLenientReplacer = (
   return { pattern: new RegExp(parts.join("|"), "gu"), lookup };
 };
 
+const replaceLenient = (value: string, replacer: LenientReplacer): string =>
+  value.replaceAll(
+    replacer.pattern,
+    (token) => replacer.lookup.get(token) ?? token,
+  );
+
 const walkLenient = (value: unknown, replacer: LenientReplacer): unknown => {
   if (typeof value === "string") {
-    return value.replaceAll(
-      replacer.pattern,
-      (token) => replacer.lookup.get(token) ?? token,
-    );
+    return replaceLenient(value, replacer);
   }
   if (Array.isArray(value)) {
     return value.map((item: unknown) => walkLenient(item, replacer));
@@ -525,7 +568,8 @@ const walkLenient = (value: unknown, replacer: LenientReplacer): unknown => {
     return value;
   }
   const entries = Object.entries(value).map(
-    ([key, nested]) => [key, walkLenient(nested, replacer)] as const,
+    ([key, nested]) =>
+      [replaceLenient(key, replacer), walkLenient(nested, replacer)] as const,
   );
   return Object.fromEntries(entries);
 };
@@ -556,7 +600,9 @@ export const prepareTextForThirdParty = async ({
       await anonymizeFields({
         context: boundary.pipelineContext,
         fields: protectedInput.fields,
-        forcedSensitiveValues: boundaryForcedSensitiveValues(boundary),
+        forcedSensitiveValues: forcedSensitiveValuesForFields(boundary, [
+          text,
+        ]),
         gazetteerEntries: await boundary.gazetteerEntries,
         excludedCanonicals: await boundary.excludedCanonicals,
         organizationId: boundary.organizationId,
@@ -600,7 +646,10 @@ const prepareTextBatchForThirdParty = async ({
       await anonymizeFields({
         context: boundary.pipelineContext,
         fields: protectedInput.fields,
-        forcedSensitiveValues: boundaryForcedSensitiveValues(boundary),
+        forcedSensitiveValues: forcedSensitiveValuesForFields(
+          boundary,
+          fields,
+        ),
         gazetteerEntries: await boundary.gazetteerEntries,
         excludedCanonicals: await boundary.excludedCanonicals,
         organizationId: boundary.organizationId,
@@ -844,11 +893,7 @@ const containsForcedBoundaryValue = (
   boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
   value: string,
 ): boolean =>
-  boundaryForcedSensitiveValues(boundary).some(
-    (forcedValue) =>
-      value.includes(forcedValue) ||
-      value.toLowerCase().includes(forcedValue.toLowerCase()),
-  );
+  boundarySensitiveSurfaces(boundary, value).length > 0;
 
 const shouldPreserveStructuredString = (
   key: string,
@@ -1136,6 +1181,20 @@ const anonymizeToolResultContent = ({
       content,
       replacements,
     });
+  }
+
+  if (
+    content.some(
+      (part) => part.type !== "text" && part.source.type === "data",
+    )
+  ) {
+    return Result.err(
+      new HandlerError({
+        status: 422,
+        message:
+          "Inline rich-media data cannot cross an anonymized third-party boundary.",
+      }),
+    );
   }
 
   const prepared = content.map((part) => {

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -134,6 +134,8 @@ type AnonymizedTextFieldsResult = {
 };
 
 const INDEXED_PLACEHOLDER = /^\[(?<label>[A-Z][A-Z0-9_]*)_(?<index>\d+)\]$/u;
+const INDEXED_PLACEHOLDER_OCCURRENCE =
+  /\[(?<label>[A-Z][A-Z0-9_]*)_(?<index>\d+)\]/gu;
 
 const parseIndexedPlaceholder = (
   placeholder: string,
@@ -164,6 +166,24 @@ const findExistingPlaceholder = (
   }
 
   return null;
+};
+
+const reserveSourcePlaceholders = (
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
+  fields: string[],
+) => {
+  for (const field of fields) {
+    for (const match of field.matchAll(INDEXED_PLACEHOLDER_OCCURRENCE)) {
+      const parsed = parseIndexedPlaceholder(match[0]);
+      if (parsed === null) {
+        continue;
+      }
+      const currentOffset = boundary.placeholderOffsets.get(parsed.label) ?? 0;
+      if (parsed.index > currentOffset) {
+        boundary.placeholderOffsets.set(parsed.label, parsed.index);
+      }
+    }
+  }
 };
 
 const rewritePlaceholders = (
@@ -434,6 +454,7 @@ export const prepareTextForThirdParty = async ({
   }
 
   const anonymizeFields = boundary.anonymizeFields ?? anonymizeTextFields;
+  reserveSourcePlaceholders(boundary, [text]);
   const protectedInput = protectBoundaryPlaceholders(boundary, [text]);
   const anonymized = await Result.tryPromise({
     try: async () =>
@@ -480,6 +501,7 @@ const prepareTextBatchForThirdParty = async ({
   }
 
   const anonymizeFields = boundary.anonymizeFields ?? anonymizeTextFields;
+  reserveSourcePlaceholders(boundary, fields);
   const protectedInput = protectBoundaryPlaceholders(boundary, fields);
   const anonymized = await Result.tryPromise({
     try: async () =>

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -662,9 +662,7 @@ export const prepareTextForThirdParty = async ({
       await anonymizeFields({
         context: boundary.pipelineContext,
         fields: protectedInput.fields,
-        forcedSensitiveValues: forcedSensitiveValuesForFields(boundary, [
-          text,
-        ]),
+        forcedSensitiveValues: forcedSensitiveValuesForFields(boundary, [text]),
         gazetteerEntries: await boundary.gazetteerEntries,
         excludedCanonicals: await boundary.excludedCanonicals,
         organizationId: boundary.organizationId,
@@ -708,10 +706,7 @@ const prepareTextBatchForThirdParty = async ({
       await anonymizeFields({
         context: boundary.pipelineContext,
         fields: protectedInput.fields,
-        forcedSensitiveValues: forcedSensitiveValuesForFields(
-          boundary,
-          fields,
-        ),
+        forcedSensitiveValues: forcedSensitiveValuesForFields(boundary, fields),
         gazetteerEntries: await boundary.gazetteerEntries,
         excludedCanonicals: await boundary.excludedCanonicals,
         organizationId: boundary.organizationId,
@@ -959,8 +954,7 @@ const TECHNICAL_IDENTIFIER_PATTERN =
 const containsForcedBoundaryValue = (
   boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
   value: string,
-): boolean =>
-  boundarySensitiveSurfaces(boundary, value).length > 0;
+): boolean => boundarySensitiveSurfaces(boundary, value).length > 0;
 
 const shouldPreserveStructuredString = (
   key: string,
@@ -1253,9 +1247,7 @@ const anonymizeToolResultContent = ({
   }
 
   if (
-    content.some(
-      (part) => part.type !== "text" && part.source.type === "data",
-    )
+    content.some((part) => part.type !== "text" && part.source.type === "data")
   ) {
     return Result.err(
       new HandlerError({

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -218,65 +218,6 @@ const encodeLateLiteralPlaceholders = (
   return rewritePlaceholders(text, replacements);
 };
 
-const encodeLateLiteralPlaceholdersInUnknown = ({
-  boundary,
-  seen = new WeakMap<object, unknown>(),
-  value,
-}: {
-  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>;
-  seen?: WeakMap<object, unknown>;
-  value: unknown;
-}): unknown => {
-  if (typeof value === "string") {
-    return encodeLateLiteralPlaceholders(boundary, value);
-  }
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    ArrayBuffer.isView(value)
-  ) {
-    return value;
-  }
-
-  const existing = seen.get(value);
-  if (existing !== undefined) {
-    return existing;
-  }
-
-  if (Array.isArray(value)) {
-    const output: unknown[] = [];
-    seen.set(value, output);
-    for (const nested of value) {
-      output.push(
-        encodeLateLiteralPlaceholdersInUnknown({
-          boundary,
-          seen,
-          value: nested,
-        }),
-      );
-    }
-    return output;
-  }
-
-  const output: Record<string, unknown> = {};
-  seen.set(value, output);
-  for (const [key, nested] of Object.entries(value)) {
-    const encodedKey = encodeLateLiteralPlaceholders(boundary, key);
-    const encodedValue = encodeLateLiteralPlaceholdersInUnknown({
-      boundary,
-      seen,
-      value: nested,
-    });
-    Object.defineProperty(output, encodedKey, {
-      configurable: true,
-      enumerable: true,
-      value: encodedValue,
-      writable: true,
-    });
-  }
-  return output;
-};
-
 export const reserveThirdPartyBoundarySourcePlaceholders = ({
   boundary,
   value,
@@ -638,10 +579,17 @@ const walkLenient = (value: unknown, replacer: LenientReplacer): unknown => {
 
 type BoundaryRefusal = HandlerError<422 | 500>;
 
-type TextReplacement = {
-  text: string;
-  apply: (value: string) => void;
-};
+type TextReplacement =
+  | {
+      type: "replace";
+      text: string;
+      apply: (value: string) => void;
+    }
+  | {
+      type: "reject-if-changed";
+      text: string;
+      message: string;
+    };
 
 export const prepareTextForThirdParty = async ({
   boundary,
@@ -726,12 +674,28 @@ const prepareTextBatchForThirdParty = async ({
   }
 
   const rewritten = rewriteBoundaryPlaceholders(boundary, anonymized.value);
-  mergeRedactionMap(boundary.redactionMap, rewritten.redactionMap);
   const restoredFields = protectedInput.restore(rewritten.fields);
 
   for (let index = 0; index < replacements.length; index += 1) {
-    const replacement = replacements[index];
-    if (replacement === undefined) {
+    const replacement = replacements.at(index);
+    if (
+      replacement?.type === "reject-if-changed" &&
+      restoredFields.at(index) !== replacement.text
+    ) {
+      return Result.err(
+        new HandlerError({
+          code: CHAT_TRANSPORT_ERROR_CODE.thirdPartyBoundaryRefusal,
+          status: 422,
+          message: replacement.message,
+        }),
+      );
+    }
+  }
+
+  mergeRedactionMap(boundary.redactionMap, rewritten.redactionMap);
+  for (let index = 0; index < replacements.length; index += 1) {
+    const replacement = replacements.at(index);
+    if (replacement?.type !== "replace") {
       continue;
     }
 
@@ -750,7 +714,23 @@ const queueTextReplacement = (
     return;
   }
 
-  replacements.push({ text, apply });
+  replacements.push({ type: "replace", text, apply });
+};
+
+const queueOpaqueTextCheck = ({
+  message,
+  replacements,
+  text,
+}: {
+  message: string;
+  replacements: TextReplacement[];
+  text: string;
+}) => {
+  if (text.length === 0) {
+    return;
+  }
+
+  replacements.push({ type: "reject-if-changed", text, message });
 };
 
 const anonymizePlainTextFile = ({
@@ -1268,12 +1248,13 @@ const anonymizeToolResultContent = ({
       return preparedPart;
     }
 
-    const preparedPart = { ...part, source: { ...part.source } };
-    queueTextReplacement(replacements, part.source.value, (value) => {
-      preparedPart.source.value = value;
-      apply(prepared);
+    queueOpaqueTextCheck({
+      message:
+        "Rich-media URLs that contain sensitive data cannot cross an anonymized third-party boundary.",
+      replacements,
+      text: part.source.value,
     });
-    return preparedPart;
+    return { ...part, source: { ...part.source } };
   });
 
   for (const preparedPart of prepared) {
@@ -1485,38 +1466,37 @@ export const prepareMcpToolSourceForThirdParty = ({
     ...source,
     tools: async (options) => {
       const tools = await source.tools(options);
-      return tools.map((tool) =>
-        prepareMcpServerToolForThirdParty(boundary, tool),
+      return await Promise.all(
+        tools.map((tool) => prepareMcpServerToolForThirdParty(boundary, tool)),
       );
     },
   };
 };
 
-const prepareMcpServerToolForThirdParty = (
+const prepareMcpServerToolForThirdParty = async (
   boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
   tool: AnyServerTool,
-): AnyServerTool => {
+): Promise<AnyServerTool> => {
   reserveThirdPartyBoundarySourcePlaceholders({ boundary, value: tool });
   const prepared = { ...tool };
-  for (const field of ["name", "description"] as const) {
-    const providerText: unknown = Reflect.get(prepared, field);
-    if (typeof providerText === "string") {
-      Reflect.set(
-        prepared,
-        field,
-        encodeLateLiteralPlaceholders(boundary, providerText),
-      );
+  for (const field of [
+    "name",
+    "description",
+    "inputSchema",
+    "outputSchema",
+  ] as const) {
+    const providerValue: unknown = Reflect.get(prepared, field);
+    if (providerValue === undefined) {
+      continue;
     }
-  }
-  for (const field of ["inputSchema", "outputSchema"] as const) {
-    const schema: unknown = Reflect.get(prepared, field);
-    if (schema !== undefined) {
-      Reflect.set(
-        prepared,
-        field,
-        encodeLateLiteralPlaceholdersInUnknown({ boundary, value: schema }),
-      );
+    const preparedValue = await prepareUnknownForThirdParty({
+      boundary,
+      value: providerValue,
+    });
+    if (Result.isError(preparedValue)) {
+      throw preparedValue.error;
     }
+    Reflect.set(prepared, field, preparedValue.value);
   }
 
   const execute = prepared.execute;

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -218,6 +218,65 @@ const encodeLateLiteralPlaceholders = (
   return rewritePlaceholders(text, replacements);
 };
 
+const encodeLateLiteralPlaceholdersInUnknown = ({
+  boundary,
+  seen = new WeakMap<object, unknown>(),
+  value,
+}: {
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>;
+  seen?: WeakMap<object, unknown>;
+  value: unknown;
+}): unknown => {
+  if (typeof value === "string") {
+    return encodeLateLiteralPlaceholders(boundary, value);
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    ArrayBuffer.isView(value)
+  ) {
+    return value;
+  }
+
+  const existing = seen.get(value);
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  if (Array.isArray(value)) {
+    const output: unknown[] = [];
+    seen.set(value, output);
+    for (const nested of value) {
+      output.push(
+        encodeLateLiteralPlaceholdersInUnknown({
+          boundary,
+          seen,
+          value: nested,
+        }),
+      );
+    }
+    return output;
+  }
+
+  const output: Record<string, unknown> = {};
+  seen.set(value, output);
+  for (const [key, nested] of Object.entries(value)) {
+    const encodedKey = encodeLateLiteralPlaceholders(boundary, key);
+    const encodedValue = encodeLateLiteralPlaceholdersInUnknown({
+      boundary,
+      seen,
+      value: nested,
+    });
+    Object.defineProperty(output, encodedKey, {
+      configurable: true,
+      enumerable: true,
+      value: encodedValue,
+      writable: true,
+    });
+  }
+  return output;
+};
+
 export const reserveThirdPartyBoundarySourcePlaceholders = ({
   boundary,
   value,
@@ -246,6 +305,9 @@ export const reserveThirdPartyBoundarySourcePlaceholders = ({
       continue;
     }
     seen.add(current);
+    for (const key of Object.keys(current)) {
+      pending.push(key);
+    }
     for (const nested of Object.values(current)) {
       pending.push(nested);
     }
@@ -845,6 +907,11 @@ export const prepareMessagesForThirdParty = async ({
     return Result.ok(providerVisibleMessages);
   }
 
+  reserveThirdPartyBoundarySourcePlaceholders({
+    boundary,
+    value: providerVisibleMessages,
+  });
+
   return await Result.gen(async function* () {
     const prepared: ChatMessage[] = [];
     const replacements: TextReplacement[] = [];
@@ -1037,6 +1104,8 @@ export const prepareUnknownForThirdParty = async ({
   if (boundary.type === "raw") {
     return Result.ok(value);
   }
+
+  reserveThirdPartyBoundarySourcePlaceholders({ boundary, value });
 
   const replacements: TextReplacement[] = [];
   let preparedValue: unknown;
@@ -1339,6 +1408,7 @@ export const prepareToolsForThirdParty = ({
   boundary: ChatThirdPartyBoundary;
   tools: ChatToolMap;
 }): ChatToolMap => {
+  reserveThirdPartyBoundarySourcePlaceholders({ boundary, value: tools });
   const hasExternalTool = Object.values(tools).some(
     (toolDefinition) =>
       toolDefinition !== undefined &&
@@ -1434,13 +1504,36 @@ const prepareMcpServerToolForThirdParty = (
   boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
   tool: AnyServerTool,
 ): AnyServerTool => {
-  const execute = tool.execute;
+  reserveThirdPartyBoundarySourcePlaceholders({ boundary, value: tool });
+  const prepared = { ...tool };
+  for (const field of ["name", "description"] as const) {
+    const providerText: unknown = Reflect.get(prepared, field);
+    if (typeof providerText === "string") {
+      Reflect.set(
+        prepared,
+        field,
+        encodeLateLiteralPlaceholders(boundary, providerText),
+      );
+    }
+  }
+  for (const field of ["inputSchema", "outputSchema"] as const) {
+    const schema: unknown = Reflect.get(prepared, field);
+    if (schema !== undefined) {
+      Reflect.set(
+        prepared,
+        field,
+        encodeLateLiteralPlaceholdersInUnknown({ boundary, value: schema }),
+      );
+    }
+  }
+
+  const execute = prepared.execute;
   if (!execute) {
-    return tool;
+    return prepared;
   }
 
   return {
-    ...tool,
+    ...prepared,
     execute: async (input, context) => {
       const outputValue: unknown = await execute(input, context);
       return await anonymizeToolOutputForThirdParty({

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -733,6 +733,20 @@ const queueOpaqueTextCheck = ({
   replacements.push({ type: "reject-if-changed", text, message });
 };
 
+const validateOpaqueTextForThirdParty = async ({
+  boundary,
+  message,
+  text,
+}: {
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>;
+  message: string;
+  text: string;
+}): Promise<Result<void, BoundaryRefusal>> => {
+  const replacements: TextReplacement[] = [];
+  queueOpaqueTextCheck({ message, replacements, text });
+  return await prepareTextBatchForThirdParty({ boundary, replacements });
+};
+
 const anonymizePlainTextFile = ({
   part,
   replacements,
@@ -965,6 +979,7 @@ const shouldPreserveStructuredString = (
 };
 
 const anonymizeUnknownStrings = ({
+  anonymizeStructuredKeys = false,
   apply,
   boundary,
   encodeClaimedPlaceholders = false,
@@ -972,6 +987,7 @@ const anonymizeUnknownStrings = ({
   replacements,
   value,
 }: {
+  anonymizeStructuredKeys?: boolean | undefined;
   apply?: ((value: unknown) => void) | undefined;
   boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>;
   encodeClaimedPlaceholders?: boolean | undefined;
@@ -1011,6 +1027,7 @@ const anonymizeUnknownStrings = ({
             output[index] = next;
             apply?.(output);
           },
+          anonymizeStructuredKeys,
           boundary,
           encodeClaimedPlaceholders,
           key,
@@ -1035,7 +1052,10 @@ const anonymizeUnknownStrings = ({
         ? encodeLateLiteralPlaceholders(boundary, nestedKey)
         : nestedKey;
       let preparedValue: unknown;
-      if (containsForcedBoundaryValue(boundary, nestedKey)) {
+      if (
+        anonymizeStructuredKeys ||
+        containsForcedBoundaryValue(boundary, nestedKey)
+      ) {
         queueTextReplacement(replacements, preparedKey, (next) => {
           Reflect.deleteProperty(output, preparedKey);
           preparedKey = next;
@@ -1044,6 +1064,7 @@ const anonymizeUnknownStrings = ({
         });
       }
       const nestedPrepared = yield* anonymizeUnknownStrings({
+        anonymizeStructuredKeys,
         apply: (next) => {
           preparedValue = next;
           Object.assign(output, { [preparedKey]: next });
@@ -1069,10 +1090,12 @@ const anonymizeUnknownStrings = ({
  * technical identifiers retain the same preservation rules as tool payloads.
  */
 export const prepareUnknownForThirdParty = async ({
+  anonymizeStructuredKeys = false,
   boundary,
   encodeClaimedPlaceholders = false,
   value,
 }: {
+  anonymizeStructuredKeys?: boolean;
   boundary: ChatThirdPartyBoundary;
   encodeClaimedPlaceholders?: boolean;
   value: unknown;
@@ -1086,6 +1109,7 @@ export const prepareUnknownForThirdParty = async ({
   const replacements: TextReplacement[] = [];
   let preparedValue: unknown;
   const anonymized = anonymizeUnknownStrings({
+    anonymizeStructuredKeys,
     apply: (next) => {
       preparedValue = next;
     },
@@ -1475,7 +1499,6 @@ export const prepareMcpToolSourceForThirdParty = ({
 };
 
 const MCP_PROVIDER_METADATA_FIELDS = [
-  "name",
   "description",
   "inputSchema",
   "outputSchema",
@@ -1512,6 +1535,18 @@ const prepareMcpServerToolForThirdParty = async (
 ): Promise<AnyServerTool> => {
   reserveThirdPartyBoundarySourcePlaceholders({ boundary, value: tool });
   const prepared = { ...tool };
+  const providerName: unknown = Reflect.get(prepared, "name");
+  if (typeof providerName === "string") {
+    const nameCheck = await validateOpaqueTextForThirdParty({
+      boundary,
+      message:
+        "MCP tool names that contain sensitive data cannot cross an anonymized third-party boundary.",
+      text: providerName,
+    });
+    if (Result.isError(nameCheck)) {
+      throw nameCheck.error;
+    }
+  }
   const providerMetadata: Record<string, unknown> = {};
   for (const field of MCP_PROVIDER_METADATA_FIELDS) {
     const providerValue: unknown = Reflect.get(prepared, field);
@@ -1520,6 +1555,7 @@ const prepareMcpServerToolForThirdParty = async (
     }
   }
   const preparedMetadata = await prepareUnknownForThirdParty({
+    anonymizeStructuredKeys: true,
     boundary,
     encodeClaimedPlaceholders: true,
     value: providerMetadata,

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -1356,6 +1356,10 @@ const anonymizeToolOutputForThirdParty = async ({
   boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>;
   outputValue: unknown;
 }): Promise<unknown> => {
+  reserveThirdPartyBoundarySourcePlaceholders({
+    boundary,
+    value: outputValue,
+  });
   const replacements: TextReplacement[] = [];
   let preparedOutput: unknown;
   const anonymizedOutput = anonymizeUnknownStrings({

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -252,6 +252,10 @@ export const reserveThirdPartyBoundarySourcePlaceholders = ({
   }
 };
 
+const boundaryForcedSensitiveValues = (
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>,
+): string[] => [boundary.organizationId, boundary.anonymizationScopeId];
+
 const rewritePlaceholders = (
   text: string,
   replacements: Map<string, string>,
@@ -552,10 +556,7 @@ export const prepareTextForThirdParty = async ({
       await anonymizeFields({
         context: boundary.pipelineContext,
         fields: protectedInput.fields,
-        forcedSensitiveValues: [
-          boundary.organizationId,
-          boundary.anonymizationScopeId,
-        ],
+        forcedSensitiveValues: boundaryForcedSensitiveValues(boundary),
         gazetteerEntries: await boundary.gazetteerEntries,
         excludedCanonicals: await boundary.excludedCanonicals,
         organizationId: boundary.organizationId,
@@ -599,10 +600,7 @@ const prepareTextBatchForThirdParty = async ({
       await anonymizeFields({
         context: boundary.pipelineContext,
         fields: protectedInput.fields,
-        forcedSensitiveValues: [
-          boundary.organizationId,
-          boundary.anonymizationScopeId,
-        ],
+        forcedSensitiveValues: boundaryForcedSensitiveValues(boundary),
         gazetteerEntries: await boundary.gazetteerEntries,
         excludedCanonicals: await boundary.excludedCanonicals,
         organizationId: boundary.organizationId,
@@ -889,13 +887,13 @@ const anonymizeUnknownStrings = ({
     const sourceValue = encodeClaimedPlaceholders
       ? encodeLateLiteralPlaceholders(boundary, value)
       : value;
-    const isForcedBoundaryValue =
-      value === boundary.organizationId ||
-      value === boundary.anonymizationScopeId;
+    const containsForcedBoundaryValue = boundaryForcedSensitiveValues(
+      boundary,
+    ).some((forcedValue) => value.includes(forcedValue));
     if (
       key &&
       shouldPreserveStructuredString(key, value) &&
-      !isForcedBoundaryValue
+      !containsForcedBoundaryValue
     ) {
       return Result.ok(sourceValue);
     }

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -1504,6 +1504,9 @@ const MCP_PROVIDER_METADATA_FIELDS = [
   "outputSchema",
 ] as const;
 
+const unknownObjectEntries = (value: object): [string, unknown][] =>
+  Object.keys(value).map((key) => [key, Reflect.get(value, key)]);
+
 const collectMcpInputKeyRestorations = ({
   original,
   prepared,
@@ -1540,8 +1543,8 @@ const collectMcpInputKeyRestorations = ({
     return;
   }
 
-  const originalEntries = Object.entries(original);
-  const preparedEntries = Object.entries(prepared);
+  const originalEntries = unknownObjectEntries(original);
+  const preparedEntries = unknownObjectEntries(prepared);
   if (originalEntries.length !== preparedEntries.length) {
     throw new TypeError(
       "MCP input schema preparation changed its object shape",
@@ -1630,7 +1633,7 @@ const prepareMcpProviderMetadataForThirdParty = async ({
     }
     Reflect.set(prepared, field, preparedMetadata.value);
   }
-  return await prepareMcpProviderMetadataForThirdParty({
+  await prepareMcpProviderMetadataForThirdParty({
     boundary,
     index: index + 1,
     inputKeyRestorations,

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -1559,11 +1559,7 @@ const collectMcpInputKeyRestorations = ({
     if (preparedEntry === undefined) {
       throw new TypeError("MCP input schema preparation lost a property");
     }
-    const preparedKey = preparedEntry.at(0);
-    const preparedValue: unknown = preparedEntry.at(1);
-    if (preparedKey === undefined) {
-      throw new TypeError("MCP input schema preparation lost a property key");
-    }
+    const [preparedKey, preparedValue] = preparedEntry;
     if (preparedKey !== originalKey) {
       restorations.set(preparedKey, originalKey);
     }

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -440,6 +440,10 @@ export const prepareTextForThirdParty = async ({
       await anonymizeFields({
         context: boundary.pipelineContext,
         fields: protectedInput.fields,
+        forcedSensitiveValues: [
+          boundary.organizationId,
+          boundary.anonymizationScopeId,
+        ],
         gazetteerEntries: await boundary.gazetteerEntries,
         excludedCanonicals: await boundary.excludedCanonicals,
         organizationId: boundary.organizationId,
@@ -482,6 +486,10 @@ const prepareTextBatchForThirdParty = async ({
       await anonymizeFields({
         context: boundary.pipelineContext,
         fields: protectedInput.fields,
+        forcedSensitiveValues: [
+          boundary.organizationId,
+          boundary.anonymizationScopeId,
+        ],
         gazetteerEntries: await boundary.gazetteerEntries,
         excludedCanonicals: await boundary.excludedCanonicals,
         organizationId: boundary.organizationId,

--- a/apps/api/src/mcp/anonymization-core.ts
+++ b/apps/api/src/mcp/anonymization-core.ts
@@ -17,6 +17,8 @@ import { buildFieldMarkers } from "@/api/mcp/field-markers";
 
 export type AnonymizeTextFieldsInput = {
   fields: string[];
+  /** Exact identifiers or terms that must be redacted in this batch. */
+  forcedSensitiveValues?: readonly string[] | undefined;
   gazetteerEntries?: GazetteerEntry[] | undefined;
   /**
    * Canonicals the user has flagged as false positives. The
@@ -117,6 +119,7 @@ const splitRedactedFields = ({
 export const anonymizeTextFieldsWithDependencies = async ({
   dependencies,
   fields,
+  forcedSensitiveValues,
   gazetteerEntries,
   excludedCanonicals,
   organizationId,
@@ -168,6 +171,7 @@ export const anonymizeTextFieldsWithDependencies = async ({
     dictionaries,
     text: combinedText,
     workspaceId,
+    forcedSensitiveValues,
     gazetteerEntries: entries,
     excludedCanonicals: allowlist,
     context,

--- a/bun.lock
+++ b/bun.lock
@@ -456,6 +456,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@stll/anonymize-wasm": "catalog:",
+        "better-result": "catalog:",
         "valibot": "catalog:",
       },
       "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -448,6 +448,7 @@
         "@tanstack/ai-mistral": "catalog:",
         "@tanstack/ai-openrouter": "catalog:",
         "bun-types": "catalog:",
+        "tsdown": "catalog:",
       },
     },
     "packages/anonymize-chat": {
@@ -462,6 +463,7 @@
         "@stll/typescript-config": "workspace:*",
         "bun-types": "catalog:",
         "fast-check": "catalog:",
+        "tsdown": "catalog:",
       },
     },
     "packages/api-client": {

--- a/packages/ai-catalog/README.md
+++ b/packages/ai-catalog/README.md
@@ -1,0 +1,34 @@
+# @stll/ai-catalog
+
+Provider-neutral model roles, provider identifiers, curated model options, and
+capability metadata for TypeScript applications.
+
+The package keeps model selection structural: callers choose a logical role,
+validate a provider/model pair against one catalogue, and can reject retired or
+unsupported selections before a provider request.
+
+```ts
+import {
+  DEFAULT_MODELS,
+  resolveWorkingBYOKModelForRole,
+} from "@stll/ai-catalog";
+
+const modelId = resolveWorkingBYOKModelForRole({
+  provider: "openai",
+  modelId: DEFAULT_MODELS.openai.fast,
+  role: "fast",
+});
+```
+
+The package contains data and validation only. It does not read environment
+variables, store credentials, or initialize provider SDKs.
+
+## Install
+
+```sh
+bun add @stll/ai-catalog
+```
+
+## License
+
+Apache-2.0

--- a/packages/ai-catalog/package.json
+++ b/packages/ai-catalog/package.json
@@ -1,26 +1,47 @@
 {
   "name": "@stll/ai-catalog",
   "version": "0.0.0",
-  "private": true,
-  "description": "Canonical AI provider/model catalog — single source of truth shared by the API runtime and the BYOK settings UI",
+  "description": "Provider-neutral AI model roles, capabilities, and curated model metadata.",
+  "keywords": [
+    "ai",
+    "models",
+    "providers",
+    "typescript"
+  ],
+  "homepage": "https://github.com/stella/stella/tree/main/packages/ai-catalog",
+  "bugs": {
+    "url": "https://github.com/stella/stella/issues"
+  },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stella/stella.git",
+    "directory": "packages/ai-catalog"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "type": "module",
   "sideEffects": false,
   "exports": {
-    ".": {
-      "types": "./src/index.ts",
-      "bun": "./src/index.ts",
-      "import": "./src/index.ts"
-    }
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
-    "clean": "git clean -xdf .cache .turbo node_modules",
+    "clean": "git clean -xdf dist .cache .turbo node_modules",
+    "build": "tsdown",
     "gen:capabilities": "bun ../scripts/src/model-catalog-capabilities-gen.ts",
+    "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test src",
     "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/ai-catalog",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/ai-catalog",
-    "format": "oxfmt ."
+    "format": "oxfmt .",
+    "prepack": "bun run build"
   },
   "dependencies": {
     "valibot": "catalog:"
@@ -32,6 +53,7 @@
     "@tanstack/ai-gemini": "catalog:",
     "@tanstack/ai-mistral": "catalog:",
     "@tanstack/ai-openrouter": "catalog:",
-    "bun-types": "catalog:"
+    "bun-types": "catalog:",
+    "tsdown": "catalog:"
   }
 }

--- a/packages/ai-catalog/tsdown.config.ts
+++ b/packages/ai-catalog/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  platform: "neutral",
+  dts: true,
+  outDir: "dist",
+  clean: true,
+});

--- a/packages/anonymize-chat/README.md
+++ b/packages/anonymize-chat/README.md
@@ -8,7 +8,10 @@ tokens, supports caller-supplied exact sensitive values, and returns one
 placeholder-to-original map for controlled restoration.
 
 ```ts
-import { runChatAnonPipeline } from "@stll/anonymize-chat";
+import {
+  findChatAnonPlaceholders,
+  runChatAnonPipeline,
+} from "@stll/anonymize-chat";
 
 const result = await runChatAnonPipeline({
   runtime,
@@ -17,10 +20,19 @@ const result = await runChatAnonPipeline({
   workspaceId,
   forcedSensitiveValues: [internalReference],
 });
+
+const allowedResponsePlaceholders = new Set([
+  ...result.redactionMap.keys(),
+  ...findChatAnonPlaceholders(text),
+]);
 ```
 
 Runtime bindings and dictionaries are dependency-injected so browser workers,
 servers, and tests can own their loading strategy.
+
+Before restoring provider responses, hosts can scan them with
+`findChatAnonPlaceholders` and reject tokens absent from the allowed set. Source
+placeholders belong in that set because the pipeline preserves literal tokens.
 
 ## Install
 

--- a/packages/anonymize-chat/README.md
+++ b/packages/anonymize-chat/README.md
@@ -1,0 +1,33 @@
+# @stll/anonymize-chat
+
+Shared contracts for reversible, placeholder-safe anonymization of text before
+it crosses a third-party boundary.
+
+The package configures `@stll/anonymize-wasm`, preserves literal placeholder
+tokens, supports caller-supplied exact sensitive values, and returns one
+placeholder-to-original map for controlled restoration.
+
+```ts
+import { runChatAnonPipeline } from "@stll/anonymize-chat";
+
+const result = await runChatAnonPipeline({
+  runtime,
+  dictionaries,
+  text,
+  workspaceId,
+  forcedSensitiveValues: [internalReference],
+});
+```
+
+Runtime bindings and dictionaries are dependency-injected so browser workers,
+servers, and tests can own their loading strategy.
+
+## Install
+
+```sh
+bun add @stll/anonymize-chat @stll/anonymize-wasm
+```
+
+## License
+
+Apache-2.0

--- a/packages/anonymize-chat/package.json
+++ b/packages/anonymize-chat/package.json
@@ -1,21 +1,47 @@
 {
   "name": "@stll/anonymize-chat",
   "version": "0.0.0",
-  "private": true,
+  "description": "Placeholder-safe, reversible anonymization contracts for provider-bound text.",
+  "keywords": [
+    "anonymization",
+    "privacy",
+    "redaction",
+    "typescript"
+  ],
+  "homepage": "https://github.com/stella/stella/tree/main/packages/anonymize-chat",
+  "bugs": {
+    "url": "https://github.com/stella/stella/issues"
+  },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stella/stella.git",
+    "directory": "packages/anonymize-chat"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "type": "module",
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
-    "clean": "git clean -xdf .cache .turbo node_modules",
+    "clean": "git clean -xdf dist .cache .turbo node_modules",
+    "build": "tsdown",
+    "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test",
     "test:property": "bun test $(grep -rlF 'fc.assert' src --include='*.test.ts')",
     "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/anonymize-chat",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/anonymize-chat",
-    "format": "oxfmt ."
+    "format": "oxfmt .",
+    "prepack": "bun run build"
   },
   "dependencies": {
     "@stll/anonymize-wasm": "catalog:",
@@ -25,6 +51,7 @@
     "@stll/property-testing": "workspace:*",
     "@stll/typescript-config": "workspace:*",
     "bun-types": "catalog:",
-    "fast-check": "catalog:"
+    "fast-check": "catalog:",
+    "tsdown": "catalog:"
   }
 }

--- a/packages/anonymize-chat/package.json
+++ b/packages/anonymize-chat/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@stll/anonymize-wasm": "catalog:",
+    "better-result": "catalog:",
     "valibot": "catalog:"
   },
   "devDependencies": {

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -87,9 +87,7 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
    */
   const buildRuntime = (
     entities: NativePipelineEntity[],
-    inspectGazetteerEntries?:
-      | ((entries: readonly GazetteerEntry[]) => void)
-      | undefined,
+    inspectGazetteerEntries?: (entries: readonly GazetteerEntry[]) => void,
   ): ChatAnonRuntime => ({
     // SAFETY: the mock binding value is opaque plumbing - the fake
     // `createNativePipelineFromConfig` below never inspects it, it
@@ -300,10 +298,10 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     );
   });
 
-  test("bounds caller-supplied forced values before building a pipeline", async () => {
+  test("bounds caller-supplied forced values before building a pipeline", () => {
     const runtime = buildRuntime([]);
 
-    await expect(
+    expect(
       runChatAnonPipeline({
         runtime,
         dictionaries,
@@ -316,7 +314,7 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
       }),
     ).rejects.toBeInstanceOf(RangeError);
 
-    await expect(
+    expect(
       runChatAnonPipeline({
         runtime,
         dictionaries,

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -362,6 +362,26 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
   });
 
+  test("accepts distinct forced values that match each other's placeholders", async () => {
+    const firstForcedValue = "[MISC_1]";
+    const secondForcedValue = "[CASE_NUMBER_1]";
+    const runtime = buildRuntime([
+      makeEntity(firstForcedValue, "case number"),
+      makeEntity(secondForcedValue, "misc"),
+    ]);
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: `${firstForcedValue} ${secondForcedValue}`,
+      workspaceId: "ws-1",
+      forcedSensitiveValues: [firstForcedValue, secondForcedValue],
+    });
+
+    expect(result.entityCount).toBe(2);
+    expect(result.redactionMap.size).toBe(2);
+  });
+
   test("bounds caller-supplied forced values before building a pipeline", () => {
     const runtime = buildRuntime([]);
 

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -332,6 +332,29 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     );
   });
 
+  test("applies forced precedence per normalized exclusion occurrence", async () => {
+    const forcedValue = "ORDER-123";
+    const exact = `Matter ${forcedValue}`;
+    const caseVariant = "matter order-123";
+    const runtime = buildRuntime([
+      makeEntity(exact, "organization"),
+      makeEntity(caseVariant, "organization"),
+    ]);
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: `${exact}; ${caseVariant}`,
+      workspaceId: "ws-1",
+      excludedCanonicals: [exact],
+      forcedSensitiveValues: [forcedValue],
+    });
+
+    expect(result.redactedText).toBe(`[ORGANIZATION_1]; ${caseVariant}`);
+    expect(result.redactionMap).toEqual(new Map([["[ORGANIZATION_1]", exact]]));
+    expect(result.entityCount).toBe(1);
+  });
+
   test("keeps forced values from colliding with literal-placeholder sentinels", async () => {
     const forcedValue = "CHAT_PLACEHOLDER_0";
     const runtime = buildRuntime([makeEntity(forcedValue, "misc")]);

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -264,6 +264,22 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
   });
 
+  test("preserves forced values containing placeholder-shaped substrings", async () => {
+    const forcedValue = "Matter [CASE_123]";
+    const runtime = buildRuntime([makeEntity(forcedValue, "misc")]);
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: forcedValue,
+      workspaceId: "ws-1",
+      forcedSensitiveValues: [forcedValue],
+    });
+
+    expect(result.redactedText).toBe("[MISC_1]");
+    expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
+  });
+
   test("bounds caller-supplied forced values before building a pipeline", async () => {
     const runtime = buildRuntime([]);
 

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -14,6 +14,7 @@ import {
   CHAT_TRANSPORT_ERROR_CODE,
   DEFAULT_CHAT_ANON_ENTITY_LABELS,
   createThirdPartyBoundaryRefusalPayload,
+  findChatAnonPlaceholders,
   FORCED_SENSITIVE_VALUES_MAX,
   FORCED_SENSITIVE_VALUE_MAX_LENGTH,
   getPreferredChatSendMode,
@@ -71,6 +72,26 @@ describe("chat anonymization pipeline contract", () => {
   test("models raw override as a first-class send mode", () => {
     expect(getPreferredChatSendMode(false)).toBe(CHAT_SEND_MODE.rawOverride);
     expect(getPreferredChatSendMode(true)).toBe(CHAT_SEND_MODE.anonymized);
+  });
+
+  test("distinguishes allowed source placeholders from unknown response tokens", () => {
+    const sourcePlaceholders = findChatAnonPlaceholders(
+      "Keep literal [CASE_NUMBER_7].",
+    );
+    const allowedPlaceholders = new Set([
+      ...sourcePlaceholders,
+      "[PERSON_1]",
+    ]);
+    const responsePlaceholders = findChatAnonPlaceholders(
+      "[CASE_NUMBER_7] [PERSON_1] [LOCATION_2] [LOCATION_2] [not_a_token]",
+    );
+
+    expect(sourcePlaceholders).toEqual(["[CASE_NUMBER_7]"]);
+    expect(
+      responsePlaceholders.filter(
+        (placeholder) => !allowedPlaceholders.has(placeholder),
+      ),
+    ).toEqual(["[LOCATION_2]"]);
   });
 });
 

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -79,15 +79,23 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     redactText: (fullText: string) => NativeStaticRedactionResult;
   };
 
+  type BuildRuntimeOptions = {
+    inspectGazetteerEntries?: (entries: readonly GazetteerEntry[]) => void;
+    inspectRedactionInput?: (text: string) => void;
+  };
+
   /**
-   * Build a `ChatAnonRuntime` test double whose `redactText` performs
-   * a naive, entity-order text replacement - good enough to exercise
-   * the post-hoc excluded-canonicals revert without a real wasm
-   * binding.
+   * Build a `ChatAnonRuntime` test double whose `redactText` splices
+   * entity spans right-to-left, matching the native offset contract
+   * closely enough to exercise exclusion and placeholder invariants
+   * without a real wasm binding.
    */
   const buildRuntime = (
     entities: NativePipelineEntity[],
-    inspectGazetteerEntries?: (entries: readonly GazetteerEntry[]) => void,
+    {
+      inspectGazetteerEntries,
+      inspectRedactionInput,
+    }: BuildRuntimeOptions = {},
   ): ChatAnonRuntime => ({
     // SAFETY: the mock binding value is opaque plumbing - the fake
     // `createNativePipelineFromConfig` below never inspects it, it
@@ -103,6 +111,7 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
       inspectGazetteerEntries?.(gazetteerEntries ?? []);
       const pipeline: FakePipeline = {
         redactText: (fullText) => {
+          inspectRedactionInput?.(fullText);
           const redactionMap = new Map<string, string>();
           const operatorMap = new Map<string, "replace">();
           const resolvedEntities = entities.map((entity) => {
@@ -241,12 +250,11 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
   test("forces exact values through the native placeholder allocation", async () => {
     const forcedValue = "ORDER-123";
     let receivedEntries: readonly GazetteerEntry[] = [];
-    const runtime = buildRuntime(
-      [makeEntity(forcedValue, "misc")],
-      (entries) => {
+    const runtime = buildRuntime([makeEntity(forcedValue, "misc")], {
+      inspectGazetteerEntries: (entries) => {
         receivedEntries = entries;
       },
-    );
+    });
 
     const result = await runChatAnonPipeline({
       runtime,
@@ -338,6 +346,38 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
 
     expect(result.redactedText).toBe("[PERSON_1] [MISC_1]");
     expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
+  });
+
+  test("keeps gazetteer terms from colliding with literal-placeholder sentinels", async () => {
+    const gazetteerVariant = "\uE000";
+    let receivedInput = "";
+    const runtime = buildRuntime([], {
+      inspectRedactionInput: (text) => {
+        receivedInput = text;
+      },
+    });
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: "[PERSON_1]",
+      workspaceId: "ws-1",
+      gazetteerEntries: [
+        {
+          id: "term-1",
+          canonical: "other",
+          label: "misc",
+          variants: [gazetteerVariant],
+          workspaceId: "ws-1",
+          createdAt: 0,
+          source: "manual",
+        },
+      ],
+    });
+
+    expect(receivedInput).not.toContain(gazetteerVariant);
+    expect(result.redactedText).toBe("[PERSON_1]");
+    expect(result.redactionMap).toEqual(new Map());
   });
 
   test("rekeys generated placeholders reserved by literal source text", async () => {

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -78,10 +78,7 @@ describe("chat anonymization pipeline contract", () => {
     const sourcePlaceholders = findChatAnonPlaceholders(
       "Keep literal [CASE_NUMBER_7].",
     );
-    const allowedPlaceholders = new Set([
-      ...sourcePlaceholders,
-      "[PERSON_1]",
-    ]);
+    const allowedPlaceholders = new Set([...sourcePlaceholders, "[PERSON_1]"]);
     const responsePlaceholders = findChatAnonPlaceholders(
       "[CASE_NUMBER_7] [PERSON_1] [LOCATION_2] [LOCATION_2] [not_a_token]",
     );

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -244,9 +244,7 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
       source: "manual",
     });
     expect(result.redactedText).toBe("[MISC_1] is selected");
-    expect(result.redactionMap).toEqual(
-      new Map([["[MISC_1]", forcedValue]]),
-    );
+    expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
   });
 
   test("forced values override matching exclusions and literal protection", async () => {
@@ -263,9 +261,7 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     });
 
     expect(result.redactedText).toBe("[MISC_1]");
-    expect(result.redactionMap).toEqual(
-      new Map([["[MISC_1]", forcedValue]]),
-    );
+    expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
   });
 
   test("bounds caller-supplied forced values before building a pipeline", async () => {

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -331,6 +331,25 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
   });
 
+  test("rekeys generated placeholders reserved by literal source text", async () => {
+    const forcedValue = "Alice";
+    const runtime = buildRuntime([makeEntity(forcedValue, "misc")]);
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: `[MISC_1] ${forcedValue}`,
+      workspaceId: "ws-1",
+      forcedSensitiveValues: [forcedValue],
+    });
+
+    expect(result.redactedText).toBe("[MISC_1] [MISC_2]");
+    expect(result.redactionMap).toEqual(new Map([["[MISC_2]", forcedValue]]));
+    expect(runtime.deanonymise(result.redactedText, result.redactionMap)).toBe(
+      `[MISC_1] ${forcedValue}`,
+    );
+  });
+
   test("fails closed when native redaction leaves a forced value", () => {
     const forcedValue = "ORDER-123";
     const runtime = buildRuntime([]);
@@ -340,6 +359,21 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
         runtime,
         dictionaries,
         text: forcedValue,
+        workspaceId: "ws-1",
+        forcedSensitiveValues: [forcedValue],
+      }),
+    ).rejects.toThrow("forced sensitive value remained after anonymization");
+  });
+
+  test("fails closed when a resolved entity covers only part of a forced value", () => {
+    const forcedValue = "ORDER-123";
+    const runtime = buildRuntime([makeEntity("XORDER", "misc")]);
+
+    expect(
+      runChatAnonPipeline({
+        runtime,
+        dictionaries,
+        text: `X${forcedValue}`,
         workspaceId: "ws-1",
         forcedSensitiveValues: [forcedValue],
       }),

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -116,19 +116,28 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
               text: entity.text,
             };
           });
-          let redactedText = fullText;
-          for (const [idx, entity] of resolvedEntities.entries()) {
+          const replacements = resolvedEntities.map((entity, idx) => {
             const placeholderLabel = entity.label
               .trim()
               .toUpperCase()
               .replaceAll(/\s+/gu, "_");
             const placeholder = `[${placeholderLabel}_${idx + 1}]`;
-            redactedText = redactedText.replaceAll(
-              entity.text,
-              () => placeholder,
-            );
             redactionMap.set(placeholder, entity.text);
             operatorMap.set(placeholder, "replace");
+            return {
+              end: entity.end,
+              placeholder,
+              start: entity.start,
+            };
+          });
+          let redactedText = fullText;
+          for (const replacement of replacements.toSorted(
+            (left, right) => right.start - left.start,
+          )) {
+            redactedText =
+              redactedText.slice(0, replacement.start) +
+              replacement.placeholder +
+              redactedText.slice(replacement.end);
           }
           return {
             resolvedEntities,
@@ -396,8 +405,8 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
   });
 
-  test("accepts distinct forced values that match each other's placeholders", async () => {
-    const firstForcedValue = "[MISC_1]";
+  test("rekeys cyclic forced-placeholder allocations without breaking round trips", async () => {
+    const firstForcedValue = "[MISC_2]";
     const secondForcedValue = "[CASE_NUMBER_1]";
     const runtime = buildRuntime([
       makeEntity(firstForcedValue, "case number"),
@@ -412,8 +421,16 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
       forcedSensitiveValues: [firstForcedValue, secondForcedValue],
     });
 
-    expect(result.entityCount).toBe(2);
-    expect(result.redactionMap.size).toBe(2);
+    expect(result.redactedText).toBe("[CASE_NUMBER_2] [MISC_1]");
+    expect(result.redactionMap).toEqual(
+      new Map([
+        ["[CASE_NUMBER_2]", firstForcedValue],
+        ["[MISC_1]", secondForcedValue],
+      ]),
+    );
+    expect(runtime.deanonymise(result.redactedText, result.redactionMap)).toBe(
+      `${firstForcedValue} ${secondForcedValue}`,
+    );
   });
 
   test("bounds caller-supplied forced values before building a pipeline", () => {

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type {
+  GazetteerEntry,
   NativeAnonymizeBinding,
   NativePipelineEntity,
   NativeStaticRedactionResult,
@@ -13,6 +14,8 @@ import {
   CHAT_TRANSPORT_ERROR_CODE,
   DEFAULT_CHAT_ANON_ENTITY_LABELS,
   createThirdPartyBoundaryRefusalPayload,
+  FORCED_SENSITIVE_VALUES_MAX,
+  FORCED_SENSITIVE_VALUE_MAX_LENGTH,
   getPreferredChatSendMode,
   isThirdPartyBoundaryRefusalError,
   isThirdPartyBoundaryRefusalPayload,
@@ -82,7 +85,12 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
    * the post-hoc excluded-canonicals revert without a real wasm
    * binding.
    */
-  const buildRuntime = (entities: NativePipelineEntity[]): ChatAnonRuntime => ({
+  const buildRuntime = (
+    entities: NativePipelineEntity[],
+    inspectGazetteerEntries?:
+      | ((entries: readonly GazetteerEntry[]) => void)
+      | undefined,
+  ): ChatAnonRuntime => ({
     // SAFETY: the mock binding value is opaque plumbing - the fake
     // `createNativePipelineFromConfig` below never inspects it, it
     // only forwards it to `redactText`'s closure over `entities`.
@@ -93,7 +101,8 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
       nativePipelinePackageKey: "",
       nativePipelinePackagePromise: null,
     }),
-    createNativePipelineFromConfig: async () => {
+    createNativePipelineFromConfig: async ({ gazetteerEntries }) => {
+      inspectGazetteerEntries?.(gazetteerEntries ?? []);
       const pipeline: FakePipeline = {
         redactText: (fullText) => {
           const redactionMap = new Map<string, string>();
@@ -205,6 +214,87 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     expect(result.pairs).toEqual([]);
     expect(result.entityCount).toBe(0);
     expect(result.redactedText).toBe("[PERSON_1] and Alice");
+  });
+
+  test("forces exact values through the native placeholder allocation", async () => {
+    const forcedValue = "ORDER-123";
+    let receivedEntries: readonly GazetteerEntry[] = [];
+    const runtime = buildRuntime(
+      [makeEntity(forcedValue, "misc")],
+      (entries) => {
+        receivedEntries = entries;
+      },
+    );
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: `${forcedValue} is selected`,
+      workspaceId: "ws-1",
+      forcedSensitiveValues: [forcedValue],
+    });
+
+    expect(receivedEntries).toContainEqual({
+      id: "forced-sensitive-1",
+      canonical: forcedValue,
+      label: "misc",
+      variants: [],
+      workspaceId: "ws-1",
+      createdAt: 0,
+      source: "manual",
+    });
+    expect(result.redactedText).toBe("[MISC_1] is selected");
+    expect(result.redactionMap).toEqual(
+      new Map([["[MISC_1]", forcedValue]]),
+    );
+  });
+
+  test("forced values override matching exclusions and literal protection", async () => {
+    const forcedValue = "[PERSON_1]";
+    const runtime = buildRuntime([makeEntity(forcedValue, "misc")]);
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: forcedValue,
+      workspaceId: "ws-1",
+      excludedCanonicals: [forcedValue],
+      forcedSensitiveValues: [forcedValue],
+    });
+
+    expect(result.redactedText).toBe("[MISC_1]");
+    expect(result.redactionMap).toEqual(
+      new Map([["[MISC_1]", forcedValue]]),
+    );
+  });
+
+  test("bounds caller-supplied forced values before building a pipeline", async () => {
+    const runtime = buildRuntime([]);
+
+    await expect(
+      runChatAnonPipeline({
+        runtime,
+        dictionaries,
+        text: "sensitive",
+        workspaceId: "ws-1",
+        forcedSensitiveValues: Array.from(
+          { length: FORCED_SENSITIVE_VALUES_MAX + 1 },
+          (_, index) => `sensitive-${String(index)}`,
+        ),
+      }),
+    ).rejects.toBeInstanceOf(RangeError);
+
+    await expect(
+      runChatAnonPipeline({
+        runtime,
+        dictionaries,
+        text: "sensitive",
+        workspaceId: "ws-1",
+        forcedSensitiveValues: [
+          "x".repeat(FORCED_SENSITIVE_VALUE_MAX_LENGTH + 1),
+        ],
+      }),
+    ).rejects.toBeInstanceOf(RangeError);
   });
 
   test("passes all entities through when no exclusions are provided", async () => {

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -105,8 +105,19 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
         redactText: (fullText) => {
           const redactionMap = new Map<string, string>();
           const operatorMap = new Map<string, "replace">();
+          const resolvedEntities = entities.map((entity) => {
+            const start = fullText.indexOf(entity.text);
+            return {
+              end: start + entity.text.length,
+              label: entity.label,
+              score: entity.score,
+              source: entity.source,
+              start,
+              text: entity.text,
+            };
+          });
           let redactedText = fullText;
-          for (const [idx, entity] of entities.entries()) {
+          for (const [idx, entity] of resolvedEntities.entries()) {
             const placeholderLabel = entity.label
               .trim()
               .toUpperCase()
@@ -120,7 +131,7 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
             operatorMap.set(placeholder, "replace");
           }
           return {
-            resolvedEntities: entities,
+            resolvedEntities,
             redaction: {
               redactedText,
               redactionMap,
@@ -333,6 +344,22 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
         forcedSensitiveValues: [forcedValue],
       }),
     ).rejects.toThrow("forced sensitive value remained after anonymization");
+  });
+
+  test("accepts forced source text contained only in generated placeholders", async () => {
+    const forcedValue = "MISC";
+    const runtime = buildRuntime([makeEntity(forcedValue, "misc")]);
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: forcedValue,
+      workspaceId: "ws-1",
+      forcedSensitiveValues: [forcedValue],
+    });
+
+    expect(result.redactedText).toBe("[MISC_1]");
+    expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
   });
 
   test("bounds caller-supplied forced values before building a pipeline", () => {

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -355,6 +355,28 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     expect(result.entityCount).toBe(1);
   });
 
+  test("restores a normalized exclusion beside an exact forced value", async () => {
+    const forcedValue = "ORDER-123";
+    const caseVariant = "order-123";
+    const runtime = buildRuntime([
+      makeEntity(forcedValue, "misc"),
+      makeEntity(caseVariant, "misc"),
+    ]);
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: `${forcedValue}; ${caseVariant}`,
+      workspaceId: "ws-1",
+      excludedCanonicals: [caseVariant],
+      forcedSensitiveValues: [forcedValue],
+    });
+
+    expect(result.redactedText).toBe(`[MISC_1]; ${caseVariant}`);
+    expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
+    expect(result.entityCount).toBe(1);
+  });
+
   test("keeps forced values from colliding with literal-placeholder sentinels", async () => {
     const forcedValue = "CHAT_PLACEHOLDER_0";
     const runtime = buildRuntime([makeEntity(forcedValue, "misc")]);

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -280,6 +280,26 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
   });
 
+  test("does not restore an excluded entity containing a forced value", async () => {
+    const forcedValue = "ORDER-123";
+    const excludedValue = `Matter ${forcedValue}`;
+    const runtime = buildRuntime([makeEntity(excludedValue, "organization")]);
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: excludedValue,
+      workspaceId: "ws-1",
+      excludedCanonicals: [excludedValue],
+      forcedSensitiveValues: [forcedValue],
+    });
+
+    expect(result.redactedText).toBe("[ORGANIZATION_1]");
+    expect(result.redactionMap).toEqual(
+      new Map([["[ORGANIZATION_1]", excludedValue]]),
+    );
+  });
+
   test("bounds caller-supplied forced values before building a pipeline", async () => {
     const runtime = buildRuntime([]);
 

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -107,7 +107,11 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
           const operatorMap = new Map<string, "replace">();
           let redactedText = fullText;
           for (const [idx, entity] of entities.entries()) {
-            const placeholder = `[${entity.label.toUpperCase()}_${idx + 1}]`;
+            const placeholderLabel = entity.label
+              .trim()
+              .toUpperCase()
+              .replaceAll(/\s+/gu, "_");
+            const placeholder = `[${placeholderLabel}_${idx + 1}]`;
             redactedText = redactedText.replaceAll(
               entity.text,
               () => placeholder,
@@ -245,9 +249,9 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
   });
 
-  test("forced values override matching exclusions and literal protection", async () => {
-    const forcedValue = "[PERSON_1]";
-    const runtime = buildRuntime([makeEntity(forcedValue, "misc")]);
+  test("forced values override exclusions without becoming their own placeholder", async () => {
+    const forcedValue = "[MISC_1]";
+    const runtime = buildRuntime([makeEntity(forcedValue, "case number")]);
 
     const result = await runChatAnonPipeline({
       runtime,
@@ -258,8 +262,10 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
       forcedSensitiveValues: [forcedValue],
     });
 
-    expect(result.redactedText).toBe("[MISC_1]");
-    expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
+    expect(result.redactedText).toBe("[CASE_NUMBER_1]");
+    expect(result.redactionMap).toEqual(
+      new Map([["[CASE_NUMBER_1]", forcedValue]]),
+    );
   });
 
   test("preserves forced values containing placeholder-shaped substrings", async () => {
@@ -296,6 +302,37 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     expect(result.redactionMap).toEqual(
       new Map([["[ORGANIZATION_1]", excludedValue]]),
     );
+  });
+
+  test("keeps forced values from colliding with literal-placeholder sentinels", async () => {
+    const forcedValue = "CHAT_PLACEHOLDER_0";
+    const runtime = buildRuntime([makeEntity(forcedValue, "misc")]);
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: `[PERSON_1] ${forcedValue}`,
+      workspaceId: "ws-1",
+      forcedSensitiveValues: [forcedValue],
+    });
+
+    expect(result.redactedText).toBe("[PERSON_1] [MISC_1]");
+    expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
+  });
+
+  test("fails closed when native redaction leaves a forced value", () => {
+    const forcedValue = "ORDER-123";
+    const runtime = buildRuntime([]);
+
+    expect(
+      runChatAnonPipeline({
+        runtime,
+        dictionaries,
+        text: forcedValue,
+        workspaceId: "ws-1",
+        forcedSensitiveValues: [forcedValue],
+      }),
+    ).rejects.toThrow("forced sensitive value remained after anonymization");
   });
 
   test("bounds caller-supplied forced values before building a pipeline", () => {

--- a/packages/anonymize-chat/src/index.test.ts
+++ b/packages/anonymize-chat/src/index.test.ts
@@ -429,6 +429,37 @@ describe("runChatAnonPipeline excludedCanonicals", () => {
     ).rejects.toThrow("forced sensitive value remained after anonymization");
   });
 
+  test("accepts self-overlapping forced occurrences removed by one full span", async () => {
+    const forcedValue = "aaa";
+    const runtime = buildRuntime([makeEntity(forcedValue, "misc")]);
+
+    const result = await runChatAnonPipeline({
+      runtime,
+      dictionaries,
+      text: "aaaa",
+      workspaceId: "ws-1",
+      forcedSensitiveValues: [forcedValue],
+    });
+
+    expect(result.redactedText).toBe("[MISC_1]a");
+    expect(result.redactionMap).toEqual(new Map([["[MISC_1]", forcedValue]]));
+  });
+
+  test("rejects a self-overlapping forced run with an uncovered occurrence", () => {
+    const forcedValue = "aaa";
+    const runtime = buildRuntime([makeEntity(forcedValue, "misc")]);
+
+    expect(
+      runChatAnonPipeline({
+        runtime,
+        dictionaries,
+        text: "aaaaaa",
+        workspaceId: "ws-1",
+        forcedSensitiveValues: [forcedValue],
+      }),
+    ).rejects.toThrow("forced sensitive value remained after anonymization");
+  });
+
   test("accepts forced source text contained only in generated placeholders", async () => {
     const forcedValue = "MISC";
     const runtime = buildRuntime([makeEntity(forcedValue, "misc")]);

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -1,3 +1,4 @@
+import { panic } from "better-result";
 import * as v from "valibot";
 
 import type {
@@ -293,9 +294,9 @@ const normalizeEntityLabelForPlaceholder = (label: string): string =>
   label.trim().toUpperCase().replaceAll(/\s+/gu, "_");
 
 const LITERAL_PLACEHOLDER_SENTINEL_RANGES = [
-  { end: 0xf8ff, start: 0xe000 },
-  { end: 0xffffd, start: 0xf0000 },
-  { end: 0x10fffd, start: 0x100000 },
+  { end: 0xf8_ff, start: 0xe0_00 },
+  { end: 0xf_ff_fd, start: 0xf_00_00 },
+  { end: 0x10_ff_fd, start: 0x10_00_00 },
 ] as const;
 
 type LiteralPlaceholderSentinelCursor = {
@@ -472,7 +473,7 @@ const assertForcedSensitiveValuesRedacted = (
 ): void => {
   for (const forcedValue of forcedSensitiveValues) {
     if (redactedText.includes(forcedValue)) {
-      throw new Error("forced sensitive value remained after anonymization");
+      panic("forced sensitive value remained after anonymization");
     }
   }
 };

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -294,6 +294,26 @@ const restoreLiteralPlaceholders = (
   return result;
 };
 
+const spanOverlapsLiteralValue = ({
+  end,
+  start,
+  text,
+  values,
+}: {
+  end: number;
+  start: number;
+  text: string;
+  values: ReadonlySet<string>;
+}): boolean => {
+  for (const value of values) {
+    const valueOffset = text.lastIndexOf(value, end - 1);
+    if (valueOffset !== -1 && valueOffset + value.length > start) {
+      return true;
+    }
+  }
+  return false;
+};
+
 const protectLiteralPlaceholders = (
   text: string,
   forcedSensitiveValues: ReadonlySet<string>,
@@ -301,29 +321,19 @@ const protectLiteralPlaceholders = (
   text: string;
   restore: (value: string) => string;
 } => {
-  const overlapsForcedSensitiveValue = (
-    placeholderOffset: number,
-    placeholderLength: number,
-  ): boolean => {
-    const placeholderEnd = placeholderOffset + placeholderLength;
-    for (const value of forcedSensitiveValues) {
-      const valueOffset = text.lastIndexOf(value, placeholderEnd - 1);
-      if (
-        valueOffset !== -1 &&
-        valueOffset + value.length > placeholderOffset
-      ) {
-        return true;
-      }
-    }
-    return false;
-  };
-
   const restoreMap = new Map<string, string>();
   let index = 0;
   const protectedText = text.replaceAll(
     PLACEHOLDER_TOKEN,
     (placeholder, offset: number) => {
-      if (overlapsForcedSensitiveValue(offset, placeholder.length)) {
+      if (
+        spanOverlapsLiteralValue({
+          end: offset + placeholder.length,
+          start: offset,
+          text,
+          values: forcedSensitiveValues,
+        })
+      ) {
         return placeholder;
       }
 
@@ -457,19 +467,41 @@ const toChatAnonResult = (
 const applyExcludedCanonicals = ({
   deanonymiseText,
   excludedCanonicals,
+  forcedSensitiveValues,
   resolvedEntities,
   redaction,
+  sourceText,
 }: {
   deanonymiseText: typeof deanonymise;
   excludedCanonicals: readonly string[] | undefined;
+  forcedSensitiveValues: ReadonlySet<string>;
   resolvedEntities: readonly NativePipelineEntity[];
   redaction: NativeRedaction;
+  sourceText: string;
 }): ChatAnonResult => {
   if (excludedCanonicals === undefined || excludedCanonicals.length === 0) {
     return toChatAnonResult(resolvedEntities, redaction);
   }
 
   const excludedSet = new Set(excludedCanonicals.map(normalizeForExclusion));
+  for (const entity of resolvedEntities) {
+    const canonical = normalizeForExclusion(entity.text);
+    if (
+      excludedSet.has(canonical) &&
+      spanOverlapsLiteralValue({
+        end: entity.end,
+        start: entity.start,
+        text: sourceText,
+        values: forcedSensitiveValues,
+      })
+    ) {
+      excludedSet.delete(canonical);
+    }
+  }
+  if (excludedSet.size === 0) {
+    return toChatAnonResult(resolvedEntities, redaction);
+  }
+
   const revertMap = new Map<string, string>();
   for (const [placeholder, original] of redaction.redactionMap) {
     if (excludedSet.has(normalizeForExclusion(original))) {
@@ -593,10 +625,10 @@ export const runChatAnonPipeline = async <
     gazetteerEntries: effectiveGazetteerEntries,
     context,
   });
-  const protectedInput = protectLiteralPlaceholders(
-    text,
-    new Set(forcedEntries.map(({ canonical }) => canonical)),
+  const forcedSensitiveSet = new Set(
+    forcedEntries.map(({ canonical }) => canonical),
   );
+  const protectedInput = protectLiteralPlaceholders(text, forcedSensitiveSet);
   const { resolvedEntities, redaction } = pipeline.redactText(
     protectedInput.text,
   );
@@ -604,8 +636,10 @@ export const runChatAnonPipeline = async <
   const result = applyExcludedCanonicals({
     deanonymiseText: runtime.deanonymise,
     excludedCanonicals: effectiveExcludedCanonicals,
+    forcedSensitiveValues: forcedSensitiveSet,
     resolvedEntities,
     redaction,
+    sourceText: protectedInput.text,
   });
   return {
     ...result,

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -289,6 +289,15 @@ const normalizeForExclusion = (value: string): string =>
 const PLACEHOLDER_TOKEN = /\[[A-Z][A-Z0-9_]*_\d+\]/gu;
 const PLACEHOLDER_LABEL = /^\[(?<label>[A-Z][A-Z0-9_]*)_\d+\]$/u;
 
+/**
+ * Return the distinct anonymization placeholders found in text, in first-seen
+ * order. Hosts can combine placeholders from source text and a redaction map
+ * to reject unknown tokens before restoring a provider response.
+ */
+export const findChatAnonPlaceholders = (text: string): string[] => [
+  ...new Set(text.match(PLACEHOLDER_TOKEN) ?? []),
+];
+
 const parsePlaceholderLabel = (placeholder: string): string | null => {
   const match = PLACEHOLDER_LABEL.exec(placeholder);
   return match?.groups?.["label"] ?? null;

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -57,6 +57,12 @@ true satisfies MissingDefaultChatAnonEntityLabel extends never ? true : never;
 export const DEFAULT_CHAT_ANON_ENTITY_LABELS =
   DEFAULT_CHAT_ANON_ENTITY_LABEL_VALUES;
 
+/** Maximum exact values one anonymization call may force into detection. */
+export const FORCED_SENSITIVE_VALUES_MAX = 256;
+
+/** Maximum UTF-16 length of one forced sensitive value. */
+export const FORCED_SENSITIVE_VALUE_MAX_LENGTH = 4096;
+
 export type ChatAnonPair = {
   placeholder: string;
   original: string;
@@ -290,6 +296,7 @@ const restoreLiteralPlaceholders = (
 
 const protectLiteralPlaceholders = (
   text: string,
+  forcedSensitiveValues: ReadonlySet<string>,
 ): {
   text: string;
   restore: (value: string) => string;
@@ -297,7 +304,15 @@ const protectLiteralPlaceholders = (
   const restoreMap = new Map<string, string>();
   let index = 0;
   const protectedText = text.replaceAll(PLACEHOLDER_TOKEN, (placeholder) => {
-    const sentinel = `\uE000CHAT_PLACEHOLDER_${index}\uE001`;
+    if (forcedSensitiveValues.has(placeholder)) {
+      return placeholder;
+    }
+
+    let sentinel = `\uE000CHAT_PLACEHOLDER_${index}\uE001`;
+    while (text.includes(sentinel) || restoreMap.has(sentinel)) {
+      index += 1;
+      sentinel = `\uE000CHAT_PLACEHOLDER_${index}\uE001`;
+    }
     restoreMap.set(sentinel, placeholder);
     index += 1;
     return sentinel;
@@ -307,6 +322,46 @@ const protectLiteralPlaceholders = (
     text: protectedText,
     restore: (value) => restoreLiteralPlaceholders(value, restoreMap),
   };
+};
+
+const forcedSensitiveGazetteerEntries = ({
+  forcedSensitiveValues,
+  text,
+  workspaceId,
+}: {
+  forcedSensitiveValues: readonly string[];
+  text: string;
+  workspaceId: string;
+}): GazetteerEntry[] => {
+  if (forcedSensitiveValues.length > FORCED_SENSITIVE_VALUES_MAX) {
+    throw new RangeError(
+      `forcedSensitiveValues exceeds ${String(FORCED_SENSITIVE_VALUES_MAX)} entries`,
+    );
+  }
+
+  const values = new Set<string>();
+  for (const value of forcedSensitiveValues) {
+    if (value.length > FORCED_SENSITIVE_VALUE_MAX_LENGTH) {
+      throw new RangeError(
+        `forced sensitive value exceeds ${String(FORCED_SENSITIVE_VALUE_MAX_LENGTH)} characters`,
+      );
+    }
+    if (value.length > 0 && text.includes(value)) {
+      values.add(value);
+    }
+  }
+
+  return [...values]
+    .toSorted((left, right) => right.length - left.length)
+    .map((canonical, index) => ({
+      id: `forced-sensitive-${String(index + 1)}`,
+      canonical,
+      label: "misc",
+      variants: [],
+      workspaceId,
+      createdAt: 0,
+      source: "manual",
+    }));
 };
 
 type NativeRedaction = {
@@ -438,6 +493,7 @@ export const runChatAnonPipeline = async <
   context: providedContext,
   dictionaries,
   excludedCanonicals,
+  forcedSensitiveValues = [],
   gazetteerEntries = [],
   runtime,
   text,
@@ -454,6 +510,12 @@ export const runChatAnonPipeline = async <
   workspaceId: string;
   gazetteerEntries?: GazetteerEntry[] | undefined;
   context?: TPipelineContext | undefined;
+  /**
+   * Exact non-empty values that must be detected even when the probabilistic
+   * pipeline would not classify them. They share the native pipeline's single
+   * placeholder allocation and override a matching allowlist entry.
+   */
+  forcedSensitiveValues?: readonly string[] | undefined;
   /** Opt in to deny-list detection; see {@link buildChatAnonPipelineConfig}. */
   enableDenyList?: boolean | undefined;
   /** Country codes whose deny-list/city dictionaries are loaded. */
@@ -478,10 +540,23 @@ export const runChatAnonPipeline = async <
     };
   }
 
+  const forcedEntries = forcedSensitiveGazetteerEntries({
+    forcedSensitiveValues,
+    text,
+    workspaceId,
+  });
+  const forcedCanonicals = new Set(
+    forcedEntries.map(({ canonical }) => normalizeForExclusion(canonical)),
+  );
+  const effectiveExcludedCanonicals = excludedCanonicals?.filter(
+    (canonical) => !forcedCanonicals.has(normalizeForExclusion(canonical)),
+  );
+  const effectiveGazetteerEntries = [...gazetteerEntries, ...forcedEntries];
+
   const context = providedContext ?? runtime.createPipelineContext();
   const config: PipelineConfig = {
     ...buildChatAnonPipelineConfig({
-      hasGazetteer: gazetteerEntries.length > 0,
+      hasGazetteer: effectiveGazetteerEntries.length > 0,
       locale,
       workspaceId,
       enableDenyList,
@@ -495,17 +570,20 @@ export const runChatAnonPipeline = async <
   const pipeline = await runtime.createNativePipelineFromConfig({
     binding,
     config,
-    gazetteerEntries,
+    gazetteerEntries: effectiveGazetteerEntries,
     context,
   });
-  const protectedInput = protectLiteralPlaceholders(text);
+  const protectedInput = protectLiteralPlaceholders(
+    text,
+    new Set(forcedEntries.map(({ canonical }) => canonical)),
+  );
   const { resolvedEntities, redaction } = pipeline.redactText(
     protectedInput.text,
   );
 
   const result = applyExcludedCanonicals({
     deanonymiseText: runtime.deanonymise,
-    excludedCanonicals,
+    excludedCanonicals: effectiveExcludedCanonicals,
     resolvedEntities,
     redaction,
   });

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -294,9 +294,13 @@ const PLACEHOLDER_LABEL = /^\[(?<label>[A-Z][A-Z0-9_]*)_\d+\]$/u;
  * order. Hosts can combine placeholders from source text and a redaction map
  * to reject unknown tokens before restoring a provider response.
  */
-export const findChatAnonPlaceholders = (text: string): string[] => [
-  ...new Set(text.match(PLACEHOLDER_TOKEN) ?? []),
-];
+export const findChatAnonPlaceholders = (text: string): string[] => {
+  const placeholders = text.match(PLACEHOLDER_TOKEN);
+  if (placeholders === null) {
+    return [];
+  }
+  return [...new Set(placeholders)];
+};
 
 const parsePlaceholderLabel = (placeholder: string): string | null => {
   const match = PLACEHOLDER_LABEL.exec(placeholder);

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -467,22 +467,43 @@ const forcedSensitiveGazetteerEntries = ({
     });
 };
 
-const assertForcedSensitiveValuesRedacted = (
-  redactedText: string,
-  forcedSensitiveValues: ReadonlySet<string>,
-): void => {
-  for (const forcedValue of forcedSensitiveValues) {
-    if (redactedText.includes(forcedValue)) {
-      panic("forced sensitive value remained after anonymization");
-    }
-  }
-};
-
 type NativeRedaction = {
   redactedText: string;
   redactionMap: Map<string, string>;
   operatorMap: Map<string, OperatorType>;
   entityCount: number;
+};
+
+const assertForcedSensitiveValuesRedacted = ({
+  forcedSensitiveValues,
+  redaction,
+  resolvedEntities,
+  sourceText,
+}: {
+  forcedSensitiveValues: ReadonlySet<string>;
+  redaction: Pick<NativeRedaction, "redactionMap">;
+  resolvedEntities: readonly NativePipelineEntity[];
+  sourceText: string;
+}): void => {
+  for (const forcedValue of forcedSensitiveValues) {
+    let offset = sourceText.indexOf(forcedValue);
+    while (offset !== -1) {
+      const end = offset + forcedValue.length;
+      const isRedacted = resolvedEntities.some(
+        (entity) => entity.start < end && entity.end > offset,
+      );
+      if (!isRedacted) {
+        panic("forced sensitive value remained after anonymization");
+      }
+      offset = sourceText.indexOf(forcedValue, offset + 1);
+    }
+  }
+
+  for (const placeholder of redaction.redactionMap.keys()) {
+    if (forcedSensitiveValues.has(placeholder)) {
+      panic("forced sensitive value became its own placeholder");
+    }
+  }
 };
 
 /**
@@ -706,6 +727,12 @@ export const runChatAnonPipeline = async <
   const { resolvedEntities, redaction } = pipeline.redactText(
     protectedInput.text,
   );
+  assertForcedSensitiveValuesRedacted({
+    forcedSensitiveValues: forcedSensitiveSet,
+    redaction,
+    resolvedEntities,
+    sourceText: protectedInput.text,
+  });
 
   const result = applyExcludedCanonicals({
     deanonymiseText: runtime.deanonymise,
@@ -716,7 +743,6 @@ export const runChatAnonPipeline = async <
     sourceText: protectedInput.text,
   });
   const redactedText = protectedInput.restore(result.redactedText);
-  assertForcedSensitiveValuesRedacted(redactedText, forcedSensitiveSet);
   return {
     ...result,
     redactedText,

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -574,20 +574,27 @@ const assertForcedSensitiveValuesRedacted = ({
   sourceText: string;
 }): void => {
   for (const forcedValue of forcedSensitiveValues) {
+    const occurrences: { end: number; start: number }[] = [];
     let offset = sourceText.indexOf(forcedValue);
     while (offset !== -1) {
-      const end = offset + forcedValue.length;
-      let isRedacted = false;
-      for (const entity of resolvedEntities) {
-        if (entity.start <= offset && entity.end >= end) {
-          isRedacted = true;
-          break;
-        }
-      }
-      if (!isRedacted) {
+      occurrences.push({ end: offset + forcedValue.length, start: offset });
+      offset = sourceText.indexOf(forcedValue, offset + 1);
+    }
+
+    const fullyCovered = occurrences.filter((occurrence) =>
+      resolvedEntities.some(
+        (entity) =>
+          entity.start <= occurrence.start && entity.end >= occurrence.end,
+      ),
+    );
+    for (const occurrence of occurrences) {
+      const overlapsCoveredOccurrence = fullyCovered.some(
+        (covered) =>
+          covered.start < occurrence.end && occurrence.start < covered.end,
+      );
+      if (!overlapsCoveredOccurrence) {
         panic("forced sensitive value remained after anonymization");
       }
-      offset = sourceText.indexOf(forcedValue, offset + 1);
     }
   }
 

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -301,22 +301,42 @@ const protectLiteralPlaceholders = (
   text: string;
   restore: (value: string) => string;
 } => {
+  const overlapsForcedSensitiveValue = (
+    placeholderOffset: number,
+    placeholderLength: number,
+  ): boolean => {
+    const placeholderEnd = placeholderOffset + placeholderLength;
+    for (const value of forcedSensitiveValues) {
+      const valueOffset = text.lastIndexOf(value, placeholderEnd - 1);
+      if (
+        valueOffset !== -1 &&
+        valueOffset + value.length > placeholderOffset
+      ) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   const restoreMap = new Map<string, string>();
   let index = 0;
-  const protectedText = text.replaceAll(PLACEHOLDER_TOKEN, (placeholder) => {
-    if (forcedSensitiveValues.has(placeholder)) {
-      return placeholder;
-    }
+  const protectedText = text.replaceAll(
+    PLACEHOLDER_TOKEN,
+    (placeholder, offset: number) => {
+      if (overlapsForcedSensitiveValue(offset, placeholder.length)) {
+        return placeholder;
+      }
 
-    let sentinel = `\uE000CHAT_PLACEHOLDER_${index}\uE001`;
-    while (text.includes(sentinel) || restoreMap.has(sentinel)) {
+      let sentinel = `\uE000CHAT_PLACEHOLDER_${index}\uE001`;
+      while (text.includes(sentinel) || restoreMap.has(sentinel)) {
+        index += 1;
+        sentinel = `\uE000CHAT_PLACEHOLDER_${index}\uE001`;
+      }
+      restoreMap.set(sentinel, placeholder);
       index += 1;
-      sentinel = `\uE000CHAT_PLACEHOLDER_${index}\uE001`;
-    }
-    restoreMap.set(sentinel, placeholder);
-    index += 1;
-    return sentinel;
-  });
+      return sentinel;
+    },
+  );
 
   return {
     text: protectedText,

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -678,27 +678,21 @@ const applyExcludedCanonicals = ({
   }
 
   const excludedSet = new Set(excludedCanonicals.map(normalizeForExclusion));
-  for (const entity of resolvedEntities) {
-    const canonical = normalizeForExclusion(entity.text);
-    if (
-      excludedSet.has(canonical) &&
-      spanOverlapsLiteralValue({
-        end: entity.end,
-        start: entity.start,
-        text: sourceText,
-        values: forcedSensitiveValues,
-      })
-    ) {
-      excludedSet.delete(canonical);
-    }
-  }
-  if (excludedSet.size === 0) {
-    return toChatAnonResult(resolvedEntities, redaction);
-  }
+  const isForcedEntity = (entity: NativePipelineEntity) =>
+    spanOverlapsLiteralValue({
+      end: entity.end,
+      start: entity.start,
+      text: sourceText,
+      values: forcedSensitiveValues,
+    });
 
   const revertMap = new Map<string, string>();
   for (const [placeholder, original] of redaction.redactionMap) {
-    if (excludedSet.has(normalizeForExclusion(original))) {
+    const isExcluded = excludedSet.has(normalizeForExclusion(original));
+    const hasForcedOccurrence = resolvedEntities.some(
+      (entity) => entity.text === original && isForcedEntity(entity),
+    );
+    if (isExcluded && !hasForcedOccurrence) {
       revertMap.set(placeholder, original);
     }
   }
@@ -714,7 +708,9 @@ const applyExcludedCanonicals = ({
     ),
   );
   const remainingEntities = resolvedEntities.filter(
-    (entity) => !excludedSet.has(normalizeForExclusion(entity.text)),
+    (entity) =>
+      !excludedSet.has(normalizeForExclusion(entity.text)) ||
+      isForcedEntity(entity),
   );
   // Occurrence-based approximation: `entityCount` reports redacted
   // *occurrences*, while `revertMap` is keyed per distinct

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -561,9 +561,13 @@ const assertForcedSensitiveValuesRedacted = ({
     let offset = sourceText.indexOf(forcedValue);
     while (offset !== -1) {
       const end = offset + forcedValue.length;
-      const isRedacted = resolvedEntities.some(
-        (entity) => entity.start <= offset && entity.end >= end,
-      );
+      let isRedacted = false;
+      for (const entity of resolvedEntities) {
+        if (entity.start <= offset && entity.end >= end) {
+          isRedacted = true;
+          break;
+        }
+      }
       if (!isRedacted) {
         panic("forced sensitive value remained after anonymization");
       }

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -787,12 +787,6 @@ export const runChatAnonPipeline = async <
     text,
     workspaceId,
   });
-  const forcedCanonicals = new Set(
-    forcedEntries.map(({ canonical }) => normalizeForExclusion(canonical)),
-  );
-  const effectiveExcludedCanonicals = excludedCanonicals?.filter(
-    (canonical) => !forcedCanonicals.has(normalizeForExclusion(canonical)),
-  );
   const effectiveGazetteerEntries = [...gazetteerEntries, ...forcedEntries];
 
   const context = providedContext ?? runtime.createPipelineContext();
@@ -839,7 +833,7 @@ export const runChatAnonPipeline = async <
 
   const result = applyExcludedCanonicals({
     deanonymiseText: runtime.deanonymise,
-    excludedCanonicals: effectiveExcludedCanonicals,
+    excludedCanonicals,
     forcedSensitiveValues: forcedSensitiveSet,
     resolvedEntities,
     redaction,

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -389,13 +389,11 @@ const protectLiteralPlaceholders = (
   text: string,
   forcedSensitiveValues: ReadonlySet<string>,
 ): {
-  protectedPlaceholders: ReadonlySet<string>;
   sourcePlaceholders: ReadonlySet<string>;
   text: string;
   restore: (value: string) => string;
 } => {
   const restoreMap = new Map<string, string>();
-  const protectedPlaceholders = new Set<string>();
   const sourcePlaceholders = new Set<string>();
   const cursor: LiteralPlaceholderSentinelCursor = {
     codePoint: LITERAL_PLACEHOLDER_SENTINEL_RANGES[0].start,
@@ -422,13 +420,11 @@ const protectLiteralPlaceholders = (
         text,
       });
       restoreMap.set(sentinel, placeholder);
-      protectedPlaceholders.add(placeholder);
       return sentinel;
     },
   );
 
   return {
-    protectedPlaceholders,
     sourcePlaceholders,
     text: protectedText,
     restore: (value) => restoreLiteralPlaceholders(value, restoreMap),
@@ -489,25 +485,23 @@ type NativeRedaction = {
   entityCount: number;
 };
 
-const rekeyProtectedPlaceholderCollisions = ({
-  blockedPlaceholders,
-  protectedPlaceholders,
+const rekeyReservedPlaceholderCollisions = ({
   redaction,
+  reservedPlaceholders,
 }: {
-  blockedPlaceholders: ReadonlySet<string>;
-  protectedPlaceholders: ReadonlySet<string>;
   redaction: NativeRedaction;
+  reservedPlaceholders: ReadonlySet<string>;
 }): NativeRedaction => {
   if (
     ![...redaction.redactionMap.keys()].some((placeholder) =>
-      protectedPlaceholders.has(placeholder),
+      reservedPlaceholders.has(placeholder),
     )
   ) {
     return redaction;
   }
 
   const blocked = new Set([
-    ...blockedPlaceholders,
+    ...reservedPlaceholders,
     ...redaction.redactionMap.keys(),
   ]);
   const redactionMap = new Map<string, string>();
@@ -516,7 +510,7 @@ const rekeyProtectedPlaceholderCollisions = ({
 
   for (const [placeholder, original] of redaction.redactionMap) {
     let replacement = placeholder;
-    if (protectedPlaceholders.has(placeholder)) {
+    if (reservedPlaceholders.has(placeholder)) {
       const label =
         parsePlaceholderLabel(placeholder) ??
         panic("native redaction emitted an invalid placeholder");
@@ -803,10 +797,9 @@ export const runChatAnonPipeline = async <
   const { resolvedEntities, redaction: nativeRedaction } = pipeline.redactText(
     protectedInput.text,
   );
-  const redaction = rekeyProtectedPlaceholderCollisions({
-    blockedPlaceholders: protectedInput.sourcePlaceholders,
-    protectedPlaceholders: protectedInput.protectedPlaceholders,
+  const redaction = rekeyReservedPlaceholderCollisions({
     redaction: nativeRedaction,
+    reservedPlaceholders: protectedInput.sourcePlaceholders,
   });
   assertForcedSensitiveValuesRedacted({
     forcedSensitiveValues: forcedSensitiveSet,

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -64,6 +64,10 @@ export const FORCED_SENSITIVE_VALUES_MAX = 256;
 /** Maximum UTF-16 length of one forced sensitive value. */
 export const FORCED_SENSITIVE_VALUE_MAX_LENGTH = 4096;
 
+const FORCED_SENSITIVE_DEFAULT_LABEL = "misc" satisfies DefaultEntityLabel;
+const FORCED_SENSITIVE_PLACEHOLDER_ESCAPE_LABEL =
+  "case number" satisfies DefaultEntityLabel;
+
 export type ChatAnonPair = {
   placeholder: string;
   original: string;
@@ -454,7 +458,10 @@ const forcedSensitiveGazetteerEntries = ({
     .toSorted((left, right) => right.length - left.length)
     .map((canonical, index) => {
       const label =
-        parsePlaceholderLabel(canonical) === "MISC" ? "case number" : "misc";
+        parsePlaceholderLabel(canonical) ===
+        normalizeEntityLabelForPlaceholder(FORCED_SENSITIVE_DEFAULT_LABEL)
+          ? FORCED_SENSITIVE_PLACEHOLDER_ESCAPE_LABEL
+          : FORCED_SENSITIVE_DEFAULT_LABEL;
       return {
         id: `forced-sensitive-${String(index + 1)}`,
         canonical,
@@ -499,8 +506,8 @@ const assertForcedSensitiveValuesRedacted = ({
     }
   }
 
-  for (const placeholder of redaction.redactionMap.keys()) {
-    if (forcedSensitiveValues.has(placeholder)) {
+  for (const [placeholder, original] of redaction.redactionMap) {
+    if (placeholder === original && forcedSensitiveValues.has(original)) {
       panic("forced sensitive value became its own placeholder");
     }
   }

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -309,12 +309,12 @@ type LiteralPlaceholderSentinelCursor = {
 };
 
 const allocateLiteralPlaceholderSentinel = ({
+  blockedValues,
   cursor,
-  forcedSensitiveValues,
   text,
 }: {
+  blockedValues: ReadonlySet<string>;
   cursor: LiteralPlaceholderSentinelCursor;
-  forcedSensitiveValues: ReadonlySet<string>;
   text: string;
 }): string => {
   while (cursor.rangeIndex < LITERAL_PLACEHOLDER_SENTINEL_RANGES.length) {
@@ -339,14 +339,14 @@ const allocateLiteralPlaceholderSentinel = ({
       continue;
     }
 
-    let overlapsForcedValue = false;
-    for (const forcedValue of forcedSensitiveValues) {
-      if (forcedValue.includes(sentinel) || sentinel.includes(forcedValue)) {
-        overlapsForcedValue = true;
+    let overlapsBlockedValue = false;
+    for (const blockedValue of blockedValues) {
+      if (blockedValue.includes(sentinel) || sentinel.includes(blockedValue)) {
+        overlapsBlockedValue = true;
         break;
       }
     }
-    if (!overlapsForcedValue) {
+    if (!overlapsBlockedValue) {
       return sentinel;
     }
   }
@@ -385,10 +385,15 @@ const spanOverlapsLiteralValue = ({
   return false;
 };
 
-const protectLiteralPlaceholders = (
-  text: string,
-  forcedSensitiveValues: ReadonlySet<string>,
-): {
+const protectLiteralPlaceholders = ({
+  detectorVisibleValues,
+  forcedSensitiveValues,
+  text,
+}: {
+  detectorVisibleValues: ReadonlySet<string>;
+  forcedSensitiveValues: ReadonlySet<string>;
+  text: string;
+}): {
   sourcePlaceholders: ReadonlySet<string>;
   text: string;
   restore: (value: string) => string;
@@ -415,8 +420,8 @@ const protectLiteralPlaceholders = (
       }
 
       const sentinel = allocateLiteralPlaceholderSentinel({
+        blockedValues: detectorVisibleValues,
         cursor,
-        forcedSensitiveValues,
         text,
       });
       restoreMap.set(sentinel, placeholder);
@@ -476,6 +481,23 @@ const forcedSensitiveGazetteerEntries = ({
         source: "manual",
       };
     });
+};
+
+const gazetteerExactValues = (
+  entries: readonly GazetteerEntry[],
+): ReadonlySet<string> => {
+  const values = new Set<string>();
+  for (const entry of entries) {
+    if (entry.canonical.length > 0) {
+      values.add(entry.canonical);
+    }
+    for (const variant of entry.variants) {
+      if (variant.length > 0) {
+        values.add(variant);
+      }
+    }
+  }
+  return values;
 };
 
 type NativeRedaction = {
@@ -793,7 +815,11 @@ export const runChatAnonPipeline = async <
   const forcedSensitiveSet = new Set(
     forcedEntries.map(({ canonical }) => canonical),
   );
-  const protectedInput = protectLiteralPlaceholders(text, forcedSensitiveSet);
+  const protectedInput = protectLiteralPlaceholders({
+    detectorVisibleValues: gazetteerExactValues(effectiveGazetteerEntries),
+    forcedSensitiveValues: forcedSensitiveSet,
+    text,
+  });
   const { resolvedEntities, redaction: nativeRedaction } = pipeline.redactText(
     protectedInput.text,
   );

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -389,10 +389,14 @@ const protectLiteralPlaceholders = (
   text: string,
   forcedSensitiveValues: ReadonlySet<string>,
 ): {
+  protectedPlaceholders: ReadonlySet<string>;
+  sourcePlaceholders: ReadonlySet<string>;
   text: string;
   restore: (value: string) => string;
 } => {
   const restoreMap = new Map<string, string>();
+  const protectedPlaceholders = new Set<string>();
+  const sourcePlaceholders = new Set<string>();
   const cursor: LiteralPlaceholderSentinelCursor = {
     codePoint: LITERAL_PLACEHOLDER_SENTINEL_RANGES[0].start,
     rangeIndex: 0,
@@ -400,6 +404,7 @@ const protectLiteralPlaceholders = (
   const protectedText = text.replaceAll(
     PLACEHOLDER_TOKEN,
     (placeholder, offset: number) => {
+      sourcePlaceholders.add(placeholder);
       if (
         spanOverlapsLiteralValue({
           end: offset + placeholder.length,
@@ -417,11 +422,14 @@ const protectLiteralPlaceholders = (
         text,
       });
       restoreMap.set(sentinel, placeholder);
+      protectedPlaceholders.add(placeholder);
       return sentinel;
     },
   );
 
   return {
+    protectedPlaceholders,
+    sourcePlaceholders,
     text: protectedText,
     restore: (value) => restoreLiteralPlaceholders(value, restoreMap),
   };
@@ -481,6 +489,63 @@ type NativeRedaction = {
   entityCount: number;
 };
 
+const rekeyProtectedPlaceholderCollisions = ({
+  blockedPlaceholders,
+  protectedPlaceholders,
+  redaction,
+}: {
+  blockedPlaceholders: ReadonlySet<string>;
+  protectedPlaceholders: ReadonlySet<string>;
+  redaction: NativeRedaction;
+}): NativeRedaction => {
+  if (
+    ![...redaction.redactionMap.keys()].some((placeholder) =>
+      protectedPlaceholders.has(placeholder),
+    )
+  ) {
+    return redaction;
+  }
+
+  const blocked = new Set([
+    ...blockedPlaceholders,
+    ...redaction.redactionMap.keys(),
+  ]);
+  const redactionMap = new Map<string, string>();
+  const operatorMap = new Map(redaction.operatorMap);
+  let redactedText = redaction.redactedText;
+
+  for (const [placeholder, original] of redaction.redactionMap) {
+    let replacement = placeholder;
+    if (protectedPlaceholders.has(placeholder)) {
+      const label =
+        parsePlaceholderLabel(placeholder) ??
+        panic("native redaction emitted an invalid placeholder");
+      let index = 1;
+      replacement = `[${label}_${String(index)}]`;
+      while (blocked.has(replacement)) {
+        index += 1;
+        replacement = `[${label}_${String(index)}]`;
+      }
+      blocked.add(replacement);
+      redactedText = redactedText.replaceAll(placeholder, () => replacement);
+      const operator = operatorMap.get(placeholder);
+      operatorMap.delete(placeholder);
+      if (operator !== undefined) {
+        operatorMap.set(replacement, operator);
+      }
+    }
+
+    redactionMap.set(replacement, original);
+  }
+
+  return {
+    entityCount: redaction.entityCount,
+    operatorMap,
+    redactedText,
+    redactionMap,
+  };
+};
+
 const assertForcedSensitiveValuesRedacted = ({
   forcedSensitiveValues,
   redaction,
@@ -497,7 +562,7 @@ const assertForcedSensitiveValuesRedacted = ({
     while (offset !== -1) {
       const end = offset + forcedValue.length;
       const isRedacted = resolvedEntities.some(
-        (entity) => entity.start < end && entity.end > offset,
+        (entity) => entity.start <= offset && entity.end >= end,
       );
       if (!isRedacted) {
         panic("forced sensitive value remained after anonymization");
@@ -731,9 +796,14 @@ export const runChatAnonPipeline = async <
     forcedEntries.map(({ canonical }) => canonical),
   );
   const protectedInput = protectLiteralPlaceholders(text, forcedSensitiveSet);
-  const { resolvedEntities, redaction } = pipeline.redactText(
+  const { resolvedEntities, redaction: nativeRedaction } = pipeline.redactText(
     protectedInput.text,
   );
+  const redaction = rekeyProtectedPlaceholderCollisions({
+    blockedPlaceholders: protectedInput.sourcePlaceholders,
+    protectedPlaceholders: protectedInput.protectedPlaceholders,
+    redaction: nativeRedaction,
+  });
   assertForcedSensitiveValuesRedacted({
     forcedSensitiveValues: forcedSensitiveSet,
     redaction,

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -282,6 +282,72 @@ const normalizeForExclusion = (value: string): string =>
   value.normalize("NFKC").toLowerCase().replaceAll(/\s+/gu, " ").trim();
 
 const PLACEHOLDER_TOKEN = /\[[A-Z][A-Z0-9_]*_\d+\]/gu;
+const PLACEHOLDER_LABEL = /^\[(?<label>[A-Z][A-Z0-9_]*)_\d+\]$/u;
+
+const parsePlaceholderLabel = (placeholder: string): string | null => {
+  const match = PLACEHOLDER_LABEL.exec(placeholder);
+  return match?.groups?.["label"] ?? null;
+};
+
+const normalizeEntityLabelForPlaceholder = (label: string): string =>
+  label.trim().toUpperCase().replaceAll(/\s+/gu, "_");
+
+const LITERAL_PLACEHOLDER_SENTINEL_RANGES = [
+  { end: 0xf8ff, start: 0xe000 },
+  { end: 0xffffd, start: 0xf0000 },
+  { end: 0x10fffd, start: 0x100000 },
+] as const;
+
+type LiteralPlaceholderSentinelCursor = {
+  codePoint: number;
+  rangeIndex: number;
+};
+
+const allocateLiteralPlaceholderSentinel = ({
+  cursor,
+  forcedSensitiveValues,
+  text,
+}: {
+  cursor: LiteralPlaceholderSentinelCursor;
+  forcedSensitiveValues: ReadonlySet<string>;
+  text: string;
+}): string => {
+  while (cursor.rangeIndex < LITERAL_PLACEHOLDER_SENTINEL_RANGES.length) {
+    const range = LITERAL_PLACEHOLDER_SENTINEL_RANGES.at(cursor.rangeIndex);
+    if (range === undefined) {
+      break;
+    }
+    if (cursor.codePoint > range.end) {
+      cursor.rangeIndex += 1;
+      const nextRange = LITERAL_PLACEHOLDER_SENTINEL_RANGES.at(
+        cursor.rangeIndex,
+      );
+      if (nextRange !== undefined) {
+        cursor.codePoint = nextRange.start;
+      }
+      continue;
+    }
+
+    const sentinel = String.fromCodePoint(cursor.codePoint);
+    cursor.codePoint += 1;
+    if (text.includes(sentinel)) {
+      continue;
+    }
+
+    let overlapsForcedValue = false;
+    for (const forcedValue of forcedSensitiveValues) {
+      if (forcedValue.includes(sentinel) || sentinel.includes(forcedValue)) {
+        overlapsForcedValue = true;
+        break;
+      }
+    }
+    if (!overlapsForcedValue) {
+      return sentinel;
+    }
+  }
+
+  throw new RangeError("literal placeholder sentinel space exhausted");
+};
 
 const restoreLiteralPlaceholders = (
   text: string,
@@ -322,7 +388,10 @@ const protectLiteralPlaceholders = (
   restore: (value: string) => string;
 } => {
   const restoreMap = new Map<string, string>();
-  let index = 0;
+  const cursor: LiteralPlaceholderSentinelCursor = {
+    codePoint: LITERAL_PLACEHOLDER_SENTINEL_RANGES[0].start,
+    rangeIndex: 0,
+  };
   const protectedText = text.replaceAll(
     PLACEHOLDER_TOKEN,
     (placeholder, offset: number) => {
@@ -337,13 +406,12 @@ const protectLiteralPlaceholders = (
         return placeholder;
       }
 
-      let sentinel = `\uE000CHAT_PLACEHOLDER_${index}\uE001`;
-      while (text.includes(sentinel) || restoreMap.has(sentinel)) {
-        index += 1;
-        sentinel = `\uE000CHAT_PLACEHOLDER_${index}\uE001`;
-      }
+      const sentinel = allocateLiteralPlaceholderSentinel({
+        cursor,
+        forcedSensitiveValues,
+        text,
+      });
       restoreMap.set(sentinel, placeholder);
-      index += 1;
       return sentinel;
     },
   );
@@ -383,15 +451,30 @@ const forcedSensitiveGazetteerEntries = ({
 
   return [...values]
     .toSorted((left, right) => right.length - left.length)
-    .map((canonical, index) => ({
-      id: `forced-sensitive-${String(index + 1)}`,
-      canonical,
-      label: "misc",
-      variants: [],
-      workspaceId,
-      createdAt: 0,
-      source: "manual",
-    }));
+    .map((canonical, index) => {
+      const label =
+        parsePlaceholderLabel(canonical) === "MISC" ? "case number" : "misc";
+      return {
+        id: `forced-sensitive-${String(index + 1)}`,
+        canonical,
+        label,
+        variants: [],
+        workspaceId,
+        createdAt: 0,
+        source: "manual",
+      };
+    });
+};
+
+const assertForcedSensitiveValuesRedacted = (
+  redactedText: string,
+  forcedSensitiveValues: ReadonlySet<string>,
+): void => {
+  for (const forcedValue of forcedSensitiveValues) {
+    if (redactedText.includes(forcedValue)) {
+      throw new Error("forced sensitive value remained after anonymization");
+    }
+  }
 };
 
 type NativeRedaction = {
@@ -400,16 +483,6 @@ type NativeRedaction = {
   operatorMap: Map<string, OperatorType>;
   entityCount: number;
 };
-
-const PLACEHOLDER_LABEL = /^\[(?<label>[A-Z][A-Z0-9_]*)_\d+\]$/u;
-
-const parsePlaceholderLabel = (placeholder: string): string | null => {
-  const match = PLACEHOLDER_LABEL.exec(placeholder);
-  return match?.groups?.["label"] ?? null;
-};
-
-const normalizeEntityLabelForPlaceholder = (label: string): string =>
-  label.trim().toUpperCase().replaceAll(/\s+/gu, "_");
 
 /**
  * Build the public {@link ChatAnonResult} from a (possibly already
@@ -641,8 +714,10 @@ export const runChatAnonPipeline = async <
     redaction,
     sourceText: protectedInput.text,
   });
+  const redactedText = protectedInput.restore(result.redactedText);
+  assertForcedSensitiveValuesRedacted(redactedText, forcedSensitiveSet);
   return {
     ...result,
-    redactedText: protectedInput.restore(result.redactedText),
+    redactedText,
   };
 };

--- a/packages/anonymize-chat/tsconfig.json
+++ b/packages/anonymize-chat/tsconfig.json
@@ -6,5 +6,5 @@
     "types": ["bun-types"]
   },
   "include": ["."],
-  "exclude": ["node_modules"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/anonymize-chat/tsdown.config.ts
+++ b/packages/anonymize-chat/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  platform: "neutral",
+  dts: true,
+  outDir: "dist",
+  clean: true,
+});

--- a/scripts/bootstrap-publish-packages.sh
+++ b/scripts/bootstrap-publish-packages.sh
@@ -69,8 +69,7 @@ for p in "${packages[@]}"; do
   (
     cd "packages/${p}"
     bun pm pack \
-      --destination "$staging_dir" \
-      --filename "$packed_filename" \
+      --filename "${staging_dir}/${packed_filename}" \
       --ignore-scripts \
       --quiet >/dev/null
   )

--- a/scripts/bootstrap-publish-packages.sh
+++ b/scripts/bootstrap-publish-packages.sh
@@ -9,7 +9,7 @@
 # and use the workflow for every release thereafter.
 #
 # All packages are authenticated, validated, built, transformed, and packed
-# before the first registry write. The transform rewrites catalog:/workspace:
+# before the first registry write. Bun's packer rewrites catalog:/workspace:
 # dependencies; npm then publishes the exact preflighted archives. A trap
 # restores every source-shaped manifest.
 #
@@ -65,19 +65,33 @@ for p in "${packages[@]}"; do
   (cd "packages/${p}" && bun run build)
   bun scripts/prepare-publish.ts "packages/${p}"
   require_placeholder_version "$p"
-  pack_json="$(
+  packed_filename="stll-${p}-0.0.0.tgz"
+  (
     cd "packages/${p}"
-    npm pack --json --ignore-scripts --pack-destination "$staging_dir"
-  )"
-  packed_name="$(jq -er '.[0].name | strings' <<<"$pack_json")"
-  packed_version="$(jq -er '.[0].version | strings' <<<"$pack_json")"
-  packed_filename="$(jq -er '.[0].filename | strings' <<<"$pack_json")"
-  packed_integrity="$(jq -er '.[0].integrity | strings' <<<"$pack_json")"
+    bun pm pack \
+      --destination "$staging_dir" \
+      --filename "$packed_filename" \
+      --ignore-scripts \
+      --quiet >/dev/null
+  )
+  tarball="${staging_dir}/${packed_filename}"
+  if [[ ! -f "$tarball" ]]; then
+    echo "error: Bun did not create the expected archive for @stll/${p}." >&2
+    exit 1
+  fi
+  packed_manifest="$(tar -xOf "$tarball" package/package.json)"
+  packed_name="$(jq -er '.name | strings' <<<"$packed_manifest")"
+  packed_version="$(jq -er '.version | strings' <<<"$packed_manifest")"
   if [[ "$packed_name" != "@stll/${p}" || "$packed_version" != "0.0.0" ]]; then
     echo "error: packed artifact identity is ${packed_name}@${packed_version}; expected @stll/${p}@0.0.0." >&2
     exit 1
   fi
-  tarballs+=("${staging_dir}/${packed_filename}")
+  if ! jq -e '[.. | strings | select(startswith("catalog:") or startswith("workspace:"))] | length == 0' >/dev/null <<<"$packed_manifest"; then
+    echo "error: packed @stll/${p}@0.0.0 still contains an unresolved dependency protocol." >&2
+    exit 1
+  fi
+  packed_integrity="sha512-$(openssl dgst -sha512 -binary "$tarball" | openssl base64 -A)"
+  tarballs+=("$tarball")
   integrities+=("$packed_integrity")
 done
 

--- a/scripts/bootstrap-publish-packages.sh
+++ b/scripts/bootstrap-publish-packages.sh
@@ -29,16 +29,23 @@ fi
 packages=(auth-model ai-catalog anonymize-chat conditions template-conditions docx-utils)
 manifests=()
 
+require_placeholder_version() {
+  local package_name="$1"
+  local manifest="packages/${package_name}/package.json"
+  local version
+  version="$(jq -er '.version | strings' "$manifest")"
+  if [[ "$version" != "0.0.0" ]]; then
+    echo "error: @stll/${package_name} is ${version}; bootstrap only publishes the 0.0.0 placeholder." >&2
+    exit 1
+  fi
+}
+
 npm whoami >/dev/null
 
 for p in "${packages[@]}"; do
   manifest="packages/${p}/package.json"
   manifests+=("$manifest")
-  version="$(jq -er '.version | strings' "$manifest")"
-  if [[ "$version" != "0.0.0" ]]; then
-    echo "error: @stll/${p} is ${version}; bootstrap only publishes the 0.0.0 placeholder." >&2
-    exit 1
-  fi
+  require_placeholder_version "$p"
   if registry_result="$(npm view "@stll/${p}" version 2>&1)"; then
     echo "error: @stll/${p} already exists on npm; refusing a bootstrap publish." >&2
     exit 1
@@ -59,11 +66,13 @@ for p in "${packages[@]}"; do
   echo "==> preparing @stll/${p}@0.0.0"
   (cd "packages/${p}" && bun run build)
   bun scripts/prepare-publish.ts "packages/${p}"
+  require_placeholder_version "$p"
   (cd "packages/${p}" && bun pm pack --dry-run)
 done
 
 for p in "${packages[@]}"; do
   echo "==> publishing @stll/${p}@0.0.0"
+  require_placeholder_version "$p"
   (cd "packages/${p}" && bun publish --access public)
 done
 

--- a/scripts/bootstrap-publish-packages.sh
+++ b/scripts/bootstrap-publish-packages.sh
@@ -73,7 +73,7 @@ done
 for p in "${packages[@]}"; do
   echo "==> publishing @stll/${p}@0.0.0"
   require_placeholder_version "$p"
-  (cd "packages/${p}" && bun publish --access public)
+  (cd "packages/${p}" && bun publish --ignore-scripts --access public)
 done
 
 cleanup

--- a/scripts/bootstrap-publish-packages.sh
+++ b/scripts/bootstrap-publish-packages.sh
@@ -23,9 +23,10 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
-# auth-model, conditions, and docx-utils are independent. Publish conditions
-# before template-conditions, which depends on it.
-packages=(auth-model conditions template-conditions docx-utils)
+# First publication needs an npm token; trusted publishing can only be configured
+# after each package exists. `template-conditions` depends on `conditions`;
+# `anonymize-chat` depends on the already-published `anonymize-wasm` package.
+packages=(auth-model ai-catalog anonymize-chat conditions template-conditions docx-utils)
 
 for p in "${packages[@]}"; do
   echo "==> publishing @stll/${p}"

--- a/scripts/bootstrap-publish-packages.sh
+++ b/scripts/bootstrap-publish-packages.sh
@@ -9,8 +9,9 @@
 # and use the workflow for every release thereafter.
 #
 # All packages are authenticated, validated, built, transformed, and packed
-# before the first registry write. `bun publish` rewrites catalog:/workspace:
-# dependencies; npm would not. A trap restores every source-shaped manifest.
+# before the first registry write. The transform rewrites catalog:/workspace:
+# dependencies; npm then publishes the exact preflighted archives. A trap
+# restores every source-shaped manifest.
 #
 # Requires npm auth (`npm whoami` must succeed) and a clean git tree.
 # Run from the repo root.
@@ -28,6 +29,9 @@ fi
 # `anonymize-chat` depends on the already-published `anonymize-wasm` package.
 packages=(auth-model ai-catalog anonymize-chat conditions template-conditions docx-utils)
 manifests=()
+integrities=()
+publish_modes=()
+tarballs=()
 
 require_placeholder_version() {
   local package_name="$1"
@@ -46,19 +50,13 @@ for p in "${packages[@]}"; do
   manifest="packages/${p}/package.json"
   manifests+=("$manifest")
   require_placeholder_version "$p"
-  if registry_result="$(npm view "@stll/${p}" version 2>&1)"; then
-    echo "error: @stll/${p} already exists on npm; refusing a bootstrap publish." >&2
-    exit 1
-  fi
-  if [[ "$registry_result" != *"E404"* ]]; then
-    echo "error: could not verify that @stll/${p} is absent from npm." >&2
-    echo "$registry_result" >&2
-    exit 1
-  fi
 done
+
+staging_dir="$(mktemp -d "${TMPDIR:-/tmp}/stella-bootstrap-publish.XXXXXX")"
 
 cleanup() {
   git checkout -- "${manifests[@]}"
+  rm -rf -- "$staging_dir"
 }
 trap cleanup EXIT
 
@@ -67,13 +65,55 @@ for p in "${packages[@]}"; do
   (cd "packages/${p}" && bun run build)
   bun scripts/prepare-publish.ts "packages/${p}"
   require_placeholder_version "$p"
-  (cd "packages/${p}" && bun pm pack --dry-run)
+  pack_json="$(
+    cd "packages/${p}"
+    npm pack --json --ignore-scripts --pack-destination "$staging_dir"
+  )"
+  packed_name="$(jq -er '.[0].name | strings' <<<"$pack_json")"
+  packed_version="$(jq -er '.[0].version | strings' <<<"$pack_json")"
+  packed_filename="$(jq -er '.[0].filename | strings' <<<"$pack_json")"
+  packed_integrity="$(jq -er '.[0].integrity | strings' <<<"$pack_json")"
+  if [[ "$packed_name" != "@stll/${p}" || "$packed_version" != "0.0.0" ]]; then
+    echo "error: packed artifact identity is ${packed_name}@${packed_version}; expected @stll/${p}@0.0.0." >&2
+    exit 1
+  fi
+  tarballs+=("${staging_dir}/${packed_filename}")
+  integrities+=("$packed_integrity")
 done
 
-for p in "${packages[@]}"; do
+for index in "${!packages[@]}"; do
+  p="${packages[$index]}"
+  package_name="@stll/${p}"
+  if registry_result="$(npm view "$package_name" version 2>&1)"; then
+    if ! registry_integrity="$(npm view "${package_name}@0.0.0" dist.integrity 2>&1)"; then
+      echo "error: ${package_name} exists, but its 0.0.0 artifact could not be verified." >&2
+      echo "$registry_integrity" >&2
+      exit 1
+    fi
+    if [[ "$registry_integrity" != "${integrities[$index]}" ]]; then
+      echo "error: ${package_name}@0.0.0 exists with an unexpected artifact; refusing to continue." >&2
+      exit 1
+    fi
+    publish_modes+=(skip)
+    continue
+  fi
+  if [[ "$registry_result" != *"E404"* ]]; then
+    echo "error: could not verify that ${package_name} is absent from npm." >&2
+    echo "$registry_result" >&2
+    exit 1
+  fi
+  publish_modes+=(publish)
+done
+
+for index in "${!packages[@]}"; do
+  p="${packages[$index]}"
+  if [[ "${publish_modes[$index]}" == "skip" ]]; then
+    echo "==> @stll/${p}@0.0.0 already matches the preflighted artifact; skipping"
+    continue
+  fi
   echo "==> publishing @stll/${p}@0.0.0"
   require_placeholder_version "$p"
-  (cd "packages/${p}" && bun publish --ignore-scripts --access public)
+  npm publish "${tarballs[$index]}" --ignore-scripts --access public
 done
 
 cleanup

--- a/scripts/bootstrap-publish-packages.sh
+++ b/scripts/bootstrap-publish-packages.sh
@@ -52,7 +52,7 @@ for p in "${packages[@]}"; do
   require_placeholder_version "$p"
 done
 
-staging_dir="$(mktemp -d "${TMPDIR:-/tmp}/stella-bootstrap-publish.XXXXXX")"
+staging_dir="$(mktemp -d)"
 
 cleanup() {
   git checkout -- "${manifests[@]}"

--- a/scripts/bootstrap-publish-packages.sh
+++ b/scripts/bootstrap-publish-packages.sh
@@ -8,9 +8,9 @@
 # settings -> Publishing) pointing at this repo + .github/workflows/publish-npm.yml,
 # and use the workflow for every release thereafter.
 #
-# Per package: build, transform the package.json to its published dist shape,
-# `bun publish` (Bun rewrites catalog:/workspace: deps; npm would not), then
-# restore the source-shaped package.json.
+# All packages are authenticated, validated, built, transformed, and packed
+# before the first registry write. `bun publish` rewrites catalog:/workspace:
+# dependencies; npm would not. A trap restores every source-shaped manifest.
 #
 # Requires npm auth (`npm whoami` must succeed) and a clean git tree.
 # Run from the repo root.
@@ -27,14 +27,48 @@ fi
 # after each package exists. `template-conditions` depends on `conditions`;
 # `anonymize-chat` depends on the already-published `anonymize-wasm` package.
 packages=(auth-model ai-catalog anonymize-chat conditions template-conditions docx-utils)
+manifests=()
+
+npm whoami >/dev/null
 
 for p in "${packages[@]}"; do
-  echo "==> publishing @stll/${p}"
+  manifest="packages/${p}/package.json"
+  manifests+=("$manifest")
+  version="$(jq -er '.version | strings' "$manifest")"
+  if [[ "$version" != "0.0.0" ]]; then
+    echo "error: @stll/${p} is ${version}; bootstrap only publishes the 0.0.0 placeholder." >&2
+    exit 1
+  fi
+  if registry_result="$(npm view "@stll/${p}" version 2>&1)"; then
+    echo "error: @stll/${p} already exists on npm; refusing a bootstrap publish." >&2
+    exit 1
+  fi
+  if [[ "$registry_result" != *"E404"* ]]; then
+    echo "error: could not verify that @stll/${p} is absent from npm." >&2
+    echo "$registry_result" >&2
+    exit 1
+  fi
+done
+
+cleanup() {
+  git checkout -- "${manifests[@]}"
+}
+trap cleanup EXIT
+
+for p in "${packages[@]}"; do
+  echo "==> preparing @stll/${p}@0.0.0"
   (cd "packages/${p}" && bun run build)
   bun scripts/prepare-publish.ts "packages/${p}"
-  (cd "packages/${p}" && bun publish --access public)
-  git checkout -- "packages/${p}/package.json"
+  (cd "packages/${p}" && bun pm pack --dry-run)
 done
+
+for p in "${packages[@]}"; do
+  echo "==> publishing @stll/${p}@0.0.0"
+  (cd "packages/${p}" && bun publish --access public)
+done
+
+cleanup
+trap - EXIT
 
 echo
 echo "Published. Next: add an npm trusted publisher for each package on npmjs.com,"

--- a/scripts/changeset-policy.json
+++ b/scripts/changeset-policy.json
@@ -1,5 +1,15 @@
 {
   "releasePaths": [
+    "packages/ai-catalog/README.md",
+    "packages/ai-catalog/package.json",
+    "packages/ai-catalog/src/**",
+    "packages/ai-catalog/tsconfig.json",
+    "packages/ai-catalog/tsdown.config.ts",
+    "packages/anonymize-chat/README.md",
+    "packages/anonymize-chat/package.json",
+    "packages/anonymize-chat/src/**",
+    "packages/anonymize-chat/tsconfig.json",
+    "packages/anonymize-chat/tsdown.config.ts",
     "packages/cli/README.md",
     "packages/cli/package.json",
     "packages/cli/src/**",
@@ -61,6 +71,10 @@
   ],
   "generatedPaths": [
     "bun.lock",
+    "packages/ai-catalog/CHANGELOG.md",
+    "packages/ai-catalog/package.json",
+    "packages/anonymize-chat/CHANGELOG.md",
+    "packages/anonymize-chat/package.json",
     "packages/cli/CHANGELOG.md",
     "packages/cli/package.json",
     "packages/cli/src/generated/cli-version.ts",
@@ -88,6 +102,8 @@
     "packages/workspace-ui/package.json"
   ],
   "packageFiles": [
+    "packages/ai-catalog/package.json",
+    "packages/anonymize-chat/package.json",
     "packages/cli/package.json",
     "packages/auth-model/package.json",
     "packages/business-registries/package.json",

--- a/scripts/check-api-cli-contract.test.ts
+++ b/scripts/check-api-cli-contract.test.ts
@@ -20,6 +20,8 @@ import { loadChangesetPolicy } from "./changeset-guard";
 
 const SHARED_NPM_PACKAGES = [
   "auth-model",
+  "ai-catalog",
+  "anonymize-chat",
   "business-registries",
   "calculations",
   "country-codes",


### PR DESCRIPTION
## Summary

- publish the provider-neutral model catalogue and reversible chat anonymization pipeline as supported packages
- add bounded exact sensitive values to the native placeholder allocation and apply it to provider-bound internal identifiers
- wire both packages into Changesets, tarball validation, bootstrap publishing, and trusted-publishing release gates

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `@stll/ai-catalog` model catalogue package for provider-neutral model information and validation.
  * Added the `@stll/anonymize-chat` package with reversible chat anonymisation and support for caller-supplied sensitive values.
  * Improved placeholder preservation and collision handling during anonymisation.
  * Added safer redaction behaviour for exact values, exclusions and invalid cases.

* **Documentation**
  * Added installation, usage, capabilities and licensing guidance for both packages.

* **Tests**
  * Expanded coverage for redaction, placeholder handling and release validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->