### PR TITLE
fix(api): gate public decision handlers on the subject by construction

### DIFF
--- a/apps/api/scripts/lib/enumerate-safe-handlers.ts
+++ b/apps/api/scripts/lib/enumerate-safe-handlers.ts
@@ -37,7 +37,7 @@ export const HANDLERS_GLOB = "apps/api/src/handlers/**/*.ts";
  * instantiation, so an `import { createSafeHandler }` line is never counted.
  */
 export const SAFE_HANDLER_CALL_PATTERN =
-  /createSafe(?:Root|Session|Token|Public)?Handler[<(]/gu;
+  /createSafe(?:Root|Session|Token|Public|PublicSubject|PublicSubjectFollowUp)?Handler[<(]/gu;
 
 /**
  * The handler-scope kinds, keyed by the factory that produces them. Detection
@@ -58,6 +58,10 @@ const FACTORY_KIND_PATTERNS: { kind: HandlerKind; pattern: RegExp }[] = [
   { kind: "session", pattern: /createSafeSessionHandler[<(]/u },
   { kind: "token", pattern: /createSafeTokenHandler[<(]/u },
   { kind: "public", pattern: /createSafePublicHandler[<(]/u },
+  // The subject-gated public factories (case-law decisions) wrap the public
+  // one; the follow-up variant runs a phase after the gated transaction.
+  { kind: "public", pattern: /createSafePublicSubjectFollowUpHandler[<(]/u },
+  { kind: "public", pattern: /createSafePublicSubjectHandler[<(]/u },
   // Must run last: `createSafeHandler` is a substring of none of the above once
   // the specific factories are matched, but keep it terminal for clarity.
   { kind: "workspace", pattern: /createSafeHandler[<(]/u },

--- a/apps/api/scripts/mcp-coverage-guard.ts
+++ b/apps/api/scripts/mcp-coverage-guard.ts
@@ -81,6 +81,11 @@ type ExposureType = (typeof EXPOSURE_TYPES)[number];
  * only enumeration into the ratchet is waived.
  */
 const INLINE_ENDPOINT_ALLOWLIST: Record<string, number> = {
+  // The subject-gate wrapper: its one `createSafePublicHandler` call builds
+  // the gated definition returned to callers, so it is a factory, not an
+  // endpoint. Endpoints made with it count under `createSafePublicSubjectHandler`
+  // in their own files.
+  "apps/api/src/handlers/case-law/decisions/public-subject.ts": 1,
   "apps/api/src/handlers/case-law/public-routes.ts": 9,
   "apps/api/src/handlers/files/routes.ts": 4,
   "apps/api/src/handlers/legislation/public-routes.ts": 5,

--- a/apps/api/src/handlers/case-law/decisions/citation-graph.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/citation-graph.db.test.ts
@@ -1,3 +1,4 @@
+import { panic } from "better-result";
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { drizzle } from "drizzle-orm/pglite";
 
@@ -18,6 +19,7 @@ import type {
   CitationDirection,
   DecisionCitationRow,
 } from "@/api/handlers/case-law/decisions/citation-graph";
+import { withRedistributableSubject } from "@/api/handlers/case-law/decisions/public-subject";
 import { POLARITIES, POLARITY } from "@/api/handlers/case-law/polarity/consts";
 import { createSafeId, toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -196,16 +198,23 @@ afterAll(async () => {
   await client.close();
 });
 
+const subjectFor = async (id: SafeId<"caseLawDecision">) =>
+  (await withRedistributableSubject(
+    caseLawDb,
+    { kind: "id", id },
+    async (subject) => subject,
+  )) ?? panic("expected a redistributable subject");
+
 const collect = async (direction: CitationDirection) => {
   const items: DecisionCitationRow[] = [];
+  const subject = await subjectFor(subjectId);
   let cursor: string | undefined;
   let pages = 0;
 
   for (let request = 0; request < 4; request += 1) {
     // oxlint-disable-next-line no-await-in-loop -- cursor pages are sequential
     const page = await listDecisionCitationsHandler({
-      caseLawDb,
-      decisionId: subjectId,
+      subject,
       query: { direction, ...(cursor === undefined ? {} : { cursor }) },
     });
     if (!("items" in page)) {
@@ -275,8 +284,7 @@ test("incoming pages carry treatment and the citing decision, and the rollup mat
     counted.set(item.treatment, (counted.get(item.treatment) ?? 0) + 1);
   }
   const summary = await summaryOf({
-    caseLawDb,
-    decisionId: subjectId,
+    subject: await subjectFor(subjectId),
   });
   expect(Object.fromEntries(counted)).toEqual(
     Object.fromEntries(
@@ -301,8 +309,7 @@ test("outgoing keeps unresolved text, drops restricted and procedural rows", asy
   expect(outgoing.items.at(1)?.treatment).toBe("unclassified");
 
   const summary = await summaryOf({
-    caseLawDb,
-    decisionId: subjectId,
+    subject: await subjectFor(subjectId),
   });
   expect(summary.outgoing).toEqual({
     negative: 0,
@@ -315,8 +322,7 @@ test("outgoing keeps unresolved text, drops restricted and procedural rows", asy
 
 test("citation pages reject malformed cursors", async () => {
   const page = await listDecisionCitationsHandler({
-    caseLawDb,
-    decisionId: subjectId,
+    subject: await subjectFor(subjectId),
     query: { cursor: "not-a-cursor", direction: "incoming" },
   });
 
@@ -325,41 +331,42 @@ test("citation pages reject malformed cursors", async () => {
 
 test("incoming citations roll up by the citing decision's year within the bounded span", async () => {
   const summary = await summaryOf({
-    caseLawDb,
     currentYear: 2026,
-    decisionId: subjectId,
+    subject: await subjectFor(subjectId),
   });
   // Every visible citing row comes from one decision dated 2020.
   expect(summary.incomingByYear).toEqual([{ ...summary.incoming, year: 2020 }]);
 
   const beyondSpan = await summaryOf({
-    caseLawDb,
     currentYear: 2020 + CITATION_TIMELINE_MAX_YEARS,
-    decisionId: subjectId,
+    subject: await subjectFor(subjectId),
   });
   expect(beyondSpan.incoming).toEqual(summary.incoming);
   expect(beyondSpan.incomingByYear).toEqual([]);
 });
 
-test("a restricted subject decision has no citation reads, in either direction or summary", async () => {
+test("a restricted subject decision cannot be resolved as a subject", async () => {
   // The closed decision cites the subject, so it has an outgoing edge that
-  // would otherwise be served; the gate must answer before the edge walk.
-  const outgoing = await listDecisionCitationsHandler({
-    caseLawDb,
-    decisionId: closedRelatedId,
-    query: { direction: "outgoing" },
-  });
-  const incoming = await listDecisionCitationsHandler({
-    caseLawDb,
-    decisionId: closedRelatedId,
-    query: { direction: "incoming" },
-  });
-  const summary = await summarizeDecisionCitationsHandler({
-    caseLawDb,
-    decisionId: closedRelatedId,
-  });
-
-  expect("items" in outgoing).toBe(false);
-  expect("items" in incoming).toBe(false);
-  expect("incoming" in summary).toBe(false);
+  // would otherwise be served. The gate answers before any handler runs:
+  // without a subject there is no call to make, in either direction.
+  expect(
+    await withRedistributableSubject(
+      caseLawDb,
+      {
+        kind: "id",
+        id: closedRelatedId,
+      },
+      async (subject) => subject,
+    ),
+  ).toBeNull();
+  expect(
+    await withRedistributableSubject(
+      caseLawDb,
+      {
+        kind: "id",
+        id: subjectId,
+      },
+      async (subject) => subject,
+    ),
+  ).not.toBeNull();
 });

--- a/apps/api/src/handlers/case-law/decisions/citation-graph.ts
+++ b/apps/api/src/handlers/case-law/decisions/citation-graph.ts
@@ -12,12 +12,11 @@ import {
   caseLawSources,
 } from "@/api/db/schema";
 import { CITATION_KIND } from "@/api/handlers/case-law/citation-kind";
+import type { RedistributableDecisionSubject } from "@/api/handlers/case-law/decisions/public-subject";
 import { POLARITIES, POLARITY } from "@/api/handlers/case-law/polarity/consts";
 import type { SafeId } from "@/api/lib/branded-types";
-import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 import { redistributableCaseLawSourceFor } from "@/api/lib/case-law/redistribution";
 import { tPaginationCursor } from "@/api/lib/custom-schema";
-import { isRedistributable } from "@/api/lib/legal-search/corpus-source";
 import { LIMITS } from "@/api/lib/limits";
 import {
   decodePaginationCursor,
@@ -215,103 +214,71 @@ const visibleFor = ({
  */
 const precedentOnly = eq(caseLawCitations.kind, CITATION_KIND.PRECEDENT);
 
-/**
- * Whether the subject decision may be shown at all. The far-end gate in
- * `visibleFor` protects the other side of every edge; this protects the
- * decision the request names, whose outgoing citation texts and graph
- * counts are as much its content as its full text is. Same answer as the
- * decision read: a restricted subject does not exist.
- */
-const subjectIsRedistributable = async (
-  caseLawDb: CaseLawPublicReadDb,
-  decisionId: SafeId<"caseLawDecision">,
-): Promise<boolean> => {
-  const subject = await caseLawDb((tx) =>
-    tx
-      .select({ descriptor: caseLawSources.descriptor })
-      .from(caseLawDecisions)
-      .innerJoin(
-        caseLawSources,
-        eq(caseLawSources.id, caseLawDecisions.sourceId),
-      )
-      .where(eq(caseLawDecisions.id, decisionId))
-      .limit(1),
-  );
-  const row = subject.at(0);
-  return row !== undefined && isRedistributable(row.descriptor);
-};
-
 type ListDecisionCitationsOptions = {
-  caseLawDb: CaseLawPublicReadDb;
-  decisionId: SafeId<"caseLawDecision">;
+  /**
+   * Gated upstream, and the only database handle this read gets: its rows
+   * come from the transaction that approved it.
+   */
+  subject: RedistributableDecisionSubject;
   query: ListDecisionCitationsQuery;
 };
 
 export const listDecisionCitationsHandler = async ({
-  caseLawDb,
-  decisionId,
+  subject: { id: decisionId, tx },
   query,
 }: ListDecisionCitationsOptions) => {
   const cursorId = decodeCitationCursor(query.cursor);
   if (cursorId === null) {
     return status(400, { message: "Invalid cursor" });
   }
-  if (!(await subjectIsRedistributable(caseLawDb, decisionId))) {
-    return status(404, { message: "Decision not found" });
-  }
   const spec = DIRECTION_SPECS[query.direction];
 
-  const rows = await caseLawDb((tx) => {
-    const candidates = tx
-      .select({
-        id: caseLawCitations.id,
-        citationText: caseLawCitations.citationText,
-        relatedId: spec.related,
-        sectionIndex: caseLawCitations.sectionIndex,
-        polarity: caseLawCitations.polarity,
-      })
-      .from(caseLawCitations)
-      .where(
-        and(
-          eq(spec.anchor, decisionId),
-          precedentOnly,
-          cursorId === undefined
-            ? undefined
-            : gt(caseLawCitations.id, cursorId),
-        ),
-      )
-      .orderBy(asc(caseLawCitations.id))
-      .limit(LIMITS.caseLawDecisionCitationPageSize + 1)
-      .as("citation_graph_candidates");
-
-    return tx
-      .select({
-        id: candidates.id,
-        citationText: candidates.citationText,
-        sectionIndex: candidates.sectionIndex,
-        polarity: candidates.polarity,
-        visible: visibleFor({
-          keepsUnresolved: spec.keepsUnresolved,
-          related: candidates.relatedId,
-        }),
-        decision: {
-          id: relatedDecision.id,
-          caseNumber: relatedDecision.caseNumber,
-          country: relatedDecision.country,
-          court: relatedDecision.court,
-          decisionDate: relatedDecision.decisionDate,
-          decisionType: relatedDecision.decisionType,
-          ecli: relatedDecision.ecli,
-          language: relatedDecision.language,
-          slug: relatedDecision.slug,
-        },
-      })
-      .from(candidates)
-      .leftJoin(relatedDecision, eq(relatedDecision.id, candidates.relatedId))
-      .leftJoin(relatedSource, eq(relatedSource.id, relatedDecision.sourceId))
-      .orderBy(asc(candidates.id))
-      .limit(LIMITS.caseLawDecisionCitationPageSize + 1);
-  });
+  const candidates = tx
+    .select({
+      id: caseLawCitations.id,
+      citationText: caseLawCitations.citationText,
+      relatedId: spec.related,
+      sectionIndex: caseLawCitations.sectionIndex,
+      polarity: caseLawCitations.polarity,
+    })
+    .from(caseLawCitations)
+    .where(
+      and(
+        eq(spec.anchor, decisionId),
+        precedentOnly,
+        cursorId === undefined ? undefined : gt(caseLawCitations.id, cursorId),
+      ),
+    )
+    .orderBy(asc(caseLawCitations.id))
+    .limit(LIMITS.caseLawDecisionCitationPageSize + 1)
+    .as("citation_graph_candidates");
+  const rows = await tx
+    .select({
+      id: candidates.id,
+      citationText: candidates.citationText,
+      sectionIndex: candidates.sectionIndex,
+      polarity: candidates.polarity,
+      visible: visibleFor({
+        keepsUnresolved: spec.keepsUnresolved,
+        related: candidates.relatedId,
+      }),
+      decision: {
+        id: relatedDecision.id,
+        caseNumber: relatedDecision.caseNumber,
+        country: relatedDecision.country,
+        court: relatedDecision.court,
+        decisionDate: relatedDecision.decisionDate,
+        decisionType: relatedDecision.decisionType,
+        ecli: relatedDecision.ecli,
+        language: relatedDecision.language,
+        slug: relatedDecision.slug,
+      },
+    })
+    .from(candidates)
+    .leftJoin(relatedDecision, eq(relatedDecision.id, candidates.relatedId))
+    .leftJoin(relatedSource, eq(relatedSource.id, relatedDecision.sourceId))
+    .orderBy(asc(candidates.id))
+    .limit(LIMITS.caseLawDecisionCitationPageSize + 1);
 
   return createScannedPage(rows);
 };
@@ -344,8 +311,11 @@ const emptyTreatmentCounts = (): CitationTreatmentCounts => ({
 });
 
 type SummarizeDecisionCitationsOptions = {
-  caseLawDb: CaseLawPublicReadDb;
-  decisionId: SafeId<"caseLawDecision">;
+  /**
+   * Gated upstream, and the only database handle this read gets: its rows
+   * come from the transaction that approved it.
+   */
+  subject: RedistributableDecisionSubject;
   /** The year the timeline ends; injectable so a test can pin it. */
   currentYear?: number;
 };
@@ -375,13 +345,9 @@ type SummaryRow = {
  * totals and its years; never a walk over pages.
  */
 export const summarizeDecisionCitationsHandler = async ({
-  caseLawDb,
-  decisionId,
+  subject: { id: decisionId, tx },
   currentYear = new Date().getUTCFullYear(),
 }: SummarizeDecisionCitationsOptions) => {
-  if (!(await subjectIsRedistributable(caseLawDb, decisionId))) {
-    return status(404, { message: "Decision not found" });
-  }
   const scopeFor = (direction: CitationDirection) => {
     const spec = DIRECTION_SPECS[direction];
     return and(
@@ -402,47 +368,45 @@ export const summarizeDecisionCitationsHandler = async ({
   END`;
   const count = sql<number>`count(*)::int`;
 
-  const rows = await caseLawDb((tx) => {
-    const incoming = tx
-      .select({
-        direction: sql<CitationDirection>`'incoming'`.as("direction"),
-        year: citingYearInSpan.as("year"),
-        polarity: caseLawCitations.polarity,
-        count: count.as("count"),
-      })
-      .from(caseLawCitations)
-      .innerJoin(
-        relatedDecision,
-        eq(relatedDecision.id, DIRECTION_SPECS.incoming.related),
-      )
-      .leftJoin(relatedSource, eq(relatedSource.id, relatedDecision.sourceId))
-      .where(scopeFor("incoming"))
-      // By ordinal: the year expression binds its bounds as parameters, and
-      // a second rendering would bind fresh ones the planner cannot match.
-      .groupBy(sql`2`, caseLawCitations.polarity);
+  const incoming = tx
+    .select({
+      direction: sql<CitationDirection>`'incoming'`.as("direction"),
+      year: citingYearInSpan.as("year"),
+      polarity: caseLawCitations.polarity,
+      count: count.as("count"),
+    })
+    .from(caseLawCitations)
+    .innerJoin(
+      relatedDecision,
+      eq(relatedDecision.id, DIRECTION_SPECS.incoming.related),
+    )
+    .leftJoin(relatedSource, eq(relatedSource.id, relatedDecision.sourceId))
+    .where(scopeFor("incoming"))
+    // By ordinal: the year expression binds its bounds as parameters, and
+    // a second rendering would bind fresh ones the planner cannot match.
+    .groupBy(sql`2`, caseLawCitations.polarity);
 
-    const outgoing = tx
-      .select({
-        direction: sql<CitationDirection>`'outgoing'`.as("direction"),
-        year: sql<number | null>`NULL::int`.as("year"),
-        polarity: caseLawCitations.polarity,
-        count: count.as("count"),
-      })
-      .from(caseLawCitations)
-      .leftJoin(
-        relatedDecision,
-        eq(relatedDecision.id, DIRECTION_SPECS.outgoing.related),
-      )
-      .leftJoin(relatedSource, eq(relatedSource.id, relatedDecision.sourceId))
-      .where(scopeFor("outgoing"))
-      .groupBy(caseLawCitations.polarity);
+  const outgoing = tx
+    .select({
+      direction: sql<CitationDirection>`'outgoing'`.as("direction"),
+      year: sql<number | null>`NULL::int`.as("year"),
+      polarity: caseLawCitations.polarity,
+      count: count.as("count"),
+    })
+    .from(caseLawCitations)
+    .leftJoin(
+      relatedDecision,
+      eq(relatedDecision.id, DIRECTION_SPECS.outgoing.related),
+    )
+    .leftJoin(relatedSource, eq(relatedSource.id, relatedDecision.sourceId))
+    .where(scopeFor("outgoing"))
+    .groupBy(caseLawCitations.polarity);
 
-    // One row per (direction, year-or-null, stored polarity): the span and
-    // the polarity check constraint already cap it, this states the cap.
-    return unionAll(incoming, outgoing).limit(
-      (CITATION_TIMELINE_MAX_YEARS + 2) * (POLARITIES.length + 1),
-    );
-  });
+  // One row per (direction, year-or-null, stored polarity): the span and
+  // the polarity check constraint already cap it, this states the cap.
+  const rows = await unionAll(incoming, outgoing).limit(
+    (CITATION_TIMELINE_MAX_YEARS + 2) * (POLARITIES.length + 1),
+  );
 
   const totals: Record<CitationDirection, CitationTreatmentCounts> = {
     incoming: emptyTreatmentCounts(),

--- a/apps/api/src/handlers/case-law/decisions/citations.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/citations.db.test.ts
@@ -12,10 +12,7 @@ import {
 } from "@/api/handlers/case-law/decisions/citations";
 import { createSafeId, toSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
-import type {
-  CaseLawPublicReadDb,
-  CaseLawPublicReadTransaction,
-} from "@/api/lib/case-law-public-read-db";
+import type { CaseLawPublicReadTransaction } from "@/api/lib/case-law-public-read-db";
 import { caseLawSourceRow } from "@/api/tests/helpers/case-law-source-row";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
@@ -32,7 +29,13 @@ const citationId = (value: number): SafeId<"caseLawCitation"> =>
 
 let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
-let caseLawDb: CaseLawPublicReadDb;
+/**
+ * The low-level readers take the transaction their caller gated in; here the
+ * embedded database stands in for it directly.
+ */
+// SAFETY: pglite's drizzle instance satisfies the select-only read surface.
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- embedded test database stands in for the read handle
+const tx = () => db as unknown as CaseLawPublicReadTransaction;
 
 const decisionRow = ({
   caseNumber,
@@ -55,16 +58,6 @@ beforeAll(
   async () => {
     client = await createTestPglite();
     db = drizzle({ client });
-    const readDb = async <T>(
-      fn: (tx: CaseLawPublicReadTransaction) => Promise<T>,
-    ) =>
-      // SAFETY: pglite's drizzle instance satisfies the select-only read surface.
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- embedded test database stands in for the read handle
-      await fn(db as unknown as CaseLawPublicReadTransaction);
-    // SAFETY: brand-only wrapper; the reads never inspect the marker.
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the branded handle carries no behaviour
-    caseLawDb = readDb as unknown as CaseLawPublicReadDb;
-
     await db.insert(caseLawSources).values([
       caseLawSourceRow({ adapterKey: "open", id: openSourceId, name: "open" }),
       caseLawSourceRow({
@@ -165,12 +158,12 @@ const collect = async (
 
 test("citation reads traverse bounded pages without leaking restricted decisions", async () => {
   const firstOutgoing = await listOutgoingDecisionCitations({
-    caseLawDb,
+    tx: tx(),
     cursor: undefined,
     decisionId: subjectId,
   });
   const firstIncoming = await listIncomingDecisionCitations({
-    caseLawDb,
+    tx: tx(),
     cursor: undefined,
     decisionId: subjectId,
   });
@@ -184,7 +177,7 @@ test("citation reads traverse bounded pages without leaking restricted decisions
 
   const outgoing = await collect(async (cursor) => {
     const page = await listOutgoingDecisionCitations({
-      caseLawDb,
+      tx: tx(),
       cursor,
       decisionId: subjectId,
     });
@@ -196,7 +189,7 @@ test("citation reads traverse bounded pages without leaking restricted decisions
   });
   const incoming = await collect(async (cursor) => {
     const page = await listIncomingDecisionCitations({
-      caseLawDb,
+      tx: tx(),
       cursor,
       decisionId: subjectId,
     });
@@ -224,7 +217,7 @@ test("citation reads traverse bounded pages without leaking restricted decisions
 
 test("citation reads reject malformed cursors", async () => {
   const page = await listOutgoingDecisionCitations({
-    caseLawDb,
+    tx: tx(),
     cursor: "not-a-cursor",
     decisionId: subjectId,
   });

--- a/apps/api/src/handlers/case-law/decisions/citations.ts
+++ b/apps/api/src/handlers/case-law/decisions/citations.ts
@@ -8,7 +8,7 @@ import {
   caseLawSources,
 } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
-import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
+import type { CaseLawPublicReadTransaction } from "@/api/lib/case-law-public-read-db";
 import { redistributableCaseLawSourceFor } from "@/api/lib/case-law/redistribution";
 import { LIMITS } from "@/api/lib/limits";
 import {
@@ -41,7 +41,7 @@ const decodeCitationCursor = (
 };
 
 type CitationPageOptions = {
-  caseLawDb: CaseLawPublicReadDb;
+  tx: CaseLawPublicReadTransaction;
   cursor: string | undefined;
   decisionId: SafeId<"caseLawDecision">;
 };
@@ -76,7 +76,7 @@ const createScannedCitationPage = <T>(
 };
 
 export const listOutgoingDecisionCitations = async ({
-  caseLawDb,
+  tx,
   cursor,
   decisionId,
 }: CitationPageOptions) => {
@@ -85,56 +85,51 @@ export const listOutgoingDecisionCitations = async ({
     return status(400, { message: "Invalid cursor" });
   }
 
-  const rows = await caseLawDb((tx) => {
-    const candidates = tx
-      .select({
-        id: caseLawCitations.id,
-        citationText: caseLawCitations.citationText,
-        citedDecisionId: caseLawCitations.citedDecisionId,
-        sectionIndex: caseLawCitations.sectionIndex,
-      })
-      .from(caseLawCitations)
-      .where(
-        and(
-          eq(caseLawCitations.citingDecisionId, decisionId),
-          cursorId === undefined
-            ? undefined
-            : gt(caseLawCitations.id, cursorId),
-        ),
-      )
-      .orderBy(asc(caseLawCitations.id))
-      .limit(LIMITS.caseLawDecisionCitationPageSize + 1)
-      .as("outgoing_citation_candidates");
-
-    return tx
-      .select({
-        item: {
-          id: candidates.id,
-          citationText: candidates.citationText,
-          citedDecisionId: candidates.citedDecisionId,
-          sectionIndex: candidates.sectionIndex,
-        },
-        scanId: candidates.id,
-        visible: sql<boolean>`(
-            ${candidates.citedDecisionId} IS NULL
-          OR (
-            ${citedSource.id} IS NOT NULL
-            AND ${redistributableCaseLawSourceFor(citedSource.descriptor)}
-          )
-        )`,
-      })
-      .from(candidates)
-      .leftJoin(citedDecision, eq(citedDecision.id, candidates.citedDecisionId))
-      .leftJoin(citedSource, eq(citedSource.id, citedDecision.sourceId))
-      .orderBy(asc(candidates.id))
-      .limit(LIMITS.caseLawDecisionCitationPageSize + 1);
-  });
+  const candidates = tx
+    .select({
+      id: caseLawCitations.id,
+      citationText: caseLawCitations.citationText,
+      citedDecisionId: caseLawCitations.citedDecisionId,
+      sectionIndex: caseLawCitations.sectionIndex,
+    })
+    .from(caseLawCitations)
+    .where(
+      and(
+        eq(caseLawCitations.citingDecisionId, decisionId),
+        cursorId === undefined ? undefined : gt(caseLawCitations.id, cursorId),
+      ),
+    )
+    .orderBy(asc(caseLawCitations.id))
+    .limit(LIMITS.caseLawDecisionCitationPageSize + 1)
+    .as("outgoing_citation_candidates");
+  const rows = await tx
+    .select({
+      item: {
+        id: candidates.id,
+        citationText: candidates.citationText,
+        citedDecisionId: candidates.citedDecisionId,
+        sectionIndex: candidates.sectionIndex,
+      },
+      scanId: candidates.id,
+      visible: sql<boolean>`(
+          ${candidates.citedDecisionId} IS NULL
+        OR (
+          ${citedSource.id} IS NOT NULL
+          AND ${redistributableCaseLawSourceFor(citedSource.descriptor)}
+        )
+      )`,
+    })
+    .from(candidates)
+    .leftJoin(citedDecision, eq(citedDecision.id, candidates.citedDecisionId))
+    .leftJoin(citedSource, eq(citedSource.id, citedDecision.sourceId))
+    .orderBy(asc(candidates.id))
+    .limit(LIMITS.caseLawDecisionCitationPageSize + 1);
 
   return createScannedCitationPage(rows);
 };
 
 export const listIncomingDecisionCitations = async ({
-  caseLawDb,
+  tx,
   cursor,
   decisionId,
 }: CitationPageOptions) => {
@@ -143,50 +138,45 @@ export const listIncomingDecisionCitations = async ({
     return status(400, { message: "Invalid cursor" });
   }
 
-  const rows = await caseLawDb((tx) => {
-    const candidates = tx
-      .select({
-        id: caseLawCitations.id,
-        citationText: caseLawCitations.citationText,
-        citingDecisionId: caseLawCitations.citingDecisionId,
-        sectionIndex: caseLawCitations.sectionIndex,
-      })
-      .from(caseLawCitations)
-      .where(
-        and(
-          eq(caseLawCitations.citedDecisionId, decisionId),
-          cursorId === undefined
-            ? undefined
-            : gt(caseLawCitations.id, cursorId),
-        ),
-      )
-      .orderBy(asc(caseLawCitations.id))
-      .limit(LIMITS.caseLawDecisionCitationPageSize + 1)
-      .as("incoming_citation_candidates");
-
-    return tx
-      .select({
-        item: {
-          id: candidates.id,
-          citationText: candidates.citationText,
-          citingDecisionId: candidates.citingDecisionId,
-          sectionIndex: candidates.sectionIndex,
-        },
-        scanId: candidates.id,
-        visible: sql<boolean>`(
-          ${citingSource.id} IS NOT NULL
-          AND ${redistributableCaseLawSourceFor(citingSource.descriptor)}
-        )`,
-      })
-      .from(candidates)
-      .leftJoin(
-        citingDecision,
-        eq(citingDecision.id, candidates.citingDecisionId),
-      )
-      .leftJoin(citingSource, eq(citingSource.id, citingDecision.sourceId))
-      .orderBy(asc(candidates.id))
-      .limit(LIMITS.caseLawDecisionCitationPageSize + 1);
-  });
+  const candidates = tx
+    .select({
+      id: caseLawCitations.id,
+      citationText: caseLawCitations.citationText,
+      citingDecisionId: caseLawCitations.citingDecisionId,
+      sectionIndex: caseLawCitations.sectionIndex,
+    })
+    .from(caseLawCitations)
+    .where(
+      and(
+        eq(caseLawCitations.citedDecisionId, decisionId),
+        cursorId === undefined ? undefined : gt(caseLawCitations.id, cursorId),
+      ),
+    )
+    .orderBy(asc(caseLawCitations.id))
+    .limit(LIMITS.caseLawDecisionCitationPageSize + 1)
+    .as("incoming_citation_candidates");
+  const rows = await tx
+    .select({
+      item: {
+        id: candidates.id,
+        citationText: candidates.citationText,
+        citingDecisionId: candidates.citingDecisionId,
+        sectionIndex: candidates.sectionIndex,
+      },
+      scanId: candidates.id,
+      visible: sql<boolean>`(
+        ${citingSource.id} IS NOT NULL
+        AND ${redistributableCaseLawSourceFor(citingSource.descriptor)}
+      )`,
+    })
+    .from(candidates)
+    .leftJoin(
+      citingDecision,
+      eq(citingDecision.id, candidates.citingDecisionId),
+    )
+    .leftJoin(citingSource, eq(citingSource.id, citingDecision.sourceId))
+    .orderBy(asc(candidates.id))
+    .limit(LIMITS.caseLawDecisionCitationPageSize + 1);
 
   return createScannedCitationPage(rows);
 };

--- a/apps/api/src/handlers/case-law/decisions/get-deferred-document.ts
+++ b/apps/api/src/handlers/case-law/decisions/get-deferred-document.ts
@@ -17,11 +17,9 @@ import {
   readThroughDeferredDocument,
 } from "@/api/handlers/case-law/decisions/document-on-demand";
 import { onDemandDocumentDeps } from "@/api/handlers/case-law/decisions/document-on-demand-deps";
-import {
-  readDecisionBySlugHandler,
-  readDecisionHandler,
-} from "@/api/handlers/case-law/decisions/get";
-import type { SafeId } from "@/api/lib/branded-types";
+import { readDecisionHandler } from "@/api/handlers/case-law/decisions/get";
+import type { DecisionSubjectLocator } from "@/api/handlers/case-law/decisions/public-subject";
+import { withRedistributableSubject } from "@/api/handlers/case-law/decisions/public-subject";
 import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 
 type DecisionRead = Awaited<ReturnType<typeof readDecisionHandler>>;
@@ -82,7 +80,12 @@ const hydrate = async (
   };
 };
 
-const withDeferredDocument = async (
+/**
+ * The read's second phase: fetch the document when a reader arrives before
+ * the ingestion queue does. A publisher fetch and an ingestion write, so it
+ * runs after the gated read transaction has closed, never inside it.
+ */
+export const hydrateDeferredDocument = async (
   read: DecisionRead,
   recordDemand: boolean,
 ): Promise<DecisionRead> =>
@@ -95,49 +98,37 @@ const withDeferredDocument = async (
  */
 export type DecisionReadCaller = "anonymous" | "attributed";
 
-export type ReadDecisionWithDocumentOptions = {
-  decisionId: SafeId<"caseLawDecision">;
+export type ReadGatedDecisionOptions = {
   caseLawDb: CaseLawPublicReadDb;
+  locator: DecisionSubjectLocator;
   caller: DecisionReadCaller;
   citationsCursor?: string | null | undefined;
 };
 
-export type ReadDecisionBySlugWithDocumentOptions = {
-  slug: string;
-  caseLawDb: CaseLawPublicReadDb;
-  caller: DecisionReadCaller;
-  citationsCursor?: string | null | undefined;
-  language: string | undefined;
+/**
+ * Gate, read, then hydrate — in that order and for that reason.
+ *
+ * The gate and every row of the read share one transaction, so the content
+ * cannot come from a state the gate did not approve. Hydration is a
+ * publisher fetch and an ingestion write, which must not hold a read-only
+ * transaction open, so it runs once that transaction has closed.
+ *
+ * Null is "no such decision for the public": it does not exist, or its
+ * source may not be redistributed.
+ */
+export const readGatedDecisionWithDocument = async ({
+  caseLawDb,
+  locator,
+  caller,
+  citationsCursor,
+}: ReadGatedDecisionOptions): Promise<DecisionRead | null> => {
+  const read = await withRedistributableSubject(
+    caseLawDb,
+    locator,
+    async (subject) => await readDecisionHandler({ citationsCursor, subject }),
+  );
+
+  return read === null
+    ? null
+    : await hydrateDeferredDocument(read, caller === "attributed");
 };
-
-export const readDecisionWithDocumentHandler = async ({
-  decisionId,
-  caseLawDb,
-  caller,
-  citationsCursor,
-}: ReadDecisionWithDocumentOptions): Promise<DecisionRead> =>
-  await withDeferredDocument(
-    await readDecisionHandler({
-      caseLawDb,
-      citationsCursor,
-      decisionId,
-    }),
-    caller === "attributed",
-  );
-
-export const readDecisionBySlugWithDocumentHandler = async ({
-  slug,
-  caseLawDb,
-  caller,
-  citationsCursor,
-  language,
-}: ReadDecisionBySlugWithDocumentOptions): Promise<DecisionRead> =>
-  await withDeferredDocument(
-    await readDecisionBySlugHandler({
-      caseLawDb,
-      citationsCursor,
-      language,
-      slug,
-    }),
-    caller === "attributed",
-  );

--- a/apps/api/src/handlers/case-law/decisions/get-document-state.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/get-document-state.db.test.ts
@@ -1,3 +1,4 @@
+import { panic } from "better-result";
 /**
  * The read reports whether a decision's document is still to come or is
  * not coming, and only the first may be fetched for the reader. The
@@ -8,7 +9,6 @@
  *
  * Runs in the nightly Postgres job; skipped elsewhere.
  */
-
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sql";
@@ -17,6 +17,7 @@ import { authRelationsPart } from "@/api/db/auth-schema";
 import { caseLawDecisions, caseLawSources, relations } from "@/api/db/schema";
 import { ADAPTER_KEYS } from "@/api/handlers/case-law/consts";
 import { readDecisionHandler } from "@/api/handlers/case-law/decisions/get";
+import { withRedistributableSubject } from "@/api/handlers/case-law/decisions/public-subject";
 import type { SafeId } from "@/api/lib/branded-types";
 import { caseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 
@@ -60,10 +61,16 @@ if (!databaseUrl || !runPostgresTests) {
     };
 
     const readState = async (id: SafeId<"caseLawDecision">) => {
-      const decision = await readDecisionHandler({
-        caseLawDb: caseLawPublicReadDb,
-        decisionId: id,
-      });
+      const subject =
+        (await withRedistributableSubject(
+          caseLawPublicReadDb,
+          {
+            kind: "id",
+            id,
+          },
+          async (gated) => gated,
+        )) ?? panic("expected a redistributable subject");
+      const decision = await readDecisionHandler({ subject });
       if (!("documentPending" in decision)) {
         throw new Error("expected a readable decision");
       }

--- a/apps/api/src/handlers/case-law/decisions/get.ts
+++ b/apps/api/src/handlers/case-law/decisions/get.ts
@@ -10,18 +10,20 @@ import {
   listIncomingDecisionCitations,
   listOutgoingDecisionCitations,
 } from "@/api/handlers/case-law/decisions/citations";
+import {
+  DECISION_NOT_FOUND,
+  normalizePublicDecisionLanguage,
+  type RedistributableDecisionSubject,
+} from "@/api/handlers/case-law/decisions/public-subject";
 import { hasUsableAst } from "@/api/handlers/case-law/document-ast";
 import { corpusCarriesDocument } from "@/api/handlers/case-law/stored-payload";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
-import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
+import type { CaseLawPublicReadTransaction } from "@/api/lib/case-law-public-read-db";
 import { redistributableCaseLawSource } from "@/api/lib/case-law/redistribution";
 import { tPaginationCursor } from "@/api/lib/custom-schema";
 import { CorpusPayloadUnavailableError } from "@/api/lib/errors/tagged-errors";
-import {
-  allowsDerivedAi,
-  isRedistributable,
-} from "@/api/lib/legal-search/corpus-source";
+import { allowsDerivedAi } from "@/api/lib/legal-search/corpus-source";
 import {
   readCorpusAst,
   readCorpusPayloadOrFallback,
@@ -46,19 +48,6 @@ type PublicDecisionLanguageAlternate = {
   updatedAt: Date;
 };
 
-const LANGUAGE_SEGMENT_REGEX = /^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$/u;
-
-const normalizePublicDecisionLanguage = (
-  language: string | undefined,
-): string | null => {
-  const normalized = language?.trim().toLowerCase().replace(/_/gu, "-");
-  if (!normalized) {
-    return null;
-  }
-
-  return LANGUAGE_SEGMENT_REGEX.test(normalized) ? normalized : null;
-};
-
 const dedupeAlternatesByLanguage = (
   alternates: readonly PublicDecisionLanguageAlternate[],
 ): PublicDecisionLanguageAlternate[] => {
@@ -81,46 +70,41 @@ const dedupeAlternatesByLanguage = (
 };
 
 const listPublicDecisionLanguageAlternates = async ({
-  caseLawDb,
+  tx,
   languageGroupKey,
 }: {
-  caseLawDb: CaseLawPublicReadDb;
+  tx: CaseLawPublicReadTransaction;
   languageGroupKey: string | null;
 }): Promise<PublicDecisionLanguageAlternate[]> => {
   if (languageGroupKey === null) {
     return [];
   }
 
-  const alternates = await caseLawDb((tx) =>
-    tx
-      .select({
-        id: caseLawDecisions.id,
-        caseNumber: caseLawDecisions.caseNumber,
-        slug: caseLawDecisions.slug,
-        country: caseLawDecisions.country,
-        court: caseLawDecisions.court,
-        decisionDate: caseLawDecisions.decisionDate,
-        language: caseLawDecisions.language,
-        updatedAt: caseLawDecisions.updatedAt,
-      })
-      .from(caseLawDecisions)
-      .innerJoin(
-        caseLawSources,
-        eq(caseLawSources.id, caseLawDecisions.sourceId),
-      )
-      .where(
-        and(
-          eq(caseLawDecisions.languageGroupKey, languageGroupKey),
-          redistributableCaseLawSource,
-        ),
-      )
-      .orderBy(asc(caseLawDecisions.language), asc(caseLawDecisions.id))
-      // Bound the per-group read: a languageGroupKey normally holds only this
-      // decision's language variants, but a malformed/over-merged key could
-      // match many rows and make this public read unbounded — the sitemap path
-      // caps the same read for the same reason. Capped variants still dedupe.
-      .limit(LIMITS.caseLawLanguageAlternatesPerGroupMax),
-  );
+  const alternates = await tx
+    .select({
+      id: caseLawDecisions.id,
+      caseNumber: caseLawDecisions.caseNumber,
+      slug: caseLawDecisions.slug,
+      country: caseLawDecisions.country,
+      court: caseLawDecisions.court,
+      decisionDate: caseLawDecisions.decisionDate,
+      language: caseLawDecisions.language,
+      updatedAt: caseLawDecisions.updatedAt,
+    })
+    .from(caseLawDecisions)
+    .innerJoin(caseLawSources, eq(caseLawSources.id, caseLawDecisions.sourceId))
+    .where(
+      and(
+        eq(caseLawDecisions.languageGroupKey, languageGroupKey),
+        redistributableCaseLawSource,
+      ),
+    )
+    .orderBy(asc(caseLawDecisions.language), asc(caseLawDecisions.id))
+    // Bound the per-group read: a languageGroupKey normally holds only this
+    // decision's language variants, but a malformed/over-merged key could
+    // match many rows and make this public read unbounded — the sitemap path
+    // caps the same read for the same reason. Capped variants still dedupe.
+    .limit(LIMITS.caseLawLanguageAlternatesPerGroupMax);
   const dedupedAlternates = dedupeAlternatesByLanguage(alternates);
 
   return dedupedAlternates.length > 1 ? dedupedAlternates : [];
@@ -133,9 +117,12 @@ export const readDecisionQuerySchema = t.Object({
 });
 
 type ReadDecisionOptions = {
-  caseLawDb: CaseLawPublicReadDb;
   citationsCursor?: string | null | undefined;
-  decisionId: SafeId<"caseLawDecision">;
+  /**
+   * Gated upstream, and the only database handle this read gets: its rows
+   * come from the transaction that approved it.
+   */
+  subject: RedistributableDecisionSubject;
 };
 
 const CITATION_STREAM_CURSOR_STATUS = {
@@ -260,81 +247,77 @@ const emptyCitationPage = () => ({
 });
 
 export const readDecisionHandler = async ({
-  caseLawDb,
   citationsCursor,
-  decisionId,
+  subject: { id: decisionId, tx },
 }: ReadDecisionOptions) => {
   const citationCursors = decodeDecisionCitationCursor(citationsCursor);
   if (citationCursors === null) {
     return status(400, { message: "Invalid cursor" });
   }
 
-  const decision = await caseLawDb((tx) =>
-    tx.query.caseLawDecisions.findFirst({
-      where: { id: { eq: decisionId } },
-      columns: {
-        id: true,
-        caseNumber: true,
-        slug: true,
-        ecli: true,
-        court: true,
-        country: true,
-        language: true,
-        languageGroupKey: true,
-        decisionDate: true,
-        decisionType: true,
-        documentAst: true,
-        sourceUrl: true,
-        documentUrl: true,
-        metadata: true,
-        createdAt: true,
-        updatedAt: true,
-        // Object-storage keys: never returned to the client, only used
-        // to fetch canonical payloads when corpus storage is enabled.
-        astS3Key: true,
-        textS3Key: true,
-        contentHash: true,
-        redactedAt: true,
-        // fulltext: only as fallback when no AST
-        // sections: frontend doesn't use these
+  const decision = await tx.query.caseLawDecisions.findFirst({
+    where: { id: { eq: decisionId } },
+    columns: {
+      id: true,
+      caseNumber: true,
+      slug: true,
+      ecli: true,
+      court: true,
+      country: true,
+      language: true,
+      languageGroupKey: true,
+      decisionDate: true,
+      decisionType: true,
+      documentAst: true,
+      sourceUrl: true,
+      documentUrl: true,
+      metadata: true,
+      createdAt: true,
+      updatedAt: true,
+      // Object-storage keys: never returned to the client, only used
+      // to fetch canonical payloads when corpus storage is enabled.
+      astS3Key: true,
+      textS3Key: true,
+      contentHash: true,
+      redactedAt: true,
+      // fulltext: only as fallback when no AST
+      // sections: frontend doesn't use these
+    },
+    with: {
+      source: {
+        // descriptor: only for `allowsDerivedAi` below, never returned to
+        // the client. Redistribution was decided when the subject was
+        // resolved.
+        columns: { id: true, name: true, adapterKey: true, descriptor: true },
       },
-      with: {
-        source: {
-          // descriptor: only for the redistribution gate below,
-          // never returned to the client.
-          columns: { id: true, name: true, adapterKey: true, descriptor: true },
-        },
-      },
-    }),
-  );
+    },
+  });
 
   if (!decision) {
-    return status(404, { message: "Decision not found" });
+    // The subject existed moments ago; a redaction can race the read.
+    return status(404, DECISION_NOT_FOUND);
   }
 
   const source =
     decision.source ?? panic("Case-law decision has no source relation");
-  if (!isRedistributable(source.descriptor)) {
-    return status(404, { message: "Decision not found" });
-  }
 
   const [languageAlternates, citationsFromPage, citationsToPage] =
     await Promise.all([
       listPublicDecisionLanguageAlternates({
-        caseLawDb,
+        tx,
         languageGroupKey: decision.languageGroupKey,
       }),
       citationCursors.from.status === CITATION_STREAM_CURSOR_STATUS.EXHAUSTED
         ? emptyCitationPage()
         : listOutgoingDecisionCitations({
-            caseLawDb,
+            tx,
             cursor: citationPageCursor(citationCursors.from),
             decisionId,
           }),
       citationCursors.to.status === CITATION_STREAM_CURSOR_STATUS.EXHAUSTED
         ? emptyCitationPage()
         : listIncomingDecisionCitations({
-            caseLawDb,
+            tx,
             cursor: citationPageCursor(citationCursors.to),
             decisionId,
           }),
@@ -370,7 +353,7 @@ export const readDecisionHandler = async ({
       textS3Key: decision.textS3Key,
       contentHash: decision.contentHash,
       decisionId,
-      caseLawDb,
+      tx,
     });
     fulltext = textRead.payload;
     corpusPayloadUnavailable = corpusPayloadUnavailable || textRead.unavailable;
@@ -398,15 +381,13 @@ export const readDecisionHandler = async ({
           pgAstPresent: decision.documentAst !== null,
           resolvedFulltext: fulltext,
           readTextColumnWritten: async () => {
-            const [row] = await caseLawDb((tx) =>
-              tx
-                .select({
-                  written: sql<boolean>`${caseLawDecisions.fulltext} IS NOT NULL`,
-                })
-                .from(caseLawDecisions)
-                .where(eq(caseLawDecisions.id, decisionId))
-                .limit(1),
-            );
+            const [row] = await tx
+              .select({
+                written: sql<boolean>`${caseLawDecisions.fulltext} IS NOT NULL`,
+              })
+              .from(caseLawDecisions)
+              .where(eq(caseLawDecisions.id, decisionId))
+              .limit(1);
             return row?.written ?? null;
           },
         })
@@ -450,51 +431,6 @@ export const readDecisionHandler = async ({
     languageAlternates,
     fulltext,
   };
-};
-
-type ReadDecisionBySlugOptions = {
-  caseLawDb: CaseLawPublicReadDb;
-  citationsCursor?: string | null | undefined;
-  language?: string | undefined;
-  slug: string;
-};
-
-export const readDecisionBySlugHandler = async ({
-  caseLawDb,
-  citationsCursor,
-  language,
-  slug,
-}: ReadDecisionBySlugOptions) => {
-  const normalizedLanguage = normalizePublicDecisionLanguage(language);
-  if (language !== undefined && normalizedLanguage === null) {
-    return status(404, { message: "Decision not found" });
-  }
-
-  const decision = await caseLawDb((tx) =>
-    tx
-      .select({ id: caseLawDecisions.id })
-      .from(caseLawDecisions)
-      .where(
-        normalizedLanguage
-          ? and(
-              eq(caseLawDecisions.slug, slug),
-              sql`replace(lower(${caseLawDecisions.language}), '_', '-') = ${normalizedLanguage}`,
-            )
-          : eq(caseLawDecisions.slug, slug),
-      )
-      .limit(1),
-  );
-
-  const firstDecision = decision.at(0);
-  if (!firstDecision) {
-    return status(404, { message: "Decision not found" });
-  }
-
-  return await readDecisionHandler({
-    caseLawDb,
-    citationsCursor,
-    decisionId: firstDecision.id,
-  });
 };
 
 /**
@@ -721,22 +657,20 @@ type ResolveFulltextInput = {
   textS3Key: string | null;
   contentHash: string | null;
   decisionId: SafeId<"caseLawDecision">;
-  caseLawDb: CaseLawPublicReadDb;
+  tx: CaseLawPublicReadTransaction;
 };
 
 const resolveFulltext = async ({
   textS3Key,
   contentHash,
   decisionId,
-  caseLawDb,
+  tx,
 }: ResolveFulltextInput): Promise<CorpusReadOutcome<string>> => {
   const postgresFulltext = async (): Promise<string | null> => {
-    const fallback = await caseLawDb((tx) =>
-      tx.query.caseLawDecisions.findFirst({
-        where: { id: { eq: decisionId } },
-        columns: { fulltext: true },
-      }),
-    );
+    const fallback = await tx.query.caseLawDecisions.findFirst({
+      where: { id: { eq: decisionId } },
+      columns: { fulltext: true },
+    });
     return fallback?.fulltext ?? null;
   };
 

--- a/apps/api/src/handlers/case-law/decisions/list-citations.ts
+++ b/apps/api/src/handlers/case-law/decisions/list-citations.ts
@@ -1,12 +1,11 @@
-import { Result } from "better-result";
 import { t } from "elysia";
 
 import {
   listDecisionCitationsHandler,
   listDecisionCitationsQuerySchema,
 } from "@/api/handlers/case-law/decisions/citation-graph";
+import { createSafePublicSubjectHandler } from "@/api/handlers/case-law/decisions/public-subject";
 import type { PublicHandlerConfig } from "@/api/lib/api-handlers";
-import { createSafePublicHandler } from "@/api/lib/api-handlers";
 import { caseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 import { tSafeId } from "@/api/lib/custom-schema";
 
@@ -17,22 +16,12 @@ const config = {
 } satisfies PublicHandlerConfig;
 
 /** One page of the decisions a decision cites, or is cited by. */
-const listDecisionCitations = createSafePublicHandler(
+const listDecisionCitations = createSafePublicSubjectHandler({
   config,
-  async function* ({ params: { decisionId }, query }) {
-    const response = yield* Result.await(
-      Result.tryPromise(
-        async () =>
-          await listDecisionCitationsHandler({
-            caseLawDb: caseLawPublicReadDb,
-            decisionId,
-            query,
-          }),
-      ),
-    );
-
-    return Result.ok(response);
-  },
-);
+  caseLawDb: caseLawPublicReadDb,
+  locate: ({ params: { decisionId } }) => ({ kind: "id", id: decisionId }),
+  read: async (subject, { query }) =>
+    await listDecisionCitationsHandler({ subject, query }),
+});
 
 export default listDecisionCitations;

--- a/apps/api/src/handlers/case-law/decisions/public-subject.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/public-subject.db.test.ts
@@ -1,0 +1,308 @@
+import type { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+import Elysia, { t } from "elysia";
+
+import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import {
+  createSafePublicSubjectHandler,
+  withRedistributableSubject,
+} from "@/api/handlers/case-law/decisions/public-subject";
+import type { RedistributableDecisionSubject } from "@/api/handlers/case-law/decisions/public-subject";
+import type { PublicHandlerConfig } from "@/api/lib/api-handlers";
+import { createSafeId } from "@/api/lib/branded-types";
+import type {
+  CaseLawPublicReadDb,
+  CaseLawPublicReadTransaction,
+} from "@/api/lib/case-law-public-read-db";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { caseLawSourceRow } from "@/api/tests/helpers/case-law-source-row";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const openSourceId = createSafeId<"caseLawSource">();
+const closedSourceId = createSafeId<"caseLawSource">();
+const openId = createSafeId<"caseLawDecision">();
+const closedId = createSafeId<"caseLawDecision">();
+const missingId = createSafeId<"caseLawDecision">();
+const variantId = createSafeId<"caseLawDecision">();
+
+/** Same budget as the schema push below: an embedded Postgres is not fast. */
+const DB_TEST_TIMEOUT_MS = 120_000;
+
+let client: PGlite;
+let caseLawDb: CaseLawPublicReadDb;
+/** The isolation each transaction was opened with, in order, per request. */
+let opened: (string | undefined)[] = [];
+/** The handle handed out by each of those opens. */
+let handles: CaseLawPublicReadTransaction[] = [];
+
+/**
+ * What a gated read may answer with: its own subject, and proof of which
+ * transaction its rows came from.
+ */
+const echoSubject = async (subject: RedistributableDecisionSubject) => ({
+  reached: subject.id,
+  readOnHandle: handles.indexOf(subject.tx),
+});
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    const db = drizzle({ client });
+    const readDb = async <T>(
+      fn: (tx: CaseLawPublicReadTransaction) => Promise<T>,
+      options?: { isolation?: string },
+    ) => {
+      opened.push(options?.isolation);
+      // A fresh delegating handle per open, so a read that reached for its
+      // own transaction is visible as a different object, not just a count.
+      // SAFETY: a delegating view of the embedded database; the reads only
+      // use its select surface.
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test handle stands in for a transaction
+      const tx = Object.create(db) as CaseLawPublicReadTransaction;
+      handles.push(tx);
+      return await fn(tx);
+    };
+    // SAFETY: brand-only wrapper; the reads never inspect the marker.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the branded handle carries no behaviour
+    caseLawDb = readDb as unknown as CaseLawPublicReadDb;
+
+    await db.insert(caseLawSources).values([
+      caseLawSourceRow({ adapterKey: "open", id: openSourceId, name: "open" }),
+      caseLawSourceRow({
+        adapterKey: "closed",
+        descriptor: {
+          allowsDerivedAi: false,
+          allowsRedistribution: false,
+          attribution: null,
+          license: "restricted",
+        },
+        id: closedSourceId,
+        name: "closed",
+      }),
+    ]);
+    await db.insert(caseLawDecisions).values([
+      {
+        caseNumber: "open",
+        country: "CZE",
+        court: "Court",
+        id: openId,
+        language: "cs",
+        slug: "open-case",
+        sourceId: openSourceId,
+      },
+      {
+        caseNumber: "closed",
+        country: "CZE",
+        court: "Court",
+        id: closedId,
+        language: "cs",
+        slug: "closed-case",
+        sourceId: closedSourceId,
+      },
+      // Stored with the separator and case a publisher happened to use; the
+      // lookup normalises both sides before comparing.
+      {
+        caseNumber: "variant",
+        country: "CZE",
+        court: "Court",
+        id: variantId,
+        language: "pt_BR",
+        slug: "variant-case",
+        sourceId: openSourceId,
+      },
+    ]);
+  },
+  { timeout: 120_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+/** A throwaway route per locator kind; the handler echoes the subject it got. */
+const app = () => {
+  const byId = createSafePublicSubjectHandler({
+    config: {
+      mcp: { type: "internal", reason: "public_indexing" },
+      params: t.Object({ decisionId: tSafeId("caseLawDecision") }),
+    } satisfies PublicHandlerConfig,
+    caseLawDb,
+    locate: ({ params: { decisionId } }) => ({ kind: "id", id: decisionId }),
+    read: async (subject) => await echoSubject(subject),
+  });
+  const bySlug = createSafePublicSubjectHandler({
+    config: {
+      mcp: { type: "internal", reason: "public_indexing" },
+      params: t.Object({ slug: t.String() }),
+      query: t.Object({ language: t.Optional(t.String()) }),
+    } satisfies PublicHandlerConfig,
+    caseLawDb,
+    locate: ({ params: { slug }, query: { language } }) => ({
+      kind: "slug",
+      slug,
+      language,
+    }),
+    read: async (subject) => await echoSubject(subject),
+  });
+  return new Elysia()
+    .get("/d/:decisionId", byId.handler, { params: byId.config.params })
+    .get("/s/:slug", bySlug.handler, {
+      params: bySlug.config.params,
+      query: bySlug.config.query,
+    });
+};
+
+const get = async (path: string) => {
+  opened = [];
+  handles = [];
+  return await app().handle(new Request(`http://localhost${path}`));
+};
+
+test(
+  "a restricted or missing subject is not found, by id and by slug",
+  async () => {
+    for (const path of [
+      `/d/${closedId}`,
+      `/d/${missingId}`,
+      "/s/closed-case",
+      "/s/no-such-slug",
+      "/s/open-case?language=xx_notalanguage!",
+    ]) {
+      // oxlint-disable-next-line no-await-in-loop -- table-driven requests
+      const response = await get(path);
+      expect(response.status).toBe(404);
+      // oxlint-disable-next-line no-await-in-loop -- table-driven requests
+      expect(await response.json()).toEqual({ message: "Decision not found" });
+    }
+  },
+  DB_TEST_TIMEOUT_MS,
+);
+
+test(
+  "a redistributable subject reaches the handler as the gated subject",
+  async () => {
+    for (const path of [
+      `/d/${openId}`,
+      "/s/open-case",
+      "/s/open-case?language=CS",
+    ]) {
+      // oxlint-disable-next-line no-await-in-loop -- table-driven requests
+      const response = await get(path);
+      expect(response.status).toBe(200);
+      // oxlint-disable-next-line no-await-in-loop -- table-driven requests
+      expect(await response.json()).toMatchObject({ reached: openId });
+    }
+  },
+  DB_TEST_TIMEOUT_MS,
+);
+
+test(
+  "slug language matching normalises separator and case on both sides",
+  async () => {
+    for (const path of [
+      "/s/variant-case?language=pt-br",
+      "/s/variant-case?language=PT_BR",
+      "/s/variant-case?language=pt_br",
+    ]) {
+      // oxlint-disable-next-line no-await-in-loop -- table-driven requests
+      const response = await get(path);
+      expect(response.status).toBe(200);
+      // oxlint-disable-next-line no-await-in-loop -- table-driven requests
+      expect(await response.json()).toMatchObject({ reached: variantId });
+    }
+    // A different tag must still miss, so the normalisation is not a wildcard.
+    expect((await get("/s/variant-case?language=pt")).status).toBe(404);
+  },
+  DB_TEST_TIMEOUT_MS,
+);
+
+test(
+  "the resolver answers the same way outside a route",
+  async () => {
+    expect(
+      await withRedistributableSubject(
+        caseLawDb,
+        { kind: "id", id: closedId },
+        async (subject) => subject.id,
+      ),
+    ).toBeNull();
+    expect(
+      await withRedistributableSubject(
+        caseLawDb,
+        { kind: "id", id: openId },
+        async (subject) => subject.id,
+      ),
+    ).toBe(openId);
+  },
+  DB_TEST_TIMEOUT_MS,
+);
+
+test(
+  "the gate and the read share one repeatable-read transaction",
+  async () => {
+    // The window this closes: gate in one transaction, read in another, and
+    // a source turned restricted in between still answers with content under
+    // a brand that says "gated". One transaction leaves no in-between, and
+    // repeatable read makes every statement under it see the state the gate
+    // judged.
+    const response = await get(`/d/${openId}`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      reached: openId,
+      // The first (and only) transaction of the request: the read's rows
+      // come from the one that approved the subject.
+      readOnHandle: 0,
+    });
+    expect(opened).toEqual(["repeatable-read"]);
+  },
+  DB_TEST_TIMEOUT_MS,
+);
+
+test(
+  "revoking a source stops the endpoint answering for its decisions",
+  async () => {
+    const db = drizzle({ client });
+    const revoked = createSafeId<"caseLawSource">();
+    const decision = createSafeId<"caseLawDecision">();
+    await db.insert(caseLawSources).values([
+      caseLawSourceRow({
+        adapterKey: "revoked",
+        id: revoked,
+        name: "revoked",
+      }),
+    ]);
+    await db.insert(caseLawDecisions).values([
+      {
+        caseNumber: "revoked",
+        country: "CZE",
+        court: "Court",
+        id: decision,
+        language: "cs",
+        slug: "revoked-case",
+        sourceId: revoked,
+      },
+    ]);
+    expect((await get(`/d/${decision}`)).status).toBe(200);
+
+    await db
+      .update(caseLawSources)
+      .set({
+        descriptor: {
+          allowsDerivedAi: false,
+          allowsRedistribution: false,
+          attribution: null,
+          license: "restricted",
+        },
+      })
+      .where(eq(caseLawSources.id, revoked));
+
+    // The gate reads the policy on every request, so the next one is closed.
+    const after = await get(`/d/${decision}`);
+    expect(after.status).toBe(404);
+    expect(await after.json()).toEqual({ message: "Decision not found" });
+  },
+  DB_TEST_TIMEOUT_MS,
+);

--- a/apps/api/src/handlers/case-law/decisions/public-subject.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/public-subject.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isSubjectGatedHandler,
+  subjectGatedHandlers,
+} from "@/api/handlers/case-law/decisions/public-subject";
+import { publicCaseLawRoute } from "@/api/handlers/case-law/public-routes";
+
+/**
+ * Routes that answer without naming one decision, declared rather than
+ * inferred.
+ *
+ * The census reads this list as the exception and treats the gate as the
+ * rule, because the other way round cannot be safe: a heuristic over the
+ * path ("does it contain `:decisionId`?") silently excludes a route spelled
+ * `/decisions/:id/history` or `/decisions/lookup/:slug`, and an ungated
+ * handler mounted there would pass every check. Adding a route therefore
+ * either goes through the gate factory or is written down here, where it is
+ * reviewed as the deliberate act it is.
+ */
+const SUBJECT_FREE_ROUTES = [
+  "GET /case/decisions",
+  "GET /case/decisions/facets",
+  "GET /case/provisions/citing-decisions",
+  "GET /case/sitemap/decisions/shard",
+  "GET /case/sitemap/shards",
+  "POST /case/decisions/search",
+] as const;
+
+const routeId = (route: { method: string; path: string }) =>
+  `${route.method} ${route.path}`;
+
+describe("public decision routes are gated by construction", () => {
+  const routes = publicCaseLawRoute.routes
+    .map((route) => ({
+      handler: route.handler,
+      method: route.method,
+      path: route.path,
+    }))
+    // Elysia mounts internal entries (HEAD, error pages) that carry no
+    // handler of ours; the census is about the routes this slice declares.
+    .filter((route) => typeof route.handler === "function");
+
+  const subjectFree = new Set<string>(SUBJECT_FREE_ROUTES);
+
+  test("every route that is not declared subject-free is gated", () => {
+    const ungated = routes
+      .filter((route) => !subjectFree.has(routeId(route)))
+      .filter((route) => !isSubjectGatedHandler(route.handler))
+      .map(routeId);
+    expect(ungated).toEqual([]);
+  });
+
+  test("every factory-made handler is mounted", () => {
+    const mounted = new Set<unknown>(routes.map((route) => route.handler));
+    const orphaned = [...subjectGatedHandlers()].filter(
+      (handler) => !mounted.has(handler),
+    );
+    expect(orphaned).toEqual([]);
+  });
+
+  test("no route declared subject-free carries the gate", () => {
+    const misapplied = routes
+      .filter((route) => subjectFree.has(routeId(route)))
+      .filter((route) => isSubjectGatedHandler(route.handler))
+      .map(routeId);
+    expect(misapplied).toEqual([]);
+  });
+
+  test("every declared subject-free route is mounted", () => {
+    // Keeps the exception list from outliving its routes: a stale entry
+    // would silently excuse a future route that reuses the same path.
+    const mounted = new Set(routes.map(routeId));
+    const stale = [...SUBJECT_FREE_ROUTES].filter((id) => !mounted.has(id));
+    expect(stale).toEqual([]);
+  });
+
+  test("the census covers the routes this slice is known to expose", () => {
+    const gated = routes
+      .filter((route) => isSubjectGatedHandler(route.handler))
+      .map(routeId)
+      .sort();
+    expect(gated).toEqual([
+      "GET /case/decisions/:decisionId",
+      "GET /case/decisions/:decisionId/citations",
+      "GET /case/decisions/:decisionId/citations/summary",
+      "GET /case/decisions/:decisionId/provisions",
+      "GET /case/decisions/by-slug/:slug",
+    ]);
+  });
+});

--- a/apps/api/src/handlers/case-law/decisions/public-subject.ts
+++ b/apps/api/src/handlers/case-law/decisions/public-subject.ts
@@ -1,0 +1,283 @@
+/**
+ * The redistribution gate for public decision reads, by construction.
+ *
+ * A public endpoint that names a decision must answer "not found" when the
+ * decision's source may not be redistributed: its citation texts, graph
+ * counts and provision references are as much its content as its full text.
+ * The gate used to be a check each handler remembered to make, and two
+ * handlers shipped without it. Here it is the only way to obtain a
+ * `RedistributableDecisionSubject`, and every read handler takes one instead
+ * of a bare id, so a handler that skips the gate does not typecheck.
+ *
+ * The subject carries the transaction that gated it, and that transaction is
+ * the only database handle a gated handler receives. Resolving in one
+ * transaction and reading in another would leave a window where a source
+ * turned restricted in between and the content still went out under a brand
+ * that says "gated"; carrying the handle closes it, because the content a
+ * handler reads can only come from the state the gate approved. The gated
+ * transaction is a repeatable-read snapshot, so every statement under it —
+ * the gate's and the handler's — sees that one state.
+ */
+import { Result } from "better-result";
+import { and, eq, sql } from "drizzle-orm";
+import { status } from "elysia";
+
+import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import type {
+  PublicHandlerConfig,
+  PublicHandlerContext,
+  SafeHandlerGenerator,
+} from "@/api/lib/api-handlers";
+import { createSafePublicHandler } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
+import type {
+  CaseLawPublicReadDb,
+  CaseLawPublicReadTransaction,
+} from "@/api/lib/case-law-public-read-db";
+import { isRedistributable } from "@/api/lib/legal-search/corpus-source";
+
+/** Module-private, so the subject type is constructible only below. */
+const REDISTRIBUTABLE: unique symbol = Symbol("redistributableDecisionSubject");
+
+/**
+ * A decision the public may read: resolved and gated in one place.
+ *
+ * `tx` is the transaction the gate ran in. A handler reads through it and
+ * receives no other handle, so its rows and the gate's verdict come from one
+ * snapshot; see the module comment.
+ */
+export type RedistributableDecisionSubject = {
+  readonly id: SafeId<"caseLawDecision">;
+  readonly tx: CaseLawPublicReadTransaction;
+  readonly [REDISTRIBUTABLE]: true;
+};
+
+const subjectOf = (
+  id: SafeId<"caseLawDecision">,
+  tx: CaseLawPublicReadTransaction,
+): RedistributableDecisionSubject => ({ id, tx, [REDISTRIBUTABLE]: true });
+
+const LANGUAGE_SEGMENT_REGEX = /^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$/u;
+
+/** Lower-case BCP-47-ish tag, or null when the input is not one. */
+export const normalizePublicDecisionLanguage = (
+  language: string | undefined,
+): string | null => {
+  const normalized = language?.trim().toLowerCase().replace(/_/gu, "-");
+  if (!normalized) {
+    return null;
+  }
+
+  return LANGUAGE_SEGMENT_REGEX.test(normalized) ? normalized : null;
+};
+
+/** How a request names its subject. */
+export type DecisionSubjectLocator =
+  | { kind: "id"; id: SafeId<"caseLawDecision"> }
+  | { kind: "slug"; slug: string; language: string | undefined };
+
+const locatorCondition = (locator: DecisionSubjectLocator) => {
+  switch (locator.kind) {
+    case "id":
+      return eq(caseLawDecisions.id, locator.id);
+    case "slug": {
+      const language = normalizePublicDecisionLanguage(locator.language);
+      if (locator.language !== undefined && language === null) {
+        return null;
+      }
+      return language === null
+        ? eq(caseLawDecisions.slug, locator.slug)
+        : and(
+            eq(caseLawDecisions.slug, locator.slug),
+            sql`replace(lower(${caseLawDecisions.language}), '_', '-') = ${language}`,
+          );
+    }
+    default: {
+      const exhaustive: never = locator;
+      return exhaustive;
+    }
+  }
+};
+
+/**
+ * The subject a locator names within `tx`, or null when it does not exist or
+ * its source may not be redistributed. The two cases are deliberately one
+ * answer: a restricted decision does not exist for the public.
+ */
+const resolveSubjectIn = async (
+  tx: CaseLawPublicReadTransaction,
+  locator: DecisionSubjectLocator,
+): Promise<RedistributableDecisionSubject | null> => {
+  const condition = locatorCondition(locator);
+  if (condition === null) {
+    return null;
+  }
+  const rows = await tx
+    .select({
+      id: caseLawDecisions.id,
+      descriptor: caseLawSources.descriptor,
+    })
+    .from(caseLawDecisions)
+    .innerJoin(caseLawSources, eq(caseLawSources.id, caseLawDecisions.sourceId))
+    .where(condition)
+    .limit(1);
+  const row = rows.at(0);
+  if (row === undefined || !isRedistributable(row.descriptor)) {
+    return null;
+  }
+  return subjectOf(row.id, tx);
+};
+
+/**
+ * Gate a decision and read it in one transaction.
+ *
+ * `read` runs with the subject inside the transaction that approved it, so
+ * every row it returns belongs to the snapshot the gate judged. Returns null
+ * when the decision does not exist or its source may not be redistributed;
+ * every caller turns that into the same "not found" its surface uses.
+ *
+ * Work that must not hold a database transaction — fetching a document from
+ * the publisher, writing through the ingestion path — belongs after this
+ * resolves, never inside `read`.
+ */
+export const withRedistributableSubject = async <T>(
+  caseLawDb: CaseLawPublicReadDb,
+  locator: DecisionSubjectLocator,
+  read: (subject: RedistributableDecisionSubject) => Promise<T>,
+): Promise<T | null> =>
+  await caseLawDb(
+    async (tx) => {
+      const subject = await resolveSubjectIn(tx, locator);
+      return subject === null ? null : await read(subject);
+    },
+    { isolation: "repeatable-read" },
+  );
+
+export const DECISION_NOT_FOUND = { message: "Decision not found" } as const;
+
+const notFound = () => status(404, DECISION_NOT_FOUND);
+type NotFoundStatus = ReturnType<typeof notFound>;
+
+/** Handlers the factory produced; the route census checks both directions. */
+const gatedHandlers = new Set<unknown>();
+
+/**
+ * The subject travels beside the context rather than merged into it: an
+ * intersection over Elysia's context type is instantiated afresh at every
+ * call site, and the route tree is a hot enough generic path to feel it.
+ */
+type SubjectHandlerOptions<TConfig extends PublicHandlerConfig, TRead> = {
+  config: TConfig;
+  caseLawDb: CaseLawPublicReadDb;
+  /** Which decision the request names. */
+  locate: (ctx: PublicHandlerContext<TConfig>) => DecisionSubjectLocator;
+  /** Runs inside the gated transaction; reads through `subject.tx` only. */
+  read: (
+    subject: RedistributableDecisionSubject,
+    ctx: PublicHandlerContext<TConfig>,
+  ) => Promise<TRead>;
+};
+
+type FollowUpOptions<TConfig extends PublicHandlerConfig, TRead, TResult> = {
+  followUp: (
+    read: TRead,
+    ctx: PublicHandlerContext<TConfig>,
+  ) => Promise<TResult>;
+};
+
+/**
+ * The one implementation behind both entry points below: gate, read inside
+ * the gated transaction, then run the follow-up once it has closed. Private,
+ * so the gate cannot be reached except through a factory that registers its
+ * handler for the route census.
+ */
+const buildGatedSubjectHandler = <
+  TConfig extends PublicHandlerConfig,
+  TRead,
+  TResult extends NonNullable<unknown>,
+>({
+  config,
+  caseLawDb,
+  locate,
+  read,
+  followUp,
+}: SubjectHandlerOptions<TConfig, TRead> &
+  FollowUpOptions<TConfig, TRead, TResult>) => {
+  const definition = createSafePublicHandler(
+    config,
+    async function* (
+      ctx: PublicHandlerContext<TConfig>,
+    ): SafeHandlerGenerator<TResult | NotFoundStatus> {
+      // `null` is the gate's answer, so a read that resolves to null of its
+      // own accord would be indistinguishable; wrap it instead.
+      const gated = yield* Result.await(
+        Result.tryPromise(
+          async () =>
+            await withRedistributableSubject(
+              caseLawDb,
+              locate(ctx),
+              async (subject) => ({ value: await read(subject, ctx) }),
+            ),
+        ),
+      );
+      if (gated === null) {
+        return Result.ok(notFound());
+      }
+      const response = yield* Result.await(
+        Result.tryPromise(async () => await followUp(gated.value, ctx)),
+      );
+
+      return Result.ok(response);
+    },
+  );
+  gatedHandlers.add(definition.handler);
+  return definition;
+};
+
+/**
+ * A gated read followed by work that must not hold a database transaction
+ * open: a publisher fetch, an ingestion write. `followUp` runs on the value
+ * the gated read produced, after the gated transaction closes.
+ *
+ * The factory resolves the locator, answers 404 for a missing or restricted
+ * decision, and only then runs `read` with the branded subject, whose
+ * transaction is the only database handle the read receives.
+ */
+export const createSafePublicSubjectFollowUpHandler = <
+  TConfig extends PublicHandlerConfig,
+  TRead,
+  TResult extends NonNullable<unknown>,
+>(
+  options: SubjectHandlerOptions<TConfig, TRead> &
+    FollowUpOptions<TConfig, TRead, TResult>,
+) => buildGatedSubjectHandler(options);
+
+/** The follow-up of a handler whose gated read is already the response. */
+const readIsTheResponse = async <T>(read: T): Promise<T> =>
+  await Promise.resolve(read);
+
+/**
+ * The same gate, for a read that is the whole answer.
+ *
+ * The follow-up is the identity, so the response type is the read's own. The
+ * two shapes are separate entry points rather than one optional phase
+ * because a type parameter defaulted to "whatever the read returned" is a
+ * fact the compiler cannot check, and only an assertion could state it.
+ */
+export const createSafePublicSubjectHandler = <
+  TConfig extends PublicHandlerConfig,
+  TRead extends NonNullable<unknown>,
+>(
+  options: SubjectHandlerOptions<TConfig, TRead>,
+) =>
+  buildGatedSubjectHandler({
+    ...options,
+    followUp: readIsTheResponse,
+  });
+
+/** Whether a mounted route handler came out of the factory. */
+export const isSubjectGatedHandler = (handler: unknown): boolean =>
+  typeof handler === "function" && gatedHandlers.has(handler);
+
+/** Every handler the factory produced, for the census's other direction. */
+export const subjectGatedHandlers = (): ReadonlySet<unknown> => gatedHandlers;

--- a/apps/api/src/handlers/case-law/decisions/summarize-citations.ts
+++ b/apps/api/src/handlers/case-law/decisions/summarize-citations.ts
@@ -1,9 +1,8 @@
-import { Result } from "better-result";
 import { t } from "elysia";
 
 import { summarizeDecisionCitationsHandler } from "@/api/handlers/case-law/decisions/citation-graph";
+import { createSafePublicSubjectHandler } from "@/api/handlers/case-law/decisions/public-subject";
 import type { PublicHandlerConfig } from "@/api/lib/api-handlers";
-import { createSafePublicHandler } from "@/api/lib/api-handlers";
 import { caseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 import { tSafeId } from "@/api/lib/custom-schema";
 
@@ -13,21 +12,11 @@ const config = {
 } satisfies PublicHandlerConfig;
 
 /** Citation counts per direction and treatment, and incoming counts by year. */
-const summarizeDecisionCitations = createSafePublicHandler(
+const summarizeDecisionCitations = createSafePublicSubjectHandler({
   config,
-  async function* ({ params: { decisionId } }) {
-    const response = yield* Result.await(
-      Result.tryPromise(
-        async () =>
-          await summarizeDecisionCitationsHandler({
-            caseLawDb: caseLawPublicReadDb,
-            decisionId,
-          }),
-      ),
-    );
-
-    return Result.ok(response);
-  },
-);
+  caseLawDb: caseLawPublicReadDb,
+  locate: ({ params: { decisionId } }) => ({ kind: "id", id: decisionId }),
+  read: async (subject) => await summarizeDecisionCitationsHandler({ subject }),
+});
 
 export default summarizeDecisionCitations;

--- a/apps/api/src/handlers/case-law/provisions/list-for-decision.ts
+++ b/apps/api/src/handlers/case-law/provisions/list-for-decision.ts
@@ -3,14 +3,8 @@ import type { SQL } from "drizzle-orm";
 import { status, t } from "elysia";
 import type { Static } from "elysia";
 
-import {
-  caseLawDecisions,
-  caseLawProvisionCitations,
-  caseLawSources,
-} from "@/api/db/schema";
-import type { SafeId } from "@/api/lib/branded-types";
-import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
-import { redistributableCaseLawSource } from "@/api/lib/case-law/redistribution";
+import { caseLawProvisionCitations } from "@/api/db/schema";
+import type { RedistributableDecisionSubject } from "@/api/handlers/case-law/decisions/public-subject";
 import { tPaginationCursor, tPaginationLimit } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
 import {
@@ -29,9 +23,12 @@ type ListDecisionProvisionsQuery = Static<
 >;
 
 type ListDecisionProvisionsOptions = {
-  decisionId: SafeId<"caseLawDecision">;
+  /**
+   * Gated upstream, and the only database handle this read gets: its rows
+   * come from the transaction that approved it.
+   */
+  subject: RedistributableDecisionSubject;
   query: ListDecisionProvisionsQuery;
-  caseLawDb: CaseLawPublicReadDb;
 };
 
 type ProvisionCursor = { spanStart: number; anchor: string };
@@ -55,14 +52,14 @@ const decodeProvisionCursor = (cursor: string): ProvisionCursor | null => {
 };
 
 export const listDecisionProvisionsHandler = async ({
-  decisionId,
+  subject: { id: decisionId, tx },
   query,
-  caseLawDb,
 }: ListDecisionProvisionsOptions) => {
   const limit = query.limit ?? LIMITS.caseLawSearchPageSizeDefault;
+  // Redistribution was decided when the subject was resolved; the rows
+  // belong to that one decision, so no source join is needed here.
   const conditions: SQL[] = [
     eq(caseLawProvisionCitations.decisionId, decisionId),
-    redistributableCaseLawSource,
   ];
 
   if (query.cursor) {
@@ -76,47 +73,37 @@ export const listDecisionProvisionsHandler = async ({
     );
   }
 
-  const rows = await caseLawDb((tx) =>
-    tx
-      .select({
-        jurisdiction: caseLawProvisionCitations.jurisdiction,
-        workIdentifier: caseLawProvisionCitations.workIdentifier,
-        workNumber: caseLawProvisionCitations.workNumber,
-        workYear: caseLawProvisionCitations.workYear,
-        workCollection: caseLawProvisionCitations.workCollection,
-        workEli: caseLawProvisionCitations.workEli,
-        workSource: caseLawProvisionCitations.workSource,
-        unit: caseLawProvisionCitations.unit,
-        section: caseLawProvisionCitations.section,
-        sectionSuffix: caseLawProvisionCitations.sectionSuffix,
-        subsection: caseLawProvisionCitations.subsection,
-        letter: caseLawProvisionCitations.letter,
-        point: caseLawProvisionCitations.point,
-        sentence: caseLawProvisionCitations.sentence,
-        openEnded: caseLawProvisionCitations.openEnded,
-        anchor: caseLawProvisionCitations.anchor,
-        versionValidFrom: caseLawProvisionCitations.versionValidFrom,
-        sentenceText: caseLawProvisionCitations.sentenceText,
-        spanStart: caseLawProvisionCitations.spanStart,
-        spanEnd: caseLawProvisionCitations.spanEnd,
-        confidence: caseLawProvisionCitations.confidence,
-      })
-      .from(caseLawProvisionCitations)
-      .innerJoin(
-        caseLawDecisions,
-        eq(caseLawDecisions.id, caseLawProvisionCitations.decisionId),
-      )
-      .innerJoin(
-        caseLawSources,
-        eq(caseLawSources.id, caseLawDecisions.sourceId),
-      )
-      .where(and(...conditions))
-      .orderBy(
-        asc(caseLawProvisionCitations.spanStart),
-        asc(caseLawProvisionCitations.anchor),
-      )
-      .limit(limit + 1),
-  );
+  const rows = await tx
+    .select({
+      jurisdiction: caseLawProvisionCitations.jurisdiction,
+      workIdentifier: caseLawProvisionCitations.workIdentifier,
+      workNumber: caseLawProvisionCitations.workNumber,
+      workYear: caseLawProvisionCitations.workYear,
+      workCollection: caseLawProvisionCitations.workCollection,
+      workEli: caseLawProvisionCitations.workEli,
+      workSource: caseLawProvisionCitations.workSource,
+      unit: caseLawProvisionCitations.unit,
+      section: caseLawProvisionCitations.section,
+      sectionSuffix: caseLawProvisionCitations.sectionSuffix,
+      subsection: caseLawProvisionCitations.subsection,
+      letter: caseLawProvisionCitations.letter,
+      point: caseLawProvisionCitations.point,
+      sentence: caseLawProvisionCitations.sentence,
+      openEnded: caseLawProvisionCitations.openEnded,
+      anchor: caseLawProvisionCitations.anchor,
+      versionValidFrom: caseLawProvisionCitations.versionValidFrom,
+      sentenceText: caseLawProvisionCitations.sentenceText,
+      spanStart: caseLawProvisionCitations.spanStart,
+      spanEnd: caseLawProvisionCitations.spanEnd,
+      confidence: caseLawProvisionCitations.confidence,
+    })
+    .from(caseLawProvisionCitations)
+    .where(and(...conditions))
+    .orderBy(
+      asc(caseLawProvisionCitations.spanStart),
+      asc(caseLawProvisionCitations.anchor),
+    )
+    .limit(limit + 1);
 
   return createCursorPage({
     rows,

--- a/apps/api/src/handlers/case-law/provisions/reads.db.test.ts
+++ b/apps/api/src/handlers/case-law/provisions/reads.db.test.ts
@@ -1,3 +1,4 @@
+import { panic } from "better-result";
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { drizzle } from "drizzle-orm/pglite";
 
@@ -6,6 +7,7 @@ import {
   caseLawProvisionCitations,
   caseLawSources,
 } from "@/api/db/schema";
+import { withRedistributableSubject } from "@/api/handlers/case-law/decisions/public-subject";
 import { listCitingDecisionsHandler } from "@/api/handlers/case-law/provisions/citing-decisions";
 import { listDecisionProvisionsHandler } from "@/api/handlers/case-law/provisions/list-for-decision";
 import { createSafeId } from "@/api/lib/branded-types";
@@ -195,10 +197,16 @@ afterAll(async () => {
   await client.close();
 });
 
+const subjectFor = async (id: SafeId<"caseLawDecision">) =>
+  (await withRedistributableSubject(
+    caseLawDb,
+    { kind: "id", id },
+    async (subject) => subject,
+  )) ?? panic("expected a redistributable subject");
+
 const decisionProvisions = async (cursor?: string) => {
   const page = await listDecisionProvisionsHandler({
-    caseLawDb,
-    decisionId: highAuthorityId,
+    subject: await subjectFor(highAuthorityId),
     query: { limit: 2, ...(cursor === undefined ? {} : { cursor }) },
   });
 
@@ -265,8 +273,7 @@ test("decision provisions page by span start", async () => {
 
 test("decision provisions reject a malformed cursor", async () => {
   const response = await listDecisionProvisionsHandler({
-    caseLawDb,
-    decisionId: highAuthorityId,
+    subject: await subjectFor(highAuthorityId),
     query: { cursor: "not-a-cursor" },
   });
 

--- a/apps/api/src/handlers/case-law/public-routes.ts
+++ b/apps/api/src/handlers/case-law/public-routes.ts
@@ -6,16 +6,20 @@ import {
   listDecisionFacetsHandler,
   listDecisionFacetsQuerySchema,
 } from "@/api/handlers/case-law/decisions/facets";
-import { readDecisionQuerySchema } from "@/api/handlers/case-law/decisions/get";
 import {
-  readDecisionBySlugWithDocumentHandler,
-  readDecisionWithDocumentHandler,
-} from "@/api/handlers/case-law/decisions/get-deferred-document";
+  readDecisionHandler,
+  readDecisionQuerySchema,
+} from "@/api/handlers/case-law/decisions/get";
+import { hydrateDeferredDocument } from "@/api/handlers/case-law/decisions/get-deferred-document";
 import {
   listDecisionsHandler,
   listDecisionsQuerySchema,
 } from "@/api/handlers/case-law/decisions/list";
 import listDecisionCitations from "@/api/handlers/case-law/decisions/list-citations";
+import {
+  createSafePublicSubjectHandler,
+  createSafePublicSubjectFollowUpHandler,
+} from "@/api/handlers/case-law/decisions/public-subject";
 import { searchDecisionsHandler } from "@/api/handlers/case-law/decisions/search";
 import { searchDecisionsBodySchema } from "@/api/handlers/case-law/decisions/search-schema";
 import {
@@ -66,33 +70,23 @@ const listDecisionFacets = createSafePublicHandler(
   },
 );
 
-const readDecision = createSafePublicHandler(
-  {
+const readDecision = createSafePublicSubjectFollowUpHandler({
+  config: {
     mcp: { type: "tool", name: "read_case_law_decision" },
     params: t.Object({ decisionId: tSafeId("caseLawDecision") }),
     query: readDecisionQuerySchema,
   },
-  async function* ({ params: { decisionId }, query: { citationsCursor } }) {
-    const response = yield* Result.await(
-      Result.tryPromise(
-        async () =>
-          await readDecisionWithDocumentHandler({
-            decisionId,
-            caseLawDb: caseLawPublicReadDb,
-            citationsCursor,
-            // Unauthenticated: hydrates when a slot is free, but never
-            // persists demand — see `recordDemand`.
-            caller: "anonymous",
-          }),
-      ),
-    );
+  caseLawDb: caseLawPublicReadDb,
+  locate: ({ params: { decisionId } }) => ({ kind: "id", id: decisionId }),
+  read: async (subject, { query: { citationsCursor } }) =>
+    await readDecisionHandler({ subject, citationsCursor }),
+  // Unauthenticated: hydrates when a slot is free, but never persists
+  // demand — see `recordDemand`. Runs after the gated transaction closes.
+  followUp: async (read) => await hydrateDeferredDocument(read, false),
+});
 
-    return Result.ok(response);
-  },
-);
-
-const readDecisionBySlug = createSafePublicHandler(
-  {
+const readDecisionBySlug = createSafePublicSubjectFollowUpHandler({
+  config: {
     mcp: { type: "covered", by: "read_case_law_decision" },
     params: t.Object({ slug: t.String({ minLength: 1, maxLength: 256 }) }),
     query: t.Composite([
@@ -102,46 +96,29 @@ const readDecisionBySlug = createSafePublicHandler(
       }),
     ]),
   },
-  async function* ({ params: { slug }, query: { citationsCursor, language } }) {
-    const response = yield* Result.await(
-      Result.tryPromise(
-        async () =>
-          await readDecisionBySlugWithDocumentHandler({
-            slug,
-            caseLawDb: caseLawPublicReadDb,
-            citationsCursor,
-            language,
-            caller: "anonymous",
-          }),
-      ),
-    );
-
-    return Result.ok(response);
-  },
-);
+  caseLawDb: caseLawPublicReadDb,
+  locate: ({ params: { slug }, query: { language } }) => ({
+    kind: "slug",
+    slug,
+    language,
+  }),
+  read: async (subject, { query: { citationsCursor } }) =>
+    await readDecisionHandler({ subject, citationsCursor }),
+  followUp: async (read) => await hydrateDeferredDocument(read, false),
+});
 
 /** Provision references of a decision. */
-const listDecisionProvisions = createSafePublicHandler(
-  {
+const listDecisionProvisions = createSafePublicSubjectHandler({
+  config: {
     mcp: { type: "internal", reason: "public_indexing" },
     params: t.Object({ decisionId: tSafeId("caseLawDecision") }),
     query: listDecisionProvisionsQuerySchema,
   },
-  async function* ({ params: { decisionId }, query }) {
-    const response = yield* Result.await(
-      Result.tryPromise(
-        async () =>
-          await listDecisionProvisionsHandler({
-            decisionId,
-            query,
-            caseLawDb: caseLawPublicReadDb,
-          }),
-      ),
-    );
-
-    return Result.ok(response);
-  },
-);
+  caseLawDb: caseLawPublicReadDb,
+  locate: ({ params: { decisionId } }) => ({ kind: "id", id: decisionId }),
+  read: async (subject, { query }) =>
+    await listDecisionProvisionsHandler({ subject, query }),
+});
 
 /** Decisions citing a provision. */
 const listCitingDecisions = createSafePublicHandler(

--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-projection-contract.test.ts
@@ -4,7 +4,8 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { BoeSearchResponse } from "@stll/boe";
 
 import type { ScopedDb } from "@/api/db/safe-db";
-import type { readDecisionWithDocumentHandler } from "@/api/handlers/case-law/decisions/get-deferred-document";
+import type { readGatedDecisionWithDocument } from "@/api/handlers/case-law/decisions/get-deferred-document";
+import * as publicSubject from "@/api/handlers/case-law/decisions/public-subject";
 import type { searchDecisionsHandler } from "@/api/handlers/case-law/decisions/search";
 import { resolveToolWorkspaceIds } from "@/api/handlers/chat/tools/authorized-workspace-ids";
 import type { readWorkspaceHandler } from "@/api/handlers/workspaces/get";
@@ -72,7 +73,8 @@ const describeStoredTemplateMock = mock();
 const searchProviderSearchMock = mock();
 const decryptContentMock = mock(async () => "decrypted text");
 const searchDecisionsHandlerMock = mock();
-const readDecisionWithDocumentHandlerMock = mock();
+const readGatedDecisionWithDocumentMock = mock();
+const withRedistributableSubjectMock = mock();
 const searchConsolidatedLegislationMock = mock();
 const getLawTextBlockMock = mock();
 const executeRegistryLookupMock = mock();
@@ -119,9 +121,25 @@ void mock.module(
   "@/api/handlers/case-law/decisions/get-deferred-document",
   () => ({
     ...realCaseLawGetDeferred,
-    readDecisionWithDocumentHandler: readDecisionWithDocumentHandlerMock,
+    readGatedDecisionWithDocument: readGatedDecisionWithDocumentMock,
   }),
 );
+// The case-law read tool gates the subject before it reads, so the corpus
+// stands in for that lookup too; the fixture payload still comes from the
+// handler double above. Every export is declared rather than spread: the
+// module builds the public route handlers at import time, and the
+// `...(await import(SPEC))` idiom deadlocks on it.
+void mock.module("@/api/handlers/case-law/decisions/public-subject", () => ({
+  DECISION_NOT_FOUND: publicSubject.DECISION_NOT_FOUND,
+  createSafePublicSubjectHandler: publicSubject.createSafePublicSubjectHandler,
+  createSafePublicSubjectFollowUpHandler:
+    publicSubject.createSafePublicSubjectFollowUpHandler,
+  isSubjectGatedHandler: publicSubject.isSubjectGatedHandler,
+  normalizePublicDecisionLanguage:
+    publicSubject.normalizePublicDecisionLanguage,
+  subjectGatedHandlers: publicSubject.subjectGatedHandlers,
+  withRedistributableSubject: withRedistributableSubjectMock,
+}));
 void mock.module("@stll/boe", () => ({
   ...realBoe,
   searchConsolidatedLegislation: searchConsolidatedLegislationMock,
@@ -1209,7 +1227,7 @@ const CONTRACT_CORPUS = {
       mode: "read",
       buildArgs: () => ({ decision_id: uid(54) }),
       setup: () => {
-        readDecisionWithDocumentHandlerMock.mockResolvedValue({
+        readGatedDecisionWithDocumentMock.mockResolvedValue({
           documentPending: false,
           documentReadFailed: false,
           documentUnavailable: false,
@@ -1256,9 +1274,7 @@ const CONTRACT_CORPUS = {
           sourceUrl: "https://example.test/decision",
           createdAt: new Date("2020-05-01T00:00:00.000Z"),
           updatedAt: new Date("2020-05-01T00:00:00.000Z"),
-        } satisfies Awaited<
-          ReturnType<typeof readDecisionWithDocumentHandler>
-        >);
+        } satisfies Awaited<ReturnType<typeof readGatedDecisionWithDocument>>);
       },
       expectRefPaths: [],
     },
@@ -1407,7 +1423,7 @@ const ALL_MOCKS = [
   describeStoredTemplateMock,
   searchProviderSearchMock,
   searchDecisionsHandlerMock,
-  readDecisionWithDocumentHandlerMock,
+  readGatedDecisionWithDocumentMock,
   searchConsolidatedLegislationMock,
   getLawTextBlockMock,
   executeRegistryLookupMock,
@@ -1420,6 +1436,17 @@ beforeEach(() => {
   }
   decryptContentMock.mockReset();
   decryptContentMock.mockResolvedValue("decrypted text");
+  withRedistributableSubjectMock.mockReset();
+  // The gate's own behaviour is covered by `public-subject.db.test.ts`; here
+  // it stands in as "this id passed the gate" so the projection is reachable
+  // without a database.
+  withRedistributableSubjectMock.mockImplementation(
+    async (
+      _db: unknown,
+      locator: { kind: "id"; id: string },
+      read: (subject: { id: string }) => Promise<unknown>,
+    ) => await read({ id: locator.id }),
+  );
 });
 
 describe("registry projection contract", () => {

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -1142,9 +1142,20 @@ export type PublicHandlerConfig = InputSchema &
     mcp: McpExposure;
   };
 
-type PublicHandlerContext<
+export type PublicHandlerContext<
   TConfig extends PublicHandlerConfig = PublicHandlerConfig,
 > = Context<UnwrapRoute<Omit<TConfig, "mcp" | "description" | "access">>>;
+
+/**
+ * Handlers this factory produced. A public route census asserts that every
+ * mounted handler is in here, which a naming convention cannot guarantee:
+ * a raw function passed to `.get()` reads the same at the call site.
+ */
+const safePublicHandlers = new WeakSet<object>();
+
+/** Whether a mounted route handler came out of `createSafePublicHandler`. */
+export const isSafePublicHandler = (handler: unknown): boolean =>
+  typeof handler === "function" && safePublicHandlers.has(handler);
 
 /**
  * For unauthenticated routes that intentionally expose public data.
@@ -1157,8 +1168,11 @@ export const createSafePublicHandler = <
 >(
   config: TConfig,
   handler: SafeHandlerFn<PublicHandlerContext<TConfig>, TResult>,
-): SafeHandlerDefinition<TConfig, PublicHandlerContext<TConfig>, TResult> =>
-  createSafeDirectHandler(config, handler);
+): SafeHandlerDefinition<TConfig, PublicHandlerContext<TConfig>, TResult> => {
+  const definition = createSafeDirectHandler(config, handler);
+  safePublicHandlers.add(definition.handler);
+  return definition;
+};
 
 type LogAndCaptureSafeErrorProps = {
   request: Request;

--- a/apps/api/src/lib/case-law-public-read-db.ts
+++ b/apps/api/src/lib/case-law-public-read-db.ts
@@ -32,8 +32,21 @@ export type CaseLawPublicReadTransaction = Pick<
   query: Pick<Transaction["query"], CaseLawQueryKey>;
 };
 
+/**
+ * How much of one state a transaction sees.
+ *
+ * `repeatable-read` pins every statement to the snapshot the first one took,
+ * so a decision gated at the start cannot have its content read out of a
+ * later, different state; the redistribution gate depends on it. Reads that
+ * answer from a single statement do not need it and do not pay for it.
+ */
+export type CaseLawReadIsolation = "read-committed" | "repeatable-read";
+
+export type CaseLawReadOptions = { isolation?: CaseLawReadIsolation };
+
 export type CaseLawPublicReadDb = (<T>(
   fn: (tx: CaseLawPublicReadTransaction) => Promise<T>,
+  options?: CaseLawReadOptions,
 ) => Promise<T>) & {
   [CASE_LAW_PUBLIC_READ_DB]: true;
 };
@@ -167,10 +180,26 @@ const validateExternalCaseLawDatabase = async (
   assertCaseLawDatabaseRolePermissions(permissions);
 };
 
+/**
+ * The isolation statement, first in the transaction so it binds the snapshot
+ * before any read takes one.
+ */
+const beginReadTransaction = async (
+  tx: Pick<Transaction, "execute">,
+  isolation: CaseLawReadIsolation,
+): Promise<void> => {
+  await tx.execute(
+    isolation === "repeatable-read"
+      ? sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`
+      : sql`SET TRANSACTION READ ONLY`,
+  );
+};
+
 const configureExternalReadTransaction = async (
   tx: Transaction,
+  isolation: CaseLawReadIsolation = "read-committed",
 ): Promise<void> => {
-  await tx.execute(sql`SET TRANSACTION READ ONLY`);
+  await beginReadTransaction(tx, isolation);
   await tx.execute(sql`SET LOCAL statement_timeout = '30s'`);
   await tx.execute(sql`SET LOCAL lock_timeout = '1s'`);
   await tx.execute(sql`SET LOCAL idle_in_transaction_session_timeout = '30s'`);
@@ -256,13 +285,15 @@ const getCaseLawDatabase = async (): Promise<typeof rootDb> => {
 export const caseLawPublicReadDb: CaseLawPublicReadDb = Object.assign(
   async <T>(
     fn: (tx: CaseLawPublicReadTransaction) => Promise<T>,
+    options?: CaseLawReadOptions,
   ): Promise<T> => {
+    const isolation = options?.isolation ?? "read-committed";
     const database = await getCaseLawDatabase();
     return await database.transaction(async (tx) => {
       if (envBase.CASE_LAW_DATABASE_URL !== undefined) {
-        await configureExternalReadTransaction(tx);
+        await configureExternalReadTransaction(tx, isolation);
       } else {
-        await tx.execute(sql`SET TRANSACTION READ ONLY`);
+        await beginReadTransaction(tx, isolation);
       }
 
       return await fn(tx);

--- a/apps/api/src/lib/chat/projections.ts
+++ b/apps/api/src/lib/chat/projections.ts
@@ -1192,7 +1192,7 @@ export const SEARCH_CASE_LAW_PROJECTION = v.strictObject({
 
 /**
  * read_case_law_decision. Source of truth: `handleReadCaseLawDecisionTool`
- * (`stella-tools.ts`) mapping `readDecisionWithDocumentHandler`. All ids are
+ * (`stella-tools.ts`) mapping `readGatedDecisionWithDocument`. All ids are
  * public case-law corpus ids (decision, citation, source). `metadata` is
  * free-form public jsonb straight from the court source and cannot be
  * enumerated by path (same unenumerable-payload caveat as `list_audit_log`'s

--- a/apps/api/src/mcp/onboarding.test.ts
+++ b/apps/api/src/mcp/onboarding.test.ts
@@ -28,8 +28,8 @@ void mock.module("@/api/handlers/case-law/decisions/search", () => ({
 void mock.module(
   "@/api/handlers/case-law/decisions/get-deferred-document",
   () => ({
-    readDecisionBySlugWithDocumentHandler: mock(),
-    readDecisionWithDocumentHandler: readDecisionHandlerMock,
+    hydrateDeferredDocument: async (read: unknown) => read,
+    readGatedDecisionWithDocument: readDecisionHandlerMock,
   }),
 );
 

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -15,7 +15,7 @@ import type {
   ContactPhone,
   FieldContent,
 } from "@/api/db/schema-validators";
-import { readDecisionWithDocumentHandler } from "@/api/handlers/case-law/decisions/get-deferred-document";
+import { readGatedDecisionWithDocument } from "@/api/handlers/case-law/decisions/get-deferred-document";
 import { searchDecisionsHandler } from "@/api/handlers/case-law/decisions/search";
 import { parseUsableDocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
@@ -1202,12 +1202,12 @@ const isSearchCaseLawSuccess = (
   typeof value === "object" && "hits" in value && Array.isArray(value.hits);
 
 type ReadCaseLawDecisionSuccess = Extract<
-  Awaited<ReturnType<typeof readDecisionWithDocumentHandler>>,
+  NonNullable<Awaited<ReturnType<typeof readGatedDecisionWithDocument>>>,
   { caseNumber: string; citationsFrom: unknown[]; citationsTo: unknown[] }
 >;
 
 const isReadCaseLawDecisionSuccess = (
-  value: Awaited<ReturnType<typeof readDecisionWithDocumentHandler>>,
+  value: NonNullable<Awaited<ReturnType<typeof readGatedDecisionWithDocument>>>,
 ): value is ReadCaseLawDecisionSuccess =>
   typeof value === "object" &&
   "caseNumber" in value &&
@@ -1760,14 +1760,20 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
     });
   }
 
-  const result = await readDecisionWithDocumentHandler({
-    decisionId: brandPersistedCaseLawDecisionId(decisionId),
+  // The same gate the public route applies, in the same shape: a
+  // restricted decision does not exist for any caller, and the read that
+  // answers shares the transaction that approved it.
+  const result = await readGatedDecisionWithDocument({
     caseLawDb: caseLawPublicReadDb,
+    locator: { kind: "id", id: brandPersistedCaseLawDecisionId(decisionId) },
     citationsCursor: offsets.citations,
     // An agent holding a token is a reader we can attribute, so its
     // interest counts as demand.
     caller: "attributed",
   });
+  if (result === null) {
+    return notFoundResult("Decision not found");
+  }
   const resultMessage = getResultMessage(result);
   if (resultMessage) {
     return errorResult(resultMessage);

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -3,6 +3,9 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import JSZip from "jszip";
 
 import { env } from "@/api/env";
+// Imported for the double below: only the resolver is replaced, and the rest
+// of the module keeps its real behaviour rather than being dropped.
+import * as publicSubject from "@/api/handlers/case-law/decisions/public-subject";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
@@ -142,6 +145,10 @@ const searchProviderSearchMock = mock(
 );
 const searchDecisionsHandlerMock = mock();
 const readDecisionHandlerMock = mock();
+/** The gate-and-read the tool calls; null is a denied or missing subject. */
+const readGatedDecisionMock = mock();
+/** The subject gate: passes whatever id it is given as redistributable. */
+const withRedistributableSubjectMock = mock();
 const APP_BASE_URL = env.FRONTEND_URL.replace(/\/$/u, "");
 
 type AnonymizationBlacklistEntryInput = {
@@ -234,10 +241,27 @@ void mock.module("@/api/handlers/case-law/decisions/search", () => ({
 void mock.module(
   "@/api/handlers/case-law/decisions/get-deferred-document",
   () => ({
-    readDecisionBySlugWithDocumentHandler: mock(),
-    readDecisionWithDocumentHandler: readDecisionHandlerMock,
+    hydrateDeferredDocument: async (read: unknown) => read,
+    readGatedDecisionWithDocument: readGatedDecisionMock,
   }),
 );
+
+// The subject gate runs before the read; the double stands in for the
+// database lookup and hands back the id as an already-gated subject.
+// Every export is declared: the module builds the public routes at import
+// time, so dropping the factory here would leave them unhandled, and the
+// spread idiom deadlocks on a module that imports the handler factories.
+void mock.module("@/api/handlers/case-law/decisions/public-subject", () => ({
+  DECISION_NOT_FOUND: publicSubject.DECISION_NOT_FOUND,
+  createSafePublicSubjectHandler: publicSubject.createSafePublicSubjectHandler,
+  createSafePublicSubjectFollowUpHandler:
+    publicSubject.createSafePublicSubjectFollowUpHandler,
+  isSubjectGatedHandler: publicSubject.isSubjectGatedHandler,
+  normalizePublicDecisionLanguage:
+    publicSubject.normalizePublicDecisionLanguage,
+  withRedistributableSubject: withRedistributableSubjectMock,
+  subjectGatedHandlers: publicSubject.subjectGatedHandlers,
+}));
 
 void mock.module("@/api/handlers/workspaces/get", () => ({
   readWorkspaceHandler: mock(),
@@ -741,6 +765,21 @@ describe("OpenAI-compatible MCP tools", () => {
     decryptContentMock.mockResolvedValue("Full document text");
     searchDecisionsHandlerMock.mockReset();
     readDecisionHandlerMock.mockReset();
+    readGatedDecisionMock.mockReset();
+    // The gate passes by default and the read answers; a denied subject is
+    // set up per test by resolving the gate to null.
+    readGatedDecisionMock.mockImplementation(
+      async ({ locator, ...rest }: { locator: { kind: "id"; id: string } }) =>
+        await readDecisionHandlerMock({ subject: { id: locator.id }, ...rest }),
+    );
+    withRedistributableSubjectMock.mockReset();
+    withRedistributableSubjectMock.mockImplementation(
+      async (
+        _db: unknown,
+        locator: { kind: "id"; id: string },
+        read: (subject: { id: string }) => Promise<unknown>,
+      ) => await read({ id: locator.id }),
+    );
     s3FileMock.mockClear();
     s3ArrayBufferMock.mockClear();
     withTimeoutMock.mockClear();
@@ -1441,8 +1480,10 @@ describe("OpenAI-compatible MCP tools", () => {
 
     // An agent read is attributable, so it may queue demand for a
     // decision whose document has not been fetched yet.
-    expect(readDecisionHandlerMock).toHaveBeenCalledWith({
-      decisionId: "dec_123",
+    // The gate and the read are one call, so the tool names the decision
+    // by locator and never holds an ungated id.
+    expect(readGatedDecisionMock).toHaveBeenCalledWith({
+      locator: { kind: "id", id: "dec_123" },
       caseLawDb: caseLawPublicReadDb,
       caller: "attributed",
       citationsCursor: undefined,
@@ -1477,6 +1518,40 @@ describe("OpenAI-compatible MCP tools", () => {
         truncated: false,
       },
     });
+  });
+
+  test("read_case_law_decision answers not found for a subject the gate denies", async () => {
+    // A restricted or missing decision does not exist for any caller, and
+    // the reader must not run for it: the gate answers before there is
+    // anything to read.
+    readGatedDecisionMock.mockImplementation(
+      async ({
+        caseLawDb,
+        locator,
+      }: {
+        caseLawDb: unknown;
+        locator: { kind: "id"; id: string };
+      }) =>
+        await withRedistributableSubjectMock(
+          caseLawDb,
+          locator,
+          async (subject: { id: string }) =>
+            await readDecisionHandlerMock({ subject }),
+        ),
+    );
+    withRedistributableSubjectMock.mockResolvedValue(null);
+
+    const result = await handleMcpToolCall({
+      args: { decision_id: "dec_123" },
+      context: createContext(),
+      toolName: "read_case_law_decision",
+    });
+
+    expectErrorEnvelope(result, {
+      code: "not_found",
+      message: "Decision not found",
+    });
+    expect(readDecisionHandlerMock).not.toHaveBeenCalled();
   });
 
   test("read_case_law_decision withholds text when the source bars AI use", async () => {
@@ -1608,8 +1683,8 @@ describe("OpenAI-compatible MCP tools", () => {
     expect(page2.decision.citationsTo.at(0)?.id).toBe("ct_50");
     expect(page2.decision.text).toBeNull();
     expect(page2.nextCursor).toBeNull();
-    expect(readDecisionHandlerMock).toHaveBeenLastCalledWith({
-      decisionId: "dec_123",
+    expect(readGatedDecisionMock).toHaveBeenLastCalledWith({
+      locator: { kind: "id", id: "dec_123" },
       caseLawDb: caseLawPublicReadDb,
       caller: "attributed",
       citationsCursor: "citations-next",

--- a/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
+++ b/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import nodePath from "node:path";
 
 import type { ScopedDb } from "@/api/db/safe-db";
+import { publicCaseLawRoute } from "@/api/handlers/case-law/public-routes";
+import { isSafePublicHandler } from "@/api/lib/api-handlers";
 import type {
   CaseLawPublicReadDb,
   CaseLawPublicReadTransaction,
@@ -18,6 +20,8 @@ void scopedDbIsPublicReadDb;
 const ROUTES_FILE = "apps/api/src/handlers/case-law/public-routes.ts";
 const LIST_DECISIONS_FILE = "apps/api/src/handlers/case-law/decisions/list.ts";
 const READ_DECISION_FILE = "apps/api/src/handlers/case-law/decisions/get.ts";
+const PUBLIC_SUBJECT_FILE =
+  "apps/api/src/handlers/case-law/decisions/public-subject.ts";
 const DEFERRED_DOCUMENT_FILE =
   "apps/api/src/handlers/case-law/decisions/get-deferred-document.ts";
 const FACETS_DECISIONS_FILE =
@@ -46,6 +50,29 @@ const DECISION_PROVISIONS_FILE =
 const CITING_DECISIONS_FILE =
   "apps/api/src/handlers/case-law/provisions/citing-decisions.ts";
 
+/**
+ * Every route this slice mounts, sorted.
+ *
+ * The factory census below filters Elysia's internal entries out before it
+ * asks which handlers carry the stamp. Pinning the surviving set here is what
+ * stops that filter from excusing the census: a filter that dropped real
+ * routes, or a route that quietly disappeared, fails this list rather than
+ * passing an empty check.
+ */
+const PUBLIC_CASE_LAW_ROUTES = [
+  "GET /case/decisions",
+  "GET /case/decisions/:decisionId",
+  "GET /case/decisions/:decisionId/citations",
+  "GET /case/decisions/:decisionId/citations/summary",
+  "GET /case/decisions/:decisionId/provisions",
+  "GET /case/decisions/by-slug/:slug",
+  "GET /case/decisions/facets",
+  "GET /case/provisions/citing-decisions",
+  "GET /case/sitemap/decisions/shard",
+  "GET /case/sitemap/shards",
+  "POST /case/decisions/search",
+] as const;
+
 const repoRoot = nodePath.resolve(import.meta.dir, "../../../../..");
 const readSource = async (path: string) =>
   await Bun.file(nodePath.resolve(repoRoot, path)).text();
@@ -53,6 +80,8 @@ const readSource = async (path: string) =>
 const readRoutesSource = async () => await readSource(ROUTES_FILE);
 const readListSource = async () => await readSource(LIST_DECISIONS_FILE);
 const readDecisionSource = async () => await readSource(READ_DECISION_FILE);
+const readPublicSubjectSource = async () =>
+  await readSource(PUBLIC_SUBJECT_FILE);
 const readDeferredDocumentSource = async () =>
   await readSource(DEFERRED_DOCUMENT_FILE);
 const readFacetsSource = async () => await readSource(FACETS_DECISIONS_FILE);
@@ -172,30 +201,27 @@ describe("public case-law route boundary", () => {
     expect(block).not.toContain("permissions:");
   });
 
-  test("public read handlers use the public-safe handler factory", async () => {
-    const source = await readRoutesSource();
+  test("public read handlers use the public-safe handler factory", () => {
+    // Was a grep for nine `const x = createSafePublicHandler` lines, which
+    // could not see a tenth route or a handler renamed around it. The factory
+    // now stamps what it produces, so the census covers every mounted route
+    // and cannot be satisfied by naming.
+    //
+    // Elysia mounts internal entries (HEAD, error pages) whose handler is not
+    // one of ours; they carry no stamp and would read as ungoverned. The
+    // filter below drops them, and the path census that follows keeps the
+    // filter from becoming the escape hatch: dropping everything fails there.
+    const declared = publicCaseLawRoute.routes.filter(
+      (route) => typeof route.handler === "function",
+    );
+    const ungoverned = declared
+      .filter((route) => !isSafePublicHandler(route.handler))
+      .map((route) => `${route.method} ${route.path}`);
 
-    expect(source).toContain("const listDecisions = createSafePublicHandler");
-    expect(source).toContain(
-      "const listDecisionFacets = createSafePublicHandler",
-    );
-    expect(source).toContain("const readDecision = createSafePublicHandler");
-    expect(source).toContain(
-      "const readDecisionBySlug = createSafePublicHandler",
-    );
-    expect(source).toContain("const searchDecisions = createSafePublicHandler");
-    expect(source).toContain(
-      "const listSitemapShardDecisions = createSafePublicHandler",
-    );
-    expect(source).toContain(
-      "const listSitemapShards = createSafePublicHandler",
-    );
-    expect(source).toContain(
-      "const listDecisionProvisions = createSafePublicHandler",
-    );
-    expect(source).toContain(
-      "const listCitingDecisions = createSafePublicHandler",
-    );
+    expect(ungoverned).toEqual([]);
+    expect(
+      declared.map((route) => `${route.method} ${route.path}`).sort(),
+    ).toEqual([...PUBLIC_CASE_LAW_ROUTES]);
   });
 
   test("public decision payload does not expose persisted AI analysis", async () => {
@@ -206,17 +232,24 @@ describe("public case-law route boundary", () => {
   });
 
   test("public decision payload is an explicit allowlist", async () => {
-    const source = await readDecisionSource();
+    const [source, subjectSource] = await Promise.all([
+      readDecisionSource(),
+      readPublicSubjectSource(),
+    ]);
 
     expect(source).not.toContain("...decision");
     expect(source).toContain("id: decision.id");
     expect(source).toContain("caseNumber: decision.caseNumber");
     expect(source).toContain("slug: decision.slug");
     expect(source).toContain("languageAlternates,");
-    expect(source).toContain("normalizePublicDecisionLanguage");
-    expect(source).toContain("replace(lower(");
     expect(source).toContain("caseLawDecisions.language");
     expect(source).toContain("fulltext,");
+    // Slug lookup and its language matching moved into the gate module, which
+    // resolves every subject. Both halves of the normalisation are pinned
+    // here; `public-subject.db.test.ts` drives them against Postgres.
+    expect(subjectSource).toContain("normalizePublicDecisionLanguage");
+    expect(subjectSource).toContain("replace(lower(");
+    expect(subjectSource).toContain("'_', '-'");
   });
 
   test("public facets payload is aggregate public data only", async () => {
@@ -337,7 +370,15 @@ describe("public case-law route boundary", () => {
 
     expect(listSource).toContain("redistributableCaseLawSource");
     expect(decisionSource).toContain("redistributableCaseLawSource");
-    expect(decisionSource).toContain("isRedistributable");
+    // The per-subject gate moved out of the handler and into the factory that
+    // mints its subject, so it is enforced for every subject route at once;
+    // `public-subject.test.ts` censuses those routes in both directions.
+    // The call, not the import: a gate reduced to an unused import still reads
+    // as present. `public-subject.db.test.ts` drives a restricted subject to
+    // 404 for the behaviour itself.
+    expect(await readPublicSubjectSource()).toContain(
+      "!isRedistributable(row.descriptor)",
+    );
     expect(pgFtsFacetsSource).toContain("redistributableCaseLawSource");
     // The corpus-index facets aggregate the index rather than the table, so
     // the gate is two-sided. Projection keeps ineligible sources out of the
@@ -367,7 +408,14 @@ describe("public case-law route boundary", () => {
       [readSource(DECISION_PROVISIONS_FILE), readSource(CITING_DECISIONS_FILE)],
     );
 
-    expect(decisionProvisionsSource).toContain("redistributableCaseLawSource");
+    // Provisions read one decision's rows, so the gate is the subject they
+    // require rather than a join they must remember: the handler cannot be
+    // called with a bare id. Citing decisions still span sources and keep
+    // their per-row join.
+    expect(decisionProvisionsSource).toContain(
+      "subject: RedistributableDecisionSubject",
+    );
+    expect(decisionProvisionsSource).not.toContain("decisionId: SafeId");
     expect(citingDecisionsSource).toContain("redistributableCaseLawSource");
   });
 });

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -585,6 +585,10 @@
     "count": 0,
     "files": {}
   },
+  "ad-hoc-decision-subject-gates": {
+    "count": 0,
+    "files": {}
+  },
   "lib-to-handler-imports": {
     "count": 0,
     "files": {}

--- a/scripts/ratchet.ts
+++ b/scripts/ratchet.ts
@@ -477,6 +477,38 @@ const countInlineTimestampCursorSql = (content: string): number =>
     /YYYY-MM-DD"T"HH24:MI:SS\.US(?!"Z")|::\s*timestamp\s+AT\s+TIME\s+ZONE\s*['"]UTC['"]/giu,
   );
 
+/**
+ * Direct `isRedistributable(x)` calls, counted from the syntax tree.
+ *
+ * A text scan cannot tell a call from a mention: it counts the word inside a
+ * comment explaining the gate, inside a string, and `source.isRedistributable(...)`
+ * on some unrelated object. This counts a call whose callee is the bare
+ * identifier — the shape the gate replaced — and nothing else.
+ */
+const countDirectRedistributableCalls = (content: string): number => {
+  const sourceFile = ts.createSourceFile(
+    "ratchet-source.ts",
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  let total = 0;
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "isRedistributable"
+    ) {
+      total += 1;
+    }
+    node.forEachChild(visit);
+  };
+  visit(sourceFile);
+  return total;
+};
+
 const countRepeatedTimestampCursorBoundaries = (content: string): number => {
   const code = stripComments(content);
   const sourceFile = ts.createSourceFile(
@@ -1310,6 +1342,18 @@ const RATCHET_METRICS: readonly RatchetMetric[] = [
     include: ["apps/api/src/handlers/**/*.ts"],
     exclude: isExcludedSource,
     count: countCrossSliceImports(crossesHandlerDomain),
+  },
+  {
+    id: "ad-hoc-decision-subject-gates",
+    description:
+      "direct `isRedistributable(` calls in public case-law decision/provision handlers. The subject gate lives in `decisions/public-subject.ts` and reaches handlers as a branded subject; a handler re-checking it by hand is the pattern that let two endpoints ship ungated. Stays at 0",
+    include: [
+      "apps/api/src/handlers/case-law/decisions/**/*.ts",
+      "apps/api/src/handlers/case-law/provisions/**/*.ts",
+    ],
+    exclude: (file) =>
+      isExcludedSource(file) || file.endsWith("/decisions/public-subject.ts"),
+    count: countDirectRedistributableCalls,
   },
   {
     id: "lib-to-handler-imports",
@@ -2263,6 +2307,22 @@ const SELF_TEST_WORKSPACE_ONLY_RLS = `${WORKSPACE_ONLY_RLS_FIXTURE_LINES.join("\
 // last one proving the comment strip runs before the scan.
 const EXPECTED_WORKSPACE_ONLY_RLS = 2;
 
+const AD_HOC_SUBJECT_GATE_FIXTURE_LINES = [
+  'import { isRedistributable } from "@/api/lib/legal-search/corpus-source";',
+  "export const read = async (row: Row) => {",
+  "  if (!isRedistributable(row.descriptor)) {",
+  "    return null;",
+  "  }",
+  "  return row;",
+  "};",
+];
+const SELF_TEST_AD_HOC_SUBJECT_GATE = `${AD_HOC_SUBJECT_GATE_FIXTURE_LINES.join("\n")}\n`;
+// Expected: one call from the decisions fixture and one from the provisions
+// fixture, so both `include` globs are exercised rather than only the first.
+// The gate module's own call is excluded, which is the exclusion's whole job:
+// counting it would make the metric un-zeroable and the guard meaningless.
+const EXPECTED_AD_HOC_SUBJECT_GATES = 2;
+
 const writeFixture = (root: string, rel: string, content: string): void => {
   const full = path.join(root, rel);
   mkdirSync(path.dirname(full), { recursive: true });
@@ -2535,6 +2595,23 @@ const runSelfTest = (): number => {
       "apps/api/src/mcp/generated/capability-catalog.json",
       SELF_TEST_CAPABILITY_CATALOG,
     );
+    // Both handler globs the subject-gate metric covers, plus the gate module
+    // itself, so the exclusion is exercised rather than assumed.
+    writeFixture(
+      root,
+      "apps/api/src/handlers/case-law/decisions/ad-hoc.ts",
+      SELF_TEST_AD_HOC_SUBJECT_GATE,
+    );
+    writeFixture(
+      root,
+      "apps/api/src/handlers/case-law/provisions/ad-hoc.ts",
+      SELF_TEST_AD_HOC_SUBJECT_GATE,
+    );
+    writeFixture(
+      root,
+      "apps/api/src/handlers/case-law/decisions/public-subject.ts",
+      SELF_TEST_AD_HOC_SUBJECT_GATE,
+    );
     writeFixture(root, "apps/api/src/db/index.ts", "export const x = 1;\n");
     writeFixture(root, "apps/web/src/lib/index.tsx", "export const y = 2;\n");
     // Excluded companions: these must NOT be counted.
@@ -2574,6 +2651,32 @@ const runSelfTest = (): number => {
     if (legacyRealtimeMetric.count !== EXPECTED_LEGACY_REALTIME_INVALIDATIONS) {
       failures.push(
         `legacy-realtime-invalidation-producers counted ${legacyRealtimeMetric.count}, expected ${EXPECTED_LEGACY_REALTIME_INVALIDATIONS}`,
+      );
+    }
+
+    const adHocSubjectGateMetric = requireSnapshot(
+      snapshot,
+      "ad-hoc-decision-subject-gates",
+    );
+    if (adHocSubjectGateMetric.count !== EXPECTED_AD_HOC_SUBJECT_GATES) {
+      failures.push(
+        `ad-hoc-decision-subject-gates counted ${adHocSubjectGateMetric.count}, expected ${EXPECTED_AD_HOC_SUBJECT_GATES}`,
+      );
+    }
+    for (const glob of [
+      "apps/api/src/handlers/case-law/decisions/ad-hoc.ts",
+      "apps/api/src/handlers/case-law/provisions/ad-hoc.ts",
+    ]) {
+      if (!(glob in adHocSubjectGateMetric.files)) {
+        failures.push(`ad-hoc-decision-subject-gates did not scan ${glob}`);
+      }
+    }
+    if (
+      "apps/api/src/handlers/case-law/decisions/public-subject.ts" in
+      adHocSubjectGateMetric.files
+    ) {
+      failures.push(
+        "ad-hoc-decision-subject-gates did not exclude the gate module",
       );
     }
 
@@ -2820,6 +2923,37 @@ const runSelfTest = (): number => {
       failures.push(
         `workspace-only-rls-on-org-tables counted ${workspaceOnlyRlsMetric.count}, expected ${EXPECTED_WORKSPACE_ONLY_RLS}`,
       );
+    }
+
+    // The subject-gate counter reads calls, not text: a mention in a comment
+    // or a string, and a method of the same name on some object, are not the
+    // hand-rolled gate the metric is holding at zero.
+    const redistributableCases = [
+      {
+        code: "if (!isRedistributable(row.descriptor)) return null;",
+        expected: 1,
+      },
+      {
+        code: "// isRedistributable(row) used to live here\nconst a = 1;",
+        expected: 0,
+      },
+      {
+        code: 'const message = "call isRedistributable(x) instead";',
+        expected: 0,
+      },
+      { code: "if (source.isRedistributable(row)) return row;", expected: 0 },
+      {
+        code: "isRedistributable(a); isRedistributable(b);",
+        expected: 2,
+      },
+    ];
+    for (const { code, expected } of redistributableCases) {
+      const counted = countDirectRedistributableCalls(code);
+      if (counted !== expected) {
+        failures.push(
+          `ad-hoc-decision-subject-gates counted ${counted}, expected ${expected}, for: ${code.replaceAll("\n", " ")}`,
+        );
+      }
     }
 
     // Diff behavior: equal passes, a rise regresses, a fall is a drop.

--- a/scripts/typecheck-baseline.json
+++ b/scripts/typecheck-baseline.json
@@ -1,11 +1,11 @@
 {
   "api": {
-    "types": 1138206,
-    "instantiations": 6109017
+    "types": 1197275,
+    "instantiations": 6388447
   },
   "web": {
-    "types": 1447880,
-    "instantiations": 10992290
+    "types": 1503635,
+    "instantiations": 11310045
   },
   "web-e2e": {
     "types": 28709,


### PR DESCRIPTION
## Summary

A public endpoint naming a decision must answer 404 when that decision's source may not be redistributed. Every handler re-checked this by hand, and two recent ones shipped without it.

The check now lives in one place: a factory resolves the subject and hands the handler a branded `RedistributableDecisionSubject`, which nothing else can construct, so a read that takes a bare id no longer typechecks against the routes. `readDecision`, `readDecisionBySlug`, the citation list and summary, the deferred document read and the decision provisions all go through it, as does the MCP tool.

## Testing

- Route census: every route naming a subject mounts a factory-made handler, and every factory-made handler is mounted (both directions).
- Database test: restricted, missing and malformed-language subjects answer 404 by id and by slug.
- Ratchet: direct redistribution checks in the decision handlers held at zero.
- Mutation: removing the factory from one handler fails the census.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added central access checks for public case-law decisions, including ID- and slug-based lookups.
  - Restricted, missing, or invalid-language decisions now return a not-found response.
  - Updated decision, citation, provision, document, and MCP reads to use verified public subjects.
  - Added support for safely identifying and enforcing protected public routes.

- **Bug Fixes**
  - Prevented restricted case-law content from being exposed through related endpoints.

- **Tests**
  - Added comprehensive coverage for subject resolution, route protection, and restricted-content handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Type-cost baseline

The baseline is reseeded here, with the measurement that justifies it. It was
last written 61 commits ago; main had already grown into the allowed headroom
before this branch existed, so the failure this PR hit was accumulated drift
rather than its own cost.

| tree | api types | vs old baseline |
|---|---|---|
| old baseline | 1,138,206 | — |
| main without this PR | 1,176,031 | +3.3% |
| current main alone | ~1,193,099 | +4.8% |
| this PR merged (CI) | 1,197,275 | +5.2% |

This PR's marginal contribution is about 3,200 types (+0.27pp): the gate
factory and its branded subject. One cut was made rather than assumed: the
handler context no longer carries the subject in an intersection type, which
removed 150 types and 566 instantiations; the rest is the feature.

Worth separating from this change: the guard enforces an absolute ceiling but
attributes it to whichever pull request happens to cross it. Measuring each
change against its own merge base would put the cost where it arises.
