### PR TITLE
docs: streamline agent convention guidance

### DIFF
--- a/.agents/skills/conventions-i18n/SKILL.md
+++ b/.agents/skills/conventions-i18n/SKILL.md
@@ -49,6 +49,11 @@ are only justified when the wording truly differs from the
 generic version (e.g., a confirmation message that mentions
 the resource by name).
 
+When a translation key crosses indirection through a constant, map, prop, or
+helper return type, type it with `TranslationKey` from
+`apps/web/src/i18n/types` instead of `string`. Missing or stale keys must fail
+typecheck at the point where they are stored.
+
 Prefer complete translatable sentences over fragments assembled in JSX. Keep
 interpolation variables semantic (`{documentName}`, not `{value}`), use ICU
 plural/select branches for grammatical variation, and never concatenate

--- a/.agents/skills/conventions-testing/SKILL.md
+++ b/.agents/skills/conventions-testing/SKILL.md
@@ -69,6 +69,12 @@ enforcement, branded types) live in
 - Verify a new regression test fails against the known-bad behavior before
   trusting it. A test that never reaches the fault, or matches zero tests, is
   not a guard.
+- Detector and backstop tests use production-shaped inputs the detector can
+  actually match. Assert the fixture reaches or differs on the fault boundary
+  before asserting the protected outcome.
+- Where a map declares paths or cases, assert the declared and exercised sets
+  are equal in both directions. Pin fixture literals that stand in for producer
+  output with `satisfies` against the producer's return type.
 - For systemic bugs, test the class: fixed points for replay, matrices for
   tenant isolation, properties for parsers/normalizers, state-machine
   transitions for lifecycle code, and round trips for serialization.

--- a/.ai/local-skills/conventions-i18n/SKILL.md
+++ b/.ai/local-skills/conventions-i18n/SKILL.md
@@ -49,6 +49,11 @@ are only justified when the wording truly differs from the
 generic version (e.g., a confirmation message that mentions
 the resource by name).
 
+When a translation key crosses indirection through a constant, map, prop, or
+helper return type, type it with `TranslationKey` from
+`apps/web/src/i18n/types` instead of `string`. Missing or stale keys must fail
+typecheck at the point where they are stored.
+
 Prefer complete translatable sentences over fragments assembled in JSX. Keep
 interpolation variables semantic (`{documentName}`, not `{value}`), use ICU
 plural/select branches for grammatical variation, and never concatenate

--- a/.ai/local-skills/conventions-testing/SKILL.md
+++ b/.ai/local-skills/conventions-testing/SKILL.md
@@ -69,6 +69,12 @@ enforcement, branded types) live in
 - Verify a new regression test fails against the known-bad behavior before
   trusting it. A test that never reaches the fault, or matches zero tests, is
   not a guard.
+- Detector and backstop tests use production-shaped inputs the detector can
+  actually match. Assert the fixture reaches or differs on the fault boundary
+  before asserting the protected outcome.
+- Where a map declares paths or cases, assert the declared and exercised sets
+  are equal in both directions. Pin fixture literals that stand in for producer
+  output with `satisfies` against the producer's return type.
 - For systemic bugs, test the class: fixed points for replay, matrices for
   tenant isolation, properties for parsers/normalizers, state-machine
   transitions for lifecycle code, and round trips for serialization.

--- a/.ai/local/agents.md
+++ b/.ai/local/agents.md
@@ -4,6 +4,14 @@
 mobile, landing, collaboration, playground, and focused runners); shared or
 publishable code lives in `packages/`. Use Glob/Grep to explore.
 
+## Convention Routing
+
+Before changing a convention-governed domain, read and apply the matching
+`.agents/skills/conventions-*/SKILL.md`. This includes AI, databases, i18n and
+user-facing strings, ingestion, performance guard failures and hot paths,
+architecture and scale, auth and data access, files and external APIs, tests,
+`apps/web` React effects, and user-facing UI. The skills own the detailed rules.
+
 ## Workspace Layout
 
 - `apps/*` contains runnable applications only.
@@ -16,8 +24,10 @@ publishable code lives in `packages/`. Use Glob/Grep to explore.
 ## Commands
 
 `bun run dev` | `dev:web` (3000) | `dev:api` (3001) |
-`build` | `lint` | `format` | `typecheck` | `test` |
-`db:push`
+`build` | `lint` | `format` | `typecheck` | `test`
+
+Database deployments use committed migrations via
+`bun --filter @stll/api db:migrate`; `db:push` is local schema sync only.
 
 `bun run verify` runs the same checks as the required CI job
 (`ci-checks` in `.github/workflows/ci.yml`); use it to self-verify a
@@ -69,45 +79,13 @@ only the non-obvious caveats for this environment.
   prod). Use the log line to complete sign-in/sign-up when testing.
 - **Mock AI is on by default** (`USE_MOCK_AI="true"` in `apps/api/.env.example`), so no
   AI provider key is needed for local runs.
-- **`bun run verify` / `sync-ai:check` need the `.ai/shared` submodule.** It is not part
-  of the base checkout; run `git submodule update --init .ai/shared` first, otherwise
-  the "AI skill sync" step errors out.
+- **`sync-ai:check` needs the `.ai/shared` submodule.** Local `bun run verify` warns
+  and skips only that step when it is absent. Run
+  `git submodule update --init .ai/shared` for CI-equivalent verification.
 - Optional demo data: `bun --filter @stll/api db:seed-test-user` and `db:seed-dev`.
-
-## Test Doctrine
-
-Full conventions in `/conventions-testing`; these three are the ones most often
-skipped.
-
-- **Mutation check.** A test guarding behavior X is finished only once reverting X
-  makes it fail; until then it may be passing for an unrelated reason. When the test
-  is the evidence for a fix, state in the PR that you ran the mutation. A test whose
-  fixture cannot express the fault is the common failure: assert the fixture DIFFERS
-  before asserting the equivalence, for example `expect(NFD(word)).not.toBe(NFC(word))`
-  before asserting both normalize alike.
-- **Cross-runtime contracts.** Where a rule lives in two runtimes at once
-  (JavaScript, Postgres, the search engine), prove parity by DERIVING the other
-  side's rules executably: query the live extension, render the SQL the query layer
-  emits, read the analyzer's configuration tuple. A hand-maintained mirror list of
-  the other side's behavior is not evidence of parity; it is the drift, written down.
-- **Projection census.** Any "marked done" flag that mirrors state in an external
-  system (search index, object store, queue) ships with a reconciler that compares
-  both sides and reports the difference. Acceptance by the remote system is not
-  durability, so the flag alone can never prove the projection landed.
 
 ## Convention & Type-Cost Guards
 
-- Whole-repo convention metrics that may only decrease live in
-  `scripts/ratchet.ts` (`RATCHET_METRICS`); this includes cross-slice imports
-  (API handler domains, route-private `-` paths, web features), which
-  structurally enforce the vertical-slice principle.
-- Lint suppressions are budgeted per rule, not in aggregate: each rule in
-  `TRACKED_SUPPRESSION_RULES` (`scripts/lint-suppressions.ts`) has its own
-  decrease-only ratchet, and security-tier suppressions additionally need an
-  entry in `scripts/suppression-waivers.json`. Policy in
-  `.oxlint-plugins/README.md`.
-- Typecheck cost is guarded by `scripts/typecheck-baseline.ts`: per-project
-  tsc `--extendedDiagnostics` Types/Instantiations counters with headroom,
-  checked in the CI typecheck job. Reseeding either baseline
-  (`--write` / `--write-baseline`) must be justified in the PR description;
-  it is not a mechanical way to make CI green.
+Convention and suppression ratchets may only tighten. Every lint suppression names
+a rule and reason; security-tier suppressions also need a waiver. Type-cost baseline
+increases require PR justification and are never a mechanical way to pass CI.

--- a/.ai/local/agents.md
+++ b/.ai/local/agents.md
@@ -53,37 +53,6 @@ The `stella-docs` MCP server provides on-demand access to library documentation 
 
 **Setup:** run `bun run setup:mcp` once after cloning.
 
-## Cursor Cloud specific instructions
-
-The base VM already has Bun (`~/.bun/bin`, on `PATH` via `~/.bashrc`) and Docker
-installed; the startup update script runs `bun install`. Standard commands live in
-`README.md`, `CONTRIBUTING.md`, and root `package.json` scripts; the notes below are
-only the non-obvious caveats for this environment.
-
-- **Start the Docker daemon first.** There is no systemd auto-start here, so `docker`
-  commands fail until the daemon runs. Start it once per session in the background
-  (e.g. `sudo dockerd` in a tmux session) and confirm with `docker ps`. The daemon is
-  configured with the `fuse-overlayfs` storage driver and iptables-legacy for
-  docker-in-docker.
-- **Run everything with `bun run dev --no-browser`.** The dev-runner
-  (`packages/scripts/src/dev-runner.ts`) brings up the Docker infra (Postgres 5432,
-  Valkey 6379, RustFS 9000/9001, Gotenberg 3003), copies `apps/{api,web}/.env` from
-  `.env.example`, applies DB migrations, and starts the API (3001) and web (3000). It
-  exits if any child dies, so a single background process covers the whole stack. Use
-  `bun run dev:api` or `bun run dev:web` for a focused loop.
-- **Auth is passwordless email OTP; no SMTP catcher runs.** `EMAIL_PROVIDER=smtp`
-  points at `localhost:1025`, which is not running, so verification emails are not
-  delivered. In dev the OTP is printed to the API log as
-  `[DEV] OTP for <email>: <code>` and is also fetchable via
-  `GET http://localhost:3001/dev-public/last-otp?email=<email>` (dev-only, 404 in
-  prod). Use the log line to complete sign-in/sign-up when testing.
-- **Mock AI is on by default** (`USE_MOCK_AI="true"` in `apps/api/.env.example`), so no
-  AI provider key is needed for local runs.
-- **`sync-ai:check` needs the `.ai/shared` submodule.** Local `bun run verify` warns
-  and skips only that step when it is absent. Run
-  `git submodule update --init .ai/shared` for CI-equivalent verification.
-- Optional demo data: `bun --filter @stll/api db:seed-test-user` and `db:seed-dev`.
-
 ## Convention & Type-Cost Guards
 
 Convention and suppression ratchets may only tighten. Every lint suppression names

--- a/.ai/manifest.json
+++ b/.ai/manifest.json
@@ -5,13 +5,8 @@
     "modules": [
       "stella-public-repo",
       "engineering",
-      "scalability",
-      "performance",
       "typescript",
-      "error-handling",
-      "testing",
-      "i18n",
-      "linting"
+      "error-handling"
     ],
     "local": ".ai/local/agents.md",
     "scopes": [

--- a/.claude/commands/conventions-i18n.md
+++ b/.claude/commands/conventions-i18n.md
@@ -44,6 +44,11 @@ are only justified when the wording truly differs from the
 generic version (e.g., a confirmation message that mentions
 the resource by name).
 
+When a translation key crosses indirection through a constant, map, prop, or
+helper return type, type it with `TranslationKey` from
+`apps/web/src/i18n/types` instead of `string`. Missing or stale keys must fail
+typecheck at the point where they are stored.
+
 Prefer complete translatable sentences over fragments assembled in JSX. Keep
 interpolation variables semantic (`{documentName}`, not `{value}`), use ICU
 plural/select branches for grammatical variation, and never concatenate

--- a/.claude/commands/conventions-testing.md
+++ b/.claude/commands/conventions-testing.md
@@ -64,6 +64,12 @@ enforcement, branded types) live in
 - Verify a new regression test fails against the known-bad behavior before
   trusting it. A test that never reaches the fault, or matches zero tests, is
   not a guard.
+- Detector and backstop tests use production-shaped inputs the detector can
+  actually match. Assert the fixture reaches or differs on the fault boundary
+  before asserting the protected outcome.
+- Where a map declares paths or cases, assert the declared and exercised sets
+  are equal in both directions. Pin fixture literals that stand in for producer
+  output with `satisfies` against the producer's return type.
 - For systemic bugs, test the class: fixed points for replay, matrices for
   tenant isolation, properties for parsers/normalizers, state-machine
   transitions for lifecycle code, and round trips for serialization.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,42 +120,9 @@ details unless they are already public in the repository.
 - AI is a tool, not a persona. No anthropomorphizing.
 - Performance is non-negotiable. Batch operations, minimize round-trips, lazy-load
   aggressively.
-- **Vertical slices over horizontal layers.** Features are independent end-to-end
-  slices (own routes, components, handlers). New capabilities land in their own slice;
-  existing code stays untouched.
-
-## Scalability
-
-Never paint yourself into a corner. Architecture must support Magic Circle scale
-without a rewrite. Never return unbounded result sets; keep the API stateless; filter
-by tenant ID in the query. Full guidelines in `/conventions-scale`.
-
-List endpoints should use cursor pagination and return the standard `Page<T>` envelope
-from `apps/api/src/lib/pagination.ts`:
-`{ items, nextCursor, limit }`. Offset pagination, `totalCount`, and unbounded lists
-require explicit justification.
-
-## Performance
-
-Performance regressions are guarded by committed baselines: a regression surfaces as
-a CI failure or a reviewable diff, never silently. The guards:
-
-- Per-route network baseline (`apps/web/e2e/network-baseline.json`): API request
-  manifest, waterfall depth, and per-endpoint DB query budgets, checked by the
-  route-smoke e2e suite.
-- Bundle-size budgets (`scripts/bundle-baseline.json`), enforced after the web build.
-- `require-loader-prefetch` oxlint rule: route suspense queries must start in the
-  route loader, not on component mount.
-- `x-db-queries` response header (dev/CI only): per-request DB query counter that
-  feeds the network baseline's query budgets.
-
-Fix the regression first. Reseeding a baseline (the route-smoke e2e suite run with
-`E2E_NETWORK_BASELINE=write` set, or `bun scripts/bundle-baseline.ts
---write-baseline`) is a product decision that must
-be justified in the PR description; it is not a mechanical way to make CI green.
-Start route data in loaders (`ensureRouteQueryData`), batch DB work instead of
-growing a query budget, and tighten baselines after a perf fix. Full guidelines,
-failure playbook, and the current hotspot burn-down list in `/conventions-perf`.
+- **Vertical slices over horizontal layers.** Features have one owning end-to-end
+  slice (routes, components, handlers). Keep cross-slice changes minimal; change
+  existing code when the end-to-end contract requires it.
 
 ## Coding Conventions
 
@@ -247,38 +214,19 @@ Record<Union, T>`, never `Partial<Record<...>>`; `Partial` lets a new union
   failures through the shared analytics or logging helpers so observability stays
   structured.
 
-## Testing
-
-Only test what can actually go wrong: bugs the type system, framework, or linter would
-miss. Prefer invariants over examples when the input space is large. Full conventions
-in `/conventions-testing`.
-
-A test guarding a detector or backstop must use inputs the detector can actually
-match: production-shaped ids and payloads, not shortened stand-ins a UUID or
-pattern guard can never trip; an "asserts nothing bad happened" test over such
-fixtures is vacuous. Where a map declares paths or cases, assert declared set
-equals exercised set in both directions, and pin fixture literals that stand in
-for a producer's output with `satisfies` against the producer's return type.
-
-## Internationalization (i18n)
-
-`use-intl` runtime. Source language: en. Check `apps/web/src/i18n/langs/` for
-supported languages. Prefer reusable `common.*` keys over feature-scoped duplicates.
-When storing translation keys in constants, maps, props, helper return types, or
-similar indirection, type them with `TranslationKey` from `apps/web/src/i18n/types`
-instead of `string` so stale or missing translation keys fail typecheck.
-Full translation flow and key naming rules in `/conventions-i18n`.
-
-## Linting
-
-oxlint (ultracite preset) + oxfmt. To suppress a rule:
-`// eslint-disable-next-line rule-name`
-
 ## Project Overview
 
 **Monorepo:** runnable services and clients live in `apps/` (`api`, `web`, desktop,
 mobile, landing, collaboration, playground, and focused runners); shared or
 publishable code lives in `packages/`. Use Glob/Grep to explore.
+
+## Convention Routing
+
+Before changing a convention-governed domain, read and apply the matching
+`.agents/skills/conventions-*/SKILL.md`. This includes AI, databases, i18n and
+user-facing strings, ingestion, performance guard failures and hot paths,
+architecture and scale, auth and data access, files and external APIs, tests,
+`apps/web` React effects, and user-facing UI. The skills own the detailed rules.
 
 ## Workspace Layout
 
@@ -292,8 +240,10 @@ publishable code lives in `packages/`. Use Glob/Grep to explore.
 ## Commands
 
 `bun run dev` | `dev:web` (3000) | `dev:api` (3001) |
-`build` | `lint` | `format` | `typecheck` | `test` |
-`db:push`
+`build` | `lint` | `format` | `typecheck` | `test`
+
+Database deployments use committed migrations via
+`bun --filter @stll/api db:migrate`; `db:push` is local schema sync only.
 
 `bun run verify` runs the same checks as the required CI job
 (`ci-checks` in `.github/workflows/ci.yml`); use it to self-verify a
@@ -345,45 +295,13 @@ only the non-obvious caveats for this environment.
   prod). Use the log line to complete sign-in/sign-up when testing.
 - **Mock AI is on by default** (`USE_MOCK_AI="true"` in `apps/api/.env.example`), so no
   AI provider key is needed for local runs.
-- **`bun run verify` / `sync-ai:check` need the `.ai/shared` submodule.** It is not part
-  of the base checkout; run `git submodule update --init .ai/shared` first, otherwise
-  the "AI skill sync" step errors out.
+- **`sync-ai:check` needs the `.ai/shared` submodule.** Local `bun run verify` warns
+  and skips only that step when it is absent. Run
+  `git submodule update --init .ai/shared` for CI-equivalent verification.
 - Optional demo data: `bun --filter @stll/api db:seed-test-user` and `db:seed-dev`.
-
-## Test Doctrine
-
-Full conventions in `/conventions-testing`; these three are the ones most often
-skipped.
-
-- **Mutation check.** A test guarding behavior X is finished only once reverting X
-  makes it fail; until then it may be passing for an unrelated reason. When the test
-  is the evidence for a fix, state in the PR that you ran the mutation. A test whose
-  fixture cannot express the fault is the common failure: assert the fixture DIFFERS
-  before asserting the equivalence, for example `expect(NFD(word)).not.toBe(NFC(word))`
-  before asserting both normalize alike.
-- **Cross-runtime contracts.** Where a rule lives in two runtimes at once
-  (JavaScript, Postgres, the search engine), prove parity by DERIVING the other
-  side's rules executably: query the live extension, render the SQL the query layer
-  emits, read the analyzer's configuration tuple. A hand-maintained mirror list of
-  the other side's behavior is not evidence of parity; it is the drift, written down.
-- **Projection census.** Any "marked done" flag that mirrors state in an external
-  system (search index, object store, queue) ships with a reconciler that compares
-  both sides and reports the difference. Acceptance by the remote system is not
-  durability, so the flag alone can never prove the projection landed.
 
 ## Convention & Type-Cost Guards
 
-- Whole-repo convention metrics that may only decrease live in
-  `scripts/ratchet.ts` (`RATCHET_METRICS`); this includes cross-slice imports
-  (API handler domains, route-private `-` paths, web features), which
-  structurally enforce the vertical-slice principle.
-- Lint suppressions are budgeted per rule, not in aggregate: each rule in
-  `TRACKED_SUPPRESSION_RULES` (`scripts/lint-suppressions.ts`) has its own
-  decrease-only ratchet, and security-tier suppressions additionally need an
-  entry in `scripts/suppression-waivers.json`. Policy in
-  `.oxlint-plugins/README.md`.
-- Typecheck cost is guarded by `scripts/typecheck-baseline.ts`: per-project
-  tsc `--extendedDiagnostics` Types/Instantiations counters with headroom,
-  checked in the CI typecheck job. Reseeding either baseline
-  (`--write` / `--write-baseline`) must be justified in the PR description;
-  it is not a mechanical way to make CI green.
+Convention and suppression ratchets may only tighten. Every lint suppression names
+a rule and reason; security-tier suppressions also need a waiver. Type-cost baseline
+increases require PR justification and are never a mechanical way to pass CI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,37 +269,6 @@ The `stella-docs` MCP server provides on-demand access to library documentation 
 
 **Setup:** run `bun run setup:mcp` once after cloning.
 
-## Cursor Cloud specific instructions
-
-The base VM already has Bun (`~/.bun/bin`, on `PATH` via `~/.bashrc`) and Docker
-installed; the startup update script runs `bun install`. Standard commands live in
-`README.md`, `CONTRIBUTING.md`, and root `package.json` scripts; the notes below are
-only the non-obvious caveats for this environment.
-
-- **Start the Docker daemon first.** There is no systemd auto-start here, so `docker`
-  commands fail until the daemon runs. Start it once per session in the background
-  (e.g. `sudo dockerd` in a tmux session) and confirm with `docker ps`. The daemon is
-  configured with the `fuse-overlayfs` storage driver and iptables-legacy for
-  docker-in-docker.
-- **Run everything with `bun run dev --no-browser`.** The dev-runner
-  (`packages/scripts/src/dev-runner.ts`) brings up the Docker infra (Postgres 5432,
-  Valkey 6379, RustFS 9000/9001, Gotenberg 3003), copies `apps/{api,web}/.env` from
-  `.env.example`, applies DB migrations, and starts the API (3001) and web (3000). It
-  exits if any child dies, so a single background process covers the whole stack. Use
-  `bun run dev:api` or `bun run dev:web` for a focused loop.
-- **Auth is passwordless email OTP; no SMTP catcher runs.** `EMAIL_PROVIDER=smtp`
-  points at `localhost:1025`, which is not running, so verification emails are not
-  delivered. In dev the OTP is printed to the API log as
-  `[DEV] OTP for <email>: <code>` and is also fetchable via
-  `GET http://localhost:3001/dev-public/last-otp?email=<email>` (dev-only, 404 in
-  prod). Use the log line to complete sign-in/sign-up when testing.
-- **Mock AI is on by default** (`USE_MOCK_AI="true"` in `apps/api/.env.example`), so no
-  AI provider key is needed for local runs.
-- **`sync-ai:check` needs the `.ai/shared` submodule.** Local `bun run verify` warns
-  and skips only that step when it is absent. Run
-  `git submodule update --init .ai/shared` for CI-equivalent verification.
-- Optional demo data: `bun --filter @stll/api db:seed-test-user` and `db:seed-dev`.
-
 ## Convention & Type-Cost Guards
 
 Convention and suppression ratchets may only tighten. Every lint suppression names


### PR DESCRIPTION
Streamlines the root agent guidance around the domain convention skills.\n\n- replaces duplicated scalability, performance, testing, i18n, and linting summaries with one convention router\n- moves unique translation-key and detector-fixture rules into their owning skills and regenerates agent artifacts\n- bumps the reviewed ai-shared pin for corrected vertical-slice ownership wording\n- removes Cursor Cloud-specific operational guidance from the shared root prompt\n- clarifies migration commands and baseline exceptions