### PR TITLE
fix(ai): update model catalog rates and reviewed exclusions

### DIFF
--- a/.changeset/tidy-model-rates.md
+++ b/.changeset/tidy-model-rates.md
@@ -1,0 +1,5 @@
+---
+"@stll/ai-catalog": patch
+---
+
+Update Gemini 3.6 Flash promotional rates and keep floating Google aliases outside fixed-model metadata.

--- a/packages/ai-catalog/src/index.test.ts
+++ b/packages/ai-catalog/src/index.test.ts
@@ -253,6 +253,15 @@ describe("MODEL_RATES economic ordering", () => {
       getModelRate("gemini-3.7-flash"),
     );
   });
+
+  test("canonical model rates match expected amounts", () => {
+    expect(getModelRate("gemini-3.6-flash")).toEqual({
+      kind: "flat",
+      inputPerMTok: 75_000,
+      outputPerMTok: 375_000,
+      cachedInputPerMTok: 7500,
+    });
+  });
 });
 
 describe("CONTEXT_WINDOW_TOKENS", () => {

--- a/packages/ai-catalog/src/index.test.ts
+++ b/packages/ai-catalog/src/index.test.ts
@@ -26,6 +26,11 @@ import {
   TANSTACK_AI_PROVIDERS,
 } from "./index";
 
+const FLOATING_GOOGLE_MODEL_POINTERS = [
+  "gemini-flash-latest",
+  "gemini-flash-lite-latest",
+] as const;
+
 describe("BYOK provider role support", () => {
   test("does not route PDF flows through Mistral document-unsupported models", () => {
     expect(
@@ -242,16 +247,21 @@ describe("MODEL_RATES economic ordering", () => {
   }
 
   test("canonical provider aliases share one rate schedule", () => {
-    expect(getModelRate("gemini-flash-latest")).toBe(
-      getModelRate("gemini-3.7-flash"),
-    );
-    expect(getModelRate("gemini-flash-lite-latest")).toBe(
-      getModelRate("gemini-3.5-flash-lite"),
-    );
     expect(getModelRate("gpt-5.6-sol")).toBe(getModelRate("gpt-5.6"));
     expect(getModelRate("google/gemini-3.7-flash")).toBe(
       getModelRate("gemini-3.7-flash"),
     );
+  });
+
+  test("floating provider pointers do not inherit fixed-model metadata", () => {
+    for (const modelId of FLOATING_GOOGLE_MODEL_POINTERS) {
+      expect(getModelRate(modelId)).toBeUndefined();
+      expect(getContextWindowTokens(modelId)).toBe(
+        DEFAULT_CONTEXT_WINDOW_TOKENS,
+      );
+      expect(getModelReasoningEfforts(modelId)).toBeNull();
+      expect(shouldEmitTemperature(modelId)).toBe(false);
+    }
   });
 
   test("canonical model rates match expected amounts", () => {
@@ -281,12 +291,6 @@ describe("CONTEXT_WINDOW_TOKENS", () => {
   });
 
   test("canonical provider aliases share context metadata", () => {
-    expect(getContextWindowTokens("gemini-flash-latest")).toBe(
-      getContextWindowTokens("gemini-3.7-flash"),
-    );
-    expect(getContextWindowTokens("gemini-flash-lite-latest")).toBe(
-      getContextWindowTokens("gemini-3.5-flash-lite"),
-    );
     expect(getContextWindowTokens("gpt-5.6-sol")).toBe(
       getContextWindowTokens("gpt-5.6"),
     );
@@ -295,12 +299,6 @@ describe("CONTEXT_WINDOW_TOKENS", () => {
 
 describe("MODEL_REASONING_EFFORTS", () => {
   test("canonical provider aliases share reasoning metadata", () => {
-    expect(getModelReasoningEfforts("gemini-flash-latest")).toEqual(
-      getModelReasoningEfforts("gemini-3.7-flash"),
-    );
-    expect(getModelReasoningEfforts("gemini-flash-lite-latest")).toEqual(
-      getModelReasoningEfforts("gemini-3.5-flash-lite"),
-    );
     expect(getModelReasoningEfforts("gpt-5.6-sol")).toEqual(
       getModelReasoningEfforts("gpt-5.6"),
     );

--- a/packages/ai-catalog/src/index.test.ts
+++ b/packages/ai-catalog/src/index.test.ts
@@ -242,6 +242,12 @@ describe("MODEL_RATES economic ordering", () => {
   }
 
   test("canonical provider aliases share one rate schedule", () => {
+    expect(getModelRate("gemini-flash-latest")).toBe(
+      getModelRate("gemini-3.7-flash"),
+    );
+    expect(getModelRate("gemini-flash-lite-latest")).toBe(
+      getModelRate("gemini-3.5-flash-lite"),
+    );
     expect(getModelRate("gpt-5.6-sol")).toBe(getModelRate("gpt-5.6"));
     expect(getModelRate("google/gemini-3.7-flash")).toBe(
       getModelRate("gemini-3.7-flash"),
@@ -266,6 +272,12 @@ describe("CONTEXT_WINDOW_TOKENS", () => {
   });
 
   test("canonical provider aliases share context metadata", () => {
+    expect(getContextWindowTokens("gemini-flash-latest")).toBe(
+      getContextWindowTokens("gemini-3.7-flash"),
+    );
+    expect(getContextWindowTokens("gemini-flash-lite-latest")).toBe(
+      getContextWindowTokens("gemini-3.5-flash-lite"),
+    );
     expect(getContextWindowTokens("gpt-5.6-sol")).toBe(
       getContextWindowTokens("gpt-5.6"),
     );
@@ -274,6 +286,12 @@ describe("CONTEXT_WINDOW_TOKENS", () => {
 
 describe("MODEL_REASONING_EFFORTS", () => {
   test("canonical provider aliases share reasoning metadata", () => {
+    expect(getModelReasoningEfforts("gemini-flash-latest")).toEqual(
+      getModelReasoningEfforts("gemini-3.7-flash"),
+    );
+    expect(getModelReasoningEfforts("gemini-flash-lite-latest")).toEqual(
+      getModelReasoningEfforts("gemini-3.5-flash-lite"),
+    );
     expect(getModelReasoningEfforts("gpt-5.6-sol")).toEqual(
       getModelReasoningEfforts("gpt-5.6"),
     );

--- a/packages/ai-catalog/src/index.ts
+++ b/packages/ai-catalog/src/index.ts
@@ -748,8 +748,6 @@ export const FALLBACK_CHAT_MODEL_BY_PROVIDER = {
 } as const satisfies Record<AIProvider, string | null>;
 
 export const MODEL_CATALOG_ID_ALIASES = {
-  "gemini-flash-latest": "gemini-3.7-flash",
-  "gemini-flash-lite-latest": "gemini-3.5-flash-lite",
   "gpt-5.6-sol": "gpt-5.6",
   // Aggregator listings use the dotted marketing forms; the catalog's
   // canonical ids are the dashed API forms.

--- a/packages/ai-catalog/src/index.ts
+++ b/packages/ai-catalog/src/index.ts
@@ -748,6 +748,8 @@ export const FALLBACK_CHAT_MODEL_BY_PROVIDER = {
 } as const satisfies Record<AIProvider, string | null>;
 
 export const MODEL_CATALOG_ID_ALIASES = {
+  "gemini-flash-latest": "gemini-3.7-flash",
+  "gemini-flash-lite-latest": "gemini-3.5-flash-lite",
   "gpt-5.6-sol": "gpt-5.6",
   // Aggregator listings use the dotted marketing forms; the catalog's
   // canonical ids are the dashed API forms.
@@ -955,9 +957,9 @@ export const MODEL_RATES = {
   },
   "gemini-3.6-flash": {
     kind: "flat",
-    inputPerMTok: 150_000,
-    outputPerMTok: 750_000,
-    cachedInputPerMTok: 15_000,
+    inputPerMTok: 75_000,
+    outputPerMTok: 375_000,
+    cachedInputPerMTok: 7500,
   },
   "gemini-3.7-flash": {
     kind: "flat",

--- a/packages/scripts/src/model-catalog-discovery.property.test.ts
+++ b/packages/scripts/src/model-catalog-discovery.property.test.ts
@@ -160,7 +160,16 @@ describe("model catalog discovery invariants", () => {
   });
 
   test("default reviewed exclusions cover unversioned Google aliases", () => {
-    const googleAliases: UpstreamDiscoveryModel[] = [
+    const googleFlashLiteAlias = {
+      provider: "google",
+      modelId: "gemini-flash-lite-latest",
+      releaseDate: "2026-07-21",
+      status: null,
+      toolCall: true,
+      structuredOutput: true,
+      outputModalities: ["text"],
+    } satisfies UpstreamDiscoveryModel;
+    const googleAliases = [
       {
         provider: "google",
         modelId: "gemini-flash-latest",
@@ -170,16 +179,8 @@ describe("model catalog discovery invariants", () => {
         structuredOutput: true,
         outputModalities: ["text"],
       },
-      {
-        provider: "google",
-        modelId: "gemini-flash-lite-latest",
-        releaseDate: "2026-07-21",
-        status: null,
-        toolCall: true,
-        structuredOutput: true,
-        outputModalities: ["text"],
-      },
-    ];
+      googleFlashLiteAlias,
+    ] satisfies UpstreamDiscoveryModel[];
 
     expect(
       findUnreviewedModels({
@@ -196,6 +197,6 @@ describe("model catalog discovery invariants", () => {
           "google:gemini-flash-latest": "2026-08-22: property-test disposition",
         },
       }),
-    ).toEqual([googleAliases[1]]);
+    ).toEqual([googleFlashLiteAlias]);
   });
 });

--- a/packages/scripts/src/model-catalog-discovery.property.test.ts
+++ b/packages/scripts/src/model-catalog-discovery.property.test.ts
@@ -158,4 +158,44 @@ describe("model catalog discovery invariants", () => {
       propertyConfig(),
     );
   });
+
+  test("default reviewed exclusions cover unversioned Google aliases", () => {
+    const googleAliases: UpstreamDiscoveryModel[] = [
+      {
+        provider: "google",
+        modelId: "gemini-flash-latest",
+        releaseDate: "2026-08-13",
+        status: null,
+        toolCall: true,
+        structuredOutput: true,
+        outputModalities: ["text"],
+      },
+      {
+        provider: "google",
+        modelId: "gemini-flash-lite-latest",
+        releaseDate: "2026-07-21",
+        status: null,
+        toolCall: true,
+        structuredOutput: true,
+        outputModalities: ["text"],
+      },
+    ];
+
+    expect(
+      findUnreviewedModels({
+        upstream: googleAliases,
+        offered: EMPTY_OFFERED,
+      }),
+    ).toEqual([]);
+
+    expect(
+      findUnreviewedModels({
+        upstream: googleAliases,
+        offered: EMPTY_OFFERED,
+        reviewedExclusions: {
+          "google:gemini-flash-latest": "2026-08-22: property-test disposition",
+        },
+      }),
+    ).toEqual([googleAliases[1]]);
+  });
 });

--- a/packages/scripts/src/model-catalog-discovery.ts
+++ b/packages/scripts/src/model-catalog-discovery.ts
@@ -30,9 +30,9 @@ type DatedReviewReason = `${number}-${number}-${number}: ${string}`;
 // oxlint-disable-next-line no-partial-record-satisfies/no-partial-record-satisfies -- DiscoveryModelKey is `${provider}:${string}`, an unbounded template-literal type; a total record is not constructible. Absence here means "no reviewed exclusion for this model ID" (the default, checked via `!== undefined` in findUnreviewedModels), not an unclassified union member.
 export const REVIEWED_MODEL_EXCLUSIONS = {
   "google:gemini-flash-latest":
-    "2026-08-22: unversioned alias pointer; offer the canonical gemini-3.7-flash ID",
+    "2026-08-22: floating alias pointer; do not offer or assign fixed-model metadata",
   "google:gemini-flash-lite-latest":
-    "2026-08-22: unversioned alias pointer; offer the canonical gemini-3.5-flash-lite ID",
+    "2026-08-22: floating alias pointer; do not offer or assign fixed-model metadata",
   "openai:gpt-5.6-luna":
     "2026-07-23: specialized GPT-5.6 tier; offer the portable gpt-5.6 ID",
   "openai:gpt-5.6-sol":

--- a/packages/scripts/src/model-catalog-discovery.ts
+++ b/packages/scripts/src/model-catalog-discovery.ts
@@ -29,6 +29,10 @@ type DatedReviewReason = `${number}-${number}-${number}: ${string}`;
  */
 // oxlint-disable-next-line no-partial-record-satisfies/no-partial-record-satisfies -- DiscoveryModelKey is `${provider}:${string}`, an unbounded template-literal type; a total record is not constructible. Absence here means "no reviewed exclusion for this model ID" (the default, checked via `!== undefined` in findUnreviewedModels), not an unclassified union member.
 export const REVIEWED_MODEL_EXCLUSIONS = {
+  "google:gemini-flash-latest":
+    "2026-08-22: unversioned alias pointer; offer the canonical gemini-3.7-flash ID",
+  "google:gemini-flash-lite-latest":
+    "2026-08-22: unversioned alias pointer; offer the canonical gemini-3.5-flash-lite ID",
   "openai:gpt-5.6-luna":
     "2026-07-23: specialized GPT-5.6 tier; offer the portable gpt-5.6 ID",
   "openai:gpt-5.6-sol":


### PR DESCRIPTION
## Summary
- Update `gemini-3.6-flash` rates to match Google’s promotional pricing.
- Keep `gemini-flash-latest` and `gemini-flash-lite-latest` outside fixed-model metadata normalization.
- Add dated discovery exclusions and mutation-checked regression coverage for both floating pointers.
- Add a patch changeset for `@stll/ai-catalog`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the promotional pricing for `gemini-3.6-flash`, including input, output and cached-input rates.
  * Prevented floating Google model aliases from being treated as fixed models with inaccurate pricing, capabilities or limits.
  * Floating aliases now use default context limits and omit unsupported pricing, reasoning and temperature metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->