### PR TITLE
fix: bootstrap only missing npm packages

### DIFF
--- a/scripts/bootstrap-publish-packages.sh
+++ b/scripts/bootstrap-publish-packages.sh
@@ -25,9 +25,9 @@ if [[ -n "$(git status --porcelain)" ]]; then
 fi
 
 # First publication needs an npm token; trusted publishing can only be configured
-# after each package exists. `template-conditions` depends on `conditions`;
-# `anonymize-chat` depends on the already-published `anonymize-wasm` package.
-packages=(auth-model ai-catalog anonymize-chat conditions template-conditions docx-utils)
+# after each package exists. `anonymize-chat` depends on the already-published
+# `anonymize-wasm` package.
+packages=(auth-model ai-catalog anonymize-chat)
 manifests=()
 integrities=()
 publish_modes=()


### PR DESCRIPTION
The one-time bootstrap script combines prior first-publish lists, but `@stll/conditions`, `@stll/template-conditions`, and `@stll/docx-utils` already exist on npm. Keep the idempotent artifact and integrity safeguards, while restricting the bootstrap target to the three absent packages: `@stll/auth-model`, `@stll/ai-catalog`, and `@stll/anonymize-chat`.