### PR TITLE
fix(api): record the error cause on reconcile failure logs

### DIFF
--- a/apps/api/src/lib/account-deletion-cleanup-queue.ts
+++ b/apps/api/src/lib/account-deletion-cleanup-queue.ts
@@ -12,7 +12,11 @@ import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
 import { detached } from "@/api/lib/detached";
-import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
+import {
+  connectionErrorFields,
+  errorSystemFields,
+  errorTag,
+} from "@/api/lib/errors/utils";
 import { deleteS3Keys } from "@/api/lib/files/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { createBullMqConnection } from "@/api/lib/redis-client";
@@ -196,9 +200,10 @@ export const initAccountDeletionCleanupWorker = () => {
           });
         } catch (error) {
           captureError(error);
-          logger.error("account_deletion_cleanup.reconcile_failed", {
-            "error.type": errorTag(error),
-          });
+          logger.error(
+            "account_deletion_cleanup.reconcile_failed",
+            errorSystemFields(error),
+          );
         }
       })(),
       "account-deletion-cleanup.reconcile",

--- a/apps/api/src/lib/document-processing-queue.ts
+++ b/apps/api/src/lib/document-processing-queue.ts
@@ -53,7 +53,11 @@ import {
 import { documentProcessingFailureFields } from "@/api/lib/document-processing-failure-fields";
 import { DocumentOcrError } from "@/api/lib/document-processing-ocr-result";
 import { startDocumentOcrWorkerReadiness } from "@/api/lib/document-processing-readiness";
-import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
+import {
+  connectionErrorFields,
+  errorSystemFields,
+  errorTag,
+} from "@/api/lib/errors/utils";
 import { createFileKey, createOcrSearchablePdfKey } from "@/api/lib/file-key";
 import { logger } from "@/api/lib/observability/logger";
 import {
@@ -2863,7 +2867,7 @@ const reconcileDocumentProcessing = async ({
           }
           captureError(error, { phase });
           logger.error("document_processing.reconcile_phase_failed", {
-            "error.type": errorTag(error),
+            ...errorSystemFields(error),
             phase,
           });
         },
@@ -2893,9 +2897,10 @@ const reconcileDocumentProcessing = async ({
       });
     } else {
       captureError(error);
-      logger.error("document_processing.reconcile_failed", {
-        "error.type": errorTag(error),
-      });
+      logger.error(
+        "document_processing.reconcile_failed",
+        errorSystemFields(error),
+      );
     }
   } finally {
     onComplete();

--- a/apps/api/src/lib/entity-deletion-cleanup-queue.ts
+++ b/apps/api/src/lib/entity-deletion-cleanup-queue.ts
@@ -13,7 +13,11 @@ import {
   failEntityDeletionEffectChunk,
   listRecoverableEntityDeletionEffectRequestIds,
 } from "@/api/lib/entity-deletion-effect-store";
-import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
+import {
+  connectionErrorFields,
+  errorSystemFields,
+  errorTag,
+} from "@/api/lib/errors/utils";
 import { deleteS3Keys } from "@/api/lib/files/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { createBullMqConnection } from "@/api/lib/redis-client";
@@ -323,9 +327,10 @@ export const initEntityDeletionCleanupWorker = () => {
     },
     onError: (error) => {
       captureError(error);
-      logger.error("entity_deletion_cleanup.reconcile_failed", {
-        "error.type": errorTag(error),
-      });
+      logger.error(
+        "entity_deletion_cleanup.reconcile_failed",
+        errorSystemFields(error),
+      );
     },
   });
   reconcile();


### PR DESCRIPTION
## Proposed change

Four reconcile failure sinks build their fields as `{ "error.type": errorTag(error) }`:
`document_processing.reconcile_phase_failed`, `document_processing.reconcile_failed`,
`account_deletion_cleanup.reconcile_failed` and `entity_deletion_cleanup.reconcile_failed`.

Every failure raised inside a Drizzle query arrives wrapped in the same class, so the tag
names the wrapper and stops there. The driver's `code`, and the wrapped cause's class and
code, are what separate a connection that went away from a constraint violation from a
statement timeout, and none of them reach the log; a reader gets `DrizzleQueryError` and
has nowhere to go next. `captureError`, called immediately above each of these sinks,
already carries that detail onto the analytics path, so the log sink is the poorer of the
two for no reason. `document-processing-failure-fields.ts` states this rationale for the
sibling `document_processing.failed` sink.

The other reconcile sinks already resolve it the other way: `workflow.reconcile_failed` and
`flow.reconcile_failed` pass `errorSystemFields(error)`. This adopts that side at the four
call sites still passing the tag alone.

`errorSystemFields` adds `error.code`, `error.errno`, `error.syscall`, `error.cause.type`
and `error.cause.code`, and excludes the message, so the fields stay non-content.
`connectionErrorFields`, the variant that also carries `error.msg`, is documented as being
only for sinks that observe connection-level failures exclusively, which a reconcile phase
running queries is not, so it is not used here.

Left alone deliberately: `errorSystemFields` reads a cause's `code`, which for the Bun
driver is the generic category rather than the SQLSTATE that `pgErrorFields` recovers from
`errno`. Folding that in would change every sink using the helper and belongs in its own
change. The paired `*_disrupted` sinks also keep the bare tag: those log an already
classified transient, where the class is the whole point.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | `bun run code-check:affected` (lint and typecheck) is clean; the error
  helper, `pg-error`, idle-exit and reconciliation-feed suites pass.
- [ ] DARK MODE SUPPORT | Not applicable: server-side log fields only.
- [ ] ISSUE LINKED
- [ ] SCREENSHOT INCLUDED | Not applicable.


---
_Generated by [Claude Code](https://claude.ai/code/session_016kbuE6Pkzw9MXViW4m5cDF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic information captured when account cleanup, document processing, or entity cleanup reconciliation fails.
  * Error reports now include broader system-level details, making failures easier to investigate and resolve.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->