### PR TITLE
fix: release corpus backfill leases

### DIFF
--- a/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-generation-backfill.db.test.ts
@@ -1505,6 +1505,245 @@ test(
 );
 
 test(
+  "releases the checkpoint lease when snapshot selection fails",
+  async () => {
+    const generation = "case_law_v80";
+    const leaseToken = "00000000-0000-4000-8000-000000000180";
+    let claimObserved = false;
+    let postClaimTransactions = 0;
+    let injected = false;
+    let backfillCalls = 0;
+    const failingScopedDb = async <T>(
+      callback: (tx: Transaction) => Promise<T>,
+    ): Promise<T> => {
+      // The first five post-claim transactions renew the writer and
+      // checkpoint leases, then drain pending projections. The next one is
+      // the snapshot page read: fail it once to model an expired pool
+      // connection while the running arm still owns the checkpoint lease.
+      if (!injected && claimObserved && postClaimTransactions >= 5) {
+        injected = true;
+        throw new Error("snapshot selection failed");
+      }
+
+      const result = await scopedDb(callback);
+      const checkpoint = await readCheckpoint(generation);
+      if (checkpoint?.leaseToken === leaseToken) {
+        if (claimObserved) {
+          postClaimTransactions += 1;
+        } else {
+          claimObserved = true;
+        }
+      }
+      return result;
+    };
+    const backfill = createCaseLawGenerationBackfill({
+      backfillRows: async () => {
+        backfillCalls += 1;
+        return indexedOutcome(0);
+      },
+      newLeaseToken: () => leaseToken,
+      removeProjection: ignoreProjectionRemoval,
+    });
+
+    try {
+      const rejection: unknown = await backfill(
+        failingScopedDb,
+        1,
+        generation,
+      ).then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+      expect(rejection).toMatchObject({
+        message: "snapshot selection failed",
+      });
+      expect(injected).toBe(true);
+      expect(postClaimTransactions).toBeGreaterThanOrEqual(5);
+      expect(backfillCalls).toBe(0);
+      expect(await readCheckpoint(generation)).toMatchObject({
+        leaseExpiresAt: null,
+        leaseToken: null,
+        status: "running",
+      });
+    } finally {
+      await db
+        .delete(caseLawCorpusIndexBackfills)
+        .where(eq(caseLawCorpusIndexBackfills.generation, generation));
+    }
+  },
+  { timeout: 30_000 },
+);
+
+test(
+  "releases the checkpoint lease when cursor advancement fails",
+  async () => {
+    const generation = "case_law_v81";
+    const leaseToken = "00000000-0000-4000-8000-000000000181";
+    let failNextTransaction = false;
+    const failingScopedDb = async <T>(
+      callback: (tx: Transaction) => Promise<T>,
+    ): Promise<T> => {
+      if (failNextTransaction) {
+        failNextTransaction = false;
+        throw new Error("cursor advancement failed");
+      }
+      return await scopedDb(callback);
+    };
+    const backfill = createCaseLawGenerationBackfill({
+      backfillRows: async (_runnerDb, rows, _rebuildGeneration, options) => {
+        await options.beforeRemoteEffect({
+          effect: completeRemoteEffect,
+          onLeaseLost: noRemoteEffectCompensation,
+        });
+        failNextTransaction = true;
+        return indexedOutcome(rows.length);
+      },
+      newLeaseToken: () => leaseToken,
+      removeProjection: ignoreProjectionRemoval,
+    });
+
+    try {
+      const rejection: unknown = await backfill(
+        failingScopedDb,
+        1,
+        generation,
+      ).then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+      expect(rejection).toMatchObject({
+        message: "cursor advancement failed",
+      });
+      expect(await readCheckpoint(generation)).toMatchObject({
+        leaseExpiresAt: null,
+        leaseToken: null,
+        status: "running",
+      });
+    } finally {
+      await db
+        .delete(caseLawCorpusIndexBackfills)
+        .where(eq(caseLawCorpusIndexBackfills.generation, generation));
+    }
+  },
+  { timeout: 30_000 },
+);
+
+test(
+  "does not reopen checkpoint cleanup after cursor advancement released it",
+  async () => {
+    const generation = "case_law_v82";
+    let advancementObserved = false;
+    let postAdvancementTransactions = 0;
+    const tracedScopedDb = async <T>(
+      callback: (tx: Transaction) => Promise<T>,
+    ): Promise<T> => {
+      if (advancementObserved) {
+        postAdvancementTransactions += 1;
+      }
+      const result = await scopedDb(callback);
+      const checkpoint = await readCheckpoint(generation);
+      if (checkpoint?.cursorId !== null && checkpoint?.leaseToken === null) {
+        advancementObserved = true;
+      }
+      return result;
+    };
+    const backfill = createCaseLawGenerationBackfill({
+      backfillRows: async (_runnerDb, rows, _generation, options) => {
+        await options.beforeRemoteEffect({
+          effect: completeRemoteEffect,
+          onLeaseLost: noRemoteEffectCompensation,
+        });
+        return indexedOutcome(rows.length);
+      },
+      newLeaseToken: () => "00000000-0000-4000-8000-000000000182",
+      removeProjection: ignoreProjectionRemoval,
+    });
+
+    try {
+      expect(await backfill(tracedScopedDb, 1, generation)).toMatchObject({
+        indexed: 1,
+        status: "advanced",
+      });
+      expect(advancementObserved).toBe(true);
+      // Only the separate generation-writer lease release remains. A second
+      // transaction would be redundant checkpoint cleanup after its CAS
+      // already cleared the token and persisted the cursor.
+      expect(postAdvancementTransactions).toBe(1);
+    } finally {
+      await db
+        .delete(caseLawCorpusIndexBackfills)
+        .where(eq(caseLawCorpusIndexBackfills.generation, generation));
+    }
+  },
+  { timeout: 30_000 },
+);
+
+test(
+  "returns completion when the retried complete lease release succeeds",
+  async () => {
+    const generation = "case_law_v83";
+    const leaseToken = "00000000-0000-4000-8000-000000000183";
+    let releaseFailures = 0;
+    await db.insert(caseLawCorpusIndexBackfills).values({
+      generation,
+      snapshotAt: new Date("2000-01-01T00:00:00.000Z"),
+    });
+    const retryingScopedDb = async <T>(
+      runTransaction: (tx: Transaction) => Promise<T>,
+    ): Promise<T> =>
+      await db.transaction(async (tx) => {
+        // SAFETY: PGlite's transaction provides the Drizzle query surface the
+        // runner uses; the explicit transaction lets this test roll back the
+        // first completed-checkpoint release at its exact state boundary.
+        // eslint-disable-next-line typescript/no-unsafe-type-assertion
+        const transaction = tx as unknown as Transaction;
+        const result = await runTransaction(transaction);
+        const checkpoint = (
+          await transaction
+            .select()
+            .from(caseLawCorpusIndexBackfills)
+            .where(eq(caseLawCorpusIndexBackfills.generation, generation))
+            .limit(1)
+        ).at(0);
+        if (
+          releaseFailures === 0 &&
+          checkpoint?.status === "complete" &&
+          checkpoint.leaseToken === null
+        ) {
+          releaseFailures += 1;
+          throw new Error("complete lease release failed");
+        }
+        return result;
+      });
+    const backfill = createCaseLawGenerationBackfill({
+      backfillRows: async () => indexedOutcome(0),
+      newLeaseToken: () => leaseToken,
+      removeProjection: ignoreProjectionRemoval,
+    });
+
+    try {
+      expect(await backfill(retryingScopedDb, 1, generation)).toEqual({
+        indexed: 0,
+        status: "complete",
+      });
+      expect(releaseFailures).toBe(1);
+      expect(await readCheckpoint(generation)).toMatchObject({
+        leaseExpiresAt: null,
+        leaseToken: null,
+        status: "complete",
+      });
+    } finally {
+      await db
+        .delete(caseLawCorpusIndexBackfills)
+        .where(eq(caseLawCorpusIndexBackfills.generation, generation));
+    }
+  },
+  { timeout: 30_000 },
+);
+
+test(
   "an expired owner cannot issue another remote write after a new owner advances",
   async () => {
     const generation = "case_law_v31";

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -1,4 +1,4 @@
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 import { and, asc, eq, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
@@ -47,6 +47,7 @@ import {
   timestampMatchesCasToken,
 } from "@/api/lib/db/timestamp-cas";
 import { ConcurrentModificationError } from "@/api/lib/errors/tagged-errors";
+import { errorSystemFields } from "@/api/lib/errors/utils";
 import { caseLawDecisionCorpusIndexIdSql } from "@/api/lib/legal-search/case-law-corpus-projection";
 import { caseLawIndexIdSql } from "@/api/lib/legal-search/case-law-index-groups";
 import {
@@ -2115,102 +2116,204 @@ export const createCaseLawGenerationBackfill =
         leaseToken,
         status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,
       });
-      await runningGuards.beforeRemoteEffect({
-        effect: completeRemoteEffect,
-        onLeaseLost: async () => await Promise.resolve(),
-      });
-
-      const releaseRunningLease = async (): Promise<void> => {
-        await scopedDb(async (tx) => {
-          // audit: skip — releasing a failed lease preserves the durable cursor for replay
-          await tx
-            .update(caseLawCorpusIndexBackfills)
-            .set({ leaseExpiresAt: null, leaseToken: null })
-            .where(
-              and(
-                eq(caseLawCorpusIndexBackfills.generation, generation),
-                ownsUnexpiredLease({
-                  checkpoint: claimedCheckpoint,
-                  leaseToken,
-                  status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,
-                }),
-              ),
-            );
-        });
+      type ClaimedLeaseState =
+        | { type: "held"; status: CaseLawCorpusIndexBackfillStatus }
+        | { type: "released" };
+      type ClaimedLease = { state: ClaimedLeaseState };
+      type CompletionState =
+        | { type: "pending" }
+        | { type: "reconciled"; result: CorpusIndexBackfillResult };
+      type Completion = { state: CompletionState };
+      const claimedLease: ClaimedLease = {
+        state: {
+          type: "held",
+          status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,
+        },
       };
+      const completion: Completion = { state: { type: "pending" } };
+      const operation = await Result.tryPromise(async () => {
+        await runningGuards.beforeRemoteEffect({
+          effect: completeRemoteEffect,
+          onLeaseLost: async () => await Promise.resolve(),
+        });
 
-      // Drain the pending queue before walking the snapshot. Pending
-      // projections are live decision traffic; the walk is a bounded rebuild
-      // of pre-snapshot rows, and a generation can sit at `running` for a long
-      // time (or forever, when its walk is wedged). Draining under RUNNING
-      // keeps newly ingested decisions searchable regardless of walk state,
-      // and draining first means a row that wedges the walk cannot also wedge
-      // live indexing. The pending_revision epoch converges these appends with
-      // walk pages that later reach the same rows.
-      let drainedIndexed = 0;
-      try {
-        const drainStartedAt = performance.now();
-        let drained: CorpusIndexBackfillResult;
+        // Drain the pending queue before walking the snapshot. Pending
+        // projections are live decision traffic; the walk is a bounded rebuild
+        // of pre-snapshot rows, and a generation can sit at `running` for a long
+        // time (or forever, when its walk is wedged). Draining under RUNNING
+        // keeps newly ingested decisions searchable regardless of walk state,
+        // and draining first means a row that wedges the walk cannot also wedge
+        // live indexing. The pending_revision epoch converges these appends with
+        // walk pages that later reach the same rows.
+        let drainedIndexed = 0;
         try {
-          drained = await drainPendingProjections({
-            checkpoint: claimedCheckpoint,
-            leaseToken,
-            status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,
-          });
-        } finally {
-          stageMs.drain = sinceMs(drainStartedAt);
-        }
-        if (drained.status === BACKFILL_STATUS.BUSY) {
-          await releaseRunningLease();
+          const drainStartedAt = performance.now();
+          let drained: CorpusIndexBackfillResult;
+          try {
+            drained = await drainPendingProjections({
+              checkpoint: claimedCheckpoint,
+              leaseToken,
+              status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,
+            });
+          } finally {
+            stageMs.drain = sinceMs(drainStartedAt);
+          }
+          if (drained.status === BACKFILL_STATUS.BUSY) {
+            reportPage({
+              outcome: "busy",
+              selected: 0,
+              indexed: 0,
+              drainedIndexed: 0,
+            });
+            return drained;
+          }
+          drainedIndexed = drained.indexed;
+        } catch (error) {
           reportPage({
-            outcome: "busy",
+            outcome: "failed",
             selected: 0,
             indexed: 0,
             drainedIndexed: 0,
           });
-          return drained;
+          throw error;
         }
-        drainedIndexed = drained.indexed;
-      } catch (error) {
-        await releaseRunningLease();
-        reportPage({
-          outcome: "failed",
-          selected: 0,
-          indexed: 0,
-          drainedIndexed: 0,
-        });
-        throw error;
-      }
-      // Reports this invocation's total durable movement: rows the drain
-      // indexed count as ADVANCED even when the walk itself could not.
-      const withDrained = (
-        result: CorpusIndexBackfillResult,
-      ): CorpusIndexBackfillResult => {
-        if (drainedIndexed === 0) {
-          return result;
-        }
-        return result.status === BACKFILL_STATUS.ADVANCED
-          ? {
-              indexed: result.indexed + drainedIndexed,
-              status: BACKFILL_STATUS.ADVANCED,
-            }
-          : { indexed: drainedIndexed, status: BACKFILL_STATUS.ADVANCED };
-      };
+        // Reports this invocation's total durable movement: rows the drain
+        // indexed count as ADVANCED even when the walk itself could not.
+        const withDrained = (
+          result: CorpusIndexBackfillResult,
+        ): CorpusIndexBackfillResult => {
+          if (drainedIndexed === 0) {
+            return result;
+          }
+          return result.status === BACKFILL_STATUS.ADVANCED
+            ? {
+                indexed: result.indexed + drainedIndexed,
+                status: BACKFILL_STATUS.ADVANCED,
+              }
+            : { indexed: drainedIndexed, status: BACKFILL_STATUS.ADVANCED };
+        };
 
-      const selectStartedAt = performance.now();
-      const page = await selectGenerationBackfillPage(scopedDb, {
-        batchSize,
-        checkpoint: claimedCheckpoint,
-      });
-      stageMs.select = sinceMs(selectStartedAt);
-      const last = page.at(-1);
-      if (!last) {
-        const completed = await scopedDb(async (tx) => {
-          // audit: skip — completion is derived projection state recorded on the checkpoint itself
-          const rows = await tx
+        const selectStartedAt = performance.now();
+        const page = await selectGenerationBackfillPage(scopedDb, {
+          batchSize,
+          checkpoint: claimedCheckpoint,
+        });
+        stageMs.select = sinceMs(selectStartedAt);
+        const last = page.at(-1);
+        if (!last) {
+          const completed = await scopedDb(async (tx) => {
+            // audit: skip — completion is derived projection state recorded on the checkpoint itself
+            const rows = await tx
+              .update(caseLawCorpusIndexBackfills)
+              .set({
+                status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE,
+              })
+              .where(
+                and(
+                  eq(caseLawCorpusIndexBackfills.generation, generation),
+                  ownsUnexpiredLease({
+                    checkpoint: claimedCheckpoint,
+                    leaseToken,
+                    status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,
+                  }),
+                ),
+              )
+              .returning(GENERATION_CHECKPOINT_COLUMNS);
+            return rows.at(0);
+          });
+          if (!completed) {
+            return withDrained({ indexed: 0, status: BACKFILL_STATUS.BUSY });
+          }
+          claimedLease.state = {
+            type: "held",
+            status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE,
+          };
+          const completedCheckpoint = toGenerationCheckpoint(completed);
+          try {
+            completion.state = {
+              result: withDrained(
+                await reconcilePending({
+                  checkpoint: completedCheckpoint,
+                  leaseToken,
+                  status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE,
+                }),
+              ),
+              type: "reconciled",
+            };
+            return completion.state.result;
+          } finally {
+            await releaseLease({
+              leaseToken,
+              status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE,
+            });
+            claimedLease.state = { type: "released" };
+          }
+        }
+
+        const rows = page
+          .filter((row) => isEligibleForGeneration(row, generation))
+          .map(withoutSourceDescriptor);
+        const removals = page.filter(
+          (row) =>
+            !isCorpusEligible(row) &&
+            hasGenerationProjectionTargets({ generation, row }),
+        );
+        let indexed: number;
+        const indexStartedAt = performance.now();
+        try {
+          // The drain above may have brought every row on this page current, so
+          // skip the indexer rather than hand it an empty batch.
+          const outcome =
+            rows.length === 0
+              ? EMPTY_BACKFILL_OUTCOME
+              : await backfillRows(scopedDb, rows, generation, {
+                  ...runningGuards,
+                  ...readConcurrencyOption,
+                  onTiming: collectTiming,
+                  // Snapshot pages of the rebuild: bulk throughput, whose
+                  // completeness the generation's census verifies rather
+                  // than each request proving it for itself.
+                  commit: CORPUS_INDEX_COMMIT.auto,
+                });
+          if (outcome.indexed !== rows.length) {
+            throw fixedPointError({
+              outcome,
+              selected: rows.length,
+              stage: FIXED_POINT_STAGE.generationBackfillPage,
+            });
+          }
+          indexed = outcome.indexed;
+          await settleAll(
+            removals.map(async (row) => {
+              await removeProjection(scopedDb, {
+                generation,
+                options: runningGuards,
+                row,
+              });
+            }),
+          );
+        } catch (error) {
+          // Keep the cursor intact, but do not make a transient search/S3 failure
+          // wait for a stale lease before its durable retry.
+          reportPage({
+            outcome: "failed",
+            selected: rows.length,
+            indexed: 0,
+            drainedIndexed,
+          });
+          throw error;
+        } finally {
+          stageMs.index = sinceMs(indexStartedAt);
+        }
+
+        const advanced = await scopedDb(async (tx) => {
+          // audit: skip — cursor advancement is the durable audit trail for this derived rebuild
+          const advancedRows = await tx
             .update(caseLawCorpusIndexBackfills)
             .set({
-              status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE,
+              ...nextGenerationWalkCursorColumns(last),
+              leaseExpiresAt: null,
+              leaseToken: null,
             })
             .where(
               and(
@@ -2222,119 +2325,56 @@ export const createCaseLawGenerationBackfill =
                 }),
               ),
             )
-            .returning(GENERATION_CHECKPOINT_COLUMNS);
-          return rows.at(0);
+            .returning({ generation: caseLawCorpusIndexBackfills.generation });
+          return advancedRows.at(0);
         });
-        if (!completed) {
-          return withDrained({ indexed: 0, status: BACKFILL_STATUS.BUSY });
+        if (advanced) {
+          claimedLease.state = { type: "released" };
         }
-        const completedCheckpoint = toGenerationCheckpoint(completed);
-        try {
-          return withDrained(
-            await reconcilePending({
-              checkpoint: completedCheckpoint,
-              leaseToken,
-              status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE,
-            }),
-          );
-        } finally {
-          await releaseLease({
-            leaseToken,
-            status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE,
-          });
-        }
-      }
-
-      const rows = page
-        .filter((row) => isEligibleForGeneration(row, generation))
-        .map(withoutSourceDescriptor);
-      const removals = page.filter(
-        (row) =>
-          !isCorpusEligible(row) &&
-          hasGenerationProjectionTargets({ generation, row }),
-      );
-      let indexed: number;
-      const indexStartedAt = performance.now();
-      try {
-        // The drain above may have brought every row on this page current, so
-        // skip the indexer rather than hand it an empty batch.
-        const outcome =
-          rows.length === 0
-            ? EMPTY_BACKFILL_OUTCOME
-            : await backfillRows(scopedDb, rows, generation, {
-                ...runningGuards,
-                ...readConcurrencyOption,
-                onTiming: collectTiming,
-                // Snapshot pages of the rebuild: bulk throughput, whose
-                // completeness the generation's census verifies rather
-                // than each request proving it for itself.
-                commit: CORPUS_INDEX_COMMIT.auto,
-              });
-        if (outcome.indexed !== rows.length) {
-          throw fixedPointError({
-            outcome,
-            selected: rows.length,
-            stage: FIXED_POINT_STAGE.generationBackfillPage,
-          });
-        }
-        indexed = outcome.indexed;
-        await settleAll(
-          removals.map(async (row) => {
-            await removeProjection(scopedDb, {
-              generation,
-              options: runningGuards,
-              row,
-            });
-          }),
-        );
-      } catch (error) {
-        // Keep the cursor intact, but do not make a transient search/S3 failure
-        // wait for a stale lease before its durable retry.
-        await releaseRunningLease();
         reportPage({
-          outcome: "failed",
+          outcome: advanced ? "advanced" : "busy",
           selected: rows.length,
-          indexed: 0,
+          indexed,
           drainedIndexed,
         });
-        throw error;
-      } finally {
-        stageMs.index = sinceMs(indexStartedAt);
+        return withDrained(
+          advanced
+            ? { indexed, status: BACKFILL_STATUS.ADVANCED }
+            : { indexed: 0, status: BACKFILL_STATUS.BUSY },
+        );
+      });
+      const claimedLeaseState = claimedLease.state;
+      const completionState = completion.state;
+      const released =
+        claimedLeaseState.type === "released"
+          ? null
+          : await Result.tryPromise(
+              async () =>
+                await releaseLease({
+                  leaseToken,
+                  status: claimedLeaseState.status,
+                }),
+            );
+      if (Result.isError(operation)) {
+        if (released !== null && Result.isError(released)) {
+          logger.error(
+            "case_law.corpus_index.generation_lease_release_failed",
+            errorSystemFields(released.error.cause),
+          );
+        }
+        if (
+          completionState.type === "reconciled" &&
+          released !== null &&
+          !Result.isError(released)
+        ) {
+          return completionState.result;
+        }
+        throw operation.error.cause;
       }
-
-      const advanced = await scopedDb(async (tx) => {
-        // audit: skip — cursor advancement is the durable audit trail for this derived rebuild
-        const advancedRows = await tx
-          .update(caseLawCorpusIndexBackfills)
-          .set({
-            ...nextGenerationWalkCursorColumns(last),
-            leaseExpiresAt: null,
-            leaseToken: null,
-          })
-          .where(
-            and(
-              eq(caseLawCorpusIndexBackfills.generation, generation),
-              ownsUnexpiredLease({
-                checkpoint: claimedCheckpoint,
-                leaseToken,
-                status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING,
-              }),
-            ),
-          )
-          .returning({ generation: caseLawCorpusIndexBackfills.generation });
-        return advancedRows.at(0);
-      });
-      reportPage({
-        outcome: advanced ? "advanced" : "busy",
-        selected: rows.length,
-        indexed,
-        drainedIndexed,
-      });
-      return withDrained(
-        advanced
-          ? { indexed, status: BACKFILL_STATUS.ADVANCED }
-          : { indexed: 0, status: BACKFILL_STATUS.BUSY },
-      );
+      if (released !== null && Result.isError(released)) {
+        throw released.error.cause;
+      }
+      return operation.value;
     } finally {
       await writerLease.release();
     }


### PR DESCRIPTION
## Summary

- release a running generation checkpoint lease from the whole post-claim execution arm
- reuse the existing token-and-status CAS so cleanup still works after lease expiry
- keep the 15-minute database pool lifetime and 30-minute lease duration unchanged

## Why

A pool connection can reach its maximum lifetime during snapshot selection or cursor advancement. Those paths previously escaped without clearing the checkpoint lease, delaying replay until the 30-minute expiry.

## Validation

- 37 generation-backfill DB tests passed
- mutation check: the new completion-recovery test fails on the reviewed head with `complete lease release failed`
- regression coverage for snapshot-selection and cursor-advance failures
- API typecheck passed
- API type-aware lint passed
- formatting and diff checks passed
- full pre-push lint/typecheck gate passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing corpus index updates.
  * Processing checkpoints are now released correctly if snapshot selection, cursor advancement, indexing, or completion encounters an error.
  * Failures continue to be reported clearly while leaving checkpoints in a recoverable state.
  * Prevented unnecessary remote indexing work when an earlier processing step fails.
  * Added regression coverage for checkpoint recovery and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->