### PR TITLE
chore: pin Changesets release workflow v2

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/changeset-release-pr.yml@48aacae31829ce15216a6b766b03a92fd2e84da3
+    uses: stella/.github/.github/workflows/changeset-release-pr.yml@c56b0c1d1e82f5e3fffa733a32b9a503a172ee35
     with:
       bun-version-file: package.json
     secrets:


### PR DESCRIPTION
## Summary

Pin the shared Changesets release workflow to the immutable revision that runs `changesets/action@v2.1.0`.