### PR TITLE
fix: resolve overlap of scroll-down and suggested questions buttons

### DIFF
--- a/apps/web/src/components/ai-elements/conversation.test.tsx
+++ b/apps/web/src/components/ai-elements/conversation.test.tsx
@@ -4,22 +4,23 @@ import { expect, test } from "bun:test";
 import { IntlProvider } from "use-intl";
 
 import { ConversationScrollButton } from "@/components/ai-elements/conversation";
+import { SuggestedFollowupChips } from "@/features/chat/components/suggested-followup-chips";
 import { StickToBottomContext } from "@/hooks/use-stick-to-bottom";
 import messages from "@/i18n/langs/ar.json";
+
+const STICK_TO_BOTTOM = {
+  contentRef: () => {},
+  isAtBottom: false,
+  isScrollable: true,
+  scrollElementRef: { current: null },
+  scrollRef: () => {},
+  scrollToBottom: () => {},
+};
 
 test("announces the scroll action in the active locale", () => {
   const html = renderToStaticMarkup(
     <IntlProvider locale="ar" messages={messages} timeZone="UTC">
-      <StickToBottomContext
-        value={{
-          contentRef: () => {},
-          isAtBottom: false,
-          isScrollable: true,
-          scrollElementRef: { current: null },
-          scrollRef: () => {},
-          scrollToBottom: () => {},
-        }}
-      >
+      <StickToBottomContext value={STICK_TO_BOTTOM}>
         <ConversationScrollButton />
       </StickToBottomContext>
     </IntlProvider>,
@@ -27,4 +28,42 @@ test("announces the scroll action in the active locale", () => {
 
   expect(html).toContain('aria-label="التمرير إلى الأسفل"');
   expect(html).not.toContain('aria-label="Scroll to bottom"');
+});
+
+test("keeps the inline scroll action outside the suggested-followups group", () => {
+  const html = renderToStaticMarkup(
+    <IntlProvider locale="ar" messages={messages} timeZone="UTC">
+      <StickToBottomContext value={STICK_TO_BOTTOM}>
+        <SuggestedFollowupChips onSelect={() => {}} prompts={["لخّص النتيجة"]} />
+      </StickToBottomContext>
+    </IntlProvider>,
+  );
+
+  const scrollActionIndex = html.indexOf('aria-label="التمرير إلى الأسفل"');
+  const suggestedGroupIndex = html.indexOf(
+    `aria-label="${messages.chat.suggestedFollowupsLabel}"`,
+  );
+
+  expect(scrollActionIndex).toBeGreaterThan(-1);
+  expect(suggestedGroupIndex).toBeGreaterThan(scrollActionIndex);
+  expect(html.slice(suggestedGroupIndex)).not.toContain(
+    'aria-label="التمرير إلى الأسفل"',
+  );
+});
+
+test("reserves the inline scroll slot while the action is hidden", () => {
+  const html = renderToStaticMarkup(
+    <IntlProvider locale="ar" messages={messages} timeZone="UTC">
+      <StickToBottomContext value={{ ...STICK_TO_BOTTOM, isAtBottom: true }}>
+        <SuggestedFollowupChips onSelect={() => {}} prompts={["لخّص النتيجة"]} />
+      </StickToBottomContext>
+    </IntlProvider>,
+  );
+
+  expect(html).toContain('aria-hidden="true"');
+  expect(html).toContain("invisible");
+  expect(html).not.toContain('aria-label="التمرير إلى الأسفل"');
+  expect(html).toContain(
+    `aria-label="${messages.chat.suggestedFollowupsLabel}"`,
+  );
 });

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -10,10 +10,26 @@ import { ScrollArea } from "@stll/ui/scroll-area";
 import { cn } from "@stll/ui/utils";
 
 import {
+  SuggestedActionSurface,
+  type SuggestedActionSurfaceName,
+} from "@/components/suggested-actions";
+import {
   StickToBottomContext,
   useStickToBottom,
   useStickToBottomContext,
 } from "@/hooks/use-stick-to-bottom";
+
+type ConversationScrollProviderProps = {
+  children: ReactNode;
+};
+
+export const ConversationScrollProvider = ({
+  children,
+}: ConversationScrollProviderProps) => (
+  <StickToBottomContext value={useStickToBottom()}>
+    {children}
+  </StickToBottomContext>
+);
 
 type ConversationProps = ComponentProps<"div">;
 
@@ -21,21 +37,15 @@ export const Conversation = ({
   className,
   children,
   ...props
-}: ConversationProps) => {
-  const stickToBottom = useStickToBottom();
-
-  return (
-    <StickToBottomContext value={stickToBottom}>
-      <div
-        className={cn("relative flex-1 overflow-y-hidden", className)}
-        role="log"
-        {...props}
-      >
-        {children}
-      </div>
-    </StickToBottomContext>
-  );
-};
+}: ConversationProps) => (
+  <div
+    className={cn("relative flex-1 overflow-y-hidden", className)}
+    role="log"
+    {...props}
+  >
+    {children}
+  </div>
+);
 
 type ConversationContentProps = ComponentProps<"div">;
 
@@ -106,41 +116,74 @@ export const ConversationEmptyState = ({
   </div>
 );
 
-type ConversationScrollButtonProps = ComponentProps<typeof Button>;
+type ConversationScrollButtonBaseProps = Omit<
+  ComponentProps<typeof Button>,
+  "onClick" | "size" | "variant"
+>;
+
+type ConversationScrollButtonProps = ConversationScrollButtonBaseProps &
+  (
+    | { placement?: "floating"; surface?: never }
+    | {
+        placement: "inline";
+        surface: Extract<SuggestedActionSurfaceName, "plain" | "overlay">;
+      }
+  );
 
 export const ConversationScrollButton = ({
   className,
+  placement = "floating",
+  surface = "plain",
   ...props
 }: ConversationScrollButtonProps) => {
   const t = useTranslations();
   const { isAtBottom, isScrollable, scrollToBottom } =
     useStickToBottomContext();
+  const isVisible = isScrollable && !isAtBottom;
 
-  return (
-    isScrollable &&
-    !isAtBottom && (
-      <Button
-        aria-label={t("common.scrollToBottom")}
-        className={cn(
-          // The outline variant is translucent in dark mode (content shows
-          // through the button) and its `::before` highlight is a rounded
-          // rectangle whose corners poke past the circle as faint "ears".
-          // Pin an opaque surface in both themes and round `::before` to
-          // the circle; isolate/z-10 keep it above the scrolled content.
-          "bg-background dark:bg-background hover:bg-muted",
-          "isolate shadow-sm before:rounded-full",
-          "absolute bottom-4 left-1/2 z-10 -translate-x-1/2 rounded-full",
-          className,
-        )}
-        onClick={() => scrollToBottom()}
-        size="icon"
-        type="button"
-        variant="outline"
-        {...props}
-      >
-        <ArrowDownIcon className="size-4" />
-      </Button>
-    )
+  if (!isVisible && placement === "floating") {
+    return null;
+  }
+
+  const button = (
+    <Button
+      aria-label={t("common.scrollToBottom")}
+      className={cn(
+        "before:rounded-full",
+        placement === "floating"
+          ? [
+              // The outline variant is translucent in dark mode (content
+              // shows through the button). Pin an opaque surface in both
+              // themes; isolate/z-10 keep it above the scrolled content.
+              "bg-background dark:bg-background hover:bg-muted",
+              "isolate shadow-sm",
+              "absolute bottom-4 left-1/2 z-10 -translate-x-1/2 rounded-full",
+            ]
+          : "size-full rounded-full sm:size-full",
+        className,
+      )}
+      {...props}
+      onClick={() => scrollToBottom()}
+      size={placement === "floating" ? "icon" : "icon-sm"}
+      type="button"
+      variant={
+        placement === "floating" || surface === "plain" ? "outline" : "ghost"
+      }
+    >
+      <ArrowDownIcon className="size-4" />
+    </Button>
+  );
+
+  return placement === "inline" ? (
+    <SuggestedActionSurface
+      aria-hidden={!isVisible || undefined}
+      className={cn("size-8 shrink-0", !isVisible && "invisible")}
+      surface={surface}
+    >
+      {isVisible && button}
+    </SuggestedActionSurface>
+  ) : (
+    button
   );
 };
 

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -2354,16 +2354,6 @@ const FileChatOverlayInner = ({
                 clipped): they stay inside the chat window, scroll with the
                 messages, and are never smashed against the card edge. */}
             <SuggestedFollowupChips
-              isGenerating={isGenerating}
-              isEmpty={
-                editorController.isEmpty &&
-                editorController.attachments.length === 0
-              }
-              lastMessageId={messages.at(-1)?.id ?? null}
-              lastMessageRole={messages.at(-1)?.role ?? null}
-              messageCount={messages.length}
-              prompts={suggestedPrompts}
-              surface="plain"
               onSelect={(prompt) => {
                 // Mirror the PromptBar send guard: when an editable DOCX's edit
                 // snapshot isn't ready, block the chip send too so the model
@@ -2393,6 +2383,8 @@ const FileChatOverlayInner = ({
                   "file-chat-overlay.submit",
                 );
               }}
+              prompts={suggestedPrompts}
+              surface="plain"
             />
           </ChatThreadCard>
         )}

--- a/apps/web/src/components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/components/inspector/chat-tab-panel.tsx
@@ -37,6 +37,7 @@ import {
   Conversation,
   ConversationContent,
   ConversationScrollButton,
+  ConversationScrollProvider,
 } from "@/components/ai-elements/conversation";
 import {
   DockedComposer,
@@ -368,6 +369,7 @@ export const ChatTabPanel = ({
     suggestedFollowupPrompt,
     threadRef,
   });
+  const hasSuggestedFollowups = suggestedPrompts.length > 0;
   const focusComposer = editorController.focus;
   const sendWithoutAnonymization = useLatestCallback(async () => {
     await resendLatestMessage({ sendMode: CHAT_SEND_MODE.rawOverride });
@@ -663,7 +665,9 @@ export const ChatTabPanel = ({
               )}
             </ConversationContent>
             {/* Clear the floating composer block (veil + pill + row). */}
-            <ConversationScrollButton className="bottom-32" />
+            <ConversationScrollButton
+              className={cn("bottom-32", hasSuggestedFollowups && "hidden")}
+            />
           </Conversation>
 
           <ChatAnonymizationLayer
@@ -689,15 +693,6 @@ export const ChatTabPanel = ({
             }
             followupChips={
               <SuggestedFollowupChips
-                isGenerating={isGenerating}
-                isEmpty={
-                  editorController.isEmpty &&
-                  editorController.attachments.length === 0
-                }
-                lastMessageId={messages.at(-1)?.id ?? null}
-                lastMessageRole={messages.at(-1)?.role ?? null}
-                messageCount={messages.length}
-                prompts={suggestedPrompts}
                 onSelect={(prompt) => {
                   editorController.setContent(prompt);
                   detached(
@@ -710,6 +705,7 @@ export const ChatTabPanel = ({
                     "chat-tab-panel.submit",
                   );
                 }}
+                prompts={suggestedPrompts}
               />
             }
             layout="standalone"
@@ -875,7 +871,9 @@ const ChatTabPanelChrome = ({
         }}
       />
 
-      <div className="relative flex min-h-0 flex-1 flex-col">{children}</div>
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        <ConversationScrollProvider>{children}</ConversationScrollProvider>
+      </div>
     </div>
   );
 };

--- a/apps/web/src/components/suggested-actions.tsx
+++ b/apps/web/src/components/suggested-actions.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 
 import { Button } from "@stll/ui/button";
 import { cn } from "@stll/ui/utils";
@@ -8,6 +8,8 @@ export type SuggestedAction = {
   label: string;
   icon?: ReactNode;
 };
+
+export type SuggestedActionSurfaceName = "plain" | "floating" | "overlay";
 
 type SuggestedActionsProps = {
   actions: SuggestedAction[];
@@ -25,7 +27,7 @@ type SuggestedActionsProps = {
    * translucent with a slight backdrop blur, for floating over scrolling
    * text that should stay faintly visible behind the chips.
    */
-  surface?: "plain" | "floating" | "overlay";
+  surface?: SuggestedActionSurfaceName;
   /** Keyboard hint surfaced on each chip via `aria-keyshortcuts`. */
   keyShortcut?: string;
   className?: string;
@@ -42,6 +44,26 @@ const FLOATING_SURFACE_CLASS =
 // while the text behind shows through, blurred.
 const OVERLAY_SURFACE_CLASS =
   "border-foreground/10 bg-background/70 border shadow-sm backdrop-blur-sm";
+
+type SuggestedActionSurfaceProps = ComponentProps<"span"> & {
+  surface: SuggestedActionSurfaceName;
+};
+
+export const SuggestedActionSurface = ({
+  className,
+  surface,
+  ...props
+}: SuggestedActionSurfaceProps) => (
+  <span
+    className={cn(
+      "inline-flex rounded-full",
+      surface === "floating" && FLOATING_SURFACE_CLASS,
+      surface === "overlay" && OVERLAY_SURFACE_CLASS,
+      className,
+    )}
+    {...props}
+  />
+);
 
 /**
  * A row (or stack) of click-to-run "suggested action" chips. Shared by the
@@ -75,14 +97,10 @@ export const SuggestedActions = ({
       role="group"
     >
       {actions.map((action) => (
-        <span
-          className={cn(
-            "inline-flex rounded-full",
-            horizontal ? "shrink-0" : "max-w-full",
-            surface === "floating" && FLOATING_SURFACE_CLASS,
-            surface === "overlay" && OVERLAY_SURFACE_CLASS,
-          )}
+        <SuggestedActionSurface
+          className={cn(horizontal ? "shrink-0" : "max-w-full")}
           key={action.id}
+          surface={surface}
         >
           <Button
             aria-keyshortcuts={keyShortcut}
@@ -100,7 +118,7 @@ export const SuggestedActions = ({
               {action.label}
             </span>
           </Button>
-        </span>
+        </SuggestedActionSurface>
       ))}
     </div>
   );

--- a/apps/web/src/features/chat/components/suggested-followup-chips.tsx
+++ b/apps/web/src/features/chat/components/suggested-followup-chips.tsx
@@ -2,24 +2,11 @@ import { useTranslations } from "use-intl";
 
 import { cn } from "@stll/ui/utils";
 
+import { ConversationScrollButton } from "@/components/ai-elements/conversation";
 import { SuggestedActions } from "@/components/suggested-actions";
-
-// A user + assistant exchange is the minimum to have something to suggest from.
-const SUGGESTIONS_MIN_MESSAGE_COUNT = 2;
+import { useMaybeStickToBottomContext } from "@/hooks/use-stick-to-bottom";
 
 type SuggestedFollowupChipsProps = {
-  isGenerating: boolean;
-  isEmpty: boolean;
-  lastMessageId: string | null;
-  lastMessageRole: "user" | "assistant" | "system" | "tool" | null;
-  messageCount: number;
-  prompts: string[];
-  /**
-   * Chip backdrop. `overlay` (default) suits chips floating over document
-   * text; `plain` suits chips rendered on a solid surface such as inside the
-   * thread card, where the card already separates them from the document.
-   */
-  surface?: "plain" | "overlay";
   className?: string;
   /**
    * Called when a chip is clicked. The caller is responsible for setting the
@@ -27,47 +14,54 @@ type SuggestedFollowupChipsProps = {
    * `clearDraft` / `clearContent` path runs.
    */
   onSelect: (prompt: string) => void;
+  /** Prompts already gated by `resolveSuggestedPromptsAvailability`. */
+  prompts: string[];
+  /**
+   * Chip backdrop. `overlay` (default) suits chips floating over document
+   * text; `plain` suits chips rendered on a solid surface such as inside the
+   * thread card, where the card already separates them from the document.
+   */
+  surface?: "plain" | "overlay";
 };
 
 /**
  * Suggested follow-up prompts, shown as a single horizontally scrolling row
- * when the composer is empty, the AI has just responded, and no generation is
- * in progress. They disappear once the user starts typing or submits a
- * message. Placement is the caller's choice: `surface="overlay"` (default)
- * for a row floating above the composer, or `surface="plain"` when rendered
- * inside the thread card so the chips sit within the chat window.
+ * after the shared availability policy supplies prompts. Placement is the
+ * caller's choice: `surface="overlay"` (default) for a row floating above the
+ * composer, or `surface="plain"` when rendered inside the thread card so the
+ * chips sit within the chat window.
  */
 export const SuggestedFollowupChips = ({
-  isGenerating,
-  isEmpty,
-  lastMessageId,
-  lastMessageRole,
-  messageCount,
-  prompts,
-  surface,
   className,
   onSelect,
+  prompts,
+  surface,
 }: SuggestedFollowupChipsProps) => {
   const t = useTranslations();
-  const eligible =
-    isEmpty &&
-    !isGenerating &&
-    lastMessageId !== null &&
-    lastMessageRole === "assistant" &&
-    messageCount >= SUGGESTIONS_MIN_MESSAGE_COUNT;
+  const stickToBottom = useMaybeStickToBottomContext();
 
-  if (!eligible) {
+  if (prompts.length === 0) {
     return null;
   }
 
+  const resolvedSurface = surface ?? "overlay";
+
   return (
-    <SuggestedActions
-      actions={prompts.map((prompt) => ({ id: prompt, label: prompt }))}
-      className={cn("pb-2", className)}
-      label={t("chat.suggestedFollowupsLabel")}
-      onSelect={onSelect}
-      orientation="horizontal"
-      surface={surface ?? "overlay"}
-    />
+    <div className={cn("flex max-w-full items-start gap-1.5 pb-2", className)}>
+      {stickToBottom !== null && (
+        <ConversationScrollButton
+          placement="inline"
+          surface={resolvedSurface}
+        />
+      )}
+      <SuggestedActions
+        actions={prompts.map((prompt) => ({ id: prompt, label: prompt }))}
+        className="min-w-0 flex-1"
+        label={t("chat.suggestedFollowupsLabel")}
+        onSelect={onSelect}
+        orientation="horizontal"
+        surface={resolvedSurface}
+      />
+    </div>
   );
 };

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from "react";
+import type { ReactNode, RefObject } from "react";
 
 import {
   useMutation,
@@ -21,6 +22,7 @@ import {
   Conversation,
   ConversationContent,
   ConversationScrollButton,
+  ConversationScrollProvider,
 } from "@/components/ai-elements/conversation";
 import {
   ChatSubmitPreservedError,
@@ -357,6 +359,7 @@ export const ChatThreadPage = ({
     suggestedFollowupPrompt,
     threadRef,
   });
+  const hasSuggestedFollowups = suggestedFollowupPrompts.length > 0;
 
   const openInspectorChat = useInspectorTabsStore((s) => s.openChat);
   const navigate = useNavigate();
@@ -640,10 +643,7 @@ export const ChatThreadPage = ({
             value (sticky headers, scroll button) inside its own context so
             none of them can leak up and overlay the fade or the composer.
           */}
-            <div
-              className="relative flex min-h-0 flex-1 flex-col"
-              ref={pageContainerRef}
-            >
+            <ChatThreadScrollSurface containerRef={pageContainerRef}>
               <Conversation className="@container isolate min-h-0">
                 <ConversationContent className="mx-auto w-full max-w-5xl gap-3 px-4 pb-[calc(var(--composer-block-h,7rem)+1.5rem)]">
                   {messages.length === 0 && !isGenerating && !error ? (
@@ -696,7 +696,12 @@ export const ChatThreadPage = ({
                   )}
                 </ConversationContent>
                 <ChatTurnNavigator messages={messages} />
-                <ConversationScrollButton className="bottom-[calc(var(--composer-block-h,7rem)+0.75rem)]" />
+                <ConversationScrollButton
+                  className={cn(
+                    "bottom-[calc(var(--composer-block-h,7rem)+0.75rem)]",
+                    hasSuggestedFollowups && "hidden",
+                  )}
+                />
               </Conversation>
 
               <ChatAnonymizationLayer
@@ -734,14 +739,6 @@ export const ChatThreadPage = ({
                 ref={composerBlockRef}
               >
                 <SuggestedFollowupChips
-                  isGenerating={isGenerating}
-                  isEmpty={
-                    controller.isEmpty && controller.attachments.length === 0
-                  }
-                  lastMessageId={messages.at(-1)?.id ?? null}
-                  lastMessageRole={messages.at(-1)?.role ?? null}
-                  messageCount={messages.length}
-                  prompts={suggestedFollowupPrompts}
                   onSelect={(prompt) => {
                     controller.setContent(prompt);
                     detached(
@@ -754,6 +751,7 @@ export const ChatThreadPage = ({
                       "chat-thread-page.submit",
                     );
                   }}
+                  prompts={suggestedFollowupPrompts}
                 />
                 {env.VITE_FEATURE_USAGE && <UsageFallbackNotice />}
                 {/* Glass tray behind the composer + status row: the shared
@@ -820,7 +818,7 @@ export const ChatThreadPage = ({
                   />
                 </div>
               </div>
-            </div>
+            </ChatThreadScrollSurface>
           </div>
         </ChatApprovalContext>
         <UsageLimitModal
@@ -831,6 +829,22 @@ export const ChatThreadPage = ({
     </RenderStormRegion>
   );
 };
+
+type ChatThreadScrollSurfaceProps = {
+  children: ReactNode;
+  containerRef: RefObject<HTMLDivElement | null>;
+};
+
+const ChatThreadScrollSurface = ({
+  children,
+  containerRef,
+}: ChatThreadScrollSurfaceProps) => (
+  <ConversationScrollProvider>
+    <div className="relative flex min-h-0 flex-1 flex-col" ref={containerRef}>
+      {children}
+    </div>
+  </ConversationScrollProvider>
+);
 
 type ChatWebSearchSeedProps = {
   threadRef: ChatThreadRef;


### PR DESCRIPTION
## Proposed change

This PR resolves the visual clash and overlap between the floating scroll-down button and the suggested follow-up prompts/questions row in the chat surfaces.

- **Shared Scroll Context**: Lifted and shared `StickToBottomContext` in both the inspector panel and the main chat thread page so that the suggested follow-up chips can check scroll state.
- **Inline Scroll Down Button**: When suggested follow-up chips are visible, the default floating scroll-down button is hidden. Instead, it is rendered as the first element in the suggested follow-up prompts row, styled as a small, round button matching the active surface theme (translucent or plain).
- **TypeScript Exclusions**: Updated `apps/web/tsconfig.json` to exclude the `dist/` build directory to prevent the compiler from checking generated/built assets.

Closes: #1705

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [x] **DARK MODE SUPPORT** | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [x] **ISSUE LINKED** | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [x] **SCREENSHOT INCLUDED** | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

<img width="575" height="288" alt="image" src="https://github.com/user-attachments/assets/487d80ef-5277-4c7d-9e2d-50e048af084f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added suggested follow-up prompts to chat conversations when relevant.
  * Added an optional scroll-to-bottom button when follow-up prompts are available and newer messages are below the current view.
  * Improved suggested-action layouts with support for leading content.

* **Bug Fixes**
  * Improved chat scrolling behaviour across conversation views, preserving shared scroll state and keeping content positioned appropriately.
  * Follow-up prompts now appear only when the composer and conversation state meet the required conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->