### PR TITLE
fix(api): support IP-family fallback for outbound requests

### DIFF
--- a/apps/api/src/lib/safe-outbound-fetch.test.ts
+++ b/apps/api/src/lib/safe-outbound-fetch.test.ts
@@ -36,6 +36,31 @@ describe("fetchWithResolvedAddress", () => {
     );
   });
 
+  test("falls back when the first resolved address is unreachable", async () => {
+    await withHttpServer(
+      (_request, response) => {
+        response.end("ready");
+      },
+      async (port) => {
+        const result = await fetchWithResolvedAddress({
+          addresses: [
+            { address: "::1", family: 6 },
+            { address: "127.0.0.1", family: 4 },
+          ],
+          maxBytes: 1024,
+          timeoutMs: 1000,
+          url: new URL(`http://example.test:${port}/probe`),
+        });
+
+        expect(Result.isOk(result)).toBe(true);
+        if (Result.isError(result)) {
+          throw result.error;
+        }
+        expect(new TextDecoder().decode(result.value.body)).toBe("ready");
+      },
+    );
+  });
+
   test("stops reading when the response exceeds the byte cap", async () => {
     await withHttpServer(
       (_request, response) => {
@@ -108,6 +133,40 @@ describe("fetchWithResolvedAddress", () => {
       async (port) => {
         const result = await fetchStreamWithResolvedAddress({
           addresses: [{ address: "127.0.0.1", family: 4 }],
+          maxBytes: 1024,
+          timeoutMs: 1000,
+          url: new URL(`http://example.test:${port}/events`),
+        });
+
+        expect(Result.isOk(result)).toBe(true);
+        if (Result.isError(result)) {
+          throw result.error;
+        }
+
+        const reader = result.value.body.getReader();
+        const firstChunk = await reader.read();
+        await reader.cancel();
+
+        expect(firstChunk.done).toBe(false);
+        expect(new TextDecoder().decode(firstChunk.value)).toContain(
+          "data: ready",
+        );
+      },
+    );
+  });
+
+  test("streams through a reachable fallback address", async () => {
+    await withHttpServer(
+      (_request, response) => {
+        response.writeHead(200, { "Content-Type": "text/event-stream" });
+        response.write("event: ping\ndata: ready\n\n");
+      },
+      async (port) => {
+        const result = await fetchStreamWithResolvedAddress({
+          addresses: [
+            { address: "::1", family: 6 },
+            { address: "127.0.0.1", family: 4 },
+          ],
           maxBytes: 1024,
           timeoutMs: 1000,
           url: new URL(`http://example.test:${port}/events`),

--- a/apps/api/src/lib/safe-outbound-fetch.ts
+++ b/apps/api/src/lib/safe-outbound-fetch.ts
@@ -4,6 +4,7 @@ import { request as requestHttp } from "node:http";
 import type { IncomingMessage } from "node:http";
 import { request as requestHttps } from "node:https";
 import { isIP } from "node:net";
+import type { LookupFunction, TcpSocketConnectOpts } from "node:net";
 import * as v from "valibot";
 
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
@@ -46,6 +47,31 @@ export type SafeOutboundFetchStreamResponse = {
 
 type SafeOutboundRedirectMode = "error" | "manual";
 
+// The caller vetted this whole set together. Keep it pinned while allowing
+// Happy Eyeballs to select a reachable family without another DNS lookup.
+const createPinnedLookup =
+  ({
+    addresses,
+    primaryAddress,
+  }: {
+    addresses: readonly SafeOutboundAddress[];
+    primaryAddress: SafeOutboundAddress;
+  }): LookupFunction =>
+  (_hostname, options, callback) => {
+    if (options.all === true) {
+      callback(
+        null,
+        addresses.map(({ address, family }) => ({ address, family })),
+      );
+      return;
+    }
+    callback(null, primaryAddress.address, primaryAddress.family);
+  };
+
+const AUTO_SELECT_FAMILY_OPTIONS = {
+  autoSelectFamily: true,
+} as const satisfies Pick<TcpSocketConnectOpts, "autoSelectFamily">;
+
 export const fetchWithResolvedAddress = async ({
   addresses,
   body,
@@ -65,8 +91,8 @@ export const fetchWithResolvedAddress = async ({
   timeoutMs: number;
   url: URL;
 }): Promise<Result<SafeOutboundFetchResponse, SafeOutboundFetchError>> => {
-  const address = addresses.at(0);
-  if (!address) {
+  const primaryAddress = addresses.at(0);
+  if (!primaryAddress) {
     return Result.err(
       new SafeOutboundFetchError({ message: "No resolved address available" }),
     );
@@ -93,15 +119,10 @@ export const fetchWithResolvedAddress = async ({
           url.protocol === "https:" ? requestHttps : requestHttp
         )(
           {
+            ...AUTO_SELECT_FAMILY_OPTIONS,
             headers: headersToObject(requestHeaders),
             hostname: url.hostname,
-            lookup: (_hostname, options, callback) => {
-              if (typeof options === "object" && options.all === true) {
-                callback(null, [address]);
-                return;
-              }
-              callback(null, address.address, address.family);
-            },
+            lookup: createPinnedLookup({ addresses, primaryAddress }),
             method,
             path: `${url.pathname}${url.search}`,
             port: url.port || undefined,
@@ -199,8 +220,8 @@ export const fetchStreamWithResolvedAddress = async ({
 }): Promise<
   Result<SafeOutboundFetchStreamResponse, SafeOutboundFetchError>
 > => {
-  const address = addresses.at(0);
-  if (!address) {
+  const primaryAddress = addresses.at(0);
+  if (!primaryAddress) {
     return Result.err(
       new SafeOutboundFetchError({ message: "No resolved address available" }),
     );
@@ -227,15 +248,10 @@ export const fetchStreamWithResolvedAddress = async ({
           url.protocol === "https:" ? requestHttps : requestHttp
         )(
           {
+            ...AUTO_SELECT_FAMILY_OPTIONS,
             headers: headersToObject(requestHeaders),
             hostname: url.hostname,
-            lookup: (_hostname, options, callback) => {
-              if (typeof options === "object" && options.all === true) {
-                callback(null, [address]);
-                return;
-              }
-              callback(null, address.address, address.family);
-            },
+            lookup: createPinnedLookup({ addresses, primaryAddress }),
             method,
             path: `${url.pathname}${url.search}`,
             port: url.port || undefined,


### PR DESCRIPTION
## Summary

- allow socket family auto-selection across the complete prevalidated DNS address set
- keep outbound requests pinned without a second DNS lookup
- cover buffered and streaming fallback when the first address family is unreachable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for outbound HTTP(S) requests when the first resolved network address is unreachable.
  - Requests can now automatically try an alternative resolved address, including both standard and streaming responses.
  - Successful responses continue to be handled normally after address selection and retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->