### PR TITLE
fix(api): surface workflow file preparation failures as a result

### DIFF
--- a/apps/api/src/lib/workflow/generate-batch-preparation.test.ts
+++ b/apps/api/src/lib/workflow/generate-batch-preparation.test.ts
@@ -1,0 +1,84 @@
+import { Result } from "better-result";
+import { describe, expect, mock, test } from "bun:test";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import type { FieldContent } from "@/api/db/schema-validators";
+import { toSafeId } from "@/api/lib/branded-types";
+import { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
+import type { GenerateBatchProps } from "@/api/lib/workflow/generate-batch-shared";
+import type { AIBatchProperty } from "@/api/lib/workflow/get-execution-plan";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+const fileFieldId = toSafeId<"field">("field_file");
+const propertyId = toSafeId<"property">("property_extract");
+
+const fileContent = {
+  version: 1,
+  type: "file",
+  id: "00000000-0000-4000-8000-000000000001",
+  fileName: "contract.pdf",
+  mimeType: "application/pdf",
+  sizeBytes: 1024,
+  encrypted: false,
+  sha256Hex: "a".repeat(64),
+  pdfFileId: null,
+} as const satisfies FieldContent;
+
+const realShared = await import("@/api/lib/workflow/generate-batch-shared");
+
+void mock.module("@/api/lib/workflow/generate-batch-shared", () => ({
+  ...realShared,
+  fetchInputFieldsForBatch: async () => [
+    { id: fileFieldId, propertyId, content: fileContent },
+  ],
+}));
+
+// The failure under test: every path in `fetchAndPrepareFiles` reaches S3
+// before it can produce a prepared file.
+const readFailure = new Error("object read failed");
+const realS3 = await import("@/api/lib/s3");
+
+void mock.module("@/api/lib/s3", () => ({
+  ...realS3,
+  readS3ArrayBuffer: async () => {
+    throw readFailure;
+  },
+}));
+
+const { generateBatch } = await import("@/api/lib/workflow/generate-batch");
+
+const aiProperty = {
+  id: propertyId,
+  status: "stale",
+  content: { version: 1, type: "text" },
+  dependencies: [],
+  tool: { version: 1, type: "ai-model", prompt: "Extract the parties." },
+} as const satisfies AIBatchProperty;
+
+const props = {
+  abortSignal: new AbortController().signal,
+  batch: { id: "batch_0", inputs: [propertyId], properties: [aiProperty] },
+  entityVersionId: toSafeId<"entityVersion">("entity_version_test"),
+  organizationId: toSafeId<"organization">("org_test"),
+  workspaceId: toSafeId<"workspace">("workspace_test"),
+  scopedDb: asTestRaw<ScopedDb>(async () => []),
+  orgAIConfig: null,
+  promptCachingEnabled: false,
+  serviceTier: "standard",
+} as const satisfies GenerateBatchProps;
+
+describe("workflow batch input preparation", () => {
+  test("reports an unreadable input file as an integration failure instead of rejecting", async () => {
+    const result = await generateBatch(props);
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+
+    // The declared error union is what the caller retries on and maps to a
+    // gateway status; a rejection would bypass both.
+    expect(WorkflowIntegrationError.is(result.error)).toBe(true);
+    expect(result.error.cause).toBe(readFailure);
+  });
+});

--- a/apps/api/src/lib/workflow/generate-batch-preparation.test.ts
+++ b/apps/api/src/lib/workflow/generate-batch-preparation.test.ts
@@ -61,7 +61,9 @@ const props = {
   entityVersionId: toSafeId<"entityVersion">("entity_version_test"),
   organizationId: toSafeId<"organization">("org_test"),
   workspaceId: toSafeId<"workspace">("workspace_test"),
-  scopedDb: asTestRaw<ScopedDb>(async () => []),
+  scopedDb: asTestRaw<ScopedDb>(async () => {
+    throw new Error("unexpected database access");
+  }),
   orgAIConfig: null,
   promptCachingEnabled: false,
   serviceTier: "standard",

--- a/apps/api/src/lib/workflow/generate-batch.ts
+++ b/apps/api/src/lib/workflow/generate-batch.ts
@@ -289,10 +289,25 @@ export const generateBatch = async ({
       });
     }
 
-    const preparedFiles = await fetchAndPrepareFiles(
-      resolvedFiles,
-      organizationId,
-      workspaceId,
+    // `fetchAndPrepareFiles` signals failure by rejecting (S3 reads, DOCX
+    // parsing, bates stamping, text extraction). Awaiting it bare would let
+    // that rejection escape `Result.gen` as a panic, so the integration
+    // failure this function declares in its error union would never reach
+    // the caller's retry and status classification.
+    const preparedFiles = yield* Result.await(
+      Result.tryPromise({
+        try: async () =>
+          await fetchAndPrepareFiles(
+            resolvedFiles,
+            organizationId,
+            workspaceId,
+          ),
+        catch: (cause) =>
+          new WorkflowIntegrationError({
+            message: "Failed to prepare workflow input files",
+            cause,
+          }),
+      }),
     );
 
     const filenames = buildJustificationFilenames(preparedFiles);


### PR DESCRIPTION
## Proposed change

`generateBatch` declares `WorkflowIntegrationError` in its result error union
(`GenerateBatchResult`), but awaits `fetchAndPrepareFiles` bare inside
`Result.gen`:

```ts
const preparedFiles = await fetchAndPrepareFiles(
  resolvedFiles,
  organizationId,
  workspaceId,
);
```

`fetchAndPrepareFiles` signals failure by rejecting: the S3 reads, the
`FolioDocxReviewer` DOCX parse, bates stamping, and the native-Office text
extraction all leave it as rejections. A rejection inside a `Result.gen` body
is not turned into an error result: `better-result` catches it and rethrows it
as a `Panic`. So `generateBatch` rejects rather than returning the error its
signature declares, and neither consumer of that union sees it:

- `shouldRetryWorkflowBatchError` classifies `WorkflowIntegrationError` as
  retryable, so a file-preparation failure skips the retry the batch runner is
  configured to give it.
- `handlers/properties/preview.ts` matches on the error to choose between a
  `skipped` response and a 502 carrying the classified provider cause. A panic
  bypasses that classification.

Wrap the call in `Result.tryPromise`, as the other call sites that need the
failure as a value already do (`lib/document-review/review-extract.ts`,
`handlers/document-reviews/propose-topics.ts`).

The remaining bare call in `lib/document-review/run-queue.ts` is deliberately
left as it is: `executeRun` documents that its failure path is identical
whether it returns or throws, and its caller wraps it.

Adds a test for the invariant, not the individual throw site: an input file
that cannot be read surfaces as `Result.err(WorkflowIntegrationError)` rather
than a rejection.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | `bun scripts/run-tests.ts src/lib/workflow/` and `src/lib/document-review/` pass; the new test fails against the previous behaviour (unhandled rejection) and passes with the fix.
- [ ] DARK MODE SUPPORT | Not applicable, API-only change.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable, no user-visible surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F58jfzMgy8HzBCezYqJJ9T)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unreadable workflow input files.
  * Failures while reading or preparing files are now reported consistently as workflow integration errors.
  * Preserved underlying error details to support clearer diagnostics and appropriate retry handling.

* **Tests**
  * Added coverage for unreadable batch input files and verified the expected failure response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->