### PR TITLE
refactor(api): keep tool results typed internally

### DIFF
--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-tool-error.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-tool-error.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import type { InternalToolError } from "@/api/mcp/tool-types";
+
+import {
+  classifyRegistryErrorKind,
+  toRegistryChatToolError,
+} from "./registry-tool-error";
+
+describe("registry tool error projection", () => {
+  test("preserves every structured recovery field at the chat boundary", () => {
+    const error = {
+      type: "structured",
+      code: "validation_error",
+      message: "The cursor is invalid.",
+      hint: "Pass the cursor verbatim or omit it to restart pagination.",
+      issues: [{ path: "cursor", message: "Invalid cursor" }],
+      retryable: false,
+      requestId: "request_123",
+    } as const satisfies InternalToolError;
+
+    const projected = toRegistryChatToolError(error);
+
+    expect(projected.kind).toBe("invalid-input");
+    expect(JSON.parse(projected.message)).toEqual({
+      error: {
+        code: "validation_error",
+        message: "The cursor is invalid.",
+        hint: "Pass the cursor verbatim or omit it to restart pagination.",
+        issues: [{ path: "cursor", message: "Invalid cursor" }],
+        retryable: false,
+        requestId: "request_123",
+      },
+    });
+  });
+
+  test("keeps legacy text errors plain and conservatively correctable", () => {
+    const error = {
+      type: "text",
+      message: "Use a supported argument combination.",
+    } as const satisfies InternalToolError;
+
+    expect(classifyRegistryErrorKind(error)).toBe("invalid-input");
+    expect(toRegistryChatToolError(error)).toMatchObject({
+      kind: "invalid-input",
+      message: "Use a supported argument combination.",
+    });
+  });
+});

--- a/apps/api/src/handlers/chat/tools/registry-adapter/registry-tool-error.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/registry-tool-error.ts
@@ -1,0 +1,56 @@
+import type { ChatToolErrorKind } from "@/api/lib/errors/tagged-errors";
+import { ChatToolError } from "@/api/lib/errors/tagged-errors";
+import type { McpErrorCode } from "@/api/mcp/error-codes";
+import type { InternalToolError } from "@/api/mcp/tool-types";
+
+const MCP_CODE_TO_CHAT_KIND = {
+  validation_error: "invalid-input",
+  missing_scope: "unavailable",
+  feature_disabled: "unavailable",
+  not_found: "not-found",
+  confirmation_required: "invalid-input",
+  permission_denied: "unavailable",
+  usage_limited: "limit",
+  // A 409 needs a different action (refetch state, rename, regenerate), which
+  // is the model correcting its input, not a defect or a bare retry.
+  conflict: "invalid-input",
+  rate_limited: "transient",
+  upstream_unavailable: "transient",
+  unknown_tool: "unavailable",
+  internal_error: "server-defect",
+} as const satisfies Record<McpErrorCode, ChatToolErrorKind>;
+
+/**
+ * Classify a typed registry error directly. Legacy code-less plain-text errors
+ * default to `invalid-input`: the conservative non-blocking kind, since a
+ * wrong `server-defect` would suppress legitimate corrected retries.
+ */
+export const classifyRegistryErrorKind = (
+  error: InternalToolError,
+): ChatToolErrorKind =>
+  error.type === "structured"
+    ? MCP_CODE_TO_CHAT_KIND[error.code]
+    : "invalid-input";
+
+/**
+ * Project one canonical internal tool error to the chat model boundary.
+ * Plain-text errors stay plain. Structured errors retain the same stable
+ * envelope agents receive over MCP, but this projection consumes the typed
+ * error directly instead of serializing and reparsing an MCP response.
+ */
+export const toRegistryChatToolError = (
+  error: InternalToolError,
+): ChatToolError => {
+  if (error.type === "text") {
+    return new ChatToolError({
+      kind: classifyRegistryErrorKind(error),
+      message: error.message,
+    });
+  }
+
+  const { type: _type, ...details } = error;
+  return new ChatToolError({
+    kind: classifyRegistryErrorKind(error),
+    message: JSON.stringify({ error: details }),
+  });
+};

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
@@ -18,10 +18,10 @@ import { STELLA_TOOL_HANDLERS } from "@/api/mcp/stella-tools";
 import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
 import type { McpToolHandler } from "@/api/mcp/tool-types";
 
-import { toRegistryChatToolError } from "./registry-tool-error";
 import type { RegistryReadToolName } from "./ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 import { dehydrateInputRefs } from "./ref-mediation";
+import { toRegistryChatToolError } from "./registry-tool-error";
 
 /**
  * The read-only registry handlers chat may drive, gathered from the per-domain

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
@@ -1,4 +1,3 @@
-import type { CallToolResult } from "@modelcontextprotocol/server";
 import { panic, Result } from "better-result";
 
 import { projectForChat } from "@/api/lib/chat/projection-schema";
@@ -10,9 +9,8 @@ import { CAPABILITY_TOOL_HANDLERS } from "@/api/mcp/capability-tools";
 import { COMPAT_TOOL_HANDLERS } from "@/api/mcp/compat-tools";
 import type { McpRequestContext } from "@/api/mcp/context";
 import { DOCUMENT_TOOL_HANDLERS } from "@/api/mcp/document-tools";
-import { finalizeMcpEgress } from "@/api/mcp/egress";
+import { finalizeToolEgress } from "@/api/mcp/egress";
 import type { McpErrorCode } from "@/api/mcp/error-codes";
-import { MCP_ERROR_CODES } from "@/api/mcp/error-codes";
 import { isMcpToolFeatureEnabled } from "@/api/mcp/gateway/list-tools";
 import { KNOWLEDGE_TOOL_HANDLERS } from "@/api/mcp/knowledge-tools";
 import { MATTER_TOOL_HANDLERS } from "@/api/mcp/matter-tools";
@@ -20,7 +18,7 @@ import { RESEARCH_ADMIN_TOOL_HANDLERS } from "@/api/mcp/research-admin-tools";
 import { getStaticMcpToolDefinition } from "@/api/mcp/static-tool-definitions";
 import { STELLA_TOOL_HANDLERS } from "@/api/mcp/stella-tools";
 import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
-import type { McpToolHandler } from "@/api/mcp/tool-types";
+import type { InternalToolError, McpToolHandler } from "@/api/mcp/tool-types";
 
 import type { RegistryReadToolName } from "./ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
@@ -64,14 +62,6 @@ const REGISTRY_READ_TOOL_HANDLERS = {
   describe_capability: CAPABILITY_TOOL_HANDLERS.describe_capability,
 } satisfies Record<RegistryReadToolName, McpToolHandler>;
 
-export const firstTextContent = (result: CallToolResult): string => {
-  const item = result.content.at(0);
-  return item?.type === "text" ? item.text : "";
-};
-
-/** Fallback for an `isError` result whose content carries no text block. */
-export const DEFAULT_TOOL_ERROR_MESSAGE = "Tool execution failed.";
-
 const MCP_CODE_TO_CHAT_KIND = {
   validation_error: "invalid-input",
   missing_scope: "unavailable",
@@ -89,63 +79,17 @@ const MCP_CODE_TO_CHAT_KIND = {
   internal_error: "server-defect",
 } as const satisfies Record<McpErrorCode, ChatToolErrorKind>;
 
-const isMcpErrorCode = (value: unknown): value is McpErrorCode =>
-  typeof value === "string" && MCP_ERROR_CODES.some((code) => code === value);
-
 /**
- * Classify a finished registry `isError` result into a chat error kind via the
- * envelope's stable `error.code` (`structuredErrorResult`). Legacy code-less
- * plain-text errors ("Forbidden", bespoke hints) default to `invalid-input`:
- * the conservative non-blocking kind, since a wrong `server-defect` would
- * suppress legitimate corrected retries. The boundary parse of an
- * already-serialized envelope is not control flow.
+ * Classify a typed registry error directly. Legacy code-less plain-text errors
+ * default to `invalid-input`: the conservative non-blocking kind, since a
+ * wrong `server-defect` would suppress legitimate corrected retries.
  */
 export const classifyRegistryErrorKind = (
-  message: string,
-): ChatToolErrorKind => {
-  try {
-    const parsed: unknown = JSON.parse(message);
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      "error" in parsed &&
-      typeof parsed.error === "object" &&
-      parsed.error !== null &&
-      "code" in parsed.error &&
-      isMcpErrorCode(parsed.error.code)
-    ) {
-      return MCP_CODE_TO_CHAT_KIND[parsed.error.code];
-    }
-  } catch {
-    // Legacy plain-text error; fall through to the default.
-  }
-  return "invalid-input";
-};
-
-/**
- * A finished registry result is a single text content block holding the
- * handler's JSON payload (`textResult`). Parse it back into the plain object the
- * chat sandbox expects, mapping a malformed body to a `ChatToolError`. The
- * try/catch is a boundary parse of an already-serialized payload, not control
- * flow.
- */
-export const parsePayload = (
-  result: CallToolResult,
-): Result<unknown, ChatToolError> => {
-  try {
-    // JSON.parse is typed `any`; pin it to `unknown` so the payload stays
-    // opaque until ref hydration walks it (no `as` cast).
-    const parsed: unknown = JSON.parse(firstTextContent(result));
-    return Result.ok(parsed);
-  } catch {
-    return Result.err(
-      new ChatToolError({
-        kind: "server-defect",
-        message: "The tool returned a response that could not be read.",
-      }),
-    );
-  }
-};
+  error: InternalToolError,
+): ChatToolErrorKind =>
+  error.type === "structured"
+    ? MCP_CODE_TO_CHAT_KIND[error.code]
+    : "invalid-input";
 
 export type RunRegistryReadToolProps = {
   toolName: RegistryReadToolName;
@@ -204,22 +148,19 @@ export const runRegistryReadTool = async ({
     args: dehydrated.value.args,
     context,
   });
-  const finished = await finalizeMcpEgress({
+  const finished = await finalizeToolEgress({
     context,
     mode: "default",
     response,
   });
 
-  if (finished.isError === true) {
-    const message = firstTextContent(finished) || DEFAULT_TOOL_ERROR_MESSAGE;
+  if (finished.status === "error") {
     return Result.err(
-      new ChatToolError({ kind: classifyRegistryErrorKind(message), message }),
+      new ChatToolError({
+        kind: classifyRegistryErrorKind(finished.error),
+        message: finished.error.message,
+      }),
     );
-  }
-
-  const payload = parsePayload(finished);
-  if (Result.isError(payload)) {
-    return Result.err(payload.error);
   }
 
   // One schema-driven pass: strict parse (an unknown key — a field nobody
@@ -228,7 +169,7 @@ export const runRegistryReadTool = async ({
   // invariant in the same walk. Failures carry only paths to telemetry.
   return projectForChat({
     dehydration: dehydrated.value,
-    payload: payload.value,
+    payload: finished.data,
     refRegistry,
     schema: entry.projection,
     source: "run-registry-tool",

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
@@ -2,7 +2,6 @@ import { panic, Result } from "better-result";
 
 import { projectForChat } from "@/api/lib/chat/projection-schema";
 import type { ChatRefRegistry } from "@/api/lib/chat/ref-registry";
-import type { ChatToolErrorKind } from "@/api/lib/errors/tagged-errors";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
 import { BILLING_TOOL_HANDLERS } from "@/api/mcp/billing-tools";
 import { CAPABILITY_TOOL_HANDLERS } from "@/api/mcp/capability-tools";
@@ -10,7 +9,6 @@ import { COMPAT_TOOL_HANDLERS } from "@/api/mcp/compat-tools";
 import type { McpRequestContext } from "@/api/mcp/context";
 import { DOCUMENT_TOOL_HANDLERS } from "@/api/mcp/document-tools";
 import { finalizeToolEgress } from "@/api/mcp/egress";
-import type { McpErrorCode } from "@/api/mcp/error-codes";
 import { isMcpToolFeatureEnabled } from "@/api/mcp/gateway/list-tools";
 import { KNOWLEDGE_TOOL_HANDLERS } from "@/api/mcp/knowledge-tools";
 import { MATTER_TOOL_HANDLERS } from "@/api/mcp/matter-tools";
@@ -18,8 +16,9 @@ import { RESEARCH_ADMIN_TOOL_HANDLERS } from "@/api/mcp/research-admin-tools";
 import { getStaticMcpToolDefinition } from "@/api/mcp/static-tool-definitions";
 import { STELLA_TOOL_HANDLERS } from "@/api/mcp/stella-tools";
 import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
-import type { InternalToolError, McpToolHandler } from "@/api/mcp/tool-types";
+import type { McpToolHandler } from "@/api/mcp/tool-types";
 
+import { toRegistryChatToolError } from "./registry-tool-error";
 import type { RegistryReadToolName } from "./ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 import { dehydrateInputRefs } from "./ref-mediation";
@@ -62,35 +61,6 @@ const REGISTRY_READ_TOOL_HANDLERS = {
   describe_capability: CAPABILITY_TOOL_HANDLERS.describe_capability,
 } satisfies Record<RegistryReadToolName, McpToolHandler>;
 
-const MCP_CODE_TO_CHAT_KIND = {
-  validation_error: "invalid-input",
-  missing_scope: "unavailable",
-  feature_disabled: "unavailable",
-  not_found: "not-found",
-  confirmation_required: "invalid-input",
-  permission_denied: "unavailable",
-  usage_limited: "limit",
-  // A 409 needs a different action (refetch state, rename, regenerate), which
-  // is the model correcting its input, not a defect or a bare retry.
-  conflict: "invalid-input",
-  rate_limited: "transient",
-  upstream_unavailable: "transient",
-  unknown_tool: "unavailable",
-  internal_error: "server-defect",
-} as const satisfies Record<McpErrorCode, ChatToolErrorKind>;
-
-/**
- * Classify a typed registry error directly. Legacy code-less plain-text errors
- * default to `invalid-input`: the conservative non-blocking kind, since a
- * wrong `server-defect` would suppress legitimate corrected retries.
- */
-export const classifyRegistryErrorKind = (
-  error: InternalToolError,
-): ChatToolErrorKind =>
-  error.type === "structured"
-    ? MCP_CODE_TO_CHAT_KIND[error.code]
-    : "invalid-input";
-
 export type RunRegistryReadToolProps = {
   toolName: RegistryReadToolName;
   args: Record<string, unknown>;
@@ -107,8 +77,8 @@ export type RunRegistryReadToolProps = {
  * 2. Dehydrate ref args to real UUIDs.
  * 3. Run the handler and finalize its egress in DEFAULT mode (chat is not the
  *    anonymized surface).
- * 4. Map an `isError` result into a `ChatToolError`; otherwise parse the JSON
- *    payload and project it for chat in a single schema-driven pass
+ * 4. Project a typed error into a `ChatToolError`; otherwise project the typed
+ *    payload for chat in a single schema-driven pass
  *    (`projectForChat`: strict parse, strip, ref hydration, UUID invariant).
  */
 export const runRegistryReadTool = async ({
@@ -155,12 +125,7 @@ export const runRegistryReadTool = async ({
   });
 
   if (finished.status === "error") {
-    return Result.err(
-      new ChatToolError({
-        kind: classifyRegistryErrorKind(finished.error),
-        message: finished.error.message,
-      }),
-    );
+    return Result.err(toRegistryChatToolError(finished.error));
   }
 
   // One schema-driven pass: strict parse (an unknown key — a field nobody

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
@@ -18,10 +18,10 @@ import { STELLA_TOOL_HANDLERS } from "@/api/mcp/stella-tools";
 import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
 import type { McpToolHandler } from "@/api/mcp/tool-types";
 
-import { toRegistryChatToolError } from "./registry-tool-error";
 import type { RegistryWriteToolName } from "./ref-field-map";
 import { WRITE_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 import { dehydrateRefs } from "./ref-mediation";
+import { toRegistryChatToolError } from "./registry-tool-error";
 
 /**
  * The write registry handlers chat may drive, gathered from the per-domain

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
@@ -18,10 +18,10 @@ import { STELLA_TOOL_HANDLERS } from "@/api/mcp/stella-tools";
 import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
 import type { McpToolHandler } from "@/api/mcp/tool-types";
 
+import { toRegistryChatToolError } from "./registry-tool-error";
 import type { RegistryWriteToolName } from "./ref-field-map";
 import { WRITE_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 import { dehydrateRefs } from "./ref-mediation";
-import { classifyRegistryErrorKind } from "./run-registry-tool";
 
 /**
  * The write registry handlers chat may drive, gathered from the per-domain
@@ -160,12 +160,7 @@ export const runRegistryWriteTool = async ({
   });
 
   if (finished.status === "error") {
-    return Result.err(
-      new ChatToolError({
-        kind: classifyRegistryErrorKind(finished.error),
-        message: finished.error.message,
-      }),
-    );
+    return Result.err(toRegistryChatToolError(finished.error));
   }
 
   // Same single schema-driven pass as the read path: strict parse (an

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
@@ -7,7 +7,7 @@ import { BILLING_TOOL_HANDLERS } from "@/api/mcp/billing-tools";
 import { CAPABILITY_TOOL_HANDLERS } from "@/api/mcp/capability-tools";
 import type { McpRequestContext } from "@/api/mcp/context";
 import { DOCUMENT_TOOL_HANDLERS } from "@/api/mcp/document-tools";
-import { finalizeMcpEgress } from "@/api/mcp/egress";
+import { finalizeToolEgress } from "@/api/mcp/egress";
 import { FEEDBACK_TOOL_HANDLERS } from "@/api/mcp/feedback-tools";
 import { isMcpToolFeatureEnabled } from "@/api/mcp/gateway/list-tools";
 import { KNOWLEDGE_TOOL_HANDLERS } from "@/api/mcp/knowledge-tools";
@@ -21,12 +21,7 @@ import type { McpToolHandler } from "@/api/mcp/tool-types";
 import type { RegistryWriteToolName } from "./ref-field-map";
 import { WRITE_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 import { dehydrateRefs } from "./ref-mediation";
-import {
-  classifyRegistryErrorKind,
-  DEFAULT_TOOL_ERROR_MESSAGE,
-  firstTextContent,
-  parsePayload,
-} from "./run-registry-tool";
+import { classifyRegistryErrorKind } from "./run-registry-tool";
 
 /**
  * The write registry handlers chat may drive, gathered from the per-domain
@@ -158,22 +153,19 @@ export const runRegistryWriteTool = async ({
     }),
     context,
   });
-  const finished = await finalizeMcpEgress({
+  const finished = await finalizeToolEgress({
     context,
     mode: "default",
     response,
   });
 
-  if (finished.isError === true) {
-    const message = firstTextContent(finished) || DEFAULT_TOOL_ERROR_MESSAGE;
+  if (finished.status === "error") {
     return Result.err(
-      new ChatToolError({ kind: classifyRegistryErrorKind(message), message }),
+      new ChatToolError({
+        kind: classifyRegistryErrorKind(finished.error),
+        message: finished.error.message,
+      }),
     );
-  }
-
-  const payload = parsePayload(finished);
-  if (Result.isError(payload)) {
-    return Result.err(payload.error);
   }
 
   // Same single schema-driven pass as the read path: strict parse (an
@@ -182,7 +174,7 @@ export const runRegistryWriteTool = async ({
   // carry only paths to telemetry, never values.
   return projectForChat({
     dehydration: dehydrated.value,
-    payload: payload.value,
+    payload: finished.data,
     refRegistry,
     schema: entry.projection,
     source: "run-registry-write-tool",

--- a/apps/api/src/lib/chat/projections.ts
+++ b/apps/api/src/lib/chat/projections.ts
@@ -207,9 +207,10 @@ const contactPhoneProjection = v.strictObject({
 
 /**
  * list_contacts. Source of truth: `listContactsPage`
- * (`handlers/contacts/list-query.ts`), whose whole `Page` envelope
- * (`items`/`limit`/`nextCursor`) is forwarded verbatim by
- * `handleListContactsTool`. The jsonb directory columns
+ * (`handlers/contacts/list-query.ts`), whose `Page` envelope
+ * (`items`/`limit`/`nextCursor`) is projected by `handleListContactsTool`.
+ * The handler converts database timestamps to ISO strings at that boundary.
+ * The jsonb directory columns
  * (`emails`/`phones`/`tags`) are nullable at the column level.
  */
 export const LIST_CONTACTS_PROJECTION = v.strictObject({
@@ -725,10 +726,9 @@ export const LIST_CLAUSES_LIST_PROJECTION = v.strictObject({
 
 /**
  * list_clauses, detail branch (`readClauseDetail` + `getClauseHandler`).
- * `metadata` is set to `undefined` at the handler, so it never survives the
- * JSON round-trip; `createdBy` is the authoring user's id (a `text` column,
- * not a uuid column, but licensed defensively in case a deployment's user
- * ids happen to be uuid-shaped).
+ * `metadata` is omitted by the handler; `createdBy` is the authoring user's id
+ * (a `text` column, not a uuid column, but licensed defensively in case a
+ * deployment's user ids happen to be uuid-shaped).
  */
 export const LIST_CLAUSES_DETAIL_PROJECTION = v.strictObject({
   clause: v.strictObject({
@@ -1447,7 +1447,7 @@ export const LIST_TEMPLATES_PROJECTION = v.union([
 
 // --- Write-tool projections ---------------------------------------------------
 // Write payloads are small acks and ids; each schema below mirrors the
-// handler's `textResult(...)` construction branch by branch. Input-param ref
+// handler's `toolDataResult(...)` construction branch by branch. Input-param ref
 // kinds were verified against each tool's actual `inputSchema` in
 // `apps/api/src/mcp/*-tools.ts`. Params that carry no chat ref kind (task
 // ids, user ids, template/clause/category/playbook ids, time-entry/version/

--- a/apps/api/src/lib/mcp-upstream/connections.ts
+++ b/apps/api/src/lib/mcp-upstream/connections.ts
@@ -28,7 +28,11 @@ import {
   validateOutboundFetchTarget,
 } from "@/api/lib/safe-outbound-fetch";
 import type { SafeOutboundFetchBody } from "@/api/lib/safe-outbound-fetch";
-import { errorResult, textResult } from "@/api/mcp/tool-utils";
+import {
+  errorResult,
+  serializeMcpData,
+  serializeToolResult,
+} from "@/api/mcp/tool-utils";
 
 import { normalizeDiscoveredMcpTools } from "./cached-tools";
 
@@ -397,7 +401,8 @@ const isExecutableMcpTool = (value: unknown): value is ExecutableMcpTool =>
 // becomes the raw object. Treat every value here as application output. A raw
 // object that happens to contain `content` or `resultType` must not be trusted
 // as a protocol envelope and allowed to overwrite our own result shape.
-const asCallToolResult = (value: unknown): CallToolResult => textResult(value);
+const asCallToolResult = (value: unknown): CallToolResult =>
+  serializeMcpData(value);
 
 export const proxyMcpToolCall = async ({
   args,
@@ -421,7 +426,9 @@ export const proxyMcpToolCall = async ({
     userId,
   });
   if (!client) {
-    return errorResult("External MCP connection is unavailable");
+    return serializeToolResult(
+      errorResult("External MCP connection is unavailable"),
+    );
   }
 
   try {
@@ -435,7 +442,9 @@ export const proxyMcpToolCall = async ({
     ]);
     const tool: unknown = tools.at(0);
     if (!isExecutableMcpTool(tool)) {
-      return errorResult("External MCP tool is unavailable");
+      return serializeToolResult(
+        errorResult("External MCP tool is unavailable"),
+      );
     }
 
     const result = await tool.execute(args);

--- a/apps/api/src/mcp/README.md
+++ b/apps/api/src/mcp/README.md
@@ -61,11 +61,12 @@ is therefore a compile error, and the two surfaces cannot silently diverge.
 ## Handlers never see the mode; the egress pipeline is central
 
 `McpToolHandler` has no `mode` parameter. A handler returns either a finished
-`CallToolResult` or an egress plan (`McpEgressPlan`) carrying the full,
+typed internal result or an egress plan (`McpEgressPlan`) carrying the full,
 pre-window, un-anonymized payload. `handleMcpToolCall` (in `tools.ts`) runs the
-handler and then `finalizeMcpEgress` (in `egress.ts`), which, in anonymized
-mode, anonymizes the declared text fields on the whole payload, THEN windows,
-THEN serializes. Anonymize-before-window keeps entity names from splitting
+handler and then `finalizeToolEgress` (in `egress.ts`), which, in anonymized
+mode, anonymizes the declared text fields on the whole payload, then windows.
+Only the outer MCP transport boundary serializes the finished result into a
+`CallToolResult`. Anonymize-before-window keeps entity names from splitting
 across a window edge and keeps placeholders stable across windows of one
 document. With no mode in scope, per-mode divergence inside a handler is
 structurally impossible. Tools with compound windowing (e.g.

--- a/apps/api/src/mcp/billing-tools.ts
+++ b/apps/api/src/mcp/billing-tools.ts
@@ -65,7 +65,7 @@ import {
   nullableStringProp,
   stringProp,
   structuredErrorResult,
-  textResult,
+  toolDataResult,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 
@@ -1098,7 +1098,7 @@ const handleSaveTimeEntryTool: McpToolHandler = async ({ args, context }) => {
     if (Result.isError(created)) {
       return internalFailureResult(created.error);
     }
-    return textResult({
+    return toolDataResult({
       timeEntryId: created.value.id,
     } satisfies v.InferInput<typeof SAVE_TIME_ENTRY_PROJECTION>);
   }
@@ -1168,7 +1168,7 @@ const handleSaveTimeEntryTool: McpToolHandler = async ({ args, context }) => {
   if (Result.isError(updated)) {
     return internalFailureResult(updated.error);
   }
-  return textResult({
+  return toolDataResult({
     timeEntryId,
     updated: true,
   } satisfies v.InferInput<typeof SAVE_TIME_ENTRY_PROJECTION>);
@@ -1219,7 +1219,7 @@ const handleDeleteTimeEntryTool: McpToolHandler = async ({ args, context }) => {
   if (Result.isError(deleted)) {
     return internalFailureResult(deleted.error);
   }
-  return textResult({
+  return toolDataResult({
     deleted: deleted.value.deleted,
   } satisfies v.InferInput<typeof DELETE_TIME_ENTRY_PROJECTION>);
 };
@@ -1285,7 +1285,7 @@ const handleResolveRateTool: McpToolHandler = async ({ args, context }) => {
 
   // Passthrough: only a rate amount (minor units) and currency code, no
   // tenant-authored text.
-  return textResult(
+  return toolDataResult(
     resolved.value ??
       ({ hourlyRate: null, currency: null } satisfies v.InferInput<
         typeof RESOLVE_RATE_PROJECTION
@@ -1581,7 +1581,7 @@ const handleGetUsageTool: McpToolHandler = async ({ args, context }) => {
   // The two payload branches are tied to GET_USAGE_NO_PLAN_PROJECTION /
   // GET_USAGE_ENTITLED_PROJECTION where they are built
   // (`readOrgEntitlementHandler`, handlers/usage/get-entitlement.ts).
-  return textResult(entitlement.value);
+  return toolDataResult(entitlement.value);
 };
 
 export const BILLING_TOOL_HANDLERS = {

--- a/apps/api/src/mcp/capability-tools.test.ts
+++ b/apps/api/src/mcp/capability-tools.test.ts
@@ -1262,19 +1262,19 @@ describe("invoke_capability file-input gate", () => {
   });
 });
 
-// Read the error envelope out of a raw mapHandlerResult return (a CallToolResult
-// for the error cases), without going through the egress pipeline.
+// Read the typed error out of a raw mapHandlerResult return without going
+// through MCP serialization.
 const mappedError = (
   mapped: ReturnType<typeof mapHandlerResult>,
 ): ErrorEnvelope => {
-  if (!("content" in mapped)) {
+  if (!("status" in mapped) || mapped.status !== "error") {
     throw new Error(`Expected an error result, got: ${JSON.stringify(mapped)}`);
   }
-  const item = mapped.content.at(0);
-  if (!item || item.type !== "text") {
-    throw new Error("Expected a text error result");
+  if (mapped.error.type !== "structured") {
+    throw new Error("Expected a structured error result");
   }
-  return asTestRaw<{ error: ErrorEnvelope }>(JSON.parse(item.text)).error;
+  const { type: _type, ...error } = mapped.error;
+  return error;
 };
 
 // --- meta-tool argument shape validation (fail-closed dry runs) ---------------

--- a/apps/api/src/mcp/capability-tools.ts
+++ b/apps/api/src/mcp/capability-tools.ts
@@ -1,4 +1,3 @@
-import type { CallToolResult } from "@modelcontextprotocol/server";
 import { KindGuard, type TSchema } from "@sinclair/typebox";
 import { ValueErrorType } from "@sinclair/typebox/errors";
 import { Value, type ValueError } from "@sinclair/typebox/value";
@@ -40,6 +39,7 @@ import { CAPABILITY_DISPATCH } from "@/api/mcp/generated/capability-dispatch";
 import type { CapabilityDispatchEntry } from "@/api/mcp/generated/capability-dispatch";
 import { defineMcpToolSet } from "@/api/mcp/tool-types";
 import type {
+  InternalToolErrorResult,
   McpEgressPlan,
   McpToolDefinition,
   McpToolHandler,
@@ -616,7 +616,7 @@ const statusResponseMessage = (response: unknown): string => {
 const mapStatusResponse = (
   statusCode: number,
   responseBody: unknown,
-): CallToolResult => {
+): InternalToolErrorResult => {
   const code = statusCodeToErrorCode(statusCode);
   const message = statusResponseMessage(responseBody);
   if (code === "internal_error") {
@@ -772,7 +772,7 @@ const decodeCapabilityCursor = (cursor: string): string | undefined | null => {
 
 // --- describe_capability -----------------------------------------------------
 
-const notFoundWithHint = (id: string): CallToolResult =>
+const notFoundWithHint = (id: string): InternalToolErrorResult =>
   notFoundResult(`No capability with id "${id}"`, hintForUnknownId(id));
 
 /**
@@ -780,7 +780,7 @@ const notFoundWithHint = (id: string): CallToolResult =>
  * as the static-tool dispatch guard (tools.ts) so agents see one behavior for
  * gated-off surface, tool or capability.
  */
-const featureDisabledResult = (): CallToolResult =>
+const featureDisabledResult = (): InternalToolErrorResult =>
   structuredErrorResult({
     code: "feature_disabled",
     message: "This feature is not enabled on this deployment",
@@ -796,7 +796,7 @@ const hintForUnknownId = (id: string): string => {
 
 type GuardedEndpoint =
   | { ok: true; endpoint: EndpointDefinition }
-  | { ok: false; result: CallToolResult };
+  | { ok: false; result: InternalToolErrorResult };
 
 /**
  * Load a capability's endpoint with failures contained: a rejecting dynamic
@@ -861,7 +861,7 @@ const describeCapabilityHandler = async ({
   const endpoint = loaded.endpoint;
 
   // The live TypeBox schemas are plain objects plus symbol metadata; the final
-  // JSON serialization (textResult in the egress pipeline) drops the symbols, so
+  // JSON serialization (toolDataResult in the egress pipeline) drops the symbols, so
   // they can go on the payload as-is. Uses the live config, never the snapshot,
   // so a snapshot-truncated capability still describes fully.
   const inputSchema = {
@@ -926,7 +926,7 @@ const transportBlockReason = (transport: CapabilityTransport): string => {
 const transportRefusal = (
   id: string,
   transport: CapabilityTransport,
-): CallToolResult | null => {
+): InternalToolErrorResult | null => {
   if (isTransportInvocable(transport)) {
     return null;
   }
@@ -951,7 +951,7 @@ const filelessFieldRefusal = (
   id: string,
   transport: CapabilityTransport,
   input: InvokeInput,
-): CallToolResult | null => {
+): InternalToolErrorResult | null => {
   const field = filelessOnlyField(transport);
   if (field === undefined || !isRecord(input.body) || !(field in input.body)) {
     return null;
@@ -1030,7 +1030,7 @@ const resolveCapabilityWorkspace = ({
   params: unknown;
 }):
   | { ok: true; workspaceId: SafeId<"workspace"> }
-  | { ok: false; result: CallToolResult } => {
+  | { ok: false; result: InternalToolErrorResult } => {
   const rawId = isRecord(params) ? params["workspaceId"] : undefined;
   if (typeof rawId !== "string" || rawId.length === 0) {
     return {
@@ -1244,7 +1244,7 @@ const invokeCapabilityHandler = async ({
  *   (`endpoint.handler`), the same code path REST uses; validateOnly
  *   additionally mirrors the permission gate explicitly (the wrapper is not
  *   called on that path).
- * - Egress finalization + anonymization (finalizeMcpEgress): applied by
+ * - Egress finalization + anonymization (finalizeToolEgress): applied by
  *   handleMcpToolCall to this handler's returned egress plan exactly as for
  *   any static tool; anonymized mode never reaches here (tools excluded).
  * - internal_error capture (tools.ts try/catch): invokeCapabilityHandler wraps

--- a/apps/api/src/mcp/document-file-upload.test.ts
+++ b/apps/api/src/mcp/document-file-upload.test.ts
@@ -18,6 +18,7 @@ import {
   DOCUMENT_TOOL_HANDLERS,
 } from "@/api/mcp/document-tools";
 import { toMcpTools } from "@/api/mcp/gateway/list-tools";
+import { errorResult } from "@/api/mcp/tool-utils";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
@@ -112,13 +113,12 @@ describe("document file upload surface", () => {
       context: createContext(),
     });
 
-    expect(result).toMatchObject({ isError: true });
-    if (!("content" in result)) {
-      panic("Expected a structured MCP validation error");
-    }
-    expect(result.content.at(0)).toMatchObject({
-      type: "text",
-      text: expect.stringContaining('"code":"validation_error"'),
+    expect(result).toMatchObject({
+      status: "error",
+      error: {
+        type: "structured",
+        code: "validation_error",
+      },
     });
   });
 
@@ -242,7 +242,7 @@ describe("document file upload surface", () => {
 
     expect(capabilities).toEqual(["uploads.create"]);
     expect(aborted).toHaveBeenCalledTimes(1);
-    expect(result).toMatchObject({ isError: true });
+    expect(result).toMatchObject({ status: "error" });
   });
 
   test("reports a failed reservation cleanup without hiding the transfer failure", async () => {
@@ -260,10 +260,7 @@ describe("document file upload surface", () => {
       dependencies: {
         abort: mock(async () => ({
           status: "error" as const,
-          result: {
-            content: [{ type: "text" as const, text: "abort failed" }],
-            isError: true,
-          },
+          result: errorResult("abort failed"),
         })),
         captureCleanupFailure,
         download: mock(async () =>
@@ -287,14 +284,12 @@ describe("document file upload surface", () => {
     });
 
     expect(result).toMatchObject({
-      isError: true,
-      content: [
-        {
-          text: expect.stringContaining(
-            "could not be transferred, and its reserved upload could not be cleaned up",
-          ),
-        },
-      ],
+      status: "error",
+      error: {
+        message: expect.stringContaining(
+          "could not be transferred, and its reserved upload could not be cleaned up",
+        ),
+      },
     });
     expect(captureCleanupFailure).toHaveBeenCalledTimes(1);
     expect(captureCleanupFailure).toHaveBeenCalledWith(expect.any(Error), {
@@ -341,6 +336,6 @@ describe("document file upload surface", () => {
       uploadId: "upload_123",
       workspaceId: "00000000-0000-4000-8000-000000000001",
     });
-    expect(result).toMatchObject({ isError: true });
+    expect(result).toMatchObject({ status: "error" });
   });
 });

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -82,6 +82,7 @@ import {
   runTextFieldSpecs,
 } from "@/api/mcp/text-field-spec";
 import type {
+  InternalToolResult,
   McpTextFieldSpec,
   McpToolDefinition,
   McpToolHandler,
@@ -104,7 +105,7 @@ import {
   nullableStringProp,
   stringProp,
   structuredErrorResult,
-  textResult,
+  toolDataResult,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 import { DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
@@ -1948,7 +1949,7 @@ const createDocumentEntity = async ({
 }: {
   context: McpRequestContext;
   input: SaveDocumentInput;
-}): Promise<ReturnType<typeof textResult>> => {
+}): Promise<InternalToolResult> => {
   if (!roles[context.memberRole].authorize({ entity: ["create"] }).success) {
     return errorResult("Forbidden");
   }
@@ -1981,7 +1982,7 @@ const createDocumentEntity = async ({
     return internalFailureResult(created.error);
   }
 
-  return textResult({
+  return toolDataResult({
     entityId: created.value.entityId,
   } satisfies v.InferInput<typeof SAVE_DOCUMENT_CREATE_PROJECTION>);
 };
@@ -2103,7 +2104,7 @@ const updateDocumentEntity = async ({
 }: {
   context: McpRequestContext;
   input: SaveDocumentInput;
-}): Promise<ReturnType<typeof textResult>> => {
+}): Promise<InternalToolResult> => {
   if (!roles[context.memberRole].authorize({ entity: ["update"] }).success) {
     return errorResult("Forbidden");
   }
@@ -2192,7 +2193,7 @@ const updateDocumentEntity = async ({
     }
   }
 
-  return textResult({
+  return toolDataResult({
     updated: true,
   } satisfies v.InferInput<typeof SAVE_DOCUMENT_UPDATE_PROJECTION>);
 };
@@ -2301,18 +2302,15 @@ const handleOpenDocumentVersionUploadTool: McpToolHandler = async ({
     return target.response;
   }
 
-  return {
-    content: [
-      {
-        type: "text",
-        text: "Choose a file in the upload panel to add a new document version.",
-      },
-    ],
-    structuredContent: {
-      entityId: target.entityId,
-      workspaceId: target.workspaceId,
-    },
+  const data = {
+    entityId: target.entityId,
+    workspaceId: target.workspaceId,
   };
+  return toolDataResult(data, {
+    primaryText:
+      "Choose a file in the upload panel to add a new document version.",
+    structuredContent: data,
+  });
 };
 
 const deleteDocumentArgsSchema = v.strictObject({
@@ -2365,7 +2363,7 @@ const handleDeleteDocumentTool: McpToolHandler = async ({ args, context }) => {
     if (Result.isError(deleted)) {
       return internalFailureResult(deleted.error);
     }
-    return textResult({
+    return toolDataResult({
       deleted: true,
     } satisfies v.InferInput<typeof DELETED_TRUE_PROJECTION>);
   }
@@ -2385,7 +2383,7 @@ const handleDeleteDocumentTool: McpToolHandler = async ({ args, context }) => {
   if (Result.isError(deleted)) {
     return internalFailureResult(deleted.error);
   }
-  return textResult({
+  return toolDataResult({
     deleted: true,
   } satisfies v.InferInput<typeof DELETED_TRUE_PROJECTION>);
 };
@@ -2616,7 +2614,7 @@ const handleSetFieldValueTool: McpToolHandler = async ({ args, context }) => {
     return internalFailureResult(result.error);
   }
 
-  return textResult(
+  return toolDataResult(
     {} satisfies v.InferInput<typeof SET_FIELD_VALUE_PROJECTION>,
   );
 };

--- a/apps/api/src/mcp/egress-canary.test.ts
+++ b/apps/api/src/mcp/egress-canary.test.ts
@@ -139,7 +139,11 @@ void mock.module("@/api/lib/templates/template-fill-service", () => ({
   describeStoredTemplate: describeStoredTemplateMock,
 }));
 
-const { finalizeMcpEgress } = await import("@/api/mcp/egress");
+const { finalizeToolEgress } = await import("@/api/mcp/egress");
+const { serializeToolResult } = await import("@/api/mcp/tool-utils");
+const finalizeMcpEgress = async (
+  options: Parameters<typeof finalizeToolEgress>[0],
+) => serializeToolResult(await finalizeToolEgress(options));
 const { ANONYMIZED_MCP_TOOL_DEFINITIONS } =
   await import("@/api/mcp/static-tool-definitions");
 const { COMPAT_TOOL_HANDLERS } = await import("@/api/mcp/compat-tools");
@@ -1558,13 +1562,10 @@ describe("MCP anonymization canary corpus", () => {
     if (isMcpEgressPlan(response)) {
       throw new Error("Expected a finished error result, not an egress plan");
     }
-    expect(response.isError).toBe(true);
-    const item = response.content.at(0);
-    if (!item || item.type !== "text") {
-      throw new Error("Expected a text MCP response");
-    }
-    expect(JSON.parse(item.text)).toEqual({
+    expect(response).toEqual({
+      status: "error",
       error: {
+        type: "structured",
         code: "validation_error",
         message: "Clause body has an unrecognized format",
         issues: [

--- a/apps/api/src/mcp/egress.test.ts
+++ b/apps/api/src/mcp/egress.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { McpRequestContext } from "@/api/mcp/context";
 import type { McpEgressPlan } from "@/api/mcp/tool-types";
+import { serializeToolResult } from "@/api/mcp/tool-utils";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
@@ -21,7 +22,11 @@ void mock.module("@/api/lib/anonymization-blacklist", () => ({
   loadAnonymizationGazetteerEntries: loadAnonymizationGazetteerEntriesMock,
 }));
 
-const { finalizeMcpEgress } = await import("@/api/mcp/egress");
+const { finalizeToolEgress } = await import("@/api/mcp/egress");
+
+const finalizeMcpEgress = async (
+  options: Parameters<typeof finalizeToolEgress>[0],
+) => serializeToolResult(await finalizeToolEgress(options));
 
 const createContext = (): McpRequestContext => {
   const scopedDb = asTestRaw<McpRequestContext["scopedDb"]>(mock());
@@ -67,12 +72,13 @@ describe("finalizeMcpEgress", () => {
     loadAnonymizationGazetteerEntriesMock.mockResolvedValue([]);
   });
 
-  test("returns a finished CallToolResult untouched", async () => {
+  test("returns a finished internal result untouched", async () => {
     const finished = {
-      content: [{ type: "text" as const, text: "already done" }],
+      status: "success" as const,
+      data: { message: "already done" },
     };
     expect(
-      await finalizeMcpEgress({
+      await finalizeToolEgress({
         context: createContext(),
         mode: "anonymized",
         response: finished,

--- a/apps/api/src/mcp/egress.ts
+++ b/apps/api/src/mcp/egress.ts
@@ -1,11 +1,10 @@
-import type { CallToolResult } from "@modelcontextprotocol/server";
-
 import { loadAnonymizationGazetteerEntries } from "@/api/lib/anonymization-blacklist";
 import { anonymizeTextFields } from "@/api/mcp/anonymization";
 import type { McpMode } from "@/api/mcp/constants";
 import type { McpRequestContext } from "@/api/mcp/context";
 import type {
   McpEgressPlan,
+  InternalToolResult,
   McpStructuredTextField,
   McpToolResponse,
 } from "@/api/mcp/tool-types";
@@ -13,7 +12,7 @@ import { isMcpEgressPlan } from "@/api/mcp/tool-types";
 import {
   isToolErrorResult,
   normalizeTextField,
-  textResult,
+  toolDataResult,
   windowTextByCursor,
 } from "@/api/mcp/tool-utils";
 
@@ -21,10 +20,10 @@ const ANONYMIZED_FIELD_MISSING_FALLBACK = "[REDACTED]";
 
 /**
  * Central egress pipeline. A handler never sees the request mode: it returns a
- * finished `CallToolResult` (no tenant text, or its own windowing) or an egress
+ * finished internal result (no tenant text, or its own windowing) or an egress
  * plan carrying the full pre-window payload. In anonymized mode this anonymizes
- * the plan's declared text fields on the whole payload, THEN windows, THEN
- * serializes, so an entity name can never be split across a window edge and
+ * the plan's declared text fields on the whole payload, then windows, so an
+ * entity name can never be split across a window edge and
  * placeholders stay stable across consecutive windows of one document.
  *
  * Deliberately out of scope: tenant/entity ids. This pipeline (and the
@@ -44,15 +43,17 @@ const ANONYMIZED_FIELD_MISSING_FALLBACK = "[REDACTED]";
  * `projection-schema.ts`). That backstop belongs there, not here, because
  * this pipeline itself never hands output to a model.
  */
-export const finalizeMcpEgress = async ({
-  context,
-  mode,
-  response,
-}: {
+type FinalizeToolEgressOptions = {
   context: McpRequestContext;
   mode: McpMode;
   response: McpToolResponse;
-}): Promise<CallToolResult> => {
+};
+
+export const finalizeToolEgress = async ({
+  context,
+  mode,
+  response,
+}: FinalizeToolEgressOptions): Promise<InternalToolResult> => {
   if (!isMcpEgressPlan(response)) {
     return response;
   }
@@ -134,7 +135,7 @@ const finalizeStructured = async ({
   context: McpRequestContext;
   mode: McpMode;
   plan: Extract<McpEgressPlan, { egress: "structured" }>;
-}): Promise<CallToolResult> => {
+}): Promise<InternalToolResult> => {
   // Anonymize the declared text fields on the whole payload first (anonymized
   // mode only), THEN window, so an entity name can never straddle a window edge
   // and placeholders stay stable across windows of one field.
@@ -154,7 +155,7 @@ const finalizeStructured = async ({
     plan.window.apply(textWindow);
   }
 
-  return textResult(plan.payload);
+  return toolDataResult(plan.payload);
 };
 
 const finalizeCompatSearch = async ({
@@ -165,7 +166,7 @@ const finalizeCompatSearch = async ({
   context: McpRequestContext;
   mode: McpMode;
   plan: Extract<McpEgressPlan, { egress: "compatSearch" }>;
-}): Promise<CallToolResult> => {
+}): Promise<InternalToolResult> => {
   // `workspaceId` is per-hit attribution the egress pipeline uses to group
   // anonymization; it is stripped before the result reaches the client.
   const results = plan.results.map(
@@ -192,7 +193,7 @@ const finalizeCompatSearch = async ({
     });
   }
 
-  return textResult({ nextCursor: plan.nextCursor, results });
+  return toolDataResult({ nextCursor: plan.nextCursor, results });
 };
 
 const finalizeCompatFetch = async ({
@@ -203,7 +204,7 @@ const finalizeCompatFetch = async ({
   context: McpRequestContext;
   mode: McpMode;
   plan: Extract<McpEgressPlan, { egress: "compatFetch" }>;
-}): Promise<CallToolResult> => {
+}): Promise<InternalToolResult> => {
   if (mode === "anonymized") {
     // Same boundary as anonymized search: the user may fetch a raw document
     // internally, but the AI client receives only the anonymized title/body.
@@ -225,7 +226,7 @@ const finalizeCompatFetch = async ({
       return textWindow;
     }
 
-    return textResult({
+    return toolDataResult({
       id: plan.id,
       title: anonymized.title,
       text: textWindow.text,
@@ -251,7 +252,7 @@ const finalizeCompatFetch = async ({
     return textWindow;
   }
 
-  return textResult({
+  return toolDataResult({
     id: plan.id,
     title: plan.title,
     text: textWindow.text,

--- a/apps/api/src/mcp/feedback-tools.test.ts
+++ b/apps/api/src/mcp/feedback-tools.test.ts
@@ -36,11 +36,10 @@ const parsePayload = async (args: Record<string, unknown>) => {
   if (isMcpEgressPlan(result)) {
     throw new TypeError("Expected a finished result");
   }
-  const item = result.content.at(0);
-  if (!item || item.type !== "text") {
-    throw new TypeError("Expected a text result");
+  if (result.status === "error") {
+    return { payload: null, result };
   }
-  const payload: unknown = JSON.parse(item.text);
+  const payload: unknown = result.data;
   if (typeof payload !== "object" || payload === null) {
     throw new TypeError("Expected an object payload");
   }
@@ -55,7 +54,7 @@ describe("MCP send_feedback tool", () => {
       body: "Details at https://private.example/path",
     });
 
-    expect(result.isError).toBeFalsy();
+    expect(result.status).toBe("success");
     expect(payload).toMatchObject({
       channel: "github",
       sanitized_title: "Problem for [redacted-email]",
@@ -73,7 +72,7 @@ describe("MCP send_feedback tool", () => {
       channel: "email",
     });
 
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe("error");
   });
 
   test("URL truncation never leaves a dangling high surrogate", () => {

--- a/apps/api/src/mcp/feedback-tools.ts
+++ b/apps/api/src/mcp/feedback-tools.ts
@@ -1,13 +1,16 @@
-import type { CallToolResult } from "@modelcontextprotocol/server";
 import * as v from "valibot";
 
 import { sanitizeFeedbackText } from "@/api/mcp/feedback-sanitize";
-import type { McpToolDefinition, McpToolHandler } from "@/api/mcp/tool-types";
+import type {
+  InternalToolSuccess,
+  McpToolDefinition,
+  McpToolHandler,
+} from "@/api/mcp/tool-types";
 import { defineMcpToolSet } from "@/api/mcp/tool-types";
 import {
   enumProp,
   stringProp,
-  textResult,
+  toolDataResult,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 
@@ -179,7 +182,7 @@ const buildGithubFeedbackResult = ({
   composedBody: string;
   redactions: number;
   sanitizedTitle: string;
-}): CallToolResult => {
+}): InternalToolSuccess => {
   const issueUrl = buildBoundedGithubIssueUrl({
     composedBody,
     title: sanitizedTitle,
@@ -188,7 +191,7 @@ const buildGithubFeedbackResult = ({
     `gh issue create --repo ${GITHUB_REPO} --label ${GITHUB_ISSUE_LABEL} ` +
     `--title ${shellSingleQuote(sanitizedTitle)} --body ${shellSingleQuote(composedBody)}`;
 
-  return textResult({
+  return toolDataResult({
     channel: "github",
     sanitized_title: sanitizedTitle,
     sanitized_body: composedBody,

--- a/apps/api/src/mcp/gateway/dispatch-call.test.ts
+++ b/apps/api/src/mcp/gateway/dispatch-call.test.ts
@@ -4,13 +4,13 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { McpRequestContext } from "@/api/mcp/context";
 import type { ResolvedSkillTool } from "@/api/mcp/gateway/skills";
+import { structuredErrorResult } from "@/api/mcp/tool-utils";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 // Mock the two dispatch collaborators so this file exercises only
-// `dispatchGatewayToolCall`'s own branch selection, audit call, and error
-// envelope. The name-classification (`isSkillToolName` / `isExternalMcpToolName`)
-// and result builders (`structuredErrorResult` / `textResult`) stay real, so the
-// asserted envelopes are the exact shapes callers receive.
+// `dispatchGatewayToolCall`'s own branch selection, audit call, and result
+// envelope. The name-classification (`isSkillToolName` /
+// `isExternalMcpToolName`) and internal result builders stay real.
 const callGatewayExternalMcpToolMock = mock();
 const gatewayLoadErrorResultMock = mock();
 const recordSkillGatewayToolAuditMock = mock(async () => undefined);
@@ -44,14 +44,6 @@ const resolvedSkill = asTestRaw<ResolvedSkillTool>({
   compatibility: "stella>=1",
   exposedName: "skill__alpha",
 });
-
-const parseResult = (result: CallToolResult | null): unknown => {
-  const text = result?.content.at(0);
-  if (text?.type !== "text") {
-    throw new Error("expected a text content block");
-  }
-  return JSON.parse(text.text);
-};
 
 describe("dispatchGatewayToolCall", () => {
   beforeEach(() => {
@@ -90,7 +82,7 @@ describe("dispatchGatewayToolCall", () => {
       toolName: "mcp__registry__lookup",
     });
 
-    expect(result).toBe(sentinel);
+    expect(result).toEqual({ type: "external_mcp", result: sentinel });
     expect(callGatewayExternalMcpToolMock).toHaveBeenCalledWith({
       args,
       context,
@@ -122,9 +114,14 @@ describe("dispatchGatewayToolCall", () => {
       toolName: "skill__missing",
     });
 
-    expect(result?.isError).toBe(true);
-    expect(parseResult(result)).toEqual({
+    expect(result?.type).toBe("internal");
+    if (result?.type !== "internal") {
+      throw new Error("expected an internal gateway result");
+    }
+    expect(result.result).toEqual({
+      status: "error",
       error: {
+        type: "structured",
         code: "unknown_tool",
         message: "Unknown tool: skill__missing",
         hint: "Call tools/list for the tools available to this session.",
@@ -143,15 +140,21 @@ describe("dispatchGatewayToolCall", () => {
       toolName: "skill__alpha",
     });
 
-    expect(result?.isError).toBeUndefined();
-    expect(parseResult(result)).toEqual({
-      body: "# Alpha skill body",
-      compatibility: "stella>=1",
-      license: "MIT",
-      metadata: { key: "value" },
-      name: "alpha",
-      origin: "authored",
-      version: "1.2.3",
+    expect(result?.type).toBe("internal");
+    if (result?.type !== "internal") {
+      throw new Error("expected an internal gateway result");
+    }
+    expect(result.result).toEqual({
+      status: "success",
+      data: {
+        body: "# Alpha skill body",
+        compatibility: "stella>=1",
+        license: "MIT",
+        metadata: { key: "value" },
+        name: "alpha",
+        origin: "authored",
+        version: "1.2.3",
+      },
     });
 
     expect(recordSkillGatewayToolAuditMock).toHaveBeenCalledTimes(1);
@@ -172,10 +175,11 @@ describe("dispatchGatewayToolCall", () => {
     // unhandled rejection.
     const loadFault = new Error("db unavailable");
     resolveSkillToolMock.mockRejectedValue(loadFault);
-    const sentinel: CallToolResult = {
-      content: [{ type: "text", text: "retryable" }],
-      isError: true,
-    };
+    const sentinel = structuredErrorResult({
+      code: "internal_error",
+      message: "retryable",
+      retryable: true,
+    });
     gatewayLoadErrorResultMock.mockReturnValue(sentinel);
 
     const result = await dispatchGatewayToolCall({
@@ -186,7 +190,7 @@ describe("dispatchGatewayToolCall", () => {
     });
 
     expect(gatewayLoadErrorResultMock).toHaveBeenCalledWith(loadFault);
-    expect(result).toBe(sentinel);
+    expect(result).toEqual({ type: "internal", result: sentinel });
     expect(recordSkillGatewayToolAuditMock).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/mcp/gateway/dispatch-call.ts
+++ b/apps/api/src/mcp/gateway/dispatch-call.ts
@@ -13,7 +13,12 @@ import {
 } from "@/api/mcp/gateway/external-tools";
 import type { ResolvedSkillTool } from "@/api/mcp/gateway/skills";
 import { resolveSkillTool } from "@/api/mcp/gateway/skills";
-import { structuredErrorResult, textResult } from "@/api/mcp/tool-utils";
+import type { InternalToolResult } from "@/api/mcp/tool-types";
+import { structuredErrorResult, toolDataResult } from "@/api/mcp/tool-utils";
+
+export type GatewayDispatchResult =
+  | { type: "external_mcp"; result: CallToolResult }
+  | { type: "internal"; result: InternalToolResult };
 
 export const dispatchGatewayToolCall = async ({
   args,
@@ -25,13 +30,16 @@ export const dispatchGatewayToolCall = async ({
   context: McpRequestContext;
   mode: McpMode;
   toolName: string;
-}): Promise<CallToolResult | null> => {
+}): Promise<GatewayDispatchResult | null> => {
   if (mode !== "default") {
     return null;
   }
 
   if (isExternalMcpToolName(toolName)) {
-    return await callGatewayExternalMcpTool({ args, context, toolName });
+    return {
+      type: "external_mcp",
+      result: await callGatewayExternalMcpTool({ args, context, toolName }),
+    };
   }
 
   if (!isSkillToolName(toolName)) {
@@ -47,16 +55,19 @@ export const dispatchGatewayToolCall = async ({
     // retryable error, never a definitive `unknown_tool`.
     const loadError = gatewayLoadErrorResult(error);
     if (loadError) {
-      return loadError;
+      return { type: "internal", result: loadError };
     }
     throw error;
   }
   if (!skill) {
-    return structuredErrorResult({
-      code: "unknown_tool",
-      message: `Unknown tool: ${toolName}`,
-      hint: "Call tools/list for the tools available to this session.",
-    });
+    return {
+      type: "internal",
+      result: structuredErrorResult({
+        code: "unknown_tool",
+        message: `Unknown tool: ${toolName}`,
+        hint: "Call tools/list for the tools available to this session.",
+      }),
+    };
   }
 
   await recordSkillGatewayToolAudit({
@@ -67,13 +78,16 @@ export const dispatchGatewayToolCall = async ({
     toolName,
   });
 
-  return textResult({
-    body: skill.body,
-    compatibility: skill.compatibility,
-    license: skill.license,
-    metadata: skill.metadata,
-    name: skill.slug,
-    origin: skill.origin,
-    version: skill.version,
-  });
+  return {
+    type: "internal",
+    result: toolDataResult({
+      body: skill.body,
+      compatibility: skill.compatibility,
+      license: skill.license,
+      metadata: skill.metadata,
+      name: skill.slug,
+      origin: skill.origin,
+      version: skill.version,
+    }),
+  };
 };

--- a/apps/api/src/mcp/gateway/external-tools.ts
+++ b/apps/api/src/mcp/gateway/external-tools.ts
@@ -17,10 +17,16 @@ import type { LoadedMcpConnection } from "@/api/lib/mcp-upstream/connections";
 import type { McpRequestContext } from "@/api/mcp/context";
 import { McpGatewayLoadError } from "@/api/mcp/errors";
 import { consumeMcpGatewayRateLimit } from "@/api/mcp/gateway/rate-limit";
+import type { InternalToolErrorResult } from "@/api/mcp/tool-types";
 import {
   MCP_INTERNAL_ERROR_HINT,
+  serializeToolResult,
   structuredErrorResult,
 } from "@/api/mcp/tool-utils";
+
+const mcpStructuredErrorResult = (
+  args: Parameters<typeof structuredErrorResult>[0],
+): CallToolResult => serializeToolResult(structuredErrorResult(args));
 
 type GatewayConnectionToolRow = {
   cachedTools: CachedMcpToolDefinition[] | null;
@@ -47,7 +53,7 @@ export type ResolvedExternalMcpTool = {
  */
 export const gatewayLoadErrorResult = (
   error: unknown,
-): CallToolResult | null =>
+): InternalToolErrorResult | null =>
   error instanceof McpGatewayLoadError
     ? structuredErrorResult({
         code: "internal_error",
@@ -132,12 +138,12 @@ export const callGatewayExternalMcpTool = async ({
     // retryable error, never a definitive `unknown_tool`.
     const loadError = gatewayLoadErrorResult(error);
     if (loadError) {
-      return loadError;
+      return serializeToolResult(loadError);
     }
     throw error;
   }
   if (!resolved) {
-    return structuredErrorResult({
+    return mcpStructuredErrorResult({
       code: "unknown_tool",
       message: `Unknown tool: ${toolName}`,
       hint: "Call tools/list for the tools available to this session.",
@@ -156,7 +162,7 @@ export const callGatewayExternalMcpTool = async ({
       resolved,
       toolKind: "external_mcp",
     });
-    return structuredErrorResult({
+    return mcpStructuredErrorResult({
       code: "rate_limited",
       message: "External MCP tool rate limit exceeded",
       retryable: true,
@@ -195,7 +201,7 @@ export const callGatewayExternalMcpTool = async ({
       resolved,
       toolKind: "external_mcp",
     });
-    return structuredErrorResult({
+    return mcpStructuredErrorResult({
       code: "internal_error",
       message: "External MCP tool execution failed",
       hint: MCP_INTERNAL_ERROR_HINT,

--- a/apps/api/src/mcp/internal-failure-envelope.test.ts
+++ b/apps/api/src/mcp/internal-failure-envelope.test.ts
@@ -42,7 +42,7 @@ const { DOCUMENT_TOOL_HANDLERS } = await import("@/api/mcp/document-tools");
 const { KNOWLEDGE_TOOL_HANDLERS } = await import("@/api/mcp/knowledge-tools");
 const { RESEARCH_ADMIN_TOOL_HANDLERS } =
   await import("@/api/mcp/research-admin-tools");
-const { internalFailureResult, MCP_INTERNAL_ERROR_HINT } =
+const { internalFailureResult, MCP_INTERNAL_ERROR_HINT, serializeToolResult } =
   await import("@/api/mcp/tool-utils");
 
 // A unique token the fake DB failure carries. The whole point of the envelope
@@ -82,7 +82,7 @@ const asCallToolResult = (result: McpToolResponse) => {
   if (isMcpEgressPlan(result)) {
     throw new Error("expected a CallToolResult, got an egress plan");
   }
-  return result;
+  return serializeToolResult(result);
 };
 
 const envelopeText = (result: McpToolResponse): string => {
@@ -185,8 +185,9 @@ describe("MCP tool DB failures return a structured internal_error envelope", () 
       new Error(`unhandled: ${DB_INTERNAL_LEAK_TOKEN}`),
     );
 
-    expect(result.isError).toBe(true);
-    const first = result.content.at(0);
+    const serialized = serializeToolResult(result);
+    expect(serialized.isError).toBe(true);
+    const first = serialized.content.at(0);
     const text = first !== undefined && "text" in first ? first.text : "";
     expect(text).not.toContain(DB_INTERNAL_LEAK_TOKEN);
     expect(JSON.parse(text)).toEqual({

--- a/apps/api/src/mcp/knowledge-tools.test.ts
+++ b/apps/api/src/mcp/knowledge-tools.test.ts
@@ -246,12 +246,10 @@ describe("MCP knowledge tools", () => {
     if (isMcpEgressPlan(response)) {
       throw new Error("Expected a finished error result, not an egress plan");
     }
-    expect(response.isError).toBe(true);
-    const message = response.content.at(0);
-    const parsed =
-      message?.type === "text" ? JSON.parse(message.text) : undefined;
-    expect(parsed).toEqual({
+    expect(response).toEqual({
+      status: "error",
       error: {
+        type: "structured",
         code: "validation_error",
         message: "Clause body has an unrecognized format",
         issues: [

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -22,6 +22,9 @@ import type { AuditEvent, AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import type {
   DELETED_TRUE_PROJECTION,
+  LIST_CLAUSES_DETAIL_PROJECTION,
+  LIST_CLAUSES_LIST_PROJECTION,
+  LIST_CLAUSES_VERSION_PROJECTION,
   LIST_PLAYBOOKS_DETAIL_PROJECTION,
   LIST_PLAYBOOKS_LIST_PROJECTION,
   RUN_PLAYBOOK_PROJECTION,
@@ -72,7 +75,7 @@ import {
   nullableStringProp,
   stringProp,
   structuredErrorResult,
-  textResult,
+  toolDataResult,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 
@@ -909,10 +912,10 @@ const readClauseDetail = async ({
     if (Result.isError(result)) {
       return internalFailureResult(result.error);
     }
-    const version = result.value;
+    const rawVersion = result.value;
     // Fail-closed (P7): a malformed version body aborts before any push runs,
     // exactly the Wave 4 fix — kept as inline control flow, unchanged.
-    if (!isClauseBody(version.body)) {
+    if (!isClauseBody(rawVersion.body)) {
       return structuredErrorResult({
         code: "validation_error",
         message: "Clause body has an unrecognized format",
@@ -921,6 +924,11 @@ const readClauseDetail = async ({
         ],
       });
     }
+    const version = {
+      ...rawVersion,
+      body: rawVersion.body,
+      createdAt: rawVersion.createdAt.toISOString(),
+    } satisfies v.InferInput<typeof LIST_CLAUSES_VERSION_PROJECTION>["version"];
     const textFields = runTextFieldSpecs(
       [
         clauseBodyTextFieldSpec({
@@ -941,20 +949,8 @@ const readClauseDetail = async ({
   if (Result.isError(result)) {
     return internalFailureResult(result.error);
   }
-  const clause = { ...result.value, metadata: undefined };
-  // title/description/usageNotes are queued unconditionally, matching the
-  // original handler: if the body guard below fails, this response (and these
-  // fields) is discarded via the early error return before it ever reaches a
-  // caller, same as before.
-  const textFields = runTextFieldSpecs(
-    clauseCoreTextFieldSpecs(organizationId),
-    {
-      clause,
-    },
-  );
-  // Fail-closed (P7): kept as inline control flow, unchanged, at the same
-  // point relative to the pushes above and below.
-  if (!isClauseBody(clause.body)) {
+  const { metadata: _metadata, ...rawClause } = result.value;
+  if (!isClauseBody(rawClause.body)) {
     return structuredErrorResult({
       code: "validation_error",
       message: "Clause body has an unrecognized format",
@@ -963,6 +959,37 @@ const readClauseDetail = async ({
       ],
     });
   }
+  const variants = [];
+  for (const rawVariant of rawClause.variants) {
+    if (!isClauseBody(rawVariant.body)) {
+      return structuredErrorResult({
+        code: "validation_error",
+        message: "Clause body has an unrecognized format",
+        issues: [
+          { path: "body", message: "Clause body has an unrecognized format" },
+        ],
+      });
+    }
+    variants.push({
+      ...rawVariant,
+      body: rawVariant.body,
+      createdAt: rawVariant.createdAt.toISOString(),
+    });
+  }
+  const clause = {
+    ...rawClause,
+    body: rawClause.body,
+    createdAt: rawClause.createdAt.toISOString(),
+    updatedAt: rawClause.updatedAt.toISOString(),
+    variants,
+    versions: rawClause.versions.map(({ createdAt, ...version }) =>
+      Object.assign(version, { createdAt: createdAt.toISOString() }),
+    ),
+  } satisfies v.InferInput<typeof LIST_CLAUSES_DETAIL_PROJECTION>["clause"];
+  const textFields = runTextFieldSpecs(
+    clauseCoreTextFieldSpecs(organizationId),
+    { clause },
+  );
   textFields.push(
     ...runTextFieldSpecs(
       [
@@ -981,16 +1008,6 @@ const readClauseDetail = async ({
         variant,
       }),
     );
-    // Fail-closed (P7): kept inline inside the variant loop, unchanged.
-    if (!isClauseBody(variant.body)) {
-      return structuredErrorResult({
-        code: "validation_error",
-        message: "Clause body has an unrecognized format",
-        issues: [
-          { path: "body", message: "Clause body has an unrecognized format" },
-        ],
-      });
-    }
     textFields.push(
       ...runTextFieldSpecs(
         [
@@ -1052,7 +1069,13 @@ const handleListClausesTool: McpToolHandler = async ({ args, context }) => {
   if (Result.isError(listed)) {
     return internalFailureResult(listed.error);
   }
-  const clauses = listed.value.items;
+  const clauses = listed.value.items.map(
+    ({ createdAt, updatedAt, ...clause }) =>
+      Object.assign(clause, {
+        createdAt: createdAt.toISOString(),
+        updatedAt: updatedAt.toISOString(),
+      }),
+  );
 
   // Sequential await, not Promise.all: a single safeDb client cannot multiplex
   // the clause and category queries concurrently.
@@ -1070,20 +1093,20 @@ const handleListClausesTool: McpToolHandler = async ({ args, context }) => {
   }
   const categories =
     categoriesResult !== undefined && !Result.isError(categoriesResult)
-      ? categoriesResult.value.categories
+      ? categoriesResult.value.categories.map(
+          ({ createdAt, updatedAt, ...category }) =>
+            Object.assign(category, {
+              createdAt: createdAt.toISOString(),
+              updatedAt: updatedAt.toISOString(),
+            }),
+        )
       : undefined;
 
-  // No compile-time tie against LIST_CLAUSES_LIST_PROJECTION here (nor on the
-  // detail/version branches below): the clause handlers return `Date` columns
-  // verbatim, and they only become the projection's `v.string()` after the JSON
-  // round-trip the chat adapter performs (`parsePayload`, run-registry-tool.ts).
-  // A `satisfies` tie would need the handler to pre-serialize those columns,
-  // which changes what every other transport returns.
   const payload = {
     clauses,
     ...(categories ? { categories } : {}),
     nextCursor: listed.value.nextCursor,
-  };
+  } satisfies v.InferInput<typeof LIST_CLAUSES_LIST_PROJECTION>;
   const textFields = [
     ...runTextFieldSpecs(clauseListTextFieldSpecs(organizationId), payload),
     ...(categories
@@ -1277,7 +1300,7 @@ const handleSaveClauseTool: McpToolHandler = async ({ args, context }) => {
     if (Result.isError(created)) {
       return internalFailureResult(created.error);
     }
-    return textResult({
+    return toolDataResult({
       clauseId: created.value.id,
     } satisfies v.InferInput<typeof SAVE_CLAUSE_PROJECTION>);
   }
@@ -1322,7 +1345,7 @@ const handleSaveClauseTool: McpToolHandler = async ({ args, context }) => {
   if (Result.isError(updated)) {
     return internalFailureResult(updated.error);
   }
-  return textResult({
+  return toolDataResult({
     clauseId: updated.value.id,
   } satisfies v.InferInput<typeof SAVE_CLAUSE_PROJECTION>);
 };
@@ -1358,7 +1381,7 @@ const handleDeleteClauseTool: McpToolHandler = async ({ args, context }) => {
   if (Result.isError(deleted)) {
     return internalFailureResult(deleted.error);
   }
-  return textResult({
+  return toolDataResult({
     deleted: true,
   } satisfies v.InferInput<typeof DELETED_TRUE_PROJECTION>);
 };
@@ -1568,7 +1591,7 @@ const handleRunPlaybookTool: McpToolHandler = async ({ args, context }) => {
   }
 
   if (outcome.materializedPropertyIds.length === 0) {
-    return textResult({ runPropertyCount: 0 } satisfies v.InferInput<
+    return toolDataResult({ runPropertyCount: 0 } satisfies v.InferInput<
       typeof RUN_PLAYBOOK_PROJECTION
     >);
   }
@@ -1598,7 +1621,7 @@ const handleRunPlaybookTool: McpToolHandler = async ({ args, context }) => {
     return workflowStartFailureResult();
   }
 
-  return textResult({
+  return toolDataResult({
     runPropertyCount: outcome.materializedPropertyIds.length,
   } satisfies v.InferInput<typeof RUN_PLAYBOOK_PROJECTION>);
 };

--- a/apps/api/src/mcp/matter-tools.ts
+++ b/apps/api/src/mcp/matter-tools.ts
@@ -36,6 +36,7 @@ import type {
   DELETED_TRUE_PROJECTION,
   LINK_MATTER_CONTACT_LINK_PROJECTION,
   LINK_MATTER_CONTACT_UNLINK_PROJECTION,
+  LIST_CONTACTS_PROJECTION,
   LIST_TASKS_DETAIL_PROJECTION,
   LIST_TASKS_LIST_PROJECTION,
   LOOKUP_BUSINESS_REGISTRY_PROJECTION,
@@ -92,7 +93,7 @@ import {
   nullableStringProp,
   stringProp,
   structuredErrorResult,
-  textResult,
+  toolDataResult,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 
@@ -669,7 +670,7 @@ const handleSaveMatterTool: McpToolHandler = async ({ args, context }) => {
     if (Result.isError(created)) {
       return internalFailureResult(created.error);
     }
-    return textResult({
+    return toolDataResult({
       matterId: created.value.id,
     } satisfies v.InferInput<typeof SAVE_MATTER_PROJECTION>);
   }
@@ -758,7 +759,7 @@ const handleSaveMatterTool: McpToolHandler = async ({ args, context }) => {
     }
   }
 
-  return textResult({
+  return toolDataResult({
     matterId: workspaceId,
     updated: true,
   } satisfies v.InferInput<typeof SAVE_MATTER_PROJECTION>);
@@ -806,7 +807,7 @@ const handleDeleteMatterTool: McpToolHandler = async ({ args, context }) => {
   if (Result.isError(deleted)) {
     return internalFailureResult(deleted.error);
   }
-  return textResult({
+  return toolDataResult({
     deleted: true,
   } satisfies v.InferInput<typeof DELETED_TRUE_PROJECTION>);
 };
@@ -858,11 +859,16 @@ const handleListContactsTool: McpToolHandler = async ({ args, context }) => {
   if (Result.isError(listed)) {
     return internalFailureResult(listed.error);
   }
-  // No compile-time tie against LIST_CONTACTS_PROJECTION: the contacts page is
-  // forwarded verbatim and carries `Date` columns that only become the
-  // projection's `v.string()` after the JSON round-trip the chat adapter
-  // performs (`parsePayload`, run-registry-tool.ts).
-  return textResult(listed.value);
+  const page = {
+    ...listed.value,
+    items: listed.value.items.map(({ createdAt, ...contact }) =>
+      Object.assign(contact, {
+        createdAt: createdAt.toISOString(),
+      }),
+    ),
+  } satisfies v.InferInput<typeof LIST_CONTACTS_PROJECTION>;
+
+  return toolDataResult(page);
 };
 
 // --- save_contact -------------------------------------------------------
@@ -972,7 +978,7 @@ const handleSaveContactTool: McpToolHandler = async ({ args, context }) => {
     if (Result.isError(created)) {
       return internalFailureResult(created.error);
     }
-    return textResult({
+    return toolDataResult({
       contactId: created.value.id,
     } satisfies v.InferInput<typeof SAVE_CONTACT_PROJECTION>);
   }
@@ -1007,7 +1013,7 @@ const handleSaveContactTool: McpToolHandler = async ({ args, context }) => {
   if (Result.isError(updated)) {
     return internalFailureResult(updated.error);
   }
-  return textResult({
+  return toolDataResult({
     contactId: updated.value.id,
   } satisfies v.InferInput<typeof SAVE_CONTACT_PROJECTION>);
 };
@@ -1043,7 +1049,7 @@ const handleDeleteContactTool: McpToolHandler = async ({ args, context }) => {
   if (Result.isError(deleted)) {
     return internalFailureResult(deleted.error);
   }
-  return textResult({
+  return toolDataResult({
     deleted: true,
   } satisfies v.InferInput<typeof DELETED_TRUE_PROJECTION>);
 };
@@ -1087,7 +1093,7 @@ const handleLookupBusinessRegistryTool: McpToolHandler = async ({
     typeof result.value,
     v.InferInput<typeof LOOKUP_BUSINESS_REGISTRY_PROJECTION>
   >;
-  return textResult(result.value satisfies LookupBusinessRegistryPayload);
+  return toolDataResult(result.value satisfies LookupBusinessRegistryPayload);
 };
 
 // --- list_tasks ---------------------------------------------------------
@@ -1782,7 +1788,7 @@ const handleSaveTaskTool: McpToolHandler = async ({ args, context }) => {
     if (Result.isError(created)) {
       return internalFailureResult(created.error);
     }
-    return textResult({
+    return toolDataResult({
       taskId: created.value.entityId,
     } satisfies v.InferInput<typeof SAVE_TASK_PROJECTION>);
   }
@@ -1918,7 +1924,7 @@ const handleSaveTaskTool: McpToolHandler = async ({ args, context }) => {
     }
   }
 
-  return textResult({
+  return toolDataResult({
     taskId,
     updated: true,
   } satisfies v.InferInput<typeof SAVE_TASK_PROJECTION>);
@@ -2048,7 +2054,7 @@ const handleLinkMatterContactTool: McpToolHandler = async ({
     if (Result.isError(removed)) {
       return internalFailureResult(removed.error);
     }
-    return textResult({
+    return toolDataResult({
       unlinked: true,
     } satisfies v.InferInput<typeof LINK_MATTER_CONTACT_UNLINK_PROJECTION>);
   }
@@ -2072,7 +2078,7 @@ const handleLinkMatterContactTool: McpToolHandler = async ({
   if (Result.isError(created)) {
     return internalFailureResult(created.error);
   }
-  return textResult({
+  return toolDataResult({
     workspaceContactId: created.value.id,
   } satisfies v.InferInput<typeof LINK_MATTER_CONTACT_LINK_PROJECTION>);
 };

--- a/apps/api/src/mcp/research-admin-tools.test.ts
+++ b/apps/api/src/mcp/research-admin-tools.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@/api/mcp/static-tool-definitions";
 import type { McpToolDefinition, McpToolResponse } from "@/api/mcp/tool-types";
 import { isMcpEgressPlan } from "@/api/mcp/tool-types";
+import { serializeToolResult } from "@/api/mcp/tool-utils";
 import { listMcpTools } from "@/api/mcp/tools";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
@@ -45,8 +46,9 @@ const errorText = (result: McpToolResponse): string => {
   if (isMcpEgressPlan(result)) {
     throw new Error("expected a CallToolResult, got an egress plan");
   }
-  expect(result.isError).toBe(true);
-  const first = result.content[0];
+  const serialized = serializeToolResult(result);
+  expect(serialized.isError).toBe(true);
+  const first = serialized.content[0];
   return first !== undefined && "text" in first ? first.text : "";
 };
 

--- a/apps/api/src/mcp/research-admin-tools.ts
+++ b/apps/api/src/mcp/research-admin-tools.ts
@@ -49,7 +49,7 @@ import {
   intProp,
   stringProp,
   structuredErrorResult,
-  textResult,
+  toolDataResult,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 
@@ -429,7 +429,7 @@ const handleSearchLegislationTool: McpToolHandler = async ({
       if (Result.isError(block)) {
         return internalFailureResult(block.error);
       }
-      return textResult({ lawId, blockId, block: block.value });
+      return toolDataResult({ lawId, blockId, block: block.value });
     }
 
     if (input.relation_type !== undefined) {
@@ -441,7 +441,7 @@ const handleSearchLegislationTool: McpToolHandler = async ({
       if (Result.isError(related)) {
         return internalFailureResult(related.error);
       }
-      return textResult(related.value);
+      return toolDataResult(related.value);
     }
 
     // Default read: the law plus its block structure. Both are external BOE
@@ -463,7 +463,7 @@ const handleSearchLegislationTool: McpToolHandler = async ({
     if (Result.isError(detail)) {
       return internalFailureResult(detail.error);
     }
-    return textResult(detail.value);
+    return toolDataResult(detail.value);
   }
 
   // Search mode.
@@ -500,7 +500,7 @@ const handleSearchLegislationTool: McpToolHandler = async ({
     typeof result.value,
     v.InferInput<typeof SEARCH_LEGISLATION_PROJECTION>
   >;
-  return textResult(result.value satisfies SearchLegislationPayload);
+  return toolDataResult(result.value satisfies SearchLegislationPayload);
 };
 
 // --- list_audit_log -----------------------------------------------------
@@ -589,7 +589,7 @@ const handleListAuditLogTool: McpToolHandler = async ({ args, context }) => {
   if (Result.isError(page)) {
     return internalFailureResult(page.error);
   }
-  return textResult(page.value);
+  return toolDataResult(page.value);
 };
 
 // --- manage_organization ------------------------------------------------
@@ -711,7 +711,7 @@ const handleAddMember = async ({
   if (Result.isError(added)) {
     return internalFailureResult(added.error);
   }
-  return textResult({
+  return toolDataResult({
     memberId: added.value.id,
   } satisfies v.InferInput<typeof MANAGE_ORGANIZATION_ADD_MEMBER_PROJECTION>);
 };
@@ -744,7 +744,7 @@ const handleRemoveMember = async ({
   if (Result.isError(removed)) {
     return internalFailureResult(removed.error);
   }
-  return textResult({
+  return toolDataResult({
     removed: true,
     id: removed.value.id,
   } satisfies v.InferInput<
@@ -834,7 +834,9 @@ const handleManageOrganizationTool: McpToolHandler = async ({
     typeof updated.value,
     v.InferInput<typeof MANAGE_ORGANIZATION_SETTINGS_PROJECTION>
   >;
-  return textResult(updated.value satisfies ManageOrganizationSettingsPayload);
+  return toolDataResult(
+    updated.value satisfies ManageOrganizationSettingsPayload,
+  );
 };
 
 export const RESEARCH_ADMIN_TOOL_HANDLERS = {

--- a/apps/api/src/mcp/server-core.ts
+++ b/apps/api/src/mcp/server-core.ts
@@ -42,10 +42,15 @@ import {
   closestToolNames,
   MCP_INTERNAL_ERROR_HINT,
   oauthScopeRecoveryHint,
+  serializeToolResult,
   structuredErrorResult,
 } from "@/api/mcp/tool-utils";
 
 const MAX_TOOL_NAME_SUGGESTION_CHARS = 128;
+
+const mcpStructuredErrorResult = (
+  args: Parameters<typeof structuredErrorResult>[0],
+): CallToolResult => serializeToolResult(structuredErrorResult(args));
 
 type ByteStreamReadResult =
   | { done: false; value: Uint8Array }
@@ -81,7 +86,7 @@ const missingScopeResult = ({
   missingScope: ToolScope;
   requiredScopes: readonly ToolScope[];
 }): CallToolResult =>
-  structuredErrorResult({
+  mcpStructuredErrorResult({
     code: "missing_scope",
     message: `Insufficient permissions. Required scope: ${missingScope}`,
     hint: oauthScopeRecoveryHint({
@@ -300,7 +305,7 @@ const retryableServerErrorResponse = () => {
  * Details never reach the caller; they are captured at the failure site.
  */
 const retryableToolErrorResult = (): CallToolResult =>
-  structuredErrorResult({
+  mcpStructuredErrorResult({
     code: "internal_error",
     message:
       "The request could not be completed due to a temporary server error",
@@ -409,7 +414,7 @@ export const createMcpHttpRequestHandler = ({
                 ),
               )
             : [];
-        return structuredErrorResult({
+        return mcpStructuredErrorResult({
           code: "unknown_tool",
           message: `Unknown tool: ${formatUnknownToolName(toolName)}`,
           hint:

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -764,14 +764,16 @@ const withOnboardingHintIfApplicable = async <TData>({
   if (jurisdictions.length > 0) {
     return result;
   }
+  const onboardingHint = buildOnboardingHintText();
+  const additionalText = result.mcp?.additionalText;
   return {
     ...result,
     mcp: {
       ...result.mcp,
-      additionalText: [
-        ...(result.mcp?.additionalText ?? []),
-        buildOnboardingHintText(),
-      ],
+      additionalText:
+        additionalText === undefined
+          ? [onboardingHint]
+          : [...additionalText, onboardingHint],
     },
   };
 };

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -1,4 +1,3 @@
-import type { CallToolResult } from "@modelcontextprotocol/server";
 import { panic, Result } from "better-result";
 import { and, desc, eq, sql } from "drizzle-orm";
 import * as v from "valibot";
@@ -74,6 +73,7 @@ import {
   runTextFieldSpecs,
 } from "@/api/mcp/text-field-spec";
 import type {
+  InternalToolSuccess,
   McpTextFieldSpec,
   McpToolDefinition,
   McpToolHandler,
@@ -99,7 +99,7 @@ import {
   resolveWindowBounds,
   stringProp,
   structuredErrorResult,
-  textResult,
+  toolDataResult,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
@@ -748,15 +748,15 @@ const buildOnboardingHintText = () =>
   `\`{ countryCode, isPrimary }\`) to enable jurisdiction-aware tools, or ` +
   `have the user complete onboarding at ${getAppBaseUrl()}.`;
 
-const withOnboardingHintIfApplicable = async ({
+const withOnboardingHintIfApplicable = async <TData>({
   context,
   isEmpty,
   result,
 }: {
   context: McpRequestContext;
   isEmpty: boolean;
-  result: CallToolResult;
-}): Promise<CallToolResult> => {
+  result: InternalToolSuccess<TData>;
+}): Promise<InternalToolSuccess<TData>> => {
   if (!isEmpty) {
     return result;
   }
@@ -766,10 +766,13 @@ const withOnboardingHintIfApplicable = async ({
   }
   return {
     ...result,
-    content: [
-      ...result.content,
-      { type: "text", text: buildOnboardingHintText() },
-    ],
+    mcp: {
+      ...result.mcp,
+      additionalText: [
+        ...(result.mcp?.additionalText ?? []),
+        buildOnboardingHintText(),
+      ],
+    },
   };
 };
 
@@ -907,7 +910,7 @@ const handleListMattersTool: McpToolHandler = async ({ args, context }) => {
     return await withOnboardingHintIfApplicable({
       context,
       isEmpty: true,
-      result: textResult({ matters, nextCursor: page.nextCursor }),
+      result: toolDataResult({ matters, nextCursor: page.nextCursor }),
     });
   }
 
@@ -1670,7 +1673,7 @@ const handleSearchCaseLawTool: McpToolHandler = async ({ args, context }) => {
     return errorResult("Case-law search failed");
   }
 
-  const payload = textResult({
+  const payload = toolDataResult({
     facets: result.facets,
     nextCursor: result.nextCursor,
     results: result.hits.map((hit) => {
@@ -1810,7 +1813,7 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
     ? encodePaginationCursor([textBounds.end, result.citationsNextCursor])
     : null;
 
-  return textResult({
+  return toolDataResult({
     nextCursor,
     decision: {
       appUrl: buildCaseLawDecisionAppUrl({
@@ -1967,7 +1970,7 @@ const handleSetPracticeJurisdictionsTool: McpToolHandler = async ({
     practiceJurisdictions,
   );
 
-  return textResult({ practiceJurisdictions } satisfies v.InferInput<
+  return toolDataResult({ practiceJurisdictions } satisfies v.InferInput<
     typeof SET_PRACTICE_JURISDICTIONS_PROJECTION
   >);
 };

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -73,6 +73,7 @@ import {
   runTextFieldSpecs,
 } from "@/api/mcp/text-field-spec";
 import type {
+  InternalToolResult,
   McpTextFieldSpec,
   McpToolDefinition,
   McpToolHandler,
@@ -90,7 +91,7 @@ import {
   parseOptionalCursor,
   stringProp,
   structuredErrorResult,
-  textResult,
+  toolDataResult,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
@@ -921,7 +922,7 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
 
   const truncated = filled.text.length > TEMPLATE_FILL_TEXT_MAX_CHARS;
 
-  return textResult({
+  return toolDataResult({
     completionStatus,
     templateName: filled.templateName,
     fileName: filled.fileName,
@@ -1133,7 +1134,7 @@ const handleSaveFilledTemplateTool: McpToolHandler = async ({
       case "claimed":
         return claim.value.claimToken;
       case "completed":
-        return textResult(claim.value.result);
+        return toolDataResult(claim.value.result);
       case "conflict":
         return structuredErrorResult({
           code: "validation_error",
@@ -1420,7 +1421,7 @@ const handleSaveFilledTemplateTool: McpToolHandler = async ({
     await releaseClaim();
     return errorResult(persistence.value.message);
   }
-  return textResult(persistence.value.value);
+  return toolDataResult(persistence.value.value);
 };
 
 // base64 encodes 3 bytes per 4 chars, so bound the encoded length to the doc
@@ -1528,7 +1529,7 @@ const createTemplateFromDocx = async ({
   docxBase64: string;
   fields: readonly unknown[] | undefined;
   name: string;
-}): Promise<ReturnType<typeof textResult>> => {
+}): Promise<InternalToolResult> => {
   const hasPermission = roles[context.memberRole].authorize({
     template: ["create"],
   });
@@ -1615,7 +1616,7 @@ const createTemplateFromDocx = async ({
     return errorResult(created.error.message);
   }
 
-  return textResult({
+  return toolDataResult({
     templateId: created.value.id,
     name: created.value.name,
     fieldCount: created.value.fieldCount,
@@ -1632,7 +1633,7 @@ const configureExistingTemplate = async ({
   context: McpRequestContext;
   fields: readonly unknown[];
   templateId: string;
-}): Promise<ReturnType<typeof textResult>> => {
+}): Promise<InternalToolResult> => {
   const hasPermission = roles[context.memberRole].authorize({
     template: ["update"],
   });
@@ -1687,7 +1688,7 @@ const configureExistingTemplate = async ({
     typeof described,
     v.InferInput<typeof TEMPLATE_DESCRIBE_PROJECTION>
   >;
-  return textResult(described satisfies ConfiguredTemplatePayload);
+  return toolDataResult(described satisfies ConfiguredTemplatePayload);
 };
 
 const handleSaveTemplateTool: McpToolHandler = async ({ args, context }) => {

--- a/apps/api/src/mcp/text-field-spec.ts
+++ b/apps/api/src/mcp/text-field-spec.ts
@@ -9,7 +9,7 @@ import type {
  * response shape; `deriveTextFieldPaths` turns that list into the
  * documentation-only path list a registry entry declares today, and
  * `runTextFieldSpecs` turns it into the `McpStructuredTextField[]` push list
- * `finalizeMcpEgress` already consumes, replacing the four duplicated
+ * `finalizeToolEgress` already consumes, replacing the four duplicated
  * `pushTextField`/`collectAnonymizableField` helpers module by module.
  *
  * No tool module is migrated to this in this commit (see plan 049 Phases

--- a/apps/api/src/mcp/tool-types.ts
+++ b/apps/api/src/mcp/tool-types.ts
@@ -1,5 +1,4 @@
 import type {
-  CallToolResult,
   JsonSchemaType,
   Tool as McpTool,
 } from "@modelcontextprotocol/server";
@@ -10,6 +9,7 @@ import type {
   MCP_DEFAULT_RESOURCE_SCOPES,
 } from "@/api/mcp/constants";
 import type { McpRequestContext } from "@/api/mcp/context";
+import type { McpErrorCode, McpValidationIssue } from "@/api/mcp/error-codes";
 import type { TextWindowResult } from "@/api/mcp/tool-utils";
 
 /**
@@ -281,9 +281,9 @@ export type McpStructuredWindow = {
 };
 
 /**
- * A handler either returns a finished `CallToolResult`, or an egress plan the
- * dispatch layer finalizes (anonymize declared text fields, then window, then
- * serialize). Egress plans keep the full, pre-window, un-anonymized payload so
+ * A handler either returns a finished internal result, or an egress plan the
+ * dispatch layer finalizes (anonymize declared text fields, then window).
+ * Egress plans keep the full, pre-window, un-anonymized payload so
  * the central pipeline can anonymize before it windows, without the handler
  * ever seeing the request mode.
  *
@@ -295,7 +295,52 @@ export type McpStructuredWindow = {
  * OpenAI-compatible-specific shaping (workspaceId stripping, anonymization
  * metadata) that does not generalize.
  */
-export type McpEgressPlan =
+export type InternalToolMcpPresentation = {
+  additionalText?: readonly string[];
+  primaryText?: string;
+  structuredContent?: Record<string, unknown>;
+};
+
+export type InternalToolSuccess<TData = unknown> = {
+  status: "success";
+  data: TData;
+  mcp?: InternalToolMcpPresentation;
+};
+
+export type InternalToolStructuredError = {
+  type: "structured";
+  code: McpErrorCode;
+  message: string;
+  hint?: string;
+  issues?: readonly McpValidationIssue[];
+  retryable?: boolean;
+  requestId?: string;
+};
+
+export type InternalToolTextError = {
+  type: "text";
+  message: string;
+};
+
+export type InternalToolError =
+  | InternalToolStructuredError
+  | InternalToolTextError;
+
+export type InternalToolErrorResult = {
+  status: "error";
+  error: InternalToolError;
+};
+
+/**
+ * Canonical result returned by Stella-owned tool execution. It contains domain
+ * data or a typed error, never an MCP content block. The MCP boundary converts
+ * this result to `CallToolResult`; internal consumers use it directly.
+ */
+export type InternalToolResult<TData = unknown> =
+  | InternalToolSuccess<TData>
+  | InternalToolErrorResult;
+
+export type McpEgressPlan<TPayload = unknown> =
   | {
       egress: "compatSearch";
       nextCursor: string | null | undefined;
@@ -313,28 +358,26 @@ export type McpEgressPlan =
     }
   | {
       egress: "structured";
-      payload: unknown;
+      payload: TPayload;
       textFields: readonly McpStructuredTextField[];
       window?: McpStructuredWindow;
     };
 
-export type McpToolResponse = CallToolResult | McpEgressPlan;
+export type McpToolResponse<TData = unknown> =
+  | InternalToolResult<TData>
+  | McpEgressPlan<TData>;
 
 export const isMcpEgressPlan = (
   response: McpToolResponse,
-): response is McpEgressPlan =>
-  // SAFETY: `CallToolResult` has no `egress` key, so its presence discriminates
-  // the egress-plan variants from a finished result. `CallToolResult` is an
-  // external SDK type we cannot brand with a shared discriminator.
-  "egress" in response;
+): response is McpEgressPlan => "egress" in response;
 
-export type McpToolHandler = ({
+export type McpToolHandler<TData = unknown> = ({
   args,
   context,
 }: {
   args: Record<string, unknown>;
   context: McpRequestContext;
-}) => McpToolResponse | Promise<McpToolResponse>;
+}) => McpToolResponse<TData> | Promise<McpToolResponse<TData>>;
 
 export type McpToolHandlerMap<
   TDefinitions extends readonly McpToolDefinition[],

--- a/apps/api/src/mcp/tool-utils.test.ts
+++ b/apps/api/src/mcp/tool-utils.test.ts
@@ -19,6 +19,7 @@ import {
   oauthScopeRecoveryHint,
   parseOptionalCursor,
   resolveWindowBounds,
+  serializeToolResult,
   slugifyCaseLawPathSegment,
   structuredErrorResult,
   validationErrorResult,
@@ -424,12 +425,20 @@ describe("parseOptionalCursor", () => {
 });
 
 const errorText = (result: ReturnType<typeof structuredErrorResult>) => {
-  const item = result.content.at(0);
+  const item = serializeToolResult(result).content.at(0);
   if (!item || item.type !== "text") {
     throw new Error("expected a text error content");
   }
   return item.text;
 };
+
+describe("serializeToolResult", () => {
+  test("rejects an undefined success payload at the MCP boundary", () => {
+    expect(() =>
+      serializeToolResult({ status: "success", data: undefined }),
+    ).toThrow("Internal tool success data must be JSON-serializable");
+  });
+});
 
 describe("oauthScopeRecoveryHint", () => {
   test("preserves granted scopes, adds every required scope, and removes duplicates", () => {
@@ -452,7 +461,7 @@ describe("structuredErrorResult", () => {
       message: "bad arg",
     });
 
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe("error");
     expect(errorText(result)).toBe(
       JSON.stringify({
         error: { code: "validation_error", message: "bad arg" },
@@ -579,7 +588,7 @@ describe("validationErrorResult", () => {
       message: "name is required",
     });
 
-    expect(result.isError).toBe(true);
+    expect(result.status).toBe("error");
     const payload = JSON.parse(errorText(result));
     expect(payload.error.code).toBe("validation_error");
     expect(payload.error.message).toBe("name is required");

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -153,8 +153,11 @@ export const serializeToolResult = (
         text: result.mcp?.primaryText ?? serializedData,
       },
     ];
-    for (const text of result.mcp?.additionalText ?? []) {
-      content.push({ type: "text", text });
+    const additionalText = result.mcp?.additionalText;
+    if (additionalText !== undefined) {
+      for (const text of additionalText) {
+        content.push({ type: "text", text });
+      }
     }
     return {
       content,

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -19,6 +19,12 @@ import type { McpRequestContext } from "@/api/mcp/context";
 import { getAccessibleWorkspaceId } from "@/api/mcp/context";
 import type { McpErrorCode, McpValidationIssue } from "@/api/mcp/error-codes";
 import { statusCodeToErrorCode } from "@/api/mcp/error-codes";
+import type {
+  InternalToolErrorResult,
+  InternalToolMcpPresentation,
+  InternalToolResult,
+  InternalToolSuccess,
+} from "@/api/mcp/tool-types";
 
 /**
  * Wrap the request-scoped recorder so audit rows written by the reused backing
@@ -119,9 +125,62 @@ export const confirmProp = (
     description,
   }) as const;
 
-export const textResult = (data: unknown): CallToolResult => ({
-  content: [{ type: "text", text: JSON.stringify(data) }],
+export const toolDataResult = <TData>(
+  data: TData,
+  mcp?: InternalToolMcpPresentation,
+): InternalToolSuccess<TData> => ({
+  status: "success",
+  data,
+  ...(mcp === undefined ? {} : { mcp }),
 });
+
+// TypeScript's JSON.stringify overload for `unknown` claims it always returns
+// a string, but the runtime returns undefined for unsupported root values.
+const stringifyJson = (value: unknown): unknown => JSON.stringify(value);
+
+/** Serialize a canonical Stella tool result at the external MCP boundary. */
+export const serializeToolResult = (
+  result: InternalToolResult,
+): CallToolResult => {
+  if (result.status === "success") {
+    const serializedData = stringifyJson(result.data);
+    if (typeof serializedData !== "string") {
+      panic("Internal tool success data must be JSON-serializable");
+    }
+    const content: CallToolResult["content"] = [
+      {
+        type: "text",
+        text: result.mcp?.primaryText ?? serializedData,
+      },
+    ];
+    for (const text of result.mcp?.additionalText ?? []) {
+      content.push({ type: "text", text });
+    }
+    return {
+      content,
+      ...(result.mcp?.structuredContent === undefined
+        ? {}
+        : { structuredContent: result.mcp.structuredContent }),
+    };
+  }
+
+  if (result.error.type === "text") {
+    return {
+      content: [{ type: "text", text: result.error.message }],
+      isError: true,
+    };
+  }
+
+  const { type: _type, ...error } = result.error;
+  return {
+    content: [{ type: "text", text: JSON.stringify({ error }) }],
+    isError: true,
+  };
+};
+
+/** Serialize unwrapped upstream data at an external MCP adapter boundary. */
+export const serializeMcpData = (data: unknown): CallToolResult =>
+  serializeToolResult(toolDataResult(data));
 
 /**
  * Legacy plain-text tool error. Kept for the handful of bespoke messages that
@@ -130,9 +189,9 @@ export const textResult = (data: unknown): CallToolResult => ({
  * `notFoundResult`, or the `validation_error`-tagged arg parsers below so agents
  * and the CLI can branch on a stable `error.code`.
  */
-export const errorResult = (message: string): CallToolResult => ({
-  content: [{ type: "text", text: message }],
-  isError: true,
+export const errorResult = (message: string): InternalToolErrorResult => ({
+  status: "error",
+  error: { type: "text", message },
 });
 
 /**
@@ -190,15 +249,16 @@ export const structuredErrorResult = ({
   issues?: readonly McpValidationIssue[] | undefined;
   message: string;
   retryable?: boolean | undefined;
-}): CallToolResult => {
+}): InternalToolErrorResult => {
   const error: {
+    type: "structured";
     code: McpErrorCode;
     message: string;
     hint?: string;
     issues?: readonly McpValidationIssue[];
     retryable?: boolean;
     requestId?: string;
-  } = { code, message };
+  } = { type: "structured", code, message };
   if (hint !== undefined) {
     error.hint = hint;
   }
@@ -213,10 +273,7 @@ export const structuredErrorResult = ({
     error.requestId = requestId;
   }
 
-  return {
-    content: [{ type: "text", text: JSON.stringify({ error }) }],
-    isError: true,
-  };
+  return { status: "error", error };
 };
 
 /**
@@ -248,7 +305,7 @@ export const validationErrorResult = ({
   hint?: string | undefined;
   issues: readonly v.BaseIssue<unknown>[];
   message: string;
-}): CallToolResult =>
+}): InternalToolErrorResult =>
   structuredErrorResult({
     code: "validation_error",
     hint,
@@ -260,7 +317,7 @@ export const validationErrorResult = ({
 export const notFoundResult = (
   message: string,
   hint?: string,
-): CallToolResult =>
+): InternalToolErrorResult =>
   structuredErrorResult({ code: "not_found", hint, message });
 
 /**
@@ -285,7 +342,9 @@ export const notFoundResult = (
  *    envelope the central pipeline's catch-all emits (see `handleMcpToolCall`),
  *    so no internal detail leaks to an external agent.
  */
-export const internalFailureResult = (error: unknown): CallToolResult => {
+export const internalFailureResult = (
+  error: unknown,
+): InternalToolErrorResult => {
   if (HandlerError.is(error)) {
     if (error.code === "upstream_unavailable") {
       captureError(error, { source: "mcp" });
@@ -384,7 +443,7 @@ export const hasErrorMessage = (value: unknown): value is { error: string } => {
  */
 export const toolThrownErrorToMcpResult = (
   err: unknown,
-): CallToolResult | null => {
+): InternalToolErrorResult | null => {
   if (TaggedError.is(err)) {
     return structuredErrorResult({
       code: "internal_error",
@@ -405,7 +464,7 @@ const argValidationError = (
   message: string,
   hint: string,
   path: string,
-): CallToolResult =>
+): InternalToolErrorResult =>
   structuredErrorResult({
     code: "validation_error",
     hint,
@@ -417,7 +476,7 @@ export const parseRequiredString = (
   args: Record<string, unknown>,
   key: string,
   opts?: { maxLength?: number },
-): string | CallToolResult => {
+): string | InternalToolErrorResult => {
   const value = args[key];
   if (typeof value !== "string" || value.length === 0) {
     return argValidationError(
@@ -446,7 +505,7 @@ export const parseOptionalEnum = <TValues extends readonly string[]>({
   defaultValue: TValues[number];
   key: string;
   values: TValues;
-}): TValues[number] | CallToolResult => {
+}): TValues[number] | InternalToolErrorResult => {
   const value = args[key];
   if (value === undefined) {
     return defaultValue;
@@ -471,7 +530,7 @@ export const parseOptionalLimit = ({
   defaultValue: number;
   key: string;
   max: number;
-}): number | CallToolResult => {
+}): number | InternalToolErrorResult => {
   const value = args[key];
   if (value === undefined) {
     return defaultValue;
@@ -491,11 +550,13 @@ export const parseOptionalLimit = ({
   return value;
 };
 
-export const isToolErrorResult = (value: unknown): value is CallToolResult =>
+export const isToolErrorResult = (
+  value: unknown,
+): value is InternalToolErrorResult =>
   typeof value === "object" &&
   value !== null &&
-  "isError" in value &&
-  value.isError === true;
+  "status" in value &&
+  value.status === "error";
 
 const MAX_CURSOR_LENGTH = 512;
 
@@ -505,7 +566,7 @@ export const parseOptionalCursor = ({
 }: {
   args: Record<string, unknown>;
   key: string;
-}): string | undefined | CallToolResult => {
+}): string | undefined | InternalToolErrorResult => {
   const value = args[key];
   if (value === undefined) {
     return undefined;
@@ -560,7 +621,7 @@ export const resolveWindowBounds = (
 
 const decodeTextWindowOffset = (
   cursor: string | undefined,
-): number | CallToolResult => {
+): number | InternalToolErrorResult => {
   if (cursor === undefined) {
     return 0;
   }
@@ -593,7 +654,7 @@ export const windowTextByCursor = ({
   cursor: string | undefined;
   maxChars: number;
   text: string;
-}): TextWindowResult | CallToolResult => {
+}): TextWindowResult | InternalToolErrorResult => {
   const offset = decodeTextWindowOffset(cursor);
   if (typeof offset !== "number") {
     return offset;
@@ -656,7 +717,7 @@ export const ensureActiveWorkspace = ({
 }: {
   context: McpRequestContext;
   workspaceId: string;
-}): SafeId<"workspace"> | CallToolResult => {
+}): SafeId<"workspace"> | InternalToolErrorResult => {
   const resolved = getAccessibleWorkspaceId({
     accessibleWorkspaceIdSet: context.accessibleWorkspaceIdSet,
     workspaceId,
@@ -823,7 +884,7 @@ export const invokeAiTool = async <TArgs extends Record<string, unknown>>({
   tool: {
     execute?: (args: TArgs, options: LocalToolExecutionOptions) => unknown;
   };
-}): Promise<CallToolResult> => {
+}): Promise<InternalToolResult> => {
   if (!tool.execute) {
     return errorResult("Tool is not executable");
   }
@@ -833,7 +894,7 @@ export const invokeAiTool = async <TArgs extends Record<string, unknown>>({
     if (hasErrorMessage(result)) {
       return errorResult(result.error);
     }
-    return textResult(result);
+    return toolDataResult(result);
   } catch (error) {
     const mapped = toolThrownErrorToMcpResult(error);
     if (mapped) {

--- a/apps/api/src/mcp/tools.ts
+++ b/apps/api/src/mcp/tools.ts
@@ -15,7 +15,7 @@ import {
   bindApprovedMcpAuditContext,
   type McpRequestContext,
 } from "@/api/mcp/context";
-import { finalizeMcpEgress } from "@/api/mcp/egress";
+import { finalizeToolEgress } from "@/api/mcp/egress";
 import { dispatchGatewayToolCall } from "@/api/mcp/gateway/dispatch-call";
 import {
   getGatewayMcpToolDefinition,
@@ -34,6 +34,7 @@ import type {
 } from "@/api/mcp/tool-types";
 import {
   MCP_INTERNAL_ERROR_HINT,
+  serializeToolResult,
   structuredErrorResult,
 } from "@/api/mcp/tool-utils";
 
@@ -121,16 +122,20 @@ export const handleMcpToolCall = async ({
     toolName,
   });
   if (gatewayResult) {
-    return gatewayResult;
+    return gatewayResult.type === "external_mcp"
+      ? gatewayResult.result
+      : serializeToolResult(gatewayResult.result);
   }
 
   const staticTool = getStaticMcpToolDefinition(toolName, mode);
   if (!staticTool) {
-    return structuredErrorResult({
-      code: "unknown_tool",
-      message: `Unknown tool: ${toolName}`,
-      hint: "Call tools/list for the tools available to this session.",
-    });
+    return serializeToolResult(
+      structuredErrorResult({
+        code: "unknown_tool",
+        message: `Unknown tool: ${toolName}`,
+        hint: "Call tools/list for the tools available to this session.",
+      }),
+    );
   }
 
   if (
@@ -138,22 +143,27 @@ export const handleMcpToolCall = async ({
     toolName === "invoke_capability" &&
     !isDocumentsMcpCapabilityAllowed(args)
   ) {
-    return structuredErrorResult({
-      code: "feature_disabled",
-      message: "This capability is not available on the documents MCP surface",
-      hint: "Use one of the upload lifecycle operations exposed by the document upload panel.",
-    });
+    return serializeToolResult(
+      structuredErrorResult({
+        code: "feature_disabled",
+        message:
+          "This capability is not available on the documents MCP surface",
+        hint: "Use one of the upload lifecycle operations exposed by the document upload panel.",
+      }),
+    );
   }
 
   // Reject a gated-off tool even when the caller names it directly: the list
   // surface hides it, and this closes the guess-the-name bypass so the gate
   // holds on both the advertisement and the dispatch path.
   if (!isMcpToolFeatureEnabled(staticTool.feature)) {
-    return structuredErrorResult({
-      code: "feature_disabled",
-      message: "This feature is not enabled on this deployment",
-      hint: "This deployment or organization has this feature turned off; it cannot be enabled from the client.",
-    });
+    return serializeToolResult(
+      structuredErrorResult({
+        code: "feature_disabled",
+        message: "This feature is not enabled on this deployment",
+        hint: "This deployment or organization has this feature turned off; it cannot be enabled from the client.",
+      }),
+    );
   }
 
   // Destructive-op guardrail (agent misuse protection): an irreversible tool
@@ -164,20 +174,24 @@ export const handleMcpToolCall = async ({
     staticTool.annotations.destructiveHint === true &&
     args["confirm"] !== true
   ) {
-    return structuredErrorResult({
-      code: "confirmation_required",
-      message: `${toolName} is an irreversible operation and was called without confirmation`,
-      hint: "This operation is irreversible. Confirm with the human user, then retry with confirm: true.",
-    });
+    return serializeToolResult(
+      structuredErrorResult({
+        code: "confirmation_required",
+        message: `${toolName} is an irreversible operation and was called without confirmation`,
+        hint: "This operation is irreversible. Confirm with the human user, then retry with confirm: true.",
+      }),
+    );
   }
 
   const handler = MCP_TOOL_HANDLERS.get(toolName);
   if (!handler) {
-    return structuredErrorResult({
-      code: "unknown_tool",
-      message: `Unknown tool: ${toolName}`,
-      hint: "Call tools/list for the tools available to this session.",
-    });
+    return serializeToolResult(
+      structuredErrorResult({
+        code: "unknown_tool",
+        message: `Unknown tool: ${toolName}`,
+        hint: "Call tools/list for the tools available to this session.",
+      }),
+    );
   }
 
   try {
@@ -187,22 +201,27 @@ export const handleMcpToolCall = async ({
         : context;
     // Handlers never see the mode: they return either a finished result or an
     // egress plan. The central pipeline applies anonymization (anonymized mode)
-    // before windowing, then serializes. Both steps run inside this try so an
-    // anonymization or windowing failure is captured like any handler failure.
+    // before windowing; this transport boundary then serializes. Both steps run
+    // inside this try so an anonymization or windowing failure is captured like
+    // any handler failure.
     const response = await handler({ args, context: executionContext });
-    return await finalizeMcpEgress({
-      context: executionContext,
-      mode,
-      response,
-    });
+    return serializeToolResult(
+      await finalizeToolEgress({
+        context: executionContext,
+        mode,
+        response,
+      }),
+    );
   } catch (error) {
     captureError(error, { source: "mcp", toolName });
     // Generic message: never leak internals to the caller. `captureError` keeps
     // the real exception for observability.
-    return structuredErrorResult({
-      code: "internal_error",
-      message: "Tool execution failed",
-      hint: MCP_INTERNAL_ERROR_HINT,
-    });
+    return serializeToolResult(
+      structuredErrorResult({
+        code: "internal_error",
+        message: "Tool execution failed",
+        hint: MCP_INTERNAL_ERROR_HINT,
+      }),
+    );
   }
 };


### PR DESCRIPTION
## Summary

- return discriminated typed data or errors from Stella-owned tool execution
- serialize MCP content only at MCP and upstream-connector boundaries
- let chat projection consume finalized data directly without JSON stringify/parse round-trips
- preserve explicit MCP presentation metadata for structured content and supplemental text
- convert database timestamps explicitly where projections require strings

Stacked on #2365.

## Validation

- `bun --filter @stll/api test`
- `bun --filter @stll/api typecheck`
- `bun --filter @stll/api lint`
- pre-push affected code checks, formatting, and i18n checks

CC on behalf of jan-kubica