### PR TITLE
fix(api): name the corpus index request that failed

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -381,3 +381,56 @@ test("an unreadable success body names the request too", async () => {
     );
   }
 });
+
+test("a body that stalls past the budget is a timeout, not an unreadable body", async () => {
+  // The timeout covers the body as well as the headers, so a response can
+  // arrive `ok` and then abort mid-stream. Reporting that as a malformed
+  // payload would hide the very timeout this client exists to name.
+  const stub = async (): Promise<Response> =>
+    new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.error(
+            new DOMException("The operation timed out.", "TimeoutError"),
+          );
+        },
+      }),
+      { status: 200 },
+    );
+  globalThis.fetch = Object.assign(stub, {
+    preconnect: originalFetch.preconnect,
+  });
+
+  const result = await getCorpusIndexClient().search({
+    indexId: "legal_corpus_v1_cze",
+    query: "text:smlouva",
+    maxHits: 10,
+  });
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toBe(
+      "corpus index POST /api/v1/legal_corpus_v1_cze/search failed within its 30000ms budget: TimeoutError: The operation timed out.",
+    );
+  }
+});
+
+test("a request that never reaches the engine is not reported as a timeout", async () => {
+  rejectFetchWith(
+    new Error("Unable to connect. Is the computer able to access the url?"),
+  );
+
+  const result = await getCorpusIndexClient().search({
+    indexId: "legal_corpus_v1_cze",
+    query: "text:smlouva",
+    maxHits: 10,
+  });
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    // No budget expired here, so quoting one would misdescribe the failure.
+    expect(result.error.message).toBe(
+      "corpus index POST /api/v1/legal_corpus_v1_cze/search could not be sent: Error: Unable to connect. Is the computer able to access the url?",
+    );
+  }
+});

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -311,3 +311,73 @@ test("ingest succeeds when every document is accepted", async () => {
 
   expect(result.isOk()).toBe(true);
 });
+
+// Bun rejects a request whose timeout fires with the abort reason alone —
+// a DOMException reading "The operation timed out." and nothing else. On
+// the backfill path that reaches the log as the whole story, so the client
+// has to say which request expired and how long it had.
+const rejectFetchWith = (reason: unknown): void => {
+  const stub = async (): Promise<Response> => {
+    throw reason;
+  };
+  globalThis.fetch = Object.assign(stub, {
+    preconnect: originalFetch.preconnect,
+  });
+};
+
+test("ingest names the request and its budget when the transport fails", async () => {
+  rejectFetchWith(new DOMException("The operation timed out.", "TimeoutError"));
+
+  const result = await getCorpusIndexClient().ingestBatch(
+    "legal_corpus_v1_cze",
+    '{"document_id":"a"}',
+    CORPUS_INDEX_COMMIT.waitFor,
+  );
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toBe(
+      `corpus index POST /api/v1/legal_corpus_v1_cze/ingest?commit=${CORPUS_INDEX_COMMIT.waitFor} failed within its ${CORPUS_INDEX_INGEST_TIMEOUT_MS}ms budget: TimeoutError: The operation timed out.`,
+    );
+  }
+});
+
+test("each request reports its own budget, not a shared one", async () => {
+  rejectFetchWith(new DOMException("The operation timed out.", "TimeoutError"));
+
+  const result = await getCorpusIndexClient().search({
+    indexId: "legal_corpus_v1_cze",
+    query: "text:smlouva",
+    maxHits: 10,
+  });
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    // The search budget differs from the ingest budget above, so a message
+    // that hardcoded one of them could not satisfy both tests.
+    expect(result.error.message).toBe(
+      "corpus index POST /api/v1/legal_corpus_v1_cze/search failed within its 30000ms budget: TimeoutError: The operation timed out.",
+    );
+  }
+});
+
+test("an unreadable success body names the request too", async () => {
+  const stub = async (): Promise<Response> =>
+    new Response("not json", { status: 200 });
+  globalThis.fetch = Object.assign(stub, {
+    preconnect: originalFetch.preconnect,
+  });
+
+  const result = await getCorpusIndexClient().search({
+    indexId: "legal_corpus_v1_cze",
+    query: "text:smlouva",
+    maxHits: 10,
+  });
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toContain(
+      "corpus index POST /api/v1/legal_corpus_v1_cze/search returned an unreadable body:",
+    );
+  }
+});

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -175,7 +175,24 @@ const requestLabel = ({ init, path }: CorpusIndexRequest): string =>
   `${init.method ?? "GET"} ${path}`;
 
 /**
- * Sends the request, naming it on a transport failure.
+ * The budget covers the whole exchange, so it can expire before the
+ * headers arrive or while the body is still streaming. Both abort with
+ * the same reason, and neither is a malformed payload.
+ */
+const isAborted = (error: unknown): boolean =>
+  error instanceof Error &&
+  (error.name === "TimeoutError" || error.name === "AbortError");
+
+type RequestFailureOptions = {
+  request: CorpusIndexRequest;
+  error: unknown;
+  /** How to describe a failure the budget did not cause. */
+  unaborted: string;
+};
+
+/**
+ * Names the request that failed, and the budget when the budget is what
+ * ended it.
  *
  * `fetchWithTimeout` rejects with the abort reason alone, so an expired
  * budget reaches the caller as "The operation timed out." and says
@@ -183,15 +200,24 @@ const requestLabel = ({ init, path }: CorpusIndexRequest): string =>
  * branch below already names the request; this gives the branch that
  * actually fires under load the same.
  */
+const requestFailure = ({
+  request,
+  error,
+  unaborted,
+}: RequestFailureOptions): CorpusIndexError =>
+  new CorpusIndexError({
+    message: isAborted(error)
+      ? `corpus index ${requestLabel(request)} failed within its ${request.timeoutMs}ms budget: ${String(error)}`
+      : `corpus index ${requestLabel(request)} ${unaborted}: ${String(error)}`,
+    cause: error,
+  });
+
 const sendRequest = async (request: CorpusIndexRequest): Promise<Response> =>
   await fetchWithTimeout(`${request.baseUrl}${request.path}`, {
     ...request.init,
     timeoutMs: request.timeoutMs,
   }).catch((error: unknown) => {
-    throw new CorpusIndexError({
-      message: `corpus index ${requestLabel(request)} failed within its ${request.timeoutMs}ms budget: ${String(error)}`,
-      cause: error,
-    });
+    throw requestFailure({ request, error, unaborted: "could not be sent" });
   });
 
 const requestJson = async (request: CorpusIndexRequest): Promise<unknown> => {
@@ -204,9 +230,10 @@ const requestJson = async (request: CorpusIndexRequest): Promise<unknown> => {
     });
   }
   return await response.json().catch((error: unknown) => {
-    throw new CorpusIndexError({
-      message: `corpus index ${requestLabel(request)} returned an unreadable body: ${String(error)}`,
-      cause: error,
+    throw requestFailure({
+      request,
+      error,
+      unaborted: "returned an unreadable body",
     });
   });
 };

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -164,24 +164,51 @@ const toCorpusIndexError = (error: unknown): CorpusIndexError =>
         cause: error,
       });
 
-const requestJson = async (
-  baseUrl: string,
-  path: string,
-  init: Omit<RequestInit, "signal">,
-  timeoutMs: number,
-): Promise<unknown> => {
-  const response = await fetchWithTimeout(`${baseUrl}${path}`, {
-    ...init,
-    timeoutMs,
+type CorpusIndexRequest = {
+  baseUrl: string;
+  path: string;
+  init: Omit<RequestInit, "signal">;
+  timeoutMs: number;
+};
+
+const requestLabel = ({ init, path }: CorpusIndexRequest): string =>
+  `${init.method ?? "GET"} ${path}`;
+
+/**
+ * Sends the request, naming it on a transport failure.
+ *
+ * `fetchWithTimeout` rejects with the abort reason alone, so an expired
+ * budget reaches the caller as "The operation timed out." and says
+ * neither which request expired nor how long it had. The rejected-status
+ * branch below already names the request; this gives the branch that
+ * actually fires under load the same.
+ */
+const sendRequest = async (request: CorpusIndexRequest): Promise<Response> =>
+  await fetchWithTimeout(`${request.baseUrl}${request.path}`, {
+    ...request.init,
+    timeoutMs: request.timeoutMs,
+  }).catch((error: unknown) => {
+    throw new CorpusIndexError({
+      message: `corpus index ${requestLabel(request)} failed within its ${request.timeoutMs}ms budget: ${String(error)}`,
+      cause: error,
+    });
   });
+
+const requestJson = async (request: CorpusIndexRequest): Promise<unknown> => {
+  const response = await sendRequest(request);
   if (!response.ok) {
     const body = await response.text().catch(() => "");
     throw new CorpusIndexError({
-      message: `corpus index ${init.method ?? "GET"} ${path} -> ${response.status}: ${body.slice(0, 500)}`,
+      message: `corpus index ${requestLabel(request)} -> ${response.status}: ${body.slice(0, 500)}`,
       status: response.status,
     });
   }
-  return await response.json();
+  return await response.json().catch((error: unknown) => {
+    throw new CorpusIndexError({
+      message: `corpus index ${requestLabel(request)} returned an unreadable body: ${String(error)}`,
+      cause: error,
+    });
+  });
 };
 
 const parseRecordArray = (value: unknown): Record<string, unknown>[] | null => {
@@ -203,16 +230,16 @@ const buildClient = (): CorpusIndexClient => ({
   createIndex: async (config) =>
     await Result.tryPromise({
       try: async () => {
-        await requestJson(
-          mutationBaseUrl(),
-          "/api/v1/indexes",
-          {
+        await requestJson({
+          baseUrl: mutationBaseUrl(),
+          path: "/api/v1/indexes",
+          init: {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify(config),
           },
-          ADMIN_TIMEOUT_MS,
-        );
+          timeoutMs: ADMIN_TIMEOUT_MS,
+        });
       },
       catch: toCorpusIndexError,
     }),
@@ -220,12 +247,12 @@ const buildClient = (): CorpusIndexClient => ({
   deleteIndex: async (indexId) =>
     await Result.tryPromise({
       try: async () => {
-        await requestJson(
-          mutationBaseUrl(),
-          `/api/v1/indexes/${indexId}`,
-          { method: "DELETE" },
-          ADMIN_TIMEOUT_MS,
-        );
+        await requestJson({
+          baseUrl: mutationBaseUrl(),
+          path: `/api/v1/indexes/${indexId}`,
+          init: { method: "DELETE" },
+          timeoutMs: ADMIN_TIMEOUT_MS,
+        });
       },
       catch: toCorpusIndexError,
     }),
@@ -233,13 +260,12 @@ const buildClient = (): CorpusIndexClient => ({
   indexExists: async (indexId) =>
     await Result.tryPromise({
       try: async () => {
-        const response = await fetchWithTimeout(
-          `${mutationBaseUrl()}/api/v1/indexes/${indexId}`,
-          {
-            method: "GET",
-            timeoutMs: ADMIN_TIMEOUT_MS,
-          },
-        );
+        const response = await sendRequest({
+          baseUrl: mutationBaseUrl(),
+          path: `/api/v1/indexes/${indexId}`,
+          init: { method: "GET" },
+          timeoutMs: ADMIN_TIMEOUT_MS,
+        });
         if (response.status === 404) {
           return false;
         }
@@ -260,16 +286,16 @@ const buildClient = (): CorpusIndexClient => ({
         const sentDocs = ndjson
           .split("\n")
           .filter((line) => line.trim().length > 0).length;
-        const response = await requestJson(
-          mutationBaseUrl(),
-          `/api/v1/${indexId}/ingest?commit=${commit}`,
-          {
+        const response = await requestJson({
+          baseUrl: mutationBaseUrl(),
+          path: `/api/v1/${indexId}/ingest?commit=${commit}`,
+          init: {
             method: "POST",
             headers: { "content-type": "application/x-ndjson" },
             body: ndjson,
           },
-          CORPUS_INDEX_INGEST_TIMEOUT_MS,
-        );
+          timeoutMs: CORPUS_INDEX_INGEST_TIMEOUT_MS,
+        });
         if (!isRecord(response)) {
           throw new CorpusIndexError({
             message: "corpus index ingest returned an invalid response",
@@ -325,16 +351,16 @@ const buildClient = (): CorpusIndexClient => ({
         if (snippetFields !== undefined && snippetFields.length > 0) {
           body["snippet_fields"] = snippetFields.join(",");
         }
-        const response = await requestJson(
-          searchBaseUrl(),
-          `/api/v1/${indexId}/search`,
-          {
+        const response = await requestJson({
+          baseUrl: searchBaseUrl(),
+          path: `/api/v1/${indexId}/search`,
+          init: {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify(body),
           },
-          SEARCH_TIMEOUT_MS,
-        );
+          timeoutMs: SEARCH_TIMEOUT_MS,
+        });
         if (!isRecord(response)) {
           throw new CorpusIndexError({
             message: "corpus index search returned an invalid response",
@@ -374,18 +400,18 @@ const buildClient = (): CorpusIndexClient => ({
   aggregate: async ({ indexId, query, aggs }) =>
     await Result.tryPromise({
       try: async () => {
-        const response = await requestJson(
-          searchBaseUrl(),
-          `/api/v1/${indexId}/search`,
-          {
+        const response = await requestJson({
+          baseUrl: searchBaseUrl(),
+          path: `/api/v1/${indexId}/search`,
+          init: {
             method: "POST",
             headers: { "content-type": "application/json" },
             // Aggregations only: hits are the expensive part of the
             // response and the caller wants counts, not documents.
             body: JSON.stringify({ query, max_hits: 0, aggs }),
           },
-          AGGREGATION_TIMEOUT_MS,
-        );
+          timeoutMs: AGGREGATION_TIMEOUT_MS,
+        });
         if (!isRecord(response) || !isRecord(response["aggregations"])) {
           throw new CorpusIndexError({
             message: "corpus index aggregation returned an invalid response",
@@ -399,16 +425,16 @@ const buildClient = (): CorpusIndexClient => ({
   deleteByQuery: async (indexId, query) =>
     await Result.tryPromise({
       try: async () => {
-        await requestJson(
-          mutationBaseUrl(),
-          `/api/v1/${indexId}/delete-tasks`,
-          {
+        await requestJson({
+          baseUrl: mutationBaseUrl(),
+          path: `/api/v1/${indexId}/delete-tasks`,
+          init: {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({ query }),
           },
-          ADMIN_TIMEOUT_MS,
-        );
+          timeoutMs: ADMIN_TIMEOUT_MS,
+        });
       },
       catch: toCorpusIndexError,
     }),

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -119,6 +119,7 @@ import {
   stepCadence,
   stepStallAlert,
 } from "./cycle-progress";
+import { formatLogDetail } from "./log-detail";
 import {
   RECOMPUTE_OUTCOME,
   type RecomputeOutcome,
@@ -132,31 +133,6 @@ import {
   SOURCE_TOTAL_POLL_TIMING,
   runSourceTotalPoll,
 } from "./source-total-poll";
-
-const formatLogDetail = (detail: unknown): string => {
-  if (detail === undefined) {
-    return "";
-  }
-
-  if (detail instanceof Error) {
-    const base = detail.stack ?? detail.message;
-    // Wrapped driver errors (e.g. DrizzleQueryError) carry the actual
-    // failure in `cause`; without it the log shows only the query text.
-    return detail.cause instanceof Error
-      ? `${base}\n[cause] ${detail.cause.stack ?? detail.cause.message}`
-      : base;
-  }
-
-  if (typeof detail === "string") {
-    return detail;
-  }
-
-  try {
-    return JSON.stringify(detail);
-  } catch {
-    return "[unserializable log detail]";
-  }
-};
 
 const logInfo = (message: string): void => {
   void Bun.write(Bun.stdout, `${message}\n`);

--- a/apps/legal-atlas-runner/src/runners/log-detail.test.ts
+++ b/apps/legal-atlas-runner/src/runners/log-detail.test.ts
@@ -56,3 +56,17 @@ test("passes a string detail through and serialises other values", () => {
     '{"adapterKey":"cz-us"}',
   );
 });
+
+// `logError` drops a falsy detail, so returning anything but a string here
+// loses the detail entirely — the same silent loss this module exists to
+// stop. Both unserialisable shapes are covered: one throws, one does not.
+test("names a detail it cannot serialise rather than returning nothing", () => {
+  const cyclic: Record<string, unknown> = {};
+  cyclic["self"] = cyclic;
+
+  expect(formatLogDetail(cyclic)).toBe("[unserializable log detail]");
+  expect(formatLogDetail(() => "work")).toBe("[unserializable log detail]");
+  expect(formatLogDetail(Symbol("adapter"))).toBe(
+    "[unserializable log detail]",
+  );
+});

--- a/apps/legal-atlas-runner/src/runners/log-detail.test.ts
+++ b/apps/legal-atlas-runner/src/runners/log-detail.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test";
+
+import { formatLogDetail } from "./log-detail";
+
+// The shape Bun rejects a timed-out `fetch` with: a DOMException carrying
+// a name and a message, and a stack that is the EMPTY STRING rather than
+// absent. Constructing one directly leaves `stack` undefined, so the empty
+// stack is set here to model what the runtime actually hands the logger.
+const timeoutError = (): Error => {
+  const error = new DOMException("The operation timed out.", "TimeoutError");
+  error.stack = "";
+  return error;
+};
+
+test("the fixture models an empty stack, not an absent one", () => {
+  // A fixture with an absent stack would exercise the nullish branch and
+  // pass under the defect this file exists to pin.
+  expect(timeoutError().stack).toBe("");
+});
+
+test("renders an error whose stack is empty rather than absent", () => {
+  expect(formatLogDetail(timeoutError())).toBe(
+    "TimeoutError: The operation timed out.",
+  );
+});
+
+test("renders a cause whose stack is empty rather than absent", () => {
+  const wrapper = new Error("corpus index ingest failed", {
+    cause: timeoutError(),
+  });
+  wrapper.stack = "Error: corpus index ingest failed\n    at ingest";
+
+  expect(formatLogDetail(wrapper)).toBe(
+    "Error: corpus index ingest failed\n    at ingest\n[cause] TimeoutError: The operation timed out.",
+  );
+});
+
+test("prefers a stack when the error has one", () => {
+  const error = new Error("boom");
+  error.stack = "Error: boom\n    at somewhere";
+
+  expect(formatLogDetail(error)).toBe("Error: boom\n    at somewhere");
+});
+
+test("omits the cause section when the cause is not an error", () => {
+  const error = new Error("boom", { cause: "a string" });
+  error.stack = "Error: boom";
+
+  expect(formatLogDetail(error)).toBe("Error: boom");
+});
+
+test("passes a string detail through and serialises other values", () => {
+  expect(formatLogDetail(undefined)).toBe("");
+  expect(formatLogDetail("plain")).toBe("plain");
+  expect(formatLogDetail({ adapterKey: "cz-us" })).toBe(
+    '{"adapterKey":"cz-us"}',
+  );
+});

--- a/apps/legal-atlas-runner/src/runners/log-detail.ts
+++ b/apps/legal-atlas-runner/src/runners/log-detail.ts
@@ -15,6 +15,16 @@
  * `name: message` also matches the first line of a stack, so both
  * branches read the same.
  */
+const UNSERIALIZABLE = "[unserializable log detail]";
+
+/**
+ * `JSON.stringify` is declared to return `string`, but returns undefined
+ * for a function, a symbol, or a value whose `toJSON` yields one. Stating
+ * the real signature keeps the fallback below visible to the type checker
+ * rather than looking redundant to it.
+ */
+const serialize = (value: unknown): string | undefined => JSON.stringify(value);
+
 const describeError = (error: Error): string => {
   const { stack } = error;
   return stack !== undefined && stack.length > 0
@@ -40,9 +50,11 @@ export const formatLogDetail = (detail: unknown): string => {
     return detail;
   }
 
+  // Two ways to be unserialisable and only one of them throws: a cyclic
+  // value raises, a function or symbol returns undefined.
   try {
-    return JSON.stringify(detail);
+    return serialize(detail) ?? UNSERIALIZABLE;
   } catch {
-    return "[unserializable log detail]";
+    return UNSERIALIZABLE;
   }
 };

--- a/apps/legal-atlas-runner/src/runners/log-detail.ts
+++ b/apps/legal-atlas-runner/src/runners/log-detail.ts
@@ -1,0 +1,48 @@
+/**
+ * Renders the detail argument of the runner's plain-text error lines.
+ *
+ * Split out of the daemon so the error shapes below are testable: how an
+ * error renders is the whole value of an error log.
+ */
+
+/**
+ * An error's own description, preferring its stack.
+ *
+ * Emptiness rather than absence is what "carries no stack" looks like
+ * here: Bun rejects a timed-out `fetch` with a `DOMException` whose
+ * `stack` is the empty string, so a nullish fallback keeps that empty
+ * string and renders the error as nothing at all. Falling back to
+ * `name: message` also matches the first line of a stack, so both
+ * branches read the same.
+ */
+const describeError = (error: Error): string => {
+  const { stack } = error;
+  return stack !== undefined && stack.length > 0
+    ? stack
+    : `${error.name}: ${error.message}`;
+};
+
+export const formatLogDetail = (detail: unknown): string => {
+  if (detail === undefined) {
+    return "";
+  }
+
+  if (detail instanceof Error) {
+    const base = describeError(detail);
+    // Wrapped driver errors (e.g. DrizzleQueryError) carry the actual
+    // failure in `cause`; without it the log shows only the query text.
+    return detail.cause instanceof Error
+      ? `${base}\n[cause] ${describeError(detail.cause)}`
+      : base;
+  }
+
+  if (typeof detail === "string") {
+    return detail;
+  }
+
+  try {
+    return JSON.stringify(detail);
+  } catch {
+    return "[unserializable log detail]";
+  }
+};

--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -30,7 +30,9 @@ const chatReadySurface = (page: Page) => {
 // the actual exception behind a blank page.
 test.beforeEach(({ page }) => {
   page.on("pageerror", (error) => {
-    console.log(`[pageerror] ${error.stack ?? String(error)}`);
+    // Emptiness, not absence, is how an error reports "no stack" here, so
+    // a nullish fallback would log the empty string instead of the error.
+    console.log(`[pageerror] ${error.stack || String(error)}`);
   });
   page.on("requestfailed", (request) => {
     const failure = request.failure()?.errorText ?? "unknown failure";


### PR DESCRIPTION
## Proposed change

Two failure paths in the corpus index stack discard the information that identifies the failure, so a request that never completes reaches the log as `CorpusIndexError: The operation timed out.` followed by an empty `[cause]` section.

**1. The client names a rejected status but not a transport failure.** `requestJson` builds a descriptive error when the engine answers (`corpus index POST /api/v1/<index>/ingest?commit=wait_for -> 503: …`), but when the request never gets a response `fetchWithTimeout` rejects with the abort reason alone and `toCorpusIndexError` re-wraps it with `error.message`. Which request expired, and which of the four budgets it had (10 s aggregation, 30 s search, 30 s admin, 120 s ingest), is then unrecoverable — and the budgets differ by an order of magnitude, so the distinction is the whole diagnosis.

**2. The runner's log formatter then drops what is left.** `formatLogDetail` falls back from an error's stack to its message with `??`. Bun rejects a timed-out `fetch` with a `DOMException` whose `stack` is the **empty string**, not `undefined`, so the fallback never runs and the wrapped cause renders as nothing at all. `apps/web/e2e/staging/staging-smoke.spec.ts` had the same fallback on `pageerror`.

### Change

- Route every corpus index call through one request helper taking `{ baseUrl, path, init, timeoutMs }`, and name the request on a transport failure and on an unreadable success body. The rejected-status message is byte-identical to before. `indexExists` went through `fetchWithTimeout` directly and now shares the helper, so no call site can lose the context.
- Fall back on emptiness rather than nullishness in both formatters.
- Move `formatLogDetail` out of the daemon module into `runners/log-detail.ts`, matching how the other runner helpers are split out, so the error shapes it handles are covered by tests.

Observability only: no request, budget or control flow changes.

### Verification

- `bun test`: `corpus-index-client.test.ts` 17/17, new `log-detail.test.ts` 6/6, `apps/legal-atlas-runner` 102/102, `apps/api/src/lib/legal-search` 319/319.
- Mutation checks, both scoped: restoring `??` fails exactly the two empty-stack tests and nothing else; removing the transport naming fails exactly the two client tests and nothing else.
- `tsc --noEmit` clean on `apps/api` and `apps/legal-atlas-runner`; scoped oxlint clean; `bun run format` a no-op; `bun scripts/ratchet.ts --check` OK at 54 metrics.

One note on the fixture: constructing a `DOMException` directly leaves `stack` undefined, so `log-detail.test.ts` sets it to `""` explicitly and asserts that it did. A fixture with an absent stack exercises the nullish branch and passes under the defect.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no user-facing surface.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no user-facing surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MY5AjvMMNTzPdJR1dPgm1d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved legal search error messages with the affected request and its timeout limit.
  - Clarified failures caused by network timeouts and unreadable responses.
  - Improved handling of empty error details so useful messages are displayed.

- **Improvements**
  - Standardised error-detail formatting across runner logs, including nested causes, timeout errors and structured values.
  - Added broader validation coverage for request failures and error formatting to support more reliable diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->