### PR TITLE
fix(api): complete legislation title cutover

### DIFF
--- a/apps/api/drizzle/20260823010000_legislation_title_text_cutover/migration.sql
+++ b/apps/api/drizzle/20260823010000_legislation_title_text_cutover/migration.sql
@@ -1,0 +1,58 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- The compatibility release taught every replica both cursor protocols. The
+-- old full-title index must be absent while the column is widened: PostgreSQL
+-- otherwise rebuilds the dependent B-tree inside ALTER TABLE, and unbounded
+-- titles would still fail its tuple-size limit.
+-- squawk-ignore transaction-nesting
+COMMIT;--> statement-breakpoint
+SET statement_timeout = 0;--> statement-breakpoint
+SET lock_timeout = 0;--> statement-breakpoint
+-- stella-migration-safety: reviewed destructive-change - the follow-up query
+-- uses the bounded expression index created below; legacy cursors remain a
+-- correct, temporary unindexed compatibility path.
+DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_country_title_id_idx";--> statement-breakpoint
+-- stella-migration-safety: reviewed destructive-change - the same trigram
+-- index is recreated concurrently after the metadata-only type change.
+DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_title_trgm_idx";--> statement-breakpoint
+
+SET statement_timeout = '5s';--> statement-breakpoint
+SET lock_timeout = '1s';--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;--> statement-breakpoint
+-- Keep lock acquisition bounded, but do not interrupt metadata-only catalog
+-- work after PostgreSQL grants the lock. No title-dependent B-tree exists in
+-- this block, so PostgreSQL does not rebuild one under ACCESS EXCLUSIVE.
+-- stella-migration-safety: metadata-only-type-change
+SET statement_timeout = 0;--> statement-breakpoint
+-- stella-migration-safety: reviewed destructive-change - widening
+-- varchar(1024) to text uses the same storage representation and loses no
+-- values. Rollback may narrow only after proving every stored title fits.
+ALTER TABLE "legislation_documents"
+  ALTER COLUMN "title" SET DATA TYPE text;--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Rebuild the bounded access path outside the migration transaction. Retry
+-- cleanup removes only an INVALID or interrupted copy with this new name.
+-- squawk-ignore transaction-nesting
+COMMIT;--> statement-breakpoint
+SET statement_timeout = 0;--> statement-breakpoint
+SET lock_timeout = 0;--> statement-breakpoint
+-- stella-migration-safety: reviewed destructive-change - retry cleanup targets
+-- only this migration's replacement index.
+DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_country_title_sort_id_idx";--> statement-breakpoint
+-- stella-migration-safety: reviewed destructive-change - retry cleanup targets
+-- only this migration's replacement trigram index.
+DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_title_trgm_idx";--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "legislation_documents_country_title_sort_id_idx"
+  ON "legislation_documents" ("country", left("title", 52), "id");--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "legislation_documents_title_trgm_idx"
+  ON "legislation_documents" USING gin ("title" gin_trgm_ops);--> statement-breakpoint
+
+SET statement_timeout = '5s';--> statement-breakpoint
+SET lock_timeout = '1s';--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/db/schema/legislation-title-cutover.db.test.ts
+++ b/apps/api/src/db/schema/legislation-title-cutover.db.test.ts
@@ -1,0 +1,119 @@
+import { PGlite } from "@electric-sql/pglite";
+import { pg_trgm } from "@electric-sql/pglite/contrib/pg_trgm";
+import { expect, test } from "bun:test";
+
+import {
+  LEGISLATION_TITLE_SORT_KEY_CHARS,
+  legislationDocuments,
+} from "@/api/db/schema";
+
+const MIGRATION = new URL(
+  "../../../drizzle/20260823010000_legislation_title_text_cutover/migration.sql",
+  import.meta.url,
+);
+const STATEMENT_BREAKPOINT = "--> statement-breakpoint";
+const ENUMERATED_AMENDMENTS = Array.from(
+  { length: 1000 },
+  (_, index) => `act-${index.toString(36).padStart(4, "0")}`,
+).join(", ");
+const LONG_LEGISLATION_TITLE = `85/1994 Sb., kterým se mění ${ENUMERATED_AMENDMENTS}`;
+
+const relationFileNode = async (client: PGlite, relation: string) => {
+  const result = await client.query<{ relfilenode: number }>(
+    "SELECT relfilenode FROM pg_class WHERE relname = $1",
+    [relation],
+  );
+  return result.rows.at(0)?.relfilenode;
+};
+
+test("the staged cutover widens titles without rewriting the table or retaining a full-title B-tree", async () => {
+  expect(LONG_LEGISLATION_TITLE.length).toBeGreaterThan(1024);
+  expect(legislationDocuments.title.getSQLType()).toBe("text");
+
+  const client = await PGlite.create({ extensions: { pg_trgm } });
+
+  try {
+    await client.exec("CREATE EXTENSION pg_trgm");
+    await client.exec(
+      'CREATE TABLE "legislation_documents" ("id" uuid PRIMARY KEY, "country" varchar(3) NOT NULL, "title" varchar(1024) NOT NULL)',
+    );
+    await client.exec(
+      'CREATE INDEX "legislation_documents_country_title_id_idx" ON "legislation_documents" ("country", "title", "id")',
+    );
+    await client.exec(
+      'CREATE INDEX "legislation_documents_title_trgm_idx" ON "legislation_documents" USING gin ("title" gin_trgm_ops)',
+    );
+    await client.query(
+      'INSERT INTO "legislation_documents" ("id", "country", "title") VALUES ($1, $2, $3)',
+      ["00000000-0000-4000-8000-000000000000", "CZE", "Short title"],
+    );
+    const tableFileNodeBefore = await relationFileNode(
+      client,
+      "legislation_documents",
+    );
+
+    const migration = await Bun.file(MIGRATION).text();
+    const alterAt = migration.indexOf(
+      'ALTER COLUMN "title" SET DATA TYPE text',
+    );
+    expect(
+      migration.indexOf(
+        'DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_country_title_id_idx"',
+      ),
+    ).toBeLessThan(alterAt);
+    expect(
+      migration.indexOf(
+        'DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_title_trgm_idx"',
+      ),
+    ).toBeLessThan(alterAt);
+    expect(
+      migration.indexOf(
+        'CREATE INDEX CONCURRENTLY "legislation_documents_country_title_sort_id_idx"',
+      ),
+    ).toBeGreaterThan(alterAt);
+    expect(
+      migration.indexOf(
+        'CREATE INDEX CONCURRENTLY "legislation_documents_title_trgm_idx"',
+      ),
+    ).toBeGreaterThan(alterAt);
+    const pgliteMigration = migration
+      .replaceAll(STATEMENT_BREAKPOINT, "")
+      .replaceAll(" CONCURRENTLY", "")
+      .replace(/^COMMIT;$/gmu, "")
+      .replace(/^BEGIN;$/gmu, "");
+    await client.exec(pgliteMigration);
+
+    expect(await relationFileNode(client, "legislation_documents")).toBe(
+      tableFileNodeBefore,
+    );
+    await client.query(
+      'INSERT INTO "legislation_documents" ("id", "country", "title") VALUES ($1, $2, $3)',
+      ["00000000-0000-4000-8000-000000000001", "CZE", LONG_LEGISLATION_TITLE],
+    );
+    const result = await client.query<{ title: string }>(
+      'SELECT "title" FROM "legislation_documents" WHERE "id" = $1',
+      ["00000000-0000-4000-8000-000000000001"],
+    );
+    expect(result.rows.at(0)?.title).toBe(LONG_LEGISLATION_TITLE);
+
+    const indexes = await client.query<{ indexname: string }>(
+      "SELECT indexname FROM pg_indexes WHERE tablename = 'legislation_documents' ORDER BY indexname",
+    );
+    expect(indexes.rows.map(({ indexname }) => indexname)).toEqual([
+      "legislation_documents_country_title_sort_id_idx",
+      "legislation_documents_pkey",
+      "legislation_documents_title_trgm_idx",
+    ]);
+    const replacementIndex = await client.query<{ indexdef: string }>(
+      "SELECT indexdef FROM pg_indexes WHERE indexname = 'legislation_documents_country_title_sort_id_idx'",
+    );
+    expect(replacementIndex.rows.at(0)?.indexdef).toMatch(
+      new RegExp(
+        `"?left"?\\(title, ${String(LEGISLATION_TITLE_SORT_KEY_CHARS)}\\)`,
+        "u",
+      ),
+    );
+  } finally {
+    await client.close();
+  }
+}, 15_000);

--- a/apps/api/src/db/schema/legislation-title-cutover.db.test.ts
+++ b/apps/api/src/db/schema/legislation-title-cutover.db.test.ts
@@ -53,26 +53,29 @@ test("the staged cutover widens titles without rewriting the table or retaining 
     );
 
     const migration = await Bun.file(MIGRATION).text();
-    const alterAt = migration.indexOf(
-      'ALTER COLUMN "title" SET DATA TYPE text',
-    );
+    const offsetOf = (statement: string) => {
+      const offset = migration.indexOf(statement);
+      expect(offset).toBeGreaterThanOrEqual(0);
+      return offset;
+    };
+    const alterAt = offsetOf('ALTER COLUMN "title" SET DATA TYPE text');
     expect(
-      migration.indexOf(
+      offsetOf(
         'DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_country_title_id_idx"',
       ),
     ).toBeLessThan(alterAt);
     expect(
-      migration.indexOf(
+      offsetOf(
         'DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_title_trgm_idx"',
       ),
     ).toBeLessThan(alterAt);
     expect(
-      migration.indexOf(
+      offsetOf(
         'CREATE INDEX CONCURRENTLY "legislation_documents_country_title_sort_id_idx"',
       ),
     ).toBeGreaterThan(alterAt);
     expect(
-      migration.indexOf(
+      offsetOf(
         'CREATE INDEX CONCURRENTLY "legislation_documents_title_trgm_idx"',
       ),
     ).toBeGreaterThan(alterAt);

--- a/apps/api/src/db/schema/legislation.ts
+++ b/apps/api/src/db/schema/legislation.ts
@@ -77,7 +77,9 @@ export const legislationDocuments = p.pgTable(
     // European Legislation Identifier / national statute id — the work key
     // shared across consolidations.
     eli: p.varchar({ length: 512 }).notNull(),
-    title: p.varchar({ length: 1024 }).notNull(),
+    // Official titles can enumerate every amended act and have no bounded
+    // maximum in the publisher's domain.
+    title: p.text().notNull(),
     country: p.varchar({ length: 3 }).notNull(),
     language: p.varchar({ length: 8 }).notNull(),
     documentType: p.varchar("document_type", { length: 128 }),
@@ -137,12 +139,11 @@ export const legislationDocuments = p.pgTable(
       .index("legislation_documents_eli_lang_valid_from_idx")
       .on(t.eli, t.language, t.versionValidFrom),
     p.index("legislation_documents_country_idx").on(t.country),
-    // The compatibility release still emits legacy full-title cursors. The
-    // follow-up cutover replaces this index after every replica understands
-    // the tagged bounded cursor protocol.
+    // Full titles are not B-tree-safe and cannot travel in a bounded cursor.
+    // The canonical expression also owns the handler's tagged ordering.
     p
-      .index("legislation_documents_country_title_id_idx")
-      .on(t.country, t.title, t.id),
+      .index("legislation_documents_country_title_sort_id_idx")
+      .on(t.country, legislationTitleSortKey(t.title), t.id),
     // Its search filter matches anywhere in the title or the identifier, so
     // the access path has to be trigram rather than btree.
     p

--- a/apps/api/src/handlers/legislation/list.ts
+++ b/apps/api/src/handlers/legislation/list.ts
@@ -125,9 +125,9 @@ export const listStatutesHandler = async (
     return status(400, { message: "Invalid cursor" });
   }
   const orderKind =
-    cursor?.type === LEGISLATION_TITLE_CURSOR_KIND
-      ? LEGISLATION_TITLE_CURSOR_KIND
-      : LEGACY_TITLE_CURSOR_KIND;
+    cursor?.type === LEGACY_TITLE_CURSOR_KIND
+      ? LEGACY_TITLE_CURSOR_KIND
+      : LEGISLATION_TITLE_CURSOR_KIND;
   const conditions: SQL[] = [
     redistributableLegislationSource,
     eq(legislationDocuments.country, query.country.toUpperCase()),

--- a/apps/api/src/handlers/legislation/list.ts
+++ b/apps/api/src/handlers/legislation/list.ts
@@ -37,14 +37,7 @@ export const listStatutesQuerySchema = t.Object({
 
 type ListStatutesQuery = Static<typeof listStatutesQuerySchema>;
 
-const LEGACY_TITLE_CURSOR_KIND = "legacy-title";
 export const LEGISLATION_TITLE_CURSOR_KIND = "title-prefix-v1";
-
-type LegacyTitleIdCursor = {
-  type: typeof LEGACY_TITLE_CURSOR_KIND;
-  title: string;
-  id: SafeId<"legislationDocument">;
-};
 
 type TitlePrefixIdCursor = {
   type: typeof LEGISLATION_TITLE_CURSOR_KIND;
@@ -52,24 +45,10 @@ type TitlePrefixIdCursor = {
   id: SafeId<"legislationDocument">;
 };
 
-type LegislationTitleCursor = LegacyTitleIdCursor | TitlePrefixIdCursor;
-
 const titleSortKey = legislationTitleSortKey(legislationDocuments.title);
 
-const decodeTitleCursor = (cursor: string): LegislationTitleCursor | null => {
+const decodeTitleCursor = (cursor: string): TitlePrefixIdCursor | null => {
   const parts = decodePaginationCursor(cursor);
-
-  if (parts?.length === 2) {
-    const [title, id] = parts;
-    if (typeof title !== "string" || !isUuidPaginationCursorPart(id)) {
-      return null;
-    }
-    return {
-      type: LEGACY_TITLE_CURSOR_KIND,
-      title,
-      id: brandPersistedLegislationDocumentId(id),
-    };
-  }
 
   if (parts?.length === 3) {
     const [kind, key, id] = parts;
@@ -124,10 +103,6 @@ export const listStatutesHandler = async (
   if (query.cursor !== undefined && cursor === null) {
     return status(400, { message: "Invalid cursor" });
   }
-  const orderKind =
-    cursor?.type === LEGACY_TITLE_CURSOR_KIND
-      ? LEGACY_TITLE_CURSOR_KIND
-      : LEGISLATION_TITLE_CURSOR_KIND;
   const conditions: SQL[] = [
     redistributableLegislationSource,
     eq(legislationDocuments.country, query.country.toUpperCase()),
@@ -157,22 +132,13 @@ export const listStatutesHandler = async (
   }
 
   if (cursor !== null) {
-    const keyset =
-      cursor.type === LEGISLATION_TITLE_CURSOR_KIND
-        ? or(
-            gt(titleSortKey, cursor.titleSortKey),
-            and(
-              eq(titleSortKey, cursor.titleSortKey),
-              gt(legislationDocuments.id, cursor.id),
-            ),
-          )
-        : or(
-            gt(legislationDocuments.title, cursor.title),
-            and(
-              eq(legislationDocuments.title, cursor.title),
-              gt(legislationDocuments.id, cursor.id),
-            ),
-          );
+    const keyset = or(
+      gt(titleSortKey, cursor.titleSortKey),
+      and(
+        eq(titleSortKey, cursor.titleSortKey),
+        gt(legislationDocuments.id, cursor.id),
+      ),
+    );
 
     if (keyset) {
       conditions.push(keyset);
@@ -203,14 +169,7 @@ export const listStatutesHandler = async (
           eq(legislationSources.id, legislationDocuments.sourceId),
         )
         .where(and(...conditions))
-        .orderBy(
-          asc(
-            orderKind === LEGISLATION_TITLE_CURSOR_KIND
-              ? titleSortKey
-              : legislationDocuments.title,
-          ),
-          asc(legislationDocuments.id),
-        )
+        .orderBy(asc(titleSortKey), asc(legislationDocuments.id))
         .limit(limit + 1),
   );
 
@@ -218,13 +177,11 @@ export const listStatutesHandler = async (
     rows,
     limit,
     cursorForItem: (item) =>
-      orderKind === LEGISLATION_TITLE_CURSOR_KIND
-        ? encodePaginationCursor([
-            LEGISLATION_TITLE_CURSOR_KIND,
-            item.titleSortKey,
-            item.id,
-          ])
-        : encodePaginationCursor([item.title, item.id]),
+      encodePaginationCursor([
+        LEGISLATION_TITLE_CURSOR_KIND,
+        item.titleSortKey,
+        item.id,
+      ]),
   });
 
   return {

--- a/apps/api/src/handlers/legislation/public-reads.db.test.ts
+++ b/apps/api/src/handlers/legislation/public-reads.db.test.ts
@@ -50,7 +50,7 @@ const registerAct = createSafeId<"legislationDocument">();
 const sunsetAct = createSafeId<"legislationDocument">();
 const withheldAct = createSafeId<"legislationDocument">();
 const enumeratedAmendments = Array.from(
-  { length: 20 },
+  { length: 1000 },
   (_, index) => `act-${index.toString(36).padStart(4, "0")}`,
 ).join(", ");
 const longOfficialTitle = `Long legislation title amending ${enumeratedAmendments}`;
@@ -382,8 +382,7 @@ describe("public statute list", () => {
       await listStatutesHandler({ country: "CZE" }, legislationDb),
     );
 
-    expect(longOfficialTitle.length).toBeGreaterThan(64);
-    expect(longOfficialTitle.length).toBeLessThanOrEqual(1024);
+    expect(longOfficialTitle.length).toBeGreaterThan(1024);
     expect(page.items.map((item) => item.title)).toEqual([
       "Civil Code",
       "Civil Code (English)",
@@ -476,7 +475,9 @@ describe("public statute list", () => {
         break;
       }
       expect(cursor.length).toBeLessThanOrEqual(PAGINATION_CURSOR_MAX_CHARS);
-      expect(decodePaginationCursor(cursor)).toHaveLength(2);
+      expect(decodePaginationCursor(cursor)?.at(0)).toBe(
+        LEGISLATION_TITLE_CURSOR_KIND,
+      );
     }
 
     expect(cursor).toBeNull();
@@ -486,6 +487,25 @@ describe("public statute list", () => {
       labourCode,
       longTitleAct,
       registerAct,
+    ]);
+  });
+
+  test("accepts and preserves the compatibility release's legacy cursor", async () => {
+    const legacyCursor = encodePaginationCursor([
+      "Civil Code (English)",
+      civilCodeEnglish,
+    ]);
+    const page = expectPage(
+      await listStatutesHandler(
+        { country: "CZE", cursor: legacyCursor, limit: 1 },
+        legislationDb,
+      ),
+    );
+
+    expect(page.items.map((item) => item.id)).toEqual([labourCode]);
+    expect(decodePaginationCursor(page.nextCursor ?? "")).toEqual([
+      "Labour Code",
+      labourCode,
     ]);
   });
 

--- a/apps/api/src/handlers/legislation/public-reads.db.test.ts
+++ b/apps/api/src/handlers/legislation/public-reads.db.test.ts
@@ -498,23 +498,21 @@ describe("public statute list", () => {
     ]);
   });
 
-  test("accepts and preserves the compatibility release's legacy cursor", async () => {
+  test("rejects the retired full-title cursor protocol", async () => {
     const legacyCursor = encodePaginationCursor([
       "Civil Code (English)",
       civilCodeEnglish,
     ]);
-    const page = expectPage(
-      await listStatutesHandler(
-        { country: "CZE", cursor: legacyCursor, limit: 1 },
-        legislationDb,
-      ),
+    const result = await listStatutesHandler(
+      { country: "CZE", cursor: legacyCursor, limit: 1 },
+      legislationDb,
     );
 
-    expect(page.items.map((item) => item.id)).toEqual([labourCode]);
-    expect(decodePaginationCursor(page.nextCursor ?? "")).toEqual([
-      "Labour Code",
-      labourCode,
-    ]);
+    expect(result).not.toHaveProperty("items");
+    expect(result).toMatchObject({
+      code: 400,
+      response: { message: "Invalid cursor" },
+    });
   });
 
   test("accepts and preserves the next release's bounded cursor protocol", async () => {
@@ -549,7 +547,7 @@ describe("public statute list", () => {
     ]);
   });
 
-  test("rejects a cursor outside both title cursor protocols", async () => {
+  test("rejects a cursor outside the bounded title protocol", async () => {
     const result = await listStatutesHandler(
       { country: "CZE", cursor: "not-a-cursor" },
       legislationDb,

--- a/apps/api/src/handlers/legislation/public-reads.db.test.ts
+++ b/apps/api/src/handlers/legislation/public-reads.db.test.ts
@@ -478,7 +478,12 @@ describe("public statute list", () => {
       const cursorParts = decodePaginationCursor(cursor);
       expect(cursorParts).toHaveLength(3);
       expect(cursorParts?.at(0)).toBe(LEGISLATION_TITLE_CURSOR_KIND);
-      expect(cursorParts?.at(1)?.length).toBeLessThanOrEqual(
+      const sortKey = cursorParts?.at(1);
+      expect(typeof sortKey).toBe("string");
+      if (typeof sortKey !== "string") {
+        throw new TypeError("Expected a title sort key in the tagged cursor");
+      }
+      expect(sortKey.length).toBeLessThanOrEqual(
         LEGISLATION_TITLE_SORT_KEY_CHARS,
       );
     }

--- a/apps/api/src/handlers/legislation/public-reads.db.test.ts
+++ b/apps/api/src/handlers/legislation/public-reads.db.test.ts
@@ -475,8 +475,11 @@ describe("public statute list", () => {
         break;
       }
       expect(cursor.length).toBeLessThanOrEqual(PAGINATION_CURSOR_MAX_CHARS);
-      expect(decodePaginationCursor(cursor)?.at(0)).toBe(
-        LEGISLATION_TITLE_CURSOR_KIND,
+      const cursorParts = decodePaginationCursor(cursor);
+      expect(cursorParts).toHaveLength(3);
+      expect(cursorParts?.at(0)).toBe(LEGISLATION_TITLE_CURSOR_KIND);
+      expect(cursorParts?.at(1)?.length).toBeLessThanOrEqual(
+        LEGISLATION_TITLE_SORT_KEY_CHARS,
       );
     }
 


### PR DESCRIPTION
## Summary

- widen official legislation titles from `varchar(1024)` to `text`
- replace the full-title B-tree with a bounded title-prefix expression index
- make the tagged bounded cursor the only accepted and emitted title cursor
- rebuild title-dependent indexes concurrently around the metadata-only type change

## Rollout boundary

v0.7.20 is fully deployed in production and every API replica accepts the bounded `title-prefix-v1` cursor. This release can therefore switch default emission safely during a rolling deployment. The old two-part full-title cursor is transient pagination state, not a durable or documented integration contract; it now returns 400 so callers restart pagination instead of carrying unbounded compatibility machinery into the `text` schema.

## Verification

- migration safety and ordering tests
- physical PGlite migration test with `pg_trgm`, unchanged table relfilenode, and a title longer than 1024 characters
- public legislation read and pagination tests, including rejection of the retired cursor protocol
- repository CI on the exact head