### PR TITLE
refactor: enforce canonical Valibot contracts

### DIFF
--- a/.changeset/clean-valibot-contracts.md
+++ b/.changeset/clean-valibot-contracts.md
@@ -1,0 +1,6 @@
+---
+"@stll/anonymize-chat": patch
+"@stll/cli": patch
+---
+
+Use canonical Valibot guards and discard unmodeled registry and OAuth response fields.

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -33,13 +33,7 @@ export const DEPLOYED_NODE_ENVS = new Set(["production", "staging"]);
 
 const databasePoolMaxSchema = (fallback = "5") =>
   v.optional(
-    v.pipe(
-      v.string(),
-      v.digits(),
-      v.toNumber(),
-      v.integer(),
-      v.minValue(1),
-    ),
+    v.pipe(v.string(), v.digits(), v.toNumber(), v.integer(), v.minValue(1)),
     fallback,
   );
 

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -36,7 +36,7 @@ const databasePoolMaxSchema = (fallback = "5") =>
     v.pipe(
       v.string(),
       v.digits(),
-      v.transform(Number),
+      v.toNumber(),
       v.integer(),
       v.minValue(1),
     ),
@@ -47,7 +47,7 @@ const documentOcrBatchIntervalMinutesSchema = v.optional(
   v.pipe(
     v.string(),
     v.digits(),
-    v.transform(Number),
+    v.toNumber(),
     v.integer(),
     v.minValue(5),
     v.maxValue(10_080),
@@ -62,7 +62,7 @@ const documentOcrBatchIntervalMinutesSchema = v.optional(
 // after upgrading the runtime. 0 disables a bound.
 const databasePoolSecondsSchema = (fallback: string) =>
   v.optional(
-    v.pipe(v.string(), v.digits(), v.transform(Number), v.integer()),
+    v.pipe(v.string(), v.digits(), v.toNumber(), v.integer()),
     fallback,
   );
 
@@ -87,7 +87,7 @@ const boundedIntegerEnv = ({ fallback, min, max }: BoundedIntegerEnvOptions) =>
     v.pipe(
       v.string(),
       v.digits(),
-      v.transform(Number),
+      v.toNumber(),
       v.integer(),
       v.minValue(min),
       v.maxValue(max),
@@ -100,7 +100,14 @@ const BACKPRESSURE_DIMENSIONS_PATTERN =
 
 const nonNegativeNumberEnv = (fallback: string) =>
   v.optional(
-    v.pipe(v.string(), v.transform(Number), v.finite(), v.minValue(0)),
+    v.pipe(
+      v.string(),
+      v.trim(),
+      v.minLength(1),
+      v.toNumber(),
+      v.finite(),
+      v.minValue(0),
+    ),
     fallback,
   );
 

--- a/apps/api/src/env-document-processing-worker-schema.ts
+++ b/apps/api/src/env-document-processing-worker-schema.ts
@@ -30,7 +30,7 @@ export const envDocumentProcessingWorkerServerSchema = {
    * minutes. Unset keeps the worker long-running.
    */
   DOCUMENT_PROCESSING_IDLE_EXIT_MINUTES: v.optional(
-    v.pipe(v.string(), v.transform(Number), v.integer(), v.minValue(1)),
+    v.pipe(v.string(), v.toNumber(), v.integer(), v.minValue(1)),
   ),
   CONTENT_ENCRYPTION_KEY: v.optional(
     v.pipe(

--- a/apps/api/src/env-schema.ts
+++ b/apps/api/src/env-schema.ts
@@ -145,7 +145,7 @@ export const envApiServerSchema = {
     v.pipe(
       v.string(),
       v.digits(),
-      v.transform(Number),
+      v.toNumber(),
       v.integer(),
       v.minValue(1),
       v.maxValue(65_535),

--- a/apps/api/src/env.test.ts
+++ b/apps/api/src/env.test.ts
@@ -134,6 +134,18 @@ describe("API environment", () => {
     );
   });
 
+  test("rejects blank numeric backpressure settings", () => {
+    const result = bootApiEnvironment({
+      ...baseEnv,
+      CORPUS_INDEX_BACKPRESSURE_LOW_WATERMARK: "   ",
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain(
+      "CORPUS_INDEX_BACKPRESSURE_LOW_WATERMARK",
+    );
+  });
+
   test.each([
     {
       expected:

--- a/apps/api/src/handlers/case-law/analysis/generate.ts
+++ b/apps/api/src/handlers/case-law/analysis/generate.ts
@@ -18,9 +18,6 @@ import type {
 } from "@stll/legal-ast/analysis";
 import {
   analysisHeadingInputSchema,
-  isAnalysisInProgress,
-  isAnalysisGenerating,
-  isDecisionAnalysis,
   parsePersistedDecisionAnalysis,
 } from "@stll/legal-ast/analysis";
 import type { DocumentAst } from "@stll/legal-ast/document-ast";
@@ -249,16 +246,16 @@ export const generateAnalysis = async (
   const analysis = parsePersistedDecisionAnalysis(decision.analysis);
 
   // Return cached analysis (complete or partial with progress)
-  if (isAnalysisInProgress(analysis)) {
+  if (analysis !== null && "status" in analysis && "tree" in analysis) {
     return Result.ok({ status: "generating", analysis });
   }
 
-  if (isDecisionAnalysis(analysis)) {
+  if (analysis !== null && !("status" in analysis)) {
     return Result.ok({ status: "done", analysis });
   }
 
   // Concurrent generation guard for the lightweight sentinel without a tree.
-  if (isAnalysisGenerating(analysis)) {
+  if (analysis !== null) {
     const startedAt = new Date(analysis.startedAt).getTime();
     if (Date.now() - startedAt < SENTINEL_STALE_MS) {
       return Result.ok({ status: "generating" });

--- a/apps/api/src/handlers/chat/tools/edit-workspace-document-tools.ts
+++ b/apps/api/src/handlers/chat/tools/edit-workspace-document-tools.ts
@@ -496,7 +496,7 @@ const editWorkspaceDocumentAuthorNameRequiredSchema = v.strictObject({
   retryable: v.literal(true),
 });
 
-const outputSchema = v.union([
+const outputSchema = v.variant("success", [
   editWorkspaceDocumentSuccessSchema,
   editWorkspaceDocumentAuthorNameRequiredSchema,
 ]);

--- a/apps/api/src/handlers/chat/tools/folder-consistency-review-tool.ts
+++ b/apps/api/src/handlers/chat/tools/folder-consistency-review-tool.ts
@@ -51,7 +51,7 @@ const skippedDocumentSchema = v.strictObject({
   reason: v.string(),
 });
 
-const citationSchema = v.union([
+const citationSchema = v.variant("type", [
   v.strictObject({
     type: v.literal("docx-folio"),
     documentName: v.string(),

--- a/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.test.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/projection-schema.test.ts
@@ -1,8 +1,10 @@
 import { Result } from "better-result";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { expectTypeOf } from "expect-type";
 import * as v from "valibot";
 
-import { toSafeId } from "@/api/lib/branded-types";
+import { type SafeId, toSafeId } from "@/api/lib/branded-types";
+import type { PersistedJsonValue } from "@/api/lib/chat/persisted-message-content";
 import type {
   ChatProjectionSchema,
   DehydratedInput,
@@ -28,15 +30,18 @@ const {
   chatEntityRef,
   chatRef,
   containsRawUuid,
+  deriveRefMediationEntry,
   passthroughId,
   PROJECTION_SCHEMA_FAILURE_MESSAGE,
+  projectionBranch,
   projectForChat,
   REF_PROJECTION_FAILURE_MESSAGE,
   renderProjectionShape,
   strippedField,
   unenumeratedJson,
 } = await import("@/api/lib/chat/projection-schema");
-const { READ_TOOL_REF_FIELD_MAP } = await import("./ref-field-map");
+const { READ_TOOL_REF_FIELD_MAP, WRITE_TOOL_REF_FIELD_MAP } =
+  await import("./ref-field-map");
 
 const LIST_MATTERS_PROJECTION = READ_TOOL_REF_FIELD_MAP.list_matters.projection;
 const READ_DOCUMENT_PROJECTION =
@@ -153,6 +158,30 @@ describe("projectForChat", () => {
       propertyId: propertyRef,
     });
     expect(containsRawUuid(projected)).toBe(false);
+  });
+
+  test("ref fields reject identifiers that cannot carry the SafeId brand", () => {
+    const schema: ChatProjectionSchema = v.strictObject({
+      entityId: chatEntityRef({ from: "sibling", key: "workspaceId" }),
+      matterId: chatRef("matter"),
+      workspaceId: chatRef("matter"),
+    });
+
+    for (const invalidId of ["", "\uD800"]) {
+      const result = project({
+        payload: {
+          entityId: invalidId,
+          matterId: invalidId,
+          workspaceId: invalidId,
+        },
+        schema,
+      });
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.message).toBe(PROJECTION_SCHEMA_FAILURE_MESSAGE);
+      }
+    }
   });
 
   test("strippedField leaves are omitted, UUIDs inside them and all", () => {
@@ -502,6 +531,88 @@ describe("projectForChat", () => {
     });
     expect(containsRawUuid(projected)).toBe(false);
   });
+
+  test("a union branch is not parsed again during projection", () => {
+    let validationRuns = 0;
+    const schema: ChatProjectionSchema = v.union([
+      projectionBranch(
+        v.strictObject({
+          type: v.literal("checked"),
+          value: v.pipe(
+            v.string(),
+            v.check((value) => {
+              validationRuns += 1;
+              return value.length > 0;
+            }),
+          ),
+        }),
+      ),
+      projectionBranch(
+        v.strictObject({
+          type: v.literal("other"),
+          value: v.string(),
+        }),
+      ),
+    ]);
+
+    const projected = project({
+      payload: { type: "checked", value: "once" },
+      schema,
+    }).unwrap();
+
+    expect(projected).toEqual({ type: "checked", value: "once" });
+    expect(validationRuns).toBe(1);
+  });
+
+  test("every registered union branch records its parse proof", () => {
+    for (const fieldMap of [
+      READ_TOOL_REF_FIELD_MAP,
+      WRITE_TOOL_REF_FIELD_MAP,
+    ]) {
+      for (const entry of Object.values(fieldMap)) {
+        if (entry.chatProjectable) {
+          expect(() => deriveRefMediationEntry(entry.projection)).not.toThrow();
+        }
+      }
+    }
+  });
+
+  test("an unwrapped union branch fails before projection", () => {
+    const schema: ChatProjectionSchema = v.union([
+      v.strictObject({ type: v.literal("unwrapped") }),
+    ]);
+
+    expect(() => deriveRefMediationEntry(schema)).toThrow(
+      "chat projection union option is not wrapped in projectionBranch",
+    );
+  });
+
+  test("a bare unknown leaf cannot bypass the JSON or strip contracts", () => {
+    const schema: ChatProjectionSchema = v.strictObject({
+      payload: v.unknown(),
+    });
+
+    expect(() => deriveRefMediationEntry(schema)).toThrow(
+      "unknown chat projection fields must use strippedField or unenumeratedJson",
+    );
+  });
+
+  test("unenumerated subtrees reject values that cannot cross a JSON boundary", () => {
+    const schema: ChatProjectionSchema = v.strictObject({
+      metadata: unenumeratedJson(),
+    });
+    const cyclic: Record<string, unknown> = {};
+    cyclic["self"] = cyclic;
+
+    for (const metadata of [1n, () => undefined, cyclic]) {
+      const result = project({ payload: { metadata }, schema });
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.message).toBe(PROJECTION_SCHEMA_FAILURE_MESSAGE);
+      }
+    }
+  });
 });
 
 describe("renderProjectionShape", () => {
@@ -541,6 +652,28 @@ describe("renderProjectionShape", () => {
  * materializes is itself a typecheck failure, which is the assertion.
  */
 describe("compile-time payload ties", () => {
+  test("annotated fields retain their precise input types", () => {
+    const schema = projectionBranch(
+      v.strictObject({
+        entityId: chatEntityRef({ from: "inputParam", param: "matter_id" }),
+        matterId: chatRef("matter"),
+        passthrough: passthroughId(),
+        stripped: strippedField(),
+        unenumerated: unenumeratedJson(),
+      }),
+    );
+    type Input = v.InferInput<typeof schema>;
+
+    expectTypeOf<Input["entityId"]>().toEqualTypeOf<SafeId<"entity">>();
+    expectTypeOf<Input["matterId"]>().toEqualTypeOf<SafeId<"workspace">>();
+    expectTypeOf<Input["passthrough"]>().toEqualTypeOf<string>();
+    expectTypeOf<Input["stripped"]>().toEqualTypeOf<unknown>();
+    expectTypeOf<Input["unenumerated"]>().toEqualTypeOf<unknown>();
+    expectTypeOf<
+      v.InferOutput<typeof schema>["unenumerated"]
+    >().toEqualTypeOf<PersistedJsonValue>();
+  });
+
   test("an unclassified field fails against the projection input", () => {
     const withExtraField = {
       matters: [],

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
@@ -1,3 +1,5 @@
+import type { GenericSchema, InferInput } from "valibot";
+
 import type {
   ChatProjectionSchema,
   RegistryRefKind,
@@ -104,6 +106,17 @@ export type ChatProjectableToolName<TMap> = {
     ? TName
     : never;
 }[keyof TMap];
+
+export type ProjectionDataByName<
+  TMap,
+  TNames extends keyof TMap,
+> = {
+  [TName in TNames]: TMap[TName] extends {
+    projection: infer TProjection extends GenericSchema;
+  }
+    ? InferInput<TProjection>
+    : never;
+};
 
 // --- Chat projection schemas -------------------------------------------------
 // One artifact per projected tool: the exact shape the chat surface forwards,

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
@@ -99,6 +99,12 @@ export type RegistryRefFieldMapEntry =
   | { chatProjectable: false }
   | ({ chatProjectable: true } & RefMediationEntry);
 
+export type ChatProjectableToolName<TMap> = {
+  [TName in keyof TMap]: TMap[TName] extends { chatProjectable: true }
+    ? TName
+    : never;
+}[keyof TMap];
+
 // --- Chat projection schemas -------------------------------------------------
 // One artifact per projected tool: the exact shape the chat surface forwards,
 // with per-field chat semantics attached (`chatRef`/`chatEntityRef`/

--- a/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/ref-field-map.ts
@@ -107,10 +107,7 @@ export type ChatProjectableToolName<TMap> = {
     : never;
 }[keyof TMap];
 
-export type ProjectionDataByName<
-  TMap,
-  TNames extends keyof TMap,
-> = {
+export type ProjectionDataByName<TMap, TNames extends keyof TMap> = {
   [TName in TNames]: TMap[TName] extends {
     projection: infer TProjection extends GenericSchema;
   }

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
@@ -16,9 +16,17 @@ import { RESEARCH_ADMIN_TOOL_HANDLERS } from "@/api/mcp/research-admin-tools";
 import { getStaticMcpToolDefinition } from "@/api/mcp/static-tool-definitions";
 import { STELLA_TOOL_HANDLERS } from "@/api/mcp/stella-tools";
 import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
-import type { McpToolHandler } from "@/api/mcp/tool-types";
+import type {
+  AllHandlerOutputsTyped,
+  AssertTrue,
+  McpToolHandler,
+  TypedHandlerDataByName,
+} from "@/api/mcp/tool-types";
 
-import type { RegistryReadToolName } from "./ref-field-map";
+import type {
+  ChatProjectableToolName,
+  RegistryReadToolName,
+} from "./ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 import { dehydrateInputRefs } from "./ref-mediation";
 import { toRegistryChatToolError } from "./registry-tool-error";
@@ -61,6 +69,27 @@ const REGISTRY_READ_TOOL_HANDLERS = {
   describe_capability: CAPABILITY_TOOL_HANDLERS.describe_capability,
 } satisfies Record<RegistryReadToolName, McpToolHandler>;
 
+type ProjectableRegistryReadToolName = ChatProjectableToolName<
+  typeof READ_TOOL_REF_FIELD_MAP
+>;
+
+const isProjectableRegistryReadToolName = (
+  toolName: RegistryReadToolName,
+): toolName is ProjectableRegistryReadToolName =>
+  READ_TOOL_REF_FIELD_MAP[toolName].chatProjectable;
+
+export type RegistryReadToolDataByName = TypedHandlerDataByName<
+  typeof REGISTRY_READ_TOOL_HANDLERS,
+  ProjectableRegistryReadToolName
+>;
+
+/** Compile-time guard: every chat-projected handler declares typed output. */
+export type RegistryReadToolOutputContract = AssertTrue<
+  AllHandlerOutputsTyped<
+    typeof REGISTRY_READ_TOOL_HANDLERS,
+    ProjectableRegistryReadToolName
+  >
+>;
 export type RunRegistryReadToolProps = {
   toolName: RegistryReadToolName;
   args: Record<string, unknown>;
@@ -87,8 +116,7 @@ export const runRegistryReadTool = async ({
   context,
   refRegistry,
 }: RunRegistryReadToolProps): Promise<Result<unknown, ChatToolError>> => {
-  const entry = READ_TOOL_REF_FIELD_MAP[toolName];
-  if (!entry.chatProjectable) {
+  if (!isProjectableRegistryReadToolName(toolName)) {
     return Result.err(
       new ChatToolError({
         kind: "unavailable",
@@ -96,6 +124,7 @@ export const runRegistryReadTool = async ({
       }),
     );
   }
+  const entry = READ_TOOL_REF_FIELD_MAP[toolName];
 
   const staticDefinition =
     getStaticMcpToolDefinition(toolName) ??

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-tool.ts
@@ -19,12 +19,14 @@ import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
 import type {
   AllHandlerOutputsTyped,
   AssertTrue,
+  HandlerOutputsMatchByName,
   McpToolHandler,
   TypedHandlerDataByName,
 } from "@/api/mcp/tool-types";
 
 import type {
   ChatProjectableToolName,
+  ProjectionDataByName,
   RegistryReadToolName,
 } from "./ref-field-map";
 import { READ_TOOL_REF_FIELD_MAP } from "./ref-field-map";
@@ -83,12 +85,23 @@ export type RegistryReadToolDataByName = TypedHandlerDataByName<
   ProjectableRegistryReadToolName
 >;
 
+type RegistryReadProjectionDataByName = ProjectionDataByName<
+  typeof READ_TOOL_REF_FIELD_MAP,
+  ProjectableRegistryReadToolName
+>;
+
 /** Compile-time guard: every chat-projected handler declares typed output. */
 export type RegistryReadToolOutputContract = AssertTrue<
   AllHandlerOutputsTyped<
     typeof REGISTRY_READ_TOOL_HANDLERS,
     ProjectableRegistryReadToolName
-  >
+  > extends true
+    ? HandlerOutputsMatchByName<
+        typeof REGISTRY_READ_TOOL_HANDLERS,
+        RegistryReadProjectionDataByName,
+        ProjectableRegistryReadToolName
+      >
+    : false
 >;
 export type RunRegistryReadToolProps = {
   toolName: RegistryReadToolName;

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
@@ -16,9 +16,17 @@ import { RESEARCH_ADMIN_TOOL_HANDLERS } from "@/api/mcp/research-admin-tools";
 import { getStaticMcpToolDefinition } from "@/api/mcp/static-tool-definitions";
 import { STELLA_TOOL_HANDLERS } from "@/api/mcp/stella-tools";
 import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
-import type { McpToolHandler } from "@/api/mcp/tool-types";
+import type {
+  AllHandlerOutputsTyped,
+  AssertTrue,
+  McpToolHandler,
+  TypedHandlerDataByName,
+} from "@/api/mcp/tool-types";
 
-import type { RegistryWriteToolName } from "./ref-field-map";
+import type {
+  ChatProjectableToolName,
+  RegistryWriteToolName,
+} from "./ref-field-map";
 import { WRITE_TOOL_REF_FIELD_MAP } from "./ref-field-map";
 import { dehydrateRefs } from "./ref-mediation";
 import { toRegistryChatToolError } from "./registry-tool-error";
@@ -64,6 +72,28 @@ const REGISTRY_WRITE_TOOL_HANDLERS = {
   // refuses it before dispatch. Wired only to keep this map exhaustive.
   invoke_capability: CAPABILITY_TOOL_HANDLERS.invoke_capability,
 } satisfies Record<RegistryWriteToolName, McpToolHandler>;
+
+type ProjectableRegistryWriteToolName = ChatProjectableToolName<
+  typeof WRITE_TOOL_REF_FIELD_MAP
+>;
+
+const isProjectableRegistryWriteToolName = (
+  toolName: RegistryWriteToolName,
+): toolName is ProjectableRegistryWriteToolName =>
+  WRITE_TOOL_REF_FIELD_MAP[toolName].chatProjectable;
+
+export type RegistryWriteToolDataByName = TypedHandlerDataByName<
+  typeof REGISTRY_WRITE_TOOL_HANDLERS,
+  ProjectableRegistryWriteToolName
+>;
+
+/** Compile-time guard: every chat-projected handler declares typed output. */
+export type RegistryWriteToolOutputContract = AssertTrue<
+  AllHandlerOutputsTyped<
+    typeof REGISTRY_WRITE_TOOL_HANDLERS,
+    ProjectableRegistryWriteToolName
+  >
+>;
 
 export type RunRegistryWriteToolProps = {
   toolName: RegistryWriteToolName;
@@ -115,8 +145,7 @@ export const runRegistryWriteTool = async ({
   context,
   refRegistry,
 }: RunRegistryWriteToolProps): Promise<Result<unknown, ChatToolError>> => {
-  const entry = WRITE_TOOL_REF_FIELD_MAP[toolName];
-  if (!entry.chatProjectable) {
+  if (!isProjectableRegistryWriteToolName(toolName)) {
     return Result.err(
       new ChatToolError({
         kind: "unavailable",
@@ -124,6 +153,7 @@ export const runRegistryWriteTool = async ({
       }),
     );
   }
+  const entry = WRITE_TOOL_REF_FIELD_MAP[toolName];
 
   const staticDefinition =
     getStaticMcpToolDefinition(toolName) ??

--- a/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/run-registry-write-tool.ts
@@ -19,12 +19,14 @@ import { TEMPLATE_TOOL_HANDLERS } from "@/api/mcp/template-tools";
 import type {
   AllHandlerOutputsTyped,
   AssertTrue,
+  HandlerOutputsMatchByName,
   McpToolHandler,
   TypedHandlerDataByName,
 } from "@/api/mcp/tool-types";
 
 import type {
   ChatProjectableToolName,
+  ProjectionDataByName,
   RegistryWriteToolName,
 } from "./ref-field-map";
 import { WRITE_TOOL_REF_FIELD_MAP } from "./ref-field-map";
@@ -87,12 +89,23 @@ export type RegistryWriteToolDataByName = TypedHandlerDataByName<
   ProjectableRegistryWriteToolName
 >;
 
+type RegistryWriteProjectionDataByName = ProjectionDataByName<
+  typeof WRITE_TOOL_REF_FIELD_MAP,
+  ProjectableRegistryWriteToolName
+>;
+
 /** Compile-time guard: every chat-projected handler declares typed output. */
 export type RegistryWriteToolOutputContract = AssertTrue<
   AllHandlerOutputsTyped<
     typeof REGISTRY_WRITE_TOOL_HANDLERS,
     ProjectableRegistryWriteToolName
-  >
+  > extends true
+    ? HandlerOutputsMatchByName<
+        typeof REGISTRY_WRITE_TOOL_HANDLERS,
+        RegistryWriteProjectionDataByName,
+        ProjectableRegistryWriteToolName
+      >
+    : false
 >;
 
 export type RunRegistryWriteToolProps = {

--- a/apps/api/src/handlers/contacts/contact-import-file.ts
+++ b/apps/api/src/handlers/contacts/contact-import-file.ts
@@ -751,7 +751,7 @@ export const validateContactImportCandidate = ({
 
   if (
     candidate.emails?.some(
-      ({ address }) => !v.safeParse(emailSchema, address).success,
+      ({ address }) => !v.is(emailSchema, address),
     )
   ) {
     report(CONTACT_IMPORT_ISSUE_CODE.INVALID_EMAIL, "primary_email");

--- a/apps/api/src/handlers/contacts/contact-import-file.ts
+++ b/apps/api/src/handlers/contacts/contact-import-file.ts
@@ -749,11 +749,7 @@ export const validateContactImportCandidate = ({
     report(CONTACT_IMPORT_ISSUE_CODE.DISPLAY_NAME_REQUIRED, "display_name");
   }
 
-  if (
-    candidate.emails?.some(
-      ({ address }) => !v.is(emailSchema, address),
-    )
-  ) {
+  if (candidate.emails?.some(({ address }) => !v.is(emailSchema, address))) {
     report(CONTACT_IMPORT_ISSUE_CODE.INVALID_EMAIL, "primary_email");
   }
   if (

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -1,7 +1,15 @@
+import * as v from "valibot";
+
 import {
+  isSafeIdValue,
   type SafeId as PortableSafeId,
-  toSafeId as toPortableSafeId,
-} from "@stll/api-contract/safe-id";
+} from "@stll/api-contract";
+
+const safeIdSchema = v.pipe(
+  v.string(),
+  v.check(isSafeIdValue, "Expected a non-empty identifier"),
+  v.brand("SafeId"),
+);
 
 export type SafeIdType =
   | "accountDeletionRequest"
@@ -135,7 +143,7 @@ export type SafeIdType =
 export type SafeId<T extends SafeIdType> = PortableSafeId<T>;
 
 export const toSafeId = <T extends SafeIdType>(value: string): SafeId<T> =>
-  toPortableSafeId<T>(value);
+  v.parse(safeIdSchema, value);
 
 export const createSafeId = <T extends SafeIdType>(): SafeId<T> =>
   toSafeId<T>(Bun.randomUUIDv7());

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -1,15 +1,7 @@
-import * as v from "valibot";
-
 import {
-  isSafeIdValue,
   type SafeId as PortableSafeId,
-} from "@stll/api-contract";
-
-const safeIdSchema = v.pipe(
-  v.string(),
-  v.check(isSafeIdValue, "Expected a non-empty identifier"),
-  v.brand("SafeId"),
-);
+  toSafeId as toPortableSafeId,
+} from "@stll/api-contract/safe-id";
 
 export type SafeIdType =
   | "accountDeletionRequest"
@@ -143,7 +135,7 @@ export type SafeIdType =
 export type SafeId<T extends SafeIdType> = PortableSafeId<T>;
 
 export const toSafeId = <T extends SafeIdType>(value: string): SafeId<T> =>
-  v.parse(safeIdSchema, value);
+  toPortableSafeId<T>(value);
 
 export const createSafeId = <T extends SafeIdType>(): SafeId<T> =>
   toSafeId<T>(Bun.randomUUIDv7());

--- a/apps/api/src/lib/chat/persisted-message-content.ts
+++ b/apps/api/src/lib/chat/persisted-message-content.ts
@@ -135,8 +135,7 @@ const isPersistedJsonValueAt = (
 
 export const isPersistedJsonValue = (
   value: unknown,
-): value is PersistedJsonValue =>
-  isPersistedJsonValueAt(value, new WeakSet());
+): value is PersistedJsonValue => isPersistedJsonValueAt(value, new WeakSet());
 
 export const provePersistedJsonValue = (value: unknown): PersistedJsonValue => {
   if (!isPersistedJsonValue(value)) {

--- a/apps/api/src/lib/chat/persisted-message-content.ts
+++ b/apps/api/src/lib/chat/persisted-message-content.ts
@@ -92,8 +92,9 @@ export type PersistedChatMessageContentV3<TPart, TMetadata> =
   PersistedChatMessageContentV3Candidate<TPart, TMetadata> &
     PersistedChatMessageContentV3Proof;
 
-export const isPersistedJsonValue = (
+const isPersistedJsonValueAt = (
   value: unknown,
+  ancestors: WeakSet<object>,
 ): value is PersistedJsonValue => {
   if (
     value === null ||
@@ -104,7 +105,15 @@ export const isPersistedJsonValue = (
     return true;
   }
   if (Array.isArray(value)) {
-    return value.every(isPersistedJsonValue);
+    if (ancestors.has(value)) {
+      return false;
+    }
+    ancestors.add(value);
+    const valid = value.every((item) =>
+      isPersistedJsonValueAt(item, ancestors),
+    );
+    ancestors.delete(value);
+    return valid;
   }
   if (
     typeof value !== "object" ||
@@ -113,8 +122,21 @@ export const isPersistedJsonValue = (
   ) {
     return false;
   }
-  return Object.values(value).every(isPersistedJsonValue);
+  if (ancestors.has(value)) {
+    return false;
+  }
+  ancestors.add(value);
+  const valid = Object.values(value).every((item) =>
+    isPersistedJsonValueAt(item, ancestors),
+  );
+  ancestors.delete(value);
+  return valid;
 };
+
+export const isPersistedJsonValue = (
+  value: unknown,
+): value is PersistedJsonValue =>
+  isPersistedJsonValueAt(value, new WeakSet());
 
 export const provePersistedJsonValue = (value: unknown): PersistedJsonValue => {
   if (!isPersistedJsonValue(value)) {

--- a/apps/api/src/lib/chat/projection-schema.ts
+++ b/apps/api/src/lib/chat/projection-schema.ts
@@ -415,7 +415,9 @@ const walkContainerSchema = (
         panic("union option is not a valibot schema");
       }
       if (!projectionBranchSources.has(option)) {
-        panic("chat projection union option is not wrapped in projectionBranch");
+        panic(
+          "chat projection union option is not wrapped in projectionBranch",
+        );
       }
       walkContainerSchema(option, segments, visit);
     }

--- a/apps/api/src/lib/chat/projection-schema.ts
+++ b/apps/api/src/lib/chat/projection-schema.ts
@@ -7,7 +7,6 @@ import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
   isPersistedJsonValue,
-  type PersistedJsonValue,
 } from "@/api/lib/chat/persisted-message-content";
 import type { ChatRefKind, ChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";

--- a/apps/api/src/lib/chat/projection-schema.ts
+++ b/apps/api/src/lib/chat/projection-schema.ts
@@ -1004,9 +1004,9 @@ type ProjectionTelemetrySource =
   | "run-registry-tool"
   | "run-registry-write-tool";
 
-export type ProjectForChatOptions = {
+export type ProjectForChatOptions<TPayload> = {
   schema: ChatProjectionSchema;
-  payload: unknown;
+  payload: TPayload;
   refRegistry: ChatRefRegistry;
   dehydration: DehydratedInput;
   /** Telemetry context only; never part of the transform. */
@@ -1033,14 +1033,14 @@ export type ProjectForChatOptions = {
  *    survivor fails closed as a `server-defect`, its path (never its value)
  *    to telemetry.
  */
-export const projectForChat = ({
+export const projectForChat = <TPayload>({
   schema,
   payload,
   refRegistry,
   dehydration,
   source,
   toolName,
-}: ProjectForChatOptions): Result<unknown, ChatToolError> => {
+}: ProjectForChatOptions<TPayload>): Result<unknown, ChatToolError> => {
   const parsed = strictParseProjection({ payload, schema });
   if (Result.isError(parsed)) {
     const error = new ChatToolError({

--- a/apps/api/src/lib/chat/projection-schema.ts
+++ b/apps/api/src/lib/chat/projection-schema.ts
@@ -5,9 +5,7 @@ import { isSafeIdValue } from "@stll/api-contract/safe-id";
 
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
-import {
-  isPersistedJsonValue,
-} from "@/api/lib/chat/persisted-message-content";
+import { isPersistedJsonValue } from "@/api/lib/chat/persisted-message-content";
 import type { ChatRefKind, ChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
 import {

--- a/apps/api/src/lib/chat/projection-schema.ts
+++ b/apps/api/src/lib/chat/projection-schema.ts
@@ -1,8 +1,14 @@
 import { panic, Result } from "better-result";
 import * as v from "valibot";
 
+import { isSafeIdValue } from "@stll/api-contract/safe-id";
+
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
+import {
+  isPersistedJsonValue,
+  type PersistedJsonValue,
+} from "@/api/lib/chat/persisted-message-content";
 import type { ChatRefKind, ChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
 import {
@@ -132,6 +138,7 @@ const annotationSchema = v.variant("role", [
   }),
   v.strictObject({ role: v.literal("passthroughId") }),
   v.strictObject({ role: v.literal("strip") }),
+  v.strictObject({ role: v.literal("json") }),
 ]);
 
 type ChatProjectionAnnotation = v.InferOutput<typeof annotationSchema>;
@@ -139,23 +146,59 @@ type ChatProjectionAnnotation = v.InferOutput<typeof annotationSchema>;
 const CHAT_PROJECTION_METADATA_KEY = "chatProjection";
 
 /**
- * The widened schema type every projection value and annotated field carries.
- * Deliberately not the inferred builder type: the payload arrives as `unknown`
- * from `JSON.parse`, so nothing consumes the precise input/output types, and
- * widening at the wrapper boundary keeps valibot's generic instantiation cost
- * out of the map (per the type-cost guard).
+ * The widened schema type used by the runtime projection registry. Individual
+ * annotated field builders retain their inferred input/output types so the
+ * same schemas can provide precise handler contracts at compile time; only the
+ * heterogeneous registry boundary widens them for AST walking.
  */
 export type ChatProjectionSchema = v.GenericSchema<
   Record<string, unknown>,
   Record<string, unknown>
 >;
 
-type AnnotatedFieldSchema = v.GenericSchema;
+const selectedProjectionBranches = new WeakMap<
+  Record<string, unknown>,
+  ChatProjectionSchema
+>();
+
+const projectionBranchSources = new WeakMap<
+  v.GenericSchema,
+  ChatProjectionSchema
+>();
+
+/**
+ * Mark one union/variant option as a projection branch. Its Valibot transform
+ * records which schema produced the canonical output object during the one
+ * strict parse; the annotation walk can then follow that branch without
+ * validating it again.
+ */
+export const projectionBranch = <TSchema extends ChatProjectionSchema>(
+  schema: TSchema,
+) => {
+  const branch = v.pipe(
+    schema,
+    v.transform((output) => {
+      selectedProjectionBranches.set(output, schema);
+      return output;
+    }),
+  );
+  projectionBranchSources.set(branch, schema);
+  return branch;
+};
+
+type SimpleRefId<TKind extends SimpleRefKind> = {
+  contact: SafeId<"contact">;
+  matter: SafeId<"workspace">;
+  property: SafeId<"property">;
+}[TKind];
 
 /** A tenant id field hydrated into a `mat_N`/`contact_N`/`prop_N` chat ref. */
-export const chatRef = (kind: SimpleRefKind): AnnotatedFieldSchema =>
+export const chatRef = <TKind extends SimpleRefKind>(kind: TKind) =>
   v.pipe(
-    v.string(),
+    v.custom<SimpleRefId<TKind>>(
+      (value) => typeof value === "string" && isSafeIdValue(value),
+      `Expected a ${kind} identifier`,
+    ),
     v.metadata({ [CHAT_PROJECTION_METADATA_KEY]: { role: "ref", kind } }),
   );
 
@@ -163,11 +206,12 @@ export const chatRef = (kind: SimpleRefKind): AnnotatedFieldSchema =>
  * A tenant entity id field hydrated into an `ent_N` chat ref, declaring where
  * its owning workspace id is recovered from.
  */
-export const chatEntityRef = (
-  workspace: EntityWorkspaceSource,
-): AnnotatedFieldSchema =>
+export const chatEntityRef = (workspace: EntityWorkspaceSource) =>
   v.pipe(
-    v.string(),
+    v.custom<SafeId<"entity">>(
+      (value) => typeof value === "string" && isSafeIdValue(value),
+      "Expected an entity identifier",
+    ),
     v.metadata({
       [CHAT_PROJECTION_METADATA_KEY]: { role: "entityRef", workspace },
     }),
@@ -177,7 +221,7 @@ export const chatEntityRef = (
  * A non-tenant handle (user/version/link/library id, opaque cursor) the model
  * may pass back verbatim; licensed to survive the runtime UUID backstop.
  */
-export const passthroughId = (): AnnotatedFieldSchema =>
+export const passthroughId = () =>
   v.pipe(
     v.string(),
     v.metadata({ [CHAT_PROJECTION_METADATA_KEY]: { role: "passthroughId" } }),
@@ -189,7 +233,7 @@ export const passthroughId = (): AnnotatedFieldSchema =>
  * base: the strict parse admits it at its declared key, then the derived
  * `stripPaths` remove it.
  */
-export const strippedField = (): AnnotatedFieldSchema =>
+export const strippedField = () =>
   v.pipe(
     v.unknown(),
     v.metadata({ [CHAT_PROJECTION_METADATA_KEY]: { role: "strip" } }),
@@ -199,15 +243,26 @@ export const strippedField = (): AnnotatedFieldSchema =>
  * A free-form JSON subtree the schema cannot enumerate by path: public-source
  * jsonb (`decision.metadata`), an external API envelope (BOE sections,
  * registry `details`), or a structural config with no stable leaf grammar
- * (playbook ask content, condition ASTs). Deliberately NOT an annotation:
- * the strict parse admits any value at the declared key, the walker records
- * nothing beneath it (an unannotated `unknown` leaf contributes no mediation
- * paths), and therefore the runtime UUID backstop still applies, unlicensed,
- * to every string inside — a UUID-shaped value in the subtree fails closed
- * exactly as it did under the hand-written entries, which never enumerated
- * these subtrees either.
+ * (playbook ask content, condition ASTs). Its annotation tells the walker to
+ * record no mediation paths but to scan every nested string for unlicensed
+ * UUIDs. A UUID-shaped value therefore fails closed exactly as it did under
+ * the hand-written entries, which never enumerated these subtrees either. The
+ * schema also proves that the subtree is canonical JSON, so direct typed
+ * execution cannot smuggle cycles, bigint, functions, symbols, or non-finite
+ * numbers past the former MCP serialization boundary.
  */
-export const unenumeratedJson = (): AnnotatedFieldSchema => v.unknown();
+export const unenumeratedJson = () =>
+  v.pipe(
+    v.unknown(),
+    v.rawTransform(({ addIssue, dataset, NEVER }) => {
+      if (!isPersistedJsonValue(dataset.value)) {
+        addIssue({ message: "Expected a canonical JSON value" });
+        return NEVER;
+      }
+      return dataset.value;
+    }),
+    v.metadata({ [CHAT_PROJECTION_METADATA_KEY]: { role: "json" } }),
+  );
 
 // --- Schema AST walking ---------------------------------------------------------
 // Valibot schemas are plain objects: `v.pipe` spreads its base schema and adds
@@ -218,6 +273,11 @@ export const unenumeratedJson = (): AnnotatedFieldSchema => v.unknown();
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isSchemaNode = (value: unknown): value is v.GenericSchema =>
+  isRecord(value) &&
+  value["kind"] === "schema" &&
+  typeof value["type"] === "string";
 
 // Memoized per schema node: `projectForChat` reads annotations on every
 // request's walk, and a node's annotation never changes after construction.
@@ -354,6 +414,12 @@ const walkContainerSchema = (
       panic("union schema node has no options array");
     }
     for (const option of options) {
+      if (!isSchemaNode(option)) {
+        panic("union option is not a valibot schema");
+      }
+      if (!projectionBranchSources.has(option)) {
+        panic("chat projection union option is not wrapped in projectionBranch");
+      }
       walkContainerSchema(option, segments, visit);
     }
     return;
@@ -371,7 +437,12 @@ const walkContainerSchema = (
   if (nodeType === "array") {
     panic("the ref path grammar cannot address nested arrays");
   }
-  // A scalar leaf (string/number/boolean/literal/picklist/unknown/null):
+  if (nodeType === "unknown") {
+    panic(
+      "unknown chat projection fields must use strippedField or unenumeratedJson",
+    );
+  }
+  // A scalar leaf (string/number/boolean/literal/picklist/null):
   // ordinary data, nothing to record.
 };
 
@@ -417,6 +488,9 @@ const buildMediationLists = (
       }
       case "strip": {
         stripPaths.add(path);
+        return;
+      }
+      case "json": {
         return;
       }
       default: {
@@ -624,11 +698,6 @@ type ProjectWalkContext = {
   uuidViolations: string[];
 };
 
-const isSchemaNode = (value: unknown): value is v.GenericSchema =>
-  isRecord(value) &&
-  value["kind"] === "schema" &&
-  typeof value["type"] === "string";
-
 /**
  * Record a violation if a string leaf carries a UUID anywhere in it. A
  * substring match (not just a bare-UUID exact match) so a UUID embedded
@@ -795,9 +864,13 @@ const projectRefLeaf = ({
   }
 };
 
-/** Pick the union/variant option that admits `value` (the outer parse already
- * proved one does), mirroring valibot's own first-match option order. */
-const matchUnionOption = (
+/**
+ * Recover the branch proof recorded while Valibot produced this canonical
+ * object. Every union/variant option must use `projectionBranch`; accepting an
+ * unmarked branch would make its annotation policy unknowable without a
+ * second parse, so it is an impossible projection-schema state.
+ */
+const selectUnionOption = (
   unionNode: Record<string, unknown>,
   value: unknown,
 ): v.GenericSchema => {
@@ -805,15 +878,26 @@ const matchUnionOption = (
   if (!Array.isArray(options)) {
     panic("union schema node has no options array");
   }
+  if (!isRecord(value)) {
+    return panic("chat projection unions must contain object branches");
+  }
+  const selected = selectedProjectionBranches.get(value);
+  if (selected === undefined) {
+    return panic("parsed projection union value has no branch proof");
+  }
   for (const option of options) {
     if (!isSchemaNode(option)) {
       panic("union option is not a valibot schema");
     }
-    if (v.safeParse(option, value).success) {
-      return option;
+    const source = projectionBranchSources.get(option);
+    if (source === undefined) {
+      panic("chat projection union option is not wrapped in projectionBranch");
+    }
+    if (source === selected) {
+      return source;
     }
   }
-  return panic("no union option matches a value the union already parsed");
+  return panic("projection branch proof does not belong to its union");
 };
 
 type ProjectFieldArgs = {
@@ -869,6 +953,11 @@ const projectField = ({
         // Licensed to survive verbatim, UUID-shaped or not.
         return value;
       }
+      case "json": {
+        const segment = Array.isArray(value) ? `${key}[]` : key;
+        scanUnenumerated(ctx, value, [...segments, segment]);
+        return value;
+      }
       case "ref": {
         return projectRefLeaf({
           ctx,
@@ -921,11 +1010,9 @@ const projectField = ({
     return value.map((entry) => projectValue(ctx, item, entry, itemSegments));
   }
   if (nodeType === "unknown") {
-    // unenumeratedJson: forwarded unmodified; the invariant scan still covers
-    // every string inside, unlicensed.
-    const segment = Array.isArray(value) ? `${key}[]` : key;
-    scanUnenumerated(ctx, value, [...segments, segment]);
-    return value;
+    return panic(
+      "unknown chat projection fields must use strippedField or unenumeratedJson",
+    );
   }
   return projectValue(ctx, schemaNode, value, [...segments, key]);
 };
@@ -954,7 +1041,7 @@ const projectValue = (
   if (UNION_TYPES.has(nodeType)) {
     return projectValue(
       ctx,
-      matchUnionOption(schemaNode, value),
+      selectUnionOption(schemaNode, value),
       value,
       segments,
     );
@@ -990,8 +1077,9 @@ const projectValue = (
     panic("the ref path grammar cannot address nested arrays");
   }
   if (nodeType === "unknown") {
-    scanUnenumerated(ctx, value, segments);
-    return value;
+    return panic(
+      "unknown chat projection fields must use strippedField or unenumeratedJson",
+    );
   }
   // A scalar leaf (string/number/boolean/literal/picklist/null): ordinary
   // data. A UUID-bearing string here is undeclared and fails closed.

--- a/apps/api/src/lib/chat/projections.ts
+++ b/apps/api/src/lib/chat/projections.ts
@@ -11,6 +11,7 @@ import {
   chatEntityRef,
   chatRef,
   passthroughId,
+  projectionBranch,
   strippedField,
   unenumeratedJson,
 } from "./projection-schema";
@@ -43,8 +44,8 @@ import {
  * The field paths in `Payload` that `SchemaInput` does not declare, at any
  * depth (arrays compared element-wise; a `Payload` union branch is compared
  * only against the `SchemaInput` branches it is assignable to; an `unknown`
- * schema field — ref/stripped/unenumerated positions — admits any payload
- * type without descending).
+ * schema field — stripped/unenumerated positions — admits any payload type
+ * without descending).
  */
 type ExtraProjectionFields<Payload, SchemaInput> =
   Payload extends readonly (infer Item)[]
@@ -181,8 +182,8 @@ export const LIST_MATTERS_DETAIL_PROJECTION = v.strictObject({
 });
 
 export const LIST_MATTERS_PROJECTION = v.union([
-  LIST_MATTERS_LIST_PROJECTION,
-  LIST_MATTERS_DETAIL_PROJECTION,
+  projectionBranch(LIST_MATTERS_LIST_PROJECTION),
+  projectionBranch(LIST_MATTERS_DETAIL_PROJECTION),
 ]);
 
 /**
@@ -322,75 +323,99 @@ export const LIST_DOCUMENTS_PROJECTION = v.strictObject({
  * out of the model context entirely.
  */
 const documentFieldContentProjection = v.variant("type", [
-  v.strictObject({ version: v.literal(1), type: v.literal("error") }),
-  v.strictObject({ version: v.literal(1), type: v.literal("pending") }),
-  v.strictObject({ version: v.literal(1), type: v.literal("unsupported") }),
-  v.strictObject({
-    version: v.literal(1),
-    type: v.literal("file"),
-    id: strippedField(),
-    fileName: v.string(),
-    mimeType: v.string(),
-    sizeBytes: v.number(),
-    encrypted: v.boolean(),
-    sha256Hex: strippedField(),
-    pdfFileId: strippedField(),
-    pdfDerivative: v.optional(strippedField()),
-    thumbnailFileId: v.optional(strippedField()),
-    placeholder: v.optional(strippedField()),
-    thumbnailDerivative: v.optional(strippedField()),
-    scanWarnings: v.optional(v.array(v.string())),
-  }),
-  v.strictObject({
-    version: v.literal(1),
-    type: v.literal("text"),
-    value: v.string(),
-  }),
-  v.strictObject({
-    version: v.literal(1),
-    type: v.literal("single-select"),
-    value: v.nullable(v.string()),
-  }),
-  v.strictObject({
-    version: v.literal(1),
-    type: v.literal("multi-select"),
-    value: v.array(v.string()),
-  }),
-  v.strictObject({
-    version: v.literal(1),
-    type: v.literal("date"),
-    value: v.nullable(v.string()),
-  }),
-  v.strictObject({
-    version: v.literal(1),
-    type: v.literal("int"),
-    value: v.number(),
-    currency: v.nullable(v.string()),
-  }),
-  v.strictObject({
-    version: v.literal(1),
-    type: v.literal("money"),
-    amountCents: v.number(),
-    currency: v.string(),
-  }),
-  v.strictObject({
-    version: v.literal(1),
-    type: v.literal("person"),
-    // The workspace member handle is machinery chat cannot act on; the name is
-    // what a model reads.
-    userId: strippedField(),
-    name: v.string(),
-    image: strippedField(),
-  }),
-  v.strictObject({
-    version: v.literal(1),
-    type: v.literal("clip"),
-    url: v.string(),
-    snippet: v.optional(v.string()),
-    citation: v.optional(v.string()),
-    jurisdiction: v.optional(v.string()),
-    sourceType: v.optional(v.string()),
-  }),
+  projectionBranch(
+    v.strictObject({ version: v.literal(1), type: v.literal("error") }),
+  ),
+  projectionBranch(
+    v.strictObject({ version: v.literal(1), type: v.literal("pending") }),
+  ),
+  projectionBranch(
+    v.strictObject({ version: v.literal(1), type: v.literal("unsupported") }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      version: v.literal(1),
+      type: v.literal("file"),
+      id: strippedField(),
+      fileName: v.string(),
+      mimeType: v.string(),
+      sizeBytes: v.number(),
+      encrypted: v.boolean(),
+      sha256Hex: strippedField(),
+      pdfFileId: strippedField(),
+      pdfDerivative: v.optional(strippedField()),
+      thumbnailFileId: v.optional(strippedField()),
+      placeholder: v.optional(strippedField()),
+      thumbnailDerivative: v.optional(strippedField()),
+      scanWarnings: v.optional(v.array(v.string())),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      version: v.literal(1),
+      type: v.literal("text"),
+      value: v.string(),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      version: v.literal(1),
+      type: v.literal("single-select"),
+      value: v.nullable(v.string()),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      version: v.literal(1),
+      type: v.literal("multi-select"),
+      value: v.array(v.string()),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      version: v.literal(1),
+      type: v.literal("date"),
+      value: v.nullable(v.string()),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      version: v.literal(1),
+      type: v.literal("int"),
+      value: v.number(),
+      currency: v.nullable(v.string()),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      version: v.literal(1),
+      type: v.literal("money"),
+      amountCents: v.number(),
+      currency: v.string(),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      version: v.literal(1),
+      type: v.literal("person"),
+      // The workspace member handle is machinery chat cannot act on; the name is
+      // what a model reads.
+      userId: strippedField(),
+      name: v.string(),
+      image: strippedField(),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      version: v.literal(1),
+      type: v.literal("clip"),
+      url: v.string(),
+      snippet: v.optional(v.string()),
+      citation: v.optional(v.string()),
+      jurisdiction: v.optional(v.string()),
+      sourceType: v.optional(v.string()),
+    }),
+  ),
 ]);
 
 /**
@@ -421,78 +446,100 @@ const readDocumentEntityId = () =>
   chatEntityRef({ from: "inputEntity", param: "entity_id" });
 
 const documentProcessingRemediationProjection = v.variant("type", [
-  v.strictObject({
-    type: v.literal("action"),
-    tool: v.literal("invoke_capability"),
-    // Internal chat cannot invoke generic capabilities. Strip arguments
-    // defensively if this unreachable branch is ever returned.
-    arguments: strippedField(),
-  }),
-  v.strictObject({
-    type: v.literal("escalation"),
-    requiredScope: v.literal("stella:matters_write"),
-    requiredPermission: v.literal("entity:update"),
-    instruction: v.string(),
-  }),
+  projectionBranch(
+    v.strictObject({
+      type: v.literal("action"),
+      tool: v.literal("invoke_capability"),
+      // Internal chat cannot invoke generic capabilities. Strip arguments
+      // defensively if this unreachable branch is ever returned.
+      arguments: strippedField(),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      type: v.literal("escalation"),
+      requiredScope: v.literal("stella:matters_write"),
+      requiredPermission: v.literal("entity:update"),
+      instruction: v.string(),
+    }),
+  ),
 ]);
 
 const documentContentStateProjection = v.variant("status", [
-  v.strictObject({ status: v.literal("not_applicable") }),
-  v.strictObject({
-    status: v.literal("ready"),
-    source: v.picklist(["direct_docx", "extracted_text"]),
-    sourceVersionId: passthroughId(),
-    updatedAt: v.string(),
-  }),
-  v.strictObject({
-    status: v.literal("pending"),
-    processingKind: v.literal(DOCUMENT_PROCESSING_KIND),
-    runId: v.nullable(passthroughId()),
-    sourceVersionId: passthroughId(),
-  }),
-  v.strictObject({
-    status: v.literal(DOCUMENT_PROCESSING_REQUIRED_STATUS),
-    sourceVersionId: passthroughId(),
-    remediation: documentProcessingRemediationProjection,
-  }),
-  v.strictObject({
-    status: v.literal("failed"),
-    processingKind: v.literal(DOCUMENT_PROCESSING_KIND),
-    runId: passthroughId(),
-    sourceVersionId: passthroughId(),
-    errorCode: v.literal(DOCUMENT_PROCESSING_FAILURE_CODE),
-    retryable: v.literal(true),
-  }),
-  v.strictObject({
-    status: v.literal("unsupported"),
-    sourceVersionId: passthroughId(),
-    reason: v.string(),
-  }),
+  projectionBranch(v.strictObject({ status: v.literal("not_applicable") })),
+  projectionBranch(
+    v.strictObject({
+      status: v.literal("ready"),
+      source: v.picklist(["direct_docx", "extracted_text"]),
+      sourceVersionId: passthroughId(),
+      updatedAt: v.string(),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      status: v.literal("pending"),
+      processingKind: v.literal(DOCUMENT_PROCESSING_KIND),
+      runId: v.nullable(passthroughId()),
+      sourceVersionId: passthroughId(),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      status: v.literal(DOCUMENT_PROCESSING_REQUIRED_STATUS),
+      sourceVersionId: passthroughId(),
+      remediation: documentProcessingRemediationProjection,
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      status: v.literal("failed"),
+      processingKind: v.literal(DOCUMENT_PROCESSING_KIND),
+      runId: passthroughId(),
+      sourceVersionId: passthroughId(),
+      errorCode: v.literal(DOCUMENT_PROCESSING_FAILURE_CODE),
+      retryable: v.literal(true),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      status: v.literal("unsupported"),
+      sourceVersionId: passthroughId(),
+      reason: v.string(),
+    }),
+  ),
 ]);
 
 const documentSearchIndexStateProjection = v.variant("status", [
-  v.strictObject({ status: v.literal("not_applicable") }),
-  v.strictObject({
-    status: v.literal("ready"),
-    sourceVersionId: passthroughId(),
-    updatedAt: v.string(),
-  }),
-  v.strictObject({
-    status: v.literal("pending"),
-    sourceVersionId: passthroughId(),
-  }),
-  v.strictObject({
-    status: v.literal("failed"),
-    runId: passthroughId(),
-    sourceVersionId: passthroughId(),
-    errorCode: v.literal("search_index_failed"),
-    retryable: v.literal(true),
-  }),
-  v.strictObject({
-    status: v.literal("unsupported"),
-    sourceVersionId: passthroughId(),
-    reason: v.string(),
-  }),
+  projectionBranch(v.strictObject({ status: v.literal("not_applicable") })),
+  projectionBranch(
+    v.strictObject({
+      status: v.literal("ready"),
+      sourceVersionId: passthroughId(),
+      updatedAt: v.string(),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      status: v.literal("pending"),
+      sourceVersionId: passthroughId(),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      status: v.literal("failed"),
+      runId: passthroughId(),
+      sourceVersionId: passthroughId(),
+      errorCode: v.literal("search_index_failed"),
+      retryable: v.literal(true),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      status: v.literal("unsupported"),
+      sourceVersionId: passthroughId(),
+      reason: v.string(),
+    }),
+  ),
 ]);
 
 /**
@@ -539,19 +586,23 @@ export const READ_DOCUMENT_DIFF_PROJECTION = v.strictObject({
     targetVersionId: passthroughId(),
     segments: v.array(
       v.variant("kind", [
-        v.strictObject({
-          kind: v.picklist(["added", "removed", "unchanged", "gap"]),
-          text: v.string(),
-        }),
-        v.strictObject({
-          kind: v.literal("changed"),
-          runs: v.array(
-            v.strictObject({
-              kind: v.picklist(["same", "del", "ins"]),
-              text: v.string(),
-            }),
-          ),
-        }),
+        projectionBranch(
+          v.strictObject({
+            kind: v.picklist(["added", "removed", "unchanged", "gap"]),
+            text: v.string(),
+          }),
+        ),
+        projectionBranch(
+          v.strictObject({
+            kind: v.literal("changed"),
+            runs: v.array(
+              v.strictObject({
+                kind: v.picklist(["same", "del", "ins"]),
+                text: v.string(),
+              }),
+            ),
+          }),
+        ),
       ]),
     ),
   }),
@@ -562,9 +613,9 @@ export const READ_DOCUMENT_DIFF_PROJECTION = v.strictObject({
  * `document-tools.ts`).
  */
 export const READ_DOCUMENT_PROJECTION = v.union([
-  READ_DOCUMENT_DEFAULT_PROJECTION,
-  READ_DOCUMENT_VERSION_PROJECTION,
-  READ_DOCUMENT_DIFF_PROJECTION,
+  projectionBranch(READ_DOCUMENT_DEFAULT_PROJECTION),
+  projectionBranch(READ_DOCUMENT_VERSION_PROJECTION),
+  projectionBranch(READ_DOCUMENT_DIFF_PROJECTION),
 ]);
 
 /**
@@ -657,8 +708,8 @@ export const LIST_TASKS_DETAIL_PROJECTION = v.strictObject({
 });
 
 export const LIST_TASKS_PROJECTION = v.union([
-  LIST_TASKS_LIST_PROJECTION,
-  LIST_TASKS_DETAIL_PROJECTION,
+  projectionBranch(LIST_TASKS_LIST_PROJECTION),
+  projectionBranch(LIST_TASKS_DETAIL_PROJECTION),
 ]);
 
 /**
@@ -773,9 +824,9 @@ export const LIST_CLAUSES_VERSION_PROJECTION = v.strictObject({
 });
 
 export const LIST_CLAUSES_PROJECTION = v.union([
-  LIST_CLAUSES_LIST_PROJECTION,
-  LIST_CLAUSES_DETAIL_PROJECTION,
-  LIST_CLAUSES_VERSION_PROJECTION,
+  projectionBranch(LIST_CLAUSES_LIST_PROJECTION),
+  projectionBranch(LIST_CLAUSES_DETAIL_PROJECTION),
+  projectionBranch(LIST_CLAUSES_VERSION_PROJECTION),
 ]);
 
 /**
@@ -788,12 +839,16 @@ export const LIST_CLAUSES_PROJECTION = v.union([
  * documents the swap.
  */
 const playbookIdealLanguageProjection = v.variant("source", [
-  v.strictObject({
-    source: v.literal("clause"),
-    clauseId: passthroughId(),
-    clauseVersion: v.optional(v.number()),
-  }),
-  v.strictObject({ source: v.literal("inline"), text: v.string() }),
+  projectionBranch(
+    v.strictObject({
+      source: v.literal("clause"),
+      clauseId: passthroughId(),
+      clauseVersion: v.optional(v.number()),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({ source: v.literal("inline"), text: v.string() }),
+  ),
 ]);
 
 /**
@@ -830,21 +885,25 @@ const playbookAskManualProjection = v.strictObject({
 });
 
 const playbookAskConfigProjection = v.variant("mode", [
-  v.strictObject({
-    mode: v.literal("auto"),
-    derived: v.optional(
-      v.strictObject({
-        question: v.string(),
-        content: unenumeratedJson(),
-        rulesHash: v.string(),
-      }),
-    ),
-  }),
-  v.strictObject({
-    mode: v.literal("manual"),
-    question: v.string(),
-    content: unenumeratedJson(),
-  }),
+  projectionBranch(
+    v.strictObject({
+      mode: v.literal("auto"),
+      derived: v.optional(
+        v.strictObject({
+          question: v.string(),
+          content: unenumeratedJson(),
+          rulesHash: v.string(),
+        }),
+      ),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      mode: v.literal("manual"),
+      question: v.string(),
+      content: unenumeratedJson(),
+    }),
+  ),
 ]);
 
 /**
@@ -853,36 +912,40 @@ const playbookAskConfigProjection = v.variant("mode", [
  * unenumerated, so the backstop still guards it.
  */
 const playbookPositionProjection = v.variant("mode", [
-  v.strictObject({
-    mode: v.literal("extract"),
-    // Client-supplied stable id that maps a position back to its
-    // materialized column across edits; run_playbook accepts none of these,
-    // but the id survives as a documented handle rather than UUID noise the
-    // strict parse would refuse.
-    sourceId: passthroughId(),
-    issue: v.string(),
-    ask: playbookAskManualProjection,
-    guidance: v.optional(v.string()),
-    enabled: v.boolean(),
-  }),
-  v.strictObject({
-    mode: v.literal("graded"),
-    sourceId: passthroughId(),
-    issue: v.string(),
-    severity: v.string(),
-    tiers: playbookTiersProjection,
-    check: v.optional(unenumeratedJson()),
-    ask: playbookAskConfigProjection,
-    guidance: v.optional(v.string()),
-    negotiation: v.optional(
-      v.strictObject({
-        rationale: v.optional(v.string()),
-        talkingPoints: v.optional(v.array(v.string())),
-        escalation: v.optional(v.string()),
-      }),
-    ),
-    enabled: v.boolean(),
-  }),
+  projectionBranch(
+    v.strictObject({
+      mode: v.literal("extract"),
+      // Client-supplied stable id that maps a position back to its
+      // materialized column across edits; run_playbook accepts none of these,
+      // but the id survives as a documented handle rather than UUID noise the
+      // strict parse would refuse.
+      sourceId: passthroughId(),
+      issue: v.string(),
+      ask: playbookAskManualProjection,
+      guidance: v.optional(v.string()),
+      enabled: v.boolean(),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      mode: v.literal("graded"),
+      sourceId: passthroughId(),
+      issue: v.string(),
+      severity: v.string(),
+      tiers: playbookTiersProjection,
+      check: v.optional(unenumeratedJson()),
+      ask: playbookAskConfigProjection,
+      guidance: v.optional(v.string()),
+      negotiation: v.optional(
+        v.strictObject({
+          rationale: v.optional(v.string()),
+          talkingPoints: v.optional(v.array(v.string())),
+          escalation: v.optional(v.string()),
+        }),
+      ),
+      enabled: v.boolean(),
+    }),
+  ),
 ]);
 
 /**
@@ -933,8 +996,8 @@ export const LIST_PLAYBOOKS_DETAIL_PROJECTION = v.strictObject({
 });
 
 export const LIST_PLAYBOOKS_PROJECTION = v.union([
-  LIST_PLAYBOOKS_LIST_PROJECTION,
-  LIST_PLAYBOOKS_DETAIL_PROJECTION,
+  projectionBranch(LIST_PLAYBOOKS_LIST_PROJECTION),
+  projectionBranch(LIST_PLAYBOOKS_DETAIL_PROJECTION),
 ]);
 
 /**
@@ -1002,8 +1065,8 @@ export const LIST_TIME_ENTRIES_DETAIL_PROJECTION = v.strictObject({
 });
 
 export const LIST_TIME_ENTRIES_PROJECTION = v.union([
-  LIST_TIME_ENTRIES_LIST_PROJECTION,
-  LIST_TIME_ENTRIES_DETAIL_PROJECTION,
+  projectionBranch(LIST_TIME_ENTRIES_LIST_PROJECTION),
+  projectionBranch(LIST_TIME_ENTRIES_DETAIL_PROJECTION),
 ]);
 
 /**
@@ -1106,8 +1169,8 @@ export const LIST_INVOICES_DETAIL_PROJECTION = v.strictObject({
 });
 
 export const LIST_INVOICES_PROJECTION = v.union([
-  LIST_INVOICES_LIST_PROJECTION,
-  LIST_INVOICES_DETAIL_PROJECTION,
+  projectionBranch(LIST_INVOICES_LIST_PROJECTION),
+  projectionBranch(LIST_INVOICES_DETAIL_PROJECTION),
 ]);
 
 /**
@@ -1140,8 +1203,8 @@ export const GET_USAGE_ENTITLED_PROJECTION = v.strictObject({
 });
 
 export const GET_USAGE_PROJECTION = v.union([
-  GET_USAGE_NO_PLAN_PROJECTION,
-  GET_USAGE_ENTITLED_PROJECTION,
+  projectionBranch(GET_USAGE_NO_PLAN_PROJECTION),
+  projectionBranch(GET_USAGE_ENTITLED_PROJECTION),
 ]);
 
 /** One facet bucket of the case-law search response. */
@@ -1260,69 +1323,77 @@ export const READ_CASE_LAW_DECISION_PROJECTION = v.strictObject({
  */
 export const SEARCH_LEGISLATION_PROJECTION = v.union([
   // block branch: one article/disposition as raw XML.
-  v.strictObject({
-    lawId: passthroughId(),
-    blockId: passthroughId(),
-    block: v.string(),
-  }),
+  projectionBranch(
+    v.strictObject({
+      lawId: passthroughId(),
+      blockId: passthroughId(),
+      block: v.string(),
+    }),
+  ),
   // related branch: `findRelatedLaws` (`@stll/boe`).
-  v.strictObject({
-    lawId: passthroughId(),
-    relationType: v.string(),
-    analysis: unenumeratedJson(),
-  }),
+  projectionBranch(
+    v.strictObject({
+      lawId: passthroughId(),
+      relationType: v.string(),
+      analysis: unenumeratedJson(),
+    }),
+  ),
   // default read branch: `{ law, structure }` (`getConsolidatedLaw` +
   // `getLawStructure`).
-  v.strictObject({
-    law: v.strictObject({
-      lawId: passthroughId(),
-      metadata: unenumeratedJson(),
-      analysis: unenumeratedJson(),
-      fullText: v.nullable(v.string()),
-      eli: v.nullable(v.string()),
+  projectionBranch(
+    v.strictObject({
+      law: v.strictObject({
+        lawId: passthroughId(),
+        metadata: unenumeratedJson(),
+        analysis: unenumeratedJson(),
+        fullText: v.nullable(v.string()),
+        eli: v.nullable(v.string()),
+      }),
+      structure: unenumeratedJson(),
     }),
-    structure: unenumeratedJson(),
-  }),
+  ),
   // search branch: the raw `BoeSearchResponse` envelope (every field
   // optional upstream).
-  v.strictObject({
-    data: v.optional(
-      v.array(
+  projectionBranch(
+    v.strictObject({
+      data: v.optional(
+        v.array(
+          v.strictObject({
+            identificador: passthroughId(),
+            titulo: v.optional(v.string()),
+            fecha_publicacion: v.optional(v.string()),
+            fecha_disposicion: v.optional(v.string()),
+            departamento: v.optional(
+              v.strictObject({
+                codigo: v.optional(v.string()),
+                texto: v.optional(v.string()),
+              }),
+            ),
+            rango: v.optional(
+              v.strictObject({
+                codigo: v.optional(v.string()),
+                texto: v.optional(v.string()),
+              }),
+            ),
+            estado_consolidacion: v.optional(
+              v.strictObject({
+                codigo: v.optional(v.string()),
+                texto: v.optional(v.string()),
+              }),
+            ),
+            url_eli: v.optional(v.string()),
+            url_html_consolidada: v.optional(v.string()),
+          }),
+        ),
+      ),
+      status: v.optional(
         v.strictObject({
-          identificador: passthroughId(),
-          titulo: v.optional(v.string()),
-          fecha_publicacion: v.optional(v.string()),
-          fecha_disposicion: v.optional(v.string()),
-          departamento: v.optional(
-            v.strictObject({
-              codigo: v.optional(v.string()),
-              texto: v.optional(v.string()),
-            }),
-          ),
-          rango: v.optional(
-            v.strictObject({
-              codigo: v.optional(v.string()),
-              texto: v.optional(v.string()),
-            }),
-          ),
-          estado_consolidacion: v.optional(
-            v.strictObject({
-              codigo: v.optional(v.string()),
-              texto: v.optional(v.string()),
-            }),
-          ),
-          url_eli: v.optional(v.string()),
-          url_html_consolidada: v.optional(v.string()),
+          code: v.optional(v.string()),
+          text: v.optional(v.string()),
         }),
       ),
-    ),
-    status: v.optional(
-      v.strictObject({
-        code: v.optional(v.string()),
-        text: v.optional(v.string()),
-      }),
-    ),
-  }),
+    }),
+  ),
 ]);
 
 /**
@@ -1359,16 +1430,20 @@ const businessRegistryHitProjection = v.strictObject({
  * `handleLookupBusinessRegistryTool` (`matter-tools.ts`).
  */
 export const LOOKUP_BUSINESS_REGISTRY_PROJECTION = v.variant("type", [
-  v.strictObject({
-    type: v.literal("lookup"),
-    registry: v.string(),
-    hit: v.nullable(businessRegistryHitProjection),
-  }),
-  v.strictObject({
-    type: v.literal("search"),
-    registry: v.string(),
-    hits: v.array(businessRegistryHitProjection),
-  }),
+  projectionBranch(
+    v.strictObject({
+      type: v.literal("lookup"),
+      registry: v.string(),
+      hit: v.nullable(businessRegistryHitProjection),
+    }),
+  ),
+  projectionBranch(
+    v.strictObject({
+      type: v.literal("search"),
+      registry: v.string(),
+      hits: v.array(businessRegistryHitProjection),
+    }),
+  ),
 ]);
 
 /**
@@ -1441,8 +1516,8 @@ export const LIST_TEMPLATES_LIST_PROJECTION = v.strictObject({
 });
 
 export const LIST_TEMPLATES_PROJECTION = v.union([
-  LIST_TEMPLATES_LIST_PROJECTION,
-  TEMPLATE_DESCRIBE_PROJECTION,
+  projectionBranch(LIST_TEMPLATES_LIST_PROJECTION),
+  projectionBranch(TEMPLATE_DESCRIBE_PROJECTION),
 ]);
 
 // --- Write-tool projections ---------------------------------------------------
@@ -1495,8 +1570,8 @@ export const LINK_MATTER_CONTACT_UNLINK_PROJECTION = v.strictObject({
 });
 
 export const LINK_MATTER_CONTACT_PROJECTION = v.union([
-  LINK_MATTER_CONTACT_LINK_PROJECTION,
-  LINK_MATTER_CONTACT_UNLINK_PROJECTION,
+  projectionBranch(LINK_MATTER_CONTACT_LINK_PROJECTION),
+  projectionBranch(LINK_MATTER_CONTACT_UNLINK_PROJECTION),
 ]);
 
 /**
@@ -1513,8 +1588,8 @@ export const SAVE_DOCUMENT_UPDATE_PROJECTION = v.strictObject({
 });
 
 export const SAVE_DOCUMENT_PROJECTION = v.union([
-  SAVE_DOCUMENT_CREATE_PROJECTION,
-  SAVE_DOCUMENT_UPDATE_PROJECTION,
+  projectionBranch(SAVE_DOCUMENT_CREATE_PROJECTION),
+  projectionBranch(SAVE_DOCUMENT_UPDATE_PROJECTION),
 ]);
 
 /** set_field_value returns `{}`. */
@@ -1567,9 +1642,9 @@ export const MANAGE_ORGANIZATION_SETTINGS_PROJECTION = v.strictObject({
 });
 
 export const MANAGE_ORGANIZATION_PROJECTION = v.union([
-  MANAGE_ORGANIZATION_ADD_MEMBER_PROJECTION,
-  MANAGE_ORGANIZATION_REMOVE_MEMBER_PROJECTION,
-  MANAGE_ORGANIZATION_SETTINGS_PROJECTION,
+  projectionBranch(MANAGE_ORGANIZATION_ADD_MEMBER_PROJECTION),
+  projectionBranch(MANAGE_ORGANIZATION_REMOVE_MEMBER_PROJECTION),
+  projectionBranch(MANAGE_ORGANIZATION_SETTINGS_PROJECTION),
 ]);
 
 /**
@@ -1594,6 +1669,6 @@ export const SAVE_TEMPLATE_CREATE_PROJECTION = v.strictObject({
 });
 
 export const SAVE_TEMPLATE_PROJECTION = v.union([
-  SAVE_TEMPLATE_CREATE_PROJECTION,
-  TEMPLATE_DESCRIBE_PROJECTION,
+  projectionBranch(SAVE_TEMPLATE_CREATE_PROJECTION),
+  projectionBranch(TEMPLATE_DESCRIBE_PROJECTION),
 ]);

--- a/apps/api/src/lib/chat/projections.ts
+++ b/apps/api/src/lib/chat/projections.ts
@@ -49,22 +49,35 @@ import {
  * schema field — stripped/unenumerated positions — admits any payload type
  * without descending).
  */
+type ProjectionScalar =
+  | string
+  | number
+  | boolean
+  | bigint
+  | symbol
+  | null
+  | undefined;
+
 type ExtraProjectionFields<Payload, SchemaInput> =
-  Payload extends readonly (infer Item)[]
-    ? SchemaInput extends readonly (infer ShapeItem)[]
-      ? ExtraProjectionFields<Item, ShapeItem>
-      : never
-    : Payload extends object
-      ? SchemaInput extends object
-        ? Payload extends SchemaInput
-          ? {
-              [K in keyof Payload]-?: K extends keyof SchemaInput
-                ? ExtraProjectionFields<Payload[K], SchemaInput[K]>
-                : K;
-            }[keyof Payload]
+  unknown extends SchemaInput
+    ? never
+    : SchemaInput extends ProjectionScalar
+      ? never
+      : Payload extends readonly (infer Item)[]
+        ? SchemaInput extends readonly (infer ShapeItem)[]
+          ? ExtraProjectionFields<Item, ShapeItem>
           : never
-        : never
-      : never;
+        : Payload extends object
+          ? SchemaInput extends object
+            ? Payload extends SchemaInput
+              ? {
+                  [K in keyof Payload]-?: K extends keyof SchemaInput
+                    ? ExtraProjectionFields<Payload[K], SchemaInput[K]>
+                    : K;
+                }[keyof Payload]
+              : never
+            : never
+          : never;
 
 /**
  * Compile-time exactness tie for a chat payload that is NOT built as an

--- a/apps/api/src/lib/chat/projections.ts
+++ b/apps/api/src/lib/chat/projections.ts
@@ -58,26 +58,25 @@ type ProjectionScalar =
   | null
   | undefined;
 
-type ExtraProjectionFields<Payload, SchemaInput> =
-  unknown extends SchemaInput
+type ExtraProjectionFields<Payload, SchemaInput> = unknown extends SchemaInput
+  ? never
+  : SchemaInput extends ProjectionScalar
     ? never
-    : SchemaInput extends ProjectionScalar
-      ? never
-      : Payload extends readonly (infer Item)[]
-        ? SchemaInput extends readonly (infer ShapeItem)[]
-          ? ExtraProjectionFields<Item, ShapeItem>
-          : never
-        : Payload extends object
-          ? SchemaInput extends object
-            ? Payload extends SchemaInput
-              ? {
-                  [K in keyof Payload]-?: K extends keyof SchemaInput
-                    ? ExtraProjectionFields<Payload[K], SchemaInput[K]>
-                    : K;
-                }[keyof Payload]
-              : never
+    : Payload extends readonly (infer Item)[]
+      ? SchemaInput extends readonly (infer ShapeItem)[]
+        ? ExtraProjectionFields<Item, ShapeItem>
+        : never
+      : Payload extends object
+        ? SchemaInput extends object
+          ? Payload extends SchemaInput
+            ? {
+                [K in keyof Payload]-?: K extends keyof SchemaInput
+                  ? ExtraProjectionFields<Payload[K], SchemaInput[K]>
+                  : K;
+              }[keyof Payload]
             : never
-          : never;
+          : never
+        : never;
 
 /**
  * Compile-time exactness tie for a chat payload that is NOT built as an
@@ -413,8 +412,8 @@ const documentFieldContentProjection = v.variant("type", [
     v.strictObject({
       version: v.literal(1),
       type: v.literal("person"),
-      // The workspace member handle is machinery chat cannot act on; the name is
-      // what a model reads.
+      // The workspace member handle is machinery chat cannot act on; the name
+      // is what a model reads.
       userId: strippedField(),
       name: v.string(),
       image: strippedField(),

--- a/apps/api/src/lib/chat/projections.ts
+++ b/apps/api/src/lib/chat/projections.ts
@@ -1,5 +1,7 @@
 import * as v from "valibot";
 
+import { ENTITY_KINDS } from "@stll/api-contract";
+
 import { TIME_ENTRY_VISIBILITY } from "@/api/lib/billing-constants";
 import {
   DOCUMENT_PROCESSING_FAILURE_CODE,
@@ -253,7 +255,7 @@ export const SEARCH_ACROSS_MATTERS_PROJECTION = v.strictObject({
       workspaceId: chatRef("matter"),
       workspaceName: v.string(),
       name: v.string(),
-      kind: v.string(),
+      kind: v.picklist(ENTITY_KINDS),
       headline: v.nullable(v.string()),
     }),
   ),
@@ -270,7 +272,7 @@ export const READ_CONTENT_ACROSS_MATTERS_PROJECTION = v.strictObject({
   // reuses the dehydrated ref; the sibling source (the hand entry's
   // declaration, kept verbatim) only backs a non-echo payload.
   entityId: chatEntityRef({ from: "sibling", key: "workspaceId" }),
-  kind: v.string(),
+  kind: v.picklist(ENTITY_KINDS),
   name: v.string(),
   text: v.string(),
   truncated: v.boolean(),

--- a/apps/api/src/lib/docx/template-manifest.ts
+++ b/apps/api/src/lib/docx/template-manifest.ts
@@ -407,35 +407,34 @@ const parseFieldPart = (el: slimdom.Element): FieldPart | null => {
   return part;
 };
 
+const parseFieldSourceCandidate = (candidate: unknown): FieldSource | null =>
+  isFieldSource(candidate) ? candidate : null;
+
 const parseFieldSource = (el: slimdom.Element): FieldSource | null => {
-  const candidate = {
-    kind: el.getAttribute("kind"),
-    role: el.getAttribute("role"),
-    ref: el.getAttribute("ref"),
-    field: el.getAttribute("field"),
-  };
-  if (!isFieldSource(candidate)) {
-    return null;
-  }
-  // Reconstruct the exact per-kind shape: isFieldSource ignores irrelevant
-  // attributes, but the stored binding must match its union member so a
-  // contact/matter/firm source never carries a stray role/ref from hand-edited
-  // XML, and a round-tripped source compares equal to its input.
-  switch (candidate.kind) {
+  const kind = el.getAttribute("kind");
+  const field = el.getAttribute("field");
+
+  switch (kind) {
     case "party":
-      return { kind: "party", role: candidate.role, field: candidate.field };
+      return parseFieldSourceCandidate({
+        kind,
+        role: el.getAttribute("role"),
+        field,
+      });
     case "attorney":
-      return { kind: "attorney", ref: candidate.ref, field: candidate.field };
+      return parseFieldSourceCandidate({
+        kind,
+        ref: el.getAttribute("ref"),
+        field,
+      });
     case "contact":
-      return { kind: "contact", field: candidate.field };
     case "matter":
-      return { kind: "matter", field: candidate.field };
     case "firm":
-      return { kind: "firm", field: candidate.field };
-    default: {
-      const exhaustive: never = candidate;
-      return exhaustive;
-    }
+      return parseFieldSourceCandidate({ kind, field });
+    case null:
+      return null;
+    default:
+      return null;
   }
 };
 

--- a/apps/api/src/lib/docx/types.test.ts
+++ b/apps/api/src/lib/docx/types.test.ts
@@ -214,6 +214,28 @@ describe("isFieldMeta", () => {
     );
   });
 
+  test("rejects multiple active derived source modes", () => {
+    expect(
+      isFieldMeta({ path: "x", aiPrompt: "draft it", aiAdapt: false }),
+    ).toBe(true);
+    expect(
+      isFieldMeta({ path: "x", aiPrompt: "draft it", aiAdapt: true }),
+    ).toBe(false);
+    expect(
+      isFieldMeta({
+        path: "x",
+        aiPrompt: "draft it",
+        lookup: { registry: "krs" },
+      }),
+    ).toBe(false);
+    expect(
+      isFieldMeta({
+        ...compositeField,
+        lookup: { registry: "krs" },
+      }),
+    ).toBe(false);
+  });
+
   test("accepts a contact-sourced field", () => {
     expect(
       isFieldMeta({

--- a/apps/api/src/lib/docx/types.test.ts
+++ b/apps/api/src/lib/docx/types.test.ts
@@ -39,6 +39,10 @@ describe("isFieldMeta", () => {
     ],
     format: "{{position}} {{name}}",
   };
+  const validLookup = {
+    registry: "krs",
+    formats: [{ key: "full", template: "[name]" }],
+  };
 
   test("accepts a composite field with parts and format", () => {
     expect(isFieldMeta(compositeField)).toBe(true);
@@ -206,7 +210,7 @@ describe("isFieldMeta", () => {
       isFieldMeta({
         path: "x",
         formula: "rent * 12",
-        lookup: { registry: "krs" },
+        lookup: validLookup,
       }),
     ).toBe(false);
     expect(isFieldMeta({ ...compositeField, formula: "rent * 12" })).toBe(
@@ -225,13 +229,13 @@ describe("isFieldMeta", () => {
       isFieldMeta({
         path: "x",
         aiPrompt: "draft it",
-        lookup: { registry: "krs" },
+        lookup: validLookup,
       }),
     ).toBe(false);
     expect(
       isFieldMeta({
         ...compositeField,
-        lookup: { registry: "krs" },
+        lookup: validLookup,
       }),
     ).toBe(false);
   });

--- a/apps/api/src/lib/docx/types.test.ts
+++ b/apps/api/src/lib/docx/types.test.ts
@@ -44,6 +44,16 @@ describe("isFieldMeta", () => {
     expect(isFieldMeta(compositeField)).toBe(true);
   });
 
+  test("rejects unknown metadata keys at every owned object boundary", () => {
+    expect(isFieldMeta({ path: "client.name", lable: "Client" })).toBe(false);
+    expect(
+      isFieldMeta({
+        ...compositeField,
+        parts: [{ key: "name", inputType: "text", lable: "Name" }],
+      }),
+    ).toBe(false);
+  });
+
   test("rejects parts without format (and vice versa)", () => {
     const { format: _format, ...partsOnly } = compositeField;
     expect(isFieldMeta(partsOnly)).toBe(false);

--- a/apps/api/src/lib/docx/types.ts
+++ b/apps/api/src/lib/docx/types.ts
@@ -16,6 +16,7 @@ import {
 
 import {
   fieldSourceSchema,
+  fieldSourceToolInputSchema,
   type FieldSource,
 } from "@/api/lib/template-binding/binding-sources";
 
@@ -440,6 +441,8 @@ const activeDerivedSourceModes = ({
 const hasCompatibleDerivedSources = (fields: DerivedSourceFields): boolean =>
   activeDerivedSourceModes(fields).length <= 1;
 
+const FIELD_SOURCE_DESCRIPTION = "Matter or contact data resolved server-side";
+
 const fieldMetaObjectSchema = v.strictObject({
   path: fieldPathSchema("Field path; must match a {{marker}} in the template"),
   label: v.optional(describedString("Human-readable field label")),
@@ -499,10 +502,7 @@ const fieldMetaObjectSchema = v.strictObject({
   ),
   lookup: v.optional(fieldLookupSchema),
   source: v.optional(
-    v.pipe(
-      fieldSourceSchema,
-      v.description("Matter or contact data resolved server-side"),
-    ),
+    v.pipe(fieldSourceSchema, v.description(FIELD_SOURCE_DESCRIPTION)),
   ),
   formula: v.optional(
     describedString("Arithmetic expression derived from other fields"),
@@ -546,9 +546,12 @@ export const fieldMetaSchema = v.pipe(
 /** Model-facing subset: conditionAst is the persisted canonical form, not an
  * authoring input. This schema derives its public fields from the persisted
  * object schema and applies the same named invariant predicates. */
-const fieldMetaToolInputObjectSchema = v.omit(fieldMetaObjectSchema, [
-  "conditionAst",
-]);
+const fieldMetaToolInputObjectSchema = v.strictObject({
+  ...v.omit(fieldMetaObjectSchema, ["conditionAst"]).entries,
+  source: v.optional(
+    v.pipe(fieldSourceToolInputSchema, v.description(FIELD_SOURCE_DESCRIPTION)),
+  ),
+});
 
 export const fieldMetaToolInputSchema = v.pipe(
   fieldMetaToolInputObjectSchema,

--- a/apps/api/src/lib/docx/types.ts
+++ b/apps/api/src/lib/docx/types.ts
@@ -2,6 +2,7 @@
 
 import * as v from "valibot";
 
+import { BUSINESS_REGISTRY_SLUGS } from "@stll/api-contract";
 import type { ExtractedDocxParagraph } from "@stll/folio-core/server";
 import {
   type BlockDirectiveKind,
@@ -13,10 +14,9 @@ import {
   isFieldPath,
 } from "@stll/template-conditions";
 
-import { BUSINESS_REGISTRY_SLUGS } from "@/api/lib/business-registries/dispatch";
 import {
+  fieldSourceSchema,
   type FieldSource,
-  isFieldSource,
 } from "@/api/lib/template-binding/binding-sources";
 
 export type { FieldSource } from "@/api/lib/template-binding/binding-sources";
@@ -207,17 +207,8 @@ export type InputType = (typeof INPUT_TYPES)[number];
 
 export type PartInputType = "text" | "select";
 
-/** One part of a composite field's value (see {@link FieldMeta.parts}). */
-export type FieldPart = {
-  /** Part key referenced by the field's format; same charset as field paths. */
-  key: string;
-  label?: string | undefined;
-  inputType: PartInputType;
-  /** Allowed values when {@link inputType} is "select". */
-  options?: string[] | undefined;
-  /** Regex matched against the whole part value at fill time. */
-  pattern?: string | undefined;
-};
+/** Canonical parsed part of a composite field value. */
+export type FieldPart = v.InferOutput<typeof fieldPartSchema>;
 
 /** Registries a lookup field can resolve against. Single-sourced from the
  *  dispatch table's slug set, so every registry the fill boundary can resolve
@@ -239,16 +230,7 @@ export type LookupRegistry = (typeof LOOKUP_REGISTRIES)[number];
  * default, addressed by the bare marker `{{path}}`; every later format is
  * addressed by a dotted marker `{{path.key}}` in the document.
  */
-export type FieldLookupFormat = {
-  /** Marker segment after the field path: `{{company.<key>}}` (the first
-   *  format is the default and is addressed by the bare `{{company}}`).
-   *  Validated like a single field-path segment (letters, digits, underscore,
-   *  dash; no dots). */
-  key: string;
-  /** [token]-substituted template rendered against the hit (supports
-   *  `**bold**` / `*italic*`). */
-  template: string;
-};
+export type FieldLookupFormat = v.InferOutput<typeof fieldLookupFormatSchema>;
 
 /** Upper bound on named formats per lookup field; keeps the manifest small and
  *  the per-fill render work bounded. */
@@ -264,144 +246,18 @@ const LOOKUP_FORMAT_KEY_RE = /^[\p{L}\p{N}_-]+$/u;
 export const isLookupFormatKey = (value: string): boolean =>
   LOOKUP_FORMAT_KEY_RE.test(value);
 
-export type FieldLookup = {
-  registry: LookupRegistry;
-  /**
-   * Named renderings of the registry hit. The registry is resolved once per
-   * fill; every format renders that one hit through its own [token] template
-   * (e.g. "[company name], with its seat in [seat], KRS [registry number]").
-   * Always non-empty: the FIRST format is the default for the bare `{{path}}`
-   * marker; every later format is addressed by a dotted marker `{{path.key}}`.
-   */
-  formats: FieldLookupFormat[];
-};
+export type FieldLookup = v.InferOutput<typeof fieldLookupSchema>;
 
 export const isFieldLookupFormat = (
   value: unknown,
 ): value is FieldLookupFormat =>
-  isRecordLike(value) &&
-  typeof value["key"] === "string" &&
-  isLookupFormatKey(value["key"]) &&
-  typeof value["template"] === "string" &&
-  value["template"].length <= LOOKUP_FORMAT_TEMPLATE_MAX_LENGTH;
+  v.is(fieldLookupFormatSchema, value);
 
-export type FieldValidation = {
-  required?: boolean;
-  minLength?: number;
-  maxLength?: number;
-  min?: number;
-  max?: number;
-  pattern?: string;
-  /** Minimum repeats for an `{{#each}}` loop; lives on the FieldMeta whose
-   *  path equals the loop's array (container) path. */
-  minItems?: number;
-  /** Maximum repeats for an `{{#each}}` loop; lives on the loop-container
-   *  FieldMeta alongside {@link minItems}. */
-  maxItems?: number;
-};
+export type FieldValidation = v.InferOutput<typeof fieldValidationSchema>;
 
-export type FieldMeta = {
-  path: string;
-  label?: string | undefined;
-  /**
-   * Short guidance for the person filling the field (expected format, where
-   * to find the value, …). Shown as the input's placeholder in the fill form
-   * and included in AI prompts so prefill maps source text to the right
-   * field. Kept short (~200 chars, enforced by the config UI).
-   */
-  hint?: string | undefined;
-  inputType?: InputType | undefined;
-  options?: string[] | undefined;
-  validation?: FieldValidation | undefined;
-  required?: boolean | undefined;
-  /**
-   * When set, the field's value is drafted by AI at fill time from this
-   * instruction (e.g. "Draft the scope of this power of attorney"), unless the
-   * user supplies a value. The model provider is injected at the fill boundary;
-   * with no provider the field is simply left unfilled.
-   */
-  aiPrompt?: string | undefined;
-  /**
-   * When true, the user-entered value is a stub that AI rewrites at fill time
-   * to fit the surrounding text of each marker occurrence (declension and
-   * phrasing differ per sentence in inflected languages). With no model
-   * provider, or on any model failure, the stub fills every occurrence as-is.
-   */
-  aiAdapt?: boolean | undefined;
-  /**
-   * Per-field opt-in for AI-drafted fields ({@link aiPrompt}): when true, the
-   * rendered document text is injected into the generator prompt so the draft
-   * can reference the surrounding contract. Default falsy keeps the token cost
-   * bounded — only opted-in fields pay for the document context.
-   */
-  aiSeesDocument?: boolean | undefined;
-  /**
-   * Composite field: the value is entered as several parts (e.g. a select for
-   * a professional title plus a free-text name) that are validated and joined
-   * by {@link format} into the single string the document's one {{marker}} is
-   * filled with. Present iff `format` is present; a field with parts ignores
-   * its own inputType for input rendering.
-   */
-  parts?: FieldPart[] | undefined;
-  /** Join template over part keys, `{{key}}` syntax (e.g. "{{position}} {{name}}").
-   *  Present iff `parts` is present. */
-  format?: string | undefined;
-  /**
-   * Dependent select: path of another field whose submitted value(s) supply
-   * this field's allowed options at fill time (e.g. the user first enters a
-   * list of parties, and this field must be one of them). Static {@link
-   * options} act as a fallback while the source field is empty.
-   */
-  optionsFrom?: string | undefined;
-  /**
-   * Registry lookup field: the submitted value is a registry number (e.g. a
-   * KRS number) that is resolved against the configured business registry at
-   * fill time and replaced with the rendered company details.
-   */
-  lookup?: FieldLookup | undefined;
-  /**
-   * Contact-sourced field: the value is resolved from a contact record (the
-   * matter's client) at fill time, not user-entered. A derived value source,
-   * mutually exclusive with the others ({@link formula}, {@link aiPrompt},
-   * {@link aiAdapt}, {@link lookup}, {@link parts}, {@link condition}).
-   */
-  source?: FieldSource | undefined;
-  /**
-   * Formula field: the value is derived from other fields via an arithmetic
-   * expression (evaluated by `evaluateNumericExpression`) at fill time, e.g.
-   * `min(rent * (1 + index / 100), rent * 1.05)`. Derived, never
-   * user-submitted; mutually exclusive with the other value sources
-   * ({@link aiPrompt}, {@link aiAdapt}, {@link lookup}, {@link parts}).
-   */
-  formula?: string | undefined;
-  /**
-   * Boolean rule condition: a yes/no value derived from a rule expression in
-   * the @stll/template-conditions grammar (e.g. `client_type == "company"`,
-   * `signing_date >= "2026-06-10" and amount > 1000`), evaluated at fill time.
-   * Meaningful only on a boolean field; markers reference it by field path
-   * (`{{#if field_path}}`). A derived value source, so it is mutually exclusive
-   * with the others ({@link formula}, {@link aiPrompt}, {@link aiAdapt},
-   * {@link lookup}, {@link parts}); a plain boolean field (no condition, no
-   * aiPrompt) is asked as a yes/no question in the fill form instead.
-   */
-  condition?: string | undefined;
-  /**
-   * The canonical condition AST, set instead of {@link condition} when the rule
-   * uses a `formula` operand (e.g. `rent * 12 < 100000`) that the `{{#if}}`
-   * expression grammar cannot represent. Authoritative when present; the
-   * string {@link condition} is used otherwise. Same mutual-exclusivity and
-   * boolean-field constraints as {@link condition}.
-   */
-  conditionAst?: ConditionNode | undefined;
-  /**
-   * Locale-aware rendering for a "date" {@link inputType} field: the
-   * submitted ISO date (the date input's value) is formatted in this locale
-   * and style before substitution — and before any AI step, so a field that
-   * also sets {@link aiAdapt} hands the formatted date to the per-occurrence
-   * adapter as the stub.
-   */
-  dateFormat?: FieldDateFormat | undefined;
-};
+/** Canonical parsed field metadata. Runtime validation, MCP schema generation,
+ * and downstream TypeScript all derive from {@link fieldMetaSchema}. */
+export type FieldMeta = v.InferOutput<typeof fieldMetaSchema>;
 
 export type TemplateManifest = {
   version: number;
@@ -410,53 +266,6 @@ export type TemplateManifest = {
 
 const isRecordLike = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
-
-const isInputType = (value: unknown): value is InputType =>
-  INPUT_TYPES.some((inputType) => inputType === value);
-
-const isFieldValidation = (value: unknown): value is FieldValidation => {
-  if (!isRecordLike(value)) {
-    return false;
-  }
-
-  return (
-    (value["required"] === undefined ||
-      typeof value["required"] === "boolean") &&
-    (value["minLength"] === undefined ||
-      typeof value["minLength"] === "number") &&
-    (value["maxLength"] === undefined ||
-      typeof value["maxLength"] === "number") &&
-    (value["min"] === undefined || typeof value["min"] === "number") &&
-    (value["max"] === undefined || typeof value["max"] === "number") &&
-    (value["pattern"] === undefined || typeof value["pattern"] === "string") &&
-    (value["minItems"] === undefined ||
-      (typeof value["minItems"] === "number" &&
-        Number.isFinite(value["minItems"]))) &&
-    (value["maxItems"] === undefined ||
-      (typeof value["maxItems"] === "number" &&
-        Number.isFinite(value["maxItems"])))
-  );
-};
-
-const isPartInputType = (value: unknown): value is PartInputType =>
-  value === "text" || value === "select";
-
-export const isFieldPart = (value: unknown): value is FieldPart =>
-  isRecordLike(value) &&
-  typeof value["key"] === "string" &&
-  isFieldPath(value["key"]) &&
-  (value["label"] === undefined || typeof value["label"] === "string") &&
-  isPartInputType(value["inputType"]) &&
-  (value["options"] === undefined ||
-    (Array.isArray(value["options"]) &&
-      value["options"].every((option) => typeof option === "string"))) &&
-  (value["pattern"] === undefined || typeof value["pattern"] === "string");
-
-const isLookupRegistry = (value: unknown): value is LookupRegistry =>
-  LOOKUP_REGISTRIES.some((registry) => registry === value);
-
-const isDateFormatStyle = (value: unknown): value is DateFormatStyle =>
-  DATE_FORMAT_STYLES.some((style) => style === value);
 
 /** Structurally malformed BCP-47 tags make `Intl` throw a RangeError; a
  *  well-formed but unknown tag passes and merely falls back to the default
@@ -470,108 +279,286 @@ export const isPlausibleLocale = (value: string): boolean => {
   }
 };
 
-export const isFieldDateFormat = (value: unknown): value is FieldDateFormat =>
-  isRecordLike(value) &&
-  typeof value["locale"] === "string" &&
-  isPlausibleLocale(value["locale"]) &&
-  isDateFormatStyle(value["style"]);
+const describedString = (description: string) =>
+  v.pipe(v.string(), v.description(description));
 
-export const isFieldLookup = (value: unknown): value is FieldLookup =>
-  isRecordLike(value) &&
-  isLookupRegistry(value["registry"]) &&
-  Array.isArray(value["formats"]) &&
-  value["formats"].length >= 1 &&
-  value["formats"].length <= LOOKUP_FORMATS_MAX &&
-  value["formats"].every(isFieldLookupFormat);
+const fieldPathSchema = (description: string) =>
+  v.pipe(
+    v.string(),
+    v.check(isFieldPath, "Invalid field path"),
+    v.description(description),
+  );
 
-export const isFieldMeta = (value: unknown): value is FieldMeta => {
-  if (!isRecordLike(value) || typeof value["path"] !== "string") {
-    return false;
-  }
+export const fieldPartSchema = v.strictObject({
+  key: fieldPathSchema("Part key referenced by the field format"),
+  label: v.optional(describedString("Human-readable part label")),
+  inputType: v.pipe(
+    v.picklist(["text", "select"]),
+    v.description("Part input control type"),
+  ),
+  options: v.optional(
+    v.pipe(
+      v.array(v.string()),
+      v.description("Allowed values for a select part"),
+    ),
+  ),
+  pattern: v.optional(
+    describedString("Regex matched against the complete part value"),
+  ),
+});
 
-  // parts and format describe one composite value together: parts without a
-  // join format (or vice versa) cannot be rendered, so reject the half-shape.
-  if ((value["parts"] === undefined) !== (value["format"] === undefined)) {
-    return false;
-  }
+export const fieldLookupFormatSchema = v.strictObject({
+  key: v.pipe(
+    v.string(),
+    v.check(isLookupFormatKey, "Invalid lookup format key"),
+    v.description("Marker segment after the path: {{path.key}}"),
+  ),
+  template: v.pipe(
+    v.string(),
+    v.maxLength(LOOKUP_FORMAT_TEMPLATE_MAX_LENGTH),
+    v.description("[token]-substituted rendering of the registry hit"),
+  ),
+});
 
-  // A formula field's value is derived at fill time, never user-entered, so
-  // the other value-source mechanisms cannot coexist with it.
+export const fieldLookupSchema = v.pipe(
+  v.strictObject({
+    registry: v.pipe(
+      v.picklist(LOOKUP_REGISTRIES),
+      v.description("Business registry to query"),
+    ),
+    formats: v.pipe(
+      v.array(fieldLookupFormatSchema),
+      v.minLength(1),
+      v.maxLength(LOOKUP_FORMATS_MAX),
+      v.description(
+        "Named output renderings; the first is the default for the bare marker",
+      ),
+    ),
+  }),
+  v.description("Who-fills = business-registry lookup"),
+);
+
+export const fieldDateFormatSchema = v.pipe(
+  v.strictObject({
+    locale: v.pipe(
+      v.string(),
+      v.check(isPlausibleLocale, "Invalid BCP-47 locale"),
+      v.description("BCP-47 language tag, e.g. 'cs', 'de', 'pl'"),
+    ),
+    style: v.pipe(
+      v.picklist(DATE_FORMAT_STYLES),
+      v.description("Date rendering style"),
+    ),
+  }),
+  v.description("Locale-aware date rendering for a date field"),
+);
+
+export const fieldValidationSchema = v.pipe(
+  v.strictObject({
+    required: v.optional(
+      v.pipe(v.boolean(), v.description("Whether a value is required")),
+    ),
+    minLength: v.optional(
+      v.pipe(v.number(), v.finite(), v.description("Minimum string length")),
+    ),
+    maxLength: v.optional(
+      v.pipe(v.number(), v.finite(), v.description("Maximum string length")),
+    ),
+    min: v.optional(
+      v.pipe(v.number(), v.finite(), v.description("Minimum numeric value")),
+    ),
+    max: v.optional(
+      v.pipe(v.number(), v.finite(), v.description("Maximum numeric value")),
+    ),
+    pattern: v.optional(
+      describedString("Regex matched against the complete value"),
+    ),
+    minItems: v.optional(
+      v.pipe(v.number(), v.finite(), v.description("Minimum repeated items")),
+    ),
+    maxItems: v.optional(
+      v.pipe(v.number(), v.finite(), v.description("Maximum repeated items")),
+    ),
+  }),
+  v.description("Field-level value constraints"),
+);
+
+const hasCompatibleDerivedSources = ({
+  aiAdapt,
+  aiPrompt,
+  condition,
+  conditionAst,
+  formula,
+  lookup,
+  parts,
+  source,
+}: {
+  aiAdapt?: boolean;
+  aiPrompt?: string;
+  condition?: string;
+  conditionAst?: ConditionNode;
+  formula?: string;
+  lookup?: FieldLookup;
+  parts?: FieldPart[];
+  source?: FieldSource;
+}): boolean => {
+  const hasFormula = formula !== undefined;
+  const hasCondition = condition !== undefined || conditionAst !== undefined;
+  const hasSource = source !== undefined;
+
   if (
-    value["formula"] !== undefined &&
-    (value["aiPrompt"] !== undefined ||
-      value["aiAdapt"] !== undefined ||
-      value["lookup"] !== undefined ||
-      value["parts"] !== undefined)
+    hasFormula &&
+    (aiPrompt !== undefined ||
+      aiAdapt !== undefined ||
+      lookup !== undefined ||
+      parts !== undefined)
   ) {
     return false;
   }
-
-  // A condition field is a boolean derived by rule at fill time; like a
-  // formula it cannot also carry another value source. The rule is held either
-  // as a `{{#if}}` string (`condition`) or, for formula-bearing rules, as the
-  // AST (`conditionAst`) — either form makes this a condition field.
   if (
-    (value["condition"] !== undefined || value["conditionAst"] !== undefined) &&
-    (value["formula"] !== undefined ||
-      value["aiPrompt"] !== undefined ||
-      value["aiAdapt"] !== undefined ||
-      value["lookup"] !== undefined ||
-      value["parts"] !== undefined)
+    hasCondition &&
+    (hasFormula ||
+      aiPrompt !== undefined ||
+      aiAdapt !== undefined ||
+      lookup !== undefined ||
+      parts !== undefined)
   ) {
     return false;
   }
-
-  // A contact-sourced field's value is resolved from a contact record at fill
-  // time, never user-entered, so it cannot coexist with another value source.
-  if (
-    value["source"] !== undefined &&
-    (value["formula"] !== undefined ||
-      value["aiPrompt"] !== undefined ||
-      value["aiAdapt"] !== undefined ||
-      value["lookup"] !== undefined ||
-      value["parts"] !== undefined ||
-      value["condition"] !== undefined ||
-      value["conditionAst"] !== undefined)
-  ) {
-    return false;
-  }
-
   return (
-    (value["label"] === undefined || typeof value["label"] === "string") &&
-    (value["hint"] === undefined || typeof value["hint"] === "string") &&
-    (value["inputType"] === undefined || isInputType(value["inputType"])) &&
-    (value["options"] === undefined ||
-      (Array.isArray(value["options"]) &&
-        value["options"].every((option) => typeof option === "string"))) &&
-    (value["validation"] === undefined ||
-      isFieldValidation(value["validation"])) &&
-    (value["required"] === undefined ||
-      typeof value["required"] === "boolean") &&
-    (value["aiPrompt"] === undefined ||
-      typeof value["aiPrompt"] === "string") &&
-    (value["aiAdapt"] === undefined || typeof value["aiAdapt"] === "boolean") &&
-    (value["aiSeesDocument"] === undefined ||
-      typeof value["aiSeesDocument"] === "boolean") &&
-    (value["parts"] === undefined ||
-      (Array.isArray(value["parts"]) &&
-        value["parts"].length > 0 &&
-        value["parts"].every(isFieldPart))) &&
-    (value["format"] === undefined || typeof value["format"] === "string") &&
-    (value["optionsFrom"] === undefined ||
-      (typeof value["optionsFrom"] === "string" &&
-        isFieldPath(value["optionsFrom"]))) &&
-    (value["lookup"] === undefined || isFieldLookup(value["lookup"])) &&
-    (value["formula"] === undefined || typeof value["formula"] === "string") &&
-    (value["condition"] === undefined ||
-      typeof value["condition"] === "string") &&
-    (value["conditionAst"] === undefined ||
-      v.is(conditionNodeSchema, value["conditionAst"])) &&
-    (value["dateFormat"] === undefined ||
-      isFieldDateFormat(value["dateFormat"])) &&
-    (value["source"] === undefined || isFieldSource(value["source"]))
+    !hasSource ||
+    (!hasFormula &&
+      !hasCondition &&
+      aiPrompt === undefined &&
+      aiAdapt === undefined &&
+      lookup === undefined &&
+      parts === undefined)
   );
 };
+
+const fieldMetaObjectSchema = v.strictObject({
+  path: fieldPathSchema("Field path; must match a {{marker}} in the template"),
+  label: v.optional(describedString("Human-readable field label")),
+  hint: v.optional(
+    describedString("Short fill guidance shown to the person filling the field"),
+  ),
+  inputType: v.optional(
+    v.pipe(v.picklist(INPUT_TYPES), v.description("Input control type")),
+  ),
+  options: v.optional(
+    v.pipe(
+      v.array(v.string()),
+      v.description("Allowed values when inputType is 'select'"),
+    ),
+  ),
+  validation: v.optional(fieldValidationSchema),
+  required: v.optional(
+    v.pipe(v.boolean(), v.description("Whether a value is required")),
+  ),
+  aiPrompt: v.optional(
+    describedString(
+      "Who-fills = AI: instruction the model uses to draft the value at fill time",
+    ),
+  ),
+  aiAdapt: v.optional(
+    v.pipe(
+      v.boolean(),
+      v.description(
+        "Who-fills = Person+AI: the entered value is a stub AI rewrites per occurrence",
+      ),
+    ),
+  ),
+  aiSeesDocument: v.optional(
+    v.pipe(
+      v.boolean(),
+      v.description("Include the rendered document in this AI field's prompt"),
+    ),
+  ),
+  parts: v.optional(
+    v.pipe(
+      v.array(fieldPartSchema),
+      v.minLength(1),
+      v.description("Composite field parts joined by format"),
+    ),
+  ),
+  format: v.optional(
+    describedString(
+      "Join template over composite part keys, e.g. '{{title}} {{name}}'",
+    ),
+  ),
+  optionsFrom: v.optional(
+    fieldPathSchema(
+      "Dependent select: path of another field whose values supply the options",
+    ),
+  ),
+  lookup: v.optional(fieldLookupSchema),
+  source: v.optional(
+    v.pipe(
+      fieldSourceSchema,
+      v.description("Matter or contact data resolved server-side"),
+    ),
+  ),
+  formula: v.optional(
+    describedString("Arithmetic expression derived from other fields"),
+  ),
+  condition: v.optional(
+    describedString(
+      "Boolean rule expression referenced by a {{#if field_path}} marker",
+    ),
+  ),
+  conditionAst: v.optional(
+    v.pipe(
+      conditionNodeSchema,
+      v.description("Canonical condition AST for manifest round-tripping"),
+    ),
+  ),
+  dateFormat: v.optional(fieldDateFormatSchema),
+});
+
+const hasCompleteCompositeField = ({
+  format,
+  parts,
+}: {
+  format?: string;
+  parts?: FieldPart[];
+}): boolean => (parts === undefined) === (format === undefined);
+
+const FIELD_META_RULES = [
+  v.check(
+    hasCompleteCompositeField,
+    "parts and format must be provided together",
+  ),
+  v.check(
+    hasCompatibleDerivedSources,
+    "Derived field sources are mutually exclusive",
+  ),
+] as const;
+
+export const fieldMetaSchema = v.pipe(
+  fieldMetaObjectSchema,
+  ...FIELD_META_RULES,
+);
+
+/** Model-facing subset: conditionAst is the persisted canonical form, not an
+ * authoring input. This schema still shares every public field and rule with
+ * fieldMetaSchema through the same object schema and rule composer. */
+export const fieldMetaToolInputSchema = v.pipe(
+  v.omit(fieldMetaObjectSchema, ["conditionAst"]),
+  ...FIELD_META_RULES,
+);
+
+export const isFieldPart = (value: unknown): value is FieldPart =>
+  v.is(fieldPartSchema, value);
+
+export const isFieldDateFormat = (
+  value: unknown,
+): value is FieldDateFormat => v.is(fieldDateFormatSchema, value);
+
+export const isFieldLookup = (value: unknown): value is FieldLookup =>
+  v.is(fieldLookupSchema, value);
+
+export const isFieldMeta = (value: unknown): value is FieldMeta =>
+  v.is(fieldMetaSchema, value);
 
 const isRichRun = (value: unknown): value is RichRun =>
   isRecordLike(value) &&

--- a/apps/api/src/lib/docx/types.ts
+++ b/apps/api/src/lib/docx/types.ts
@@ -523,28 +523,39 @@ const hasCompleteCompositeField = ({
   parts?: FieldPart[];
 }): boolean => (parts === undefined) === (format === undefined);
 
-const FIELD_META_RULES = [
+export const fieldMetaSchema = v.pipe(
+  fieldMetaObjectSchema,
   v.check(
-    hasCompleteCompositeField,
+    (field: v.InferOutput<typeof fieldMetaObjectSchema>) =>
+      hasCompleteCompositeField(field),
     "parts and format must be provided together",
   ),
   v.check(
-    hasCompatibleDerivedSources,
+    (field: v.InferOutput<typeof fieldMetaObjectSchema>) =>
+      hasCompatibleDerivedSources(field),
     "Derived field sources are mutually exclusive",
   ),
-] as const;
-
-export const fieldMetaSchema = v.pipe(
-  fieldMetaObjectSchema,
-  ...FIELD_META_RULES,
 );
 
 /** Model-facing subset: conditionAst is the persisted canonical form, not an
- * authoring input. This schema still shares every public field and rule with
- * fieldMetaSchema through the same object schema and rule composer. */
+ * authoring input. This schema derives its public fields from the persisted
+ * object schema and applies the same named invariant predicates. */
+const fieldMetaToolInputObjectSchema = v.omit(fieldMetaObjectSchema, [
+  "conditionAst",
+]);
+
 export const fieldMetaToolInputSchema = v.pipe(
-  v.omit(fieldMetaObjectSchema, ["conditionAst"]),
-  ...FIELD_META_RULES,
+  fieldMetaToolInputObjectSchema,
+  v.check(
+    (field: v.InferOutput<typeof fieldMetaToolInputObjectSchema>) =>
+      hasCompleteCompositeField(field),
+    "parts and format must be provided together",
+  ),
+  v.check(
+    (field: v.InferOutput<typeof fieldMetaToolInputObjectSchema>) =>
+      hasCompatibleDerivedSources(field),
+    "Derived field sources are mutually exclusive",
+  ),
 );
 
 export const isFieldPart = (value: unknown): value is FieldPart =>

--- a/apps/api/src/lib/docx/types.ts
+++ b/apps/api/src/lib/docx/types.ts
@@ -413,15 +413,27 @@ const activeDerivedSourceModes = ({
   source,
 }: DerivedSourceFields): DerivedSourceMode[] => {
   const modes: DerivedSourceMode[] = [];
-  if (aiAdapt === true) modes.push("ai-adapt");
-  if (aiPrompt !== undefined) modes.push("ai-prompt");
+  if (aiAdapt === true) {
+    modes.push("ai-adapt");
+  }
+  if (aiPrompt !== undefined) {
+    modes.push("ai-prompt");
+  }
   if (condition !== undefined || conditionAst !== undefined) {
     modes.push("condition");
   }
-  if (formula !== undefined) modes.push("formula");
-  if (lookup !== undefined) modes.push("lookup");
-  if (parts !== undefined) modes.push("parts");
-  if (source !== undefined) modes.push("source");
+  if (formula !== undefined) {
+    modes.push("formula");
+  }
+  if (lookup !== undefined) {
+    modes.push("lookup");
+  }
+  if (parts !== undefined) {
+    modes.push("parts");
+  }
+  if (source !== undefined) {
+    modes.push("source");
+  }
   return modes;
 };
 

--- a/apps/api/src/lib/docx/types.ts
+++ b/apps/api/src/lib/docx/types.ts
@@ -250,8 +250,7 @@ export type FieldLookup = v.InferOutput<typeof fieldLookupSchema>;
 
 export const isFieldLookupFormat = (
   value: unknown,
-): value is FieldLookupFormat =>
-  v.is(fieldLookupFormatSchema, value);
+): value is FieldLookupFormat => v.is(fieldLookupFormatSchema, value);
 
 export type FieldValidation = v.InferOutput<typeof fieldValidationSchema>;
 
@@ -433,7 +432,9 @@ const fieldMetaObjectSchema = v.strictObject({
   path: fieldPathSchema("Field path; must match a {{marker}} in the template"),
   label: v.optional(describedString("Human-readable field label")),
   hint: v.optional(
-    describedString("Short fill guidance shown to the person filling the field"),
+    describedString(
+      "Short fill guidance shown to the person filling the field",
+    ),
   ),
   inputType: v.optional(
     v.pipe(v.picklist(INPUT_TYPES), v.description("Input control type")),
@@ -554,9 +555,8 @@ export const fieldMetaToolInputSchema = v.pipe(
 export const isFieldPart = (value: unknown): value is FieldPart =>
   v.is(fieldPartSchema, value);
 
-export const isFieldDateFormat = (
-  value: unknown,
-): value is FieldDateFormat => v.is(fieldDateFormatSchema, value);
+export const isFieldDateFormat = (value: unknown): value is FieldDateFormat =>
+  v.is(fieldDateFormatSchema, value);
 
 export const isFieldLookup = (value: unknown): value is FieldLookup =>
   v.is(fieldLookupSchema, value);

--- a/apps/api/src/lib/docx/types.ts
+++ b/apps/api/src/lib/docx/types.ts
@@ -393,14 +393,14 @@ const hasCompatibleDerivedSources = ({
   parts,
   source,
 }: {
-  aiAdapt?: boolean;
-  aiPrompt?: string;
-  condition?: string;
-  conditionAst?: ConditionNode;
-  formula?: string;
-  lookup?: FieldLookup;
-  parts?: FieldPart[];
-  source?: FieldSource;
+  aiAdapt?: boolean | undefined;
+  aiPrompt?: string | undefined;
+  condition?: string | undefined;
+  conditionAst?: ConditionNode | undefined;
+  formula?: string | undefined;
+  lookup?: FieldLookup | undefined;
+  parts?: FieldPart[] | undefined;
+  source?: FieldSource | undefined;
 }): boolean => {
   const hasFormula = formula !== undefined;
   const hasCondition = condition !== undefined || conditionAst !== undefined;
@@ -519,8 +519,8 @@ const hasCompleteCompositeField = ({
   format,
   parts,
 }: {
-  format?: string;
-  parts?: FieldPart[];
+  format?: string | undefined;
+  parts?: FieldPart[] | undefined;
 }): boolean => (parts === undefined) === (format === undefined);
 
 export const fieldMetaSchema = v.pipe(

--- a/apps/api/src/lib/docx/types.ts
+++ b/apps/api/src/lib/docx/types.ts
@@ -383,16 +383,16 @@ export const fieldValidationSchema = v.pipe(
   v.description("Field-level value constraints"),
 );
 
-const hasCompatibleDerivedSources = ({
-  aiAdapt,
-  aiPrompt,
-  condition,
-  conditionAst,
-  formula,
-  lookup,
-  parts,
-  source,
-}: {
+type DerivedSourceMode =
+  | "ai-adapt"
+  | "ai-prompt"
+  | "condition"
+  | "formula"
+  | "lookup"
+  | "parts"
+  | "source";
+
+type DerivedSourceFields = {
   aiAdapt?: boolean | undefined;
   aiPrompt?: string | undefined;
   condition?: string | undefined;
@@ -401,40 +401,33 @@ const hasCompatibleDerivedSources = ({
   lookup?: FieldLookup | undefined;
   parts?: FieldPart[] | undefined;
   source?: FieldSource | undefined;
-}): boolean => {
-  const hasFormula = formula !== undefined;
-  const hasCondition = condition !== undefined || conditionAst !== undefined;
-  const hasSource = source !== undefined;
-
-  if (
-    hasFormula &&
-    (aiPrompt !== undefined ||
-      aiAdapt !== undefined ||
-      lookup !== undefined ||
-      parts !== undefined)
-  ) {
-    return false;
-  }
-  if (
-    hasCondition &&
-    (hasFormula ||
-      aiPrompt !== undefined ||
-      aiAdapt !== undefined ||
-      lookup !== undefined ||
-      parts !== undefined)
-  ) {
-    return false;
-  }
-  return (
-    !hasSource ||
-    (!hasFormula &&
-      !hasCondition &&
-      aiPrompt === undefined &&
-      aiAdapt === undefined &&
-      lookup === undefined &&
-      parts === undefined)
-  );
 };
+
+const activeDerivedSourceModes = ({
+  aiAdapt,
+  aiPrompt,
+  condition,
+  conditionAst,
+  formula,
+  lookup,
+  parts,
+  source,
+}: DerivedSourceFields): DerivedSourceMode[] => {
+  const modes: DerivedSourceMode[] = [];
+  if (aiAdapt === true) modes.push("ai-adapt");
+  if (aiPrompt !== undefined) modes.push("ai-prompt");
+  if (condition !== undefined || conditionAst !== undefined) {
+    modes.push("condition");
+  }
+  if (formula !== undefined) modes.push("formula");
+  if (lookup !== undefined) modes.push("lookup");
+  if (parts !== undefined) modes.push("parts");
+  if (source !== undefined) modes.push("source");
+  return modes;
+};
+
+const hasCompatibleDerivedSources = (fields: DerivedSourceFields): boolean =>
+  activeDerivedSourceModes(fields).length <= 1;
 
 const fieldMetaObjectSchema = v.strictObject({
   path: fieldPathSchema("Field path; must match a {{marker}} in the template"),

--- a/apps/api/src/lib/files/office-evidence-types.ts
+++ b/apps/api/src/lib/files/office-evidence-types.ts
@@ -7,6 +7,7 @@ import {
   OFFICE_EVIDENCE_LIMITS,
   OFFICE_EVIDENCE_STATUS,
   OFFICE_EVIDENCE_UNAVAILABLE_CODE,
+  OFFICE_EVIDENCE_UNAVAILABLE_CODES,
   type OfficeEvidenceFormat,
   type OfficeEvidenceUnavailableCode,
 } from "@/api/lib/files/office-evidence-domain";
@@ -112,10 +113,7 @@ export const officeEvidencePayloadSchema = v.variant("format", [
 ]);
 
 const unavailableResultSchema = v.object({
-  errorCode: v.union([
-    v.literal(OFFICE_EVIDENCE_UNAVAILABLE_CODE.parseFailed),
-    v.literal(OFFICE_EVIDENCE_UNAVAILABLE_CODE.resourceLimit),
-  ]),
+  errorCode: v.picklist(OFFICE_EVIDENCE_UNAVAILABLE_CODES),
   status: v.literal(OFFICE_EVIDENCE_STATUS.unavailable),
 });
 

--- a/apps/api/src/lib/mcp-upstream/oauth.ts
+++ b/apps/api/src/lib/mcp-upstream/oauth.ts
@@ -53,26 +53,18 @@ const authorizationServerMetadataSchema = v.looseObject({
   client_id_metadata_document_supported: v.optional(v.boolean()),
 });
 
-const dynamicClientRegistrationResponseSchema = v.intersect([
-  v.object({
-    client_id: v.string(),
-  }),
-  v.looseObject({
-    client_secret: v.optional(v.string()),
-  }),
-]);
+const dynamicClientRegistrationResponseSchema = v.looseObject({
+  client_id: v.string(),
+  client_secret: v.optional(v.string()),
+});
 
-const tokenResponseSchema = v.intersect([
-  v.object({
-    access_token: v.string(),
-  }),
-  v.looseObject({
-    refresh_token: v.optional(v.string()),
-    token_type: v.optional(v.string()),
-    expires_in: v.optional(v.number()),
-    scope: v.optional(v.string()),
-  }),
-]);
+const tokenResponseSchema = v.looseObject({
+  access_token: v.string(),
+  refresh_token: v.optional(v.string()),
+  token_type: v.optional(v.string()),
+  expires_in: v.optional(v.number()),
+  scope: v.optional(v.string()),
+});
 
 export type ProtectedResourceMetadata = v.InferOutput<
   typeof protectedResourceMetadataSchema

--- a/apps/api/src/lib/template-binding/binding-sources.ts
+++ b/apps/api/src/lib/template-binding/binding-sources.ts
@@ -116,6 +116,11 @@ export const fieldSourceSchema = v.variant("kind", [
   }),
 ]);
 
+/** Provider-portable projection of the same discriminated branches. Runtime
+ * parsing uses the indexed variant above; tool JSON Schema uses `anyOf`
+ * because model providers do not share support for `oneOf`. */
+export const fieldSourceToolInputSchema = v.union(fieldSourceSchema.options);
+
 export type FieldSource = v.InferOutput<typeof fieldSourceSchema>;
 
 /**

--- a/apps/api/src/lib/template-binding/binding-sources.ts
+++ b/apps/api/src/lib/template-binding/binding-sources.ts
@@ -116,10 +116,32 @@ export const fieldSourceSchema = v.variant("kind", [
   }),
 ]);
 
+const toFieldSourceToolInputOption = <
+  const TKind extends BindingSourceKind,
+  const TEntries extends v.ObjectEntries & {
+    kind: v.LiteralSchema<TKind, undefined>;
+  },
+>(
+  option: v.StrictObjectSchema<TEntries, undefined>,
+) =>
+  v.strictObject({
+    ...option.entries,
+    kind: v.picklist([option.entries.kind.literal]),
+  });
+
+const [contactSource, partySource, matterSource, attorneySource, firmSource] =
+  fieldSourceSchema.options;
+
 /** Provider-portable projection of the same discriminated branches. Runtime
- * parsing uses the indexed variant above; tool JSON Schema uses `anyOf`
- * because model providers do not share support for `oneOf`. */
-export const fieldSourceToolInputSchema = v.union(fieldSourceSchema.options);
+ * parsing uses the indexed variant above; tool JSON Schema uses `anyOf` plus
+ * single-value enums because providers do not share `oneOf`/`const` support. */
+export const fieldSourceToolInputSchema = v.union([
+  toFieldSourceToolInputOption(contactSource),
+  toFieldSourceToolInputOption(partySource),
+  toFieldSourceToolInputOption(matterSource),
+  toFieldSourceToolInputOption(attorneySource),
+  toFieldSourceToolInputOption(firmSource),
+]);
 
 export type FieldSource = v.InferOutput<typeof fieldSourceSchema>;
 

--- a/apps/api/src/lib/template-binding/binding-sources.ts
+++ b/apps/api/src/lib/template-binding/binding-sources.ts
@@ -12,6 +12,8 @@
  * display label, so renaming a label never breaks a saved binding.
  */
 
+import * as v from "valibot";
+
 import {
   WORKSPACE_CONTACT_ROLES,
   type WorkspaceContactRole,
@@ -79,25 +81,42 @@ export type BindingSourceKind = (typeof BINDING_SOURCE_KINDS)[number];
  * A contact/matter data binding on a template field. Discriminated on `kind`;
  * `field` is the stable key within the resolved record (see module docs).
  */
-export type FieldSource =
-  | { kind: "contact"; field: string }
-  | { kind: "party"; role: WorkspaceContactRole; field: string }
-  | { kind: "matter"; field: string }
-  | { kind: "attorney"; ref: AttorneyRef; field: string }
-  | { kind: "firm"; field: string };
-
-const isRecordLike = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const isMember = (members: readonly string[], value: unknown): boolean =>
-  typeof value === "string" && members.includes(value);
+const workspaceContactRoleSchema = v.picklist(WORKSPACE_CONTACT_ROLES);
+const attorneyRefSchema = v.picklist(ATTORNEY_REFS);
 
 export const isWorkspaceContactRole = (
   value: unknown,
-): value is WorkspaceContactRole => isMember(WORKSPACE_CONTACT_ROLES, value);
+): value is WorkspaceContactRole => v.is(workspaceContactRoleSchema, value);
 
 export const isAttorneyRef = (value: unknown): value is AttorneyRef =>
-  isMember(ATTORNEY_REFS, value);
+  v.is(attorneyRefSchema, value);
+
+export const fieldSourceSchema = v.variant("kind", [
+  v.strictObject({
+    kind: v.literal("contact"),
+    field: v.picklist(CONTACT_FIELDS),
+  }),
+  v.strictObject({
+    kind: v.literal("party"),
+    role: workspaceContactRoleSchema,
+    field: v.picklist(CONTACT_FIELDS),
+  }),
+  v.strictObject({
+    kind: v.literal("matter"),
+    field: v.picklist(MATTER_FIELDS),
+  }),
+  v.strictObject({
+    kind: v.literal("attorney"),
+    ref: attorneyRefSchema,
+    field: v.picklist(USER_FIELDS),
+  }),
+  v.strictObject({
+    kind: v.literal("firm"),
+    field: v.picklist(FIRM_FIELDS),
+  }),
+]);
+
+export type FieldSource = v.InferOutput<typeof fieldSourceSchema>;
 
 /**
  * Validate a {@link FieldSource}: a known `kind`, a `field` key allowed for
@@ -105,27 +124,5 @@ export const isAttorneyRef = (value: unknown): value is AttorneyRef =>
  * are checked against the per-kind allow-lists; when the registry lands this
  * widens to also accept property ids.
  */
-export const isFieldSource = (value: unknown): value is FieldSource => {
-  if (!isRecordLike(value) || typeof value["field"] !== "string") {
-    return false;
-  }
-  switch (value["kind"]) {
-    case "contact":
-      return isMember(CONTACT_FIELDS, value["field"]);
-    case "party":
-      return (
-        isWorkspaceContactRole(value["role"]) &&
-        isMember(CONTACT_FIELDS, value["field"])
-      );
-    case "matter":
-      return isMember(MATTER_FIELDS, value["field"]);
-    case "attorney":
-      return (
-        isAttorneyRef(value["ref"]) && isMember(USER_FIELDS, value["field"])
-      );
-    case "firm":
-      return isMember(FIRM_FIELDS, value["field"]);
-    default:
-      return false;
-  }
-};
+export const isFieldSource = (value: unknown): value is FieldSource =>
+  v.is(fieldSourceSchema, value);

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -722,29 +722,34 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     },
     "inputSchema": {
       "type": "object",
+      "required": [],
+      "additionalProperties": false,
       "properties": {
         "template_id": {
           "type": "string",
-          "description": "Existing template id to configure its fields; omit (with docx_base64) to create a new template"
+          "minLength": 1,
+          "description": "Existing template id to configure; omit when creating a template"
         },
         "name": {
           "type": "string",
-          "description": "Template display name; required when creating",
-          "maxLength": 256
+          "minLength": 1,
+          "maxLength": 256,
+          "description": "Template display name; required when creating"
         },
         "docx_base64": {
           "type": "string",
-          "description": "Base64-encoded DOCX file bytes (Office Open XML, max ~10 MB decoded); required when creating, omit when configuring"
+          "minLength": 1,
+          "maxLength": 69905068,
+          "description": "Base64-encoded DOCX bytes; required when creating, omit when configuring"
         },
         "fields": {
           "type": "array",
-          "description": "Field configuration overlay, one entry per field to configure. Each entry's 'path' must match a {{marker}} in the template. Configurable: label, hint, inputType, required, options, optionsFrom (dependent select), date format, composite parts + format, and who-fills the field — a person (default), AI (aiPrompt), Person+AI (aiAdapt), a formula, or a company-register lookup (registry + named output formats). formula is mutually exclusive with aiPrompt/aiAdapt/lookup/parts.",
           "items": {
             "type": "object",
             "properties": {
               "path": {
                 "type": "string",
-                "description": "Field path — must match a {{marker}} in the template"
+                "description": "Field path; must match a {{marker}} in the template"
               },
               "label": {
                 "type": "string",
@@ -755,7 +760,6 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                 "description": "Short fill guidance shown to the person filling the field"
               },
               "inputType": {
-                "type": "string",
                 "enum": [
                   "text",
                   "number",
@@ -763,11 +767,8 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                   "date",
                   "select"
                 ],
+                "type": "string",
                 "description": "Input control type"
-              },
-              "required": {
-                "type": "boolean",
-                "description": "Whether a value is required"
               },
               "options": {
                 "type": "array",
@@ -776,9 +777,49 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                 },
                 "description": "Allowed values when inputType is 'select'"
               },
-              "optionsFrom": {
-                "type": "string",
-                "description": "Dependent select: path of another field whose value(s) supply the options"
+              "validation": {
+                "type": "object",
+                "properties": {
+                  "required": {
+                    "type": "boolean",
+                    "description": "Whether a value is required"
+                  },
+                  "minLength": {
+                    "type": "number",
+                    "description": "Minimum string length"
+                  },
+                  "maxLength": {
+                    "type": "number",
+                    "description": "Maximum string length"
+                  },
+                  "min": {
+                    "type": "number",
+                    "description": "Minimum numeric value"
+                  },
+                  "max": {
+                    "type": "number",
+                    "description": "Maximum numeric value"
+                  },
+                  "pattern": {
+                    "type": "string",
+                    "description": "Regex matched against the complete value"
+                  },
+                  "minItems": {
+                    "type": "number",
+                    "description": "Minimum repeated items"
+                  },
+                  "maxItems": {
+                    "type": "number",
+                    "description": "Maximum repeated items"
+                  }
+                },
+                "required": [],
+                "additionalProperties": false,
+                "description": "Field-level value constraints"
+              },
+              "required": {
+                "type": "boolean",
+                "description": "Whether a value is required"
               },
               "aiPrompt": {
                 "type": "string",
@@ -788,61 +829,82 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                 "type": "boolean",
                 "description": "Who-fills = Person+AI: the entered value is a stub AI rewrites per occurrence"
               },
-              "formula": {
-                "type": "string",
-                "description": "Who-fills = formula: arithmetic expression over other fields, derived at fill time"
-              },
-              "condition": {
-                "type": "string",
-                "description": "Boolean field derived by rule: a condition expression (e.g. client_type == \\"company\\"), evaluated at fill time. A {{#if field_path}} marker references it by path. Mutually exclusive with formula/aiPrompt/aiAdapt/lookup/parts."
+              "aiSeesDocument": {
+                "type": "boolean",
+                "description": "Include the rendered document in this AI field's prompt"
               },
               "parts": {
                 "type": "array",
-                "description": "Composite field parts (joined by 'format')",
                 "items": {
                   "type": "object",
-                  "additionalProperties": true
-                }
+                  "properties": {
+                    "key": {
+                      "type": "string",
+                      "description": "Part key referenced by the field format"
+                    },
+                    "label": {
+                      "type": "string",
+                      "description": "Human-readable part label"
+                    },
+                    "inputType": {
+                      "enum": [
+                        "text",
+                        "select"
+                      ],
+                      "type": "string",
+                      "description": "Part input control type"
+                    },
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Allowed values for a select part"
+                    },
+                    "pattern": {
+                      "type": "string",
+                      "description": "Regex matched against the complete part value"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "inputType"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1,
+                "description": "Composite field parts joined by format"
               },
               "format": {
                 "type": "string",
                 "description": "Join template over composite part keys, e.g. '{{title}} {{name}}'"
               },
-              "dateFormat": {
-                "type": "object",
-                "description": "Locale-aware date rendering for a date field",
-                "properties": {
-                  "locale": {
-                    "type": "string",
-                    "description": "BCP-47 language tag, e.g. 'cs', 'de', 'pl'"
-                  },
-                  "style": {
-                    "type": "string",
-                    "enum": [
-                      "long",
-                      "medium",
-                      "short",
-                      "iso"
-                    ],
-                    "description": "Date style"
-                  }
-                },
-                "required": [
-                  "locale",
-                  "style"
-                ]
+              "optionsFrom": {
+                "type": "string",
+                "description": "Dependent select: path of another field whose values supply the options"
               },
               "lookup": {
                 "type": "object",
-                "description": "Who-fills = company-register lookup",
                 "properties": {
                   "registry": {
+                    "enum": [
+                      "ares",
+                      "brreg",
+                      "companies-house",
+                      "denue",
+                      "edgar",
+                      "gcis",
+                      "krs",
+                      "orsr",
+                      "prh",
+                      "recherche-entreprises",
+                      "vies"
+                    ],
                     "type": "string",
-                    "description": "Registry slug, e.g. 'krs'"
+                    "description": "Business registry to query"
                   },
                   "formats": {
                     "type": "array",
-                    "description": "Named output renderings; the first is the default for the bare {{marker}}",
                     "items": {
                       "type": "object",
                       "properties": {
@@ -852,27 +914,241 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                         },
                         "template": {
                           "type": "string",
+                          "maxLength": 2000,
                           "description": "[token]-substituted rendering of the registry hit"
                         }
                       },
                       "required": [
                         "key",
                         "template"
-                      ]
-                    }
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "maxItems": 10,
+                    "description": "Named output renderings; the first is the default for the bare marker"
                   }
                 },
                 "required": [
                   "registry",
                   "formats"
-                ]
+                ],
+                "additionalProperties": false,
+                "description": "Who-fills = business-registry lookup"
+              },
+              "source": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "enum": [
+                          "contact"
+                        ],
+                        "type": "string"
+                      },
+                      "field": {
+                        "enum": [
+                          "displayName",
+                          "firstName",
+                          "lastName",
+                          "organizationName",
+                          "email",
+                          "phone",
+                          "address",
+                          "addressStreet",
+                          "addressCity",
+                          "addressPostalCode",
+                          "addressCountry",
+                          "registrationNumber",
+                          "taxId",
+                          "iban",
+                          "bic",
+                          "dataBox"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "field"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "enum": [
+                          "party"
+                        ],
+                        "type": "string"
+                      },
+                      "role": {
+                        "enum": [
+                          "opposing_party",
+                          "opposing_counsel",
+                          "co_counsel",
+                          "witness",
+                          "expert_witness",
+                          "third_party",
+                          "judge",
+                          "mediator",
+                          "other"
+                        ],
+                        "type": "string"
+                      },
+                      "field": {
+                        "enum": [
+                          "displayName",
+                          "firstName",
+                          "lastName",
+                          "organizationName",
+                          "email",
+                          "phone",
+                          "address",
+                          "addressStreet",
+                          "addressCity",
+                          "addressPostalCode",
+                          "addressCountry",
+                          "registrationNumber",
+                          "taxId",
+                          "iban",
+                          "bic",
+                          "dataBox"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "role",
+                      "field"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "enum": [
+                          "matter"
+                        ],
+                        "type": "string"
+                      },
+                      "field": {
+                        "enum": [
+                          "name",
+                          "reference",
+                          "billingReference",
+                          "status"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "field"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "enum": [
+                          "attorney"
+                        ],
+                        "type": "string"
+                      },
+                      "ref": {
+                        "enum": [
+                          "responsible",
+                          "originating",
+                          "lead"
+                        ],
+                        "type": "string"
+                      },
+                      "field": {
+                        "enum": [
+                          "name",
+                          "email"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "ref",
+                      "field"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "enum": [
+                          "firm"
+                        ],
+                        "type": "string"
+                      },
+                      "field": {
+                        "enum": [
+                          "name"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "field"
+                    ],
+                    "additionalProperties": false
+                  }
+                ],
+                "description": "Matter or contact data resolved server-side"
+              },
+              "formula": {
+                "type": "string",
+                "description": "Arithmetic expression derived from other fields"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Boolean rule expression referenced by a {{#if field_path}} marker"
+              },
+              "dateFormat": {
+                "type": "object",
+                "properties": {
+                  "locale": {
+                    "type": "string",
+                    "description": "BCP-47 language tag, e.g. 'cs', 'de', 'pl'"
+                  },
+                  "style": {
+                    "enum": [
+                      "long",
+                      "medium",
+                      "short",
+                      "iso"
+                    ],
+                    "type": "string",
+                    "description": "Date rendering style"
+                  }
+                },
+                "required": [
+                  "locale",
+                  "style"
+                ],
+                "additionalProperties": false,
+                "description": "Locale-aware date rendering for a date field"
               }
             },
             "required": [
               "path"
             ],
             "additionalProperties": false
-          }
+          },
+          "description": "Strict field configuration overlay; each path must match a template marker"
         }
       }
     }
@@ -1039,44 +1315,44 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "openWorldHint": true
     },
     "inputSchema": {
-      "additionalProperties": false,
       "type": "object",
       "required": [
         "entity_id",
         "file"
       ],
+      "additionalProperties": false,
       "properties": {
         "entity_id": {
+          "type": "string",
           "minLength": 1,
-          "description": "Existing document entity ID that will receive a new version",
-          "type": "string"
+          "description": "Existing document entity ID that will receive a new version"
         },
         "file": {
-          "additionalProperties": false,
-          "description": "File reference supplied by a compatible MCP host",
           "type": "object",
+          "properties": {
+            "download_url": {
+              "type": "string",
+              "description": "Temporary URL supplied by the host for downloading the file"
+            },
+            "file_id": {
+              "type": "string",
+              "description": "Host-assigned identifier for the attached file"
+            },
+            "mime_type": {
+              "type": "string",
+              "description": "MIME type reported by the host"
+            },
+            "file_name": {
+              "type": "string",
+              "description": "Original file name reported by the host"
+            }
+          },
           "required": [
             "download_url",
             "file_id"
           ],
-          "properties": {
-            "download_url": {
-              "description": "Temporary URL supplied by the host for downloading the file",
-              "type": "string"
-            },
-            "file_id": {
-              "description": "Host-assigned identifier for the attached file",
-              "type": "string"
-            },
-            "mime_type": {
-              "description": "MIME type reported by the host",
-              "type": "string"
-            },
-            "file_name": {
-              "description": "Original file name reported by the host",
-              "type": "string"
-            }
-          }
+          "additionalProperties": false,
+          "description": "File reference supplied by a compatible MCP host"
         }
       }
     }
@@ -1092,16 +1368,16 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
       "openWorldHint": true
     },
     "inputSchema": {
-      "additionalProperties": false,
       "type": "object",
       "required": [
         "entity_id"
       ],
+      "additionalProperties": false,
       "properties": {
         "entity_id": {
+          "type": "string",
           "minLength": 1,
-          "description": "Existing document entity ID that will receive a new version",
-          "type": "string"
+          "description": "Existing document entity ID that will receive a new version"
         }
       }
     }
@@ -2302,47 +2578,55 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     },
     "inputSchema": {
       "type": "object",
+      "required": [],
+      "additionalProperties": false,
       "properties": {
         "workspace_id": {
           "type": "string",
+          "minLength": 1,
           "description": "Only entries scoped to this matter/workspace"
         },
         "action": {
           "type": "string",
+          "minLength": 1,
           "description": "Only entries with this audit action"
         },
         "resource_type": {
           "type": "string",
+          "minLength": 1,
           "description": "Only entries about this resource type"
         },
         "resource_id": {
           "type": "string",
+          "minLength": 1,
           "description": "Only entries about this resource id; requires resource_type"
         },
         "user_id": {
           "type": "string",
+          "minLength": 1,
           "description": "Only entries whose actor is this user"
         },
         "from": {
           "type": "string",
-          "description": "Only entries created on or after this ISO date-time",
-          "maxLength": 40
+          "maxLength": 40,
+          "description": "Only entries created on or after this ISO date-time"
         },
         "to": {
           "type": "string",
-          "description": "Only entries created on or before this ISO date-time",
-          "maxLength": 40
+          "maxLength": 40,
+          "description": "Only entries created on or before this ISO date-time"
         },
         "limit": {
           "type": "integer",
-          "description": "Max entries to return",
           "minimum": 1,
-          "maximum": 200
+          "maximum": 200,
+          "description": "Max entries to return"
         },
         "cursor": {
           "type": "string",
-          "description": "Opaque cursor from a previous list_audit_log call to fetch the next page",
-          "maxLength": 512
+          "minLength": 1,
+          "maxLength": 512,
+          "description": "Opaque cursor from a previous list_audit_log call to fetch the next page"
         }
       }
     }

--- a/apps/api/src/mcp/billing-tools.ts
+++ b/apps/api/src/mcp/billing-tools.ts
@@ -64,6 +64,7 @@ import {
   errorResult,
   internalFailureResult,
   intProp,
+  ISO_DATE_SCHEMA,
   MAX_LIST_LIMIT,
   notFoundResult,
   nullableStringProp,
@@ -80,8 +81,6 @@ type BillingToolName =
   | "resolve_rate"
   | "list_invoices"
   | "get_usage";
-
-const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/u;
 
 // --- list_time_entries text-field specs ---------------------------------
 
@@ -680,8 +679,8 @@ const listTimeEntriesArgsSchema = v.pipe(
     time_entry_id: v.optional(v.pipe(v.string(), v.minLength(1))),
     entity_id: v.optional(v.pipe(v.string(), v.minLength(1))),
     user_id: v.optional(v.pipe(v.string(), v.minLength(1))),
-    date_from: v.optional(v.pipe(v.string(), v.regex(ISO_DATE))),
-    date_to: v.optional(v.pipe(v.string(), v.regex(ISO_DATE))),
+    date_from: v.optional(ISO_DATE_SCHEMA),
+    date_to: v.optional(ISO_DATE_SCHEMA),
     status: v.optional(v.picklist(TIME_ENTRY_STATUSES)),
     limit: v.optional(
       v.pipe(
@@ -955,7 +954,7 @@ const saveTimeEntryArgsSchema = v.pipe(
     time_entry_id: v.optional(v.pipe(v.string(), v.minLength(1))),
     matter_id: v.optional(v.pipe(v.string(), v.minLength(1))),
     entity_id: v.optional(v.nullable(v.pipe(v.string(), v.minLength(1)))),
-    date_worked: v.optional(v.pipe(v.string(), v.regex(ISO_DATE))),
+    date_worked: v.optional(ISO_DATE_SCHEMA),
     timezone_id: v.optional(
       v.pipe(v.string(), v.minLength(1), v.maxLength(64)),
     ),
@@ -1239,7 +1238,7 @@ const handleDeleteTimeEntryTool: TypedMcpToolHandler<
 const resolveRateArgsSchema = v.strictObject({
   matter_id: v.pipe(v.string(), v.minLength(1)),
   user_id: v.pipe(v.string(), v.minLength(1)),
-  date: v.pipe(v.string(), v.regex(ISO_DATE)),
+  date: ISO_DATE_SCHEMA,
 });
 
 const handleResolveRateTool: McpToolHandler = async ({ args, context }) => {

--- a/apps/api/src/mcp/billing-tools.ts
+++ b/apps/api/src/mcp/billing-tools.ts
@@ -17,10 +17,13 @@ import { resolveRate } from "@/api/lib/billing-rates";
 import type { SafeId } from "@/api/lib/branded-types";
 import type {
   DELETE_TIME_ENTRY_PROJECTION,
+  GET_USAGE_PROJECTION,
   LIST_INVOICES_DETAIL_PROJECTION,
   LIST_INVOICES_LIST_PROJECTION,
+  LIST_INVOICES_PROJECTION,
   LIST_TIME_ENTRIES_DETAIL_PROJECTION,
   LIST_TIME_ENTRIES_LIST_PROJECTION,
+  LIST_TIME_ENTRIES_PROJECTION,
   RESOLVE_RATE_PROJECTION,
   SAVE_TIME_ENTRY_PROJECTION,
 } from "@/api/lib/chat/projections";
@@ -49,6 +52,7 @@ import type {
   McpTextFieldSpec,
   McpToolDefinition,
   McpToolHandler,
+  TypedMcpToolHandler,
 } from "@/api/mcp/tool-types";
 import { defineMcpToolSet } from "@/api/mcp/tool-types";
 import {
@@ -733,7 +737,9 @@ const decodeTimeEntryPageCursor = (
   return { dateWorked, id: brandPersistedTimeEntryId(id) };
 };
 
-const handleListTimeEntriesTool: McpToolHandler = async ({ args, context }) => {
+const handleListTimeEntriesTool: TypedMcpToolHandler<
+  v.InferInput<typeof LIST_TIME_ENTRIES_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ timeEntry: ["read"] }).success) {
     return errorResult("Forbidden");
   }
@@ -1035,7 +1041,9 @@ const saveTimeEntryArgsSchema = v.pipe(
   ),
 );
 
-const handleSaveTimeEntryTool: McpToolHandler = async ({ args, context }) => {
+const handleSaveTimeEntryTool: TypedMcpToolHandler<
+  v.InferInput<typeof SAVE_TIME_ENTRY_PROJECTION>
+> = async ({ args, context }) => {
   const parsed = v.safeParse(saveTimeEntryArgsSchema, args);
   if (!parsed.success) {
     return validationErrorResult({
@@ -1181,7 +1189,9 @@ const deleteTimeEntryArgsSchema = v.strictObject({
   confirm: v.optional(v.boolean()),
 });
 
-const handleDeleteTimeEntryTool: McpToolHandler = async ({ args, context }) => {
+const handleDeleteTimeEntryTool: TypedMcpToolHandler<
+  v.InferInput<typeof DELETE_TIME_ENTRY_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ timeEntry: ["delete"] }).success) {
     return errorResult("Forbidden");
   }
@@ -1371,7 +1381,9 @@ const readInvoiceDetail = async ({
     }),
   );
 
-const handleListInvoicesTool: McpToolHandler = async ({ args, context }) => {
+const handleListInvoicesTool: TypedMcpToolHandler<
+  v.InferInput<typeof LIST_INVOICES_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ workspace: ["read"] }).success) {
     return errorResult("Forbidden");
   }
@@ -1550,7 +1562,9 @@ const handleListInvoicesTool: McpToolHandler = async ({ args, context }) => {
 
 const getUsageArgsSchema = v.strictObject({});
 
-const handleGetUsageTool: McpToolHandler = async ({ args, context }) => {
+const handleGetUsageTool: TypedMcpToolHandler<
+  v.InferInput<typeof GET_USAGE_PROJECTION>
+> = async ({ args, context }) => {
   if (
     !roles[context.memberRole].authorize({ organizationSettings: ["update"] })
       .success

--- a/apps/api/src/mcp/document-file-upload.ts
+++ b/apps/api/src/mcp/document-file-upload.ts
@@ -1,6 +1,5 @@
 import { Result } from "better-result";
-import { t } from "elysia";
-import type { Static } from "elysia";
+import * as v from "valibot";
 
 import {
   buildDocumentVersionUploadReservationInput,
@@ -30,52 +29,53 @@ export const DOCUMENT_UPLOAD_APP_RESOURCE_URI =
  * canonical static-tool input schema and is also the runtime validator: the
  * host adapter therefore cannot accept a shape different from `tools/list`.
  */
-export const OPENAI_FILE_REFERENCE_SCHEMA = t.Object(
-  {
-    download_url: t.String({
-      description:
+export const OPENAI_FILE_REFERENCE_SCHEMA = v.pipe(
+  v.strictObject({
+    download_url: v.pipe(
+      v.string(),
+      v.description(
         "Temporary URL supplied by the host for downloading the file",
-    }),
-    file_id: t.String({
-      description: "Host-assigned identifier for the attached file",
-    }),
-    mime_type: t.Optional(
-      t.String({ description: "MIME type reported by the host" }),
+      ),
     ),
-    file_name: t.Optional(
-      t.String({ description: "Original file name reported by the host" }),
+    file_id: v.pipe(
+      v.string(),
+      v.description("Host-assigned identifier for the attached file"),
     ),
-  },
-  {
-    additionalProperties: false,
-    description: "File reference supplied by a compatible MCP host",
-  },
+    mime_type: v.optional(
+      v.pipe(v.string(), v.description("MIME type reported by the host")),
+    ),
+    file_name: v.optional(
+      v.pipe(
+        v.string(),
+        v.description("Original file name reported by the host"),
+      ),
+    ),
+  }),
+  v.description("File reference supplied by a compatible MCP host"),
 );
 
-export const UPLOAD_DOCUMENT_VERSION_INPUT_SCHEMA = t.Object(
-  {
-    entity_id: t.String({
-      minLength: 1,
-      description:
-        "Existing document entity ID that will receive a new version",
-    }),
-    file: OPENAI_FILE_REFERENCE_SCHEMA,
-  },
-  { additionalProperties: false },
-);
+export const UPLOAD_DOCUMENT_VERSION_INPUT_SCHEMA = v.strictObject({
+  entity_id: v.pipe(
+    v.string(),
+    v.minLength(1),
+    v.description(
+      "Existing document entity ID that will receive a new version",
+    ),
+  ),
+  file: OPENAI_FILE_REFERENCE_SCHEMA,
+});
 
-export const OPEN_DOCUMENT_VERSION_UPLOAD_INPUT_SCHEMA = t.Object(
-  {
-    entity_id: t.String({
-      minLength: 1,
-      description:
-        "Existing document entity ID that will receive a new version",
-    }),
-  },
-  { additionalProperties: false },
-);
+export const OPEN_DOCUMENT_VERSION_UPLOAD_INPUT_SCHEMA = v.strictObject({
+  entity_id: v.pipe(
+    v.string(),
+    v.minLength(1),
+    v.description(
+      "Existing document entity ID that will receive a new version",
+    ),
+  ),
+});
 
-export type UploadDocumentVersionInput = Static<
+export type UploadDocumentVersionInput = v.InferOutput<
   typeof UPLOAD_DOCUMENT_VERSION_INPUT_SCHEMA
 >;
 
@@ -238,7 +238,7 @@ const abortCreatedReservation = async ({
 };
 
 const normalizedMimeType = (
-  file: UploadDocumentVersionInput["file"] & object,
+  file: UploadDocumentVersionInput["file"],
   responseHeaders: Headers,
 ): string =>
   file.mime_type ??
@@ -261,7 +261,7 @@ export const uploadRemoteDocumentVersion = async ({
   context: McpRequestContext;
   dependencies?: DocumentFileUploadDependencies;
   entityId: string;
-  file: UploadDocumentVersionInput["file"] & object;
+  file: UploadDocumentVersionInput["file"];
   workspaceId: string;
 }): Promise<McpToolResponse> => {
   const downloaded = await dependencies.download({

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -35,8 +35,10 @@ import type {
   LIST_PROPERTIES_PROJECTION,
   READ_DOCUMENT_DEFAULT_PROJECTION,
   READ_DOCUMENT_DIFF_PROJECTION,
+  READ_DOCUMENT_PROJECTION,
   READ_DOCUMENT_VERSION_PROJECTION,
   SAVE_DOCUMENT_CREATE_PROJECTION,
+  SAVE_DOCUMENT_PROJECTION,
   SAVE_DOCUMENT_UPDATE_PROJECTION,
   SET_FIELD_VALUE_PROJECTION,
 } from "@/api/lib/chat/projections";
@@ -87,6 +89,7 @@ import type {
   McpToolDefinition,
   McpToolHandler,
   McpToolResponse,
+  TypedMcpToolHandler,
 } from "@/api/mcp/tool-types";
 import { defineMcpToolSet } from "@/api/mcp/tool-types";
 import {
@@ -947,7 +950,9 @@ const documentsParentCondition = ({
   return undefined;
 };
 
-const handleListDocumentsTool: McpToolHandler = async ({ args, context }) => {
+const handleListDocumentsTool: TypedMcpToolHandler<
+  v.InferInput<typeof LIST_DOCUMENTS_PROJECTION>
+> = async ({ args, context }) => {
   const hasPermission = roles[context.memberRole].authorize({
     workspace: ["read"],
   });
@@ -1625,7 +1630,9 @@ const loadDocumentProcessingStates = async ({
   return { contentState, searchIndexState };
 };
 
-const handleReadDocumentTool: McpToolHandler = async ({ args, context }) => {
+const handleReadDocumentTool: TypedMcpToolHandler<
+  v.InferInput<typeof READ_DOCUMENT_PROJECTION>
+> = async ({ args, context }) => {
   const hasPermission = roles[context.memberRole].authorize({
     workspace: ["read"],
   });
@@ -1949,7 +1956,9 @@ const createDocumentEntity = async ({
 }: {
   context: McpRequestContext;
   input: SaveDocumentInput;
-}): Promise<InternalToolResult> => {
+}): Promise<
+  InternalToolResult<v.InferInput<typeof SAVE_DOCUMENT_PROJECTION>>
+> => {
   if (!roles[context.memberRole].authorize({ entity: ["create"] }).success) {
     return errorResult("Forbidden");
   }
@@ -2104,7 +2113,9 @@ const updateDocumentEntity = async ({
 }: {
   context: McpRequestContext;
   input: SaveDocumentInput;
-}): Promise<InternalToolResult> => {
+}): Promise<
+  InternalToolResult<v.InferInput<typeof SAVE_DOCUMENT_PROJECTION>>
+> => {
   if (!roles[context.memberRole].authorize({ entity: ["update"] }).success) {
     return errorResult("Forbidden");
   }
@@ -2198,7 +2209,9 @@ const updateDocumentEntity = async ({
   } satisfies v.InferInput<typeof SAVE_DOCUMENT_UPDATE_PROJECTION>);
 };
 
-const handleSaveDocumentTool: McpToolHandler = async ({ args, context }) => {
+const handleSaveDocumentTool: TypedMcpToolHandler<
+  v.InferInput<typeof SAVE_DOCUMENT_PROJECTION>
+> = async ({ args, context }) => {
   const parsed = v.safeParse(saveDocumentArgsSchema, args);
   if (!parsed.success) {
     return validationErrorResult({
@@ -2319,7 +2332,9 @@ const deleteDocumentArgsSchema = v.strictObject({
   confirm: v.optional(v.boolean()),
 });
 
-const handleDeleteDocumentTool: McpToolHandler = async ({ args, context }) => {
+const handleDeleteDocumentTool: TypedMcpToolHandler<
+  v.InferInput<typeof DELETED_TRUE_PROJECTION>
+> = async ({ args, context }) => {
   const parsed = v.safeParse(deleteDocumentArgsSchema, args);
   if (!parsed.success) {
     return validationErrorResult({
@@ -2401,7 +2416,9 @@ const propertyPageCursorCodec = createTimestampIdCursorCodec({
   brandId: brandPersistedPropertyId,
 });
 
-const handleListPropertiesTool: McpToolHandler = async ({ args, context }) => {
+const handleListPropertiesTool: TypedMcpToolHandler<
+  v.InferInput<typeof LIST_PROPERTIES_PROJECTION>
+> = async ({ args, context }) => {
   const hasPermission = roles[context.memberRole].authorize({
     workspace: ["read"],
   });
@@ -2540,7 +2557,9 @@ const toFieldContent = (content: SetFieldValueContent): UpsertFieldContent => {
   return { version: 1, type: "text", value: content.value };
 };
 
-const handleSetFieldValueTool: McpToolHandler = async ({ args, context }) => {
+const handleSetFieldValueTool: TypedMcpToolHandler<
+  v.InferInput<typeof SET_FIELD_VALUE_PROJECTION>
+> = async ({ args, context }) => {
   const hasPermission = roles[context.memberRole].authorize({
     entity: ["create", "update"],
   });

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -1,4 +1,3 @@
-import { Value } from "@sinclair/typebox/value";
 import { panic, Result } from "better-result";
 import { and, asc, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import * as v from "valibot";
@@ -111,6 +110,7 @@ import {
   toolDataResult,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
+import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
 import { DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
 
 type DocumentToolName =
@@ -489,6 +489,50 @@ const READ_DOCUMENT_TEXT_FIELD_PATHS = [
   ]),
 ];
 
+const UPLOAD_DOCUMENT_VERSION_TOOL_DEFINITION = defineValibotMcpTool({
+  _meta: {
+    "openai/fileParams": ["file"],
+  },
+  annotations: {
+    title: "Upload document version",
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  description:
+    "Upload an attached host file as a new version of an existing document. " +
+    "Pass entity_id and file. Use open_document_version_upload only when the " +
+    "host cannot supply MCP file parameters. The upload uses stella's standard " +
+    "presigned, checksum-verified, scanned, and audited file-version pipeline.",
+  inputSchema: UPLOAD_DOCUMENT_VERSION_INPUT_SCHEMA,
+  access: "write",
+  anonymized: { exposure: "excluded", reason: "write" },
+  name: DOCUMENT_VERSION_UPLOAD_TRANSPORT.toolName,
+  scope: "stella:documents_write",
+});
+
+const OPEN_DOCUMENT_VERSION_UPLOAD_TOOL_DEFINITION = defineValibotMcpTool({
+  _meta: {
+    ui: {
+      resourceUri: DOCUMENT_UPLOAD_APP_RESOURCE_URI,
+      visibility: ["model", "app"],
+    },
+  },
+  annotations: {
+    title: "Open document version upload",
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  description:
+    "Open a portable file picker for uploading a new version of an existing " +
+    "document. Use only when upload_document_version cannot receive a host file " +
+    "reference; do not use when the host already supplied an attached file.",
+  inputSchema: OPEN_DOCUMENT_VERSION_UPLOAD_INPUT_SCHEMA,
+  access: "write",
+  anonymized: { exposure: "excluded", reason: "write" },
+  name: DOCUMENT_VERSION_UPLOAD_TRANSPORT.pickerToolName,
+  scope: "stella:documents_write",
+});
+
 export const DOCUMENT_TOOL_DEFINITIONS = [
   {
     annotations: {
@@ -641,48 +685,8 @@ export const DOCUMENT_TOOL_DEFINITIONS = [
     name: "save_document",
     scope: "stella:documents_write",
   },
-  {
-    _meta: {
-      "openai/fileParams": ["file"],
-    },
-    annotations: {
-      title: "Upload document version",
-      idempotentHint: false,
-      openWorldHint: true,
-    },
-    description:
-      "Upload an attached host file as a new version of an existing document. " +
-      "Pass entity_id and file. Use open_document_version_upload only when the " +
-      "host cannot supply MCP file parameters. The upload uses stella's standard " +
-      "presigned, checksum-verified, scanned, and audited file-version pipeline.",
-    inputSchema: UPLOAD_DOCUMENT_VERSION_INPUT_SCHEMA,
-    access: "write",
-    anonymized: { exposure: "excluded", reason: "write" },
-    name: DOCUMENT_VERSION_UPLOAD_TRANSPORT.toolName,
-    scope: "stella:documents_write",
-  },
-  {
-    _meta: {
-      ui: {
-        resourceUri: DOCUMENT_UPLOAD_APP_RESOURCE_URI,
-        visibility: ["model", "app"],
-      },
-    },
-    annotations: {
-      title: "Open document version upload",
-      idempotentHint: false,
-      openWorldHint: true,
-    },
-    description:
-      "Open a portable file picker for uploading a new version of an existing " +
-      "document. Use only when upload_document_version cannot receive a host file " +
-      "reference; do not use when the host already supplied an attached file.",
-    inputSchema: OPEN_DOCUMENT_VERSION_UPLOAD_INPUT_SCHEMA,
-    access: "write",
-    anonymized: { exposure: "excluded", reason: "write" },
-    name: DOCUMENT_VERSION_UPLOAD_TRANSPORT.pickerToolName,
-    scope: "stella:documents_write",
-  },
+  UPLOAD_DOCUMENT_VERSION_TOOL_DEFINITION,
+  OPEN_DOCUMENT_VERSION_UPLOAD_TOOL_DEFINITION,
   {
     annotations: {
       title: "Delete document",
@@ -2272,9 +2276,13 @@ const handleUploadDocumentVersionTool: McpToolHandler = async ({
   args,
   context,
 }) => {
-  if (!Value.Check(UPLOAD_DOCUMENT_VERSION_INPUT_SCHEMA, args)) {
-    return structuredErrorResult({
-      code: "validation_error",
+  const parsed = v.safeParse(
+    UPLOAD_DOCUMENT_VERSION_TOOL_DEFINITION.inputSchemaSource,
+    args,
+  );
+  if (!parsed.success) {
+    return validationErrorResult({
+      issues: parsed.issues,
       message:
         "Invalid input: expected { entity_id: string, file: { download_url, file_id, mime_type?, file_name? } }",
     });
@@ -2282,7 +2290,7 @@ const handleUploadDocumentVersionTool: McpToolHandler = async ({
 
   const target = await resolveDocumentVersionUploadTarget({
     context,
-    entityId: args.entity_id,
+    entityId: parsed.output.entity_id,
   });
   if (target.status === "error") {
     return target.response;
@@ -2291,7 +2299,7 @@ const handleUploadDocumentVersionTool: McpToolHandler = async ({
   return await uploadRemoteDocumentVersion({
     context,
     entityId: target.entityId,
-    file: args.file,
+    file: parsed.output.file,
     workspaceId: target.workspaceId,
   });
 };
@@ -2300,16 +2308,20 @@ const handleOpenDocumentVersionUploadTool: McpToolHandler = async ({
   args,
   context,
 }) => {
-  if (!Value.Check(OPEN_DOCUMENT_VERSION_UPLOAD_INPUT_SCHEMA, args)) {
-    return structuredErrorResult({
-      code: "validation_error",
+  const parsed = v.safeParse(
+    OPEN_DOCUMENT_VERSION_UPLOAD_TOOL_DEFINITION.inputSchemaSource,
+    args,
+  );
+  if (!parsed.success) {
+    return validationErrorResult({
+      issues: parsed.issues,
       message: "Invalid input: expected { entity_id: string }",
     });
   }
 
   const target = await resolveDocumentVersionUploadTarget({
     context,
-    entityId: args.entity_id,
+    entityId: parsed.output.entity_id,
   });
   if (target.status === "error") {
     return target.response;

--- a/apps/api/src/mcp/egress.ts
+++ b/apps/api/src/mcp/egress.ts
@@ -3,10 +3,11 @@ import { anonymizeTextFields } from "@/api/mcp/anonymization";
 import type { McpMode } from "@/api/mcp/constants";
 import type { McpRequestContext } from "@/api/mcp/context";
 import type {
-  McpEgressPlan,
   InternalToolResult,
+  McpEgressPlan,
   McpStructuredTextField,
   McpToolResponse,
+  TypedMcpToolResponse,
 } from "@/api/mcp/tool-types";
 import { isMcpEgressPlan } from "@/api/mcp/tool-types";
 import {
@@ -43,17 +44,23 @@ const ANONYMIZED_FIELD_MISSING_FALLBACK = "[REDACTED]";
  * `projection-schema.ts`). That backstop belongs there, not here, because
  * this pipeline itself never hands output to a model.
  */
-type FinalizeToolEgressOptions = {
+type FinalizeToolEgressOptions<TResponse extends McpToolResponse> = {
   context: McpRequestContext;
   mode: McpMode;
-  response: McpToolResponse;
+  response: TResponse;
 };
 
-export const finalizeToolEgress = async ({
+export function finalizeToolEgress<TData>(
+  options: FinalizeToolEgressOptions<TypedMcpToolResponse<TData>>,
+): Promise<InternalToolResult<TData>>;
+export function finalizeToolEgress(
+  options: FinalizeToolEgressOptions<McpToolResponse>,
+): Promise<InternalToolResult>;
+export async function finalizeToolEgress({
   context,
   mode,
   response,
-}: FinalizeToolEgressOptions): Promise<InternalToolResult> => {
+}: FinalizeToolEgressOptions<McpToolResponse>): Promise<InternalToolResult> {
   if (!isMcpEgressPlan(response)) {
     return response;
   }
@@ -67,7 +74,7 @@ export const finalizeToolEgress = async ({
   }
 
   return await finalizeStructured({ context, mode, plan: response });
-};
+}
 
 /**
  * Anonymize a flat list of text fields grouped by their `workspaceId` scope.

--- a/apps/api/src/mcp/knowledge-tools.test.ts
+++ b/apps/api/src/mcp/knowledge-tools.test.ts
@@ -190,7 +190,7 @@ describe("MCP knowledge tools", () => {
       args: {},
       context: createContext({ scopedDb: createClauseScopedDb(rows) }),
     });
-    if (!isMcpEgressPlan(response) || response.egress !== "structured") {
+    if (!isMcpEgressPlan(response)) {
       throw new Error("Expected a structured egress plan");
     }
 

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -24,9 +24,11 @@ import type {
   DELETED_TRUE_PROJECTION,
   LIST_CLAUSES_DETAIL_PROJECTION,
   LIST_CLAUSES_LIST_PROJECTION,
+  LIST_CLAUSES_PROJECTION,
   LIST_CLAUSES_VERSION_PROJECTION,
   LIST_PLAYBOOKS_DETAIL_PROJECTION,
   LIST_PLAYBOOKS_LIST_PROJECTION,
+  LIST_PLAYBOOKS_PROJECTION,
   RUN_PLAYBOOK_PROJECTION,
   SAVE_CLAUSE_PROJECTION,
 } from "@/api/lib/chat/projections";
@@ -62,6 +64,7 @@ import type {
   McpTextFieldSpec,
   McpToolDefinition,
   McpToolHandler,
+  TypedMcpToolHandler,
 } from "@/api/mcp/tool-types";
 import { defineMcpToolSet } from "@/api/mcp/tool-types";
 import {
@@ -1024,7 +1027,9 @@ const readClauseDetail = async ({
   return { egress: "structured", payload: { clause }, textFields } as const;
 };
 
-const handleListClausesTool: McpToolHandler = async ({ args, context }) => {
+const handleListClausesTool: TypedMcpToolHandler<
+  v.InferInput<typeof LIST_CLAUSES_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ workspace: ["read"] }).success) {
     return errorResult("Forbidden");
   }
@@ -1213,7 +1218,9 @@ const saveClauseArgsSchema = v.pipe(
   ),
 );
 
-const handleSaveClauseTool: McpToolHandler = async ({ args, context }) => {
+const handleSaveClauseTool: TypedMcpToolHandler<
+  v.InferInput<typeof SAVE_CLAUSE_PROJECTION>
+> = async ({ args, context }) => {
   const parsed = v.safeParse(saveClauseArgsSchema, args);
   if (!parsed.success) {
     return validationErrorResult({
@@ -1357,7 +1364,9 @@ const deleteClauseArgsSchema = v.strictObject({
   confirm: v.optional(v.boolean()),
 });
 
-const handleDeleteClauseTool: McpToolHandler = async ({ args, context }) => {
+const handleDeleteClauseTool: TypedMcpToolHandler<
+  v.InferInput<typeof DELETED_TRUE_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ clause: ["delete"] }).success) {
     return errorResult("Forbidden");
   }
@@ -1445,7 +1454,9 @@ const readPlaybookDetail = async ({
   } as const;
 };
 
-const handleListPlaybooksTool: McpToolHandler = async ({ args, context }) => {
+const handleListPlaybooksTool: TypedMcpToolHandler<
+  v.InferInput<typeof LIST_PLAYBOOKS_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ workspace: ["read"] }).success) {
     return errorResult("Forbidden");
   }
@@ -1518,7 +1529,9 @@ const workflowStartFailureResult = () =>
     retryable: true,
   });
 
-const handleRunPlaybookTool: McpToolHandler = async ({ args, context }) => {
+const handleRunPlaybookTool: TypedMcpToolHandler<
+  v.InferInput<typeof RUN_PLAYBOOK_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ playbook: ["apply"] }).success) {
     return errorResult("Forbidden");
   }

--- a/apps/api/src/mcp/matter-tools.ts
+++ b/apps/api/src/mcp/matter-tools.ts
@@ -36,9 +36,11 @@ import type {
   DELETED_TRUE_PROJECTION,
   LINK_MATTER_CONTACT_LINK_PROJECTION,
   LINK_MATTER_CONTACT_UNLINK_PROJECTION,
+  LINK_MATTER_CONTACT_PROJECTION,
   LIST_CONTACTS_PROJECTION,
   LIST_TASKS_DETAIL_PROJECTION,
   LIST_TASKS_LIST_PROJECTION,
+  LIST_TASKS_PROJECTION,
   LOOKUP_BUSINESS_REGISTRY_PROJECTION,
   SAVE_CONTACT_PROJECTION,
   SAVE_MATTER_PROJECTION,
@@ -75,6 +77,7 @@ import type {
   McpTextFieldSpec,
   McpToolDefinition,
   McpToolHandler,
+  TypedMcpToolHandler,
 } from "@/api/mcp/tool-types";
 import { defineMcpToolSet } from "@/api/mcp/tool-types";
 import {
@@ -611,7 +614,9 @@ const saveMatterArgsSchema = v.pipe(
   ),
 );
 
-const handleSaveMatterTool: McpToolHandler = async ({ args, context }) => {
+const handleSaveMatterTool: TypedMcpToolHandler<
+  v.InferInput<typeof SAVE_MATTER_PROJECTION>
+> = async ({ args, context }) => {
   const parsed = v.safeParse(saveMatterArgsSchema, args);
   if (!parsed.success) {
     return validationErrorResult({
@@ -772,7 +777,9 @@ const deleteMatterArgsSchema = v.strictObject({
   confirm: v.optional(v.boolean()),
 });
 
-const handleDeleteMatterTool: McpToolHandler = async ({ args, context }) => {
+const handleDeleteMatterTool: TypedMcpToolHandler<
+  v.InferInput<typeof DELETED_TRUE_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ workspace: ["delete"] }).success) {
     return errorResult("Forbidden");
   }
@@ -828,7 +835,9 @@ const listContactsArgsSchema = v.strictObject({
   ),
 });
 
-const handleListContactsTool: McpToolHandler = async ({ args, context }) => {
+const handleListContactsTool: TypedMcpToolHandler<
+  v.InferInput<typeof LIST_CONTACTS_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ workspace: ["read"] }).success) {
     return errorResult("Forbidden");
   }
@@ -928,7 +937,9 @@ const saveContactArgsSchema = v.pipe(
   ),
 );
 
-const handleSaveContactTool: McpToolHandler = async ({ args, context }) => {
+const handleSaveContactTool: TypedMcpToolHandler<
+  v.InferInput<typeof SAVE_CONTACT_PROJECTION>
+> = async ({ args, context }) => {
   const parsed = v.safeParse(saveContactArgsSchema, args);
   if (!parsed.success) {
     return validationErrorResult({
@@ -1025,7 +1036,9 @@ const deleteContactArgsSchema = v.strictObject({
   confirm: v.optional(v.boolean()),
 });
 
-const handleDeleteContactTool: McpToolHandler = async ({ args, context }) => {
+const handleDeleteContactTool: TypedMcpToolHandler<
+  v.InferInput<typeof DELETED_TRUE_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ contact: ["delete"] }).success) {
     return errorResult("Forbidden");
   }
@@ -1061,10 +1074,9 @@ const lookupBusinessRegistryArgsSchema = v.strictObject({
   query: v.pipe(v.string(), v.minLength(1), v.maxLength(256)),
 });
 
-const handleLookupBusinessRegistryTool: McpToolHandler = async ({
-  args,
-  context,
-}) => {
+const handleLookupBusinessRegistryTool: TypedMcpToolHandler<
+  v.InferInput<typeof LOOKUP_BUSINESS_REGISTRY_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ workspace: ["read"] }).success) {
     return errorResult("Forbidden");
   }
@@ -1261,7 +1273,9 @@ const readTaskDetail = async ({
   };
 };
 
-const handleListTasksTool: McpToolHandler = async ({ args, context }) => {
+const handleListTasksTool: TypedMcpToolHandler<
+  v.InferInput<typeof LIST_TASKS_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ workspace: ["read"] }).success) {
     return errorResult("Forbidden");
   }
@@ -1730,7 +1744,9 @@ const validateSaveTaskTargets = async ({
   return null;
 };
 
-const handleSaveTaskTool: McpToolHandler = async ({ args, context }) => {
+const handleSaveTaskTool: TypedMcpToolHandler<
+  v.InferInput<typeof SAVE_TASK_PROJECTION>
+> = async ({ args, context }) => {
   const parsed = v.safeParse(saveTaskArgsSchema, args);
   if (!parsed.success) {
     return validationErrorResult({
@@ -2003,10 +2019,9 @@ const resolveUnlinkWorkspaceContactId = async ({
   return brandPersistedWorkspaceContactId(first.id);
 };
 
-const handleLinkMatterContactTool: McpToolHandler = async ({
-  args,
-  context,
-}) => {
+const handleLinkMatterContactTool: TypedMcpToolHandler<
+  v.InferInput<typeof LINK_MATTER_CONTACT_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ workspace: ["update"] }).success) {
     return errorResult("Forbidden");
   }

--- a/apps/api/src/mcp/matter-tools.ts
+++ b/apps/api/src/mcp/matter-tools.ts
@@ -91,6 +91,7 @@ import {
   internalFailureResult,
   getWorkspaceStatus,
   intProp,
+  ISO_DATE_SCHEMA,
   MAX_LIST_LIMIT,
   notFoundResult,
   nullableStringProp,
@@ -1144,14 +1145,12 @@ const resolveTaskWorkspace = async ({
   return { status: "ok", workspaceId: entity.workspaceId };
 };
 
-const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/u;
-
 const listTasksArgsSchema = v.pipe(
   v.strictObject({
     matter_id: v.optional(v.pipe(v.string(), v.minLength(1))),
     task_id: v.optional(v.pipe(v.string(), v.minLength(1))),
-    date_from: v.optional(v.pipe(v.string(), v.regex(ISO_DATE))),
-    date_to: v.optional(v.pipe(v.string(), v.regex(ISO_DATE))),
+    date_from: v.optional(ISO_DATE_SCHEMA),
+    date_to: v.optional(ISO_DATE_SCHEMA),
     status: v.optional(v.pipe(v.string(), v.minLength(1), v.maxLength(32))),
     limit: v.optional(
       v.pipe(
@@ -1464,7 +1463,7 @@ const saveTaskArgsSchema = v.pipe(
     list_description: v.optional(
       v.nullable(v.pipe(v.string(), v.maxLength(10_000))),
     ),
-    due_date: v.optional(v.nullable(v.pipe(v.string(), v.regex(ISO_DATE)))),
+    due_date: v.optional(v.nullable(ISO_DATE_SCHEMA)),
     workflow_reason: v.optional(
       v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(1000)),
     ),

--- a/apps/api/src/mcp/registry-quality.test.ts
+++ b/apps/api/src/mcp/registry-quality.test.ts
@@ -64,10 +64,13 @@ const TOOL_COUNT_CEILING: Record<SurfaceMode, number> = {
 // phase 2): measured 51_580 chars. The anonymized surface is unchanged (all
 // three are excluded from it).
 // default bumped 54_000 -> 61_000 after contact discovery and template
-// persistence brought the measured payload to 55_283 chars; the new ceiling
-// retains roughly 10% review headroom.
+// persistence brought the measured payload to 55_283 chars.
+// default bumped 61_000 -> 70_000 after save_template began advertising the
+// canonical strict field-configuration contract instead of a loose object
+// approximation: measured 63_213 chars. The new ceiling retains roughly 10%
+// review headroom without weakening the provider-visible schema.
 const TOOLS_LIST_PAYLOAD_CHAR_CEILING: Record<SurfaceMode, number> = {
-  default: 61_000,
+  default: 70_000,
   anonymized: 22_000,
 };
 

--- a/apps/api/src/mcp/research-admin-tools.test.ts
+++ b/apps/api/src/mcp/research-admin-tools.test.ts
@@ -115,6 +115,15 @@ describe("list_audit_log", () => {
       "resourceType is required when resourceId is provided",
     );
   });
+
+  test("rejects permissive Date inputs that are not ISO timestamps", async () => {
+    const result = await RESEARCH_ADMIN_TOOL_HANDLERS.list_audit_log({
+      args: { from: "August 23, 2026" },
+      context: createContext("owner"),
+    });
+
+    expect(errorMessage(result)).toContain("Invalid input");
+  });
 });
 
 describe("search_legislation feature gating", () => {

--- a/apps/api/src/mcp/research-admin-tools.ts
+++ b/apps/api/src/mcp/research-admin-tools.ts
@@ -587,8 +587,10 @@ const handleListAuditLogTool: McpToolHandler = async ({ args, context }) => {
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message:
+      message: crossFieldOrGeneric(
+        parsed.issues,
         "Invalid input: expected { workspace_id?, action?, resource_type?, resource_id?, user_id?, from?, to?, limit?, cursor? }",
+      ),
     });
   }
   const input = parsed.output;

--- a/apps/api/src/mcp/research-admin-tools.ts
+++ b/apps/api/src/mcp/research-admin-tools.ts
@@ -188,9 +188,9 @@ const LIST_AUDIT_LOG_TOOL_DEFINITION = defineValibotMcpTool({
     "cursor. Requires organization audit-log access.",
   inputSchema: listAuditLogArgsSchema,
   jsonSchemaProjectionWaiver: {
-    ignoreActions: ["partial_check"],
+    ignoreActions: ["iso_timestamp", "partial_check"],
     reason:
-      "The resource_id dependency remains authoritative in the runtime schema.",
+      "The CLI trust boundary does not interpret format; ISO timestamps and the resource_id dependency remain authoritative in the runtime schema.",
   },
   // Audit payloads carry free-form tenant-authored change diffs whose text
   // fields cannot be enumerated for redaction, so this read tool fails closed

--- a/apps/api/src/mcp/research-admin-tools.ts
+++ b/apps/api/src/mcp/research-admin-tools.ts
@@ -26,6 +26,7 @@ import type {
   MANAGE_ORGANIZATION_ADD_MEMBER_PROJECTION,
   MANAGE_ORGANIZATION_REMOVE_MEMBER_PROJECTION,
   MANAGE_ORGANIZATION_SETTINGS_PROJECTION,
+  MANAGE_ORGANIZATION_PROJECTION,
   SEARCH_LEGISLATION_PROJECTION,
 } from "@/api/lib/chat/projections";
 import { LIMITS } from "@/api/lib/limits";
@@ -37,7 +38,11 @@ import {
   bindApprovedMcpAuditContext,
   type McpRequestContext,
 } from "@/api/mcp/context";
-import type { McpToolDefinition, McpToolHandler } from "@/api/mcp/tool-types";
+import type {
+  McpToolDefinition,
+  McpToolHandler,
+  TypedMcpToolHandler,
+} from "@/api/mcp/tool-types";
 import { defineMcpToolSet } from "@/api/mcp/tool-types";
 import {
   bindWorkspaceRecorder,
@@ -396,10 +401,9 @@ const searchLegislationArgsSchema = v.pipe(
   ),
 );
 
-const handleSearchLegislationTool: McpToolHandler = async ({
-  args,
-  context,
-}) => {
+const handleSearchLegislationTool: TypedMcpToolHandler<
+  v.InferInput<typeof SEARCH_LEGISLATION_PROJECTION>
+> = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ workspace: ["read"] }).success) {
     return errorResult("Forbidden");
   }
@@ -752,10 +756,9 @@ const handleRemoveMember = async ({
   >);
 };
 
-const handleManageOrganizationTool: McpToolHandler = async ({
-  args,
-  context,
-}) => {
+const handleManageOrganizationTool: TypedMcpToolHandler<
+  v.InferInput<typeof MANAGE_ORGANIZATION_PROJECTION>
+> = async ({ args, context }) => {
   const parsed = v.safeParse(manageOrganizationArgsSchema, args);
   if (!parsed.success) {
     return validationErrorResult({

--- a/apps/api/src/mcp/research-admin-tools.ts
+++ b/apps/api/src/mcp/research-admin-tools.ts
@@ -57,6 +57,7 @@ import {
   toolDataResult,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
+import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
 
 type ResearchAdminToolName =
   | "search_legislation"
@@ -85,6 +86,120 @@ const MANAGE_ORG_ACTIONS = [
   "remove_member",
   "update_org_settings",
 ] as const;
+
+const listAuditLogArgsSchema = v.pipe(
+  v.strictObject({
+    workspace_id: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.description("Only entries scoped to this matter/workspace"),
+      ),
+    ),
+    action: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.description("Only entries with this audit action"),
+      ),
+    ),
+    resource_type: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.description("Only entries about this resource type"),
+      ),
+    ),
+    resource_id: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.description(
+          "Only entries about this resource id; requires resource_type",
+        ),
+      ),
+    ),
+    user_id: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.description("Only entries whose actor is this user"),
+      ),
+    ),
+    from: v.optional(
+      v.pipe(
+        v.string(),
+        v.isoTimestamp(),
+        v.maxLength(40),
+        v.description("Only entries created on or after this ISO date-time"),
+      ),
+    ),
+    to: v.optional(
+      v.pipe(
+        v.string(),
+        v.isoTimestamp(),
+        v.maxLength(40),
+        v.description("Only entries created on or before this ISO date-time"),
+      ),
+    ),
+    limit: v.optional(
+      v.pipe(
+        v.number(),
+        v.integer(),
+        v.minValue(1),
+        v.maxValue(LIMITS.auditLogPageSizeMax),
+        v.description("Max entries to return"),
+      ),
+    ),
+    cursor: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.maxLength(512),
+        v.description(
+          "Opaque cursor from a previous list_audit_log call to fetch the next page",
+        ),
+      ),
+    ),
+  }),
+  v.forward(
+    v.partialCheck(
+      [["resource_type"], ["resource_id"]],
+      ({ resource_id, resource_type }) =>
+        resource_id === undefined || resource_type !== undefined,
+      "resourceType is required when resourceId is provided",
+    ),
+    ["resource_id"],
+  ),
+);
+
+const LIST_AUDIT_LOG_TOOL_DEFINITION = defineValibotMcpTool({
+  annotations: {
+    title: "List audit log",
+    readOnlyHint: true,
+    openWorldHint: false,
+  },
+  description:
+    "Read the organization's audit trail (compliance view). Returns audit " +
+    "entries newest first, each with its action, resource type and id, actor " +
+    "user id, workspace, timestamp, and change detail. Filter by workspace_id, " +
+    "action, resource_type (with optional resource_id), user_id, and a " +
+    "created-at range (from/to, ISO date-time). Paginate with limit and " +
+    "cursor. Requires organization audit-log access.",
+  inputSchema: listAuditLogArgsSchema,
+  jsonSchemaProjectionWaiver: {
+    ignoreActions: ["partial_check"],
+    reason:
+      "The resource_id dependency remains authoritative in the runtime schema.",
+  },
+  // Audit payloads carry free-form tenant-authored change diffs whose text
+  // fields cannot be enumerated for redaction, so this read tool fails closed
+  // and never appears on the anonymized surface.
+  access: "read",
+  anonymized: { exposure: "excluded", reason: "dynamic_tenant_payload" },
+  name: "list_audit_log",
+  scope: "stella:admin_read",
+});
 
 export const RESEARCH_ADMIN_TOOL_DEFINITIONS = [
   {
@@ -164,56 +279,7 @@ export const RESEARCH_ADMIN_TOOL_DEFINITIONS = [
     name: "search_legislation",
     scope: "stella:read",
   },
-  {
-    annotations: {
-      title: "List audit log",
-      readOnlyHint: true,
-      openWorldHint: false,
-    },
-    description:
-      "Read the organization's audit trail (compliance view). Returns audit " +
-      "entries newest first, each with its action, resource type and id, actor " +
-      "user id, workspace, timestamp, and change detail. Filter by workspace_id, " +
-      "action, resource_type (with optional resource_id), user_id, and a " +
-      "created-at range (from/to, ISO date-time). Paginate with limit and " +
-      "cursor. Requires organization audit-log access.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        workspace_id: stringProp(
-          "Only entries scoped to this matter/workspace",
-        ),
-        action: stringProp("Only entries with this audit action"),
-        resource_type: stringProp("Only entries about this resource type"),
-        resource_id: stringProp(
-          "Only entries about this resource id; requires resource_type",
-        ),
-        user_id: stringProp("Only entries whose actor is this user"),
-        from: stringProp(
-          "Only entries created on or after this ISO date-time",
-          { maxLength: 40 },
-        ),
-        to: stringProp("Only entries created on or before this ISO date-time", {
-          maxLength: 40,
-        }),
-        limit: intProp("Max entries to return", {
-          min: 1,
-          max: LIMITS.auditLogPageSizeMax,
-        }),
-        cursor: stringProp(
-          "Opaque cursor from a previous list_audit_log call to fetch the next page",
-          { maxLength: 512 },
-        ),
-      },
-    },
-    // Audit payloads carry free-form tenant-authored change diffs whose text
-    // fields cannot be enumerated for redaction, so this read tool fails closed
-    // and never appears on the anonymized surface.
-    access: "read",
-    anonymized: { exposure: "excluded", reason: "dynamic_tenant_payload" },
-    name: "list_audit_log",
-    scope: "stella:admin_read",
-  },
+  LIST_AUDIT_LOG_TOOL_DEFINITION,
   {
     description:
       "Manage organization members and non-secret settings. Member actions " +
@@ -509,40 +575,15 @@ const handleSearchLegislationTool: TypedMcpToolHandler<
 
 // --- list_audit_log -----------------------------------------------------
 
-const ISO_DATE_INPUT = v.pipe(
-  v.string(),
-  v.minLength(1),
-  v.check(
-    (value) => !Number.isNaN(new Date(value).getTime()),
-    "must be an ISO date or date-time",
-  ),
-);
-
-const listAuditLogArgsSchema = v.strictObject({
-  workspace_id: v.optional(v.pipe(v.string(), v.minLength(1))),
-  action: v.optional(v.pipe(v.string(), v.minLength(1))),
-  resource_type: v.optional(v.pipe(v.string(), v.minLength(1))),
-  resource_id: v.optional(v.pipe(v.string(), v.minLength(1))),
-  user_id: v.optional(v.pipe(v.string(), v.minLength(1))),
-  from: v.optional(ISO_DATE_INPUT),
-  to: v.optional(ISO_DATE_INPUT),
-  limit: v.optional(
-    v.pipe(
-      v.number(),
-      v.integer(),
-      v.minValue(1),
-      v.maxValue(LIMITS.auditLogPageSizeMax),
-    ),
-  ),
-  cursor: v.optional(v.pipe(v.string(), v.minLength(1), v.maxLength(512))),
-});
-
 const handleListAuditLogTool: McpToolHandler = async ({ args, context }) => {
   if (!roles[context.memberRole].authorize({ auditLog: ["read"] }).success) {
     return errorResult("Forbidden");
   }
 
-  const parsed = v.safeParse(listAuditLogArgsSchema, args);
+  const parsed = v.safeParse(
+    LIST_AUDIT_LOG_TOOL_DEFINITION.inputSchemaSource,
+    args,
+  );
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,

--- a/apps/api/src/mcp/static-tool-definitions.ts
+++ b/apps/api/src/mcp/static-tool-definitions.ts
@@ -78,6 +78,26 @@ type LegacyManualInputToolName = Exclude<
   ValibotInputToolName
 >;
 
+type ListAuditLogInputDefinition = Extract<
+  (typeof DEFAULT_MCP_TOOL_DEFINITIONS)[number],
+  { name: "list_audit_log" }
+>;
+type SaveTemplateInputDefinition = Extract<
+  (typeof DEFAULT_MCP_TOOL_DEFINITIONS)[number],
+  { name: "save_template" }
+>;
+
+true satisfies ListAuditLogInputDefinition extends {
+  inputSchemaSource: unknown;
+}
+  ? true
+  : never;
+true satisfies SaveTemplateInputDefinition extends {
+  inputSchemaSource: unknown;
+}
+  ? true
+  : never;
+
 /**
  * Ratchet for native tools whose advertised JSON Schema still mirrors a
  * separate runtime validator. New tools must use defineValibotMcpTool; each
@@ -143,10 +163,8 @@ type MigratedInputToolStillDeclaredLegacy = Exclude<
   LegacyManualInputToolName
 >;
 
-true satisfies [
-  MissingLegacyManualInputToolName,
-  MigratedInputToolStillDeclaredLegacy,
-] extends [never, never]
+true satisfies MissingLegacyManualInputToolName extends never ? true : never;
+true satisfies MigratedInputToolStillDeclaredLegacy extends never
   ? true
   : never;
 

--- a/apps/api/src/mcp/static-tool-definitions.ts
+++ b/apps/api/src/mcp/static-tool-definitions.ts
@@ -69,6 +69,87 @@ true satisfies [MissingMcpToolName, ExtraMcpToolName] extends [never, never]
   ? true
   : never;
 
+type ValibotInputToolName = Extract<
+  (typeof DEFAULT_MCP_TOOL_DEFINITIONS)[number],
+  { inputSchemaSource: object }
+>["name"];
+type LegacyManualInputToolName = Exclude<
+  RegisteredMcpToolName,
+  ValibotInputToolName
+>;
+
+/**
+ * Ratchet for native tools whose advertised JSON Schema still mirrors a
+ * separate runtime validator. New tools must use defineValibotMcpTool; each
+ * migration removes a name here. The bidirectional check prevents this debt
+ * list from drifting away from the executable registry; the shared
+ * `legacy-manual-mcp-input-schemas` decrease-only metric prevents it growing.
+ */
+const MCP_LEGACY_MANUAL_INPUT_SCHEMA_TOOL_NAMES = [
+  "search",
+  "fetch",
+  "list_matters",
+  "search_across_matters",
+  "search_case_law",
+  "read_content_across_matters",
+  "read_case_law_decision",
+  "read_contact",
+  "set_practice_jurisdictions",
+  "list_templates",
+  "fill_template",
+  "save_filled_template",
+  "list_documents",
+  "read_document",
+  "save_document",
+  "delete_document",
+  "list_properties",
+  "set_field_value",
+  "save_matter",
+  "delete_matter",
+  "list_contacts",
+  "save_contact",
+  "delete_contact",
+  "lookup_business_registry",
+  "list_tasks",
+  "save_task",
+  "link_matter_contact",
+  "list_clauses",
+  "save_clause",
+  "delete_clause",
+  "list_playbooks",
+  "run_playbook",
+  "list_time_entries",
+  "save_time_entry",
+  "delete_time_entry",
+  "resolve_rate",
+  "list_invoices",
+  "get_usage",
+  "search_legislation",
+  "manage_organization",
+  "send_feedback",
+  "list_capabilities",
+  "describe_capability",
+  "invoke_capability",
+] as const satisfies readonly LegacyManualInputToolName[];
+
+type DeclaredLegacyManualInputToolName =
+  (typeof MCP_LEGACY_MANUAL_INPUT_SCHEMA_TOOL_NAMES)[number];
+type MissingLegacyManualInputToolName = Exclude<
+  LegacyManualInputToolName,
+  DeclaredLegacyManualInputToolName
+>;
+type MigratedInputToolStillDeclaredLegacy = Exclude<
+  DeclaredLegacyManualInputToolName,
+  LegacyManualInputToolName
+>;
+
+true satisfies [
+  MissingLegacyManualInputToolName,
+  MigratedInputToolStillDeclaredLegacy,
+] extends [never, never]
+  ? true
+  : never;
+
 /**
  * The closed set of curated static MCP tool names, derived from the single
  * default registry. Source of truth for the `McpToolName` type

--- a/apps/api/src/mcp/static-tool-definitions.ts
+++ b/apps/api/src/mcp/static-tool-definitions.ts
@@ -71,7 +71,7 @@ true satisfies [MissingMcpToolName, ExtraMcpToolName] extends [never, never]
 
 type ValibotInputToolName = Extract<
   (typeof DEFAULT_MCP_TOOL_DEFINITIONS)[number],
-  { inputSchemaSource: object }
+  { inputSchemaSource: unknown }
 >["name"];
 type LegacyManualInputToolName = Exclude<
   RegisteredMcpToolName,

--- a/apps/api/src/mcp/static-tool-definitions.ts
+++ b/apps/api/src/mcp/static-tool-definitions.ts
@@ -78,26 +78,6 @@ type LegacyManualInputToolName = Exclude<
   ValibotInputToolName
 >;
 
-type ListAuditLogInputDefinition = Extract<
-  (typeof DEFAULT_MCP_TOOL_DEFINITIONS)[number],
-  { name: "list_audit_log" }
->;
-type SaveTemplateInputDefinition = Extract<
-  (typeof DEFAULT_MCP_TOOL_DEFINITIONS)[number],
-  { name: "save_template" }
->;
-
-true satisfies ListAuditLogInputDefinition extends {
-  inputSchemaSource: unknown;
-}
-  ? true
-  : never;
-true satisfies SaveTemplateInputDefinition extends {
-  inputSchemaSource: unknown;
-}
-  ? true
-  : never;
-
 /**
  * Ratchet for native tools whose advertised JSON Schema still mirrors a
  * separate runtime validator. New tools must use defineValibotMcpTool; each
@@ -163,8 +143,10 @@ type MigratedInputToolStillDeclaredLegacy = Exclude<
   LegacyManualInputToolName
 >;
 
-true satisfies MissingLegacyManualInputToolName extends never ? true : never;
-true satisfies MigratedInputToolStillDeclaredLegacy extends never
+true satisfies [
+  MissingLegacyManualInputToolName,
+  MigratedInputToolStillDeclaredLegacy,
+] extends [never, never]
   ? true
   : never;
 

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -62,6 +62,7 @@ import {
   brandPersistedCaseLawSourceId,
   brandPersistedContactId,
   brandPersistedEntityId,
+  brandPersistedWorkspaceId,
 } from "@/api/lib/safe-id-boundaries";
 import { decodeCursor } from "@/api/lib/search/cursor";
 import { getSearchProvider } from "@/api/lib/search/provider";
@@ -1086,8 +1087,8 @@ const handleSearchAcrossMattersTool: TypedMcpToolHandler<
   });
 
   const hits = result.hits.map((hit) => ({
-    entityId: hit.entityId,
-    workspaceId: hit.workspaceId,
+    entityId: brandPersistedEntityId(hit.entityId),
+    workspaceId: brandPersistedWorkspaceId(hit.workspaceId),
     workspaceName: hit.workspaceName,
     name: hit.title,
     kind: hit.kind,
@@ -1534,7 +1535,7 @@ const handleReadContentAcrossMattersTool: TypedMcpToolHandler<
     text,
     truncated: false,
     nextCursor: initialNextCursor(),
-    workspaceId: currentDocument.workspaceId,
+    workspaceId: brandPersistedWorkspaceId(currentDocument.workspaceId),
   };
   // The egress window's `apply` below mutates this object in place, so the tie
   // cannot ride on the literal: a `satisfies` clause would contextually pin

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -33,6 +33,7 @@ import type {
   AssertNoExtraFields,
   LIST_MATTERS_DETAIL_PROJECTION,
   LIST_MATTERS_LIST_PROJECTION,
+  LIST_MATTERS_PROJECTION,
   READ_CASE_LAW_DECISION_PROJECTION,
   READ_CONTACT_PROJECTION,
   READ_CONTENT_ACROSS_MATTERS_PROJECTION,
@@ -77,6 +78,7 @@ import type {
   McpTextFieldSpec,
   McpToolDefinition,
   McpToolHandler,
+  TypedMcpToolHandler,
 } from "@/api/mcp/tool-types";
 import { defineMcpToolSet } from "@/api/mcp/tool-types";
 import {
@@ -790,7 +792,9 @@ const decodeMatterPageCursor = (cursor: string): string | null => {
   return isUuidPaginationCursorPart(rawId) ? rawId : null;
 };
 
-const handleListMattersTool: McpToolHandler = async ({ args, context }) => {
+const handleListMattersTool: TypedMcpToolHandler<
+  v.InferInput<typeof LIST_MATTERS_PROJECTION>
+> = async ({ args, context }) => {
   // Detail mode: matter_id selects one matter's overview. The list-only
   // filters (status/limit/cursor) do not apply, so reject the mixed request
   // up front rather than silently ignoring them.
@@ -931,7 +935,9 @@ const handleListMattersTool: McpToolHandler = async ({ args, context }) => {
 // Detail branch of list_matters: one matter's overview (counts, recent
 // entities, contacts, members). Reused verbatim from the former
 // get_matter_overview tool, which list_matters absorbed.
-const readMatterOverview: McpToolHandler = async ({ args, context }) => {
+const readMatterOverview: TypedMcpToolHandler<
+  v.InferInput<typeof LIST_MATTERS_PROJECTION>
+> = async ({ args, context }) => {
   const matterId = parseRequiredString(args, "matter_id");
   if (typeof matterId !== "string") {
     return matterId;
@@ -1035,10 +1041,9 @@ const readMatterOverview: McpToolHandler = async ({ args, context }) => {
   return { egress: "structured", payload, textFields };
 };
 
-const handleSearchAcrossMattersTool: McpToolHandler = async ({
-  args,
-  context,
-}) => {
+const handleSearchAcrossMattersTool: TypedMcpToolHandler<
+  v.InferInput<typeof SEARCH_ACROSS_MATTERS_PROJECTION>
+> = async ({ args, context }) => {
   const query = parseRequiredString(args, "query", {
     maxLength: LIMITS.searchQueryMaxLength,
   });
@@ -1354,10 +1359,9 @@ const loadCurrentVersionDocxMarkdown = async ({
     : { kind: "markdown", text: markdownResult.value };
 };
 
-const handleReadContentAcrossMattersTool: McpToolHandler = async ({
-  args,
-  context,
-}) => {
+const handleReadContentAcrossMattersTool: TypedMcpToolHandler<
+  v.InferInput<typeof READ_CONTENT_ACROSS_MATTERS_PROJECTION>
+> = async ({ args, context }) => {
   const rawEntityId = parseRequiredString(args, "entity_id");
   if (typeof rawEntityId !== "string") {
     return rawEntityId;
@@ -1562,7 +1566,9 @@ const handleReadContentAcrossMattersTool: McpToolHandler = async ({
   };
 };
 
-const handleSearchCaseLawTool: McpToolHandler = async ({ args, context }) => {
+const handleSearchCaseLawTool: TypedMcpToolHandler<
+  v.InferInput<typeof SEARCH_CASE_LAW_PROJECTION>
+> = async ({ args, context }) => {
   const query = parseRequiredString(args, "query", {
     maxLength: LIMITS.searchQueryMaxLength,
   });
@@ -1745,7 +1751,9 @@ const decodeDecisionCursor = (
   return { citations, text };
 };
 
-const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
+const handleReadCaseLawDecisionTool: TypedMcpToolHandler<
+  v.InferInput<typeof READ_CASE_LAW_DECISION_PROJECTION>
+> = async ({ args }) => {
   const decisionId = parseRequiredString(args, "decision_id");
   if (typeof decisionId !== "string") {
     return decisionId;
@@ -1857,7 +1865,9 @@ const handleReadCaseLawDecisionTool: McpToolHandler = async ({ args }) => {
   } satisfies v.InferInput<typeof READ_CASE_LAW_DECISION_PROJECTION>);
 };
 
-const handleReadContactTool: McpToolHandler = async ({ args, context }) => {
+const handleReadContactTool: TypedMcpToolHandler<
+  v.InferInput<typeof READ_CONTACT_PROJECTION>
+> = async ({ args, context }) => {
   const rawContactId = parseRequiredString(args, "contact_id");
   if (typeof rawContactId !== "string") {
     return rawContactId;
@@ -1927,10 +1937,9 @@ const setPracticeJurisdictionsArgsSchema = v.strictObject({
   ),
 });
 
-const handleSetPracticeJurisdictionsTool: McpToolHandler = async ({
-  args,
-  context,
-}) => {
+const handleSetPracticeJurisdictionsTool: TypedMcpToolHandler<
+  v.InferInput<typeof SET_PRACTICE_JURISDICTIONS_PROJECTION>
+> = async ({ args, context }) => {
   const hasPermission = roles[context.memberRole].authorize({
     organizationSettings: ["update"],
   });

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -1426,8 +1426,27 @@ describe("MCP template tools", () => {
 
     expect(result.isError).toBe(true);
     expect(createStoredTemplateMock).not.toHaveBeenCalled();
-    const message = result.content.at(0);
-    expect(message?.type === "text" && message.text).toContain("fields[0]");
+    const error = validationEnvelope(result);
+    const issues = asTestRaw<{ path: string }[]>(error["issues"]);
+    expect(issues.some(({ path }) => path === "fields.0")).toBe(true);
+  });
+
+  test("save_template rejects unknown field metadata keys before inserting", async () => {
+    const result = await handleMcpToolCall({
+      args: {
+        name: "NDA",
+        docx_base64: await makeValidDocxBase64(),
+        fields: [{ path: "fee", lable: "Misspelled label" }],
+      },
+      context: createContext(),
+      toolName: "save_template",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(createStoredTemplateMock).not.toHaveBeenCalled();
+    const error = validationEnvelope(result);
+    const issues = asTestRaw<{ path: string }[]>(error["issues"]);
+    expect(issues.some(({ path }) => path === "fields.0.lable")).toBe(true);
   });
 
   test("save_template (create) surfaces the service's unknown-path rejection", async () => {

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -1431,6 +1431,30 @@ describe("MCP template tools", () => {
     expect(issues.some(({ path }) => path === "fields.0")).toBe(true);
   });
 
+  test("save_template rejects conflicting derived source modes", async () => {
+    const result = await handleMcpToolCall({
+      args: {
+        name: "NDA",
+        docx_base64: await makeValidDocxBase64(),
+        fields: [
+          {
+            path: "company",
+            aiPrompt: "Draft the company details",
+            lookup: { registry: "krs" },
+          },
+        ],
+      },
+      context: createContext(),
+      toolName: "save_template",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(createStoredTemplateMock).not.toHaveBeenCalled();
+    const error = validationEnvelope(result);
+    const issues = asTestRaw<{ path: string }[]>(error["issues"]);
+    expect(issues.some(({ path }) => path === "fields.0")).toBe(true);
+  });
+
   test("save_template rejects unknown field metadata keys before inserting", async () => {
     const result = await handleMcpToolCall({
       args: {

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -1440,7 +1440,10 @@ describe("MCP template tools", () => {
           {
             path: "company",
             aiPrompt: "Draft the company details",
-            lookup: { registry: "krs" },
+            lookup: {
+              registry: "krs",
+              formats: [{ key: "default", template: "[name]" }],
+            },
           },
         ],
       },

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -26,7 +26,7 @@ import {
   buildAiOccurrenceAdapter,
 } from "@/api/lib/docx/ai-field-generator";
 import type { FieldMeta, FieldPart } from "@/api/lib/docx/types";
-import { INPUT_TYPES, isFieldMeta } from "@/api/lib/docx/types";
+import { fieldMetaToolInputSchema } from "@/api/lib/docx/types";
 import { validateDocxBuffer } from "@/api/lib/entity-versions/validate-docx-buffer";
 import { FILE_SIZE_LIMIT_BYTES, LIMITS } from "@/api/lib/limits";
 import {
@@ -97,6 +97,7 @@ import {
   toolDataResult,
   validationErrorResult,
 } from "@/api/mcp/tool-utils";
+import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
 type TemplateToolName =
@@ -109,106 +110,84 @@ type TemplateToolName =
 const TEMPLATE_FILL_TEXT_MAX_CHARS = 16_000;
 const SAVE_FILLED_TEMPLATE_RENDER_TIMEOUT_MS = 300_000;
 
-/**
- * One field-configuration overlay entry. Each object configures the field at
- * `path` (a marker discovered in the DOCX); every property except `path` is
- * optional and merged onto the discovered/stored field. Shape mirrors
- * `FieldMeta`, validated with the same `isFieldMeta` the REST manifest overlay
- * uses. JSON Schema is kept loose (`additionalProperties`) so callers can pass
- * the full shape; the handler validates each entry strictly.
- */
-const fieldConfigItemSchema = {
-  type: "object",
-  properties: {
-    path: stringProp("Field path — must match a {{marker}} in the template"),
-    label: stringProp("Human-readable field label"),
-    hint: stringProp(
-      "Short fill guidance shown to the person filling the field",
-    ),
-    inputType: enumProp("Input control type", INPUT_TYPES),
-    required: { type: "boolean", description: "Whether a value is required" },
-    options: {
-      type: "array",
-      items: { type: "string" },
-      description: "Allowed values when inputType is 'select'",
-    },
-    optionsFrom: stringProp(
-      "Dependent select: path of another field whose value(s) supply the options",
-    ),
-    aiPrompt: stringProp(
-      "Who-fills = AI: instruction the model uses to draft the value at fill time",
-    ),
-    aiAdapt: {
-      type: "boolean",
-      description:
-        "Who-fills = Person+AI: the entered value is a stub AI rewrites per occurrence",
-    },
-    formula: stringProp(
-      "Who-fills = formula: arithmetic expression over other fields, derived at fill time",
-    ),
-    condition: stringProp(
-      "Boolean field derived by rule: a condition expression (e.g. " +
-        'client_type == "company"), evaluated at fill time. A {{#if field_path}} ' +
-        "marker references it by path. Mutually exclusive with " +
-        "formula/aiPrompt/aiAdapt/lookup/parts.",
-    ),
-    parts: {
-      type: "array",
-      description: "Composite field parts (joined by 'format')",
-      items: { type: "object", additionalProperties: true },
-    },
-    format: stringProp(
-      "Join template over composite part keys, e.g. '{{title}} {{name}}'",
-    ),
-    dateFormat: {
-      type: "object",
-      description: "Locale-aware date rendering for a date field",
-      properties: {
-        locale: stringProp("BCP-47 language tag, e.g. 'cs', 'de', 'pl'"),
-        style: enumProp("Date style", ["long", "medium", "short", "iso"]),
-      },
-      required: ["locale", "style"],
-    },
-    lookup: {
-      type: "object",
-      description: "Who-fills = company-register lookup",
-      properties: {
-        registry: stringProp("Registry slug, e.g. 'krs'"),
-        formats: {
-          type: "array",
-          description:
-            "Named output renderings; the first is the default for the bare {{marker}}",
-          items: {
-            type: "object",
-            properties: {
-              key: stringProp("Marker segment after the path: {{path.key}}"),
-              template: stringProp(
-                "[token]-substituted rendering of the registry hit",
-              ),
-            },
-            required: ["key", "template"],
-          },
-        },
-      },
-      required: ["registry", "formats"],
-    },
-  },
-  required: ["path"],
-  additionalProperties: false,
-} as const;
+// Base64 encodes 3 bytes per 4 chars, so bound the encoded length to the doc
+// size limit and reject an oversized upload at parse time, before it is decoded
+// into a Buffer.
+const MAX_DOCX_BASE64_LENGTH =
+  Math.ceil(FILE_SIZE_LIMIT_BYTES.document / 3) * 4;
 
-const fieldsOverlayProp = {
-  type: "array",
-  description:
-    "Field configuration overlay, one entry per field to configure. Each " +
-    "entry's 'path' must match a {{marker}} in the template. Configurable: " +
-    "label, hint, inputType, required, options, optionsFrom (dependent select), " +
-    "date format, composite parts + format, and who-fills the field — a person " +
-    "(default), AI (aiPrompt), Person+AI (aiAdapt), a formula, or a " +
-    "company-register lookup (registry + named output formats). formula is " +
-    "mutually exclusive with aiPrompt/aiAdapt/lookup/parts.",
-  items: fieldConfigItemSchema,
-} as const;
+const saveTemplateArgsSchema = v.pipe(
+  v.strictObject({
+    template_id: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.description(
+          "Existing template id to configure; omit when creating a template",
+        ),
+      ),
+    ),
+    name: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.maxLength(256),
+        v.description("Template display name; required when creating"),
+      ),
+    ),
+    docx_base64: v.optional(
+      v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.maxLength(MAX_DOCX_BASE64_LENGTH),
+        v.description(
+          "Base64-encoded DOCX bytes; required when creating, omit when configuring",
+        ),
+      ),
+    ),
+    fields: v.optional(
+      v.pipe(
+        v.array(fieldMetaToolInputSchema),
+        v.description(
+          "Strict field configuration overlay; each path must match a template marker",
+        ),
+      ),
+    ),
+  }),
+  v.partialCheck(
+    [["template_id"], ["docx_base64"]],
+    ({ template_id, docx_base64 }) =>
+      (template_id === undefined) !== (docx_base64 === undefined),
+    "Provide docx_base64 to create a template, or template_id to configure an existing template's fields",
+  ),
+  v.forward(
+    v.partialCheck(
+      [["docx_base64"], ["name"]],
+      ({ docx_base64, name }) =>
+        docx_base64 === undefined || name !== undefined,
+      "name is required to create a template",
+    ),
+    ["name"],
+  ),
+  v.forward(
+    v.partialCheck(
+      [["template_id"], ["name"]],
+      ({ template_id, name }) =>
+        template_id === undefined || name === undefined,
+      "name applies only when creating a template; omit it when configuring",
+    ),
+    ["name"],
+  ),
+  v.forward(
+    v.partialCheck(
+      [["template_id"], ["fields"]],
+      ({ template_id, fields }) =>
+        template_id === undefined || fields !== undefined,
+      "fields is required to configure a template",
+    ),
+    ["fields"],
+  ),
+);
 
 // --- Text-field specs (plan 049, Option B) --------------------------------
 //
@@ -405,6 +384,36 @@ const buildTemplateDetailTextFieldSpecs = (
   }),
 ];
 
+const SAVE_TEMPLATE_TOOL_DEFINITION = defineValibotMcpTool({
+  description:
+    "Create a document template from a DOCX, or configure an existing " +
+    "template's fields. To create, pass docx_base64 (base64-encoded .docx / " +
+    "Office Open XML bytes, max ~10 MB decoded) and a name; the {{field}} " +
+    "markers in the file become the template's fillable fields, and you can " +
+    "pass fields to configure them in the same call. To configure an existing " +
+    "template, pass template_id with fields and no docx_base64; only the " +
+    "manifest changes, the document's {{markers}} stay untouched. Each fields " +
+    "entry's path must match a {{marker}} in the template. Read the marker " +
+    "grammar from the template-markers reference resource when unsure. " +
+    "Returns the template id and field count when creating, or the updated " +
+    "field list when configuring.",
+  inputSchema: saveTemplateArgsSchema,
+  jsonSchemaProjectionWaiver: {
+    ignoreActions: ["check", "finite", "partial_check"],
+    reason:
+      "Field compatibility checks remain runtime-only; JSON numbers are finite on the wire.",
+  },
+  annotations: {
+    title: "Save template",
+    idempotentHint: false,
+    openWorldHint: false,
+  },
+  access: "write",
+  anonymized: { exposure: "excluded", reason: "write" },
+  name: "save_template",
+  scope: "stella:templates",
+});
+
 export const TEMPLATE_TOOL_DEFINITIONS = [
   {
     annotations: {
@@ -555,44 +564,7 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
     name: "save_filled_template",
     scope: "stella:documents_write",
   },
-  {
-    description:
-      "Create a document template from a DOCX, or configure an existing " +
-      "template's fields. To create, pass docx_base64 (base64-encoded .docx / " +
-      "Office Open XML bytes, max ~10 MB decoded) and a name; the {{field}} " +
-      "markers in the file become the template's fillable fields, and you can " +
-      "pass fields to configure them in the same call. To configure an existing " +
-      "template, pass template_id with fields and no docx_base64; only the " +
-      "manifest changes, the document's {{markers}} stay untouched. Each fields " +
-      "entry's path must match a {{marker}} in the template. Read the marker " +
-      "grammar from the template-markers reference resource when unsure. " +
-      "Returns the template id and field count when creating, or the updated " +
-      "field list when configuring.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        template_id: stringProp(
-          "Existing template id to configure its fields; omit (with docx_base64) to create a new template",
-        ),
-        name: stringProp("Template display name; required when creating", {
-          maxLength: 256,
-        }),
-        docx_base64: stringProp(
-          "Base64-encoded DOCX file bytes (Office Open XML, max ~10 MB decoded); required when creating, omit when configuring",
-        ),
-        fields: fieldsOverlayProp,
-      },
-    },
-    annotations: {
-      title: "Save template",
-      idempotentHint: false,
-      openWorldHint: false,
-    },
-    access: "write",
-    anonymized: { exposure: "excluded", reason: "write" },
-    name: "save_template",
-    scope: "stella:templates",
-  },
+  SAVE_TEMPLATE_TOOL_DEFINITION,
 ] as const satisfies readonly McpToolDefinition[];
 
 const listTemplatesArgsSchema = v.strictObject({
@@ -1431,12 +1403,6 @@ const handleSaveFilledTemplateTool: McpToolHandler = async ({
   return toolDataResult(persistence.value.value);
 };
 
-// base64 encodes 3 bytes per 4 chars, so bound the encoded length to the doc
-// size limit and reject an oversized upload at parse time, before it is decoded
-// into a Buffer.
-const MAX_DOCX_BASE64_LENGTH =
-  Math.ceil(FILE_SIZE_LIMIT_BYTES.document / 3) * 4;
-
 /**
  * Prefer a cross-field (`partial_check`) validation message when present,
  * falling back to the hand-written shape hint for structural failures.
@@ -1447,81 +1413,6 @@ const crossFieldOrGeneric = (
 ): string =>
   issues.find((issue) => issue.type === "partial_check")?.message ??
   genericMessage;
-
-const saveTemplateArgsSchema = v.pipe(
-  v.strictObject({
-    template_id: v.optional(v.pipe(v.string(), v.minLength(1))),
-    name: v.optional(v.pipe(v.string(), v.minLength(1), v.maxLength(256))),
-    docx_base64: v.optional(
-      v.pipe(v.string(), v.minLength(1), v.maxLength(MAX_DOCX_BASE64_LENGTH)),
-    ),
-    // Validated structurally below with isFieldMeta — the same validator the
-    // REST manifest overlay uses — so the JSON-schema-level shape stays loose.
-    fields: v.optional(v.array(v.unknown())),
-  }),
-  // Exactly one mode: create (docx_base64, no template_id) or configure
-  // (template_id, no docx_base64). Both absent or both present is rejected.
-  v.partialCheck(
-    [["template_id"], ["docx_base64"]],
-    ({ template_id, docx_base64 }) =>
-      (template_id === undefined) !== (docx_base64 === undefined),
-    "Provide docx_base64 to create a template, or template_id to configure an existing template's fields",
-  ),
-  // Creating (docx_base64) requires a name.
-  v.forward(
-    v.partialCheck(
-      [["docx_base64"], ["name"]],
-      ({ docx_base64, name }) =>
-        docx_base64 === undefined || name !== undefined,
-      "name is required to create a template",
-    ),
-    ["name"],
-  ),
-  // name applies only to creation; a configure call must not send it.
-  v.forward(
-    v.partialCheck(
-      [["template_id"], ["name"]],
-      ({ template_id, name }) =>
-        template_id === undefined || name === undefined,
-      "name applies only when creating a template; omit it when configuring",
-    ),
-    ["name"],
-  ),
-  // Configuring (template_id) requires a fields overlay to apply.
-  v.forward(
-    v.partialCheck(
-      [["template_id"], ["fields"]],
-      ({ template_id, fields }) =>
-        template_id === undefined || fields !== undefined,
-      "fields is required to configure a template",
-    ),
-    ["fields"],
-  ),
-);
-
-/**
- * Validate a raw `fields` overlay with the SAME `isFieldMeta` validator the
- * REST manifest path uses. Returns the typed fields, or the offending entry's
- * index so the caller can name it. `isFieldMeta` also enforces the
- * mutual-exclusivity rules (formula vs aiPrompt/aiAdapt/lookup/parts; parts iff
- * format).
- */
-type FieldsOverlayResult =
-  | { ok: true; fields: FieldMeta[] }
-  | { ok: false; index: number };
-
-const validateFieldsOverlay = (
-  fields: readonly unknown[],
-): FieldsOverlayResult => {
-  const validated: FieldMeta[] = [];
-  for (const [index, field] of fields.entries()) {
-    if (!isFieldMeta(field)) {
-      return { ok: false, index };
-    }
-    validated.push(field);
-  }
-  return { ok: true, fields: validated };
-};
 
 // Create branch of save_template: a new template from an uploaded DOCX, with an
 // optional field-configuration overlay. Reused from the former create_template
@@ -1534,7 +1425,7 @@ const createTemplateFromDocx = async ({
 }: {
   context: McpRequestContext;
   docxBase64: string;
-  fields: readonly unknown[] | undefined;
+  fields: FieldMeta[] | undefined;
   name: string;
 }): Promise<
   InternalToolResult<v.InferInput<typeof SAVE_TEMPLATE_PROJECTION>>
@@ -1548,23 +1439,7 @@ const createTemplateFromDocx = async ({
 
   let clientManifest: { fields: FieldMeta[] } | null = null;
   if (fields !== undefined) {
-    const overlay = validateFieldsOverlay(fields);
-    if (!overlay.ok) {
-      return structuredErrorResult({
-        code: "validation_error",
-        message:
-          `Invalid field config at fields[${overlay.index}]: not a valid ` +
-          "field configuration (check input type, lookup, and that formula is " +
-          "not combined with aiPrompt/aiAdapt/lookup/parts).",
-        issues: [
-          {
-            path: `fields.${overlay.index}`,
-            message: "Not a valid field configuration",
-          },
-        ],
-      });
-    }
-    clientManifest = { fields: overlay.fields };
+    clientManifest = { fields };
   }
 
   const buffer = Buffer.from(docxBase64, "base64");
@@ -1640,7 +1515,7 @@ const configureExistingTemplate = async ({
   templateId: rawTemplateId,
 }: {
   context: McpRequestContext;
-  fields: readonly unknown[];
+  fields: FieldMeta[];
   templateId: string;
 }): Promise<
   InternalToolResult<v.InferInput<typeof SAVE_TEMPLATE_PROJECTION>>
@@ -1652,23 +1527,6 @@ const configureExistingTemplate = async ({
     return errorResult("Forbidden");
   }
 
-  const overlay = validateFieldsOverlay(fields);
-  if (!overlay.ok) {
-    return structuredErrorResult({
-      code: "validation_error",
-      message:
-        `Invalid field config at fields[${overlay.index}]: not a valid field ` +
-        "configuration (check input type, lookup, and that formula is not " +
-        "combined with aiPrompt/aiAdapt/lookup/parts).",
-      issues: [
-        {
-          path: `fields.${overlay.index}`,
-          message: "Not a valid field configuration",
-        },
-      ],
-    });
-  }
-
   const templateId = brandPersistedTemplateId(rawTemplateId);
 
   const configured = await Result.gen(() =>
@@ -1676,7 +1534,7 @@ const configureExistingTemplate = async ({
       safeDb: context.safeDb,
       organizationId: context.organizationId,
       templateId,
-      fields: overlay.fields,
+      fields,
       recordAuditEvent: context.recordAuditEvent,
     }),
   );
@@ -1705,7 +1563,10 @@ const configureExistingTemplate = async ({
 const handleSaveTemplateTool: TypedMcpToolHandler<
   v.InferInput<typeof SAVE_TEMPLATE_PROJECTION>
 > = async ({ args, context }) => {
-  const parsed = v.safeParse(saveTemplateArgsSchema, args);
+  const parsed = v.safeParse(
+    SAVE_TEMPLATE_TOOL_DEFINITION.inputSchemaSource,
+    args,
+  );
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -15,7 +15,9 @@ import { assertUsageAvailableForHandler } from "@/api/lib/api-handlers";
 import type {
   AssertNoExtraFields,
   LIST_TEMPLATES_LIST_PROJECTION,
+  LIST_TEMPLATES_PROJECTION,
   SAVE_TEMPLATE_CREATE_PROJECTION,
+  SAVE_TEMPLATE_PROJECTION,
   TEMPLATE_DESCRIBE_PROJECTION,
 } from "@/api/lib/chat/projections";
 import {
@@ -77,6 +79,7 @@ import type {
   McpTextFieldSpec,
   McpToolDefinition,
   McpToolHandler,
+  TypedMcpToolHandler,
 } from "@/api/mcp/tool-types";
 import { defineMcpToolSet } from "@/api/mcp/tool-types";
 import {
@@ -607,7 +610,9 @@ const decodeTemplatePageCursor = (cursor: string): string | null => {
   return isUuidPaginationCursorPart(rawId) ? rawId : null;
 };
 
-const handleListTemplatesTool: McpToolHandler = async ({ args, context }) => {
+const handleListTemplatesTool: TypedMcpToolHandler<
+  v.InferInput<typeof LIST_TEMPLATES_PROJECTION>
+> = async ({ args, context }) => {
   const hasPermission = roles[context.memberRole].authorize({
     workspace: ["read"],
   });
@@ -719,7 +724,9 @@ const describeTemplateArgsSchema = v.strictObject({
 // Detail branch of list_templates: one template's field configuration. Reused
 // verbatim from the former describe_template tool, which list_templates
 // absorbed. The caller (list_templates) already checked the read permission.
-const describeTemplateDetail: McpToolHandler = async ({ args, context }) => {
+const describeTemplateDetail: TypedMcpToolHandler<
+  v.InferInput<typeof LIST_TEMPLATES_PROJECTION>
+> = async ({ args, context }) => {
   const parsed = v.safeParse(describeTemplateArgsSchema, args);
   if (!parsed.success) {
     return validationErrorResult({
@@ -1529,7 +1536,9 @@ const createTemplateFromDocx = async ({
   docxBase64: string;
   fields: readonly unknown[] | undefined;
   name: string;
-}): Promise<InternalToolResult> => {
+}): Promise<
+  InternalToolResult<v.InferInput<typeof SAVE_TEMPLATE_PROJECTION>>
+> => {
   const hasPermission = roles[context.memberRole].authorize({
     template: ["create"],
   });
@@ -1633,7 +1642,9 @@ const configureExistingTemplate = async ({
   context: McpRequestContext;
   fields: readonly unknown[];
   templateId: string;
-}): Promise<InternalToolResult> => {
+}): Promise<
+  InternalToolResult<v.InferInput<typeof SAVE_TEMPLATE_PROJECTION>>
+> => {
   const hasPermission = roles[context.memberRole].authorize({
     template: ["update"],
   });
@@ -1691,7 +1702,9 @@ const configureExistingTemplate = async ({
   return toolDataResult(described satisfies ConfiguredTemplatePayload);
 };
 
-const handleSaveTemplateTool: McpToolHandler = async ({ args, context }) => {
+const handleSaveTemplateTool: TypedMcpToolHandler<
+  v.InferInput<typeof SAVE_TEMPLATE_PROJECTION>
+> = async ({ args, context }) => {
   const parsed = v.safeParse(saveTemplateArgsSchema, args);
   if (!parsed.success) {
     return validationErrorResult({

--- a/apps/api/src/mcp/tool-types.test.ts
+++ b/apps/api/src/mcp/tool-types.test.ts
@@ -1,0 +1,58 @@
+import { describe, test } from "bun:test";
+import { expectTypeOf } from "expect-type";
+
+import type {
+  AllHandlerOutputsTyped,
+  HandlerOutputsMatchByName,
+  McpToolHandler,
+  TypedMcpToolHandler,
+} from "@/api/mcp/tool-types";
+
+type HandlerMap<TData> = {
+  test_tool: TypedMcpToolHandler<TData>;
+};
+
+type UnvalidatedJson = ReturnType<typeof JSON.parse>;
+
+describe("typed tool output contract", () => {
+  test("accepts a declared record output", () => {
+    expectTypeOf<
+      AllHandlerOutputsTyped<HandlerMap<{ id: string }>, "test_tool">
+    >().toEqualTypeOf<true>();
+  });
+
+  test("rejects broad and missing output types", () => {
+    expectTypeOf<
+      AllHandlerOutputsTyped<HandlerMap<UnvalidatedJson>, "test_tool">
+    >().toEqualTypeOf<false>();
+    expectTypeOf<
+      AllHandlerOutputsTyped<HandlerMap<never>, "test_tool">
+    >().toEqualTypeOf<false>();
+    expectTypeOf<
+      AllHandlerOutputsTyped<HandlerMap<unknown>, "test_tool">
+    >().toEqualTypeOf<false>();
+    expectTypeOf<
+      AllHandlerOutputsTyped<HandlerMap<Record<string, unknown>>, "test_tool">
+    >().toEqualTypeOf<false>();
+    expectTypeOf<
+      AllHandlerOutputsTyped<{ test_tool: McpToolHandler }, "test_tool">
+    >().toEqualTypeOf<false>();
+  });
+
+  test("binds each handler output to its named projection contract", () => {
+    expectTypeOf<
+      HandlerOutputsMatchByName<
+        HandlerMap<{ id: string }>,
+        { test_tool: { id: string } },
+        "test_tool"
+      >
+    >().toEqualTypeOf<true>();
+    expectTypeOf<
+      HandlerOutputsMatchByName<
+        HandlerMap<{ id: string }>,
+        { test_tool: { name: string } },
+        "test_tool"
+      >
+    >().toEqualTypeOf<false>();
+  });
+});

--- a/apps/api/src/mcp/tool-types.ts
+++ b/apps/api/src/mcp/tool-types.ts
@@ -402,13 +402,63 @@ export type TypedHandlerDataByName<
   [TName in TNames]: TypedHandlerData<THandlers[TName]>;
 };
 
-export type AllHandlerOutputsTyped<THandlers, TNames extends keyof THandlers> =
-  Pick<THandlers, TNames> extends Record<
-    TNames,
-    TypedMcpToolHandler<Record<string, unknown>>
-  >
+type IsAny<TValue> = 0 extends 1 & TValue ? true : false;
+
+type IsNever<TValue> = [TValue] extends [never] ? true : false;
+
+type IsUnknown<TValue> = IsAny<TValue> extends true
+  ? false
+  : unknown extends TValue
     ? true
     : false;
+
+type IsBroadRecord<TValue> = string extends keyof TValue ? true : false;
+
+type HandlerOutputIsTyped<
+  THandler,
+  TData = TypedHandlerData<THandler>,
+> = IsNever<TData> extends true
+  ? false
+  : IsAny<TData> extends true
+    ? false
+    : IsUnknown<TData> extends true
+      ? false
+      : IsBroadRecord<TData> extends true
+        ? false
+        : TData extends Record<string, unknown>
+          ? true
+          : false;
+
+type HandlerOutputMatches<THandler, TExpected> =
+  HandlerOutputIsTyped<THandler> extends true
+    ? [TypedHandlerData<THandler>] extends [TExpected]
+      ? [TExpected] extends [TypedHandlerData<THandler>]
+        ? true
+        : false
+      : false
+    : false;
+
+export type AllHandlerOutputsTyped<
+  THandlers,
+  TNames extends keyof THandlers,
+> = false extends {
+  [TName in TNames]: HandlerOutputIsTyped<THandlers[TName]>;
+}[TNames]
+  ? false
+  : true;
+
+export type HandlerOutputsMatchByName<
+  THandlers,
+  TExpectedByName,
+  TNames extends keyof THandlers & keyof TExpectedByName,
+> = false extends {
+  [TName in TNames]: HandlerOutputMatches<
+    THandlers[TName],
+    TExpectedByName[TName]
+  >;
+}[TNames]
+  ? false
+  : true;
 
 export type AssertTrue<TValue extends true> = TValue;
 

--- a/apps/api/src/mcp/tool-types.ts
+++ b/apps/api/src/mcp/tool-types.ts
@@ -367,6 +367,10 @@ export type McpToolResponse<TData = unknown> =
   | InternalToolResult<TData>
   | McpEgressPlan<TData>;
 
+export type TypedMcpToolResponse<TData> =
+  | InternalToolResult<TData>
+  | Extract<McpEgressPlan<TData>, { egress: "structured" }>;
+
 export const isMcpEgressPlan = (
   response: McpToolResponse,
 ): response is McpEgressPlan => "egress" in response;
@@ -378,6 +382,35 @@ export type McpToolHandler<TData = unknown> = ({
   args: Record<string, unknown>;
   context: McpRequestContext;
 }) => McpToolResponse<TData> | Promise<McpToolResponse<TData>>;
+
+type TypedMcpToolHandlerResult<TData> =
+  | TypedMcpToolResponse<TData>
+  | Promise<TypedMcpToolResponse<TData>>;
+
+export type TypedMcpToolHandler<TData> = (options: {
+  args: Record<string, unknown>;
+  context: McpRequestContext;
+}) => TypedMcpToolHandlerResult<TData>;
+
+type TypedHandlerData<THandler> =
+  THandler extends TypedMcpToolHandler<infer TData> ? TData : never;
+
+export type TypedHandlerDataByName<
+  THandlers,
+  TNames extends keyof THandlers,
+> = {
+  [TName in TNames]: TypedHandlerData<THandlers[TName]>;
+};
+
+export type AllHandlerOutputsTyped<THandlers, TNames extends keyof THandlers> =
+  Pick<THandlers, TNames> extends Record<
+    TNames,
+    TypedMcpToolHandler<Record<string, unknown>>
+  >
+    ? true
+    : false;
+
+export type AssertTrue<TValue extends true> = TValue;
 
 export type McpToolHandlerMap<
   TDefinitions extends readonly McpToolDefinition[],

--- a/apps/api/src/mcp/tool-types.ts
+++ b/apps/api/src/mcp/tool-types.ts
@@ -414,20 +414,18 @@ type IsUnknown<TValue> = IsAny<TValue> extends true
 
 type IsBroadRecord<TValue> = string extends keyof TValue ? true : false;
 
-type HandlerOutputIsTyped<
-  THandler,
-  TData = TypedHandlerData<THandler>,
-> = IsNever<TData> extends true
-  ? false
-  : IsAny<TData> extends true
+type HandlerOutputIsTyped<THandler, TData = TypedHandlerData<THandler>> =
+  IsNever<TData> extends true
     ? false
-    : IsUnknown<TData> extends true
+    : IsAny<TData> extends true
       ? false
-      : IsBroadRecord<TData> extends true
+      : IsUnknown<TData> extends true
         ? false
-        : TData extends Record<string, unknown>
-          ? true
-          : false;
+        : IsBroadRecord<TData> extends true
+          ? false
+          : TData extends Record<string, unknown>
+            ? true
+            : false;
 
 type HandlerOutputMatches<THandler, TExpected> =
   HandlerOutputIsTyped<THandler> extends true
@@ -438,14 +436,12 @@ type HandlerOutputMatches<THandler, TExpected> =
       : false
     : false;
 
-export type AllHandlerOutputsTyped<
-  THandlers,
-  TNames extends keyof THandlers,
-> = false extends {
-  [TName in TNames]: HandlerOutputIsTyped<THandlers[TName]>;
-}[TNames]
-  ? false
-  : true;
+export type AllHandlerOutputsTyped<THandlers, TNames extends keyof THandlers> =
+  false extends {
+    [TName in TNames]: HandlerOutputIsTyped<THandlers[TName]>;
+  }[TNames]
+    ? false
+    : true;
 
 export type HandlerOutputsMatchByName<
   THandlers,

--- a/apps/api/src/mcp/tool-types.ts
+++ b/apps/api/src/mcp/tool-types.ts
@@ -406,11 +406,8 @@ type IsAny<TValue> = 0 extends 1 & TValue ? true : false;
 
 type IsNever<TValue> = [TValue] extends [never] ? true : false;
 
-type IsUnknown<TValue> = IsAny<TValue> extends true
-  ? false
-  : unknown extends TValue
-    ? true
-    : false;
+type IsUnknown<TValue> =
+  IsAny<TValue> extends true ? false : unknown extends TValue ? true : false;
 
 type IsBroadRecord<TValue> = string extends keyof TValue ? true : false;
 
@@ -436,12 +433,14 @@ type HandlerOutputMatches<THandler, TExpected> =
       : false
     : false;
 
-export type AllHandlerOutputsTyped<THandlers, TNames extends keyof THandlers> =
-  false extends {
-    [TName in TNames]: HandlerOutputIsTyped<THandlers[TName]>;
-  }[TNames]
-    ? false
-    : true;
+export type AllHandlerOutputsTyped<
+  THandlers,
+  TNames extends keyof THandlers,
+> = false extends {
+  [TName in TNames]: HandlerOutputIsTyped<THandlers[TName]>;
+}[TNames]
+  ? false
+  : true;
 
 export type HandlerOutputsMatchByName<
   THandlers,

--- a/apps/api/src/mcp/tool-utils.test.ts
+++ b/apps/api/src/mcp/tool-utils.test.ts
@@ -13,6 +13,7 @@ import {
   closestToolNames,
   ensureActiveWorkspace,
   ensureWorkspaceAccess,
+  ISO_DATE_SCHEMA,
   isToolErrorResult,
   mapValibotIssues,
   notFoundResult,
@@ -31,6 +32,13 @@ import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 // the test env preload; getAppBaseUrl() strips any trailing slash.
 const BASE = "http://localhost:3000";
 const WORKSPACE_ID = toSafeId<"workspace">("ws_1");
+
+describe("MCP ISO date contract", () => {
+  test("accepts ISO dates and rejects out-of-range date components", () => {
+    expect(v.is(ISO_DATE_SCHEMA, "2026-08-23")).toBe(true);
+    expect(v.is(ISO_DATE_SCHEMA, "2026-99-99")).toBe(false);
+  });
+});
 
 const createWorkspaceGateContext = (
   status: "active" | "archived",

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -55,6 +55,7 @@ export const MAX_LIST_LIMIT = LIMITS.mcpListPageSizeMax;
 export const MAX_SEARCH_LIMIT = LIMITS.mcpSearchPageSizeMax;
 export const DEFAULT_COMPAT_SEARCH_LIMIT =
   LIMITS.mcpCompatSearchPageSizeDefault;
+export const ISO_DATE_SCHEMA = v.pipe(v.string(), v.isoDate());
 
 type LocalToolExecutionOptions = {
   messages: [];

--- a/apps/api/src/mcp/valibot-tool-definition.test.ts
+++ b/apps/api/src/mcp/valibot-tool-definition.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import * as v from "valibot";
+
+import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
+
+describe("Valibot-backed MCP tool definitions", () => {
+  test("derives the wire schema from the handler's strict runtime schema", () => {
+    const inputSchema = v.strictObject({
+      from: v.pipe(
+        v.string(),
+        v.isoTimestamp(),
+        v.description("Inclusive ISO timestamp"),
+      ),
+      limit: v.optional(
+        v.pipe(
+          v.number(),
+          v.integer(),
+          v.minValue(1),
+          v.maxValue(100),
+          v.description("Maximum rows"),
+        ),
+      ),
+      score: v.optional(
+        v.pipe(
+          v.number(),
+          v.finite(),
+          v.description("Finite relevance score"),
+        ),
+      ),
+    });
+    const definition = defineValibotMcpTool({
+      access: "read",
+      annotations: { title: "Read example", readOnlyHint: true },
+      anonymized: { exposure: "passthrough" },
+      description: "Read an example.",
+      inputSchema,
+      jsonSchemaProjectionWaiver: {
+        ignoreActions: ["finite"],
+        reason: "JSON numbers are finite on the MCP wire.",
+      },
+      name: "read_example",
+      scope: "stella:read",
+    });
+
+    expect(definition.inputSchemaSource).toBe(inputSchema);
+    expect(definition).not.toHaveProperty("jsonSchemaProjectionWaiver");
+    expect(definition.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        from: {
+          type: "string",
+          format: "date-time",
+          description: "Inclusive ISO timestamp",
+        },
+        limit: {
+          type: "integer",
+          minimum: 1,
+          maximum: 100,
+          description: "Maximum rows",
+        },
+        score: {
+          type: "number",
+          description: "Finite relevance score",
+        },
+      },
+      required: ["from"],
+      additionalProperties: false,
+    });
+    expect(definition.inputSchema).not.toHaveProperty("$schema");
+
+    // The handler parses the exact schema object supplied to the definition;
+    // generated JSON is transport metadata, never a second runtime validator.
+    expect(
+      v.safeParse(definition.inputSchemaSource, {
+        from: "2026-08-23T12:00:00Z",
+        limit: 20,
+      }).success,
+    ).toBe(true);
+    expect(
+      v.safeParse(definition.inputSchemaSource, {
+        from: "August 23, 2026",
+        limit: 20,
+        ignored: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  test("rejects an unsupported action without an explicit projection waiver", () => {
+    expect(() =>
+      defineValibotMcpTool({
+        access: "read",
+        annotations: { title: "Read example", readOnlyHint: true },
+        anonymized: { exposure: "passthrough" },
+        description: "Read an example.",
+        inputSchema: v.strictObject({
+          score: v.pipe(v.number(), v.finite()),
+        }),
+        name: "read_example",
+        scope: "stella:read",
+      }),
+    ).toThrow(/finite/u);
+  });
+
+  test("rejects an input schema that admits unknown root properties", () => {
+    expect(() =>
+      defineValibotMcpTool({
+        access: "read",
+        annotations: { title: "Read example", readOnlyHint: true },
+        anonymized: { exposure: "passthrough" },
+        description: "Read an example.",
+        inputSchema: v.looseObject({ query: v.string() }),
+        name: "read_example",
+        scope: "stella:read",
+      }),
+    ).toThrow(
+      "A native MCP tool input schema must reject unknown root properties",
+    );
+  });
+});

--- a/apps/api/src/mcp/valibot-tool-definition.test.ts
+++ b/apps/api/src/mcp/valibot-tool-definition.test.ts
@@ -21,11 +21,7 @@ describe("Valibot-backed MCP tool definitions", () => {
         ),
       ),
       score: v.optional(
-        v.pipe(
-          v.number(),
-          v.finite(),
-          v.description("Finite relevance score"),
-        ),
+        v.pipe(v.number(), v.finite(), v.description("Finite relevance score")),
       ),
     });
     const definition = defineValibotMcpTool({

--- a/apps/api/src/mcp/valibot-tool-definition.test.ts
+++ b/apps/api/src/mcp/valibot-tool-definition.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { expectTypeOf } from "expect-type";
 import * as v from "valibot";
 
 import { defineValibotMcpTool } from "@/api/mcp/valibot-tool-definition";
@@ -38,6 +39,10 @@ describe("Valibot-backed MCP tool definitions", () => {
       scope: "stella:read",
     });
 
+    expectTypeOf(definition.name).toEqualTypeOf<"read_example">();
+    expectTypeOf(definition.inputSchemaSource).toEqualTypeOf<
+      typeof inputSchema
+    >();
     expect(definition.inputSchemaSource).toBe(inputSchema);
     expect(definition).not.toHaveProperty("jsonSchemaProjectionWaiver");
     expect(definition.inputSchema).toEqual({

--- a/apps/api/src/mcp/valibot-tool-definition.ts
+++ b/apps/api/src/mcp/valibot-tool-definition.ts
@@ -57,16 +57,20 @@ const deriveMcpInputSchema = (
  */
 export const defineValibotMcpTool = <
   const TSchema extends v.GenericSchema,
-  const TDefinition extends Omit<McpToolDefinition, "inputSchema">,
+  const TName extends string,
+  const TDefinition extends Omit<McpToolDefinition, "inputSchema" | "name">,
 >({
   inputSchema,
   jsonSchemaProjectionWaiver,
+  name,
   ...definition
 }: TDefinition & {
   inputSchema: TSchema;
   jsonSchemaProjectionWaiver?: JsonSchemaProjectionWaiver;
+  name: TName;
 }) => ({
   ...definition,
   inputSchema: deriveMcpInputSchema(inputSchema, jsonSchemaProjectionWaiver),
   inputSchemaSource: inputSchema,
+  name,
 });

--- a/apps/api/src/mcp/valibot-tool-definition.ts
+++ b/apps/api/src/mcp/valibot-tool-definition.ts
@@ -20,15 +20,17 @@ type JsonSchemaProjectionWaiver = {
   reason: string;
 };
 
-type ValibotMcpToolDefinition<
-  TSchema extends v.GenericSchema,
-  TDefinition extends Omit<McpToolDefinition, "inputSchema">,
-> = Omit<
+type ValibotMcpToolInput = Omit<McpToolDefinition, "inputSchema"> & {
+  inputSchema: v.GenericSchema;
+  jsonSchemaProjectionWaiver?: JsonSchemaProjectionWaiver;
+};
+
+type ValibotMcpToolDefinition<TDefinition extends ValibotMcpToolInput> = Omit<
   TDefinition,
   "inputSchema" | "jsonSchemaProjectionWaiver"
 > & {
   inputSchema: McpToolInputSchema;
-  inputSchemaSource: TSchema;
+  inputSchemaSource: TDefinition["inputSchema"];
 };
 
 const deriveMcpInputSchema = (
@@ -67,12 +69,10 @@ const deriveMcpInputSchema = (
  * to distinguish derived schemas from legacy hand-maintained mirrors.
  */
 export const defineValibotMcpTool = <
-  const TSchema extends v.GenericSchema,
-  const TDefinition extends Omit<McpToolDefinition, "inputSchema">,
->(definition: TDefinition & {
-  inputSchema: TSchema;
-  jsonSchemaProjectionWaiver?: JsonSchemaProjectionWaiver;
-}): ValibotMcpToolDefinition<TSchema, TDefinition> => {
+  const TDefinition extends ValibotMcpToolInput,
+>(
+  definition: TDefinition,
+): ValibotMcpToolDefinition<TDefinition> => {
   const { inputSchema, jsonSchemaProjectionWaiver, ...toolDefinition } =
     definition;
   return {

--- a/apps/api/src/mcp/valibot-tool-definition.ts
+++ b/apps/api/src/mcp/valibot-tool-definition.ts
@@ -1,6 +1,6 @@
 import { toJsonSchema } from "@valibot/to-json-schema";
 import { panic } from "better-result";
-import * as v from "valibot";
+import type * as v from "valibot";
 
 import type {
   McpToolDefinition,

--- a/apps/api/src/mcp/valibot-tool-definition.ts
+++ b/apps/api/src/mcp/valibot-tool-definition.ts
@@ -1,0 +1,65 @@
+import { toJsonSchema } from "@valibot/to-json-schema";
+import { panic } from "better-result";
+import * as v from "valibot";
+
+import type {
+  McpToolDefinition,
+  McpToolInputSchema,
+} from "@/api/mcp/tool-types";
+
+const VALIBOT_MCP_JSON_SCHEMA_CONFIG = {
+  errorMode: "throw",
+  target: "draft-07",
+  typeMode: "input",
+} as const;
+
+type ToJsonSchemaConfig = NonNullable<Parameters<typeof toJsonSchema>[1]>;
+
+type JsonSchemaProjectionWaiver = {
+  ignoreActions: NonNullable<ToJsonSchemaConfig["ignoreActions"]>;
+  reason: string;
+};
+
+const deriveMcpInputSchema = (
+  schema: v.GenericSchema,
+  projectionWaiver: JsonSchemaProjectionWaiver | undefined,
+): McpToolInputSchema => {
+  const { $schema: _dialect, ...jsonSchema } = toJsonSchema(
+    schema,
+    projectionWaiver === undefined
+      ? VALIBOT_MCP_JSON_SCHEMA_CONFIG
+      : {
+          ...VALIBOT_MCP_JSON_SCHEMA_CONFIG,
+          ignoreActions: projectionWaiver.ignoreActions,
+        },
+  );
+  if (jsonSchema.type !== "object") {
+    return panic("A native MCP tool input schema must accept an object root");
+  }
+  if (jsonSchema.additionalProperties !== false) {
+    return panic(
+      "A native MCP tool input schema must reject unknown root properties",
+    );
+  }
+
+  return { ...jsonSchema, type: "object" };
+};
+
+/**
+ * Defines a native tool from the same Valibot schema its handler parses.
+ * `inputSchemaSource` retains that actual schema as internal registry metadata:
+ * handlers parse through the definition, while wire projection selects only
+ * MCP protocol fields. The static compile-time ratchet also uses its presence
+ * to distinguish derived schemas from legacy hand-maintained mirrors.
+ */
+export const defineValibotMcpTool = <
+  const TSchema extends v.GenericSchema,
+  const TDefinition extends Omit<McpToolDefinition, "inputSchema"> & {
+    inputSchema: TSchema;
+    jsonSchemaProjectionWaiver?: JsonSchemaProjectionWaiver;
+  },
+>({ inputSchema, jsonSchemaProjectionWaiver, ...definition }: TDefinition) => ({
+  ...definition,
+  inputSchema: deriveMcpInputSchema(inputSchema, jsonSchemaProjectionWaiver),
+  inputSchemaSource: inputSchema,
+});

--- a/apps/api/src/mcp/valibot-tool-definition.ts
+++ b/apps/api/src/mcp/valibot-tool-definition.ts
@@ -42,7 +42,10 @@ const deriveMcpInputSchema = (
     );
   }
 
-  return { ...jsonSchema, type: "object" };
+  const { properties, ...objectSchema } = jsonSchema;
+  return properties === undefined
+    ? { ...objectSchema, type: "object" }
+    : { ...objectSchema, properties, type: "object" };
 };
 
 /**
@@ -53,9 +56,8 @@ const deriveMcpInputSchema = (
  * to distinguish derived schemas from legacy hand-maintained mirrors.
  */
 export const defineValibotMcpTool = <
-  const TSchema extends v.GenericSchema,
   const TDefinition extends Omit<McpToolDefinition, "inputSchema"> & {
-    inputSchema: TSchema;
+    inputSchema: v.GenericSchema;
     jsonSchemaProjectionWaiver?: JsonSchemaProjectionWaiver;
   },
 >({ inputSchema, jsonSchemaProjectionWaiver, ...definition }: TDefinition) => ({

--- a/apps/api/src/mcp/valibot-tool-definition.ts
+++ b/apps/api/src/mcp/valibot-tool-definition.ts
@@ -56,11 +56,16 @@ const deriveMcpInputSchema = (
  * to distinguish derived schemas from legacy hand-maintained mirrors.
  */
 export const defineValibotMcpTool = <
-  const TDefinition extends Omit<McpToolDefinition, "inputSchema"> & {
-    inputSchema: v.GenericSchema;
-    jsonSchemaProjectionWaiver?: JsonSchemaProjectionWaiver;
-  },
->({ inputSchema, jsonSchemaProjectionWaiver, ...definition }: TDefinition) => ({
+  const TSchema extends v.GenericSchema,
+  const TDefinition extends Omit<McpToolDefinition, "inputSchema">,
+>({
+  inputSchema,
+  jsonSchemaProjectionWaiver,
+  ...definition
+}: TDefinition & {
+  inputSchema: TSchema;
+  jsonSchemaProjectionWaiver?: JsonSchemaProjectionWaiver;
+}) => ({
   ...definition,
   inputSchema: deriveMcpInputSchema(inputSchema, jsonSchemaProjectionWaiver),
   inputSchemaSource: inputSchema,

--- a/apps/api/src/mcp/valibot-tool-definition.ts
+++ b/apps/api/src/mcp/valibot-tool-definition.ts
@@ -22,15 +22,13 @@ type JsonSchemaProjectionWaiver = {
 
 type ValibotMcpToolDefinition<
   TSchema extends v.GenericSchema,
-  TName extends string,
-  TDefinition extends Omit<McpToolDefinition, "inputSchema" | "name">,
+  TDefinition extends Omit<McpToolDefinition, "inputSchema">,
 > = Omit<
   TDefinition,
-  "inputSchema" | "jsonSchemaProjectionWaiver" | "name"
+  "inputSchema" | "jsonSchemaProjectionWaiver"
 > & {
   inputSchema: McpToolInputSchema;
   inputSchemaSource: TSchema;
-  name: TName;
 };
 
 const deriveMcpInputSchema = (
@@ -70,19 +68,16 @@ const deriveMcpInputSchema = (
  */
 export const defineValibotMcpTool = <
   const TSchema extends v.GenericSchema,
-  const TName extends string,
-  const TDefinition extends Omit<McpToolDefinition, "inputSchema" | "name">,
+  const TDefinition extends Omit<McpToolDefinition, "inputSchema">,
 >(definition: TDefinition & {
   inputSchema: TSchema;
   jsonSchemaProjectionWaiver?: JsonSchemaProjectionWaiver;
-  name: TName;
-}): ValibotMcpToolDefinition<TSchema, TName, TDefinition> => {
-  const { inputSchema, jsonSchemaProjectionWaiver, name, ...toolDefinition } =
+}): ValibotMcpToolDefinition<TSchema, TDefinition> => {
+  const { inputSchema, jsonSchemaProjectionWaiver, ...toolDefinition } =
     definition;
   return {
     ...toolDefinition,
     inputSchema: deriveMcpInputSchema(inputSchema, jsonSchemaProjectionWaiver),
     inputSchemaSource: inputSchema,
-    name,
   };
 };

--- a/apps/api/src/mcp/valibot-tool-definition.ts
+++ b/apps/api/src/mcp/valibot-tool-definition.ts
@@ -20,6 +20,19 @@ type JsonSchemaProjectionWaiver = {
   reason: string;
 };
 
+type ValibotMcpToolDefinition<
+  TSchema extends v.GenericSchema,
+  TName extends string,
+  TDefinition extends Omit<McpToolDefinition, "inputSchema" | "name">,
+> = Omit<
+  TDefinition,
+  "inputSchema" | "jsonSchemaProjectionWaiver" | "name"
+> & {
+  inputSchema: McpToolInputSchema;
+  inputSchemaSource: TSchema;
+  name: TName;
+};
+
 const deriveMcpInputSchema = (
   schema: v.GenericSchema,
   projectionWaiver: JsonSchemaProjectionWaiver | undefined,
@@ -59,18 +72,17 @@ export const defineValibotMcpTool = <
   const TSchema extends v.GenericSchema,
   const TName extends string,
   const TDefinition extends Omit<McpToolDefinition, "inputSchema" | "name">,
->({
-  inputSchema,
-  jsonSchemaProjectionWaiver,
-  name,
-  ...definition
-}: TDefinition & {
+>(definition: TDefinition & {
   inputSchema: TSchema;
   jsonSchemaProjectionWaiver?: JsonSchemaProjectionWaiver;
   name: TName;
-}) => ({
-  ...definition,
-  inputSchema: deriveMcpInputSchema(inputSchema, jsonSchemaProjectionWaiver),
-  inputSchemaSource: inputSchema,
-  name,
-});
+}): ValibotMcpToolDefinition<TSchema, TName, TDefinition> => {
+  const { inputSchema, jsonSchemaProjectionWaiver, name, ...toolDefinition } =
+    definition;
+  return {
+    ...toolDefinition,
+    inputSchema: deriveMcpInputSchema(inputSchema, jsonSchemaProjectionWaiver),
+    inputSchemaSource: inputSchema,
+    name,
+  };
+};

--- a/apps/collab/src/env-schema.ts
+++ b/apps/collab/src/env-schema.ts
@@ -6,7 +6,7 @@ export const envCollabServerSchema = {
     v.pipe(
       v.string(),
       v.digits(),
-      v.transform(Number),
+      v.toNumber(),
       v.integer(),
       v.minValue(1),
       v.maxValue(65_535),

--- a/apps/web/src/env-schema.ts
+++ b/apps/web/src/env-schema.ts
@@ -35,7 +35,7 @@ export const envWebClientSchema = {
     v.pipe(
       v.string(),
       v.digits(),
-      v.transform(Number),
+      v.toNumber(),
       v.integer(),
       v.minValue(1),
       v.maxValue(65_535),

--- a/apps/web/src/features/case-law/components/case-viewer/analysis/use-decision-analysis.test.ts
+++ b/apps/web/src/features/case-law/components/case-viewer/analysis/use-decision-analysis.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseAnalysisResponse } from "./use-decision-analysis";
+
+const heading = {
+  id: "h1",
+  label: "Facts",
+  category: "facts",
+  startAnchorId: "a1",
+  endAnchorId: "a2",
+  annotations: [],
+  children: [],
+};
+
+describe("decision analysis response parsing", () => {
+  test("keeps the canonical in-progress tree", () => {
+    expect(
+      parseAnalysisResponse({
+        status: "generating",
+        analysis: {
+          version: 1,
+          status: "generating",
+          generatedAt: "2026-08-23T10:00:00.000Z",
+          model: "test-model",
+          tree: [heading],
+        },
+      }),
+    ).toEqual({ status: "generating", tree: [heading] });
+  });
+
+  test("rejects an in-progress payload presented as complete", () => {
+    expect(
+      parseAnalysisResponse({
+        status: "done",
+        analysis: {
+          version: 1,
+          status: "generating",
+          generatedAt: "2026-08-23T10:00:00.000Z",
+          model: "test-model",
+          tree: [heading],
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/features/case-law/components/case-viewer/analysis/use-decision-analysis.ts
+++ b/apps/web/src/features/case-law/components/case-viewer/analysis/use-decision-analysis.ts
@@ -9,10 +9,10 @@ import { useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-import type { DecisionAnalysis } from "@stll/legal-ast/analysis";
 import {
-  isAnalysisInProgress,
-  isDecisionAnalysis,
+  type DecisionAnalysis,
+  type PersistedDecisionAnalysis,
+  parsePersistedDecisionAnalysis,
 } from "@stll/legal-ast/analysis";
 
 import { caseLawDecisionKeys } from "@/features/case-law/queries/decisions";
@@ -37,7 +37,19 @@ const POLL_INTERVAL_MS = 2000;
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
-const parseAnalysisResponse = (value: unknown): AnalysisResponse | null => {
+const completeAnalysis = (
+  analysis: PersistedDecisionAnalysis | null,
+): DecisionAnalysis | null =>
+  analysis !== null && !("status" in analysis) ? analysis : null;
+
+const analysisTree = (
+  analysis: PersistedDecisionAnalysis | null,
+): DecisionAnalysis["tree"] =>
+  analysis !== null && "tree" in analysis ? analysis.tree : [];
+
+export const parseAnalysisResponse = (
+  value: unknown,
+): AnalysisResponse | null => {
   if (!isRecord(value)) {
     return null;
   }
@@ -45,15 +57,17 @@ const parseAnalysisResponse = (value: unknown): AnalysisResponse | null => {
   const status = value["status"];
 
   if (status === "done") {
-    const analysis = value["analysis"];
-    return isDecisionAnalysis(analysis) ? { status: "done", analysis } : null;
+    const analysis = completeAnalysis(
+      parsePersistedDecisionAnalysis(value["analysis"]),
+    );
+    return analysis === null ? null : { status: "done", analysis };
   }
 
   if (status === "generating") {
-    const analysis = value["analysis"];
+    const analysis = parsePersistedDecisionAnalysis(value["analysis"]);
     return {
       status: "generating",
-      tree: isDecisionAnalysis(analysis) ? analysis.tree : [],
+      tree: analysisTree(analysis),
     };
   }
 
@@ -81,9 +95,10 @@ export const useDecisionAnalysis = (
   existingAnalysis: unknown,
 ) => {
   const queryClient = useQueryClient();
-  const hasFreshAnalysis =
-    isDecisionAnalysis(existingAnalysis) &&
-    !isAnalysisInProgress(existingAnalysis);
+  const existingCompleteAnalysis = completeAnalysis(
+    parsePersistedDecisionAnalysis(existingAnalysis),
+  );
+  const hasFreshAnalysis = existingCompleteAnalysis !== null;
   // Track which decision the user kicked generation off for. Comparing
   // against the current `decisionId` in the same render keeps a stale
   // value from enabling a fetch (and an unintended backend kick-off)
@@ -179,8 +194,8 @@ export const useDecisionAnalysis = (
   };
 
   const state: AnalysisState = (() => {
-    if (hasFreshAnalysis && isDecisionAnalysis(existingAnalysis)) {
-      return { status: "done", analysis: existingAnalysis };
+    if (existingCompleteAnalysis !== null) {
+      return { status: "done", analysis: existingCompleteAnalysis };
     }
     if (!isGenerating) {
       return { status: "idle" };

--- a/apps/web/src/lib/mcp-oauth-channel.ts
+++ b/apps/web/src/lib/mcp-oauth-channel.ts
@@ -13,7 +13,7 @@ type PostMessageOpener = {
 // `window.message` listener on the opener page can't pick up
 // unrelated messages that happen to share `status`. Callers only
 // see the public `McpOAuthOutcome` (without `kind`).
-const mcpOAuthMessageSchema = v.union([
+const mcpOAuthMessageSchema = v.variant("status", [
   v.strictObject({
     kind: v.literal(MESSAGE_KIND),
     status: v.literal("connected"),

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -103,7 +103,7 @@ export const CHAT_SEND_MODE = {
 export const chatSendModeSchema = v.picklist(CHAT_SEND_MODES);
 
 export const isChatSendMode = (value: unknown): value is ChatSendMode =>
-  v.safeParse(chatSendModeSchema, value).success;
+  v.is(chatSendModeSchema, value);
 
 export const getPreferredChatSendMode = (anonymized: boolean): ChatSendMode =>
   anonymized ? CHAT_SEND_MODE.anonymized : CHAT_SEND_MODE.rawOverride;

--- a/packages/api-contract/src/realtime-events.ts
+++ b/packages/api-contract/src/realtime-events.ts
@@ -62,6 +62,13 @@ const resourcesChangedEventSchema = v.object({
   ),
 });
 
+const resourceChangeCountSchema = v.pipe(
+  v.number(),
+  v.integer(),
+  v.minValue(1),
+  v.maxValue(MAX_RESOURCE_CHANGES_PER_EVENT),
+);
+
 const resourceSetUpdatedEventSchema = v.object({
   type: v.literal(REALTIME_EVENT_TYPE.RESOURCE_SET_UPDATED),
   resourceType: v.custom<ResourceType>(isResourceType),
@@ -150,11 +157,13 @@ export const resourceDeletedChange = (resource: ResourceRef) =>
 
 export const resourcesChangedRealtimeEvent = (
   changes: readonly ResourceChange[],
-): ResourceRealtimeEvent =>
-  v.parse(resourcesChangedEventSchema, {
+): ResourceRealtimeEvent => {
+  v.parse(resourceChangeCountSchema, changes.length);
+  return {
     type: REALTIME_EVENT_TYPE.RESOURCES_CHANGED,
     changes: [...changes],
-  });
+  };
+};
 
 export const resourceSetUpdatedRealtimeEvent = (resourceType: ResourceType) =>
   ({

--- a/packages/cli/src/auth/oauth-client-registration.ts
+++ b/packages/cli/src/auth/oauth-client-registration.ts
@@ -17,7 +17,7 @@ import {
 import { ClientRegistrationError } from "./errors.js";
 import type { AuthorizationServerMetadata } from "./oauth-metadata.js";
 
-const registrationResponseSchema = v.looseObject({
+const registrationResponseSchema = v.object({
   client_id: v.string(),
 });
 

--- a/packages/cli/src/auth/token-exchange.ts
+++ b/packages/cli/src/auth/token-exchange.ts
@@ -18,7 +18,7 @@ export type TokenResponse = {
   readonly token_type: string;
 };
 
-const tokenResponseSchema = v.looseObject({
+const tokenResponseSchema = v.object({
   access_token: v.string(),
   expires_in: v.number(),
   refresh_token: v.optional(v.string()),
@@ -26,7 +26,7 @@ const tokenResponseSchema = v.looseObject({
   token_type: v.string(),
 });
 
-const oauthErrorBodySchema = v.looseObject({
+const oauthErrorBodySchema = v.object({
   error: v.string(),
   error_description: v.optional(v.string()),
 });

--- a/packages/cli/src/capability-catalog-load.ts
+++ b/packages/cli/src/capability-catalog-load.ts
@@ -24,18 +24,18 @@ const jsonSchemaSchema = v.record(v.string(), v.unknown());
 // an exporter whose transport union has moved on fails validation here (and the
 // exporter runs this parser over its own output), so the mirrored union in
 // generate-capability-tree.ts cannot silently fall behind the API-side one.
-const fileInputSchema = v.looseObject({
+const fileInputSchema = v.object({
   field: v.string(),
   required: v.boolean(),
 });
 const transportSchema = v.variant("type", [
-  v.looseObject({ type: v.literal("json") }),
-  v.looseObject({ type: v.literal("file-input"), input: fileInputSchema }),
-  v.looseObject({ type: v.literal("file-response") }),
-  v.looseObject({ type: v.literal("file-both"), input: fileInputSchema }),
+  v.object({ type: v.literal("json") }),
+  v.object({ type: v.literal("file-input"), input: fileInputSchema }),
+  v.object({ type: v.literal("file-response") }),
+  v.object({ type: v.literal("file-both"), input: fileInputSchema }),
 ]);
 
-const catalogEntrySchema = v.looseObject({
+const catalogEntrySchema = v.object({
   id: v.string(),
   description: v.optional(v.string()),
   handlerKind: v.picklist(["workspace", "root", "session"]),
@@ -44,7 +44,7 @@ const catalogEntrySchema = v.looseObject({
   scope: v.string(),
   additionalScopes: v.optional(v.array(v.string())),
   transport: transportSchema,
-  inputSchema: v.looseObject({
+  inputSchema: v.object({
     $defs: v.optional(jsonSchemaSchema),
     body: v.optional(jsonSchemaSchema),
     params: v.optional(jsonSchemaSchema),

--- a/packages/cli/src/cli-release-channel.ts
+++ b/packages/cli/src/cli-release-channel.ts
@@ -7,7 +7,7 @@ const stableVersionSchema = v.pipe(
   v.string(),
   v.regex(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/u),
 );
-const npmPackageSchema = v.looseObject({ version: stableVersionSchema });
+const npmPackageSchema = v.object({ version: stableVersionSchema });
 type ReleaseChannelFetch = (
   input: string | URL | Request,
   init?: RequestInit,

--- a/packages/cli/src/codegen.ts
+++ b/packages/cli/src/codegen.ts
@@ -48,14 +48,14 @@ const annotationOutputUrl = new URL(
 
 const stringArraySchema = v.array(v.string());
 
-const discriminatorSubcommandSchema = v.looseObject({
+const discriminatorSubcommandSchema = v.object({
   command: v.string(),
   destructive: v.optional(v.literal(true)),
   include: v.optional(stringArraySchema),
   required: v.optional(stringArraySchema),
 });
 
-const cliAnnotationSchema = v.looseObject({
+const cliAnnotationSchema = v.object({
   command: stringArraySchema,
   additionalScopes: v.optional(v.array(v.picklist(MCP_CLI_TOOL_SCOPES))),
   requestTimeoutMs: v.optional(
@@ -70,7 +70,7 @@ const cliAnnotationSchema = v.looseObject({
   paginationless: v.optional(v.literal(true)),
   inputOnly: v.optional(stringArraySchema),
   discriminator: v.optional(
-    v.looseObject({
+    v.object({
       prop: v.string(),
       subcommands: v.record(v.string(), discriminatorSubcommandSchema),
     }),
@@ -156,13 +156,13 @@ const projectToolAnnotation = (cli: ParsedCliAnnotation): ToolAnnotation => {
 // Validate the snapshot into the four wire fields so the codegen input is typed
 // (not `any` off `.json()`) and a malformed snapshot fails loudly.
 const listingSchema = v.array(
-  v.looseObject({
+  v.object({
     cli: cliAnnotationSchema,
     name: v.string(),
     description: v.string(),
     inputSchema: v.record(v.string(), v.unknown()),
     annotations: v.optional(
-      v.looseObject({
+      v.object({
         readOnlyHint: v.optional(v.boolean()),
         destructiveHint: v.optional(v.boolean()),
       }),

--- a/packages/cli/src/compatibility.ts
+++ b/packages/cli/src/compatibility.ts
@@ -18,11 +18,11 @@ const SEMVER_PATTERN =
 const SEMVER_BUILD_PATTERN = /^[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*$/u;
 const positiveIntegerSchema = v.pipe(v.number(), v.integer(), v.minValue(1));
 
-const compatibilityMetadataSchema = v.looseObject({
+const compatibilityMetadataSchema = v.object({
   resource: v.pipe(v.string(), v.url()),
   scopes_supported: v.array(v.string()),
   stella_contract: v.optional(
-    v.looseObject({
+    v.object({
       protocol: positiveIntegerSchema,
       revision: positiveIntegerSchema,
       capabilities: v.record(v.string(), positiveIntegerSchema),

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -955,7 +955,7 @@
                 "description": "Who-fills = business-registry lookup"
               },
               "source": {
-                "oneOf": [
+                "anyOf": [
                   {
                     "type": "object",
                     "properties": {

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -758,29 +758,34 @@
     "description": "Create a document template from a DOCX, or configure an existing template's fields. To create, pass docx_base64 (base64-encoded .docx / Office Open XML bytes, max ~10 MB decoded) and a name; the {{field}} markers in the file become the template's fillable fields, and you can pass fields to configure them in the same call. To configure an existing template, pass template_id with fields and no docx_base64; only the manifest changes, the document's {{markers}} stay untouched. Each fields entry's path must match a {{marker}} in the template. Read the marker grammar from the template-markers reference resource when unsure. Returns the template id and field count when creating, or the updated field list when configuring.",
     "inputSchema": {
       "type": "object",
+      "required": [],
+      "additionalProperties": false,
       "properties": {
         "template_id": {
           "type": "string",
-          "description": "Existing template id to configure its fields; omit (with docx_base64) to create a new template"
+          "minLength": 1,
+          "description": "Existing template id to configure; omit when creating a template"
         },
         "name": {
           "type": "string",
-          "description": "Template display name; required when creating",
-          "maxLength": 256
+          "minLength": 1,
+          "maxLength": 256,
+          "description": "Template display name; required when creating"
         },
         "docx_base64": {
           "type": "string",
-          "description": "Base64-encoded DOCX file bytes (Office Open XML, max ~10 MB decoded); required when creating, omit when configuring"
+          "minLength": 1,
+          "maxLength": 69905068,
+          "description": "Base64-encoded DOCX bytes; required when creating, omit when configuring"
         },
         "fields": {
           "type": "array",
-          "description": "Field configuration overlay, one entry per field to configure. Each entry's 'path' must match a {{marker}} in the template. Configurable: label, hint, inputType, required, options, optionsFrom (dependent select), date format, composite parts + format, and who-fills the field — a person (default), AI (aiPrompt), Person+AI (aiAdapt), a formula, or a company-register lookup (registry + named output formats). formula is mutually exclusive with aiPrompt/aiAdapt/lookup/parts.",
           "items": {
             "type": "object",
             "properties": {
               "path": {
                 "type": "string",
-                "description": "Field path — must match a {{marker}} in the template"
+                "description": "Field path; must match a {{marker}} in the template"
               },
               "label": {
                 "type": "string",
@@ -791,13 +796,9 @@
                 "description": "Short fill guidance shown to the person filling the field"
               },
               "inputType": {
-                "type": "string",
                 "enum": ["text", "number", "boolean", "date", "select"],
+                "type": "string",
                 "description": "Input control type"
-              },
-              "required": {
-                "type": "boolean",
-                "description": "Whether a value is required"
               },
               "options": {
                 "type": "array",
@@ -806,9 +807,49 @@
                 },
                 "description": "Allowed values when inputType is 'select'"
               },
-              "optionsFrom": {
-                "type": "string",
-                "description": "Dependent select: path of another field whose value(s) supply the options"
+              "validation": {
+                "type": "object",
+                "properties": {
+                  "required": {
+                    "type": "boolean",
+                    "description": "Whether a value is required"
+                  },
+                  "minLength": {
+                    "type": "number",
+                    "description": "Minimum string length"
+                  },
+                  "maxLength": {
+                    "type": "number",
+                    "description": "Maximum string length"
+                  },
+                  "min": {
+                    "type": "number",
+                    "description": "Minimum numeric value"
+                  },
+                  "max": {
+                    "type": "number",
+                    "description": "Maximum numeric value"
+                  },
+                  "pattern": {
+                    "type": "string",
+                    "description": "Regex matched against the complete value"
+                  },
+                  "minItems": {
+                    "type": "number",
+                    "description": "Minimum repeated items"
+                  },
+                  "maxItems": {
+                    "type": "number",
+                    "description": "Maximum repeated items"
+                  }
+                },
+                "required": [],
+                "additionalProperties": false,
+                "description": "Field-level value constraints"
+              },
+              "required": {
+                "type": "boolean",
+                "description": "Whether a value is required"
               },
               "aiPrompt": {
                 "type": "string",
@@ -818,53 +859,76 @@
                 "type": "boolean",
                 "description": "Who-fills = Person+AI: the entered value is a stub AI rewrites per occurrence"
               },
-              "formula": {
-                "type": "string",
-                "description": "Who-fills = formula: arithmetic expression over other fields, derived at fill time"
-              },
-              "condition": {
-                "type": "string",
-                "description": "Boolean field derived by rule: a condition expression (e.g. client_type == \"company\"), evaluated at fill time. A {{#if field_path}} marker references it by path. Mutually exclusive with formula/aiPrompt/aiAdapt/lookup/parts."
+              "aiSeesDocument": {
+                "type": "boolean",
+                "description": "Include the rendered document in this AI field's prompt"
               },
               "parts": {
                 "type": "array",
-                "description": "Composite field parts (joined by 'format')",
                 "items": {
                   "type": "object",
-                  "additionalProperties": true
-                }
+                  "properties": {
+                    "key": {
+                      "type": "string",
+                      "description": "Part key referenced by the field format"
+                    },
+                    "label": {
+                      "type": "string",
+                      "description": "Human-readable part label"
+                    },
+                    "inputType": {
+                      "enum": ["text", "select"],
+                      "type": "string",
+                      "description": "Part input control type"
+                    },
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Allowed values for a select part"
+                    },
+                    "pattern": {
+                      "type": "string",
+                      "description": "Regex matched against the complete part value"
+                    }
+                  },
+                  "required": ["key", "inputType"],
+                  "additionalProperties": false
+                },
+                "minItems": 1,
+                "description": "Composite field parts joined by format"
               },
               "format": {
                 "type": "string",
                 "description": "Join template over composite part keys, e.g. '{{title}} {{name}}'"
               },
-              "dateFormat": {
-                "type": "object",
-                "description": "Locale-aware date rendering for a date field",
-                "properties": {
-                  "locale": {
-                    "type": "string",
-                    "description": "BCP-47 language tag, e.g. 'cs', 'de', 'pl'"
-                  },
-                  "style": {
-                    "type": "string",
-                    "enum": ["long", "medium", "short", "iso"],
-                    "description": "Date style"
-                  }
-                },
-                "required": ["locale", "style"]
+              "optionsFrom": {
+                "type": "string",
+                "description": "Dependent select: path of another field whose values supply the options"
               },
               "lookup": {
                 "type": "object",
-                "description": "Who-fills = company-register lookup",
                 "properties": {
                   "registry": {
+                    "enum": [
+                      "ares",
+                      "brreg",
+                      "companies-house",
+                      "denue",
+                      "edgar",
+                      "gcis",
+                      "krs",
+                      "orsr",
+                      "prh",
+                      "recherche-entreprises",
+                      "vies"
+                    ],
                     "type": "string",
-                    "description": "Registry slug, e.g. 'krs'"
+                    "description": "Business registry to query"
                   },
                   "formats": {
                     "type": "array",
-                    "description": "Named output renderings; the first is the default for the bare {{marker}}",
                     "items": {
                       "type": "object",
                       "properties": {
@@ -874,19 +938,184 @@
                         },
                         "template": {
                           "type": "string",
+                          "maxLength": 2000,
                           "description": "[token]-substituted rendering of the registry hit"
                         }
                       },
-                      "required": ["key", "template"]
-                    }
+                      "required": ["key", "template"],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "maxItems": 10,
+                    "description": "Named output renderings; the first is the default for the bare marker"
                   }
                 },
-                "required": ["registry", "formats"]
+                "required": ["registry", "formats"],
+                "additionalProperties": false,
+                "description": "Who-fills = business-registry lookup"
+              },
+              "source": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "const": "contact"
+                      },
+                      "field": {
+                        "enum": [
+                          "displayName",
+                          "firstName",
+                          "lastName",
+                          "organizationName",
+                          "email",
+                          "phone",
+                          "address",
+                          "addressStreet",
+                          "addressCity",
+                          "addressPostalCode",
+                          "addressCountry",
+                          "registrationNumber",
+                          "taxId",
+                          "iban",
+                          "bic",
+                          "dataBox"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": ["kind", "field"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "const": "party"
+                      },
+                      "role": {
+                        "enum": [
+                          "opposing_party",
+                          "opposing_counsel",
+                          "co_counsel",
+                          "witness",
+                          "expert_witness",
+                          "third_party",
+                          "judge",
+                          "mediator",
+                          "other"
+                        ],
+                        "type": "string"
+                      },
+                      "field": {
+                        "enum": [
+                          "displayName",
+                          "firstName",
+                          "lastName",
+                          "organizationName",
+                          "email",
+                          "phone",
+                          "address",
+                          "addressStreet",
+                          "addressCity",
+                          "addressPostalCode",
+                          "addressCountry",
+                          "registrationNumber",
+                          "taxId",
+                          "iban",
+                          "bic",
+                          "dataBox"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": ["kind", "role", "field"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "const": "matter"
+                      },
+                      "field": {
+                        "enum": [
+                          "name",
+                          "reference",
+                          "billingReference",
+                          "status"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": ["kind", "field"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "const": "attorney"
+                      },
+                      "ref": {
+                        "enum": ["responsible", "originating", "lead"],
+                        "type": "string"
+                      },
+                      "field": {
+                        "enum": ["name", "email"],
+                        "type": "string"
+                      }
+                    },
+                    "required": ["kind", "ref", "field"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "const": "firm"
+                      },
+                      "field": {
+                        "enum": ["name"],
+                        "type": "string"
+                      }
+                    },
+                    "required": ["kind", "field"],
+                    "additionalProperties": false
+                  }
+                ],
+                "description": "Matter or contact data resolved server-side"
+              },
+              "formula": {
+                "type": "string",
+                "description": "Arithmetic expression derived from other fields"
+              },
+              "condition": {
+                "type": "string",
+                "description": "Boolean rule expression referenced by a {{#if field_path}} marker"
+              },
+              "dateFormat": {
+                "type": "object",
+                "properties": {
+                  "locale": {
+                    "type": "string",
+                    "description": "BCP-47 language tag, e.g. 'cs', 'de', 'pl'"
+                  },
+                  "style": {
+                    "enum": ["long", "medium", "short", "iso"],
+                    "type": "string",
+                    "description": "Date rendering style"
+                  }
+                },
+                "required": ["locale", "style"],
+                "additionalProperties": false,
+                "description": "Locale-aware date rendering for a date field"
               }
             },
             "required": ["path"],
             "additionalProperties": false
-          }
+          },
+          "description": "Strict field configuration overlay; each path must match a template marker"
         }
       }
     },
@@ -2241,47 +2470,57 @@
     "description": "Read the organization's audit trail (compliance view). Returns audit entries newest first, each with its action, resource type and id, actor user id, workspace, timestamp, and change detail. Filter by workspace_id, action, resource_type (with optional resource_id), user_id, and a created-at range (from/to, ISO date-time). Paginate with limit and cursor. Requires organization audit-log access.",
     "inputSchema": {
       "type": "object",
+      "required": [],
+      "additionalProperties": false,
       "properties": {
         "workspace_id": {
           "type": "string",
+          "minLength": 1,
           "description": "Only entries scoped to this matter/workspace"
         },
         "action": {
           "type": "string",
+          "minLength": 1,
           "description": "Only entries with this audit action"
         },
         "resource_type": {
           "type": "string",
+          "minLength": 1,
           "description": "Only entries about this resource type"
         },
         "resource_id": {
           "type": "string",
+          "minLength": 1,
           "description": "Only entries about this resource id; requires resource_type"
         },
         "user_id": {
           "type": "string",
+          "minLength": 1,
           "description": "Only entries whose actor is this user"
         },
         "from": {
           "type": "string",
-          "description": "Only entries created on or after this ISO date-time",
-          "maxLength": 40
+          "format": "date-time",
+          "maxLength": 40,
+          "description": "Only entries created on or after this ISO date-time"
         },
         "to": {
           "type": "string",
-          "description": "Only entries created on or before this ISO date-time",
-          "maxLength": 40
+          "format": "date-time",
+          "maxLength": 40,
+          "description": "Only entries created on or before this ISO date-time"
         },
         "limit": {
           "type": "integer",
-          "description": "Max entries to return",
           "minimum": 1,
-          "maximum": 200
+          "maximum": 200,
+          "description": "Max entries to return"
         },
         "cursor": {
           "type": "string",
-          "description": "Opaque cursor from a previous list_audit_log call to fetch the next page",
-          "maxLength": 512
+          "minLength": 1,
+          "maxLength": 512,
+          "description": "Opaque cursor from a previous list_audit_log call to fetch the next page"
         }
       }
     },

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -960,7 +960,8 @@
                     "type": "object",
                     "properties": {
                       "kind": {
-                        "const": "contact"
+                        "enum": ["contact"],
+                        "type": "string"
                       },
                       "field": {
                         "enum": [
@@ -991,7 +992,8 @@
                     "type": "object",
                     "properties": {
                       "kind": {
-                        "const": "party"
+                        "enum": ["party"],
+                        "type": "string"
                       },
                       "role": {
                         "enum": [
@@ -1036,7 +1038,8 @@
                     "type": "object",
                     "properties": {
                       "kind": {
-                        "const": "matter"
+                        "enum": ["matter"],
+                        "type": "string"
                       },
                       "field": {
                         "enum": [
@@ -1055,7 +1058,8 @@
                     "type": "object",
                     "properties": {
                       "kind": {
-                        "const": "attorney"
+                        "enum": ["attorney"],
+                        "type": "string"
                       },
                       "ref": {
                         "enum": ["responsible", "originating", "lead"],
@@ -1073,7 +1077,8 @@
                     "type": "object",
                     "properties": {
                       "kind": {
-                        "const": "firm"
+                        "enum": ["firm"],
+                        "type": "string"
                       },
                       "field": {
                         "enum": ["name"],

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -2500,13 +2500,11 @@
         },
         "from": {
           "type": "string",
-          "format": "date-time",
           "maxLength": 40,
           "description": "Only entries created on or after this ISO date-time"
         },
         "to": {
           "type": "string",
-          "format": "date-time",
           "maxLength": 40,
           "description": "Only entries created on or before this ISO date-time"
         },

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -1277,38 +1277,38 @@
     "name": "upload_document_version",
     "description": "Upload an attached host file as a new version of an existing document. Pass entity_id and file. Use open_document_version_upload only when the host cannot supply MCP file parameters. The upload uses stella's standard presigned, checksum-verified, scanned, and audited file-version pipeline.",
     "inputSchema": {
-      "additionalProperties": false,
       "type": "object",
       "required": ["entity_id", "file"],
+      "additionalProperties": false,
       "properties": {
         "entity_id": {
+          "type": "string",
           "minLength": 1,
-          "description": "Existing document entity ID that will receive a new version",
-          "type": "string"
+          "description": "Existing document entity ID that will receive a new version"
         },
         "file": {
-          "additionalProperties": false,
-          "description": "File reference supplied by a compatible MCP host",
           "type": "object",
-          "required": ["download_url", "file_id"],
           "properties": {
             "download_url": {
-              "description": "Temporary URL supplied by the host for downloading the file",
-              "type": "string"
+              "type": "string",
+              "description": "Temporary URL supplied by the host for downloading the file"
             },
             "file_id": {
-              "description": "Host-assigned identifier for the attached file",
-              "type": "string"
+              "type": "string",
+              "description": "Host-assigned identifier for the attached file"
             },
             "mime_type": {
-              "description": "MIME type reported by the host",
-              "type": "string"
+              "type": "string",
+              "description": "MIME type reported by the host"
             },
             "file_name": {
-              "description": "Original file name reported by the host",
-              "type": "string"
+              "type": "string",
+              "description": "Original file name reported by the host"
             }
-          }
+          },
+          "required": ["download_url", "file_id"],
+          "additionalProperties": false,
+          "description": "File reference supplied by a compatible MCP host"
         }
       }
     },
@@ -1327,14 +1327,14 @@
     "name": "open_document_version_upload",
     "description": "Open a portable file picker for uploading a new version of an existing document. Use only when upload_document_version cannot receive a host file reference; do not use when the host already supplied an attached file.",
     "inputSchema": {
-      "additionalProperties": false,
       "type": "object",
       "required": ["entity_id"],
+      "additionalProperties": false,
       "properties": {
         "entity_id": {
+          "type": "string",
           "minLength": 1,
-          "description": "Existing document entity ID that will receive a new version",
-          "type": "string"
+          "description": "Existing document entity ID that will receive a new version"
         }
       }
     },

--- a/packages/cli/src/generated/route-map.ts
+++ b/packages/cli/src/generated/route-map.ts
@@ -1830,7 +1830,7 @@ export const generatedRouteMap: RouteNode = {
                 kind: "string",
                 repeatable: false,
                 description:
-                  "Existing template id to configure its fields; omit (with docx_base64) to create a new template",
+                  "Existing template id to configure; omit when creating a template",
                 required: false,
               },
               {
@@ -1847,7 +1847,7 @@ export const generatedRouteMap: RouteNode = {
                 kind: "string",
                 repeatable: false,
                 description:
-                  "Base64-encoded DOCX file bytes (Office Open XML, max ~10 MB decoded); required when creating, omit when configuring",
+                  "Base64-encoded DOCX bytes; required when creating, omit when configuring",
                 required: false,
               },
             ],
@@ -1858,33 +1858,37 @@ export const generatedRouteMap: RouteNode = {
             scope: "templates",
             inputSchema: {
               type: "object",
+              required: [],
+              additionalProperties: false,
               properties: {
                 template_id: {
                   type: "string",
+                  minLength: 1,
                   description:
-                    "Existing template id to configure its fields; omit (with docx_base64) to create a new template",
+                    "Existing template id to configure; omit when creating a template",
                 },
                 name: {
                   type: "string",
-                  description: "Template display name; required when creating",
+                  minLength: 1,
                   maxLength: 256,
+                  description: "Template display name; required when creating",
                 },
                 docx_base64: {
                   type: "string",
+                  minLength: 1,
+                  maxLength: 69905068,
                   description:
-                    "Base64-encoded DOCX file bytes (Office Open XML, max ~10 MB decoded); required when creating, omit when configuring",
+                    "Base64-encoded DOCX bytes; required when creating, omit when configuring",
                 },
                 fields: {
                   type: "array",
-                  description:
-                    "Field configuration overlay, one entry per field to configure. Each entry's 'path' must match a {{marker}} in the template. Configurable: label, hint, inputType, required, options, optionsFrom (dependent select), date format, composite parts + format, and who-fills the field — a person (default), AI (aiPrompt), Person+AI (aiAdapt), a formula, or a company-register lookup (registry + named output formats). formula is mutually exclusive with aiPrompt/aiAdapt/lookup/parts.",
                   items: {
                     type: "object",
                     properties: {
                       path: {
                         type: "string",
                         description:
-                          "Field path — must match a {{marker}} in the template",
+                          "Field path; must match a {{marker}} in the template",
                       },
                       label: {
                         type: "string",
@@ -1896,13 +1900,9 @@ export const generatedRouteMap: RouteNode = {
                           "Short fill guidance shown to the person filling the field",
                       },
                       inputType: {
-                        type: "string",
                         enum: ["text", "number", "boolean", "date", "select"],
+                        type: "string",
                         description: "Input control type",
-                      },
-                      required: {
-                        type: "boolean",
-                        description: "Whether a value is required",
                       },
                       options: {
                         type: "array",
@@ -1912,10 +1912,50 @@ export const generatedRouteMap: RouteNode = {
                         description:
                           "Allowed values when inputType is 'select'",
                       },
-                      optionsFrom: {
-                        type: "string",
-                        description:
-                          "Dependent select: path of another field whose value(s) supply the options",
+                      validation: {
+                        type: "object",
+                        properties: {
+                          required: {
+                            type: "boolean",
+                            description: "Whether a value is required",
+                          },
+                          minLength: {
+                            type: "number",
+                            description: "Minimum string length",
+                          },
+                          maxLength: {
+                            type: "number",
+                            description: "Maximum string length",
+                          },
+                          min: {
+                            type: "number",
+                            description: "Minimum numeric value",
+                          },
+                          max: {
+                            type: "number",
+                            description: "Maximum numeric value",
+                          },
+                          pattern: {
+                            type: "string",
+                            description:
+                              "Regex matched against the complete value",
+                          },
+                          minItems: {
+                            type: "number",
+                            description: "Minimum repeated items",
+                          },
+                          maxItems: {
+                            type: "number",
+                            description: "Maximum repeated items",
+                          },
+                        },
+                        required: [],
+                        additionalProperties: false,
+                        description: "Field-level value constraints",
+                      },
+                      required: {
+                        type: "boolean",
+                        description: "Whether a value is required",
                       },
                       aiPrompt: {
                         type: "string",
@@ -1927,60 +1967,81 @@ export const generatedRouteMap: RouteNode = {
                         description:
                           "Who-fills = Person+AI: the entered value is a stub AI rewrites per occurrence",
                       },
-                      formula: {
-                        type: "string",
+                      aiSeesDocument: {
+                        type: "boolean",
                         description:
-                          "Who-fills = formula: arithmetic expression over other fields, derived at fill time",
-                      },
-                      condition: {
-                        type: "string",
-                        description:
-                          'Boolean field derived by rule: a condition expression (e.g. client_type == "company"), evaluated at fill time. A {{#if field_path}} marker references it by path. Mutually exclusive with formula/aiPrompt/aiAdapt/lookup/parts.',
+                          "Include the rendered document in this AI field's prompt",
                       },
                       parts: {
                         type: "array",
-                        description:
-                          "Composite field parts (joined by 'format')",
                         items: {
                           type: "object",
-                          additionalProperties: true,
+                          properties: {
+                            key: {
+                              type: "string",
+                              description:
+                                "Part key referenced by the field format",
+                            },
+                            label: {
+                              type: "string",
+                              description: "Human-readable part label",
+                            },
+                            inputType: {
+                              enum: ["text", "select"],
+                              type: "string",
+                              description: "Part input control type",
+                            },
+                            options: {
+                              type: "array",
+                              items: {
+                                type: "string",
+                              },
+                              description: "Allowed values for a select part",
+                            },
+                            pattern: {
+                              type: "string",
+                              description:
+                                "Regex matched against the complete part value",
+                            },
+                          },
+                          required: ["key", "inputType"],
+                          additionalProperties: false,
                         },
+                        minItems: 1,
+                        description: "Composite field parts joined by format",
                       },
                       format: {
                         type: "string",
                         description:
                           "Join template over composite part keys, e.g. '{{title}} {{name}}'",
                       },
-                      dateFormat: {
-                        type: "object",
+                      optionsFrom: {
+                        type: "string",
                         description:
-                          "Locale-aware date rendering for a date field",
-                        properties: {
-                          locale: {
-                            type: "string",
-                            description:
-                              "BCP-47 language tag, e.g. 'cs', 'de', 'pl'",
-                          },
-                          style: {
-                            type: "string",
-                            enum: ["long", "medium", "short", "iso"],
-                            description: "Date style",
-                          },
-                        },
-                        required: ["locale", "style"],
+                          "Dependent select: path of another field whose values supply the options",
                       },
                       lookup: {
                         type: "object",
-                        description: "Who-fills = company-register lookup",
                         properties: {
                           registry: {
+                            enum: [
+                              "ares",
+                              "brreg",
+                              "companies-house",
+                              "denue",
+                              "edgar",
+                              "gcis",
+                              "krs",
+                              "orsr",
+                              "prh",
+                              "recherche-entreprises",
+                              "vies",
+                            ],
                             type: "string",
-                            description: "Registry slug, e.g. 'krs'",
+                            description: "Business registry to query",
                           },
                           formats: {
                             type: "array",
-                            description:
-                              "Named output renderings; the first is the default for the bare {{marker}}",
                             items: {
                               type: "object",
                               properties: {
@@ -1991,20 +2052,192 @@ export const generatedRouteMap: RouteNode = {
                                 },
                                 template: {
                                   type: "string",
+                                  maxLength: 2000,
                                   description:
                                     "[token]-substituted rendering of the registry hit",
                                 },
                               },
                               required: ["key", "template"],
+                              additionalProperties: false,
                             },
+                            minItems: 1,
+                            maxItems: 10,
+                            description:
+                              "Named output renderings; the first is the default for the bare marker",
                           },
                         },
                         required: ["registry", "formats"],
+                        additionalProperties: false,
+                        description: "Who-fills = business-registry lookup",
+                      },
+                      source: {
+                        oneOf: [
+                          {
+                            type: "object",
+                            properties: {
+                              kind: {
+                                const: "contact",
+                              },
+                              field: {
+                                enum: [
+                                  "displayName",
+                                  "firstName",
+                                  "lastName",
+                                  "organizationName",
+                                  "email",
+                                  "phone",
+                                  "address",
+                                  "addressStreet",
+                                  "addressCity",
+                                  "addressPostalCode",
+                                  "addressCountry",
+                                  "registrationNumber",
+                                  "taxId",
+                                  "iban",
+                                  "bic",
+                                  "dataBox",
+                                ],
+                                type: "string",
+                              },
+                            },
+                            required: ["kind", "field"],
+                            additionalProperties: false,
+                          },
+                          {
+                            type: "object",
+                            properties: {
+                              kind: {
+                                const: "party",
+                              },
+                              role: {
+                                enum: [
+                                  "opposing_party",
+                                  "opposing_counsel",
+                                  "co_counsel",
+                                  "witness",
+                                  "expert_witness",
+                                  "third_party",
+                                  "judge",
+                                  "mediator",
+                                  "other",
+                                ],
+                                type: "string",
+                              },
+                              field: {
+                                enum: [
+                                  "displayName",
+                                  "firstName",
+                                  "lastName",
+                                  "organizationName",
+                                  "email",
+                                  "phone",
+                                  "address",
+                                  "addressStreet",
+                                  "addressCity",
+                                  "addressPostalCode",
+                                  "addressCountry",
+                                  "registrationNumber",
+                                  "taxId",
+                                  "iban",
+                                  "bic",
+                                  "dataBox",
+                                ],
+                                type: "string",
+                              },
+                            },
+                            required: ["kind", "role", "field"],
+                            additionalProperties: false,
+                          },
+                          {
+                            type: "object",
+                            properties: {
+                              kind: {
+                                const: "matter",
+                              },
+                              field: {
+                                enum: [
+                                  "name",
+                                  "reference",
+                                  "billingReference",
+                                  "status",
+                                ],
+                                type: "string",
+                              },
+                            },
+                            required: ["kind", "field"],
+                            additionalProperties: false,
+                          },
+                          {
+                            type: "object",
+                            properties: {
+                              kind: {
+                                const: "attorney",
+                              },
+                              ref: {
+                                enum: ["responsible", "originating", "lead"],
+                                type: "string",
+                              },
+                              field: {
+                                enum: ["name", "email"],
+                                type: "string",
+                              },
+                            },
+                            required: ["kind", "ref", "field"],
+                            additionalProperties: false,
+                          },
+                          {
+                            type: "object",
+                            properties: {
+                              kind: {
+                                const: "firm",
+                              },
+                              field: {
+                                enum: ["name"],
+                                type: "string",
+                              },
+                            },
+                            required: ["kind", "field"],
+                            additionalProperties: false,
+                          },
+                        ],
+                        description:
+                          "Matter or contact data resolved server-side",
+                      },
+                      formula: {
+                        type: "string",
+                        description:
+                          "Arithmetic expression derived from other fields",
+                      },
+                      condition: {
+                        type: "string",
+                        description:
+                          "Boolean rule expression referenced by a {{#if field_path}} marker",
+                      },
+                      dateFormat: {
+                        type: "object",
+                        properties: {
+                          locale: {
+                            type: "string",
+                            description:
+                              "BCP-47 language tag, e.g. 'cs', 'de', 'pl'",
+                          },
+                          style: {
+                            enum: ["long", "medium", "short", "iso"],
+                            type: "string",
+                            description: "Date rendering style",
+                          },
+                        },
+                        required: ["locale", "style"],
+                        additionalProperties: false,
+                        description:
+                          "Locale-aware date rendering for a date field",
                       },
                     },
                     required: ["path"],
                     additionalProperties: false,
                   },
+                  description:
+                    "Strict field configuration overlay; each path must match a template marker",
                 },
               },
             },
@@ -4012,51 +4245,61 @@ export const generatedRouteMap: RouteNode = {
             scope: "admin_read",
             inputSchema: {
               type: "object",
+              required: [],
+              additionalProperties: false,
               properties: {
                 workspace_id: {
                   type: "string",
+                  minLength: 1,
                   description: "Only entries scoped to this matter/workspace",
                 },
                 action: {
                   type: "string",
+                  minLength: 1,
                   description: "Only entries with this audit action",
                 },
                 resource_type: {
                   type: "string",
+                  minLength: 1,
                   description: "Only entries about this resource type",
                 },
                 resource_id: {
                   type: "string",
+                  minLength: 1,
                   description:
                     "Only entries about this resource id; requires resource_type",
                 },
                 user_id: {
                   type: "string",
+                  minLength: 1,
                   description: "Only entries whose actor is this user",
                 },
                 from: {
                   type: "string",
+                  format: "date-time",
+                  maxLength: 40,
                   description:
                     "Only entries created on or after this ISO date-time",
-                  maxLength: 40,
                 },
                 to: {
                   type: "string",
+                  format: "date-time",
+                  maxLength: 40,
                   description:
                     "Only entries created on or before this ISO date-time",
-                  maxLength: 40,
                 },
                 limit: {
                   type: "integer",
-                  description: "Max entries to return",
                   minimum: 1,
                   maximum: 200,
+                  description: "Max entries to return",
                 },
                 cursor: {
                   type: "string",
+                  minLength: 1,
+                  maxLength: 512,
                   description:
                     "Opaque cursor from a previous list_audit_log call to fetch the next page",
-                  maxLength: 512,
                 },
               },
             },

--- a/packages/cli/src/generated/route-map.ts
+++ b/packages/cli/src/generated/route-map.ts
@@ -4276,14 +4276,12 @@ export const generatedRouteMap: RouteNode = {
                 },
                 from: {
                   type: "string",
-                  format: "date-time",
                   maxLength: 40,
                   description:
                     "Only entries created on or after this ISO date-time",
                 },
                 to: {
                   type: "string",
-                  format: "date-time",
                   maxLength: 40,
                   description:
                     "Only entries created on or before this ISO date-time",

--- a/packages/cli/src/generated/route-map.ts
+++ b/packages/cli/src/generated/route-map.ts
@@ -2076,7 +2076,8 @@ export const generatedRouteMap: RouteNode = {
                             type: "object",
                             properties: {
                               kind: {
-                                const: "contact",
+                                enum: ["contact"],
+                                type: "string",
                               },
                               field: {
                                 enum: [
@@ -2107,7 +2108,8 @@ export const generatedRouteMap: RouteNode = {
                             type: "object",
                             properties: {
                               kind: {
-                                const: "party",
+                                enum: ["party"],
+                                type: "string",
                               },
                               role: {
                                 enum: [
@@ -2152,7 +2154,8 @@ export const generatedRouteMap: RouteNode = {
                             type: "object",
                             properties: {
                               kind: {
-                                const: "matter",
+                                enum: ["matter"],
+                                type: "string",
                               },
                               field: {
                                 enum: [
@@ -2171,7 +2174,8 @@ export const generatedRouteMap: RouteNode = {
                             type: "object",
                             properties: {
                               kind: {
-                                const: "attorney",
+                                enum: ["attorney"],
+                                type: "string",
                               },
                               ref: {
                                 enum: ["responsible", "originating", "lead"],
@@ -2189,7 +2193,8 @@ export const generatedRouteMap: RouteNode = {
                             type: "object",
                             properties: {
                               kind: {
-                                const: "firm",
+                                enum: ["firm"],
+                                type: "string",
                               },
                               field: {
                                 enum: ["name"],

--- a/packages/cli/src/generated/route-map.ts
+++ b/packages/cli/src/generated/route-map.ts
@@ -2071,7 +2071,7 @@ export const generatedRouteMap: RouteNode = {
                         description: "Who-fills = business-registry lookup",
                       },
                       source: {
-                        oneOf: [
+                        anyOf: [
                           {
                             type: "object",
                             properties: {

--- a/packages/legal-ast/src/analysis.test.ts
+++ b/packages/legal-ast/src/analysis.test.ts
@@ -27,6 +27,43 @@ describe("parsePersistedDecisionAnalysis", () => {
     ).toBeNull();
   });
 
+  test("returns the canonical parsed payload instead of the raw object", () => {
+    expect(
+      parsePersistedDecisionAnalysis({
+        version: 1,
+        generatedAt: "2026-04-30T12:00:00.000Z",
+        model: "test-model",
+        tree: [
+          {
+            id: "h1",
+            label: "Heading",
+            category: "facts",
+            startAnchorId: "a1",
+            endAnchorId: "a2",
+            annotations: [],
+            children: [],
+            staleProducerField: true,
+          },
+        ],
+      }),
+    ).toEqual({
+      version: 1,
+      generatedAt: "2026-04-30T12:00:00.000Z",
+      model: "test-model",
+      tree: [
+        {
+          id: "h1",
+          label: "Heading",
+          category: "facts",
+          startAnchorId: "a1",
+          endAnchorId: "a2",
+          annotations: [],
+          children: [],
+        },
+      ],
+    });
+  });
+
   test("rejects a decision analysis with malformed headings", () => {
     const malformed = {
       version: 1,

--- a/packages/legal-ast/src/analysis.ts
+++ b/packages/legal-ast/src/analysis.ts
@@ -88,55 +88,57 @@ export const analysisHeadingSchema: v.GenericSchema<AnalysisHeading> = v.object(
 );
 
 export const decisionAnalysisSchema: v.GenericSchema<DecisionAnalysis> =
-  v.object({
+  v.strictObject({
     version: v.literal(1),
     generatedAt: v.string(),
     model: v.string(),
     tree: v.array(analysisHeadingSchema),
   });
 
-const analysisInProgressSchema: v.GenericSchema<AnalysisInProgress> = v.object({
-  version: v.literal(1),
-  generatedAt: v.string(),
-  model: v.string(),
-  tree: v.array(analysisHeadingSchema),
-  status: v.literal("generating"),
-});
+const analysisInProgressSchema: v.GenericSchema<AnalysisInProgress> =
+  v.strictObject({
+    version: v.literal(1),
+    generatedAt: v.string(),
+    model: v.string(),
+    tree: v.array(analysisHeadingSchema),
+    status: v.literal("generating"),
+  });
 
-const analysisGeneratingSchema: v.GenericSchema<AnalysisGenerating> = v.object({
-  version: v.literal(1),
-  status: v.literal("generating"),
-  startedAt: v.string(),
-});
+const analysisGeneratingSchema: v.GenericSchema<AnalysisGenerating> =
+  v.strictObject({
+    version: v.literal(1),
+    status: v.literal("generating"),
+    startedAt: v.string(),
+  });
+
+const persistedDecisionAnalysisSchema: v.GenericSchema<PersistedDecisionAnalysis> =
+  v.union([
+    analysisInProgressSchema,
+    analysisGeneratingSchema,
+    decisionAnalysisSchema,
+  ]);
 
 export const isAnalysisGenerating = (val: unknown): val is AnalysisGenerating =>
-  v.safeParse(analysisGeneratingSchema, val).success;
+  v.is(analysisGeneratingSchema, val);
 
 export const isDecisionAnalysis = (val: unknown): val is DecisionAnalysis =>
-  v.safeParse(decisionAnalysisSchema, val).success &&
-  !(typeof val === "object" && val !== null && Object.hasOwn(val, "status"));
+  v.is(decisionAnalysisSchema, val);
 
 export const isAnalysisInProgress = (val: unknown): val is AnalysisInProgress =>
-  v.safeParse(analysisInProgressSchema, val).success;
+  v.is(analysisInProgressSchema, val);
 
 export const parsePersistedDecisionAnalysis = (
   val: unknown,
 ): PersistedDecisionAnalysis | null => {
-  if (
-    isAnalysisInProgress(val) ||
-    isDecisionAnalysis(val) ||
-    isAnalysisGenerating(val)
-  ) {
-    return val;
+  let candidate = val;
+  if (typeof candidate === "string") {
+    try {
+      candidate = JSON.parse(candidate);
+    } catch {
+      return null;
+    }
   }
 
-  if (typeof val !== "string") {
-    return null;
-  }
-
-  try {
-    return parsePersistedDecisionAnalysis(JSON.parse(val));
-  } catch {
-    return null;
-  }
+  const result = v.safeParse(persistedDecisionAnalysisSchema, candidate);
+  return result.success ? result.output : null;
 };

--- a/packages/legal-ast/src/document-ast.ts
+++ b/packages/legal-ast/src/document-ast.ts
@@ -213,7 +213,7 @@ export const persistedDocumentAstSchema: v.GenericSchema<unknown, DocumentAst> =
   );
 
 export const isDocumentAst = (val: unknown): val is DocumentAst =>
-  v.safeParse(documentAstSchema, val).success;
+  v.is(documentAstSchema, val);
 
 export const parseDocumentAst = (raw: unknown): DocumentAst | null => {
   if (raw === null || raw === undefined) {

--- a/packages/legal-ast/src/inline.ts
+++ b/packages/legal-ast/src/inline.ts
@@ -44,10 +44,10 @@ export const inlineSchema: v.GenericSchema<Inline> = v.variant("type", [
 const inlineArraySchema = v.array(v.lazy(() => inlineSchema));
 
 export const isInlineArray = (val: unknown): val is Inline[] =>
-  v.safeParse(inlineArraySchema, val).success;
+  v.is(inlineArraySchema, val);
 
 export const isInline = (val: unknown): val is Inline =>
-  v.safeParse(inlineSchema, val).success;
+  v.is(inlineSchema, val);
 
 export const flattenInlineText = (inlines: readonly Inline[]): string => {
   const parts: string[] = [];

--- a/packages/template-packs/scripts/generate-manifest.ts
+++ b/packages/template-packs/scripts/generate-manifest.ts
@@ -86,20 +86,12 @@ const assertIndexAgrees = ({
     return;
   }
   const disagreements = [
-    indexed.license !== undefined && indexed.license !== effective.license
-      ? "license"
-      : null,
-    indexed.jurisdictions !== undefined &&
+    indexed.license !== effective.license ? "license" : null,
     !sameJson(indexed.jurisdictions, effective.jurisdictions)
       ? "jurisdictions"
       : null,
-    indexed.languages !== undefined &&
-    !sameJson(indexed.languages, effective.languages)
-      ? "languages"
-      : null,
-    indexed.legalArea !== undefined && indexed.legalArea !== effective.legalArea
-      ? "legalArea"
-      : null,
+    !sameJson(indexed.languages, effective.languages) ? "languages" : null,
+    indexed.legalArea !== effective.legalArea ? "legalArea" : null,
   ].filter((field) => field !== null);
   if (disagreements.length > 0) {
     panic(

--- a/packages/template-packs/src/fixtures/content/index.json
+++ b/packages/template-packs/src/fixtures/content/index.json
@@ -26,6 +26,9 @@
       {
         "slug": "employment-agreement",
         "title": "Employment agreement",
+        "file": "templates/employment-agreement/template.docx",
+        "license": "CC-BY-4.0",
+        "jurisdictions": [{ "country": "CZ" }],
         "languages": ["en"],
         "legalArea": "employment",
         "fields": [

--- a/packages/template-packs/src/schema.test.ts
+++ b/packages/template-packs/src/schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import * as v from "valibot";
+
+import { packManifestSchema } from "./schema";
+
+const validTemplate = {
+  slug: "sample-template",
+  title: "Sample template",
+  file: "template.docx",
+  readme: "README.md",
+};
+
+const validManifest = {
+  id: "sample-pack",
+  name: "Sample pack",
+  version: "1.0.0",
+  license: "CC0-1.0",
+  templates: [validTemplate],
+};
+
+describe("template pack manifest contract", () => {
+  test("rejects unknown fields in repo-owned manifests", () => {
+    expect(v.safeParse(packManifestSchema, validManifest).success).toBe(true);
+    expect(
+      v.safeParse(packManifestSchema, {
+        ...validManifest,
+        templates: [
+          {
+            ...validTemplate,
+            misspelledLicense: "CC0-1.0",
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/template-packs/src/schema.test.ts
+++ b/packages/template-packs/src/schema.test.ts
@@ -24,6 +24,34 @@ describe("template pack manifest contract", () => {
     expect(
       v.safeParse(packManifestSchema, {
         ...validManifest,
+        licenceUrl: "https://example.test/license",
+      }).success,
+    ).toBe(false);
+    expect(
+      v.safeParse(packManifestSchema, {
+        ...validManifest,
+        jurisdictions: [{ country: "CZ", subdivisionName: "Praha" }],
+      }).success,
+    ).toBe(false);
+    expect(
+      v.safeParse(packManifestSchema, {
+        ...validManifest,
+        authors: [{ name: "A", role: "drafter", org: "Example" }],
+      }).success,
+    ).toBe(false);
+    expect(
+      v.safeParse(packManifestSchema, {
+        ...validManifest,
+        source: {
+          name: "Example",
+          url: "https://example.test/source",
+          archiveUrl: "https://example.test/archive",
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      v.safeParse(packManifestSchema, {
+        ...validManifest,
         templates: [
           {
             ...validTemplate,

--- a/packages/template-packs/src/schema.ts
+++ b/packages/template-packs/src/schema.ts
@@ -39,7 +39,7 @@ const relativePathSchema = v.pipe(
 const nonEmptyString = v.pipe(v.string(), v.trim(), v.minLength(1));
 const optionalString = v.optional(v.string());
 
-export const templatePackJurisdictionSchema = v.object({
+export const templatePackJurisdictionSchema = v.strictObject({
   country: v.pipe(v.string(), v.regex(COUNTRY_PATTERN)),
   subdivision: optionalString,
 });
@@ -47,7 +47,7 @@ export type TemplatePackJurisdiction = v.InferOutput<
   typeof templatePackJurisdictionSchema
 >;
 
-export const templatePackAuthorSchema = v.object({
+export const templatePackAuthorSchema = v.strictObject({
   name: nonEmptyString,
   organization: optionalString,
   url: optionalString,
@@ -56,14 +56,14 @@ export const templatePackAuthorSchema = v.object({
 });
 export type TemplatePackAuthor = v.InferOutput<typeof templatePackAuthorSchema>;
 
-export const templatePackSourceSchema = v.object({
+export const templatePackSourceSchema = v.strictObject({
   name: nonEmptyString,
   url: nonEmptyString,
   retrievedAt: optionalString,
 });
 export type TemplatePackSource = v.InferOutput<typeof templatePackSourceSchema>;
 
-const templateEntrySchema = v.object({
+const templateEntrySchema = v.strictObject({
   slug: slugSchema,
   title: nonEmptyString,
   /** Path of the DOCX relative to the pack directory. */
@@ -77,7 +77,7 @@ const templateEntrySchema = v.object({
 });
 
 /** `pack.json` as committed in the content repository. */
-export const packManifestSchema = v.object({
+export const packManifestSchema = v.strictObject({
   id: slugSchema,
   name: nonEmptyString,
   version: nonEmptyString,
@@ -100,10 +100,10 @@ export type PackManifest = v.InferOutput<typeof packManifestSchema>;
 /** `index.json` at the content root: per-template field lists, hashes and
  *  the effective (template-or-pack) license, jurisdictions and languages. */
 export const packIndexSchema = v.array(
-  v.object({
+  v.strictObject({
     id: slugSchema,
     templates: v.array(
-      v.object({
+      v.strictObject({
         slug: slugSchema,
         license: v.optional(v.string()),
         jurisdictions: v.optional(v.array(templatePackJurisdictionSchema)),

--- a/packages/template-packs/src/schema.ts
+++ b/packages/template-packs/src/schema.ts
@@ -97,19 +97,28 @@ export const packManifestSchema = v.strictObject({
 });
 export type PackManifest = v.InferOutput<typeof packManifestSchema>;
 
-/** `index.json` at the content root: per-template field lists, hashes and
- *  the effective (template-or-pack) license, jurisdictions and languages. */
+/** `index.json` at the content root: the complete generated catalogue shape. */
 export const packIndexSchema = v.array(
   v.strictObject({
     id: slugSchema,
+    name: nonEmptyString,
+    version: nonEmptyString,
+    license: nonEmptyString,
+    jurisdictions: v.array(templatePackJurisdictionSchema),
+    languages: v.array(nonEmptyString),
+    legalAreas: v.array(nonEmptyString),
+    authors: v.array(templatePackAuthorSchema),
+    templateCount: v.pipe(v.number(), v.integer(), v.minValue(0)),
     templates: v.array(
       v.strictObject({
         slug: slugSchema,
-        license: v.optional(v.string()),
-        jurisdictions: v.optional(v.array(templatePackJurisdictionSchema)),
-        languages: v.optional(v.array(v.string())),
-        legalArea: v.optional(v.nullable(v.string())),
-        fields: v.optional(v.array(v.string()), []),
+        title: nonEmptyString,
+        file: relativePathSchema,
+        license: nonEmptyString,
+        jurisdictions: v.array(templatePackJurisdictionSchema),
+        languages: v.array(nonEmptyString),
+        legalArea: v.nullable(nonEmptyString),
+        fields: v.array(nonEmptyString),
         sha256: v.pipe(v.string(), v.regex(SHA256_PATTERN)),
       }),
     ),

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -11,6 +11,12 @@
     "count": 0,
     "files": {}
   },
+  "legacy-manual-mcp-input-schemas": {
+    "count": 44,
+    "files": {
+      "apps/api/src/mcp/static-tool-definitions.ts": 44
+    }
+  },
   "nullish-array-fallback": {
     "count": 7,
     "files": {

--- a/scripts/ratchet.ts
+++ b/scripts/ratchet.ts
@@ -1116,6 +1116,78 @@ const countWorkspaceOnlyRlsOnOrgTables = (content: string): number => {
   return count;
 };
 
+const LEGACY_MANUAL_MCP_INPUT_SCHEMA_ALLOWLIST =
+  "MCP_LEGACY_MANUAL_INPUT_SCHEMA_TOOL_NAMES";
+
+const unwrapExpression = (expression: ts.Expression): ts.Expression => {
+  let current = expression;
+  while (
+    ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isParenthesizedExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+};
+
+/**
+ * Entries in the explicit legacy native-MCP input-schema inventory. Each entry
+ * is a tool whose hand-authored JSON Schema still mirrors a separate runtime
+ * validator; the count may only shrink as tools move to Valibot-derived wire
+ * schemas. Parse the exact declaration so comments and unrelated arrays cannot
+ * buy or consume this debt budget.
+ */
+const countLegacyManualMcpInputSchemas = (
+  content: string,
+  file: string,
+): number => {
+  const sourceFile = ts.createSourceFile(
+    file,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) {
+      continue;
+    }
+    for (const declaration of statement.declarationList.declarations) {
+      if (
+        !ts.isIdentifier(declaration.name) ||
+        declaration.name.text !== LEGACY_MANUAL_MCP_INPUT_SCHEMA_ALLOWLIST
+      ) {
+        continue;
+      }
+      if (declaration.initializer === undefined) {
+        return panic(
+          `${LEGACY_MANUAL_MCP_INPUT_SCHEMA_ALLOWLIST} must have an array initializer`,
+        );
+      }
+      const initializer = unwrapExpression(declaration.initializer);
+      if (!ts.isArrayLiteralExpression(initializer)) {
+        return panic(
+          `${LEGACY_MANUAL_MCP_INPUT_SCHEMA_ALLOWLIST} must be an array literal`,
+        );
+      }
+      for (const element of initializer.elements) {
+        if (!ts.isStringLiteralLike(element)) {
+          return panic(
+            `${LEGACY_MANUAL_MCP_INPUT_SCHEMA_ALLOWLIST} must contain only string literals`,
+          );
+        }
+      }
+      return initializer.elements.length;
+    }
+  }
+
+  return panic(
+    `${LEGACY_MANUAL_MCP_INPUT_SCHEMA_ALLOWLIST} is missing from ${file}`,
+  );
+};
+
 type FileCounter = (content: string, file: string) => number;
 
 type RatchetMetric = {
@@ -1174,6 +1246,14 @@ const RATCHET_METRICS: readonly RatchetMetric[] = [
     include: ["apps/api/src/**/*.{ts,tsx}"],
     exclude: isExcludedSource,
     count: countLegacyRealtimeInvalidationProducers,
+  },
+  {
+    id: "legacy-manual-mcp-input-schemas",
+    description:
+      "tools in MCP_LEGACY_MANUAL_INPUT_SCHEMA_TOOL_NAMES whose hand-authored JSON Schema mirrors a separate runtime validator; each Valibot source-of-truth conversion removes one entry",
+    include: ["apps/api/src/mcp/static-tool-definitions.ts"],
+    exclude: () => false,
+    count: countLegacyManualMcpInputSchemas,
   },
   {
     id: "nullish-array-fallback",
@@ -1900,6 +1980,18 @@ const LEGACY_REALTIME_INVALIDATION_FIXTURE_LINES = [
 const SELF_TEST_LEGACY_REALTIME_INVALIDATIONS = `${LEGACY_REALTIME_INVALIDATION_FIXTURE_LINES.join("\n")}\n`;
 const EXPECTED_LEGACY_REALTIME_INVALIDATIONS = 7;
 
+const LEGACY_MANUAL_MCP_INPUT_SCHEMA_FIXTURE_LINES = [
+  "const MCP_LEGACY_MANUAL_INPUT_SCHEMA_TOOL_NAMES = [",
+  '  "search",',
+  '  "fetch",',
+  '  "list_matters",',
+  "] as const satisfies readonly LegacyManualInputToolName[];",
+  'const unrelated = ["save_template"];',
+  '// "commented_tool",',
+];
+const SELF_TEST_LEGACY_MANUAL_MCP_INPUT_SCHEMAS = `${LEGACY_MANUAL_MCP_INPUT_SCHEMA_FIXTURE_LINES.join("\n")}\n`;
+const EXPECTED_LEGACY_MANUAL_MCP_INPUT_SCHEMAS = 3;
+
 const ENTITY_GLYPH_FIXTURE_LINES = [
   'import { FolderIcon, FolderOpenIcon, ListTodoIcon } from "lucide-react";',
   "const shut = <FolderIcon />;",
@@ -2480,6 +2572,11 @@ const runSelfTest = (): number => {
     );
     writeFixture(
       root,
+      "apps/api/src/mcp/static-tool-definitions.ts",
+      SELF_TEST_LEGACY_MANUAL_MCP_INPUT_SCHEMAS,
+    );
+    writeFixture(
+      root,
       "apps/web/src/entity-glyphs.tsx",
       SELF_TEST_ENTITY_GLYPHS,
     );
@@ -2651,6 +2748,19 @@ const runSelfTest = (): number => {
     if (legacyRealtimeMetric.count !== EXPECTED_LEGACY_REALTIME_INVALIDATIONS) {
       failures.push(
         `legacy-realtime-invalidation-producers counted ${legacyRealtimeMetric.count}, expected ${EXPECTED_LEGACY_REALTIME_INVALIDATIONS}`,
+      );
+    }
+
+    const legacyManualMcpInputSchemaMetric = requireSnapshot(
+      snapshot,
+      "legacy-manual-mcp-input-schemas",
+    );
+    if (
+      legacyManualMcpInputSchemaMetric.count !==
+      EXPECTED_LEGACY_MANUAL_MCP_INPUT_SCHEMAS
+    ) {
+      failures.push(
+        `legacy-manual-mcp-input-schemas counted ${legacyManualMcpInputSchemaMetric.count}, expected ${EXPECTED_LEGACY_MANUAL_MCP_INPUT_SCHEMAS}`,
       );
     }
 


### PR DESCRIPTION
## Summary

- preserve typed and branded handler outputs through one-pass chat projection; bind every handler output to its named projection and fail closed on non-JSON or unclassified data
- derive save_template and list_audit_log MCP input JSON Schema from the exact runtime Valibot schema, with explicit projection waivers and a 44-tool decrease-only migration ratchet
- parse persisted decision analysis once into a canonical union; remove downstream revalidation
- modernize lower-priority Valibot boundaries with isoDate and isoTimestamp actions, toNumber, discriminator variants, strict or projection objects, v.is guards, and the canonical SafeId schema
- include patch changesets for the affected published packages

This PR is stacked on #2371.

## Validation

- git diff --check
- local lint, formatting, and typecheck intentionally skipped due host load; remote CI is authoritative

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an audit-log listing tool with ISO timestamp validation and clearer input errors.
  * Added template metadata for the employment agreement, including licence and jurisdiction details.
  * Improved template creation validation for field configuration and encoded content.

* **Bug Fixes**
  * Improved handling of in-progress and completed decision analyses.
  * Prevented cyclic data from being treated as valid persisted JSON.
  * Added safeguards for invalid environment settings and realtime resource-change counts.

* **Improvements**
  * Strengthened validation across MCP tools, imported data, OAuth responses, capability catalogues and template packs.
  * Improved error reporting for malformed template metadata and unsupported inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->