### PR TITLE
fix(api): make corpus census counts constant-time

### DIFF
--- a/apps/api/drizzle/20260823020000_case_law_corpus_index_counts/migration.sql
+++ b/apps/api/drizzle/20260823020000_case_law_corpus_index_counts/migration.sql
@@ -1,0 +1,260 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Nullable and metadata-only on the live projection table. Existing rows are
+-- accounted by the bounded keyset backfill below; every new or changed row is
+-- derived synchronously by the trigger installed in this migration.
+ALTER TABLE "case_law_corpus_index_projections"
+  ADD COLUMN "accounted_index_id" varchar(64);--> statement-breakpoint
+
+ALTER TABLE "case_law_corpus_index_projections"
+  ADD CONSTRAINT "case_law_corpus_index_projections_accounted_shape"
+  CHECK (
+    "accounted_index_id" IS NULL
+    OR (
+      "pending_action" IS NULL
+      AND "indexed_hash" IS NOT NULL
+      AND "accounted_index_id" = "index_id"
+    )
+  ) NOT VALID;--> statement-breakpoint
+
+CREATE TABLE "case_law_corpus_index_counts" (
+  "generation" varchar(32) NOT NULL,
+  "index_id" varchar(64) NOT NULL,
+  "marked_indexed" bigint DEFAULT 0 NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "case_law_corpus_index_counts_pk"
+    PRIMARY KEY ("generation", "index_id"),
+  CONSTRAINT "case_law_corpus_index_counts_generation_fk"
+    FOREIGN KEY ("generation")
+    REFERENCES "case_law_corpus_index_backfills"("generation")
+    ON DELETE CASCADE,
+  CONSTRAINT "case_law_corpus_index_counts_nonnegative"
+    CHECK ("marked_indexed" >= 0)
+);--> statement-breakpoint
+
+ALTER TABLE "case_law_corpus_index_counts" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "case_law_ingestion_access"
+  ON "case_law_corpus_index_counts"
+  AS PERMISSIVE FOR ALL TO stella_ingestion
+  USING (true) WITH CHECK (true);--> statement-breakpoint
+GRANT SELECT ON TABLE "case_law_corpus_index_counts" TO stella;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON TABLE "case_law_corpus_index_counts" TO stella_ingestion;--> statement-breakpoint
+
+CREATE TABLE "case_law_corpus_index_count_backfills" (
+  "generation" varchar(32) PRIMARY KEY,
+  "cursor_decision_id" uuid,
+  "status" text DEFAULT 'running' NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "case_law_corpus_index_count_backfills_generation_fk"
+    FOREIGN KEY ("generation")
+    REFERENCES "case_law_corpus_index_backfills"("generation")
+    ON DELETE CASCADE,
+  CONSTRAINT "case_law_corpus_index_count_backfills_status_values"
+    CHECK ("status" IN ('running', 'complete'))
+);--> statement-breakpoint
+
+ALTER TABLE "case_law_corpus_index_count_backfills" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "case_law_ingestion_access"
+  ON "case_law_corpus_index_count_backfills"
+  AS PERMISSIVE FOR ALL TO stella_ingestion
+  USING (true) WITH CHECK (true);--> statement-breakpoint
+GRANT SELECT ON TABLE "case_law_corpus_index_count_backfills" TO stella;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON TABLE "case_law_corpus_index_count_backfills" TO stella_ingestion;--> statement-breakpoint
+
+-- Only generations that predate this migration need a seed walk. A generation
+-- created after the accounting trigger exists starts exact at zero.
+INSERT INTO "case_law_corpus_index_count_backfills" ("generation", "status")
+SELECT "generation", 'running'
+FROM "case_law_corpus_index_backfills";--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION derive_case_law_corpus_index_accounting()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+  decision_content_hash varchar(64);
+  decision_country varchar(3);
+BEGIN
+  SELECT decision.content_hash, decision.country
+  INTO STRICT decision_content_hash, decision_country
+  FROM case_law_decisions AS decision
+  WHERE decision.id = NEW.decision_id;
+
+  NEW.accounted_index_id := CASE
+    WHEN NEW.pending_action IS NULL
+      AND NEW.indexed_hash = decision_content_hash
+      AND NEW.index_id = case_law_corpus_index_id(
+        NEW.generation,
+        decision_country
+      )
+    THEN NEW.index_id
+    ELSE NULL
+  END;
+  RETURN NEW;
+END
+$function$;--> statement-breakpoint
+
+CREATE TRIGGER case_law_corpus_index_projection_derive_accounting
+BEFORE INSERT OR UPDATE OF generation, decision_id, index_id, indexed_hash, pending_action, accounted_index_id
+ON "case_law_corpus_index_projections"
+FOR EACH ROW
+EXECUTE FUNCTION derive_case_law_corpus_index_accounting();--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION add_inserted_case_law_corpus_index_counts()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  INSERT INTO case_law_corpus_index_counts AS counts (
+    generation,
+    index_id,
+    marked_indexed,
+    updated_at
+  )
+  SELECT generation, accounted_index_id, count(*)::bigint, clock_timestamp()
+  FROM new_projections
+  WHERE accounted_index_id IS NOT NULL
+  GROUP BY generation, accounted_index_id
+  ON CONFLICT ON CONSTRAINT case_law_corpus_index_counts_pk DO UPDATE
+  SET marked_indexed = counts.marked_indexed + EXCLUDED.marked_indexed,
+      updated_at = EXCLUDED.updated_at;
+  RETURN NULL;
+END
+$function$;--> statement-breakpoint
+
+CREATE TRIGGER case_law_corpus_index_projection_count_insert
+AFTER INSERT ON "case_law_corpus_index_projections"
+REFERENCING NEW TABLE AS new_projections
+FOR EACH STATEMENT
+EXECUTE FUNCTION add_inserted_case_law_corpus_index_counts();--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION apply_updated_case_law_corpus_index_counts()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  -- Materialize a zero bucket first. A negative delta without an existing
+  -- bucket then violates the nonnegative CHECK instead of disappearing.
+  WITH deltas AS (
+    SELECT generation, index_id, sum(delta)::bigint AS delta
+    FROM (
+      SELECT generation, accounted_index_id AS index_id, -count(*)::bigint AS delta
+      FROM old_projections
+      WHERE accounted_index_id IS NOT NULL
+      GROUP BY generation, accounted_index_id
+      UNION ALL
+      SELECT generation, accounted_index_id AS index_id, count(*)::bigint AS delta
+      FROM new_projections
+      WHERE accounted_index_id IS NOT NULL
+      GROUP BY generation, accounted_index_id
+    ) AS changes
+    GROUP BY generation, index_id
+    HAVING sum(delta) <> 0
+  )
+  INSERT INTO case_law_corpus_index_counts (
+    generation,
+    index_id,
+    marked_indexed,
+    updated_at
+  )
+  SELECT generation, index_id, 0, clock_timestamp()
+  FROM deltas
+  ON CONFLICT ON CONSTRAINT case_law_corpus_index_counts_pk DO NOTHING;
+
+  WITH deltas AS (
+    SELECT generation, index_id, sum(delta)::bigint AS delta
+    FROM (
+      SELECT generation, accounted_index_id AS index_id, -count(*)::bigint AS delta
+      FROM old_projections
+      WHERE accounted_index_id IS NOT NULL
+      GROUP BY generation, accounted_index_id
+      UNION ALL
+      SELECT generation, accounted_index_id AS index_id, count(*)::bigint AS delta
+      FROM new_projections
+      WHERE accounted_index_id IS NOT NULL
+      GROUP BY generation, accounted_index_id
+    ) AS changes
+    GROUP BY generation, index_id
+    HAVING sum(delta) <> 0
+  )
+  UPDATE case_law_corpus_index_counts AS counts
+  SET marked_indexed = counts.marked_indexed + deltas.delta,
+      updated_at = clock_timestamp()
+  FROM deltas
+  WHERE counts.generation = deltas.generation
+    AND counts.index_id = deltas.index_id;
+  RETURN NULL;
+END
+$function$;--> statement-breakpoint
+
+CREATE TRIGGER case_law_corpus_index_projection_count_update
+AFTER UPDATE ON "case_law_corpus_index_projections"
+REFERENCING OLD TABLE AS old_projections NEW TABLE AS new_projections
+FOR EACH STATEMENT
+EXECUTE FUNCTION apply_updated_case_law_corpus_index_counts();--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION subtract_deleted_case_law_corpus_index_counts()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  WITH deltas AS (
+    SELECT generation, accounted_index_id AS index_id, count(*)::bigint AS delta
+    FROM old_projections
+    WHERE accounted_index_id IS NOT NULL
+    GROUP BY generation, accounted_index_id
+  )
+  UPDATE case_law_corpus_index_counts AS counts
+  SET marked_indexed = counts.marked_indexed - deltas.delta,
+      updated_at = clock_timestamp()
+  FROM deltas
+  WHERE counts.generation = deltas.generation
+    AND counts.index_id = deltas.index_id;
+
+  IF EXISTS (
+    SELECT 1
+    FROM old_projections AS deleted
+    WHERE deleted.accounted_index_id IS NOT NULL
+      AND EXISTS (
+        SELECT 1
+        FROM case_law_corpus_index_backfills AS generation
+        WHERE generation.generation = deleted.generation
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM case_law_corpus_index_counts AS counts
+        WHERE counts.generation = deleted.generation
+          AND counts.index_id = deleted.accounted_index_id
+      )
+  ) THEN
+    RAISE EXCEPTION 'case-law corpus index accounting bucket is missing';
+  END IF;
+  RETURN NULL;
+END
+$function$;--> statement-breakpoint
+
+CREATE TRIGGER case_law_corpus_index_projection_count_delete
+AFTER DELETE ON "case_law_corpus_index_projections"
+REFERENCING OLD TABLE AS old_projections
+FOR EACH STATEMENT
+EXECUTE FUNCTION subtract_deleted_case_law_corpus_index_counts();--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION seed_case_law_corpus_index_count_backfill()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  INSERT INTO case_law_corpus_index_count_backfills (generation, status)
+  VALUES (NEW.generation, 'complete')
+  ON CONFLICT (generation) DO NOTHING;
+  RETURN NEW;
+END
+$function$;--> statement-breakpoint
+
+CREATE TRIGGER case_law_corpus_index_backfill_seed_count
+AFTER INSERT ON "case_law_corpus_index_backfills"
+FOR EACH ROW
+EXECUTE FUNCTION seed_case_law_corpus_index_count_backfill();

--- a/apps/api/drizzle/20260823020000_case_law_corpus_index_counts/migration.sql
+++ b/apps/api/drizzle/20260823020000_case_law_corpus_index_counts/migration.sql
@@ -78,7 +78,7 @@ LANGUAGE plpgsql
 AS $function$
 BEGIN
   INSERT INTO case_law_corpus_index_count_backfills (generation, status)
-  VALUES (NEW.generation, 'complete')
+  VALUES (NEW.generation, 'running')
   ON CONFLICT ON CONSTRAINT case_law_corpus_index_count_backfills_pkey
   DO NOTHING;
   RETURN NEW;
@@ -87,14 +87,16 @@ $function$;--> statement-breakpoint
 
 -- Install generation tracking before taking the snapshot. CREATE TRIGGER's
 -- table lock separates earlier inserts, which the snapshot sees, from later
--- inserts, which this trigger records as exact empty generations.
+-- inserts, which this trigger records as generations that must remain
+-- unready until their generation walk has completed.
 CREATE TRIGGER case_law_corpus_index_backfill_seed_count
 AFTER INSERT ON "case_law_corpus_index_backfills"
 FOR EACH ROW
 EXECUTE FUNCTION seed_case_law_corpus_index_count_backfill();--> statement-breakpoint
 
--- Only generations that predate this migration need a seed walk. A generation
--- created after the accounting trigger exists starts exact at zero.
+-- Every generation needs a durable readiness checkpoint. Existing projections
+-- need a seed walk; new projections are counted by the trigger, but their
+-- generation can still expose legacy decision markers until its rebuild ends.
 INSERT INTO "case_law_corpus_index_count_backfills" ("generation", "status")
 SELECT "generation", 'running'
 FROM "case_law_corpus_index_backfills"

--- a/apps/api/drizzle/20260823020000_case_law_corpus_index_counts/migration.sql
+++ b/apps/api/drizzle/20260823020000_case_law_corpus_index_counts/migration.sql
@@ -72,11 +72,34 @@ GRANT SELECT ON TABLE "case_law_corpus_index_count_backfills" TO stella;--> stat
 GRANT SELECT, INSERT, UPDATE, DELETE
   ON TABLE "case_law_corpus_index_count_backfills" TO stella_ingestion;--> statement-breakpoint
 
+CREATE OR REPLACE FUNCTION seed_case_law_corpus_index_count_backfill()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  INSERT INTO case_law_corpus_index_count_backfills (generation, status)
+  VALUES (NEW.generation, 'complete')
+  ON CONFLICT ON CONSTRAINT case_law_corpus_index_count_backfills_pkey
+  DO NOTHING;
+  RETURN NEW;
+END
+$function$;--> statement-breakpoint
+
+-- Install generation tracking before taking the snapshot. CREATE TRIGGER's
+-- table lock separates earlier inserts, which the snapshot sees, from later
+-- inserts, which this trigger records as exact empty generations.
+CREATE TRIGGER case_law_corpus_index_backfill_seed_count
+AFTER INSERT ON "case_law_corpus_index_backfills"
+FOR EACH ROW
+EXECUTE FUNCTION seed_case_law_corpus_index_count_backfill();--> statement-breakpoint
+
 -- Only generations that predate this migration need a seed walk. A generation
 -- created after the accounting trigger exists starts exact at zero.
 INSERT INTO "case_law_corpus_index_count_backfills" ("generation", "status")
 SELECT "generation", 'running'
-FROM "case_law_corpus_index_backfills";--> statement-breakpoint
+FROM "case_law_corpus_index_backfills"
+ON CONFLICT ON CONSTRAINT case_law_corpus_index_count_backfills_pkey
+DO NOTHING;--> statement-breakpoint
 
 CREATE OR REPLACE FUNCTION derive_case_law_corpus_index_accounting()
 RETURNS trigger
@@ -249,21 +272,3 @@ AFTER DELETE ON "case_law_corpus_index_projections"
 REFERENCING OLD TABLE AS old_projections
 FOR EACH STATEMENT
 EXECUTE FUNCTION subtract_deleted_case_law_corpus_index_counts();--> statement-breakpoint
-
-CREATE OR REPLACE FUNCTION seed_case_law_corpus_index_count_backfill()
-RETURNS trigger
-LANGUAGE plpgsql
-AS $function$
-BEGIN
-  INSERT INTO case_law_corpus_index_count_backfills (generation, status)
-  VALUES (NEW.generation, 'complete')
-  ON CONFLICT ON CONSTRAINT case_law_corpus_index_count_backfills_pkey
-  DO NOTHING;
-  RETURN NEW;
-END
-$function$;--> statement-breakpoint
-
-CREATE TRIGGER case_law_corpus_index_backfill_seed_count
-AFTER INSERT ON "case_law_corpus_index_backfills"
-FOR EACH ROW
-EXECUTE FUNCTION seed_case_law_corpus_index_count_backfill();

--- a/apps/api/drizzle/20260823020000_case_law_corpus_index_counts/migration.sql
+++ b/apps/api/drizzle/20260823020000_case_law_corpus_index_counts/migration.sql
@@ -38,6 +38,10 @@ CREATE POLICY "case_law_ingestion_access"
   ON "case_law_corpus_index_counts"
   AS PERMISSIVE FOR ALL TO stella_ingestion
   USING (true) WITH CHECK (true);--> statement-breakpoint
+CREATE POLICY "case_law_global_access"
+  ON "case_law_corpus_index_counts"
+  AS PERMISSIVE FOR SELECT TO stella
+  USING (true);--> statement-breakpoint
 GRANT SELECT ON TABLE "case_law_corpus_index_counts" TO stella;--> statement-breakpoint
 GRANT SELECT, INSERT, UPDATE, DELETE
   ON TABLE "case_law_corpus_index_counts" TO stella_ingestion;--> statement-breakpoint
@@ -60,6 +64,10 @@ CREATE POLICY "case_law_ingestion_access"
   ON "case_law_corpus_index_count_backfills"
   AS PERMISSIVE FOR ALL TO stella_ingestion
   USING (true) WITH CHECK (true);--> statement-breakpoint
+CREATE POLICY "case_law_global_access"
+  ON "case_law_corpus_index_count_backfills"
+  AS PERMISSIVE FOR SELECT TO stella
+  USING (true);--> statement-breakpoint
 GRANT SELECT ON TABLE "case_law_corpus_index_count_backfills" TO stella;--> statement-breakpoint
 GRANT SELECT, INSERT, UPDATE, DELETE
   ON TABLE "case_law_corpus_index_count_backfills" TO stella_ingestion;--> statement-breakpoint
@@ -249,7 +257,8 @@ AS $function$
 BEGIN
   INSERT INTO case_law_corpus_index_count_backfills (generation, status)
   VALUES (NEW.generation, 'complete')
-  ON CONFLICT (generation) DO NOTHING;
+  ON CONFLICT ON CONSTRAINT case_law_corpus_index_count_backfills_pkey
+  DO NOTHING;
   RETURN NEW;
 END
 $function$;--> statement-breakpoint

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -1656,6 +1656,13 @@ export const caseLawCorpusIndexProjections = p.pgTable(
       .default(sql`'{}'::varchar(64)[]`),
     pendingRevision: p.integer("pending_revision").default(0).notNull(),
     /**
+     * Physical index whose membership is reflected in the exact aggregate.
+     * A database trigger derives this from the same current-decision and
+     * committed-projection state accepted by the serving query; null means
+     * this row contributes no document to the aggregate.
+     */
+    accountedIndexId: p.varchar("accounted_index_id", { length: 64 }),
+    /**
      * When a reservation last crossed the external append boundary. Only the
      * append reservation sets it — the projection trigger never does — so
      * its absence, with no committed copy, proves nothing has reached the
@@ -1697,6 +1704,10 @@ export const caseLawCorpusIndexProjections = p.pgTable(
       "case_law_corpus_index_projections_pending_revision_nonnegative",
       sql`${t.pendingRevision} >= 0`,
     ),
+    p.check(
+      "case_law_corpus_index_projections_accounted_shape",
+      sql`${t.accountedIndexId} IS NULL OR (${t.pendingAction} IS NULL AND ${t.indexedHash} IS NOT NULL AND ${t.accountedIndexId} = ${t.indexId})`,
+    ),
     p.index("case_law_corpus_index_projections_decision_idx").on(t.decisionId),
     p
       .index("case_law_corpus_index_projections_pending_idx")
@@ -1704,6 +1715,84 @@ export const caseLawCorpusIndexProjections = p.pgTable(
       .where(isNotNull(t.pendingAction)),
     ...globalCaseLawPolicies(),
     ...publicCaseLawReaderPolicies(),
+  ],
+);
+
+export const CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUSES = [
+  "running",
+  "complete",
+] as const;
+
+export type CaseLawCorpusIndexCountBackfillStatus =
+  (typeof CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUSES)[number];
+
+export const CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS = {
+  RUNNING: CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUSES[0],
+  COMPLETE: CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUSES[1],
+} as const satisfies Record<string, CaseLawCorpusIndexCountBackfillStatus>;
+
+/** Exact, transactionally maintained document count per physical index. */
+export const caseLawCorpusIndexCounts = p.pgTable(
+  "case_law_corpus_index_counts",
+  {
+    generation: p.varchar({ length: 32 }).notNull(),
+    indexId: p.varchar("index_id", { length: 64 }).notNull(),
+    markedIndexed: p
+      .bigint("marked_indexed", { mode: "number" })
+      .default(0)
+      .notNull(),
+    updatedAt: timestamptz("updated_at").defaultNow().notNull(),
+  },
+  (t) => [
+    p.primaryKey({
+      columns: [t.generation, t.indexId],
+      name: "case_law_corpus_index_counts_pk",
+    }),
+    p
+      .foreignKey({
+        name: "case_law_corpus_index_counts_generation_fk",
+        columns: [t.generation],
+        foreignColumns: [caseLawCorpusIndexBackfills.generation],
+      })
+      .onDelete("cascade"),
+    p.check(
+      "case_law_corpus_index_counts_nonnegative",
+      sql`${t.markedIndexed} >= 0`,
+    ),
+    ...globalCaseLawPolicies(),
+  ],
+);
+
+/** Durable keyset progress for accounting projections created before rollout. */
+export const caseLawCorpusIndexCountBackfills = p.pgTable(
+  "case_law_corpus_index_count_backfills",
+  {
+    generation: p.varchar({ length: 32 }).primaryKey(),
+    cursorDecisionId: safeUuid<"caseLawDecision">("cursor_decision_id"),
+    status: p
+      .text({ enum: CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUSES })
+      .notNull()
+      .default(CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.RUNNING),
+    updatedAt: timestamptz("updated_at").defaultNow().notNull(),
+  },
+  (t) => [
+    p
+      .foreignKey({
+        name: "case_law_corpus_index_count_backfills_generation_fk",
+        columns: [t.generation],
+        foreignColumns: [caseLawCorpusIndexBackfills.generation],
+      })
+      .onDelete("cascade"),
+    p.check(
+      "case_law_corpus_index_count_backfills_status_values",
+      sql`${t.status} IN (${sql.join(
+        CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUSES.map((status) =>
+          sql.raw(`'${status}'`),
+        ),
+        sql.raw(","),
+      )})`,
+    ),
+    ...globalCaseLawPolicies(),
   ],
 );
 

--- a/apps/api/src/lib/corpus-index/census-counts.db.test.ts
+++ b/apps/api/src/lib/corpus-index/census-counts.db.test.ts
@@ -1,0 +1,290 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { asc, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import type { ScopedDb } from "@/api/db/safe-db";
+import {
+  CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS,
+  caseLawCorpusIndexBackfills,
+  caseLawCorpusIndexCountBackfills,
+  caseLawCorpusIndexCounts,
+  caseLawCorpusIndexProjections,
+  caseLawDecisions,
+  caseLawSources,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import { advanceCaseLawCorpusIndexCountBackfill } from "@/api/lib/corpus-index/census";
+import {
+  installCaseLawProjectionAccounting,
+  installCaseLawProjectionTrigger,
+} from "@/api/tests/helpers/case-law-projection-trigger";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const GENERATION = "case_law_v2";
+const FUTURE_GENERATION = "case_law_v3";
+const INDEX_CZE = `${GENERATION}_cze`;
+const INDEX_SVK = `${GENERATION}_svk`;
+const sourceId = toSafeId<"caseLawSource">(
+  "00000000-0000-4000-8000-0000000000a1",
+);
+const currentDecisionId = toSafeId<"caseLawDecision">(
+  "00000000-0000-4000-8000-0000000000b1",
+);
+const pendingDecisionId = toSafeId<"caseLawDecision">(
+  "00000000-0000-4000-8000-0000000000b2",
+);
+const racedDecisionId = toSafeId<"caseLawDecision">(
+  "00000000-0000-4000-8000-0000000000b3",
+);
+const insertedDecisionId = toSafeId<"caseLawDecision">(
+  "00000000-0000-4000-8000-0000000000b4",
+);
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+let scopedDb: ScopedDb;
+
+const countRows = async () =>
+  await db
+    .select({
+      indexId: caseLawCorpusIndexCounts.indexId,
+      markedIndexed: caseLawCorpusIndexCounts.markedIndexed,
+    })
+    .from(caseLawCorpusIndexCounts)
+    .where(eq(caseLawCorpusIndexCounts.generation, GENERATION))
+    .orderBy(asc(caseLawCorpusIndexCounts.indexId));
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+  const handle = async (callback: (tx: Transaction) => Promise<unknown>) =>
+    await db.transaction(
+      // SAFETY: the embedded Drizzle transaction implements the transaction
+      // surface used by the count backfill.
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- PGlite is the scoped database in this integration test
+      async (tx) => await callback(tx as unknown as Transaction),
+    );
+  // SAFETY: this brand adds no runtime behavior.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-only scoped handle
+  scopedDb = handle as unknown as ScopedDb;
+
+  await db.insert(caseLawSources).values({
+    adapterKey: "public",
+    id: sourceId,
+    name: "Public",
+  });
+  await db
+    .insert(caseLawCorpusIndexBackfills)
+    .values({ generation: GENERATION });
+  await db.insert(caseLawDecisions).values([
+    {
+      caseNumber: "current",
+      contentHash: "hash-current",
+      country: "CZE",
+      court: "Test court",
+      id: currentDecisionId,
+      language: "cs",
+      sourceId,
+    },
+    {
+      caseNumber: "pending",
+      contentHash: "hash-pending",
+      country: "SVK",
+      court: "Test court",
+      id: pendingDecisionId,
+      language: "sk",
+      sourceId,
+    },
+    {
+      caseNumber: "raced",
+      contentHash: "hash-raced",
+      country: "CZE",
+      court: "Test court",
+      id: racedDecisionId,
+      language: "cs",
+      sourceId,
+    },
+  ]);
+  await db.insert(caseLawCorpusIndexProjections).values([
+    {
+      decisionId: currentDecisionId,
+      generation: GENERATION,
+      indexId: INDEX_CZE,
+      indexedHash: "hash-current",
+    },
+    {
+      decisionId: pendingDecisionId,
+      generation: GENERATION,
+      pendingAction: "index",
+      pendingHash: "hash-pending",
+      pendingIndexIds: [INDEX_SVK],
+      pendingRevision: 1,
+    },
+    {
+      decisionId: racedDecisionId,
+      generation: GENERATION,
+      indexId: INDEX_CZE,
+      indexedHash: "hash-raced",
+    },
+  ]);
+
+  await installCaseLawProjectionTrigger(db);
+  await installCaseLawProjectionAccounting(db);
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("exact accounting converges across replay, races, and valid projection transitions", async () => {
+  const seeded = await db
+    .select()
+    .from(caseLawCorpusIndexCountBackfills)
+    .where(eq(caseLawCorpusIndexCountBackfills.generation, GENERATION));
+  expect(seeded.at(0)?.status).toBe(
+    CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.RUNNING,
+  );
+  expect(await countRows()).toEqual([]);
+
+  // A post-migration update accounts this old row before the backfill reaches
+  // it. Touching the row again during the seed must have a net delta of zero.
+  await db
+    .update(caseLawCorpusIndexProjections)
+    .set({ indexId: INDEX_CZE })
+    .where(eq(caseLawCorpusIndexProjections.decisionId, racedDecisionId));
+
+  await db.insert(caseLawDecisions).values({
+    caseNumber: "inserted",
+    contentHash: "hash-inserted",
+    country: "SVK",
+    court: "Test court",
+    id: insertedDecisionId,
+    language: "sk",
+    sourceId,
+  });
+  await db
+    .update(caseLawCorpusIndexProjections)
+    .set({
+      indexId: INDEX_SVK,
+      indexedHash: "hash-inserted",
+      pendingAction: null,
+      pendingHash: null,
+      pendingIndexIds: [],
+    })
+    .where(eq(caseLawCorpusIndexProjections.decisionId, insertedDecisionId));
+  expect(await countRows()).toEqual([
+    { indexId: INDEX_CZE, markedIndexed: 1 },
+    { indexId: INDEX_SVK, markedIndexed: 1 },
+  ]);
+
+  const page = await advanceCaseLawCorpusIndexCountBackfill(
+    scopedDb,
+    GENERATION,
+  );
+  expect(page).toEqual({
+    generation: GENERATION,
+    processed: 4,
+    status: "running",
+  });
+  expect(await countRows()).toEqual([
+    { indexId: INDEX_CZE, markedIndexed: 2 },
+    { indexId: INDEX_SVK, markedIndexed: 1 },
+  ]);
+
+  // A settled projection with a stale hash is not accepted by serving and
+  // must leave the count until the current hash is committed again.
+  await db
+    .update(caseLawCorpusIndexProjections)
+    .set({ indexedHash: "stale-hash" })
+    .where(eq(caseLawCorpusIndexProjections.decisionId, racedDecisionId));
+  expect(await countRows()).toEqual([
+    { indexId: INDEX_CZE, markedIndexed: 1 },
+    { indexId: INDEX_SVK, markedIndexed: 1 },
+  ]);
+  await db
+    .update(caseLawCorpusIndexProjections)
+    .set({ indexedHash: "hash-raced" })
+    .where(eq(caseLawCorpusIndexProjections.decisionId, racedDecisionId));
+  expect(await countRows()).toEqual([
+    { indexId: INDEX_CZE, markedIndexed: 2 },
+    { indexId: INDEX_SVK, markedIndexed: 1 },
+  ]);
+
+  const complete = await advanceCaseLawCorpusIndexCountBackfill(
+    scopedDb,
+    GENERATION,
+  );
+  expect(complete).toEqual({
+    generation: GENERATION,
+    processed: 0,
+    status: "complete",
+  });
+  expect(
+    await advanceCaseLawCorpusIndexCountBackfill(scopedDb, GENERATION),
+  ).toEqual(complete);
+  expect(await countRows()).toEqual([
+    { indexId: INDEX_CZE, markedIndexed: 2 },
+    { indexId: INDEX_SVK, markedIndexed: 1 },
+  ]);
+
+  // The production decision trigger queues a jurisdiction move. The count
+  // leaves the old physical index in the same transaction.
+  await db
+    .update(caseLawDecisions)
+    .set({ country: "SVK" })
+    .where(eq(caseLawDecisions.id, currentDecisionId));
+  expect(await countRows()).toEqual([
+    { indexId: INDEX_CZE, markedIndexed: 1 },
+    { indexId: INDEX_SVK, markedIndexed: 1 },
+  ]);
+
+  // Clearing the queue is insufficient when the committed index does not
+  // match the decision's current jurisdiction.
+  await db
+    .update(caseLawCorpusIndexProjections)
+    .set({
+      indexId: INDEX_CZE,
+      pendingAction: null,
+      pendingHash: null,
+      pendingIndexIds: [],
+    })
+    .where(eq(caseLawCorpusIndexProjections.decisionId, currentDecisionId));
+  expect(await countRows()).toEqual([
+    { indexId: INDEX_CZE, markedIndexed: 1 },
+    { indexId: INDEX_SVK, markedIndexed: 1 },
+  ]);
+
+  await db
+    .update(caseLawCorpusIndexProjections)
+    .set({
+      indexId: INDEX_SVK,
+      pendingAction: null,
+      pendingHash: null,
+      pendingIndexIds: [],
+    })
+    .where(eq(caseLawCorpusIndexProjections.decisionId, currentDecisionId));
+  expect(await countRows()).toEqual([
+    { indexId: INDEX_CZE, markedIndexed: 1 },
+    { indexId: INDEX_SVK, markedIndexed: 2 },
+  ]);
+
+  await db
+    .delete(caseLawCorpusIndexProjections)
+    .where(eq(caseLawCorpusIndexProjections.decisionId, currentDecisionId));
+  expect(await countRows()).toEqual([
+    { indexId: INDEX_CZE, markedIndexed: 1 },
+    { indexId: INDEX_SVK, markedIndexed: 1 },
+  ]);
+
+  await db
+    .insert(caseLawCorpusIndexBackfills)
+    .values({ generation: FUTURE_GENERATION });
+  const checkpoint = await db
+    .select({ status: caseLawCorpusIndexCountBackfills.status })
+    .from(caseLawCorpusIndexCountBackfills)
+    .where(eq(caseLawCorpusIndexCountBackfills.generation, FUTURE_GENERATION));
+  expect(checkpoint.at(0)?.status).toBe(
+    CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.COMPLETE,
+  );
+});

--- a/apps/api/src/lib/corpus-index/census-counts.db.test.ts
+++ b/apps/api/src/lib/corpus-index/census-counts.db.test.ts
@@ -5,6 +5,7 @@ import { drizzle } from "drizzle-orm/pglite";
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
+  CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS,
   CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS,
   caseLawCorpusIndexBackfills,
   caseLawCorpusIndexCountBackfills,
@@ -76,7 +77,10 @@ beforeAll(async () => {
   });
   await db
     .insert(caseLawCorpusIndexBackfills)
-    .values({ generation: GENERATION });
+    .values({
+      generation: GENERATION,
+      status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE,
+    });
   await db.insert(caseLawDecisions).values([
     {
       caseNumber: "current",
@@ -297,7 +301,7 @@ test("exact accounting converges across replay, races, and valid projection tran
 
   await db
     .update(caseLawCorpusIndexBackfills)
-    .set({ status: "complete" })
+    .set({ status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE })
     .where(eq(caseLawCorpusIndexBackfills.generation, FUTURE_GENERATION));
   expect(
     await advanceCaseLawCorpusIndexCountBackfill(scopedDb, FUTURE_GENERATION),

--- a/apps/api/src/lib/corpus-index/census-counts.db.test.ts
+++ b/apps/api/src/lib/corpus-index/census-counts.db.test.ts
@@ -285,6 +285,25 @@ test("exact accounting converges across replay, races, and valid projection tran
     .from(caseLawCorpusIndexCountBackfills)
     .where(eq(caseLawCorpusIndexCountBackfills.generation, FUTURE_GENERATION));
   expect(checkpoint.at(0)?.status).toBe(
-    CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.COMPLETE,
+    CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.RUNNING,
   );
+  expect(
+    await advanceCaseLawCorpusIndexCountBackfill(scopedDb, FUTURE_GENERATION),
+  ).toEqual({
+    generation: FUTURE_GENERATION,
+    processed: 0,
+    status: CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.RUNNING,
+  });
+
+  await db
+    .update(caseLawCorpusIndexBackfills)
+    .set({ status: "complete" })
+    .where(eq(caseLawCorpusIndexBackfills.generation, FUTURE_GENERATION));
+  expect(
+    await advanceCaseLawCorpusIndexCountBackfill(scopedDb, FUTURE_GENERATION),
+  ).toEqual({
+    generation: FUTURE_GENERATION,
+    processed: 0,
+    status: CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.COMPLETE,
+  });
 });

--- a/apps/api/src/lib/corpus-index/census-counts.db.test.ts
+++ b/apps/api/src/lib/corpus-index/census-counts.db.test.ts
@@ -75,12 +75,10 @@ beforeAll(async () => {
     id: sourceId,
     name: "Public",
   });
-  await db
-    .insert(caseLawCorpusIndexBackfills)
-    .values({
-      generation: GENERATION,
-      status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE,
-    });
+  await db.insert(caseLawCorpusIndexBackfills).values({
+    generation: GENERATION,
+    status: CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.COMPLETE,
+  });
   await db.insert(caseLawDecisions).values([
     {
       caseNumber: "current",

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -18,6 +18,7 @@ import {
   CENSUS_CYCLE_INTERVAL,
   CENSUS_DISPOSITION,
   CENSUS_TOLERANCE,
+  CaseLawCorpusIndexCountNotReadyError,
   censusIndex,
   createCaseLawCensus,
   reportIndexCensus,
@@ -83,19 +84,16 @@ const engineHolding = (numHits: number, ok = true): void => {
 };
 
 /**
- * A database whose only answer is the count the census asks for. Every
- * aggregate the module runs returns the same single row, which is enough
- * because the census takes exactly one count per side.
+ * A database whose only answer is the maintained count the census asks for.
+ * The lookup returns one row; the engine supplies the other side.
  */
 const databaseHolding = (
   marked: number,
   jurisdictions?: string[],
+  countStatus = "complete",
 ): ScopedDb => {
   const handle = async (callback: (tx: Transaction) => Promise<unknown>) => {
-    const rows =
-      jurisdictions === undefined
-        ? [{ marked }]
-        : jurisdictions.map((country) => ({ country, marked }));
+    let rows: Record<string, unknown>[] = [];
     const chain = {
       from: () => chain,
       leftJoin: () => chain,
@@ -103,8 +101,17 @@ const databaseHolding = (
       orderBy: () => chain,
       where: () => rows,
     };
-    const tx = { select: () => chain, selectDistinct: () => chain };
-    // SAFETY: the census only ever builds the two aggregate chains above.
+    const tx = {
+      select: (selection: Record<string, unknown>) => {
+        rows = "status" in selection ? [{ marked, status: countStatus }] : [];
+        return chain;
+      },
+      selectDistinct: () => {
+        rows = (jurisdictions ?? []).map((country) => ({ country }));
+        return chain;
+      },
+    };
+    // SAFETY: the census only builds the two inert query chains above.
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- inert query-builder double
     return await callback(tx as unknown as Transaction);
   };
@@ -191,6 +198,22 @@ describe("index census", () => {
     });
 
     expect(census.isErr()).toBe(true);
+  });
+
+  test("a partially seeded exact count is unavailable, never zero", async () => {
+    engineHolding(0);
+
+    const rejection: unknown = await censusIndex({
+      scopedDb: databaseHolding(10_000, undefined, "running"),
+      generation: GENERATION,
+      indexId: INDEX_ID,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBeInstanceOf(CaseLawCorpusIndexCountNotReadyError);
+    expect(countedIndexIds).toEqual([]);
   });
 });
 
@@ -318,9 +341,8 @@ describe("census reporting", () => {
       await census.step();
     }
 
-    // Two aggregates per census against a corpus this size is real query
-    // budget; paying it on every backfill batch would answer the same
-    // slow-moving question over and over.
+    // The engine aggregate is real query budget; paying it on every backfill
+    // batch would answer the same slow-moving question over and over.
     expect(warn).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -21,6 +21,7 @@ import {
   CaseLawCorpusIndexCountNotReadyError,
   censusIndex,
   createCaseLawCensus,
+  createCaseLawCorpusIndexCountSeed,
   reportIndexCensus,
 } from "@/api/lib/corpus-index/census";
 import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
@@ -127,6 +128,62 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+});
+
+describe("count seed driver", () => {
+  let seedWarn: ReturnType<typeof spyOn<typeof logger, "warn">>;
+
+  beforeEach(() => {
+    seedWarn = spyOn(logger, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    seedWarn.mockRestore();
+  });
+
+  test("advances once per cycle and stops permanently at completion", async () => {
+    const statuses = ["running", "complete"] as const;
+    let calls = 0;
+    const seed = createCaseLawCorpusIndexCountSeed({
+      generation: GENERATION,
+      scopedDb: databaseHolding(0),
+      advance: async (_scopedDb, generation) => ({
+        generation,
+        processed: 1,
+        status: statuses.at(calls++) ?? "complete",
+      }),
+    });
+
+    await seed.step();
+    await seed.step();
+    await seed.step();
+
+    expect(calls).toBe(2);
+  });
+
+  test("contains a failed page and retries it on the next cycle", async () => {
+    let calls = 0;
+    const seed = createCaseLawCorpusIndexCountSeed({
+      generation: GENERATION,
+      scopedDb: databaseHolding(0),
+      advance: async (_scopedDb, generation) => {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error("pool exhausted");
+        }
+        return { generation, processed: 0, status: "complete" };
+      },
+    });
+
+    await seed.step();
+    await seed.step();
+    await seed.step();
+
+    expect(calls).toBe(2);
+    expect(seedWarn.mock.calls.at(0)?.at(0)).toBe(
+      "case_law.corpus_index.count_seed_failed",
+    );
+  });
 });
 
 describe("index census", () => {

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -218,8 +218,8 @@ export const createCaseLawCorpusIndexCountSeed = ({
       if (complete) {
         return;
       }
-      const outcome = await Result.tryPromise(() =>
-        advance(scopedDb, generation),
+      const outcome = await Result.tryPromise(async () =>
+        await advance(scopedDb, generation),
       );
       if (Result.isError(outcome)) {
         logger.warn("case_law.corpus_index.count_seed_failed", {

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -82,6 +82,11 @@ export type CaseLawCorpusIndexCountBackfillStep = {
   status: CaseLawCorpusIndexCountBackfillStatus;
 };
 
+type AdvanceCaseLawCorpusIndexCountBackfill = (
+  scopedDb: ScopedDb,
+  generation: string,
+) => Promise<CaseLawCorpusIndexCountBackfillStep>;
+
 /**
  * Account one keyset page of projections that predate the aggregate.
  *
@@ -187,6 +192,48 @@ export const advanceCaseLawCorpusIndexCountBackfill = async (
       status: CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.RUNNING,
     };
   });
+
+type CaseLawCorpusIndexCountSeedOptions = {
+  scopedDb: ScopedDb;
+  generation: string;
+  advance?: AdvanceCaseLawCorpusIndexCountBackfill;
+};
+
+/**
+ * Drive the rollout-only count seed one bounded page per corpus-worker cycle.
+ *
+ * Completion is remembered in-process, so the steady-state worker pays no
+ * database round-trip. A failure is reported and retried on the next cycle;
+ * it never stops the corpus projection loop that owns this maintenance work.
+ */
+export const createCaseLawCorpusIndexCountSeed = ({
+  scopedDb,
+  generation,
+  advance = advanceCaseLawCorpusIndexCountBackfill,
+}: CaseLawCorpusIndexCountSeedOptions): { step: () => Promise<void> } => {
+  let complete = false;
+
+  return {
+    step: async (): Promise<void> => {
+      if (complete) {
+        return;
+      }
+      const outcome = await Result.tryPromise(() =>
+        advance(scopedDb, generation),
+      );
+      if (Result.isError(outcome)) {
+        logger.warn("case_law.corpus_index.count_seed_failed", {
+          generation,
+          "error.type": errorTag(outcome.error),
+        });
+        return;
+      }
+      complete =
+        outcome.value.status ===
+        CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.COMPLETE;
+    },
+  };
+};
 
 /**
  * How far the two sides may disagree in one observation.

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -218,8 +218,8 @@ export const createCaseLawCorpusIndexCountSeed = ({
       if (complete) {
         return;
       }
-      const outcome = await Result.tryPromise(async () =>
-        await advance(scopedDb, generation),
+      const outcome = await Result.tryPromise(
+        async () => await advance(scopedDb, generation),
       );
       if (Result.isError(outcome)) {
         logger.warn("case_law.corpus_index.count_seed_failed", {

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -37,8 +37,10 @@ import { and, asc, eq, gt, inArray, type SQL, sql } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
+  CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS,
   CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS,
   type CaseLawCorpusIndexCountBackfillStatus,
+  caseLawCorpusIndexBackfills,
   caseLawCorpusIndexCountBackfills,
   caseLawCorpusIndexCounts,
   caseLawCorpusIndexProjections,
@@ -104,9 +106,17 @@ export const advanceCaseLawCorpusIndexCountBackfill = async (
       await tx
         .select({
           cursorDecisionId: caseLawCorpusIndexCountBackfills.cursorDecisionId,
+          generationStatus: caseLawCorpusIndexBackfills.status,
           status: caseLawCorpusIndexCountBackfills.status,
         })
         .from(caseLawCorpusIndexCountBackfills)
+        .innerJoin(
+          caseLawCorpusIndexBackfills,
+          eq(
+            caseLawCorpusIndexBackfills.generation,
+            caseLawCorpusIndexCountBackfills.generation,
+          ),
+        )
         .where(eq(caseLawCorpusIndexCountBackfills.generation, generation))
         .for("update")
     ).at(0);
@@ -146,6 +156,20 @@ export const advanceCaseLawCorpusIndexCountBackfill = async (
       .for("update");
 
     if (page.length === 0) {
+      // A running generation can still be served through the legacy decision
+      // marker before its projection walk reaches every row. Keep the count
+      // unavailable until that walk removes the fallback population; newly
+      // written projections are already exact through the accounting trigger.
+      if (
+        checkpoint.generationStatus ===
+        CASE_LAW_CORPUS_INDEX_BACKFILL_STATUS.RUNNING
+      ) {
+        return {
+          generation,
+          processed: 0,
+          status: CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.RUNNING,
+        };
+      }
       await tx
         .update(caseLawCorpusIndexCountBackfills)
         .set({

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -12,11 +12,11 @@
  * has an `indexedHash`) nor stale (the hash matches), so nothing selects
  * it again and the gap is permanent and invisible.
  *
- * A census is what makes it visible. It is a count on both sides, not a
- * diff: naming the missing documents would mean streaming the whole
- * index out of the engine, while the number alone is one cheap
- * aggregate per side and is enough to decide that an index needs
- * re-indexing. The repair is correspondingly blunt — un-mark a slice of
+ * A census is what makes it visible. It compares counts rather than
+ * identities: naming the missing documents would mean streaming the whole
+ * index out of the engine, while the number alone needs one engine aggregate
+ * and one exact PostgreSQL counter lookup. That is enough to decide that an
+ * index needs re-indexing. The repair is correspondingly blunt — un-mark a slice of
  * the index's rows and let the ordinary backfill re-project it — because
  * the projection is idempotent and re-ingesting a document the engine
  * already holds converges on the same split.
@@ -27,15 +27,20 @@
  * ones whose country the index holds (`corpusIndexJurisdictions`, the
  * inverse of that derivation), in the state the search path accepts.
  *
- * Bounded by construction: one index per call, one aggregate query per
- * side, and a caller that decides how often to run it.
+ * Bounded by construction: one index per call, one engine aggregate, one
+ * constant-time PostgreSQL lookup, and a caller that decides how often to run
+ * it.
  */
 
-import { Result } from "better-result";
-import { inArray, type SQL, sql } from "drizzle-orm";
+import { Result, TaggedError } from "better-result";
+import { and, asc, eq, gt, inArray, type SQL, sql } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
+  CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS,
+  type CaseLawCorpusIndexCountBackfillStatus,
+  caseLawCorpusIndexCountBackfills,
+  caseLawCorpusIndexCounts,
   caseLawCorpusIndexProjections,
   caseLawDecisions,
 } from "@/api/db/schema";
@@ -60,6 +65,128 @@ import { isRecord } from "@/api/lib/type-guards";
  * granularity the family is indexed at.
  */
 const DOCUMENT_COUNT_QUERY = "seq:0";
+
+/** One short transaction's maximum accounting seed work. */
+export const CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_BATCH_SIZE = 1000;
+
+export class CaseLawCorpusIndexCountNotReadyError extends TaggedError(
+  "CaseLawCorpusIndexCountNotReadyError",
+)<{
+  message: string;
+  generation: string;
+}> {}
+
+export type CaseLawCorpusIndexCountBackfillStep = {
+  generation: string;
+  processed: number;
+  status: CaseLawCorpusIndexCountBackfillStatus;
+};
+
+/**
+ * Account one keyset page of projections that predate the aggregate.
+ *
+ * The row trigger derives `accountedIndexId` under the same row lock, and the
+ * statement trigger applies the net per-index delta once. Inserts and updates
+ * racing behind the cursor are already accounted by that trigger, so replay,
+ * overlap, and a process restart all converge without a snapshot transaction.
+ */
+export const advanceCaseLawCorpusIndexCountBackfill = async (
+  scopedDb: ScopedDb,
+  generation: string,
+): Promise<CaseLawCorpusIndexCountBackfillStep> =>
+  await scopedDb(async (tx) => {
+    const checkpoint = (
+      await tx
+        .select({
+          cursorDecisionId: caseLawCorpusIndexCountBackfills.cursorDecisionId,
+          status: caseLawCorpusIndexCountBackfills.status,
+        })
+        .from(caseLawCorpusIndexCountBackfills)
+        .where(eq(caseLawCorpusIndexCountBackfills.generation, generation))
+        .for("update")
+    ).at(0);
+
+    if (checkpoint === undefined) {
+      throw new CaseLawCorpusIndexCountNotReadyError({
+        generation,
+        message: `No corpus-index count checkpoint exists for ${generation}`,
+      });
+    }
+    if (
+      checkpoint.status === CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.COMPLETE
+    ) {
+      return {
+        generation,
+        processed: 0,
+        status: CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.COMPLETE,
+      };
+    }
+
+    const page = await tx
+      .select({ decisionId: caseLawCorpusIndexProjections.decisionId })
+      .from(caseLawCorpusIndexProjections)
+      .where(
+        and(
+          eq(caseLawCorpusIndexProjections.generation, generation),
+          checkpoint.cursorDecisionId === null
+            ? undefined
+            : gt(
+                caseLawCorpusIndexProjections.decisionId,
+                checkpoint.cursorDecisionId,
+              ),
+        ),
+      )
+      .orderBy(asc(caseLawCorpusIndexProjections.decisionId))
+      .limit(CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_BATCH_SIZE)
+      .for("update");
+
+    if (page.length === 0) {
+      await tx
+        .update(caseLawCorpusIndexCountBackfills)
+        .set({
+          status: CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.COMPLETE,
+          updatedAt: new Date(),
+        })
+        .where(eq(caseLawCorpusIndexCountBackfills.generation, generation));
+      return {
+        generation,
+        processed: 0,
+        status: CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.COMPLETE,
+      };
+    }
+
+    const decisionIds = sql.join(
+      page.map(({ decisionId }) => sql`${decisionId}::uuid`),
+      sql`, `,
+    );
+    // Deliberately assign the accounting marker to itself. The database's
+    // BEFORE trigger derives the current bucket; raw SQL avoids changing the
+    // projection's application-level updated_at CAS token.
+    await tx.execute(sql`
+      UPDATE ${caseLawCorpusIndexProjections}
+      SET accounted_index_id = accounted_index_id
+      WHERE generation = ${generation}
+        AND decision_id IN (${decisionIds})
+    `);
+
+    const cursorDecisionId = page.at(-1)?.decisionId;
+    if (cursorDecisionId === undefined) {
+      throw new CaseLawCorpusIndexCountNotReadyError({
+        generation,
+        message: `Corpus-index count page for ${generation} lost its cursor`,
+      });
+    }
+    await tx
+      .update(caseLawCorpusIndexCountBackfills)
+      .set({ cursorDecisionId, updatedAt: new Date() })
+      .where(eq(caseLawCorpusIndexCountBackfills.generation, generation));
+
+    return {
+      generation,
+      processed: page.length,
+      status: CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.RUNNING,
+    };
+  });
 
 /**
  * How far the two sides may disagree in one observation.
@@ -149,15 +276,31 @@ const countMarkedIndexed = async (
 ): Promise<number> => {
   const rows = await scopedDb((tx) =>
     tx
-      .select({ marked: sql<number>`count(*)::int` })
-      .from(caseLawDecisions)
+      .select({
+        marked: caseLawCorpusIndexCounts.markedIndexed,
+        status: caseLawCorpusIndexCountBackfills.status,
+      })
+      .from(caseLawCorpusIndexCountBackfills)
       .leftJoin(
-        caseLawCorpusIndexProjections,
-        caseLawCorpusProjectionJoin(generation),
+        caseLawCorpusIndexCounts,
+        and(
+          eq(
+            caseLawCorpusIndexCounts.generation,
+            caseLawCorpusIndexCountBackfills.generation,
+          ),
+          eq(caseLawCorpusIndexCounts.indexId, indexId),
+        ),
       )
-      .where(censusPopulation(generation, indexId)),
+      .where(eq(caseLawCorpusIndexCountBackfills.generation, generation)),
   );
-  return rows.at(0)?.marked ?? 0;
+  const row = rows.at(0);
+  if (row?.status !== CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_STATUS.COMPLETE) {
+    throw new CaseLawCorpusIndexCountNotReadyError({
+      generation,
+      message: `Corpus-index count for ${generation} is not ready`,
+    });
+  }
+  return row.marked ?? 0;
 };
 
 export type CensusIndexOptions = {
@@ -298,11 +441,10 @@ export const listCaseLawIndexIds = async (
 /**
  * Backfill cycles between one census and the next.
  *
- * The census is a diagnostic, not a gate: it costs an aggregate on each
- * side and the drift it looks for accumulates over hours, so running it
- * on every batch would spend real query budget to answer the same
- * question. One index per census means a corpus of N indexes is fully
- * covered every N of these.
+ * The census is a diagnostic, not a gate: the engine aggregate still costs
+ * query budget and the drift it looks for accumulates over hours, so running
+ * it on every batch would answer the same question repeatedly. One index per
+ * census means a corpus of N indexes is fully covered every N of these.
  */
 export const CENSUS_CYCLE_INTERVAL = 20;
 

--- a/apps/api/src/tests/helpers/case-law-projection-trigger.ts
+++ b/apps/api/src/tests/helpers/case-law-projection-trigger.ts
@@ -89,9 +89,7 @@ export const installCaseLawProjectionTrigger = async (
 
 /** The seed statement and triggers that maintain exact projection counts. */
 export const caseLawProjectionAccountingStatements = (): string[] =>
-  migrationStatements(latestMigrationContaining(ACCOUNTING_FUNCTION)).filter(
-    (statement) => ACCOUNTING_OBJECT.test(statement),
-  );
+  latestStatements(ACCOUNTING_FUNCTION, ACCOUNTING_OBJECT);
 
 /** Install exact projection accounting in a schema-built test database. */
 export const installCaseLawProjectionAccounting = async (

--- a/apps/api/src/tests/helpers/case-law-projection-trigger.ts
+++ b/apps/api/src/tests/helpers/case-law-projection-trigger.ts
@@ -24,6 +24,10 @@ const PROJECTION_TRIGGER =
   "CREATE TRIGGER case_law_decisions_enqueue_corpus_index_projection";
 const PROJECTION_TRIGGER_STATEMENT =
   /\b(?:CREATE|DROP) TRIGGER (?:IF EXISTS )?case_law_decisions_enqueue_corpus_index_projection\b/u;
+const ACCOUNTING_FUNCTION =
+  "CREATE OR REPLACE FUNCTION derive_case_law_corpus_index_accounting()";
+const ACCOUNTING_OBJECT =
+  /(?:INSERT INTO "case_law_corpus_index_count_backfills"|derive_case_law_corpus_index_accounting|add_inserted_case_law_corpus_index_counts|apply_updated_case_law_corpus_index_counts|subtract_deleted_case_law_corpus_index_counts|seed_case_law_corpus_index_count_backfill|case_law_corpus_index_projection_(?:derive_accounting|count_(?:insert|update|delete))|case_law_corpus_index_backfill_seed_count)/u;
 
 /** Statements of a migration file, in order, comments included. */
 export const migrationStatements = (path: string): string[] =>
@@ -79,6 +83,22 @@ export const installCaseLawProjectionTrigger = async (
 ): Promise<void> => {
   for (const statement of caseLawProjectionTriggerStatements()) {
     // oxlint-disable-next-line no-await-in-loop -- functions, replacement drop, and trigger creation are order-dependent DDL
+    await db.execute(sql.raw(statement));
+  }
+};
+
+/** The seed statement and triggers that maintain exact projection counts. */
+export const caseLawProjectionAccountingStatements = (): string[] =>
+  migrationStatements(latestMigrationContaining(ACCOUNTING_FUNCTION)).filter(
+    (statement) => ACCOUNTING_OBJECT.test(statement),
+  );
+
+/** Install exact projection accounting in a schema-built test database. */
+export const installCaseLawProjectionAccounting = async (
+  db: Executor,
+): Promise<void> => {
+  for (const statement of caseLawProjectionAccountingStatements()) {
+    // oxlint-disable-next-line no-await-in-loop -- seed state, functions, and triggers are order-dependent DDL
     await db.execute(sql.raw(statement));
   }
 };

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -209,13 +209,37 @@ type SqlKeywordIndexOptions = {
   sql: string;
 };
 
+const ASCII_LOWERCASE_A = 97;
+const ASCII_LOWERCASE_Z = 122;
+const ASCII_CASE_OFFSET = 32;
+
+const asciiUpperCode = (code: number): number =>
+  code >= ASCII_LOWERCASE_A && code <= ASCII_LOWERCASE_Z
+    ? code - ASCII_CASE_OFFSET
+    : code;
+
+const startsWithSqlKeyword = (
+  sql: string,
+  keyword: string,
+  index: number,
+): boolean => {
+  for (let offset = 0; offset < keyword.length; offset += 1) {
+    if (
+      asciiUpperCode(sql.charCodeAt(index + offset)) !==
+      keyword.charCodeAt(offset)
+    ) {
+      return false;
+    }
+  }
+  return true;
+};
+
 /** Locate structural SQL outside double-quoted identifiers. */
 const sqlKeywordIndex = ({
   from = 0,
   keyword,
   sql,
 }: SqlKeywordIndexOptions): number => {
-  const upperSql = sql.toUpperCase();
   let quoted = false;
 
   for (let index = 0; index <= sql.length - keyword.length; index += 1) {
@@ -227,7 +251,7 @@ const sqlKeywordIndex = ({
       quoted = !quoted;
       continue;
     }
-    if (!quoted && index >= from && upperSql.startsWith(keyword, index)) {
+    if (!quoted && index >= from && startsWithSqlKeyword(sql, keyword, index)) {
       return index;
     }
   }
@@ -378,6 +402,14 @@ describe("RLS table grants", () => {
     ).toEqual({
       privileges: new Set(["select", "update"]),
       tables: ["classified_table"],
+    });
+    expect(
+      stellaTableGrant(
+        'GRANT SELECT, UPDATE ON TABLE classified_table, "straße" TO stella',
+      ),
+    ).toEqual({
+      privileges: new Set(["select", "update"]),
+      tables: ["classified_table", "straße"],
     });
     expect(
       stellaTableGrant(

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -5,6 +5,18 @@ import nodePath from "node:path";
 const DRIZZLE_DIR = nodePath.resolve(import.meta.dir, "../../../drizzle");
 const BOOTSTRAP_MIGRATION = "20260510140000_document_rls_role_bootstrap";
 
+// Deployed migrations contain these six reviewed dynamic grants. New grants
+// must be literal SQL so the privilege parser below can classify their target;
+// an exact site allowlist prevents EXECUTE format(...) from becoming a bypass.
+const AUDITED_DYNAMIC_GRANT_SITES = new Set([
+  "20260510140000_document_rls_role_bootstrap: EXECUTE format( 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %s TO stella', target_table )",
+  "20260510140000_document_rls_role_bootstrap: EXECUTE format('GRANT USAGE, SELECT ON SEQUENCE %s TO stella', target_sequence)",
+  "20260510140000_document_rls_role_bootstrap: EXECUTE format('GRANT stella TO %I', CURRENT_USER)",
+  "20260516000000_case_law_ingestion_role: EXECUTE format( 'GRANT USAGE, SELECT ON SEQUENCE %s TO stella_ingestion', target_sequence )",
+  "20260516000000_case_law_ingestion_role: EXECUTE format('GRANT stella_ingestion TO %I', CURRENT_USER)",
+  "20260808014000_legal_lists: EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %I TO stella', table_name)",
+]);
+
 // These migrations were already in the tree when the bootstrap migration
 // introduced the `stella` RLS role and dynamically granted all existing
 // RLS tables. Do not add new migrations here; post-bootstrap tables need
@@ -110,6 +122,8 @@ const POST_BOOTSTRAP_DENY_STELLA_TABLES = new Set([
 
 const SQL_IDENTIFIER_PATTERN =
   /"(?<quoted>[^"]+)"|(?<unquoted>[a-z_][a-z0-9_]*)/giu;
+const DYNAMIC_GRANT_PATTERN =
+  /EXECUTE\s+format\s*\([^;]*?\bGRANT\b[^;]*?\)/giu;
 
 type RlsTableIntroduction = {
   migration: string;
@@ -145,6 +159,19 @@ const sqlStatements = (contents: string): string[] =>
     .map((statement) => statement.replace(/\s+/gu, " ").trim())
     .filter((statement) => statement.length > 0);
 
+type DynamicGrantSitesOptions = {
+  contents: string;
+  migration: string;
+};
+
+const dynamicGrantSites = ({
+  contents,
+  migration,
+}: DynamicGrantSitesOptions): string[] =>
+  [...contents.matchAll(DYNAMIC_GRANT_PATTERN)].map(
+    (match) => `${migration}: ${match[0].replace(/\s+/gu, " ").trim()}`,
+  );
+
 type GrantsRequiredPrivilegesOptions = {
   table: string;
   privileges: Set<string>;
@@ -161,6 +188,7 @@ const TABLE_MUTATION_PRIVILEGES = new Set([
   "truncate",
   "update",
 ]);
+const STELLA_GRANT_GRANTEES = new Set(["public", "stella"]);
 
 const grantsRequiredPrivileges = ({
   table,
@@ -269,14 +297,15 @@ const grantTargetsStella = (targetClause: string): boolean => {
     optionsStart === undefined
       ? targetClause
       : targetClause.slice(0, optionsStart);
-  return identifierNamesFromSql(granteesSql).some(
-    (grantee) => grantee.toLowerCase() === "stella",
+  return identifierNamesFromSql(granteesSql).some((grantee) =>
+    STELLA_GRANT_GRANTEES.has(grantee.toLowerCase()),
   );
 };
 
 const stellaTableGrant = (statement: string): StellaTableGrant | null => {
   const prefix = "GRANT ";
-  const onTableMarker = " ON TABLE ";
+  const onMarker = " ON ";
+  const tableMarker = "TABLE ";
   const toMarker = " TO ";
   const upperStatement = statement.toUpperCase();
 
@@ -284,24 +313,32 @@ const stellaTableGrant = (statement: string): StellaTableGrant | null => {
     return null;
   }
 
-  const onTableIndex = sqlKeywordIndex({
-    keyword: onTableMarker,
+  const onIndex = sqlKeywordIndex({
+    keyword: onMarker,
     sql: statement,
   });
+  if (onIndex === -1) {
+    return null;
+  }
+  const targetStart = onIndex + onMarker.length;
+  const tablesStart = startsWithSqlKeyword(
+    statement,
+    tableMarker,
+    targetStart,
+  )
+    ? targetStart + tableMarker.length
+    : targetStart;
   const toIndex = sqlKeywordIndex({
-    from: onTableIndex + onTableMarker.length,
+    from: tablesStart,
     keyword: toMarker,
     sql: statement,
   });
-  if (onTableIndex === -1 || toIndex <= onTableIndex) {
+  if (toIndex <= onIndex) {
     return null;
   }
 
-  const privilegesSql = statement.slice(prefix.length, onTableIndex);
-  const tablesSql = statement.slice(
-    onTableIndex + onTableMarker.length,
-    toIndex,
-  );
+  const privilegesSql = statement.slice(prefix.length, onIndex);
+  const tablesSql = statement.slice(tablesStart, toIndex);
   const targetRoleSql = statement.slice(toIndex + toMarker.length);
 
   if (!grantTargetsStella(targetRoleSql)) {
@@ -342,10 +379,18 @@ const collectRlsGrantState = () => {
   const rlsTables: RlsTableIntroduction[] = [];
   const explicitGrantMigrationsByTable = new Map<string, string[]>();
   const selectOnlyMutationGrants: string[] = [];
+  const unexpectedDynamicGrantSites: string[] = [];
 
   for (const path of migrationSqlFiles()) {
     const migration = nodePath.basename(nodePath.resolve(path, ".."));
-    const statements = sqlStatements(readFileSync(path, "utf-8"));
+    const contents = readFileSync(path, "utf-8");
+    const statements = sqlStatements(contents);
+
+    for (const site of dynamicGrantSites({ contents, migration })) {
+      if (!AUDITED_DYNAMIC_GRANT_SITES.has(site)) {
+        unexpectedDynamicGrantSites.push(site);
+      }
+    }
 
     for (const statement of statements) {
       const rlsTable = enableRlsTableName(statement);
@@ -383,10 +428,24 @@ const collectRlsGrantState = () => {
     explicitGrantMigrationsByTable,
     rlsTables,
     selectOnlyMutationGrants,
+    unexpectedDynamicGrantSites,
   };
 };
 
 describe("RLS table grants", () => {
+  test("rejects dynamic grants outside the exact deployed allowlist", () => {
+    expect(
+      dynamicGrantSites({
+        contents:
+          "EXECUTE format($grant$GRANT UPDATE ON TABLE %I TO stella$grant$, table_name);",
+        migration: "future_migration",
+      }),
+    ).toEqual([
+      "future_migration: EXECUTE format($grant$GRANT UPDATE ON TABLE %I TO stella$grant$, table_name)",
+    ]);
+    expect(collectRlsGrantState().unexpectedDynamicGrantSites).toEqual([]);
+  });
+
   test("classifies stella in a grantee list but not as the grantor", () => {
     expect(
       stellaTableGrant(
@@ -411,6 +470,14 @@ describe("RLS table grants", () => {
     ).toEqual({
       privileges: new Set(["select", "update"]),
       tables: ["classified_table", "straße"],
+    });
+    expect(
+      stellaTableGrant(
+        "GRANT SELECT, UPDATE ON classified_table TO PUBLIC",
+      ),
+    ).toEqual({
+      privileges: new Set(["select", "update"]),
+      tables: ["classified_table"],
     });
     expect(
       stellaTableGrant(

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -367,7 +367,7 @@ const stellaTableGrant = (statement: string): StellaTableGrant | null => {
 
 const explicitStellaGrantTables = (statement: string): string[] => {
   const grant = stellaTableGrant(statement);
-  if (grant === null || grant.type !== "tables") {
+  if (grant?.type !== "tables") {
     return [];
   }
   const grantsTableDml =

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -50,6 +50,10 @@ const POST_BOOTSTRAP_SELECT_ONLY_TABLES = new Set([
   "case_law_corpus_index_source_reconciliations",
   "case_law_corpus_index_writer_leases",
   "case_law_corpus_index_projections",
+  // Exact corpus-index accounting is maintained only by ingestion triggers
+  // and the bounded seed worker; request handlers may observe its status.
+  "case_law_corpus_index_counts",
+  "case_law_corpus_index_count_backfills",
   "legislation_sources",
   "legislation_documents",
   "legislation_search_documents",

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -224,9 +224,10 @@ const startsWithSqlKeyword = (
   index: number,
 ): boolean => {
   for (let offset = 0; offset < keyword.length; offset += 1) {
+    const sqlCode = sql.codePointAt(index + offset);
     if (
-      asciiUpperCode(sql.charCodeAt(index + offset)) !==
-      keyword.charCodeAt(offset)
+      sqlCode === undefined ||
+      asciiUpperCode(sqlCode) !== keyword.codePointAt(offset)
     ) {
       return false;
     }

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -145,10 +145,6 @@ const sqlStatements = (contents: string): string[] =>
     .map((statement) => statement.replace(/\s+/gu, " ").trim())
     .filter((statement) => statement.length > 0);
 
-const isStellaIdentifier = (value: string): boolean =>
-  value.trim().toLowerCase() === "stella" ||
-  value.trim().toLowerCase() === '"stella"';
-
 type GrantsRequiredPrivilegesOptions = {
   table: string;
   privileges: Set<string>;
@@ -207,6 +203,17 @@ type StellaTableGrant = {
   tables: string[];
 };
 
+const GRANT_OPTION_PATTERN = /\s+(?:WITH\s+GRANT\s+OPTION|GRANTED\s+BY)\b/iu;
+
+const grantTargetsStella = (targetClause: string): boolean => {
+  const optionsStart = targetClause.search(GRANT_OPTION_PATTERN);
+  const granteesSql =
+    optionsStart === -1 ? targetClause : targetClause.slice(0, optionsStart);
+  return identifierNamesFromSql(granteesSql).some(
+    (grantee) => grantee.toLowerCase() === "stella",
+  );
+};
+
 const stellaTableGrant = (statement: string): StellaTableGrant | null => {
   const prefix = "GRANT ";
   const onTableMarker = " ON TABLE ";
@@ -230,7 +237,7 @@ const stellaTableGrant = (statement: string): StellaTableGrant | null => {
   );
   const targetRoleSql = statement.slice(toIndex + toMarker.length);
 
-  if (!isStellaIdentifier(targetRoleSql)) {
+  if (!grantTargetsStella(targetRoleSql)) {
     return null;
   }
 
@@ -313,6 +320,22 @@ const collectRlsGrantState = () => {
 };
 
 describe("RLS table grants", () => {
+  test("classifies stella in a grantee list but not as the grantor", () => {
+    expect(
+      stellaTableGrant(
+        "GRANT SELECT, UPDATE ON TABLE classified_table TO stella, another_role WITH GRANT OPTION",
+      ),
+    ).toEqual({
+      privileges: new Set(["select", "update"]),
+      tables: ["classified_table"],
+    });
+    expect(
+      stellaTableGrant(
+        "GRANT SELECT ON TABLE classified_table TO another_role GRANTED BY stella",
+      ),
+    ).toBeNull();
+  });
+
   test("SELECT-only tables never grant mutation privileges to stella", () => {
     expect(collectRlsGrantState().selectOnlyMutationGrants).toEqual([]);
   });

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -122,8 +122,7 @@ const POST_BOOTSTRAP_DENY_STELLA_TABLES = new Set([
 
 const SQL_IDENTIFIER_PATTERN =
   /"(?<quoted>[^"]+)"|(?<unquoted>[a-z_][a-z0-9_]*)/giu;
-const DYNAMIC_GRANT_PATTERN =
-  /EXECUTE\s+format\s*\([^;]*?\bGRANT\b[^;]*?\)/giu;
+const DYNAMIC_GRANT_PATTERN = /EXECUTE\s+format\s*\([^;]*?\bGRANT\b[^;]*?\)/giu;
 
 type RlsTableIntroduction = {
   migration: string;
@@ -321,11 +320,7 @@ const stellaTableGrant = (statement: string): StellaTableGrant | null => {
     return null;
   }
   const targetStart = onIndex + onMarker.length;
-  const tablesStart = startsWithSqlKeyword(
-    statement,
-    tableMarker,
-    targetStart,
-  )
+  const tablesStart = startsWithSqlKeyword(statement, tableMarker, targetStart)
     ? targetStart + tableMarker.length
     : targetStart;
   const toIndex = sqlKeywordIndex({
@@ -472,9 +467,7 @@ describe("RLS table grants", () => {
       tables: ["classified_table", "straße"],
     });
     expect(
-      stellaTableGrant(
-        "GRANT SELECT, UPDATE ON classified_table TO PUBLIC",
-      ),
+      stellaTableGrant("GRANT SELECT, UPDATE ON classified_table TO PUBLIC"),
     ).toEqual({
       privileges: new Set(["select", "update"]),
       tables: ["classified_table"],

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -159,6 +159,7 @@ const TABLE_MUTATION_PRIVILEGES = new Set([
   "all",
   "delete",
   "insert",
+  "maintain",
   "references",
   "trigger",
   "truncate",

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -155,13 +155,26 @@ type GrantsRequiredPrivilegesOptions = {
   grantsTableDml: boolean;
 };
 
+const TABLE_MUTATION_PRIVILEGES = new Set([
+  "all",
+  "delete",
+  "insert",
+  "references",
+  "trigger",
+  "truncate",
+  "update",
+]);
+
 const grantsRequiredPrivileges = ({
   table,
   privileges,
   grantsTableDml,
 }: GrantsRequiredPrivilegesOptions): boolean => {
   if (POST_BOOTSTRAP_SELECT_ONLY_TABLES.has(table)) {
-    return privileges.has("select");
+    return (
+      privileges.has("select") &&
+      privileges.isDisjointFrom(TABLE_MUTATION_PRIVILEGES)
+    );
   }
   if (POST_BOOTSTRAP_SCOPED_HANDOFF_TABLES.has(table)) {
     return privileges.has("insert");
@@ -188,20 +201,25 @@ const enableRlsTableName = (statement: string): string | null => {
   return tableNameFromSql(statement.slice(prefix.length, -suffix.length));
 };
 
-const explicitStellaGrantTables = (statement: string): string[] => {
+type StellaTableGrant = {
+  privileges: Set<string>;
+  tables: string[];
+};
+
+const stellaTableGrant = (statement: string): StellaTableGrant | null => {
   const prefix = "GRANT ";
   const onTableMarker = " ON TABLE ";
   const toMarker = " TO ";
   const upperStatement = statement.toUpperCase();
 
   if (!upperStatement.startsWith(prefix)) {
-    return [];
+    return null;
   }
 
   const onTableIndex = upperStatement.indexOf(onTableMarker);
   const toIndex = upperStatement.lastIndexOf(toMarker);
   if (onTableIndex === -1 || toIndex <= onTableIndex) {
-    return [];
+    return null;
   }
 
   const privilegesSql = statement.slice(prefix.length, onTableIndex);
@@ -212,30 +230,43 @@ const explicitStellaGrantTables = (statement: string): string[] => {
   const targetRoleSql = statement.slice(toIndex + toMarker.length);
 
   if (!isStellaIdentifier(targetRoleSql)) {
-    return [];
+    return null;
   }
 
   const privileges = new Set(identifierNamesFromSql(privilegesSql));
-  const grantsTableDml =
-    privileges.has("select") &&
-    privileges.has("insert") &&
-    privileges.has("update") &&
-    privileges.has("delete");
-
   const tables = identifierNamesFromSql(tablesSql).filter(
     (name) => name !== "public",
   );
 
+  return { privileges, tables };
+};
+
+const explicitStellaGrantTables = (statement: string): string[] => {
+  const grant = stellaTableGrant(statement);
+  if (grant === null) {
+    return [];
+  }
+  const grantsTableDml =
+    grant.privileges.has("select") &&
+    grant.privileges.has("insert") &&
+    grant.privileges.has("update") &&
+    grant.privileges.has("delete");
+
   // Normal post-bootstrap tables grant full DML; explicit internal categories
   // enforce their narrower request-role surface.
-  return tables.filter((table) =>
-    grantsRequiredPrivileges({ table, privileges, grantsTableDml }),
+  return grant.tables.filter((table) =>
+    grantsRequiredPrivileges({
+      table,
+      privileges: grant.privileges,
+      grantsTableDml,
+    }),
   );
 };
 
 const collectRlsGrantState = () => {
   const rlsTables: RlsTableIntroduction[] = [];
   const explicitGrantMigrationsByTable = new Map<string, string[]>();
+  const selectOnlyMutationGrants: string[] = [];
 
   for (const path of migrationSqlFiles()) {
     const migration = nodePath.basename(nodePath.resolve(path, ".."));
@@ -257,13 +288,34 @@ const collectRlsGrantState = () => {
         migrations.push(migration);
         explicitGrantMigrationsByTable.set(table, migrations);
       }
+
+      const grant = stellaTableGrant(statement);
+      if (grant === null) {
+        continue;
+      }
+      for (const table of grant.tables) {
+        if (
+          POST_BOOTSTRAP_SELECT_ONLY_TABLES.has(table) &&
+          !grant.privileges.isDisjointFrom(TABLE_MUTATION_PRIVILEGES)
+        ) {
+          selectOnlyMutationGrants.push(`${migration}: ${table}`);
+        }
+      }
     }
   }
 
-  return { explicitGrantMigrationsByTable, rlsTables };
+  return {
+    explicitGrantMigrationsByTable,
+    rlsTables,
+    selectOnlyMutationGrants,
+  };
 };
 
 describe("RLS table grants", () => {
+  test("SELECT-only tables never grant mutation privileges to stella", () => {
+    expect(collectRlsGrantState().selectOnlyMutationGrants).toEqual([]);
+  });
+
   test("post-bootstrap RLS tables explicitly grant stella table privileges", () => {
     const { explicitGrantMigrationsByTable, rlsTables } =
       collectRlsGrantState();

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -166,10 +166,12 @@ type DynamicGrantSitesOptions = {
 const dynamicGrantSites = ({
   contents,
   migration,
-}: DynamicGrantSitesOptions): string[] =>
-  [...stripSqlLineComments(contents).matchAll(DYNAMIC_GRANT_PATTERN)].map(
+}: DynamicGrantSitesOptions): string[] => {
+  const uncommented = stripSqlLineComments(contents);
+  return [...uncommented.matchAll(DYNAMIC_GRANT_PATTERN)].map(
     (match) => `${migration}: ${match[0].replace(/\s+/gu, " ").trim()}`,
   );
+};
 
 type GrantsRequiredPrivilegesOptions = {
   table: string;
@@ -390,9 +392,10 @@ const selectOnlyMutationTargets = (grant: StellaTableGrant): string[] => {
     return [];
   }
   if (grant.type === "all_tables_in_schema") {
-    return grant.schemas.includes("public")
-      ? ["all tables in schema public"]
-      : [];
+    if (!grant.schemas.includes("public")) {
+      return [];
+    }
+    return ["all tables in schema public"];
   }
   return grant.tables.filter((table) =>
     POST_BOOTSTRAP_SELECT_ONLY_TABLES.has(table),
@@ -514,19 +517,14 @@ describe("RLS table grants", () => {
         "GRANT SELECT ON TABLE classified_table TO another_role GRANTED BY stella",
       ),
     ).toBeNull();
-    expect(
-      stellaTableGrant(
-        "GRANT UPDATE ON ALL TABLES IN SCHEMA public TO PUBLIC",
-      ),
-    ).toEqual({
+    const schemaWideMutation = stellaTableGrant(
+      "GRANT UPDATE ON ALL TABLES IN SCHEMA public TO PUBLIC",
+    );
+    expect(schemaWideMutation).toEqual({
       type: "all_tables_in_schema",
       privileges: new Set(["update"]),
       schemas: ["public"],
     });
-    const schemaWideMutation = stellaTableGrant(
-      "GRANT UPDATE ON ALL TABLES IN SCHEMA public TO PUBLIC",
-    );
-    expect(schemaWideMutation).not.toBeNull();
     if (schemaWideMutation !== null) {
       expect(selectOnlyMutationTargets(schemaWideMutation)).toEqual([
         "all tables in schema public",

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -203,12 +203,47 @@ type StellaTableGrant = {
   tables: string[];
 };
 
-const GRANT_OPTION_PATTERN = /\s+(?:WITH\s+GRANT\s+OPTION|GRANTED\s+BY)\b/iu;
+type SqlKeywordIndexOptions = {
+  from?: number;
+  keyword: string;
+  sql: string;
+};
+
+/** Locate structural SQL outside double-quoted identifiers. */
+const sqlKeywordIndex = ({
+  from = 0,
+  keyword,
+  sql,
+}: SqlKeywordIndexOptions): number => {
+  const upperSql = sql.toUpperCase();
+  let quoted = false;
+
+  for (let index = 0; index <= sql.length - keyword.length; index += 1) {
+    if (sql.at(index) === '"') {
+      if (quoted && sql.at(index + 1) === '"') {
+        index += 1;
+        continue;
+      }
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted && index >= from && upperSql.startsWith(keyword, index)) {
+      return index;
+    }
+  }
+  return -1;
+};
 
 const grantTargetsStella = (targetClause: string): boolean => {
-  const optionsStart = targetClause.search(GRANT_OPTION_PATTERN);
+  const optionsStart = [" WITH GRANT OPTION", " GRANTED BY "]
+    .map((keyword) => sqlKeywordIndex({ keyword, sql: targetClause }))
+    .filter((index) => index !== -1)
+    .toSorted((left, right) => left - right)
+    .at(0);
   const granteesSql =
-    optionsStart === -1 ? targetClause : targetClause.slice(0, optionsStart);
+    optionsStart === undefined
+      ? targetClause
+      : targetClause.slice(0, optionsStart);
   return identifierNamesFromSql(granteesSql).some(
     (grantee) => grantee.toLowerCase() === "stella",
   );
@@ -224,8 +259,15 @@ const stellaTableGrant = (statement: string): StellaTableGrant | null => {
     return null;
   }
 
-  const onTableIndex = upperStatement.indexOf(onTableMarker);
-  const toIndex = upperStatement.lastIndexOf(toMarker);
+  const onTableIndex = sqlKeywordIndex({
+    keyword: onTableMarker,
+    sql: statement,
+  });
+  const toIndex = sqlKeywordIndex({
+    from: onTableIndex + onTableMarker.length,
+    keyword: toMarker,
+    sql: statement,
+  });
   if (onTableIndex === -1 || toIndex <= onTableIndex) {
     return null;
   }
@@ -324,6 +366,14 @@ describe("RLS table grants", () => {
     expect(
       stellaTableGrant(
         "GRANT SELECT, UPDATE ON TABLE classified_table TO stella, another_role WITH GRANT OPTION",
+      ),
+    ).toEqual({
+      privileges: new Set(["select", "update"]),
+      tables: ["classified_table"],
+    });
+    expect(
+      stellaTableGrant(
+        'GRANT SELECT, UPDATE ON TABLE classified_table TO stella, "read TO audit", "read WITH GRANT OPTION audit" GRANTED BY owner',
       ),
     ).toEqual({
       privileges: new Set(["select", "update"]),

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -122,7 +122,7 @@ const POST_BOOTSTRAP_DENY_STELLA_TABLES = new Set([
 
 const SQL_IDENTIFIER_PATTERN =
   /"(?<quoted>[^"]+)"|(?<unquoted>[a-z_][a-z0-9_]*)/giu;
-const DYNAMIC_GRANT_PATTERN = /EXECUTE\s+format\s*\([^;]*?\bGRANT\b[^;]*?\)/giu;
+const DYNAMIC_GRANT_PATTERN = /\bEXECUTE\b[^;]*\bGRANT\b[^;]*/giu;
 
 type RlsTableIntroduction = {
   migration: string;
@@ -167,7 +167,7 @@ const dynamicGrantSites = ({
   contents,
   migration,
 }: DynamicGrantSitesOptions): string[] =>
-  [...contents.matchAll(DYNAMIC_GRANT_PATTERN)].map(
+  [...stripSqlLineComments(contents).matchAll(DYNAMIC_GRANT_PATTERN)].map(
     (match) => `${migration}: ${match[0].replace(/\s+/gu, " ").trim()}`,
   );
 
@@ -225,10 +225,17 @@ const enableRlsTableName = (statement: string): string | null => {
   return tableNameFromSql(statement.slice(prefix.length, -suffix.length));
 };
 
-type StellaTableGrant = {
-  privileges: Set<string>;
-  tables: string[];
-};
+type StellaTableGrant =
+  | {
+      type: "tables";
+      privileges: Set<string>;
+      tables: string[];
+    }
+  | {
+      type: "all_tables_in_schema";
+      privileges: Set<string>;
+      schemas: string[];
+    };
 
 type SqlKeywordIndexOptions = {
   from?: number;
@@ -341,16 +348,24 @@ const stellaTableGrant = (statement: string): StellaTableGrant | null => {
   }
 
   const privileges = new Set(identifierNamesFromSql(privilegesSql));
+  const allTablesPrefix = "ALL TABLES IN SCHEMA ";
+  if (startsWithSqlKeyword(tablesSql, allTablesPrefix, 0)) {
+    return {
+      type: "all_tables_in_schema",
+      privileges,
+      schemas: identifierNamesFromSql(tablesSql.slice(allTablesPrefix.length)),
+    };
+  }
   const tables = identifierNamesFromSql(tablesSql).filter(
     (name) => name !== "public",
   );
 
-  return { privileges, tables };
+  return { type: "tables", privileges, tables };
 };
 
 const explicitStellaGrantTables = (statement: string): string[] => {
   const grant = stellaTableGrant(statement);
-  if (grant === null) {
+  if (grant === null || grant.type !== "tables") {
     return [];
   }
   const grantsTableDml =
@@ -367,6 +382,20 @@ const explicitStellaGrantTables = (statement: string): string[] => {
       privileges: grant.privileges,
       grantsTableDml,
     }),
+  );
+};
+
+const selectOnlyMutationTargets = (grant: StellaTableGrant): string[] => {
+  if (grant.privileges.isDisjointFrom(TABLE_MUTATION_PRIVILEGES)) {
+    return [];
+  }
+  if (grant.type === "all_tables_in_schema") {
+    return grant.schemas.includes("public")
+      ? ["all tables in schema public"]
+      : [];
+  }
+  return grant.tables.filter((table) =>
+    POST_BOOTSTRAP_SELECT_ONLY_TABLES.has(table),
   );
 };
 
@@ -408,13 +437,8 @@ const collectRlsGrantState = () => {
       if (grant === null) {
         continue;
       }
-      for (const table of grant.tables) {
-        if (
-          POST_BOOTSTRAP_SELECT_ONLY_TABLES.has(table) &&
-          !grant.privileges.isDisjointFrom(TABLE_MUTATION_PRIVILEGES)
-        ) {
-          selectOnlyMutationGrants.push(`${migration}: ${table}`);
-        }
+      for (const target of selectOnlyMutationTargets(grant)) {
+        selectOnlyMutationGrants.push(`${migration}: ${target}`);
       }
     }
   }
@@ -438,6 +462,15 @@ describe("RLS table grants", () => {
     ).toEqual([
       "future_migration: EXECUTE format($grant$GRANT UPDATE ON TABLE %I TO stella$grant$, table_name)",
     ]);
+    expect(
+      dynamicGrantSites({
+        contents:
+          "EXECUTE 'GRANT UPDATE ON TABLE case_law_corpus_index_counts TO stella';",
+        migration: "future_migration",
+      }),
+    ).toEqual([
+      "future_migration: EXECUTE 'GRANT UPDATE ON TABLE case_law_corpus_index_counts TO stella'",
+    ]);
     expect(collectRlsGrantState().unexpectedDynamicGrantSites).toEqual([]);
   });
 
@@ -447,6 +480,7 @@ describe("RLS table grants", () => {
         "GRANT SELECT, UPDATE ON TABLE classified_table TO stella, another_role WITH GRANT OPTION",
       ),
     ).toEqual({
+      type: "tables",
       privileges: new Set(["select", "update"]),
       tables: ["classified_table"],
     });
@@ -455,6 +489,7 @@ describe("RLS table grants", () => {
         'GRANT SELECT, UPDATE ON TABLE classified_table TO stella, "read TO audit", "read WITH GRANT OPTION audit" GRANTED BY owner',
       ),
     ).toEqual({
+      type: "tables",
       privileges: new Set(["select", "update"]),
       tables: ["classified_table"],
     });
@@ -463,12 +498,14 @@ describe("RLS table grants", () => {
         'GRANT SELECT, UPDATE ON TABLE classified_table, "straße" TO stella',
       ),
     ).toEqual({
+      type: "tables",
       privileges: new Set(["select", "update"]),
       tables: ["classified_table", "straße"],
     });
     expect(
       stellaTableGrant("GRANT SELECT, UPDATE ON classified_table TO PUBLIC"),
     ).toEqual({
+      type: "tables",
       privileges: new Set(["select", "update"]),
       tables: ["classified_table"],
     });
@@ -477,6 +514,24 @@ describe("RLS table grants", () => {
         "GRANT SELECT ON TABLE classified_table TO another_role GRANTED BY stella",
       ),
     ).toBeNull();
+    expect(
+      stellaTableGrant(
+        "GRANT UPDATE ON ALL TABLES IN SCHEMA public TO PUBLIC",
+      ),
+    ).toEqual({
+      type: "all_tables_in_schema",
+      privileges: new Set(["update"]),
+      schemas: ["public"],
+    });
+    const schemaWideMutation = stellaTableGrant(
+      "GRANT UPDATE ON ALL TABLES IN SCHEMA public TO PUBLIC",
+    );
+    expect(schemaWideMutation).not.toBeNull();
+    if (schemaWideMutation !== null) {
+      expect(selectOnlyMutationTargets(schemaWideMutation)).toEqual([
+        "all tables in schema public",
+      ]);
+    }
   });
 
   test("SELECT-only tables never grant mutation privileges to stella", () => {

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -1466,7 +1466,11 @@ export const runCaseLawIngest = async (
       await Promise.all([
         Bun.sleep(CORPUS_INDEX_INTERVAL_MS),
         census.step(),
-        countSeed.step(),
+        runWithHardDeadline(
+          "corpus-index-count-seed",
+          BACKFILL_HARD_DEADLINE_MS,
+          async () => await countSeed.step(),
+        ),
       ]);
       if (isDraining()) {
         return;

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -52,7 +52,10 @@ import {
 import { backfillLegislationCorpusIndex } from "@/api/handlers/legislation/corpus-index";
 import { backfillLegislationSearchIndex } from "@/api/handlers/legislation/search-index";
 import { captureError } from "@/api/lib/analytics/capture";
-import { createCaseLawCensus } from "@/api/lib/corpus-index/census";
+import {
+  createCaseLawCensus,
+  createCaseLawCorpusIndexCountSeed,
+} from "@/api/lib/corpus-index/census";
 import {
   IngestionStallError,
   TimeoutError,
@@ -1425,6 +1428,10 @@ export const runCaseLawIngest = async (
     // at all: the rows it lost are neither missing nor stale, so nothing
     // else in this process would ever look at them again.
     const census = createCaseLawCensus({ generation, scopedDb: backfillDb });
+    const countSeed = createCaseLawCorpusIndexCountSeed({
+      generation,
+      scopedDb: backfillDb,
+    });
     // A leaked lease (every step BUSY) and a failing backend (every step
     // throws) both look like idle silence in this loop unless counted.
     let corpusStreaks: CorpusIndexStreaks = INITIAL_CORPUS_INDEX_STREAKS;
@@ -1456,7 +1463,11 @@ export const runCaseLawIngest = async (
       // exactly when drift stops being repaired. It contains its own
       // failures, so it cannot turn a slow cycle into a stopped loop.
       // oxlint-disable-next-line no-await-in-loop -- fixed-interval backfill poll; the loop must wait CORPUS_INDEX_INTERVAL_MS between batches, so this await is intentionally sequential
-      await Promise.all([Bun.sleep(CORPUS_INDEX_INTERVAL_MS), census.step()]);
+      await Promise.all([
+        Bun.sleep(CORPUS_INDEX_INTERVAL_MS),
+        census.step(),
+        countSeed.step(),
+      ]);
       if (isDraining()) {
         return;
       }


### PR DESCRIPTION
## Summary

- maintain exact per-generation, per-index projection counts transactionally in PostgreSQL
- seed pre-existing generations through a durable bounded keyset backfill
- replace the expensive census table scan with a constant-time count lookup
- fail explicitly until the count seed is complete

## Safety

- the projection row trigger derives membership from the same current-decision and committed-projection invariants used by serving
- statement triggers apply net deltas for inserts, updates, and deletes
- replay and concurrent projection changes converge through the nullable accounting marker
- new generations start exact at zero; existing generations remain unavailable until the durable seed completes

## Validation

- integration coverage exercises replay, races, jurisdiction moves, stale hashes, inserts, deletes, and new-generation initialization
- repository CI is the validation authority for this head

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added accurate per-index case-law document counts, maintained automatically as records are added, updated, or removed.
  - Added count backfill processing with progress tracking, retry handling, and readiness checks.
  - Census results now use verified database counts and clearly indicate when counts are still being prepared.
  - Count preparation now runs alongside regular case-law ingestion to keep results current.

- **Bug Fixes**
  - Improved handling of stale records, jurisdiction changes, repeated processing, and incomplete count preparation.
  - Strengthened access controls for count data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->