### PR TITLE
feat(ui): add directional icon playground demo

### DIFF
--- a/apps/web/src/routes/dev/-components/ui-playground.tsx
+++ b/apps/web/src/routes/dev/-components/ui-playground.tsx
@@ -2,9 +2,11 @@ import { useRef, useState } from "react";
 import type * as React from "react";
 
 import {
+  ArrowRightIcon,
   ArchiveIcon,
   BellIcon,
   ChevronDownIcon,
+  ChevronRightIcon,
   ClockIcon,
   CogIcon,
   CopyIcon,
@@ -73,6 +75,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@stll/ui/dialog";
+import { DirectionalIcon } from "@stll/ui/directional-icon";
 import {
   Field,
   FieldDescription,
@@ -904,6 +907,48 @@ export function UiPlayground() {
                     </BreadcrumbItem>
                   </BreadcrumbList>
                 </Breadcrumb>
+              </PlaygroundSection>
+
+              <PlaygroundSection
+                description="Chevrons and arrows in default and RTL layouts."
+                title="Directional Icon"
+              >
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="flex flex-col gap-3 rounded-md border p-3">
+                    <span className="text-muted-foreground text-xs font-medium">
+                      Default direction
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <DirectionalIcon
+                        className="size-5"
+                        icon={ChevronRightIcon}
+                      />
+                      <DirectionalIcon
+                        className="size-5"
+                        icon={ArrowRightIcon}
+                      />
+                    </div>
+                  </div>
+
+                  <div
+                    className="flex flex-col gap-3 rounded-md border p-3"
+                    dir="rtl"
+                  >
+                    <span className="text-muted-foreground text-xs font-medium">
+                      RTL direction
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <DirectionalIcon
+                        className="size-5"
+                        icon={ChevronRightIcon}
+                      />
+                      <DirectionalIcon
+                        className="size-5"
+                        icon={ArrowRightIcon}
+                      />
+                    </div>
+                  </div>
+                </div>
               </PlaygroundSection>
 
               <PlaygroundSection


### PR DESCRIPTION
## Proposed change

Adds a `DirectionalIcon` section to the UI playground with chevron and arrow examples in both default and RTL layouts.

Closes #1659

## Checklist

- [x] BUILD ASSURANCE | **YES** — `bun run verify -- --base upstream/main`
- [x] TESTING | **YES** — full affected web test suite and local `/dev` visual check
- [x] DARK MODE SUPPORT | **YES** — uses the existing semantic styles
- [x] ISSUE LINKED | **YES** — closes #1659
- [ ] SCREENSHOT INCLUDED | **NO** — verified locally in the UI playground


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a navigation icon playground showcasing chevrons and arrows.
  - Demonstrated icon rendering in both default and right-to-left directions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->