### PR TITLE
feat: model decision identifiers

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
+import { DECISION_IDENTIFIER_TYPES } from "@stll/legal-ast/decision-identifier";
+import type { DecisionIdentifiers } from "@stll/legal-ast/decision-identifier";
+
 import {
   bareCitationKey,
+  decisionIdentifiersFromMetadata,
   extractCitations,
   isSelfCitation,
 } from "@/api/handlers/case-law/ingestion/citation-extractor";
@@ -78,7 +82,10 @@ describe("extractCitations", () => {
     const citations = extractCitations([{ index: 0, text }]);
     expect(citations).toHaveLength(1);
     expect(
-      isSelfCitation("C‑128/22", { caseNumber: "C-128/22", ecli: null }),
+      isSelfCitation(
+        "C‑128/22",
+        decisionIdentifiersFromMetadata({ caseNumber: "C-128/22" }),
+      ),
     ).toBe(true);
   });
 
@@ -433,10 +440,12 @@ describe("extractCitations", () => {
 
   test("recognizes a self-citation to an insolvency case number spelled with a different separator", () => {
     expect(
-      isSelfCitation("č. j. KSCB 26INS/8270/2018", {
-        caseNumber: "KSCB 26 INS 8270/2018",
-        ecli: null,
-      }),
+      isSelfCitation(
+        "č. j. KSCB 26INS/8270/2018",
+        decisionIdentifiersFromMetadata({
+          caseNumber: "KSCB 26 INS 8270/2018",
+        }),
+      ),
     ).toBe(true);
   });
 
@@ -456,10 +465,12 @@ describe("extractCitations", () => {
 
   test("recognizes a self-citation to an insolvency case number whose stored court code is not uppercase", () => {
     expect(
-      isSelfCitation("č. j. MSPH 99 INS 19057/2012", {
-        caseNumber: "Msph 99 INS 19057/2012",
-        ecli: null,
-      }),
+      isSelfCitation(
+        "č. j. MSPH 99 INS 19057/2012",
+        decisionIdentifiersFromMetadata({
+          caseNumber: "Msph 99 INS 19057/2012",
+        }),
+      ),
     ).toBe(true);
   });
 
@@ -469,10 +480,10 @@ describe("extractCitations", () => {
     expect(citations).toHaveLength(1);
     expect(citations[0]?.citationText).toBe("č. j.: 137 Ex 1850/23");
     expect(
-      isSelfCitation("č. j.: 137 Ex 1850/23", {
-        caseNumber: "137 Ex 1850/23",
-        ecli: null,
-      }),
+      isSelfCitation(
+        "č. j.: 137 Ex 1850/23",
+        decisionIdentifiersFromMetadata({ caseNumber: "137 Ex 1850/23" }),
+      ),
     ).toBe(true);
   });
 
@@ -988,10 +999,10 @@ describe("extractCitations", () => {
     expect(citations).toHaveLength(1);
     expect(citations[0]?.citationText).toBe("č. k. 4 Obo 48/02");
     expect(
-      isSelfCitation("č. k. 4 Obo 48/02", {
-        caseNumber: "4 Obo 48/02",
-        ecli: null,
-      }),
+      isSelfCitation(
+        "č. k. 4 Obo 48/02",
+        decisionIdentifiersFromMetadata({ caseNumber: "4 Obo 48/02" }),
+      ),
     ).toBe(true);
   });
 
@@ -1891,10 +1902,10 @@ describe("extractCitations", () => {
 });
 
 describe("isSelfCitation", () => {
-  const decision = {
+  const decision = decisionIdentifiersFromMetadata({
     caseNumber: "21 Cdo 1234/2020",
     ecli: "ECLI:CZ:NS:2020:21.CDO.1234.2020.1",
-  };
+  });
 
   test("detects ECLI self-reference", () => {
     expect(isSelfCitation("ECLI:CZ:NS:2020:21.CDO.1234.2020.1", decision)).toBe(
@@ -1925,22 +1936,56 @@ describe("isSelfCitation", () => {
   });
 
   test("case-insensitive match", () => {
-    const d = { caseNumber: "21 cdo 1234/2020" };
+    const d = decisionIdentifiersFromMetadata({
+      caseNumber: "21 cdo 1234/2020",
+    });
     expect(isSelfCitation("sp. zn. 21 Cdo 1234/2020", d)).toBe(true);
   });
 
   test("detects sygn. akt self-reference (Polish)", () => {
-    const d = { caseNumber: "II CSK 123/20" };
+    const d = decisionIdentifiersFromMetadata({ caseNumber: "II CSK 123/20" });
     expect(isSelfCitation("sygn. akt II CSK 123/20", d)).toBe(true);
   });
 
   test("detects sygn. self-reference without akt", () => {
-    const d = { caseNumber: "II CSK 123/20" };
+    const d = decisionIdentifiersFromMetadata({ caseNumber: "II CSK 123/20" });
     expect(isSelfCitation("sygn. II CSK 123/20", d)).toBe(true);
   });
 
   test("returns false when decision has no ECLI", () => {
-    const d = { caseNumber: "21 Cdo 1234/2020" };
+    const d = decisionIdentifiersFromMetadata({
+      caseNumber: "21 Cdo 1234/2020",
+    });
     expect(isSelfCitation("ECLI:CZ:NS:2019:30.CDO.5678.2019.1", d)).toBe(false);
+  });
+
+  test("detects any parallel reporter citation", () => {
+    const identifiers = [
+      {
+        type: DECISION_IDENTIFIER_TYPES.CASE_NUMBER,
+        value: "A-123",
+      },
+      {
+        type: DECISION_IDENTIFIER_TYPES.REPORTER_CITATION,
+        value: "12 Example Reports 34",
+      },
+      {
+        type: DECISION_IDENTIFIER_TYPES.REPORTER_CITATION,
+        value: "56 Parallel Reports 78",
+      },
+    ] as const satisfies DecisionIdentifiers;
+
+    expect(isSelfCitation("56 Parallel Reports 78", identifiers)).toBe(true);
+  });
+
+  test("detects a neutral citation", () => {
+    const identifiers = [
+      {
+        type: DECISION_IDENTIFIER_TYPES.NEUTRAL_CITATION,
+        value: "[2026] Example Court 12",
+      },
+    ] as const satisfies DecisionIdentifiers;
+
+    expect(isSelfCitation("[2026] Example Court 12", identifiers)).toBe(true);
   });
 });

--- a/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
+++ b/apps/api/src/handlers/case-law/ingestion/citation-extractor.ts
@@ -1,3 +1,11 @@
+import { panic } from "better-result";
+
+import { DECISION_IDENTIFIER_TYPES } from "@stll/legal-ast/decision-identifier";
+import type {
+  DecisionIdentifier,
+  DecisionIdentifiers,
+} from "@stll/legal-ast/decision-identifier";
+
 import {
   type CitationDecisionTypeHint,
   detectCitationDecisionTypeHint,
@@ -627,9 +635,28 @@ const stripPrefix = (text: string): string => {
   return trimmed;
 };
 
-type DecisionIdentity = {
+type DecisionMetadata = {
   caseNumber: string;
   ecli?: string | null;
+};
+
+export const decisionIdentifiersFromMetadata = ({
+  caseNumber,
+  ecli,
+}: DecisionMetadata): DecisionIdentifiers => {
+  const caseNumberIdentifier = {
+    type: DECISION_IDENTIFIER_TYPES.CASE_NUMBER,
+    value: caseNumber,
+  } as const;
+
+  if (!ecli) {
+    return [caseNumberIdentifier];
+  }
+
+  return [
+    caseNumberIdentifier,
+    { type: DECISION_IDENTIFIER_TYPES.ECLI, value: ecli },
+  ];
 };
 
 /**
@@ -654,26 +681,37 @@ export const bareCitationKey = (text: string): string =>
 export const citationKeyOf = (text: string): string | null =>
   bareCitationKey(text) || null;
 
+const identifierComparisonKey = (
+  citationText: string,
+  identifier: DecisionIdentifier,
+): string => {
+  switch (identifier.type) {
+    case DECISION_IDENTIFIER_TYPES.CASE_NUMBER:
+      return bareCitationKey(citationText);
+    case DECISION_IDENTIFIER_TYPES.ECLI:
+    case DECISION_IDENTIFIER_TYPES.NEUTRAL_CITATION:
+    case DECISION_IDENTIFIER_TYPES.REPORTER_CITATION:
+      return canonicalizeDedupKey(citationText);
+    default: {
+      const unhandled: never = identifier;
+      return panic(`Unhandled decision identifier: ${String(unhandled)}`);
+    }
+  }
+};
+
 /**
  * Check whether a citation text refers to the same decision that
  * contains it (self-citation).
  */
 export const isSelfCitation = (
   citationText: string,
-  decision: DecisionIdentity,
-): boolean => {
-  const trimmed = citationText.trim();
-
-  // ECLI exact match
-  if (decision.ecli && trimmed === decision.ecli) {
-    return true;
-  }
-
-  // Compare bare case numbers, using the same canonicalization as the
-  // extractor's dedup key so a self-citation written with a different
-  // (but equivalent) separator, dot, or case spelling is still recognized.
-  return bareCitationKey(trimmed) === canonicalizeDedupKey(decision.caseNumber);
-};
+  identifiers: DecisionIdentifiers,
+): boolean =>
+  identifiers.some(
+    (identifier) =>
+      identifierComparisonKey(citationText, identifier) ===
+      canonicalizeDedupKey(identifier.value),
+  );
 
 /**
  * Extract citation references from decision text.

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -40,6 +40,7 @@ import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters/adapter-r
 import {
   bareCitationKey,
   citationKeyOf,
+  decisionIdentifiersFromMetadata,
   extractCitations,
   isSelfCitation,
 } from "@/api/handlers/case-law/ingestion/citation-extractor";
@@ -1259,15 +1260,13 @@ const processDecisionAttempt = async ({
     (caseNumber) => bareCitationKey(caseNumber),
   );
 
+  const decisionIdentifiers = decisionIdentifiersFromMetadata({
+    caseNumber: result.caseNumber,
+    ecli: result.ecli ?? null,
+  });
   const citations = extractCitations(
     sections.map((s) => ({ index: s.index, text: s.text })),
-  ).filter(
-    (c) =>
-      !isSelfCitation(c.citationText, {
-        caseNumber: result.caseNumber,
-        ecli: result.ecli ?? null,
-      }),
-  );
+  ).filter((c) => !isSelfCitation(c.citationText, decisionIdentifiers));
 
   // Where the publisher supplies its own cited-decisions list, it is the
   // one ground truth extraction can be measured against without measuring

--- a/apps/api/src/lib/legal-search/corpus-sanitize.ts
+++ b/apps/api/src/lib/legal-search/corpus-sanitize.ts
@@ -1,4 +1,11 @@
+import { stripDangerousChars } from "@stll/legal-ast/text-sanitize";
+
 import { isRecord } from "@/api/lib/type-guards";
+
+export {
+  DANGEROUS_CHARS,
+  stripDangerousChars,
+} from "@stll/legal-ast/text-sanitize";
 
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonObject | JsonArray;
@@ -6,23 +13,6 @@ type JsonObject = {
   [key: string]: JsonPrimitive | JsonObject | JsonArray;
 };
 type JsonArray = JsonValue[];
-
-export const DANGEROUS_CHARS = new RegExp(
-  "[" +
-    "\x00" +
-    "\uFEFF\uFFFE" +
-    "\u0000-\u0008" +
-    "\u000B\u000C" +
-    "\u000E-\u001F" +
-    "\u200B-\u200D" +
-    "\u2060" +
-    "\uFFF9-\uFFFB" +
-    "]",
-  "gu",
-);
-
-export const stripDangerousChars = (value: string): string =>
-  value.replace(DANGEROUS_CHARS, "").replace(/\u00A0/gu, " ");
 
 const sanitizeMetadataValue = (value: unknown): JsonValue => {
   if (typeof value === "string") {

--- a/packages/legal-ast/package.json
+++ b/packages/legal-ast/package.json
@@ -35,6 +35,10 @@
       "types": "./src/document-ast.ts",
       "import": "./src/document-ast.ts"
     },
+    "./decision-identifier": {
+      "types": "./src/decision-identifier.ts",
+      "import": "./src/decision-identifier.ts"
+    },
     "./inline": {
       "types": "./src/inline.ts",
       "import": "./src/inline.ts"
@@ -42,6 +46,10 @@
     "./statute-ast": {
       "types": "./src/statute-ast.ts",
       "import": "./src/statute-ast.ts"
+    },
+    "./text-sanitize": {
+      "types": "./src/text-sanitize.ts",
+      "import": "./src/text-sanitize.ts"
     }
   },
   "scripts": {

--- a/packages/legal-ast/src/decision-identifier.test.ts
+++ b/packages/legal-ast/src/decision-identifier.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DECISION_IDENTIFIER_TYPES,
+  isDecisionIdentifier,
+} from "./decision-identifier";
+import type { DecisionIdentifiers } from "./decision-identifier";
+
+describe("decision identifiers", () => {
+  test.each(Object.values(DECISION_IDENTIFIER_TYPES))("accepts %s", (type) => {
+    expect(isDecisionIdentifier({ type, value: "published identifier" })).toBe(
+      true,
+    );
+  });
+
+  test("rejects blank identifier values", () => {
+    expect(
+      isDecisionIdentifier({
+        type: DECISION_IDENTIFIER_TYPES.REPORTER_CITATION,
+        value: " \n ",
+      }),
+    ).toBe(false);
+  });
+
+  test.each(["\u0000", "\u200B", " \uFEFF\u2060\n"])(
+    "rejects invisible-only identifier value %j",
+    (value) => {
+      expect(
+        isDecisionIdentifier({
+          type: DECISION_IDENTIFIER_TYPES.REPORTER_CITATION,
+          value,
+        }),
+      ).toBe(false);
+    },
+  );
+
+  test("rejects fields from a different identifier shape", () => {
+    expect(
+      isDecisionIdentifier({
+        type: DECISION_IDENTIFIER_TYPES.ECLI,
+        value: "ECLI:XX:COURT:2026:1",
+        reporter: "Example Reports",
+      }),
+    ).toBe(false);
+  });
+
+  test("represents parallel citations as identifiers for one decision", () => {
+    const identifiers = [
+      {
+        type: DECISION_IDENTIFIER_TYPES.CASE_NUMBER,
+        value: "A-123",
+      },
+      {
+        type: DECISION_IDENTIFIER_TYPES.REPORTER_CITATION,
+        value: "12 Example Reports 34",
+      },
+      {
+        type: DECISION_IDENTIFIER_TYPES.REPORTER_CITATION,
+        value: "56 Parallel Reports 78",
+      },
+    ] as const satisfies DecisionIdentifiers;
+
+    expect(identifiers).toHaveLength(3);
+  });
+});

--- a/packages/legal-ast/src/decision-identifier.ts
+++ b/packages/legal-ast/src/decision-identifier.ts
@@ -1,0 +1,78 @@
+import * as v from "valibot";
+
+import { stripDangerousChars } from "./text-sanitize.js";
+
+export const DECISION_IDENTIFIER_TYPES = {
+  CASE_NUMBER: "case-number",
+  ECLI: "ecli",
+  NEUTRAL_CITATION: "neutral-citation",
+  REPORTER_CITATION: "reporter-citation",
+} as const;
+
+export type DecisionIdentifierType =
+  (typeof DECISION_IDENTIFIER_TYPES)[keyof typeof DECISION_IDENTIFIER_TYPES];
+
+export type CaseNumberIdentifier = {
+  type: typeof DECISION_IDENTIFIER_TYPES.CASE_NUMBER;
+  value: string;
+};
+
+export type EcliIdentifier = {
+  type: typeof DECISION_IDENTIFIER_TYPES.ECLI;
+  value: string;
+};
+
+export type NeutralCitationIdentifier = {
+  type: typeof DECISION_IDENTIFIER_TYPES.NEUTRAL_CITATION;
+  value: string;
+};
+
+export type ReporterCitationIdentifier = {
+  type: typeof DECISION_IDENTIFIER_TYPES.REPORTER_CITATION;
+  value: string;
+};
+
+export type DecisionIdentifier =
+  | CaseNumberIdentifier
+  | EcliIdentifier
+  | NeutralCitationIdentifier
+  | ReporterCitationIdentifier;
+
+/** A decision has one or more identifiers; parallel citations are separate items. */
+export type DecisionIdentifiers = readonly [
+  DecisionIdentifier,
+  ...DecisionIdentifier[],
+];
+
+const identifierValueSchema = v.pipe(
+  v.string(),
+  v.check(
+    (value) => /\S/u.test(stripDangerousChars(value)),
+    "Identifier values must contain visible content",
+  ),
+);
+
+export const decisionIdentifierSchema: v.GenericSchema<DecisionIdentifier> =
+  v.variant("type", [
+    v.strictObject({
+      type: v.literal(DECISION_IDENTIFIER_TYPES.CASE_NUMBER),
+      value: identifierValueSchema,
+    }),
+    v.strictObject({
+      type: v.literal(DECISION_IDENTIFIER_TYPES.ECLI),
+      value: identifierValueSchema,
+    }),
+    v.strictObject({
+      type: v.literal(DECISION_IDENTIFIER_TYPES.NEUTRAL_CITATION),
+      value: identifierValueSchema,
+    }),
+    v.strictObject({
+      type: v.literal(DECISION_IDENTIFIER_TYPES.REPORTER_CITATION),
+      value: identifierValueSchema,
+    }),
+  ]);
+
+export const isDecisionIdentifier = (
+  value: unknown,
+): value is DecisionIdentifier =>
+  v.safeParse(decisionIdentifierSchema, value).success;

--- a/packages/legal-ast/src/text-sanitize.ts
+++ b/packages/legal-ast/src/text-sanitize.ts
@@ -1,0 +1,16 @@
+export const DANGEROUS_CHARS = new RegExp(
+  "[" +
+    "\x00" +
+    "\uFEFF\uFFFE" +
+    "\u0000-\u0008" +
+    "\u000B\u000C" +
+    "\u000E-\u001F" +
+    "\u200B-\u200D" +
+    "\u2060" +
+    "\uFFF9-\uFFFB" +
+    "]",
+  "gu",
+);
+
+export const stripDangerousChars = (value: string): string =>
+  value.replace(DANGEROUS_CHARS, "").replace(/\u00A0/gu, " ");


### PR DESCRIPTION
## Summary

- add a shared discriminated contract and strict validator for decision identifiers
- represent parallel citations as a non-empty identifier collection
- adapt existing metadata and compare self-citations across identifier forms

CC on behalf of jan-kubica