### PR TITLE
feat: add Better Auth migration audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1927,6 +1927,11 @@ jobs:
             --outfile apps/api/src/db/migrate.js \
             apps/api/src/db/migrate.ts
           test -s apps/api/src/db/migrate.js
+          bun build \
+            --target bun \
+            --outfile /tmp/better-auth-migration-audit.js \
+            apps/api/src/scripts/better-auth-migration-audit.ts
+          test -s /tmp/better-auth-migration-audit.js
           mkdir -p /tmp/runtime-workers
           bun build \
             --target bun \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,6 +350,13 @@ jobs:
               exit 1
             fi
           done
+          audit_output=$(docker run --rm stella-api:smoke timeout 20 bun /app/better-auth-migration-audit.js 2>&1 || true)
+          if grep -qiE "cannot (find|resolve) (module|package)" <<<"$audit_output" \
+            || ! grep -q '"code":"invalid-arguments"' <<<"$audit_output"; then
+            echo "::error::Better Auth migration audit bundle failed its command smoke."
+            printf '%s\n' "$audit_output"
+            exit 1
+          fi
           docker run --rm stella-api:smoke bun /app/legal-atlas.js list
 
   build:

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -61,6 +61,15 @@ RUN bun build \
     --target bun \
     --outfile /app/backfill.js \
     apps/api/src/scripts/backfill-case-law-slugs.ts
+# Better Auth migration rehearsal validator. It accepts only a database
+# credential plus a private tmpfs baseline path; stdout is a redacted JSON
+# report. Run on the isolated clone task with command override:
+#   ["bun", "/app/better-auth-migration-audit.js", "pre-migration",
+#    "--baseline", "/tmp/better-auth-baseline.json"]
+RUN bun build \
+    --target bun \
+    --outfile /app/better-auth-migration-audit.js \
+    apps/api/src/scripts/better-auth-migration-audit.ts
 # Dedicated durable document-processing worker. Deploy the same image with
 # command override ["bun", "/app/document-processing-worker.js"]. OCR runs
 # in-image through the isolated local ONNX worker.
@@ -165,6 +174,7 @@ RUN groupadd --system --gid 1001 stella && \
     useradd --system --uid 1001 --gid stella --no-create-home stella
 COPY --chown=stella:stella --from=builder /app/server /app/server
 COPY --chown=stella:stella --from=builder /app/backfill.js /app/backfill.js
+COPY --chown=stella:stella --from=builder /app/better-auth-migration-audit.js /app/better-auth-migration-audit.js
 COPY --chown=stella:stella --from=builder /app/document-processing-worker.js /app/document-processing-worker.js
 COPY --chown=stella:stella --from=builder /app/apps/legal-atlas-runner/dist/index.js /app/legal-atlas.js
 # Bundled migration task entrypoint:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,6 +30,7 @@
     "canary:mcp": "bun --env-file=.env.example src/scripts/mcp-canary.ts",
     "bench:chat-read-surface": "NODE_ENV=development bun scripts/benchmark-chat-read-surface.ts",
     "db:migrate": "bun run --env-file=.env src/db/migrate.ts",
+    "db:audit-better-auth": "bun run --env-file=.env src/scripts/better-auth-migration-audit.ts",
     "db:push": "bun run db:migrate && bun run --env-file=.env drizzle-kit push",
     "db:seed-test-user": "bun scripts/seed-test-user.ts",
     "db:seed-dev": "bun scripts/seed-dev.ts",

--- a/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
@@ -1,0 +1,417 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { eq, sql, TransactionRollbackError } from "drizzle-orm";
+
+import { account, oauthClient, session, user } from "@/api/db/auth-schema";
+import {
+  BETTER_AUTH_AUDIT_CHECKS,
+  BETTER_AUTH_AUDIT_MODES,
+  runBetterAuthMigrationAudit,
+} from "@/api/scripts/better-auth-migration-audit.logic";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+
+let database: TestDatabase;
+
+beforeAll(async () => {
+  database = await getTestDb();
+});
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+const checkStatus = (
+  report: Awaited<ReturnType<typeof runBetterAuthMigrationAudit>>,
+  name: string,
+) => {
+  if (report.status === "error") {
+    return "query-error";
+  }
+  return report.value.report.checks.find((check) => check.name === name)
+    ?.status;
+};
+
+test("pre-migration audit is repeatable and rejects ownership corruption and an orphan", async () => {
+  try {
+    await database.transaction(async (transaction) => {
+      const suffix = Bun.randomUUIDv7();
+      const userId = `audit-user-${suffix}`;
+      const accountId = `audit-account-${suffix}`;
+      const sessionId = `audit-session-${suffix}`;
+      await transaction.insert(user).values({
+        id: userId,
+        email: `audit-${suffix}@example.invalid`,
+        name: "Audit fixture",
+      });
+      await transaction.insert(account).values({
+        id: accountId,
+        accountId: userId,
+        providerId: "credential",
+        userId,
+      });
+      await transaction.insert(session).values({
+        id: sessionId,
+        expiresAt: new Date(Date.now() + 60_000),
+        token: `audit-token-${suffix}`,
+        updatedAt: new Date(),
+        userId,
+      });
+
+      const auditDatabase = {
+        execute: async (statement: Parameters<typeof transaction.execute>[0]) =>
+          await transaction.execute(statement),
+      };
+      const first = await runBetterAuthMigrationAudit({
+        baseline: null,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+      });
+      if (first.status === "error") {
+        throw first.error;
+      }
+      expect(first.status).toBe("ok");
+      expect(first.value.report.status).toBe("passed");
+
+      const second = await runBetterAuthMigrationAudit({
+        baseline: null,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+      });
+      if (second.status === "error") {
+        throw second.error;
+      }
+      expect(second.status).toBe("ok");
+      expect(second.value.baseline).toEqual(first.value.baseline);
+
+      await transaction
+        .update(account)
+        .set({ accountId: `wrong-owner-${suffix}` })
+        .where(eq(account.id, accountId));
+      const wrongOwner = await runBetterAuthMigrationAudit({
+        baseline: null,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+      });
+      expect(
+        checkStatus(
+          wrongOwner,
+          BETTER_AUTH_AUDIT_CHECKS.CREDENTIAL_ACCOUNT_OWNERSHIP,
+        ),
+      ).toBe("failed");
+
+      await transaction
+        .update(account)
+        .set({ accountId: userId })
+        .where(eq(account.id, accountId));
+      await transaction.execute(
+        sql`ALTER TABLE "session" DROP CONSTRAINT "session_user_id_user_id_fkey"`,
+      );
+      const missingForeignKey = await runBetterAuthMigrationAudit({
+        baseline: null,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+      });
+      expect(
+        checkStatus(
+          missingForeignKey,
+          BETTER_AUTH_AUDIT_CHECKS.AUTH_FOREIGN_KEYS_VALIDATED,
+        ),
+      ).toBe("failed");
+
+      await transaction
+        .update(session)
+        .set({ userId: `missing-user-${suffix}` })
+        .where(eq(session.id, sessionId));
+      const orphaned = await runBetterAuthMigrationAudit({
+        baseline: null,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+      });
+      expect(
+        checkStatus(
+          orphaned,
+          BETTER_AUTH_AUDIT_CHECKS.AUTH_FOREIGN_KEYS_REACHABLE,
+        ),
+      ).toBe("failed");
+
+      transaction.rollback();
+    });
+  } catch (error) {
+    if (!(error instanceof TransactionRollbackError)) {
+      throw error;
+    }
+  }
+});
+
+test("post phases require resource links, final constraints, and the exact baseline row set", async () => {
+  try {
+    await database.transaction(async (transaction) => {
+      await transaction.execute(
+        sql`ALTER TABLE account ADD COLUMN issuer text`,
+      );
+      await transaction.execute(
+        sql`ALTER TABLE oauth_access_token ADD COLUMN resources text[]`,
+      );
+      await transaction.execute(sql`
+        ALTER TABLE oauth_access_token
+          ADD COLUMN authorization_code_id text,
+          ADD COLUMN requested_user_info_claims text[],
+          ADD COLUMN revoked timestamptz,
+          ADD COLUMN confirmation jsonb
+      `);
+      await transaction.execute(
+        sql`ALTER TABLE oauth_refresh_token ADD COLUMN resources text[]`,
+      );
+      await transaction.execute(sql`
+        ALTER TABLE oauth_refresh_token
+          ADD COLUMN authorization_code_id text,
+          ADD COLUMN requested_user_info_claims text[],
+          ADD COLUMN rotated_at timestamptz,
+          ADD COLUMN rotation_replay_response text,
+          ADD COLUMN rotation_replay_expires_at timestamptz,
+          ADD COLUMN confirmation jsonb
+      `);
+      await transaction.execute(
+        sql`ALTER TABLE oauth_consent ADD COLUMN resources text[]`,
+      );
+      await transaction.execute(sql`
+        ALTER TABLE oauth_consent
+          ADD COLUMN requested_user_info_claims text[]
+      `);
+      await transaction.execute(sql`
+        ALTER TABLE oauth_client
+          ADD COLUMN client_discovery_id text,
+          ADD COLUMN client_credentials_scopes text[] NOT NULL DEFAULT '{}',
+          ADD COLUMN backchannel_logout_uri text,
+          ADD COLUMN backchannel_logout_session_required boolean,
+          ADD COLUMN application_type text,
+          ADD COLUMN jwks text,
+          ADD COLUMN jwks_uri text,
+          ADD COLUMN dpop_bound_access_tokens boolean
+      `);
+      await transaction.execute(sql`
+        CREATE TABLE oauth_resource (
+          id text PRIMARY KEY,
+          identifier text NOT NULL UNIQUE,
+          name text NOT NULL,
+          access_token_ttl integer,
+          refresh_token_ttl integer,
+          signing_algorithm text,
+          signing_key_id text,
+          allowed_scopes text[],
+          custom_claims jsonb,
+          dpop_bound_access_tokens_required boolean,
+          disabled boolean,
+          created_at timestamptz,
+          updated_at timestamptz,
+          policy_version integer,
+          metadata jsonb
+        )
+      `);
+      await transaction.execute(sql`
+        CREATE TABLE oauth_client_resource (
+          id text PRIMARY KEY,
+          client_id text NOT NULL REFERENCES oauth_client(client_id),
+          resource_id text NOT NULL REFERENCES oauth_resource(identifier),
+          metadata jsonb,
+          created_at timestamptz,
+          UNIQUE (client_id, resource_id)
+        )
+      `);
+      await transaction.execute(sql`
+        CREATE TABLE oauth_client_assertion (
+          id text PRIMARY KEY,
+          expires_at timestamptz NOT NULL
+        )
+      `);
+      for (const tableName of [
+        "oauth_resource",
+        "oauth_client_resource",
+        "oauth_client_assertion",
+      ]) {
+        // eslint-disable-next-line no-await-in-loop -- transactional DDL must stay ordered on one connection
+        await transaction.execute(
+          sql`ALTER TABLE ${sql.identifier(tableName)} ENABLE ROW LEVEL SECURITY`,
+        );
+        // eslint-disable-next-line no-await-in-loop -- policy creation follows RLS enablement
+        await transaction.execute(
+          sql`CREATE POLICY auth_no_stella_access ON ${sql.identifier(tableName)} FOR ALL TO stella USING (false) WITH CHECK (false)`,
+        );
+        // eslint-disable-next-line no-await-in-loop -- privilege revocation follows policy creation
+        await transaction.execute(
+          sql`REVOKE ALL PRIVILEGES ON TABLE ${sql.identifier(tableName)} FROM stella`,
+        );
+      }
+
+      const suffix = Bun.randomUUIDv7();
+      const userId = `audit-post-user-${suffix}`;
+      const accountRowId = `audit-post-account-${suffix}`;
+      const clientId = `audit-post-client-${suffix}`;
+      const resourceId = `https://audit-${suffix}.example.invalid`;
+      await transaction.insert(user).values({
+        id: userId,
+        email: `audit-post-${suffix}@example.invalid`,
+        name: "Audit post fixture",
+      });
+      await transaction.insert(account).values({
+        id: accountRowId,
+        accountId: userId,
+        providerId: "credential",
+        userId,
+      });
+      await transaction.execute(
+        sql`UPDATE account SET issuer = 'local:credential' WHERE id = ${accountRowId}`,
+      );
+      await transaction.insert(oauthClient).values({
+        id: `audit-post-client-row-${suffix}`,
+        clientId,
+        redirectUris: [`https://client-${suffix}.example.invalid/callback`],
+        tokenEndpointAuthMethod: "none",
+      });
+      await transaction.execute(
+        sql`UPDATE oauth_client SET application_type = 'web' WHERE client_id = ${clientId}`,
+      );
+      await transaction.execute(sql`
+        INSERT INTO oauth_resource (id, identifier, name)
+        VALUES (${`audit-resource-${suffix}`}, ${resourceId}, 'Audit resource')
+      `);
+      await transaction.execute(sql`
+        INSERT INTO oauth_client_resource (id, client_id, resource_id)
+        VALUES (${`audit-link-${suffix}`}, ${clientId}, ${resourceId})
+      `);
+
+      const auditDatabase = {
+        execute: async (statement: Parameters<typeof transaction.execute>[0]) =>
+          await transaction.execute(statement),
+      };
+      const preMigration = await runBetterAuthMigrationAudit({
+        baseline: null,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+      });
+      expect(preMigration.status).toBe("ok");
+      if (preMigration.status === "error") {
+        throw preMigration.error;
+      }
+
+      const postBackfill = await runBetterAuthMigrationAudit({
+        baseline: preMigration.value.baseline,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+      });
+      if (postBackfill.status === "error") {
+        throw postBackfill.error;
+      }
+      expect(postBackfill.status).toBe("ok");
+      expect(postBackfill.value.report.status).toBe("passed");
+
+      const beforeConstraints = await runBetterAuthMigrationAudit({
+        baseline: preMigration.value.baseline,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.POST_MIGRATION,
+      });
+      expect(
+        checkStatus(
+          beforeConstraints,
+          BETTER_AUTH_AUDIT_CHECKS.FINAL_ACCOUNT_CONSTRAINTS,
+        ),
+      ).toBe("failed");
+
+      await transaction.execute(
+        sql`ALTER TABLE account ALTER COLUMN issuer SET NOT NULL`,
+      );
+      await transaction.execute(
+        sql`CREATE UNIQUE INDEX account_issuer_account_id_uidx ON account (issuer, account_id)`,
+      );
+      const postMigration = await runBetterAuthMigrationAudit({
+        baseline: preMigration.value.baseline,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.POST_MIGRATION,
+      });
+      expect(postMigration.status).toBe("ok");
+      if (postMigration.status === "error") {
+        throw postMigration.error;
+      }
+      expect(postMigration.value.report.status).toBe("passed");
+
+      await transaction.execute(
+        sql`UPDATE "user" SET name = 'Unexpected migration mutation' WHERE id = ${userId}`,
+      );
+      const changedRow = await runBetterAuthMigrationAudit({
+        baseline: preMigration.value.baseline,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+      });
+      expect(
+        checkStatus(changedRow, BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_PRESERVED),
+      ).toBe("failed");
+      await transaction.execute(
+        sql`UPDATE "user" SET name = 'Audit post fixture' WHERE id = ${userId}`,
+      );
+
+      await transaction.execute(sql`GRANT SELECT ON oauth_resource TO stella`);
+      const widenedAccess = await runBetterAuthMigrationAudit({
+        baseline: preMigration.value.baseline,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+      });
+      expect(
+        checkStatus(
+          widenedAccess,
+          BETTER_AUTH_AUDIT_CHECKS.AUTH_ACCESS_BOUNDARIES,
+        ),
+      ).toBe("failed");
+      await transaction.execute(
+        sql`REVOKE SELECT ON oauth_resource FROM stella`,
+      );
+
+      await transaction.execute(
+        sql`DELETE FROM oauth_client_resource WHERE client_id = ${clientId}`,
+      );
+      const missingLink = await runBetterAuthMigrationAudit({
+        baseline: preMigration.value.baseline,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+      });
+      expect(
+        checkStatus(
+          missingLink,
+          BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENT_RESOURCE_LINKS,
+        ),
+      ).toBe("failed");
+      await transaction.execute(sql`
+        INSERT INTO oauth_client_resource (id, client_id, resource_id)
+        VALUES (${`audit-link-restored-${suffix}`}, ${clientId}, ${resourceId})
+      `);
+
+      await transaction.delete(account).where(eq(account.id, accountRowId));
+      await transaction.execute(sql`
+        INSERT INTO account (
+          id, account_id, provider_id, user_id, issuer, created_at, updated_at
+        ) VALUES (
+          ${`audit-post-account-replaced-${suffix}`},
+          ${userId},
+          'credential',
+          ${userId},
+          'local:credential',
+          now(),
+          now()
+        )
+      `);
+      const replacedRow = await runBetterAuthMigrationAudit({
+        baseline: preMigration.value.baseline,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+      });
+      expect(
+        checkStatus(replacedRow, BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_PRESERVED),
+      ).toBe("failed");
+
+      transaction.rollback();
+    });
+  } catch (error) {
+    if (!(error instanceof TransactionRollbackError)) {
+      throw error;
+    }
+  }
+});

--- a/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, expect, test } from "bun:test";
+import { afterAll, beforeAll, expect, setDefaultTimeout, test } from "bun:test";
 import { eq, sql, TransactionRollbackError } from "drizzle-orm";
 
 import { account, oauthClient, session, user } from "@/api/db/auth-schema";
@@ -11,6 +11,8 @@ import type { TestDatabase } from "@/api/tests/security/test-utils";
 import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
 
 let database: TestDatabase;
+
+setDefaultTimeout(120_000);
 
 beforeAll(async () => {
   database = await getTestDb();

--- a/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
@@ -83,21 +83,37 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
       expect(second.status).toBe("ok");
       expect(second.value.baseline).toEqual(first.value.baseline);
 
+      await transaction.execute(sql`
+        ALTER POLICY auth_no_stella_access ON account
+          USING (true)
+          WITH CHECK (true)
+      `);
       await transaction
         .update(account)
         .set({ accountId: `wrong-owner-${suffix}` })
         .where(eq(account.id, accountId));
-      const wrongOwner = await runBetterAuthMigrationAudit({
+      const corruptedAccessAndOwnership = await runBetterAuthMigrationAudit({
         baseline: null,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
       });
       expect(
         checkStatus(
-          wrongOwner,
+          corruptedAccessAndOwnership,
+          BETTER_AUTH_AUDIT_CHECKS.AUTH_ACCESS_BOUNDARIES,
+        ),
+      ).toBe("failed");
+      expect(
+        checkStatus(
+          corruptedAccessAndOwnership,
           BETTER_AUTH_AUDIT_CHECKS.CREDENTIAL_ACCOUNT_OWNERSHIP,
         ),
       ).toBe("failed");
+      await transaction.execute(sql`
+        ALTER POLICY auth_no_stella_access ON account
+          USING (false)
+          WITH CHECK (false)
+      `);
 
       await transaction
         .update(account)
@@ -211,11 +227,15 @@ test("post phases require resource links, final constraints, and the exact basel
       await transaction.execute(sql`
         CREATE TABLE oauth_client_resource (
           id text PRIMARY KEY,
-          client_id text NOT NULL REFERENCES oauth_client(client_id),
-          resource_id text NOT NULL REFERENCES oauth_resource(identifier),
+          client_id text NOT NULL,
+          resource_id text NOT NULL,
           metadata jsonb,
           created_at timestamptz,
-          UNIQUE (client_id, resource_id)
+          UNIQUE (client_id, resource_id),
+          CONSTRAINT oauth_client_resource_client_fk
+            FOREIGN KEY (client_id) REFERENCES oauth_client(client_id),
+          CONSTRAINT oauth_client_resource_resource_fk
+            FOREIGN KEY (resource_id) REFERENCES oauth_resource(identifier)
         )
       `);
       await transaction.execute(sql`
@@ -293,6 +313,9 @@ test("post phases require resource links, final constraints, and the exact basel
       if (preMigration.status === "error") {
         throw preMigration.error;
       }
+      expect(
+        preMigration.value.baseline.tables["account"]?.preservedColumns,
+      ).not.toContain("issuer");
 
       const postBackfill = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
@@ -321,6 +344,23 @@ test("post phases require resource links, final constraints, and the exact basel
         sql`ALTER TABLE account ALTER COLUMN issuer SET NOT NULL`,
       );
       await transaction.execute(
+        sql`CREATE UNIQUE INDEX account_issuer_account_id_partial_uidx ON account (issuer, account_id) WHERE issuer IS NOT NULL`,
+      );
+      const partialIdentityIndex = await runBetterAuthMigrationAudit({
+        baseline: preMigration.value.baseline,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.POST_MIGRATION,
+      });
+      expect(
+        checkStatus(
+          partialIdentityIndex,
+          BETTER_AUTH_AUDIT_CHECKS.FINAL_ACCOUNT_CONSTRAINTS,
+        ),
+      ).toBe("failed");
+      await transaction.execute(
+        sql`DROP INDEX account_issuer_account_id_partial_uidx`,
+      );
+      await transaction.execute(
         sql`CREATE UNIQUE INDEX account_issuer_account_id_uidx ON account (issuer, account_id)`,
       );
       const postMigration = await runBetterAuthMigrationAudit({
@@ -333,6 +373,54 @@ test("post phases require resource links, final constraints, and the exact basel
         throw postMigration.error;
       }
       expect(postMigration.value.report.status).toBe("passed");
+
+      await transaction.execute(sql`
+        ALTER POLICY auth_member_select ON member
+          USING (organization_id IS NOT NULL)
+      `);
+      const changedScopedPolicy = await runBetterAuthMigrationAudit({
+        baseline: preMigration.value.baseline,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+      });
+      expect(
+        checkStatus(
+          changedScopedPolicy,
+          BETTER_AUTH_AUDIT_CHECKS.AUTH_ACCESS_BOUNDARIES,
+        ),
+      ).toBe("failed");
+      await transaction.execute(sql`
+        ALTER POLICY auth_member_select ON member
+          USING (
+            organization_id = (
+              SELECT current_setting('app.organization_id', true)
+            )
+          )
+      `);
+
+      await transaction.execute(sql`
+        ALTER TABLE oauth_client_resource
+          DROP CONSTRAINT oauth_client_resource_client_fk,
+          ADD CONSTRAINT oauth_client_resource_resource_duplicate_fk
+            FOREIGN KEY (resource_id) REFERENCES oauth_resource(identifier)
+      `);
+      const wrongResourceForeignKeys = await runBetterAuthMigrationAudit({
+        baseline: preMigration.value.baseline,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.POST_MIGRATION,
+      });
+      expect(
+        checkStatus(
+          wrongResourceForeignKeys,
+          BETTER_AUTH_AUDIT_CHECKS.POST_MIGRATION_CONSTRAINTS,
+        ),
+      ).toBe("failed");
+      await transaction.execute(sql`
+        ALTER TABLE oauth_client_resource
+          DROP CONSTRAINT oauth_client_resource_resource_duplicate_fk,
+          ADD CONSTRAINT oauth_client_resource_client_fk
+            FOREIGN KEY (client_id) REFERENCES oauth_client(client_id)
+      `);
 
       await transaction.execute(
         sql`UPDATE "user" SET name = 'Unexpected migration mutation' WHERE id = ${userId}`,

--- a/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
@@ -161,6 +161,55 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
   }
 });
 
+test("census crosses page boundaries with stable database-native ordering", async () => {
+  try {
+    await database.transaction(async (transaction) => {
+      const suffix = Bun.randomUUIDv7();
+      await transaction.insert(user).values(
+        Array.from({ length: 1001 }, (_, index) => {
+          const caseMarker = index % 2 === 0 ? "A" : "a";
+          return {
+            id: `audit-page-${caseMarker}-${index.toString().padStart(4, "0")}-${suffix}`,
+            email: `audit-page-${index}-${suffix}@example.invalid`,
+            name: "Audit pagination fixture",
+          };
+        }),
+      );
+
+      const auditDatabase = {
+        execute: async (statement: Parameters<typeof transaction.execute>[0]) =>
+          await transaction.execute(statement),
+      };
+      const first = await runBetterAuthMigrationAudit({
+        baseline: null,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+      });
+      if (first.status === "error") {
+        throw first.error;
+      }
+      const second = await runBetterAuthMigrationAudit({
+        baseline: null,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+      });
+      if (second.status === "error") {
+        throw second.error;
+      }
+
+      expect(
+        BigInt(first.value.baseline.tables["user"]?.rowCount ?? "0"),
+      ).toBeGreaterThan(1000n);
+      expect(second.value.baseline).toEqual(first.value.baseline);
+      throw new TransactionRollbackError();
+    });
+  } catch (error) {
+    if (!(error instanceof TransactionRollbackError)) {
+      throw error;
+    }
+  }
+});
+
 test("post phases require resource links, final constraints, and the exact baseline row set", async () => {
   try {
     await database.transaction(async (transaction) => {

--- a/apps/api/src/scripts/better-auth-migration-audit.logic.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.logic.ts
@@ -1,0 +1,1470 @@
+/**
+ * Read-only, redacted invariants for the Better Auth 1.6 -> 1.7 migration.
+ *
+ * The audit deliberately keeps database rows and counts out of its report.
+ * Counts live only in a private baseline file passed between rehearsal phases;
+ * stdout contains stable check names and statuses only.
+ */
+
+import { Result, TaggedError } from "better-result";
+import { getColumns, getTableName, sql } from "drizzle-orm";
+import type { SQL, Table } from "drizzle-orm";
+
+import { authSchema } from "@/api/db/auth-schema";
+import { isRecord } from "@/api/lib/type-guards";
+
+export const BETTER_AUTH_AUDIT_MODES = {
+  POST_BACKFILL: "post-backfill",
+  POST_MIGRATION: "post-migration",
+  PRE_MIGRATION: "pre-migration",
+} as const;
+
+export type BetterAuthAuditMode =
+  (typeof BETTER_AUTH_AUDIT_MODES)[keyof typeof BETTER_AUTH_AUDIT_MODES];
+
+const AUTH_PROVIDER_IDS = {
+  CREDENTIAL: "credential",
+  GOOGLE: "google",
+  MICROSOFT: "microsoft",
+} as const;
+
+const ACCOUNT_ISSUERS = {
+  CREDENTIAL: "local:credential",
+  GOOGLE: "https://accounts.google.com",
+  MICROSOFT_PREFIX: "https://login.microsoftonline.com/",
+  MICROSOFT_SUFFIX: "/v2.0",
+} as const;
+
+type AuthModel = keyof typeof authSchema;
+
+type ForeignKeyPolicy = {
+  column: string;
+  referencedColumn: string;
+  referencedModel: AuthModel;
+};
+
+type AuthTableAuditPolicy = {
+  foreignKeys: readonly ForeignKeyPolicy[];
+  preservedColumns: readonly string[];
+  tableName: string;
+};
+
+type AuthAccessPolicy = {
+  access: "denied" | "scoped";
+  policyNames: readonly string[];
+  tableName: string;
+};
+
+const columnNames = (table: Table) =>
+  Object.values(getColumns(table)).map(({ name }) => name);
+
+/**
+ * Total by construction: adding a table to `authSchema` fails typechecking
+ * until its preservation and reachability policy is chosen here.
+ */
+export const AUTH_TABLE_AUDIT_POLICY = {
+  account: {
+    foreignKeys: [
+      { column: "user_id", referencedColumn: "id", referencedModel: "user" },
+    ],
+    preservedColumns: columnNames(authSchema.account),
+    tableName: getTableName(authSchema.account),
+  },
+  apikey: {
+    foreignKeys: [
+      {
+        column: "reference_id",
+        referencedColumn: "id",
+        referencedModel: "user",
+      },
+    ],
+    preservedColumns: columnNames(authSchema.apikey),
+    tableName: getTableName(authSchema.apikey),
+  },
+  invitation: {
+    foreignKeys: [
+      {
+        column: "organization_id",
+        referencedColumn: "id",
+        referencedModel: "organization",
+      },
+      { column: "inviter_id", referencedColumn: "id", referencedModel: "user" },
+    ],
+    preservedColumns: columnNames(authSchema.invitation),
+    tableName: getTableName(authSchema.invitation),
+  },
+  jwks: {
+    foreignKeys: [],
+    preservedColumns: columnNames(authSchema.jwks),
+    tableName: getTableName(authSchema.jwks),
+  },
+  member: {
+    foreignKeys: [
+      {
+        column: "organization_id",
+        referencedColumn: "id",
+        referencedModel: "organization",
+      },
+      { column: "user_id", referencedColumn: "id", referencedModel: "user" },
+    ],
+    preservedColumns: columnNames(authSchema.member),
+    tableName: getTableName(authSchema.member),
+  },
+  oauthAccessToken: {
+    foreignKeys: [
+      {
+        column: "client_id",
+        referencedColumn: "client_id",
+        referencedModel: "oauthClient",
+      },
+      {
+        column: "session_id",
+        referencedColumn: "id",
+        referencedModel: "session",
+      },
+      { column: "user_id", referencedColumn: "id", referencedModel: "user" },
+      {
+        column: "refresh_id",
+        referencedColumn: "id",
+        referencedModel: "oauthRefreshToken",
+      },
+    ],
+    preservedColumns: columnNames(authSchema.oauthAccessToken),
+    tableName: getTableName(authSchema.oauthAccessToken),
+  },
+  oauthClient: {
+    foreignKeys: [
+      { column: "user_id", referencedColumn: "id", referencedModel: "user" },
+    ],
+    preservedColumns: columnNames(authSchema.oauthClient),
+    tableName: getTableName(authSchema.oauthClient),
+  },
+  oauthConsent: {
+    foreignKeys: [
+      {
+        column: "client_id",
+        referencedColumn: "client_id",
+        referencedModel: "oauthClient",
+      },
+      { column: "user_id", referencedColumn: "id", referencedModel: "user" },
+    ],
+    preservedColumns: columnNames(authSchema.oauthConsent),
+    tableName: getTableName(authSchema.oauthConsent),
+  },
+  oauthRefreshToken: {
+    foreignKeys: [
+      {
+        column: "client_id",
+        referencedColumn: "client_id",
+        referencedModel: "oauthClient",
+      },
+      {
+        column: "session_id",
+        referencedColumn: "id",
+        referencedModel: "session",
+      },
+      { column: "user_id", referencedColumn: "id", referencedModel: "user" },
+    ],
+    preservedColumns: columnNames(authSchema.oauthRefreshToken),
+    tableName: getTableName(authSchema.oauthRefreshToken),
+  },
+  organization: {
+    foreignKeys: [],
+    preservedColumns: columnNames(authSchema.organization),
+    tableName: getTableName(authSchema.organization),
+  },
+  session: {
+    foreignKeys: [
+      { column: "user_id", referencedColumn: "id", referencedModel: "user" },
+    ],
+    preservedColumns: columnNames(authSchema.session),
+    tableName: getTableName(authSchema.session),
+  },
+  twoFactor: {
+    foreignKeys: [
+      { column: "user_id", referencedColumn: "id", referencedModel: "user" },
+    ],
+    preservedColumns: columnNames(authSchema.twoFactor),
+    tableName: getTableName(authSchema.twoFactor),
+  },
+  user: {
+    foreignKeys: [],
+    preservedColumns: columnNames(authSchema.user),
+    tableName: getTableName(authSchema.user),
+  },
+  verification: {
+    foreignKeys: [],
+    preservedColumns: columnNames(authSchema.verification),
+    tableName: getTableName(authSchema.verification),
+  },
+} as const satisfies Record<AuthModel, AuthTableAuditPolicy>;
+
+/**
+ * Separate from table coverage on purpose. A 1.7-only table is audited but is
+ * not expected in the baseline written by the 1.6 image. When `authSchema`
+ * grows, this total map forces that preservation decision at compile time.
+ */
+const AUTH_BASELINE_DISPOSITION = {
+  account: "preserve",
+  apikey: "preserve",
+  invitation: "preserve",
+  jwks: "preserve",
+  member: "preserve",
+  oauthAccessToken: "preserve",
+  oauthClient: "preserve",
+  oauthConsent: "preserve",
+  oauthRefreshToken: "preserve",
+  organization: "preserve",
+  session: "preserve",
+  twoFactor: "preserve",
+  user: "preserve",
+  verification: "preserve",
+} as const satisfies Record<AuthModel, "introduced" | "preserve">;
+
+const isPreservedDisposition = (value: "introduced" | "preserve") =>
+  value === "preserve";
+
+const AUTH_MODEL_NAMES = Object.entries(AUTH_BASELINE_DISPOSITION)
+  .filter(([, disposition]) => isPreservedDisposition(disposition))
+  .map(([model]) => model);
+const AUTH_TABLE_POLICIES = Object.values(AUTH_TABLE_AUDIT_POLICY);
+
+const isAuthModel = (value: string): value is AuthModel =>
+  Object.hasOwn(AUTH_TABLE_AUDIT_POLICY, value);
+
+const AUTH_ACCESS_POLICY = {
+  account: {
+    access: "denied",
+    policyNames: ["auth_no_stella_access"],
+    tableName: AUTH_TABLE_AUDIT_POLICY.account.tableName,
+  },
+  apikey: {
+    access: "denied",
+    policyNames: ["auth_no_stella_access"],
+    tableName: AUTH_TABLE_AUDIT_POLICY.apikey.tableName,
+  },
+  invitation: {
+    access: "denied",
+    policyNames: ["auth_no_stella_access"],
+    tableName: AUTH_TABLE_AUDIT_POLICY.invitation.tableName,
+  },
+  jwks: {
+    access: "denied",
+    policyNames: ["auth_no_stella_access"],
+    tableName: AUTH_TABLE_AUDIT_POLICY.jwks.tableName,
+  },
+  member: {
+    access: "scoped",
+    policyNames: [
+      "auth_member_select",
+      "auth_member_update_last_active_workspace",
+    ],
+    tableName: AUTH_TABLE_AUDIT_POLICY.member.tableName,
+  },
+  oauthAccessToken: {
+    access: "denied",
+    policyNames: ["auth_no_stella_access"],
+    tableName: AUTH_TABLE_AUDIT_POLICY.oauthAccessToken.tableName,
+  },
+  oauthClient: {
+    access: "denied",
+    policyNames: ["auth_no_stella_access"],
+    tableName: AUTH_TABLE_AUDIT_POLICY.oauthClient.tableName,
+  },
+  oauthConsent: {
+    access: "denied",
+    policyNames: ["auth_no_stella_access"],
+    tableName: AUTH_TABLE_AUDIT_POLICY.oauthConsent.tableName,
+  },
+  oauthRefreshToken: {
+    access: "denied",
+    policyNames: ["auth_no_stella_access"],
+    tableName: AUTH_TABLE_AUDIT_POLICY.oauthRefreshToken.tableName,
+  },
+  organization: {
+    access: "scoped",
+    policyNames: ["auth_organization_select"],
+    tableName: AUTH_TABLE_AUDIT_POLICY.organization.tableName,
+  },
+  session: {
+    access: "denied",
+    policyNames: ["auth_no_stella_access"],
+    tableName: AUTH_TABLE_AUDIT_POLICY.session.tableName,
+  },
+  twoFactor: {
+    access: "denied",
+    policyNames: ["auth_no_stella_access"],
+    tableName: AUTH_TABLE_AUDIT_POLICY.twoFactor.tableName,
+  },
+  user: {
+    access: "scoped",
+    policyNames: ["auth_user_select"],
+    tableName: AUTH_TABLE_AUDIT_POLICY.user.tableName,
+  },
+  verification: {
+    access: "denied",
+    policyNames: ["auth_no_stella_access"],
+    tableName: AUTH_TABLE_AUDIT_POLICY.verification.tableName,
+  },
+} as const satisfies Record<AuthModel, AuthAccessPolicy>;
+
+const FUTURE_AUTH_TABLES = {
+  OAUTH_CLIENT_ASSERTION: "oauth_client_assertion",
+  OAUTH_CLIENT_RESOURCE: "oauth_client_resource",
+  OAUTH_RESOURCE: "oauth_resource",
+} as const;
+
+const FUTURE_AUTH_ACCESS_POLICY = Object.values(FUTURE_AUTH_TABLES).map(
+  (tableName) => ({
+    access: "denied" as const,
+    policyNames: ["auth_no_stella_access"],
+    tableName,
+  }),
+);
+
+const POST_BACKFILL_COLUMNS = {
+  account: ["issuer"],
+  oauth_access_token: ["resources"],
+  oauth_client: ["application_type", "client_credentials_scopes"],
+  oauth_consent: ["resources"],
+  oauth_client_resource: ["client_id", "resource_id"],
+  oauth_resource: ["identifier"],
+  oauth_refresh_token: ["resources"],
+} as const;
+
+const POST_MIGRATION_COLUMNS = {
+  account: ["issuer"],
+  oauth_access_token: [
+    "authorization_code_id",
+    "confirmation",
+    "requested_user_info_claims",
+    "resources",
+    "revoked",
+  ],
+  oauth_client: [
+    "application_type",
+    "backchannel_logout_session_required",
+    "backchannel_logout_uri",
+    "client_credentials_scopes",
+    "client_discovery_id",
+    "dpop_bound_access_tokens",
+    "jwks",
+    "jwks_uri",
+    // Kept through the rollback window for the Better Auth 1.6 image.
+    "public",
+    "type",
+  ],
+  oauth_client_assertion: ["expires_at", "id"],
+  oauth_client_resource: [
+    "client_id",
+    "created_at",
+    "id",
+    "metadata",
+    "resource_id",
+  ],
+  oauth_consent: ["requested_user_info_claims", "resources"],
+  oauth_refresh_token: [
+    "authorization_code_id",
+    "confirmation",
+    "requested_user_info_claims",
+    "resources",
+    "rotated_at",
+    "rotation_replay_expires_at",
+    "rotation_replay_response",
+  ],
+  oauth_resource: [
+    "access_token_ttl",
+    "allowed_scopes",
+    "created_at",
+    "custom_claims",
+    "disabled",
+    "dpop_bound_access_tokens_required",
+    "id",
+    "identifier",
+    "metadata",
+    "name",
+    "policy_version",
+    "refresh_token_ttl",
+    "signing_algorithm",
+    "signing_key_id",
+    "updated_at",
+  ],
+} as const;
+
+export const BETTER_AUTH_AUDIT_CHECKS = {
+  ACCOUNT_IDENTITY_COMPLETE: "account-identity-complete",
+  ACCOUNT_IDENTITY_UNIQUE: "account-identity-unique",
+  ACCOUNT_ISSUERS_TRUSTED: "account-issuers-trusted",
+  ACCOUNT_PROVIDERS_CLASSIFIED: "account-providers-classified",
+  AUTH_FOREIGN_KEYS_REACHABLE: "auth-foreign-keys-reachable",
+  AUTH_FOREIGN_KEYS_VALIDATED: "auth-foreign-keys-validated",
+  AUTH_ACCESS_BOUNDARIES: "auth-access-boundaries",
+  AUTH_ROWS_BASELINED: "auth-rows-baselined",
+  AUTH_ROWS_PRESERVED: "auth-rows-preserved",
+  CREDENTIAL_ACCOUNT_OWNERSHIP: "credential-account-ownership",
+  CURRENT_SCHEMA_COMPLETE: "current-auth-schema-complete",
+  FINAL_ACCOUNT_CONSTRAINTS: "final-account-constraints",
+  FINAL_SCHEMA_COMPLETE: "final-auth-schema-complete",
+  OAUTH_CLIENTS_CLASSIFIED: "oauth-clients-classified",
+  OAUTH_CLIENT_RESOURCE_LINKS: "oauth-client-resource-links-complete",
+  OAUTH_RESOURCE_REFERENCES: "oauth-resource-references-reachable",
+  POST_BACKFILL_SCHEMA_COMPLETE: "post-backfill-schema-complete",
+  POST_MIGRATION_CONSTRAINTS: "post-migration-constraints",
+} as const;
+
+type BetterAuthAuditCheckName =
+  (typeof BETTER_AUTH_AUDIT_CHECKS)[keyof typeof BETTER_AUTH_AUDIT_CHECKS];
+
+const CHECKS_BY_MODE = {
+  [BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION]: [
+    BETTER_AUTH_AUDIT_CHECKS.CURRENT_SCHEMA_COMPLETE,
+    BETTER_AUTH_AUDIT_CHECKS.AUTH_ACCESS_BOUNDARIES,
+    BETTER_AUTH_AUDIT_CHECKS.AUTH_FOREIGN_KEYS_REACHABLE,
+    BETTER_AUTH_AUDIT_CHECKS.AUTH_FOREIGN_KEYS_VALIDATED,
+    BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_PROVIDERS_CLASSIFIED,
+    BETTER_AUTH_AUDIT_CHECKS.CREDENTIAL_ACCOUNT_OWNERSHIP,
+    BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_BASELINED,
+  ],
+  [BETTER_AUTH_AUDIT_MODES.POST_BACKFILL]: [
+    BETTER_AUTH_AUDIT_CHECKS.CURRENT_SCHEMA_COMPLETE,
+    BETTER_AUTH_AUDIT_CHECKS.POST_BACKFILL_SCHEMA_COMPLETE,
+    BETTER_AUTH_AUDIT_CHECKS.AUTH_ACCESS_BOUNDARIES,
+    BETTER_AUTH_AUDIT_CHECKS.AUTH_FOREIGN_KEYS_REACHABLE,
+    BETTER_AUTH_AUDIT_CHECKS.AUTH_FOREIGN_KEYS_VALIDATED,
+    BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_PROVIDERS_CLASSIFIED,
+    BETTER_AUTH_AUDIT_CHECKS.CREDENTIAL_ACCOUNT_OWNERSHIP,
+    BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_COMPLETE,
+    BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_UNIQUE,
+    BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_ISSUERS_TRUSTED,
+    BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENT_RESOURCE_LINKS,
+    BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENTS_CLASSIFIED,
+    BETTER_AUTH_AUDIT_CHECKS.OAUTH_RESOURCE_REFERENCES,
+    BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_PRESERVED,
+  ],
+  [BETTER_AUTH_AUDIT_MODES.POST_MIGRATION]: [
+    BETTER_AUTH_AUDIT_CHECKS.CURRENT_SCHEMA_COMPLETE,
+    BETTER_AUTH_AUDIT_CHECKS.POST_BACKFILL_SCHEMA_COMPLETE,
+    BETTER_AUTH_AUDIT_CHECKS.AUTH_ACCESS_BOUNDARIES,
+    BETTER_AUTH_AUDIT_CHECKS.AUTH_FOREIGN_KEYS_REACHABLE,
+    BETTER_AUTH_AUDIT_CHECKS.AUTH_FOREIGN_KEYS_VALIDATED,
+    BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_PROVIDERS_CLASSIFIED,
+    BETTER_AUTH_AUDIT_CHECKS.CREDENTIAL_ACCOUNT_OWNERSHIP,
+    BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_COMPLETE,
+    BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_UNIQUE,
+    BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_ISSUERS_TRUSTED,
+    BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENT_RESOURCE_LINKS,
+    BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENTS_CLASSIFIED,
+    BETTER_AUTH_AUDIT_CHECKS.OAUTH_RESOURCE_REFERENCES,
+    BETTER_AUTH_AUDIT_CHECKS.FINAL_SCHEMA_COMPLETE,
+    BETTER_AUTH_AUDIT_CHECKS.FINAL_ACCOUNT_CONSTRAINTS,
+    BETTER_AUTH_AUDIT_CHECKS.POST_MIGRATION_CONSTRAINTS,
+    BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_PRESERVED,
+  ],
+} as const satisfies Record<
+  BetterAuthAuditMode,
+  readonly BetterAuthAuditCheckName[]
+>;
+
+export type BetterAuthAuditCheck = {
+  name: BetterAuthAuditCheckName;
+  status: "failed" | "passed";
+};
+
+export type BetterAuthAuditBaseline = {
+  formatVersion: 1;
+  tables: Record<
+    string,
+    { primaryKeyDigest: string; rowContentDigest: string; rowCount: string }
+  >;
+};
+
+export type BetterAuthAuditReport = {
+  checks: readonly BetterAuthAuditCheck[];
+  mode: BetterAuthAuditMode;
+  status: "failed" | "passed";
+};
+
+export class BetterAuthAuditError extends TaggedError("BetterAuthAuditError")<{
+  cause?: unknown;
+  code: "database-query-failed" | "invalid-baseline";
+  message: string;
+}> {}
+
+export type BetterAuthAuditDatabase = {
+  execute: (statement: SQL) => Promise<unknown>;
+};
+
+type AuditRunResult = {
+  baseline: BetterAuthAuditBaseline;
+  report: BetterAuthAuditReport;
+};
+
+const queryRows = async (database: BetterAuthAuditDatabase, statement: SQL) => {
+  const queried = await Result.tryPromise({
+    try: async () => await database.execute(statement),
+    catch: (cause) =>
+      new BetterAuthAuditError({
+        cause,
+        code: "database-query-failed",
+        message: "Better Auth audit database query failed",
+      }),
+  });
+  if (Result.isError(queried)) {
+    return queried;
+  }
+  let rows: unknown[] | null = null;
+  if (Array.isArray(queried.value)) {
+    rows = queried.value;
+  } else if (isRecord(queried.value) && Array.isArray(queried.value["rows"])) {
+    rows = queried.value["rows"];
+  }
+  if (rows === null) {
+    return Result.err(
+      new BetterAuthAuditError({
+        code: "database-query-failed",
+        message: "Better Auth audit database returned an invalid result",
+      }),
+    );
+  }
+  return Result.ok(rows);
+};
+
+const requiredString = (value: unknown): string | null =>
+  typeof value === "string" ? value : null;
+
+const requiredBoolean = (value: unknown): boolean | null =>
+  typeof value === "boolean" ? value : null;
+
+const tableInventoryStatement = sql`
+  SELECT table_name AS "tableName"
+    FROM information_schema.tables
+   WHERE table_schema = 'public'
+     AND table_type = 'BASE TABLE'
+`;
+
+const columnInventoryStatement = sql`
+  SELECT table_name AS "tableName", column_name AS "columnName"
+    FROM information_schema.columns
+   WHERE table_schema = 'public'
+`;
+
+const PRIMARY_KEY_PAGE_SIZE = 1000;
+
+const foreignKeyOrphanStatements = AUTH_TABLE_POLICIES.flatMap((policy) =>
+  policy.foreignKeys.map(({ column, referencedColumn, referencedModel }) => {
+    const referenced = AUTH_TABLE_AUDIT_POLICY[referencedModel];
+    return sql`
+      EXISTS (
+        SELECT 1
+          FROM ${sql.identifier(policy.tableName)} child
+          LEFT JOIN ${sql.identifier(referenced.tableName)} parent
+            ON child.${sql.identifier(column)} = parent.${sql.identifier(referencedColumn)}
+         WHERE child.${sql.identifier(column)} IS NOT NULL
+           AND parent.${sql.identifier(referencedColumn)} IS NULL
+      )
+    `;
+  }),
+);
+
+const noForeignKeyOrphansStatement = sql`
+  SELECT NOT (${sql.join(foreignKeyOrphanStatements, sql` OR `)}) AS "passed"
+`;
+
+const expectedForeignKeys = AUTH_TABLE_POLICIES.flatMap((policy) =>
+  policy.foreignKeys.map(({ column, referencedColumn, referencedModel }) => {
+    const referenced = AUTH_TABLE_AUDIT_POLICY[referencedModel];
+    return sql`(
+      ${policy.tableName}::text,
+      ${column}::text,
+      ${referenced.tableName}::text,
+      ${referencedColumn}::text
+    )`;
+  }),
+);
+
+const foreignKeysValidatedStatement = sql`
+  WITH expected(child_table, child_column, parent_table, parent_column) AS (
+    VALUES ${sql.join(expectedForeignKeys, sql`, `)}
+  )
+  SELECT NOT EXISTS (
+    SELECT 1
+      FROM expected
+     WHERE NOT EXISTS (
+       SELECT 1
+         FROM pg_constraint constraint_record
+         JOIN pg_class child ON child.oid = constraint_record.conrelid
+         JOIN pg_namespace child_namespace
+           ON child_namespace.oid = child.relnamespace
+         JOIN pg_class parent ON parent.oid = constraint_record.confrelid
+         JOIN pg_namespace parent_namespace
+           ON parent_namespace.oid = parent.relnamespace
+         JOIN pg_attribute child_attribute
+           ON child_attribute.attrelid = child.oid
+          AND child_attribute.attnum = constraint_record.conkey[1]
+         JOIN pg_attribute parent_attribute
+           ON parent_attribute.attrelid = parent.oid
+          AND parent_attribute.attnum = constraint_record.confkey[1]
+        WHERE constraint_record.contype = 'f'
+          AND constraint_record.convalidated
+          AND cardinality(constraint_record.conkey) = 1
+          AND cardinality(constraint_record.confkey) = 1
+          AND child_namespace.nspname = 'public'
+          AND parent_namespace.nspname = 'public'
+          AND child.relname = expected.child_table
+          AND child_attribute.attname = expected.child_column
+          AND parent.relname = expected.parent_table
+          AND parent_attribute.attname = expected.parent_column
+     )
+  ) AS "passed"
+`;
+
+const accessBoundariesStatement = (includeFutureTables: boolean) => {
+  const policies: readonly AuthAccessPolicy[] = includeFutureTables
+    ? [...Object.values(AUTH_ACCESS_POLICY), ...FUTURE_AUTH_ACCESS_POLICY]
+    : Object.values(AUTH_ACCESS_POLICY);
+  const expectedTables = policies.map(
+    ({ access, tableName }) => sql`(${tableName}::text, ${access}::text)`,
+  );
+  const expectedPolicies = policies.flatMap(({ policyNames, tableName }) =>
+    policyNames.map(
+      (policyName) => sql`(${tableName}::text, ${policyName}::text)`,
+    ),
+  );
+  return sql`
+    WITH expected_tables(table_name, access) AS (
+      VALUES ${sql.join(expectedTables, sql`, `)}
+    ),
+    expected_policies(table_name, policy_name) AS (
+      VALUES ${sql.join(expectedPolicies, sql`, `)}
+    )
+    SELECT
+      NOT EXISTS (
+        SELECT 1
+          FROM expected_tables expected
+          LEFT JOIN pg_namespace namespace
+            ON namespace.nspname = 'public'
+          LEFT JOIN pg_class table_record
+            ON table_record.relnamespace = namespace.oid
+           AND table_record.relname = expected.table_name
+         WHERE table_record.oid IS NULL OR NOT table_record.relrowsecurity
+      )
+      AND NOT EXISTS (
+        SELECT 1
+          FROM expected_policies expected
+         WHERE NOT EXISTS (
+           SELECT 1
+             FROM pg_policies policy
+            WHERE policy.schemaname = 'public'
+              AND policy.tablename = expected.table_name
+              AND policy.policyname = expected.policy_name
+              AND policy.roles @> ARRAY['stella']::name[]
+         )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+          FROM expected_tables expected
+         WHERE expected.access = 'denied'
+           AND (
+             has_table_privilege(
+               'stella',
+               format('%I.%I', 'public', expected.table_name),
+               'SELECT'
+             )
+             OR has_table_privilege(
+               'stella',
+               format('%I.%I', 'public', expected.table_name),
+               'INSERT'
+             )
+             OR has_table_privilege(
+               'stella',
+               format('%I.%I', 'public', expected.table_name),
+               'UPDATE'
+             )
+             OR has_table_privilege(
+               'stella',
+               format('%I.%I', 'public', expected.table_name),
+               'DELETE'
+             )
+             OR has_table_privilege(
+               'stella',
+               format('%I.%I', 'public', expected.table_name),
+               'TRUNCATE'
+             )
+             OR has_table_privilege(
+               'stella',
+               format('%I.%I', 'public', expected.table_name),
+               'REFERENCES'
+             )
+             OR has_table_privilege(
+               'stella',
+               format('%I.%I', 'public', expected.table_name),
+               'TRIGGER'
+             )
+           )
+      ) AS "passed"
+  `;
+};
+
+const providersClassifiedStatement = sql`
+  SELECT NOT EXISTS (
+    SELECT 1
+      FROM account
+     WHERE provider_id NOT IN (
+       ${AUTH_PROVIDER_IDS.CREDENTIAL},
+       ${AUTH_PROVIDER_IDS.GOOGLE},
+       ${AUTH_PROVIDER_IDS.MICROSOFT}
+     )
+  ) AS "passed"
+`;
+
+const credentialOwnershipStatement = sql`
+  SELECT NOT EXISTS (
+    SELECT 1
+     FROM account
+     WHERE provider_id = ${AUTH_PROVIDER_IDS.CREDENTIAL}
+       AND account_id IS DISTINCT FROM user_id
+  ) AS "passed"
+`;
+
+const accountIdentityCompleteStatement = sql`
+  SELECT NOT EXISTS (
+    SELECT 1
+      FROM account
+     WHERE issuer IS NULL
+        OR issuer = ''
+        OR account_id = ''
+  ) AS "passed"
+`;
+
+const accountIdentityUniqueStatement = sql`
+  SELECT NOT EXISTS (
+    SELECT 1
+      FROM account
+     GROUP BY issuer, account_id
+    HAVING count(*) > 1
+  ) AS "passed"
+`;
+
+const accountIssuersTrustedStatement = sql`
+  SELECT NOT EXISTS (
+    SELECT 1
+      FROM account
+     WHERE (provider_id = ${AUTH_PROVIDER_IDS.CREDENTIAL}
+            AND issuer IS DISTINCT FROM ${ACCOUNT_ISSUERS.CREDENTIAL})
+        OR (provider_id = ${AUTH_PROVIDER_IDS.GOOGLE}
+            AND issuer IS DISTINCT FROM ${ACCOUNT_ISSUERS.GOOGLE})
+        OR (provider_id = ${AUTH_PROVIDER_IDS.MICROSOFT}
+            AND (issuer NOT LIKE ${`${ACCOUNT_ISSUERS.MICROSOFT_PREFIX}%${ACCOUNT_ISSUERS.MICROSOFT_SUFFIX}`}
+                 OR account_id IS NOT DISTINCT FROM user_id))
+  ) AS "passed"
+`;
+
+const oauthClientResourceLinksStatement = sql`
+  SELECT NOT EXISTS (
+    SELECT 1
+      FROM oauth_client client
+     WHERE NOT EXISTS (
+       SELECT 1
+         FROM oauth_client_resource link
+        WHERE link.client_id = client.client_id
+     )
+  ) AS "passed"
+`;
+
+const oauthClientsClassifiedStatement = sql`
+  SELECT NOT EXISTS (
+    SELECT 1
+      FROM oauth_client
+     WHERE application_type NOT IN ('web', 'native')
+        OR application_type IS NULL
+        OR client_credentials_scopes IS NULL
+        OR token_endpoint_auth_method IS NULL
+  ) AS "passed"
+`;
+
+const oauthResourceReferencesStatement = sql`
+  SELECT NOT EXISTS (
+    SELECT 1
+      FROM oauth_client_resource link
+      LEFT JOIN oauth_client client ON client.client_id = link.client_id
+      LEFT JOIN oauth_resource resource ON resource.identifier = link.resource_id
+     WHERE client.client_id IS NULL OR resource.identifier IS NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1
+      FROM oauth_access_token token
+      CROSS JOIN LATERAL
+        unnest(coalesce(token.resources, ARRAY[]::text[])) requested(identifier)
+      LEFT JOIN oauth_resource resource
+        ON resource.identifier = requested.identifier
+      LEFT JOIN oauth_client_resource link
+        ON link.client_id = token.client_id
+       AND link.resource_id = requested.identifier
+     WHERE resource.identifier IS NULL OR link.client_id IS NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1
+      FROM oauth_refresh_token token
+      CROSS JOIN LATERAL
+        unnest(coalesce(token.resources, ARRAY[]::text[])) requested(identifier)
+      LEFT JOIN oauth_resource resource
+        ON resource.identifier = requested.identifier
+      LEFT JOIN oauth_client_resource link
+        ON link.client_id = token.client_id
+       AND link.resource_id = requested.identifier
+     WHERE resource.identifier IS NULL OR link.client_id IS NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1
+      FROM oauth_consent consent
+      CROSS JOIN LATERAL
+        unnest(coalesce(consent.resources, ARRAY[]::text[])) requested(identifier)
+      LEFT JOIN oauth_resource resource
+        ON resource.identifier = requested.identifier
+      LEFT JOIN oauth_client_resource link
+        ON link.client_id = consent.client_id
+       AND link.resource_id = requested.identifier
+     WHERE resource.identifier IS NULL OR link.client_id IS NULL
+  ) AS "passed"
+`;
+
+const finalAccountConstraintsStatement = sql`
+  SELECT
+    EXISTS (
+      SELECT 1
+        FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = 'account'
+         AND column_name = 'issuer'
+         AND is_nullable = 'NO'
+    )
+    AND EXISTS (
+      SELECT 1
+        FROM pg_index index_record
+        JOIN pg_class table_record ON table_record.oid = index_record.indrelid
+        JOIN pg_namespace namespace ON namespace.oid = table_record.relnamespace
+       WHERE namespace.nspname = 'public'
+         AND table_record.relname = 'account'
+         AND index_record.indisunique
+         AND index_record.indisvalid
+         AND (
+           SELECT array_agg(attribute.attname ORDER BY key_position.ordinality)
+             FROM unnest(index_record.indkey) WITH ORDINALITY key_position(attnum, ordinality)
+             JOIN pg_attribute attribute
+               ON attribute.attrelid = table_record.oid
+              AND attribute.attnum = key_position.attnum
+         ) = ARRAY['issuer', 'account_id']::name[]
+    ) AS "passed"
+`;
+
+const postMigrationConstraintsStatement = sql`
+  SELECT
+    EXISTS (
+      SELECT 1
+        FROM pg_index index_record
+        JOIN pg_class table_record ON table_record.oid = index_record.indrelid
+        JOIN pg_namespace namespace ON namespace.oid = table_record.relnamespace
+       WHERE namespace.nspname = 'public'
+         AND table_record.relname = ${FUTURE_AUTH_TABLES.OAUTH_CLIENT_RESOURCE}
+         AND index_record.indisunique
+         AND index_record.indisvalid
+         AND (
+           SELECT array_agg(attribute.attname ORDER BY key_position.ordinality)
+             FROM unnest(index_record.indkey) WITH ORDINALITY key_position(attnum, ordinality)
+             JOIN pg_attribute attribute
+               ON attribute.attrelid = table_record.oid
+              AND attribute.attnum = key_position.attnum
+         ) = ARRAY['client_id', 'resource_id']::name[]
+    )
+    AND EXISTS (
+      SELECT 1
+        FROM pg_index index_record
+        JOIN pg_class table_record ON table_record.oid = index_record.indrelid
+        JOIN pg_namespace namespace ON namespace.oid = table_record.relnamespace
+       WHERE namespace.nspname = 'public'
+         AND table_record.relname = ${FUTURE_AUTH_TABLES.OAUTH_RESOURCE}
+         AND index_record.indisunique
+         AND index_record.indisvalid
+         AND (
+           SELECT array_agg(attribute.attname ORDER BY key_position.ordinality)
+             FROM unnest(index_record.indkey) WITH ORDINALITY key_position(attnum, ordinality)
+             JOIN pg_attribute attribute
+               ON attribute.attrelid = table_record.oid
+              AND attribute.attnum = key_position.attnum
+         ) = ARRAY['identifier']::name[]
+    )
+    AND (
+      SELECT count(*)
+        FROM pg_constraint constraint_record
+        JOIN pg_class child ON child.oid = constraint_record.conrelid
+        JOIN pg_namespace namespace ON namespace.oid = child.relnamespace
+       WHERE namespace.nspname = 'public'
+         AND child.relname = ${FUTURE_AUTH_TABLES.OAUTH_CLIENT_RESOURCE}
+         AND constraint_record.contype = 'f'
+         AND constraint_record.convalidated
+    ) = 2
+    AND EXISTS (
+      SELECT 1
+        FROM pg_constraint constraint_record
+        JOIN pg_class child ON child.oid = constraint_record.conrelid
+        JOIN pg_namespace namespace ON namespace.oid = child.relnamespace
+       WHERE namespace.nspname = 'public'
+         AND child.relname = ${FUTURE_AUTH_TABLES.OAUTH_CLIENT_ASSERTION}
+         AND constraint_record.contype = 'p'
+         AND constraint_record.convalidated
+    )
+    AND NOT EXISTS (
+      SELECT 1
+        FROM pg_constraint constraint_record
+        JOIN pg_class child ON child.oid = constraint_record.conrelid
+        JOIN pg_namespace namespace ON namespace.oid = child.relnamespace
+       WHERE namespace.nspname = 'public'
+         AND child.relname IN (
+           ${FUTURE_AUTH_TABLES.OAUTH_CLIENT_RESOURCE},
+           ${FUTURE_AUTH_TABLES.OAUTH_CLIENT_ASSERTION}
+         )
+         AND constraint_record.contype IN ('p', 'f', 'u')
+         AND NOT constraint_record.convalidated
+    ) AS "passed"
+`;
+
+const booleanCheck = async (
+  database: BetterAuthAuditDatabase,
+  name: BetterAuthAuditCheckName,
+  statement: SQL,
+) => {
+  const queried = await queryRows(database, statement);
+  if (Result.isError(queried)) {
+    return queried;
+  }
+  const row = queried.value.at(0);
+  const passed = isRecord(row) ? requiredBoolean(row["passed"]) : null;
+  if (passed === null) {
+    return Result.err(
+      new BetterAuthAuditError({
+        code: "database-query-failed",
+        message: "Better Auth audit check returned an invalid result",
+      }),
+    );
+  }
+  return Result.ok({ name, status: passed ? "passed" : "failed" } as const);
+};
+
+const tableInventory = async (database: BetterAuthAuditDatabase) => {
+  const queried = await queryRows(database, tableInventoryStatement);
+  if (Result.isError(queried)) {
+    return queried;
+  }
+  const names = new Set<string>();
+  for (const row of queried.value) {
+    if (!isRecord(row)) {
+      return Result.err(
+        new BetterAuthAuditError({
+          code: "database-query-failed",
+          message: "Better Auth table inventory returned an invalid row",
+        }),
+      );
+    }
+    const name = requiredString(row["tableName"]);
+    if (name === null) {
+      return Result.err(
+        new BetterAuthAuditError({
+          code: "database-query-failed",
+          message: "Better Auth table inventory returned an invalid name",
+        }),
+      );
+    }
+    names.add(name);
+  }
+  return Result.ok(names);
+};
+
+const columnInventory = async (database: BetterAuthAuditDatabase) => {
+  const queried = await queryRows(database, columnInventoryStatement);
+  if (Result.isError(queried)) {
+    return queried;
+  }
+  const columns = new Set<string>();
+  for (const row of queried.value) {
+    if (!isRecord(row)) {
+      return Result.err(
+        new BetterAuthAuditError({
+          code: "database-query-failed",
+          message: "Better Auth column inventory returned an invalid row",
+        }),
+      );
+    }
+    const tableName = requiredString(row["tableName"]);
+    const columnName = requiredString(row["columnName"]);
+    if (tableName === null || columnName === null) {
+      return Result.err(
+        new BetterAuthAuditError({
+          code: "database-query-failed",
+          message: "Better Auth column inventory returned an invalid name",
+        }),
+      );
+    }
+    columns.add(`${tableName}.${columnName}`);
+  }
+  return Result.ok(columns);
+};
+
+type TableCensus = {
+  primaryKeyDigest: string;
+  rowContentDigest: string;
+  rowCount: string;
+};
+
+const readTableCensus = async (
+  database: BetterAuthAuditDatabase,
+  policy: AuthTableAuditPolicy,
+) => {
+  const primaryKeyHasher = new Bun.CryptoHasher("sha256");
+  const rowContentHasher = new Bun.CryptoHasher("sha256");
+  const { preservedColumns, tableName } = policy;
+  const preservedValues = preservedColumns.map((column) =>
+    sql.identifier(column),
+  );
+  const readPage = async (
+    after: string | null,
+    rowCount: bigint,
+  ): Promise<Result<TableCensus, BetterAuthAuditError>> => {
+    const statement =
+      after === null
+        ? sql`
+            SELECT id AS "primaryKey",
+                   jsonb_build_array(${sql.join(preservedValues, sql`, `)})::text
+                     AS "rowContent"
+              FROM ${sql.identifier(tableName)}
+             ORDER BY id
+             LIMIT ${PRIMARY_KEY_PAGE_SIZE}
+          `
+        : sql`
+            SELECT id AS "primaryKey",
+                   jsonb_build_array(${sql.join(preservedValues, sql`, `)})::text
+                     AS "rowContent"
+              FROM ${sql.identifier(tableName)}
+             WHERE id > ${after}
+             ORDER BY id
+             LIMIT ${PRIMARY_KEY_PAGE_SIZE}
+          `;
+    const queried = await queryRows(database, statement);
+    if (Result.isError(queried)) {
+      return queried;
+    }
+    let nextAfter = after;
+    let nextRowCount = rowCount;
+    for (const row of queried.value) {
+      const primaryKey = isRecord(row)
+        ? requiredString(row["primaryKey"])
+        : null;
+      const rowContent = isRecord(row)
+        ? requiredString(row["rowContent"])
+        : null;
+      if (
+        primaryKey === null ||
+        rowContent === null ||
+        (nextAfter !== null && primaryKey <= nextAfter)
+      ) {
+        return Result.err(
+          new BetterAuthAuditError({
+            code: "database-query-failed",
+            message: "Better Auth primary-key census returned invalid data",
+          }),
+        );
+      }
+      // PostgreSQL text cannot contain NUL, so this delimiter makes the
+      // ordered stream unambiguous without retaining identifiers in memory.
+      primaryKeyHasher.update(primaryKey);
+      primaryKeyHasher.update("\0");
+      rowContentHasher.update(primaryKey);
+      rowContentHasher.update("\0");
+      rowContentHasher.update(rowContent);
+      rowContentHasher.update("\0");
+      nextAfter = primaryKey;
+      nextRowCount += 1n;
+    }
+    if (queried.value.length < PRIMARY_KEY_PAGE_SIZE) {
+      return Result.ok({
+        primaryKeyDigest: primaryKeyHasher.digest("hex"),
+        rowContentDigest: rowContentHasher.digest("hex"),
+        rowCount: nextRowCount.toString(),
+      });
+    }
+    return await readPage(nextAfter, nextRowCount);
+  };
+
+  return await readPage(null, 0n);
+};
+
+const readAuthCensus = async (database: BetterAuthAuditDatabase) => {
+  const entries: BetterAuthAuditBaseline["tables"] = {};
+  const readModel = async (
+    index: number,
+  ): Promise<
+    Result<BetterAuthAuditBaseline["tables"], BetterAuthAuditError>
+  > => {
+    const model = AUTH_MODEL_NAMES.at(index);
+    if (model === undefined) {
+      return Result.ok(entries);
+    }
+    if (!isAuthModel(model)) {
+      return Result.err(
+        new BetterAuthAuditError({
+          code: "database-query-failed",
+          message: "Better Auth baseline policy contains an unknown model",
+        }),
+      );
+    }
+    const census = await readTableCensus(
+      database,
+      AUTH_TABLE_AUDIT_POLICY[model],
+    );
+    if (Result.isError(census)) {
+      return census;
+    }
+    entries[model] = census.value;
+    return await readModel(index + 1);
+  };
+
+  return await readModel(0);
+};
+
+const check = (
+  name: BetterAuthAuditCheckName,
+  passed: boolean,
+): BetterAuthAuditCheck => ({
+  name,
+  status: passed ? "passed" : "failed",
+});
+
+const report = (
+  mode: BetterAuthAuditMode,
+  checks: readonly BetterAuthAuditCheck[],
+): BetterAuthAuditReport => ({
+  checks,
+  mode,
+  status: checks.every(({ status }) => status === "passed")
+    ? "passed"
+    : "failed",
+});
+
+const createBaseline = (tables: BetterAuthAuditBaseline["tables"]) => ({
+  formatVersion: 1 as const,
+  tables,
+});
+
+const emptyBaseline = (): BetterAuthAuditBaseline =>
+  createBaseline(
+    Object.fromEntries(
+      AUTH_MODEL_NAMES.map((model) => [
+        model,
+        { primaryKeyDigest: "", rowContentDigest: "", rowCount: "0" },
+      ]),
+    ),
+  );
+
+type NamedAuditStatement = readonly [BetterAuthAuditCheckName, SQL];
+
+const evaluateBooleanChecks = async (
+  database: BetterAuthAuditDatabase,
+  statements: readonly NamedAuditStatement[],
+  checks: BetterAuthAuditCheck[],
+  index = 0,
+): Promise<Result<void, BetterAuthAuditError>> => {
+  const statement = statements.at(index);
+  if (statement === undefined) {
+    return Result.ok(undefined);
+  }
+  const [name, query] = statement;
+  const evaluated = await booleanCheck(database, name, query);
+  if (Result.isError(evaluated)) {
+    return evaluated;
+  }
+  checks.push(evaluated.value);
+  return await evaluateBooleanChecks(database, statements, checks, index + 1);
+};
+
+type RunBetterAuthMigrationAuditOptions = {
+  baseline: BetterAuthAuditBaseline | null;
+  database: BetterAuthAuditDatabase;
+  mode: BetterAuthAuditMode;
+};
+
+export const runBetterAuthMigrationAudit = async ({
+  baseline,
+  database,
+  mode,
+}: RunBetterAuthMigrationAuditOptions): Promise<
+  Result<AuditRunResult, BetterAuthAuditError>
+> => {
+  const checks: BetterAuthAuditCheck[] = [];
+  const tables = await tableInventory(database);
+  if (Result.isError(tables)) {
+    return tables;
+  }
+
+  const currentSchemaComplete = AUTH_TABLE_POLICIES.every(({ tableName }) =>
+    tables.value.has(tableName),
+  );
+  checks.push(
+    check(
+      BETTER_AUTH_AUDIT_CHECKS.CURRENT_SCHEMA_COMPLETE,
+      currentSchemaComplete,
+    ),
+  );
+  if (!currentSchemaComplete) {
+    return Result.ok({
+      baseline: emptyBaseline(),
+      report: report(mode, checks),
+    });
+  }
+
+  if (mode !== BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION) {
+    const columns = await columnInventory(database);
+    if (Result.isError(columns)) {
+      return columns;
+    }
+    const futureTablesComplete = Object.values(FUTURE_AUTH_TABLES).every(
+      (tableName) => tables.value.has(tableName),
+    );
+    const futureColumnsComplete = Object.entries(POST_BACKFILL_COLUMNS).every(
+      ([tableName, requiredColumns]) =>
+        requiredColumns.every((column) =>
+          columns.value.has(`${tableName}.${column}`),
+        ),
+    );
+    const postBackfillSchemaComplete =
+      futureTablesComplete && futureColumnsComplete;
+    checks.push(
+      check(
+        BETTER_AUTH_AUDIT_CHECKS.POST_BACKFILL_SCHEMA_COMPLETE,
+        postBackfillSchemaComplete,
+      ),
+    );
+    if (!postBackfillSchemaComplete) {
+      return Result.ok({
+        baseline: emptyBaseline(),
+        report: report(mode, checks),
+      });
+    }
+  }
+
+  const accessBoundaries = await booleanCheck(
+    database,
+    BETTER_AUTH_AUDIT_CHECKS.AUTH_ACCESS_BOUNDARIES,
+    accessBoundariesStatement(mode !== BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION),
+  );
+  if (Result.isError(accessBoundaries)) {
+    return accessBoundaries;
+  }
+  checks.push(accessBoundaries.value);
+
+  const commonChecks = [
+    [
+      BETTER_AUTH_AUDIT_CHECKS.AUTH_FOREIGN_KEYS_REACHABLE,
+      noForeignKeyOrphansStatement,
+    ],
+    [
+      BETTER_AUTH_AUDIT_CHECKS.AUTH_FOREIGN_KEYS_VALIDATED,
+      foreignKeysValidatedStatement,
+    ],
+    [
+      BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_PROVIDERS_CLASSIFIED,
+      providersClassifiedStatement,
+    ],
+    [
+      BETTER_AUTH_AUDIT_CHECKS.CREDENTIAL_ACCOUNT_OWNERSHIP,
+      credentialOwnershipStatement,
+    ],
+  ] as const;
+  const commonChecksEvaluated = await evaluateBooleanChecks(
+    database,
+    commonChecks,
+    checks,
+  );
+  if (Result.isError(commonChecksEvaluated)) {
+    return commonChecksEvaluated;
+  }
+
+  if (mode !== BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION) {
+    const postBackfillChecks = [
+      [
+        BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_COMPLETE,
+        accountIdentityCompleteStatement,
+      ],
+      [
+        BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_UNIQUE,
+        accountIdentityUniqueStatement,
+      ],
+      [
+        BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_ISSUERS_TRUSTED,
+        accountIssuersTrustedStatement,
+      ],
+      [
+        BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENT_RESOURCE_LINKS,
+        oauthClientResourceLinksStatement,
+      ],
+      [
+        BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENTS_CLASSIFIED,
+        oauthClientsClassifiedStatement,
+      ],
+      [
+        BETTER_AUTH_AUDIT_CHECKS.OAUTH_RESOURCE_REFERENCES,
+        oauthResourceReferencesStatement,
+      ],
+    ] as const;
+    const postBackfillChecksEvaluated = await evaluateBooleanChecks(
+      database,
+      postBackfillChecks,
+      checks,
+    );
+    if (Result.isError(postBackfillChecksEvaluated)) {
+      return postBackfillChecksEvaluated;
+    }
+  }
+
+  if (mode === BETTER_AUTH_AUDIT_MODES.POST_MIGRATION) {
+    const columns = await columnInventory(database);
+    if (Result.isError(columns)) {
+      return columns;
+    }
+    checks.push(
+      check(
+        BETTER_AUTH_AUDIT_CHECKS.FINAL_SCHEMA_COMPLETE,
+        Object.entries(POST_MIGRATION_COLUMNS).every(
+          ([tableName, requiredColumns]) =>
+            requiredColumns.every((column) =>
+              columns.value.has(`${tableName}.${column}`),
+            ),
+        ),
+      ),
+    );
+    const postMigrationChecks = [
+      [
+        BETTER_AUTH_AUDIT_CHECKS.FINAL_ACCOUNT_CONSTRAINTS,
+        finalAccountConstraintsStatement,
+      ],
+      [
+        BETTER_AUTH_AUDIT_CHECKS.POST_MIGRATION_CONSTRAINTS,
+        postMigrationConstraintsStatement,
+      ],
+    ] as const;
+    const postMigrationChecksEvaluated = await evaluateBooleanChecks(
+      database,
+      postMigrationChecks,
+      checks,
+    );
+    if (Result.isError(postMigrationChecksEvaluated)) {
+      return postMigrationChecksEvaluated;
+    }
+  }
+
+  const census = await readAuthCensus(database);
+  if (Result.isError(census)) {
+    return census;
+  }
+  const nextBaseline = createBaseline(census.value);
+  if (mode === BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION) {
+    checks.push(check(BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_BASELINED, true));
+  } else {
+    const preserved =
+      baseline !== null &&
+      AUTH_MODEL_NAMES.every((model) => {
+        const expected = baseline.tables[model];
+        const actual = census.value[model];
+        return (
+          expected !== undefined &&
+          actual !== undefined &&
+          expected.rowCount === actual.rowCount &&
+          expected.primaryKeyDigest === actual.primaryKeyDigest &&
+          expected.rowContentDigest === actual.rowContentDigest
+        );
+      });
+    checks.push(check(BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_PRESERVED, preserved));
+  }
+
+  const expectedCheckNames = CHECKS_BY_MODE[mode];
+  const evaluatedByName = new Set(checks.map(({ name }) => name));
+  if (expectedCheckNames.some((name) => !evaluatedByName.has(name))) {
+    return Result.err(
+      new BetterAuthAuditError({
+        code: "database-query-failed",
+        message: "Better Auth audit mode omitted a required check",
+      }),
+    );
+  }
+
+  return Result.ok({ baseline: nextBaseline, report: report(mode, checks) });
+};
+
+export const parseBetterAuthAuditBaseline = (
+  value: unknown,
+): Result<BetterAuthAuditBaseline, BetterAuthAuditError> => {
+  if (!isRecord(value) || value["formatVersion"] !== 1) {
+    return Result.err(
+      new BetterAuthAuditError({
+        code: "invalid-baseline",
+        message: "Better Auth audit baseline is invalid",
+      }),
+    );
+  }
+  const rawTables = value["tables"];
+  if (!isRecord(rawTables)) {
+    return Result.err(
+      new BetterAuthAuditError({
+        code: "invalid-baseline",
+        message: "Better Auth audit baseline is invalid",
+      }),
+    );
+  }
+  const keys = Object.keys(rawTables);
+  if (
+    keys.length !== AUTH_MODEL_NAMES.length ||
+    AUTH_MODEL_NAMES.some((model) => {
+      const table = rawTables[model];
+      return (
+        !isRecord(table) ||
+        Object.keys(table).length !== 3 ||
+        !/^\d+$/u.test(requiredString(table["rowCount"]) ?? "") ||
+        !/^[a-f\d]{64}$/u.test(
+          requiredString(table["primaryKeyDigest"]) ?? "",
+        ) ||
+        !/^[a-f\d]{64}$/u.test(requiredString(table["rowContentDigest"]) ?? "")
+      );
+    })
+  ) {
+    return Result.err(
+      new BetterAuthAuditError({
+        code: "invalid-baseline",
+        message: "Better Auth audit baseline is invalid",
+      }),
+    );
+  }
+  return Result.ok({
+    formatVersion: 1,
+    tables: Object.fromEntries(
+      AUTH_MODEL_NAMES.map((model) => {
+        const table = rawTables[model];
+        if (!isRecord(table)) {
+          return [
+            model,
+            { primaryKeyDigest: "", rowContentDigest: "", rowCount: "" },
+          ];
+        }
+        return [
+          model,
+          {
+            primaryKeyDigest: requiredString(table["primaryKeyDigest"]) ?? "",
+            rowContentDigest: requiredString(table["rowContentDigest"]) ?? "",
+            rowCount: requiredString(table["rowCount"]) ?? "",
+          },
+        ];
+      }),
+    ),
+  });
+};
+
+export const renderBetterAuthAuditReport = (
+  value: BetterAuthAuditReport,
+): string => `${JSON.stringify(value)}\n`;

--- a/apps/api/src/scripts/better-auth-migration-audit.logic.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.logic.ts
@@ -9,6 +9,7 @@
 import { Result, TaggedError } from "better-result";
 import { getColumns, getTableName, sql } from "drizzle-orm";
 import type { SQL, Table } from "drizzle-orm";
+import * as v from "valibot";
 
 import { authSchema } from "@/api/db/auth-schema";
 import { isRecord } from "@/api/lib/type-guards";
@@ -205,6 +206,9 @@ export const AUTH_TABLE_AUDIT_POLICY = {
   },
 } as const satisfies Record<AuthModel, AuthTableAuditPolicy>;
 
+const isAuthModel = (value: string): value is AuthModel =>
+  Object.hasOwn(AUTH_TABLE_AUDIT_POLICY, value);
+
 /**
  * Separate from table coverage on purpose. A 1.7-only table is audited but is
  * not expected in the baseline written by the 1.6 image. When `authSchema`
@@ -230,13 +234,10 @@ const AUTH_BASELINE_DISPOSITION = {
 const isPreservedDisposition = (value: "introduced" | "preserve") =>
   value === "preserve";
 
-const AUTH_MODEL_NAMES = Object.entries(AUTH_BASELINE_DISPOSITION)
-  .filter(([, disposition]) => isPreservedDisposition(disposition))
-  .map(([model]) => model);
+const AUTH_MODEL_NAMES = Object.keys(AUTH_BASELINE_DISPOSITION)
+  .filter(isAuthModel)
+  .filter((model) => isPreservedDisposition(AUTH_BASELINE_DISPOSITION[model]));
 const AUTH_TABLE_POLICIES = Object.values(AUTH_TABLE_AUDIT_POLICY);
-
-const isAuthModel = (value: string): value is AuthModel =>
-  Object.hasOwn(AUTH_TABLE_AUDIT_POLICY, value);
 
 const PRESERVED_AUTH_TABLE_NAMES = AUTH_MODEL_NAMES.flatMap((model) =>
   isAuthModel(model) ? [AUTH_TABLE_AUDIT_POLICY[model].tableName] : [],
@@ -1249,13 +1250,6 @@ const columnInventory = async (database: BetterAuthAuditDatabase) => {
   return Result.ok(columns);
 };
 
-type TableCensus = {
-  preservedColumns: readonly string[];
-  primaryKeyDigest: string;
-  rowContentDigest: string;
-  rowCount: string;
-};
-
 type ReadTableCensusOptions = {
   preservedColumns: readonly string[];
   tableName: string;
@@ -1270,35 +1264,50 @@ const readTableCensus = async (
   const preservedValues = preservedColumns.map((column) =>
     sql.identifier(column),
   );
-  const readPage = async (
-    after: string | null,
-    rowCount: bigint,
-  ): Promise<Result<TableCensus, BetterAuthAuditError>> => {
-    const statement =
-      after === null
-        ? sql`
-            SELECT id AS "primaryKey",
-                   jsonb_build_array(${sql.join(preservedValues, sql`, `)})::text
-                     AS "rowContent"
-              FROM ${sql.identifier(tableName)}
-             ORDER BY id
-             LIMIT ${PRIMARY_KEY_PAGE_SIZE}
-          `
-        : sql`
-            SELECT id AS "primaryKey",
-                   jsonb_build_array(${sql.join(preservedValues, sql`, `)})::text
-                     AS "rowContent"
-              FROM ${sql.identifier(tableName)}
-             WHERE id > ${after}
-             ORDER BY id
-             LIMIT ${PRIMARY_KEY_PAGE_SIZE}
-          `;
-    const queried = await queryRows(database, statement);
+  let after: string | null = null;
+  let rowCount = 0n;
+  const pages = {
+    [Symbol.asyncIterator]: () => {
+      let complete = false;
+      return {
+        next: async () => {
+          if (complete) {
+            return { done: true as const, value: undefined };
+          }
+          const statement =
+            after === null
+              ? sql`
+                  SELECT id AS "primaryKey",
+                         jsonb_build_array(${sql.join(preservedValues, sql`, `)})::text
+                           AS "rowContent"
+                    FROM ${sql.identifier(tableName)}
+                   ORDER BY id
+                   LIMIT ${PRIMARY_KEY_PAGE_SIZE}
+                `
+              : sql`
+                  SELECT id AS "primaryKey",
+                         jsonb_build_array(${sql.join(preservedValues, sql`, `)})::text
+                           AS "rowContent"
+                    FROM ${sql.identifier(tableName)}
+                   WHERE id > ${after}
+                   ORDER BY id
+                   LIMIT ${PRIMARY_KEY_PAGE_SIZE}
+                `;
+          const queried = await queryRows(database, statement);
+          complete =
+            Result.isError(queried) ||
+            queried.value.length < PRIMARY_KEY_PAGE_SIZE;
+          return { done: false as const, value: queried };
+        },
+      };
+    },
+  };
+
+  for await (const queried of pages) {
     if (Result.isError(queried)) {
       return queried;
     }
-    let nextAfter = after;
-    let nextRowCount = rowCount;
+    let nextAfter: string | null = after;
     for (const row of queried.value) {
       const primaryKey = isRecord(row)
         ? requiredString(row["primaryKey"])
@@ -1306,10 +1315,12 @@ const readTableCensus = async (
       const rowContent = isRecord(row)
         ? requiredString(row["rowContent"])
         : null;
+      // PostgreSQL's primary-key collation owns both ORDER BY and the cursor.
+      // JavaScript lexical comparison can disagree for mixed-case text IDs.
       if (
         primaryKey === null ||
         rowContent === null ||
-        (nextAfter !== null && primaryKey <= nextAfter)
+        (nextAfter !== null && primaryKey === nextAfter)
       ) {
         return Result.err(
           new BetterAuthAuditError({
@@ -1327,20 +1338,17 @@ const readTableCensus = async (
       rowContentHasher.update(rowContent);
       rowContentHasher.update("\0");
       nextAfter = primaryKey;
-      nextRowCount += 1n;
+      rowCount += 1n;
     }
-    if (queried.value.length < PRIMARY_KEY_PAGE_SIZE) {
-      return Result.ok({
-        preservedColumns,
-        primaryKeyDigest: primaryKeyHasher.digest("hex"),
-        rowContentDigest: rowContentHasher.digest("hex"),
-        rowCount: nextRowCount.toString(),
-      });
-    }
-    return await readPage(nextAfter, nextRowCount);
-  };
+    after = nextAfter;
+  }
 
-  return await readPage(null, 0n);
+  return Result.ok({
+    preservedColumns,
+    primaryKeyDigest: primaryKeyHasher.digest("hex"),
+    rowContentDigest: rowContentHasher.digest("hex"),
+    rowCount: rowCount.toString(),
+  });
 };
 
 const readAuthCensus = async (
@@ -1675,6 +1683,49 @@ export const runBetterAuthMigrationAudit = async ({
   return Result.ok({ baseline: nextBaseline, report: report(mode, checks) });
 };
 
+const digestSchema = v.pipe(v.string(), v.regex(/^[a-f\d]{64}$/u));
+const rowCountSchema = v.pipe(v.string(), v.regex(/^\d+$/u));
+
+const tableCensusSchema = (model: AuthModel) => {
+  const allowedColumns = new Set<string>(
+    AUTH_TABLE_AUDIT_POLICY[model].preservedColumns,
+  );
+  return v.strictObject({
+    preservedColumns: v.pipe(
+      v.array(v.string()),
+      v.minLength(1),
+      v.check(
+        (columns) => new Set(columns).size === columns.length,
+        "Preserved columns must be unique",
+      ),
+      v.check(
+        (columns) => columns.includes("id"),
+        "Preserved columns must include id",
+      ),
+      v.check(
+        (columns) => columns.every((column) => allowedColumns.has(column)),
+        "Preserved columns must be reviewed",
+      ),
+    ),
+    primaryKeyDigest: digestSchema,
+    rowContentDigest: digestSchema,
+    rowCount: rowCountSchema,
+  });
+};
+
+const betterAuthAuditBaselineSchema: v.GenericSchema<
+  unknown,
+  BetterAuthAuditBaseline
+> = v.strictObject({
+  accessPolicyDigest: digestSchema,
+  formatVersion: v.literal(2),
+  tables: v.strictObject(
+    Object.fromEntries(
+      AUTH_MODEL_NAMES.map((model) => [model, tableCensusSchema(model)]),
+    ),
+  ),
+});
+
 export const parseBetterAuthAuditBaseline = (
   value: unknown,
 ): Result<BetterAuthAuditBaseline, BetterAuthAuditError> => {
@@ -1685,78 +1736,8 @@ export const parseBetterAuthAuditBaseline = (
         message: "Better Auth audit baseline is invalid",
       }),
     );
-  if (
-    !isRecord(value) ||
-    Object.keys(value).length !== 3 ||
-    value["formatVersion"] !== 2 ||
-    !/^[a-f\d]{64}$/u.test(requiredString(value["accessPolicyDigest"]) ?? "")
-  ) {
-    return invalidBaseline();
-  }
-  const rawTables = value["tables"];
-  if (!isRecord(rawTables)) {
-    return invalidBaseline();
-  }
-  const keys = Object.keys(rawTables);
-  if (keys.length !== AUTH_MODEL_NAMES.length) {
-    return invalidBaseline();
-  }
-
-  const tables: BetterAuthAuditBaseline["tables"] = {};
-  for (const model of AUTH_MODEL_NAMES) {
-    if (!isAuthModel(model)) {
-      return invalidBaseline();
-    }
-    const table = rawTables[model];
-    if (!isRecord(table) || Object.keys(table).length !== 4) {
-      return invalidBaseline();
-    }
-    const rawPreservedColumns = table["preservedColumns"];
-    if (!Array.isArray(rawPreservedColumns)) {
-      return invalidBaseline();
-    }
-    const preservedColumns: string[] = [];
-    for (const column of rawPreservedColumns) {
-      if (typeof column !== "string") {
-        return invalidBaseline();
-      }
-      preservedColumns.push(column);
-    }
-    const uniqueColumns = new Set(preservedColumns);
-    const allowedColumns = new Set<string>(
-      AUTH_TABLE_AUDIT_POLICY[model].preservedColumns,
-    );
-    if (
-      preservedColumns.length === 0 ||
-      uniqueColumns.size !== preservedColumns.length ||
-      !uniqueColumns.has("id") ||
-      preservedColumns.some((column) => !allowedColumns.has(column))
-    ) {
-      return invalidBaseline();
-    }
-    const primaryKeyDigest = requiredString(table["primaryKeyDigest"]);
-    const rowContentDigest = requiredString(table["rowContentDigest"]);
-    const rowCount = requiredString(table["rowCount"]);
-    if (
-      !/^\d+$/u.test(rowCount ?? "") ||
-      !/^[a-f\d]{64}$/u.test(primaryKeyDigest ?? "") ||
-      !/^[a-f\d]{64}$/u.test(rowContentDigest ?? "")
-    ) {
-      return invalidBaseline();
-    }
-    tables[model] = {
-      preservedColumns,
-      primaryKeyDigest: primaryKeyDigest ?? "",
-      rowContentDigest: rowContentDigest ?? "",
-      rowCount: rowCount ?? "",
-    };
-  }
-
-  return Result.ok({
-    accessPolicyDigest: requiredString(value["accessPolicyDigest"]) ?? "",
-    formatVersion: 2,
-    tables,
-  });
+  const parsed = v.safeParse(betterAuthAuditBaselineSchema, value);
+  return parsed.success ? Result.ok(parsed.output) : invalidBaseline();
 };
 
 export const renderBetterAuthAuditReport = (

--- a/apps/api/src/scripts/better-auth-migration-audit.logic.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.logic.ts
@@ -51,8 +51,14 @@ type AuthTableAuditPolicy = {
 
 type AuthAccessPolicy = {
   access: "denied" | "scoped";
-  policyNames: readonly string[];
+  policies: readonly AuthPolicyRule[];
   tableName: string;
+};
+
+type AuthPolicyRule = {
+  command: "ALL" | "SELECT" | "UPDATE";
+  name: string;
+  predicate: "deny" | "scoped-read" | "scoped-write";
 };
 
 const columnNames = (table: Table) =>
@@ -232,78 +238,168 @@ const AUTH_TABLE_POLICIES = Object.values(AUTH_TABLE_AUDIT_POLICY);
 const isAuthModel = (value: string): value is AuthModel =>
   Object.hasOwn(AUTH_TABLE_AUDIT_POLICY, value);
 
+const PRESERVED_AUTH_TABLE_NAMES = AUTH_MODEL_NAMES.flatMap((model) =>
+  isAuthModel(model) ? [AUTH_TABLE_AUDIT_POLICY[model].tableName] : [],
+);
+
 const AUTH_ACCESS_POLICY = {
   account: {
     access: "denied",
-    policyNames: ["auth_no_stella_access"],
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
     tableName: AUTH_TABLE_AUDIT_POLICY.account.tableName,
   },
   apikey: {
     access: "denied",
-    policyNames: ["auth_no_stella_access"],
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
     tableName: AUTH_TABLE_AUDIT_POLICY.apikey.tableName,
   },
   invitation: {
     access: "denied",
-    policyNames: ["auth_no_stella_access"],
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
     tableName: AUTH_TABLE_AUDIT_POLICY.invitation.tableName,
   },
   jwks: {
     access: "denied",
-    policyNames: ["auth_no_stella_access"],
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
     tableName: AUTH_TABLE_AUDIT_POLICY.jwks.tableName,
   },
   member: {
     access: "scoped",
-    policyNames: [
-      "auth_member_select",
-      "auth_member_update_last_active_workspace",
+    policies: [
+      {
+        command: "SELECT",
+        name: "auth_member_select",
+        predicate: "scoped-read",
+      },
+      {
+        command: "UPDATE",
+        name: "auth_member_update_last_active_workspace",
+        predicate: "scoped-write",
+      },
     ],
     tableName: AUTH_TABLE_AUDIT_POLICY.member.tableName,
   },
   oauthAccessToken: {
     access: "denied",
-    policyNames: ["auth_no_stella_access"],
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
     tableName: AUTH_TABLE_AUDIT_POLICY.oauthAccessToken.tableName,
   },
   oauthClient: {
     access: "denied",
-    policyNames: ["auth_no_stella_access"],
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
     tableName: AUTH_TABLE_AUDIT_POLICY.oauthClient.tableName,
   },
   oauthConsent: {
     access: "denied",
-    policyNames: ["auth_no_stella_access"],
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
     tableName: AUTH_TABLE_AUDIT_POLICY.oauthConsent.tableName,
   },
   oauthRefreshToken: {
     access: "denied",
-    policyNames: ["auth_no_stella_access"],
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
     tableName: AUTH_TABLE_AUDIT_POLICY.oauthRefreshToken.tableName,
   },
   organization: {
     access: "scoped",
-    policyNames: ["auth_organization_select"],
+    policies: [
+      {
+        command: "SELECT",
+        name: "auth_organization_select",
+        predicate: "scoped-read",
+      },
+    ],
     tableName: AUTH_TABLE_AUDIT_POLICY.organization.tableName,
   },
   session: {
     access: "denied",
-    policyNames: ["auth_no_stella_access"],
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
     tableName: AUTH_TABLE_AUDIT_POLICY.session.tableName,
   },
   twoFactor: {
     access: "denied",
-    policyNames: ["auth_no_stella_access"],
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
     tableName: AUTH_TABLE_AUDIT_POLICY.twoFactor.tableName,
   },
   user: {
     access: "scoped",
-    policyNames: ["auth_user_select"],
+    policies: [
+      {
+        command: "SELECT",
+        name: "auth_user_select",
+        predicate: "scoped-read",
+      },
+    ],
     tableName: AUTH_TABLE_AUDIT_POLICY.user.tableName,
   },
   verification: {
     access: "denied",
-    policyNames: ["auth_no_stella_access"],
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
     tableName: AUTH_TABLE_AUDIT_POLICY.verification.tableName,
   },
 } as const satisfies Record<AuthModel, AuthAccessPolicy>;
@@ -317,7 +413,13 @@ const FUTURE_AUTH_TABLES = {
 const FUTURE_AUTH_ACCESS_POLICY = Object.values(FUTURE_AUTH_TABLES).map(
   (tableName) => ({
     access: "denied" as const,
-    policyNames: ["auth_no_stella_access"],
+    policies: [
+      {
+        command: "ALL" as const,
+        name: "auth_no_stella_access",
+        predicate: "deny" as const,
+      },
+    ],
     tableName,
   }),
 );
@@ -471,10 +573,16 @@ export type BetterAuthAuditCheck = {
 };
 
 export type BetterAuthAuditBaseline = {
-  formatVersion: 1;
+  accessPolicyDigest: string;
+  formatVersion: 2;
   tables: Record<
     string,
-    { primaryKeyDigest: string; rowContentDigest: string; rowCount: string }
+    {
+      preservedColumns: readonly string[];
+      primaryKeyDigest: string;
+      rowContentDigest: string;
+      rowCount: string;
+    }
   >;
 };
 
@@ -625,16 +733,23 @@ const accessBoundariesStatement = (includeFutureTables: boolean) => {
   const expectedTables = policies.map(
     ({ access, tableName }) => sql`(${tableName}::text, ${access}::text)`,
   );
-  const expectedPolicies = policies.flatMap(({ policyNames, tableName }) =>
-    policyNames.map(
-      (policyName) => sql`(${tableName}::text, ${policyName}::text)`,
-    ),
+  const expectedPolicies = policies.flatMap(
+    ({ policies: policyRules, tableName }) =>
+      policyRules.map(
+        ({ command, name, predicate }) =>
+          sql`(
+          ${tableName}::text,
+          ${name}::text,
+          ${command}::text,
+          ${predicate}::text
+        )`,
+      ),
   );
   return sql`
     WITH expected_tables(table_name, access) AS (
       VALUES ${sql.join(expectedTables, sql`, `)}
     ),
-    expected_policies(table_name, policy_name) AS (
+    expected_policies(table_name, policy_name, command, predicate) AS (
       VALUES ${sql.join(expectedPolicies, sql`, `)}
     )
     SELECT
@@ -657,8 +772,40 @@ const accessBoundariesStatement = (includeFutureTables: boolean) => {
             WHERE policy.schemaname = 'public'
               AND policy.tablename = expected.table_name
               AND policy.policyname = expected.policy_name
-              AND policy.roles @> ARRAY['stella']::name[]
+              AND policy.permissive = 'PERMISSIVE'
+              AND policy.cmd = expected.command
+              AND policy.roles = ARRAY['stella']::name[]
+              AND CASE expected.predicate
+                    WHEN 'deny' THEN
+                      policy.qual = 'false' AND policy.with_check = 'false'
+                    WHEN 'scoped-read' THEN
+                      policy.qual IS NOT NULL
+                      AND policy.qual <> 'true'
+                      AND policy.with_check IS NULL
+                    WHEN 'scoped-write' THEN
+                      policy.qual IS NOT NULL
+                      AND policy.qual <> 'true'
+                      AND policy.with_check = policy.qual
+                    ELSE false
+                  END
          )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+          FROM pg_policies policy
+          JOIN expected_tables expected
+            ON expected.table_name = policy.tablename
+         WHERE policy.schemaname = 'public'
+           AND (
+             policy.roles @> ARRAY['stella']::name[]
+             OR policy.roles @> ARRAY['public']::name[]
+           )
+           AND NOT EXISTS (
+             SELECT 1
+               FROM expected_policies expected_policy
+              WHERE expected_policy.table_name = policy.tablename
+                AND expected_policy.policy_name = policy.policyname
+           )
       )
       AND NOT EXISTS (
         SELECT 1
@@ -703,6 +850,54 @@ const accessBoundariesStatement = (includeFutureTables: boolean) => {
            )
       ) AS "passed"
   `;
+};
+
+const accessPolicyInventoryStatement = sql`
+  SELECT jsonb_build_array(
+           table_record.relname,
+           table_record.relrowsecurity,
+           policy.policyname,
+           policy.permissive,
+           policy.cmd,
+           policy.roles::text,
+           policy.qual,
+           policy.with_check
+         )::text AS "fingerprintPart"
+    FROM pg_class table_record
+    JOIN pg_namespace namespace ON namespace.oid = table_record.relnamespace
+    LEFT JOIN pg_policies policy
+      ON policy.schemaname = namespace.nspname
+     AND policy.tablename = table_record.relname
+   WHERE namespace.nspname = 'public'
+     AND table_record.relname IN (${sql.join(
+       PRESERVED_AUTH_TABLE_NAMES.map((tableName) => sql`${tableName}`),
+       sql`, `,
+     )})
+   ORDER BY table_record.relname, policy.policyname
+`;
+
+const readAccessPolicyDigest = async (database: BetterAuthAuditDatabase) => {
+  const queried = await queryRows(database, accessPolicyInventoryStatement);
+  if (Result.isError(queried)) {
+    return queried;
+  }
+  const hasher = new Bun.CryptoHasher("sha256");
+  for (const row of queried.value) {
+    const fingerprintPart = isRecord(row)
+      ? requiredString(row["fingerprintPart"])
+      : null;
+    if (fingerprintPart === null) {
+      return Result.err(
+        new BetterAuthAuditError({
+          code: "database-query-failed",
+          message: "Better Auth access policy inventory returned invalid data",
+        }),
+      );
+    }
+    hasher.update(fingerprintPart);
+    hasher.update("\0");
+  }
+  return Result.ok(hasher.digest("hex"));
 };
 
 const providersClassifiedStatement = sql`
@@ -847,6 +1042,8 @@ const finalAccountConstraintsStatement = sql`
          AND table_record.relname = 'account'
          AND index_record.indisunique
          AND index_record.indisvalid
+         AND index_record.indpred IS NULL
+         AND index_record.indexprs IS NULL
          AND (
            SELECT array_agg(attribute.attname ORDER BY key_position.ordinality)
              FROM unnest(index_record.indkey) WITH ORDINALITY key_position(attnum, ordinality)
@@ -858,6 +1055,15 @@ const finalAccountConstraintsStatement = sql`
 `;
 
 const postMigrationConstraintsStatement = sql`
+  WITH expected_resource_foreign_keys(
+    child_column,
+    parent_table,
+    parent_column
+  ) AS (
+    VALUES
+      ('client_id'::text, 'oauth_client'::text, 'client_id'::text),
+      ('resource_id'::text, 'oauth_resource'::text, 'identifier'::text)
+  )
   SELECT
     EXISTS (
       SELECT 1
@@ -868,6 +1074,8 @@ const postMigrationConstraintsStatement = sql`
          AND table_record.relname = ${FUTURE_AUTH_TABLES.OAUTH_CLIENT_RESOURCE}
          AND index_record.indisunique
          AND index_record.indisvalid
+         AND index_record.indpred IS NULL
+         AND index_record.indexprs IS NULL
          AND (
            SELECT array_agg(attribute.attname ORDER BY key_position.ordinality)
              FROM unnest(index_record.indkey) WITH ORDINALITY key_position(attnum, ordinality)
@@ -885,6 +1093,8 @@ const postMigrationConstraintsStatement = sql`
          AND table_record.relname = ${FUTURE_AUTH_TABLES.OAUTH_RESOURCE}
          AND index_record.indisunique
          AND index_record.indisvalid
+         AND index_record.indpred IS NULL
+         AND index_record.indexprs IS NULL
          AND (
            SELECT array_agg(attribute.attname ORDER BY key_position.ordinality)
              FROM unnest(index_record.indkey) WITH ORDINALITY key_position(attnum, ordinality)
@@ -892,6 +1102,36 @@ const postMigrationConstraintsStatement = sql`
                ON attribute.attrelid = table_record.oid
               AND attribute.attnum = key_position.attnum
          ) = ARRAY['identifier']::name[]
+    )
+    AND NOT EXISTS (
+      SELECT 1
+        FROM expected_resource_foreign_keys expected
+       WHERE NOT EXISTS (
+         SELECT 1
+           FROM pg_constraint constraint_record
+           JOIN pg_class child ON child.oid = constraint_record.conrelid
+           JOIN pg_namespace child_namespace
+             ON child_namespace.oid = child.relnamespace
+           JOIN pg_class parent ON parent.oid = constraint_record.confrelid
+           JOIN pg_namespace parent_namespace
+             ON parent_namespace.oid = parent.relnamespace
+           JOIN pg_attribute child_attribute
+             ON child_attribute.attrelid = child.oid
+            AND child_attribute.attnum = constraint_record.conkey[1]
+           JOIN pg_attribute parent_attribute
+             ON parent_attribute.attrelid = parent.oid
+            AND parent_attribute.attnum = constraint_record.confkey[1]
+          WHERE constraint_record.contype = 'f'
+            AND constraint_record.convalidated
+            AND cardinality(constraint_record.conkey) = 1
+            AND cardinality(constraint_record.confkey) = 1
+            AND child_namespace.nspname = 'public'
+            AND parent_namespace.nspname = 'public'
+            AND child.relname = ${FUTURE_AUTH_TABLES.OAUTH_CLIENT_RESOURCE}
+            AND child_attribute.attname = expected.child_column
+            AND parent.relname = expected.parent_table
+            AND parent_attribute.attname = expected.parent_column
+       )
     )
     AND (
       SELECT count(*)
@@ -902,7 +1142,7 @@ const postMigrationConstraintsStatement = sql`
          AND child.relname = ${FUTURE_AUTH_TABLES.OAUTH_CLIENT_RESOURCE}
          AND constraint_record.contype = 'f'
          AND constraint_record.convalidated
-    ) = 2
+    ) = (SELECT count(*) FROM expected_resource_foreign_keys)
     AND EXISTS (
       SELECT 1
         FROM pg_constraint constraint_record
@@ -1010,18 +1250,23 @@ const columnInventory = async (database: BetterAuthAuditDatabase) => {
 };
 
 type TableCensus = {
+  preservedColumns: readonly string[];
   primaryKeyDigest: string;
   rowContentDigest: string;
   rowCount: string;
 };
 
+type ReadTableCensusOptions = {
+  preservedColumns: readonly string[];
+  tableName: string;
+};
+
 const readTableCensus = async (
   database: BetterAuthAuditDatabase,
-  policy: AuthTableAuditPolicy,
+  { preservedColumns, tableName }: ReadTableCensusOptions,
 ) => {
   const primaryKeyHasher = new Bun.CryptoHasher("sha256");
   const rowContentHasher = new Bun.CryptoHasher("sha256");
-  const { preservedColumns, tableName } = policy;
   const preservedValues = preservedColumns.map((column) =>
     sql.identifier(column),
   );
@@ -1086,6 +1331,7 @@ const readTableCensus = async (
     }
     if (queried.value.length < PRIMARY_KEY_PAGE_SIZE) {
       return Result.ok({
+        preservedColumns,
         primaryKeyDigest: primaryKeyHasher.digest("hex"),
         rowContentDigest: rowContentHasher.digest("hex"),
         rowCount: nextRowCount.toString(),
@@ -1097,7 +1343,10 @@ const readTableCensus = async (
   return await readPage(null, 0n);
 };
 
-const readAuthCensus = async (database: BetterAuthAuditDatabase) => {
+const readAuthCensus = async (
+  database: BetterAuthAuditDatabase,
+  baseline: BetterAuthAuditBaseline | null,
+) => {
   const entries: BetterAuthAuditBaseline["tables"] = {};
   const readModel = async (
     index: number,
@@ -1116,10 +1365,12 @@ const readAuthCensus = async (database: BetterAuthAuditDatabase) => {
         }),
       );
     }
-    const census = await readTableCensus(
-      database,
-      AUTH_TABLE_AUDIT_POLICY[model],
-    );
+    const policy = AUTH_TABLE_AUDIT_POLICY[model];
+    const census = await readTableCensus(database, {
+      preservedColumns:
+        baseline?.tables[model]?.preservedColumns ?? policy.preservedColumns,
+      tableName: policy.tableName,
+    });
     if (Result.isError(census)) {
       return census;
     }
@@ -1149,19 +1400,29 @@ const report = (
     : "failed",
 });
 
-const createBaseline = (tables: BetterAuthAuditBaseline["tables"]) => ({
-  formatVersion: 1 as const,
+const createBaseline = (
+  tables: BetterAuthAuditBaseline["tables"],
+  accessPolicyDigest: string,
+): BetterAuthAuditBaseline => ({
+  accessPolicyDigest,
+  formatVersion: 2,
   tables,
 });
 
 const emptyBaseline = (): BetterAuthAuditBaseline =>
   createBaseline(
     Object.fromEntries(
-      AUTH_MODEL_NAMES.map((model) => [
+      Object.entries(AUTH_TABLE_AUDIT_POLICY).map(([model, policy]) => [
         model,
-        { primaryKeyDigest: "", rowContentDigest: "", rowCount: "0" },
+        {
+          preservedColumns: policy.preservedColumns,
+          primaryKeyDigest: "",
+          rowContentDigest: "",
+          rowCount: "0",
+        },
       ]),
     ),
+    "0".repeat(64),
   );
 
 type NamedAuditStatement = readonly [BetterAuthAuditCheckName, SQL];
@@ -1250,6 +1511,10 @@ export const runBetterAuthMigrationAudit = async ({
     }
   }
 
+  const accessPolicyDigest = await readAccessPolicyDigest(database);
+  if (Result.isError(accessPolicyDigest)) {
+    return accessPolicyDigest;
+  }
   const accessBoundaries = await booleanCheck(
     database,
     BETTER_AUTH_AUDIT_CHECKS.AUTH_ACCESS_BOUNDARIES,
@@ -1258,7 +1523,15 @@ export const runBetterAuthMigrationAudit = async ({
   if (Result.isError(accessBoundaries)) {
     return accessBoundaries;
   }
-  checks.push(accessBoundaries.value);
+  checks.push(
+    check(
+      BETTER_AUTH_AUDIT_CHECKS.AUTH_ACCESS_BOUNDARIES,
+      accessBoundaries.value.status === "passed" &&
+        (mode === BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION ||
+          (baseline !== null &&
+            baseline.accessPolicyDigest === accessPolicyDigest.value)),
+    ),
+  );
 
   const commonChecks = [
     [
@@ -1360,11 +1633,11 @@ export const runBetterAuthMigrationAudit = async ({
     }
   }
 
-  const census = await readAuthCensus(database);
+  const census = await readAuthCensus(database, baseline);
   if (Result.isError(census)) {
     return census;
   }
-  const nextBaseline = createBaseline(census.value);
+  const nextBaseline = createBaseline(census.value, accessPolicyDigest.value);
   if (mode === BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION) {
     checks.push(check(BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_BASELINED, true));
   } else {
@@ -1376,6 +1649,10 @@ export const runBetterAuthMigrationAudit = async ({
         return (
           expected !== undefined &&
           actual !== undefined &&
+          expected.preservedColumns.length === actual.preservedColumns.length &&
+          expected.preservedColumns.every(
+            (column, index) => actual.preservedColumns.at(index) === column,
+          ) &&
           expected.rowCount === actual.rowCount &&
           expected.primaryKeyDigest === actual.primaryKeyDigest &&
           expected.rowContentDigest === actual.rowContentDigest
@@ -1401,67 +1678,84 @@ export const runBetterAuthMigrationAudit = async ({
 export const parseBetterAuthAuditBaseline = (
   value: unknown,
 ): Result<BetterAuthAuditBaseline, BetterAuthAuditError> => {
-  if (!isRecord(value) || value["formatVersion"] !== 1) {
-    return Result.err(
+  const invalidBaseline = () =>
+    Result.err(
       new BetterAuthAuditError({
         code: "invalid-baseline",
         message: "Better Auth audit baseline is invalid",
       }),
     );
+  if (
+    !isRecord(value) ||
+    Object.keys(value).length !== 3 ||
+    value["formatVersion"] !== 2 ||
+    !/^[a-f\d]{64}$/u.test(requiredString(value["accessPolicyDigest"]) ?? "")
+  ) {
+    return invalidBaseline();
   }
   const rawTables = value["tables"];
   if (!isRecord(rawTables)) {
-    return Result.err(
-      new BetterAuthAuditError({
-        code: "invalid-baseline",
-        message: "Better Auth audit baseline is invalid",
-      }),
-    );
+    return invalidBaseline();
   }
   const keys = Object.keys(rawTables);
-  if (
-    keys.length !== AUTH_MODEL_NAMES.length ||
-    AUTH_MODEL_NAMES.some((model) => {
-      const table = rawTables[model];
-      return (
-        !isRecord(table) ||
-        Object.keys(table).length !== 3 ||
-        !/^\d+$/u.test(requiredString(table["rowCount"]) ?? "") ||
-        !/^[a-f\d]{64}$/u.test(
-          requiredString(table["primaryKeyDigest"]) ?? "",
-        ) ||
-        !/^[a-f\d]{64}$/u.test(requiredString(table["rowContentDigest"]) ?? "")
-      );
-    })
-  ) {
-    return Result.err(
-      new BetterAuthAuditError({
-        code: "invalid-baseline",
-        message: "Better Auth audit baseline is invalid",
-      }),
-    );
+  if (keys.length !== AUTH_MODEL_NAMES.length) {
+    return invalidBaseline();
   }
+
+  const tables: BetterAuthAuditBaseline["tables"] = {};
+  for (const model of AUTH_MODEL_NAMES) {
+    if (!isAuthModel(model)) {
+      return invalidBaseline();
+    }
+    const table = rawTables[model];
+    if (!isRecord(table) || Object.keys(table).length !== 4) {
+      return invalidBaseline();
+    }
+    const rawPreservedColumns = table["preservedColumns"];
+    if (!Array.isArray(rawPreservedColumns)) {
+      return invalidBaseline();
+    }
+    const preservedColumns: string[] = [];
+    for (const column of rawPreservedColumns) {
+      if (typeof column !== "string") {
+        return invalidBaseline();
+      }
+      preservedColumns.push(column);
+    }
+    const uniqueColumns = new Set(preservedColumns);
+    const allowedColumns = new Set<string>(
+      AUTH_TABLE_AUDIT_POLICY[model].preservedColumns,
+    );
+    if (
+      preservedColumns.length === 0 ||
+      uniqueColumns.size !== preservedColumns.length ||
+      !uniqueColumns.has("id") ||
+      preservedColumns.some((column) => !allowedColumns.has(column))
+    ) {
+      return invalidBaseline();
+    }
+    const primaryKeyDigest = requiredString(table["primaryKeyDigest"]);
+    const rowContentDigest = requiredString(table["rowContentDigest"]);
+    const rowCount = requiredString(table["rowCount"]);
+    if (
+      !/^\d+$/u.test(rowCount ?? "") ||
+      !/^[a-f\d]{64}$/u.test(primaryKeyDigest ?? "") ||
+      !/^[a-f\d]{64}$/u.test(rowContentDigest ?? "")
+    ) {
+      return invalidBaseline();
+    }
+    tables[model] = {
+      preservedColumns,
+      primaryKeyDigest: primaryKeyDigest ?? "",
+      rowContentDigest: rowContentDigest ?? "",
+      rowCount: rowCount ?? "",
+    };
+  }
+
   return Result.ok({
-    formatVersion: 1,
-    tables: Object.fromEntries(
-      AUTH_MODEL_NAMES.map((model) => {
-        const table = rawTables[model];
-        if (!isRecord(table)) {
-          return [
-            model,
-            { primaryKeyDigest: "", rowContentDigest: "", rowCount: "" },
-          ];
-        }
-        return [
-          model,
-          {
-            primaryKeyDigest: requiredString(table["primaryKeyDigest"]) ?? "",
-            rowContentDigest: requiredString(table["rowContentDigest"]) ?? "",
-            rowCount: requiredString(table["rowCount"]) ?? "",
-          },
-        ];
-      }),
-    ),
+    accessPolicyDigest: requiredString(value["accessPolicyDigest"]) ?? "",
+    formatVersion: 2,
+    tables,
   });
 };
 

--- a/apps/api/src/scripts/better-auth-migration-audit.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.test.ts
@@ -28,11 +28,13 @@ afterAll(async () => {
 });
 
 const baselinePayload = () => ({
-  formatVersion: 1,
+  accessPolicyDigest: "c".repeat(64),
+  formatVersion: 2,
   tables: Object.fromEntries(
-    Object.keys(AUTH_TABLE_AUDIT_POLICY).map((model) => [
+    Object.entries(AUTH_TABLE_AUDIT_POLICY).map(([model, policy]) => [
       model,
       {
+        preservedColumns: [...policy.preservedColumns],
         primaryKeyDigest: "a".repeat(64),
         rowContentDigest: "b".repeat(64),
         rowCount: "7",
@@ -71,10 +73,11 @@ describe("Better Auth migration audit command", () => {
   test("rejects incomplete, expanded, or malformed private baselines", () => {
     expect(parseBetterAuthAuditBaseline(baselinePayload()).status).toBe("ok");
     expect(
-      parseBetterAuthAuditBaseline({ formatVersion: 1, tables: {} }).status,
+      parseBetterAuthAuditBaseline({ formatVersion: 2, tables: {} }).status,
     ).toBe("error");
     const expanded = baselinePayload();
     expanded.tables["unreviewedAuthTable"] = {
+      preservedColumns: ["id"],
       primaryKeyDigest: "a".repeat(64),
       rowContentDigest: "b".repeat(64),
       rowCount: "0",
@@ -86,6 +89,21 @@ describe("Better Auth migration audit command", () => {
       first.primaryKeyDigest = "not-a-digest";
     }
     expect(parseBetterAuthAuditBaseline(malformed).status).toBe("error");
+
+    const unknownColumn = baselinePayload();
+    const unknownColumnTable = Object.values(unknownColumn.tables).at(0);
+    if (unknownColumnTable) {
+      unknownColumnTable.preservedColumns.push("unreviewed_column");
+    }
+    expect(parseBetterAuthAuditBaseline(unknownColumn).status).toBe("error");
+
+    const duplicateColumn = baselinePayload();
+    const duplicateColumnTable = Object.values(duplicateColumn.tables).at(0);
+    const duplicated = duplicateColumnTable?.preservedColumns.at(0);
+    if (duplicateColumnTable && duplicated) {
+      duplicateColumnTable.preservedColumns.push(duplicated);
+    }
+    expect(parseBetterAuthAuditBaseline(duplicateColumn).status).toBe("error");
   });
 
   test("creates the baseline once, accepts an identical rerun, and refuses replacement", async () => {

--- a/apps/api/src/scripts/better-auth-migration-audit.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.test.ts
@@ -1,0 +1,166 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  parseBetterAuthAuditArgs,
+  persistBetterAuthAuditBaseline,
+  readBetterAuthAuditBaseline,
+} from "@/api/scripts/better-auth-migration-audit";
+import {
+  AUTH_TABLE_AUDIT_POLICY,
+  BETTER_AUTH_AUDIT_CHECKS,
+  BETTER_AUTH_AUDIT_MODES,
+  parseBetterAuthAuditBaseline,
+  renderBetterAuthAuditReport,
+} from "@/api/scripts/better-auth-migration-audit.logic";
+import type { BetterAuthAuditReport } from "@/api/scripts/better-auth-migration-audit.logic";
+
+const temporaryDirectories: string[] = [];
+
+afterAll(async () => {
+  await Promise.all(
+    temporaryDirectories.map(
+      async (directory) => await rm(directory, { recursive: true }),
+    ),
+  );
+});
+
+const baselinePayload = () => ({
+  formatVersion: 1,
+  tables: Object.fromEntries(
+    Object.keys(AUTH_TABLE_AUDIT_POLICY).map((model) => [
+      model,
+      {
+        primaryKeyDigest: "a".repeat(64),
+        rowContentDigest: "b".repeat(64),
+        rowCount: "7",
+      },
+    ]),
+  ),
+});
+
+describe("Better Auth migration audit command", () => {
+  test("requires one explicit mode and a private baseline path", () => {
+    expect(
+      parseBetterAuthAuditArgs([
+        BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        "--baseline",
+        "/private/baseline.json",
+      ]),
+    ).toMatchObject({
+      status: "ok",
+      value: {
+        baselinePath: "/private/baseline.json",
+        mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+      },
+    });
+    for (const args of [
+      [],
+      [BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION],
+      ["unknown", "--baseline", "/private/baseline.json"],
+      [BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION, "--output", "x"],
+      [BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION, "--baseline", ""],
+      [BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION, "--baseline", "x", "extra"],
+    ]) {
+      expect(parseBetterAuthAuditArgs(args).status).toBe("error");
+    }
+  });
+
+  test("rejects incomplete, expanded, or malformed private baselines", () => {
+    expect(parseBetterAuthAuditBaseline(baselinePayload()).status).toBe("ok");
+    expect(
+      parseBetterAuthAuditBaseline({ formatVersion: 1, tables: {} }).status,
+    ).toBe("error");
+    const expanded = baselinePayload();
+    expanded.tables["unreviewedAuthTable"] = {
+      primaryKeyDigest: "a".repeat(64),
+      rowContentDigest: "b".repeat(64),
+      rowCount: "0",
+    };
+    expect(parseBetterAuthAuditBaseline(expanded).status).toBe("error");
+    const malformed = baselinePayload();
+    const first = Object.values(malformed.tables).at(0);
+    if (first) {
+      first.primaryKeyDigest = "not-a-digest";
+    }
+    expect(parseBetterAuthAuditBaseline(malformed).status).toBe("error");
+  });
+
+  test("creates the baseline once, accepts an identical rerun, and refuses replacement", async () => {
+    const directory = await mkdtemp(
+      path.join(tmpdir(), "stella-better-auth-audit-"),
+    );
+    temporaryDirectories.push(directory);
+    const baselinePath = path.join(directory, "baseline.json");
+    const parsed = parseBetterAuthAuditBaseline(baselinePayload());
+    expect(parsed.status).toBe("ok");
+    if (parsed.status === "error") {
+      return;
+    }
+
+    expect(
+      (await persistBetterAuthAuditBaseline(baselinePath, parsed.value)).status,
+    ).toBe("ok");
+    expect(
+      (await persistBetterAuthAuditBaseline(baselinePath, parsed.value)).status,
+    ).toBe("ok");
+    expect((await readBetterAuthAuditBaseline(baselinePath)).status).toBe("ok");
+
+    const changedPayload = baselinePayload();
+    const first = Object.values(changedPayload.tables).at(0);
+    if (first) {
+      first.rowCount = "8";
+    }
+    const changed = parseBetterAuthAuditBaseline(changedPayload);
+    expect(changed.status).toBe("ok");
+    if (changed.status === "ok") {
+      const conflict = await persistBetterAuthAuditBaseline(
+        baselinePath,
+        changed.value,
+      );
+      expect(conflict).toMatchObject({
+        error: { code: "baseline-conflict" },
+        status: "error",
+      });
+    }
+
+    await chmod(baselinePath, 0o644);
+    expect((await readBetterAuthAuditBaseline(baselinePath)).status).toBe(
+      "error",
+    );
+    await chmod(baselinePath, 0o600);
+    const linkedPath = path.join(directory, "linked-baseline.json");
+    await symlink(baselinePath, linkedPath);
+    expect((await readBetterAuthAuditBaseline(linkedPath)).status).toBe(
+      "error",
+    );
+  });
+
+  test("renders only stable names and statuses", () => {
+    const report = {
+      checks: [
+        {
+          name: BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_PRESERVED,
+          status: "failed",
+        },
+      ],
+      mode: BETTER_AUTH_AUDIT_MODES.POST_MIGRATION,
+      status: "failed",
+    } as const satisfies BetterAuthAuditReport;
+    const rendered = renderBetterAuthAuditReport(report);
+
+    expect(JSON.parse(rendered)).toEqual(report);
+    for (const forbidden of [
+      "person@example.invalid",
+      "client-secret-sentinel",
+      "token-sentinel",
+      "postgres://database.invalid",
+      "primary-key-digest-sentinel",
+      '"rowCount"',
+    ]) {
+      expect(rendered).not.toContain(forbidden);
+    }
+  });
+});

--- a/apps/api/src/scripts/better-auth-migration-audit.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.ts
@@ -1,0 +1,285 @@
+/**
+ * Usage:
+ *   bun src/scripts/better-auth-migration-audit.ts <mode> --baseline <path>
+ *
+ * The baseline belongs on the rehearsal task's private tmpfs. It contains
+ * auth-table counts and primary-key digests, and must never be uploaded as an
+ * artifact. The command itself emits only redacted named check results.
+ */
+
+import { Result, TaggedError } from "better-result";
+import { SQL } from "bun";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sql";
+import { constants } from "node:fs";
+import { open, writeFile } from "node:fs/promises";
+
+import { hasSecureDatabaseTransport, resolveDatabaseUrl } from "@/api/db-url";
+import { isRecord } from "@/api/lib/type-guards";
+import {
+  BETTER_AUTH_AUDIT_MODES,
+  BetterAuthAuditError,
+  parseBetterAuthAuditBaseline,
+  renderBetterAuthAuditReport,
+  runBetterAuthMigrationAudit,
+} from "@/api/scripts/better-auth-migration-audit.logic";
+import type {
+  BetterAuthAuditBaseline,
+  BetterAuthAuditMode,
+} from "@/api/scripts/better-auth-migration-audit.logic";
+
+const EXIT_CODE = {
+  CONFIGURATION_OR_QUERY_FAILURE: 2,
+  INVARIANT_FAILURE: 1,
+  SUCCESS: 0,
+} as const;
+
+const TRANSACTION_TIMEOUT = "60s";
+const LOCK_TIMEOUT = "2s";
+
+class BetterAuthAuditCommandError extends TaggedError(
+  "BetterAuthAuditCommandError",
+)<{
+  code:
+    | "baseline-conflict"
+    | "baseline-read-failed"
+    | "baseline-write-failed"
+    | "invalid-arguments";
+  message: string;
+}> {}
+
+type BetterAuthAuditCommandArgs = {
+  baselinePath: string;
+  mode: BetterAuthAuditMode;
+};
+
+const isAuditMode = (value: string): value is BetterAuthAuditMode =>
+  Object.values(BETTER_AUTH_AUDIT_MODES).some((mode) => mode === value);
+
+export const parseBetterAuthAuditArgs = (
+  args: readonly string[],
+): Result<BetterAuthAuditCommandArgs, BetterAuthAuditCommandError> => {
+  const mode = args.at(0);
+  const baselineFlag = args.at(1);
+  const baselinePath = args.at(2);
+  if (
+    mode === undefined ||
+    !isAuditMode(mode) ||
+    baselineFlag !== "--baseline" ||
+    baselinePath === undefined ||
+    baselinePath.length === 0 ||
+    args.length !== 3
+  ) {
+    return Result.err(
+      new BetterAuthAuditCommandError({
+        code: "invalid-arguments",
+        message:
+          "Usage: better-auth-migration-audit <pre-migration|post-backfill|post-migration> --baseline <private-path>",
+      }),
+    );
+  }
+  return Result.ok({ baselinePath, mode });
+};
+
+const isNodeErrorCode = (value: unknown, code: string): boolean =>
+  isRecord(value) && value["code"] === code;
+
+export const readBetterAuthAuditBaseline = async (
+  path: string,
+): Promise<
+  Result<
+    BetterAuthAuditBaseline,
+    BetterAuthAuditCommandError | BetterAuthAuditError
+  >
+> => {
+  const loaded = await Result.tryPromise({
+    try: async () => {
+      const handle = await open(path, constants.O_NOFOLLOW);
+      try {
+        const metadata = await handle.stat();
+        if (!metadata.isFile() || metadata.mode % 0o100 !== 0) {
+          throw new BetterAuthAuditCommandError({
+            code: "baseline-read-failed",
+            message: "Better Auth audit baseline is not a private regular file",
+          });
+        }
+        const parsed: unknown = JSON.parse(await handle.readFile("utf-8"));
+        return parsed;
+      } finally {
+        await handle.close();
+      }
+    },
+    catch: () =>
+      new BetterAuthAuditCommandError({
+        code: "baseline-read-failed",
+        message: "Better Auth audit baseline could not be read",
+      }),
+  });
+  if (Result.isError(loaded)) {
+    return loaded;
+  }
+  return parseBetterAuthAuditBaseline(loaded.value);
+};
+
+/**
+ * Create once, or accept a byte-equivalent rerun. Never replace a different
+ * baseline: that would erase the only row-set evidence the later phases use.
+ */
+export const persistBetterAuthAuditBaseline = async (
+  path: string,
+  baseline: BetterAuthAuditBaseline,
+): Promise<
+  Result<void, BetterAuthAuditCommandError | BetterAuthAuditError>
+> => {
+  const content = `${JSON.stringify(baseline)}\n`;
+  const written = await Result.tryPromise({
+    try: async () => {
+      await writeFile(path, content, {
+        encoding: "utf-8",
+        flag: "wx",
+        mode: 0o600,
+      });
+    },
+    catch: (cause) => cause,
+  });
+  if (Result.isOk(written)) {
+    return Result.ok(undefined);
+  }
+  if (!isNodeErrorCode(written.error, "EEXIST")) {
+    return Result.err(
+      new BetterAuthAuditCommandError({
+        code: "baseline-write-failed",
+        message: "Better Auth audit baseline could not be written",
+      }),
+    );
+  }
+
+  const existing = await readBetterAuthAuditBaseline(path);
+  if (existing.status === "error") {
+    return existing;
+  }
+  if (JSON.stringify(existing.value) !== JSON.stringify(baseline)) {
+    return Result.err(
+      new BetterAuthAuditCommandError({
+        code: "baseline-conflict",
+        message: "Better Auth audit baseline conflicts with the current census",
+      }),
+    );
+  }
+  return Result.ok(undefined);
+};
+
+const run = async (
+  args: readonly string[],
+): Promise<
+  Result<number, BetterAuthAuditCommandError | BetterAuthAuditError>
+> => {
+  const parsed = parseBetterAuthAuditArgs(args);
+  if (Result.isError(parsed)) {
+    return parsed;
+  }
+
+  let baseline: BetterAuthAuditBaseline | null = null;
+  if (parsed.value.mode !== BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION) {
+    const loadedBaseline = await readBetterAuthAuditBaseline(
+      parsed.value.baselinePath,
+    );
+    if (loadedBaseline.status === "error") {
+      return loadedBaseline;
+    }
+    baseline = loadedBaseline.value;
+  }
+
+  const databaseUrl = resolveDatabaseUrl();
+  if (!databaseUrl || !hasSecureDatabaseTransport(databaseUrl)) {
+    return Result.err(
+      new BetterAuthAuditCommandError({
+        code: "invalid-arguments",
+        message: "Better Auth audit requires a secure database connection",
+      }),
+    );
+  }
+
+  const client = new SQL({ url: databaseUrl, max: 1 });
+  const database = drizzle({ client });
+  const executed = await Result.tryPromise({
+    try: async () =>
+      await database.transaction(async (transaction) => {
+        await transaction.execute(
+          sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`,
+        );
+        await transaction.execute(
+          sql`SELECT set_config('statement_timeout', ${TRANSACTION_TIMEOUT}, true)`,
+        );
+        await transaction.execute(
+          sql`SELECT set_config('lock_timeout', ${LOCK_TIMEOUT}, true)`,
+        );
+        await transaction.execute(
+          sql`SELECT set_config('idle_in_transaction_session_timeout', ${TRANSACTION_TIMEOUT}, true)`,
+        );
+        return await runBetterAuthMigrationAudit({
+          baseline,
+          database: {
+            execute: async (statement) => await transaction.execute(statement),
+          },
+          mode: parsed.value.mode,
+        });
+      }),
+    catch: (cause) =>
+      new BetterAuthAuditError({
+        cause,
+        code: "database-query-failed",
+        message: "Better Auth audit transaction failed",
+      }),
+  });
+  await client.end();
+  if (Result.isError(executed)) {
+    return executed;
+  }
+  if (Result.isError(executed.value)) {
+    return executed.value;
+  }
+
+  const { report, baseline: nextBaseline } = executed.value.value;
+  if (
+    parsed.value.mode === BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION &&
+    report.status === "passed"
+  ) {
+    const persisted = await persistBetterAuthAuditBaseline(
+      parsed.value.baselinePath,
+      nextBaseline,
+    );
+    if (Result.isError(persisted)) {
+      return persisted;
+    }
+  }
+
+  process.stdout.write(renderBetterAuthAuditReport(report));
+  return Result.ok(
+    report.status === "passed"
+      ? EXIT_CODE.SUCCESS
+      : EXIT_CODE.INVARIANT_FAILURE,
+  );
+};
+
+if (import.meta.main) {
+  run(Bun.argv.slice(2))
+    .then((result) => {
+      if (Result.isError(result)) {
+        process.stderr.write(
+          `${JSON.stringify({ code: result.error.code, status: "error" })}\n`,
+        );
+        process.exitCode = EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
+        return undefined;
+      }
+      process.exitCode = result.value;
+      return undefined;
+    })
+    .catch(() => {
+      process.stderr.write(
+        `${JSON.stringify({ code: "audit-execution-failed", status: "error" })}\n`,
+      );
+      process.exitCode = EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
+      return undefined;
+    });
+}

--- a/apps/api/src/tests/pglite-test-db.ts
+++ b/apps/api/src/tests/pglite-test-db.ts
@@ -1,6 +1,6 @@
 import { PGlite } from "@electric-sql/pglite";
 import { pg_trgm } from "@electric-sql/pglite/contrib/pg_trgm";
-import { sql } from "drizzle-orm";
+import { getTableName, sql } from "drizzle-orm";
 import type { SQLWrapper } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
@@ -64,19 +64,7 @@ export const withPublicLawReaderRole = async <
   });
 
 const AUTH_TABLES_SQL = [
-  "user",
-  "organization",
-  "member",
-  "session",
-  "account",
-  "verification",
-  "invitation",
-  "jwks",
-  "oauth_client",
-  "oauth_refresh_token",
-  "oauth_access_token",
-  "oauth_consent",
-  "two_factor",
+  ...Object.values(authSchema.authSchema).map((table) => getTableName(table)),
   "agent_registration",
   "agent_trusted_issuer",
   "agent_delegation",


### PR DESCRIPTION
Adds a read-only Better Auth migration audit with redacted, mode-specific invariant reports and a private baseline contract.

Packages the command in the API image, adds synthetic database corruption coverage, and derives PGlite auth-table revocations from the schema source of truth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only Better Auth migration audit command covering pre-migration, post-backfill and post-migration checks.
  - Added secure baseline handling, redacted JSON reports and distinct status outcomes for successful, failed or misconfigured audits.
  - Added a package script for running the audit with environment configuration.

- **Bug Fixes**
  - Improved migration verification for schema integrity, access policies, foreign keys, ownership and orphaned records.

- **Tests**
  - Added comprehensive automated coverage for audit logic, database scenarios, security safeguards and release-image smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->