### PR TITLE
chore(api): consolidate MCP validation plumbing

### DIFF
--- a/apps/api/src/mcp/billing-tools.ts
+++ b/apps/api/src/mcp/billing-tools.ts
@@ -11,7 +11,6 @@ import { createTimeEntryHandler } from "@/api/handlers/time-entries/create";
 import { deleteTimeEntryHandler } from "@/api/handlers/time-entries/delete";
 import { updateTimeEntryHandler } from "@/api/handlers/time-entries/update";
 import { readOrgEntitlementHandler } from "@/api/handlers/usage/get-entitlement";
-import type { AuditEvent, AuditRecorder } from "@/api/lib/audit-log";
 import { TIME_ENTRY_VISIBILITY } from "@/api/lib/billing-constants";
 import { resolveRate } from "@/api/lib/billing-rates";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -56,6 +55,7 @@ import type {
 } from "@/api/mcp/tool-types";
 import { defineMcpToolSet } from "@/api/mcp/tool-types";
 import {
+  bindWorkspaceRecorder,
   confirmProp,
   DEFAULT_LIST_LIMIT,
   ensureActiveWorkspace,
@@ -564,38 +564,6 @@ export const BILLING_TOOL_DEFINITIONS = [
   },
 ] as const satisfies readonly McpToolDefinition[];
 
-/**
- * Wrap the request-scoped recorder so audit rows written by the reused backing
- * handlers carry the resolved workspace. The MCP recorder binds workspaceId to
- * null (org-scoped); workspace-scoped handlers build events without a
- * workspaceId, so inject it per event (an event that sets its own wins).
- */
-const bindWorkspaceRecorder =
-  (
-    context: McpRequestContext,
-    workspaceId: SafeId<"workspace">,
-  ): AuditRecorder =>
-  async (tx, event) => {
-    const events: AuditEvent[] = Array.isArray(event) ? event : [event];
-    for (const e of events) {
-      if (e.workspaceId === undefined) {
-        e.workspaceId = workspaceId;
-      }
-    }
-    await context.recordAuditEvent(tx, events);
-  };
-
-/**
- * Prefer a cross-field (`partial_check`) validation message when present,
- * falling back to the hand-written shape hint for structural failures.
- */
-const crossFieldOrGeneric = (
-  issues: readonly v.BaseIssue<unknown>[],
-  genericMessage: string,
-): string =>
-  issues.find((issue) => issue.type === "partial_check")?.message ??
-  genericMessage;
-
 /** Resolve the accessible workspace that owns a time entry, or null. */
 const resolveTimeEntryWorkspace = async ({
   context,
@@ -747,10 +715,8 @@ const handleListTimeEntriesTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { matter_id?: string, time_entry_id?: string, entity_id?: string, user_id?: string, date_from?: YYYY-MM-DD, date_to?: YYYY-MM-DD, status?: string, limit?: integer, cursor?: string }",
-      ),
     });
   }
   const input = parsed.output;
@@ -1047,10 +1013,8 @@ const handleSaveTimeEntryTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { time_entry_id?, matter_id?, entity_id?, date_worked?, timezone_id?, duration_minutes?, narrative?, invoice_narrative?, billable?, no_charge?, task_code?, activity_code? }",
-      ),
     });
   }
   const input = parsed.output;
@@ -1391,10 +1355,8 @@ const handleListInvoicesTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { matter_id?: string, invoice_id?: string, limit?: integer, cursor?: string }",
-      ),
     });
   }
   const input = parsed.output;

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -893,20 +893,6 @@ const decodeEntityPageCursor = (
   return { createdAt, id: brandPersistedEntityId(id) };
 };
 
-/**
- * Prefer a cross-field (`partial_check`) validation message when one is
- * present, falling back to the hand-written shape hint for structural failures.
- * The partialCheck rules carry actionable messages ("parent_id requires mode
- * 'children'", etc.); valibot's raw structural errors are less useful to a tool
- * caller than the generic shape summary.
- */
-const crossFieldOrGeneric = (
-  issues: readonly v.BaseIssue<unknown>[],
-  genericMessage: string,
-): string =>
-  issues.find((issue) => issue.type === "partial_check")?.message ??
-  genericMessage;
-
 const listDocumentsArgsSchema = v.pipe(
   v.strictObject({
     matter_id: v.pipe(v.string(), v.minLength(1)),
@@ -968,10 +954,8 @@ const handleListDocumentsTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { matter_id: string, mode?: 'flat'|'children', parent_id?: string, limit?: integer, cursor?: string }",
-      ),
     });
   }
 
@@ -1648,10 +1632,7 @@ const handleReadDocumentTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
-        "Invalid input: expected { entity_id: string, ... }",
-      ),
+      message: "Invalid input: expected { entity_id: string, ... }",
     });
   }
 
@@ -2220,10 +2201,8 @@ const handleSaveDocumentTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { matter_id, name, parent_id?, kind? } to create, or { entity_id, name?/parent_id?/move_to_root?/version_id?/label?/description? } to update",
-      ),
     });
   }
   const input = parsed.output;

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -18,7 +18,6 @@ import {
   listPlaybookDefinitionsHandler,
 } from "@/api/handlers/playbooks/read";
 import { captureError } from "@/api/lib/analytics/capture";
-import type { AuditEvent, AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import type {
   DELETED_TRUE_PROJECTION,
@@ -68,6 +67,7 @@ import type {
 } from "@/api/mcp/tool-types";
 import { defineMcpToolSet } from "@/api/mcp/tool-types";
 import {
+  bindWorkspaceRecorder,
   confirmProp,
   ensureActiveWorkspace,
   enumProp,
@@ -810,38 +810,6 @@ export const KNOWLEDGE_TOOL_DEFINITIONS = [
   },
 ] as const satisfies readonly McpToolDefinition[];
 
-/**
- * Wrap the request-scoped recorder so audit rows written by the reused backing
- * handlers carry the resolved workspace. The MCP recorder binds workspaceId to
- * null (org-scoped); the workspace-scoped playbook run builds its EXECUTE event
- * without a workspaceId, so inject it per event (an event that sets its own wins).
- */
-const bindWorkspaceRecorder =
-  (
-    context: McpRequestContext,
-    workspaceId: SafeId<"workspace">,
-  ): AuditRecorder =>
-  async (tx, event) => {
-    const events: AuditEvent[] = Array.isArray(event) ? event : [event];
-    for (const e of events) {
-      if (e.workspaceId === undefined) {
-        e.workspaceId = workspaceId;
-      }
-    }
-    await context.recordAuditEvent(tx, events);
-  };
-
-/**
- * Prefer a cross-field (`partial_check`) validation message when present,
- * falling back to the hand-written shape hint for structural failures.
- */
-const crossFieldOrGeneric = (
-  issues: readonly v.BaseIssue<unknown>[],
-  genericMessage: string,
-): string =>
-  issues.find((issue) => issue.type === "partial_check")?.message ??
-  genericMessage;
-
 // --- list_clauses -------------------------------------------------------
 
 const listClausesArgsSchema = v.pipe(
@@ -1038,10 +1006,8 @@ const handleListClausesTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { clause_id?: string, version_id?: string, category_id?: string, query?: string, include_categories?: boolean, limit?: integer, cursor?: string }",
-      ),
     });
   }
   const input = parsed.output;
@@ -1225,10 +1191,8 @@ const handleSaveClauseTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { clause_id?: string, title?: string, body?: array, category_id?: string|null, language?: string|null, description?: string|null, usage_notes?: string|null, metadata?: object|null, snapshot_version?: boolean }",
-      ),
     });
   }
   const input = parsed.output;
@@ -1465,10 +1429,8 @@ const handleListPlaybooksTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { playbook_id?: string, limit?: integer, cursor?: string }",
-      ),
     });
   }
   const input = parsed.output;

--- a/apps/api/src/mcp/matter-tools.ts
+++ b/apps/api/src/mcp/matter-tools.ts
@@ -549,17 +549,6 @@ export const MATTER_TOOL_DEFINITIONS = [
   },
 ] as const satisfies readonly McpToolDefinition[];
 
-/**
- * Prefer a cross-field (`partial_check`) validation message when present,
- * falling back to the hand-written shape hint for structural failures.
- */
-const crossFieldOrGeneric = (
-  issues: readonly v.BaseIssue<unknown>[],
-  genericMessage: string,
-): string =>
-  issues.find((issue) => issue.type === "partial_check")?.message ??
-  genericMessage;
-
 // --- save_matter --------------------------------------------------------
 
 const saveMatterArgsSchema = v.pipe(
@@ -622,10 +611,8 @@ const handleSaveMatterTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { matter_id?: string, name?: string, client_id?: string, reference?: string, billing_reference?: string|null, status?: 'active'|'archived' }",
-      ),
     });
   }
   const input = parsed.output;
@@ -945,10 +932,8 @@ const handleSaveContactTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { contact_id?: string, type?: 'person'|'organization', display_name?: string, first_name?: string|null, last_name?: string|null, organization_name?: string|null, notes?: string|null }",
-      ),
     });
   }
   const input = parsed.output;
@@ -1283,10 +1268,8 @@ const handleListTasksTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { matter_id?: string, task_id?: string, date_from?: YYYY-MM-DD, date_to?: YYYY-MM-DD, status?: string, limit?: integer, cursor?: string }",
-      ),
     });
   }
   const input = parsed.output;
@@ -1750,10 +1733,8 @@ const handleSaveTaskTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { task_id?, matter_id?, name?, item_type?, status?, priority?, due_date?, workflow_reason?, add_assignee_user_id?, remove_assignee_user_id?, link_entity_id?, unlink_link_id? }",
-      ),
     });
   }
   const input = parsed.output;
@@ -2029,10 +2010,8 @@ const handleLinkMatterContactTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { matter_id: string, contact_id?: string, role?: string, workspace_contact_id?: string }",
-      ),
     });
   }
   const input = parsed.output;

--- a/apps/api/src/mcp/research-admin-tools.ts
+++ b/apps/api/src/mcp/research-admin-tools.ts
@@ -334,17 +334,6 @@ export const RESEARCH_ADMIN_TOOL_DEFINITIONS = [
   },
 ] as const satisfies readonly McpToolDefinition[];
 
-/**
- * Prefer a cross-field (`partial_check`) validation message when present,
- * falling back to the hand-written shape hint for structural failures.
- */
-const crossFieldOrGeneric = (
-  issues: readonly v.BaseIssue<unknown>[],
-  genericMessage: string,
-): string =>
-  issues.find((issue) => issue.type === "partial_check")?.message ??
-  genericMessage;
-
 // --- search_legislation -------------------------------------------------
 
 const searchLegislationArgsSchema = v.pipe(
@@ -478,10 +467,8 @@ const handleSearchLegislationTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected search filters (query/title/…) or law_id with optional block_id/relation_type/full_text",
-      ),
     });
   }
   const input = parsed.output;
@@ -587,10 +574,8 @@ const handleListAuditLogTool: McpToolHandler = async ({ args, context }) => {
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { workspace_id?, action?, resource_type?, resource_id?, user_id?, from?, to?, limit?, cursor? }",
-      ),
     });
   }
   const input = parsed.output;
@@ -806,10 +791,8 @@ const handleManageOrganizationTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { action: 'add_member'|'remove_member'|'update_org_settings', matter_id?, user_id?, matter_number_pattern?, matter_number_padding?, prompt_caching_enabled?, document_processing_mode? }",
-      ),
     });
   }
   const input = parsed.output;

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -1403,17 +1403,6 @@ const handleSaveFilledTemplateTool: McpToolHandler = async ({
   return toolDataResult(persistence.value.value);
 };
 
-/**
- * Prefer a cross-field (`partial_check`) validation message when present,
- * falling back to the hand-written shape hint for structural failures.
- */
-const crossFieldOrGeneric = (
-  issues: readonly v.BaseIssue<unknown>[],
-  genericMessage: string,
-): string =>
-  issues.find((issue) => issue.type === "partial_check")?.message ??
-  genericMessage;
-
 // Create branch of save_template: a new template from an uploaded DOCX, with an
 // optional field-configuration overlay. Reused from the former create_template
 // tool.
@@ -1570,10 +1559,8 @@ const handleSaveTemplateTool: TypedMcpToolHandler<
   if (!parsed.success) {
     return validationErrorResult({
       issues: parsed.issues,
-      message: crossFieldOrGeneric(
-        parsed.issues,
+      message:
         "Invalid input: expected { docx_base64: string, name: string, fields?: array } to create, or { template_id: string, fields: array } to configure",
-      ),
     });
   }
   const input = parsed.output;

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -295,11 +295,8 @@ export const mapValibotIssues = (
   }));
 
 /**
- * `validation_error` envelope for a failed tool argument parse. `message` is the
- * caller-facing summary (today's collapsed single line); `issues` is the raw
- * Valibot issue list, mapped to the structured `{ path, message }[]` the CLI and
- * agents branch on. This is the single sink every `safeParse` failure path in
- * the tool modules routes through, replacing the legacy code-less `errorResult`.
+ * Build the shared validation envelope. Prefer an actionable cross-field issue
+ * as its summary; `message` is the fallback for structural failures.
  */
 export const validationErrorResult = ({
   hint,
@@ -314,7 +311,9 @@ export const validationErrorResult = ({
     code: "validation_error",
     hint,
     issues: mapValibotIssues(issues),
-    message,
+    message:
+      issues.find((issue) => issue.type === "partial_check")?.message ??
+      message,
   });
 
 /** `not_found` envelope for a resource that does not exist or is inaccessible. */


### PR DESCRIPTION
## Summary

- centralize actionable Valibot cross-field messages in the shared validation-error sink
- reuse the existing workspace-scoped audit recorder in billing and knowledge tools
- remove 149 net lines of duplicated runtime code without deleting tests or generated contracts

CC on behalf of jan-kubica