### PR TITLE
chore(api): remove duplicate validation plumbing

### DIFF
--- a/apps/api/src/handlers/chat/tools/execute/chat-code-mode.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-code-mode.ts
@@ -26,6 +26,7 @@ import type { ChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import type { ChatToolDefectMemo } from "@/api/lib/chat/tool-defect-memo";
 import { knownDefectRefusalMessage } from "@/api/lib/chat/tool-defect-memo";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
+import { isRecord } from "@/api/lib/type-guards";
 import {
   DEFAULT_MCP_TOOL_DEFINITIONS,
   getStaticMcpToolDefinition,
@@ -62,9 +63,6 @@ import {
  * read surface reachable.
  */
 const EAGER_CHAT_READ_TOOLS = new Set<RegistryReadToolName>(["list_matters"]);
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 /**
  * The chat-projectable read tools, in registry order. Derived from the

--- a/apps/api/src/handlers/chat/tools/registry-adapter/input-ref-hydration.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/input-ref-hydration.ts
@@ -9,6 +9,7 @@ import type {
   ChatRefInputState,
   ChatUnresolvedInputRefContext,
 } from "@/api/lib/chat/ref-token";
+import { isRecord } from "@/api/lib/type-guards";
 
 import { NATIVE_CHAT_REF_POLICY } from "./native-chat-ref-policy";
 import type { InputRefParam, RegistryRefFieldMapEntry } from "./ref-field-map";
@@ -64,9 +65,6 @@ const buildInputRefsByTool = (): ReadonlyMap<
 };
 
 const INPUT_REFS_BY_TOOL = buildInputRefsByTool();
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 /**
  * The workspace an entity param's ref key needs. Chat's write tools that take

--- a/apps/api/src/handlers/chat/tools/registry-adapter/output-ref-resolution.ts
+++ b/apps/api/src/handlers/chat/tools/registry-adapter/output-ref-resolution.ts
@@ -10,6 +10,7 @@ import type {
   ChatEntityRefContext,
   ChatRefInputState,
 } from "@/api/lib/chat/ref-token";
+import { isRecord } from "@/api/lib/type-guards";
 
 import { NATIVE_CHAT_REF_POLICY } from "./native-chat-ref-policy";
 import type { RegistryRefFieldMapEntry } from "./ref-field-map";
@@ -80,9 +81,6 @@ const buildOutputRefPathsByTool = (): ReadonlyMap<
 };
 
 const OUTPUT_REF_PATHS_BY_TOOL = buildOutputRefPathsByTool();
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const readScalarPath = (root: unknown, path: string): unknown => {
   let value = root;

--- a/apps/api/src/handlers/chat/tools/registry-write-tools.ts
+++ b/apps/api/src/handlers/chat/tools/registry-write-tools.ts
@@ -18,6 +18,7 @@ import type { ChatRefRegistry } from "@/api/lib/chat/ref-registry";
 import type { ChatToolDefectMemo } from "@/api/lib/chat/tool-defect-memo";
 import { knownDefectRefusalMessage } from "@/api/lib/chat/tool-defect-memo";
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
+import { isRecord } from "@/api/lib/type-guards";
 import {
   DEFAULT_MCP_TOOL_DEFINITIONS,
   getStaticMcpToolDefinition,
@@ -55,9 +56,6 @@ export type ProjectedWriteToolName = {
 export type ChatRegistryWriteToolMap = {
   [K in ProjectedWriteToolName]: ServerTool<SchemaInput, SchemaInput, K>;
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 /**
  * The projected write tools, in registry order. Derived from the `as const`

--- a/apps/api/src/handlers/contacts/contact-metadata.ts
+++ b/apps/api/src/handlers/contacts/contact-metadata.ts
@@ -6,9 +6,7 @@ import type {
 } from "@/api/db/schema-validators";
 import { toJsonObject, toJsonValue } from "@/api/lib/json-value";
 import type { JsonObject } from "@/api/lib/json-value";
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
+import { isRecord } from "@/api/lib/type-guards";
 
 const CONTACT_METADATA_VERSION = 1;
 const CONTACT_METADATA_KEYS = new Set(["version", "dataBoxes", "customFields"]);

--- a/apps/api/src/lib/chat/projection-schema.ts
+++ b/apps/api/src/lib/chat/projection-schema.ts
@@ -14,6 +14,7 @@ import {
   brandPersistedPropertyId,
   brandPersistedWorkspaceId,
 } from "@/api/lib/safe-id-boundaries";
+import { isRecord } from "@/api/lib/type-guards";
 
 /**
  * Chat projection schemas: one Valibot `strictObject` per converted tool that
@@ -267,9 +268,6 @@ export const unenumeratedJson = () =>
 // wrappers carry `wrapped`; objects carry `entries`; arrays carry `item`;
 // unions/variants carry `options`. The walker reads that runtime AST through
 // structural guards, so it needs no valibot generics at all.
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const isSchemaNode = (value: unknown): value is v.GenericSchema =>
   isRecord(value) &&

--- a/apps/api/src/lib/chat/ref-token.ts
+++ b/apps/api/src/lib/chat/ref-token.ts
@@ -6,6 +6,8 @@ import {
   type ResourceRef,
 } from "@stll/api-contract";
 
+import { isRecord } from "@/api/lib/type-guards";
+
 /**
  * Model-facing spellings only. Persisted IDs may have the same text; the
  * protocol stage, not a reserved string namespace, distinguishes them.
@@ -67,9 +69,6 @@ export type ChatRefContext = {
   unresolvedInputs: ChatUnresolvedInputRefContext[];
   workspaceScope: ResourceRef<"workspace">[];
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const isChatEntityRefContext = (
   value: unknown,

--- a/apps/api/src/lib/mcp-upstream/cached-tools.ts
+++ b/apps/api/src/lib/mcp-upstream/cached-tools.ts
@@ -1,14 +1,12 @@
 import type { CachedMcpToolDefinition } from "@/api/db/schema";
 import { LIMITS } from "@/api/lib/limits";
+import { isRecord } from "@/api/lib/type-guards";
 
 import { namespaceMcpToolName, shortToolNameHash } from "./namespace";
 
 type ToolAnnotationInput = {
   readOnlyHint?: unknown;
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const stringValue = (value: unknown, maxLength: number): string | undefined =>
   typeof value === "string" ? value.slice(0, maxLength) : undefined;

--- a/apps/api/src/lib/search/index-chat.ts
+++ b/apps/api/src/lib/search/index-chat.ts
@@ -9,12 +9,10 @@ import type { TimestampCasToken } from "@/api/lib/db/timestamp-cas";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
 import { CHAT_SEARCH_DISPLAY_METADATA_GENERATION } from "@/api/lib/search/chat-search-generation";
+import { isRecord } from "@/api/lib/type-guards";
 
 const BACKFILL_BATCH_SIZE = 200;
 const ZERO_UUID = "00000000-0000-0000-0000-000000000000";
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 type SearchablePersistedChatMessageContent = {
   data: unknown[];

--- a/apps/api/src/lib/skills/skill-package.ts
+++ b/apps/api/src/lib/skills/skill-package.ts
@@ -13,6 +13,7 @@ import { SKILL_PACKAGE_LIMITS } from "@stll/skills/package-limits";
 import { HandlerError, unreachable } from "@/api/lib/errors/tagged-errors";
 import { FILE_SIZE_LIMIT_BYTES, LIMITS } from "@/api/lib/limits";
 import { safeOutboundFetchBytes } from "@/api/lib/safe-outbound-fetch";
+import { isRecord } from "@/api/lib/type-guards";
 
 const SKILL_FILE_NAME = "SKILL.md";
 const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/u;
@@ -1999,9 +2000,6 @@ const zipUncompressedSize = (file: JSZip.JSZipObject): number | null => {
     ? size
     : null;
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const toHandlerError = (cause: unknown): HandlerError =>
   HandlerError.is(cause)

--- a/apps/api/src/lib/templates/template-input-contract.ts
+++ b/apps/api/src/lib/templates/template-input-contract.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "@/api/lib/type-guards";
+
 type FindUnusedTemplateValueKeysOptions = {
   contract: TemplateInputContract;
   values: Record<string, unknown>;
@@ -259,9 +261,6 @@ const isFlattenedArrayDescendant = (
   }
   return false;
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const isTemplateLoopPrimitive = (
   value: unknown,

--- a/apps/api/src/mcp/auth.ts
+++ b/apps/api/src/mcp/auth.ts
@@ -3,6 +3,7 @@ import type { JWTPayload } from "jose";
 
 import { getAuthEndpointUrl, getAuthIssuerUrl } from "@/api/lib/auth-paths";
 import { isMachineApiKeyCredential } from "@/api/lib/machine-api-key-config";
+import { isRecord } from "@/api/lib/type-guards";
 import { AGENT_RUN_TOKEN_PURPOSE } from "@/api/mcp/agent-run-token";
 import { resolveMachineApiKeySession } from "@/api/mcp/api-key-auth";
 import type { McpMode } from "@/api/mcp/constants";
@@ -50,9 +51,6 @@ export const getMcpAccessTokenVerificationOptions = (
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) &&
   value.every((item) => typeof item === "string" && item.length > 0);
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const isMcpCredential = (
   value: unknown,

--- a/apps/api/src/mcp/billing-tools.ts
+++ b/apps/api/src/mcp/billing-tools.ts
@@ -713,11 +713,7 @@ const handleListTimeEntriesTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(listTimeEntriesArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { matter_id?: string, time_entry_id?: string, entity_id?: string, user_id?: string, date_from?: YYYY-MM-DD, date_to?: YYYY-MM-DD, status?: string, limit?: integer, cursor?: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -1011,11 +1007,7 @@ const handleSaveTimeEntryTool: TypedMcpToolHandler<
 > = async ({ args, context }) => {
   const parsed = v.safeParse(saveTimeEntryArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { time_entry_id?, matter_id?, entity_id?, date_worked?, timezone_id?, duration_minutes?, narrative?, invoice_narrative?, billable?, no_charge?, task_code?, activity_code? }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -1161,10 +1153,7 @@ const handleDeleteTimeEntryTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(deleteTimeEntryArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message: "Invalid input: expected { time_entry_id: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const timeEntryId = brandPersistedTimeEntryId(parsed.output.time_entry_id);
@@ -1212,11 +1201,7 @@ const handleResolveRateTool: McpToolHandler = async ({ args, context }) => {
 
   const parsed = v.safeParse(resolveRateArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { matter_id: string, user_id: string, date: YYYY-MM-DD }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const workspaceId = ensureWorkspaceAccess({
@@ -1353,11 +1338,7 @@ const handleListInvoicesTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(listInvoicesArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { matter_id?: string, invoice_id?: string, limit?: integer, cursor?: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -1535,10 +1516,7 @@ const handleGetUsageTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(getUsageArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message: "Invalid input: expected no parameters",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const entitlement = await Result.gen(() =>

--- a/apps/api/src/mcp/capability-tools.ts
+++ b/apps/api/src/mcp/capability-tools.ts
@@ -24,6 +24,7 @@ import {
 } from "@/api/lib/pagination";
 import { hasMemberPermission } from "@/api/lib/permission-authorization";
 import { brandPersistedWorkspaceId } from "@/api/lib/safe-id-boundaries";
+import { isRecord } from "@/api/lib/type-guards";
 import { synthesizeCapabilityContext } from "@/api/mcp/capability-context";
 import type { SynthesizedCapabilityContext } from "@/api/mcp/capability-context";
 import { isCapabilityFeatureEnabled } from "@/api/mcp/capability-feature";
@@ -123,9 +124,6 @@ type CatalogEntry = {
   inputSchema?: { body?: unknown; params?: unknown; query?: unknown };
   mcp: CapabilityMcpDisposition;
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const HANDLER_KIND_SET = new Set<string>(HANDLER_KINDS);
 

--- a/apps/api/src/mcp/document-file-upload.ts
+++ b/apps/api/src/mcp/document-file-upload.ts
@@ -12,6 +12,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
 import { safeOutboundFetchBytes } from "@/api/lib/safe-outbound-fetch";
+import { isRecord } from "@/api/lib/type-guards";
 import { CAPABILITY_TOOL_HANDLERS } from "@/api/mcp/capability-tools";
 import type { McpRequestContext } from "@/api/mcp/context";
 import { isMcpEgressPlan } from "@/api/mcp/tool-types";
@@ -107,9 +108,6 @@ const invokeCapability = async ({
   }
   return { status: "ok", payload: response.payload };
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 type UploadReservation = {
   headers: Record<string, string>;

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -952,11 +952,7 @@ const handleListDocumentsTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(listDocumentsArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { matter_id: string, mode?: 'flat'|'children', parent_id?: string, limit?: integer, cursor?: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const workspaceId = ensureWorkspaceAccess({
@@ -1630,10 +1626,7 @@ const handleReadDocumentTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(readDocumentArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message: "Invalid input: expected { entity_id: string, ... }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const entityId = brandPersistedEntityId(parsed.output.entity_id);
@@ -2199,11 +2192,7 @@ const handleSaveDocumentTool: TypedMcpToolHandler<
 > = async ({ args, context }) => {
   const parsed = v.safeParse(saveDocumentArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { matter_id, name, parent_id?, kind? } to create, or { entity_id, name?/parent_id?/move_to_root?/version_id?/label?/description? } to update",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -2260,11 +2249,7 @@ const handleUploadDocumentVersionTool: McpToolHandler = async ({
     args,
   );
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { entity_id: string, file: { download_url, file_id, mime_type?, file_name? } }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const target = await resolveDocumentVersionUploadTarget({
@@ -2292,10 +2277,7 @@ const handleOpenDocumentVersionUploadTool: McpToolHandler = async ({
     args,
   );
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message: "Invalid input: expected { entity_id: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const target = await resolveDocumentVersionUploadTarget({
@@ -2328,11 +2310,7 @@ const handleDeleteDocumentTool: TypedMcpToolHandler<
 > = async ({ args, context }) => {
   const parsed = v.safeParse(deleteDocumentArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { entity_id: string, version_id?: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const entityId = brandPersistedEntityId(parsed.output.entity_id);
@@ -2419,11 +2397,7 @@ const handleListPropertiesTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(listPropertiesArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { matter_id: string, limit?: integer, cursor?: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const workspaceId = ensureWorkspaceAccess({
@@ -2580,11 +2554,7 @@ const handleSetFieldValueTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(setFieldValueArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { entity_id: string, property_id: string, content: { type, value, currency? } }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   if (!isUuid(parsed.output.property_id)) {
     return structuredErrorResult({

--- a/apps/api/src/mcp/feedback-tools.ts
+++ b/apps/api/src/mcp/feedback-tools.ts
@@ -209,15 +209,12 @@ const buildGithubFeedbackResult = ({
 const handleSendFeedbackTool: McpToolHandler = async ({ args }) => {
   const parsed = await Promise.resolve(v.safeParse(feedbackArgsSchema, args));
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        parsed.issues.at(0)?.message ?? "Invalid send_feedback arguments",
-      hint:
-        `Provide kind (one of ${FEEDBACK_KINDS.join(", ")}), a non-empty title ` +
+    return validationErrorResult(
+      parsed.issues,
+      `Provide kind (one of ${FEEDBACK_KINDS.join(", ")}), a non-empty title ` +
         `(<= ${MAX_FEEDBACK_TITLE_CHARS} chars), and a non-empty body ` +
         `(<= ${MAX_FEEDBACK_BODY_CHARS} chars).`,
-    });
+    );
   }
   const { body, kind, title } = parsed.output;
   const sanitizedTitlePass = sanitizeFeedbackText(title);

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -1004,11 +1004,7 @@ const handleListClausesTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(listClausesArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { clause_id?: string, version_id?: string, category_id?: string, query?: string, include_categories?: boolean, limit?: integer, cursor?: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -1189,11 +1185,7 @@ const handleSaveClauseTool: TypedMcpToolHandler<
 > = async ({ args, context }) => {
   const parsed = v.safeParse(saveClauseArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { clause_id?: string, title?: string, body?: array, category_id?: string|null, language?: string|null, description?: string|null, usage_notes?: string|null, metadata?: object|null, snapshot_version?: boolean }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -1337,10 +1329,7 @@ const handleDeleteClauseTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(deleteClauseArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message: "Invalid input: expected { clause_id: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const deleted = await Result.gen(() =>
@@ -1427,11 +1416,7 @@ const handleListPlaybooksTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(listPlaybooksArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { playbook_id?: string, limit?: integer, cursor?: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -1500,11 +1485,7 @@ const handleRunPlaybookTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(runPlaybookArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { matter_id: string, playbook_id: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   // A playbook run materializes columns in the matter, so the matter must be

--- a/apps/api/src/mcp/matter-tools.ts
+++ b/apps/api/src/mcp/matter-tools.ts
@@ -609,11 +609,7 @@ const handleSaveMatterTool: TypedMcpToolHandler<
 > = async ({ args, context }) => {
   const parsed = v.safeParse(saveMatterArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { matter_id?: string, name?: string, client_id?: string, reference?: string, billing_reference?: string|null, status?: 'active'|'archived' }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -774,10 +770,7 @@ const handleDeleteMatterTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(deleteMatterArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message: "Invalid input: expected { matter_id: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   // The HTTP delete route sits inside the active-only workspace group, so an
@@ -832,11 +825,7 @@ const handleListContactsTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(listContactsArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { q?: string, type?: 'person'|'organization', cursor?: string, limit?: integer }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const listed = await listContactsPage({
@@ -930,11 +919,7 @@ const handleSaveContactTool: TypedMcpToolHandler<
 > = async ({ args, context }) => {
   const parsed = v.safeParse(saveContactArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { contact_id?: string, type?: 'person'|'organization', display_name?: string, first_name?: string|null, last_name?: string|null, organization_name?: string|null, notes?: string|null }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -1031,10 +1016,7 @@ const handleDeleteContactTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(deleteContactArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message: "Invalid input: expected { contact_id: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const deleted = await Result.gen(() =>
@@ -1069,10 +1051,7 @@ const handleLookupBusinessRegistryTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(lookupBusinessRegistryArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message: `Invalid input: expected { registry: one of ${BUSINESS_REGISTRY_SLUGS.join(", ")}, query: string }`,
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const result = await lookupBusinessRegistryShared({
@@ -1266,11 +1245,7 @@ const handleListTasksTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(listTasksArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { matter_id?: string, task_id?: string, date_from?: YYYY-MM-DD, date_to?: YYYY-MM-DD, status?: string, limit?: integer, cursor?: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -1731,11 +1706,7 @@ const handleSaveTaskTool: TypedMcpToolHandler<
 > = async ({ args, context }) => {
   const parsed = v.safeParse(saveTaskArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { task_id?, matter_id?, name?, item_type?, status?, priority?, due_date?, workflow_reason?, add_assignee_user_id?, remove_assignee_user_id?, link_entity_id?, unlink_link_id? }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -2008,11 +1979,7 @@ const handleLinkMatterContactTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(linkMatterContactArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { matter_id: string, contact_id?: string, role?: string, workspace_contact_id?: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 

--- a/apps/api/src/mcp/research-admin-tools.test.ts
+++ b/apps/api/src/mcp/research-admin-tools.test.ts
@@ -122,7 +122,7 @@ describe("list_audit_log", () => {
       context: createContext("owner"),
     });
 
-    expect(errorMessage(result)).toContain("Invalid input");
+    expect(errorText(result)).toContain('"code":"validation_error"');
   });
 });
 

--- a/apps/api/src/mcp/research-admin-tools.ts
+++ b/apps/api/src/mcp/research-admin-tools.ts
@@ -465,11 +465,7 @@ const handleSearchLegislationTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(searchLegislationArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected search filters (query/title/…) or law_id with optional block_id/relation_type/full_text",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -572,11 +568,7 @@ const handleListAuditLogTool: McpToolHandler = async ({ args, context }) => {
     args,
   );
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { workspace_id?, action?, resource_type?, resource_id?, user_id?, from?, to?, limit?, cursor? }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -789,11 +781,7 @@ const handleManageOrganizationTool: TypedMcpToolHandler<
 > = async ({ args, context }) => {
   const parsed = v.safeParse(manageOrganizationArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { action: 'add_member'|'remove_member'|'update_org_settings', matter_id?, user_id?, matter_number_pattern?, matter_number_padding?, prompt_caching_enabled?, document_processing_mode? }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -1950,11 +1950,7 @@ const handleSetPracticeJurisdictionsTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(setPracticeJurisdictionsArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { jurisdictions: Array<{ countryCode: ISO 3166-1 alpha-2, isPrimary: boolean }> }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const primaryCount = parsed.output.jurisdictions.filter(

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -615,10 +615,7 @@ const handleListTemplatesTool: TypedMcpToolHandler<
 
   const parsed = v.safeParse(listTemplatesArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message: "Invalid input: list_templates accepts template_id or cursor",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const cursor = parseOptionalCursor({ args, key: "cursor" });
@@ -701,10 +698,7 @@ const describeTemplateDetail: TypedMcpToolHandler<
 > = async ({ args, context }) => {
   const parsed = v.safeParse(describeTemplateArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message: "Invalid input: expected { template_id: string }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   const result = await describeStoredTemplate({
@@ -756,11 +750,7 @@ const handleFillTemplateTool: McpToolHandler = async ({ args, context }) => {
 
   const parsed = v.safeParse(fillTemplateArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { template_id: string, values: object }",
-    });
+    return validationErrorResult(parsed.issues);
   }
 
   // Load the org's AI config so AI-fillable / aiAdapt fields behave exactly as
@@ -1029,11 +1019,7 @@ const handleSaveFilledTemplateTool: McpToolHandler = async ({
 }) => {
   const parsed = v.safeParse(saveFilledTemplateArgsSchema, args);
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { action, template_id, matter_id, idempotency_key, values, entity_id?, parent_id?, name? }",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 
@@ -1557,11 +1543,7 @@ const handleSaveTemplateTool: TypedMcpToolHandler<
     args,
   );
   if (!parsed.success) {
-    return validationErrorResult({
-      issues: parsed.issues,
-      message:
-        "Invalid input: expected { docx_base64: string, name: string, fields?: array } to create, or { template_id: string, fields: array } to configure",
-    });
+    return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
 

--- a/apps/api/src/mcp/tool-utils.test.ts
+++ b/apps/api/src/mcp/tool-utils.test.ts
@@ -591,15 +591,12 @@ describe("validationErrorResult", () => {
       throw new Error("expected a validation failure");
     }
 
-    const result = validationErrorResult({
-      issues: parsed.issues,
-      message: "name is required",
-    });
+    const result = validationErrorResult(parsed.issues);
 
     expect(result.status).toBe("error");
     const payload = JSON.parse(errorText(result));
     expect(payload.error.code).toBe("validation_error");
-    expect(payload.error.message).toBe("name is required");
+    expect(payload.error.message).toBe(parsed.issues.at(0)?.message);
     expect(payload.error.issues).toEqual([
       { path: "name", message: expect.any(String) },
     ]);

--- a/apps/api/src/mcp/tool-utils.ts
+++ b/apps/api/src/mcp/tool-utils.ts
@@ -296,24 +296,22 @@ export const mapValibotIssues = (
 
 /**
  * Build the shared validation envelope. Prefer an actionable cross-field issue
- * as its summary; `message` is the fallback for structural failures.
+ * as its summary, then the first structural issue. The structured issue list is
+ * the canonical schema-derived error detail; callers must not mirror schemas in
+ * handwritten fallback messages that can drift from the contract.
  */
-export const validationErrorResult = ({
-  hint,
-  issues,
-  message,
-}: {
-  hint?: string | undefined;
-  issues: readonly v.BaseIssue<unknown>[];
-  message: string;
-}): InternalToolErrorResult =>
+export const validationErrorResult = (
+  issues: readonly v.BaseIssue<unknown>[],
+  hint?: string,
+): InternalToolErrorResult =>
   structuredErrorResult({
     code: "validation_error",
     hint,
     issues: mapValibotIssues(issues),
     message:
       issues.find((issue) => issue.type === "partial_check")?.message ??
-      message,
+      issues.at(0)?.message ??
+      "Invalid tool input",
   });
 
 /** `not_found` envelope for a resource that does not exist or is inaccessible. */

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -3742,10 +3742,11 @@ describe("OpenAI-compatible MCP tools", () => {
       toolName: "list_contacts",
     });
 
-    expectValidationMessage(
-      result,
-      "Invalid input: expected { q?: string, type?: 'person'|'organization', cursor?: string, limit?: integer }",
-    );
+    const error = validationEnvelope(result);
+    expect(error["code"]).toBe("validation_error");
+    expect(error["issues"]).toEqual([
+      { path: "registry", message: expect.any(String) },
+    ]);
   });
 
   test("save_task rejects a create with no matter_id", async () => {


### PR DESCRIPTION
MCP validation errors now derive their summary from the canonical Valibot issue list. Cross-field `partialCheck` messages remain preferred, structural failures use the first issue, and recovery hints plus structured paths remain intact.

This removes handwritten schema summaries from 38 handlers and reuses the API plain-object guard across 14 production modules. Array-accepting guards and browser-bundle-local guards remain separate because their contracts differ.

Net change: 171 lines removed.