### PR TITLE
chore(api): internalize rate limiting

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -121,7 +121,6 @@
     "domhandler": "^6.0.1",
     "drizzle-orm": "catalog:",
     "elysia": "catalog:",
-    "elysia-rate-limit": "^4.6.2",
     "ip-address": "^10.5.0",
     "jose": "^6.2.9",
     "jszip": "catalog:",

--- a/apps/api/src/handlers/entities/routes.ts
+++ b/apps/api/src/handlers/entities/routes.ts
@@ -1,5 +1,4 @@
 import Elysia from "elysia";
-import { rateLimit } from "elysia-rate-limit";
 
 import { RESOURCE_TYPE } from "@stll/api-contract";
 
@@ -53,6 +52,7 @@ import versionDiff from "@/api/handlers/entities/version-diff";
 import versionSummarize from "@/api/handlers/entities/version-summarize";
 import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
+import { rateLimit } from "@/api/lib/rate-limit/rate-limit";
 import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 import {
   resourceRealtime,
@@ -83,7 +83,6 @@ export const entitiesRoute = new Elysia({
   .use(permissionMacro)
   .use(
     rateLimit({
-      scoping: "scoped",
       duration: API_RATE_LIMITS.upload.duration,
       max: API_RATE_LIMITS.upload.max,
       ...createRedisRateLimit({
@@ -95,7 +94,6 @@ export const entitiesRoute = new Elysia({
   )
   .use(
     rateLimit({
-      scoping: "scoped",
       duration: API_RATE_LIMITS.translate.duration,
       max: API_RATE_LIMITS.translate.max,
       ...createRedisRateLimit({

--- a/apps/api/src/handlers/hosted-usage-webhook/routes.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/routes.ts
@@ -11,10 +11,10 @@
 
 import { panic } from "better-result";
 import Elysia, { t } from "elysia";
-import { rateLimit } from "elysia-rate-limit";
 
 import { receiveHostedUsageWebhook } from "@/api/handlers/hosted-usage-webhook/receive";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
+import { rateLimit } from "@/api/lib/rate-limit/rate-limit";
 import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 
 export const hostedUsageWebhookRoute = new Elysia({
@@ -22,7 +22,6 @@ export const hostedUsageWebhookRoute = new Elysia({
 })
   .use(
     rateLimit({
-      scoping: "scoped",
       duration: API_RATE_LIMITS.hostedUsageWebhook.duration,
       max: API_RATE_LIMITS.hostedUsageWebhook.max,
       ...createRedisRateLimit({

--- a/apps/api/src/handlers/me/routes.ts
+++ b/apps/api/src/handlers/me/routes.ts
@@ -1,5 +1,4 @@
 import Elysia from "elysia";
-import { rateLimit } from "elysia-rate-limit";
 
 import disconnectOAuthConnection from "@/api/handlers/me/disconnect-oauth-connection";
 import listOAuthConnections from "@/api/handlers/me/list-oauth-connections";
@@ -10,6 +9,7 @@ import updateGuideProgress from "@/api/handlers/me/update-guide-progress";
 import deleteAccountVerify from "@/api/handlers/me/verify-delete";
 import { sessionAuthMacro } from "@/api/lib/auth";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
+import { rateLimit } from "@/api/lib/rate-limit/rate-limit";
 import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 
 const isDeleteAccountOtpSendPath = (pathname: string): boolean =>
@@ -33,7 +33,6 @@ export const meRoute = new Elysia({ prefix: "/me" })
       .get("/pending-tasks", deleteAccountPendingTasks.handler)
       .use(
         rateLimit({
-          scoping: "scoped",
           duration: API_RATE_LIMITS.deleteAccountOtp.duration,
           max: API_RATE_LIMITS.deleteAccountOtp.max,
           ...createRedisRateLimit({
@@ -52,7 +51,6 @@ export const meRoute = new Elysia({ prefix: "/me" })
     app
       .use(
         rateLimit({
-          scoping: "scoped",
           duration: API_RATE_LIMITS.twoFactorManageOtp.duration,
           max: API_RATE_LIMITS.twoFactorManageOtp.max,
           ...createRedisRateLimit({

--- a/apps/api/src/handlers/memories/rate-limit.test.ts
+++ b/apps/api/src/handlers/memories/rate-limit.test.ts
@@ -14,7 +14,7 @@ describe("memories rate limiting", () => {
     );
 
     try {
-      const key = await options.generator(request, null, {});
+      const key = await options.generator(request, null);
 
       expect(options.context).toBeInstanceOf(RedisRateLimitContext);
       expect(key.startsWith("api\u001f")).toBe(true);

--- a/apps/api/src/handlers/memories/rate-limit.ts
+++ b/apps/api/src/handlers/memories/rate-limit.ts
@@ -1,12 +1,10 @@
-import type { Options } from "elysia-rate-limit";
-
 import { env } from "@/api/env";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
+import type { RateLimitOptions } from "@/api/lib/rate-limit/rate-limit";
 import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 
 export const createMemoriesRateLimitOptions = () =>
   ({
-    scoping: "scoped",
     duration: API_RATE_LIMITS.api.duration,
     max: API_RATE_LIMITS.api.max,
     ...createRedisRateLimit({
@@ -14,4 +12,4 @@ export const createMemoriesRateLimitOptions = () =>
       scope: "api",
     }),
     skip: () => env.E2E_DISABLE_AUTH_RATE_LIMIT,
-  }) as const satisfies Partial<Options>;
+  }) as const satisfies RateLimitOptions;

--- a/apps/api/src/handlers/memories/routes.ts
+++ b/apps/api/src/handlers/memories/routes.ts
@@ -1,5 +1,4 @@
 import Elysia from "elysia";
-import { rateLimit } from "elysia-rate-limit";
 
 import { env } from "@/api/env";
 import createMemory from "@/api/handlers/memories/create";
@@ -9,6 +8,7 @@ import { createMemoriesRateLimitOptions } from "@/api/handlers/memories/rate-lim
 import updateMemory from "@/api/handlers/memories/update";
 import { authMacro, permissionMacro } from "@/api/lib/auth";
 import { deploymentFeatureGate } from "@/api/lib/deployment-feature-route";
+import { rateLimit } from "@/api/lib/rate-limit/rate-limit";
 
 // Mounted at `/v1/memories` directly at the root because folding another
 // `.use()` into the large `/v1` group tips Elysia's inferred type past

--- a/apps/api/src/handlers/skills/routes.ts
+++ b/apps/api/src/handlers/skills/routes.ts
@@ -1,5 +1,4 @@
 import Elysia from "elysia";
-import { rateLimit } from "elysia-rate-limit";
 
 import { RESOURCE_TYPE } from "@stll/api-contract";
 
@@ -28,6 +27,7 @@ import updateSkill from "@/api/handlers/skills/update";
 import uploadSkill from "@/api/handlers/skills/upload";
 import { authMacro, permissionMacro } from "@/api/lib/auth";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
+import { rateLimit } from "@/api/lib/rate-limit/rate-limit";
 import {
   organizationResourceSetUpdates,
   resourceRealtime,
@@ -44,7 +44,6 @@ export const skillsRoute = new Elysia({ prefix: "/skills" })
   .use(resourceRealtime)
   .use(
     rateLimit({
-      scoping: "scoped",
       duration: API_RATE_LIMITS.skillSource.duration,
       max: API_RATE_LIMITS.skillSource.max,
       ...skillSourceRateLimitBinding,

--- a/apps/api/src/handlers/skills/source-rate-limit.ts
+++ b/apps/api/src/handlers/skills/source-rate-limit.ts
@@ -1,7 +1,9 @@
-import type { Context, Generator } from "elysia-rate-limit";
-
 import { resolveClientIp } from "@/api/lib/client-ip";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
+import type {
+  RateLimitContext,
+  RateLimitGenerator,
+} from "@/api/lib/rate-limit/rate-limit";
 import {
   createRedisRateLimit,
   createRedisRateLimitRequestKey,
@@ -20,7 +22,7 @@ const skillSourceRateLimitCounterKey = (clientIp: string | null): string =>
     ? `${SKILL_SOURCE_RATE_LIMIT_SCOPE}:${clientIp}`
     : SKILL_SOURCE_RATE_LIMIT_SCOPE;
 
-const skillSourceCounterKeyGenerator: Generator = (request, server) =>
+const skillSourceCounterKeyGenerator: RateLimitGenerator = (request, server) =>
   skillSourceRateLimitCounterKey(resolveClientIp(request, server ?? null));
 
 export const skillSourceRateLimitBinding = createRedisRateLimit({
@@ -40,7 +42,7 @@ export const consumeSkillSourceRateLimit = async ({
   requestId = Bun.randomUUIDv7(),
 }: {
   clientIp: string | null;
-  context?: Pick<Context, "increment">;
+  context?: Pick<RateLimitContext, "increment">;
   requestId?: string;
 }): Promise<SkillSourceRateLimitResult> => {
   const counterKey = skillSourceRateLimitCounterKey(clientIp);

--- a/apps/api/src/handlers/style-sets/routes.ts
+++ b/apps/api/src/handlers/style-sets/routes.ts
@@ -1,5 +1,4 @@
 import Elysia from "elysia";
-import { rateLimit } from "elysia-rate-limit";
 
 import createStyleSet from "@/api/handlers/style-sets/create";
 import createStyleSetFromEditor from "@/api/handlers/style-sets/create-from-editor";
@@ -14,6 +13,7 @@ import updateStyleSetFromEditor from "@/api/handlers/style-sets/update-from-edit
 import { isStyleSetUploadRateLimitedRequest } from "@/api/handlers/style-sets/upload-rate-limit";
 import { authMacro, permissionMacro } from "@/api/lib/auth";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
+import { rateLimit } from "@/api/lib/rate-limit/rate-limit";
 import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 
 export const styleSetsRoute = new Elysia({ prefix: "/style-sets" })
@@ -21,7 +21,6 @@ export const styleSetsRoute = new Elysia({ prefix: "/style-sets" })
   .use(permissionMacro)
   .use(
     rateLimit({
-      scoping: "scoped",
       duration: API_RATE_LIMITS.upload.duration,
       max: API_RATE_LIMITS.upload.max,
       ...createRedisRateLimit({

--- a/apps/api/src/handlers/uploads/routes.ts
+++ b/apps/api/src/handlers/uploads/routes.ts
@@ -1,5 +1,4 @@
 import Elysia from "elysia";
-import { rateLimit } from "elysia-rate-limit";
 
 import { RESOURCE_TYPE } from "@stll/api-contract";
 
@@ -10,6 +9,7 @@ import preflightEntityCreate from "@/api/handlers/uploads/preflight-entity-creat
 import finalizeUpload from "@/api/handlers/uploads/update";
 import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
 import { API_RATE_LIMITS } from "@/api/lib/limits";
+import { rateLimit } from "@/api/lib/rate-limit/rate-limit";
 import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 import {
   resourceRealtime,
@@ -55,7 +55,6 @@ export const uploadsRoute = new Elysia({
   .use(permissionMacro)
   .use(
     rateLimit({
-      scoping: "scoped",
       duration: API_RATE_LIMITS.upload.duration,
       max: API_RATE_LIMITS.upload.max,
       ...createRedisRateLimit({

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -21,7 +21,6 @@ import { panic, Result } from "better-result";
 import { and, eq, exists, inArray, isNotNull, or } from "drizzle-orm";
 import type { InferSelectModel } from "drizzle-orm";
 import Elysia, { t } from "elysia";
-import type { Context as RateLimitContext } from "elysia-rate-limit";
 
 import { BETTER_AUTH_ORGANIZATION_OPTIONS } from "@stll/auth-model";
 import { ac, roles } from "@stll/permissions";
@@ -105,6 +104,7 @@ import {
   readAuthorizedMemberRole,
 } from "@/api/lib/permission-authorization";
 import { createAuthRateLimitStorage } from "@/api/lib/rate-limit/auth-storage";
+import type { RateLimitContext } from "@/api/lib/rate-limit/rate-limit";
 import { memoizePerRequest } from "@/api/lib/request-memo";
 import {
   brandPersistedOrganizationId,

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -516,7 +516,7 @@ export const AUTH_RATE_LIMIT_MAX_WINDOW = Math.max(
 );
 
 /**
- * Rate limits for API endpoints (elysia-rate-limit).
+ * Rate limits for API endpoints.
  * Duration is in milliseconds, max is the request ceiling
  * per duration window.
  */

--- a/apps/api/src/lib/rate-limit/rate-limit.test.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import Elysia from "elysia";
-import type { Options } from "elysia-rate-limit";
-import { rateLimit } from "elysia-rate-limit";
+import Elysia, { t } from "elysia";
 
+import {
+  rateLimit,
+  type RateLimitContext,
+  type RateLimitContextConfig,
+  type RateLimitOptions,
+} from "@/api/lib/rate-limit/rate-limit";
 import {
   createRedisRateLimit,
   createRedisRateLimitRequestKey,
@@ -11,15 +15,11 @@ import {
 
 const WINDOW_MS = 1000;
 const RATE_LIMIT_OPTIONS = {
-  countFailedRequest: false,
   duration: WINDOW_MS,
-  errorResponse: "rate limit reached",
   generator: () => "shared-client",
-  headers: true,
   max: 2,
-  scoping: "scoped",
   skip: () => false,
-} as const satisfies Omit<Options, "context">;
+} as const satisfies Omit<RateLimitOptions, "context">;
 
 describe("RedisRateLimitContext", () => {
   test("keeps one refund identity per request while sharing the counter key", async () => {
@@ -34,9 +34,9 @@ describe("RedisRateLimitContext", () => {
       cookie: {},
     });
 
-    const firstKey = await generator(firstRequest, null, {});
-    const repeatedKey = await generator(firstRequest, null, {});
-    const secondKey = await generator(secondRequest, null, {});
+    const firstKey = await generator(firstRequest, null);
+    const repeatedKey = await generator(firstRequest, null);
+    const secondKey = await generator(secondRequest, null);
 
     expect(firstKey).toBe(repeatedKey);
     expect(secondKey).not.toBe(firstKey);
@@ -396,10 +396,201 @@ describe("RedisRateLimitContext", () => {
     expect(limited.headers.get("RateLimit-Remaining")).toBe("0");
     expect(limited.headers.get("RateLimit-Reset")).toBe("1");
     expect(limited.headers.get("Retry-After")).toBe("1");
+    expect(await limited.text()).toBe("rate-limit reached");
     firstContext.kill();
     secondContext.kill();
   });
+
+  test("refunds only requests that reached a failing handler", async () => {
+    const context = new TrackingRateLimitContext();
+    const app = createTrackingRateLimitedApp({ context, max: 1 })
+      .get("/fails", () => {
+        throw new TypeError("handler failed");
+      })
+      .get("/passes", () => "ok");
+
+    const failed = await app.handle(new Request("http://localhost/fails"));
+    const passed = await app.handle(new Request("http://localhost/passes"));
+    const limited = await app.handle(new Request("http://localhost/passes"));
+
+    expect(failed.status).toBe(500);
+    expect(passed.status).toBe(200);
+    expect(limited.status).toBe(429);
+    expect(context.decrementedKeys).toEqual(["shared-client"]);
+  });
+
+  test("skipped failing requests cannot refund another request", async () => {
+    const context = new TrackingRateLimitContext();
+    const app = createTrackingRateLimitedApp({
+      context,
+      max: 1,
+      skip: (request) => new URL(request.url).pathname === "/skipped",
+    })
+      .get("/skipped", () => {
+        throw new TypeError("skipped handler failed");
+      })
+      .get("/limited", () => "ok");
+
+    const skipped = await app.handle(new Request("http://localhost/skipped"));
+    const passed = await app.handle(new Request("http://localhost/limited"));
+    const limited = await app.handle(new Request("http://localhost/limited"));
+
+    expect(skipped.status).toBe(500);
+    expect(passed.status).toBe(200);
+    expect(limited.status).toBe(429);
+    expect(context.incrementedKeys).toEqual(["shared-client", "shared-client"]);
+    expect(context.decrementedKeys).toEqual([]);
+  });
+
+  test("counts malformed and request-validation failures", async () => {
+    const context = new TrackingRateLimitContext();
+    const app = createTrackingRateLimitedApp({ context, max: 2 }).post(
+      "/",
+      () => "ok",
+      { body: t.Object({ name: t.String() }) },
+    );
+
+    const malformed = await app.handle(
+      new Request("http://localhost/", {
+        body: "{",
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+    const invalid = await app.handle(
+      new Request("http://localhost/", {
+        body: JSON.stringify({ name: 42 }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+    const limited = await app.handle(
+      new Request("http://localhost/", {
+        body: JSON.stringify({ name: "Stella" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+
+    expect(malformed.status).toBe(400);
+    expect(invalid.status).toBe(422);
+    expect(limited.status).toBe(429);
+    expect(context.incrementedKeys).toEqual([
+      "shared-client",
+      "shared-client",
+      "shared-client",
+    ]);
+  });
+
+  test("counts unknown routes that bypass before-handle hooks", async () => {
+    const context = new TrackingRateLimitContext();
+    const app = createTrackingRateLimitedApp({ context, max: 1 }).get(
+      "/known",
+      () => "ok",
+    );
+
+    const missing = await app.handle(new Request("http://localhost/missing"));
+    const limited = await app.handle(new Request("http://localhost/known"));
+
+    expect(missing.status).toBe(404);
+    expect(limited.status).toBe(429);
+    expect(context.incrementedKeys).toEqual(["shared-client", "shared-client"]);
+  });
+
+  test("registers equal-limit scoped plugins independently", async () => {
+    const firstContext = new TrackingRateLimitContext();
+    const secondContext = new TrackingRateLimitContext();
+    const app = new Elysia()
+      .use(
+        createTrackingRateLimitedApp({
+          context: firstContext,
+          max: 1,
+          prefix: "/first",
+        }).get("/", () => "first"),
+      )
+      .use(
+        createTrackingRateLimitedApp({
+          context: secondContext,
+          max: 1,
+          prefix: "/second",
+        }).get("/", () => "second"),
+      );
+
+    const first = await app.handle(new Request("http://localhost/first/"));
+    const second = await app.handle(new Request("http://localhost/second/"));
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(firstContext.incrementedKeys).toEqual(["shared-client"]);
+    expect(secondContext.incrementedKeys).toEqual(["shared-client"]);
+  });
+
+  test("cleans up its context when the app stops", async () => {
+    const context = new TrackingRateLimitContext();
+    const app = createTrackingRateLimitedApp({ context, max: 1 })
+      .get("/", () => "ok")
+      .listen({ hostname: "127.0.0.1", port: 0 });
+
+    await app.stop();
+
+    expect(context.killCount).toBe(1);
+  });
 });
+
+class TrackingRateLimitContext implements RateLimitContext {
+  readonly decrementedKeys: string[] = [];
+  readonly incrementedKeys: string[] = [];
+  killCount = 0;
+  private readonly counts = new Map<string, number>();
+  private duration = WINDOW_MS;
+
+  decrement(key: string): void {
+    this.decrementedKeys.push(key);
+    const count = this.counts.get(key) ?? 0;
+    this.counts.set(key, Math.max(0, count - 1));
+  }
+
+  increment(key: string, duration = this.duration, requestTime = Date.now()) {
+    this.incrementedKeys.push(key);
+    const count = (this.counts.get(key) ?? 0) + 1;
+    this.counts.set(key, count);
+    return {
+      count,
+      nextReset: new Date(requestTime + duration),
+      start: requestTime,
+    };
+  }
+
+  init({ duration }: RateLimitContextConfig): void {
+    this.duration = duration;
+  }
+
+  kill(): void {
+    this.killCount += 1;
+    this.counts.clear();
+  }
+}
+
+const createTrackingRateLimitedApp = ({
+  context,
+  max,
+  prefix,
+  skip,
+}: {
+  context: TrackingRateLimitContext;
+  max: number;
+  prefix?: string;
+  skip?: RateLimitOptions["skip"];
+}) =>
+  new Elysia(prefix === undefined ? {} : { prefix }).use(
+    rateLimit({
+      context,
+      duration: WINDOW_MS,
+      generator: () => "shared-client",
+      max,
+      ...(skip === undefined ? {} : { skip }),
+    }),
+  );
 
 type FakeRedisEntry = {
   attempts: Set<string>;

--- a/apps/api/src/lib/rate-limit/rate-limit.test.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.test.ts
@@ -600,6 +600,48 @@ describe("RedisRateLimitContext", () => {
     ]);
   });
 
+  test("returns the rate-limit body when an early failure exceeds the quota", async () => {
+    const context = new TrackingRateLimitContext();
+    const app = new Elysia()
+      .onError(({ set }) => {
+        set.status = 400;
+        return { message: "sanitized" };
+      })
+      .use(
+        rateLimit({
+          context,
+          duration: WINDOW_MS,
+          generator: () => "shared-client",
+          max: 1,
+        }),
+      )
+      .post("/known", () => "ok", {
+        body: t.Object({ name: t.String() }),
+      });
+
+    const first = await app.handle(
+      new Request("http://localhost/known", {
+        body: "{",
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+    const limited = await app.handle(
+      new Request("http://localhost/known", {
+        body: "{",
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+
+    expect(first.status).toBe(400);
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get("RateLimit-Limit")).toBe("1");
+    expect(limited.headers.get("RateLimit-Remaining")).toBe("0");
+    expect(limited.headers.get("Retry-After")).toBe("1");
+    expect(await limited.text()).toBe("rate-limit reached");
+  });
+
   test("counts unknown routes that bypass before-handle hooks", async () => {
     const context = new TrackingRateLimitContext();
     const app = createTrackingRateLimitedApp({ context, max: 1 }).get(

--- a/apps/api/src/lib/rate-limit/rate-limit.test.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import Elysia, { t } from "elysia";
+import Elysia, { status, t } from "elysia";
 
 import {
   rateLimit,
@@ -419,6 +419,50 @@ describe("RedisRateLimitContext", () => {
     expect(context.decrementedKeys).toEqual(["shared-client"]);
   });
 
+  test("counts handlers that return a failed status", async () => {
+    const context = new TrackingRateLimitContext();
+    const app = createTrackingRateLimitedApp({ context, max: 1 })
+      .get("/fails", () => status(400, { message: "failed" }))
+      .get("/passes", () => "ok");
+
+    const failed = await app.handle(new Request("http://localhost/fails"));
+    const limited = await app.handle(new Request("http://localhost/passes"));
+
+    expect(failed.status).toBe(400);
+    expect(limited.status).toBe(429);
+    expect(context.decrementedKeys).toEqual([]);
+  });
+
+  test("refunds thrown failures after an earlier error handler returns", async () => {
+    const context = new TrackingRateLimitContext();
+    const app = new Elysia()
+      .onError(({ set }) => {
+        set.status = 500;
+        return { message: "sanitized" };
+      })
+      .use(
+        rateLimit({
+          context,
+          duration: WINDOW_MS,
+          generator: () => "shared-client",
+          max: 1,
+        }),
+      )
+      .get("/fails", () => {
+        throw new TypeError("handler failed");
+      })
+      .get("/passes", () => "ok");
+
+    const failed = await app.handle(new Request("http://localhost/fails"));
+    const passed = await app.handle(new Request("http://localhost/passes"));
+    const limited = await app.handle(new Request("http://localhost/passes"));
+
+    expect(failed.status).toBe(500);
+    expect(passed.status).toBe(200);
+    expect(limited.status).toBe(429);
+    expect(context.decrementedKeys).toEqual(["shared-client"]);
+  });
+
   test("skipped failing requests cannot refund another request", async () => {
     const context = new TrackingRateLimitContext();
     const app = createTrackingRateLimitedApp({
@@ -476,6 +520,80 @@ describe("RedisRateLimitContext", () => {
     expect(invalid.status).toBe(422);
     expect(limited.status).toBe(429);
     expect(context.incrementedKeys).toEqual([
+      "shared-client",
+      "shared-client",
+      "shared-client",
+    ]);
+  });
+
+  test("accounts for early failures after an earlier error handler returns", async () => {
+    const context = new TrackingRateLimitContext();
+    const app = new Elysia()
+      .onError(({ code, set }) => {
+        switch (code) {
+          case "NOT_FOUND":
+            set.status = 404;
+            break;
+          case "PARSE":
+            set.status = 400;
+            break;
+          case "VALIDATION":
+            set.status = 422;
+            break;
+          case "INTERNAL_SERVER_ERROR":
+          case "INVALID_COOKIE_SIGNATURE":
+          case "INVALID_FILE_TYPE":
+          case "UNKNOWN":
+            set.status = 500;
+            break;
+          default:
+            set.status = 500;
+        }
+        return { message: "sanitized" };
+      })
+      .use(
+        rateLimit({
+          context,
+          duration: WINDOW_MS,
+          generator: () => "shared-client",
+          max: 3,
+        }),
+      )
+      .post("/known", () => "ok", {
+        body: t.Object({ name: t.String() }),
+      });
+
+    const malformed = await app.handle(
+      new Request("http://localhost/known", {
+        body: "{",
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+    const invalid = await app.handle(
+      new Request("http://localhost/known", {
+        body: JSON.stringify({ name: 42 }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+    const missing = await app.handle(
+      new Request("http://localhost/missing", { method: "POST" }),
+    );
+    const limited = await app.handle(
+      new Request("http://localhost/known", {
+        body: JSON.stringify({ name: "Stella" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+
+    expect(malformed.status).toBe(400);
+    expect(invalid.status).toBe(422);
+    expect(missing.status).toBe(404);
+    expect(limited.status).toBe(429);
+    expect(context.incrementedKeys).toEqual([
+      "shared-client",
       "shared-client",
       "shared-client",
       "shared-client",

--- a/apps/api/src/lib/rate-limit/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.ts
@@ -341,14 +341,24 @@ export const rateLimit = ({
 
     if (state === undefined) {
       if (handledError && isEarlyFailureStatus(statusCode)) {
-        await applyRateLimit({
+        const rateLimitResponse = await applyRateLimit({
           phase: "early_failure",
           request,
           server,
           set,
         });
+        if (rateLimitResponse !== undefined) {
+          const headers = new Headers();
+          for (const [name, value] of Object.entries(set.headers)) {
+            headers.set(name, String(value));
+          }
+          return new Response(rateLimitResponse, {
+            headers,
+            status: 429,
+          });
+        }
       }
-      return;
+      return undefined;
     }
 
     switch (state.type) {
@@ -357,15 +367,15 @@ export const rateLimit = ({
           requestState.set(request, { type: "refunded" });
           await context.decrement(state.key);
         }
-        return;
+        return undefined;
       case "counted_early_failure":
       case "limited":
       case "refunded":
       case "skipped":
-        return;
+        return undefined;
       default: {
         state satisfies never;
-        return;
+        return undefined;
       }
     }
   });

--- a/apps/api/src/lib/rate-limit/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.ts
@@ -1,4 +1,6 @@
-import { Elysia } from "elysia";
+import { Elysia, type Context } from "elysia";
+
+import { resolveResponseStatus } from "@/api/lib/observability/response-status";
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -144,10 +146,16 @@ export class InMemoryRateLimitContext implements RateLimitContext {
   }
 }
 
-type RateLimitResponseSet = {
-  headers: Record<string, string | number | boolean | undefined>;
-  status?: number | string;
-};
+type RateLimitResponseSet = Context["set"];
+
+type RateLimitRequestState =
+  | { type: "counted"; key: string }
+  | { type: "counted_early_failure" }
+  | { type: "limited" }
+  | { type: "refunded" }
+  | { type: "skipped" };
+
+type RateLimitApplicationPhase = "before_handler" | "early_failure";
 
 const DEFAULT_RATE_LIMIT_ERROR_RESPONSE = "rate-limit reached";
 
@@ -191,6 +199,9 @@ const isResponseValidationError = (error: unknown): boolean =>
   "type" in error &&
   error.type === "response";
 
+const isEarlyFailureStatus = (statusCode: number): boolean =>
+  statusCode === 400 || statusCode === 404 || statusCode === 422;
+
 /**
  * Stella's Elysia adapter for its replica-safe rate-limit contexts.
  *
@@ -206,7 +217,7 @@ export const rateLimit = ({
   skip = () => false,
 }: RateLimitOptions) => {
   context.init({ duration });
-  const countedKeyByRequest = new WeakMap<Request, string>();
+  const requestState = new WeakMap<Request, RateLimitRequestState>();
 
   // Each registration owns a route subtree even when two subtrees share the
   // same counter key and limits. Keeping the plugin unnamed prevents Elysia's
@@ -214,15 +225,18 @@ export const rateLimit = ({
   const plugin = new Elysia();
 
   const applyRateLimit = async ({
+    phase,
     request,
     server,
     set,
   }: {
+    phase: RateLimitApplicationPhase;
     request: Request;
     server: RequestIpServer | null;
     set: RateLimitResponseSet;
   }): Promise<string | undefined> => {
     if (await skip(request)) {
+      requestState.set(request, { type: "skipped" });
       return undefined;
     }
 
@@ -248,28 +262,51 @@ export const rateLimit = ({
     });
 
     if (exceeded) {
+      requestState.set(request, { type: "limited" });
       set.status = 429;
       return DEFAULT_RATE_LIMIT_ERROR_RESPONSE;
     }
 
-    countedKeyByRequest.set(request, key);
+    requestState.set(
+      request,
+      phase === "before_handler"
+        ? { type: "counted", key }
+        : { type: "counted_early_failure" },
+    );
     return undefined;
   };
 
   plugin.onBeforeHandle(
     { as: "scoped" },
     async ({ request, server, set }) =>
-      await applyRateLimit({ request, server, set }),
+      await applyRateLimit({
+        phase: "before_handler",
+        request,
+        server,
+        set,
+      }),
   );
 
   plugin.onError(
     { as: "scoped" },
     async ({ code, error, request, server, set }) => {
-      const countedKey = countedKeyByRequest.get(request);
-      if (countedKey !== undefined) {
-        countedKeyByRequest.delete(request);
-        await context.decrement(countedKey);
-        return undefined;
+      const state = requestState.get(request);
+      if (state !== undefined) {
+        switch (state.type) {
+          case "counted":
+            requestState.set(request, { type: "refunded" });
+            await context.decrement(state.key);
+            return undefined;
+          case "counted_early_failure":
+          case "limited":
+          case "refunded":
+          case "skipped":
+            return undefined;
+          default: {
+            const unreachable: never = state;
+            return unreachable;
+          }
+        }
       }
 
       const currentStatus =
@@ -282,11 +319,56 @@ export const rateLimit = ({
         rateLimitErrorStatus(error) === 404;
 
       if (failedBeforeRateLimit) {
-        return await applyRateLimit({ request, server, set });
+        return await applyRateLimit({
+          phase: "early_failure",
+          request,
+          server,
+          set,
+        });
       }
       return undefined;
     },
   );
+
+  plugin.mapResponse({ as: "scoped" }, async (lifecycle) => {
+    const { request, responseValue, server, set } = lifecycle;
+    const handledError = Object.hasOwn(lifecycle, "code");
+    const statusCode = resolveResponseStatus({
+      response: responseValue,
+      set,
+    });
+    const state = requestState.get(request);
+
+    if (state === undefined) {
+      if (handledError && isEarlyFailureStatus(statusCode)) {
+        await applyRateLimit({
+          phase: "early_failure",
+          request,
+          server,
+          set,
+        });
+      }
+      return;
+    }
+
+    switch (state.type) {
+      case "counted":
+        if (handledError) {
+          requestState.set(request, { type: "refunded" });
+          await context.decrement(state.key);
+        }
+        return;
+      case "counted_early_failure":
+      case "limited":
+      case "refunded":
+      case "skipped":
+        return;
+      default: {
+        state satisfies never;
+        return;
+      }
+    }
+  });
 
   plugin.onStop(async () => {
     await context.kill();

--- a/apps/api/src/lib/rate-limit/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit/rate-limit.ts
@@ -1,4 +1,44 @@
-import type { Context, Generator, Options } from "elysia-rate-limit";
+import { Elysia } from "elysia";
+
+type MaybePromise<T> = T | Promise<T>;
+
+export type RateLimitCounter = {
+  count: number;
+  nextReset: Date;
+  start: number;
+};
+
+export type RateLimitContextConfig = {
+  duration: number;
+};
+
+export type RateLimitContext = {
+  decrement: (key: string) => MaybePromise<void>;
+  increment: (
+    key: string,
+    duration?: number,
+    requestTime?: number,
+  ) => MaybePromise<RateLimitCounter>;
+  init: (options: RateLimitContextConfig) => void;
+  kill: () => MaybePromise<void>;
+};
+
+export type RequestIpServer = {
+  requestIP: (request: Request) => { address: string } | null;
+};
+
+export type RateLimitGenerator = (
+  request: Request,
+  server: RequestIpServer | null,
+) => MaybePromise<string>;
+
+export type RateLimitOptions = {
+  context: RateLimitContext;
+  duration: number;
+  generator: RateLimitGenerator;
+  max: number;
+  skip?: (request: Request) => MaybePromise<boolean>;
+};
 
 type RateLimitEntry = {
   count: number;
@@ -14,13 +54,9 @@ const CLEANUP_INTERVAL_MS = 60_000;
  * counters.
  */
 export const scopedGenerator =
-  (scope: string): Generator =>
+  (scope: string): RateLimitGenerator =>
   (request, server) =>
     scopedRateLimitKey(scope, request, server);
-
-type RequestIpServer = {
-  requestIP: (request: Request) => { address: string } | null;
-};
 
 export const scopedRateLimitKey = (
   scope: string,
@@ -37,7 +73,7 @@ export const scopedRateLimitKey = (
  * to N× the configured limit. The hard global limit is
  * enforced at the network edge.
  */
-export class InMemoryRateLimitContext implements Context {
+export class InMemoryRateLimitContext implements RateLimitContext {
   private durationMs = 60_000;
   private readonly store = new Map<string, RateLimitEntry>();
   private readonly cleanupTimer: ReturnType<typeof setInterval>;
@@ -50,10 +86,8 @@ export class InMemoryRateLimitContext implements Context {
     this.cleanupTimer.unref();
   }
 
-  init(options: Omit<Options, "context">) {
-    if (typeof options.duration === "number") {
-      this.durationMs = options.duration;
-    }
+  init({ duration }: RateLimitContextConfig) {
+    this.durationMs = duration;
   }
 
   increment(key: string, duration?: number, requestTime?: number) {
@@ -109,3 +143,154 @@ export class InMemoryRateLimitContext implements Context {
     }
   }
 }
+
+type RateLimitResponseSet = {
+  headers: Record<string, string | number | boolean | undefined>;
+  status?: number | string;
+};
+
+const DEFAULT_RATE_LIMIT_ERROR_RESPONSE = "rate-limit reached";
+
+const writeRateLimitHeaders = ({
+  max,
+  remaining,
+  reset,
+  retryAfter,
+  set,
+}: {
+  max: number;
+  remaining: number;
+  reset: number;
+  retryAfter: boolean;
+  set: RateLimitResponseSet;
+}): void => {
+  set.headers["RateLimit-Limit"] = String(max);
+  set.headers["RateLimit-Remaining"] = String(remaining);
+  set.headers["RateLimit-Reset"] = String(reset);
+  if (retryAfter) {
+    set.headers["Retry-After"] = String(reset);
+  }
+};
+
+const rateLimitErrorStatus = (error: unknown): number | undefined => {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+  if ("status" in error && typeof error.status === "number") {
+    return error.status;
+  }
+  if ("statusCode" in error && typeof error.statusCode === "number") {
+    return error.statusCode;
+  }
+  return undefined;
+};
+
+const isResponseValidationError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "type" in error &&
+  error.type === "response";
+
+/**
+ * Stella's Elysia adapter for its replica-safe rate-limit contexts.
+ *
+ * The adapter deliberately exposes only the static fixed-window policy Stella
+ * uses. Counter storage, outage behavior, and refund identity remain owned by
+ * the supplied context rather than by framework middleware.
+ */
+export const rateLimit = ({
+  context,
+  duration,
+  generator,
+  max,
+  skip = () => false,
+}: RateLimitOptions) => {
+  context.init({ duration });
+  const countedKeyByRequest = new WeakMap<Request, string>();
+
+  // Each registration owns a route subtree even when two subtrees share the
+  // same counter key and limits. Keeping the plugin unnamed prevents Elysia's
+  // named-plugin deduplication from dropping either scoped hook.
+  const plugin = new Elysia();
+
+  const applyRateLimit = async ({
+    request,
+    server,
+    set,
+  }: {
+    request: Request;
+    server: RequestIpServer | null;
+    set: RateLimitResponseSet;
+  }): Promise<string | undefined> => {
+    if (await skip(request)) {
+      return undefined;
+    }
+
+    const key = await generator(request, server);
+    const { count, nextReset } = await context.increment(
+      key,
+      duration,
+      Date.now(),
+    );
+    const remaining = Math.max(max - count, 0);
+    const reset = Math.max(
+      0,
+      Math.ceil((nextReset.getTime() - Date.now()) / 1000),
+    );
+    const exceeded = count > max;
+
+    writeRateLimitHeaders({
+      max,
+      remaining,
+      reset,
+      retryAfter: exceeded,
+      set,
+    });
+
+    if (exceeded) {
+      set.status = 429;
+      return DEFAULT_RATE_LIMIT_ERROR_RESPONSE;
+    }
+
+    countedKeyByRequest.set(request, key);
+    return undefined;
+  };
+
+  plugin.onBeforeHandle(
+    { as: "scoped" },
+    async ({ request, server, set }) =>
+      await applyRateLimit({ request, server, set }),
+  );
+
+  plugin.onError(
+    { as: "scoped" },
+    async ({ code, error, request, server, set }) => {
+      const countedKey = countedKeyByRequest.get(request);
+      if (countedKey !== undefined) {
+        countedKeyByRequest.delete(request);
+        await context.decrement(countedKey);
+        return undefined;
+      }
+
+      const currentStatus =
+        typeof set.status === "number" ? set.status : undefined;
+      const failedBeforeRateLimit =
+        code === "NOT_FOUND" ||
+        code === "PARSE" ||
+        (code === "VALIDATION" && !isResponseValidationError(error)) ||
+        currentStatus === 404 ||
+        rateLimitErrorStatus(error) === 404;
+
+      if (failedBeforeRateLimit) {
+        return await applyRateLimit({ request, server, set });
+      }
+      return undefined;
+    },
+  );
+
+  plugin.onStop(async () => {
+    await context.kill();
+  });
+
+  return plugin;
+};

--- a/apps/api/src/lib/rate-limit/redis-context.cold-start.test.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.cold-start.test.ts
@@ -14,7 +14,8 @@
  */
 
 import { afterAll, describe, expect, mock, test } from "bun:test";
-import type { Options as RateLimitOptions } from "elysia-rate-limit";
+
+import type { RateLimitOptions } from "@/api/lib/rate-limit/rate-limit";
 
 // Any count the per-process fallback cannot produce on a first increment, so
 // the assertion below can only pass when the reply came from the peer.
@@ -52,13 +53,9 @@ const { RedisRateLimitContext } =
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const CONNECT_DEADLINE_MS = 5000;
 const RATE_LIMIT_OPTIONS = {
-  countFailedRequest: false,
   duration: RATE_LIMIT_WINDOW_MS,
-  errorResponse: "rate limit reached",
   generator: () => "cold-start-client",
-  headers: true,
   max: 10,
-  scoping: "scoped",
   skip: () => false,
 } as const satisfies Omit<RateLimitOptions, "context">;
 

--- a/apps/api/src/lib/rate-limit/redis-context.ts
+++ b/apps/api/src/lib/rate-limit/redis-context.ts
@@ -1,5 +1,4 @@
 import { Result, TaggedError } from "better-result";
-import type { Context, Generator, Options } from "elysia-rate-limit";
 
 import { detached } from "@/api/lib/detached";
 import { TimeoutError } from "@/api/lib/errors/tagged-errors";
@@ -7,6 +6,10 @@ import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import {
   InMemoryRateLimitContext,
+  type RateLimitContext,
+  type RateLimitContextConfig,
+  type RateLimitGenerator,
+  type RateLimitOptions,
   scopedGenerator,
 } from "@/api/lib/rate-limit/rate-limit";
 import {
@@ -89,12 +92,12 @@ type RedisRateLimitContextOptions = {
 };
 
 type CreateRedisRateLimitOptions = {
-  counterKeyGenerator?: Generator;
+  counterKeyGenerator?: RateLimitGenerator;
   failurePolicy: RedisRateLimitFailurePolicy;
   scope: string;
 };
 
-type RedisRateLimitBinding = Pick<Options, "context" | "generator">;
+type RedisRateLimitBinding = Pick<RateLimitOptions, "context" | "generator">;
 
 type RateLimitCounter = {
   count: number;
@@ -125,7 +128,7 @@ class RedisRateLimitReplyError extends TaggedError("RedisRateLimitReplyError")<{
 }> {}
 
 /** Replica-safe fixed-window context with a bounded, explicit outage policy. */
-export class RedisRateLimitContext implements Context {
+export class RedisRateLimitContext implements RateLimitContext {
   private readonly commandTimeoutMs: number;
   private readonly createRedis: () => RedisRateLimitClient;
   private readonly failurePolicy: RedisRateLimitFailurePolicy;
@@ -180,10 +183,8 @@ export class RedisRateLimitContext implements Context {
     this.openRedis();
   }
 
-  init(options: Omit<Options, "context">): void {
-    if (typeof options.duration === "number") {
-      this.durationMs = options.duration;
-    }
+  init(options: RateLimitContextConfig): void {
+    this.durationMs = options.duration;
     this.fallback.init(options);
   }
 
@@ -413,11 +414,11 @@ const parseRequestScopedKey = (key: string): ParsedRequestScopedKey => {
 const requestScopedGenerator = (
   scope: string,
   counterKeyGenerator = scopedGenerator(scope),
-): Generator => {
+): RateLimitGenerator => {
   const requestIds = new WeakMap<Request, string>();
 
-  return async (request, server, derived) => {
-    const counterKey = await counterKeyGenerator(request, server, derived);
+  return async (request, server) => {
+    const counterKey = await counterKeyGenerator(request, server);
     let requestId = requestIds.get(request);
     if (requestId === undefined) {
       requestId = Bun.randomUUIDv7();

--- a/apps/api/src/lib/redis-outage.test.ts
+++ b/apps/api/src/lib/redis-outage.test.ts
@@ -15,9 +15,10 @@
  */
 
 import { describe, expect, mock, test } from "bun:test";
-import type { Options as RateLimitOptions } from "elysia-rate-limit";
 
 import { resourceRef, RESOURCE_TYPE } from "@stll/api-contract";
+
+import type { RateLimitOptions } from "@/api/lib/rate-limit/rate-limit";
 
 // Port 1 is privileged and unbound in every environment this runs in, so a
 // connect attempt fails immediately rather than hanging on a routing black
@@ -65,13 +66,9 @@ const RATE_LIMIT_MAX = 10;
 // Time for a connect rejected by `kill()` to reach its handler.
 const CONNECT_SETTLE_MS = 100;
 const RATE_LIMIT_OPTIONS = {
-  countFailedRequest: false,
   duration: RATE_LIMIT_WINDOW_MS,
-  errorResponse: "rate limit reached",
   generator: () => "outage-client",
-  headers: true,
   max: RATE_LIMIT_MAX,
-  scoping: "scoped",
   skip: () => false,
 } as const satisfies Omit<RateLimitOptions, "context">;
 

--- a/apps/api/src/lib/signup-abuse.ts
+++ b/apps/api/src/lib/signup-abuse.ts
@@ -1,10 +1,10 @@
 import { disposableEmailBlocklistSet } from "disposable-email-domains-js";
-import type { Context } from "elysia-rate-limit";
 import { Address4, Address6 } from "ip-address";
 import { isIP } from "node:net";
 
 import { env } from "@/api/env";
 import { NEW_ACCOUNT_OTP_RATE_LIMITS } from "@/api/lib/limits";
+import type { RateLimitContext } from "@/api/lib/rate-limit/rate-limit";
 import { RedisRateLimitContext } from "@/api/lib/rate-limit/redis-context";
 
 const DISPOSABLE_EMAIL_DOMAINS = disposableEmailBlocklistSet();
@@ -92,7 +92,7 @@ export const consumeSignupOtpRateLimit = async ({
   identity,
   kind,
 }: {
-  context?: Pick<Context, "increment">;
+  context?: Pick<RateLimitContext, "increment">;
   identity: string;
   kind: "email" | "ip";
 }): Promise<SignupOtpRateLimitResult> => {
@@ -126,7 +126,7 @@ export const evaluateNewAccountOtpPolicy = async ({
 }: {
   accountExists: (normalizedEmail: string) => Promise<boolean>;
   clientIp: string | null;
-  context?: Pick<Context, "increment">;
+  context?: Pick<RateLimitContext, "increment">;
   email: string;
 }): Promise<NewAccountOtpPolicyResult> => {
   const normalizedEmail = normalizeAuthEmail(email);

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,7 +1,6 @@
 import cors from "@elysiajs/cors";
 import { Elysia } from "elysia";
 import type { Context } from "elysia";
-import { rateLimit } from "elysia-rate-limit";
 
 import { STELLA_API_VERSION_PREFIX } from "@stll/api-contract";
 
@@ -137,6 +136,7 @@ import {
 import { emitRequestDurationMetric } from "@/api/lib/observability/request-metrics";
 import { runWithRequestScope } from "@/api/lib/observability/request-scope";
 import { resolveResponseStatus } from "@/api/lib/observability/response-status";
+import { rateLimit } from "@/api/lib/rate-limit/rate-limit";
 import { createRedisRateLimit } from "@/api/lib/rate-limit/redis-context";
 import {
   isCorpusS3Stale,
@@ -518,7 +518,6 @@ const api = new Elysia()
     new Elysia()
       .use(
         rateLimit({
-          scoping: "scoped",
           duration: API_RATE_LIMITS.agentAuth.duration,
           max: API_RATE_LIMITS.agentAuth.max,
           ...createRedisRateLimit({
@@ -536,7 +535,6 @@ const api = new Elysia()
     new Elysia()
       .use(
         rateLimit({
-          scoping: "scoped",
           duration: API_RATE_LIMITS.api.duration,
           max: API_RATE_LIMITS.api.max,
           ...createRedisRateLimit({
@@ -565,7 +563,6 @@ const api = new Elysia()
 
       .use(
         rateLimit({
-          scoping: "scoped",
           duration: API_RATE_LIMITS.api.duration,
           max: API_RATE_LIMITS.api.max,
           ...createRedisRateLimit({
@@ -613,7 +610,6 @@ const api = new Elysia()
         new Elysia()
           .use(
             rateLimit({
-              scoping: "scoped",
               duration: API_RATE_LIMITS.folioCollab.duration,
               max: API_RATE_LIMITS.folioCollab.max,
               ...createRedisRateLimit({

--- a/bun.lock
+++ b/bun.lock
@@ -123,7 +123,6 @@
         "domhandler": "^6.0.1",
         "drizzle-orm": "catalog:",
         "elysia": "catalog:",
-        "elysia-rate-limit": "^4.6.2",
         "ip-address": "^10.5.0",
         "jose": "^6.2.9",
         "jszip": "catalog:",
@@ -996,8 +995,6 @@
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
     "@ag-ui/core": ["@ag-ui/core@0.1.1-canary.beta.0", "", { "peerDependencies": { "zod": "^3.25.18 || ^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-zcP3RH5p3HJTZ0kyQxNOL1blnVFTDpaShitR7UMS/thwFdl48V6CAG+WQBcYEu/dfa8mKonRez88N0Ok+nEI+w=="],
-
-    "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
@@ -3383,8 +3380,6 @@
 
     "elysia": ["elysia@1.4.29", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-GwMRGGwSdjfPt+w3LA0fqTuYJtS8uVRJicvoar98/HrO5qdFKDc9CwjIb6Kja+v39lkY+58hr2JvdR9jQzlUuA=="],
 
-    "elysia-rate-limit": ["elysia-rate-limit@4.6.2", "", { "dependencies": { "@alloc/quick-lru": "5.2.0", "debug": "4.3.4" }, "peerDependencies": { "elysia": ">= 1.0.0" } }, "sha512-3axf0dl9PECqg+Duo+qfiI/RWyYnl63osuVgaI4DnXJjLs7PxNzJINfnKIV1Tyg0mqONO1jzdAjwDrJ3HEmuug=="],
-
     "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -5339,8 +5334,6 @@
 
     "domutils/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
-    "elysia-rate-limit/debug": ["debug@4.3.4", "", { "dependencies": { "ms": "2.1.2" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ=="],
-
     "estree-util-to-js/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "expo-modules-autolinking/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -5734,8 +5727,6 @@
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
-
-    "elysia-rate-limit/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
     "expo-modules-autolinking/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 


### PR DESCRIPTION
## Summary

- replace `elysia-rate-limit` with a narrow internal Elysia adapter
- preserve Redis-backed fixed-window counters, scoped skips, response headers, failure refunds, and cleanup
- cover malformed requests, shared-client refunds, route scope, shutdown, and the 429 response contract

## Context

This removes the community plugin boundary so Elysia lifecycle compatibility is owned in one API module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limit handling across API requests, including appropriate refunds when requests fail.
  * Ensured rate-limit headers, skipped requests, early failures and scoped limits behave consistently.
  * Improved cleanup when rate-limiting services or the application shut down.

* **Refactor**
  * Replaced the external rate-limiting implementation with the application’s internal solution.
  * Preserved existing request limits and Redis-backed protection across API features.

* **Tests**
  * Expanded coverage for failures, validation errors, skipped requests, unknown routes and service outages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->