### PR TITLE
chore(api): consolidate case-law day traversal

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/adapters/calendar-day-slice-walk.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/calendar-day-slice-walk.ts
@@ -1,0 +1,48 @@
+import { panic } from "better-result";
+
+import type { AdapterKey } from "@/api/handlers/case-law/consts";
+import {
+  addUtcDays,
+  isoCalendarDay,
+  toUtcDateString,
+} from "@/api/lib/dates";
+
+type CalendarDaySliceWalkOptions = {
+  firstSlice: string;
+  source: AdapterKey;
+};
+
+export const createCalendarDaySliceWalk = ({
+  firstSlice,
+  source,
+}: CalendarDaySliceWalkOptions) => {
+  const dayStart = (slice: string): Date => {
+    const day = isoCalendarDay(slice);
+    if (day === null || day !== slice) {
+      panic(`${source} slice is not a UTC calendar day: ${slice}`);
+    }
+    return new Date(`${day}T00:00:00.000Z`);
+  };
+
+  const stepSlice = (slice: string, days: number): string =>
+    toUtcDateString(addUtcDays(dayStart(slice), days));
+
+  const nextSlice = (slice: string): string | null => {
+    const next = stepSlice(slice, 1);
+    return next > toUtcDateString(new Date()) ? null : next;
+  };
+
+  const previousSlice = (slice: string): string | null => {
+    const previous = stepSlice(slice, -1);
+    return previous < firstSlice ? null : previous;
+  };
+
+  return {
+    dayStart,
+    walk: {
+      sliceOf: toUtcDateString,
+      nextSlice,
+      previousSlice,
+    },
+  };
+};

--- a/apps/api/src/handlers/case-law/ingestion/adapters/calendar-day-slice-walk.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/calendar-day-slice-walk.ts
@@ -1,11 +1,7 @@
 import { panic } from "better-result";
 
 import type { AdapterKey } from "@/api/handlers/case-law/consts";
-import {
-  addUtcDays,
-  isoCalendarDay,
-  toUtcDateString,
-} from "@/api/lib/dates";
+import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
 
 type CalendarDaySliceWalkOptions = {
   firstSlice: string;

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -22,9 +22,7 @@ import type {
   ReconciliationSlicePage,
   ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
-import {
-  createCalendarDaySliceWalk,
-} from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
+import { createCalendarDaySliceWalk } from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
 import {
   INGESTION_USER_AGENT,
   adapterCatch,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -23,6 +23,9 @@ import type {
   ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import {
+  createCalendarDaySliceWalk,
+} from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
+import {
   INGESTION_USER_AGENT,
   adapterCatch,
   hashContent,
@@ -35,7 +38,6 @@ import {
   toOptionalValue,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
 import { parseNsDecisionHtml } from "@/api/handlers/case-law/ingestion/parsers/cz-ns";
-import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 import { errorTag } from "@/api/lib/errors/utils";
 import { fetchWithTimeout } from "@/api/lib/fetch";
@@ -494,30 +496,14 @@ export const CZ_NS_FIRST_SLICE = "2010-01-01";
  */
 const CZ_NS_TIP_WINDOW_DAYS = 14;
 
-const czNsDayStart = (slice: string): Date => {
-  const day = isoCalendarDay(slice);
-  if (day === null || day !== slice) {
-    panic(`cz-ns slice is not a UTC calendar day: ${slice}`);
-  }
-  return new Date(`${day}T00:00:00.000Z`);
-};
-
-const czNsStepSlice = (slice: string, days: number): string =>
-  toUtcDateString(addUtcDays(czNsDayStart(slice), days));
-
-const czNsNextSlice = (slice: string): string | null => {
-  const next = czNsStepSlice(slice, 1);
-  return next > toUtcDateString(new Date()) ? null : next;
-};
-
-const czNsPreviousSlice = (slice: string): string | null => {
-  const previous = czNsStepSlice(slice, -1);
-  return previous < CZ_NS_FIRST_SLICE ? null : previous;
-};
+const czNsDaySlices = createCalendarDaySliceWalk({
+  firstSlice: CZ_NS_FIRST_SLICE,
+  source: ADAPTER_KEYS.CZ_NS,
+});
 
 /** The publisher's own date literal for a slice: `DD.MM.YYYY`. */
 const czNsSliceDate = (slice: string): string => {
-  const start = czNsDayStart(slice);
+  const start = czNsDaySlices.dayStart(slice);
   const day = String(start.getUTCDate()).padStart(2, "0");
   const month = String(start.getUTCMonth() + 1).padStart(2, "0");
   return `${day}.${month}.${String(start.getUTCFullYear()).padStart(4, "0")}`;
@@ -784,9 +770,7 @@ export const czNsAdapter = defineSourceAdapter({
    */
   reconciliation: {
     firstSlice: CZ_NS_FIRST_SLICE,
-    sliceOf: toUtcDateString,
-    nextSlice: czNsNextSlice,
-    previousSlice: czNsPreviousSlice,
+    ...czNsDaySlices.walk,
     tipWindowDays: CZ_NS_TIP_WINDOW_DAYS,
     listSlicePage: listCzNsSlicePage,
     buildDecision: buildCzNsFromPayload,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -22,9 +22,7 @@ import type {
   ReconciliationSlicePage,
   ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
-import {
-  createCalendarDaySliceWalk,
-} from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
+import { createCalendarDaySliceWalk } from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
 import {
   INGESTION_USER_AGENT,
   adapterCatch,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -23,6 +23,9 @@ import type {
   ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import {
+  createCalendarDaySliceWalk,
+} from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
+import {
   INGESTION_USER_AGENT,
   adapterCatch,
   hashContent,
@@ -30,7 +33,7 @@ import {
   stripHtml,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
 import { parseNssDecisionHtml } from "@/api/handlers/case-law/ingestion/parsers/cz-nss";
-import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
+import { addUtcDays } from "@/api/lib/dates";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 import { errorTag } from "@/api/lib/errors/utils";
 import { fetchWithTimeout } from "@/api/lib/fetch";
@@ -1189,26 +1192,10 @@ export const czNssListingIdentity = (row: ParsedRow): ListingIdentity => {
  * it a day at a time. `YYYY-MM-DD` sorts lexicographically in chronological
  * order, which is the ordering the ledger relies on.
  */
-const czNssDayStart = (slice: string): Date => {
-  const day = isoCalendarDay(slice);
-  if (day === null || day !== slice) {
-    panic(`cz-nss slice is not a UTC calendar day: ${slice}`);
-  }
-  return new Date(`${day}T00:00:00.000Z`);
-};
-
-const czNssStepSlice = (slice: string, days: number): string =>
-  toUtcDateString(addUtcDays(czNssDayStart(slice), days));
-
-const czNssNextSlice = (slice: string): string | null => {
-  const next = czNssStepSlice(slice, 1);
-  return next > todayIso() ? null : next;
-};
-
-const czNssPreviousSlice = (slice: string): string | null => {
-  const previous = czNssStepSlice(slice, -1);
-  return previous < CZ_NSS_FIRST_SLICE ? null : previous;
-};
+const czNssDaySlices = createCalendarDaySliceWalk({
+  firstSlice: CZ_NSS_FIRST_SLICE,
+  source: ADAPTER_KEYS.CZ_NSS,
+});
 
 /**
  * One page of the portal's own listing for a decision day, with no detail or
@@ -1234,7 +1221,7 @@ const listCzNssSlicePage = async ({
 }: ReconciliationSlicePageOptions): Promise<ReconciliationSlicePage> => {
   // Refuse a slice this adapter cannot have produced before it reaches the
   // date formatter, which would silently query some other day for it.
-  czNssDayStart(slice);
+  czNssDaySlices.dayStart(slice);
   const effectiveSignal =
     signal ?? AbortSignal.timeout(CZ_NSS_LISTING_TIMEOUT_MS);
 
@@ -1473,9 +1460,7 @@ export const czNssAdapter = defineSourceAdapter({
    */
   reconciliation: {
     firstSlice: CZ_NSS_FIRST_SLICE,
-    sliceOf: toUtcDateString,
-    nextSlice: czNssNextSlice,
-    previousSlice: czNssPreviousSlice,
+    ...czNssDaySlices.walk,
     tipWindowDays: CZ_NSS_TIP_WINDOW_DAYS,
     listSlicePage: listCzNssSlicePage,
     buildDecision: buildCzNssFromPayload,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -23,6 +23,9 @@ import type {
   ReconciliationSlicePage,
   ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
+import {
+  createCalendarDaySliceWalk,
+} from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
 import { fetchWithRetry } from "@/api/handlers/case-law/ingestion/adapters/retry";
 import {
   INGESTION_USER_AGENT,
@@ -37,7 +40,7 @@ import {
   toOptionalValue,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
 import { parseRegionalDecision } from "@/api/handlers/case-law/ingestion/parsers/cz-regional";
-import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
+import { addUtcDays } from "@/api/lib/dates";
 import {
   AdapterFetchError,
   FetchBoundaryError,
@@ -842,26 +845,10 @@ export const buildCzRegionalDecision = async (
  * sorts lexicographically in chronological order, which is the ordering the
  * ledger relies on.
  */
-const czRegionalDayStart = (slice: string): Date => {
-  const day = isoCalendarDay(slice);
-  if (day === null || day !== slice) {
-    panic(`cz-regional slice is not a UTC calendar day: ${slice}`);
-  }
-  return new Date(`${day}T00:00:00.000Z`);
-};
-
-const czRegionalStepSlice = (slice: string, days: number): string =>
-  toUtcDateString(addUtcDays(czRegionalDayStart(slice), days));
-
-const czRegionalNextSlice = (slice: string): string | null => {
-  const next = czRegionalStepSlice(slice, 1);
-  return next > todayIso() ? null : next;
-};
-
-const czRegionalPreviousSlice = (slice: string): string | null => {
-  const previous = czRegionalStepSlice(slice, -1);
-  return previous < CZ_REGIONAL_FEED_START ? null : previous;
-};
+const czRegionalDaySlices = createCalendarDaySliceWalk({
+  firstSlice: CZ_REGIONAL_FEED_START,
+  source: ADAPTER_KEYS.CZ_REGIONAL,
+});
 
 const listCzRegionalSlicePage = async ({
   slice,
@@ -969,9 +956,7 @@ export const czRegionalAdapter = defineSourceAdapter({
    */
   reconciliation: {
     firstSlice: CZ_REGIONAL_FEED_START,
-    sliceOf: toUtcDateString,
-    nextSlice: czRegionalNextSlice,
-    previousSlice: czRegionalPreviousSlice,
+    ...czRegionalDaySlices.walk,
     tipWindowDays: CZ_REGIONAL_TIP_WINDOW_DAYS,
     listSlicePage: listCzRegionalSlicePage,
     buildDecision: buildCzRegionalFromPayload,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -23,9 +23,7 @@ import type {
   ReconciliationSlicePage,
   ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
-import {
-  createCalendarDaySliceWalk,
-} from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
+import { createCalendarDaySliceWalk } from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
 import { fetchWithRetry } from "@/api/handlers/case-law/ingestion/adapters/retry";
 import {
   INGESTION_USER_AGENT,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -21,6 +21,9 @@ import type {
   ReconciliationSlicePage,
   ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
+import {
+  createCalendarDaySliceWalk,
+} from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
 import { createPagePaginatedFetch } from "@/api/handlers/case-law/ingestion/adapters/pagination";
 import {
   hashContent,
@@ -33,7 +36,6 @@ import {
   toOptionalValue,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
 import { parsePlDecisionContent } from "@/api/handlers/case-law/ingestion/parsers/pl-courts";
-import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 import { errorTag } from "@/api/lib/errors/utils";
 import { fetchWithTimeout } from "@/api/lib/fetch";
@@ -929,26 +931,10 @@ const parseItemWithDetail = async (
  * `YYYY-MM-DD` sorts lexicographically in chronological order, which is the
  * ordering the ledger relies on.
  */
-const plCourtsDayStart = (slice: string): Date => {
-  const day = isoCalendarDay(slice);
-  if (day === null || day !== slice) {
-    panic(`pl-courts slice is not a UTC calendar day: ${slice}`);
-  }
-  return new Date(`${day}T00:00:00.000Z`);
-};
-
-const plCourtsStepSlice = (slice: string, days: number): string =>
-  toUtcDateString(addUtcDays(plCourtsDayStart(slice), days));
-
-const plCourtsNextSlice = (slice: string): string | null => {
-  const next = plCourtsStepSlice(slice, 1);
-  return next > toUtcDateString(new Date()) ? null : next;
-};
-
-const plCourtsPreviousSlice = (slice: string): string | null => {
-  const previous = plCourtsStepSlice(slice, -1);
-  return previous < PL_COURTS_FIRST_SLICE ? null : previous;
-};
+const plCourtsDaySlices = createCalendarDaySliceWalk({
+  firstSlice: PL_COURTS_FIRST_SLICE,
+  source: ADAPTER_KEYS.PL_COURTS,
+});
 
 /** The search endpoint's answer, read only for what a slice walk needs. */
 type SaosSliceResponse = {
@@ -1189,9 +1175,7 @@ export const plCourtsAdapter = defineSourceAdapter({
    */
   reconciliation: {
     firstSlice: PL_COURTS_FIRST_SLICE,
-    sliceOf: toUtcDateString,
-    nextSlice: plCourtsNextSlice,
-    previousSlice: plCourtsPreviousSlice,
+    ...plCourtsDaySlices.walk,
     tipWindowDays: PL_COURTS_TIP_WINDOW_DAYS,
     listSlicePage: listPlCourtsSlicePage,
     buildDecision: buildPlCourtsFromPayload,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -21,9 +21,7 @@ import type {
   ReconciliationSlicePage,
   ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
-import {
-  createCalendarDaySliceWalk,
-} from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
+import { createCalendarDaySliceWalk } from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
 import { createPagePaginatedFetch } from "@/api/handlers/case-law/ingestion/adapters/pagination";
 import {
   hashContent,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -20,6 +20,9 @@ import type {
   ReconciliationSlicePage,
   ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
+import {
+  createCalendarDaySliceWalk,
+} from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
 import { createPagePaginatedFetch } from "@/api/handlers/case-law/ingestion/adapters/pagination";
 import {
   INGESTION_USER_AGENT,
@@ -32,7 +35,6 @@ import {
   parseCeDate,
   toOptionalValue,
 } from "@/api/handlers/case-law/ingestion/adapters/utils";
-import { addUtcDays, isoCalendarDay, toUtcDateString } from "@/api/lib/dates";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
 import { fetchWithTimeout } from "@/api/lib/fetch";
 import { restrictSkCourtDocumentUrl } from "@/api/lib/legal-search/sk-court-document-url";
@@ -616,26 +618,10 @@ const SLICE_SORT_DIRECTION = "ASC";
  * a single year, and a slice of that size cannot be walked to the end, so the
  * ledger could never record it at all.
  */
-const skCourtsDayStart = (slice: string): Date => {
-  const day = isoCalendarDay(slice);
-  if (day === null || day !== slice) {
-    panic(`sk-courts slice is not a UTC calendar day: ${slice}`);
-  }
-  return new Date(`${day}T00:00:00.000Z`);
-};
-
-const skCourtsStepSlice = (slice: string, days: number): string =>
-  toUtcDateString(addUtcDays(skCourtsDayStart(slice), days));
-
-const skCourtsNextSlice = (slice: string): string | null => {
-  const next = skCourtsStepSlice(slice, 1);
-  return next > toUtcDateString(new Date()) ? null : next;
-};
-
-const skCourtsPreviousSlice = (slice: string): string | null => {
-  const previous = skCourtsStepSlice(slice, -1);
-  return previous < SK_COURTS_FIRST_SLICE ? null : previous;
-};
+const skCourtsDaySlices = createCalendarDaySliceWalk({
+  firstSlice: SK_COURTS_FIRST_SLICE,
+  source: ADAPTER_KEYS.SK_COURTS,
+});
 
 /**
  * The envelope a slice walk reads.
@@ -678,7 +664,7 @@ const listSkCourtsSlicePage = async ({
   // Refused here rather than at the publisher: this endpoint ignores a date it
   // cannot parse and answers the whole 4.6M-decision collection instead, which
   // a walk would read as one date holding all of it.
-  skCourtsDayStart(slice);
+  skCourtsDaySlices.dayStart(slice);
   const url = `${BASE_URL}?${new URLSearchParams({
     page: String(page + LISTING_FIRST_PAGE),
     size: String(LISTING_PAGE_SIZE),
@@ -823,9 +809,7 @@ export const skCourtsAdapter = defineSourceAdapter({
    */
   reconciliation: {
     firstSlice: SK_COURTS_FIRST_SLICE,
-    sliceOf: toUtcDateString,
-    nextSlice: skCourtsNextSlice,
-    previousSlice: skCourtsPreviousSlice,
+    ...skCourtsDaySlices.walk,
     tipWindowDays: SK_COURTS_TIP_WINDOW_DAYS,
     listSlicePage: listSkCourtsSlicePage,
     buildDecision: buildSkCourtsFromPayload,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -20,9 +20,7 @@ import type {
   ReconciliationSlicePage,
   ReconciliationSlicePageOptions,
 } from "@/api/handlers/case-law/ingestion/adapter";
-import {
-  createCalendarDaySliceWalk,
-} from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
+import { createCalendarDaySliceWalk } from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
 import { createPagePaginatedFetch } from "@/api/handlers/case-law/ingestion/adapters/pagination";
 import {
   INGESTION_USER_AGENT,


### PR DESCRIPTION
## Summary

- replace five duplicate strict UTC calendar-day traversal implementations with one adapter helper
- keep each source’s first-slice boundary, current-day ceiling, and source-specific invariant message
- reuse the same strict parser for reconciliation traversal and publisher-query validation

## Validation

- `git diff --check`
- staged secret scan
- local lint, format, typecheck, and test runs intentionally deferred to CI

## Size

- 123 lines removed, 79 added; net -44 lines