### PR TITLE
chore(api): consolidate BullMQ lifecycle plumbing

### DIFF
--- a/apps/api/src/handlers/reports/report-export-queue.ts
+++ b/apps/api/src/handlers/reports/report-export-queue.ts
@@ -14,7 +14,7 @@
  */
 
 import { Result } from "better-result";
-import { Queue, Worker } from "bullmq";
+import { Worker } from "bullmq";
 import { and, eq, inArray } from "drizzle-orm";
 
 import type { SafeDb, ScopedDb } from "@/api/db/safe-db";
@@ -39,6 +39,7 @@ import { assertUsageAvailableForHandler } from "@/api/lib/api-handlers";
 import { createBackgroundAuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
 import {
   buildAiConditionDecider,
   buildAiFieldGenerator,
@@ -47,6 +48,7 @@ import {
 import { createEntityFromBuffer } from "@/api/lib/entities/create-from-buffer";
 import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
 import { convertToPdf } from "@/api/lib/files/gotenberg";
+import { startNonOverlappingInterval } from "@/api/lib/non-overlapping-interval";
 import { logger } from "@/api/lib/observability/logger";
 import { createBullMqConnection } from "@/api/lib/redis-client";
 import { listPendingReportExportNotifications } from "@/api/lib/report-export-notification-recovery";
@@ -105,25 +107,14 @@ export type EnqueueReportExportArgs = {
   aiNarrative: boolean;
 };
 
-let queue: Queue<ReportExportJobData> | null = null;
-let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
-
-const getQueueConnection = () => {
-  queueConnection ??= createBullMqConnection();
-  return queueConnection;
-};
-
-const getQueue = (): Queue<ReportExportJobData> => {
-  queue ??= new Queue<ReportExportJobData>(QUEUE_NAME, {
-    connection: getQueueConnection(),
-    defaultJobOptions: {
-      attempts: JOB_ATTEMPTS,
-      removeOnComplete: 100,
-      removeOnFail: 500,
-    },
-  });
-  return queue;
-};
+const getQueue = createLazyBullMqQueue<ReportExportJobData>({
+  name: QUEUE_NAME,
+  defaultJobOptions: {
+    attempts: JOB_ATTEMPTS,
+    removeOnComplete: 100,
+    removeOnFail: 500,
+  },
+});
 
 export const enqueueReportExport = async ({
   exportId,
@@ -204,8 +195,6 @@ export const initReportExportWorker = () => {
     logger.error("report_export.worker_error", connectionErrorFields(error));
   });
 
-  let closing = false;
-  let activeNotificationReconcile: Promise<void> | null = null;
   const runNotificationReconcile = async (): Promise<void> => {
     const { actors, suppressed } = await listPendingReportExportNotifications();
     const results = await Promise.all(
@@ -227,26 +216,15 @@ export const initReportExportWorker = () => {
       });
     }
   };
-  const scheduleNotificationReconcile = (): void => {
-    if (closing || activeNotificationReconcile !== null) {
-      return;
-    }
-    activeNotificationReconcile = runNotificationReconcile()
-      .catch((error: unknown) => {
-        captureError(error, {
-          operation: "report_export.notification.reconcile",
-        });
-      })
-      .finally(() => {
-        activeNotificationReconcile = null;
+  const closeNotificationReconcile = startNonOverlappingInterval({
+    intervalMs: NOTIFICATION_RECONCILE_INTERVAL_MS,
+    run: runNotificationReconcile,
+    onError: (error) => {
+      captureError(error, {
+        operation: "report_export.notification.reconcile",
       });
-  };
-  scheduleNotificationReconcile();
-  const notificationReconcileTimer = setInterval(
-    scheduleNotificationReconcile,
-    NOTIFICATION_RECONCILE_INTERVAL_MS,
-  );
-  notificationReconcileTimer.unref();
+    },
+  });
 
   logger.info("report_export.worker_started", {
     concurrency: String(WORKER_CONCURRENCY),
@@ -254,11 +232,7 @@ export const initReportExportWorker = () => {
 
   return {
     close: async () => {
-      closing = true;
-      clearInterval(notificationReconcileTimer);
-      if (activeNotificationReconcile !== null) {
-        await activeNotificationReconcile;
-      }
+      await closeNotificationReconcile();
       await worker.close();
     },
   };

--- a/apps/api/src/lib/account-deletion-cleanup-queue.ts
+++ b/apps/api/src/lib/account-deletion-cleanup-queue.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { Queue, Worker } from "bullmq";
+import { type Queue, Worker } from "bullmq";
 
 import {
   claimNextAccountDeletionEffectChunk,
@@ -11,6 +11,7 @@ import {
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
 import { detached } from "@/api/lib/detached";
 import {
   connectionErrorFields,
@@ -53,26 +54,15 @@ const defaultCleanupRequestDeps: AccountDeletionCleanupRequestDeps = {
   failChunk: failAccountDeletionEffectChunk,
 };
 
-let queue: Queue<AccountDeletionCleanupJobData> | null = null;
-let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
-
-const getQueueConnection = () => {
-  queueConnection ??= createBullMqConnection();
-  return queueConnection;
-};
-
-const getQueue = (): Queue<AccountDeletionCleanupJobData> => {
-  queue ??= new Queue<AccountDeletionCleanupJobData>(QUEUE_NAME, {
-    connection: getQueueConnection(),
-    defaultJobOptions: {
-      attempts: DEFAULT_JOB_ATTEMPTS,
-      backoff: { type: "exponential", delay: 30_000 },
-      removeOnComplete: 100,
-      removeOnFail: 500,
-    },
-  });
-  return queue;
-};
+const getQueue = createLazyBullMqQueue<AccountDeletionCleanupJobData>({
+  name: QUEUE_NAME,
+  defaultJobOptions: {
+    attempts: DEFAULT_JOB_ATTEMPTS,
+    backoff: { type: "exponential", delay: 30_000 },
+    removeOnComplete: 100,
+    removeOnFail: 500,
+  },
+});
 
 export const enqueueAccountDeletionCleanup = async (
   requestId: SafeId<"accountDeletionRequest">,

--- a/apps/api/src/lib/bilingual/run-queue.ts
+++ b/apps/api/src/lib/bilingual/run-queue.ts
@@ -12,7 +12,7 @@
  */
 
 import { Result } from "better-result";
-import { Queue, Worker } from "bullmq";
+import { Worker } from "bullmq";
 import { and, asc, eq, inArray, lt, or, sql } from "drizzle-orm";
 
 import { applyFolioAIEditsToBuffer } from "@stll/folio-core/server";
@@ -48,11 +48,13 @@ import type { StoredRow } from "@/api/lib/bilingual/operations";
 import { checkTranslationConsistency } from "@/api/lib/bilingual/rows";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
 import { createEntityVersionFromBuffer } from "@/api/lib/entity-versions/create-entity-version-from-buffer";
 import { loadEntityVersionDocxBuffer } from "@/api/lib/entity-versions/load-entity-version-docx-buffer";
 import { validateDocxBuffer } from "@/api/lib/entity-versions/validate-docx-buffer";
 import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
 import { getScanWarnings, scanFile } from "@/api/lib/file-scan/scan";
+import { startNonOverlappingInterval } from "@/api/lib/non-overlapping-interval";
 import { logger } from "@/api/lib/observability/logger";
 import { createBullMqConnection } from "@/api/lib/redis-client";
 import { createRootSafeDb, createRootScopedDb } from "@/api/lib/root-scoped-db";
@@ -87,25 +89,14 @@ export type EnqueueBilingualRunArgs = {
   userId: SafeId<"user">;
 };
 
-let queue: Queue<BilingualRunJobData> | null = null;
-let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
-
-const getQueueConnection = () => {
-  queueConnection ??= createBullMqConnection();
-  return queueConnection;
-};
-
-const getQueue = (): Queue<BilingualRunJobData> => {
-  queue ??= new Queue<BilingualRunJobData>(QUEUE_NAME, {
-    connection: getQueueConnection(),
-    defaultJobOptions: {
-      attempts: JOB_ATTEMPTS,
-      removeOnComplete: 100,
-      removeOnFail: 500,
-    },
-  });
-  return queue;
-};
+const getQueue = createLazyBullMqQueue<BilingualRunJobData>({
+  name: QUEUE_NAME,
+  defaultJobOptions: {
+    attempts: JOB_ATTEMPTS,
+    removeOnComplete: 100,
+    removeOnFail: 500,
+  },
+});
 
 export const enqueueBilingualRun = async ({
   runId,
@@ -179,34 +170,20 @@ export const initBilingualRunWorker = () => {
     logger.error("bilingual_run.worker_error", connectionErrorFields(error));
   });
 
-  let closing = false;
-  let activeReconcile: Promise<void> | null = null;
-  const scheduleReconcile = (): void => {
-    if (closing || activeReconcile !== null) {
-      return;
-    }
-    activeReconcile = reconcileStuckBilingualRuns()
-      .then((recovered) => {
-        if (recovered > 0) {
-          logger.warn("bilingual_run.recovered_stuck", {
-            count: String(recovered),
-          });
-        }
-        return undefined;
-      })
-      .catch((error: unknown) => {
-        captureError(error, { operation: "bilingual_run.reconcile" });
-      })
-      .finally(() => {
-        activeReconcile = null;
-      });
-  };
-  scheduleReconcile();
-  const reconcileTimer = setInterval(
-    scheduleReconcile,
-    ORPHAN_RECONCILE_INTERVAL_MS,
-  );
-  reconcileTimer.unref();
+  const closeReconcile = startNonOverlappingInterval({
+    intervalMs: ORPHAN_RECONCILE_INTERVAL_MS,
+    run: async () => {
+      const recovered = await reconcileStuckBilingualRuns();
+      if (recovered > 0) {
+        logger.warn("bilingual_run.recovered_stuck", {
+          count: String(recovered),
+        });
+      }
+    },
+    onError: (error) => {
+      captureError(error, { operation: "bilingual_run.reconcile" });
+    },
+  });
 
   logger.info("bilingual_run.worker_started", {
     concurrency: String(WORKER_CONCURRENCY),
@@ -214,11 +191,7 @@ export const initBilingualRunWorker = () => {
 
   return {
     close: async () => {
-      closing = true;
-      clearInterval(reconcileTimer);
-      if (activeReconcile !== null) {
-        await activeReconcile;
-      }
+      await closeReconcile();
       await worker.close();
     },
   };

--- a/apps/api/src/lib/bullmq-queue.ts
+++ b/apps/api/src/lib/bullmq-queue.ts
@@ -1,0 +1,27 @@
+import { Queue } from "bullmq";
+import type { QueueOptions } from "bullmq";
+
+import { createBullMqConnection } from "@/api/lib/redis-client";
+
+type LazyBullMqQueueOptions = Omit<QueueOptions, "connection"> & {
+  createConnection?: () => ReturnType<typeof createBullMqConnection>;
+  name: string;
+};
+
+export const createLazyBullMqQueue = <DataType>({
+  createConnection = createBullMqConnection,
+  name,
+  ...options
+}: LazyBullMqQueueOptions) => {
+  let connection: ReturnType<typeof createBullMqConnection> | null = null;
+  let queue: Queue<DataType> | null = null;
+
+  return () => {
+    connection ??= createConnection();
+    queue ??= new Queue<DataType>(name, {
+      ...options,
+      connection,
+    });
+    return queue;
+  };
+};

--- a/apps/api/src/lib/bullmq-queue.ts
+++ b/apps/api/src/lib/bullmq-queue.ts
@@ -1,15 +1,16 @@
 import { Queue } from "bullmq";
 import type { QueueOptions } from "bullmq";
+import type { RedisOptions } from "bun";
 
 import { createBullMqConnection } from "@/api/lib/redis-client";
 
 type LazyBullMqQueueOptions = Omit<QueueOptions, "connection"> & {
-  createConnection?: () => ReturnType<typeof createBullMqConnection>;
+  connectionOptions?: RedisOptions;
   name: string;
 };
 
 export const createLazyBullMqQueue = <DataType>({
-  createConnection = createBullMqConnection,
+  connectionOptions,
   name,
   ...options
 }: LazyBullMqQueueOptions) => {
@@ -17,7 +18,7 @@ export const createLazyBullMqQueue = <DataType>({
   let queue: Queue<DataType> | null = null;
 
   return () => {
-    connection ??= createConnection();
+    connection ??= createBullMqConnection(connectionOptions);
     queue ??= new Queue<DataType>(name, {
       ...options,
       connection,

--- a/apps/api/src/lib/document-processing-enqueue.ts
+++ b/apps/api/src/lib/document-processing-enqueue.ts
@@ -1,7 +1,6 @@
 import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
 import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
-import { createBullMqConnection } from "@/api/lib/redis-client";
 
 export const DOCUMENT_PROCESSING_QUEUE_NAME = "document-processing";
 export const DOCUMENT_PROCESSING_OCR_JOB_NAME = "ocr";
@@ -17,11 +16,10 @@ export type DocumentProcessingJobData = {
 
 const getQueue = createLazyBullMqQueue<DocumentProcessingJobData>({
   name: DOCUMENT_PROCESSING_QUEUE_NAME,
-  createConnection: () =>
-    createBullMqConnection({
-      connectionTimeout: QUEUE_OPERATION_TIMEOUT_MS,
-      enableOfflineQueue: false,
-    }),
+  connectionOptions: {
+    connectionTimeout: QUEUE_OPERATION_TIMEOUT_MS,
+    enableOfflineQueue: false,
+  },
   defaultJobOptions: {
     attempts: DEFAULT_JOB_ATTEMPTS,
     removeOnComplete: 1000,

--- a/apps/api/src/lib/document-processing-enqueue.ts
+++ b/apps/api/src/lib/document-processing-enqueue.ts
@@ -1,7 +1,6 @@
-import { Queue } from "bullmq";
-
 import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
 import { createBullMqConnection } from "@/api/lib/redis-client";
 
 export const DOCUMENT_PROCESSING_QUEUE_NAME = "document-processing";
@@ -16,31 +15,19 @@ export type DocumentProcessingJobData = {
   runId: SafeId<"documentProcessingRun">;
 };
 
-let queue: Queue<DocumentProcessingJobData> | null = null;
-let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
-
-const getQueueConnection = () => {
-  queueConnection ??= createBullMqConnection({
-    connectionTimeout: QUEUE_OPERATION_TIMEOUT_MS,
-    enableOfflineQueue: false,
-  });
-  return queueConnection;
-};
-
-const getQueue = (): Queue<DocumentProcessingJobData> => {
-  queue ??= new Queue<DocumentProcessingJobData>(
-    DOCUMENT_PROCESSING_QUEUE_NAME,
-    {
-      connection: getQueueConnection(),
-      defaultJobOptions: {
-        attempts: DEFAULT_JOB_ATTEMPTS,
-        removeOnComplete: 1000,
-        removeOnFail: 5000,
-      },
-    },
-  );
-  return queue;
-};
+const getQueue = createLazyBullMqQueue<DocumentProcessingJobData>({
+  name: DOCUMENT_PROCESSING_QUEUE_NAME,
+  createConnection: () =>
+    createBullMqConnection({
+      connectionTimeout: QUEUE_OPERATION_TIMEOUT_MS,
+      enableOfflineQueue: false,
+    }),
+  defaultJobOptions: {
+    attempts: DEFAULT_JOB_ATTEMPTS,
+    removeOnComplete: 1000,
+    removeOnFail: 5000,
+  },
+});
 
 /**
  * Jobs currently visible to the queue in any not-yet-finished state. The

--- a/apps/api/src/lib/document-review/run-queue.ts
+++ b/apps/api/src/lib/document-review/run-queue.ts
@@ -18,7 +18,7 @@
  */
 
 import { Result } from "better-result";
-import { Queue, Worker } from "bullmq";
+import { Worker } from "bullmq";
 import { and, eq, inArray, lt, or } from "drizzle-orm";
 
 import { DAY_IN_MS } from "@stll/time";
@@ -37,6 +37,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import type { AIUsageMetering } from "@/api/lib/analytics/tanstack-ai";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
 import type { DocumentReviewTopic } from "@/api/lib/document-review/contract";
 import {
   buildDocumentReviewFindingRow,
@@ -62,6 +63,7 @@ import { finalizeReviewRun } from "@/api/lib/document-review/run-finalize";
 import { planReviewRun } from "@/api/lib/document-review/run-plan";
 import type { ReviewRunPlan } from "@/api/lib/document-review/run-plan";
 import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
+import { startNonOverlappingInterval } from "@/api/lib/non-overlapping-interval";
 import { logger } from "@/api/lib/observability/logger";
 import { createBullMqConnection } from "@/api/lib/redis-client";
 import { createRootSafeDb, createRootScopedDb } from "@/api/lib/root-scoped-db";
@@ -115,25 +117,14 @@ export type EnqueueDocumentReviewRunArgs = {
   userId: SafeId<"user">;
 };
 
-let queue: Queue<DocumentReviewRunJobData> | null = null;
-let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
-
-const getQueueConnection = () => {
-  queueConnection ??= createBullMqConnection();
-  return queueConnection;
-};
-
-const getQueue = (): Queue<DocumentReviewRunJobData> => {
-  queue ??= new Queue<DocumentReviewRunJobData>(QUEUE_NAME, {
-    connection: getQueueConnection(),
-    defaultJobOptions: {
-      attempts: JOB_ATTEMPTS,
-      removeOnComplete: 100,
-      removeOnFail: 500,
-    },
-  });
-  return queue;
-};
+const getQueue = createLazyBullMqQueue<DocumentReviewRunJobData>({
+  name: QUEUE_NAME,
+  defaultJobOptions: {
+    attempts: JOB_ATTEMPTS,
+    removeOnComplete: 100,
+    removeOnFail: 500,
+  },
+});
 
 /** One job, described exactly as the queue takes it. The run id IS the job
  *  identity: a duplicate enqueue collapses onto the job already in flight
@@ -257,8 +248,6 @@ export const initDocumentReviewRunWorker = () => {
     );
   });
 
-  let closing = false;
-  let activeReconcile: Promise<void> | null = null;
   const runReconcile = async (): Promise<void> => {
     const recovered = await reconcileStuckDocumentReviewRuns();
     if (recovered > 0) {
@@ -267,24 +256,13 @@ export const initDocumentReviewRunWorker = () => {
       });
     }
   };
-  const scheduleReconcile = (): void => {
-    if (closing || activeReconcile !== null) {
-      return;
-    }
-    activeReconcile = runReconcile()
-      .catch((error: unknown) => {
-        captureError(error, { operation: "document_review_run.reconcile" });
-      })
-      .finally(() => {
-        activeReconcile = null;
-      });
-  };
-  scheduleReconcile();
-  const reconcileTimer = setInterval(
-    scheduleReconcile,
-    ORPHAN_RECONCILE_INTERVAL_MS,
-  );
-  reconcileTimer.unref();
+  const closeReconcile = startNonOverlappingInterval({
+    intervalMs: ORPHAN_RECONCILE_INTERVAL_MS,
+    run: runReconcile,
+    onError: (error) => {
+      captureError(error, { operation: "document_review_run.reconcile" });
+    },
+  });
 
   logger.info("document_review_run.worker_started", {
     concurrency: String(WORKER_CONCURRENCY),
@@ -292,11 +270,7 @@ export const initDocumentReviewRunWorker = () => {
 
   return {
     close: async () => {
-      closing = true;
-      clearInterval(reconcileTimer);
-      if (activeReconcile !== null) {
-        await activeReconcile;
-      }
+      await closeReconcile();
       await worker.close();
     },
   };

--- a/apps/api/src/lib/entity-deletion-cleanup-queue.ts
+++ b/apps/api/src/lib/entity-deletion-cleanup-queue.ts
@@ -65,11 +65,10 @@ const defaultCleanupRequestDeps: EntityDeletionCleanupRequestDeps = {
 
 const getQueue = createLazyBullMqQueue<EntityDeletionCleanupJobData>({
   name: QUEUE_NAME,
-  createConnection: () =>
-    createBullMqConnection({
-      connectionTimeout: QUEUE_OPERATION_TIMEOUT_MS,
-      enableOfflineQueue: false,
-    }),
+  connectionOptions: {
+    connectionTimeout: QUEUE_OPERATION_TIMEOUT_MS,
+    enableOfflineQueue: false,
+  },
   defaultJobOptions: {
     attempts: DEFAULT_JOB_ATTEMPTS,
     backoff: { type: "exponential", delay: 30_000 },

--- a/apps/api/src/lib/entity-deletion-cleanup-queue.ts
+++ b/apps/api/src/lib/entity-deletion-cleanup-queue.ts
@@ -1,10 +1,11 @@
 import { Result, UnhandledException } from "better-result";
-import { Queue, Worker } from "bullmq";
+import { type Queue, Worker } from "bullmq";
 
 import type { EntityDeletionCleanupStatus } from "@/api/db/schema";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
 import { detached } from "@/api/lib/detached";
 import {
   claimNextEntityDeletionEffectChunk,
@@ -62,29 +63,20 @@ const defaultCleanupRequestDeps: EntityDeletionCleanupRequestDeps = {
   storageDeleteTimeoutMs: STORAGE_DELETE_TIMEOUT_MS,
 };
 
-let queue: Queue<EntityDeletionCleanupJobData> | null = null;
-let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
-
-const getQueueConnection = () => {
-  queueConnection ??= createBullMqConnection({
-    connectionTimeout: QUEUE_OPERATION_TIMEOUT_MS,
-    enableOfflineQueue: false,
-  });
-  return queueConnection;
-};
-
-const getQueue = (): Queue<EntityDeletionCleanupJobData> => {
-  queue ??= new Queue<EntityDeletionCleanupJobData>(QUEUE_NAME, {
-    connection: getQueueConnection(),
-    defaultJobOptions: {
-      attempts: DEFAULT_JOB_ATTEMPTS,
-      backoff: { type: "exponential", delay: 30_000 },
-      removeOnComplete: 100,
-      removeOnFail: 500,
-    },
-  });
-  return queue;
-};
+const getQueue = createLazyBullMqQueue<EntityDeletionCleanupJobData>({
+  name: QUEUE_NAME,
+  createConnection: () =>
+    createBullMqConnection({
+      connectionTimeout: QUEUE_OPERATION_TIMEOUT_MS,
+      enableOfflineQueue: false,
+    }),
+  defaultJobOptions: {
+    attempts: DEFAULT_JOB_ATTEMPTS,
+    backoff: { type: "exponential", delay: 30_000 },
+    removeOnComplete: 100,
+    removeOnFail: 500,
+  },
+});
 
 export const enqueueEntityDeletionCleanup = async (
   requestId: SafeId<"entityDeletionCleanupRequest">,

--- a/apps/api/src/lib/file-derivative-queue.ts
+++ b/apps/api/src/lib/file-derivative-queue.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { Queue, Worker } from "bullmq";
+import { Worker } from "bullmq";
 import { and, eq, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
@@ -14,6 +14,7 @@ import type {
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
 import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
 import { decidePdfDerivativeAction } from "@/api/lib/file-derivative-decision";
 import {
@@ -84,26 +85,15 @@ type EnqueueFileDerivativeArgs = {
   workspaceId: SafeId<"workspace">;
 };
 
-let queue: Queue<FileDerivativeJobData> | null = null;
-let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
-
-const getQueueConnection = () => {
-  queueConnection ??= createBullMqConnection();
-  return queueConnection;
-};
-
-const getQueue = (): Queue<FileDerivativeJobData> => {
-  queue ??= new Queue<FileDerivativeJobData>(QUEUE_NAME, {
-    connection: getQueueConnection(),
-    defaultJobOptions: {
-      attempts: DEFAULT_JOB_ATTEMPTS,
-      backoff: { type: "exponential", delay: 30_000 },
-      removeOnComplete: 100,
-      removeOnFail: 500,
-    },
-  });
-  return queue;
-};
+const getQueue = createLazyBullMqQueue<FileDerivativeJobData>({
+  name: QUEUE_NAME,
+  defaultJobOptions: {
+    attempts: DEFAULT_JOB_ATTEMPTS,
+    backoff: { type: "exponential", delay: 30_000 },
+    removeOnComplete: 100,
+    removeOnFail: 500,
+  },
+});
 
 export const enqueuePdfDerivative = async ({
   encrypted,

--- a/apps/api/src/lib/flows/flow-run-queue.ts
+++ b/apps/api/src/lib/flows/flow-run-queue.ts
@@ -1,6 +1,4 @@
-import { Queue } from "bullmq";
-
-import { createBullMqConnection } from "@/api/lib/redis-client";
+import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
 
 // ── Queue name + payload ────────────────────────────────
 
@@ -30,26 +28,15 @@ const FLOW_STEP_JOB_BACKOFF_MS = 5000;
 
 // ── Lazy singletons ─────────────────────────────────────
 
-let queue: Queue<FlowStepJobData> | null = null;
-let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
-
-const getQueueConnection = () => {
-  queueConnection ??= createBullMqConnection();
-  return queueConnection;
-};
-
-const getQueue = (): Queue<FlowStepJobData> => {
-  queue ??= new Queue<FlowStepJobData>(FLOW_RUN_QUEUE_NAME, {
-    connection: getQueueConnection(),
-    defaultJobOptions: {
-      removeOnComplete: 100,
-      removeOnFail: 500,
-      attempts: FLOW_STEP_JOB_ATTEMPTS,
-      backoff: { type: "exponential", delay: FLOW_STEP_JOB_BACKOFF_MS },
-    },
-  });
-  return queue;
-};
+const getQueue = createLazyBullMqQueue<FlowStepJobData>({
+  name: FLOW_RUN_QUEUE_NAME,
+  defaultJobOptions: {
+    removeOnComplete: 100,
+    removeOnFail: 500,
+    attempts: FLOW_STEP_JOB_ATTEMPTS,
+    backoff: { type: "exponential", delay: FLOW_STEP_JOB_BACKOFF_MS },
+  },
+});
 
 // Deterministic per-(run, step) job id. Prevents the same step being enqueued
 // twice (start + orphan sweep, or two concurrent review resolutions) and lets

--- a/apps/api/src/lib/non-overlapping-interval.ts
+++ b/apps/api/src/lib/non-overlapping-interval.ts
@@ -1,0 +1,37 @@
+type NonOverlappingIntervalOptions = {
+  intervalMs: number;
+  onError: (error: unknown) => void;
+  run: () => Promise<void>;
+};
+
+export const startNonOverlappingInterval = ({
+  intervalMs,
+  onError,
+  run,
+}: NonOverlappingIntervalOptions) => {
+  let active: Promise<void> | null = null;
+  let closing = false;
+
+  const schedule = (): void => {
+    if (closing || active !== null) {
+      return;
+    }
+    active = run()
+      .catch(onError)
+      .finally(() => {
+        active = null;
+      });
+  };
+
+  schedule();
+  const timer = setInterval(schedule, intervalMs);
+  timer.unref();
+
+  return async () => {
+    closing = true;
+    clearInterval(timer);
+    if (active !== null) {
+      await active;
+    }
+  };
+};

--- a/apps/api/src/lib/style-set-package-cleanup-queue.ts
+++ b/apps/api/src/lib/style-set-package-cleanup-queue.ts
@@ -1,9 +1,10 @@
-import { Queue, Worker } from "bullmq";
+import { Worker } from "bullmq";
 import { eq, or } from "drizzle-orm";
 
 import { rootDb } from "@/api/db/root";
 import { styleSets } from "@/api/db/schema";
 import { createBullMqJobId } from "@/api/lib/bullmq-job-id";
+import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
 import { connectionErrorFields, errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { createBullMqConnection } from "@/api/lib/redis-client";
@@ -45,26 +46,15 @@ type StyleSetPackageCleanupQueue = {
   getJob: (jobId: string) => Promise<StyleSetPackageCleanupJob | undefined>;
 };
 
-let queue: Queue<StyleSetPackageCleanupJobData> | null = null;
-let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
-
-const getQueueConnection = () => {
-  queueConnection ??= createBullMqConnection();
-  return queueConnection;
-};
-
-const getQueue = (): Queue<StyleSetPackageCleanupJobData> => {
-  queue ??= new Queue<StyleSetPackageCleanupJobData>(QUEUE_NAME, {
-    connection: getQueueConnection(),
-    defaultJobOptions: {
-      attempts: DEFAULT_JOB_ATTEMPTS,
-      backoff: { type: "exponential", delay: 30_000 },
-      removeOnComplete: 100,
-      removeOnFail: 500,
-    },
-  });
-  return queue;
-};
+const getQueue = createLazyBullMqQueue<StyleSetPackageCleanupJobData>({
+  name: QUEUE_NAME,
+  defaultJobOptions: {
+    attempts: DEFAULT_JOB_ATTEMPTS,
+    backoff: { type: "exponential", delay: 30_000 },
+    removeOnComplete: 100,
+    removeOnFail: 500,
+  },
+});
 
 export const enqueueStyleSetPackageCleanup = async ({
   s3Key,

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -2546,10 +2546,11 @@ export default defineConfig({
           "error",
           {
             allowedFiles: [
-              // Queue transport. Each module owns one BullMQ queue's
-              // connection lifecycle; BullMQ owns the key layout under its
-              // own prefix (see redis-client.ts for the cluster cutover).
-              "apps/api/src/lib/document-processing-enqueue.ts",
+              // Queue transport. The shared facade owns lazy producer
+              // connections; worker modules own their dedicated blocking
+              // connections. BullMQ owns the key layout under its own prefix
+              // (see redis-client.ts for the cluster cutover).
+              "apps/api/src/lib/bullmq-queue.ts",
               "apps/api/src/lib/document-processing-queue.ts",
               "apps/api/src/lib/workflow-queue.ts",
               "apps/api/src/lib/file-derivative-queue.ts",
@@ -2558,7 +2559,6 @@ export default defineConfig({
               "apps/api/src/lib/style-set-package-cleanup-queue.ts",
               "apps/api/src/lib/document-review/run-queue.ts",
               "apps/api/src/lib/bilingual/run-queue.ts",
-              "apps/api/src/lib/flows/flow-run-queue.ts",
               "apps/api/src/lib/flows/flow-run-worker.ts",
               "apps/api/src/lib/scheduler/bullmq.ts",
               "apps/api/src/handlers/reports/report-export-queue.ts",


### PR DESCRIPTION
## Summary

- replace nine duplicate lazy BullMQ queue/connection pairs with one typed helper
- centralize producer connection options while preserving retry, backoff, retention, and fail-fast policies
- replace three duplicate non-overlapping reconciliation timers with one shutdown-aware interval helper
- keep domain processors, failed-job handling, telemetry, and worker ownership local

## Validation

- `git diff --check`
- staged secret scan
- local lint, format, typecheck, and test runs intentionally deferred to CI

## Size

- 283 lines removed, 202 added; net -81 lines