### PR TITLE
refactor(cli): consolidate command execution contracts

### DIFF
--- a/.changeset/consolidate-cli-execution.md
+++ b/.changeset/consolidate-cli-execution.md
@@ -1,0 +1,5 @@
+---
+"@stll/cli": patch
+---
+
+Consolidate shared command execution contracts without changing CLI behavior.

--- a/packages/cli/src/run-capability-command.ts
+++ b/packages/cli/src/run-capability-command.ts
@@ -6,35 +6,21 @@
 // output contract) so the output/behavior contract stays identical CLI-wide.
 
 import { Result } from "better-result";
-import { readFile } from "node:fs/promises";
 
 import type { Context } from "./context.js";
 import { expandSchemaDefs } from "./expand-schema-defs.js";
 import { validateAgainstSchema } from "./json-schema-validate.js";
 import { callTool, type CallToolResult } from "./mcp-client.js";
 import { EXIT_CODES } from "./mcp-constants.js";
-import {
-  buildRenderPlan,
-  renderResult,
-  type OutputFormat,
-  type Writers,
-} from "./output.js";
 import type { CapabilityLeafSpec } from "./route-types.js";
 import {
-  approvalReRunHint,
-  coerceFlagValue,
+  composeInputFromFlags,
   confirmDestructive,
-  errorEnvelope,
-  flagKey,
-  flagValueProvided,
-  hasInputPath,
   mapClientErrorExit,
-  parsePayload,
-  readAllStdin,
+  maybeConfirmAndRetry,
+  parseInputObject,
   readOutputFormat,
-  readRequestReceipt,
-  renderToolError,
-  requestIdLine,
+  renderCommandResult,
   RESERVED_FLAG_KEYS,
   reservedFlagUsageError,
   scopePreflightFailure,
@@ -52,89 +38,6 @@ type LeafFlags = Record<string, unknown>;
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-type InputResult =
-  | { ok: true; input: Record<string, unknown> }
-  | { ok: false; message: string };
-
-/**
- * Overlay parsed value flags onto `base` (the `{ body?, params?, query? }`
- * object built from `--input`, or `{}` when no `--input` was given). Each SET
- * flag is coerced and written at its known input path (`${part}.${partPath}` —
- * the same mapping the flag would use on its own), so an explicit flag WINS over
- * the same path in the JSON. A required flag is satisfied either by being set or
- * by already being present in `base`, so `--input` can carry it.
- */
-const buildInputFromFlags = async (
-  spec: CapabilityLeafSpec,
-  flags: LeafFlags,
-  base: Record<string, unknown> = {},
-): Promise<InputResult> => {
-  const input = base;
-  for (const flagSpec of spec.flags) {
-    const value = flags[flagKey(flagSpec)];
-    if (!flagValueProvided(flagSpec, value)) {
-      continue;
-    }
-    // eslint-disable-next-line no-await-in-loop -- @file/@- reads must stay sequential
-    const coerced = await coerceFlagValue(flagSpec, value);
-    if (Result.isError(coerced)) {
-      return { ok: false, message: coerced.error };
-    }
-    setPath(input, `${flagSpec.part}.${flagSpec.partPath}`, coerced.value);
-  }
-  for (const flagSpec of spec.flags) {
-    if (
-      flagSpec.required &&
-      !hasInputPath(input, `${flagSpec.part}.${flagSpec.partPath}`)
-    ) {
-      return { ok: false, message: `missing required flag ${flagSpec.flag}` };
-    }
-  }
-  return { ok: true, input };
-};
-
-/** Resolve `--input` (`-` stdin / `@file` / literal) to the parsed input object. */
-const buildInputFromRaw = async ({
-  inputRaw,
-  writers,
-}: {
-  inputRaw: string;
-  writers: Writers;
-}): Promise<Record<string, unknown> | undefined> => {
-  let jsonText: string;
-  if (inputRaw === "-") {
-    jsonText = await readAllStdin();
-  } else if (inputRaw.startsWith("@")) {
-    const read = await Result.tryPromise({
-      try: async () => await readFile(inputRaw.slice(1), "utf-8"),
-      catch: (cause) => cause,
-    });
-    if (Result.isError(read)) {
-      writers.stderr(`--input could not read file ${inputRaw.slice(1)}\n`);
-      return undefined;
-    }
-    jsonText = read.value;
-  } else {
-    jsonText = inputRaw;
-  }
-
-  const parsed = Result.try((): unknown => JSON.parse(jsonText));
-  if (Result.isError(parsed)) {
-    writers.stderr("--input is not valid JSON.\n");
-    return undefined;
-  }
-  if (!isRecord(parsed.value)) {
-    writers.stderr("--input must be a JSON object.\n");
-    return undefined;
-  }
-  // Parse only: schema validation runs on the COMPOSED input (after value flags
-  // overlay their paths), never on the raw `--input` alone. Validating here would
-  // reject a `--input` that legitimately omits a required flag-backed path (e.g.
-  // the synthetic `params.workspaceId` supplied by `--workspace`), defeating the
-  // compose semantics for exactly the required flags they target.
-  return parsed.value;
-};
-
 /** A fresh copy of the invoke args with `cursor` set inside the pagination part. */
 const withCursor = (
   base: Record<string, unknown>,
@@ -147,133 +50,6 @@ const withCursor = (
     ...base,
     input: { ...input, [part]: { ...partObj, cursor } },
   };
-};
-
-const renderCapabilityResult = ({
-  context,
-  spec,
-  result,
-  format,
-  writers,
-}: {
-  context: Context;
-  spec: CapabilityLeafSpec;
-  result: CallToolResult;
-  format: OutputFormat;
-  writers: Writers;
-}): void => {
-  if (result.isError) {
-    renderToolError({ context, result, writers });
-    return;
-  }
-  const payload = parsePayload(result);
-  if (payload === undefined) {
-    writers.stdout(`${result.content.at(0)?.text ?? ""}\n`);
-    return;
-  }
-  // A list-shaped capability (Page<T>) renders as a page/table; anything else
-  // renders as a single object. `itemsKey` is set only for paginated leaves.
-  const plan = buildRenderPlan({
-    payload,
-    itemsKey: spec.itemsKey,
-    windowedText: false,
-    singleReadActive: false,
-    columns: undefined,
-  });
-  renderResult({ plan, format, writers, allActive: false });
-
-  const hint = approvalReRunHint({
-    isTTY: context.process.stdout.isTTY,
-    payload,
-  });
-  if (hint !== null) {
-    writers.stderr(`${hint}\n`);
-  }
-
-  // Surface the server's request-id receipt for a mutation only: a write is an
-  // action an operator may need to reference, a read is not. The id rides the
-  // success payload's `meta.requestId` (stdout stays pure result; the receipt
-  // goes to stderr).
-  if (spec.access === "write") {
-    const requestId = readRequestReceipt(payload);
-    if (requestId !== undefined) {
-      writers.stderr(requestIdLine(requestId, context.process.stderr.isTTY));
-    }
-  }
-};
-
-type CapabilityRetryOptions = {
-  args: Record<string, unknown>;
-  call: CallToolResult;
-  context: Context;
-  flags: LeafFlags;
-  format: OutputFormat;
-  serverUrl: string;
-  spec: CapabilityLeafSpec;
-  token: string;
-  writers: Writers;
-};
-
-/**
- * Confirm-passthrough prompt-and-retry: a call WITHOUT `confirm` that comes back
- * `confirmation_required` prompts (on a TTY, unless `--no-input`) and retries
- * once with `confirm: true`. Returns true when it fully handled the command. A
- * declined/refused prompt is terminal (one stderr `aborted` line, exit 7): the
- * original envelope is NOT rendered on top of the abort, matching the pre-call
- * destructive abort flow.
- */
-const maybeConfirmRetry = async ({
-  args,
-  call,
-  context,
-  flags,
-  format,
-  serverUrl,
-  spec,
-  token,
-  writers,
-}: CapabilityRetryOptions): Promise<boolean> => {
-  if (
-    call.isError !== true ||
-    args["confirm"] === true ||
-    !context.process.stdin.isTTY
-  ) {
-    return false;
-  }
-  const envelope = errorEnvelope(parsePayload(call));
-  if (envelope?.code !== "confirmation_required") {
-    return false;
-  }
-  const outcome = await confirmDestructive({
-    context,
-    flags,
-    writers,
-    label: spec.commandPath.join(" "),
-  });
-  if (outcome !== "proceed") {
-    writers.stderr("aborted\n");
-    setExit(context, EXIT_CODES.aborted);
-    return true;
-  }
-  const retry = await callTool({
-    serverUrl,
-    token,
-    name: INVOKE_TOOL,
-    args: { ...args, confirm: true },
-  });
-  if (Result.isError(retry)) {
-    writers.stderr(`${retry.error.message}\n`);
-    setExit(context, mapClientErrorExit(retry.error));
-    return true;
-  }
-  renderCapabilityResult({
-    context,
-    spec,
-    result: retry.value,
-    format,
-    writers,
-  });
-  return true;
 };
 
 /** Run one capability leaf end to end. Sets `process.exitCode` per spec S4. */
@@ -312,19 +88,24 @@ export const runCapabilityCommand = async ({
   const inputRaw = flags[RESERVED_FLAG_KEYS.input];
   const inputBase =
     typeof inputRaw === "string"
-      ? await buildInputFromRaw({ inputRaw, writers })
+      ? await parseInputObject({ inputRaw, writers })
       : {};
   if (inputBase === undefined) {
     setExit(context, EXIT_CODES.validation);
     return;
   }
-  const built = await buildInputFromFlags(spec, flags, inputBase);
+  const built = await composeInputFromFlags({
+    base: inputBase,
+    flagPath: (flagSpec) => `${flagSpec.part}.${flagSpec.partPath}`,
+    flagSpecs: spec.flags,
+    flags,
+  });
   if (!built.ok) {
     writers.stderr(`${built.message}\n`);
     setExit(context, EXIT_CODES.validation);
     return;
   }
-  const input = built.input;
+  const input = built.args;
 
   // Validate the COMPOSED input (JSON base + overlaid flags) against the snapshot
   // schema, only when `--input` supplied JSON. Flags-only requests keep relying on
@@ -365,6 +146,17 @@ export const runCapabilityCommand = async ({
   }
 
   const format = readOutputFormat(flags, context);
+  const renderCall = (result: CallToolResult) => {
+    renderCommandResult({
+      context,
+      format,
+      itemsKey: spec.itemsKey,
+      result,
+      windowedText: false,
+      writers,
+      writeReceipt: spec.access === "write",
+    });
+  };
   const allActive = spec.paginated && flags[RESERVED_FLAG_KEYS.all] === true;
   const paginationPart = spec.paginationPart;
 
@@ -440,26 +232,23 @@ export const runCapabilityCommand = async ({
     return;
   }
 
-  const retried = await maybeConfirmRetry({
+  const retried = await maybeConfirmAndRetry({
     args: toolArgs,
     call: call.value,
     context,
+    enabled: true,
     flags,
-    format,
+    label: spec.commandPath.join(" "),
+    renderCall,
     serverUrl,
-    spec,
+    timeoutMs: undefined,
     token,
+    toolName: INVOKE_TOOL,
     writers,
   });
   if (retried) {
     return;
   }
 
-  renderCapabilityResult({
-    context,
-    spec,
-    result: call.value,
-    format,
-    writers,
-  });
+  renderCall(call.value);
 };

--- a/packages/cli/src/run-leaf-command.ts
+++ b/packages/cli/src/run-leaf-command.ts
@@ -337,12 +337,12 @@ export const composeInputFromFlags = async <T extends FlagSpec>({
  * path in the JSON. A required flag is satisfied either by being set or by
  * already being present in `base`, so `--input` can carry it. Exported for tests.
  */
-export const buildArgsFromFlags = (
+export const buildArgsFromFlags = async (
   spec: LeafCommandSpec,
   flags: LeafFlags,
   base: Record<string, unknown> = {},
 ): Promise<ArgsResult> =>
-  composeInputFromFlags({
+  await composeInputFromFlags({
     base,
     flagPath: (flagSpec) => flagSpec.prop,
     flagSpecs: spec.flags,

--- a/packages/cli/src/run-leaf-command.ts
+++ b/packages/cli/src/run-leaf-command.ts
@@ -168,10 +168,6 @@ export const hasInputPath = (
   return node !== undefined;
 };
 
-type ArgsResult =
-  | { ok: true; args: Record<string, unknown> }
-  | { ok: false; message: string };
-
 const parseBoundedInt = (
   spec: FlagSpec,
   raw: string,
@@ -294,21 +290,25 @@ export const coerceFlagValue = async (
   return Result.ok(raw);
 };
 
-/**
- * Overlay parsed value flags onto `base` (spec S3). `base` is the args object
- * built from `--input` (or `{}` when no `--input` was given): each SET flag is
- * coerced and written at its `prop` path, so an explicit flag WINS over the same
- * path in the JSON. A required flag is satisfied either by being set or by
- * already being present in `base`, so `--input` can carry it. Exported for tests.
- */
-export const buildArgsFromFlags = async (
-  spec: LeafCommandSpec,
-  flags: LeafFlags,
-  base: Record<string, unknown> = {},
-): Promise<ArgsResult> => {
-  const args = base;
+type ArgsResult =
+  | { ok: true; args: Record<string, unknown> }
+  | { ok: false; message: string };
 
-  for (const flagSpec of spec.flags) {
+type ComposeInputFromFlagsOptions<T extends FlagSpec> = {
+  base: Record<string, unknown>;
+  flagPath: (flagSpec: T) => string;
+  flagSpecs: readonly T[];
+  flags: LeafFlags;
+};
+
+export const composeInputFromFlags = async <T extends FlagSpec>({
+  base,
+  flagPath,
+  flagSpecs,
+  flags,
+}: ComposeInputFromFlagsOptions<T>): Promise<ArgsResult> => {
+  for (const flagSpec of flagSpecs) {
+    const path = flagPath(flagSpec);
     const value = flags[flagKey(flagSpec)];
     if (!flagValueProvided(flagSpec, value)) {
       continue;
@@ -318,21 +318,38 @@ export const buildArgsFromFlags = async (
     if (Result.isError(coerced)) {
       return { ok: false, message: coerced.error };
     }
-    setPath(args, flagSpec.prop, coerced.value);
+    setPath(base, path, coerced.value);
   }
 
-  // Enforce required flags (spec S3): unset AND absent from `--input` -> usage
-  // error (exit 2 upstream), naming the missing flag.
-  for (const flagSpec of spec.flags) {
-    if (flagSpec.required && !hasInputPath(args, flagSpec.prop)) {
+  for (const flagSpec of flagSpecs) {
+    if (flagSpec.required && !hasInputPath(base, flagPath(flagSpec))) {
       return { ok: false, message: `missing required flag ${flagSpec.flag}` };
     }
   }
 
-  return { ok: true, args };
+  return { ok: true, args: base };
 };
 
-const buildArgsFromInput = async ({
+/**
+ * Overlay parsed value flags onto `base` (spec S3). `base` is the args object
+ * built from `--input` (or `{}` when no `--input` was given): each SET flag is
+ * coerced and written at its `prop` path, so an explicit flag WINS over the same
+ * path in the JSON. A required flag is satisfied either by being set or by
+ * already being present in `base`, so `--input` can carry it. Exported for tests.
+ */
+export const buildArgsFromFlags = (
+  spec: LeafCommandSpec,
+  flags: LeafFlags,
+  base: Record<string, unknown> = {},
+): Promise<ArgsResult> =>
+  composeInputFromFlags({
+    base,
+    flagPath: (flagSpec) => flagSpec.prop,
+    flagSpecs: spec.flags,
+    flags,
+  });
+
+export const parseInputObject = async ({
   inputRaw,
   writers,
 }: {
@@ -965,19 +982,25 @@ export const renderToolError = ({
   setExit(context, classifyToolError(errorPayload));
 };
 
-const renderCallResult = ({
-  context,
-  spec,
-  result,
-  format,
-  writers,
-}: {
+type RenderCommandResultOptions = {
   context: Context;
-  spec: LeafCommandSpec;
-  result: CallToolResult;
   format: OutputFormat;
+  itemsKey: string | undefined;
+  result: CallToolResult;
+  windowedText: boolean;
   writers: Writers;
-}): void => {
+  writeReceipt: boolean;
+};
+
+export const renderCommandResult = ({
+  context,
+  format,
+  itemsKey,
+  result,
+  windowedText,
+  writers,
+  writeReceipt,
+}: RenderCommandResultOptions): void => {
   if (result.isError) {
     renderToolError({ context, result, writers });
     return;
@@ -989,8 +1012,8 @@ const renderCallResult = ({
   }
   const plan = buildRenderPlan({
     payload,
-    itemsKey: spec.itemsKey,
-    windowedText: spec.windowedText,
+    itemsKey,
+    windowedText,
     singleReadActive: false,
     columns: undefined,
   });
@@ -1005,6 +1028,12 @@ const renderCallResult = ({
   });
   if (hint !== null) {
     writers.stderr(`${hint}\n`);
+  }
+  if (writeReceipt) {
+    const requestId = readRequestReceipt(payload);
+    if (requestId !== undefined) {
+      writers.stderr(requestIdLine(requestId, context.process.stderr.isTTY));
+    }
   }
 };
 
@@ -1044,7 +1073,7 @@ export const runLeafCommand = async ({
   const inputRaw = flags[RESERVED_FLAG_KEYS.input];
   const argsBase =
     typeof inputRaw === "string"
-      ? await buildArgsFromInput({ inputRaw, writers })
+      ? await parseInputObject({ inputRaw, writers })
       : {};
   if (argsBase === undefined) {
     setExit(context, EXIT_CODES.validation);
@@ -1114,6 +1143,17 @@ export const runLeafCommand = async ({
     spec.windowedText && !explicitJson
       ? "table"
       : readOutputFormat(flags, context);
+  const renderCall = (result: CallToolResult) => {
+    renderCommandResult({
+      context,
+      format,
+      itemsKey: spec.itemsKey,
+      result,
+      windowedText: spec.windowedText,
+      writers,
+      writeReceipt: false,
+    });
+  };
   const allActive = spec.paginated && flags[RESERVED_FLAG_KEYS.all] === true;
 
   // Reserved pagination flags map onto the tool's cursor/limit args (spec S3).
@@ -1162,22 +1202,25 @@ export const runLeafCommand = async ({
     return;
   }
 
-  const retried = await maybeConfirmRetry({
+  const retried = await maybeConfirmAndRetry({
     args,
     call: call.value,
     context,
+    enabled: spec.confirmPassthrough === true,
     flags,
-    format,
+    label: spec.commandPath.join(" "),
+    renderCall,
     serverUrl,
-    spec,
+    timeoutMs: spec.requestTimeoutMs,
     token,
+    toolName: spec.toolName,
     writers,
   });
   if (retried) {
     return;
   }
 
-  renderCallResult({ context, spec, result: call.value, format, writers });
+  renderCall(call.value);
 };
 
 type ConfirmGateOutcome = { aborted: boolean; args: Record<string, unknown> };
@@ -1189,7 +1232,7 @@ type ConfirmGateOutcome = { aborted: boolean; args: Record<string, unknown> };
  *  - a confirm-PASSTHROUGH leaf (per-target destructiveness, e.g.
  *    `capability invoke`) never prompts upfront, but --yes pre-approves the
  *    server's confirmation_required gate by injecting `confirm: true`; without
- *    --yes the post-call prompt-and-retry flow (`maybeConfirmRetry`) handles it.
+ *    --yes the post-call prompt-and-retry flow handles it.
  */
 const applyConfirmGates = async ({
   args,
@@ -1235,18 +1278,21 @@ type ConfirmRetryOptions = {
   args: Record<string, unknown>;
   call: CallToolResult;
   context: Context;
+  enabled: boolean;
   flags: LeafFlags;
-  format: OutputFormat;
+  label: string;
+  renderCall: (result: CallToolResult) => void;
   serverUrl: string;
-  spec: LeafCommandSpec;
+  timeoutMs: number | undefined;
   token: string;
+  toolName: string;
   writers: Writers;
 };
 
 /**
  * Confirm-passthrough prompt-and-retry: when a call WITHOUT `confirm` comes
- * back `confirmation_required` on a confirm-passthrough leaf and stdin is a
- * TTY, ask the human exactly like the destructive prompt and retry ONCE with
+ * back `confirmation_required` for an eligible command and stdin is a TTY, ask
+ * the human exactly like the destructive prompt and retry ONCE with
  * `confirm: true`. Returns true when it fully handled the command (rendered a
  * retry result, a retry transport error, or a terminal abort); false lets the
  * caller render the original envelope, so every non-TTY call keeps today's
@@ -1254,19 +1300,22 @@ type ConfirmRetryOptions = {
  * `aborted` line, exit 7, no envelope render on top — matching the pre-call
  * destructive abort flow and the capability executor.
  */
-const maybeConfirmRetry = async ({
+export const maybeConfirmAndRetry = async ({
   args,
   call,
   context,
+  enabled,
   flags,
-  format,
+  label,
+  renderCall,
   serverUrl,
-  spec,
+  timeoutMs,
   token,
+  toolName,
   writers,
 }: ConfirmRetryOptions): Promise<boolean> => {
   if (
-    spec.confirmPassthrough !== true ||
+    !enabled ||
     call.isError !== true ||
     args["confirm"] === true ||
     !context.process.stdin.isTTY
@@ -1281,7 +1330,7 @@ const maybeConfirmRetry = async ({
     context,
     flags,
     writers,
-    label: spec.commandPath.join(" "),
+    label,
   });
   if (outcome !== "proceed") {
     writers.stderr("aborted\n");
@@ -1291,17 +1340,15 @@ const maybeConfirmRetry = async ({
   const retry = await callTool({
     serverUrl,
     token,
-    name: spec.toolName,
+    name: toolName,
     args: { ...args, confirm: true },
-    ...(spec.requestTimeoutMs === undefined
-      ? {}
-      : { timeoutMs: spec.requestTimeoutMs }),
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
   });
   if (Result.isError(retry)) {
     writers.stderr(`${retry.error.message}\n`);
     setExit(context, mapClientErrorExit(retry.error));
     return true;
   }
-  renderCallResult({ context, spec, result: retry.value, format, writers });
+  renderCall(retry.value);
   return true;
 };


### PR DESCRIPTION
## Summary

- share `--input` object parsing and flag overlay validation across curated and capability commands
- share MCP result rendering, approval hints, and mutation receipts
- share the confirmation-required prompt-and-retry state machine while keeping route-specific eligibility and timeouts explicit

## Validation

- `git diff --check`
- staged secret scan
- existing curated and capability executor tests cover the consolidated contracts
- local lint, format, typecheck, and test runs intentionally deferred to CI

## Size

- runtime code: 298 lines removed, 134 added; net -164 lines
- including the required package changeset: net -159 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency across CLI commands when combining supplied input with command-line flags.
  * Standardised command result displays, including success receipts and capability details.
  * Confirmation retries now follow consistent behaviour across commands, with errors handled reliably.

* **Chores**
  * Prepared a patch release for the CLI package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->