### PR TITLE
fix(api): bundle the stdnum native binding and guard registry identifier checks

### DIFF
--- a/.changeset/stdnum-static-binding-resolution.md
+++ b/.changeset/stdnum-static-binding-resolution.md
@@ -1,0 +1,5 @@
+---
+"@stll/business-registries": patch
+---
+
+Bump `@stll/stdnum` to 2.3.2, whose loader resolves the native binding through literal requires so bundlers embed it.

--- a/apps/api/src/lib/business-registries/dispatch.test.ts
+++ b/apps/api/src/lib/business-registries/dispatch.test.ts
@@ -354,3 +354,21 @@ describe("DENUE deployment gating", () => {
     }
   });
 });
+
+describe("executeRegistryLookup — canonical-id guard", () => {
+  test("maps an isCanonicalId failure to a handler error instead of throwing", async () => {
+    const result = await executeRegistryLookup({
+      handler: stubHandler({
+        isCanonicalId: () => {
+          throw new Error("native binding unavailable");
+        },
+      }),
+      query: "27082440",
+    });
+
+    if (!(result instanceof Error)) {
+      throw new TypeError("expected a handler error");
+    }
+    expect(result.status).toBe(500);
+  });
+});

--- a/apps/api/src/lib/business-registries/dispatch.test.ts
+++ b/apps/api/src/lib/business-registries/dispatch.test.ts
@@ -12,6 +12,7 @@ import {
   isBusinessRegistryNativeToolDeployAvailable,
   type RegistryHandler,
 } from "@/api/lib/business-registries/dispatch";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
 const ARES_COMPANY_FIXTURE: AresCompany = {
   ico: "27082440",
@@ -366,7 +367,7 @@ describe("executeRegistryLookup — canonical-id guard", () => {
       query: "27082440",
     });
 
-    if (!(result instanceof Error)) {
+    if (!(result instanceof HandlerError)) {
       throw new TypeError("expected a handler error");
     }
     expect(result.status).toBe(500);

--- a/apps/api/src/lib/business-registries/dispatch.ts
+++ b/apps/api/src/lib/business-registries/dispatch.ts
@@ -7,8 +7,6 @@
 // `executeRegistryLookup` so the two surfaces never drift in error
 // mapping, normalisation, or shape detection.
 
-import { panic } from "better-result";
-
 import type { BusinessRegistrySlug } from "@stll/api-contract";
 import {
   AresAPIError,
@@ -1574,22 +1572,19 @@ export const executeRegistryLookup = async ({
     });
   }
 
-  const isLookup = handler.isCanonicalId(trimmed);
   const searchFn = handler.search;
-  if (!isLookup && !searchFn) {
-    return new HandlerError({
-      status: 400,
-      message: `Registry '${handler.slug}' does not support name search; provide a canonical identifier`,
-    });
-  }
-
+  // `isCanonicalId` runs inside the guard: adapters validate through native
+  // checksum bindings, and a binding failure must map like any adapter error.
   try {
-    if (isLookup) {
+    if (handler.isCanonicalId(trimmed)) {
       const hit = await handler.lookup(trimmed);
       return { type: "lookup", registry: handler.slug, hit };
     }
     if (!searchFn) {
-      panic("searchFn must be defined when !isLookup reaches here");
+      return new HandlerError({
+        status: 400,
+        message: `Registry '${handler.slug}' does not support name search; provide a canonical identifier`,
+      });
     }
     const hits = await searchFn(
       trimmed,

--- a/apps/api/src/scripts/image-smoke.ts
+++ b/apps/api/src/scripts/image-smoke.ts
@@ -21,6 +21,7 @@ import {
   isNativeAnonymizeBinding,
   loadNativeAnonymizeBinding,
 } from "@stll/anonymize";
+import { validateIco } from "@stll/business-registries/ares";
 
 import { OCR_LOCAL_MODEL_FILES } from "@/api/lib/document-processing-contract";
 import { yaraRuleFileCount, yaraScanner } from "@/api/lib/file-scan/yara";
@@ -157,6 +158,15 @@ await probe("anonymize native engine", () => {
   const binding = loadNativeAnonymizeBinding();
   if (!isNativeAnonymizeBinding(binding)) {
     panic("anonymize native loader returned an unexpected binding shape");
+  }
+});
+
+// Registry adapters validate identifiers through the stdnum native binding,
+// which loads lazily on first call; a well-formed IČO proves the addon is
+// embedded and callable.
+await probe("stdnum native binding", () => {
+  if (!validateIco("27082440")) {
+    panic("stdnum rejected a well-formed identifier");
   }
 });
 

--- a/bun.lock
+++ b/bun.lock
@@ -517,7 +517,7 @@
       "version": "0.3.0",
       "dependencies": {
         "@stll/country-codes": "workspace:*",
-        "@stll/stdnum": "^2.3.1",
+        "@stll/stdnum": "^2.3.2",
       },
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
@@ -2405,19 +2405,19 @@
 
     "@stll/skills": ["@stll/skills@workspace:packages/skills"],
 
-    "@stll/stdnum": ["@stll/stdnum@2.3.1", "", { "optionalDependencies": { "@stll/stdnum-darwin-arm64": "2.3.1", "@stll/stdnum-darwin-x64": "2.3.1", "@stll/stdnum-linux-arm64-gnu": "2.3.1", "@stll/stdnum-linux-x64-gnu": "2.3.1", "@stll/stdnum-wasm": "2.3.1", "@stll/stdnum-win32-x64-msvc": "2.3.1" } }, "sha512-FcBwuU3tbHsVDE/QJ+z6X+wEi1pEdjm4DHRAPm6tXcf9zcoCtCfJeLvTYUE8h24sAON1qjBovWmdDWJUXwEObg=="],
+    "@stll/stdnum": ["@stll/stdnum@2.3.2", "", { "optionalDependencies": { "@stll/stdnum-darwin-arm64": "2.3.2", "@stll/stdnum-darwin-x64": "2.3.2", "@stll/stdnum-linux-arm64-gnu": "2.3.2", "@stll/stdnum-linux-x64-gnu": "2.3.2", "@stll/stdnum-wasm": "2.3.2", "@stll/stdnum-win32-x64-msvc": "2.3.2" } }, "sha512-HnICsbwqTwbttzvEBwOPJQ2RCi9MzWrNwq7aZLDhRtt+Wo7EfTtStpnyJ3ZVY7Z2AyhA2ebnPQCo1hFQdVyftQ=="],
 
-    "@stll/stdnum-darwin-arm64": ["@stll/stdnum-darwin-arm64@2.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MBJmUub1ocSe8rCe5KXijJ4d0uUr2XGjsHm6OdQToYQ5muDdHepAV07DNCpbXsVWopYUB0q8+XtsEXBFXIoQBA=="],
+    "@stll/stdnum-darwin-arm64": ["@stll/stdnum-darwin-arm64@2.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-28xqzzrFAHGcBPTArkU+sWWijWCt3o4R50qsSHA+cuoX/JXamBIGArRbGtAjuqDvRuWGBvtKZFPxC5YN2V+I/w=="],
 
-    "@stll/stdnum-darwin-x64": ["@stll/stdnum-darwin-x64@2.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-QMc7i8qdm0oEWcYKRr0ZLpNx2qT+1Veutsoieb5WnjjXSHiFUfC1NtMAEy78nkIz/EhWHd3bpbU8Lc3C9Hq7og=="],
+    "@stll/stdnum-darwin-x64": ["@stll/stdnum-darwin-x64@2.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-zTzzQ0070M9wANXxSCTWp11XCRHurFUB+6zrcZ8G3VzYFiee+1wCYOR/NkZwrtXRZK5gxcOE51J4JM0mQtN74g=="],
 
-    "@stll/stdnum-linux-arm64-gnu": ["@stll/stdnum-linux-arm64-gnu@2.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-ix1Wq33kjet/4sbYiL2U1Up8RggioCJh9tJxtbqADvSR0SjL5jRyFfRgzS5SFjXZdMU6nm8q4+FCOHSR7IiJwA=="],
+    "@stll/stdnum-linux-arm64-gnu": ["@stll/stdnum-linux-arm64-gnu@2.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-XG0rEcLmu46+t6vXnJGYThVk6zJCSlH2GzYb9IpJl+xsquIdrFvztGcYZInmzMODMysUh9Bh110JL+1nb5ePig=="],
 
-    "@stll/stdnum-linux-x64-gnu": ["@stll/stdnum-linux-x64-gnu@2.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-UAOB6UvB+Vn/9C+uOeDTBWhOOmNQz4ijVVpPy84xYDpSwNKVGRR4f9d2j7YoixFwYwJk8Q8xSP9EEVNPCyzaxA=="],
+    "@stll/stdnum-linux-x64-gnu": ["@stll/stdnum-linux-x64-gnu@2.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-dkCX/iNaMGo9n6/9jd/yWSjEcRobPW3vx6/g5S22hIZV8BCrAHtKmbVff/11vIC/yif4c3OVOldLLMlalt7jiw=="],
 
-    "@stll/stdnum-wasm": ["@stll/stdnum-wasm@2.3.1", "", {}, "sha512-jEFZNIksWD8lebfw5vLB0l0/mn6kGKmmUqymNU0sNwpywbQ3A+9mi8+i4wXt6MjeseqRi3QJALgbLfKnyV1IzA=="],
+    "@stll/stdnum-wasm": ["@stll/stdnum-wasm@2.3.2", "", {}, "sha512-qFS64tB1bL9Furpwfu/YvV+UsznVvQJVuAHaqA/WSJUeCXCaqI6A2jNk/ISQD3pwPsRh5gCq8H/bBoKuWkARnw=="],
 
-    "@stll/stdnum-win32-x64-msvc": ["@stll/stdnum-win32-x64-msvc@2.3.1", "", { "os": "win32", "cpu": "x64" }, "sha512-nROrzvHoctQL6v1/GGMq7k5Tv/9EayszgycICnj9PystcajvOvuesWlKkTYokdTP3XBbvD86oQWefswnFqqz3g=="],
+    "@stll/stdnum-win32-x64-msvc": ["@stll/stdnum-win32-x64-msvc@2.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-E3+wlj8nHOmdY6MnAwi9CZ3FxENhg/08bTNjYetRme7KBt2l8OsjxeYXJbjF/Y3esG0aDzZIJFSGV7aKKhu+Kg=="],
 
     "@stll/template-conditions": ["@stll/template-conditions@workspace:packages/template-conditions"],
 

--- a/packages/business-registries/package.json
+++ b/packages/business-registries/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@stll/country-codes": "workspace:*",
-    "@stll/stdnum": "^2.3.1"
+    "@stll/stdnum": "^2.3.2"
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",


### PR DESCRIPTION
## Problem

`@stll/stdnum` resolved its native addon through a computed `require` specifier, which the bundler cannot embed; the compiled API binary ships no `node_modules`, so the first identifier check on a stdnum-backed registry adapter threw `Unable to load the native stdnum binding`. That call ran outside the lookup's error guard and surfaced as an unhandled `Panic` (500) on `GET /v1/contacts/business-registries` and the `lookup_business_registry` tool.

## Change

- Bump `@stll/stdnum` to 2.3.2 (stella/stdnum#190): the loader now uses literal requires, so the compiled bundle carries the addon as a sidecar. Verified with a `bun build --compile` probe run outside `node_modules`.
- `executeRegistryLookup` runs `isCanonicalId` inside its error guard, so an adapter failure there maps to a handler error like any other adapter error (regression test).
- `image-smoke` probes the stdnum binding, so a runner image that cannot load it fails the image build instead of the first request.

https://claude.ai/code/session_012SYqP9zTF7cJtXDhx4CHGj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Registry lookup errors from identifier validation are now returned as controlled server errors instead of causing uncaught failures.
  - Unsupported search requests continue through the standard error-handling flow.

- **Reliability**
  - Improved validation of business identifiers when the native validation component is loaded.
  - Updated the business registry package to support reliable bundling of the native validation component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->