### PR TITLE
fix: treat a bracketless decorative marker as a word boundary

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
@@ -196,6 +196,73 @@ describe("validateAst", () => {
       expect(result.stats.missingWords).toEqual([]);
     });
 
+    test("treats a bracketless decorative marker as a boundary, not glue", () => {
+      // NSS also serves the emblem placeholder without brackets, flush
+      // against the following word ("OBRÁZEKČeská", "OBRÁZEKaplikační").
+      // cheerio's .text() concatenates it with no space, so the fused
+      // token reaches the word set with no bracket for the marker split
+      // to act on. The AST is right to drop the decoration, so the
+      // remainder ("česká", "aplikační") must not read as missing.
+      const html = wrapInHtml(
+        "OBRÁZEKČeská republika rozsudek jménem republiky " +
+          "OBRÁZEKaplikační doložka OBRÁZEKpro úplnost",
+      );
+      const blocks: Block[] = [
+        makeHeading("H"),
+        makeBlock({
+          plainText:
+            "Česká republika rozsudek jménem republiky " +
+            "aplikační doložka pro úplnost",
+        }),
+      ];
+
+      const result = validateAst(html, blocks);
+
+      expect(result.stats.missingWords).toEqual([]);
+    });
+
+    test("treats an inline-element marker boundary as glue, not loss", () => {
+      // The same placeholder wrapped in an inline element
+      // ("<span>Obrázek</span>Česká") glues the same way: .text()
+      // joins the span's text to the next node with no space.
+      const html = wrapInHtml(
+        "<span>Obrázek</span>Česká republika rozsudek jménem republiky " +
+          "<span>Obrázek</span>aplikační doložka",
+      );
+      const blocks: Block[] = [
+        makeHeading("H"),
+        makeBlock({
+          plainText:
+            "Česká republika rozsudek jménem republiky aplikační doložka",
+        }),
+      ];
+
+      const result = validateAst(html, blocks);
+
+      expect(result.stats.missingWords).toEqual([]);
+    });
+
+    test("still reports a real word lost behind a decorative marker", () => {
+      // Peeling the marker must not swallow genuine loss: the remainder
+      // is absent from the AST, so it stays missing.
+      const html = wrapInHtml(
+        "OBRÁZEKžaloba byla podána včas a je důvodná podle soudu",
+      );
+      const blocks: Block[] = [
+        makeHeading("H"),
+        makeBlock({ plainText: "byla podána včas a je důvodná podle soudu" }),
+      ];
+
+      const result = validateAst(html, blocks);
+
+      // The genuinely absent word still surfaces (as the fused token,
+      // since its peeled remainder resolves to neither the AST nor a
+      // skip word): peeling clears phantoms, it does not hide loss.
+      expect(result.stats.missingWords.some((w) => w.includes("žaloba"))).toBe(
+        true,
+      );
+    });
+
     test("keeps a mid-word anonymization marker joined", () => {
       // "[o]rganizace" anonymizes one letter inside a word: the
       // brackets are removed, not treated as a boundary, or the

--- a/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
@@ -242,6 +242,25 @@ describe("validateAst", () => {
       expect(result.stats.missingWords).toEqual([]);
     });
 
+    test("clears a marker glued to a word too short to be meaningful", () => {
+      // "OBRÁZEKje" fuses the marker to "je" (2 chars). The AST is right
+      // to carry only "je", which is below the meaningful-word length, so
+      // it never enters the AST word set. The peeled remainder must be
+      // judged by that same length rule and the phantom cleared, not left
+      // missing for want of an AST match.
+      const html = wrapInHtml(
+        "OBRÁZEKje rozsudek jménem republiky OBRÁZEKna úplnost",
+      );
+      const blocks: Block[] = [
+        makeHeading("H"),
+        makeBlock({ plainText: "je rozsudek jménem republiky na úplnost" }),
+      ];
+
+      const result = validateAst(html, blocks);
+
+      expect(result.stats.missingWords).toEqual([]);
+    });
+
     test("still reports a real word lost behind a decorative marker", () => {
       // Peeling the marker must not swallow genuine loss: the remainder
       // is absent from the AST, so it stays missing.

--- a/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.test.ts
@@ -221,6 +221,20 @@ describe("validateAst", () => {
       expect(result.stats.missingWords).toEqual([]);
     });
 
+    test("peels repeated leading markers off one fused token", () => {
+      // Consecutive placeholders glue into one token ("OBRÁZEKOBRÁZEKČeská");
+      // peeling must strip every leading marker, not just the first.
+      const html = wrapInHtml("OBRÁZEKOBRÁZEKČeská republika rozsudek");
+      const blocks: Block[] = [
+        makeHeading("H"),
+        makeBlock({ plainText: "Česká republika rozsudek" }),
+      ];
+
+      const result = validateAst(html, blocks);
+
+      expect(result.stats.missingWords).toEqual([]);
+    });
+
     test("treats an inline-element marker boundary as glue, not loss", () => {
       // The same placeholder wrapped in an inline element
       // ("<span>Obrázek</span>Česká") glues the same way: .text()

--- a/apps/api/src/lib/legal-search/parsers/validate-ast.ts
+++ b/apps/api/src/lib/legal-search/parsers/validate-ast.ts
@@ -112,6 +112,14 @@ const separateSkipMarkers = (text: string): string => {
   return separated;
 };
 
+// What counts as a missing-word candidate: long enough to be meaningful,
+// not a bare number, not a skip word. Shared so extractWords and the
+// missing-word check judge a peeled remainder by the same rule; a short
+// or numeric remainder is not a meaningful word, so a marker glued to one
+// ("OBRÁZEKje") is not a lost word.
+const isMeaningfulWord = (clean: string): boolean =>
+  clean.length >= 3 && !/^\d+$/u.test(clean) && !SKIP_WORDS.has(clean);
+
 const extractWords = (text: string): Set<string> => {
   const words = new Set<string>();
   for (const w of separateSkipMarkers(text).split(/\s+/u)) {
@@ -120,12 +128,7 @@ const extractWords = (text: string): Set<string> => {
     // non-letter chars from edges.
     const noBrackets = w.replace(/[[\]]/gu, "");
     const clean = trimNonLetters(noBrackets.toLowerCase());
-    if (
-      clean.length >= 3 &&
-      !/^\d+$/u.test(clean) &&
-      !/^\[\d+\]$/u.test(w.toLowerCase()) &&
-      !SKIP_WORDS.has(clean)
-    ) {
+    if (isMeaningfulWord(clean) && !/^\[\d+\]$/u.test(w.toLowerCase())) {
       words.add(clean);
     }
   }
@@ -284,19 +287,18 @@ export const validateAst = (
   const originalWords = extractWords(originalText);
   const astWords = extractWords(astText);
   // A decorative marker fused to its neighbour must not read as missing
-  // when the peeled remainder is itself in the AST or is a skip word.
-  // Peeling only ever clears a phantom: a genuinely absent word survives,
-  // because its remainder resolves to neither, so real loss is still
-  // reported.
+  // when the peeled remainder is accounted for. It is accounted for when
+  // it is present in the AST, or when it is not a meaningful word in its
+  // own right (a skip word, or too short/numeric to count) — judged by
+  // the same rule extractWords applies. Peeling only ever clears a
+  // phantom: a genuinely absent meaningful word keeps a remainder that is
+  // meaningful and not in the AST, so real loss is still reported.
   const missingWords = [...originalWords].filter((w) => {
     if (astWords.has(w)) {
       return false;
     }
     const peeled = peelDecorativeMarkers(w);
-    if (peeled === w) {
-      return true;
-    }
-    return !(astWords.has(peeled) || SKIP_WORDS.has(peeled));
+    return isMeaningfulWord(peeled) && !astWords.has(peeled);
   });
 
   if (retainedPct < minRetainedPct) {

--- a/apps/api/src/lib/legal-search/parsers/validate-ast.ts
+++ b/apps/api/src/lib/legal-search/parsers/validate-ast.ts
@@ -132,6 +132,32 @@ const extractWords = (text: string): Set<string> => {
   return words;
 };
 
+// NSS renders decorative figures with the alt text "obrázek" (Czech for
+// "image"). When one sits flush against its neighbour — as bracketless
+// text, or across an inline-element boundary that cheerio's .text()
+// concatenates with no space ("<span>Obrázek</span>Česká" →
+// "ObrázekČeská") — there is no bracket for separateSkipMarkers to split
+// on, so the fused token ("obrázekčeská") matches no AST word and no
+// SKIP_WORDS entry and reads as missing. Peeling leading markers recovers
+// the real remainder; the caller keeps a word only when that remainder is
+// itself unaccounted for, so peeling can clear a phantom but never hides
+// genuine loss.
+const DECORATIVE_MARKERS = ["obrázek"];
+const peelDecorativeMarkers = (word: string): string => {
+  let peeled = word;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const marker of DECORATIVE_MARKERS) {
+      if (peeled.length > marker.length && peeled.startsWith(marker)) {
+        peeled = peeled.slice(marker.length);
+        changed = true;
+      }
+    }
+  }
+  return peeled;
+};
+
 /** Flatten inline nodes to text (line-break → space). */
 const inlineText = (inlines: readonly Inline[]): string => {
   let text = "";
@@ -257,7 +283,21 @@ export const validateAst = (
 
   const originalWords = extractWords(originalText);
   const astWords = extractWords(astText);
-  const missingWords = [...originalWords].filter((w) => !astWords.has(w));
+  // A decorative marker fused to its neighbour must not read as missing
+  // when the peeled remainder is itself in the AST or is a skip word.
+  // Peeling only ever clears a phantom: a genuinely absent word survives,
+  // because its remainder resolves to neither, so real loss is still
+  // reported.
+  const missingWords = [...originalWords].filter((w) => {
+    if (astWords.has(w)) {
+      return false;
+    }
+    const peeled = peelDecorativeMarkers(w);
+    if (peeled === w) {
+      return true;
+    }
+    return !(astWords.has(peeled) || SKIP_WORDS.has(peeled));
+  });
 
   if (retainedPct < minRetainedPct) {
     issues.push({


### PR DESCRIPTION
## Problem

The AST content validator (`validate-ast.ts`) already splits a decorative image marker off its neighbour, but only when the marker is **bracketed**. `separateSkipMarkers` scans for `[...]` groups and turns a skippable one (`[OBRÁZEK]`, the image alt text NSS renders for its emblem and inline figures) into a word boundary, so `[OBRÁZEK]ČESKÁ` does not glue.

NSS also serves the same placeholder **without brackets**, flush against the following word:

- as a bare text node — `OBRÁZEKČeská`
- wrapped in an inline element — `<span>Obrázek</span>Česká`, where cheerio's `.text()` concatenates the two with no separating space (the same gluing `$("br").replaceWith(" ")` already guards against for `<br>`).

There is no bracket for `separateSkipMarkers` to act on, so the fused token (`obrázekčeská`, `obrázekaplikační`) reaches the word set, matches no AST word and no skip word, and is reported as a missing meaningful word. A document carrying several such placeholders accumulates enough phantom words to cross the `MISSING_WORDS` threshold and is flagged at ERROR (`ast_content_lost`) even though its text is fully retained.

## Fix

Peel leading decorative markers before judging a word missing. A token clears only when its peeled remainder is itself present in the AST or is a skip word, so peeling can remove a phantom report but never hide genuine loss: a real word absent behind a marker keeps a remainder that resolves to neither and stays missing. The change is confined to the missing-word decision, so it feeds both the `MISSING_WORDS` issue and `stats.missingWords`. Character-based `CONTENT_LOSS` (retention) is untouched.

## Tests

`validate-ast.test.ts` gains three cases, alongside the existing bracketed-marker test:

- a bracketless glued text node produces no missing words;
- an inline-element marker boundary produces no missing words;
- a genuinely lost word behind a marker is still reported.

The first two fail on the current code and pass with the fix; the third passes both ways (it guards against over-peeling).

`bun scripts/run-tests.ts` for the file (35 pass), plus `@stll/api` typecheck and lint, are green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CpZPp9efJmRLPZjjtLGeZG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved legal document validation for decorative “obrázek” markers attached to adjacent words.
  - Prevented false missing-word warnings when decorative markers appear without brackets or within inline elements.
  - Continued reporting genuinely missing content after marker removal.

- **Tests**
  - Added coverage for decorative marker boundary handling and preservation of real content-loss detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->