### PR TITLE
chore(api): use official Elysia packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -196,6 +196,7 @@ updates:
       elysia:
         patterns:
           - "elysia"
+          - "@elysia/*"
           - "@elysiajs/*"
       react-email:
         patterns:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,6 +465,12 @@ jobs:
         if: needs.ci-plan.outputs.package_checks_required == 'true'
         run: bun run lint:ws
 
+      - name: Dependabot group guard
+        # Related framework and plugin updates must stay in one PR even when
+        # upstream moves packages between scopes.
+        if: needs.ci-plan.outputs.package_checks_required == 'true'
+        run: bun test scripts/dependabot-grouping.test.ts
+
       - name: Lockfile workspace-version guard
         # `bun.lock` caches each workspace's `name`/`version`; `bun install`
         # (frozen or not) never rewrites that cache when only a workspace's

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,6 @@ jobs:
       - name: Dependabot group guard
         # Related framework and plugin updates must stay in one PR even when
         # upstream moves packages between scopes.
-        if: needs.ci-plan.outputs.package_checks_required == 'true'
         run: bun test scripts/dependabot-grouping.test.ts
 
       - name: Lockfile workspace-version guard

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1113.0",
     "@better-auth/api-key": "catalog:",
     "@better-auth/oauth-provider": "catalog:",
-    "@elysiajs/cors": "^1.4.2",
+    "@elysia/cors": "^1.4.2",
     "@firecrawl/anydoc": "0.1.9",
     "@google/genai": "^2.17.1",
     "@hyzyla/pdfium": "2.1.13",

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,4 +1,4 @@
-import cors from "@elysiajs/cors";
+import cors from "@elysia/cors";
 import { Elysia } from "elysia";
 import type { Context } from "elysia";
 

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
         "@aws-sdk/s3-request-presigner": "^3.1113.0",
         "@better-auth/api-key": "catalog:",
         "@better-auth/oauth-provider": "catalog:",
-        "@elysiajs/cors": "^1.4.2",
+        "@elysia/cors": "^1.4.2",
         "@firecrawl/anydoc": "0.1.9",
         "@google/genai": "^2.17.1",
         "@hyzyla/pdfium": "2.1.13",
@@ -469,7 +469,7 @@
       "name": "@stll/api-client",
       "version": "0.0.0",
       "dependencies": {
-        "@elysiajs/eden": "^1.4.9",
+        "@elysia/eden": "^1.4.10",
       },
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
@@ -1356,9 +1356,9 @@
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.5.4", "", {}, "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g=="],
 
-    "@elysiajs/cors": ["@elysiajs/cors@1.4.2", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-FTCcbH35brTLigF1W7BYySRZomgI/dBEMK9BgK9RP9Nez7zmpGh4koL/Yr1BFv8nYz7CfhRvcM8d/c+XnwMaVQ=="],
+    "@elysia/cors": ["@elysia/cors@1.4.2", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-dXkfo1IxZWJkJReNYnPJorJqb+XpWno0D/YWlMEJSkiFIFd751zJ4R/YswAYdo88mLWo8cycEj673o7L+gbxsw=="],
 
-    "@elysiajs/eden": ["@elysiajs/eden@1.4.9", "", { "peerDependencies": { "elysia": ">=1.4.19" } }, "sha512-3CKVD4ycVjB8nCNssfmhnUuq3SzSHkUES3v5PNCFr9LxIrx39/HVRAZ8z2sLxrFqzUs48dCBZaxoZzJ5UUVHDA=="],
+    "@elysia/eden": ["@elysia/eden@1.4.10", "", { "peerDependencies": { "elysia": ">=1.4.19" } }, "sha512-vcZXQcW6wZj6rhTxaiTkuCbVuS/yAJQ9jqCM6b83a5hu99F5Aj3HOyWXL17iod2Rz+pJpYsQGX0XaeoCsMpw2g=="],
 
     "@emmetio/abbreviation": ["@emmetio/abbreviation@2.3.3", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA=="],
 

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -17,7 +17,7 @@
     "format": "oxfmt ."
   },
   "dependencies": {
-    "@elysiajs/eden": "^1.4.9"
+    "@elysia/eden": "^1.4.10"
   },
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,5 +1,5 @@
-import { treaty } from "@elysiajs/eden";
-import type { Treaty } from "@elysiajs/eden";
+import { treaty } from "@elysia/eden";
+import type { Treaty } from "@elysia/eden";
 import type { AnyElysia } from "elysia";
 
 export type StellaEdenClientOptions = Omit<Treaty.Config, "parseDate">;

--- a/scripts/dependabot-grouping.test.ts
+++ b/scripts/dependabot-grouping.test.ts
@@ -12,7 +12,7 @@ const dependencyFields = [
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const readElysiaGroupPatterns = async (): Promise<string[]> => {
+const readElysiaGroupPatterns = async () => {
   const dependabot = await Bun.file(
     new URL("../.github/dependabot.yml", import.meta.url),
   ).text();
@@ -29,10 +29,7 @@ const readElysiaGroupPatterns = async (): Promise<string[]> => {
   ].flatMap((match) => (match[1] === undefined ? [] : [match[1]]));
 };
 
-const matchesDependabotPattern = (
-  dependency: string,
-  pattern: string,
-): boolean => {
+const matchesDependabotPattern = (dependency: string, pattern: string) => {
   const escaped = pattern.replace(/[.+?^${}()|[\]\\]/gu, "\\$&");
   return new RegExp(`^${escaped.replaceAll("*", ".*")}$`, "u").test(dependency);
 };

--- a/scripts/dependabot-grouping.test.ts
+++ b/scripts/dependabot-grouping.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const dependencyFields = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+] as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const readElysiaGroupPatterns = async (): Promise<string[]> => {
+  const dependabot = await Bun.file(
+    new URL("../.github/dependabot.yml", import.meta.url),
+  ).text();
+  const groupMarker = "\n      elysia:\n";
+  const groupStart = dependabot.indexOf(groupMarker);
+  expect(groupStart).toBeGreaterThanOrEqual(0);
+
+  const groupTail = dependabot.slice(groupStart + groupMarker.length);
+  const nextGroupOffset = groupTail.search(/^ {6}[a-z0-9][a-z0-9-]*:$/mu);
+  expect(nextGroupOffset).toBeGreaterThanOrEqual(0);
+
+  return [
+    ...groupTail.slice(0, nextGroupOffset).matchAll(/^ {10}- "([^"]+)"$/gmu),
+  ].flatMap((match) => (match[1] === undefined ? [] : [match[1]]));
+};
+
+const matchesDependabotPattern = (
+  dependency: string,
+  pattern: string,
+): boolean => {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/gu, "\\$&");
+  return new RegExp(`^${escaped.replaceAll("*", ".*")}$`, "u").test(dependency);
+};
+
+describe("Dependabot dependency groups", () => {
+  test("keeps every installed Elysia package in one update group", async () => {
+    const manifestPaths = [
+      "package.json",
+      ...(await Array.fromAsync(
+        new Bun.Glob("apps/*/package.json").scan(repositoryRoot),
+      )),
+      ...(await Array.fromAsync(
+        new Bun.Glob("packages/*/package.json").scan(repositoryRoot),
+      )),
+    ];
+    const installedElysiaPackages = new Set<string>();
+    const manifests = await Promise.all(
+      manifestPaths.map(async (manifestPath) => ({
+        manifest: await Bun.file(`${repositoryRoot}/${manifestPath}`).json(),
+        manifestPath,
+      })),
+    );
+
+    for (const { manifest, manifestPath } of manifests) {
+      if (!isRecord(manifest)) {
+        throw new TypeError(`${manifestPath} must contain a JSON object`);
+      }
+
+      for (const field of dependencyFields) {
+        const dependencies = manifest[field];
+        if (!isRecord(dependencies)) {
+          continue;
+        }
+        for (const dependency of Object.keys(dependencies)) {
+          if (
+            dependency === "elysia" ||
+            dependency.startsWith("@elysia/") ||
+            dependency.startsWith("@elysiajs/")
+          ) {
+            installedElysiaPackages.add(dependency);
+          }
+        }
+      }
+    }
+
+    const groupPatterns = await readElysiaGroupPatterns();
+    const uncovered = [...installedElysiaPackages]
+      .filter(
+        (dependency) =>
+          !groupPatterns.some((pattern) =>
+            matchesDependabotPattern(dependency, pattern),
+          ),
+      )
+      .sort();
+
+    expect(uncovered).toEqual([]);
+  });
+});

--- a/scripts/dependabot-grouping.test.ts
+++ b/scripts/dependabot-grouping.test.ts
@@ -12,27 +12,69 @@ const dependencyFields = [
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const readElysiaGroupPatterns = async () => {
-  const dependabot = await Bun.file(
-    new URL("../.github/dependabot.yml", import.meta.url),
-  ).text();
-  const groupMarker = "\n      elysia:\n";
-  const groupStart = dependabot.indexOf(groupMarker);
-  expect(groupStart).toBeGreaterThanOrEqual(0);
-
-  const groupTail = dependabot.slice(groupStart + groupMarker.length);
-  const nextGroupOffset = groupTail.search(/^ {6}[a-z0-9][a-z0-9-]*:$/mu);
-  expect(nextGroupOffset).toBeGreaterThanOrEqual(0);
-
-  return [
-    ...groupTail.slice(0, nextGroupOffset).matchAll(/^ {10}- "([^"]+)"$/gmu),
-  ].flatMap((match) => (match[1] === undefined ? [] : [match[1]]));
+const readStringArray = (value: unknown, field: string) => {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${field} must be an array of strings`);
+  }
+  const strings = value.flatMap((item) =>
+    typeof item === "string" ? [item] : [],
+  );
+  if (strings.length !== value.length) {
+    throw new TypeError(`${field} must be an array of strings`);
+  }
+  return strings;
 };
+
+const parseElysiaGroup = (source: string) => {
+  const dependabot: unknown = Bun.YAML.parse(source);
+  if (!isRecord(dependabot) || !Array.isArray(dependabot["updates"])) {
+    throw new TypeError("Dependabot config must contain an updates array");
+  }
+  const bunUpdate = dependabot["updates"].find(
+    (update) => isRecord(update) && update["package-ecosystem"] === "bun",
+  );
+  if (!isRecord(bunUpdate) || !isRecord(bunUpdate["groups"])) {
+    throw new TypeError("Dependabot config must contain Bun dependency groups");
+  }
+  const elysiaGroup = bunUpdate["groups"]["elysia"];
+  if (!isRecord(elysiaGroup)) {
+    throw new TypeError("Dependabot config must contain the Elysia group");
+  }
+
+  return {
+    excludePatterns:
+      elysiaGroup["exclude-patterns"] === undefined
+        ? []
+        : readStringArray(
+            elysiaGroup["exclude-patterns"],
+            "Elysia exclude-patterns",
+          ),
+    patterns: readStringArray(elysiaGroup["patterns"], "Elysia patterns"),
+  };
+};
+
+const readElysiaGroup = async () =>
+  parseElysiaGroup(
+    await Bun.file(
+      new URL("../.github/dependabot.yml", import.meta.url),
+    ).text(),
+  );
 
 const matchesDependabotPattern = (dependency: string, pattern: string) => {
   const escaped = pattern.replace(/[.+?^${}()|[\]\\]/gu, "\\$&");
   return new RegExp(`^${escaped.replaceAll("*", ".*")}$`, "u").test(dependency);
 };
+
+type DependabotGroup = ReturnType<typeof parseElysiaGroup>;
+
+const isDependencyInGroup = (
+  dependency: string,
+  { excludePatterns, patterns }: DependabotGroup,
+) =>
+  patterns.some((pattern) => matchesDependabotPattern(dependency, pattern)) &&
+  !excludePatterns.some((pattern) =>
+    matchesDependabotPattern(dependency, pattern),
+  );
 
 describe("Dependabot dependency groups", () => {
   test("keeps every installed Elysia package in one update group", async () => {
@@ -75,16 +117,28 @@ describe("Dependabot dependency groups", () => {
       }
     }
 
-    const groupPatterns = await readElysiaGroupPatterns();
+    const group = await readElysiaGroup();
     const uncovered = [...installedElysiaPackages]
-      .filter(
-        (dependency) =>
-          !groupPatterns.some((pattern) =>
-            matchesDependabotPattern(dependency, pattern),
-          ),
-      )
+      .filter((dependency) => !isDependencyInGroup(dependency, group))
       .sort();
 
     expect(uncovered).toEqual([]);
+  });
+
+  test("applies exclude patterns after include patterns", () => {
+    const group = parseElysiaGroup(`
+version: 2
+updates:
+  - package-ecosystem: bun
+    groups:
+      elysia:
+        patterns:
+          - "@elysia/*"
+        exclude-patterns:
+          - "@elysia/eden"
+`);
+
+    expect(isDependencyInGroup("@elysia/cors", group)).toBe(true);
+    expect(isDependencyInGroup("@elysia/eden", group)).toBe(false);
   });
 });

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -220,6 +220,7 @@ run_test() {
 run_step "AI skill sync wrapper self-test" bash scripts/check-ai-skill-sync.test.sh
 run_step "AI skill sync" bash scripts/check-ai-skill-sync.sh .
 run_step "Workspace hygiene" bun run lint:ws
+run_step "Dependabot group guard" bun test scripts/dependabot-grouping.test.ts
 run_step "Lockfile workspace-version guard" bun scripts/check-lockfile-workspace-versions.ts
 run_step "Quarantine-exclude guards" run_quarantine_exclude_guard
 run_step "Policy evidence" bun run policies:check


### PR DESCRIPTION
## Summary

- move CORS and Eden imports to the official `@elysia/*` scope
- keep the API on Elysia 1.4 while preparing the v2 upgrade
- refresh the Bun lockfile without changing runtime behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated API integrations to use the latest package names and versions.
  * Maintained existing CORS and API client functionality with no user-facing behaviour changes.
  * Added automated checks to ensure Elysia packages remain correctly grouped for dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->