### PR TITLE
chore: autofix Dependabot Bun lockfiles

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,66 @@
+name: autofix.ci # autofix.ci uses this exact name as a security boundary
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "bun.lock"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dependabot-bun-dedupe:
+    name: Dedupe Dependabot Bun lockfile
+    if: >-
+      github.actor == 'dependabot[bot]'
+      && github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.event.pull_request.head.ref, 'dependabot/bun/')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      # autofix-ci/action v1.3.4 declares Node 24 support, but its action
+      # metadata still names node20 for compatibility with older runners.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+    steps:
+      - name: Checkout Dependabot head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: "package.json"
+
+      # No install is needed. --lockfile-only and --ignore-scripts keep the
+      # fixer from materializing dependencies or running PR-controlled hooks.
+      - name: Dedupe lockfile
+        run: bun --no-env-file dedupe --lockfile-only --ignore-scripts
+
+      - name: Restrict generated changes to the lockfile
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          unexpected_tracked="$(git diff --name-only -- . ':(exclude)bun.lock')"
+          unexpected_untracked="$(git ls-files --others --exclude-standard)"
+          if [[ -n "${unexpected_tracked}${unexpected_untracked}" ]]; then
+            echo "::error::Bun dedupe changed files outside bun.lock."
+            git status --short
+            exit 1
+          fi
+
+          git diff --check -- bun.lock
+
+      - name: Push dedupe fix
+        uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4
+        with:
+          commit-message: "chore: dedupe Bun lockfile"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -917,7 +917,10 @@ jobs:
         run: bash scripts/detect-desktop-release-changes.test.sh
 
       - name: Test CI workflow invariants
-        run: bun test scripts/detect-e2e-changes.test.ts
+        run: >-
+          bun test
+          scripts/detect-e2e-changes.test.ts
+          scripts/autofix-workflow.test.ts
 
       - name: Test affected code-check planner
         if: needs.ci-plan.outputs.package_checks_required == 'true'

--- a/scripts/autofix-workflow.test.ts
+++ b/scripts/autofix-workflow.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+const WORKFLOW_URL = new URL(
+  "../.github/workflows/autofix.yml",
+  import.meta.url,
+);
+
+describe("Dependabot Bun autofix boundary", () => {
+  test("keeps the runner read-only and hands off only a verified lockfile", async () => {
+    const workflow = await Bun.file(WORKFLOW_URL).text();
+    const restrictionStep = workflow.indexOf(
+      "- name: Restrict generated changes to the lockfile",
+    );
+    const pushStep = workflow.indexOf("- name: Push dedupe fix");
+
+    expect(workflow).toContain(
+      "name: autofix.ci # autofix.ci uses this exact name as a security boundary",
+    );
+    expect(workflow).not.toContain("pull_request_target:");
+    expect(workflow).toContain("permissions:\n  contents: read");
+    expect(workflow).not.toContain("contents: write");
+    expect(workflow).not.toContain("secrets.");
+
+    expect(workflow).toContain("github.actor == 'dependabot[bot]'");
+    expect(workflow).toContain(
+      "github.event.pull_request.user.login == 'dependabot[bot]'",
+    );
+    expect(workflow).toContain(
+      "github.event.pull_request.head.repo.full_name == github.repository",
+    );
+    expect(workflow).toContain(
+      "startsWith(github.event.pull_request.head.ref, 'dependabot/bun/')",
+    );
+    expect(workflow).toContain(
+      `ref: \${{ github.event.pull_request.head.sha }}`,
+    );
+    expect(workflow).toContain("persist-credentials: false");
+
+    expect(workflow).toContain(
+      "bun --no-env-file dedupe --lockfile-only --ignore-scripts",
+    );
+    expect(workflow).toContain(
+      "git diff --name-only -- . ':(exclude)bun.lock'",
+    );
+    expect(workflow).toContain("git ls-files --others --exclude-standard");
+    expect(restrictionStep).toBeGreaterThanOrEqual(0);
+    expect(pushStep).toBeGreaterThan(restrictionStep);
+    expect(workflow).toContain(
+      "autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4",
+    );
+  });
+});

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -276,6 +276,8 @@ run_step "Release manifest self-test" bash scripts/create-release-manifest.test.
 run_step "Maintenance release preparation self-test" bun test \
   scripts/prepare-maintenance-release.property.test.ts
 run_step "Desktop-release-changes self-test" bash scripts/detect-desktop-release-changes.test.sh
+run_step "Dependabot Bun autofix self-test" bun test \
+  scripts/autofix-workflow.test.ts
 run_step "Bridge-version guard" bash scripts/check-bridge-version.sh
 
 echo


### PR DESCRIPTION
## Summary

- dedupe `bun.lock` automatically on same-repository Dependabot Bun pull requests
- keep the workflow token read-only and reject generated changes outside the lockfile
- enforce the automation boundary with a CI invariant test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated workflow to safely deduplicate Bun lockfiles in eligible Dependabot updates.
  * Restricts automated changes to the lockfile and submits the fix automatically.

* **Tests**
  * Added validation covering workflow security, permissions, checkout behaviour and lockfile-only changes.
  * Included the workflow checks in the standard verification and CI processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->