### PR TITLE
feat: open cited decisions in the inspector

### DIFF
--- a/.changeset/public-law-inspector-chip.md
+++ b/.changeset/public-law-inspector-chip.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": patch
+---
+
+Render inspector rail tabs as canonical square active chips.

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
@@ -148,7 +148,8 @@ describe("parseNssDecisionHtml", () => {
 
       const { documentAst } = parseNssDecisionHtml(baseInput(html));
       const titles = documentAst.blocks.filter(
-        (block) => block.type === "heading" && block.role === "decision-title",
+        (block): block is Extract<Block, { type: "heading" }> =>
+          block.type === "heading" && block.role === "decision-title",
       );
 
       expect(titles.map((title) => title.plainText)).toEqual([

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
@@ -123,6 +123,40 @@ describe("parseNssDecisionHtml", () => {
       expect(fulltext).toContain("stěžovatel");
       expect(fulltext).toContain("Krajský soud");
     });
+
+    test("canonicalizes publisher-spaced decision titles as centred headings", () => {
+      const html = `<html><body>
+        <p style="text-align:center">4 As 3/2008 - 78</p>
+        <p style="text-align:center">
+          <span style="font-weight:bold">R O Z</span>
+          <span style="font-weight:bold">&nbsp;</span>
+          <span style="font-weight:bold">S</span>
+          <span style="font-weight:bold">&nbsp;</span>
+          <span style="font-weight:bold">U D E K</span>
+        </p>
+        <p style="text-align:center">
+          <span style="font-weight:bold">J M É N E M</span>
+          <span style="font-weight:bold; -aw-import:spaces">&nbsp;&nbsp;&nbsp;</span>
+          <span style="font-weight:bold">R E P U B L I K</span>
+          <span style="font-weight:bold">&nbsp;</span>
+          <span style="font-weight:bold">Y</span>
+        </p>
+        <p>Nejvyšší správní soud rozhodl v rozšířeném senátě složeném z předsedy
+        senátu a soudců v právní věci žalobkyně proti žalovanému o kasační
+        stížnosti proti rozsudku městského soudu a po posouzení věci rozhodl.</p>
+      </body></html>`;
+
+      const { documentAst } = parseNssDecisionHtml(baseInput(html));
+      const titles = documentAst.blocks.filter(
+        (block) => block.type === "heading" && block.role === "decision-title",
+      );
+
+      expect(titles.map((title) => title.plainText)).toEqual([
+        "ROZSUDEK",
+        "JMÉNEM REPUBLIKY",
+      ]);
+      expect(titles.map((title) => title.level)).toEqual([1, 1]);
+    });
   });
 
   describe("skip patterns", () => {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -330,8 +330,38 @@ const parseFontSize = (style: string): number => {
  */
 const SKIP_RE = /^\[OBRÁZEK\]|^pokračování$|^ČESKÁ REPUBLIKA$/u;
 
-/** Decision title. */
-const TITLE_RE = /^(?:ROZSUDEK|USNESENÍ|JMÉNEM REPUBLIKY)$/u;
+/**
+ * Decision titles keyed by their semantic letters. Older Aspose exports split
+ * one title across spans and insert ordinary or non-breaking spaces between
+ * letters. Comparing the compact form keeps that presentation noise out of
+ * the AST while preserving one canonical title for readers and search.
+ */
+const DECISION_TITLE_BY_COMPACT_TEXT = {
+  ROZSUDEK: "ROZSUDEK",
+  USNESENÍ: "USNESENÍ",
+  JMÉNEMREPUBLIKY: "JMÉNEM REPUBLIKY",
+} as const;
+
+type CanonicalDecisionTitle =
+  (typeof DECISION_TITLE_BY_COMPACT_TEXT)[keyof typeof DECISION_TITLE_BY_COMPACT_TEXT];
+
+const isDecisionTitleKey = (
+  value: string,
+): value is keyof typeof DECISION_TITLE_BY_COMPACT_TEXT =>
+  value in DECISION_TITLE_BY_COMPACT_TEXT;
+
+const canonicalDecisionTitle = (
+  plainText: string,
+): CanonicalDecisionTitle | null => {
+  const compact = plainText
+    .normalize("NFKC")
+    .toLocaleUpperCase("cs-CZ")
+    .replace(/\s+/gu, "");
+
+  return isDecisionTitleKey(compact)
+    ? DECISION_TITLE_BY_COMPACT_TEXT[compact]
+    : null;
+};
 
 /** "takto:" separator. */
 const TAKTO_RE = /^t\s*a\s*k\s*t\s*o\s*(?::\s*)?$/iu;
@@ -404,12 +434,14 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
       continue;
     }
 
+    const decisionTitle = canonicalDecisionTitle(plainText);
+
     // Case number: first content before the title, centered
     // Case number line (e.g. "2 As 3/2025 - 56")
     if (
       !sawTitle &&
       centered &&
-      !TITLE_RE.test(plainText) &&
+      decisionTitle === null &&
       !sawCaseNumber &&
       /\d/u.test(plainText)
     ) {
@@ -427,7 +459,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
     }
 
     // Decision title: ROZSUDEK, USNESENÍ, JMÉNEM REPUBLIKY
-    if (TITLE_RE.test(plainText)) {
+    if (decisionTitle !== null) {
       sawTitle = true;
       blockIndex += 1;
       blocks.push({
@@ -436,8 +468,8 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
         type: "heading",
         level: 1,
         role: "decision-title",
-        inlines,
-        plainText,
+        inlines: [{ type: "text", text: decisionTitle }],
+        plainText: decisionTitle,
       });
       continue;
     }

--- a/apps/web/src/components/inspector/case-decision-view.ts
+++ b/apps/web/src/components/inspector/case-decision-view.ts
@@ -106,11 +106,13 @@ type CitationClick = Pick<
 >;
 
 /** Plain primary clicks stay in context; browser navigation gestures remain native. */
-export const opensCitationInInspector = ({
-  altKey,
-  button,
-  ctrlKey,
-  metaKey,
-  shiftKey,
-}: CitationClick): boolean =>
-  button === 0 && !altKey && !ctrlKey && !metaKey && !shiftKey;
+export const opensCitationInInspector = (
+  { altKey, button, ctrlKey, metaKey, shiftKey }: CitationClick,
+  inspectorAvailable: boolean,
+): boolean =>
+  inspectorAvailable &&
+  button === 0 &&
+  !altKey &&
+  !ctrlKey &&
+  !metaKey &&
+  !shiftKey;

--- a/apps/web/src/components/inspector/case-decision-view.ts
+++ b/apps/web/src/components/inspector/case-decision-view.ts
@@ -1,6 +1,6 @@
 import { createCaseLawDecisionRouteParams } from "@/lib/case-law-route";
 
-/** Inspector view kind for one public case-law decision. */
+/** Registered inspector view kind for one public case-law decision. */
 export const CASE_DECISION_VIEW = "case-law-decision";
 
 export type CaseDecisionViewPayload = {

--- a/apps/web/src/components/inspector/inspector-rail.tsx
+++ b/apps/web/src/components/inspector/inspector-rail.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { InspectorRailTab } from "@stll/ui/inspector";
 import { ScrollArea } from "@stll/ui/scroll-area";
 import { containedEventHandler } from "@stll/ui/use-contained-handler";
 import { cn } from "@stll/ui/utils";
@@ -141,7 +142,7 @@ export const InspectorRail = ({
       </div>
       <ScrollArea className="flex-1">
         <div
-          className="flex h-full flex-col"
+          className="flex h-full flex-col items-center gap-1 py-2"
           onContextMenu={(event) => {
             event.preventDefault();
             railContextMenu.openAt(event);
@@ -516,21 +517,10 @@ const VerticalTab = ({
       <Tooltip
         content={tooltipLabel}
         render={
-          <button
+          <InspectorRailTab
+            active={active}
             ref={tabRef}
             aria-label={tooltipLabel}
-            className={cn(
-              "group/tab relative flex min-h-8 w-full items-center justify-center border-b transition-colors",
-              "text-muted-foreground hover:bg-accent hover:text-foreground",
-              TOOLBAR_ROW_HEIGHT,
-              active &&
-                cn(
-                  "bg-background text-foreground before:bg-primary",
-                  "before:absolute",
-                  "before:inset-y-0",
-                  "before:inset-s-0 before:w-0.5",
-                ),
-            )}
             onAuxClick={(e) => {
               if (e.button === 1) {
                 e.preventDefault();
@@ -539,7 +529,6 @@ const VerticalTab = ({
             }}
             onClick={containedEventHandler(onActivate)}
             onContextMenu={containedEventHandler(contextMenu.openAt)}
-            type="button"
           />
         }
         side="left"

--- a/apps/web/src/components/legal-reader/cited-decision-link.tsx
+++ b/apps/web/src/components/legal-reader/cited-decision-link.tsx
@@ -8,6 +8,7 @@ import {
   PreviewCardPopup,
   PreviewCardTrigger,
 } from "@stll/ui/preview-card";
+import { useIsMobile } from "@stll/ui/use-mobile";
 import { cn } from "@stll/ui/utils";
 
 import {
@@ -48,6 +49,7 @@ export const CitedDecisionLink = ({
   decision,
 }: CitedDecisionLinkProps) => {
   const format = useFormatter();
+  const isMobile = useIsMobile();
   const inspector = useInspectorView();
   const params = createCaseLawDecisionRouteParams({
     caseNumber: decision.caseNumber,
@@ -61,7 +63,7 @@ export const CitedDecisionLink = ({
   });
   const decided = formatDecisionDate(decision.decisionDate, format);
   const onCitationClick = (event: MouseEvent<HTMLAnchorElement>) => {
-    if (!opensCitationInInspector(event)) {
+    if (!opensCitationInInspector(event, !isMobile)) {
       return;
     }
 

--- a/apps/web/src/components/legal-reader/cited-decision-link.tsx
+++ b/apps/web/src/components/legal-reader/cited-decision-link.tsx
@@ -10,15 +10,15 @@ import {
 } from "@stll/ui/preview-card";
 import { cn } from "@stll/ui/utils";
 
-import { useInspectorView } from "@/components/inspector/use-inspector-view";
 import {
   createCaseDecisionViewTab,
   opensCitationInInspector,
-} from "@/features/case-law/case-decision-inspector.logic";
-import { citedDecisionLabel } from "@/features/case-law/cited-decision-label";
-import { formatDecisionDate } from "@/features/case-law/decision-date";
+} from "@/components/inspector/case-decision-view";
+import { useInspectorView } from "@/components/inspector/use-inspector-view";
 import { useFormatter } from "@/i18n/formatting-context";
 import { createCaseLawDecisionRouteParams } from "@/lib/case-law-route";
+import { citedDecisionLabel } from "@/lib/cited-decision-label";
+import { formatDecisionDate } from "@/lib/decision-date";
 
 type CitedDecisionLinkProps = {
   children: ReactNode;

--- a/apps/web/src/features/case-law/case-decision-inspector-registration.tsx
+++ b/apps/web/src/features/case-law/case-decision-inspector-registration.tsx
@@ -1,0 +1,45 @@
+import { lazy, Suspense } from "react";
+
+import { ScaleIcon } from "lucide-react";
+
+import { cn } from "@stll/ui/utils";
+
+import { registerInspectorView } from "@/components/inspector/view-registry";
+import type {
+  InspectorRailIconProps,
+  InspectorViewRenderProps,
+} from "@/components/inspector/view-registry";
+import {
+  CASE_DECISION_VIEW,
+  isCaseDecisionViewPayload,
+} from "@/features/case-law/case-decision-inspector.logic";
+import type { CaseDecisionViewPayload } from "@/features/case-law/case-decision-inspector.logic";
+
+const LazyCaseDecisionInspectorView = lazy(async () => {
+  const module =
+    await import("@/features/case-law/components/case-decision-inspector-view");
+  return { default: module.CaseDecisionInspectorView };
+});
+
+const CaseDecisionRailIcon = ({
+  active,
+}: InspectorRailIconProps<CaseDecisionViewPayload>) => (
+  <ScaleIcon className={cn("size-3.5", !active && "opacity-70")} />
+);
+
+const CaseDecisionView = (
+  props: InspectorViewRenderProps<CaseDecisionViewPayload>,
+) => (
+  <Suspense fallback={<div className="bg-background flex-1" />}>
+    <LazyCaseDecisionInspectorView {...props} />
+  </Suspense>
+);
+
+registerInspectorView<CaseDecisionViewPayload>({
+  type: CASE_DECISION_VIEW,
+  render: CaseDecisionView,
+  railIcon: CaseDecisionRailIcon,
+  navigationPolicy: "persist",
+  validate: isCaseDecisionViewPayload,
+  ariaLabel: (tab) => tab.label,
+});

--- a/apps/web/src/features/case-law/case-decision-inspector-registration.tsx
+++ b/apps/web/src/features/case-law/case-decision-inspector-registration.tsx
@@ -4,16 +4,16 @@ import { ScaleIcon } from "lucide-react";
 
 import { cn } from "@stll/ui/utils";
 
+import {
+  CASE_DECISION_VIEW,
+  isCaseDecisionViewPayload,
+} from "@/components/inspector/case-decision-view";
+import type { CaseDecisionViewPayload } from "@/components/inspector/case-decision-view";
 import { registerInspectorView } from "@/components/inspector/view-registry";
 import type {
   InspectorRailIconProps,
   InspectorViewRenderProps,
 } from "@/components/inspector/view-registry";
-import {
-  CASE_DECISION_VIEW,
-  isCaseDecisionViewPayload,
-} from "@/features/case-law/case-decision-inspector.logic";
-import type { CaseDecisionViewPayload } from "@/features/case-law/case-decision-inspector.logic";
 
 const LazyCaseDecisionInspectorView = lazy(async () => {
   const module =

--- a/apps/web/src/features/case-law/case-decision-inspector.logic.test.ts
+++ b/apps/web/src/features/case-law/case-decision-inspector.logic.test.ts
@@ -5,7 +5,7 @@ import {
   createCaseDecisionViewTab,
   isCaseDecisionViewPayload,
   opensCitationInInspector,
-} from "@/features/case-law/case-decision-inspector.logic";
+} from "@/components/inspector/case-decision-view";
 
 describe("case decision inspector", () => {
   test("derives one stable tab and canonical route payload", () => {

--- a/apps/web/src/features/case-law/case-decision-inspector.logic.test.ts
+++ b/apps/web/src/features/case-law/case-decision-inspector.logic.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CASE_DECISION_VIEW,
+  createCaseDecisionViewTab,
+  isCaseDecisionViewPayload,
+  opensCitationInInspector,
+} from "@/features/case-law/case-decision-inspector.logic";
+
+describe("case decision inspector", () => {
+  test("derives one stable tab and canonical route payload", () => {
+    expect(
+      createCaseDecisionViewTab({
+        caseNumber: "4 As 3/2008",
+        country: "CZ",
+        court: "Nejvyšší správní soud",
+        decisionId: "d4f1bfe6-f7e4-42a2-9d4f-fd121ea90b34",
+        slug: "4-as-3-2008",
+      }),
+    ).toEqual({
+      type: CASE_DECISION_VIEW,
+      id: "case-law-decision:d4f1bfe6-f7e4-42a2-9d4f-fd121ea90b34",
+      label: "4 As 3/2008",
+      payload: {
+        caseNumber: "4 As 3/2008",
+        country: "cz",
+        court: "nejvyssi-spravni-soud",
+        decisionId: "d4f1bfe6-f7e4-42a2-9d4f-fd121ea90b34",
+        slug: "4-as-3-2008",
+      },
+    });
+  });
+
+  test("validates synchronized payloads", () => {
+    const payload = createCaseDecisionViewTab({
+      caseNumber: "4 As 3/2008",
+      country: "CZ",
+      court: "NSS",
+      decisionId: "decision-id",
+      language: "cs",
+      languageAlternateCount: 2,
+      slug: "4-as-3-2008",
+    }).payload;
+
+    expect(isCaseDecisionViewPayload(payload)).toBe(true);
+    expect(isCaseDecisionViewPayload({ ...payload, decisionId: "" })).toBe(
+      false,
+    );
+  });
+
+  test("intercepts only an unmodified primary click", () => {
+    const primary = {
+      altKey: false,
+      button: 0,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+    };
+
+    expect(opensCitationInInspector(primary)).toBe(true);
+    expect(opensCitationInInspector({ ...primary, button: 1 })).toBe(false);
+    expect(opensCitationInInspector({ ...primary, metaKey: true })).toBe(false);
+    expect(opensCitationInInspector({ ...primary, ctrlKey: true })).toBe(false);
+    expect(opensCitationInInspector({ ...primary, shiftKey: true })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/web/src/features/case-law/case-decision-inspector.logic.test.ts
+++ b/apps/web/src/features/case-law/case-decision-inspector.logic.test.ts
@@ -57,11 +57,18 @@ describe("case decision inspector", () => {
       shiftKey: false,
     };
 
-    expect(opensCitationInInspector(primary)).toBe(true);
-    expect(opensCitationInInspector({ ...primary, button: 1 })).toBe(false);
-    expect(opensCitationInInspector({ ...primary, metaKey: true })).toBe(false);
-    expect(opensCitationInInspector({ ...primary, ctrlKey: true })).toBe(false);
-    expect(opensCitationInInspector({ ...primary, shiftKey: true })).toBe(
+    expect(opensCitationInInspector(primary, true)).toBe(true);
+    expect(opensCitationInInspector(primary, false)).toBe(false);
+    expect(opensCitationInInspector({ ...primary, button: 1 }, true)).toBe(
+      false,
+    );
+    expect(opensCitationInInspector({ ...primary, metaKey: true }, true)).toBe(
+      false,
+    );
+    expect(opensCitationInInspector({ ...primary, ctrlKey: true }, true)).toBe(
+      false,
+    );
+    expect(opensCitationInInspector({ ...primary, shiftKey: true }, true)).toBe(
       false,
     );
   });

--- a/apps/web/src/features/case-law/case-decision-inspector.logic.ts
+++ b/apps/web/src/features/case-law/case-decision-inspector.logic.ts
@@ -1,0 +1,116 @@
+import { createCaseLawDecisionRouteParams } from "@/lib/case-law-route";
+
+/** Inspector view kind for one public case-law decision. */
+export const CASE_DECISION_VIEW = "case-law-decision";
+
+export type CaseDecisionViewPayload = {
+  caseNumber: string;
+  country: string;
+  court: string;
+  decisionId: string;
+  language?: string | undefined;
+  slug: string;
+};
+
+type CaseDecisionTarget = {
+  caseNumber: string;
+  country: string;
+  court: string;
+  decisionId: string;
+  language?: string | null | undefined;
+  languageAlternateCount?: number | null | undefined;
+  languageAlternates?: readonly unknown[] | null | undefined;
+  slug?: string | null | undefined;
+};
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.length > 0;
+
+export const isCaseDecisionViewPayload = (
+  value: unknown,
+): value is CaseDecisionViewPayload => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  return (
+    "caseNumber" in value &&
+    isNonEmptyString(value.caseNumber) &&
+    "country" in value &&
+    isNonEmptyString(value.country) &&
+    "court" in value &&
+    isNonEmptyString(value.court) &&
+    "decisionId" in value &&
+    isNonEmptyString(value.decisionId) &&
+    "slug" in value &&
+    isNonEmptyString(value.slug) &&
+    (!("language" in value) ||
+      value.language === undefined ||
+      isNonEmptyString(value.language))
+  );
+};
+
+export const caseDecisionTabId = (decisionId: string): string =>
+  `${CASE_DECISION_VIEW}:${decisionId}`;
+
+export type CaseDecisionViewTab = {
+  type: typeof CASE_DECISION_VIEW;
+  id: string;
+  label: string;
+  payload: CaseDecisionViewPayload;
+};
+
+/**
+ * One tab per decision. Route identity is resolved once at the click boundary,
+ * then survives inspector synchronization as plain structured-clone data.
+ */
+export const createCaseDecisionViewTab = ({
+  caseNumber,
+  country,
+  court,
+  decisionId,
+  language,
+  languageAlternateCount,
+  languageAlternates,
+  slug,
+}: CaseDecisionTarget): CaseDecisionViewTab => {
+  const route = createCaseLawDecisionRouteParams({
+    caseNumber,
+    country,
+    court,
+    decisionId,
+    language,
+    languageAlternateCount,
+    languageAlternates,
+    slug,
+  });
+
+  return {
+    type: CASE_DECISION_VIEW,
+    id: caseDecisionTabId(decisionId),
+    label: caseNumber,
+    payload: {
+      caseNumber,
+      country: route.country,
+      court: route.court,
+      decisionId,
+      slug: route.slug,
+      ...(route.language === undefined ? {} : { language: route.language }),
+    },
+  };
+};
+
+type CitationClick = Pick<
+  MouseEvent,
+  "altKey" | "button" | "ctrlKey" | "metaKey" | "shiftKey"
+>;
+
+/** Plain primary clicks stay in context; browser navigation gestures remain native. */
+export const opensCitationInInspector = ({
+  altKey,
+  button,
+  ctrlKey,
+  metaKey,
+  shiftKey,
+}: CitationClick): boolean =>
+  button === 0 && !altKey && !ctrlKey && !metaKey && !shiftKey;

--- a/apps/web/src/features/case-law/cited-decision-label.test.ts
+++ b/apps/web/src/features/case-law/cited-decision-label.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { citedDecisionLabel } from "@/features/case-law/cited-decision-label";
+import { citedDecisionLabel } from "@/lib/cited-decision-label";
 
 describe("citedDecisionLabel", () => {
   test("two documents of one file get distinct labels", () => {

--- a/apps/web/src/features/case-law/cited-decision-label.ts
+++ b/apps/web/src/features/case-law/cited-decision-label.ts
@@ -1,9 +1,8 @@
-import type { CitedDecision } from "@/features/case-law/citation-treatment";
-
-type LabelSource = Pick<
-  CitedDecision,
-  "caseNumber" | "decisionDate" | "decisionType"
->;
+type LabelSource = {
+  caseNumber: string;
+  decisionDate: string | null;
+  decisionType?: string | null | undefined;
+};
 
 /**
  * The label a cited decision is shown under.

--- a/apps/web/src/features/case-law/components/case-decision-inspector-view.tsx
+++ b/apps/web/src/features/case-law/components/case-decision-inspector-view.tsx
@@ -1,0 +1,136 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { Maximize2Icon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import { BidiText } from "@stll/ui/bidi-text";
+import { Button } from "@stll/ui/button";
+import { ScrollArea } from "@stll/ui/scroll-area";
+import { Skeleton } from "@stll/ui/skeleton";
+
+import { InspectorTabHeader } from "@/components/inspector/inspector-tab-header";
+import type { InspectorViewRenderProps } from "@/components/inspector/view-registry";
+import Tooltip from "@/components/tooltip";
+import type { CaseDecisionViewPayload } from "@/features/case-law/case-decision-inspector.logic";
+import { CitationHeader } from "@/features/case-law/components/case-viewer/citation-header";
+import { DecisionCitations } from "@/features/case-law/components/case-viewer/decision-citations";
+import { DecisionText } from "@/features/case-law/components/case-viewer/decision-text";
+import { ProvisionsCited } from "@/features/case-law/components/case-viewer/provisions-cited";
+import { useDecisionCitationAnchors } from "@/features/case-law/components/case-viewer/use-decision-citation-anchors";
+import { decisionOptions } from "@/features/case-law/queries/decisions";
+import { detached } from "@/lib/detached";
+import { toSafeId } from "@/lib/safe-id";
+
+/** A compact decision reader composed for the inspector's bounded width. */
+export const CaseDecisionInspectorView = ({
+  onClose,
+  tab,
+}: InspectorViewRenderProps<CaseDecisionViewPayload>) => {
+  const t = useTranslations();
+  const { payload } = tab;
+  const decisionId = toSafeId<"caseLawDecision">(payload.decisionId);
+  const citationAnchors = useDecisionCitationAnchors(decisionId);
+  const {
+    data: decision,
+    isError,
+    isPending,
+    refetch,
+  } = useQuery(decisionOptions(decisionId));
+  const mainLink =
+    payload.language === undefined ? (
+      <Link
+        onClick={onClose}
+        params={{
+          country: payload.country,
+          court: payload.court,
+          slug: payload.slug,
+        }}
+        to="/law/$country/cases/$court/$slug"
+      />
+    ) : (
+      <Link
+        onClick={onClose}
+        params={{
+          country: payload.country,
+          court: payload.court,
+          language: payload.language,
+          slug: payload.slug,
+        }}
+        to="/law/$country/cases/$court/$language/$slug"
+      />
+    );
+
+  return (
+    <div className="bg-background flex min-h-0 flex-1 flex-col overflow-hidden">
+      <InspectorTabHeader
+        actions={
+          <Tooltip
+            content={t("chat.moveToMain")}
+            render={
+              <Button
+                aria-label={t("chat.moveToMain")}
+                render={mainLink}
+                size="icon-xs"
+                variant="ghost"
+              />
+            }
+          >
+            <Maximize2Icon className="size-3.5" />
+          </Tooltip>
+        }
+        label={tab.label}
+        onClose={onClose}
+      />
+      <ScrollArea className="min-h-0 flex-1">
+        <main className="reader-paper min-h-full px-4 py-6">
+          <h1 className="sr-only">
+            <BidiText as="span">{payload.caseNumber}</BidiText>
+          </h1>
+          {isPending && <DecisionInspectorLoader />}
+          {isError && (
+            <div className="flex flex-col items-start gap-2 font-sans">
+              <p className="text-muted-foreground text-xs">
+                {t("errors.actionFailed")}
+              </p>
+              <Button
+                onClick={() => {
+                  detached(refetch(), "case-law.inspector-retry");
+                }}
+                size="sm"
+                variant="ghost"
+              >
+                {t("common.retry")}
+              </Button>
+            </div>
+          )}
+          {decision !== undefined && (
+            <>
+              <CitationHeader
+                decisionDate={decision.decisionDate}
+                decisionId={decisionId}
+              />
+              <DecisionCitations decisionId={decisionId} />
+              <ProvisionsCited decisionId={decisionId} />
+              <DecisionText
+                activeMatchIndex={0}
+                citationAnchors={citationAnchors}
+                decision={decision}
+                searchQuery=""
+              />
+            </>
+          )}
+        </main>
+      </ScrollArea>
+    </div>
+  );
+};
+
+const DecisionInspectorLoader = () => (
+  <div className="flex flex-col gap-4">
+    <Skeleton className="ms-auto h-3 w-24" />
+    <Skeleton className="mx-auto h-5 w-32" />
+    <Skeleton className="h-3 w-full" />
+    <Skeleton className="h-3 w-11/12" />
+    <Skeleton className="h-3 w-full" />
+  </div>
+);

--- a/apps/web/src/features/case-law/components/case-decision-inspector-view.tsx
+++ b/apps/web/src/features/case-law/components/case-decision-inspector-view.tsx
@@ -8,10 +8,10 @@ import { Button } from "@stll/ui/button";
 import { ScrollArea } from "@stll/ui/scroll-area";
 import { Skeleton } from "@stll/ui/skeleton";
 
+import type { CaseDecisionViewPayload } from "@/components/inspector/case-decision-view";
 import { InspectorTabHeader } from "@/components/inspector/inspector-tab-header";
 import type { InspectorViewRenderProps } from "@/components/inspector/view-registry";
 import Tooltip from "@/components/tooltip";
-import type { CaseDecisionViewPayload } from "@/features/case-law/case-decision-inspector.logic";
 import { CitationHeader } from "@/features/case-law/components/case-viewer/citation-header";
 import { DecisionCitations } from "@/features/case-law/components/case-viewer/decision-citations";
 import { DecisionText } from "@/features/case-law/components/case-viewer/decision-text";

--- a/apps/web/src/features/case-law/components/case-viewer/decision-citations.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-citations.tsx
@@ -8,6 +8,7 @@ import { BidiText } from "@stll/ui/bidi-text";
 import { Button } from "@stll/ui/button";
 import { cn } from "@stll/ui/utils";
 
+import { CitedDecisionLink } from "@/components/legal-reader/cited-decision-link";
 import {
   CITATION_TREATMENT_DOT,
   CITATION_TREATMENT_LABEL,
@@ -19,9 +20,6 @@ import type {
   CitationTreatmentCounts,
   DecisionCitation,
 } from "@/features/case-law/citation-treatment";
-import { citedDecisionLabel } from "@/features/case-law/cited-decision-label";
-import { CitedDecisionLink } from "@/features/case-law/components/cited-decision-link";
-import { formatDecisionDate } from "@/features/case-law/decision-date";
 import {
   decisionCitationsInfiniteOptions,
   decisionCitationSummaryOptions,
@@ -30,6 +28,8 @@ import type { CitationDirection } from "@/features/case-law/queries/citations";
 import { useFormatter } from "@/i18n/formatting-context";
 import type { TranslationKey } from "@/i18n/types";
 import { optionalArray } from "@/lib/arrays";
+import { citedDecisionLabel } from "@/lib/cited-decision-label";
+import { formatDecisionDate } from "@/lib/decision-date";
 import { detached } from "@/lib/detached";
 import type { SafeId } from "@/lib/safe-id";
 

--- a/apps/web/src/features/case-law/components/case-viewer/decision-text.logic.test.ts
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-text.logic.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import type { DocumentAst } from "@stll/legal-ast/document-ast";
+
+import { visibleDecisionBlocks } from "@/features/case-law/components/case-viewer/decision-text.logic";
+
+const ast = {
+  version: 1,
+  source: { system: "test", documentId: "1", webUrl: "", printUrl: "" },
+  metadata: {
+    caseNumber: "1 As 1/2026",
+    ecli: null,
+    court: "Nejvyšší správní soud",
+    decisionDate: null,
+    decisionType: "Rozsudek",
+    keywords: [],
+    statutes: [],
+  },
+  blocks: [
+    {
+      id: "case-number",
+      anchorId: "case-number",
+      type: "paragraph",
+      role: "case-number",
+      inlines: [{ type: "text", text: "1 As 1/2026" }],
+      plainText: "1 As 1/2026",
+    },
+    {
+      id: "title",
+      anchorId: "title",
+      type: "heading",
+      level: 1,
+      role: "decision-title",
+      inlines: [{ type: "text", text: "JMÉNEM REPUBLIKY" }],
+      plainText: "JMÉNEM REPUBLIKY",
+    },
+    {
+      id: "related",
+      anchorId: "related",
+      type: "table",
+      role: "related-proceedings",
+      rows: [],
+      plainText: "Related proceedings",
+    },
+    {
+      id: "body",
+      anchorId: "body",
+      type: "paragraph",
+      inlines: [{ type: "text", text: "Body" }],
+      plainText: "Body",
+    },
+  ],
+} as const satisfies DocumentAst;
+
+describe("visible decision blocks", () => {
+  test("keeps semantic headings while removing separately rendered metadata", () => {
+    expect(visibleDecisionBlocks(ast).map((block) => block.id)).toEqual([
+      "title",
+      "body",
+    ]);
+  });
+});

--- a/apps/web/src/features/case-law/components/case-viewer/decision-text.logic.ts
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-text.logic.ts
@@ -1,0 +1,18 @@
+import type { Block, DocumentAst } from "@stll/legal-ast/document-ast";
+
+/**
+ * Remove structural metadata that the reader renders elsewhere. Content is
+ * never hidden by matching its words: a court's title and constitutional
+ * formula are part of the decision and remain visible as AST headings.
+ */
+export const visibleDecisionBlocks = (ast: DocumentAst | null): Block[] => {
+  if (ast === null) {
+    return [];
+  }
+
+  return ast.blocks.filter(
+    (block) =>
+      !(block.type === "paragraph" && block.role === "case-number") &&
+      !(block.type === "table" && block.role === "related-proceedings"),
+  );
+};

--- a/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 
 import { useTranslations } from "use-intl";
 
-import type { Block, DocumentAst } from "@stll/legal-ast/document-ast";
+import type { Block } from "@stll/legal-ast/document-ast";
 import { parseDocumentAst } from "@stll/legal-ast/document-ast";
 import { cn } from "@stll/ui/utils";
 
@@ -23,6 +23,7 @@ import type {
 import { buildSearchResults } from "@/components/legal-reader/reader-search";
 import { locateCitationAnchors } from "@/features/case-law/citation-anchors";
 import type { CitationAnchorSource } from "@/features/case-law/citation-anchors";
+import { visibleDecisionBlocks } from "@/features/case-law/components/case-viewer/decision-text.logic";
 import { CitedDecisionLink } from "@/features/case-law/components/cited-decision-link";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 
@@ -70,22 +71,6 @@ const cleanSupplement = (value: unknown): string | null => {
     return null;
   }
   return trimmed;
-};
-
-const getVisibleBlocks = (ast: DocumentAst | null): Block[] => {
-  if (!ast) {
-    return [];
-  }
-
-  return ast.blocks.filter(
-    (block) =>
-      !(block.type === "paragraph" && block.role === "case-number") &&
-      !(
-        block.type === "heading" &&
-        block.plainText.toUpperCase() === "JMÉNEM REPUBLIKY"
-      ) &&
-      !(block.type === "table" && block.role === "related-proceedings"),
-  );
 };
 
 const EditorialSupplement = ({
@@ -267,7 +252,7 @@ export const DecisionText = ({
   const t = useTranslations();
 
   const ast = parseDocumentAst(decision.documentAst);
-  const visibleBlocks = getVisibleBlocks(ast);
+  const visibleBlocks = visibleDecisionBlocks(ast);
   const articleRef = useRef<HTMLElement>(null);
 
   const caseNumberBlock = ast?.blocks.find(

--- a/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
@@ -7,6 +7,7 @@ import type { Block } from "@stll/legal-ast/document-ast";
 import { parseDocumentAst } from "@stll/legal-ast/document-ast";
 import { cn } from "@stll/ui/utils";
 
+import { CitedDecisionLink } from "@/components/legal-reader/cited-decision-link";
 import {
   BlockRenderer,
   FulltextFallback,
@@ -24,7 +25,6 @@ import { buildSearchResults } from "@/components/legal-reader/reader-search";
 import { locateCitationAnchors } from "@/features/case-law/citation-anchors";
 import type { CitationAnchorSource } from "@/features/case-law/citation-anchors";
 import { visibleDecisionBlocks } from "@/features/case-law/components/case-viewer/decision-text.logic";
-import { CitedDecisionLink } from "@/features/case-law/components/cited-decision-link";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 
 type Decision = {

--- a/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useRef, useState } from "react";
 
-import { useInfiniteQuery } from "@tanstack/react-query";
 import { Loader2Icon, SparklesIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/react/shallow";
@@ -11,7 +10,6 @@ import { Button } from "@stll/ui/button";
 import { OutlineRail } from "@stll/ui/outline-rail";
 import type { OutlineItem } from "@stll/ui/outline-rail";
 
-import type { CitationAnchorSource } from "@/features/case-law/citation-anchors";
 import { MarginNotes } from "@/features/case-law/components/case-viewer/analysis/margin-notes";
 import {
   buildSectionMap,
@@ -23,9 +21,8 @@ import { CitationHeader } from "@/features/case-law/components/case-viewer/citat
 import { DecisionCitations } from "@/features/case-law/components/case-viewer/decision-citations";
 import { DecisionText } from "@/features/case-law/components/case-viewer/decision-text";
 import { ProvisionsCited } from "@/features/case-law/components/case-viewer/provisions-cited";
-import { decisionCitationsInfiniteOptions } from "@/features/case-law/queries/citations";
+import { useDecisionCitationAnchors } from "@/features/case-law/components/case-viewer/use-decision-citation-anchors";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
-import { optionalArray } from "@/lib/arrays";
 import { useCaseSearchStore } from "@/lib/case-search-store";
 import { detached } from "@/lib/detached";
 import type { SafeId } from "@/lib/safe-id";
@@ -100,21 +97,7 @@ export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
 
   // The text links every cited decision the first outgoing page resolves;
   // the panel below pages further, the links stop at what is already read.
-  const { data: outgoingCitations } = useInfiniteQuery(
-    decisionCitationsInfiniteOptions(decisionId, "outgoing"),
-  );
-  const citationAnchors: CitationAnchorSource[] = [];
-  for (const page of optionalArray(outgoingCitations?.pages)) {
-    for (const item of page.items) {
-      if (item.decision !== null) {
-        citationAnchors.push({
-          citationText: item.citationText,
-          decision: item.decision,
-          id: item.id,
-        });
-      }
-    }
-  }
+  const citationAnchors = useDecisionCitationAnchors(decisionId);
 
   const { state: analysisState, generate: generateDecisionAnalysis } =
     useDecisionAnalysis(decisionId, decision.analysis ?? null);

--- a/apps/web/src/features/case-law/components/case-viewer/use-decision-citation-anchors.ts
+++ b/apps/web/src/features/case-law/components/case-viewer/use-decision-citation-anchors.ts
@@ -1,0 +1,30 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import type { CitationAnchorSource } from "@/features/case-law/citation-anchors";
+import { decisionCitationsInfiniteOptions } from "@/features/case-law/queries/citations";
+import { optionalArray } from "@/lib/arrays";
+import type { SafeId } from "@/lib/safe-id";
+
+/** Resolved outgoing citations already loaded for inline linking in a decision. */
+export const useDecisionCitationAnchors = (
+  decisionId: SafeId<"caseLawDecision">,
+): CitationAnchorSource[] => {
+  const { data } = useInfiniteQuery(
+    decisionCitationsInfiniteOptions(decisionId, "outgoing"),
+  );
+  const anchors: CitationAnchorSource[] = [];
+
+  for (const page of optionalArray(data?.pages)) {
+    for (const item of page.items) {
+      if (item.decision !== null) {
+        anchors.push({
+          citationText: item.citationText,
+          decision: item.decision,
+          id: item.id,
+        });
+      }
+    }
+  }
+
+  return anchors;
+};

--- a/apps/web/src/features/case-law/components/cited-decision-link.tsx
+++ b/apps/web/src/features/case-law/components/cited-decision-link.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 
 import { Link } from "@tanstack/react-router";
 
@@ -10,7 +10,11 @@ import {
 } from "@stll/ui/preview-card";
 import { cn } from "@stll/ui/utils";
 
-import type { CitedDecision } from "@/features/case-law/citation-treatment";
+import { useInspectorView } from "@/components/inspector/use-inspector-view";
+import {
+  createCaseDecisionViewTab,
+  opensCitationInInspector,
+} from "@/features/case-law/case-decision-inspector.logic";
 import { citedDecisionLabel } from "@/features/case-law/cited-decision-label";
 import { formatDecisionDate } from "@/features/case-law/decision-date";
 import { useFormatter } from "@/i18n/formatting-context";
@@ -19,7 +23,18 @@ import { createCaseLawDecisionRouteParams } from "@/lib/case-law-route";
 type CitedDecisionLinkProps = {
   children: ReactNode;
   className?: string | undefined;
-  decision: CitedDecision;
+  decision: {
+    caseNumber: string;
+    country: string;
+    court: string;
+    decisionDate: string | null;
+    decisionType?: string | null | undefined;
+    id: string;
+    language?: string | null | undefined;
+    languageAlternateCount?: number | null | undefined;
+    languageAlternates?: readonly unknown[] | null | undefined;
+    slug?: string | null | undefined;
+  };
 };
 
 /**
@@ -33,35 +48,70 @@ export const CitedDecisionLink = ({
   decision,
 }: CitedDecisionLinkProps) => {
   const format = useFormatter();
+  const inspector = useInspectorView();
   const params = createCaseLawDecisionRouteParams({
     caseNumber: decision.caseNumber,
     country: decision.country,
     court: decision.court,
     decisionId: decision.id,
+    language: decision.language,
+    languageAlternateCount: decision.languageAlternateCount,
+    languageAlternates: decision.languageAlternates,
     slug: decision.slug,
   });
   const decided = formatDecisionDate(decision.decisionDate, format);
+  const onCitationClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (!opensCitationInInspector(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    inspector.open(
+      createCaseDecisionViewTab({
+        caseNumber: decision.caseNumber,
+        country: decision.country,
+        court: decision.court,
+        decisionId: decision.id,
+        language: decision.language,
+        languageAlternateCount: decision.languageAlternateCount,
+        languageAlternates: decision.languageAlternates,
+        slug: decision.slug,
+      }),
+    );
+  };
+  const linkClassName = cn(
+    "text-primary decoration-primary/40 underline underline-offset-2 hover:decoration-current",
+    className,
+  );
+  const link =
+    params.language === undefined ? (
+      <Link
+        className={linkClassName}
+        onClick={onCitationClick}
+        params={{
+          country: params.country,
+          court: params.court,
+          slug: params.slug,
+        }}
+        to="/law/$country/cases/$court/$slug"
+      />
+    ) : (
+      <Link
+        className={linkClassName}
+        onClick={onCitationClick}
+        params={{
+          country: params.country,
+          court: params.court,
+          language: params.language,
+          slug: params.slug,
+        }}
+        to="/law/$country/cases/$court/$language/$slug"
+      />
+    );
 
   return (
     <PreviewCard>
-      <PreviewCardTrigger
-        render={
-          <Link
-            className={cn(
-              "text-primary decoration-primary/40 underline underline-offset-2 hover:decoration-current",
-              className,
-            )}
-            params={{
-              country: params.country,
-              court: params.court,
-              slug: params.slug,
-            }}
-            to="/law/$country/cases/$court/$slug"
-          />
-        }
-      >
-        {children}
-      </PreviewCardTrigger>
+      <PreviewCardTrigger render={link}>{children}</PreviewCardTrigger>
       <PreviewCardPopup className="w-auto max-w-72 flex-col gap-0.5 p-3 font-sans">
         <BidiText as="span" className="text-foreground text-sm font-medium">
           {citedDecisionLabel(decision)}

--- a/apps/web/src/features/statutes/components/provision-citing-decisions.tsx
+++ b/apps/web/src/features/statutes/components/provision-citing-decisions.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
 import { BidiText } from "@stll/ui/bidi-text";
@@ -9,12 +8,12 @@ import { Button } from "@stll/ui/button";
 import { Input } from "@stll/ui/input";
 import { Skeleton } from "@stll/ui/skeleton";
 
+import { CitedDecisionLink } from "@/features/case-law/components/cited-decision-link";
 import { filterCitingDecisions } from "@/features/statutes/provision-inspector.logic";
 import { citingDecisionsInfiniteOptions } from "@/features/statutes/queries/citing-decisions";
 import { formatValidityDate } from "@/features/statutes/statute-format";
 import { useFormatter } from "@/i18n/formatting-context";
 import { optionalArray } from "@/lib/arrays";
-import { createCaseLawDecisionRouteParams } from "@/lib/case-law-route";
 import { detached } from "@/lib/detached";
 
 type ProvisionCitingDecisionsProps = {
@@ -106,25 +105,20 @@ export const ProvisionCitingDecisions = ({
       )}
       <ul className="m-0 flex list-none flex-col p-0">
         {visible.map((decision) => {
-          const params = createCaseLawDecisionRouteParams({
-            caseNumber: decision.caseNumber,
-            country: decision.country,
-            court: decision.court,
-            decisionId: decision.decisionId,
-            slug: decision.slug,
-          });
           const decided = formatValidityDate(decision.decisionDate, format);
 
           return (
             <li key={`${decision.decisionId}-${decision.spanStart}`}>
-              <Link
+              <CitedDecisionLink
                 className="hover:bg-accent -mx-2 flex flex-col gap-0.5 rounded-md px-2 py-1.5 no-underline"
-                params={{
-                  country: params.country,
-                  court: params.court,
-                  slug: params.slug,
+                decision={{
+                  caseNumber: decision.caseNumber,
+                  country: decision.country,
+                  court: decision.court,
+                  decisionDate: decision.decisionDate,
+                  id: decision.decisionId,
+                  slug: decision.slug,
                 }}
-                to="/law/$country/cases/$court/$slug"
               >
                 <BidiText
                   as="span"
@@ -140,7 +134,7 @@ export const ProvisionCitingDecisions = ({
                 <span className="text-foreground-strong-muted line-clamp-3 text-[0.72rem] leading-snug">
                   {decision.sentenceText}
                 </span>
-              </Link>
+              </CitedDecisionLink>
             </li>
           );
         })}

--- a/apps/web/src/features/statutes/components/provision-citing-decisions.tsx
+++ b/apps/web/src/features/statutes/components/provision-citing-decisions.tsx
@@ -8,7 +8,7 @@ import { Button } from "@stll/ui/button";
 import { Input } from "@stll/ui/input";
 import { Skeleton } from "@stll/ui/skeleton";
 
-import { CitedDecisionLink } from "@/features/case-law/components/cited-decision-link";
+import { CitedDecisionLink } from "@/components/legal-reader/cited-decision-link";
 import { filterCitingDecisions } from "@/features/statutes/provision-inspector.logic";
 import { citingDecisionsInfiniteOptions } from "@/features/statutes/queries/citing-decisions";
 import { formatValidityDate } from "@/features/statutes/statute-format";

--- a/apps/web/src/lib/cited-decision-label.ts
+++ b/apps/web/src/lib/cited-decision-label.ts
@@ -1,4 +1,4 @@
-type LabelSource = {
+type CitedDecisionLabelSource = {
   caseNumber: string;
   decisionDate: string | null;
   decisionType?: string | null | undefined;
@@ -18,7 +18,7 @@ export const citedDecisionLabel = ({
   caseNumber,
   decisionDate,
   decisionType,
-}: LabelSource): string => {
+}: CitedDecisionLabelSource): string => {
   const type = decisionType?.trim();
   if (!type) {
     return caseNumber;

--- a/apps/web/src/lib/decision-date.ts
+++ b/apps/web/src/lib/decision-date.ts
@@ -4,7 +4,7 @@ import { parseDeterministicDate } from "@/lib/deterministic-date";
 
 type IntlFormatter = ReturnType<typeof createFormatter>;
 
-/** A decision date as a medium date in UTC, or null when none is stored. */
+/** A legal decision date as a medium date in UTC, or null when none is stored. */
 export const formatDecisionDate = (
   value: Date | string | null,
   format: IntlFormatter,

--- a/apps/web/src/routes/law/$country/statutes/$documentId.tsx
+++ b/apps/web/src/routes/law/$country/statutes/$documentId.tsx
@@ -20,7 +20,6 @@ import {
   STATUTE_OUTLINE_COLLAPSE_LEVEL,
   withProvisionRanges,
 } from "@/components/legal-reader/reader-outline";
-import "@/features/statutes/provision-inspector-registration";
 import { StatuteStatusPill } from "@/features/statutes/components/statute-status-pill";
 import { StatuteText } from "@/features/statutes/components/statute-text";
 import { StatuteVersionSwitcher } from "@/features/statutes/components/statute-version-switcher";

--- a/apps/web/src/routes/law/-case-detail.tsx
+++ b/apps/web/src/routes/law/-case-detail.tsx
@@ -67,7 +67,13 @@ export function PublicDecisionViewer({
         <Tooltip
           content={t("chat.moveToSide")}
           render={
-            <Button onClick={moveToSide} size="icon-sm" variant="ghost">
+            <Button
+              aria-label={t("chat.moveToSide")}
+              className="hidden md:inline-flex"
+              onClick={moveToSide}
+              size="icon-sm"
+              variant="ghost"
+            >
               <Minimize2Icon className="size-4" />
             </Button>
           }

--- a/apps/web/src/routes/law/-case-detail.tsx
+++ b/apps/web/src/routes/law/-case-detail.tsx
@@ -1,7 +1,18 @@
 import { lazy, Suspense } from "react";
 
+import { useNavigate } from "@tanstack/react-router";
+import { Minimize2Icon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/button";
+
+import { useInspectorView } from "@/components/inspector/use-inspector-view";
+import Tooltip from "@/components/tooltip";
+import { createCaseDecisionViewTab } from "@/features/case-law/case-decision-inspector.logic";
 import { DecisionWorkspace } from "@/features/case-law/components/case-viewer/decision-workspace";
 import { useClientAuthStatus } from "@/hooks/use-client-auth-status";
+import { ChromeHeaderActions } from "@/lib/chrome-header-actions";
+import { detached } from "@/lib/detached";
 import {
   extractId,
   type PublicCaseLawDecision,
@@ -25,9 +36,43 @@ export function PublicDecisionViewer({
 }: PublicDecisionViewerProps) {
   const decisionId = extractId(decision.id);
   const authStatus = useClientAuthStatus();
+  const inspector = useInspectorView();
+  const navigate = useNavigate();
+  const t = useTranslations();
+
+  const moveToSide = () => {
+    inspector.open(
+      createCaseDecisionViewTab({
+        caseNumber: decision.caseNumber,
+        country: decision.country,
+        court: decision.court,
+        decisionId: decision.id,
+        language: decision.language,
+        languageAlternates: decision.languageAlternates,
+        slug: decision.slug,
+      }),
+    );
+    detached(
+      navigate({
+        to: "/law/cases",
+        search: { country: decision.country.toLowerCase() },
+      }),
+      "case-law.move-to-side",
+    );
+  };
 
   return (
     <main className="flex min-h-0 flex-1 overflow-hidden">
+      <ChromeHeaderActions>
+        <Tooltip
+          content={t("chat.moveToSide")}
+          render={
+            <Button onClick={moveToSide} size="icon-sm" variant="ghost">
+              <Minimize2Icon className="size-4" />
+            </Button>
+          }
+        />
+      </ChromeHeaderActions>
       {authStatus.isAuthenticated ? (
         <Suspense
           fallback={

--- a/apps/web/src/routes/law/-case-detail.tsx
+++ b/apps/web/src/routes/law/-case-detail.tsx
@@ -6,9 +6,9 @@ import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/button";
 
+import { createCaseDecisionViewTab } from "@/components/inspector/case-decision-view";
 import { useInspectorView } from "@/components/inspector/use-inspector-view";
 import Tooltip from "@/components/tooltip";
-import { createCaseDecisionViewTab } from "@/features/case-law/case-decision-inspector.logic";
 import { DecisionWorkspace } from "@/features/case-law/components/case-viewer/decision-workspace";
 import { useClientAuthStatus } from "@/hooks/use-client-auth-status";
 import { ChromeHeaderActions } from "@/lib/chrome-header-actions";

--- a/apps/web/src/routes/law/-components/public-law-inspector.tsx
+++ b/apps/web/src/routes/law/-components/public-law-inspector.tsx
@@ -4,6 +4,7 @@ import { useRouterState } from "@tanstack/react-router";
 import { PanelRightIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { InspectorRailTab } from "@stll/ui/inspector";
 import { cn } from "@stll/ui/utils";
 
 import {
@@ -68,7 +69,7 @@ export const PublicLawInspector = () => {
 
   const viewTabs = tabs.filter(isGenericInspectorTab);
 
-  if (viewTabs.length === 0 || caseReaderOwnsDock) {
+  if (viewTabs.length === 0) {
     // `requestSignIn` is provided by the public shell this dock renders in;
     // without it the rail's affordances would lead nowhere.
     return requestSignIn === null ? null : (
@@ -173,16 +174,10 @@ const RailTabButton = ({ active, onActivate, tab }: RailTabButtonProps) => {
     <Tooltip
       content={tab.label}
       render={
-        <button
-          aria-current={active ? "true" : undefined}
+        <InspectorRailTab
+          active={active}
           aria-label={tab.label}
-          className={cn(
-            "text-muted-foreground hover:bg-accent hover:text-foreground flex items-center justify-center rounded-md transition-colors",
-            SIDE_RAIL_ICON_BUTTON_SIZE,
-            active && "bg-accent text-foreground",
-          )}
           onClick={onActivate}
-          type="button"
         />
       }
     >

--- a/apps/web/src/routes/law/-components/public-law-shell.tsx
+++ b/apps/web/src/routes/law/-components/public-law-shell.tsx
@@ -5,6 +5,7 @@ import { Separator } from "@stll/ui/separator";
 
 import { PublicWorkspaceShell } from "@/components/public-workspace-shell";
 import { SidebarTrigger, useSidebar } from "@/components/sidebar";
+import { ChromeHeaderActionsSlot } from "@/lib/chrome-header-actions";
 import { toStatuteCountrySegment } from "@/lib/statute-route";
 import { PublicLawInspector } from "@/routes/law/-components/public-law-inspector";
 
@@ -59,7 +60,7 @@ function PublicLawTopBar() {
       )}
       <nav
         aria-label={t("common.legalDatabase")}
-        className="flex min-w-0 items-center gap-1.5 text-sm"
+        className="flex min-w-0 flex-1 items-center gap-1.5 text-sm"
       >
         <Link
           activeProps={{ className: "text-foreground font-medium" }}
@@ -86,6 +87,7 @@ function PublicLawTopBar() {
           </>
         )}
       </nav>
+      <ChromeHeaderActionsSlot />
     </header>
   );
 }

--- a/apps/web/src/routes/law/route.tsx
+++ b/apps/web/src/routes/law/route.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
 
+import "@/features/case-law/case-decision-inspector-registration";
+import "@/features/statutes/provision-inspector-registration";
 import { isPublicLawRouteEnabled } from "@/lib/public-law-launch";
 import { PublicLawShell } from "@/routes/law/-components/public-law-shell";
 

--- a/packages/ui/src/inspector/chrome.test.tsx
+++ b/packages/ui/src/inspector/chrome.test.tsx
@@ -59,7 +59,6 @@ describe("row rhythm", () => {
     ["inspector-empty-row", <InspectorEmptyRow key="e" />],
     ["inspector-header", <InspectorHeader key="h" />],
     ["inspector-rail-cell", <InspectorRailCell key="c" />],
-    ["inspector-rail-tab", <InspectorRailTab key="t" />],
   ])("%s is exactly one row tall", (slot, element) => {
     const classes = classesOf(renderToStaticMarkup(element), slot);
     expect(classes).toContain(TOOLBAR_ROW_HEIGHT);
@@ -88,6 +87,21 @@ describe("row rhythm", () => {
 });
 
 describe("rail", () => {
+  test("uses one square filled chip for the active tab", () => {
+    const classes = classesOf(
+      renderToStaticMarkup(<InspectorRailTab active />),
+      "inspector-rail-tab",
+    );
+
+    expect(classes).toEqual(
+      expect.arrayContaining(["size-8", "rounded-md", "bg-accent"]),
+    );
+    expect(classes).not.toContain("w-full");
+    expect(classes.some((className) => className.startsWith("before:"))).toBe(
+      false,
+    );
+  });
+
   test("occupies exactly the reserved 48px and is desktop-only", () => {
     const classes = classesOf(
       renderToStaticMarkup(<InspectorRail />),

--- a/packages/ui/src/inspector/chrome.test.tsx
+++ b/packages/ui/src/inspector/chrome.test.tsx
@@ -94,12 +94,14 @@ describe("rail", () => {
     );
 
     expect(classes).toEqual(
-      expect.arrayContaining(["size-8", "rounded-md", "bg-accent"]),
+      expect.arrayContaining([
+        "size-12",
+        "rounded-md",
+        "before:inset-2",
+        "before:bg-accent",
+      ]),
     );
     expect(classes).not.toContain("w-full");
-    expect(classes.some((className) => className.startsWith("before:"))).toBe(
-      false,
-    );
   });
 
   test("occupies exactly the reserved 48px and is desktop-only", () => {

--- a/packages/ui/src/inspector/chrome.tsx
+++ b/packages/ui/src/inspector/chrome.tsx
@@ -91,11 +91,7 @@ export const InspectorRailIconButton = ({
   />
 );
 
-/**
- * A rail tab. The active tab carries a 2px spine on the rail's inline-start
- * edge — the same affordance the workspace rail uses to say "this pane is
- * showing that tab".
- */
+/** A square rail chip. Active state uses the same filled box in every dock. */
 export const InspectorRailTab = ({
   active = false,
   className,
@@ -104,10 +100,10 @@ export const InspectorRailTab = ({
   <button
     aria-current={active ? "true" : undefined}
     className={cn(
-      "group/tab relative flex min-h-8 w-full items-center justify-center border-b transition-colors",
-      TOOLBAR_ROW_HEIGHT,
+      "group/tab relative flex items-center justify-center rounded-md transition-colors",
+      SIDE_RAIL_ICON_BUTTON_SIZE,
       active
-        ? "bg-background text-foreground before:bg-primary before:absolute before:inset-y-0 before:inset-s-0 before:w-0.5"
+        ? "bg-accent text-foreground"
         : "text-muted-foreground hover:bg-accent hover:text-foreground",
       className,
     )}

--- a/packages/ui/src/inspector/chrome.tsx
+++ b/packages/ui/src/inspector/chrome.tsx
@@ -5,6 +5,7 @@ import {
   PROPERTY_ROW_GRID,
   SIDE_RAIL_CONTAINER_CLASS,
   SIDE_RAIL_ICON_BUTTON_SIZE,
+  SIDE_RAIL_TAB_HIT_TARGET_SIZE,
   TOOLBAR_ROW_HEIGHT,
 } from "./layout-tokens";
 
@@ -100,11 +101,11 @@ export const InspectorRailTab = ({
   <button
     aria-current={active ? "true" : undefined}
     className={cn(
-      "group/tab relative flex items-center justify-center rounded-md transition-colors",
-      SIDE_RAIL_ICON_BUTTON_SIZE,
+      "group/tab relative flex items-center justify-center rounded-md transition-colors before:pointer-events-none before:absolute before:inset-2 before:rounded-md before:transition-colors before:content-[''] [&>*]:relative [&>*]:z-10",
+      SIDE_RAIL_TAB_HIT_TARGET_SIZE,
       active
-        ? "bg-accent text-foreground"
-        : "text-muted-foreground hover:bg-accent hover:text-foreground",
+        ? "text-foreground before:bg-accent"
+        : "text-muted-foreground hover:text-foreground hover:before:bg-accent",
       className,
     )}
     data-active={active ? "" : undefined}

--- a/packages/ui/src/inspector/layout-tokens.ts
+++ b/packages/ui/src/inspector/layout-tokens.ts
@@ -23,6 +23,7 @@ export const SIDE_RAIL_WIDTH = "w-12" as const;
 export const SIDE_RAIL_CONTAINER_CLASS =
   `bg-sidebar flex shrink-0 flex-col border-s border-e ${SIDE_RAIL_WIDTH}` as const;
 export const SIDE_RAIL_ICON_BUTTON_SIZE = "size-8" as const;
+export const SIDE_RAIL_TAB_HIT_TARGET_SIZE = "size-12" as const;
 export const SIDE_RAIL_TAB_ICON_SIZE = "size-3.5" as const;
 
 /** Two-column grid the key/value rows share. */


### PR DESCRIPTION
Cited decisions now open as persistent inspector tabs while native modified-click navigation remains available. Decisions can move between the main reader and side inspector, and case-law and statute citation surfaces share the behavior.

The change also canonicalizes publisher-spaced Czech decision titles into centered semantic headings, keeps constitutional formulas visible, and unifies inspector rail tabs on the shared square chip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an inspector view for case-law decisions, including metadata, citations, provisions, decision text, loading states, errors and retry support.
  - Case citations can now open in inspector tabs while preserving standard browser click behaviour.
  - Added an option to move a decision from the public viewer into the inspector.
  - Improved inspector rail tab layout and active-state styling.

- **Bug Fixes**
  - Improved recognition and formatting of decision titles, including varied spacing and Unicode forms.
  - Cleaned decision text to hide case-number and related-proceedings metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->