### PR TITLE
feat(api): track corpus delete settlement

### DIFF
--- a/apps/api/drizzle/20260825100000_corpus_delete_watermarks/migration.sql
+++ b/apps/api/drizzle/20260825100000_corpus_delete_watermarks/migration.sql
@@ -25,6 +25,29 @@ GRANT SELECT ON TABLE "case_law_corpus_index_delete_watermarks" TO stella;--> st
 GRANT SELECT, INSERT, UPDATE
   ON TABLE "case_law_corpus_index_delete_watermarks" TO stella_ingestion;--> statement-breakpoint
 
+CREATE TABLE "case_law_corpus_index_pending_deletes" (
+  "index_id" varchar(64) NOT NULL,
+  "decision_id" uuid NOT NULL,
+  "opstamp" bigint NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "case_law_corpus_index_pending_deletes_pkey"
+    PRIMARY KEY ("index_id", "decision_id"),
+  CONSTRAINT "case_law_corpus_index_pending_deletes_nonnegative"
+    CHECK ("opstamp" >= 0)
+);--> statement-breakpoint
+
+CREATE INDEX "case_law_corpus_index_pending_deletes_settlement_idx"
+  ON "case_law_corpus_index_pending_deletes" ("index_id", "opstamp");--> statement-breakpoint
+ALTER TABLE "case_law_corpus_index_pending_deletes" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "case_law_ingestion_access"
+  ON "case_law_corpus_index_pending_deletes"
+  AS PERMISSIVE FOR ALL TO stella_ingestion
+  USING (true) WITH CHECK (true);--> statement-breakpoint
+REVOKE ALL PRIVILEGES
+  ON TABLE "case_law_corpus_index_pending_deletes" FROM stella;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON TABLE "case_law_corpus_index_pending_deletes" TO stella_ingestion;--> statement-breakpoint
+
 CREATE TABLE "legislation_corpus_index_delete_watermarks" (
   "index_id" varchar(64) PRIMARY KEY,
   "opstamp" bigint NOT NULL,

--- a/apps/api/drizzle/20260825100000_corpus_delete_watermarks/migration.sql
+++ b/apps/api/drizzle/20260825100000_corpus_delete_watermarks/migration.sql
@@ -1,0 +1,47 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Quickwit deletions are asynchronous. These constant-size high-water marks
+-- retain the task identity returned by the engine, so settlement checks never
+-- need to scan its append-only delete-task history.
+CREATE TABLE "case_law_corpus_index_delete_watermarks" (
+  "index_id" varchar(64) PRIMARY KEY,
+  "opstamp" bigint NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "case_law_corpus_index_delete_watermarks_nonnegative"
+    CHECK ("opstamp" >= 0)
+);--> statement-breakpoint
+
+ALTER TABLE "case_law_corpus_index_delete_watermarks" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "case_law_ingestion_access"
+  ON "case_law_corpus_index_delete_watermarks"
+  AS PERMISSIVE FOR ALL TO stella_ingestion
+  USING (true) WITH CHECK (true);--> statement-breakpoint
+CREATE POLICY "case_law_global_access"
+  ON "case_law_corpus_index_delete_watermarks"
+  AS PERMISSIVE FOR SELECT TO stella
+  USING (true);--> statement-breakpoint
+GRANT SELECT ON TABLE "case_law_corpus_index_delete_watermarks" TO stella;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE
+  ON TABLE "case_law_corpus_index_delete_watermarks" TO stella_ingestion;--> statement-breakpoint
+
+CREATE TABLE "legislation_corpus_index_delete_watermarks" (
+  "index_id" varchar(64) PRIMARY KEY,
+  "opstamp" bigint NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "legislation_corpus_index_delete_watermarks_nonnegative"
+    CHECK ("opstamp" >= 0)
+);--> statement-breakpoint
+
+ALTER TABLE "legislation_corpus_index_delete_watermarks" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "case_law_ingestion_access"
+  ON "legislation_corpus_index_delete_watermarks"
+  AS PERMISSIVE FOR ALL TO stella_ingestion
+  USING (true) WITH CHECK (true);--> statement-breakpoint
+CREATE POLICY "case_law_global_access"
+  ON "legislation_corpus_index_delete_watermarks"
+  AS PERMISSIVE FOR SELECT TO stella
+  USING (true);--> statement-breakpoint
+GRANT SELECT ON TABLE "legislation_corpus_index_delete_watermarks" TO stella;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE
+  ON TABLE "legislation_corpus_index_delete_watermarks" TO stella_ingestion;

--- a/apps/api/drizzle/20260825100000_corpus_delete_watermarks/migration.sql
+++ b/apps/api/drizzle/20260825100000_corpus_delete_watermarks/migration.sql
@@ -51,6 +51,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE
 CREATE TABLE "legislation_corpus_index_delete_watermarks" (
   "index_id" varchar(64) PRIMARY KEY,
   "opstamp" bigint NOT NULL,
+  "last_checked_at" timestamptz,
   "updated_at" timestamptz DEFAULT now() NOT NULL,
   CONSTRAINT "legislation_corpus_index_delete_watermarks_nonnegative"
     CHECK ("opstamp" >= 0)
@@ -68,3 +69,28 @@ CREATE POLICY "case_law_global_access"
 GRANT SELECT ON TABLE "legislation_corpus_index_delete_watermarks" TO stella;--> statement-breakpoint
 GRANT SELECT, INSERT, UPDATE
   ON TABLE "legislation_corpus_index_delete_watermarks" TO stella_ingestion;
+CREATE INDEX "legislation_corpus_index_delete_watermarks_check_idx"
+  ON "legislation_corpus_index_delete_watermarks" ("last_checked_at");--> statement-breakpoint
+
+CREATE TABLE "legislation_corpus_index_pending_deletes" (
+  "index_id" varchar(64) NOT NULL,
+  "document_id" uuid NOT NULL,
+  "opstamp" bigint NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "legislation_corpus_index_pending_deletes_pkey"
+    PRIMARY KEY ("index_id", "document_id"),
+  CONSTRAINT "legislation_corpus_index_pending_deletes_nonnegative"
+    CHECK ("opstamp" >= 0)
+);--> statement-breakpoint
+
+CREATE INDEX "legislation_corpus_index_pending_deletes_settlement_idx"
+  ON "legislation_corpus_index_pending_deletes" ("index_id", "opstamp");--> statement-breakpoint
+ALTER TABLE "legislation_corpus_index_pending_deletes" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "case_law_ingestion_access"
+  ON "legislation_corpus_index_pending_deletes"
+  AS PERMISSIVE FOR ALL TO stella_ingestion
+  USING (true) WITH CHECK (true);--> statement-breakpoint
+REVOKE ALL PRIVILEGES
+  ON TABLE "legislation_corpus_index_pending_deletes" FROM stella;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON TABLE "legislation_corpus_index_pending_deletes" TO stella_ingestion;

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -1580,7 +1580,10 @@ export const caseLawCorpusIndexPendingDeletes = p.pgTable(
     createdAt: timestamptz("created_at").defaultNow().notNull(),
   },
   (t) => [
-    p.primaryKey({ columns: [t.indexId, t.decisionId] }),
+    p.primaryKey({
+      name: "case_law_corpus_index_pending_deletes_pkey",
+      columns: [t.indexId, t.decisionId],
+    }),
     p
       .index("case_law_corpus_index_pending_deletes_settlement_idx")
       .on(t.indexId, t.opstamp),

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -1564,6 +1564,35 @@ export const caseLawCorpusIndexDeleteWatermarks = p.pgTable(
   ],
 );
 
+/**
+ * Documents whose accepted Quickwit delete task has not been observed on
+ * every published split. The composite key makes task replay idempotent;
+ * census removes a row only after the split watermark reaches its opstamp.
+ */
+export const caseLawCorpusIndexPendingDeletes = p.pgTable(
+  "case_law_corpus_index_pending_deletes",
+  {
+    indexId: p.varchar("index_id", { length: 64 }).notNull(),
+    // No foreign key: a source deletion must not erase settlement ownership
+    // before the engine has removed the decision from every published split.
+    decisionId: safeUuid<"caseLawDecision">("decision_id").notNull(),
+    opstamp: p.bigint({ mode: "number" }).notNull(),
+    createdAt: timestamptz("created_at").defaultNow().notNull(),
+  },
+  (t) => [
+    p.primaryKey({ columns: [t.indexId, t.decisionId] }),
+    p.index("case_law_corpus_index_pending_deletes_settlement_idx").on(
+      t.indexId,
+      t.opstamp,
+    ),
+    p.check(
+      "case_law_corpus_index_pending_deletes_nonnegative",
+      sql`${t.opstamp} >= 0`,
+    ),
+    ...caseLawIngestionOnlyPolicies(),
+  ],
+);
+
 export const CASE_LAW_CORPUS_INDEX_BACKFILL_STATUSES = [
   "running",
   "complete",

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -1543,6 +1543,27 @@ export const caseLawIndexJobs = p.pgTable(
   ],
 );
 
+/**
+ * Highest Quickwit delete task durably observed for each physical case-law
+ * index. One row replaces an unbounded scan of the engine's task history:
+ * settlement means every published split has reached this opstamp.
+ */
+export const caseLawCorpusIndexDeleteWatermarks = p.pgTable(
+  "case_law_corpus_index_delete_watermarks",
+  {
+    indexId: p.varchar("index_id", { length: 64 }).primaryKey(),
+    opstamp: p.bigint({ mode: "number" }).notNull(),
+    updatedAt: timestamptz("updated_at").defaultNow().notNull(),
+  },
+  (t) => [
+    p.check(
+      "case_law_corpus_index_delete_watermarks_nonnegative",
+      sql`${t.opstamp} >= 0`,
+    ),
+    ...globalCaseLawPolicies(),
+  ],
+);
+
 export const CASE_LAW_CORPUS_INDEX_BACKFILL_STATUSES = [
   "running",
   "complete",

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -1581,10 +1581,9 @@ export const caseLawCorpusIndexPendingDeletes = p.pgTable(
   },
   (t) => [
     p.primaryKey({ columns: [t.indexId, t.decisionId] }),
-    p.index("case_law_corpus_index_pending_deletes_settlement_idx").on(
-      t.indexId,
-      t.opstamp,
-    ),
+    p
+      .index("case_law_corpus_index_pending_deletes_settlement_idx")
+      .on(t.indexId, t.opstamp),
     p.check(
       "case_law_corpus_index_pending_deletes_nonnegative",
       sql`${t.opstamp} >= 0`,

--- a/apps/api/src/db/schema/legislation.ts
+++ b/apps/api/src/db/schema/legislation.ts
@@ -242,4 +242,21 @@ export const legislationIndexJobs = p.pgTable(
   ],
 );
 
+/** Highest engine delete task observed for each physical legislation index. */
+export const legislationCorpusIndexDeleteWatermarks = p.pgTable(
+  "legislation_corpus_index_delete_watermarks",
+  {
+    indexId: p.varchar("index_id", { length: 64 }).primaryKey(),
+    opstamp: p.bigint({ mode: "number" }).notNull(),
+    updatedAt: timestamptz("updated_at").defaultNow().notNull(),
+  },
+  (t) => [
+    p.check(
+      "legislation_corpus_index_delete_watermarks_nonnegative",
+      sql`${t.opstamp} >= 0`,
+    ),
+    ...globalCaseLawPolicies(),
+  ],
+);
+
 // -- Chat --

--- a/apps/api/src/db/schema/legislation.ts
+++ b/apps/api/src/db/schema/legislation.ts
@@ -3,6 +3,7 @@ import type { SQLWrapper } from "drizzle-orm";
 import { LEGISLATION_DOCUMENT_STATUSES } from "@stll/api-contract/legislation-status";
 
 import {
+  caseLawIngestionOnlyPolicies,
   globalCaseLawPolicies,
   isNotNull,
   isNull,
@@ -248,14 +249,49 @@ export const legislationCorpusIndexDeleteWatermarks = p.pgTable(
   {
     indexId: p.varchar("index_id", { length: 64 }).primaryKey(),
     opstamp: p.bigint({ mode: "number" }).notNull(),
+    lastCheckedAt: timestamptz("last_checked_at"),
     updatedAt: timestamptz("updated_at").defaultNow().notNull(),
   },
   (t) => [
+    p
+      .index("legislation_corpus_index_delete_watermarks_check_idx")
+      .on(t.lastCheckedAt),
     p.check(
       "legislation_corpus_index_delete_watermarks_nonnegative",
       sql`${t.opstamp} >= 0`,
     ),
     ...globalCaseLawPolicies(),
+  ],
+);
+
+/**
+ * Documents whose accepted Quickwit delete task remains unapplied on one or
+ * more published splits. The key makes task replay idempotent; the bounded
+ * reconciler removes a row only after every split reaches its opstamp.
+ */
+export const legislationCorpusIndexPendingDeletes = p.pgTable(
+  "legislation_corpus_index_pending_deletes",
+  {
+    indexId: p.varchar("index_id", { length: 64 }).notNull(),
+    // No foreign key: source deletion must not erase settlement ownership
+    // before the search engine has removed the legislation document.
+    documentId: safeUuid<"legislationDocument">("document_id").notNull(),
+    opstamp: p.bigint({ mode: "number" }).notNull(),
+    createdAt: timestamptz("created_at").defaultNow().notNull(),
+  },
+  (t) => [
+    p.primaryKey({
+      name: "legislation_corpus_index_pending_deletes_pkey",
+      columns: [t.indexId, t.documentId],
+    }),
+    p
+      .index("legislation_corpus_index_pending_deletes_settlement_idx")
+      .on(t.indexId, t.opstamp),
+    p.check(
+      "legislation_corpus_index_pending_deletes_nonnegative",
+      sql`${t.opstamp} >= 0`,
+    ),
+    ...caseLawIngestionOnlyPolicies(),
   ],
 );
 

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -6,6 +6,7 @@ import type { ScopedDb } from "@/api/db/safe-db";
 import {
   caseLawCorpusIndexBackfills,
   caseLawCorpusIndexDeleteWatermarks,
+  caseLawCorpusIndexPendingDeletes,
   caseLawCorpusIndexProjections,
   caseLawCorpusIndexSourceReconciliations,
   caseLawCorpusIndexWriterLeases,
@@ -899,6 +900,26 @@ export const caseLawCorpusIndexAdapter = {
           set: {
             opstamp: sql`GREATEST(${caseLawCorpusIndexDeleteWatermarks.opstamp}, excluded.opstamp)`,
             updatedAt: new Date(),
+          },
+        });
+      // audit: skip — bounded settlement state; append-only index jobs above
+      // remain the audit trail after settled rows are removed by census
+      await tx
+        .insert(caseLawCorpusIndexPendingDeletes)
+        .values(
+          jobs.map((job) => ({
+            indexId,
+            decisionId: job.entityId,
+            opstamp,
+          })),
+        )
+        .onConflictDoUpdate({
+          target: [
+            caseLawCorpusIndexPendingDeletes.indexId,
+            caseLawCorpusIndexPendingDeletes.decisionId,
+          ],
+          set: {
+            opstamp: sql`GREATEST(${caseLawCorpusIndexPendingDeletes.opstamp}, excluded.opstamp)`,
           },
         });
     });

--- a/apps/api/src/handlers/case-law/corpus-index.ts
+++ b/apps/api/src/handlers/case-law/corpus-index.ts
@@ -5,6 +5,7 @@ import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
   caseLawCorpusIndexBackfills,
+  caseLawCorpusIndexDeleteWatermarks,
   caseLawCorpusIndexProjections,
   caseLawCorpusIndexSourceReconciliations,
   caseLawCorpusIndexWriterLeases,
@@ -867,6 +868,39 @@ export const caseLawCorpusIndexAdapter = {
           errorMessage: job.errorMessage ?? null,
         })),
       );
+    });
+  },
+  recordDeleteJobs: async (scopedDb, { indexId, jobs, opstamp }) => {
+    if (jobs.length === 0) {
+      return;
+    }
+    await scopedDb(async (tx) => {
+      // audit: skip — append-only index-job rows ARE the indexing audit trail
+      await tx.insert(caseLawIndexJobs).values(
+        jobs.map((job) => ({
+          decisionId: job.entityId,
+          generation: indexId,
+          operation: job.operation,
+          status: job.status,
+          contentHash: job.contentHash,
+          errorMessage: job.errorMessage ?? null,
+        })),
+      );
+      if (opstamp === null) {
+        return;
+      }
+      // audit: skip — derived engine-settlement watermark; the job rows above
+      // are the document-level audit trail for the same remote effect
+      await tx
+        .insert(caseLawCorpusIndexDeleteWatermarks)
+        .values({ indexId, opstamp })
+        .onConflictDoUpdate({
+          target: caseLawCorpusIndexDeleteWatermarks.indexId,
+          set: {
+            opstamp: sql`GREATEST(${caseLawCorpusIndexDeleteWatermarks.opstamp}, excluded.opstamp)`,
+            updatedAt: new Date(),
+          },
+        });
     });
   },
 } satisfies CorpusIndexAdapter<"caseLawDecision", IndexableRow>;

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -11,6 +11,7 @@ import {
   sql,
 } from "drizzle-orm";
 
+import type { ScopedDb } from "@/api/db/safe-db";
 import {
   legislationCorpusIndexDeleteWatermarks,
   legislationCorpusIndexPendingDeletes,
@@ -18,7 +19,6 @@ import {
   legislationIndexJobs,
   legislationSources,
 } from "@/api/db/schema";
-import type { ScopedDb } from "@/api/db/safe-db";
 import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
 import type { SafeId } from "@/api/lib/branded-types";
 import { DELETE_SETTLEMENT_STALE_MS } from "@/api/lib/corpus-index/census";
@@ -31,11 +31,11 @@ import {
   timestampCasToken,
   type TimestampCasToken,
 } from "@/api/lib/db/timestamp-cas";
-import { readCorpusText } from "@/api/lib/legal-search/corpus-storage";
 import {
   CorpusIndexError,
   getCorpusIndexClient,
 } from "@/api/lib/legal-search/corpus-index-client";
+import { readCorpusText } from "@/api/lib/legal-search/corpus-storage";
 import { logger } from "@/api/lib/observability/logger";
 
 /**
@@ -444,10 +444,7 @@ export const reconcileNextLegislationCorpusIndexDelete = async (
             .delete(legislationCorpusIndexPendingDeletes)
             .where(
               and(
-                eq(
-                  legislationCorpusIndexPendingDeletes.indexId,
-                  next.indexId,
-                ),
+                eq(legislationCorpusIndexPendingDeletes.indexId, next.indexId),
                 lte(
                   legislationCorpusIndexPendingDeletes.opstamp,
                   appliedOpstamp,

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -1,6 +1,7 @@
 import { and, eq, isNotNull, isNull, sql } from "drizzle-orm";
 
 import {
+  legislationCorpusIndexDeleteWatermarks,
   legislationDocuments,
   legislationIndexJobs,
   legislationSources,
@@ -278,6 +279,39 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
           errorMessage: job.errorMessage ?? null,
         })),
       );
+    });
+  },
+  recordDeleteJobs: async (scopedDb, { indexId, jobs, opstamp }) => {
+    if (jobs.length === 0) {
+      return;
+    }
+    await scopedDb(async (tx) => {
+      // audit: skip — append-only index-job rows ARE the indexing audit trail
+      await tx.insert(legislationIndexJobs).values(
+        jobs.map((job) => ({
+          documentId: job.entityId,
+          generation: indexId,
+          operation: job.operation,
+          status: job.status,
+          contentHash: job.contentHash,
+          errorMessage: job.errorMessage ?? null,
+        })),
+      );
+      if (opstamp === null) {
+        return;
+      }
+      // audit: skip — derived engine-settlement watermark; the job rows above
+      // are the document-level audit trail for the same remote effect
+      await tx
+        .insert(legislationCorpusIndexDeleteWatermarks)
+        .values({ indexId, opstamp })
+        .onConflictDoUpdate({
+          target: legislationCorpusIndexDeleteWatermarks.indexId,
+          set: {
+            opstamp: sql`GREATEST(${legislationCorpusIndexDeleteWatermarks.opstamp}, excluded.opstamp)`,
+            updatedAt: new Date(),
+          },
+        });
     });
   },
 });

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -1,13 +1,27 @@
-import { and, eq, isNotNull, isNull, sql } from "drizzle-orm";
+import { Result } from "better-result";
+import {
+  and,
+  count,
+  eq,
+  exists,
+  isNotNull,
+  isNull,
+  lte,
+  min,
+  sql,
+} from "drizzle-orm";
 
 import {
   legislationCorpusIndexDeleteWatermarks,
+  legislationCorpusIndexPendingDeletes,
   legislationDocuments,
   legislationIndexJobs,
   legislationSources,
 } from "@/api/db/schema";
+import type { ScopedDb } from "@/api/db/safe-db";
 import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
 import type { SafeId } from "@/api/lib/branded-types";
+import { DELETE_SETTLEMENT_STALE_MS } from "@/api/lib/corpus-index/census";
 import type { CorpusDocumentPayload } from "@/api/lib/corpus-index/core";
 import {
   createCorpusIndexer,
@@ -18,6 +32,11 @@ import {
   type TimestampCasToken,
 } from "@/api/lib/db/timestamp-cas";
 import { readCorpusText } from "@/api/lib/legal-search/corpus-storage";
+import {
+  CorpusIndexError,
+  getCorpusIndexClient,
+} from "@/api/lib/legal-search/corpus-index-client";
+import { logger } from "@/api/lib/observability/logger";
 
 /**
  * corpus index projection for the `legislation` family. Domain adapter over the
@@ -308,14 +327,194 @@ const indexer = createCorpusIndexer<"legislationDocument", IndexableRow>({
         .onConflictDoUpdate({
           target: legislationCorpusIndexDeleteWatermarks.indexId,
           set: {
-            opstamp: sql`GREATEST(${legislationCorpusIndexDeleteWatermarks.opstamp}, excluded.opstamp)`,
+            opstamp: sql`GREATEST(
+              ${legislationCorpusIndexDeleteWatermarks.opstamp},
+              excluded.opstamp
+            )`,
             updatedAt: new Date(),
+          },
+        });
+      // audit: skip — bounded settlement state; append-only index jobs above
+      // remain the audit trail after settled rows are removed by reconciliation
+      await tx
+        .insert(legislationCorpusIndexPendingDeletes)
+        .values(
+          jobs.map((job) => ({
+            indexId,
+            documentId: job.entityId,
+            opstamp,
+          })),
+        )
+        .onConflictDoUpdate({
+          target: [
+            legislationCorpusIndexPendingDeletes.indexId,
+            legislationCorpusIndexPendingDeletes.documentId,
+          ],
+          set: {
+            opstamp: sql`GREATEST(
+              ${legislationCorpusIndexPendingDeletes.opstamp},
+              excluded.opstamp
+            )`,
           },
         });
     });
   },
 });
 
+export type LegislationDeleteSettlement = {
+  indexId: string;
+  pendingDocuments: number;
+  stale: boolean;
+  settled: boolean;
+};
+
+/**
+ * Reconcile one oldest legislation delete backlog. Delete tasks apply to
+ * Quickwit splits asynchronously, so an accepted task cannot clear its
+ * durable ownership until every published split reaches the task opstamp.
+ * One index per call bounds engine and database work; the daemon calls this
+ * every index cycle and drains every remaining backlog over time.
+ */
+// audit: skip — scheduler-owned, derived corpus-index settlement state; the
+// append-only index-job rows retain the document-level audit trail.
+export const reconcileNextLegislationCorpusIndexDelete = async (
+  scopedDb: ScopedDb,
+): Promise<Result<LegislationDeleteSettlement | null, CorpusIndexError>> =>
+  await Result.tryPromise({
+    try: async () => {
+      const next = (
+        await scopedDb((tx) =>
+          tx
+            .select({
+              indexId: legislationCorpusIndexDeleteWatermarks.indexId,
+              opstamp: legislationCorpusIndexDeleteWatermarks.opstamp,
+            })
+            .from(legislationCorpusIndexDeleteWatermarks)
+            .where(
+              exists(
+                tx
+                  .select({
+                    indexId: legislationCorpusIndexPendingDeletes.indexId,
+                  })
+                  .from(legislationCorpusIndexPendingDeletes)
+                  .where(
+                    eq(
+                      legislationCorpusIndexPendingDeletes.indexId,
+                      legislationCorpusIndexDeleteWatermarks.indexId,
+                    ),
+                  )
+                  .limit(1),
+              ),
+            )
+            .orderBy(
+              sql`${legislationCorpusIndexDeleteWatermarks.lastCheckedAt} NULLS FIRST`,
+            )
+            .limit(1),
+        )
+      ).at(0);
+      if (next === undefined) {
+        return null;
+      }
+      // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+      await scopedDb((tx) => {
+        // audit: skip — scheduler-owned, derived settlement scheduling state
+        return tx
+          .update(legislationCorpusIndexDeleteWatermarks)
+          .set({ lastCheckedAt: new Date() })
+          .where(
+            eq(legislationCorpusIndexDeleteWatermarks.indexId, next.indexId),
+          );
+      });
+
+      const settlement = await getCorpusIndexClient().readDeleteSettlement(
+        next.indexId,
+        next.opstamp,
+      );
+      if (settlement.isErr()) {
+        throw settlement.error;
+      }
+      const appliedOpstamp =
+        settlement.value.publishedSplits === 0
+          ? next.opstamp
+          : settlement.value.minAppliedOpstamp;
+      const pending = await scopedDb(async (tx) => {
+        if (appliedOpstamp !== null) {
+          // audit: skip — bounded derived settlement state
+          await tx
+            .delete(legislationCorpusIndexPendingDeletes)
+            .where(
+              and(
+                eq(
+                  legislationCorpusIndexPendingDeletes.indexId,
+                  next.indexId,
+                ),
+                lte(
+                  legislationCorpusIndexPendingDeletes.opstamp,
+                  appliedOpstamp,
+                ),
+              ),
+            );
+        }
+        return await tx
+          .select({
+            oldestPendingAt: min(
+              legislationCorpusIndexPendingDeletes.createdAt,
+            ),
+            pendingDocuments: count(),
+          })
+          .from(legislationCorpusIndexPendingDeletes)
+          .where(
+            eq(legislationCorpusIndexPendingDeletes.indexId, next.indexId),
+          );
+      });
+      const state = pending.at(0);
+      const oldestPendingAt = state?.oldestPendingAt ?? null;
+      const pendingDocuments = state?.pendingDocuments ?? 0;
+      return {
+        indexId: next.indexId,
+        pendingDocuments,
+        stale:
+          oldestPendingAt !== null &&
+          Date.now() - oldestPendingAt.getTime() >= DELETE_SETTLEMENT_STALE_MS,
+        settled: pendingDocuments === 0,
+      };
+    },
+    catch: (error) =>
+      error instanceof CorpusIndexError
+        ? error
+        : new CorpusIndexError({
+            message:
+              error instanceof Error
+                ? error.message
+                : "legislation delete settlement failed",
+            cause: error,
+          }),
+  });
+
 export const loadDocsForBatch = indexer.loadDocsForBatch;
-export const backfillLegislationCorpusIndex = indexer.backfill;
+export const backfillLegislationCorpusIndex = async (
+  scopedDb: ScopedDb,
+  batchSize: number,
+  generation: string,
+  options: { readConcurrency?: number } = {},
+): Promise<number> => {
+  const indexed = await indexer.backfill(
+    scopedDb,
+    batchSize,
+    generation,
+    options,
+  );
+  const settlement = await reconcileNextLegislationCorpusIndexDelete(scopedDb);
+  if (settlement.isErr()) {
+    logger.warn("legislation.corpus_index.delete_settlement_unavailable", {
+      "error.type": settlement.error._tag,
+    });
+  } else if (settlement.value?.stale) {
+    logger.warn("legislation.corpus_index.delete_settlement_stalled", {
+      indexId: settlement.value.indexId,
+      pendingDocuments: settlement.value.pendingDocuments,
+    });
+  }
+  return indexed;
+};
 export const removeLegislationFromCorpusIndex = indexer.remove;

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -415,10 +415,9 @@ export const reconcileNextLegislationCorpusIndexDelete = async (
       if (next === undefined) {
         return null;
       }
-      // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-      await scopedDb((tx) => {
+      await scopedDb(async (tx) => {
         // audit: skip — scheduler-owned, derived settlement scheduling state
-        return tx
+        await tx
           .update(legislationCorpusIndexDeleteWatermarks)
           .set({ lastCheckedAt: new Date() })
           .where(

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -45,7 +45,11 @@ const indexIdOfCountRequest = (url: string): string | undefined =>
   /\/api\/v1\/(?<indexId>[^/]+)\/search/u.exec(url)?.groups?.["indexId"];
 
 /** Serves the engine's document count, and nothing else. */
-const engineHolding = (numHits: number, ok = true): void => {
+const engineHolding = (
+  numHits: number,
+  ok = true,
+  splitOpstamps: readonly number[] = [],
+): void => {
   const resolveUrl = (input: Parameters<typeof fetch>[0]): string => {
     if (typeof input === "string") {
       return input;
@@ -77,6 +81,19 @@ const engineHolding = (numHits: number, ok = true): void => {
         { status: 200 },
       );
     }
+    if (url.includes("/splits")) {
+      return new Response(
+        JSON.stringify({
+          offset: 0,
+          size: splitOpstamps.length,
+          splits: splitOpstamps.map((opstamp) => ({
+            split_state: "Published",
+            delete_opstamp: opstamp,
+          })),
+        }),
+        { status: 200 },
+      );
+    }
     return new Response(JSON.stringify({}), { status: 200 });
   };
   globalThis.fetch = Object.assign(stub, {
@@ -92,6 +109,7 @@ const databaseHolding = (
   marked: number,
   jurisdictions?: string[],
   countStatus = "complete",
+  deleteOpstamp?: number,
 ): ScopedDb => {
   const handle = async (callback: (tx: Transaction) => Promise<unknown>) => {
     let rows: Record<string, unknown>[] = [];
@@ -104,7 +122,12 @@ const databaseHolding = (
     };
     const tx = {
       select: (selection: Record<string, unknown>) => {
-        rows = "status" in selection ? [{ marked, status: countStatus }] : [];
+        rows =
+          "status" in selection
+            ? [{ marked, status: countStatus }]
+            : "opstamp" in selection && deleteOpstamp !== undefined
+              ? [{ opstamp: deleteOpstamp }]
+              : [];
         return chain;
       },
       selectDistinct: () => {
@@ -243,6 +266,27 @@ describe("index census", () => {
     );
   });
 
+  test("a retained delete task explains surplus until every split applies it", async () => {
+    engineHolding(50_000, true, [42, 41, 45]);
+
+    const census = await censusIndex({
+      scopedDb: databaseHolding(10_000, undefined, "complete", 42),
+      generation: GENERATION,
+      indexId: INDEX_ID,
+    });
+
+    expect(census.isOk() && census.value.disposition).toBe(
+      CENSUS_DISPOSITION.pendingDelete,
+    );
+    expect(census.isOk() && census.value.deleteSettlement).toEqual({
+      requiredOpstamp: 42,
+      publishedSplits: 3,
+      laggingSplits: 1,
+      minAppliedOpstamp: 41,
+      settled: false,
+    });
+  });
+
   test("an unreachable index is a failure, not an empty index", async () => {
     // Counting it as empty would report the whole index as drifted and
     // point the repair at rows that are perfectly indexed.
@@ -295,6 +339,7 @@ describe("census reporting", () => {
         markedIndexed: 10_000,
         shortfall: 9100,
         disposition: CENSUS_DISPOSITION.short,
+        deleteSettlement: null,
       },
     });
 
@@ -322,6 +367,7 @@ describe("census reporting", () => {
         markedIndexed: 10_000,
         shortfall: 0,
         disposition: CENSUS_DISPOSITION.aligned,
+        deleteSettlement: null,
       },
     });
 
@@ -341,6 +387,7 @@ describe("census reporting", () => {
         markedIndexed: 10_000,
         shortfall: 9100,
         disposition: CENSUS_DISPOSITION.short,
+        deleteSettlement: null,
       },
     });
 
@@ -357,12 +404,36 @@ describe("census reporting", () => {
         markedIndexed: 10_000,
         shortfall: -2000,
         disposition: CENSUS_DISPOSITION.surplus,
+        deleteSettlement: null,
       },
     });
 
     expect(warn.mock.calls.at(0)?.at(1)).toMatchObject({
       disposition: CENSUS_DISPOSITION.surplus,
     });
+  });
+
+  test("a surplus with an unapplied retained delete is not reported as drift", () => {
+    reportIndexCensus({
+      generation: GENERATION,
+      previous: CENSUS_DISPOSITION.pendingDelete,
+      census: {
+        indexId: INDEX_ID,
+        engineDocuments: 12_000,
+        markedIndexed: 10_000,
+        shortfall: -2000,
+        disposition: CENSUS_DISPOSITION.pendingDelete,
+        deleteSettlement: {
+          requiredOpstamp: 42,
+          publishedSplits: 3,
+          laggingSplits: 1,
+          minAppliedOpstamp: 41,
+          settled: false,
+        },
+      },
+    });
+
+    expect(warn).not.toHaveBeenCalled();
   });
 
   test("an unreachable index reports separately from drift", async () => {

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -131,7 +131,13 @@ const databaseHolding = (
       delete: () => chain,
       select: (selection: Record<string, unknown>) => {
         if ("status" in selection) {
-          rows = [{ marked, status: countStatus }];
+          rows = [
+            {
+              marked,
+              status: countStatus,
+              hasPendingDelete: pendingDelete.count > 0,
+            },
+          ];
         } else if ("pendingDocuments" in selection) {
           rows = [
             {
@@ -516,6 +522,35 @@ describe("census reporting", () => {
     });
 
     expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls.at(0)?.at(0)).toBe(
+      "case_law.corpus_index.delete_settlement_stalled",
+    );
+  });
+
+  test("a small stale delete is reported inside census tolerance", async () => {
+    engineHolding(10_000 + CENSUS_TOLERANCE, true, [41]);
+
+    const census = await censusIndex({
+      scopedDb: databaseHolding(10_000, undefined, "complete", 42, {
+        count: CENSUS_TOLERANCE,
+        oldest: new Date(Date.now() - DELETE_SETTLEMENT_STALE_MS - 1),
+      }),
+      generation: GENERATION,
+      indexId: INDEX_ID,
+    });
+    if (census.isErr()) {
+      throw census.error;
+    }
+
+    expect(census.value.disposition).toBe(CENSUS_DISPOSITION.aligned);
+    expect(census.value.deleteSettlement?.stale).toBe(true);
+
+    reportIndexCensus({
+      generation: GENERATION,
+      previous: CENSUS_DISPOSITION.aligned,
+      census: census.value,
+    });
+
     expect(warn.mock.calls.at(0)?.at(0)).toBe(
       "case_law.corpus_index.delete_settlement_stalled",
     );

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -18,6 +18,7 @@ import {
   CENSUS_CYCLE_INTERVAL,
   CENSUS_DISPOSITION,
   CENSUS_TOLERANCE,
+  DELETE_SETTLEMENT_STALE_MS,
   CaseLawCorpusIndexCountNotReadyError,
   censusIndex,
   createCaseLawCensus,
@@ -49,6 +50,7 @@ const engineHolding = (
   numHits: number,
   ok = true,
   splitOpstamps: readonly number[] = [],
+  splitOk = true,
 ): void => {
   const resolveUrl = (input: Parameters<typeof fetch>[0]): string => {
     if (typeof input === "string") {
@@ -82,6 +84,9 @@ const engineHolding = (
       );
     }
     if (url.includes("/splits")) {
+      if (!splitOk) {
+        return new Response("split list unavailable", { status: 503 });
+      }
       return new Response(
         JSON.stringify({
           offset: 0,
@@ -110,6 +115,10 @@ const databaseHolding = (
   jurisdictions?: string[],
   countStatus = "complete",
   deleteOpstamp?: number,
+  pendingDelete: { count: number; oldest: Date | null } = {
+    count: 0,
+    oldest: null,
+  },
 ): ScopedDb => {
   const handle = async (callback: (tx: Transaction) => Promise<unknown>) => {
     let rows: Record<string, unknown>[] = [];
@@ -121,11 +130,19 @@ const databaseHolding = (
       where: () => rows,
     };
     const tx = {
+      delete: () => chain,
       select: (selection: Record<string, unknown>) => {
         rows =
           "status" in selection
             ? [{ marked, status: countStatus }]
-            : "opstamp" in selection && deleteOpstamp !== undefined
+            : "pendingDocuments" in selection
+              ? [
+                  {
+                    oldestPendingAt: pendingDelete.oldest,
+                    pendingDocuments: pendingDelete.count,
+                  },
+                ]
+              : "opstamp" in selection && deleteOpstamp !== undefined
               ? [{ opstamp: deleteOpstamp }]
               : [];
         return chain;
@@ -270,7 +287,10 @@ describe("index census", () => {
     engineHolding(50_000, true, [42, 41, 45]);
 
     const census = await censusIndex({
-      scopedDb: databaseHolding(10_000, undefined, "complete", 42),
+      scopedDb: databaseHolding(10_000, undefined, "complete", 42, {
+        count: 40_000,
+        oldest: new Date(),
+      }),
       generation: GENERATION,
       indexId: INDEX_ID,
     });
@@ -283,8 +303,40 @@ describe("index census", () => {
       publishedSplits: 3,
       laggingSplits: 1,
       minAppliedOpstamp: 41,
+      pendingDocuments: 40_000,
+      oldestPendingAt: expect.any(Date),
+      stale: false,
       settled: false,
     });
+  });
+
+  test("a pending delete explains no more surplus than its document set", async () => {
+    engineHolding(50_000, true, [41]);
+
+    const census = await censusIndex({
+      scopedDb: databaseHolding(10_000, undefined, "complete", 42, {
+        count: 10,
+        oldest: new Date(),
+      }),
+      generation: GENERATION,
+      indexId: INDEX_ID,
+    });
+
+    expect(census.isOk() && census.value.disposition).toBe(
+      CENSUS_DISPOSITION.surplus,
+    );
+  });
+
+  test("a split settlement failure stays in the census Result", async () => {
+    engineHolding(50_000, true, [41], false);
+
+    const census = await censusIndex({
+      scopedDb: databaseHolding(10_000, undefined, "complete", 42),
+      generation: GENERATION,
+      indexId: INDEX_ID,
+    });
+
+    expect(census.isErr()).toBe(true);
   });
 
   test("an unreachable index is a failure, not an empty index", async () => {
@@ -428,12 +480,46 @@ describe("census reporting", () => {
           publishedSplits: 3,
           laggingSplits: 1,
           minAppliedOpstamp: 41,
+          pendingDocuments: 2000,
+          oldestPendingAt: new Date(),
+          stale: false,
           settled: false,
         },
       },
     });
 
     expect(warn).not.toHaveBeenCalled();
+  });
+
+  test("an old pending delete is reported as stalled settlement", () => {
+    reportIndexCensus({
+      generation: GENERATION,
+      previous: CENSUS_DISPOSITION.pendingDelete,
+      census: {
+        indexId: INDEX_ID,
+        engineDocuments: 12_000,
+        markedIndexed: 10_000,
+        shortfall: -2000,
+        disposition: CENSUS_DISPOSITION.pendingDelete,
+        deleteSettlement: {
+          requiredOpstamp: 42,
+          publishedSplits: 3,
+          laggingSplits: 1,
+          minAppliedOpstamp: 41,
+          pendingDocuments: 2000,
+          oldestPendingAt: new Date(
+            Date.now() - DELETE_SETTLEMENT_STALE_MS - 1,
+          ),
+          stale: true,
+          settled: false,
+        },
+      },
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls.at(0)?.at(0)).toBe(
+      "case_law.corpus_index.delete_settlement_stalled",
+    );
   });
 
   test("an unreachable index reports separately from drift", async () => {

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -275,7 +275,7 @@ describe("index census", () => {
     // reason this direction cannot simply be ignored — each one cancels
     // a genuinely missing document in the same subtraction. Reporting
     // the surplus is what stops the pair going quiet together.
-    engineHolding(50_000);
+    engineHolding(50_000, true, [], false);
 
     const census = await censusIndex({
       scopedDb: databaseHolding(10_000),
@@ -337,7 +337,10 @@ describe("index census", () => {
     engineHolding(50_000, true, [41], false);
 
     const census = await censusIndex({
-      scopedDb: databaseHolding(10_000, undefined, "complete", 42),
+      scopedDb: databaseHolding(10_000, undefined, "complete", 42, {
+        count: 1,
+        oldest: new Date(),
+      }),
       generation: GENERATION,
       indexId: INDEX_ID,
     });

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -93,6 +93,7 @@ const engineHolding = (
           offset: 0,
           size: splitOpstamps.length,
           splits: splitOpstamps.map((opstamp) => ({
+            split_id: `split-${opstamp}`,
             split_state: "Published",
             delete_opstamp: opstamp,
           })),

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -143,8 +143,8 @@ const databaseHolding = (
                   },
                 ]
               : "opstamp" in selection && deleteOpstamp !== undefined
-              ? [{ opstamp: deleteOpstamp }]
-              : [];
+                ? [{ opstamp: deleteOpstamp }]
+                : [];
         return chain;
       },
       selectDistinct: () => {

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -37,6 +37,7 @@ const INDEX_ID = corpusIndexId(GENERATION, JURISDICTION);
 const LAST_CYCLE_START = 0.99;
 
 const originalFetch = globalThis.fetch;
+const NO_PENDING_DELETE = { count: 0, oldest: null } as const;
 
 /** Index ids the engine was asked to count, in request order. */
 let countedIndexIds: string[];
@@ -115,10 +116,7 @@ const databaseHolding = (
   jurisdictions?: string[],
   countStatus = "complete",
   deleteOpstamp?: number,
-  pendingDelete: { count: number; oldest: Date | null } = {
-    count: 0,
-    oldest: null,
-  },
+  pendingDelete: { count: number; oldest: Date | null } = NO_PENDING_DELETE,
 ): ScopedDb => {
   const handle = async (callback: (tx: Transaction) => Promise<unknown>) => {
     let rows: Record<string, unknown>[] = [];
@@ -132,19 +130,20 @@ const databaseHolding = (
     const tx = {
       delete: () => chain,
       select: (selection: Record<string, unknown>) => {
-        rows =
-          "status" in selection
-            ? [{ marked, status: countStatus }]
-            : "pendingDocuments" in selection
-              ? [
-                  {
-                    oldestPendingAt: pendingDelete.oldest,
-                    pendingDocuments: pendingDelete.count,
-                  },
-                ]
-              : "opstamp" in selection && deleteOpstamp !== undefined
-                ? [{ opstamp: deleteOpstamp }]
-                : [];
+        if ("status" in selection) {
+          rows = [{ marked, status: countStatus }];
+        } else if ("pendingDocuments" in selection) {
+          rows = [
+            {
+              oldestPendingAt: pendingDelete.oldest,
+              pendingDocuments: pendingDelete.count,
+            },
+          ];
+        } else if ("opstamp" in selection && deleteOpstamp !== undefined) {
+          rows = [{ opstamp: deleteOpstamp }];
+        } else {
+          rows = [];
+        }
         return chain;
       },
       selectDistinct: () => {

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -33,7 +33,18 @@
  */
 
 import { Result, TaggedError } from "better-result";
-import { and, asc, eq, gt, inArray, type SQL, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  count,
+  eq,
+  gt,
+  inArray,
+  lte,
+  min,
+  type SQL,
+  sql,
+} from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
@@ -44,6 +55,7 @@ import {
   caseLawCorpusIndexCountBackfills,
   caseLawCorpusIndexCounts,
   caseLawCorpusIndexDeleteWatermarks,
+  caseLawCorpusIndexPendingDeletes,
   caseLawCorpusIndexProjections,
   caseLawDecisions,
 } from "@/api/db/schema";
@@ -278,6 +290,9 @@ export const createCaseLawCorpusIndexCountSeed = ({
  */
 export const CENSUS_TOLERANCE = 5;
 
+/** Pending engine deletion old enough to require operator attention. */
+export const DELETE_SETTLEMENT_STALE_MS = 6 * 60 * 60 * 1000;
+
 /**
  * What one observation says about an index.
  *
@@ -321,6 +336,9 @@ export type IndexCensus = {
     publishedSplits: number;
     laggingSplits: number;
     minAppliedOpstamp: number | null;
+    pendingDocuments: number;
+    oldestPendingAt: Date | null;
+    stale: boolean;
     settled: boolean;
   } | null;
 };
@@ -335,7 +353,10 @@ const dispositionOf = (
   if (shortfall >= -CENSUS_TOLERANCE) {
     return CENSUS_DISPOSITION.aligned;
   }
-  return deleteSettlement?.settled === false
+  const surplus = -shortfall;
+  return deleteSettlement !== null &&
+    deleteSettlement.pendingDocuments > 0 &&
+    surplus <= deleteSettlement.pendingDocuments + CENSUS_TOLERANCE
     ? CENSUS_DISPOSITION.pendingDelete
     : CENSUS_DISPOSITION.surplus;
 };
@@ -343,7 +364,7 @@ const dispositionOf = (
 const readDeleteSettlement = async (
   scopedDb: ScopedDb,
   indexId: string,
-): Promise<IndexCensus["deleteSettlement"]> => {
+): Promise<Result<IndexCensus["deleteSettlement"], CorpusIndexError>> => {
   const watermark = (
     await scopedDb((tx) =>
       tx
@@ -353,16 +374,52 @@ const readDeleteSettlement = async (
     )
   ).at(0);
   if (watermark === undefined) {
-    return null;
+    return Result.ok(null);
   }
   const settlement = await getCorpusIndexClient().readDeleteSettlement(
     indexId,
     watermark.opstamp,
   );
   if (Result.isError(settlement)) {
-    throw settlement.error;
+    return Result.err(settlement.error);
   }
-  return settlement.value;
+  const appliedOpstamp =
+    settlement.value.publishedSplits === 0
+      ? watermark.opstamp
+      : settlement.value.minAppliedOpstamp;
+  const pending = await scopedDb(async (tx) => {
+    if (appliedOpstamp !== null) {
+      // audit: skip — bounded derived settlement state; append-only index-job
+      // rows retain the deletion audit trail
+      await tx
+        .delete(caseLawCorpusIndexPendingDeletes)
+        .where(
+          and(
+            eq(caseLawCorpusIndexPendingDeletes.indexId, indexId),
+            lte(caseLawCorpusIndexPendingDeletes.opstamp, appliedOpstamp),
+          ),
+        );
+    }
+    return await tx
+      .select({
+        oldestPendingAt: min(caseLawCorpusIndexPendingDeletes.createdAt),
+        pendingDocuments: count(),
+      })
+      .from(caseLawCorpusIndexPendingDeletes)
+      .where(eq(caseLawCorpusIndexPendingDeletes.indexId, indexId));
+  });
+  const state = pending.at(0);
+  const pendingDocuments = state?.pendingDocuments ?? 0;
+  const oldestPendingAt = state?.oldestPendingAt ?? null;
+  return Result.ok({
+    ...settlement.value,
+    pendingDocuments,
+    oldestPendingAt,
+    stale:
+      oldestPendingAt !== null &&
+      Date.now() - oldestPendingAt.getTime() >= DELETE_SETTLEMENT_STALE_MS,
+    settled: pendingDocuments === 0,
+  });
 };
 
 /**
@@ -456,10 +513,14 @@ export const censusIndex = async ({
   }
 
   const shortfall = markedIndexed - counted.value.numHits;
-  const deleteSettlement =
+  const deleteSettlementResult =
     shortfall < -CENSUS_TOLERANCE
       ? await readDeleteSettlement(scopedDb, indexId)
-      : null;
+      : Result.ok(null);
+  if (Result.isError(deleteSettlementResult)) {
+    return Result.err(deleteSettlementResult.error);
+  }
+  const deleteSettlement = deleteSettlementResult.value;
 
   return Result.ok({
     indexId,
@@ -501,6 +562,16 @@ export const reportIndexCensus = ({
   census,
   previous,
 }: ReportIndexCensusOptions): void => {
+  if (census.deleteSettlement?.stale === true) {
+    logger.warn("case_law.corpus_index.delete_settlement_stalled", {
+      generation,
+      indexId: census.indexId,
+      deleteLaggingSplits: census.deleteSettlement.laggingSplits,
+      deleteOldestPendingAt: census.deleteSettlement.oldestPendingAt,
+      deletePendingDocuments: census.deleteSettlement.pendingDocuments,
+      deleteRequiredOpstamp: census.deleteSettlement.requiredOpstamp,
+    });
+  }
   if (
     census.disposition === CENSUS_DISPOSITION.aligned ||
     census.disposition === CENSUS_DISPOSITION.pendingDelete ||

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -567,7 +567,8 @@ export const reportIndexCensus = ({
       generation,
       indexId: census.indexId,
       deleteLaggingSplits: census.deleteSettlement.laggingSplits,
-      deleteOldestPendingAt: census.deleteSettlement.oldestPendingAt,
+      deleteOldestPendingAt:
+        census.deleteSettlement.oldestPendingAt?.toISOString() ?? "unknown",
       deletePendingDocuments: census.deleteSettlement.pendingDocuments,
       deleteRequiredOpstamp: census.deleteSettlement.requiredOpstamp,
     });
@@ -579,6 +580,13 @@ export const reportIndexCensus = ({
   ) {
     return;
   }
+  const deleteSettlementAttributes =
+    census.deleteSettlement === null
+      ? {}
+      : {
+          deleteLaggingSplits: census.deleteSettlement.laggingSplits,
+          deleteRequiredOpstamp: census.deleteSettlement.requiredOpstamp,
+        };
   logger.warn("case_law.corpus_index.census_drift", {
     generation,
     disposition: census.disposition,
@@ -586,8 +594,7 @@ export const reportIndexCensus = ({
     engineDocuments: census.engineDocuments,
     markedIndexed: census.markedIndexed,
     shortfall: census.shortfall,
-    deleteLaggingSplits: census.deleteSettlement?.laggingSplits,
-    deleteRequiredOpstamp: census.deleteSettlement?.requiredOpstamp,
+    ...deleteSettlementAttributes,
     tolerance: CENSUS_TOLERANCE,
   });
 };

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -479,7 +479,7 @@ const countMarkedIndexed = async (
   }
   return {
     markedIndexed: row.marked ?? 0,
-    hasPendingDelete: row.hasPendingDelete,
+    hasPendingDelete: row.hasPendingDelete === true,
   };
 };
 

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -38,6 +38,7 @@ import {
   asc,
   count,
   eq,
+  exists,
   gt,
   inArray,
   lte,
@@ -442,12 +443,19 @@ const censusPopulation = (generation: string, indexId: string): SQL =>
 const countMarkedIndexed = async (
   scopedDb: ScopedDb,
   { generation, indexId }: { generation: string; indexId: string },
-): Promise<number> => {
+): Promise<{ markedIndexed: number; hasPendingDelete: boolean }> => {
   const rows = await scopedDb((tx) =>
     tx
       .select({
         marked: caseLawCorpusIndexCounts.markedIndexed,
         status: caseLawCorpusIndexCountBackfills.status,
+        hasPendingDelete: exists(
+          tx
+            .select({ indexId: caseLawCorpusIndexPendingDeletes.indexId })
+            .from(caseLawCorpusIndexPendingDeletes)
+            .where(eq(caseLawCorpusIndexPendingDeletes.indexId, indexId))
+            .limit(1),
+        ),
       })
       .from(caseLawCorpusIndexCountBackfills)
       .leftJoin(
@@ -469,7 +477,10 @@ const countMarkedIndexed = async (
       message: `Corpus-index count for ${generation} is not ready`,
     });
   }
-  return row.marked ?? 0;
+  return {
+    markedIndexed: row.marked ?? 0,
+    hasPendingDelete: row.hasPendingDelete,
+  };
 };
 
 export type CensusIndexOptions = {
@@ -499,7 +510,7 @@ export const censusIndex = async ({
   // is still visible to the engine count that follows. The other order
   // would need a tolerance the size of a batch, which is exactly the
   // size of the smallest loss worth finding.
-  const markedIndexed = await countMarkedIndexed(scopedDb, {
+  const marked = await countMarkedIndexed(scopedDb, {
     generation,
     indexId,
   });
@@ -512,9 +523,9 @@ export const censusIndex = async ({
     return Result.err(counted.error);
   }
 
-  const shortfall = markedIndexed - counted.value.numHits;
+  const shortfall = marked.markedIndexed - counted.value.numHits;
   const deleteSettlementResult =
-    shortfall < -CENSUS_TOLERANCE
+    shortfall < -CENSUS_TOLERANCE || marked.hasPendingDelete
       ? await readDeleteSettlement(scopedDb, indexId)
       : Result.ok(null);
   if (Result.isError(deleteSettlementResult)) {
@@ -525,7 +536,7 @@ export const censusIndex = async ({
   return Result.ok({
     indexId,
     engineDocuments: counted.value.numHits,
-    markedIndexed,
+    markedIndexed: marked.markedIndexed,
     shortfall,
     disposition: dispositionOf(shortfall, deleteSettlement),
     deleteSettlement,

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -453,8 +453,7 @@ const countMarkedIndexed = async (
           tx
             .select({ indexId: caseLawCorpusIndexPendingDeletes.indexId })
             .from(caseLawCorpusIndexPendingDeletes)
-            .where(eq(caseLawCorpusIndexPendingDeletes.indexId, indexId))
-            .limit(1),
+            .where(eq(caseLawCorpusIndexPendingDeletes.indexId, indexId)),
         ),
       })
       .from(caseLawCorpusIndexCountBackfills)

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -43,6 +43,7 @@ import {
   caseLawCorpusIndexBackfills,
   caseLawCorpusIndexCountBackfills,
   caseLawCorpusIndexCounts,
+  caseLawCorpusIndexDeleteWatermarks,
   caseLawCorpusIndexProjections,
   caseLawDecisions,
 } from "@/api/db/schema";
@@ -297,6 +298,8 @@ export const CENSUS_DISPOSITION = {
   aligned: "aligned",
   /** The engine holds fewer documents than the corpus claims. */
   short: "short",
+  /** Surplus is explained by a recorded delete not yet applied to every split. */
+  pendingDelete: "surplus_pending_delete",
   /** The engine holds documents the corpus does not account for. */
   surplus: "surplus",
 } as const;
@@ -313,15 +316,53 @@ export type IndexCensus = {
   /** Positive where the corpus claims more than the engine holds. */
   shortfall: number;
   disposition: CensusDisposition;
+  deleteSettlement: {
+    requiredOpstamp: number;
+    publishedSplits: number;
+    laggingSplits: number;
+    minAppliedOpstamp: number | null;
+    settled: boolean;
+  } | null;
 };
 
-const dispositionOf = (shortfall: number): CensusDisposition => {
+const dispositionOf = (
+  shortfall: number,
+  deleteSettlement: IndexCensus["deleteSettlement"],
+): CensusDisposition => {
   if (shortfall > CENSUS_TOLERANCE) {
     return CENSUS_DISPOSITION.short;
   }
-  return shortfall < -CENSUS_TOLERANCE
-    ? CENSUS_DISPOSITION.surplus
-    : CENSUS_DISPOSITION.aligned;
+  if (shortfall >= -CENSUS_TOLERANCE) {
+    return CENSUS_DISPOSITION.aligned;
+  }
+  return deleteSettlement?.settled === false
+    ? CENSUS_DISPOSITION.pendingDelete
+    : CENSUS_DISPOSITION.surplus;
+};
+
+const readDeleteSettlement = async (
+  scopedDb: ScopedDb,
+  indexId: string,
+): Promise<IndexCensus["deleteSettlement"]> => {
+  const watermark = (
+    await scopedDb((tx) =>
+      tx
+        .select({ opstamp: caseLawCorpusIndexDeleteWatermarks.opstamp })
+        .from(caseLawCorpusIndexDeleteWatermarks)
+        .where(eq(caseLawCorpusIndexDeleteWatermarks.indexId, indexId)),
+    )
+  ).at(0);
+  if (watermark === undefined) {
+    return null;
+  }
+  const settlement = await getCorpusIndexClient().readDeleteSettlement(
+    indexId,
+    watermark.opstamp,
+  );
+  if (Result.isError(settlement)) {
+    throw settlement.error;
+  }
+  return settlement.value;
 };
 
 /**
@@ -415,13 +456,18 @@ export const censusIndex = async ({
   }
 
   const shortfall = markedIndexed - counted.value.numHits;
+  const deleteSettlement =
+    shortfall < -CENSUS_TOLERANCE
+      ? await readDeleteSettlement(scopedDb, indexId)
+      : null;
 
   return Result.ok({
     indexId,
     engineDocuments: counted.value.numHits,
     markedIndexed,
     shortfall,
-    disposition: dispositionOf(shortfall),
+    disposition: dispositionOf(shortfall, deleteSettlement),
+    deleteSettlement,
   });
 };
 
@@ -457,6 +503,7 @@ export const reportIndexCensus = ({
 }: ReportIndexCensusOptions): void => {
   if (
     census.disposition === CENSUS_DISPOSITION.aligned ||
+    census.disposition === CENSUS_DISPOSITION.pendingDelete ||
     census.disposition !== previous
   ) {
     return;
@@ -468,6 +515,8 @@ export const reportIndexCensus = ({
     engineDocuments: census.engineDocuments,
     markedIndexed: census.markedIndexed,
     shortfall: census.shortfall,
+    deleteLaggingSplits: census.deleteSettlement?.laggingSplits,
+    deleteRequiredOpstamp: census.deleteSettlement?.requiredOpstamp,
     tolerance: CENSUS_TOLERANCE,
   });
 };

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -524,10 +524,9 @@ export const censusIndex = async ({
   }
 
   const shortfall = marked.markedIndexed - counted.value.numHits;
-  const deleteSettlementResult =
-    shortfall < -CENSUS_TOLERANCE || marked.hasPendingDelete
-      ? await readDeleteSettlement(scopedDb, indexId)
-      : Result.ok(null);
+  const deleteSettlementResult = marked.hasPendingDelete
+    ? await readDeleteSettlement(scopedDb, indexId)
+    : Result.ok(null);
   if (Result.isError(deleteSettlementResult)) {
     return Result.err(deleteSettlementResult.error);
   }

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -299,73 +299,68 @@ describe("idempotent corpus removals", () => {
     ]);
   });
 
-  test(
-    "a successful deletion records the engine opstamp with its audit job",
-    async () => {
-      const row = {
-        id: toSafeId<"caseLawDecision">("settled-delete-row"),
-        country: "CZ",
-        textS3Key: null,
-        astS3Key: null,
-        contentHash: null,
-        indexedHash: null,
-        indexedGeneration: null,
-        // SAFETY: the removal path never reads the fabricated timestamp token.
-        // eslint-disable-next-line typescript/no-unsafe-type-assertion
-        updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
-      };
-      const deleteRecords: {
-        jobs: CorpusJobInput<"caseLawDecision">[];
-        opstamp: number | null;
-      }[] = [];
-      const indexer = createCorpusIndexer<"caseLawDecision", typeof row>({
-        family: "case_law",
-        captureStep: "test",
-        granularity: "document",
-        generationProjectionIndexIds: () => [],
-        buildDocs: () => [],
-        readCorpusText: async () => "unused",
-        selectMissing: async () => [],
-        selectStale: async () => [],
-        fetchFulltext: async () => null,
-        markIndexedBatch: async () => new Set(),
-        insertSucceededJobs: async () => undefined,
-        recordJobs: async () => undefined,
-        recordDeleteJobs: async (_db, { jobs, opstamp }) => {
-          deleteRecords.push({ jobs: [...jobs], opstamp });
-        },
-      });
-      let nextDeleteOpstamp = 40;
-      globalThis.fetch = Object.assign(
-        async () => {
-          nextDeleteOpstamp += 1;
-          return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
-            status: 200,
-          });
-        },
-        { preconnect: originalFetch.preconnect },
-      );
-      const scopedDb: ScopedDb = async () => {
-        throw new Error("removal should not open a database transaction");
-      };
+  test("a successful deletion records the engine opstamp with its audit job", async () => {
+    const row = {
+      id: toSafeId<"caseLawDecision">("settled-delete-row"),
+      country: "CZ",
+      textS3Key: null,
+      astS3Key: null,
+      contentHash: null,
+      indexedHash: null,
+      indexedGeneration: null,
+      // SAFETY: the removal path never reads the fabricated timestamp token.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
+    };
+    const deleteRecords: {
+      jobs: CorpusJobInput<"caseLawDecision">[];
+      opstamp: number | null;
+    }[] = [];
+    const indexer = createCorpusIndexer<"caseLawDecision", typeof row>({
+      family: "case_law",
+      captureStep: "test",
+      granularity: "document",
+      generationProjectionIndexIds: () => [],
+      buildDocs: () => [],
+      readCorpusText: async () => "unused",
+      selectMissing: async () => [],
+      selectStale: async () => [],
+      fetchFulltext: async () => null,
+      markIndexedBatch: async () => new Set(),
+      insertSucceededJobs: async () => undefined,
+      recordJobs: async () => undefined,
+      recordDeleteJobs: async (_db, { jobs, opstamp }) => {
+        deleteRecords.push({ jobs: [...jobs], opstamp });
+      },
+    });
+    let nextDeleteOpstamp = 40;
+    globalThis.fetch = Object.assign(
+      async () => {
+        nextDeleteOpstamp += 1;
+        return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
+          status: 200,
+        });
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+    const scopedDb: ScopedDb = async () => {
+      throw new Error("removal should not open a database transaction");
+    };
 
-      const removed = await indexer.remove(
-        row.id,
-        scopedDb,
-        corpusIndexId("case_law_v2", "CZ"),
-      );
+    const removed = await indexer.remove(
+      row.id,
+      scopedDb,
+      corpusIndexId("case_law_v2", "CZ"),
+    );
 
-      expect(removed.isOk()).toBe(true);
-      expect(deleteRecords).toMatchObject([
-        {
-          jobs: [
-            { entityId: row.id, operation: "delete", status: "succeeded" },
-          ],
-          opstamp: 41,
-        },
-      ]);
-    },
-  );
+    expect(removed.isOk()).toBe(true);
+    expect(deleteRecords).toMatchObject([
+      {
+        jobs: [{ entityId: row.id, operation: "delete", status: "succeeded" }],
+        opstamp: 41,
+      },
+    ]);
+  });
 
   test("a fenced removal records guard failures after the remote effect", async () => {
     const row = {

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -299,73 +299,70 @@ describe("idempotent corpus removals", () => {
     ]);
   });
 
-  test(
-    "a successful deletion records the engine opstamp with its audit job",
-    async () => {
-      const row = {
-        id: toSafeId<"caseLawDecision">("settled-delete-row"),
-        country: "CZ",
-        textS3Key: null,
-        astS3Key: null,
-        contentHash: null,
-        indexedHash: null,
-        indexedGeneration: null,
-        // SAFETY: the removal path never reads the fabricated timestamp token.
-        // eslint-disable-next-line typescript/no-unsafe-type-assertion
-        updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
-      };
-      const deleteRecords: {
-        jobs: CorpusJobInput<"caseLawDecision">[];
-        opstamp: number | null;
-      }[] = [];
-      const indexer = createCorpusIndexer<"caseLawDecision", typeof row>({
-        family: "case_law",
-        captureStep: "test",
-        granularity: "document",
-        generationProjectionIndexIds: () => [],
-        buildDocs: () => [],
-        readCorpusText: async () => "unused",
-        selectMissing: async () => [],
-        selectStale: async () => [],
-        fetchFulltext: async () => null,
-        markIndexedBatch: async () => new Set(),
-        insertSucceededJobs: async () => undefined,
-        recordJobs: async () => undefined,
-        recordDeleteJobs: async (_db, { jobs, opstamp }) => {
-          deleteRecords.push({ jobs: [...jobs], opstamp });
-        },
-      });
-      let nextDeleteOpstamp = 40;
-      globalThis.fetch = Object.assign(
-        async () => {
-          nextDeleteOpstamp += 1;
-          return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
-            status: 200,
-          });
-        },
-        { preconnect: originalFetch.preconnect },
-      );
-      const scopedDb: ScopedDb = async () => {
-        throw new Error("removal should not open a database transaction");
-      };
+  test("a successful deletion records its opstamp", async () => {
+    const row = {
+      id: toSafeId<"caseLawDecision">("settled-delete-row"),
+      country: "CZ",
+      textS3Key: null,
+      astS3Key: null,
+      contentHash: null,
+      indexedHash: null,
+      indexedGeneration: null,
+      // SAFETY: the removal path never reads the fabricated timestamp token.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
+    };
+    const deleteRecords: {
+      jobs: CorpusJobInput<"caseLawDecision">[];
+      opstamp: number | null;
+    }[] = [];
+    const indexer = createCorpusIndexer<"caseLawDecision", typeof row>({
+      family: "case_law",
+      captureStep: "test",
+      granularity: "document",
+      generationProjectionIndexIds: () => [],
+      buildDocs: () => [],
+      readCorpusText: async () => "unused",
+      selectMissing: async () => [],
+      selectStale: async () => [],
+      fetchFulltext: async () => null,
+      markIndexedBatch: async () => new Set(),
+      insertSucceededJobs: async () => undefined,
+      recordJobs: async () => undefined,
+      recordDeleteJobs: async (_db, { jobs, opstamp }) => {
+        deleteRecords.push({ jobs: [...jobs], opstamp });
+      },
+    });
+    let nextDeleteOpstamp = 40;
+    globalThis.fetch = Object.assign(
+      async () => {
+        nextDeleteOpstamp += 1;
+        return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
+          status: 200,
+        });
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+    const scopedDb: ScopedDb = async () => {
+      throw new Error("removal should not open a database transaction");
+    };
 
-      const removed = await indexer.remove(
-        row.id,
-        scopedDb,
-        corpusIndexId("case_law_v2", "CZ"),
-      );
+    const removed = await indexer.remove(
+      row.id,
+      scopedDb,
+      corpusIndexId("case_law_v2", "CZ"),
+    );
 
-      expect(removed.isOk()).toBe(true);
-      expect(deleteRecords).toMatchObject([
-        {
-          jobs: [
-            { entityId: row.id, operation: "delete", status: "succeeded" },
-          ],
-          opstamp: 41,
-        },
-      ]);
-    },
-  );
+    expect(removed.isOk()).toBe(true);
+    expect(deleteRecords).toMatchObject([
+      {
+        jobs: [
+          { entityId: row.id, operation: "delete", status: "succeeded" },
+        ],
+        opstamp: 41,
+      },
+    ]);
+  });
 
   test("a fenced removal records guard failures after the remote effect", async () => {
     const row = {

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -686,6 +686,9 @@ describe("failed index jobs always reach the audit trail", () => {
           status: 200,
         });
       }
+      if (lastUrl.includes("/delete-tasks")) {
+        return new Response(JSON.stringify({ opstamp: 1 }), { status: 200 });
+      }
       return new Response(JSON.stringify({}), { status: 200 });
     };
     globalThis.fetch = Object.assign(stub, {
@@ -1215,7 +1218,11 @@ describe("first-ever fenced appends", () => {
     input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
   ) => {
-    if (!requestUrl(input).includes("/ingest")) {
+    const url = requestUrl(input);
+    if (url.includes("/delete-tasks")) {
+      return new Response(JSON.stringify({ opstamp: 1 }), { status: 200 });
+    }
+    if (!url.includes("/ingest")) {
       return new Response(JSON.stringify({}), { status: 200 });
     }
     const body = typeof init?.body === "string" ? init.body : "";

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -275,6 +275,9 @@ describe("idempotent corpus removals", () => {
       recordJobs: async (_db, jobs) => {
         recorded.push(...jobs);
       },
+      recordDeleteJobs: async (_db, { jobs }) => {
+        recorded.push(...jobs);
+      },
     });
     globalThis.fetch = Object.assign(
       async () => new Response("missing", { status: 404 }),
@@ -293,6 +296,69 @@ describe("idempotent corpus removals", () => {
     expect(removed.isOk()).toBe(true);
     expect(recorded).toMatchObject([
       { entityId: row.id, operation: "delete", status: "succeeded" },
+    ]);
+  });
+
+  test("a successful deletion records the engine opstamp with its audit job", async () => {
+    const row = {
+      id: toSafeId<"caseLawDecision">("settled-delete-row"),
+      country: "CZ",
+      textS3Key: null,
+      astS3Key: null,
+      contentHash: null,
+      indexedHash: null,
+      indexedGeneration: null,
+      // SAFETY: the removal path never reads the fabricated timestamp token.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
+    };
+    const deleteRecords: {
+      jobs: CorpusJobInput<"caseLawDecision">[];
+      opstamp: number | null;
+    }[] = [];
+    const indexer = createCorpusIndexer<"caseLawDecision", typeof row>({
+      family: "case_law",
+      captureStep: "test",
+      granularity: "document",
+      generationProjectionIndexIds: () => [],
+      buildDocs: () => [],
+      readCorpusText: async () => "unused",
+      selectMissing: async () => [],
+      selectStale: async () => [],
+      fetchFulltext: async () => null,
+      markIndexedBatch: async () => new Set(),
+      insertSucceededJobs: async () => undefined,
+      recordJobs: async () => undefined,
+      recordDeleteJobs: async (_db, { jobs, opstamp }) => {
+        deleteRecords.push({ jobs: [...jobs], opstamp });
+      },
+    });
+    let nextDeleteOpstamp = 40;
+    globalThis.fetch = Object.assign(
+      async () => {
+        nextDeleteOpstamp += 1;
+        return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
+          status: 200,
+        });
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+    const scopedDb: ScopedDb = async () => {
+      throw new Error("removal should not open a database transaction");
+    };
+
+    const removed = await indexer.remove(
+      row.id,
+      scopedDb,
+      corpusIndexId("case_law_v2", "CZ"),
+    );
+
+    expect(removed.isOk()).toBe(true);
+    expect(deleteRecords).toMatchObject([
+      {
+        jobs: [{ entityId: row.id, operation: "delete", status: "succeeded" }],
+        opstamp: 41,
+      },
     ]);
   });
 
@@ -325,9 +391,18 @@ describe("idempotent corpus removals", () => {
       recordJobs: async (_db, jobs) => {
         recorded.push(...jobs);
       },
+      recordDeleteJobs: async (_db, { jobs }) => {
+        recorded.push(...jobs);
+      },
     });
+    let nextDeleteOpstamp = 0;
     globalThis.fetch = Object.assign(
-      async () => new Response(JSON.stringify({}), { status: 200 }),
+      async () => {
+        nextDeleteOpstamp += 1;
+        return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
+          status: 200,
+        });
+      },
       { preconnect: originalFetch.preconnect },
     );
     const scopedDb: ScopedDb = async () => {
@@ -380,10 +455,18 @@ describe("fenced serving-generation appends", () => {
       updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
     };
     const events: string[] = [];
+    let nextDeleteOpstamp = 0;
     globalThis.fetch = Object.assign(
       async (input: Parameters<typeof fetch>[0]) => {
         const url = input instanceof Request ? input.url : String(input);
         events.push(url.includes("/ingest") ? "ingest" : "remote");
+        if (url.includes("/delete-tasks")) {
+          nextDeleteOpstamp += 1;
+          return new Response(
+            JSON.stringify({ opstamp: nextDeleteOpstamp }),
+            { status: 200 },
+          );
+        }
         return new Response(
           url.includes("/ingest")
             ? JSON.stringify({ num_docs_for_processing: 1 })
@@ -412,6 +495,7 @@ describe("fenced serving-generation appends", () => {
         new Set(rows.map((selected) => selected.id)),
       insertSucceededJobs: async () => undefined,
       recordJobs: async () => undefined,
+      recordDeleteJobs: async () => undefined,
     });
 
     expect(
@@ -503,6 +587,7 @@ describe("failed index jobs always reach the audit trail", () => {
   beforeEach(() => {
     // The CZ index rejects its ingest; the SK index accepts. Everything else
     // the indexer probes succeeds.
+    let nextDeleteOpstamp = 0;
     const resolveUrl = (input: Parameters<typeof fetch>[0]): string => {
       if (typeof input === "string") {
         return input;
@@ -516,6 +601,12 @@ describe("failed index jobs always reach the audit trail", () => {
       }
       if (url.includes("/ingest")) {
         return new Response(JSON.stringify({ num_docs_for_processing: 1 }), {
+          status: 200,
+        });
+      }
+      if (url.includes("/delete-tasks")) {
+        nextDeleteOpstamp += 1;
+        return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
           status: 200,
         });
       }
@@ -557,6 +648,7 @@ describe("failed index jobs always reach the audit trail", () => {
       recordJobs: async (_db, jobs, indexId) => {
         recorded.push({ indexId, jobs: [...jobs] });
       },
+      recordDeleteJobs: async () => undefined,
     });
 
     const outcome = await indexer.backfill(scopedDb, 10, GENERATION).then(
@@ -619,6 +711,7 @@ describe("failed index jobs always reach the audit trail", () => {
       recordJobs: async (_db, jobs) => {
         recorded.push(...jobs);
       },
+      recordDeleteJobs: async () => undefined,
     });
 
     const outcome: unknown = await indexer
@@ -673,6 +766,7 @@ describe("failed index jobs always reach the audit trail", () => {
 
   test("reserved replays delete every durable target in rebuild and serving modes", async () => {
     const calls: { method: string; url: string; body?: string }[] = [];
+    let nextDeleteOpstamp = 0;
     const stub = async (
       input: Parameters<typeof fetch>[0],
       init?: RequestInit,
@@ -692,6 +786,12 @@ describe("failed index jobs always reach the audit trail", () => {
       });
       if (url.includes("/ingest")) {
         return new Response(JSON.stringify({ num_docs_for_processing: 1 }), {
+          status: 200,
+        });
+      }
+      if (url.includes("/delete-tasks")) {
+        nextDeleteOpstamp += 1;
+        return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
           status: 200,
         });
       }
@@ -728,6 +828,7 @@ describe("failed index jobs always reach the audit trail", () => {
       },
       insertSucceededJobs: async () => undefined,
       recordJobs: async () => undefined,
+      recordDeleteJobs: async () => undefined,
     });
 
     let guardedEffects = 0;
@@ -977,6 +1078,7 @@ describe("ingest commit mode", () => {
         new Set(rows.map((selected) => selected.id)),
       insertSucceededJobs: async () => undefined,
       recordJobs: async () => undefined,
+      recordDeleteJobs: async () => undefined,
     });
 
   test("the incremental backfill waits for the commit", async () => {
@@ -1079,6 +1181,7 @@ describe("first-ever fenced appends", () => {
         new Set(markedRows.map((selected) => selected.id)),
       insertSucceededJobs: async () => undefined,
       recordJobs: async () => undefined,
+      recordDeleteJobs: async () => undefined,
     });
 
     const outcome = await indexer.backfillRows(scopedDb, [row], GENERATION, {
@@ -1185,6 +1288,7 @@ describe("first-ever fenced appends", () => {
       _jobs: readonly CorpusJobInput<"caseLawDecision">[],
       _indexId: string,
     ): Promise<void> => undefined,
+    recordDeleteJobs: async (): Promise<void> => undefined,
   };
 
   const outcomeIndexer = (
@@ -1367,6 +1471,7 @@ describe("delete-task amplification", () => {
     rowCount: number,
   ): Promise<{ deletes: DeleteCall[]; indexed: number }> => {
     const deletes: DeleteCall[] = [];
+    let nextDeleteOpstamp = 0;
     const stub = async (
       input: Parameters<typeof fetch>[0],
       init?: Parameters<typeof fetch>[1],
@@ -1389,6 +1494,10 @@ describe("delete-task amplification", () => {
             ? parsed["query"]
             : "";
         deletes.push({ url, query });
+        nextDeleteOpstamp += 1;
+        return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
+          status: 200,
+        });
       }
       if (url.includes("/ingest")) {
         const sent = body.split("\n").filter((line) => line.length > 0).length;
@@ -1438,6 +1547,7 @@ describe("delete-task amplification", () => {
         new Set(markedRows.map((selected) => selected.id)),
       insertSucceededJobs: async () => undefined,
       recordJobs: async () => undefined,
+      recordDeleteJobs: async () => undefined,
     });
 
     const { indexed } = await indexer.backfillRows(scopedDb, rows, GENERATION, {

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -299,68 +299,73 @@ describe("idempotent corpus removals", () => {
     ]);
   });
 
-  test("a successful deletion records the engine opstamp with its audit job", async () => {
-    const row = {
-      id: toSafeId<"caseLawDecision">("settled-delete-row"),
-      country: "CZ",
-      textS3Key: null,
-      astS3Key: null,
-      contentHash: null,
-      indexedHash: null,
-      indexedGeneration: null,
-      // SAFETY: the removal path never reads the fabricated timestamp token.
-      // eslint-disable-next-line typescript/no-unsafe-type-assertion
-      updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
-    };
-    const deleteRecords: {
-      jobs: CorpusJobInput<"caseLawDecision">[];
-      opstamp: number | null;
-    }[] = [];
-    const indexer = createCorpusIndexer<"caseLawDecision", typeof row>({
-      family: "case_law",
-      captureStep: "test",
-      granularity: "document",
-      generationProjectionIndexIds: () => [],
-      buildDocs: () => [],
-      readCorpusText: async () => "unused",
-      selectMissing: async () => [],
-      selectStale: async () => [],
-      fetchFulltext: async () => null,
-      markIndexedBatch: async () => new Set(),
-      insertSucceededJobs: async () => undefined,
-      recordJobs: async () => undefined,
-      recordDeleteJobs: async (_db, { jobs, opstamp }) => {
-        deleteRecords.push({ jobs: [...jobs], opstamp });
-      },
-    });
-    let nextDeleteOpstamp = 40;
-    globalThis.fetch = Object.assign(
-      async () => {
-        nextDeleteOpstamp += 1;
-        return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
-          status: 200,
-        });
-      },
-      { preconnect: originalFetch.preconnect },
-    );
-    const scopedDb: ScopedDb = async () => {
-      throw new Error("removal should not open a database transaction");
-    };
+  test(
+    "a successful deletion records the engine opstamp with its audit job",
+    async () => {
+      const row = {
+        id: toSafeId<"caseLawDecision">("settled-delete-row"),
+        country: "CZ",
+        textS3Key: null,
+        astS3Key: null,
+        contentHash: null,
+        indexedHash: null,
+        indexedGeneration: null,
+        // SAFETY: the removal path never reads the fabricated timestamp token.
+        // eslint-disable-next-line typescript/no-unsafe-type-assertion
+        updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
+      };
+      const deleteRecords: {
+        jobs: CorpusJobInput<"caseLawDecision">[];
+        opstamp: number | null;
+      }[] = [];
+      const indexer = createCorpusIndexer<"caseLawDecision", typeof row>({
+        family: "case_law",
+        captureStep: "test",
+        granularity: "document",
+        generationProjectionIndexIds: () => [],
+        buildDocs: () => [],
+        readCorpusText: async () => "unused",
+        selectMissing: async () => [],
+        selectStale: async () => [],
+        fetchFulltext: async () => null,
+        markIndexedBatch: async () => new Set(),
+        insertSucceededJobs: async () => undefined,
+        recordJobs: async () => undefined,
+        recordDeleteJobs: async (_db, { jobs, opstamp }) => {
+          deleteRecords.push({ jobs: [...jobs], opstamp });
+        },
+      });
+      let nextDeleteOpstamp = 40;
+      globalThis.fetch = Object.assign(
+        async () => {
+          nextDeleteOpstamp += 1;
+          return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
+            status: 200,
+          });
+        },
+        { preconnect: originalFetch.preconnect },
+      );
+      const scopedDb: ScopedDb = async () => {
+        throw new Error("removal should not open a database transaction");
+      };
 
-    const removed = await indexer.remove(
-      row.id,
-      scopedDb,
-      corpusIndexId("case_law_v2", "CZ"),
-    );
+      const removed = await indexer.remove(
+        row.id,
+        scopedDb,
+        corpusIndexId("case_law_v2", "CZ"),
+      );
 
-    expect(removed.isOk()).toBe(true);
-    expect(deleteRecords).toMatchObject([
-      {
-        jobs: [{ entityId: row.id, operation: "delete", status: "succeeded" }],
-        opstamp: 41,
-      },
-    ]);
-  });
+      expect(removed.isOk()).toBe(true);
+      expect(deleteRecords).toMatchObject([
+        {
+          jobs: [
+            { entityId: row.id, operation: "delete", status: "succeeded" },
+          ],
+          opstamp: 41,
+        },
+      ]);
+    },
+  );
 
   test("a fenced removal records guard failures after the remote effect", async () => {
     const row = {

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -356,9 +356,7 @@ describe("idempotent corpus removals", () => {
     expect(removed.isOk()).toBe(true);
     expect(deleteRecords).toMatchObject([
       {
-        jobs: [
-          { entityId: row.id, operation: "delete", status: "succeeded" },
-        ],
+        jobs: [{ entityId: row.id, operation: "delete", status: "succeeded" }],
         opstamp: 41,
       },
     ]);
@@ -464,10 +462,9 @@ describe("fenced serving-generation appends", () => {
         events.push(url.includes("/ingest") ? "ingest" : "remote");
         if (url.includes("/delete-tasks")) {
           nextDeleteOpstamp += 1;
-          return new Response(
-            JSON.stringify({ opstamp: nextDeleteOpstamp }),
-            { status: 200 },
-          );
+          return new Response(JSON.stringify({ opstamp: nextDeleteOpstamp }), {
+            status: 200,
+          });
         }
         return new Response(
           url.includes("/ingest")

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -592,6 +592,20 @@ export type CorpusIndexAdapter<
     jobs: readonly CorpusJobInput<TBrand>[],
     generation: string,
   ) => Promise<void>;
+  /**
+   * Atomically record document audit rows and the engine task that carries
+   * their asynchronous deletion. A successful task without this durable
+   * watermark is not settled evidence, so persistence failure must fail the
+   * page and let replay create a newer task.
+   */
+  recordDeleteJobs: (
+    scopedDb: ScopedDb,
+    args: {
+      indexId: string;
+      jobs: readonly CorpusJobInput<TBrand>[];
+      opstamp: number | null;
+    },
+  ) => Promise<void>;
 };
 
 export type LoadedBatch<TBrand extends SafeIdType, TRow> = {
@@ -980,24 +994,29 @@ export const createCorpusIndexer = <
     // avoids retrying an index that can no longer contain the document.
     const result =
       deleted.isErr() && deleted.error.status === 404
-        ? Result.ok(undefined)
+        ? Result.ok(null)
         : deleted;
     // One audit row per entity however many entities shared the task: the
     // trail records what happened to a document, not what carried it.
-    await adapter.recordJobs(
+    await adapter.recordDeleteJobs(
       scopedDb,
-      entityIds.map((entityId) => ({
-        entityId,
-        contentHash: null,
-        operation,
-        status: result.isErr() ? ("failed" as const) : ("succeeded" as const),
-        ...(result.isErr()
-          ? { errorMessage: result.error.message.slice(0, 2048) }
-          : {}),
-      })),
-      indexId,
+      {
+        indexId,
+        jobs: entityIds.map((entityId) => ({
+          entityId,
+          contentHash: null,
+          operation,
+          status: result.isErr()
+            ? ("failed" as const)
+            : ("succeeded" as const),
+          ...(result.isErr()
+            ? { errorMessage: result.error.message.slice(0, 2048) }
+            : {}),
+        })),
+        opstamp: result.isOk() ? (result.value?.opstamp ?? null) : null,
+      },
     );
-    return result;
+    return result.isErr() ? result : Result.ok(undefined);
   };
 
   // Narrows on `args`, not on destructured locals: destructuring splits the

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -998,24 +998,19 @@ export const createCorpusIndexer = <
         : deleted;
     // One audit row per entity however many entities shared the task: the
     // trail records what happened to a document, not what carried it.
-    await adapter.recordDeleteJobs(
-      scopedDb,
-      {
-        indexId,
-        jobs: entityIds.map((entityId) => ({
-          entityId,
-          contentHash: null,
-          operation,
-          status: result.isErr()
-            ? ("failed" as const)
-            : ("succeeded" as const),
-          ...(result.isErr()
-            ? { errorMessage: result.error.message.slice(0, 2048) }
-            : {}),
-        })),
-        opstamp: result.isOk() ? (result.value?.opstamp ?? null) : null,
-      },
-    );
+    await adapter.recordDeleteJobs(scopedDb, {
+      indexId,
+      jobs: entityIds.map((entityId) => ({
+        entityId,
+        contentHash: null,
+        operation,
+        status: result.isErr() ? ("failed" as const) : ("succeeded" as const),
+        ...(result.isErr()
+          ? { errorMessage: result.error.message.slice(0, 2048) }
+          : {}),
+      })),
+      opstamp: result.isOk() ? (result.value?.opstamp ?? null) : null,
+    });
     return result.isErr() ? result : Result.ok(undefined);
   };
 

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -249,7 +249,7 @@ test("ingest fails when the engine reports rejected documents", async () => {
 });
 
 test("delete-by-query posts one document-scoped delete task", async () => {
-  responseBody = {};
+  responseBody = { opstamp: 42 };
 
   const result = await getCorpusIndexClient().deleteByQuery(
     "legal_corpus_v1_cze",
@@ -257,6 +257,9 @@ test("delete-by-query posts one document-scoped delete task", async () => {
   );
 
   expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value).toEqual({ opstamp: 42 });
+  }
   // One task per document, whatever the index layout: a passage-split
   // document is removed by the same single query as a whole one, so the
   // indexer never has to know how many documents a row previously emitted.
@@ -266,6 +269,54 @@ test("delete-by-query posts one document-scoped delete task", async () => {
   expect(request?.path).toBe("/api/v1/legal_corpus_v1_cze/delete-tasks");
   const body: Record<string, unknown> = JSON.parse(request?.body ?? "{}");
   expect(body["query"]).toBe('document_id:"dec-1"');
+});
+
+test("delete-by-query rejects a response without a usable opstamp", async () => {
+  responseBody = {};
+
+  const result = await getCorpusIndexClient().deleteByQuery(
+    "legal_corpus_v1_cze",
+    'document_id:"dec-1"',
+  );
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toContain("invalid response");
+  }
+});
+
+test("delete settlement compares every published split with the retained task", async () => {
+  responseBody = {
+    offset: 0,
+    size: 3,
+    splits: [
+      { split_state: "Published", delete_opstamp: 42 },
+      { split_state: "Published", delete_opstamp: 41 },
+      { split_state: "Published", delete_opstamp: 45 },
+    ],
+  };
+
+  const result = await getCorpusIndexClient().readDeleteSettlement(
+    "legal_corpus_v1_cze",
+    42,
+  );
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value).toEqual({
+      requiredOpstamp: 42,
+      publishedSplits: 3,
+      laggingSplits: 1,
+      minAppliedOpstamp: 41,
+      settled: false,
+    });
+  }
+  expect(requests.at(0)?.path).toBe(
+    "/api/v1/indexes/legal_corpus_v1_cze/splits",
+  );
+  expect(requests.at(0)?.search).toBe(
+    "?offset=0&limit=1000&split_states=Published",
+  );
 });
 
 test("ingest sends the commit mode the caller asked for", async () => {

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -24,7 +24,7 @@ type RecordedRequest = {
 };
 
 let requests: RecordedRequest[];
-let responseBody: unknown;
+let responseBody: unknown | ((url: URL) => unknown);
 const originalFetch = globalThis.fetch;
 const originalCorpusIndexEndpoint = envBase.CORPUS_INDEX_ENDPOINT;
 const originalCorpusIndexSearchEndpoint = envBase.CORPUS_INDEX_SEARCH_ENDPOINT;
@@ -52,7 +52,9 @@ beforeEach(() => {
       search: url.search,
       body: typeof init?.body === "string" ? init.body : "",
     });
-    return new Response(JSON.stringify(responseBody), { status: 200 });
+    const body =
+      typeof responseBody === "function" ? responseBody(url) : responseBody;
+    return new Response(JSON.stringify(body), { status: 200 });
   };
   globalThis.fetch = Object.assign(stub, {
     preconnect: originalFetch.preconnect,
@@ -317,6 +319,46 @@ test("delete settlement compares every published split with the retained task", 
   expect(requests.at(0)?.search).toBe(
     "?offset=0&limit=1000&split_states=Published",
   );
+});
+
+const settlementResponse = (splitCount: number) => (url: URL) => {
+  const offset = Number(url.searchParams.get("offset") ?? "0");
+  const pageSize = Math.min(1000, Math.max(splitCount - offset, 0));
+  return {
+    splits: Array.from({ length: pageSize }, () => ({
+      split_state: "Published",
+      delete_opstamp: 42,
+    })),
+  };
+};
+
+test("delete settlement accepts exactly the published split ceiling", async () => {
+  responseBody = settlementResponse(10_000);
+
+  const result = await getCorpusIndexClient().readDeleteSettlement(
+    "legal_corpus_v1_cze",
+    42,
+  );
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value.publishedSplits).toBe(10_000);
+    expect(result.value.settled).toBe(true);
+  }
+});
+
+test("delete settlement rejects the first split beyond its ceiling", async () => {
+  responseBody = settlementResponse(10_001);
+
+  const result = await getCorpusIndexClient().readDeleteSettlement(
+    "legal_corpus_v1_cze",
+    42,
+  );
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toContain("exceeds 10000");
+  }
 });
 
 test("ingest sends the commit mode the caller asked for", async () => {

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -24,7 +24,8 @@ type RecordedRequest = {
 };
 
 let requests: RecordedRequest[];
-let responseBody: unknown | ((url: URL) => unknown);
+let responseBody: unknown;
+let responseBodyForUrl: ((url: URL) => unknown) | null;
 const originalFetch = globalThis.fetch;
 const originalCorpusIndexEndpoint = envBase.CORPUS_INDEX_ENDPOINT;
 const originalCorpusIndexSearchEndpoint = envBase.CORPUS_INDEX_SEARCH_ENDPOINT;
@@ -32,6 +33,7 @@ const originalCorpusIndexSearchEndpoint = envBase.CORPUS_INDEX_SEARCH_ENDPOINT;
 beforeEach(() => {
   requests = [];
   responseBody = {};
+  responseBodyForUrl = null;
   const resolveUrl = (input: Parameters<typeof fetch>[0]): string => {
     if (typeof input === "string") {
       return input;
@@ -53,7 +55,7 @@ beforeEach(() => {
       body: typeof init?.body === "string" ? init.body : "",
     });
     const body =
-      typeof responseBody === "function" ? responseBody(url) : responseBody;
+      responseBodyForUrl === null ? responseBody : responseBodyForUrl(url);
     return new Response(JSON.stringify(body), { status: 200 });
   };
   globalThis.fetch = Object.assign(stub, {
@@ -333,7 +335,7 @@ const settlementResponse = (splitCount: number) => (url: URL) => {
 };
 
 test("delete settlement accepts exactly the published split ceiling", async () => {
-  responseBody = settlementResponse(10_000);
+  responseBodyForUrl = settlementResponse(10_000);
 
   const result = await getCorpusIndexClient().readDeleteSettlement(
     "legal_corpus_v1_cze",
@@ -348,7 +350,7 @@ test("delete settlement accepts exactly the published split ceiling", async () =
 });
 
 test("delete settlement rejects the first split beyond its ceiling", async () => {
-  responseBody = settlementResponse(10_001);
+  responseBodyForUrl = settlementResponse(10_001);
 
   const result = await getCorpusIndexClient().readDeleteSettlement(
     "legal_corpus_v1_cze",

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -294,9 +294,21 @@ test("delete settlement compares every published split with the retained task", 
     offset: 0,
     size: 3,
     splits: [
-      { split_state: "Published", delete_opstamp: 42 },
-      { split_state: "Published", delete_opstamp: 41 },
-      { split_state: "Published", delete_opstamp: 45 },
+      {
+        split_id: "split-42",
+        split_state: "Published",
+        delete_opstamp: 42,
+      },
+      {
+        split_id: "split-41",
+        split_state: "Published",
+        delete_opstamp: 41,
+      },
+      {
+        split_id: "split-45",
+        split_state: "Published",
+        delete_opstamp: 45,
+      },
     ],
   };
 
@@ -327,12 +339,43 @@ const settlementResponse = (splitCount: number) => (url: URL) => {
   const offset = Number(url.searchParams.get("offset") ?? "0");
   const pageSize = Math.min(1000, Math.max(splitCount - offset, 0));
   return {
-    splits: Array.from({ length: pageSize }, () => ({
+    splits: Array.from({ length: pageSize }, (_, index) => ({
+      split_id: `split-${offset + index}`,
       split_state: "Published",
       delete_opstamp: 42,
     })),
   };
 };
+
+test("delete settlement repeats an offset scan until split identities stabilize", async () => {
+  let firstPageReads = 0;
+  responseBodyForUrl = (url) => {
+    const offset = Number(url.searchParams.get("offset") ?? "0");
+    if (offset === 0) {
+      firstPageReads += 1;
+      return {
+        splits: Array.from({ length: 1000 }, (_, index) => ({
+          split_id:
+            firstPageReads === 1 || index > 0 ? `split-${index}` : "split-new",
+          split_state: "Published",
+          delete_opstamp: 42,
+        })),
+      };
+    }
+    return { splits: [] };
+  };
+
+  const result = await getCorpusIndexClient().readDeleteSettlement(
+    "legal_corpus_v1_cze",
+    42,
+  );
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value.publishedSplits).toBe(1000);
+  }
+  expect(firstPageReads).toBe(3);
+});
 
 test("delete settlement accepts exactly the published split ceiling", async () => {
   responseBodyForUrl = settlementResponse(10_000);

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -335,6 +335,34 @@ test("delete settlement compares every published split with the retained task", 
   );
 });
 
+test("delete settlement rejects an invalid required opstamp", async () => {
+  const result = await getCorpusIndexClient().readDeleteSettlement(
+    "legal_corpus_v1_cze",
+    -1,
+  );
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toContain("invalid opstamp");
+  }
+});
+
+test("delete settlement rejects a split without a usable delete opstamp", async () => {
+  responseBody = {
+    splits: [{ split_id: "split-1", split_state: "Published" }],
+  };
+
+  const result = await getCorpusIndexClient().readDeleteSettlement(
+    "legal_corpus_v1_cze",
+    42,
+  );
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toContain("invalid response");
+  }
+});
+
 const settlementResponse = (splitCount: number) => (url: URL) => {
   const offset = Number(url.searchParams.get("offset") ?? "0");
   const pageSize = Math.min(1000, Math.max(splitCount - offset, 0));

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -505,7 +505,10 @@ const buildClient = (): CorpusIndexClient => ({
   readDeleteSettlement: async (indexId, requiredOpstamp) =>
     await Result.tryPromise({
       try: async () => {
-        if (!Number.isSafeInteger(requiredOpstamp) || requiredOpstamp < 0) {
+        if (
+          !Number.isSafeInteger(requiredOpstamp) ||
+          requiredOpstamp < 0
+        ) {
           throw new CorpusIndexError({
             message: "corpus index delete settlement received an invalid opstamp",
           });
@@ -514,10 +517,11 @@ const buildClient = (): CorpusIndexClient => ({
         let publishedSplits = 0;
         let laggingSplits = 0;
         let minAppliedOpstamp: number | null = null;
-        for (;;) {
+        const readSplitPage = async (): Promise<void> => {
           const response = await requestJson({
             baseUrl: mutationBaseUrl(),
-            path: `/api/v1/indexes/${indexId}/splits?offset=${offset}&limit=${SPLIT_PAGE_SIZE}&split_states=Published`,
+            path:
+              `/api/v1/indexes/${indexId}/splits?offset=${offset}&limit=${SPLIT_PAGE_SIZE}&split_states=Published`,
             init: { method: "GET" },
             timeoutMs: ADMIN_TIMEOUT_MS,
           });
@@ -552,14 +556,17 @@ const buildClient = (): CorpusIndexClient => ({
           publishedSplits += splits.length;
           if (publishedSplits > MAX_SETTLEMENT_SPLITS) {
             throw new CorpusIndexError({
-              message: `corpus index split list exceeds ${MAX_SETTLEMENT_SPLITS} published splits`,
+              message:
+                `corpus index split list exceeds ${MAX_SETTLEMENT_SPLITS} published splits`,
             });
           }
           if (splits.length < SPLIT_PAGE_SIZE) {
-            break;
+            return;
           }
           offset += splits.length;
-        }
+          await readSplitPage();
+        };
+        await readSplitPage();
         return {
           requiredOpstamp,
           publishedSplits,

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -507,10 +507,7 @@ const buildClient = (): CorpusIndexClient => ({
   readDeleteSettlement: async (indexId, requiredOpstamp) =>
     await Result.tryPromise({
       try: async () => {
-        if (
-          !Number.isSafeInteger(requiredOpstamp) ||
-          requiredOpstamp < 0
-        ) {
+        if (!Number.isSafeInteger(requiredOpstamp) || requiredOpstamp < 0) {
           throw new CorpusIndexError({
             message:
               "corpus index delete settlement received an invalid opstamp",
@@ -551,8 +548,7 @@ const buildClient = (): CorpusIndexClient => ({
               : null;
             if (splits === null) {
               throw new CorpusIndexError({
-                message:
-                  "corpus index split list returned an invalid response",
+                message: "corpus index split list returned an invalid response",
               });
             }
             scannedSplits += splits.length;

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -48,6 +48,7 @@ const ADMIN_TIMEOUT_MS = 30_000;
 const AGGREGATION_TIMEOUT_MS = 10_000;
 const SPLIT_PAGE_SIZE = 1000;
 const MAX_SETTLEMENT_SPLITS = 10_000;
+const MAX_SETTLEMENT_SCAN_PASSES = 3;
 
 /**
  * What "the engine accepted this batch" is allowed to mean.
@@ -513,60 +514,95 @@ const buildClient = (): CorpusIndexClient => ({
             message: "corpus index delete settlement received an invalid opstamp",
           });
         }
-        let offset = 0;
-        let publishedSplits = 0;
-        let laggingSplits = 0;
-        let minAppliedOpstamp: number | null = null;
-        const readSplitPage = async (): Promise<void> => {
-          const response = await requestJson({
-            baseUrl: mutationBaseUrl(),
-            path:
-              `/api/v1/indexes/${indexId}/splits?offset=${offset}&limit=${SPLIT_PAGE_SIZE}&split_states=Published`,
-            init: { method: "GET" },
-            timeoutMs: ADMIN_TIMEOUT_MS,
-          });
-          const splits = isRecord(response)
-            ? parseRecordArray(response["splits"])
-            : null;
-          if (splits === null) {
+        const observedSplitOpstamps = new Map<string, number>();
+        let finalPassSplitIds = new Set<string>();
+        let scanPasses = 0;
+        const readSplitPass = async (): Promise<void> => {
+          scanPasses += 1;
+          if (scanPasses > MAX_SETTLEMENT_SCAN_PASSES) {
             throw new CorpusIndexError({
-              message: "corpus index split list returned an invalid response",
+              message:
+                "corpus index split list did not reach a stable published-split set",
             });
           }
-          for (const split of splits) {
-            const opstamp = split["delete_opstamp"];
-            if (
-              split["split_state"] !== "Published" ||
-              typeof opstamp !== "number" ||
-              !Number.isSafeInteger(opstamp) ||
-              opstamp < 0
-            ) {
+          let offset = 0;
+          let scannedSplits = 0;
+          let sawUnobservedSplit = false;
+          const currentSplitIds = new Set<string>();
+          const readSplitPage = async (): Promise<void> => {
+            const response = await requestJson({
+              baseUrl: mutationBaseUrl(),
+              path:
+                `/api/v1/indexes/${indexId}/splits?offset=${offset}&limit=${SPLIT_PAGE_SIZE}&split_states=Published`,
+              init: { method: "GET" },
+              timeoutMs: ADMIN_TIMEOUT_MS,
+            });
+            const splits = isRecord(response)
+              ? parseRecordArray(response["splits"])
+              : null;
+            if (splits === null) {
               throw new CorpusIndexError({
                 message: "corpus index split list returned an invalid response",
               });
             }
-            minAppliedOpstamp =
-              minAppliedOpstamp === null
-                ? opstamp
-                : Math.min(minAppliedOpstamp, opstamp);
-            if (opstamp < requiredOpstamp) {
-              laggingSplits += 1;
+            scannedSplits += splits.length;
+            if (scannedSplits > MAX_SETTLEMENT_SPLITS) {
+              throw new CorpusIndexError({
+                message:
+                  `corpus index split list exceeds ${MAX_SETTLEMENT_SPLITS} published splits`,
+              });
             }
-          }
-          publishedSplits += splits.length;
-          if (publishedSplits > MAX_SETTLEMENT_SPLITS) {
-            throw new CorpusIndexError({
-              message:
-                `corpus index split list exceeds ${MAX_SETTLEMENT_SPLITS} published splits`,
-            });
-          }
-          if (splits.length < SPLIT_PAGE_SIZE) {
-            return;
-          }
-          offset += splits.length;
+            for (const split of splits) {
+              const splitId = split["split_id"];
+              const opstamp = split["delete_opstamp"];
+              if (
+                split["split_state"] !== "Published" ||
+                typeof splitId !== "string" ||
+                splitId.length === 0 ||
+                typeof opstamp !== "number" ||
+                !Number.isSafeInteger(opstamp) ||
+                opstamp < 0
+              ) {
+                throw new CorpusIndexError({
+                  message: "corpus index split list returned an invalid response",
+                });
+              }
+              const previousOpstamp = observedSplitOpstamps.get(splitId);
+              currentSplitIds.add(splitId);
+              if (previousOpstamp === undefined) {
+                sawUnobservedSplit = true;
+                observedSplitOpstamps.set(splitId, opstamp);
+              } else {
+                observedSplitOpstamps.set(
+                  splitId,
+                  Math.min(previousOpstamp, opstamp),
+                );
+              }
+            }
+            if (splits.length < SPLIT_PAGE_SIZE) {
+              return;
+            }
+            offset += splits.length;
+            await readSplitPage();
+          };
           await readSplitPage();
+          finalPassSplitIds = currentSplitIds;
+          // Quickwit lists by numeric offset, not a snapshot cursor. A split
+          // published or retired while an earlier page is read can shift a
+          // later page. Only clear durable delete state after one complete
+          // pass adds no split identity; ongoing churn fails closed instead.
+          if (sawUnobservedSplit) {
+            await readSplitPass();
+          }
         };
-        await readSplitPage();
+        await readSplitPass();
+        const appliedOpstamps = [...observedSplitOpstamps.values()];
+        const publishedSplits = finalPassSplitIds.size;
+        const laggingSplits = appliedOpstamps.filter(
+          (opstamp) => opstamp < requiredOpstamp,
+        ).length;
+        const minAppliedOpstamp =
+          appliedOpstamps.length === 0 ? null : Math.min(...appliedOpstamps);
         return {
           requiredOpstamp,
           publishedSplits,

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -506,10 +506,7 @@ const buildClient = (): CorpusIndexClient => ({
   readDeleteSettlement: async (indexId, requiredOpstamp) =>
     await Result.tryPromise({
       try: async () => {
-        if (
-          !Number.isSafeInteger(requiredOpstamp) ||
-          requiredOpstamp < 0
-        ) {
+        if (!Number.isSafeInteger(requiredOpstamp) || requiredOpstamp < 0) {
           throw new CorpusIndexError({
             message: "corpus index delete settlement received an invalid opstamp",
           });
@@ -532,8 +529,7 @@ const buildClient = (): CorpusIndexClient => ({
           const readSplitPage = async (): Promise<void> => {
             const response = await requestJson({
               baseUrl: mutationBaseUrl(),
-              path:
-                `/api/v1/indexes/${indexId}/splits?offset=${offset}&limit=${SPLIT_PAGE_SIZE}&split_states=Published`,
+              path: `/api/v1/indexes/${indexId}/splits?offset=${offset}&limit=${SPLIT_PAGE_SIZE}&split_states=Published`,
               init: { method: "GET" },
               timeoutMs: ADMIN_TIMEOUT_MS,
             });
@@ -548,8 +544,7 @@ const buildClient = (): CorpusIndexClient => ({
             scannedSplits += splits.length;
             if (scannedSplits > MAX_SETTLEMENT_SPLITS) {
               throw new CorpusIndexError({
-                message:
-                  `corpus index split list exceeds ${MAX_SETTLEMENT_SPLITS} published splits`,
+                message: `corpus index split list exceeds ${MAX_SETTLEMENT_SPLITS} published splits`,
               });
             }
             for (const split of splits) {

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -505,10 +505,7 @@ const buildClient = (): CorpusIndexClient => ({
   readDeleteSettlement: async (indexId, requiredOpstamp) =>
     await Result.tryPromise({
       try: async () => {
-        if (
-          !Number.isSafeInteger(requiredOpstamp) ||
-          requiredOpstamp < 0
-        ) {
+        if (!Number.isSafeInteger(requiredOpstamp) || requiredOpstamp < 0) {
           throw new CorpusIndexError({
             message: "corpus index delete settlement received an invalid opstamp",
           });
@@ -552,13 +549,13 @@ const buildClient = (): CorpusIndexClient => ({
             }
           }
           publishedSplits += splits.length;
-          if (splits.length < SPLIT_PAGE_SIZE) {
-            break;
-          }
-          if (publishedSplits >= MAX_SETTLEMENT_SPLITS) {
+          if (publishedSplits > MAX_SETTLEMENT_SPLITS) {
             throw new CorpusIndexError({
               message: `corpus index split list exceeds ${MAX_SETTLEMENT_SPLITS} published splits`,
             });
+          }
+          if (splits.length < SPLIT_PAGE_SIZE) {
+            break;
           }
           offset += splits.length;
         }

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -49,6 +49,7 @@ const AGGREGATION_TIMEOUT_MS = 10_000;
 const SPLIT_PAGE_SIZE = 1000;
 const MAX_SETTLEMENT_SPLITS = 10_000;
 const MAX_SETTLEMENT_SCAN_PASSES = 3;
+const SETTLEMENT_SCAN_TIMEOUT_MS = 60_000;
 
 /**
  * What "the engine accepted this batch" is allowed to mean.
@@ -506,15 +507,28 @@ const buildClient = (): CorpusIndexClient => ({
   readDeleteSettlement: async (indexId, requiredOpstamp) =>
     await Result.tryPromise({
       try: async () => {
-        if (!Number.isSafeInteger(requiredOpstamp) || requiredOpstamp < 0) {
+        if (
+          !Number.isSafeInteger(requiredOpstamp) ||
+          requiredOpstamp < 0
+        ) {
           throw new CorpusIndexError({
-            message: "corpus index delete settlement received an invalid opstamp",
+            message:
+              "corpus index delete settlement received an invalid opstamp",
           });
         }
+        const deadline = Date.now() + SETTLEMENT_SCAN_TIMEOUT_MS;
+        const remainingBudget = (): number => {
+          const remaining = deadline - Date.now();
+          if (remaining <= 0) {
+            throw new CorpusIndexError({
+              message: `corpus index delete settlement exceeded its ${SETTLEMENT_SCAN_TIMEOUT_MS}ms budget`,
+            });
+          }
+          return Math.min(remaining, ADMIN_TIMEOUT_MS);
+        };
         const observedSplitOpstamps = new Map<string, number>();
-        let finalPassSplitIds = new Set<string>();
         let scanPasses = 0;
-        const readSplitPass = async (): Promise<void> => {
+        const readSplitPass = async (): Promise<Set<string>> => {
           scanPasses += 1;
           if (scanPasses > MAX_SETTLEMENT_SCAN_PASSES) {
             throw new CorpusIndexError({
@@ -524,21 +538,21 @@ const buildClient = (): CorpusIndexClient => ({
           }
           let offset = 0;
           let scannedSplits = 0;
-          let sawUnobservedSplit = false;
           const currentSplitIds = new Set<string>();
           const readSplitPage = async (): Promise<void> => {
             const response = await requestJson({
               baseUrl: mutationBaseUrl(),
               path: `/api/v1/indexes/${indexId}/splits?offset=${offset}&limit=${SPLIT_PAGE_SIZE}&split_states=Published`,
               init: { method: "GET" },
-              timeoutMs: ADMIN_TIMEOUT_MS,
+              timeoutMs: remainingBudget(),
             });
             const splits = isRecord(response)
               ? parseRecordArray(response["splits"])
               : null;
             if (splits === null) {
               throw new CorpusIndexError({
-                message: "corpus index split list returned an invalid response",
+                message:
+                  "corpus index split list returned an invalid response",
               });
             }
             scannedSplits += splits.length;
@@ -559,13 +573,13 @@ const buildClient = (): CorpusIndexClient => ({
                 opstamp < 0
               ) {
                 throw new CorpusIndexError({
-                  message: "corpus index split list returned an invalid response",
+                  message:
+                    "corpus index split list returned an invalid response",
                 });
               }
               const previousOpstamp = observedSplitOpstamps.get(splitId);
               currentSplitIds.add(splitId);
               if (previousOpstamp === undefined) {
-                sawUnobservedSplit = true;
                 observedSplitOpstamps.set(splitId, opstamp);
               } else {
                 observedSplitOpstamps.set(
@@ -581,17 +595,32 @@ const buildClient = (): CorpusIndexClient => ({
             await readSplitPage();
           };
           await readSplitPage();
-          finalPassSplitIds = currentSplitIds;
+          return currentSplitIds;
+        };
+        const readStableSplitPass = async (
+          previousPassSplitIds: ReadonlySet<string>,
+        ): Promise<Set<string>> => {
+          const currentSplitIds = await readSplitPass();
           // Quickwit lists by numeric offset, not a snapshot cursor. A split
           // published or retired while an earlier page is read can shift a
           // later page. Only clear durable delete state after one complete
-          // pass adds no split identity; ongoing churn fails closed instead.
-          if (sawUnobservedSplit) {
-            await readSplitPass();
+          // pass has exactly the same identity set; ongoing churn fails closed.
+          const stable =
+            currentSplitIds.size === previousPassSplitIds.size &&
+            currentSplitIds.isSubsetOf(previousPassSplitIds);
+          if (stable) {
+            return currentSplitIds;
           }
+          return await readStableSplitPass(currentSplitIds);
         };
-        await readSplitPass();
-        const appliedOpstamps = [...observedSplitOpstamps.values()];
+        const finalPassSplitIds = await readStableSplitPass(new Set());
+        const appliedOpstamps = [...finalPassSplitIds].map((splitId) => {
+          const opstamp = observedSplitOpstamps.get(splitId);
+          if (opstamp === undefined) {
+            panic("settlement scan lost a published split opstamp");
+          }
+          return opstamp;
+        });
         const publishedSplits = finalPassSplitIds.size;
         const laggingSplits = appliedOpstamps.filter(
           (opstamp) => opstamp < requiredOpstamp,

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -521,8 +521,9 @@ const buildClient = (): CorpusIndexClient => ({
             init: { method: "GET" },
             timeoutMs: ADMIN_TIMEOUT_MS,
           });
-          const splits =
-            isRecord(response) ? parseRecordArray(response["splits"]) : null;
+          const splits = isRecord(response)
+            ? parseRecordArray(response["splits"])
+            : null;
           if (splits === null) {
             throw new CorpusIndexError({
               message: "corpus index split list returned an invalid response",

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -46,6 +46,8 @@ const ADMIN_TIMEOUT_MS = 30_000;
  * hold the request open for the full search timeout.
  */
 const AGGREGATION_TIMEOUT_MS = 10_000;
+const SPLIT_PAGE_SIZE = 1000;
+const MAX_SETTLEMENT_SPLITS = 10_000;
 
 /**
  * What "the engine accepted this batch" is allowed to mean.
@@ -106,6 +108,25 @@ export type CorpusIndexSearchResponse = {
   snippets: Record<string, unknown>[];
 };
 
+/**
+ * Durable identity of one asynchronous engine deletion.
+ *
+ * Quickwit applies delete tasks to published splits after accepting the
+ * request. Retaining the returned opstamp is the bounded proof boundary;
+ * discarding it forces operators to list the engine's ever-growing task log.
+ */
+export type CorpusIndexDeleteTask = {
+  opstamp: number;
+};
+
+export type CorpusIndexDeleteSettlement = {
+  requiredOpstamp: number;
+  publishedSplits: number;
+  laggingSplits: number;
+  minAppliedOpstamp: number | null;
+  settled: boolean;
+};
+
 export type CorpusIndexClient = {
   createIndex: (
     config: CorpusIndexConfig,
@@ -131,7 +152,11 @@ export type CorpusIndexClient = {
   deleteByQuery: (
     indexId: string,
     query: string,
-  ) => Promise<Result<void, CorpusIndexError>>;
+  ) => Promise<Result<CorpusIndexDeleteTask, CorpusIndexError>>;
+  readDeleteSettlement: (
+    indexId: string,
+    requiredOpstamp: number,
+  ) => Promise<Result<CorpusIndexDeleteSettlement, CorpusIndexError>>;
 };
 
 const mutationBaseUrl = (): string => {
@@ -452,7 +477,7 @@ const buildClient = (): CorpusIndexClient => ({
   deleteByQuery: async (indexId, query) =>
     await Result.tryPromise({
       try: async () => {
-        await requestJson({
+        const response = await requestJson({
           baseUrl: mutationBaseUrl(),
           path: `/api/v1/${indexId}/delete-tasks`,
           init: {
@@ -462,6 +487,88 @@ const buildClient = (): CorpusIndexClient => ({
           },
           timeoutMs: ADMIN_TIMEOUT_MS,
         });
+        if (
+          !isRecord(response) ||
+          typeof response["opstamp"] !== "number" ||
+          !Number.isSafeInteger(response["opstamp"]) ||
+          response["opstamp"] < 0
+        ) {
+          throw new CorpusIndexError({
+            message: "corpus index delete task returned an invalid response",
+          });
+        }
+        return { opstamp: response["opstamp"] };
+      },
+      catch: toCorpusIndexError,
+    }),
+
+  readDeleteSettlement: async (indexId, requiredOpstamp) =>
+    await Result.tryPromise({
+      try: async () => {
+        if (
+          !Number.isSafeInteger(requiredOpstamp) ||
+          requiredOpstamp < 0
+        ) {
+          throw new CorpusIndexError({
+            message: "corpus index delete settlement received an invalid opstamp",
+          });
+        }
+        let offset = 0;
+        let publishedSplits = 0;
+        let laggingSplits = 0;
+        let minAppliedOpstamp: number | null = null;
+        for (;;) {
+          const response = await requestJson({
+            baseUrl: mutationBaseUrl(),
+            path: `/api/v1/indexes/${indexId}/splits?offset=${offset}&limit=${SPLIT_PAGE_SIZE}&split_states=Published`,
+            init: { method: "GET" },
+            timeoutMs: ADMIN_TIMEOUT_MS,
+          });
+          const splits =
+            isRecord(response) ? parseRecordArray(response["splits"]) : null;
+          if (splits === null) {
+            throw new CorpusIndexError({
+              message: "corpus index split list returned an invalid response",
+            });
+          }
+          for (const split of splits) {
+            const opstamp = split["delete_opstamp"];
+            if (
+              split["split_state"] !== "Published" ||
+              typeof opstamp !== "number" ||
+              !Number.isSafeInteger(opstamp) ||
+              opstamp < 0
+            ) {
+              throw new CorpusIndexError({
+                message: "corpus index split list returned an invalid response",
+              });
+            }
+            minAppliedOpstamp =
+              minAppliedOpstamp === null
+                ? opstamp
+                : Math.min(minAppliedOpstamp, opstamp);
+            if (opstamp < requiredOpstamp) {
+              laggingSplits += 1;
+            }
+          }
+          publishedSplits += splits.length;
+          if (splits.length < SPLIT_PAGE_SIZE) {
+            break;
+          }
+          if (publishedSplits >= MAX_SETTLEMENT_SPLITS) {
+            throw new CorpusIndexError({
+              message: `corpus index split list exceeds ${MAX_SETTLEMENT_SPLITS} published splits`,
+            });
+          }
+          offset += splits.length;
+        }
+        return {
+          requiredOpstamp,
+          publishedSplits,
+          laggingSplits,
+          minAppliedOpstamp,
+          settled: laggingSplits === 0,
+        };
       },
       catch: toCorpusIndexError,
     }),

--- a/apps/api/src/tests/pglite-test-db.ts
+++ b/apps/api/src/tests/pglite-test-db.ts
@@ -78,6 +78,22 @@ const AUTH_USER_STELLA_SELECT_COLUMNS_SQL =
     ", ",
   );
 
+const CORPUS_DELETE_WATERMARK_TABLES_SQL = [
+  schema.caseLawCorpusIndexDeleteWatermarks,
+  schema.legislationCorpusIndexDeleteWatermarks,
+]
+  .map(getTableName)
+  .map(quoteSqlIdentifier)
+  .join(", ");
+
+const CORPUS_PENDING_DELETE_TABLES_SQL = [
+  schema.caseLawCorpusIndexPendingDeletes,
+  schema.legislationCorpusIndexPendingDeletes,
+]
+  .map(getTableName)
+  .map(quoteSqlIdentifier)
+  .join(", ");
+
 // The snapshot bakes in the superset every suite needs: RLS roles, schema,
 // workspace-access objects, and the role grants. Suites that never SET ROLE
 // simply ignore the grants.
@@ -194,6 +210,29 @@ const ROLE_GRANT_STATEMENTS = [
   `,
   `
     GRANT INSERT ON TABLE "legislation_index_jobs" TO stella_ingestion
+  `,
+  // Corpus delete settlement mirrors the migration's least-privilege split:
+  // request handlers may inspect watermarks, while only ingestion owns the
+  // pending ledger and advances settlement.
+  `
+    REVOKE INSERT, UPDATE, DELETE ON TABLE
+      ${CORPUS_DELETE_WATERMARK_TABLES_SQL}
+    FROM stella
+  `,
+  `
+    REVOKE ALL PRIVILEGES ON TABLE
+      ${CORPUS_PENDING_DELETE_TABLES_SQL}
+    FROM stella
+  `,
+  `
+    GRANT SELECT, INSERT, UPDATE ON TABLE
+      ${CORPUS_DELETE_WATERMARK_TABLES_SQL}
+    TO stella_ingestion
+  `,
+  `
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE
+      ${CORPUS_PENDING_DELETE_TABLES_SQL}
+    TO stella_ingestion
   `,
   // Preserve the v0.7.22 reader contract until its rollback window closes.
   `

--- a/apps/api/src/tests/security/rls-coverage.test.ts
+++ b/apps/api/src/tests/security/rls-coverage.test.ts
@@ -766,11 +766,16 @@ describe("policy coverage", () => {
         "UPDATE",
       ]);
     }
-    expect(
-      privilegesForTable(
-        tablePrivileges,
-        "case_law_corpus_index_pending_deletes",
-      ),
-    ).toEqual(["DELETE", "INSERT", "SELECT", "UPDATE"]);
+    for (const table of [
+      "case_law_corpus_index_pending_deletes",
+      "legislation_corpus_index_pending_deletes",
+    ]) {
+      expect(privilegesForTable(tablePrivileges, table)).toEqual([
+        "DELETE",
+        "INSERT",
+        "SELECT",
+        "UPDATE",
+      ]);
+    }
   });
 });

--- a/apps/api/src/tests/security/rls-coverage.test.ts
+++ b/apps/api/src/tests/security/rls-coverage.test.ts
@@ -766,5 +766,11 @@ describe("policy coverage", () => {
         "UPDATE",
       ]);
     }
+    expect(
+      privilegesForTable(
+        tablePrivileges,
+        "case_law_corpus_index_pending_deletes",
+      ),
+    ).toEqual(["DELETE", "INSERT", "SELECT", "UPDATE"]);
   });
 });

--- a/apps/api/src/tests/security/rls-coverage.test.ts
+++ b/apps/api/src/tests/security/rls-coverage.test.ts
@@ -102,6 +102,7 @@ describe("policy coverage", () => {
   const GLOBAL_CASE_LAW_TABLES = [
     "case_law_citations",
     "case_law_court_weights",
+    "case_law_corpus_index_delete_watermarks",
     "case_law_decisions",
     "case_law_fts_configs",
     "case_law_index_jobs",
@@ -112,16 +113,19 @@ describe("policy coverage", () => {
     "case_law_sources",
     "legislation_sources",
     "legislation_documents",
+    "legislation_corpus_index_delete_watermarks",
     "legislation_search_documents",
     "legislation_index_jobs",
   ];
-  // *_sources are config (column-restricted writes); *_index_jobs are
-  // append-only audit trails (SELECT + INSERT).
+  // Sources are config (column-restricted writes), index jobs are append-only
+  // audit trails, and delete watermarks are monotone (no DELETE privilege).
   const CONFIG_OR_APPEND_ONLY = new Set([
     "case_law_sources",
     "case_law_index_jobs",
+    "case_law_corpus_index_delete_watermarks",
     "legislation_sources",
     "legislation_index_jobs",
+    "legislation_corpus_index_delete_watermarks",
   ]);
   const INGESTION_MUTABLE_CASE_LAW_TABLES = GLOBAL_CASE_LAW_TABLES.filter(
     (table) => !CONFIG_OR_APPEND_ONLY.has(table),
@@ -752,5 +756,15 @@ describe("policy coverage", () => {
     expect(
       privilegesForTable(tablePrivileges, "legislation_index_jobs"),
     ).toEqual(["INSERT", "SELECT"]);
+    for (const table of [
+      "case_law_corpus_index_delete_watermarks",
+      "legislation_corpus_index_delete_watermarks",
+    ]) {
+      expect(privilegesForTable(tablePrivileges, table)).toEqual([
+        "INSERT",
+        "SELECT",
+        "UPDATE",
+      ]);
+    }
   });
 });

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -66,10 +66,12 @@ const POST_BOOTSTRAP_SELECT_ONLY_TABLES = new Set([
   // and the bounded seed worker; request handlers may observe its status.
   "case_law_corpus_index_counts",
   "case_law_corpus_index_count_backfills",
+  "case_law_corpus_index_delete_watermarks",
   "legislation_sources",
   "legislation_documents",
   "legislation_search_documents",
   "legislation_index_jobs",
+  "legislation_corpus_index_delete_watermarks",
   // Crawl bookkeeping: the app role reads coverage for reporting, only
   // ingestion writes it.
   "case_law_coverage_slices",

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -118,6 +118,7 @@ const POST_BOOTSTRAP_DENY_STELLA_TABLES = new Set([
   // the owner connection.
   "apikey",
   "case_law_corpus_upload_intents",
+  "case_law_corpus_index_pending_deletes",
   // Internal ingestion coordination: publisher aliases are reserved before
   // decision writes and must never be queried through the request role.
   "case_law_decision_source_identities",

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -119,6 +119,7 @@ const POST_BOOTSTRAP_DENY_STELLA_TABLES = new Set([
   "apikey",
   "case_law_corpus_upload_intents",
   "case_law_corpus_index_pending_deletes",
+  "legislation_corpus_index_pending_deletes",
   // Internal ingestion coordination: publisher aliases are reserved before
   // decision writes and must never be queried through the request role.
   "case_law_decision_source_identities",


### PR DESCRIPTION
Quickwit delete tasks are asynchronous, so a successful request alone cannot prove stale documents have left every published split.

This change retains each returned delete opstamp, atomically advances a per-index high-water mark with the existing audit rows, and teaches corpus census to distinguish an explained pending-delete surplus from persistent drift. Split inspection is cursor-paginated with a hard ceiling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved deletion tracking across case-law and legislation indexes.
  - Added monitoring of deletion settlement across published index splits.
  - Deletion progress now reports lagging splits and the minimum applied operation.

- **Bug Fixes**
  - Prevented unsettled deletions from being reported incorrectly as corpus drift.
  - Improved handling of completed, pending and partially applied deletion tasks.

- **Tests**
  - Added coverage for deletion progress, pending deletions, settlement reporting and deletion recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->