### PR TITLE
fix: preserve Czech NSS document structure

### DIFF
--- a/apps/api/src/handlers/case-law/document-ast.ts
+++ b/apps/api/src/handlers/case-law/document-ast.ts
@@ -12,6 +12,7 @@ export type {
   InlineLink,
   InlineText,
   ParagraphBlock,
+  ParagraphNote,
   ParagraphRole,
   TableBlock,
   TableCell,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/at-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/at-courts.ts
@@ -3,7 +3,7 @@ import { panic, Result } from "better-result";
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
-  PARSER_VERSION,
+  PARSER_VERSIONS,
 } from "@/api/handlers/case-law/consts";
 import {
   defineSourceAdapter,
@@ -654,7 +654,7 @@ const buildListingOnly = ({
     },
     rawHash: hashContent(sourceRaw),
     documentAst: EMPTY_AST,
-    parserVersion: PARSER_VERSION,
+    parserVersion: PARSER_VERSIONS[source.key],
     sourceRaw,
     sourceRawContentType: "application/json",
   };
@@ -804,7 +804,7 @@ const buildDecision = async ({
     rawHash: hashContent(sourceRaw),
     documentAst: parsed.documentAst,
     sections: sectionsFromAst(parsed.documentAst.blocks),
-    parserVersion: PARSER_VERSION,
+    parserVersion: PARSER_VERSIONS[source.key],
     sourceRaw,
     sourceRawContentType: "application/json",
   };

--- a/apps/api/src/handlers/case-law/ingestion/adapters/at-findok.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/at-findok.ts
@@ -3,7 +3,7 @@ import { panic, Result } from "better-result";
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
-  PARSER_VERSION,
+  PARSER_VERSIONS,
 } from "@/api/handlers/case-law/consts";
 import {
   defineSourceAdapter,
@@ -542,7 +542,7 @@ const buildListingOnly = (
     },
     rawHash: hashContent(sourceRaw),
     documentAst: EMPTY_AST,
-    parserVersion: PARSER_VERSION,
+    parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.AT_FINDOK],
     sourceRaw,
     sourceRawContentType: "application/json",
   };
@@ -651,7 +651,7 @@ const buildDecision = async ({
     rawHash: hashContent(sourceRaw),
     documentAst: parsed.documentAst,
     sections: sectionsFromAst(parsed.documentAst.blocks),
-    parserVersion: PARSER_VERSION,
+    parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.AT_FINDOK],
     sourceRaw,
     sourceRawContentType: "application/json",
   };

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -3,7 +3,7 @@ import { Result, panic } from "better-result";
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
-  PARSER_VERSION,
+  PARSER_VERSIONS,
 } from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
@@ -416,7 +416,7 @@ export const buildCzNsDecision = async (
         category: meta["category"]?.trim(),
       },
       rawHash: hashContent(raw),
-      parserVersion: PARSER_VERSION,
+      parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.CZ_NS],
       documentAst,
       sourceRaw: JSON.stringify({ webHtml, printHtml }),
       sourceRawContentType: "text/html",

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -19,6 +19,7 @@ import {
   test,
 } from "bun:test";
 
+import type { StoredRawReparseInput } from "@/api/handlers/case-law/ingestion/adapter";
 import {
   buildCzNssDecision,
   courtFromEcli,
@@ -985,6 +986,46 @@ describe("cz-nss buildDecision", () => {
     expect(built.decision.sourceUrl).toBe(
       `${BASE_URL}/DokumentDetail/Index/${MUNICIPAL_ROW.documentId}`,
     );
+  });
+
+  test("replays stored HTML to the same result without contacting the court", async () => {
+    const payload = await listedRow();
+    installStub({ search: [] });
+    const built = await reconciliation.buildDecision(payload);
+    if (built.type !== "built") {
+      throw new TypeError("Expected the fixture decision to build");
+    }
+    const decision = built.decision;
+    const reparse = czNssAdapter.reparseStoredRaw;
+    if (reparse === undefined) {
+      throw new TypeError("Expected cz-nss to implement stored-raw replay");
+    }
+
+    globalThis.fetch = asFetchMock(() => {
+      throw new TypeError("Stored-raw replay must not contact the publisher");
+    });
+
+    const stored = {
+      raw: new TextEncoder().encode(decision.sourceRaw ?? ""),
+      contentType: decision.sourceRawContentType ?? null,
+      caseNumber: decision.caseNumber,
+      sourceDocumentId: decision.sourceDocumentId ?? null,
+      language: decision.language,
+      court: decision.court,
+      ecli: decision.ecli ?? null,
+      decisionDate: decision.decisionDate ?? null,
+      decisionType: decision.decisionType ?? null,
+      sourceUrl: decision.sourceUrl ?? null,
+      documentUrl: decision.documentUrl ?? null,
+      metadata: decision.metadata,
+    } satisfies StoredRawReparseInput;
+    const outcome = await reparse(stored);
+
+    expect(outcome.type).toBe("parsed");
+    if (outcome.type !== "parsed") {
+      return;
+    }
+    expect(outcome.result).toEqual(decision);
   });
 
   test("refuses to write a row whose document the court did not serve", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -5,7 +5,7 @@ import { DECISION_IDENTIFIER_TYPES } from "@stll/legal-ast/decision-identifier";
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
-  PARSER_VERSION,
+  PARSER_VERSIONS,
 } from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
@@ -825,7 +825,7 @@ const rowToResult = (
       citation: detail.citation,
     },
     rawHash: hashContent(raw),
-    parserVersion: PARSER_VERSION,
+    parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.CZ_NSS],
     documentAst: content.documentAst ?? EMPTY_AST,
     sourceRaw: content.sourceRaw,
     sourceRawContentType: "text/html",

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -12,6 +12,7 @@ import {
   defineSourceAdapter,
   EMPTY_AST,
   isPersistableSourceDocumentId,
+  STORED_RAW_REPARSE_REJECTION,
   SOURCE_TOTAL_PROBE_FAILURE,
   sourceTotalProbeFailed,
   sourceTotalRead,
@@ -23,6 +24,8 @@ import type {
   ReconciliationBuildOutcome,
   ReconciliationSlicePage,
   ReconciliationSlicePageOptions,
+  StoredRawReparseInput,
+  StoredRawReparseOutcome,
 } from "@/api/handlers/case-law/ingestion/adapter";
 import { createCalendarDaySliceWalk } from "@/api/handlers/case-law/ingestion/adapters/calendar-day-slice-walk";
 import {
@@ -529,6 +532,25 @@ type DecisionContent = {
   sourceRaw: string | undefined;
 };
 
+const CZ_NSS_REPARSABLE_CONTENT_TYPES = new Set(["text/html"]);
+
+const nonEmptyString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+type CzNssSourceHashOptions = {
+  caseNumber: string;
+  decisionDate: string | undefined;
+  decisionType: string | undefined;
+};
+
+/** Stable source-side fields shared by a crawl and a stored-raw replay. */
+const czNssSourceHash = ({
+  caseNumber,
+  decisionDate,
+  decisionType,
+}: CzNssSourceHashOptions): string =>
+  hashContent(`${caseNumber}|${decisionDate ?? ""}|${decisionType ?? ""}`);
+
 /**
  * Fetch rich HTML from /DokumentOriginal/Html/{id} and parse
  * it into a DocumentAst. Falls back to /Text/{id} for plain
@@ -759,11 +781,18 @@ const rowToResult = (
   content: DecisionContent,
   detail: DetailMetadata,
 ): IngestionResult => {
-  // Hash must be stable across runs regardless of transient
-  // network failures — never include fulltext in the hash.
-  const raw = `${row.caseNumber}|${row.decisionDate ?? ""}|${row.decisionType ?? ""}`;
   const sourceDocumentId = czNssSourceDocumentId(row);
   const court = courtFromEcli(detail.ecli);
+  const decisionDate = (() => {
+    if (detail.decisionDate) {
+      return parseCeDate(detail.decisionDate);
+    }
+    if (row.decisionDate) {
+      return parseCeDate(row.decisionDate);
+    }
+    return undefined;
+  })();
+  const decisionType = (detail.decisionType ?? row.decisionType)?.toLowerCase();
 
   return {
     caseNumber: row.caseNumber,
@@ -793,18 +822,10 @@ const rowToResult = (
     court,
     country: "CZE",
     language: CZ_NSS_LANGUAGE,
-    decisionDate: (() => {
-      if (detail.decisionDate) {
-        return parseCeDate(detail.decisionDate);
-      }
-      if (row.decisionDate) {
-        return parseCeDate(row.decisionDate);
-      }
-      return undefined;
-    })(),
+    decisionDate,
     // Prefer structured decisionType from detail page over
     // the heuristic cell match from the search results table
-    decisionType: (detail.decisionType ?? row.decisionType)?.toLowerCase(),
+    decisionType,
     fulltext: content.fulltext,
     sourceUrl: row.documentUrl,
     documentUrl: row.documentUrl,
@@ -824,11 +845,100 @@ const rowToResult = (
       administrativeAuthority: detail.administrativeAuthority,
       citation: detail.citation,
     },
-    rawHash: hashContent(raw),
+    // Fulltext is parser output, not publisher identity. Keeping it out makes
+    // crawl and replay converge on the same source hash after parser changes.
+    rawHash: czNssSourceHash({
+      caseNumber: row.caseNumber,
+      decisionDate,
+      decisionType,
+    }),
     parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.CZ_NSS],
     documentAst: content.documentAst ?? EMPTY_AST,
     sourceRaw: content.sourceRaw,
     sourceRawContentType: "text/html",
+  };
+};
+
+/** Rebuild one NSS decision from the exact HTML the crawl stored. */
+const reparseStoredRaw = (
+  stored: StoredRawReparseInput,
+): StoredRawReparseOutcome => {
+  if (
+    stored.contentType !== null &&
+    !CZ_NSS_REPARSABLE_CONTENT_TYPES.has(stored.contentType)
+  ) {
+    return {
+      type: "rejected",
+      rejection: STORED_RAW_REPARSE_REJECTION.UNSUPPORTED_CONTENT,
+      detail: `stored content type ${stored.contentType}`,
+    };
+  }
+
+  const html = new TextDecoder().decode(stored.raw);
+  const sourceUrl = stored.sourceUrl ?? undefined;
+  const decisionDate = stored.decisionDate ?? undefined;
+  const decisionType = stored.decisionType ?? undefined;
+  const ecli = stored.ecli ?? undefined;
+  const parsed = parseNssDecisionHtml({
+    caseNumber: stored.caseNumber,
+    ecli,
+    court: stored.court,
+    decisionDate,
+    decisionType,
+    sourceUrl,
+    html,
+    detailMetadata: stored.metadata,
+  });
+
+  if (parsed.documentAst.blocks.length === 0) {
+    return {
+      type: "rejected",
+      rejection: STORED_RAW_REPARSE_REJECTION.NO_DOCUMENT,
+      detail: `no blocks parsed from the stored payload for ${stored.caseNumber}`,
+    };
+  }
+
+  const citation = nonEmptyString(stored.metadata["citation"]);
+  const sourceDocumentId = stored.sourceDocumentId ?? undefined;
+
+  return {
+    type: "parsed",
+    result: {
+      caseNumber: stored.caseNumber,
+      ...(citation === undefined
+        ? {}
+        : {
+            identifiers: [
+              {
+                type: DECISION_IDENTIFIER_TYPES.REPORTER_CITATION,
+                value: citation,
+              },
+            ],
+          }),
+      sourceDocumentId,
+      ...(sourceDocumentId === undefined
+        ? {}
+        : { legacySourceUrls: [detailUrl(sourceDocumentId)] }),
+      ecli,
+      court: stored.court,
+      country: "CZE",
+      language: stored.language,
+      decisionDate,
+      decisionType,
+      fulltext: parsed.fulltext,
+      sourceUrl,
+      documentUrl: stored.documentUrl ?? undefined,
+      metadata: stored.metadata,
+      rawHash: czNssSourceHash({
+        caseNumber: stored.caseNumber,
+        decisionDate,
+        decisionType,
+      }),
+      parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.CZ_NSS],
+      documentAst: parsed.documentAst,
+      sourceRaw: html,
+      sourceRawContentType: "text/html",
+    },
   };
 };
 
@@ -1403,6 +1513,9 @@ export const czNssAdapter = defineSourceAdapter({
   // With ~20 decisions/day and fulltext fetches, ~30s/page.
   pageTimeoutMs: 120_000,
   maxSyncPages: 20,
+  // One stored NSS HTML payload is exactly one decision, so parser upgrades
+  // can replay it locally without re-contacting or rate-limiting the court.
+  reparseStoredRaw,
 
   /**
    * The portal aggregates several courts, and its search filters cannot be

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-regional.ts
@@ -4,7 +4,7 @@ import { splitCaseReference } from "@/api/handlers/case-law/case-number";
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
-  PARSER_VERSION,
+  PARSER_VERSIONS,
 } from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
@@ -541,7 +541,7 @@ const parseItem = (item: CzRegionalApiItem): IngestionResult | null => {
       mentionedStatutes: item.zminenaUstanoveni,
     },
     rawHash: hashContent(raw),
-    parserVersion: PARSER_VERSION,
+    parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.CZ_REGIONAL],
     // Court-specific AST parsing is not available for regional courts yet.
     documentAst: EMPTY_AST,
   };

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -4,7 +4,7 @@ import * as cheerio from "cheerio";
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
-  PARSER_VERSION,
+  PARSER_VERSIONS,
 } from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
@@ -487,7 +487,7 @@ const parseDecisionPage = ({
       nalusSz,
     },
     rawHash: hashContent(raw),
-    parserVersion: PARSER_VERSION,
+    parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.CZ_US],
     documentAst,
     sourceRaw: html,
     sourceRawContentType: "text/html",
@@ -1303,7 +1303,7 @@ const listedOnlyDecision = (
   rawHash: hashContent(
     `${listed.sourceDocumentId}|${listed.caseNumber}|listed-only|${reason}`,
   ),
-  parserVersion: PARSER_VERSION,
+  parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.CZ_US],
   documentAst: EMPTY_AST,
   sourceRaw: rawSource?.sourceRaw ?? listed.listingHtml,
   sourceRawContentType: rawSource?.sourceRawContentType ?? "text/html",

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.ts
@@ -3,7 +3,7 @@ import { panic, Result } from "better-result";
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
-  PARSER_VERSION,
+  PARSER_VERSIONS,
 } from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
@@ -828,7 +828,7 @@ const ecjDecisionFromHtml = ({
     rawHash: hashContent(
       `${celex}|${ecli}|${decisionDate}|${language}|${fulltext}`,
     ),
-    parserVersion: PARSER_VERSION,
+    parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.EU_ECJ],
     documentAst,
     sections,
     sourceRaw: html,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pl-courts.ts
@@ -6,7 +6,7 @@ import type { DecisionIdentifier } from "@stll/legal-ast/decision-identifier";
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
-  PARSER_VERSION,
+  PARSER_VERSIONS,
 } from "@/api/handlers/case-law/consts";
 import {
   defineSourceAdapter,
@@ -915,7 +915,7 @@ const buildPlDecision = ({
       }),
     },
     rawHash,
-    parserVersion: PARSER_VERSION,
+    parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.PL_COURTS],
     documentAst,
     sourceRaw: rawPayload,
     sourceRawContentType: "application/json",

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -3,7 +3,7 @@ import { panic } from "better-result";
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
-  PARSER_VERSION,
+  PARSER_VERSIONS,
 } from "@/api/handlers/case-law/consts";
 import {
   defineSourceAdapter,
@@ -438,7 +438,7 @@ const buildDecisionFromParts = ({
       updateDate: toOptionalValue(detail?.updateDate),
     },
     rawHash,
-    parserVersion: PARSER_VERSION,
+    parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.SK_COURTS],
     documentAst: EMPTY_AST,
     sourceRaw: JSON.stringify({ listItem: item, detail }),
     sourceRawContentType: "application/json",

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -37,7 +37,7 @@ import { Result, panic } from "better-result";
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
-  PARSER_VERSION,
+  PARSER_VERSIONS,
 } from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import {
@@ -444,7 +444,7 @@ export const buildSkUsDecision = async (
       typeOfEntry: doc.mkTypeOfEntry,
     },
     rawHash,
-    parserVersion: PARSER_VERSION,
+    parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.SK_US],
     documentAst,
     sourceRaw: JSON.stringify(doc),
     sourceRawBytes: pdfBytes,

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
@@ -633,6 +633,52 @@ describe("parseNssDecisionHtml", () => {
       });
     });
 
+    test("does not reopen holdings for takto text quoted in reasoning", () => {
+      const html = `<html><body>
+        <p>Soud rozhodl takto:</p>
+        <p>Kasační stížnost se zamítá.</p>
+        <p>Odůvodnění:</p>
+        <p>Napadený soud rozhodl takto:</p>
+        <p>[1] Citované rozhodnutí soud přezkoumal.</p>
+        <p>Další část odůvodnění.</p>
+      </body></html>`;
+
+      const { documentAst } = parseNssDecisionHtml(baseInput(html));
+      const holdings = findAllByRole(documentAst.blocks, "holding");
+
+      expect(holdings.map((holding) => holding.plainText)).toEqual([
+        "Kasační stížnost se zamítá.",
+      ]);
+      expect(documentAst.blocks.map((block) => block.plainText)).toContain(
+        "Napadený soud rozhodl takto:",
+      );
+      expect(documentAst.blocks.map((block) => block.plainText)).toContain(
+        "Citované rozhodnutí soud přezkoumal.",
+      );
+    });
+
+    test("uses a numbered paragraph to end a holding with no separator", () => {
+      const html = `<html><body>
+        <p>Soud rozhodl takto:</p>
+        <p>Kasační stížnost se zamítá.</p>
+        <p>[1] Soud přezkoumal napadené rozhodnutí.</p>
+        <p>Další část odůvodnění.</p>
+      </body></html>`;
+
+      const { documentAst } = parseNssDecisionHtml(baseInput(html));
+      const holdings = findAllByRole(documentAst.blocks, "holding");
+
+      expect(holdings.map((holding) => holding.plainText)).toEqual([
+        "Kasační stížnost se zamítá.",
+      ]);
+      expect(documentAst.blocks.map((block) => block.plainText)).toContain(
+        "Soud přezkoumal napadené rozhodnutí.",
+      );
+      expect(documentAst.blocks.map((block) => block.plainText)).toContain(
+        "Další část odůvodnění.",
+      );
+    });
+
     test("gives every paragraph in one publisher footnote a unique anchor", () => {
       const html = `<html><body>
         <p>Text<a href="#_ftn1">[1]</a>.</p>

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
@@ -578,8 +578,8 @@ describe("parseNssDecisionHtml", () => {
       const republicTitle = documentAst.blocks.find(
         (block) => block.plainText === "JMÉNEM REPUBLIKY",
       );
-      const reference = documentAst.blocks.find(
-        (block) => block.plainText.includes("Historický text"),
+      const reference = documentAst.blocks.find((block) =>
+        block.plainText.includes("Historický text"),
       );
       const footnote = documentAst.blocks.find(
         (block) =>

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
@@ -617,20 +617,20 @@ describe("parseNssDecisionHtml", () => {
       </body></html>`;
 
       const { documentAst } = parseNssDecisionHtml(baseInput(html));
+      const inlineIntro = documentAst.blocks.find(
+        (block) => block.plainText === "Soud rozhodl takto:",
+      );
+      const holding = documentAst.blocks.find(
+        (block) => block.type === "paragraph" && block.role === "holding",
+      );
 
       expect(documentAst.blocks.map((block) => block.plainText)).toContain(
         "Soud rozhodl takto:",
       );
-      expect(
-        documentAst.blocks.find(
-          (block) => block.plainText === "Soud rozhodl takto:",
-        ),
-      ).toMatchObject({ type: "paragraph" });
-      expect(
-        documentAst.blocks.find(
-          (block) => block.type === "paragraph" && block.role === "holding",
-        ),
-      ).toMatchObject({ plainText: "I. Kasační stížnost se zamítá." });
+      expect(inlineIntro).toMatchObject({ type: "paragraph" });
+      expect(holding).toMatchObject({
+        plainText: "I. Kasační stížnost se zamítá.",
+      });
     });
 
     test("gives every paragraph in one publisher footnote a unique anchor", () => {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
@@ -176,6 +176,9 @@ describe("parseNssDecisionHtml", () => {
         <p style="text-align:center">
           <span style="font-weight:bold">ROZSUDEK</span>
         </p>
+        <p style="text-align:center">
+          <span style="font-weight:bold">J M É N E M&nbsp;&nbsp;&nbsp;&nbsp;R E P U B L I K Y</span>
+        </p>
         <p>Soud rozhodl takto:</p>
         <p style="text-align:center">
           <span style="font-weight:bold">Odůvodnění:</span>
@@ -515,6 +518,91 @@ describe("parseNssDecisionHtml", () => {
 
       const texts = documentAst.blocks.map((b) => b.plainText);
       expect(texts).not.toContain("ČESKÁ REPUBLIKA");
+    });
+  });
+
+  describe("Aspose document structure", () => {
+    test("keeps an unnumbered ruling readable and preserves linked footnotes", () => {
+      const html = `<html><body>
+        <p style="text-align:center">
+          <span style="font-weight:bold">ROZSUDEK</span>
+        </p>
+        <p style="text-align:center">
+          <span style="font-weight:bold">t a k t o :</span>
+        </p>
+        <p>
+          Usnesení soudu
+          <span style="font-weight:bold">s</span>
+          <span style="font-weight:bold">&nbsp;</span>
+          <span style="font-weight:bold">e</span>
+          <span style="font-weight:bold">&nbsp;&nbsp;&nbsp;&nbsp;</span>
+          <span style="font-weight:bold">z</span>
+          <span style="font-weight:bold">&nbsp;</span>
+          <span style="font-weight:bold">r</span>
+          <span style="font-weight:bold">&nbsp;</span>
+          <span style="font-weight:bold">u</span>
+          <span style="font-weight:bold">&nbsp;</span>
+          <span style="font-weight:bold">š</span>
+          <span style="font-weight:bold">&nbsp;</span>
+          <span style="font-weight:bold">u</span>
+          <span style="font-weight:bold">&nbsp;</span>
+          <span style="font-weight:bold">j</span>
+          <span style="font-weight:bold">&nbsp;</span>
+          <span style="font-weight:bold">e</span>.
+        </p>
+        <p style="text-align:center">
+          <span style="font-weight:bold">Odůvodnění:</span>
+        </p>
+        <p>
+          Historický text<a id="_ftnref1" href="#_ftn1">[1]</a> pokračuje.
+        </p>
+        <hr style="-aw-footnote-type:0" />
+        <div id="_ftn1" style="-aw-footnote-isauto:1">
+          <p>
+            <a href="#_ftnref1">[1]</a>
+            <span style="font-style:italic">Poznámka pod čarou.</span>
+          </p>
+        </div>
+      </body></html>`;
+
+      const { documentAst } = parseNssDecisionHtml(
+        baseInput(html, { caseNumber: "4 As 3/2008" }),
+      );
+      const holding = documentAst.blocks.find(
+        (block) => block.type === "paragraph" && block.role === "holding",
+      );
+      const republicTitle = documentAst.blocks.find(
+        (block) => block.plainText === "JMÉNEM REPUBLIKY",
+      );
+      const reference = documentAst.blocks.find(
+        (block) => block.plainText.includes("Historický text"),
+      );
+      const footnote = documentAst.blocks.find(
+        (block) =>
+          block.type === "paragraph" && block.note?.type === "footnote",
+      );
+
+      expect(republicTitle).toMatchObject({
+        type: "heading",
+        role: "decision-title",
+      });
+      expect(holding?.plainText).toContain("se zrušuje");
+      expect(holding?.inlines).toContainEqual({
+        type: "bold",
+        children: [{ type: "text", text: "se zrušuje" }],
+      });
+      expect(
+        reference?.type === "paragraph" ? reference.inlines : [],
+      ).toContainEqual({
+          type: "link",
+          href: "#_ftn1",
+          children: [{ type: "text", text: "[1]" }],
+      });
+      expect(footnote).toMatchObject({
+        anchorId: "_ftn1",
+        note: { type: "footnote", label: "1" },
+        plainText: "[1] Poznámka pod čarou.",
+      });
     });
   });
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
@@ -528,6 +528,9 @@ describe("parseNssDecisionHtml", () => {
           <span style="font-weight:bold">ROZSUDEK</span>
         </p>
         <p style="text-align:center">
+          <span style="font-weight:bold">J M É N E M&nbsp;&nbsp;&nbsp;&nbsp;R E P U B L I K Y</span>
+        </p>
+        <p style="text-align:center">
           <span style="font-weight:bold">t a k t o :</span>
         </p>
         <p>
@@ -569,7 +572,8 @@ describe("parseNssDecisionHtml", () => {
         baseInput(html, { caseNumber: "4 As 3/2008" }),
       );
       const holding = documentAst.blocks.find(
-        (block) => block.type === "paragraph" && block.role === "holding",
+        (block): block is Extract<Block, { type: "paragraph" }> =>
+          block.type === "paragraph" && block.role === "holding",
       );
       const republicTitle = documentAst.blocks.find(
         (block) => block.plainText === "JMÉNEM REPUBLIKY",
@@ -594,15 +598,63 @@ describe("parseNssDecisionHtml", () => {
       expect(
         reference?.type === "paragraph" ? reference.inlines : [],
       ).toContainEqual({
-          type: "link",
-          href: "#_ftn1",
-          children: [{ type: "text", text: "[1]" }],
+        type: "link",
+        href: "#_ftn1",
+        children: [{ type: "text", text: "[1]" }],
       });
       expect(footnote).toMatchObject({
         anchorId: "_ftn1",
         note: { type: "footnote", label: "1" },
         plainText: "[1] Poznámka pod čarou.",
       });
+    });
+
+    test("keeps inline takto prose and marks its ordered ruling as a holding", () => {
+      const html = `<html><body>
+        <p>Soud rozhodl takto:</p>
+        <ol type="I"><li>Kasační stížnost se zamítá.</li></ol>
+        <p>Odůvodnění:</p>
+      </body></html>`;
+
+      const { documentAst } = parseNssDecisionHtml(baseInput(html));
+
+      expect(documentAst.blocks.map((block) => block.plainText)).toContain(
+        "Soud rozhodl takto:",
+      );
+      expect(
+        documentAst.blocks.find(
+          (block) => block.plainText === "Soud rozhodl takto:",
+        ),
+      ).toMatchObject({ type: "paragraph" });
+      expect(
+        documentAst.blocks.find(
+          (block) => block.type === "paragraph" && block.role === "holding",
+        ),
+      ).toMatchObject({ plainText: "I. Kasační stížnost se zamítá." });
+    });
+
+    test("gives every paragraph in one publisher footnote a unique anchor", () => {
+      const html = `<html><body>
+        <p>Text<a href="#_ftn1">[1]</a>.</p>
+        <div id="_ftn1">
+          <p><a href="#_ftnref1">[1]</a> První odstavec.</p>
+          <p>Druhý odstavec.</p>
+        </div>
+      </body></html>`;
+
+      const { documentAst } = parseNssDecisionHtml(baseInput(html));
+      const footnotes = documentAst.blocks.filter(
+        (block): block is Extract<Block, { type: "paragraph" }> =>
+          block.type === "paragraph" && block.note?.type === "footnote",
+      );
+
+      expect(footnotes.map((footnote) => footnote.anchorId)).toEqual([
+        "_ftn1",
+        "_ftn1-2",
+      ]);
+      expect(new Set(footnotes.map((footnote) => footnote.anchorId)).size).toBe(
+        footnotes.length,
+      );
     });
   });
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -135,9 +135,7 @@ type PChunk = {
 const FOOTNOTE_CONTAINER_SELECTOR = "div[id^='_ftn']";
 const FOOTNOTE_ID_RE = /^_ftn(?<label>\d+)$/u;
 
-const footnoteOf = (
-  el: cheerio.Cheerio<AnyNode>,
-): PChunk["footnote"] => {
+const footnoteOf = (el: cheerio.Cheerio<AnyNode>): PChunk["footnote"] => {
   const container = el.closest(FOOTNOTE_CONTAINER_SELECTOR).first();
   const id = container.attr("id");
   const label =
@@ -469,8 +467,9 @@ const canonicalDecisionTitle = (
     : null;
 };
 
-/** "takto:" separator. */
-const TAKTO_RE = /^t\s*a\s*k\s*t\s*o\s*(?::\s*)?$/iu;
+/** "takto:" alone, or at the end of introductory prose. */
+const TAKTO_STANDALONE_RE = /^t\s*a\s*k\s*t\s*o\s*(?::\s*)?$/iu;
+const TAKTO_SUFFIX_RE = /(?:^|\s)t\s*a\s*k\s*t\s*o\s*(?::\s*)?$/iu;
 
 /** "Odůvodnění:" separator. */
 const ODUVODNENI_RE =
@@ -524,6 +523,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
   let inOduvodneni = false;
   let inPouceni = false;
   let inHolding = false;
+  const footnoteOccurrences = new Map<string, number>();
   let sawCaseNumber = false;
   let sawTitle = false;
 
@@ -542,10 +542,16 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
     }
 
     if (chunk.footnote !== null) {
+      const occurrence =
+        (footnoteOccurrences.get(chunk.footnote.anchorId) ?? 0) + 1;
+      footnoteOccurrences.set(chunk.footnote.anchorId, occurrence);
       blockIndex += 1;
       blocks.push({
         id: makeBlockId(),
-        anchorId: chunk.footnote.anchorId,
+        anchorId:
+          occurrence === 1
+            ? chunk.footnote.anchorId
+            : `${chunk.footnote.anchorId}-${occurrence}`,
         type: "paragraph",
         note: { type: "footnote", label: chunk.footnote.label },
         inlines,
@@ -595,7 +601,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
     }
 
     // "takto:" separator (centered, bold, letter-spaced)
-    if (TAKTO_RE.test(plainText)) {
+    if (TAKTO_STANDALONE_RE.test(plainText)) {
       inHolding = true;
       blockIndex += 1;
       blocks.push({
@@ -607,6 +613,22 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
         inlines: [{ type: "text", text: "takto:" }],
         plainText: "takto:",
       });
+      continue;
+    }
+
+    // Some exports keep the introductory sentence and separator in one
+    // paragraph. Preserve that prose as prose, then open the same structural
+    // zone for the ordered or unnumbered holdings that follow it.
+    if (TAKTO_SUFFIX_RE.test(plainText)) {
+      blockIndex += 1;
+      blocks.push({
+        id: makeBlockId(),
+        anchorId: makeAnchorId("p", blockIndex),
+        type: "paragraph",
+        inlines,
+        plainText,
+      });
+      inHolding = true;
       continue;
     }
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -496,6 +496,15 @@ const SECTION_HEADING_RE =
 /** Numbered paragraph: [1], [2], ... */
 const NUMBERED_PARA_RE = /^\[(?:\d+)\]\s*/u;
 
+const DOCUMENT_PHASE = {
+  PREAMBLE: "preamble",
+  HOLDING: "holding",
+  REASONING: "reasoning",
+  INSTRUCTION: "instruction",
+} as const;
+
+type DocumentPhase = (typeof DOCUMENT_PHASE)[keyof typeof DOCUMENT_PHASE];
+
 /**
  * Closing line: "V Brně dne ...", "Praha 10. březen 2026",
  * or just "City + date" pattern.
@@ -520,9 +529,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
   const blocks: Block[] = [];
   let blockIndex = 0;
 
-  let inOduvodneni = false;
-  let inPouceni = false;
-  let inHolding = false;
+  let phase: DocumentPhase = DOCUMENT_PHASE.PREAMBLE;
   const footnoteOccurrences = new Map<string, number>();
   let sawCaseNumber = false;
   let sawTitle = false;
@@ -601,8 +608,11 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
     }
 
     // "takto:" separator (centered, bold, letter-spaced)
-    if (TAKTO_STANDALONE_RE.test(plainText)) {
-      inHolding = true;
+    if (
+      phase === DOCUMENT_PHASE.PREAMBLE &&
+      TAKTO_STANDALONE_RE.test(plainText)
+    ) {
+      phase = DOCUMENT_PHASE.HOLDING;
       blockIndex += 1;
       blocks.push({
         id: makeBlockId(),
@@ -619,7 +629,10 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
     // Some exports keep the introductory sentence and separator in one
     // paragraph. Preserve that prose as prose, then open the same structural
     // zone for the ordered or unnumbered holdings that follow it.
-    if (TAKTO_SUFFIX_RE.test(plainText)) {
+    if (
+      phase === DOCUMENT_PHASE.PREAMBLE &&
+      TAKTO_SUFFIX_RE.test(plainText)
+    ) {
       blockIndex += 1;
       blocks.push({
         id: makeBlockId(),
@@ -628,14 +641,13 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
         inlines,
         plainText,
       });
-      inHolding = true;
+      phase = DOCUMENT_PHASE.HOLDING;
       continue;
     }
 
     // "Odůvodnění:" separator
     if (ODUVODNENI_RE.test(plainText)) {
-      inHolding = false;
-      inOduvodneni = true;
+      phase = DOCUMENT_PHASE.REASONING;
       blockIndex += 1;
       blocks.push({
         id: makeBlockId(),
@@ -651,8 +663,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
 
     // "Poučení:" standalone
     if (POUCENI_STANDALONE_RE.test(plainText)) {
-      inHolding = false;
-      inPouceni = true;
+      phase = DOCUMENT_PHASE.INSTRUCTION;
       blockIndex += 1;
       blocks.push({
         id: makeBlockId(),
@@ -668,8 +679,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
 
     // "Poučení:" inline (bold prefix + text in same <p>)
     if (POUCENI_INLINE_RE.test(plainText) && bold) {
-      inHolding = false;
-      inPouceni = true;
+      phase = DOCUMENT_PHASE.INSTRUCTION;
       blockIndex += 1;
       blocks.push({
         id: makeBlockId(),
@@ -732,7 +742,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
     if (
       centered &&
       plainText.length < 60 &&
-      !inPouceni &&
+      phase !== DOCUMENT_PHASE.INSTRUCTION &&
       chunks.indexOf(chunk) < chunks.length - 1
     ) {
       const nextChunk = chunks[chunks.indexOf(chunk) + 1];
@@ -753,7 +763,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
     // <ol> list items: holding paragraphs before Odůvodnění,
     // numbered paragraphs after
     if (chunk.listItemIndex !== null) {
-      if (inHolding) {
+      if (phase === DOCUMENT_PHASE.HOLDING) {
         // Reconstruct the full text with Roman numeral prefix
         const roman = `${toRoman(chunk.listItemIndex)}.`;
         const fullInlines: Inline[] = [
@@ -783,9 +793,19 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
       continue;
     }
 
+    // A numbered paragraph starts reasoning even when the publisher omitted
+    // or misspelled its separator. Keep the phase transition durable so later
+    // unnumbered reasoning cannot leak back into the holding section.
+    if (
+      phase === DOCUMENT_PHASE.HOLDING &&
+      NUMBERED_PARA_RE.test(plainText)
+    ) {
+      phase = DOCUMENT_PHASE.REASONING;
+    }
+
     // A single unnumbered výrok is a regular paragraph in Aspose HTML.
     // Its position, between the two structural separators, is definitive.
-    if (inHolding) {
+    if (phase === DOCUMENT_PHASE.HOLDING) {
       blockIndex += 1;
       blocks.push({
         id: makeBlockId(),
@@ -801,7 +821,10 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
     // Ruling items by text pattern (before Odůvodnění):
     // detected by Roman numeral prefix, emitted as holding
     // paragraphs with the full original text preserved.
-    if (!inOduvodneni && !inPouceni && RULING_ITEM_RE.test(plainText)) {
+    if (
+      phase === DOCUMENT_PHASE.PREAMBLE &&
+      RULING_ITEM_RE.test(plainText)
+    ) {
       blockIndex += 1;
       blocks.push({
         id: makeBlockId(),
@@ -817,8 +840,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
     // Section headings in Odůvodnění (centered or bold,
     // short, matching Roman numeral pattern)
     if (
-      inOduvodneni &&
-      !inPouceni &&
+      phase === DOCUMENT_PHASE.REASONING &&
       SECTION_HEADING_RE.test(plainText) &&
       plainText.length < 120
     ) {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -146,7 +146,7 @@ const footnoteOf = (el: cheerio.Cheerio<AnyNode>): PChunk["footnote"] => {
     : { anchorId: id, label };
 };
 
-const SPACED_EMPHASIS_RE = /^\s*(?:\p{L}\s+){1,}\p{L}\s*(?:[,:;.!?])?\s*$/u;
+const SPACED_EMPHASIS_RE = /^(?:\p{L} +)+\p{L}(?: *[,:;.!?])?$/u;
 const MULTI_SPACE_MARKER = "\u0000";
 
 /**
@@ -191,14 +191,14 @@ const normalizeNssInlines = (
     }
     if (node.type === "text") {
       const whitespaceNormalized = node.text.replace(/\s/gu, " ");
+      const trimmed = whitespaceNormalized.trim();
       const text =
-        spacedEmphasis && SPACED_EMPHASIS_RE.test(whitespaceNormalized)
-          ? whitespaceNormalized
-              .trim()
+        spacedEmphasis && SPACED_EMPHASIS_RE.test(trimmed)
+          ? trimmed
               .replace(/ {2,}/gu, () => MULTI_SPACE_MARKER)
               .replace(/(?<=\p{L}) (?=\p{L})/gu, "")
               .replaceAll(MULTI_SPACE_MARKER, " ")
-              .replace(/\s+([,:;.!?])/gu, "$1")
+              .replace(/(?<=\p{L}) +(?=[,:;.!?])/gu, "")
           : collapseSpacedLetters(whitespaceNormalized);
       return node.anonymized === true
         ? { type: "text", text, anonymized: true }

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -139,17 +139,14 @@ const footnoteOf = (el: cheerio.Cheerio<AnyNode>): PChunk["footnote"] => {
   const container = el.closest(FOOTNOTE_CONTAINER_SELECTOR).first();
   const id = container.attr("id");
   const label =
-    id === undefined
-      ? undefined
-      : FOOTNOTE_ID_RE.exec(id)?.groups?.["label"];
+    id === undefined ? undefined : FOOTNOTE_ID_RE.exec(id)?.groups?.["label"];
 
   return id === undefined || label === undefined
     ? null
     : { anchorId: id, label };
 };
 
-const SPACED_EMPHASIS_RE =
-  /^\s*(?:\p{L}\s+){1,}\p{L}\s*(?:[,:;.!?])?\s*$/u;
+const SPACED_EMPHASIS_RE = /^\s*(?:\p{L}\s+){1,}\p{L}\s*(?:[,:;.!?])?\s*$/u;
 const MULTI_SPACE_MARKER = "\u0000";
 
 /**
@@ -627,10 +624,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
     // Some exports keep the introductory sentence and separator in one
     // paragraph. Preserve that prose as prose, then open the same structural
     // zone for the ordered or unnumbered holdings that follow it.
-    if (
-      phase === DOCUMENT_PHASE.PREAMBLE &&
-      TAKTO_SUFFIX_RE.test(plainText)
-    ) {
+    if (phase === DOCUMENT_PHASE.PREAMBLE && TAKTO_SUFFIX_RE.test(plainText)) {
       blockIndex += 1;
       blocks.push({
         id: makeBlockId(),
@@ -794,10 +788,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
     // A numbered paragraph starts reasoning even when the publisher omitted
     // or misspelled its separator. Keep the phase transition durable so later
     // unnumbered reasoning cannot leak back into the holding section.
-    if (
-      phase === DOCUMENT_PHASE.HOLDING &&
-      NUMBERED_PARA_RE.test(plainText)
-    ) {
+    if (phase === DOCUMENT_PHASE.HOLDING && NUMBERED_PARA_RE.test(plainText)) {
       phase = DOCUMENT_PHASE.REASONING;
     }
 
@@ -819,10 +810,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
     // Ruling items by text pattern (before Odůvodnění):
     // detected by Roman numeral prefix, emitted as holding
     // paragraphs with the full original text preserved.
-    if (
-      phase === DOCUMENT_PHASE.PREAMBLE &&
-      RULING_ITEM_RE.test(plainText)
-    ) {
+    if (phase === DOCUMENT_PHASE.PREAMBLE && RULING_ITEM_RE.test(plainText)) {
       blockIndex += 1;
       blocks.push({
         id: makeBlockId(),

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -26,6 +26,8 @@
 import * as cheerio from "cheerio";
 import type { AnyNode } from "domhandler";
 
+import { collapseSpacedLetters } from "@stll/text-normalize";
+
 import type {
   Block,
   DocumentAst,
@@ -127,6 +129,106 @@ type PChunk = {
   fontSize: number;
   /** Set when the chunk comes from an <ol type="I"><li>. */
   listItemIndex: number | null;
+  footnote: { anchorId: string; label: string } | null;
+};
+
+const FOOTNOTE_CONTAINER_SELECTOR = "div[id^='_ftn']";
+const FOOTNOTE_ID_RE = /^_ftn(?<label>\d+)$/u;
+
+const footnoteOf = (
+  el: cheerio.Cheerio<AnyNode>,
+): PChunk["footnote"] => {
+  const container = el.closest(FOOTNOTE_CONTAINER_SELECTOR).first();
+  const id = container.attr("id");
+  const label =
+    id === undefined
+      ? undefined
+      : FOOTNOTE_ID_RE.exec(id)?.groups?.["label"];
+
+  return id === undefined || label === undefined
+    ? null
+    : { anchorId: id, label };
+};
+
+const SPACED_EMPHASIS_RE =
+  /^\s*(?:\p{L}\s+){1,}\p{L}\s*(?:[,:;.!?])?\s*$/u;
+const MULTI_SPACE_MARKER = "\u0000";
+
+/**
+ * Aspose expresses letter-spacing as one emphasized node per letter. Merge
+ * identical wrappers first, then recover word boundaries: one source space
+ * joins letters, while two or more source spaces separate words.
+ */
+const normalizeNssInlines = (
+  source: Inline[],
+  spacedEmphasis = false,
+): Inline[] => {
+  const merged: Inline[] = [];
+
+  for (const node of source) {
+    const previous = merged.at(-1);
+    if (node.type === "text" && previous?.type === "text") {
+      previous.text += node.text;
+      continue;
+    }
+    if (node.type === "bold" && previous?.type === "bold") {
+      previous.children.push(...node.children);
+      continue;
+    }
+    if (node.type === "italic" && previous?.type === "italic") {
+      previous.children.push(...node.children);
+      continue;
+    }
+    if (
+      node.type === "link" &&
+      previous?.type === "link" &&
+      previous.href === node.href
+    ) {
+      previous.children.push(...node.children);
+      continue;
+    }
+    merged.push(node);
+  }
+
+  return merged.map((node): Inline => {
+    if (node.type === "line-break") {
+      return node;
+    }
+    if (node.type === "text") {
+      const whitespaceNormalized = node.text.replace(/\s/gu, " ");
+      const text =
+        spacedEmphasis && SPACED_EMPHASIS_RE.test(whitespaceNormalized)
+          ? whitespaceNormalized
+              .trim()
+              .replace(/ {2,}/gu, MULTI_SPACE_MARKER)
+              .replace(/(?<=\p{L}) (?=\p{L})/gu, "")
+              .replaceAll(MULTI_SPACE_MARKER, " ")
+              .replace(/\s+([,:;.!?])/gu, "$1")
+          : collapseSpacedLetters(whitespaceNormalized);
+      return {
+        type: "text",
+        text,
+        ...(node.anonymized === true && { anonymized: true as const }),
+      };
+    }
+    if (node.type === "bold") {
+      return {
+        type: "bold",
+        children: normalizeNssInlines(node.children, true),
+      };
+    }
+    if (node.type === "italic") {
+      return {
+        type: "italic",
+        children: normalizeNssInlines(node.children, spacedEmphasis),
+      };
+    }
+    return {
+      type: "link",
+      href: node.href,
+      children: normalizeNssInlines(node.children, spacedEmphasis),
+    };
+  });
 };
 
 /** Convert a 1-based index to a Roman numeral. */
@@ -179,7 +281,7 @@ const extractChunks = ($: cheerio.CheerioAPI): PChunk[] => {
       }
 
       const style = $el.attr("style") ?? "";
-      const inlines = walkInlines($, $el);
+      const inlines = normalizeNssInlines(walkInlines($, $el));
       const plainText = inlinesToPlainText(inlines).trim();
       if (!plainText) {
         return;
@@ -203,6 +305,7 @@ const extractChunks = ($: cheerio.CheerioAPI): PChunk[] => {
         letterSpacing,
         fontSize,
         listItemIndex: null,
+        footnote: footnoteOf($el),
       });
       return;
     }
@@ -247,6 +350,7 @@ const extractChunks = ($: cheerio.CheerioAPI): PChunk[] => {
           letterSpacing: false,
           fontSize: 12,
           listItemIndex: null,
+          footnote: footnoteOf($el),
         });
       });
       return;
@@ -259,7 +363,7 @@ const extractChunks = ($: cheerio.CheerioAPI): PChunk[] => {
 
       $el.find("> li").each((_li, liEl) => {
         const $li = $(liEl);
-        const inlines = walkInlines($, $li);
+        const inlines = normalizeNssInlines(walkInlines($, $li));
         const plainText = inlinesToPlainText(inlines).trim();
 
         if (!plainText) {
@@ -275,6 +379,7 @@ const extractChunks = ($: cheerio.CheerioAPI): PChunk[] => {
           letterSpacing: false,
           fontSize: 12,
           listItemIndex: listStart,
+          footnote: footnoteOf($li),
         });
         listStart++;
       });
@@ -283,7 +388,7 @@ const extractChunks = ($: cheerio.CheerioAPI): PChunk[] => {
 
     // Regular <p>
     const style = $el.attr("style") ?? "";
-    const inlines = walkInlines($, $el);
+    const inlines = normalizeNssInlines(walkInlines($, $el));
     const plainText = inlinesToPlainText(inlines).trim();
 
     if (!plainText) {
@@ -310,6 +415,7 @@ const extractChunks = ($: cheerio.CheerioAPI): PChunk[] => {
       letterSpacing,
       fontSize,
       listItemIndex: null,
+      footnote: footnoteOf($el),
     });
   });
 
@@ -417,6 +523,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
 
   let inOduvodneni = false;
   let inPouceni = false;
+  let inHolding = false;
   let sawCaseNumber = false;
   let sawTitle = false;
 
@@ -431,6 +538,19 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
 
     // Skip decorative lines
     if (SKIP_RE.test(plainText)) {
+      continue;
+    }
+
+    if (chunk.footnote !== null) {
+      blockIndex += 1;
+      blocks.push({
+        id: makeBlockId(),
+        anchorId: chunk.footnote.anchorId,
+        type: "paragraph",
+        note: { type: "footnote", label: chunk.footnote.label },
+        inlines,
+        plainText,
+      });
       continue;
     }
 
@@ -476,6 +596,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
 
     // "takto:" separator (centered, bold, letter-spaced)
     if (TAKTO_RE.test(plainText)) {
+      inHolding = true;
       blockIndex += 1;
       blocks.push({
         id: makeBlockId(),
@@ -491,6 +612,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
 
     // "Odůvodnění:" separator
     if (ODUVODNENI_RE.test(plainText)) {
+      inHolding = false;
       inOduvodneni = true;
       blockIndex += 1;
       blocks.push({
@@ -507,6 +629,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
 
     // "Poučení:" standalone
     if (POUCENI_STANDALONE_RE.test(plainText)) {
+      inHolding = false;
       inPouceni = true;
       blockIndex += 1;
       blocks.push({
@@ -523,6 +646,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
 
     // "Poučení:" inline (bold prefix + text in same <p>)
     if (POUCENI_INLINE_RE.test(plainText) && bold) {
+      inHolding = false;
       inPouceni = true;
       blockIndex += 1;
       blocks.push({
@@ -607,7 +731,7 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
     // <ol> list items: holding paragraphs before Odůvodnění,
     // numbered paragraphs after
     if (chunk.listItemIndex !== null) {
-      if (!inOduvodneni && !inPouceni) {
+      if (inHolding) {
         // Reconstruct the full text with Roman numeral prefix
         const roman = `${toRoman(chunk.listItemIndex)}.`;
         const fullInlines: Inline[] = [
@@ -634,6 +758,21 @@ const classifyChunks = (chunks: readonly PChunk[]): Block[] => {
           plainText,
         });
       }
+      continue;
+    }
+
+    // A single unnumbered výrok is a regular paragraph in Aspose HTML.
+    // Its position, between the two structural separators, is definitive.
+    if (inHolding) {
+      blockIndex += 1;
+      blocks.push({
+        id: makeBlockId(),
+        anchorId: makeAnchorId("p", blockIndex),
+        type: "paragraph",
+        role: "holding",
+        inlines,
+        plainText,
+      });
       continue;
     }
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -198,16 +198,14 @@ const normalizeNssInlines = (
         spacedEmphasis && SPACED_EMPHASIS_RE.test(whitespaceNormalized)
           ? whitespaceNormalized
               .trim()
-              .replace(/ {2,}/gu, MULTI_SPACE_MARKER)
+              .replace(/ {2,}/gu, () => MULTI_SPACE_MARKER)
               .replace(/(?<=\p{L}) (?=\p{L})/gu, "")
               .replaceAll(MULTI_SPACE_MARKER, " ")
               .replace(/\s+([,:;.!?])/gu, "$1")
           : collapseSpacedLetters(whitespaceNormalized);
-      return {
-        type: "text",
-        text,
-        ...(node.anonymized === true && { anonymized: true as const }),
-      };
+      return node.anonymized === true
+        ? { type: "text", text, anonymized: true }
+        : { type: "text", text };
     }
     if (node.type === "bold") {
       return {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -148,8 +148,7 @@ const footnoteOf = (el: cheerio.Cheerio<AnyNode>): PChunk["footnote"] => {
     : { anchorId: id, label };
 };
 
-const SPACED_EMPHASIS_RE =
-  /^\s*(?:\p{L}\s+){1,}\p{L}\s*(?:[,:;.!?])?\s*$/u;
+const SPACED_EMPHASIS_RE = /^\s*(?:\p{L}\s+){1,}\p{L}\s*(?:[,:;.!?])?\s*$/u;
 const MULTI_SPACE_MARKER = "\u0000";
 
 /**

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -148,7 +148,8 @@ const footnoteOf = (el: cheerio.Cheerio<AnyNode>): PChunk["footnote"] => {
     : { anchorId: id, label };
 };
 
-const SPACED_EMPHASIS_RE = /^\s*(?:\p{L}\s+){1,}\p{L}\s*(?:[,:;.!?])?\s*$/u;
+const SPACED_EMPHASIS_RE =
+  /^\s*(?:\p{L}\s+){1,}\p{L}\s*(?:[,:;.!?])?\s*$/u;
 const MULTI_SPACE_MARKER = "\u0000";
 
 /**

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -149,10 +149,59 @@ const footnoteOf = (el: cheerio.Cheerio<AnyNode>): PChunk["footnote"] => {
 const SPACED_EMPHASIS_RE = /^(?:\p{L} +)+\p{L}(?: *[,:;.!?])?$/u;
 const MULTI_SPACE_MARKER = "\u0000";
 
+type SpacedBoldRun = {
+  children: Inline[];
+  endIndex: number;
+};
+
+const collectSpacedBoldRun = (
+  source: readonly Inline[],
+  startIndex: number,
+): SpacedBoldRun | null => {
+  const first = source.at(startIndex);
+  if (first?.type !== "bold") {
+    return null;
+  }
+
+  const children = [...first.children];
+  let endIndex = startIndex;
+
+  for (let index = startIndex + 1; index < source.length; index++) {
+    const node = source[index];
+    if (node?.type === "bold") {
+      children.push(...node.children);
+      endIndex = index;
+      continue;
+    }
+
+    const next = source.at(index + 1);
+    if (
+      node?.type === "text" &&
+      node.text.trim().length === 0 &&
+      next?.type === "bold"
+    ) {
+      children.push(...next.children);
+      endIndex = index + 1;
+      index += 1;
+      continue;
+    }
+    break;
+  }
+
+  if (endIndex === startIndex) {
+    return null;
+  }
+
+  const text = inlinesToPlainText(children).replace(/\s/gu, " ").trim();
+  return SPACED_EMPHASIS_RE.test(text) ? { children, endIndex } : null;
+};
+
 /**
  * Aspose expresses letter-spacing as one emphasized node per letter. Merge
- * identical wrappers first, then recover word boundaries: one source space
- * joins letters, while two or more source spaces separate words.
+ * identical wrappers first, ignoring indentation between single-letter
+ * wrappers only when their complete run proves the pattern. Then recover word
+ * boundaries: one source space joins letters, while two or more source spaces
+ * separate words.
  */
 const normalizeNssInlines = (
   source: Inline[],
@@ -160,7 +209,19 @@ const normalizeNssInlines = (
 ): Inline[] => {
   const merged: Inline[] = [];
 
-  for (const node of source) {
+  for (let index = 0; index < source.length; index++) {
+    const node = source[index];
+    if (node === undefined) {
+      continue;
+    }
+
+    const spacedBoldRun = collectSpacedBoldRun(source, index);
+    if (spacedBoldRun !== null) {
+      merged.push({ type: "bold", children: spacedBoldRun.children });
+      index = spacedBoldRun.endIndex;
+      continue;
+    }
+
     const previous = merged.at(-1);
     if (node.type === "text" && previous?.type === "text") {
       previous.text += node.text;

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -147,6 +147,7 @@ const footnoteOf = (el: cheerio.Cheerio<AnyNode>): PChunk["footnote"] => {
 };
 
 const SPACED_EMPHASIS_RE = /^(?:\p{L} +)+\p{L}(?: *[,:;.!?])?$/u;
+const SINGLE_LETTER_RE = /^\p{L}$/u;
 const MULTI_SPACE_MARKER = "\u0000";
 
 type SpacedBoldRun = {
@@ -163,29 +164,52 @@ const collectSpacedBoldRun = (
     return null;
   }
 
+  const firstText = inlinesToPlainText(first.children).replace(/\s/gu, " ");
+  if (!SINGLE_LETTER_RE.test(firstText.trim())) {
+    return null;
+  }
+
   const children = [...first.children];
   let endIndex = startIndex;
 
-  for (let index = startIndex + 1; index < source.length; index++) {
-    const node = source[index];
-    if (node?.type === "bold") {
-      children.push(...node.children);
-      endIndex = index;
-      continue;
+  while (endIndex + 1 < source.length) {
+    let separatorIndex = endIndex + 1;
+    const gapBeforeSeparator = source.at(separatorIndex);
+    if (
+      gapBeforeSeparator?.type === "text" &&
+      gapBeforeSeparator.text.trim().length === 0
+    ) {
+      separatorIndex += 1;
     }
 
-    const next = source.at(index + 1);
+    const separator = source.at(separatorIndex);
     if (
-      node?.type === "text" &&
-      node.text.trim().length === 0 &&
-      next?.type === "bold"
+      separator?.type !== "bold" ||
+      inlinesToPlainText(separator.children).trim().length !== 0
     ) {
-      children.push(...next.children);
-      endIndex = index + 1;
-      index += 1;
-      continue;
+      break;
     }
-    break;
+
+    let letterIndex = separatorIndex + 1;
+    const gapBeforeLetter = source.at(letterIndex);
+    if (
+      gapBeforeLetter?.type === "text" &&
+      gapBeforeLetter.text.trim().length === 0
+    ) {
+      letterIndex += 1;
+    }
+
+    const letter = source.at(letterIndex);
+    if (letter?.type !== "bold") {
+      break;
+    }
+    const letterText = inlinesToPlainText(letter.children).replace(/\s/gu, " ");
+    if (!SINGLE_LETTER_RE.test(letterText.trim())) {
+      break;
+    }
+
+    children.push(...separator.children, ...letter.children);
+    endIndex = letterIndex;
   }
 
   if (endIndex === startIndex) {

--- a/apps/api/src/handlers/case-law/ingestion/pipeline-refresh.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline-refresh.db.test.ts
@@ -22,10 +22,7 @@ import { drizzle } from "drizzle-orm/bun-sql";
 import { authRelationsPart } from "@/api/db/auth-schema";
 import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawDecisions, caseLawSources, relations } from "@/api/db/schema";
-import {
-  ADAPTER_KEYS,
-  PARSER_VERSIONS,
-} from "@/api/handlers/case-law/consts";
+import { ADAPTER_KEYS, PARSER_VERSIONS } from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
 import { EMPTY_AST } from "@/api/handlers/case-law/ingestion/adapter";

--- a/apps/api/src/handlers/case-law/ingestion/pipeline-refresh.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline-refresh.db.test.ts
@@ -22,7 +22,10 @@ import { drizzle } from "drizzle-orm/bun-sql";
 import { authRelationsPart } from "@/api/db/auth-schema";
 import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawDecisions, caseLawSources, relations } from "@/api/db/schema";
-import { ADAPTER_KEYS, PARSER_VERSION } from "@/api/handlers/case-law/consts";
+import {
+  ADAPTER_KEYS,
+  PARSER_VERSIONS,
+} from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
 import { EMPTY_AST } from "@/api/handlers/case-law/ingestion/adapter";
@@ -102,7 +105,7 @@ if (!databaseUrl || !runPostgresTests) {
           sections: [
             { index: 0, type: "header", title: null, text: "Rozsudok" },
           ],
-          parserVersion: PARSER_VERSION,
+          parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.SK_COURTS],
           documentUrl: "https://example.test/refresh.pdf",
           metadata: { judge: "Old Judge" },
           sourceHash: "hash-before",
@@ -151,7 +154,7 @@ if (!databaseUrl || !runPostgresTests) {
       documentUrl: "https://example.test/refresh.pdf",
       metadata: { judge: "New Judge" },
       rawHash: "hash-after",
-      parserVersion: PARSER_VERSION,
+      parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.SK_COURTS],
       documentAst: EMPTY_AST,
     });
 

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.db.test.ts
@@ -5,10 +5,7 @@ import { drizzle } from "drizzle-orm/bun-sql";
 import { authRelationsPart } from "@/api/db/auth-schema";
 import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawDecisions, caseLawSources, relations } from "@/api/db/schema";
-import {
-  ADAPTER_KEYS,
-  PARSER_VERSIONS,
-} from "@/api/handlers/case-law/consts";
+import { ADAPTER_KEYS, PARSER_VERSIONS } from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
 import { processDecision } from "@/api/handlers/case-law/ingestion/pipeline";

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.db.test.ts
@@ -5,7 +5,10 @@ import { drizzle } from "drizzle-orm/bun-sql";
 import { authRelationsPart } from "@/api/db/auth-schema";
 import type { ScopedDb } from "@/api/db/safe-db";
 import { caseLawDecisions, caseLawSources, relations } from "@/api/db/schema";
-import { ADAPTER_KEYS, PARSER_VERSION } from "@/api/handlers/case-law/consts";
+import {
+  ADAPTER_KEYS,
+  PARSER_VERSIONS,
+} from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
 import { processDecision } from "@/api/handlers/case-law/ingestion/pipeline";
@@ -65,7 +68,7 @@ const ingestionResult = {
   metadata: { source: "regression" },
   rawHash: "jsonb-regression-hash",
   documentAst,
-  parserVersion: PARSER_VERSION,
+  parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.CZ_NS],
 } satisfies IngestionResult;
 
 if (!databaseUrl || !runPostgresTests) {

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
@@ -20,7 +20,10 @@ import {
   caseLawSources,
   relations,
 } from "@/api/db/schema";
-import { ADAPTER_KEYS, PARSER_VERSION } from "@/api/handlers/case-law/consts";
+import {
+  ADAPTER_KEYS,
+  PARSER_VERSIONS,
+} from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import type { SafeId } from "@/api/lib/branded-types";
 import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/lib/legal-search/corpus-storage";
@@ -272,7 +275,9 @@ if (!databaseUrl || !runPostgresTests) {
 
       expect(row?.fulltext).toContain("Odôvodnenie");
       expect(row?.sections).toHaveLength(1);
-      expect(row?.parserVersion).toBe(PARSER_VERSION);
+      expect(row?.parserVersion).toBe(
+        PARSER_VERSIONS[ADAPTER_KEYS.SK_COURTS],
+      );
       expect(
         row?.documentAst && "blocks" in row.documentAst
           ? row.documentAst.blocks.length

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
@@ -272,9 +272,7 @@ if (!databaseUrl || !runPostgresTests) {
 
       expect(row?.fulltext).toContain("Odôvodnenie");
       expect(row?.sections).toHaveLength(1);
-      expect(row?.parserVersion).toBe(
-        PARSER_VERSIONS[ADAPTER_KEYS.SK_COURTS],
-      );
+      expect(row?.parserVersion).toBe(PARSER_VERSIONS[ADAPTER_KEYS.SK_COURTS]);
       expect(
         row?.documentAst && "blocks" in row.documentAst
           ? row.documentAst.blocks.length

--- a/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/sk-document-backfill.db.test.ts
@@ -20,10 +20,7 @@ import {
   caseLawSources,
   relations,
 } from "@/api/db/schema";
-import {
-  ADAPTER_KEYS,
-  PARSER_VERSIONS,
-} from "@/api/handlers/case-law/consts";
+import { ADAPTER_KEYS, PARSER_VERSIONS } from "@/api/handlers/case-law/consts";
 import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import type { SafeId } from "@/api/lib/branded-types";
 import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/lib/legal-search/corpus-storage";

--- a/apps/api/src/lib/case-law/document-ast.ts
+++ b/apps/api/src/lib/case-law/document-ast.ts
@@ -12,6 +12,7 @@ export type {
   InlineLink,
   InlineText,
   ParagraphBlock,
+  ParagraphNote,
   ParagraphRole,
   TableBlock,
   TableCell,

--- a/apps/api/src/lib/legal-search/ingestion-constants.ts
+++ b/apps/api/src/lib/legal-search/ingestion-constants.ts
@@ -25,6 +25,37 @@ export const ADAPTER_KEYS = {
 export type AdapterKey = (typeof ADAPTER_KEYS)[keyof typeof ADAPTER_KEYS];
 
 /**
+ * Parser output version for each source.
+ *
+ * A parser change must only make that source's rows eligible for replay. The
+ * total map makes a version decision mandatory whenever an adapter is added;
+ * a single global number would turn one publisher's markup fix into a replay
+ * of every court corpus.
+ */
+export const PARSER_VERSIONS = {
+  [ADAPTER_KEYS.CZ_REGIONAL]: 2,
+  [ADAPTER_KEYS.CZ_NS]: 2,
+  [ADAPTER_KEYS.CZ_NSS]: 3,
+  [ADAPTER_KEYS.CZ_US]: 2,
+  [ADAPTER_KEYS.SK_COURTS]: 2,
+  [ADAPTER_KEYS.SK_US]: 2,
+  [ADAPTER_KEYS.PL_COURTS]: 2,
+  [ADAPTER_KEYS.AT_COURTS]: 2,
+  [ADAPTER_KEYS.AT_VFGH]: 2,
+  [ADAPTER_KEYS.AT_VWGH]: 2,
+  [ADAPTER_KEYS.AT_BVWG]: 2,
+  [ADAPTER_KEYS.AT_LVWG]: 2,
+  [ADAPTER_KEYS.AT_ASYLGH]: 2,
+  [ADAPTER_KEYS.AT_UBAS]: 2,
+  [ADAPTER_KEYS.AT_UVS]: 2,
+  [ADAPTER_KEYS.AT_VERG]: 2,
+  [ADAPTER_KEYS.AT_UMSE]: 2,
+  [ADAPTER_KEYS.AT_BKS]: 2,
+  [ADAPTER_KEYS.AT_FINDOK]: 2,
+  [ADAPTER_KEYS.EU_ECJ]: 2,
+} as const satisfies Record<AdapterKey, number>;
+
+/**
  * The jurisdictions the corpus holds decisions for, and the union every
  * per-jurisdiction decision in the case-law slice is total over.
  *
@@ -83,13 +114,6 @@ export const CASE_LAW_SOURCE_ROWS_BOUND = 64;
 
 export const CASE_LAW_SOURCE_ROWS_INVARIANT =
   "case_law_sources is an operator-curated catalogue of at most a few dozen rows; the adapter registry is validated per row at read time, not by this bound";
-
-/**
- * Global parser version. Bump when ANY parser's AST output
- * changes. Stale decisions (parserVersion < PARSER_VERSION)
- * are re-parsed lazily from sourceRaw on next user access.
- */
-export const PARSER_VERSION = 2;
 
 /** Maximum number of pages to sync per invocation. */
 export const MAX_SYNC_PAGES = 100;

--- a/apps/api/src/lib/legal-search/sk-document-backfill.ts
+++ b/apps/api/src/lib/legal-search/sk-document-backfill.ts
@@ -70,7 +70,7 @@ import type {
 } from "@/api/lib/legal-search/corpus-storage";
 import {
   ADAPTER_KEYS,
-  PARSER_VERSION,
+  PARSER_VERSIONS,
 } from "@/api/lib/legal-search/ingestion-constants";
 import { sanitizeResult } from "@/api/lib/legal-search/ingestion-normalization";
 import { parseSkDecisionPdf } from "@/api/lib/legal-search/parsers/sk-courts";
@@ -648,7 +648,7 @@ export const storeBackfilledDocument = async ({
       .update(caseLawDecisions)
       .set({
         ...payloadColumns,
-        parserVersion: PARSER_VERSION,
+        parserVersion: PARSER_VERSIONS[ADAPTER_KEYS.SK_COURTS],
         ...corpusMirrorColumns({
           status: CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED,
           written,

--- a/apps/api/src/tests/module-mock-factories.test.ts
+++ b/apps/api/src/tests/module-mock-factories.test.ts
@@ -161,7 +161,7 @@ describe("module mock factories", () => {
 
     // consts.ts declares nothing itself; every name comes through `export *`.
     expect([...readModuleExports(constsFile, API_ROOT)]).toContain(
-      "PARSER_VERSION",
+      "PARSER_VERSIONS",
     );
   });
 

--- a/apps/web/src/components/legal-reader/document-ast-text.tsx
+++ b/apps/web/src/components/legal-reader/document-ast-text.tsx
@@ -545,6 +545,8 @@ export const BlockRenderer = ({
           "group relative mb-[var(--reader-paragraph-gap)] scroll-mt-[var(--reader-anchor-offset)] last:mb-0",
           shouldJustify && "reader-justify",
           block.role === "holding" && "font-[520]",
+          block.note?.type === "footnote" &&
+            "text-muted-foreground border-border mb-2 border-s-2 ps-4 text-[0.86em] leading-relaxed",
           isRomanNumeralDivider &&
             "mt-[var(--reader-section-gap-top)] mb-[var(--reader-section-gap-bottom)] text-center text-sm font-semibold",
           block.role === "case-number" &&

--- a/packages/legal-ast/src/document-ast.test.ts
+++ b/packages/legal-ast/src/document-ast.test.ts
@@ -217,6 +217,27 @@ describe("parseDocumentAst", () => {
     expect(parsed).toEqual(documentAst);
     expect(parsed === null ? false : isDocumentAst(parsed)).toBe(true);
   });
+
+  test("round-trips additive footnote metadata on a v1 paragraph", () => {
+    const withFootnote = {
+      ...documentAst,
+      blocks: [
+        ...documentAst.blocks,
+        {
+          id: "fn1",
+          anchorId: "_ftn1",
+          type: "paragraph",
+          note: { type: "footnote", label: "1" },
+          inlines: [{ type: "text", text: "[1] Note" }],
+          plainText: "[1] Note",
+        },
+      ],
+    } as const satisfies DocumentAst;
+
+    expect(parseDocumentAst(JSON.stringify(withFootnote))).toEqual(
+      withFootnote,
+    );
+  });
 });
 
 describe("getDocumentAstMetadata", () => {

--- a/packages/legal-ast/src/document-ast.ts
+++ b/packages/legal-ast/src/document-ast.ts
@@ -44,11 +44,21 @@ export type ParagraphRole =
   | "signature"
   | "unknown";
 
+export type ParagraphNote = {
+  type: "footnote";
+  label: string;
+};
+
 export type ParagraphBlock = {
   id: string;
   anchorId: string;
   type: "paragraph";
   role?: ParagraphRole | undefined;
+  /**
+   * Publisher-authored note metadata. Kept separate from `role`: notes can
+   * occur in any positional section.
+   */
+  note?: ParagraphNote | undefined;
   /**
    * Paragraph number assigned by the publishing court, when the source
    * numbers its paragraphs (CJEU judgments, opinions and orders do).
@@ -129,6 +139,14 @@ const blockSchema: v.GenericSchema<Block> = v.variant("type", [
         "closing",
         "signature",
         "unknown",
+      ]),
+    ),
+    note: v.optional(
+      v.variant("type", [
+        v.object({
+          type: v.literal("footnote"),
+          label: v.string(),
+        }),
       ]),
     ),
     number: v.optional(v.pipe(v.number(), v.finite())),

--- a/packages/legal-ast/src/index.ts
+++ b/packages/legal-ast/src/index.ts
@@ -31,6 +31,7 @@ export type {
   HeadingBlock,
   HeadingLevel,
   ParagraphBlock,
+  ParagraphNote,
   ParagraphRole,
   TableBlock,
   TableCell,


### PR DESCRIPTION
## Summary

- recover readable words from Aspose letter-spaced emphasis while preserving inline formatting
- classify unnumbered text between `takto` and `Odůvodnění` as the holding
- preserve publisher footnote anchors and metadata, with linked reader styling
- replace the global parser version with a total per-source version map so the repair is scoped to Czech NSS

## Evidence

The NSS Aspose HTML represents emphasized words as individually wrapped letters and identifies notes with `_ftnN` containers. The previous parser kept the visual spacing and later treated the note paragraphs as numbered body paragraphs.

## Validation

- added an Aspose-structure regression covering the decision title, unnumbered holding, inline emphasis, linked reference, and footnote
- added legal-AST schema round-trip coverage for footnote metadata
- `git diff --check`
- repository validation runs in CI

CC on behalf of sok0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for footnote metadata in legal document paragraphs.
  - Improved preservation and display of footnotes, including clearer visual styling in the document reader.
  - Added parser version tracking specific to each legal source.
  - Added the ability to reprocess stored legal documents without contacting the original publisher.

- **Bug Fixes**
  - Improved parsing of Czech Supreme Court decisions, including spaced titles, unnumbered rulings, formatting, linked footnotes and ruling boundaries.

- **Tests**
  - Added coverage for footnote preservation, document parsing and source-specific parser versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->