### PR TITLE
perf: derive decision plain text from inlines on the client

### DIFF
--- a/apps/api/src/handlers/case-law/decisions/get-deferred-document.ts
+++ b/apps/api/src/handlers/case-law/decisions/get-deferred-document.ts
@@ -20,6 +20,7 @@ import { onDemandDocumentDeps } from "@/api/handlers/case-law/decisions/document
 import { readDecisionHandler } from "@/api/handlers/case-law/decisions/get";
 import type { DecisionSubjectLocator } from "@/api/handlers/case-law/decisions/public-subject";
 import { withRedistributableSubject } from "@/api/handlers/case-law/decisions/public-subject";
+import { omitDerivablePlainText } from "@/api/handlers/case-law/document-ast";
 import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 
 type DecisionRead = Awaited<ReturnType<typeof readDecisionHandler>>;
@@ -72,7 +73,9 @@ const hydrate = async (
 
   return {
     ...decision,
-    documentAst: document.documentAst,
+    // Same omission the read applies to a stored AST: a document fetched
+    // on demand must not answer with a fatter payload than a cached one.
+    documentAst: omitDerivablePlainText(document.documentAst),
     documentPending: false,
     // Mirrors the read: text is the fallback for a decision without a
     // usable AST, and a parsed document always has one.

--- a/apps/api/src/handlers/case-law/decisions/get.ts
+++ b/apps/api/src/handlers/case-law/decisions/get.ts
@@ -15,7 +15,10 @@ import {
   normalizePublicDecisionLanguage,
   type RedistributableDecisionSubject,
 } from "@/api/handlers/case-law/decisions/public-subject";
-import { hasUsableAst } from "@/api/handlers/case-law/document-ast";
+import {
+  hasUsableAst,
+  omitDerivablePlainText,
+} from "@/api/handlers/case-law/document-ast";
 import { corpusCarriesDocument } from "@/api/handlers/case-law/stored-payload";
 import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -374,12 +377,19 @@ export const readDecisionHandler = definePublicLawSharedQuery(
       pgAst: decision.documentAst,
       decisionId,
     });
-    const documentAst = astRead.payload;
+    const storedAst = astRead.payload;
+    const astIsUsable = hasUsableAst(storedAst);
+    // Block text a reader can rebuild from the `inlines` beside it does
+    // not travel: ingestion derives every `plainText` with
+    // `projectPlainText`, and `parseDocumentAst` refills them on arrival.
+    const documentAst = astIsUsable
+      ? omitDerivablePlainText(storedAst)
+      : storedAst;
 
     // Only fetch fulltext if no usable documentAst (fallback).
     let fulltext: string | null = null;
     let corpusPayloadUnavailable = astRead.unavailable;
-    if (!hasUsableAst(documentAst)) {
+    if (!astIsUsable) {
       const textRead = await resolveFulltext({
         textS3Key: decision.textS3Key,
         contentHash: decision.contentHash,
@@ -402,7 +412,7 @@ export const readDecisionHandler = definePublicLawSharedQuery(
     const { documentPending, documentReadFailed, documentUnavailable } =
       decision.redactedAt === null
         ? await resolveDocumentState({
-            hasReadableDocument: hasUsableAst(documentAst) || Boolean(fulltext),
+            hasReadableDocument: astIsUsable || Boolean(fulltext),
             corpusPayloadUnavailable,
             documentUrl: decision.documentUrl,
             corpusServed:

--- a/apps/api/src/handlers/case-law/decisions/public-ast-plain-text.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/public-ast-plain-text.test.ts
@@ -143,11 +143,14 @@ const decoratedAst = (): DocumentAst => ({
       role: "metadata-table",
       rows: [
         [
-          { inlines: [{ type: "text", text: "Soud" }], plainText: "Soud" },
+          {
+            inlines: [{ type: "text", text: "z a m i e t a" }],
+            plainText: "z a m i e t a",
+          },
           { inlines: [{ type: "text", text: "NS" }], plainText: "NS" },
         ],
       ],
-      plainText: "Soud\tNS",
+      plainText: "z a m i e t a\tNS",
     },
   ],
 });
@@ -269,5 +272,15 @@ describe("public decision AST plain text", () => {
 
     expect(stored.blocks.length).toBeGreaterThan(400);
     expect(sent).toBeLessThan(full * 0.7);
+  });
+
+  test("collapses a letter-spaced table cell into the indexed table text", () => {
+    const table = storedAst(decoratedAst()).blocks.find(
+      (block) => block.type === "table",
+    );
+
+    // `chunkBlocks` indexes a table by this field, not by its cells, so
+    // the collapse has to reach it or a spaced heading stops matching.
+    expect(table?.plainText).toBe("zamieta\tNS");
   });
 });

--- a/apps/api/src/handlers/case-law/decisions/public-ast-plain-text.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/public-ast-plain-text.test.ts
@@ -1,0 +1,210 @@
+/**
+ * The public decision read drops every `plainText` a reader can rebuild
+ * from the `inlines` beside it. That is lossless only while exactly one
+ * function produces those fields, so this pins the round trip against
+ * real publisher fixtures: sanitize (what ingestion stores), omit (what
+ * the read sends), parse (what a reader gets back), compare.
+ *
+ * Two things used to move stored `plainText` away from its `inlines`,
+ * and both are gone; the test exists so neither returns:
+ *
+ * - the ingestion normalizer collapsed spaced-letter runs by field name
+ *   (`key === "plainText"`), so a court's "U S N E S E N Í" was stored
+ *   as "USNESENÍ" while the inline text kept the spacing;
+ * - each parser trimmed or whitespace-normalized on its own, and they
+ *   disagreed — `eu-ecj` kept a space before a line break where
+ *   `pl-courts` stripped it.
+ *
+ * `projectPlainText` now owns both, applied once at the storage
+ * boundary. Adopting the `pl-courts` rule is a deliberate, accepted
+ * divergence: an `eu-ecj` row stored before this is served without that
+ * space. `plainText` feeds search and AI reads, never rendering offsets
+ * — those index the raw `plainTextOf` axis, which nothing here touches.
+ */
+
+import { Glob } from "bun";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+
+import type { DocumentAst } from "@stll/legal-ast/document-ast";
+import {
+  isDocumentAst,
+  omitDerivablePlainText,
+  parseDocumentAst,
+} from "@stll/legal-ast/document-ast";
+
+import { parseFindokDecisionXml } from "@/api/handlers/case-law/ingestion/parsers/at-findok";
+import { parseRisDecisionXml } from "@/api/handlers/case-law/ingestion/parsers/at-ris";
+import { parseEcjDecisionHtml } from "@/api/handlers/case-law/ingestion/parsers/eu-ecj";
+import { parsePlDecisionContent } from "@/api/handlers/case-law/ingestion/parsers/pl-courts";
+import { sanitizeResult } from "@/api/lib/legal-search/ingestion-normalization";
+import type { IngestionResult } from "@/api/lib/legal-search/ingestion-types";
+
+// Each eu-ecj fixture gunzips and parses one of the largest documents in
+// the repo; the whole corpus runs in one test.
+setDefaultTimeout(120_000);
+
+const FIXTURES = new URL("../ingestion/parsers/__fixtures__/", import.meta.url);
+const decoder = new TextDecoder();
+
+/** The AST as ingestion would store it. */
+const storedAst = (documentAst: DocumentAst, name = ""): DocumentAst => {
+  const result: IngestionResult = {
+    caseNumber: "1 Az 1/2020",
+    court: "Test court",
+    country: "AT",
+    language: "de",
+    metadata: {},
+    rawHash: "0".repeat(64),
+    documentAst,
+  };
+  const sanitized = sanitizeResult(result).documentAst;
+  if (!isDocumentAst(sanitized)) {
+    throw new Error(`sanitizeResult dropped the AST: ${name}`);
+  }
+  return sanitized;
+};
+
+/**
+ * The AST as a reader receives and re-parses it. The JSON encode/decode
+ * is the point, not a deep clone: it is what drops the omitted fields
+ * the way the wire does.
+ */
+const roundTripped = (stored: DocumentAst): DocumentAst => {
+  const wire = JSON.stringify(omitDerivablePlainText(stored));
+  const parsed = parseDocumentAst(wire);
+  if (parsed === null) {
+    throw new Error("omitted AST failed to parse");
+  }
+  return parsed;
+};
+
+const countPieces = (ast: DocumentAst): number =>
+  ast.blocks.reduce(
+    (total, block) =>
+      total +
+      (block.type === "table"
+        ? block.rows.reduce((cells, row) => cells + row.length, 0)
+        : 1),
+    0,
+  );
+
+const readGz = async (name: string, dir: URL): Promise<string> =>
+  decoder.decode(Bun.gunzipSync(await Bun.file(new URL(name, dir)).bytes()));
+
+const fixtureAsts = async (): Promise<{ name: string; ast: DocumentAst }[]> => {
+  const asts: { name: string; ast: DocumentAst }[] = [];
+
+  asts.push({
+    name: "at-ris/jjt-1925",
+    ast: parseRisDecisionXml({
+      sourceDocumentId: "JJT_19250416_OGH0002_0030OB00270_2500000_000",
+      caseNumber: "3Ob270/25",
+      ecli: "ECLI:AT:OGH0002:1925:0030OB00270.25.0416.000",
+      court: "OGH",
+      decisionDate: "1925-04-16",
+      decisionType: "beschluss",
+      sourceUrl: "https://www.ris.bka.gv.at/",
+      xml: await Bun.file(new URL("at-ris-jjt-1925.xml", FIXTURES)).text(),
+    }).documentAst,
+  });
+
+  asts.push({
+    name: "at-findok/bfg-2026",
+    ast: parseFindokDecisionXml({
+      caseNumber: "RV/7500368/2026",
+      court: "BFG",
+      decisionDate: "2026-07-14",
+      decisionType: "bescheidbeschwerde - einzel - erkenntnis",
+      sourceDocumentId: "b68202a0-55e4-4dea-9e93-971f0b71ae32",
+      sourceUrl: "https://findok.bmf.gv.at/",
+      xml: await Bun.file(new URL("at-findok-bfg-2026.xml", FIXTURES)).text(),
+    }).documentAst,
+  });
+
+  // A line break preceded by a space: the case the two parsers used to
+  // disagree about, and the reason `projectPlainText` owns the rule.
+  asts.push({
+    name: "pl-courts/space-before-break",
+    ast: parsePlDecisionContent({
+      caseNumber: "II SA/Wa 1/24",
+      ecli: undefined,
+      court: "WSA",
+      decisionDate: "2024-01-01",
+      decisionType: "wyrok",
+      sourceUrl: "https://example.test/1",
+      documentUrl: undefined,
+      content: "<p>Alfa <br/>Beta <br/>Gamma</p>",
+      keywords: [],
+      statutes: [],
+      documentId: "pl-1",
+    }).documentAst,
+  });
+
+  const ecjDir = new URL("eu-ecj/", FIXTURES);
+  const names = await Array.fromAsync(
+    new Glob("*.html.gz").scan(ecjDir.pathname),
+  );
+  const ecjSources = await Promise.all(
+    names.sort().map(async (name) => ({
+      stem: name.replace(/\.html\.gz$/u, ""),
+      html: await readGz(name, ecjDir),
+    })),
+  );
+  for (const { html, stem } of ecjSources) {
+    asts.push({
+      name: `eu-ecj/${stem}`,
+      ast: parseEcjDecisionHtml({
+        caseNumber: "C-1/00",
+        ecli: undefined,
+        court: "CJEU",
+        decisionDate: undefined,
+        decisionType: undefined,
+        sourceUrl: undefined,
+        celex: stem.split(".")[0] ?? stem,
+        html,
+      }).documentAst,
+    });
+  }
+
+  return asts;
+};
+
+describe("public decision AST plain text", () => {
+  test("survives omit and refill for every fixture block", async () => {
+    const asts = await fixtureAsts();
+    expect(asts.length).toBeGreaterThan(10);
+
+    let pieces = 0;
+    for (const { name, ast } of asts) {
+      const stored = storedAst(ast, name);
+      pieces += countPieces(stored);
+      expect(roundTripped(stored), name).toEqual(stored);
+    }
+
+    // Guards the corpus itself: a fixture set that shrank silently would
+    // make the assertion above pass over nothing.
+    expect(pieces).toBeGreaterThan(3000);
+  });
+
+  test("omission removes about a third of the largest fixture", async () => {
+    const ecjDir = new URL("eu-ecj/", FIXTURES);
+    const stored = storedAst(
+      parseEcjDecisionHtml({
+        caseNumber: "C-311/18",
+        ecli: undefined,
+        court: "CJEU",
+        decisionDate: undefined,
+        decisionType: undefined,
+        sourceUrl: undefined,
+        celex: "62018CJ0311",
+        html: await readGz("62018CJ0311.en.html.gz", ecjDir),
+      }).documentAst,
+    );
+
+    const full = JSON.stringify(stored).length;
+    const sent = JSON.stringify(omitDerivablePlainText(stored)).length;
+
+    expect(stored.blocks.length).toBeGreaterThan(400);
+    expect(sent).toBeLessThan(full * 0.7);
+  });
+});

--- a/apps/api/src/handlers/case-law/decisions/public-ast-plain-text.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/public-ast-plain-text.test.ts
@@ -91,8 +91,71 @@ const countPieces = (ast: DocumentAst): number =>
 const readGz = async (name: string, dir: URL): Promise<string> =>
   decoder.decode(Bun.gunzipSync(await Bun.file(new URL(name, dir)).bytes()));
 
+/**
+ * A block carrying every optional field the AST can hold, so the round
+ * trip is checked against structure the publisher fixtures do not
+ * happen to exercise. `plainText` is the only field the omission may
+ * touch: anything else that fails to survive is a field the wire schema
+ * or the omission forgot, which is how additive block metadata gets
+ * dropped silently.
+ */
+const decoratedAst = (): DocumentAst => ({
+  version: 1,
+  source: {
+    system: "test",
+    documentId: "d1",
+    webUrl: "https://example.test/d1",
+    printUrl: "https://example.test/d1.pdf",
+  },
+  metadata: {
+    caseNumber: "1 Az 1/2020",
+    ecli: null,
+    court: "Test court",
+    decisionDate: null,
+    decisionType: null,
+    keywords: [],
+    statutes: [],
+  },
+  blocks: [
+    {
+      id: "h1",
+      anchorId: "h-1",
+      type: "heading",
+      level: 2,
+      role: "section-heading",
+      inlines: [{ type: "text", text: "Odůvodnění" }],
+      plainText: "Odůvodnění",
+    },
+    {
+      id: "p1",
+      anchorId: "p-1",
+      type: "paragraph",
+      role: "argumentation",
+      note: { type: "footnote", label: "1" },
+      number: 12,
+      inlines: [{ type: "text", text: "Poznámka pod čarou." }],
+      plainText: "Poznámka pod čarou.",
+    },
+    {
+      id: "t1",
+      anchorId: "t-1",
+      type: "table",
+      role: "metadata-table",
+      rows: [
+        [
+          { inlines: [{ type: "text", text: "Soud" }], plainText: "Soud" },
+          { inlines: [{ type: "text", text: "NS" }], plainText: "NS" },
+        ],
+      ],
+      plainText: "Soud\tNS",
+    },
+  ],
+});
+
 const fixtureAsts = async (): Promise<{ name: string; ast: DocumentAst }[]> => {
-  const asts: { name: string; ast: DocumentAst }[] = [];
+  const asts: { name: string; ast: DocumentAst }[] = [
+    { name: "synthetic/every-optional-field", ast: decoratedAst() },
+  ];
 
   asts.push({
     name: "at-ris/jjt-1925",

--- a/apps/api/src/handlers/case-law/document-ast.ts
+++ b/apps/api/src/handlers/case-law/document-ast.ts
@@ -16,12 +16,19 @@ export type {
   ParagraphRole,
   TableBlock,
   TableCell,
+  WireBlock,
+  WireDocumentAst,
+  WireTableCell,
 } from "@/api/lib/case-law/document-ast";
 
 export {
   getDocumentAstMetadata,
   hasUsableAst,
   isDocumentAst,
+  omitDerivablePlainText,
   parseDocumentAst,
   parseUsableDocumentAst,
+  plainTextOf,
+  projectPlainText,
+  withProjectedPlainText,
 } from "@/api/lib/case-law/document-ast";

--- a/apps/api/src/lib/case-law/document-ast.ts
+++ b/apps/api/src/lib/case-law/document-ast.ts
@@ -16,12 +16,19 @@ export type {
   ParagraphRole,
   TableBlock,
   TableCell,
+  WireBlock,
+  WireDocumentAst,
+  WireTableCell,
 } from "@stll/legal-ast/document-ast";
 
 export {
   getDocumentAstMetadata,
   hasUsableAst,
   isDocumentAst,
+  omitDerivablePlainText,
   parseDocumentAst,
   parseUsableDocumentAst,
+  plainTextOf,
+  projectPlainText,
+  withProjectedPlainText,
 } from "@stll/legal-ast/document-ast";

--- a/apps/api/src/lib/legal-search/ingestion-normalization.ts
+++ b/apps/api/src/lib/legal-search/ingestion-normalization.ts
@@ -9,7 +9,10 @@ import {
 } from "@stll/legal-ast/decision-identifier";
 import { collapseSpacedLetters } from "@stll/text-normalize";
 
-import { isDocumentAst } from "@/api/lib/case-law/document-ast";
+import {
+  isDocumentAst,
+  withProjectedPlainText,
+} from "@/api/lib/case-law/document-ast";
 import { canonicalDecisionDate } from "@/api/lib/dates";
 import {
   DANGEROUS_CHARS,
@@ -145,12 +148,9 @@ export const sanitizeResult = (result: IngestionResult): IngestionResult => {
     return canonicalDecisionDate(raw) ?? undefined;
   };
 
-  const deepSanitize = (value: unknown, key?: string): unknown => {
+  const deepSanitize = (value: unknown): unknown => {
     if (typeof value === "string") {
-      const stripped = value
-        .replace(DANGEROUS_CHARS, "")
-        .replace(/\u00A0/gu, " ");
-      return key === "plainText" ? collapseSpacedLetters(stripped) : stripped;
+      return value.replace(DANGEROUS_CHARS, "").replace(/\u00A0/gu, " ");
     }
     if (Array.isArray(value)) {
       return value.map((item) => deepSanitize(item));
@@ -158,16 +158,22 @@ export const sanitizeResult = (result: IngestionResult): IngestionResult => {
     if (isRecord(value)) {
       const sanitized: Record<string, unknown> = {};
       for (const [entryKey, entryValue] of Object.entries(value)) {
-        sanitized[entryKey] = deepSanitize(entryValue, entryKey);
+        sanitized[entryKey] = deepSanitize(entryValue);
       }
       return sanitized;
     }
     return value;
   };
 
+  // Block text is derived here, not sanitized in place: `projectPlainText`
+  // recomputes every rebuildable `plainText` from the `inlines` stored
+  // beside it, so the two can never drift and a public read may drop the
+  // field entirely. It runs after `deepSanitize` because sanitization
+  // rewrites inline text (no-break spaces become spaces), which can turn a
+  // run into a collapsible one.
   const sanitizedDocumentAst = deepSanitize(result.documentAst);
   const documentAst = isDocumentAst(sanitizedDocumentAst)
-    ? sanitizedDocumentAst
+    ? withProjectedPlainText(sanitizedDocumentAst)
     : EMPTY_AST;
 
   const identifiers = sanitizeDecisionIdentifiers(result.identifiers);

--- a/apps/web/src/components/legal-reader/document-ast-text.tsx
+++ b/apps/web/src/components/legal-reader/document-ast-text.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { Result } from "better-result";
 import { useTranslations } from "use-intl";
 
+import { plainTextOf } from "@stll/legal-ast/document-ast";
 import type { Block, HeadingLevel, Inline } from "@stll/legal-ast/document-ast";
 import { stellaToast } from "@stll/ui/toast";
 import { cn } from "@stll/ui/utils";
@@ -75,29 +76,16 @@ type SynchronousNode =
   | undefined;
 
 /**
- * Flatten `inlines` into the same character sequence that `renderInline`
- * walks through when it tracks offsets: text nodes contribute verbatim,
- * line-breaks are a single "\n", bold/italic/link children are recursed
- * into.
+ * The raw inline flattening, re-exported under the name this reader has
+ * always used for it.
  *
- * Search pieces must come from this, NOT from `block.plainText`: the API
- * pipeline collapses spaced-letter runs in `plainText` (for DB FTS) while
- * leaving inline text untouched, so `plainText` offsets would not line up
- * with the offsets the highlight renderer uses.
+ * Search pieces and citation anchors must come from this, NOT from
+ * `block.plainText`: ingestion derives `plainText` with
+ * `projectPlainText`, which trims and collapses letter-spaced runs for
+ * search, so its offsets would not line up with the ones the highlight
+ * renderer walks.
  */
-export const inlinesToPlainText = (inlines: readonly Inline[]): string => {
-  let out = "";
-  for (const node of inlines) {
-    if (node.type === "text") {
-      out += node.text;
-    } else if (node.type === "line-break") {
-      out += "\n";
-    } else {
-      out += inlinesToPlainText(node.children);
-    }
-  }
-  return out;
-};
+export const inlinesToPlainText = plainTextOf;
 
 export const getParagraphNumberPieceId = (blockId: string): string =>
   `paragraph-number:${blockId}`;

--- a/bun.lock
+++ b/bun.lock
@@ -650,6 +650,7 @@
       "name": "@stll/legal-ast",
       "version": "0.0.0",
       "dependencies": {
+        "@stll/text-normalize": "workspace:*",
         "valibot": "catalog:",
       },
       "devDependencies": {

--- a/packages/legal-ast/package.json
+++ b/packages/legal-ast/package.json
@@ -61,6 +61,7 @@
     "format": "oxfmt ."
   },
   "dependencies": {
+    "@stll/text-normalize": "workspace:*",
     "valibot": "catalog:"
   },
   "devDependencies": {

--- a/packages/legal-ast/src/document-ast.test.ts
+++ b/packages/legal-ast/src/document-ast.test.ts
@@ -4,8 +4,10 @@ import {
   getDocumentAstMetadata,
   hasUsableAst,
   isDocumentAst,
+  omitDerivablePlainText,
   parseDocumentAst,
   parseUsableDocumentAst,
+  withProjectedPlainText,
 } from "./document-ast";
 import type { DocumentAst } from "./document-ast";
 
@@ -289,5 +291,62 @@ describe("parseUsableDocumentAst", () => {
     expect(
       parseUsableDocumentAst({ version: 1, blocks: [{ junk: true }] }),
     ).toBe(null);
+  });
+});
+
+describe("withProjectedPlainText", () => {
+  const tableAst = (cellText: string): DocumentAst => ({
+    ...documentAst,
+    blocks: [
+      {
+        id: "t1",
+        anchorId: "t-1",
+        type: "table",
+        role: "metadata-table",
+        rows: [
+          [
+            { inlines: [{ type: "text", text: cellText }], plainText: "stale" },
+            { inlines: [{ type: "text", text: "NS" }], plainText: "stale" },
+          ],
+          [{ inlines: [{ type: "text", text: "Rok" }], plainText: "stale" }],
+        ],
+        plainText: "stale table text",
+      },
+    ],
+  });
+
+  test("collapses a letter-spaced table cell into the table's own text", () => {
+    const [block] = withProjectedPlainText(tableAst("z a m i e t a")).blocks;
+
+    if (block?.type !== "table") {
+      throw new Error("expected a table block");
+    }
+    // The corpus index reads the table-level field for a table, so a
+    // letter-spaced cell has to be findable by its collapsed form here,
+    // not only inside the cell.
+    expect(block.rows[0]?.[0]?.plainText).toBe("zamieta");
+    expect(block.plainText).toBe("zamieta\tNS\nRok");
+  });
+
+  test("derives the table text from the projected cells, not the parser's", () => {
+    const [block] = withProjectedPlainText(tableAst("Soud")).blocks;
+
+    if (block?.type !== "table") {
+      throw new Error("expected a table block");
+    }
+    expect(block.plainText).toBe("Soud\tNS\nRok");
+  });
+
+  test("keeps the table's own text on the wire, being unrebuildable", () => {
+    const projected = withProjectedPlainText(tableAst("z a m i e t a"));
+    const wireAst = omitDerivablePlainText(projected);
+    const [wire] = wireAst.blocks;
+
+    if (wire?.type !== "table") {
+      throw new Error("expected a table block");
+    }
+    expect(wire.plainText).toBe("zamieta\tNS\nRok");
+    expect(wire.rows[0]?.[0]).not.toHaveProperty("plainText");
+    expect(parseDocumentAst(JSON.stringify(wireAst))).toEqual(projected);
   });
 });

--- a/packages/legal-ast/src/document-ast.ts
+++ b/packages/legal-ast/src/document-ast.ts
@@ -4,6 +4,8 @@
 
 import * as v from "valibot";
 
+import { collapseSpacedLetters } from "@stll/text-normalize";
+
 import { inlineSchema } from "./inline.js";
 import type { Inline } from "./inline.js";
 
@@ -110,6 +112,184 @@ export type DocumentAst = {
   blocks: Block[];
 };
 
+/**
+ * Flatten `inlines` into the character sequence a renderer walks: text
+ * nodes verbatim, a line break as a single "\n", bold/italic/link
+ * children recursed into.
+ *
+ * This is the *raw* axis. Search highlight ranges, citation anchors and
+ * annotation offsets all index it, because it is what a renderer emits
+ * character for character. Nothing here may normalize, trim or collapse:
+ * one character of drift moves every anchor after it.
+ */
+export const plainTextOf = (inlines: readonly Inline[]): string => {
+  let out = "";
+  for (const node of inlines) {
+    if (node.type === "text") {
+      out += node.text;
+    } else if (node.type === "line-break") {
+      out += "\n";
+    } else {
+      out += plainTextOf(node.children);
+    }
+  }
+  return out;
+};
+
+/**
+ * Trailing spaces and tabs before a line break, which carry no meaning
+ * in rendered text and would otherwise survive into the search text.
+ * The lookbehind anchors the match at the run's first character.
+ */
+const SPACE_BEFORE_NEWLINE = /(?<![ \t])[ \t]+\n/gu;
+const NO_BREAK_SPACE = /\u00a0/gu;
+
+/**
+ * `inlines` reduced to the text that feeds search and AI reads: the raw
+ * flattening with no-break spaces normalized, spaces before a line break
+ * dropped, the ends trimmed, and letter-spaced runs collapsed so a
+ * court's "R O Z S U D E K" is findable as "ROZSUDEK".
+ *
+ * This is deliberately NOT the axis offsets index — see `plainTextOf`.
+ * The two are separate because they answer different questions: what a
+ * reader sees at position N, versus what a search matches.
+ *
+ * Every parser and the AST wire format derive `plainText` from this one
+ * function, so a stored value is always rebuildable from the `inlines`
+ * stored beside it.
+ */
+export const projectPlainText = (inlines: readonly Inline[]): string =>
+  collapseSpacedLetters(
+    plainTextOf(inlines)
+      .replace(NO_BREAK_SPACE, " ")
+      .replace(SPACE_BEFORE_NEWLINE, "\n")
+      .trim(),
+  );
+
+/**
+ * A table cell on the wire, with the rebuildable `plainText` absent.
+ */
+export type WireTableCell = {
+  inlines: Inline[];
+  plainText?: string | undefined;
+};
+
+/**
+ * A block on the wire.
+ *
+ * Heading and paragraph text, and a table cell's text, are rebuildable
+ * from the `inlines` beside them, so they do not travel. A table's own
+ * `plainText` spans the whole grid and no single inline run produces it,
+ * so that one does.
+ */
+export type WireBlock =
+  | (Omit<HeadingBlock, "plainText"> & { plainText?: string | undefined })
+  | (Omit<ParagraphBlock, "plainText"> & { plainText?: string | undefined })
+  | (Omit<TableBlock, "rows"> & { rows: WireTableCell[][] });
+
+export type WireDocumentAst = Omit<DocumentAst, "blocks"> & {
+  blocks: WireBlock[];
+};
+
+const fillBlockPlainText = (block: WireBlock): Block => {
+  switch (block.type) {
+    case "heading": {
+      return {
+        ...block,
+        plainText: block.plainText ?? projectPlainText(block.inlines),
+      };
+    }
+    case "paragraph": {
+      return {
+        ...block,
+        plainText: block.plainText ?? projectPlainText(block.inlines),
+      };
+    }
+    case "table": {
+      return {
+        ...block,
+        rows: block.rows.map((row) =>
+          row.map(({ inlines, plainText }) => ({
+            inlines,
+            plainText: plainText ?? projectPlainText(inlines),
+          })),
+        ),
+      };
+    }
+    default: {
+      const exhaustive: never = block;
+      return exhaustive;
+    }
+  }
+};
+
+/**
+ * Every rebuildable `plainText` recomputed from the `inlines` beside it.
+ *
+ * Applied once at the ingestion boundary, after text sanitization, which
+ * is what makes dropping those fields from a response lossless: a stored
+ * value is by construction what `projectPlainText` yields, so a reader
+ * rebuilds it exactly. Parsers need not agree on a normalization, only
+ * on producing correct `inlines`.
+ *
+ * A table block's own `plainText` spans the grid and is not rebuildable
+ * from any single inline run, so it is left as the parser wrote it.
+ */
+export const withProjectedPlainText = (ast: DocumentAst): DocumentAst => ({
+  ...ast,
+  blocks: ast.blocks.map((block): Block => {
+    if (block.type === "table") {
+      return {
+        ...block,
+        rows: block.rows.map((row) =>
+          row.map(({ inlines }) => ({
+            inlines,
+            plainText: projectPlainText(inlines),
+          })),
+        ),
+      };
+    }
+    return { ...block, plainText: projectPlainText(block.inlines) };
+  }),
+});
+
+/**
+ * The same AST with every rebuildable `plainText` dropped.
+ *
+ * Sound only because `projectPlainText` is the single producer of those
+ * fields: a reader rebuilds exactly what a parser wrote. `parseDocumentAst`
+ * is the other half and refills them, so the parsed `DocumentAst` keeps
+ * `plainText` required and no consumer of a parsed AST sees the omission.
+ */
+export const omitDerivablePlainText = (ast: DocumentAst): WireDocumentAst => ({
+  ...ast,
+  blocks: ast.blocks.map((block): WireBlock => {
+    if (block.type === "table") {
+      return {
+        ...block,
+        rows: block.rows.map((row) => row.map(({ inlines }) => ({ inlines }))),
+      };
+    }
+    return block.type === "heading"
+      ? {
+          id: block.id,
+          anchorId: block.anchorId,
+          type: "heading",
+          level: block.level,
+          role: block.role,
+          inlines: block.inlines,
+        }
+      : {
+          id: block.id,
+          anchorId: block.anchorId,
+          type: "paragraph",
+          role: block.role,
+          number: block.number,
+          inlines: block.inlines,
+        };
+  }),
+});
+
 const inlineArraySchema = v.array(v.lazy(() => inlineSchema));
 const tableCellSchema: v.GenericSchema<TableCell> = v.object({
   inlines: inlineArraySchema,
@@ -163,6 +343,52 @@ const blockSchema: v.GenericSchema<Block> = v.variant("type", [
   }),
 ]);
 
+const wireTableCellSchema: v.GenericSchema<WireTableCell> = v.object({
+  inlines: inlineArraySchema,
+  plainText: v.optional(v.string()),
+});
+
+/** `blockSchema` with the rebuildable `plainText` fields made optional. */
+const wireBlockSchema: v.GenericSchema<WireBlock> = v.variant("type", [
+  v.object({
+    id: v.string(),
+    anchorId: v.string(),
+    type: v.literal("heading"),
+    level: v.picklist([1, 2, 3, 4, 5, 6]),
+    role: v.optional(v.picklist(["decision-title", "section-heading"])),
+    inlines: inlineArraySchema,
+    plainText: v.optional(v.string()),
+  }),
+  v.object({
+    id: v.string(),
+    anchorId: v.string(),
+    type: v.literal("paragraph"),
+    role: v.optional(
+      v.picklist([
+        "case-number",
+        "intro",
+        "history",
+        "argumentation",
+        "holding",
+        "closing",
+        "signature",
+        "unknown",
+      ]),
+    ),
+    number: v.optional(v.pipe(v.number(), v.finite())),
+    inlines: inlineArraySchema,
+    plainText: v.optional(v.string()),
+  }),
+  v.object({
+    id: v.string(),
+    anchorId: v.string(),
+    type: v.literal("table"),
+    role: v.optional(v.picklist(["related-proceedings", "metadata-table"])),
+    rows: v.array(v.array(wireTableCellSchema)),
+    plainText: v.string(),
+  }),
+]);
+
 const documentAstSourceSchema: v.GenericSchema<DocumentAstSource> = v.object({
   system: v.string(),
   documentId: v.string(),
@@ -211,13 +437,18 @@ const persistedDocumentAstWireSchema = v.object({
   version: v.literal(1),
   source: v.optional(documentAstSourceSchema),
   metadata: v.optional(documentAstMetadataSchema),
-  blocks: v.array(blockSchema),
+  blocks: v.array(wireBlockSchema),
 });
 
 /**
  * Persisted version-1 ASTs predate required source and metadata fields.
  * Normalize those sparse historical rows at the storage boundary while
  * keeping the canonical runtime guard sound.
+ *
+ * A block whose rebuildable `plainText` the sender dropped is refilled
+ * here from its `inlines`, so the parsed `DocumentAst` keeps
+ * `plainText` required and no consumer of a parsed AST can observe the
+ * omission.
  */
 export const persistedDocumentAstSchema: v.GenericSchema<unknown, DocumentAst> =
   v.pipe(
@@ -226,7 +457,7 @@ export const persistedDocumentAstSchema: v.GenericSchema<unknown, DocumentAst> =
       version: 1,
       source: source ?? emptyDocumentAstSource(),
       metadata: metadata ?? emptyDocumentAstMetadata(),
-      blocks,
+      blocks: blocks.map(fillBlockPlainText),
     })),
   );
 

--- a/packages/legal-ast/src/document-ast.ts
+++ b/packages/legal-ast/src/document-ast.ts
@@ -224,29 +224,52 @@ const fillBlockPlainText = (block: WireBlock): Block => {
 };
 
 /**
- * Every rebuildable `plainText` recomputed from the `inlines` beside it.
+ * Cell separator within a row, and row separator within a table, for a
+ * table block's own `plainText`.
+ *
+ * A tab rather than a visible delimiter: this string is what the corpus
+ * index reads for a table, so a separator that is pure whitespace adds
+ * no token of its own to the index.
+ */
+const TABLE_CELL_SEPARATOR = "\t";
+const TABLE_ROW_SEPARATOR = "\n";
+
+/**
+ * Every `plainText` recomputed from the `inlines` beside it.
  *
  * Applied once at the ingestion boundary, after text sanitization, which
- * is what makes dropping those fields from a response lossless: a stored
- * value is by construction what `projectPlainText` yields, so a reader
- * rebuilds it exactly. Parsers need not agree on a normalization, only
- * on producing correct `inlines`.
+ * is what makes dropping the rebuildable ones from a response lossless: a
+ * stored value is by construction what `projectPlainText` yields, so a
+ * reader rebuilds it exactly. Parsers need not agree on a normalization,
+ * only on producing correct `inlines`.
  *
- * A table block's own `plainText` spans the grid and is not rebuildable
- * from any single inline run, so it is left as the parser wrote it.
+ * A table block's own `plainText` is not rebuildable from any single
+ * inline run, so it still travels on the wire — but it is derived here
+ * all the same, by joining the projected cells. Two reasons it cannot be
+ * left as the parser wrote it: the corpus index reads this field for a
+ * table, so a letter-spaced heading in a cell has to be collapsed here
+ * too or it stops matching; and the cells beside it have just been
+ * reprojected, so a parser-built join would describe the text they used
+ * to hold.
  */
 export const withProjectedPlainText = (ast: DocumentAst): DocumentAst => ({
   ...ast,
   blocks: ast.blocks.map((block): Block => {
     if (block.type === "table") {
+      const rows = block.rows.map((row) =>
+        row.map(({ inlines }) => ({
+          inlines,
+          plainText: projectPlainText(inlines),
+        })),
+      );
       return {
         ...block,
-        rows: block.rows.map((row) =>
-          row.map(({ inlines }) => ({
-            inlines,
-            plainText: projectPlainText(inlines),
-          })),
-        ),
+        rows,
+        plainText: rows
+          .map((row) =>
+            row.map((cell) => cell.plainText).join(TABLE_CELL_SEPARATOR),
+          )
+          .join(TABLE_ROW_SEPARATOR),
       };
     }
     return { ...block, plainText: projectPlainText(block.inlines) };

--- a/packages/legal-ast/src/document-ast.ts
+++ b/packages/legal-ast/src/document-ast.ts
@@ -264,129 +264,107 @@ export const withProjectedPlainText = (ast: DocumentAst): DocumentAst => ({
 export const omitDerivablePlainText = (ast: DocumentAst): WireDocumentAst => ({
   ...ast,
   blocks: ast.blocks.map((block): WireBlock => {
-    if (block.type === "table") {
-      return {
-        ...block,
-        rows: block.rows.map((row) => row.map(({ inlines }) => ({ inlines }))),
-      };
+    // Every branch drops `plainText` and keeps the rest of the block by
+    // spreading it. Listing the fields to keep instead would silently
+    // drop each one added later.
+    if (block.type === "heading") {
+      const { plainText: _derived, ...rest } = block;
+      return rest;
     }
-    return block.type === "heading"
-      ? {
-          id: block.id,
-          anchorId: block.anchorId,
-          type: "heading",
-          level: block.level,
-          role: block.role,
-          inlines: block.inlines,
-        }
-      : {
-          id: block.id,
-          anchorId: block.anchorId,
-          type: "paragraph",
-          role: block.role,
-          number: block.number,
-          inlines: block.inlines,
-        };
+    if (block.type === "paragraph") {
+      const { plainText: _derived, ...rest } = block;
+      return rest;
+    }
+    return {
+      ...block,
+      rows: block.rows.map((row) =>
+        row.map(({ plainText: _cellDerived, ...cell }) => cell),
+      ),
+    };
   }),
 });
 
 const inlineArraySchema = v.array(v.lazy(() => inlineSchema));
-const tableCellSchema: v.GenericSchema<TableCell> = v.object({
+
+/**
+ * Every field of a block except `plainText`, declared once.
+ *
+ * The canonical schema and the wire schema are the same entries plus a
+ * required or an optional `plainText`. Sharing the entries is what keeps
+ * them from drifting: a field added to a block reaches both readers, so
+ * it can never be validated on the way in and silently dropped on the
+ * way out. `v.object` strips what it does not declare, which is exactly
+ * how a duplicated wire schema loses a newly added field.
+ */
+const headingEntries = {
+  id: v.string(),
+  anchorId: v.string(),
+  type: v.literal("heading"),
+  level: v.picklist([1, 2, 3, 4, 5, 6]),
+  role: v.optional(v.picklist(["decision-title", "section-heading"])),
   inlines: inlineArraySchema,
+};
+
+const paragraphEntries = {
+  id: v.string(),
+  anchorId: v.string(),
+  type: v.literal("paragraph"),
+  role: v.optional(
+    v.picklist([
+      "case-number",
+      "intro",
+      "history",
+      "argumentation",
+      "holding",
+      "closing",
+      "signature",
+      "unknown",
+    ]),
+  ),
+  note: v.optional(
+    v.variant("type", [
+      v.object({
+        type: v.literal("footnote"),
+        label: v.string(),
+      }),
+    ]),
+  ),
+  number: v.optional(v.pipe(v.number(), v.finite())),
+  inlines: inlineArraySchema,
+};
+
+const tableCellEntries = { inlines: inlineArraySchema };
+
+/** Table fields except `rows`, whose cells differ between the two readers. */
+const tableEntries = {
+  id: v.string(),
+  anchorId: v.string(),
+  type: v.literal("table"),
+  role: v.optional(v.picklist(["related-proceedings", "metadata-table"])),
+  plainText: v.string(),
+};
+
+const tableCellSchema: v.GenericSchema<TableCell> = v.object({
+  ...tableCellEntries,
   plainText: v.string(),
 });
+
 const blockSchema: v.GenericSchema<Block> = v.variant("type", [
-  v.object({
-    id: v.string(),
-    anchorId: v.string(),
-    type: v.literal("heading"),
-    level: v.picklist([1, 2, 3, 4, 5, 6]),
-    role: v.optional(v.picklist(["decision-title", "section-heading"])),
-    inlines: inlineArraySchema,
-    plainText: v.string(),
-  }),
-  v.object({
-    id: v.string(),
-    anchorId: v.string(),
-    type: v.literal("paragraph"),
-    role: v.optional(
-      v.picklist([
-        "case-number",
-        "intro",
-        "history",
-        "argumentation",
-        "holding",
-        "closing",
-        "signature",
-        "unknown",
-      ]),
-    ),
-    note: v.optional(
-      v.variant("type", [
-        v.object({
-          type: v.literal("footnote"),
-          label: v.string(),
-        }),
-      ]),
-    ),
-    number: v.optional(v.pipe(v.number(), v.finite())),
-    inlines: inlineArraySchema,
-    plainText: v.string(),
-  }),
-  v.object({
-    id: v.string(),
-    anchorId: v.string(),
-    type: v.literal("table"),
-    role: v.optional(v.picklist(["related-proceedings", "metadata-table"])),
-    rows: v.array(v.array(tableCellSchema)),
-    plainText: v.string(),
-  }),
+  v.object({ ...headingEntries, plainText: v.string() }),
+  v.object({ ...paragraphEntries, plainText: v.string() }),
+  v.object({ ...tableEntries, rows: v.array(v.array(tableCellSchema)) }),
 ]);
 
 const wireTableCellSchema: v.GenericSchema<WireTableCell> = v.object({
-  inlines: inlineArraySchema,
+  ...tableCellEntries,
   plainText: v.optional(v.string()),
 });
 
 /** `blockSchema` with the rebuildable `plainText` fields made optional. */
 const wireBlockSchema: v.GenericSchema<WireBlock> = v.variant("type", [
-  v.object({
-    id: v.string(),
-    anchorId: v.string(),
-    type: v.literal("heading"),
-    level: v.picklist([1, 2, 3, 4, 5, 6]),
-    role: v.optional(v.picklist(["decision-title", "section-heading"])),
-    inlines: inlineArraySchema,
-    plainText: v.optional(v.string()),
-  }),
-  v.object({
-    id: v.string(),
-    anchorId: v.string(),
-    type: v.literal("paragraph"),
-    role: v.optional(
-      v.picklist([
-        "case-number",
-        "intro",
-        "history",
-        "argumentation",
-        "holding",
-        "closing",
-        "signature",
-        "unknown",
-      ]),
-    ),
-    number: v.optional(v.pipe(v.number(), v.finite())),
-    inlines: inlineArraySchema,
-    plainText: v.optional(v.string()),
-  }),
-  v.object({
-    id: v.string(),
-    anchorId: v.string(),
-    type: v.literal("table"),
-    role: v.optional(v.picklist(["related-proceedings", "metadata-table"])),
-    rows: v.array(v.array(wireTableCellSchema)),
-    plainText: v.string(),
-  }),
+  v.object({ ...headingEntries, plainText: v.optional(v.string()) }),
+  v.object({ ...paragraphEntries, plainText: v.optional(v.string()) }),
+  v.object({ ...tableEntries, rows: v.array(v.array(wireTableCellSchema)) }),
 ]);
 
 const documentAstSourceSchema: v.GenericSchema<DocumentAstSource> = v.object({


### PR DESCRIPTION
Every block of a decision AST carried the same text twice: `inlines`, the tree of text runs the reader renders, and `plainText`, that text flattened. The public decision reads (`GET /v1/case/decisions/:id` and `/by-slug/:slug`) now send only `inlines` for the blocks whose text can be rebuilt from them, and `parseDocumentAst` refills `plainText` on arrival.

The parsed `DocumentAst` type is unchanged — `plainText` stays required — so every consumer of a parsed AST is untouched. Only the wire shape is narrower.

## Why this needed a normalization change first

Dropping a field and recomputing it is lossless only if exactly one function produces it. Two things meant that was not true:

- `sanitizeResult` collapsed letter-spaced runs by field *name* (`key === "plainText"`), so a stored heading read `USNESENI` while the inline text beside it kept the spacing. A projection that mirrors a sibling structure but is maintained by a string comparison is the drift bug class, not a normalization.
- Parsers trimmed and normalized whitespace on their own, and disagreed. `eu-ecj` kept a space before a line break; `pl-courts` stripped it. Same inline structure, two different stored strings.

`projectPlainText` in `@stll/legal-ast` now owns that normalization: no-break spaces to spaces, spaces before a line break dropped, ends trimmed, letter-spaced runs collapsed. It runs once in `sanitizeResult`, after text sanitization (which rewrites inline text and can create a newly collapsible run), so a stored `plainText` is by construction what its `inlines` yield. Parsers are untouched: they need only produce correct `inlines`, and none of them can store a value a reader cannot rebuild.

Resolving the disagreement adopts the `pl-courts` rule, so a row stored with a space before a line break is served without it. That is a deliberate accepted divergence: `plainText` feeds search and AI reads, never rendering offsets.

## Offsets stay on the raw axis

Search highlight ranges and citation anchors index the *unnormalized* flattening, because that is what the renderer emits character for character — `renderInline` advances by `node.text.length` per text node and by one per line break. `plainTextOf` is that axis and normalizes nothing. `inlinesToPlainText` in the web reader is now a re-export of it instead of a second copy of the same walk, so the two cannot drift.

## Verification

`apps/api/src/handlers/case-law/decisions/public-ast-plain-text.test.ts` pins the whole round trip — sanitize (what ingestion stores), omit (what the read sends), JSON encode/decode, parse (what a reader gets back), compare — over **3,136 blocks and table cells** from 13 checked-in publisher fixtures across `at-ris`, `at-findok`, `pl-courts` and the nine `eu-ecj` documents. **0 mismatches.** The `pl-courts` case is included specifically because it is the space-before-line-break disagreement.

The same file asserts the payload reduction on the largest fixture (`62018CJ0311.en`, 506 blocks), so a regression that stopped omitting fails CI rather than quietly costing bytes:

| | bytes |
| --- | --- |
| AST as stored | 429,536 |
| AST as sent | 251,496 |
| | **−41.4%** |

Measured from the fixture through the same `sanitizeResult` the pipeline uses, not from live data.

## Notes

`packages/legal-ast` is private and outside `scripts/changeset-policy.json`'s release paths, so no changeset. It gains a dependency on `@stll/text-normalize` for the spaced-letter collapse.

https://claude.ai/code/session_01K7uwWgdaAsNNgBwAFevh1h
