### PR TITLE
fix: prevent activity timeline overlap

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.tsx
@@ -1617,7 +1617,8 @@ const ActivityTriplet = ({ detail, group, size }: ActivityTripletProps) => {
   return (
     <span
       className={cn(
-        compact ? "min-w-0 text-[13px] leading-5" : "min-w-0 text-sm leading-5",
+        "min-w-0 wrap-anywhere",
+        compact ? "text-[13px] leading-5" : "text-sm leading-5",
       )}
     >
       <span className="block min-h-5 font-medium">


### PR DESCRIPTION
## Summary

Prevent long activity text from painting into adjacent horizontal timeline milestones. Activity triplets now allow wrapping at arbitrary character boundaries while preserving the full actor, target, and provenance text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity panel text wrapping to prevent long content from overflowing.
  * Preserved compact and standard typography styling across activity entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->