### PR TITLE
fix(api): keep the stack frame of an error with no message

### DIFF
--- a/apps/api/src/lib/errors/utils.test.ts
+++ b/apps/api/src/lib/errors/utils.test.ts
@@ -201,6 +201,22 @@ describe("errorFingerprint", () => {
     expect(errorFingerprint(error)["error.frame"]).toMatch(/:\d+:\d+$/u);
   });
 
+  test("does not parse a multiline error name as an empty-message frame", () => {
+    const error = new Error(NO_MESSAGE);
+    error.name = "Error\n    at merger-secret.docx:12:34";
+    error.stack = [
+      "Error",
+      "    at merger-secret.docx:12:34",
+      "    at safeFrame (/repo/apps/api/src/lib/errors/utils.test.ts:123:45)",
+    ].join("\n");
+
+    const fingerprint = errorFingerprint(error);
+    expect(fingerprint["error.frame"]).toBeUndefined();
+    for (const value of Object.values(fingerprint)) {
+      expect(value).not.toContain("merger-secret");
+    }
+  });
+
   test("never throws on hostile Error accessors", () => {
     const error = new Error("boom");
     Object.defineProperties(error, {

--- a/apps/api/src/lib/errors/utils.test.ts
+++ b/apps/api/src/lib/errors/utils.test.ts
@@ -101,6 +101,10 @@ describe("connectionErrorFields", () => {
   });
 });
 
+// An error can be raised with no message at all; its stack header is then the
+// bare class name.
+const NO_MESSAGE = "";
+
 describe("errorFingerprint", () => {
   test("extracts the class, stable code, and a code-location frame", () => {
     const error = new TypeError("cannot read property 'x' of undefined");
@@ -168,6 +172,33 @@ describe("errorFingerprint", () => {
     for (const value of Object.values(fingerprint)) {
       expect(value).not.toContain("merger-secret");
     }
+  });
+
+  // The message never decides whether a frame is found: parsing skips exactly
+  // the message lines and keeps the first frame after them. A dropped frame
+  // costs the fingerprint the one field that separates two defects of the same
+  // class, so every message shape must reach the same frame.
+  test.each([
+    ["no message", NO_MESSAGE, "Error"],
+    ["a single-line message", "boom", "Error: boom"],
+    [
+      "a message shaped like a frame",
+      "privileged\n    at merger-secret.docx:12:34",
+      "Error: privileged\n    at merger-secret.docx:12:34",
+    ],
+  ])("finds the top frame with %s", (_shape, message, header) => {
+    const error = new Error(message);
+    error.stack = `${header}\n    at boot (/repo/apps/api/src/server.ts:12:34)`;
+    expect(errorFingerprint(error)["error.frame"]).toBe(
+      "/repo/apps/api/src/server.ts:12:34",
+    );
+  });
+
+  // The same invariant against a stack the runtime wrote, so the parser cannot
+  // pass on a synthesized header while missing the real one.
+  test("keeps the frame of an error raised without a message", () => {
+    const error = new Error(NO_MESSAGE);
+    expect(errorFingerprint(error)["error.frame"]).toMatch(/:\d+:\d+$/u);
   });
 
   test("never throws on hostile Error accessors", () => {

--- a/apps/api/src/lib/errors/utils.ts
+++ b/apps/api/src/lib/errors/utils.ts
@@ -276,6 +276,20 @@ const stackFrameLines = (error: Error, stack: string): string[] => {
     return [];
   }
 
+  if (message === "") {
+    const name = safeErrorStringProperty(error, "name");
+    if (
+      name === undefined ||
+      name.includes("\n") ||
+      name.includes("\r") ||
+      name !== errorClassName(error) ||
+      firstLine !== name
+    ) {
+      return [];
+    }
+    return lines.slice(1);
+  }
+
   const messageLines = message.split("\n");
   const firstMessageLine = messageLines.at(0);
   if (firstMessageLine && !firstLine.endsWith(firstMessageLine)) {

--- a/apps/api/src/lib/errors/utils.ts
+++ b/apps/api/src/lib/errors/utils.ts
@@ -110,40 +110,28 @@ export const safeErrorTelemetryFields = (
   return { ...fields, exitCode: String(error.exitCode) };
 };
 
+const safeErrorProperty = (error: Error, key: string): unknown => {
+  try {
+    return key in error ? Reflect.get(error, key) : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 const safeErrorStringProperty = (
   error: Error,
   key: string,
 ): string | undefined => {
-  try {
-    if (!(key in error)) {
-      return undefined;
-    }
-    const value: unknown = Reflect.get(error, key);
-    if (typeof value === "string" && value) {
-      return value;
-    }
-  } catch {
-    return undefined;
-  }
-  return undefined;
+  const value = safeErrorProperty(error, key);
+  return typeof value === "string" && value !== "" ? value : undefined;
 };
 
 const safeErrorNumberProperty = (
   error: Error,
   key: string,
 ): number | undefined => {
-  try {
-    if (!(key in error)) {
-      return undefined;
-    }
-    const value: unknown = Reflect.get(error, key);
-    if (typeof value === "number") {
-      return value;
-    }
-  } catch {
-    return undefined;
-  }
-  return undefined;
+  const value = safeErrorProperty(error, key);
+  return typeof value === "number" ? value : undefined;
 };
 
 export const safeErrorCause = (error: Error): unknown => {
@@ -159,6 +147,18 @@ export const safeErrorCode = (error: Error): string | undefined =>
 
 const safeErrorMessage = (error: Error): string | undefined =>
   safeErrorStringProperty(error, "message");
+
+/**
+ * The message exactly as the stack's own header carries it, empty string
+ * included. `safeErrorMessage` reports an empty message as absent, which is
+ * what the telemetry fields want; frame parsing needs the distinction, because
+ * an error raised without a message still has a stack whose header line is the
+ * bare class name and whose frames follow it.
+ */
+const safeErrorMessageText = (error: Error): string | undefined => {
+  const value = safeErrorProperty(error, "message");
+  return typeof value === "string" ? value : undefined;
+};
 
 const safeErrorStack = (error: Error): string | undefined =>
   safeErrorStringProperty(error, "stack");
@@ -265,7 +265,7 @@ const frameLocation = (line: string): string | undefined => {
 };
 
 const stackFrameLines = (error: Error, stack: string): string[] => {
-  const message = safeErrorMessage(error);
+  const message = safeErrorMessageText(error);
   if (message === undefined) {
     return [];
   }


### PR DESCRIPTION
## Proposed change

`stackFrameLines` in `apps/api/src/lib/errors/utils.ts` reads the message through `safeErrorStringProperty`, which reports an empty string as absent, and then returns no frames when the read comes back `undefined`. An error raised without a message therefore contributes no `error.frame` to `errorFingerprint`.

The parsing right below that read already handles an empty header line correctly: it slices off exactly the message lines and skips the header comparison when the first message line is empty. The empty-string-as-absent read is what makes that path unreachable for the case it was written for.

`error.frame` is the field that separates two failures of the same class, both in the structural fingerprint and in the suppression key `lib/analytics/capture.ts` builds from it, so every messageless error of one class currently collapses onto a single key.

Fix: read the message for frame parsing through a reader that keeps the empty string. `safeErrorStringProperty` keeps its non-empty contract, which is what the field builders want (an empty `error.msg` stays omitted). Both readers now share one guarded property read instead of repeating it.

Guards: a table test asserting the same frame is found for no message, a single-line message, and a message shaped like a frame, plus one against a stack the runtime wrote rather than a synthesized one. Both new cases fail without the change.

Checked with `bun --filter @stll/api lint`, `bun --filter @stll/api typecheck`, and the `apps/api` tests for `lib/errors`, `lib/pg-error`, `lib/analytics`, and `lib/observability`.

## Checklist

- [ ] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QmE5SHdYNUbjpaq1oVj6vu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for empty messages and messages resembling stack traces.
  * Ensured the correct first stack frame is retained across a wider range of error formats.
  * Preserved existing telemetry behaviour when errors have no meaningful message.
  * Improved handling of multiline error names during stack parsing.

* **Tests**
  * Added regression coverage for empty, single-line, stack-like, multiline, and runtime-generated error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->