### PR TITLE
fix: make corpus jurisdiction census constant-time

### DIFF
--- a/apps/api/drizzle/20260825120000_case_law_corpus_jurisdictions/migration.sql
+++ b/apps/api/drizzle/20260825120000_case_law_corpus_jurisdictions/migration.sql
@@ -1,0 +1,87 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Constant-size source of truth for the jurisdiction indexes a corpus
+-- generation must hold. The case-law table has millions of rows and only a
+-- handful of countries; SELECT DISTINCT nevertheless plans as a full parallel
+-- scan in production. This registry is derived at the write boundary instead.
+CREATE TABLE "case_law_corpus_jurisdictions" (
+  "country" varchar(3) PRIMARY KEY,
+  "first_observed_at" timestamptz DEFAULT now() NOT NULL
+);--> statement-breakpoint
+
+ALTER TABLE "case_law_corpus_jurisdictions" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "case_law_ingestion_access"
+  ON "case_law_corpus_jurisdictions"
+  AS PERMISSIVE FOR ALL TO stella_ingestion
+  USING (true) WITH CHECK (true);--> statement-breakpoint
+CREATE POLICY "case_law_global_access"
+  ON "case_law_corpus_jurisdictions"
+  AS PERMISSIVE FOR SELECT TO stella
+  USING (true);--> statement-breakpoint
+GRANT SELECT ON TABLE "case_law_corpus_jurisdictions" TO stella;--> statement-breakpoint
+GRANT SELECT, INSERT ON TABLE "case_law_corpus_jurisdictions" TO stella_ingestion;--> statement-breakpoint
+
+-- Inserts are normally batched, so register their distinct countries once per
+-- statement. Country corrections are rare and use a row trigger whose WHEN
+-- clause prevents unrelated decision updates from paying registry work.
+CREATE FUNCTION register_inserted_case_law_corpus_jurisdictions()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  INSERT INTO case_law_corpus_jurisdictions (country)
+  SELECT DISTINCT country
+  FROM inserted_decisions
+  ON CONFLICT (country) DO NOTHING;
+  RETURN NULL;
+END
+$function$;--> statement-breakpoint
+
+CREATE FUNCTION register_updated_case_law_corpus_jurisdiction()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  INSERT INTO case_law_corpus_jurisdictions (country)
+  VALUES (NEW.country)
+  ON CONFLICT (country) DO NOTHING;
+  RETURN NULL;
+END
+$function$;--> statement-breakpoint
+
+-- Install the derivation before the seed. CREATE TRIGGER's table lock closes
+-- the gap in which a concurrent decision could otherwise commit after the
+-- seed's snapshot but before future writes were observed.
+CREATE TRIGGER case_law_corpus_jurisdictions_insert
+AFTER INSERT ON "case_law_decisions"
+REFERENCING NEW TABLE AS inserted_decisions
+FOR EACH STATEMENT
+EXECUTE FUNCTION register_inserted_case_law_corpus_jurisdictions();--> statement-breakpoint
+
+CREATE TRIGGER case_law_corpus_jurisdictions_country_update
+AFTER UPDATE OF "country" ON "case_law_decisions"
+FOR EACH ROW
+WHEN (OLD.country IS DISTINCT FROM NEW.country)
+EXECUTE FUNCTION register_updated_case_law_corpus_jurisdiction();--> statement-breakpoint
+
+-- PostgreSQL otherwise chooses a sequential aggregate over the whole corpus.
+-- This loose index scan performs one case_law_decisions_country_idx seek per
+-- distinct country, so the additive migration remains bounded at corpus scale.
+WITH RECURSIVE observed_countries(country) AS (
+  SELECT min(country)
+  FROM case_law_decisions
+  UNION ALL
+  SELECT (
+    SELECT min(decision.country)
+    FROM case_law_decisions AS decision
+    WHERE decision.country > observed_countries.country
+  )
+  FROM observed_countries
+  WHERE observed_countries.country IS NOT NULL
+)
+INSERT INTO case_law_corpus_jurisdictions (country)
+SELECT country
+FROM observed_countries
+WHERE country IS NOT NULL
+ON CONFLICT (country) DO NOTHING;

--- a/apps/api/drizzle/20260825120000_case_law_corpus_jurisdictions/migration.sql
+++ b/apps/api/drizzle/20260825120000_case_law_corpus_jurisdictions/migration.sql
@@ -6,8 +6,9 @@ SET statement_timeout = '5s';--> statement-breakpoint
 -- handful of countries; SELECT DISTINCT nevertheless plans as a full parallel
 -- scan in production. This registry is derived at the write boundary instead.
 CREATE TABLE "case_law_corpus_jurisdictions" (
-  "country" varchar(3) PRIMARY KEY,
-  "first_observed_at" timestamptz DEFAULT now() NOT NULL
+  "country" varchar(3) NOT NULL,
+  "first_observed_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "case_law_corpus_jurisdictions_pkey" PRIMARY KEY ("country")
 );--> statement-breakpoint
 
 ALTER TABLE "case_law_corpus_jurisdictions" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
@@ -33,7 +34,7 @@ BEGIN
   INSERT INTO case_law_corpus_jurisdictions (country)
   SELECT DISTINCT country
   FROM inserted_decisions
-  ON CONFLICT (country) DO NOTHING;
+  ON CONFLICT ON CONSTRAINT case_law_corpus_jurisdictions_pkey DO NOTHING;
   RETURN NULL;
 END
 $function$;--> statement-breakpoint
@@ -45,7 +46,7 @@ AS $function$
 BEGIN
   INSERT INTO case_law_corpus_jurisdictions (country)
   VALUES (NEW.country)
-  ON CONFLICT (country) DO NOTHING;
+  ON CONFLICT ON CONSTRAINT case_law_corpus_jurisdictions_pkey DO NOTHING;
   RETURN NULL;
 END
 $function$;--> statement-breakpoint
@@ -68,6 +69,7 @@ EXECUTE FUNCTION register_updated_case_law_corpus_jurisdiction();--> statement-b
 -- PostgreSQL otherwise chooses a sequential aggregate over the whole corpus.
 -- This loose index scan performs one case_law_decisions_country_idx seek per
 -- distinct country, so the additive migration remains bounded at corpus scale.
+-- stella-migration-safety: reviewed bulk-backfill - the loose index scan performs one indexed min(country) seek per distinct three-letter jurisdiction rather than scanning case_law_decisions; it inserts at most the bounded jurisdiction-code domain into a new empty registry and is idempotent.
 WITH RECURSIVE observed_countries(country) AS (
   SELECT min(country)
   FROM case_law_decisions
@@ -84,4 +86,4 @@ INSERT INTO case_law_corpus_jurisdictions (country)
 SELECT country
 FROM observed_countries
 WHERE country IS NOT NULL
-ON CONFLICT (country) DO NOTHING;
+ON CONFLICT ON CONSTRAINT case_law_corpus_jurisdictions_pkey DO NOTHING;

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -253,6 +253,24 @@ export const caseLawSources = p.pgTable(
   ],
 );
 
+/**
+ * Jurisdictions ever observed in the case-law corpus.
+ *
+ * A migration-owned trigger derives this registry from decision writes. Census
+ * reads it instead of scanning the multi-million-row decision table merely to
+ * rediscover a handful of country codes. Rows are intentionally append-only:
+ * an emptied jurisdiction still names an index whose surplus must remain
+ * visible to the rollout gate.
+ */
+export const caseLawCorpusJurisdictions = p.pgTable(
+  "case_law_corpus_jurisdictions",
+  {
+    country: p.varchar({ length: 3 }).primaryKey(),
+    firstObservedAt: timestamptz("first_observed_at").defaultNow().notNull(),
+  },
+  () => [...globalCaseLawPolicies()],
+);
+
 export const caseLawDecisions = p.pgTable(
   "case_law_decisions",
   {

--- a/apps/api/src/lib/corpus-index/census-jurisdictions.db.test.ts
+++ b/apps/api/src/lib/corpus-index/census-jurisdictions.db.test.ts
@@ -1,0 +1,68 @@
+import { PGlite } from "@electric-sql/pglite";
+import { expect, test } from "bun:test";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import type { ScopedDb } from "@/api/db/safe-db";
+import { listCaseLawJurisdictions } from "@/api/lib/corpus-index/census";
+
+const MIGRATION = new URL(
+  "../../../drizzle/20260825120000_case_law_corpus_jurisdictions/migration.sql",
+  import.meta.url,
+);
+const STATEMENT_BREAKPOINT = "--> statement-breakpoint";
+
+test("the jurisdiction registry is seeded and remains derived at the decision write boundary", async () => {
+  const client = await PGlite.create();
+  try {
+    await client.exec(`
+      CREATE ROLE stella;
+      CREATE ROLE stella_ingestion;
+      CREATE TABLE case_law_decisions (
+        id uuid PRIMARY KEY,
+        country varchar(3) NOT NULL
+      );
+      CREATE INDEX case_law_decisions_country_idx
+        ON case_law_decisions (country);
+      INSERT INTO case_law_decisions (id, country) VALUES
+        ('00000000-0000-4000-8000-000000000001', 'CZE'),
+        ('00000000-0000-4000-8000-000000000002', 'POL'),
+        ('00000000-0000-4000-8000-000000000003', 'CZE');
+    `);
+    const migration = (await Bun.file(MIGRATION).text()).replaceAll(
+      STATEMENT_BREAKPOINT,
+      "",
+    );
+    await client.exec(migration);
+
+    await client.exec(`
+      INSERT INTO case_law_decisions (id, country) VALUES
+        ('00000000-0000-4000-8000-000000000004', 'SVK'),
+        ('00000000-0000-4000-8000-000000000005', 'EU');
+      UPDATE case_law_decisions
+      SET country = 'AUT'
+      WHERE id = '00000000-0000-4000-8000-000000000005';
+      DELETE FROM case_law_decisions;
+    `);
+
+    const db = drizzle({ client });
+    const handle = async (callback: (tx: Transaction) => Promise<unknown>) =>
+      // SAFETY: PGlite's Drizzle handle supplies the read-only transaction
+      // surface used by listCaseLawJurisdictions.
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- embedded database stands in for the scoped handle
+      await callback(db as unknown as Transaction);
+    // SAFETY: ScopedDb is a brand over the callback shape above.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test-only scoped handle
+    const scopedDb = handle as unknown as ScopedDb;
+
+    expect(await listCaseLawJurisdictions(scopedDb)).toEqual([
+      "AUT",
+      "CZE",
+      "EU",
+      "POL",
+      "SVK",
+    ]);
+  } finally {
+    await client.close();
+  }
+});

--- a/apps/api/src/lib/corpus-index/census-jurisdictions.db.test.ts
+++ b/apps/api/src/lib/corpus-index/census-jurisdictions.db.test.ts
@@ -4,7 +4,7 @@ import { drizzle } from "drizzle-orm/pglite";
 
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
-import { caseLawCorpusJurisdictions } from "@/api/db/schema/case-law";
+import { caseLawCorpusJurisdictions } from "@/api/db/schema";
 import { listCaseLawJurisdictions } from "@/api/lib/corpus-index/census";
 
 const MIGRATION = new URL(
@@ -68,7 +68,7 @@ test("the jurisdiction registry is seeded and remains derived at the decision wr
       const first = Math.floor(index / (26 * 26));
       const second = Math.floor(index / 26) % 26;
       const third = index % 26;
-      return String.fromCharCode(65 + first, 65 + second, 65 + third);
+      return String.fromCodePoint(65 + first, 65 + second, 65 + third);
     });
     await db
       .insert(caseLawCorpusJurisdictions)

--- a/apps/api/src/lib/corpus-index/census-jurisdictions.db.test.ts
+++ b/apps/api/src/lib/corpus-index/census-jurisdictions.db.test.ts
@@ -4,6 +4,7 @@ import { drizzle } from "drizzle-orm/pglite";
 
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
+import { caseLawCorpusJurisdictions } from "@/api/db/schema/case-law";
 import { listCaseLawJurisdictions } from "@/api/lib/corpus-index/census";
 
 const MIGRATION = new URL(
@@ -62,6 +63,21 @@ test("the jurisdiction registry is seeded and remains derived at the decision wr
       "POL",
       "SVK",
     ]);
+
+    const overflowJurisdictions = Array.from({ length: 257 }, (_, index) => {
+      const first = Math.floor(index / (26 * 26));
+      const second = Math.floor(index / 26) % 26;
+      const third = index % 26;
+      return String.fromCharCode(65 + first, 65 + second, 65 + third);
+    });
+    await db
+      .insert(caseLawCorpusJurisdictions)
+      .values(overflowJurisdictions.map((country) => ({ country })))
+      .onConflictDoNothing();
+
+    expect(listCaseLawJurisdictions(scopedDb)).rejects.toThrow(
+      "exceeds the 256 jurisdiction census ceiling",
+    );
   } finally {
     await client.close();
   }

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -148,13 +148,11 @@ const databaseHolding = (
           ];
         } else if ("opstamp" in selection && deleteOpstamp !== undefined) {
           rows = [{ opstamp: deleteOpstamp }];
+        } else if ("country" in selection) {
+          rows = (jurisdictions ?? []).map((country) => ({ country }));
         } else {
           rows = [];
         }
-        return chain;
-      },
-      selectDistinct: () => {
-        rows = (jurisdictions ?? []).map((country) => ({ country }));
         return chain;
       },
     };

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -32,7 +32,7 @@
  * it.
  */
 
-import { Result, TaggedError } from "better-result";
+import { Result, TaggedError, panic } from "better-result";
 import {
   and,
   asc,
@@ -58,6 +58,7 @@ import {
   caseLawCorpusIndexDeleteWatermarks,
   caseLawCorpusIndexPendingDeletes,
   caseLawCorpusIndexProjections,
+  caseLawCorpusJurisdictions,
   caseLawDecisions,
 } from "@/api/db/schema";
 import { errorTag } from "@/api/lib/errors/error-tag";
@@ -626,11 +627,16 @@ export const listCaseLawJurisdictions = async (
 ): Promise<string[]> => {
   const rows = await scopedDb((tx) =>
     tx
-      .selectDistinct({ country: caseLawDecisions.country })
-      .from(caseLawDecisions)
-      .orderBy(caseLawDecisions.country)
-      .limit(MAX_CENSUSED_JURISDICTIONS),
+      .select({ country: caseLawCorpusJurisdictions.country })
+      .from(caseLawCorpusJurisdictions)
+      .orderBy(caseLawCorpusJurisdictions.country)
+      .limit(MAX_CENSUSED_JURISDICTIONS + 1),
   );
+  if (rows.length > MAX_CENSUSED_JURISDICTIONS) {
+    return panic(
+      `Case-law corpus exceeds the ${MAX_CENSUSED_JURISDICTIONS} jurisdiction census ceiling`,
+    );
+  }
   return rows.map(({ country }) => country);
 };
 

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -618,9 +618,9 @@ export const reportIndexCensus = ({
 const MAX_CENSUSED_JURISDICTIONS = 256;
 
 /**
- * Jurisdictions the corpus holds. Read from the decisions themselves
- * rather than from a hand-kept list, so a new country's index cannot be
- * uncensused because nobody remembered to add it.
+ * Jurisdictions the corpus has ever held. The write-boundary-derived registry
+ * keeps the read constant-size without becoming a hand-maintained list, so a
+ * new country's index cannot be uncensused because nobody remembered to add it.
  */
 export const listCaseLawJurisdictions = async (
   scopedDb: ScopedDb,

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -66,6 +66,9 @@ const POST_BOOTSTRAP_SELECT_ONLY_TABLES = new Set([
   // and the bounded seed worker; request handlers may observe its status.
   "case_law_corpus_index_counts",
   "case_law_corpus_index_count_backfills",
+  // Append-only ingestion registry: request code reads the bounded country
+  // set for census; decision-write triggers are its only writer.
+  "case_law_corpus_jurisdictions",
   "case_law_corpus_index_delete_watermarks",
   "legislation_sources",
   "legislation_documents",


### PR DESCRIPTION
## Summary

- derive an append-only jurisdiction registry from case-law decision writes
- seed the registry with a loose index scan instead of a full corpus aggregate
- make corpus census read the bounded registry and fail if its ceiling is exceeded

## Verification

- added a database test covering migration seeding, batched inserts, country updates, and retained empty-jurisdiction visibility
- local secret scan passed
- lint, format, typecheck, and tests are delegated to CI

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a maintained registry of jurisdictions represented in the case law corpus.
  * Jurisdictions are automatically recorded when decisions are added or updated.
  * Census results now use the registry for faster, more reliable jurisdiction discovery.
  * Added validation when the number of jurisdictions exceeds the supported limit.

* **Bug Fixes**
  * Ensured jurisdictions remain visible in census results even when their associated decisions are later removed.

* **Tests**
  * Added coverage for jurisdiction tracking across inserts, updates and deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->