### PR TITLE
fix: negative polarity cues must name the cited decision

### DIFF
--- a/apps/api/scripts/classify-citations.ts
+++ b/apps/api/scripts/classify-citations.ts
@@ -13,11 +13,14 @@
  *   --language cs  Only process citations in this language
  *   --seed         Seed initial polarity rules before classifying
  *   --dry-run      Classify but don't persist results
+ *   --ids FILE     Only the citation ids in FILE (a JSON array), all of them:
+ *                  the set `seed-polarity-rules.ts` writes when it retires a
+ *                  rule. Overrides --limit.
  *
  * Idempotent: only processes citations with NULL polarity.
  */
 
-import { and, desc, eq, isNull } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 
 import { rootDb, rlsDb } from "@/api/db/root";
 import {
@@ -35,12 +38,14 @@ import { RULE_SOURCE } from "@/api/handlers/case-law/polarity/consts";
 import type { RuleCache } from "@/api/handlers/case-law/polarity/rule-engine";
 import { SEED_RULES } from "@/api/handlers/case-law/polarity/seed-rules";
 import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
 
 type Args = {
   limit: number;
   language: string | null;
   seed: boolean;
   dryRun: boolean;
+  idsFile: string | null;
 };
 
 const parseArgs = (): Args => {
@@ -50,6 +55,7 @@ const parseArgs = (): Args => {
     language: null,
     seed: false,
     dryRun: false,
+    idsFile: null,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -68,10 +74,25 @@ const parseArgs = (): Args => {
       result.seed = true;
     } else if (args[i] === "--dry-run") {
       result.dryRun = true;
+    } else if (args[i] === "--ids" && next) {
+      result.idsFile = next;
+      i++;
     }
   }
 
   return result;
+};
+
+/** The ids a retirement wrote; anything but a list of ids is a wrong file. */
+const readIdsFile = async (
+  path: string,
+): Promise<SafeId<"caseLawCitation">[]> => {
+  const raw: unknown = await Bun.file(path).json();
+  if (!Array.isArray(raw) || !raw.every((id) => typeof id === "string")) {
+    console.error(`Expected a JSON array of citation ids in ${path}`);
+    process.exit(1);
+  }
+  return raw.map((id) => toSafeId<"caseLawCitation">(id));
 };
 
 const seedRules = async () => {
@@ -113,6 +134,12 @@ const main = async () => {
   if (args.language) {
     conditions.push(eq(caseLawDecisions.language, args.language));
   }
+  const onlyIds =
+    args.idsFile === null ? null : await readIdsFile(args.idsFile);
+  if (onlyIds !== null) {
+    conditions.push(inArray(caseLawCitations.id, onlyIds));
+  }
+  const limit = onlyIds === null ? args.limit : onlyIds.length;
 
   // Fetch unclassified citations with their decision context
   const citations = await rootDb
@@ -130,7 +157,7 @@ const main = async () => {
     )
     .where(and(...conditions))
     .orderBy(desc(caseLawCitations.createdAt))
-    .limit(args.limit);
+    .limit(limit);
 
   if (citations.length === 0) {
     console.log("No unclassified citations found.");

--- a/apps/api/scripts/classify-citations.ts
+++ b/apps/api/scripts/classify-citations.ts
@@ -74,7 +74,13 @@ const parseArgs = (): Args => {
       result.seed = true;
     } else if (args[i] === "--dry-run") {
       result.dryRun = true;
-    } else if (args[i] === "--ids" && next) {
+    } else if (args[i] === "--ids") {
+      // Without the file the run would fall back to the newest unclassified
+      // rows and classify the wrong set: refuse rather than guess.
+      if (!next) {
+        console.error("Missing file path after --ids");
+        process.exit(1);
+      }
       result.idsFile = next;
       i++;
     }

--- a/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
@@ -117,6 +117,9 @@ describe("seed rules", () => {
     const testCases = [
       "na rozdíl od předchozího rozhodnutí",
       "tento závěr byl překonán",
+      "bez dalšího nelze aplikovat ani dovolatelkou zmiňovaný rozsudek Nejvyššího soudu",
+      "v této věci nelze aplikovat závěry vyplývající z rozsudků",
+      "na daný případ nelze aplikovat rozsudek Nejvyššího soudu",
     ];
 
     for (const text of testCases) {
@@ -124,6 +127,43 @@ describe("seed rules", () => {
         new RegExp(r.pattern, "iu").test(text),
       );
       expect(matched).toBe(true);
+    }
+  });
+
+  /**
+   * Windows from the corpus in which a negative cue speaks of a party, a
+   * court or a statute, next to a citation the court relies on. A negative
+   * rule that fires on any of these labels an authority as overruled; the
+   * class of defect is a cue without the cited decision as its object.
+   */
+  test("Czech negative rules stay silent where the cue is not about the cited decision", () => {
+    const negativeRules = SEED_RULES.filter(
+      (r) => r.language === "cs" && r.polarity === "negative",
+    );
+
+    const windows = [
+      "Takovým postupem by přestal být nestranným rozhodčím sporu (viz např. rozsudek rozšířeného senátu Nejvyššího správního soudu ze dne 24. 8. 2010, č. j. 4 As 3/2008 – 78). Zcela obecné žalobní body tedy soud vypořádává se stejnou mírou obecnosti.",
+      "V tomto směru podle názoru krajského soudu neobstojí odvolací námitka nedoručení výměru odůvodněná tvrzením, že povinná v jiné věci (sp. zn. 26 E 1519/1997) předložila generální plnou moc.",
+      "Rovněž tak neobstojí jiné vyjádření, které ukazuje na značnou nejistotu souvislosti chybného postupu s nastalým stavem.",
+      "Neobstojí ani případná argumentace, že se jednalo o vyjádření svobodné vůle účastníků s důsledky pacta sunt servanda.",
+      "Pouhá paragrafová či slovní citace některého zákonného ustanovení jako stížní bod neobstojí.",
+      "neboť ten, kdo odebíral plyn, na rozdíl od povinného, neměl uzavřenou žádnou smlouvu o odběru.",
+      "nemá důvodu pochybovat o pravdivosti jeho tvrzení, neboť na rozdíl od stěžovatele nemá na výsledku řízení zájem.",
+      "odvolací soud (na rozdíl od soudu prvního stupně) neuzavřel, že by nárok byl promlčen.",
+      "Leasingovým společnostem, byť jsou vlastníky předmětu leasingu, na rozdíl od nájemního vztahu nezáleží na tom, zda leasingoví nájemci zhodnocují předmět leasingu.",
+      "postup k odstranění pochybností nelze na rozdíl od daňové kontroly použít pro namátkové prošetření tvrzení daňového subjektu.",
+      "Rozhodnutí odvolacího soudu o tom, že na posuzovanou věc nelze aplikovat § 1765 odst. 1 o. z., spočívá na závěrech, podle nichž závazek zanikl.",
+      "nález Ústavního soudu vydaný v listopadu 2008 nelze aplikovat na daňovou kontrolu zahájenou v březnu téhož roku.",
+    ];
+
+    for (const text of windows) {
+      const fired = negativeRules.filter((r) =>
+        new RegExp(r.pattern, "iu").test(text),
+      );
+      expect({ text, fired: fired.map((r) => r.pattern) }).toEqual({
+        text,
+        fired: [],
+      });
     }
   });
 

--- a/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
@@ -120,6 +120,8 @@ describe("seed rules", () => {
       "bez dalšího nelze aplikovat ani dovolatelkou zmiňovaný rozsudek Nejvyššího soudu",
       "v této věci nelze aplikovat závěry vyplývající z rozsudků",
       "na daný případ nelze aplikovat rozsudek Nejvyššího soudu",
+      "tento rozsudek však nelze aplikovat",
+      "závěry citovaného usnesení nelze aplikovat na projednávanou věc",
     ];
 
     for (const text of testCases) {
@@ -154,6 +156,8 @@ describe("seed rules", () => {
       "postup k odstranění pochybností nelze na rozdíl od daňové kontroly použít pro namátkové prošetření tvrzení daňového subjektu.",
       "Rozhodnutí odvolacího soudu o tom, že na posuzovanou věc nelze aplikovat § 1765 odst. 1 o. z., spočívá na závěrech, podle nichž závazek zanikl.",
       "nález Ústavního soudu vydaný v listopadu 2008 nelze aplikovat na daňovou kontrolu zahájenou v březnu téhož roku.",
+      "Ustanovení § 1765 o. z. nelze aplikovat na daný případ (srov. rozsudek Nejvyššího soudu ze dne 11. 4. 2018, sp. zn. 31 Cdo 927/2016).",
+      "Na rozdíl od situace v projednávané věci šlo o jednostranný zápočet; k tomu srov. rozsudek Nejvyššího soudu sp. zn. 31 Cdo 927/2016.",
     ];
 
     for (const text of windows) {
@@ -165,6 +169,25 @@ describe("seed rules", () => {
         fired: [],
       });
     }
+  });
+
+  /**
+   * A positive cue and a negative one in one window, the negative about the
+   * cited decision: negative wins precedence, so the negative rule has to
+   * fire or the retired cue's loss turns an inapplicable citation positive.
+   */
+  test("a decision named before the negative cue is still read as negative", () => {
+    const rules = compileRules(
+      SEED_RULES.filter((r) => r.language === "cs").map((r) => ({
+        id: createSafeId<"caseLawPolarityRule">(),
+        pattern: r.pattern,
+        polarity: r.polarity,
+        confidence: 1,
+      })),
+    );
+    const context =
+      "Dovolatel odkazuje na rozsudek Nejvyššího soudu ze dne 25. 11. 2008, sp. zn. 22 Cdo 3554/2008; tento rozsudek však nelze aplikovat, neboť vychází z jiných skutkových okolností.";
+    expect(selectRuleMatch(rules, context)?.polarity).toBe(POLARITY.NEGATIVE);
   });
 
   test("Czech supportive rules match expected phrases", () => {

--- a/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/polarity-classifier.test.ts
@@ -158,6 +158,8 @@ describe("seed rules", () => {
       "nález Ústavního soudu vydaný v listopadu 2008 nelze aplikovat na daňovou kontrolu zahájenou v březnu téhož roku.",
       "Ustanovení § 1765 o. z. nelze aplikovat na daný případ (srov. rozsudek Nejvyššího soudu ze dne 11. 4. 2018, sp. zn. 31 Cdo 927/2016).",
       "Na rozdíl od situace v projednávané věci šlo o jednostranný zápočet; k tomu srov. rozsudek Nejvyššího soudu sp. zn. 31 Cdo 927/2016.",
+      "Na rozdíl od krajského soudu, jehož rozsudek ze dne 3. 5. 2019 vycházel z jiného skutkového stavu, Nejvyšší soud dospěl k závěru, že žaloba je důvodná.",
+      "Rozsudek uvádí, že § 1765 nelze aplikovat na závazky vzniklé před účinností zákona (srov. usnesení Nejvyššího soudu sp. zn. 29 Cdo 2303/2013).",
     ];
 
     for (const text of windows) {

--- a/apps/api/src/handlers/case-law/polarity/seed-rules.ts
+++ b/apps/api/src/handlers/case-law/polarity/seed-rules.ts
@@ -16,6 +16,17 @@ type SeedRule = {
 
 type RetiredSeedRule = Pick<SeedRule, "pattern" | "language">;
 
+/**
+ * The words a court uses for the decision it is treating, as stems so the
+ * cases inflect freely. A negative cue anchored on one of these names the
+ * cited decision; the same cue without one names a party, a court or a
+ * statute, and says nothing about the citation.
+ */
+const CS_DECISION_ANCHOR =
+  "(?:závěr|rozsud|usnesen|nález|judikat|rozhodnut|stanovisk|věci|případ|situac)";
+const SK_DECISION_ANCHOR =
+  "(?:záver|rozsud|uznesen|nález|judikat|rozhodnut|stanovisk|veci|prípad|situác)";
+
 export const SEED_RULES: readonly SeedRule[] = [
   // -- Czech: positive -------------------------------------------
   { pattern: "v\\s+souladu\\s+s", polarity: "positive", language: "cs" },
@@ -58,13 +69,25 @@ export const SEED_RULES: readonly SeedRule[] = [
   },
 
   // -- Czech: negative -------------------------------------------
-  { pattern: "na\\s+rozdíl\\s+od", polarity: "negative", language: "cs" },
+  // A negative cue must have the cited decision as its object. "na rozdíl
+  // od" mostly compares parties or courts, and "nelze aplikovat" mostly
+  // speaks of a statute; each is a treatment only when what follows is a
+  // decision, so the anchor is part of the pattern (see the regression
+  // corpus in `__tests__/polarity-classifier.test.ts`).
+  {
+    pattern: `na\\s+rozdíl\\s+od[^.;]{0,30}\\b${CS_DECISION_ANCHOR}`,
+    polarity: "negative",
+    language: "cs",
+  },
   { pattern: "překonán[aouy]?", polarity: "negative", language: "cs" },
   { pattern: "odchyluje\\s+se", polarity: "negative", language: "cs" },
-  { pattern: "nelze\\s+aplikovat", polarity: "negative", language: "cs" },
+  {
+    pattern: `nelze\\s+aplikovat[^.;]{0,40}\\b${CS_DECISION_ANCHOR}`,
+    polarity: "negative",
+    language: "cs",
+  },
   { pattern: "odlišuje\\s+se\\s+od", polarity: "negative", language: "cs" },
   { pattern: "nesprávně\\s+dovodil", polarity: "negative", language: "cs" },
-  { pattern: "neobstojí", polarity: "negative", language: "cs" },
 
   // -- Slovak: positive ------------------------------------------
   { pattern: "v\\s+súlade\\s+s", polarity: "positive", language: "sk" },
@@ -78,7 +101,11 @@ export const SEED_RULES: readonly SeedRule[] = [
   { pattern: "obdobne", polarity: "supportive", language: "sk" },
 
   // -- Slovak: negative ------------------------------------------
-  { pattern: "na\\s+rozdiel\\s+od", polarity: "negative", language: "sk" },
+  {
+    pattern: `na\\s+rozdiel\\s+od[^.;]{0,30}\\b${SK_DECISION_ANCHOR}`,
+    polarity: "negative",
+    language: "sk",
+  },
   { pattern: "prekonan[áéý]?", polarity: "negative", language: "sk" },
   { pattern: "odlišuje\\s+sa\\s+od", polarity: "negative", language: "sk" },
 ];
@@ -90,8 +117,19 @@ export const SEED_RULES: readonly SeedRule[] = [
  * "byl zrušen" names the fate of a judgment under review far more often than
  * a precedent being overruled, and it sits next to the citations of whatever
  * quashed it, so as a negative cue it mislabelled the authority it invoked.
+ *
+ * "neobstojí" is what a court says of a party's objection ("námitka
+ * neobstojí"), never of the precedent it cites beside it; "na rozdíl od" and
+ * "nelze aplikovat" without an object are comparisons of parties and courts
+ * and statements about statutes. Sampled on the corpus they were wrong in
+ * 14 of 21 windows and never right without the anchor their replacements
+ * carry. Retiring a rule resets the rows it labelled, so they are read again.
  */
 export const RETIRED_SEED_RULES: readonly RetiredSeedRule[] = [
   { pattern: "byl[aoyi]?\\s+zrušen[aouy]?", language: "cs" },
   { pattern: "bol[aoi]?\\s+zrušen[áéý]?", language: "sk" },
+  { pattern: "neobstojí", language: "cs" },
+  { pattern: "na\\s+rozdíl\\s+od", language: "cs" },
+  { pattern: "nelze\\s+aplikovat", language: "cs" },
+  { pattern: "na\\s+rozdiel\\s+od", language: "sk" },
 ];

--- a/apps/api/src/handlers/case-law/polarity/seed-rules.ts
+++ b/apps/api/src/handlers/case-law/polarity/seed-rules.ts
@@ -29,6 +29,15 @@ const CS_DECISION_ANCHOR =
 const SK_DECISION_ANCHOR =
   "(?:záver|rozsud|uznesen|nález|judikat|rozhodnut|stanovisk)";
 
+/**
+ * What may stand between a cue and its object: up to three plain words,
+ * no punctuation. Nearness alone is not binding: "na rozdíl od krajského
+ * soudu, jehož rozsudek…" has a decision word within reach but the comma
+ * says the cue's object is the court; "Rozsudek uvádí, že § 1765 nelze
+ * aplikovat" likewise. A clause break ends the search.
+ */
+const WORDS_BETWEEN = "(?:[^\\s,;.()]+\\s+){0,3}?";
+
 export const SEED_RULES: readonly SeedRule[] = [
   // -- Czech: positive -------------------------------------------
   { pattern: "v\\s+souladu\\s+s", polarity: "positive", language: "cs" },
@@ -77,21 +86,21 @@ export const SEED_RULES: readonly SeedRule[] = [
   // decision, so the anchor is part of the pattern (see the regression
   // corpus in `__tests__/polarity-classifier.test.ts`).
   {
-    pattern: `na\\s+rozdíl\\s+od[^.;]{0,30}\\b${CS_DECISION_ANCHOR}`,
+    pattern: `na\\s+rozdíl\\s+od\\s+${WORDS_BETWEEN}${CS_DECISION_ANCHOR}`,
     polarity: "negative",
     language: "cs",
   },
   { pattern: "překonán[aouy]?", polarity: "negative", language: "cs" },
   { pattern: "odchyluje\\s+se", polarity: "negative", language: "cs" },
   {
-    pattern: `nelze\\s+aplikovat[^.;]{0,40}\\b${CS_DECISION_ANCHOR}`,
+    pattern: `nelze\\s+aplikovat\\s+${WORDS_BETWEEN}${CS_DECISION_ANCHOR}`,
     polarity: "negative",
     language: "cs",
   },
   // The decision may be named before the cue ("tento rozsudek však nelze
-  // aplikovat"); within the same clause the anchor still binds it.
+  // aplikovat"); within the same clause the object still binds.
   {
-    pattern: `\\b${CS_DECISION_ANCHOR}\\w*[^.;]{0,40}\\bnelze\\s+aplikovat`,
+    pattern: `\\b${CS_DECISION_ANCHOR}\\w*\\s+${WORDS_BETWEEN}nelze\\s+aplikovat`,
     polarity: "negative",
     language: "cs",
   },
@@ -111,7 +120,7 @@ export const SEED_RULES: readonly SeedRule[] = [
 
   // -- Slovak: negative ------------------------------------------
   {
-    pattern: `na\\s+rozdiel\\s+od[^.;]{0,30}\\b${SK_DECISION_ANCHOR}`,
+    pattern: `na\\s+rozdiel\\s+od\\s+${WORDS_BETWEEN}${SK_DECISION_ANCHOR}`,
     polarity: "negative",
     language: "sk",
   },

--- a/apps/api/src/handlers/case-law/polarity/seed-rules.ts
+++ b/apps/api/src/handlers/case-law/polarity/seed-rules.ts
@@ -19,13 +19,15 @@ type RetiredSeedRule = Pick<SeedRule, "pattern" | "language">;
 /**
  * The words a court uses for the decision it is treating, as stems so the
  * cases inflect freely. A negative cue anchored on one of these names the
- * cited decision; the same cue without one names a party, a court or a
- * statute, and says nothing about the citation.
+ * cited decision; the same cue without one names a party, a court, a
+ * statute or the matter at hand ("na daný případ nelze aplikovat § 1765"),
+ * and says nothing about the citation. Words for the matter itself (věc,
+ * případ, situace) are deliberately absent for that reason.
  */
 const CS_DECISION_ANCHOR =
-  "(?:závěr|rozsud|usnesen|nález|judikat|rozhodnut|stanovisk|věci|případ|situac)";
+  "(?:závěr|rozsud|usnesen|nález|judikat|rozhodnut|stanovisk)";
 const SK_DECISION_ANCHOR =
-  "(?:záver|rozsud|uznesen|nález|judikat|rozhodnut|stanovisk|veci|prípad|situác)";
+  "(?:záver|rozsud|uznesen|nález|judikat|rozhodnut|stanovisk)";
 
 export const SEED_RULES: readonly SeedRule[] = [
   // -- Czech: positive -------------------------------------------
@@ -83,6 +85,13 @@ export const SEED_RULES: readonly SeedRule[] = [
   { pattern: "odchyluje\\s+se", polarity: "negative", language: "cs" },
   {
     pattern: `nelze\\s+aplikovat[^.;]{0,40}\\b${CS_DECISION_ANCHOR}`,
+    polarity: "negative",
+    language: "cs",
+  },
+  // The decision may be named before the cue ("tento rozsudek však nelze
+  // aplikovat"); within the same clause the anchor still binds it.
+  {
+    pattern: `\\b${CS_DECISION_ANCHOR}\\w*[^.;]{0,40}\\bnelze\\s+aplikovat`,
     polarity: "negative",
     language: "cs",
   },

--- a/apps/api/src/scripts/seed-polarity-rules.ts
+++ b/apps/api/src/scripts/seed-polarity-rules.ts
@@ -3,16 +3,17 @@
  *
  * Idempotent: each rule is keyed on `(pattern, language)`, so re-running
  * updates the polarity a rule asserts rather than accumulating duplicates of
- * it, and rules listed as retired are marked so rather than deleted. Run after
+ * it, and rules listed as retired are marked so rather than deleted, with the
+ * citations they labelled returned to the unclassified pool. Run after
  * changing `polarity/seed-rules.ts`; nothing else writes rows with
  * `source = 'manual'`.
  *
  *   bun apps/api/src/scripts/seed-polarity-rules.ts
  */
 
-import { and, eq, or } from "drizzle-orm";
+import { and, eq, inArray, or, sql } from "drizzle-orm";
 
-import { caseLawPolarityRules } from "@/api/db/schema";
+import { caseLawCitations, caseLawPolarityRules } from "@/api/db/schema";
 import { RULE_SOURCE } from "@/api/handlers/case-law/polarity/consts";
 import {
   RETIRED_SEED_RULES,
@@ -49,8 +50,12 @@ for (const rule of SEED_RULES) {
     });
 }
 
+/** Rows reset per statement; bounded so the lock never spans the table. */
+const RESET_BATCH = 5000;
+
+let resetTotal = 0;
 if (RETIRED_SEED_RULES.length > 0) {
-  await rootDb
+  const retired = await rootDb
     .update(caseLawPolarityRules)
     .set({ source: RULE_SOURCE.RETIRED })
     .where(
@@ -62,11 +67,43 @@ if (RETIRED_SEED_RULES.length > 0) {
           ),
         ),
       ),
-    );
+    )
+    .returning({ id: caseLawPolarityRules.id });
+
+  // A retired rule's verdicts go with it: the citations it labelled return
+  // to the unclassified pool, and `scripts/classify-citations.ts` reads them
+  // again under the rules that remain. Left in place, a withdrawn rule would
+  // keep speaking through every row it ever touched.
+  const retiredIds = retired.map((rule) => rule.id);
+  if (retiredIds.length > 0) {
+    for (;;) {
+      // oxlint-disable-next-line no-await-in-loop -- bounded batches, each its own short statement
+      const reset = await rootDb
+        .update(caseLawCitations)
+        .set({ polarity: null, polarityRuleId: null })
+        .where(
+          sql`${caseLawCitations.id} IN (
+            SELECT ${caseLawCitations.id} FROM ${caseLawCitations}
+            WHERE ${inArray(caseLawCitations.polarityRuleId, retiredIds)}
+            LIMIT ${RESET_BATCH}
+          )`,
+        )
+        .returning({ id: caseLawCitations.id });
+      resetTotal += reset.length;
+      if (reset.length < RESET_BATCH) {
+        break;
+      }
+    }
+  }
 }
 
 console.log(
-  `Done. ${SEED_RULES.length} rules upserted, ${RETIRED_SEED_RULES.length} retired.`,
+  `Done. ${SEED_RULES.length} rules upserted, ${RETIRED_SEED_RULES.length} retired, ${resetTotal} citations returned to the unclassified pool.`,
 );
+if (resetTotal > 0) {
+  console.log(
+    "Next: bun apps/api/scripts/classify-citations.ts, then bun apps/api/src/scripts/backfill-citation-authority.ts.",
+  );
+}
 
 process.exit(0);

--- a/apps/api/src/scripts/seed-polarity-rules.ts
+++ b/apps/api/src/scripts/seed-polarity-rules.ts
@@ -75,25 +75,24 @@ if (RETIRED_SEED_RULES.length > 0) {
   // again under the rules that remain. Left in place, a withdrawn rule would
   // keep speaking through every row it ever touched.
   const retiredIds = retired.map((rule) => rule.id);
+  const resetBatch = async (): Promise<number> => {
+    const reset = await rootDb
+      .update(caseLawCitations)
+      .set({ polarity: null, polarityRuleId: null })
+      .where(
+        sql`${caseLawCitations.id} IN (
+          SELECT ${caseLawCitations.id} FROM ${caseLawCitations}
+          WHERE ${inArray(caseLawCitations.polarityRuleId, retiredIds)}
+          LIMIT ${RESET_BATCH}
+        )`,
+      )
+      .returning({ id: caseLawCitations.id });
+    return reset.length < RESET_BATCH
+      ? reset.length
+      : reset.length + (await resetBatch());
+  };
   if (retiredIds.length > 0) {
-    for (;;) {
-      // oxlint-disable-next-line no-await-in-loop -- bounded batches, each its own short statement
-      const reset = await rootDb
-        .update(caseLawCitations)
-        .set({ polarity: null, polarityRuleId: null })
-        .where(
-          sql`${caseLawCitations.id} IN (
-            SELECT ${caseLawCitations.id} FROM ${caseLawCitations}
-            WHERE ${inArray(caseLawCitations.polarityRuleId, retiredIds)}
-            LIMIT ${RESET_BATCH}
-          )`,
-        )
-        .returning({ id: caseLawCitations.id });
-      resetTotal += reset.length;
-      if (reset.length < RESET_BATCH) {
-        break;
-      }
-    }
+    resetTotal = await resetBatch();
   }
 }
 

--- a/apps/api/src/scripts/seed-polarity-rules.ts
+++ b/apps/api/src/scripts/seed-polarity-rules.ts
@@ -12,6 +12,8 @@
  */
 
 import { and, eq, inArray, or, sql } from "drizzle-orm";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 import { caseLawCitations, caseLawPolarityRules } from "@/api/db/schema";
 import { RULE_SOURCE } from "@/api/handlers/case-law/polarity/consts";
@@ -53,7 +55,7 @@ for (const rule of SEED_RULES) {
 /** Rows reset per statement; bounded so the lock never spans the table. */
 const RESET_BATCH = 5000;
 
-let resetTotal = 0;
+let resetIds: string[] = [];
 if (RETIRED_SEED_RULES.length > 0) {
   const retired = await rootDb
     .update(caseLawPolarityRules)
@@ -75,7 +77,7 @@ if (RETIRED_SEED_RULES.length > 0) {
   // again under the rules that remain. Left in place, a withdrawn rule would
   // keep speaking through every row it ever touched.
   const retiredIds = retired.map((rule) => rule.id);
-  const resetBatch = async (): Promise<number> => {
+  const resetBatch = async (): Promise<string[]> => {
     const reset = await rootDb
       .update(caseLawCitations)
       .set({ polarity: null, polarityRuleId: null })
@@ -87,21 +89,26 @@ if (RETIRED_SEED_RULES.length > 0) {
         )`,
       )
       .returning({ id: caseLawCitations.id });
-    return reset.length < RESET_BATCH
-      ? reset.length
-      : reset.length + (await resetBatch());
+    const ids = reset.map((row) => row.id);
+    return reset.length < RESET_BATCH ? ids : [...ids, ...(await resetBatch())];
   };
   if (retiredIds.length > 0) {
-    resetTotal = await resetBatch();
+    resetIds = await resetBatch();
   }
 }
 
 console.log(
-  `Done. ${SEED_RULES.length} rules upserted, ${RETIRED_SEED_RULES.length} retired, ${resetTotal} citations returned to the unclassified pool.`,
+  `Done. ${SEED_RULES.length} rules upserted, ${RETIRED_SEED_RULES.length} retired, ${resetIds.length} citations returned to the unclassified pool.`,
 );
-if (resetTotal > 0) {
+if (resetIds.length > 0) {
+  // The classifier walks the newest unclassified rows first and stops at a
+  // limit; the reset rows are old and would wait behind the backlog. Their
+  // ids go to a file the classifier can be pointed at, so the pass that
+  // follows consumes exactly this set.
+  const resetFile = path.join(tmpdir(), `polarity-reset-${Date.now()}.json`);
+  await Bun.write(resetFile, JSON.stringify(resetIds));
   console.log(
-    "Next: bun apps/api/scripts/classify-citations.ts, then bun apps/api/src/scripts/backfill-citation-authority.ts.",
+    `Next: bun apps/api/scripts/classify-citations.ts --ids ${resetFile}, then bun apps/api/src/scripts/backfill-citation-authority.ts.`,
   );
 }
 


### PR DESCRIPTION
## What

Three seeded negative polarity cues fired on text that is not about the cited decision:

- `neobstojí` names a party's objection ("námitka neobstojí"), never the precedent cited beside it.
- `na rozdíl od` compares parties, courts or instruments.
- `nelze aplikovat` mostly speaks of a statute.

Sampled on the corpus they were wrong in 14 of 21 windows and right only when their object was a decision. Because negative wins precedence and carries no authority weight, one such word near a citation labelled the cited decision as overruled and lowered its ranking.

## Change

- `neobstojí` (cs) is retired.
- `na rozdíl od` / `na rozdiel od` and `nelze aplikovat` now require a decision as their object (`…[^.;]{0,30}\b(závěr|rozsud|usnesen|nález|judikat|rozhodnut|stanovisk|věci|případ|situac)`).
- A regression corpus of real windows where the cue is not about the cited decision asserts that no negative rule fires; the correct `nelze aplikovat …rozsudek/závěry` forms assert a match.
- `seed-polarity-rules.ts` now returns the citations a retired rule labelled to the unclassified pool (batched), so `classify-citations.ts` reads them again instead of a withdrawn rule speaking through old rows.

## Rollout

After merge: `seed-polarity-rules.ts`, then `classify-citations.ts`, then `backfill-citation-authority.ts`.

https://claude.ai/code/session_01K7uwWgdaAsNNgBwAFevh1h


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Czech and Slovak case-law polarity detection for negative phrases involving cited decisions.
  - Reduced false negative classifications when negative wording refers to a party, court, or statute rather than the cited decision.
  - Improved precedence handling so relevant negative signals are correctly prioritised.

- **Improvements**
  - Added more reliable, targeted citation classification and reclassification workflows for maintaining accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->