### PR TITLE
fix: restore PSGallery before desktop signing

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -428,6 +428,25 @@ jobs:
         # only the .exe lands and no .nsis.zip is created.
         run: bun run build -- --target ${{ matrix.target }} --bundles nsis --verbose --verbose
 
+      # GitHub-hosted Windows runners can start without the default PSGallery
+      # registration. The Azure action installs ArtifactSigning from PSGallery
+      # and otherwise fails before authentication or signing begins.
+      - name: Ensure PSGallery is registered (Windows only)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          $expectedSourceLocation = "https://www.powershellgallery.com/api/v2"
+          $repository = Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue
+
+          if (-not $repository) {
+            Register-PSRepository -Default
+            $repository = Get-PSRepository -Name PSGallery -ErrorAction Stop
+          }
+
+          if ($repository.SourceLocation.TrimEnd("/") -ne $expectedSourceLocation) {
+            throw "PSGallery has an unexpected source location: $($repository.SourceLocation)"
+          }
+
       - name: Sign Windows installers via Azure Trusted Signing
         if: matrix.os == 'windows'
         uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -285,6 +285,10 @@ describe("API deployment health receipt", () => {
       desktopResolveStart,
       desktopBuildStart,
     );
+    const desktopBuild = releaseDesktopWorkflow.slice(
+      desktopBuildStart,
+      desktopVerifyStart,
+    );
     const desktopVerify = releaseDesktopWorkflow.slice(
       desktopVerifyStart,
       desktopManifestStart,
@@ -309,6 +313,18 @@ describe("API deployment health receipt", () => {
       "github.event.workflow_run.conclusion == 'success'",
     );
     expect(desktopResolve).not.toContain('["success", "failure"]');
+    const psGalleryPreflight = desktopBuild.indexOf(
+      "Ensure PSGallery is registered (Windows only)",
+    );
+    const azureSigning = desktopBuild.indexOf("azure/trusted-signing-action@");
+    expect(psGalleryPreflight).toBeGreaterThanOrEqual(0);
+    expect(azureSigning).toBeGreaterThan(psGalleryPreflight);
+    expect(desktopBuild).toContain(
+      "Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue",
+    );
+    expect(desktopBuild).toContain("if (-not $repository) {");
+    expect(desktopBuild).toContain("Register-PSRepository -Default");
+    expect(desktopBuild).toContain("https://www.powershellgallery.com/api/v2");
     expect(desktopVerify).toContain("API_DEPLOYMENT_PROBE_PATH: ready");
     expect(desktopVerify).toContain("API_DEPLOYMENT_PROBE_PATH: version.json");
     expect(desktopManifest).toContain(


### PR DESCRIPTION
## Summary

- restore the default PSGallery registration when a hosted Windows runner starts without it
- verify PSGallery uses the official source before Azure signing
- guard the preflight and signing order in the release workflow contract