### PR TITLE
feat: create a folder from the matter target picker

### DIFF
--- a/apps/web/src/components/inspector/email-attachments-facet.tsx
+++ b/apps/web/src/components/inspector/email-attachments-facet.tsx
@@ -51,8 +51,9 @@ import {
 import { MeasuredPdfProvider } from "@/components/inspector/measured-pdf-provider";
 import {
   MatterTargetPicker,
-  type MatterTarget,
+  useResolveMatterTarget,
 } from "@/components/matter-target-picker";
+import type { MatterTarget } from "@/components/matter-target-picker.logic";
 import { PeekPdfControls } from "@/components/pdf/peek/peek-pdf-viewer";
 import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { usePermissions } from "@/hooks/use-permissions";
@@ -117,6 +118,7 @@ export const EmailAttachmentsFacet = ({
   const t = useTranslations();
   const canSave = usePermissions({ entity: ["create"] });
   const queryClient = useQueryClient();
+  const resolveTarget = useResolveMatterTarget();
   const [saveTargetId, setSaveTargetId] = useState<string | null>(null);
   const [matterTarget, setMatterTarget] = useState<MatterTarget | null>(null);
   const [saveState, setSaveState] = useState(createInitialSaveState);
@@ -157,12 +159,31 @@ export const EmailAttachmentsFacet = ({
     setSaveState({ status: EMAIL_ATTACHMENT_SAVE_STATUS.saving });
     detached(
       (async () => {
+        const resolved = await resolveTarget(destination);
+        if (Result.isError(resolved)) {
+          savingRef.current = false;
+          setSaveState({ status: EMAIL_ATTACHMENT_SAVE_STATUS.idle });
+          stellaToast.add({
+            title: t("errors.actionFailed"),
+            type: "error",
+          });
+          return;
+        }
+        if (destination.type === "pending") {
+          // A staged folder now exists; keep it so a retry after a failed save
+          // does not create a second one.
+          setMatterTarget({
+            type: "existing",
+            workspaceId: resolved.value.workspaceId,
+            parentId: resolved.value.parentId,
+          });
+        }
         const result = await Result.tryPromise(async () => {
           const saved = await saveEmailAttachment({
             attachmentId: attachment.id,
-            destinationWorkspaceId: destination.workspaceId,
+            destinationWorkspaceId: resolved.value.workspaceId,
             fieldId,
-            parentId: destination.parentId,
+            parentId: resolved.value.parentId,
             sourceWorkspaceId: workspaceId,
           });
           await Promise.all([
@@ -215,7 +236,7 @@ export const EmailAttachmentsFacet = ({
         onSave={() =>
           saveAttachment({
             attachment: selected,
-            destination: { workspaceId, parentId: null },
+            destination: { type: "existing", workspaceId, parentId: null },
           })
         }
         saving={saving}
@@ -235,7 +256,7 @@ export const EmailAttachmentsFacet = ({
         onSave={(attachment) =>
           saveAttachment({
             attachment,
-            destination: { workspaceId, parentId: null },
+            destination: { type: "existing", workspaceId, parentId: null },
           })
         }
         onSelect={onSelectedIdChange}

--- a/apps/web/src/components/matter-target-picker.logic.test.ts
+++ b/apps/web/src/components/matter-target-picker.logic.test.ts
@@ -2,6 +2,7 @@ import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
 import {
+  matterFolderPath,
   resolveMatterTarget,
   stageMatterFolder,
 } from "@/components/matter-target-picker.logic";
@@ -75,6 +76,40 @@ describe("staging a folder in the matter picker", () => {
     });
     expect(stageMatterFolder(root, "   ")).toBeNull();
     expect(stageMatterFolder(root, "")).toBeNull();
+  });
+});
+
+describe("revealing a folder's path in the matter picker", () => {
+  const TREE = [
+    { entityId: "root", parentId: null },
+    { entityId: "child", parentId: "root" },
+    { entityId: "grandchild", parentId: "child" },
+  ];
+
+  test("returns the folder and every folder above it, root-first", () => {
+    expect(matterFolderPath(TREE, "grandchild")).toEqual([
+      "root",
+      "child",
+      "grandchild",
+    ]);
+  });
+
+  test("has no path for the matter root", () => {
+    expect(matterFolderPath(TREE, null)).toEqual([]);
+  });
+
+  test("stops at a parent the tree does not contain", () => {
+    expect(
+      matterFolderPath([{ entityId: "orphan", parentId: "gone" }], "orphan"),
+    ).toEqual(["orphan"]);
+  });
+
+  test("terminates on a cycle instead of hanging", () => {
+    const cycle = [
+      { entityId: "a", parentId: "b" },
+      { entityId: "b", parentId: "a" },
+    ];
+    expect(matterFolderPath(cycle, "a")).toEqual(["b", "a"]);
   });
 });
 

--- a/apps/web/src/components/matter-target-picker.logic.test.ts
+++ b/apps/web/src/components/matter-target-picker.logic.test.ts
@@ -1,0 +1,135 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import {
+  resolveMatterTarget,
+  stageMatterFolder,
+} from "@/components/matter-target-picker.logic";
+import type { MatterTarget } from "@/components/matter-target-picker.logic";
+
+const WORKSPACE_ID = "11111111-1111-4111-8111-111111111111";
+const FOLDER_ID = "22222222-2222-4222-8222-222222222222";
+const CREATED_ID = "33333333-3333-4333-8333-333333333333";
+
+type CreateCall = {
+  workspaceId: string;
+  parentId: string | null;
+  name: string;
+};
+
+const recordingCreate = (entityId: string) => {
+  const calls: CreateCall[] = [];
+  return {
+    calls,
+    createFolder: async (folder: CreateCall) => {
+      calls.push(folder);
+      return await Promise.resolve({ entityId });
+    },
+  };
+};
+
+describe("staging a folder in the matter picker", () => {
+  test("hangs the new folder off whatever is selected now", () => {
+    const target = {
+      type: "existing",
+      workspaceId: WORKSPACE_ID,
+      parentId: FOLDER_ID,
+    } as const satisfies MatterTarget;
+
+    expect(stageMatterFolder(target, "Pleadings")).toEqual({
+      type: "pending",
+      workspaceId: WORKSPACE_ID,
+      name: "Pleadings",
+      parentId: FOLDER_ID,
+    });
+  });
+
+  test("restages against the pending folder's parent, never inside it", () => {
+    const staged = stageMatterFolder(
+      { type: "existing", workspaceId: WORKSPACE_ID, parentId: FOLDER_ID },
+      "Pleadings",
+    );
+    if (staged === null) {
+      throw new Error("a non-blank name must stage a pending folder");
+    }
+
+    // Staging again must replace the pending folder, not nest under it.
+    expect(stageMatterFolder(staged, "Exhibits")).toEqual({
+      type: "pending",
+      workspaceId: WORKSPACE_ID,
+      name: "Exhibits",
+      parentId: FOLDER_ID,
+    });
+  });
+
+  test("trims the name and rejects one that is blank once trimmed", () => {
+    const root = {
+      type: "existing",
+      workspaceId: WORKSPACE_ID,
+      parentId: null,
+    } as const satisfies MatterTarget;
+
+    expect(stageMatterFolder(root, "  Exhibits  ")).toMatchObject({
+      name: "Exhibits",
+      parentId: null,
+    });
+    expect(stageMatterFolder(root, "   ")).toBeNull();
+    expect(stageMatterFolder(root, "")).toBeNull();
+  });
+});
+
+describe("resolving a matter target before a write", () => {
+  test("passes an existing target through without creating anything", async () => {
+    const { calls, createFolder } = recordingCreate(CREATED_ID);
+
+    const resolved = await resolveMatterTarget(
+      { type: "existing", workspaceId: WORKSPACE_ID, parentId: FOLDER_ID },
+      createFolder,
+    );
+
+    expect(calls).toEqual([]);
+    expect(resolved).toEqual(
+      Result.ok({ workspaceId: WORKSPACE_ID, parentId: FOLDER_ID }),
+    );
+  });
+
+  test("creates the staged folder once and writes into it", async () => {
+    const { calls, createFolder } = recordingCreate(CREATED_ID);
+
+    const resolved = await resolveMatterTarget(
+      {
+        type: "pending",
+        workspaceId: WORKSPACE_ID,
+        name: "Pleadings",
+        parentId: FOLDER_ID,
+      },
+      createFolder,
+    );
+
+    expect(calls).toEqual([
+      { workspaceId: WORKSPACE_ID, parentId: FOLDER_ID, name: "Pleadings" },
+    ]);
+    expect(resolved).toEqual(
+      Result.ok({ workspaceId: WORKSPACE_ID, parentId: CREATED_ID }),
+    );
+  });
+
+  test("surfaces a failed create as an error instead of writing to the parent", async () => {
+    const resolved = await resolveMatterTarget(
+      {
+        type: "pending",
+        workspaceId: WORKSPACE_ID,
+        name: "Pleadings",
+        parentId: null,
+      },
+      async () => {
+        throw new Error("Entities limit reached");
+      },
+    );
+
+    expect(Result.isError(resolved)).toBe(true);
+    expect(Result.isError(resolved) && resolved.error.message).toContain(
+      "Entities limit reached",
+    );
+  });
+});

--- a/apps/web/src/components/matter-target-picker.logic.ts
+++ b/apps/web/src/components/matter-target-picker.logic.ts
@@ -47,6 +47,39 @@ export const stageMatterFolder = (
   };
 };
 
+/** The shape of a folder row the path walk needs; `WorkspaceFolder` satisfies it. */
+type FolderLink = {
+  entityId: string;
+  parentId: string | null;
+};
+
+/**
+ * A folder and every folder above it, root-first. Expanding this whole path is
+ * what keeps the new-folder row visible: expanding only the immediate parent
+ * still leaves it inside a collapsed grandparent. `null` (the matter root) has
+ * no path. An id the tree does not contain is left out and ends the walk, and a
+ * cycle in a malformed tree terminates instead of hanging.
+ */
+export const matterFolderPath = (
+  folders: readonly FolderLink[],
+  folderId: string | null,
+): string[] => {
+  const byId = new Map(folders.map((folder) => [folder.entityId, folder]));
+  const path: string[] = [];
+  const seen = new Set<string>();
+  let current = folderId;
+  while (current !== null && !seen.has(current)) {
+    const folder = byId.get(current);
+    if (folder === undefined) {
+      break;
+    }
+    seen.add(current);
+    path.push(current);
+    current = folder.parentId;
+  }
+  return path.toReversed();
+};
+
 type CreateFolder = (folder: {
   workspaceId: string;
   parentId: string | null;

--- a/apps/web/src/components/matter-target-picker.logic.ts
+++ b/apps/web/src/components/matter-target-picker.logic.ts
@@ -1,0 +1,85 @@
+import { Result } from "better-result";
+import type { UnhandledException } from "better-result";
+
+/** A destination that exists on the server and can be written to directly. */
+export type ResolvedMatterTarget = {
+  workspaceId: string;
+  parentId: string | null;
+};
+
+/**
+ * The matter picker's value. A `pending` folder is staged in the UI only:
+ * nothing is created until {@link resolveMatterTarget} runs, so cancelling the
+ * dialog leaves no orphan behind. `pending.parentId` is always an existing
+ * folder (or the matter root), which makes nesting a pending folder
+ * unrepresentable.
+ */
+export type MatterTarget =
+  | ({ type: "existing" } & ResolvedMatterTarget)
+  | {
+      type: "pending";
+      workspaceId: string;
+      name: string;
+      parentId: string | null;
+    };
+
+/** Matches the server's entity-name bound (`handlers/entities/create.ts`). */
+export const MAX_FOLDER_NAME_LENGTH = 255;
+
+/**
+ * Stage a folder under whatever the picker has selected. Returns `null` for a
+ * name that is empty once trimmed, matching the server's validation.
+ */
+export const stageMatterFolder = (
+  target: MatterTarget,
+  name: string,
+): MatterTarget | null => {
+  const trimmed = name.trim();
+  if (trimmed === "") {
+    return null;
+  }
+  return {
+    type: "pending",
+    workspaceId: target.workspaceId,
+    name: trimmed,
+    // The current selection, so a pending folder never nests in another.
+    parentId: target.parentId,
+  };
+};
+
+type CreateFolder = (folder: {
+  workspaceId: string;
+  parentId: string | null;
+  name: string;
+}) => Promise<{ entityId: string }>;
+
+/**
+ * Turn a {@link MatterTarget} into a {@link ResolvedMatterTarget}, creating the
+ * staged folder if there is one. An `existing` target never touches the network.
+ */
+export const resolveMatterTarget = async (
+  target: MatterTarget,
+  createFolder: CreateFolder,
+): Promise<Result<ResolvedMatterTarget, UnhandledException>> => {
+  if (target.type === "existing") {
+    return Result.ok({
+      workspaceId: target.workspaceId,
+      parentId: target.parentId,
+    });
+  }
+  const created = await Result.tryPromise(
+    async () =>
+      await createFolder({
+        workspaceId: target.workspaceId,
+        parentId: target.parentId,
+        name: target.name,
+      }),
+  );
+  if (Result.isError(created)) {
+    return Result.err(created.error);
+  }
+  return Result.ok({
+    workspaceId: target.workspaceId,
+    parentId: created.value.entityId,
+  });
+};

--- a/apps/web/src/components/matter-target-picker.tsx
+++ b/apps/web/src/components/matter-target-picker.tsx
@@ -33,13 +33,20 @@ import {
 import type { WorkspaceFolder } from "@/lib/workspaces/queries/entities";
 
 /**
- * Exists for one case: the user typed a new folder name in the picker (a
- * `pending` target). The folder is created here, just before the caller's
- * write (copy, move, save), and the matter's folder tree is refreshed. An
- * `existing` target passes straight through. Callers must
- * replace a `pending` target with the resolved one, or a retry after a failed
- * write creates the folder again; the folder is kept on failure since an
- * empty folder beats a duplicate.
+ * Handles the case where the user types a new folder name in the picker. The
+ * folder is created here, just before the caller's write (copy, move, save),
+ * and the matter's folder tree is refreshed.
+ *
+ * Returns a `Result` whose value is a `ResolvedMatterTarget`:
+ * - `workspaceId`: the chosen matter, unchanged from the input.
+ * - `parentId`: the folder to write into. For a `pending` target this is the
+ *   id of the folder just created; for an `existing` target it is the input's
+ *   `parentId` (`null` means the matter root).
+ * The error branch carries the failed folder creation; nothing was written.
+ *
+ * Callers must replace a `pending` target with the resolved one, or a retry
+ * after a failed write creates the folder again; the folder is kept on
+ * failure since an empty folder beats a duplicate.
  */
 export const useResolveMatterTarget = () => {
   const createEntities = useCreateEntities();

--- a/apps/web/src/components/matter-target-picker.tsx
+++ b/apps/web/src/components/matter-target-picker.tsx
@@ -33,20 +33,15 @@ import {
 import type { WorkspaceFolder } from "@/lib/workspaces/queries/entities";
 
 /**
- * Shared "pick a matter (and optionally a folder in it)" control: matter
- * rows show the matter icon in the matter's colour, the list is filterable
- * by typing, and matters arrive ordered by most recent activity (the
- * workspaces endpoint sorts by lastActivityAt). Used by the copy/move
- * dialog and the template "save to matter" flow.
- */
-
-/**
- * Binds {@link resolveMatterTarget} to the entity-create mutation, then
- * refreshes the target matter's folder tree so a freshly created folder is a
- * real row the picker can show as selected. Callers must store the resolved
- * target in place of a `pending` one, or a retry after a failed write creates
- * the folder a second time. The folder is kept if the write then fails: an
- * empty folder is cheaper for the user than a duplicate on retry.
+ * Shared "pick a matter (and optionally a folder in it)" control. Matter rows
+ * show the matter icon in its colour, the list filters as you type, and
+ * matters arrive ordered by most recent activity (the workspaces endpoint
+ * sorts by lastActivityAt).
+ *
+ * `useResolveMatterTarget` creates a staged folder before a write and
+ * refreshes the target's folder tree. Callers must replace a `pending` target
+ * with the resolved one, or a retry after a failed write creates the folder
+ * again; the folder is kept on failure since an empty folder beats a duplicate.
  */
 export const useResolveMatterTarget = () => {
   const createEntities = useCreateEntities();

--- a/apps/web/src/components/matter-target-picker.tsx
+++ b/apps/web/src/components/matter-target-picker.tsx
@@ -91,8 +91,7 @@ type MatterTargetPickerProps = {
  * Shared "pick a matter (and optionally a folder in it)" control. Matter rows
  * show the matter icon in its colour, the list filters as you type, and
  * matters arrive ordered by most recent activity (the workspaces endpoint
- * sorts by lastActivityAt). Used by the copy/move dialog, the template
- * "save to matter" form, and the email-attachments facet.
+ * sorts by lastActivityAt).
  */
 export const MatterTargetPicker = ({
   value,

--- a/apps/web/src/components/matter-target-picker.tsx
+++ b/apps/web/src/components/matter-target-picker.tsx
@@ -38,10 +38,13 @@ import type { WorkspaceFolder } from "@/lib/workspaces/queries/entities";
  * matters arrive ordered by most recent activity (the workspaces endpoint
  * sorts by lastActivityAt).
  *
- * `useResolveMatterTarget` creates a staged folder before a write and
- * refreshes the target's folder tree. Callers must replace a `pending` target
- * with the resolved one, or a retry after a failed write creates the folder
- * again; the folder is kept on failure since an empty folder beats a duplicate.
+ * `useResolveMatterTarget` exists for one case: the user typed a new folder
+ * name in the picker (a `pending` target). The folder is created here, just
+ * before the caller's write (copy, move, save), and the matter's folder tree
+ * is refreshed. An `existing` target passes straight through. Callers must
+ * replace a `pending` target with the resolved one, or a retry after a failed
+ * write creates the folder again; the folder is kept on failure since an
+ * empty folder beats a duplicate.
  */
 export const useResolveMatterTarget = () => {
   const createEntities = useCreateEntities();

--- a/apps/web/src/components/matter-target-picker.tsx
+++ b/apps/web/src/components/matter-target-picker.tsx
@@ -15,6 +15,7 @@ import { cn } from "@stll/ui/utils";
 import { MatterIcon } from "@/components/matter-icon";
 import {
   MAX_FOLDER_NAME_LENGTH,
+  matterFolderPath,
   resolveMatterTarget,
   stageMatterFolder,
 } from "@/components/matter-target-picker.logic";
@@ -259,6 +260,22 @@ const FolderPicker = ({ value, onChange }: FolderPickerProps) => {
   };
 
   /**
+   * Reveal a destination: the folder itself and every folder above it. The
+   * new-folder row lives inside `value.parentId`, so a collapsed ancestor
+   * anywhere up the chain would hide it.
+   */
+  const expandFolderPath = (folderId: string | null) => {
+    if (folders === undefined) {
+      return;
+    }
+    const path = matterFolderPath(folders, folderId);
+    if (path.length === 0) {
+      return;
+    }
+    setExpandedFolders((prev) => new Set([...prev, ...path]));
+  };
+
+  /**
    * Stage a folder under whatever is selected now; it is created on submit.
    * Runs on Enter and on blur, so a name typed straight before clicking the
    * dialog's submit button is not dropped. An empty name closes the input.
@@ -270,86 +287,99 @@ const FolderPicker = ({ value, onChange }: FolderPickerProps) => {
       return;
     }
     onChange(staged);
-    if (staged.parentId !== null) {
-      const parentId = staged.parentId;
-      setExpandedFolders((prev) => new Set(prev).add(parentId));
-    }
+    expandFolderPath(staged.parentId);
     setDraftName(null);
   };
 
-  const newFolderRow = (() => {
-    if (!canCreate) {
-      return null;
-    }
-    if (draftName === null) {
+  /**
+   * The folder about to be created: the draft input while its name is typed,
+   * then the staged row. Both are the same thing at different moments, so one
+   * node renders them and the preview cannot sit somewhere the folder will not.
+   */
+  const newFolderSlot = (() => {
+    if (draftName !== null) {
       return (
-        <button
-          className="hover:bg-accent text-muted-foreground flex w-full items-center gap-1 rounded px-2 py-1 text-start text-sm"
-          onClick={() => {
-            draftCancelledRef.current = false;
-            setDraftName("");
+        <Input
+          aria-label={t("workspaces.newFolder")}
+          autoFocus
+          className="h-7 min-w-0 flex-1 px-2 text-sm"
+          maxLength={MAX_FOLDER_NAME_LENGTH}
+          onBlur={() => {
+            if (draftCancelledRef.current) {
+              draftCancelledRef.current = false;
+              return;
+            }
+            stageFolder();
           }}
-          type="button"
-        >
-          <FolderPlusIcon className="size-4 shrink-0" />
-          <span className="truncate">{t("workspaces.newFolder")}</span>
-        </button>
+          onChange={(e) => setDraftName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              stageFolder();
+            }
+            if (e.key === "Escape") {
+              // Cancel only the draft; the enclosing dialog dismisses on Escape.
+              e.stopPropagation();
+              draftCancelledRef.current = true;
+              setDraftName(null);
+            }
+          }}
+          placeholder={t("workspaces.newFolder")}
+          value={draftName}
+        />
       );
     }
-    return (
-      <Input
-        aria-label={t("workspaces.newFolder")}
-        autoFocus
-        className="h-7 px-2 text-sm"
-        maxLength={MAX_FOLDER_NAME_LENGTH}
-        onBlur={() => {
-          if (draftCancelledRef.current) {
-            draftCancelledRef.current = false;
-            return;
-          }
-          stageFolder();
-        }}
-        onChange={(e) => setDraftName(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            stageFolder();
-          }
-          if (e.key === "Escape") {
-            // Cancel only the draft; the enclosing dialog dismisses on Escape.
-            e.stopPropagation();
-            draftCancelledRef.current = true;
-            setDraftName(null);
-          }
-        }}
-        placeholder={t("workspaces.newFolder")}
-        value={draftName}
-      />
-    );
+    if (pendingFolder !== null) {
+      return (
+        <div className="bg-accent flex min-w-0 flex-1 items-center gap-1 rounded px-2 py-1 text-sm">
+          <EntityKindIcon className="size-4 shrink-0" kind="folder" />
+          <BidiText as="span" className="truncate">
+            {pendingFolder.name}
+          </BidiText>
+        </div>
+      );
+    }
+    return null;
   })();
 
-  const renderPendingFolder = (name: string, depth: number) => (
-    <div
-      className="flex items-center gap-1"
-      style={{ paddingLeft: `${depth * 16 + 8}px` }}
-    >
-      <span className="w-4" />
-      <div className="bg-accent flex min-w-0 flex-1 items-center gap-1 rounded px-2 py-1 text-sm">
-        <EntityKindIcon className="size-4 shrink-0" kind="folder" />
-        <BidiText as="span" className="truncate">
-          {name}
-        </BidiText>
+  /**
+   * Called from the two positions that can hold the slot, both keyed off
+   * `value.parentId`: the destination the folder will be created in.
+   */
+  const renderNewFolderSlot = (depth: number) =>
+    newFolderSlot === null ? null : (
+      <div
+        className="flex items-center gap-1"
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+      >
+        <span className="w-4" />
+        {newFolderSlot}
       </div>
-    </div>
-  );
+    );
+
+  const newFolderButton =
+    canCreate && draftName === null ? (
+      <button
+        className="hover:bg-accent text-muted-foreground flex w-full items-center gap-1 rounded px-2 py-1 text-start text-sm"
+        onClick={() => {
+          draftCancelledRef.current = false;
+          setDraftName("");
+          expandFolderPath(value.parentId);
+        }}
+        type="button"
+      >
+        <FolderPlusIcon className="size-4 shrink-0" />
+        <span className="truncate">{t("workspaces.newFolder")}</span>
+      </button>
+    ) : null;
 
   const renderFolder = (folder: WorkspaceFolder, depth: number) => {
     const children = folders
       ? folders.filter((f) => f.parentId === folder.entityId)
       : [];
-    const pendingChild =
-      pendingFolder?.parentId === folder.entityId ? pendingFolder : null;
-    const hasChildren = children.length > 0 || pendingChild !== null;
+    const hasNewFolderSlot =
+      newFolderSlot !== null && value.parentId === folder.entityId;
+    const hasChildren = children.length > 0 || hasNewFolderSlot;
     const isExpanded = expandedFolders.has(folder.entityId);
     const isSelected =
       value.type === "existing" && value.parentId === folder.entityId;
@@ -411,8 +441,7 @@ const FolderPicker = ({ value, onChange }: FolderPickerProps) => {
         {hasChildren && isExpanded && (
           <div>
             {children.map((child) => renderFolder(child, depth + 1))}
-            {pendingChild !== null &&
-              renderPendingFolder(pendingChild.name, depth + 1)}
+            {hasNewFolderSlot && renderNewFolderSlot(depth + 1)}
           </div>
         )}
       </div>
@@ -437,10 +466,8 @@ const FolderPicker = ({ value, onChange }: FolderPickerProps) => {
           </span>
         </button>
         {rootFolders.map((folder) => renderFolder(folder, 0))}
-        {pendingFolder !== null &&
-          pendingFolder.parentId === null &&
-          renderPendingFolder(pendingFolder.name, 0)}
-        {newFolderRow}
+        {value.parentId === null && renderNewFolderSlot(0)}
+        {newFolderButton}
       </div>
     </ScrollArea>
   );

--- a/apps/web/src/components/matter-target-picker.tsx
+++ b/apps/web/src/components/matter-target-picker.tsx
@@ -33,15 +33,10 @@ import {
 import type { WorkspaceFolder } from "@/lib/workspaces/queries/entities";
 
 /**
- * Shared "pick a matter (and optionally a folder in it)" control. Matter rows
- * show the matter icon in its colour, the list filters as you type, and
- * matters arrive ordered by most recent activity (the workspaces endpoint
- * sorts by lastActivityAt).
- *
- * `useResolveMatterTarget` exists for one case: the user typed a new folder
- * name in the picker (a `pending` target). The folder is created here, just
- * before the caller's write (copy, move, save), and the matter's folder tree
- * is refreshed. An `existing` target passes straight through. Callers must
+ * Exists for one case: the user typed a new folder name in the picker (a
+ * `pending` target). The folder is created here, just before the caller's
+ * write (copy, move, save), and the matter's folder tree is refreshed. An
+ * `existing` target passes straight through. Callers must
  * replace a `pending` target with the resolved one, or a retry after a failed
  * write creates the folder again; the folder is kept on failure since an
  * empty folder beats a duplicate.
@@ -85,6 +80,13 @@ type MatterTargetPickerProps = {
   showFolderPicker?: boolean | undefined;
 };
 
+/**
+ * Shared "pick a matter (and optionally a folder in it)" control. Matter rows
+ * show the matter icon in its colour, the list filters as you type, and
+ * matters arrive ordered by most recent activity (the workspaces endpoint
+ * sorts by lastActivityAt). Used by the copy/move dialog, the template
+ * "save to matter" form, and the email-attachments facet.
+ */
 export const MatterTargetPicker = ({
   value,
   onChange,

--- a/apps/web/src/components/matter-target-picker.tsx
+++ b/apps/web/src/components/matter-target-picker.tsx
@@ -350,7 +350,7 @@ const FolderPicker = ({ value, onChange }: FolderPickerProps) => {
     newFolderSlot === null ? null : (
       <div
         className="flex items-center gap-1"
-        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+        style={{ paddingInlineStart: `${depth * 16 + 8}px` }}
       >
         <span className="w-4" />
         {newFolderSlot}
@@ -388,7 +388,7 @@ const FolderPicker = ({ value, onChange }: FolderPickerProps) => {
       <div key={folder.entityId}>
         <div
           className="flex items-center gap-1"
-          style={{ paddingLeft: `${depth * 16 + 8}px` }}
+          style={{ paddingInlineStart: `${depth * 16 + 8}px` }}
         >
           {hasChildren ? (
             <Tooltip

--- a/apps/web/src/components/matter-target-picker.tsx
+++ b/apps/web/src/components/matter-target-picker.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Result } from "better-result";
@@ -213,6 +213,8 @@ const FolderPicker = ({ value, onChange }: FolderPickerProps) => {
   );
   /** `null` while the new-folder row is a button; a string while it is an input. */
   const [draftName, setDraftName] = useState<string | null>(null);
+  /** Set by Escape so the blur that follows unmounting does not stage the draft. */
+  const draftCancelledRef = useRef(false);
 
   if (isLoading) {
     return (
@@ -245,10 +247,15 @@ const FolderPicker = ({ value, onChange }: FolderPickerProps) => {
     });
   };
 
-  /** Stage a folder under whatever is selected now; it is created on submit. */
+  /**
+   * Stage a folder under whatever is selected now; it is created on submit.
+   * Runs on Enter and on blur, so a name typed straight before clicking the
+   * dialog's submit button is not dropped. An empty name closes the input.
+   */
   const stageFolder = () => {
     const staged = stageMatterFolder(value, draftName ?? "");
     if (staged === null) {
+      setDraftName(null);
       return;
     }
     onChange(staged);
@@ -267,7 +274,10 @@ const FolderPicker = ({ value, onChange }: FolderPickerProps) => {
       return (
         <button
           className="hover:bg-accent text-muted-foreground flex w-full items-center gap-1 rounded px-2 py-1 text-start text-sm"
-          onClick={() => setDraftName("")}
+          onClick={() => {
+            draftCancelledRef.current = false;
+            setDraftName("");
+          }}
           type="button"
         >
           <FolderPlusIcon className="size-4 shrink-0" />
@@ -281,6 +291,13 @@ const FolderPicker = ({ value, onChange }: FolderPickerProps) => {
         autoFocus
         className="h-7 px-2 text-sm"
         maxLength={MAX_FOLDER_NAME_LENGTH}
+        onBlur={() => {
+          if (draftCancelledRef.current) {
+            draftCancelledRef.current = false;
+            return;
+          }
+          stageFolder();
+        }}
         onChange={(e) => setDraftName(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === "Enter") {
@@ -290,6 +307,7 @@ const FolderPicker = ({ value, onChange }: FolderPickerProps) => {
           if (e.key === "Escape") {
             // Cancel only the draft; the enclosing dialog dismisses on Escape.
             e.stopPropagation();
+            draftCancelledRef.current = true;
             setDraftName(null);
           }
         }}

--- a/apps/web/src/components/matter-target-picker.tsx
+++ b/apps/web/src/components/matter-target-picker.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 
-import { useQuery } from "@tanstack/react-query";
-import { ChevronRightIcon } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Result } from "better-result";
+import { ChevronRightIcon, FolderPlusIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { BidiText } from "@stll/ui/bidi-text";
@@ -12,11 +13,23 @@ import { ScrollArea } from "@stll/ui/scroll-area";
 import { cn } from "@stll/ui/utils";
 
 import { MatterIcon } from "@/components/matter-icon";
+import {
+  MAX_FOLDER_NAME_LENGTH,
+  resolveMatterTarget,
+  stageMatterFolder,
+} from "@/components/matter-target-picker.logic";
+import type { MatterTarget } from "@/components/matter-target-picker.logic";
 import Tooltip from "@/components/tooltip";
 import { EntityKindIcon } from "@/components/workspaces/entity-kind-icon";
+import { usePermissions } from "@/hooks/use-permissions";
 import { useAuthenticatedUser } from "@/lib/authenticated-user-context";
+import { detached } from "@/lib/detached";
+import { useCreateEntities } from "@/lib/workspaces/mutations/entities";
 import { workspacesOptions } from "@/lib/workspaces/queries";
-import { workspaceFoldersOptions } from "@/lib/workspaces/queries/entities";
+import {
+  entitiesKeys,
+  workspaceFoldersOptions,
+} from "@/lib/workspaces/queries/entities";
 import type { WorkspaceFolder } from "@/lib/workspaces/queries/entities";
 
 /**
@@ -27,9 +40,42 @@ import type { WorkspaceFolder } from "@/lib/workspaces/queries/entities";
  * dialog and the template "save to matter" flow.
  */
 
-export type MatterTarget = {
-  workspaceId: string;
-  parentId: string | null;
+/**
+ * Binds {@link resolveMatterTarget} to the entity-create mutation, then
+ * refreshes the target matter's folder tree so a freshly created folder is a
+ * real row the picker can show as selected. Callers must store the resolved
+ * target in place of a `pending` one, or a retry after a failed write creates
+ * the folder a second time. The folder is kept if the write then fails: an
+ * empty folder is cheaper for the user than a duplicate on retry.
+ */
+export const useResolveMatterTarget = () => {
+  const createEntities = useCreateEntities();
+  const queryClient = useQueryClient();
+
+  return async (target: MatterTarget) => {
+    const resolved = await resolveMatterTarget(
+      target,
+      async ({ workspaceId, parentId, name }) =>
+        await createEntities.mutateAsync({
+          type: "manual-input",
+          kind: "folder",
+          workspaceId,
+          parentId,
+          name,
+        }),
+    );
+    if (target.type === "pending" && Result.isOk(resolved)) {
+      // Not awaited: the active folder-tree query refetches on invalidation,
+      // and the caller's write must not wait behind it.
+      detached(
+        queryClient.invalidateQueries({
+          queryKey: entitiesKeys.all(target.workspaceId),
+        }),
+        "matter-target-picker.invalidate-folders",
+      );
+    }
+    return resolved;
+  };
 };
 
 type MatterTargetPickerProps = {
@@ -105,7 +151,11 @@ export const MatterTargetPicker = ({
                     )}
                     key={workspace.id}
                     onClick={() =>
-                      onChange({ workspaceId: workspace.id, parentId: null })
+                      onChange({
+                        type: "existing",
+                        workspaceId: workspace.id,
+                        parentId: null,
+                      })
                     }
                     type="button"
                   >
@@ -135,12 +185,12 @@ export const MatterTargetPicker = ({
       {showFolderPicker && value !== null && (
         <div className="space-y-2">
           <Label>{t("workspaces.copyToMatter.targetFolder")}</Label>
+          {/* Keyed by matter so expansion and the new-folder draft cannot
+              carry over to a different matter's tree. */}
           <FolderPicker
-            onSelect={(parentId) =>
-              onChange({ workspaceId: value.workspaceId, parentId })
-            }
-            selectedFolderId={value.parentId}
-            workspaceId={value.workspaceId}
+            key={value.workspaceId}
+            onChange={onChange}
+            value={value}
           />
         </div>
       )}
@@ -149,17 +199,14 @@ export const MatterTargetPicker = ({
 };
 
 type FolderPickerProps = {
-  workspaceId: string;
-  selectedFolderId: string | null;
-  onSelect: (folderId: string | null) => void;
+  value: MatterTarget;
+  onChange: (target: MatterTarget) => void;
 };
 
-const FolderPicker = ({
-  workspaceId,
-  selectedFolderId,
-  onSelect,
-}: FolderPickerProps) => {
+const FolderPicker = ({ value, onChange }: FolderPickerProps) => {
   const t = useTranslations();
+  const canCreate = usePermissions({ entity: ["create"] });
+  const workspaceId = value.workspaceId;
   const {
     data: folders,
     isLoading,
@@ -169,6 +216,8 @@ const FolderPicker = ({
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
     new Set(),
   );
+  /** `null` while the new-folder row is a button; a string while it is an input. */
+  const [draftName, setDraftName] = useState<string | null>(null);
 
   if (isLoading) {
     return (
@@ -187,6 +236,7 @@ const FolderPicker = ({
   }
 
   const rootFolders = folders ? folders.filter((f) => f.parentId === null) : [];
+  const pendingFolder = value.type === "pending" ? value : null;
 
   const toggleExpand = (folderId: string) => {
     setExpandedFolders((prev) => {
@@ -200,11 +250,85 @@ const FolderPicker = ({
     });
   };
 
+  /** Stage a folder under whatever is selected now; it is created on submit. */
+  const stageFolder = () => {
+    const staged = stageMatterFolder(value, draftName ?? "");
+    if (staged === null) {
+      return;
+    }
+    onChange(staged);
+    if (staged.parentId !== null) {
+      const parentId = staged.parentId;
+      setExpandedFolders((prev) => new Set(prev).add(parentId));
+    }
+    setDraftName(null);
+  };
+
+  const newFolderRow = (() => {
+    if (!canCreate) {
+      return null;
+    }
+    if (draftName === null) {
+      return (
+        <button
+          className="hover:bg-accent text-muted-foreground flex w-full items-center gap-1 rounded px-2 py-1 text-start text-sm"
+          onClick={() => setDraftName("")}
+          type="button"
+        >
+          <FolderPlusIcon className="size-4 shrink-0" />
+          <span className="truncate">{t("workspaces.newFolder")}</span>
+        </button>
+      );
+    }
+    return (
+      <Input
+        aria-label={t("workspaces.newFolder")}
+        autoFocus
+        className="h-7 px-2 text-sm"
+        maxLength={MAX_FOLDER_NAME_LENGTH}
+        onChange={(e) => setDraftName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            stageFolder();
+          }
+          if (e.key === "Escape") {
+            // Cancel only the draft; the enclosing dialog dismisses on Escape.
+            e.stopPropagation();
+            setDraftName(null);
+          }
+        }}
+        placeholder={t("workspaces.newFolder")}
+        value={draftName}
+      />
+    );
+  })();
+
+  const renderPendingFolder = (name: string, depth: number) => (
+    <div
+      className="flex items-center gap-1"
+      style={{ paddingLeft: `${depth * 16 + 8}px` }}
+    >
+      <span className="w-4" />
+      <div className="bg-accent flex min-w-0 flex-1 items-center gap-1 rounded px-2 py-1 text-sm">
+        <EntityKindIcon className="size-4 shrink-0" kind="folder" />
+        <BidiText as="span" className="truncate">
+          {name}
+        </BidiText>
+      </div>
+    </div>
+  );
+
   const renderFolder = (folder: WorkspaceFolder, depth: number) => {
-    const children = folders?.filter((f) => f.parentId === folder.entityId);
-    const hasChildren = children && children.length > 0;
+    const children = folders
+      ? folders.filter((f) => f.parentId === folder.entityId)
+      : [];
+    const pendingChild =
+      pendingFolder?.parentId === folder.entityId ? pendingFolder : null;
+    const hasChildren = children.length > 0 || pendingChild !== null;
     const isExpanded = expandedFolders.has(folder.entityId);
-    const isSelected = selectedFolderId === folder.entityId;
+    const isSelected =
+      value.type === "existing" && value.parentId === folder.entityId;
 
     return (
       <div key={folder.entityId}>
@@ -245,7 +369,13 @@ const FolderPicker = ({
               "hover:bg-accent flex min-w-0 flex-1 items-center gap-1 rounded px-2 py-1 text-start text-sm",
               isSelected && "bg-accent",
             )}
-            onClick={() => onSelect(folder.entityId)}
+            onClick={() =>
+              onChange({
+                type: "existing",
+                workspaceId,
+                parentId: folder.entityId,
+              })
+            }
             type="button"
           >
             <EntityKindIcon className="size-4 shrink-0" kind="folder" />
@@ -255,7 +385,11 @@ const FolderPicker = ({
           </button>
         </div>
         {hasChildren && isExpanded && (
-          <div>{children.map((child) => renderFolder(child, depth + 1))}</div>
+          <div>
+            {children.map((child) => renderFolder(child, depth + 1))}
+            {pendingChild !== null &&
+              renderPendingFolder(pendingChild.name, depth + 1)}
+          </div>
         )}
       </div>
     );
@@ -267,9 +401,11 @@ const FolderPicker = ({
         <button
           className={cn(
             "hover:bg-accent flex w-full items-center gap-1 rounded px-2 py-1 text-start text-sm",
-            selectedFolderId === null && "bg-accent",
+            value.type === "existing" && value.parentId === null && "bg-accent",
           )}
-          onClick={() => onSelect(null)}
+          onClick={() =>
+            onChange({ type: "existing", workspaceId, parentId: null })
+          }
           type="button"
         >
           <span className="text-muted-foreground">
@@ -277,6 +413,10 @@ const FolderPicker = ({
           </span>
         </button>
         {rootFolders.map((folder) => renderFolder(folder, 0))}
+        {pendingFolder !== null &&
+          pendingFolder.parentId === null &&
+          renderPendingFolder(pendingFolder.name, 0)}
+        {newFolderRow}
       </div>
     </ScrollArea>
   );

--- a/apps/web/src/components/templates/template-form.tsx
+++ b/apps/web/src/components/templates/template-form.tsx
@@ -46,8 +46,11 @@ import { stellaToast } from "@stll/ui/toast";
 import { cn } from "@stll/ui/utils";
 
 import { DatePickerPopover } from "@/components/date-picker-popover";
-import { MatterTargetPicker } from "@/components/matter-target-picker";
-import type { MatterTarget } from "@/components/matter-target-picker";
+import {
+  MatterTargetPicker,
+  useResolveMatterTarget,
+} from "@/components/matter-target-picker";
+import type { MatterTarget } from "@/components/matter-target-picker.logic";
 import type { ClauseBody } from "@/components/templates/clause-editor-types";
 import {
   buildAutofillUpdates,
@@ -2136,6 +2139,7 @@ export const TemplateForm = ({
   // ── Save to matter ────────────────────────────────
   const [matterDialogOpen, setMatterDialogOpen] = useState(false);
   const [matterTarget, setMatterTarget] = useState<MatterTarget | null>(null);
+  const resolveTarget = useResolveMatterTarget();
 
   /** Fill server-side and persist the result as a document entity in the
    *  given matter (the fill-to endpoint). Validates like a download. */
@@ -2237,9 +2241,28 @@ export const TemplateForm = ({
     }
   };
 
-  const fillToMatter = async (workspaceId: string, parentId: string | null) => {
+  /** Resolve inside the single flight so a double submit cannot create the
+   *  staged folder twice. */
+  const fillToMatter = async (target: MatterTarget) => {
     await runLeadingSingleFlight(fillToMatterFlight, async () => {
-      await performFillToMatter(workspaceId, parentId);
+      const resolved = await resolveTarget(target);
+      if (Result.isError(resolved)) {
+        stellaToast.add({ type: "error", title: t("errors.actionFailed") });
+        return;
+      }
+      if (target.type === "pending") {
+        // A staged folder now exists; keep it so a retry after a failed fill
+        // does not create a second one.
+        setMatterTarget({
+          type: "existing",
+          workspaceId: resolved.value.workspaceId,
+          parentId: resolved.value.parentId,
+        });
+      }
+      await performFillToMatter(
+        resolved.value.workspaceId,
+        resolved.value.parentId,
+      );
     });
   };
 
@@ -2276,7 +2299,11 @@ export const TemplateForm = ({
         return;
       }
       detached(
-        fillToMatter(saveTarget.workspaceId, saveTarget.parentId ?? null),
+        fillToMatter({
+          type: "existing",
+          workspaceId: saveTarget.workspaceId,
+          parentId: saveTarget.parentId ?? null,
+        }),
         "template-form.fill-to-matter",
       );
       return;
@@ -2308,7 +2335,11 @@ export const TemplateForm = ({
     }
     if (saveTarget?.kind === "matter") {
       detached(
-        fillToMatter(saveTarget.workspaceId, saveTarget.parentId ?? null),
+        fillToMatter({
+          type: "existing",
+          workspaceId: saveTarget.workspaceId,
+          parentId: saveTarget.parentId ?? null,
+        }),
         "template-form.fill-to-matter",
       );
     }
@@ -2591,10 +2622,7 @@ export const TemplateForm = ({
               onClick={() => {
                 if (matterTarget !== null) {
                   detached(
-                    fillToMatter(
-                      matterTarget.workspaceId,
-                      matterTarget.parentId,
-                    ),
+                    fillToMatter(matterTarget),
                     "template-form.fill-to-matter",
                   );
                 }

--- a/apps/web/src/components/templates/template-form.tsx
+++ b/apps/web/src/components/templates/template-form.tsx
@@ -2241,8 +2241,6 @@ export const TemplateForm = ({
     }
   };
 
-  /** Resolve inside the single flight so a double submit cannot create the
-   *  staged folder twice. */
   const fillToMatter = async (target: MatterTarget) => {
     await runLeadingSingleFlight(fillToMatterFlight, async () => {
       const resolved = await resolveTarget(target);

--- a/apps/web/src/components/workspaces/copy-to-matter-dialog.tsx
+++ b/apps/web/src/components/workspaces/copy-to-matter-dialog.tsx
@@ -20,8 +20,9 @@ import { stellaToast } from "@stll/ui/toast";
 
 import {
   MatterTargetPicker,
-  type MatterTarget,
+  useResolveMatterTarget,
 } from "@/components/matter-target-picker";
+import type { MatterTarget } from "@/components/matter-target-picker.logic";
 import {
   getCopyToMatterRootEntities,
   type CopyToMatterEntity,
@@ -57,10 +58,15 @@ export const CopyToMatterDialog = ({
   const [mode, setMode] = useState<MoveMode>("copy");
   const [target, setTarget] = useState<MatterTarget | null>(
     initialTargetWorkspaceId
-      ? { workspaceId: initialTargetWorkspaceId, parentId: null }
+      ? {
+          type: "existing",
+          workspaceId: initialTargetWorkspaceId,
+          parentId: null,
+        }
       : null,
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const resolveTarget = useResolveMatterTarget();
 
   // The dialog is mounted once and reused across drops, so re-seed the target
   // matter each time it opens with a fresh preset (drag-onto-matter path).
@@ -68,7 +74,11 @@ export const CopyToMatterDialog = ({
     if (open) {
       setTarget(
         initialTargetWorkspaceId
-          ? { workspaceId: initialTargetWorkspaceId, parentId: null }
+          ? {
+              type: "existing",
+              workspaceId: initialTargetWorkspaceId,
+              parentId: null,
+            }
           : null,
       );
     }
@@ -82,9 +92,26 @@ export const CopyToMatterDialog = ({
     if (!target) {
       return;
     }
-    const { workspaceId: targetWorkspaceId, parentId: targetParentId } = target;
 
     setIsSubmitting(true);
+
+    const resolved = await resolveTarget(target);
+    if (Result.isError(resolved)) {
+      setIsSubmitting(false);
+      stellaToast.add({ title: t("errors.actionFailed"), type: "error" });
+      return;
+    }
+    const { workspaceId: targetWorkspaceId, parentId: targetParentId } =
+      resolved.value;
+    if (target.type === "pending") {
+      // A staged folder now exists; keep it so a retry after a failed transfer
+      // does not create a second one.
+      setTarget({
+        type: "existing",
+        workspaceId: targetWorkspaceId,
+        parentId: targetParentId,
+      });
+    }
 
     let failedCount = 0;
     let firstErrorMessage: string | null = null;

--- a/apps/web/src/lib/workspaces/mutations/entities.ts
+++ b/apps/web/src/lib/workspaces/mutations/entities.ts
@@ -24,7 +24,6 @@ export const useCreateEntities = () => {
   const analytics = useAnalytics();
 
   return useMutation({
-    retry: 3,
     mutationFn: async ({ workspaceId, ...body }: CreateEntitiesVars) => {
       const response = await api
         .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })


### PR DESCRIPTION
## Proposed change

Lets the user create a folder in the target matter from the copy/move-to-matter screen instead of leaving to set up the structure first.

- `MatterTarget` becomes a discriminated union: `existing` (writable now) or `pending` (a staged folder with a name and an existing parent). The picker shows a "New folder" row under the selected folder; Enter stages it, Escape cancels only the draft. A pending folder always hangs off an existing folder or the root, so nesting pending folders is unrepresentable.
- Affects three areas of the UI: Copy to Matter, Email Attachment save, and Template Fill-to-Matter.
- The new folder is not created until until the caller writes. `useResolveMatterTarget` creates the _staged_ folder and returns a writable destination; the copy dialog, email-attachment save, and template fill-to-matter all resolve inside their existing single-flight guards and replace a `pending` target with the resolved one. (This is so a retry after a failed write does not create the folder twice.)
- Pure staging/resolution logic lives in `matter-target-picker.logic.ts` with unit tests.

Closes #1672

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [x] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [x] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [x] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)

https://github.com/user-attachments/assets/cfdd436d-0582-44d9-a083-0dc091f2b7ea




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline folder creation when selecting destinations for matters and attachments.
  * New folders can be named, staged, and created on submission.
  * Staged folders are retained for retries and displayed within the folder picker.
  * Folder paths now expand fully to show nested destinations.

* **Bug Fixes**
  * Improved destination handling when saving attachments, templates, and copied matters.
  * Added clearer error handling when folder creation or destination resolution fails.
  * Prevented invalid blank folder names and unintended nested pending folders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->