### PR TITLE
feat(lint): add safe automatic fixes

### DIFF
--- a/.oxlint-plugins/README.md
+++ b/.oxlint-plugins/README.md
@@ -12,6 +12,24 @@ local links in sync. `bash scripts/lint-oxlint-fixtures.sh` proves the positive 
 if a detector stops reporting, its intentionally suppressed fixture becomes an unused
 directive and CI fails.
 
+## Automatic fixes
+
+`oxlint --fix` repairs violations only when the rule can derive one local,
+deterministic result without choosing a domain value, dependency, or control-flow
+contract:
+
+- `no-physical-properties` maps physical Tailwind directions, including logical
+  corner radii and scroll spacing.
+- `no-awaited-builder-union` moves `await` into the leaves of a directly wrapped
+  conditional.
+- `no-coerced-optional-union-enum` expands inline string values in a namespaced
+  `t.Optional(t.UnionEnum(...))` call.
+
+Context-dependent forms remain diagnostics. `scripts/oxlint-safe-fixers.test.ts`
+runs the real CLI twice per repair, checks the exact output, and proves each fixer
+reaches a fixed point. It also checks representative ambiguous forms remain
+unchanged for a human or coding agent to resolve.
+
 ## How to read the catalogue
 
 The text below is a concise contract, not a claim that syntax analysis proves more

--- a/.oxlint-plugins/README.md
+++ b/.oxlint-plugins/README.md
@@ -18,8 +18,8 @@ directive and CI fails.
 deterministic result without choosing a domain value, dependency, or control-flow
 contract:
 
-- `no-physical-properties` maps physical Tailwind directions, including logical
-  corner radii and scroll spacing.
+- `no-physical-properties` maps physical Tailwind directions in direct JSX
+  `className` values, including logical corner radii and scroll spacing.
 - `no-awaited-builder-union` moves `await` into the leaves of a directly wrapped
   conditional.
 - `no-coerced-optional-union-enum` expands inline string values in a namespaced

--- a/.oxlint-plugins/no-awaited-builder-union.ts
+++ b/.oxlint-plugins/no-awaited-builder-union.ts
@@ -86,6 +86,24 @@ const collectBranches = (node, branches) => {
   return branches;
 };
 
+// A wrapper anywhere inside the conditional tree can change what a TypeScript
+// assertion constrains after branchwise `await` insertion. Keep the diagnostic,
+// but refuse the fix even when the wrapped expression is itself a nested
+// conditional rather than a final leaf.
+const hasFixUnsafeWrapper = (node) => {
+  const expression = unwrapWrappers(node);
+  if (expression !== node) {
+    return true;
+  }
+  if (expression?.type !== "ConditionalExpression") {
+    return false;
+  }
+  return (
+    hasFixUnsafeWrapper(expression.consequent) ||
+    hasFixUnsafeWrapper(expression.alternate)
+  );
+};
+
 // Resolve an expression to its root plus the member/call steps applied to it,
 // outermost step last:
 //   query                      -> root "query",      steps [".for()"]…
@@ -229,9 +247,7 @@ export default eslintCompatPlugin({
               fix: (fixer) => {
                 const awaitEnd = node.range[0] + AWAIT_KEYWORD_LENGTH;
                 const branches = collectBranches(node.argument, []);
-                if (
-                  branches.some((branch) => unwrapWrappers(branch) !== branch)
-                ) {
+                if (hasFixUnsafeWrapper(node.argument)) {
                   return null;
                 }
                 const hasInterveningComment = context.sourceCode

--- a/.oxlint-plugins/no-awaited-builder-union.ts
+++ b/.oxlint-plugins/no-awaited-builder-union.ts
@@ -28,9 +28,9 @@
 //   const q = lock ? query.for("update") : query     // not awaited
 //
 // `--fix` performs the branchwise-await rewrite when the await directly wraps
-// the conditional. TypeScript wrappers around the whole conditional remain a
-// diagnostic because moving the wrapper into each branch requires a semantic
-// choice about which expression the assertion should constrain.
+// the conditional. TypeScript wrappers around the whole conditional or either
+// branch remain a diagnostic because moving them requires a semantic choice
+// about which expression the assertion should constrain.
 //
 // Also allowed, and the reason detection is not merely "steps differ":
 //   await (json ? response.json() : response.text())  // siblings, no builder
@@ -80,7 +80,9 @@ const collectBranches = (node, branches) => {
     collectBranches(expression.alternate, branches);
     return branches;
   }
-  branches.push(expression);
+  // Keep the original leaf so the fixer can refuse branch-local TypeScript
+  // wrappers. describeChain still unwraps it for detection.
+  branches.push(node);
   return branches;
 };
 
@@ -226,13 +228,28 @@ export default eslintCompatPlugin({
               data: { root: first.root },
               fix: (fixer) => {
                 const awaitEnd = node.range[0] + AWAIT_KEYWORD_LENGTH;
+                const branches = collectBranches(node.argument, []);
+                if (
+                  branches.some((branch) => unwrapWrappers(branch) !== branch)
+                ) {
+                  return null;
+                }
+                const hasInterveningComment = context.sourceCode
+                  .getAllComments()
+                  .some(
+                    (comment) =>
+                      comment.range[0] >= awaitEnd &&
+                      comment.range[0] < node.argument.range[0],
+                  );
+                if (hasInterveningComment) {
+                  return null;
+                }
                 let removalEnd = awaitEnd;
                 while (
                   /\s/u.test(context.sourceCode.text.at(removalEnd) ?? "")
                 ) {
                   removalEnd += 1;
                 }
-                const branches = collectBranches(node.argument, []);
                 return [
                   fixer.removeRange([node.range[0], removalEnd]),
                   ...branches.map((branch) =>

--- a/.oxlint-plugins/no-awaited-builder-union.ts
+++ b/.oxlint-plugins/no-awaited-builder-union.ts
@@ -27,6 +27,11 @@
 //   await (paged ? loadRows(1) : loadRows(2))        // same call, one type
 //   const q = lock ? query.for("update") : query     // not awaited
 //
+// `--fix` performs the branchwise-await rewrite when the await directly wraps
+// the conditional. TypeScript wrappers around the whole conditional remain a
+// diagnostic because moving the wrapper into each branch requires a semantic
+// choice about which expression the assertion should constrain.
+//
 // Also allowed, and the reason detection is not merely "steps differ":
 //   await (json ? response.json() : response.text())  // siblings, no builder
 //   await (primary ? jobs.primary : jobs.secondary)   // siblings, no builder
@@ -48,6 +53,8 @@
 import { eslintCompatPlugin } from "@oxlint/plugins";
 
 import { getPropertyName } from "./utils.ts";
+
+const AWAIT_KEYWORD_LENGTH = "await".length;
 
 // Peel TS-only and optional-chain wrappers so a shape check sees the
 // underlying expression.
@@ -172,6 +179,7 @@ export default eslintCompatPlugin({
     "no-awaited-builder-union": {
       meta: {
         type: "problem",
+        fixable: "code",
         messages: {
           awaitedBuilderUnion:
             "Awaiting a ternary over two chain states of `{{root}}` makes " +
@@ -204,10 +212,34 @@ export default eslintCompatPlugin({
             if (!isBuilderChainUnion(chains)) {
               return;
             }
+            if (node.argument.type !== "ConditionalExpression") {
+              context.report({
+                node,
+                messageId: "awaitedBuilderUnion",
+                data: { root: first.root },
+              });
+              return;
+            }
             context.report({
               node,
               messageId: "awaitedBuilderUnion",
               data: { root: first.root },
+              fix: (fixer) => {
+                const awaitEnd = node.range[0] + AWAIT_KEYWORD_LENGTH;
+                let removalEnd = awaitEnd;
+                while (
+                  /\s/u.test(context.sourceCode.text.at(removalEnd) ?? "")
+                ) {
+                  removalEnd += 1;
+                }
+                const branches = collectBranches(node.argument, []);
+                return [
+                  fixer.removeRange([node.range[0], removalEnd]),
+                  ...branches.map((branch) =>
+                    fixer.insertTextBefore(branch, "await "),
+                  ),
+                ];
+              },
             });
           },
         };

--- a/.oxlint-plugins/no-coerced-optional-union-enum.ts
+++ b/.oxlint-plugins/no-coerced-optional-union-enum.ts
@@ -19,6 +19,11 @@
 //   type: t.Optional(t.Union([t.Literal("person"), t.Literal("organization")]))
 //   fieldMode: t.Optional(t.Union([t.Literal("full"), t.Literal("visible")]))
 //
+// `--fix` expands a namespaced call whose values are inline string literals.
+// Dynamic value arrays and destructured helper calls remain diagnostics because
+// the fixer cannot expand the former or prove the latter has `Union` and
+// `Literal` bindings in scope.
+//
 // Both callees are matched by leaf name, so the namespaced
 // `t.Optional(t.UnionEnum(...))` and a destructured `Optional(UnionEnum(...))`
 // (`const { Optional, UnionEnum } = t`) are caught the same way.
@@ -36,12 +41,45 @@ const memberName = (node) => {
   }
   if (
     node.type === "MemberExpression" &&
-    node.property &&
-    node.property.type === "Identifier"
+    node.property?.type === "Identifier"
   ) {
     return node.property.name;
   }
   return null;
+};
+
+const namespacedCallee = (node, expectedName) => {
+  if (
+    node?.type !== "MemberExpression" ||
+    node.computed ||
+    node.object.type !== "Identifier" ||
+    node.property.type !== "Identifier" ||
+    node.property.name !== expectedName
+  ) {
+    return null;
+  }
+  return node;
+};
+
+const staticUnionEnumElements = (node) => {
+  if (node.arguments.length !== 1) {
+    return null;
+  }
+  const values = node.arguments.at(0);
+  if (values?.type !== "ArrayExpression") {
+    return null;
+  }
+  if (
+    values.elements.some(
+      (element) =>
+        element === null ||
+        element.type !== "Literal" ||
+        typeof element.value !== "string",
+    )
+  ) {
+    return null;
+  }
+  return values.elements;
 };
 
 export default eslintCompatPlugin({
@@ -50,6 +88,7 @@ export default eslintCompatPlugin({
     "no-coerced-optional-union-enum": {
       meta: {
         type: "problem",
+        fixable: "code",
         messages: {
           coerced:
             "`t.Optional(t.UnionEnum(...))` coerces an absent field to its " +
@@ -64,14 +103,39 @@ export default eslintCompatPlugin({
             if (memberName(node.callee) !== "Optional") {
               return;
             }
-            const arg = node.arguments && node.arguments[0];
+            const arg = node.arguments.at(0);
             if (
-              arg &&
-              arg.type === "CallExpression" &&
-              memberName(arg.callee) === "UnionEnum"
+              arg?.type !== "CallExpression" ||
+              memberName(arg.callee) !== "UnionEnum"
+            ) {
+              return;
+            }
+            const optionalCallee = namespacedCallee(node.callee, "Optional");
+            const unionEnumCallee = namespacedCallee(arg.callee, "UnionEnum");
+            const elements = staticUnionEnumElements(arg);
+            if (
+              optionalCallee === null ||
+              unionEnumCallee === null ||
+              optionalCallee.object.name !== unionEnumCallee.object.name ||
+              elements === null
             ) {
               context.report({ node, messageId: "coerced" });
+              return;
             }
+            context.report({
+              node,
+              messageId: "coerced",
+              fix: (fixer) => [
+                fixer.replaceText(unionEnumCallee.property, "Union"),
+                ...elements.flatMap((element) => [
+                  fixer.insertTextBefore(
+                    element,
+                    `${optionalCallee.object.name}.Literal(`,
+                  ),
+                  fixer.insertTextAfter(element, ")"),
+                ]),
+              ],
+            });
           },
         };
       },

--- a/.oxlint-plugins/no-physical-properties.ts
+++ b/.oxlint-plugins/no-physical-properties.ts
@@ -13,7 +13,10 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 // ESM resolver as well as Bun's, and Node does not infer one. Without it the
 // whole plugin set fails to load under Node, and the error names this file's
 // import rather than whatever the caller was linting.
-import { hasPhysicalProperty } from "./physical-properties.ts";
+import {
+  hasPhysicalProperty,
+  replacePhysicalProperties,
+} from "./physical-properties.ts";
 
 export default eslintCompatPlugin({
   meta: { name: "no-physical-properties" },
@@ -21,6 +24,7 @@ export default eslintCompatPlugin({
     "no-physical-properties": {
       meta: {
         type: "problem",
+        fixable: "code",
         messages: {
           physicalProperty:
             "Physical directional CSS property breaks RTL. " +
@@ -42,6 +46,13 @@ export default eslintCompatPlugin({
               context.report({
                 node,
                 messageId: "physicalProperty",
+                fix: (fixer) => {
+                  const source = context.sourceCode.getText(node);
+                  const replacement = replacePhysicalProperties(source);
+                  return replacement === source
+                    ? null
+                    : fixer.replaceText(node, replacement);
+                },
               });
             }
           },
@@ -50,6 +61,13 @@ export default eslintCompatPlugin({
               context.report({
                 node,
                 messageId: "physicalProperty",
+                fix: (fixer) => {
+                  const source = context.sourceCode.getText(node);
+                  const replacement = replacePhysicalProperties(source);
+                  return replacement === source
+                    ? null
+                    : fixer.replaceText(node, replacement);
+                },
               });
             }
           },

--- a/.oxlint-plugins/no-physical-properties.ts
+++ b/.oxlint-plugins/no-physical-properties.ts
@@ -44,6 +44,10 @@ const isDirectClassNameValue = (node) => {
   const container = template?.parent;
   return (
     template?.type === "TemplateLiteral" &&
+    // A later quasi may continue an arbitrary bracket payload opened before
+    // or by an interpolation. Its class-token boundaries are not independently
+    // provable, so keep those matches diagnostic-only.
+    template.quasis.at(0) === node &&
     container?.type === "JSXExpressionContainer" &&
     container.expression === template &&
     isClassNameAttribute(container.parent)

--- a/.oxlint-plugins/no-physical-properties.ts
+++ b/.oxlint-plugins/no-physical-properties.ts
@@ -64,6 +64,16 @@ const reportPhysicalProperty = (context, node) => {
     messageId: "physicalProperty",
     fix: (fixer) => {
       const source = context.sourceCode.getText(node);
+      // The rule detects literals from their cooked value, while a fixer edits
+      // raw source. Escapes or JSX character references can therefore hide an
+      // arbitrary-value bracket from the source scanner. Keep such values
+      // diagnostic-only instead of guessing at their decoded boundaries.
+      if (
+        source.includes("\\") ||
+        /&(?:#(?:x[\da-f]+|\d+)|[a-z][\da-z]+);/iu.test(source)
+      ) {
+        return null;
+      }
       const replacement = replacePhysicalProperties(source);
       return replacement === source
         ? null

--- a/.oxlint-plugins/no-physical-properties.ts
+++ b/.oxlint-plugins/no-physical-properties.ts
@@ -18,6 +18,56 @@ import {
   replacePhysicalProperties,
 } from "./physical-properties.ts";
 
+const isClassNameAttribute = (node) =>
+  node?.type === "JSXAttribute" &&
+  node.name.type === "JSXIdentifier" &&
+  node.name.name === "className";
+
+// Only direct JSX className values prove that a matched token is a Tailwind
+// class. Other strings still receive the diagnostic, but not a potentially
+// meaning-changing fix (for example, prose containing "right-click").
+const isDirectClassNameValue = (node) => {
+  if (isClassNameAttribute(node.parent) && node.parent.value === node) {
+    return true;
+  }
+  if (
+    node.parent?.type === "JSXExpressionContainer" &&
+    node.parent.expression === node &&
+    isClassNameAttribute(node.parent.parent)
+  ) {
+    return true;
+  }
+  if (node.type !== "TemplateElement") {
+    return false;
+  }
+  const template = node.parent;
+  const container = template?.parent;
+  return (
+    template?.type === "TemplateLiteral" &&
+    container?.type === "JSXExpressionContainer" &&
+    container.expression === template &&
+    isClassNameAttribute(container.parent)
+  );
+};
+
+const reportPhysicalProperty = (context, node) => {
+  if (!isDirectClassNameValue(node)) {
+    context.report({ node, messageId: "physicalProperty" });
+    return;
+  }
+  context.report({
+    node,
+    messageId: "physicalProperty",
+    fix: (fixer) => {
+      const source = context.sourceCode.getText(node);
+      const replacement = replacePhysicalProperties(source);
+      return replacement === source
+        ? null
+        : fixer.replaceText(node, replacement);
+    },
+  });
+};
+
 export default eslintCompatPlugin({
   meta: { name: "no-physical-properties" },
   rules: {
@@ -43,32 +93,12 @@ export default eslintCompatPlugin({
               return;
             }
             if (hasPhysicalProperty(node.value)) {
-              context.report({
-                node,
-                messageId: "physicalProperty",
-                fix: (fixer) => {
-                  const source = context.sourceCode.getText(node);
-                  const replacement = replacePhysicalProperties(source);
-                  return replacement === source
-                    ? null
-                    : fixer.replaceText(node, replacement);
-                },
-              });
+              reportPhysicalProperty(context, node);
             }
           },
           TemplateElement(node) {
             if (hasPhysicalProperty(node.value.raw)) {
-              context.report({
-                node,
-                messageId: "physicalProperty",
-                fix: (fixer) => {
-                  const source = context.sourceCode.getText(node);
-                  const replacement = replacePhysicalProperties(source);
-                  return replacement === source
-                    ? null
-                    : fixer.replaceText(node, replacement);
-                },
-              });
+              reportPhysicalProperty(context, node);
             }
           },
         };

--- a/.oxlint-plugins/physical-properties.ts
+++ b/.oxlint-plugins/physical-properties.ts
@@ -105,11 +105,27 @@ const replaceOutsideArbitraryBrackets = (
   let bracketStart = 0;
   let depth = 0;
   let escaped = false;
+  let quote: string | null = null;
 
   for (let index = 0; index < value.length; index += 1) {
     const character = value[index];
     if (character === "\\" && !escaped) {
       escaped = true;
+      continue;
+    }
+    if (depth > 0 && quote !== null) {
+      if (!escaped && character === quote) {
+        quote = null;
+      }
+      escaped = false;
+      continue;
+    }
+    if (
+      !escaped &&
+      depth > 0 &&
+      (character === '"' || character === "'" || character === "`")
+    ) {
+      quote = character;
       continue;
     }
     if (!escaped && character === "[") {

--- a/.oxlint-plugins/physical-properties.ts
+++ b/.oxlint-plugins/physical-properties.ts
@@ -92,10 +92,52 @@ const PHYSICAL_REPLACEMENTS = [
     ),
 ] as const satisfies readonly ((value: string) => string)[];
 
+// Tailwind arbitrary values and selectors may contain prose or CSS whose
+// physical-looking words are data, not utility names. Apply a replacement only
+// outside balanced square brackets; an unclosed bracket conservatively protects
+// the rest of the value.
+const replaceOutsideArbitraryBrackets = (
+  value: string,
+  replace: (segment: string) => string,
+): string => {
+  let result = "";
+  let segmentStart = 0;
+  let bracketStart = 0;
+  let depth = 0;
+  let escaped = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (character === "\\" && !escaped) {
+      escaped = true;
+      continue;
+    }
+    if (!escaped && character === "[") {
+      if (depth === 0) {
+        result += replace(value.slice(segmentStart, index));
+        bracketStart = index;
+      }
+      depth += 1;
+    } else if (!escaped && character === "]" && depth > 0) {
+      depth -= 1;
+      if (depth === 0) {
+        result += value.slice(bracketStart, index + 1);
+        segmentStart = index + 1;
+      }
+    }
+    escaped = false;
+  }
+
+  if (depth > 0) {
+    return result + value.slice(bracketStart);
+  }
+  return result + replace(value.slice(segmentStart));
+};
+
 export const replacePhysicalProperties = (value: string): string => {
   let replaced = value;
   for (const replace of PHYSICAL_REPLACEMENTS) {
-    replaced = replace(replaced);
+    replaced = replaceOutsideArbitraryBrackets(replaced, replace);
   }
   return replaced;
 };

--- a/.oxlint-plugins/physical-properties.ts
+++ b/.oxlint-plugins/physical-properties.ts
@@ -7,14 +7,98 @@
 // rule (apps/web / packages/ui / packages/folio `.tsx`) and the landing's
 // .astro check (which oxlint cannot parse), so the two cannot drift.
 
-export const PHYSICAL_PATTERNS: readonly RegExp[] = [
-  /(?:^|[\s"'`{(])(?:-?)(?:[\w[\]:]*:)?(?:ml|mr|pl|pr)-/,
-  /(?:^|[\s"'`{(])(?:[\w[\]:]*:)?text-(?:left|right)(?=["'\s`})]|$)/,
-  /(?:^|[\s"'`{(])(?:[\w[\]:]*:)?border-[lr](?=[-\s"'`})]|$)/,
-  /(?:^|[\s"'`{(])(?:[\w[\]:]*:)?rounded-(?:l|r|tl|tr|bl|br)(?=[-\s"'`})]|$)/,
-  /(?:^|[\s"'`{(])(?:-?)(?:[\w[\]:]*:)?(?:left|right)-/,
-  /(?:^|[\s"'`{(])(?:[\w[\]:]*:)?scroll-(?:ml|mr|pl|pr)-/,
-];
+const PHYSICAL_REPLACEMENTS = [
+  (value) =>
+    value.replace(/(^|[\s"'`{(])(-?)((?:[\w[\]:]*:)?)ml-/gu, "$1$2$3ms-"),
+  (value) =>
+    value.replace(/(^|[\s"'`{(])(-?)((?:[\w[\]:]*:)?)mr-/gu, "$1$2$3me-"),
+  (value) =>
+    value.replace(/(^|[\s"'`{(])(-?)((?:[\w[\]:]*:)?)pl-/gu, "$1$2$3ps-"),
+  (value) =>
+    value.replace(/(^|[\s"'`{(])(-?)((?:[\w[\]:]*:)?)pr-/gu, "$1$2$3pe-"),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)text-left(?=["'\s`})]|$)/gu,
+      "$1$2text-start",
+    ),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)text-right(?=["'\s`})]|$)/gu,
+      "$1$2text-end",
+    ),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)border-l(?=[-\s"'`})]|$)/gu,
+      "$1$2border-s",
+    ),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)border-r(?=[-\s"'`})]|$)/gu,
+      "$1$2border-e",
+    ),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)rounded-tl(?=[-\s"'`})]|$)/gu,
+      "$1$2rounded-ss",
+    ),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)rounded-tr(?=[-\s"'`})]|$)/gu,
+      "$1$2rounded-se",
+    ),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)rounded-bl(?=[-\s"'`})]|$)/gu,
+      "$1$2rounded-es",
+    ),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)rounded-br(?=[-\s"'`})]|$)/gu,
+      "$1$2rounded-ee",
+    ),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)rounded-l(?=[-\s"'`})]|$)/gu,
+      "$1$2rounded-s",
+    ),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)rounded-r(?=[-\s"'`})]|$)/gu,
+      "$1$2rounded-e",
+    ),
+  (value) =>
+    value.replace(/(^|[\s"'`{(])(-?)((?:[\w[\]:]*:)?)left-/gu, "$1$2$3start-"),
+  (value) =>
+    value.replace(/(^|[\s"'`{(])(-?)((?:[\w[\]:]*:)?)right-/gu, "$1$2$3end-"),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)scroll-ml-/gu,
+      "$1$2scroll-ms-",
+    ),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)scroll-mr-/gu,
+      "$1$2scroll-me-",
+    ),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)scroll-pl-/gu,
+      "$1$2scroll-ps-",
+    ),
+  (value) =>
+    value.replace(
+      /(^|[\s"'`{(])((?:[\w[\]:]*:)?)scroll-pr-/gu,
+      "$1$2scroll-pe-",
+    ),
+] as const satisfies readonly ((value: string) => string)[];
+
+export const replacePhysicalProperties = (value: string): string => {
+  let replaced = value;
+  for (const replace of PHYSICAL_REPLACEMENTS) {
+    replaced = replace(replaced);
+  }
+  return replaced;
+};
 
 export const hasPhysicalProperty = (value: string): boolean =>
-  PHYSICAL_PATTERNS.some((pattern) => pattern.test(value));
+  PHYSICAL_REPLACEMENTS.some((replace) => replace(value) !== value);

--- a/scripts/code-check-affected.test.ts
+++ b/scripts/code-check-affected.test.ts
@@ -183,6 +183,7 @@ describe("affected code-check planning", () => {
   test.each([
     ["scripts/check-oxlint-plugin-registry.ts", "plugin-registry"],
     ["scripts/lint-oxlint-fixtures.sh", "plugin-fixtures"],
+    ["scripts/oxlint-safe-fixers.test.ts", "plugin-fixtures"],
     ["scripts/lint-root-scripts.sh", "root-script-lint"],
     ["scripts/tsconfig.json", "root-script-lint"],
     ["tsconfig.json", "plugin-fixtures"],
@@ -333,6 +334,9 @@ describe("Turbo cache input contract", () => {
     );
     expect(PLUGIN_FIXTURE_INPUTS).toContain(
       "$TURBO_ROOT$/scripts/lint-oxlint-fixtures.sh",
+    );
+    expect(PLUGIN_FIXTURE_INPUTS).toContain(
+      "$TURBO_ROOT$/scripts/oxlint-safe-fixers.test.ts",
     );
   });
 

--- a/scripts/code-check-affected.ts
+++ b/scripts/code-check-affected.ts
@@ -55,6 +55,7 @@ export const PLUGIN_FIXTURE_INPUTS = [
   ...SHARED_COMPILER_CACHE_INPUTS,
   ...OXLINT_CONFIGURATION_CACHE_INPUTS,
   "$TURBO_ROOT$/scripts/lint-oxlint-fixtures.sh",
+  "$TURBO_ROOT$/scripts/oxlint-safe-fixers.test.ts",
   "$TURBO_ROOT$/tsconfig.json",
   "$TURBO_ROOT$/tsconfig.oxlint-plugins.json",
 ] as const;

--- a/scripts/lint-oxlint-fixtures.sh
+++ b/scripts/lint-oxlint-fixtures.sh
@@ -36,6 +36,8 @@ if grep -qE "Failed to load JS plugin|ERR_MODULE_NOT_FOUND" \
   exit 1
 fi
 
+bun test ./scripts/oxlint-safe-fixers.test.ts
+
 exec bun --bun oxlint -c oxlint.config.ts \
   --report-unused-disable-directives-severity=error \
   --deny-warnings \

--- a/scripts/oxlint-safe-fixers.test.ts
+++ b/scripts/oxlint-safe-fixers.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const REPOSITORY_ROOT = path.resolve(import.meta.dir, "..");
+const temporaryDirectories: string[] = [];
+
+setDefaultTimeout(20_000);
+
+const PLUGINS = [
+  "no-awaited-builder-union",
+  "no-coerced-optional-union-enum",
+  "no-physical-properties",
+] as const;
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map(
+        async (directory) =>
+          await rm(directory, { force: true, recursive: true }),
+      ),
+  );
+});
+
+type FixCase = {
+  expected: string;
+  source: string;
+};
+
+const runOxlint = async (configPath: string, sourcePath: string) => {
+  const spawned = Bun.spawn(
+    [
+      process.execPath,
+      "--bun",
+      "oxlint",
+      "-c",
+      configPath,
+      "--fix",
+      sourcePath,
+    ],
+    {
+      cwd: REPOSITORY_ROOT,
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
+  const [exitCode, stderr, stdout] = await Promise.all([
+    spawned.exited,
+    new Response(spawned.stderr).text(),
+    new Response(spawned.stdout).text(),
+  ]);
+  return { exitCode, output: `${stdout}\n${stderr}` };
+};
+
+const writeHarness = async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "stella-oxlint-fixers-"));
+  temporaryDirectories.push(directory);
+  const configPath = path.join(directory, "oxlint.config.ts");
+  const jsPlugins = PLUGINS.map((plugin) =>
+    path.join(REPOSITORY_ROOT, ".oxlint-plugins", `${plugin}.ts`),
+  );
+  const rules = Object.fromEntries(
+    PLUGINS.map((plugin) => [`${plugin}/${plugin}`, "error"]),
+  );
+  await Bun.write(
+    configPath,
+    `export default ${JSON.stringify({ jsPlugins, rules })};\n`,
+  );
+  return { configPath, directory };
+};
+
+const expectFixedPoint = async ({ expected, source }: FixCase) => {
+  const { configPath, directory } = await writeHarness();
+  const sourcePath = path.join(directory, "subject.ts");
+  await Bun.write(sourcePath, source);
+
+  const firstRun = await runOxlint(configPath, sourcePath);
+  expect(firstRun.exitCode).toBe(0);
+  for (const plugin of PLUGINS) {
+    expect(firstRun.output).not.toContain(`${plugin}/${plugin}`);
+  }
+  expect(await Bun.file(sourcePath).text()).toBe(expected);
+
+  const secondRun = await runOxlint(configPath, sourcePath);
+  expect(secondRun.exitCode).toBe(0);
+  for (const plugin of PLUGINS) {
+    expect(secondRun.output).not.toContain(`${plugin}/${plugin}`);
+  }
+  expect(await Bun.file(sourcePath).text()).toBe(expected);
+};
+
+describe.serial("custom oxlint safe fixers", () => {
+  test("rewrites every supported physical Tailwind direction", async () => {
+    await expectFixedPoint({
+      source:
+        'const classes = "ml-2 mr-3 pl-4 pr-5 -left-1 right-[2px] text-left text-right border-l border-r-2 rounded-l rounded-r-xl rounded-tl-md rounded-tr rounded-bl-lg rounded-br scroll-ml-2 scroll-mr-2 scroll-pl-3 hover:scroll-pr-3";\nconst template = `hover:pr-4 md:rounded-l-lg`;\n',
+      expected:
+        'const classes = "ms-2 me-3 ps-4 pe-5 -start-1 end-[2px] text-start text-end border-s border-e-2 rounded-s rounded-e-xl rounded-ss-md rounded-se rounded-es-lg rounded-ee scroll-ms-2 scroll-me-2 scroll-ps-3 hover:scroll-pe-3";\nconst template = `hover:pe-4 md:rounded-s-lg`;\n',
+    });
+  });
+
+  test("moves await into direct builder-union branches", async () => {
+    await expectFixedPoint({
+      source:
+        "async function load() { return await\n  (lock ? query : paged ? query.limit(1) : query.offset(2)); }\n",
+      expected:
+        "async function load() { return (lock ? await query : paged ? await query.limit(1) : await query.offset(2)); }\n",
+    });
+  });
+
+  test("expands a static namespaced optional UnionEnum", async () => {
+    await expectFixedPoint({
+      source:
+        'const schema = t.Optional(t.UnionEnum(["person", /* keep */ "organization"]));\n',
+      expected:
+        'const schema = t.Optional(t.Union([t.Literal("person"), /* keep */ t.Literal("organization")]));\n',
+    });
+  });
+
+  test("leaves context-dependent violations for the agent", async () => {
+    const { configPath, directory } = await writeHarness();
+    const sourcePath = path.join(directory, "subject.ts");
+    const source = [
+      "async function load() {",
+      "  return await ((lock ? query.for('update') : query) satisfies Builder);",
+      "}",
+      "const schema = t.Optional(t.UnionEnum(VALUES));",
+      "",
+    ].join("\n");
+    await Bun.write(sourcePath, source);
+
+    const result = await runOxlint(configPath, sourcePath);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("no-awaited-builder-union");
+    expect(result.output).toContain("no-coerced-optional-union-enum");
+    expect(await Bun.file(sourcePath).text()).toBe(source);
+  });
+});

--- a/scripts/oxlint-safe-fixers.test.ts
+++ b/scripts/oxlint-safe-fixers.test.ts
@@ -142,6 +142,7 @@ describe.serial("custom oxlint safe fixers", () => {
       "const schema = t.Optional(t.UnionEnum(VALUES));",
       'const guidance = "Use right-click to open the menu";',
       `const arbitraryContent = <span className="before:content-['right-click']" />;`,
+      `const quotedBracketContent = <span className="before:content-['a] right-click']" />;`,
       "const interpolatedArbitrary = <span className={`content-[$" +
         "{prefix} right-click] mr-2`} />;",
       "",

--- a/scripts/oxlint-safe-fixers.test.ts
+++ b/scripts/oxlint-safe-fixers.test.ts
@@ -27,6 +27,7 @@ afterEach(async () => {
 
 type FixCase = {
   expected: string;
+  fileName?: string;
   source: string;
 };
 
@@ -72,9 +73,9 @@ const writeHarness = async () => {
   return { configPath, directory };
 };
 
-const expectFixedPoint = async ({ expected, source }: FixCase) => {
+const expectFixedPoint = async ({ expected, fileName, source }: FixCase) => {
   const { configPath, directory } = await writeHarness();
-  const sourcePath = path.join(directory, "subject.ts");
+  const sourcePath = path.join(directory, fileName ?? "subject.ts");
   await Bun.write(sourcePath, source);
 
   const firstRun = await runOxlint(configPath, sourcePath);
@@ -95,10 +96,11 @@ const expectFixedPoint = async ({ expected, source }: FixCase) => {
 describe.serial("custom oxlint safe fixers", () => {
   test("rewrites every supported physical Tailwind direction", async () => {
     await expectFixedPoint({
+      fileName: "subject.tsx",
       source:
-        'const classes = "ml-2 mr-3 pl-4 pr-5 -left-1 right-[2px] text-left text-right border-l border-r-2 rounded-l rounded-r-xl rounded-tl-md rounded-tr rounded-bl-lg rounded-br scroll-ml-2 scroll-mr-2 scroll-pl-3 hover:scroll-pr-3";\nconst template = `hover:pr-4 md:rounded-l-lg`;\n',
+        'export const view = <div className="ml-2 mr-3 pl-4 pr-5 -left-1 right-[2px] text-left text-right border-l border-r-2 rounded-l rounded-r-xl rounded-tl-md rounded-tr rounded-bl-lg rounded-br scroll-ml-2 scroll-mr-2 scroll-pl-3 hover:scroll-pr-3" />;\nexport const template = <div className={`hover:pr-4 md:rounded-l-lg`} />;\n',
       expected:
-        'const classes = "ms-2 me-3 ps-4 pe-5 -start-1 end-[2px] text-start text-end border-s border-e-2 rounded-s rounded-e-xl rounded-ss-md rounded-se rounded-es-lg rounded-ee scroll-ms-2 scroll-me-2 scroll-ps-3 hover:scroll-pe-3";\nconst template = `hover:pe-4 md:rounded-s-lg`;\n',
+        'export const view = <div className="ms-2 me-3 ps-4 pe-5 -start-1 end-[2px] text-start text-end border-s border-e-2 rounded-s rounded-e-xl rounded-ss-md rounded-se rounded-es-lg rounded-ee scroll-ms-2 scroll-me-2 scroll-ps-3 hover:scroll-pe-3" />;\nexport const template = <div className={`hover:pe-4 md:rounded-s-lg`} />;\n',
     });
   });
 
@@ -127,7 +129,15 @@ describe.serial("custom oxlint safe fixers", () => {
       "async function load() {",
       "  return await ((lock ? query.for('update') : query) satisfies Builder);",
       "}",
+      "async function loadWithRationale() {",
+      "  return await // preserve rationale",
+      "    (lock ? query : query.limit(1));",
+      "}",
+      "async function loadWithBranchWrappers() {",
+      "  return await (lock ? (query as Builder) : (query.limit(1) satisfies Builder));",
+      "}",
       "const schema = t.Optional(t.UnionEnum(VALUES));",
+      'const guidance = "Use right-click to open the menu";',
       "",
     ].join("\n");
     await Bun.write(sourcePath, source);
@@ -136,6 +146,7 @@ describe.serial("custom oxlint safe fixers", () => {
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain("no-awaited-builder-union");
     expect(result.output).toContain("no-coerced-optional-union-enum");
+    expect(result.output).toContain("no-physical-properties");
     expect(await Bun.file(sourcePath).text()).toBe(source);
   });
 });

--- a/scripts/oxlint-safe-fixers.test.ts
+++ b/scripts/oxlint-safe-fixers.test.ts
@@ -143,6 +143,7 @@ describe.serial("custom oxlint safe fixers", () => {
       'const guidance = "Use right-click to open the menu";',
       `const arbitraryContent = <span className="before:content-['right-click']" />;`,
       `const quotedBracketContent = <span className="before:content-['a] right-click']" />;`,
+      `const escapedBracketContent = <span className={"before:content-\\u005b'right-click'\\u005d"} />;`,
       "const interpolatedArbitrary = <span className={`content-[$" +
         "{prefix} right-click] mr-2`} />;",
       "",

--- a/scripts/oxlint-safe-fixers.test.ts
+++ b/scripts/oxlint-safe-fixers.test.ts
@@ -124,7 +124,7 @@ describe.serial("custom oxlint safe fixers", () => {
 
   test("leaves context-dependent violations for the agent", async () => {
     const { configPath, directory } = await writeHarness();
-    const sourcePath = path.join(directory, "subject.ts");
+    const sourcePath = path.join(directory, "subject.tsx");
     const source = [
       "async function load() {",
       "  return await ((lock ? query.for('update') : query) satisfies Builder);",
@@ -136,8 +136,12 @@ describe.serial("custom oxlint safe fixers", () => {
       "async function loadWithBranchWrappers() {",
       "  return await (lock ? (query as Builder) : (query.limit(1) satisfies Builder));",
       "}",
+      "async function loadWithNestedBranchWrapper() {",
+      "  return await (lock ? ((paged ? query : query.limit(1)) satisfies Builder) : query.offset(2));",
+      "}",
       "const schema = t.Optional(t.UnionEnum(VALUES));",
       'const guidance = "Use right-click to open the menu";',
+      `const arbitraryContent = <span className="before:content-['right-click']" />;`,
       "",
     ].join("\n");
     await Bun.write(sourcePath, source);

--- a/scripts/oxlint-safe-fixers.test.ts
+++ b/scripts/oxlint-safe-fixers.test.ts
@@ -142,6 +142,8 @@ describe.serial("custom oxlint safe fixers", () => {
       "const schema = t.Optional(t.UnionEnum(VALUES));",
       'const guidance = "Use right-click to open the menu";',
       `const arbitraryContent = <span className="before:content-['right-click']" />;`,
+      "const interpolatedArbitrary = <span className={`content-[$" +
+        "{prefix} right-click] mr-2`} />;",
       "",
     ].join("\n");
     await Bun.write(sourcePath, source);


### PR DESCRIPTION
Adds deterministic `--fix` support to three custom oxlint rules: physical Tailwind directions, awaited builder unions, and static optional `UnionEnum` calls. Context-dependent forms remain diagnostic-only.

A real oxlint CLI suite verifies exact rewrites, comment preservation, refusal of ambiguous cases, and fixed-point behavior; it is wired into plugin fixture and affected-check planning.