### PR TITLE
feat: scope case-law parser replay

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/replay-apply.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/replay-apply.db.test.ts
@@ -15,6 +15,7 @@ import type { DocumentAst } from "@/api/handlers/case-law/document-ast";
 import { EMPTY_AST } from "@/api/handlers/case-law/ingestion/adapter";
 import type { SourceAdapter } from "@/api/handlers/case-law/ingestion/adapter";
 import {
+  CASE_LAW_REPLAY_SCOPE,
   REPLAY_ROW_OUTCOME,
   replayCaseLawSource,
 } from "@/api/handlers/case-law/ingestion/replay";
@@ -172,6 +173,7 @@ test("a writing replay goes through the pipeline, and replaying again converges"
       adapter,
       scopedDb,
       sourceId,
+      scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
       readStoredRaw: async () =>
         await Promise.resolve(new TextEncoder().encode(STORED_PAYLOAD)),
       sourceLease,
@@ -361,6 +363,7 @@ test("a restructure the flattened text does not show is still applied", async ()
     adapter: restructuringAdapter,
     scopedDb,
     sourceId,
+    scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
     readStoredRaw: async () =>
       await Promise.resolve(new TextEncoder().encode(STORED_PAYLOAD)),
     sourceLease,
@@ -394,6 +397,7 @@ test("a restructure the flattened text does not show is still applied", async ()
     adapter: restructuringAdapter,
     scopedDb,
     sourceId,
+    scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
     readStoredRaw: async () =>
       await Promise.resolve(new TextEncoder().encode(STORED_PAYLOAD)),
     sourceLease,

--- a/apps/api/src/handlers/case-law/ingestion/replay.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/replay.db.test.ts
@@ -18,12 +18,16 @@ import { EMPTY_AST } from "@/api/handlers/case-law/ingestion/adapter";
 import type { SourceAdapter } from "@/api/handlers/case-law/ingestion/adapter";
 import { czNsAdapter } from "@/api/handlers/case-law/ingestion/adapters/cz-ns";
 import {
+  CASE_LAW_REPLAY_SCOPE,
   countReplayability,
   REPLAY_ROW_OUTCOME,
   replayCaseLawSource,
   selectReplayPage,
 } from "@/api/handlers/case-law/ingestion/replay";
-import type { StoredRawReader } from "@/api/handlers/case-law/ingestion/replay";
+import type {
+  CaseLawReplayScope,
+  StoredRawReader,
+} from "@/api/handlers/case-law/ingestion/replay";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { ADAPTER_KEYS } from "@/api/lib/legal-search/ingestion-constants";
@@ -67,6 +71,7 @@ type InsertDecisionOptions = {
   /** Sub-millisecond digits, 0-999. */
   sub: number;
   caseNumber: string;
+  court?: string | undefined;
   storedRaw: boolean;
   sourceHash: string;
 };
@@ -80,6 +85,7 @@ const insertDecision = async ({
   id,
   sub,
   caseNumber,
+  court = "Court of Justice",
   storedRaw,
   sourceHash,
 }: InsertDecisionOptions): Promise<void> => {
@@ -93,7 +99,7 @@ const insertDecision = async ({
        source_raw_s3_key, source_raw_content_type, source_hash,
        document_ast, metadata, created_at)
     values (
-      ${id}, ${sourceId}, ${caseNumber}, 'Court of Justice', 'EU', 'en',
+      ${id}, ${sourceId}, ${caseNumber}, ${court}, 'EU', 'en',
       ${storedRaw ? `case-law/raw/${sourceId}/${id}` : null},
       ${storedRaw ? "application/xhtml+xml" : null},
       ${sourceHash},
@@ -127,6 +133,7 @@ const walkIds = async (
     const page = await selectReplayPage({
       scopedDb,
       sourceId,
+      scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
       after,
       limit: pageSize,
     });
@@ -225,6 +232,7 @@ describe("replay walk boundary", () => {
     const exact = await selectReplayPage({
       scopedDb,
       sourceId,
+      scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
       after: boundaryId,
       limit: 10,
     });
@@ -314,6 +322,7 @@ describe("replay of a source", () => {
       adapter: czNsAdapter,
       scopedDb,
       sourceId,
+      scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
       readStoredRaw: storedRawReader(refusedReads),
       sourceLease: null,
       limit: 10,
@@ -339,6 +348,7 @@ describe("replay of a source", () => {
       }),
       scopedDb,
       sourceId,
+      scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
       readStoredRaw: storedRawReader(capableReads),
       sourceLease: null,
       limit: 10,
@@ -387,6 +397,7 @@ describe("replay of a source", () => {
         adapter,
         scopedDb,
         sourceId,
+        scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
         readStoredRaw,
         sourceLease: null,
         limit: 10,
@@ -454,6 +465,7 @@ describe("replay of a source", () => {
         adapter,
         scopedDb,
         sourceId,
+        scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
         readStoredRaw: storedRawReader(reads),
         sourceLease: null,
         limit: 10,
@@ -474,6 +486,100 @@ describe("replay of a source", () => {
       after: unknownId,
     });
     expect(reads).toEqual([]);
+  });
+
+  test("a court scope selects, counts, and resumes inside that court only", async () => {
+    const sourceId = await createSource();
+    const matchingId = createSafeId<"caseLawDecision">();
+    const matchingWithoutRawId = createSafeId<"caseLawDecision">();
+    const otherCourtId = createSafeId<"caseLawDecision">();
+    const court = "Nejvyšší správní soud";
+    await insertDecision({
+      sourceId,
+      id: matchingId,
+      sub: 11,
+      caseNumber: "4 As 3/2008",
+      court,
+      storedRaw: true,
+      sourceHash: "nss-stored",
+    });
+    await insertDecision({
+      sourceId,
+      id: matchingWithoutRawId,
+      sub: 12,
+      caseNumber: "5 As 4/2009",
+      court,
+      storedRaw: false,
+      sourceHash: "nss-refetch",
+    });
+    await insertDecision({
+      sourceId,
+      id: otherCourtId,
+      sub: 13,
+      caseNumber: "30 Cdo 1/2010",
+      court: "Nejvyšší soud",
+      storedRaw: true,
+      sourceHash: "ns-stored",
+    });
+    const scope = {
+      type: "court",
+      court,
+    } as const satisfies CaseLawReplayScope;
+
+    const selected = await selectReplayPage({
+      scopedDb,
+      sourceId,
+      scope,
+      after: null,
+      limit: 10,
+    });
+    expect(selected.map(({ id }) => id)).toEqual([matchingId]);
+    expect(await countReplayability({ scopedDb, sourceId, scope })).toEqual({
+      storedLocally: 1,
+      needsRefetch: 1,
+    });
+
+    const reads: string[] = [];
+    const adapter = stubAdapter({
+      reparse: () => ({
+        type: "rejected",
+        rejection: "no-document",
+        detail: "stub",
+      }),
+    });
+    const outsideBoundary = await replayCaseLawSource({
+      adapter,
+      scopedDb,
+      sourceId,
+      scope,
+      readStoredRaw: storedRawReader(reads),
+      sourceLease: null,
+      limit: 10,
+      pageSize: 10,
+      after: otherCourtId,
+    });
+    expect(outsideBoundary).toEqual({
+      type: "unknown-boundary",
+      after: otherCourtId,
+    });
+    expect(reads).toEqual([]);
+
+    const ran = await replayCaseLawSource({
+      adapter,
+      scopedDb,
+      sourceId,
+      scope,
+      readStoredRaw: storedRawReader(reads),
+      sourceLease: null,
+      limit: 10,
+      pageSize: 10,
+    });
+    if (ran.type !== "ran") {
+      throw new TypeError("Expected the court-scoped adapter to run");
+    }
+    expect(ran.report.visited).toBe(1);
+    expect(ran.report.resumeAfter).toBe(matchingId);
+    expect(reads).toHaveLength(1);
   });
 
   test("a dry run classifies each row by its re-parsed hash and writes nothing", async () => {
@@ -517,6 +623,7 @@ describe("replay of a source", () => {
       }),
       scopedDb,
       sourceId,
+      scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
       readStoredRaw: storedRawReader([]),
       sourceLease: null,
       limit: 10,
@@ -574,6 +681,7 @@ describe("replay of a source", () => {
       }),
       scopedDb,
       sourceId,
+      scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
       readStoredRaw: storedRawReader([]),
       sourceLease: null,
       limit: 10,
@@ -622,6 +730,7 @@ describe("replay of a source", () => {
       }),
       scopedDb,
       sourceId,
+      scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
       readStoredRaw: storedRawReader([]),
       sourceLease: null,
       limit: 10,
@@ -662,6 +771,7 @@ describe("replay of a source", () => {
       }),
       scopedDb,
       sourceId,
+      scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
       readStoredRaw: storedRawReader([]),
       sourceLease: null,
       limit: inserted.length,
@@ -698,7 +808,13 @@ describe("replay of a source", () => {
       });
     }
 
-    expect(await countReplayability(scopedDb, sourceId)).toEqual({
+    expect(
+      await countReplayability({
+        scopedDb,
+        sourceId,
+        scope: CASE_LAW_REPLAY_SCOPE.SOURCE,
+      }),
+    ).toEqual({
       storedLocally: 2,
       needsRefetch: 3,
     });

--- a/apps/api/src/handlers/case-law/ingestion/replay.ts
+++ b/apps/api/src/handlers/case-law/ingestion/replay.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, asc, eq, isNotNull, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, isNotNull, isNull, sql, type SQL } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db/safe-db";
 import {
@@ -111,18 +111,39 @@ export type ReplayDecisionRow = {
   corpusMirrorStatus: (typeof CASE_LAW_CORPUS_MIRROR_STATUS)[keyof typeof CASE_LAW_CORPUS_MIRROR_STATUS];
 };
 
+export const CASE_LAW_REPLAY_SCOPE = {
+  SOURCE: { type: "source" },
+} as const;
+
+/**
+ * Exact subset of one source a replay walks. A discriminator makes adding a
+ * future dependency scope an explicit query and cursor-boundary decision.
+ */
+export type CaseLawReplayScope =
+  | (typeof CASE_LAW_REPLAY_SCOPE)[keyof typeof CASE_LAW_REPLAY_SCOPE]
+  | { type: "court"; court: string }
+  | { type: "celex"; celex: string };
+
+const replayScopePredicate = (scope: CaseLawReplayScope): SQL | undefined => {
+  switch (scope.type) {
+    case "source":
+      return undefined;
+    case "court":
+      return eq(caseLawDecisions.court, scope.court);
+    case "celex":
+      return sql`${caseLawDecisions.metadata}->>'celex' = ${scope.celex}`;
+    default:
+      return scope satisfies never;
+  }
+};
+
 type SelectReplayPageOptions = {
   scopedDb: ScopedDb;
   sourceId: SafeId<"caseLawSource">;
+  scope: CaseLawReplayScope;
   /** Boundary row id; the page returns rows strictly after it. */
   after: SafeId<"caseLawDecision"> | null;
   limit: number;
-  /**
-   * Restrict the walk to the decision whose publisher id this is, as the
-   * adapter recorded it in `metadata.celex`. Targets one decision for a
-   * rehearsal before a whole-source run.
-   */
-  celex?: string | undefined;
 };
 
 /**
@@ -136,9 +157,9 @@ type SelectReplayPageOptions = {
 export const selectReplayPage = async ({
   scopedDb,
   sourceId,
+  scope,
   after,
   limit,
-  celex,
 }: SelectReplayPageOptions): Promise<ReplayDecisionRow[]> => {
   const rows = await scopedDb((tx) =>
     tx
@@ -165,11 +186,9 @@ export const selectReplayPage = async ({
       .where(
         and(
           eq(caseLawDecisions.sourceId, sourceId),
+          replayScopePredicate(scope),
           isNotNull(caseLawDecisions.sourceRawS3Key),
           isNull(caseLawDecisions.redactedAt),
-          celex === undefined
-            ? undefined
-            : sql`${caseLawDecisions.metadata}->>'celex' = ${celex}`,
           // The boundary row's `(created_at, id)` is looked up by id inside
           // the database, so the comparison stays at the column's microsecond
           // precision. A boundary carried out as a JS `Date` would be
@@ -196,14 +215,21 @@ export type ReplayabilitySplit = {
   needsRefetch: number;
 };
 
+type CountReplayabilityOptions = {
+  scopedDb: ScopedDb;
+  sourceId: SafeId<"caseLawSource">;
+  scope: CaseLawReplayScope;
+};
+
 /**
- * How much of a source can be replayed without the publisher. Redacted rows
+ * How much of a scope can be replayed without the publisher. Redacted rows
  * are in neither count: they are not re-parsed by any path.
  */
-export const countReplayability = async (
-  scopedDb: ScopedDb,
-  sourceId: SafeId<"caseLawSource">,
-): Promise<ReplayabilitySplit> => {
+export const countReplayability = async ({
+  scopedDb,
+  sourceId,
+  scope,
+}: CountReplayabilityOptions): Promise<ReplayabilitySplit> => {
   const [counts] = await scopedDb((tx) =>
     tx
       .select({
@@ -214,6 +240,7 @@ export const countReplayability = async (
       .where(
         and(
           eq(caseLawDecisions.sourceId, sourceId),
+          replayScopePredicate(scope),
           isNull(caseLawDecisions.redactedAt),
         ),
       ),
@@ -605,7 +632,7 @@ export type ReplayCaseLawSourceOptions = {
   limit: number;
   pageSize: number;
   after?: SafeId<"caseLawDecision"> | null;
-  celex?: string | undefined;
+  scope: CaseLawReplayScope;
 };
 
 export type ReplayRun =
@@ -614,7 +641,7 @@ export type ReplayRun =
   | { type: "ran"; report: ReplayRunReport };
 
 /**
- * A resume boundary must be a row of the source being replayed.
+ * A resume boundary must be a row of the exact scope being replayed.
  *
  * The keyset looks the boundary up by id alone, so an id belonging to
  * another source would position the walk by an unrelated timestamp and skip
@@ -622,14 +649,16 @@ export type ReplayRun =
  * tuple comparison null and return nothing at all. Both read as "no work to
  * do", which is the one thing a resume must never say quietly.
  */
-const boundaryBelongsToSource = async ({
+const boundaryBelongsToScope = async ({
   after,
   scopedDb,
   sourceId,
+  scope,
 }: {
   after: SafeId<"caseLawDecision">;
   scopedDb: ScopedDb;
   sourceId: SafeId<"caseLawSource">;
+  scope: CaseLawReplayScope;
 }): Promise<boolean> => {
   const found = await scopedDb((tx) =>
     tx
@@ -639,6 +668,7 @@ const boundaryBelongsToSource = async ({
         and(
           eq(caseLawDecisions.id, after),
           eq(caseLawDecisions.sourceId, sourceId),
+          replayScopePredicate(scope),
         ),
       )
       .limit(1),
@@ -671,7 +701,7 @@ export const replayCaseLawSource = async ({
   limit,
   pageSize,
   after = null,
-  celex,
+  scope,
 }: ReplayCaseLawSourceOptions): Promise<ReplayRun> => {
   const capability = replayCapability(adapter);
   if (capability.type === "unsupported") {
@@ -680,7 +710,12 @@ export const replayCaseLawSource = async ({
 
   if (
     after !== null &&
-    !(await boundaryBelongsToSource({ after, scopedDb, sourceId }))
+    !(await boundaryBelongsToScope({
+      after,
+      scopedDb,
+      sourceId,
+      scope,
+    }))
   ) {
     return { type: "unknown-boundary", after };
   }
@@ -762,9 +797,9 @@ export const replayCaseLawSource = async ({
     const page = await selectReplayPage({
       scopedDb,
       sourceId,
+      scope,
       after: cursor,
       limit: Math.min(pageSize, limit - visited),
-      celex,
     });
     if (page.length === 0) {
       return;

--- a/apps/api/src/scripts/replay-case-law-source.ts
+++ b/apps/api/src/scripts/replay-case-law-source.ts
@@ -120,11 +120,11 @@ const pageSize = positiveInteger(
 );
 const celex = flagValue("celex");
 const court = flagValue("court");
-if (celex !== undefined && celex.length === 0) {
+if (celex?.length === 0) {
   console.error("--celex requires a non-empty value");
   process.exit(1);
 }
-if (court !== undefined && court.length === 0) {
+if (court?.length === 0) {
   console.error("--court requires a non-empty value");
   process.exit(1);
 }
@@ -132,12 +132,16 @@ if (celex !== undefined && court !== undefined) {
   console.error("--celex and --court are mutually exclusive replay scopes");
   process.exit(1);
 }
-const scope =
-  court !== undefined
-    ? ({ type: "court", court } as const satisfies CaseLawReplayScope)
-    : celex !== undefined
-      ? ({ type: "celex", celex } as const satisfies CaseLawReplayScope)
-      : CASE_LAW_REPLAY_SCOPE.SOURCE;
+const replayScope = (): CaseLawReplayScope => {
+  if (court !== undefined) {
+    return { type: "court", court };
+  }
+  if (celex !== undefined) {
+    return { type: "celex", celex };
+  }
+  return CASE_LAW_REPLAY_SCOPE.SOURCE;
+};
+const scope = replayScope();
 const afterArgument = flagValue("after");
 const after =
   afterArgument === undefined

--- a/apps/api/src/scripts/replay-case-law-source.ts
+++ b/apps/api/src/scripts/replay-case-law-source.ts
@@ -21,6 +21,10 @@ import { caseLawSources } from "@/api/db/schema";
  *   bun run src/scripts/replay-case-law-source.ts --adapter eu-ecj \
  *     --celex 62022CJ0123 --apply
  *
+ *   # one court after deploying a parser improvement for that court
+ *   bun run src/scripts/replay-case-law-source.ts --adapter cz-nss \
+ *     --court "Nejvyšší správní soud" --apply
+ *
  *   # resume where an interrupted run stopped
  *   bun run src/scripts/replay-case-law-source.ts --adapter eu-ecj \
  *     --after <decisionId> --apply
@@ -30,12 +34,16 @@ import { caseLawSources } from "@/api/db/schema";
  */
 import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters/adapter-registry";
 import {
+  CASE_LAW_REPLAY_SCOPE,
   countReplayability,
   REPLAY_ROW_OUTCOME,
   replayCapability,
   replayCaseLawSource,
 } from "@/api/handlers/case-law/ingestion/replay";
-import type { StoredRawReader } from "@/api/handlers/case-law/ingestion/replay";
+import type {
+  CaseLawReplayScope,
+  StoredRawReader,
+} from "@/api/handlers/case-law/ingestion/replay";
 import { enterCaseLawMaintenanceLane } from "@/api/lib/case-law/maintenance-lane";
 import { acquireCaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
 import {
@@ -60,6 +68,7 @@ const USAGE = `Usage: bun run src/scripts/replay-case-law-source.ts --adapter <k
   --apply           Write the re-parsed results. Omitted, the run reports
                     what it would change and writes nothing.
   --limit <n>       Maximum decisions to visit (default ${DEFAULT_LIMIT}).
+  --court <name>    Replay only decisions from this exact court.
   --celex <value>   Replay only the decision stored under this publisher id
                     (metadata.celex).
   --after <id>      Resume strictly after this decision id.
@@ -110,6 +119,25 @@ const pageSize = positiveInteger(
   "page-size",
 );
 const celex = flagValue("celex");
+const court = flagValue("court");
+if (celex !== undefined && celex.length === 0) {
+  console.error("--celex requires a non-empty value");
+  process.exit(1);
+}
+if (court !== undefined && court.length === 0) {
+  console.error("--court requires a non-empty value");
+  process.exit(1);
+}
+if (celex !== undefined && court !== undefined) {
+  console.error("--celex and --court are mutually exclusive replay scopes");
+  process.exit(1);
+}
+const scope =
+  court !== undefined
+    ? ({ type: "court", court } as const satisfies CaseLawReplayScope)
+    : celex !== undefined
+      ? ({ type: "celex", celex } as const satisfies CaseLawReplayScope)
+      : CASE_LAW_REPLAY_SCOPE.SOURCE;
 const afterArgument = flagValue("after");
 const after =
   afterArgument === undefined
@@ -156,13 +184,20 @@ if (!source) {
   process.exit(1);
 }
 
-const split = await countReplayability(ingestionDb, source.id);
+const split = await countReplayability({
+  scopedDb: ingestionDb,
+  sourceId: source.id,
+  scope,
+});
 console.log(`=== REPLAY ${adapterKey} (${source.name}) ===`);
 console.log(`mode:                ${apply ? "apply" : "dry run"}`);
 console.log(`replayable locally:  ${split.storedLocally}`);
 console.log(`needs a re-fetch:    ${split.needsRefetch}`);
 if (celex !== undefined) {
   console.log(`targeting celex:     ${celex}`);
+}
+if (court !== undefined) {
+  console.log(`targeting court:     ${court}`);
 }
 
 // `null` only where the store confirmed it holds no such object, which is a
@@ -206,7 +241,7 @@ const replayed = await Result.tryPromise({
       limit,
       pageSize,
       after,
-      celex,
+      scope,
     }),
   catch: (cause) => cause,
 });
@@ -225,8 +260,8 @@ if (replayed.value.type === "unsupported") {
 }
 if (replayed.value.type === "unknown-boundary") {
   console.error(
-    `--after ${replayed.value.after} is not a decision of source ${adapterKey}. ` +
-      "Resume from an id this source's own run reported.",
+    `--after ${replayed.value.after} is outside the selected ${scope.type} scope for ${adapterKey}. ` +
+      "Resume from an id this scope's own run reported.",
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

- model stored-raw replay selection as an explicit source, court, or CELEX scope
- apply the same scope to selection, replayability counts, and resume-boundary validation
- expose exact-court replay through the operator script for bounded parser updates

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added court-specific replay support for case-law ingestion.
  - Replay operations can now be scoped by source, court, or CELEX identifier.
  - Added validation to prevent conflicting scope selections and ensure resume boundaries match the selected scope.

- **Bug Fixes**
  - Improved replayability counting and execution accuracy for scoped replays.
  - Updated replay tests to verify court filtering and boundary validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->