### PR TITLE
feat: register corpus index generations

### DIFF
--- a/apps/api/drizzle/20260825137000_corpus_index_generations/migration.sql
+++ b/apps/api/drizzle/20260825137000_corpus_index_generations/migration.sql
@@ -1,0 +1,52 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- One generation resolves to one closed cluster identity. Endpoints and
+-- credentials remain trusted deployment configuration rather than data that
+-- can redirect an internal HTTP client.
+CREATE TABLE "corpus_index_generations" (
+  "family" varchar(32) NOT NULL,
+  "generation" varchar(64) NOT NULL,
+  "cluster" varchar(32) NOT NULL,
+  "status" varchar(16) NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "corpus_index_generations_pkey"
+    PRIMARY KEY ("family", "generation"),
+  CONSTRAINT "corpus_index_generations_family_values"
+    CHECK ("family" IN ('case_law','legislation')),
+  CONSTRAINT "corpus_index_generations_cluster_values"
+    CHECK ("cluster" IN ('quickwit_08','quickwit_09')),
+  CONSTRAINT "corpus_index_generations_status_values"
+    CHECK ("status" IN ('building','serving','retiring','retired')),
+  CONSTRAINT "corpus_index_generations_name_matches_family"
+    CHECK (CASE "family"
+      WHEN 'case_law' THEN "generation" ~ '^case_law_v[1-9][0-9]*$'
+      WHEN 'legislation' THEN "generation" ~ '^legislation_v[1-9][0-9]*$'
+      ELSE false
+    END)
+);--> statement-breakpoint
+
+CREATE UNIQUE INDEX "corpus_index_generations_serving_family_uidx"
+  ON "corpus_index_generations" ("family")
+  WHERE "status" = 'serving';--> statement-breakpoint
+
+ALTER TABLE "corpus_index_generations" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "case_law_ingestion_access"
+  ON "corpus_index_generations"
+  AS PERMISSIVE FOR ALL TO stella_ingestion
+  USING (true) WITH CHECK (true);--> statement-breakpoint
+CREATE POLICY "case_law_global_access"
+  ON "corpus_index_generations"
+  AS PERMISSIVE FOR SELECT TO stella
+  USING (true);--> statement-breakpoint
+CREATE POLICY "public_law_reader_access"
+  ON "corpus_index_generations"
+  AS PERMISSIVE FOR SELECT TO stella_public_law_reader
+  USING (true);--> statement-breakpoint
+
+GRANT SELECT ON TABLE "corpus_index_generations" TO stella;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON TABLE "corpus_index_generations" TO stella_ingestion;--> statement-breakpoint
+GRANT SELECT ("family", "generation", "cluster", "status")
+  ON TABLE "corpus_index_generations" TO stella_public_law_reader;

--- a/apps/api/drizzle/20260825137100_corpus_index_generations/migration.sql
+++ b/apps/api/drizzle/20260825137100_corpus_index_generations/migration.sql
@@ -17,7 +17,7 @@ CREATE TABLE "corpus_index_generations" (
   CONSTRAINT "corpus_index_generations_family_values"
     CHECK ("family" IN ('case_law','legislation')),
   CONSTRAINT "corpus_index_generations_cluster_values"
-    CHECK ("cluster" IN ('quickwit_08','quickwit_09')),
+    CHECK ("cluster" IN ('q08','q09')),
   CONSTRAINT "corpus_index_generations_status_values"
     CHECK ("status" IN ('building','serving','retiring','retired')),
   CONSTRAINT "corpus_index_generations_manifest_digest_shape"

--- a/apps/api/drizzle/20260825137100_corpus_index_generations/migration.sql
+++ b/apps/api/drizzle/20260825137100_corpus_index_generations/migration.sql
@@ -5,10 +5,11 @@ SET statement_timeout = '5s';--> statement-breakpoint
 -- credentials remain trusted deployment configuration rather than data that
 -- can redirect an internal HTTP client.
 CREATE TABLE "corpus_index_generations" (
-  "family" varchar(32) NOT NULL,
-  "generation" varchar(64) NOT NULL,
-  "cluster" varchar(32) NOT NULL,
-  "status" varchar(16) NOT NULL,
+  "family" text NOT NULL,
+  "generation" varchar(32) NOT NULL,
+  "cluster" text NOT NULL,
+  "manifest_digest" varchar(64) NOT NULL,
+  "status" text NOT NULL,
   "created_at" timestamptz DEFAULT now() NOT NULL,
   "updated_at" timestamptz DEFAULT now() NOT NULL,
   CONSTRAINT "corpus_index_generations_pkey"
@@ -19,6 +20,8 @@ CREATE TABLE "corpus_index_generations" (
     CHECK ("cluster" IN ('quickwit_08','quickwit_09')),
   CONSTRAINT "corpus_index_generations_status_values"
     CHECK ("status" IN ('building','serving','retiring','retired')),
+  CONSTRAINT "corpus_index_generations_manifest_digest_shape"
+    CHECK ("manifest_digest" ~ '^[0-9a-f]{64}$'),
   CONSTRAINT "corpus_index_generations_name_matches_family"
     CHECK (CASE "family"
       WHEN 'case_law' THEN "generation" ~ '^case_law_v[1-9][0-9]*$'
@@ -30,6 +33,24 @@ CREATE TABLE "corpus_index_generations" (
 CREATE UNIQUE INDEX "corpus_index_generations_serving_family_uidx"
   ON "corpus_index_generations" ("family")
   WHERE "status" = 'serving';--> statement-breakpoint
+
+CREATE FUNCTION "prevent_corpus_index_generation_retarget"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF (NEW."family", NEW."generation", NEW."cluster", NEW."manifest_digest") IS DISTINCT FROM
+     (OLD."family", OLD."generation", OLD."cluster", OLD."manifest_digest") THEN
+    RAISE EXCEPTION 'corpus index generation identity is immutable';
+  END IF;
+  RETURN NEW;
+END;
+$$;--> statement-breakpoint
+
+CREATE TRIGGER "corpus_index_generations_identity_immutable"
+  BEFORE UPDATE ON "corpus_index_generations"
+  FOR EACH ROW
+  EXECUTE FUNCTION "prevent_corpus_index_generation_retarget"();--> statement-breakpoint
 
 ALTER TABLE "corpus_index_generations" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
 CREATE POLICY "case_law_ingestion_access"
@@ -46,7 +67,9 @@ CREATE POLICY "public_law_reader_access"
   USING (true);--> statement-breakpoint
 
 GRANT SELECT ON TABLE "corpus_index_generations" TO stella;--> statement-breakpoint
-GRANT SELECT, INSERT, UPDATE, DELETE
+GRANT SELECT, INSERT, DELETE
   ON TABLE "corpus_index_generations" TO stella_ingestion;--> statement-breakpoint
-GRANT SELECT ("family", "generation", "cluster", "status")
+GRANT UPDATE ("status", "updated_at")
+  ON TABLE "corpus_index_generations" TO stella_ingestion;--> statement-breakpoint
+GRANT SELECT ("family", "generation", "cluster", "manifest_digest", "status")
   ON TABLE "corpus_index_generations" TO stella_public_law_reader;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -8,6 +8,7 @@ export * from "./schema/workspace-admin";
 export * from "./schema/clauses";
 export * from "./schema/case-law";
 export * from "./schema/legislation";
+export * from "./schema/corpus-index-generations";
 export * from "./schema/lists";
 export * from "./schema/chat";
 export * from "./schema/docx-suggestions";

--- a/apps/api/src/db/schema/corpus-index-generations.ts
+++ b/apps/api/src/db/schema/corpus-index-generations.ts
@@ -1,10 +1,8 @@
 import {
   CORPUS_FAMILIES,
+  CORPUS_INDEX_GENERATION_MAX_LENGTH,
   CORPUS_INDEX_GENERATION_STATUSES,
   QUICKWIT_CLUSTERS,
-  type CorpusFamily,
-  type CorpusIndexGenerationStatus,
-  type QuickwitCluster,
 } from "@/api/lib/legal-search/corpus-generation-contract";
 
 import {
@@ -30,13 +28,13 @@ const sqlValues = (values: readonly string[]) =>
 export const corpusIndexGenerations = p.pgTable(
   "corpus_index_generations",
   {
-    family: p.varchar({ length: 32 }).notNull().$type<CorpusFamily>(),
-    generation: p.varchar({ length: 64 }).notNull(),
-    cluster: p.varchar({ length: 32 }).notNull().$type<QuickwitCluster>(),
-    status: p
-      .varchar({ length: 16 })
-      .notNull()
-      .$type<CorpusIndexGenerationStatus>(),
+    family: p.text({ enum: CORPUS_FAMILIES }).notNull(),
+    generation: p
+      .varchar({ length: CORPUS_INDEX_GENERATION_MAX_LENGTH })
+      .notNull(),
+    cluster: p.text({ enum: QUICKWIT_CLUSTERS }).notNull(),
+    manifestDigest: p.varchar("manifest_digest", { length: 64 }).notNull(),
+    status: p.text({ enum: CORPUS_INDEX_GENERATION_STATUSES }).notNull(),
     createdAt: timestamptz("created_at").defaultNow().notNull(),
     updatedAt: timestamptz("updated_at")
       .defaultNow()
@@ -63,6 +61,10 @@ export const corpusIndexGenerations = p.pgTable(
     p.check(
       "corpus_index_generations_status_values",
       sql`${t.status} IN (${sqlValues(CORPUS_INDEX_GENERATION_STATUSES)})`,
+    ),
+    p.check(
+      "corpus_index_generations_manifest_digest_shape",
+      sql`${t.manifestDigest} ~ '^[0-9a-f]{64}$'`,
     ),
     p.check(
       "corpus_index_generations_name_matches_family",

--- a/apps/api/src/db/schema/corpus-index-generations.ts
+++ b/apps/api/src/db/schema/corpus-index-generations.ts
@@ -1,0 +1,78 @@
+import {
+  CORPUS_FAMILIES,
+  CORPUS_INDEX_GENERATION_STATUSES,
+  QUICKWIT_CLUSTERS,
+  type CorpusFamily,
+  type CorpusIndexGenerationStatus,
+  type QuickwitCluster,
+} from "@/api/lib/legal-search/corpus-generation-contract";
+
+import {
+  globalCaseLawPolicies,
+  p,
+  publicLawReaderPolicies,
+  sql,
+  timestamptz,
+} from "./common";
+
+const sqlValues = (values: readonly string[]) =>
+  sql.join(
+    values.map((value) => sql.raw(`'${value}'`)),
+    sql.raw(","),
+  );
+
+/**
+ * Immutable binding of one corpus generation to the trusted Quickwit cluster
+ * that owns it, plus the generation's small serving lifecycle. Endpoint URLs
+ * remain deployment configuration: persisted state can select only a closed
+ * cluster identifier, never an arbitrary internal request target.
+ */
+export const corpusIndexGenerations = p.pgTable(
+  "corpus_index_generations",
+  {
+    family: p.varchar({ length: 32 }).notNull().$type<CorpusFamily>(),
+    generation: p.varchar({ length: 64 }).notNull(),
+    cluster: p.varchar({ length: 32 }).notNull().$type<QuickwitCluster>(),
+    status: p
+      .varchar({ length: 16 })
+      .notNull()
+      .$type<CorpusIndexGenerationStatus>(),
+    createdAt: timestamptz("created_at").defaultNow().notNull(),
+    updatedAt: timestamptz("updated_at")
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => [
+    p.primaryKey({
+      name: "corpus_index_generations_pkey",
+      columns: [t.family, t.generation],
+    }),
+    p
+      .uniqueIndex("corpus_index_generations_serving_family_uidx")
+      .on(t.family)
+      .where(sql`${t.status} = 'serving'`),
+    p.check(
+      "corpus_index_generations_family_values",
+      sql`${t.family} IN (${sqlValues(CORPUS_FAMILIES)})`,
+    ),
+    p.check(
+      "corpus_index_generations_cluster_values",
+      sql`${t.cluster} IN (${sqlValues(QUICKWIT_CLUSTERS)})`,
+    ),
+    p.check(
+      "corpus_index_generations_status_values",
+      sql`${t.status} IN (${sqlValues(CORPUS_INDEX_GENERATION_STATUSES)})`,
+    ),
+    p.check(
+      "corpus_index_generations_name_matches_family",
+      sql`CASE ${t.family}
+        WHEN 'case_law' THEN ${t.generation} ~ '^case_law_v[1-9][0-9]*$'
+        WHEN 'legislation' THEN ${t.generation} ~ '^legislation_v[1-9][0-9]*$'
+        ELSE false
+      END`,
+    ),
+    ...globalCaseLawPolicies(),
+    ...publicLawReaderPolicies(),
+  ],
+);

--- a/apps/api/src/lib/legal-search/corpus-family.ts
+++ b/apps/api/src/lib/legal-search/corpus-family.ts
@@ -1,18 +1,11 @@
 import { envBase } from "@/api/env-base";
+import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
 
-/**
- * Document families served by the corpus / corpus index DB. The search,
- * index, storage, and rerank substrate is generic over these; each
- * family differs only in its index field mappings (below) and its
- * ingestion source (a per-family slice). Adding "gazette", "regulation",
- * etc. is: extend this union + register an index field spec + a doc
- * source — not a re-architecture.
- */
-export const CORPUS_FAMILIES = ["case_law", "legislation"] as const;
-export type CorpusFamily = (typeof CORPUS_FAMILIES)[number];
-
-export const parseCorpusFamily = (value: unknown): CorpusFamily | null =>
-  CORPUS_FAMILIES.find((family) => family === value) ?? null;
+export {
+  CORPUS_FAMILIES,
+  parseCorpusFamily,
+} from "@/api/lib/legal-search/corpus-generation-contract";
+export type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
 
 /**
  * Blue-green generation prefix per family. Index ids are

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 
 import {
   CORPUS_FAMILIES,
+  CORPUS_INDEX_GENERATION_MAX_LENGTH,
   CORPUS_INDEX_GENERATION_STATUSES,
   isCorpusGeneration,
   parseCorpusFamily,
@@ -38,4 +39,10 @@ test("generation names belong to exactly their declared family", () => {
   expect(isCorpusGeneration("legislation", "case_law_v5")).toBe(false);
   expect(isCorpusGeneration("case_law", "case_law_v0")).toBe(false);
   expect(isCorpusGeneration("case_law", "case_law_v5_preview")).toBe(false);
+  expect(
+    isCorpusGeneration(
+      "case_law",
+      `case_law_v${"1".repeat(CORPUS_INDEX_GENERATION_MAX_LENGTH)}`,
+    ),
+  ).toBe(false);
 });

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+
+import {
+  CORPUS_FAMILIES,
+  CORPUS_INDEX_GENERATION_STATUSES,
+  isCorpusGeneration,
+  parseCorpusFamily,
+  parseCorpusIndexGenerationStatus,
+  parseQuickwitCluster,
+  QUICKWIT_CLUSTERS,
+  requireQuickwitCluster,
+} from "@/api/lib/legal-search/corpus-generation-contract";
+
+test("closed corpus and cluster values parse without a fallback", () => {
+  for (const family of CORPUS_FAMILIES) {
+    expect(parseCorpusFamily(family)).toBe(family);
+  }
+  for (const cluster of QUICKWIT_CLUSTERS) {
+    expect(parseQuickwitCluster(cluster)).toBe(cluster);
+    expect(requireQuickwitCluster(cluster)).toBe(cluster);
+  }
+  for (const status of CORPUS_INDEX_GENERATION_STATUSES) {
+    expect(parseCorpusIndexGenerationStatus(status)).toBe(status);
+  }
+
+  expect(parseCorpusFamily("judgments")).toBeNull();
+  expect(parseQuickwitCluster("https://internal.example")).toBeNull();
+  expect(parseCorpusIndexGenerationStatus("ready")).toBeNull();
+  expect(() => requireQuickwitCluster("quickwit_10")).toThrow(
+    "Unknown Quickwit cluster reference",
+  );
+});
+
+test("generation names belong to exactly their declared family", () => {
+  expect(isCorpusGeneration("case_law", "case_law_v5")).toBe(true);
+  expect(isCorpusGeneration("legislation", "legislation_v2")).toBe(true);
+  expect(isCorpusGeneration("case_law", "legislation_v2")).toBe(false);
+  expect(isCorpusGeneration("legislation", "case_law_v5")).toBe(false);
+  expect(isCorpusGeneration("case_law", "case_law_v0")).toBe(false);
+  expect(isCorpusGeneration("case_law", "case_law_v5_preview")).toBe(false);
+});

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.ts
@@ -1,0 +1,48 @@
+import { panic } from "better-result";
+
+/** Document families sharing the corpus storage and search substrate. */
+export const CORPUS_FAMILIES = ["case_law", "legislation"] as const;
+export type CorpusFamily = (typeof CORPUS_FAMILIES)[number];
+
+export const QUICKWIT_CLUSTERS = ["quickwit_08", "quickwit_09"] as const;
+export type QuickwitCluster = (typeof QUICKWIT_CLUSTERS)[number];
+
+export const CORPUS_INDEX_GENERATION_STATUSES = [
+  "building",
+  "serving",
+  "retiring",
+  "retired",
+] as const;
+export type CorpusIndexGenerationStatus =
+  (typeof CORPUS_INDEX_GENERATION_STATUSES)[number];
+
+const memberOf = <T extends string>(
+  values: readonly T[],
+  value: unknown,
+): T | null => values.find((candidate) => candidate === value) ?? null;
+
+export const parseCorpusFamily = (value: unknown): CorpusFamily | null =>
+  memberOf(CORPUS_FAMILIES, value);
+
+export const parseQuickwitCluster = (
+  value: unknown,
+): QuickwitCluster | null => memberOf(QUICKWIT_CLUSTERS, value);
+
+export const requireQuickwitCluster = (value: unknown): QuickwitCluster =>
+  parseQuickwitCluster(value) ??
+  panic(`Unknown Quickwit cluster reference: ${String(value)}`);
+
+export const parseCorpusIndexGenerationStatus = (
+  value: unknown,
+): CorpusIndexGenerationStatus | null =>
+  memberOf(CORPUS_INDEX_GENERATION_STATUSES, value);
+
+const GENERATION_PATTERNS = {
+  case_law: /^case_law_v[1-9][0-9]*$/u,
+  legislation: /^legislation_v[1-9][0-9]*$/u,
+} as const satisfies Record<CorpusFamily, RegExp>;
+
+export const isCorpusGeneration = (
+  family: CorpusFamily,
+  generation: string,
+): boolean => GENERATION_PATTERNS[family].test(generation);

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.ts
@@ -4,7 +4,7 @@ import { panic } from "better-result";
 export const CORPUS_FAMILIES = ["case_law", "legislation"] as const;
 export type CorpusFamily = (typeof CORPUS_FAMILIES)[number];
 
-export const QUICKWIT_CLUSTERS = ["quickwit_08", "quickwit_09"] as const;
+export const QUICKWIT_CLUSTERS = ["q08", "q09"] as const;
 export type QuickwitCluster = (typeof QUICKWIT_CLUSTERS)[number];
 
 /** Shared persistence bound for generation names and derived physical ids. */

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.ts
@@ -7,6 +7,9 @@ export type CorpusFamily = (typeof CORPUS_FAMILIES)[number];
 export const QUICKWIT_CLUSTERS = ["quickwit_08", "quickwit_09"] as const;
 export type QuickwitCluster = (typeof QUICKWIT_CLUSTERS)[number];
 
+/** Shared persistence bound for generation names and derived physical ids. */
+export const CORPUS_INDEX_GENERATION_MAX_LENGTH = 32;
+
 export const CORPUS_INDEX_GENERATION_STATUSES = [
   "building",
   "serving",
@@ -24,9 +27,8 @@ const memberOf = <T extends string>(
 export const parseCorpusFamily = (value: unknown): CorpusFamily | null =>
   memberOf(CORPUS_FAMILIES, value);
 
-export const parseQuickwitCluster = (
-  value: unknown,
-): QuickwitCluster | null => memberOf(QUICKWIT_CLUSTERS, value);
+export const parseQuickwitCluster = (value: unknown): QuickwitCluster | null =>
+  memberOf(QUICKWIT_CLUSTERS, value);
 
 export const requireQuickwitCluster = (value: unknown): QuickwitCluster =>
   parseQuickwitCluster(value) ??
@@ -45,4 +47,6 @@ const GENERATION_PATTERNS = {
 export const isCorpusGeneration = (
   family: CorpusFamily,
   generation: string,
-): boolean => GENERATION_PATTERNS[family].test(generation);
+): boolean =>
+  generation.length <= CORPUS_INDEX_GENERATION_MAX_LENGTH &&
+  GENERATION_PATTERNS[family].test(generation);

--- a/apps/api/src/lib/legal-search/corpus-index-generations.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generations.db.test.ts
@@ -8,6 +8,10 @@ import { createTestPglite } from "@/api/tests/pglite-test-db";
 let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
 const MANIFEST_DIGEST = "a".repeat(64);
+const MIGRATION_URL = new URL(
+  "../../../drizzle/20260825137100_corpus_index_generations/migration.sql",
+  import.meta.url,
+);
 
 const errorMessageChain = (error: unknown): string => {
   const messages: string[] = [];
@@ -29,6 +33,23 @@ beforeAll(
   async () => {
     client = await createTestPglite();
     db = drizzle({ client });
+
+    // drizzle-kit reconstructs tables and constraints for the lightweight
+    // PGlite snapshot, but triggers exist only in committed migrations. Apply
+    // the exact migration-owned function and trigger so this suite exercises
+    // the production immutability boundary rather than a test-only copy.
+    const migration = await Bun.file(MIGRATION_URL).text();
+    for (const statement of migration.split("--> statement-breakpoint")) {
+      const ddl = statement.trim();
+      if (
+        !ddl.startsWith("CREATE FUNCTION") &&
+        !ddl.startsWith("CREATE TRIGGER")
+      ) {
+        continue;
+      }
+      // oxlint-disable-next-line no-await-in-loop -- the trigger depends on the function created immediately before it
+      await db.execute(sql.raw(ddl));
+    }
   },
   { timeout: 120_000 },
 );

--- a/apps/api/src/lib/legal-search/corpus-index-generations.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generations.db.test.ts
@@ -7,6 +7,7 @@ import { createTestPglite } from "@/api/tests/pglite-test-db";
 
 let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
+const MANIFEST_DIGEST = "a".repeat(64);
 
 beforeAll(
   async () => {
@@ -26,18 +27,21 @@ test("each family can serve exactly one independently routed generation", async 
       cluster: "quickwit_08",
       family: "case_law",
       generation: "case_law_v2",
+      manifestDigest: MANIFEST_DIGEST,
       status: "serving",
     },
     {
       cluster: "quickwit_09",
       family: "case_law",
       generation: "case_law_v5",
+      manifestDigest: MANIFEST_DIGEST,
       status: "building",
     },
     {
       cluster: "quickwit_08",
       family: "legislation",
       generation: "legislation_v1",
+      manifestDigest: MANIFEST_DIGEST,
       status: "serving",
     },
   ]);
@@ -47,6 +51,7 @@ test("each family can serve exactly one independently routed generation", async 
       cluster: "quickwit_09",
       family: "case_law",
       generation: "case_law_v6",
+      manifestDigest: MANIFEST_DIGEST,
       status: "serving",
     }),
   ).rejects.toThrow();
@@ -78,22 +83,67 @@ test("each family can serve exactly one independently routed generation", async 
 test("database constraints reject drift outside the TypeScript contract", async () => {
   await expect(
     db.execute(sql`
-      INSERT INTO corpus_index_generations (family, generation, cluster, status)
-      VALUES ('case_law', 'legislation_v2', 'quickwit_09', 'building')
+      INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
+      VALUES ('case_law', 'legislation_v2', 'quickwit_09', ${MANIFEST_DIGEST}, 'building')
     `),
   ).rejects.toThrow();
 
   await expect(
     db.execute(sql`
-      INSERT INTO corpus_index_generations (family, generation, cluster, status)
-      VALUES ('legislation', 'legislation_v2', 'quickwit_10', 'building')
+      INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
+      VALUES ('legislation', 'legislation_v2', 'quickwit_10', ${MANIFEST_DIGEST}, 'building')
     `),
   ).rejects.toThrow();
 
   await expect(
     db.execute(sql`
-      INSERT INTO corpus_index_generations (family, generation, cluster, status)
-      VALUES ('legislation', 'legislation_v2', 'quickwit_09', 'ready')
+      INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
+      VALUES ('legislation', 'legislation_v2', 'quickwit_09', ${MANIFEST_DIGEST}, 'ready')
     `),
   ).rejects.toThrow();
+
+  await expect(
+    db.execute(sql`
+      INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
+      VALUES ('case_law', 'case_law_v11111111111111111111111111111111', 'quickwit_09', ${MANIFEST_DIGEST}, 'building')
+    `),
+  ).rejects.toThrow();
+
+  await expect(
+    db.execute(sql`
+      INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
+      VALUES ('case_law', 'case_law_v8', 'quickwit_09', 'not-a-digest', 'building')
+    `),
+  ).rejects.toThrow();
+});
+
+test("generation identity cannot be retargeted after registration", async () => {
+  await db.insert(corpusIndexGenerations).values({
+    cluster: "quickwit_09",
+    family: "case_law",
+    generation: "case_law_v7",
+    manifestDigest: MANIFEST_DIGEST,
+    status: "building",
+  });
+
+  await db
+    .update(corpusIndexGenerations)
+    .set({ status: "retiring" })
+    .where(eq(corpusIndexGenerations.generation, "case_law_v7"));
+
+  await expect(
+    db.execute(sql`
+      UPDATE corpus_index_generations
+      SET cluster = 'quickwit_08'
+      WHERE family = 'case_law' AND generation = 'case_law_v7'
+    `),
+  ).rejects.toThrow("corpus index generation identity is immutable");
+
+  await expect(
+    db.execute(sql`
+      UPDATE corpus_index_generations
+      SET manifest_digest = ${"b".repeat(64)}
+      WHERE family = 'case_law' AND generation = 'case_law_v7'
+    `),
+  ).rejects.toThrow("corpus index generation identity is immutable");
 });

--- a/apps/api/src/lib/legal-search/corpus-index-generations.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generations.db.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import { corpusIndexGenerations } from "@/api/db/schema";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    db = drizzle({ client });
+  },
+  { timeout: 120_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("each family can serve exactly one independently routed generation", async () => {
+  await db.insert(corpusIndexGenerations).values([
+    {
+      cluster: "quickwit_08",
+      family: "case_law",
+      generation: "case_law_v2",
+      status: "serving",
+    },
+    {
+      cluster: "quickwit_09",
+      family: "case_law",
+      generation: "case_law_v5",
+      status: "building",
+    },
+    {
+      cluster: "quickwit_08",
+      family: "legislation",
+      generation: "legislation_v1",
+      status: "serving",
+    },
+  ]);
+
+  await expect(
+    db.insert(corpusIndexGenerations).values({
+      cluster: "quickwit_09",
+      family: "case_law",
+      generation: "case_law_v6",
+      status: "serving",
+    }),
+  ).rejects.toThrow();
+
+  const serving = await db
+    .select({
+      cluster: corpusIndexGenerations.cluster,
+      family: corpusIndexGenerations.family,
+      generation: corpusIndexGenerations.generation,
+    })
+    .from(corpusIndexGenerations)
+    .where(eq(corpusIndexGenerations.status, "serving"))
+    .orderBy(corpusIndexGenerations.family);
+
+  expect(serving).toEqual([
+    {
+      cluster: "quickwit_08",
+      family: "case_law",
+      generation: "case_law_v2",
+    },
+    {
+      cluster: "quickwit_08",
+      family: "legislation",
+      generation: "legislation_v1",
+    },
+  ]);
+});
+
+test("database constraints reject drift outside the TypeScript contract", async () => {
+  await expect(
+    db.execute(sql`
+      INSERT INTO corpus_index_generations (family, generation, cluster, status)
+      VALUES ('case_law', 'legislation_v2', 'quickwit_09', 'building')
+    `),
+  ).rejects.toThrow();
+
+  await expect(
+    db.execute(sql`
+      INSERT INTO corpus_index_generations (family, generation, cluster, status)
+      VALUES ('legislation', 'legislation_v2', 'quickwit_10', 'building')
+    `),
+  ).rejects.toThrow();
+
+  await expect(
+    db.execute(sql`
+      INSERT INTO corpus_index_generations (family, generation, cluster, status)
+      VALUES ('legislation', 'legislation_v2', 'quickwit_09', 'ready')
+    `),
+  ).rejects.toThrow();
+});

--- a/apps/api/src/lib/legal-search/corpus-index-generations.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generations.db.test.ts
@@ -24,21 +24,21 @@ afterAll(async () => {
 test("each family can serve exactly one independently routed generation", async () => {
   await db.insert(corpusIndexGenerations).values([
     {
-      cluster: "quickwit_08",
+      cluster: "q08",
       family: "case_law",
       generation: "case_law_v2",
       manifestDigest: MANIFEST_DIGEST,
       status: "serving",
     },
     {
-      cluster: "quickwit_09",
+      cluster: "q09",
       family: "case_law",
       generation: "case_law_v5",
       manifestDigest: MANIFEST_DIGEST,
       status: "building",
     },
     {
-      cluster: "quickwit_08",
+      cluster: "q08",
       family: "legislation",
       generation: "legislation_v1",
       manifestDigest: MANIFEST_DIGEST,
@@ -48,7 +48,7 @@ test("each family can serve exactly one independently routed generation", async 
 
   await expect(
     db.insert(corpusIndexGenerations).values({
-      cluster: "quickwit_09",
+      cluster: "q09",
       family: "case_law",
       generation: "case_law_v6",
       manifestDigest: MANIFEST_DIGEST,
@@ -68,12 +68,12 @@ test("each family can serve exactly one independently routed generation", async 
 
   expect(serving).toEqual([
     {
-      cluster: "quickwit_08",
+      cluster: "q08",
       family: "case_law",
       generation: "case_law_v2",
     },
     {
-      cluster: "quickwit_08",
+      cluster: "q08",
       family: "legislation",
       generation: "legislation_v1",
     },
@@ -84,7 +84,7 @@ test("database constraints reject drift outside the TypeScript contract", async 
   await expect(
     db.execute(sql`
       INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
-      VALUES ('case_law', 'legislation_v2', 'quickwit_09', ${MANIFEST_DIGEST}, 'building')
+      VALUES ('case_law', 'legislation_v2', 'q09', ${MANIFEST_DIGEST}, 'building')
     `),
   ).rejects.toThrow();
 
@@ -98,28 +98,28 @@ test("database constraints reject drift outside the TypeScript contract", async 
   await expect(
     db.execute(sql`
       INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
-      VALUES ('legislation', 'legislation_v2', 'quickwit_09', ${MANIFEST_DIGEST}, 'ready')
+      VALUES ('legislation', 'legislation_v2', 'q09', ${MANIFEST_DIGEST}, 'ready')
     `),
   ).rejects.toThrow();
 
   await expect(
     db.execute(sql`
       INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
-      VALUES ('case_law', 'case_law_v11111111111111111111111111111111', 'quickwit_09', ${MANIFEST_DIGEST}, 'building')
+      VALUES ('case_law', 'case_law_v11111111111111111111111111111111', 'q09', ${MANIFEST_DIGEST}, 'building')
     `),
   ).rejects.toThrow();
 
   await expect(
     db.execute(sql`
       INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
-      VALUES ('case_law', 'case_law_v8', 'quickwit_09', 'not-a-digest', 'building')
+      VALUES ('case_law', 'case_law_v8', 'q09', 'not-a-digest', 'building')
     `),
   ).rejects.toThrow();
 });
 
 test("generation identity cannot be retargeted after registration", async () => {
   await db.insert(corpusIndexGenerations).values({
-    cluster: "quickwit_09",
+    cluster: "q09",
     family: "case_law",
     generation: "case_law_v7",
     manifestDigest: MANIFEST_DIGEST,
@@ -134,7 +134,7 @@ test("generation identity cannot be retargeted after registration", async () => 
   await expect(
     db.execute(sql`
       UPDATE corpus_index_generations
-      SET cluster = 'quickwit_08'
+      SET cluster = 'q08'
       WHERE family = 'case_law' AND generation = 'case_law_v7'
     `),
   ).rejects.toThrow("corpus index generation identity is immutable");

--- a/apps/api/src/lib/legal-search/corpus-index-generations.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generations.db.test.ts
@@ -9,6 +9,22 @@ let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
 const MANIFEST_DIGEST = "a".repeat(64);
 
+const errorMessageChain = (error: unknown): string => {
+  const messages: string[] = [];
+  let current = error;
+  while (current instanceof Error) {
+    messages.push(current.message);
+    current = current.cause;
+  }
+  return messages.join(" | ");
+};
+
+const rejectionMessage = async (run: Promise<unknown>): Promise<string> =>
+  await run.then(
+    () => "no rejection",
+    (error: unknown) => errorMessageChain(error),
+  );
+
 beforeAll(
   async () => {
     client = await createTestPglite();
@@ -46,15 +62,20 @@ test("each family can serve exactly one independently routed generation", async 
     },
   ]);
 
-  await expect(
-    db.insert(corpusIndexGenerations).values({
-      cluster: "q09",
-      family: "case_law",
-      generation: "case_law_v6",
-      manifestDigest: MANIFEST_DIGEST,
-      status: "serving",
-    }),
-  ).rejects.toThrow();
+  expect(
+    await rejectionMessage(
+      db
+        .insert(corpusIndexGenerations)
+        .values({
+          cluster: "q09",
+          family: "case_law",
+          generation: "case_law_v6",
+          manifestDigest: MANIFEST_DIGEST,
+          status: "serving",
+        })
+        .execute(),
+    ),
+  ).toContain("corpus_index_generations_serving_family_uidx");
 
   const serving = await db
     .select({
@@ -81,40 +102,50 @@ test("each family can serve exactly one independently routed generation", async 
 });
 
 test("database constraints reject drift outside the TypeScript contract", async () => {
-  await expect(
-    db.execute(sql`
-      INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
-      VALUES ('case_law', 'legislation_v2', 'q09', ${MANIFEST_DIGEST}, 'building')
-    `),
-  ).rejects.toThrow();
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
+        VALUES ('case_law', 'legislation_v2', 'q09', ${MANIFEST_DIGEST}, 'building')
+      `),
+    ),
+  ).toContain("corpus_index_generations_name_matches_family");
 
-  await expect(
-    db.execute(sql`
-      INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
-      VALUES ('legislation', 'legislation_v2', 'quickwit_10', ${MANIFEST_DIGEST}, 'building')
-    `),
-  ).rejects.toThrow();
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
+        VALUES ('legislation', 'legislation_v2', 'quickwit_10', ${MANIFEST_DIGEST}, 'building')
+      `),
+    ),
+  ).toContain("corpus_index_generations_cluster_values");
 
-  await expect(
-    db.execute(sql`
-      INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
-      VALUES ('legislation', 'legislation_v2', 'q09', ${MANIFEST_DIGEST}, 'ready')
-    `),
-  ).rejects.toThrow();
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
+        VALUES ('legislation', 'legislation_v2', 'q09', ${MANIFEST_DIGEST}, 'ready')
+      `),
+    ),
+  ).toContain("corpus_index_generations_status_values");
 
-  await expect(
-    db.execute(sql`
-      INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
-      VALUES ('case_law', 'case_law_v11111111111111111111111111111111', 'q09', ${MANIFEST_DIGEST}, 'building')
-    `),
-  ).rejects.toThrow();
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
+        VALUES ('case_law', 'case_law_v11111111111111111111111111111111', 'q09', ${MANIFEST_DIGEST}, 'building')
+      `),
+    ),
+  ).toContain("value too long for type character varying(32)");
 
-  await expect(
-    db.execute(sql`
-      INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
-      VALUES ('case_law', 'case_law_v8', 'q09', 'not-a-digest', 'building')
-    `),
-  ).rejects.toThrow();
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        INSERT INTO corpus_index_generations (family, generation, cluster, manifest_digest, status)
+        VALUES ('case_law', 'case_law_v8', 'q09', 'not-a-digest', 'building')
+      `),
+    ),
+  ).toContain("corpus_index_generations_manifest_digest_shape");
 });
 
 test("generation identity cannot be retargeted after registration", async () => {
@@ -131,19 +162,23 @@ test("generation identity cannot be retargeted after registration", async () => 
     .set({ status: "retiring" })
     .where(eq(corpusIndexGenerations.generation, "case_law_v7"));
 
-  await expect(
-    db.execute(sql`
-      UPDATE corpus_index_generations
-      SET cluster = 'q08'
-      WHERE family = 'case_law' AND generation = 'case_law_v7'
-    `),
-  ).rejects.toThrow("corpus index generation identity is immutable");
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        UPDATE corpus_index_generations
+        SET cluster = 'q08'
+        WHERE family = 'case_law' AND generation = 'case_law_v7'
+      `),
+    ),
+  ).toContain("corpus index generation identity is immutable");
 
-  await expect(
-    db.execute(sql`
-      UPDATE corpus_index_generations
-      SET manifest_digest = ${"b".repeat(64)}
-      WHERE family = 'case_law' AND generation = 'case_law_v7'
-    `),
-  ).rejects.toThrow("corpus index generation identity is immutable");
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        UPDATE corpus_index_generations
+        SET manifest_digest = ${"b".repeat(64)}
+        WHERE family = 'case_law' AND generation = 'case_law_v7'
+      `),
+    ),
+  ).toContain("corpus index generation identity is immutable");
 });

--- a/apps/api/src/lib/legal-search/index-naming.ts
+++ b/apps/api/src/lib/legal-search/index-naming.ts
@@ -8,6 +8,7 @@ import {
   isCaseLawIndexGroup,
   POSTGRES_INTEGER_MAX,
 } from "@/api/lib/legal-search/case-law-index-groups";
+import { CORPUS_INDEX_GENERATION_MAX_LENGTH } from "@/api/lib/legal-search/corpus-generation-contract";
 
 /**
  * corpus index index naming, generic over document family. The `generation`
@@ -26,7 +27,7 @@ import {
 // Corpus index ids must match ^[a-zA-Z][a-zA-Z0-9._-]{2,254}$. Database
 // columns use the tighter bound below so every constructed physical id has
 // one storage contract across decisions, audit rows, and projection state.
-export const CORPUS_INDEX_GENERATION_MAX_LENGTH = 32;
+export { CORPUS_INDEX_GENERATION_MAX_LENGTH };
 export const CORPUS_INDEX_ID_MAX_LENGTH = 64;
 
 const GENERATION_PATTERN = new RegExp(

--- a/apps/api/src/lib/public-law-relations.ts
+++ b/apps/api/src/lib/public-law-relations.ts
@@ -13,6 +13,7 @@ export const PUBLIC_LAW_RELATION_BY_SCHEMA_IMPORT = {
   caseLawDecisions: "case_law_decisions",
   caseLawProvisionCitations: "case_law_provision_citations",
   caseLawSources: "case_law_sources",
+  corpusIndexGenerations: "corpus_index_generations",
   legislationDocuments: "legislation_documents",
   legislationSources: "legislation_sources",
 } as const;
@@ -103,6 +104,12 @@ export const PUBLIC_LAW_COLUMNS_BY_RELATION = {
     "confidence",
   ],
   case_law_sources: ["id", "name", "adapter_key", "descriptor"],
+  corpus_index_generations: [
+    "family",
+    "generation",
+    "cluster",
+    "status",
+  ],
   legislation_documents: [
     "id",
     "source_id",

--- a/apps/api/src/lib/public-law-relations.ts
+++ b/apps/api/src/lib/public-law-relations.ts
@@ -108,6 +108,7 @@ export const PUBLIC_LAW_COLUMNS_BY_RELATION = {
     "family",
     "generation",
     "cluster",
+    "manifest_digest",
     "status",
   ],
   legislation_documents: [

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -98,6 +98,9 @@ const POST_BOOTSTRAP_SELECT_ONLY_TABLES = new Set([
   // Durable operator progress: request code may inspect the rollout receipt;
   // only the ingestion role and the maintenance script may advance it.
   "case_law_decision_identifier_backfills",
+  // Corpus-index generation identity is immutable control-plane state. The
+  // request role resolves serving generations but never mutates the registry.
+  "corpus_index_generations",
 ]);
 
 // Internal handoff tables whose scoped role needs INSERT but not table-wide


### PR DESCRIPTION
## Summary

- add a shared, typed generation lifecycle for case law and legislation
- bind each generation to a closed Quickwit cluster identifier rather than a persisted URL
- enforce one serving generation per family and family-correct generation names in PostgreSQL
- expose only the four routing columns through the public-law reader role

## Validation

- git diff --check
- CI is the lint, format, type, migration, and database-test authority; local checks were skipped because the workstation is under sustained load

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tracking for case-law and legislation index generations, including cluster, status, timestamps and serving-generation rules.
  - Added validation for supported corpus families, search clusters, generation statuses and family-specific generation names.
  - Exposed index-generation data through public-law relations.

- **Tests**
  - Added coverage for valid and invalid generation configurations, routing and database constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->