### PR TITLE
feat: add Better Auth 1.7 migration bridge

### DIFF
--- a/.github/workflows/build-api-image.yml
+++ b/.github/workflows/build-api-image.yml
@@ -1,0 +1,118 @@
+name: Build API image from protected history
+
+run-name: Build API image (${{ inputs.source_sha }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Exact commit SHA reachable from protected main
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: api-image-${{ inputs.source_sha }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/stella-api
+
+jobs:
+  resolve:
+    name: Resolve protected source
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      source_sha: ${{ steps.source.outputs.sha }}
+
+    steps:
+      - name: Verify exact main ancestor
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::source_sha must be an exact 40-character lowercase commit SHA"
+            exit 1
+          fi
+
+          main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          relationship="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/compare/${SOURCE_SHA}...${main_sha}" \
+              --jq '.status'
+          )"
+          if [[ "$relationship" != "ahead" && "$relationship" != "identical" ]]; then
+            echo "::error::source_sha is not reachable from protected main"
+            exit 1
+          fi
+          echo "sha=${SOURCE_SHA}" >>"$GITHUB_OUTPUT"
+
+  build:
+    name: Build and attest API image
+    needs: resolve
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+
+    steps:
+      - name: Checkout verified source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          persist-credentials: false
+          submodules: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:commit-${{ needs.resolve.outputs.source_sha }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-staging
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-staging,mode=max
+          build-args: |
+            STELLA_VERSION=main-${{ needs.resolve.outputs.source_sha }}
+            STELLA_COMMIT_SHA=${{ needs.resolve.outputs.source_sha }}
+
+      - name: Attest image provenance
+        uses: ./.github/actions/provenance
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+
+      - name: Record immutable image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+        run: |
+          {
+            echo "### API image"
+            echo "Source: \`${SOURCE_SHA}\`"
+            echo "Digest: \`${DIGEST}\`"
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -66,7 +66,8 @@ RUN bun build \
 # report. Run on the isolated clone task with command override:
 #   ["bun", "/app/better-auth-migration-audit.js", "pre-migration",
 #    "--baseline", "/tmp/better-auth-baseline.json", "--identity-map",
-#    "/tmp/better-auth-identity-map.json"]
+#    "/tmp/better-auth-identity-map.json", "--oauth-base-url",
+#    "https://api.stll.app"]
 RUN bun build \
     --target bun \
     --outfile /app/better-auth-migration-audit.js \

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -65,11 +65,18 @@ RUN bun build \
 # credential plus a private tmpfs baseline path; stdout is a redacted JSON
 # report. Run on the isolated clone task with command override:
 #   ["bun", "/app/better-auth-migration-audit.js", "pre-migration",
-#    "--baseline", "/tmp/better-auth-baseline.json"]
+#    "--baseline", "/tmp/better-auth-baseline.json", "--identity-map",
+#    "/tmp/better-auth-identity-map.json"]
 RUN bun build \
     --target bun \
     --outfile /app/better-auth-migration-audit.js \
     apps/api/src/scripts/better-auth-migration-audit.ts
+# Bounded Better Auth bridge backfill. The command reproduces the private
+# baseline before mutating and runs the post-backfill audit before succeeding.
+RUN bun build \
+    --target bun \
+    --outfile /app/better-auth-17-backfill.js \
+    apps/api/src/scripts/better-auth-17-backfill.ts
 # Dedicated durable document-processing worker. Deploy the same image with
 # command override ["bun", "/app/document-processing-worker.js"]. OCR runs
 # in-image through the isolated local ONNX worker.
@@ -175,6 +182,7 @@ RUN groupadd --system --gid 1001 stella && \
 COPY --chown=stella:stella --from=builder /app/server /app/server
 COPY --chown=stella:stella --from=builder /app/backfill.js /app/backfill.js
 COPY --chown=stella:stella --from=builder /app/better-auth-migration-audit.js /app/better-auth-migration-audit.js
+COPY --chown=stella:stella --from=builder /app/better-auth-17-backfill.js /app/better-auth-17-backfill.js
 COPY --chown=stella:stella --from=builder /app/document-processing-worker.js /app/document-processing-worker.js
 COPY --chown=stella:stella --from=builder /app/apps/legal-atlas-runner/dist/index.js /app/legal-atlas.js
 # Bundled migration task entrypoint:

--- a/apps/api/drizzle/20260825140000_better_auth_17_additive/migration.sql
+++ b/apps/api/drizzle/20260825140000_better_auth_17_additive/migration.sql
@@ -100,6 +100,6 @@ CREATE POLICY "auth_no_stella_access" ON "oauth_client_assertion"
   AS PERMISSIVE FOR ALL TO "stella"
   USING (false) WITH CHECK (false);--> statement-breakpoint
 
-REVOKE ALL PRIVILEGES ON TABLE "oauth_resource" FROM "stella";--> statement-breakpoint
-REVOKE ALL PRIVILEGES ON TABLE "oauth_client_resource" FROM "stella";--> statement-breakpoint
-REVOKE ALL PRIVILEGES ON TABLE "oauth_client_assertion" FROM "stella";
+REVOKE ALL PRIVILEGES ON TABLE "oauth_resource" FROM stella;--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON TABLE "oauth_client_resource" FROM stella;--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON TABLE "oauth_client_assertion" FROM stella;

--- a/apps/api/drizzle/20260825140000_better_auth_17_additive/migration.sql
+++ b/apps/api/drizzle/20260825140000_better_auth_17_additive/migration.sql
@@ -1,0 +1,105 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '30s';--> statement-breakpoint
+
+-- Better Auth 1.7 bridge schema. This migration is additive so the current
+-- 1.6 image remains deployable throughout rehearsal and rollback. Account
+-- identities and OAuth resource policy are populated by the separately gated,
+-- private-manifest backfill; no existing auth value changes here.
+ALTER TABLE "account"
+  ADD COLUMN "issuer" text;--> statement-breakpoint
+
+ALTER TABLE "oauth_client"
+  ADD COLUMN "client_discovery_id" text,
+  ADD COLUMN "client_credentials_scopes" text[] DEFAULT '{}' NOT NULL,
+  ADD COLUMN "backchannel_logout_uri" text,
+  ADD COLUMN "backchannel_logout_session_required" boolean,
+  ADD COLUMN "application_type" text,
+  ADD COLUMN "jwks" text,
+  ADD COLUMN "jwks_uri" text,
+  ADD COLUMN "dpop_bound_access_tokens" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+
+ALTER TABLE "oauth_refresh_token"
+  ADD COLUMN "authorization_code_id" text,
+  ADD COLUMN "resources" text[],
+  ADD COLUMN "requested_user_info_claims" text[],
+  ADD COLUMN "rotated_at" timestamptz,
+  ADD COLUMN "rotation_replay_response" text,
+  ADD COLUMN "rotation_replay_expires_at" timestamptz,
+  ADD COLUMN "confirmation" jsonb;--> statement-breakpoint
+
+ALTER TABLE "oauth_access_token"
+  ADD COLUMN "authorization_code_id" text,
+  ADD COLUMN "resources" text[],
+  ADD COLUMN "requested_user_info_claims" text[],
+  ADD COLUMN "revoked" timestamptz,
+  ADD COLUMN "confirmation" jsonb;--> statement-breakpoint
+
+ALTER TABLE "oauth_consent"
+  ADD COLUMN "resources" text[],
+  ADD COLUMN "requested_user_info_claims" text[];--> statement-breakpoint
+
+CREATE TABLE "oauth_resource" (
+  "id" text PRIMARY KEY,
+  "identifier" text NOT NULL UNIQUE,
+  "name" text NOT NULL,
+  "access_token_ttl" integer,
+  "refresh_token_ttl" integer,
+  "signing_algorithm" text,
+  "signing_key_id" text,
+  "allowed_scopes" text[],
+  "custom_claims" jsonb,
+  "dpop_bound_access_tokens_required" boolean DEFAULT false NOT NULL,
+  "disabled" boolean DEFAULT false NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL,
+  "policy_version" integer DEFAULT 1 NOT NULL,
+  "metadata" jsonb
+);--> statement-breakpoint
+
+CREATE TABLE "oauth_client_resource" (
+  "id" text PRIMARY KEY,
+  "client_id" text NOT NULL,
+  "resource_id" text NOT NULL,
+  "metadata" jsonb,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "oauth_client_resource_client_id_resource_id_unique"
+    UNIQUE ("client_id", "resource_id"),
+  CONSTRAINT "oauth_client_resource_client_id_oauth_client_client_id_fk"
+    FOREIGN KEY ("client_id") REFERENCES "oauth_client"("client_id")
+    ON DELETE CASCADE,
+  CONSTRAINT "oauth_client_resource_resource_id_oauth_resource_identifier_fk"
+    FOREIGN KEY ("resource_id") REFERENCES "oauth_resource"("identifier")
+    ON DELETE CASCADE
+);--> statement-breakpoint
+
+CREATE TABLE "oauth_client_assertion" (
+  "id" text PRIMARY KEY,
+  "expires_at" timestamptz NOT NULL
+);--> statement-breakpoint
+
+CREATE INDEX "oauth_refresh_token_authorization_code_id_idx"
+  ON "oauth_refresh_token" ("authorization_code_id");--> statement-breakpoint
+CREATE INDEX "oauth_access_token_authorization_code_id_idx"
+  ON "oauth_access_token" ("authorization_code_id");--> statement-breakpoint
+CREATE INDEX "oauth_client_resource_client_id_idx"
+  ON "oauth_client_resource" ("client_id");--> statement-breakpoint
+CREATE INDEX "oauth_client_resource_resource_id_idx"
+  ON "oauth_client_resource" ("resource_id");--> statement-breakpoint
+
+ALTER TABLE "oauth_resource" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "oauth_client_resource" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "oauth_client_assertion" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+
+CREATE POLICY "auth_no_stella_access" ON "oauth_resource"
+  AS PERMISSIVE FOR ALL TO "stella"
+  USING (false) WITH CHECK (false);--> statement-breakpoint
+CREATE POLICY "auth_no_stella_access" ON "oauth_client_resource"
+  AS PERMISSIVE FOR ALL TO "stella"
+  USING (false) WITH CHECK (false);--> statement-breakpoint
+CREATE POLICY "auth_no_stella_access" ON "oauth_client_assertion"
+  AS PERMISSIVE FOR ALL TO "stella"
+  USING (false) WITH CHECK (false);--> statement-breakpoint
+
+REVOKE ALL PRIVILEGES ON TABLE "oauth_resource" FROM "stella";--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON TABLE "oauth_client_resource" FROM "stella";--> statement-breakpoint
+REVOKE ALL PRIVILEGES ON TABLE "oauth_client_assertion" FROM "stella";

--- a/apps/api/drizzle/20260825140000_better_auth_17_additive/migration.sql
+++ b/apps/api/drizzle/20260825140000_better_auth_17_additive/migration.sql
@@ -62,8 +62,6 @@ CREATE TABLE "oauth_client_resource" (
   "resource_id" text NOT NULL,
   "metadata" jsonb,
   "created_at" timestamptz DEFAULT now() NOT NULL,
-  CONSTRAINT "oauth_client_resource_client_id_resource_id_unique"
-    UNIQUE ("client_id", "resource_id"),
   CONSTRAINT "oauth_client_resource_client_id_oauth_client_client_id_fk"
     FOREIGN KEY ("client_id") REFERENCES "oauth_client"("client_id")
     ON DELETE CASCADE,
@@ -77,10 +75,8 @@ CREATE TABLE "oauth_client_assertion" (
   "expires_at" timestamptz NOT NULL
 );--> statement-breakpoint
 
-CREATE INDEX "oauth_refresh_token_authorization_code_id_idx"
-  ON "oauth_refresh_token" ("authorization_code_id");--> statement-breakpoint
-CREATE INDEX "oauth_access_token_authorization_code_id_idx"
-  ON "oauth_access_token" ("authorization_code_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "oauth_client_resource_client_id_resource_id_unique"
+  ON "oauth_client_resource" ("client_id", "resource_id");--> statement-breakpoint
 CREATE INDEX "oauth_client_resource_client_id_idx"
   ON "oauth_client_resource" ("client_id");--> statement-breakpoint
 CREATE INDEX "oauth_client_resource_resource_id_idx"

--- a/apps/api/drizzle/20260825141000_better_auth_17_bridge_indexes/migration.sql
+++ b/apps/api/drizzle/20260825141000_better_auth_17_bridge_indexes/migration.sql
@@ -1,0 +1,26 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- These indexes target token tables already serving Better Auth 1.6 traffic.
+-- Drizzle wraps migrations in a transaction, while PostgreSQL requires
+-- concurrent index builds to run outside one. Split the transaction so the
+-- bridge never blocks token writes for the duration of an index scan.
+-- squawk-ignore transaction-nesting
+COMMIT;--> statement-breakpoint
+SET statement_timeout = 0;--> statement-breakpoint
+SET lock_timeout = 0;--> statement-breakpoint
+
+DROP INDEX CONCURRENTLY IF EXISTS "oauth_refresh_token_authorization_code_id_idx";--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts -- IF NOT EXISTS would retain an INVALID index left by an interrupted concurrent build
+CREATE INDEX CONCURRENTLY "oauth_refresh_token_authorization_code_id_idx"
+  ON "oauth_refresh_token" ("authorization_code_id");--> statement-breakpoint
+
+DROP INDEX CONCURRENTLY IF EXISTS "oauth_access_token_authorization_code_id_idx";--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts -- IF NOT EXISTS would retain an INVALID index left by an interrupted concurrent build
+CREATE INDEX CONCURRENTLY "oauth_access_token_authorization_code_id_idx"
+  ON "oauth_access_token" ("authorization_code_id");--> statement-breakpoint
+
+SET statement_timeout = '5s';--> statement-breakpoint
+SET lock_timeout = '1s';--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -31,6 +31,7 @@
     "bench:chat-read-surface": "NODE_ENV=development bun scripts/benchmark-chat-read-surface.ts",
     "db:migrate": "bun run --env-file=.env src/db/migrate.ts",
     "db:audit-better-auth": "bun run --env-file=.env src/scripts/better-auth-migration-audit.ts",
+    "db:backfill-better-auth-17": "bun run --env-file=.env src/scripts/better-auth-17-backfill.ts",
     "db:push": "bun run db:migrate && bun run --env-file=.env drizzle-kit push",
     "db:seed-test-user": "bun scripts/seed-test-user.ts",
     "db:seed-dev": "bun scripts/seed-dev.ts",

--- a/apps/api/src/db/auth-schema.test.ts
+++ b/apps/api/src/db/auth-schema.test.ts
@@ -1,6 +1,7 @@
 import { twoFactor as betterAuthTwoFactor } from "better-auth/plugins";
 import { describe, expect, test } from "bun:test";
 import { getColumns } from "drizzle-orm";
+import type { InferSelectModel } from "drizzle-orm";
 import { getTableConfig, PgDialect } from "drizzle-orm/pg-core";
 import type { AnyPgTable } from "drizzle-orm/pg-core";
 
@@ -19,6 +20,7 @@ import type {
 import {
   AUTH_USER_STELLA_SELECT_COLUMN_NAMES,
   AUTH_USER_STELLA_SELECT_COLUMNS,
+  BETTER_AUTH_17_BRIDGE_MODEL_NAMES,
   account,
   authSchema,
   invitation,
@@ -51,6 +53,12 @@ const PRODUCT_AUTH_MODEL_NAMES = [
 const CORE_AUTH_MODEL_NAMES: readonly string[] = Object.keys(
   BETTER_AUTH_CORE_SCHEMA,
 );
+
+const BETTER_AUTH_17_BRIDGE_CORE_FIELD_NAMES = {
+  account: ["issuer"],
+} as const satisfies {
+  account: readonly (keyof InferSelectModel<typeof account>)[];
+};
 
 const normalizeDateStorage = (
   storage: BetterAuthFieldContract["database"]["storage"] | undefined,
@@ -271,11 +279,20 @@ const referenceTo = (tableName: string): BetterAuthFieldReference => {
   throw new Error(`Unsupported core auth reference: ${tableName}`);
 };
 
-const normalizeModel = (
-  modelName: string,
-  table: AnyPgTable,
-  expectedFields: Record<string, BetterAuthFieldContract>,
-) => {
+type NormalizeModelOptions = {
+  bridgeFieldNames?: readonly string[];
+  expectedFields: Record<string, BetterAuthFieldContract>;
+  modelName: string;
+  table: AnyPgTable;
+};
+
+const normalizeModel = ({
+  bridgeFieldNames = [],
+  expectedFields,
+  modelName,
+  table,
+}: NormalizeModelOptions) => {
+  const bridgeFields = new Set(bridgeFieldNames);
   const columns = getColumns(table);
   const config = getTableConfig(table);
   const logicalNameByColumn = new Map(
@@ -309,6 +326,9 @@ const normalizeModel = (
 
   const fields: Record<string, BetterAuthFieldContract> = {};
   for (const [logicalName, column] of Object.entries(columns)) {
+    if (bridgeFields.has(logicalName)) {
+      continue;
+    }
     const expected = expectedFields[logicalName];
     if (!expected) {
       throw new Error(`Undeclared auth field ${modelName}.${logicalName}`);
@@ -382,42 +402,56 @@ describe("auth schema", () => {
       Object.keys(authSchema)
         .filter((modelName) => !CORE_AUTH_MODEL_NAMES.includes(modelName))
         .toSorted(),
-    ).toEqual(PRODUCT_AUTH_MODEL_NAMES.toSorted());
+    ).toEqual(
+      [
+        ...PRODUCT_AUTH_MODEL_NAMES,
+        ...BETTER_AUTH_17_BRIDGE_MODEL_NAMES,
+      ].toSorted(),
+    );
 
     const models: Record<string, BetterAuthModelContract> = {
-      user: normalizeModel("user", user, {
-        ...BETTER_AUTH_CORE_SCHEMA.user.fields,
-        ...HOST_USER_FIELDS,
+      user: normalizeModel({
+        expectedFields: {
+          ...BETTER_AUTH_CORE_SCHEMA.user.fields,
+          ...HOST_USER_FIELDS,
+        },
+        modelName: "user",
+        table: user,
       }),
-      session: normalizeModel(
-        "session",
-        session,
-        BETTER_AUTH_CORE_SCHEMA.session.fields,
-      ),
-      account: normalizeModel(
-        "account",
-        account,
-        BETTER_AUTH_CORE_SCHEMA.account.fields,
-      ),
-      verification: normalizeModel(
-        "verification",
-        verification,
-        BETTER_AUTH_CORE_SCHEMA.verification.fields,
-      ),
-      organization: normalizeModel(
-        "organization",
-        organization,
-        BETTER_AUTH_CORE_SCHEMA.organization.fields,
-      ),
-      member: normalizeModel("member", member, {
-        ...BETTER_AUTH_CORE_SCHEMA.member.fields,
-        ...HOST_MEMBER_FIELDS,
+      session: normalizeModel({
+        expectedFields: BETTER_AUTH_CORE_SCHEMA.session.fields,
+        modelName: "session",
+        table: session,
       }),
-      invitation: normalizeModel(
-        "invitation",
-        invitation,
-        BETTER_AUTH_CORE_SCHEMA.invitation.fields,
-      ),
+      account: normalizeModel({
+        bridgeFieldNames: BETTER_AUTH_17_BRIDGE_CORE_FIELD_NAMES.account,
+        expectedFields: BETTER_AUTH_CORE_SCHEMA.account.fields,
+        modelName: "account",
+        table: account,
+      }),
+      verification: normalizeModel({
+        expectedFields: BETTER_AUTH_CORE_SCHEMA.verification.fields,
+        modelName: "verification",
+        table: verification,
+      }),
+      organization: normalizeModel({
+        expectedFields: BETTER_AUTH_CORE_SCHEMA.organization.fields,
+        modelName: "organization",
+        table: organization,
+      }),
+      member: normalizeModel({
+        expectedFields: {
+          ...BETTER_AUTH_CORE_SCHEMA.member.fields,
+          ...HOST_MEMBER_FIELDS,
+        },
+        modelName: "member",
+        table: member,
+      }),
+      invitation: normalizeModel({
+        expectedFields: BETTER_AUTH_CORE_SCHEMA.invitation.fields,
+        modelName: "invitation",
+        table: invitation,
+      }),
     };
     for (const modelName of PRODUCT_AUTH_MODEL_NAMES) {
       models[modelName] = PRODUCT_MODEL_PLACEHOLDER;

--- a/apps/api/src/db/auth-schema.ts
+++ b/apps/api/src/db/auth-schema.ts
@@ -121,6 +121,7 @@ export const account = pgTable(
   "account",
   {
     id: text("id").primaryKey(),
+    issuer: text("issuer"),
     accountId: text("account_id").notNull(),
     providerId: text("provider_id").notNull(),
     userId: text("user_id")
@@ -366,11 +367,16 @@ export const oauthClient = pgTable(
     id: text("id").primaryKey(),
     clientId: text("client_id").notNull().unique(),
     clientSecret: text("client_secret"),
+    clientDiscoveryId: text("client_discovery_id"),
     disabled: boolean("disabled").default(false).notNull(),
     skipConsent: boolean("skip_consent"),
     enableEndSession: boolean("enable_end_session"),
     subjectType: text("subject_type"),
     scopes: text("scopes").array(),
+    clientCredentialsScopes: text("client_credentials_scopes")
+      .array()
+      .default([])
+      .notNull(),
     userId: text("user_id").references(() => user.id, {
       onDelete: "cascade",
     }),
@@ -390,12 +396,22 @@ export const oauthClient = pgTable(
     softwareStatement: text("software_statement"),
     redirectUris: text("redirect_uris").array().notNull(),
     postLogoutRedirectUris: text("post_logout_redirect_uris").array(),
+    backchannelLogoutUri: text("backchannel_logout_uri"),
+    backchannelLogoutSessionRequired: boolean(
+      "backchannel_logout_session_required",
+    ),
     tokenEndpointAuthMethod: text("token_endpoint_auth_method"),
+    applicationType: text("application_type"),
+    jwks: text("jwks"),
+    jwksUri: text("jwks_uri"),
     grantTypes: text("grant_types").array(),
     responseTypes: text("response_types").array(),
     public: boolean("public"),
     type: text("type"),
     requirePKCE: boolean("require_pkce"),
+    dpopBoundAccessTokens: boolean("dpop_bound_access_tokens")
+      .default(false)
+      .notNull(),
     referenceId: text("reference_id"),
     metadata: jsonb("metadata"),
   },
@@ -405,6 +421,66 @@ export const oauthClient = pgTable(
     index("oauth_client_reference_id_idx").on(table.referenceId),
     ...denyStellaAccessPolicies(),
   ],
+);
+
+export const oauthResource = pgTable(
+  "oauth_resource",
+  {
+    id: text("id").primaryKey(),
+    identifier: text("identifier").notNull().unique(),
+    name: text("name").notNull(),
+    accessTokenTtl: integer("access_token_ttl"),
+    refreshTokenTtl: integer("refresh_token_ttl"),
+    signingAlgorithm: text("signing_algorithm"),
+    signingKeyId: text("signing_key_id"),
+    allowedScopes: text("allowed_scopes").array(),
+    customClaims: jsonb("custom_claims"),
+    dpopBoundAccessTokensRequired: boolean("dpop_bound_access_tokens_required")
+      .default(false)
+      .notNull(),
+    disabled: boolean("disabled").default(false).notNull(),
+    createdAt: timestamptz("created_at").defaultNow().notNull(),
+    updatedAt: timestamptz("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+    policyVersion: integer("policy_version").default(1).notNull(),
+    metadata: jsonb("metadata"),
+  },
+  () => [...denyStellaAccessPolicies()],
+);
+
+export const oauthClientResource = pgTable(
+  "oauth_client_resource",
+  {
+    id: text("id").primaryKey(),
+    clientId: text("client_id")
+      .notNull()
+      .references(() => oauthClient.clientId, { onDelete: "cascade" }),
+    resourceId: text("resource_id")
+      .notNull()
+      .references(() => oauthResource.identifier, { onDelete: "cascade" }),
+    metadata: jsonb("metadata"),
+    createdAt: timestamptz("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("oauth_client_resource_client_id_resource_id_unique").on(
+      table.clientId,
+      table.resourceId,
+    ),
+    index("oauth_client_resource_client_id_idx").on(table.clientId),
+    index("oauth_client_resource_resource_id_idx").on(table.resourceId),
+    ...denyStellaAccessPolicies(),
+  ],
+);
+
+export const oauthClientAssertion = pgTable(
+  "oauth_client_assertion",
+  {
+    id: text("id").primaryKey(),
+    expiresAt: timestamptz("expires_at").notNull(),
+  },
+  () => [...denyStellaAccessPolicies()],
 );
 
 export const oauthRefreshToken = pgTable(
@@ -426,10 +502,17 @@ export const oauthRefreshToken = pgTable(
         onDelete: "cascade",
       }),
     referenceId: text("reference_id"),
+    authorizationCodeId: text("authorization_code_id"),
+    resources: text("resources").array(),
+    requestedUserInfoClaims: text("requested_user_info_claims").array(),
     expiresAt: timestamptz("expires_at").notNull(),
     createdAt: timestamptz("created_at").defaultNow().notNull(),
     revoked: timestamptz("revoked"),
+    rotatedAt: timestamptz("rotated_at"),
+    rotationReplayResponse: text("rotation_replay_response"),
+    rotationReplayExpiresAt: timestamptz("rotation_replay_expires_at"),
     authTime: timestamptz("auth_time"),
+    confirmation: jsonb("confirmation"),
     scopes: text("scopes").array().notNull(),
   },
   (table) => [
@@ -437,6 +520,9 @@ export const oauthRefreshToken = pgTable(
     index("oauth_refresh_token_session_id_idx").on(table.sessionId),
     index("oauth_refresh_token_user_id_idx").on(table.userId),
     index("oauth_refresh_token_reference_id_idx").on(table.referenceId),
+    index("oauth_refresh_token_authorization_code_id_idx").on(
+      table.authorizationCodeId,
+    ),
     ...denyStellaAccessPolicies(),
   ],
 );
@@ -458,11 +544,16 @@ export const oauthAccessToken = pgTable(
       onDelete: "cascade",
     }),
     referenceId: text("reference_id"),
+    authorizationCodeId: text("authorization_code_id"),
+    resources: text("resources").array(),
+    requestedUserInfoClaims: text("requested_user_info_claims").array(),
     refreshId: text("refresh_id").references(() => oauthRefreshToken.id, {
       onDelete: "set null",
     }),
     expiresAt: timestamptz("expires_at").notNull(),
     createdAt: timestamptz("created_at").defaultNow().notNull(),
+    revoked: timestamptz("revoked"),
+    confirmation: jsonb("confirmation"),
     scopes: text("scopes").array().notNull(),
   },
   (table) => [
@@ -471,6 +562,9 @@ export const oauthAccessToken = pgTable(
     index("oauth_access_token_user_id_idx").on(table.userId),
     index("oauth_access_token_reference_id_idx").on(table.referenceId),
     index("oauth_access_token_refresh_id_idx").on(table.refreshId),
+    index("oauth_access_token_authorization_code_id_idx").on(
+      table.authorizationCodeId,
+    ),
     ...denyStellaAccessPolicies(),
   ],
 );
@@ -488,6 +582,8 @@ export const oauthConsent = pgTable(
       onDelete: "cascade",
     }),
     referenceId: text("reference_id"),
+    resources: text("resources").array(),
+    requestedUserInfoClaims: text("requested_user_info_claims").array(),
     scopes: text("scopes").array().notNull(),
     createdAt: timestamptz("created_at").defaultNow().notNull(),
     updatedAt: timestamptz("updated_at")
@@ -515,6 +611,9 @@ export const authSchema = {
   jwks,
   apikey,
   oauthClient,
+  oauthResource,
+  oauthClientResource,
+  oauthClientAssertion,
   oauthAccessToken,
   oauthRefreshToken,
   oauthConsent,
@@ -546,6 +645,22 @@ export const authRelationsPart = defineRelationsPart(authSchema, (r) => ({
       to: r.oauthConsent.userId,
     }),
     twoFactors: r.many.twoFactor({ from: r.user.id, to: r.twoFactor.userId }),
+  },
+  oauthResource: {
+    clients: r.many.oauthClientResource({
+      from: r.oauthResource.identifier,
+      to: r.oauthClientResource.resourceId,
+    }),
+  },
+  oauthClientResource: {
+    client: r.one.oauthClient({
+      from: r.oauthClientResource.clientId,
+      to: r.oauthClient.clientId,
+    }),
+    resource: r.one.oauthResource({
+      from: r.oauthClientResource.resourceId,
+      to: r.oauthResource.identifier,
+    }),
   },
   session: {
     user: r.one.user({ from: r.session.userId, to: r.user.id }),
@@ -607,6 +722,10 @@ export const authRelationsPart = defineRelationsPart(authSchema, (r) => ({
     consents: r.many.oauthConsent({
       from: r.oauthClient.clientId,
       to: r.oauthConsent.clientId,
+    }),
+    resources: r.many.oauthClientResource({
+      from: r.oauthClient.clientId,
+      to: r.oauthClientResource.clientId,
     }),
   },
   oauthRefreshToken: {

--- a/apps/api/src/db/auth-schema.ts
+++ b/apps/api/src/db/auth-schema.ts
@@ -619,6 +619,17 @@ export const authSchema = {
   oauthConsent,
 };
 
+/**
+ * Additive tables staged before the Better Auth 1.7 runtime cutover. The
+ * current 1.6 runtime ignores them; the follow-up cutover promotes them into
+ * the shared Better Auth contract after rehearsal and backfill validation.
+ */
+export const BETTER_AUTH_17_BRIDGE_MODEL_NAMES = [
+  "oauthResource",
+  "oauthClientResource",
+  "oauthClientAssertion",
+] as const satisfies readonly (keyof typeof authSchema)[];
+
 export const authRelationsPart = defineRelationsPart(authSchema, (r) => ({
   user: {
     sessions: r.many.session({ from: r.user.id, to: r.session.userId }),

--- a/apps/api/src/lib/oauth-resource-policy.ts
+++ b/apps/api/src/lib/oauth-resource-policy.ts
@@ -1,0 +1,25 @@
+import {
+  getMcpResourceScopes,
+  getMcpResourceUrl,
+  MCP_MODES,
+} from "@/api/mcp/constants";
+import type { McpMode } from "@/api/mcp/constants";
+
+const OAUTH_RESOURCE_NAMES = {
+  anonymized: "Stella MCP anonymized",
+  default: "Stella MCP",
+  documents: "Stella MCP documents",
+} as const satisfies Record<McpMode, string>;
+
+/**
+ * One source of truth for Better Auth's persisted and runtime OAuth resource
+ * policy. Existing 1.6 clients are linked to every entry during the bridge
+ * backfill, which preserves the old global `validAudiences` capability. New
+ * 1.7 registrations receive an explicit subset at creation time.
+ */
+export const getBetterAuthOAuthResources = () =>
+  MCP_MODES.map((mode) => ({
+    allowedScopes: [...getMcpResourceScopes(mode)],
+    identifier: getMcpResourceUrl(mode),
+    name: OAUTH_RESOURCE_NAMES[mode],
+  }));

--- a/apps/api/src/lib/oauth-resource-policy.ts
+++ b/apps/api/src/lib/oauth-resource-policy.ts
@@ -1,15 +1,5 @@
-import {
-  getMcpResourceScopes,
-  getMcpResourceUrl,
-  MCP_MODES,
-} from "@/api/mcp/constants";
-import type { McpMode } from "@/api/mcp/constants";
-
-const OAUTH_RESOURCE_NAMES = {
-  anonymized: "Stella MCP anonymized",
-  default: "Stella MCP",
-  documents: "Stella MCP documents",
-} as const satisfies Record<McpMode, string>;
+import { getMcpBaseUrl } from "@/api/mcp/constants";
+import { buildBetterAuthOAuthResources } from "@/api/mcp/resource-policy-contract";
 
 /**
  * One source of truth for Better Auth's persisted and runtime OAuth resource
@@ -18,8 +8,4 @@ const OAUTH_RESOURCE_NAMES = {
  * 1.7 registrations receive an explicit subset at creation time.
  */
 export const getBetterAuthOAuthResources = () =>
-  MCP_MODES.map((mode) => ({
-    allowedScopes: [...getMcpResourceScopes(mode)],
-    identifier: getMcpResourceUrl(mode),
-    name: OAUTH_RESOURCE_NAMES[mode],
-  }));
+  buildBetterAuthOAuthResources(getMcpBaseUrl());

--- a/apps/api/src/mcp/constants.ts
+++ b/apps/api/src/mcp/constants.ts
@@ -10,6 +10,17 @@ import {
 import { env } from "@/api/env";
 import { REQUEST_ID_HEADER } from "@/api/lib/observability/request-context";
 import { declareCliSupportBand } from "@/api/mcp/cli-support-band";
+import {
+  getMcpResourceModeConfig,
+  getMcpResourceScopes,
+  MCP_ANONYMIZED_DISCOVERY_PATH,
+  MCP_DISCOVERY_PATH,
+  MCP_DOCUMENTS_RESOURCE_SCOPES,
+  MCP_DOCUMENTS_DISCOVERY_PATH,
+  MCP_MODES,
+  ROOT_MCP_DISCOVERY_PATH,
+} from "@/api/mcp/resource-policy-contract";
+import type { McpMode } from "@/api/mcp/resource-policy-contract";
 
 export {
   MCP_ANONYMIZED_RESOURCE_SCOPES,
@@ -17,20 +28,8 @@ export {
   MCP_DEFAULT_RESOURCE_SCOPES,
 };
 
-/**
- * Least-privilege remote-host surface for document workflows. Hosted clients
- * commonly request every scope in protected-resource metadata, so this
- * resource advertises only the grants its projected tool registry can use.
- */
-export const MCP_DOCUMENTS_RESOURCE_SCOPES = [
-  "stella:read",
-  "stella:documents_write",
-  // The canonical presigned-upload lifecycle currently owns one scope across
-  // entity-create and entity-version purposes. The documents MCP audience
-  // restricts invoke_capability to the three lifecycle IDs, so this grant does
-  // not expose unrelated matter mutations through that endpoint.
-  "stella:matters_write",
-] as const;
+export { MCP_DOCUMENTS_RESOURCE_SCOPES, MCP_MODES };
+export type { McpMode };
 
 export const MCP_ALL_RESOURCE_SCOPES = [
   ...MCP_DEFAULT_RESOURCE_SCOPES,
@@ -80,17 +79,12 @@ export const MCP_STATELESS_ALLOW_HEADER = "OPTIONS, GET, POST";
  */
 export const MCP_NOTIFICATION_KEEP_ALIVE_MS = 5000;
 
-export const ROOT_MCP_DISCOVERY_PATH =
-  "/.well-known/oauth-protected-resource" as const;
-
-export const MCP_DISCOVERY_PATH =
-  `/.well-known/oauth-protected-resource${MCP_HTTP_PATH}` as const;
-
-export const MCP_DOCUMENTS_DISCOVERY_PATH =
-  `/.well-known/oauth-protected-resource${MCP_DOCUMENTS_HTTP_PATH}` as const;
-
-export const MCP_ANONYMIZED_DISCOVERY_PATH =
-  `/.well-known/oauth-protected-resource${MCP_ANONYMIZED_HTTP_PATH}` as const;
+export {
+  MCP_ANONYMIZED_DISCOVERY_PATH,
+  MCP_DISCOVERY_PATH,
+  MCP_DOCUMENTS_DISCOVERY_PATH,
+  ROOT_MCP_DISCOVERY_PATH,
+};
 
 export const MCP_ALLOWED_HEADERS = [
   "Authorization",
@@ -153,48 +147,13 @@ export const MCP_EXPOSE_HEADERS = [
   REQUEST_ID_HEADER,
 ] as const;
 
-const MCP_MODE_CONFIG = {
-  default: {
-    discoveryPath: MCP_DISCOVERY_PATH,
-    httpPath: MCP_HTTP_PATH,
-    resourceScopes: MCP_DEFAULT_RESOURCE_SCOPES,
-  },
-  documents: {
-    discoveryPath: MCP_DOCUMENTS_DISCOVERY_PATH,
-    httpPath: MCP_DOCUMENTS_HTTP_PATH,
-    resourceScopes: MCP_DOCUMENTS_RESOURCE_SCOPES,
-  },
-  anonymized: {
-    discoveryPath: MCP_ANONYMIZED_DISCOVERY_PATH,
-    httpPath: MCP_ANONYMIZED_HTTP_PATH,
-    resourceScopes: MCP_ANONYMIZED_RESOURCE_SCOPES,
-  },
-} as const;
-
-export type McpMode = keyof typeof MCP_MODE_CONFIG;
-
-const MCP_MODE_VALUES = [
-  "default",
-  "documents",
-  "anonymized",
-] as const satisfies readonly McpMode[];
-
-type MissingMcpMode = Exclude<McpMode, (typeof MCP_MODE_VALUES)[number]>;
-
-true satisfies MissingMcpMode extends never ? true : never;
-
-export const MCP_MODES = MCP_MODE_VALUES;
-
-const getMcpModeConfig = (mode: McpMode) => MCP_MODE_CONFIG[mode];
-
-export const getMcpResourceScopes = (mode: McpMode) =>
-  getMcpModeConfig(mode).resourceScopes;
+export { getMcpResourceScopes };
 
 export const getMcpBaseUrl = () => env.PUBLIC_URL ?? env.BETTER_AUTH_URL;
 
 export const getMcpResourceUrl = (mode: McpMode = "default") =>
   new URL(
-    getMcpModeConfig(mode).httpPath,
+    getMcpResourceModeConfig(mode).httpPath,
     `${getMcpBaseUrl().replace(/\/$/u, "")}/`,
   ).toString();
 
@@ -203,6 +162,6 @@ export const getMcpResourceUrls = () =>
 
 export const getMcpProtectedResourceMetadataUrl = (mode: McpMode = "default") =>
   new URL(
-    getMcpModeConfig(mode).discoveryPath,
+    getMcpResourceModeConfig(mode).discoveryPath,
     `${getMcpBaseUrl().replace(/\/$/u, "")}/`,
   ).toString();

--- a/apps/api/src/mcp/resource-policy-contract.test.ts
+++ b/apps/api/src/mcp/resource-policy-contract.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildBetterAuthOAuthResources,
+  normalizeBetterAuthOAuthBaseUrl,
+} from "@/api/mcp/resource-policy-contract";
+
+describe("Better Auth OAuth resource policy contract", () => {
+  test("derives every resource from an explicit origin", () => {
+    expect(
+      buildBetterAuthOAuthResources("https://api.stll.app").map(
+        ({ identifier }) => identifier,
+      ),
+    ).toEqual([
+      "https://api.stll.app/mcp",
+      "https://api.stll.app/mcp-documents",
+      "https://api.stll.app/mcp-anonymized",
+    ]);
+  });
+
+  test("accepts only a credential-free HTTPS origin", () => {
+    expect(normalizeBetterAuthOAuthBaseUrl("https://api.stll.app/")).toBe(
+      "https://api.stll.app",
+    );
+    for (const value of [
+      "http://api.stll.app",
+      "https://user:secret@api.stll.app",
+      "https://api.stll.app/path",
+      "https://api.stll.app?query=1",
+      "https://api.stll.app#fragment",
+      "not-a-url",
+    ]) {
+      expect(normalizeBetterAuthOAuthBaseUrl(value)).toBeNull();
+    }
+  });
+});

--- a/apps/api/src/mcp/resource-policy-contract.ts
+++ b/apps/api/src/mcp/resource-policy-contract.ts
@@ -84,8 +84,7 @@ export const buildBetterAuthOAuthResources = (baseUrl: string) =>
 export const normalizeBetterAuthOAuthBaseUrl = (value: string) => {
   const parsed = URL.parse(value);
   if (
-    parsed === null ||
-    parsed.protocol !== "https:" ||
+    parsed?.protocol !== "https:" ||
     parsed.username !== "" ||
     parsed.password !== "" ||
     parsed.pathname !== "/" ||

--- a/apps/api/src/mcp/resource-policy-contract.ts
+++ b/apps/api/src/mcp/resource-policy-contract.ts
@@ -1,0 +1,98 @@
+import {
+  MCP_ANONYMIZED_HTTP_PATH,
+  MCP_ANONYMIZED_RESOURCE_SCOPES,
+  MCP_DEFAULT_RESOURCE_SCOPES,
+  MCP_DOCUMENTS_HTTP_PATH,
+  MCP_HTTP_PATH,
+} from "@stll/api-contract";
+
+/**
+ * Least-privilege remote-host surface for document workflows. Hosted clients
+ * commonly request every scope in protected-resource metadata, so this
+ * resource advertises only the grants its projected tool registry can use.
+ */
+export const MCP_DOCUMENTS_RESOURCE_SCOPES = [
+  "stella:read",
+  "stella:documents_write",
+  // The canonical presigned-upload lifecycle currently owns one scope across
+  // entity-create and entity-version purposes. The documents MCP audience
+  // restricts invoke_capability to the three lifecycle IDs, so this grant does
+  // not expose unrelated matter mutations through that endpoint.
+  "stella:matters_write",
+] as const;
+
+export const ROOT_MCP_DISCOVERY_PATH =
+  "/.well-known/oauth-protected-resource" as const;
+export const MCP_DISCOVERY_PATH =
+  `/.well-known/oauth-protected-resource${MCP_HTTP_PATH}` as const;
+export const MCP_DOCUMENTS_DISCOVERY_PATH =
+  `/.well-known/oauth-protected-resource${MCP_DOCUMENTS_HTTP_PATH}` as const;
+export const MCP_ANONYMIZED_DISCOVERY_PATH =
+  `/.well-known/oauth-protected-resource${MCP_ANONYMIZED_HTTP_PATH}` as const;
+
+export const MCP_RESOURCE_MODE_CONFIG = {
+  default: {
+    discoveryPath: MCP_DISCOVERY_PATH,
+    httpPath: MCP_HTTP_PATH,
+    resourceName: "Stella MCP",
+    resourceScopes: MCP_DEFAULT_RESOURCE_SCOPES,
+  },
+  documents: {
+    discoveryPath: MCP_DOCUMENTS_DISCOVERY_PATH,
+    httpPath: MCP_DOCUMENTS_HTTP_PATH,
+    resourceName: "Stella MCP documents",
+    resourceScopes: MCP_DOCUMENTS_RESOURCE_SCOPES,
+  },
+  anonymized: {
+    discoveryPath: MCP_ANONYMIZED_DISCOVERY_PATH,
+    httpPath: MCP_ANONYMIZED_HTTP_PATH,
+    resourceName: "Stella MCP anonymized",
+    resourceScopes: MCP_ANONYMIZED_RESOURCE_SCOPES,
+  },
+} as const;
+
+export type McpMode = keyof typeof MCP_RESOURCE_MODE_CONFIG;
+
+export const MCP_MODES = [
+  "default",
+  "documents",
+  "anonymized",
+] as const satisfies readonly McpMode[];
+
+type MissingMcpMode = Exclude<McpMode, (typeof MCP_MODES)[number]>;
+true satisfies MissingMcpMode extends never ? true : never;
+
+export const getMcpResourceModeConfig = (mode: McpMode) =>
+  MCP_RESOURCE_MODE_CONFIG[mode];
+
+export const getMcpResourceScopes = (mode: McpMode) =>
+  getMcpResourceModeConfig(mode).resourceScopes;
+
+export const buildBetterAuthOAuthResources = (baseUrl: string) =>
+  MCP_MODES.map((mode) => {
+    const config = getMcpResourceModeConfig(mode);
+    return {
+      allowedScopes: [...config.resourceScopes],
+      identifier: new URL(
+        config.httpPath,
+        `${baseUrl.replace(/\/$/u, "")}/`,
+      ).toString(),
+      name: config.resourceName,
+    };
+  });
+
+export const normalizeBetterAuthOAuthBaseUrl = (value: string) => {
+  const parsed = URL.parse(value);
+  if (
+    parsed === null ||
+    parsed.protocol !== "https:" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.pathname !== "/" ||
+    parsed.search !== "" ||
+    parsed.hash !== ""
+  ) {
+    return null;
+  }
+  return parsed.origin;
+};

--- a/apps/api/src/scripts/better-auth-17-backfill.db.test.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.db.test.ts
@@ -105,7 +105,9 @@ test("the Better Auth bridge backfill is exact, bounded, and reaches a fixed poi
 
       const first = await runBetterAuth17Backfill(options);
       if (first.status === "error") {
-        throw first.error.cause ?? first.error;
+        throw first.error.cause instanceof Error
+          ? first.error.cause
+          : first.error;
       }
       expect(first).toMatchObject({ status: "ok", value: { changed: true } });
       const second = await runBetterAuth17Backfill(options);

--- a/apps/api/src/scripts/better-auth-17-backfill.db.test.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.db.test.ts
@@ -1,0 +1,216 @@
+import { afterAll, beforeAll, expect, setDefaultTimeout, test } from "bun:test";
+import { eq, sql, TransactionRollbackError } from "drizzle-orm";
+
+import { account, oauthClient, user } from "@/api/db/auth-schema";
+import { runBetterAuth17Backfill } from "@/api/scripts/better-auth-17-backfill.logic";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
+
+let database: TestDatabase;
+
+const TEST_RESOURCES = [
+  {
+    allowedScopes: ["stella:read"],
+    identifier: "https://audit.example.invalid/mcp",
+    name: "Audit MCP",
+  },
+  {
+    allowedScopes: ["stella:anonymous"],
+    identifier: "https://audit.example.invalid/mcp/anonymized",
+    name: "Audit anonymized MCP",
+  },
+] as const;
+
+setDefaultTimeout(120_000);
+
+beforeAll(async () => {
+  database = await getTestDb();
+});
+
+afterAll(async () => {
+  await releaseTestDb();
+});
+
+test("the Better Auth bridge backfill is exact, bounded, and reaches a fixed point", async () => {
+  try {
+    await database.transaction(async (transaction) => {
+      const suffix = Bun.randomUUIDv7();
+      const userId = `backfill-user-${suffix}`;
+      const credentialRowId = `backfill-credential-${suffix}`;
+      const googleRowId = `backfill-google-${suffix}`;
+      const microsoftRowId = `backfill-microsoft-${suffix}`;
+      const microsoftLegacySub = `microsoft-legacy-${suffix}`;
+      const microsoftOid = "71c02436-6600-42fd-84d0-417484a177b0";
+      const microsoftIssuer =
+        "https://login.microsoftonline.com/3a893563-0d4e-4309-9a31-b6e4e9f64479/v2.0";
+      const clientId = `backfill-client-${suffix}`;
+
+      await transaction.insert(user).values({
+        email: `backfill-${suffix}@example.invalid`,
+        id: userId,
+        name: "Backfill fixture",
+      });
+      await transaction.insert(account).values([
+        {
+          accountId: userId,
+          id: credentialRowId,
+          providerId: "credential",
+          userId,
+        },
+        {
+          accountId: `google-sub-${suffix}`,
+          id: googleRowId,
+          providerId: "google",
+          userId,
+        },
+        {
+          accountId: microsoftLegacySub,
+          id: microsoftRowId,
+          providerId: "microsoft",
+          userId,
+        },
+      ]);
+      await transaction.insert(oauthClient).values({
+        clientId,
+        grantTypes: ["client_credentials"],
+        id: `backfill-client-row-${suffix}`,
+        public: false,
+        redirectUris: ["https://client.example.invalid/callback"],
+        scopes: ["openid", "offline_access", "stella:read"],
+        type: "web",
+      });
+
+      const migration = await Bun.file(
+        new URL(
+          "../../drizzle/20260825140000_better_auth_17_additive/migration.sql",
+          import.meta.url,
+        ),
+      ).text();
+      for (const statement of migration.split("--> statement-breakpoint")) {
+        // eslint-disable-next-line no-await-in-loop -- migration order is part of this bridge contract
+        await transaction.execute(sql.raw(statement));
+      }
+
+      const backfillDatabase = {
+        transaction: async <T>(
+          callback: (nested: {
+            execute: typeof transaction.execute;
+          }) => Promise<T>,
+        ) =>
+          await transaction.transaction(
+            async (nested) =>
+              await callback({
+                execute: async (statement) => await nested.execute(statement),
+              }),
+          ),
+      };
+      const options = {
+        batchSize: 1,
+        database: backfillDatabase,
+        expectedOAuthResources: TEST_RESOURCES,
+        trustedIdentityMap: {
+          formatVersion: 1,
+          microsoftAccounts: [
+            {
+              accountId: microsoftOid,
+              accountRowId: microsoftRowId,
+              issuer: microsoftIssuer,
+              legacyAccountId: microsoftLegacySub,
+            },
+          ],
+        },
+      } as const;
+
+      const first = await runBetterAuth17Backfill(options);
+      if (first.status === "error") {
+        throw first.error.cause ?? first.error;
+      }
+      expect(first).toMatchObject({ status: "ok", value: { changed: true } });
+      const second = await runBetterAuth17Backfill(options);
+      expect(second).toMatchObject({
+        status: "ok",
+        value: { changed: false },
+      });
+
+      const identities = await transaction.execute(sql`
+        SELECT id, issuer, account_id AS "accountId"
+          FROM account
+         WHERE id IN (${credentialRowId}, ${googleRowId}, ${microsoftRowId})
+         ORDER BY id
+      `);
+      expect(identities.rows).toEqual([
+        {
+          accountId: userId,
+          id: credentialRowId,
+          issuer: "local:credential",
+        },
+        {
+          accountId: `google-sub-${suffix}`,
+          id: googleRowId,
+          issuer: "https://accounts.google.com",
+        },
+        {
+          accountId: microsoftOid,
+          id: microsoftRowId,
+          issuer: microsoftIssuer,
+        },
+      ]);
+
+      const clientPolicy = await transaction.execute(sql`
+        SELECT application_type AS "applicationType",
+               client_credentials_scopes AS "clientCredentialsScopes",
+               ARRAY(
+                 SELECT resource_id
+                   FROM oauth_client_resource
+                  WHERE client_id = ${clientId}
+                  ORDER BY resource_id
+               ) AS resources
+          FROM oauth_client
+         WHERE client_id = ${clientId}
+      `);
+      expect(clientPolicy.rows).toEqual([
+        {
+          applicationType: "web",
+          clientCredentialsScopes: ["stella:read"],
+          resources: TEST_RESOURCES.map(
+            ({ identifier }) => identifier,
+          ).toSorted(),
+        },
+      ]);
+
+      await transaction
+        .update(account)
+        .set({ accountId: "untrusted-microsoft-subject" })
+        .where(eq(account.id, microsoftRowId));
+      const rollbackResourceIdentifier = `https://audit.example.invalid/mcp/rollback-${suffix}`;
+      expect(
+        await runBetterAuth17Backfill({
+          ...options,
+          expectedOAuthResources: [
+            ...TEST_RESOURCES,
+            {
+              allowedScopes: ["stella:rollback"],
+              identifier: rollbackResourceIdentifier,
+              name: "Rollback proof",
+            },
+          ],
+        }),
+      ).toMatchObject({
+        error: { code: "invalid-source-state" },
+        status: "error",
+      });
+      const rolledBackResources = await transaction.execute(sql`
+        SELECT identifier
+          FROM oauth_resource
+         WHERE identifier = ${rollbackResourceIdentifier}
+      `);
+      expect(rolledBackResources.rows).toEqual([]);
+
+      transaction.rollback();
+    });
+  } catch (error) {
+    if (!(error instanceof TransactionRollbackError)) {
+      throw error;
+    }
+  }
+});

--- a/apps/api/src/scripts/better-auth-17-backfill.db.test.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.db.test.ts
@@ -3,6 +3,7 @@ import { eq, sql, TransactionRollbackError } from "drizzle-orm";
 
 import { account, oauthClient, user } from "@/api/db/auth-schema";
 import { runBetterAuth17Backfill } from "@/api/scripts/better-auth-17-backfill.logic";
+import type { BetterAuthBackfillTransaction } from "@/api/scripts/better-auth-17-backfill.logic";
 import type { TestDatabase } from "@/api/tests/security/test-utils";
 import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
 
@@ -45,31 +46,25 @@ test("the Better Auth bridge backfill is exact, bounded, and reaches a fixed poi
         "https://login.microsoftonline.com/3a893563-0d4e-4309-9a31-b6e4e9f64479/v2.0";
       const clientId = `backfill-client-${suffix}`;
 
+      // The shared test schema represents the final 1.7 state. Relax only the
+      // final constraint inside this rollback-only transaction to recreate the
+      // additive bridge state the backfill consumes.
+      await transaction.execute(sql`
+        ALTER TABLE account ALTER COLUMN issuer DROP NOT NULL
+      `);
+
       await transaction.insert(user).values({
         email: `backfill-${suffix}@example.invalid`,
         id: userId,
         name: "Backfill fixture",
       });
-      await transaction.insert(account).values([
-        {
-          accountId: userId,
-          id: credentialRowId,
-          providerId: "credential",
-          userId,
-        },
-        {
-          accountId: `google-sub-${suffix}`,
-          id: googleRowId,
-          providerId: "google",
-          userId,
-        },
-        {
-          accountId: microsoftLegacySub,
-          id: microsoftRowId,
-          providerId: "microsoft",
-          userId,
-        },
-      ]);
+      await transaction.execute(sql`
+        INSERT INTO account (id, account_id, provider_id, user_id, updated_at)
+        VALUES
+          (${credentialRowId}, ${userId}, 'credential', ${userId}, now()),
+          (${googleRowId}, ${`google-sub-${suffix}`}, 'google', ${userId}, now()),
+          (${microsoftRowId}, ${microsoftLegacySub}, 'microsoft', ${userId}, now())
+      `);
       await transaction.insert(oauthClient).values({
         clientId,
         grantTypes: ["client_credentials"],
@@ -80,22 +75,9 @@ test("the Better Auth bridge backfill is exact, bounded, and reaches a fixed poi
         type: "web",
       });
 
-      const migration = await Bun.file(
-        new URL(
-          "../../drizzle/20260825140000_better_auth_17_additive/migration.sql",
-          import.meta.url,
-        ),
-      ).text();
-      for (const statement of migration.split("--> statement-breakpoint")) {
-        // eslint-disable-next-line no-await-in-loop -- migration order is part of this bridge contract
-        await transaction.execute(sql.raw(statement));
-      }
-
       const backfillDatabase = {
         transaction: async <T>(
-          callback: (nested: {
-            execute: typeof transaction.execute;
-          }) => Promise<T>,
+          callback: (nested: BetterAuthBackfillTransaction) => Promise<T>,
         ) =>
           await transaction.transaction(
             async (nested) =>

--- a/apps/api/src/scripts/better-auth-17-backfill.logic.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.logic.ts
@@ -324,8 +324,9 @@ const backfillAccounts = async (
   );
   let after: string | null = null;
   let changed = false;
-  while (true) {
-    // eslint-disable-next-line no-await-in-loop -- the keyset page is bounded while the outer all-or-nothing transaction retains its write fence
+  const readNextPage = async (): Promise<
+    Result<boolean, BetterAuthBackfillError>
+  > => {
     const page = await backfillAccountPage({
       after,
       batchSize,
@@ -333,23 +334,27 @@ const backfillAccounts = async (
       transaction,
     });
     if (Result.isError(page)) {
-      return page;
+      return Result.err(page.error);
     }
     changed ||= page.value.changed;
     after = page.value.nextAfter;
-    if (page.value.complete) {
-      return Result.ok(changed);
-    }
-  }
+    return page.value.complete ? Result.ok(changed) : readNextPage();
+  };
+  return readNextPage();
 };
 
 const seedOAuthResources = async (
   transaction: BetterAuthBackfillTransaction,
   expectedResources: readonly BetterAuthExpectedOAuthResource[],
 ) => {
-  let changed = false;
-  for (const resource of expectedResources) {
-    // eslint-disable-next-line no-await-in-loop -- resource validation and insert must remain ordered under one write-fenced transaction
+  const seedResource = async (
+    index: number,
+    changed: boolean,
+  ): Promise<Result<boolean, BetterAuthBackfillError>> => {
+    const resource = expectedResources.at(index);
+    if (resource === undefined) {
+      return Result.ok(changed);
+    }
     const existing = await queryRows(
       transaction,
       sql`
@@ -377,9 +382,8 @@ const seedOAuthResources = async (
       ) {
         return invalidSourceState();
       }
-      continue;
+      return seedResource(index + 1, changed);
     }
-    // eslint-disable-next-line no-await-in-loop -- each validated resource is inserted before the next conflict check
     const inserted = await queryRows(
       transaction,
       sql`
@@ -400,9 +404,9 @@ const seedOAuthResources = async (
     if (Result.isError(inserted)) {
       return inserted;
     }
-    changed = true;
-  }
-  return Result.ok(changed);
+    return seedResource(index + 1, true);
+  };
+  return seedResource(0, false);
 };
 
 type OAuthClientBackfillValue = {
@@ -564,8 +568,9 @@ const backfillOAuthClients = async (
 ) => {
   let after: string | null = null;
   let changed = false;
-  while (true) {
-    // eslint-disable-next-line no-await-in-loop -- the keyset page is bounded while the outer all-or-nothing transaction retains its write fence
+  const readNextPage = async (): Promise<
+    Result<boolean, BetterAuthBackfillError>
+  > => {
     const page = await backfillOAuthClientPage({
       after,
       batchSize,
@@ -573,14 +578,13 @@ const backfillOAuthClients = async (
       transaction,
     });
     if (Result.isError(page)) {
-      return page;
+      return Result.err(page.error);
     }
     changed ||= page.value.changed;
     after = page.value.nextAfter;
-    if (page.value.complete) {
-      return Result.ok(changed);
-    }
-  }
+    return page.value.complete ? Result.ok(changed) : readNextPage();
+  };
+  return readNextPage();
 };
 
 type BetterAuthBackfillTransactionOptions = Omit<

--- a/apps/api/src/scripts/better-auth-17-backfill.logic.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.logic.ts
@@ -1,0 +1,657 @@
+import { Result, TaggedError } from "better-result";
+import { sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+
+import { isRecord } from "@/api/lib/type-guards";
+import type {
+  BetterAuthExpectedOAuthResource,
+  BetterAuthTrustedIdentityMap,
+} from "@/api/scripts/better-auth-migration-audit.logic";
+
+const PROVIDER_ID = {
+  CREDENTIAL: "credential",
+  GOOGLE: "google",
+  MICROSOFT: "microsoft",
+} as const;
+
+const ISSUER = {
+  CREDENTIAL: "local:credential",
+  GOOGLE: "https://accounts.google.com",
+} as const;
+
+const APPLICATION_TYPES = new Set(["native", "web"]);
+const OAUTH_PROTOCOL_SCOPES = new Set([
+  "email",
+  "offline_access",
+  "openid",
+  "profile",
+]);
+
+export class BetterAuthBackfillError extends TaggedError(
+  "BetterAuthBackfillError",
+)<{
+  cause?: unknown;
+  code: "database-query-failed" | "invalid-source-state";
+  message: string;
+}> {}
+
+export type BetterAuthBackfillDatabase = {
+  transaction: <T>(
+    callback: (transaction: BetterAuthBackfillTransaction) => Promise<T>,
+  ) => Promise<T>;
+};
+
+export type BetterAuthBackfillTransaction = {
+  execute: (statement: SQL) => Promise<unknown>;
+};
+
+type BetterAuthBackfillOptions = {
+  batchSize: number;
+  database: BetterAuthBackfillDatabase;
+  expectedOAuthResources: readonly BetterAuthExpectedOAuthResource[];
+  trustedIdentityMap: BetterAuthTrustedIdentityMap;
+};
+
+export type BetterAuthBackfillResult = {
+  changed: boolean;
+};
+
+const queryRows = async (
+  transaction: BetterAuthBackfillTransaction,
+  statement: SQL,
+) => {
+  const queried = await Result.tryPromise({
+    try: async () => await transaction.execute(statement),
+    catch: (cause) =>
+      new BetterAuthBackfillError({
+        cause,
+        code: "database-query-failed",
+        message: "Better Auth backfill database query failed",
+      }),
+  });
+  if (Result.isError(queried)) {
+    return queried;
+  }
+  if (Array.isArray(queried.value)) {
+    return Result.ok(queried.value);
+  }
+  if (isRecord(queried.value) && Array.isArray(queried.value["rows"])) {
+    return Result.ok(queried.value["rows"]);
+  }
+  return Result.err(
+    new BetterAuthBackfillError({
+      code: "database-query-failed",
+      message: "Better Auth backfill database returned an invalid result",
+    }),
+  );
+};
+
+const requiredString = (value: unknown): string | null =>
+  typeof value === "string" ? value : null;
+
+const optionalStringArray = (value: unknown): readonly string[] | null => {
+  if (value === null) {
+    return [];
+  }
+  return Array.isArray(value) &&
+    value.every((entry) => typeof entry === "string")
+    ? value
+    : null;
+};
+
+const nullableString = (value: unknown): string | null | undefined => {
+  if (value === null) {
+    return null;
+  }
+  return typeof value === "string" ? value : undefined;
+};
+
+const invalidSourceState = () =>
+  Result.err(
+    new BetterAuthBackfillError({
+      code: "invalid-source-state",
+      message: "Better Auth backfill source state is not trusted",
+    }),
+  );
+
+const runBackfillTransaction = async <T>(
+  database: BetterAuthBackfillDatabase,
+  operation: (
+    transaction: BetterAuthBackfillTransaction,
+  ) => Promise<Result<T, BetterAuthBackfillError>>,
+): Promise<Result<T, BetterAuthBackfillError>> =>
+  await Result.tryPromise({
+    try: async () =>
+      await database.transaction(async (transaction) => {
+        const result = await operation(transaction);
+        if (Result.isError(result)) {
+          throw result.error;
+        }
+        return result.value;
+      }),
+    catch: (cause) =>
+      cause instanceof BetterAuthBackfillError
+        ? cause
+        : new BetterAuthBackfillError({
+            cause,
+            code: "database-query-failed",
+            message: "Better Auth backfill transaction failed",
+          }),
+  });
+
+/**
+ * Fence every table whose identity or OAuth policy this command mutates.
+ * SHARE ROW EXCLUSIVE still permits reads, but conflicts with ordinary DML
+ * and with another backfill. The private cutover also scales application
+ * writers to zero; this lock makes a missed or delayed writer fail the short
+ * lock timeout instead of racing a partially migrated identity.
+ */
+export const lockBetterAuth17BackfillTables = async (
+  transaction: BetterAuthBackfillTransaction,
+) =>
+  await queryRows(
+    transaction,
+    sql`
+      LOCK TABLE account,
+                 oauth_client,
+                 oauth_client_resource,
+                 oauth_resource
+        IN SHARE ROW EXCLUSIVE MODE
+    `,
+  );
+
+const deterministicId = (type: "link" | "resource", values: string[]) => {
+  const hasher = new Bun.CryptoHasher("sha256");
+  for (const value of values) {
+    hasher.update(value);
+    hasher.update("\0");
+  }
+  return `better-auth-${type}-${hasher.digest("hex")}`;
+};
+
+type AccountBackfillValue = {
+  accountId: string;
+  accountRowId: string;
+  issuer: string;
+};
+
+const backfillAccountPage = async ({
+  after,
+  batchSize,
+  microsoftByRowId,
+  transaction,
+}: {
+  after: string | null;
+  batchSize: number;
+  microsoftByRowId: ReadonlyMap<
+    string,
+    BetterAuthTrustedIdentityMap["microsoftAccounts"][number]
+  >;
+  transaction: BetterAuthBackfillTransaction;
+}) => {
+  const selected = await queryRows(
+    transaction,
+    after === null
+      ? sql`
+          SELECT id AS "accountRowId",
+                 account_id AS "accountId",
+                 provider_id AS "providerId",
+                 user_id AS "userId",
+                 issuer
+            FROM account
+           ORDER BY id
+           LIMIT ${batchSize}
+           FOR UPDATE
+        `
+      : sql`
+          SELECT id AS "accountRowId",
+                 account_id AS "accountId",
+                 provider_id AS "providerId",
+                 user_id AS "userId",
+                 issuer
+            FROM account
+           WHERE id > ${after}
+           ORDER BY id
+           LIMIT ${batchSize}
+           FOR UPDATE
+        `,
+  );
+  if (Result.isError(selected)) {
+    return selected;
+  }
+
+  const updates: AccountBackfillValue[] = [];
+  let nextAfter: string | null = after;
+  for (const row of selected.value) {
+    const accountRowId = isRecord(row)
+      ? requiredString(row["accountRowId"])
+      : null;
+    const currentAccountId = isRecord(row)
+      ? requiredString(row["accountId"])
+      : null;
+    const providerId = isRecord(row) ? requiredString(row["providerId"]) : null;
+    const userId = isRecord(row) ? requiredString(row["userId"]) : null;
+    const currentIssuer = isRecord(row)
+      ? nullableString(row["issuer"])
+      : undefined;
+    if (
+      accountRowId === null ||
+      currentAccountId === null ||
+      providerId === null ||
+      userId === null ||
+      currentIssuer === undefined
+    ) {
+      return invalidSourceState();
+    }
+
+    let accountId = currentAccountId;
+    let issuer: string;
+    switch (providerId) {
+      case PROVIDER_ID.CREDENTIAL:
+        if (currentAccountId !== userId) {
+          return invalidSourceState();
+        }
+        issuer = ISSUER.CREDENTIAL;
+        break;
+      case PROVIDER_ID.GOOGLE:
+        issuer = ISSUER.GOOGLE;
+        break;
+      case PROVIDER_ID.MICROSOFT: {
+        const mapping = microsoftByRowId.get(accountRowId);
+        if (
+          mapping === undefined ||
+          !(
+            (currentAccountId === mapping.legacyAccountId &&
+              currentIssuer === null) ||
+            (currentAccountId === mapping.accountId &&
+              currentIssuer === mapping.issuer)
+          )
+        ) {
+          return invalidSourceState();
+        }
+        accountId = mapping.accountId;
+        issuer = mapping.issuer;
+        break;
+      }
+      default:
+        return invalidSourceState();
+    }
+    updates.push({ accountId, accountRowId, issuer });
+    nextAfter = accountRowId;
+  }
+
+  if (updates.length === 0) {
+    return Result.ok({ changed: false, complete: true, nextAfter });
+  }
+  const updated = await queryRows(
+    transaction,
+    sql`
+      WITH input AS (
+        SELECT *
+          FROM jsonb_to_recordset(${JSON.stringify(updates)}::text::jsonb)
+            AS row_value("accountId" text, "accountRowId" text, issuer text)
+      )
+      UPDATE account target
+         SET account_id = input."accountId",
+             issuer = input.issuer
+        FROM input
+       WHERE target.id = input."accountRowId"
+         AND (target.account_id, target.issuer)
+             IS DISTINCT FROM (input."accountId", input.issuer)
+      RETURNING target.id
+    `,
+  );
+  if (Result.isError(updated)) {
+    return updated;
+  }
+  return Result.ok({
+    changed: updated.value.length > 0,
+    complete: selected.value.length < batchSize,
+    nextAfter,
+  });
+};
+
+const backfillAccounts = async (
+  transaction: BetterAuthBackfillTransaction,
+  batchSize: number,
+  trustedIdentityMap: BetterAuthTrustedIdentityMap,
+) => {
+  const microsoftByRowId = new Map(
+    trustedIdentityMap.microsoftAccounts.map((mapping) => [
+      mapping.accountRowId,
+      mapping,
+    ]),
+  );
+  let after: string | null = null;
+  let changed = false;
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop -- the keyset page is bounded while the outer all-or-nothing transaction retains its write fence
+    const page = await backfillAccountPage({
+      after,
+      batchSize,
+      microsoftByRowId,
+      transaction,
+    });
+    if (Result.isError(page)) {
+      return page;
+    }
+    changed ||= page.value.changed;
+    after = page.value.nextAfter;
+    if (page.value.complete) {
+      return Result.ok(changed);
+    }
+  }
+};
+
+const seedOAuthResources = async (
+  transaction: BetterAuthBackfillTransaction,
+  expectedResources: readonly BetterAuthExpectedOAuthResource[],
+) => {
+  let changed = false;
+  for (const resource of expectedResources) {
+    // eslint-disable-next-line no-await-in-loop -- resource validation and insert must remain ordered under one write-fenced transaction
+    const existing = await queryRows(
+      transaction,
+      sql`
+          SELECT name, allowed_scopes AS "allowedScopes"
+            FROM oauth_resource
+           WHERE identifier = ${resource.identifier}
+           FOR UPDATE
+        `,
+    );
+    if (Result.isError(existing)) {
+      return existing;
+    }
+    const expectedScopes = [...resource.allowedScopes].toSorted();
+    const row = existing.value.at(0);
+    if (row !== undefined) {
+      const name = isRecord(row) ? requiredString(row["name"]) : null;
+      const allowedScopes = isRecord(row)
+        ? optionalStringArray(row["allowedScopes"])
+        : null;
+      if (
+        name !== resource.name ||
+        allowedScopes === null ||
+        JSON.stringify([...allowedScopes].toSorted()) !==
+          JSON.stringify(expectedScopes)
+      ) {
+        return invalidSourceState();
+      }
+      continue;
+    }
+    // eslint-disable-next-line no-await-in-loop -- each validated resource is inserted before the next conflict check
+    const inserted = await queryRows(
+      transaction,
+      sql`
+          INSERT INTO oauth_resource (id, identifier, name, allowed_scopes)
+          VALUES (
+            ${deterministicId("resource", [resource.identifier])},
+            ${resource.identifier},
+            ${resource.name},
+            ARRAY(
+              SELECT jsonb_array_elements_text(
+                ${JSON.stringify(expectedScopes)}::text::jsonb
+              )
+            )
+          )
+          RETURNING id
+        `,
+    );
+    if (Result.isError(inserted)) {
+      return inserted;
+    }
+    changed = true;
+  }
+  return Result.ok(changed);
+};
+
+type OAuthClientBackfillValue = {
+  applicationType: string;
+  clientCredentialsScopes: readonly string[];
+  clientId: string;
+};
+
+const backfillOAuthClientPage = async ({
+  after,
+  batchSize,
+  expectedResources,
+  transaction,
+}: {
+  after: string | null;
+  batchSize: number;
+  expectedResources: readonly BetterAuthExpectedOAuthResource[];
+  transaction: BetterAuthBackfillTransaction;
+}) => {
+  const selected = await queryRows(
+    transaction,
+    after === null
+      ? sql`
+            SELECT client_id AS "clientId",
+                   type AS "applicationType",
+                   scopes,
+                   grant_types AS "grantTypes"
+              FROM oauth_client
+             ORDER BY client_id
+             LIMIT ${batchSize}
+             FOR UPDATE
+          `
+      : sql`
+            SELECT client_id AS "clientId",
+                   type AS "applicationType",
+                   scopes,
+                   grant_types AS "grantTypes"
+              FROM oauth_client
+             WHERE client_id > ${after}
+             ORDER BY client_id
+             LIMIT ${batchSize}
+             FOR UPDATE
+          `,
+  );
+  if (Result.isError(selected)) {
+    return selected;
+  }
+  const clients: OAuthClientBackfillValue[] = [];
+  let nextAfter = after;
+  for (const row of selected.value) {
+    const clientId = isRecord(row) ? requiredString(row["clientId"]) : null;
+    const applicationType = isRecord(row)
+      ? requiredString(row["applicationType"])
+      : null;
+    const scopes = isRecord(row) ? optionalStringArray(row["scopes"]) : null;
+    const grantTypes = isRecord(row)
+      ? optionalStringArray(row["grantTypes"])
+      : null;
+    if (
+      clientId === null ||
+      applicationType === null ||
+      !APPLICATION_TYPES.has(applicationType) ||
+      scopes === null ||
+      grantTypes === null
+    ) {
+      return invalidSourceState();
+    }
+    clients.push({
+      applicationType,
+      clientCredentialsScopes: grantTypes.includes("client_credentials")
+        ? [...new Set(scopes)]
+            .filter((scope) => !OAUTH_PROTOCOL_SCOPES.has(scope))
+            .toSorted()
+        : [],
+      clientId,
+    });
+    nextAfter = clientId;
+  }
+  if (clients.length === 0) {
+    return Result.ok({ changed: false, complete: true, nextAfter });
+  }
+
+  const updated = await queryRows(
+    transaction,
+    sql`
+        WITH input AS (
+          SELECT *
+            FROM jsonb_to_recordset(${JSON.stringify(clients)}::text::jsonb)
+              AS row_value(
+                "applicationType" text,
+                "clientCredentialsScopes" jsonb,
+                "clientId" text
+              )
+        )
+        UPDATE oauth_client target
+           SET application_type = input."applicationType",
+               client_credentials_scopes = ARRAY(
+                 SELECT jsonb_array_elements_text(
+                   input."clientCredentialsScopes"
+                 )
+               )
+          FROM input
+         WHERE target.client_id = input."clientId"
+           AND (target.application_type, target.client_credentials_scopes)
+               IS DISTINCT FROM (
+                 input."applicationType",
+                 ARRAY(
+                   SELECT jsonb_array_elements_text(
+                     input."clientCredentialsScopes"
+                   )
+                 )
+               )
+        RETURNING target.client_id
+      `,
+  );
+  if (Result.isError(updated)) {
+    return updated;
+  }
+  let changed = updated.value.length > 0;
+  const links = clients.flatMap(({ clientId }) =>
+    expectedResources.map(({ identifier }) => ({
+      clientId,
+      id: deterministicId("link", [clientId, identifier]),
+      resourceId: identifier,
+    })),
+  );
+  if (links.length > 0) {
+    const inserted = await queryRows(
+      transaction,
+      sql`
+          WITH input AS (
+            SELECT *
+              FROM jsonb_to_recordset(${JSON.stringify(links)}::text::jsonb)
+                AS row_value("clientId" text, id text, "resourceId" text)
+          )
+          INSERT INTO oauth_client_resource (id, client_id, resource_id)
+          SELECT id, "clientId", "resourceId"
+            FROM input
+          ON CONFLICT (client_id, resource_id) DO NOTHING
+          RETURNING id
+        `,
+    );
+    if (Result.isError(inserted)) {
+      return inserted;
+    }
+    changed ||= inserted.value.length > 0;
+  }
+  return Result.ok({
+    changed,
+    complete: selected.value.length < batchSize,
+    nextAfter,
+  });
+};
+
+const backfillOAuthClients = async (
+  transaction: BetterAuthBackfillTransaction,
+  batchSize: number,
+  expectedResources: readonly BetterAuthExpectedOAuthResource[],
+) => {
+  let after: string | null = null;
+  let changed = false;
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop -- the keyset page is bounded while the outer all-or-nothing transaction retains its write fence
+    const page = await backfillOAuthClientPage({
+      after,
+      batchSize,
+      expectedResources,
+      transaction,
+    });
+    if (Result.isError(page)) {
+      return page;
+    }
+    changed ||= page.value.changed;
+    after = page.value.nextAfter;
+    if (page.value.complete) {
+      return Result.ok(changed);
+    }
+  }
+};
+
+type BetterAuthBackfillTransactionOptions = Omit<
+  BetterAuthBackfillOptions,
+  "database"
+> & {
+  transaction: BetterAuthBackfillTransaction;
+};
+
+export const runBetterAuth17BackfillInTransaction = async ({
+  batchSize,
+  expectedOAuthResources,
+  transaction,
+  trustedIdentityMap,
+}: BetterAuthBackfillTransactionOptions): Promise<
+  Result<BetterAuthBackfillResult, BetterAuthBackfillError>
+> => {
+  const resources = await seedOAuthResources(
+    transaction,
+    expectedOAuthResources,
+  );
+  if (Result.isError(resources)) {
+    return resources;
+  }
+  const accounts = await backfillAccounts(
+    transaction,
+    batchSize,
+    trustedIdentityMap,
+  );
+  if (Result.isError(accounts)) {
+    return accounts;
+  }
+  const clients = await backfillOAuthClients(
+    transaction,
+    batchSize,
+    expectedOAuthResources,
+  );
+  if (Result.isError(clients)) {
+    return clients;
+  }
+  return Result.ok({
+    changed: resources.value || accounts.value || clients.value,
+  });
+};
+
+export const runBetterAuth17Backfill = async ({
+  batchSize,
+  database,
+  expectedOAuthResources,
+  trustedIdentityMap,
+}: BetterAuthBackfillOptions): Promise<
+  Result<BetterAuthBackfillResult, BetterAuthBackfillError>
+> => {
+  if (
+    !Number.isSafeInteger(batchSize) ||
+    batchSize < 1 ||
+    batchSize > 1000 ||
+    expectedOAuthResources.length === 0
+  ) {
+    return invalidSourceState();
+  }
+  return await runBackfillTransaction(database, async (transaction) => {
+    const locked = await lockBetterAuth17BackfillTables(transaction);
+    if (Result.isError(locked)) {
+      return locked;
+    }
+    return await runBetterAuth17BackfillInTransaction({
+      batchSize,
+      expectedOAuthResources,
+      transaction,
+      trustedIdentityMap,
+    });
+  });
+};

--- a/apps/api/src/scripts/better-auth-17-backfill.logic.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.logic.ts
@@ -645,7 +645,7 @@ export const runBetterAuth17Backfill = async ({
   return await runBackfillTransaction(database, async (transaction) => {
     const locked = await lockBetterAuth17BackfillTables(transaction);
     if (Result.isError(locked)) {
-      return locked;
+      return Result.err(locked.error);
     }
     return await runBetterAuth17BackfillInTransaction({
       batchSize,

--- a/apps/api/src/scripts/better-auth-17-backfill.test.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.test.ts
@@ -11,6 +11,8 @@ test("the Better Auth backfill requires private evidence, a bound, and an explic
       "/private/identity-map.json",
       "--batch-size",
       "500",
+      "--oauth-base-url",
+      "https://api.stll.app/",
       "--writes-frozen",
     ]),
   ).toMatchObject({
@@ -19,6 +21,7 @@ test("the Better Auth backfill requires private evidence, a bound, and an explic
       baselinePath: "/private/baseline.json",
       batchSize: 500,
       identityMapPath: "/private/identity-map.json",
+      oauthBaseUrl: "https://api.stll.app",
     },
   });
 
@@ -31,6 +34,8 @@ test("the Better Auth backfill requires private evidence, a bound, and an explic
       "map",
       "--batch-size",
       "0",
+      "--oauth-base-url",
+      "https://api.stll.app",
       "--writes-frozen",
     ],
     [
@@ -40,9 +45,22 @@ test("the Better Auth backfill requires private evidence, a bound, and an explic
       "map",
       "--batch-size",
       "1001",
+      "--oauth-base-url",
+      "https://api.stll.app",
       "--writes-frozen",
     ],
     ["--baseline", "baseline", "--identity-map", "map", "--batch-size", "500"],
+    [
+      "--baseline",
+      "baseline",
+      "--identity-map",
+      "map",
+      "--batch-size",
+      "500",
+      "--oauth-base-url",
+      "https://api.stll.app/path",
+      "--writes-frozen",
+    ],
   ]) {
     expect(parseBetterAuthBackfillArgs(args).status).toBe("error");
   }

--- a/apps/api/src/scripts/better-auth-17-backfill.test.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+
+import { parseBetterAuthBackfillArgs } from "@/api/scripts/better-auth-17-backfill";
+
+test("the Better Auth backfill requires private evidence, a bound, and an explicit write freeze", () => {
+  expect(
+    parseBetterAuthBackfillArgs([
+      "--baseline",
+      "/private/baseline.json",
+      "--identity-map",
+      "/private/identity-map.json",
+      "--batch-size",
+      "500",
+      "--writes-frozen",
+    ]),
+  ).toMatchObject({
+    status: "ok",
+    value: {
+      baselinePath: "/private/baseline.json",
+      batchSize: 500,
+      identityMapPath: "/private/identity-map.json",
+    },
+  });
+
+  for (const args of [
+    [],
+    [
+      "--baseline",
+      "baseline",
+      "--identity-map",
+      "map",
+      "--batch-size",
+      "0",
+      "--writes-frozen",
+    ],
+    [
+      "--baseline",
+      "baseline",
+      "--identity-map",
+      "map",
+      "--batch-size",
+      "1001",
+      "--writes-frozen",
+    ],
+    ["--baseline", "baseline", "--identity-map", "map", "--batch-size", "500"],
+  ]) {
+    expect(parseBetterAuthBackfillArgs(args).status).toBe("error");
+  }
+});

--- a/apps/api/src/scripts/better-auth-17-backfill.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.ts
@@ -1,6 +1,6 @@
 /**
  * Usage:
- *   bun src/scripts/better-auth-17-backfill.ts --baseline <path> --identity-map <path> --batch-size <1..1000> --writes-frozen
+ *   bun src/scripts/better-auth-17-backfill.ts --baseline <path> --identity-map <path> --batch-size <1..1000> --oauth-base-url <https-origin> --writes-frozen
  *
  * The command refuses to mutate until the private baseline is reproduced
  * exactly from the same trusted Microsoft map and public OAuth resource policy.
@@ -14,12 +14,20 @@ import { drizzle } from "drizzle-orm/bun-sql";
 
 import { hasSecureDatabaseTransport, resolveDatabaseUrl } from "@/api/db-url";
 import {
+  buildBetterAuthOAuthResources,
+  normalizeBetterAuthOAuthBaseUrl,
+} from "@/api/mcp/resource-policy-contract";
+import {
   BetterAuthBackfillError,
   lockBetterAuth17BackfillTables,
   runBetterAuth17BackfillInTransaction,
 } from "@/api/scripts/better-auth-17-backfill.logic";
-import type { BetterAuthBackfillTransaction } from "@/api/scripts/better-auth-17-backfill.logic";
+import type {
+  BetterAuthBackfillResult,
+  BetterAuthBackfillTransaction,
+} from "@/api/scripts/better-auth-17-backfill.logic";
 import {
+  type BetterAuthAuditCommandError,
   readBetterAuthAuditBaseline,
   readBetterAuthTrustedIdentityMap,
 } from "@/api/scripts/better-auth-migration-audit";
@@ -55,36 +63,52 @@ type BetterAuthBackfillCommandArgs = {
   baselinePath: string;
   batchSize: number;
   identityMapPath: string;
+  oauthBaseUrl: string;
 };
 
 export const parseBetterAuthBackfillArgs = (
   args: readonly string[],
 ): Result<BetterAuthBackfillCommandArgs, BetterAuthBackfillCommandError> => {
+  const baselinePath = args.at(1);
+  const identityMapPath = args.at(3);
   const batchSize = Number(args.at(5));
+  const oauthBaseUrl = args.at(7);
   if (
     args.at(0) !== "--baseline" ||
-    !args.at(1) ||
+    !baselinePath ||
     args.at(2) !== "--identity-map" ||
-    !args.at(3) ||
+    !identityMapPath ||
     args.at(4) !== "--batch-size" ||
     !Number.isSafeInteger(batchSize) ||
     batchSize < 1 ||
     batchSize > 1000 ||
-    args.at(6) !== "--writes-frozen" ||
-    args.length !== 7
+    args.at(6) !== "--oauth-base-url" ||
+    !oauthBaseUrl ||
+    args.at(8) !== "--writes-frozen" ||
+    args.length !== 9
   ) {
     return Result.err(
       new BetterAuthBackfillCommandError({
         code: "invalid-arguments",
         message:
-          "Usage: better-auth-17-backfill --baseline <private-path> --identity-map <private-path> --batch-size <1..1000> --writes-frozen",
+          "Usage: better-auth-17-backfill --baseline <private-path> --identity-map <private-path> --batch-size <1..1000> --oauth-base-url <https-url> --writes-frozen",
+      }),
+    );
+  }
+  const normalizedOAuthBaseUrl = normalizeBetterAuthOAuthBaseUrl(oauthBaseUrl);
+  if (normalizedOAuthBaseUrl === null) {
+    return Result.err(
+      new BetterAuthBackfillCommandError({
+        code: "invalid-arguments",
+        message: "Better Auth backfill OAuth base URL is invalid",
       }),
     );
   }
   return Result.ok({
-    baselinePath: args[1],
+    baselinePath,
     batchSize,
-    identityMapPath: args[3],
+    identityMapPath,
+    oauthBaseUrl: normalizedOAuthBaseUrl,
   });
 };
 
@@ -233,7 +257,15 @@ const executeBackfill = async ({
   return Result.ok(executed.value.backfilled);
 };
 
-const run = async (args: readonly string[]) => {
+type BetterAuthBackfillRunError =
+  | BetterAuthAuditCommandError
+  | BetterAuthAuditError
+  | BetterAuthBackfillCommandError
+  | BetterAuthBackfillError;
+
+const run = async (
+  args: readonly string[],
+): Promise<Result<BetterAuthBackfillResult, BetterAuthBackfillRunError>> => {
   const parsed = parseBetterAuthBackfillArgs(args);
   if (Result.isError(parsed)) {
     return parsed;
@@ -257,14 +289,14 @@ const run = async (args: readonly string[]) => {
       }),
     );
   }
-  const { getBetterAuthOAuthResources } =
-    await import("@/api/lib/oauth-resource-policy");
   const client = new SQL({ max: 1, url: databaseUrl });
   const result = await executeBackfill({
     baseline: baseline.value,
     batchSize: parsed.value.batchSize,
     client,
-    expectedOAuthResources: getBetterAuthOAuthResources(),
+    expectedOAuthResources: buildBetterAuthOAuthResources(
+      parsed.value.oauthBaseUrl,
+    ),
     trustedIdentityMap: trustedIdentityMap.value,
   });
   await client.end();

--- a/apps/api/src/scripts/better-auth-17-backfill.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.ts
@@ -1,0 +1,301 @@
+/**
+ * Usage:
+ *   bun src/scripts/better-auth-17-backfill.ts --baseline <path> --identity-map <path> --batch-size <1..1000> --writes-frozen
+ *
+ * The command refuses to mutate until the private baseline is reproduced
+ * exactly from the same trusted Microsoft map and public OAuth resource policy.
+ * It emits only named audit checks and a coarse changed/fixed-point result.
+ */
+
+import { Result, TaggedError } from "better-result";
+import { SQL } from "bun";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sql";
+
+import { hasSecureDatabaseTransport, resolveDatabaseUrl } from "@/api/db-url";
+import {
+  BetterAuthBackfillError,
+  lockBetterAuth17BackfillTables,
+  runBetterAuth17BackfillInTransaction,
+} from "@/api/scripts/better-auth-17-backfill.logic";
+import type { BetterAuthBackfillTransaction } from "@/api/scripts/better-auth-17-backfill.logic";
+import {
+  readBetterAuthAuditBaseline,
+  readBetterAuthTrustedIdentityMap,
+} from "@/api/scripts/better-auth-migration-audit";
+import {
+  BETTER_AUTH_AUDIT_MODES,
+  BetterAuthAuditError,
+  renderBetterAuthAuditReport,
+  runBetterAuthMigrationAudit,
+} from "@/api/scripts/better-auth-migration-audit.logic";
+import type {
+  BetterAuthAuditBaseline,
+  BetterAuthExpectedOAuthResource,
+  BetterAuthTrustedIdentityMap,
+} from "@/api/scripts/better-auth-migration-audit.logic";
+
+const EXIT_CODE = {
+  CONFIGURATION_OR_QUERY_FAILURE: 2,
+  INVARIANT_FAILURE: 1,
+  SUCCESS: 0,
+} as const;
+
+const TRANSACTION_TIMEOUT = "5min";
+const LOCK_TIMEOUT = "2s";
+
+class BetterAuthBackfillCommandError extends TaggedError(
+  "BetterAuthBackfillCommandError",
+)<{
+  code: "invalid-arguments" | "preflight-mismatch";
+  message: string;
+}> {}
+
+type BetterAuthBackfillCommandArgs = {
+  baselinePath: string;
+  batchSize: number;
+  identityMapPath: string;
+};
+
+export const parseBetterAuthBackfillArgs = (
+  args: readonly string[],
+): Result<BetterAuthBackfillCommandArgs, BetterAuthBackfillCommandError> => {
+  const batchSize = Number(args.at(5));
+  if (
+    args.at(0) !== "--baseline" ||
+    !args.at(1) ||
+    args.at(2) !== "--identity-map" ||
+    !args.at(3) ||
+    args.at(4) !== "--batch-size" ||
+    !Number.isSafeInteger(batchSize) ||
+    batchSize < 1 ||
+    batchSize > 1000 ||
+    args.at(6) !== "--writes-frozen" ||
+    args.length !== 7
+  ) {
+    return Result.err(
+      new BetterAuthBackfillCommandError({
+        code: "invalid-arguments",
+        message:
+          "Usage: better-auth-17-backfill --baseline <private-path> --identity-map <private-path> --batch-size <1..1000> --writes-frozen",
+      }),
+    );
+  }
+  return Result.ok({
+    baselinePath: args[1],
+    batchSize,
+    identityMapPath: args[3],
+  });
+};
+
+const runAuditInTransaction = async ({
+  baseline,
+  expectedOAuthResources,
+  mode,
+  transaction,
+  trustedIdentityMap,
+}: {
+  baseline: BetterAuthAuditBaseline | null;
+  expectedOAuthResources: readonly BetterAuthExpectedOAuthResource[];
+  mode:
+    | typeof BETTER_AUTH_AUDIT_MODES.POST_BACKFILL
+    | typeof BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION;
+  transaction: BetterAuthBackfillTransaction;
+  trustedIdentityMap: BetterAuthTrustedIdentityMap | null;
+}) =>
+  await runBetterAuthMigrationAudit({
+    baseline,
+    database: {
+      execute: async (statement) => await transaction.execute(statement),
+    },
+    expectedOAuthResources,
+    mode,
+    trustedIdentityMap,
+  });
+
+const sameBaseline = (
+  expected: BetterAuthAuditBaseline,
+  actual: BetterAuthAuditBaseline,
+) => JSON.stringify(expected) === JSON.stringify(actual);
+
+const executeBackfill = async ({
+  baseline,
+  batchSize,
+  client,
+  expectedOAuthResources,
+  trustedIdentityMap,
+}: {
+  baseline: BetterAuthAuditBaseline;
+  batchSize: number;
+  client: SQL;
+  expectedOAuthResources: readonly BetterAuthExpectedOAuthResource[];
+  trustedIdentityMap: BetterAuthTrustedIdentityMap;
+}) => {
+  const database = drizzle({ client });
+  const executed = await Result.tryPromise({
+    try: async () =>
+      await database.transaction(async (transaction) => {
+        await transaction.execute(
+          sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ`,
+        );
+        await transaction.execute(
+          sql`SELECT set_config('statement_timeout', ${TRANSACTION_TIMEOUT}, true)`,
+        );
+        await transaction.execute(
+          sql`SELECT set_config('lock_timeout', ${LOCK_TIMEOUT}, true)`,
+        );
+        const backfillTransaction: BetterAuthBackfillTransaction = {
+          execute: async (statement) => await transaction.execute(statement),
+        };
+        const locked =
+          await lockBetterAuth17BackfillTables(backfillTransaction);
+        if (Result.isError(locked)) {
+          throw locked.error;
+        }
+
+        const preflight = await runAuditInTransaction({
+          baseline: null,
+          expectedOAuthResources,
+          mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+          transaction: backfillTransaction,
+          trustedIdentityMap,
+        });
+        if (Result.isError(preflight)) {
+          throw preflight.error;
+        }
+        if (
+          preflight.value.report.status !== "passed" ||
+          !sameBaseline(baseline, preflight.value.baseline)
+        ) {
+          throw new BetterAuthBackfillCommandError({
+            code: "preflight-mismatch",
+            message:
+              "Better Auth backfill preflight does not match its baseline",
+          });
+        }
+
+        const backfilled = await runBetterAuth17BackfillInTransaction({
+          batchSize,
+          expectedOAuthResources,
+          transaction: backfillTransaction,
+          trustedIdentityMap,
+        });
+        if (Result.isError(backfilled)) {
+          throw backfilled.error;
+        }
+
+        const postBackfill = await runAuditInTransaction({
+          baseline,
+          expectedOAuthResources,
+          mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+          transaction: backfillTransaction,
+          trustedIdentityMap: null,
+        });
+        if (Result.isError(postBackfill)) {
+          throw postBackfill.error;
+        }
+        if (postBackfill.value.report.status !== "passed") {
+          throw new BetterAuthBackfillCommandError({
+            code: "preflight-mismatch",
+            message: "Better Auth post-backfill audit failed",
+          });
+        }
+        return {
+          backfilled: backfilled.value,
+          postBackfillReport: postBackfill.value.report,
+          preflightReport: preflight.value.report,
+        };
+      }),
+    catch: (cause) => {
+      if (
+        cause instanceof BetterAuthAuditError ||
+        cause instanceof BetterAuthBackfillError ||
+        cause instanceof BetterAuthBackfillCommandError
+      ) {
+        return cause;
+      }
+      return new BetterAuthBackfillError({
+        cause,
+        code: "database-query-failed",
+        message: "Better Auth backfill transaction failed",
+      });
+    },
+  });
+  if (Result.isError(executed)) {
+    return executed;
+  }
+  process.stdout.write(
+    renderBetterAuthAuditReport(executed.value.preflightReport),
+  );
+  process.stdout.write(
+    renderBetterAuthAuditReport(executed.value.postBackfillReport),
+  );
+  return Result.ok(executed.value.backfilled);
+};
+
+const run = async (args: readonly string[]) => {
+  const parsed = parseBetterAuthBackfillArgs(args);
+  if (Result.isError(parsed)) {
+    return parsed;
+  }
+  const [baseline, trustedIdentityMap] = await Promise.all([
+    readBetterAuthAuditBaseline(parsed.value.baselinePath),
+    readBetterAuthTrustedIdentityMap(parsed.value.identityMapPath),
+  ]);
+  if (Result.isError(baseline)) {
+    return baseline;
+  }
+  if (Result.isError(trustedIdentityMap)) {
+    return trustedIdentityMap;
+  }
+  const databaseUrl = resolveDatabaseUrl();
+  if (!databaseUrl || !hasSecureDatabaseTransport(databaseUrl)) {
+    return Result.err(
+      new BetterAuthBackfillCommandError({
+        code: "invalid-arguments",
+        message: "Better Auth backfill requires a secure database connection",
+      }),
+    );
+  }
+  const { getBetterAuthOAuthResources } =
+    await import("@/api/lib/oauth-resource-policy");
+  const client = new SQL({ max: 1, url: databaseUrl });
+  const result = await executeBackfill({
+    baseline: baseline.value,
+    batchSize: parsed.value.batchSize,
+    client,
+    expectedOAuthResources: getBetterAuthOAuthResources(),
+    trustedIdentityMap: trustedIdentityMap.value,
+  });
+  await client.end();
+  return result;
+};
+
+if (import.meta.main) {
+  run(Bun.argv.slice(2))
+    .then((result) => {
+      if (Result.isError(result)) {
+        process.stderr.write(
+          `${JSON.stringify({ code: result.error.code, status: "error" })}\n`,
+        );
+        process.exitCode =
+          result.error instanceof BetterAuthBackfillCommandError &&
+          result.error.code === "preflight-mismatch"
+            ? EXIT_CODE.INVARIANT_FAILURE
+            : EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
+        return undefined;
+      }
+      process.stdout.write(
+        `${JSON.stringify({ changed: result.value.changed, status: "passed" })}\n`,
+      );
+      process.exitCode = EXIT_CODE.SUCCESS;
+      return undefined;
+    })
+    .catch(() => {
+      process.stderr.write(
+        `${JSON.stringify({ code: "backfill-execution-failed", status: "error" })}\n`,
+      );
+      process.exitCode = EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
+      return undefined;
+    });
+}

--- a/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
@@ -46,6 +46,36 @@ const checkStatus = (
     ?.status;
 };
 
+test("pre-migration audit never queries tables introduced by the bridge", async () => {
+  try {
+    await database.transaction(async (transaction) => {
+      await transaction.execute(sql`
+        ALTER TABLE oauth_client_resource
+          RENAME TO oauth_client_resource_not_yet_migrated
+      `);
+      const audit = await runBetterAuthMigrationAudit({
+        baseline: null,
+        database: {
+          execute: async (statement) => await transaction.execute(statement),
+        },
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
+        mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
+      });
+      if (audit.status === "error") {
+        throw audit.error;
+      }
+
+      expect(audit.value.report.status).toBe("passed");
+      transaction.rollback();
+    });
+  } catch (error) {
+    if (!(error instanceof TransactionRollbackError)) {
+      throw error;
+    }
+  }
+});
+
 test("pre-migration audit is repeatable and rejects ownership corruption and an orphan", async () => {
   try {
     await database.transaction(async (transaction) => {

--- a/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
@@ -53,17 +53,18 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
       const userId = `audit-user-${suffix}`;
       const accountId = `audit-account-${suffix}`;
       const sessionId = `audit-session-${suffix}`;
+      await transaction.execute(sql`
+        ALTER TABLE account ALTER COLUMN issuer DROP NOT NULL
+      `);
       await transaction.insert(user).values({
         id: userId,
         email: `audit-${suffix}@example.invalid`,
         name: "Audit fixture",
       });
-      await transaction.insert(account).values({
-        id: accountId,
-        accountId: userId,
-        providerId: "credential",
-        userId,
-      });
+      await transaction.execute(sql`
+        INSERT INTO account (id, account_id, provider_id, user_id, updated_at)
+        VALUES (${accountId}, ${userId}, 'credential', ${userId}, now())
+      `);
       await transaction.insert(session).values({
         id: sessionId,
         expiresAt: new Date(Date.now() + 60_000),
@@ -240,16 +241,15 @@ test("census crosses page boundaries with stable database-native ordering", asyn
 test("post phases require resource links, final constraints, and the exact baseline row set", async () => {
   try {
     await database.transaction(async (transaction) => {
-      const migration = await Bun.file(
-        new URL(
-          "../../drizzle/20260825140000_better_auth_17_additive/migration.sql",
-          import.meta.url,
-        ),
-      ).text();
-      for (const statement of migration.split("--> statement-breakpoint")) {
-        // eslint-disable-next-line no-await-in-loop -- migration statements must execute in committed order on one transaction
-        await transaction.execute(sql.raw(statement));
-      }
+      // The shared schema is the final 1.7 shape. Recreate the additive bridge
+      // state inside this rollback-only transaction before exercising each
+      // audit phase.
+      await transaction.execute(sql`
+        ALTER TABLE account ALTER COLUMN issuer DROP NOT NULL
+      `);
+      await transaction.execute(sql`
+        DROP INDEX IF EXISTS account_issuer_account_id_uidx
+      `);
 
       const suffix = Bun.randomUUIDv7();
       const userId = `audit-post-user-${suffix}`;
@@ -266,18 +266,12 @@ test("post phases require resource links, final constraints, and the exact basel
         email: `audit-post-${suffix}@example.invalid`,
         name: "Audit post fixture",
       });
-      await transaction.insert(account).values({
-        id: accountRowId,
-        accountId: userId,
-        providerId: "credential",
-        userId,
-      });
-      await transaction.insert(account).values({
-        id: microsoftAccountRowId,
-        accountId: microsoftLegacySub,
-        providerId: "microsoft",
-        userId,
-      });
+      await transaction.execute(sql`
+        INSERT INTO account (id, account_id, provider_id, user_id, updated_at)
+        VALUES
+          (${accountRowId}, ${userId}, 'credential', ${userId}, now()),
+          (${microsoftAccountRowId}, ${microsoftLegacySub}, 'microsoft', ${userId}, now())
+      `);
       await transaction.execute(
         sql`UPDATE account SET issuer = 'local:credential' WHERE id = ${accountRowId}`,
       );
@@ -486,7 +480,7 @@ test("post phases require resource links, final constraints, and the exact basel
 
       await transaction.execute(sql`
         ALTER TABLE oauth_client_resource
-          DROP CONSTRAINT oauth_client_resource_client_id_oauth_client_client_id_fk,
+          DROP CONSTRAINT oauth_client_resource_client_id_oauth_client_client_id_fkey,
           ADD CONSTRAINT oauth_client_resource_resource_duplicate_fk
             FOREIGN KEY (resource_id) REFERENCES oauth_resource(identifier)
       `);
@@ -506,7 +500,7 @@ test("post phases require resource links, final constraints, and the exact basel
       await transaction.execute(sql`
         ALTER TABLE oauth_client_resource
           DROP CONSTRAINT oauth_client_resource_resource_duplicate_fk,
-          ADD CONSTRAINT oauth_client_resource_client_id_oauth_client_client_id_fk
+          ADD CONSTRAINT oauth_client_resource_client_id_oauth_client_client_id_fkey
             FOREIGN KEY (client_id) REFERENCES oauth_client(client_id)
             ON DELETE CASCADE
       `);

--- a/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
@@ -17,6 +17,14 @@ const EMPTY_TRUSTED_IDENTITY_MAP = {
   microsoftAccounts: [],
 } as const;
 
+const TEST_OAUTH_RESOURCES = [
+  {
+    allowedScopes: ["stella:read"],
+    identifier: "https://audit.example.invalid/mcp",
+    name: "Audit resource",
+  },
+] as const;
+
 setDefaultTimeout(120_000);
 
 beforeAll(async () => {
@@ -71,6 +79,7 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
       const first = await runBetterAuthMigrationAudit({
         baseline: null,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
         trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
@@ -83,6 +92,7 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
       const second = await runBetterAuthMigrationAudit({
         baseline: null,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
         trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
@@ -104,6 +114,7 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
       const corruptedAccessAndOwnership = await runBetterAuthMigrationAudit({
         baseline: null,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
         trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
@@ -135,6 +146,7 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
       const missingForeignKey = await runBetterAuthMigrationAudit({
         baseline: null,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
         trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
@@ -152,6 +164,7 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
       const orphaned = await runBetterAuthMigrationAudit({
         baseline: null,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
         trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
@@ -193,6 +206,7 @@ test("census crosses page boundaries with stable database-native ordering", asyn
       const first = await runBetterAuthMigrationAudit({
         baseline: null,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
         trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
@@ -202,6 +216,7 @@ test("census crosses page boundaries with stable database-native ordering", asyn
       const second = await runBetterAuthMigrationAudit({
         baseline: null,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
         trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
@@ -225,105 +240,15 @@ test("census crosses page boundaries with stable database-native ordering", asyn
 test("post phases require resource links, final constraints, and the exact baseline row set", async () => {
   try {
     await database.transaction(async (transaction) => {
-      await transaction.execute(
-        sql`ALTER TABLE account ADD COLUMN issuer text`,
-      );
-      await transaction.execute(
-        sql`ALTER TABLE oauth_access_token ADD COLUMN resources text[]`,
-      );
-      await transaction.execute(sql`
-        ALTER TABLE oauth_access_token
-          ADD COLUMN authorization_code_id text,
-          ADD COLUMN requested_user_info_claims text[],
-          ADD COLUMN revoked timestamptz,
-          ADD COLUMN confirmation jsonb
-      `);
-      await transaction.execute(
-        sql`ALTER TABLE oauth_refresh_token ADD COLUMN resources text[]`,
-      );
-      await transaction.execute(sql`
-        ALTER TABLE oauth_refresh_token
-          ADD COLUMN authorization_code_id text,
-          ADD COLUMN requested_user_info_claims text[],
-          ADD COLUMN rotated_at timestamptz,
-          ADD COLUMN rotation_replay_response text,
-          ADD COLUMN rotation_replay_expires_at timestamptz,
-          ADD COLUMN confirmation jsonb
-      `);
-      await transaction.execute(
-        sql`ALTER TABLE oauth_consent ADD COLUMN resources text[]`,
-      );
-      await transaction.execute(sql`
-        ALTER TABLE oauth_consent
-          ADD COLUMN requested_user_info_claims text[]
-      `);
-      await transaction.execute(sql`
-        ALTER TABLE oauth_client
-          ADD COLUMN client_discovery_id text,
-          ADD COLUMN client_credentials_scopes text[] NOT NULL DEFAULT '{}',
-          ADD COLUMN backchannel_logout_uri text,
-          ADD COLUMN backchannel_logout_session_required boolean,
-          ADD COLUMN application_type text,
-          ADD COLUMN jwks text,
-          ADD COLUMN jwks_uri text,
-          ADD COLUMN dpop_bound_access_tokens boolean
-      `);
-      await transaction.execute(sql`
-        CREATE TABLE oauth_resource (
-          id text PRIMARY KEY,
-          identifier text NOT NULL UNIQUE,
-          name text NOT NULL,
-          access_token_ttl integer,
-          refresh_token_ttl integer,
-          signing_algorithm text,
-          signing_key_id text,
-          allowed_scopes text[],
-          custom_claims jsonb,
-          dpop_bound_access_tokens_required boolean,
-          disabled boolean,
-          created_at timestamptz,
-          updated_at timestamptz,
-          policy_version integer,
-          metadata jsonb
-        )
-      `);
-      await transaction.execute(sql`
-        CREATE TABLE oauth_client_resource (
-          id text PRIMARY KEY,
-          client_id text NOT NULL,
-          resource_id text NOT NULL,
-          metadata jsonb,
-          created_at timestamptz,
-          UNIQUE (client_id, resource_id),
-          CONSTRAINT oauth_client_resource_client_fk
-            FOREIGN KEY (client_id) REFERENCES oauth_client(client_id),
-          CONSTRAINT oauth_client_resource_resource_fk
-            FOREIGN KEY (resource_id) REFERENCES oauth_resource(identifier)
-        )
-      `);
-      await transaction.execute(sql`
-        CREATE TABLE oauth_client_assertion (
-          id text PRIMARY KEY,
-          expires_at timestamptz NOT NULL
-        )
-      `);
-      for (const tableName of [
-        "oauth_resource",
-        "oauth_client_resource",
-        "oauth_client_assertion",
-      ]) {
-        // eslint-disable-next-line no-await-in-loop -- transactional DDL must stay ordered on one connection
-        await transaction.execute(
-          sql`ALTER TABLE ${sql.identifier(tableName)} ENABLE ROW LEVEL SECURITY`,
-        );
-        // eslint-disable-next-line no-await-in-loop -- policy creation follows RLS enablement
-        await transaction.execute(
-          sql`CREATE POLICY auth_no_stella_access ON ${sql.identifier(tableName)} FOR ALL TO stella USING (false) WITH CHECK (false)`,
-        );
-        // eslint-disable-next-line no-await-in-loop -- privilege revocation follows policy creation
-        await transaction.execute(
-          sql`REVOKE ALL PRIVILEGES ON TABLE ${sql.identifier(tableName)} FROM stella`,
-        );
+      const migration = await Bun.file(
+        new URL(
+          "../../drizzle/20260825140000_better_auth_17_additive/migration.sql",
+          import.meta.url,
+        ),
+      ).text();
+      for (const statement of migration.split("--> statement-breakpoint")) {
+        // eslint-disable-next-line no-await-in-loop -- migration statements must execute in committed order on one transaction
+        await transaction.execute(sql.raw(statement));
       }
 
       const suffix = Bun.randomUUIDv7();
@@ -335,7 +260,7 @@ test("post phases require resource links, final constraints, and the exact basel
       const microsoftIssuer =
         "https://login.microsoftonline.com/3a893563-0d4e-4309-9a31-b6e4e9f64479/v2.0";
       const clientId = `audit-post-client-${suffix}`;
-      const resourceId = `https://audit-${suffix}.example.invalid`;
+      const resourceId = TEST_OAUTH_RESOURCES[0].identifier;
       await transaction.insert(user).values({
         id: userId,
         email: `audit-post-${suffix}@example.invalid`,
@@ -359,15 +284,22 @@ test("post phases require resource links, final constraints, and the exact basel
       await transaction.insert(oauthClient).values({
         id: `audit-post-client-row-${suffix}`,
         clientId,
+        public: true,
         redirectUris: [`https://client-${suffix}.example.invalid/callback`],
         tokenEndpointAuthMethod: "none",
+        type: "web",
       });
       await transaction.execute(
         sql`UPDATE oauth_client SET application_type = 'web' WHERE client_id = ${clientId}`,
       );
       await transaction.execute(sql`
-        INSERT INTO oauth_resource (id, identifier, name)
-        VALUES (${`audit-resource-${suffix}`}, ${resourceId}, 'Audit resource')
+        INSERT INTO oauth_resource (id, identifier, name, allowed_scopes)
+        VALUES (
+          ${`audit-resource-${suffix}`},
+          ${resourceId},
+          'Audit resource',
+          ARRAY['stella:read']::text[]
+        )
       `);
       await transaction.execute(sql`
         INSERT INTO oauth_client_resource (id, client_id, resource_id)
@@ -392,6 +324,7 @@ test("post phases require resource links, final constraints, and the exact basel
       const preMigration = await runBetterAuthMigrationAudit({
         baseline: null,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
         trustedIdentityMap,
       });
@@ -405,6 +338,25 @@ test("post phases require resource links, final constraints, and the exact basel
       expect(
         preMigration.value.baseline.tables["account"]?.preservedColumns,
       ).toContain("account_id");
+      await transaction.execute(
+        sql`UPDATE oauth_client SET type = 'invalid' WHERE client_id = ${clientId}`,
+      );
+      const invalidProjectedOAuthPolicy = await runBetterAuthMigrationAudit({
+        baseline: null,
+        database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
+        mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        trustedIdentityMap,
+      });
+      expect(
+        checkStatus(
+          invalidProjectedOAuthPolicy,
+          BETTER_AUTH_AUDIT_CHECKS.OAUTH_POLICY_PROJECTED_VALID,
+        ),
+      ).toBe("failed");
+      await transaction.execute(
+        sql`UPDATE oauth_client SET type = 'web' WHERE client_id = ${clientId}`,
+      );
       await transaction.execute(sql`
         UPDATE account
            SET account_id = ${microsoftOid}, issuer = ${microsoftIssuer}
@@ -414,6 +366,7 @@ test("post phases require resource links, final constraints, and the exact basel
       const postBackfill = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
         trustedIdentityMap: null,
       });
@@ -431,6 +384,7 @@ test("post phases require resource links, final constraints, and the exact basel
       const wrongMicrosoftIdentity = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
         trustedIdentityMap: null,
       });
@@ -455,6 +409,7 @@ test("post phases require resource links, final constraints, and the exact basel
       const beforeConstraints = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.POST_MIGRATION,
         trustedIdentityMap: null,
       });
@@ -474,6 +429,7 @@ test("post phases require resource links, final constraints, and the exact basel
       const partialIdentityIndex = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.POST_MIGRATION,
         trustedIdentityMap: null,
       });
@@ -492,6 +448,7 @@ test("post phases require resource links, final constraints, and the exact basel
       const postMigration = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.POST_MIGRATION,
         trustedIdentityMap: null,
       });
@@ -508,6 +465,7 @@ test("post phases require resource links, final constraints, and the exact basel
       const changedScopedPolicy = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
         trustedIdentityMap: null,
       });
@@ -528,13 +486,14 @@ test("post phases require resource links, final constraints, and the exact basel
 
       await transaction.execute(sql`
         ALTER TABLE oauth_client_resource
-          DROP CONSTRAINT oauth_client_resource_client_fk,
+          DROP CONSTRAINT oauth_client_resource_client_id_oauth_client_client_id_fk,
           ADD CONSTRAINT oauth_client_resource_resource_duplicate_fk
             FOREIGN KEY (resource_id) REFERENCES oauth_resource(identifier)
       `);
       const wrongResourceForeignKeys = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.POST_MIGRATION,
         trustedIdentityMap: null,
       });
@@ -547,8 +506,9 @@ test("post phases require resource links, final constraints, and the exact basel
       await transaction.execute(sql`
         ALTER TABLE oauth_client_resource
           DROP CONSTRAINT oauth_client_resource_resource_duplicate_fk,
-          ADD CONSTRAINT oauth_client_resource_client_fk
+          ADD CONSTRAINT oauth_client_resource_client_id_oauth_client_client_id_fk
             FOREIGN KEY (client_id) REFERENCES oauth_client(client_id)
+            ON DELETE CASCADE
       `);
 
       await transaction.execute(
@@ -557,6 +517,7 @@ test("post phases require resource links, final constraints, and the exact basel
       const changedRow = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
         trustedIdentityMap: null,
       });
@@ -571,6 +532,7 @@ test("post phases require resource links, final constraints, and the exact basel
       const widenedAccess = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
         trustedIdentityMap: null,
       });
@@ -590,6 +552,7 @@ test("post phases require resource links, final constraints, and the exact basel
       const missingLink = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
         trustedIdentityMap: null,
       });
@@ -597,6 +560,12 @@ test("post phases require resource links, final constraints, and the exact basel
         checkStatus(
           missingLink,
           BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENT_RESOURCE_LINKS,
+        ),
+      ).toBe("failed");
+      expect(
+        checkStatus(
+          missingLink,
+          BETTER_AUTH_AUDIT_CHECKS.OAUTH_POLICY_MATCHES_TRUSTED_PROJECTION,
         ),
       ).toBe("failed");
       await transaction.execute(sql`
@@ -621,6 +590,7 @@ test("post phases require resource links, final constraints, and the exact basel
       const replacedRow = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
         mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
         trustedIdentityMap: null,
       });

--- a/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
@@ -12,6 +12,11 @@ import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
 
 let database: TestDatabase;
 
+const EMPTY_TRUSTED_IDENTITY_MAP = {
+  formatVersion: 1,
+  microsoftAccounts: [],
+} as const;
+
 setDefaultTimeout(120_000);
 
 beforeAll(async () => {
@@ -67,6 +72,7 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
         baseline: null,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
       if (first.status === "error") {
         throw first.error;
@@ -78,6 +84,7 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
         baseline: null,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
       if (second.status === "error") {
         throw second.error;
@@ -98,6 +105,7 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
         baseline: null,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
       expect(
         checkStatus(
@@ -128,6 +136,7 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
         baseline: null,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
       expect(
         checkStatus(
@@ -144,6 +153,7 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
         baseline: null,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
       expect(
         checkStatus(
@@ -184,6 +194,7 @@ test("census crosses page boundaries with stable database-native ordering", asyn
         baseline: null,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
       if (first.status === "error") {
         throw first.error;
@@ -192,6 +203,7 @@ test("census crosses page boundaries with stable database-native ordering", asyn
         baseline: null,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        trustedIdentityMap: EMPTY_TRUSTED_IDENTITY_MAP,
       });
       if (second.status === "error") {
         throw second.error;
@@ -317,6 +329,11 @@ test("post phases require resource links, final constraints, and the exact basel
       const suffix = Bun.randomUUIDv7();
       const userId = `audit-post-user-${suffix}`;
       const accountRowId = `audit-post-account-${suffix}`;
+      const microsoftAccountRowId = `audit-post-microsoft-${suffix}`;
+      const microsoftLegacySub = `legacy-microsoft-sub-${suffix}`;
+      const microsoftOid = "71c02436-6600-42fd-84d0-417484a177b0";
+      const microsoftIssuer =
+        "https://login.microsoftonline.com/3a893563-0d4e-4309-9a31-b6e4e9f64479/v2.0";
       const clientId = `audit-post-client-${suffix}`;
       const resourceId = `https://audit-${suffix}.example.invalid`;
       await transaction.insert(user).values({
@@ -328,6 +345,12 @@ test("post phases require resource links, final constraints, and the exact basel
         id: accountRowId,
         accountId: userId,
         providerId: "credential",
+        userId,
+      });
+      await transaction.insert(account).values({
+        id: microsoftAccountRowId,
+        accountId: microsoftLegacySub,
+        providerId: "microsoft",
         userId,
       });
       await transaction.execute(
@@ -355,10 +378,22 @@ test("post phases require resource links, final constraints, and the exact basel
         execute: async (statement: Parameters<typeof transaction.execute>[0]) =>
           await transaction.execute(statement),
       };
+      const trustedIdentityMap = {
+        formatVersion: 1,
+        microsoftAccounts: [
+          {
+            accountId: microsoftOid,
+            accountRowId: microsoftAccountRowId,
+            issuer: microsoftIssuer,
+            legacyAccountId: microsoftLegacySub,
+          },
+        ],
+      } as const;
       const preMigration = await runBetterAuthMigrationAudit({
         baseline: null,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        trustedIdentityMap,
       });
       expect(preMigration.status).toBe("ok");
       if (preMigration.status === "error") {
@@ -367,11 +402,20 @@ test("post phases require resource links, final constraints, and the exact basel
       expect(
         preMigration.value.baseline.tables["account"]?.preservedColumns,
       ).not.toContain("issuer");
+      expect(
+        preMigration.value.baseline.tables["account"]?.preservedColumns,
+      ).toContain("account_id");
+      await transaction.execute(sql`
+        UPDATE account
+           SET account_id = ${microsoftOid}, issuer = ${microsoftIssuer}
+         WHERE id = ${microsoftAccountRowId}
+      `);
 
       const postBackfill = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+        trustedIdentityMap: null,
       });
       if (postBackfill.status === "error") {
         throw postBackfill.error;
@@ -379,10 +423,40 @@ test("post phases require resource links, final constraints, and the exact basel
       expect(postBackfill.status).toBe("ok");
       expect(postBackfill.value.report.status).toBe("passed");
 
+      await transaction.execute(sql`
+        UPDATE account
+           SET account_id = ${microsoftLegacySub}
+         WHERE id = ${microsoftAccountRowId}
+      `);
+      const wrongMicrosoftIdentity = await runBetterAuthMigrationAudit({
+        baseline: preMigration.value.baseline,
+        database: auditDatabase,
+        mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+        trustedIdentityMap: null,
+      });
+      expect(
+        checkStatus(
+          wrongMicrosoftIdentity,
+          BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITIES_MATCH_TRUSTED_PROJECTION,
+        ),
+      ).toBe("failed");
+      expect(
+        checkStatus(
+          wrongMicrosoftIdentity,
+          BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_PRESERVED,
+        ),
+      ).toBe("passed");
+      await transaction.execute(sql`
+        UPDATE account
+           SET account_id = ${microsoftOid}
+         WHERE id = ${microsoftAccountRowId}
+      `);
+
       const beforeConstraints = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.POST_MIGRATION,
+        trustedIdentityMap: null,
       });
       expect(
         checkStatus(
@@ -401,6 +475,7 @@ test("post phases require resource links, final constraints, and the exact basel
         baseline: preMigration.value.baseline,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.POST_MIGRATION,
+        trustedIdentityMap: null,
       });
       expect(
         checkStatus(
@@ -418,6 +493,7 @@ test("post phases require resource links, final constraints, and the exact basel
         baseline: preMigration.value.baseline,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.POST_MIGRATION,
+        trustedIdentityMap: null,
       });
       expect(postMigration.status).toBe("ok");
       if (postMigration.status === "error") {
@@ -433,6 +509,7 @@ test("post phases require resource links, final constraints, and the exact basel
         baseline: preMigration.value.baseline,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+        trustedIdentityMap: null,
       });
       expect(
         checkStatus(
@@ -459,6 +536,7 @@ test("post phases require resource links, final constraints, and the exact basel
         baseline: preMigration.value.baseline,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.POST_MIGRATION,
+        trustedIdentityMap: null,
       });
       expect(
         checkStatus(
@@ -480,6 +558,7 @@ test("post phases require resource links, final constraints, and the exact basel
         baseline: preMigration.value.baseline,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+        trustedIdentityMap: null,
       });
       expect(
         checkStatus(changedRow, BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_PRESERVED),
@@ -493,6 +572,7 @@ test("post phases require resource links, final constraints, and the exact basel
         baseline: preMigration.value.baseline,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+        trustedIdentityMap: null,
       });
       expect(
         checkStatus(
@@ -511,6 +591,7 @@ test("post phases require resource links, final constraints, and the exact basel
         baseline: preMigration.value.baseline,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+        trustedIdentityMap: null,
       });
       expect(
         checkStatus(
@@ -541,6 +622,7 @@ test("post phases require resource links, final constraints, and the exact basel
         baseline: preMigration.value.baseline,
         database: auditDatabase,
         mode: BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+        trustedIdentityMap: null,
       });
       expect(
         checkStatus(replacedRow, BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_PRESERVED),

--- a/apps/api/src/scripts/better-auth-migration-audit.logic.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.logic.ts
@@ -38,6 +38,35 @@ const ACCOUNT_ISSUERS = {
 } as const;
 
 const TRANSFORMED_ACCOUNT_COLUMNS = new Set(["issuer"]);
+const INTRODUCED_OAUTH_COLUMNS = {
+  oauthAccessToken: new Set([
+    "authorization_code_id",
+    "confirmation",
+    "requested_user_info_claims",
+    "resources",
+    "revoked",
+  ]),
+  oauthClient: new Set([
+    "application_type",
+    "backchannel_logout_session_required",
+    "backchannel_logout_uri",
+    "client_credentials_scopes",
+    "client_discovery_id",
+    "dpop_bound_access_tokens",
+    "jwks",
+    "jwks_uri",
+  ]),
+  oauthConsent: new Set(["requested_user_info_claims", "resources"]),
+  oauthRefreshToken: new Set([
+    "authorization_code_id",
+    "confirmation",
+    "requested_user_info_claims",
+    "resources",
+    "rotated_at",
+    "rotation_replay_expires_at",
+    "rotation_replay_response",
+  ]),
+} as const;
 const MICROSOFT_ACCOUNT_ID_CENSUS_SENTINEL =
   "better-auth-1.7-trusted-microsoft-identity";
 
@@ -74,6 +103,9 @@ type AuthPolicyRule = {
 
 const columnNames = (table: Table) =>
   Object.values(getColumns(table)).map(({ name }) => name);
+
+const preservedColumnNames = (table: Table, introduced: ReadonlySet<string>) =>
+  columnNames(table).filter((column) => !introduced.has(column));
 
 /**
  * Total by construction: adding a table to `authSchema` fails typechecking
@@ -150,14 +182,20 @@ export const AUTH_TABLE_AUDIT_POLICY = {
         referencedModel: "oauthRefreshToken",
       },
     ],
-    preservedColumns: columnNames(authSchema.oauthAccessToken),
+    preservedColumns: preservedColumnNames(
+      authSchema.oauthAccessToken,
+      INTRODUCED_OAUTH_COLUMNS.oauthAccessToken,
+    ),
     tableName: getTableName(authSchema.oauthAccessToken),
   },
   oauthClient: {
     foreignKeys: [
       { column: "user_id", referencedColumn: "id", referencedModel: "user" },
     ],
-    preservedColumns: columnNames(authSchema.oauthClient),
+    preservedColumns: preservedColumnNames(
+      authSchema.oauthClient,
+      INTRODUCED_OAUTH_COLUMNS.oauthClient,
+    ),
     tableName: getTableName(authSchema.oauthClient),
   },
   oauthConsent: {
@@ -169,7 +207,10 @@ export const AUTH_TABLE_AUDIT_POLICY = {
       },
       { column: "user_id", referencedColumn: "id", referencedModel: "user" },
     ],
-    preservedColumns: columnNames(authSchema.oauthConsent),
+    preservedColumns: preservedColumnNames(
+      authSchema.oauthConsent,
+      INTRODUCED_OAUTH_COLUMNS.oauthConsent,
+    ),
     tableName: getTableName(authSchema.oauthConsent),
   },
   oauthRefreshToken: {
@@ -186,13 +227,42 @@ export const AUTH_TABLE_AUDIT_POLICY = {
       },
       { column: "user_id", referencedColumn: "id", referencedModel: "user" },
     ],
-    preservedColumns: columnNames(authSchema.oauthRefreshToken),
+    preservedColumns: preservedColumnNames(
+      authSchema.oauthRefreshToken,
+      INTRODUCED_OAUTH_COLUMNS.oauthRefreshToken,
+    ),
     tableName: getTableName(authSchema.oauthRefreshToken),
   },
   organization: {
     foreignKeys: [],
     preservedColumns: columnNames(authSchema.organization),
     tableName: getTableName(authSchema.organization),
+  },
+  oauthClientAssertion: {
+    foreignKeys: [],
+    preservedColumns: columnNames(authSchema.oauthClientAssertion),
+    tableName: getTableName(authSchema.oauthClientAssertion),
+  },
+  oauthClientResource: {
+    foreignKeys: [
+      {
+        column: "client_id",
+        referencedColumn: "client_id",
+        referencedModel: "oauthClient",
+      },
+      {
+        column: "resource_id",
+        referencedColumn: "identifier",
+        referencedModel: "oauthResource",
+      },
+    ],
+    preservedColumns: columnNames(authSchema.oauthClientResource),
+    tableName: getTableName(authSchema.oauthClientResource),
+  },
+  oauthResource: {
+    foreignKeys: [],
+    preservedColumns: columnNames(authSchema.oauthResource),
+    tableName: getTableName(authSchema.oauthResource),
   },
   session: {
     foreignKeys: [
@@ -236,8 +306,11 @@ const AUTH_BASELINE_DISPOSITION = {
   member: "preserve",
   oauthAccessToken: "preserve",
   oauthClient: "preserve",
+  oauthClientAssertion: "introduced",
+  oauthClientResource: "introduced",
   oauthConsent: "preserve",
   oauthRefreshToken: "preserve",
+  oauthResource: "introduced",
   organization: "preserve",
   session: "preserve",
   twoFactor: "preserve",
@@ -248,12 +321,12 @@ const AUTH_BASELINE_DISPOSITION = {
 const isPreservedDisposition = (value: "introduced" | "preserve") =>
   value === "preserve";
 
-const AUTH_MODEL_NAMES = Object.keys(AUTH_BASELINE_DISPOSITION)
+export const AUTH_BASELINE_MODEL_NAMES = Object.keys(AUTH_BASELINE_DISPOSITION)
   .filter(isAuthModel)
   .filter((model) => isPreservedDisposition(AUTH_BASELINE_DISPOSITION[model]));
 const AUTH_TABLE_POLICIES = Object.values(AUTH_TABLE_AUDIT_POLICY);
 
-const PRESERVED_AUTH_TABLE_NAMES = AUTH_MODEL_NAMES.flatMap((model) =>
+const PRESERVED_AUTH_TABLE_NAMES = AUTH_BASELINE_MODEL_NAMES.flatMap((model) =>
   isAuthModel(model) ? [AUTH_TABLE_AUDIT_POLICY[model].tableName] : [],
 );
 
@@ -340,6 +413,28 @@ const AUTH_ACCESS_POLICY = {
     ],
     tableName: AUTH_TABLE_AUDIT_POLICY.oauthClient.tableName,
   },
+  oauthClientAssertion: {
+    access: "denied",
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
+    tableName: AUTH_TABLE_AUDIT_POLICY.oauthClientAssertion.tableName,
+  },
+  oauthClientResource: {
+    access: "denied",
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
+    tableName: AUTH_TABLE_AUDIT_POLICY.oauthClientResource.tableName,
+  },
   oauthConsent: {
     access: "denied",
     policies: [
@@ -361,6 +456,17 @@ const AUTH_ACCESS_POLICY = {
       },
     ],
     tableName: AUTH_TABLE_AUDIT_POLICY.oauthRefreshToken.tableName,
+  },
+  oauthResource: {
+    access: "denied",
+    policies: [
+      {
+        command: "ALL",
+        name: "auth_no_stella_access",
+        predicate: "deny",
+      },
+    ],
+    tableName: AUTH_TABLE_AUDIT_POLICY.oauthResource.tableName,
   },
   organization: {
     access: "scoped",
@@ -424,20 +530,6 @@ const FUTURE_AUTH_TABLES = {
   OAUTH_CLIENT_RESOURCE: "oauth_client_resource",
   OAUTH_RESOURCE: "oauth_resource",
 } as const;
-
-const FUTURE_AUTH_ACCESS_POLICY = Object.values(FUTURE_AUTH_TABLES).map(
-  (tableName) => ({
-    access: "denied" as const,
-    policies: [
-      {
-        command: "ALL" as const,
-        name: "auth_no_stella_access",
-        predicate: "deny" as const,
-      },
-    ],
-    tableName,
-  }),
-);
 
 const POST_BACKFILL_COLUMNS = {
   account: ["issuer"],
@@ -1297,9 +1389,12 @@ const foreignKeysValidatedStatement = sql`
 `;
 
 const accessBoundariesStatement = (includeFutureTables: boolean) => {
-  const policies: readonly AuthAccessPolicy[] = includeFutureTables
-    ? [...Object.values(AUTH_ACCESS_POLICY), ...FUTURE_AUTH_ACCESS_POLICY]
-    : Object.values(AUTH_ACCESS_POLICY);
+  const policies: readonly AuthAccessPolicy[] = Object.values(
+    AUTH_ACCESS_POLICY,
+  ).filter(
+    ({ tableName }) =>
+      includeFutureTables || PRESERVED_AUTH_TABLE_NAMES.includes(tableName),
+  );
   const expectedTables = policies.map(
     ({ access, tableName }) => sql`(${tableName}::text, ${access}::text)`,
   );
@@ -1956,7 +2051,7 @@ const readAuthCensus = async (
   ): Promise<
     Result<BetterAuthAuditBaseline["tables"], BetterAuthAuditError>
   > => {
-    const model = AUTH_MODEL_NAMES.at(index);
+    const model = AUTH_BASELINE_MODEL_NAMES.at(index);
     if (model === undefined) {
       return Result.ok(entries);
     }
@@ -2019,10 +2114,10 @@ const createBaseline = (
 const emptyBaseline = (): BetterAuthAuditBaseline =>
   createBaseline(
     Object.fromEntries(
-      Object.entries(AUTH_TABLE_AUDIT_POLICY).map(([model, policy]) => [
+      AUTH_BASELINE_MODEL_NAMES.map((model) => [
         model,
         {
-          preservedColumns: policy.preservedColumns,
+          preservedColumns: AUTH_TABLE_AUDIT_POLICY[model].preservedColumns,
           primaryKeyDigest: "",
           rowContentDigest: "",
           rowCount: "0",
@@ -2082,7 +2177,13 @@ export const runBetterAuthMigrationAudit = async ({
     return tables;
   }
 
-  const currentSchemaComplete = AUTH_TABLE_POLICIES.every(({ tableName }) =>
+  const requiredTablePolicies =
+    mode === BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION
+      ? AUTH_TABLE_POLICIES.filter(({ tableName }) =>
+          PRESERVED_AUTH_TABLE_NAMES.includes(tableName),
+        )
+      : AUTH_TABLE_POLICIES;
+  const currentSchemaComplete = requiredTablePolicies.every(({ tableName }) =>
     tables.value.has(tableName),
   );
   checks.push(
@@ -2368,7 +2469,7 @@ export const runBetterAuthMigrationAudit = async ({
   } else {
     const preserved =
       baseline !== null &&
-      AUTH_MODEL_NAMES.every((model) => {
+      AUTH_BASELINE_MODEL_NAMES.every((model) => {
         const expected = baseline.tables[model];
         const actual = census.value[model];
         return (
@@ -2447,7 +2548,10 @@ const betterAuthAuditBaselineSchema: v.GenericSchema<
   }),
   tables: v.strictObject(
     Object.fromEntries(
-      AUTH_MODEL_NAMES.map((model) => [model, tableCensusSchema(model)]),
+      AUTH_BASELINE_MODEL_NAMES.map((model) => [
+        model,
+        tableCensusSchema(model),
+      ]),
     ),
   ),
 });

--- a/apps/api/src/scripts/better-auth-migration-audit.logic.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.logic.ts
@@ -12,6 +12,7 @@ import type { SQL, Table } from "drizzle-orm";
 import * as v from "valibot";
 
 import { authSchema } from "@/api/db/auth-schema";
+import { compareCodepoint } from "@/api/lib/collation";
 import { isRecord } from "@/api/lib/type-guards";
 
 export const BETTER_AUTH_AUDIT_MODES = {
@@ -528,6 +529,9 @@ export const BETTER_AUTH_AUDIT_CHECKS = {
   OAUTH_CLIENTS_CLASSIFIED: "oauth-clients-classified",
   OAUTH_CLIENT_RESOURCE_LINKS: "oauth-client-resource-links-complete",
   OAUTH_RESOURCE_REFERENCES: "oauth-resource-references-reachable",
+  OAUTH_POLICY_MATCHES_TRUSTED_PROJECTION:
+    "oauth-policy-matches-trusted-projection",
+  OAUTH_POLICY_PROJECTED_VALID: "oauth-policy-projected-valid",
   POST_BACKFILL_SCHEMA_COMPLETE: "post-backfill-schema-complete",
   POST_MIGRATION_CONSTRAINTS: "post-migration-constraints",
 } as const;
@@ -545,6 +549,7 @@ const CHECKS_BY_MODE = {
     BETTER_AUTH_AUDIT_CHECKS.CREDENTIAL_ACCOUNT_OWNERSHIP,
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_MAPPING_COMPLETE,
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_PROJECTED_UNIQUE,
+    BETTER_AUTH_AUDIT_CHECKS.OAUTH_POLICY_PROJECTED_VALID,
     BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_BASELINED,
   ],
   [BETTER_AUTH_AUDIT_MODES.POST_BACKFILL]: [
@@ -559,6 +564,7 @@ const CHECKS_BY_MODE = {
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_UNIQUE,
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_ISSUERS_TRUSTED,
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITIES_MATCH_TRUSTED_PROJECTION,
+    BETTER_AUTH_AUDIT_CHECKS.OAUTH_POLICY_MATCHES_TRUSTED_PROJECTION,
     BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENT_RESOURCE_LINKS,
     BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENTS_CLASSIFIED,
     BETTER_AUTH_AUDIT_CHECKS.OAUTH_RESOURCE_REFERENCES,
@@ -576,6 +582,7 @@ const CHECKS_BY_MODE = {
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_UNIQUE,
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_ISSUERS_TRUSTED,
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITIES_MATCH_TRUSTED_PROJECTION,
+    BETTER_AUTH_AUDIT_CHECKS.OAUTH_POLICY_MATCHES_TRUSTED_PROJECTION,
     BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENT_RESOURCE_LINKS,
     BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENTS_CLASSIFIED,
     BETTER_AUTH_AUDIT_CHECKS.OAUTH_RESOURCE_REFERENCES,
@@ -600,7 +607,12 @@ export type BetterAuthAuditBaseline = {
     rowCount: string;
   };
   accessPolicyDigest: string;
-  formatVersion: 3;
+  formatVersion: 4;
+  oauthPolicyProjection: {
+    clientCount: string;
+    digest: string;
+    resourceCount: string;
+  };
   tables: Record<
     string,
     {
@@ -620,6 +632,12 @@ export type BetterAuthTrustedIdentityMap = {
     issuer: string;
     legacyAccountId: string;
   }[];
+};
+
+export type BetterAuthExpectedOAuthResource = {
+  allowedScopes: readonly string[];
+  identifier: string;
+  name: string;
 };
 
 export type BetterAuthAuditReport = {
@@ -678,6 +696,14 @@ const requiredString = (value: unknown): string | null =>
 
 const requiredBoolean = (value: unknown): boolean | null =>
   typeof value === "boolean" ? value : null;
+
+const requiredStringArray = (value: unknown): readonly string[] | null =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "string")
+    ? value
+    : null;
+
+const optionalStringArray = (value: unknown): readonly string[] | null =>
+  value === null ? [] : requiredStringArray(value);
 
 type AccountIdentityProjection = {
   collisionFree: boolean;
@@ -916,6 +942,275 @@ const readActualAccountIdentities = async (
     digest: projectionHasher.digest("hex"),
     rowCount: rowCount.toString(),
   });
+};
+
+type OAuthPolicyProjection =
+  BetterAuthAuditBaseline["oauthPolicyProjection"] & {
+    valid: boolean;
+  };
+
+const OAUTH_POLICY_PAGE_SIZE = 1000;
+const OAUTH_PROTOCOL_SCOPES = new Set([
+  "email",
+  "offline_access",
+  "openid",
+  "profile",
+]);
+
+const updateOAuthPolicyValue = (
+  hasher: Bun.CryptoHasher,
+  values: readonly string[],
+) => {
+  for (const value of values) {
+    hasher.update(value);
+    hasher.update("\0");
+  }
+};
+
+const sortedUnique = (values: readonly string[]) =>
+  [...new Set(values)].toSorted();
+
+const initializeOAuthPolicyProjection = (
+  expectedResources: readonly BetterAuthExpectedOAuthResource[],
+) => {
+  const hasher = new Bun.CryptoHasher("sha256");
+  const sortedResources = [...expectedResources].toSorted((left, right) =>
+    compareCodepoint(left.identifier, right.identifier),
+  );
+  let valid =
+    sortedResources.length > 0 &&
+    new Set(sortedResources.map(({ identifier }) => identifier)).size ===
+      sortedResources.length;
+  for (const resource of sortedResources) {
+    const scopes = sortedUnique(resource.allowedScopes);
+    valid &&=
+      resource.identifier.length > 0 &&
+      resource.name.length > 0 &&
+      scopes.length > 0 &&
+      scopes.length === resource.allowedScopes.length;
+    updateOAuthPolicyValue(hasher, [
+      "resource",
+      resource.identifier,
+      resource.name,
+      ...scopes,
+    ]);
+  }
+  return { hasher, resourceCount: BigInt(sortedResources.length), valid };
+};
+
+const readProjectedOAuthPolicy = async (
+  database: BetterAuthAuditDatabase,
+  expectedResources: readonly BetterAuthExpectedOAuthResource[],
+) => {
+  const initialized = initializeOAuthPolicyProjection(expectedResources);
+  const resourceIdentifiers = expectedResources
+    .map(({ identifier }) => identifier)
+    .toSorted();
+  let after: string | null = null;
+  let clientCount = 0n;
+  let valid = initialized.valid;
+
+  while (true) {
+    const statement =
+      after === null
+        ? sql`
+            SELECT client_id AS "clientId",
+                   type AS "applicationType",
+                   scopes,
+                   grant_types AS "grantTypes"
+              FROM oauth_client
+             ORDER BY client_id
+             LIMIT ${OAUTH_POLICY_PAGE_SIZE}
+          `
+        : sql`
+            SELECT client_id AS "clientId",
+                   type AS "applicationType",
+                   scopes,
+                   grant_types AS "grantTypes"
+              FROM oauth_client
+             WHERE client_id > ${after}
+             ORDER BY client_id
+             LIMIT ${OAUTH_POLICY_PAGE_SIZE}
+          `;
+    // eslint-disable-next-line no-await-in-loop -- keyset pages must feed one ordered policy digest
+    const queried = await queryRows(database, statement);
+    if (Result.isError(queried)) {
+      return queried;
+    }
+    for (const row of queried.value) {
+      const clientId = isRecord(row) ? requiredString(row["clientId"]) : null;
+      const applicationType = isRecord(row)
+        ? requiredString(row["applicationType"])
+        : null;
+      const scopes = isRecord(row) ? optionalStringArray(row["scopes"]) : null;
+      const grantTypes = isRecord(row)
+        ? optionalStringArray(row["grantTypes"])
+        : null;
+      if (clientId === null || scopes === null || grantTypes === null) {
+        return Result.err(
+          new BetterAuthAuditError({
+            code: "database-query-failed",
+            message:
+              "Better Auth OAuth policy projection returned invalid data",
+          }),
+        );
+      }
+      const classifiedApplicationType =
+        applicationType === "native" || applicationType === "web"
+          ? applicationType
+          : "invalid";
+      valid &&= classifiedApplicationType !== "invalid";
+      const clientCredentialsScopes = grantTypes.includes("client_credentials")
+        ? sortedUnique(
+            scopes.filter((scope) => !OAUTH_PROTOCOL_SCOPES.has(scope)),
+          )
+        : [];
+      updateOAuthPolicyValue(initialized.hasher, [
+        "client",
+        clientId,
+        classifiedApplicationType,
+        ...clientCredentialsScopes,
+        "resources",
+        ...resourceIdentifiers,
+      ]);
+      after = clientId;
+      clientCount += 1n;
+    }
+    if (queried.value.length < OAUTH_POLICY_PAGE_SIZE) {
+      break;
+    }
+  }
+
+  return Result.ok({
+    clientCount: clientCount.toString(),
+    digest: initialized.hasher.digest("hex"),
+    resourceCount: initialized.resourceCount.toString(),
+    valid,
+  } satisfies OAuthPolicyProjection);
+};
+
+const readActualOAuthPolicy = async (database: BetterAuthAuditDatabase) => {
+  const resourceRows = await queryRows(
+    database,
+    sql`
+      SELECT identifier, name, allowed_scopes AS "allowedScopes"
+        FROM oauth_resource
+       ORDER BY identifier
+    `,
+  );
+  if (Result.isError(resourceRows)) {
+    return resourceRows;
+  }
+  const resources: BetterAuthExpectedOAuthResource[] = [];
+  for (const row of resourceRows.value) {
+    const identifier = isRecord(row) ? requiredString(row["identifier"]) : null;
+    const name = isRecord(row) ? requiredString(row["name"]) : null;
+    const allowedScopes = isRecord(row)
+      ? requiredStringArray(row["allowedScopes"])
+      : null;
+    if (identifier === null || name === null || allowedScopes === null) {
+      return Result.err(
+        new BetterAuthAuditError({
+          code: "database-query-failed",
+          message: "Better Auth OAuth resource census returned invalid data",
+        }),
+      );
+    }
+    resources.push({ allowedScopes, identifier, name });
+  }
+
+  const initialized = initializeOAuthPolicyProjection(resources);
+  let after: string | null = null;
+  let clientCount = 0n;
+  let valid = initialized.valid;
+  while (true) {
+    const statement =
+      after === null
+        ? sql`
+            SELECT client.client_id AS "clientId",
+                   client.application_type AS "applicationType",
+                   client.client_credentials_scopes AS "clientCredentialsScopes",
+                   ARRAY(
+                     SELECT link.resource_id
+                       FROM oauth_client_resource link
+                      WHERE link.client_id = client.client_id
+                      ORDER BY link.resource_id
+                   ) AS "resourceIdentifiers"
+              FROM oauth_client client
+             ORDER BY client.client_id
+             LIMIT ${OAUTH_POLICY_PAGE_SIZE}
+          `
+        : sql`
+            SELECT client.client_id AS "clientId",
+                   client.application_type AS "applicationType",
+                   client.client_credentials_scopes AS "clientCredentialsScopes",
+                   ARRAY(
+                     SELECT link.resource_id
+                       FROM oauth_client_resource link
+                      WHERE link.client_id = client.client_id
+                      ORDER BY link.resource_id
+                   ) AS "resourceIdentifiers"
+              FROM oauth_client client
+             WHERE client.client_id > ${after}
+             ORDER BY client.client_id
+             LIMIT ${OAUTH_POLICY_PAGE_SIZE}
+          `;
+    // eslint-disable-next-line no-await-in-loop -- keyset pages must feed one ordered policy digest
+    const queried = await queryRows(database, statement);
+    if (Result.isError(queried)) {
+      return queried;
+    }
+    for (const row of queried.value) {
+      const clientId = isRecord(row) ? requiredString(row["clientId"]) : null;
+      const applicationType = isRecord(row)
+        ? requiredString(row["applicationType"])
+        : null;
+      const clientCredentialsScopes = isRecord(row)
+        ? requiredStringArray(row["clientCredentialsScopes"])
+        : null;
+      const resourceIdentifiers = isRecord(row)
+        ? requiredStringArray(row["resourceIdentifiers"])
+        : null;
+      if (
+        clientId === null ||
+        applicationType === null ||
+        clientCredentialsScopes === null ||
+        resourceIdentifiers === null
+      ) {
+        return Result.err(
+          new BetterAuthAuditError({
+            code: "database-query-failed",
+            message:
+              "Better Auth OAuth client policy census returned invalid data",
+          }),
+        );
+      }
+      valid &&=
+        (applicationType === "native" || applicationType === "web") &&
+        sortedUnique(clientCredentialsScopes).length ===
+          clientCredentialsScopes.length &&
+        sortedUnique(resourceIdentifiers).length === resourceIdentifiers.length;
+      updateOAuthPolicyValue(initialized.hasher, [
+        "client",
+        clientId,
+        applicationType,
+        ...clientCredentialsScopes.toSorted(),
+        "resources",
+        ...resourceIdentifiers.toSorted(),
+      ]);
+      after = clientId;
+      clientCount += 1n;
+    }
+    if (queried.value.length < OAUTH_POLICY_PAGE_SIZE) {
+      break;
+    }
+  }
+  return Result.ok({
+    clientCount: clientCount.toString(),
+    digest: initialized.hasher.digest("hex"),
+    resourceCount: initialized.resourceCount.toString(),
+    valid,
+  } satisfies OAuthPolicyProjection);
 };
 
 const tableInventoryStatement = sql`
@@ -1712,10 +2007,12 @@ const createBaseline = (
   tables: BetterAuthAuditBaseline["tables"],
   accessPolicyDigest: string,
   accountIdentityProjection: BetterAuthAuditBaseline["accountIdentityProjection"],
+  oauthPolicyProjection: BetterAuthAuditBaseline["oauthPolicyProjection"],
 ): BetterAuthAuditBaseline => ({
   accountIdentityProjection,
   accessPolicyDigest,
-  formatVersion: 3,
+  formatVersion: 4,
+  oauthPolicyProjection,
   tables,
 });
 
@@ -1734,6 +2031,11 @@ const emptyBaseline = (): BetterAuthAuditBaseline =>
     ),
     "0".repeat(64),
     { digest: "0".repeat(64), rowCount: "0" },
+    {
+      clientCount: "0",
+      digest: "0".repeat(64),
+      resourceCount: "0",
+    },
   );
 
 type NamedAuditStatement = readonly [BetterAuthAuditCheckName, SQL];
@@ -1760,6 +2062,7 @@ const evaluateBooleanChecks = async (
 type RunBetterAuthMigrationAuditOptions = {
   baseline: BetterAuthAuditBaseline | null;
   database: BetterAuthAuditDatabase;
+  expectedOAuthResources: readonly BetterAuthExpectedOAuthResource[];
   mode: BetterAuthAuditMode;
   trustedIdentityMap: BetterAuthTrustedIdentityMap | null;
 };
@@ -1767,6 +2070,7 @@ type RunBetterAuthMigrationAuditOptions = {
 export const runBetterAuthMigrationAudit = async ({
   baseline,
   database,
+  expectedOAuthResources,
   mode,
   trustedIdentityMap,
 }: RunBetterAuthMigrationAuditOptions): Promise<
@@ -1874,6 +2178,7 @@ export const runBetterAuthMigrationAudit = async ({
   }
 
   let expectedAccountIdentityProjection: BetterAuthAuditBaseline["accountIdentityProjection"];
+  let expectedOAuthPolicyProjection: BetterAuthAuditBaseline["oauthPolicyProjection"];
   if (mode === BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION) {
     if (trustedIdentityMap === null) {
       return Result.err(
@@ -1915,6 +2220,24 @@ export const runBetterAuthMigrationAudit = async ({
       digest: projection.value.digest,
       rowCount: projection.value.rowCount,
     };
+    const oauthProjection = await readProjectedOAuthPolicy(
+      database,
+      expectedOAuthResources,
+    );
+    if (Result.isError(oauthProjection)) {
+      return oauthProjection;
+    }
+    checks.push(
+      check(
+        BETTER_AUTH_AUDIT_CHECKS.OAUTH_POLICY_PROJECTED_VALID,
+        oauthProjection.value.valid,
+      ),
+    );
+    expectedOAuthPolicyProjection = {
+      clientCount: oauthProjection.value.clientCount,
+      digest: oauthProjection.value.digest,
+      resourceCount: oauthProjection.value.resourceCount,
+    };
   } else {
     if (baseline === null) {
       return Result.err(
@@ -1936,6 +2259,23 @@ export const runBetterAuthMigrationAudit = async ({
           baseline.accountIdentityProjection.digest &&
           actualProjection.value.rowCount ===
             baseline.accountIdentityProjection.rowCount,
+      ),
+    );
+    const actualOAuthPolicy = await readActualOAuthPolicy(database);
+    if (Result.isError(actualOAuthPolicy)) {
+      return actualOAuthPolicy;
+    }
+    expectedOAuthPolicyProjection = baseline.oauthPolicyProjection;
+    checks.push(
+      check(
+        BETTER_AUTH_AUDIT_CHECKS.OAUTH_POLICY_MATCHES_TRUSTED_PROJECTION,
+        actualOAuthPolicy.value.valid &&
+          actualOAuthPolicy.value.digest ===
+            baseline.oauthPolicyProjection.digest &&
+          actualOAuthPolicy.value.clientCount ===
+            baseline.oauthPolicyProjection.clientCount &&
+          actualOAuthPolicy.value.resourceCount ===
+            baseline.oauthPolicyProjection.resourceCount,
       ),
     );
   }
@@ -2021,6 +2361,7 @@ export const runBetterAuthMigrationAudit = async ({
     census.value,
     accessPolicyDigest.value,
     expectedAccountIdentityProjection,
+    expectedOAuthPolicyProjection,
   );
   if (mode === BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION) {
     checks.push(check(BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_BASELINED, true));
@@ -2098,7 +2439,12 @@ const betterAuthAuditBaselineSchema: v.GenericSchema<
     rowCount: rowCountSchema,
   }),
   accessPolicyDigest: digestSchema,
-  formatVersion: v.literal(3),
+  formatVersion: v.literal(4),
+  oauthPolicyProjection: v.strictObject({
+    clientCount: rowCountSchema,
+    digest: digestSchema,
+    resourceCount: rowCountSchema,
+  }),
   tables: v.strictObject(
     Object.fromEntries(
       AUTH_MODEL_NAMES.map((model) => [model, tableCensusSchema(model)]),

--- a/apps/api/src/scripts/better-auth-migration-audit.logic.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.logic.ts
@@ -36,6 +36,15 @@ const ACCOUNT_ISSUERS = {
   MICROSOFT_SUFFIX: "/v2.0",
 } as const;
 
+const TRANSFORMED_ACCOUNT_COLUMNS = new Set(["issuer"]);
+const MICROSOFT_ACCOUNT_ID_CENSUS_SENTINEL =
+  "better-auth-1.7-trusted-microsoft-identity";
+
+const preservedAccountColumnNames = () =>
+  columnNames(authSchema.account).filter(
+    (column) => !TRANSFORMED_ACCOUNT_COLUMNS.has(column),
+  );
+
 type AuthModel = keyof typeof authSchema;
 
 type ForeignKeyPolicy = {
@@ -74,7 +83,11 @@ export const AUTH_TABLE_AUDIT_POLICY = {
     foreignKeys: [
       { column: "user_id", referencedColumn: "id", referencedModel: "user" },
     ],
-    preservedColumns: columnNames(authSchema.account),
+    // Better Auth 1.7 adds issuer. Microsoft account_id deliberately changes
+    // from sub to a verified oid, so the census masks only that provider's
+    // value while preserving Google and credential account IDs byte-for-byte.
+    // The trusted identity projection below owns the Microsoft transition.
+    preservedColumns: preservedAccountColumnNames(),
     tableName: getTableName(authSchema.account),
   },
   apikey: {
@@ -496,6 +509,10 @@ const POST_MIGRATION_COLUMNS = {
 
 export const BETTER_AUTH_AUDIT_CHECKS = {
   ACCOUNT_IDENTITY_COMPLETE: "account-identity-complete",
+  ACCOUNT_IDENTITY_MAPPING_COMPLETE: "account-identity-mapping-complete",
+  ACCOUNT_IDENTITY_PROJECTED_UNIQUE: "account-identity-projected-unique",
+  ACCOUNT_IDENTITIES_MATCH_TRUSTED_PROJECTION:
+    "account-identities-match-trusted-projection",
   ACCOUNT_IDENTITY_UNIQUE: "account-identity-unique",
   ACCOUNT_ISSUERS_TRUSTED: "account-issuers-trusted",
   ACCOUNT_PROVIDERS_CLASSIFIED: "account-providers-classified",
@@ -526,6 +543,8 @@ const CHECKS_BY_MODE = {
     BETTER_AUTH_AUDIT_CHECKS.AUTH_FOREIGN_KEYS_VALIDATED,
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_PROVIDERS_CLASSIFIED,
     BETTER_AUTH_AUDIT_CHECKS.CREDENTIAL_ACCOUNT_OWNERSHIP,
+    BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_MAPPING_COMPLETE,
+    BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_PROJECTED_UNIQUE,
     BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_BASELINED,
   ],
   [BETTER_AUTH_AUDIT_MODES.POST_BACKFILL]: [
@@ -539,6 +558,7 @@ const CHECKS_BY_MODE = {
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_COMPLETE,
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_UNIQUE,
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_ISSUERS_TRUSTED,
+    BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITIES_MATCH_TRUSTED_PROJECTION,
     BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENT_RESOURCE_LINKS,
     BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENTS_CLASSIFIED,
     BETTER_AUTH_AUDIT_CHECKS.OAUTH_RESOURCE_REFERENCES,
@@ -555,6 +575,7 @@ const CHECKS_BY_MODE = {
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_COMPLETE,
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_UNIQUE,
     BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_ISSUERS_TRUSTED,
+    BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITIES_MATCH_TRUSTED_PROJECTION,
     BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENT_RESOURCE_LINKS,
     BETTER_AUTH_AUDIT_CHECKS.OAUTH_CLIENTS_CLASSIFIED,
     BETTER_AUTH_AUDIT_CHECKS.OAUTH_RESOURCE_REFERENCES,
@@ -574,8 +595,12 @@ export type BetterAuthAuditCheck = {
 };
 
 export type BetterAuthAuditBaseline = {
+  accountIdentityProjection: {
+    digest: string;
+    rowCount: string;
+  };
   accessPolicyDigest: string;
-  formatVersion: 2;
+  formatVersion: 3;
   tables: Record<
     string,
     {
@@ -587,6 +612,16 @@ export type BetterAuthAuditBaseline = {
   >;
 };
 
+export type BetterAuthTrustedIdentityMap = {
+  formatVersion: 1;
+  microsoftAccounts: readonly {
+    accountId: string;
+    accountRowId: string;
+    issuer: string;
+    legacyAccountId: string;
+  }[];
+};
+
 export type BetterAuthAuditReport = {
   checks: readonly BetterAuthAuditCheck[];
   mode: BetterAuthAuditMode;
@@ -595,7 +630,7 @@ export type BetterAuthAuditReport = {
 
 export class BetterAuthAuditError extends TaggedError("BetterAuthAuditError")<{
   cause?: unknown;
-  code: "database-query-failed" | "invalid-baseline";
+  code: "database-query-failed" | "invalid-baseline" | "invalid-identity-map";
   message: string;
 }> {}
 
@@ -643,6 +678,245 @@ const requiredString = (value: unknown): string | null =>
 
 const requiredBoolean = (value: unknown): boolean | null =>
   typeof value === "boolean" ? value : null;
+
+type AccountIdentityProjection = {
+  collisionFree: boolean;
+  digest: string;
+  mappingComplete: boolean;
+  rowCount: string;
+};
+
+const ACCOUNT_IDENTITY_PAGE_SIZE = 1000;
+
+const accountIdentityKeyDigest = (issuer: string, accountId: string) => {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(issuer);
+  hasher.update("\0");
+  hasher.update(accountId);
+  return hasher.digest("hex");
+};
+
+const updateAccountIdentityProjection = (
+  hasher: Bun.CryptoHasher,
+  accountRowId: string,
+  issuer: string,
+  accountId: string,
+) => {
+  hasher.update(accountRowId);
+  hasher.update("\0");
+  hasher.update(issuer);
+  hasher.update("\0");
+  hasher.update(accountId);
+  hasher.update("\0");
+};
+
+const readProjectedAccountIdentities = async (
+  database: BetterAuthAuditDatabase,
+  trustedIdentityMap: BetterAuthTrustedIdentityMap,
+) => {
+  const microsoftByAccountRowId = new Map(
+    trustedIdentityMap.microsoftAccounts.map((identity) => [
+      identity.accountRowId,
+      identity,
+    ]),
+  );
+  let mappingComplete =
+    microsoftByAccountRowId.size ===
+    trustedIdentityMap.microsoftAccounts.length;
+  const seenMicrosoftAccountRowIds = new Set<string>();
+  const projectionHasher = new Bun.CryptoHasher("sha256");
+  const microsoftIdentityKeys = new Set(
+    trustedIdentityMap.microsoftAccounts.map(({ accountId, issuer }) =>
+      accountIdentityKeyDigest(issuer, accountId),
+    ),
+  );
+  const collisionFree =
+    microsoftIdentityKeys.size === trustedIdentityMap.microsoftAccounts.length;
+  let after: string | null = null;
+  let rowCount = 0n;
+
+  while (true) {
+    const statement =
+      after === null
+        ? sql`
+            SELECT id AS "accountRowId",
+                   account_id AS "accountId",
+                   provider_id AS "providerId",
+                   user_id AS "userId"
+              FROM account
+             ORDER BY id
+             LIMIT ${ACCOUNT_IDENTITY_PAGE_SIZE}
+          `
+        : sql`
+            SELECT id AS "accountRowId",
+                   account_id AS "accountId",
+                   provider_id AS "providerId",
+                   user_id AS "userId"
+              FROM account
+             WHERE id > ${after}
+             ORDER BY id
+             LIMIT ${ACCOUNT_IDENTITY_PAGE_SIZE}
+          `;
+    // eslint-disable-next-line no-await-in-loop -- keyset pages must be read in primary-key order for one stable digest
+    const queried = await queryRows(database, statement);
+    if (Result.isError(queried)) {
+      return queried;
+    }
+
+    for (const row of queried.value) {
+      const accountRowId = isRecord(row)
+        ? requiredString(row["accountRowId"])
+        : null;
+      const currentAccountId = isRecord(row)
+        ? requiredString(row["accountId"])
+        : null;
+      const providerId = isRecord(row)
+        ? requiredString(row["providerId"])
+        : null;
+      const userId = isRecord(row) ? requiredString(row["userId"]) : null;
+      if (
+        accountRowId === null ||
+        currentAccountId === null ||
+        providerId === null ||
+        userId === null
+      ) {
+        return Result.err(
+          new BetterAuthAuditError({
+            code: "database-query-failed",
+            message:
+              "Better Auth account identity projection returned invalid data",
+          }),
+        );
+      }
+
+      let projectedIssuer = "local:invalid";
+      let projectedAccountId = currentAccountId;
+      const microsoftIdentity = microsoftByAccountRowId.get(accountRowId);
+      switch (providerId) {
+        case AUTH_PROVIDER_IDS.CREDENTIAL:
+          projectedIssuer = ACCOUNT_ISSUERS.CREDENTIAL;
+          projectedAccountId = userId;
+          if (microsoftIdentity !== undefined) {
+            mappingComplete = false;
+          }
+          break;
+        case AUTH_PROVIDER_IDS.GOOGLE:
+          projectedIssuer = ACCOUNT_ISSUERS.GOOGLE;
+          if (microsoftIdentity !== undefined) {
+            mappingComplete = false;
+          }
+          break;
+        case AUTH_PROVIDER_IDS.MICROSOFT:
+          if (
+            microsoftIdentity === undefined ||
+            microsoftIdentity.legacyAccountId !== currentAccountId
+          ) {
+            mappingComplete = false;
+            break;
+          }
+          seenMicrosoftAccountRowIds.add(accountRowId);
+          projectedIssuer = microsoftIdentity.issuer;
+          projectedAccountId = microsoftIdentity.accountId;
+          break;
+        default:
+          mappingComplete = false;
+      }
+
+      updateAccountIdentityProjection(
+        projectionHasher,
+        accountRowId,
+        projectedIssuer,
+        projectedAccountId,
+      );
+      after = accountRowId;
+      rowCount += 1n;
+    }
+
+    if (queried.value.length < ACCOUNT_IDENTITY_PAGE_SIZE) {
+      break;
+    }
+  }
+
+  if (
+    seenMicrosoftAccountRowIds.size !==
+    trustedIdentityMap.microsoftAccounts.length
+  ) {
+    mappingComplete = false;
+  }
+
+  return Result.ok({
+    collisionFree,
+    digest: projectionHasher.digest("hex"),
+    mappingComplete,
+    rowCount: rowCount.toString(),
+  } satisfies AccountIdentityProjection);
+};
+
+const readActualAccountIdentities = async (
+  database: BetterAuthAuditDatabase,
+) => {
+  const projectionHasher = new Bun.CryptoHasher("sha256");
+  let after: string | null = null;
+  let rowCount = 0n;
+
+  while (true) {
+    const statement =
+      after === null
+        ? sql`
+            SELECT id AS "accountRowId",
+                   issuer,
+                   account_id AS "accountId"
+              FROM account
+             ORDER BY id
+             LIMIT ${ACCOUNT_IDENTITY_PAGE_SIZE}
+          `
+        : sql`
+            SELECT id AS "accountRowId",
+                   issuer,
+                   account_id AS "accountId"
+              FROM account
+             WHERE id > ${after}
+             ORDER BY id
+             LIMIT ${ACCOUNT_IDENTITY_PAGE_SIZE}
+          `;
+    // eslint-disable-next-line no-await-in-loop -- keyset pages must be read in primary-key order for one stable digest
+    const queried = await queryRows(database, statement);
+    if (Result.isError(queried)) {
+      return queried;
+    }
+    for (const row of queried.value) {
+      const accountRowId = isRecord(row)
+        ? requiredString(row["accountRowId"])
+        : null;
+      const issuer = isRecord(row) ? requiredString(row["issuer"]) : null;
+      const accountId = isRecord(row) ? requiredString(row["accountId"]) : null;
+      if (accountRowId === null || issuer === null || accountId === null) {
+        return Result.err(
+          new BetterAuthAuditError({
+            code: "database-query-failed",
+            message:
+              "Better Auth account identity census returned invalid data",
+          }),
+        );
+      }
+      updateAccountIdentityProjection(
+        projectionHasher,
+        accountRowId,
+        issuer,
+        accountId,
+      );
+      after = accountRowId;
+      rowCount += 1n;
+    }
+    if (queried.value.length < ACCOUNT_IDENTITY_PAGE_SIZE) {
+      break;
+    }
+  }
+  return Result.ok({
+    digest: projectionHasher.digest("hex"),
+    rowCount: rowCount.toString(),
+  });
+};
 
 const tableInventoryStatement = sql`
   SELECT table_name AS "tableName"
@@ -919,6 +1193,25 @@ const credentialOwnershipStatement = sql`
      FROM account
      WHERE provider_id = ${AUTH_PROVIDER_IDS.CREDENTIAL}
        AND account_id IS DISTINCT FROM user_id
+  ) AS "passed"
+`;
+
+const nonMicrosoftProjectedIdentityUniqueStatement = sql`
+  SELECT NOT EXISTS (
+    SELECT 1
+      FROM account
+     WHERE provider_id <> ${AUTH_PROVIDER_IDS.MICROSOFT}
+     GROUP BY
+       CASE provider_id
+         WHEN ${AUTH_PROVIDER_IDS.CREDENTIAL} THEN ${ACCOUNT_ISSUERS.CREDENTIAL}
+         WHEN ${AUTH_PROVIDER_IDS.GOOGLE} THEN ${ACCOUNT_ISSUERS.GOOGLE}
+         ELSE 'local:invalid'
+       END,
+       CASE provider_id
+         WHEN ${AUTH_PROVIDER_IDS.CREDENTIAL} THEN user_id
+         ELSE account_id
+       END
+    HAVING count(*) > 1
   ) AS "passed"
 `;
 
@@ -1262,7 +1555,14 @@ const readTableCensus = async (
   const primaryKeyHasher = new Bun.CryptoHasher("sha256");
   const rowContentHasher = new Bun.CryptoHasher("sha256");
   const preservedValues = preservedColumns.map((column) =>
-    sql.identifier(column),
+    tableName === AUTH_TABLE_AUDIT_POLICY.account.tableName &&
+    column === "account_id"
+      ? sql`CASE
+              WHEN provider_id = ${AUTH_PROVIDER_IDS.MICROSOFT}
+                THEN ${MICROSOFT_ACCOUNT_ID_CENSUS_SENTINEL}
+              ELSE account_id
+            END`
+      : sql.identifier(column),
   );
   let after: string | null = null;
   let rowCount = 0n;
@@ -1411,9 +1711,11 @@ const report = (
 const createBaseline = (
   tables: BetterAuthAuditBaseline["tables"],
   accessPolicyDigest: string,
+  accountIdentityProjection: BetterAuthAuditBaseline["accountIdentityProjection"],
 ): BetterAuthAuditBaseline => ({
+  accountIdentityProjection,
   accessPolicyDigest,
-  formatVersion: 2,
+  formatVersion: 3,
   tables,
 });
 
@@ -1431,6 +1733,7 @@ const emptyBaseline = (): BetterAuthAuditBaseline =>
       ]),
     ),
     "0".repeat(64),
+    { digest: "0".repeat(64), rowCount: "0" },
   );
 
 type NamedAuditStatement = readonly [BetterAuthAuditCheckName, SQL];
@@ -1458,12 +1761,14 @@ type RunBetterAuthMigrationAuditOptions = {
   baseline: BetterAuthAuditBaseline | null;
   database: BetterAuthAuditDatabase;
   mode: BetterAuthAuditMode;
+  trustedIdentityMap: BetterAuthTrustedIdentityMap | null;
 };
 
 export const runBetterAuthMigrationAudit = async ({
   baseline,
   database,
   mode,
+  trustedIdentityMap,
 }: RunBetterAuthMigrationAuditOptions): Promise<
   Result<AuditRunResult, BetterAuthAuditError>
 > => {
@@ -1568,6 +1873,73 @@ export const runBetterAuthMigrationAudit = async ({
     return commonChecksEvaluated;
   }
 
+  let expectedAccountIdentityProjection: BetterAuthAuditBaseline["accountIdentityProjection"];
+  if (mode === BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION) {
+    if (trustedIdentityMap === null) {
+      return Result.err(
+        new BetterAuthAuditError({
+          code: "invalid-identity-map",
+          message:
+            "Better Auth trusted identity map is required before migration",
+        }),
+      );
+    }
+    const projection = await readProjectedAccountIdentities(
+      database,
+      trustedIdentityMap,
+    );
+    if (Result.isError(projection)) {
+      return projection;
+    }
+    const nonMicrosoftUnique = await booleanCheck(
+      database,
+      BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_PROJECTED_UNIQUE,
+      nonMicrosoftProjectedIdentityUniqueStatement,
+    );
+    if (Result.isError(nonMicrosoftUnique)) {
+      return nonMicrosoftUnique;
+    }
+    checks.push(
+      check(
+        BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_MAPPING_COMPLETE,
+        projection.value.mappingComplete,
+      ),
+      check(
+        BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_PROJECTED_UNIQUE,
+        projection.value.mappingComplete &&
+          projection.value.collisionFree &&
+          nonMicrosoftUnique.value.status === "passed",
+      ),
+    );
+    expectedAccountIdentityProjection = {
+      digest: projection.value.digest,
+      rowCount: projection.value.rowCount,
+    };
+  } else {
+    if (baseline === null) {
+      return Result.err(
+        new BetterAuthAuditError({
+          code: "invalid-baseline",
+          message: "Better Auth audit baseline is required after migration",
+        }),
+      );
+    }
+    const actualProjection = await readActualAccountIdentities(database);
+    if (Result.isError(actualProjection)) {
+      return actualProjection;
+    }
+    expectedAccountIdentityProjection = baseline.accountIdentityProjection;
+    checks.push(
+      check(
+        BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITIES_MATCH_TRUSTED_PROJECTION,
+        actualProjection.value.digest ===
+          baseline.accountIdentityProjection.digest &&
+          actualProjection.value.rowCount ===
+            baseline.accountIdentityProjection.rowCount,
+      ),
+    );
+  }
+
   if (mode !== BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION) {
     const postBackfillChecks = [
       [
@@ -1645,7 +2017,11 @@ export const runBetterAuthMigrationAudit = async ({
   if (Result.isError(census)) {
     return census;
   }
-  const nextBaseline = createBaseline(census.value, accessPolicyDigest.value);
+  const nextBaseline = createBaseline(
+    census.value,
+    accessPolicyDigest.value,
+    expectedAccountIdentityProjection,
+  );
   if (mode === BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION) {
     checks.push(check(BETTER_AUTH_AUDIT_CHECKS.AUTH_ROWS_BASELINED, true));
   } else {
@@ -1717,11 +2093,57 @@ const betterAuthAuditBaselineSchema: v.GenericSchema<
   unknown,
   BetterAuthAuditBaseline
 > = v.strictObject({
+  accountIdentityProjection: v.strictObject({
+    digest: digestSchema,
+    rowCount: rowCountSchema,
+  }),
   accessPolicyDigest: digestSchema,
-  formatVersion: v.literal(2),
+  formatVersion: v.literal(3),
   tables: v.strictObject(
     Object.fromEntries(
       AUTH_MODEL_NAMES.map((model) => [model, tableCensusSchema(model)]),
+    ),
+  ),
+});
+
+const GUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u;
+const MICROSOFT_ISSUER_PATTERN =
+  /^https:\/\/login\.microsoftonline\.com\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/v2\.0$/u;
+const nonEmptyStringSchema = v.pipe(
+  v.string(),
+  v.minLength(1),
+  v.maxLength(512),
+);
+const MAX_MICROSOFT_IDENTITY_MAPPINGS = 100_000;
+
+const betterAuthTrustedIdentityMapSchema: v.GenericSchema<
+  unknown,
+  BetterAuthTrustedIdentityMap
+> = v.strictObject({
+  formatVersion: v.literal(1),
+  microsoftAccounts: v.pipe(
+    v.array(
+      v.strictObject({
+        accountId: v.pipe(v.string(), v.regex(GUID_PATTERN)),
+        accountRowId: nonEmptyStringSchema,
+        issuer: v.pipe(v.string(), v.regex(MICROSOFT_ISSUER_PATTERN)),
+        legacyAccountId: nonEmptyStringSchema,
+      }),
+    ),
+    v.maxLength(MAX_MICROSOFT_IDENTITY_MAPPINGS),
+    v.check(
+      (accounts) =>
+        new Set(accounts.map(({ accountRowId }) => accountRowId)).size ===
+        accounts.length,
+      "Microsoft account row IDs must be unique",
+    ),
+    v.check(
+      (accounts) =>
+        new Set(
+          accounts.map(({ accountId, issuer }) => `${issuer}\0${accountId}`),
+        ).size === accounts.length,
+      "Microsoft account identities must be unique",
     ),
   ),
 });
@@ -1738,6 +2160,20 @@ export const parseBetterAuthAuditBaseline = (
     );
   const parsed = v.safeParse(betterAuthAuditBaselineSchema, value);
   return parsed.success ? Result.ok(parsed.output) : invalidBaseline();
+};
+
+export const parseBetterAuthTrustedIdentityMap = (
+  value: unknown,
+): Result<BetterAuthTrustedIdentityMap, BetterAuthAuditError> => {
+  const parsed = v.safeParse(betterAuthTrustedIdentityMapSchema, value);
+  return parsed.success
+    ? Result.ok(parsed.output)
+    : Result.err(
+        new BetterAuthAuditError({
+          code: "invalid-identity-map",
+          message: "Better Auth trusted identity map is invalid",
+        }),
+      );
 };
 
 export const renderBetterAuthAuditReport = (

--- a/apps/api/src/scripts/better-auth-migration-audit.logic.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.logic.ts
@@ -1320,39 +1320,44 @@ const columnInventoryStatement = sql`
 
 const PRIMARY_KEY_PAGE_SIZE = 1000;
 
-const foreignKeyOrphanStatements = AUTH_TABLE_POLICIES.flatMap((policy) =>
-  policy.foreignKeys.map(({ column, referencedColumn, referencedModel }) => {
-    const referenced = AUTH_TABLE_AUDIT_POLICY[referencedModel];
-    return sql`
-      EXISTS (
-        SELECT 1
-          FROM ${sql.identifier(policy.tableName)} child
-          LEFT JOIN ${sql.identifier(referenced.tableName)} parent
-            ON child.${sql.identifier(column)} = parent.${sql.identifier(referencedColumn)}
-         WHERE child.${sql.identifier(column)} IS NOT NULL
-           AND parent.${sql.identifier(referencedColumn)} IS NULL
-      )
-    `;
-  }),
-);
+const noForeignKeyOrphansStatement = (
+  policies: readonly AuthTableAuditPolicy[],
+) => {
+  const orphanStatements = policies.flatMap((policy) =>
+    policy.foreignKeys.map(({ column, referencedColumn, referencedModel }) => {
+      const referenced = AUTH_TABLE_AUDIT_POLICY[referencedModel];
+      return sql`
+        EXISTS (
+          SELECT 1
+            FROM ${sql.identifier(policy.tableName)} child
+            LEFT JOIN ${sql.identifier(referenced.tableName)} parent
+              ON child.${sql.identifier(column)} = parent.${sql.identifier(referencedColumn)}
+           WHERE child.${sql.identifier(column)} IS NOT NULL
+             AND parent.${sql.identifier(referencedColumn)} IS NULL
+        )
+      `;
+    }),
+  );
+  return sql`
+    SELECT NOT (${sql.join(orphanStatements, sql` OR `)}) AS "passed"
+  `;
+};
 
-const noForeignKeyOrphansStatement = sql`
-  SELECT NOT (${sql.join(foreignKeyOrphanStatements, sql` OR `)}) AS "passed"
-`;
-
-const expectedForeignKeys = AUTH_TABLE_POLICIES.flatMap((policy) =>
-  policy.foreignKeys.map(({ column, referencedColumn, referencedModel }) => {
-    const referenced = AUTH_TABLE_AUDIT_POLICY[referencedModel];
-    return sql`(
-      ${policy.tableName}::text,
-      ${column}::text,
-      ${referenced.tableName}::text,
-      ${referencedColumn}::text
-    )`;
-  }),
-);
-
-const foreignKeysValidatedStatement = sql`
+const foreignKeysValidatedStatement = (
+  policies: readonly AuthTableAuditPolicy[],
+) => {
+  const expectedForeignKeys = policies.flatMap((policy) =>
+    policy.foreignKeys.map(({ column, referencedColumn, referencedModel }) => {
+      const referenced = AUTH_TABLE_AUDIT_POLICY[referencedModel];
+      return sql`(
+        ${policy.tableName}::text,
+        ${column}::text,
+        ${referenced.tableName}::text,
+        ${referencedColumn}::text
+      )`;
+    }),
+  );
+  return sql`
   WITH expected(child_table, child_column, parent_table, parent_column) AS (
     VALUES ${sql.join(expectedForeignKeys, sql`, `)}
   )
@@ -1386,7 +1391,8 @@ const foreignKeysValidatedStatement = sql`
           AND parent_attribute.attname = expected.parent_column
      )
   ) AS "passed"
-`;
+  `;
+};
 
 const accessBoundariesStatement = (includeFutureTables: boolean) => {
   const policies: readonly AuthAccessPolicy[] = Object.values(
@@ -2254,11 +2260,11 @@ export const runBetterAuthMigrationAudit = async ({
   const commonChecks = [
     [
       BETTER_AUTH_AUDIT_CHECKS.AUTH_FOREIGN_KEYS_REACHABLE,
-      noForeignKeyOrphansStatement,
+      noForeignKeyOrphansStatement(requiredTablePolicies),
     ],
     [
       BETTER_AUTH_AUDIT_CHECKS.AUTH_FOREIGN_KEYS_VALIDATED,
-      foreignKeysValidatedStatement,
+      foreignKeysValidatedStatement(requiredTablePolicies),
     ],
     [
       BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_PROVIDERS_CLASSIFIED,

--- a/apps/api/src/scripts/better-auth-migration-audit.logic.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.logic.ts
@@ -753,7 +753,12 @@ type AuditRunResult = {
   report: BetterAuthAuditReport;
 };
 
-const queryRows = async (database: BetterAuthAuditDatabase, statement: SQL) => {
+type AuditRowsResult = Result<unknown[], BetterAuthAuditError>;
+
+const queryRows = async (
+  database: BetterAuthAuditDatabase,
+  statement: SQL,
+): Promise<AuditRowsResult> => {
   const queried = await Result.tryPromise({
     try: async () => await database.execute(statement),
     catch: (cause) =>
@@ -853,7 +858,9 @@ const readProjectedAccountIdentities = async (
   let after: string | null = null;
   let rowCount = 0n;
 
-  while (true) {
+  const readNextPage = async (): Promise<
+    Result<void, BetterAuthAuditError>
+  > => {
     const statement =
       after === null
         ? sql`
@@ -875,10 +882,9 @@ const readProjectedAccountIdentities = async (
              ORDER BY id
              LIMIT ${ACCOUNT_IDENTITY_PAGE_SIZE}
           `;
-    // eslint-disable-next-line no-await-in-loop -- keyset pages must be read in primary-key order for one stable digest
     const queried = await queryRows(database, statement);
     if (Result.isError(queried)) {
-      return queried;
+      return Result.err(queried.error);
     }
 
     for (const row of queried.value) {
@@ -950,9 +956,13 @@ const readProjectedAccountIdentities = async (
       rowCount += 1n;
     }
 
-    if (queried.value.length < ACCOUNT_IDENTITY_PAGE_SIZE) {
-      break;
-    }
+    return queried.value.length < ACCOUNT_IDENTITY_PAGE_SIZE
+      ? Result.ok(undefined)
+      : readNextPage();
+  };
+  const pagesRead = await readNextPage();
+  if (Result.isError(pagesRead)) {
+    return Result.err(pagesRead.error);
   }
 
   if (
@@ -977,7 +987,9 @@ const readActualAccountIdentities = async (
   let after: string | null = null;
   let rowCount = 0n;
 
-  while (true) {
+  const readNextPage = async (): Promise<
+    Result<void, BetterAuthAuditError>
+  > => {
     const statement =
       after === null
         ? sql`
@@ -997,10 +1009,9 @@ const readActualAccountIdentities = async (
              ORDER BY id
              LIMIT ${ACCOUNT_IDENTITY_PAGE_SIZE}
           `;
-    // eslint-disable-next-line no-await-in-loop -- keyset pages must be read in primary-key order for one stable digest
     const queried = await queryRows(database, statement);
     if (Result.isError(queried)) {
-      return queried;
+      return Result.err(queried.error);
     }
     for (const row of queried.value) {
       const accountRowId = isRecord(row)
@@ -1026,9 +1037,13 @@ const readActualAccountIdentities = async (
       after = accountRowId;
       rowCount += 1n;
     }
-    if (queried.value.length < ACCOUNT_IDENTITY_PAGE_SIZE) {
-      break;
-    }
+    return queried.value.length < ACCOUNT_IDENTITY_PAGE_SIZE
+      ? Result.ok(undefined)
+      : readNextPage();
+  };
+  const pagesRead = await readNextPage();
+  if (Result.isError(pagesRead)) {
+    return Result.err(pagesRead.error);
   }
   return Result.ok({
     digest: projectionHasher.digest("hex"),
@@ -1102,7 +1117,9 @@ const readProjectedOAuthPolicy = async (
   let clientCount = 0n;
   let valid = initialized.valid;
 
-  while (true) {
+  const readNextPage = async (): Promise<
+    Result<void, BetterAuthAuditError>
+  > => {
     const statement =
       after === null
         ? sql`
@@ -1124,10 +1141,9 @@ const readProjectedOAuthPolicy = async (
              ORDER BY client_id
              LIMIT ${OAUTH_POLICY_PAGE_SIZE}
           `;
-    // eslint-disable-next-line no-await-in-loop -- keyset pages must feed one ordered policy digest
     const queried = await queryRows(database, statement);
     if (Result.isError(queried)) {
-      return queried;
+      return Result.err(queried.error);
     }
     for (const row of queried.value) {
       const clientId = isRecord(row) ? requiredString(row["clientId"]) : null;
@@ -1168,9 +1184,13 @@ const readProjectedOAuthPolicy = async (
       after = clientId;
       clientCount += 1n;
     }
-    if (queried.value.length < OAUTH_POLICY_PAGE_SIZE) {
-      break;
-    }
+    return queried.value.length < OAUTH_POLICY_PAGE_SIZE
+      ? Result.ok(undefined)
+      : readNextPage();
+  };
+  const pagesRead = await readNextPage();
+  if (Result.isError(pagesRead)) {
+    return Result.err(pagesRead.error);
   }
 
   return Result.ok({
@@ -1215,7 +1235,9 @@ const readActualOAuthPolicy = async (database: BetterAuthAuditDatabase) => {
   let after: string | null = null;
   let clientCount = 0n;
   let valid = initialized.valid;
-  while (true) {
+  const readNextPage = async (): Promise<
+    Result<void, BetterAuthAuditError>
+  > => {
     const statement =
       after === null
         ? sql`
@@ -1247,10 +1269,9 @@ const readActualOAuthPolicy = async (database: BetterAuthAuditDatabase) => {
              ORDER BY client.client_id
              LIMIT ${OAUTH_POLICY_PAGE_SIZE}
           `;
-    // eslint-disable-next-line no-await-in-loop -- keyset pages must feed one ordered policy digest
     const queried = await queryRows(database, statement);
     if (Result.isError(queried)) {
-      return queried;
+      return Result.err(queried.error);
     }
     for (const row of queried.value) {
       const clientId = isRecord(row) ? requiredString(row["clientId"]) : null;
@@ -1293,9 +1314,13 @@ const readActualOAuthPolicy = async (database: BetterAuthAuditDatabase) => {
       after = clientId;
       clientCount += 1n;
     }
-    if (queried.value.length < OAUTH_POLICY_PAGE_SIZE) {
-      break;
-    }
+    return queried.value.length < OAUTH_POLICY_PAGE_SIZE
+      ? Result.ok(undefined)
+      : readNextPage();
+  };
+  const pagesRead = await readNextPage();
+  if (Result.isError(pagesRead)) {
+    return Result.err(pagesRead.error);
   }
   return Result.ok({
     clientCount: clientCount.toString(),

--- a/apps/api/src/scripts/better-auth-migration-audit.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { chmod, mkdtemp, rm, symlink } from "node:fs/promises";
+import { chmod, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -7,12 +7,14 @@ import {
   parseBetterAuthAuditArgs,
   persistBetterAuthAuditBaseline,
   readBetterAuthAuditBaseline,
+  readBetterAuthTrustedIdentityMap,
 } from "@/api/scripts/better-auth-migration-audit";
 import {
   AUTH_TABLE_AUDIT_POLICY,
   BETTER_AUTH_AUDIT_CHECKS,
   BETTER_AUTH_AUDIT_MODES,
   parseBetterAuthAuditBaseline,
+  parseBetterAuthTrustedIdentityMap,
   renderBetterAuthAuditReport,
 } from "@/api/scripts/better-auth-migration-audit.logic";
 import type { BetterAuthAuditReport } from "@/api/scripts/better-auth-migration-audit.logic";
@@ -28,8 +30,12 @@ afterAll(async () => {
 });
 
 const baselinePayload = () => ({
+  accountIdentityProjection: {
+    digest: "d".repeat(64),
+    rowCount: "7",
+  },
   accessPolicyDigest: "c".repeat(64),
-  formatVersion: 2,
+  formatVersion: 3,
   tables: Object.fromEntries(
     Object.entries(AUTH_TABLE_AUDIT_POLICY).map(([model, policy]) => [
       model,
@@ -43,27 +49,58 @@ const baselinePayload = () => ({
   ),
 });
 
+const identityMapPayload = () =>
+  ({
+    formatVersion: 1,
+    microsoftAccounts: [
+      {
+        accountId: "71c02436-6600-42fd-84d0-417484a177b0",
+        accountRowId: "account-row-1",
+        issuer:
+          "https://login.microsoftonline.com/3a893563-0d4e-4309-9a31-b6e4e9f64479/v2.0",
+        legacyAccountId: "legacy-subject",
+      },
+    ],
+  }) as const;
+
 describe("Better Auth migration audit command", () => {
-  test("requires one explicit mode and a private baseline path", () => {
+  test("requires an identity map before migration and only a baseline after it", () => {
     expect(
       parseBetterAuthAuditArgs([
         BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
         "--baseline",
         "/private/baseline.json",
+        "--identity-map",
+        "/private/identity-map.json",
       ]),
     ).toMatchObject({
       status: "ok",
       value: {
         baselinePath: "/private/baseline.json",
+        identityMapPath: "/private/identity-map.json",
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
       },
     });
+    expect(
+      parseBetterAuthAuditArgs([
+        BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+        "--baseline",
+        "/private/baseline.json",
+      ]).status,
+    ).toBe("ok");
     for (const args of [
       [],
       [BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION],
       ["unknown", "--baseline", "/private/baseline.json"],
       [BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION, "--output", "x"],
       [BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION, "--baseline", ""],
+      [
+        BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        "--baseline",
+        "x",
+        "--identity-map",
+        "",
+      ],
       [BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION, "--baseline", "x", "extra"],
     ]) {
       expect(parseBetterAuthAuditArgs(args).status).toBe("error");
@@ -73,7 +110,7 @@ describe("Better Auth migration audit command", () => {
   test("rejects incomplete, expanded, or malformed private baselines", () => {
     expect(parseBetterAuthAuditBaseline(baselinePayload()).status).toBe("ok");
     expect(
-      parseBetterAuthAuditBaseline({ formatVersion: 2, tables: {} }).status,
+      parseBetterAuthAuditBaseline({ formatVersion: 3, tables: {} }).status,
     ).toBe("error");
     const expanded = baselinePayload();
     expanded.tables["unreviewedAuthTable"] = {
@@ -104,6 +141,52 @@ describe("Better Auth migration audit command", () => {
       duplicateColumnTable.preservedColumns.push(duplicated);
     }
     expect(parseBetterAuthAuditBaseline(duplicateColumn).status).toBe("error");
+  });
+
+  test("accepts only canonical, unique Microsoft identity mappings", () => {
+    const mapping = identityMapPayload();
+
+    expect(parseBetterAuthTrustedIdentityMap(mapping).status).toBe("ok");
+    expect(
+      parseBetterAuthTrustedIdentityMap({
+        ...mapping,
+        microsoftAccounts: [
+          ...mapping.microsoftAccounts,
+          mapping.microsoftAccounts[0],
+        ],
+      }).status,
+    ).toBe("error");
+    expect(
+      parseBetterAuthTrustedIdentityMap({
+        ...mapping,
+        microsoftAccounts: [
+          { ...mapping.microsoftAccounts[0], accountId: "not-an-oid" },
+        ],
+      }).status,
+    ).toBe("error");
+  });
+
+  test("reads the trusted map only from a private regular file", async () => {
+    const directory = await mkdtemp(
+      path.join(tmpdir(), "stella-better-auth-identity-map-"),
+    );
+    temporaryDirectories.push(directory);
+    const mapPath = path.join(directory, "identity-map.json");
+    await writeFile(mapPath, JSON.stringify(identityMapPayload()), {
+      mode: 0o600,
+    });
+    expect((await readBetterAuthTrustedIdentityMap(mapPath)).status).toBe("ok");
+
+    await chmod(mapPath, 0o644);
+    expect((await readBetterAuthTrustedIdentityMap(mapPath)).status).toBe(
+      "error",
+    );
+    await chmod(mapPath, 0o600);
+    const linkedPath = path.join(directory, "linked-identity-map.json");
+    await symlink(mapPath, linkedPath);
+    expect((await readBetterAuthTrustedIdentityMap(linkedPath)).status).toBe(
+      "error",
+    );
   });
 
   test("creates the baseline once, accepts an identical rerun, and refuses replacement", async () => {

--- a/apps/api/src/scripts/better-auth-migration-audit.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@/api/scripts/better-auth-migration-audit";
 import {
   AUTH_TABLE_AUDIT_POLICY,
+  AUTH_BASELINE_MODEL_NAMES,
   BETTER_AUTH_AUDIT_CHECKS,
   BETTER_AUTH_AUDIT_MODES,
   parseBetterAuthAuditBaseline,
@@ -42,10 +43,10 @@ const baselinePayload = () => ({
     resourceCount: "3",
   },
   tables: Object.fromEntries(
-    Object.entries(AUTH_TABLE_AUDIT_POLICY).map(([model, policy]) => [
+    AUTH_BASELINE_MODEL_NAMES.map((model) => [
       model,
       {
-        preservedColumns: [...policy.preservedColumns],
+        preservedColumns: [...AUTH_TABLE_AUDIT_POLICY[model].preservedColumns],
         primaryKeyDigest: "a".repeat(64),
         rowContentDigest: "b".repeat(64),
         rowCount: "7",
@@ -77,6 +78,8 @@ describe("Better Auth migration audit command", () => {
         "/private/baseline.json",
         "--identity-map",
         "/private/identity-map.json",
+        "--oauth-base-url",
+        "https://api.stll.app",
       ]),
     ).toMatchObject({
       status: "ok",
@@ -84,6 +87,7 @@ describe("Better Auth migration audit command", () => {
         baselinePath: "/private/baseline.json",
         identityMapPath: "/private/identity-map.json",
         mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        oauthBaseUrl: "https://api.stll.app",
       },
     });
     expect(
@@ -91,6 +95,8 @@ describe("Better Auth migration audit command", () => {
         BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
         "--baseline",
         "/private/baseline.json",
+        "--oauth-base-url",
+        "https://api.stll.app/",
       ]).status,
     ).toBe("ok");
     for (const args of [
@@ -107,6 +113,20 @@ describe("Better Auth migration audit command", () => {
         "",
       ],
       [BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION, "--baseline", "x", "extra"],
+      [
+        BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+        "--baseline",
+        "x",
+        "--oauth-base-url",
+        "http://api.stll.app",
+      ],
+      [
+        BETTER_AUTH_AUDIT_MODES.POST_BACKFILL,
+        "--baseline",
+        "x",
+        "--oauth-base-url",
+        "https://api.stll.app/auth",
+      ],
     ]) {
       expect(parseBetterAuthAuditArgs(args).status).toBe("error");
     }

--- a/apps/api/src/scripts/better-auth-migration-audit.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.test.ts
@@ -35,7 +35,12 @@ const baselinePayload = () => ({
     rowCount: "7",
   },
   accessPolicyDigest: "c".repeat(64),
-  formatVersion: 3,
+  formatVersion: 4,
+  oauthPolicyProjection: {
+    clientCount: "3",
+    digest: "e".repeat(64),
+    resourceCount: "3",
+  },
   tables: Object.fromEntries(
     Object.entries(AUTH_TABLE_AUDIT_POLICY).map(([model, policy]) => [
       model,
@@ -110,7 +115,7 @@ describe("Better Auth migration audit command", () => {
   test("rejects incomplete, expanded, or malformed private baselines", () => {
     expect(parseBetterAuthAuditBaseline(baselinePayload()).status).toBe("ok");
     expect(
-      parseBetterAuthAuditBaseline({ formatVersion: 3, tables: {} }).status,
+      parseBetterAuthAuditBaseline({ formatVersion: 4, tables: {} }).status,
     ).toBe("error");
     const expanded = baselinePayload();
     expanded.tables["unreviewedAuthTable"] = {

--- a/apps/api/src/scripts/better-auth-migration-audit.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.ts
@@ -1,7 +1,7 @@
 /**
  * Usage:
- *   bun src/scripts/better-auth-migration-audit.ts pre-migration --baseline <path> --identity-map <path>
- *   bun src/scripts/better-auth-migration-audit.ts <post-mode> --baseline <path>
+ *   bun src/scripts/better-auth-migration-audit.ts pre-migration --baseline <path> --identity-map <path> --oauth-base-url <https-origin>
+ *   bun src/scripts/better-auth-migration-audit.ts <post-mode> --baseline <path> --oauth-base-url <https-origin>
  *
  * The baseline belongs on the rehearsal task's private tmpfs. It contains
  * auth-table counts and primary-key digests, and must never be uploaded as an
@@ -17,6 +17,10 @@ import { open, writeFile } from "node:fs/promises";
 
 import { hasSecureDatabaseTransport, resolveDatabaseUrl } from "@/api/db-url";
 import { isRecord } from "@/api/lib/type-guards";
+import {
+  buildBetterAuthOAuthResources,
+  normalizeBetterAuthOAuthBaseUrl,
+} from "@/api/mcp/resource-policy-contract";
 import {
   BETTER_AUTH_AUDIT_MODES,
   BetterAuthAuditError,
@@ -41,7 +45,7 @@ const TRANSACTION_TIMEOUT = "60s";
 const LOCK_TIMEOUT = "2s";
 const MAX_TRUSTED_IDENTITY_MAP_BYTES = 16 * 1024 * 1024;
 
-class BetterAuthAuditCommandError extends TaggedError(
+export class BetterAuthAuditCommandError extends TaggedError(
   "BetterAuthAuditCommandError",
 )<{
   code:
@@ -58,6 +62,7 @@ type BetterAuthAuditCommandArgs =
       baselinePath: string;
       identityMapPath: string;
       mode: typeof BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION;
+      oauthBaseUrl: string;
     }
   | {
       baselinePath: string;
@@ -65,6 +70,7 @@ type BetterAuthAuditCommandArgs =
         BetterAuthAuditMode,
         typeof BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION
       >;
+      oauthBaseUrl: string;
     };
 
 const isAuditMode = (value: string): value is BetterAuthAuditMode =>
@@ -76,12 +82,18 @@ export const parseBetterAuthAuditArgs = (
   const mode = args.at(0);
   const baselineFlag = args.at(1);
   const baselinePath = args.at(2);
+  const oauthBaseUrlFlag = args.at(
+    mode === BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION ? 5 : 3,
+  );
+  const oauthBaseUrl = args.at(
+    mode === BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION ? 6 : 4,
+  );
   const invalidArguments = () =>
     Result.err(
       new BetterAuthAuditCommandError({
         code: "invalid-arguments",
         message:
-          "Usage: better-auth-migration-audit pre-migration --baseline <private-path> --identity-map <private-path> | <post-backfill|post-migration> --baseline <private-path>",
+          "Usage: better-auth-migration-audit pre-migration --baseline <private-path> --identity-map <private-path> --oauth-base-url <https-url> | <post-backfill|post-migration> --baseline <private-path> --oauth-base-url <https-url>",
       }),
     );
   if (
@@ -89,8 +101,14 @@ export const parseBetterAuthAuditArgs = (
     !isAuditMode(mode) ||
     baselineFlag !== "--baseline" ||
     baselinePath === undefined ||
-    baselinePath.length === 0
+    baselinePath.length === 0 ||
+    oauthBaseUrlFlag !== "--oauth-base-url" ||
+    oauthBaseUrl === undefined
   ) {
+    return invalidArguments();
+  }
+  const normalizedOAuthBaseUrl = normalizeBetterAuthOAuthBaseUrl(oauthBaseUrl);
+  if (normalizedOAuthBaseUrl === null) {
     return invalidArguments();
   }
   if (mode === BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION) {
@@ -99,12 +117,21 @@ export const parseBetterAuthAuditArgs = (
     return identityMapFlag === "--identity-map" &&
       identityMapPath !== undefined &&
       identityMapPath.length > 0 &&
-      args.length === 5
-      ? Result.ok({ baselinePath, identityMapPath, mode })
+      args.length === 7
+      ? Result.ok({
+          baselinePath,
+          identityMapPath,
+          mode,
+          oauthBaseUrl: normalizedOAuthBaseUrl,
+        })
       : invalidArguments();
   }
-  return args.length === 3
-    ? Result.ok({ baselinePath, mode })
+  return args.length === 5
+    ? Result.ok({
+        baselinePath,
+        mode,
+        oauthBaseUrl: normalizedOAuthBaseUrl,
+      })
     : invalidArguments();
 };
 
@@ -278,12 +305,9 @@ const run = async (
     );
   }
 
-  // Load runtime OAuth policy only after command validation. Its MCP URL source
-  // owns environment initialization, while this module is also imported by
-  // argument/parser tests that must remain side-effect free.
-  const { getBetterAuthOAuthResources } =
-    await import("@/api/lib/oauth-resource-policy");
-  const expectedOAuthResources = getBetterAuthOAuthResources();
+  const expectedOAuthResources = buildBetterAuthOAuthResources(
+    parsed.value.oauthBaseUrl,
+  );
   const client = new SQL({ url: databaseUrl, max: 1 });
   const database = drizzle({ client });
   const executed = await Result.tryPromise({

--- a/apps/api/src/scripts/better-auth-migration-audit.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.ts
@@ -278,6 +278,12 @@ const run = async (
     );
   }
 
+  // Load runtime OAuth policy only after command validation. Its MCP URL source
+  // owns environment initialization, while this module is also imported by
+  // argument/parser tests that must remain side-effect free.
+  const { getBetterAuthOAuthResources } =
+    await import("@/api/lib/oauth-resource-policy");
+  const expectedOAuthResources = getBetterAuthOAuthResources();
   const client = new SQL({ url: databaseUrl, max: 1 });
   const database = drizzle({ client });
   const executed = await Result.tryPromise({
@@ -300,6 +306,7 @@ const run = async (
           database: {
             execute: async (statement) => await transaction.execute(statement),
           },
+          expectedOAuthResources,
           mode: parsed.value.mode,
           trustedIdentityMap,
         });

--- a/apps/api/src/scripts/better-auth-migration-audit.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.ts
@@ -1,6 +1,7 @@
 /**
  * Usage:
- *   bun src/scripts/better-auth-migration-audit.ts <mode> --baseline <path>
+ *   bun src/scripts/better-auth-migration-audit.ts pre-migration --baseline <path> --identity-map <path>
+ *   bun src/scripts/better-auth-migration-audit.ts <post-mode> --baseline <path>
  *
  * The baseline belongs on the rehearsal task's private tmpfs. It contains
  * auth-table counts and primary-key digests, and must never be uploaded as an
@@ -20,12 +21,14 @@ import {
   BETTER_AUTH_AUDIT_MODES,
   BetterAuthAuditError,
   parseBetterAuthAuditBaseline,
+  parseBetterAuthTrustedIdentityMap,
   renderBetterAuthAuditReport,
   runBetterAuthMigrationAudit,
 } from "@/api/scripts/better-auth-migration-audit.logic";
 import type {
   BetterAuthAuditBaseline,
   BetterAuthAuditMode,
+  BetterAuthTrustedIdentityMap,
 } from "@/api/scripts/better-auth-migration-audit.logic";
 
 const EXIT_CODE = {
@@ -36,6 +39,7 @@ const EXIT_CODE = {
 
 const TRANSACTION_TIMEOUT = "60s";
 const LOCK_TIMEOUT = "2s";
+const MAX_TRUSTED_IDENTITY_MAP_BYTES = 16 * 1024 * 1024;
 
 class BetterAuthAuditCommandError extends TaggedError(
   "BetterAuthAuditCommandError",
@@ -44,14 +48,24 @@ class BetterAuthAuditCommandError extends TaggedError(
     | "baseline-conflict"
     | "baseline-read-failed"
     | "baseline-write-failed"
+    | "identity-map-read-failed"
     | "invalid-arguments";
   message: string;
 }> {}
 
-type BetterAuthAuditCommandArgs = {
-  baselinePath: string;
-  mode: BetterAuthAuditMode;
-};
+type BetterAuthAuditCommandArgs =
+  | {
+      baselinePath: string;
+      identityMapPath: string;
+      mode: typeof BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION;
+    }
+  | {
+      baselinePath: string;
+      mode: Exclude<
+        BetterAuthAuditMode,
+        typeof BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION
+      >;
+    };
 
 const isAuditMode = (value: string): value is BetterAuthAuditMode =>
   Object.values(BETTER_AUTH_AUDIT_MODES).some((mode) => mode === value);
@@ -62,23 +76,36 @@ export const parseBetterAuthAuditArgs = (
   const mode = args.at(0);
   const baselineFlag = args.at(1);
   const baselinePath = args.at(2);
+  const invalidArguments = () =>
+    Result.err(
+      new BetterAuthAuditCommandError({
+        code: "invalid-arguments",
+        message:
+          "Usage: better-auth-migration-audit pre-migration --baseline <private-path> --identity-map <private-path> | <post-backfill|post-migration> --baseline <private-path>",
+      }),
+    );
   if (
     mode === undefined ||
     !isAuditMode(mode) ||
     baselineFlag !== "--baseline" ||
     baselinePath === undefined ||
-    baselinePath.length === 0 ||
-    args.length !== 3
+    baselinePath.length === 0
   ) {
-    return Result.err(
-      new BetterAuthAuditCommandError({
-        code: "invalid-arguments",
-        message:
-          "Usage: better-auth-migration-audit <pre-migration|post-backfill|post-migration> --baseline <private-path>",
-      }),
-    );
+    return invalidArguments();
   }
-  return Result.ok({ baselinePath, mode });
+  if (mode === BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION) {
+    const identityMapFlag = args.at(3);
+    const identityMapPath = args.at(4);
+    return identityMapFlag === "--identity-map" &&
+      identityMapPath !== undefined &&
+      identityMapPath.length > 0 &&
+      args.length === 5
+      ? Result.ok({ baselinePath, identityMapPath, mode })
+      : invalidArguments();
+  }
+  return args.length === 3
+    ? Result.ok({ baselinePath, mode })
+    : invalidArguments();
 };
 
 const isNodeErrorCode = (value: unknown, code: string): boolean =>
@@ -119,6 +146,48 @@ export const readBetterAuthAuditBaseline = async (
     return loaded;
   }
   return parseBetterAuthAuditBaseline(loaded.value);
+};
+
+export const readBetterAuthTrustedIdentityMap = async (
+  path: string,
+): Promise<
+  Result<
+    BetterAuthTrustedIdentityMap,
+    BetterAuthAuditCommandError | BetterAuthAuditError
+  >
+> => {
+  const loaded = await Result.tryPromise({
+    try: async () => {
+      const handle = await open(path, constants.O_NOFOLLOW);
+      try {
+        const metadata = await handle.stat();
+        if (
+          !metadata.isFile() ||
+          metadata.mode % 0o100 !== 0 ||
+          metadata.size > MAX_TRUSTED_IDENTITY_MAP_BYTES
+        ) {
+          throw new BetterAuthAuditCommandError({
+            code: "identity-map-read-failed",
+            message:
+              "Better Auth trusted identity map is not a private regular file",
+          });
+        }
+        const parsed: unknown = JSON.parse(await handle.readFile("utf-8"));
+        return parsed;
+      } finally {
+        await handle.close();
+      }
+    },
+    catch: () =>
+      new BetterAuthAuditCommandError({
+        code: "identity-map-read-failed",
+        message: "Better Auth trusted identity map could not be read",
+      }),
+  });
+  if (Result.isError(loaded)) {
+    return loaded;
+  }
+  return parseBetterAuthTrustedIdentityMap(loaded.value);
 };
 
 /**
@@ -180,6 +249,7 @@ const run = async (
   }
 
   let baseline: BetterAuthAuditBaseline | null = null;
+  let trustedIdentityMap: BetterAuthTrustedIdentityMap | null = null;
   if (parsed.value.mode !== BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION) {
     const loadedBaseline = await readBetterAuthAuditBaseline(
       parsed.value.baselinePath,
@@ -188,6 +258,14 @@ const run = async (
       return loadedBaseline;
     }
     baseline = loadedBaseline.value;
+  } else {
+    const loadedIdentityMap = await readBetterAuthTrustedIdentityMap(
+      parsed.value.identityMapPath,
+    );
+    if (Result.isError(loadedIdentityMap)) {
+      return loadedIdentityMap;
+    }
+    trustedIdentityMap = loadedIdentityMap.value;
   }
 
   const databaseUrl = resolveDatabaseUrl();
@@ -223,6 +301,7 @@ const run = async (
             execute: async (statement) => await transaction.execute(statement),
           },
           mode: parsed.value.mode,
+          trustedIdentityMap,
         });
       }),
     catch: (cause) =>

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -118,6 +118,11 @@ const POST_BOOTSTRAP_DENY_STELLA_TABLES = new Set([
   "agent_trusted_issuer",
   "agent_delegation",
   "agent_assertion_replay",
+  // Better Auth OAuth control-plane state. Request-role access would expose
+  // resource policy or let tenant traffic change token authorization rules.
+  "oauth_resource",
+  "oauth_client_resource",
+  "oauth_client_assertion",
   // Machine API keys: credential digests plus the permission set each key
   // carries. A tenant-scoped connection must be able to neither read a digest
   // nor widen a key's permissions, so every access goes through better-auth on


### PR DESCRIPTION
## Summary

- Add the Better Auth 1.7 additive database bridge while the application remains on Better Auth 1.6.26.
- Add exact preflight evidence, a bounded identity and OAuth resource backfill, and post-backfill/final audit modes.
- Add a protected workflow that builds an immutable API image from an exact commit on main without deploying it.

## Migration safety

- The additive migration introduces nullable columns and new tables only; it does not apply the 1.7 runtime or final constraints.
- Preflight uses only tables that exist before the bridge, records an exact operator-supplied trusted identity baseline, and rejects ownership corruption, orphaned rows, ambiguous identities, and schema drift.
- Backfill requires an explicit write freeze, has a configured row bound, runs transactionally, and must reach a fixed point.
- New OAuth control-plane tables deny the request database role and are covered by the table-grant guard.
- The image workflow accepts only a protected lowercase 40-character main commit and emits provenance for the exact artifact.

## Rollout boundary

This PR is phase one only. The Better Auth 1.7 dependency update and final NOT NULL/uniqueness cutover will land in a follow-up PR only after this bridge is deployed, the restored-data rehearsal passes, the backfill reaches a fixed point, and post-backfill evidence is accepted. Production promotion remains a separate explicit go/no-go.

## Verification

- `bun run verify`
- 22 focused migration, schema, backfill, and RLS tests
- 55 ratchets at or below baseline
- Repository-wide type-aware lint, native TypeScript, test, security, generated-contract, and release guards