### PR TITLE
feat: define final corpus index manifests

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -87,7 +87,7 @@ type CorpusIndexFieldMapping = {
  * the engine's defaults, restated: a merge policy declared by halves is harder
  * to reason about than one declared whole.
  */
-const MERGE_POLICY = {
+export const CORPUS_INDEX_MERGE_POLICY = {
   type: "stable_log",
   maturation_period: "7days",
   merge_factor: 10,
@@ -114,7 +114,7 @@ export type CorpusIndexConfig = {
     store_source: boolean;
   };
   indexing_settings: {
-    merge_policy: typeof MERGE_POLICY;
+    merge_policy: typeof CORPUS_INDEX_MERGE_POLICY;
   };
   search_settings: {
     default_search_fields: string[];
@@ -123,7 +123,11 @@ export type CorpusIndexConfig = {
 
 export const CORPUS_INDEX_CONFIG_VERSION = "0.8";
 
-const DATE_INPUT_FORMATS = ["%Y-%m-%d", "rfc3339", "unix_timestamp"];
+export const CORPUS_INDEX_DATE_INPUT_FORMATS = [
+  "%Y-%m-%d",
+  "rfc3339",
+  "unix_timestamp",
+];
 
 // Fields every family shares. `document_id` is the stable join key back
 // to Postgres; `text`/`title` carry BM25.
@@ -337,7 +341,7 @@ const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
       indexed: true,
       stored: true,
       fast: true,
-      input_formats: DATE_INPUT_FORMATS,
+      input_formats: CORPUS_INDEX_DATE_INPUT_FORMATS,
     },
     {
       name: DECISION_TIMESTAMP_FIELD,
@@ -346,7 +350,7 @@ const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
       stored: true,
       fast: true,
       fast_precision: "seconds",
-      input_formats: DATE_INPUT_FORMATS,
+      input_formats: CORPUS_INDEX_DATE_INPUT_FORMATS,
     },
     {
       name: "ecli",
@@ -393,7 +397,7 @@ const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
       indexed: true,
       stored: true,
       fast: true,
-      input_formats: DATE_INPUT_FORMATS,
+      input_formats: CORPUS_INDEX_DATE_INPUT_FORMATS,
     },
     // The consolidation's point-in-time validity window, half-open
     // `[version_valid_from, version_valid_to)`: the text in force on date D is
@@ -418,7 +422,7 @@ const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
       indexed: true,
       stored: true,
       fast: true,
-      input_formats: DATE_INPUT_FORMATS,
+      input_formats: CORPUS_INDEX_DATE_INPUT_FORMATS,
     },
     {
       name: "version_valid_to",
@@ -426,7 +430,7 @@ const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
       indexed: true,
       stored: true,
       fast: true,
-      input_formats: DATE_INPUT_FORMATS,
+      input_formats: CORPUS_INDEX_DATE_INPUT_FORMATS,
     },
     // European Legislation Identifier / national statute number.
     {
@@ -525,7 +529,7 @@ export const corpusIndexConfig = (
       ...(timestampField === null ? {} : { timestamp_field: timestampField }),
       store_source: false,
     },
-    indexing_settings: { merge_policy: MERGE_POLICY },
+    indexing_settings: { merge_policy: CORPUS_INDEX_MERGE_POLICY },
     search_settings: {
       // The rule under a passage layout: no field that repeats across a
       // document's passages may be a default search field. One free-text term

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
@@ -37,9 +37,9 @@ test("manifest digests pin every semantic array and ignore object key order", ()
   expect(corpusIndexManifestDigest(CORPUS_INDEX_MANIFESTS.case_law_v5)).toBe(
     EXPECTED_DIGESTS.case_law_v5,
   );
-  expect(
-    corpusIndexManifestDigest(CORPUS_INDEX_MANIFESTS.legislation_v2),
-  ).toBe(EXPECTED_DIGESTS.legislation_v2);
+  expect(corpusIndexManifestDigest(CORPUS_INDEX_MANIFESTS.legislation_v2)).toBe(
+    EXPECTED_DIGESTS.legislation_v2,
+  );
   for (const digest of Object.values(EXPECTED_DIGESTS)) {
     expect(digest).toMatch(/^[0-9a-f]{64}$/u);
   }
@@ -180,7 +180,8 @@ test("final manifests make every storage and index cost explicit", () => {
         ({ name }) => name,
       ),
     );
-    for (const field of manifest.engine.indexConfig.doc_mapping.field_mappings) {
+    for (const field of manifest.engine.indexConfig.doc_mapping
+      .field_mappings) {
       expect(typeof field.indexed).toBe("boolean");
       expect(typeof field.stored).toBe("boolean");
       expect(typeof field.fast).toBe("boolean");

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
@@ -1,0 +1,263 @@
+import { expect, test } from "bun:test";
+
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexConfigFromManifest,
+  corpusIndexManifestDigest,
+  requireCorpusIndexManifest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+
+const EXPECTED_DIGESTS = {
+  case_law_v5:
+    "95c84d0c4a841ab65b69469824cdde3c0c438e310fa004927ddf26af1ea4b60d",
+  legislation_v2:
+    "9ab1f962750f78cd4472a05551f6e265d55f428e0fb94de9b15467b61f24f9dd",
+} as const satisfies Record<keyof typeof CORPUS_INDEX_MANIFESTS, string>;
+
+test("the final-generation registry is exact and fails closed", () => {
+  expect(Object.keys(CORPUS_INDEX_MANIFESTS).sort()).toEqual([
+    "case_law_v5",
+    "legislation_v2",
+  ]);
+  expect(requireCorpusIndexManifest("case_law", "case_law_v5")).toBe(
+    CORPUS_INDEX_MANIFESTS.case_law_v5,
+  );
+  expect(requireCorpusIndexManifest("legislation", "legislation_v2")).toBe(
+    CORPUS_INDEX_MANIFESTS.legislation_v2,
+  );
+  expect(() => requireCorpusIndexManifest("case_law", "case_law_v4")).toThrow(
+    "Unknown case-law index manifest: case_law_v4",
+  );
+  expect(() =>
+    requireCorpusIndexManifest("legislation", "legislation_v1"),
+  ).toThrow("Unknown legislation index manifest: legislation_v1");
+});
+
+test("manifest digests pin every semantic array and ignore object key order", () => {
+  expect(corpusIndexManifestDigest(CORPUS_INDEX_MANIFESTS.case_law_v5)).toBe(
+    EXPECTED_DIGESTS.case_law_v5,
+  );
+  expect(
+    corpusIndexManifestDigest(CORPUS_INDEX_MANIFESTS.legislation_v2),
+  ).toBe(EXPECTED_DIGESTS.legislation_v2);
+  for (const digest of Object.values(EXPECTED_DIGESTS)) {
+    expect(digest).toMatch(/^[0-9a-f]{64}$/u);
+  }
+
+  const manifest = CORPUS_INDEX_MANIFESTS.case_law_v5;
+  const rootKeysReordered = {
+    route: manifest.route,
+    projection: manifest.projection,
+    engine: manifest.engine,
+    cluster: manifest.cluster,
+    generation: manifest.generation,
+    family: manifest.family,
+    schemaVersion: manifest.schemaVersion,
+  } satisfies typeof manifest;
+  expect(corpusIndexManifestDigest(rootKeysReordered)).toBe(
+    EXPECTED_DIGESTS.case_law_v5,
+  );
+
+  const tagOrderChanged = {
+    ...manifest,
+    engine: {
+      ...manifest.engine,
+      indexConfig: {
+        ...manifest.engine.indexConfig,
+        doc_mapping: {
+          ...manifest.engine.indexConfig.doc_mapping,
+          tag_fields: [
+            ...manifest.engine.indexConfig.doc_mapping.tag_fields,
+          ].reverse(),
+        },
+      },
+    },
+  };
+  expect(corpusIndexManifestDigest(tagOrderChanged)).not.toBe(
+    EXPECTED_DIGESTS.case_law_v5,
+  );
+});
+
+test("physical index ids are deployment state, not manifest identity", () => {
+  const manifest = CORPUS_INDEX_MANIFESTS.case_law_v5;
+  const csSkConfig = corpusIndexConfigFromManifest(
+    manifest,
+    "case_law_v5_cs_sk",
+  );
+  expect(csSkConfig).toEqual({
+    ...manifest.engine.indexConfig,
+    index_id: "case_law_v5_cs_sk",
+  });
+  expect(corpusIndexConfigFromManifest(manifest, "case_law_v5_pol")).toEqual({
+    ...manifest.engine.indexConfig,
+    index_id: "case_law_v5_pol",
+  });
+  expect(corpusIndexManifestDigest(manifest)).toBe(
+    EXPECTED_DIGESTS.case_law_v5,
+  );
+
+  csSkConfig.doc_mapping.tag_fields.reverse();
+  expect(manifest.engine.indexConfig.doc_mapping.tag_fields).toEqual([
+    "jurisdiction",
+    "document_type",
+    "source",
+    "court",
+    "language",
+  ]);
+});
+
+test("v5 removes stale and repeated physical fields", () => {
+  const manifest = CORPUS_INDEX_MANIFESTS.case_law_v5;
+  const fields = new Map(
+    manifest.engine.indexConfig.doc_mapping.field_mappings.map((field) => [
+      field.name,
+      field,
+    ]),
+  );
+  expect(manifest.engine.binaryVersion).toBe("0.9.0");
+  expect(manifest.engine.indexConfig.version).toBe("0.8");
+  expect(manifest.engine.indexConfig.doc_mapping.mode).toBe("strict");
+  expect(manifest.engine.indexConfig.doc_mapping.timestamp_field).toBe(
+    "decision_date_ts",
+  );
+  expect(manifest.engine.indexConfig.doc_mapping.tokenizers).toEqual([
+    {
+      name: "folded",
+      type: "simple",
+      filters: ["lower_caser", "ascii_folding", "remove_long"],
+    },
+  ]);
+  expect(fields.get("document_id")).toMatchObject({
+    tokenizer: "raw",
+    indexed: true,
+    stored: true,
+    fast: false,
+  });
+  expect(fields.get("projection_revision")).toMatchObject({
+    tokenizer: "raw",
+    indexed: true,
+    stored: true,
+    fast: false,
+  });
+  expect(fields.get("is_opening")).toEqual({
+    name: "is_opening",
+    type: "bool",
+    indexed: true,
+    stored: false,
+    fast: false,
+  });
+  expect(fields.get("title")).toMatchObject({
+    tokenizer: "folded",
+    indexed: true,
+    stored: false,
+    fast: false,
+  });
+  expect(fields.get("text")).toMatchObject({
+    tokenizer: "folded",
+    indexed: true,
+    stored: true,
+    fast: false,
+  });
+  expect(fields.get("anchor_id")).toEqual({
+    name: "anchor_id",
+    type: "text",
+    indexed: false,
+    stored: true,
+    fast: false,
+  });
+  expect(fields.get("decision_date_ts")).toMatchObject({
+    type: "datetime",
+    indexed: true,
+    stored: false,
+    fast: true,
+    fast_precision: "seconds",
+  });
+
+});
+
+test("final manifests make every storage and index cost explicit", () => {
+  for (const manifest of Object.values(CORPUS_INDEX_MANIFESTS)) {
+    const fields = new Set(
+      manifest.engine.indexConfig.doc_mapping.field_mappings.map(
+        ({ name }) => name,
+      ),
+    );
+    for (const field of manifest.engine.indexConfig.doc_mapping.field_mappings) {
+      expect(typeof field.indexed).toBe("boolean");
+      expect(typeof field.stored).toBe("boolean");
+      expect(typeof field.fast).toBe("boolean");
+    }
+    for (const absent of [
+      "year",
+      "seq",
+      "chunk_id",
+      "heading_path",
+      "citation_authority",
+      "citation_count",
+      "canonical_text_key",
+      "canonical_ast_key",
+    ]) {
+      expect(fields.has(absent)).toBe(false);
+    }
+    expect(manifest.engine.indexConfig.doc_mapping.store_source).toBe(false);
+    expect(manifest.engine.indexConfig.search_settings).toEqual({
+      default_search_fields: ["title", "text"],
+    });
+  }
+});
+
+test("published manifests are immutable snapshots", () => {
+  expect(Object.isFrozen(CORPUS_INDEX_MANIFESTS)).toBe(true);
+  for (const manifest of Object.values(CORPUS_INDEX_MANIFESTS)) {
+    const tokenizerFilters =
+      manifest.engine.indexConfig.doc_mapping.tokenizers.at(0)?.filters;
+    expect(Object.isFrozen(manifest)).toBe(true);
+    expect(Object.isFrozen(manifest.engine.indexConfig)).toBe(true);
+    expect(
+      Object.isFrozen(manifest.engine.indexConfig.doc_mapping.field_mappings),
+    ).toBe(true);
+    expect(
+      Object.isFrozen(manifest.engine.indexConfig.doc_mapping.tag_fields),
+    ).toBe(true);
+    expect(tokenizerFilters).toEqual([
+      "lower_caser",
+      "ascii_folding",
+      "remove_long",
+    ]);
+    expect(Object.isFrozen(tokenizerFilters)).toBe(true);
+  }
+});
+
+test("route topology and tag pruning are part of the manifest", () => {
+  const caseLaw = CORPUS_INDEX_MANIFESTS.case_law_v5;
+  expect(caseLaw.route).toEqual({
+    type: "case_law_group",
+    byJurisdiction: {
+      AUT: "aut",
+      CZE: "cs_sk",
+      EU: "eu",
+      POL: "pol",
+      SVK: "cs_sk",
+    },
+  });
+  expect(caseLaw.engine.indexConfig.doc_mapping.tag_fields).toEqual([
+    "jurisdiction",
+    "document_type",
+    "source",
+    "court",
+    "language",
+  ]);
+
+  const legislation = CORPUS_INDEX_MANIFESTS.legislation_v2;
+  // Plane may add a jurisdiction without changing the public routing rule:
+  // every legislation jurisdiction always receives its own physical index.
+  expect(legislation.route).toEqual({ type: "jurisdiction" });
+  expect(legislation.engine.indexConfig.doc_mapping.mode).toBe("strict");
+  expect(legislation.engine.indexConfig.doc_mapping.tag_fields).toEqual([
+    "jurisdiction",
+    "document_type",
+    "source",
+    "status",
+    "language",
+  ]);
+});

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
@@ -66,9 +66,8 @@ test("manifest digests pin every semantic array and ignore object key order", ()
         ...manifest.engine.indexConfig,
         doc_mapping: {
           ...manifest.engine.indexConfig.doc_mapping,
-          tag_fields: [
-            ...manifest.engine.indexConfig.doc_mapping.tag_fields,
-          ].toReversed(),
+          tag_fields:
+            manifest.engine.indexConfig.doc_mapping.tag_fields.toReversed(),
         },
       },
     },
@@ -172,7 +171,6 @@ test("v5 removes stale and repeated physical fields", () => {
     fast: true,
     fast_precision: "seconds",
   });
-
 });
 
 test("final manifests make every storage and index cost explicit", () => {

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
@@ -68,7 +68,7 @@ test("manifest digests pin every semantic array and ignore object key order", ()
           ...manifest.engine.indexConfig.doc_mapping,
           tag_fields: [
             ...manifest.engine.indexConfig.doc_mapping.tag_fields,
-          ].reverse(),
+          ].toReversed(),
         },
       },
     },

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -244,7 +244,7 @@ export const requireCorpusIndexManifest = (
         ? CORPUS_INDEX_MANIFESTS.legislation_v2
         : panic(`Unknown legislation index manifest: ${generation}`);
     default:
-      return panic(`Unknown corpus index manifest family: ${family}`);
+      return panic("Unknown corpus index manifest family");
   }
 };
 

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -285,10 +285,7 @@ const canonicalJson = (value: unknown): string => {
     compareCanonicalJsonKeys(left, right),
   );
   return `{${entries
-    .map(
-      ([key, entry]) =>
-        `${JSON.stringify(key)}:${canonicalJson(entry)}`,
-    )
+    .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
     .join(",")}}`;
 };
 

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -244,8 +244,18 @@ export const requireCorpusIndexManifest = (
         ? CORPUS_INDEX_MANIFESTS.legislation_v2
         : panic(`Unknown legislation index manifest: ${generation}`);
     default:
-      return family satisfies never;
+      return panic(`Unknown corpus index manifest family: ${family}`);
   }
+};
+
+const compareCanonicalJsonKeys = (left: string, right: string): number => {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
 };
 
 const canonicalJson = (value: unknown): string => {
@@ -254,11 +264,11 @@ const canonicalJson = (value: unknown): string => {
     typeof value === "boolean" ||
     typeof value === "string"
   ) {
-    return JSON.stringify(value) ?? panic("Canonical JSON primitive failed");
+    return JSON.stringify(value);
   }
   if (typeof value === "number") {
     return Number.isFinite(value)
-      ? (JSON.stringify(value) ?? panic("Canonical JSON number failed"))
+      ? JSON.stringify(value)
       : panic("Canonical JSON forbids non-finite numbers");
   }
   if (Array.isArray(value)) {
@@ -267,17 +277,17 @@ const canonicalJson = (value: unknown): string => {
   if (typeof value !== "object") {
     return panic(`Canonical JSON forbids ${typeof value}`);
   }
-  const prototype = Object.getPrototypeOf(value);
+  const prototype = Reflect.getPrototypeOf(value);
   if (prototype !== Object.prototype && prototype !== null) {
     return panic("Canonical JSON accepts plain objects only");
   }
   const entries = Object.entries(value).sort(([left], [right]) =>
-    left < right ? -1 : left > right ? 1 : 0,
+    compareCanonicalJsonKeys(left, right),
   );
   return `{${entries
     .map(
       ([key, entry]) =>
-        `${JSON.stringify(key) ?? panic("Canonical JSON key failed")}:${canonicalJson(entry)}`,
+        `${JSON.stringify(key)}:${canonicalJson(entry)}`,
     )
     .join(",")}}`;
 };

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -50,8 +50,7 @@ type LegislationV2Manifest = CorpusIndexManifestBase & {
 };
 
 export type CorpusIndexManifest = CaseLawV5Manifest | LegislationV2Manifest;
-export type CorpusIndexManifestGeneration =
-  CorpusIndexManifest["generation"];
+export type CorpusIndexManifestGeneration = CorpusIndexManifest["generation"];
 
 type CorpusIndexFieldMapping =
   CorpusIndexConfig["doc_mapping"]["field_mappings"][number];
@@ -292,9 +291,7 @@ const canonicalJson = (value: unknown): string => {
 export const corpusIndexManifestDigest = (
   manifest: CorpusIndexManifest,
 ): string =>
-  new Bun.CryptoHasher("sha256")
-    .update(canonicalJson(manifest))
-    .digest("hex");
+  new Bun.CryptoHasher("sha256").update(canonicalJson(manifest)).digest("hex");
 
 export const corpusIndexConfigFromManifest = (
   manifest: CorpusIndexManifest,

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -1,0 +1,298 @@
+import { panic } from "better-result";
+
+import { CASE_LAW_INDEX_GROUP_OF } from "@/api/lib/legal-search/case-law-index-groups";
+import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
+import {
+  CORPUS_INDEX_CONFIG_VERSION,
+  CORPUS_INDEX_DATE_INPUT_FORMATS,
+  CORPUS_INDEX_MERGE_POLICY,
+  DECISION_TIMESTAMP_FIELD,
+  FOLDED_TOKENIZER,
+  type CorpusIndexConfig,
+} from "@/api/lib/legal-search/corpus-index-config";
+
+export const CORPUS_INDEX_MANIFEST_SCHEMA_VERSION = 1;
+export const QUICKWIT_V09_BINARY_VERSION = "0.9.0";
+
+type CorpusIndexProjectionContract = {
+  documentIdField: "document_id";
+  projectionRevisionField: "projection_revision";
+  openingField: "is_opening";
+};
+
+type CorpusIndexManifestBase = {
+  schemaVersion: typeof CORPUS_INDEX_MANIFEST_SCHEMA_VERSION;
+  cluster: "q09";
+  engine: {
+    binaryVersion: typeof QUICKWIT_V09_BINARY_VERSION;
+    indexConfig: Omit<CorpusIndexConfig, "index_id">;
+  };
+};
+
+type CaseLawV5Manifest = CorpusIndexManifestBase & {
+  family: "case_law";
+  generation: "case_law_v5";
+  projection: CorpusIndexProjectionContract & { layout: "passage" };
+  route: {
+    type: "case_law_group";
+    byJurisdiction: typeof CASE_LAW_INDEX_GROUP_OF;
+  };
+};
+
+type LegislationV2Manifest = CorpusIndexManifestBase & {
+  family: "legislation";
+  generation: "legislation_v2";
+  projection: CorpusIndexProjectionContract & { layout: "document" };
+  // The routing rule is fixed while the jurisdiction set is deliberately
+  // open: adding a corpus creates another jurisdiction index without changing
+  // the manifest. Plane decides which jurisdictions to build and when.
+  route: { type: "jurisdiction" };
+};
+
+export type CorpusIndexManifest = CaseLawV5Manifest | LegislationV2Manifest;
+export type CorpusIndexManifestGeneration =
+  CorpusIndexManifest["generation"];
+
+type CorpusIndexFieldMapping =
+  CorpusIndexConfig["doc_mapping"]["field_mappings"][number];
+
+const rawField = (
+  name: string,
+  options: { stored: boolean; fast: boolean },
+): CorpusIndexFieldMapping => ({
+  name,
+  type: "text",
+  tokenizer: "raw",
+  indexed: true,
+  stored: options.stored,
+  fast: options.fast,
+});
+
+const dateField = (name: string): CorpusIndexFieldMapping => ({
+  name,
+  type: "datetime",
+  indexed: true,
+  stored: false,
+  fast: true,
+  input_formats: CORPUS_INDEX_DATE_INPUT_FORMATS,
+});
+
+const commonFields = (): CorpusIndexFieldMapping[] => [
+  rawField("document_id", { stored: true, fast: false }),
+  rawField("projection_revision", { stored: true, fast: false }),
+  rawField("jurisdiction", { stored: false, fast: true }),
+  rawField("document_type", { stored: false, fast: true }),
+  rawField("source", { stored: false, fast: true }),
+  rawField("language", { stored: false, fast: true }),
+  {
+    name: "title",
+    type: "text",
+    tokenizer: FOLDED_TOKENIZER.name,
+    record: "position",
+    fieldnorms: true,
+    indexed: true,
+    stored: false,
+    fast: false,
+  },
+  {
+    name: "text",
+    type: "text",
+    tokenizer: FOLDED_TOKENIZER.name,
+    record: "position",
+    fieldnorms: true,
+    indexed: true,
+    stored: true,
+    fast: false,
+  },
+  {
+    name: "is_opening",
+    type: "bool",
+    indexed: true,
+    stored: false,
+    fast: false,
+  },
+];
+
+const indexConfig = (
+  fieldMappings: CorpusIndexFieldMapping[],
+  tagFields: string[],
+  timestampField?: string,
+): Omit<CorpusIndexConfig, "index_id"> => ({
+  version: CORPUS_INDEX_CONFIG_VERSION,
+  doc_mapping: {
+    mode: "strict",
+    field_mappings: fieldMappings,
+    tokenizers: [FOLDED_TOKENIZER],
+    tag_fields: tagFields,
+    ...(timestampField === undefined
+      ? {}
+      : { timestamp_field: timestampField }),
+    store_source: false,
+  },
+  indexing_settings: { merge_policy: CORPUS_INDEX_MERGE_POLICY },
+  search_settings: { default_search_fields: ["title", "text"] },
+});
+
+const deepFreeze = <T>(value: T): T => {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  for (const child of Object.values(value)) {
+    deepFreeze(child);
+  }
+  Object.freeze(value);
+  return value;
+};
+
+const CASE_LAW_V5_INDEX_CONFIG = deepFreeze(
+  structuredClone(
+    indexConfig(
+      [
+        ...commonFields(),
+        {
+          name: "anchor_id",
+          type: "text",
+          indexed: false,
+          stored: true,
+          fast: false,
+        },
+        rawField("case_number", { stored: false, fast: false }),
+        rawField("court", { stored: false, fast: true }),
+        dateField("decision_date"),
+        {
+          ...dateField(DECISION_TIMESTAMP_FIELD),
+          fast_precision: "seconds",
+        },
+        rawField("ecli", { stored: false, fast: false }),
+      ],
+      ["jurisdiction", "document_type", "source", "court", "language"],
+      DECISION_TIMESTAMP_FIELD,
+    ),
+  ),
+);
+
+const LEGISLATION_V2_INDEX_CONFIG = deepFreeze(
+  structuredClone(
+    indexConfig(
+      [
+        ...commonFields(),
+        rawField("status", { stored: false, fast: true }),
+        dateField("effective_date"),
+        dateField("version_valid_from"),
+        dateField("version_valid_to"),
+        rawField("eli", { stored: false, fast: false }),
+      ],
+      ["jurisdiction", "document_type", "source", "status", "language"],
+    ),
+  ),
+);
+
+export const CORPUS_INDEX_MANIFESTS = deepFreeze({
+  case_law_v5: {
+    schemaVersion: CORPUS_INDEX_MANIFEST_SCHEMA_VERSION,
+    family: "case_law",
+    generation: "case_law_v5",
+    cluster: "q09",
+    engine: {
+      binaryVersion: QUICKWIT_V09_BINARY_VERSION,
+      indexConfig: CASE_LAW_V5_INDEX_CONFIG,
+    },
+    projection: {
+      layout: "passage",
+      documentIdField: "document_id",
+      projectionRevisionField: "projection_revision",
+      openingField: "is_opening",
+    },
+    route: {
+      type: "case_law_group",
+      byJurisdiction: { ...CASE_LAW_INDEX_GROUP_OF },
+    },
+  },
+  legislation_v2: {
+    schemaVersion: CORPUS_INDEX_MANIFEST_SCHEMA_VERSION,
+    family: "legislation",
+    generation: "legislation_v2",
+    cluster: "q09",
+    engine: {
+      binaryVersion: QUICKWIT_V09_BINARY_VERSION,
+      indexConfig: LEGISLATION_V2_INDEX_CONFIG,
+    },
+    projection: {
+      layout: "document",
+      documentIdField: "document_id",
+      projectionRevisionField: "projection_revision",
+      openingField: "is_opening",
+    },
+    route: { type: "jurisdiction" },
+  },
+} as const satisfies Record<
+  CorpusIndexManifestGeneration,
+  CorpusIndexManifest
+>);
+
+export const requireCorpusIndexManifest = (
+  family: CorpusFamily,
+  generation: string,
+): CorpusIndexManifest => {
+  switch (family) {
+    case "case_law":
+      return generation === "case_law_v5"
+        ? CORPUS_INDEX_MANIFESTS.case_law_v5
+        : panic(`Unknown case-law index manifest: ${generation}`);
+    case "legislation":
+      return generation === "legislation_v2"
+        ? CORPUS_INDEX_MANIFESTS.legislation_v2
+        : panic(`Unknown legislation index manifest: ${generation}`);
+    default:
+      return family satisfies never;
+  }
+};
+
+const canonicalJson = (value: unknown): string => {
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "string"
+  ) {
+    return JSON.stringify(value) ?? panic("Canonical JSON primitive failed");
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value)
+      ? (JSON.stringify(value) ?? panic("Canonical JSON number failed"))
+      : panic("Canonical JSON forbids non-finite numbers");
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (typeof value !== "object") {
+    return panic(`Canonical JSON forbids ${typeof value}`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return panic("Canonical JSON accepts plain objects only");
+  }
+  const entries = Object.entries(value).sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  );
+  return `{${entries
+    .map(
+      ([key, entry]) =>
+        `${JSON.stringify(key) ?? panic("Canonical JSON key failed")}:${canonicalJson(entry)}`,
+    )
+    .join(",")}}`;
+};
+
+export const corpusIndexManifestDigest = (
+  manifest: CorpusIndexManifest,
+): string =>
+  new Bun.CryptoHasher("sha256")
+    .update(canonicalJson(manifest))
+    .digest("hex");
+
+export const corpusIndexConfigFromManifest = (
+  manifest: CorpusIndexManifest,
+  indexId: string,
+): CorpusIndexConfig => {
+  const config = structuredClone(manifest.engine.indexConfig);
+  return { ...config, index_id: indexId };
+};


### PR DESCRIPTION
## Summary

- define immutable, digest-bound Quickwit 0.9 manifests for case-law v5 and legislation v2
- remove physical storage pointers and repeated legacy ranking fields from the final index shape
- freeze route topology, tokenizer filters, mapping costs, and projection revision fields into deterministic Bun-native SHA-256 identities
- keep the manifests inert until generation-aware writers and readers land

## Safety

This change does not create an index, select a serving generation, or alter current v1/v2 writes. Strict-mode activation remains gated on writers emitting `projection_revision` and `is_opening`.

## Verification

- independent read-only schema review found no Quickwit 0.9-invalid mappings
- deterministic digest and runtime immutability tests included
- `git diff --check`
- full validation delegated to CI to avoid loading the development machine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced versioned index manifests for case law and legislation search data.
  - Added consistent index configurations, routing, field mappings and search defaults across supported legal content.
  - Added safeguards to reject unknown index generations and verify configuration integrity.
  - Added stable fingerprints for detecting meaningful index configuration changes.

- **Bug Fixes**
  - Standardised date handling across legal search fields to improve indexing consistency.
  - Improved protection against configuration changes that could affect search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->