### PR TITLE
feat: add durable corpus projection intents

### DIFF
--- a/apps/api/drizzle/20260825142000_corpus_index_projection_intents/migration.sql
+++ b/apps/api/drizzle/20260825142000_corpus_index_projection_intents/migration.sql
@@ -1,0 +1,659 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+ALTER TABLE "case_law_decisions"
+  ADD COLUMN "projection_epoch" bigint DEFAULT 0 NOT NULL,
+  ADD CONSTRAINT "case_law_decisions_projection_epoch_nonnegative"
+    CHECK ("projection_epoch" >= 0) NOT VALID;--> statement-breakpoint
+
+ALTER TABLE "legislation_documents"
+  ADD COLUMN "projection_epoch" bigint DEFAULT 0 NOT NULL,
+  ADD CONSTRAINT "legislation_documents_projection_epoch_nonnegative"
+    CHECK ("projection_epoch" >= 0) NOT VALID;--> statement-breakpoint
+
+CREATE TABLE "corpus_index_projection_intents" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "family" text NOT NULL,
+  "generation" varchar(32) NOT NULL,
+  "entity_id" uuid NOT NULL,
+  "epoch" bigint NOT NULL,
+  "fingerprint" varchar(64) NOT NULL,
+  "index_id" varchar(64) NOT NULL,
+  "status" text NOT NULL,
+  "lease_token" uuid,
+  "lease_expires_at" timestamptz,
+  "append_started_at" timestamptz,
+  "append_committed_at" timestamptz,
+  "applied_at" timestamptz,
+  "append_publish_barrier_at" timestamptz,
+  "cleanup_not_before" timestamptz,
+  "cleanup_started_at" timestamptz,
+  "delete_opstamp" bigint,
+  "settled_at" timestamptz,
+  "cancelled_at" timestamptz,
+  "cleanup_attempts" integer DEFAULT 0 NOT NULL,
+  "last_error" varchar(2048),
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "corpus_index_projection_intents_generation_fk"
+    FOREIGN KEY ("family", "generation")
+    REFERENCES "corpus_index_generations" ("family", "generation")
+    ON DELETE RESTRICT,
+  CONSTRAINT "corpus_index_projection_intents_family_values"
+    CHECK ("family" IN ('case_law','legislation')),
+  CONSTRAINT "corpus_index_projection_intents_status_values"
+    CHECK ("status" IN (
+      'reserved','append_started','append_committed','applied',
+      'cleanup_pending','cleanup_started','cleanup_committed','settled','cancelled'
+    )),
+  CONSTRAINT "corpus_index_projection_intents_epoch_positive"
+    CHECK ("epoch" > 0),
+  CONSTRAINT "corpus_index_projection_intents_fingerprint_shape"
+    CHECK ("fingerprint" ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT "corpus_index_projection_intents_index_id_shape"
+    CHECK ("index_id" ~ '^[a-z0-9_]+$'),
+  CONSTRAINT "corpus_index_projection_intents_lease_shape"
+    CHECK (("lease_token" IS NULL) = ("lease_expires_at" IS NULL)),
+  CONSTRAINT "corpus_index_projection_intents_cleanup_attempts_nonnegative"
+    CHECK ("cleanup_attempts" >= 0),
+  CONSTRAINT "corpus_index_projection_intents_delete_opstamp_nonnegative"
+    CHECK ("delete_opstamp" IS NULL OR "delete_opstamp" >= 0),
+  CONSTRAINT "corpus_index_projection_intents_status_shape"
+    CHECK (CASE "status"
+      WHEN 'reserved' THEN
+        "lease_token" IS NOT NULL
+        AND "append_started_at" IS NULL
+        AND "append_committed_at" IS NULL
+        AND "applied_at" IS NULL
+        AND "append_publish_barrier_at" IS NULL
+        AND "cleanup_not_before" IS NULL
+        AND "cleanup_started_at" IS NULL
+        AND "delete_opstamp" IS NULL
+        AND "settled_at" IS NULL
+        AND "cancelled_at" IS NULL
+      WHEN 'append_started' THEN
+        "lease_token" IS NOT NULL
+        AND "append_started_at" IS NOT NULL
+        AND "append_committed_at" IS NULL
+        AND "applied_at" IS NULL
+        AND "append_publish_barrier_at" IS NULL
+        AND "cleanup_not_before" IS NULL
+        AND "cleanup_started_at" IS NULL
+        AND "delete_opstamp" IS NULL
+        AND "settled_at" IS NULL
+        AND "cancelled_at" IS NULL
+      WHEN 'append_committed' THEN
+        "lease_token" IS NOT NULL
+        AND "append_started_at" IS NOT NULL
+        AND "append_committed_at" IS NOT NULL
+        AND "applied_at" IS NULL
+        AND "append_publish_barrier_at" IS NULL
+        AND "cleanup_not_before" IS NULL
+        AND "cleanup_started_at" IS NULL
+        AND "delete_opstamp" IS NULL
+        AND "settled_at" IS NULL
+        AND "cancelled_at" IS NULL
+      WHEN 'applied' THEN
+        "lease_token" IS NULL
+        AND "append_started_at" IS NOT NULL
+        AND "append_committed_at" IS NOT NULL
+        AND "applied_at" IS NOT NULL
+        AND "append_publish_barrier_at" IS NULL
+        AND "cleanup_not_before" IS NULL
+        AND "cleanup_started_at" IS NULL
+        AND "delete_opstamp" IS NULL
+        AND "settled_at" IS NULL
+        AND "cancelled_at" IS NULL
+      WHEN 'cleanup_pending' THEN
+        "append_started_at" IS NOT NULL
+        AND "append_publish_barrier_at" IS NOT NULL
+        AND "cleanup_not_before" IS NOT NULL
+        AND "cleanup_started_at" IS NULL
+        AND "delete_opstamp" IS NULL
+        AND "settled_at" IS NULL
+        AND "cancelled_at" IS NULL
+      WHEN 'cleanup_started' THEN
+        "append_started_at" IS NOT NULL
+        AND "append_publish_barrier_at" IS NOT NULL
+        AND "cleanup_not_before" IS NOT NULL
+        AND "cleanup_started_at" IS NOT NULL
+        AND "delete_opstamp" IS NULL
+        AND "settled_at" IS NULL
+        AND "cancelled_at" IS NULL
+      WHEN 'cleanup_committed' THEN
+        "append_started_at" IS NOT NULL
+        AND "append_publish_barrier_at" IS NOT NULL
+        AND "cleanup_not_before" IS NOT NULL
+        AND "cleanup_started_at" IS NOT NULL
+        AND "delete_opstamp" IS NOT NULL
+        AND "settled_at" IS NULL
+        AND "cancelled_at" IS NULL
+      WHEN 'settled' THEN
+        "lease_token" IS NULL
+        AND "append_started_at" IS NOT NULL
+        AND "append_publish_barrier_at" IS NOT NULL
+        AND "cleanup_not_before" IS NOT NULL
+        AND "cleanup_started_at" IS NOT NULL
+        AND "delete_opstamp" IS NOT NULL
+        AND "settled_at" IS NOT NULL
+        AND "cancelled_at" IS NULL
+      WHEN 'cancelled' THEN
+        "lease_token" IS NULL
+        AND "append_started_at" IS NULL
+        AND "append_committed_at" IS NULL
+        AND "applied_at" IS NULL
+        AND "append_publish_barrier_at" IS NULL
+        AND "cleanup_not_before" IS NULL
+        AND "cleanup_started_at" IS NULL
+        AND "delete_opstamp" IS NULL
+        AND "settled_at" IS NULL
+        AND "cancelled_at" IS NOT NULL
+      ELSE false
+    END),
+  CONSTRAINT "corpus_index_projection_intents_cleanup_order"
+    CHECK ("cleanup_not_before" IS NULL OR (
+      "cleanup_not_before" >= "append_publish_barrier_at"
+      AND ("cleanup_started_at" IS NULL OR "cleanup_started_at" >= "cleanup_not_before")
+      AND ("settled_at" IS NULL OR "settled_at" >= "cleanup_started_at")
+    )),
+  CONSTRAINT "corpus_index_projection_intents_append_order"
+    CHECK (("append_committed_at" IS NULL OR "append_committed_at" >= "append_started_at")
+      AND ("applied_at" IS NULL OR "applied_at" >= "append_committed_at")
+      AND ("append_publish_barrier_at" IS NULL OR "append_publish_barrier_at" >= "append_started_at"))
+);--> statement-breakpoint
+
+CREATE UNIQUE INDEX "corpus_index_projection_intents_live_epoch_uidx"
+  ON "corpus_index_projection_intents" ("family", "generation", "entity_id", "epoch")
+  WHERE "status" NOT IN ('settled', 'cancelled');--> statement-breakpoint
+
+CREATE UNIQUE INDEX "corpus_index_projection_intents_identity_uidx"
+  ON "corpus_index_projection_intents"
+  ("id", "family", "generation", "entity_id", "epoch", "fingerprint", "index_id");--> statement-breakpoint
+
+CREATE INDEX "corpus_index_projection_intents_work_idx"
+  ON "corpus_index_projection_intents"
+  ("family", "generation", "status", "cleanup_not_before", "lease_expires_at", "created_at");--> statement-breakpoint
+
+CREATE INDEX "corpus_index_projection_intents_entity_idx"
+  ON "corpus_index_projection_intents"
+  ("family", "generation", "entity_id", "created_at");--> statement-breakpoint
+
+CREATE TABLE "corpus_index_projection_states" (
+  "family" text NOT NULL,
+  "generation" varchar(32) NOT NULL,
+  "entity_id" uuid NOT NULL,
+  "desired_action" text NOT NULL,
+  "desired_epoch" bigint NOT NULL,
+  "desired_fingerprint" varchar(64),
+  "desired_index_id" varchar(64),
+  "applied_action" text,
+  "applied_epoch" bigint,
+  "applied_revision" uuid,
+  "applied_fingerprint" varchar(64),
+  "applied_index_id" varchar(64),
+  "applied_at" timestamptz,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "corpus_index_projection_states_pkey"
+    PRIMARY KEY ("family", "generation", "entity_id"),
+  CONSTRAINT "corpus_index_projection_states_generation_fk"
+    FOREIGN KEY ("family", "generation")
+    REFERENCES "corpus_index_generations" ("family", "generation")
+    ON DELETE RESTRICT,
+  CONSTRAINT "corpus_index_projection_states_applied_revision_fk"
+    FOREIGN KEY (
+      "applied_revision", "family", "generation", "entity_id",
+      "applied_epoch", "applied_fingerprint", "applied_index_id"
+    ) REFERENCES "corpus_index_projection_intents" (
+      "id", "family", "generation", "entity_id", "epoch", "fingerprint",
+      "index_id"
+    ) ON DELETE RESTRICT,
+  CONSTRAINT "corpus_index_projection_states_family_values"
+    CHECK ("family" IN ('case_law','legislation')),
+  CONSTRAINT "corpus_index_projection_states_desired_action_values"
+    CHECK ("desired_action" IN ('upsert','erase')),
+  CONSTRAINT "corpus_index_projection_states_applied_action_values"
+    CHECK ("applied_action" IS NULL OR "applied_action" IN ('upsert','erase')),
+  CONSTRAINT "corpus_index_projection_states_epoch_order"
+    CHECK ("desired_epoch" > 0 AND (
+      "applied_epoch" IS NULL
+      OR ("applied_epoch" > 0 AND "applied_epoch" <= "desired_epoch")
+    )),
+  CONSTRAINT "corpus_index_projection_states_desired_shape"
+    CHECK (CASE "desired_action"
+      WHEN 'upsert' THEN
+        "desired_fingerprint" IS NOT NULL
+        AND "desired_fingerprint" ~ '^[0-9a-f]{64}$'
+        AND "desired_index_id" IS NOT NULL
+        AND "desired_index_id" ~ '^[a-z0-9_]+$'
+      WHEN 'erase' THEN
+        "desired_fingerprint" IS NULL
+        AND "desired_index_id" IS NULL
+      ELSE false
+    END),
+  CONSTRAINT "corpus_index_projection_states_applied_shape"
+    CHECK (CASE
+      WHEN "applied_action" IS NULL THEN
+        "applied_epoch" IS NULL
+        AND "applied_revision" IS NULL
+        AND "applied_fingerprint" IS NULL
+        AND "applied_index_id" IS NULL
+        AND "applied_at" IS NULL
+      WHEN "applied_action" = 'upsert' THEN
+        "applied_epoch" IS NOT NULL
+        AND "applied_revision" IS NOT NULL
+        AND "applied_fingerprint" IS NOT NULL
+        AND "applied_fingerprint" ~ '^[0-9a-f]{64}$'
+        AND "applied_index_id" IS NOT NULL
+        AND "applied_index_id" ~ '^[a-z0-9_]+$'
+        AND "applied_at" IS NOT NULL
+      WHEN "applied_action" = 'erase' THEN
+        "applied_epoch" IS NOT NULL
+        AND "applied_revision" IS NULL
+        AND "applied_fingerprint" IS NULL
+        AND "applied_index_id" IS NULL
+        AND "applied_at" IS NOT NULL
+      ELSE false
+    END)
+);--> statement-breakpoint
+
+CREATE UNIQUE INDEX "corpus_index_projection_states_applied_revision_uidx"
+  ON "corpus_index_projection_states" ("applied_revision")
+  WHERE "applied_revision" IS NOT NULL;--> statement-breakpoint
+
+CREATE INDEX "corpus_index_projection_states_pending_idx"
+  ON "corpus_index_projection_states" ("family", "generation", "updated_at", "entity_id")
+  WHERE "applied_action" IS NULL
+    OR "applied_action" IS DISTINCT FROM "desired_action"
+    OR "applied_epoch" IS DISTINCT FROM "desired_epoch"
+    OR "applied_fingerprint" IS DISTINCT FROM "desired_fingerprint"
+    OR "applied_index_id" IS DISTINCT FROM "desired_index_id";--> statement-breakpoint
+
+CREATE FUNCTION "guard_corpus_projection_epoch"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW."projection_epoch" < OLD."projection_epoch" THEN
+    RAISE EXCEPTION 'corpus projection epoch cannot decrease';
+  END IF;
+  RETURN NEW;
+END;
+$$;--> statement-breakpoint
+
+CREATE TRIGGER "case_law_decisions_projection_epoch_monotonic"
+  BEFORE UPDATE ON "case_law_decisions"
+  FOR EACH ROW EXECUTE FUNCTION "guard_corpus_projection_epoch"();--> statement-breakpoint
+
+CREATE TRIGGER "legislation_documents_projection_epoch_monotonic"
+  BEFORE UPDATE ON "legislation_documents"
+  FOR EACH ROW EXECUTE FUNCTION "guard_corpus_projection_epoch"();--> statement-breakpoint
+
+-- Retired is the irreversible boundary after which projection history may be
+-- deleted. Rollback remains possible while a generation is merely retiring.
+CREATE FUNCTION "guard_retired_corpus_index_generation"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD."status" = 'retired' AND NEW."status" <> 'retired' THEN
+    RAISE EXCEPTION 'retired corpus index generation is terminal';
+  END IF;
+  RETURN NEW;
+END;
+$$;--> statement-breakpoint
+
+CREATE TRIGGER "corpus_index_generations_retired_terminal"
+  BEFORE UPDATE ON "corpus_index_generations"
+  FOR EACH ROW EXECUTE FUNCTION "guard_retired_corpus_index_generation"();--> statement-breakpoint
+
+CREATE FUNCTION "guard_corpus_index_projection_intent_insert"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW."status" <> 'reserved' THEN
+    RAISE EXCEPTION 'corpus index projection intent must start reserved';
+  END IF;
+
+  PERFORM 1
+    FROM "corpus_index_projection_states" state
+    WHERE state."family" = NEW."family"
+      AND state."generation" = NEW."generation"
+      AND state."entity_id" = NEW."entity_id"
+      AND state."desired_action" = 'upsert'
+      AND state."desired_epoch" = NEW."epoch"
+      AND state."desired_fingerprint" = NEW."fingerprint"
+      AND state."desired_index_id" = NEW."index_id"
+    FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'corpus index projection intent does not match desired state';
+  END IF;
+  RETURN NEW;
+END;
+$$;--> statement-breakpoint
+
+CREATE TRIGGER "corpus_index_projection_intents_insert_guard"
+  BEFORE INSERT ON "corpus_index_projection_intents"
+  FOR EACH ROW EXECUTE FUNCTION "guard_corpus_index_projection_intent_insert"();--> statement-breakpoint
+
+CREATE FUNCTION "corpus_index_projection_intent_transition_allowed"(
+  from_status text,
+  to_status text
+)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+  SELECT CASE from_status
+    WHEN 'reserved' THEN to_status IN ('append_started','cancelled')
+    WHEN 'append_started' THEN to_status IN ('append_committed','cleanup_pending')
+    WHEN 'append_committed' THEN to_status IN ('applied','cleanup_pending')
+    WHEN 'applied' THEN to_status = 'cleanup_pending'
+    WHEN 'cleanup_pending' THEN to_status = 'cleanup_started'
+    WHEN 'cleanup_started' THEN to_status IN ('cleanup_pending','cleanup_committed')
+    WHEN 'cleanup_committed' THEN to_status = 'settled'
+    WHEN 'settled' THEN to_status = 'cleanup_pending'
+    ELSE false
+  END
+$$;--> statement-breakpoint
+
+CREATE FUNCTION "guard_corpus_index_projection_intent_update"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  transition_allowed boolean;
+BEGIN
+  IF (NEW."id", NEW."family", NEW."generation", NEW."entity_id", NEW."epoch", NEW."fingerprint", NEW."index_id", NEW."created_at")
+     IS DISTINCT FROM
+     (OLD."id", OLD."family", OLD."generation", OLD."entity_id", OLD."epoch", OLD."fingerprint", OLD."index_id", OLD."created_at") THEN
+    RAISE EXCEPTION 'corpus index projection intent identity is immutable';
+  END IF;
+
+  IF NEW."cleanup_attempts" < OLD."cleanup_attempts" THEN
+    RAISE EXCEPTION 'corpus index projection cleanup attempts cannot decrease';
+  END IF;
+
+  IF OLD."append_started_at" IS NOT NULL
+     AND NEW."append_started_at" IS DISTINCT FROM OLD."append_started_at" THEN
+    RAISE EXCEPTION 'corpus index append start is immutable once recorded';
+  END IF;
+  IF OLD."append_committed_at" IS NOT NULL
+     AND NEW."append_committed_at" IS DISTINCT FROM OLD."append_committed_at" THEN
+    RAISE EXCEPTION 'corpus index append commit is immutable once recorded';
+  END IF;
+  IF OLD."applied_at" IS NOT NULL
+     AND NEW."applied_at" IS DISTINCT FROM OLD."applied_at" THEN
+    RAISE EXCEPTION 'corpus index apply time is immutable once recorded';
+  END IF;
+  IF OLD."append_publish_barrier_at" IS NOT NULL
+     AND NEW."append_publish_barrier_at" IS DISTINCT FROM OLD."append_publish_barrier_at" THEN
+    RAISE EXCEPTION 'corpus index append barrier is immutable once recorded';
+  END IF;
+
+  IF NEW."status" IS DISTINCT FROM OLD."status" THEN
+    transition_allowed := corpus_index_projection_intent_transition_allowed(
+      OLD."status",
+      NEW."status"
+    );
+    IF NOT transition_allowed THEN
+      RAISE EXCEPTION 'invalid corpus index projection intent transition: % -> %', OLD."status", NEW."status";
+    END IF;
+    IF NEW."status" IN ('append_started','append_committed','applied')
+    THEN
+      PERFORM 1
+      FROM "corpus_index_projection_states" state
+      WHERE state."family" = NEW."family"
+        AND state."generation" = NEW."generation"
+        AND state."entity_id" = NEW."entity_id"
+        AND state."desired_action" = 'upsert'
+        AND state."desired_epoch" = NEW."epoch"
+        AND state."desired_fingerprint" = NEW."fingerprint"
+        AND state."desired_index_id" = NEW."index_id"
+      FOR UPDATE;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'stale corpus index projection intent cannot advance';
+      END IF;
+    END IF;
+  END IF;
+
+  IF OLD."status" = 'applied' AND NEW."status" = 'cleanup_pending'
+     AND EXISTS (
+       SELECT 1 FROM "corpus_index_projection_states" state
+       WHERE state."applied_revision" = OLD."id"
+         AND state."desired_action" <> 'erase'
+     ) THEN
+    RAISE EXCEPTION 'current corpus index projection revision requires a replacement before cleanup';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;--> statement-breakpoint
+
+CREATE TRIGGER "corpus_index_projection_intents_update_guard"
+  BEFORE UPDATE ON "corpus_index_projection_intents"
+  FOR EACH ROW EXECUTE FUNCTION "guard_corpus_index_projection_intent_update"();--> statement-breakpoint
+
+CREATE FUNCTION "guard_corpus_index_projection_state"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  canonical_epoch bigint;
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    IF (NEW."family", NEW."generation", NEW."entity_id", NEW."created_at")
+       IS DISTINCT FROM
+       (OLD."family", OLD."generation", OLD."entity_id", OLD."created_at") THEN
+      RAISE EXCEPTION 'corpus index projection state identity is immutable';
+    END IF;
+    IF NEW."desired_epoch" < OLD."desired_epoch" THEN
+      RAISE EXCEPTION 'corpus index desired epoch cannot decrease';
+    END IF;
+    IF (NEW."desired_action", NEW."desired_fingerprint", NEW."desired_index_id")
+       IS DISTINCT FROM (OLD."desired_action", OLD."desired_fingerprint", OLD."desired_index_id")
+       AND NEW."desired_epoch" <= OLD."desired_epoch" THEN
+      RAISE EXCEPTION 'changed corpus index desired state requires a newer epoch';
+    END IF;
+    IF OLD."applied_epoch" IS NOT NULL
+       AND (NEW."applied_epoch" IS NULL OR NEW."applied_epoch" < OLD."applied_epoch") THEN
+      RAISE EXCEPTION 'corpus index applied epoch cannot decrease';
+    END IF;
+  END IF;
+
+  IF NEW."family" = 'case_law' THEN
+    SELECT "projection_epoch" INTO canonical_epoch
+    FROM "case_law_decisions"
+    WHERE "id" = NEW."entity_id";
+  ELSIF NEW."family" = 'legislation' THEN
+    SELECT "projection_epoch" INTO canonical_epoch
+    FROM "legislation_documents"
+    WHERE "id" = NEW."entity_id";
+  END IF;
+  IF canonical_epoch IS NULL OR canonical_epoch <> NEW."desired_epoch" THEN
+    RAISE EXCEPTION 'corpus index desired epoch must match the canonical row';
+  END IF;
+
+  IF NEW."applied_action" = 'upsert' AND NOT EXISTS (
+    SELECT 1
+    FROM "corpus_index_projection_intents" intent
+    WHERE intent."id" = NEW."applied_revision"
+      AND intent."family" = NEW."family"
+      AND intent."generation" = NEW."generation"
+      AND intent."entity_id" = NEW."entity_id"
+      AND intent."epoch" = NEW."applied_epoch"
+      AND intent."fingerprint" = NEW."applied_fingerprint"
+      AND intent."index_id" = NEW."applied_index_id"
+      AND intent."status" = 'applied'
+  ) THEN
+    RAISE EXCEPTION 'applied corpus index state requires its exact applied intent';
+  END IF;
+
+  IF NEW."applied_action" = 'erase' AND EXISTS (
+    SELECT 1
+    FROM "corpus_index_projection_intents" intent
+    WHERE intent."family" = NEW."family"
+      AND intent."generation" = NEW."generation"
+      AND intent."entity_id" = NEW."entity_id"
+      AND intent."epoch" <= NEW."applied_epoch"
+      AND intent."status" NOT IN ('settled', 'cancelled')
+  ) THEN
+    RAISE EXCEPTION 'erased corpus index state requires every prior revision settled';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;--> statement-breakpoint
+
+CREATE TRIGGER "corpus_index_projection_states_guard"
+  BEFORE INSERT OR UPDATE ON "corpus_index_projection_states"
+  FOR EACH ROW EXECUTE FUNCTION "guard_corpus_index_projection_state"();--> statement-breakpoint
+
+CREATE FUNCTION "guard_corpus_index_projection_history_delete"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM "corpus_index_generations" generation
+    WHERE generation."family" = OLD."family"
+      AND generation."generation" = OLD."generation"
+      AND generation."status" = 'retired'
+  ) THEN
+    RAISE EXCEPTION 'corpus index projection history requires a retired generation';
+  END IF;
+
+  IF TG_TABLE_NAME = 'corpus_index_projection_intents'
+     AND OLD."status" NOT IN ('settled', 'cancelled') THEN
+    RAISE EXCEPTION 'nonterminal corpus index projection intent cannot be deleted';
+  END IF;
+
+  IF TG_TABLE_NAME = 'corpus_index_projection_states' AND EXISTS (
+    SELECT 1
+    FROM "corpus_index_projection_intents" intent
+    WHERE intent."family" = OLD."family"
+      AND intent."generation" = OLD."generation"
+      AND intent."entity_id" = OLD."entity_id"
+      AND intent."status" NOT IN ('settled', 'cancelled')
+  ) THEN
+    RAISE EXCEPTION 'projection state with nonterminal intents cannot be deleted';
+  END IF;
+
+  RETURN OLD;
+END;
+$$;--> statement-breakpoint
+
+CREATE TRIGGER "corpus_index_projection_intents_delete_guard"
+  BEFORE DELETE ON "corpus_index_projection_intents"
+  FOR EACH ROW EXECUTE FUNCTION "guard_corpus_index_projection_history_delete"();--> statement-breakpoint
+
+CREATE TRIGGER "corpus_index_projection_states_delete_guard"
+  BEFORE DELETE ON "corpus_index_projection_states"
+  FOR EACH ROW EXECUTE FUNCTION "guard_corpus_index_projection_history_delete"();--> statement-breakpoint
+
+-- stella-migration-safety: reviewed security-definer - fixed search_path, retired-generation and terminal-intent checks, plus a 10000-entity ceiling preserve least privilege; rollback drops this function without restoring table DELETE
+CREATE FUNCTION "purge_retired_corpus_index_projection_history"(
+  target_family text,
+  target_generation text,
+  max_entities integer
+)
+RETURNS TABLE (
+  deleted_state_count integer,
+  deleted_intent_count integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  selected_entities uuid[];
+  state_count integer;
+  intent_count integer;
+BEGIN
+  IF max_entities IS NULL OR max_entities < 1 OR max_entities > 10000 THEN
+    RAISE EXCEPTION 'projection history purge batch must be between 1 and 10000 entities';
+  END IF;
+
+  PERFORM 1
+  FROM public."corpus_index_generations" generation
+  WHERE generation."family" = target_family
+    AND generation."generation" = target_generation
+    AND generation."status" = 'retired'
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'projection history purge requires a retired generation';
+  END IF;
+
+  SELECT array_agg(candidate."entity_id")
+  INTO selected_entities
+  FROM (
+    SELECT state."entity_id"
+    FROM public."corpus_index_projection_states" state
+    WHERE state."family" = target_family
+      AND state."generation" = target_generation
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public."corpus_index_projection_intents" intent
+        WHERE intent."family" = state."family"
+          AND intent."generation" = state."generation"
+          AND intent."entity_id" = state."entity_id"
+          AND intent."status" NOT IN ('settled', 'cancelled')
+      )
+    ORDER BY state."entity_id"
+    LIMIT max_entities
+    FOR UPDATE OF state SKIP LOCKED
+  ) candidate;
+
+  IF selected_entities IS NULL THEN
+    RETURN QUERY SELECT 0, 0;
+    RETURN;
+  END IF;
+
+  DELETE FROM public."corpus_index_projection_states" state
+  WHERE state."family" = target_family
+    AND state."generation" = target_generation
+    AND state."entity_id" = ANY(selected_entities);
+  GET DIAGNOSTICS state_count = ROW_COUNT;
+
+  DELETE FROM public."corpus_index_projection_intents" intent
+  WHERE intent."family" = target_family
+    AND intent."generation" = target_generation
+    AND intent."entity_id" = ANY(selected_entities);
+  GET DIAGNOSTICS intent_count = ROW_COUNT;
+
+  RETURN QUERY SELECT state_count, intent_count;
+END;
+$$;--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION "purge_retired_corpus_index_projection_history"(text, text, integer)
+  FROM PUBLIC;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION "purge_retired_corpus_index_projection_history"(text, text, integer)
+  TO stella_ingestion;--> statement-breakpoint
+
+ALTER TABLE "corpus_index_projection_intents" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "corpus_index_projection_states" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+
+CREATE POLICY "case_law_global_access"
+  ON "corpus_index_projection_intents"
+  AS PERMISSIVE FOR SELECT TO stella USING (true);--> statement-breakpoint
+CREATE POLICY "case_law_ingestion_access"
+  ON "corpus_index_projection_intents"
+  AS PERMISSIVE FOR ALL TO stella_ingestion USING (true) WITH CHECK (true);--> statement-breakpoint
+CREATE POLICY "case_law_global_access"
+  ON "corpus_index_projection_states"
+  AS PERMISSIVE FOR SELECT TO stella USING (true);--> statement-breakpoint
+CREATE POLICY "case_law_ingestion_access"
+  ON "corpus_index_projection_states"
+  AS PERMISSIVE FOR ALL TO stella_ingestion USING (true) WITH CHECK (true);--> statement-breakpoint
+
+GRANT SELECT ON TABLE
+  "corpus_index_projection_intents",
+  "corpus_index_projection_states"
+TO stella;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE ON TABLE
+  "corpus_index_projection_intents",
+  "corpus_index_projection_states"
+TO stella_ingestion;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -9,6 +9,7 @@ export * from "./schema/clauses";
 export * from "./schema/case-law";
 export * from "./schema/legislation";
 export * from "./schema/corpus-index-generations";
+export * from "./schema/corpus-index-projections";
 export * from "./schema/lists";
 export * from "./schema/chat";
 export * from "./schema/docx-suggestions";

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -425,6 +425,15 @@ export const caseLawDecisions = p.pgTable(
     indexedHash: p.varchar("indexed_hash", { length: 64 }),
     indexedGeneration: p.varchar("indexed_generation", { length: 64 }),
     indexedAt: timestamptz("indexed_at"),
+    /**
+     * Monotonic fence captured by final-generation projection intents. Any
+     * desired-state transaction increments it before changing the projection,
+     * so a worker leased against an older value cannot publish stale content.
+     */
+    projectionEpoch: p
+      .bigint("projection_epoch", { mode: "bigint" })
+      .default(0n)
+      .notNull(),
     createdAt: timestamptz("created_at")
       .default(sql`clock_timestamp()`)
       .notNull(),
@@ -434,6 +443,10 @@ export const caseLawDecisions = p.pgTable(
       .$onUpdate(() => new Date()),
   },
   (t) => [
+    p.check(
+      "case_law_decisions_projection_epoch_nonnegative",
+      sql`${t.projectionEpoch} >= 0`,
+    ),
     p.check(
       "case_law_decisions_corpus_mirror_status_values",
       sql`${t.corpusMirrorStatus} IN (${sql.join(CASE_LAW_CORPUS_MIRROR_STATUS_SQL_VALUES, sql`, `)})`,

--- a/apps/api/src/db/schema/corpus-index-projections.ts
+++ b/apps/api/src/db/schema/corpus-index-projections.ts
@@ -1,0 +1,391 @@
+import {
+  CORPUS_FAMILIES,
+  CORPUS_INDEX_GENERATION_MAX_LENGTH,
+} from "@/api/lib/legal-search/corpus-generation-contract";
+import {
+  CORPUS_INDEX_DESIRED_ACTIONS,
+  CORPUS_INDEX_INTENT_STATUSES,
+} from "@/api/lib/legal-search/corpus-index-projection-contract";
+
+import {
+  globalCaseLawPolicies,
+  p,
+  pUuid,
+  type SafeId,
+  sql,
+  timestamptz,
+} from "./common";
+import { corpusIndexGenerations } from "./corpus-index-generations";
+
+const sqlValues = (values: readonly string[]) =>
+  sql.join(
+    values.map((value) => sql.raw(`'${value}'`)),
+    sql.raw(","),
+  );
+
+/**
+ * One immutable Quickwit append attempt. Its UUID is written into every
+ * passage as `projection_revision`, so cleanup can delete this attempt without
+ * touching a later append whose content fingerprint happens to be identical.
+ */
+export const corpusIndexProjectionIntents = p.pgTable(
+  "corpus_index_projection_intents",
+  {
+    id: pUuid<"corpusIndexProjectionIntent">().primaryKey(),
+    family: p.text({ enum: CORPUS_FAMILIES }).notNull(),
+    generation: p
+      .varchar({ length: CORPUS_INDEX_GENERATION_MAX_LENGTH })
+      .notNull(),
+    entityId: p.uuid("entity_id").notNull(),
+    epoch: p.bigint({ mode: "bigint" }).notNull(),
+    fingerprint: p.varchar({ length: 64 }).notNull(),
+    indexId: p.varchar("index_id", { length: 64 }).notNull(),
+    status: p.text({ enum: CORPUS_INDEX_INTENT_STATUSES }).notNull(),
+    leaseToken: p.uuid("lease_token"),
+    leaseExpiresAt: timestamptz("lease_expires_at"),
+    appendStartedAt: timestamptz("append_started_at"),
+    appendCommittedAt: timestamptz("append_committed_at"),
+    appliedAt: timestamptz("applied_at"),
+    appendPublishBarrierAt: timestamptz("append_publish_barrier_at"),
+    cleanupNotBefore: timestamptz("cleanup_not_before"),
+    cleanupStartedAt: timestamptz("cleanup_started_at"),
+    deleteOpstamp: p.bigint("delete_opstamp", { mode: "bigint" }),
+    settledAt: timestamptz("settled_at"),
+    cancelledAt: timestamptz("cancelled_at"),
+    cleanupAttempts: p.integer("cleanup_attempts").default(0).notNull(),
+    lastError: p.varchar("last_error", { length: 2048 }),
+    createdAt: timestamptz("created_at").defaultNow().notNull(),
+    updatedAt: timestamptz("updated_at")
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => [
+    p
+      .foreignKey({
+        name: "corpus_index_projection_intents_generation_fk",
+        columns: [t.family, t.generation],
+        foreignColumns: [
+          corpusIndexGenerations.family,
+          corpusIndexGenerations.generation,
+        ],
+      })
+      .onDelete("restrict"),
+    p
+      .uniqueIndex("corpus_index_projection_intents_live_epoch_uidx")
+      .on(t.family, t.generation, t.entityId, t.epoch)
+      .where(sql`${t.status} NOT IN ('settled', 'cancelled')`),
+    p
+      .uniqueIndex("corpus_index_projection_intents_identity_uidx")
+      .on(
+        t.id,
+        t.family,
+        t.generation,
+        t.entityId,
+        t.epoch,
+        t.fingerprint,
+        t.indexId,
+      ),
+    p
+      .index("corpus_index_projection_intents_work_idx")
+      .on(
+        t.family,
+        t.generation,
+        t.status,
+        t.cleanupNotBefore,
+        t.leaseExpiresAt,
+        t.createdAt,
+      ),
+    p
+      .index("corpus_index_projection_intents_entity_idx")
+      .on(t.family, t.generation, t.entityId, t.createdAt),
+    p.check(
+      "corpus_index_projection_intents_family_values",
+      sql`${t.family} IN (${sqlValues(CORPUS_FAMILIES)})`,
+    ),
+    p.check(
+      "corpus_index_projection_intents_status_values",
+      sql`${t.status} IN (${sqlValues(CORPUS_INDEX_INTENT_STATUSES)})`,
+    ),
+    p.check(
+      "corpus_index_projection_intents_epoch_positive",
+      sql`${t.epoch} > 0`,
+    ),
+    p.check(
+      "corpus_index_projection_intents_fingerprint_shape",
+      sql`${t.fingerprint} ~ '^[0-9a-f]{64}$'`,
+    ),
+    p.check(
+      "corpus_index_projection_intents_index_id_shape",
+      sql`${t.indexId} ~ '^[a-z0-9_]+$'`,
+    ),
+    p.check(
+      "corpus_index_projection_intents_lease_shape",
+      sql`(${t.leaseToken} IS NULL) = (${t.leaseExpiresAt} IS NULL)`,
+    ),
+    p.check(
+      "corpus_index_projection_intents_cleanup_attempts_nonnegative",
+      sql`${t.cleanupAttempts} >= 0`,
+    ),
+    p.check(
+      "corpus_index_projection_intents_delete_opstamp_nonnegative",
+      sql`${t.deleteOpstamp} IS NULL OR ${t.deleteOpstamp} >= 0`,
+    ),
+    p.check(
+      "corpus_index_projection_intents_status_shape",
+      sql`CASE ${t.status}
+        WHEN 'reserved' THEN
+          ${t.leaseToken} IS NOT NULL
+          AND ${t.appendStartedAt} IS NULL
+          AND ${t.appendCommittedAt} IS NULL
+          AND ${t.appliedAt} IS NULL
+          AND ${t.appendPublishBarrierAt} IS NULL
+          AND ${t.cleanupNotBefore} IS NULL
+          AND ${t.cleanupStartedAt} IS NULL
+          AND ${t.deleteOpstamp} IS NULL
+          AND ${t.settledAt} IS NULL
+          AND ${t.cancelledAt} IS NULL
+        WHEN 'append_started' THEN
+          ${t.leaseToken} IS NOT NULL
+          AND ${t.appendStartedAt} IS NOT NULL
+          AND ${t.appendCommittedAt} IS NULL
+          AND ${t.appliedAt} IS NULL
+          AND ${t.appendPublishBarrierAt} IS NULL
+          AND ${t.cleanupNotBefore} IS NULL
+          AND ${t.cleanupStartedAt} IS NULL
+          AND ${t.deleteOpstamp} IS NULL
+          AND ${t.settledAt} IS NULL
+          AND ${t.cancelledAt} IS NULL
+        WHEN 'append_committed' THEN
+          ${t.leaseToken} IS NOT NULL
+          AND ${t.appendStartedAt} IS NOT NULL
+          AND ${t.appendCommittedAt} IS NOT NULL
+          AND ${t.appliedAt} IS NULL
+          AND ${t.appendPublishBarrierAt} IS NULL
+          AND ${t.cleanupNotBefore} IS NULL
+          AND ${t.cleanupStartedAt} IS NULL
+          AND ${t.deleteOpstamp} IS NULL
+          AND ${t.settledAt} IS NULL
+          AND ${t.cancelledAt} IS NULL
+        WHEN 'applied' THEN
+          ${t.leaseToken} IS NULL
+          AND ${t.appendStartedAt} IS NOT NULL
+          AND ${t.appendCommittedAt} IS NOT NULL
+          AND ${t.appliedAt} IS NOT NULL
+          AND ${t.appendPublishBarrierAt} IS NULL
+          AND ${t.cleanupNotBefore} IS NULL
+          AND ${t.cleanupStartedAt} IS NULL
+          AND ${t.deleteOpstamp} IS NULL
+          AND ${t.settledAt} IS NULL
+          AND ${t.cancelledAt} IS NULL
+        WHEN 'cleanup_pending' THEN
+          ${t.appendStartedAt} IS NOT NULL
+          AND ${t.appendPublishBarrierAt} IS NOT NULL
+          AND ${t.cleanupNotBefore} IS NOT NULL
+          AND ${t.cleanupStartedAt} IS NULL
+          AND ${t.deleteOpstamp} IS NULL
+          AND ${t.settledAt} IS NULL
+          AND ${t.cancelledAt} IS NULL
+        WHEN 'cleanup_started' THEN
+          ${t.appendStartedAt} IS NOT NULL
+          AND ${t.appendPublishBarrierAt} IS NOT NULL
+          AND ${t.cleanupNotBefore} IS NOT NULL
+          AND ${t.cleanupStartedAt} IS NOT NULL
+          AND ${t.deleteOpstamp} IS NULL
+          AND ${t.settledAt} IS NULL
+          AND ${t.cancelledAt} IS NULL
+        WHEN 'cleanup_committed' THEN
+          ${t.appendStartedAt} IS NOT NULL
+          AND ${t.appendPublishBarrierAt} IS NOT NULL
+          AND ${t.cleanupNotBefore} IS NOT NULL
+          AND ${t.cleanupStartedAt} IS NOT NULL
+          AND ${t.deleteOpstamp} IS NOT NULL
+          AND ${t.settledAt} IS NULL
+          AND ${t.cancelledAt} IS NULL
+        WHEN 'settled' THEN
+          ${t.leaseToken} IS NULL
+          AND ${t.appendStartedAt} IS NOT NULL
+          AND ${t.appendPublishBarrierAt} IS NOT NULL
+          AND ${t.cleanupNotBefore} IS NOT NULL
+          AND ${t.cleanupStartedAt} IS NOT NULL
+          AND ${t.deleteOpstamp} IS NOT NULL
+          AND ${t.settledAt} IS NOT NULL
+          AND ${t.cancelledAt} IS NULL
+        WHEN 'cancelled' THEN
+          ${t.leaseToken} IS NULL
+          AND ${t.appendStartedAt} IS NULL
+          AND ${t.appendCommittedAt} IS NULL
+          AND ${t.appliedAt} IS NULL
+          AND ${t.appendPublishBarrierAt} IS NULL
+          AND ${t.cleanupNotBefore} IS NULL
+          AND ${t.cleanupStartedAt} IS NULL
+          AND ${t.deleteOpstamp} IS NULL
+          AND ${t.settledAt} IS NULL
+          AND ${t.cancelledAt} IS NOT NULL
+        ELSE false
+      END`,
+    ),
+    p.check(
+      "corpus_index_projection_intents_cleanup_order",
+      // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- column-to-column comparison evaluated in Postgres; no JS Date is bound
+      sql`${t.cleanupNotBefore} IS NULL OR (
+        ${t.cleanupNotBefore} >= ${t.appendPublishBarrierAt}
+        AND (${t.cleanupStartedAt} IS NULL OR ${t.cleanupStartedAt} >= ${t.cleanupNotBefore})
+        AND (${t.settledAt} IS NULL OR ${t.settledAt} >= ${t.cleanupStartedAt})
+      )`,
+    ),
+    p.check(
+      "corpus_index_projection_intents_append_order",
+      // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- column-to-column comparison evaluated in Postgres; no JS Date is bound
+      sql`(${t.appendCommittedAt} IS NULL OR ${t.appendCommittedAt} >= ${t.appendStartedAt})
+        AND (${t.appliedAt} IS NULL OR ${t.appliedAt} >= ${t.appendCommittedAt})
+        AND (${t.appendPublishBarrierAt} IS NULL OR ${t.appendPublishBarrierAt} >= ${t.appendStartedAt})`,
+    ),
+    ...globalCaseLawPolicies(),
+  ],
+);
+
+/** PostgreSQL-authoritative desired and applied state for one generation. */
+export const corpusIndexProjectionStates = p.pgTable(
+  "corpus_index_projection_states",
+  {
+    family: p.text({ enum: CORPUS_FAMILIES }).notNull(),
+    generation: p
+      .varchar({ length: CORPUS_INDEX_GENERATION_MAX_LENGTH })
+      .notNull(),
+    entityId: p.uuid("entity_id").notNull(),
+    desiredAction: p
+      .text("desired_action", { enum: CORPUS_INDEX_DESIRED_ACTIONS })
+      .notNull(),
+    desiredEpoch: p.bigint("desired_epoch", { mode: "bigint" }).notNull(),
+    desiredFingerprint: p.varchar("desired_fingerprint", { length: 64 }),
+    desiredIndexId: p.varchar("desired_index_id", { length: 64 }),
+    appliedAction: p.text("applied_action", {
+      enum: CORPUS_INDEX_DESIRED_ACTIONS,
+    }),
+    appliedEpoch: p.bigint("applied_epoch", { mode: "bigint" }),
+    appliedRevision: p
+      .uuid("applied_revision")
+      .$type<SafeId<"corpusIndexProjectionIntent">>(),
+    appliedFingerprint: p.varchar("applied_fingerprint", { length: 64 }),
+    appliedIndexId: p.varchar("applied_index_id", { length: 64 }),
+    appliedAt: timestamptz("applied_at"),
+    createdAt: timestamptz("created_at").defaultNow().notNull(),
+    updatedAt: timestamptz("updated_at")
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => [
+    p.primaryKey({
+      name: "corpus_index_projection_states_pkey",
+      columns: [t.family, t.generation, t.entityId],
+    }),
+    p
+      .foreignKey({
+        name: "corpus_index_projection_states_generation_fk",
+        columns: [t.family, t.generation],
+        foreignColumns: [
+          corpusIndexGenerations.family,
+          corpusIndexGenerations.generation,
+        ],
+      })
+      .onDelete("restrict"),
+    p
+      .foreignKey({
+        name: "corpus_index_projection_states_applied_revision_fk",
+        columns: [
+          t.appliedRevision,
+          t.family,
+          t.generation,
+          t.entityId,
+          t.appliedEpoch,
+          t.appliedFingerprint,
+          t.appliedIndexId,
+        ],
+        foreignColumns: [
+          corpusIndexProjectionIntents.id,
+          corpusIndexProjectionIntents.family,
+          corpusIndexProjectionIntents.generation,
+          corpusIndexProjectionIntents.entityId,
+          corpusIndexProjectionIntents.epoch,
+          corpusIndexProjectionIntents.fingerprint,
+          corpusIndexProjectionIntents.indexId,
+        ],
+      })
+      .onDelete("restrict"),
+    p
+      .uniqueIndex("corpus_index_projection_states_applied_revision_uidx")
+      .on(t.appliedRevision)
+      .where(sql`${t.appliedRevision} IS NOT NULL`),
+    p
+      .index("corpus_index_projection_states_pending_idx")
+      .on(t.family, t.generation, t.updatedAt, t.entityId).where(sql`
+        ${t.appliedAction} IS NULL
+        OR ${t.appliedAction} IS DISTINCT FROM ${t.desiredAction}
+        OR ${t.appliedEpoch} IS DISTINCT FROM ${t.desiredEpoch}
+        OR ${t.appliedFingerprint} IS DISTINCT FROM ${t.desiredFingerprint}
+        OR ${t.appliedIndexId} IS DISTINCT FROM ${t.desiredIndexId}
+      `),
+    p.check(
+      "corpus_index_projection_states_family_values",
+      sql`${t.family} IN (${sqlValues(CORPUS_FAMILIES)})`,
+    ),
+    p.check(
+      "corpus_index_projection_states_desired_action_values",
+      sql`${t.desiredAction} IN (${sqlValues(CORPUS_INDEX_DESIRED_ACTIONS)})`,
+    ),
+    p.check(
+      "corpus_index_projection_states_applied_action_values",
+      sql`${t.appliedAction} IS NULL OR ${t.appliedAction} IN (${sqlValues(CORPUS_INDEX_DESIRED_ACTIONS)})`,
+    ),
+    p.check(
+      "corpus_index_projection_states_epoch_order",
+      sql`${t.desiredEpoch} > 0 AND (
+        ${t.appliedEpoch} IS NULL
+        OR (${t.appliedEpoch} > 0 AND ${t.appliedEpoch} <= ${t.desiredEpoch})
+      )`,
+    ),
+    p.check(
+      "corpus_index_projection_states_desired_shape",
+      sql`CASE ${t.desiredAction}
+        WHEN 'upsert' THEN
+          ${t.desiredFingerprint} IS NOT NULL
+          AND ${t.desiredFingerprint} ~ '^[0-9a-f]{64}$'
+          AND ${t.desiredIndexId} IS NOT NULL
+          AND ${t.desiredIndexId} ~ '^[a-z0-9_]+$'
+        WHEN 'erase' THEN
+          ${t.desiredFingerprint} IS NULL
+          AND ${t.desiredIndexId} IS NULL
+        ELSE false
+      END`,
+    ),
+    p.check(
+      "corpus_index_projection_states_applied_shape",
+      sql`CASE
+        WHEN ${t.appliedAction} IS NULL THEN
+          ${t.appliedEpoch} IS NULL
+          AND ${t.appliedRevision} IS NULL
+          AND ${t.appliedFingerprint} IS NULL
+          AND ${t.appliedIndexId} IS NULL
+          AND ${t.appliedAt} IS NULL
+        WHEN ${t.appliedAction} = 'upsert' THEN
+          ${t.appliedEpoch} IS NOT NULL
+          AND ${t.appliedRevision} IS NOT NULL
+          AND ${t.appliedFingerprint} IS NOT NULL
+          AND ${t.appliedFingerprint} ~ '^[0-9a-f]{64}$'
+          AND ${t.appliedIndexId} IS NOT NULL
+          AND ${t.appliedIndexId} ~ '^[a-z0-9_]+$'
+          AND ${t.appliedAt} IS NOT NULL
+        WHEN ${t.appliedAction} = 'erase' THEN
+          ${t.appliedEpoch} IS NOT NULL
+          AND ${t.appliedRevision} IS NULL
+          AND ${t.appliedFingerprint} IS NULL
+          AND ${t.appliedIndexId} IS NULL
+          AND ${t.appliedAt} IS NOT NULL
+        ELSE false
+      END`,
+    ),
+    ...globalCaseLawPolicies(),
+  ],
+);

--- a/apps/api/src/db/schema/legislation.ts
+++ b/apps/api/src/db/schema/legislation.ts
@@ -119,6 +119,11 @@ export const legislationDocuments = p.pgTable(
     indexedHash: p.varchar("indexed_hash", { length: 64 }),
     indexedGeneration: p.varchar("indexed_generation", { length: 64 }),
     indexedAt: timestamptz("indexed_at"),
+    /** Monotonic fence advanced by each desired-state transaction. */
+    projectionEpoch: p
+      .bigint("projection_epoch", { mode: "bigint" })
+      .default(0n)
+      .notNull(),
     createdAt: timestamptz("created_at").defaultNow().notNull(),
     updatedAt: timestamptz("updated_at")
       .defaultNow()
@@ -126,6 +131,10 @@ export const legislationDocuments = p.pgTable(
       .$onUpdate(() => new Date()),
   },
   (t) => [
+    p.check(
+      "legislation_documents_projection_epoch_nonnegative",
+      sql`${t.projectionEpoch} >= 0`,
+    ),
     p
       .uniqueIndex("legislation_documents_eli_version_lang_idx")
       .on(t.sourceId, t.eli, t.versionValidFrom, t.language)

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -51,6 +51,7 @@ export type SafeIdType =
   | "contactExtractionUpload"
   | "contactImportRequest"
   | "contactRelationship"
+  | "corpusIndexProjectionIntent"
   | "usageAllocation"
   | "usageLaneCounter"
   | "usageSeatAssignment"

--- a/apps/api/src/lib/legal-search/corpus-index-projection-contract.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-contract.test.ts
@@ -1,0 +1,146 @@
+import { expect, test } from "bun:test";
+
+import {
+  canTransitionCorpusIndexIntent,
+  CORPUS_INDEX_INTENT_STATUSES,
+  CORPUS_INDEX_INTENT_TRANSITIONS,
+  corpusIndexIntentStatusAfterUnknownAppend,
+  isCorpusIndexIntentOutstanding,
+  isCorpusIndexProjectionConverged,
+  type CorpusIndexDesiredProjection,
+} from "@/api/lib/legal-search/corpus-index-projection-contract";
+
+test("intent transitions are total and never reuse an uncertain append", () => {
+  expect(Object.keys(CORPUS_INDEX_INTENT_TRANSITIONS).sort()).toEqual(
+    [...CORPUS_INDEX_INTENT_STATUSES].sort(),
+  );
+  expect(canTransitionCorpusIndexIntent("reserved", "append_started")).toBe(
+    true,
+  );
+  expect(canTransitionCorpusIndexIntent("append_started", "reserved")).toBe(
+    false,
+  );
+  expect(corpusIndexIntentStatusAfterUnknownAppend("append_started")).toBe(
+    "cleanup_pending",
+  );
+  expect(corpusIndexIntentStatusAfterUnknownAppend("append_committed")).toBe(
+    "cleanup_pending",
+  );
+  expect(corpusIndexIntentStatusAfterUnknownAppend("reserved")).toBe(
+    "reserved",
+  );
+});
+
+test("cleanup retries until one retired revision settles", () => {
+  expect(CORPUS_INDEX_INTENT_TRANSITIONS.applied).toEqual(["cleanup_pending"]);
+  expect(CORPUS_INDEX_INTENT_TRANSITIONS.cleanup_pending).toEqual([
+    "cleanup_started",
+  ]);
+  expect(CORPUS_INDEX_INTENT_TRANSITIONS.cleanup_started).toEqual([
+    "cleanup_pending",
+    "cleanup_committed",
+  ]);
+  expect(CORPUS_INDEX_INTENT_TRANSITIONS.cleanup_committed).toEqual([
+    "settled",
+  ]);
+  expect(CORPUS_INDEX_INTENT_TRANSITIONS.settled).toEqual(["cleanup_pending"]);
+  expect(CORPUS_INDEX_INTENT_TRANSITIONS.cancelled).toEqual([]);
+});
+
+test("an applied intent is quiet only when authoritative state references it", () => {
+  const revision = "0198e331-e578-7000-8000-000000000001";
+  expect(
+    isCorpusIndexIntentOutstanding({
+      status: "applied",
+      revision,
+      appliedRevision: revision,
+    }),
+  ).toBe(false);
+  expect(
+    isCorpusIndexIntentOutstanding({
+      status: "applied",
+      revision,
+      appliedRevision: null,
+    }),
+  ).toBe(true);
+  expect(
+    isCorpusIndexIntentOutstanding({
+      status: "applied",
+      revision,
+      appliedRevision: "0198e331-e578-7000-8000-000000000002",
+    }),
+  ).toBe(true);
+  expect(
+    isCorpusIndexIntentOutstanding({
+      status: "settled",
+      revision,
+      appliedRevision: null,
+    }),
+  ).toBe(false);
+});
+
+test("convergence requires desired state, epoch, fingerprint, and quiet intents", () => {
+  const desired = {
+    action: "upsert",
+    epoch: 8n,
+    fingerprint: "a".repeat(64),
+    indexId: "case_law_v5_cs_sk",
+  } as const satisfies CorpusIndexDesiredProjection;
+  const applied = {
+    ...desired,
+    revision: "0198e331-e578-7000-8000-000000000001",
+  };
+
+  expect(
+    isCorpusIndexProjectionConverged({
+      desired,
+      applied,
+      outstandingIntentCount: 0,
+    }),
+  ).toBe(true);
+  expect(
+    isCorpusIndexProjectionConverged({
+      desired,
+      applied,
+      outstandingIntentCount: 1,
+    }),
+  ).toBe(false);
+  expect(
+    isCorpusIndexProjectionConverged({
+      desired,
+      applied: { ...applied, epoch: 7n },
+      outstandingIntentCount: 0,
+    }),
+  ).toBe(false);
+  expect(
+    isCorpusIndexProjectionConverged({
+      desired,
+      applied: { ...applied, fingerprint: "b".repeat(64) },
+      outstandingIntentCount: 0,
+    }),
+  ).toBe(false);
+  expect(
+    isCorpusIndexProjectionConverged({
+      desired,
+      applied: { ...applied, indexId: "case_law_v5_eu" },
+      outstandingIntentCount: 0,
+    }),
+  ).toBe(false);
+});
+
+test("an erased entity converges without an index revision", () => {
+  expect(
+    isCorpusIndexProjectionConverged({
+      desired: { action: "erase", epoch: 11n },
+      applied: { action: "erase", epoch: 11n },
+      outstandingIntentCount: 0,
+    }),
+  ).toBe(true);
+  expect(
+    isCorpusIndexProjectionConverged({
+      desired: { action: "erase", epoch: 11n },
+      applied: { action: "missing" },
+      outstandingIntentCount: 0,
+    }),
+  ).toBe(false);
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-contract.ts
@@ -1,0 +1,135 @@
+export const CORPUS_INDEX_DESIRED_ACTIONS = ["upsert", "erase"] as const;
+export type CorpusIndexDesiredAction =
+  (typeof CORPUS_INDEX_DESIRED_ACTIONS)[number];
+
+export const CORPUS_INDEX_INTENT_STATUSES = [
+  "reserved",
+  "append_started",
+  "append_committed",
+  "applied",
+  "cleanup_pending",
+  "cleanup_started",
+  "cleanup_committed",
+  "settled",
+  "cancelled",
+] as const;
+export type CorpusIndexIntentStatus =
+  (typeof CORPUS_INDEX_INTENT_STATUSES)[number];
+
+export const CORPUS_INDEX_QUIESCENT_INTENT_STATUSES = [
+  "settled",
+  "cancelled",
+] as const satisfies readonly CorpusIndexIntentStatus[];
+
+/**
+ * Legal intent transitions. A response lost after an append never returns to
+ * `reserved`: its revision is assumed written and must pass through exact
+ * cleanup before the same desired epoch can be attempted again.
+ */
+export const CORPUS_INDEX_INTENT_TRANSITIONS = {
+  reserved: ["append_started", "cancelled"],
+  append_started: ["append_committed", "cleanup_pending"],
+  append_committed: ["applied", "cleanup_pending"],
+  applied: ["cleanup_pending"],
+  cleanup_pending: ["cleanup_started"],
+  cleanup_started: ["cleanup_pending", "cleanup_committed"],
+  cleanup_committed: ["settled"],
+  // A zero-hit census may later disprove settlement if an append was still in
+  // an ingester tail. Reopening exact-revision cleanup is safe and makes that
+  // engine edge self-healing.
+  settled: ["cleanup_pending"],
+  cancelled: [],
+} as const satisfies Record<
+  CorpusIndexIntentStatus,
+  readonly CorpusIndexIntentStatus[]
+>;
+
+export const canTransitionCorpusIndexIntent = (
+  from: CorpusIndexIntentStatus,
+  to: CorpusIndexIntentStatus,
+): boolean =>
+  CORPUS_INDEX_INTENT_TRANSITIONS[from].some((candidate) => candidate === to);
+
+export const corpusIndexIntentStatusAfterUnknownAppend = (
+  status: CorpusIndexIntentStatus,
+): CorpusIndexIntentStatus =>
+  status === "append_started" || status === "append_committed"
+    ? "cleanup_pending"
+    : status;
+
+type CorpusIndexIntentOutstandingInput = {
+  status: CorpusIndexIntentStatus;
+  revision: string;
+  appliedRevision: string | null;
+};
+
+/**
+ * `applied` is quiet only while PostgreSQL names that exact revision as
+ * authoritative. A crash before the state CAS, or a replaced revision not yet
+ * queued for cleanup, remains visible work for the reconciler.
+ */
+export const isCorpusIndexIntentOutstanding = ({
+  status,
+  revision,
+  appliedRevision,
+}: CorpusIndexIntentOutstandingInput): boolean => {
+  if (
+    CORPUS_INDEX_QUIESCENT_INTENT_STATUSES.some((value) => value === status)
+  ) {
+    return false;
+  }
+  return status !== "applied" || revision !== appliedRevision;
+};
+
+export type CorpusIndexDesiredProjection =
+  | {
+      action: "upsert";
+      epoch: bigint;
+      fingerprint: string;
+      indexId: string;
+    }
+  | { action: "erase"; epoch: bigint };
+
+export type CorpusIndexAppliedProjection =
+  | { action: "missing" }
+  | {
+      action: "upsert";
+      epoch: bigint;
+      fingerprint: string;
+      indexId: string;
+      revision: string;
+    }
+  | { action: "erase"; epoch: bigint };
+
+type CorpusIndexConvergenceInput = {
+  desired: CorpusIndexDesiredProjection;
+  applied: CorpusIndexAppliedProjection;
+  /**
+   * Every nonterminal intent except the exact revision currently referenced by
+   * `applied`. An unreferenced `applied` intent is outstanding cleanup work.
+   */
+  outstandingIntentCount: number;
+};
+
+/**
+ * A generation is current for one entity only when PostgreSQL desired and
+ * applied state agree and no append or cleanup can still change Quickwit.
+ */
+export const isCorpusIndexProjectionConverged = ({
+  desired,
+  applied,
+  outstandingIntentCount,
+}: CorpusIndexConvergenceInput): boolean => {
+  if (outstandingIntentCount !== 0 || applied.action !== desired.action) {
+    return false;
+  }
+  if (desired.action === "erase") {
+    return applied.action === "erase" && applied.epoch === desired.epoch;
+  }
+  return (
+    applied.action === "upsert" &&
+    applied.epoch === desired.epoch &&
+    applied.fingerprint === desired.fingerprint &&
+    applied.indexId === desired.indexId
+  );
+};

--- a/apps/api/src/lib/legal-search/corpus-index-projections.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projections.db.test.ts
@@ -1,0 +1,644 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import {
+  canTransitionCorpusIndexIntent,
+  CORPUS_INDEX_INTENT_STATUSES,
+} from "@/api/lib/legal-search/corpus-index-projection-contract";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const MIGRATION_URL = new URL(
+  "../../../drizzle/20260825142000_corpus_index_projection_intents/migration.sql",
+  import.meta.url,
+);
+const SOURCE_ID = "0198e331-e578-7000-8000-000000000001";
+const FIRST_DECISION_ID = "0198e331-e578-7000-8000-000000000002";
+const RACED_DECISION_ID = "0198e331-e578-7000-8000-000000000003";
+const FIRST_REVISION = "0198e331-e578-7000-8000-000000000004";
+const RACED_REVISION = "0198e331-e578-7000-8000-000000000005";
+const LEASE_TOKEN = "0198e331-e578-7000-8000-000000000006";
+const SECOND_REVISION = "0198e331-e578-7000-8000-000000000007";
+const LEGISLATION_SOURCE_ID = "0198e331-e578-7000-8000-000000000008";
+const LEGISLATION_DOCUMENT_ID = "0198e331-e578-7000-8000-000000000009";
+const LEGISLATION_REVISION = "0198e331-e578-7000-8000-000000000010";
+const RETIRED_DECISION_ID = "0198e331-e578-7000-8000-000000000011";
+const RETIRED_REVISION = "0198e331-e578-7000-8000-000000000012";
+const FIRST_FINGERPRINT = "a".repeat(64);
+const SECOND_FINGERPRINT = "b".repeat(64);
+const MANIFEST_DIGEST = "c".repeat(64);
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const errorMessageChain = (error: unknown): string => {
+  const messages: string[] = [];
+  let current = error;
+  while (current instanceof Error) {
+    messages.push(current.message);
+    current = current.cause;
+  }
+  return messages.join(" | ");
+};
+
+const rejectionMessage = async (run: Promise<unknown>): Promise<string> =>
+  await run.then(
+    () => "no rejection",
+    (error: unknown) => errorMessageChain(error),
+  );
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    db = drizzle({ client });
+
+    await db.execute(sql`
+      INSERT INTO case_law_sources (id, adapter_key, name)
+      VALUES (${SOURCE_ID}, 'projection-contract-test', 'Projection contract test')
+    `);
+    await db.execute(sql`
+      INSERT INTO case_law_decisions (
+        id, source_id, case_number, court, country, language, fulltext,
+        projection_epoch
+      ) VALUES
+        (${FIRST_DECISION_ID}, ${SOURCE_ID}, '1 A 1/2026', 'Test court', 'CZE', 'cs', 'first', 1),
+        (${RACED_DECISION_ID}, ${SOURCE_ID}, '1 A 2/2026', 'Test court', 'CZE', 'cs', 'raced', 1)
+    `);
+    await db.execute(sql`
+      INSERT INTO corpus_index_generations (
+        family, generation, cluster, manifest_digest, status
+      ) VALUES
+        ('case_law', 'case_law_v5', 'q09', ${MANIFEST_DIGEST}, 'building'),
+        ('legislation', 'legislation_v2', 'q09', ${MANIFEST_DIGEST}, 'building')
+    `);
+    await db.execute(sql`
+      INSERT INTO legislation_sources (id, adapter_key, name)
+      VALUES (
+        ${LEGISLATION_SOURCE_ID}, 'projection-contract-test',
+        'Projection contract test'
+      )
+    `);
+    await db.execute(sql`
+      INSERT INTO legislation_documents (
+        id, source_id, eli, title, country, language, projection_epoch
+      ) VALUES (
+        ${LEGISLATION_DOCUMENT_ID}, ${LEGISLATION_SOURCE_ID},
+        'eli/cz/test', 'Test act', 'CZE', 'cs', 1
+      )
+    `);
+
+    const migration = await Bun.file(MIGRATION_URL).text();
+    for (const statement of migration.split("--> statement-breakpoint")) {
+      const ddl = statement.trim();
+      if (
+        !ddl.startsWith("CREATE FUNCTION") &&
+        !ddl.startsWith("CREATE TRIGGER") &&
+        !ddl.includes(
+          'FUNCTION "purge_retired_corpus_index_projection_history"',
+        )
+      ) {
+        continue;
+      }
+      // oxlint-disable-next-line no-await-in-loop -- ordered migration-owned functions and dependent triggers
+      await db.execute(sql.raw(ddl));
+    }
+  },
+  { timeout: 120_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("one exact append revision becomes authoritative", async () => {
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        INSERT INTO corpus_index_projection_states (
+          family, generation, entity_id, desired_action, desired_epoch,
+          desired_fingerprint, desired_index_id
+        ) VALUES (
+          'case_law', 'case_law_v5', ${FIRST_DECISION_ID}, 'upsert', 1, NULL,
+          'case_law_v5_cs_sk'
+        )
+      `),
+    ),
+  ).toContain("corpus_index_projection_states_desired_shape");
+
+  await db.execute(sql`
+    INSERT INTO corpus_index_projection_states (
+      family, generation, entity_id, desired_action, desired_epoch,
+      desired_fingerprint, desired_index_id
+    ) VALUES (
+      'case_law', 'case_law_v5', ${FIRST_DECISION_ID}, 'upsert', 1,
+      ${FIRST_FINGERPRINT}, 'case_law_v5_cs_sk'
+    )
+  `);
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        INSERT INTO corpus_index_projection_intents (
+          id, family, generation, entity_id, epoch, fingerprint, index_id,
+          status, append_started_at, append_committed_at, applied_at
+        ) VALUES (
+          '0198e331-e578-7000-8000-000000000098', 'case_law', 'case_law_v5',
+          ${FIRST_DECISION_ID}, 1, ${FIRST_FINGERPRINT},
+          'case_law_v5_cs_sk', 'applied', clock_timestamp(),
+          clock_timestamp(), clock_timestamp()
+        )
+      `),
+    ),
+  ).toContain("corpus index projection intent must start reserved");
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        INSERT INTO corpus_index_projection_intents (
+          id, family, generation, entity_id, epoch, fingerprint, index_id,
+          status, lease_token, lease_expires_at
+        ) VALUES (
+          '0198e331-e578-7000-8000-000000000097', 'case_law', 'case_law_v5',
+          ${FIRST_DECISION_ID}, 1, ${FIRST_FINGERPRINT}, 'case_law_v5_eu',
+          'reserved', ${LEASE_TOKEN}, clock_timestamp() + interval '5 minutes'
+        )
+      `),
+    ),
+  ).toContain("corpus index projection intent does not match desired state");
+  await db.execute(sql`
+    INSERT INTO corpus_index_projection_intents (
+      id, family, generation, entity_id, epoch, fingerprint, index_id,
+      status, lease_token, lease_expires_at
+    ) VALUES (
+      ${FIRST_REVISION}, 'case_law', 'case_law_v5', ${FIRST_DECISION_ID}, 1,
+      ${FIRST_FINGERPRINT}, 'case_law_v5_cs_sk', 'reserved', ${LEASE_TOKEN},
+      clock_timestamp() + interval '5 minutes'
+    )
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'append_started', append_started_at = clock_timestamp()
+    WHERE id = ${FIRST_REVISION}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'append_committed', append_committed_at = clock_timestamp()
+    WHERE id = ${FIRST_REVISION}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'applied', applied_at = clock_timestamp(),
+        lease_token = NULL, lease_expires_at = NULL
+    WHERE id = ${FIRST_REVISION}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_states
+    SET applied_action = 'upsert', applied_epoch = 1,
+        applied_revision = ${FIRST_REVISION},
+        applied_fingerprint = ${FIRST_FINGERPRINT},
+        applied_index_id = 'case_law_v5_cs_sk',
+        applied_at = clock_timestamp()
+    WHERE family = 'case_law'
+      AND generation = 'case_law_v5'
+      AND entity_id = ${FIRST_DECISION_ID}
+  `);
+
+  const state = await db.execute<{
+    applied_revision: string;
+    applied_index_id: string;
+    desired_epoch: number;
+    desired_index_id: string;
+    applied_epoch: number;
+  }>(sql`
+    SELECT applied_revision, applied_index_id, desired_epoch,
+           desired_index_id, applied_epoch
+    FROM corpus_index_projection_states
+    WHERE entity_id = ${FIRST_DECISION_ID}
+  `);
+  expect(state.rows).toEqual([
+    {
+      applied_revision: FIRST_REVISION,
+      applied_index_id: "case_law_v5_cs_sk",
+      desired_epoch: 1,
+      desired_index_id: "case_law_v5_cs_sk",
+      applied_epoch: 1,
+    },
+  ]);
+
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        INSERT INTO corpus_index_projection_intents (
+          id, family, generation, entity_id, epoch, fingerprint, index_id,
+          status, lease_token, lease_expires_at
+        ) VALUES (
+          '0198e331-e578-7000-8000-000000000099', 'case_law', 'case_law_v5',
+          ${FIRST_DECISION_ID}, 1, ${FIRST_FINGERPRINT},
+          'case_law_v5_cs_sk', 'reserved', ${LEASE_TOKEN},
+          clock_timestamp() + interval '5 minutes'
+        )
+      `),
+    ),
+  ).toContain("corpus_index_projection_intents_live_epoch_uidx");
+
+  await db.execute(sql`
+    UPDATE case_law_decisions SET projection_epoch = 2
+    WHERE id = ${FIRST_DECISION_ID}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_states
+    SET desired_epoch = 2, desired_fingerprint = ${SECOND_FINGERPRINT},
+        desired_index_id = 'case_law_v5_cs_sk'
+    WHERE family = 'case_law'
+      AND generation = 'case_law_v5'
+      AND entity_id = ${FIRST_DECISION_ID}
+  `);
+  await db.execute(sql`
+    INSERT INTO corpus_index_projection_intents (
+      id, family, generation, entity_id, epoch, fingerprint, index_id,
+      status, lease_token, lease_expires_at
+    ) VALUES (
+      ${SECOND_REVISION}, 'case_law', 'case_law_v5', ${FIRST_DECISION_ID}, 2,
+      ${SECOND_FINGERPRINT}, 'case_law_v5_cs_sk', 'reserved', ${LEASE_TOKEN},
+      clock_timestamp() + interval '5 minutes'
+    )
+  `);
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        UPDATE corpus_index_projection_intents
+        SET status = 'cleanup_pending',
+            append_publish_barrier_at = clock_timestamp(),
+            cleanup_not_before = clock_timestamp(),
+            lease_token = NULL, lease_expires_at = NULL
+        WHERE id = ${FIRST_REVISION}
+      `),
+    ),
+  ).toContain(
+    "current corpus index projection revision requires a replacement before cleanup",
+  );
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'append_started', append_started_at = clock_timestamp()
+    WHERE id = ${SECOND_REVISION}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'append_committed', append_committed_at = clock_timestamp()
+    WHERE id = ${SECOND_REVISION}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'applied', applied_at = clock_timestamp(),
+        lease_token = NULL, lease_expires_at = NULL
+    WHERE id = ${SECOND_REVISION}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_states
+    SET applied_epoch = 2, applied_revision = ${SECOND_REVISION},
+        applied_fingerprint = ${SECOND_FINGERPRINT},
+        applied_index_id = 'case_law_v5_cs_sk',
+        applied_at = clock_timestamp()
+    WHERE family = 'case_law'
+      AND generation = 'case_law_v5'
+      AND entity_id = ${FIRST_DECISION_ID}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'cleanup_pending',
+        append_publish_barrier_at = clock_timestamp(),
+        cleanup_not_before = clock_timestamp(),
+        lease_token = NULL, lease_expires_at = NULL
+    WHERE id = ${FIRST_REVISION}
+  `);
+
+  const revisions = await db.execute<{ id: string; status: string }>(sql`
+    SELECT id, status
+    FROM corpus_index_projection_intents
+    WHERE entity_id = ${FIRST_DECISION_ID}
+    ORDER BY epoch
+  `);
+  expect(revisions.rows).toEqual([
+    { id: FIRST_REVISION, status: "cleanup_pending" },
+    { id: SECOND_REVISION, status: "applied" },
+  ]);
+
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        DELETE FROM corpus_index_projection_states
+        WHERE family = 'case_law'
+          AND generation = 'case_law_v5'
+          AND entity_id = ${FIRST_DECISION_ID}
+      `),
+    ),
+  ).toContain("projection history requires a retired generation");
+});
+
+test("an erasure epoch fences an in-flight append until exact cleanup settles", async () => {
+  await db.execute(sql`
+    INSERT INTO corpus_index_projection_states (
+      family, generation, entity_id, desired_action, desired_epoch,
+      desired_fingerprint, desired_index_id
+    ) VALUES (
+      'case_law', 'case_law_v5', ${RACED_DECISION_ID}, 'upsert', 1,
+      ${FIRST_FINGERPRINT}, 'case_law_v5_cs_sk'
+    )
+  `);
+  await db.execute(sql`
+    INSERT INTO corpus_index_projection_intents (
+      id, family, generation, entity_id, epoch, fingerprint, index_id,
+      status, lease_token, lease_expires_at
+    ) VALUES (
+      ${RACED_REVISION}, 'case_law', 'case_law_v5', ${RACED_DECISION_ID}, 1,
+      ${FIRST_FINGERPRINT}, 'case_law_v5_cs_sk', 'reserved', ${LEASE_TOKEN},
+      clock_timestamp() + interval '5 minutes'
+    )
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'append_started', append_started_at = clock_timestamp()
+    WHERE id = ${RACED_REVISION}
+  `);
+
+  await db.execute(sql`
+    UPDATE case_law_decisions SET projection_epoch = 2
+    WHERE id = ${RACED_DECISION_ID}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_states
+    SET desired_action = 'erase', desired_epoch = 2,
+        desired_fingerprint = NULL, desired_index_id = NULL
+    WHERE family = 'case_law'
+      AND generation = 'case_law_v5'
+      AND entity_id = ${RACED_DECISION_ID}
+  `);
+
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        UPDATE corpus_index_projection_intents
+        SET status = 'append_committed', append_committed_at = clock_timestamp()
+        WHERE id = ${RACED_REVISION}
+      `),
+    ),
+  ).toContain("stale corpus index projection intent cannot advance");
+
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        UPDATE corpus_index_projection_states
+        SET applied_action = 'erase', applied_epoch = 2,
+            applied_revision = NULL, applied_fingerprint = NULL,
+            applied_index_id = NULL,
+            applied_at = clock_timestamp()
+        WHERE family = 'case_law'
+          AND generation = 'case_law_v5'
+          AND entity_id = ${RACED_DECISION_ID}
+      `),
+    ),
+  ).toContain(
+    "erased corpus index state requires every prior revision settled",
+  );
+
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'cleanup_pending',
+        lease_token = NULL, lease_expires_at = NULL,
+        append_publish_barrier_at = clock_timestamp() + interval '1 second',
+        cleanup_not_before = clock_timestamp() + interval '1 second'
+    WHERE id = ${RACED_REVISION}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'cleanup_started', cleanup_started_at = cleanup_not_before
+    WHERE id = ${RACED_REVISION}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'cleanup_committed', delete_opstamp = 42
+    WHERE id = ${RACED_REVISION}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'settled', settled_at = cleanup_started_at
+    WHERE id = ${RACED_REVISION}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_states
+    SET applied_action = 'erase', applied_epoch = 2,
+        applied_revision = NULL, applied_fingerprint = NULL,
+        applied_index_id = NULL,
+        applied_at = clock_timestamp()
+    WHERE family = 'case_law'
+      AND generation = 'case_law_v5'
+      AND entity_id = ${RACED_DECISION_ID}
+  `);
+
+  const result = await db.execute<{
+    applied_action: string;
+    applied_epoch: number;
+    status: string;
+  }>(sql`
+    SELECT state.applied_action, state.applied_epoch, intent.status
+    FROM corpus_index_projection_states state
+    JOIN corpus_index_projection_intents intent
+      ON intent.id = ${RACED_REVISION}
+    WHERE state.entity_id = ${RACED_DECISION_ID}
+  `);
+  expect(result.rows).toEqual([
+    { applied_action: "erase", applied_epoch: 2, status: "settled" },
+  ]);
+});
+
+test("epochs and intent identities cannot move backward or retarget", async () => {
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        UPDATE case_law_decisions SET projection_epoch = 0
+        WHERE id = ${FIRST_DECISION_ID}
+      `),
+    ),
+  ).toContain("corpus projection epoch cannot decrease");
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        UPDATE corpus_index_projection_intents
+        SET fingerprint = ${SECOND_FINGERPRINT}
+        WHERE id = ${FIRST_REVISION}
+      `),
+    ),
+  ).toContain("corpus index projection intent identity is immutable");
+});
+
+test("the database transition function matches the exhaustive TypeScript matrix", async () => {
+  const values = sql.join(
+    CORPUS_INDEX_INTENT_STATUSES.map((status) => sql`(${status})`),
+    sql.raw(","),
+  );
+  const result = await db.execute<{
+    from_status: (typeof CORPUS_INDEX_INTENT_STATUSES)[number];
+    to_status: (typeof CORPUS_INDEX_INTENT_STATUSES)[number];
+    allowed: boolean;
+  }>(sql`
+    WITH statuses(status) AS (VALUES ${values})
+    SELECT source.status AS from_status, target.status AS to_status,
+           corpus_index_projection_intent_transition_allowed(
+             source.status,
+             target.status
+           ) AS allowed
+    FROM statuses source
+    CROSS JOIN statuses target
+  `);
+
+  for (const row of result.rows) {
+    expect(row.allowed).toBe(
+      canTransitionCorpusIndexIntent(row.from_status, row.to_status),
+    );
+  }
+  expect(result.rows).toHaveLength(CORPUS_INDEX_INTENT_STATUSES.length ** 2);
+});
+
+test("retired generations cannot be reactivated after history becomes deletable", async () => {
+  await db.execute(sql`
+    INSERT INTO corpus_index_generations (
+      family, generation, cluster, manifest_digest, status
+    ) VALUES (
+      'case_law', 'case_law_v6', 'q09', ${MANIFEST_DIGEST}, 'retiring'
+    )
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_generations
+    SET status = 'retired'
+    WHERE family = 'case_law' AND generation = 'case_law_v6'
+  `);
+
+  expect(
+    await rejectionMessage(
+      db.execute(sql`
+        UPDATE corpus_index_generations
+        SET status = 'building'
+        WHERE family = 'case_law' AND generation = 'case_law_v6'
+      `),
+    ),
+  ).toContain("retired corpus index generation is terminal");
+});
+
+test("the ingestion role purges retired history only through the bounded function", async () => {
+  await db.execute(sql`
+    INSERT INTO case_law_decisions (
+      id, source_id, case_number, court, country, language, fulltext,
+      projection_epoch
+    ) VALUES (
+      ${RETIRED_DECISION_ID}, ${SOURCE_ID}, '1 A 3/2026', 'Test court',
+      'CZE', 'cs', 'retired', 1
+    )
+  `);
+  await db.execute(sql`
+    INSERT INTO corpus_index_generations (
+      family, generation, cluster, manifest_digest, status
+    ) VALUES (
+      'case_law', 'case_law_v8', 'q09', ${MANIFEST_DIGEST}, 'building'
+    )
+  `);
+  await db.execute(sql`
+    INSERT INTO corpus_index_projection_states (
+      family, generation, entity_id, desired_action, desired_epoch,
+      desired_fingerprint, desired_index_id
+    ) VALUES (
+      'case_law', 'case_law_v8', ${RETIRED_DECISION_ID}, 'upsert', 1,
+      ${FIRST_FINGERPRINT}, 'case_law_v8_cs_sk'
+    )
+  `);
+  await db.execute(sql`
+    INSERT INTO corpus_index_projection_intents (
+      id, family, generation, entity_id, epoch, fingerprint, index_id,
+      status, lease_token, lease_expires_at
+    ) VALUES (
+      ${RETIRED_REVISION}, 'case_law', 'case_law_v8',
+      ${RETIRED_DECISION_ID}, 1, ${FIRST_FINGERPRINT}, 'case_law_v8_cs_sk',
+      'reserved', ${LEASE_TOKEN}, clock_timestamp() + interval '5 minutes'
+    )
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'cancelled', cancelled_at = clock_timestamp(),
+        lease_token = NULL, lease_expires_at = NULL
+    WHERE id = ${RETIRED_REVISION}
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_generations
+    SET status = 'retired'
+    WHERE family = 'case_law' AND generation = 'case_law_v8'
+  `);
+
+  expect(
+    await rejectionMessage(
+      db.transaction(async (tx) => {
+        await tx.execute(sql`SET LOCAL ROLE stella_ingestion`);
+        await tx.execute(sql`
+          DELETE FROM corpus_index_projection_states
+          WHERE family = 'case_law' AND generation = 'case_law_v8'
+        `);
+      }),
+    ),
+  ).toContain("permission denied");
+
+  const purged = await db.transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL ROLE stella_ingestion`);
+    const result = await tx.execute<{
+      deleted_state_count: number;
+      deleted_intent_count: number;
+    }>(sql`
+      SELECT * FROM purge_retired_corpus_index_projection_history(
+        'case_law', 'case_law_v8', 100
+      )
+    `);
+    await tx.execute(sql`
+      DELETE FROM corpus_index_generations
+      WHERE family = 'case_law' AND generation = 'case_law_v8'
+    `);
+    return result.rows;
+  });
+  expect(purged).toEqual([{ deleted_state_count: 1, deleted_intent_count: 1 }]);
+
+  const remaining = await db.execute<{ count: number }>(sql`
+    SELECT count(*)::integer AS count
+    FROM corpus_index_projection_intents
+    WHERE generation = 'case_law_v8'
+  `);
+  expect(remaining.rows).toEqual([{ count: 0 }]);
+});
+
+test("the same fenced contract owns legislation generations", async () => {
+  await db.execute(sql`
+    INSERT INTO corpus_index_projection_states (
+      family, generation, entity_id, desired_action, desired_epoch,
+      desired_fingerprint, desired_index_id
+    ) VALUES (
+      'legislation', 'legislation_v2', ${LEGISLATION_DOCUMENT_ID}, 'upsert', 1,
+      ${FIRST_FINGERPRINT}, 'legislation_v2_cze'
+    )
+  `);
+  await db.execute(sql`
+    INSERT INTO corpus_index_projection_intents (
+      id, family, generation, entity_id, epoch, fingerprint, index_id,
+      status, lease_token, lease_expires_at
+    ) VALUES (
+      ${LEGISLATION_REVISION}, 'legislation', 'legislation_v2',
+      ${LEGISLATION_DOCUMENT_ID}, 1, ${FIRST_FINGERPRINT},
+      'legislation_v2_cze', 'reserved', ${LEASE_TOKEN},
+      clock_timestamp() + interval '5 minutes'
+    )
+  `);
+  await db.execute(sql`
+    UPDATE corpus_index_projection_intents
+    SET status = 'cancelled', cancelled_at = clock_timestamp(),
+        lease_token = NULL, lease_expires_at = NULL
+    WHERE id = ${LEGISLATION_REVISION}
+  `);
+
+  const result = await db.execute<{ status: string }>(sql`
+    SELECT status FROM corpus_index_projection_intents
+    WHERE id = ${LEGISLATION_REVISION}
+  `);
+  expect(result.rows).toEqual([{ status: "cancelled" }]);
+});

--- a/apps/api/src/lib/resource-identity.ts
+++ b/apps/api/src/lib/resource-identity.ts
@@ -100,6 +100,7 @@ export const RESOURCE_IDENTITY_DISPOSITION = {
   contactExtractionUpload: { type: "non_resource", reason: "workflow" },
   contactImportRequest: { type: "non_resource", reason: "workflow" },
   contactRelationship: { type: "non_resource", reason: "association" },
+  corpusIndexProjectionIntent: { type: "non_resource", reason: "workflow" },
   usageAllocation: { type: "non_resource", reason: "policy" },
   usageLaneCounter: { type: "non_resource", reason: "event" },
   usageSeatAssignment: { type: "non_resource", reason: "policy" },

--- a/apps/api/src/tests/pglite-test-db.ts
+++ b/apps/api/src/tests/pglite-test-db.ts
@@ -94,6 +94,14 @@ const CORPUS_PENDING_DELETE_TABLES_SQL = [
   .map(quoteSqlIdentifier)
   .join(", ");
 
+const CORPUS_PROJECTION_HISTORY_TABLES_SQL = [
+  schema.corpusIndexProjectionIntents,
+  schema.corpusIndexProjectionStates,
+]
+  .map(getTableName)
+  .map(quoteSqlIdentifier)
+  .join(", ");
+
 // The snapshot bakes in the superset every suite needs: RLS roles, schema,
 // workspace-access objects, and the role grants. Suites that never SET ROLE
 // simply ignore the grants.
@@ -235,6 +243,33 @@ const ROLE_GRANT_STATEMENTS = [
   `
     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE
       ${CORPUS_PENDING_DELETE_TABLES_SQL}
+    TO stella_ingestion
+  `,
+  // Final-generation state is observable by request code but mutated only by
+  // ingestion. A narrowly scoped database function owns retirement deletes.
+  `
+    REVOKE INSERT, UPDATE, DELETE ON TABLE
+      "corpus_index_generations",
+      ${CORPUS_PROJECTION_HISTORY_TABLES_SQL}
+    FROM stella
+  `,
+  `
+    GRANT SELECT ON TABLE
+      "corpus_index_generations",
+      ${CORPUS_PROJECTION_HISTORY_TABLES_SQL}
+    TO stella_ingestion
+  `,
+  `
+    GRANT INSERT, DELETE ON TABLE "corpus_index_generations"
+    TO stella_ingestion
+  `,
+  `
+    GRANT UPDATE (status, updated_at)
+      ON TABLE "corpus_index_generations" TO stella_ingestion
+  `,
+  `
+    GRANT INSERT, UPDATE ON TABLE
+      ${CORPUS_PROJECTION_HISTORY_TABLES_SQL}
     TO stella_ingestion
   `,
   // Preserve the v0.7.22 reader contract until its rollback window closes.

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -101,6 +101,11 @@ const POST_BOOTSTRAP_SELECT_ONLY_TABLES = new Set([
   // Corpus-index generation identity is immutable control-plane state. The
   // request role resolves serving generations but never mutates the registry.
   "corpus_index_generations",
+  // Final-generation desired/applied state and append intents are durable
+  // control-plane records. Request handlers may observe them; ingestion alone
+  // mutates the state machine.
+  "corpus_index_projection_states",
+  "corpus_index_projection_intents",
 ]);
 
 // Internal handoff tables whose scoped role needs INSERT but not table-wide


### PR DESCRIPTION
## Summary

- add PostgreSQL-authoritative desired/applied state for case-law v5 and legislation v2
- record every Quickwit append attempt as a unique projection revision with fenced lifecycle transitions
- enforce monotonic epochs, exact-route CAS, erasure settlement, and retired-generation history deletion in the database
- cover replacement, crash recovery, erasure races, and legislation with contract and database tests

## Safety

The schema is inert until the projection operations and Plane worker adopt it. Existing serving generations are unchanged.

## Verification

- targeted formatting on changed TypeScript files
- `git diff --check`
- full repository validation delegated to CI because the local workstation is under load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controlled tracking for search-index updates, including retries, cleanup, and completion states.
  * Added projection versioning to case-law and legislation records to prevent stale updates.
  * Added safeguards for valid lifecycle transitions, data consistency, and access permissions.

* **Tests**
  * Added comprehensive coverage for projection lifecycles, retries, cleanup, version fencing, and database security rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->