### PR TITLE
feat: derive final corpus projection state

### DIFF
--- a/apps/api/drizzle/20260825142000_corpus_index_projection_intents/migration.sql
+++ b/apps/api/drizzle/20260825142000_corpus_index_projection_intents/migration.sql
@@ -526,20 +526,21 @@ BEGIN
     RAISE EXCEPTION 'corpus index projection history requires a retired generation';
   END IF;
 
-  IF TG_TABLE_NAME = 'corpus_index_projection_intents'
-     AND OLD."status" NOT IN ('settled', 'cancelled') THEN
-    RAISE EXCEPTION 'nonterminal corpus index projection intent cannot be deleted';
-  END IF;
-
-  IF TG_TABLE_NAME = 'corpus_index_projection_states' AND EXISTS (
-    SELECT 1
-    FROM "corpus_index_projection_intents" intent
-    WHERE intent."family" = OLD."family"
-      AND intent."generation" = OLD."generation"
-      AND intent."entity_id" = OLD."entity_id"
-      AND intent."status" NOT IN ('settled', 'cancelled')
-  ) THEN
-    RAISE EXCEPTION 'projection state with nonterminal intents cannot be deleted';
+  IF TG_TABLE_NAME = 'corpus_index_projection_intents' THEN
+    IF OLD."status" NOT IN ('settled', 'cancelled') THEN
+      RAISE EXCEPTION 'nonterminal corpus index projection intent cannot be deleted';
+    END IF;
+  ELSIF TG_TABLE_NAME = 'corpus_index_projection_states' THEN
+    IF EXISTS (
+      SELECT 1
+      FROM "corpus_index_projection_intents" intent
+      WHERE intent."family" = OLD."family"
+        AND intent."generation" = OLD."generation"
+        AND intent."entity_id" = OLD."entity_id"
+        AND intent."status" NOT IN ('settled', 'cancelled')
+    ) THEN
+      RAISE EXCEPTION 'projection state with nonterminal intents cannot be deleted';
+    END IF;
   END IF;
 
   RETURN OLD;

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -2,7 +2,10 @@ import { panic, Result, TaggedError } from "better-result";
 
 import { envBase } from "@/api/env-base";
 import { fetchWithTimeout } from "@/api/lib/fetch";
-import type { CorpusIndexConfig } from "@/api/lib/legal-search/corpus-index-config";
+import {
+  CORPUS_INDEX_COMMIT_TIMEOUT_SECS,
+  type CorpusIndexConfig,
+} from "@/api/lib/legal-search/corpus-index-config";
 import { isRecord } from "@/api/lib/type-guards";
 
 /**
@@ -30,7 +33,8 @@ const SEARCH_TIMEOUT_MS = 30_000;
  * does not override it, so raising it engine-side means raising the
  * budget with it.
  */
-export const CORPUS_INDEX_COMMIT_WAIT_TIMEOUT_MS = 60_000;
+export const CORPUS_INDEX_COMMIT_WAIT_TIMEOUT_MS =
+  CORPUS_INDEX_COMMIT_TIMEOUT_SECS * 1000;
 
 /**
  * Whole-request budget for an ingest. Must exceed the commit wait above,

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -95,6 +95,9 @@ export const CORPUS_INDEX_MERGE_POLICY = {
   min_level_num_docs: 100_000,
 } as const;
 
+/** Engine commit window pinned by final-generation manifests and clients. */
+export const CORPUS_INDEX_COMMIT_TIMEOUT_SECS = 60;
+
 type CorpusIndexDocMappingMode = "lenient" | "strict" | "dynamic";
 
 export type CorpusIndexConfig = {
@@ -115,6 +118,7 @@ export type CorpusIndexConfig = {
   };
   indexing_settings: {
     merge_policy: typeof CORPUS_INDEX_MERGE_POLICY;
+    commit_timeout_secs?: number;
   };
   search_settings: {
     default_search_fields: string[];

--- a/apps/api/src/lib/legal-search/corpus-index-generations.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generations.db.test.ts
@@ -42,8 +42,8 @@ beforeAll(
     for (const statement of migration.split("--> statement-breakpoint")) {
       const ddl = statement.trim();
       if (
-        !ddl.startsWith("CREATE FUNCTION") &&
-        !ddl.startsWith("CREATE TRIGGER")
+        !/(?:^|\n)\s*CREATE (?:OR REPLACE )?FUNCTION\b/u.test(ddl) &&
+        !/(?:^|\n)\s*CREATE TRIGGER\b/u.test(ddl)
       ) {
         continue;
       }

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
@@ -1,17 +1,19 @@
 import { expect, test } from "bun:test";
 
+import { CORPUS_INDEX_COMMIT_TIMEOUT_SECS } from "@/api/lib/legal-search/corpus-index-config";
 import {
   CORPUS_INDEX_MANIFESTS,
   corpusIndexConfigFromManifest,
+  corpusIndexIdFromManifest,
   corpusIndexManifestDigest,
   requireCorpusIndexManifest,
 } from "@/api/lib/legal-search/corpus-index-manifest";
 
 const EXPECTED_DIGESTS = {
   case_law_v5:
-    "95c84d0c4a841ab65b69469824cdde3c0c438e310fa004927ddf26af1ea4b60d",
+    "98d516f3f4ee413bf716e6cbec345fb217390a3ae516dba20a5ae1bd2ac77741",
   legislation_v2:
-    "9ab1f962750f78cd4472a05551f6e265d55f428e0fb94de9b15467b61f24f9dd",
+    "fc0d1e8e972d95cae450f4863d5a9902db7c9634517e65f57748027a4ca2a265",
 } as const satisfies Record<keyof typeof CORPUS_INDEX_MANIFESTS, string>;
 
 test("the final-generation registry is exact and fails closed", () => {
@@ -105,6 +107,24 @@ test("physical index ids are deployment state, not manifest identity", () => {
   ]);
 });
 
+test("manifest routing is exact and case-law additions fail closed", () => {
+  expect(
+    corpusIndexIdFromManifest(CORPUS_INDEX_MANIFESTS.case_law_v5, "CZE"),
+  ).toBe("case_law_v5_cs_sk");
+  expect(
+    corpusIndexIdFromManifest(CORPUS_INDEX_MANIFESTS.case_law_v5, "SVK"),
+  ).toBe("case_law_v5_cs_sk");
+  expect(() =>
+    corpusIndexIdFromManifest(CORPUS_INDEX_MANIFESTS.case_law_v5, "HUN"),
+  ).toThrow("Unrouted case-law jurisdiction: HUN");
+  expect(
+    corpusIndexIdFromManifest(CORPUS_INDEX_MANIFESTS.legislation_v2, "HUN"),
+  ).toBe("legislation_v2_hun");
+  expect(() =>
+    corpusIndexIdFromManifest(CORPUS_INDEX_MANIFESTS.legislation_v2, "cz;drop"),
+  ).toThrow("Invalid corpus jurisdiction");
+});
+
 test("v5 removes stale and repeated physical fields", () => {
   const manifest = CORPUS_INDEX_MANIFESTS.case_law_v5;
   const fields = new Map(
@@ -114,6 +134,7 @@ test("v5 removes stale and repeated physical fields", () => {
     ]),
   );
   expect(manifest.engine.binaryVersion).toBe("0.9.0");
+  expect(manifest.projection.builderVersion).toBe("case-law-passages-v1");
   expect(manifest.engine.indexConfig.version).toBe("0.8");
   expect(manifest.engine.indexConfig.doc_mapping.mode).toBe("strict");
   expect(manifest.engine.indexConfig.doc_mapping.timestamp_field).toBe(
@@ -135,8 +156,8 @@ test("v5 removes stale and repeated physical fields", () => {
   expect(fields.get("projection_revision")).toMatchObject({
     tokenizer: "raw",
     indexed: true,
-    stored: true,
-    fast: false,
+    stored: false,
+    fast: true,
   });
   expect(fields.get("is_opening")).toEqual({
     name: "is_opening",
@@ -246,11 +267,15 @@ test("route topology and tag pruning are part of the manifest", () => {
     "court",
     "language",
   ]);
+  expect(caseLaw.engine.indexConfig.indexing_settings.commit_timeout_secs).toBe(
+    CORPUS_INDEX_COMMIT_TIMEOUT_SECS,
+  );
 
   const legislation = CORPUS_INDEX_MANIFESTS.legislation_v2;
   // Plane may add a jurisdiction without changing the public routing rule:
   // every legislation jurisdiction always receives its own physical index.
   expect(legislation.route).toEqual({ type: "jurisdiction" });
+  expect(legislation.projection.builderVersion).toBe("legislation-document-v1");
   expect(legislation.engine.indexConfig.doc_mapping.mode).toBe("strict");
   expect(legislation.engine.indexConfig.doc_mapping.tag_fields).toEqual([
     "jurisdiction",

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -309,9 +309,19 @@ const canonicalJson = (value: unknown): string => {
 export const corpusIndexContractDigest = (value: unknown): string =>
   new Bun.CryptoHasher("sha256").update(canonicalJson(value)).digest("hex");
 
+const manifestDigestByIdentity = new WeakMap<CorpusIndexManifest, string>();
+
 export const corpusIndexManifestDigest = (
   manifest: CorpusIndexManifest,
-): string => corpusIndexContractDigest(manifest);
+): string => {
+  const cachedDigest = manifestDigestByIdentity.get(manifest);
+  if (cachedDigest !== undefined) {
+    return cachedDigest;
+  }
+  const digest = corpusIndexContractDigest(manifest);
+  manifestDigestByIdentity.set(manifest, digest);
+  return digest;
+};
 
 export const corpusIndexConfigFromManifest = (
   manifest: CorpusIndexManifest,

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -4,12 +4,17 @@ import { CASE_LAW_INDEX_GROUP_OF } from "@/api/lib/legal-search/case-law-index-g
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
 import {
   CORPUS_INDEX_CONFIG_VERSION,
+  CORPUS_INDEX_COMMIT_TIMEOUT_SECS,
   CORPUS_INDEX_DATE_INPUT_FORMATS,
   CORPUS_INDEX_MERGE_POLICY,
   DECISION_TIMESTAMP_FIELD,
   FOLDED_TOKENIZER,
   type CorpusIndexConfig,
 } from "@/api/lib/legal-search/corpus-index-config";
+import {
+  CORPUS_INDEX_ID_MAX_LENGTH,
+  isCorpusIndexJurisdiction,
+} from "@/api/lib/legal-search/index-naming";
 
 export const CORPUS_INDEX_MANIFEST_SCHEMA_VERSION = 1;
 export const QUICKWIT_V09_BINARY_VERSION = "0.9.0";
@@ -32,7 +37,10 @@ type CorpusIndexManifestBase = {
 type CaseLawV5Manifest = CorpusIndexManifestBase & {
   family: "case_law";
   generation: "case_law_v5";
-  projection: CorpusIndexProjectionContract & { layout: "passage" };
+  projection: CorpusIndexProjectionContract & {
+    layout: "passage";
+    builderVersion: "case-law-passages-v1";
+  };
   route: {
     type: "case_law_group";
     byJurisdiction: typeof CASE_LAW_INDEX_GROUP_OF;
@@ -42,7 +50,10 @@ type CaseLawV5Manifest = CorpusIndexManifestBase & {
 type LegislationV2Manifest = CorpusIndexManifestBase & {
   family: "legislation";
   generation: "legislation_v2";
-  projection: CorpusIndexProjectionContract & { layout: "document" };
+  projection: CorpusIndexProjectionContract & {
+    layout: "document";
+    builderVersion: "legislation-document-v1";
+  };
   // The routing rule is fixed while the jurisdiction set is deliberately
   // open: adding a corpus creates another jurisdiction index without changing
   // the manifest. Plane decides which jurisdictions to build and when.
@@ -78,7 +89,9 @@ const dateField = (name: string): CorpusIndexFieldMapping => ({
 
 const commonFields = (): CorpusIndexFieldMapping[] => [
   rawField("document_id", { stored: true, fast: false }),
-  rawField("projection_revision", { stored: true, fast: false }),
+  // Exact cleanup queries and the standing orphan-revision census need this
+  // attempt identity in the columnar store. It is never returned to readers.
+  rawField("projection_revision", { stored: false, fast: true }),
   rawField("jurisdiction", { stored: false, fast: true }),
   rawField("document_type", { stored: false, fast: true }),
   rawField("source", { stored: false, fast: true }),
@@ -128,7 +141,10 @@ const indexConfig = (
       : { timestamp_field: timestampField }),
     store_source: false,
   },
-  indexing_settings: { merge_policy: CORPUS_INDEX_MERGE_POLICY },
+  indexing_settings: {
+    merge_policy: CORPUS_INDEX_MERGE_POLICY,
+    commit_timeout_secs: CORPUS_INDEX_COMMIT_TIMEOUT_SECS,
+  },
   search_settings: { default_search_fields: ["title", "text"] },
 });
 
@@ -198,6 +214,7 @@ export const CORPUS_INDEX_MANIFESTS = deepFreeze({
     },
     projection: {
       layout: "passage",
+      builderVersion: "case-law-passages-v1",
       documentIdField: "document_id",
       projectionRevisionField: "projection_revision",
       openingField: "is_opening",
@@ -218,6 +235,7 @@ export const CORPUS_INDEX_MANIFESTS = deepFreeze({
     },
     projection: {
       layout: "document",
+      builderVersion: "legislation-document-v1",
       documentIdField: "document_id",
       projectionRevisionField: "projection_revision",
       openingField: "is_opening",
@@ -288,10 +306,12 @@ const canonicalJson = (value: unknown): string => {
     .join(",")}}`;
 };
 
+export const corpusIndexContractDigest = (value: unknown): string =>
+  new Bun.CryptoHasher("sha256").update(canonicalJson(value)).digest("hex");
+
 export const corpusIndexManifestDigest = (
   manifest: CorpusIndexManifest,
-): string =>
-  new Bun.CryptoHasher("sha256").update(canonicalJson(manifest)).digest("hex");
+): string => corpusIndexContractDigest(manifest);
 
 export const corpusIndexConfigFromManifest = (
   manifest: CorpusIndexManifest,
@@ -299,4 +319,42 @@ export const corpusIndexConfigFromManifest = (
 ): CorpusIndexConfig => {
   const config = structuredClone(manifest.engine.indexConfig);
   return { ...config, index_id: indexId };
+};
+
+/**
+ * Resolve a canonical jurisdiction through the immutable generation route.
+ * Case-law topology is closed over the manifest; a new court corpus requires
+ * an explicit manifest decision. Legislation keeps the deliberate one-index-
+ * per-jurisdiction rule and therefore accepts any valid jurisdiction code.
+ */
+export const corpusIndexIdFromManifest = (
+  manifest: CorpusIndexManifest,
+  jurisdiction: string,
+): string => {
+  const canonical = jurisdiction.toUpperCase();
+  if (!isCorpusIndexJurisdiction(canonical)) {
+    return panic(`Invalid corpus jurisdiction: ${jurisdiction}`);
+  }
+
+  let suffix: string;
+  switch (manifest.route.type) {
+    case "case_law_group": {
+      const route = Object.entries(manifest.route.byJurisdiction).find(
+        ([candidate]) => candidate === canonical,
+      );
+      suffix =
+        route?.at(1) ?? panic(`Unrouted case-law jurisdiction: ${canonical}`);
+      break;
+    }
+    case "jurisdiction":
+      suffix = canonical.toLowerCase();
+      break;
+    default:
+      return manifest.route satisfies never;
+  }
+
+  const indexId = `${manifest.generation}_${suffix}`;
+  return indexId.length <= CORPUS_INDEX_ID_MAX_LENGTH
+    ? indexId
+    : panic(`Corpus index id exceeds storage limit: ${indexId}`);
 };

--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.db.test.ts
@@ -1,0 +1,241 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  caseLawDecisions,
+  caseLawSources,
+  corpusIndexGenerations,
+  corpusIndexProjectionStates,
+  legislationDocuments,
+  legislationSources,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import { bootstrapCorpusProjectionDesiredStateBatchTx } from "@/api/lib/legal-search/corpus-index-projection-bootstrap";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const CASE_LAW_SOURCE_ID = toSafeId<"caseLawSource">(
+  "0198e331-e578-7000-8000-000000000101",
+);
+const CASE_LAW_DECISION_ID = toSafeId<"caseLawDecision">(
+  "0198e331-e578-7000-8000-000000000102",
+);
+const SECOND_CASE_LAW_DECISION_ID = toSafeId<"caseLawDecision">(
+  "0198e331-e578-7000-8000-000000000105",
+);
+const LEGISLATION_SOURCE_ID = toSafeId<"legislationSource">(
+  "0198e331-e578-7000-8000-000000000103",
+);
+const LEGISLATION_DOCUMENT_ID = toSafeId<"legislationDocument">(
+  "0198e331-e578-7000-8000-000000000104",
+);
+const SECOND_LEGISLATION_DOCUMENT_ID = toSafeId<"legislationDocument">(
+  "0198e331-e578-7000-8000-000000000106",
+);
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+});
+
+beforeEach(async () => {
+  await db.delete(corpusIndexProjectionStates).where(sql`true`);
+  await db.delete(caseLawDecisions).where(sql`true`);
+  await db.delete(legislationDocuments).where(sql`true`);
+  await db.delete(caseLawSources).where(sql`true`);
+  await db.delete(legislationSources).where(sql`true`);
+  await db.delete(corpusIndexGenerations).where(sql`true`);
+
+  await db.insert(caseLawSources).values({
+    id: CASE_LAW_SOURCE_ID,
+    adapterKey: "projection-desired-state",
+    name: "Projection desired state",
+  });
+  await db.insert(caseLawDecisions).values([
+    {
+      id: CASE_LAW_DECISION_ID,
+      sourceId: CASE_LAW_SOURCE_ID,
+      caseNumber: "4 As 3/2008",
+      court: "Nejvyšší správní soud",
+      country: "CZE",
+      language: "cs",
+      contentHash: "a".repeat(64),
+    },
+    {
+      id: SECOND_CASE_LAW_DECISION_ID,
+      sourceId: CASE_LAW_SOURCE_ID,
+      caseNumber: "5 As 4/2009",
+      court: "Nejvyšší správní soud",
+      country: "CZE",
+      language: "cs",
+      contentHash: "c".repeat(64),
+    },
+  ]);
+  await db.insert(legislationSources).values({
+    id: LEGISLATION_SOURCE_ID,
+    adapterKey: "projection-desired-state",
+    name: "Projection desired state",
+  });
+  await db.insert(legislationDocuments).values([
+    {
+      id: LEGISLATION_DOCUMENT_ID,
+      sourceId: LEGISLATION_SOURCE_ID,
+      eli: "eli/cz/sb/2012/89",
+      title: "Občanský zákoník",
+      country: "CZE",
+      language: "cs",
+      contentHash: "b".repeat(64),
+    },
+    {
+      id: SECOND_LEGISLATION_DOCUMENT_ID,
+      sourceId: LEGISLATION_SOURCE_ID,
+      eli: "eli/cz/sb/2013/90",
+      title: "Zákon o státní službě",
+      country: "CZE",
+      language: "cs",
+      contentHash: "d".repeat(64),
+    },
+  ]);
+  await db.insert(corpusIndexGenerations).values([
+    {
+      family: "case_law",
+      generation: "case_law_v5",
+      cluster: "q09",
+      manifestDigest: corpusIndexManifestDigest(
+        CORPUS_INDEX_MANIFESTS.case_law_v5,
+      ),
+      status: "building",
+    },
+    {
+      family: "legislation",
+      generation: "legislation_v2",
+      cluster: "q09",
+      manifestDigest: corpusIndexManifestDigest(
+        CORPUS_INDEX_MANIFESTS.legislation_v2,
+      ),
+      status: "building",
+    },
+  ]);
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("bulk bootstrap advances a keyset cursor and reaches a fixed point", async () => {
+  const first = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        { family: "case_law", generation: "case_law_v5", limit: 1 },
+      ),
+  );
+  expect(first).toMatchObject({
+    status: "advanced",
+    family: "case_law",
+    generation: "case_law_v5",
+    claimedCount: 1,
+    seededCount: 1,
+    nextAfterEntityId: CASE_LAW_DECISION_ID,
+  });
+  expect(first.entityIds).toEqual([CASE_LAW_DECISION_ID]);
+
+  const second = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          limit: 1,
+          afterEntityId: CASE_LAW_DECISION_ID,
+        },
+      ),
+  );
+  expect(second).toMatchObject({
+    status: "advanced",
+    family: "case_law",
+    generation: "case_law_v5",
+    claimedCount: 1,
+    seededCount: 1,
+    entityIds: [SECOND_CASE_LAW_DECISION_ID],
+    nextAfterEntityId: SECOND_CASE_LAW_DECISION_ID,
+  });
+
+  const rangeComplete = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          limit: 1,
+          afterEntityId: SECOND_CASE_LAW_DECISION_ID,
+        },
+      ),
+  );
+  expect(rangeComplete).toEqual({
+    status: "range_complete",
+    family: "case_law",
+    generation: "case_law_v5",
+    claimedCount: 0,
+    seededCount: 0,
+    entityIds: [],
+  });
+
+  const complete = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        { family: "case_law", generation: "case_law_v5", limit: 1 },
+      ),
+  );
+  expect(complete).toEqual({
+    status: "complete",
+    family: "case_law",
+    generation: "case_law_v5",
+    claimedCount: 0,
+    seededCount: 0,
+    entityIds: [],
+  });
+
+  expect(
+    await db
+      .select({ entityId: corpusIndexProjectionStates.entityId })
+      .from(corpusIndexProjectionStates),
+  ).toHaveLength(2);
+  expect(
+    await db
+      .select({ epoch: caseLawDecisions.projectionEpoch })
+      .from(caseLawDecisions)
+      .orderBy(caseLawDecisions.id),
+  ).toEqual([{ epoch: 1n }, { epoch: 1n }]);
+});
+
+test("bulk bootstrap uses the same contract for legislation", async () => {
+  const result = await db.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        { family: "legislation", generation: "legislation_v2", limit: 2 },
+      ),
+  );
+
+  expect(result).toMatchObject({
+    status: "advanced",
+    family: "legislation",
+    generation: "legislation_v2",
+    claimedCount: 2,
+    seededCount: 2,
+  });
+  expect(result.entityIds).toHaveLength(2);
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
@@ -359,10 +359,11 @@ const bootstrapCaseLaw = async (
         documentType: row.documentType,
         contentHash: row.contentHash,
         redistributionEligible: isRedistributable(
-          descriptors.get(row.sourceId) ??
-            panic(
-              `Corpus projection bootstrap lost source descriptor for case-law source ${row.sourceId}`,
-            ),
+          descriptors.has(row.sourceId)
+            ? (descriptors.get(row.sourceId) ?? null)
+            : panic(
+                `Corpus projection bootstrap lost source descriptor for case-law source ${row.sourceId}`,
+              ),
         ),
         redacted: row.redactedAt !== null,
         caseNumber: row.caseNumber,
@@ -517,10 +518,11 @@ const bootstrapLegislation = async (
         documentType: row.documentType,
         contentHash: row.contentHash,
         redistributionEligible: isRedistributable(
-          descriptors.get(row.sourceId) ??
-            panic(
-              `Corpus projection bootstrap lost source descriptor for legislation source ${row.sourceId}`,
-            ),
+          descriptors.has(row.sourceId)
+            ? (descriptors.get(row.sourceId) ?? null)
+            : panic(
+                `Corpus projection bootstrap lost source descriptor for legislation source ${row.sourceId}`,
+              ),
         ),
         title: row.title,
         status: row.status,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
@@ -216,7 +216,41 @@ const bootstrapCaseLaw = async (
       ? []
       : [gt(caseLawDecisions.id, afterEntityId)]),
   ];
-  const rows = await tx
+  const candidates = await tx
+    .select({
+      documentId: caseLawDecisions.id,
+      sourceId: caseLawDecisions.sourceId,
+      sourceDescriptor: caseLawSources.descriptor,
+    })
+    .from(caseLawDecisions)
+    .innerJoin(caseLawSources, eq(caseLawSources.id, caseLawDecisions.sourceId))
+    .leftJoin(
+      corpusIndexProjectionStates,
+      and(
+        eq(corpusIndexProjectionStates.family, "case_law"),
+        eq(corpusIndexProjectionStates.generation, generation),
+        eq(corpusIndexProjectionStates.entityId, caseLawDecisions.id),
+      ),
+    )
+    .where(and(...conditions))
+    .orderBy(asc(caseLawDecisions.id))
+    .limit(limit)
+    // Canonical mutations lock source policy before the decision. Bootstrap
+    // uses the same order; a short policy update may delay this bounded claim.
+    .for("share", { of: caseLawSources });
+  if (candidates.length === 0) {
+    if (afterEntityId !== undefined) {
+      return emptyBootstrapResult("range_complete", "case_law", generation);
+    }
+    return emptyBootstrapResult(
+      (await hasUnseededCaseLawRows(tx, generation)) ? "busy" : "complete",
+      "case_law",
+      generation,
+    );
+  }
+
+  const candidateIds = candidates.map(({ documentId }) => documentId);
+  const lockedRows = await tx
     .select({
       documentId: caseLawDecisions.id,
       sourceId: caseLawDecisions.sourceId,
@@ -240,39 +274,32 @@ const bootstrapCaseLaw = async (
         eq(corpusIndexProjectionStates.entityId, caseLawDecisions.id),
       ),
     )
-    .where(and(...conditions))
+    .where(and(...conditions, inArray(caseLawDecisions.id, candidateIds)))
     .orderBy(asc(caseLawDecisions.id))
     .limit(limit)
     .for("update", { of: caseLawDecisions, skipLocked: true });
-  if (rows.length === 0) {
-    if (afterEntityId !== undefined) {
-      return emptyBootstrapResult("range_complete", "case_law", generation);
+  const lockedById = new Map(lockedRows.map((row) => [row.documentId, row]));
+  // Advance only across the contiguous prefix actually locked. Skipping past
+  // an earlier busy row would make a keyset cursor strand it indefinitely.
+  const rows: BootstrapCaseLawRow[] = [];
+  for (const candidate of candidates) {
+    const row = lockedById.get(candidate.documentId);
+    if (row === undefined) {
+      break;
     }
-    return emptyBootstrapResult(
-      (await hasUnseededCaseLawRows(tx, generation)) ? "busy" : "complete",
-      "case_law",
-      generation,
-    );
+    rows.push(row);
+  }
+  if (rows.length === 0) {
+    return emptyBootstrapResult("busy", "case_law", generation);
   }
 
   const entityIds = rows.map(({ documentId }) => documentId);
-  const sourceIds = [...new Set(rows.map(({ sourceId }) => sourceId))];
-  const sourceRows = await tx
-    .select({ id: caseLawSources.id, descriptor: caseLawSources.descriptor })
-    .from(caseLawSources)
-    .where(inArray(caseLawSources.id, sourceIds))
-    .orderBy(asc(caseLawSources.id))
-    .limit(sourceIds.length)
-    // A source-policy writer may already hold this row after another worker
-    // claimed one of its decisions. Do not wait in the opposite lock order;
-    // retry the bounded claim instead.
-    .for("share", { skipLocked: true });
   const descriptors = new Map(
-    sourceRows.map(({ id, descriptor }) => [id, descriptor]),
+    candidates.map(({ sourceId, sourceDescriptor }) => [
+      sourceId,
+      sourceDescriptor,
+    ]),
   );
-  if (descriptors.size !== sourceIds.length) {
-    return emptyBootstrapResult("busy", "case_law", generation);
-  }
 
   const identifiers = await tx
     .select({
@@ -387,7 +414,42 @@ const bootstrapLegislation = async (
       ? []
       : [gt(legislationDocuments.id, afterEntityId)]),
   ];
-  const rows = await tx
+  const candidates = await tx
+    .select({
+      documentId: legislationDocuments.id,
+      sourceId: legislationDocuments.sourceId,
+      sourceDescriptor: legislationSources.descriptor,
+    })
+    .from(legislationDocuments)
+    .innerJoin(
+      legislationSources,
+      eq(legislationSources.id, legislationDocuments.sourceId),
+    )
+    .leftJoin(
+      corpusIndexProjectionStates,
+      and(
+        eq(corpusIndexProjectionStates.family, "legislation"),
+        eq(corpusIndexProjectionStates.generation, generation),
+        eq(corpusIndexProjectionStates.entityId, legislationDocuments.id),
+      ),
+    )
+    .where(and(...conditions))
+    .orderBy(asc(legislationDocuments.id))
+    .limit(limit)
+    .for("share", { of: legislationSources });
+  if (candidates.length === 0) {
+    if (afterEntityId !== undefined) {
+      return emptyBootstrapResult("range_complete", "legislation", generation);
+    }
+    return emptyBootstrapResult(
+      (await hasUnseededLegislationRows(tx, generation)) ? "busy" : "complete",
+      "legislation",
+      generation,
+    );
+  }
+
+  const candidateIds = candidates.map(({ documentId }) => documentId);
+  const lockedRows = await tx
     .select({
       documentId: legislationDocuments.id,
       sourceId: legislationDocuments.sourceId,
@@ -412,40 +474,31 @@ const bootstrapLegislation = async (
         eq(corpusIndexProjectionStates.entityId, legislationDocuments.id),
       ),
     )
-    .where(and(...conditions))
+    .where(and(...conditions, inArray(legislationDocuments.id, candidateIds)))
     .orderBy(asc(legislationDocuments.id))
     .limit(limit)
     .for("update", { of: legislationDocuments, skipLocked: true });
-  if (rows.length === 0) {
-    if (afterEntityId !== undefined) {
-      return emptyBootstrapResult("range_complete", "legislation", generation);
+  const lockedById = new Map(lockedRows.map((row) => [row.documentId, row]));
+  // See the case-law path: the cursor may cross only a fully claimed prefix.
+  const rows: BootstrapLegislationRow[] = [];
+  for (const candidate of candidates) {
+    const row = lockedById.get(candidate.documentId);
+    if (row === undefined) {
+      break;
     }
-    return emptyBootstrapResult(
-      (await hasUnseededLegislationRows(tx, generation)) ? "busy" : "complete",
-      "legislation",
-      generation,
-    );
+    rows.push(row);
+  }
+  if (rows.length === 0) {
+    return emptyBootstrapResult("busy", "legislation", generation);
   }
 
   const entityIds = rows.map(({ documentId }) => documentId);
-  const sourceIds = [...new Set(rows.map(({ sourceId }) => sourceId))];
-  const sourceRows = await tx
-    .select({
-      id: legislationSources.id,
-      descriptor: legislationSources.descriptor,
-    })
-    .from(legislationSources)
-    .where(inArray(legislationSources.id, sourceIds))
-    .orderBy(asc(legislationSources.id))
-    .limit(sourceIds.length)
-    // Keep source-policy updates from deadlocking a decision-first claim.
-    .for("share", { skipLocked: true });
   const descriptors = new Map(
-    sourceRows.map(({ id, descriptor }) => [id, descriptor]),
+    candidates.map(({ sourceId, sourceDescriptor }) => [
+      sourceId,
+      sourceDescriptor,
+    ]),
   );
-  if (descriptors.size !== sourceIds.length) {
-    return emptyBootstrapResult("busy", "legislation", generation);
-  }
 
   await readActiveCorpusProjectionManifest(tx, "legislation", generation, true);
   await setZeroLegislationProjectionEpochs(tx, entityIds);

--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
@@ -1,0 +1,537 @@
+import { panic } from "better-result";
+import { and, asc, eq, gt, inArray, isNull } from "drizzle-orm";
+
+import { DECISION_IDENTIFIER_MAX_COUNT } from "@stll/legal-ast/decision-identifier";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  caseLawDecisionIdentifiers,
+  caseLawDecisions,
+  caseLawSources,
+  corpusIndexProjectionStates,
+  legislationDocuments,
+  legislationSources,
+} from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+import type { CorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
+import { deriveCorpusIndexProjectionDescriptor } from "@/api/lib/legal-search/corpus-index-projection-descriptor";
+import {
+  buildCorpusIndexProjectionDesiredStateValues,
+  readActiveCorpusProjectionManifest,
+  type CorpusIndexProjectionSubject,
+} from "@/api/lib/legal-search/corpus-index-projection-desired-state";
+import { isRedistributable } from "@/api/lib/legal-search/corpus-source";
+
+/**
+ * Upper bound for one bootstrap transaction. This bounds row locks and the
+ * in-memory descriptor set; Plane chooses how often to call the primitive.
+ */
+export const CORPUS_INDEX_PROJECTION_BOOTSTRAP_MAX_BATCH_SIZE = 1000;
+
+export type CorpusIndexProjectionBootstrapOptions =
+  | {
+      family: "case_law";
+      generation: string;
+      limit: number;
+      afterEntityId?: SafeId<"caseLawDecision">;
+    }
+  | {
+      family: "legislation";
+      generation: string;
+      limit: number;
+      afterEntityId?: SafeId<"legislationDocument">;
+    };
+
+export type CorpusIndexProjectionBootstrapResult =
+  | {
+      status: "advanced";
+      family: "case_law";
+      generation: string;
+      claimedCount: number;
+      seededCount: number;
+      entityIds: readonly SafeId<"caseLawDecision">[];
+      nextAfterEntityId: SafeId<"caseLawDecision">;
+    }
+  | {
+      status: "advanced";
+      family: "legislation";
+      generation: string;
+      claimedCount: number;
+      seededCount: number;
+      entityIds: readonly SafeId<"legislationDocument">[];
+      nextAfterEntityId: SafeId<"legislationDocument">;
+    }
+  | {
+      status: "complete" | "busy" | "range_complete";
+      family: CorpusIndexProjectionSubject["family"];
+      generation: string;
+      claimedCount: 0;
+      seededCount: 0;
+      entityIds: readonly [];
+    };
+
+const emptyBootstrapResult = (
+  status: "complete" | "busy" | "range_complete",
+  family: CorpusIndexProjectionSubject["family"],
+  generation: string,
+): CorpusIndexProjectionBootstrapResult => ({
+  status,
+  family,
+  generation,
+  claimedCount: 0,
+  seededCount: 0,
+  entityIds: [],
+});
+
+const validateBootstrapLimit = (limit: number): number => {
+  if (
+    !Number.isSafeInteger(limit) ||
+    limit < 1 ||
+    limit > CORPUS_INDEX_PROJECTION_BOOTSTRAP_MAX_BATCH_SIZE
+  ) {
+    return panic(
+      `Corpus projection bootstrap limit must be an integer from 1 to ${CORPUS_INDEX_PROJECTION_BOOTSTRAP_MAX_BATCH_SIZE}`,
+    );
+  }
+  return limit;
+};
+
+type BootstrapCaseLawRow = {
+  documentId: SafeId<"caseLawDecision">;
+  sourceId: SafeId<"caseLawSource">;
+  jurisdiction: string;
+  language: string;
+  documentType: string | null;
+  contentHash: string | null;
+  redactedAt: Date | null;
+  caseNumber: string;
+  court: string;
+  decisionDate: string | null;
+  ecli: string | null;
+  projectionEpoch: bigint;
+};
+
+type BootstrapLegislationRow = {
+  documentId: SafeId<"legislationDocument">;
+  sourceId: SafeId<"legislationSource">;
+  jurisdiction: string;
+  language: string;
+  documentType: string | null;
+  contentHash: string | null;
+  title: string;
+  status: string;
+  effectiveDate: string | null;
+  versionValidFrom: string | null;
+  versionValidTo: string | null;
+  eli: string;
+  projectionEpoch: bigint;
+};
+
+const setZeroCaseLawProjectionEpochs = async (
+  tx: Transaction,
+  entityIds: readonly SafeId<"caseLawDecision">[],
+): Promise<void> => {
+  if (entityIds.length === 0) {
+    return;
+  }
+  await tx
+    .update(caseLawDecisions)
+    .set({ projectionEpoch: 1n })
+    .where(
+      and(
+        inArray(caseLawDecisions.id, entityIds),
+        eq(caseLawDecisions.projectionEpoch, 0n),
+      ),
+    );
+};
+
+const setZeroLegislationProjectionEpochs = async (
+  tx: Transaction,
+  entityIds: readonly SafeId<"legislationDocument">[],
+): Promise<void> => {
+  if (entityIds.length === 0) {
+    return;
+  }
+  await tx
+    .update(legislationDocuments)
+    .set({ projectionEpoch: 1n })
+    .where(
+      and(
+        inArray(legislationDocuments.id, entityIds),
+        eq(legislationDocuments.projectionEpoch, 0n),
+      ),
+    );
+};
+
+const hasUnseededCaseLawRows = async (
+  tx: Transaction,
+  generation: string,
+): Promise<boolean> => {
+  const rows = await tx
+    .select({ documentId: caseLawDecisions.id })
+    .from(caseLawDecisions)
+    .leftJoin(
+      corpusIndexProjectionStates,
+      and(
+        eq(corpusIndexProjectionStates.family, "case_law"),
+        eq(corpusIndexProjectionStates.generation, generation),
+        eq(corpusIndexProjectionStates.entityId, caseLawDecisions.id),
+      ),
+    )
+    .where(isNull(corpusIndexProjectionStates.entityId))
+    .limit(1);
+  return rows.length > 0;
+};
+
+const hasUnseededLegislationRows = async (
+  tx: Transaction,
+  generation: string,
+): Promise<boolean> => {
+  const rows = await tx
+    .select({ documentId: legislationDocuments.id })
+    .from(legislationDocuments)
+    .leftJoin(
+      corpusIndexProjectionStates,
+      and(
+        eq(corpusIndexProjectionStates.family, "legislation"),
+        eq(corpusIndexProjectionStates.generation, generation),
+        eq(corpusIndexProjectionStates.entityId, legislationDocuments.id),
+      ),
+    )
+    .where(isNull(corpusIndexProjectionStates.entityId))
+    .limit(1);
+  return rows.length > 0;
+};
+
+const bootstrapCaseLaw = async (
+  tx: Transaction,
+  generation: string,
+  limit: number,
+  afterEntityId: SafeId<"caseLawDecision"> | undefined,
+  manifest: CorpusIndexManifest,
+): Promise<CorpusIndexProjectionBootstrapResult> => {
+  const conditions = [
+    isNull(corpusIndexProjectionStates.entityId),
+    ...(afterEntityId === undefined
+      ? []
+      : [gt(caseLawDecisions.id, afterEntityId)]),
+  ];
+  const rows = await tx
+    .select({
+      documentId: caseLawDecisions.id,
+      sourceId: caseLawDecisions.sourceId,
+      jurisdiction: caseLawDecisions.country,
+      language: caseLawDecisions.language,
+      documentType: caseLawDecisions.decisionType,
+      contentHash: caseLawDecisions.contentHash,
+      redactedAt: caseLawDecisions.redactedAt,
+      caseNumber: caseLawDecisions.caseNumber,
+      court: caseLawDecisions.court,
+      decisionDate: caseLawDecisions.decisionDate,
+      ecli: caseLawDecisions.ecli,
+      projectionEpoch: caseLawDecisions.projectionEpoch,
+    })
+    .from(caseLawDecisions)
+    .leftJoin(
+      corpusIndexProjectionStates,
+      and(
+        eq(corpusIndexProjectionStates.family, "case_law"),
+        eq(corpusIndexProjectionStates.generation, generation),
+        eq(corpusIndexProjectionStates.entityId, caseLawDecisions.id),
+      ),
+    )
+    .where(and(...conditions))
+    .orderBy(asc(caseLawDecisions.id))
+    .limit(limit)
+    .for("update", { of: caseLawDecisions, skipLocked: true });
+  if (rows.length === 0) {
+    if (afterEntityId !== undefined) {
+      return emptyBootstrapResult("range_complete", "case_law", generation);
+    }
+    return emptyBootstrapResult(
+      (await hasUnseededCaseLawRows(tx, generation)) ? "busy" : "complete",
+      "case_law",
+      generation,
+    );
+  }
+
+  const entityIds = rows.map(({ documentId }) => documentId);
+  const sourceIds = [...new Set(rows.map(({ sourceId }) => sourceId))];
+  const sourceRows = await tx
+    .select({ id: caseLawSources.id, descriptor: caseLawSources.descriptor })
+    .from(caseLawSources)
+    .where(inArray(caseLawSources.id, sourceIds))
+    .orderBy(asc(caseLawSources.id))
+    .limit(sourceIds.length)
+    // A source-policy writer may already hold this row after another worker
+    // claimed one of its decisions. Do not wait in the opposite lock order;
+    // retry the bounded claim instead.
+    .for("share", { skipLocked: true });
+  const descriptors = new Map(
+    sourceRows.map(({ id, descriptor }) => [id, descriptor]),
+  );
+  if (descriptors.size !== sourceIds.length) {
+    return emptyBootstrapResult("busy", "case_law", generation);
+  }
+
+  const identifiers = await tx
+    .select({
+      decisionId: caseLawDecisionIdentifiers.decisionId,
+      type: caseLawDecisionIdentifiers.type,
+      value: caseLawDecisionIdentifiers.value,
+    })
+    .from(caseLawDecisionIdentifiers)
+    .where(inArray(caseLawDecisionIdentifiers.decisionId, entityIds))
+    .orderBy(
+      asc(caseLawDecisionIdentifiers.decisionId),
+      asc(caseLawDecisionIdentifiers.type),
+      asc(caseLawDecisionIdentifiers.value),
+    )
+    .limit(entityIds.length * DECISION_IDENTIFIER_MAX_COUNT + 1)
+    .for("share");
+  if (identifiers.length > entityIds.length * DECISION_IDENTIFIER_MAX_COUNT) {
+    return panic(
+      `Corpus projection bootstrap identifier count exceeds ${DECISION_IDENTIFIER_MAX_COUNT} per decision`,
+    );
+  }
+  const identifiersByDecision = new Map<
+    string,
+    { type: string; value: string }[]
+  >(entityIds.map((entityId) => [entityId, []]));
+  for (const identifier of identifiers) {
+    const values = identifiersByDecision.get(identifier.decisionId);
+    if (values === undefined) {
+      return panic(
+        `Corpus projection bootstrap loaded an identifier for unclaimed decision ${identifier.decisionId}`,
+      );
+    }
+    if (values.length >= DECISION_IDENTIFIER_MAX_COUNT) {
+      return panic(
+        `Corpus projection bootstrap decision exceeds ${DECISION_IDENTIFIER_MAX_COUNT} identifiers: ${identifier.decisionId}`,
+      );
+    }
+    values.push({ type: identifier.type, value: identifier.value });
+  }
+
+  // Recheck the generation after claiming canonical rows. Retirement waits on
+  // this share lock, and a changed status rolls back the whole bounded claim.
+  await readActiveCorpusProjectionManifest(tx, "case_law", generation, true);
+  await setZeroCaseLawProjectionEpochs(tx, entityIds);
+
+  const values = rows.map((row: BootstrapCaseLawRow) =>
+    buildCorpusIndexProjectionDesiredStateValues({
+      subject: { family: "case_law", entityId: row.documentId },
+      generation,
+      epoch: row.projectionEpoch === 0n ? 1n : row.projectionEpoch,
+      descriptor: deriveCorpusIndexProjectionDescriptor(manifest, {
+        family: "case_law",
+        documentId: row.documentId,
+        sourceId: row.sourceId,
+        jurisdiction: row.jurisdiction,
+        language: row.language,
+        documentType: row.documentType,
+        contentHash: row.contentHash,
+        redistributionEligible: isRedistributable(
+          descriptors.get(row.sourceId) ?? null,
+        ),
+        redacted: row.redactedAt !== null,
+        caseNumber: row.caseNumber,
+        identifiers:
+          identifiersByDecision.get(row.documentId) ??
+          panic(
+            `Corpus projection bootstrap lost identifier state for decision ${row.documentId}`,
+          ),
+        court: row.court,
+        decisionDate: row.decisionDate,
+        ecli: row.ecli,
+      }),
+    }),
+  );
+  const inserted = await tx
+    .insert(corpusIndexProjectionStates)
+    .values(values)
+    .returning({ entityId: corpusIndexProjectionStates.entityId });
+  if (inserted.length !== rows.length) {
+    return panic(
+      `Corpus projection bootstrap inserted ${inserted.length} of ${rows.length} case-law states`,
+    );
+  }
+  const lastEntityId = rows.at(-1)?.documentId;
+  if (lastEntityId === undefined) {
+    return panic("Corpus projection bootstrap claimed no case-law row");
+  }
+  return {
+    status: "advanced",
+    family: "case_law",
+    generation,
+    claimedCount: rows.length,
+    seededCount: inserted.length,
+    entityIds,
+    nextAfterEntityId: lastEntityId,
+  };
+};
+
+const bootstrapLegislation = async (
+  tx: Transaction,
+  generation: string,
+  limit: number,
+  afterEntityId: SafeId<"legislationDocument"> | undefined,
+  manifest: CorpusIndexManifest,
+): Promise<CorpusIndexProjectionBootstrapResult> => {
+  const conditions = [
+    isNull(corpusIndexProjectionStates.entityId),
+    ...(afterEntityId === undefined
+      ? []
+      : [gt(legislationDocuments.id, afterEntityId)]),
+  ];
+  const rows = await tx
+    .select({
+      documentId: legislationDocuments.id,
+      sourceId: legislationDocuments.sourceId,
+      jurisdiction: legislationDocuments.country,
+      language: legislationDocuments.language,
+      documentType: legislationDocuments.documentType,
+      contentHash: legislationDocuments.contentHash,
+      title: legislationDocuments.title,
+      status: legislationDocuments.status,
+      effectiveDate: legislationDocuments.effectiveDate,
+      versionValidFrom: legislationDocuments.versionValidFrom,
+      versionValidTo: legislationDocuments.versionValidTo,
+      eli: legislationDocuments.eli,
+      projectionEpoch: legislationDocuments.projectionEpoch,
+    })
+    .from(legislationDocuments)
+    .leftJoin(
+      corpusIndexProjectionStates,
+      and(
+        eq(corpusIndexProjectionStates.family, "legislation"),
+        eq(corpusIndexProjectionStates.generation, generation),
+        eq(corpusIndexProjectionStates.entityId, legislationDocuments.id),
+      ),
+    )
+    .where(and(...conditions))
+    .orderBy(asc(legislationDocuments.id))
+    .limit(limit)
+    .for("update", { of: legislationDocuments, skipLocked: true });
+  if (rows.length === 0) {
+    if (afterEntityId !== undefined) {
+      return emptyBootstrapResult("range_complete", "legislation", generation);
+    }
+    return emptyBootstrapResult(
+      (await hasUnseededLegislationRows(tx, generation)) ? "busy" : "complete",
+      "legislation",
+      generation,
+    );
+  }
+
+  const entityIds = rows.map(({ documentId }) => documentId);
+  const sourceIds = [...new Set(rows.map(({ sourceId }) => sourceId))];
+  const sourceRows = await tx
+    .select({
+      id: legislationSources.id,
+      descriptor: legislationSources.descriptor,
+    })
+    .from(legislationSources)
+    .where(inArray(legislationSources.id, sourceIds))
+    .orderBy(asc(legislationSources.id))
+    .limit(sourceIds.length)
+    // Keep source-policy updates from deadlocking a decision-first claim.
+    .for("share", { skipLocked: true });
+  const descriptors = new Map(
+    sourceRows.map(({ id, descriptor }) => [id, descriptor]),
+  );
+  if (descriptors.size !== sourceIds.length) {
+    return emptyBootstrapResult("busy", "legislation", generation);
+  }
+
+  await readActiveCorpusProjectionManifest(tx, "legislation", generation, true);
+  await setZeroLegislationProjectionEpochs(tx, entityIds);
+
+  const values = rows.map((row: BootstrapLegislationRow) =>
+    buildCorpusIndexProjectionDesiredStateValues({
+      subject: { family: "legislation", entityId: row.documentId },
+      generation,
+      epoch: row.projectionEpoch === 0n ? 1n : row.projectionEpoch,
+      descriptor: deriveCorpusIndexProjectionDescriptor(manifest, {
+        family: "legislation",
+        documentId: row.documentId,
+        sourceId: row.sourceId,
+        jurisdiction: row.jurisdiction,
+        language: row.language,
+        documentType: row.documentType,
+        contentHash: row.contentHash,
+        redistributionEligible: isRedistributable(
+          descriptors.get(row.sourceId) ?? null,
+        ),
+        title: row.title,
+        status: row.status,
+        effectiveDate: row.effectiveDate,
+        versionValidFrom: row.versionValidFrom,
+        versionValidTo: row.versionValidTo,
+        eli: row.eli,
+      }),
+    }),
+  );
+  const inserted = await tx
+    .insert(corpusIndexProjectionStates)
+    .values(values)
+    .returning({ entityId: corpusIndexProjectionStates.entityId });
+  if (inserted.length !== rows.length) {
+    return panic(
+      `Corpus projection bootstrap inserted ${inserted.length} of ${rows.length} legislation states`,
+    );
+  }
+  const lastEntityId = rows.at(-1)?.documentId;
+  if (lastEntityId === undefined) {
+    return panic("Corpus projection bootstrap claimed no legislation row");
+  }
+  return {
+    status: "advanced",
+    family: "legislation",
+    generation,
+    claimedCount: rows.length,
+    seededCount: inserted.length,
+    entityIds,
+    nextAfterEntityId: lastEntityId,
+  };
+};
+
+/**
+ * Seed one active final generation in a bounded, replay-safe batch. The query
+ * uses a keyset cursor so a large seeded prefix is not rescanned on every
+ * batch. Rows skipped because another worker owns them remain eligible for a
+ * later null-cursor sweep; callers reset the cursor after range_complete.
+ * A busy result never advances the cursor.
+ */
+export const bootstrapCorpusProjectionDesiredStateBatchTx = async (
+  tx: Transaction,
+  options: CorpusIndexProjectionBootstrapOptions,
+): Promise<CorpusIndexProjectionBootstrapResult> => {
+  const limit = validateBootstrapLimit(options.limit);
+  const manifest = await readActiveCorpusProjectionManifest(
+    tx,
+    options.family,
+    options.generation,
+    false,
+  );
+  switch (options.family) {
+    case "case_law":
+      return await bootstrapCaseLaw(
+        tx,
+        options.generation,
+        limit,
+        options.afterEntityId,
+        manifest,
+      );
+    case "legislation":
+      return await bootstrapLegislation(
+        tx,
+        options.generation,
+        limit,
+        options.afterEntityId,
+        manifest,
+      );
+    default:
+      return options satisfies never;
+  }
+};

--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
@@ -332,7 +332,10 @@ const bootstrapCaseLaw = async (
         documentType: row.documentType,
         contentHash: row.contentHash,
         redistributionEligible: isRedistributable(
-          descriptors.get(row.sourceId) ?? null,
+          descriptors.get(row.sourceId) ??
+            panic(
+              `Corpus projection bootstrap lost source descriptor for case-law source ${row.sourceId}`,
+            ),
         ),
         redacted: row.redactedAt !== null,
         caseNumber: row.caseNumber,
@@ -461,7 +464,10 @@ const bootstrapLegislation = async (
         documentType: row.documentType,
         contentHash: row.contentHash,
         redistributionEligible: isRedistributable(
-          descriptors.get(row.sourceId) ?? null,
+          descriptors.get(row.sourceId) ??
+            panic(
+              `Corpus projection bootstrap lost source descriptor for legislation source ${row.sourceId}`,
+            ),
         ),
         title: row.title,
         status: row.status,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.test.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "bun:test";
+
+import { CORPUS_INDEX_MANIFESTS } from "@/api/lib/legal-search/corpus-index-manifest";
+import {
+  caseLawV5Title,
+  deriveCorpusIndexProjectionDescriptor,
+  type CaseLawV5ProjectionInput,
+  type LegislationV2ProjectionInput,
+} from "@/api/lib/legal-search/corpus-index-projection-descriptor";
+
+const CASE_LAW_INPUT = {
+  family: "case_law",
+  documentId: "0198e331-e578-7000-8000-000000000001",
+  sourceId: "0198e331-e578-7000-8000-000000000002",
+  jurisdiction: "CZE",
+  language: "cs",
+  documentType: "judgment",
+  contentHash: "a".repeat(64),
+  redistributionEligible: true,
+  redacted: false,
+  caseNumber: "4 As 3/2008",
+  identifiers: [
+    { type: "source", value: "NSS-4-AS-3-2008" },
+    { type: "docket", value: "4 As 3/2008" },
+  ],
+  court: "Nejvyšší správní soud",
+  decisionDate: "2008-02-27",
+  ecli: null,
+} as const satisfies CaseLawV5ProjectionInput;
+
+const LEGISLATION_INPUT = {
+  family: "legislation",
+  documentId: "0198e331-e578-7000-8000-000000000003",
+  sourceId: "0198e331-e578-7000-8000-000000000004",
+  jurisdiction: "CZE",
+  language: "cs",
+  documentType: "act",
+  contentHash: "b".repeat(64),
+  redistributionEligible: true,
+  title: "Občanský zákoník",
+  status: "current",
+  effectiveDate: "2014-01-01",
+  versionValidFrom: "2014-01-01",
+  versionValidTo: null,
+  eli: "eli/cz/sb/2012/89",
+} as const satisfies LegislationV2ProjectionInput;
+
+test("case-law title and fingerprint canonicalize identifier order", () => {
+  expect(caseLawV5Title(CASE_LAW_INPUT)).toBe(
+    "4 As 3/2008 · NSS-4-AS-3-2008 — Nejvyšší správní soud",
+  );
+  const first = deriveCorpusIndexProjectionDescriptor(
+    CORPUS_INDEX_MANIFESTS.case_law_v5,
+    CASE_LAW_INPUT,
+  );
+  const second = deriveCorpusIndexProjectionDescriptor(
+    CORPUS_INDEX_MANIFESTS.case_law_v5,
+    { ...CASE_LAW_INPUT, identifiers: CASE_LAW_INPUT.identifiers.toReversed() },
+  );
+  expect(first).toEqual(second);
+  expect(first).toMatchObject({
+    action: "upsert",
+    indexId: "case_law_v5_cs_sk",
+  });
+  expect(first.action === "upsert" ? first.fingerprint : "").toMatch(
+    /^[0-9a-f]{64}$/u,
+  );
+});
+
+test("every projected metadata change invalidates the input fingerprint", () => {
+  const first = deriveCorpusIndexProjectionDescriptor(
+    CORPUS_INDEX_MANIFESTS.case_law_v5,
+    CASE_LAW_INPUT,
+  );
+  const changed = deriveCorpusIndexProjectionDescriptor(
+    CORPUS_INDEX_MANIFESTS.case_law_v5,
+    { ...CASE_LAW_INPUT, court: "Ústavní soud" },
+  );
+  expect(changed).not.toEqual(first);
+});
+
+test("redaction, missing payload, and redistribution revocation erase", () => {
+  for (const input of [
+    { ...CASE_LAW_INPUT, redacted: true },
+    { ...CASE_LAW_INPUT, contentHash: null },
+    { ...CASE_LAW_INPUT, redistributionEligible: false },
+  ]) {
+    expect(
+      deriveCorpusIndexProjectionDescriptor(
+        CORPUS_INDEX_MANIFESTS.case_law_v5,
+        input,
+      ),
+    ).toEqual({ action: "erase" });
+  }
+});
+
+test("legislation uses the open jurisdiction route and exact metadata", () => {
+  const first = deriveCorpusIndexProjectionDescriptor(
+    CORPUS_INDEX_MANIFESTS.legislation_v2,
+    LEGISLATION_INPUT,
+  );
+  expect(first).toMatchObject({
+    action: "upsert",
+    indexId: "legislation_v2_cze",
+  });
+  expect(
+    deriveCorpusIndexProjectionDescriptor(
+      CORPUS_INDEX_MANIFESTS.legislation_v2,
+      { ...LEGISLATION_INPUT, status: "repealed" },
+    ),
+  ).not.toEqual(first);
+});
+
+test("manifest and projection families cannot be crossed", () => {
+  expect(() =>
+    deriveCorpusIndexProjectionDescriptor(
+      CORPUS_INDEX_MANIFESTS.legislation_v2,
+      CASE_LAW_INPUT,
+    ),
+  ).toThrow("Corpus projection family mismatch");
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.ts
@@ -1,0 +1,145 @@
+import { panic } from "better-result";
+
+import { UNDATED_DECISION_TIMESTAMP } from "@/api/lib/legal-search/corpus-index-config";
+import {
+  corpusIndexContractDigest,
+  corpusIndexIdFromManifest,
+  corpusIndexManifestDigest,
+  type CorpusIndexManifest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+
+type ProjectionInputBase = {
+  documentId: string;
+  sourceId: string;
+  jurisdiction: string;
+  language: string;
+  documentType: string | null;
+  contentHash: string | null;
+  redistributionEligible: boolean;
+};
+
+export type CaseLawV5ProjectionInput = ProjectionInputBase & {
+  family: "case_law";
+  redacted: boolean;
+  caseNumber: string;
+  identifiers: readonly { type: string; value: string }[];
+  court: string;
+  decisionDate: string | null;
+  ecli: string | null;
+};
+
+export type LegislationV2ProjectionInput = ProjectionInputBase & {
+  family: "legislation";
+  title: string;
+  status: string;
+  effectiveDate: string | null;
+  versionValidFrom: string | null;
+  versionValidTo: string | null;
+  eli: string;
+};
+
+export type CorpusIndexProjectionInput =
+  | CaseLawV5ProjectionInput
+  | LegislationV2ProjectionInput;
+
+export type CorpusIndexProjectionDescriptor =
+  | { action: "erase" }
+  | { action: "upsert"; fingerprint: string; indexId: string };
+
+const compareIdentifiers = (
+  left: CaseLawV5ProjectionInput["identifiers"][number],
+  right: CaseLawV5ProjectionInput["identifiers"][number],
+): number => {
+  if (left.type < right.type) {
+    return -1;
+  }
+  if (left.type > right.type) {
+    return 1;
+  }
+  if (left.value < right.value) {
+    return -1;
+  }
+  return left.value > right.value ? 1 : 0;
+};
+
+export const caseLawV5Title = ({
+  identifiers,
+  caseNumber,
+  court,
+}: Pick<
+  CaseLawV5ProjectionInput,
+  "identifiers" | "caseNumber" | "court"
+>): string => {
+  const canonicalIdentifiers = identifiers.toSorted(compareIdentifiers);
+  const reference =
+    canonicalIdentifiers.length === 0
+      ? caseNumber
+      : canonicalIdentifiers.map(({ value }) => value).join(" · ");
+  return `${reference} — ${court}`;
+};
+
+export const deriveCorpusIndexProjectionDescriptor = (
+  manifest: CorpusIndexManifest,
+  input: CorpusIndexProjectionInput,
+): CorpusIndexProjectionDescriptor => {
+  if (manifest.family !== input.family) {
+    return panic(
+      `Corpus projection family mismatch: ${manifest.family}/${input.family}`,
+    );
+  }
+  if (
+    input.contentHash === null ||
+    !input.redistributionEligible ||
+    (input.family === "case_law" && input.redacted)
+  ) {
+    return { action: "erase" };
+  }
+
+  const indexId = corpusIndexIdFromManifest(manifest, input.jurisdiction);
+  const common = {
+    contract: "corpus-index-projection-v1",
+    manifestDigest: corpusIndexManifestDigest(manifest),
+    documentId: input.documentId,
+    contentHash: input.contentHash,
+    indexId,
+    jurisdiction: input.jurisdiction.toUpperCase(),
+    source: input.sourceId,
+    language: input.language,
+    documentType: input.documentType,
+    redistributionEligible: true,
+  } as const;
+
+  switch (input.family) {
+    case "case_law":
+      return {
+        action: "upsert",
+        indexId,
+        fingerprint: corpusIndexContractDigest({
+          ...common,
+          title: caseLawV5Title(input),
+          caseNumber: input.caseNumber,
+          court: input.court,
+          decisionDate: input.decisionDate,
+          decisionDateTimestamp:
+            input.decisionDate ?? UNDATED_DECISION_TIMESTAMP,
+          ecli: input.ecli,
+        }),
+      };
+    case "legislation":
+      return {
+        action: "upsert",
+        indexId,
+        fingerprint: corpusIndexContractDigest({
+          ...common,
+          title: input.title,
+          status: input.status,
+          effectiveDate: input.effectiveDate,
+          versionValidFrom: input.versionValidFrom,
+          versionValidTo: input.versionValidTo,
+          eli: input.eli,
+        }),
+      };
+    default:
+      return input satisfies never;
+  }
+};

--- a/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.db.test.ts
@@ -1,0 +1,272 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  caseLawDecisions,
+  caseLawSources,
+  corpusIndexGenerations,
+  corpusIndexProjectionStates,
+  legislationDocuments,
+  legislationSources,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import {
+  advanceCorpusProjectionDesiredStateTx,
+  ensureCorpusProjectionDesiredStateTx,
+  reconcileCorpusProjectionDesiredStateTx,
+} from "@/api/lib/legal-search/corpus-index-projection-desired-state";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const CASE_LAW_SOURCE_ID = toSafeId<"caseLawSource">(
+  "0198e331-e578-7000-8000-000000000101",
+);
+const CASE_LAW_DECISION_ID = toSafeId<"caseLawDecision">(
+  "0198e331-e578-7000-8000-000000000102",
+);
+const LEGISLATION_SOURCE_ID = toSafeId<"legislationSource">(
+  "0198e331-e578-7000-8000-000000000103",
+);
+const LEGISLATION_DOCUMENT_ID = toSafeId<"legislationDocument">(
+  "0198e331-e578-7000-8000-000000000104",
+);
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+});
+
+beforeEach(async () => {
+  await db.delete(corpusIndexProjectionStates).where(sql`true`);
+  await db.delete(caseLawDecisions).where(sql`true`);
+  await db.delete(legislationDocuments).where(sql`true`);
+  await db.delete(caseLawSources).where(sql`true`);
+  await db.delete(legislationSources).where(sql`true`);
+  await db.delete(corpusIndexGenerations).where(sql`true`);
+
+  await db.insert(caseLawSources).values({
+    id: CASE_LAW_SOURCE_ID,
+    adapterKey: "projection-desired-state",
+    name: "Projection desired state",
+  });
+  await db.insert(caseLawDecisions).values({
+    id: CASE_LAW_DECISION_ID,
+    sourceId: CASE_LAW_SOURCE_ID,
+    caseNumber: "4 As 3/2008",
+    court: "Nejvyšší správní soud",
+    country: "CZE",
+    language: "cs",
+    contentHash: "a".repeat(64),
+  });
+  await db.insert(legislationSources).values({
+    id: LEGISLATION_SOURCE_ID,
+    adapterKey: "projection-desired-state",
+    name: "Projection desired state",
+  });
+  await db.insert(legislationDocuments).values({
+    id: LEGISLATION_DOCUMENT_ID,
+    sourceId: LEGISLATION_SOURCE_ID,
+    eli: "eli/cz/sb/2012/89",
+    title: "Občanský zákoník",
+    country: "CZE",
+    language: "cs",
+    contentHash: "b".repeat(64),
+  });
+  await db.insert(corpusIndexGenerations).values([
+    {
+      family: "case_law",
+      generation: "case_law_v5",
+      cluster: "q09",
+      manifestDigest: corpusIndexManifestDigest(
+        CORPUS_INDEX_MANIFESTS.case_law_v5,
+      ),
+      status: "building",
+    },
+    {
+      family: "legislation",
+      generation: "legislation_v2",
+      cluster: "q09",
+      manifestDigest: corpusIndexManifestDigest(
+        CORPUS_INDEX_MANIFESTS.legislation_v2,
+      ),
+      status: "building",
+    },
+  ]);
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("generation bootstrap is idempotent and does not advance another generation", async () => {
+  const subject = {
+    family: "case_law",
+    entityId: CASE_LAW_DECISION_ID,
+  } as const;
+  const first = await db.transaction(
+    async (tx) =>
+      await ensureCorpusProjectionDesiredStateTx(
+        asTestRaw<Transaction>(tx),
+        subject,
+        "case_law_v5",
+      ),
+  );
+  const second = await db.transaction(
+    async (tx) =>
+      await ensureCorpusProjectionDesiredStateTx(
+        asTestRaw<Transaction>(tx),
+        subject,
+        "case_law_v5",
+      ),
+  );
+
+  expect(first).toEqual({ created: true, epoch: 1n });
+  expect(second).toEqual({ created: false, epoch: 1n });
+  expect(
+    await db
+      .select({ epoch: caseLawDecisions.projectionEpoch })
+      .from(caseLawDecisions)
+      .where(eq(caseLawDecisions.id, CASE_LAW_DECISION_ID)),
+  ).toEqual([{ epoch: 1n }]);
+});
+
+test("one canonical mutation advances every active family generation once", async () => {
+  const subject = {
+    family: "case_law",
+    entityId: CASE_LAW_DECISION_ID,
+  } as const;
+  const first = await db.transaction(
+    async (tx) =>
+      await ensureCorpusProjectionDesiredStateTx(
+        asTestRaw<Transaction>(tx),
+        subject,
+        "case_law_v5",
+      ),
+  );
+  const before = await db
+    .select({ fingerprint: corpusIndexProjectionStates.desiredFingerprint })
+    .from(corpusIndexProjectionStates)
+    .where(eq(corpusIndexProjectionStates.entityId, CASE_LAW_DECISION_ID));
+
+  const advanced = await db.transaction(async (tx) => {
+    await tx
+      .update(caseLawDecisions)
+      .set({ court: "Ústavní soud" })
+      .where(eq(caseLawDecisions.id, CASE_LAW_DECISION_ID));
+    return await advanceCorpusProjectionDesiredStateTx(
+      asTestRaw<Transaction>(tx),
+      subject,
+    );
+  });
+  const after = await db
+    .select({
+      epoch: corpusIndexProjectionStates.desiredEpoch,
+      fingerprint: corpusIndexProjectionStates.desiredFingerprint,
+      indexId: corpusIndexProjectionStates.desiredIndexId,
+    })
+    .from(corpusIndexProjectionStates)
+    .where(eq(corpusIndexProjectionStates.entityId, CASE_LAW_DECISION_ID));
+
+  expect(first.epoch).toBe(1n);
+  expect(advanced).toEqual({ epoch: 2n, generationCount: 1 });
+  expect(after).toMatchObject([{ epoch: 2n, indexId: "case_law_v5_cs_sk" }]);
+  expect(after.at(0)?.fingerprint).not.toBe(before.at(0)?.fingerprint);
+});
+
+test("redistribution revocation becomes an erase desired state", async () => {
+  const subject = {
+    family: "legislation",
+    entityId: LEGISLATION_DOCUMENT_ID,
+  } as const;
+  await db.transaction(
+    async (tx) =>
+      await ensureCorpusProjectionDesiredStateTx(
+        asTestRaw<Transaction>(tx),
+        subject,
+        "legislation_v2",
+      ),
+  );
+  await db.transaction(async (tx) => {
+    await tx
+      .update(legislationSources)
+      .set({
+        descriptor: {
+          license: "restricted",
+          attribution: null,
+          allowsRedistribution: false,
+          allowsDerivedAi: false,
+        },
+      })
+      .where(eq(legislationSources.id, LEGISLATION_SOURCE_ID));
+    await advanceCorpusProjectionDesiredStateTx(
+      asTestRaw<Transaction>(tx),
+      subject,
+    );
+  });
+
+  expect(
+    await db
+      .select({
+        action: corpusIndexProjectionStates.desiredAction,
+        epoch: corpusIndexProjectionStates.desiredEpoch,
+        fingerprint: corpusIndexProjectionStates.desiredFingerprint,
+        indexId: corpusIndexProjectionStates.desiredIndexId,
+      })
+      .from(corpusIndexProjectionStates)
+      .where(eq(corpusIndexProjectionStates.entityId, LEGISLATION_DOCUMENT_ID)),
+  ).toEqual([{ action: "erase", epoch: 2n, fingerprint: null, indexId: null }]);
+});
+
+test("bounded reconciliation repairs drift once and then reaches a fixed point", async () => {
+  const subject = {
+    family: "legislation",
+    entityId: LEGISLATION_DOCUMENT_ID,
+  } as const;
+  await db.transaction(
+    async (tx) =>
+      await ensureCorpusProjectionDesiredStateTx(
+        asTestRaw<Transaction>(tx),
+        subject,
+        "legislation_v2",
+      ),
+  );
+  await db
+    .update(legislationDocuments)
+    .set({ title: "Nový občanský zákoník" })
+    .where(eq(legislationDocuments.id, LEGISLATION_DOCUMENT_ID));
+
+  const repaired = await db.transaction(
+    async (tx) =>
+      await reconcileCorpusProjectionDesiredStateTx(
+        asTestRaw<Transaction>(tx),
+        subject,
+      ),
+  );
+  const fixedPoint = await db.transaction(
+    async (tx) =>
+      await reconcileCorpusProjectionDesiredStateTx(
+        asTestRaw<Transaction>(tx),
+        subject,
+      ),
+  );
+
+  expect(repaired).toEqual({
+    epoch: 2n,
+    changed: true,
+    generationCount: 1,
+  });
+  expect(fixedPoint).toEqual({
+    epoch: 2n,
+    changed: false,
+    generationCount: 1,
+  });
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
@@ -1,0 +1,605 @@
+import { panic, TaggedError } from "better-result";
+import { and, asc, eq, or, sql } from "drizzle-orm";
+
+import { DECISION_IDENTIFIER_MAX_COUNT } from "@stll/legal-ast/decision-identifier";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  caseLawDecisionIdentifiers,
+  caseLawDecisions,
+  caseLawSources,
+  corpusIndexGenerations,
+  corpusIndexProjectionStates,
+  legislationDocuments,
+  legislationSources,
+} from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+  requireCorpusIndexManifest,
+  type CorpusIndexManifest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import {
+  deriveCorpusIndexProjectionDescriptor,
+  type CorpusIndexProjectionDescriptor,
+  type CorpusIndexProjectionInput,
+} from "@/api/lib/legal-search/corpus-index-projection-descriptor";
+import { isRedistributable } from "@/api/lib/legal-search/corpus-source";
+
+const CORPUS_INDEX_MANIFEST_COUNT = Object.keys(CORPUS_INDEX_MANIFESTS).length;
+
+export type CorpusIndexProjectionSubject =
+  | {
+      family: "case_law";
+      entityId: SafeId<"caseLawDecision">;
+    }
+  | {
+      family: "legislation";
+      entityId: SafeId<"legislationDocument">;
+    };
+
+export class CorpusIndexProjectionSubjectMissingError extends TaggedError(
+  "CorpusIndexProjectionSubjectMissingError",
+)<{ message: string; subject: CorpusIndexProjectionSubject }> {}
+
+type LockedProjectionInput = {
+  epoch: bigint;
+  input: CorpusIndexProjectionInput;
+};
+
+const lockCaseLawProjectionInput = async (
+  tx: Transaction,
+  subject: Extract<CorpusIndexProjectionSubject, { family: "case_law" }>,
+): Promise<LockedProjectionInput> => {
+  // Source-policy writers own the source row before walking its documents.
+  // Take the compatible source lock first so per-document projection never
+  // inverts that order or exclusively serializes every decision in a source.
+  const sourceRows = await tx
+    .select({
+      sourceId: caseLawSources.id,
+      sourceDescriptor: caseLawSources.descriptor,
+    })
+    .from(caseLawSources)
+    .innerJoin(
+      caseLawDecisions,
+      eq(caseLawDecisions.sourceId, caseLawSources.id),
+    )
+    .where(eq(caseLawDecisions.id, subject.entityId))
+    .limit(1)
+    .for("share", { of: caseLawSources });
+  const source = sourceRows.at(0);
+  if (source === undefined) {
+    throw new CorpusIndexProjectionSubjectMissingError({
+      message: `Case-law projection subject does not exist: ${subject.entityId}`,
+      subject,
+    });
+  }
+  const rows = await tx
+    .select({
+      documentId: caseLawDecisions.id,
+      sourceId: caseLawDecisions.sourceId,
+      jurisdiction: caseLawDecisions.country,
+      language: caseLawDecisions.language,
+      documentType: caseLawDecisions.decisionType,
+      contentHash: caseLawDecisions.contentHash,
+      redactedAt: caseLawDecisions.redactedAt,
+      caseNumber: caseLawDecisions.caseNumber,
+      court: caseLawDecisions.court,
+      decisionDate: caseLawDecisions.decisionDate,
+      ecli: caseLawDecisions.ecli,
+      projectionEpoch: caseLawDecisions.projectionEpoch,
+    })
+    .from(caseLawDecisions)
+    .where(
+      and(
+        eq(caseLawDecisions.id, subject.entityId),
+        eq(caseLawDecisions.sourceId, source.sourceId),
+      ),
+    )
+    .limit(1)
+    .for("update", { of: caseLawDecisions });
+  const row = rows.at(0);
+  if (row === undefined) {
+    throw new CorpusIndexProjectionSubjectMissingError({
+      message: `Case-law projection subject does not exist: ${subject.entityId}`,
+      subject,
+    });
+  }
+  const identifiers = await tx
+    .select({
+      type: caseLawDecisionIdentifiers.type,
+      value: caseLawDecisionIdentifiers.value,
+    })
+    .from(caseLawDecisionIdentifiers)
+    .where(eq(caseLawDecisionIdentifiers.decisionId, subject.entityId))
+    .orderBy(
+      asc(caseLawDecisionIdentifiers.type),
+      asc(caseLawDecisionIdentifiers.value),
+    )
+    .limit(DECISION_IDENTIFIER_MAX_COUNT + 1)
+    .for("share");
+  if (identifiers.length > DECISION_IDENTIFIER_MAX_COUNT) {
+    return panic(
+      `Case-law projection subject exceeds ${DECISION_IDENTIFIER_MAX_COUNT} identifiers: ${subject.entityId}`,
+    );
+  }
+  return {
+    epoch: row.projectionEpoch,
+    input: {
+      family: "case_law",
+      documentId: row.documentId,
+      sourceId: row.sourceId,
+      jurisdiction: row.jurisdiction,
+      language: row.language,
+      documentType: row.documentType,
+      contentHash: row.contentHash,
+      redistributionEligible: isRedistributable(source.sourceDescriptor),
+      redacted: row.redactedAt !== null,
+      caseNumber: row.caseNumber,
+      identifiers,
+      court: row.court,
+      decisionDate: row.decisionDate,
+      ecli: row.ecli,
+    },
+  };
+};
+
+const lockLegislationProjectionInput = async (
+  tx: Transaction,
+  subject: Extract<CorpusIndexProjectionSubject, { family: "legislation" }>,
+): Promise<LockedProjectionInput> => {
+  const sourceRows = await tx
+    .select({
+      sourceId: legislationSources.id,
+      sourceDescriptor: legislationSources.descriptor,
+    })
+    .from(legislationSources)
+    .innerJoin(
+      legislationDocuments,
+      eq(legislationDocuments.sourceId, legislationSources.id),
+    )
+    .where(eq(legislationDocuments.id, subject.entityId))
+    .limit(1)
+    .for("share", { of: legislationSources });
+  const source = sourceRows.at(0);
+  if (source === undefined) {
+    throw new CorpusIndexProjectionSubjectMissingError({
+      message: `Legislation projection subject does not exist: ${subject.entityId}`,
+      subject,
+    });
+  }
+  const rows = await tx
+    .select({
+      documentId: legislationDocuments.id,
+      sourceId: legislationDocuments.sourceId,
+      jurisdiction: legislationDocuments.country,
+      language: legislationDocuments.language,
+      documentType: legislationDocuments.documentType,
+      contentHash: legislationDocuments.contentHash,
+      title: legislationDocuments.title,
+      status: legislationDocuments.status,
+      effectiveDate: legislationDocuments.effectiveDate,
+      versionValidFrom: legislationDocuments.versionValidFrom,
+      versionValidTo: legislationDocuments.versionValidTo,
+      eli: legislationDocuments.eli,
+      projectionEpoch: legislationDocuments.projectionEpoch,
+    })
+    .from(legislationDocuments)
+    .where(
+      and(
+        eq(legislationDocuments.id, subject.entityId),
+        eq(legislationDocuments.sourceId, source.sourceId),
+      ),
+    )
+    .limit(1)
+    .for("update", { of: legislationDocuments });
+  const row = rows.at(0);
+  if (row === undefined) {
+    throw new CorpusIndexProjectionSubjectMissingError({
+      message: `Legislation projection subject does not exist: ${subject.entityId}`,
+      subject,
+    });
+  }
+  return {
+    epoch: row.projectionEpoch,
+    input: {
+      family: "legislation",
+      documentId: row.documentId,
+      sourceId: row.sourceId,
+      jurisdiction: row.jurisdiction,
+      language: row.language,
+      documentType: row.documentType,
+      contentHash: row.contentHash,
+      redistributionEligible: isRedistributable(source.sourceDescriptor),
+      title: row.title,
+      status: row.status,
+      effectiveDate: row.effectiveDate,
+      versionValidFrom: row.versionValidFrom,
+      versionValidTo: row.versionValidTo,
+      eli: row.eli,
+    },
+  };
+};
+
+const lockProjectionInput = async (
+  tx: Transaction,
+  subject: CorpusIndexProjectionSubject,
+): Promise<LockedProjectionInput> => {
+  switch (subject.family) {
+    case "case_law":
+      return await lockCaseLawProjectionInput(tx, subject);
+    case "legislation":
+      return await lockLegislationProjectionInput(tx, subject);
+    default:
+      return subject satisfies never;
+  }
+};
+
+const setCanonicalProjectionEpoch = async (
+  tx: Transaction,
+  subject: CorpusIndexProjectionSubject,
+  epoch: bigint,
+): Promise<void> => {
+  switch (subject.family) {
+    case "case_law":
+      await tx
+        .update(caseLawDecisions)
+        .set({ projectionEpoch: epoch })
+        .where(eq(caseLawDecisions.id, subject.entityId));
+      return;
+    case "legislation":
+      await tx
+        .update(legislationDocuments)
+        .set({ projectionEpoch: epoch })
+        .where(eq(legislationDocuments.id, subject.entityId));
+      return;
+    default:
+      return subject satisfies never;
+  }
+};
+
+type RegisteredManifest = {
+  generation: string;
+  manifest: CorpusIndexManifest;
+};
+
+const verifiedManifest = ({
+  family,
+  generation,
+  cluster,
+  manifestDigest,
+}: typeof corpusIndexGenerations.$inferSelect): CorpusIndexManifest => {
+  const manifest = requireCorpusIndexManifest(family, generation);
+  const expectedDigest = corpusIndexManifestDigest(manifest);
+  if (cluster !== manifest.cluster || manifestDigest !== expectedDigest) {
+    return panic(
+      `Corpus generation contract mismatch: ${family}/${generation}`,
+    );
+  }
+  return manifest;
+};
+
+const activeManifests = async (
+  tx: Transaction,
+  family: CorpusIndexProjectionSubject["family"],
+): Promise<RegisteredManifest[]> => {
+  const rows = await tx
+    .select()
+    .from(corpusIndexGenerations)
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, family),
+        or(
+          eq(corpusIndexGenerations.status, "building"),
+          eq(corpusIndexGenerations.status, "serving"),
+        ),
+      ),
+    )
+    .orderBy(asc(corpusIndexGenerations.generation))
+    .limit(CORPUS_INDEX_MANIFEST_COUNT + 1)
+    .for("share");
+  if (rows.length > CORPUS_INDEX_MANIFEST_COUNT) {
+    return panic(`Active corpus generation registry exceeds its manifest set`);
+  }
+  return rows.map((row) => ({
+    generation: row.generation,
+    manifest: verifiedManifest(row),
+  }));
+};
+
+export const readActiveCorpusProjectionManifest = async (
+  tx: Transaction,
+  family: CorpusIndexProjectionSubject["family"],
+  generation: string,
+  lock: boolean,
+): Promise<CorpusIndexManifest> => {
+  const query = tx
+    .select()
+    .from(corpusIndexGenerations)
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, family),
+        eq(corpusIndexGenerations.generation, generation),
+        or(
+          eq(corpusIndexGenerations.status, "building"),
+          eq(corpusIndexGenerations.status, "serving"),
+        ),
+      ),
+    )
+    .limit(1);
+  const rows = lock ? await query.for("share") : await query;
+  const row = rows.at(0);
+  if (row === undefined) {
+    return panic(
+      `Active corpus generation is not registered: ${family}/${generation}`,
+    );
+  }
+  return verifiedManifest(row);
+};
+
+export const buildCorpusIndexProjectionDesiredStateValues = ({
+  subject,
+  generation,
+  epoch,
+  descriptor,
+}: {
+  subject: CorpusIndexProjectionSubject;
+  generation: string;
+  epoch: bigint;
+  descriptor: CorpusIndexProjectionDescriptor;
+}): typeof corpusIndexProjectionStates.$inferInsert => ({
+  family: subject.family,
+  generation,
+  entityId: subject.entityId,
+  desiredAction: descriptor.action,
+  desiredEpoch: epoch,
+  desiredFingerprint:
+    descriptor.action === "upsert" ? descriptor.fingerprint : null,
+  desiredIndexId: descriptor.action === "upsert" ? descriptor.indexId : null,
+});
+
+const writeDesiredStates = async (
+  tx: Transaction,
+  values: (typeof corpusIndexProjectionStates.$inferInsert)[],
+): Promise<void> => {
+  if (values.length === 0) {
+    return;
+  }
+  await tx
+    .insert(corpusIndexProjectionStates)
+    .values(values)
+    .onConflictDoUpdate({
+      target: [
+        corpusIndexProjectionStates.family,
+        corpusIndexProjectionStates.generation,
+        corpusIndexProjectionStates.entityId,
+      ],
+      set: {
+        desiredAction: sql`excluded.desired_action`,
+        desiredEpoch: sql`excluded.desired_epoch`,
+        desiredFingerprint: sql`excluded.desired_fingerprint`,
+        desiredIndexId: sql`excluded.desired_index_id`,
+        updatedAt: new Date(),
+      },
+    });
+};
+
+type DesiredStateSnapshot = {
+  generation: string;
+  desiredAction: "upsert" | "erase";
+  desiredEpoch: bigint;
+  desiredFingerprint: string | null;
+  desiredIndexId: string | null;
+};
+
+const desiredStateMatches = (
+  state: DesiredStateSnapshot,
+  epoch: bigint,
+  descriptor: CorpusIndexProjectionDescriptor,
+): boolean =>
+  state.desiredEpoch === epoch &&
+  state.desiredAction === descriptor.action &&
+  state.desiredFingerprint ===
+    (descriptor.action === "upsert" ? descriptor.fingerprint : null) &&
+  state.desiredIndexId ===
+    (descriptor.action === "upsert" ? descriptor.indexId : null);
+
+/**
+ * Advance one canonical mutation across every active final generation. The
+ * caller must invoke this inside the same transaction that changed the
+ * projection-relevant canonical fields.
+ */
+export const advanceCorpusProjectionDesiredStateTx = async (
+  tx: Transaction,
+  subject: CorpusIndexProjectionSubject,
+): Promise<{ epoch: bigint; generationCount: number }> => {
+  const locked = await lockProjectionInput(tx, subject);
+  const manifests = await activeManifests(tx, subject.family);
+  if (manifests.length === 0) {
+    return { epoch: locked.epoch, generationCount: 0 };
+  }
+
+  const epoch = locked.epoch + 1n;
+  await setCanonicalProjectionEpoch(tx, subject, epoch);
+  await writeDesiredStates(
+    tx,
+    manifests.map(({ generation, manifest }) =>
+      buildCorpusIndexProjectionDesiredStateValues({
+        subject,
+        generation,
+        epoch,
+        descriptor: deriveCorpusIndexProjectionDescriptor(
+          manifest,
+          locked.input,
+        ),
+      }),
+    ),
+  );
+  return { epoch, generationCount: manifests.length };
+};
+
+/**
+ * Repair or seed desired state from authoritative corpus rows. Plane may call
+ * this from bounded sweeps after a projector or source-policy change; exact
+ * matches are a fixed point and therefore do not manufacture new epochs.
+ */
+export const reconcileCorpusProjectionDesiredStateTx = async (
+  tx: Transaction,
+  subject: CorpusIndexProjectionSubject,
+): Promise<{ epoch: bigint; changed: boolean; generationCount: number }> => {
+  const locked = await lockProjectionInput(tx, subject);
+  const manifests = await activeManifests(tx, subject.family);
+  if (manifests.length === 0) {
+    return {
+      epoch: locked.epoch,
+      changed: false,
+      generationCount: 0,
+    };
+  }
+
+  const existing = await tx
+    .select({
+      generation: corpusIndexProjectionStates.generation,
+      desiredAction: corpusIndexProjectionStates.desiredAction,
+      desiredEpoch: corpusIndexProjectionStates.desiredEpoch,
+      desiredFingerprint: corpusIndexProjectionStates.desiredFingerprint,
+      desiredIndexId: corpusIndexProjectionStates.desiredIndexId,
+    })
+    .from(corpusIndexProjectionStates)
+    .where(
+      and(
+        eq(corpusIndexProjectionStates.family, subject.family),
+        eq(corpusIndexProjectionStates.entityId, subject.entityId),
+      ),
+    )
+    .for("update");
+  const byGeneration = new Map(
+    existing.map((state) => [state.generation, state]),
+  );
+  const projections = manifests.map(({ generation, manifest }) => ({
+    generation,
+    descriptor: deriveCorpusIndexProjectionDescriptor(manifest, locked.input),
+  }));
+  const existingDrifted = projections.some(({ generation, descriptor }) => {
+    const state = byGeneration.get(generation);
+    return (
+      state !== undefined &&
+      !desiredStateMatches(state, locked.epoch, descriptor)
+    );
+  });
+
+  let epoch = locked.epoch;
+  if (existingDrifted || epoch === 0n) {
+    epoch += 1n;
+    await setCanonicalProjectionEpoch(tx, subject, epoch);
+  }
+
+  const values = projections
+    .filter(({ generation, descriptor }) => {
+      const state = byGeneration.get(generation);
+      return (
+        existingDrifted ||
+        state === undefined ||
+        !desiredStateMatches(state, epoch, descriptor)
+      );
+    })
+    .map(({ generation, descriptor }) =>
+      buildCorpusIndexProjectionDesiredStateValues({
+        subject,
+        generation,
+        epoch,
+        descriptor,
+      }),
+    );
+  await writeDesiredStates(tx, values);
+  return {
+    epoch,
+    changed: values.length > 0,
+    generationCount: manifests.length,
+  };
+};
+
+/** Seed one newly registered generation without invalidating existing ones. */
+export const ensureCorpusProjectionDesiredStateTx = async (
+  tx: Transaction,
+  subject: CorpusIndexProjectionSubject,
+  generation: string,
+): Promise<{ epoch: bigint; created: boolean }> => {
+  const locked = await lockProjectionInput(tx, subject);
+  const generationRows = await tx
+    .select()
+    .from(corpusIndexGenerations)
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, subject.family),
+        eq(corpusIndexGenerations.generation, generation),
+        or(
+          eq(corpusIndexGenerations.status, "building"),
+          eq(corpusIndexGenerations.status, "serving"),
+        ),
+      ),
+    )
+    .limit(1)
+    .for("share");
+  const generationRow = generationRows.at(0);
+  if (generationRow === undefined) {
+    return panic(
+      `Active corpus generation is not registered: ${subject.family}/${generation}`,
+    );
+  }
+  const manifest = verifiedManifest(generationRow);
+  const descriptor = deriveCorpusIndexProjectionDescriptor(
+    manifest,
+    locked.input,
+  );
+  const existing = await tx
+    .select({
+      desiredAction: corpusIndexProjectionStates.desiredAction,
+      desiredEpoch: corpusIndexProjectionStates.desiredEpoch,
+      desiredFingerprint: corpusIndexProjectionStates.desiredFingerprint,
+      desiredIndexId: corpusIndexProjectionStates.desiredIndexId,
+    })
+    .from(corpusIndexProjectionStates)
+    .where(
+      and(
+        eq(corpusIndexProjectionStates.family, subject.family),
+        eq(corpusIndexProjectionStates.generation, generation),
+        eq(corpusIndexProjectionStates.entityId, subject.entityId),
+      ),
+    )
+    .limit(1)
+    .for("update");
+  const existingState = existing.at(0);
+  if (existingState !== undefined) {
+    const expectedFingerprint =
+      descriptor.action === "upsert" ? descriptor.fingerprint : null;
+    const expectedIndexId =
+      descriptor.action === "upsert" ? descriptor.indexId : null;
+    if (
+      existingState.desiredEpoch !== locked.epoch ||
+      existingState.desiredAction !== descriptor.action ||
+      existingState.desiredFingerprint !== expectedFingerprint ||
+      existingState.desiredIndexId !== expectedIndexId
+    ) {
+      return panic(
+        `Existing corpus desired state does not match canonical input: ${subject.family}/${generation}/${subject.entityId}`,
+      );
+    }
+    return { epoch: locked.epoch, created: false };
+  }
+
+  const epoch = locked.epoch === 0n ? 1n : locked.epoch;
+  if (epoch !== locked.epoch) {
+    await setCanonicalProjectionEpoch(tx, subject, epoch);
+  }
+  await writeDesiredStates(tx, [
+    buildCorpusIndexProjectionDesiredStateValues({
+      subject,
+      generation,
+      epoch,
+      descriptor,
+    }),
+  ]);
+  return { epoch, created: true };
+};


### PR DESCRIPTION
## Summary

- derive family-specific, manifest-bound desired projection state for case law and legislation
- seed generations with bounded, keyset-based, lock-safe batches
- make replay and drift repair converge through epoch-fenced PostgreSQL state

## Validation

- `git diff --check`
- exact touched-file formatting
- full validation delegated to required CI

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for preparing and managing searchable indexes for case law and legislation.
  - Improved routing of content to the appropriate jurisdiction-specific indexes.
  - Added consistent projection metadata, versioning and fingerprinting for reliable index updates.
  - Added handling for redacted, unavailable or no-longer-redistributable content, including removal from indexes.

- **Bug Fixes**
  - Improved index update timing and configuration consistency.
  - Strengthened validation and recovery when index data becomes out of sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->