### PR TITLE
feat: add final corpus projection engine

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -478,6 +478,46 @@ test("ingest succeeds when every document is accepted", async () => {
   expect(result.isOk()).toBe(true);
 });
 
+test("final-generation ingest requires the exact committed V2 receipt", async () => {
+  responseBody = {
+    num_docs_for_processing: 2,
+    num_ingested_docs: 2,
+    num_rejected_docs: 0,
+  };
+
+  const result = await getCorpusIndexClient().ingestCommittedBatch(
+    "case_law_v5_cs_sk",
+    '{"document_id":"a"}\n{"document_id":"b"}',
+  );
+
+  expect(result.isOk()).toBe(true);
+  expect(requests.at(0)?.search).toBe("?commit=wait_for");
+});
+
+test("final-generation ingest rejects missing or partial V2 counters", async () => {
+  for (const receipt of [
+    { num_docs_for_processing: 2, num_rejected_docs: 0 },
+    {
+      num_docs_for_processing: 2,
+      num_ingested_docs: 1,
+      num_rejected_docs: 0,
+    },
+    {
+      num_docs_for_processing: 2,
+      num_ingested_docs: 2,
+      num_rejected_docs: 1,
+    },
+  ]) {
+    responseBody = receipt;
+    // oxlint-disable-next-line no-await-in-loop -- each malformed receipt is observed independently by the request recorder
+    const result = await getCorpusIndexClient().ingestCommittedBatch(
+      "case_law_v5_cs_sk",
+      '{"document_id":"a"}\n{"document_id":"b"}',
+    );
+    expect(result.isErr()).toBe(true);
+  }
+});
+
 // Bun rejects a request whose timeout fires with the abort reason alone —
 // a DOMException reading "The operation timed out." and nothing else. On
 // the backfill path that reaches the log as the whole story, so the client

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -149,6 +149,11 @@ export type CorpusIndexClient = {
     ndjson: string,
     commit: CorpusIndexCommitMode,
   ) => Promise<Result<void, CorpusIndexError>>;
+  /** Final-generation append: durable commit plus an exact V2 receipt. */
+  ingestCommittedBatch: (
+    indexId: string,
+    ndjson: string,
+  ) => Promise<Result<void, CorpusIndexError>>;
   search: (
     input: CorpusIndexSearchInput,
   ) => Promise<Result<CorpusIndexSearchResponse, CorpusIndexError>>;
@@ -284,6 +289,81 @@ const parseRecordArray = (value: unknown): Record<string, unknown>[] | null => {
   return records;
 };
 
+type IngestReceiptMode = "compatible" | "exact-v2";
+
+type IngestBatchOptions = {
+  indexId: string;
+  ndjson: string;
+  commit: CorpusIndexCommitMode;
+  receiptMode: IngestReceiptMode;
+};
+
+const ingestBatch = async ({
+  indexId,
+  ndjson,
+  commit,
+  receiptMode,
+}: IngestBatchOptions): Promise<Result<void, CorpusIndexError>> =>
+  await Result.tryPromise({
+    try: async () => {
+      const sentDocs = ndjson
+        .split("\n")
+        .filter((line) => line.trim().length > 0).length;
+      const response = await requestJson({
+        baseUrl: mutationBaseUrl(),
+        path: `/api/v1/${indexId}/ingest?commit=${commit}`,
+        init: {
+          method: "POST",
+          headers: { "content-type": "application/x-ndjson" },
+          body: ndjson,
+        },
+        timeoutMs: CORPUS_INDEX_INGEST_TIMEOUT_MS,
+      });
+      if (!isRecord(response)) {
+        throw new CorpusIndexError({
+          message: "corpus index ingest returned an invalid response",
+        });
+      }
+      const processing = response["num_docs_for_processing"];
+      const ingested = response["num_ingested_docs"];
+      const rejectedValue = response["num_rejected_docs"];
+      const parseFailures = response["parse_failures"];
+      let rejected = 0;
+      if (typeof rejectedValue === "number") {
+        rejected = rejectedValue;
+      } else if (Array.isArray(parseFailures)) {
+        rejected = parseFailures.length;
+      }
+      if (receiptMode === "exact-v2") {
+        if (
+          sentDocs === 0 ||
+          processing !== sentDocs ||
+          ingested !== sentDocs ||
+          rejectedValue !== 0
+        ) {
+          throw new CorpusIndexError({
+            message: `corpus index ingest receipt did not commit all ${sentDocs} documents (processing=${String(processing)}, ingested=${String(ingested)}, rejected=${String(rejectedValue)})`,
+          });
+        }
+        return;
+      }
+      // The legacy engine can accept the HTTP request while dropping
+      // documents. v0.8 reports fewer counters than v0.9, so this path keeps
+      // the compatible checks until the old cluster is retired.
+      if (rejected > 0) {
+        throw new CorpusIndexError({
+          message: `corpus index ingest rejected ${rejected} of ${sentDocs} documents`,
+        });
+      }
+      if (typeof processing === "number" && processing < sentDocs) {
+        throw new CorpusIndexError({
+          message: `corpus index ingest accepted ${processing} of ${sentDocs} documents`,
+        });
+      }
+    },
+    catch: toCorpusIndexError,
+  });
+
 const buildClient = (): CorpusIndexClient => ({
   createIndex: async (config) =>
     await Result.tryPromise({
@@ -339,51 +419,19 @@ const buildClient = (): CorpusIndexClient => ({
     }),
 
   ingestBatch: async (indexId, ndjson, commit) =>
-    await Result.tryPromise({
-      try: async () => {
-        const sentDocs = ndjson
-          .split("\n")
-          .filter((line) => line.trim().length > 0).length;
-        const response = await requestJson({
-          baseUrl: mutationBaseUrl(),
-          path: `/api/v1/${indexId}/ingest?commit=${commit}`,
-          init: {
-            method: "POST",
-            headers: { "content-type": "application/x-ndjson" },
-            body: ndjson,
-          },
-          timeoutMs: CORPUS_INDEX_INGEST_TIMEOUT_MS,
-        });
-        if (!isRecord(response)) {
-          throw new CorpusIndexError({
-            message: "corpus index ingest returned an invalid response",
-          });
-        }
-        // The engine can accept the HTTP request while dropping documents.
-        // v0.8 only reports num_docs_for_processing (per-document parse
-        // failures surface in server logs, not the response); newer engines
-        // report rejections explicitly. Fail the batch on any signal that
-        // not every document was accepted so the backfill retries instead
-        // of committing indexedHash for documents that never landed.
-        let rejected = 0;
-        if (typeof response["num_rejected_docs"] === "number") {
-          rejected = response["num_rejected_docs"];
-        } else if (Array.isArray(response["parse_failures"])) {
-          rejected = response["parse_failures"].length;
-        }
-        if (rejected > 0) {
-          throw new CorpusIndexError({
-            message: `corpus index ingest rejected ${rejected} of ${sentDocs} documents`,
-          });
-        }
-        const accepted = response["num_docs_for_processing"];
-        if (typeof accepted === "number" && accepted < sentDocs) {
-          throw new CorpusIndexError({
-            message: `corpus index ingest accepted ${accepted} of ${sentDocs} documents`,
-          });
-        }
-      },
-      catch: toCorpusIndexError,
+    await ingestBatch({
+      indexId,
+      ndjson,
+      commit,
+      receiptMode: "compatible",
+    }),
+
+  ingestCommittedBatch: async (indexId, ndjson) =>
+    await ingestBatch({
+      indexId,
+      ndjson,
+      commit: CORPUS_INDEX_COMMIT.waitFor,
+      receiptMode: "exact-v2",
     }),
 
   search: async ({

--- a/apps/api/src/lib/legal-search/corpus-index-projection-builder.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-builder.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import { UNDATED_DECISION_TIMESTAMP } from "@/api/lib/legal-search/corpus-index-config";
+import { CORPUS_INDEX_MANIFESTS } from "@/api/lib/legal-search/corpus-index-manifest";
+import {
+  buildCaseLawV5ProjectionDocuments,
+  buildCorpusProjectionDocuments,
+  buildLegislationV2ProjectionDocuments,
+} from "@/api/lib/legal-search/corpus-index-projection-builder";
+import type {
+  CaseLawV5ProjectionInput,
+  LegislationV2ProjectionInput,
+} from "@/api/lib/legal-search/corpus-index-projection-descriptor";
+
+const REVISION = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000001",
+);
+const CASE_LAW_INPUT = {
+  family: "case_law",
+  documentId: "0198e331-e578-7000-8000-000000000002",
+  sourceId: "0198e331-e578-7000-8000-000000000003",
+  jurisdiction: "cze",
+  language: "cs",
+  documentType: "judgment",
+  contentHash: "a".repeat(64),
+  redistributionEligible: true,
+  redacted: false,
+  caseNumber: "4 As 3/2008",
+  identifiers: [
+    { type: "source", value: "NSS-4-AS-3-2008" },
+    { type: "docket", value: "4 As 3/2008" },
+  ],
+  court: "Nejvyšší správní soud",
+  decisionDate: null,
+  ecli: null,
+} as const satisfies CaseLawV5ProjectionInput;
+const LEGISLATION_INPUT = {
+  family: "legislation",
+  documentId: "0198e331-e578-7000-8000-000000000004",
+  sourceId: "0198e331-e578-7000-8000-000000000005",
+  jurisdiction: "CZE",
+  language: "cs",
+  documentType: "act",
+  contentHash: "b".repeat(64),
+  redistributionEligible: true,
+  title: "Občanský zákoník",
+  status: "current",
+  effectiveDate: "2014-01-01",
+  versionValidFrom: "2014-01-01",
+  versionValidTo: null,
+  eli: "eli/cz/sb/2012/89",
+} as const satisfies LegislationV2ProjectionInput;
+
+const manifestFields = (family: "case_law" | "legislation"): Set<string> =>
+  new Set(
+    CORPUS_INDEX_MANIFESTS[
+      family === "case_law" ? "case_law_v5" : "legislation_v2"
+    ].engine.indexConfig.doc_mapping.field_mappings.map(({ name }) => name),
+  );
+
+test("case-law v5 emits exact attempt identity and one opening passage", () => {
+  const documents = buildCaseLawV5ProjectionDocuments({
+    input: CASE_LAW_INPUT,
+    payload: {
+      text: `${"první ".repeat(400)}\n\n${"druhý ".repeat(400)}`,
+      ast: null,
+    },
+    revision: REVISION,
+  });
+
+  expect(documents.length).toBeGreaterThan(1);
+  expect(documents.filter(({ is_opening }) => is_opening)).toHaveLength(1);
+  expect(documents.at(0)).toMatchObject({
+    document_id: CASE_LAW_INPUT.documentId,
+    projection_revision: REVISION,
+    jurisdiction: "CZE",
+    is_opening: true,
+    title: "4 As 3/2008 · NSS-4-AS-3-2008 — Nejvyšší správní soud",
+    decision_date_ts: UNDATED_DECISION_TIMESTAMP,
+  });
+  for (const [index, document] of documents.entries()) {
+    expect(document.projection_revision).toBe(REVISION);
+    expect("title" in document).toBe(index === 0);
+    expect(
+      Object.keys(document).every((key) => manifestFields("case_law").has(key)),
+    ).toBe(true);
+  }
+});
+
+test("legislation v2 emits one strict pointer-free document", () => {
+  const documents = buildLegislationV2ProjectionDocuments({
+    input: LEGISLATION_INPUT,
+    payload: { text: "§ 1 Předmět úpravy", ast: null },
+    revision: REVISION,
+  });
+
+  expect(documents).toEqual([
+    {
+      document_id: LEGISLATION_INPUT.documentId,
+      projection_revision: REVISION,
+      jurisdiction: "CZE",
+      source: LEGISLATION_INPUT.sourceId,
+      language: "cs",
+      document_type: "act",
+      title: "Občanský zákoník",
+      text: "§ 1 Předmět úpravy",
+      is_opening: true,
+      status: "current",
+      effective_date: "2014-01-01",
+      version_valid_from: "2014-01-01",
+      eli: "eli/cz/sb/2012/89",
+    },
+  ]);
+  expect(
+    Object.keys(documents[0]).every((key) =>
+      manifestFields("legislation").has(key),
+    ),
+  ).toBe(true);
+});
+
+test("builder dispatch is exhaustive over manifest-owned versions", () => {
+  expect(
+    buildCorpusProjectionDocuments({
+      manifest: CORPUS_INDEX_MANIFESTS.case_law_v5,
+      input: CASE_LAW_INPUT,
+      payload: { text: "Rozsudek", ast: null },
+      revision: REVISION,
+    }),
+  ).toHaveLength(1);
+  expect(
+    buildCorpusProjectionDocuments({
+      manifest: CORPUS_INDEX_MANIFESTS.legislation_v2,
+      input: LEGISLATION_INPUT,
+      payload: { text: "Zákon", ast: null },
+      revision: REVISION,
+    }),
+  ).toHaveLength(1);
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-builder.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-builder.ts
@@ -1,0 +1,150 @@
+import { panic } from "better-result";
+
+import type { SafeId } from "@/api/lib/branded-types";
+import { hasUsableAst } from "@/api/lib/case-law/document-ast";
+import { chunkDocument } from "@/api/lib/corpus-index/chunking";
+import type { CorpusDocumentPayload } from "@/api/lib/corpus-index/core";
+import { UNDATED_DECISION_TIMESTAMP } from "@/api/lib/legal-search/corpus-index-config";
+import type { CorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
+import {
+  caseLawV5Title,
+  type CaseLawV5ProjectionInput,
+  type LegislationV2ProjectionInput,
+} from "@/api/lib/legal-search/corpus-index-projection-descriptor";
+
+type ProjectionRevision = SafeId<"corpusIndexProjectionIntent">;
+
+type SharedProjectionDocument = {
+  document_id: string;
+  projection_revision: ProjectionRevision;
+  jurisdiction: string;
+  source: string;
+  language: string;
+  document_type?: string;
+  title?: string;
+  text: string;
+  is_opening: boolean;
+};
+
+type CaseLawV5ProjectionDocument = SharedProjectionDocument & {
+  anchor_id?: string;
+  case_number: string;
+  court: string;
+  decision_date?: string;
+  decision_date_ts: string;
+  ecli?: string;
+};
+
+type LegislationV2ProjectionDocument = SharedProjectionDocument & {
+  status: string;
+  effective_date?: string;
+  version_valid_from?: string;
+  version_valid_to?: string;
+  eli: string;
+};
+
+type ProjectionBuildBase = {
+  payload: CorpusDocumentPayload;
+  revision: ProjectionRevision;
+};
+
+type BuildCorpusProjectionDocumentsOptions =
+  | (ProjectionBuildBase & {
+      manifest: Extract<CorpusIndexManifest, { family: "case_law" }>;
+      input: CaseLawV5ProjectionInput;
+    })
+  | (ProjectionBuildBase & {
+      manifest: Extract<CorpusIndexManifest, { family: "legislation" }>;
+      input: LegislationV2ProjectionInput;
+    });
+
+const sharedFields = (
+  input: CaseLawV5ProjectionInput | LegislationV2ProjectionInput,
+  revision: ProjectionRevision,
+): Omit<SharedProjectionDocument, "title" | "text" | "is_opening"> => ({
+  document_id: input.documentId,
+  projection_revision: revision,
+  jurisdiction: input.jurisdiction.toUpperCase(),
+  source: input.sourceId,
+  language: input.language,
+  ...(input.documentType === null ? {} : { document_type: input.documentType }),
+});
+
+type BuildCaseLawV5Options = ProjectionBuildBase & {
+  input: CaseLawV5ProjectionInput;
+};
+
+export const buildCaseLawV5ProjectionDocuments = ({
+  input,
+  payload,
+  revision,
+}: BuildCaseLawV5Options): CaseLawV5ProjectionDocument[] => {
+  const shared = {
+    ...sharedFields(input, revision),
+    case_number: input.caseNumber,
+    court: input.court,
+    decision_date_ts: input.decisionDate ?? UNDATED_DECISION_TIMESTAMP,
+    ...(input.decisionDate === null
+      ? {}
+      : { decision_date: input.decisionDate }),
+    ...(input.ecli === null ? {} : { ecli: input.ecli }),
+  };
+  const title = caseLawV5Title(input);
+  return chunkDocument({
+    ast: hasUsableAst(payload.ast) ? payload.ast : null,
+    fallbackText: payload.text,
+  }).map((chunk) => ({
+    ...shared,
+    text: chunk.text,
+    is_opening: chunk.seq === 0,
+    ...(chunk.seq === 0 ? { title } : {}),
+    ...(chunk.anchorId === null ? {} : { anchor_id: chunk.anchorId }),
+  }));
+};
+
+type BuildLegislationV2Options = ProjectionBuildBase & {
+  input: LegislationV2ProjectionInput;
+};
+
+export const buildLegislationV2ProjectionDocuments = ({
+  input,
+  payload,
+  revision,
+}: BuildLegislationV2Options): [LegislationV2ProjectionDocument] => [
+  {
+    ...sharedFields(input, revision),
+    title: input.title,
+    text: payload.text,
+    is_opening: true,
+    status: input.status,
+    eli: input.eli,
+    ...(input.effectiveDate === null
+      ? {}
+      : { effective_date: input.effectiveDate }),
+    ...(input.versionValidFrom === null
+      ? {}
+      : { version_valid_from: input.versionValidFrom }),
+    ...(input.versionValidTo === null
+      ? {}
+      : { version_valid_to: input.versionValidTo }),
+  },
+];
+
+export const buildCorpusProjectionDocuments = (
+  options: BuildCorpusProjectionDocumentsOptions,
+): Record<string, unknown>[] => {
+  switch (options.manifest.projection.builderVersion) {
+    case "case-law-passages-v1":
+      if (options.input.family !== "case_law") {
+        return panic("Case-law projection builder received legislation input");
+      }
+      return buildCaseLawV5ProjectionDocuments(options);
+    case "legislation-document-v1":
+      if (options.input.family !== "legislation") {
+        return panic("Legislation projection builder received case-law input");
+      }
+      return buildLegislationV2ProjectionDocuments(options);
+    default:
+      return options.manifest.projection.builderVersion satisfies never;
+  }
+};

--- a/apps/api/src/lib/legal-search/corpus-index-projection-builder.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-builder.ts
@@ -90,16 +90,21 @@ export const buildCaseLawV5ProjectionDocuments = ({
     ...(input.ecli === null ? {} : { ecli: input.ecli }),
   };
   const title = caseLawV5Title(input);
-  return chunkDocument({
+  const chunks = chunkDocument({
     ast: hasUsableAst(payload.ast) ? payload.ast : null,
     fallbackText: payload.text,
-  }).map((chunk) => ({
-    ...shared,
-    text: chunk.text,
-    is_opening: chunk.seq === 0,
-    ...(chunk.seq === 0 ? { title } : {}),
-    ...(chunk.anchorId === null ? {} : { anchor_id: chunk.anchorId }),
-  }));
+  });
+  const documents: CaseLawV5ProjectionDocument[] = [];
+  for (const chunk of chunks) {
+    documents.push({
+      ...shared,
+      text: chunk.text,
+      is_opening: chunk.seq === 0,
+      ...(chunk.seq === 0 ? { title } : {}),
+      ...(chunk.anchorId === null ? {} : { anchor_id: chunk.anchorId }),
+    });
+  }
+  return documents;
 };
 
 type BuildLegislationV2Options = ProjectionBuildBase & {

--- a/apps/api/src/lib/legal-search/corpus-index-projection-builder.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-builder.ts
@@ -133,18 +133,24 @@ export const buildLegislationV2ProjectionDocuments = ({
 export const buildCorpusProjectionDocuments = (
   options: BuildCorpusProjectionDocumentsOptions,
 ): Record<string, unknown>[] => {
-  switch (options.manifest.projection.builderVersion) {
-    case "case-law-passages-v1":
-      if (options.input.family !== "case_law") {
-        return panic("Case-law projection builder received legislation input");
-      }
-      return buildCaseLawV5ProjectionDocuments(options);
-    case "legislation-document-v1":
-      if (options.input.family !== "legislation") {
-        return panic("Legislation projection builder received case-law input");
-      }
-      return buildLegislationV2ProjectionDocuments(options);
-    default:
-      return options.manifest.projection.builderVersion satisfies never;
+  if (options.input.family === "case_law") {
+    if (options.manifest.projection.builderVersion !== "case-law-passages-v1") {
+      return panic("Case-law projection input has a non-case-law manifest");
+    }
+    return buildCaseLawV5ProjectionDocuments({
+      input: options.input,
+      payload: options.payload,
+      revision: options.revision,
+    });
   }
+  if (
+    options.manifest.projection.builderVersion !== "legislation-document-v1"
+  ) {
+    return panic("Legislation projection input has a non-legislation manifest");
+  }
+  return buildLegislationV2ProjectionDocuments({
+    input: options.input,
+    payload: options.payload,
+    revision: options.revision,
+  });
 };

--- a/apps/api/src/lib/legal-search/corpus-index-projection-engine.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-engine.test.ts
@@ -105,18 +105,27 @@ test("append rejects a document carrying another attempt revision", async () => 
   expect(result.isErr()).toBe(true);
   if (result.isErr()) {
     expect(result.error.message).toContain("does not belong to revision");
+    expect(result.error.code).toBe("invalid_document");
     expect(result.error.stage).toBe("validation");
     expect(result.error.unattemptedRevisions).toEqual([FIRST_REVISION]);
   }
 });
 
 test("append failure reports the exact revisions with unknown outcomes", async () => {
+  const unknownOutcomeObservedAt = new Date("2026-08-25T12:00:00.000Z");
+  let appendReturned = false;
   const result = await appendCorpusProjectionBatch({
     client: {
-      ingestCommittedBatch: async () =>
-        Result.err(new CorpusIndexError({ message: "response lost" })),
+      ingestCommittedBatch: async () => {
+        appendReturned = true;
+        return Result.err(new CorpusIndexError({ message: "response lost" }));
+      },
     },
     indexId: "case_law_v5_cs_sk",
+    clock: () => {
+      expect(appendReturned).toBe(true);
+      return unknownOutcomeObservedAt;
+    },
     entries: [
       {
         revision: FIRST_REVISION,
@@ -142,12 +151,16 @@ test("append failure reports the exact revisions with unknown outcomes", async (
   expect(result.isErr()).toBe(true);
   if (result.isErr()) {
     expect(result.error.stage).toBe("append");
+    expect(result.error.code).toBe("append_unknown");
     expect(result.error.committedRevisions).toEqual([]);
     expect(result.error.unknownRevisions).toEqual([
       FIRST_REVISION,
       SECOND_REVISION,
     ]);
     expect(result.error.unattemptedRevisions).toEqual([]);
+    expect(result.error.unknownOutcomeObservedAt).toEqual(
+      unknownOutcomeObservedAt,
+    );
   }
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-projection-engine.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-engine.test.ts
@@ -1,0 +1,170 @@
+import { Result } from "better-result";
+import { expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import {
+  CORPUS_INDEX_INGEST_TIMEOUT_MS,
+  CorpusIndexError,
+} from "@/api/lib/legal-search/corpus-index-client";
+import { CORPUS_INDEX_MANIFESTS } from "@/api/lib/legal-search/corpus-index-manifest";
+import {
+  appendCorpusProjectionBatch,
+  corpusIndexUnknownAppendBarrierAt,
+  corpusProjectionRevisionsQuery,
+  CORPUS_PROJECTION_DELETE_MAX_REVISIONS,
+  CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS,
+} from "@/api/lib/legal-search/corpus-index-projection-engine";
+
+const FIRST_REVISION = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000001",
+);
+const SECOND_REVISION = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000002",
+);
+
+test("projection deletes select exact unique append attempts", () => {
+  expect(
+    corpusProjectionRevisionsQuery([FIRST_REVISION, SECOND_REVISION]),
+  ).toBe(
+    `projection_revision:"${FIRST_REVISION}" OR projection_revision:"${SECOND_REVISION}"`,
+  );
+  expect(() =>
+    corpusProjectionRevisionsQuery([
+      toSafeId<"corpusIndexProjectionIntent">('bad" OR document_id:"all'),
+    ]),
+  ).toThrow("invalid corpus projection revision");
+  expect(() => corpusProjectionRevisionsQuery([])).toThrow(
+    `requires 1-${CORPUS_PROJECTION_DELETE_MAX_REVISIONS} revisions`,
+  );
+});
+
+test("committed appends preserve row boundaries and exact revision ownership", async () => {
+  const requests: string[] = [];
+  const client = {
+    ingestCommittedBatch: async (_indexId: string, ndjson: string) => {
+      requests.push(ndjson);
+      return Result.ok(undefined);
+    },
+  };
+  const result = await appendCorpusProjectionBatch({
+    client,
+    indexId: "case_law_v5_cs_sk",
+    entries: [
+      {
+        revision: FIRST_REVISION,
+        documents: [
+          {
+            document_id: "0198e331-e578-7000-8000-000000000011",
+            projection_revision: FIRST_REVISION,
+          },
+          {
+            document_id: "0198e331-e578-7000-8000-000000000011",
+            projection_revision: FIRST_REVISION,
+          },
+        ],
+      },
+      {
+        revision: SECOND_REVISION,
+        documents: [
+          {
+            document_id: "0198e331-e578-7000-8000-000000000012",
+            projection_revision: SECOND_REVISION,
+          },
+        ],
+      },
+    ],
+  });
+
+  expect(result).toEqual(
+    Result.ok({ revisionCount: 2, documentCount: 3, requestCount: 1 }),
+  );
+  expect(requests).toHaveLength(1);
+  expect(requests.at(0)?.split("\n")).toHaveLength(3);
+});
+
+test("append rejects a document carrying another attempt revision", async () => {
+  const result = await appendCorpusProjectionBatch({
+    client: {
+      ingestCommittedBatch: async () =>
+        Result.err(new CorpusIndexError({ message: "must not be called" })),
+    },
+    indexId: "case_law_v5_cs_sk",
+    entries: [
+      {
+        revision: FIRST_REVISION,
+        documents: [
+          {
+            document_id: "0198e331-e578-7000-8000-000000000011",
+            projection_revision: SECOND_REVISION,
+          },
+        ],
+      },
+    ],
+  });
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toContain("does not belong to revision");
+    expect(result.error.stage).toBe("validation");
+    expect(result.error.unattemptedRevisions).toEqual([FIRST_REVISION]);
+  }
+});
+
+test("append failure reports the exact revisions with unknown outcomes", async () => {
+  const result = await appendCorpusProjectionBatch({
+    client: {
+      ingestCommittedBatch: async () =>
+        Result.err(new CorpusIndexError({ message: "response lost" })),
+    },
+    indexId: "case_law_v5_cs_sk",
+    entries: [
+      {
+        revision: FIRST_REVISION,
+        documents: [
+          {
+            document_id: "0198e331-e578-7000-8000-000000000011",
+            projection_revision: FIRST_REVISION,
+          },
+        ],
+      },
+      {
+        revision: SECOND_REVISION,
+        documents: [
+          {
+            document_id: "0198e331-e578-7000-8000-000000000012",
+            projection_revision: SECOND_REVISION,
+          },
+        ],
+      },
+    ],
+  });
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.stage).toBe("append");
+    expect(result.error.committedRevisions).toEqual([]);
+    expect(result.error.unknownRevisions).toEqual([
+      FIRST_REVISION,
+      SECOND_REVISION,
+    ]);
+    expect(result.error.unattemptedRevisions).toEqual([]);
+  }
+});
+
+test("unknown append cleanup waits beyond both request and engine windows", () => {
+  const startedAt = new Date("2026-08-25T12:00:00.000Z");
+  const commitTimeoutMs =
+    (CORPUS_INDEX_MANIFESTS.case_law_v5.engine.indexConfig.indexing_settings
+      .commit_timeout_secs ?? 0) * 1000;
+  expect(
+    corpusIndexUnknownAppendBarrierAt(
+      startedAt,
+      CORPUS_INDEX_MANIFESTS.case_law_v5,
+    ).getTime(),
+  ).toBe(
+    startedAt.getTime() +
+      CORPUS_INDEX_INGEST_TIMEOUT_MS +
+      commitTimeoutMs +
+      CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS,
+  );
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-engine.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-engine.ts
@@ -1,0 +1,261 @@
+import { panic, Result, TaggedError } from "better-result";
+import { Buffer } from "node:buffer";
+
+import type { SafeId } from "@/api/lib/branded-types";
+import { splitIngestRequests } from "@/api/lib/corpus-index/core";
+import { isUuid } from "@/api/lib/custom-schema";
+import {
+  CORPUS_INDEX_INGEST_TIMEOUT_MS,
+  CorpusIndexError,
+  type CorpusIndexClient,
+  type CorpusIndexDeleteSettlement,
+  type CorpusIndexDeleteTask,
+} from "@/api/lib/legal-search/corpus-index-client";
+import type { CorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
+import { LIMITS } from "@/api/lib/limits";
+
+type ProjectionRevision = SafeId<"corpusIndexProjectionIntent">;
+
+export const CORPUS_PROJECTION_APPEND_MAX_REVISIONS = 512;
+export const CORPUS_PROJECTION_APPEND_MAX_SINGLE_REVISION_BYTES =
+  LIMITS.corpusPayloadMaxDecompressedBytes;
+export const CORPUS_PROJECTION_DELETE_MAX_REVISIONS = 128;
+export const CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS = 5_000;
+
+type CorpusProjectionAppendEntry = {
+  revision: ProjectionRevision;
+  documents: readonly Record<string, unknown>[];
+};
+
+type CorpusProjectionAppendClient = Pick<
+  CorpusIndexClient,
+  "ingestCommittedBatch"
+>;
+
+type AppendCorpusProjectionBatchOptions = {
+  client: CorpusProjectionAppendClient;
+  indexId: string;
+  entries: readonly CorpusProjectionAppendEntry[];
+};
+
+export type CorpusProjectionAppendReceipt = {
+  revisionCount: number;
+  documentCount: number;
+  requestCount: number;
+};
+
+export class CorpusProjectionAppendError extends TaggedError(
+  "CorpusProjectionAppendError",
+)<{
+  message: string;
+  stage: "validation" | "append";
+  committedRevisions: ProjectionRevision[];
+  unknownRevisions: ProjectionRevision[];
+  unattemptedRevisions: ProjectionRevision[];
+  cause?: CorpusIndexError | undefined;
+}> {}
+
+const invalidAppend = (
+  message: string,
+  unattemptedRevisions: ProjectionRevision[],
+): Result<never, CorpusProjectionAppendError> =>
+  Result.err(
+    new CorpusProjectionAppendError({
+      message,
+      stage: "validation",
+      committedRevisions: [],
+      unknownRevisions: [],
+      unattemptedRevisions,
+    }),
+  );
+
+export const appendCorpusProjectionBatch = async ({
+  client,
+  indexId,
+  entries,
+}: AppendCorpusProjectionBatchOptions): Promise<
+  Result<CorpusProjectionAppendReceipt, CorpusProjectionAppendError>
+> => {
+  const revisions = entries.map(({ revision }) => revision);
+  if (
+    entries.length === 0 ||
+    entries.length > CORPUS_PROJECTION_APPEND_MAX_REVISIONS
+  ) {
+    return invalidAppend(
+      `corpus projection append requires 1-${CORPUS_PROJECTION_APPEND_MAX_REVISIONS} revisions`,
+      revisions,
+    );
+  }
+
+  const uniqueRevisions = new Set<ProjectionRevision>();
+  let documentCount = 0;
+  for (const entry of entries) {
+    if (
+      !isUuid(entry.revision) ||
+      uniqueRevisions.has(entry.revision) ||
+      entry.documents.length === 0
+    ) {
+      return invalidAppend(
+        `corpus projection append received an invalid, duplicate, or empty revision: ${entry.revision}`,
+        revisions,
+      );
+    }
+    uniqueRevisions.add(entry.revision);
+    documentCount += entry.documents.length;
+    for (const document of entry.documents) {
+      if (
+        document["projection_revision"] !== entry.revision ||
+        typeof document["document_id"] !== "string"
+      ) {
+        return invalidAppend(
+          `corpus projection document does not belong to revision ${entry.revision}`,
+          revisions,
+        );
+      }
+    }
+  }
+
+  const requests = splitIngestRequests(
+    entries.map((entry) => ({ row: entry, docs: [...entry.documents] })),
+    LIMITS.corpusIndexIngestMaxBytes,
+  );
+  for (const request of requests) {
+    if (
+      Buffer.byteLength(request.ndjson, "utf8") >
+      CORPUS_PROJECTION_APPEND_MAX_SINGLE_REVISION_BYTES
+    ) {
+      return invalidAppend(
+        "one corpus projection revision exceeds the append safety ceiling",
+        revisions,
+      );
+    }
+  }
+
+  const committedRevisions: ProjectionRevision[] = [];
+  for (const [requestIndex, request] of requests.entries()) {
+    // oxlint-disable-next-line no-await-in-loop -- ordered committed requests bound search-engine pressure and make the returned prefix authoritative
+    const ingested = await client.ingestCommittedBatch(indexId, request.ndjson);
+    if (ingested.isErr()) {
+      const unknownRevisions = request.entries.map(
+        ({ row: { revision } }) => revision,
+      );
+      const unattemptedRevisions = requests
+        .slice(requestIndex + 1)
+        .flatMap(({ entries: laterEntries }) =>
+          laterEntries.map(({ row: { revision } }) => revision),
+        );
+      return Result.err(
+        new CorpusProjectionAppendError({
+          message: "corpus projection append outcome is partially unknown",
+          stage: "append",
+          committedRevisions,
+          unknownRevisions,
+          unattemptedRevisions,
+          cause: ingested.error,
+        }),
+      );
+    }
+    committedRevisions.push(
+      ...request.entries.map(({ row: { revision } }) => revision),
+    );
+  }
+  return Result.ok({
+    revisionCount: entries.length,
+    documentCount,
+    requestCount: requests.length,
+  });
+};
+
+export const corpusProjectionRevisionsQuery = (
+  revisions: readonly ProjectionRevision[],
+): string => {
+  if (
+    revisions.length === 0 ||
+    revisions.length > CORPUS_PROJECTION_DELETE_MAX_REVISIONS
+  ) {
+    return panic(
+      `corpus projection delete requires 1-${CORPUS_PROJECTION_DELETE_MAX_REVISIONS} revisions`,
+    );
+  }
+  return revisions
+    .map((revision) =>
+      isUuid(revision)
+        ? `projection_revision:"${revision}"`
+        : panic(`invalid corpus projection revision: ${revision}`),
+    )
+    .join(" OR ");
+};
+
+type CorpusProjectionDeleteClient = Pick<
+  CorpusIndexClient,
+  "deleteByQuery" | "readDeleteSettlement" | "search"
+>;
+
+type ProjectionRevisionOperationOptions = {
+  client: CorpusProjectionDeleteClient;
+  indexId: string;
+  revisions: readonly ProjectionRevision[];
+};
+
+export const deleteCorpusProjectionRevisions = async ({
+  client,
+  indexId,
+  revisions,
+}: ProjectionRevisionOperationOptions): Promise<
+  Result<CorpusIndexDeleteTask, CorpusIndexError>
+> =>
+  await client.deleteByQuery(
+    indexId,
+    corpusProjectionRevisionsQuery(revisions),
+  );
+
+type ReadCorpusProjectionDeleteSettlementOptions = {
+  client: CorpusProjectionDeleteClient;
+  indexId: string;
+  requiredOpstamp: number;
+};
+
+export const readCorpusProjectionDeleteSettlement = async ({
+  client,
+  indexId,
+  requiredOpstamp,
+}: ReadCorpusProjectionDeleteSettlementOptions): Promise<
+  Result<CorpusIndexDeleteSettlement, CorpusIndexError>
+> => await client.readDeleteSettlement(indexId, requiredOpstamp);
+
+export const countCorpusProjectionRevisions = async ({
+  client,
+  indexId,
+  revisions,
+}: ProjectionRevisionOperationOptions): Promise<
+  Result<number, CorpusIndexError>
+> => {
+  const searched = await client.search({
+    indexId,
+    query: corpusProjectionRevisionsQuery(revisions),
+    maxHits: 0,
+  });
+  return searched.map(({ numHits }) => numHits);
+};
+
+export const corpusIndexUnknownAppendBarrierAt = (
+  appendStartedAt: Date,
+  manifest: CorpusIndexManifest,
+): Date => {
+  const commitTimeoutSecs =
+    manifest.engine.indexConfig.indexing_settings.commit_timeout_secs;
+  if (
+    !Number.isFinite(appendStartedAt.getTime()) ||
+    commitTimeoutSecs === undefined ||
+    !Number.isSafeInteger(commitTimeoutSecs) ||
+    commitTimeoutSecs <= 0
+  ) {
+    return panic("Corpus projection append barrier contract is invalid");
+  }
+  return new Date(
+    appendStartedAt.getTime() +
+      CORPUS_INDEX_INGEST_TIMEOUT_MS +
+      commitTimeoutSecs * 1000 +
+      CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS,
+  );
+};

--- a/apps/api/src/lib/legal-search/corpus-index-projection-engine.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-engine.ts
@@ -6,7 +6,7 @@ import { splitIngestRequests } from "@/api/lib/corpus-index/core";
 import { isUuid } from "@/api/lib/custom-schema";
 import {
   CORPUS_INDEX_INGEST_TIMEOUT_MS,
-  CorpusIndexError,
+  type CorpusIndexError,
   type CorpusIndexClient,
   type CorpusIndexDeleteSettlement,
   type CorpusIndexDeleteTask,
@@ -20,7 +20,7 @@ export const CORPUS_PROJECTION_APPEND_MAX_REVISIONS = 512;
 export const CORPUS_PROJECTION_APPEND_MAX_SINGLE_REVISION_BYTES =
   LIMITS.corpusPayloadMaxDecompressedBytes;
 export const CORPUS_PROJECTION_DELETE_MAX_REVISIONS = 128;
-export const CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS = 5_000;
+export const CORPUS_PROJECTION_UNKNOWN_APPEND_MARGIN_MS = 5000;
 
 type CorpusProjectionAppendEntry = {
   revision: ProjectionRevision;
@@ -36,6 +36,7 @@ type AppendCorpusProjectionBatchOptions = {
   client: CorpusProjectionAppendClient;
   indexId: string;
   entries: readonly CorpusProjectionAppendEntry[];
+  clock?: () => Date;
 };
 
 export type CorpusProjectionAppendReceipt = {
@@ -48,24 +49,34 @@ export class CorpusProjectionAppendError extends TaggedError(
   "CorpusProjectionAppendError",
 )<{
   message: string;
+  code:
+    | "invalid_batch"
+    | "invalid_revision"
+    | "invalid_document"
+    | "revision_too_large"
+    | "append_unknown";
   stage: "validation" | "append";
   committedRevisions: ProjectionRevision[];
   unknownRevisions: ProjectionRevision[];
   unattemptedRevisions: ProjectionRevision[];
+  unknownOutcomeObservedAt: Date | null;
   cause?: CorpusIndexError | undefined;
 }> {}
 
 const invalidAppend = (
+  code: Exclude<CorpusProjectionAppendError["code"], "append_unknown">,
   message: string,
   unattemptedRevisions: ProjectionRevision[],
 ): Result<never, CorpusProjectionAppendError> =>
   Result.err(
     new CorpusProjectionAppendError({
       message,
+      code,
       stage: "validation",
       committedRevisions: [],
       unknownRevisions: [],
       unattemptedRevisions,
+      unknownOutcomeObservedAt: null,
     }),
   );
 
@@ -73,6 +84,7 @@ export const appendCorpusProjectionBatch = async ({
   client,
   indexId,
   entries,
+  clock = () => new Date(),
 }: AppendCorpusProjectionBatchOptions): Promise<
   Result<CorpusProjectionAppendReceipt, CorpusProjectionAppendError>
 > => {
@@ -82,6 +94,7 @@ export const appendCorpusProjectionBatch = async ({
     entries.length > CORPUS_PROJECTION_APPEND_MAX_REVISIONS
   ) {
     return invalidAppend(
+      "invalid_batch",
       `corpus projection append requires 1-${CORPUS_PROJECTION_APPEND_MAX_REVISIONS} revisions`,
       revisions,
     );
@@ -96,6 +109,7 @@ export const appendCorpusProjectionBatch = async ({
       entry.documents.length === 0
     ) {
       return invalidAppend(
+        "invalid_revision",
         `corpus projection append received an invalid, duplicate, or empty revision: ${entry.revision}`,
         revisions,
       );
@@ -108,6 +122,7 @@ export const appendCorpusProjectionBatch = async ({
         typeof document["document_id"] !== "string"
       ) {
         return invalidAppend(
+          "invalid_document",
           `corpus projection document does not belong to revision ${entry.revision}`,
           revisions,
         );
@@ -121,10 +136,11 @@ export const appendCorpusProjectionBatch = async ({
   );
   for (const request of requests) {
     if (
-      Buffer.byteLength(request.ndjson, "utf8") >
+      Buffer.byteLength(request.ndjson, "utf-8") >
       CORPUS_PROJECTION_APPEND_MAX_SINGLE_REVISION_BYTES
     ) {
       return invalidAppend(
+        "revision_too_large",
         "one corpus projection revision exceeds the append safety ceiling",
         revisions,
       );
@@ -141,6 +157,7 @@ export const appendCorpusProjectionBatch = async ({
     }
     const ingested = await client.ingestCommittedBatch(indexId, request.ndjson);
     if (ingested.isErr()) {
+      const unknownOutcomeObservedAt = clock();
       const unknownRevisions = request.entries.map(
         ({ row: { revision } }) => revision,
       );
@@ -152,10 +169,12 @@ export const appendCorpusProjectionBatch = async ({
       return Result.err(
         new CorpusProjectionAppendError({
           message: "corpus projection append outcome is partially unknown",
+          code: "append_unknown",
           stage: "append",
           committedRevisions,
           unknownRevisions,
           unattemptedRevisions,
+          unknownOutcomeObservedAt,
           cause: ingested.error,
         }),
       );

--- a/apps/api/src/lib/legal-search/corpus-index-projection-engine.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-engine.ts
@@ -132,8 +132,13 @@ export const appendCorpusProjectionBatch = async ({
   }
 
   const committedRevisions: ProjectionRevision[] = [];
-  for (const [requestIndex, request] of requests.entries()) {
-    // oxlint-disable-next-line no-await-in-loop -- ordered committed requests bound search-engine pressure and make the returned prefix authoritative
+  const appendRequestAt = async (
+    requestIndex: number,
+  ): Promise<Result<void, CorpusProjectionAppendError>> => {
+    const request = requests.at(requestIndex);
+    if (request === undefined) {
+      return Result.ok(undefined);
+    }
     const ingested = await client.ingestCommittedBatch(indexId, request.ndjson);
     if (ingested.isErr()) {
       const unknownRevisions = request.entries.map(
@@ -158,6 +163,11 @@ export const appendCorpusProjectionBatch = async ({
     committedRevisions.push(
       ...request.entries.map(({ row: { revision } }) => revision),
     );
+    return appendRequestAt(requestIndex + 1);
+  };
+  const appendResult = await appendRequestAt(0);
+  if (appendResult.isErr()) {
+    return Result.err(appendResult.error);
   }
   return Result.ok({
     revisionCount: entries.length,


### PR DESCRIPTION
## Summary

- build strict, pointer-free case-law v5 and legislation v2 projections
- append exact per-attempt revisions through Quickwit V2 with complete receipt validation
- expose bounded exact-revision deletion, split-opstamp settlement, zero-hit checks, and the unknown-outcome barrier

## Validation

- `git diff --check`
- exact touched-file formatting
- full validation delegated to required CI

Stacked on #2467.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for building searchable case-law and legislation projection documents with richer metadata, titles, anchors, dates and statuses.
  - Improved batching and processing of corpus updates for more reliable indexing.
- **Bug Fixes**
  - Indexing now verifies that all documents are fully processed and committed before reporting success.
  - Added safeguards for rejected, incomplete or partially accepted batches.
  - Improved handling of failed updates to prevent unknown or duplicate indexing outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->