### PR TITLE
feat: route corpus indexes by cluster

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -246,14 +246,14 @@ S3_SCOPED_SIGNING_ROLE_ARN=""
 # [internal] Optional. Corpus index endpoint.
 # CORPUS_INDEX_ENDPOINT=""
 
+# [internal] Optional. Local-development-only read endpoint for Quickwit 0.9.
+# Unset uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.
+# CORPUS_INDEX_Q09_SEARCH_ENDPOINT=""
+
 # [internal] Optional. Isolated Quickwit 0.9 mutation endpoint. Final
 # generations registered on q09 use this endpoint; it never falls back to the
 # legacy cluster.
 # CORPUS_INDEX_Q09_ENDPOINT=""
-
-# [internal] Optional. Local-development-only read endpoint for Quickwit 0.9.
-# Unset uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.
-# CORPUS_INDEX_Q09_SEARCH_ENDPOINT=""
 
 # [internal] Optional. Corpus index s3 bucket.
 # CORPUS_INDEX_S3_BUCKET=""

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -246,6 +246,15 @@ S3_SCOPED_SIGNING_ROLE_ARN=""
 # [internal] Optional. Corpus index endpoint.
 # CORPUS_INDEX_ENDPOINT=""
 
+# [internal] Optional. Isolated Quickwit 0.9 mutation endpoint. Final
+# generations registered on q09 use this endpoint; it never falls back to the
+# legacy cluster.
+# CORPUS_INDEX_Q09_ENDPOINT=""
+
+# [internal] Optional. Local-development-only read endpoint for Quickwit 0.9.
+# Unset uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.
+# CORPUS_INDEX_Q09_SEARCH_ENDPOINT=""
+
 # [internal] Optional. Corpus index s3 bucket.
 # CORPUS_INDEX_S3_BUCKET=""
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -250,9 +250,10 @@ S3_SCOPED_SIGNING_ROLE_ARN=""
 # Unset uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.
 # CORPUS_INDEX_Q09_SEARCH_ENDPOINT=""
 
-# [internal] Optional. Isolated Quickwit 0.9 mutation endpoint. Final
-# generations registered on q09 use this endpoint; it never falls back to the
-# legacy cluster.
+# [internal] Conditionally required when CORPUS_INDEXING_ENABLED is true and
+# LEGAL_SEARCH_INDEX_GENERATION is case_law_v5. Isolated Quickwit 0.9 mutation
+# endpoint. Final generations registered on q09 use this endpoint; it never
+# falls back to the legacy cluster.
 # CORPUS_INDEX_Q09_ENDPOINT=""
 
 # [internal] Optional. Corpus index s3 bucket.

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -397,14 +397,14 @@ export const envBaseInvariantViolation = ({
     CORPUS_INDEX_SEARCH_ENDPOINT === undefined &&
     CORPUS_INDEX_Q09_SEARCH_ENDPOINT === undefined
   ) {
-    return "Public-law database URLs require a corpus-index search endpoint.";
+    return "Public-law database URLs require CORPUS_INDEX_SEARCH_ENDPOINT or CORPUS_INDEX_Q09_SEARCH_ENDPOINT.";
   }
   if (
     hasPublicLawDatabaseUrl &&
     (CORPUS_INDEX_ENDPOINT !== undefined ||
       CORPUS_INDEX_Q09_ENDPOINT !== undefined)
   ) {
-    return "Corpus-index mutation endpoints must be unset when a public-law database URL is configured.";
+    return "CORPUS_INDEX_ENDPOINT and CORPUS_INDEX_Q09_ENDPOINT must be unset when a public-law database URL is configured.";
   }
   if (hasPublicLawDatabaseUrl && CORPUS_INDEXING_ENABLED) {
     return "CORPUS_INDEXING_ENABLED must be false when a public-law database URL is configured.";

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -166,6 +166,8 @@ export const envBaseServerSchema = {
   // admin endpoint below, which shared-corpus mode requires to stay unset.
   CORPUS_INDEX_SEARCH_ENDPOINT: v.optional(v.pipe(v.string(), v.url())),
   CORPUS_INDEX_ENDPOINT: v.optional(v.pipe(v.string(), v.url())),
+  CORPUS_INDEX_Q09_SEARCH_ENDPOINT: v.optional(v.pipe(v.string(), v.url())),
+  CORPUS_INDEX_Q09_ENDPOINT: v.optional(v.pipe(v.string(), v.url())),
   CORPUS_INDEX_S3_BUCKET: v.optional(v.string()),
   // Falls back to S3_BUCKET when unset (dev). Required when corpus
   // storage is on (enforced post-validation).
@@ -258,6 +260,8 @@ type EnvBaseInvariantInput = {
   CORPUS_INDEX_BACKPRESSURE_METRIC?: string | undefined;
   CORPUS_INDEX_BACKPRESSURE_NAMESPACE?: string | undefined;
   CORPUS_INDEX_ENDPOINT?: string | undefined;
+  CORPUS_INDEX_Q09_ENDPOINT?: string | undefined;
+  CORPUS_INDEX_Q09_SEARCH_ENDPOINT?: string | undefined;
   CORPUS_INDEX_SEARCH_ENDPOINT?: string | undefined;
   CORPUS_INDEXING_ENABLED: boolean;
   CORPUS_STORAGE_ENABLED: boolean;
@@ -282,6 +286,8 @@ export const envBaseInvariantViolation = ({
   CORPUS_INDEX_BACKPRESSURE_METRIC,
   CORPUS_INDEX_BACKPRESSURE_NAMESPACE,
   CORPUS_INDEX_ENDPOINT,
+  CORPUS_INDEX_Q09_ENDPOINT,
+  CORPUS_INDEX_Q09_SEARCH_ENDPOINT,
   CORPUS_INDEX_SEARCH_ENDPOINT,
   CORPUS_INDEXING_ENABLED,
   CORPUS_STORAGE_ENABLED,
@@ -355,6 +361,18 @@ export const envBaseInvariantViolation = ({
   if (!isDev && CORPUS_INDEX_SEARCH_ENDPOINT !== undefined) {
     return "CORPUS_INDEX_SEARCH_ENDPOINT is only supported in local development.";
   }
+  if (
+    CORPUS_INDEX_Q09_SEARCH_ENDPOINT !== undefined &&
+    !isTlsOrLoopbackUrl(CORPUS_INDEX_Q09_SEARCH_ENDPOINT, {
+      plaintextProtocol: "http:",
+      tlsProtocol: "https:",
+    })
+  ) {
+    return "CORPUS_INDEX_Q09_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address.";
+  }
+  if (!isDev && CORPUS_INDEX_Q09_SEARCH_ENDPOINT !== undefined) {
+    return "CORPUS_INDEX_Q09_SEARCH_ENDPOINT is only supported in local development.";
+  }
   // REMOVAL CONDITION: delete this invariant in the PR that makes a corpus
   // cursor carry the dictionary version it was built against.
   //
@@ -371,11 +389,19 @@ export const envBaseInvariantViolation = ({
   if (hasPublicLawDatabaseUrl && LEGAL_SEARCH_PROVIDER !== "corpus-index") {
     return 'Public-law database URLs require LEGAL_SEARCH_PROVIDER="corpus-index".';
   }
-  if (hasPublicLawDatabaseUrl && CORPUS_INDEX_SEARCH_ENDPOINT === undefined) {
-    return "Public-law database URLs require CORPUS_INDEX_SEARCH_ENDPOINT.";
+  if (
+    hasPublicLawDatabaseUrl &&
+    CORPUS_INDEX_SEARCH_ENDPOINT === undefined &&
+    CORPUS_INDEX_Q09_SEARCH_ENDPOINT === undefined
+  ) {
+    return "Public-law database URLs require a corpus-index search endpoint.";
   }
-  if (hasPublicLawDatabaseUrl && CORPUS_INDEX_ENDPOINT !== undefined) {
-    return "CORPUS_INDEX_ENDPOINT must be unset when a public-law database URL is configured.";
+  if (
+    hasPublicLawDatabaseUrl &&
+    (CORPUS_INDEX_ENDPOINT !== undefined ||
+      CORPUS_INDEX_Q09_ENDPOINT !== undefined)
+  ) {
+    return "Corpus-index mutation endpoints must be unset when a public-law database URL is configured.";
   }
   if (hasPublicLawDatabaseUrl && CORPUS_INDEXING_ENABLED) {
     return "CORPUS_INDEXING_ENABLED must be false when a public-law database URL is configured.";
@@ -400,9 +426,11 @@ export const envBaseInvariantViolation = ({
   if (
     LEGAL_SEARCH_PROVIDER === "corpus-index" &&
     CORPUS_INDEX_SEARCH_ENDPOINT === undefined &&
-    CORPUS_INDEX_ENDPOINT === undefined
+    CORPUS_INDEX_ENDPOINT === undefined &&
+    CORPUS_INDEX_Q09_SEARCH_ENDPOINT === undefined &&
+    CORPUS_INDEX_Q09_ENDPOINT === undefined
   ) {
-    return "LEGAL_SEARCH_PROVIDER=corpus-index requires CORPUS_INDEX_SEARCH_ENDPOINT or CORPUS_INDEX_ENDPOINT to be set.";
+    return "LEGAL_SEARCH_PROVIDER=corpus-index requires a configured corpus-index endpoint.";
   }
 
   return corpusStorageInvariantViolation({

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -16,6 +16,7 @@ import {
   corpusStorageInvariantViolation,
   resolveCorpusStorageMode,
 } from "@/api/lib/corpus-storage-mode";
+import { parseCorpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import {
   QUERY_EXPANSION_MODES,
   type QueryExpansionMode,
@@ -268,6 +269,7 @@ type EnvBaseInvariantInput = {
   CORPUS_STORAGE_MODE?: CorpusStorageMode | undefined;
   DATABASE_URL: string;
   LEGAL_CORPUS_S3_BUCKET?: string | undefined;
+  LEGAL_SEARCH_INDEX_GENERATION: string;
   LEGAL_SEARCH_PROVIDER: "pg-fts" | "corpus-index";
   QUERY_EXPANSION_MODE: QueryExpansionMode;
   S3_ACCESS_KEY_ID?: string | undefined;
@@ -294,6 +296,7 @@ export const envBaseInvariantViolation = ({
   CORPUS_STORAGE_MODE,
   DATABASE_URL,
   LEGAL_CORPUS_S3_BUCKET,
+  LEGAL_SEARCH_INDEX_GENERATION,
   LEGAL_SEARCH_PROVIDER,
   QUERY_EXPANSION_MODE,
   S3_ACCESS_KEY_ID,
@@ -423,14 +426,27 @@ export const envBaseInvariantViolation = ({
   if (S3_CREDENTIALS_PROVIDER === "env" && !(hasAccessKey && hasSecretKey)) {
     return 'S3_CREDENTIALS_PROVIDER="env" requires static S3 credentials.';
   }
+  const caseLawCluster = parseCorpusIndexClusterForGeneration(
+    "case_law",
+    LEGAL_SEARCH_INDEX_GENERATION,
+  );
+  if (LEGAL_SEARCH_PROVIDER === "corpus-index" && caseLawCluster === null) {
+    return `Unknown case-law corpus index generation: ${LEGAL_SEARCH_INDEX_GENERATION}.`;
+  }
   if (
     LEGAL_SEARCH_PROVIDER === "corpus-index" &&
     CORPUS_INDEX_SEARCH_ENDPOINT === undefined &&
-    CORPUS_INDEX_ENDPOINT === undefined &&
+    CORPUS_INDEX_ENDPOINT === undefined
+  ) {
+    return "Serving legislation_v1 on q08 requires CORPUS_INDEX_SEARCH_ENDPOINT or CORPUS_INDEX_ENDPOINT.";
+  }
+  if (
+    LEGAL_SEARCH_PROVIDER === "corpus-index" &&
+    caseLawCluster === "q09" &&
     CORPUS_INDEX_Q09_SEARCH_ENDPOINT === undefined &&
     CORPUS_INDEX_Q09_ENDPOINT === undefined
   ) {
-    return "LEGAL_SEARCH_PROVIDER=corpus-index requires a configured corpus-index endpoint.";
+    return "Serving case_law_v5 on q09 requires CORPUS_INDEX_Q09_SEARCH_ENDPOINT or CORPUS_INDEX_Q09_ENDPOINT.";
   }
 
   return corpusStorageInvariantViolation({

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -376,6 +376,15 @@ export const envBaseInvariantViolation = ({
   if (!isDev && CORPUS_INDEX_Q09_SEARCH_ENDPOINT !== undefined) {
     return "CORPUS_INDEX_Q09_SEARCH_ENDPOINT is only supported in local development.";
   }
+  if (
+    CORPUS_INDEX_Q09_ENDPOINT !== undefined &&
+    !isTlsOrLoopbackUrl(CORPUS_INDEX_Q09_ENDPOINT, {
+      plaintextProtocol: "http:",
+      tlsProtocol: "https:",
+    })
+  ) {
+    return "CORPUS_INDEX_Q09_ENDPOINT must use HTTPS unless it targets a loopback address.";
+  }
   // REMOVAL CONDITION: delete this invariant in the PR that makes a corpus
   // cursor carry the dictionary version it was built against.
   //
@@ -447,6 +456,13 @@ export const envBaseInvariantViolation = ({
     CORPUS_INDEX_Q09_ENDPOINT === undefined
   ) {
     return "Serving case_law_v5 on q09 requires CORPUS_INDEX_Q09_SEARCH_ENDPOINT or CORPUS_INDEX_Q09_ENDPOINT.";
+  }
+  if (
+    CORPUS_INDEXING_ENABLED &&
+    caseLawCluster === "q09" &&
+    CORPUS_INDEX_Q09_ENDPOINT === undefined
+  ) {
+    return "Indexing case_law_v5 on q09 requires CORPUS_INDEX_Q09_ENDPOINT.";
   }
 
   return corpusStorageInvariantViolation({

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -457,6 +457,9 @@ export const envBaseInvariantViolation = ({
   ) {
     return "Serving case_law_v5 on q09 requires CORPUS_INDEX_Q09_SEARCH_ENDPOINT or CORPUS_INDEX_Q09_ENDPOINT.";
   }
+  if (CORPUS_INDEXING_ENABLED && CORPUS_INDEX_ENDPOINT === undefined) {
+    return "Corpus indexing requires CORPUS_INDEX_ENDPOINT for legislation_v1 on q08.";
+  }
   if (
     CORPUS_INDEXING_ENABLED &&
     caseLawCluster === "q09" &&

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -37,6 +37,7 @@ import {
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
+import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 import {
   caseLawCorpusQuery,
@@ -634,6 +635,7 @@ const searchCorpusIndexDecisions = async (
   }
 
   const searchPage = await readCorpusIndexSearchPage({
+    cluster: corpusIndexClusterForGeneration("case_law", generation),
     indexId,
     query,
     limit,

--- a/apps/api/src/handlers/case-law/erasure.ts
+++ b/apps/api/src/handlers/case-law/erasure.ts
@@ -322,7 +322,10 @@ export const redactCaseLawDecision = async ({
   // index) and from the current-country index in case a move was
   // mid-flight; the recorded pointer is only cleared once both succeed.
   let auditedViaCorpusIndex = false;
-  if (envBase.CORPUS_INDEX_ENDPOINT !== undefined) {
+  if (
+    envBase.CORPUS_INDEX_ENDPOINT !== undefined ||
+    envBase.CORPUS_INDEX_Q09_ENDPOINT !== undefined
+  ) {
     const projectionTargets = await scopedDb((tx) =>
       tx
         .select({

--- a/apps/api/src/handlers/legislation/corpus-index.ts
+++ b/apps/api/src/handlers/legislation/corpus-index.ts
@@ -31,11 +31,13 @@ import {
   timestampCasToken,
   type TimestampCasToken,
 } from "@/api/lib/db/timestamp-cas";
+import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import {
   CorpusIndexError,
   getCorpusIndexClient,
 } from "@/api/lib/legal-search/corpus-index-client";
 import { readCorpusText } from "@/api/lib/legal-search/corpus-storage";
+import { corpusIndexGeneration } from "@/api/lib/legal-search/index-naming";
 import { logger } from "@/api/lib/observability/logger";
 
 /**
@@ -425,10 +427,12 @@ export const reconcileNextLegislationCorpusIndexDelete = async (
           );
       });
 
-      const settlement = await getCorpusIndexClient().readDeleteSettlement(
-        next.indexId,
-        next.opstamp,
-      );
+      const settlement = await getCorpusIndexClient(
+        corpusIndexClusterForGeneration(
+          "legislation",
+          corpusIndexGeneration(next.indexId),
+        ),
+      ).readDeleteSettlement(next.indexId, next.opstamp);
       if (settlement.isErr()) {
         throw settlement.error;
       }

--- a/apps/api/src/handlers/legislation/search.ts
+++ b/apps/api/src/handlers/legislation/search.ts
@@ -19,6 +19,7 @@ import {
 } from "@/api/lib/custom-schema";
 import { blendedRankSql } from "@/api/lib/legal-search/authority-sql";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
+import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 import {
   corpusFreeTextClause,
@@ -364,6 +365,7 @@ const corpusIndexSearch = async (
   }
 
   const searchPage = await readCorpusIndexSearchPage({
+    cluster: corpusIndexClusterForGeneration("legislation", generation),
     indexId,
     query,
     limit,

--- a/apps/api/src/lib/corpus-index/census.test.ts
+++ b/apps/api/src/lib/corpus-index/census.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
+import { envBase } from "@/api/env-base";
 import {
   CENSUS_CYCLE_INTERVAL,
   CENSUS_DISPOSITION,
@@ -42,6 +43,7 @@ const NO_PENDING_DELETE = { count: 0, oldest: null } as const;
 /** Index ids the engine was asked to count, in request order. */
 let countedIndexIds: string[];
 let countedMaxHits: unknown[];
+let countedQueries: unknown[];
 
 const indexIdOfCountRequest = (url: string): string | undefined =>
   /\/api\/v1\/(?<indexId>[^/]+)\/search/u.exec(url)?.groups?.["indexId"];
@@ -76,6 +78,7 @@ const engineHolding = (
         typeof init?.body === "string" ? init.body : "{}",
       );
       countedMaxHits.push(body["max_hits"]);
+      countedQueries.push(body["query"]);
       return new Response(
         JSON.stringify({
           num_hits: numHits,
@@ -168,6 +171,7 @@ const databaseHolding = (
 beforeEach(() => {
   countedIndexIds = [];
   countedMaxHits = [];
+  countedQueries = [];
 });
 
 afterEach(() => {
@@ -231,6 +235,27 @@ describe("count seed driver", () => {
 });
 
 describe("index census", () => {
+  test("v5 counts the manifest opening passage", async () => {
+    engineHolding(10_000);
+    const generation = "case_law_v5";
+    const originalEndpoint = envBase.CORPUS_INDEX_Q09_ENDPOINT;
+    Object.assign(envBase, {
+      CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
+    });
+    try {
+      const census = await censusIndex({
+        scopedDb: databaseHolding(10_000),
+        generation,
+        indexId: corpusIndexId(generation, "CZE"),
+      });
+      expect(census.isOk()).toBe(true);
+    } finally {
+      Object.assign(envBase, { CORPUS_INDEX_Q09_ENDPOINT: originalEndpoint });
+    }
+
+    expect(countedQueries).toEqual(["is_opening:true"]);
+  });
+
   test("noise inside the tolerance is not a shortfall", async () => {
     engineHolding(10_000 - CENSUS_TOLERANCE);
 

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -66,6 +66,7 @@ import {
   caseLawCorpusProjectionJoin,
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
+import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import type { CorpusIndexError } from "@/api/lib/legal-search/corpus-index-client";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
 import {
@@ -365,6 +366,7 @@ const dispositionOf = (
 
 const readDeleteSettlement = async (
   scopedDb: ScopedDb,
+  generation: string,
   indexId: string,
 ): Promise<Result<IndexCensus["deleteSettlement"], CorpusIndexError>> => {
   const watermark = (
@@ -378,10 +380,9 @@ const readDeleteSettlement = async (
   if (watermark === undefined) {
     return Result.ok(null);
   }
-  const settlement = await getCorpusIndexClient().readDeleteSettlement(
-    indexId,
-    watermark.opstamp,
-  );
+  const settlement = await getCorpusIndexClient(
+    corpusIndexClusterForGeneration("case_law", generation),
+  ).readDeleteSettlement(indexId, watermark.opstamp);
   if (Result.isError(settlement)) {
     return Result.err(settlement.error);
   }
@@ -514,18 +515,16 @@ export const censusIndex = async ({
     generation,
     indexId,
   });
-  const counted = await getCorpusIndexClient().search({
-    indexId,
-    query: DOCUMENT_COUNT_QUERY,
-    maxHits: 1,
-  });
+  const counted = await getCorpusIndexClient(
+    corpusIndexClusterForGeneration("case_law", generation),
+  ).search({ indexId, query: DOCUMENT_COUNT_QUERY, maxHits: 1 });
   if (Result.isError(counted)) {
     return Result.err(counted.error);
   }
 
   const shortfall = marked.markedIndexed - counted.value.numHits;
   const deleteSettlementResult = marked.hasPendingDelete
-    ? await readDeleteSettlement(scopedDb, indexId)
+    ? await readDeleteSettlement(scopedDb, generation, indexId)
     : Result.ok(null);
   if (Result.isError(deleteSettlementResult)) {
     return Result.err(deleteSettlementResult.error);

--- a/apps/api/src/lib/corpus-index/census.ts
+++ b/apps/api/src/lib/corpus-index/census.ts
@@ -69,20 +69,13 @@ import {
 import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import type { CorpusIndexError } from "@/api/lib/legal-search/corpus-index-client";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
+import { corpusIndexReadContract } from "@/api/lib/legal-search/corpus-index-read-contract";
 import {
   corpusIndexIdsFor,
   corpusIndexJurisdictions,
 } from "@/api/lib/legal-search/index-naming";
 import { logger } from "@/api/lib/observability/logger";
 import { isRecord } from "@/api/lib/type-guards";
-
-/**
- * Counts documents rather than passages. A passage-granular index holds
- * one entry per chunk and exactly one of them per document carries
- * `seq:0`, so this is the document count on the engine side whichever
- * granularity the family is indexed at.
- */
-const DOCUMENT_COUNT_QUERY = "seq:0";
 
 /** One short transaction's maximum accounting seed work. */
 export const CASE_LAW_CORPUS_INDEX_COUNT_BACKFILL_BATCH_SIZE = 1000;
@@ -517,7 +510,11 @@ export const censusIndex = async ({
   });
   const counted = await getCorpusIndexClient(
     corpusIndexClusterForGeneration("case_law", generation),
-  ).search({ indexId, query: DOCUMENT_COUNT_QUERY, maxHits: 1 });
+  ).search({
+    indexId,
+    query: corpusIndexReadContract("case_law", generation).openingPassageQuery,
+    maxHits: 1,
+  });
   if (Result.isError(counted)) {
     return Result.err(counted.error);
   }

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -591,11 +591,19 @@ describe("generation mutation routing", () => {
         ),
     };
 
-    await expect(
-      indexer.backfillRows(scopedDb, [row], "case_law_v5", {
+    const finalGenerationRejection: unknown = await indexer
+      .backfillRows(scopedDb, [row], "case_law_v5", {
         ...rebuildOptions,
-      }),
-    ).rejects.toThrow(
+      })
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+    expect(
+      finalGenerationRejection instanceof Error
+        ? finalGenerationRejection.message
+        : null,
+    ).toBe(
       "Legacy case_law corpus indexer cannot write final generation case_law_v5",
     );
     expect(

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -506,7 +506,7 @@ describe("generation mutation routing", () => {
     });
   });
 
-  test("rebuild writes v5 to q09 and a legacy generation to q08", async () => {
+  test("legacy rebuild rejects v5 and writes a legacy generation to q08", async () => {
     Object.assign(envBase, {
       CORPUS_INDEX_ENDPOINT: "http://localhost:7281",
       CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
@@ -591,18 +591,20 @@ describe("generation mutation routing", () => {
         ),
     };
 
-    expect(
-      await indexer.backfillRows(scopedDb, [row], "case_law_v5", {
+    await expect(
+      indexer.backfillRows(scopedDb, [row], "case_law_v5", {
         ...rebuildOptions,
       }),
-    ).toMatchObject({ indexed: 1 });
+    ).rejects.toThrow(
+      "Legacy case_law corpus indexer cannot write final generation case_law_v5",
+    );
     expect(
       await indexer.backfillRows(scopedDb, [row], "case_law_v4", {
         ...rebuildOptions,
       }),
     ).toMatchObject({ indexed: 1 });
-    expect(createHosts).toEqual(["localhost:7291", "localhost:7281"]);
-    expect(ingestHosts).toEqual(["localhost:7291", "localhost:7281"]);
+    expect(createHosts).toEqual(["localhost:7281"]);
+    expect(ingestHosts).toEqual(["localhost:7281"]);
   });
 });
 

--- a/apps/api/src/lib/corpus-index/core.test.ts
+++ b/apps/api/src/lib/corpus-index/core.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import type { Transaction } from "@/api/db/root";
 import type { ScopedDb } from "@/api/db/safe-db";
+import { envBase } from "@/api/env-base";
 import type { SafeId } from "@/api/lib/branded-types";
 import { toSafeId } from "@/api/lib/branded-types";
 import type {
@@ -241,9 +242,13 @@ describe("settleAllCleanup", () => {
 
 describe("idempotent corpus removals", () => {
   const originalFetch = globalThis.fetch;
+  const originalQ09Endpoint = envBase.CORPUS_INDEX_Q09_ENDPOINT;
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    Object.assign(envBase, {
+      CORPUS_INDEX_Q09_ENDPOINT: originalQ09Endpoint,
+    });
   });
 
   test("a missing retired index is recorded as an achieved deletion", async () => {
@@ -290,7 +295,7 @@ describe("idempotent corpus removals", () => {
     const removed = await indexer.remove(
       row.id,
       scopedDb,
-      corpusIndexId("case_law_retired", "CZ"),
+      corpusIndexId("case_law_v4", "CZ"),
     );
 
     expect(removed.isOk()).toBe(true);
@@ -362,6 +367,60 @@ describe("idempotent corpus removals", () => {
     ]);
   });
 
+  test("a final-generation deletion uses the q09 mutation endpoint", async () => {
+    const row = {
+      id: toSafeId<"caseLawDecision">("q09-delete-row"),
+      country: "CZ",
+      textS3Key: null,
+      astS3Key: null,
+      contentHash: null,
+      indexedHash: null,
+      indexedGeneration: null,
+      // SAFETY: the removal path never reads the fabricated timestamp token.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
+    };
+    Object.assign(envBase, {
+      CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
+    });
+    let requestHost = "";
+    globalThis.fetch = Object.assign(
+      async (input: Parameters<typeof fetch>[0]) => {
+        const url = requestUrl(input);
+        requestHost = new URL(url).host;
+        return new Response(JSON.stringify({ opstamp: 7 }), { status: 200 });
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+    const indexer = createCorpusIndexer<"caseLawDecision", typeof row>({
+      family: "case_law",
+      captureStep: "test",
+      granularity: "document",
+      generationProjectionIndexIds: () => [],
+      buildDocs: () => [],
+      readCorpusText: async () => "unused",
+      selectMissing: async () => [],
+      selectStale: async () => [],
+      fetchFulltext: async () => null,
+      markIndexedBatch: async () => new Set(),
+      insertSucceededJobs: async () => undefined,
+      recordJobs: async () => undefined,
+      recordDeleteJobs: async () => undefined,
+    });
+    const scopedDb: ScopedDb = async () => {
+      throw new Error("removal should not open a database transaction");
+    };
+
+    const removed = await indexer.remove(
+      row.id,
+      scopedDb,
+      corpusIndexId("case_law_v5", "CZ"),
+    );
+
+    expect(removed.isOk()).toBe(true);
+    expect(requestHost).toBe("localhost:7291");
+  });
+
   test("a fenced removal records guard failures after the remote effect", async () => {
     const row = {
       id: toSafeId<"caseLawDecision">("expired-removal-lease-row"),
@@ -431,6 +490,119 @@ describe("idempotent corpus removals", () => {
         status: "failed",
       },
     ]);
+  });
+});
+
+describe("generation mutation routing", () => {
+  const originalFetch = globalThis.fetch;
+  const originalQ08Endpoint = envBase.CORPUS_INDEX_ENDPOINT;
+  const originalQ09Endpoint = envBase.CORPUS_INDEX_Q09_ENDPOINT;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.assign(envBase, {
+      CORPUS_INDEX_ENDPOINT: originalQ08Endpoint,
+      CORPUS_INDEX_Q09_ENDPOINT: originalQ09Endpoint,
+    });
+  });
+
+  test("rebuild writes v5 to q09 and a legacy generation to q08", async () => {
+    Object.assign(envBase, {
+      CORPUS_INDEX_ENDPOINT: "http://localhost:7281",
+      CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
+    });
+    const createHosts: string[] = [];
+    const ingestHosts: string[] = [];
+    globalThis.fetch = Object.assign(
+      async (
+        input: Parameters<typeof fetch>[0],
+        init?: Parameters<typeof fetch>[1],
+      ) => {
+        const url = requestUrl(input);
+        const parsed = new URL(url);
+        if (parsed.pathname === "/api/v1/indexes") {
+          createHosts.push(parsed.host);
+        }
+        if (parsed.pathname.includes("/ingest")) {
+          ingestHosts.push(parsed.host);
+          return new Response(JSON.stringify({ num_docs_for_processing: 1 }), {
+            status: 200,
+          });
+        }
+        if ((init?.method ?? "GET") === "GET") {
+          return new Response("missing", { status: 404 });
+        }
+        return new Response("{}", { status: 200 });
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+    const row = {
+      id: toSafeId<"caseLawDecision">("generation-routing-row"),
+      country: "CZ",
+      textS3Key: null,
+      astS3Key: null,
+      contentHash: "hash",
+      indexedHash: null,
+      indexedGeneration: null,
+      // SAFETY: the adapter ignores this fabricated token in the test.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      updatedAtToken: "2026-01-01 00:00:00" as TimestampCasToken,
+    };
+    const scopedDb: ScopedDb = async (callback) =>
+      // SAFETY: this test only observes the external routing and the adapter
+      // callbacks do not inspect the inert transaction.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      await callback({} as Transaction);
+    const indexer = createCorpusIndexer<"caseLawDecision", typeof row>({
+      family: "case_law",
+      captureStep: "test",
+      granularity: "document",
+      generationProjectionIndexIds: () => [],
+      buildDocs: (selected) => [{ document_id: selected.id, text: "body" }],
+      readCorpusText: async () => "body",
+      selectMissing: async () => [],
+      selectStale: async () => [],
+      fetchFulltext: async () => "body",
+      markIndexedBatch: async (_tx, { rows }) =>
+        new Set(rows.map((selected) => selected.id)),
+      insertSucceededJobs: async () => undefined,
+      recordJobs: async () => undefined,
+      recordDeleteJobs: async () => undefined,
+    });
+    const rebuildOptions = {
+      commit: CORPUS_INDEX_COMMIT.auto,
+      beforeDatabaseMark: async () => await Promise.resolve(),
+      beforeRemoteEffect: async <T>({ effect }: FencedRemoteEffect<T>) =>
+        await effect(),
+      recoverRemoteEffectLeaseLoss: async () => await Promise.resolve(),
+      reserveExternalAppend: async (
+        _tx: Transaction,
+        { rows: reservedRows }: { rows: readonly (typeof row)[] },
+      ) =>
+        new Map(
+          reservedRows.map((selected) => [
+            selected.id,
+            {
+              indexIds: [],
+              revision: 1,
+              mayHaveCopy: false,
+            },
+          ]),
+        ),
+    };
+
+    expect(
+      await indexer.backfillRows(scopedDb, [row], "case_law_v5", {
+        ...rebuildOptions,
+      }),
+    ).toMatchObject({ indexed: 1 });
+    expect(
+      await indexer.backfillRows(scopedDb, [row], "case_law_v4", {
+        ...rebuildOptions,
+      }),
+    ).toMatchObject({ indexed: 1 });
+    expect(createHosts).toEqual(["localhost:7291", "localhost:7281"]);
+    expect(ingestHosts).toEqual(["localhost:7291", "localhost:7281"]);
   });
 });
 

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -759,6 +759,17 @@ export const createCorpusIndexer = <
     );
   const clientForIndexId = (indexId: string): CorpusIndexClient =>
     clientForGeneration(corpusIndexGeneration(indexId));
+  const legacyWriterClientForGeneration = (
+    generation: string,
+  ): CorpusIndexClient => {
+    const cluster = corpusIndexClusterForGeneration(adapter.family, generation);
+    if (cluster !== "q08") {
+      return panic(
+        `Legacy ${adapter.family} corpus indexer cannot write final generation ${generation}`,
+      );
+    }
+    return getCorpusIndexClient(cluster);
+  };
 
   // Per-jurisdiction indexes are created on first write. Cache the ids we
   // have confirmed this process so we don't probe corpus index every batch.
@@ -1255,7 +1266,7 @@ export const createCorpusIndexer = <
     options: BackfillSelectedRowsOptions<TBrand, TRow>,
     timing: CorpusBackfillTiming,
   ): Promise<CorpusBackfillOutcome> => {
-    const client = clientForGeneration(generation);
+    const client = legacyWriterClientForGeneration(generation);
     // Load text (S3) with bounded concurrency, then ingest one NDJSON batch.
     // A per-document read failure fails only that document; record it and let
     // the rest still commit.

--- a/apps/api/src/lib/corpus-index/core.ts
+++ b/apps/api/src/lib/corpus-index/core.ts
@@ -7,14 +7,21 @@ import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId, SafeIdType } from "@/api/lib/branded-types";
 import type { TimestampCasToken } from "@/api/lib/db/timestamp-cas";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-family";
+import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import {
   CORPUS_INDEX_COMMIT,
   CorpusIndexError,
   getCorpusIndexClient,
 } from "@/api/lib/legal-search/corpus-index-client";
-import type { CorpusIndexCommitMode } from "@/api/lib/legal-search/corpus-index-client";
+import type {
+  CorpusIndexClient,
+  CorpusIndexCommitMode,
+} from "@/api/lib/legal-search/corpus-index-client";
 import { corpusIndexConfig } from "@/api/lib/legal-search/corpus-index-config";
-import { corpusIndexId } from "@/api/lib/legal-search/index-naming";
+import {
+  corpusIndexGeneration,
+  corpusIndexId,
+} from "@/api/lib/legal-search/index-naming";
 import { LIMITS } from "@/api/lib/limits";
 import { isRecord } from "@/api/lib/type-guards";
 
@@ -483,6 +490,7 @@ type CorpusIndexMarkMode<TBrand extends SafeIdType> =
     };
 
 type IngestBatchWithGuardArgs = {
+  client: CorpusIndexClient;
   commit: CorpusIndexCommitMode;
   indexId: string;
   ndjson: string;
@@ -503,9 +511,9 @@ const ingestBatchWithGuard = async ({
   indexId,
   ndjson,
   onLeaseLost,
+  client,
 }: IngestBatchWithGuardArgs): Promise<Result<void, CorpusIndexError>> => {
-  const effect = async () =>
-    await getCorpusIndexClient().ingestBatch(indexId, ndjson, commit);
+  const effect = async () => await client.ingestBatch(indexId, ndjson, commit);
   if (beforeRemoteEffect === undefined) {
     return await effect();
   }
@@ -745,21 +753,29 @@ export const createCorpusIndexer = <
 >(
   adapter: CorpusIndexAdapter<TBrand, TRow>,
 ) => {
+  const clientForGeneration = (generation: string): CorpusIndexClient =>
+    getCorpusIndexClient(
+      corpusIndexClusterForGeneration(adapter.family, generation),
+    );
+  const clientForIndexId = (indexId: string): CorpusIndexClient =>
+    clientForGeneration(corpusIndexGeneration(indexId));
+
   // Per-jurisdiction indexes are created on first write. Cache the ids we
   // have confirmed this process so we don't probe corpus index every batch.
   const ensuredIndexes = new Set<string>();
 
   const ensureIndex = async ({
     beforeRemoteEffect,
+    client,
     indexId,
   }: {
     beforeRemoteEffect?: GuardRemoteEffect;
+    client: CorpusIndexClient;
     indexId: string;
   }): Promise<Result<void, CorpusIndexError>> => {
     if (ensuredIndexes.has(indexId)) {
       return Result.ok(undefined);
     }
-    const client = getCorpusIndexClient();
     const indexExists = async () => await client.indexExists(indexId);
     const exists = beforeRemoteEffect
       ? await beforeRemoteEffect({
@@ -946,6 +962,7 @@ export const createCorpusIndexer = <
       };
 
   type RemoveTargets = {
+    client: CorpusIndexClient;
     indexId: string;
     operation: "delete" | "redact";
     scopedDb: ScopedDb;
@@ -961,6 +978,7 @@ export const createCorpusIndexer = <
 
   const removeManyWithOptions = async ({
     beforeRemoteEffect,
+    client,
     entityIds,
     indexId,
     onLeaseLost,
@@ -971,7 +989,7 @@ export const createCorpusIndexer = <
       return Result.ok(undefined);
     }
     const deleteByQuery = async () =>
-      await getCorpusIndexClient().deleteByQuery(
+      await client.deleteByQuery(
         indexId,
         corpusDocumentsDeleteQuery(entityIds),
       );
@@ -1023,9 +1041,16 @@ export const createCorpusIndexer = <
     const { entityId, indexId, operation, scopedDb } = args;
     return await removeManyWithOptions(
       args.beforeRemoteEffect === undefined
-        ? { entityIds: [entityId], indexId, operation, scopedDb }
+        ? {
+            client: args.client,
+            entityIds: [entityId],
+            indexId,
+            operation,
+            scopedDb,
+          }
         : {
             beforeRemoteEffect: args.beforeRemoteEffect,
+            client: args.client,
             entityIds: [entityId],
             indexId,
             onLeaseLost: args.onLeaseLost,
@@ -1041,7 +1066,44 @@ export const createCorpusIndexer = <
     indexId: string,
     operation: "delete" | "redact" = "delete",
   ): Promise<Result<void, CorpusIndexError>> =>
-    await removeWithOptions({ entityId, scopedDb, indexId, operation });
+    await removeWithOptions({
+      client: clientForIndexId(indexId),
+      entityId,
+      indexId,
+      operation,
+      scopedDb,
+    });
+
+  type PublicRemoveWithOptionsArgs = {
+    indexId: string;
+    operation: "delete" | "redact";
+    scopedDb: ScopedDb;
+    entityId: SafeId<TBrand>;
+  } & RemoteEffectGuard;
+
+  const removeFenced = async (
+    args: PublicRemoveWithOptionsArgs,
+  ): Promise<Result<void, CorpusIndexError>> => {
+    const client = clientForIndexId(args.indexId);
+    if (args.beforeRemoteEffect === undefined) {
+      return await removeWithOptions({
+        client,
+        entityId: args.entityId,
+        indexId: args.indexId,
+        operation: args.operation,
+        scopedDb: args.scopedDb,
+      });
+    }
+    return await removeWithOptions({
+      beforeRemoteEffect: args.beforeRemoteEffect,
+      client,
+      entityId: args.entityId,
+      indexId: args.indexId,
+      onLeaseLost: args.onLeaseLost,
+      operation: args.operation,
+      scopedDb: args.scopedDb,
+    });
+  };
 
   /**
    * Index a batch of corpus-backed rows into the given generation. Two-query
@@ -1193,6 +1255,7 @@ export const createCorpusIndexer = <
     options: BackfillSelectedRowsOptions<TBrand, TRow>,
     timing: CorpusBackfillTiming,
   ): Promise<CorpusBackfillOutcome> => {
+    const client = clientForGeneration(generation);
     // Load text (S3) with bounded concurrency, then ingest one NDJSON batch.
     // A per-document read failure fails only that document; record it and let
     // the rest still commit.
@@ -1270,6 +1333,7 @@ export const createCorpusIndexer = <
         ...(options.type === "incremental"
           ? {}
           : { beforeRemoteEffect: options.beforeRemoteEffect }),
+        client,
         indexId,
       });
       timing.reserveMs += elapsedSince(reserveStartedAt);
@@ -1386,6 +1450,7 @@ export const createCorpusIndexer = <
                       indexId: unit.indexId,
                     }),
                 }),
+            client,
             entityIds: unit.entityIds,
             indexId: unit.indexId,
             operation: "delete",
@@ -1434,6 +1499,7 @@ export const createCorpusIndexer = <
                       indexId,
                     }),
                 }),
+            client,
             indexId,
             ndjson,
           });
@@ -1526,6 +1592,7 @@ export const createCorpusIndexer = <
                         indexId,
                       }),
                   }),
+              client,
               entityId: missedId,
               indexId,
               operation: "delete",
@@ -1585,6 +1652,6 @@ export const createCorpusIndexer = <
     backfillFenced,
     backfillRows,
     remove,
-    removeFenced: removeWithOptions,
+    removeFenced,
   };
 };

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
@@ -12,6 +12,7 @@ import {
   QUICKWIT_CLUSTERS,
   requireQuickwitCluster,
 } from "@/api/lib/legal-search/corpus-generation-contract";
+import { CORPUS_INDEX_MANIFESTS } from "@/api/lib/legal-search/corpus-index-manifest";
 
 test("closed corpus and cluster values parse without a fallback", () => {
   for (const family of CORPUS_FAMILIES) {
@@ -64,4 +65,12 @@ test("every deployable generation selects one explicit Quickwit cluster", () => 
   expect(() =>
     corpusIndexClusterForGeneration("case_law", "case_law_v6"),
   ).toThrow("Unknown case_law corpus index generation");
+});
+
+test("every final manifest generation selects its declared cluster", () => {
+  for (const manifest of Object.values(CORPUS_INDEX_MANIFESTS)) {
+    expect(
+      corpusIndexClusterForGeneration(manifest.family, manifest.generation),
+    ).toBe(manifest.cluster);
+  }
 });

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.test.ts
@@ -4,6 +4,7 @@ import {
   CORPUS_FAMILIES,
   CORPUS_INDEX_GENERATION_MAX_LENGTH,
   CORPUS_INDEX_GENERATION_STATUSES,
+  corpusIndexClusterForGeneration,
   isCorpusGeneration,
   parseCorpusFamily,
   parseCorpusIndexGenerationStatus,
@@ -45,4 +46,22 @@ test("generation names belong to exactly their declared family", () => {
       `case_law_v${"1".repeat(CORPUS_INDEX_GENERATION_MAX_LENGTH)}`,
     ),
   ).toBe(false);
+});
+
+test("every deployable generation selects one explicit Quickwit cluster", () => {
+  expect(corpusIndexClusterForGeneration("case_law", "case_law_v2")).toBe(
+    "q08",
+  );
+  expect(corpusIndexClusterForGeneration("case_law", "case_law_v5")).toBe(
+    "q09",
+  );
+  expect(corpusIndexClusterForGeneration("legislation", "legislation_v1")).toBe(
+    "q08",
+  );
+  expect(corpusIndexClusterForGeneration("legislation", "legislation_v2")).toBe(
+    "q09",
+  );
+  expect(() =>
+    corpusIndexClusterForGeneration("case_law", "case_law_v6"),
+  ).toThrow("Unknown case_law corpus index generation");
 });

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.ts
@@ -1,5 +1,7 @@
 import { panic } from "better-result";
 
+import type { CorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
+
 /** Document families sharing the corpus storage and search substrate. */
 export const CORPUS_FAMILIES = ["case_law", "legislation"] as const;
 export type CorpusFamily = (typeof CORPUS_FAMILIES)[number];
@@ -35,10 +37,41 @@ const LEGACY_Q08_GENERATIONS = {
   legislation: ["legislation_v1"],
 } as const satisfies Record<CorpusFamily, readonly string[]>;
 
+type FinalManifestGenerationByFamily = {
+  [Family in CorpusFamily]: Extract<
+    CorpusIndexManifest,
+    { family: Family; cluster: "q09" }
+  >["generation"];
+};
+
 const FINAL_Q09_GENERATIONS = {
   case_law: ["case_law_v5"],
   legislation: ["legislation_v2"],
-} as const satisfies Record<CorpusFamily, readonly string[]>;
+} as const satisfies {
+  [Family in CorpusFamily]: readonly FinalManifestGenerationByFamily[Family][];
+};
+
+type DeclaredFinalManifestGeneration =
+  (typeof FINAL_Q09_GENERATIONS)[CorpusFamily][number];
+type MissingFinalManifestGeneration = Exclude<
+  CorpusIndexManifest["generation"],
+  DeclaredFinalManifestGeneration
+>;
+type UnexpectedFinalManifestGeneration = Exclude<
+  DeclaredFinalManifestGeneration,
+  CorpusIndexManifest["generation"]
+>;
+
+/**
+ * Keep the explicit legacy boundary below, but make every final manifest
+ * generation require a corresponding cluster declaration here. The manifest
+ * contract currently restricts final generations to q09.
+ */
+true satisfies MissingFinalManifestGeneration extends never
+  ? UnexpectedFinalManifestGeneration extends never
+    ? true
+    : never
+  : never;
 
 export const parseCorpusIndexClusterForGeneration = (
   family: CorpusFamily,

--- a/apps/api/src/lib/legal-search/corpus-generation-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-generation-contract.ts
@@ -30,6 +30,36 @@ export const parseCorpusFamily = (value: unknown): CorpusFamily | null =>
 export const parseQuickwitCluster = (value: unknown): QuickwitCluster | null =>
   memberOf(QUICKWIT_CLUSTERS, value);
 
+const LEGACY_Q08_GENERATIONS = {
+  case_law: ["case_law_v1", "case_law_v2", "case_law_v3", "case_law_v4"],
+  legislation: ["legislation_v1"],
+} as const satisfies Record<CorpusFamily, readonly string[]>;
+
+const FINAL_Q09_GENERATIONS = {
+  case_law: ["case_law_v5"],
+  legislation: ["legislation_v2"],
+} as const satisfies Record<CorpusFamily, readonly string[]>;
+
+export const parseCorpusIndexClusterForGeneration = (
+  family: CorpusFamily,
+  generation: string,
+): QuickwitCluster | null => {
+  if (FINAL_Q09_GENERATIONS[family].some((value) => value === generation)) {
+    return "q09";
+  }
+  if (LEGACY_Q08_GENERATIONS[family].some((value) => value === generation)) {
+    return "q08";
+  }
+  return null;
+};
+
+export const corpusIndexClusterForGeneration = (
+  family: CorpusFamily,
+  generation: string,
+): QuickwitCluster =>
+  parseCorpusIndexClusterForGeneration(family, generation) ??
+  panic(`Unknown ${family} corpus index generation: ${generation}`);
+
 export const requireQuickwitCluster = (value: unknown): QuickwitCluster =>
   parseQuickwitCluster(value) ??
   panic(`Unknown Quickwit cluster reference: ${String(value)}`);

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -270,6 +270,7 @@ test("search pagination always requests BM25 relevance order", async () => {
   };
 
   await readCorpusIndexSearchPage({
+    cluster: "q08",
     indexId: "legal_corpus_v1_cze",
     query: "text:smlouva",
     limit: 10,

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -149,7 +149,7 @@ test("q09 mutations cannot leak onto its read endpoint", async () => {
 test("search sends the documented sort_by parameter", async () => {
   responseBody = { num_hits: 0, hits: [], snippets: [] };
 
-  const result = await getCorpusIndexClient().search({
+  const result = await getCorpusIndexClient("q08").search({
     indexId: "legal_corpus_v1_cze",
     query: "text:smlouva",
     maxHits: 10,
@@ -177,7 +177,7 @@ test("search accepts a response without snippets", async () => {
     errors: [],
   };
 
-  const result = await getCorpusIndexClient().search({
+  const result = await getCorpusIndexClient("q08").search({
     indexId: "legal_corpus_v1_cze",
     query: "seq:0",
     maxHits: 0,
@@ -193,7 +193,7 @@ test("search accepts a response without snippets", async () => {
 test("search rejects a response without snippets when snippet fields were requested", async () => {
   responseBody = { num_hits: 1, hits: [{ id: "a" }] };
 
-  const result = await getCorpusIndexClient().search({
+  const result = await getCorpusIndexClient("q08").search({
     indexId: "legal_corpus_v1_cze",
     query: "text:smlouva",
     maxHits: 10,
@@ -206,7 +206,7 @@ test("search rejects a response without snippets when snippet fields were reques
 test("search rejects a malformed snippets value", async () => {
   responseBody = { num_hits: 1, hits: [], snippets: "no" };
 
-  const result = await getCorpusIndexClient().search({
+  const result = await getCorpusIndexClient("q08").search({
     indexId: "legal_corpus_v1_cze",
     query: "seq:0",
     maxHits: 0,
@@ -222,7 +222,7 @@ test("search falls back to the shared corpus index endpoint", async () => {
     CORPUS_INDEX_SEARCH_ENDPOINT: undefined,
   });
 
-  const result = await getCorpusIndexClient().search({
+  const result = await getCorpusIndexClient("q08").search({
     indexId: "legal_corpus_v1_cze",
     query: "text:smlouva",
     maxHits: 10,
@@ -235,7 +235,7 @@ test("search falls back to the shared corpus index endpoint", async () => {
 test("search rejects a malformed external response", async () => {
   responseBody = [];
 
-  const result = await getCorpusIndexClient().search({
+  const result = await getCorpusIndexClient("q08").search({
     indexId: "legal_corpus_v1_cze",
     query: "text:smlouva",
     maxHits: 10,
@@ -250,7 +250,7 @@ test("search rejects a malformed external response", async () => {
 test("search rejects a malformed object response", async () => {
   responseBody = { error: "index unavailable" };
 
-  const result = await getCorpusIndexClient().search({
+  const result = await getCorpusIndexClient("q08").search({
     indexId: "legal_corpus_v1_cze",
     query: "text:smlouva",
     maxHits: 10,
@@ -301,7 +301,7 @@ test("search pagination always requests BM25 relevance order", async () => {
 test("ingest fails when the engine accepts fewer documents than sent", async () => {
   responseBody = { num_docs_for_processing: 1 };
 
-  const result = await getCorpusIndexClient().ingestBatch(
+  const result = await getCorpusIndexClient("q08").ingestBatch(
     "legal_corpus_v1_cze",
     '{"document_id":"a"}\n{"document_id":"b"}',
     CORPUS_INDEX_COMMIT.waitFor,
@@ -316,7 +316,7 @@ test("ingest fails when the engine accepts fewer documents than sent", async () 
 test("ingest fails when the engine reports rejected documents", async () => {
   responseBody = { num_docs_for_processing: 2, num_rejected_docs: 1 };
 
-  const result = await getCorpusIndexClient().ingestBatch(
+  const result = await getCorpusIndexClient("q08").ingestBatch(
     "legal_corpus_v1_cze",
     '{"document_id":"a"}\n{"document_id":"b"}',
     CORPUS_INDEX_COMMIT.waitFor,
@@ -331,7 +331,7 @@ test("ingest fails when the engine reports rejected documents", async () => {
 test("delete-by-query posts one document-scoped delete task", async () => {
   responseBody = { opstamp: 42 };
 
-  const result = await getCorpusIndexClient().deleteByQuery(
+  const result = await getCorpusIndexClient("q08").deleteByQuery(
     "legal_corpus_v1_cze",
     'document_id:"dec-1"',
   );
@@ -354,7 +354,7 @@ test("delete-by-query posts one document-scoped delete task", async () => {
 test("delete-by-query rejects a response without a usable opstamp", async () => {
   responseBody = {};
 
-  const result = await getCorpusIndexClient().deleteByQuery(
+  const result = await getCorpusIndexClient("q08").deleteByQuery(
     "legal_corpus_v1_cze",
     'document_id:"dec-1"',
   );
@@ -388,7 +388,7 @@ test("delete settlement compares every published split with the retained task", 
     ],
   };
 
-  const result = await getCorpusIndexClient().readDeleteSettlement(
+  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
     "legal_corpus_v1_cze",
     42,
   );
@@ -412,7 +412,7 @@ test("delete settlement compares every published split with the retained task", 
 });
 
 test("delete settlement rejects an invalid required opstamp", async () => {
-  const result = await getCorpusIndexClient().readDeleteSettlement(
+  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
     "legal_corpus_v1_cze",
     -1,
   );
@@ -428,7 +428,7 @@ test("delete settlement rejects a split without a usable delete opstamp", async 
     splits: [{ split_id: "split-1", split_state: "Published" }],
   };
 
-  const result = await getCorpusIndexClient().readDeleteSettlement(
+  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
     "legal_corpus_v1_cze",
     42,
   );
@@ -469,7 +469,7 @@ test("delete settlement repeats an offset scan until split identities stabilize"
     return { splits: [] };
   };
 
-  const result = await getCorpusIndexClient().readDeleteSettlement(
+  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
     "legal_corpus_v1_cze",
     42,
   );
@@ -484,7 +484,7 @@ test("delete settlement repeats an offset scan until split identities stabilize"
 test("delete settlement accepts exactly the published split ceiling", async () => {
   responseBodyForUrl = settlementResponse(10_000);
 
-  const result = await getCorpusIndexClient().readDeleteSettlement(
+  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
     "legal_corpus_v1_cze",
     42,
   );
@@ -499,7 +499,7 @@ test("delete settlement accepts exactly the published split ceiling", async () =
 test("delete settlement rejects the first split beyond its ceiling", async () => {
   responseBodyForUrl = settlementResponse(10_001);
 
-  const result = await getCorpusIndexClient().readDeleteSettlement(
+  const result = await getCorpusIndexClient("q08").readDeleteSettlement(
     "legal_corpus_v1_cze",
     42,
   );
@@ -515,7 +515,7 @@ test("ingest sends the commit mode the caller asked for", async () => {
 
   for (const commit of Object.values(CORPUS_INDEX_COMMIT)) {
     // oxlint-disable-next-line no-await-in-loop -- one request per mode; the recorder is order-sensitive
-    await getCorpusIndexClient().ingestBatch(
+    await getCorpusIndexClient("q08").ingestBatch(
       "legal_corpus_v1_cze",
       '{"document_id":"a"}',
       commit,
@@ -545,7 +545,7 @@ test("the ingest budget outlasts the engine's commit wait", () => {
 test("ingest succeeds when every document is accepted", async () => {
   responseBody = { num_docs_for_processing: 2 };
 
-  const result = await getCorpusIndexClient().ingestBatch(
+  const result = await getCorpusIndexClient("q08").ingestBatch(
     "legal_corpus_v1_cze",
     '{"document_id":"a"}\n{"document_id":"b"}',
     CORPUS_INDEX_COMMIT.waitFor,
@@ -561,7 +561,7 @@ test("final-generation ingest requires the exact committed V2 receipt", async ()
     num_rejected_docs: 0,
   };
 
-  const result = await getCorpusIndexClient().ingestCommittedBatch(
+  const result = await getCorpusIndexClient("q08").ingestCommittedBatch(
     "case_law_v5_cs_sk",
     '{"document_id":"a"}\n{"document_id":"b"}',
   );
@@ -586,7 +586,7 @@ test("final-generation ingest rejects missing or partial V2 counters", async () 
   ]) {
     responseBody = receipt;
     // oxlint-disable-next-line no-await-in-loop -- each malformed receipt is observed independently by the request recorder
-    const result = await getCorpusIndexClient().ingestCommittedBatch(
+    const result = await getCorpusIndexClient("q08").ingestCommittedBatch(
       "case_law_v5_cs_sk",
       '{"document_id":"a"}\n{"document_id":"b"}',
     );
@@ -610,7 +610,7 @@ const rejectFetchWith = (reason: unknown): void => {
 test("ingest names the request and its budget when the transport fails", async () => {
   rejectFetchWith(new DOMException("The operation timed out.", "TimeoutError"));
 
-  const result = await getCorpusIndexClient().ingestBatch(
+  const result = await getCorpusIndexClient("q08").ingestBatch(
     "legal_corpus_v1_cze",
     '{"document_id":"a"}',
     CORPUS_INDEX_COMMIT.waitFor,
@@ -627,7 +627,7 @@ test("ingest names the request and its budget when the transport fails", async (
 test("each request reports its own budget, not a shared one", async () => {
   rejectFetchWith(new DOMException("The operation timed out.", "TimeoutError"));
 
-  const result = await getCorpusIndexClient().search({
+  const result = await getCorpusIndexClient("q08").search({
     indexId: "legal_corpus_v1_cze",
     query: "text:smlouva",
     maxHits: 10,
@@ -650,7 +650,7 @@ test("an unreadable success body names the request too", async () => {
     preconnect: originalFetch.preconnect,
   });
 
-  const result = await getCorpusIndexClient().search({
+  const result = await getCorpusIndexClient("q08").search({
     indexId: "legal_corpus_v1_cze",
     query: "text:smlouva",
     maxHits: 10,
@@ -683,7 +683,7 @@ test("a body that stalls past the budget is a timeout, not an unreadable body", 
     preconnect: originalFetch.preconnect,
   });
 
-  const result = await getCorpusIndexClient().search({
+  const result = await getCorpusIndexClient("q08").search({
     indexId: "legal_corpus_v1_cze",
     query: "text:smlouva",
     maxHits: 10,
@@ -702,7 +702,7 @@ test("a request that never reaches the engine is not reported as a timeout", asy
     new Error("Unable to connect. Is the computer able to access the url?"),
   );
 
-  const result = await getCorpusIndexClient().search({
+  const result = await getCorpusIndexClient("q08").search({
     indexId: "legal_corpus_v1_cze",
     query: "text:smlouva",
     maxHits: 10,

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 
 import { envBase } from "@/api/env-base";
 import {
+  CORPUS_INDEX_CLUSTER_CONFIG,
   CORPUS_INDEX_COMMIT,
   CORPUS_INDEX_COMMIT_WAIT_TIMEOUT_MS,
   CORPUS_INDEX_INGEST_TIMEOUT_MS,
@@ -29,6 +30,8 @@ let responseBodyForUrl: ((url: URL) => unknown) | null;
 const originalFetch = globalThis.fetch;
 const originalCorpusIndexEndpoint = envBase.CORPUS_INDEX_ENDPOINT;
 const originalCorpusIndexSearchEndpoint = envBase.CORPUS_INDEX_SEARCH_ENDPOINT;
+const originalQ09Endpoint = envBase.CORPUS_INDEX_Q09_ENDPOINT;
+const originalQ09SearchEndpoint = envBase.CORPUS_INDEX_Q09_SEARCH_ENDPOINT;
 
 beforeEach(() => {
   requests = [];
@@ -68,7 +71,79 @@ afterEach(() => {
   Object.assign(envBase, {
     CORPUS_INDEX_ENDPOINT: originalCorpusIndexEndpoint,
     CORPUS_INDEX_SEARCH_ENDPOINT: originalCorpusIndexSearchEndpoint,
+    CORPUS_INDEX_Q09_ENDPOINT: originalQ09Endpoint,
+    CORPUS_INDEX_Q09_SEARCH_ENDPOINT: originalQ09SearchEndpoint,
   });
+});
+
+test("cluster registry is total and q09 never falls back to q08", async () => {
+  expect(CORPUS_INDEX_CLUSTER_CONFIG).toEqual({
+    q08: {
+      mutationEnv: "CORPUS_INDEX_ENDPOINT",
+      searchEnv: "CORPUS_INDEX_SEARCH_ENDPOINT",
+    },
+    q09: {
+      mutationEnv: "CORPUS_INDEX_Q09_ENDPOINT",
+      searchEnv: "CORPUS_INDEX_Q09_SEARCH_ENDPOINT",
+    },
+  });
+  Object.assign(envBase, {
+    CORPUS_INDEX_ENDPOINT: "http://localhost:7281",
+    CORPUS_INDEX_SEARCH_ENDPOINT: "http://localhost:7282",
+    CORPUS_INDEX_Q09_ENDPOINT: undefined,
+    CORPUS_INDEX_Q09_SEARCH_ENDPOINT: undefined,
+  });
+
+  const result = await getCorpusIndexClient("q09").search({
+    indexId: "case_law_v5_cs_sk",
+    query: "text:smlouva",
+    maxHits: 10,
+  });
+
+  expect(result.isErr()).toBe(true);
+  expect(requests).toEqual([]);
+  if (result.isErr()) {
+    expect(result.error.message).toContain("CORPUS_INDEX_Q09_SEARCH_ENDPOINT");
+  }
+});
+
+test("q09 uses only its registered endpoint pair", async () => {
+  responseBody = { num_hits: 0, hits: [], snippets: [] };
+  Object.assign(envBase, {
+    CORPUS_INDEX_ENDPOINT: "http://localhost:7281",
+    CORPUS_INDEX_SEARCH_ENDPOINT: "http://localhost:7282",
+    CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
+    CORPUS_INDEX_Q09_SEARCH_ENDPOINT: "http://localhost:7292",
+  });
+
+  const result = await getCorpusIndexClient("q09").search({
+    indexId: "case_law_v5_cs_sk",
+    query: "text:smlouva",
+    maxHits: 10,
+  });
+
+  expect(result.isOk()).toBe(true);
+  expect(requests.at(0)?.host).toBe("localhost:7292");
+});
+
+test("q09 mutations cannot leak onto its read endpoint", async () => {
+  responseBody = {
+    num_docs_for_processing: 1,
+    num_ingested_docs: 1,
+    num_rejected_docs: 0,
+  };
+  Object.assign(envBase, {
+    CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
+    CORPUS_INDEX_Q09_SEARCH_ENDPOINT: "http://localhost:7292",
+  });
+
+  const result = await getCorpusIndexClient("q09").ingestCommittedBatch(
+    "case_law_v5_cs_sk",
+    '{"document_id":"a"}',
+  );
+
+  expect(result.isOk()).toBe(true);
+  expect(requests.at(0)?.host).toBe("localhost:7291");
 });
 
 test("search sends the documented sort_by parameter", async () => {

--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -126,6 +126,23 @@ test("q09 uses only its registered endpoint pair", async () => {
   expect(requests.at(0)?.host).toBe("localhost:7292");
 });
 
+test("q09 search falls back to its mutation endpoint", async () => {
+  responseBody = { num_hits: 0, hits: [], snippets: [] };
+  Object.assign(envBase, {
+    CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
+    CORPUS_INDEX_Q09_SEARCH_ENDPOINT: undefined,
+  });
+
+  const result = await getCorpusIndexClient("q09").search({
+    indexId: "case_law_v5_cs_sk",
+    query: "text:smlouva",
+    maxHits: 10,
+  });
+
+  expect(result.isOk()).toBe(true);
+  expect(requests.at(0)?.host).toBe("localhost:7291");
+});
+
 test("q09 mutations cannot leak onto its read endpoint", async () => {
   responseBody = {
     num_docs_for_processing: 1,

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -715,13 +715,8 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
 
 const cachedClients = new Map<QuickwitCluster, CorpusIndexClient>();
 
-/**
- * The default is the concrete compatibility boundary for the still-serving
- * v2/legislation-v1 cluster. Final generations always pass their registered
- * cluster explicitly; remove the default when q08 has no serving generation.
- */
 export const getCorpusIndexClient = (
-  cluster: QuickwitCluster = "q08",
+  cluster: QuickwitCluster,
 ): CorpusIndexClient => {
   const cached = cachedClients.get(cluster);
   if (cached !== undefined) {

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -2,6 +2,7 @@ import { panic, Result, TaggedError } from "better-result";
 
 import { envBase } from "@/api/env-base";
 import { fetchWithTimeout } from "@/api/lib/fetch";
+import type { QuickwitCluster } from "@/api/lib/legal-search/corpus-generation-contract";
 import {
   CORPUS_INDEX_COMMIT_TIMEOUT_SECS,
   type CorpusIndexConfig,
@@ -170,21 +171,42 @@ export type CorpusIndexClient = {
   ) => Promise<Result<CorpusIndexDeleteSettlement, CorpusIndexError>>;
 };
 
-const mutationBaseUrl = (): string => {
-  const value = envBase.CORPUS_INDEX_ENDPOINT;
+type CorpusIndexEndpointEnv =
+  | "CORPUS_INDEX_ENDPOINT"
+  | "CORPUS_INDEX_SEARCH_ENDPOINT"
+  | "CORPUS_INDEX_Q09_ENDPOINT"
+  | "CORPUS_INDEX_Q09_SEARCH_ENDPOINT";
+
+type CorpusIndexClusterConfig = {
+  mutationEnv: CorpusIndexEndpointEnv;
+  searchEnv: CorpusIndexEndpointEnv;
+};
+
+export const CORPUS_INDEX_CLUSTER_CONFIG = {
+  q08: {
+    mutationEnv: "CORPUS_INDEX_ENDPOINT",
+    searchEnv: "CORPUS_INDEX_SEARCH_ENDPOINT",
+  },
+  q09: {
+    mutationEnv: "CORPUS_INDEX_Q09_ENDPOINT",
+    searchEnv: "CORPUS_INDEX_Q09_SEARCH_ENDPOINT",
+  },
+} as const satisfies Record<QuickwitCluster, CorpusIndexClusterConfig>;
+
+const mutationBaseUrl = (cluster: QuickwitCluster): string => {
+  const { mutationEnv } = CORPUS_INDEX_CLUSTER_CONFIG[cluster];
+  const value = envBase[mutationEnv];
   if (value === undefined || value.length === 0) {
-    panic("CORPUS_INDEX_ENDPOINT is required for corpus index mutations");
+    panic(`${mutationEnv} is required for ${cluster} corpus index mutations`);
   }
   return value.replace(/(?<!\/)\/+$/u, "");
 };
 
-const searchBaseUrl = (): string => {
-  const value =
-    envBase.CORPUS_INDEX_SEARCH_ENDPOINT ?? envBase.CORPUS_INDEX_ENDPOINT;
+const searchBaseUrl = (cluster: QuickwitCluster): string => {
+  const { mutationEnv, searchEnv } = CORPUS_INDEX_CLUSTER_CONFIG[cluster];
+  const value = envBase[searchEnv] ?? envBase[mutationEnv];
   if (value === undefined || value.length === 0) {
-    panic(
-      "CORPUS_INDEX_SEARCH_ENDPOINT or CORPUS_INDEX_ENDPOINT is required when the corpus index search provider is selected",
-    );
+    panic(`${searchEnv} or ${mutationEnv} is required for ${cluster} search`);
   }
   return value.replace(/(?<!\/)\/+$/u, "");
 };
@@ -292,6 +314,7 @@ const parseRecordArray = (value: unknown): Record<string, unknown>[] | null => {
 type IngestReceiptMode = "compatible" | "exact-v2";
 
 type IngestBatchOptions = {
+  baseUrl: string;
   indexId: string;
   ndjson: string;
   commit: CorpusIndexCommitMode;
@@ -299,6 +322,7 @@ type IngestBatchOptions = {
 };
 
 const ingestBatch = async ({
+  baseUrl,
   indexId,
   ndjson,
   commit,
@@ -310,7 +334,7 @@ const ingestBatch = async ({
         .split("\n")
         .filter((line) => line.trim().length > 0).length;
       const response = await requestJson({
-        baseUrl: mutationBaseUrl(),
+        baseUrl,
         path: `/api/v1/${indexId}/ingest?commit=${commit}`,
         init: {
           method: "POST",
@@ -364,12 +388,12 @@ const ingestBatch = async ({
     catch: toCorpusIndexError,
   });
 
-const buildClient = (): CorpusIndexClient => ({
+const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
   createIndex: async (config) =>
     await Result.tryPromise({
       try: async () => {
         await requestJson({
-          baseUrl: mutationBaseUrl(),
+          baseUrl: mutationBaseUrl(cluster),
           path: "/api/v1/indexes",
           init: {
             method: "POST",
@@ -386,7 +410,7 @@ const buildClient = (): CorpusIndexClient => ({
     await Result.tryPromise({
       try: async () => {
         await requestJson({
-          baseUrl: mutationBaseUrl(),
+          baseUrl: mutationBaseUrl(cluster),
           path: `/api/v1/indexes/${indexId}`,
           init: { method: "DELETE" },
           timeoutMs: ADMIN_TIMEOUT_MS,
@@ -399,7 +423,7 @@ const buildClient = (): CorpusIndexClient => ({
     await Result.tryPromise({
       try: async () => {
         const response = await sendRequest({
-          baseUrl: mutationBaseUrl(),
+          baseUrl: mutationBaseUrl(cluster),
           path: `/api/v1/indexes/${indexId}`,
           init: { method: "GET" },
           timeoutMs: ADMIN_TIMEOUT_MS,
@@ -420,6 +444,7 @@ const buildClient = (): CorpusIndexClient => ({
 
   ingestBatch: async (indexId, ndjson, commit) =>
     await ingestBatch({
+      baseUrl: mutationBaseUrl(cluster),
       indexId,
       ndjson,
       commit,
@@ -428,6 +453,7 @@ const buildClient = (): CorpusIndexClient => ({
 
   ingestCommittedBatch: async (indexId, ndjson) =>
     await ingestBatch({
+      baseUrl: mutationBaseUrl(cluster),
       indexId,
       ndjson,
       commit: CORPUS_INDEX_COMMIT.waitFor,
@@ -458,7 +484,7 @@ const buildClient = (): CorpusIndexClient => ({
           body["snippet_fields"] = snippetFields.join(",");
         }
         const response = await requestJson({
-          baseUrl: searchBaseUrl(),
+          baseUrl: searchBaseUrl(cluster),
           path: `/api/v1/${indexId}/search`,
           init: {
             method: "POST",
@@ -507,7 +533,7 @@ const buildClient = (): CorpusIndexClient => ({
     await Result.tryPromise({
       try: async () => {
         const response = await requestJson({
-          baseUrl: searchBaseUrl(),
+          baseUrl: searchBaseUrl(cluster),
           path: `/api/v1/${indexId}/search`,
           init: {
             method: "POST",
@@ -532,7 +558,7 @@ const buildClient = (): CorpusIndexClient => ({
     await Result.tryPromise({
       try: async () => {
         const response = await requestJson({
-          baseUrl: mutationBaseUrl(),
+          baseUrl: mutationBaseUrl(cluster),
           path: `/api/v1/${indexId}/delete-tasks`,
           init: {
             method: "POST",
@@ -590,7 +616,7 @@ const buildClient = (): CorpusIndexClient => ({
           const currentSplitIds = new Set<string>();
           const readSplitPage = async (): Promise<void> => {
             const response = await requestJson({
-              baseUrl: mutationBaseUrl(),
+              baseUrl: mutationBaseUrl(cluster),
               path: `/api/v1/indexes/${indexId}/splits?offset=${offset}&limit=${SPLIT_PAGE_SIZE}&split_states=Published`,
               init: { method: "GET" },
               timeoutMs: remainingBudget(),
@@ -687,9 +713,21 @@ const buildClient = (): CorpusIndexClient => ({
     }),
 });
 
-let cached: CorpusIndexClient | null = null;
+const cachedClients = new Map<QuickwitCluster, CorpusIndexClient>();
 
-export const getCorpusIndexClient = (): CorpusIndexClient => {
-  cached ??= buildClient();
-  return cached;
+/**
+ * The default is the concrete compatibility boundary for the still-serving
+ * v2/legislation-v1 cluster. Final generations always pass their registered
+ * cluster explicitly; remove the default when q08 has no serving generation.
+ */
+export const getCorpusIndexClient = (
+  cluster: QuickwitCluster = "q08",
+): CorpusIndexClient => {
+  const cached = cachedClients.get(cluster);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const client = buildClient(cluster);
+  cachedClients.set(cluster, client);
+  return client;
 };

--- a/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
@@ -2,6 +2,7 @@ import { Result } from "better-result";
 import { afterEach, beforeEach, expect, spyOn, test } from "bun:test";
 import * as v from "valibot";
 
+import { envBase } from "@/api/env-base";
 import * as corpusFamily from "@/api/lib/legal-search/corpus-family";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import {
@@ -104,6 +105,29 @@ test("aggregates over opening passages only, so buckets count decisions", async 
   // an unrestricted aggregation would count a long judgment once per passage.
   expect(requests.at(0)?.body["query"]).toBe("seq:0");
   expect(requests.at(0)?.body["max_hits"]).toBe(0);
+});
+
+test("v5 facets use only manifest-owned fields", async () => {
+  responseBody = engineResponse();
+  const generation = spyOn(corpusFamily, "corpusGeneration").mockReturnValue(
+    "case_law_v5",
+  );
+  const originalEndpoint = envBase.CORPUS_INDEX_Q09_ENDPOINT;
+  Object.assign(envBase, {
+    CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
+  });
+  try {
+    await corpusIndexBrowseFacets({ excludedSourceIds: [], limit: 20 });
+  } finally {
+    generation.mockRestore();
+    Object.assign(envBase, { CORPUS_INDEX_Q09_ENDPOINT: originalEndpoint });
+  }
+
+  expect(requests.at(0)?.url).toContain("/case_law_v5_*/search");
+  expect(requests.at(0)?.body["query"]).toBe("is_opening:true");
+  expect(requestedAggregations()["year"]).toMatchObject({
+    terms: { field: "decision_year" },
+  });
 });
 
 test("requests exactly the aggregations the response is read from", async () => {

--- a/apps/api/src/lib/legal-search/corpus-index-facets.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.ts
@@ -4,6 +4,7 @@ import { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
+import { corpusIndexReadContract } from "@/api/lib/legal-search/corpus-index-read-contract";
 import { quoteCorpusValue } from "@/api/lib/legal-search/corpus-query";
 import { corpusIndexRoute } from "@/api/lib/legal-search/index-naming";
 import type {
@@ -21,9 +22,10 @@ import { isRecord } from "@/api/lib/type-guards";
  *
  * The index is passage-granular: every passage carries its decision's shared
  * fields, so an unrestricted terms aggregation counts passages, not decisions.
- * `seq:0` restricts it to each decision's opening passage — `chunkDocument`
- * numbers passages from zero and always emits at least one, so exactly one
- * document per decision matches — and every bucket then counts decisions.
+ * The serving generation's opening-passage predicate restricts it to exactly
+ * one document per decision, so every bucket counts decisions rather than
+ * passages. The predicate is generation-owned because final manifests do not
+ * retain legacy sequence fields.
  *
  * Projection is only the first half of the redistribution gate: it keeps
  * ineligible sources out of the index, but revoking a source's redistribution
@@ -39,12 +41,11 @@ import { isRecord } from "@/api/lib/type-guards";
  * is the set these filters exist to narrow.
  */
 
-const OPENING_PASSAGE_QUERY = "seq:0";
-
 type BrowseFacetsQueryOptions = {
   excludedSourceIds: readonly string[];
   /** Set when the selected index holds other jurisdictions too. */
   jurisdictionClause: string | undefined;
+  openingPassageQuery: string;
 };
 
 /**
@@ -57,8 +58,9 @@ type BrowseFacetsQueryOptions = {
 const browseFacetsQuery = ({
   excludedSourceIds,
   jurisdictionClause,
+  openingPassageQuery,
 }: BrowseFacetsQueryOptions): string => {
-  const clauses = [OPENING_PASSAGE_QUERY];
+  const clauses = [openingPassageQuery];
   if (jurisdictionClause !== undefined) {
     clauses.push(`jurisdiction:${quoteCorpusValue(jurisdictionClause)}`);
   }
@@ -92,27 +94,33 @@ type BrowseFacetSpec = {
  * and the parse cannot drift. `country` reads `jurisdiction` because that is
  * the index's name for the decision's country.
  */
-const BROWSE_FACETS = {
-  country: { field: "jurisdiction", order: { _count: "desc" } },
-  court: { field: "court", order: { _count: "desc" } },
-  year: { field: "year", order: { _key: "desc" } },
-} as const satisfies Record<keyof LegalBrowseFacets, BrowseFacetSpec>;
+const browseFacetSpecs = (yearFacetField: string) =>
+  ({
+    country: { field: "jurisdiction", order: { _count: "desc" } },
+    court: { field: "court", order: { _count: "desc" } },
+    year: { field: yearFacetField, order: { _key: "desc" } },
+  }) as const satisfies Record<keyof LegalBrowseFacets, BrowseFacetSpec>;
 
-export const browseFacetNames = Object.keys(BROWSE_FACETS);
+export const browseFacetNames = Object.keys(browseFacetSpecs("year"));
 
-const buildAggregations = (limit: number): Record<string, unknown> =>
+const buildAggregations = (
+  limit: number,
+  yearFacetField: string,
+): Record<string, unknown> =>
   Object.fromEntries(
-    Object.entries(BROWSE_FACETS).map(([name, { field, order }]) => [
-      name,
-      {
-        terms: {
-          field,
-          size: limit,
-          segment_size: FACET_SEGMENT_SIZE,
-          order,
+    Object.entries(browseFacetSpecs(yearFacetField)).map(
+      ([name, { field, order }]) => [
+        name,
+        {
+          terms: {
+            field,
+            size: limit,
+            segment_size: FACET_SEGMENT_SIZE,
+            order,
+          },
         },
-      },
-    ]),
+      ],
+    ),
   );
 
 /**
@@ -162,7 +170,16 @@ const parseTermsBuckets = (aggregation: unknown): FacetBucket[] | null => {
 export const corpusIndexBrowseFacets = async (
   query: LegalBrowseFacetsQuery,
 ): Promise<Result<LegalBrowseFacets, LegalBrowseFacetsError>> => {
-  const generation = corpusGeneration(query.documentFamily ?? "case_law");
+  const family = query.documentFamily ?? "case_law";
+  const generation = corpusGeneration(family);
+  const readContract = corpusIndexReadContract(family, generation);
+  if (readContract.family !== "case_law") {
+    return Result.err(
+      new LegalBrowseFacetsError({
+        message: "browse facets are only defined for the case-law corpus",
+      }),
+    );
+  }
   // Scoped query → that jurisdiction's index, plus a jurisdiction clause when
   // that index holds other jurisdictions; unscoped → the generation glob (one
   // multi-index aggregation across every index of the generation).
@@ -172,17 +189,15 @@ export const corpusIndexBrowseFacets = async (
   );
 
   const aggregated = await getCorpusIndexClient(
-    corpusIndexClusterForGeneration(
-      query.documentFamily ?? "case_law",
-      generation,
-    ),
+    corpusIndexClusterForGeneration(family, generation),
   ).aggregate({
     indexId,
     query: browseFacetsQuery({
       excludedSourceIds: query.excludedSourceIds,
       jurisdictionClause,
+      openingPassageQuery: readContract.openingPassageQuery,
     }),
-    aggs: buildAggregations(query.limit),
+    aggs: buildAggregations(query.limit, readContract.yearFacetField),
   });
   if (Result.isError(aggregated)) {
     return Result.err(

--- a/apps/api/src/lib/legal-search/corpus-index-facets.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.ts
@@ -2,6 +2,7 @@ import { Result } from "better-result";
 
 import { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
+import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
 import { quoteCorpusValue } from "@/api/lib/legal-search/corpus-query";
 import { corpusIndexRoute } from "@/api/lib/legal-search/index-naming";
@@ -170,7 +171,12 @@ export const corpusIndexBrowseFacets = async (
     query.jurisdiction,
   );
 
-  const aggregated = await getCorpusIndexClient().aggregate({
+  const aggregated = await getCorpusIndexClient(
+    corpusIndexClusterForGeneration(
+      query.documentFamily ?? "case_law",
+      generation,
+    ),
+  ).aggregate({
     indexId,
     query: browseFacetsQuery({
       excludedSourceIds: query.excludedSourceIds,

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
@@ -11,7 +11,7 @@ import {
 
 const EXPECTED_DIGESTS = {
   case_law_v5:
-    "98d516f3f4ee413bf716e6cbec345fb217390a3ae516dba20a5ae1bd2ac77741",
+    "c4ce8a1f9b80f87639af82d6c3a4c426b3bf553e0398ab8ff08c663d7ad0a87b",
   legislation_v2:
     "fc0d1e8e972d95cae450f4863d5a9902db7c9634517e65f57748027a4ca2a265",
 } as const satisfies Record<keyof typeof CORPUS_INDEX_MANIFESTS, string>;
@@ -192,6 +192,14 @@ test("v5 removes stale and repeated physical fields", () => {
     fast: true,
     fast_precision: "seconds",
   });
+  expect(fields.get("decision_year")).toEqual({
+    name: "decision_year",
+    type: "u64",
+    indexed: false,
+    stored: false,
+    fast: true,
+  });
+  expect(manifest.projection.yearFacetField).toBe("decision_year");
 });
 
 test("final manifests make every storage and index cost explicit", () => {

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -40,6 +40,7 @@ type CaseLawV5Manifest = CorpusIndexManifestBase & {
   projection: CorpusIndexProjectionContract & {
     layout: "passage";
     builderVersion: "case-law-passages-v1";
+    yearFacetField: "decision_year";
   };
   route: {
     type: "case_law_group";
@@ -85,6 +86,14 @@ const dateField = (name: string): CorpusIndexFieldMapping => ({
   stored: false,
   fast: true,
   input_formats: CORPUS_INDEX_DATE_INPUT_FORMATS,
+});
+
+const unsignedIntegerField = (name: string): CorpusIndexFieldMapping => ({
+  name,
+  type: "u64",
+  indexed: false,
+  stored: false,
+  fast: true,
 });
 
 const commonFields = (): CorpusIndexFieldMapping[] => [
@@ -174,6 +183,11 @@ const CASE_LAW_V5_INDEX_CONFIG = deepFreeze(
         rawField("case_number", { stored: false, fast: false }),
         rawField("court", { stored: false, fast: true }),
         dateField("decision_date"),
+        // Quickwit 0.9 supports only fixed, not calendar, date-histogram
+        // intervals. The projection emits this exact civil year on the one
+        // opening passage only, avoiding both leap-year drift and per-passage
+        // fast-field duplication for browse facets.
+        unsignedIntegerField("decision_year"),
         {
           ...dateField(DECISION_TIMESTAMP_FIELD),
           fast_precision: "seconds",
@@ -218,6 +232,7 @@ export const CORPUS_INDEX_MANIFESTS = deepFreeze({
       documentIdField: "document_id",
       projectionRevisionField: "projection_revision",
       openingField: "is_opening",
+      yearFacetField: "decision_year",
     },
     route: {
       type: "case_law_group",

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.test.ts
@@ -60,6 +60,7 @@ afterEach(() => {
 
 const readPage = async (limit = 10) =>
   await readCorpusIndexSearchPage({
+    cluster: "q08",
     indexId: "case_law_v2_cze",
     query: "text:promlčení",
     limit,

--- a/apps/api/src/lib/legal-search/corpus-index-pagination.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-pagination.ts
@@ -1,3 +1,4 @@
+import type { QuickwitCluster } from "@/api/lib/legal-search/corpus-generation-contract";
 import type { CorpusIndexHit } from "@/api/lib/legal-search/corpus-index-client";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
 import type { RankedHit, ScoredCandidate } from "@/api/lib/legal-search/rerank";
@@ -14,6 +15,7 @@ type CorpusIndexRanking<TContext> = {
 };
 
 type CorpusIndexSearchPageInput<TContext> = {
+  cluster: QuickwitCluster;
   indexId: string;
   query: string;
   limit: number;
@@ -104,6 +106,7 @@ const windowAfterCursor = (
     : ranked.filter((hit) => isAfterSearchCursor(hit, parsedCursor));
 
 export const readCorpusIndexSearchPage = async <TContext>({
+  cluster,
   indexId,
   query,
   limit,
@@ -155,7 +158,7 @@ export const readCorpusIndexSearchPage = async <TContext>({
     // document-id order and the rank-based lexical score below would be
     // meaningless.
     // oxlint-disable-next-line no-await-in-loop -- offset pagination: each scan depends on the previous startOffset
-    const result = await getCorpusIndexClient().search({
+    const result = await getCorpusIndexClient(cluster).search({
       indexId,
       query,
       maxHits,

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -21,6 +21,7 @@ import {
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
 import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
+import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import { corpusIndexBrowseFacets } from "@/api/lib/legal-search/corpus-index-facets";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
@@ -172,6 +173,7 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
   }
 
   const searchPage = await readCorpusIndexSearchPage({
+    cluster: corpusIndexClusterForGeneration("case_law", generation),
     indexId,
     query: engineQuery,
     limit,

--- a/apps/api/src/lib/legal-search/corpus-index-read-contract.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-read-contract.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+
+import { corpusIndexReadContract } from "@/api/lib/legal-search/corpus-index-read-contract";
+
+test("legacy and final case-law reads use their declared schema", () => {
+  expect(corpusIndexReadContract("case_law", "case_law_v4")).toEqual({
+    family: "case_law",
+    openingPassageQuery: "seq:0",
+    yearFacetField: "year",
+  });
+  expect(corpusIndexReadContract("case_law", "case_law_v5")).toEqual({
+    family: "case_law",
+    openingPassageQuery: "is_opening:true",
+    yearFacetField: "decision_year",
+  });
+});
+
+test("legislation reads derive the final opening marker", () => {
+  expect(corpusIndexReadContract("legislation", "legislation_v1")).toEqual({
+    family: "legislation",
+    openingPassageQuery: "seq:0",
+  });
+  expect(corpusIndexReadContract("legislation", "legislation_v2")).toEqual({
+    family: "legislation",
+    openingPassageQuery: "is_opening:true",
+  });
+});

--- a/apps/api/src/lib/legal-search/corpus-index-read-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-read-contract.ts
@@ -1,0 +1,57 @@
+import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
+import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
+import { requireCorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
+
+type CaseLawIndexReadContract = {
+  family: "case_law";
+  openingPassageQuery: string;
+  yearFacetField: string;
+};
+
+type LegislationIndexReadContract = {
+  family: "legislation";
+  openingPassageQuery: string;
+};
+
+export type CorpusIndexReadContract =
+  | CaseLawIndexReadContract
+  | LegislationIndexReadContract;
+
+/**
+ * Query capabilities owned by a generation's physical schema. Legacy q08
+ * generations share their established fields; final q09 generations derive
+ * every field name from the immutable manifest so readers cannot drift from
+ * writers when a generation changes shape.
+ */
+export const corpusIndexReadContract = (
+  family: CorpusFamily,
+  generation: string,
+): CorpusIndexReadContract => {
+  const cluster = corpusIndexClusterForGeneration(family, generation);
+  if (cluster === "q08") {
+    return family === "case_law"
+      ? {
+          family,
+          openingPassageQuery: "seq:0",
+          yearFacetField: "year",
+        }
+      : { family, openingPassageQuery: "seq:0" };
+  }
+
+  const manifest = requireCorpusIndexManifest(family, generation);
+  switch (manifest.family) {
+    case "case_law":
+      return {
+        family: manifest.family,
+        openingPassageQuery: `${manifest.projection.openingField}:true`,
+        yearFacetField: manifest.projection.yearFacetField,
+      };
+    case "legislation":
+      return {
+        family: manifest.family,
+        openingPassageQuery: `${manifest.projection.openingField}:true`,
+      };
+    default:
+      return manifest satisfies never;
+  }
+};

--- a/apps/api/src/lib/legal-search/corpus-index-read-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-read-contract.ts
@@ -2,13 +2,13 @@ import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-cont
 import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import { requireCorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
 
-type CaseLawIndexReadContract = {
+export type CaseLawIndexReadContract = {
   family: "case_law";
   openingPassageQuery: string;
   yearFacetField: string;
 };
 
-type LegislationIndexReadContract = {
+export type LegislationIndexReadContract = {
   family: "legislation";
   openingPassageQuery: string;
 };
@@ -23,10 +23,22 @@ export type CorpusIndexReadContract =
  * every field name from the immutable manifest so readers cannot drift from
  * writers when a generation changes shape.
  */
-export const corpusIndexReadContract = (
+export function corpusIndexReadContract(
+  family: "case_law",
+  generation: string,
+): CaseLawIndexReadContract;
+export function corpusIndexReadContract(
+  family: "legislation",
+  generation: string,
+): LegislationIndexReadContract;
+export function corpusIndexReadContract(
   family: CorpusFamily,
   generation: string,
-): CorpusIndexReadContract => {
+): CorpusIndexReadContract;
+export function corpusIndexReadContract(
+  family: CorpusFamily,
+  generation: string,
+): CorpusIndexReadContract {
   const cluster = corpusIndexClusterForGeneration(family, generation);
   if (cluster === "q08") {
     return family === "case_law"
@@ -54,4 +66,4 @@ export const corpusIndexReadContract = (
     default:
       return manifest satisfies never;
   }
-};
+}

--- a/apps/api/src/scripts/corpus-index-query-diff-client.test.ts
+++ b/apps/api/src/scripts/corpus-index-query-diff-client.test.ts
@@ -15,18 +15,19 @@ const originalEndpoints = {
 
 let requests: RecordedRequest[];
 
+const requestUrl = (input: Parameters<typeof fetch>[0]): string => {
+  if (typeof input === "string") {
+    return input;
+  }
+  return input instanceof URL ? input.href : input.url;
+};
+
 beforeEach(() => {
   requests = [];
   const stub = async (
     input: Parameters<typeof fetch>[0],
   ): Promise<Response> => {
-    const url = new URL(
-      typeof input === "string"
-        ? input
-        : input instanceof URL
-          ? input.href
-          : input.url,
-    );
+    const url = new URL(requestUrl(input));
     requests.push({ host: url.host });
     return new Response(
       JSON.stringify({ num_hits: 0, hits: [], snippets: [] }),

--- a/apps/api/src/scripts/corpus-index-query-diff-client.test.ts
+++ b/apps/api/src/scripts/corpus-index-query-diff-client.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+
+import { envBase } from "@/api/env-base";
+import { corpusIndexQueryDiffClientForGeneration } from "@/api/scripts/corpus-index-query-diff-client";
+
+type RecordedRequest = { host: string };
+
+const originalFetch = globalThis.fetch;
+const originalEndpoints = {
+  CORPUS_INDEX_ENDPOINT: envBase.CORPUS_INDEX_ENDPOINT,
+  CORPUS_INDEX_SEARCH_ENDPOINT: envBase.CORPUS_INDEX_SEARCH_ENDPOINT,
+  CORPUS_INDEX_Q09_ENDPOINT: envBase.CORPUS_INDEX_Q09_ENDPOINT,
+  CORPUS_INDEX_Q09_SEARCH_ENDPOINT: envBase.CORPUS_INDEX_Q09_SEARCH_ENDPOINT,
+};
+
+let requests: RecordedRequest[];
+
+beforeEach(() => {
+  requests = [];
+  const stub = async (
+    input: Parameters<typeof fetch>[0],
+  ): Promise<Response> => {
+    const url = new URL(
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url,
+    );
+    requests.push({ host: url.host });
+    return new Response(
+      JSON.stringify({ num_hits: 0, hits: [], snippets: [] }),
+      { status: 200 },
+    );
+  };
+  globalThis.fetch = Object.assign(stub, {
+    preconnect: originalFetch.preconnect,
+  });
+  Object.assign(envBase, {
+    CORPUS_INDEX_ENDPOINT: "http://localhost:7281",
+    CORPUS_INDEX_SEARCH_ENDPOINT: "http://localhost:7282",
+    CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
+    CORPUS_INDEX_Q09_SEARCH_ENDPOINT: "http://localhost:7292",
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  Object.assign(envBase, originalEndpoints);
+});
+
+test("v4 and v5 query clients use their distinct cluster endpoints", async () => {
+  const base = await corpusIndexQueryDiffClientForGeneration(
+    "case_law_v4",
+  ).search({
+    indexId: "case_law_v4_cze",
+    query: "text:smlouva",
+    maxHits: 1,
+  });
+  const candidate = await corpusIndexQueryDiffClientForGeneration(
+    "case_law_v5",
+  ).search({
+    indexId: "case_law_v5_cs_sk",
+    query: "text:smlouva",
+    maxHits: 1,
+  });
+
+  expect(base.isOk()).toBe(true);
+  expect(candidate.isOk()).toBe(true);
+  expect(requests.map(({ host }) => host)).toEqual([
+    "localhost:7282",
+    "localhost:7292",
+  ]);
+  expect(requests.at(0)?.host).not.toBe(requests.at(1)?.host);
+});

--- a/apps/api/src/scripts/corpus-index-query-diff-client.ts
+++ b/apps/api/src/scripts/corpus-index-query-diff-client.ts
@@ -1,0 +1,14 @@
+import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
+import {
+  getCorpusIndexClient,
+  type CorpusIndexClient,
+} from "@/api/lib/legal-search/corpus-index-client";
+
+/**
+ * Golden queries are case-law queries, so each generation resolves through
+ * the case-law generation contract before selecting its Quickwit client.
+ */
+export const corpusIndexQueryDiffClientForGeneration = (
+  generation: string,
+): CorpusIndexClient =>
+  getCorpusIndexClient(corpusIndexClusterForGeneration("case_law", generation));

--- a/apps/api/src/scripts/corpus-index-query-diff.ts
+++ b/apps/api/src/scripts/corpus-index-query-diff.ts
@@ -1,11 +1,12 @@
 import { Result } from "better-result";
 
-import {
-  type CorpusIndexHit,
-  getCorpusIndexClient,
+import type {
+  CorpusIndexClient,
+  CorpusIndexHit,
 } from "@/api/lib/legal-search/corpus-index-client";
 import { isCorpusIndexGeneration } from "@/api/lib/legal-search/index-naming";
 import { LIMITS } from "@/api/lib/limits";
+import { corpusIndexQueryDiffClientForGeneration } from "@/api/scripts/corpus-index-query-diff-client";
 import {
   divergedQueries,
   type GoldenQuery,
@@ -159,8 +160,6 @@ if (Result.isError(queries)) {
   fail(queries.error.message);
 }
 
-const client = getCorpusIndexClient();
-
 /**
  * Bounded offset scan until the top-N distinct documents are collected.
  * A passage-granularity index can put hundreds of one judgment's passages
@@ -173,6 +172,7 @@ const client = getCorpusIndexClient();
  * jurisdiction clause the search paths carry.
  */
 const runQuery = async (
+  client: CorpusIndexClient,
   generation: string,
   query: GoldenQuery,
 ): Promise<QueryRunOutcome> => {
@@ -216,11 +216,14 @@ const runQuery = async (
 };
 
 const rows: GoldenQueryDiffRow[] = [];
+const baseClient = corpusIndexQueryDiffClientForGeneration(baseGeneration);
+const candidateClient =
+  corpusIndexQueryDiffClientForGeneration(candidateGeneration);
 for (const query of queries.value) {
   // oxlint-disable-next-line no-await-in-loop -- one query at a time keeps the load on the engine bounded
   const [base, candidate] = await Promise.all([
-    runQuery(baseGeneration, query),
-    runQuery(candidateGeneration, query),
+    runQuery(baseClient, baseGeneration, query),
+    runQuery(candidateClient, candidateGeneration, query),
   ]);
   rows.push({
     query,

--- a/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
+++ b/apps/api/src/tests/security/case-law-public-route-invariants.test.ts
@@ -8,6 +8,7 @@ import type {
   CaseLawPublicReadDb,
   CaseLawPublicReadTransaction,
 } from "@/api/lib/case-law-public-read-db";
+import { corpusIndexReadContract } from "@/api/lib/legal-search/corpus-index-read-contract";
 
 type ScopedDbIsPublicReadDb = ScopedDb extends CaseLawPublicReadDb
   ? true
@@ -297,7 +298,15 @@ describe("public case-law route boundary", () => {
     expect(pgFtsSource).toContain("caseLawDecisions.decisionDate");
     expect(corpusIndexSource).toContain('field: "jurisdiction"');
     expect(corpusIndexSource).toContain('field: "court"');
-    expect(corpusIndexSource).toContain('field: "year"');
+    expect(corpusIndexSource).toContain(
+      "buildAggregations(query.limit, readContract.yearFacetField)",
+    );
+    expect(
+      corpusIndexReadContract("case_law", "case_law_v4").yearFacetField,
+    ).toBe("year");
+    expect(
+      corpusIndexReadContract("case_law", "case_law_v5").yearFacetField,
+    ).toBe("decision_year");
   });
 
   test("public search payload is aggregate public data only", async () => {

--- a/scripts/env-catalog.ts
+++ b/scripts/env-catalog.ts
@@ -426,6 +426,8 @@ const CONDITIONAL_REQUIREMENT_NOTES: Record<string, string> = {
   CONTENT_ENCRYPTION_KEY: "NODE_ENV is production or staging",
   CORPUS_INDEX_SEARCH_ENDPOINT:
     "LEGAL_SEARCH_PROVIDER is corpus-index and CORPUS_INDEX_ENDPOINT is unset",
+  CORPUS_INDEX_Q09_ENDPOINT:
+    "CORPUS_INDEXING_ENABLED is true and LEGAL_SEARCH_INDEX_GENERATION is case_law_v5",
   LEGAL_CORPUS_S3_BUCKET: "corpus storage is enabled in a deployed environment",
   MICROSOFT_AUTH_TENANT_ID: "Microsoft OAuth credentials are configured",
   S3_ACCESS_KEY_ID: 'S3_CREDENTIALS_PROVIDER is "env"',

--- a/scripts/env-catalog.ts
+++ b/scripts/env-catalog.ts
@@ -85,6 +85,8 @@ const INTERNAL_SERVER_KEYS = new Set([
   "CORPUS_INDEX_BATCH_SIZE",
   "CORPUS_INDEX_ENDPOINT",
   "CORPUS_INDEX_INTERVAL_MS",
+  "CORPUS_INDEX_Q09_ENDPOINT",
+  "CORPUS_INDEX_Q09_SEARCH_ENDPOINT",
   "CORPUS_INDEX_READ_CONCURRENCY",
   "CORPUS_INDEX_SEARCH_ENDPOINT",
   "CORPUS_INDEX_S3_BUCKET",
@@ -271,6 +273,10 @@ const DESCRIPTION_OVERRIDES: Record<string, string> = {
     "CloudWatch namespace of the pacing metric.",
   CORPUS_INDEX_BACKPRESSURE_SAMPLE_INTERVAL_MS:
     "Minimum interval between pacing-metric samples.",
+  CORPUS_INDEX_Q09_ENDPOINT:
+    "Isolated Quickwit 0.9 mutation endpoint. Final generations registered on q09 use this endpoint; it never falls back to the legacy cluster.",
+  CORPUS_INDEX_Q09_SEARCH_ENDPOINT:
+    "Local-development-only read endpoint for Quickwit 0.9. Unset uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.",
   CORPUS_INDEX_SEARCH_ENDPOINT:
     "Local-development-only search endpoint for a shared corpus index. Unset uses CORPUS_INDEX_ENDPOINT; this endpoint is never used for index mutations.",
   DATABASE_URL:

--- a/scripts/env-tool.test.ts
+++ b/scripts/env-tool.test.ts
@@ -401,8 +401,17 @@ describe("environment doctor output", () => {
     },
     {
       expected:
-        "LEGAL_SEARCH_PROVIDER=corpus-index requires CORPUS_INDEX_SEARCH_ENDPOINT or CORPUS_INDEX_ENDPOINT to be set.",
+        "Serving legislation_v1 on q08 requires CORPUS_INDEX_SEARCH_ENDPOINT or CORPUS_INDEX_ENDPOINT.",
       overrides: { LEGAL_SEARCH_PROVIDER: "corpus-index" },
+    },
+    {
+      expected:
+        "Serving case_law_v5 on q09 requires CORPUS_INDEX_Q09_SEARCH_ENDPOINT or CORPUS_INDEX_Q09_ENDPOINT.",
+      overrides: {
+        CORPUS_INDEX_SEARCH_ENDPOINT: "https://quickwit-08.example.com",
+        LEGAL_SEARCH_INDEX_GENERATION: "case_law_v5",
+        LEGAL_SEARCH_PROVIDER: "corpus-index",
+      },
     },
     // Removed together with the invariant, in the PR that makes a corpus
     // cursor carry the dictionary version it was built against.

--- a/scripts/env-tool.test.ts
+++ b/scripts/env-tool.test.ts
@@ -505,7 +505,7 @@ describe("environment doctor output", () => {
     },
     {
       expected:
-        "Public-law database URLs require CORPUS_INDEX_SEARCH_ENDPOINT.",
+        "Public-law database URLs require CORPUS_INDEX_SEARCH_ENDPOINT or CORPUS_INDEX_Q09_SEARCH_ENDPOINT.",
       overrides: {
         PUBLIC_LAW_DATABASE_URL:
           "postgres://case_law_reader:password@db.example.com:5432/stella?sslmode=require",
@@ -514,7 +514,7 @@ describe("environment doctor output", () => {
     },
     {
       expected:
-        "CORPUS_INDEX_ENDPOINT must be unset when a public-law database URL is configured.",
+        "CORPUS_INDEX_ENDPOINT and CORPUS_INDEX_Q09_ENDPOINT must be unset when a public-law database URL is configured.",
       overrides: {
         PUBLIC_LAW_DATABASE_URL:
           "postgres://case_law_reader:password@db.example.com:5432/stella?sslmode=require",

--- a/scripts/env-tool.test.ts
+++ b/scripts/env-tool.test.ts
@@ -413,6 +413,16 @@ describe("environment doctor output", () => {
         LEGAL_SEARCH_PROVIDER: "corpus-index",
       },
     },
+    {
+      expected:
+        "Indexing case_law_v5 on q09 requires CORPUS_INDEX_Q09_ENDPOINT.",
+      overrides: {
+        CORPUS_INDEXING_ENABLED: "true",
+        CORPUS_INDEX_Q09_SEARCH_ENDPOINT:
+          "https://quickwit-09-search.example.com",
+        LEGAL_SEARCH_INDEX_GENERATION: "case_law_v5",
+      },
+    },
     // Removed together with the invariant, in the PR that makes a corpus
     // cursor carry the dictionary version it was built against.
     {
@@ -493,6 +503,13 @@ describe("environment doctor output", () => {
         CONTENT_ENCRYPTION_KEY: "a".repeat(64),
         CORPUS_INDEX_SEARCH_ENDPOINT: "https://search.example.com",
         NODE_ENV: "staging",
+      },
+    },
+    {
+      expected:
+        "CORPUS_INDEX_Q09_ENDPOINT must use HTTPS unless it targets a loopback address.",
+      overrides: {
+        CORPUS_INDEX_Q09_ENDPOINT: "http://quickwit-admin.example.com",
       },
     },
     {

--- a/scripts/env-tool.test.ts
+++ b/scripts/env-tool.test.ts
@@ -417,10 +417,18 @@ describe("environment doctor output", () => {
       expected:
         "Indexing case_law_v5 on q09 requires CORPUS_INDEX_Q09_ENDPOINT.",
       overrides: {
+        CORPUS_INDEX_ENDPOINT: "https://quickwit-08.example.com",
         CORPUS_INDEXING_ENABLED: "true",
         CORPUS_INDEX_Q09_SEARCH_ENDPOINT:
           "https://quickwit-09-search.example.com",
         LEGAL_SEARCH_INDEX_GENERATION: "case_law_v5",
+      },
+    },
+    {
+      expected:
+        "Corpus indexing requires CORPUS_INDEX_ENDPOINT for legislation_v1 on q08.",
+      overrides: {
+        CORPUS_INDEXING_ENABLED: "true",
       },
     },
     // Removed together with the invariant, in the PR that makes a corpus
@@ -510,6 +518,22 @@ describe("environment doctor output", () => {
         "CORPUS_INDEX_Q09_ENDPOINT must use HTTPS unless it targets a loopback address.",
       overrides: {
         CORPUS_INDEX_Q09_ENDPOINT: "http://quickwit-admin.example.com",
+      },
+    },
+    {
+      expected:
+        "CORPUS_INDEX_Q09_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address.",
+      overrides: {
+        CORPUS_INDEX_Q09_SEARCH_ENDPOINT: "http://quickwit-search.example.com",
+      },
+    },
+    {
+      expected:
+        "CORPUS_INDEX_Q09_SEARCH_ENDPOINT is only supported in local development.",
+      overrides: {
+        CONTENT_ENCRYPTION_KEY: "a".repeat(64),
+        CORPUS_INDEX_Q09_SEARCH_ENDPOINT: "https://quickwit-search.example.com",
+        NODE_ENV: "staging",
       },
     },
     {


### PR DESCRIPTION
## Summary

- route corpus-index clients through the generation-owned q08/q09 cluster discriminator
- require dedicated q09 mutation and search endpoints with no fallback to q08
- keep the temporary no-argument client explicitly pinned to q08 until no q08 generation serves

## Validation

- `git diff --check`
- exact touched-file formatting
- full validation delegated to required CI

Stacked on #2468.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for separate search and update services for different legal-data generations.
  - Searches and index updates now route automatically to the appropriate service.
  - Added configuration options for the latest search service.

- **Bug Fixes**
  - Improved endpoint validation and legal-search configuration handling.
  - Prevented searches, updates and data removal from being sent to the wrong service.

- **Tests**
  - Expanded coverage for generation-specific routing, endpoint validation and search behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->