### PR TITLE
chore: expand oxlint rules (poteto inspired)

### DIFF
--- a/.agents/skills/conventions-testing/SKILL.md
+++ b/.agents/skills/conventions-testing/SKILL.md
@@ -52,6 +52,11 @@ enforcement, branded types) live in
 - Prefer plain fakes over mocking libraries for simple cases;
   use mocks when simulating failure modes, testing varied
   edge-case inputs, or isolating external services
+- Assert observable behavior or an invariant, not the implementation sequence.
+  A test that only proves "does not throw" or re-encodes the production algorithm
+  needs a stronger assertion.
+- Use snapshots only when the serialized output is itself a stable, reviewable
+  contract. Do not use snapshots as a substitute for behavioral assertions.
 - Test tenant isolation and ownership-source rules at the
   highest meaningful layer, not only as pure helper tests
 - Every bug fix needs a durable guard, but not necessarily an example test:

--- a/.ai/local-skills/conventions-testing/SKILL.md
+++ b/.ai/local-skills/conventions-testing/SKILL.md
@@ -52,6 +52,11 @@ enforcement, branded types) live in
 - Prefer plain fakes over mocking libraries for simple cases;
   use mocks when simulating failure modes, testing varied
   edge-case inputs, or isolating external services
+- Assert observable behavior or an invariant, not the implementation sequence.
+  A test that only proves "does not throw" or re-encodes the production algorithm
+  needs a stronger assertion.
+- Use snapshots only when the serialized output is itself a stable, reviewable
+  contract. Do not use snapshots as a substitute for behavioral assertions.
 - Test tenant isolation and ownership-source rules at the
   highest meaningful layer, not only as pure helper tests
 - Every bug fix needs a durable guard, but not necessarily an example test:

--- a/.ai/local/agents.md
+++ b/.ai/local/agents.md
@@ -12,6 +12,21 @@ user-facing strings, ingestion, performance guard failures and hot paths,
 architecture and scale, auth and data access, files and external APIs, tests,
 `apps/web` React effects, and user-facing UI. The skills own the detailed rules.
 
+## Implementation Quality
+
+- Comments explain a non-obvious invariant, trade-off, safety constraint, or why
+  the code exists. Do not narrate the next statement, add empty documentation
+  blocks, or label closing braces.
+- Make abstractions earn their keep. Avoid pass-through wrappers, single-use
+  helpers, and interfaces with one implementation unless they establish a real
+  ownership boundary, contract, or test seam.
+- Prefer deleting concepts, branches, and layers over moving complexity around.
+  Keep feature-specific behavior at its canonical owner; do not scatter flags and
+  special cases through shared flows.
+- Defensive code belongs at real trust and failure boundaries. Do not add null
+  checks, silent fallbacks, or catch-and-log blocks for states already excluded by
+  types, validation, or framework guarantees.
+
 ## Workspace Layout
 
 - `apps/*` contains runnable applications only.

--- a/.claude/commands/conventions-testing.md
+++ b/.claude/commands/conventions-testing.md
@@ -47,6 +47,11 @@ enforcement, branded types) live in
 - Prefer plain fakes over mocking libraries for simple cases;
   use mocks when simulating failure modes, testing varied
   edge-case inputs, or isolating external services
+- Assert observable behavior or an invariant, not the implementation sequence.
+  A test that only proves "does not throw" or re-encodes the production algorithm
+  needs a stronger assertion.
+- Use snapshots only when the serialized output is itself a stable, reviewable
+  contract. Do not use snapshots as a substitute for behavioral assertions.
 - Test tenant isolation and ownership-source rules at the
   highest meaningful layer, not only as pure helper tests
 - Every bug fix needs a durable guard, but not necessarily an example test:

--- a/.oxlint-plugins/README.md
+++ b/.oxlint-plugins/README.md
@@ -56,6 +56,7 @@ runtime validation, or integration tests.
 - [`no-raw-user-id-schema`](./no-raw-user-id-schema.ts) (`no-raw-user-id-schema`): prevents plain string schemas from laundering user IDs across trust boundaries.
 - [`no-secret-in-log-sink`](./no-secret-in-log-sink.ts) (`no-secret-in-log-sink`): traces secret-named values into logging, analytics, error, and serialization sinks.
 - [`no-unbranded-ownership-id-param`](./no-unbranded-ownership-id-param.ts) (`no-unbranded-ownership-id-param`): requires validated workspace and organization IDs to retain their branded type through API parameters.
+- [`no-unjustified-double-assertion`](./no-unjustified-double-assertion.ts) (`no-unjustified-double-assertion`): requires a nearby `SAFETY:` explanation when a direct TypeScript assertion chain widens through `unknown`, `object`, or an open record before asserting a narrower contract.
 - [`no-unowned-file-version-write`](./no-unowned-file-version-write.ts) (`no-unowned-file-version-write`): prevents file-version writes that are not tied to an authorized owning workspace or document.
 - [`no-unsafe-inner-html`](./no-unsafe-inner-html.ts) (`no-unsafe-inner-html`): permits static markup; dynamic HTML requires an adjacent `safe-html:` provenance comment because sanitizer-looking function names are not proof.
 - [`no-unvalidated-json-domain-cast`](./no-unvalidated-json-domain-cast.ts) (`no-unvalidated-json-domain-cast`): rejects assertions that turn unvalidated `response.json()` or `JSON.parse()` output into closed domain types.

--- a/.oxlint-plugins/__fixtures__/no-truncated-timestamp-comparison.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-truncated-timestamp-comparison.fixture.ts
@@ -12,21 +12,25 @@ import { and, eq, gt, gte, lt, lte, ne, or, sql } from "drizzle-orm";
 // Only the shapes matter: the rule reads `<object>.<columnName>` and the
 // operand's syntax, never their types.
 const createdAt = sql`created_at`;
-const decisions = {
+declare const pgTable: <TColumns extends Record<string, unknown>>(
+  name: string,
+  columns: TColumns,
+) => TColumns;
+const decisions = pgTable("decisions", {
   createdAt,
   updatedAt: sql`updated_at`,
   id: sql`id`,
   sourceId: sql`source_id`,
-};
+});
 const allocations = {
   periodStart: sql`period_start`,
   periodEnd: sql`period_end`,
 };
 const searchDocuments = { updatedAt: sql`updated_at` };
-const projectionIntents = {
+const projectionIntents = pgTable("projection_intents", {
   appendPublishBarrierAt: sql`append_publish_barrier_at`,
   cleanupNotBefore: sql`cleanup_not_before`,
-};
+});
 const cursor = { createdAt: new Date(), id: "row-id" };
 const checkpoint = {
   cursorCreatedAt: new Date(),
@@ -155,6 +159,15 @@ const _sameOwnerColumnTuple = sql`(${decisions.updatedAt}, ${decisions.id}) >= (
 const _sameOwnerColumnCall = gte(decisions.updatedAt, decisions.createdAt);
 const _legacySameOwnerColumn = sql`${projectionIntents.cleanupNotBefore} >= ${projectionIntents.appendPublishBarrierAt}`;
 
+// A plain helper object is not a schema table even when both operands use the
+// same syntactic owner: cursorAt still contains a truncated JavaScript Date.
+const operands = {
+  storedAt: decisions.createdAt,
+  cursorAt: cursor.createdAt,
+};
+// oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison
+const _sameHelperOwner = gt(operands.storedAt, operands.cursorAt);
+
 // A nested SQL fragment can still bind a truncated JS Date; the tag alone
 // does not make every interpolation a database-native expression.
 // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison
@@ -246,6 +259,7 @@ export const __noTruncatedTimestampComparisonFixture = {
   _sameOwnerColumnTuple,
   _sameOwnerColumnCall,
   _legacySameOwnerColumn,
+  _sameHelperOwner,
   _columnOnRight,
   _nestedBoundDate,
   _conditionalClock,

--- a/.oxlint-plugins/__fixtures__/no-truncated-timestamp-comparison.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-truncated-timestamp-comparison.fixture.ts
@@ -23,6 +23,10 @@ const allocations = {
   periodEnd: sql`period_end`,
 };
 const searchDocuments = { updatedAt: sql`updated_at` };
+const projectionIntents = {
+  appendPublishBarrierAt: sql`append_publish_barrier_at`,
+  cleanupNotBefore: sql`cleanup_not_before`,
+};
 const cursor = { createdAt: new Date(), id: "row-id" };
 const checkpoint = {
   cursorCreatedAt: new Date(),
@@ -144,6 +148,13 @@ const _mutableBinding = lte(decisions.updatedAt, mutableNow);
 // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison
 const _columnToColumn = gt(decisions.updatedAt, searchDocuments.updatedAt);
 
+// Two timestamp members owned by the same schema object are database-native
+// operands when interpolated into one SQL template.
+const _sameOwnerColumnToColumn = sql`${decisions.updatedAt} >= ${decisions.createdAt}`;
+const _sameOwnerColumnTuple = sql`(${decisions.updatedAt}, ${decisions.id}) >= (${decisions.createdAt}, ${decisions.sourceId})`;
+const _sameOwnerColumnCall = gte(decisions.updatedAt, decisions.createdAt);
+const _legacySameOwnerColumn = sql`${projectionIntents.cleanupNotBefore} >= ${projectionIntents.appendPublishBarrierAt}`;
+
 // A nested SQL fragment can still bind a truncated JS Date; the tag alone
 // does not make every interpolation a database-native expression.
 // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison
@@ -231,6 +242,10 @@ export const __noTruncatedTimestampComparisonFixture = {
   _parsedDate,
   _mutableBinding,
   _columnToColumn,
+  _sameOwnerColumnToColumn,
+  _sameOwnerColumnTuple,
+  _sameOwnerColumnCall,
+  _legacySameOwnerColumn,
   _columnOnRight,
   _nestedBoundDate,
   _conditionalClock,

--- a/.oxlint-plugins/__fixtures__/no-unjustified-double-assertion.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-unjustified-double-assertion.fixture.ts
@@ -1,0 +1,32 @@
+// Passive regression fixture for
+// `no-unjustified-double-assertion/no-unjustified-double-assertion`.
+
+type MatterSummary = {
+  matterId: string;
+  title: string;
+};
+
+declare const externalValue: unknown;
+declare const openRecord: Record<string, unknown>;
+
+// oxlint-disable-next-line no-unjustified-double-assertion/no-unjustified-double-assertion -- fixture: unknown laundering has no reviewed runtime invariant
+export const unreviewedUnknown = externalValue as unknown as MatterSummary;
+
+// oxlint-disable-next-line no-unjustified-double-assertion/no-unjustified-double-assertion -- fixture: an open record is asserted into a closed domain contract
+export const unreviewedRecord = openRecord as Record<
+  string,
+  unknown
+> as MatterSummary;
+
+// SAFETY: the adapter validates matterId and title before returning the value.
+export const reviewedBoundary = externalValue as unknown as MatterSummary;
+
+// See SAFETY comment on reviewedBoundary above.
+export const referencedBoundary = externalValue as unknown as MatterSummary;
+
+export const directAssertion = externalValue as MatterSummary;
+
+declare const identified: { matterId: string };
+export const nonBroadIntermediate = identified as {
+  matterId: string;
+} as MatterSummary;

--- a/.oxlint-plugins/__fixtures__/no-unjustified-double-assertion.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-unjustified-double-assertion.fixture.ts
@@ -30,6 +30,12 @@ export const unrelatedDirectAssertion = externalValue as MatterSummary;
 // oxlint-disable-next-line no-unjustified-double-assertion/no-unjustified-double-assertion -- fixture: an intervening statement separates this cast from the unrelated rationale
 export const separatedBoundary = externalValue as unknown as MatterSummary;
 
+export const earlierStatement = externalValue as MatterSummary; // SAFETY: this comment documents only the earlier statement.
+
+export const trailingCommentBoundary =
+  // oxlint-disable-next-line no-unjustified-double-assertion/no-unjustified-double-assertion -- fixture: a trailing comment on an earlier statement cannot justify this cast
+  externalValue as unknown as MatterSummary;
+
 export const directAssertion = externalValue as MatterSummary;
 
 declare const identified: { matterId: string };

--- a/.oxlint-plugins/__fixtures__/no-unjustified-double-assertion.fixture.ts
+++ b/.oxlint-plugins/__fixtures__/no-unjustified-double-assertion.fixture.ts
@@ -24,6 +24,12 @@ export const reviewedBoundary = externalValue as unknown as MatterSummary;
 // See SAFETY comment on reviewedBoundary above.
 export const referencedBoundary = externalValue as unknown as MatterSummary;
 
+// SAFETY: this rationale belongs only to the direct assertion below.
+export const unrelatedDirectAssertion = externalValue as MatterSummary;
+
+// oxlint-disable-next-line no-unjustified-double-assertion/no-unjustified-double-assertion -- fixture: an intervening statement separates this cast from the unrelated rationale
+export const separatedBoundary = externalValue as unknown as MatterSummary;
+
 export const directAssertion = externalValue as MatterSummary;
 
 declare const identified: { matterId: string };

--- a/.oxlint-plugins/no-truncated-timestamp-comparison.ts
+++ b/.oxlint-plugins/no-truncated-timestamp-comparison.ts
@@ -144,7 +144,7 @@ const isTimestampColumnExpression = (node: unknown): boolean => {
   return typeof name === "string" && isTimestampColumnName(name);
 };
 
-const timestampColumnOwner = (node: unknown): string | undefined => {
+const timestampColumnOwner = (node: unknown): AstNode | undefined => {
   if (!isTimestampColumnExpression(node) || !isAstNode(node)) {
     return undefined;
   }
@@ -152,16 +152,7 @@ const timestampColumnOwner = (node: unknown): string | undefined => {
   if (!isAstNode(object) || object.type !== "Identifier") {
     return undefined;
   }
-  const name = object.name;
-  return typeof name === "string" ? name : undefined;
-};
-
-const hasSameTimestampColumnOwner = (
-  left: unknown,
-  right: unknown,
-): boolean => {
-  const leftOwner = timestampColumnOwner(left);
-  return leftOwner !== undefined && leftOwner === timestampColumnOwner(right);
+  return typeof object.name === "string" ? object : undefined;
 };
 
 // ── SQL text ─────────────────────────────────────────────────────────────
@@ -482,6 +473,50 @@ export default eslintCompatPlugin({
             scope?.set.get(identifier.name) ??
             (scope?.upper ? findVariable(scope.upper) : null);
           return findVariable(context.sourceCode.getScope(identifier));
+        };
+
+        const isPgTableCall = (node: unknown): boolean =>
+          isAstNode(node) &&
+          node.type === "CallExpression" &&
+          calleeName(node) === "pgTable";
+
+        // The same spelling on both operands is not enough: a helper object
+        // can group a real column and a round-tripped Date under one owner.
+        // Accept the exemption only when that owner resolves to a pgTable
+        // binding or to the table parameter of pgTable's checks callback.
+        const isPgTableOwner = (owner: AstNode): boolean => {
+          const variable = resolveVariable(owner);
+          return (
+            variable !== null &&
+            variable.defs.some((def) => {
+              if (def.type === "Variable" && isAstNode(def.node)) {
+                return (
+                  def.node.type === "VariableDeclarator" &&
+                  isPgTableCall(def.node.init)
+                );
+              }
+              if (def.type !== "Parameter" || !isAstNode(def.node)) {
+                return false;
+              }
+              return isPgTableCall(def.node.parent);
+            })
+          );
+        };
+
+        const hasSameTimestampColumnOwner = (
+          left: unknown,
+          right: unknown,
+        ): boolean => {
+          const leftOwner = timestampColumnOwner(left);
+          const rightOwner = timestampColumnOwner(right);
+          if (
+            leftOwner === undefined ||
+            rightOwner === undefined ||
+            leftOwner.name !== rightOwner.name
+          ) {
+            return false;
+          }
+          return isPgTableOwner(leftOwner) && isPgTableOwner(rightOwner);
         };
 
         // One hop from an identifier to the `const` initializer it was bound

--- a/.oxlint-plugins/no-truncated-timestamp-comparison.ts
+++ b/.oxlint-plugins/no-truncated-timestamp-comparison.ts
@@ -65,6 +65,7 @@ import { eslintCompatPlugin } from "@oxlint/plugins";
 //   lte(jobs.nextRunAt, now)          // `const now = new Date()` in this file
 //   lte(sources.leaseExpiresAt, sql`now()`)              // compared in-DB
 //   lt(decisions.createdAt, pgTimestampCursorBoundary(cursor))
+//   gte(table.settledAt, table.cleanupStartedAt)          // same schema owner
 //
 // A comparison against a clock-derived cutoff is the one exemption resolved
 // from syntax rather than from a name: an inequality against a moving cutoff
@@ -95,6 +96,7 @@ const isAstNode = (node: unknown): node is AstNode =>
 // the reason to keep naming new ones `...At`.
 const EXTRA_TIMESTAMP_COLUMN_NAMES = [
   "authTime",
+  "cleanupNotBefore",
   "currentPeriodEnd",
   "currentPeriodStart",
   "lastRequest",
@@ -138,8 +140,28 @@ const isTimestampColumnExpression = (node: unknown): boolean => {
   if (!isAstNode(property) || property.type !== "Identifier") {
     return false;
   }
-  const name = property["name"];
+  const name = property.name;
   return typeof name === "string" && isTimestampColumnName(name);
+};
+
+const timestampColumnOwner = (node: unknown): string | undefined => {
+  if (!isTimestampColumnExpression(node) || !isAstNode(node)) {
+    return undefined;
+  }
+  const { object } = node;
+  if (!isAstNode(object) || object.type !== "Identifier") {
+    return undefined;
+  }
+  const name = object.name;
+  return typeof name === "string" ? name : undefined;
+};
+
+const hasSameTimestampColumnOwner = (
+  left: unknown,
+  right: unknown,
+): boolean => {
+  const leftOwner = timestampColumnOwner(left);
+  return leftOwner !== undefined && leftOwner === timestampColumnOwner(right);
 };
 
 // ── SQL text ─────────────────────────────────────────────────────────────
@@ -286,13 +308,13 @@ const calleeName = (node: unknown): string | undefined => {
     return undefined;
   }
   if (callee.type === "Identifier") {
-    const name = callee["name"];
+    const name = callee.name;
     return typeof name === "string" ? name : undefined;
   }
   if (callee.type === "MemberExpression" && callee.computed !== true) {
     const { property } = callee;
     if (isAstNode(property) && property.type === "Identifier") {
-      const name = property["name"];
+      const name = property.name;
       return typeof name === "string" ? name : undefined;
     }
   }
@@ -311,21 +333,21 @@ const isSqlTaggedTemplate = (node: unknown): boolean => {
     return false;
   }
   if (tag.type === "Identifier") {
-    return tag["name"] === "sql";
+    return tag.name === "sql";
   }
   if (tag.type === "MemberExpression" && tag.computed !== true) {
     const { property } = tag;
     return (
       isAstNode(property) &&
       property.type === "Identifier" &&
-      property["name"] === "sql"
+      property.name === "sql"
     );
   }
   return false;
 };
 
 const isIdentifierNamed = (node: unknown, name: string): boolean =>
-  isAstNode(node) && node.type === "Identifier" && node["name"] === name;
+  isAstNode(node) && node.type === "Identifier" && node.name === name;
 
 const isDateNowCall = (node: unknown): boolean => {
   if (!isAstNode(node) || node.type !== "CallExpression") {
@@ -349,10 +371,10 @@ const isClockAdjustment = (node: unknown): boolean =>
     node.type === "Identifier" ||
     (node.type === "UnaryExpression" && isClockAdjustment(node.argument)) ||
     (node.type === "BinaryExpression" &&
-      (node["operator"] === "+" ||
-        node["operator"] === "-" ||
-        node["operator"] === "*" ||
-        node["operator"] === "/") &&
+      (node.operator === "+" ||
+        node.operator === "-" ||
+        node.operator === "*" ||
+        node.operator === "/") &&
       isClockAdjustment(node.left) &&
       isClockAdjustment(node.right)));
 
@@ -363,7 +385,7 @@ const isClockArithmetic = (node: unknown): boolean => {
   if (!isAstNode(node) || node.type !== "BinaryExpression") {
     return false;
   }
-  const operator = node["operator"];
+  const operator = node.operator;
   if (
     operator !== "+" &&
     operator !== "-" &&
@@ -404,6 +426,18 @@ const isFreshClockRead = (node: unknown): boolean => {
 // because they bind no value; `between` is absent because nothing in this
 // codebase applies it to a timestamp column — add it here if that changes.
 const DRIZZLE_COMPARISONS = new Set(["eq", "ne", "gt", "gte", "lt", "lte"]);
+
+const configuredAllowedOperandCalls = (options: unknown): unknown[] => {
+  if (
+    typeof options !== "object" ||
+    options === null ||
+    Array.isArray(options)
+  ) {
+    return [];
+  }
+  const calls = Reflect.get(options, "allowedOperandCalls");
+  return Array.isArray(calls) ? calls : [];
+};
 
 export default eslintCompatPlugin({
   meta: { name: "no-truncated-timestamp-comparison" },
@@ -457,7 +491,7 @@ export default eslintCompatPlugin({
           if (
             !isAstNode(node) ||
             node.type !== "Identifier" ||
-            typeof node["name"] !== "string"
+            typeof node.name !== "string"
           ) {
             return false;
           }
@@ -501,8 +535,8 @@ export default eslintCompatPlugin({
               staticSql,
             );
           if (
-            selected?.groups?.["name"] !== undefined &&
-            isTimestampColumnName(selected.groups["name"])
+            selected?.groups?.name !== undefined &&
+            isTimestampColumnName(selected.groups.name)
           ) {
             return true;
           }
@@ -531,7 +565,7 @@ export default eslintCompatPlugin({
           if (
             !isAstNode(node) ||
             node.type !== "Identifier" ||
-            typeof node["name"] !== "string"
+            typeof node.name !== "string"
           ) {
             return false;
           }
@@ -616,19 +650,12 @@ export default eslintCompatPlugin({
 
         return {
           before() {
-            const options = context.options?.[0] ?? {};
             allowedOperandCalls.clear();
-            const configuredCalls =
-              typeof options === "object" &&
-              options !== null &&
-              !Array.isArray(options)
-                ? options["allowedOperandCalls"]
-                : undefined;
-            if (Array.isArray(configuredCalls)) {
-              for (const call of configuredCalls) {
-                if (typeof call === "string") {
-                  allowedOperandCalls.add(call);
-                }
+            for (const call of configuredAllowedOperandCalls(
+              context.options[0],
+            )) {
+              if (typeof call === "string") {
+                allowedOperandCalls.add(call);
               }
             }
           },
@@ -675,6 +702,26 @@ export default eslintCompatPlugin({
                   index,
                   precedingSql,
                 )
+              ) {
+                continue;
+              }
+              const comparison = findComparisonOperator(before);
+              const comparisonHead =
+                comparison === undefined
+                  ? ""
+                  : before.slice(0, comparison.index);
+              const tupleFirst = TUPLE_COMPARISON.test(before)
+                ? leftTupleFirstIndex(quasis, index)
+                : undefined;
+              const leftComparisonOperand =
+                tupleFirst !== undefined
+                  ? expressions[tupleFirst]
+                  : comparison !== undefined && comparisonHead.trim() === ""
+                    ? expressions[index - 1]
+                    : undefined;
+              if (
+                leftComparisonOperand !== undefined &&
+                hasSameTimestampColumnOwner(leftComparisonOperand, expression)
               ) {
                 continue;
               }
@@ -726,7 +773,11 @@ export default eslintCompatPlugin({
               : isTimestampColumnExpression(right)
                 ? left
                 : undefined;
-            if (operand === undefined || isAllowedOperand(operand)) {
+            if (
+              operand === undefined ||
+              hasSameTimestampColumnOwner(left, right) ||
+              isAllowedOperand(operand)
+            ) {
               return;
             }
             report(operand);

--- a/.oxlint-plugins/no-unjustified-double-assertion.ts
+++ b/.oxlint-plugins/no-unjustified-double-assertion.ts
@@ -28,16 +28,21 @@ import { isAstNode } from "./utils.ts";
 const BROAD_INTERMEDIATE =
   /^(?:unknown|object|Record<(?:string|number|symbol|PropertyKey),(?:unknown|object)>|Readonly<Record<(?:string|number|symbol|PropertyKey),(?:unknown|object)>>)$/u;
 const SAFETY_COMMENT = /\bSAFETY(?::|\s+comment\b)/u;
+const COMMENT_TEXT = /\/\*[\s\S]*?\*\/|\/\/[^\r\n]*/gu;
 const MAX_SAFETY_COMMENT_DISTANCE = 12;
 
-type Comment = { value: string };
+type Comment = { range: [number, number]; value: string };
 
 const isComment = (value: unknown): value is Comment =>
   typeof value === "object" &&
   value !== null &&
   "value" in value &&
   typeof value.value === "string" &&
-  "loc" in value;
+  "loc" in value &&
+  "range" in value &&
+  Array.isArray(value.range) &&
+  value.range.length === 2 &&
+  value.range.every((offset) => typeof offset === "number");
 
 const locationLine = (
   value: unknown,
@@ -112,6 +117,8 @@ export default eslintCompatPlugin({
             return;
           }
           const startLine = locationLine(node, "start");
+          const assertionLineStart =
+            context.sourceCode.text.lastIndexOf("\n", node.range[0] - 1) + 1;
           if (
             startLine !== undefined &&
             comments.some((comment) => {
@@ -120,7 +127,11 @@ export default eslintCompatPlugin({
                 endLine !== undefined &&
                 endLine < startLine &&
                 startLine - endLine <= MAX_SAFETY_COMMENT_DISTANCE &&
-                SAFETY_COMMENT.test(comment.value)
+                SAFETY_COMMENT.test(comment.value) &&
+                context.sourceCode.text
+                  .slice(comment.range[1], assertionLineStart)
+                  .replaceAll(COMMENT_TEXT, "")
+                  .trim() === ""
               );
             })
           ) {

--- a/.oxlint-plugins/no-unjustified-double-assertion.ts
+++ b/.oxlint-plugins/no-unjustified-double-assertion.ts
@@ -1,0 +1,142 @@
+// Require an explicit safety argument for TypeScript double assertions that
+// first widen a value through `unknown`, `object`, or an open record and then
+// assert a narrower contract.
+//
+// A double assertion discards the evidence that lets TypeScript compare the
+// source and target. It is sometimes necessary at a third-party type boundary,
+// but the exception must state the runtime invariant that makes it sound or
+// explicitly point to the canonical safety explanation.
+//
+// Flagged:
+//   value as unknown as Widget
+//   value as Record<string, unknown> as Widget
+//
+// Accepted:
+//   value as Widget
+//   // SAFETY: the adapter constructs every field consumed by Widget.
+//   value as unknown as Widget
+//
+// Boundary: this is a syntax check. It recognizes direct assertion chains and
+// a small set of deliberately broad intermediate spellings. It does not follow
+// aliases or variables, and a SAFETY comment is evidence of review rather than
+// proof that the assertion is sound.
+
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { isAstNode } from "./utils.ts";
+
+const BROAD_INTERMEDIATE =
+  /^(?:unknown|object|Record<(?:string|number|symbol|PropertyKey),(?:unknown|object)>|Readonly<Record<(?:string|number|symbol|PropertyKey),(?:unknown|object)>>)$/u;
+const SAFETY_COMMENT = /\bSAFETY(?::|\s+comment\b)/u;
+const MAX_SAFETY_COMMENT_DISTANCE = 12;
+
+type Comment = { value: string };
+
+const isComment = (value: unknown): value is Comment =>
+  typeof value === "object" &&
+  value !== null &&
+  "value" in value &&
+  typeof value.value === "string" &&
+  "loc" in value;
+
+const locationLine = (
+  value: unknown,
+  edge: "end" | "start",
+): number | undefined => {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("loc" in value) ||
+    typeof value.loc !== "object" ||
+    value.loc === null ||
+    !(edge in value.loc)
+  ) {
+    return undefined;
+  }
+  const point = value.loc[edge];
+  if (
+    typeof point !== "object" ||
+    point === null ||
+    !("line" in point) ||
+    typeof point.line !== "number"
+  ) {
+    return undefined;
+  }
+  return point.line;
+};
+
+const unwrapParentheses = (node: unknown): unknown => {
+  let current = node;
+  while (isAstNode(current) && current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+};
+
+export default eslintCompatPlugin({
+  meta: { name: "no-unjustified-double-assertion" },
+  rules: {
+    "no-unjustified-double-assertion": {
+      meta: {
+        type: "problem",
+        messages: {
+          unjustified:
+            "This double assertion discards source-type evidence. Remove it, " +
+            "narrow or validate the value, or add a nearby safety rationale " +
+            "that states the runtime invariant or references its canonical explanation.",
+        },
+      },
+      createOnce(context) {
+        let comments: readonly Comment[] = [];
+
+        const check = (node: unknown): void => {
+          if (
+            !isAstNode(node) ||
+            (node.type !== "TSAsExpression" && node.type !== "TSTypeAssertion")
+          ) {
+            return;
+          }
+          const inner = unwrapParentheses(node.expression);
+          if (
+            !isAstNode(inner) ||
+            (inner.type !== "TSAsExpression" &&
+              inner.type !== "TSTypeAssertion") ||
+            !isAstNode(inner.typeAnnotation)
+          ) {
+            return;
+          }
+          const intermediate = context.sourceCode
+            .getText(inner.typeAnnotation)
+            .replaceAll(/\s+/gu, "");
+          if (!BROAD_INTERMEDIATE.test(intermediate)) {
+            return;
+          }
+          const startLine = locationLine(node, "start");
+          if (
+            startLine !== undefined &&
+            comments.some((comment) => {
+              const endLine = locationLine(comment, "end");
+              return (
+                endLine !== undefined &&
+                endLine < startLine &&
+                startLine - endLine <= MAX_SAFETY_COMMENT_DISTANCE &&
+                SAFETY_COMMENT.test(comment.value)
+              );
+            })
+          ) {
+            return;
+          }
+          context.report({ node, messageId: "unjustified" });
+        };
+
+        return {
+          Program() {
+            comments = context.sourceCode.getAllComments().filter(isComment);
+          },
+          TSAsExpression: check,
+          TSTypeAssertion: check,
+        };
+      },
+    },
+  },
+});

--- a/.oxlint-plugins/no-unjustified-double-assertion.ts
+++ b/.oxlint-plugins/no-unjustified-double-assertion.ts
@@ -123,11 +123,19 @@ export default eslintCompatPlugin({
             startLine !== undefined &&
             comments.some((comment) => {
               const endLine = locationLine(comment, "end");
+              const commentLineStart =
+                context.sourceCode.text.lastIndexOf(
+                  "\n",
+                  comment.range[0] - 1,
+                ) + 1;
               return (
                 endLine !== undefined &&
                 endLine < startLine &&
                 startLine - endLine <= MAX_SAFETY_COMMENT_DISTANCE &&
                 SAFETY_COMMENT.test(comment.value) &&
+                context.sourceCode.text
+                  .slice(commentLineStart, comment.range[0])
+                  .trim() === "" &&
                 context.sourceCode.text
                   .slice(comment.range[1], assertionLineStart)
                   .replaceAll(COMMENT_TEXT, "")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,21 @@ user-facing strings, ingestion, performance guard failures and hot paths,
 architecture and scale, auth and data access, files and external APIs, tests,
 `apps/web` React effects, and user-facing UI. The skills own the detailed rules.
 
+## Implementation Quality
+
+- Comments explain a non-obvious invariant, trade-off, safety constraint, or why
+  the code exists. Do not narrate the next statement, add empty documentation
+  blocks, or label closing braces.
+- Make abstractions earn their keep. Avoid pass-through wrappers, single-use
+  helpers, and interfaces with one implementation unless they establish a real
+  ownership boundary, contract, or test seam.
+- Prefer deleting concepts, branches, and layers over moving complexity around.
+  Keep feature-specific behavior at its canonical owner; do not scatter flags and
+  special cases through shared flows.
+- Defensive code belongs at real trust and failure boundaries. Do not add null
+  checks, silent fallbacks, or catch-and-log blocks for states already excluded by
+  types, validation, or framework guarantees.
+
 ## Workspace Layout
 
 - `apps/*` contains runnable applications only.

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -1998,7 +1998,6 @@ export const caseLawCorpusIndexSourceReconciliations = p.pgTable(
     ),
     p.check(
       "case_law_source_reconciliations_cursor_upper",
-      // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- column-to-column comparison evaluated in Postgres; no JS Date is bound
       sql`${t.cursorCreatedAt} IS NULL OR (${t.upperCreatedAt} IS NOT NULL AND (${t.cursorCreatedAt}, ${t.cursorId}) <= (${t.upperCreatedAt}, ${t.upperId}))`,
     ),
     p

--- a/apps/api/src/db/schema/chat.ts
+++ b/apps/api/src/db/schema/chat.ts
@@ -477,12 +477,10 @@ export const chatTurns = p.pgTable(
     ),
     p.check(
       "chat_turns_lease_after_created_check",
-      // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- column-to-column comparison evaluated in Postgres; no JS Date is bound
       sql`${table.leaseExpiresAt} IS NULL OR ${table.leaseExpiresAt} > ${table.createdAt}`,
     ),
     p.check(
       "chat_turns_settled_after_created_check",
-      // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- column-to-column comparison evaluated in Postgres; no JS Date is bound
       sql`${table.settledAt} IS NULL OR ${table.settledAt} >= ${table.createdAt}`,
     ),
     p.index("chat_turns_thread_id_idx").on(table.threadId),

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -185,6 +185,9 @@ const fixtureRuleOverrides = [
   fixtureRuleOverride("no-unbranded-ownership-id-param.fixture.ts", [
     "no-unbranded-ownership-id-param/no-unbranded-ownership-id-param",
   ]),
+  fixtureRuleOverride("no-unjustified-double-assertion.fixture.ts", [
+    "no-unjustified-double-assertion/no-unjustified-double-assertion",
+  ]),
   fixtureRuleOverride("no-untranslated-jsx-literal.fixture.tsx", [
     "no-untranslated-jsx-literal/no-untranslated-jsx-literal",
   ]),
@@ -498,6 +501,7 @@ export default defineConfig({
     "no-raw-date-input/no-raw-date-input": "error",
     "stella-lowercase/stella-lowercase": "error",
     "no-unvalidated-json-domain-cast/no-unvalidated-json-domain-cast": "error",
+    "no-unjustified-double-assertion/no-unjustified-double-assertion": "error",
     "no-partial-record-satisfies/no-partial-record-satisfies": "error",
     "no-raw-public-law-seo/no-raw-public-law-seo": "off",
     "public-case-law-db-boundary/public-case-law-db-boundary": "off",
@@ -734,6 +738,7 @@ export default defineConfig({
     "./.oxlint-plugins/no-inline-endpoint-in-routes.ts",
     "./.oxlint-plugins/security-guards.ts",
     "./.oxlint-plugins/no-unbranded-ownership-id-param.ts",
+    "./.oxlint-plugins/no-unjustified-double-assertion.ts",
     "./.oxlint-plugins/no-raw-user-id-schema.ts",
     "./.oxlint-plugins/no-offset-pagination.ts",
     "./.oxlint-plugins/require-query-limit.ts",
@@ -3001,6 +3006,18 @@ export default defineConfig({
       },
     },
     {
+      // The fixture deliberately asserts open inputs into closed contracts to
+      // exercise the justification rule. Native assertion diagnostics would
+      // duplicate those expected violations rather than test this detector.
+      files: [
+        ".oxlint-plugins/__fixtures__/no-unjustified-double-assertion.fixture.ts",
+      ],
+      rules: {
+        "typescript/no-unsafe-type-assertion": "off",
+        "typescript/no-unnecessary-type-assertion": "off",
+      },
+    },
+    {
       files: [
         "**/*.{test,spec}.{ts,tsx,js,jsx}",
         "**/__tests__/**/*.{ts,tsx,js,jsx}",
@@ -3024,6 +3041,8 @@ export default defineConfig({
         "no-raw-user-id-schema/no-raw-user-id-schema": "off",
         "no-untyped-updates/no-untyped-updates": "off",
         "no-unbranded-ownership-id-param/no-unbranded-ownership-id-param":
+          "off",
+        "no-unjustified-double-assertion/no-unjustified-double-assertion":
           "off",
         "no-raw-colors/no-raw-colors": "off",
         "no-physical-properties/no-physical-properties": "off",

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -241,7 +241,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 747,
+    "count": 744,
     "files": {
       "apps/api/scripts/ai-provider-canary-config.ts": 1,
       "apps/api/scripts/ai-provider-canary.ts": 4,
@@ -263,8 +263,6 @@
       "apps/api/scripts/seed-usage-policies.ts": 1,
       "apps/api/src/db/migrate.ts": 2,
       "apps/api/src/db/schema.ts": 1,
-      "apps/api/src/db/schema/case-law.ts": 1,
-      "apps/api/src/db/schema/chat.ts": 2,
       "apps/api/src/dev/register-mock-ai.ts": 1,
       "apps/api/src/handlers/agent-auth/events.ts": 1,
       "apps/api/src/handlers/ai-autocomplete/stream.ts": 1,


### PR DESCRIPTION
## Summary

- add a Stella-local Oxlint rule requiring an explicit safety rationale for broad TypeScript double assertions
- cover unknown, object, and open-record assertion chains with a passive regression fixture while exempting test doubles
- bind safety rationales to assertions with no intervening executable statement
- recognize database-native same-schema timestamp comparisons and remove three obsolete lint suppressions
- expand generated agent guidance for meaningful comments, earned abstractions, real defensive boundaries, observable behavior, and snapshots

## Validation

- the pre-push affected code-quality gate passes: all-package lint plus API, web, legal-atlas, and repository typechecks
- Oxlint plugin registry, fixture suite, AI prompt sync, formatting, i18n, and ratchet checks pass
- mutation checks confirmed both new fixture cases fail against the pre-fix rule behavior
- the lint-suppression ratchet tightens from 747 to 744

CC on behalf of jan-kubica
