### PR TITLE
fix: repair corpus projection delete guard

### DIFF
--- a/apps/api/drizzle/20260825211300_corpus_projection_delete_guard_record/migration.sql
+++ b/apps/api/drizzle/20260825211300_corpus_projection_delete_guard_record/migration.sql
@@ -1,0 +1,37 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION "guard_corpus_index_projection_history_delete"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM "corpus_index_generations" generation
+    WHERE generation."family" = OLD."family"
+      AND generation."generation" = OLD."generation"
+      AND generation."status" = 'retired'
+  ) THEN
+    RAISE EXCEPTION 'corpus index projection history requires a retired generation';
+  END IF;
+
+  IF TG_TABLE_NAME = 'corpus_index_projection_intents'
+     AND (to_jsonb(OLD)->>'status') NOT IN ('settled', 'cancelled') THEN
+    RAISE EXCEPTION 'nonterminal corpus index projection intent cannot be deleted';
+  END IF;
+
+  IF TG_TABLE_NAME = 'corpus_index_projection_states' AND EXISTS (
+    SELECT 1
+    FROM "corpus_index_projection_intents" intent
+    WHERE intent."family" = OLD."family"
+      AND intent."generation" = OLD."generation"
+      AND intent."entity_id" = OLD."entity_id"
+      AND intent."status" NOT IN ('settled', 'cancelled')
+  ) THEN
+    RAISE EXCEPTION 'projection state with nonterminal intents cannot be deleted';
+  END IF;
+
+  RETURN OLD;
+END;
+$$;

--- a/apps/api/src/db/schema/corpus-index-projections.ts
+++ b/apps/api/src/db/schema/corpus-index-projections.ts
@@ -227,19 +227,17 @@ export const corpusIndexProjectionIntents = p.pgTable(
     ),
     p.check(
       "corpus_index_projection_intents_cleanup_order",
-      // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- column-to-column comparison evaluated in Postgres; no JS Date is bound
       sql`${t.cleanupNotBefore} IS NULL OR (
-        ${t.cleanupNotBefore} >= ${t.appendPublishBarrierAt}
-        AND (${t.cleanupStartedAt} IS NULL OR ${t.cleanupStartedAt} >= ${t.cleanupNotBefore})
-        AND (${t.settledAt} IS NULL OR ${t.settledAt} >= ${t.cleanupStartedAt})
+        ${t.cleanupNotBefore}::timestamptz >= ${t.appendPublishBarrierAt}::timestamptz
+        AND (${t.cleanupStartedAt} IS NULL OR ${t.cleanupStartedAt}::timestamptz >= ${t.cleanupNotBefore}::timestamptz)
+        AND (${t.settledAt} IS NULL OR ${t.settledAt}::timestamptz >= ${t.cleanupStartedAt}::timestamptz)
       )`,
     ),
     p.check(
       "corpus_index_projection_intents_append_order",
-      // oxlint-disable-next-line no-truncated-timestamp-comparison/no-truncated-timestamp-comparison -- column-to-column comparison evaluated in Postgres; no JS Date is bound
-      sql`(${t.appendCommittedAt} IS NULL OR ${t.appendCommittedAt} >= ${t.appendStartedAt})
-        AND (${t.appliedAt} IS NULL OR ${t.appliedAt} >= ${t.appendCommittedAt})
-        AND (${t.appendPublishBarrierAt} IS NULL OR ${t.appendPublishBarrierAt} >= ${t.appendStartedAt})`,
+      sql`(${t.appendCommittedAt} IS NULL OR ${t.appendCommittedAt}::timestamptz >= ${t.appendStartedAt}::timestamptz)
+        AND (${t.appliedAt} IS NULL OR ${t.appliedAt}::timestamptz >= ${t.appendCommittedAt}::timestamptz)
+        AND (${t.appendPublishBarrierAt} IS NULL OR ${t.appendPublishBarrierAt}::timestamptz >= ${t.appendStartedAt}::timestamptz)`,
     ),
     ...globalCaseLawPolicies(),
   ],

--- a/apps/api/src/lib/legal-search/corpus-index-projections.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projections.db.test.ts
@@ -8,10 +8,16 @@ import {
 } from "@/api/lib/legal-search/corpus-index-projection-contract";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
-const MIGRATION_URL = new URL(
-  "../../../drizzle/20260825142000_corpus_index_projection_intents/migration.sql",
-  import.meta.url,
-);
+const MIGRATION_URLS = [
+  new URL(
+    "../../../drizzle/20260825142000_corpus_index_projection_intents/migration.sql",
+    import.meta.url,
+  ),
+  new URL(
+    "../../../drizzle/20260825211300_corpus_projection_delete_guard_record/migration.sql",
+    import.meta.url,
+  ),
+] as const;
 const SOURCE_ID = "0198e331-e578-7000-8000-000000000001";
 const FIRST_DECISION_ID = "0198e331-e578-7000-8000-000000000002";
 const RACED_DECISION_ID = "0198e331-e578-7000-8000-000000000003";
@@ -87,20 +93,25 @@ beforeAll(
       )
     `);
 
-    const migration = await Bun.file(MIGRATION_URL).text();
-    for (const statement of migration.split("--> statement-breakpoint")) {
-      const ddl = statement.trim();
-      if (
-        !ddl.startsWith("CREATE FUNCTION") &&
-        !ddl.startsWith("CREATE TRIGGER") &&
-        !ddl.includes(
-          'FUNCTION "purge_retired_corpus_index_projection_history"',
-        )
-      ) {
-        continue;
+    for (const migrationUrl of MIGRATION_URLS) {
+      // oxlint-disable-next-line no-await-in-loop -- migrations and their dependent DDL must replay in committed order
+      const migration = await Bun.file(migrationUrl).text();
+      for (const statement of migration.split("--> statement-breakpoint")) {
+        const ddl = statement.trim();
+        const uncommentedDdl = ddl.replace(/^(?:--[^\n]*(?:\n|$)\s*)+/u, "");
+        if (
+          !uncommentedDdl.startsWith("CREATE FUNCTION") &&
+          !uncommentedDdl.startsWith("CREATE OR REPLACE FUNCTION") &&
+          !uncommentedDdl.startsWith("CREATE TRIGGER") &&
+          !uncommentedDdl.includes(
+            'FUNCTION "purge_retired_corpus_index_projection_history"',
+          )
+        ) {
+          continue;
+        }
+        // oxlint-disable-next-line no-await-in-loop -- ordered migration-owned functions and dependent triggers
+        await db.execute(sql.raw(ddl));
       }
-      // oxlint-disable-next-line no-await-in-loop -- ordered migration-owned functions and dependent triggers
-      await db.execute(sql.raw(ddl));
     }
   },
   { timeout: 120_000 },


### PR DESCRIPTION
## Summary

- replace the shared corpus projection delete guard with record-safe status access
- replay both the original and forward migration in the database contract test
- make timestamp precision explicit without lint suppressions

## Root cause

The delete trigger function is shared by intent and state history tables, but it referenced `OLD.status`; state rows do not have that field. The migration replay helper also skipped commented function DDL, so the test did not install the same trigger contract as production.

## Verification

- `bun run verify`
- corpus projection database contract: 7 tests, 100 assertions
- migration safety check
- suppression/type-cost ratchet
- mandatory pre-push lint, typecheck, formatting, and i18n checks

The regression test failed first on the missing trigger function, then on `record "old" has no field "status"`; it passes with the forward migration.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to prevent removal of corpus projection history while related generations or projection processes remain active.
  * Improved validation of projection intent ordering and state transitions.
  * Ensured successful deletions return the affected record consistently.

* **Tests**
  * Updated database migration test coverage to validate the new deletion safeguards and related trigger behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->