### PR TITLE
fix: exclude tooling dependencies from docs catalog

### DIFF
--- a/.claude/mcp/doc-sources.ts
+++ b/.claude/mcp/doc-sources.ts
@@ -27,7 +27,6 @@ export const DOC_SOURCES = {
     url: "https://atlassian.design/llms.txt",
   },
   Valibot: { dependency: "valibot", url: "https://valibot.dev/llms.txt" },
-  Zod: { dependency: "zod", url: "https://zod.dev/llms.txt" },
   TipTap: {
     dependency: "@tiptap/core",
     url: "https://tiptap.dev/llms.txt",

--- a/scripts/docs-source-dependency-guard.test.ts
+++ b/scripts/docs-source-dependency-guard.test.ts
@@ -13,7 +13,7 @@ describe("documentation source dependency guard", () => {
     expect(checkDocSourceDependencies(`${import.meta.dir}/..`)).toEqual([]);
   });
 
-  test("discovers dependencies declared by the documentation MCP", () => {
+  test("excludes dependencies declared only by the documentation MCP", () => {
     const root = mkdtempSync(path.join(tmpdir(), "stella-doc-sources-"));
     try {
       mkdirSync(path.join(root, ".claude", "mcp"), { recursive: true });
@@ -25,7 +25,7 @@ describe("documentation source dependency guard", () => {
         JSON.stringify({ dependencies: { "mcp-only-dependency": "1.0.0" } }),
       );
 
-      expect(getDeclaredDocSourceDependencies(root)).toContain(
+      expect(getDeclaredDocSourceDependencies(root)).not.toContain(
         "mcp-only-dependency",
       );
     } finally {

--- a/scripts/docs-source-dependency-guard.ts
+++ b/scripts/docs-source-dependency-guard.ts
@@ -25,10 +25,6 @@ const readManifestDependencies = (manifestPath: string): string[] => {
 
 const getDependencyManifestPaths = (root: string): string[] => {
   const manifests = [path.join(root, "package.json")];
-  const docsMcpManifest = path.join(root, ".claude", "mcp", "package.json");
-  if (existsSync(docsMcpManifest)) {
-    manifests.push(docsMcpManifest);
-  }
   for (const workspaceRoot of ["apps", "packages"]) {
     const directory = path.join(root, workspaceRoot);
     for (const entry of readdirSync(directory, { withFileTypes: true })) {


### PR DESCRIPTION
## Summary

- scope documentation sources to direct root and workspace-package dependencies
- exclude documentation MCP implementation dependencies from the catalog invariant
- remove the Zod documentation source and cover the boundary with a regression test