### PR TITLE
fix: refresh self-host environment example

### DIFF
--- a/deploy/selfhost/.env.example
+++ b/deploy/selfhost/.env.example
@@ -252,6 +252,16 @@ S3_REGION="us-east-1"
 # [internal] Optional. Corpus index endpoint.
 # CORPUS_INDEX_ENDPOINT=""
 
+# [internal] Optional. Local-development-only read endpoint for Quickwit 0.9.
+# Unset uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.
+# CORPUS_INDEX_Q09_SEARCH_ENDPOINT=""
+
+# [internal] Conditionally required when CORPUS_INDEXING_ENABLED is true and
+# LEGAL_SEARCH_INDEX_GENERATION is case_law_v5. Isolated Quickwit 0.9 mutation
+# endpoint. Final generations registered on q09 use this endpoint; it never
+# falls back to the legacy cluster.
+# CORPUS_INDEX_Q09_ENDPOINT=""
+
 # [internal] Optional. Corpus index s3 bucket.
 # CORPUS_INDEX_S3_BUCKET=""
 

--- a/deploy/selfhost/.env.example
+++ b/deploy/selfhost/.env.example
@@ -256,10 +256,10 @@ S3_REGION="us-east-1"
 # Unset uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.
 # CORPUS_INDEX_Q09_SEARCH_ENDPOINT=""
 
-# [internal] Conditionally required when CORPUS_INDEXING_ENABLED is true and
-# LEGAL_SEARCH_INDEX_GENERATION is case_law_v5. Isolated Quickwit 0.9 mutation
-# endpoint. Final generations registered on q09 use this endpoint; it never
-# falls back to the legacy cluster.
+# [internal] Conditionally required for case_law_v5 when LEGAL_SEARCH_PROVIDER
+# is corpus-index (serving), or when CORPUS_INDEXING_ENABLED is true (indexing).
+# Isolated Quickwit 0.9 mutation endpoint. Final generations registered on q09
+# use this endpoint; it never falls back to the legacy cluster.
 # CORPUS_INDEX_Q09_ENDPOINT=""
 
 # [internal] Optional. Corpus index s3 bucket.


### PR DESCRIPTION
## Proposed change

Regenerate `deploy/selfhost/.env.example` so it includes the existing Quickwit 0.9 read and mutation endpoint settings from the canonical environment schema.

## Validation

- `bun run selfhost:check`
- `bun run verify`
- pre-push checks

## Checklist

- [x] **YES** BUILD ASSURANCE | Code builds correctly and without errors or warnings.
- [x] **YES** TESTING | The generated self-host contract and repository verifier pass.
- [x] **NOT APPLICABLE** DARK MODE SUPPORT | No user interface changes.
- [ ] **NO** ISSUE LINKED | No linked issue.
- [x] **NOT APPLICABLE** SCREENSHOT INCLUDED | Generated configuration documentation only.