### PR TITLE
fix: guard Better Auth production cutover

### DIFF
--- a/.github/actions/promote-dispatch/action.yml
+++ b/.github/actions/promote-dispatch/action.yml
@@ -55,6 +55,10 @@ inputs:
       main-<sha> refs; for tagged releases the tag is the checkout target.
     required: false
     default: ""
+  better-auth-cutover-authorization:
+    description: One-time Better Auth 1.7 production cutover authorization
+    required: false
+    default: blocked
 
 runs:
   using: composite
@@ -73,6 +77,7 @@ runs:
         IMAGE_DIGEST: ${{ inputs.image-digest }}
         WEB_IMAGE_DIGEST: ${{ inputs.web-image-digest }}
         GIT_SHA: ${{ inputs.git-sha }}
+        BETTER_AUTH_CUTOVER_AUTHORIZATION: ${{ inputs.better-auth-cutover-authorization }}
       run: |
         set -euo pipefail
 
@@ -179,6 +184,7 @@ runs:
           -f "inputs[target_environment]=${TARGET_ENV}"
           -f "inputs[run_migrations]=${RUN_MIGRATIONS}"
           -f "inputs[frontend]=${FRONTEND}"
+          -f "inputs[better_auth_cutover_authorization]=${BETTER_AUTH_CUTOVER_AUTHORIZATION}"
         )
         # Only sent when set: promote-release.yml rejects git_sha on tagged
         # releases, where a populated value would silently swap the checked-out

--- a/.github/cutovers/better-auth-17-required
+++ b/.github/cutovers/better-auth-17-required
@@ -1,0 +1,5 @@
+The Better Auth 1.7 production cutover has not completed.
+
+Stable releases containing this marker require the explicit Better Auth
+cutover authorization. Remove the marker in a reviewed follow-up only after
+the production cutover and canaries have completed successfully.

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -11,6 +11,7 @@ on:
       - "apps/api/drizzle.config.ts"
       - "scripts/check-migration-safety.ts"
       - "scripts/check-migrations.sh"
+      - "scripts/rehearse-better-auth-constraint-retry.sh"
       - ".squawk.toml"
       - ".github/workflows/db-migrations.yml"
       - ".github/workflows/release.yml"

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -137,6 +137,13 @@ jobs:
             exit 1
           }
 
+      - name: Rehearse interrupted Better Auth constraints migration
+        env:
+          DATABASE_URL: postgres://stella_owner:stella@127.0.0.1:5432/stella
+        run: >-
+          bash scripts/rehearse-better-auth-constraint-retry.sh
+          --local-test-database
+
       - name: Reject inconsistent migration history
         env:
           DATABASE_URL: postgres://stella_owner:stella@127.0.0.1:5432/stella

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,14 @@ on:
         description: "Git tag to publish, for example v1.2.3 or v1.2.3-rc.1"
         required: true
         type: string
+      better_auth_cutover_authorization:
+        description: "Authorize the one-time Better Auth 1.7 production cutover"
+        required: true
+        default: blocked
+        type: choice
+        options:
+          - blocked
+          - approved
 
 # Every job declares its own least-privilege block.
 permissions: {}
@@ -99,6 +107,22 @@ jobs:
           file_version="$(tr -d '[:space:]' < VERSION)"
           if [[ "$file_version" != "$VERSION" ]]; then
             echo "::error::VERSION ($file_version) does not match $RELEASE_REF"
+            exit 1
+          fi
+
+      - name: Guard Better Auth production cutover
+        env:
+          CUTOVER_AUTHORIZATION: ${{ github.event_name == 'workflow_dispatch' && inputs.better_auth_cutover_authorization || 'blocked' }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_REF: ${{ steps.release.outputs.ref }}
+        run: |
+          if [[ "$RELEASE_REF" == *-* ]] \
+              || [[ ! -f .github/cutovers/better-auth-17-required ]]; then
+            exit 0
+          fi
+          if [[ "$EVENT_NAME" != "workflow_dispatch" \
+              || "$CUTOVER_AUTHORIZATION" != "approved" ]]; then
+            echo "::error::This stable tag is the Better Auth 1.7 production cutover. Re-run this workflow manually with explicit cutover authorization after every rehearsal gate is green."
             exit 1
           fi
 
@@ -960,6 +984,7 @@ jobs:
           release-ref: ${{ needs.resolve.outputs.release_ref }}
           target-environment: production
           web-image-digest: ${{ needs.prepare-web-image.outputs.digest }}
+          better-auth-cutover-authorization: ${{ inputs.better_auth_cutover_authorization || 'blocked' }}
 
       # Swap the workspace to the release being promoted: the verification
       # script must come from that revision, not from the workflow's.

--- a/apps/api/drizzle/20260825220000_better_auth_17_constraints/migration.sql
+++ b/apps/api/drizzle/20260825220000_better_auth_17_constraints/migration.sql
@@ -1,14 +1,28 @@
 SET lock_timeout = '2s';--> statement-breakpoint
 SET statement_timeout = '30s';--> statement-breakpoint
 
--- The trusted backfill has already proved every existing (issuer, account_id)
--- pair is complete and collision-free. Build the new identity key without
--- blocking reads or writes; the deployment runbook keeps application writers
--- scaled to zero until the 1.7 image is ready.
-SET statement_timeout = 0;--> statement-breakpoint
-SET lock_timeout = 0;--> statement-breakpoint
+-- Refuse the cutover before committing any constraint state or index work when
+-- the trusted backfill is incomplete. DROP + ADD makes every later retry
+-- converge if an earlier run committed this check but stopped before Drizzle
+-- recorded the migration receipt.
+-- stella-migration-safety: reviewed drop-constraint - Retry cleanup removes
+-- only this migration's temporary validation proof and recreates it below in
+-- the same transaction.
+ALTER TABLE "account"
+  DROP CONSTRAINT IF EXISTS "account_issuer_not_null_check";--> statement-breakpoint
+ALTER TABLE "account"
+  ADD CONSTRAINT "account_issuer_not_null_check"
+  CHECK ("issuer" IS NOT NULL) NOT VALID;--> statement-breakpoint
+ALTER TABLE "account"
+  VALIDATE CONSTRAINT "account_issuer_not_null_check";--> statement-breakpoint
 -- squawk-ignore transaction-nesting
 COMMIT;--> statement-breakpoint
+
+-- The validated check proves every existing identity has an issuer. Build the
+-- unique identity key without blocking reads or writes; the deployment runbook
+-- keeps application writers frozen until the 1.7 image is ready.
+SET statement_timeout = 0;--> statement-breakpoint
+SET lock_timeout = 0;--> statement-breakpoint
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
   "account_issuer_account_id_uidx"
   ON "account" ("issuer", "account_id");--> statement-breakpoint
@@ -19,21 +33,6 @@ REINDEX INDEX CONCURRENTLY "account_issuer_account_id_uidx";--> statement-breakp
 BEGIN;--> statement-breakpoint
 SET lock_timeout = '2s';--> statement-breakpoint
 SET statement_timeout = '30s';--> statement-breakpoint
-
--- This is deliberately fail-closed. An accidental candidate deploy before
--- the sealed backfill leaves NULL issuers and must stop here rather than start
--- Better Auth 1.7 against ambiguous account identities.
-ALTER TABLE "account"
-  ADD CONSTRAINT "account_issuer_not_null_check"
-  CHECK ("issuer" IS NOT NULL) NOT VALID;--> statement-breakpoint
--- squawk-ignore transaction-nesting
-COMMIT;--> statement-breakpoint
--- squawk-ignore transaction-nesting, ban-uncommitted-transaction
-BEGIN;--> statement-breakpoint
-SET lock_timeout = '2s';--> statement-breakpoint
-SET statement_timeout = '30s';--> statement-breakpoint
-ALTER TABLE "account"
-  VALIDATE CONSTRAINT "account_issuer_not_null_check";--> statement-breakpoint
 -- The validated check lets PostgreSQL promote the column without a table scan.
 -- squawk-ignore adding-not-nullable-field
 ALTER TABLE "account"

--- a/apps/api/drizzle/20260825220000_better_auth_17_constraints/migration.sql
+++ b/apps/api/drizzle/20260825220000_better_auth_17_constraints/migration.sql
@@ -4,7 +4,15 @@ SET statement_timeout = '30s';--> statement-breakpoint
 -- Refuse the cutover before committing any constraint state or index work when
 -- the trusted backfill is incomplete. DROP + ADD makes every later retry
 -- converge if an earlier run committed this check but stopped before Drizzle
--- recorded the migration receipt.
+-- recorded the migration receipt. The operational write freeze prevents a new
+-- NULL between this precondition and the constraint becoming enforced.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "account" WHERE "issuer" IS NULL) THEN
+    RAISE EXCEPTION 'account_issuer_not_null_check: issuer backfill is incomplete';
+  END IF;
+END
+$$;--> statement-breakpoint
 -- stella-migration-safety: reviewed drop-constraint - Retry cleanup removes
 -- only this migration's temporary validation proof and recreates it below in
 -- the same transaction.
@@ -13,6 +21,15 @@ ALTER TABLE "account"
 ALTER TABLE "account"
   ADD CONSTRAINT "account_issuer_not_null_check"
   CHECK ("issuer" IS NOT NULL) NOT VALID;--> statement-breakpoint
+-- squawk-ignore transaction-nesting
+COMMIT;--> statement-breakpoint
+
+-- Validate outside the ADD CONSTRAINT transaction so the table scan does not
+-- hold the stronger ADD lock. The NOT VALID check already rejects new NULLs.
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;--> statement-breakpoint
+SET lock_timeout = '2s';--> statement-breakpoint
+SET statement_timeout = '30s';--> statement-breakpoint
 ALTER TABLE "account"
   VALIDATE CONSTRAINT "account_issuer_not_null_check";--> statement-breakpoint
 -- squawk-ignore transaction-nesting

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -84,6 +84,10 @@ const APPROVED_PROCEDURAL_STATEMENTS = new Set([
   // body is static DDL; the conditional makes the file retryable after the
   // VALIDATE that follows it outside the migrator transaction.
   "20260818090000_case_law_decision_date_bounds/migration.sql:31f2786a7f7aed2d2e55bd3161acad6ad49e606ec1bc75e9235de07cdadd96e0",
+  // Fails the Better Auth cutover before any constraint or index state is
+  // committed when the trusted issuer backfill is incomplete. The static body
+  // performs one bounded existence read and raises; it executes no dynamic SQL.
+  "20260825220000_better_auth_17_constraints/migration.sql:4c1e0d5fdbb50e29863c067586c405148beb02f76a2af8ebbced851a866abc13",
 ]);
 
 type TimeoutState = "bounded" | "unbounded" | "unset";

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -362,6 +362,49 @@ describe("API deployment health receipt", () => {
     expect(desktopCarry).toContain("bash scripts/promote-desktop-release.sh");
   });
 
+  test("requires an explicit Better Auth production cutover dispatch", async () => {
+    const [releaseWorkflow, promoteAction, cutoverMarker] = await Promise.all([
+      Bun.file(
+        new URL("../.github/workflows/release.yml", import.meta.url),
+      ).text(),
+      Bun.file(
+        new URL(
+          "../.github/actions/promote-dispatch/action.yml",
+          import.meta.url,
+        ),
+      ).text(),
+      Bun.file(
+        new URL("../.github/cutovers/better-auth-17-required", import.meta.url),
+      ).text(),
+    ]);
+    const guardStart = releaseWorkflow.indexOf(
+      "- name: Guard Better Auth production cutover",
+    );
+    const receiptStart = releaseWorkflow.indexOf(
+      "- name: Write trusted release receipt",
+    );
+
+    expect(cutoverMarker).toContain(
+      "Better Auth 1.7 production cutover has not completed",
+    );
+    expect(releaseWorkflow).toContain("better_auth_cutover_authorization:");
+    expect(releaseWorkflow).toContain("default: blocked");
+    expect(releaseWorkflow).toContain(`EVENT_NAME: \${{ github.event_name }}`);
+    expect(releaseWorkflow).toContain(
+      `[[ "$EVENT_NAME" != "workflow_dispatch"`,
+    );
+    expect(releaseWorkflow).toContain(`"$CUTOVER_AUTHORIZATION" != "approved"`);
+    expect(guardStart).toBeGreaterThanOrEqual(0);
+    expect(receiptStart).toBeGreaterThan(guardStart);
+    expect(releaseWorkflow).toContain(
+      `better-auth-cutover-authorization: \${{ inputs.better_auth_cutover_authorization || 'blocked' }}`,
+    );
+    expect(promoteAction).toContain("better-auth-cutover-authorization:");
+    expect(promoteAction).toContain(
+      `inputs[better_auth_cutover_authorization]=\${BETTER_AUTH_CUTOVER_AUTHORIZATION}`,
+    );
+  });
+
   test("gates API releases on readiness", async () => {
     const [deploymentScript, releaseWorkflow, publishWorkflow] =
       await Promise.all([

--- a/scripts/rehearse-better-auth-constraint-retry.sh
+++ b/scripts/rehearse-better-auth-constraint-retry.sh
@@ -10,6 +10,7 @@ fi
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 readonly repo_root
 readonly constraints_migration="20260825220000_better_auth_17_constraints"
+readonly constraints_sql="$repo_root/apps/api/drizzle/$constraints_migration/migration.sql"
 
 if [[ -z "${DATABASE_URL:-}" ]]; then
   echo "DATABASE_URL is required" >&2
@@ -20,12 +21,27 @@ if [[ ! "$DATABASE_URL" =~ @127\.0\.0\.1:[0-9]+/ ]]; then
   exit 1
 fi
 
-latest_migration="$(
-  find "$repo_root/apps/api/drizzle" -mindepth 1 -maxdepth 1 -type d -name '20*' \
-    -exec basename {} \; | sort | tail -1
+if command -v sha256sum >/dev/null 2>&1; then
+  constraints_hash="$(sha256sum "$constraints_sql" | awk '{ print $1 }')"
+elif command -v shasum >/dev/null 2>&1; then
+  constraints_hash="$(shasum -a 256 "$constraints_sql" | awk '{ print $1 }')"
+else
+  echo "sha256sum or shasum is required" >&2
+  exit 1
+fi
+readonly constraints_hash
+
+recorded_constraints="$(
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -At \
+    -v constraints_migration="$constraints_migration" \
+    -v constraints_hash="$constraints_hash" <<'SQL'
+SELECT count(*) FROM drizzle.__drizzle_migrations
+WHERE name = :'constraints_migration'
+  AND hash = :'constraints_hash';
+SQL
 )"
-if [[ "$latest_migration" != "$constraints_migration" ]]; then
-  echo "Expected $constraints_migration to remain the latest migration; found $latest_migration" >&2
+if [[ "$recorded_constraints" -ne 1 ]]; then
+  echo "Expected exactly one matching Better Auth constraints migration receipt" >&2
   exit 1
 fi
 
@@ -34,7 +50,9 @@ recorded_before="$(
     'SELECT count(*) FROM drizzle.__drizzle_migrations'
 )"
 
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+  -v constraints_migration="$constraints_migration" \
+  -v constraints_hash="$constraints_hash" <<'SQL' >/dev/null
 BEGIN;
 DROP INDEX "account_issuer_account_id_uidx";
 ALTER TABLE "account"
@@ -49,7 +67,8 @@ VALUES (
   'constraint-retry-user', NULL, now()
 );
 DELETE FROM drizzle.__drizzle_migrations
-WHERE id = (SELECT max(id) FROM drizzle.__drizzle_migrations);
+WHERE name = :'constraints_migration'
+  AND hash = :'constraints_hash';
 COMMIT;
 SQL
 
@@ -94,7 +113,9 @@ SQL
   bun run src/db/migrate.ts
 )
 
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+  -v constraints_migration="$constraints_migration" \
+  -v constraints_hash="$constraints_hash" <<'SQL' >/dev/null
 BEGIN;
 ALTER TABLE "account"
   ALTER COLUMN "issuer" DROP NOT NULL;
@@ -102,7 +123,8 @@ ALTER TABLE "account"
   ADD CONSTRAINT "account_issuer_not_null_check"
   CHECK ("issuer" IS NOT NULL) NOT VALID;
 DELETE FROM drizzle.__drizzle_migrations
-WHERE id = (SELECT max(id) FROM drizzle.__drizzle_migrations);
+WHERE name = :'constraints_migration'
+  AND hash = :'constraints_hash';
 COMMIT;
 SQL
 

--- a/scripts/rehearse-better-auth-constraint-retry.sh
+++ b/scripts/rehearse-better-auth-constraint-retry.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 || "$1" != "--local-test-database" ]]; then
+  echo "usage: $0 --local-test-database" >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+readonly repo_root
+readonly constraints_migration="20260825220000_better_auth_17_constraints"
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "DATABASE_URL is required" >&2
+  exit 1
+fi
+if [[ ! "$DATABASE_URL" =~ @127\.0\.0\.1:[0-9]+/ ]]; then
+  echo "The constraint retry rehearsal requires a loopback Postgres URL" >&2
+  exit 1
+fi
+
+latest_migration="$(
+  find "$repo_root/apps/api/drizzle" -mindepth 1 -maxdepth 1 -type d -name '20*' \
+    -exec basename {} \; | sort | tail -1
+)"
+if [[ "$latest_migration" != "$constraints_migration" ]]; then
+  echo "Expected $constraints_migration to remain the latest migration; found $latest_migration" >&2
+  exit 1
+fi
+
+recorded_before="$(
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -Atc \
+    'SELECT count(*) FROM drizzle.__drizzle_migrations'
+)"
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
+BEGIN;
+DROP INDEX "account_issuer_account_id_uidx";
+ALTER TABLE "account"
+  ALTER COLUMN "issuer" DROP NOT NULL;
+INSERT INTO "user" ("id", "name", "email")
+VALUES ('constraint-retry-user', 'Constraint Retry', 'constraint-retry@example.invalid');
+INSERT INTO "account" (
+  "id", "account_id", "provider_id", "user_id", "issuer", "updated_at"
+)
+VALUES (
+  'constraint-retry-account', 'constraint-retry', 'google',
+  'constraint-retry-user', NULL, now()
+);
+DELETE FROM drizzle.__drizzle_migrations
+WHERE id = (SELECT max(id) FROM drizzle.__drizzle_migrations);
+COMMIT;
+SQL
+
+failure_log="$(mktemp)"
+readonly failure_log
+trap 'rm -f "$failure_log"' EXIT
+if (
+  cd "$repo_root/apps/api"
+  bun run src/db/migrate.ts
+) >"$failure_log" 2>&1; then
+  echo "Constraints migration accepted an incomplete issuer backfill" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'account_issuer_not_null_check' "$failure_log"; then
+  echo "Constraints migration failed for an unrelated reason" >&2
+  tail -40 "$failure_log" >&2
+  exit 1
+fi
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -Atc "
+SELECT
+  NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.account'::regclass
+      AND conname = 'account_issuer_not_null_check'
+  )
+  AND to_regclass('public.account_issuer_account_id_uidx') IS NULL;
+" | grep -qx t || {
+  echo "Incomplete backfill left committed constraint side effects" >&2
+  exit 1
+}
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
+DELETE FROM "account" WHERE "id" = 'constraint-retry-account';
+DELETE FROM "user" WHERE "id" = 'constraint-retry-user';
+SQL
+
+(
+  cd "$repo_root/apps/api"
+  bun run src/db/migrate.ts
+)
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
+BEGIN;
+ALTER TABLE "account"
+  ALTER COLUMN "issuer" DROP NOT NULL;
+ALTER TABLE "account"
+  ADD CONSTRAINT "account_issuer_not_null_check"
+  CHECK ("issuer" IS NOT NULL) NOT VALID;
+DELETE FROM drizzle.__drizzle_migrations
+WHERE id = (SELECT max(id) FROM drizzle.__drizzle_migrations);
+COMMIT;
+SQL
+
+recorded_interrupted="$(
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -Atc \
+    'SELECT count(*) FROM drizzle.__drizzle_migrations'
+)"
+if [[ "$recorded_interrupted" -ne $((recorded_before - 1)) ]]; then
+  echo "Interrupted rehearsal did not remove exactly one migration receipt" >&2
+  exit 1
+fi
+
+(
+  cd "$repo_root/apps/api"
+  bun run src/db/migrate.ts
+)
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -Atc "
+SELECT
+  (SELECT count(*) = ${recorded_before}
+   FROM drizzle.__drizzle_migrations)
+  AND (SELECT attnotnull
+       FROM pg_attribute
+       WHERE attrelid = 'public.account'::regclass
+         AND attname = 'issuer')
+  AND NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.account'::regclass
+      AND conname = 'account_issuer_not_null_check'
+  )
+  AND (SELECT indisvalid AND indisready
+       FROM pg_index
+       WHERE indexrelid = 'public.account_issuer_account_id_uidx'::regclass);
+" | grep -qx t || {
+  echo "Retried Better Auth constraints migration did not converge" >&2
+  exit 1
+}
+
+echo "Better Auth constraints migration converged after an interrupted receipt"


### PR DESCRIPTION
## Proposed change

Validate Better Auth account issuer completeness before the final migration commits constraint or index state, make the migration converge after an interrupted internal commit, and require explicit authorization while the one-time production cutover marker exists.

Add a fresh PostgreSQL rehearsal that proves an incomplete backfill fails without committed side effects and the ordinary migrator converges from a committed partial state.

## Validation

- `actionlint .github/workflows/release.yml .github/workflows/db-migrations.yml`
- `shellcheck scripts/rehearse-better-auth-constraint-retry.sh`
- `bun test scripts/check-api-deployment.test.ts`
- `bun test apps/api/src/db/migration-concurrent-index.test.ts`
- Better Auth schema/backfill/audit suite
- PostgreSQL 18.4 interrupted-migration rehearsal
- `bun scripts/check-migration-safety.ts`
- `bun run env:check`
- pre-push checks

## Checklist

- [x] **YES** BUILD ASSURANCE | Affected lint and typechecks pass.
- [x] **YES** TESTING | Migration safety, release guard, schema parity, and retry behavior are covered.
- [x] **NOT APPLICABLE** DARK MODE SUPPORT | No user interface changes.
- [ ] **NO** ISSUE LINKED | No linked issue.
- [x] **NOT APPLICABLE** SCREENSHOT INCLUDED | Database and release-workflow changes only.
