### PR TITLE
fix: allow private q09 mutation endpoint

### DIFF
--- a/apps/api/src/env-base-schema.test.ts
+++ b/apps/api/src/env-base-schema.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import { envBaseInvariantViolation } from "@/api/env-base-schema";
+
+const deployedCorpusEnvironment = {
+  CORPUS_INDEX_BACKPRESSURE_HIGH_WATERMARK: 80,
+  CORPUS_INDEX_BACKPRESSURE_LOW_WATERMARK: 60,
+  CORPUS_INDEX_ENDPOINT: "http://corpus-index.stella-staging.local:7280",
+  CORPUS_INDEXING_ENABLED: true,
+  CORPUS_STORAGE_ENABLED: true,
+  DATABASE_URL: "postgres://stella@database.internal/stella?sslmode=require",
+  LEGAL_CORPUS_S3_BUCKET: "stella-staging-legal-corpus",
+  LEGAL_SEARCH_INDEX_GENERATION: "case_law_v2",
+  LEGAL_SEARCH_PROVIDER: "corpus-index",
+  QUERY_EXPANSION_MODE: "off",
+  S3_CREDENTIALS_PROVIDER: "aws-runtime",
+  S3_ENDPOINT: "https://s3.eu-central-1.amazonaws.com",
+  isDev: false,
+} as const;
+
+describe("corpus cluster endpoint transport", () => {
+  test("accepts the VPC-only q09 mutation endpoint used by deployment", () => {
+    expect(
+      envBaseInvariantViolation({
+        ...deployedCorpusEnvironment,
+        CORPUS_INDEX_Q09_ENDPOINT:
+          "http://corpus-index-v09.stella-staging.local:7280",
+      }),
+    ).toBeNull();
+  });
+
+  test("keeps a remote plaintext search override forbidden", () => {
+    expect(
+      envBaseInvariantViolation({
+        ...deployedCorpusEnvironment,
+        CORPUS_INDEX_Q09_SEARCH_ENDPOINT: "http://search.example.com",
+      }),
+    ).toBe(
+      "CORPUS_INDEX_Q09_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address.",
+    );
+  });
+});

--- a/apps/api/src/env-base-schema.test.ts
+++ b/apps/api/src/env-base-schema.test.ts
@@ -39,4 +39,15 @@ describe("corpus cluster endpoint transport", () => {
       "CORPUS_INDEX_Q09_SEARCH_ENDPOINT must use HTTPS unless it targets a loopback address.",
     );
   });
+
+  test("keeps a remote plaintext mutation endpoint forbidden", () => {
+    expect(
+      envBaseInvariantViolation({
+        ...deployedCorpusEnvironment,
+        CORPUS_INDEX_Q09_ENDPOINT: "http://quickwit-admin.example.com",
+      }),
+    ).toBe(
+      "CORPUS_INDEX_Q09_ENDPOINT must use HTTPS unless it targets loopback or the private corpus-index-v09 Cloud Map service.",
+    );
+  });
 });

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -376,15 +376,9 @@ export const envBaseInvariantViolation = ({
   if (!isDev && CORPUS_INDEX_Q09_SEARCH_ENDPOINT !== undefined) {
     return "CORPUS_INDEX_Q09_SEARCH_ENDPOINT is only supported in local development.";
   }
-  if (
-    CORPUS_INDEX_Q09_ENDPOINT !== undefined &&
-    !isTlsOrLoopbackUrl(CORPUS_INDEX_Q09_ENDPOINT, {
-      plaintextProtocol: "http:",
-      tlsProtocol: "https:",
-    })
-  ) {
-    return "CORPUS_INDEX_Q09_ENDPOINT must use HTTPS unless it targets a loopback address.";
-  }
+  // Mutation endpoints are private deployment control-plane inputs. Both
+  // q08 and q09 run on VPC-only Cloud Map HTTP; public or local read-only
+  // overrides use the separately validated *_SEARCH_ENDPOINT variables.
   // REMOVAL CONDITION: delete this invariant in the PR that makes a corpus
   // cursor carry the dictionary version it was built against.
   //

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -22,7 +22,10 @@ import {
   type QueryExpansionMode,
 } from "@/api/lib/legal-search/query-expansion-mode";
 import { isUsableStaticCredential } from "@/api/lib/s3-credentials";
-import { isTlsOrLoopbackUrl } from "@/api/lib/secure-service-url";
+import {
+  isLoopbackHostname,
+  isTlsOrLoopbackUrl,
+} from "@/api/lib/secure-service-url";
 
 /**
  * NODE_ENV values that identify a deployed (non-local) Stella
@@ -97,6 +100,22 @@ const boundedIntegerEnv = ({ fallback, min, max }: BoundedIntegerEnvOptions) =>
 
 const BACKPRESSURE_DIMENSIONS_PATTERN =
   /^[^=,\s]+=[^=,]+(?:,[^=,\s]+=[^=,]+)*$/u;
+
+const Q09_PRIVATE_SERVICE_HOSTNAME_PATTERN =
+  /^corpus-index-v09\.[a-z0-9-]+\.local$/u;
+
+const isSecureOrPrivateQ09MutationEndpoint = (value: string) => {
+  if (!URL.canParse(value)) {
+    return false;
+  }
+  const url = new URL(value);
+  return (
+    url.protocol === "https:" ||
+    (url.protocol === "http:" &&
+      (isLoopbackHostname(url.hostname) ||
+        Q09_PRIVATE_SERVICE_HOSTNAME_PATTERN.test(url.hostname.toLowerCase())))
+  );
+};
 
 const nonNegativeNumberEnv = (fallback: string) =>
   v.optional(
@@ -376,9 +395,12 @@ export const envBaseInvariantViolation = ({
   if (!isDev && CORPUS_INDEX_Q09_SEARCH_ENDPOINT !== undefined) {
     return "CORPUS_INDEX_Q09_SEARCH_ENDPOINT is only supported in local development.";
   }
-  // Mutation endpoints are private deployment control-plane inputs. Both
-  // q08 and q09 run on VPC-only Cloud Map HTTP; public or local read-only
-  // overrides use the separately validated *_SEARCH_ENDPOINT variables.
+  if (
+    CORPUS_INDEX_Q09_ENDPOINT !== undefined &&
+    !isSecureOrPrivateQ09MutationEndpoint(CORPUS_INDEX_Q09_ENDPOINT)
+  ) {
+    return "CORPUS_INDEX_Q09_ENDPOINT must use HTTPS unless it targets loopback or the private corpus-index-v09 Cloud Map service.";
+  }
   // REMOVAL CONDITION: delete this invariant in the PR that makes a corpus
   // cursor carry the dictionary version it was built against.
   //

--- a/scripts/env-tool.test.ts
+++ b/scripts/env-tool.test.ts
@@ -515,7 +515,7 @@ describe("environment doctor output", () => {
     },
     {
       expected:
-        "CORPUS_INDEX_Q09_ENDPOINT must use HTTPS unless it targets a loopback address.",
+        "CORPUS_INDEX_Q09_ENDPOINT must use HTTPS unless it targets loopback or the private corpus-index-v09 Cloud Map service.",
       overrides: {
         CORPUS_INDEX_Q09_ENDPOINT: "http://quickwit-admin.example.com",
       },


### PR DESCRIPTION
## Summary

- accept the VPC-only Cloud Map HTTP transport used by the q09 mutation endpoint, matching q08
- keep remote plaintext search overrides rejected
- cover both boundaries with focused environment-invariant tests

## Validation

- `bun test --preload ./apps/api/src/tests/setup-env.ts apps/api/src/env-base-schema.test.ts`
- exact touched-file formatting
- `git diff --check`

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment configuration validation for private, VPC-only control-plane endpoints.
  - Allowed supported local and private service endpoints to use HTTP where appropriate.
  - Continued to reject insecure remote search and mutation endpoints that use plaintext connections.
  - Improved handling and validation of corpus cluster endpoint settings for supported deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->