### PR TITLE
feat: add final projection convergence probe

### DIFF
--- a/apps/api/drizzle/20260826003900_corpus_projection_launch_probe/migration.sql
+++ b/apps/api/drizzle/20260826003900_corpus_projection_launch_probe/migration.sql
@@ -1,0 +1,164 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Projection execution is not active yet. Add the explicit same-epoch repair
+-- queue before bootstrap, preserving monotonic applied history while census
+-- drift retires and replaces one exact attempt.
+-- stella-migration-safety: reviewed drop-constraint - Projection execution has not shipped, so no running API task writes these inert rows; this transaction immediately installs stricter replacement constraints and rolls back atomically on failure.
+ALTER TABLE "corpus_index_projection_states"
+  DROP CONSTRAINT "corpus_index_projection_states_work_status_values",
+  DROP CONSTRAINT "corpus_index_projection_states_work_shape";--> statement-breakpoint
+
+ALTER TABLE "corpus_index_projection_states"
+  ADD CONSTRAINT "corpus_index_projection_states_work_status_values"
+    CHECK (
+      "work_status" IN (
+        'eligible',
+        'retry_scheduled',
+        'repair_scheduled',
+        'blocked'
+      )
+    ) NOT VALID,
+  ADD CONSTRAINT "corpus_index_projection_states_work_shape"
+    CHECK (CASE "work_status"
+      WHEN 'eligible' THEN
+        "retry_not_before" IS NULL
+        AND "failure_attempts" = 0
+        AND "last_failure_kind" IS NULL
+        AND "last_failure_message" IS NULL
+      WHEN 'retry_scheduled' THEN
+        "retry_not_before" IS NOT NULL
+        AND "failure_attempts" > 0
+        AND "last_failure_kind" IS NOT NULL
+        AND "last_failure_message" IS NOT NULL
+      WHEN 'repair_scheduled' THEN
+        "retry_not_before" IS NULL
+        AND "failure_attempts" = 0
+        AND "last_failure_kind" IS NULL
+        AND "last_failure_message" IS NULL
+      WHEN 'blocked' THEN
+        "retry_not_before" IS NULL
+        AND "failure_attempts" > 0
+        AND "last_failure_kind" IS NOT NULL
+        AND "last_failure_message" IS NOT NULL
+      ELSE false
+    END) NOT VALID;--> statement-breakpoint
+
+-- Same-epoch repair deliberately retires the currently applied immutable
+-- revision before rebuilding it. Keep the original replacement fence for
+-- every other path; only the exact explicit repair state may cross it.
+CREATE OR REPLACE FUNCTION "guard_corpus_index_projection_intent_update"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  transition_allowed boolean;
+BEGIN
+  IF (NEW."id", NEW."family", NEW."generation", NEW."entity_id", NEW."epoch", NEW."fingerprint", NEW."index_id", NEW."created_at")
+     IS DISTINCT FROM
+     (OLD."id", OLD."family", OLD."generation", OLD."entity_id", OLD."epoch", OLD."fingerprint", OLD."index_id", OLD."created_at") THEN
+    RAISE EXCEPTION 'corpus index projection intent identity is immutable';
+  END IF;
+
+  IF NEW."cleanup_attempts" < OLD."cleanup_attempts" THEN
+    RAISE EXCEPTION 'corpus index projection cleanup attempts cannot decrease';
+  END IF;
+
+  IF OLD."append_started_at" IS NOT NULL
+     AND NEW."append_started_at" IS DISTINCT FROM OLD."append_started_at" THEN
+    RAISE EXCEPTION 'corpus index append start is immutable once recorded';
+  END IF;
+  IF OLD."append_committed_at" IS NOT NULL
+     AND NEW."append_committed_at" IS DISTINCT FROM OLD."append_committed_at" THEN
+    RAISE EXCEPTION 'corpus index append commit is immutable once recorded';
+  END IF;
+  IF OLD."applied_at" IS NOT NULL
+     AND NEW."applied_at" IS DISTINCT FROM OLD."applied_at" THEN
+    RAISE EXCEPTION 'corpus index apply time is immutable once recorded';
+  END IF;
+  IF OLD."append_publish_barrier_at" IS NOT NULL
+     AND NEW."append_publish_barrier_at" IS DISTINCT FROM OLD."append_publish_barrier_at" THEN
+    RAISE EXCEPTION 'corpus index append barrier is immutable once recorded';
+  END IF;
+
+  IF NEW."status" IS DISTINCT FROM OLD."status" THEN
+    transition_allowed := corpus_index_projection_intent_transition_allowed(
+      OLD."status",
+      NEW."status"
+    );
+    IF NOT transition_allowed THEN
+      RAISE EXCEPTION 'invalid corpus index projection intent transition: % -> %', OLD."status", NEW."status";
+    END IF;
+    IF NEW."status" IN ('append_started','append_committed','applied')
+    THEN
+      PERFORM 1
+      FROM "corpus_index_projection_states" state
+      WHERE state."family" = NEW."family"
+        AND state."generation" = NEW."generation"
+        AND state."entity_id" = NEW."entity_id"
+        AND state."desired_action" = 'upsert'
+        AND state."desired_epoch" = NEW."epoch"
+        AND state."desired_fingerprint" = NEW."fingerprint"
+        AND state."desired_index_id" = NEW."index_id"
+      FOR UPDATE;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'stale corpus index projection intent cannot advance';
+      END IF;
+    END IF;
+  END IF;
+
+  IF OLD."status" = 'applied' AND NEW."status" = 'cleanup_pending'
+     AND EXISTS (
+       SELECT 1 FROM "corpus_index_projection_states" state
+       WHERE state."applied_revision" = OLD."id"
+         AND state."desired_action" <> 'erase'
+         AND state."desired_epoch" <= OLD."epoch"
+         AND NOT (
+           state."work_status" = 'repair_scheduled'
+           AND state."desired_action" = 'upsert'
+           AND state."desired_epoch" = OLD."epoch"
+           AND state."desired_fingerprint" = OLD."fingerprint"
+           AND state."desired_index_id" = OLD."index_id"
+         )
+     ) THEN
+    RAISE EXCEPTION 'current corpus index projection revision requires newer desired state or exact repair before cleanup';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;--> statement-breakpoint
+
+-- squawk-ignore require-concurrent-index-deletion
+DROP INDEX "corpus_index_projection_states_pending_idx";--> statement-breakpoint
+
+-- squawk-ignore require-concurrent-index-creation
+CREATE INDEX "corpus_index_projection_states_pending_idx"
+  ON "corpus_index_projection_states" (
+    "family",
+    "generation",
+    (coalesce("retry_not_before", "updated_at")),
+    "entity_id"
+  )
+  WHERE "work_status" = 'repair_scheduled'
+    OR (
+      "work_status" IN ('eligible', 'retry_scheduled')
+      AND (
+        "applied_action" IS NULL
+        OR "applied_action" IS DISTINCT FROM "desired_action"
+        OR "applied_epoch" IS DISTINCT FROM "desired_epoch"
+        OR "applied_fingerprint" IS DISTINCT FROM "desired_fingerprint"
+        OR "applied_index_id" IS DISTINCT FROM "desired_index_id"
+      )
+    );--> statement-breakpoint
+
+-- The final projection tables remain inert until Plane is released with the
+-- v5/v2 executor. Install the empty-table launch probe before bootstrap; this
+-- keeps every later zero-blocked proof index-only.
+-- squawk-ignore require-concurrent-index-creation
+CREATE INDEX "corpus_index_projection_states_blocked_idx"
+  ON "corpus_index_projection_states" (
+    "family",
+    "generation",
+    "entity_id"
+  )
+  WHERE "work_status" = 'blocked';--> statement-breakpoint

--- a/apps/api/drizzle/20260826003910_corpus_projection_repair_validate/migration.sql
+++ b/apps/api/drizzle/20260826003910_corpus_projection_repair_validate/migration.sql
@@ -1,0 +1,8 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+ALTER TABLE "corpus_index_projection_states"
+  VALIDATE CONSTRAINT "corpus_index_projection_states_work_status_values";--> statement-breakpoint
+
+ALTER TABLE "corpus_index_projection_states"
+  VALIDATE CONSTRAINT "corpus_index_projection_states_work_shape";--> statement-breakpoint

--- a/apps/api/src/db/schema/corpus-index-projections.ts
+++ b/apps/api/src/db/schema/corpus-index-projections.ts
@@ -10,6 +10,10 @@ import {
   CORPUS_INDEX_PROJECTION_FAILURE_KINDS,
   CORPUS_INDEX_PROJECTION_WORK_STATUSES,
 } from "@/api/lib/legal-search/corpus-index-projection-contract";
+import {
+  corpusIndexProjectionIsBlocked,
+  corpusIndexProjectionNeedsWork,
+} from "@/api/lib/legal-search/corpus-index-projection-sql";
 
 import {
   globalCaseLawPolicies,
@@ -396,16 +400,12 @@ export const corpusIndexProjectionStates = p.pgTable(
         t.generation,
         sql`coalesce(${t.retryNotBefore}, ${t.updatedAt})`,
         t.entityId,
-      ).where(sql`
-        ${t.workStatus} IN ('eligible', 'retry_scheduled')
-        AND (
-          ${t.appliedAction} IS NULL
-          OR ${t.appliedAction} IS DISTINCT FROM ${t.desiredAction}
-          OR ${t.appliedEpoch} IS DISTINCT FROM ${t.desiredEpoch}
-          OR ${t.appliedFingerprint} IS DISTINCT FROM ${t.desiredFingerprint}
-          OR ${t.appliedIndexId} IS DISTINCT FROM ${t.desiredIndexId}
-        )
-      `),
+      )
+      .where(corpusIndexProjectionNeedsWork(t)),
+    p
+      .index("corpus_index_projection_states_blocked_idx")
+      .on(t.family, t.generation, t.entityId)
+      .where(corpusIndexProjectionIsBlocked(t.workStatus)),
     p
       .index("corpus_index_projection_states_applied_census_idx")
       .on(t.family, t.generation, t.appliedIndexId, t.entityId)
@@ -449,6 +449,11 @@ export const corpusIndexProjectionStates = p.pgTable(
           AND ${t.failureAttempts} > 0
           AND ${t.lastFailureKind} IS NOT NULL
           AND ${t.lastFailureMessage} IS NOT NULL
+        WHEN 'repair_scheduled' THEN
+          ${t.retryNotBefore} IS NULL
+          AND ${t.failureAttempts} = 0
+          AND ${t.lastFailureKind} IS NULL
+          AND ${t.lastFailureMessage} IS NULL
         WHEN 'blocked' THEN
           ${t.retryNotBefore} IS NULL
           AND ${t.failureAttempts} > 0

--- a/apps/api/src/lib/legal-search/corpus-index-projection-census-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-census-store.ts
@@ -1,5 +1,5 @@
 import { panic } from "better-result";
-import { and, asc, eq, gt, inArray, isNotNull } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, isNotNull, sql } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
 import {
@@ -183,6 +183,115 @@ export const revalidateAppliedCorpusProjectionCensusTx = async (
     .orderBy(asc(corpusIndexProjectionStates.entityId))
     .limit(options.revisions.length);
   return candidates.map(requireAppliedCandidateDocumentCount);
+};
+
+type RepairAppliedCorpusProjectionDriftOptions = {
+  family: CorpusFamily;
+  generation: string;
+  indexId: string;
+  revisions: readonly ProjectionRevision[];
+  testNow?: Date;
+};
+
+/**
+ * Fence still-authoritative broken revisions into exact cleanup. The explicit
+ * repair state makes the unchanged desired epoch runnable again only after
+ * that cleanup settles, without moving applied history backward.
+ */
+export const repairAppliedCorpusProjectionDriftTx = async (
+  tx: Transaction,
+  options: RepairAppliedCorpusProjectionDriftOptions,
+): Promise<number> => {
+  if (
+    options.revisions.length === 0 ||
+    options.revisions.length > CORPUS_PROJECTION_DELETE_MAX_REVISIONS
+  ) {
+    return panic("Corpus projection census repair batch is invalid");
+  }
+  await readRegisteredCorpusProjectionManifestForCleanup(
+    tx,
+    options.family,
+    options.generation,
+  );
+  const candidates = await tx
+    .select({
+      entityId: corpusIndexProjectionStates.entityId,
+      revision: corpusIndexProjectionIntents.id,
+    })
+    .from(corpusIndexProjectionStates)
+    .innerJoin(
+      corpusIndexProjectionIntents,
+      eq(
+        corpusIndexProjectionIntents.id,
+        corpusIndexProjectionStates.appliedRevision,
+      ),
+    )
+    .where(
+      and(
+        eq(corpusIndexProjectionStates.family, options.family),
+        eq(corpusIndexProjectionStates.generation, options.generation),
+        eq(corpusIndexProjectionStates.appliedAction, "upsert"),
+        eq(corpusIndexProjectionStates.appliedIndexId, options.indexId),
+        inArray(corpusIndexProjectionIntents.id, options.revisions),
+        eq(corpusIndexProjectionIntents.status, "applied"),
+      ),
+    )
+    .orderBy(asc(corpusIndexProjectionStates.entityId))
+    .limit(options.revisions.length)
+    .for("update", { of: corpusIndexProjectionStates });
+  if (candidates.length === 0) {
+    return 0;
+  }
+  const revisions = candidates.map(({ revision }) => revision);
+  await tx
+    .select({ id: corpusIndexProjectionIntents.id })
+    .from(corpusIndexProjectionIntents)
+    .where(inArray(corpusIndexProjectionIntents.id, revisions))
+    .orderBy(asc(corpusIndexProjectionIntents.id))
+    .limit(revisions.length)
+    .for("update");
+  const repairAt = options.testNow ?? sql<Date>`clock_timestamp()`;
+  const scheduled = await tx
+    .update(corpusIndexProjectionStates)
+    .set({
+      workStatus: "repair_scheduled",
+      retryNotBefore: null,
+      failureAttempts: 0,
+      lastFailureKind: null,
+      lastFailureMessage: null,
+      updatedAt: repairAt,
+    })
+    .where(
+      and(
+        eq(corpusIndexProjectionStates.family, options.family),
+        eq(corpusIndexProjectionStates.generation, options.generation),
+        inArray(corpusIndexProjectionStates.appliedRevision, revisions),
+      ),
+    )
+    .returning({ entityId: corpusIndexProjectionStates.entityId });
+  const retired = await tx
+    .update(corpusIndexProjectionIntents)
+    .set({
+      status: "cleanup_pending",
+      appendPublishBarrierAt: corpusIndexProjectionIntents.appendCommittedAt,
+      cleanupNotBefore: repairAt,
+      lastError: "applied census observed engine drift",
+      updatedAt: repairAt,
+    })
+    .where(
+      and(
+        inArray(corpusIndexProjectionIntents.id, revisions),
+        eq(corpusIndexProjectionIntents.status, "applied"),
+      ),
+    )
+    .returning({ id: corpusIndexProjectionIntents.id });
+  if (
+    scheduled.length !== candidates.length ||
+    retired.length !== candidates.length
+  ) {
+    return panic("Corpus projection census repair lost its state fence");
+  }
+  return retired.length;
 };
 
 /** Bounded retired revisions that the engine must no longer contain. */

--- a/apps/api/src/lib/legal-search/corpus-index-projection-contract.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-contract.ts
@@ -16,6 +16,31 @@ export const CORPUS_INDEX_INTENT_STATUSES = [
 export type CorpusIndexIntentStatus =
   (typeof CORPUS_INDEX_INTENT_STATUSES)[number];
 
+/**
+ * What a generation-level launch probe must do with each intent state.
+ * `applied` still needs the engine census because it may not be the revision
+ * referenced by authoritative projection state.
+ */
+export const CORPUS_INDEX_INTENT_LAUNCH_DISPOSITION = {
+  reserved: "blocking",
+  append_started: "blocking",
+  append_committed: "blocking",
+  applied: "census_required",
+  cleanup_pending: "blocking",
+  cleanup_started: "blocking",
+  cleanup_committed: "blocking",
+  settled: "terminal",
+  cancelled: "terminal",
+} as const satisfies Record<
+  CorpusIndexIntentStatus,
+  "blocking" | "census_required" | "terminal"
+>;
+
+export const CORPUS_INDEX_LAUNCH_BLOCKING_INTENT_STATUSES =
+  CORPUS_INDEX_INTENT_STATUSES.filter(
+    (status) => CORPUS_INDEX_INTENT_LAUNCH_DISPOSITION[status] === "blocking",
+  );
+
 /** Phases that can create or expose one exact append revision. */
 export const CORPUS_INDEX_APPEND_PRODUCING_INTENT_STATUSES = [
   "reserved",
@@ -33,6 +58,7 @@ export const CORPUS_INDEX_DOCUMENT_COUNT_REQUIRED_INTENT_STATUSES = [
 export const CORPUS_INDEX_PROJECTION_WORK_STATUSES = [
   "eligible",
   "retry_scheduled",
+  "repair_scheduled",
   "blocked",
 ] as const;
 export type CorpusIndexProjectionWorkStatus =

--- a/apps/api/src/lib/legal-search/corpus-index-projection-convergence.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-convergence.db.test.ts
@@ -1,0 +1,170 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { and, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  corpusIndexGenerations,
+  corpusIndexProjectionIntents,
+  corpusIndexProjectionStates,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import { readCorpusIndexProjectionConvergenceTx } from "@/api/lib/legal-search/corpus-index-projection-convergence";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const TARGET = {
+  family: "case_law",
+  generation: "case_law_v5",
+} as const;
+const ENTITY_ID = "0198e331-e578-7000-8000-000000000301";
+const APPLIED_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000302",
+);
+const CLEANUP_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000303",
+);
+const ORPHAN_APPLIED_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000304",
+);
+const INDEX_ID = "case_law_v5_cs_sk";
+const FINGERPRINT = "a".repeat(64);
+const NOW = new Date("2026-08-26T00:00:00.000Z");
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const readStatus = async () =>
+  await db.transaction(
+    async (tx) =>
+      await readCorpusIndexProjectionConvergenceTx(
+        asTestRaw<Transaction>(tx),
+        TARGET,
+      ),
+  );
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+  await db.insert(corpusIndexGenerations).values({
+    ...TARGET,
+    cluster: "q09",
+    manifestDigest: "a".repeat(64),
+    status: "building",
+  });
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("the launch probe requires populated current state before census", async () => {
+  expect(await readStatus()).toBe("empty");
+
+  await db.insert(corpusIndexProjectionStates).values({
+    ...TARGET,
+    entityId: ENTITY_ID,
+    desiredAction: "upsert",
+    desiredEpoch: 1n,
+    desiredFingerprint: FINGERPRINT,
+    desiredIndexId: INDEX_ID,
+  });
+  expect(await readStatus()).toBe("pending");
+
+  await db
+    .update(corpusIndexProjectionStates)
+    .set({
+      workStatus: "blocked",
+      failureAttempts: 1,
+      lastFailureKind: "payload_unavailable",
+      lastFailureMessage: "fixture payload is unavailable",
+    })
+    .where(
+      and(
+        eq(corpusIndexProjectionStates.family, TARGET.family),
+        eq(corpusIndexProjectionStates.generation, TARGET.generation),
+        eq(corpusIndexProjectionStates.entityId, ENTITY_ID),
+      ),
+    );
+  expect(await readStatus()).toBe("blocked");
+
+  await db.insert(corpusIndexProjectionIntents).values({
+    id: APPLIED_INTENT_ID,
+    ...TARGET,
+    entityId: ENTITY_ID,
+    epoch: 1n,
+    fingerprint: FINGERPRINT,
+    indexId: INDEX_ID,
+    status: "applied",
+    appendStartedAt: NOW,
+    appendCommittedAt: NOW,
+    expectedDocumentCount: 1,
+    appliedAt: NOW,
+  });
+  await db
+    .update(corpusIndexProjectionStates)
+    .set({
+      workStatus: "eligible",
+      failureAttempts: 0,
+      lastFailureKind: null,
+      lastFailureMessage: null,
+      appliedAction: "upsert",
+      appliedEpoch: 1n,
+      appliedRevision: APPLIED_INTENT_ID,
+      appliedFingerprint: FINGERPRINT,
+      appliedIndexId: INDEX_ID,
+      appliedAt: NOW,
+    })
+    .where(
+      and(
+        eq(corpusIndexProjectionStates.family, TARGET.family),
+        eq(corpusIndexProjectionStates.generation, TARGET.generation),
+        eq(corpusIndexProjectionStates.entityId, ENTITY_ID),
+      ),
+    );
+  expect(await readStatus()).toBe("ready_for_census");
+
+  await db
+    .update(corpusIndexProjectionStates)
+    .set({ workStatus: "repair_scheduled" })
+    .where(eq(corpusIndexProjectionStates.entityId, ENTITY_ID));
+  expect(await readStatus()).toBe("pending");
+  await db
+    .update(corpusIndexProjectionStates)
+    .set({ workStatus: "eligible" })
+    .where(eq(corpusIndexProjectionStates.entityId, ENTITY_ID));
+  expect(await readStatus()).toBe("ready_for_census");
+
+  await db.insert(corpusIndexProjectionIntents).values({
+    id: ORPHAN_APPLIED_INTENT_ID,
+    ...TARGET,
+    entityId: ENTITY_ID,
+    epoch: 2n,
+    fingerprint: "b".repeat(64),
+    indexId: INDEX_ID,
+    status: "applied",
+    appendStartedAt: NOW,
+    appendCommittedAt: NOW,
+    expectedDocumentCount: 1,
+    appliedAt: NOW,
+  });
+  expect(await readStatus()).toBe("intent_outstanding");
+  await db
+    .delete(corpusIndexProjectionIntents)
+    .where(eq(corpusIndexProjectionIntents.id, ORPHAN_APPLIED_INTENT_ID));
+  expect(await readStatus()).toBe("ready_for_census");
+
+  await db.insert(corpusIndexProjectionIntents).values({
+    id: CLEANUP_INTENT_ID,
+    ...TARGET,
+    entityId: ENTITY_ID,
+    epoch: 2n,
+    fingerprint: "b".repeat(64),
+    indexId: INDEX_ID,
+    status: "cleanup_pending",
+    appendStartedAt: NOW,
+    appendPublishBarrierAt: NOW,
+    cleanupNotBefore: NOW,
+  });
+  expect(await readStatus()).toBe("intent_outstanding");
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-convergence.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-convergence.ts
@@ -1,0 +1,124 @@
+import { panic } from "better-result";
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  corpusIndexProjectionIntents,
+  corpusIndexProjectionStates,
+} from "@/api/db/schema";
+import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
+import { CORPUS_INDEX_LAUNCH_BLOCKING_INTENT_STATUSES } from "@/api/lib/legal-search/corpus-index-projection-contract";
+import {
+  corpusIndexProjectionIsBlocked,
+  corpusIndexProjectionNeedsWork,
+} from "@/api/lib/legal-search/corpus-index-projection-sql";
+import { isRecord } from "@/api/lib/type-guards";
+
+export const CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS = {
+  empty: "empty",
+  blocked: "blocked",
+  pending: "pending",
+  intentOutstanding: "intent_outstanding",
+  readyForCensus: "ready_for_census",
+} as const;
+
+export type CorpusIndexProjectionConvergenceStatus =
+  (typeof CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS)[keyof typeof CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS];
+
+type CorpusIndexProjectionConvergenceTarget = {
+  family: CorpusFamily;
+  generation: string;
+};
+
+const stateScope = ({
+  family,
+  generation,
+}: CorpusIndexProjectionConvergenceTarget) =>
+  and(
+    eq(corpusIndexProjectionStates.family, family),
+    eq(corpusIndexProjectionStates.generation, generation),
+  );
+
+const rowsOf = (result: unknown): unknown[] => {
+  if (Array.isArray(result)) {
+    return result;
+  }
+  if (isRecord(result) && Array.isArray(result["rows"])) {
+    return result["rows"];
+  }
+  return [];
+};
+
+/** Constant-time PostgreSQL precondition for a fresh zero-drift engine census. */
+export const readCorpusIndexProjectionConvergenceTx = async (
+  tx: Transaction,
+  target: CorpusIndexProjectionConvergenceTarget,
+): Promise<CorpusIndexProjectionConvergenceStatus> => {
+  const scope = stateScope(target);
+  const intentScope = and(
+    eq(corpusIndexProjectionIntents.family, target.family),
+    eq(corpusIndexProjectionIntents.generation, target.generation),
+  );
+  const result: unknown = await tx.execute(sql`
+    SELECT EXISTS (
+      SELECT 1 FROM ${corpusIndexProjectionStates} WHERE ${scope}
+    ) AS "hasState",
+    EXISTS (
+      SELECT 1
+      FROM ${corpusIndexProjectionStates}
+      WHERE ${scope}
+        AND ${corpusIndexProjectionIsBlocked(
+          corpusIndexProjectionStates.workStatus,
+        )}
+    ) AS "hasBlockedState",
+    EXISTS (
+      SELECT 1
+      FROM ${corpusIndexProjectionStates}
+      WHERE ${scope}
+        AND ${corpusIndexProjectionNeedsWork(corpusIndexProjectionStates)}
+    ) AS "hasPendingState",
+    EXISTS (
+      SELECT 1
+      FROM ${corpusIndexProjectionIntents}
+      WHERE ${intentScope}
+        AND (
+          ${inArray(
+            corpusIndexProjectionIntents.status,
+            CORPUS_INDEX_LAUNCH_BLOCKING_INTENT_STATUSES,
+          )}
+          OR (
+            ${corpusIndexProjectionIntents.status} = 'applied'
+            AND NOT EXISTS (
+              SELECT 1
+              FROM ${corpusIndexProjectionStates}
+              WHERE ${scope}
+                AND ${corpusIndexProjectionStates.appliedRevision} =
+                    ${corpusIndexProjectionIntents.id}
+            )
+          )
+        )
+    ) AS "hasOutstandingIntent"
+  `);
+  const observation = rowsOf(result).at(0);
+  if (
+    !isRecord(observation) ||
+    typeof observation["hasState"] !== "boolean" ||
+    typeof observation["hasBlockedState"] !== "boolean" ||
+    typeof observation["hasPendingState"] !== "boolean" ||
+    typeof observation["hasOutstandingIntent"] !== "boolean"
+  ) {
+    return panic("Corpus projection convergence probe returned malformed row");
+  }
+  if (!observation["hasState"]) {
+    return CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS.empty;
+  }
+  if (observation["hasBlockedState"]) {
+    return CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS.blocked;
+  }
+  if (observation["hasPendingState"]) {
+    return CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS.pending;
+  }
+  return observation["hasOutstandingIntent"]
+    ? CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS.intentOutstanding
+    : CORPUS_INDEX_PROJECTION_CONVERGENCE_STATUS.readyForCensus;
+};

--- a/apps/api/src/lib/legal-search/corpus-index-projection-sql.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-sql.ts
@@ -1,0 +1,41 @@
+import { sql, type SQLWrapper } from "drizzle-orm";
+
+type CorpusProjectionWorkColumns = {
+  workStatus: SQLWrapper;
+  appliedAction: SQLWrapper;
+  desiredAction: SQLWrapper;
+  appliedEpoch: SQLWrapper;
+  desiredEpoch: SQLWrapper;
+  appliedFingerprint: SQLWrapper;
+  desiredFingerprint: SQLWrapper;
+  appliedIndexId: SQLWrapper;
+  desiredIndexId: SQLWrapper;
+};
+
+/** One source of truth for the scheduler and its partial queue index. */
+export const corpusIndexProjectionNeedsWork = ({
+  workStatus,
+  appliedAction,
+  desiredAction,
+  appliedEpoch,
+  desiredEpoch,
+  appliedFingerprint,
+  desiredFingerprint,
+  appliedIndexId,
+  desiredIndexId,
+}: CorpusProjectionWorkColumns) => sql`(
+  ${workStatus} = 'repair_scheduled'
+  OR (
+    ${workStatus} IN ('eligible', 'retry_scheduled')
+    AND (
+      ${appliedAction} IS NULL
+      OR ${appliedAction} IS DISTINCT FROM ${desiredAction}
+      OR ${appliedEpoch} IS DISTINCT FROM ${desiredEpoch}
+      OR ${appliedFingerprint} IS DISTINCT FROM ${desiredFingerprint}
+      OR ${appliedIndexId} IS DISTINCT FROM ${desiredIndexId}
+    )
+  )
+)`;
+
+export const corpusIndexProjectionIsBlocked = (workStatus: SQLWrapper) =>
+  sql`${workStatus} = 'blocked'`;

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -21,6 +21,7 @@ import { censusAppliedCorpusProjections } from "@/api/lib/legal-search/corpus-in
 import {
   readAppliedCorpusProjectionCensusPageTx,
   readSettledCorpusProjectionCensusPageTx,
+  repairAppliedCorpusProjectionDriftTx,
   revalidateAppliedCorpusProjectionCensusTx,
 } from "@/api/lib/legal-search/corpus-index-projection-census-store";
 import {
@@ -82,24 +83,7 @@ const FIRST_FINGERPRINT = "a".repeat(64);
 const SECOND_FINGERPRINT = "b".repeat(64);
 const INDEX_ID = "case_law_v5_cs_sk";
 const INITIAL_RUNNABLE_AT = new Date("2026-08-25T00:00:00.000Z");
-const PROJECTION_MIGRATION_URLS = [
-  new URL(
-    "../../../drizzle/20260825142000_corpus_index_projection_intents/migration.sql",
-    import.meta.url,
-  ),
-  new URL(
-    "../../../drizzle/20260826003530_corpus_projection_replacement_order/migration.sql",
-    import.meta.url,
-  ),
-  new URL(
-    "../../../drizzle/20260826003600_corpus_projection_applied_history_guard/migration.sql",
-    import.meta.url,
-  ),
-  new URL(
-    "../../../drizzle/20260826003700_corpus_projection_work_schedule/migration.sql",
-    import.meta.url,
-  ),
-] as const;
+const DRIZZLE_DIR = new URL("../../../drizzle/", import.meta.url);
 
 let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
@@ -175,9 +159,15 @@ const verifySettlement = async ({
 };
 
 const installProjectionMigrationDdl = async (): Promise<void> => {
+  const projectionMigrations = [
+    ...new Bun.Glob("*corpus*projection*/migration.sql").scanSync(
+      Bun.fileURLToPath(DRIZZLE_DIR),
+    ),
+  ].sort();
   const migrations = await Promise.all(
-    PROJECTION_MIGRATION_URLS.map(
-      async (migrationUrl) => await Bun.file(migrationUrl).text(),
+    projectionMigrations.map(
+      async (migration) =>
+        await Bun.file(new URL(migration, DRIZZLE_DIR)).text(),
     ),
   );
   const ddls = migrations.flatMap((migration) =>
@@ -565,6 +555,65 @@ test("applied census rejects an incomplete multi-document revision", async () =>
       complete: false,
     }),
   );
+  await db
+    .update(corpusIndexProjectionStates)
+    .set({
+      workStatus: "blocked",
+      failureAttempts: 2,
+      lastFailureKind: "payload_unavailable",
+      lastFailureMessage: "fixture failure",
+    })
+    .where(eq(corpusIndexProjectionStates.entityId, DECISION_ID));
+  expect(
+    await db.transaction(
+      async (tx) =>
+        await repairAppliedCorpusProjectionDriftTx(asTestRaw<Transaction>(tx), {
+          family: "case_law",
+          generation: "case_law_v5",
+          indexId: INDEX_ID,
+          revisions: [FIRST_INTENT_ID],
+          testNow: appliedAt,
+        }),
+    ),
+  ).toBe(1);
+  const repairedState = await db
+    .select({
+      appliedRevision: corpusIndexProjectionStates.appliedRevision,
+      failureAttempts: corpusIndexProjectionStates.failureAttempts,
+      lastFailureKind: corpusIndexProjectionStates.lastFailureKind,
+      lastFailureMessage: corpusIndexProjectionStates.lastFailureMessage,
+      retryNotBefore: corpusIndexProjectionStates.retryNotBefore,
+      workStatus: corpusIndexProjectionStates.workStatus,
+    })
+    .from(corpusIndexProjectionStates)
+    .where(eq(corpusIndexProjectionStates.entityId, DECISION_ID));
+  const repairedIntent = await db
+    .select({ status: corpusIndexProjectionIntents.status })
+    .from(corpusIndexProjectionIntents)
+    .where(eq(corpusIndexProjectionIntents.id, FIRST_INTENT_ID));
+  expect(repairedState).toEqual([
+    {
+      appliedRevision: FIRST_INTENT_ID,
+      failureAttempts: 0,
+      lastFailureKind: null,
+      lastFailureMessage: null,
+      retryNotBefore: null,
+      workStatus: "repair_scheduled",
+    },
+  ]);
+  expect(repairedIntent).toEqual([{ status: "cleanup_pending" }]);
+  expect(
+    await db.transaction(
+      async (tx) =>
+        await repairAppliedCorpusProjectionDriftTx(asTestRaw<Transaction>(tx), {
+          family: "case_law",
+          generation: "case_law_v5",
+          indexId: INDEX_ID,
+          revisions: [FIRST_INTENT_ID],
+          testNow: appliedAt,
+        }),
+    ),
+  ).toBe(0);
 });
 
 test("one append request receives one post-lock database timestamp", async () => {

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
@@ -18,6 +18,7 @@ import {
   CORPUS_PROJECTION_APPEND_MAX_REVISIONS,
   corpusIndexUnknownAppendBarrierAt,
 } from "@/api/lib/legal-search/corpus-index-projection-engine";
+import { corpusIndexProjectionNeedsWork } from "@/api/lib/legal-search/corpus-index-projection-sql";
 
 export const CORPUS_PROJECTION_STORE_MAX_BATCH_SIZE =
   CORPUS_PROJECTION_APPEND_MAX_REVISIONS;
@@ -96,13 +97,9 @@ const readPostgresClock = async (tx: Transaction): Promise<Date> => {
   return value;
 };
 
-const pendingDesiredState = sql`(
-  ${corpusIndexProjectionStates.appliedAction} IS NULL
-  OR ${corpusIndexProjectionStates.appliedAction} IS DISTINCT FROM ${corpusIndexProjectionStates.desiredAction}
-  OR ${corpusIndexProjectionStates.appliedEpoch} IS DISTINCT FROM ${corpusIndexProjectionStates.desiredEpoch}
-  OR ${corpusIndexProjectionStates.appliedFingerprint} IS DISTINCT FROM ${corpusIndexProjectionStates.desiredFingerprint}
-  OR ${corpusIndexProjectionStates.appliedIndexId} IS DISTINCT FROM ${corpusIndexProjectionStates.desiredIndexId}
-)`;
+const pendingDesiredState = corpusIndexProjectionNeedsWork(
+  corpusIndexProjectionStates,
+);
 
 const noOutstandingIntent = sql`NOT EXISTS (
       SELECT 1
@@ -165,6 +162,7 @@ export const reserveCorpusProjectionIntentsTx = async (
         inArray(corpusIndexProjectionStates.workStatus, [
           "eligible",
           "retry_scheduled",
+          "repair_scheduled",
         ]),
         lte(runnableAt, eligibilityAt),
         inArray(corpusIndexGenerations.status, ["building", "serving"]),
@@ -1133,7 +1131,10 @@ export const classifyCorpusProjectionReservationFailureTx = async (
     case undefined:
       return "stale_cancelled";
     case "eligible":
-      return panic("Projection failure classification returned eligible work");
+    case "repair_scheduled":
+      return panic(
+        `Projection failure classification returned ${workStatus} work`,
+      );
     default:
       return workStatus satisfies never;
   }


### PR DESCRIPTION
## Summary

- derive the projection scheduler and partial-index work predicate from one SQL boundary
- add an indexed blocked-state probe and a bounded PostgreSQL readiness check for final corpus generations
- classify every projection intent status for launch gating, while requiring an engine census for applied revisions

## Validation

- `bun test apps/api/src/lib/legal-search/corpus-index-projection-contract.test.ts`
- `bash scripts/check-migrations.sh`
- `git diff --check`

The PGlite lifecycle test is included for CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved monitoring of corpus index projection progress, including clearer states for blocked, pending, repair, and census-ready work.
  * Added automatic detection and scheduling of projection repairs when applied data falls out of sync.
* **Bug Fixes**
  * Improved recovery of incomplete or inconsistent projection updates.
  * Prevented blocked work from being incorrectly treated as ready for processing.
* **Tests**
  * Added coverage for projection state transitions, convergence checks, and repair handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->