### PR TITLE
feat: add corpus generation registration boundary

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.db.test.ts
@@ -27,10 +27,7 @@ let db: ReturnType<typeof drizzle>;
 const register = async (target: typeof CASE_LAW_TARGET) =>
   await db.transaction(
     async (tx) =>
-      await registerCorpusIndexGenerationTx(
-        asTestRaw<Transaction>(tx),
-        target,
-      ),
+      await registerCorpusIndexGenerationTx(asTestRaw<Transaction>(tx), target),
   );
 
 beforeAll(async () => {
@@ -57,10 +54,7 @@ test("generation registration is idempotent and manifest-derived", async () => {
     .where(
       and(
         eq(corpusIndexGenerations.family, CASE_LAW_TARGET.family),
-        eq(
-          corpusIndexGenerations.generation,
-          CASE_LAW_TARGET.generation,
-        ),
+        eq(corpusIndexGenerations.generation, CASE_LAW_TARGET.generation),
       ),
     );
   expect(rows).toHaveLength(1);

--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.db.test.ts
@@ -3,7 +3,7 @@ import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import type { Transaction } from "@/api/db/root";
-import { corpusIndexGenerations } from "@/api/db/schema/corpus-index-generations";
+import { corpusIndexGenerations } from "@/api/db/schema";
 import { registerCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
 import {
   corpusIndexManifestDigest,
@@ -79,15 +79,21 @@ test("generation registration fails closed on a drifted binding", async () => {
     status: "building",
   });
 
-  await expect(
-    db.transaction(
+  // bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+  // type-aware lint; capture the rejection explicitly instead.
+  const rejection: unknown = await db
+    .transaction(
       async (tx) =>
         await registerCorpusIndexGenerationTx(
           asTestRaw<Transaction>(tx),
           LEGISLATION_TARGET,
         ),
-    ),
-  ).rejects.toThrow(
-    "Corpus generation contract mismatch: legislation/legislation_v2",
-  );
+    )
+    .then(
+      () => null,
+      (error: unknown) => error,
+    );
+  expect(rejection).toMatchObject({
+    message: "Corpus generation contract mismatch: legislation/legislation_v2",
+  });
 });

--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.db.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { and, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import { corpusIndexGenerations } from "@/api/db/schema/corpus-index-generations";
+import { registerCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
+import {
+  corpusIndexManifestDigest,
+  requireCorpusIndexManifest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const CASE_LAW_TARGET = {
+  family: "case_law",
+  generation: "case_law_v5",
+} as const;
+const LEGISLATION_TARGET = {
+  family: "legislation",
+  generation: "legislation_v2",
+} as const;
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const register = async (target: typeof CASE_LAW_TARGET) =>
+  await db.transaction(
+    async (tx) =>
+      await registerCorpusIndexGenerationTx(
+        asTestRaw<Transaction>(tx),
+        target,
+      ),
+  );
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("generation registration is idempotent and manifest-derived", async () => {
+  expect(await register(CASE_LAW_TARGET)).toEqual(
+    requireCorpusIndexManifest(
+      CASE_LAW_TARGET.family,
+      CASE_LAW_TARGET.generation,
+    ),
+  );
+  await register(CASE_LAW_TARGET);
+
+  const rows = await db
+    .select()
+    .from(corpusIndexGenerations)
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, CASE_LAW_TARGET.family),
+        eq(
+          corpusIndexGenerations.generation,
+          CASE_LAW_TARGET.generation,
+        ),
+      ),
+    );
+  expect(rows).toHaveLength(1);
+  expect(rows.at(0)).toMatchObject({
+    ...CASE_LAW_TARGET,
+    cluster: "q09",
+    manifestDigest: corpusIndexManifestDigest(
+      requireCorpusIndexManifest(
+        CASE_LAW_TARGET.family,
+        CASE_LAW_TARGET.generation,
+      ),
+    ),
+    status: "building",
+  });
+});
+
+test("generation registration fails closed on a drifted binding", async () => {
+  await db.insert(corpusIndexGenerations).values({
+    ...LEGISLATION_TARGET,
+    cluster: "q09",
+    manifestDigest: "f".repeat(64),
+    status: "building",
+  });
+
+  await expect(
+    db.transaction(
+      async (tx) =>
+        await registerCorpusIndexGenerationTx(
+          asTestRaw<Transaction>(tx),
+          LEGISLATION_TARGET,
+        ),
+    ),
+  ).rejects.toThrow(
+    "Corpus generation contract mismatch: legislation/legislation_v2",
+  );
+});

--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
@@ -2,7 +2,7 @@ import { panic } from "better-result";
 import { and, eq } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
-import { corpusIndexGenerations } from "@/api/db/schema/corpus-index-generations";
+import { corpusIndexGenerations } from "@/api/db/schema";
 import {
   corpusIndexManifestDigest,
   requireCorpusIndexManifest,

--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
@@ -1,0 +1,79 @@
+import { panic } from "better-result";
+import { and, eq } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db/root";
+import { corpusIndexGenerations } from "@/api/db/schema/corpus-index-generations";
+import {
+  corpusIndexManifestDigest,
+  requireCorpusIndexManifest,
+  type CorpusIndexManifest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+
+type GenerationTargetFor<TManifest extends CorpusIndexManifest> =
+  TManifest extends CorpusIndexManifest
+    ? Pick<TManifest, "family" | "generation">
+    : never;
+
+export type CorpusIndexGenerationTarget =
+  GenerationTargetFor<CorpusIndexManifest>;
+
+export const requireRegisteredCorpusIndexManifest = ({
+  family,
+  generation,
+  cluster,
+  manifestDigest,
+}: typeof corpusIndexGenerations.$inferSelect): CorpusIndexManifest => {
+  const manifest = requireCorpusIndexManifest(family, generation);
+  const expectedDigest = corpusIndexManifestDigest(manifest);
+  if (cluster !== manifest.cluster || manifestDigest !== expectedDigest) {
+    return panic(
+      `Corpus generation contract mismatch: ${family}/${generation}`,
+    );
+  }
+  return manifest;
+};
+
+/**
+ * Register one immutable final-generation contract before any writer targets
+ * it. Replays converge; an existing retired or mismatched binding fails closed.
+ */
+export const registerCorpusIndexGenerationTx = async (
+  tx: Transaction,
+  target: CorpusIndexGenerationTarget,
+): Promise<CorpusIndexManifest> => {
+  const manifest = requireCorpusIndexManifest(
+    target.family,
+    target.generation,
+  );
+  await tx
+    .insert(corpusIndexGenerations)
+    .values({
+      family: manifest.family,
+      generation: manifest.generation,
+      cluster: manifest.cluster,
+      manifestDigest: corpusIndexManifestDigest(manifest),
+      status: "building",
+    })
+    .onConflictDoNothing();
+  const rows = await tx
+    .select()
+    .from(corpusIndexGenerations)
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, manifest.family),
+        eq(corpusIndexGenerations.generation, manifest.generation),
+      ),
+    )
+    .limit(1)
+    .for("share");
+  const row = rows.at(0);
+  if (
+    row === undefined ||
+    (row.status !== "building" && row.status !== "serving")
+  ) {
+    return panic(
+      `Active corpus generation registration failed: ${target.family}/${target.generation}`,
+    );
+  }
+  return requireRegisteredCorpusIndexManifest(row);
+};

--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
@@ -41,10 +41,7 @@ export const registerCorpusIndexGenerationTx = async (
   tx: Transaction,
   target: CorpusIndexGenerationTarget,
 ): Promise<CorpusIndexManifest> => {
-  const manifest = requireCorpusIndexManifest(
-    target.family,
-    target.generation,
-  );
+  const manifest = requireCorpusIndexManifest(target.family, target.generation);
   await tx
     .insert(corpusIndexGenerations)
     .values({

--- a/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
@@ -650,7 +650,7 @@ export const ensureCorpusProjectionDesiredStateTx = async (
       `Active corpus generation is not registered: ${subject.family}/${generation}`,
     );
   }
-  const manifest = verifiedManifest(generationRow);
+  const manifest = requireRegisteredCorpusIndexManifest(generationRow);
   const descriptor = deriveCorpusIndexProjectionDescriptor(
     manifest,
     locked.input,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
@@ -14,10 +14,9 @@ import {
   legislationSources,
 } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
+import { requireRegisteredCorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-generation-store";
 import {
   CORPUS_INDEX_MANIFESTS,
-  corpusIndexManifestDigest,
-  requireCorpusIndexManifest,
   type CorpusIndexManifest,
 } from "@/api/lib/legal-search/corpus-index-manifest";
 import {
@@ -337,22 +336,6 @@ type RegisteredManifest = {
   manifest: CorpusIndexManifest;
 };
 
-const verifiedManifest = ({
-  family,
-  generation,
-  cluster,
-  manifestDigest,
-}: typeof corpusIndexGenerations.$inferSelect): CorpusIndexManifest => {
-  const manifest = requireCorpusIndexManifest(family, generation);
-  const expectedDigest = corpusIndexManifestDigest(manifest);
-  if (cluster !== manifest.cluster || manifestDigest !== expectedDigest) {
-    return panic(
-      `Corpus generation contract mismatch: ${family}/${generation}`,
-    );
-  }
-  return manifest;
-};
-
 const activeManifests = async (
   tx: Transaction,
   family: CorpusIndexProjectionSubject["family"],
@@ -377,7 +360,7 @@ const activeManifests = async (
   }
   return rows.map((row) => ({
     generation: row.generation,
-    manifest: verifiedManifest(row),
+    manifest: requireRegisteredCorpusIndexManifest(row),
   }));
 };
 
@@ -408,7 +391,7 @@ export const readActiveCorpusProjectionManifest = async (
       `Active corpus generation is not registered: ${family}/${generation}`,
     );
   }
-  return verifiedManifest(row);
+  return requireRegisteredCorpusIndexManifest(row);
 };
 
 /**
@@ -438,7 +421,7 @@ export const readRegisteredCorpusProjectionManifestForCleanup = async (
       `Corpus generation is not registered for cleanup: ${family}/${generation}`,
     );
   }
-  return verifiedManifest(row);
+  return requireRegisteredCorpusIndexManifest(row);
 };
 
 export const buildCorpusIndexProjectionDesiredStateValues = ({


### PR DESCRIPTION
Moves final-generation registration and manifest verification behind one typed public primitive. Replays converge, while retired or drifted bindings fail closed.

Projection desired-state reads now reuse the same verifier, eliminating a duplicate contract check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved the reliability of legal search index generation registration and validation.
  - Added safeguards against inconsistent corpus manifests, generations, clusters, or digests.
  - Ensured repeated registration requests remain consistent without creating duplicate records.
  - Improved handling of index generation states by accepting only valid building or serving states.
  - Centralised manifest verification for more reliable corpus projection updates.

- **Tests**
  - Added coverage for successful registration, idempotency, stored metadata, and contract mismatch failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->