### PR TITLE
feat: add corpus serving-generation boundary

### DIFF
--- a/apps/api/drizzle/20260826004000_corpus_index_serving_generation/migration.sql
+++ b/apps/api/drizzle/20260826004000_corpus_index_serving_generation/migration.sql
@@ -1,0 +1,73 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Seed the concrete pre-q09 serving generations for the first DB-authoritative
+-- reader release. Never displace an existing serving row: replaying this
+-- migration against a newer environment must not roll it back.
+INSERT INTO "corpus_index_generations" (
+  "family", "generation", "cluster", "manifest_digest", "status"
+) VALUES
+  (
+    'case_law',
+    'case_law_v2',
+    'q08',
+    '58871c9e83109374ed1081f73e240472d79c2d60d2e58f5e1c5f19026975b564',
+    'building'
+  ),
+  (
+    'legislation',
+    'legislation_v1',
+    'q08',
+    '8d88e2788a736d27d1220eb9913582df62f5c87e564e1f3d91b7a4aec67b1f9c',
+    'building'
+  )
+ON CONFLICT ON CONSTRAINT "corpus_index_generations_pkey"
+DO NOTHING;--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+      FROM "corpus_index_generations"
+     WHERE ("family", "generation") IN (
+       ('case_law', 'case_law_v2'),
+       ('legislation', 'legislation_v1')
+     )
+       AND "cluster" <> 'q08'
+  ) THEN
+    RAISE EXCEPTION 'legacy corpus generation has an invalid cluster binding';
+  END IF;
+END;
+$$;--> statement-breakpoint
+
+UPDATE "corpus_index_generations" target
+   SET "status" = 'serving',
+       "updated_at" = clock_timestamp()
+ WHERE (target."family", target."generation") IN (
+   ('case_law', 'case_law_v2'),
+   ('legislation', 'legislation_v1')
+ )
+   AND target."status" IN ('building', 'retiring')
+   AND NOT EXISTS (
+     SELECT 1
+       FROM "corpus_index_generations" serving
+      WHERE serving."family" = target."family"
+        AND serving."status" = 'serving'
+   );--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT family
+      FROM (VALUES ('case_law'), ('legislation')) required(family)
+     WHERE NOT EXISTS (
+       SELECT 1
+         FROM "corpus_index_generations" serving
+        WHERE serving."family" = required.family
+          AND serving."status" = 'serving'
+     )
+  ) THEN
+    RAISE EXCEPTION 'corpus family has no serving generation';
+  END IF;
+END;
+$$;

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -88,6 +88,14 @@ const APPROVED_PROCEDURAL_STATEMENTS = new Set([
   // committed when the trusted issuer backfill is incomplete. The static body
   // performs one bounded existence read and raises; it executes no dynamic SQL.
   "20260825220000_better_auth_17_constraints/migration.sql:4c1e0d5fdbb50e29863c067586c405148beb02f76a2af8ebbced851a866abc13",
+  // Refuses to seed a legacy serving route over an existing generation bound
+  // to a different cluster. The static body reads two primary-key rows and
+  // raises; it executes no dynamic SQL.
+  "20260826004000_corpus_index_serving_generation/migration.sql:2a9afa811510709034b847b4ecdcf3f3a78d5c499cb4f584ac6ef0e9410d8419",
+  // Refuses to finish the reader cutover unless both families have a serving
+  // generation. The static body performs one bounded existence read over
+  // corpus_index_generations and raises; it executes no dynamic SQL.
+  "20260826004000_corpus_index_serving_generation/migration.sql:3cf1be3c49aad9abb99793f955b1c60e6d4fc5926ca1538e9ae2419a14242738",
 ]);
 
 type TimeoutState = "bounded" | "unbounded" | "unset";

--- a/apps/api/src/handlers/case-law/decisions/search.ts
+++ b/apps/api/src/handlers/case-law/decisions/search.ts
@@ -36,8 +36,7 @@ import {
   caseLawCorpusProjectionJoin,
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
-import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
-import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
+import { readServingCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 import {
   caseLawCorpusQuery,
@@ -621,7 +620,10 @@ const searchCorpusIndexDecisions = async (
     return status(400, { message: "Invalid country" });
   }
 
-  const generation = corpusGeneration("case_law");
+  const serving = await caseLawDb(
+    async (tx) => await readServingCorpusIndexGenerationTx(tx, "case_law"),
+  );
+  const generation = serving.generation;
   // Scoped query → that country's index, plus a jurisdiction clause when that
   // index holds other countries; unscoped → the generation glob.
   const { indexId, jurisdictionClause } = corpusIndexRoute(
@@ -635,7 +637,7 @@ const searchCorpusIndexDecisions = async (
   }
 
   const searchPage = await readCorpusIndexSearchPage({
-    cluster: corpusIndexClusterForGeneration("case_law", generation),
+    cluster: serving.cluster,
     indexId,
     query,
     limit,

--- a/apps/api/src/handlers/legislation/search.ts
+++ b/apps/api/src/handlers/legislation/search.ts
@@ -18,8 +18,7 @@ import {
   tSafeId,
 } from "@/api/lib/custom-schema";
 import { blendedRankSql } from "@/api/lib/legal-search/authority-sql";
-import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
-import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
+import { readServingCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 import {
   corpusFreeTextClause,
@@ -354,7 +353,10 @@ const corpusIndexSearch = async (
   legislationDb: LegislationReadDb,
 ): Promise<{ hits: LegislationHit[]; nextCursor: string | null }> => {
   const limit = body.limit ?? LIMITS.caseLawSearchPageSizeDefault;
-  const generation = corpusGeneration("legislation");
+  const serving = await legislationDb(
+    async (tx) => await readServingCorpusIndexGenerationTx(tx, "legislation"),
+  );
+  const generation = serving.generation;
   const indexId = body.jurisdiction
     ? corpusIndexId(generation, body.jurisdiction)
     : corpusIndexPattern(generation);
@@ -365,7 +367,7 @@ const corpusIndexSearch = async (
   }
 
   const searchPage = await readCorpusIndexSearchPage({
-    cluster: corpusIndexClusterForGeneration("legislation", generation),
+    cluster: serving.cluster,
     indexId,
     query,
     limit,

--- a/apps/api/src/lib/legal-search/corpus-family.ts
+++ b/apps/api/src/lib/legal-search/corpus-family.ts
@@ -8,14 +8,13 @@ export {
 export type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
 
 /**
- * Blue-green generation prefix per family. Index ids are
- * `<generation>_<jurisdiction>` (e.g. `case_law_v1_svk`,
- * `legislation_v1_svk`), or `<generation>_<group>` for case-law generations
- * from 3 on (`corpusIndexId`). Bumping a prefix rebuilds that family across
- * all jurisdictions, then you flip to it. case_law keeps its existing env
- * override for back-compat; other families default to `<family>_v1`.
+ * Compatibility boundary for pre-final public backfills. Readers and final
+ * projections use the database generation registry. Remove this after those
+ * public backfills are retired from every deployment.
  */
-export const corpusGeneration = (family: CorpusFamily): string => {
+export const legacyOperationalCorpusGeneration = (
+  family: CorpusFamily,
+): string => {
   switch (family) {
     case "case_law":
       return envBase.LEGAL_SEARCH_INDEX_GENERATION;

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -419,7 +419,7 @@ const FAMILY_FIELDS: Record<CorpusFamily, CorpusIndexFieldMapping[]> = {
     // change: the engine never diffs the mapping of an index that exists, and
     // in `lenient` mode it would take the fields and drop them. An existing
     // legislation index would therefore need a generation bump to serve an
-    // as-of filter — `corpusGeneration("legislation")` is the flip.
+    // as-of filter; the serving-generation row is the flip.
     {
       name: "version_valid_from",
       type: "datetime",

--- a/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.test.ts
@@ -1,14 +1,13 @@
 import { Result } from "better-result";
-import { afterEach, beforeEach, expect, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, expect, test } from "bun:test";
 import * as v from "valibot";
 
 import { envBase } from "@/api/env-base";
-import * as corpusFamily from "@/api/lib/legal-search/corpus-family";
-import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import {
   browseFacetNames,
-  corpusIndexBrowseFacets,
+  corpusIndexBrowseFacets as readCorpusIndexBrowseFacets,
 } from "@/api/lib/legal-search/corpus-index-facets";
+import type { ServingCorpusIndexGeneration } from "@/api/lib/legal-search/corpus-index-generation-store";
 
 const segmentSizeSchema = v.pipe(
   v.object({ terms: v.object({ segment_size: v.number() }) }),
@@ -38,11 +37,28 @@ const originalFetch = globalThis.fetch;
 let requests: { url: string; body: Record<string, unknown> }[];
 let responseBody: unknown;
 let responseStatus: number;
+let servingGeneration: ServingCorpusIndexGeneration = {
+  family: "case_law",
+  generation: "case_law_v2",
+  cluster: "q08",
+};
+
+const corpusIndexBrowseFacets = async (
+  query: Parameters<typeof readCorpusIndexBrowseFacets>[0],
+) =>
+  await readCorpusIndexBrowseFacets(query, {
+    readServingGeneration: async () => await Promise.resolve(servingGeneration),
+  });
 
 beforeEach(() => {
   requests = [];
   responseStatus = 200;
   responseBody = { aggregations: {} };
+  servingGeneration = {
+    family: "case_law",
+    generation: "case_law_v2",
+    cluster: "q08",
+  };
   const stub = async (
     input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
@@ -109,9 +125,11 @@ test("aggregates over opening passages only, so buckets count decisions", async 
 
 test("v5 facets use only manifest-owned fields", async () => {
   responseBody = engineResponse();
-  const generation = spyOn(corpusFamily, "corpusGeneration").mockReturnValue(
-    "case_law_v5",
-  );
+  servingGeneration = {
+    family: "case_law",
+    generation: "case_law_v5",
+    cluster: "q09",
+  };
   const originalEndpoint = envBase.CORPUS_INDEX_Q09_ENDPOINT;
   Object.assign(envBase, {
     CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
@@ -119,7 +137,6 @@ test("v5 facets use only manifest-owned fields", async () => {
   try {
     await corpusIndexBrowseFacets({ excludedSourceIds: [], limit: 20 });
   } finally {
-    generation.mockRestore();
     Object.assign(envBase, { CORPUS_INDEX_Q09_ENDPOINT: originalEndpoint });
   }
 
@@ -173,7 +190,7 @@ test("reads string and numeric bucket keys into the same bucket shape", async ()
 
 test("scopes to one jurisdiction index, and to the generation glob without one", async () => {
   responseBody = engineResponse();
-  const generation = corpusGeneration("case_law");
+  const generation = servingGeneration.generation;
 
   await corpusIndexBrowseFacets({
     excludedSourceIds: [],
@@ -190,23 +207,21 @@ test("a scoped query on a shared index carries its jurisdiction as a clause", as
   responseBody = engineResponse();
   // From generation 3 on CZE and SVK share one physical index, so selecting
   // the index alone would aggregate over both countries.
-  const generation = spyOn(corpusFamily, "corpusGeneration").mockReturnValue(
-    "case_law_v3",
-  );
-  try {
-    await corpusIndexBrowseFacets({
-      excludedSourceIds: [],
-      jurisdiction: "CZE",
-      limit: 20,
-    });
-    await corpusIndexBrowseFacets({
-      excludedSourceIds: ["018f0a2b-0000-7000-8000-000000000001"],
-      jurisdiction: "POL",
-      limit: 20,
-    });
-  } finally {
-    generation.mockRestore();
-  }
+  servingGeneration = {
+    family: "case_law",
+    generation: "case_law_v3",
+    cluster: "q08",
+  };
+  await corpusIndexBrowseFacets({
+    excludedSourceIds: [],
+    jurisdiction: "CZE",
+    limit: 20,
+  });
+  await corpusIndexBrowseFacets({
+    excludedSourceIds: ["018f0a2b-0000-7000-8000-000000000001"],
+    jurisdiction: "POL",
+    limit: 20,
+  });
 
   expect(requests.at(0)?.url).toContain("/case_law_v3_cs_sk/search");
   expect(requests.at(0)?.body["query"]).toBe('seq:0 AND jurisdiction:"CZE"');

--- a/apps/api/src/lib/legal-search/corpus-index-facets.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-facets.ts
@@ -1,9 +1,11 @@
 import { Result } from "better-result";
 
 import { LegalBrowseFacetsError } from "@/api/lib/legal-search/browse-facets";
-import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
-import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import { getCorpusIndexClient } from "@/api/lib/legal-search/corpus-index-client";
+import {
+  readServingCorpusIndexGenerationTx,
+  type ServingCorpusIndexGeneration,
+} from "@/api/lib/legal-search/corpus-index-generation-store";
 import { corpusIndexReadContract } from "@/api/lib/legal-search/corpus-index-read-contract";
 import { quoteCorpusValue } from "@/api/lib/legal-search/corpus-query";
 import { corpusIndexRoute } from "@/api/lib/legal-search/index-naming";
@@ -167,19 +169,28 @@ const parseTermsBuckets = (aggregation: unknown): FacetBucket[] | null => {
   return buckets;
 };
 
+type CorpusIndexBrowseFacetsDependencies = {
+  readServingGeneration: () => Promise<ServingCorpusIndexGeneration>;
+};
+
+const defaultCorpusIndexBrowseFacetsDependencies = {
+  readServingGeneration: async () => {
+    const { caseLawPublicReadDb } =
+      await import("@/api/lib/case-law-public-read-db");
+    return await caseLawPublicReadDb(
+      async (tx) => await readServingCorpusIndexGenerationTx(tx, "case_law"),
+    );
+  },
+} satisfies CorpusIndexBrowseFacetsDependencies;
+
 export const corpusIndexBrowseFacets = async (
   query: LegalBrowseFacetsQuery,
+  dependencies: CorpusIndexBrowseFacetsDependencies = defaultCorpusIndexBrowseFacetsDependencies,
 ): Promise<Result<LegalBrowseFacets, LegalBrowseFacetsError>> => {
   const family = query.documentFamily ?? "case_law";
-  const generation = corpusGeneration(family);
+  const serving = await dependencies.readServingGeneration();
+  const generation = serving.generation;
   const readContract = corpusIndexReadContract(family, generation);
-  if (readContract.family !== "case_law") {
-    return Result.err(
-      new LegalBrowseFacetsError({
-        message: "browse facets are only defined for the case-law corpus",
-      }),
-    );
-  }
   // Scoped query → that jurisdiction's index, plus a jurisdiction clause when
   // that index holds other jurisdictions; unscoped → the generation glob (one
   // multi-index aggregation across every index of the generation).
@@ -188,9 +199,7 @@ export const corpusIndexBrowseFacets = async (
     query.jurisdiction,
   );
 
-  const aggregated = await getCorpusIndexClient(
-    corpusIndexClusterForGeneration(family, generation),
-  ).aggregate({
+  const aggregated = await getCorpusIndexClient(serving.cluster).aggregate({
     indexId,
     query: browseFacetsQuery({
       excludedSourceIds: query.excludedSourceIds,

--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.db.test.ts
@@ -4,7 +4,12 @@ import { drizzle } from "drizzle-orm/pglite";
 
 import type { Transaction } from "@/api/db/root";
 import { corpusIndexGenerations } from "@/api/db/schema";
-import { registerCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
+import {
+  readServingCorpusIndexGenerationTx,
+  registerCorpusIndexGenerationTx,
+  resumeRetiringCorpusIndexGenerationTx,
+  setServingCorpusIndexGenerationTx,
+} from "@/api/lib/legal-search/corpus-index-generation-store";
 import {
   corpusIndexManifestDigest,
   requireCorpusIndexManifest,
@@ -95,5 +100,95 @@ test("generation registration fails closed on a drifted binding", async () => {
     );
   expect(rejection).toMatchObject({
     message: "Corpus generation contract mismatch: legislation/legislation_v2",
+  });
+});
+
+test("serving generation reads and flips are family-independent", async () => {
+  await register(CASE_LAW_TARGET);
+  await db.insert(corpusIndexGenerations).values([
+    {
+      family: "case_law",
+      generation: "case_law_v2",
+      cluster: "q08",
+      manifestDigest: "a".repeat(64),
+      status: "serving",
+    },
+    {
+      family: "legislation",
+      generation: "legislation_v1",
+      cluster: "q08",
+      manifestDigest: "b".repeat(64),
+      status: "serving",
+    },
+  ]);
+
+  expect(
+    await readServingCorpusIndexGenerationTx(
+      asTestRaw<Transaction>(db),
+      "case_law",
+    ),
+  ).toEqual({
+    family: "case_law",
+    generation: "case_law_v2",
+    cluster: "q08",
+  });
+
+  const promoted = await db.transaction(
+    async (tx) =>
+      await setServingCorpusIndexGenerationTx(
+        asTestRaw<Transaction>(tx),
+        CASE_LAW_TARGET,
+      ),
+  );
+  expect(promoted).toEqual({
+    family: "case_law",
+    generation: "case_law_v5",
+    cluster: "q09",
+  });
+  const immediateRollbackRejection: unknown = await db
+    .transaction(
+      async (tx) =>
+        await setServingCorpusIndexGenerationTx(asTestRaw<Transaction>(tx), {
+          family: "case_law",
+          generation: "case_law_v2",
+        }),
+    )
+    .then(
+      () => null,
+      (error: unknown) => error,
+    );
+  expect(immediateRollbackRejection).toMatchObject({
+    message: "Corpus serving target is not reconciled: case_law/case_law_v2",
+  });
+
+  await db.transaction(
+    async (tx) =>
+      await resumeRetiringCorpusIndexGenerationTx(asTestRaw<Transaction>(tx), {
+        family: "case_law",
+        generation: "case_law_v2",
+      }),
+  );
+  expect(
+    await db.transaction(
+      async (tx) =>
+        await setServingCorpusIndexGenerationTx(asTestRaw<Transaction>(tx), {
+          family: "case_law",
+          generation: "case_law_v2",
+        }),
+    ),
+  ).toEqual({
+    family: "case_law",
+    generation: "case_law_v2",
+    cluster: "q08",
+  });
+  expect(
+    await readServingCorpusIndexGenerationTx(
+      asTestRaw<Transaction>(db),
+      "legislation",
+    ),
+  ).toEqual({
+    family: "legislation",
+    generation: "legislation_v1",
+    cluster: "q08",
   });
 });

--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
@@ -1,8 +1,13 @@
 import { panic } from "better-result";
-import { and, eq } from "drizzle-orm";
+import { and, eq, or, sql } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
 import { corpusIndexGenerations } from "@/api/db/schema";
+import {
+  corpusIndexClusterForGeneration,
+  type CorpusFamily,
+  type QuickwitCluster,
+} from "@/api/lib/legal-search/corpus-generation-contract";
 import {
   corpusIndexManifestDigest,
   requireCorpusIndexManifest,
@@ -17,12 +22,25 @@ type GenerationTargetFor<TManifest extends CorpusIndexManifest> =
 export type CorpusIndexGenerationTarget =
   GenerationTargetFor<CorpusIndexManifest>;
 
+export type ServingCorpusIndexGeneration = {
+  family: CorpusFamily;
+  generation: string;
+  cluster: QuickwitCluster;
+};
+
+type CorpusIndexGenerationReadTransaction = Pick<Transaction, "select">;
+type CorpusIndexGenerationRow = typeof corpusIndexGenerations.$inferSelect;
+type CorpusIndexGenerationContractRow = Pick<
+  CorpusIndexGenerationRow,
+  "cluster" | "family" | "generation" | "manifestDigest" | "status"
+>;
+
 export const requireRegisteredCorpusIndexManifest = ({
   family,
   generation,
   cluster,
   manifestDigest,
-}: typeof corpusIndexGenerations.$inferSelect): CorpusIndexManifest => {
+}: CorpusIndexGenerationContractRow): CorpusIndexManifest => {
   const manifest = requireCorpusIndexManifest(family, generation);
   const expectedDigest = corpusIndexManifestDigest(manifest);
   if (cluster !== manifest.cluster || manifestDigest !== expectedDigest) {
@@ -31,6 +49,118 @@ export const requireRegisteredCorpusIndexManifest = ({
     );
   }
   return manifest;
+};
+
+const requireServingCorpusIndexGeneration = (
+  row: CorpusIndexGenerationContractRow,
+  family: CorpusFamily,
+): ServingCorpusIndexGeneration => {
+  if (row.family !== family || row.status !== "serving") {
+    return panic(`Serving corpus generation row is malformed: ${family}`);
+  }
+  const expectedCluster = corpusIndexClusterForGeneration(
+    family,
+    row.generation,
+  );
+  if (row.cluster !== expectedCluster) {
+    return panic(
+      `Serving corpus generation cluster mismatch: ${family}/${row.generation}`,
+    );
+  }
+  if (row.cluster === "q09") {
+    requireRegisteredCorpusIndexManifest(row);
+  }
+  return {
+    family,
+    generation: row.generation,
+    cluster: row.cluster,
+  };
+};
+
+/** Read the one database-authoritative generation and closed cluster route. */
+export const readServingCorpusIndexGenerationTx = async (
+  tx: CorpusIndexGenerationReadTransaction,
+  family: CorpusFamily,
+): Promise<ServingCorpusIndexGeneration> => {
+  const rows = await tx
+    .select({
+      cluster: corpusIndexGenerations.cluster,
+      family: corpusIndexGenerations.family,
+      generation: corpusIndexGenerations.generation,
+      manifestDigest: corpusIndexGenerations.manifestDigest,
+      status: corpusIndexGenerations.status,
+    })
+    .from(corpusIndexGenerations)
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, family),
+        eq(corpusIndexGenerations.status, "serving"),
+      ),
+    )
+    .limit(2);
+  if (rows.length !== 1) {
+    return panic(`Expected one serving corpus generation: ${family}`);
+  }
+  return requireServingCorpusIndexGeneration(
+    rows.at(0) ?? panic(`Serving corpus generation disappeared: ${family}`),
+    family,
+  );
+};
+
+const requireActiveGenerationTarget = (
+  row: CorpusIndexGenerationContractRow,
+  target: { family: CorpusFamily; generation: string },
+): void => {
+  const expectedCluster = corpusIndexClusterForGeneration(
+    target.family,
+    target.generation,
+  );
+  if (row.cluster !== expectedCluster) {
+    return panic(
+      `Corpus serving target cluster mismatch: ${target.family}/${target.generation}`,
+    );
+  }
+  if (row.cluster === "q09") {
+    requireRegisteredCorpusIndexManifest(row);
+  }
+};
+
+/**
+ * Return a retiring generation to the build set before a rollback. Plane must
+ * reconcile and prove this generation again before it can become serving.
+ */
+export const resumeRetiringCorpusIndexGenerationTx = async (
+  tx: Transaction,
+  target: { family: CorpusFamily; generation: string },
+): Promise<void> => {
+  const rows = await tx
+    .select()
+    .from(corpusIndexGenerations)
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, target.family),
+        eq(corpusIndexGenerations.generation, target.generation),
+      ),
+    )
+    .limit(1)
+    .for("update");
+  const row = rows.at(0);
+  if (row?.status !== "retiring") {
+    return panic(
+      `Corpus generation is not retiring: ${target.family}/${target.generation}`,
+    );
+  }
+  requireActiveGenerationTarget(row, target);
+  await tx
+    .update(corpusIndexGenerations)
+    .set({ status: "building", updatedAt: sql`clock_timestamp()` })
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, target.family),
+        eq(corpusIndexGenerations.generation, target.generation),
+        eq(corpusIndexGenerations.status, "retiring"),
+      ),
+    );
 };
 
 /**
@@ -73,4 +203,68 @@ export const registerCorpusIndexGenerationTx = async (
     );
   }
   return requireRegisteredCorpusIndexManifest(row);
+};
+
+/**
+ * Atomically flip one family to a registered generation. Families route and
+ * roll back independently; retired generations cannot be resurrected.
+ */
+export const setServingCorpusIndexGenerationTx = async (
+  tx: Transaction,
+  target: { family: CorpusFamily; generation: string },
+): Promise<ServingCorpusIndexGeneration> => {
+  const rows = await tx
+    .select()
+    .from(corpusIndexGenerations)
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, target.family),
+        or(
+          eq(corpusIndexGenerations.generation, target.generation),
+          eq(corpusIndexGenerations.status, "serving"),
+        ),
+      ),
+    )
+    .orderBy(corpusIndexGenerations.generation)
+    .limit(2)
+    .for("update");
+  const targetRow = rows.find((row) => row.generation === target.generation);
+  if (
+    targetRow === undefined ||
+    (targetRow.status !== "building" && targetRow.status !== "serving")
+  ) {
+    return panic(
+      `Corpus serving target is not reconciled: ${target.family}/${target.generation}`,
+    );
+  }
+  requireActiveGenerationTarget(targetRow, target);
+  if (targetRow.status === "serving") {
+    return requireServingCorpusIndexGeneration(targetRow, target.family);
+  }
+  await tx
+    .update(corpusIndexGenerations)
+    .set({ status: "retiring", updatedAt: sql`clock_timestamp()` })
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, target.family),
+        eq(corpusIndexGenerations.status, "serving"),
+      ),
+    );
+  const promoted = await tx
+    .update(corpusIndexGenerations)
+    .set({ status: "serving", updatedAt: sql`clock_timestamp()` })
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, target.family),
+        eq(corpusIndexGenerations.generation, target.generation),
+      ),
+    )
+    .returning();
+  const promotedRow = promoted.at(0);
+  if (promoted.length !== 1 || promotedRow === undefined) {
+    return panic(
+      `Corpus serving target was lost: ${target.family}/${target.generation}`,
+    );
+  }
+  return requireServingCorpusIndexGeneration(promotedRow, target.family);
 };

--- a/apps/api/src/lib/legal-search/corpus-index-provider.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-provider.ts
@@ -20,9 +20,8 @@ import {
   caseLawCorpusProjectionJoin,
   currentCaseLawCorpusProjection,
 } from "@/api/lib/legal-search/case-law-corpus-projection";
-import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
-import { corpusIndexClusterForGeneration } from "@/api/lib/legal-search/corpus-generation-contract";
 import { corpusIndexBrowseFacets } from "@/api/lib/legal-search/corpus-index-facets";
+import { readServingCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 import { caseLawCorpusQuery } from "@/api/lib/legal-search/corpus-query";
 import { loadDocumentContext } from "@/api/lib/legal-search/document-context";
@@ -135,7 +134,11 @@ export const rehydrateCorpusIndexProviderCandidates =
 
 const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
   const limit = query.limit;
-  const generation = corpusGeneration(query.documentFamily ?? "case_law");
+  const family = query.documentFamily ?? "case_law";
+  const serving = await caseLawPublicReadDb(
+    async (tx) => await readServingCorpusIndexGenerationTx(tx, family),
+  );
+  const generation = serving.generation;
 
   // Scoped query → that jurisdiction's index, plus a jurisdiction clause when
   // that index holds other jurisdictions; unscoped → the generation glob
@@ -173,7 +176,7 @@ const search = async (query: LegalSearchQuery): Promise<LegalSearchResult> => {
   }
 
   const searchPage = await readCorpusIndexSearchPage({
-    cluster: corpusIndexClusterForGeneration("case_law", generation),
+    cluster: serving.cluster,
     indexId,
     query: engineQuery,
     limit,

--- a/apps/api/src/lib/legal-search/types.ts
+++ b/apps/api/src/lib/legal-search/types.ts
@@ -9,6 +9,8 @@ import type { CorpusFamily } from "@/api/lib/legal-search/corpus-family";
 import type { EmptyAst } from "@/api/lib/legal-search/document-types";
 import type { FacetBucket } from "@/api/lib/search/types";
 
+type LegalSearchDocumentFamily = Extract<CorpusFamily, "case_law">;
+
 /**
  * Provider-neutral contract for legal-corpus search. The app calls this,
  * never an engine directly, so swapping Postgres FTS for corpus index (and
@@ -21,8 +23,8 @@ export type LegalSearchEngine = (typeof LEGAL_SEARCH_ENGINES)[number];
 
 export type LegalSearchQuery = {
   query: string;
-  /** Document family to search; selects the index family. Default case_law. */
-  documentFamily?: CorpusFamily | undefined;
+  /** This provider contract returns decision-shaped case-law hits. */
+  documentFamily?: LegalSearchDocumentFamily | undefined;
   /** Maps from the decision's `country`. Required scoping in practice. */
   jurisdiction?: string | undefined;
   /** Maps from the decision's `decisionType`. */
@@ -103,8 +105,8 @@ export type LegalDocumentContext = {
  * cacheable for minutes.
  */
 export type LegalBrowseFacetsQuery = {
-  /** Document family to facet; selects the index family. Default case_law. */
-  documentFamily?: CorpusFamily | undefined;
+  /** Browse facets currently describe the case-law decision corpus. */
+  documentFamily?: LegalSearchDocumentFamily | undefined;
   /** Maps from the decision's `country`; scopes every facet to it. */
   jurisdiction?: string | undefined;
   /**

--- a/apps/api/src/tests/security/public-law-reader-role.test.ts
+++ b/apps/api/src/tests/security/public-law-reader-role.test.ts
@@ -8,7 +8,11 @@ import {
   stellaCaseLawReader,
   stellaPublicLawReader,
 } from "@/api/db/rls";
-import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import {
+  caseLawDecisions,
+  caseLawSources,
+  corpusIndexGenerations,
+} from "@/api/db/schema";
 import {
   readDecisionHandler,
   readDecisionTextColumnWritten,
@@ -35,6 +39,7 @@ import {
 } from "@/api/lib/case-law/language-alternate-counts";
 import { readNonRedistributableCaseLawSourceIdsQuery } from "@/api/lib/case-law/non-redistributable-sources";
 import { getCollator } from "@/api/lib/collation";
+import { readServingCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
 import { rehydrateCorpusIndexProviderCandidates } from "@/api/lib/legal-search/corpus-index-provider";
 import { readDocumentContextDecision } from "@/api/lib/legal-search/document-context";
 import { readPgFtsBrowseFacets } from "@/api/lib/legal-search/pg-fts-browse-facets";
@@ -484,6 +489,44 @@ describe("public-law reader role", () => {
     expect(errorMessageChain(publisherPayloadRejection)).toContain(
       "legislation_documents",
     );
+  });
+
+  test("resolves both serving generations as the public-law reader role", async () => {
+    try {
+      await testDb.transaction(async (tx) => {
+        await tx.insert(corpusIndexGenerations).values([
+          {
+            family: "case_law",
+            generation: "case_law_v2",
+            cluster: "q08",
+            manifestDigest: "a".repeat(64),
+            status: "serving",
+          },
+          {
+            family: "legislation",
+            generation: "legislation_v1",
+            cluster: "q08",
+            manifestDigest: "a".repeat(64),
+            status: "serving",
+          },
+        ]);
+        await tx.execute(sql.raw(`SET LOCAL ROLE ${quoted(READER_ROLE)}`));
+        expect(
+          await readServingCorpusIndexGenerationTx(tx, "case_law"),
+        ).toMatchObject({ family: "case_law", generation: "case_law_v2" });
+        expect(
+          await readServingCorpusIndexGenerationTx(tx, "legislation"),
+        ).toMatchObject({
+          family: "legislation",
+          generation: "legislation_v1",
+        });
+        tx.rollback();
+      });
+    } catch (error) {
+      if (!(error instanceof TransactionRollbackError)) {
+        throw error;
+      }
+    }
   });
 
   test("executes the production legislation rehydration query as the reader role", async () => {

--- a/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
@@ -17,7 +17,7 @@ import {
   timestampMatchesCasToken,
 } from "@/api/lib/db/timestamp-cas";
 import { ConcurrentModificationError } from "@/api/lib/errors/tagged-errors";
-import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
+import { legacyOperationalCorpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import { writeCorpusDocument } from "@/api/lib/legal-search/corpus-storage";
 import type {
   DecisionSection,
@@ -503,7 +503,7 @@ const backfillCaseLawIndex = async (
   limit: number | null,
   bulk: { indexBatchSize: number | null; indexReadConcurrency: number | null },
 ): Promise<IndexBackfillResult> => {
-  const generation = corpusGeneration("case_law");
+  const generation = legacyOperationalCorpusGeneration("case_law");
   let indexed = 0;
 
   while (true) {
@@ -555,7 +555,7 @@ const backfillLegislationIndex = async (
   limit: number | null,
   bulk: { indexBatchSize: number | null; indexReadConcurrency: number | null },
 ): Promise<IndexBackfillResult> => {
-  const generation = corpusGeneration("legislation");
+  const generation = legacyOperationalCorpusGeneration("legislation");
   let indexed = 0;
 
   while (true) {

--- a/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-ingest.ts
@@ -60,7 +60,7 @@ import { IngestionStallError } from "@/api/lib/errors/tagged-errors";
 import { errorTag } from "@/api/lib/errors/utils";
 import { backfillSearchIndex } from "@/api/lib/legal-search/case-law-search-index";
 import { acquireCaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
-import { corpusGeneration } from "@/api/lib/legal-search/corpus-family";
+import { legacyOperationalCorpusGeneration } from "@/api/lib/legal-search/corpus-family";
 import {
   DOCUMENT_FETCH_BUDGET_MS,
   fetchDecisionDocument,
@@ -1541,7 +1541,7 @@ export const runCaseLawIngest = async (
     if (!envBase.CORPUS_INDEXING_ENABLED) {
       return;
     }
-    const generation = corpusGeneration("legislation");
+    const generation = legacyOperationalCorpusGeneration("legislation");
     logInfo(`[legislation-corpus-index] Enabled for generation ${generation}`);
     while (true) {
       if (isDraining()) {


### PR DESCRIPTION
## Summary

- resolve every case-law and legislation corpus read from one database-authoritative serving row per family
- bind each generation to a closed q08/q09 cluster with no endpoint or env fallback
- add an atomic, independently reversible family flip primitive
- seed the current q08 generations without displacing any existing serving generation
- narrow the shared decision-search contract to case law; legislation keeps its dedicated typed handler

## Verification

- migration structure check and fresh-database rehearsal pass
- `git diff --check`
- focused database coverage for independent reads, promotion, and rollback
- full repository checks delegated to CI because the local dependency install is intentionally absent

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Search and facet browsing now use the active serving corpus configuration for consistent routing and pagination.
  - Added controlled promotion, retirement, resumption, and validation of corpus index generations.
  - Initial serving configurations are available for case law and legislation.

- **Bug Fixes**
  - Prevented conflicting or incomplete corpus cutovers.
  - Added safeguards for missing serving generations and invalid cluster or manifest assignments.

- **Tests**
  - Expanded coverage for serving-generation routing, promotions, rollbacks, security access, and migration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->