### PR TITLE
feat: fence corpus projection revisions

### DIFF
--- a/apps/api/drizzle/20260826004100_corpus_projection_revision_fence/migration.sql
+++ b/apps/api/drizzle/20260826004100_corpus_projection_revision_fence/migration.sql
@@ -1,0 +1,115 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- A generation-local mutation clock lets a standing engine census prove that
+-- its PostgreSQL desired-state snapshot remained current through promotion.
+ALTER TABLE "corpus_index_generations"
+  ADD COLUMN "projection_revision" bigint DEFAULT 1 NOT NULL;--> statement-breakpoint
+
+ALTER TABLE "corpus_index_generations"
+  ADD CONSTRAINT "corpus_index_generations_projection_revision_positive"
+  CHECK ("projection_revision" > 0) NOT VALID;--> statement-breakpoint
+
+-- stella-migration-safety: reviewed security-definer - trigger-only function has a fixed search path and PUBLIC execute is revoked below; rollback drops its triggers and function
+CREATE FUNCTION "bump_corpus_projection_revision_from_new"()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  UPDATE public."corpus_index_generations" generation
+     SET "projection_revision" = generation."projection_revision" + 1
+    FROM (
+      SELECT DISTINCT "family", "generation"
+        FROM new_rows
+    ) changed
+   WHERE generation."family" = changed."family"
+     AND generation."generation" = changed."generation";
+  RETURN NULL;
+END;
+$$;--> statement-breakpoint
+
+-- stella-migration-safety: reviewed security-definer - trigger-only function has a fixed search path and PUBLIC execute is revoked below; rollback drops its triggers and function
+CREATE FUNCTION "bump_corpus_projection_revision_from_old"()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  UPDATE public."corpus_index_generations" generation
+     SET "projection_revision" = generation."projection_revision" + 1
+    FROM (
+      SELECT DISTINCT "family", "generation"
+        FROM old_rows
+    ) changed
+   WHERE generation."family" = changed."family"
+     AND generation."generation" = changed."generation";
+  RETURN NULL;
+END;
+$$;--> statement-breakpoint
+
+-- stella-migration-safety: reviewed security-definer - trigger-only function has a fixed search path and PUBLIC execute is revoked below; rollback drops its triggers and function
+CREATE FUNCTION "bump_corpus_projection_revision_from_update"()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  UPDATE public."corpus_index_generations" generation
+     SET "projection_revision" = generation."projection_revision" + 1
+    FROM (
+      SELECT "family", "generation" FROM old_rows
+      UNION
+      SELECT "family", "generation" FROM new_rows
+    ) changed
+   WHERE generation."family" = changed."family"
+     AND generation."generation" = changed."generation";
+  RETURN NULL;
+END;
+$$;--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION "bump_corpus_projection_revision_from_new"()
+  FROM PUBLIC;--> statement-breakpoint
+REVOKE ALL ON FUNCTION "bump_corpus_projection_revision_from_old"()
+  FROM PUBLIC;--> statement-breakpoint
+REVOKE ALL ON FUNCTION "bump_corpus_projection_revision_from_update"()
+  FROM PUBLIC;--> statement-breakpoint
+
+CREATE TRIGGER "corpus_projection_states_revision_insert"
+  AFTER INSERT ON "corpus_index_projection_states"
+  REFERENCING NEW TABLE AS new_rows
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION "bump_corpus_projection_revision_from_new"();--> statement-breakpoint
+
+CREATE TRIGGER "corpus_projection_states_revision_update"
+  AFTER UPDATE ON "corpus_index_projection_states"
+  REFERENCING OLD TABLE AS old_rows NEW TABLE AS new_rows
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION "bump_corpus_projection_revision_from_update"();--> statement-breakpoint
+
+CREATE TRIGGER "corpus_projection_states_revision_delete"
+  AFTER DELETE ON "corpus_index_projection_states"
+  REFERENCING OLD TABLE AS old_rows
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION "bump_corpus_projection_revision_from_old"();--> statement-breakpoint
+
+CREATE TRIGGER "corpus_projection_intents_revision_insert"
+  AFTER INSERT ON "corpus_index_projection_intents"
+  REFERENCING NEW TABLE AS new_rows
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION "bump_corpus_projection_revision_from_new"();--> statement-breakpoint
+
+CREATE TRIGGER "corpus_projection_intents_revision_update"
+  AFTER UPDATE ON "corpus_index_projection_intents"
+  REFERENCING OLD TABLE AS old_rows NEW TABLE AS new_rows
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION "bump_corpus_projection_revision_from_update"();--> statement-breakpoint
+
+CREATE TRIGGER "corpus_projection_intents_revision_delete"
+  AFTER DELETE ON "corpus_index_projection_intents"
+  REFERENCING OLD TABLE AS old_rows
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION "bump_corpus_projection_revision_from_old"();

--- a/apps/api/drizzle/20260826004110_corpus_projection_revision_validate/migration.sql
+++ b/apps/api/drizzle/20260826004110_corpus_projection_revision_validate/migration.sql
@@ -1,0 +1,8 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Validate outside the ADD transaction so the table scan does not inherit its
+-- ACCESS EXCLUSIVE lock. The generation registry is bounded and currently
+-- small; the timeout keeps that assumption explicit.
+ALTER TABLE "corpus_index_generations"
+  VALIDATE CONSTRAINT "corpus_index_generations_projection_revision_positive";

--- a/apps/api/src/db/schema/corpus-index-generations.ts
+++ b/apps/api/src/db/schema/corpus-index-generations.ts
@@ -35,6 +35,10 @@ export const corpusIndexGenerations = p.pgTable(
     cluster: p.text({ enum: QUICKWIT_CLUSTERS }).notNull(),
     manifestDigest: p.varchar("manifest_digest", { length: 64 }).notNull(),
     status: p.text({ enum: CORPUS_INDEX_GENERATION_STATUSES }).notNull(),
+    projectionRevision: p
+      .bigint("projection_revision", { mode: "number" })
+      .default(1)
+      .notNull(),
     createdAt: timestamptz("created_at").defaultNow().notNull(),
     updatedAt: timestamptz("updated_at")
       .defaultNow()
@@ -65,6 +69,10 @@ export const corpusIndexGenerations = p.pgTable(
     p.check(
       "corpus_index_generations_manifest_digest_shape",
       sql`${t.manifestDigest} ~ '^[0-9a-f]{64}$'`,
+    ),
+    p.check(
+      "corpus_index_generations_projection_revision_positive",
+      sql`${t.projectionRevision} > 0`,
     ),
     p.check(
       "corpus_index_generations_name_matches_family",

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.db.test.ts
@@ -1,0 +1,159 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  corpusIndexGenerations,
+  corpusIndexProjectionIntents,
+  corpusIndexProjectionStates,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+import {
+  lockCorpusIndexProjectionPromotionTx,
+  lockCorpusIndexProjectionRevisionTx,
+  readCorpusIndexProjectionRevisionTx,
+} from "./corpus-index-projection-revision";
+
+const TARGET = {
+  family: "case_law",
+  generation: "case_law_v5",
+} as const;
+const ENTITY_IDS = [
+  "0198e331-e578-7000-8000-000000000501",
+  "0198e331-e578-7000-8000-000000000502",
+] as const;
+const INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000503",
+);
+const MIGRATION_URL = new URL(
+  "../../../drizzle/20260826004100_corpus_projection_revision_fence/migration.sql",
+  import.meta.url,
+);
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const revision = async (): Promise<number> => {
+  const rows = await db
+    .select({ value: corpusIndexGenerations.projectionRevision })
+    .from(corpusIndexGenerations)
+    .where(eq(corpusIndexGenerations.generation, TARGET.generation));
+  return rows.at(0)?.value ?? 0;
+};
+
+beforeAll(
+  async () => {
+    client = await createTestPglite();
+    db = drizzle({ client });
+    const migration = await Bun.file(MIGRATION_URL).text();
+    for (const statement of migration.split("--> statement-breakpoint")) {
+      const ddl = statement.trim();
+      if (
+        !/(?:^|\n)\s*CREATE FUNCTION\b/u.test(ddl) &&
+        !/(?:^|\n)\s*REVOKE ALL ON FUNCTION\b/u.test(ddl) &&
+        !/(?:^|\n)\s*CREATE TRIGGER\b/u.test(ddl)
+      ) {
+        continue;
+      }
+      // oxlint-disable-next-line no-await-in-loop -- each trigger depends on its preceding production function and privilege statement
+      await db.execute(sql.raw(ddl));
+    }
+    await db.insert(corpusIndexGenerations).values({
+      ...TARGET,
+      cluster: "q09",
+      manifestDigest: "a".repeat(64),
+      status: "building",
+    });
+  },
+  { timeout: 120_000 },
+);
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("projection mutations advance one durable revision per statement", async () => {
+  expect(await revision()).toBe(1);
+
+  await db.insert(corpusIndexProjectionStates).values([
+    {
+      ...TARGET,
+      entityId: ENTITY_IDS[0],
+      desiredAction: "erase",
+      desiredEpoch: 1n,
+    },
+    {
+      ...TARGET,
+      entityId: ENTITY_IDS[1],
+      desiredAction: "erase",
+      desiredEpoch: 1n,
+    },
+  ]);
+  expect(await revision()).toBe(2);
+
+  await db.insert(corpusIndexProjectionIntents).values({
+    id: INTENT_ID,
+    ...TARGET,
+    entityId: ENTITY_IDS[0],
+    epoch: 1n,
+    fingerprint: "b".repeat(64),
+    indexId: "case_law_v5_cs_sk",
+    status: "cancelled",
+    cancelledAt: new Date("2026-08-26T00:00:00.000Z"),
+  });
+  expect(await revision()).toBe(3);
+
+  await db
+    .update(corpusIndexProjectionStates)
+    .set({ updatedAt: new Date("2026-08-26T00:00:01.000Z") })
+    .where(eq(corpusIndexProjectionStates.family, TARGET.family));
+  expect(await revision()).toBe(4);
+
+  await db
+    .delete(corpusIndexProjectionIntents)
+    .where(eq(corpusIndexProjectionIntents.id, INTENT_ID));
+  expect(await revision()).toBe(5);
+
+  await db
+    .update(corpusIndexProjectionStates)
+    .set({ updatedAt: new Date("2026-08-26T00:00:02.000Z") })
+    .where(
+      eq(
+        corpusIndexProjectionStates.entityId,
+        "0198e331-e578-7000-8000-000000000599",
+      ),
+    );
+  expect(await revision()).toBe(5);
+});
+
+test("the revision shares the projection mutation transaction", async () => {
+  const beforeRollback = await revision();
+  await expect(
+    db.transaction(async (tx) => {
+      await tx
+        .update(corpusIndexProjectionStates)
+        .set({ updatedAt: new Date("2026-08-26T00:00:03.000Z") })
+        .where(eq(corpusIndexProjectionStates.entityId, ENTITY_IDS[0]));
+      throw new Error("roll back revision fixture");
+    }),
+  ).rejects.toThrow("roll back revision fixture");
+  expect(await revision()).toBe(beforeRollback);
+});
+
+test("the typed read and proof boundaries return the current revision", async () => {
+  const [read, locked, promotion] = await db.transaction(async (tx) => {
+    const transaction = asTestRaw<Transaction>(tx);
+    return [
+      await readCorpusIndexProjectionRevisionTx(transaction, TARGET),
+      await lockCorpusIndexProjectionRevisionTx(transaction, TARGET),
+      await lockCorpusIndexProjectionPromotionTx(transaction, TARGET),
+    ];
+  });
+  expect(read).toBe(await revision());
+  expect(locked).toBe(read);
+  expect(promotion).toBe(read);
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.db.test.ts
@@ -132,15 +132,23 @@ test("projection mutations advance one durable revision per statement", async ()
 
 test("the revision shares the projection mutation transaction", async () => {
   const beforeRollback = await revision();
-  await expect(
-    db.transaction(async (tx) => {
+  // bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+  // type-aware lint; capture the rejection explicitly instead.
+  const rejection: unknown = await db
+    .transaction(async (tx) => {
       await tx
         .update(corpusIndexProjectionStates)
         .set({ updatedAt: new Date("2026-08-26T00:00:03.000Z") })
         .where(eq(corpusIndexProjectionStates.entityId, ENTITY_IDS[0]));
       throw new Error("roll back revision fixture");
-    }),
-  ).rejects.toThrow("roll back revision fixture");
+    })
+    .then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+  expect(rejection).toBeInstanceOf(Error);
+  expect(rejection).toMatchObject({ message: "roll back revision fixture" });
   expect(await revision()).toBe(beforeRollback);
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.ts
@@ -1,0 +1,78 @@
+import { panic } from "better-result";
+import { and, eq } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db/root";
+import { corpusIndexGenerations } from "@/api/db/schema";
+import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
+
+type CorpusProjectionRevisionTarget = {
+  family: CorpusFamily;
+  generation: string;
+};
+
+const projectionRevisionQuery = (
+  tx: Transaction,
+  target: CorpusProjectionRevisionTarget,
+) =>
+  tx
+    .select({ projectionRevision: corpusIndexGenerations.projectionRevision })
+    .from(corpusIndexGenerations)
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, target.family),
+        eq(corpusIndexGenerations.generation, target.generation),
+      ),
+    )
+    .limit(1);
+
+const requireProjectionRevision = (
+  rows: { projectionRevision: number }[],
+  target: CorpusProjectionRevisionTarget,
+): number => {
+  const revision = rows.at(0)?.projectionRevision;
+  if (
+    typeof revision !== "number" ||
+    !Number.isSafeInteger(revision) ||
+    revision < 1
+  ) {
+    return panic(
+      `Corpus projection revision is malformed: ${target.family}/${target.generation}`,
+    );
+  }
+  return revision;
+};
+
+/** Read the mutation clock without holding its row lock across engine I/O. */
+export const readCorpusIndexProjectionRevisionTx = async (
+  tx: Transaction,
+  target: CorpusProjectionRevisionTarget,
+): Promise<number> =>
+  requireProjectionRevision(await projectionRevisionQuery(tx, target), target);
+
+/**
+ * Fence a generation's desired/applied state at one exact mutation revision.
+ * Projection-table statement triggers need an exclusive lock on this row, so
+ * they cannot commit across a transaction that holds this proof through flip.
+ */
+export const lockCorpusIndexProjectionRevisionTx = async (
+  tx: Transaction,
+  target: CorpusProjectionRevisionTarget,
+): Promise<number> =>
+  requireProjectionRevision(
+    await projectionRevisionQuery(tx, target).for("share"),
+    target,
+  );
+
+/**
+ * Serialize explicit promotion before its final proof and serving flip. This
+ * avoids two operators taking shared proofs and deadlocking while both try to
+ * upgrade the generation row for the transition.
+ */
+export const lockCorpusIndexProjectionPromotionTx = async (
+  tx: Transaction,
+  target: CorpusProjectionRevisionTarget,
+): Promise<number> =>
+  requireProjectionRevision(
+    await projectionRevisionQuery(tx, target).for("update"),
+    target,
+  );


### PR DESCRIPTION
## Summary

- add a generation-local mutation revision for corpus projection state and intents
- advance it once per affected generation and SQL statement through fixed-search-path triggers
- expose separate typed boundaries for unlocked census reads and shared-lock final proofs

The shared-lock boundary prevents projection mutations from committing across a final proof transaction. Long engine scans use the unlocked read, then compare under the lock only when persisting a zero-drift result.

## Tests

- `bun test apps/api/src/lib/legal-search/corpus-index-projection-revision.db.test.ts apps/api/src/db/migration-concurrent-index.test.ts` (21 passed)

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added revision tracking for corpus index projections.
  - Added reliable reading and locking of projection revisions during processing.
- **Bug Fixes**
  - Improved consistency when projection data is inserted, updated or deleted.
  - Revisions now roll back correctly when related transactions fail.
  - Unrelated data changes no longer affect projection revisions.
- **Tests**
  - Added coverage for revision updates, transaction rollbacks, validation and consistent access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->