### PR TITLE
feat: ask about start on login during onboarding

### DIFF
--- a/apps/desktop/fixtures/desktop-telemetry-contract.json
+++ b/apps/desktop/fixtures/desktop-telemetry-contract.json
@@ -1,0 +1,35 @@
+{
+  "windows": [
+    "clipboard",
+    "clipboardEditor",
+    "main",
+    "selfHostConnectDialog",
+    "takeoverDialog"
+  ],
+  "operations": [
+    "autostartRead",
+    "autostartUpdate",
+    "clipboardEditorClose",
+    "clipboardEditorRead",
+    "clipboardEditorSave",
+    "clipboardCopy",
+    "clipboardExternalOpen",
+    "clipboardHistoryRead",
+    "clipboardHistorySubscribe",
+    "clipboardHistoryUpdate",
+    "clipboardWindowHide",
+    "render",
+    "runtime"
+  ],
+  "errorCodes": [
+    "eventSubscriptionFailed",
+    "invalidResponse",
+    "invokeFailed",
+    "reactCaught",
+    "reactRecoverable",
+    "reactUncaught",
+    "unhandledError",
+    "unhandledRejection",
+    "windowLabelMismatch"
+  ]
+}

--- a/apps/desktop/src-tauri/capabilities/clipboard.json
+++ b/apps/desktop/src-tauri/capabilities/clipboard.json
@@ -5,6 +5,8 @@
   "permissions": [
     "core:event:allow-listen",
     "core:event:allow-unlisten",
+    "allow-is-autostart-enabled",
+    "allow-set-autostart",
     "allow-clipboard-get-snapshot",
     "allow-clipboard-complete-welcome",
     "allow-clipboard-set-capture-status",

--- a/apps/desktop/src-tauri/src/desktop_telemetry.rs
+++ b/apps/desktop/src-tauri/src/desktop_telemetry.rs
@@ -42,6 +42,8 @@ impl DesktopTelemetryWindow {
 pub enum DesktopTelemetryOperation {
   Runtime,
   Render,
+  AutostartRead,
+  AutostartUpdate,
   ClipboardHistoryRead,
   ClipboardHistorySubscribe,
   ClipboardHistoryUpdate,
@@ -62,6 +64,8 @@ impl DesktopTelemetryOperation {
     match self {
       Self::Runtime => "runtime",
       Self::Render => "render",
+      Self::AutostartRead => "autostartRead",
+      Self::AutostartUpdate => "autostartUpdate",
       Self::ClipboardHistoryRead => "clipboardHistoryRead",
       Self::ClipboardHistorySubscribe => "clipboardHistorySubscribe",
       Self::ClipboardHistoryUpdate => "clipboardHistoryUpdate",
@@ -293,6 +297,14 @@ pub fn desktop_report_error(
 mod tests {
   use super::*;
 
+  #[derive(Deserialize)]
+  #[serde(rename_all = "camelCase")]
+  struct FrontendTelemetryContract {
+    windows: Vec<DesktopTelemetryWindow>,
+    operations: Vec<DesktopTelemetryOperation>,
+    error_codes: Vec<DesktopTelemetryErrorCode>,
+  }
+
   fn config() -> AnalyticsSinkConfig {
     AnalyticsSinkConfig {
       endpoint: Url::parse("https://example.com/capture/").unwrap(),
@@ -344,6 +356,33 @@ mod tests {
         .unwrap()
         .insert(field.to_string(), json!("private"));
       assert!(serde_json::from_value::<DesktopErrorReport>(value).is_err());
+    }
+  }
+
+  #[test]
+  fn frontend_telemetry_contract_deserializes_in_native_code() {
+    let contract: FrontendTelemetryContract = serde_json::from_str(include_str!(
+      "../../fixtures/desktop-telemetry-contract.json"
+    ))
+    .unwrap();
+
+    for window in contract.windows {
+      assert_eq!(
+        serde_json::to_value(window).unwrap(),
+        json!(window.as_str())
+      );
+    }
+    for operation in contract.operations {
+      assert_eq!(
+        serde_json::to_value(operation).unwrap(),
+        json!(operation.as_str())
+      );
+    }
+    for error_code in contract.error_codes {
+      assert_eq!(
+        serde_json::to_value(error_code).unwrap(),
+        json!(error_code.as_str())
+      );
     }
   }
 }

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -915,8 +915,8 @@ const ClipboardWelcomeDialog = ({ onClose }: ClipboardWelcomeDialogProps) => {
   return (
     <Dialog
       onOpenChange={(open) => {
-        if (!open && autostartChoice.status !== "saving") {
-          onClose();
+        if (!open) {
+          completeWelcome();
         }
       }}
       open

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -36,6 +36,7 @@ import {
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/button";
+import { Checkbox } from "@stll/ui/checkbox";
 import {
   Dialog,
   DialogClose,
@@ -52,6 +53,7 @@ import {
   InputGroupAddon,
   InputGroupInput,
 } from "@stll/ui/input-group";
+import { Label } from "@stll/ui/label";
 import {
   Menu,
   MenuItem,
@@ -770,8 +772,33 @@ type ClipboardWelcomeDialogProps = {
   onClose: () => void;
 };
 
+const AUTOSTART_ERROR = {
+  read: "read",
+  update: "update",
+} as const;
+
+type AutostartError = (typeof AUTOSTART_ERROR)[keyof typeof AUTOSTART_ERROR];
+
+type AutostartChoiceState =
+  | { status: "loading" }
+  | {
+      enabled: boolean;
+      error: AutostartError | null;
+      initialEnabled: boolean | null;
+      status: "ready";
+    }
+  | {
+      enabled: boolean;
+      initialEnabled: boolean | null;
+      status: "saving";
+    };
+
 const ClipboardWelcomeDialog = ({ onClose }: ClipboardWelcomeDialogProps) => {
   const t = useTranslations("clipboard");
+  const settingsT = useTranslations("settings");
+  const [autostartChoice, setAutostartChoice] = useState<AutostartChoiceState>({
+    status: "loading",
+  });
   const features = [
     {
       description: t("welcomeCaptureDescription"),
@@ -792,10 +819,103 @@ const ClipboardWelcomeDialog = ({ onClose }: ClipboardWelcomeDialogProps) => {
     },
   ];
 
+  useEffect(() => {
+    let mounted = true;
+    void invoke<boolean>("is_autostart_enabled")
+      .then((enabled) => {
+        if (!mounted) {
+          return undefined;
+        }
+        setAutostartChoice({
+          enabled,
+          error: null,
+          initialEnabled: enabled,
+          status: "ready",
+        });
+        return undefined;
+      })
+      .catch(() => {
+        reportDesktopError({
+          code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+          operation: DESKTOP_TELEMETRY_OPERATIONS.autostartRead,
+          window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
+        });
+        if (!mounted) {
+          return;
+        }
+        setAutostartChoice({
+          enabled: false,
+          error: AUTOSTART_ERROR.read,
+          initialEnabled: null,
+          status: "ready",
+        });
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const completeWelcome = () => {
+    if (autostartChoice.status === "loading") {
+      onClose();
+      return;
+    }
+    if (autostartChoice.status === "saving") {
+      return;
+    }
+    const { enabled, initialEnabled } = autostartChoice;
+    if (enabled === initialEnabled || (initialEnabled === null && !enabled)) {
+      onClose();
+      return;
+    }
+    setAutostartChoice({ enabled, initialEnabled, status: "saving" });
+    void invoke<boolean>("set_autostart", { enabled })
+      .then((updatedEnabled) => {
+        if (updatedEnabled === enabled) {
+          onClose();
+          return undefined;
+        }
+        reportDesktopError({
+          code: DESKTOP_TELEMETRY_ERROR_CODES.invalidResponse,
+          operation: DESKTOP_TELEMETRY_OPERATIONS.autostartUpdate,
+          window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
+        });
+        setAutostartChoice({
+          enabled,
+          error: AUTOSTART_ERROR.update,
+          initialEnabled,
+          status: "ready",
+        });
+        return undefined;
+      })
+      .catch(() => {
+        reportDesktopError({
+          code: DESKTOP_TELEMETRY_ERROR_CODES.invokeFailed,
+          operation: DESKTOP_TELEMETRY_OPERATIONS.autostartUpdate,
+          window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
+        });
+        setAutostartChoice({
+          enabled,
+          error: AUTOSTART_ERROR.update,
+          initialEnabled,
+          status: "ready",
+        });
+      });
+  };
+
+  const autostartEnabled =
+    autostartChoice.status === "loading" ? false : autostartChoice.enabled;
+  const autostartError =
+    autostartChoice.status === "ready" ? autostartChoice.error : null;
+  const autostartErrorMessage =
+    autostartError === AUTOSTART_ERROR.read
+      ? settingsT("errorReadState")
+      : settingsT("errorUpdateAutostart");
+
   return (
     <Dialog
       onOpenChange={(open) => {
-        if (!open) {
+        if (!open && autostartChoice.status !== "saving") {
           onClose();
         }
       }}
@@ -839,11 +959,50 @@ const ClipboardWelcomeDialog = ({ onClose }: ClipboardWelcomeDialogProps) => {
               </div>
             ))}
           </div>
+          <Label
+            className="bg-muted/48 mt-3 min-h-14 w-full cursor-pointer items-start gap-3 rounded-2xl px-4 py-3"
+            htmlFor="clipboard-welcome-autostart"
+          >
+            <Checkbox
+              checked={autostartEnabled}
+              className="mt-0.5"
+              disabled={autostartChoice.status !== "ready"}
+              id="clipboard-welcome-autostart"
+              onCheckedChange={(enabled) => {
+                if (autostartChoice.status !== "ready") {
+                  return;
+                }
+                setAutostartChoice({
+                  enabled,
+                  error: null,
+                  initialEnabled: autostartChoice.initialEnabled,
+                  status: "ready",
+                });
+              }}
+            />
+            <span className="min-w-0 flex-1">
+              <span className="block text-sm font-medium">
+                {settingsT("startOnLogin")}
+              </span>
+              <span className="text-muted-foreground mt-1 block text-sm leading-relaxed">
+                {settingsT("startOnLoginDescription")}
+              </span>
+              {autostartError ? (
+                <span
+                  className="text-destructive mt-1 block text-xs leading-relaxed"
+                  role="alert"
+                >
+                  {autostartErrorMessage}
+                </span>
+              ) : null}
+            </span>
+          </Label>
         </DialogPanel>
         <DialogFooter className="px-5 pb-5" variant="bare">
           <Button
             className="min-h-11 rounded-xl"
-            onClick={onClose}
+            disabled={autostartChoice.status !== "ready"}
+            onClick={completeWelcome}
             type="button"
           >
             {t("welcomeStart")}

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -857,7 +857,6 @@ const ClipboardWelcomeDialog = ({ onClose }: ClipboardWelcomeDialogProps) => {
 
   const completeWelcome = () => {
     if (autostartChoice.status === "loading") {
-      onClose();
       return;
     }
     if (autostartChoice.status === "saving") {

--- a/apps/desktop/src/i18n/langs/cs.json
+++ b/apps/desktop/src/i18n/langs/cs.json
@@ -61,6 +61,7 @@
     "errorEmailSupport": "stella desktop nemohl otevřít vaši poštovní aplikaci.",
     "errorReadState": "stella desktop nemohl přečíst svůj aktuální stav.",
     "errorRevealAppData": "stella desktop nemohl zobrazit data aplikace.",
+    "errorUpdateAutostart": "Aplikaci stella desktop se nepodařilo nastavit spouštění při přihlášení.",
     "errorUpdatePreferences": "stella desktop nemohl aktualizovat nastavení oznámení.",
     "general": "Obecné",
     "lastVerified": "Naposledy ověřeno",

--- a/apps/desktop/src/i18n/langs/de.json
+++ b/apps/desktop/src/i18n/langs/de.json
@@ -61,6 +61,7 @@
     "errorEmailSupport": "stella desktop konnte Ihre E-Mail-App nicht öffnen.",
     "errorReadState": "stella desktop konnte seinen aktuellen Status nicht lesen.",
     "errorRevealAppData": "stella desktop konnte die App-Daten nicht anzeigen.",
+    "errorUpdateAutostart": "stella desktop konnte den Start bei der Anmeldung nicht aktualisieren.",
     "errorUpdatePreferences": "stella desktop konnte die Benachrichtigungseinstellungen nicht aktualisieren.",
     "general": "Allgemein",
     "lastVerified": "Zuletzt überprüft",

--- a/apps/desktop/src/i18n/langs/en.json
+++ b/apps/desktop/src/i18n/langs/en.json
@@ -63,6 +63,7 @@
     "errorEmailSupport": "stella desktop could not open your mail app.",
     "errorReadState": "stella desktop could not read its current state.",
     "errorRevealAppData": "stella desktop could not reveal app data.",
+    "errorUpdateAutostart": "stella desktop could not update start-on-login.",
     "errorUpdatePreferences": "stella desktop could not update notification settings.",
     "general": "General",
     "lastVerified": "Last verified",

--- a/apps/desktop/src/i18n/langs/es.json
+++ b/apps/desktop/src/i18n/langs/es.json
@@ -61,6 +61,7 @@
     "errorEmailSupport": "stella desktop no pudo abrir su aplicación de correo.",
     "errorReadState": "stella desktop no pudo leer su estado actual.",
     "errorRevealAppData": "stella desktop no pudo mostrar los datos de la app.",
+    "errorUpdateAutostart": "stella desktop no pudo actualizar el inicio de sesión automático.",
     "errorUpdatePreferences": "stella desktop no pudo actualizar la configuración de notificaciones.",
     "general": "General",
     "lastVerified": "Última verificación",

--- a/apps/desktop/src/i18n/langs/es.json
+++ b/apps/desktop/src/i18n/langs/es.json
@@ -61,7 +61,7 @@
     "errorEmailSupport": "stella desktop no pudo abrir su aplicación de correo.",
     "errorReadState": "stella desktop no pudo leer su estado actual.",
     "errorRevealAppData": "stella desktop no pudo mostrar los datos de la app.",
-    "errorUpdateAutostart": "stella desktop no pudo actualizar el inicio de sesión automático.",
+    "errorUpdateAutostart": "stella desktop no pudo actualizar el inicio de la aplicación al iniciar sesión.",
     "errorUpdatePreferences": "stella desktop no pudo actualizar la configuración de notificaciones.",
     "general": "General",
     "lastVerified": "Última verificación",

--- a/apps/desktop/src/i18n/langs/et.json
+++ b/apps/desktop/src/i18n/langs/et.json
@@ -61,6 +61,7 @@
     "errorEmailSupport": "stella desktop ei saanud teie meilirakendust avada.",
     "errorReadState": "stella desktop ei saanud oma praegust olekut lugeda.",
     "errorRevealAppData": "stella desktop ei saanud rakenduse andmeid kuvada.",
+    "errorUpdateAutostart": "stella desktop ei saanud sisselogimisel käivitamist uuendada.",
     "errorUpdatePreferences": "stella desktop ei saanud teavituste seadeid uuendada.",
     "general": "Üldine",
     "lastVerified": "Viimati kontrollitud",

--- a/apps/desktop/src/i18n/langs/fr.json
+++ b/apps/desktop/src/i18n/langs/fr.json
@@ -61,6 +61,7 @@
     "errorEmailSupport": "stella desktop n'a pas pu ouvrir votre application de messagerie.",
     "errorReadState": "stella desktop n'a pas pu lire son état actuel.",
     "errorRevealAppData": "stella desktop n'a pas pu afficher les données de l'app.",
+    "errorUpdateAutostart": "stella desktop n’a pas pu modifier le démarrage à la connexion.",
     "errorUpdatePreferences": "stella desktop n'a pas pu mettre à jour les paramètres de notification.",
     "general": "Général",
     "lastVerified": "Dernière vérification",

--- a/apps/desktop/src/i18n/langs/hu.json
+++ b/apps/desktop/src/i18n/langs/hu.json
@@ -61,6 +61,7 @@
     "errorEmailSupport": "A stella desktop nem tudta megnyitni az e-mail alkalmazást.",
     "errorReadState": "A stella desktop nem tudta beolvasni az aktuális állapotát.",
     "errorRevealAppData": "A stella desktop nem tudta megjeleníteni az alkalmazásadatokat.",
+    "errorUpdateAutostart": "A stella desktop nem tudta frissíteni a bejelentkezéskori indítást.",
     "errorUpdatePreferences": "A stella desktop nem tudta frissíteni az értesítési beállításokat.",
     "general": "Általános",
     "lastVerified": "Utoljára ellenőrizve",

--- a/apps/desktop/src/i18n/langs/lt.json
+++ b/apps/desktop/src/i18n/langs/lt.json
@@ -61,6 +61,7 @@
     "errorEmailSupport": "stella desktop nepavyko atidaryti jūsų el. pašto programos.",
     "errorReadState": "stella desktop nepavyko nuskaityti dabartinės būsenos.",
     "errorRevealAppData": "stella desktop nepavyko parodyti programos duomenų.",
+    "errorUpdateAutostart": "stella desktop nepavyko atnaujinti paleidimo prisijungiant.",
     "errorUpdatePreferences": "stella desktop nepavyko atnaujinti pranešimų nustatymų.",
     "general": "Bendra",
     "lastVerified": "Paskutinį kartą patikrinta",

--- a/apps/desktop/src/i18n/langs/lv.json
+++ b/apps/desktop/src/i18n/langs/lv.json
@@ -61,6 +61,7 @@
     "errorEmailSupport": "stella desktop nevarēja atvērt jūsu e-pasta lietotni.",
     "errorReadState": "stella desktop nevarēja nolasīt savu pašreizējo stāvokli.",
     "errorRevealAppData": "stella desktop nevarēja rādīt lietotnes datus.",
+    "errorUpdateAutostart": "stella desktop neizdevās atjaunināt palaišanu piesakoties.",
     "errorUpdatePreferences": "stella desktop nevarēja atjaunināt paziņojumu iestatījumus.",
     "general": "Vispārīgi",
     "lastVerified": "Pēdējo reizi pārbaudīts",

--- a/apps/desktop/src/i18n/langs/pl.json
+++ b/apps/desktop/src/i18n/langs/pl.json
@@ -61,6 +61,7 @@
     "errorEmailSupport": "stella desktop nie mógł otworzyć aplikacji pocztowej.",
     "errorReadState": "stella desktop nie mógł odczytać swojego bieżącego stanu.",
     "errorRevealAppData": "stella desktop nie mógł wyświetlić danych aplikacji.",
+    "errorUpdateAutostart": "stella desktop nie mogła zmienić uruchamiania przy logowaniu.",
     "errorUpdatePreferences": "stella desktop nie mógł zaktualizować ustawień powiadomień.",
     "general": "Ogólne",
     "lastVerified": "Ostatnio zweryfikowano",

--- a/apps/desktop/src/i18n/langs/sk.json
+++ b/apps/desktop/src/i18n/langs/sk.json
@@ -61,6 +61,7 @@
     "errorEmailSupport": "stella desktop nemohol otvoriť vašu poštovú aplikáciu.",
     "errorReadState": "stella desktop nemohol prečítať svoj aktuálny stav.",
     "errorRevealAppData": "stella desktop nemohol zobraziť dáta aplikácie.",
+    "errorUpdateAutostart": "Aplikácii stella desktop sa nepodarilo zmeniť spúšťanie pri prihlásení.",
     "errorUpdatePreferences": "stella desktop nemohol aktualizovať nastavenia oznámení.",
     "general": "Všeobecné",
     "lastVerified": "Naposledy overené",

--- a/apps/desktop/src/telemetry/desktop-telemetry.ts
+++ b/apps/desktop/src/telemetry/desktop-telemetry.ts
@@ -9,6 +9,8 @@ export const DESKTOP_TELEMETRY_WINDOWS = {
 } as const;
 
 export const DESKTOP_TELEMETRY_OPERATIONS = {
+  autostartRead: "autostartRead",
+  autostartUpdate: "autostartUpdate",
   clipboardEditorClose: "clipboardEditorClose",
   clipboardEditorRead: "clipboardEditorRead",
   clipboardEditorSave: "clipboardEditorSave",

--- a/apps/desktop/tests/clipboard-capabilities.test.ts
+++ b/apps/desktop/tests/clipboard-capabilities.test.ts
@@ -3,15 +3,18 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 const DESKTOP_ROOT = path.join(import.meta.dir, "..");
-const COMMAND_PATTERN =
-  /\b(?:applySnapshotCommand|invoke(?:<[^>]+>)?|onCommand)\(\s*"(clipboard_[a-z_]+)"/gu;
+const INVOKE_COMMAND_PATTERN = /\binvoke(?:<[^>]+>)?\(\s*"([a-z_]+)"/gu;
+const SNAPSHOT_COMMAND_PATTERN =
+  /\b(?:applySnapshotCommand|onCommand)\(\s*"(clipboard_[a-z_]+)"/gu;
 
 const invokedClipboardCommands = async (sourcePath: string) => {
   const source = await readFile(path.join(DESKTOP_ROOT, sourcePath), "utf-8");
-  return [...source.matchAll(COMMAND_PATTERN)].flatMap((match) => {
-    const command = match.at(1);
-    return command ? [command] : [];
-  });
+  return [INVOKE_COMMAND_PATTERN, SNAPSHOT_COMMAND_PATTERN].flatMap((pattern) =>
+    [...source.matchAll(pattern)].flatMap((match) => {
+      const command = match.at(1);
+      return command ? [command] : [];
+    }),
+  );
 };
 
 const grantedCommands = async (capabilityPath: string) => {

--- a/apps/desktop/tests/desktop-telemetry-contract.test.ts
+++ b/apps/desktop/tests/desktop-telemetry-contract.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import contract from "../fixtures/desktop-telemetry-contract.json" with { type: "json" };
+import {
+  DESKTOP_TELEMETRY_ERROR_CODES,
+  DESKTOP_TELEMETRY_OPERATIONS,
+  DESKTOP_TELEMETRY_WINDOWS,
+} from "../src/telemetry/desktop-telemetry";
+
+describe("desktop telemetry contract", () => {
+  test("lists every value sent from the frontend", () => {
+    expect(contract.windows).toEqual(Object.values(DESKTOP_TELEMETRY_WINDOWS));
+    expect(contract.operations).toEqual(
+      Object.values(DESKTOP_TELEMETRY_OPERATIONS),
+    );
+    expect(contract.errorCodes).toEqual(
+      Object.values(DESKTOP_TELEMETRY_ERROR_CODES),
+    );
+  });
+});

--- a/apps/web/src/routes/onboarding/-components/steps/download-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/download-step.tsx
@@ -1,6 +1,11 @@
 import type * as React from "react";
 
-import { MonitorIcon, PlugIcon, TerminalIcon } from "lucide-react";
+import {
+  ClipboardListIcon,
+  MonitorIcon,
+  PlugIcon,
+  TerminalIcon,
+} from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { MCP_HTTP_PATH } from "@stll/api-contract";
@@ -239,9 +244,38 @@ const AssistantSetupPanel = () => {
 const DesktopSetupPanel = () => {
   const t = useTranslations();
   const platform = useHydrationSafeDesktopPlatform();
+  const shortcut = platform === "mac" ? "⌘ ⇧ V" : "Ctrl + Shift + V";
 
   return (
     <SetupPanel title={t("settings.account.desktop")}>
+      <div className="border-border/60 relative isolate overflow-hidden rounded-xl border p-5 shadow-sm">
+        <img
+          alt=""
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 -z-10 size-full opacity-35"
+          src="/branding/onboarding-gradient-light.svg"
+        />
+        <span className="bg-primary/10 text-primary grid size-10 place-items-center rounded-xl shadow-xs">
+          <ClipboardListIcon aria-hidden="true" className="size-5" />
+        </span>
+        <h4 className="text-foreground mt-4 text-lg font-semibold tracking-tight text-balance">
+          {t("settings.account.desktopHeroTitle")}
+        </h4>
+        <p className="text-muted-foreground mt-2 text-sm leading-relaxed text-pretty">
+          {t("settings.account.desktopClipboardDescription")}
+        </p>
+        <div className="mt-4 flex items-center gap-3">
+          <kbd
+            className="bg-background/75 border-border rounded-lg border px-3 py-1.5 font-mono text-xs shadow-xs backdrop-blur-sm"
+            dir="ltr"
+          >
+            {shortcut}
+          </kbd>
+          <span className="text-muted-foreground text-xs font-medium">
+            {t("settings.account.desktopClipboardTitle")}
+          </span>
+        </div>
+      </div>
       <DesktopDownloadButtons platform={platform} />
     </SetupPanel>
   );

--- a/deploy/selfhost/.env.example
+++ b/deploy/selfhost/.env.example
@@ -256,10 +256,10 @@ S3_REGION="us-east-1"
 # Unset uses CORPUS_INDEX_Q09_ENDPOINT; never used for mutations.
 # CORPUS_INDEX_Q09_SEARCH_ENDPOINT=""
 
-# [internal] Conditionally required for case_law_v5 when LEGAL_SEARCH_PROVIDER
-# is corpus-index (serving), or when CORPUS_INDEXING_ENABLED is true (indexing).
-# Isolated Quickwit 0.9 mutation endpoint. Final generations registered on q09
-# use this endpoint; it never falls back to the legacy cluster.
+# [internal] Conditionally required when CORPUS_INDEXING_ENABLED is true and
+# LEGAL_SEARCH_INDEX_GENERATION is case_law_v5. Isolated Quickwit 0.9 mutation
+# endpoint. Final generations registered on q09 use this endpoint; it never
+# falls back to the legacy cluster.
 # CORPUS_INDEX_Q09_ENDPOINT=""
 
 # [internal] Optional. Corpus index s3 bucket.


### PR DESCRIPTION
## Summary

- add an explicit, opt-in start-on-login choice to clipboard onboarding
- persist the choice through Tauri on macOS and Windows, with localized failure handling and capability coverage
- refresh a stale generated self-host environment description surfaced by repository verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option in the desktop welcome dialog to launch the app automatically when signing in.
  - The preference is loaded, saved, and updated directly from the dialog.

- **Bug Fixes**
  - Added clear error handling when the startup preference cannot be read or updated.
  - Improved clipboard command detection reliability.

- **Localisation**
  - Added startup-setting error messages across supported languages.

- **Documentation**
  - Clarified when the corpus indexing endpoint configuration is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->