### PR TITLE
chore: update shared npm release workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -174,7 +174,7 @@ jobs:
 
       # Cross-repo reference resolves regardless of which release tag this
       # job checks out, unlike a workspace-local action.
-      - uses: stella/.github/actions/setup-bun-cached@232337e5623d0551ed2c034ce5e5b9ee4d193bac
+      - uses: stella/.github/actions/setup-bun-cached@7198083e27bdd963cacc0b7d70ca54fe3ec83393
 
       # --ignore-scripts: the package builds run tsc/tsdown only and do not
       # depend on install lifecycle scripts; other CI jobs build the same
@@ -445,7 +445,7 @@ jobs:
       contents: write # Create immutable package tags and GitHub releases.
       id-token: write # Exchange a short-lived npm trusted-publishing credential.
     # The repository owner publishes this versioned shared contract.
-    uses: stella/.github/.github/workflows/npm-independent-release.yml@232337e5623d0551ed2c034ce5e5b9ee4d193bac # release job environment input
+    uses: stella/.github/.github/workflows/npm-independent-release.yml@7198083e27bdd963cacc0b7d70ca54fe3ec83393 # release job environment input
     with:
       # The release App key is an environment secret; the shared job runs in
       # this environment so only main and release tags can mint the token.


### PR DESCRIPTION
Update the shared npm release workflow pin to immutable commit 7198083e27bdd963cacc0b7d70ca54fe3ec83393. The shared workflow now uses the common five-minute npm registry visibility policy before completing a release; caller inputs and release semantics stay unchanged.

CC on behalf of jan-kubica