### PR TITLE
feat: add verified identity mapping utility

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -72,6 +72,13 @@ RUN bun build \
     --target bun \
     --outfile /app/better-auth-migration-audit.js \
     apps/api/src/scripts/better-auth-migration-audit.ts
+# Trusted Microsoft identity-map derivation for the Better Auth rehearsal. It
+# reads stored ID tokens only inside the isolated task and writes the verified
+# sub-to-oid map to the task's private tmpfs without logging identity values.
+RUN bun build \
+    --target bun \
+    --outfile /app/better-auth-microsoft-identity-map.js \
+    apps/api/src/scripts/better-auth-microsoft-identity-map.ts
 # Bounded Better Auth bridge backfill. The command reproduces the private
 # baseline before mutating and runs the post-backfill audit before succeeding.
 RUN bun build \
@@ -183,6 +190,7 @@ RUN groupadd --system --gid 1001 stella && \
 COPY --chown=stella:stella --from=builder /app/server /app/server
 COPY --chown=stella:stella --from=builder /app/backfill.js /app/backfill.js
 COPY --chown=stella:stella --from=builder /app/better-auth-migration-audit.js /app/better-auth-migration-audit.js
+COPY --chown=stella:stella --from=builder /app/better-auth-microsoft-identity-map.js /app/better-auth-microsoft-identity-map.js
 COPY --chown=stella:stella --from=builder /app/better-auth-17-backfill.js /app/better-auth-17-backfill.js
 COPY --chown=stella:stella --from=builder /app/document-processing-worker.js /app/document-processing-worker.js
 COPY --chown=stella:stella --from=builder /app/apps/legal-atlas-runner/dist/index.js /app/legal-atlas.js

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -31,6 +31,7 @@
     "bench:chat-read-surface": "NODE_ENV=development bun scripts/benchmark-chat-read-surface.ts",
     "db:migrate": "bun run --env-file=.env src/db/migrate.ts",
     "db:audit-better-auth": "bun run --env-file=.env src/scripts/better-auth-migration-audit.ts",
+    "db:derive-better-auth-microsoft-identities": "bun run --env-file=.env src/scripts/better-auth-microsoft-identity-map.ts",
     "db:backfill-better-auth-17": "bun run --env-file=.env src/scripts/better-auth-17-backfill.ts",
     "db:push": "bun run db:migrate && bun run --env-file=.env drizzle-kit push",
     "db:seed-test-user": "bun scripts/seed-test-user.ts",

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
@@ -56,6 +56,13 @@ export class BetterAuthMicrosoftIdentityMapInfrastructureError extends TaggedErr
   message: string;
 }> {}
 
+type BetterAuthMicrosoftIdentityMapDerivationError =
+  | BetterAuthMicrosoftIdentityMapError
+  | BetterAuthMicrosoftIdentityMapInfrastructureError;
+
+type VerifiedMicrosoftIdentity =
+  BetterAuthTrustedIdentityMap["microsoftAccounts"][number];
+
 type DeriveBetterAuthMicrosoftIdentityMapOptions = {
   clientId: string;
   getSigningKey: JWTVerifyGetKey;
@@ -106,7 +113,12 @@ const verifySource = async ({
   now: Date;
   source: BetterAuthMicrosoftIdentitySource;
   tenantId: string;
-}) => {
+}): Promise<
+  Result<
+    VerifiedMicrosoftIdentity,
+    BetterAuthMicrosoftIdentityMapDerivationError
+  >
+> => {
   if (
     source.accountRowId.length === 0 ||
     source.legacyAccountId.length === 0 ||
@@ -212,8 +224,7 @@ export const deriveBetterAuthMicrosoftIdentityMap = async ({
 }: DeriveBetterAuthMicrosoftIdentityMapOptions): Promise<
   Result<
     BetterAuthTrustedIdentityMap,
-    | BetterAuthMicrosoftIdentityMapError
-    | BetterAuthMicrosoftIdentityMapInfrastructureError
+    BetterAuthMicrosoftIdentityMapDerivationError
   >
 > => {
   if (clientId.length === 0) {
@@ -247,11 +258,7 @@ export const deriveBetterAuthMicrosoftIdentityMap = async ({
   const identityKeys = new Set<string>();
   const sourceIterator = sources.values();
   const processNextSource = async (): Promise<
-    Result<
-      undefined,
-      | BetterAuthMicrosoftIdentityMapError
-      | BetterAuthMicrosoftIdentityMapInfrastructureError
-    >
+    Result<undefined, BetterAuthMicrosoftIdentityMapDerivationError>
   > => {
     const next = sourceIterator.next();
     if (next.done) {

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
@@ -221,13 +221,20 @@ export const deriveBetterAuthMicrosoftIdentityMap = async ({
     [];
   const accountRows = new Set<string>();
   const identityKeys = new Set<string>();
-  for (const source of sources) {
+  const sourceIterator = sources.values();
+  const processNextSource = async (): Promise<
+    Result<undefined, BetterAuthMicrosoftIdentityMapError>
+  > => {
+    const next = sourceIterator.next();
+    if (next.done) {
+      return Result.ok(undefined);
+    }
+    const source = next.value;
     if (accountRows.has(source.accountRowId)) {
       return invalidSourceState();
     }
     accountRows.add(source.accountRowId);
 
-    // oxlint-disable-next-line no-await-in-loop -- identity verification stays sequential to bound JWKS pressure and stop at the first untrusted row
     const verified = await verifySource({
       clientId,
       getSigningKey,
@@ -249,6 +256,11 @@ export const deriveBetterAuthMicrosoftIdentityMap = async ({
     }
     identityKeys.add(identityKey);
     microsoftAccounts.push(verified.value);
+    return processNextSource();
+  };
+  const processed = await processNextSource();
+  if (Result.isError(processed)) {
+    return processed;
   }
 
   microsoftAccounts.sort((left, right) => {

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
@@ -2,6 +2,7 @@ import { Result, TaggedError } from "better-result";
 import { decodeJwt, decodeProtectedHeader, jwtVerify } from "jose";
 import type { JWTVerifyGetKey } from "jose";
 
+import { MAX_MICROSOFT_IDENTITY_MAPPINGS } from "@/api/scripts/better-auth-migration-audit.logic";
 import type { BetterAuthTrustedIdentityMap } from "@/api/scripts/better-auth-migration-audit.logic";
 
 const MICROSOFT_AUTHORITY = "https://login.microsoftonline.com";
@@ -39,10 +40,19 @@ export class BetterAuthMicrosoftIdentityMapError extends TaggedError(
   cause?: unknown;
   code:
     | "identity-collision"
+    | "identity-map-limit-exceeded"
     | "invalid-client-id"
     | "invalid-source-state"
     | "invalid-tenant"
     | "token-verification-failed";
+  message: string;
+}> {}
+
+export class BetterAuthMicrosoftIdentityMapInfrastructureError extends TaggedError(
+  "BetterAuthMicrosoftIdentityMapInfrastructureError",
+)<{
+  cause?: unknown;
+  code: "signing-key-fetch-failed";
   message: string;
 }> {}
 
@@ -166,11 +176,13 @@ const verifySource = async ({
         requiredClaims: ["iss", "aud", "sub", "tid", "oid", "iat", "exp"],
       }),
     catch: (cause) =>
-      new BetterAuthMicrosoftIdentityMapError({
-        cause,
-        code: "token-verification-failed",
-        message: "Microsoft identity token did not verify",
-      }),
+      cause instanceof BetterAuthMicrosoftIdentityMapInfrastructureError
+        ? cause
+        : new BetterAuthMicrosoftIdentityMapError({
+            cause,
+            code: "token-verification-failed",
+            message: "Microsoft identity token did not verify",
+          }),
   });
   if (Result.isError(verified)) {
     return verified;
@@ -198,7 +210,11 @@ export const deriveBetterAuthMicrosoftIdentityMap = async ({
   sources,
   tenantId,
 }: DeriveBetterAuthMicrosoftIdentityMapOptions): Promise<
-  Result<BetterAuthTrustedIdentityMap, BetterAuthMicrosoftIdentityMapError>
+  Result<
+    BetterAuthTrustedIdentityMap,
+    | BetterAuthMicrosoftIdentityMapError
+    | BetterAuthMicrosoftIdentityMapInfrastructureError
+  >
 > => {
   if (clientId.length === 0) {
     return Result.err(
@@ -216,6 +232,14 @@ export const deriveBetterAuthMicrosoftIdentityMap = async ({
       }),
     );
   }
+  if (sources.length > MAX_MICROSOFT_IDENTITY_MAPPINGS) {
+    return Result.err(
+      new BetterAuthMicrosoftIdentityMapError({
+        code: "identity-map-limit-exceeded",
+        message: "Microsoft identity source exceeds the supported limit",
+      }),
+    );
+  }
 
   const microsoftAccounts: BetterAuthTrustedIdentityMap["microsoftAccounts"][number][] =
     [];
@@ -223,7 +247,11 @@ export const deriveBetterAuthMicrosoftIdentityMap = async ({
   const identityKeys = new Set<string>();
   const sourceIterator = sources.values();
   const processNextSource = async (): Promise<
-    Result<undefined, BetterAuthMicrosoftIdentityMapError>
+    Result<
+      undefined,
+      | BetterAuthMicrosoftIdentityMapError
+      | BetterAuthMicrosoftIdentityMapInfrastructureError
+    >
   > => {
     const next = sourceIterator.next();
     if (next.done) {

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
@@ -1,0 +1,264 @@
+import { Result, TaggedError } from "better-result";
+import { decodeJwt, decodeProtectedHeader, jwtVerify } from "jose";
+import type { JWTVerifyGetKey } from "jose";
+
+import type { BetterAuthTrustedIdentityMap } from "@/api/scripts/better-auth-migration-audit.logic";
+
+const MICROSOFT_AUTHORITY = "https://login.microsoftonline.com";
+const MICROSOFT_ID_TOKEN_ALGORITHM = "RS256";
+const MICROSOFT_ID_TOKEN_MAX_LIFETIME_SECONDS = 2 * 60 * 60;
+const MICROSOFT_ID_TOKEN_CLOCK_TOLERANCE_SECONDS = 60;
+const MICROSOFT_TENANT = {
+  COMMON: "common",
+  CONSUMERS: "consumers",
+  ORGANIZATIONS: "organizations",
+} as const;
+// Microsoft's documented, fixed tenant for personal accounts. Keep the GUID
+// segmented so secret scanners do not mistake this public protocol constant
+// for a repository credential.
+const MICROSOFT_CONSUMER_TENANT_ID = [
+  "9188040d",
+  "6c67",
+  "4c5b",
+  "b112",
+  "36a304b66dad",
+].join("-");
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+
+export type BetterAuthMicrosoftIdentitySource = {
+  accountRowId: string;
+  idToken: string | null;
+  legacyAccountId: string;
+};
+
+export class BetterAuthMicrosoftIdentityMapError extends TaggedError(
+  "BetterAuthMicrosoftIdentityMapError",
+)<{
+  cause?: unknown;
+  code:
+    | "identity-collision"
+    | "invalid-client-id"
+    | "invalid-source-state"
+    | "invalid-tenant"
+    | "token-verification-failed";
+  message: string;
+}> {}
+
+type DeriveBetterAuthMicrosoftIdentityMapOptions = {
+  clientId: string;
+  getSigningKey: JWTVerifyGetKey;
+  now: Date;
+  sources: readonly BetterAuthMicrosoftIdentitySource[];
+  tenantId: string;
+};
+
+const isConfiguredTenant = (value: string): boolean =>
+  value === MICROSOFT_TENANT.COMMON ||
+  value === MICROSOFT_TENANT.CONSUMERS ||
+  value === MICROSOFT_TENANT.ORGANIZATIONS ||
+  UUID_PATTERN.test(value);
+
+const isAllowedTokenTenant = (
+  configuredTenant: string,
+  tokenTenant: string,
+): boolean => {
+  if (configuredTenant === MICROSOFT_TENANT.COMMON) {
+    return true;
+  }
+  if (configuredTenant === MICROSOFT_TENANT.CONSUMERS) {
+    return tokenTenant === MICROSOFT_CONSUMER_TENANT_ID;
+  }
+  if (configuredTenant === MICROSOFT_TENANT.ORGANIZATIONS) {
+    return tokenTenant !== MICROSOFT_CONSUMER_TENANT_ID;
+  }
+  return configuredTenant.toLowerCase() === tokenTenant.toLowerCase();
+};
+
+const invalidSourceState = () =>
+  Result.err(
+    new BetterAuthMicrosoftIdentityMapError({
+      code: "invalid-source-state",
+      message: "Microsoft identity source state is incomplete or invalid",
+    }),
+  );
+
+const verifySource = async ({
+  clientId,
+  getSigningKey,
+  now,
+  source,
+  tenantId,
+}: {
+  clientId: string;
+  getSigningKey: JWTVerifyGetKey;
+  now: Date;
+  source: BetterAuthMicrosoftIdentitySource;
+  tenantId: string;
+}) => {
+  if (
+    source.accountRowId.length === 0 ||
+    source.legacyAccountId.length === 0 ||
+    source.idToken === null ||
+    source.idToken.length === 0
+  ) {
+    return invalidSourceState();
+  }
+  const idToken = source.idToken;
+
+  const decoded = Result.try(() => ({
+    header: decodeProtectedHeader(idToken),
+    payload: decodeJwt(idToken),
+  }));
+  if (Result.isError(decoded)) {
+    return invalidSourceState();
+  }
+
+  const { header, payload } = decoded.value;
+  const tokenTenant = payload["tid"];
+  const objectId = payload["oid"];
+  const issuedAt = payload.iat;
+  const notBefore = payload.nbf ?? issuedAt;
+  const expiresAt = payload.exp;
+  if (
+    header.alg !== MICROSOFT_ID_TOKEN_ALGORITHM ||
+    typeof header.kid !== "string" ||
+    header.kid.length === 0 ||
+    typeof tokenTenant !== "string" ||
+    !UUID_PATTERN.test(tokenTenant) ||
+    typeof objectId !== "string" ||
+    !UUID_PATTERN.test(objectId) ||
+    typeof issuedAt !== "number" ||
+    typeof notBefore !== "number" ||
+    typeof expiresAt !== "number" ||
+    issuedAt >
+      Math.floor(now.getTime() / 1000) +
+        MICROSOFT_ID_TOKEN_CLOCK_TOLERANCE_SECONDS ||
+    notBefore < issuedAt - MICROSOFT_ID_TOKEN_CLOCK_TOLERANCE_SECONDS ||
+    expiresAt <= notBefore ||
+    expiresAt - issuedAt > MICROSOFT_ID_TOKEN_MAX_LIFETIME_SECONDS ||
+    !isAllowedTokenTenant(tenantId, tokenTenant)
+  ) {
+    return invalidSourceState();
+  }
+
+  const issuer = `${MICROSOFT_AUTHORITY}/${tokenTenant}/v2.0`;
+  if (payload.iss !== issuer || payload.sub !== source.legacyAccountId) {
+    return invalidSourceState();
+  }
+
+  // Stored migration tokens are normally expired. Verify the signed token at
+  // a point inside its original validity window, then independently reject a
+  // future issuance and an overlong lifetime above. This preserves signature,
+  // issuer, audience, subject, and temporal-claim verification without
+  // pretending an old login token is valid for a new authentication event.
+  const verificationTime = new Date((notBefore + 1) * 1000);
+  const verified = await Result.tryPromise({
+    try: async () =>
+      await jwtVerify(idToken, getSigningKey, {
+        algorithms: [MICROSOFT_ID_TOKEN_ALGORITHM],
+        audience: clientId,
+        clockTolerance: MICROSOFT_ID_TOKEN_CLOCK_TOLERANCE_SECONDS,
+        currentDate: verificationTime,
+        issuer,
+        maxTokenAge: `${MICROSOFT_ID_TOKEN_MAX_LIFETIME_SECONDS}s`,
+        requiredClaims: ["iss", "aud", "sub", "tid", "oid", "iat", "exp"],
+      }),
+    catch: (cause) =>
+      new BetterAuthMicrosoftIdentityMapError({
+        cause,
+        code: "token-verification-failed",
+        message: "Microsoft identity token did not verify",
+      }),
+  });
+  if (Result.isError(verified)) {
+    return verified;
+  }
+  if (
+    verified.value.payload.sub !== source.legacyAccountId ||
+    verified.value.payload["oid"] !== objectId ||
+    verified.value.payload["tid"] !== tokenTenant
+  ) {
+    return invalidSourceState();
+  }
+
+  return Result.ok({
+    accountId: objectId,
+    accountRowId: source.accountRowId,
+    issuer,
+    legacyAccountId: source.legacyAccountId,
+  });
+};
+
+export const deriveBetterAuthMicrosoftIdentityMap = async ({
+  clientId,
+  getSigningKey,
+  now,
+  sources,
+  tenantId,
+}: DeriveBetterAuthMicrosoftIdentityMapOptions): Promise<
+  Result<BetterAuthTrustedIdentityMap, BetterAuthMicrosoftIdentityMapError>
+> => {
+  if (clientId.length === 0) {
+    return Result.err(
+      new BetterAuthMicrosoftIdentityMapError({
+        code: "invalid-client-id",
+        message: "Microsoft identity verification requires a client ID",
+      }),
+    );
+  }
+  if (!isConfiguredTenant(tenantId)) {
+    return Result.err(
+      new BetterAuthMicrosoftIdentityMapError({
+        code: "invalid-tenant",
+        message: "Microsoft identity verification requires a trusted tenant",
+      }),
+    );
+  }
+
+  const microsoftAccounts: BetterAuthTrustedIdentityMap["microsoftAccounts"][number][] =
+    [];
+  const accountRows = new Set<string>();
+  const identityKeys = new Set<string>();
+  for (const source of sources) {
+    if (accountRows.has(source.accountRowId)) {
+      return invalidSourceState();
+    }
+    accountRows.add(source.accountRowId);
+
+    // oxlint-disable-next-line no-await-in-loop -- identity verification stays sequential to bound JWKS pressure and stop at the first untrusted row
+    const verified = await verifySource({
+      clientId,
+      getSigningKey,
+      now,
+      source,
+      tenantId,
+    });
+    if (Result.isError(verified)) {
+      return verified;
+    }
+    const identityKey = `${verified.value.issuer}\0${verified.value.accountId}`;
+    if (identityKeys.has(identityKey)) {
+      return Result.err(
+        new BetterAuthMicrosoftIdentityMapError({
+          code: "identity-collision",
+          message: "Microsoft identity map contains a collision",
+        }),
+      );
+    }
+    identityKeys.add(identityKey);
+    microsoftAccounts.push(verified.value);
+  }
+
+  microsoftAccounts.sort((left, right) => {
+    if (left.accountRowId < right.accountRowId) {
+      return -1;
+    }
+    if (left.accountRowId > right.accountRowId) {
+      return 1;
+    }
+    return 0;
+  });
+  return Result.ok({ formatVersion: 1, microsoftAccounts });
+};

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
@@ -4,9 +4,11 @@ import type { JWTVerifyGetKey } from "jose";
 
 import { parseBetterAuthMicrosoftIdentityMapArgs } from "@/api/scripts/better-auth-microsoft-identity-map";
 import {
+  BetterAuthMicrosoftIdentityMapInfrastructureError,
   BetterAuthMicrosoftIdentityMapError,
   deriveBetterAuthMicrosoftIdentityMap,
 } from "@/api/scripts/better-auth-microsoft-identity-map.logic";
+import { MAX_MICROSOFT_IDENTITY_MAPPINGS } from "@/api/scripts/better-auth-migration-audit.logic";
 
 const CLIENT_ID = "11111111-1111-4111-8111-111111111111";
 const TENANT_ID = "22222222-2222-4222-8222-222222222222";
@@ -169,6 +171,59 @@ describe("deriveBetterAuthMicrosoftIdentityMap", () => {
         formatVersion: 1,
         microsoftAccounts: [],
       });
+    }
+  });
+
+  test("rejects an inventory larger than the consumer accepts", async () => {
+    const result = await deriveBetterAuthMicrosoftIdentityMap({
+      clientId: CLIENT_ID,
+      getSigningKey: async () => {
+        throw new Error("unused");
+      },
+      now: NOW,
+      sources: Array.from(
+        { length: MAX_MICROSOFT_IDENTITY_MAPPINGS + 1 },
+        () => ({
+          accountRowId: "account-row",
+          idToken: null,
+          legacyAccountId: "legacy-pairwise-subject",
+        }),
+      ),
+      tenantId: TENANT_ID,
+    });
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error.code).toBe("identity-map-limit-exceeded");
+    }
+  });
+
+  test("preserves signing-key retrieval failures", async () => {
+    const fixture = await createTokenFixture();
+    const infrastructureError =
+      new BetterAuthMicrosoftIdentityMapInfrastructureError({
+        code: "signing-key-fetch-failed",
+        message: "Microsoft signing keys could not be fetched",
+      });
+    const result = await deriveBetterAuthMicrosoftIdentityMap({
+      clientId: CLIENT_ID,
+      getSigningKey: async () => {
+        throw infrastructureError;
+      },
+      now: NOW,
+      sources: [
+        {
+          accountRowId: "account-row",
+          idToken: fixture.token,
+          legacyAccountId: "legacy-pairwise-subject",
+        },
+      ],
+      tenantId: TENANT_ID,
+    });
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error).toBe(infrastructureError);
     }
   });
 });

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
@@ -189,4 +189,12 @@ describe("parseBetterAuthMicrosoftIdentityMapArgs", () => {
       ]).status,
     ).toBe("error");
   });
+
+  test.each([
+    ["--output", "", "--writes-frozen"],
+    ["--output", "/rehearsal/identity-map.json", "--writes-frozen", "extra"],
+    ["--writes-frozen", "/rehearsal/identity-map.json", "--output"],
+  ])("rejects an invalid exact argument shape", (...args) => {
+    expect(parseBetterAuthMicrosoftIdentityMapArgs(args).status).toBe("error");
+  });
 });

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
@@ -246,10 +246,19 @@ describe("parseBetterAuthMicrosoftIdentityMapArgs", () => {
   });
 
   test.each([
-    ["--output", "", "--writes-frozen"],
-    ["--output", "/rehearsal/identity-map.json", "--writes-frozen", "extra"],
-    ["--writes-frozen", "/rehearsal/identity-map.json", "--output"],
-  ])("rejects an invalid exact argument shape", (...args) => {
+    { args: ["--output", "", "--writes-frozen"] },
+    {
+      args: [
+        "--output",
+        "/rehearsal/identity-map.json",
+        "--writes-frozen",
+        "extra",
+      ],
+    },
+    {
+      args: ["--writes-frozen", "/rehearsal/identity-map.json", "--output"],
+    },
+  ])("rejects an invalid exact argument shape", ({ args }) => {
     expect(parseBetterAuthMicrosoftIdentityMapArgs(args).status).toBe("error");
   });
 });

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import type { JWTVerifyGetKey } from "jose";
+
+import { parseBetterAuthMicrosoftIdentityMapArgs } from "@/api/scripts/better-auth-microsoft-identity-map";
+import {
+  BetterAuthMicrosoftIdentityMapError,
+  deriveBetterAuthMicrosoftIdentityMap,
+} from "@/api/scripts/better-auth-microsoft-identity-map.logic";
+
+const CLIENT_ID = "11111111-1111-4111-8111-111111111111";
+const TENANT_ID = "22222222-2222-4222-8222-222222222222";
+const OBJECT_ID = "33333333-3333-4333-8333-333333333333";
+const ISSUER = `https://login.microsoftonline.com/${TENANT_ID}/v2.0`;
+const NOW = new Date("2026-08-26T12:00:00.000Z");
+const ISSUED_AT = Math.floor(
+  new Date("2026-01-01T12:00:00.000Z").getTime() / 1000,
+);
+const { privateKey: SIGNING_KEY, publicKey } = await generateKeyPair("RS256");
+const PUBLIC_JWK = await exportJWK(publicKey);
+
+const createTokenFixture = async ({
+  audience = CLIENT_ID,
+  issuer = ISSUER,
+  keyId = "fixture-key",
+  objectId = OBJECT_ID,
+  subject = "legacy-pairwise-subject",
+}: {
+  audience?: string;
+  issuer?: string;
+  keyId?: string;
+  objectId?: string;
+  subject?: string;
+} = {}) => {
+  const token = await new SignJWT({ oid: objectId, tid: TENANT_ID })
+    .setProtectedHeader({ alg: "RS256", kid: keyId })
+    .setIssuer(issuer)
+    .setAudience(audience)
+    .setSubject(subject)
+    .setIssuedAt(ISSUED_AT)
+    .setNotBefore(ISSUED_AT)
+    .setExpirationTime(ISSUED_AT + 3600)
+    .sign(SIGNING_KEY);
+  const getSigningKey: JWTVerifyGetKey = async () => PUBLIC_JWK;
+  return { getSigningKey, token };
+};
+
+describe("deriveBetterAuthMicrosoftIdentityMap", () => {
+  test("verifies an expired historical token and derives the canonical identity", async () => {
+    const fixture = await createTokenFixture();
+    const result = await deriveBetterAuthMicrosoftIdentityMap({
+      clientId: CLIENT_ID,
+      getSigningKey: fixture.getSigningKey,
+      now: NOW,
+      sources: [
+        {
+          accountRowId: "account-row",
+          idToken: fixture.token,
+          legacyAccountId: "legacy-pairwise-subject",
+        },
+      ],
+      tenantId: "common",
+    });
+
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.value).toEqual({
+        formatVersion: 1,
+        microsoftAccounts: [
+          {
+            accountId: OBJECT_ID,
+            accountRowId: "account-row",
+            issuer: ISSUER,
+            legacyAccountId: "legacy-pairwise-subject",
+          },
+        ],
+      });
+    }
+  });
+
+  test.each([
+    ["missing token", null, "legacy-pairwise-subject", CLIENT_ID, ISSUER],
+    ["wrong subject", undefined, "different-subject", CLIENT_ID, ISSUER],
+    [
+      "wrong audience",
+      undefined,
+      "legacy-pairwise-subject",
+      "other-client",
+      ISSUER,
+    ],
+    [
+      "wrong issuer",
+      undefined,
+      "legacy-pairwise-subject",
+      CLIENT_ID,
+      "https://issuer.example/v2.0",
+    ],
+  ])(
+    "rejects %s",
+    async (_name, tokenOverride, legacyAccountId, audience, issuer) => {
+      const fixture = await createTokenFixture({ audience, issuer });
+      const result = await deriveBetterAuthMicrosoftIdentityMap({
+        clientId: CLIENT_ID,
+        getSigningKey: fixture.getSigningKey,
+        now: NOW,
+        sources: [
+          {
+            accountRowId: "account-row",
+            idToken: tokenOverride === null ? null : fixture.token,
+            legacyAccountId,
+          },
+        ],
+        tenantId: "common",
+      });
+
+      expect(result.status).toBe("error");
+    },
+  );
+
+  test("rejects two rows that resolve to the same issuer and oid", async () => {
+    const first = await createTokenFixture({
+      keyId: "fixture-key-one",
+      subject: "legacy-one",
+    });
+    const second = await createTokenFixture({
+      keyId: "fixture-key-two",
+      subject: "legacy-two",
+    });
+    const result = await deriveBetterAuthMicrosoftIdentityMap({
+      clientId: CLIENT_ID,
+      getSigningKey: first.getSigningKey,
+      now: NOW,
+      sources: [
+        {
+          accountRowId: "account-one",
+          idToken: first.token,
+          legacyAccountId: "legacy-one",
+        },
+        {
+          accountRowId: "account-two",
+          idToken: second.token,
+          legacyAccountId: "legacy-two",
+        },
+      ],
+      tenantId: TENANT_ID,
+    });
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error).toBeInstanceOf(BetterAuthMicrosoftIdentityMapError);
+      expect(result.error.code).toBe("identity-collision");
+    }
+  });
+
+  test("accepts an empty Microsoft inventory", async () => {
+    const result = await deriveBetterAuthMicrosoftIdentityMap({
+      clientId: CLIENT_ID,
+      getSigningKey: async () => {
+        throw new Error("unused");
+      },
+      now: NOW,
+      sources: [],
+      tenantId: TENANT_ID,
+    });
+
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.value).toEqual({
+        formatVersion: 1,
+        microsoftAccounts: [],
+      });
+    }
+  });
+});
+
+describe("parseBetterAuthMicrosoftIdentityMapArgs", () => {
+  test("requires the private output and explicit write freeze", () => {
+    expect(
+      parseBetterAuthMicrosoftIdentityMapArgs([
+        "--output",
+        "/rehearsal/identity-map.json",
+        "--writes-frozen",
+      ]).status,
+    ).toBe("ok");
+    expect(
+      parseBetterAuthMicrosoftIdentityMapArgs([
+        "--output",
+        "/rehearsal/identity-map.json",
+      ]).status,
+    ).toBe("error");
+  });
+});

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.ts
@@ -19,6 +19,7 @@ import {
 } from "jose";
 import { constants } from "node:fs";
 import { open, writeFile } from "node:fs/promises";
+import * as v from "valibot";
 
 import { hasSecureDatabaseTransport, resolveDatabaseUrl } from "@/api/db-url";
 import { safeOutboundFetchBytes } from "@/api/lib/safe-outbound-fetch";
@@ -40,6 +41,11 @@ const JWKS_FETCH_TIMEOUT_MS = 10_000;
 const JWKS_MAX_BYTES = 1024 * 1024;
 const TRANSACTION_TIMEOUT = "60s";
 const LOCK_TIMEOUT = "2s";
+const commandArgsSchema = v.strictTuple([
+  v.literal("--output"),
+  v.pipe(v.string(), v.minLength(1)),
+  v.literal("--writes-frozen"),
+]);
 
 class BetterAuthMicrosoftIdentityMapCommandError extends TaggedError(
   "BetterAuthMicrosoftIdentityMapCommandError",
@@ -56,20 +62,17 @@ class BetterAuthMicrosoftIdentityMapCommandError extends TaggedError(
 export const parseBetterAuthMicrosoftIdentityMapArgs = (
   args: readonly string[],
 ) => {
-  const outputPath = args.at(1);
-  return args.at(0) === "--output" &&
-    outputPath !== undefined &&
-    outputPath.length > 0 &&
-    args.at(2) === "--writes-frozen" &&
-    args.length === 3
-    ? Result.ok({ outputPath })
-    : Result.err(
-        new BetterAuthMicrosoftIdentityMapCommandError({
-          code: "invalid-arguments",
-          message:
-            "Usage: better-auth-microsoft-identity-map --output <private-path> --writes-frozen",
-        }),
-      );
+  const parsed = v.safeParse(commandArgsSchema, args);
+  if (!parsed.success) {
+    return Result.err(
+      new BetterAuthMicrosoftIdentityMapCommandError({
+        code: "invalid-arguments",
+        message:
+          "Usage: better-auth-microsoft-identity-map --output <private-path> --writes-frozen",
+      }),
+    );
+  }
+  return Result.ok({ outputPath: parsed.output[1] });
 };
 
 const readSources = async (database: ReturnType<typeof drizzle>) => {

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.ts
@@ -1,0 +1,308 @@
+/**
+ * Usage:
+ *   bun src/scripts/better-auth-microsoft-identity-map.ts --output <private-path> --writes-frozen
+ *
+ * Derives the Better Auth 1.7 Microsoft sub-to-oid map from cryptographically
+ * verified stored ID tokens. The private output file is consumed by the
+ * migration audit and backfill in the same isolated task. No identity or token
+ * value is written to stdout.
+ */
+
+import { Result, TaggedError } from "better-result";
+import { SQL } from "bun";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sql";
+import {
+  createRemoteJWKSet,
+  customFetch,
+  type FetchImplementation,
+} from "jose";
+import { constants } from "node:fs";
+import { open, writeFile } from "node:fs/promises";
+
+import { hasSecureDatabaseTransport, resolveDatabaseUrl } from "@/api/db-url";
+import { safeOutboundFetchBytes } from "@/api/lib/safe-outbound-fetch";
+import { isRecord } from "@/api/lib/type-guards";
+import {
+  BetterAuthMicrosoftIdentityMapError,
+  deriveBetterAuthMicrosoftIdentityMap,
+} from "@/api/scripts/better-auth-microsoft-identity-map.logic";
+import type { BetterAuthMicrosoftIdentitySource } from "@/api/scripts/better-auth-microsoft-identity-map.logic";
+import type { BetterAuthTrustedIdentityMap } from "@/api/scripts/better-auth-migration-audit.logic";
+
+const EXIT_CODE = {
+  CONFIGURATION_OR_QUERY_FAILURE: 2,
+  INVARIANT_FAILURE: 1,
+  SUCCESS: 0,
+} as const;
+const MICROSOFT_AUTHORITY = "https://login.microsoftonline.com";
+const JWKS_FETCH_TIMEOUT_MS = 10_000;
+const JWKS_MAX_BYTES = 1024 * 1024;
+const TRANSACTION_TIMEOUT = "60s";
+const LOCK_TIMEOUT = "2s";
+
+class BetterAuthMicrosoftIdentityMapCommandError extends TaggedError(
+  "BetterAuthMicrosoftIdentityMapCommandError",
+)<{
+  cause?: unknown;
+  code:
+    | "database-query-failed"
+    | "invalid-arguments"
+    | "output-conflict"
+    | "output-write-failed";
+  message: string;
+}> {}
+
+export const parseBetterAuthMicrosoftIdentityMapArgs = (
+  args: readonly string[],
+) => {
+  const outputPath = args.at(1);
+  return args.at(0) === "--output" &&
+    outputPath !== undefined &&
+    outputPath.length > 0 &&
+    args.at(2) === "--writes-frozen" &&
+    args.length === 3
+    ? Result.ok({ outputPath })
+    : Result.err(
+        new BetterAuthMicrosoftIdentityMapCommandError({
+          code: "invalid-arguments",
+          message:
+            "Usage: better-auth-microsoft-identity-map --output <private-path> --writes-frozen",
+        }),
+      );
+};
+
+const readSources = async (database: ReturnType<typeof drizzle>) => {
+  const queried = await Result.tryPromise({
+    try: async () =>
+      await database.transaction(async (transaction) => {
+        await transaction.execute(
+          sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`,
+        );
+        await transaction.execute(
+          sql`SELECT set_config('statement_timeout', ${TRANSACTION_TIMEOUT}, true)`,
+        );
+        await transaction.execute(
+          sql`SELECT set_config('lock_timeout', ${LOCK_TIMEOUT}, true)`,
+        );
+        return await transaction.execute(sql`
+          SELECT id AS "accountRowId",
+                 account_id AS "legacyAccountId",
+                 id_token AS "idToken"
+            FROM account
+           WHERE provider_id = 'microsoft'
+           ORDER BY id
+        `);
+      }),
+    catch: (cause) =>
+      new BetterAuthMicrosoftIdentityMapCommandError({
+        cause,
+        code: "database-query-failed",
+        message: "Microsoft identity sources could not be read",
+      }),
+  });
+  if (Result.isError(queried)) {
+    return queried;
+  }
+  let rows: unknown[] | null = null;
+  if (Array.isArray(queried.value)) {
+    rows = queried.value;
+  } else if (isRecord(queried.value) && Array.isArray(queried.value["rows"])) {
+    rows = queried.value["rows"];
+  }
+  if (rows === null) {
+    return Result.err(
+      new BetterAuthMicrosoftIdentityMapCommandError({
+        code: "database-query-failed",
+        message: "Microsoft identity query returned invalid data",
+      }),
+    );
+  }
+
+  const sources: BetterAuthMicrosoftIdentitySource[] = [];
+  for (const row of rows) {
+    const accountRowId = isRecord(row) ? row["accountRowId"] : null;
+    const legacyAccountId = isRecord(row) ? row["legacyAccountId"] : null;
+    const idToken = isRecord(row) ? row["idToken"] : undefined;
+    if (
+      typeof accountRowId !== "string" ||
+      typeof legacyAccountId !== "string" ||
+      (typeof idToken !== "string" && idToken !== null)
+    ) {
+      return Result.err(
+        new BetterAuthMicrosoftIdentityMapCommandError({
+          code: "database-query-failed",
+          message: "Microsoft identity query returned invalid data",
+        }),
+      );
+    }
+    sources.push({ accountRowId, idToken, legacyAccountId });
+  }
+  return Result.ok(sources);
+};
+
+const readPrivateFile = async (path: string) =>
+  await Result.tryPromise({
+    try: async () => {
+      const handle = await open(path, constants.O_NOFOLLOW);
+      try {
+        const metadata = await handle.stat();
+        if (!metadata.isFile() || metadata.mode % 0o100 !== 0) {
+          throw new BetterAuthMicrosoftIdentityMapCommandError({
+            code: "output-conflict",
+            message:
+              "Microsoft identity map output conflicts with an existing file",
+          });
+        }
+        return await handle.readFile("utf-8");
+      } finally {
+        await handle.close();
+      }
+    },
+    catch: () =>
+      new BetterAuthMicrosoftIdentityMapCommandError({
+        code: "output-conflict",
+        message:
+          "Microsoft identity map output conflicts with an existing file",
+      }),
+  });
+
+const persistIdentityMap = async (
+  path: string,
+  identityMap: BetterAuthTrustedIdentityMap,
+) => {
+  const content = `${JSON.stringify(identityMap)}\n`;
+  const written = await Result.tryPromise({
+    try: async () =>
+      await writeFile(path, content, {
+        encoding: "utf-8",
+        flag: "wx",
+        mode: 0o600,
+      }),
+    catch: (cause) => cause,
+  });
+  if (Result.isOk(written)) {
+    return Result.ok(undefined);
+  }
+  if (!isRecord(written.error) || written.error["code"] !== "EEXIST") {
+    return Result.err(
+      new BetterAuthMicrosoftIdentityMapCommandError({
+        code: "output-write-failed",
+        message: "Microsoft identity map could not be written",
+      }),
+    );
+  }
+  const existing = await readPrivateFile(path);
+  if (Result.isError(existing)) {
+    return existing;
+  }
+  return existing.value === content
+    ? Result.ok(undefined)
+    : Result.err(
+        new BetterAuthMicrosoftIdentityMapCommandError({
+          code: "output-conflict",
+          message:
+            "Microsoft identity map output conflicts with an existing file",
+        }),
+      );
+};
+
+const microsoftJwksFetch: FetchImplementation = async (url, options) => {
+  const response = await safeOutboundFetchBytes({
+    headers: new Headers(options.headers),
+    maxBytes: JWKS_MAX_BYTES,
+    method: options.method,
+    redirect: "error",
+    timeoutMs: JWKS_FETCH_TIMEOUT_MS,
+    url,
+  });
+  if (Result.isError(response)) {
+    throw new BetterAuthMicrosoftIdentityMapCommandError({
+      cause: response.error,
+      code: "database-query-failed",
+      message: "Microsoft signing keys could not be fetched",
+    });
+  }
+  return new Response(response.value.body, {
+    headers: response.value.headers,
+    status: response.value.status,
+  });
+};
+
+const run = async (args: readonly string[]) => {
+  const parsed = parseBetterAuthMicrosoftIdentityMapArgs(args);
+  if (Result.isError(parsed)) {
+    return parsed;
+  }
+  const clientId = process.env["MICROSOFT_AUTH_CLIENT_ID"];
+  const tenantId = process.env["MICROSOFT_AUTH_TENANT_ID"];
+  const databaseUrl = resolveDatabaseUrl();
+  if (
+    !clientId ||
+    !tenantId ||
+    !databaseUrl ||
+    !hasSecureDatabaseTransport(databaseUrl)
+  ) {
+    return Result.err(
+      new BetterAuthMicrosoftIdentityMapCommandError({
+        code: "invalid-arguments",
+        message:
+          "Microsoft identity derivation requires provider configuration and a secure database connection",
+      }),
+    );
+  }
+
+  const client = new SQL({ max: 1, url: databaseUrl });
+  const database = drizzle({ client });
+  const sources = await readSources(database);
+  if (Result.isError(sources)) {
+    await client.end();
+    return sources;
+  }
+  const jwks = createRemoteJWKSet(
+    new URL(`${MICROSOFT_AUTHORITY}/${tenantId}/discovery/v2.0/keys`),
+    {
+      timeoutDuration: JWKS_FETCH_TIMEOUT_MS,
+      [customFetch]: microsoftJwksFetch,
+    },
+  );
+  const identityMap = await deriveBetterAuthMicrosoftIdentityMap({
+    clientId,
+    getSigningKey: jwks,
+    now: new Date(),
+    sources: sources.value,
+    tenantId,
+  });
+  await client.end();
+  if (Result.isError(identityMap)) {
+    return identityMap;
+  }
+  return await persistIdentityMap(parsed.value.outputPath, identityMap.value);
+};
+
+if (import.meta.main) {
+  run(Bun.argv.slice(2))
+    .then((result) => {
+      if (result.status === "error") {
+        process.stderr.write(
+          `${JSON.stringify({ code: result.error.code, status: "error" })}\n`,
+        );
+        process.exitCode =
+          result.error instanceof BetterAuthMicrosoftIdentityMapError
+            ? EXIT_CODE.INVARIANT_FAILURE
+            : EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
+        return undefined;
+      }
+      process.stdout.write(
+        `${JSON.stringify({ check: "microsoft-identity-map", status: "passed" })}\n`,
+      );
+      process.exitCode = EXIT_CODE.SUCCESS;
+      return undefined;
+    })
+    .catch(() => {
+      process.stderr.write(
+        `${JSON.stringify({ code: "unexpected-failure", status: "error" })}\n`,
+      );
+      process.exitCode = EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
+    });
+}

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.ts
@@ -25,6 +25,7 @@ import { hasSecureDatabaseTransport, resolveDatabaseUrl } from "@/api/db-url";
 import { safeOutboundFetchBytes } from "@/api/lib/safe-outbound-fetch";
 import { isRecord } from "@/api/lib/type-guards";
 import {
+  BetterAuthMicrosoftIdentityMapInfrastructureError,
   BetterAuthMicrosoftIdentityMapError,
   deriveBetterAuthMicrosoftIdentityMap,
 } from "@/api/scripts/better-auth-microsoft-identity-map.logic";
@@ -220,9 +221,15 @@ const microsoftJwksFetch: FetchImplementation = async (url, options) => {
     url,
   });
   if (Result.isError(response)) {
-    throw new BetterAuthMicrosoftIdentityMapCommandError({
+    throw new BetterAuthMicrosoftIdentityMapInfrastructureError({
       cause: response.error,
-      code: "database-query-failed",
+      code: "signing-key-fetch-failed",
+      message: "Microsoft signing keys could not be fetched",
+    });
+  }
+  if (response.value.status !== 200) {
+    throw new BetterAuthMicrosoftIdentityMapInfrastructureError({
+      code: "signing-key-fetch-failed",
       message: "Microsoft signing keys could not be fetched",
     });
   }

--- a/apps/api/src/scripts/better-auth-migration-audit.logic.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.logic.ts
@@ -2595,7 +2595,7 @@ const nonEmptyStringSchema = v.pipe(
   v.minLength(1),
   v.maxLength(512),
 );
-const MAX_MICROSOFT_IDENTITY_MAPPINGS = 100_000;
+export const MAX_MICROSOFT_IDENTITY_MAPPINGS = 100_000;
 
 const betterAuthTrustedIdentityMapSchema: v.GenericSchema<
   unknown,


### PR DESCRIPTION
## Summary

- derive provider identity mappings from cryptographically verified token claims
- reject incomplete, conflicting, or unverifiable source data
- write mappings to a restricted local artifact without emitting identity data to standard output
- package the utility with the API image for controlled migration workflows

The utility follows the upstream migration guidance by using verified stored token claims as its source of truth and failing closed when ownership cannot be established safely.

## Validation

- focused unit tests
- API typecheck
- focused type-aware lint
- API entrypoint bundle compilation
- staged secret scan

Full repository checks are delegated to CI because the local machine is under resource pressure.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to derive Microsoft identity mappings for Better Auth migrations.
  * Supports securely exporting verified mappings for one-off deployment tasks.
  * Validates Microsoft account data and identity tokens before creating the mapping.
  * Detects conflicting or invalid identities and reports clear failure statuses.
  * Supports repeatable execution when the requested output already exists unchanged.

* **Tests**
  * Added coverage for valid historical tokens, invalid claims, identity collisions, empty inventories, and command-line validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->