### PR TITLE
fix: attest final corpus index configs

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-client.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.test.ts
@@ -8,6 +8,10 @@ import {
   CORPUS_INDEX_INGEST_TIMEOUT_MS,
   getCorpusIndexClient,
 } from "@/api/lib/legal-search/corpus-index-client";
+import {
+  corpusIndexConfigFromManifest,
+  CORPUS_INDEX_MANIFESTS,
+} from "@/api/lib/legal-search/corpus-index-manifest";
 import { readCorpusIndexSearchPage } from "@/api/lib/legal-search/corpus-index-pagination";
 
 // Pins the corpus-index HTTP request contract. The engine defaults search
@@ -27,6 +31,7 @@ type RecordedRequest = {
 let requests: RecordedRequest[];
 let responseBody: unknown;
 let responseBodyForUrl: ((url: URL) => unknown) | null;
+let responseStatus: number;
 const originalFetch = globalThis.fetch;
 const originalCorpusIndexEndpoint = envBase.CORPUS_INDEX_ENDPOINT;
 const originalCorpusIndexSearchEndpoint = envBase.CORPUS_INDEX_SEARCH_ENDPOINT;
@@ -37,6 +42,7 @@ beforeEach(() => {
   requests = [];
   responseBody = {};
   responseBodyForUrl = null;
+  responseStatus = 200;
   const resolveUrl = (input: Parameters<typeof fetch>[0]): string => {
     if (typeof input === "string") {
       return input;
@@ -59,7 +65,7 @@ beforeEach(() => {
     });
     const body =
       responseBodyForUrl === null ? responseBody : responseBodyForUrl(url);
-    return new Response(JSON.stringify(body), { status: 200 });
+    return new Response(JSON.stringify(body), { status: responseStatus });
   };
   globalThis.fetch = Object.assign(stub, {
     preconnect: originalFetch.preconnect,
@@ -161,6 +167,163 @@ test("q09 mutations cannot leak onto its read endpoint", async () => {
 
   expect(result.isOk()).toBe(true);
   expect(requests.at(0)?.host).toBe("localhost:7291");
+});
+
+const finalCaseLawConfig = () =>
+  corpusIndexConfigFromManifest(
+    CORPUS_INDEX_MANIFESTS.case_law_v5,
+    "case_law_v5_cs_sk",
+  );
+
+test("config attestation distinguishes a missing immutable index", async () => {
+  responseStatus = 404;
+  Object.assign(envBase, {
+    CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
+  });
+
+  const result =
+    await getCorpusIndexClient("q09").attestIndexConfig(finalCaseLawConfig());
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value).toEqual({ status: "missing" });
+  }
+});
+
+test("config attestation accepts Quickwit-owned metadata and defaults", async () => {
+  const config = finalCaseLawConfig();
+  responseBody = {
+    index_uid: `${config.index_id}:01JTEST`,
+    index_config: {
+      ...config,
+      index_uri: `s3://corpus-indexes/${config.index_id}`,
+      doc_mapping: {
+        ...config.doc_mapping,
+        doc_mapping_uid: "01JTESTDOCMAPPING",
+        tag_fields: config.doc_mapping.tag_fields.toReversed(),
+        max_num_partitions: 200,
+        index_field_presence: false,
+        store_document_size: false,
+      },
+      indexing_settings: {
+        ...config.indexing_settings,
+        split_num_docs_target: 10_000_000,
+        docstore_compression_level: 8,
+      },
+      ingest_settings: { min_shards: 1 },
+      retention: null,
+    },
+  };
+  Object.assign(envBase, {
+    CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
+  });
+
+  const result = await getCorpusIndexClient("q09").attestIndexConfig(config);
+
+  expect(result.isOk()).toBe(true);
+  if (result.isOk()) {
+    expect(result.value).toEqual({
+      status: "matching",
+      indexUri: `s3://corpus-indexes/${config.index_id}`,
+    });
+  }
+});
+
+test("config attestation rejects semantic keys omitted from a manifest", async () => {
+  const config = corpusIndexConfigFromManifest(
+    CORPUS_INDEX_MANIFESTS.legislation_v2,
+    "legislation_v2_cze",
+  );
+  const { timestamp_field: expectedTimestamp, ...mappingWithoutTimestamp } =
+    config.doc_mapping;
+  expect(expectedTimestamp).toBeNull();
+  const configWithoutTimestamp = {
+    ...config,
+    doc_mapping: mappingWithoutTimestamp,
+  };
+  responseBody = {
+    index_config: {
+      ...configWithoutTimestamp,
+      index_uri: `s3://corpus-indexes/${config.index_id}`,
+      doc_mapping: {
+        ...mappingWithoutTimestamp,
+        timestamp_field: "effective_date",
+        doc_mapping_uid: "01JTESTDOCMAPPING",
+      },
+    },
+  };
+  Object.assign(envBase, {
+    CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
+  });
+
+  const result = await getCorpusIndexClient("q09").attestIndexConfig(
+    configWithoutTimestamp,
+  );
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toContain(
+      "configuration drift at $.doc_mapping.timestamp_field",
+    );
+  }
+});
+
+test("config attestation fails closed on physical mapping drift", async () => {
+  const config = finalCaseLawConfig();
+  const fieldMappings = config.doc_mapping.field_mappings.map((field) =>
+    field.name === "text" ? { ...field, tokenizer: "raw" as const } : field,
+  );
+  responseBody = {
+    index_config: {
+      ...config,
+      index_uri: `s3://corpus-indexes/${config.index_id}`,
+      doc_mapping: { ...config.doc_mapping, field_mappings: fieldMappings },
+    },
+  };
+  Object.assign(envBase, {
+    CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
+  });
+
+  const result = await getCorpusIndexClient("q09").attestIndexConfig(config);
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toContain("configuration drift");
+    expect(result.error.message).toContain("tokenizer");
+  }
+});
+
+test("config attestation rejects an extra physical field mapping", async () => {
+  const config = finalCaseLawConfig();
+  responseBody = {
+    index_config: {
+      ...config,
+      index_uri: `s3://corpus-indexes/${config.index_id}`,
+      doc_mapping: {
+        ...config.doc_mapping,
+        field_mappings: [
+          ...config.doc_mapping.field_mappings,
+          {
+            name: "unexpected",
+            type: "text",
+            indexed: true,
+            stored: false,
+            fast: false,
+          },
+        ],
+      },
+    },
+  };
+  Object.assign(envBase, {
+    CORPUS_INDEX_Q09_ENDPOINT: "http://localhost:7291",
+  });
+
+  const result = await getCorpusIndexClient("q09").attestIndexConfig(config);
+
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toContain("field_mappings.length");
+  }
 });
 
 test("search sends the documented sort_by parameter", async () => {

--- a/apps/api/src/lib/legal-search/corpus-index-client.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-client.ts
@@ -134,12 +134,25 @@ export type CorpusIndexDeleteSettlement = {
   settled: boolean;
 };
 
+/** Result of checking one immutable manifest against its physical index. */
+export type CorpusIndexConfigAttestation =
+  | { status: "missing" }
+  | { status: "matching"; indexUri: string };
+
 export type CorpusIndexClient = {
   createIndex: (
     config: CorpusIndexConfig,
   ) => Promise<Result<void, CorpusIndexError>>;
   deleteIndex: (indexId: string) => Promise<Result<void, CorpusIndexError>>;
   indexExists: (indexId: string) => Promise<Result<boolean, CorpusIndexError>>;
+  /**
+   * Read the engine's materialized config and compare every manifest-pinned
+   * value. Quickwit adds defaults and a random doc-mapping UID to the GET
+   * response, so raw-object equality is not a valid contract check.
+   */
+  attestIndexConfig: (
+    config: CorpusIndexConfig,
+  ) => Promise<Result<CorpusIndexConfigAttestation, CorpusIndexError>>;
   /**
    * `commit` is required rather than defaulted: the difference between
    * the two modes is whether the caller may persist the acceptance, and
@@ -388,6 +401,96 @@ const ingestBatch = async ({
     catch: toCorpusIndexError,
   });
 
+const CONFIG_TAG_FIELDS_PATH = "$.doc_mapping.tag_fields";
+const isQuickwitOwnedConfigValue = (
+  path: string,
+  key: string,
+  value: unknown,
+): boolean =>
+  ((path === "$" && key === "index_uri") ||
+    (path === "$.doc_mapping" && key === "doc_mapping_uid")) &&
+  typeof value === "string" &&
+  value.length > 0;
+
+const isStringArray = (value: readonly unknown[]): value is readonly string[] =>
+  value.every((item) => typeof item === "string");
+
+const compareConfigKeys = (left: string, right: string): number => {
+  if (left < right) {
+    return -1;
+  }
+  return left > right ? 1 : 0;
+};
+
+const normalizeAttestedArray = (
+  path: string,
+  value: readonly unknown[],
+): readonly unknown[] =>
+  path === CONFIG_TAG_FIELDS_PATH && isStringArray(value)
+    ? value.toSorted(compareConfigKeys)
+    : value;
+
+/**
+ * Return the first manifest-pinned value that differs from Quickwit state.
+ *
+ * Final manifests pin materialized engine defaults. Only server-owned values
+ * such as `index_uri` and `doc_mapping_uid` are outside this comparison. Arrays
+ * remain exact: an extra field mapping or tokenizer is physical schema drift.
+ */
+const configDifference = (
+  expected: unknown,
+  observed: unknown,
+  path = "$",
+): string | null => {
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(observed)) {
+      return path;
+    }
+    const normalizedExpected = normalizeAttestedArray(path, expected);
+    const normalizedObserved = normalizeAttestedArray(path, observed);
+    if (normalizedExpected.length !== normalizedObserved.length) {
+      return `${path}.length`;
+    }
+    for (const [index, expectedItem] of normalizedExpected.entries()) {
+      const difference = configDifference(
+        expectedItem,
+        normalizedObserved.at(index),
+        `${path}[${index}]`,
+      );
+      if (difference !== null) {
+        return difference;
+      }
+    }
+    return null;
+  }
+  if (isRecord(expected)) {
+    if (!isRecord(observed)) {
+      return path;
+    }
+    for (const [key, expectedValue] of Object.entries(expected)) {
+      const difference = configDifference(
+        expectedValue,
+        observed[key],
+        `${path}.${key}`,
+      );
+      if (difference !== null) {
+        return difference;
+      }
+    }
+    for (const key of Object.keys(observed)) {
+      if (
+        Object.hasOwn(expected, key) ||
+        isQuickwitOwnedConfigValue(path, key, observed[key])
+      ) {
+        continue;
+      }
+      return `${path}.${key}`;
+    }
+    return null;
+  }
+  return Object.is(expected, observed) ? null : path;
+};
+
 const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
   createIndex: async (config) =>
     await Result.tryPromise({
@@ -438,6 +541,55 @@ const buildClient = (cluster: QuickwitCluster): CorpusIndexClient => ({
           });
         }
         return true;
+      },
+      catch: toCorpusIndexError,
+    }),
+
+  attestIndexConfig: async (config) =>
+    await Result.tryPromise({
+      try: async () => {
+        const request = {
+          baseUrl: mutationBaseUrl(cluster),
+          path: `/api/v1/indexes/${config.index_id}`,
+          init: { method: "GET" },
+          timeoutMs: ADMIN_TIMEOUT_MS,
+        } satisfies CorpusIndexRequest;
+        const response = await sendRequest(request);
+        if (response.status === 404) {
+          return { status: "missing" } as const;
+        }
+        if (!response.ok) {
+          throw new CorpusIndexError({
+            message: `corpus index ${requestLabel(request)} -> ${response.status}`,
+            status: response.status,
+          });
+        }
+        const metadata = await response.json().catch((error: unknown) => {
+          throw requestFailure({
+            request,
+            error,
+            unaborted: "returned an unreadable body",
+          });
+        });
+        if (!isRecord(metadata) || !isRecord(metadata["index_config"])) {
+          throw new CorpusIndexError({
+            message: "corpus index metadata omitted its index config",
+          });
+        }
+        const observedConfig = metadata["index_config"];
+        const difference = configDifference(config, observedConfig);
+        if (difference !== null) {
+          throw new CorpusIndexError({
+            message: `corpus index ${config.index_id} configuration drift at ${difference}`,
+          });
+        }
+        const indexUri = observedConfig["index_uri"];
+        if (typeof indexUri !== "string" || indexUri.length === 0) {
+          throw new CorpusIndexError({
+            message: `corpus index ${config.index_id} metadata omitted its index URI`,
+          });
+        }
+        return { status: "matching", indexUri } as const;
       },
       catch: toCorpusIndexError,
     }),

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -72,6 +72,8 @@ type CorpusIndexFieldMapping = {
   /** Fast-field resolution for a datetime; coarser truncates harder. */
   fast_precision?: "seconds" | "milliseconds" | "microseconds" | "nanoseconds";
   input_formats?: string[];
+  coerce?: boolean;
+  output_format?: "number" | "string" | "rfc3339";
 };
 
 /**
@@ -101,7 +103,7 @@ export const CORPUS_INDEX_COMMIT_TIMEOUT_SECS = 60;
 type CorpusIndexDocMappingMode = "lenient" | "strict" | "dynamic";
 
 export type CorpusIndexConfig = {
-  version: string;
+  version: "0.8" | "0.9";
   index_id: string;
   doc_mapping: {
     mode: CorpusIndexDocMappingMode;
@@ -113,19 +115,38 @@ export type CorpusIndexConfig = {
      * engine stores its min/max per split and prunes on it, and it is what
      * `start_timestamp` / `end_timestamp` search parameters address.
      */
-    timestamp_field?: string;
+    timestamp_field?: string | null;
+    partition_key?: string | null;
+    max_num_partitions?: number;
+    index_field_presence?: boolean;
+    store_document_size?: boolean;
     store_source: boolean;
   };
   indexing_settings: {
     merge_policy: typeof CORPUS_INDEX_MERGE_POLICY;
     commit_timeout_secs?: number;
+    docstore_blocksize?: number;
+    docstore_compression_level?: number;
+    split_num_docs_target?: number;
+    resources?: { heap_size: number };
   };
+  ingest_settings?: { min_shards: number };
   search_settings: {
     default_search_fields: string[];
   };
+  retention?: null;
 };
 
 export const CORPUS_INDEX_CONFIG_VERSION = "0.8";
+
+/** Config format consumed by the isolated Quickwit 0.9 final generations. */
+export const CORPUS_FINAL_INDEX_CONFIG_VERSION = "0.9";
+export const CORPUS_FINAL_INDEX_MAX_PARTITIONS = 200;
+export const CORPUS_FINAL_INDEX_DOCSTORE_BLOCKSIZE = 1_000_000;
+export const CORPUS_FINAL_INDEX_DOCSTORE_COMPRESSION_LEVEL = 8;
+export const CORPUS_FINAL_INDEX_SPLIT_NUM_DOCS_TARGET = 10_000_000;
+export const CORPUS_FINAL_INDEX_HEAP_SIZE_BYTES = 2_000_000_000;
+export const CORPUS_FINAL_INDEX_MIN_SHARDS = 1;
 
 export const CORPUS_INDEX_DATE_INPUT_FORMATS = [
   "%Y-%m-%d",

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
@@ -11,9 +11,9 @@ import {
 
 const EXPECTED_DIGESTS = {
   case_law_v5:
-    "c4ce8a1f9b80f87639af82d6c3a4c426b3bf553e0398ab8ff08c663d7ad0a87b",
+    "07de324370d49c611adfaa9b0667853a936a33deaf16e36d69859c051bdfdce4",
   legislation_v2:
-    "fc0d1e8e972d95cae450f4863d5a9902db7c9634517e65f57748027a4ca2a265",
+    "4b10263aa850392fc929b596a776a7bda7746d39e190a4224aeb54510b310fba",
 } as const satisfies Record<keyof typeof CORPUS_INDEX_MANIFESTS, string>;
 
 test("the final-generation registry is exact and fails closed", () => {
@@ -135,7 +135,7 @@ test("v5 removes stale and repeated physical fields", () => {
   );
   expect(manifest.engine.binaryVersion).toBe("0.9.0");
   expect(manifest.projection.builderVersion).toBe("case-law-passages-v1");
-  expect(manifest.engine.indexConfig.version).toBe("0.8");
+  expect(manifest.engine.indexConfig.version).toBe("0.9");
   expect(manifest.engine.indexConfig.doc_mapping.mode).toBe("strict");
   expect(manifest.engine.indexConfig.doc_mapping.timestamp_field).toBe(
     "decision_date_ts",
@@ -184,6 +184,7 @@ test("v5 removes stale and repeated physical fields", () => {
     indexed: false,
     stored: true,
     fast: false,
+    fieldnorms: false,
   });
   expect(fields.get("decision_date_ts")).toMatchObject({
     type: "datetime",
@@ -191,6 +192,7 @@ test("v5 removes stale and repeated physical fields", () => {
     stored: false,
     fast: true,
     fast_precision: "seconds",
+    output_format: "rfc3339",
   });
   expect(fields.get("decision_year")).toEqual({
     name: "decision_year",
@@ -198,6 +200,8 @@ test("v5 removes stale and repeated physical fields", () => {
     indexed: false,
     stored: false,
     fast: true,
+    coerce: true,
+    output_format: "number",
   });
   expect(manifest.projection.yearFacetField).toBe("decision_year");
 });
@@ -228,6 +232,26 @@ test("final manifests make every storage and index cost explicit", () => {
       expect(fields.has(absent)).toBe(false);
     }
     expect(manifest.engine.indexConfig.doc_mapping.store_source).toBe(false);
+    expect(manifest.engine.indexConfig.doc_mapping.max_num_partitions).toBe(
+      200,
+    );
+    expect(manifest.engine.indexConfig.doc_mapping.index_field_presence).toBe(
+      false,
+    );
+    expect(manifest.engine.indexConfig.doc_mapping.store_document_size).toBe(
+      false,
+    );
+    expect(manifest.engine.indexConfig.indexing_settings).toMatchObject({
+      commit_timeout_secs: 60,
+      docstore_blocksize: 1_000_000,
+      docstore_compression_level: 8,
+      split_num_docs_target: 10_000_000,
+      resources: { heap_size: 2_000_000_000 },
+    });
+    expect(manifest.engine.indexConfig.ingest_settings).toEqual({
+      min_shards: 1,
+    });
+    expect(manifest.engine.indexConfig.retention).toBeNull();
     expect(manifest.engine.indexConfig.search_settings).toEqual({
       default_search_fields: ["title", "text"],
     });

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -3,7 +3,13 @@ import { panic } from "better-result";
 import { CASE_LAW_INDEX_GROUP_OF } from "@/api/lib/legal-search/case-law-index-groups";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
 import {
-  CORPUS_INDEX_CONFIG_VERSION,
+  CORPUS_FINAL_INDEX_CONFIG_VERSION,
+  CORPUS_FINAL_INDEX_DOCSTORE_BLOCKSIZE,
+  CORPUS_FINAL_INDEX_DOCSTORE_COMPRESSION_LEVEL,
+  CORPUS_FINAL_INDEX_HEAP_SIZE_BYTES,
+  CORPUS_FINAL_INDEX_MAX_PARTITIONS,
+  CORPUS_FINAL_INDEX_MIN_SHARDS,
+  CORPUS_FINAL_INDEX_SPLIT_NUM_DOCS_TARGET,
   CORPUS_INDEX_COMMIT_TIMEOUT_SECS,
   CORPUS_INDEX_DATE_INPUT_FORMATS,
   CORPUS_INDEX_MERGE_POLICY,
@@ -77,6 +83,8 @@ const rawField = (
   indexed: true,
   stored: options.stored,
   fast: options.fast,
+  record: "basic",
+  fieldnorms: false,
 });
 
 const dateField = (name: string): CorpusIndexFieldMapping => ({
@@ -86,6 +94,8 @@ const dateField = (name: string): CorpusIndexFieldMapping => ({
   stored: false,
   fast: true,
   input_formats: CORPUS_INDEX_DATE_INPUT_FORMATS,
+  fast_precision: "seconds",
+  output_format: "rfc3339",
 });
 
 const unsignedIntegerField = (name: string): CorpusIndexFieldMapping => ({
@@ -94,6 +104,8 @@ const unsignedIntegerField = (name: string): CorpusIndexFieldMapping => ({
   indexed: false,
   stored: false,
   fast: true,
+  coerce: true,
+  output_format: "number",
 });
 
 const commonFields = (): CorpusIndexFieldMapping[] => [
@@ -139,22 +151,29 @@ const indexConfig = (
   tagFields: string[],
   timestampField?: string,
 ): Omit<CorpusIndexConfig, "index_id"> => ({
-  version: CORPUS_INDEX_CONFIG_VERSION,
+  version: CORPUS_FINAL_INDEX_CONFIG_VERSION,
   doc_mapping: {
     mode: "strict",
     field_mappings: fieldMappings,
     tokenizers: [FOLDED_TOKENIZER],
     tag_fields: tagFields,
-    ...(timestampField === undefined
-      ? {}
-      : { timestamp_field: timestampField }),
+    timestamp_field: timestampField ?? null,
+    max_num_partitions: CORPUS_FINAL_INDEX_MAX_PARTITIONS,
+    index_field_presence: false,
+    store_document_size: false,
     store_source: false,
   },
   indexing_settings: {
     merge_policy: CORPUS_INDEX_MERGE_POLICY,
     commit_timeout_secs: CORPUS_INDEX_COMMIT_TIMEOUT_SECS,
+    docstore_blocksize: CORPUS_FINAL_INDEX_DOCSTORE_BLOCKSIZE,
+    docstore_compression_level: CORPUS_FINAL_INDEX_DOCSTORE_COMPRESSION_LEVEL,
+    split_num_docs_target: CORPUS_FINAL_INDEX_SPLIT_NUM_DOCS_TARGET,
+    resources: { heap_size: CORPUS_FINAL_INDEX_HEAP_SIZE_BYTES },
   },
+  ingest_settings: { min_shards: CORPUS_FINAL_INDEX_MIN_SHARDS },
   search_settings: { default_search_fields: ["title", "text"] },
+  retention: null,
 });
 
 const deepFreeze = <T>(value: T): T => {
@@ -179,6 +198,7 @@ const CASE_LAW_V5_INDEX_CONFIG = deepFreeze(
           indexed: false,
           stored: true,
           fast: false,
+          fieldnorms: false,
         },
         rawField("case_number", { stored: false, fast: false }),
         rawField("court", { stored: false, fast: true }),


### PR DESCRIPTION
## Summary

- verify manifest-pinned Quickwit config values before final-generation writers start
- distinguish missing indexes from matching physical contracts and fail closed on drift
- pin final-generation config format to Quickwit 0.9 while retaining legacy q08 format

## Validation

- `bun test apps/api/src/lib/legal-search/corpus-index-client.test.ts apps/api/src/lib/legal-search/corpus-index-manifest.test.ts`

CC on behalf of jan-kubica