### PR TITLE
feat(web): support dark XLSX viewer chrome

### DIFF
--- a/apps/web/scripts/assert-start-runtime-build.ts
+++ b/apps/web/scripts/assert-start-runtime-build.ts
@@ -44,8 +44,13 @@ const RUNTIME_ASSET_CONTRACTS = [
   },
   {
     expectedCount: 2,
-    label: "Office render workers",
+    label: "Office render worker hosts",
     pattern: "dist/client/assets/render-worker-host-*.js",
+  },
+  {
+    expectedCount: 2,
+    label: "Office render workers",
+    pattern: "dist/client/assets/render-worker-????????-????????.js",
   },
   {
     expectedCount: 1,

--- a/apps/web/src/components/office/office-file-viewer.css
+++ b/apps/web/src/components/office/office-file-viewer.css
@@ -1,74 +1,13 @@
 .stella-office-spreadsheet[data-color-scheme="dark"] {
   color-scheme: dark;
-}
-
-.stella-office-spreadsheet[data-color-scheme="dark"] .xlsx-tab-strip {
-  scrollbar-color: var(--border) transparent;
-}
-
-.stella-office-spreadsheet[data-color-scheme="dark"]
-  .stella-office-spreadsheet-tab-bar {
-  background: var(--background) !important;
-  border-color: var(--border) !important;
-  color: var(--muted-foreground) !important;
-}
-
-.stella-office-spreadsheet[data-color-scheme="dark"]
-  .xlsx-tab-strip
-  > div
-  > button {
-  background: var(--muted) !important;
-  border-color: var(--border) !important;
-  color: var(--muted-foreground) !important;
-}
-
-.stella-office-spreadsheet[data-color-scheme="dark"]
-  .xlsx-tab-strip
-  > div
-  > .stella-office-spreadsheet-tab-active {
-  background: var(--background) !important;
-  border-bottom-color: var(--background) !important;
-  color: var(--foreground) !important;
-}
-
-.stella-office-spreadsheet[data-color-scheme="dark"]
-  .stella-office-spreadsheet-tab-bar
-  > div:last-child,
-.stella-office-spreadsheet[data-color-scheme="dark"]
-  .stella-office-spreadsheet-tab-bar
-  > div:last-child
-  > button {
-  color: var(--muted-foreground) !important;
-}
-
-.stella-office-spreadsheet[data-color-scheme="dark"] .xlsx-tab-nav {
-  color: var(--muted-foreground) !important;
-}
-
-.stella-office-spreadsheet[data-color-scheme="dark"] .xlsx-tab-nav:hover {
-  background: color-mix(in srgb, var(--foreground) 8%, transparent) !important;
-}
-
-.stella-office-spreadsheet[data-color-scheme="dark"] .xlsx-zoom-slider {
-  color: var(--muted-foreground);
-}
-
-.stella-office-spreadsheet[data-color-scheme="dark"]
-  .xlsx-zoom-slider::-webkit-slider-runnable-track {
-  background: var(--border);
-}
-
-.stella-office-spreadsheet[data-color-scheme="dark"]
-  .xlsx-zoom-slider::-webkit-slider-thumb {
-  background: var(--muted-foreground);
-}
-
-.stella-office-spreadsheet[data-color-scheme="dark"]
-  .xlsx-zoom-slider::-moz-range-track {
-  background: var(--border);
-}
-
-.stella-office-spreadsheet[data-color-scheme="dark"]
-  .xlsx-zoom-slider::-moz-range-thumb {
-  background: var(--muted-foreground);
+  --ooxml-xlsx-chrome-background: var(--background);
+  --ooxml-xlsx-chrome-surface: var(--background);
+  --ooxml-xlsx-chrome-surface-muted: var(--muted);
+  --ooxml-xlsx-chrome-text: var(--foreground);
+  --ooxml-xlsx-chrome-text-muted: var(--muted-foreground);
+  --ooxml-xlsx-chrome-border: var(--border);
+  --ooxml-xlsx-chrome-selection-background: var(--muted);
+  --ooxml-xlsx-chrome-accent: var(--ring);
+  --ooxml-xlsx-chrome-scrollbar-color: var(--border) transparent;
+  --ooxml-xlsx-focus-ring: var(--ring);
 }

--- a/apps/web/src/components/office/silurus-office-viewer.tsx
+++ b/apps/web/src/components/office/silurus-office-viewer.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 
-import type { Cell, CellRange, Row } from "@silurus/ooxml/xlsx";
+import type { Cell, Row, XlsxSelectionState } from "@silurus/ooxml/xlsx";
 import { panic } from "better-result";
 
 import type { OfficeCitationLocator } from "@stll/api-contract";
@@ -223,7 +223,7 @@ export const SilurusOfficeFileViewer = ({
         const spreadsheetReady = new Promise<void>((resolve) => {
           resolveSpreadsheetReady = resolve;
         });
-        const reportSelection = (selection: CellRange | null) => {
+        const reportSelection = (selection: XlsxSelectionState | null) => {
           if (disposed) {
             return;
           }
@@ -235,7 +235,7 @@ export const SilurusOfficeFileViewer = ({
           }
 
           const sheetIndex = currentSheetIndex;
-          const { col, row } = selection.active;
+          const { col, row } = selection.activeCell;
           detached(
             loadedWorkbook
               .getWorksheet(sheetIndex)
@@ -259,7 +259,7 @@ export const SilurusOfficeFileViewer = ({
         const xlsxViewer = XlsxViewer.fromWorkbook(container, loadedWorkbook, {
           enableHyperlinks: false,
           onError: reportError,
-          onSelectionChange: reportSelection,
+          onSelectionStateChange: reportSelection,
           onSheetChange: (sheetIndex) => {
             if (disposed) {
               return;
@@ -267,7 +267,6 @@ export const SilurusOfficeFileViewer = ({
             currentSheetIndex = sheetIndex;
             selectionRequest += 1;
             onSpreadsheetSelectionChange?.(null);
-            markActiveSpreadsheetTab(container, sheetIndex);
             finishSpreadsheetLoad();
           },
           resizable: true,
@@ -344,7 +343,7 @@ type OfficeNavigationViewer =
       viewer: {
         goToSheet: (index: number) => Promise<void>;
         scrollToCell: (reference: string) => Promise<void>;
-        select: (reference: string) => void;
+        setSelection: (reference: string) => void;
       };
     };
 
@@ -374,7 +373,7 @@ const applyOfficeNavigation = async ({
     if (!isCurrent()) {
       return false;
     }
-    target.viewer.select(locator.range);
+    target.viewer.setSelection(locator.range);
     const separatorIndex = locator.range.indexOf(":");
     const anchor =
       separatorIndex === -1
@@ -457,29 +456,10 @@ const setSpreadsheetFooterHeight = (container: HTMLElement, height: number) => {
     panic("Silurus XLSX tab strip is missing");
   }
 
-  tabBar.classList.add("stella-office-spreadsheet-tab-bar");
   tabBar.style.height = `${String(height)}px`;
   tabBar.style.alignItems = "center";
   const tabList = tabStrip.firstElementChild;
   if (tabList instanceof HTMLElement) {
     tabList.style.alignItems = "center";
-  }
-};
-
-const markActiveSpreadsheetTab = (
-  container: HTMLElement,
-  activeSheetIndex: number,
-) => {
-  const tabStrip = container.querySelector(".xlsx-tab-strip");
-  const tabList = tabStrip?.firstElementChild;
-  if (!(tabList instanceof HTMLElement)) {
-    panic("Silurus XLSX tab list is missing");
-  }
-
-  for (const [index, tab] of [...tabList.children].entries()) {
-    tab.classList.toggle(
-      "stella-office-spreadsheet-tab-active",
-      index === activeSheetIndex,
-    );
   }
 };

--- a/bun.lock
+++ b/bun.lock
@@ -932,7 +932,7 @@
     "@libpdf/core": "0.4.1",
     "@mcp-ui/client": "7.1.1",
     "@oxlint/plugins": "1.77.0",
-    "@silurus/ooxml": "0.76.2",
+    "@silurus/ooxml": "0.82.1",
     "@stll/anonymize": "2.8.1",
     "@stll/anonymize-data": "0.0.10",
     "@stll/anonymize-wasm": "2.8.0",
@@ -2265,7 +2265,7 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
-    "@silurus/ooxml": ["@silurus/ooxml@0.76.2", "", {}, "sha512-9QuYq47ZPFx92wGelABp5m3aDOQxx8iiBi0h55jTeyaLQOUtVJXbLCVUujdrBJ6p1ObgoGbIxTNV2bI4bbZEUQ=="],
+    "@silurus/ooxml": ["@silurus/ooxml@0.82.1", "", {}, "sha512-60SKDqkKMUuNcATsujAxS9+b/eh2STH4aVPbsGHkUB/6OdNAhBIJDbwUb3Lq9ZqNIuwpGXanIYxFTbGyr/yjKg=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -12,6 +12,9 @@ minimumReleaseAge = 432_000
 minimumReleaseAgeExcludes = [
   # Temporary third-party exceptions must carry the exact instant at which
   # the normal five-day quarantine admits the currently pinned release.
+  # @silurus/ooxml 0.82.1 adds host-controlled XLSX viewer chrome colors.
+  # Remove this exception once the normal quarantine admits it.
+  "@silurus/ooxml", # quarantine-expires: 2026-08-31T07:24:25.545Z
   # Keep Astro's framework and Markdown packages on one patch line while
   # verifying their Vite 8.2/Rolldown 1.2 compatibility. Remove these
   # exceptions once the normal quarantine admits them.

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@libpdf/core": "0.4.1",
     "@mcp-ui/client": "7.1.1",
     "@oxlint/plugins": "1.77.0",
-    "@silurus/ooxml": "0.76.2",
+    "@silurus/ooxml": "0.82.1",
     "@stll/anonymize": "2.8.1",
     "@stll/anonymize-data": "0.0.10",
     "@stll/anonymize-wasm": "2.8.0",

--- a/scripts/bundle-baseline.json
+++ b/scripts/bundle-baseline.json
@@ -1,8 +1,8 @@
 {
   "entry": 1230,
   "largest-route": 568513,
-  "routes": 6722036,
-  "total": 7739927,
+  "routes": 7364198,
+  "total": 8403279,
   "vendor-anonymize-data": 0,
   "vendor-base-ui": 149409,
   "vendor-editor": 115760,


### PR DESCRIPTION
## Summary

- update `@silurus/ooxml` to 0.82.1 with an expiring release-age quarantine exception
- consume the upstream XLSX chrome theme variables and migrate to its canonical selection API
- register the package-owned render workers in the production runtime asset contract

## Bundle impact

- 0.82.x is the first upstream line that exposes the supported XLSX chrome theme variables; it also introduces self-contained XLSX and PPTX render workers
- the two lazy worker assets measure 605,621 bytes gzip combined (299,389 and 306,232 bytes), accounting for most of the 647.8 KiB total increase
- the bundle baseline changes only the `routes` and `total` groups; all unrelated limits remain unchanged

## Validation

- production client build completed and emitted exactly two Office render workers plus two hosts
- `bun scripts/bundle-baseline.ts --self-test`
- `bun scripts/bundle-baseline.ts --check`

Refs https://github.com/yukiyokotani/office-open-xml-viewer/issues/1184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved spreadsheet viewing with more reliable active-cell selection and navigation.
  - Updated dark-mode styling for spreadsheet controls, including tabs, navigation, zoom, focus states and scrollbars.

- **Bug Fixes**
  - Improved sheet switching and selection-state handling in the spreadsheet viewer.
  - Refined footer sizing and layout behaviour for spreadsheet navigation.

- **Chores**
  - Updated spreadsheet rendering support and refreshed application bundle performance baselines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->