### PR TITLE
chore: enable cyclomatic complexity guard

### DIFF
--- a/.oxlint-plugins/__fixtures__/require-cn-for-classname-composition.fixture.tsx
+++ b/.oxlint-plugins/__fixtures__/require-cn-for-classname-composition.fixture.tsx
@@ -25,6 +25,7 @@ function declaredCanonicalClass({ selected }: { selected: boolean }) {
   return cn("rounded-md", selected && "ring-1");
 }
 
+// oxlint-disable-next-line complexity -- fixture intentionally enumerates classname-composition branches for another lint rule
 const MatterRow = ({ active, className, status }: MatterRowProps) => {
   // oxlint-disable-next-line no-var -- fixture: var bindings must not launder dynamic class composition
   var mutableWrittenClass = "bg-background";

--- a/apps/api/scripts/export-capability-catalog.ts
+++ b/apps/api/scripts/export-capability-catalog.ts
@@ -964,13 +964,14 @@ const buildCatalog = async (): Promise<BuildResult> => {
     }
   }
 
-  for (const endpoint of endpoints) {
+  /** Compile one discovered handler into its catalog and dispatch projections. */
+  const projectEndpoint = (endpoint: (typeof endpoints)[number]): void => {
     if (
       endpoint.exposure.type !== "tool" &&
       endpoint.exposure.type !== "covered" &&
       endpoint.exposure.type !== "capability"
     ) {
-      continue;
+      return;
     }
     const id = deriveCapabilityId({
       file: endpoint.file,
@@ -984,7 +985,7 @@ const buildCatalog = async (): Promise<BuildResult> => {
       errors.push(
         `malformed capability id "${id}" from ${endpoint.file}: every \`.\`-separated segment must be lowercase kebab-case (${CAPABILITY_ID_SEGMENT_PATTERN.source}). Capability ids are public, so give this endpoint its own kebab-case-named file and export it as the file's DEFAULT export instead of a named one`,
       );
-      continue;
+      return;
     }
     if (!isAllowedActionVerb(id)) {
       // The final id segment is the PUBLIC action verb (`stella contacts list`,
@@ -994,14 +995,14 @@ const buildCatalog = async (): Promise<BuildResult> => {
       errors.push(
         `non-conforming action verb "${deriveActionVerb(id)}" in capability id "${id}" from ${endpoint.file}: the final id segment must be one of ${[...CANONICAL_ACTION_VERBS].sort().join(", ")}, or an explicitly reviewed entry in DOMAIN_ACTION_VERBS. Prefer renaming the handler file to a canonical verb, or splitting a compound verb into a nested resource directory (\`clauses/categories/create.ts\` over \`clauses/categories-create.ts\`)`,
       );
-      continue;
+      return;
     }
     const existing = idToFile.get(id);
     if (existing !== undefined) {
       errors.push(
         `duplicate capability id "${id}" from ${existing} and ${endpoint.file}`,
       );
-      continue;
+      return;
     }
     idToFile.set(id, endpoint.file);
 
@@ -1110,7 +1111,7 @@ const buildCatalog = async (): Promise<BuildResult> => {
       accessResolution.status !== "resolved" ||
       scopeResolution.status !== "resolved"
     ) {
-      continue;
+      return;
     }
 
     const override = ENTRY_SCOPE_OVERRIDES[id];
@@ -1118,7 +1119,7 @@ const buildCatalog = async (): Promise<BuildResult> => {
       errors.push(
         `capability "${id}" pins unknown scope "${override}" in ENTRY_SCOPE_OVERRIDES`,
       );
-      continue;
+      return;
     }
     const isRead = accessResolution.access === "read";
     // The write/consent scope for this entry: an ENTRY_SCOPE_OVERRIDES pin names
@@ -1153,7 +1154,7 @@ const buildCatalog = async (): Promise<BuildResult> => {
       });
       if (entryScope.status === "error") {
         errors.push(entryScope.message);
-        continue;
+        return;
       }
       scope = entryScope.scope;
       const coveringAdditionalScopes = toolAdditionalScopesByName.get(toolName);
@@ -1161,7 +1162,7 @@ const buildCatalog = async (): Promise<BuildResult> => {
         errors.push(
           `capability "${id}" references unknown covering tool "${toolName}"`,
         );
-        continue;
+        return;
       }
       additionalScopes = [...new Set(coveringAdditionalScopes)].filter(
         (requiredScope) => requiredScope !== scope,
@@ -1204,7 +1205,7 @@ const buildCatalog = async (): Promise<BuildResult> => {
       errors.push(
         `capability "${id}" has a malformed \`transport\` declaration; see CapabilityTransport in apps/api/src/lib/capability-transport.ts`,
       );
-      continue;
+      return;
     }
     const { transport } = transportParse;
     const transportErrors = checkTransportAgainstDerived({
@@ -1216,7 +1217,7 @@ const buildCatalog = async (): Promise<BuildResult> => {
       errors.push(message);
     }
     if (transportErrors.length > 0) {
-      continue;
+      return;
     }
     // Deployment feature gate: the covering tool's flag wins (mechanical
     // inheritance), the reviewed domain table covers the rest.
@@ -1250,6 +1251,10 @@ const buildCatalog = async (): Promise<BuildResult> => {
     if (source !== undefined) {
       entrySources.push({ id, source });
     }
+  };
+
+  for (const endpoint of endpoints) {
+    projectEndpoint(endpoint);
   }
 
   // Class guards over the built entries (context-fidelity, file-response,

--- a/apps/api/scripts/seed-dev.ts
+++ b/apps/api/scripts/seed-dev.ts
@@ -5385,15 +5385,11 @@ export async function seed(organizationId?: string, userId?: string) {
   });
   const seedUserRates = buildSeedUserRates(seedUserIds);
 
-  if (process.env.NODE_ENV === "production") {
-    panic("Refusing to run in production.");
-  }
-
-  // Ensure referenced users exist in the target org before
-  // seeding matters, billing, and analytics data.
-  if (ORG_ID === DEFAULT_ORG_ID && USER_ID === DEFAULT_USER_ID) {
-    await ensureTestUsers(ORG_ID);
-  } else {
+  const ensureSeedUsers = async () => {
+    if (ORG_ID === DEFAULT_ORG_ID && USER_ID === DEFAULT_USER_ID) {
+      await ensureTestUsers(ORG_ID);
+      return;
+    }
     await ensurePrimarySeedUserInOrganization({
       organizationId: ORG_ID,
       userId: USER_ID,
@@ -5402,51 +5398,53 @@ export async function seed(organizationId?: string, userId?: string) {
       organizationId: ORG_ID,
       colleagueCount: DEFAULT_SEED_COLLEAGUE_COUNT,
     });
-  }
+  };
 
-  // Clean up any previous seed data so re-running for a different
-  // org works correctly (deterministic seedId means same IDs every run).
-  const allSeedContactIds = [
-    ...orgContacts,
-    ...personContacts,
-    ...moreOrgContacts,
-  ].map((c) => c.id);
-  const allSeedWorkspaceIds = [
-    ...seedWorkspaces.map((ws) => ws.id),
-    ...MORE_WORKSPACES.map((mw) => seedId(`extra-ws-${mw.reference}`)),
-  ];
-
-  if (allSeedWorkspaceIds.length > 0) {
-    await rootDb
-      .delete(chatMessages)
-      .where(sql`${chatMessages.workspaceId} IN ${allSeedWorkspaceIds}`);
-    await rootDb
-      .delete(chatThreads)
-      .where(sql`${chatThreads.workspaceId} IN ${allSeedWorkspaceIds}`);
-    // property_dependencies.depends_on_property_id uses ON DELETE RESTRICT,
-    // which blocks the workspace cascade from removing properties. Clear
-    // dependencies first so the cascade can complete.
-    await rootDb
-      .delete(propertyDependencies)
-      .where(
-        sql`${propertyDependencies.workspaceId} IN ${allSeedWorkspaceIds}`,
-      );
-    await rootDb
-      .delete(workspaces)
-      .where(sql`${workspaces.id} IN ${allSeedWorkspaceIds}`);
-  }
-  if (allSeedContactIds.length > 0) {
-    // Delete any workspaces referencing seed contacts (including
-    // manually-created ones) to avoid FK constraint violations.
+  const clearSeedData = async () => {
+    const allSeedContactIds = [
+      ...orgContacts,
+      ...personContacts,
+      ...moreOrgContacts,
+    ].map((contact) => contact.id);
+    const allSeedWorkspaceIds = [
+      ...seedWorkspaces.map((workspace) => workspace.id),
+      ...MORE_WORKSPACES.map((workspace) =>
+        seedId(`extra-ws-${workspace.reference}`),
+      ),
+    ];
+    if (allSeedWorkspaceIds.length > 0) {
+      await rootDb
+        .delete(chatMessages)
+        .where(sql`${chatMessages.workspaceId} IN ${allSeedWorkspaceIds}`);
+      await rootDb
+        .delete(chatThreads)
+        .where(sql`${chatThreads.workspaceId} IN ${allSeedWorkspaceIds}`);
+      // property_dependencies.depends_on_property_id uses ON DELETE RESTRICT,
+      // so dependencies must be removed before the workspace cascade.
+      await rootDb
+        .delete(propertyDependencies)
+        .where(
+          sql`${propertyDependencies.workspaceId} IN ${allSeedWorkspaceIds}`,
+        );
+      await rootDb
+        .delete(workspaces)
+        .where(sql`${workspaces.id} IN ${allSeedWorkspaceIds}`);
+    }
+    if (allSeedContactIds.length === 0) {
+      return;
+    }
+    // Include manually created workspaces that reference seed contacts, not
+    // only workspaces whose IDs came from this script.
     const clientWorkspaces = await rootDb.query.workspaces.findMany({
       where: { clientId: { in: allSeedContactIds } },
       columns: { id: true },
     });
-    const clientWorkspaceIds = clientWorkspaces.map((w) => w.id);
+    const clientWorkspaceIds = clientWorkspaces.map(
+      (workspace) => workspace.id,
+    );
     if (clientWorkspaceIds.length > 0) {
-      // chat_messages.workspace_id and chat_threads.workspace_id are
-      // ON DELETE RESTRICT, same as property_dependencies; clear them
-      // before the workspace delete cascades.
+      // These relations use ON DELETE RESTRICT and can belong to manually
+      // created workspaces that reference deterministic seed contacts.
       await rootDb
         .delete(chatMessages)
         .where(sql`${chatMessages.workspaceId} IN ${clientWorkspaceIds}`);
@@ -5465,75 +5463,88 @@ export async function seed(organizationId?: string, userId?: string) {
     await rootDb
       .delete(contacts)
       .where(sql`${contacts.id} IN ${allSeedContactIds}`);
+  };
+
+  if (process.env.NODE_ENV === "production") {
+    panic("Refusing to run in production.");
   }
+
+  // Ensure referenced users exist in the target org before seeding matters,
+  // billing, and analytics data; then clear deterministic IDs for replay.
+  await ensureSeedUsers();
+  await clearSeedData();
 
   console.log("Seeding development data...\n");
 
-  // 1. Contacts (original orgs + people)
-  const coreContacts = [...orgContacts, ...personContacts];
-  for (const c of coreContacts) {
-    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order
-    await rootDb
-      .insert(contacts)
-      .values({
-        id: c.id,
-        organizationId: ORG_ID,
-        type: c.type,
-        displayName: c.displayName,
-        prefix: "prefix" in c ? c.prefix : undefined,
-        firstName: "firstName" in c ? c.firstName : undefined,
-        lastName: "lastName" in c ? c.lastName : undefined,
-        suffix: "suffix" in c ? c.suffix : undefined,
-        organizationName:
-          "organizationName" in c ? c.organizationName : undefined,
-        notes: "notes" in c ? c.notes : undefined,
-        emails: "emails" in c ? c.emails : undefined,
-        phones: "phones" in c ? c.phones : undefined,
-        color: c.color,
-        registrationNumber:
-          "registrationNumber" in c ? c.registrationNumber : undefined,
-        taxId: "taxId" in c ? c.taxId : undefined,
-        bankAccounts: "bankAccounts" in c ? c.bankAccounts : undefined,
-        billingAddress: "billingAddress" in c ? c.billingAddress : undefined,
-        defaultHourlyRate:
-          "defaultHourlyRate" in c ? cents(c.defaultHourlyRate) : undefined,
-        currency: "currency" in c ? c.currency : undefined,
-        paymentTermDays: "paymentTermDays" in c ? c.paymentTermDays : undefined,
-        originatingAttorneyId: USER_ID,
-        responsibleAttorneyId: USER_ID,
-        createdBy: USER_ID,
-      })
-      .onConflictDoNothing();
-  }
-  // 1b. Additional org contacts for overview stress-testing
-  for (const c of moreOrgContacts) {
-    // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order
-    await rootDb
-      .insert(contacts)
-      .values({
-        id: c.id,
-        organizationId: ORG_ID,
-        type: c.type,
-        displayName: c.displayName,
-        organizationName: c.organizationName,
-        registrationNumber: c.registrationNumber,
-        taxId: c.taxId,
-        billingAddress: c.billingAddress,
-        defaultHourlyRate: cents(c.defaultHourlyRate),
-        currency: c.currency,
-        paymentTermDays: c.paymentTermDays,
-        emails: c.emails,
-        color: c.color,
-        originatingAttorneyId: USER_ID,
-        responsibleAttorneyId: USER_ID,
-        createdBy: USER_ID,
-      })
-      .onConflictDoNothing();
-  }
-  const totalContacts = coreContacts.length + moreOrgContacts.length;
-  console.log(
-    `  Contacts: ${totalContacts} (${orgContacts.length + moreOrgContacts.length} orgs, ${personContacts.length} people)`,
-  );
+  const seedContacts = async () => {
+    // 1. Contacts (original orgs + people)
+    const coreContacts = [...orgContacts, ...personContacts];
+    for (const c of coreContacts) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order
+      await rootDb
+        .insert(contacts)
+        .values({
+          id: c.id,
+          organizationId: ORG_ID,
+          type: c.type,
+          displayName: c.displayName,
+          prefix: "prefix" in c ? c.prefix : undefined,
+          firstName: "firstName" in c ? c.firstName : undefined,
+          lastName: "lastName" in c ? c.lastName : undefined,
+          suffix: "suffix" in c ? c.suffix : undefined,
+          organizationName:
+            "organizationName" in c ? c.organizationName : undefined,
+          notes: "notes" in c ? c.notes : undefined,
+          emails: "emails" in c ? c.emails : undefined,
+          phones: "phones" in c ? c.phones : undefined,
+          color: c.color,
+          registrationNumber:
+            "registrationNumber" in c ? c.registrationNumber : undefined,
+          taxId: "taxId" in c ? c.taxId : undefined,
+          bankAccounts: "bankAccounts" in c ? c.bankAccounts : undefined,
+          billingAddress: "billingAddress" in c ? c.billingAddress : undefined,
+          defaultHourlyRate:
+            "defaultHourlyRate" in c ? cents(c.defaultHourlyRate) : undefined,
+          currency: "currency" in c ? c.currency : undefined,
+          paymentTermDays:
+            "paymentTermDays" in c ? c.paymentTermDays : undefined,
+          originatingAttorneyId: USER_ID,
+          responsibleAttorneyId: USER_ID,
+          createdBy: USER_ID,
+        })
+        .onConflictDoNothing();
+    }
+    // 1b. Additional org contacts for overview stress-testing
+    for (const c of moreOrgContacts) {
+      // oxlint-disable-next-line no-await-in-loop -- sequential seeding preserves insert order
+      await rootDb
+        .insert(contacts)
+        .values({
+          id: c.id,
+          organizationId: ORG_ID,
+          type: c.type,
+          displayName: c.displayName,
+          organizationName: c.organizationName,
+          registrationNumber: c.registrationNumber,
+          taxId: c.taxId,
+          billingAddress: c.billingAddress,
+          defaultHourlyRate: cents(c.defaultHourlyRate),
+          currency: c.currency,
+          paymentTermDays: c.paymentTermDays,
+          emails: c.emails,
+          color: c.color,
+          originatingAttorneyId: USER_ID,
+          responsibleAttorneyId: USER_ID,
+          createdBy: USER_ID,
+        })
+        .onConflictDoNothing();
+    }
+    const totalContacts = coreContacts.length + moreOrgContacts.length;
+    console.log(
+      `  Contacts: ${totalContacts} (${orgContacts.length + moreOrgContacts.length} orgs, ${personContacts.length} people)`,
+    );
+  };
+  await seedContacts();
 
   // 1c. Organization settings: pin the practice jurisdiction (the seeded
   // cast is a Czech firm) so jurisdiction-derived surfaces, notably the

--- a/apps/api/src/db/migration-concurrent-index.test.ts
+++ b/apps/api/src/db/migration-concurrent-index.test.ts
@@ -482,20 +482,129 @@ const isUnapprovedProceduralStatement = (
   return !APPROVED_PROCEDURAL_STATEMENTS.has(`${relativePath}:${hash}`);
 };
 
+type ConcurrentTimeoutState = {
+  concurrentBlockOpen: boolean;
+  lockTimeout: TimeoutState;
+  lockTimeoutCheckpoint: TimeoutState | undefined;
+  lockTimeoutRequiresRestore: boolean;
+  statementTimeout: TimeoutState;
+  statementTimeoutCheckpoint: TimeoutState | undefined;
+  statementTimeoutRequiresRestore: boolean;
+  statementTimeoutRestored: boolean;
+};
+
+const applyConcurrentTimeoutUpdate = ({
+  relativePath,
+  state,
+  timeoutUpdate,
+  violations,
+}: {
+  relativePath: string;
+  state: ConcurrentTimeoutState;
+  timeoutUpdate: TimeoutUpdate | undefined;
+  violations: string[];
+}): void => {
+  if (timeoutUpdate?.type === "checkpoint") {
+    if (timeoutUpdate.name === "statement") {
+      state.statementTimeoutCheckpoint = state.statementTimeout;
+    } else {
+      state.lockTimeoutCheckpoint = state.lockTimeout;
+    }
+    return;
+  }
+  if (timeoutUpdate?.type === "restore") {
+    const checkpoint =
+      timeoutUpdate.name === "statement"
+        ? state.statementTimeoutCheckpoint
+        : state.lockTimeoutCheckpoint;
+    if (checkpoint === undefined) {
+      violations.push(
+        `${relativePath}: ${timeoutUpdate.name} timeout restore lacks a checkpoint`,
+      );
+      return;
+    }
+    if (timeoutUpdate.name === "statement") {
+      state.statementTimeout = checkpoint;
+      state.statementTimeoutRequiresRestore = false;
+    } else {
+      state.lockTimeout = checkpoint;
+      state.lockTimeoutRequiresRestore = false;
+    }
+    return;
+  }
+  if (timeoutUpdate?.type === "set" && timeoutUpdate.scope === "session") {
+    if (timeoutUpdate.name === "statement") {
+      state.statementTimeout = timeoutUpdate.state;
+      state.statementTimeoutRequiresRestore =
+        timeoutUpdate.state === "unbounded";
+    } else {
+      state.lockTimeout = timeoutUpdate.state;
+      state.lockTimeoutRequiresRestore = timeoutUpdate.state !== "bounded";
+    }
+    return;
+  }
+  if (timeoutUpdate?.type === "reset") {
+    if (timeoutUpdate.name === "all" || timeoutUpdate.name === "statement") {
+      state.statementTimeout = "unset";
+    }
+    if (timeoutUpdate.name === "all" || timeoutUpdate.name === "lock") {
+      state.lockTimeout = "unset";
+      if (state.concurrentBlockOpen) {
+        state.lockTimeoutRequiresRestore = true;
+      }
+    }
+  }
+};
+
+const enforceConcurrentRestoreProtocol = ({
+  isConcurrentOperation,
+  isProtocolBridge,
+  isStatementRestore,
+  relativePath,
+  state,
+  violations,
+}: {
+  isConcurrentOperation: boolean;
+  isProtocolBridge: boolean;
+  isStatementRestore: boolean;
+  relativePath: string;
+  state: ConcurrentTimeoutState;
+  violations: string[];
+}): void => {
+  if (!state.concurrentBlockOpen) {
+    return;
+  }
+  if (isStatementRestore) {
+    state.statementTimeoutRestored = true;
+  }
+  if (state.statementTimeoutRestored && !state.lockTimeoutRequiresRestore) {
+    state.concurrentBlockOpen = false;
+    return;
+  }
+  if (!isConcurrentOperation && !isStatementRestore && !isProtocolBridge) {
+    violations.push(
+      `${relativePath}: timeouts are not restored immediately after concurrent index operations`,
+    );
+    state.concurrentBlockOpen = false;
+  }
+};
+
 const collectUnsafeConcurrentTimeouts = (
   relativePath: string,
   source: string,
 ) => {
   const violations = [];
   const statements = splitSqlStatements(source);
-  let statementTimeout: TimeoutState = "unset";
-  let lockTimeout: TimeoutState = "unset";
-  let statementTimeoutCheckpoint: TimeoutState | undefined;
-  let lockTimeoutCheckpoint: TimeoutState | undefined;
-  let statementTimeoutRequiresRestore = false;
-  let concurrentBlockOpen = false;
-  let statementTimeoutRestored = false;
-  let lockTimeoutRequiresRestore = false;
+  const state: ConcurrentTimeoutState = {
+    concurrentBlockOpen: false,
+    lockTimeout: "unset",
+    lockTimeoutCheckpoint: undefined,
+    lockTimeoutRequiresRestore: false,
+    statementTimeout: "unset",
+    statementTimeoutCheckpoint: undefined,
+    statementTimeoutRequiresRestore: false,
+    statementTimeoutRestored: false,
+  };
 
   for (const statement of statements) {
     if (isUnapprovedProceduralStatement(relativePath, statement)) {
@@ -511,7 +620,7 @@ const collectUnsafeConcurrentTimeouts = (
     const isStatementRestore =
       (timeoutUpdate?.type === "restore" &&
         timeoutUpdate.name === "statement" &&
-        statementTimeoutCheckpoint !== undefined) ||
+        state.statementTimeoutCheckpoint !== undefined) ||
       (timeoutUpdate?.type === "set" &&
         timeoutUpdate.name === "statement" &&
         timeoutUpdate.scope === "session" &&
@@ -529,68 +638,20 @@ const collectUnsafeConcurrentTimeouts = (
       );
     }
 
-    if (timeoutUpdate?.type === "checkpoint") {
-      if (timeoutUpdate.name === "statement") {
-        statementTimeoutCheckpoint = statementTimeout;
-      } else {
-        lockTimeoutCheckpoint = lockTimeout;
-      }
-    } else if (timeoutUpdate?.type === "restore") {
-      const checkpoint =
-        timeoutUpdate.name === "statement"
-          ? statementTimeoutCheckpoint
-          : lockTimeoutCheckpoint;
-      if (checkpoint === undefined) {
-        violations.push(
-          `${relativePath}: ${timeoutUpdate.name} timeout restore lacks a checkpoint`,
-        );
-      } else if (timeoutUpdate.name === "statement") {
-        statementTimeout = checkpoint;
-        statementTimeoutRequiresRestore = false;
-      } else {
-        lockTimeout = checkpoint;
-        lockTimeoutRequiresRestore = false;
-      }
-    } else if (
-      timeoutUpdate?.type === "set" &&
-      timeoutUpdate.scope === "session"
-    ) {
-      if (timeoutUpdate.name === "statement") {
-        statementTimeout = timeoutUpdate.state;
-        statementTimeoutRequiresRestore = timeoutUpdate.state === "unbounded";
-      } else {
-        lockTimeout = timeoutUpdate.state;
-        lockTimeoutRequiresRestore = timeoutUpdate.state !== "bounded";
-      }
-    } else if (timeoutUpdate?.type === "reset") {
-      if (timeoutUpdate.name === "all" || timeoutUpdate.name === "statement") {
-        statementTimeout = "unset";
-      }
-      if (timeoutUpdate.name === "all" || timeoutUpdate.name === "lock") {
-        lockTimeout = "unset";
-        if (concurrentBlockOpen) {
-          lockTimeoutRequiresRestore = true;
-        }
-      }
-    }
-
-    if (concurrentBlockOpen) {
-      if (isStatementRestore) {
-        statementTimeoutRestored = true;
-      }
-      if (statementTimeoutRestored && !lockTimeoutRequiresRestore) {
-        concurrentBlockOpen = false;
-      } else if (
-        !isConcurrentOperation &&
-        !isStatementRestore &&
-        !isProtocolBridge
-      ) {
-        violations.push(
-          `${relativePath}: timeouts are not restored immediately after concurrent index operations`,
-        );
-        concurrentBlockOpen = false;
-      }
-    }
+    applyConcurrentTimeoutUpdate({
+      relativePath,
+      state,
+      timeoutUpdate,
+      violations,
+    });
+    enforceConcurrentRestoreProtocol({
+      isConcurrentOperation,
+      isProtocolBridge,
+      isStatementRestore,
+      relativePath,
+      state,
+      violations,
+    });
 
     if (timeoutUpdate || isUnsupportedTransactionReversal) {
       continue;
@@ -599,22 +660,22 @@ const collectUnsafeConcurrentTimeouts = (
       continue;
     }
 
-    if (statementTimeout !== "unbounded") {
+    if (state.statementTimeout !== "unbounded") {
       violations.push(
         `${relativePath}: concurrent index operation has a timeout`,
       );
     }
-    concurrentBlockOpen = true;
-    statementTimeoutRestored = false;
-    lockTimeoutRequiresRestore = lockTimeout === "unbounded";
+    state.concurrentBlockOpen = true;
+    state.statementTimeoutRestored = false;
+    state.lockTimeoutRequiresRestore = state.lockTimeout === "unbounded";
   }
 
-  if (concurrentBlockOpen && lockTimeoutRequiresRestore) {
+  if (state.concurrentBlockOpen && state.lockTimeoutRequiresRestore) {
     violations.push(`${relativePath}: lock timeout is not restored`);
   }
   if (
-    (concurrentBlockOpen && !statementTimeoutRestored) ||
-    (!concurrentBlockOpen && statementTimeoutRequiresRestore)
+    (state.concurrentBlockOpen && !state.statementTimeoutRestored) ||
+    (!state.concurrentBlockOpen && state.statementTimeoutRequiresRestore)
   ) {
     violations.push(`${relativePath}: statement timeout is not restored`);
   }
@@ -714,6 +775,209 @@ const collectUnsafeConcurrentIndexes = async (): Promise<string[]> => {
   return violations.sort();
 };
 
+type TypeChangeTimeoutState = {
+  activePolicy: TypeChangePolicy | undefined;
+  activePolicyUsed: boolean;
+  lockTimeout: TimeoutState;
+  lockTimeoutCheckpoint: TimeoutState | undefined;
+  metadataOnlyBlockOpen: boolean;
+  sawCustomStatementBudget: boolean;
+  statementTimeout: TimeoutState;
+  statementTimeoutCheckpoint: TimeoutState | undefined;
+  statementTimeoutRequiresRestore: boolean;
+};
+
+const applyTypeChangePolicy = ({
+  declaredPolicy,
+  relativePath,
+  state,
+  violations,
+}: {
+  declaredPolicy: TypeChangePolicy;
+  relativePath: string;
+  state: TypeChangeTimeoutState;
+  violations: string[];
+}): void => {
+  if (state.metadataOnlyBlockOpen) {
+    violations.push(
+      `${relativePath}: statement timeout is not restored immediately after metadata-only type changes`,
+    );
+    state.metadataOnlyBlockOpen = false;
+  }
+  if (state.activePolicy && !state.activePolicyUsed) {
+    violations.push(`${relativePath}: type change policy is unused`);
+  }
+  state.activePolicy = declaredPolicy;
+  state.activePolicyUsed = false;
+};
+
+const closeCompletedBoundedRewritePolicy = ({
+  isTypeChange,
+  state,
+}: {
+  isTypeChange: boolean;
+  state: TypeChangeTimeoutState;
+}): void => {
+  if (
+    state.activePolicy === "boundedRewrite" &&
+    state.activePolicyUsed &&
+    !isTypeChange
+  ) {
+    state.activePolicy = undefined;
+    state.activePolicyUsed = false;
+  }
+};
+
+const enforceMetadataOnlyRestore = ({
+  isImmediateRestore,
+  isTypeChange,
+  relativePath,
+  state,
+  violations,
+}: {
+  isImmediateRestore: boolean;
+  isTypeChange: boolean;
+  relativePath: string;
+  state: TypeChangeTimeoutState;
+  violations: string[];
+}): void => {
+  if (!state.metadataOnlyBlockOpen) {
+    return;
+  }
+  if (!isTypeChange && !isImmediateRestore) {
+    violations.push(
+      `${relativePath}: statement timeout is not restored immediately after metadata-only type changes`,
+    );
+  }
+  if (!isTypeChange || isImmediateRestore) {
+    state.metadataOnlyBlockOpen = false;
+    state.activePolicy = undefined;
+    state.activePolicyUsed = false;
+  }
+};
+
+const applyTypeChangeTimeoutUpdate = ({
+  statement,
+  state,
+  timeoutUpdate,
+  relativePath,
+  violations,
+}: {
+  statement: string;
+  state: TypeChangeTimeoutState;
+  timeoutUpdate: TimeoutUpdate | undefined;
+  relativePath: string;
+  violations: string[];
+}): boolean => {
+  if (timeoutUpdate?.type === "checkpoint") {
+    if (timeoutUpdate.name === "lock") {
+      state.lockTimeoutCheckpoint = state.lockTimeout;
+    } else {
+      state.statementTimeoutCheckpoint = state.statementTimeout;
+    }
+    return true;
+  }
+  if (timeoutUpdate?.type === "restore") {
+    const checkpoint =
+      timeoutUpdate.name === "lock"
+        ? state.lockTimeoutCheckpoint
+        : state.statementTimeoutCheckpoint;
+    if (checkpoint === undefined) {
+      violations.push(
+        `${relativePath}: ${timeoutUpdate.name} timeout restore lacks a checkpoint`,
+      );
+    } else if (timeoutUpdate.name === "lock") {
+      state.lockTimeout = checkpoint;
+    } else {
+      state.statementTimeout = checkpoint;
+      state.statementTimeoutRequiresRestore = false;
+    }
+    return true;
+  }
+  if (timeoutUpdate?.type === "set") {
+    const nextState =
+      timeoutUpdate.scope === "session" ? timeoutUpdate.state : "unset";
+    if (timeoutUpdate.name === "lock") {
+      state.lockTimeout = nextState;
+    } else {
+      state.statementTimeout = nextState;
+      state.statementTimeoutRequiresRestore = nextState === "unbounded";
+    }
+    return true;
+  }
+  if (timeoutUpdate?.type === "reset") {
+    if (timeoutUpdate.name === "all" || timeoutUpdate.name === "lock") {
+      state.lockTimeout = "unset";
+    }
+    if (timeoutUpdate.name === "all" || timeoutUpdate.name === "statement") {
+      state.statementTimeout = "unset";
+    }
+    return true;
+  }
+  if (isCustomStatementBudget(statement)) {
+    state.sawCustomStatementBudget = true;
+    state.statementTimeout = "bounded";
+    return true;
+  }
+  return false;
+};
+
+const enforceTypeChangeBudget = ({
+  isCustomBoundedMigration,
+  relativePath,
+  state,
+  typeChangeClauseCount,
+  violations,
+}: {
+  isCustomBoundedMigration: boolean;
+  relativePath: string;
+  state: TypeChangeTimeoutState;
+  typeChangeClauseCount: number;
+  violations: string[];
+}): void => {
+  if (!isCustomBoundedMigration && !state.activePolicy) {
+    violations.push(
+      `${relativePath}: type change lacks an explicit execution policy`,
+    );
+    return;
+  }
+  if (state.lockTimeout !== "bounded") {
+    violations.push(`${relativePath}: type change has an unbounded lock wait`);
+  }
+  if (isCustomBoundedMigration) {
+    if (
+      !state.sawCustomStatementBudget ||
+      state.statementTimeout !== "bounded"
+    ) {
+      violations.push(
+        `${relativePath}: custom type rewrite lacks its bounded execution budget`,
+      );
+    }
+    return;
+  }
+  if (state.activePolicy === "metadataOnly" && typeChangeClauseCount > 1) {
+    violations.push(
+      `${relativePath}: multiple type changes in one statement are not supported by the metadata-only timeout policy`,
+    );
+    return;
+  }
+  state.activePolicyUsed = true;
+  if (state.activePolicy === "metadataOnly") {
+    if (state.statementTimeout !== "unbounded") {
+      violations.push(
+        `${relativePath}: type change has a bounded execution timeout`,
+      );
+    }
+    state.metadataOnlyBlockOpen = true;
+    return;
+  }
+  if (state.statementTimeout !== "bounded") {
+    violations.push(
+      `${relativePath}: type rewrite lacks a bounded execution timeout`,
+    );
+  }
+};
+
 const collectUnsafeTypeChangesInMigration = (
   relativePath: string,
   source: string,
@@ -723,15 +987,17 @@ const collectUnsafeTypeChangesInMigration = (
     CUSTOM_BOUNDED_TYPE_CHANGE_MIGRATIONS.has(relativePath);
   const statements = splitSqlStatements(source);
 
-  let lockTimeout: TimeoutState = "unset";
-  let statementTimeout: TimeoutState = "unset";
-  let lockTimeoutCheckpoint: TimeoutState | undefined;
-  let statementTimeoutCheckpoint: TimeoutState | undefined;
-  let statementTimeoutRequiresRestore = false;
-  let metadataOnlyBlockOpen = false;
-  let activePolicy: TypeChangePolicy | undefined;
-  let activePolicyUsed = false;
-  let sawCustomStatementBudget = false;
+  const state: TypeChangeTimeoutState = {
+    activePolicy: undefined,
+    activePolicyUsed: false,
+    lockTimeout: "unset",
+    lockTimeoutCheckpoint: undefined,
+    metadataOnlyBlockOpen: false,
+    sawCustomStatementBudget: false,
+    statementTimeout: "unset",
+    statementTimeoutCheckpoint: undefined,
+    statementTimeoutRequiresRestore: false,
+  };
 
   for (const statement of statements) {
     const typeChangeClauseCount = [...statement.matchAll(TYPE_CHANGE_CLAUSE)]
@@ -757,17 +1023,12 @@ const collectUnsafeTypeChangesInMigration = (
 
     const declaredPolicy = parseTypeChangePolicy(statement);
     if (declaredPolicy) {
-      if (metadataOnlyBlockOpen) {
-        violations.push(
-          `${relativePath}: statement timeout is not restored immediately after metadata-only type changes`,
-        );
-        metadataOnlyBlockOpen = false;
-      }
-      if (activePolicy && !activePolicyUsed) {
-        violations.push(`${relativePath}: type change policy is unused`);
-      }
-      activePolicy = declaredPolicy;
-      activePolicyUsed = false;
+      applyTypeChangePolicy({
+        declaredPolicy,
+        relativePath,
+        state,
+        violations,
+      });
       continue;
     }
 
@@ -776,135 +1037,48 @@ const collectUnsafeTypeChangesInMigration = (
     const isImmediateRestore =
       (timeoutUpdate?.type === "restore" &&
         timeoutUpdate.name === "statement" &&
-        statementTimeoutCheckpoint !== undefined) ||
+        state.statementTimeoutCheckpoint !== undefined) ||
       (timeoutUpdate?.type === "set" &&
         timeoutUpdate.name === "statement" &&
         timeoutUpdate.scope === "session" &&
         timeoutUpdate.state === "bounded");
 
+    closeCompletedBoundedRewritePolicy({ isTypeChange, state });
+    enforceMetadataOnlyRestore({
+      isImmediateRestore,
+      isTypeChange,
+      relativePath,
+      state,
+      violations,
+    });
     if (
-      activePolicy === "boundedRewrite" &&
-      activePolicyUsed &&
-      !isTypeChange
+      applyTypeChangeTimeoutUpdate({
+        relativePath,
+        state,
+        statement,
+        timeoutUpdate,
+        violations,
+      })
     ) {
-      activePolicy = undefined;
-      activePolicyUsed = false;
-    }
-
-    if (metadataOnlyBlockOpen) {
-      if (!isTypeChange && !isImmediateRestore) {
-        violations.push(
-          `${relativePath}: statement timeout is not restored immediately after metadata-only type changes`,
-        );
-        metadataOnlyBlockOpen = false;
-        activePolicy = undefined;
-        activePolicyUsed = false;
-      } else if (isImmediateRestore) {
-        metadataOnlyBlockOpen = false;
-        activePolicy = undefined;
-        activePolicyUsed = false;
-      }
-    }
-
-    if (timeoutUpdate?.type === "checkpoint") {
-      if (timeoutUpdate.name === "lock") {
-        lockTimeoutCheckpoint = lockTimeout;
-      } else {
-        statementTimeoutCheckpoint = statementTimeout;
-      }
-      continue;
-    }
-    if (timeoutUpdate?.type === "restore") {
-      const checkpoint =
-        timeoutUpdate.name === "lock"
-          ? lockTimeoutCheckpoint
-          : statementTimeoutCheckpoint;
-      if (checkpoint === undefined) {
-        violations.push(
-          `${relativePath}: ${timeoutUpdate.name} timeout restore lacks a checkpoint`,
-        );
-      } else if (timeoutUpdate.name === "lock") {
-        lockTimeout = checkpoint;
-      } else {
-        statementTimeout = checkpoint;
-        statementTimeoutRequiresRestore = false;
-      }
-      continue;
-    }
-    if (timeoutUpdate?.type === "set") {
-      const nextState =
-        timeoutUpdate.scope === "session" ? timeoutUpdate.state : "unset";
-      if (timeoutUpdate.name === "lock") {
-        lockTimeout = nextState;
-      } else {
-        statementTimeout = nextState;
-        statementTimeoutRequiresRestore = nextState === "unbounded";
-      }
-      continue;
-    }
-    if (timeoutUpdate?.type === "reset") {
-      if (timeoutUpdate.name === "all" || timeoutUpdate.name === "lock") {
-        lockTimeout = "unset";
-      }
-      if (timeoutUpdate.name === "all" || timeoutUpdate.name === "statement") {
-        statementTimeout = "unset";
-      }
-      continue;
-    }
-    if (isCustomStatementBudget(statement)) {
-      sawCustomStatementBudget = true;
-      statementTimeout = "bounded";
       continue;
     }
     if (!isTypeChange) {
       continue;
     }
 
-    if (!isCustomBoundedMigration && !activePolicy) {
-      violations.push(
-        `${relativePath}: type change lacks an explicit execution policy`,
-      );
-      continue;
-    }
-    if (lockTimeout !== "bounded") {
-      violations.push(
-        `${relativePath}: type change has an unbounded lock wait`,
-      );
-    }
-    if (isCustomBoundedMigration) {
-      if (!sawCustomStatementBudget || statementTimeout !== "bounded") {
-        violations.push(
-          `${relativePath}: custom type rewrite lacks its bounded execution budget`,
-        );
-      }
-      continue;
-    }
-    if (activePolicy === "metadataOnly" && typeChangeClauseCount > 1) {
-      violations.push(
-        `${relativePath}: multiple type changes in one statement are not supported by the metadata-only timeout policy`,
-      );
-      continue;
-    }
-    activePolicyUsed = true;
-    if (activePolicy === "metadataOnly" && statementTimeout !== "unbounded") {
-      violations.push(
-        `${relativePath}: type change has a bounded execution timeout`,
-      );
-    }
-    if (activePolicy === "metadataOnly") {
-      metadataOnlyBlockOpen = true;
-    }
-    if (activePolicy === "boundedRewrite" && statementTimeout !== "bounded") {
-      violations.push(
-        `${relativePath}: type rewrite lacks a bounded execution timeout`,
-      );
-    }
+    enforceTypeChangeBudget({
+      isCustomBoundedMigration,
+      relativePath,
+      state,
+      typeChangeClauseCount,
+      violations,
+    });
   }
 
-  if (activePolicy && !activePolicyUsed) {
+  if (state.activePolicy && !state.activePolicyUsed) {
     violations.push(`${relativePath}: type change policy is unused`);
   }
-  if (metadataOnlyBlockOpen || statementTimeoutRequiresRestore) {
+  if (state.metadataOnlyBlockOpen || state.statementTimeoutRequiresRestore) {
     violations.push(`${relativePath}: statement timeout is not restored`);
   }
 

--- a/apps/api/src/env-base-schema.ts
+++ b/apps/api/src/env-base-schema.ts
@@ -298,7 +298,7 @@ type EnvBaseInvariantInput = {
   isDev: boolean;
 };
 
-export const envBaseInvariantViolation = ({
+const backpressureInvariantViolation = ({
   CASE_LAW_DATABASE_URL,
   PUBLIC_LAW_DATABASE_URL,
   CORPUS_INDEX_BACKPRESSURE_DIMENSIONS,
@@ -306,28 +306,7 @@ export const envBaseInvariantViolation = ({
   CORPUS_INDEX_BACKPRESSURE_LOW_WATERMARK,
   CORPUS_INDEX_BACKPRESSURE_METRIC,
   CORPUS_INDEX_BACKPRESSURE_NAMESPACE,
-  CORPUS_INDEX_ENDPOINT,
-  CORPUS_INDEX_Q09_ENDPOINT,
-  CORPUS_INDEX_Q09_SEARCH_ENDPOINT,
-  CORPUS_INDEX_SEARCH_ENDPOINT,
-  CORPUS_INDEXING_ENABLED,
-  CORPUS_STORAGE_ENABLED,
-  CORPUS_STORAGE_MODE,
-  DATABASE_URL,
-  LEGAL_CORPUS_S3_BUCKET,
-  LEGAL_SEARCH_INDEX_GENERATION,
-  LEGAL_SEARCH_PROVIDER,
-  QUERY_EXPANSION_MODE,
-  S3_ACCESS_KEY_ID,
-  S3_CREDENTIALS_PROVIDER,
-  S3_ENDPOINT,
-  S3_SECRET_ACCESS_KEY,
-  isDev,
 }: EnvBaseInvariantInput): string | null => {
-  const hasPublicLawDatabaseUrl =
-    PUBLIC_LAW_DATABASE_URL !== undefined ||
-    CASE_LAW_DATABASE_URL !== undefined;
-
   if (
     CASE_LAW_DATABASE_URL !== undefined &&
     PUBLIC_LAW_DATABASE_URL === undefined
@@ -353,6 +332,18 @@ export const envBaseInvariantViolation = ({
   ) {
     return "CORPUS_INDEX_BACKPRESSURE_LOW_WATERMARK must be below CORPUS_INDEX_BACKPRESSURE_HIGH_WATERMARK.";
   }
+  return null;
+};
+
+const databaseTransportInvariantViolation = ({
+  CASE_LAW_DATABASE_URL,
+  DATABASE_URL,
+  PUBLIC_LAW_DATABASE_URL,
+  isDev,
+}: EnvBaseInvariantInput): string | null => {
+  const hasPublicLawDatabaseUrl =
+    PUBLIC_LAW_DATABASE_URL !== undefined ||
+    CASE_LAW_DATABASE_URL !== undefined;
   if (!isDev && !hasSecureDatabaseTransport(DATABASE_URL)) {
     return "DATABASE_URL must enable TLS outside loopback or Railway private networking.";
   }
@@ -371,6 +362,16 @@ export const envBaseInvariantViolation = ({
   if (!isDev && hasPublicLawDatabaseUrl) {
     return "Public-law database URLs are only supported in local development.";
   }
+  return null;
+};
+
+const corpusEndpointInvariantViolation = ({
+  CORPUS_INDEX_Q09_ENDPOINT,
+  CORPUS_INDEX_Q09_SEARCH_ENDPOINT,
+  CORPUS_INDEX_SEARCH_ENDPOINT,
+  QUERY_EXPANSION_MODE,
+  isDev,
+}: EnvBaseInvariantInput): string | null => {
   if (
     CORPUS_INDEX_SEARCH_ENDPOINT !== undefined &&
     !isTlsOrLoopbackUrl(CORPUS_INDEX_SEARCH_ENDPOINT, {
@@ -414,6 +415,22 @@ export const envBaseInvariantViolation = ({
   if (QUERY_EXPANSION_MODE === "on") {
     return 'QUERY_EXPANSION_MODE="on" requires dictionary-version-carrying cursors; not yet implemented — use "shadow".';
   }
+  return null;
+};
+
+const publicLawTopologyInvariantViolation = ({
+  CASE_LAW_DATABASE_URL,
+  CORPUS_INDEX_ENDPOINT,
+  CORPUS_INDEX_Q09_ENDPOINT,
+  CORPUS_INDEX_Q09_SEARCH_ENDPOINT,
+  CORPUS_INDEX_SEARCH_ENDPOINT,
+  CORPUS_INDEXING_ENABLED,
+  LEGAL_SEARCH_PROVIDER,
+  PUBLIC_LAW_DATABASE_URL,
+}: EnvBaseInvariantInput): string | null => {
+  const hasPublicLawDatabaseUrl =
+    PUBLIC_LAW_DATABASE_URL !== undefined ||
+    CASE_LAW_DATABASE_URL !== undefined;
   if (hasPublicLawDatabaseUrl && LEGAL_SEARCH_PROVIDER !== "corpus-index") {
     return 'Public-law database URLs require LEGAL_SEARCH_PROVIDER="corpus-index".';
   }
@@ -434,6 +451,26 @@ export const envBaseInvariantViolation = ({
   if (hasPublicLawDatabaseUrl && CORPUS_INDEXING_ENABLED) {
     return "CORPUS_INDEXING_ENABLED must be false when a public-law database URL is configured.";
   }
+  return null;
+};
+
+const storageAndIndexInvariantViolation = ({
+  CORPUS_INDEX_ENDPOINT,
+  CORPUS_INDEX_Q09_ENDPOINT,
+  CORPUS_INDEX_Q09_SEARCH_ENDPOINT,
+  CORPUS_INDEX_SEARCH_ENDPOINT,
+  CORPUS_INDEXING_ENABLED,
+  CORPUS_STORAGE_ENABLED,
+  CORPUS_STORAGE_MODE,
+  LEGAL_CORPUS_S3_BUCKET,
+  LEGAL_SEARCH_INDEX_GENERATION,
+  LEGAL_SEARCH_PROVIDER,
+  S3_ACCESS_KEY_ID,
+  S3_CREDENTIALS_PROVIDER,
+  S3_ENDPOINT,
+  S3_SECRET_ACCESS_KEY,
+  isDev,
+}: EnvBaseInvariantInput): string | null => {
   if (
     !isDev &&
     !isTlsOrLoopbackUrl(S3_ENDPOINT, {
@@ -495,3 +532,12 @@ export const envBaseInvariantViolation = ({
     isDev,
   });
 };
+
+export const envBaseInvariantViolation = (
+  input: EnvBaseInvariantInput,
+): string | null =>
+  backpressureInvariantViolation(input) ??
+  databaseTransportInvariantViolation(input) ??
+  corpusEndpointInvariantViolation(input) ??
+  publicLawTopologyInvariantViolation(input) ??
+  storageAndIndexInvariantViolation(input);

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -248,6 +248,107 @@ export const decodeTraversalCursor = (
 export const encodeTraversalCursor = (mode: string, offset: number): string =>
   `${mode}:${offset}`;
 
+type ParsedPageItems = {
+  decisions: IngestionResult[];
+  itemsSkipped: number;
+  processedThroughIndex: number;
+};
+
+type ParsePageItemsOptions = {
+  adapterKey: string;
+  items: unknown[];
+  itemConcurrency?: number | undefined;
+  page: number;
+  parseItem: PagePaginationOptions<unknown>["parseItem"];
+  signal?: AbortSignal | undefined;
+};
+
+const parsePageItems = async ({
+  adapterKey,
+  items,
+  itemConcurrency,
+  page,
+  parseItem,
+  signal,
+}: ParsePageItemsOptions): Promise<ParsedPageItems> => {
+  const decisions: IngestionResult[] = [];
+  let itemsSkipped = 0;
+  let processedThroughIndex = 0;
+  const chunkSize = Math.max(1, itemConcurrency ?? 1);
+  // Complete chunks sequentially so an abort can rewind to the last durable
+  // chunk boundary. Replaying that chunk is safe because inserts are
+  // idempotent; advancing past an in-flight chunk would lose decisions.
+  for (let i = 0; i < items.length; i += chunkSize) {
+    if (signal?.aborted) {
+      break;
+    }
+    const chunk = items.slice(i, i + chunkSize);
+    // oxlint-disable-next-line no-await-in-loop -- sequential chunk processing: abort/rewind bookkeeping depends on prior chunk completing
+    const results = await Promise.allSettled(
+      chunk.map(async (item) => await parseItem(item, signal)),
+    );
+    if (signal?.aborted) {
+      break;
+    }
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        if (result.value) {
+          decisions.push(result.value);
+        }
+      } else {
+        // A poison item is isolated from the rest of the page. The skip is
+        // counted and logged below so it remains operator-visible.
+        itemsSkipped++;
+      }
+    }
+    processedThroughIndex = i + chunk.length;
+  }
+  if (itemsSkipped > 0) {
+    logger.warn("case_law.ingestion.page_items_skipped", {
+      adapterKey,
+      page,
+      skipped: itemsSkipped,
+      total: items.length,
+    });
+  }
+  return { decisions, itemsSkipped, processedThroughIndex };
+};
+
+const resolveNextCursor = ({
+  encode,
+  fetched,
+  fetchedItemsCount,
+  hasMore,
+  offset,
+  pageSize,
+  pageStartOffset,
+  processedItemsCount,
+  processedThroughIndex,
+  signal,
+}: {
+  encode: (offset: number) => string;
+  fetched: number;
+  fetchedItemsCount: number;
+  hasMore: boolean;
+  offset: number;
+  pageSize: number;
+  pageStartOffset: number;
+  processedItemsCount: number;
+  processedThroughIndex: number;
+  signal?: AbortSignal | undefined;
+}): string => {
+  if (signal?.aborted) {
+    return encode(offset + processedThroughIndex);
+  }
+  if (hasMore) {
+    return encode(fetched);
+  }
+  if (fetchedItemsCount > 0) {
+    return encode(offset + processedItemsCount);
+  }
+  return encode(Math.max(0, pageStartOffset - pageSize));
+};
+
 export const createPagePaginatedFetch = <TResponse>(
   opts: PagePaginationOptions<TResponse>,
 ) => {
@@ -409,51 +510,15 @@ export const createPagePaginatedFetch = <TResponse>(
         const fetchMs = Math.round(performance.now() - fetchT0);
         const { items: fetchedItems, total } = opts.extractItems(data);
         const items = fetchedItems.slice(itemsAlreadyFetched);
-        const decisions: IngestionResult[] = [];
-
-        let itemsSkipped = 0;
-        // Process items in parallel batches when the adapter
-        // opts in via itemConcurrency. Default is serial.
-        // On abort, discard the in-flight chunk's results and keep
-        // processedThroughIndex at the previous chunk boundary so the
-        // next cycle re-fetches and re-processes that chunk.
-        // Idempotent inserts handle the resulting duplicates.
-        let processedThroughIndex = 0;
-        const chunkSize = Math.max(1, opts.itemConcurrency ?? 1);
-        for (let i = 0; i < items.length; i += chunkSize) {
-          if (signal?.aborted) {
-            break;
-          }
-          const chunk = items.slice(i, i + chunkSize);
-          // oxlint-disable-next-line no-await-in-loop -- sequential chunk processing: abort/rewind bookkeeping depends on prior chunk completing
-          const results = await Promise.allSettled(
-            chunk.map(async (item) => await opts.parseItem(item, signal)),
-          );
-          if (signal?.aborted) {
-            break;
-          }
-          for (const result of results) {
-            if (result.status === "fulfilled") {
-              if (result.value) {
-                decisions.push(result.value);
-              }
-            } else {
-              // Skip individual items that fail to parse;
-              // don't abort the entire page.
-              itemsSkipped++;
-            }
-          }
-          processedThroughIndex = i + chunk.length;
-        }
-
-        if (itemsSkipped > 0) {
-          logger.warn("case_law.ingestion.page_items_skipped", {
-            adapterKey: opts.adapterKey,
-            page,
-            skipped: itemsSkipped,
-            total: items.length,
-          });
-        }
+        const parsedItems = await parsePageItems({
+          adapterKey: opts.adapterKey,
+          items,
+          itemConcurrency: opts.itemConcurrency,
+          page,
+          parseItem: opts.parseItem,
+          signal,
+        });
+        const { decisions, itemsSkipped, processedThroughIndex } = parsedItems;
 
         const totalMs = Math.round(performance.now() - fetchT0);
         logger.info("case_law.ingestion.page_completed", {
@@ -481,14 +546,18 @@ export const createPagePaginatedFetch = <TResponse>(
         // re-processing the already consumed page tail.
         // When exhausted with zero results (overshot past end),
         // step back so the cursor recovers into the valid range.
-        let nextCursor = encode(Math.max(0, pageStartOffset - opts.pageSize));
-        if (signal?.aborted) {
-          nextCursor = encode(offset + processedThroughIndex);
-        } else if (hasMore) {
-          nextCursor = encode(fetched);
-        } else if (fetchedItems.length > 0) {
-          nextCursor = encode(offset + items.length);
-        }
+        let nextCursor = resolveNextCursor({
+          encode,
+          fetched,
+          fetchedItemsCount: fetchedItems.length,
+          hasMore,
+          offset,
+          pageSize: opts.pageSize,
+          pageStartOffset,
+          processedItemsCount: items.length,
+          processedThroughIndex,
+          signal,
+        });
 
         // A bounded walk returns to its own start rather than carrying on
         // deeper. Reaching the edge of the window is not the end of

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -740,139 +740,150 @@ const processDecisionAttempt = async ({
       sourceRawContentType: true,
       sourceUrl: true,
     } as const;
-    let provisionalIdentified = await tx.query.caseLawDecisions.findFirst({
-      where:
-        provisionalClaimedDecisionId === undefined
-          ? caseLawDecisionIdentityWhere({
-              caseNumber: result.caseNumber,
-              language: result.language,
-              sourceDocumentId: result.sourceDocumentId,
-              sourceId,
-            })
-          : { id: { eq: provisionalClaimedDecisionId } },
-      columns: identityColumns,
-    });
-    if (
-      exactClaimedDecisionId !== undefined &&
-      provisionalIdentified === undefined
-    ) {
-      // A task from the previous rollout can insert the decision after a new
-      // task reserved its identities but before that reservation produced a
-      // row. Reconcile the durable reservation to the decision-table winner;
-      // otherwise every replay targets the abandoned UUID and loses the same
-      // publisher-identity uniqueness race forever.
-      const rolloutWinners = await tx.query.caseLawDecisions.findMany({
-        where: {
-          sourceId: { eq: sourceId },
-          sourceDocumentId: { in: exactSourceIdentityCandidates },
-        },
+    const resolveExistingDecision = async () => {
+      let provisionalIdentified = await tx.query.caseLawDecisions.findFirst({
+        where:
+          provisionalClaimedDecisionId === undefined
+            ? caseLawDecisionIdentityWhere({
+                caseNumber: result.caseNumber,
+                language: result.language,
+                sourceDocumentId: result.sourceDocumentId,
+                sourceId,
+              })
+            : { id: { eq: provisionalClaimedDecisionId } },
         columns: identityColumns,
-        limit: MAX_SOURCE_IDENTITY_CANDIDATES,
       });
-      const rolloutWinnerIds = [...new Set(rolloutWinners.map(({ id }) => id))];
-      if (rolloutWinnerIds.length > 1) {
-        panic("Publisher identities have conflicting decision rows");
-      }
-      const rolloutWinner = rolloutWinners.at(0);
-      if (rolloutWinner !== undefined) {
-        const abandonedDecisionId = exactClaimedDecisionId;
-        // audit: skip — rolling-deployment identity convergence; public data
-        await tx
-          .update(caseLawDecisionSourceIdentities)
-          .set({ decisionId: rolloutWinner.id })
-          .where(
-            and(
-              eq(caseLawDecisionSourceIdentities.sourceId, sourceId),
-              eq(
-                caseLawDecisionSourceIdentities.decisionId,
-                abandonedDecisionId,
-              ),
-              inArray(
-                caseLawDecisionSourceIdentities.sourceDocumentId,
-                exactSourceIdentityCandidates,
-              ),
-            ),
-          );
-        exactClaimedDecisionId = rolloutWinner.id;
-        provisionalClaimedDecisionId = rolloutWinner.id;
-        provisionalIdentified = rolloutWinner;
-      }
-    }
-    // A repair-only claim is consumable only while the decision is still
-    // stored under that degraded identity. Once upgraded, the retained audit
-    // mapping must not let an unrelated row reuse the heuristic fingerprint.
-    const repairClaimIsCurrent =
-      exactClaimedDecisionId !== undefined ||
-      repairClaimedDecisionId === undefined ||
-      (provisionalIdentified?.sourceDocumentId !== null &&
-        provisionalIdentified?.sourceDocumentId !== undefined &&
-        repairSourceIdentityCandidates.includes(
-          provisionalIdentified.sourceDocumentId,
-        ));
-    const claimedDecisionId = repairClaimIsCurrent
-      ? provisionalClaimedDecisionId
-      : undefined;
-    const exactIdentified =
-      claimedDecisionId === provisionalClaimedDecisionId
-        ? provisionalIdentified
-        : await tx.query.caseLawDecisions.findFirst({
-            where: caseLawDecisionIdentityWhere({
-              caseNumber: result.caseNumber,
-              language: result.language,
-              sourceDocumentId: result.sourceDocumentId,
-              sourceId,
-            }),
-            columns: identityColumns,
-          });
-    const identified =
-      exactIdentified ??
-      (claimedDecisionId === undefined &&
-      exactSourceIdentityCandidates.length > 1
-        ? await tx.query.caseLawDecisions.findFirst({
-            where: {
-              sourceId: { eq: sourceId },
-              sourceDocumentId: {
-                in: exactSourceIdentityCandidates.filter(
-                  (identity) => identity !== result.sourceDocumentId,
+      if (
+        exactClaimedDecisionId !== undefined &&
+        provisionalIdentified === undefined
+      ) {
+        // A task from the previous rollout can insert the decision after a new
+        // task reserved its identities but before that reservation produced a
+        // row. Reconcile the durable reservation to the decision-table winner;
+        // otherwise every replay targets the abandoned UUID and loses the same
+        // publisher-identity uniqueness race forever.
+        const rolloutWinners = await tx.query.caseLawDecisions.findMany({
+          where: {
+            sourceId: { eq: sourceId },
+            sourceDocumentId: { in: exactSourceIdentityCandidates },
+          },
+          columns: identityColumns,
+          limit: MAX_SOURCE_IDENTITY_CANDIDATES,
+        });
+        const rolloutWinnerIds = [
+          ...new Set(rolloutWinners.map(({ id }) => id)),
+        ];
+        if (rolloutWinnerIds.length > 1) {
+          panic("Publisher identities have conflicting decision rows");
+        }
+        const rolloutWinner = rolloutWinners.at(0);
+        if (rolloutWinner !== undefined) {
+          const abandonedDecisionId = exactClaimedDecisionId;
+          // audit: skip — rolling-deployment identity convergence; public data
+          await tx
+            .update(caseLawDecisionSourceIdentities)
+            .set({ decisionId: rolloutWinner.id })
+            .where(
+              and(
+                eq(caseLawDecisionSourceIdentities.sourceId, sourceId),
+                eq(
+                  caseLawDecisionSourceIdentities.decisionId,
+                  abandonedDecisionId,
                 ),
+                inArray(
+                  caseLawDecisionSourceIdentities.sourceDocumentId,
+                  exactSourceIdentityCandidates,
+                ),
+              ),
+            );
+          exactClaimedDecisionId = rolloutWinner.id;
+          provisionalClaimedDecisionId = rolloutWinner.id;
+          provisionalIdentified = rolloutWinner;
+        }
+      }
+      // A repair-only claim is consumable only while the decision is still
+      // stored under that degraded identity. Once upgraded, the retained audit
+      // mapping must not let an unrelated row reuse the heuristic fingerprint.
+      const repairClaimIsCurrent =
+        exactClaimedDecisionId !== undefined ||
+        repairClaimedDecisionId === undefined ||
+        (provisionalIdentified?.sourceDocumentId !== null &&
+          provisionalIdentified?.sourceDocumentId !== undefined &&
+          repairSourceIdentityCandidates.includes(
+            provisionalIdentified.sourceDocumentId,
+          ));
+      const claimedDecisionId = repairClaimIsCurrent
+        ? provisionalClaimedDecisionId
+        : undefined;
+      const exactIdentified =
+        claimedDecisionId === provisionalClaimedDecisionId
+          ? provisionalIdentified
+          : await tx.query.caseLawDecisions.findFirst({
+              where: caseLawDecisionIdentityWhere({
+                caseNumber: result.caseNumber,
+                language: result.language,
+                sourceDocumentId: result.sourceDocumentId,
+                sourceId,
+              }),
+              columns: identityColumns,
+            });
+      const identified =
+        exactIdentified ??
+        (claimedDecisionId === undefined &&
+        exactSourceIdentityCandidates.length > 1
+          ? await tx.query.caseLawDecisions.findFirst({
+              where: {
+                sourceId: { eq: sourceId },
+                sourceDocumentId: {
+                  in: exactSourceIdentityCandidates.filter(
+                    (identity) => identity !== result.sourceDocumentId,
+                  ),
+                },
               },
-            },
-            columns: identityColumns,
-          })
-        : undefined);
+              columns: identityColumns,
+            })
+          : undefined);
 
-    // Adapters that learned the publisher's document id after their first
-    // release may adopt a legacy null-id row, but only after proving which
-    // publisher document produced it. A docket can publish siblings, so
-    // encounter order is not identity.
-    const legacy =
-      identified || !result.sourceDocumentId || claimedDecisionId !== undefined
-        ? undefined
-        : await tx.query.caseLawDecisions.findFirst({
-            where: {
-              sourceId: { eq: sourceId },
-              caseNumber: result.caseNumber,
-              language: result.language,
-              sourceDocumentId: { isNull: true },
-            },
-            columns: identityColumns,
-          });
-    const ecliMatches =
-      legacy !== undefined &&
-      result.ecli !== undefined &&
-      legacy.ecli === result.ecli;
-    const legacyEcliContradicts =
-      legacy !== undefined &&
-      legacy.ecli !== null &&
-      result.ecli !== undefined &&
-      legacy.ecli !== result.ecli;
-    const sourceUrlMatches =
-      legacy !== undefined &&
-      !legacyEcliContradicts &&
-      legacy.sourceUrl !== null &&
-      result.legacySourceUrls?.includes(legacy.sourceUrl) === true;
-    const legacyMatches = ecliMatches || sourceUrlMatches;
-    const existing = identified ?? (legacyMatches ? legacy : undefined);
+      // Adapters that learned the publisher's document id after their first
+      // release may adopt a legacy null-id row, but only after proving which
+      // publisher document produced it. A docket can publish siblings, so
+      // encounter order is not identity.
+      const legacy =
+        identified ||
+        !result.sourceDocumentId ||
+        claimedDecisionId !== undefined
+          ? undefined
+          : await tx.query.caseLawDecisions.findFirst({
+              where: {
+                sourceId: { eq: sourceId },
+                caseNumber: result.caseNumber,
+                language: result.language,
+                sourceDocumentId: { isNull: true },
+              },
+              columns: identityColumns,
+            });
+      const ecliMatches =
+        legacy !== undefined &&
+        result.ecli !== undefined &&
+        legacy.ecli === result.ecli;
+      const legacyEcliContradicts =
+        legacy !== undefined &&
+        legacy.ecli !== null &&
+        result.ecli !== undefined &&
+        legacy.ecli !== result.ecli;
+      const sourceUrlMatches =
+        legacy !== undefined &&
+        !legacyEcliContradicts &&
+        legacy.sourceUrl !== null &&
+        result.legacySourceUrls?.includes(legacy.sourceUrl) === true;
+      const legacyMatches = ecliMatches || sourceUrlMatches;
+      const existing = identified ?? (legacyMatches ? legacy : undefined);
+      return {
+        claimedDecisionId,
+        existing,
+      };
+    };
+    const { claimedDecisionId, existing } = await resolveExistingDecision();
     const decisionId = claimedDecisionId ?? existing?.id ?? proposedDecisionId;
     const existingIdentity = existing?.sourceDocumentId ?? undefined;
     const incomingSupersedesExisting =
@@ -943,462 +954,525 @@ const processDecisionAttempt = async ({
       (result.isListingOnly === true &&
         !storedPartialObservation.isListingOnly));
 
-  if (
-    preservesExistingDetail &&
-    existing.corpusMirrorStatus !== CASE_LAW_CORPUS_MIRROR_STATUS.PENDING
-  ) {
-    // A listing-only result carries less information than an identified row
-    // that was previously enriched from detail. Advance only the source
-    // observation watermark: replacing metadata, dates, raw-source pointers
-    // or payload fields would make a temporary publisher regression durable.
-    // A pending corpus mirror deliberately continues below: it must replay
-    // the stored payload before this source page is allowed to advance.
-    const watermarkAdvanced = await scopedDb(
-      // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-      async (tx) => {
-        // audit: skip — background case-law observation watermark; public data
-        return (
-          await tx
-            .update(caseLawDecisions)
-            .set({
-              sourceObservedAt: observedAt,
-              sourceObservationOrder: observationOrder,
-              sourceObservationHash: result.rawHash,
-              updatedAt: sql`${caseLawDecisions.updatedAt}`,
-            })
-            .where(
-              and(
-                eq(caseLawDecisions.id, existing.id),
-                storedObservationPrecedes({ order: observationOrder }),
-                isNull(caseLawDecisions.redactedAt),
-                eq(
-                  caseLawDecisions.corpusMirrorStatus,
-                  CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED,
-                ),
-              ),
-            )
-            .returning({ id: caseLawDecisions.id })
-        ).at(0);
-      },
-    );
-    if (!watermarkAdvanced) {
-      const current = await scopedDb((tx) =>
-        tx.query.caseLawDecisions.findFirst({
-          where: { id: { eq: existing.id } },
-          columns: {
-            corpusMirrorStatus: true,
-            sourceObservationOrder: true,
-            redactedAt: true,
+  const resolveExistingDecisionPolicy =
+    async (): Promise<ProcessResult | null> => {
+      if (
+        preservesExistingDetail &&
+        existing.corpusMirrorStatus !== CASE_LAW_CORPUS_MIRROR_STATUS.PENDING
+      ) {
+        // A listing-only result carries less information than an identified row
+        // that was previously enriched from detail. Advance only the source
+        // observation watermark: replacing metadata, dates, raw-source pointers
+        // or payload fields would make a temporary publisher regression durable.
+        // A pending corpus mirror deliberately continues below: it must replay
+        // the stored payload before this source page is allowed to advance.
+        const watermarkAdvanced = await scopedDb(
+          // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+          async (tx) => {
+            // audit: skip — background case-law observation watermark; public data
+            return (
+              await tx
+                .update(caseLawDecisions)
+                .set({
+                  sourceObservedAt: observedAt,
+                  sourceObservationOrder: observationOrder,
+                  sourceObservationHash: result.rawHash,
+                  updatedAt: sql`${caseLawDecisions.updatedAt}`,
+                })
+                .where(
+                  and(
+                    eq(caseLawDecisions.id, existing.id),
+                    storedObservationPrecedes({ order: observationOrder }),
+                    isNull(caseLawDecisions.redactedAt),
+                    eq(
+                      caseLawDecisions.corpusMirrorStatus,
+                      CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED,
+                    ),
+                  ),
+                )
+                .returning({ id: caseLawDecisions.id })
+            ).at(0);
           },
-        }),
-      );
-      if (current?.redactedAt) {
+        );
+        if (!watermarkAdvanced) {
+          const current = await scopedDb((tx) =>
+            tx.query.caseLawDecisions.findFirst({
+              where: { id: { eq: existing.id } },
+              columns: {
+                corpusMirrorStatus: true,
+                sourceObservationOrder: true,
+                redactedAt: true,
+              },
+            }),
+          );
+          if (current?.redactedAt) {
+            return {
+              status: PROCESS_DECISION_STATUS.COMPLETE,
+              inserted: false,
+              searchVectorFailed: false,
+            };
+          }
+          if (
+            current?.corpusMirrorStatus ===
+            CASE_LAW_CORPUS_MIRROR_STATUS.PENDING
+          ) {
+            return {
+              status: PROCESS_DECISION_STATUS.RETRYABLE,
+              inserted: false,
+              reason: PROCESS_DECISION_RETRY_REASON.CORPUS_WRITE,
+            };
+          }
+          if (
+            !current ||
+            (current.sourceObservationOrder !== null &&
+              current.sourceObservationOrder >= observationOrder)
+          ) {
+            return {
+              status: PROCESS_DECISION_STATUS.COMPLETE,
+              inserted: false,
+              searchVectorFailed: false,
+            };
+          }
+          if (contentionReconciliation === CONTENTION_RECONCILIATION.RETRY) {
+            return {
+              status: PROCESS_DECISION_STATUS.RETRYABLE,
+              inserted: false,
+              reason: PROCESS_DECISION_RETRY_REASON.CONTENTION,
+            };
+          }
+          return await processDecisionAttempt({
+            input,
+            sourceId,
+            scopedDb,
+            observedAt,
+            observationOrder,
+            contentionReconciliation: CONTENTION_RECONCILIATION.RETRY,
+            refresh,
+          });
+        }
         return {
           status: PROCESS_DECISION_STATUS.COMPLETE,
           inserted: false,
           searchVectorFailed: false,
         };
       }
+
       if (
-        current?.corpusMirrorStatus === CASE_LAW_CORPUS_MIRROR_STATUS.PENDING
+        existing &&
+        existing.corpusMirrorStatus === CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED &&
+        refresh === DECISION_REFRESH.WHEN_SOURCE_CHANGED &&
+        shouldSkipRefresh({
+          existingMetadata: existing.metadata,
+          existingSourceRawContentType: existing.sourceRawContentType,
+          existingSourceHash: existing.sourceHash,
+          incomingMetadata: result.metadata,
+          incomingRawHash: result.rawHash,
+          incomingSourceRawContentType:
+            result.sourceRawContentType ?? "text/plain",
+          incomingUsesSourceRawBytes: result.sourceRawBytes !== undefined,
+        })
       ) {
-        return {
-          status: PROCESS_DECISION_STATUS.RETRYABLE,
-          inserted: false,
-          reason: PROCESS_DECISION_RETRY_REASON.CORPUS_WRITE,
-        };
-      }
-      if (
-        !current ||
-        (current.sourceObservationOrder !== null &&
-          current.sourceObservationOrder >= observationOrder)
-      ) {
+        const watermarkAdvanced = await scopedDb(
+          // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+          async (tx) => {
+            // audit: skip — background case-law ingestion ordering metadata; public case-law data, not user actions
+            return (
+              await tx
+                .update(caseLawDecisions)
+                .set({
+                  sourceObservedAt: observedAt,
+                  sourceObservationOrder: observationOrder,
+                  sourceObservationHash: result.rawHash,
+                  // Drizzle applies the schema's on-update value unless this column is
+                  // explicit. A watermark-only replay is not a content modification.
+                  updatedAt: sql`${caseLawDecisions.updatedAt}`,
+                })
+                .where(
+                  and(
+                    eq(caseLawDecisions.id, existing.id),
+                    storedObservationPrecedes({ order: observationOrder }),
+                    isNull(caseLawDecisions.redactedAt),
+                    sql`${caseLawDecisions.sourceHash} IS NOT DISTINCT FROM ${existing.sourceHash}`,
+                    // `::text::jsonb`, never a bare `::jsonb`: the cast fixes the
+                    // bind parameter's type, and the driver then JSON-encodes the
+                    // already-serialized string, so the comparison sees a jsonb
+                    // *string* rather than the object and never matches.
+                    sql`${caseLawDecisions.metadata} IS NOT DISTINCT FROM ${JSON.stringify(existing.metadata)}::text::jsonb`,
+                  ),
+                )
+                .returning({ id: caseLawDecisions.id })
+            ).at(0);
+          },
+        );
+        if (!watermarkAdvanced) {
+          const current = await scopedDb((tx) =>
+            tx.query.caseLawDecisions.findFirst({
+              where: { id: { eq: existing.id } },
+              columns: {
+                corpusMirrorStatus: true,
+                sourceObservationOrder: true,
+                redactedAt: true,
+              },
+            }),
+          );
+          if (current?.redactedAt) {
+            return {
+              status: PROCESS_DECISION_STATUS.COMPLETE,
+              inserted: false,
+              searchVectorFailed: false,
+            };
+          }
+          if (
+            current?.corpusMirrorStatus ===
+            CASE_LAW_CORPUS_MIRROR_STATUS.PENDING
+          ) {
+            return {
+              status: PROCESS_DECISION_STATUS.RETRYABLE,
+              inserted: false,
+              reason: PROCESS_DECISION_RETRY_REASON.CORPUS_WRITE,
+            };
+          }
+          if (
+            !current ||
+            (current.sourceObservationOrder !== null &&
+              current.sourceObservationOrder >= observationOrder)
+          ) {
+            return {
+              status: PROCESS_DECISION_STATUS.COMPLETE,
+              inserted: false,
+              searchVectorFailed: false,
+            };
+          }
+          if (contentionReconciliation === CONTENTION_RECONCILIATION.RETRY) {
+            return {
+              status: PROCESS_DECISION_STATUS.RETRYABLE,
+              inserted: false,
+              reason: PROCESS_DECISION_RETRY_REASON.CONTENTION,
+            };
+          }
+          return await processDecisionAttempt({
+            input,
+            sourceId,
+            scopedDb,
+            observedAt,
+            observationOrder,
+            contentionReconciliation: CONTENTION_RECONCILIATION.RETRY,
+            refresh,
+          });
+        }
         return {
           status: PROCESS_DECISION_STATUS.COMPLETE,
           inserted: false,
           searchVectorFailed: false,
         };
       }
-      if (contentionReconciliation === CONTENTION_RECONCILIATION.RETRY) {
-        return {
-          status: PROCESS_DECISION_STATUS.RETRYABLE,
-          inserted: false,
-          reason: PROCESS_DECISION_RETRY_REASON.CONTENTION,
-        };
-      }
-      return await processDecisionAttempt({
-        input,
-        sourceId,
-        scopedDb,
-        observedAt,
-        observationOrder,
-        contentionReconciliation: CONTENTION_RECONCILIATION.RETRY,
-        refresh,
-      });
-    }
-    return {
-      status: PROCESS_DECISION_STATUS.COMPLETE,
-      inserted: false,
-      searchVectorFailed: false,
+
+      return null;
     };
+  const existingPolicyOutcome = await resolveExistingDecisionPolicy();
+  if (existingPolicyOutcome !== null) {
+    return existingPolicyOutcome;
   }
 
-  if (
-    existing &&
-    existing.corpusMirrorStatus === CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED &&
-    refresh === DECISION_REFRESH.WHEN_SOURCE_CHANGED &&
-    shouldSkipRefresh({
-      existingMetadata: existing.metadata,
-      existingSourceRawContentType: existing.sourceRawContentType,
-      existingSourceHash: existing.sourceHash,
-      incomingMetadata: result.metadata,
-      incomingRawHash: result.rawHash,
-      incomingSourceRawContentType: result.sourceRawContentType ?? "text/plain",
-      incomingUsesSourceRawBytes: result.sourceRawBytes !== undefined,
-    })
-  ) {
-    const watermarkAdvanced = await scopedDb(
-      // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-      async (tx) => {
-        // audit: skip — background case-law ingestion ordering metadata; public case-law data, not user actions
-        return (
-          await tx
-            .update(caseLawDecisions)
-            .set({
-              sourceObservedAt: observedAt,
-              sourceObservationOrder: observationOrder,
-              sourceObservationHash: result.rawHash,
-              // Drizzle applies the schema's on-update value unless this column is
-              // explicit. A watermark-only replay is not a content modification.
-              updatedAt: sql`${caseLawDecisions.updatedAt}`,
-            })
-            .where(
-              and(
-                eq(caseLawDecisions.id, existing.id),
-                storedObservationPrecedes({ order: observationOrder }),
-                isNull(caseLawDecisions.redactedAt),
-                sql`${caseLawDecisions.sourceHash} IS NOT DISTINCT FROM ${existing.sourceHash}`,
-                // `::text::jsonb`, never a bare `::jsonb`: the cast fixes the
-                // bind parameter's type, and the driver then JSON-encodes the
-                // already-serialized string, so the comparison sees a jsonb
-                // *string* rather than the object and never matches.
-                sql`${caseLawDecisions.metadata} IS NOT DISTINCT FROM ${JSON.stringify(existing.metadata)}::text::jsonb`,
-              ),
-            )
-            .returning({ id: caseLawDecisions.id })
-        ).at(0);
-      },
-    );
-    if (!watermarkAdvanced) {
-      const current = await scopedDb((tx) =>
-        tx.query.caseLawDecisions.findFirst({
-          where: { id: { eq: existing.id } },
-          columns: {
-            corpusMirrorStatus: true,
-            sourceObservationOrder: true,
-            redactedAt: true,
-          },
-        }),
-      );
-      if (current?.redactedAt) {
-        return {
-          status: PROCESS_DECISION_STATUS.COMPLETE,
-          inserted: false,
-          searchVectorFailed: false,
-        };
-      }
-      if (
-        current?.corpusMirrorStatus === CASE_LAW_CORPUS_MIRROR_STATUS.PENDING
-      ) {
-        return {
-          status: PROCESS_DECISION_STATUS.RETRYABLE,
-          inserted: false,
-          reason: PROCESS_DECISION_RETRY_REASON.CORPUS_WRITE,
-        };
-      }
-      if (
-        !current ||
-        (current.sourceObservationOrder !== null &&
-          current.sourceObservationOrder >= observationOrder)
-      ) {
-        return {
-          status: PROCESS_DECISION_STATUS.COMPLETE,
-          inserted: false,
-          searchVectorFailed: false,
-        };
-      }
-      if (contentionReconciliation === CONTENTION_RECONCILIATION.RETRY) {
-        return {
-          status: PROCESS_DECISION_STATUS.RETRYABLE,
-          inserted: false,
-          reason: PROCESS_DECISION_RETRY_REASON.CONTENTION,
-        };
-      }
-      return await processDecisionAttempt({
-        input,
-        sourceId,
-        scopedDb,
-        observedAt,
-        observationOrder,
-        contentionReconciliation: CONTENTION_RECONCILIATION.RETRY,
-        refresh,
-      });
-    }
-    return {
-      status: PROCESS_DECISION_STATUS.COMPLETE,
-      inserted: false,
-      searchVectorFailed: false,
-    };
-  }
+  // Acquire the raw-source artifact before persisting its hash. A new row
+  // cannot safely advance without the artifact; an update preserves its old
+  // key and carries a retryable failure through the eventual row outcome.
+  const acquireSourceRawArtifact = async () => {
+    const rawPayload = preservesExistingDetail
+      ? undefined
+      : (result.sourceRawBytes ?? result.sourceRaw);
+    const rawContentType = result.sourceRawContentType ?? "text/plain";
 
-  // Upload sourceRaw to S3 — best-effort; failure must not
-  // prevent the decision from being inserted.
-  const rawPayload = preservesExistingDetail
-    ? undefined
-    : (result.sourceRawBytes ?? result.sourceRaw);
-  const rawContentType = result.sourceRawContentType ?? "text/plain";
-
-  let sourceRawS3Key: string | null = null;
-  let sourceRawContentType: string | null = null;
-  let s3UploadFailed = false;
-  if (preservesExistingDetail) {
-    sourceRawS3Key = existing.sourceRawS3Key;
-    sourceRawContentType = existing.sourceRawContentType;
-  } else if (rawPayload !== undefined) {
-    try {
-      sourceRawS3Key = await uploadSourceRaw({
-        sourceId,
-        data: rawPayload,
-        contentType: rawContentType,
-        storedKey: existing?.sourceRawS3Key ?? null,
-        storedContentType: existing?.sourceRawContentType ?? null,
-      });
-      sourceRawContentType = rawContentType;
-    } catch (error) {
-      if (!existing) {
-        // New decision: hold the page's cursor and retry the slice.
-        // Inserting with sourceRawS3Key: null would set sourceHash,
-        // causing the dedup check to skip it permanently — the raw
-        // source would be lost forever.
-        //
-        // Reported as retryable rather than thrown: the decision loop
-        // catches a throw, counts it as skipped, and lets the cursor
-        // advance, so a forward-only traversal passes the decision and
-        // never returns to it. Only a retryable outcome reaches the
-        // page-level hold.
-        logger.error("case_law.ingestion.source_raw_write_failed", {
-          sourceId,
-          caseNumber: result.caseNumber,
-          ...errorSystemFields(error),
-          ...pgErrorFields(error),
-          "error.detail": wrappedErrorDetail(error),
-        });
-        captureError(error, { sourceId, step: "uploadSourceRaw" });
-
-        return {
-          status: PROCESS_DECISION_STATUS.RETRYABLE,
-          inserted: false,
-          reason: PROCESS_DECISION_RETRY_REASON.SOURCE_RAW_WRITE,
-        };
-      }
-
-      captureError(error, { sourceId, step: "uploadSourceRaw" });
-
-      // Update: preserve existing S3 key and DO NOT advance sourceHash.
-      // If we wrote the new hash with the old key, the hash mismatch
-      // would never trigger again and the stale raw source could never
-      // be corrected through normal ingestion.
+    let sourceRawS3Key: string | null = null;
+    let sourceRawContentType: string | null = null;
+    let s3UploadFailed = false;
+    if (preservesExistingDetail) {
       sourceRawS3Key = existing.sourceRawS3Key;
       sourceRawContentType = existing.sourceRawContentType;
-      s3UploadFailed = true;
-    }
-  }
-
-  const sections = decisionSections(result);
-
-  // A metadata-first source keeps refreshing a decision it has no
-  // document for: the list endpoint's fields change, the hash moves, and
-  // the adapter returns the same empty AST it returned at first sight.
-  // Applying that over a decision whose document has since arrived — by
-  // hydration or backfill — would put the empty AST back, and under
-  // corpus storage would rewrite the objects empty and move the row's
-  // keys onto them, which is precisely the state the repair pass exists
-  // to undo. Nothing the refresh carries is a document, so nothing it
-  // carries may replace one: the metadata is updated and the payload,
-  // its object-storage pointers and the citations drawn from it are left
-  // as they are.
-  const incomingCarriesDocument = Boolean(
-    result.fulltext || hasUsableAst(result.documentAst),
-  );
-  const preserveStoredDocument =
-    existing !== undefined &&
-    !incomingCarriesDocument &&
-    (await hasStoredDocument(existing.id, scopedDb));
-  const pendingMirrorPayload =
-    existing?.corpusMirrorStatus === CASE_LAW_CORPUS_MIRROR_STATUS.PENDING &&
-    !incomingCarriesDocument
-      ? await loadPendingMirrorPayload(existing.id, scopedDb)
-      : null;
-
-  // Parsers report their own quality through `validateAndLog`, but a
-  // source whose parser never runs reports nothing at all. Emit the
-  // same signal here so every stored decision is accounted for, and
-  // split the severity the same way: no text is an error, text without
-  // structure is a warning. A refresh that preserves the stored document
-  // reports nothing: it did not store an empty decision, it left a full
-  // one alone, and these errors are what an operator sweeps for.
-  const astBlocks = hasUsableAst(result.documentAst)
-    ? result.documentAst.blocks.length
-    : 0;
-  const signal =
-    preserveStoredDocument || pendingMirrorPayload !== null
-      ? undefined
-      : storedDecisionSignal({
-          hasFulltext: Boolean(result.fulltext),
-          astBlocks,
+    } else if (rawPayload !== undefined) {
+      try {
+        sourceRawS3Key = await uploadSourceRaw({
+          sourceId,
+          data: rawPayload,
+          contentType: rawContentType,
+          storedKey: existing?.sourceRawS3Key ?? null,
+          storedContentType: existing?.sourceRawContentType ?? null,
         });
-  if (signal) {
-    const subject = {
-      sourceId,
-      caseNumber: result.caseNumber,
-      language: result.language,
-      url: result.sourceUrl ?? result.documentUrl ?? "",
-      fulltextLength: result.fulltext?.length ?? 0,
-    };
-    if (signal.level === "error") {
-      logger.error(signal.event, subject);
-    } else {
-      logger.warn(signal.event, subject);
-    }
-  }
+        sourceRawContentType = rawContentType;
+      } catch (error) {
+        if (!existing) {
+          // New decision: hold the page's cursor and retry the slice.
+          // Inserting with sourceRawS3Key: null would set sourceHash,
+          // causing the dedup check to skip it permanently — the raw
+          // source would be lost forever.
+          //
+          // Reported as retryable rather than thrown: the decision loop
+          // catches a throw, counts it as skipped, and lets the cursor
+          // advance, so a forward-only traversal passes the decision and
+          // never returns to it. Only a retryable outcome reaches the
+          // page-level hold.
+          logger.error("case_law.ingestion.source_raw_write_failed", {
+            sourceId,
+            caseNumber: result.caseNumber,
+            ...errorSystemFields(error),
+            ...pgErrorFields(error),
+            "error.detail": wrappedErrorDetail(error),
+          });
+          captureError(error, { sourceId, step: "uploadSourceRaw" });
 
-  // The publisher's own statement of the case's procedural history, where
-  // it supplies one; classification consults it before any heuristic.
-  const proceduralKeys = proceduralKeysFromMetadata(
-    result.metadata,
-    (caseNumber) => bareCitationKey(caseNumber),
-  );
-
-  const decisionIdentifiers = decisionIdentifiersFromMetadata({
-    caseNumber: result.caseNumber,
-    ecli: result.ecli ?? null,
-    identifiers: result.identifiers,
-  });
-  const identifierRows = decisionIdentifiers.map((identifier) => ({
-    type: identifier.type,
-    value: identifier.value,
-    normalizedValue: normalizeDecisionIdentifier(identifier),
-  }));
-  const citations = extractCitations(
-    sections.map((s) => ({ index: s.index, text: s.text })),
-  ).filter((c) => !isSelfCitation(c.citationText, decisionIdentifiers));
-
-  // Where the publisher supplies its own cited-decisions list, it is the
-  // one ground truth extraction can be measured against without measuring
-  // it against itself. Computed here, emitted only after the row write
-  // commits (a replayed decision must not re-count) — and emitted for
-  // zero-gap decisions too, or aggregated events could not produce a
-  // recall denominator.
-  // Measured only when the incoming payload carries a document: an empty
-  // payload has nothing for extraction to find, so every publisher
-  // citation would read as missed — on document-preserving refreshes and
-  // equally when a concurrent backfill wins the row between the read and
-  // the transaction. Emitted here rather than after the write because an
-  // ambiguous timeout can commit the row yet throw, and the replay
-  // dedup-skips before re-measuring; the source hash is the identity a
-  // consumer deduplicates retries on.
-  if (
-    incomingCarriesDocument &&
-    !preserveStoredDocument &&
-    result.publisherCitedCases &&
-    result.publisherCitedCases.length > 0
-  ) {
-    const recall = publisherCitationGap({
-      extracted: citations.map((c) => c.citationText),
-      publisherCited: result.publisherCitedCases,
-    });
-    const level = recall.missed.length > 0 ? "warn" : "info";
-    logger[level]("case_law.ingestion.citation_recall", {
-      caseNumber: result.caseNumber,
-      language: result.language,
-      url: result.sourceUrl ?? "",
-      sourceHash: result.rawHash,
-      publisherCitedCount: recall.publisherCitedCount,
-      missedCount: recall.missed.length,
-      missed: recall.missed.slice(0, 10).join("; "),
-    });
-  }
-
-  const languageGroupKey = result.ecli || `${sourceId}:${result.caseNumber}`;
-
-  // Corpus objects and every publisher alias now share the UUID reserved by
-  // identity resolution before any external write.
-
-  const corpusPayload: CorpusWritePayload =
-    pendingMirrorPayload === null
-      ? {
-          documentId: decisionId,
-          jurisdiction: result.country,
-          ...caseLawCanonicalPayload(result),
+          return {
+            type: "retry",
+            outcome: {
+              status: PROCESS_DECISION_STATUS.RETRYABLE,
+              inserted: false,
+              reason: PROCESS_DECISION_RETRY_REASON.SOURCE_RAW_WRITE,
+            },
+          } as const;
         }
-      : {
-          documentId: decisionId,
-          jurisdiction: result.country,
-          ...pendingMirrorPayload,
-        };
-  const mirrorCarriesDocument = Boolean(
-    corpusPayload.text || hasUsableAst(corpusPayload.ast),
-  );
 
-  const corpusPlan: CorpusWritePlan =
-    preserveStoredDocument && pendingMirrorPayload === null
-      ? { type: "preserve-stored" }
-      : planCorpusWrite(corpusStorageMode);
+        captureError(error, { sourceId, step: "uploadSourceRaw" });
 
-  const postgresPayload = {
-    fulltext: corpusPayload.text,
-    sections: corpusPayload.sections,
-    documentAst: corpusPayload.ast,
-  };
-
-  const payloadColumns = (() => {
-    switch (corpusPlan.type) {
-      case "postgres-only":
-        // This refresh supersedes whatever the corpus holds and nothing
-        // will follow to rewrite the pointers, so a row carrying keys from
-        // an earlier canonical/dual-write period would point at objects
-        // that no longer match its columns. Clear them.
-        return {
-          ...postgresPayload,
-          ...corpusMirrorColumns({
-            status: CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED,
-            written: null,
-          }),
-        };
-      case "postgres-mirrored":
-      case "object-storage":
-        // Persist retry intent with the Postgres payload. Clearing every old
-        // pointer makes the pending branch structurally unable to serve a
-        // stale mirror while an unchanged replay repairs it.
-        return {
-          ...postgresPayload,
-          ...corpusMirrorColumns({
-            status: CASE_LAW_CORPUS_MIRROR_STATUS.PENDING,
-          }),
-        };
-      case "preserve-stored":
-        // Every payload column, and every pointer into object storage,
-        // stays exactly as stored. Leaving them out of the update is
-        // what preserves them.
-        return {};
-      default: {
-        const unhandled: never = corpusPlan;
-        return panic(`Unhandled corpus write plan: ${String(unhandled)}`);
+        // Update: preserve existing S3 key and DO NOT advance sourceHash.
+        // If we wrote the new hash with the old key, the hash mismatch
+        // would never trigger again and the stale raw source could never
+        // be corrected through normal ingestion.
+        sourceRawS3Key = existing.sourceRawS3Key;
+        sourceRawContentType = existing.sourceRawContentType;
+        s3UploadFailed = true;
       }
     }
-  })();
 
-  const incomingCitationKey = citationKeyOf(result.caseNumber);
+    return {
+      type: "acquired",
+      artifact: { s3UploadFailed, sourceRawContentType, sourceRawS3Key },
+    } as const;
+  };
+  const sourceRawArtifact = await acquireSourceRawArtifact();
+  if (sourceRawArtifact.type === "retry") {
+    return sourceRawArtifact.outcome;
+  }
+  const {
+    sourceRawContentType,
+    sourceRawS3Key,
+    s3UploadFailed: rawUploadFailed,
+  } = sourceRawArtifact.artifact;
+  let s3UploadFailed = rawUploadFailed;
+
+  const preparePersistenceInputs = async () => {
+    const sections = decisionSections(result);
+
+    // A metadata-first source keeps refreshing a decision it has no
+    // document for: the list endpoint's fields change, the hash moves, and
+    // the adapter returns the same empty AST it returned at first sight.
+    // Applying that over a decision whose document has since arrived — by
+    // hydration or backfill — would put the empty AST back, and under
+    // corpus storage would rewrite the objects empty and move the row's
+    // keys onto them, which is precisely the state the repair pass exists
+    // to undo. Nothing the refresh carries is a document, so nothing it
+    // carries may replace one: the metadata is updated and the payload,
+    // its object-storage pointers and the citations drawn from it are left
+    // as they are.
+    const incomingCarriesDocument = Boolean(
+      result.fulltext || hasUsableAst(result.documentAst),
+    );
+    const preserveStoredDocument =
+      existing !== undefined &&
+      !incomingCarriesDocument &&
+      (await hasStoredDocument(existing.id, scopedDb));
+    const pendingMirrorPayload =
+      existing?.corpusMirrorStatus === CASE_LAW_CORPUS_MIRROR_STATUS.PENDING &&
+      !incomingCarriesDocument
+        ? await loadPendingMirrorPayload(existing.id, scopedDb)
+        : null;
+
+    // Parsers report their own quality through `validateAndLog`, but a
+    // source whose parser never runs reports nothing at all. Emit the
+    // same signal here so every stored decision is accounted for, and
+    // split the severity the same way: no text is an error, text without
+    // structure is a warning. A refresh that preserves the stored document
+    // reports nothing: it did not store an empty decision, it left a full
+    // one alone, and these errors are what an operator sweeps for.
+    const astBlocks = hasUsableAst(result.documentAst)
+      ? result.documentAst.blocks.length
+      : 0;
+    const signal =
+      preserveStoredDocument || pendingMirrorPayload !== null
+        ? undefined
+        : storedDecisionSignal({
+            hasFulltext: Boolean(result.fulltext),
+            astBlocks,
+          });
+    if (signal) {
+      const subject = {
+        sourceId,
+        caseNumber: result.caseNumber,
+        language: result.language,
+        url: result.sourceUrl ?? result.documentUrl ?? "",
+        fulltextLength: result.fulltext?.length ?? 0,
+      };
+      if (signal.level === "error") {
+        logger.error(signal.event, subject);
+      } else {
+        logger.warn(signal.event, subject);
+      }
+    }
+
+    // The publisher's own statement of the case's procedural history, where
+    // it supplies one; classification consults it before any heuristic.
+    const proceduralKeys = proceduralKeysFromMetadata(
+      result.metadata,
+      (caseNumber) => bareCitationKey(caseNumber),
+    );
+
+    const decisionIdentifiers = decisionIdentifiersFromMetadata({
+      caseNumber: result.caseNumber,
+      ecli: result.ecli ?? null,
+      identifiers: result.identifiers,
+    });
+    const identifierRows = decisionIdentifiers.map((identifier) => ({
+      type: identifier.type,
+      value: identifier.value,
+      normalizedValue: normalizeDecisionIdentifier(identifier),
+    }));
+    const citations = extractCitations(
+      sections.map((s) => ({ index: s.index, text: s.text })),
+    ).filter((c) => !isSelfCitation(c.citationText, decisionIdentifiers));
+
+    // Where the publisher supplies its own cited-decisions list, it is the
+    // one ground truth extraction can be measured against without measuring
+    // it against itself. Computed here, emitted only after the row write
+    // commits (a replayed decision must not re-count) — and emitted for
+    // zero-gap decisions too, or aggregated events could not produce a
+    // recall denominator.
+    // Measured only when the incoming payload carries a document: an empty
+    // payload has nothing for extraction to find, so every publisher
+    // citation would read as missed — on document-preserving refreshes and
+    // equally when a concurrent backfill wins the row between the read and
+    // the transaction. Emitted here rather than after the write because an
+    // ambiguous timeout can commit the row yet throw, and the replay
+    // dedup-skips before re-measuring; the source hash is the identity a
+    // consumer deduplicates retries on.
+    if (
+      incomingCarriesDocument &&
+      !preserveStoredDocument &&
+      result.publisherCitedCases &&
+      result.publisherCitedCases.length > 0
+    ) {
+      const recall = publisherCitationGap({
+        extracted: citations.map((c) => c.citationText),
+        publisherCited: result.publisherCitedCases,
+      });
+      const level = recall.missed.length > 0 ? "warn" : "info";
+      logger[level]("case_law.ingestion.citation_recall", {
+        caseNumber: result.caseNumber,
+        language: result.language,
+        url: result.sourceUrl ?? "",
+        sourceHash: result.rawHash,
+        publisherCitedCount: recall.publisherCitedCount,
+        missedCount: recall.missed.length,
+        missed: recall.missed.slice(0, 10).join("; "),
+      });
+    }
+
+    const languageGroupKey = result.ecli || `${sourceId}:${result.caseNumber}`;
+
+    // Corpus objects and every publisher alias now share the UUID reserved by
+    // identity resolution before any external write.
+
+    const corpusPayload: CorpusWritePayload =
+      pendingMirrorPayload === null
+        ? {
+            documentId: decisionId,
+            jurisdiction: result.country,
+            ...caseLawCanonicalPayload(result),
+          }
+        : {
+            documentId: decisionId,
+            jurisdiction: result.country,
+            ...pendingMirrorPayload,
+          };
+    const mirrorCarriesDocument = Boolean(
+      corpusPayload.text || hasUsableAst(corpusPayload.ast),
+    );
+
+    const corpusPlan: CorpusWritePlan =
+      preserveStoredDocument && pendingMirrorPayload === null
+        ? { type: "preserve-stored" }
+        : planCorpusWrite(corpusStorageMode);
+
+    const postgresPayload = {
+      fulltext: corpusPayload.text,
+      sections: corpusPayload.sections,
+      documentAst: corpusPayload.ast,
+    };
+
+    const payloadColumns = (() => {
+      switch (corpusPlan.type) {
+        case "postgres-only":
+          // This refresh supersedes whatever the corpus holds and nothing
+          // will follow to rewrite the pointers, so a row carrying keys from
+          // an earlier canonical/dual-write period would point at objects
+          // that no longer match its columns. Clear them.
+          return {
+            ...postgresPayload,
+            ...corpusMirrorColumns({
+              status: CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED,
+              written: null,
+            }),
+          };
+        case "postgres-mirrored":
+        case "object-storage":
+          // Persist retry intent with the Postgres payload. Clearing every old
+          // pointer makes the pending branch structurally unable to serve a
+          // stale mirror while an unchanged replay repairs it.
+          return {
+            ...postgresPayload,
+            ...corpusMirrorColumns({
+              status: CASE_LAW_CORPUS_MIRROR_STATUS.PENDING,
+            }),
+          };
+        case "preserve-stored":
+          // Every payload column, and every pointer into object storage,
+          // stays exactly as stored. Leaving them out of the update is
+          // what preserves them.
+          return {};
+        default: {
+          const unhandled: never = corpusPlan;
+          return panic(`Unhandled corpus write plan: ${String(unhandled)}`);
+        }
+      }
+    })();
+
+    const incomingCitationKey = citationKeyOf(result.caseNumber);
+    return {
+      citations,
+      corpusPayload,
+      corpusPlan,
+      identifierRows,
+      incomingCarriesDocument,
+      incomingCitationKey,
+      languageGroupKey,
+      mirrorCarriesDocument,
+      payloadColumns,
+      pendingMirrorPayload,
+      proceduralKeys,
+      sections,
+    };
+  };
+  const {
+    citations,
+    corpusPayload,
+    corpusPlan,
+    identifierRows,
+    incomingCarriesDocument,
+    incomingCitationKey,
+    languageGroupKey,
+    mirrorCarriesDocument,
+    payloadColumns,
+    pendingMirrorPayload,
+    proceduralKeys,
+    sections,
+  } = await preparePersistenceInputs();
 
   /**
    * Tell the citation graph which normalized identifiers this decision holds.
@@ -2148,10 +2222,8 @@ export const runIngestionPipeline = async ({
       catch: (cause) => cause,
     });
 
-  // oxlint-disable-next-line no-unreachable-loop -- successful pages advance the cursor and pagesProcessed at the loop tail; break paths halt ingestion
-  while (pagesProcessed < maxPages) {
+  const fetchNextObservedPage = async () => {
     if (signal?.aborted) {
-      haltReason = "Cycle timeout exceeded";
       logger.warn("case_law.ingestion.cycle_timeout", {
         adapterKey: adapter.key,
         cursor: cursor ?? "",
@@ -2159,21 +2231,20 @@ export const runIngestionPipeline = async ({
         inserted,
         skipped,
       });
-      break;
+      return { type: "halt", reason: "Cycle timeout exceeded" } as const;
     }
-
     const pageTimeout = adapter.pageTimeoutMs ?? ADAPTER_TIMEOUT.PAGE;
     const pageSignal = signal
       ? AbortSignal.any([signal, AbortSignal.timeout(pageTimeout)])
       : AbortSignal.timeout(pageTimeout);
     recentCursors.add(cursor);
-    // oxlint-disable-next-line no-await-in-loop -- sequential paginated crawl (each page's cursor depends on the previous page)
     const observedPageResult = await fetchObservedPage(cursor, pageSignal);
-
     if (Result.isError(observedPageResult)) {
       if (observedPageResult.error instanceof TimeoutError) {
-        haltReason = databaseTimeoutHaltReason(observedPageResult.error);
-        break;
+        return {
+          type: "halt",
+          reason: databaseTimeoutHaltReason(observedPageResult.error),
+        } as const;
       }
       if (observedPageResult.error instanceof Error) {
         throw observedPageResult.error;
@@ -2182,22 +2253,29 @@ export const runIngestionPipeline = async ({
         message: "Case-law source observation failed",
       });
     }
-
-    const observedPage = observedPageResult.value;
-    if (observedPage.type === "fetch-error") {
-      // Expected operational failure (a source outage fails every attempt),
-      // so no per-attempt exception capture: this halt is recorded in the
-      // ingestion-events row and the structured log, and the runner captures
-      // one exception per sustained stall episode instead.
-      haltReason = `Page fetch failed: ${observedPage.error.message}`;
+    if (observedPageResult.value.type === "fetch-error") {
+      // Expected operational failure: record one halt in the event/log path;
+      // the runner, rather than every attempt, captures sustained stalls.
+      const reason = `Page fetch failed: ${observedPageResult.value.error.message}`;
       logger.error("case_law.ingestion.adapter_halted", {
         adapterKey: adapter.key,
         cursor: cursor ?? "",
-        httpStatus: String(observedPage.error.httpStatus ?? ""),
-        reason: haltReason,
+        httpStatus: String(observedPageResult.value.error.httpStatus ?? ""),
+        reason,
         inserted,
         skipped,
       });
+      return { type: "halt", reason } as const;
+    }
+    return observedPageResult.value;
+  };
+
+  // oxlint-disable-next-line no-unreachable-loop -- successful pages advance the cursor and pagesProcessed at the loop tail; break paths halt ingestion
+  while (pagesProcessed < maxPages) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential paginated crawl (each page's cursor depends on the previous page)
+    const observedPage = await fetchNextObservedPage();
+    if (observedPage.type === "halt") {
+      haltReason = observedPage.reason;
       break;
     }
 

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -1,4 +1,5 @@
 import { panic, Result } from "better-result";
+import type { InferOk } from "better-result";
 import { deepEquals } from "bun";
 import { and, eq } from "drizzle-orm";
 
@@ -161,6 +162,7 @@ import {
   createSafeRootHandler,
 } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { AccessibleWorkspace } from "@/api/lib/auth";
 import type { SafeId } from "@/api/lib/branded-types";
 import { resolveEffectiveChatModelSelection } from "@/api/lib/chat-model-selection";
@@ -201,6 +203,7 @@ import {
   requireTanStackAIAvailableForRole,
   validateTanStackDevModelOverride,
 } from "@/api/lib/tanstack-ai-models";
+import type { UsageLaneDecision } from "@/api/lib/usage/lane-routing";
 import { loadWebSearchProvidersForOrg } from "@/api/lib/web-search/load-org-keys";
 import { getAppBaseUrl } from "@/api/mcp/tool-utils";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
@@ -364,11 +367,932 @@ const stampValidatedMessageWithActiveDraftContext = ({
 type ClaimedChatTurnOwnership =
   | { status: "unclaimed" }
   | {
-      status: "preflight";
+      status: "preflight" | "streaming";
       execution: ChatTurnExecution;
       owningAssistantMessage?: PersistableChatMessage | undefined;
+    };
+
+type ChatSendLifecycleOptions = {
+  externalMcpToolsLoader: LazyExternalMcpToolsLoader;
+  recordAuditEvent: AuditRecorder;
+  safeDb: SafeDb;
+  threadId: SafeId<"chatThread">;
+  userId: SafeId<"user">;
+  workspaceId: SafeId<"workspace"> | null;
+};
+
+/** Owns every resource that must be settled when a send stops before streaming. */
+class ChatSendLifecycle {
+  private readonly options: ChatSendLifecycleOptions;
+  private claimedTurn: ClaimedChatTurnOwnership = { status: "unclaimed" };
+  private connectorsHandedOff = false;
+  private pendingSideEffects:
+    | {
+        threadState: ChatThreadState;
+        uploadedFiles: UploadedChatFile[];
+      }
+    | undefined;
+
+  constructor(options: ChatSendLifecycleOptions) {
+    this.options = options;
+  }
+
+  adoptThread(threadState: ChatThreadState): void {
+    this.pendingSideEffects = { threadState, uploadedFiles: [] };
+  }
+
+  trackUploadedFiles(uploadedFiles: UploadedChatFile[]): void {
+    if (this.pendingSideEffects === undefined) {
+      panic("Cannot track chat uploads without rollback ownership");
     }
-  | { status: "streaming" };
+    this.pendingSideEffects.uploadedFiles = uploadedFiles;
+  }
+
+  releaseSideEffects(): void {
+    this.pendingSideEffects = undefined;
+  }
+
+  claimTurn(
+    execution: ChatTurnExecution,
+    owningAssistantMessage: PersistableChatMessage | undefined,
+  ): void {
+    this.claimedTurn = {
+      status: "preflight",
+      execution,
+      ...(owningAssistantMessage === undefined
+        ? {}
+        : { owningAssistantMessage }),
+    };
+  }
+
+  handOffConnectors(loaded: boolean): void {
+    this.connectorsHandedOff = loaded;
+  }
+
+  markStreaming(): void {
+    if (this.claimedTurn.status === "unclaimed") {
+      panic("Cannot stream a chat turn without durable ownership");
+    }
+    this.claimedTurn = {
+      status: "streaming",
+      execution: this.claimedTurn.execution,
+      owningAssistantMessage: this.claimedTurn.owningAssistantMessage,
+    };
+  }
+
+  async failCurrentTurn(
+    code: ChatTurnFailureCode,
+    retryable: boolean,
+  ): Promise<void> {
+    if (this.claimedTurn.status === "unclaimed") {
+      panic("Cannot fail a chat turn without durable ownership");
+    }
+    const failureResult = await persistFailedChatTurn({
+      code,
+      execution: this.claimedTurn.execution,
+      recordAuditEvent: this.options.recordAuditEvent,
+      retryable,
+      owningAssistantMessage: this.claimedTurn.owningAssistantMessage,
+      safeDb: this.options.safeDb,
+      threadId: this.options.threadId,
+      userId: this.options.userId,
+      workspaceId: this.options.workspaceId,
+    });
+    if (Result.isError(failureResult)) {
+      captureError(failureResult.error, { threadId: this.options.threadId });
+      return;
+    }
+    this.claimedTurn = { status: "unclaimed" };
+  }
+
+  async interruptCurrentTurn() {
+    if (this.claimedTurn.status === "unclaimed") {
+      return panic("Cannot interrupt a chat turn without durable ownership");
+    }
+    const settlementResult = await persistInterruptedChatTurn({
+      execution: this.claimedTurn.execution,
+      owningAssistantMessage: this.claimedTurn.owningAssistantMessage,
+      recordAuditEvent: this.options.recordAuditEvent,
+      safeDb: this.options.safeDb,
+      threadId: this.options.threadId,
+      userId: this.options.userId,
+      workspaceId: this.options.workspaceId,
+    });
+    if (Result.isOk(settlementResult)) {
+      this.claimedTurn = { status: "unclaimed" };
+    }
+    return settlementResult;
+  }
+
+  async cleanup(): Promise<void> {
+    if (this.claimedTurn.status === "preflight") {
+      const failureResult = await persistFailedChatTurn({
+        code: "internal",
+        execution: this.claimedTurn.execution,
+        owningAssistantMessage: this.claimedTurn.owningAssistantMessage,
+        recordAuditEvent: this.options.recordAuditEvent,
+        retryable: true,
+        safeDb: this.options.safeDb,
+        threadId: this.options.threadId,
+        userId: this.options.userId,
+        workspaceId: this.options.workspaceId,
+      });
+      if (Result.isError(failureResult)) {
+        captureError(failureResult.error, {
+          source: "send-message-claimed-turn-preflight-cleanup",
+          threadId: this.options.threadId,
+        });
+      }
+    }
+    if (this.pendingSideEffects !== undefined) {
+      const rollbackResult = await rollbackUnpersistedChatSideEffects({
+        recordAuditEvent: this.options.recordAuditEvent,
+        safeDb: this.options.safeDb,
+        threadId: this.options.threadId,
+        threadState: this.pendingSideEffects.threadState,
+        uploadedFiles: this.pendingSideEffects.uploadedFiles,
+        userId: this.options.userId,
+      });
+      if (Result.isError(rollbackResult)) {
+        captureError(rollbackResult.error, {
+          source: "send-message-unpersisted-side-effect-rollback",
+          threadId: this.options.threadId,
+        });
+      }
+    }
+    if (!this.connectorsHandedOff) {
+      await this.options.externalMcpToolsLoader.closeIfLoaded();
+    }
+  }
+}
+
+type ThreadValidationState = InferOk<
+  Awaited<ReturnType<typeof readThreadValidationState>>
+>;
+
+type AcceptIncomingTurnOptions = {
+  accessibleSet: ReadonlySet<string>;
+  accessibleWorkspaceIds: SafeId<"workspace">[];
+  body: ChatSendRequest;
+  effectiveContextMatterIds: SafeId<"workspace">[];
+  lifecycle: ChatSendLifecycle;
+  organizationId: SafeId<"organization">;
+  recordAuditEvent: AuditRecorder;
+  safeDb: SafeDb;
+  thread: ChatThreadState;
+  uploadedMessage: PersistableChatMessage;
+  userId: SafeId<"user">;
+  validationThreadState: ThreadValidationState;
+  workspaceId: SafeId<"workspace"> | null;
+};
+
+/** Persists the incoming message and establishes the turn's durable owner. */
+const acceptIncomingTurn = async ({
+  accessibleSet,
+  accessibleWorkspaceIds,
+  body,
+  effectiveContextMatterIds,
+  lifecycle,
+  organizationId,
+  recordAuditEvent,
+  safeDb,
+  thread,
+  uploadedMessage,
+  userId,
+  validationThreadState,
+  workspaceId,
+}: AcceptIncomingTurnOptions) =>
+  await Result.gen(async function* () {
+    const parsedMessage = parseMessage({
+      accessibleWorkspaceIds,
+      message: uploadedMessage,
+    });
+    const isExplicitRegeneration =
+      body.turnIntent === CHAT_TURN_INTENT.regenerate;
+    if (
+      isExplicitRegeneration &&
+      (parsedMessage.message.role !== "user" ||
+        body.truncateAfterMessageId !== undefined)
+    ) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Regeneration requires one unambiguous user-message target",
+        }),
+      );
+    }
+    const replayTargetMessageId =
+      body.truncateAfterMessageId ??
+      (isExplicitRegeneration ? parsedMessage.message.id : undefined);
+
+    let messagesForPersistence: ChatThreadState["data"]["messages"] =
+      thread.data.messages;
+    let deleteMessageIdsBeforeLatest: SafeId<"chatMessage">[] = [];
+    let incomingMessageExists = false;
+    if (replayTargetMessageId !== undefined) {
+      if (parsedMessage.message.id !== replayTargetMessageId) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Truncation target must match the incoming message",
+          }),
+        );
+      }
+      const truncationTarget = yield* Result.await(
+        resolveTruncationTarget({
+          safeDb,
+          threadId: body.threadId,
+          targetMessageId: replayTargetMessageId,
+        }),
+      );
+      if (truncationTarget === null) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Truncation target was not found in the chat thread",
+          }),
+        );
+      }
+      messagesForPersistence = truncationTarget.messagesForPersistence;
+      deleteMessageIdsBeforeLatest =
+        truncationTarget.deleteMessageIdsBeforeLatest;
+      if (isExplicitRegeneration && truncationTarget.hasLaterUserMessage) {
+        return Result.err(
+          new HandlerError({
+            status: 409,
+            message: "Only the latest user turn can be regenerated",
+          }),
+        );
+      }
+    } else {
+      incomingMessageExists = yield* Result.await(
+        chatMessageExistsForThread({
+          messageId: brandPersistedChatMessageId(parsedMessage.message.id),
+          safeDb,
+          threadId: body.threadId,
+        }),
+      );
+    }
+
+    const baseLatestMessagePlan = planMessagePersistence({
+      message: parsedMessage.message,
+      storedMessages: messagesForPersistence,
+      incomingMessageExists,
+    });
+    if (
+      isExplicitRegeneration &&
+      baseLatestMessagePlan.persistencePlan.type !== "none"
+    ) {
+      return Result.err(
+        new HandlerError({
+          status: 409,
+          message: "Regeneration target is not a persisted user message",
+        }),
+      );
+    }
+    const latestMessagePlan = isExplicitRegeneration
+      ? {
+          existingIds: baseLatestMessagePlan.existingIds,
+          messages: baseLatestMessagePlan.messages,
+          persistencePlan: {
+            message: parsedMessage.message,
+            messageId: parsedMessage.message.id,
+            type: "update",
+          } satisfies MessagePersistencePlan,
+        }
+      : baseLatestMessagePlan;
+    if (
+      replayTargetMessageId !== undefined &&
+      latestMessagePlan.persistencePlan.type !== "update"
+    ) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Truncation requires updating an existing message",
+        }),
+      );
+    }
+
+    const recomputedDataWorkspaceIds =
+      replayTargetMessageId === undefined
+        ? null
+        : recomputeThreadDataScope({
+            accessibleSet,
+            baseWorkspaceId: workspaceId,
+            messages: latestMessagePlan.messages,
+          });
+    const incomingMessageWorkspaceIds = extractIncomingMessageWorkspaceIds({
+      mentions: parsedMessage.mentions,
+      message: parsedMessage.message,
+    }).filter((id) => accessibleSet.has(id));
+    const dataScopeAfterIncomingMessage =
+      recomputedDataWorkspaceIds ??
+      Array.from(
+        new Set([
+          ...thread.data.dataWorkspaceIds,
+          ...incomingMessageWorkspaceIds,
+        ]),
+      );
+    const toolWorkspaceIds = resolveToolWorkspaceIds({
+      pinnedIds: effectiveContextMatterIds,
+      accessibleWorkspaceIds,
+    });
+    const sandboxRunResult =
+      body.runMode === CHAT_RUN_MODE.agent
+        ? await Result.tryPromise({
+            try: async () =>
+              await resolveChatSandboxPlan({
+                organizationId,
+                runId: Bun.randomUUIDv7(),
+                userId,
+                workspaceIds: toolWorkspaceIds,
+              }),
+            catch: (cause) =>
+              cause instanceof HandlerError
+                ? cause
+                : new HandlerError({
+                    cause,
+                    message: "Failed to prepare agent sandbox run",
+                    status: 500,
+                  }),
+          })
+        : Result.ok(undefined);
+    if (Result.isError(sandboxRunResult)) {
+      return yield* Result.err(sandboxRunResult.error);
+    }
+    const sandboxRun = sandboxRunResult.value;
+    const turnAcceptance =
+      parsedMessage.message.role === "user" &&
+      latestMessagePlan.persistencePlan.type !== "none"
+        ? createChatTurnAcceptance({
+            organizationId,
+            threadId: body.threadId,
+            userId,
+            userMessageId: parsedMessage.message.id,
+            workspaceId,
+          })
+        : undefined;
+    const persistenceProps = {
+      acceptedSendMode: body.sendMode,
+      recordAuditEvent,
+      safeDb,
+      threadId: body.threadId,
+      turnAcceptance,
+      userId,
+      workspaceId,
+      persistencePlan: latestMessagePlan.persistencePlan,
+      dataScopeExpansion:
+        recomputedDataWorkspaceIds === null
+          ? { newWorkspaceIds: incomingMessageWorkspaceIds }
+          : undefined,
+      deleteMessageIds: deleteMessageIdsBeforeLatest,
+      dataScopeReplacement:
+        recomputedDataWorkspaceIds === null
+          ? undefined
+          : {
+              observedDataWorkspaceIds: thread.data.dataWorkspaceIds,
+              newDataWorkspaceIds: recomputedDataWorkspaceIds,
+            },
+    } as const;
+
+    let turnExecution: ChatTurnExecution | null;
+    if (parsedMessage.message.role === "assistant") {
+      if (latestMessagePlan.persistencePlan.type !== "update") {
+        return Result.err(
+          new HandlerError({
+            status: 409,
+            message: "Interactive replay must update its owning message",
+          }),
+        );
+      }
+      const replayResult = await persistClaimedReplayMessage({
+        ...persistenceProps,
+        claim: {
+          acceptedTurnId: null,
+          continuationInteraction:
+            getResumedUserInteraction({
+              awaited: getAwaitingUserInteractions(
+                validationThreadState.persistedMessage === null
+                  ? null
+                  : chatMessageFromPersisted({
+                      content: validationThreadState.persistedMessage.content,
+                      id: parsedMessage.message.id,
+                      role: validationThreadState.persistedMessage.role,
+                    }),
+              ),
+              message: parsedMessage.message,
+            }) ?? undefined,
+          incomingMessageId: parsedMessage.message.id,
+          incomingMessageRole: parsedMessage.message.role,
+          organizationId,
+          threadId: body.threadId,
+          userId,
+          workspaceId,
+        },
+        persistencePlan: latestMessagePlan.persistencePlan,
+      });
+      if (Result.isError(replayResult)) {
+        return Result.err(replayResult.error);
+      }
+      turnExecution = replayResult.value;
+      if (turnExecution !== null) {
+        lifecycle.releaseSideEffects();
+      }
+    } else if (turnAcceptance === undefined) {
+      const persistenceResult = await persistMessage(persistenceProps);
+      if (Result.isError(persistenceResult)) {
+        return Result.err(persistenceResult.error);
+      }
+      turnExecution = yield* Result.await(
+        claimChatTurnForExecution({
+          acceptedTurnId: null,
+          incomingMessageId: parsedMessage.message.id,
+          incomingMessageRole: parsedMessage.message.role,
+          organizationId,
+          safeDb,
+          threadId: body.threadId,
+          userId,
+          workspaceId,
+        }),
+      );
+    } else {
+      const persistenceResult = await persistAcceptedMessageWithClaim({
+        ...persistenceProps,
+        turnAcceptance,
+      });
+      if (Result.isError(persistenceResult)) {
+        return Result.err(persistenceResult.error);
+      }
+      turnExecution = persistenceResult.value;
+    }
+    if (
+      parsedMessage.message.role !== "assistant" &&
+      latestMessagePlan.persistencePlan.type !== "none"
+    ) {
+      lifecycle.releaseSideEffects();
+    }
+    if (turnExecution === null) {
+      return Result.err(
+        new HandlerError({
+          status: 409,
+          message: "Chat turn has no durable execution owner",
+        }),
+      );
+    }
+    const owningAssistantMessage =
+      parsedMessage.message.role === "assistant"
+        ? parsedMessage.message
+        : undefined;
+    lifecycle.claimTurn(turnExecution, owningAssistantMessage);
+    return Result.ok({
+      dataScopeAfterIncomingMessage,
+      deleteMessageIdsBeforeLatest,
+      latestMessagePlan,
+      owningAssistantMessage,
+      parsedMessage,
+      replayTargetMessageId,
+      sandboxRun,
+      toolWorkspaceIds,
+      turnExecution,
+    });
+  });
+
+type ChatToolsInput = Parameters<typeof getChatTools>[0];
+
+type PrepareValidatedIncomingMessageOptions = {
+  authorization: {
+    accessibleWorkspaceIds: SafeId<"workspace">[];
+    memberRole: { role: ChatToolsInput["memberRole"] };
+    pinServerValidatedWorkspaceId: ChatToolsInput["pinServerValidatedWorkspaceId"];
+    requestedContextMatterIds: SafeId<"workspace">[];
+    workspaceStatusById: NonNullable<ChatToolsInput["workspaceStatusById"]>;
+  };
+  lifecycle: ChatSendLifecycle;
+  persistence: {
+    recordAuditEvent: AuditRecorder;
+    safeDb: SafeDb;
+    scopedDb: ChatToolsInput["scopedDb"];
+  };
+  prerequisites: {
+    activeDraftContext: InferOk<
+      Awaited<ReturnType<typeof validateActiveDraftContext>>
+    >;
+    activeFileForTools: ChatToolsInput["activeFile"];
+    validationThreadState: ThreadValidationState;
+  };
+  request: {
+    body: ChatSendRequest;
+    isClientConnectionAborted: () => boolean;
+    organizationId: SafeId<"organization">;
+    resume: Parameters<typeof validateMessage>[0]["resume"];
+    userId: SafeId<"user">;
+    workspaceId: SafeId<"workspace"> | null;
+  };
+  tools: {
+    disabledNativeToolSlugs: ChatToolsInput["disabledNativeToolSlugs"];
+    docxEditRepresentation: NonNullable<
+      ChatToolsInput["docxEditRepresentation"]
+    >;
+    editApplyMode: NonNullable<ChatToolsInput["editApplyMode"]>;
+    externalMcpToolsLoader: LazyExternalMcpToolsLoader;
+    orgAIConfig: OrgAIConfig | null;
+    refRegistry: ReturnType<typeof createChatRefRegistry>;
+    toolDefectMemo: ReturnType<typeof createChatToolDefectMemo>;
+    usageLane: UsageLaneDecision | undefined;
+    validationActiveSkillContext: ActiveChatSkillContext | null;
+  };
+};
+
+/** Validates the provider-facing message and adopts thread/file rollback ownership. */
+const prepareValidatedIncomingMessage = async ({
+  authorization: {
+    accessibleWorkspaceIds,
+    memberRole,
+    pinServerValidatedWorkspaceId,
+    requestedContextMatterIds,
+    workspaceStatusById,
+  },
+  lifecycle,
+  persistence: { recordAuditEvent, safeDb, scopedDb },
+  prerequisites: {
+    activeDraftContext,
+    activeFileForTools,
+    validationThreadState,
+  },
+  request: {
+    body,
+    isClientConnectionAborted,
+    organizationId,
+    resume,
+    userId,
+    workspaceId,
+  },
+  tools: {
+    disabledNativeToolSlugs,
+    docxEditRepresentation,
+    editApplyMode,
+    externalMcpToolsLoader,
+    orgAIConfig,
+    refRegistry,
+    toolDefectMemo,
+    usageLane,
+    validationActiveSkillContext,
+  },
+}: PrepareValidatedIncomingMessageOptions) =>
+  await Result.gen(async function* () {
+    if (isClientConnectionAborted()) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Client disconnected before AI work started",
+        }),
+      );
+    }
+
+    // Resolve the org's web-search providers once (BYOK key first,
+    // platform env key as fallback) and reuse for both the validation
+    // and streaming tool sets.
+    const webSearchProviders =
+      await loadWebSearchProvidersForOrg(organizationId);
+
+    if (isClientConnectionAborted()) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Client disconnected before AI work started",
+        }),
+      );
+    }
+
+    // Agent runs cannot use per-user external connectors. Keep them out of
+    // validation too, so an invalid external-tool part is rejected by the
+    // tool schema without starting connector discovery. Normal streaming
+    // still reuses a validation-triggered load through the memoized loader.
+    const externalToolsForValidation =
+      body.runMode === CHAT_RUN_MODE.agent
+        ? undefined
+        : await resolveExternalToolsForValidation(
+            body.message,
+            externalMcpToolsLoader,
+          );
+
+    if (isClientConnectionAborted()) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Client disconnected before AI work started",
+        }),
+      );
+    }
+
+    // Tool input schemas don't depend on `accessibleWorkspaceIds`
+    // (scope is checked at execute time, not in the schema), so we
+    // can validate the incoming message against the broad set and
+    // then rebuild the tools with the narrowed `effective` set
+    // before streaming. This lets the picker's scope actually
+    // govern tool authorization rather than just being persisted.
+    // Validation tools include the broadest workspace surface, but
+    // still honor thread/org gates for tools whose presence is an
+    // explicit user or administrator opt-in.
+    const validationTools = getChatTools({
+      organizationId,
+      memberRole: memberRole.role,
+      orgAIConfig,
+      pinServerValidatedWorkspaceId,
+      requestWorkspaceId: workspaceId,
+      refRegistry,
+      toolDefectMemo,
+      safeDb,
+      scopedDb,
+      threadId: body.threadId,
+      workspaceId,
+      userId,
+      // Schema validation only; this tool set's `spawn_subagents` never
+      // executes, so a raw (non-anonymizing) boundary is correct here —
+      // the real per-request boundary is created below and threaded
+      // into the streaming tool set instead.
+      thirdPartyBoundary: { type: "raw" },
+      // Schema validation runs against the user's full accessible
+      // set; per-tool scope checks happen at execute time below.
+      toolWorkspaceIds: resolveToolWorkspaceIds({
+        pinnedIds: [],
+        accessibleWorkspaceIds,
+      }),
+      activeFile: activeFileForTools,
+      hasActiveDocxEditClient: true,
+      hasActiveDocxFileClient: true,
+      editApplyMode,
+      docxEditRepresentation,
+      includeAllDocxEditToolsForValidation: true,
+      includeRememberToolForValidation: true,
+      webSearchEnabled: validationThreadState.webSearchEnabled,
+      webSearchProviders,
+      externalTools: externalToolsForValidation,
+      disabledNativeToolSlugs,
+      activeSkillContext: validationActiveSkillContext,
+      recordAuditEvent,
+      resolveMemorySourceWorkspaceIds: () =>
+        resolveMemorySourceWorkspaceIds({
+          accessibleWorkspaceIds: new Set(accessibleWorkspaceIds),
+          contextMatterIds: [],
+          dataWorkspaceIds: [],
+          registeredWorkspaceIds: refRegistry.getRegisteredWorkspaceIds(),
+          workspaceId,
+        }),
+      workspaceStatusById,
+    });
+
+    const validatedMessageResult = await validateMessage({
+      message: body.message,
+      persistedMessage: validationThreadState.persistedMessage,
+      resume,
+      safeDb,
+      threadId: body.threadId,
+      tools: validationTools,
+      userId,
+    });
+    if (Result.isError(validatedMessageResult)) {
+      // The wrapping try/finally closes `externalMcpToolsLoader` on this
+      // exit path too (a no-op if this message never needed the external
+      // tools) — no explicit close needed here.
+      return Result.err(validatedMessageResult.error);
+    }
+    const validatedMessage = validatedMessageResult.value;
+
+    // Captured once and threaded through to generateThreadTitle below: the
+    // generator's guard compares the thread's live title against this
+    // value to detect any rename (even one whose titleSource column went
+    // stale) rather than trusting titleSource alone.
+    const initialThreadTitle = extractTitle(validatedMessage.message.parts);
+
+    const thread = yield* Result.await(
+      loadThread({
+        initialDataWorkspaceIds:
+          activeDraftContext === null
+            ? []
+            : activeDraftContext.originDataWorkspaceIds,
+        initialContextMatterIds: requestedContextMatterIds,
+        organizationId,
+        recordAuditEvent,
+        safeDb,
+        threadId: body.threadId,
+        title: initialThreadTitle,
+        userId,
+        workspaceId,
+      }),
+    );
+    // Own the thread from creation through the first durable message. The
+    // enclosing finally is the sole rollback boundary for every later
+    // return, error, or SDK short-circuit before that persistence succeeds.
+    lifecycle.adoptThread(thread);
+
+    const activeDraft = body.activeDraft;
+    if (activeDraft !== undefined) {
+      const hasPersistedContext =
+        thread.type === "created"
+          ? false
+          : yield* Result.await(
+              safeDb(async (tx) =>
+                hasPersistedGeneratedDocumentActiveDraftContext({
+                  generatedDraft: {
+                    originChatMessageId: activeDraft.originChatMessageId,
+                    originChatThreadId: activeDraft.originChatThreadId,
+                    toolCallId: activeDraft.toolCallId,
+                  },
+                  organizationId,
+                  threadId: thread.data.id,
+                  tx,
+                  userId,
+                }),
+              ),
+            );
+      if (
+        !canUseChatThreadForGeneratedDocumentDraft({
+          hasPersistedContext,
+          threadType: thread.type,
+        })
+      ) {
+        return Result.err(
+          new HandlerError({
+            status: 409,
+            message:
+              "Active generated document draft is not bound to this chat",
+          }),
+        );
+      }
+    }
+
+    const stampedValidatedMessage = {
+      ...validatedMessage,
+      message: stampValidatedMessageWithActiveDraftContext({
+        activeDraft: body.activeDraft,
+        message: validatedMessage.message,
+      }),
+    };
+
+    // Existing-thread pin changes are durable side effects, so stop before
+    // applying them when any earlier validation or thread read observed a
+    // client disconnect. Created threads still need their rollback token
+    // cleaned up on this exit path.
+    if (isClientConnectionAborted()) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Client disconnected before AI work started",
+        }),
+      );
+    }
+
+    // The thread's persisted chat-model override wins over the org/instance
+    // default, but the dev-only body override still wins over everything
+    // (matches `assertDevModelOverride` above). Re-validated here (not just
+    // at write time in update-thread-model.ts) so a provider key removal or
+    // a catalog bump that drops the model falls back to the org default
+    // silently instead of failing the send.
+    const {
+      modelId: selectedChatModel,
+      reasoningEffort: selectedReasoningEffort,
+    } = resolveEffectiveChatModelSelection({
+      devModelId: body.devModelId,
+      threadChatModel: thread.data.chatModel,
+      threadReasoningEffort: thread.data.chatReasoningEffort,
+      orgAIConfig,
+    });
+
+    // Budget routing. Inside the included budget any selection
+    // stands. When the pre-flight resolved the reduced-cost lane, an
+    // unselected turn is served on the lane's own model. Two cases
+    // instead fall through to the pool, which must be able to cover
+    // them — the same 402 a pool-only org would see: an explicit
+    // model selection, and an agent-mode send (machine work never
+    // settles an interactive budget).
+    let chatModelOverride = selectedChatModel;
+    let chatReasoningEffort = selectedReasoningEffort;
+    let turnLane = usageLane ?? { lane: "pool" as const };
+    const explicitSelectionNeedsPool =
+      turnLane.lane === "fallback" &&
+      selectedChatModel !== undefined &&
+      selectedChatModel !== turnLane.forcedModelSelection;
+    const agentModeNeedsPool =
+      body.runMode === "agent" && turnLane.lane !== "pool";
+    if (explicitSelectionNeedsPool || agentModeNeedsPool) {
+      const poolCheck = yield* Result.await(
+        Result.tryPromise({
+          try: async () =>
+            await assertUsageAvailableForHandler({
+              metering: { actionType: "chat" },
+              organizationId,
+              orgAIConfig,
+              workspaceId: null,
+              userId,
+              safeDb,
+            }),
+          catch: (cause) =>
+            new HandlerError({
+              status: 500,
+              message: "Usage check failed",
+              cause,
+            }),
+        }),
+      );
+      if (poolCheck !== null) {
+        return Result.err(poolCheck);
+      }
+      turnLane = { lane: "pool" };
+    } else if (turnLane.lane === "fallback") {
+      chatModelOverride = turnLane.forcedModelSelection;
+      chatReasoningEffort = undefined;
+    }
+
+    // For an existing thread, accept a non-empty body update as
+    // "user changed scope, persist it"; an omitted/empty body keeps
+    // the stored value so re-sends from cached transports don't
+    // silently widen access. Persisted pins are always intersected
+    // with the currently accessible set so a revoked workspace
+    // cannot be re-authorized through a stale stored pin.
+    const storedPinsThisRequest =
+      thread.type === "existing" && body.contextMatterIds !== undefined
+        ? requestedContextMatterIds
+        : thread.data.contextMatterIds;
+    const effectiveContextMatterIds = intersectAccessibleWorkspaceIds({
+      pinnedIds: storedPinsThisRequest,
+      accessibleWorkspaceIds,
+    });
+    if (
+      thread.type === "existing" &&
+      !workspaceIdsEqual(
+        thread.data.contextMatterIds,
+        effectiveContextMatterIds,
+      )
+    ) {
+      yield* Result.await(
+        safeDb(async (tx) => {
+          await tx
+            .update(chatThreads)
+            .set({ contextMatterIds: effectiveContextMatterIds })
+            .where(eq(chatThreads.id, body.threadId));
+
+          await recordAuditEvent(tx, {
+            action: AUDIT_ACTION.UPDATE,
+            resourceType: AUDIT_RESOURCE_TYPE.CHAT_THREAD,
+            resourceId: body.threadId,
+            workspaceId,
+            changes: {
+              contextMatterIds: {
+                old: [...thread.data.contextMatterIds],
+                new: [...effectiveContextMatterIds],
+              },
+            },
+          });
+        }),
+      );
+    }
+
+    const thirdPartyBoundary = createChatThirdPartyBoundary({
+      anonymizationScopeId: workspaceId ?? body.threadId,
+      organizationId,
+      scopedDb,
+      sendMode: body.sendMode,
+      workspaceId: workspaceId ?? undefined,
+    });
+
+    if (isClientConnectionAborted()) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Client disconnected before AI work started",
+        }),
+      );
+    }
+
+    const uploadResult = await uploadMessageFilesWithRollback({
+      message: stampedValidatedMessage.message,
+      recordAuditEvent,
+      safeDb,
+      threadId: thread.data.id,
+      threadState: thread,
+      userId,
+    });
+    if (Result.isError(uploadResult)) {
+      // The upload helper already cleans a partial upload (and a newly
+      // created thread) before returning an error.
+      lifecycle.releaseSideEffects();
+      return Result.err(uploadResult.error);
+    }
+    lifecycle.trackUploadedFiles(uploadResult.value.uploadedFiles);
+
+    return Result.ok({
+      chatModelOverride,
+      chatReasoningEffort,
+      effectiveContextMatterIds,
+      initialThreadTitle,
+      thirdPartyBoundary,
+      thread,
+      turnLane,
+      uploadedMessage: uploadResult.value.message,
+      webSearchProviders,
+    });
+  });
 
 const sendMessage = createSafeRootHandler(
   config,
@@ -412,7 +1336,7 @@ const sendMessage = createSafeRootHandler(
       role: "chat",
     });
 
-    const correlationMismatch =
+    const hasEnvelopeCorrelationMismatch = (): boolean =>
       transportBody.threadId !== body.threadId ||
       transportBody.runId !== body.runId ||
       transportParentRunId !== parentRunId ||
@@ -422,7 +1346,7 @@ const sendMessage = createSafeRootHandler(
         (message) =>
           message.id === body.message.id && message.role === body.message.role,
       );
-    if (correlationMismatch) {
+    if (hasEnvelopeCorrelationMismatch()) {
       return Result.err(
         new HandlerError({
           status: 400,
@@ -597,11 +1521,8 @@ const sendMessage = createSafeRootHandler(
     // callers ask — `createLazyExternalMcpToolsLoader` caches the first
     // call's promise, so a validation-triggered load is reused by the
     // streaming pass instead of running discovery twice.
-    // `externalMcpToolsHandedOffToStreaming` below tracks whether
-    // ownership of closing these connectors (if ever loaded) passed to the
-    // streaming try/catch, so every other exit path (validation failure,
-    // any early return or throw between here and streaming) still closes
-    // them exactly once.
+    // The lifecycle owner tracks whether closing loaded connectors passed to
+    // the streaming response, so every earlier exit still closes them once.
     const externalMcpToolsLoader = createLazyExternalMcpToolsLoader(
       async () =>
         await loadExternalMcpToolsForUser({
@@ -611,734 +1532,113 @@ const sendMessage = createSafeRootHandler(
           userId: user.id,
         }),
     );
-    let externalMcpToolsHandedOffToStreaming = false;
-    let pendingUnpersistedSideEffects:
-      | {
-          threadState: ChatThreadState;
-          uploadedFiles: UploadedChatFile[];
-        }
-      | undefined;
-    let claimedChatTurnOwnership: ClaimedChatTurnOwnership = {
-      status: "unclaimed",
-    };
+    const lifecycle = new ChatSendLifecycle({
+      externalMcpToolsLoader,
+      recordAuditEvent,
+      safeDb,
+      threadId: body.threadId,
+      userId: user.id,
+      workspaceId,
+    });
 
     // The try/finally starts immediately after the loader is constructed
     // (rather than just around the streaming pass) so that a throw from
     // any of the awaited steps below — web-search provider load,
     // tool-set construction, message validation — still closes
     // `externalMcpToolsLoader` (a no-op if nothing was ever loaded)
-    // instead of leaking MCP clients. The streaming pass further below
-    // takes over ownership once it starts consuming the clients (flips
-    // `externalMcpToolsHandedOffToStreaming`); until then this `finally` is
-    // the sole owner. `Result.gen`'s `yield*` short-circuit resumes the
+    // instead of leaking MCP clients. The streaming pass takes over connector
+    // ownership once it starts consuming the clients; until then this
+    // `finally` is the sole owner. `Result.gen`'s `yield*` short-circuit resumes the
     // generator via `.return()`, which unwinds this `finally` like a normal
     // early `return` would.
     try {
-      if (isClientConnectionAborted()) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: "Client disconnected before AI work started",
-          }),
-        );
-      }
-
-      // Resolve the org's web-search providers once (BYOK key first,
-      // platform env key as fallback) and reuse for both the validation
-      // and streaming tool sets.
-      const webSearchProviders = await loadWebSearchProvidersForOrg(
-        session.activeOrganizationId,
-      );
-
-      if (isClientConnectionAborted()) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: "Client disconnected before AI work started",
-          }),
-        );
-      }
-
-      // Agent runs cannot use per-user external connectors. Keep them out of
-      // validation too, so an invalid external-tool part is rejected by the
-      // tool schema without starting connector discovery. Normal streaming
-      // still reuses a validation-triggered load through the memoized loader.
-      const externalToolsForValidation =
-        body.runMode === CHAT_RUN_MODE.agent
-          ? undefined
-          : await resolveExternalToolsForValidation(
-              body.message,
-              externalMcpToolsLoader,
-            );
-
-      if (isClientConnectionAborted()) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: "Client disconnected before AI work started",
-          }),
-        );
-      }
-
-      // Tool input schemas don't depend on `accessibleWorkspaceIds`
-      // (scope is checked at execute time, not in the schema), so we
-      // can validate the incoming message against the broad set and
-      // then rebuild the tools with the narrowed `effective` set
-      // before streaming. This lets the picker's scope actually
-      // govern tool authorization rather than just being persisted.
-      // Validation tools include the broadest workspace surface, but
-      // still honor thread/org gates for tools whose presence is an
-      // explicit user or administrator opt-in.
-      const validationTools = getChatTools({
-        organizationId: session.activeOrganizationId,
-        memberRole: memberRole.role,
-        orgAIConfig,
-        pinServerValidatedWorkspaceId,
-        requestWorkspaceId: workspaceId,
-        refRegistry,
-        toolDefectMemo,
-        safeDb,
-        scopedDb,
-        threadId: body.threadId,
-        workspaceId,
-        userId: user.id,
-        // Schema validation only; this tool set's `spawn_subagents` never
-        // executes, so a raw (non-anonymizing) boundary is correct here —
-        // the real per-request boundary is created below and threaded
-        // into the streaming tool set instead.
-        thirdPartyBoundary: { type: "raw" },
-        // Schema validation runs against the user's full accessible
-        // set; per-tool scope checks happen at execute time below.
-        toolWorkspaceIds: resolveToolWorkspaceIds({
-          pinnedIds: [],
-          accessibleWorkspaceIds,
-        }),
-        activeFile: activeFileForTools,
-        hasActiveDocxEditClient: true,
-        hasActiveDocxFileClient: true,
-        editApplyMode,
-        docxEditRepresentation,
-        includeAllDocxEditToolsForValidation: true,
-        includeRememberToolForValidation: true,
-        webSearchEnabled: validationThreadState.webSearchEnabled,
-        webSearchProviders,
-        externalTools: externalToolsForValidation,
-        disabledNativeToolSlugs,
-        activeSkillContext: validationActiveSkillContext,
-        recordAuditEvent,
-        resolveMemorySourceWorkspaceIds: () =>
-          resolveMemorySourceWorkspaceIds({
-            accessibleWorkspaceIds: new Set(accessibleWorkspaceIds),
-            contextMatterIds: [],
-            dataWorkspaceIds: [],
-            registeredWorkspaceIds: refRegistry.getRegisteredWorkspaceIds(),
-            workspaceId,
-          }),
-        workspaceStatusById,
-      });
-
-      const validatedMessageResult = await validateMessage({
-        message: body.message,
-        persistedMessage: validationThreadState.persistedMessage,
-        resume,
-        safeDb,
-        threadId: body.threadId,
-        tools: validationTools,
-        userId: user.id,
-      });
-      if (Result.isError(validatedMessageResult)) {
-        // The wrapping try/finally closes `externalMcpToolsLoader` on this
-        // exit path too (a no-op if this message never needed the external
-        // tools) — no explicit close needed here.
-        return Result.err(validatedMessageResult.error);
-      }
-      const validatedMessage = validatedMessageResult.value;
-
-      // Captured once and threaded through to generateThreadTitle below: the
-      // generator's guard compares the thread's live title against this
-      // value to detect any rename (even one whose titleSource column went
-      // stale) rather than trusting titleSource alone.
-      const initialThreadTitle = extractTitle(validatedMessage.message.parts);
-
-      const thread = yield* Result.await(
-        loadThread({
-          initialDataWorkspaceIds:
-            activeDraftContext === null
-              ? []
-              : activeDraftContext.originDataWorkspaceIds,
-          initialContextMatterIds: requestedContextMatterIds,
-          organizationId: session.activeOrganizationId,
-          recordAuditEvent,
-          safeDb,
-          threadId: body.threadId,
-          title: initialThreadTitle,
-          userId: user.id,
-          workspaceId,
-        }),
-      );
-      // Own the thread from creation through the first durable message. The
-      // enclosing finally is the sole rollback boundary for every later
-      // return, error, or SDK short-circuit before that persistence succeeds.
-      pendingUnpersistedSideEffects = {
-        threadState: thread,
-        uploadedFiles: [],
-      };
-
-      const activeDraft = body.activeDraft;
-      if (activeDraft !== undefined) {
-        const hasPersistedContext =
-          thread.type === "created"
-            ? false
-            : yield* Result.await(
-                safeDb(async (tx) =>
-                  hasPersistedGeneratedDocumentActiveDraftContext({
-                    generatedDraft: {
-                      originChatMessageId: activeDraft.originChatMessageId,
-                      originChatThreadId: activeDraft.originChatThreadId,
-                      toolCallId: activeDraft.toolCallId,
-                    },
-                    organizationId: session.activeOrganizationId,
-                    threadId: thread.data.id,
-                    tx,
-                    userId: user.id,
-                  }),
-                ),
-              );
-        if (
-          !canUseChatThreadForGeneratedDocumentDraft({
-            hasPersistedContext,
-            threadType: thread.type,
-          })
-        ) {
-          return Result.err(
-            new HandlerError({
-              status: 409,
-              message:
-                "Active generated document draft is not bound to this chat",
-            }),
-          );
-        }
-      }
-
-      const stampedValidatedMessage = {
-        ...validatedMessage,
-        message: stampValidatedMessageWithActiveDraftContext({
-          activeDraft: body.activeDraft,
-          message: validatedMessage.message,
-        }),
-      };
-
-      // Existing-thread pin changes are durable side effects, so stop before
-      // applying them when any earlier validation or thread read observed a
-      // client disconnect. Created threads still need their rollback token
-      // cleaned up on this exit path.
-      if (isClientConnectionAborted()) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: "Client disconnected before AI work started",
-          }),
-        );
-      }
-
-      // The thread's persisted chat-model override wins over the org/instance
-      // default, but the dev-only body override still wins over everything
-      // (matches `assertDevModelOverride` above). Re-validated here (not just
-      // at write time in update-thread-model.ts) so a provider key removal or
-      // a catalog bump that drops the model falls back to the org default
-      // silently instead of failing the send.
-      const {
-        modelId: selectedChatModel,
-        reasoningEffort: selectedReasoningEffort,
-      } = resolveEffectiveChatModelSelection({
-        devModelId: body.devModelId,
-        threadChatModel: thread.data.chatModel,
-        threadReasoningEffort: thread.data.chatReasoningEffort,
-        orgAIConfig,
-      });
-
-      // Budget routing. Inside the included budget any selection
-      // stands. When the pre-flight resolved the reduced-cost lane, an
-      // unselected turn is served on the lane's own model. Two cases
-      // instead fall through to the pool, which must be able to cover
-      // them — the same 402 a pool-only org would see: an explicit
-      // model selection, and an agent-mode send (machine work never
-      // settles an interactive budget).
-      let chatModelOverride = selectedChatModel;
-      let chatReasoningEffort = selectedReasoningEffort;
-      let turnLane = usageLane ?? { lane: "pool" as const };
-      const explicitSelectionNeedsPool =
-        turnLane.lane === "fallback" &&
-        selectedChatModel !== undefined &&
-        selectedChatModel !== turnLane.forcedModelSelection;
-      const agentModeNeedsPool =
-        body.runMode === "agent" && turnLane.lane !== "pool";
-      if (explicitSelectionNeedsPool || agentModeNeedsPool) {
-        const poolCheck = yield* Result.await(
-          Result.tryPromise({
-            try: async () =>
-              await assertUsageAvailableForHandler({
-                metering: { actionType: "chat" },
-                organizationId: session.activeOrganizationId,
-                orgAIConfig,
-                workspaceId: null,
-                userId: user.id,
-                safeDb,
-              }),
-            catch: (cause) =>
-              new HandlerError({
-                status: 500,
-                message: "Usage check failed",
-                cause,
-              }),
-          }),
-        );
-        if (poolCheck !== null) {
-          return Result.err(poolCheck);
-        }
-        turnLane = { lane: "pool" };
-      } else if (turnLane.lane === "fallback") {
-        chatModelOverride = turnLane.forcedModelSelection;
-        chatReasoningEffort = undefined;
-      }
-
-      // For an existing thread, accept a non-empty body update as
-      // "user changed scope, persist it"; an omitted/empty body keeps
-      // the stored value so re-sends from cached transports don't
-      // silently widen access. Persisted pins are always intersected
-      // with the currently accessible set so a revoked workspace
-      // cannot be re-authorized through a stale stored pin.
-      const storedPinsThisRequest =
-        thread.type === "existing" && body.contextMatterIds !== undefined
-          ? requestedContextMatterIds
-          : thread.data.contextMatterIds;
-      const effectiveContextMatterIds = intersectAccessibleWorkspaceIds({
-        pinnedIds: storedPinsThisRequest,
-        accessibleWorkspaceIds,
-      });
-      if (
-        thread.type === "existing" &&
-        !workspaceIdsEqual(
-          thread.data.contextMatterIds,
-          effectiveContextMatterIds,
-        )
-      ) {
-        yield* Result.await(
-          safeDb(async (tx) => {
-            await tx
-              .update(chatThreads)
-              .set({ contextMatterIds: effectiveContextMatterIds })
-              .where(eq(chatThreads.id, body.threadId));
-
-            await recordAuditEvent(tx, {
-              action: AUDIT_ACTION.UPDATE,
-              resourceType: AUDIT_RESOURCE_TYPE.CHAT_THREAD,
-              resourceId: body.threadId,
-              workspaceId,
-              changes: {
-                contextMatterIds: {
-                  old: [...thread.data.contextMatterIds],
-                  new: [...effectiveContextMatterIds],
-                },
-              },
-            });
-          }),
-        );
-      }
-
-      const thirdPartyBoundary = createChatThirdPartyBoundary({
-        anonymizationScopeId: workspaceId ?? body.threadId,
-        organizationId: session.activeOrganizationId,
-        scopedDb,
-        sendMode: body.sendMode,
-        workspaceId: workspaceId ?? undefined,
-      });
-
-      if (isClientConnectionAborted()) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: "Client disconnected before AI work started",
-          }),
-        );
-      }
-
-      const uploadResult = await uploadMessageFilesWithRollback({
-        message: stampedValidatedMessage.message,
-        recordAuditEvent,
-        safeDb,
-        threadId: thread.data.id,
-        threadState: thread,
-        userId: user.id,
-      });
-      if (Result.isError(uploadResult)) {
-        // The upload helper already cleans a partial upload (and a newly
-        // created thread) before returning an error.
-        pendingUnpersistedSideEffects = undefined;
-        return Result.err(uploadResult.error);
-      }
-      pendingUnpersistedSideEffects.uploadedFiles =
-        uploadResult.value.uploadedFiles;
-
-      const parsedMessage = parseMessage({
-        accessibleWorkspaceIds,
-        message: uploadResult.value.message,
-      });
-
-      const isExplicitRegeneration =
-        body.turnIntent === CHAT_TURN_INTENT.regenerate;
-      if (
-        isExplicitRegeneration &&
-        (parsedMessage.message.role !== "user" ||
-          body.truncateAfterMessageId !== undefined)
-      ) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message:
-              "Regeneration requires one unambiguous user-message target",
-          }),
-        );
-      }
-      const replayTargetMessageId =
-        body.truncateAfterMessageId ??
-        (isExplicitRegeneration ? parsedMessage.message.id : undefined);
-
-      let messagesForPersistence: ChatThreadState["data"]["messages"] =
-        thread.data.messages;
-      let deleteMessageIdsBeforeLatest: SafeId<"chatMessage">[] = [];
-      // The incoming message normally is new. Outside the truncation path the
-      // stored list is a bounded window that may exclude an old re-sent/edited
-      // id, so a targeted existence check guards against a duplicate insert.
-      let incomingMessageExists = false;
-      if (replayTargetMessageId !== undefined) {
-        if (parsedMessage.message.id !== replayTargetMessageId) {
-          return Result.err(
-            new HandlerError({
-              status: 400,
-              message: "Truncation target must match the incoming message",
-            }),
-          );
-        }
-
-        // Resolve the target against the full thread history, not the windowed
-        // in-memory list: a replay target can be older than the window. The
-        // retained prefix is needed to recompute the thread data scope.
-        const truncationTarget = yield* Result.await(
-          resolveTruncationTarget({
-            safeDb,
-            threadId: body.threadId,
-            targetMessageId: replayTargetMessageId,
-          }),
-        );
-        if (truncationTarget === null) {
-          return Result.err(
-            new HandlerError({
-              status: 400,
-              message: "Truncation target was not found in the chat thread",
-            }),
-          );
-        }
-
-        messagesForPersistence = truncationTarget.messagesForPersistence;
-        deleteMessageIdsBeforeLatest =
-          truncationTarget.deleteMessageIdsBeforeLatest;
-        if (isExplicitRegeneration && truncationTarget.hasLaterUserMessage) {
-          return Result.err(
-            new HandlerError({
-              status: 409,
-              message: "Only the latest user turn can be regenerated",
-            }),
-          );
-        }
-      } else {
-        incomingMessageExists = yield* Result.await(
-          chatMessageExistsForThread({
-            messageId: brandPersistedChatMessageId(parsedMessage.message.id),
-            safeDb,
-            threadId: body.threadId,
-          }),
-        );
-      }
-
-      const baseLatestMessagePlan = planMessagePersistence({
-        message: parsedMessage.message,
-        storedMessages: messagesForPersistence,
-        incomingMessageExists,
-      });
-      if (
-        isExplicitRegeneration &&
-        baseLatestMessagePlan.persistencePlan.type !== "none"
-      ) {
-        return Result.err(
-          new HandlerError({
-            status: 409,
-            message: "Regeneration target is not a persisted user message",
-          }),
-        );
-      }
-      const latestMessagePlan = isExplicitRegeneration
-        ? {
-            existingIds: baseLatestMessagePlan.existingIds,
-            messages: baseLatestMessagePlan.messages,
-            persistencePlan: {
-              message: parsedMessage.message,
-              messageId: parsedMessage.message.id,
-              type: "update",
-            } satisfies MessagePersistencePlan,
-          }
-        : baseLatestMessagePlan;
-      if (
-        replayTargetMessageId !== undefined &&
-        latestMessagePlan.persistencePlan.type !== "update"
-      ) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: "Truncation requires updating an existing message",
-          }),
-        );
-      }
-
-      const recomputedDataWorkspaceIds =
-        replayTargetMessageId !== undefined
-          ? recomputeThreadDataScope({
-              accessibleSet,
-              baseWorkspaceId: workspaceId,
-              messages: latestMessagePlan.messages,
-            })
-          : null;
-
-      // Keep the thread's data scope aligned with the messages being
-      // stored. Normal sends append newly observed workspace IDs
-      // before persisting. Replay truncation recomputes the exact
-      // retained scope and writes it in the same transaction as the
-      // replay update below.
-      //
-      // Intersect with `accessibleWorkspaceIds` first: an unknown ID
-      // (model hallucination, copy-pasted UUID from elsewhere) added
-      // to `data_workspace_ids` would fail the RLS subset check on
-      // every subsequent message persist, silently breaking the
-      // thread.
-      const incomingMessageWorkspaceIds = extractIncomingMessageWorkspaceIds({
-        mentions: parsedMessage.mentions,
-        message: parsedMessage.message,
-      }).filter((id) => accessibleSet.has(id));
-      const dataScopeAfterIncomingMessage =
-        recomputedDataWorkspaceIds ??
-        Array.from(
-          new Set([
-            ...thread.data.dataWorkspaceIds,
-            ...incomingMessageWorkspaceIds,
-          ]),
-        );
-
-      // Resolve the opaque sandbox boundary before persisting or claiming the
-      // turn. A disabled or incomplete deployment must reject the explicit
-      // agent request without leaving a durable incoming message behind.
-      const toolWorkspaceIds = resolveToolWorkspaceIds({
-        pinnedIds: effectiveContextMatterIds,
-        accessibleWorkspaceIds,
-      });
-      const sandboxRunResult =
-        body.runMode === CHAT_RUN_MODE.agent
-          ? await Result.tryPromise({
-              try: async () =>
-                await resolveChatSandboxPlan({
-                  organizationId: session.activeOrganizationId,
-                  runId: Bun.randomUUIDv7(),
-                  userId: user.id,
-                  workspaceIds: toolWorkspaceIds,
-                }),
-              catch: (cause) =>
-                cause instanceof HandlerError
-                  ? cause
-                  : new HandlerError({
-                      cause,
-                      message: "Failed to prepare agent sandbox run",
-                      status: 500,
-                    }),
-            })
-          : Result.ok(undefined);
-      if (Result.isError(sandboxRunResult)) {
-        // The enclosing finally owns rollback of the created thread and any
-        // uploaded files, preserving the original sandbox preflight error.
-        return yield* Result.err(sandboxRunResult.error);
-      }
-      const sandboxRun = sandboxRunResult.value;
-      const turnAcceptance =
-        parsedMessage.message.role === "user" &&
-        latestMessagePlan.persistencePlan.type !== "none"
-          ? createChatTurnAcceptance({
-              organizationId: session.activeOrganizationId,
-              threadId: body.threadId,
-              userId: user.id,
-              userMessageId: parsedMessage.message.id,
-              workspaceId,
-            })
-          : undefined;
-
-      const persistenceProps = {
-        acceptedSendMode: body.sendMode,
-        recordAuditEvent,
-        safeDb,
-        threadId: body.threadId,
-        turnAcceptance,
-        userId: user.id,
-        workspaceId,
-        persistencePlan: latestMessagePlan.persistencePlan,
-        dataScopeExpansion:
-          recomputedDataWorkspaceIds === null
-            ? { newWorkspaceIds: incomingMessageWorkspaceIds }
-            : undefined,
-        deleteMessageIds: deleteMessageIdsBeforeLatest,
-        dataScopeReplacement:
-          recomputedDataWorkspaceIds === null
-            ? undefined
-            : {
-                observedDataWorkspaceIds: thread.data.dataWorkspaceIds,
-                newDataWorkspaceIds: recomputedDataWorkspaceIds,
-              },
-      } as const;
-      let turnExecution: ChatTurnExecution | null;
-      if (parsedMessage.message.role === "assistant") {
-        if (latestMessagePlan.persistencePlan.type !== "update") {
-          return Result.err(
-            new HandlerError({
-              status: 409,
-              message: "Interactive replay must update its owning message",
-            }),
-          );
-        }
-        const replayResult = await persistClaimedReplayMessage({
-          ...persistenceProps,
-          claim: {
-            acceptedTurnId: null,
-            continuationInteraction:
-              getResumedUserInteraction({
-                awaited: getAwaitingUserInteractions(
-                  validationThreadState.persistedMessage === null
-                    ? null
-                    : chatMessageFromPersisted({
-                        content: validationThreadState.persistedMessage.content,
-                        id: parsedMessage.message.id,
-                        role: validationThreadState.persistedMessage.role,
-                      }),
-                ),
-                message: parsedMessage.message,
-              }) ?? undefined,
-            incomingMessageId: parsedMessage.message.id,
-            incomingMessageRole: parsedMessage.message.role,
+      const preparedIncomingMessageResult =
+        await prepareValidatedIncomingMessage({
+          authorization: {
+            accessibleWorkspaceIds,
+            memberRole,
+            pinServerValidatedWorkspaceId,
+            requestedContextMatterIds,
+            workspaceStatusById,
+          },
+          lifecycle,
+          persistence: { recordAuditEvent, safeDb, scopedDb },
+          prerequisites: {
+            activeDraftContext,
+            activeFileForTools,
+            validationThreadState,
+          },
+          request: {
+            body,
+            isClientConnectionAborted,
             organizationId: session.activeOrganizationId,
-            threadId: body.threadId,
+            resume,
             userId: user.id,
             workspaceId,
           },
-          persistencePlan: latestMessagePlan.persistencePlan,
+          tools: {
+            disabledNativeToolSlugs,
+            docxEditRepresentation,
+            editApplyMode,
+            externalMcpToolsLoader,
+            orgAIConfig,
+            refRegistry,
+            toolDefectMemo,
+            usageLane,
+            validationActiveSkillContext,
+          },
         });
-        if (Result.isError(replayResult)) {
-          return Result.err(replayResult.error);
-        }
-        turnExecution = replayResult.value;
-        if (turnExecution !== null) {
-          pendingUnpersistedSideEffects = undefined;
-        }
-      } else {
-        if (turnAcceptance === undefined) {
-          const persistenceResult = await persistMessage(persistenceProps);
-          if (Result.isError(persistenceResult)) {
-            return Result.err(persistenceResult.error);
-          }
-          turnExecution = yield* Result.await(
-            claimChatTurnForExecution({
-              acceptedTurnId: null,
-              incomingMessageId: parsedMessage.message.id,
-              incomingMessageRole: parsedMessage.message.role,
-              organizationId: session.activeOrganizationId,
-              safeDb,
-              threadId: body.threadId,
-              userId: user.id,
-              workspaceId,
-            }),
-          );
-        } else {
-          const persistenceResult = await persistAcceptedMessageWithClaim({
-            ...persistenceProps,
-            turnAcceptance,
-          });
-          if (Result.isError(persistenceResult)) {
-            return Result.err(persistenceResult.error);
-          }
-          turnExecution = persistenceResult.value;
-        }
-        if (latestMessagePlan.persistencePlan.type !== "none") {
-          pendingUnpersistedSideEffects = undefined;
-        }
+      if (Result.isError(preparedIncomingMessageResult)) {
+        return Result.err(preparedIncomingMessageResult.error);
       }
-      if (turnExecution === null) {
-        return Result.err(
-          new HandlerError({
-            status: 409,
-            message: "Chat turn has no durable execution owner",
-          }),
-        );
+      const {
+        chatModelOverride,
+        chatReasoningEffort,
+        effectiveContextMatterIds,
+        initialThreadTitle,
+        thirdPartyBoundary,
+        thread,
+        turnLane,
+        uploadedMessage,
+        webSearchProviders,
+      } = preparedIncomingMessageResult.value;
+
+      const acceptedTurnResult = await acceptIncomingTurn({
+        accessibleSet,
+        accessibleWorkspaceIds,
+        body,
+        effectiveContextMatterIds,
+        lifecycle,
+        organizationId: session.activeOrganizationId,
+        recordAuditEvent,
+        safeDb,
+        thread,
+        uploadedMessage,
+        userId: user.id,
+        validationThreadState,
+        workspaceId,
+      });
+      if (Result.isError(acceptedTurnResult)) {
+        return Result.err(acceptedTurnResult.error);
       }
-      claimedChatTurnOwnership = {
-        status: "preflight",
-        execution: turnExecution,
-        ...(parsedMessage.message.role === "assistant"
-          ? { owningAssistantMessage: parsedMessage.message }
-          : {}),
-      };
-      const owningAssistantMessage =
-        parsedMessage.message.role === "assistant"
-          ? parsedMessage.message
-          : undefined;
-      const failCurrentTurn = async (
-        code: ChatTurnFailureCode,
-        retryable: boolean,
-      ): Promise<void> => {
-        const failureResult = await persistFailedChatTurn({
-          code,
-          execution: turnExecution,
-          recordAuditEvent,
-          retryable,
-          owningAssistantMessage,
-          safeDb,
-          threadId: body.threadId,
-          userId: user.id,
-          workspaceId,
-        });
-        if (Result.isError(failureResult)) {
-          captureError(failureResult.error, { threadId: body.threadId });
-          return;
-        }
-        claimedChatTurnOwnership = { status: "unclaimed" };
-      };
-      // Like `persistFailedChatTurn`, a pre-stream disconnect must hydrate as
-      // the same terminal assistant turn as a streamed interruption.
-      const interruptCurrentTurn = async () => {
-        const settlementResult = await persistInterruptedChatTurn({
-          execution: turnExecution,
-          owningAssistantMessage,
-          recordAuditEvent,
-          safeDb,
-          threadId: body.threadId,
-          userId: user.id,
-          workspaceId,
-        });
-        if (Result.isOk(settlementResult)) {
-          claimedChatTurnOwnership = { status: "unclaimed" };
-        }
-        return settlementResult;
-      };
+      const {
+        dataScopeAfterIncomingMessage,
+        deleteMessageIdsBeforeLatest,
+        latestMessagePlan,
+        owningAssistantMessage,
+        parsedMessage,
+        replayTargetMessageId,
+        sandboxRun,
+        toolWorkspaceIds,
+        turnExecution,
+      } = acceptedTurnResult.value;
 
       // The incoming message is durable now, so a disconnect must not run the
       // pre-persistence rollback (which would delete files referenced by that
       // message). It should still stop before connector discovery and any
       // metered provider work.
       if (isClientConnectionAborted()) {
-        yield* Result.await(interruptCurrentTurn());
+        yield* Result.await(lifecycle.interruptCurrentTurn());
         return Result.err(
           new HandlerError({
             status: 400,
@@ -1360,7 +1660,7 @@ const sendMessage = createSafeRootHandler(
       const createMeteredAIAbortSignal = () =>
         AbortSignal.timeout(CHAT_METERED_PROVIDER_TIMEOUT_MS);
       if (isClientConnectionAborted()) {
-        yield* Result.await(interruptCurrentTurn());
+        yield* Result.await(lifecycle.interruptCurrentTurn());
         return Result.err(
           new HandlerError({
             status: 400,
@@ -1385,12 +1685,12 @@ const sendMessage = createSafeRootHandler(
         workspaceId,
       });
       if (Result.isError(messagesForContextResult)) {
-        await failCurrentTurn("provider-error", true);
+        await lifecycle.failCurrentTurn("provider-error", true);
         return Result.err(messagesForContextResult.error);
       }
 
       if (isClientConnectionAborted()) {
-        yield* Result.await(interruptCurrentTurn());
+        yield* Result.await(lifecycle.interruptCurrentTurn());
         return Result.err(
           new HandlerError({
             status: 400,
@@ -1446,7 +1746,7 @@ const sendMessage = createSafeRootHandler(
         refRegistry,
       });
       if (Result.isError(chatContextResult)) {
-        await failCurrentTurn(
+        await lifecycle.failCurrentTurn(
           "internal",
           !(chatContextResult.error instanceof HandlerError) ||
             chatContextResult.error.status >= 500,
@@ -1456,7 +1756,7 @@ const sendMessage = createSafeRootHandler(
       const chatContext = chatContextResult.value;
 
       if (isClientConnectionAborted()) {
-        yield* Result.await(interruptCurrentTurn());
+        yield* Result.await(lifecycle.interruptCurrentTurn());
         return Result.err(
           new HandlerError({
             status: 400,
@@ -1482,7 +1782,7 @@ const sendMessage = createSafeRootHandler(
           })
         : Result.ok(undefined);
       if (Result.isError(externalMcpToolsResult)) {
-        await failCurrentTurn("connector-discovery", true);
+        await lifecycle.failCurrentTurn("connector-discovery", true);
         return Result.err(externalMcpToolsResult.error);
       }
       const externalMcpTools = externalMcpToolsResult.value;
@@ -1592,7 +1892,7 @@ const sendMessage = createSafeRootHandler(
 
       // A normal chat hands loaded clients to the stream. Agent runs leave
       // this false so the outer finally closes any validation-only load.
-      externalMcpToolsHandedOffToStreaming = externalMcpTools !== undefined;
+      lifecycle.handOffConnectors(externalMcpTools !== undefined);
       const response = yield* Result.await(
         Result.tryPromise({
           try: async () => {
@@ -1714,7 +2014,7 @@ const sendMessage = createSafeRootHandler(
                     captureError(persistResult.error, {
                       threadId: body.threadId,
                     });
-                    await failCurrentTurn("persistence", true);
+                    await lifecycle.failCurrentTurn("persistence", true);
                     throw new HandlerError({
                       status: 500,
                       message: "Failed to persist assistant turn",
@@ -1815,9 +2115,12 @@ const sendMessage = createSafeRootHandler(
                 // refusal). No terminal middleware hook runs in that branch,
                 // so settle the claimed turn here instead of leaving it
                 // indefinitely running.
-                await failCurrentTurn("internal", chatResponse.status >= 500);
+                await lifecycle.failCurrentTurn(
+                  "internal",
+                  chatResponse.status >= 500,
+                );
               } else {
-                claimedChatTurnOwnership = { status: "streaming" };
+                lifecycle.markStreaming();
               }
 
               return chatResponse;
@@ -1825,7 +2128,7 @@ const sendMessage = createSafeRootHandler(
               if (externalMcpTools !== undefined) {
                 await externalMcpTools.close();
               }
-              await failCurrentTurn("internal", true);
+              await lifecycle.failCurrentTurn("internal", true);
               throw error;
             }
           },
@@ -1842,51 +2145,7 @@ const sendMessage = createSafeRootHandler(
 
       return Result.ok(response);
     } finally {
-      if (claimedChatTurnOwnership.status === "preflight") {
-        const failureResult = await persistFailedChatTurn({
-          code: "internal",
-          execution: claimedChatTurnOwnership.execution,
-          owningAssistantMessage:
-            claimedChatTurnOwnership.owningAssistantMessage,
-          recordAuditEvent,
-          retryable: true,
-          safeDb,
-          threadId: body.threadId,
-          userId: user.id,
-          workspaceId,
-        });
-        if (Result.isError(failureResult)) {
-          captureError(failureResult.error, {
-            source: "send-message-claimed-turn-preflight-cleanup",
-            threadId: body.threadId,
-          });
-        }
-      }
-      if (pendingUnpersistedSideEffects !== undefined) {
-        const rollbackResult = await rollbackUnpersistedChatSideEffects({
-          recordAuditEvent,
-          safeDb,
-          threadId: body.threadId,
-          threadState: pendingUnpersistedSideEffects.threadState,
-          uploadedFiles: pendingUnpersistedSideEffects.uploadedFiles,
-          userId: user.id,
-        });
-        if (Result.isError(rollbackResult)) {
-          // Preserve the request's original outcome while recording cleanup
-          // failure for the orphan-recovery path; control flow from a finally
-          // block must not silently replace the send result.
-          captureError(rollbackResult.error, {
-            source: "send-message-unpersisted-side-effect-rollback",
-            threadId: body.threadId,
-          });
-        }
-      }
-      // No-op if `getExternalMcpTools` was never called on this exit path
-      // (the message needed neither validation nor streaming to load
-      // external tools before failing/returning early).
-      if (!externalMcpToolsHandedOffToStreaming) {
-        await externalMcpToolsLoader.closeIfLoaded();
-      }
+      await lifecycle.cleanup();
     }
   },
 );

--- a/apps/api/src/handlers/chat/tools/chat-tools.ts
+++ b/apps/api/src/handlers/chat/tools/chat-tools.ts
@@ -491,6 +491,55 @@ const createCreateDocumentTools = () => ({
   [CREATE_DOCUMENT_TOOL_NAME]: createCreateDocumentTool(),
 });
 
+type CreateWorkspaceDocumentChatToolsProps = Pick<
+  GetChatToolsProps,
+  | "memberRole"
+  | "organizationId"
+  | "recordAuditEvent"
+  | "refRegistry"
+  | "requestWorkspaceId"
+  | "scopedDb"
+  | "toolWorkspaceIds"
+  | "userId"
+  | "workspaceStatusById"
+>;
+
+/**
+ * Mirrors the REST/MCP entity-create boundary for the direct chat mutation.
+ * Keeping the full gate here prevents registration from drifting away from
+ * the authorization required by its execution path.
+ */
+const createAuthorizedWorkspaceDocumentTools = ({
+  memberRole,
+  organizationId,
+  recordAuditEvent,
+  refRegistry,
+  requestWorkspaceId,
+  scopedDb,
+  toolWorkspaceIds,
+  userId,
+  workspaceStatusById,
+}: CreateWorkspaceDocumentChatToolsProps): ChatToolMap => {
+  if (
+    requestWorkspaceId === null ||
+    recordAuditEvent === undefined ||
+    !toolWorkspaceIds.includes(requestWorkspaceId) ||
+    workspaceStatusById?.get(requestWorkspaceId) !== "active" ||
+    !roles[memberRole].authorize({ entity: ["create"] }).success
+  ) {
+    return {};
+  }
+
+  return createCreateWorkspaceDocumentTools({
+    scopedDb,
+    organizationId,
+    userId,
+    workspaceId: requestWorkspaceId,
+    recordAuditEvent,
+    refRegistry,
+  });
+};
+
 type CreateRememberToolsProps = {
   canManageWorkspaceMemory: boolean;
   organizationId: SafeId<"organization">;
@@ -900,24 +949,17 @@ export const getChatTools = (props: GetChatToolsProps): ChatToolMap => {
   //     this tool alone.
   // KNOWN LIMITATION: creates at the matter root every time — there is no
   // folder/parent targeting yet.
-  const canCreateWorkspaceDocument = roles[memberRole].authorize({
-    entity: ["create"],
-  }).success;
-  const createWorkspaceDocumentTools =
-    requestWorkspaceId !== null &&
-    recordAuditEvent !== undefined &&
-    toolWorkspaceIds.includes(requestWorkspaceId) &&
-    canCreateWorkspaceDocument &&
-    workspaceStatusById?.get(requestWorkspaceId) === "active"
-      ? createCreateWorkspaceDocumentTools({
-          scopedDb,
-          organizationId,
-          userId,
-          workspaceId: requestWorkspaceId,
-          recordAuditEvent,
-          refRegistry,
-        })
-      : {};
+  const createWorkspaceDocumentTools = createAuthorizedWorkspaceDocumentTools({
+    memberRole,
+    organizationId,
+    recordAuditEvent,
+    refRegistry,
+    requestWorkspaceId,
+    scopedDb,
+    toolWorkspaceIds,
+    userId,
+    workspaceStatusById,
+  });
 
   // edit_workspace_document is the headless (`auto`) counterpart to
   // `apply-active-docx-edits`: it writes a new entity version directly

--- a/apps/api/src/handlers/tasks/update.ts
+++ b/apps/api/src/handlers/tasks/update.ts
@@ -233,6 +233,89 @@ const taskUpdateValues = ({
   updatedAt: new Date(),
 });
 
+type LockedWorkObligation = NonNullable<
+  Awaited<ReturnType<typeof lockWorkObligation>>
+>;
+
+type ResolveWorkflowStatusTransitionOptions = {
+  governedWorkflow: boolean;
+  requestedStatus: string | undefined;
+  userId: SafeId<"user">;
+  workflow: LockedWorkObligation;
+  workflowReason: string | undefined;
+};
+
+const reopenedWorkflowStatus = (workflow: LockedWorkObligation) => {
+  if (workflow.ownerUserId === null) {
+    return WORK_OBLIGATION_STATUS.UNASSIGNED;
+  }
+  if (workflow.acknowledgedAt === null) {
+    return WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT;
+  }
+  return WORK_OBLIGATION_STATUS.ACTIVE;
+};
+
+const resolveWorkflowStatusTransition = ({
+  governedWorkflow,
+  requestedStatus,
+  userId,
+  workflow,
+  workflowReason,
+}: ResolveWorkflowStatusTransitionOptions) => {
+  if (requestedStatus === "done" && workflow.status !== "completed") {
+    if (
+      governedWorkflow &&
+      (workflow.status !== WORK_OBLIGATION_STATUS.ACTIVE ||
+        workflow.ownerUserId !== userId)
+    ) {
+      throw new HandlerError({
+        status: 409,
+        message:
+          "Only the acknowledged accountable owner can complete this work",
+      });
+    }
+    return {
+      eventType: WORK_OBLIGATION_EVENT_TYPE.COMPLETED,
+      status: WORK_OBLIGATION_STATUS.COMPLETED,
+    };
+  }
+
+  if (
+    requestedStatus === "cancelled" &&
+    workflow.status !== WORK_OBLIGATION_STATUS.CANCELLED
+  ) {
+    if (
+      governedWorkflow &&
+      workflow.status !== WORK_OBLIGATION_STATUS.UNASSIGNED &&
+      !workflowReason
+    ) {
+      throw new HandlerError({
+        status: 400,
+        message: "A reason is required when cancelling assigned work",
+      });
+    }
+    return {
+      eventType: WORK_OBLIGATION_EVENT_TYPE.CANCELLED,
+      status: WORK_OBLIGATION_STATUS.CANCELLED,
+    };
+  }
+
+  const reopensClosedWorkflow =
+    requestedStatus !== undefined &&
+    requestedStatus !== "done" &&
+    requestedStatus !== "cancelled" &&
+    (workflow.status === WORK_OBLIGATION_STATUS.COMPLETED ||
+      workflow.status === WORK_OBLIGATION_STATUS.CANCELLED);
+  if (!reopensClosedWorkflow) {
+    return { eventType: undefined, status: workflow.status };
+  }
+
+  return {
+    eventType: WORK_OBLIGATION_EVENT_TYPE.REOPENED,
+    status: reopenedWorkflowStatus(workflow),
+  };
+};
+
 export type UpdateTaskHandlerProps = {
   safeDb: SafeDb;
   workspaceId: SafeId<"workspace">;
@@ -324,60 +407,14 @@ export const updateTaskHandler = async function* ({
         const nextLegacyHardDeadlineDate = updatesLegacyDeadline
           ? body.dueDate
           : undefined;
-        let nextWorkflowStatus = workflow.status;
-        let workflowEventType:
-          | "completed"
-          | "cancelled"
-          | "reopened"
-          | undefined;
-
-        if (body.status === "done" && workflow.status !== "completed") {
-          if (
-            features.governedWorkflow &&
-            (workflow.status !== WORK_OBLIGATION_STATUS.ACTIVE ||
-              workflow.ownerUserId !== userId)
-          ) {
-            throw new HandlerError({
-              status: 409,
-              message:
-                "Only the acknowledged accountable owner can complete this work",
-            });
-          }
-          nextWorkflowStatus = WORK_OBLIGATION_STATUS.COMPLETED;
-          workflowEventType = WORK_OBLIGATION_EVENT_TYPE.COMPLETED;
-        } else if (
-          body.status === "cancelled" &&
-          workflow.status !== WORK_OBLIGATION_STATUS.CANCELLED
-        ) {
-          if (
-            features.governedWorkflow &&
-            workflow.status !== WORK_OBLIGATION_STATUS.UNASSIGNED &&
-            !workflowReason
-          ) {
-            throw new HandlerError({
-              status: 400,
-              message: "A reason is required when cancelling assigned work",
-            });
-          }
-          nextWorkflowStatus = WORK_OBLIGATION_STATUS.CANCELLED;
-          workflowEventType = WORK_OBLIGATION_EVENT_TYPE.CANCELLED;
-        } else if (
-          body.status !== undefined &&
-          body.status !== "done" &&
-          body.status !== "cancelled" &&
-          (workflow.status === WORK_OBLIGATION_STATUS.COMPLETED ||
-            workflow.status === WORK_OBLIGATION_STATUS.CANCELLED)
-        ) {
-          if (workflow.ownerUserId === null) {
-            nextWorkflowStatus = WORK_OBLIGATION_STATUS.UNASSIGNED;
-          } else if (workflow.acknowledgedAt === null) {
-            nextWorkflowStatus =
-              WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT;
-          } else {
-            nextWorkflowStatus = WORK_OBLIGATION_STATUS.ACTIVE;
-          }
-          workflowEventType = WORK_OBLIGATION_EVENT_TYPE.REOPENED;
-        }
+        const { eventType: workflowEventType, status: nextWorkflowStatus } =
+          resolveWorkflowStatusTransition({
+            governedWorkflow: features.governedWorkflow,
+            requestedStatus: body.status,
+            userId,
+            workflow,
+            workflowReason,
+          });
 
         if (nextWorkflowStatus !== workflow.status && workflowEventType) {
           workflowSet.status = nextWorkflowStatus;

--- a/apps/api/src/handlers/work-obligations/update.ts
+++ b/apps/api/src/handlers/work-obligations/update.ts
@@ -1,6 +1,7 @@
 import { Result } from "better-result";
 import { and, eq } from "drizzle-orm";
 import { t } from "elysia";
+import type { Static } from "elysia";
 
 import {
   entities,
@@ -51,6 +52,70 @@ const updateWorkObligationBody = t.Object({
   sourceDescription: t.Optional(t.Nullable(t.String({ maxLength: 1000 }))),
   reason: t.Optional(t.String({ minLength: 1, maxLength: 1000 })),
 });
+
+type UpdateWorkObligationBody = Static<typeof updateWorkObligationBody>;
+type LockedWorkObligation = NonNullable<
+  Awaited<ReturnType<typeof lockWorkObligation>>
+>;
+
+const changesOwnerOfClosedObligation = (
+  body: UpdateWorkObligationBody,
+  existing: LockedWorkObligation,
+): boolean =>
+  body.ownerUserId !== undefined &&
+  body.ownerUserId !== existing.ownerUserId &&
+  (existing.status === WORK_OBLIGATION_STATUS.COMPLETED ||
+    existing.status === WORK_OBLIGATION_STATUS.CANCELLED);
+
+type WorkObligationTransitionViolation =
+  | "target_after_deadline"
+  | "delegation_reason_required"
+  | "deadline_reason_required";
+
+/** Ordered business-policy validation after related entity ownership is known. */
+const workObligationTransitionViolation = ({
+  body,
+  existing,
+  reason,
+}: {
+  body: UpdateWorkObligationBody;
+  existing: LockedWorkObligation;
+  reason: string | undefined;
+}): WorkObligationTransitionViolation | null => {
+  const nextWorkingTargetDate =
+    body.workingTargetDate === undefined
+      ? existing.workingTargetDate
+      : body.workingTargetDate;
+  const nextHardDeadlineDate =
+    body.hardDeadlineDate === undefined
+      ? existing.hardDeadlineDate
+      : body.hardDeadlineDate;
+
+  if (
+    nextWorkingTargetDate !== null &&
+    nextHardDeadlineDate !== null &&
+    nextWorkingTargetDate > nextHardDeadlineDate
+  ) {
+    return "target_after_deadline";
+  }
+  if (
+    body.ownerUserId !== undefined &&
+    existing.ownerUserId !== null &&
+    body.ownerUserId !== existing.ownerUserId &&
+    !reason
+  ) {
+    return "delegation_reason_required";
+  }
+  if (
+    body.hardDeadlineDate !== undefined &&
+    existing.hardDeadlineDate !== null &&
+    body.hardDeadlineDate !== existing.hardDeadlineDate &&
+    !reason
+  ) {
+    return "deadline_reason_required";
+  }
+  return null;
+};
 
 const updateWorkObligation = createSafeHandler(
   {
@@ -131,12 +196,7 @@ const updateWorkObligation = createSafeHandler(
           return { status: "not_found" as const };
         }
 
-        if (
-          body.ownerUserId !== undefined &&
-          body.ownerUserId !== existing.ownerUserId &&
-          (existing.status === WORK_OBLIGATION_STATUS.COMPLETED ||
-            existing.status === WORK_OBLIGATION_STATUS.CANCELLED)
-        ) {
+        if (changesOwnerOfClosedObligation(body, existing)) {
           return { status: "closed_owner_change" as const };
         }
 
@@ -157,39 +217,13 @@ const updateWorkObligation = createSafeHandler(
           }
         }
 
-        const nextWorkingTargetDate =
-          body.workingTargetDate === undefined
-            ? existing.workingTargetDate
-            : body.workingTargetDate;
-        const nextHardDeadlineDate =
-          body.hardDeadlineDate === undefined
-            ? existing.hardDeadlineDate
-            : body.hardDeadlineDate;
-
-        if (
-          nextWorkingTargetDate !== null &&
-          nextHardDeadlineDate !== null &&
-          nextWorkingTargetDate > nextHardDeadlineDate
-        ) {
-          return { status: "target_after_deadline" as const };
-        }
-
-        if (
-          body.ownerUserId !== undefined &&
-          existing.ownerUserId !== null &&
-          body.ownerUserId !== existing.ownerUserId &&
-          !reason
-        ) {
-          return { status: "delegation_reason_required" as const };
-        }
-
-        if (
-          body.hardDeadlineDate !== undefined &&
-          existing.hardDeadlineDate !== null &&
-          body.hardDeadlineDate !== existing.hardDeadlineDate &&
-          !reason
-        ) {
-          return { status: "deadline_reason_required" as const };
+        const transitionViolation = workObligationTransitionViolation({
+          body,
+          existing,
+          reason,
+        });
+        if (transitionViolation !== null) {
+          return { status: transitionViolation };
         }
 
         const now = new Date();

--- a/apps/api/src/lib/audit-log.ts
+++ b/apps/api/src/lib/audit-log.ts
@@ -1,5 +1,3 @@
-import { panic } from "better-result";
-
 import type { Transaction } from "@/api/db/root";
 import type {
   AUDIT_ACTIVITY_CATEGORIES,
@@ -174,97 +172,105 @@ const executionColumns = (
   };
 };
 
+const entityActivityCategory = (event: AuditEvent): AuditActivityCategory => {
+  const createdEntity = event.changes?.["created"]?.new;
+  const createdKind =
+    typeof createdEntity === "object" &&
+    createdEntity !== null &&
+    "kind" in createdEntity
+      ? createdEntity.kind
+      : null;
+  const deletedEntity = event.changes?.["deleted"]?.old;
+  const deletedKind =
+    typeof deletedEntity === "object" &&
+    deletedEntity !== null &&
+    "kind" in deletedEntity
+      ? deletedEntity.kind
+      : null;
+  return event.metadata?.["kind"] === "task" ||
+    createdKind === "task" ||
+    deletedKind === "task"
+    ? "tasks"
+    : "documents";
+};
+
+const taskOrDocumentActivityCategory = (
+  event: AuditEvent,
+): AuditActivityCategory =>
+  event.metadata?.["kind"] === "task" ? "tasks" : "documents";
+
+const playbookActivityCategory = (event: AuditEvent): AuditActivityCategory =>
+  event.action === AUDIT_ACTION.EXECUTE ? "automation" : "other";
+
+const workspaceActivityCategory = (event: AuditEvent): AuditActivityCategory =>
+  event.changes?.["membersAdded"] !== undefined ||
+  event.changes?.["membersRemoved"] !== undefined
+    ? "team"
+    : "matter";
+
+type AuditActivityCategoryResolver =
+  | AuditActivityCategory
+  | ((event: AuditEvent) => AuditActivityCategory);
+
+const AUDIT_ACTIVITY_CATEGORY_BY_RESOURCE_TYPE = {
+  entity: entityActivityCategory,
+  field: taskOrDocumentActivityCategory,
+  entity_version: taskOrDocumentActivityCategory,
+  work_obligation: "tasks",
+  user_file: "documents",
+  workspace_member: "team",
+  workspace_contact: "team",
+  case_law_matter_link: "court",
+  case_law_decision_annotation: "court",
+  bilingual_translation_run: "automation",
+  document_translation_run: "automation",
+  document_review_run: "automation",
+  flow_run: "automation",
+  playbook: playbookActivityCategory,
+  workspace: workspaceActivityCategory,
+  audit_log: "other",
+  agent_skill: "other",
+  ai_memory: "other",
+  billing_code: "other",
+  chat_file: "other",
+  chat_message: "other",
+  chat_thread: "other",
+  clause: "other",
+  clause_category: "other",
+  clause_template_link: "other",
+  clause_variant: "other",
+  contact: "other",
+  contact_directory: "other",
+  document_type: "other",
+  usage_allocation: "other",
+  usage_entitlement: "other",
+  usage_event: "other",
+  desktop_edit_session: "other",
+  expense: "other",
+  flow_definition: "other",
+  folio_collab_session: "other",
+  invoice: "other",
+  machine_api_key: "other",
+  legal_list: "other",
+  legal_list_generation: "other",
+  legal_list_item: "other",
+  mcp_gateway_tool: "other",
+  organization_settings: "other",
+  property: "other",
+  rate_entry: "other",
+  report_export: "other",
+  rate_table: "other",
+  saved_search: "other",
+  style_set: "other",
+  template: "other",
+  time_entry: "other",
+  view: "other",
+  view_template: "other",
+} as const satisfies Record<AuditResourceType, AuditActivityCategoryResolver>;
+
 const activityCategoryForEvent = (event: AuditEvent): AuditActivityCategory => {
-  switch (event.resourceType) {
-    case "entity": {
-      const createdEntity = event.changes?.["created"]?.new;
-      const createdKind =
-        typeof createdEntity === "object" &&
-        createdEntity !== null &&
-        "kind" in createdEntity
-          ? createdEntity.kind
-          : null;
-      const deletedEntity = event.changes?.["deleted"]?.old;
-      const deletedKind =
-        typeof deletedEntity === "object" &&
-        deletedEntity !== null &&
-        "kind" in deletedEntity
-          ? deletedEntity.kind
-          : null;
-      return event.metadata?.["kind"] === "task" ||
-        createdKind === "task" ||
-        deletedKind === "task"
-        ? "tasks"
-        : "documents";
-    }
-    case "field":
-      return event.metadata?.["kind"] === "task" ? "tasks" : "documents";
-    case "entity_version":
-      return event.metadata?.["kind"] === "task" ? "tasks" : "documents";
-    case "work_obligation":
-      return "tasks";
-    case "user_file":
-      return "documents";
-    case "workspace_member":
-    case "workspace_contact":
-      return "team";
-    case "case_law_matter_link":
-    case "case_law_decision_annotation":
-      return "court";
-    case "bilingual_translation_run":
-    case "document_translation_run":
-    case "document_review_run":
-    case "flow_run":
-      return "automation";
-    case "playbook":
-      return event.action === AUDIT_ACTION.EXECUTE ? "automation" : "other";
-    case "workspace":
-      return event.changes?.["membersAdded"] !== undefined ||
-        event.changes?.["membersRemoved"] !== undefined
-        ? "team"
-        : "matter";
-    case "audit_log":
-    case "agent_skill":
-    case "ai_memory":
-    case "billing_code":
-    case "chat_file":
-    case "chat_message":
-    case "chat_thread":
-    case "clause":
-    case "clause_category":
-    case "clause_template_link":
-    case "clause_variant":
-    case "contact":
-    case "contact_directory":
-    case "document_type":
-    case "usage_allocation":
-    case "usage_entitlement":
-    case "usage_event":
-    case "desktop_edit_session":
-    case "expense":
-    case "flow_definition":
-    case "folio_collab_session":
-    case "invoice":
-    case "machine_api_key":
-    case "legal_list":
-    case "legal_list_generation":
-    case "legal_list_item":
-    case "mcp_gateway_tool":
-    case "organization_settings":
-    case "property":
-    case "rate_entry":
-    case "report_export":
-    case "rate_table":
-    case "saved_search":
-    case "style_set":
-    case "template":
-    case "time_entry":
-    case "view":
-    case "view_template":
-      return "other";
-    default:
-      return panic("Unsupported audit resource type");
-  }
+  const resolver = AUDIT_ACTIVITY_CATEGORY_BY_RESOURCE_TYPE[event.resourceType];
+  return typeof resolver === "function" ? resolver(event) : resolver;
 };
 
 const runIdForEvent = (

--- a/apps/api/src/lib/docx/discover-template.ts
+++ b/apps/api/src/lib/docx/discover-template.ts
@@ -391,38 +391,22 @@ const buildConditionMapFromRanges = (
   return map;
 };
 
-/**
- * Analyze a container element (w:body, w:hdr, or w:ftr) to
- * extract field information from its paragraphs.
- */
-const analyzeContainer = (
-  body: slimdom.Element,
-): {
+type AnalysisResult = {
   fields: FieldAccumulator;
   errors: TemplateStructureError[];
   placeholderCounts: Map<string, number>;
-  /** Map of placeholder path to its visibleWhen expr. */
   fieldConditions: Map<string, string | null>;
-} => {
-  const fields: FieldAccumulator = new Map();
-  const placeholderCounts = new Map<string, number>();
-  const errors: TemplateStructureError[] = [];
-  // Track per-field condition. `null` means the field
-  // appears outside any conditional (always visible).
-  const fieldConditions = new Map<string, string | null>();
+};
 
+const collectContainerStructure = (
+  body: slimdom.Element,
+  fields: FieldAccumulator,
+  errors: TemplateStructureError[],
+) => {
   const paragraphs = body.getElementsByTagNameNS(W_NS, "p");
-
-  // 1. Scan block directives for structural fields
   const directives = scanBlockDirectives(body);
   const { blocks, errors: parseErrors } = parseBlockTree(directives);
   errors.push(...parseErrors);
-
-  // Retain the full directive stream instead of relying on the flattened
-  // block result: nested blocks are intentionally consumed by parseBlockTree.
-  // The active loop path makes an unqualified condition available both as a
-  // global input and as a row-local input, matching the fill evaluator's
-  // global context overlaid with each row.
   const arrayScopes = new Map<number, readonly RowScope[]>();
   const activeArrays: RowScope[] = [];
   const directiveByParagraph = new Map(
@@ -453,61 +437,74 @@ const analyzeContainer = (
     }
     arrayScopes.set(i, [...activeArrays]);
   }
-
-  // Track which paragraph indices are directives (skip for
-  // placeholder scanning)
   const directiveIndices = new Set<number>();
   for (const d of directives) {
     directiveIndices.add(d.paragraphIndex);
   }
 
-  // Build paragraph → condition map from directives
-  const conditionMap = buildConditionMapFromRanges(
-    directives,
-    paragraphs.length,
-  );
+  return {
+    arrayScopes,
+    blocks,
+    conditionMap: buildConditionMapFromRanges(directives, paragraphs.length),
+    directiveIndices,
+    paragraphs,
+  };
+};
 
-  // 2. Analyze blocks for field types
+const collectLoopItemFields = ({
+  arrayScopes,
+  blocks,
+  directiveIndices,
+  fields,
+  paragraphs,
+}: ReturnType<typeof collectContainerStructure> & {
+  fields: FieldAccumulator;
+}): void => {
   for (const block of blocks) {
-    if (block.kind === "each") {
-      const blockScope = requireRowScopes(
-        arrayScopes,
-        block.contentStart - 1,
-      ).at(-1);
-      if (blockScope === undefined) {
-        panic(`Missing loop scope for block ${block.arrayPath}`);
+    if (block.kind !== "each") {
+      continue;
+    }
+    const blockScope = requireRowScopes(arrayScopes, block.contentStart - 1).at(
+      -1,
+    );
+    if (blockScope === undefined) {
+      panic(`Missing loop scope for block ${block.arrayPath}`);
+    }
+    const arrayPath = blockScope.scopedPath;
+    registerField(fields, arrayPath, "array");
+
+    const entry = fields.get(arrayPath);
+    for (let i = block.contentStart; i < block.contentEnd; i++) {
+      const para = paragraphs[i];
+      if (!para) {
+        break;
       }
-      const arrayPath = blockScope.scopedPath;
-      registerField(fields, arrayPath, "array");
+      if (directiveIndices.has(i)) {
+        continue;
+      }
 
-      // Scan content paragraphs for item field references
-      const entry = fields.get(arrayPath);
-      for (let i = block.contentStart; i < block.contentEnd; i++) {
-        const para = paragraphs[i];
-        if (!para) {
-          break;
-        }
-        if (directiveIndices.has(i)) {
-          continue;
-        }
-
-        const text = paragraphText(para);
-        const prefix = `${block.arrayPath}.`;
-        for (const match of text.matchAll(PLACEHOLDER_RE)) {
-          const name = match.groups?.["name"];
-          if (!name) {
-            continue;
-          }
-          if (name.startsWith(prefix)) {
-            const itemField = name.slice(prefix.length);
-            entry?.itemPaths.add(itemField);
-          }
+      const text = paragraphText(para);
+      const prefix = `${block.arrayPath}.`;
+      for (const match of text.matchAll(PLACEHOLDER_RE)) {
+        const name = match.groups?.["name"];
+        if (name?.startsWith(prefix)) {
+          entry?.itemPaths.add(name.slice(prefix.length));
         }
       }
     }
   }
+};
 
-  // 3. Scan all non-directive paragraphs for placeholders
+const collectParagraphPlaceholders = ({
+  arrayScopes,
+  conditionMap,
+  directiveIndices,
+  errors,
+  fieldConditions,
+  fields,
+  paragraphs,
+  placeholderCounts,
+}: ReturnType<typeof collectContainerStructure> & AnalysisResult): void => {
   for (let i = 0; i < paragraphs.length; i++) {
     if (directiveIndices.has(i)) {
       continue;
@@ -655,18 +652,31 @@ const analyzeContainer = (
       }
     }
   }
+};
+
+/**
+ * Analyze a container element (w:body, w:hdr, or w:ftr) to
+ * extract field information from its paragraphs.
+ */
+const analyzeContainer = (body: slimdom.Element): AnalysisResult => {
+  const fields: FieldAccumulator = new Map();
+  const placeholderCounts = new Map<string, number>();
+  const errors: TemplateStructureError[] = [];
+  const fieldConditions = new Map<string, string | null>();
+  const structure = collectContainerStructure(body, fields, errors);
+  collectLoopItemFields({ ...structure, fields });
+  collectParagraphPlaceholders({
+    ...structure,
+    errors,
+    fieldConditions,
+    fields,
+    placeholderCounts,
+  });
 
   return { fields, errors, placeholderCounts, fieldConditions };
 };
 
 // ── Merge helpers ────────────────────────────────────────
-
-type AnalysisResult = {
-  fields: FieldAccumulator;
-  errors: TemplateStructureError[];
-  placeholderCounts: Map<string, number>;
-  fieldConditions: Map<string, string | null>;
-};
 
 /**
  * Merge fields from a secondary container (header/footer)

--- a/apps/api/src/lib/docx/template-manifest.ts
+++ b/apps/api/src/lib/docx/template-manifest.ts
@@ -438,28 +438,25 @@ const parseFieldSource = (el: slimdom.Element): FieldSource | null => {
   }
 };
 
-const parseFieldMeta = (el: slimdom.Element): FieldMeta => {
-  const path = el.getAttribute("path") ?? "";
-  const label = el.getAttribute("label") ?? undefined;
-  const rawInputType = el.getAttribute("inputType");
-  const inputType =
-    rawInputType && isInputType(rawInputType) ? rawInputType : undefined;
-  const requiredAttr = el.getAttribute("required");
-  const required = requiredAttr !== null ? requiredAttr === "true" : undefined;
-
-  const field: FieldMeta = { path };
-  if (label !== undefined) {
+const applyStandardFieldAttributes = (
+  field: FieldMeta,
+  el: slimdom.Element,
+): void => {
+  const label = el.getAttribute("label");
+  if (label !== null) {
     field.label = label;
   }
   const hint = el.getAttribute("hint");
   if (hint !== null) {
     field.hint = hint;
   }
-  if (inputType) {
+  const inputType = el.getAttribute("inputType");
+  if (inputType !== null && isInputType(inputType)) {
     field.inputType = inputType;
   }
-  if (required !== undefined) {
-    field.required = required;
+  const required = el.getAttribute("required");
+  if (required !== null) {
+    field.required = required === "true";
   }
   const aiPrompt = el.getAttribute("aiPrompt");
   if (aiPrompt !== null) {
@@ -473,107 +470,102 @@ const parseFieldMeta = (el: slimdom.Element): FieldMeta => {
   if (aiSeesDocument !== null) {
     field.aiSeesDocument = aiSeesDocument === "true";
   }
-  // A hand-edited value outside the field-path grammar is dropped so the
-  // isFieldMeta invariant holds downstream.
   const optionsFrom = el.getAttribute("optionsFrom");
   if (optionsFrom !== null && isFieldPath(optionsFrom)) {
     field.optionsFrom = optionsFrom;
   }
 
-  // Parse options
   const optionsEl = getFirstElementChild(el, "options");
-  if (optionsEl) {
-    const optionEls = getElementChildren(optionsEl, "option");
-    const options = optionEls
-      .map((o) => o.getAttribute("value"))
-      .filter((v): v is string => v !== null);
-    if (options.length > 0) {
-      field.options = options;
+  if (!optionsEl) {
+    return;
+  }
+  const options = getElementChildren(optionsEl, "option")
+    .map((option) => option.getAttribute("value"))
+    .filter((value): value is string => value !== null);
+  if (options.length > 0) {
+    field.options = options;
+  }
+};
+
+const parseFieldValidation = (
+  validationEl: slimdom.Element | null,
+): FieldValidation | undefined => {
+  if (!validationEl) {
+    return undefined;
+  }
+  const validation: FieldValidation = {};
+  const required = validationEl.getAttribute("required");
+  if (required !== null) {
+    validation.required = required === "true";
+  }
+  const numberAttributes = [
+    ["minLength", "minLength"],
+    ["maxLength", "maxLength"],
+    ["minItems", "minItems"],
+    ["maxItems", "maxItems"],
+  ] as const;
+  for (const [attribute, property] of numberAttributes) {
+    const value = validationEl.getAttribute(attribute);
+    if (value === null) {
+      continue;
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      validation[property] = parsed;
     }
   }
+  const pattern = validationEl.getAttribute("pattern");
+  if (pattern !== null) {
+    validation.pattern = pattern;
+  }
+  return Object.keys(validation).length > 0 ? validation : undefined;
+};
 
-  // Parse validation
-  const validationEl = getFirstElementChild(el, "validation");
-  if (validationEl) {
-    const validation: FieldValidation = {};
-    const vRequired = validationEl.getAttribute("required");
-    if (vRequired !== null) {
-      validation.required = vRequired === "true";
-    }
-    const minLen = validationEl.getAttribute("minLength");
-    if (minLen !== null) {
-      const parsed = Number.parseInt(minLen, 10);
-      if (Number.isFinite(parsed)) {
-        validation.minLength = parsed;
-      }
-    }
-    const maxLen = validationEl.getAttribute("maxLength");
-    if (maxLen !== null) {
-      const parsed = Number.parseInt(maxLen, 10);
-      if (Number.isFinite(parsed)) {
-        validation.maxLength = parsed;
-      }
-    }
-    const pattern = validationEl.getAttribute("pattern");
-    if (pattern !== null) {
-      validation.pattern = pattern;
-    }
-    const minItems = validationEl.getAttribute("minItems");
-    if (minItems !== null) {
-      const parsed = Number.parseInt(minItems, 10);
-      if (Number.isFinite(parsed)) {
-        validation.minItems = parsed;
-      }
-    }
-    const maxItems = validationEl.getAttribute("maxItems");
-    if (maxItems !== null) {
-      const parsed = Number.parseInt(maxItems, 10);
-      if (Number.isFinite(parsed)) {
-        validation.maxItems = parsed;
-      }
-    }
-    if (Object.keys(validation).length > 0) {
-      field.validation = validation;
+const parseFieldLookup = (
+  lookupEl: slimdom.Element | null,
+): FieldMeta["lookup"] | undefined => {
+  if (!lookupEl) {
+    return undefined;
+  }
+  const registry = lookupEl.getAttribute("registry");
+  if (registry === null || !isLookupRegistry(registry)) {
+    return undefined;
+  }
+  const formatsEl = getFirstElementChild(lookupEl, "lookupFormats");
+  if (!formatsEl) {
+    return undefined;
+  }
+  const formats: FieldLookupFormat[] = [];
+  for (const formatEl of getElementChildren(formatsEl, "lookupFormat")) {
+    const key = formatEl.getAttribute("key");
+    const template = formatEl.getAttribute("template");
+    if (
+      key !== null &&
+      isLookupFormatKey(key) &&
+      template !== null &&
+      template.length <= LOOKUP_FORMAT_TEMPLATE_MAX_LENGTH
+    ) {
+      formats.push({ key, template });
     }
   }
+  return formats.length > 0
+    ? { registry, formats: formats.slice(0, LOOKUP_FORMATS_MAX) }
+    : undefined;
+};
 
-  // A hand-edited registry outside the supported set is dropped so the
-  // isFieldMeta invariant holds downstream.
-  const lookupEl = getFirstElementChild(el, "lookup");
-  if (lookupEl) {
-    const registry = lookupEl.getAttribute("registry");
-    if (registry !== null && isLookupRegistry(registry)) {
-      // Output formats round-trip nested under the lookup element; the first
-      // child is the default for the bare marker. A hand-edited key outside the
-      // segment grammar or an over-long template is dropped, and a lookup with
-      // no valid format is itself dropped so the isFieldLookup invariant holds.
-      const formats: FieldLookupFormat[] = [];
-      const formatsEl = getFirstElementChild(lookupEl, "lookupFormats");
-      if (formatsEl) {
-        for (const formatEl of getElementChildren(formatsEl, "lookupFormat")) {
-          const key = formatEl.getAttribute("key");
-          const template = formatEl.getAttribute("template");
-          if (
-            key !== null &&
-            isLookupFormatKey(key) &&
-            template !== null &&
-            template.length <= LOOKUP_FORMAT_TEMPLATE_MAX_LENGTH
-          ) {
-            formats.push({ key, template });
-          }
-        }
-      }
-      if (formats.length > 0) {
-        field.lookup = {
-          registry,
-          formats: formats.slice(0, LOOKUP_FORMATS_MAX),
-        };
-      }
-    }
-  }
+const hasDerivedValueSource = (field: FieldMeta): boolean =>
+  field.formula !== undefined ||
+  field.condition !== undefined ||
+  field.conditionAst !== undefined ||
+  field.aiPrompt !== undefined ||
+  field.aiAdapt !== undefined ||
+  field.lookup !== undefined ||
+  field.parts !== undefined;
 
-  // A hand-edited locale that is not a plausible BCP-47 tag (or an unknown
-  // style) is dropped so the isFieldMeta invariant holds downstream.
+const applyDerivedFieldAttributes = (
+  field: FieldMeta,
+  el: slimdom.Element,
+): void => {
   const dateFormatEl = getFirstElementChild(el, "dateFormat");
   if (dateFormatEl) {
     const candidate = {
@@ -585,86 +577,61 @@ const parseFieldMeta = (el: slimdom.Element): FieldMeta => {
     }
   }
 
-  // parts + format round-trip together; a half-shape (hand-edited XML) is
-  // dropped so the "both present or both absent" invariant holds downstream.
   const format = el.getAttribute("format");
   const partsEl = getFirstElementChild(el, "parts");
-  const parts =
-    partsEl === null
-      ? []
-      : getElementChildren(partsEl, "part")
-          .map(parseFieldPart)
-          .filter((part): part is FieldPart => part !== null);
+  const parts = partsEl
+    ? getElementChildren(partsEl, "part")
+        .map(parseFieldPart)
+        .filter((part): part is FieldPart => part !== null)
+    : [];
   if (format !== null && parts.length > 0) {
     field.parts = parts;
     field.format = format;
   }
 
-  // A formula field's value is derived, never user-entered; a hand-edited
-  // formula on a field that already has another value source (AI prompt or
-  // adapt, lookup, composite parts) is dropped so the isFieldMeta invariant
-  // holds downstream.
   const formula = el.getAttribute("formula");
-  if (
-    formula !== null &&
-    field.aiPrompt === undefined &&
-    field.aiAdapt === undefined &&
-    field.lookup === undefined &&
-    field.parts === undefined
-  ) {
+  if (formula !== null && !hasDerivedValueSource(field)) {
     field.formula = formula;
   }
-
   const conditionAst = parseConditionAst({
     version: el.getAttribute("conditionAstVersion"),
     value: el.getAttribute("conditionAst"),
   });
-  if (
-    conditionAst !== undefined &&
-    field.formula === undefined &&
-    field.aiPrompt === undefined &&
-    field.aiAdapt === undefined &&
-    field.lookup === undefined &&
-    field.parts === undefined
-  ) {
+  if (conditionAst !== undefined && !hasDerivedValueSource(field)) {
     field.conditionAst = conditionAst;
   }
-
-  // A condition field is a boolean derived by rule; like a formula it cannot
-  // coexist with another value source. A hand-edited condition on a field that
-  // already has one is dropped so the isFieldMeta invariant holds downstream.
   const condition = el.getAttribute("condition");
-  if (
-    condition !== null &&
-    field.conditionAst === undefined &&
-    field.formula === undefined &&
-    field.aiPrompt === undefined &&
-    field.aiAdapt === undefined &&
-    field.lookup === undefined &&
-    field.parts === undefined
-  ) {
+  if (condition !== null && !hasDerivedValueSource(field)) {
     field.condition = condition;
   }
-
-  // A data binding is a derived value; a hand-edited source on a field that
-  // already carries another value source is dropped so the isFieldMeta
-  // invariant holds downstream.
   const sourceEl = getFirstElementChild(el, "source");
-  if (
-    sourceEl &&
-    field.formula === undefined &&
-    field.condition === undefined &&
-    field.conditionAst === undefined &&
-    field.aiPrompt === undefined &&
-    field.aiAdapt === undefined &&
-    field.lookup === undefined &&
-    field.parts === undefined
-  ) {
-    const source = parseFieldSource(sourceEl);
-    if (source !== null) {
-      field.source = source;
-    }
+  if (!sourceEl || hasDerivedValueSource(field)) {
+    return;
   }
+  const source = parseFieldSource(sourceEl);
+  if (source !== null) {
+    field.source = source;
+  }
+};
+
+const parseFieldMeta = (el: slimdom.Element): FieldMeta => {
+  const path = el.getAttribute("path") ?? "";
+  const field: FieldMeta = { path };
+  applyStandardFieldAttributes(field, el);
+  const validation = parseFieldValidation(
+    getFirstElementChild(el, "validation"),
+  );
+  if (validation !== undefined) {
+    field.validation = validation;
+  }
+
+  // A hand-edited registry outside the supported set is dropped so the
+  // isFieldMeta invariant holds downstream.
+  const lookup = parseFieldLookup(getFirstElementChild(el, "lookup"));
+  if (lookup !== undefined) {
+    field.lookup = lookup;
+  }
+  applyDerivedFieldAttributes(field, el);
 
   return field;
 };

--- a/apps/api/src/mcp/document-tools.ts
+++ b/apps/api/src/mcp/document-tools.ts
@@ -1445,130 +1445,139 @@ const loadDocumentProcessingStates = async ({
     }).success &&
     context.grantedScopes.includes("stella:matters_write");
 
-  let contentState: DocumentContentState;
-  if (
-    !sourceFile.encrypted &&
-    sourceFile.mimeType === DOCX_MIME_TYPE &&
-    currentExtracted === null &&
-    nativeRun?.status === "failed" &&
-    nativeRun.errorCode !== "search_index_failed"
-  ) {
-    contentState = {
-      status: "failed",
-      processingKind: DOCUMENT_PROCESSING_KIND,
-      runId: nativeRun.id,
-      sourceVersionId: current.currentVersionId,
-      errorCode: DOCUMENT_PROCESSING_FAILURE_CODE,
-      retryable: true,
-    };
-  } else if (!sourceFile.encrypted && sourceFile.mimeType === DOCX_MIME_TYPE) {
-    contentState = {
-      status: "ready",
-      source: "direct_docx",
-      sourceVersionId: current.currentVersionId,
-      updatedAt: current.currentVersionCreatedAt.toISOString(),
-    };
-  } else if (currentExtracted && currentExtracted.charCount > 0) {
-    contentState = {
-      status: "ready",
-      source: "extracted_text",
-      sourceVersionId: current.currentVersionId,
-      updatedAt: currentExtracted.extractedAt.toISOString(),
-    };
-  } else if (
-    ocrRun?.status === "failed" &&
-    ocrRun.errorCode !== "search_index_failed"
-  ) {
-    contentState = {
-      status: "failed",
-      processingKind: DOCUMENT_PROCESSING_KIND,
-      runId: ocrRun.id,
-      sourceVersionId: current.currentVersionId,
-      errorCode: DOCUMENT_PROCESSING_FAILURE_CODE,
-      retryable: true,
-    };
-  } else if (ocrRun?.status === "queued" || ocrRun?.status === "running") {
-    contentState = {
-      status: "pending",
-      processingKind: DOCUMENT_PROCESSING_KIND,
-      runId: ocrRun.id,
-      sourceVersionId: current.currentVersionId,
-    };
-  } else if (
-    ocrRun?.status === "cancelled" &&
-    ocrRun.errorCode === "workspace_unavailable"
-  ) {
-    contentState = {
-      status: "unsupported",
-      sourceVersionId: current.currentVersionId,
-      reason:
-        "Document processing is unavailable while the matter is not active.",
-    };
-  } else if (
-    currentExtracted?.charCount === 0 &&
-    (ocrRun === undefined || ocrTerminalCancellation) &&
-    extractionMimeType === PDF_MIME_TYPE &&
-    (settings?.documentProcessingMode ?? DEFAULT_DOCUMENT_PROCESSING_MODE) ===
-      "off"
-  ) {
-    contentState = {
-      status: DOCUMENT_PROCESSING_REQUIRED_STATUS,
-      sourceVersionId: current.currentVersionId,
-      remediation: canQueueManualOcr
-        ? {
-            type: "action",
-            tool: "invoke_capability",
-            arguments: {
-              capability: "entities.ocr.create",
-              input: {
-                params: { workspaceId, entityId },
-                body: {
-                  // A source file is present in this branch by construction.
-                  fieldId:
-                    sourceFieldId ??
-                    panic("OCR remediation requires a source field"),
+  const resolveContentState = (): DocumentContentState => {
+    if (
+      !sourceFile.encrypted &&
+      sourceFile.mimeType === DOCX_MIME_TYPE &&
+      currentExtracted === null &&
+      nativeRun?.status === "failed" &&
+      nativeRun.errorCode !== "search_index_failed"
+    ) {
+      return {
+        status: "failed",
+        processingKind: DOCUMENT_PROCESSING_KIND,
+        runId: nativeRun.id,
+        sourceVersionId: current.currentVersionId,
+        errorCode: DOCUMENT_PROCESSING_FAILURE_CODE,
+        retryable: true,
+      };
+    }
+    if (!sourceFile.encrypted && sourceFile.mimeType === DOCX_MIME_TYPE) {
+      return {
+        status: "ready",
+        source: "direct_docx",
+        sourceVersionId: current.currentVersionId,
+        updatedAt: current.currentVersionCreatedAt.toISOString(),
+      };
+    }
+    if (currentExtracted && currentExtracted.charCount > 0) {
+      return {
+        status: "ready",
+        source: "extracted_text",
+        sourceVersionId: current.currentVersionId,
+        updatedAt: currentExtracted.extractedAt.toISOString(),
+      };
+    }
+    if (
+      ocrRun?.status === "failed" &&
+      ocrRun.errorCode !== "search_index_failed"
+    ) {
+      return {
+        status: "failed",
+        processingKind: DOCUMENT_PROCESSING_KIND,
+        runId: ocrRun.id,
+        sourceVersionId: current.currentVersionId,
+        errorCode: DOCUMENT_PROCESSING_FAILURE_CODE,
+        retryable: true,
+      };
+    }
+    if (ocrRun?.status === "queued" || ocrRun?.status === "running") {
+      return {
+        status: "pending",
+        processingKind: DOCUMENT_PROCESSING_KIND,
+        runId: ocrRun.id,
+        sourceVersionId: current.currentVersionId,
+      };
+    }
+    if (
+      ocrRun?.status === "cancelled" &&
+      ocrRun.errorCode === "workspace_unavailable"
+    ) {
+      return {
+        status: "unsupported",
+        sourceVersionId: current.currentVersionId,
+        reason:
+          "Document processing is unavailable while the matter is not active.",
+      };
+    }
+    if (
+      currentExtracted?.charCount === 0 &&
+      (ocrRun === undefined || ocrTerminalCancellation) &&
+      extractionMimeType === PDF_MIME_TYPE &&
+      (settings?.documentProcessingMode ?? DEFAULT_DOCUMENT_PROCESSING_MODE) ===
+        "off"
+    ) {
+      return {
+        status: DOCUMENT_PROCESSING_REQUIRED_STATUS,
+        sourceVersionId: current.currentVersionId,
+        remediation: canQueueManualOcr
+          ? {
+              type: "action",
+              tool: "invoke_capability",
+              arguments: {
+                capability: "entities.ocr.create",
+                input: {
+                  params: { workspaceId, entityId },
+                  body: {
+                    fieldId:
+                      sourceFieldId ??
+                      panic("OCR remediation requires a source field"),
+                  },
                 },
               },
+            }
+          : {
+              type: "escalation",
+              requiredScope: "stella:matters_write",
+              requiredPermission: "entity:update",
+              instruction:
+                "Ask a matter editor to start document processing for this field.",
             },
-          }
-        : {
-            type: "escalation",
-            requiredScope: "stella:matters_write",
-            requiredPermission: "entity:update",
-            instruction:
-              "Ask a matter editor to start document processing for this field.",
-          },
-    };
-  } else if (currentExtracted) {
-    contentState = {
-      status: "ready",
-      source: "extracted_text",
-      sourceVersionId: current.currentVersionId,
-      updatedAt: currentExtracted.extractedAt.toISOString(),
-    };
-  } else if (nativeRun?.status === "failed") {
-    contentState = {
-      status: "failed",
-      processingKind: DOCUMENT_PROCESSING_KIND,
-      runId: nativeRun.id,
-      sourceVersionId: current.currentVersionId,
-      errorCode: DOCUMENT_PROCESSING_FAILURE_CODE,
-      retryable: true,
-    };
-  } else if (sourceFile.encrypted) {
-    contentState = {
-      status: "unsupported",
-      sourceVersionId: current.currentVersionId,
-      reason: "Encrypted document content cannot be extracted.",
-    };
-  } else if (!extractionCanBecomeAvailable) {
-    contentState = {
-      status: "unsupported",
-      sourceVersionId: current.currentVersionId,
-      reason: `Content extraction is not supported for ${sourceFile.mimeType}.`,
-    };
-  } else {
-    contentState = {
+      };
+    }
+    if (currentExtracted) {
+      return {
+        status: "ready",
+        source: "extracted_text",
+        sourceVersionId: current.currentVersionId,
+        updatedAt: currentExtracted.extractedAt.toISOString(),
+      };
+    }
+    if (nativeRun?.status === "failed") {
+      return {
+        status: "failed",
+        processingKind: DOCUMENT_PROCESSING_KIND,
+        runId: nativeRun.id,
+        sourceVersionId: current.currentVersionId,
+        errorCode: DOCUMENT_PROCESSING_FAILURE_CODE,
+        retryable: true,
+      };
+    }
+    if (sourceFile.encrypted) {
+      return {
+        status: "unsupported",
+        sourceVersionId: current.currentVersionId,
+        reason: "Encrypted document content cannot be extracted.",
+      };
+    }
+    if (!extractionCanBecomeAvailable) {
+      return {
+        status: "unsupported",
+        sourceVersionId: current.currentVersionId,
+        reason: `Content extraction is not supported for ${sourceFile.mimeType}.`,
+      };
+    }
+    return {
       status: "pending",
       processingKind: DOCUMENT_PROCESSING_KIND,
       runId:
@@ -1577,40 +1586,40 @@ const loadDocumentProcessingStates = async ({
           : null,
       sourceVersionId: current.currentVersionId,
     };
-  }
+  };
 
-  let searchIndexState: DocumentSearchIndexState;
-  if (searchFailure) {
-    searchIndexState = {
-      status: "failed",
-      runId: searchFailure.id,
-      sourceVersionId: current.currentVersionId,
-      errorCode: "search_index_failed",
-      retryable: true,
-    };
-  } else {
+  const resolveSearchIndexState = (): DocumentSearchIndexState => {
+    if (searchFailure) {
+      return {
+        status: "failed",
+        runId: searchFailure.id,
+        sourceVersionId: current.currentVersionId,
+        errorCode: "search_index_failed",
+        retryable: true,
+      };
+    }
     const sourceRunCompleted = completedIndexRun !== undefined;
     const freshUntrackedProjection =
       latestIndexRun === undefined &&
       searchDocument !== undefined &&
       searchDocument.updatedAt >= current.currentVersionCreatedAt;
-
     if (searchDocument && (sourceRunCompleted || freshUntrackedProjection)) {
-      searchIndexState = {
+      return {
         status: "ready",
         sourceVersionId: current.currentVersionId,
         updatedAt: (
           completedIndexRun?.finishedAt ?? searchDocument.updatedAt
         ).toISOString(),
       };
-    } else {
-      searchIndexState = {
-        status: "pending",
-        sourceVersionId: current.currentVersionId,
-      };
     }
-  }
+    return {
+      status: "pending",
+      sourceVersionId: current.currentVersionId,
+    };
+  };
 
+  const contentState = resolveContentState();
+  const searchIndexState = resolveSearchIndexState();
   return { contentState, searchIndexState };
 };
 

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -21,7 +21,7 @@ import {
   useRef,
   useState,
 } from "react";
-import type { RefObject } from "react";
+import type { Dispatch, RefObject, SetStateAction } from "react";
 
 import {
   useQuery,
@@ -1107,6 +1107,164 @@ type FileChatOverlayInnerProps = Omit<FileChatOverlayProps, "chatThreadId"> & {
   ensureFileThreadPersisted?: (() => Promise<ChatThreadId>) | undefined;
 };
 
+const getFileChatThreadRef = (
+  chatThreadId: ChatThreadId,
+  workspaceId: string | undefined,
+): ChatThreadRef =>
+  workspaceId === undefined
+    ? { scope: "global", threadId: chatThreadId }
+    : {
+        scope: "workspace",
+        threadId: chatThreadId,
+        workspaceId,
+      };
+
+const useFileChatReviewState = ({
+  activeDraft,
+  activeFile,
+}: Pick<FileChatOverlayInnerProps, "activeDraft" | "activeFile">) => {
+  let reviewEntityId: string | undefined;
+  if (activeFile !== undefined) {
+    reviewEntityId = resolveFileReviewSessionId({
+      type: "file",
+      entityId: activeFile.entityId,
+    });
+  } else if (activeDraft !== undefined) {
+    reviewEntityId = resolveFileReviewSessionId({
+      type: "draft",
+      toolCallId: activeDraft.toolCallId,
+    });
+  } else {
+    reviewEntityId = resolveFileReviewSessionId({ type: "none" });
+  }
+  const hasPendingReview = useReviewStore((state) => {
+    if (reviewEntityId === undefined) {
+      return false;
+    }
+    return (
+      state.sessions[reviewEntityId]?.some(
+        (item) => item.status === "pending" || item.status === "applying",
+      ) === true
+    );
+  });
+  return { hasPendingReview, reviewEntityId };
+};
+
+const useFileChatDocxLifecycle = ({
+  activeDraft,
+  activeFile,
+  docxEditorRef,
+  editorReady,
+  hasDocxEditSurface,
+  setEditorReady,
+}: Pick<
+  FileChatOverlayInnerProps,
+  "activeDraft" | "activeFile" | "docxEditorRef"
+> & {
+  editorReady: boolean;
+  hasDocxEditSurface: boolean;
+  setEditorReady: Dispatch<SetStateAction<boolean>>;
+}) => {
+  const lastSentDocxEditSnapshotRef = useRef<FolioAIEditSnapshot | null>(null);
+  const activeDocumentKey = activeFile
+    ? `${activeFile.entityId}:${activeFile.fileFieldId ?? ""}`
+    : activeDraft?.toolCallId;
+  const [readyForDocumentKey, setReadyForDocumentKey] =
+    useState(activeDocumentKey);
+  if (activeDocumentKey !== readyForDocumentKey) {
+    setReadyForDocumentKey(activeDocumentKey);
+    setEditorReady(false);
+  }
+  useExternalSyncEffect(() => {
+    lastSentDocxEditSnapshotRef.current = null;
+    return undefined;
+  }, [activeDocumentKey]);
+  useExternalSyncEffect(() => {
+    if (editorReady || !hasDocxEditSurface) {
+      return undefined;
+    }
+    const ensure = () =>
+      docxEditorRef?.current?.ensureEditorView({ focus: false });
+    ensure();
+    const probe = () => {
+      if (docxEditorRef?.current?.createAIEditSnapshot()) {
+        setEditorReady(true);
+        return true;
+      }
+      return false;
+    };
+    if (probe()) {
+      return undefined;
+    }
+    const id = window.setInterval(() => {
+      ensure();
+      if (probe()) {
+        window.clearInterval(id);
+      }
+    }, 80);
+    const fallbackTimer = window.setTimeout(() => {
+      window.clearInterval(id);
+      setEditorReady(true);
+    }, 3000);
+    return () => {
+      window.clearInterval(id);
+      window.clearTimeout(fallbackTimer);
+    };
+  }, [editorReady, hasDocxEditSurface, docxEditorRef, setEditorReady]);
+  return { lastSentDocxEditSnapshotRef };
+};
+
+const useFileChatPlaceholder = ({
+  activeDraft,
+  activeExternal,
+  activeFile,
+  docxEditSafety,
+}: Pick<
+  FileChatOverlayInnerProps,
+  "activeDraft" | "activeExternal" | "activeFile" | "docxEditSafety"
+>) => {
+  const t = useTranslations();
+  if (activeDraft !== undefined) {
+    return {
+      placeholder: t("chat.editableFilePlaceholder", {
+        fileName: activeDraft.fileName,
+      }),
+      placeholderAction: t("chat.editableFilePlaceholderAction"),
+      sourceLabel: activeDraft.fileName,
+    };
+  }
+  if (activeFile !== undefined) {
+    const canOfferEdit =
+      activeFile.editable === true && docxEditSafety !== "unsafe";
+    return {
+      placeholder: t(
+        canOfferEdit ? "chat.editableFilePlaceholder" : "chat.filePlaceholder",
+        { fileName: activeFile.fileName },
+      ),
+      placeholderAction: t(
+        canOfferEdit
+          ? "chat.editableFilePlaceholderAction"
+          : "chat.filePlaceholderAction",
+      ),
+      sourceLabel: activeFile.fileName,
+    };
+  }
+  if (activeExternal !== undefined) {
+    return {
+      placeholder: t("chat.externalSourcePlaceholder", {
+        title: activeExternal.title,
+      }),
+      placeholderAction: t("chat.externalSourcePlaceholderAction"),
+      sourceLabel: activeExternal.title,
+    };
+  }
+  return {
+    placeholder: undefined,
+    placeholderAction: undefined,
+    sourceLabel: undefined,
+  };
+};
+
 const FileChatOverlayInner = ({
   workspaceId,
   chatThreadId,
@@ -1140,18 +1298,8 @@ const FileChatOverlayInner = ({
   const activeOrganizationId = useAuthenticatedUser().activeOrganizationId;
   const userContext = useChatUserContext();
   const getUserContext = useLatestCallback(() => userContext);
-  const threadRef = useMemo<ChatThreadRef>(
-    () =>
-      workspaceId === undefined
-        ? {
-            scope: "global",
-            threadId: chatThreadId,
-          }
-        : {
-            scope: "workspace",
-            threadId: chatThreadId,
-            workspaceId,
-          },
+  const threadRef = useMemo(
+    () => getFileChatThreadRef(chatThreadId, workspaceId),
     [chatThreadId, workspaceId],
   );
   // Per-send anonymization now reads the shared per-thread store keyed by
@@ -1177,7 +1325,6 @@ const FileChatOverlayInner = ({
   const getContextMatterIds = useLatestCallback(
     () => contextMatterIds ?? UNSEEDED_CONTEXT_MATTER_IDS,
   );
-  const lastSentDocxEditSnapshotRef = useRef<FolioAIEditSnapshot | null>(null);
   // Seeded with the shared empty constant instead of normalizing during
   // render (the initializer would rebuild and discard the value every
   // render); the layout effect below fills it before anything reads it.
@@ -1192,30 +1339,9 @@ const FileChatOverlayInner = ({
   // renders while any suggestion is pending/applying (mirrors the bar's own
   // `isPending` gate). When it is, the thread card lifts above the bar so the
   // two floating surfaces never overlap.
-  let reviewEntityId: string | undefined;
-  if (activeFile !== undefined) {
-    reviewEntityId = resolveFileReviewSessionId({
-      type: "file",
-      entityId: activeFile.entityId,
-    });
-  } else if (activeDraft !== undefined) {
-    reviewEntityId = resolveFileReviewSessionId({
-      type: "draft",
-      toolCallId: activeDraft.toolCallId,
-    });
-  } else {
-    reviewEntityId = resolveFileReviewSessionId({ type: "none" });
-  }
-  const hasPendingReview = useReviewStore((state) => {
-    if (reviewEntityId === undefined) {
-      return false;
-    }
-    const session = state.sessions[reviewEntityId];
-    return (
-      session?.some(
-        (item) => item.status === "pending" || item.status === "applying",
-      ) === true
-    );
+  const { hasPendingReview, reviewEntityId } = useFileChatReviewState({
+    activeDraft,
+    activeFile,
   });
   const editModeOptionId = useChatEditModeStore((state) => state.optionId);
   const setEditModeOptionId = useChatEditModeStore(
@@ -1252,10 +1378,6 @@ const FileChatOverlayInner = ({
   // Suspense swap unmounts + remounts this subtree with fresh state,
   // and the poller racing with a second rerender can leave the gate
   // stuck closed even though the underlying view is live).
-  // eslint-disable-next-line react/react-compiler -- mount-time seed of readiness from the imperative Folio editor instance so a transition-induced remount of an already-ready editor starts ready; the ref read runs once in the useState initializer
-  const [editorReady, setEditorReady] = useState(() =>
-    Boolean(docxEditorRef?.current?.createAIEditSnapshot()),
-  );
   // Reset readiness when the active file changes (the new doc has its
   // own mount cycle). Done during render rather than in an effect: the
   // editor now creates its hidden view synchronously inside
@@ -1268,61 +1390,18 @@ const FileChatOverlayInner = ({
   // hold several file fields, so an entity-only key would keep `editorReady`
   // true when switching to another file/version on the same entity and skip the
   // snapshot poll for the newly mounted editor.
-  const activeDocumentKey = activeFile
-    ? `${activeFile.entityId}:${activeFile.fileFieldId ?? ""}`
-    : activeDraft?.toolCallId;
-  const [readyForDocumentKey, setReadyForDocumentKey] =
-    useState(activeDocumentKey);
-  if (activeDocumentKey !== readyForDocumentKey) {
-    setReadyForDocumentKey(activeDocumentKey);
-    setEditorReady(false);
-  }
-  useExternalSyncEffect(() => {
-    lastSentDocxEditSnapshotRef.current = null;
-    return undefined;
-  }, [activeDocumentKey]);
-  useExternalSyncEffect(() => {
-    if (editorReady || !hasDocxEditSurface) {
-      return undefined;
-    }
-    const ensure = () =>
-      docxEditorRef.current?.ensureEditorView({ focus: false });
-    ensure();
-    const probe = () => {
-      if (docxEditorRef.current?.createAIEditSnapshot()) {
-        setEditorReady(true);
-        return true;
-      }
-      return false;
-    };
-    if (probe()) {
-      return undefined;
-    }
-    const id = window.setInterval(() => {
-      // Re-call ensure on each tick: when the surrounding tree is in
-      // a concurrent transition (e.g. right after the "new chat" swap),
-      // the first ensure can be coalesced away by React's batching.
-      // The state setter is a no-op once the view is already created.
-      ensure();
-      if (probe()) {
-        window.clearInterval(id);
-      }
-    }, 80);
-    // Safety net: never leave the chat input gated indefinitely. If the probe
-    // hasn't succeeded after a few seconds (e.g. an edge case where the
-    // virtualised paged editor hasn't surfaced a non-empty doc to
-    // `createAIEditSnapshot` yet), unlock the input anyway —
-    // `canSubmitWithCurrentDocxSnapshot` runs at submit time and re-checks
-    // the snapshot, so a stale unlock can't send unanchored edits.
-    const fallbackTimer = window.setTimeout(() => {
-      window.clearInterval(id);
-      setEditorReady(true);
-    }, 3000);
-    return () => {
-      window.clearInterval(id);
-      window.clearTimeout(fallbackTimer);
-    };
-  }, [editorReady, hasDocxEditSurface, docxEditorRef]);
+  // eslint-disable-next-line react/react-compiler -- mount-time seed of readiness from the imperative Folio editor instance so a transition-induced remount of an already-ready editor starts ready; the ref read runs once in the useState initializer
+  const [editorReady, setEditorReady] = useState(() =>
+    Boolean(docxEditorRef?.current?.createAIEditSnapshot()),
+  );
+  const { lastSentDocxEditSnapshotRef } = useFileChatDocxLifecycle({
+    activeDraft,
+    activeFile,
+    docxEditorRef,
+    editorReady,
+    hasDocxEditSurface,
+    setEditorReady,
+  });
 
   // Subscribe to the inspector chip's pulse channel so the bar
   // glows when the user clicks the AI-suggestions facet.
@@ -1650,36 +1729,16 @@ const FileChatOverlayInner = ({
     openIfAIUnavailable();
   }, [openIfAIUnavailable]);
 
-  let filePlaceholder: string | undefined;
-  let filePlaceholderAction: string | undefined;
-  if (activeDraft) {
-    filePlaceholder = t("chat.editableFilePlaceholder", {
-      fileName: activeDraft.fileName,
-    });
-    filePlaceholderAction = t("chat.editableFilePlaceholderAction");
-  } else if (activeFile === undefined) {
-    if (activeExternal) {
-      filePlaceholder = t("chat.externalSourcePlaceholder", {
-        title: activeExternal.title,
-      });
-      filePlaceholderAction = t("chat.externalSourcePlaceholderAction");
-    }
-  } else {
-    // Only offer "…or edit" when the file can actually be edited: editable in
-    // principle AND not blocked as unsafe-to-rewrite (view only). Otherwise the
-    // placeholder promises an edit the user can't make.
-    const canOfferEdit =
-      activeFile.editable === true && docxEditSafety !== "unsafe";
-    filePlaceholder = t(
-      canOfferEdit ? "chat.editableFilePlaceholder" : "chat.filePlaceholder",
-      { fileName: activeFile.fileName },
-    );
-    filePlaceholderAction = t(
-      canOfferEdit
-        ? "chat.editableFilePlaceholderAction"
-        : "chat.filePlaceholderAction",
-    );
-  }
+  const {
+    placeholder: filePlaceholder,
+    placeholderAction: filePlaceholderAction,
+    sourceLabel: filePlaceholderSourceLabel,
+  } = useFileChatPlaceholder({
+    activeDraft,
+    activeExternal,
+    activeFile,
+    docxEditSafety,
+  });
 
   // Check eligibility for suggested prompts using draft state (avoids
   // unnecessary API calls when user is typing).
@@ -2472,8 +2531,7 @@ const FileChatOverlayInner = ({
           reservedCommands={{ hasPersistedThread: hasMessages }}
           skillsOrganizationId={activeOrganizationId}
           emptyPlaceholder={
-            (activeFile || activeDraft || activeExternal) &&
-            filePlaceholderAction ? (
+            filePlaceholderAction !== undefined ? (
               <span
                 className={cn(
                   "text-foreground-ghost flex min-w-0 items-center gap-1.5",
@@ -2485,9 +2543,7 @@ const FileChatOverlayInner = ({
                   as="span"
                   className="text-foreground-label max-w-64 truncate"
                 >
-                  {activeFile?.fileName ??
-                    activeDraft?.fileName ??
-                    activeExternal?.title}
+                  {filePlaceholderSourceLabel}
                 </BidiText>
               </span>
             ) : undefined

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -655,39 +655,34 @@ export const PromptBar = (props: PromptBarProps) => {
     removeFile,
   } = editorController;
 
-  const isGenerating = status === "generating";
-  const busy = isGenerating || status === "applying";
-  const showBusyPlaceholder = shouldShowPromptBarBusyPlaceholder({
+  const {
+    busy,
+    composerActionMode,
+    composerSubmitDisabled,
+    inputDisabled,
+    isGenerating,
+    isSendBlocked,
+    retryOffer,
+    showBusyPlaceholder,
+  } = getPromptBarAvailability({
     isEmpty,
+    onRetry,
+    onStop,
     queueWhileGenerating,
+    sendDisabledReason,
     status,
   });
-  const isSendBlocked = sendDisabledReason !== undefined;
-  const inputDisabled = isSendBlocked;
-  const submitDisabled = busy || isSendBlocked;
   // With queuing enabled the composer keeps accepting input while a
   // response streams: `useChatSession` holds submitted drafts until the
   // turn finishes. The single action button still morphs to Stop while
   // generating (on every surface); sending mid-turn happens through
   // Enter/submit, which queues the draft — same behaviour as the main
   // chat, and structurally no second button can appear beside it.
-  const composerSubmitDisabled = queueWhileGenerating
-    ? status === "applying" || isSendBlocked
-    : submitDisabled;
   // After a stop the send arrow becomes Retry until the user starts
   // a new draft (the owner also clears `onRetry` then; the `isEmpty`
   // gate just avoids a one-render flash before that state lands).
   // Passing `undefined` otherwise keeps the offer out of the button's
   // state entirely, so it can never shadow Send while typing.
-  const retryOffer =
-    onRetry !== undefined && isEmpty && !busy && !isSendBlocked
-      ? onRetry
-      : undefined;
-  const composerActionMode = resolveChatComposerAction({
-    isGenerating,
-    onStop,
-    onRetry: retryOffer,
-  });
 
   // Glow on attention pulse — kicked from the inspector when the
   // user clicks the AI-suggestions chip so they see the bar light
@@ -1115,6 +1110,51 @@ export const PromptBar = (props: PromptBarProps) => {
       {...(dock === undefined ? {} : { dock })}
     />
   );
+};
+
+const getPromptBarAvailability = ({
+  isEmpty,
+  onRetry,
+  onStop,
+  queueWhileGenerating,
+  sendDisabledReason,
+  status,
+}: {
+  isEmpty: boolean;
+  onRetry: PromptBarProps["onRetry"];
+  onStop: PromptBarProps["onStop"];
+  queueWhileGenerating: boolean;
+  sendDisabledReason: PromptBarProps["sendDisabledReason"];
+  status: PromptBarProps["status"];
+}) => {
+  const isGenerating = status === "generating";
+  const busy = isGenerating || status === "applying";
+  const isSendBlocked = sendDisabledReason !== undefined;
+  const submitDisabled = busy || isSendBlocked;
+  const retryOffer =
+    onRetry !== undefined && isEmpty && !busy && !isSendBlocked
+      ? onRetry
+      : undefined;
+  return {
+    busy,
+    composerActionMode: resolveChatComposerAction({
+      isGenerating,
+      onStop,
+      onRetry: retryOffer,
+    }),
+    composerSubmitDisabled: queueWhileGenerating
+      ? status === "applying" || isSendBlocked
+      : submitDisabled,
+    inputDisabled: isSendBlocked,
+    isGenerating,
+    isSendBlocked,
+    retryOffer,
+    showBusyPlaceholder: shouldShowPromptBarBusyPlaceholder({
+      isEmpty,
+      queueWhileGenerating,
+      status,
+    }),
+  };
 };
 
 type SuggestionCardProps = {

--- a/apps/web/src/components/chat/tool-approval-card.tsx
+++ b/apps/web/src/components/chat/tool-approval-card.tsx
@@ -421,49 +421,28 @@ export const ToolApprovalCard = ({
   const submittedApprovalIdRef = useRef<string | null>(null);
   const [responded, setResponded] = useState(false);
 
-  const isApprovalRequested = part.state === "approval-requested";
-  const isApprovalResponded = part.state === "approval-responded";
-  const isStructuredEditFailure =
-    part.name === "edit_workspace_document" &&
-    part.state === "complete" &&
-    part.output !== undefined &&
-    !part.output.success;
-  const isApproved =
-    part.state === "complete" &&
-    part.output !== undefined &&
-    !isStructuredEditFailure;
-  const isDenied =
-    isStructuredEditFailure ||
-    (part.state === "approval-responded" && part.approval.approved === false);
-  const isProcessing =
-    isApprovalResponded || (responded && isApprovalRequested);
-  const isBlocked = blockedApprovalTools?.has(name) ?? false;
-  const isExternalMcpApproval = isExternalMcpToolName(name);
-  const showsExternalInput =
-    isExternalMcpApproval || isExternalInputChatToolName(name);
-  // High-impact writes may only be approved once or denied: no persistent
-  // grant can auto-approve a later call.
-  const isApprovalOnce = isApprovalOnceChatToolName(name);
-  const canAllowInConversation =
-    name !== "apply-active-docx-edits" &&
-    !isApprovalOnce &&
-    !isNonPersistentGrantChatToolName(name);
-  const canAlwaysAllow = canAllowInConversation;
-  const isPublicOfficialApproval = isPublicOfficialChatToolName(name);
-  /**
-   * DOCX edit batches always go to the side review panel — never
-   * gated by a chat-level Allow/Deny. The card collapses to a
-   * compact status and auto-approves once so the queueing
-   * handler can register the suggestions.
-   */
-  const isDocxEditBatch = name === "apply-active-docx-edits";
-  const externalMcpProviderName = getExternalMcpProviderName(name);
-  const label = externalMcpProviderName ?? t(getChatToolTitleKey(name));
-  const externalMcpConnectorSlug = getExternalMcpConnectorSlug(name);
-  const externalInput =
-    showsExternalInput && part.state !== "input-streaming"
-      ? getApprovalPartInput(part)
-      : undefined;
+  const {
+    canAllowInConversation,
+    canAlwaysAllow,
+    externalInput,
+    externalMcpConnectorSlug,
+    externalMcpProviderName,
+    isApprovalRequested,
+    isApproved,
+    isBlocked,
+    isDocxEditBatch,
+    isProcessing,
+    isPublicOfficialApproval,
+    isDenied,
+    label,
+    showsExternalInput,
+  } = getToolApprovalState({
+    blockedApprovalTools,
+    defaultLabel: t(getChatToolTitleKey(name)),
+    name,
+    part,
+    responded,
+  });
   const { data: mcpConnectorsData } = useQuery({
     ...mcpConnectorsOptions(activeOrganizationId),
     enabled: externalMcpConnectorSlug !== null,
@@ -515,44 +494,10 @@ export const ToolApprovalCard = ({
     return true;
   };
 
-  // Clicking a DOCX-edit-batch card jumps the user to the review
-  // facet for the entity those edits target. The output's `queued`
-  // ids are the same client-side suggestion ids the review store
-  // keys its session entries by, so we look up the entity by
-  // matching any of them.
-  const docxEditBatchOutput =
-    isDocxEditBatch &&
-    part.name === "apply-active-docx-edits" &&
-    part.state === "complete"
-      ? part.output
-      : undefined;
-  const queuedIds =
-    docxEditBatchOutput?.queued !== undefined
-      ? docxEditBatchOutput.queued.map((q) => q.id)
-      : null;
-  const handleOpenReviewPanel =
-    queuedIds !== null && queuedIds.length > 0
-      ? () => {
-          const opIds = new Set(queuedIds);
-          const sessions = useReviewStore.getState().sessions;
-          const entityIdMatch = Object.entries(sessions).find(([, items]) =>
-            items.some((item) => opIds.has(item.id)),
-          )?.[0];
-          if (!entityIdMatch) {
-            return;
-          }
-          const inspector = useInspectorTabsStore.getState();
-          const tab = inspector.tabs.find(
-            (candidate) =>
-              candidate.type === "pdf" && candidate.entityId === entityIdMatch,
-          );
-          if (!tab) {
-            return;
-          }
-          inspector.setActive(tab.id);
-          inspector.setFileFacet(tab.id, "suggestions", { pulse: true });
-        }
-      : null;
+  const handleOpenReviewPanel = getDocxReviewPanelHandler({
+    isDocxEditBatch,
+    part,
+  });
 
   return (
     // oxlint-disable-next-line jsx-a11y/no-static-element-interactions -- conditional role/handlers are paired below; the linter can't see they're always set together
@@ -600,63 +545,18 @@ export const ToolApprovalCard = ({
         )}
       </div>
 
-      {/* Rich summary */}
-      {part.name === "update-entity-fields" &&
-        part.state !== "input-streaming" &&
-        part.input !== undefined && <UpdateSummary input={part.input} />}
-      {part.name === "apply-active-docx-edits" &&
-        part.state !== "input-streaming" &&
-        part.input !== undefined && (
-          <ActiveDocxEditSummary input={part.input} />
-        )}
-      {part.name === "create_workspace_document" &&
-        part.state !== "input-streaming" &&
-        part.input !== undefined && (
-          <CreateWorkspaceDocumentSummary input={part.input} />
-        )}
-      {part.name === "edit_workspace_document" &&
-        part.state !== "input-streaming" &&
-        part.input !== undefined && (
-          <EditWorkspaceDocumentSummary
-            activeFileName={activeFileName}
-            input={part.input}
-          />
-        )}
-      {part.name === "edit_workspace_document" &&
-        part.state === "complete" &&
-        part.output !== undefined && (
-          <EditWorkspaceDocumentResult output={part.output} />
-        )}
-      {part.name === "spawn_subagents" &&
-        part.state !== "input-streaming" &&
-        part.input !== undefined && (
-          <SpawnSubagentsSubtaskList
-            isAwaitingApproval={isApprovalRequested}
-            subagents={part.input.subagents}
-          />
-        )}
-      {showsExternalInput &&
-        part.state !== "input-streaming" &&
-        externalInput !== undefined && (
-          <ExternalMcpInputSummary
-            input={externalInput}
-            isAwaitingDecision={
-              isApprovalRequested &&
-              !isProcessing &&
-              !isBlocked &&
-              !isPublicOfficialApproval
-            }
-            providerName={externalMcpProviderName ?? label}
-          />
-        )}
-      {isRegistryWriteSummaryToolName(name) &&
-        part.state !== "input-streaming" &&
-        getApprovalPartInput(part) !== undefined && (
-          <RegistryWriteSummary
-            input={getApprovalPartInput(part)}
-            toolName={name}
-          />
-        )}
+      <ToolApprovalSummary
+        activeFileName={activeFileName}
+        externalInput={showsExternalInput ? externalInput : undefined}
+        isAwaitingExternalDecision={
+          isApprovalRequested &&
+          !isProcessing &&
+          !isBlocked &&
+          !isPublicOfficialApproval
+        }
+        part={part}
+        providerName={externalMcpProviderName ?? label}
+      />
 
       {/* Actions — hidden for DOCX edit batches (reviewed in the side panel). */}
       {approvalId &&
@@ -724,6 +624,68 @@ export const ToolApprovalCard = ({
   );
 };
 
+const ToolApprovalSummary = ({
+  activeFileName,
+  externalInput,
+  isAwaitingExternalDecision,
+  part,
+  providerName,
+}: {
+  activeFileName: string | undefined;
+  externalInput: unknown;
+  isAwaitingExternalDecision: boolean;
+  part: ApprovalToolPart;
+  providerName: string;
+}) => {
+  if (part.state === "input-streaming") {
+    return null;
+  }
+
+  const name = getApprovalToolName(part);
+  const input = getApprovalPartInput(part);
+  return (
+    <>
+      {part.name === "update-entity-fields" && part.input !== undefined && (
+        <UpdateSummary input={part.input} />
+      )}
+      {part.name === "apply-active-docx-edits" && part.input !== undefined && (
+        <ActiveDocxEditSummary input={part.input} />
+      )}
+      {part.name === "create_workspace_document" &&
+        part.input !== undefined && (
+          <CreateWorkspaceDocumentSummary input={part.input} />
+        )}
+      {part.name === "edit_workspace_document" && part.input !== undefined && (
+        <EditWorkspaceDocumentSummary
+          activeFileName={activeFileName}
+          input={part.input}
+        />
+      )}
+      {part.name === "edit_workspace_document" &&
+        part.state === "complete" &&
+        part.output !== undefined && (
+          <EditWorkspaceDocumentResult output={part.output} />
+        )}
+      {part.name === "spawn_subagents" && part.input !== undefined && (
+        <SpawnSubagentsSubtaskList
+          isAwaitingApproval={part.state === "approval-requested"}
+          subagents={part.input.subagents}
+        />
+      )}
+      {externalInput !== undefined && (
+        <ExternalMcpInputSummary
+          input={externalInput}
+          isAwaitingDecision={isAwaitingExternalDecision}
+          providerName={providerName}
+        />
+      )}
+      {isRegistryWriteSummaryToolName(name) && input !== undefined && (
+        <RegistryWriteSummary input={input} toolName={name} />
+      )}
+    </>
+  );
+};
+
 type SummaryMatter = { color: string | null; id: string; name: string };
 
 /**
@@ -756,6 +718,111 @@ const useMattersById = (): ReadonlyMap<string, SummaryMatter> => {
  * reads everywhere else in the app. The id itself is what the user least needs
  * to see when deciding whether to allow a write.
  */
+const getDocxReviewPanelHandler = ({
+  isDocxEditBatch,
+  part,
+}: {
+  isDocxEditBatch: boolean;
+  part: ApprovalToolPart;
+}) => {
+  const output =
+    isDocxEditBatch &&
+    part.name === "apply-active-docx-edits" &&
+    part.state === "complete"
+      ? part.output
+      : undefined;
+  const queued = output?.queued;
+  if (queued === undefined || queued.length === 0) {
+    return null;
+  }
+  const queuedIds = queued.map((item) => item.id);
+  return () => {
+    const opIds = new Set(queuedIds);
+    const sessions = useReviewStore.getState().sessions;
+    const entityIdMatch = Object.entries(sessions).find(([, items]) =>
+      items.some((item) => opIds.has(item.id)),
+    )?.[0];
+    if (!entityIdMatch) {
+      return;
+    }
+    const inspector = useInspectorTabsStore.getState();
+    const tab = inspector.tabs.find(
+      (candidate) =>
+        candidate.type === "pdf" && candidate.entityId === entityIdMatch,
+    );
+    if (!tab) {
+      return;
+    }
+    inspector.setActive(tab.id);
+    inspector.setFileFacet(tab.id, "suggestions", { pulse: true });
+  };
+};
+
+const getToolApprovalState = ({
+  blockedApprovalTools,
+  defaultLabel,
+  name,
+  part,
+  responded,
+}: {
+  blockedApprovalTools: ReturnType<
+    typeof useChatApproval
+  >["blockedApprovalTools"];
+  defaultLabel: string;
+  name: ApprovalToolName;
+  part: ApprovalToolPart;
+  responded: boolean;
+}) => {
+  const isApprovalRequested = part.state === "approval-requested";
+  const isApprovalResponded = part.state === "approval-responded";
+  const isStructuredEditFailure =
+    part.name === "edit_workspace_document" &&
+    part.state === "complete" &&
+    part.output !== undefined &&
+    !part.output.success;
+  const isApproved =
+    part.state === "complete" &&
+    part.output !== undefined &&
+    !isStructuredEditFailure;
+  const isDenied =
+    isStructuredEditFailure ||
+    (part.state === "approval-responded" && part.approval.approved === false);
+  const isBlocked = blockedApprovalTools?.has(name) ?? false;
+  const isExternalMcpApproval = isExternalMcpToolName(name);
+  const showsExternalInput =
+    isExternalMcpApproval || isExternalInputChatToolName(name);
+  const isApprovalOnce = isApprovalOnceChatToolName(name);
+  const canAllowInConversation =
+    name !== "apply-active-docx-edits" &&
+    !isApprovalOnce &&
+    !isNonPersistentGrantChatToolName(name);
+  const isDocxEditBatch = name === "apply-active-docx-edits";
+  const externalMcpProviderName = getExternalMcpProviderName(name);
+
+  return {
+    canAllowInConversation,
+    canAlwaysAllow: canAllowInConversation,
+    externalInput:
+      showsExternalInput && part.state !== "input-streaming"
+        ? getApprovalPartInput(part)
+        : undefined,
+    externalMcpConnectorSlug: getExternalMcpConnectorSlug(name),
+    externalMcpProviderName,
+    isApprovalRequested,
+    isApprovalResponded,
+    isApproved,
+    isBlocked,
+    isDenied,
+    isDocxEditBatch,
+    isExternalMcpApproval,
+    isProcessing: isApprovalResponded || (responded && isApprovalRequested),
+    isPublicOfficialApproval: isPublicOfficialChatToolName(name),
+    isStructuredEditFailure,
+    label: externalMcpProviderName ?? defaultLabel,
+    showsExternalInput,
+  };
+};
+
 const RegistryWriteSummaryRow = ({
   label,
   matter,

--- a/apps/web/src/components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/components/docx/docx-browser-editor.tsx
@@ -106,7 +106,10 @@ import {
   resolveCheckpointAutosaveStatus,
 } from "./docx-edit-mode.logic";
 import type { AutosaveStatus } from "./docx-edit-mode.logic";
-import type { EditSessionErrorReason } from "./use-edit-session";
+import type {
+  EditSessionErrorReason,
+  EditSessionState,
+} from "./use-edit-session";
 import { useEditSession } from "./use-edit-session";
 
 const CHANGE_CHECKPOINT_DELAY = 2000;
@@ -1423,29 +1426,15 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
   // editor against `previewFile.buffer` for the few hundred ms before
   // the parent unmounts us — and the Stella fallback would flash.
   /* eslint-disable react/react-compiler -- editing buffers and the derived editor buffer are intentionally latched in refs across the save transition */
-  const preservedLoadedBufferSnapshot = preservedLoadedBufferRef.current;
-  const preservedLoadedBuffer =
-    preservedLoadedBufferSnapshot?.fieldId === fieldId
-      ? preservedLoadedBufferSnapshot.buffer
-      : null;
-  const lastEditingBuffer = lastEditingBufferRef.current;
-  const collaborationSeedBuffer =
-    collaborationSession?.seedDocumentBuffer ?? null;
-  const editorBuffer = selectDocxBrowserEditorBuffer({
-    collaborationSeedBuffer,
+  const editorBuffer = resolveAndPreserveDocxEditorBuffer({
+    collaborationSeedBuffer: collaborationSession?.seedDocumentBuffer ?? null,
+    fieldId,
     isCollaborativeEditing,
-    lastEditingBuffer,
-    preservedLoadedBuffer,
+    lastEditingBufferRef,
+    preservedLoadedBufferRef,
     previewBuffer: previewFile?.buffer,
     state,
   });
-  if (
-    (state.status === "editing" || isCollaborativeEditing) &&
-    editorBuffer !== undefined
-  ) {
-    lastEditingBufferRef.current = editorBuffer;
-    preservedLoadedBufferRef.current = null;
-  }
   /* eslint-enable react/react-compiler */
   const finishEditingLabel = t("folio.finishEditing");
 
@@ -1700,6 +1689,51 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       </div>
     </div>
   );
+};
+
+type ResolveAndPreserveDocxEditorBufferOptions = {
+  collaborationSeedBuffer: ArrayBuffer | null;
+  fieldId: string;
+  isCollaborativeEditing: boolean;
+  lastEditingBufferRef: RefObject<ArrayBuffer | null>;
+  preservedLoadedBufferRef: RefObject<{
+    buffer: ArrayBuffer;
+    fieldId: string;
+  } | null>;
+  previewBuffer: ArrayBuffer | undefined;
+  state: EditSessionState;
+};
+
+const resolveAndPreserveDocxEditorBuffer = ({
+  collaborationSeedBuffer,
+  fieldId,
+  isCollaborativeEditing,
+  lastEditingBufferRef,
+  preservedLoadedBufferRef,
+  previewBuffer,
+  state,
+}: ResolveAndPreserveDocxEditorBufferOptions) => {
+  const preservedLoadedBufferSnapshot = preservedLoadedBufferRef.current;
+  const preservedLoadedBuffer =
+    preservedLoadedBufferSnapshot?.fieldId === fieldId
+      ? preservedLoadedBufferSnapshot.buffer
+      : null;
+  const editorBuffer = selectDocxBrowserEditorBuffer({
+    collaborationSeedBuffer,
+    isCollaborativeEditing,
+    lastEditingBuffer: lastEditingBufferRef.current,
+    preservedLoadedBuffer,
+    previewBuffer,
+    state,
+  });
+  if (
+    (state.status === "editing" || isCollaborativeEditing) &&
+    editorBuffer !== undefined
+  ) {
+    lastEditingBufferRef.current = editorBuffer;
+    preservedLoadedBufferRef.current = null;
+  }
+  return editorBuffer;
 };
 
 type UseDocxBrowserCollaborationOptions = {

--- a/apps/web/src/components/inspector/file-tab-panel.tsx
+++ b/apps/web/src/components/inspector/file-tab-panel.tsx
@@ -1,5 +1,11 @@
 import { lazy, Suspense, useState } from "react";
-import type { Dispatch, MouseEvent, RefObject, SetStateAction } from "react";
+import type {
+  Dispatch,
+  MouseEvent,
+  ReactElement,
+  RefObject,
+  SetStateAction,
+} from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
@@ -153,6 +159,238 @@ const stripExtension = (name: string): string => {
   return name.slice(0, dotIndex);
 };
 
+const getFileTabDisplayState = ({
+  activeId,
+  minimized,
+  scaleOffsets,
+  tab,
+}: Pick<
+  FileTabPanelProps,
+  "activeId" | "minimized" | "scaleOffsets" | "tab"
+>) => {
+  const isActive = tab.id === activeId;
+  const nativePreviewKind = getFileTabNativePreviewKind({
+    fileName: tab.fileName,
+    mimeType: tab.mimeType,
+  });
+  const isNativeDocxDisplay = tab.mimeType === DOCX_MIME;
+  const isEmailDisplay = nativePreviewKind === "email";
+  const storedScaleOffset = scaleOffsets.get(tab.id);
+  const scaleOffset = storedScaleOffset ?? 0;
+  return {
+    canResetZoom: scaleOffset !== 0,
+    desktopEditFileType: getDesktopEditFileType({
+      fileName: tab.fileName,
+      mimeType: tab.mimeType,
+    }),
+    isActive,
+    isEmailDisplay,
+    isEmailViewerActive: isEmailDisplay && isActive && !minimized,
+    isMarkdownDisplay: nativePreviewKind === "markdown",
+    isNativeDocxDisplay,
+    isOfficeDisplay: nativePreviewKind === "office",
+    requiresPdfMeasurement:
+      !isNativeDocxDisplay && nativePreviewKind !== "office",
+    needsPropertyResolution:
+      isNativeDocxDisplay && tab.propertyId === undefined,
+    officeViewerFormat: getNativeOfficeViewerFormat(tab.mimeType),
+    renderId: tab.renderId ?? tab.id,
+    scaleOffset,
+  };
+};
+
+const getFileTabEntityState = ({
+  entityData,
+  entityQueryError,
+  needsPropertyResolution,
+  tab,
+}: {
+  entityData:
+    | {
+        extractionFileFieldId?: string | null | undefined;
+        fields: { id: string; propertyId?: string | undefined }[];
+      }
+    | undefined;
+  entityQueryError: boolean;
+  needsPropertyResolution: boolean;
+  tab: FileTabPanelProps["tab"];
+}) => {
+  const resolvedEmailChatMode = getEmailChatMode({
+    extractionFileFieldId: entityData?.extractionFileFieldId,
+    fieldId: tab.id,
+  });
+  const shouldSurfaceEmailResolutionError =
+    shouldSurfaceEmailChatResolutionError({
+      hasData: entityData !== undefined,
+      isError: entityQueryError,
+    });
+  return {
+    emailChatMode: shouldSurfaceEmailResolutionError
+      ? EMAIL_CHAT_MODE.resolutionError
+      : resolvedEmailChatMode,
+    filePropertyId:
+      tab.propertyId ??
+      (needsPropertyResolution
+        ? entityData?.fields.find((field) => field.id === tab.id)?.propertyId
+        : undefined),
+    resolvedEmailChatMode,
+    shouldSurfaceEmailResolutionError,
+  };
+};
+
+const getEmailAttachmentState = ({
+  isActive,
+  scaleOffsets,
+  selectedEmailAttachmentId,
+  tab,
+}: {
+  isActive: boolean;
+  scaleOffsets: FileTabPanelProps["scaleOffsets"];
+  selectedEmailAttachmentId: string | null;
+  tab: FileTabPanelProps["tab"];
+}) => {
+  const selectedEmailAttachmentPreviewId = selectedEmailAttachmentId
+    ? getEmailAttachmentPreviewId({
+        attachmentId: selectedEmailAttachmentId,
+        fieldId: tab.id,
+        workspaceId: tab.workspaceId,
+      })
+    : null;
+  const facet = tab.facet ?? "preview";
+  const isPreviewActive = isActive && facet === "preview";
+  return {
+    emailAttachmentOverlayActivation:
+      isActive && tab.facet === "attachments"
+        ? FILE_CHAT_OVERLAY_ACTIVATION.active
+        : FILE_CHAT_OVERLAY_ACTIVATION.deferred,
+    emailAttachmentScaleOffset: selectedEmailAttachmentPreviewId
+      ? (scaleOffsets.get(selectedEmailAttachmentPreviewId) ?? 0)
+      : 0,
+    emailPreviewOverlayActivation: isPreviewActive
+      ? FILE_CHAT_OVERLAY_ACTIVATION.active
+      : FILE_CHAT_OVERLAY_ACTIVATION.deferred,
+    emailSidepeekOverlayActivation:
+      isPreviewActive || (isActive && tab.facet === "attachments")
+        ? FILE_CHAT_OVERLAY_ACTIVATION.active
+        : FILE_CHAT_OVERLAY_ACTIVATION.deferred,
+    selectedEmailAttachmentPreviewId,
+  };
+};
+
+const getFileTabEditorState = ({
+  canUpdateEntity,
+  desktopEditFileType,
+  editingDocxTabId,
+  entityData,
+  filePropertyId,
+  flashingDocxEditTabId,
+  isNativeDocxDisplay,
+  tab,
+}: {
+  canUpdateEntity: boolean;
+  desktopEditFileType: ReturnType<typeof getDesktopEditFileType>;
+  editingDocxTabId: string | null;
+  entityData:
+    | { fields: { id: string; propertyId?: string | undefined }[] }
+    | undefined;
+  filePropertyId: string | undefined;
+  flashingDocxEditTabId: string | null;
+  isNativeDocxDisplay: boolean;
+  tab: FileTabPanelProps["tab"];
+}) => {
+  const isEditingNativeDocx =
+    isNativeDocxDisplay &&
+    editingDocxTabId === tab.id &&
+    filePropertyId !== undefined;
+  const isCurrentDesktopEditField =
+    filePropertyId !== undefined &&
+    entityData?.fields.some(
+      (field) => field.id === tab.id && field.propertyId === filePropertyId,
+    ) === true;
+  return {
+    canUnlockNativeDocx:
+      canUpdateEntity &&
+      isNativeDocxDisplay &&
+      filePropertyId !== undefined &&
+      !isEditingNativeDocx,
+    desktopEditTarget:
+      canUpdateEntity &&
+      desktopEditFileType !== null &&
+      filePropertyId !== undefined &&
+      isCurrentDesktopEditField
+        ? { fileType: desktopEditFileType, propertyId: filePropertyId }
+        : null,
+    isEditingNativeDocx,
+    isMetadataLaneExpanded: (tab.metadataLane ?? "closed") === "expanded",
+    isPromptingDocxUnlock: flashingDocxEditTabId === tab.id,
+  };
+};
+
+const shouldQueryFileTabEntity = ({
+  canUpdateEntity,
+  desktopEditFileType,
+  isActive,
+  isEmailViewerActive,
+  minimized,
+  needsPropertyResolution,
+}: {
+  canUpdateEntity: boolean;
+  desktopEditFileType: ReturnType<typeof getDesktopEditFileType>;
+  isActive: boolean;
+  isEmailViewerActive: boolean;
+  minimized: boolean;
+  needsPropertyResolution: boolean;
+}) =>
+  isEmailViewerActive ||
+  needsPropertyResolution ||
+  (isActive && !minimized && canUpdateEntity && desktopEditFileType !== null);
+
+type MarkdownSyncInput = {
+  fieldId: string;
+  isDirty: boolean;
+  isMarkdownDisplay: boolean;
+  serverText: string | undefined;
+};
+
+const shouldSyncMarkdownDraft = ({
+  lastSyncInput,
+  syncInput,
+}: {
+  lastSyncInput: MarkdownSyncInput | null;
+  syncInput: MarkdownSyncInput;
+}) =>
+  lastSyncInput === null ||
+  lastSyncInput.fieldId !== syncInput.fieldId ||
+  lastSyncInput.isDirty !== syncInput.isDirty ||
+  lastSyncInput.isMarkdownDisplay !== syncInput.isMarkdownDisplay ||
+  lastSyncInput.serverText !== syncInput.serverText;
+
+const getFileTabChromeState = ({
+  isEditingNativeDocx,
+  isEmailDisplay,
+  isMarkdownDisplay,
+  isOfficeDisplay,
+  tab,
+}: {
+  isEditingNativeDocx: boolean;
+  isEmailDisplay: boolean;
+  isMarkdownDisplay: boolean;
+  isOfficeDisplay: boolean;
+  tab: FileTabPanelProps["tab"];
+}) => {
+  const isPreviewFacet = (tab.facet ?? "preview") === "preview";
+  return {
+    canOpenFullView: !isEmailDisplay && !isMarkdownDisplay,
+    isPreviewFacet,
+    isPreviewOverlayVisible:
+      isPreviewFacet &&
+      !isEditingNativeDocx &&
+      !isEmailDisplay &&
+      !isMarkdownDisplay &&
+      !isOfficeDisplay,
+  };
+};
+
 export const FileTabPanel = ({
   activeId,
   canUpdateEntity,
@@ -200,85 +438,66 @@ export const FileTabPanel = ({
   const replaceFileFieldId = useInspectorTabsStore((s) => s.replaceFileFieldId);
   const setFileFacet = useInspectorTabsStore((s) => s.setFileFacet);
   const requestDocxEdit = useInspectorCommandStore((s) => s.requestDocxEdit);
-  const isActive = tab.id === activeId;
-  const isNativeDocxDisplay = tab.mimeType === DOCX_MIME;
-  const nativePreviewKind = getFileTabNativePreviewKind({
-    fileName: tab.fileName,
-    mimeType: tab.mimeType,
-  });
-  const isEmailDisplay = nativePreviewKind === "email";
-  const isEmailViewerActive = isEmailDisplay && isActive && !minimized;
-  const isMarkdownDisplay = nativePreviewKind === "markdown";
-  const officeViewerFormat = getNativeOfficeViewerFormat(tab.mimeType);
-  const isOfficeDisplay = nativePreviewKind === "office";
-  const desktopEditFileType = getDesktopEditFileType({
-    fileName: tab.fileName,
-    mimeType: tab.mimeType,
-  });
+  const {
+    canResetZoom,
+    desktopEditFileType,
+    isActive,
+    isEmailDisplay,
+    isEmailViewerActive,
+    isMarkdownDisplay,
+    isNativeDocxDisplay,
+    isOfficeDisplay,
+    needsPropertyResolution,
+    officeViewerFormat,
+    renderId,
+    requiresPdfMeasurement,
+    scaleOffset,
+  } = getFileTabDisplayState({ activeId, minimized, scaleOffsets, tab });
   // A DOCX tab opened by a caller that knows only the file field (a review's
   // reference, a search hit) still needs the field's property to mount the
   // editor; read it off the entity rather than leaving the viewer empty.
-  const needsPropertyResolution =
-    isNativeDocxDisplay && tab.propertyId === undefined;
   const entityQuery = useQuery({
     ...entityOptions(tab.workspaceId, tab.entityId),
-    enabled:
-      isEmailViewerActive ||
-      needsPropertyResolution ||
-      (isActive &&
-        !minimized &&
-        canUpdateEntity &&
-        desktopEditFileType !== null),
+    enabled: shouldQueryFileTabEntity({
+      canUpdateEntity,
+      desktopEditFileType,
+      isActive,
+      isEmailViewerActive,
+      minimized,
+      needsPropertyResolution,
+    }),
     refetchInterval: ({ state }) =>
       getEmailExtractionRefetchInterval({
         extractionFileFieldId: state.data?.extractionFileFieldId,
         isEmailViewerActive,
       }),
   });
-  const filePropertyId =
-    tab.propertyId ??
-    (needsPropertyResolution
-      ? entityQuery.data?.fields.find((field) => field.id === tab.id)
-          ?.propertyId
-      : undefined);
-  const resolvedEmailChatMode = getEmailChatMode({
-    extractionFileFieldId: entityQuery.data?.extractionFileFieldId,
-    fieldId: tab.id,
+  const {
+    emailChatMode,
+    filePropertyId,
+    resolvedEmailChatMode,
+    shouldSurfaceEmailResolutionError,
+  } = getFileTabEntityState({
+    entityData: entityQuery.data,
+    entityQueryError: entityQuery.isError,
+    needsPropertyResolution,
+    tab,
   });
-  const shouldSurfaceEmailResolutionError =
-    shouldSurfaceEmailChatResolutionError({
-      hasData: entityQuery.data !== undefined,
-      isError: entityQuery.isError,
-    });
-  const emailChatMode = shouldSurfaceEmailResolutionError
-    ? EMAIL_CHAT_MODE.resolutionError
-    : resolvedEmailChatMode;
   const [selectedEmailAttachmentId, setSelectedEmailAttachmentId] = useState<
     string | null
   >(null);
-  const selectedEmailAttachmentPreviewId = selectedEmailAttachmentId
-    ? getEmailAttachmentPreviewId({
-        attachmentId: selectedEmailAttachmentId,
-        fieldId: tab.id,
-        workspaceId: tab.workspaceId,
-      })
-    : null;
-  const emailAttachmentScaleOffset = selectedEmailAttachmentPreviewId
-    ? (scaleOffsets.get(selectedEmailAttachmentPreviewId) ?? 0)
-    : 0;
-  const emailPreviewOverlayActivation =
-    isActive && (tab.facet ?? "preview") === "preview"
-      ? FILE_CHAT_OVERLAY_ACTIVATION.active
-      : FILE_CHAT_OVERLAY_ACTIVATION.deferred;
-  const emailAttachmentOverlayActivation =
-    isActive && tab.facet === "attachments"
-      ? FILE_CHAT_OVERLAY_ACTIVATION.active
-      : FILE_CHAT_OVERLAY_ACTIVATION.deferred;
-  const emailSidepeekOverlayActivation =
-    isActive &&
-    ((tab.facet ?? "preview") === "preview" || tab.facet === "attachments")
-      ? FILE_CHAT_OVERLAY_ACTIVATION.active
-      : FILE_CHAT_OVERLAY_ACTIVATION.deferred;
+  const {
+    emailAttachmentOverlayActivation,
+    emailAttachmentScaleOffset,
+    emailPreviewOverlayActivation,
+    emailSidepeekOverlayActivation,
+    selectedEmailAttachmentPreviewId,
+  } = getEmailAttachmentState({
+    isActive,
+    scaleOffsets,
+    selectedEmailAttachmentId,
+    tab,
+  });
   const openEmailAttachment = (attachmentId: string | null) => {
     setSelectedEmailAttachmentId(attachmentId);
     setFileFacet(tab.id, "attachments");
@@ -303,12 +522,8 @@ export const FileTabPanel = ({
   >(null);
   const markdownText = markdownTextQuery.data?.text ?? "";
   const markdownIsDirty = markdownDraft !== markdownText;
-  const [lastMarkdownSyncInput, setLastMarkdownSyncInput] = useState<{
-    fieldId: string;
-    isDirty: boolean;
-    isMarkdownDisplay: boolean;
-    serverText: string | undefined;
-  } | null>(null);
+  const [lastMarkdownSyncInput, setLastMarkdownSyncInput] =
+    useState<MarkdownSyncInput | null>(null);
   const markdownSaveMutation = useMutation({
     mutationFn: async ({
       entityId,
@@ -368,14 +583,12 @@ export const FileTabPanel = ({
     isDirty: markdownIsDirty,
     isMarkdownDisplay,
     serverText: markdownTextQuery.data?.text,
-  };
+  } satisfies MarkdownSyncInput;
   if (
-    lastMarkdownSyncInput === null ||
-    lastMarkdownSyncInput.fieldId !== markdownSyncInput.fieldId ||
-    lastMarkdownSyncInput.isDirty !== markdownSyncInput.isDirty ||
-    lastMarkdownSyncInput.isMarkdownDisplay !==
-      markdownSyncInput.isMarkdownDisplay ||
-    lastMarkdownSyncInput.serverText !== markdownSyncInput.serverText
+    shouldSyncMarkdownDraft({
+      lastSyncInput: lastMarkdownSyncInput,
+      syncInput: markdownSyncInput,
+    })
   ) {
     setLastMarkdownSyncInput(markdownSyncInput);
     if (!isMarkdownDisplay) {
@@ -406,30 +619,22 @@ export const FileTabPanel = ({
   // Justification bbox highlighting on Folio is a separate
   // follow-up; until then the bbox overlay is omitted on
   // DOCX, but the doc itself remains editable.
-  const isEditingNativeDocx =
-    isNativeDocxDisplay &&
-    editingDocxTabId === tab.id &&
-    filePropertyId !== undefined;
-  const canUnlockNativeDocx =
-    canUpdateEntity &&
-    isNativeDocxDisplay &&
-    filePropertyId !== undefined &&
-    !isEditingNativeDocx;
-  const isPromptingDocxUnlock = flashingDocxEditTabId === tab.id;
-  const metadataLane = tab.metadataLane ?? "closed";
-  const isMetadataLaneExpanded = metadataLane === "expanded";
-  const isCurrentDesktopEditField =
-    filePropertyId !== undefined &&
-    entityQuery.data?.fields.some(
-      (field) => field.id === tab.id && field.propertyId === filePropertyId,
-    ) === true;
-  const desktopEditTarget =
-    canUpdateEntity &&
-    desktopEditFileType !== null &&
-    filePropertyId !== undefined &&
-    isCurrentDesktopEditField
-      ? { fileType: desktopEditFileType, propertyId: filePropertyId }
-      : null;
+  const {
+    canUnlockNativeDocx,
+    desktopEditTarget,
+    isEditingNativeDocx,
+    isMetadataLaneExpanded,
+    isPromptingDocxUnlock,
+  } = getFileTabEditorState({
+    canUpdateEntity,
+    desktopEditFileType,
+    editingDocxTabId,
+    entityData: entityQuery.data,
+    filePropertyId,
+    flashingDocxEditTabId,
+    isNativeDocxDisplay,
+    tab,
+  });
   const desktopOpenButton =
     desktopEditTarget !== null ? (
       <DesktopOpenButton
@@ -482,7 +687,7 @@ export const FileTabPanel = ({
           "bg-background flex flex-1 flex-col overflow-hidden",
           !isActive && "hidden",
         )}
-        key={tab.renderId ?? tab.id}
+        key={renderId}
       >
         <FullViewPreviewGuard
           facet={tab.facet}
@@ -691,7 +896,14 @@ export const FileTabPanel = ({
   // facets unmounts the editor; if the user is on a non-
   // preview facet, we hide the toggle entirely (Full view
   // alone) rather than show a button that would no-op.
-  const isPreviewFacet = (tab.facet ?? "preview") === "preview";
+  const { canOpenFullView, isPreviewFacet, isPreviewOverlayVisible } =
+    getFileTabChromeState({
+      isEditingNativeDocx,
+      isEmailDisplay,
+      isMarkdownDisplay,
+      isOfficeDisplay,
+      tab,
+    });
   const markdownActions = (() => {
     if (!isMarkdownDisplay) {
       return null;
@@ -791,7 +1003,7 @@ export const FileTabPanel = ({
       {downloadButton}
       {desktopOpenButton}
       {isPreviewFacet && (markdownActions ?? editToggle)}
-      {!isEmailDisplay && !isMarkdownDisplay && fullViewButton}
+      {canOpenFullView && fullViewButton}
     </>
   );
 
@@ -799,22 +1011,17 @@ export const FileTabPanel = ({
   // viewer body — zoom controls only. The Edit / Save mode
   // toggle lives in the tab header (`fileActions` above) so
   // primary state changes have one stable location.
-  const previewOverlay =
-    (tab.facet ?? "preview") === "preview" &&
-    !isEditingNativeDocx &&
-    !isEmailDisplay &&
-    !isMarkdownDisplay &&
-    !isOfficeDisplay ? (
-      <div className="bg-background/80 supports-[backdrop-filter]:bg-background/65 absolute end-2 top-2 z-10 flex items-center gap-1 rounded-md border p-0.5 shadow-sm backdrop-blur">
-        <PeekPdfControls
-          canResetZoom={scaleOffsets.get(tab.id) !== 0}
-          onResetZoom={() => handleResetZoom(tab.id)}
-          onZoomIn={() => handleZoom(tab.id, "in")}
-          onZoomOut={() => handleZoom(tab.id, "out")}
-          scaleOffset={scaleOffsets.get(tab.id) ?? 0}
-        />
-      </div>
-    ) : null;
+  const previewOverlay = isPreviewOverlayVisible ? (
+    <div className="bg-background/80 supports-[backdrop-filter]:bg-background/65 absolute end-2 top-2 z-10 flex items-center gap-1 rounded-md border p-0.5 shadow-sm backdrop-blur">
+      <PeekPdfControls
+        canResetZoom={canResetZoom}
+        onResetZoom={() => handleResetZoom(tab.id)}
+        onZoomIn={() => handleZoom(tab.id, "in")}
+        onZoomOut={() => handleZoom(tab.id, "out")}
+        scaleOffset={scaleOffset}
+      />
+    </div>
+  ) : null;
 
   const contextBar = (
     <InspectorTabHeader
@@ -1010,12 +1217,12 @@ export const FileTabPanel = ({
                 return next;
               });
               setScaleOffsets((prev) => {
-                const scaleOffset = prev.get(tab.id);
-                if (scaleOffset === undefined) {
+                const savedScaleOffset = prev.get(tab.id);
+                if (savedScaleOffset === undefined) {
                   return prev;
                 }
                 const next = new Map(prev);
-                next.set(fieldId, scaleOffset);
+                next.set(fieldId, savedScaleOffset);
                 return next;
               });
               useInspectorTabsStore
@@ -1025,7 +1232,7 @@ export const FileTabPanel = ({
           }}
           onScrollTopChange={handleDocxScrollTopChange}
           propertyId={filePropertyId}
-          scaleOffset={scaleOffsets.get(tab.id) ?? 0}
+          scaleOffset={scaleOffset}
           showActionBar={false}
           surface="inspector"
           workspaceId={tab.workspaceId}
@@ -1044,7 +1251,7 @@ export const FileTabPanel = ({
         onError={handleViewerError}
         onPeekNavigate={closeAll}
         onWheelZoom={(deltaY) => handleWheelZoom(tab.id, deltaY)}
-        scaleOffset={scaleOffsets.get(tab.id) ?? 0}
+        scaleOffset={scaleOffset}
         viewId={peekPdfViewId}
         workspaceId={tab.workspaceId}
       />
@@ -1053,27 +1260,29 @@ export const FileTabPanel = ({
 
   const viewerPane = (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-      {tab.justificationFieldId && !isEmailDisplay && !isMarkdownDisplay && (
-        <Suspense
-          fallback={
-            <div
-              className={cn(
-                "text-muted-foreground flex items-center border-b px-3 text-xs italic",
-                TOOLBAR_ROW_HEIGHT,
-              )}
-            >
-              {t("common.loading")}...
-            </div>
-          }
-        >
-          <DocumentAiSourceBar
-            activeTab={tab}
-            fieldId={tab.justificationFieldId}
-            isActiveTab={isActive}
-            workspaceId={tab.workspaceId}
-          />
-        </Suspense>
-      )}
+      {tab.justificationFieldId !== undefined &&
+        !isEmailDisplay &&
+        !isMarkdownDisplay && (
+          <Suspense
+            fallback={
+              <div
+                className={cn(
+                  "text-muted-foreground flex items-center border-b px-3 text-xs italic",
+                  TOOLBAR_ROW_HEIGHT,
+                )}
+              >
+                {t("common.loading")}...
+              </div>
+            }
+          >
+            <DocumentAiSourceBar
+              activeTab={tab}
+              fieldId={tab.justificationFieldId}
+              isActiveTab={isActive}
+              workspaceId={tab.workspaceId}
+            />
+          </Suspense>
+        )}
       <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">
         {fileViewer}
         {previewOverlay}
@@ -1314,34 +1523,55 @@ export const FileTabPanel = ({
         "flex flex-1 flex-col overflow-hidden",
         !isActive && "hidden",
       )}
-      key={tab.renderId ?? tab.id}
+      key={renderId}
     >
-      {isNativeDocxDisplay || isOfficeDisplay ? (
-        <>
-          {contextBar}
-          {facetBar}
-          {sidepeekContent}
-        </>
-      ) : (
-        <>
-          {contextBar}
-          {facetBar}
-          <div className="min-h-0 min-w-0 flex-1">
-            <MeasuredPdfProvider
-              active={isActive}
-              fallback={{
-                suspense: <PeekSuspenseFallback />,
-                error: <InspectorPdfErrorFallback />,
-              }}
-              fieldId={tab.id}
-              initialScaleOffset={scaleOffsets.get(tab.id) ?? 0}
-              onError={handleViewerError}
-            >
-              {sidepeekContent}
-            </MeasuredPdfProvider>
-          </div>
-        </>
-      )}
+      {contextBar}
+      {facetBar}
+      <FileTabMeasurementBoundary
+        active={isActive}
+        fieldId={tab.id}
+        measured={requiresPdfMeasurement}
+        onError={handleViewerError}
+        scaleOffset={scaleOffset}
+      >
+        {sidepeekContent}
+      </FileTabMeasurementBoundary>
+    </div>
+  );
+};
+
+const FileTabMeasurementBoundary = ({
+  active,
+  children,
+  fieldId,
+  measured,
+  onError,
+  scaleOffset,
+}: {
+  active: boolean;
+  children: ReactElement;
+  fieldId: string;
+  measured: boolean;
+  onError: () => void;
+  scaleOffset: number;
+}): ReactElement => {
+  if (!measured) {
+    return children;
+  }
+  return (
+    <div className="min-h-0 min-w-0 flex-1">
+      <MeasuredPdfProvider
+        active={active}
+        fallback={{
+          suspense: <PeekSuspenseFallback />,
+          error: <InspectorPdfErrorFallback />,
+        }}
+        fieldId={fieldId}
+        initialScaleOffset={scaleOffset}
+        onError={onError}
+      >
+        {children}
+      </MeasuredPdfProvider>
     </div>
   );
 };

--- a/apps/web/src/components/inspector/inspector-broadcast.ts
+++ b/apps/web/src/components/inspector/inspector-broadcast.ts
@@ -190,86 +190,128 @@ const isInspectorTab = (value: unknown): value is InspectorTab => {
   }
   const type = value["type"];
   const id = value["id"];
-  const label = value["label"];
   if (typeof type !== "string" || typeof id !== "string") {
     return false;
   }
+  return isInspectorTabType(value, type);
+};
+
+const isInspectorTabType = (value: Record<string, unknown>, type: string) => {
+  const label = value["label"];
   if (type === "task") {
-    const status = value["status"];
-    return (
-      typeof label === "string" &&
-      typeof value["isNew"] === "boolean" &&
-      (status === undefined || status === null || isTaskStatus(status))
-    );
+    return isInspectorTaskTab(value, label);
   }
   if (type === "chat") {
-    return (
-      typeof label === "string" &&
-      isOptionalString(value["workspaceId"]) &&
-      isStringArray(value["contextMatterIds"]) &&
-      isOptionalString(value["activeDecisionId"]) &&
-      isActiveSkillContext(value["activeSkill"])
-    );
+    return isInspectorChatTab(value, label);
   }
   if (type === "external") {
-    const workspaceId = value["workspaceId"];
-    return (
-      typeof label === "string" &&
-      typeof value["chatThreadId"] === "string" &&
-      typeof value["url"] === "string" &&
-      (workspaceId === null || typeof workspaceId === "string") &&
-      isOptionalString(value["connectorSlug"]) &&
-      isOptionalString(value["iconHref"]) &&
-      isOptionalString(value["provider"]) &&
-      isOptionalString(value["snippet"]) &&
-      isOptionalString(value["sourceToolName"]) &&
-      isOptionalString(value["text"])
-    );
+    return isInspectorExternalTab(value, label);
   }
   if (type === "matter") {
-    const color = value["color"];
-    return (
-      typeof label === "string" &&
-      typeof value["workspaceId"] === "string" &&
-      (color === undefined || color === null || typeof color === "string")
-    );
+    return isInspectorMatterTab(value, label);
   }
   if (type === "skill-resource") {
-    const skillId = value["skillId"];
-    const origin = value["origin"];
-    const target = value["target"];
-    return (
-      typeof label === "string" &&
-      typeof value["skillName"] === "string" &&
-      (skillId === null || typeof skillId === "string") &&
-      (origin === "authored" ||
-        origin === "built-in" ||
-        origin === "bundled" ||
-        origin === "upload" ||
-        origin === "url") &&
-      (target === undefined || target === "body" || target === "resource") &&
-      typeof value["resourcePath"] === "string" &&
-      typeof value["mimeType"] === "string" &&
-      typeof value["content"] === "string"
-    );
+    return isInspectorSkillResourceTab(value, label);
   }
   if (type === "pdf") {
-    const pdfFileId = value["pdfFileId"];
-    return (
-      typeof label === "string" &&
-      typeof value["fileName"] === "string" &&
-      typeof value["entityId"] === "string" &&
-      typeof value["workspaceId"] === "string" &&
-      (pdfFileId === null || typeof pdfFileId === "string") &&
-      isOptionalString(value["renderId"]) &&
-      isOptionalString(value["mimeType"]) &&
-      isOptionalString(value["justificationFieldId"]) &&
-      isOptionalString(value["propertyId"]) &&
-      isMetadataLane(value["metadataLane"]) &&
-      isFileFacet(value["facet"]) &&
-      isOptionalNumber(value["facetPulseSeq"])
-    );
+    return isInspectorPdfTab(value, label);
   }
+  return isInspectorViewTab(value, type, label);
+};
+
+const isInspectorTaskTab = (value: Record<string, unknown>, label: unknown) => {
+  const status = value["status"];
+  return (
+    typeof label === "string" &&
+    typeof value["isNew"] === "boolean" &&
+    (status === undefined || status === null || isTaskStatus(status))
+  );
+};
+
+const isInspectorChatTab = (value: Record<string, unknown>, label: unknown) =>
+  typeof label === "string" &&
+  isOptionalString(value["workspaceId"]) &&
+  isStringArray(value["contextMatterIds"]) &&
+  isOptionalString(value["activeDecisionId"]) &&
+  isActiveSkillContext(value["activeSkill"]);
+
+const isInspectorExternalTab = (
+  value: Record<string, unknown>,
+  label: unknown,
+) => {
+  const workspaceId = value["workspaceId"];
+  return (
+    typeof label === "string" &&
+    typeof value["chatThreadId"] === "string" &&
+    typeof value["url"] === "string" &&
+    (workspaceId === null || typeof workspaceId === "string") &&
+    isOptionalString(value["connectorSlug"]) &&
+    isOptionalString(value["iconHref"]) &&
+    isOptionalString(value["provider"]) &&
+    isOptionalString(value["snippet"]) &&
+    isOptionalString(value["sourceToolName"]) &&
+    isOptionalString(value["text"])
+  );
+};
+
+const isInspectorMatterTab = (
+  value: Record<string, unknown>,
+  label: unknown,
+) => {
+  const color = value["color"];
+  return (
+    typeof label === "string" &&
+    typeof value["workspaceId"] === "string" &&
+    (color === undefined || color === null || typeof color === "string")
+  );
+};
+
+const isInspectorSkillResourceTab = (
+  value: Record<string, unknown>,
+  label: unknown,
+) => {
+  const skillId = value["skillId"];
+  const origin = value["origin"];
+  const target = value["target"];
+  return (
+    typeof label === "string" &&
+    typeof value["skillName"] === "string" &&
+    (skillId === null || typeof skillId === "string") &&
+    (origin === "authored" ||
+      origin === "built-in" ||
+      origin === "bundled" ||
+      origin === "upload" ||
+      origin === "url") &&
+    (target === undefined || target === "body" || target === "resource") &&
+    typeof value["resourcePath"] === "string" &&
+    typeof value["mimeType"] === "string" &&
+    typeof value["content"] === "string"
+  );
+};
+
+const isInspectorPdfTab = (value: Record<string, unknown>, label: unknown) => {
+  const pdfFileId = value["pdfFileId"];
+  return (
+    typeof label === "string" &&
+    typeof value["fileName"] === "string" &&
+    typeof value["entityId"] === "string" &&
+    typeof value["workspaceId"] === "string" &&
+    (pdfFileId === null || typeof pdfFileId === "string") &&
+    isOptionalString(value["renderId"]) &&
+    isOptionalString(value["mimeType"]) &&
+    isOptionalString(value["justificationFieldId"]) &&
+    isOptionalString(value["propertyId"]) &&
+    isMetadataLane(value["metadataLane"]) &&
+    isFileFacet(value["facet"]) &&
+    isOptionalNumber(value["facetPulseSeq"])
+  );
+};
+
+const isInspectorViewTab = (
+  value: Record<string, unknown>,
+  type: string,
+  label: unknown,
+) => {
   if (type !== "view" || typeof label !== "string") {
     return false;
   }

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent } from "react";
+import type {
+  ComponentProps,
+  CSSProperties,
+  Dispatch,
+  KeyboardEvent as ReactKeyboardEvent,
+  ReactElement,
+  SetStateAction,
+} from "react";
 
 import {
   useInfiniteQuery,
@@ -9,14 +16,12 @@ import {
 } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import type { VirtualItem } from "@tanstack/react-virtual";
 import { LoaderIcon, PanelRightIcon, WandSparklesIcon } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
 import { useTranslations } from "use-intl";
 
-import {
-  GLOBAL_SEARCH_RESULT_TYPES,
-  type GlobalSearchResultType,
-} from "@stll/api-contract";
+import { GLOBAL_SEARCH_RESULT_TYPES } from "@stll/api-contract";
 import type { GlobalSearchHit } from "@stll/api/types";
 import { Button } from "@stll/ui/button";
 import {
@@ -123,7 +128,7 @@ import {
   recentFilePreviewFieldOptions,
   searchInfiniteOptions,
 } from "@/lib/search";
-import type { SearchAISummaryParams, TimePreset } from "@/lib/search";
+import type { SearchAISummaryParams } from "@/lib/search";
 import {
   readRecentFiles,
   readRecentSearches,
@@ -231,6 +236,57 @@ const filtersForMode = (
 type SearchFiltersUpdate =
   | SearchFilters
   | ((filters: SearchFilters) => SearchFilters);
+
+type SearchResultsStatus =
+  | { type: "hidden" }
+  | { type: "unavailable" }
+  | { type: "error" }
+  | { type: "loading" }
+  | { query: string | null; type: "empty" }
+  | { type: "results" };
+
+const resolveSearchResultsStatus = ({
+  hasActiveSearch,
+  hasQuery,
+  hasResults,
+  hasUnavailableSelectedType,
+  hasVisibleSearch,
+  isBlockingSearchError,
+  isLoading,
+  searchQuery,
+}: {
+  hasActiveSearch: boolean;
+  hasQuery: boolean;
+  hasResults: boolean;
+  hasUnavailableSelectedType: boolean;
+  hasVisibleSearch: boolean;
+  isBlockingSearchError: boolean;
+  isLoading: boolean;
+  searchQuery: string;
+}): SearchResultsStatus => {
+  if (!hasVisibleSearch) {
+    return { type: "hidden" };
+  }
+  if (hasUnavailableSelectedType) {
+    return { type: "unavailable" };
+  }
+  if (hasActiveSearch && isBlockingSearchError) {
+    return { type: "error" };
+  }
+  if (
+    !isBlockingSearchError &&
+    !hasResults &&
+    (!hasActiveSearch || isLoading)
+  ) {
+    return { type: "loading" };
+  }
+  if (hasActiveSearch && !isBlockingSearchError && !isLoading && !hasResults) {
+    return { query: hasQuery ? searchQuery : null, type: "empty" };
+  }
+  return !isBlockingSearchError && hasResults
+    ? { type: "results" }
+    : { type: "hidden" };
+};
 
 type SearchDialogProps = {
   open: boolean;
@@ -839,49 +895,6 @@ export const SearchDialog = ({
     });
   };
 
-  const toggleTypeFilter = (type: GlobalSearchResultType) => {
-    setFilters((prev) => ({
-      ...prev,
-      types: toggleArrayMember(prev.types, type),
-    }));
-  };
-
-  const toggleWorkspaceFilter = (workspaceId: string) => {
-    setFilters((prev) => ({
-      ...prev,
-      workspaceIds: toggleArrayMember(prev.workspaceIds, workspaceId),
-    }));
-  };
-
-  const toggleEditorFilter = (editorId: string) => {
-    setFilters((prev) => ({
-      ...prev,
-      editedByUserIds: toggleArrayMember(prev.editedByUserIds, editorId),
-    }));
-  };
-
-  const setTimePreset = (preset: TimePreset | undefined) => {
-    setFilters((prev) => setPresetTime(prev, preset));
-  };
-
-  const setCustomDateRange = (range: {
-    updatedFrom?: string;
-    updatedTo?: string;
-  }) => {
-    setFilters((prev) => setCustomTime(prev, range));
-  };
-
-  const clearTimeFilter = () => {
-    setFilters(clearTime);
-  };
-
-  const toggleMimeTypeFilter = (mimeType: string) => {
-    setFilters((prev) => ({
-      ...prev,
-      mimeTypes: toggleArrayMember(prev.mimeTypes, mimeType),
-    }));
-  };
-
   const handleResultClick = (
     hit: GlobalSearchHit,
     options?: { locationModifier?: boolean },
@@ -1084,6 +1097,16 @@ export const SearchDialog = ({
     !isBlockingSearchError &&
     hasResults;
   const commandHits = shouldShowResults ? allHits : [];
+  const resultsStatus = resolveSearchResultsStatus({
+    hasActiveSearch,
+    hasQuery,
+    hasResults,
+    hasUnavailableSelectedType,
+    hasVisibleSearch,
+    isBlockingSearchError,
+    isLoading,
+    searchQuery,
+  });
   const filterEditorIdsKey = filters.editedByUserIds.join("|");
 
   // Clear any prior AI summary whenever the effective search changes. The
@@ -1425,101 +1448,18 @@ export const SearchDialog = ({
                   showPreview ? "xl:block" : "sm:block",
                 )}
               >
-                <TimeFacetGroup
+                <SearchFacetsBody
+                  editorBuckets={editorBuckets}
+                  facetSearchParams={facetSearchParams}
+                  filters={filters}
+                  hasSearchCriteria={hasSearchCriteria}
                   locale={locale}
-                  onClearCustom={clearTimeFilter}
-                  onPresetChange={(preset) =>
-                    setTimePreset(
-                      filters.time?.mode === "preset" &&
-                        filters.time.preset === preset
-                        ? undefined
-                        : preset,
-                    )
-                  }
-                  onCustomChange={setCustomDateRange}
-                  time={filters.time}
+                  mimeTypeBuckets={mimeTypeBuckets}
+                  publicLawPreviewEnabled={publicLawPreviewEnabled}
+                  setFilters={setFilters}
+                  typeBuckets={typeBuckets}
+                  workspaceBuckets={workspaceBuckets}
                 />
-
-                {hasSearchCriteria && (
-                  <>
-                    {(facets?.type.length ?? 0) + filters.types.length > 0 && (
-                      <div className="mt-4">
-                        <FacetGroup
-                          buckets={mergeSelectedBuckets(
-                            typeBuckets.flatMap((bucket) => {
-                              if (!isSearchKindOption(bucket.value)) {
-                                return [];
-                              }
-                              if (
-                                !isAvailableSearchKind(
-                                  bucket.value,
-                                  publicLawPreviewEnabled,
-                                )
-                              ) {
-                                return [];
-                              }
-                              return [
-                                {
-                                  value: bucket.value,
-                                  count: bucket.count,
-                                  label: t(KIND_TRANSLATION_KEYS[bucket.value]),
-                                },
-                              ];
-                            }),
-                            filters.types,
-                            (value) =>
-                              isSearchKindOption(value)
-                                ? t(KIND_TRANSLATION_KEYS[value])
-                                : value,
-                          )}
-                          onChange={(value) => {
-                            if (isSearchKindOption(value)) {
-                              toggleTypeFilter(value);
-                            }
-                          }}
-                          selected={filters.types}
-                          title={t("common.kind")}
-                        />
-                      </div>
-                    )}
-
-                    <div className="mt-4">
-                      <SearchableFacetGroup
-                        defaultBuckets={mimeTypeBuckets}
-                        facet="mimeType"
-                        formatLabel={(bucket) =>
-                          formatMimeTypeLabel(bucket.value)
-                        }
-                        onChange={toggleMimeTypeFilter}
-                        searchParams={facetSearchParams}
-                        selected={filters.mimeTypes}
-                        title={t("search.mimeType")}
-                      />
-                    </div>
-
-                    <div className="mt-4">
-                      <SearchableFacetGroup
-                        defaultBuckets={editorBuckets}
-                        facet="editor"
-                        onChange={toggleEditorFilter}
-                        searchParams={facetSearchParams}
-                        selected={filters.editedByUserIds}
-                        title={t("search.editedBy")}
-                      />
-                    </div>
-
-                    <div className="mt-4">
-                      <SearchableFacetGroup
-                        defaultBuckets={workspaceBuckets}
-                        facet="workspace"
-                        onChange={toggleWorkspaceFilter}
-                        searchParams={facetSearchParams}
-                        selected={filters.workspaceIds}
-                        title={t("common.matter")}
-                      />
-                    </div>
-                  </>
-                )}
               </div>
 
               <SearchColumnResizeHandle
@@ -1537,278 +1477,588 @@ export const SearchDialog = ({
                 onKeyDown={handleEmptyScreenListKeyDown}
                 ref={setResultsElement}
               >
-                {!hasVisibleSearch && (
-                  <>
-                    <SavedSearches
-                      filters={filters}
-                      isOpen={open}
-                      onApply={applySavedSearch}
-                      overlayLayer="search-child"
-                      query={query}
-                      showTrigger={false}
-                    />
-                    <SearchRecents
-                      onFileClick={openRecentFile}
-                      onFilePreview={setRecentPreviewFile}
-                      onSearchClick={applyRecentSearch}
-                      previewedFileId={displayedRecentFile?.entityId ?? null}
-                      recentFiles={recentFiles}
-                      recentSearches={recentSearches}
-                    />
-                  </>
-                )}
-
-                {hasVisibleSearch && hasUnavailableSelectedType && (
-                  <div className="flex h-full items-center justify-center px-4 py-8">
-                    <p className="text-muted-foreground text-sm">
-                      {t("common.comingSoon")}
-                    </p>
-                  </div>
-                )}
-
-                {hasVisibleSearch &&
-                  !hasUnavailableSelectedType &&
-                  hasActiveSearch &&
-                  isBlockingSearchError && (
-                    <div className="flex h-full flex-col items-center justify-center gap-3 px-4 py-8">
-                      <p className="text-muted-foreground text-sm">
-                        {t("common.somethingWentWrong")}
-                      </p>
-                      <Button
-                        onClick={() => {
-                          detached(
-                            refetchSearch(),
-                            "search-dialog.refetch-search",
-                          );
-                        }}
-                        size="sm"
-                        variant="outline"
-                      >
-                        {t("common.retry")}
-                      </Button>
-                    </div>
-                  )}
-
-                {hasVisibleSearch &&
-                  !hasUnavailableSelectedType &&
-                  !isBlockingSearchError &&
-                  !hasResults &&
-                  (!hasActiveSearch || isLoading) && (
-                    <div className="space-y-3 px-4 py-3">
-                      {Array.from({ length: 4 }).map((_, i) => (
-                        // eslint-disable-next-line react/no-array-index-key -- static skeleton-loader placeholder, never reorders
-                        <div className="space-y-2" key={`skeleton-${i}`}>
-                          <Skeleton className="h-4 w-3/4" />
-                          <Skeleton className="h-3 w-1/2" />
-                        </div>
-                      ))}
-                    </div>
-                  )}
-
-                {hasVisibleSearch &&
-                  hasActiveSearch &&
-                  !isBlockingSearchError &&
-                  !isLoading &&
-                  !hasResults && (
-                    <div className="flex h-full items-center justify-center px-4 py-8">
-                      <p className="text-muted-foreground text-sm">
-                        {hasQuery
-                          ? t("search.noResults", { query: searchQuery })
-                          : t("common.noResults")}
-                      </p>
-                    </div>
-                  )}
-
-                {shouldShowResults && (
-                  <div className="px-2 py-2">
-                    <p className="text-muted-foreground px-2 pb-2 text-xs">
-                      {t("search.resultCount", {
-                        count: totalCount,
-                      })}
-                    </p>
-                    {showSearchSummary && (
-                      <SearchSummaryItem
-                        isOpeningChat={createSummaryChatMutation.isPending}
-                        onCitationClick={(citationId) => {
-                          const hit = allHits.find(
-                            (item) => item.id === citationId,
-                          );
-                          if (hit) {
-                            openSearchResult(hit);
-                          }
-                        }}
-                        onClick={() => {
-                          handleSummarizeResults();
-                        }}
-                        onOpenChat={() => {
-                          handleOpenSummaryChat();
-                        }}
-                        summarizeMutation={summarizeSearchMutation}
-                      />
-                    )}
-                    <div
-                      className="relative"
-                      style={{ height: `${hitVirtualizer.getTotalSize()}px` }}
-                    >
-                      {virtualHits.map((virtualHit) => {
-                        const hit = allHits.at(virtualHit.index);
-                        if (!hit) {
-                          return null;
-                        }
-                        return (
-                          <div
-                            className="absolute inset-x-0 top-0"
-                            data-index={virtualHit.index}
-                            key={hit.id}
-                            ref={hitVirtualizer.measureElement}
-                            style={{
-                              transform: `translateY(${virtualHit.start}px)`,
-                            }}
-                          >
-                            <SearchResultItem
-                              hit={hit}
-                              index={virtualHit.index}
-                              onClick={(selectedHit, options) => {
-                                openSearchResult(selectedHit, options);
-                              }}
-                              resultNumber={virtualHit.index + 1}
-                            />
-                          </div>
-                        );
-                      })}
-                    </div>
-                    {(hasNextPage || isFetchNextPageError) && (
-                      <div
-                        className="flex h-10 items-center justify-center px-2 pt-2"
-                        ref={isFetchNextPageError ? undefined : loadMoreRef}
-                      >
-                        {isFetchNextPageError && (
-                          <Button
-                            onClick={() => {
-                              detached(
-                                fetchNextPage(),
-                                "search-dialog.fetch-next-page",
-                              );
-                            }}
-                            size="sm"
-                            variant="outline"
-                          >
-                            {t("common.retry")}
-                          </Button>
-                        )}
-                        {!isFetchNextPageError && isFetchingNextPage && (
-                          <LoaderIcon className="text-muted-foreground size-4 animate-spin" />
-                        )}
-                        {!isFetchNextPageError && !isFetchingNextPage && (
-                          <span className="sr-only">
-                            {t("common.loadMore")}
-                          </span>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </CommandList>
-              {showPreview && (
-                <SearchColumnResizeHandle
-                  className="hidden md:block"
-                  label={t("search.resizePreview")}
-                  max={SEARCH_PREVIEW_MAX_WIDTH}
-                  min={SEARCH_PREVIEW_MIN_WIDTH}
-                  onResize={resizePreviewColumn}
-                  value={previewWidth ?? SEARCH_PREVIEW_DEFAULT_WIDTH}
+                <SearchRecentsScreen
+                  filters={filters}
+                  onApplySavedSearch={applySavedSearch}
+                  onFileClick={openRecentFile}
+                  onFilePreview={setRecentPreviewFile}
+                  onSearchClick={applyRecentSearch}
+                  open={open}
+                  previewedFileId={displayedRecentFile?.entityId ?? null}
+                  query={query}
+                  recentFiles={recentFiles}
+                  recentSearches={recentSearches}
+                  visible={!hasVisibleSearch}
                 />
-              )}
-              {showPreview && displayedPreviewHit && (
-                <SearchPreviewPanel
-                  hit={displayedPreviewHit}
-                  locationModifierHeld={locationModifierHeld}
-                  onOpen={openSearchResult}
-                  organizationId={searchRecentsScope.organizationId}
-                  previewLocatorCandidates={previewLocatorCandidates}
-                  query={searchQuery}
-                  userId={searchRecentsScope.userId}
-                />
-              )}
-              {showPreview && !displayedPreviewHit && displayedRecentFile && (
-                <RecentFilePreviewPanel
-                  file={displayedRecentFile}
-                  locationModifierHeld={locationModifierHeld}
-                  organizationId={searchRecentsScope.organizationId}
-                  onOpen={() => {
-                    openRecentFile(displayedRecentFile);
+                <SearchResultsContent
+                  onRetry={() => {
+                    detached(refetchSearch(), "search-dialog.refetch-search");
                   }}
-                  userId={searchRecentsScope.userId}
-                />
-              )}
-              {showPreview && !displayedPreviewHit && !displayedRecentFile && (
-                <div
-                  aria-hidden="true"
-                  className={SEARCH_PREVIEW_COLUMN_CLASS_NAME}
-                  data-slot="search-preview-placeholder"
-                />
-              )}
+                  status={resultsStatus}
+                >
+                  <SearchHitResults
+                    hits={allHits}
+                    onOpenResult={openSearchResult}
+                    pagination={{
+                      fetchNextPage,
+                      hasNextPage,
+                      isFetchNextPageError,
+                      isFetchingNextPage,
+                      loadMoreRef,
+                    }}
+                    summary={{
+                      isOpeningChat: createSummaryChatMutation.isPending,
+                      onOpenChat: handleOpenSummaryChat,
+                      onSummarize: handleSummarizeResults,
+                      summarizeMutation: summarizeSearchMutation,
+                      visible: showSearchSummary,
+                    }}
+                    totalCount={totalCount}
+                    virtual={{
+                      items: virtualHits,
+                      measureElement: hitVirtualizer.measureElement,
+                      totalSize: hitVirtualizer.getTotalSize(),
+                    }}
+                  />
+                </SearchResultsContent>
+              </CommandList>
+              <SearchPreviewColumn
+                displayedHit={displayedPreviewHit}
+                displayedRecentFile={displayedRecentFile}
+                locationModifierHeld={locationModifierHeld}
+                onOpenRecentFile={openRecentFile}
+                onOpenSearchResult={openSearchResult}
+                onResize={resizePreviewColumn}
+                previewLocatorCandidates={previewLocatorCandidates}
+                previewWidth={previewWidth}
+                query={searchQuery}
+                scope={searchRecentsScope}
+                visible={showPreview}
+              />
             </div>
 
             {/* Footer: keyboard hints on the left, dialog-level controls on
                 the right — everything that is not the query itself lives
                 here so the input row stays a plain input. */}
-            <div className="flex shrink-0 items-center gap-4 border-t px-4 py-1.5">
-              <div className="text-muted-foreground flex items-center gap-4 text-xs">
-                <SearchFooterHint translationKey="search.hintNavigate" />
-                {mode.type === "pick" ? (
-                  <span className="hidden items-center gap-1 sm:inline-flex">
-                    <kbd className="border-border bg-muted rounded border px-1 py-0.5 text-[0.625rem] leading-none">
-                      ↵
-                    </kbd>
-                    {PICK_HINT_LABEL}
-                  </span>
-                ) : (
-                  <SearchFooterHint translationKey="search.hintOpen" />
-                )}
-                {canAskAI && mode.type === "browse" && (
-                  <Button
-                    aria-keyshortcuts="Tab"
-                    // The button's own `sm:text-sm` would outsize the sibling
-                    // hints at desktop widths, so both breakpoints are pinned.
-                    className="text-muted-foreground hover:text-foreground h-auto gap-1.5 px-1 py-0.5 text-xs font-normal sm:text-xs"
-                    disabled={askAIMutation.isPending}
-                    onClick={handleAskAI}
-                    variant="ghost"
-                  >
-                    {askAIMutation.isPending && (
-                      <LoaderIcon className="size-3 animate-spin" />
-                    )}
-                    {/* Below `sm` there is no Tab key to press, so the
-                        button carries a plain label; the hint wording is
-                        keyboard-first. */}
-                    <span className="sm:hidden">{t("common.askAI")}</span>
-                    <span className="hidden sm:inline">
-                      <SearchFooterHintText translationKey="search.hintAskAI" />
-                    </span>
-                  </Button>
-                )}
-                <SearchFooterHint translationKey="search.hintClose" />
-              </div>
-              <div className="ms-auto flex shrink-0 items-center gap-1">
-                <Button
-                  aria-label={t("common.preview")}
-                  aria-pressed={previewEnabled}
-                  className="hidden size-8 shrink-0 md:inline-flex"
-                  onClick={() => {
-                    setPreviewEnabled((enabled) => !enabled);
-                  }}
-                  size="icon-sm"
-                  title={t("common.preview")}
-                  variant={previewEnabled ? "secondary" : "ghost"}
-                >
-                  <DirectionalIcon className="size-4" icon={PanelRightIcon} />
-                </Button>
-              </div>
-            </div>
+            <SearchDialogFooter
+              canAskAI={canAskAI}
+              isAskingAI={askAIMutation.isPending}
+              mode={mode.type}
+              onAskAI={handleAskAI}
+              previewEnabled={previewEnabled}
+              setPreviewEnabled={setPreviewEnabled}
+            />
           </Command>
         </RenderStormRegion>
       </CommandDialogPopup>
     </CommandDialog>
+  );
+};
+
+type SearchFacetsBodyProps = {
+  editorBuckets: ComponentProps<typeof SearchableFacetGroup>["defaultBuckets"];
+  facetSearchParams: ComponentProps<
+    typeof SearchableFacetGroup
+  >["searchParams"];
+  filters: SearchFilters;
+  hasSearchCriteria: boolean;
+  locale: string;
+  mimeTypeBuckets: ComponentProps<
+    typeof SearchableFacetGroup
+  >["defaultBuckets"];
+  publicLawPreviewEnabled: boolean;
+  setFilters: (update: SearchFiltersUpdate) => void;
+  typeBuckets: readonly ComponentProps<typeof FacetGroup>["buckets"][number][];
+  workspaceBuckets: ComponentProps<
+    typeof SearchableFacetGroup
+  >["defaultBuckets"];
+};
+
+const SearchFacetsBody = ({
+  editorBuckets,
+  facetSearchParams,
+  filters,
+  hasSearchCriteria,
+  locale,
+  mimeTypeBuckets,
+  publicLawPreviewEnabled,
+  setFilters,
+  typeBuckets,
+  workspaceBuckets,
+}: SearchFacetsBodyProps) => {
+  const t = useTranslations();
+  const toggleFilter = (
+    key: "editedByUserIds" | "mimeTypes" | "types" | "workspaceIds",
+    value: string,
+  ) => {
+    setFilters((current) => ({
+      ...current,
+      [key]: toggleArrayMember(current[key], value),
+    }));
+  };
+  const selectedTypeBuckets = mergeSelectedBuckets(
+    typeBuckets.flatMap((bucket) => {
+      if (!isSearchKindOption(bucket.value)) {
+        return [];
+      }
+      if (!isAvailableSearchKind(bucket.value, publicLawPreviewEnabled)) {
+        return [];
+      }
+      return [
+        {
+          value: bucket.value,
+          count: bucket.count,
+          label: t(KIND_TRANSLATION_KEYS[bucket.value]),
+        },
+      ];
+    }),
+    filters.types,
+    (value) =>
+      isSearchKindOption(value) ? t(KIND_TRANSLATION_KEYS[value]) : value,
+  );
+  return (
+    <>
+      <TimeFacetGroup
+        locale={locale}
+        onClearCustom={() => setFilters(clearTime)}
+        onCustomChange={(range) =>
+          setFilters((current) => setCustomTime(current, range))
+        }
+        onPresetChange={(preset) =>
+          setFilters((current) =>
+            setPresetTime(
+              current,
+              current.time?.mode === "preset" && current.time.preset === preset
+                ? undefined
+                : preset,
+            ),
+          )
+        }
+        time={filters.time}
+      />
+      {hasSearchCriteria && (
+        <>
+          {typeBuckets.length + filters.types.length > 0 && (
+            <div className="mt-4">
+              <FacetGroup
+                buckets={selectedTypeBuckets}
+                onChange={(value) => {
+                  if (isSearchKindOption(value)) {
+                    toggleFilter("types", value);
+                  }
+                }}
+                selected={filters.types}
+                title={t("common.kind")}
+              />
+            </div>
+          )}
+          <div className="mt-4">
+            <SearchableFacetGroup
+              defaultBuckets={mimeTypeBuckets}
+              facet="mimeType"
+              formatLabel={(bucket) => formatMimeTypeLabel(bucket.value)}
+              onChange={(value) => toggleFilter("mimeTypes", value)}
+              searchParams={facetSearchParams}
+              selected={filters.mimeTypes}
+              title={t("search.mimeType")}
+            />
+          </div>
+          <div className="mt-4">
+            <SearchableFacetGroup
+              defaultBuckets={editorBuckets}
+              facet="editor"
+              onChange={(value) => toggleFilter("editedByUserIds", value)}
+              searchParams={facetSearchParams}
+              selected={filters.editedByUserIds}
+              title={t("search.editedBy")}
+            />
+          </div>
+          <div className="mt-4">
+            <SearchableFacetGroup
+              defaultBuckets={workspaceBuckets}
+              facet="workspace"
+              onChange={(value) => toggleFilter("workspaceIds", value)}
+              searchParams={facetSearchParams}
+              selected={filters.workspaceIds}
+              title={t("common.matter")}
+            />
+          </div>
+        </>
+      )}
+    </>
+  );
+};
+
+type SearchPreviewColumnProps = {
+  displayedHit: ComponentProps<typeof SearchPreviewPanel>["hit"] | null;
+  displayedRecentFile: RecentFile | null;
+  locationModifierHeld: boolean;
+  onOpenRecentFile: (file: RecentFile) => void;
+  onOpenSearchResult: ComponentProps<typeof SearchPreviewPanel>["onOpen"];
+  onResize: (clientX: number) => void;
+  previewLocatorCandidates: ComponentProps<
+    typeof SearchPreviewPanel
+  >["previewLocatorCandidates"];
+  previewWidth: number | null;
+  query: string;
+  scope: SearchRecentsScope;
+  visible: boolean;
+};
+
+const SearchPreviewColumn = ({
+  displayedHit,
+  displayedRecentFile,
+  locationModifierHeld,
+  onOpenRecentFile,
+  onOpenSearchResult,
+  onResize,
+  previewLocatorCandidates,
+  previewWidth,
+  query,
+  scope,
+  visible,
+}: SearchPreviewColumnProps) => {
+  const t = useTranslations();
+  if (!visible) {
+    return null;
+  }
+  let content;
+  if (displayedHit !== null) {
+    content = (
+      <SearchPreviewPanel
+        hit={displayedHit}
+        locationModifierHeld={locationModifierHeld}
+        onOpen={onOpenSearchResult}
+        organizationId={scope.organizationId}
+        previewLocatorCandidates={previewLocatorCandidates}
+        query={query}
+        userId={scope.userId}
+      />
+    );
+  } else if (displayedRecentFile !== null) {
+    content = (
+      <RecentFilePreviewPanel
+        file={displayedRecentFile}
+        locationModifierHeld={locationModifierHeld}
+        organizationId={scope.organizationId}
+        onOpen={() => onOpenRecentFile(displayedRecentFile)}
+        userId={scope.userId}
+      />
+    );
+  } else {
+    content = (
+      <div
+        aria-hidden="true"
+        className={SEARCH_PREVIEW_COLUMN_CLASS_NAME}
+        data-slot="search-preview-placeholder"
+      />
+    );
+  }
+  return (
+    <>
+      <SearchColumnResizeHandle
+        className="hidden md:block"
+        label={t("search.resizePreview")}
+        max={SEARCH_PREVIEW_MAX_WIDTH}
+        min={SEARCH_PREVIEW_MIN_WIDTH}
+        onResize={onResize}
+        value={previewWidth ?? SEARCH_PREVIEW_DEFAULT_WIDTH}
+      />
+      {content}
+    </>
+  );
+};
+
+type SearchDialogFooterProps = {
+  canAskAI: boolean;
+  isAskingAI: boolean;
+  mode: SearchDialogMode["type"];
+  onAskAI: () => void;
+  previewEnabled: boolean;
+  setPreviewEnabled: Dispatch<SetStateAction<boolean>>;
+};
+
+const SearchDialogFooter = ({
+  canAskAI,
+  isAskingAI,
+  mode,
+  onAskAI,
+  previewEnabled,
+  setPreviewEnabled,
+}: SearchDialogFooterProps) => {
+  const t = useTranslations();
+  return (
+    <div className="flex shrink-0 items-center gap-4 border-t px-4 py-1.5">
+      <div className="text-muted-foreground flex items-center gap-4 text-xs">
+        <SearchFooterHint translationKey="search.hintNavigate" />
+        {mode === "pick" ? (
+          <span className="hidden items-center gap-1 sm:inline-flex">
+            <kbd className="border-border bg-muted rounded border px-1 py-0.5 text-[0.625rem] leading-none">
+              ↵
+            </kbd>
+            {PICK_HINT_LABEL}
+          </span>
+        ) : (
+          <SearchFooterHint translationKey="search.hintOpen" />
+        )}
+        {canAskAI && mode === "browse" && (
+          <Button
+            aria-keyshortcuts="Tab"
+            className="text-muted-foreground hover:text-foreground h-auto gap-1.5 px-1 py-0.5 text-xs font-normal sm:text-xs"
+            disabled={isAskingAI}
+            onClick={onAskAI}
+            variant="ghost"
+          >
+            {isAskingAI && <LoaderIcon className="size-3 animate-spin" />}
+            <span className="sm:hidden">{t("common.askAI")}</span>
+            <span className="hidden sm:inline">
+              <SearchFooterHintText translationKey="search.hintAskAI" />
+            </span>
+          </Button>
+        )}
+        <SearchFooterHint translationKey="search.hintClose" />
+      </div>
+      <div className="ms-auto flex shrink-0 items-center gap-1">
+        <Button
+          aria-label={t("common.preview")}
+          aria-pressed={previewEnabled}
+          className="hidden size-8 shrink-0 md:inline-flex"
+          onClick={() => setPreviewEnabled((enabled) => !enabled)}
+          size="icon-sm"
+          title={t("common.preview")}
+          variant={previewEnabled ? "secondary" : "ghost"}
+        >
+          <DirectionalIcon className="size-4" icon={PanelRightIcon} />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+type SearchRecentsScreenProps = {
+  filters: SearchFilters;
+  onApplySavedSearch: (criteria: SavedSearchCriteria) => void;
+  onFileClick: (file: RecentFile) => void;
+  onFilePreview: (file: RecentFile) => void;
+  onSearchClick: (search: RecentSearch) => void;
+  open: boolean;
+  previewedFileId: string | null;
+  query: string;
+  recentFiles: RecentFile[];
+  recentSearches: RecentSearch[];
+  visible: boolean;
+};
+
+const SearchRecentsScreen = ({
+  filters,
+  onApplySavedSearch,
+  onFileClick,
+  onFilePreview,
+  onSearchClick,
+  open,
+  previewedFileId,
+  query,
+  recentFiles,
+  recentSearches,
+  visible,
+}: SearchRecentsScreenProps) => {
+  if (!visible) {
+    return null;
+  }
+  return (
+    <>
+      <SavedSearches
+        filters={filters}
+        isOpen={open}
+        onApply={onApplySavedSearch}
+        overlayLayer="search-child"
+        query={query}
+        showTrigger={false}
+      />
+      <SearchRecents
+        onFileClick={onFileClick}
+        onFilePreview={onFilePreview}
+        onSearchClick={onSearchClick}
+        previewedFileId={previewedFileId}
+        recentFiles={recentFiles}
+        recentSearches={recentSearches}
+      />
+    </>
+  );
+};
+
+const SearchResultsContent = ({
+  children,
+  onRetry,
+  status,
+}: {
+  children: ReactElement;
+  onRetry: () => void;
+  status: SearchResultsStatus;
+}): ReactElement | null => {
+  const t = useTranslations();
+  switch (status.type) {
+    case "hidden":
+      return null;
+    case "unavailable":
+      return (
+        <div className="flex h-full items-center justify-center px-4 py-8">
+          <p className="text-muted-foreground text-sm">
+            {t("common.comingSoon")}
+          </p>
+        </div>
+      );
+    case "error":
+      return (
+        <div className="flex h-full flex-col items-center justify-center gap-3 px-4 py-8">
+          <p className="text-muted-foreground text-sm">
+            {t("common.somethingWentWrong")}
+          </p>
+          <Button onClick={onRetry} size="sm" variant="outline">
+            {t("common.retry")}
+          </Button>
+        </div>
+      );
+    case "loading":
+      return (
+        <div className="space-y-3 px-4 py-3">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div className="space-y-2" key={`skeleton-${String(index)}`}>
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+          ))}
+        </div>
+      );
+    case "empty":
+      return (
+        <div className="flex h-full items-center justify-center px-4 py-8">
+          <p className="text-muted-foreground text-sm">
+            {status.query === null
+              ? t("common.noResults")
+              : t("search.noResults", { query: status.query })}
+          </p>
+        </div>
+      );
+    case "results":
+      return children;
+    default: {
+      const exhaustive: never = status;
+      return exhaustive;
+    }
+  }
+};
+
+type SearchHitResultsProps = {
+  hits: readonly GlobalSearchHit[];
+  onOpenResult: ComponentProps<typeof SearchResultItem>["onClick"];
+  pagination: {
+    fetchNextPage: () => Promise<unknown>;
+    hasNextPage: boolean;
+    isFetchNextPageError: boolean;
+    isFetchingNextPage: boolean;
+    loadMoreRef: (target: HTMLDivElement | null) => (() => void) | undefined;
+  };
+  summary: {
+    isOpeningChat: boolean;
+    onOpenChat: () => void;
+    onSummarize: () => void;
+    summarizeMutation: ComponentProps<
+      typeof SearchSummaryItem
+    >["summarizeMutation"];
+    visible: boolean;
+  };
+  totalCount: number;
+  virtual: {
+    items: VirtualItem[];
+    measureElement: (element: Element | null) => void;
+    totalSize: number;
+  };
+};
+
+const SearchHitResults = ({
+  hits,
+  onOpenResult,
+  pagination,
+  summary,
+  totalCount,
+  virtual,
+}: SearchHitResultsProps) => {
+  const t = useTranslations();
+  return (
+    <div className="px-2 py-2">
+      <p className="text-muted-foreground px-2 pb-2 text-xs">
+        {t("search.resultCount", { count: totalCount })}
+      </p>
+      {summary.visible && (
+        <SearchSummaryItem
+          isOpeningChat={summary.isOpeningChat}
+          onCitationClick={(citationId) => {
+            const hit = hits.find((item) => item.id === citationId);
+            if (hit) {
+              onOpenResult(hit);
+            }
+          }}
+          onClick={summary.onSummarize}
+          onOpenChat={summary.onOpenChat}
+          summarizeMutation={summary.summarizeMutation}
+        />
+      )}
+      <div className="relative" style={{ height: `${virtual.totalSize}px` }}>
+        {virtual.items.map((virtualHit) => {
+          const hit = hits.at(virtualHit.index);
+          if (!hit) {
+            return null;
+          }
+          return (
+            <div
+              className="absolute inset-x-0 top-0"
+              data-index={virtualHit.index}
+              key={hit.id}
+              ref={virtual.measureElement}
+              style={{ transform: `translateY(${virtualHit.start}px)` }}
+            >
+              <SearchResultItem
+                hit={hit}
+                index={virtualHit.index}
+                onClick={onOpenResult}
+                resultNumber={virtualHit.index + 1}
+              />
+            </div>
+          );
+        })}
+      </div>
+      {(pagination.hasNextPage || pagination.isFetchNextPageError) && (
+        <div
+          className="flex h-10 items-center justify-center px-2 pt-2"
+          ref={
+            pagination.isFetchNextPageError ? undefined : pagination.loadMoreRef
+          }
+        >
+          {pagination.isFetchNextPageError && (
+            <Button
+              onClick={() => {
+                detached(
+                  pagination.fetchNextPage(),
+                  "search-dialog.fetch-next-page",
+                );
+              }}
+              size="sm"
+              variant="outline"
+            >
+              {t("common.retry")}
+            </Button>
+          )}
+          {!pagination.isFetchNextPageError &&
+            pagination.isFetchingNextPage && (
+              <LoaderIcon className="text-muted-foreground size-4 animate-spin" />
+            )}
+          {!pagination.isFetchNextPageError &&
+            !pagination.isFetchingNextPage && (
+              <span className="sr-only">{t("common.loadMore")}</span>
+            )}
+        </div>
+      )}
+    </div>
   );
 };

--- a/apps/web/src/components/workspaces/create-property.tsx
+++ b/apps/web/src/components/workspaces/create-property.tsx
@@ -483,12 +483,11 @@ const PropertyComposerBody = ({
   // was renamed/removed, or if the user switched away from a select
   // content type. The backend rejects mismatched fallbacks; sanitising
   // here keeps the UI honest without round-tripping through setState.
-  const effectiveFallback =
-    fallback !== null &&
-    needsOptions &&
-    options.some((o) => o.value === fallback)
-      ? fallback
-      : null;
+  const effectiveFallback = getEffectiveFallback({
+    fallback,
+    needsOptions,
+    options,
+  });
 
   // Keep the auto-included file chips in sync if the underlying
   // properties list changes (e.g., a file property is created from
@@ -499,46 +498,23 @@ const PropertyComposerBody = ({
     validFileIds.has(id),
   );
 
-  const dependencyIds = [
-    ...new Set([...effectiveSelectedFileIds, ...textareaMentions]),
-  ];
-
-  const availableFileToAdd = fileProperties.filter(
-    (p) => !effectiveSelectedFileIds.includes(p.id),
-  );
-
-  // The dependency list the save sends, derived on every render so the cap
-  // below sees the same count the server will. Per-dependency conditions
-  // configured via the conditions sub-modal are preserved; new mentions
-  // default to null. The "Applies to" scope owns the classifier slot: drop
-  // the classifier dependency only when it is (or was) a scope gate, then
-  // re-add the gate below for the chosen document type. A plain classifier
-  // mention with no scope is preserved with its condition.
-  const dependencies: PropertyDependency[] = [];
-  for (const id of dependencyIds) {
-    const isScopeGate =
-      id === classifier?.id &&
-      !(scopeDocType === null && initialScopeDocType === null);
-    if (isScopeGate) {
-      continue;
-    }
-    dependencies.push({
-      dependsOnPropertyId: toSafeId<"property">(id),
-      condition: initialDependencyConditions.get(id) ?? null,
-    });
-  }
-  if (classifier && scopeDocType !== null) {
-    dependencies.push(buildDocTypeGate(classifier.id, scopeDocType));
-  }
-
-  // Mirrors the server rule: a list stored under an earlier, larger cap may
-  // be kept or shrunk, never grown past the cap.
-  const dependencyCap = Math.max(
-    PROPERTY_DEPENDENCIES_PER_PROPERTY_MAX,
-    editingTool?.type === "ai-model" ? editingTool.dependencies.length : 0,
-  );
-  const canAddDependency = dependencies.length < dependencyCap;
-  const overDependencyCap = dependencies.length > dependencyCap;
+  const {
+    availableFileToAdd,
+    canAddDependency,
+    dependencies,
+    dependencyCap,
+    dependencyIds,
+    overDependencyCap,
+  } = getPropertyDependencyState({
+    classifier,
+    editingTool,
+    effectiveSelectedFileIds,
+    fileProperties,
+    initialDependencyConditions,
+    initialScopeDocType,
+    scopeDocType,
+    textareaMentions,
+  });
 
   // Manual properties skip the prompt + dependency requirements; the
   // user fills values by hand. Select-type rules still apply.
@@ -831,6 +807,75 @@ const PropertyComposerBody = ({
     </>
   );
 };
+
+const getPropertyDependencyState = ({
+  classifier,
+  editingTool,
+  effectiveSelectedFileIds,
+  fileProperties,
+  initialDependencyConditions,
+  initialScopeDocType,
+  scopeDocType,
+  textareaMentions,
+}: {
+  classifier: ReturnType<typeof resolveDocumentTypeClassifier>;
+  editingTool: WorkspaceProperty["tool"] | undefined;
+  effectiveSelectedFileIds: string[];
+  fileProperties: WorkspaceProperty[];
+  initialDependencyConditions: Map<string, PropertyDependency["condition"]>;
+  initialScopeDocType: string | null;
+  scopeDocType: string | null;
+  textareaMentions: string[];
+}) => {
+  const dependencyIds = [
+    ...new Set([...effectiveSelectedFileIds, ...textareaMentions]),
+  ];
+  const dependencies: PropertyDependency[] = [];
+  for (const id of dependencyIds) {
+    const isScopeGate =
+      id === classifier?.id &&
+      !(scopeDocType === null && initialScopeDocType === null);
+    if (isScopeGate) {
+      continue;
+    }
+    dependencies.push({
+      dependsOnPropertyId: toSafeId<"property">(id),
+      condition: initialDependencyConditions.get(id) ?? null,
+    });
+  }
+  if (classifier && scopeDocType !== null) {
+    dependencies.push(buildDocTypeGate(classifier.id, scopeDocType));
+  }
+  const dependencyCap = Math.max(
+    PROPERTY_DEPENDENCIES_PER_PROPERTY_MAX,
+    editingTool?.type === "ai-model" ? editingTool.dependencies.length : 0,
+  );
+  return {
+    availableFileToAdd: fileProperties.filter(
+      (property) => !effectiveSelectedFileIds.includes(property.id),
+    ),
+    canAddDependency: dependencies.length < dependencyCap,
+    dependencies,
+    dependencyCap,
+    dependencyIds,
+    overDependencyCap: dependencies.length > dependencyCap,
+  };
+};
+
+const getEffectiveFallback = ({
+  fallback,
+  needsOptions,
+  options,
+}: {
+  fallback: string | null;
+  needsOptions: boolean;
+  options: WorkspacePropertyOption[];
+}) =>
+  fallback !== null &&
+  needsOptions &&
+  options.some((option) => option.value === fallback)
+    ? fallback
+    : null;
 
 type ComposerCardProps = {
   workspaceId: string;

--- a/apps/web/src/features/chat/chat-runtime.ts
+++ b/apps/web/src/features/chat/chat-runtime.ts
@@ -650,6 +650,79 @@ export const buildSendRequestBody = ({
     body.userContext = userContext;
   }
 
+  applyChatContext({ body, context });
+
+  const { editApplyMode, docxEditRepresentation } =
+    resolveChatRequestDocxEditPreferences({
+      context,
+      key,
+      messages,
+      requestBody,
+    });
+  if (editApplyMode !== undefined) {
+    body.editApplyMode = editApplyMode;
+  }
+
+  if (docxEditRepresentation !== undefined) {
+    body.docxEditRepresentation = docxEditRepresentation;
+  }
+
+  if (
+    message.role === "user" &&
+    (editApplyMode !== undefined || docxEditRepresentation !== undefined)
+  ) {
+    body.message.metadata = {
+      ...message.metadata,
+      docxEditPreferences: {
+        ...(editApplyMode === undefined ? {} : { editApplyMode }),
+        ...(docxEditRepresentation === undefined
+          ? {}
+          : { docxEditRepresentation }),
+      },
+    };
+  }
+
+  if (run.resume === undefined) {
+    if (run.parentRunId !== undefined) {
+      panic("Chat continuation parent is missing native resume data");
+    }
+    return body;
+  }
+  const continuationMessage = body.message;
+  if (
+    run.parentRunId === undefined ||
+    continuationMessage.role !== "assistant"
+  ) {
+    panic("Native chat resume must continue an assistant message");
+  }
+  return {
+    ...body,
+    message: { ...continuationMessage, role: "assistant" },
+    parentRunId: run.parentRunId,
+    resume: run.resume.map((resolution) => {
+      if (resolution.status === "cancelled") {
+        return {
+          interruptId: resolution.interruptId,
+          status: resolution.status,
+        };
+      }
+      const payload: unknown = resolution.payload;
+      return {
+        interruptId: resolution.interruptId,
+        ...(payload === undefined ? {} : { payload }),
+        status: resolution.status,
+      };
+    }),
+  };
+};
+
+const applyChatContext = ({
+  body,
+  context,
+}: {
+  body: ChatSendRequestDraft;
+  context: ChatThreadOptionsContext | undefined;
+}) => {
   const activeFile = context?.getActiveFile?.();
   if (activeFile) {
     body.activeFile = {
@@ -749,69 +822,6 @@ export const buildSendRequestBody = ({
       toSafeId<"workspace">(id),
     );
   }
-
-  const { editApplyMode, docxEditRepresentation } =
-    resolveChatRequestDocxEditPreferences({
-      context,
-      key,
-      messages,
-      requestBody,
-    });
-  if (editApplyMode !== undefined) {
-    body.editApplyMode = editApplyMode;
-  }
-
-  if (docxEditRepresentation !== undefined) {
-    body.docxEditRepresentation = docxEditRepresentation;
-  }
-
-  if (
-    message.role === "user" &&
-    (editApplyMode !== undefined || docxEditRepresentation !== undefined)
-  ) {
-    body.message.metadata = {
-      ...message.metadata,
-      docxEditPreferences: {
-        ...(editApplyMode === undefined ? {} : { editApplyMode }),
-        ...(docxEditRepresentation === undefined
-          ? {}
-          : { docxEditRepresentation }),
-      },
-    };
-  }
-
-  if (run.resume === undefined) {
-    if (run.parentRunId !== undefined) {
-      panic("Chat continuation parent is missing native resume data");
-    }
-    return body;
-  }
-  const continuationMessage = body.message;
-  if (
-    run.parentRunId === undefined ||
-    continuationMessage.role !== "assistant"
-  ) {
-    panic("Native chat resume must continue an assistant message");
-  }
-  return {
-    ...body,
-    message: { ...continuationMessage, role: "assistant" },
-    parentRunId: run.parentRunId,
-    resume: run.resume.map((resolution) => {
-      if (resolution.status === "cancelled") {
-        return {
-          interruptId: resolution.interruptId,
-          status: resolution.status,
-        };
-      }
-      const payload: unknown = resolution.payload;
-      return {
-        interruptId: resolution.interruptId,
-        ...(payload === undefined ? {} : { payload }),
-        status: resolution.status,
-      };
-    }),
-  };
 };
 
 const getRequestSendMode = (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -826,340 +826,82 @@ export const RowActions = ({
       </Tooltip>
       <MenuPopup anchor={anchor ?? undefined}>
         {/* --- View / Edit --- */}
-        {resolvedOnOpen && (
-          <MenuItem onClick={resolvedOnOpen}>
-            <EyeIcon />
-            {t("common.preview")}
-          </MenuItem>
-        )}
-        {!isBulk && onRename && (
-          <MenuItem onClick={onRename}>
-            <PencilIcon />
-            {t("common.rename")}
-          </MenuItem>
-        )}
-        {!isCellContext && canUploadVersion && (
-          <MenuItem
-            disabled={uploadVersion.isPending}
-            onClick={handleUploadVersionSelect}
-          >
-            <UploadIcon />
-            {t("fileDetail.uploadNewVersion")}
-          </MenuItem>
-        )}
-        {canRunOcr && (
-          <MenuItem
-            className="min-h-11 sm:min-h-11"
-            disabled={isOcrPending}
-            onClick={() => {
-              detached(handleRunOcr(ocrSource), "row-actions.run-ocr");
-            }}
-          >
-            <ScanTextIcon />
-            {t("workspaces.files.runOcr")}
-          </MenuItem>
-        )}
-        {rowOcrSources.length > 0 && (
-          <MenuSub>
-            <MenuSubTrigger className="min-h-11 sm:min-h-11">
-              <ScanTextIcon />
-              {t("workspaces.files.runOcr")}
-            </MenuSubTrigger>
-            <MenuSubPopup>
-              {rowOcrSources.map((source) => (
-                <MenuItem
-                  className="min-h-11 sm:min-h-11"
-                  disabled={isOcrPending}
-                  key={source.fieldId}
-                  onClick={() => {
-                    detached(handleRunOcr(source), "row-actions.run-ocr");
-                  }}
-                >
-                  <ScanTextIcon />
-                  <BidiText as="span" className="max-w-64 truncate">
-                    {source.fileName}
-                  </BidiText>
-                </MenuItem>
-              ))}
-            </MenuSubPopup>
-          </MenuSub>
-        )}
-        {!isBulk && cellMetadataTarget && (
-          <>
-            {canRetryCell && (
-              <MenuItem
-                disabled={retryDisabled}
-                onClick={() =>
-                  detached(handleRetryCell(), "row-actions.retry-cell")
-                }
-              >
-                <RefreshCwIcon />
-                {t("common.retry")}
-              </MenuItem>
-            )}
-            <CellLockMenuItem
-              entityId={entity.entityId}
-              metadata={cellMetadataTarget.metadata}
-              propertyId={cellMetadataTarget.propertyId}
-              workspaceId={workspaceId}
-            />
-            <MenuSeparator />
-            <CellMetadataMenuSection
-              entityId={entity.entityId}
-              metadata={cellMetadataTarget.metadata}
-              propertyId={cellMetadataTarget.propertyId}
-              workspaceId={workspaceId}
-            />
-          </>
-        )}
-        {!isCellContext && !isBulk && isFolder && onSubfolderCreated && (
-          <CreateSubfolderMenuItem
-            entity={entity}
-            onSubfolderCreated={onSubfolderCreated}
-            workspaceId={workspaceId}
-          />
-        )}
-        {!isCellContext && canOpenInDesktop && (
-          <MenuItem
-            onClick={() => {
-              detached(handleOpenInDesktop(), "row-actions.open-in-desktop");
-            }}
-          >
-            <LaptopIcon />
-            {t("workspaces.files.desktopEdit.action")}
-          </MenuItem>
-        )}
-        {!isCellContext &&
-          !entity.readOnly &&
-          hasDesktopEditFileType &&
-          desktopEditLockState !== "unlocked" && (
-            <MenuItem
-              onClick={() => {
-                detached(handleReleaseLock(), "row-actions.release-lock");
-              }}
-            >
-              <LockOpenIcon />
-              {t("workspaces.files.desktopEdit.releaseLock")}
-            </MenuItem>
-          )}
+        <RowOpenMenuActions
+          canUploadVersion={canUploadVersion}
+          isBulk={isBulk}
+          isCellContext={isCellContext}
+          onOpen={resolvedOnOpen}
+          onRename={onRename}
+          onUploadVersion={handleUploadVersionSelect}
+          uploadVersionPending={uploadVersion.isPending}
+        />
+        <RowOcrMenuActions
+          canRunOcr={canRunOcr}
+          isPending={isOcrPending}
+          onRun={handleRunOcr}
+          rowSources={rowOcrSources}
+          selectedSource={ocrSource}
+        />
+        <RowCellMenuActions
+          canRetry={canRetryCell}
+          entityId={entity.entityId}
+          isBulk={isBulk}
+          metadataTarget={cellMetadataTarget}
+          onRetry={handleRetryCell}
+          retryDisabled={retryDisabled}
+          workspaceId={workspaceId}
+        />
+        <RowFolderDesktopMenuActions
+          canOpenInDesktop={canOpenInDesktop}
+          canReleaseDesktopLock={
+            !entity.readOnly &&
+            hasDesktopEditFileType &&
+            desktopEditLockState !== "unlocked"
+          }
+          entity={entity}
+          isBulk={isBulk}
+          isCellContext={isCellContext}
+          isFolder={isFolder}
+          onOpenInDesktop={handleOpenInDesktop}
+          onReleaseDesktopLock={handleReleaseLock}
+          onSubfolderCreated={onSubfolderCreated}
+          workspaceId={workspaceId}
+        />
 
         <MenuSeparator />
 
         {/* --- Features --- */}
-        {!isBulk && !isFolder && entity.kind !== "task" && file && (
-          <MenuItem onClick={openVersionHistory}>
-            {/* Same intent as the inspector's full-view button
-                (open this file in the document route — the
-                versions panel is just one of the facets there).
-                Match the icon + label so the two surfaces don't
-                look like two different actions. */}
-            <Maximize2Icon />
-            {t("workspaces.pdf.fullView")}
-          </MenuItem>
-        )}
-        <MenuItem onClick={handleChatAbout}>
-          <MessageSquareIcon />
-          {t("chat.chatAbout")}
-        </MenuItem>
-
-        {isCellContext && exportableOcrSources.length === 1 && (
-          <>
-            <MenuSeparator />
-            {exportableOcrSources.map((source) => (
-              <OcrExportMenuItems
-                key={source.fieldId}
-                exportStatus={source.exportStatus}
-                onDownload={(format) => {
-                  detached(
-                    handleOcrExport(source, format),
-                    "row-actions.ocr-export",
-                  );
-                }}
-                searchablePdfLabel={t("workspaces.files.downloadSearchablePdf")}
-                textLabel={t("workspaces.files.downloadExtractedText")}
-              />
-            ))}
-          </>
-        )}
-
-        {!isCellContext && (
-          <>
-            <MenuSeparator />
-
-            {/* --- File operations --- */}
-            {hasAnyFile && (isBulk || !hasDownloadVariants) && (
-              <MenuItem
-                onClick={() => {
-                  detached(handleDownload(), "row-actions.download");
-                }}
-              >
-                <DownloadIcon />
-                {t("common.download")}
-              </MenuItem>
-            )}
-            {hasDownloadVariants && (
-              <MenuSub>
-                <MenuSubTrigger>
-                  <DownloadIcon />
-                  {t("common.download")}
-                </MenuSubTrigger>
-                <MenuSubPopup>
-                  <MenuItem
-                    onClick={() => {
-                      detached(handleDownload(), "row-actions.download");
-                    }}
-                  >
-                    <DownloadIcon />
-                    {t("workspaces.files.downloadOriginal")}
-                  </MenuItem>
-                  {hasPdfConversion && (
-                    <MenuItem
-                      onClick={() => {
-                        detached(handleDownload("pdf"), "row-actions.download");
-                      }}
-                    >
-                      <FileOutputIcon />
-                      {t("workspaces.files.downloadPdf")}
-                    </MenuItem>
-                  )}
-                  {canScrub && (
-                    <Tooltip
-                      content={t("workspaces.files.downloadScrubbedHint")}
-                      render={
-                        <MenuItem
-                          onClick={() => {
-                            detached(
-                              handleDownload("scrubbed"),
-                              "row-actions.download",
-                            );
-                          }}
-                        >
-                          <EraserIcon />
-                          {t("workspaces.files.downloadScrubbed")}
-                        </MenuItem>
-                      }
-                    />
-                  )}
-                  {exportableOcrSources.length === 1 &&
-                    exportableOcrSources.map((source) => (
-                      <OcrExportMenuItems
-                        key={source.fieldId}
-                        exportStatus={source.exportStatus}
-                        onDownload={(format) => {
-                          detached(
-                            handleOcrExport(source, format),
-                            "row-actions.ocr-export",
-                          );
-                        }}
-                        searchablePdfLabel={t(
-                          "workspaces.files.downloadSearchablePdf",
-                        )}
-                        textLabel={t("workspaces.files.downloadExtractedText")}
-                      />
-                    ))}
-                  {exportableOcrSources.length > 1 &&
-                    exportableOcrSources.map((source) => (
-                      <MenuSub key={source.fieldId}>
-                        <MenuSubTrigger>
-                          <ScanTextIcon />
-                          <BidiText as="span" className="max-w-64 truncate">
-                            {source.fileName}
-                          </BidiText>
-                        </MenuSubTrigger>
-                        <MenuSubPopup>
-                          <OcrExportMenuItems
-                            exportStatus={source.exportStatus}
-                            onDownload={(format) => {
-                              detached(
-                                handleOcrExport(source, format),
-                                "row-actions.ocr-export",
-                              );
-                            }}
-                            searchablePdfLabel={t(
-                              "workspaces.files.downloadSearchablePdf",
-                            )}
-                            textLabel={t(
-                              "workspaces.files.downloadExtractedText",
-                            )}
-                          />
-                        </MenuSubPopup>
-                      </MenuSub>
-                    ))}
-                </MenuSubPopup>
-              </MenuSub>
-            )}
-            {hasAnyFolder && (
-              <MenuItem
-                onClick={() => {
-                  detached(handleZipDownload(), "row-actions.zip-download");
-                }}
-              >
-                <ArchiveIcon />
-                {t("workspaces.files.downloadAsZip")}
-              </MenuItem>
-            )}
-            <MenuItem
-              onClick={() => {
-                detached(handleDuplicate(), "row-actions.duplicate");
-              }}
-            >
-              <CopyIcon />
-              {t("common.duplicate")}
-            </MenuItem>
-            <MenuItem
-              onClick={() => {
-                openCopyToMatterDialog();
-              }}
-            >
-              <FolderSyncIcon />
-              {t("workspaces.copyToMatter.menuItem")}
-            </MenuItem>
-
-            <MenuSeparator />
-
-            {/* --- Destructive --- */}
-            <AlertDialog>
-              <AlertDialogTrigger
-                render={<MenuItem closeOnClick={false} variant="destructive" />}
-              >
-                <Trash2Icon />
-                {t("common.delete")}
-              </AlertDialogTrigger>
-              <AlertDialogPopup>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>
-                    {isBulk
-                      ? t("workspaces.deleteItems", {
-                          count: selectedEntities.length,
-                        })
-                      : t("workspaces.deleteItem")}
-                  </AlertDialogTitle>
-                  <AlertDialogDescription>
-                    {isBulk
-                      ? t("workspaces.deleteItemsDescription", {
-                          count: selectedEntities.length,
-                        })
-                      : t("common.deleteConfirmDescription", {
-                          name,
-                        })}
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogClose render={<Button variant="ghost" />}>
-                    {t("common.cancel")}
-                  </AlertDialogClose>
-                  <AlertDialogClose
-                    render={
-                      <Button onClick={handleDelete} variant="destructive" />
-                    }
-                  >
-                    {t("common.delete")}
-                  </AlertDialogClose>
-                </AlertDialogFooter>
-              </AlertDialogPopup>
-            </AlertDialog>
-          </>
-        )}
+        <RowFeatureMenuActions
+          file={file}
+          isBulk={isBulk}
+          isFolder={isFolder}
+          kind={entity.kind}
+          onChatAbout={handleChatAbout}
+          onOpenVersionHistory={openVersionHistory}
+        />
+        <RowCellOcrExportMenuActions
+          isCellContext={isCellContext}
+          onExport={handleOcrExport}
+          sources={exportableOcrSources}
+        />
+        <RowFileOperationsMenu
+          canScrub={canScrub}
+          exportableOcrSources={exportableOcrSources}
+          hasAnyFile={hasAnyFile}
+          hasAnyFolder={hasAnyFolder}
+          hasDownloadVariants={hasDownloadVariants}
+          hasPdfConversion={hasPdfConversion}
+          isBulk={isBulk}
+          isCellContext={isCellContext}
+          name={name}
+          onCopyToMatter={openCopyToMatterDialog}
+          onDelete={handleDelete}
+          onDownload={handleDownload}
+          onDuplicate={handleDuplicate}
+          onOcrExport={handleOcrExport}
+          onZipDownload={handleZipDownload}
+          selectedCount={bulkTargets.length}
+        />
       </MenuPopup>
       <CopyToMatterDialog
         entities={copyToMatterEntities}
@@ -1178,6 +920,466 @@ export const RowActions = ({
         />
       )}
     </Menu>
+  );
+};
+
+const RowOpenMenuActions = ({
+  canUploadVersion,
+  isBulk,
+  isCellContext,
+  onOpen,
+  onRename,
+  onUploadVersion,
+  uploadVersionPending,
+}: {
+  canUploadVersion: boolean;
+  isBulk: boolean;
+  isCellContext: boolean;
+  onOpen: (() => void) | undefined;
+  onRename: (() => void) | undefined;
+  onUploadVersion: () => void;
+  uploadVersionPending: boolean;
+}) => {
+  const t = useTranslations();
+  return (
+    <>
+      {onOpen !== undefined && (
+        <MenuItem onClick={onOpen}>
+          <EyeIcon />
+          {t("common.preview")}
+        </MenuItem>
+      )}
+      {!isBulk && onRename !== undefined && (
+        <MenuItem onClick={onRename}>
+          <PencilIcon />
+          {t("common.rename")}
+        </MenuItem>
+      )}
+      {!isCellContext && canUploadVersion && (
+        <MenuItem disabled={uploadVersionPending} onClick={onUploadVersion}>
+          <UploadIcon />
+          {t("fileDetail.uploadNewVersion")}
+        </MenuItem>
+      )}
+    </>
+  );
+};
+
+const RowOcrMenuActions = ({
+  canRunOcr,
+  isPending,
+  onRun,
+  rowSources,
+  selectedSource,
+}: {
+  canRunOcr: boolean;
+  isPending: boolean;
+  onRun: (source: OcrSource | undefined) => Promise<void>;
+  rowSources: readonly OcrSource[];
+  selectedSource: OcrSource | undefined;
+}) => {
+  const t = useTranslations();
+  return (
+    <>
+      {canRunOcr && (
+        <MenuItem
+          className="min-h-11 sm:min-h-11"
+          disabled={isPending}
+          onClick={() => detached(onRun(selectedSource), "row-actions.run-ocr")}
+        >
+          <ScanTextIcon />
+          {t("workspaces.files.runOcr")}
+        </MenuItem>
+      )}
+      {rowSources.length > 0 && (
+        <MenuSub>
+          <MenuSubTrigger className="min-h-11 sm:min-h-11">
+            <ScanTextIcon />
+            {t("workspaces.files.runOcr")}
+          </MenuSubTrigger>
+          <MenuSubPopup>
+            {rowSources.map((source) => (
+              <MenuItem
+                className="min-h-11 sm:min-h-11"
+                disabled={isPending}
+                key={source.fieldId}
+                onClick={() => detached(onRun(source), "row-actions.run-ocr")}
+              >
+                <ScanTextIcon />
+                <BidiText as="span" className="max-w-64 truncate">
+                  {source.fileName}
+                </BidiText>
+              </MenuItem>
+            ))}
+          </MenuSubPopup>
+        </MenuSub>
+      )}
+    </>
+  );
+};
+
+const RowCellMenuActions = ({
+  canRetry,
+  entityId,
+  isBulk,
+  metadataTarget,
+  onRetry,
+  retryDisabled,
+  workspaceId,
+}: {
+  canRetry: boolean;
+  entityId: string;
+  isBulk: boolean;
+  metadataTarget: RowActionsProps["cellMetadataTarget"];
+  onRetry: () => Promise<void>;
+  retryDisabled: boolean;
+  workspaceId: string;
+}) => {
+  const t = useTranslations();
+  if (isBulk || metadataTarget === null || metadataTarget === undefined) {
+    return null;
+  }
+  return (
+    <>
+      {canRetry && (
+        <MenuItem
+          disabled={retryDisabled}
+          onClick={() => detached(onRetry(), "row-actions.retry-cell")}
+        >
+          <RefreshCwIcon />
+          {t("common.retry")}
+        </MenuItem>
+      )}
+      <CellLockMenuItem
+        entityId={entityId}
+        metadata={metadataTarget.metadata}
+        propertyId={metadataTarget.propertyId}
+        workspaceId={workspaceId}
+      />
+      <MenuSeparator />
+      <CellMetadataMenuSection
+        entityId={entityId}
+        metadata={metadataTarget.metadata}
+        propertyId={metadataTarget.propertyId}
+        workspaceId={workspaceId}
+      />
+    </>
+  );
+};
+
+const RowFolderDesktopMenuActions = ({
+  canOpenInDesktop,
+  canReleaseDesktopLock,
+  entity,
+  isBulk,
+  isCellContext,
+  isFolder,
+  onOpenInDesktop,
+  onReleaseDesktopLock,
+  onSubfolderCreated,
+  workspaceId,
+}: {
+  canOpenInDesktop: boolean;
+  canReleaseDesktopLock: boolean;
+  entity: WorkspaceEntity;
+  isBulk: boolean;
+  isCellContext: boolean;
+  isFolder: boolean;
+  onOpenInDesktop: () => Promise<void>;
+  onReleaseDesktopLock: () => Promise<void>;
+  onSubfolderCreated: RowActionsProps["onSubfolderCreated"];
+  workspaceId: string;
+}) => {
+  const t = useTranslations();
+  if (isCellContext) {
+    return null;
+  }
+  return (
+    <>
+      {!isBulk && isFolder && onSubfolderCreated !== undefined && (
+        <CreateSubfolderMenuItem
+          entity={entity}
+          onSubfolderCreated={onSubfolderCreated}
+          workspaceId={workspaceId}
+        />
+      )}
+      {canOpenInDesktop && (
+        <MenuItem
+          onClick={() =>
+            detached(onOpenInDesktop(), "row-actions.open-in-desktop")
+          }
+        >
+          <LaptopIcon />
+          {t("workspaces.files.desktopEdit.action")}
+        </MenuItem>
+      )}
+      {canReleaseDesktopLock && (
+        <MenuItem
+          onClick={() =>
+            detached(onReleaseDesktopLock(), "row-actions.release-lock")
+          }
+        >
+          <LockOpenIcon />
+          {t("workspaces.files.desktopEdit.releaseLock")}
+        </MenuItem>
+      )}
+    </>
+  );
+};
+
+const RowFeatureMenuActions = ({
+  file,
+  isBulk,
+  isFolder,
+  kind,
+  onChatAbout,
+  onOpenVersionHistory,
+}: {
+  file: ReturnType<typeof getFirstFile>;
+  isBulk: boolean;
+  isFolder: boolean;
+  kind: WorkspaceEntity["kind"];
+  onChatAbout: () => void;
+  onOpenVersionHistory: (() => void) | undefined;
+}) => {
+  const t = useTranslations();
+  return (
+    <>
+      {!isBulk &&
+        !isFolder &&
+        kind !== "task" &&
+        file !== null &&
+        onOpenVersionHistory !== undefined && (
+          <MenuItem onClick={onOpenVersionHistory}>
+            <Maximize2Icon />
+            {t("workspaces.pdf.fullView")}
+          </MenuItem>
+        )}
+      <MenuItem onClick={onChatAbout}>
+        <MessageSquareIcon />
+        {t("chat.chatAbout")}
+      </MenuItem>
+    </>
+  );
+};
+
+const RowCellOcrExportMenuActions = ({
+  isCellContext,
+  onExport,
+  sources,
+}: {
+  isCellContext: boolean;
+  onExport: (source: OcrSource, format: OcrExportFormat) => Promise<void>;
+  sources: readonly OcrSource[];
+}) => {
+  const t = useTranslations();
+  if (!isCellContext || sources.length !== 1) {
+    return null;
+  }
+  return (
+    <>
+      <MenuSeparator />
+      {sources.map((source) => (
+        <OcrExportMenuItems
+          key={source.fieldId}
+          exportStatus={source.exportStatus}
+          onDownload={(format) =>
+            detached(onExport(source, format), "row-actions.ocr-export")
+          }
+          searchablePdfLabel={t("workspaces.files.downloadSearchablePdf")}
+          textLabel={t("workspaces.files.downloadExtractedText")}
+        />
+      ))}
+    </>
+  );
+};
+
+type RowFileOperationsMenuProps = {
+  canScrub: boolean;
+  exportableOcrSources: readonly OcrSource[];
+  hasAnyFile: boolean;
+  hasAnyFolder: boolean;
+  hasDownloadVariants: boolean;
+  hasPdfConversion: boolean;
+  isBulk: boolean;
+  isCellContext: boolean;
+  name: string;
+  onCopyToMatter: () => void;
+  onDelete: () => void;
+  onDownload: (variant?: DownloadVariant) => Promise<void>;
+  onDuplicate: () => Promise<void>;
+  onOcrExport: (source: OcrSource, format: OcrExportFormat) => Promise<void>;
+  onZipDownload: () => Promise<void>;
+  selectedCount: number;
+};
+
+const RowFileOperationsMenu = ({
+  canScrub,
+  exportableOcrSources,
+  hasAnyFile,
+  hasAnyFolder,
+  hasDownloadVariants,
+  hasPdfConversion,
+  isBulk,
+  isCellContext,
+  name,
+  onCopyToMatter,
+  onDelete,
+  onDownload,
+  onDuplicate,
+  onOcrExport,
+  onZipDownload,
+  selectedCount,
+}: RowFileOperationsMenuProps) => {
+  const t = useTranslations();
+  if (isCellContext) {
+    return null;
+  }
+  const renderOcrExport = (source: OcrSource) => (
+    <OcrExportMenuItems
+      exportStatus={source.exportStatus}
+      onDownload={(format) =>
+        detached(onOcrExport(source, format), "row-actions.ocr-export")
+      }
+      searchablePdfLabel={t("workspaces.files.downloadSearchablePdf")}
+      textLabel={t("workspaces.files.downloadExtractedText")}
+    />
+  );
+  return (
+    <>
+      <MenuSeparator />
+      {hasAnyFile && (isBulk || !hasDownloadVariants) && (
+        <MenuItem
+          onClick={() => detached(onDownload(), "row-actions.download")}
+        >
+          <DownloadIcon />
+          {t("common.download")}
+        </MenuItem>
+      )}
+      {hasDownloadVariants && (
+        <MenuSub>
+          <MenuSubTrigger>
+            <DownloadIcon />
+            {t("common.download")}
+          </MenuSubTrigger>
+          <MenuSubPopup>
+            <MenuItem
+              onClick={() => detached(onDownload(), "row-actions.download")}
+            >
+              <DownloadIcon />
+              {t("workspaces.files.downloadOriginal")}
+            </MenuItem>
+            {hasPdfConversion && (
+              <MenuItem
+                onClick={() =>
+                  detached(onDownload("pdf"), "row-actions.download")
+                }
+              >
+                <FileOutputIcon />
+                {t("workspaces.files.downloadPdf")}
+              </MenuItem>
+            )}
+            {canScrub && (
+              <Tooltip
+                content={t("workspaces.files.downloadScrubbedHint")}
+                render={
+                  <MenuItem
+                    onClick={() =>
+                      detached(onDownload("scrubbed"), "row-actions.download")
+                    }
+                  >
+                    <EraserIcon />
+                    {t("workspaces.files.downloadScrubbed")}
+                  </MenuItem>
+                }
+              />
+            )}
+            {exportableOcrSources.length === 1 &&
+              exportableOcrSources.map((source) => (
+                <OcrExportMenuItems
+                  key={source.fieldId}
+                  exportStatus={source.exportStatus}
+                  onDownload={(format) =>
+                    detached(
+                      onOcrExport(source, format),
+                      "row-actions.ocr-export",
+                    )
+                  }
+                  searchablePdfLabel={t(
+                    "workspaces.files.downloadSearchablePdf",
+                  )}
+                  textLabel={t("workspaces.files.downloadExtractedText")}
+                />
+              ))}
+            {exportableOcrSources.length > 1 &&
+              exportableOcrSources.map((source) => (
+                <MenuSub key={source.fieldId}>
+                  <MenuSubTrigger>
+                    <ScanTextIcon />
+                    <BidiText as="span" className="max-w-64 truncate">
+                      {source.fileName}
+                    </BidiText>
+                  </MenuSubTrigger>
+                  <MenuSubPopup>{renderOcrExport(source)}</MenuSubPopup>
+                </MenuSub>
+              ))}
+          </MenuSubPopup>
+        </MenuSub>
+      )}
+      {hasAnyFolder && (
+        <MenuItem
+          onClick={() => detached(onZipDownload(), "row-actions.zip-download")}
+        >
+          <ArchiveIcon />
+          {t("workspaces.files.downloadAsZip")}
+        </MenuItem>
+      )}
+      <MenuItem
+        onClick={() => detached(onDuplicate(), "row-actions.duplicate")}
+      >
+        <CopyIcon />
+        {t("common.duplicate")}
+      </MenuItem>
+      <MenuItem onClick={onCopyToMatter}>
+        <FolderSyncIcon />
+        {t("workspaces.copyToMatter.menuItem")}
+      </MenuItem>
+      <MenuSeparator />
+      <AlertDialog>
+        <AlertDialogTrigger
+          render={<MenuItem closeOnClick={false} variant="destructive" />}
+        >
+          <Trash2Icon />
+          {t("common.delete")}
+        </AlertDialogTrigger>
+        <AlertDialogPopup>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {isBulk
+                ? t("workspaces.deleteItems", { count: selectedCount })
+                : t("workspaces.deleteItem")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {isBulk
+                ? t("workspaces.deleteItemsDescription", {
+                    count: selectedCount,
+                  })
+                : t("common.deleteConfirmDescription", { name })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose render={<Button variant="ghost" />}>
+              {t("common.cancel")}
+            </AlertDialogClose>
+            <AlertDialogClose
+              render={<Button onClick={onDelete} variant="destructive" />}
+            >
+              {t("common.delete")}
+            </AlertDialogClose>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
+    </>
   );
 };
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -532,7 +532,7 @@ export default defineConfig({
     "class-methods-use-this": "off",
     "no-unmodified-loop-condition": "error",
     "no-loop-func": "error",
-    complexity: "off",
+    complexity: ["error", 50],
     "func-style": "off",
     "func-names": "off",
 

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -241,7 +241,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 744,
+    "count": 743,
     "files": {
       "apps/api/scripts/ai-provider-canary-config.ts": 1,
       "apps/api/scripts/ai-provider-canary.ts": 4,
@@ -472,7 +472,6 @@
       "apps/web/src/components/legal-reader/document-ast-text.tsx": 1,
       "apps/web/src/components/pdf/page-citation.tsx": 1,
       "apps/web/src/components/pdf/versions-sidebar.tsx": 1,
-      "apps/web/src/components/search-dialog.tsx": 1,
       "apps/web/src/components/templates/template-form.tsx": 3,
       "apps/web/src/components/workspaces/copy-to-matter-dialog.tsx": 1,
       "apps/web/src/components/workspaces/hooks/use-create-b-boxes.ts": 1,


### PR DESCRIPTION
Enable Oxlint’s cyclomatic complexity rule with a maximum of 50.

Refactor over-limit code around explicit policy, state-machine, lifecycle, and rendering ownership boundaries while preserving behavior.

Tighten the residual lint-suppression ratchet from 744 to 743. Keep only the fixture-local exemption for the intentionally exhaustive lint fixture.

CC on behalf of jan-kubica