### PR TITLE
fix(api): accept auth-generated ids when branding an org member

### DIFF
--- a/apps/api/src/lib/safe-id-boundaries.test.ts
+++ b/apps/api/src/lib/safe-id-boundaries.test.ts
@@ -1,6 +1,30 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseExternalOrganizationId } from "@/api/lib/safe-id-boundaries";
+import {
+  AUTH_GENERATED_ID_PATTERN,
+  parseExternalOrganizationId,
+} from "@/api/lib/safe-id-boundaries";
+
+// Better Auth's default generator mints 32 characters of base62 text, which
+// is not a UUID and must survive every check that reads one of its ids.
+const AUTH_GENERATED_ID = "AuthGeneratedIdAuthGeneratedId12";
+
+describe("auth-generated id pattern", () => {
+  test("accepts the opaque text Better Auth mints", () => {
+    expect(AUTH_GENERATED_ID_PATTERN.test(AUTH_GENERATED_ID)).toBe(true);
+  });
+
+  test("accepts UUID ids, which self-hosted generators may still produce", () => {
+    expect(
+      AUTH_GENERATED_ID_PATTERN.test("0191d14d-9a63-7d2e-a021-06053e542c85"),
+    ).toBe(true);
+  });
+
+  test("rejects separators that could smuggle a second identifier", () => {
+    expect(AUTH_GENERATED_ID_PATTERN.test("not/an/id")).toBe(false);
+    expect(AUTH_GENERATED_ID_PATTERN.test("")).toBe(false);
+  });
+});
 
 describe("external organization id parsing", () => {
   test("accepts UUID organization ids", () => {
@@ -9,6 +33,12 @@ describe("external organization id parsing", () => {
         parseExternalOrganizationId("0191d14d-9a63-7d2e-a021-06053e542c85"),
       ),
     ).toBe("0191d14d-9a63-7d2e-a021-06053e542c85");
+  });
+
+  test("accepts auth-generated organization ids", () => {
+    expect(String(parseExternalOrganizationId(AUTH_GENERATED_ID))).toBe(
+      AUTH_GENERATED_ID,
+    );
   });
 
   test("rejects malformed provider metadata before database access", () => {

--- a/apps/api/src/lib/safe-id-boundaries.ts
+++ b/apps/api/src/lib/safe-id-boundaries.ts
@@ -243,11 +243,19 @@ export const brandPersistedOrganizationId = (
   organizationId: string,
 ): SafeId<"organization"> => toSafeId<"organization">(organizationId);
 
+/**
+ * Shape of an id minted by Better Auth's default generator, which the `user`,
+ * `organization`, and `member` tables store as opaque `text` rather than a
+ * UUID. Every check on one of those ids reads this pattern so that no call
+ * site can assume a narrower format than the columns actually hold.
+ */
+export const AUTH_GENERATED_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/u;
+
 /** Validate an organization id received from an external system before branding it. */
 export const parseExternalOrganizationId = (
   organizationId: string,
 ): SafeId<"organization"> | null =>
-  /^[A-Za-z0-9_-]{1,128}$/u.test(organizationId)
+  AUTH_GENERATED_ID_PATTERN.test(organizationId)
     ? toSafeId<"organization">(organizationId)
     : null;
 

--- a/apps/api/src/lib/validated-org-user-id.test.ts
+++ b/apps/api/src/lib/validated-org-user-id.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Transaction } from "@/api/db/root";
+import { toSafeId } from "@/api/lib/branded-types";
+import { validateOrgUserId } from "@/api/lib/validated-org-user-id";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+// `user.id` and `member.user_id` are text columns holding whatever the auth
+// provider mints. Better Auth's default generator produces base62 text, so
+// these two shapes are both stored ids, not just accepted input.
+const AUTH_GENERATED_ID = "AuthGeneratedIdAuthGeneratedId12";
+const UUID_ID = "0191d14d-9a63-7d2e-a021-06053e542c85";
+
+const txReturning = (rows: { userId: string }[]) =>
+  asTestRaw<Transaction>({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => rows,
+        }),
+      }),
+    }),
+  });
+
+const organizationId = toSafeId<"organization">(AUTH_GENERATED_ID);
+
+describe("validateOrgUserId", () => {
+  test.each([
+    ["auth-generated", AUTH_GENERATED_ID],
+    ["UUID", UUID_ID],
+  ])("brands a confirmed member holding an %s id", async (_shape, userId) => {
+    const validated = await validateOrgUserId(
+      txReturning([{ userId }]),
+      toSafeId<"user">(userId),
+      organizationId,
+    );
+
+    expect(String(validated)).toBe(userId);
+  });
+
+  test("returns null when the user is not a member", async () => {
+    const validated = await validateOrgUserId(
+      txReturning([]),
+      toSafeId<"user">(AUTH_GENERATED_ID),
+      organizationId,
+    );
+
+    expect(validated).toBeNull();
+  });
+});

--- a/apps/api/src/lib/validated-org-user-id.ts
+++ b/apps/api/src/lib/validated-org-user-id.ts
@@ -4,18 +4,23 @@ import * as v from "valibot";
 import { member } from "@/api/db/auth-schema";
 import type { Transaction } from "@/api/db/root";
 import type { SafeId } from "@/api/lib/branded-types";
+import { AUTH_GENERATED_ID_PATTERN } from "@/api/lib/safe-id-boundaries";
 
 /**
  * A user ID that has been validated as belonging to the given organization.
  * Prevents cross-org user ID injection at the type level: handlers that
  * accept a userId from user input must call `validateOrgUserId` first,
  * and the branded return type proves the check happened.
+ *
+ * The membership query is what establishes the guarantee; the predicate only
+ * gates branding. It is parsed with `v.parse`, so it must accept every id the
+ * `member.user_id` column can hold or a confirmed member throws instead of
+ * branding.
  */
 const validatedOrgUserIdSchema = v.pipe(
-  v.custom<SafeId<"user">>((value) =>
-    typeof value === "string"
-      ? v.is(v.pipe(v.string(), v.uuid()), value)
-      : false,
+  v.custom<SafeId<"user">>(
+    (value) =>
+      typeof value === "string" && AUTH_GENERATED_ID_PATTERN.test(value),
   ),
   v.brand("ValidatedOrgUserId"),
 );


### PR DESCRIPTION
## Proposed change

`validatedOrgUserIdSchema` (`apps/api/src/lib/validated-org-user-id.ts`) requires the id to be a UUID:

```ts
v.custom<SafeId<"user">>((value) =>
  typeof value === "string" ? v.is(v.pipe(v.string(), v.uuid()), value) : false,
)
```

`user.id` and `member.user_id` are `text` columns (`apps/api/src/db/auth-schema.ts`) holding whatever the auth provider mints. `AUTH_DATABASE_ID_OPTIONS` is `{}`, so Better Auth uses its default generator, `createRandomStringGenerator("a-z", "A-Z", "0-9")(32)`: 32 characters of base62, never a UUID. The route contract agrees that the id is opaque text, since `tUserId` is `t.String({ minLength: 1, maxLength: 128 })`.

The predicate runs under `v.parse`, which throws on a mismatch, and it is reached only after the membership query has already returned a row. That inverts the intended outcome:

- user **is** a member: row found, `v.parse` throws `ValiError`, which leaves `safeDb` wrapped as `UnhandledException` and answers 500
- user is **not** a member: no row, `null` returned, intended 400

So the check rejects exactly the users it is meant to admit. Six call sites pass a user id through `validateOrgUserId`: contacts create and update (originating/responsible attorney), rates resolve, rates entries-create, time-entries list, and the MCP billing tools.

The fix checks the same pattern `parseExternalOrganizationId` already applies to the sibling organization id, shared as `AUTH_GENERATED_ID_PATTERN` so the two cannot drift apart. The membership query, not the predicate, is what establishes the guarantee the brand carries; the predicate only gates branding.

Existing coverage missed this because `createTestIds` mints ids with `Bun.randomUUIDv7()`, so the UUID branch was the only one ever exercised. Added cases cover a confirmed member holding either id shape, a non-member still returning `null`, and the shared pattern accepting both shapes while rejecting separators.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings. `tsc --noEmit -p apps/api` and `oxlint apps/api` are both clean.
- [x] **TESTING** | `bun test src/lib/validated-org-user-id.test.ts src/lib/safe-id-boundaries.test.ts` passes (9 tests). Restoring the previous predicate fails the new auth-generated case with the `ValiError` described above, so the test pins the behaviour rather than the implementation.
- [ ] DARK MODE SUPPORT | Not applicable; API only, no UI surface.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable; no user-visible UI change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NW4D4m5e4CsQ8KYqRLGTK6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for organisation and user identifiers.
  * Auth-generated IDs and UUIDs are now accepted consistently.
  * Invalid, empty, or separator-containing IDs continue to be rejected.
  * Organisation user validation now correctly recognises valid members and rejects non-members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->