### PR TITLE
fix: prevent blank space in clipboard arrow navigation

### DIFF
--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -157,25 +157,33 @@ const focusTimeline = (node: HTMLDivElement | null) => {
   }
 };
 
-const scrollCardIntoView = (id: string) => {
+const focusCard = (rail: HTMLDivElement | null, id: string) => {
   requestAnimationFrame(() => {
-    document
-      .querySelector(`[data-clipboard-id="${CSS.escape(id)}"]`)
-      ?.scrollIntoView({
-        behavior: "smooth",
-        block: "nearest",
-        inline: "center",
-      });
-  });
-};
+    if (!rail) {
+      return;
+    }
+    const card = rail.querySelector<HTMLElement>(
+      `[data-clipboard-id="${CSS.escape(id)}"]`,
+    );
+    if (!card) {
+      return;
+    }
+    card
+      .querySelector<HTMLElement>("[data-clipboard-card-trigger]")
+      ?.focus({ preventScroll: true });
 
-const focusCard = (id: string) => {
-  requestAnimationFrame(() => {
-    document
-      .querySelector<HTMLElement>(
-        `[data-clipboard-id="${CSS.escape(id)}"] [data-clipboard-card-trigger]`,
-      )
-      ?.focus();
+    const railBounds = rail.getBoundingClientRect();
+    const cardBounds = card.getBoundingClientRect();
+    const left =
+      cardBounds.left +
+      cardBounds.width / 2 -
+      (railBounds.left + railBounds.width / 2);
+    rail.scrollBy({
+      behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches
+        ? "auto"
+        : "smooth",
+      left,
+    });
   });
 };
 
@@ -1024,6 +1032,7 @@ const ClipboardApp = () => {
   const t = useTranslations("clipboard");
   const searchInputRef = useRef<HTMLInputElement>(null);
   const timelineRef = useRef<HTMLDivElement>(null);
+  const timelineRailRef = useRef<HTMLDivElement>(null);
   const contextMenuTriggerRef = useRef<HTMLElement>(null);
   const snapshotRequestIdRef = useRef(0);
   const [snapshot, setSnapshot] = useState<ClipboardSnapshot>(EMPTY_SNAPSHOT);
@@ -1143,7 +1152,7 @@ const ClipboardApp = () => {
   useEffect(() => {
     const focusActiveCard = () => {
       if (activeItemId) {
-        focusCard(activeItemId);
+        focusCard(timelineRailRef.current, activeItemId);
         return;
       }
       timelineRef.current?.focus();
@@ -1392,8 +1401,7 @@ const ClipboardApp = () => {
     setSelectedIndex(index);
     const item = filteredItems.at(index);
     if (item) {
-      scrollCardIntoView(item.id);
-      focusCard(item.id);
+      focusCard(timelineRailRef.current, item.id);
     }
   };
 
@@ -1613,7 +1621,8 @@ const ClipboardApp = () => {
         ) : (
           <div
             aria-label={t("timeline")}
-            className="absolute inset-0 flex snap-x scrollbar-none items-stretch gap-3 overflow-x-auto px-5 py-1"
+            className="absolute inset-0 flex scrollbar-none items-stretch gap-3 overflow-x-auto overscroll-x-none px-5 py-1"
+            ref={timelineRailRef}
             role="list"
           >
             {filteredItems.map((item, index) => {

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -130,7 +130,7 @@ export const nextClipboardIndex = (
     return 0;
   }
   const offset = direction === "next" ? 1 : -1;
-  return (currentIndex + offset + itemCount) % itemCount;
+  return Math.max(0, Math.min(currentIndex + offset, itemCount - 1));
 };
 
 export const quickCopyIndex = (key: string, itemCount: number) => {

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -142,9 +142,11 @@ test("source apps receive a stable tint from the bounded palette", () => {
 });
 
 describe("keyboard indexes", () => {
-  test("timeline navigation wraps in either direction", () => {
-    expect(nextClipboardIndex(1, "next", 2)).toBe(0);
-    expect(nextClipboardIndex(0, "previous", 2)).toBe(1);
+  test("timeline navigation stops at either edge", () => {
+    expect(nextClipboardIndex(0, "next", 2)).toBe(1);
+    expect(nextClipboardIndex(1, "next", 2)).toBe(1);
+    expect(nextClipboardIndex(1, "previous", 2)).toBe(0);
+    expect(nextClipboardIndex(0, "previous", 2)).toBe(0);
   });
 
   test("quick copy only accepts visible slots one through nine", () => {


### PR DESCRIPTION
## Summary

- keep keyboard navigation within the finite clipboard history rail
- focus cards without triggering a competing ancestor scroll
- contain horizontal overscroll and respect reduced-motion preferences
- cover keyboard navigation at both rail edges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeline cards now automatically centre within the rail when focused.
  * Scrolling respects the system’s reduced-motion preference.
* **Bug Fixes**
  * Keyboard navigation now stops at the first and last timeline items instead of wrapping around.
  * Improved horizontal timeline scrolling behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->