### PR TITLE
fix(api): type auth-provider ids as their own family and mint fixtures with the real generator

### DIFF
--- a/.claude/mcp/doc-sources.ts
+++ b/.claude/mcp/doc-sources.ts
@@ -160,6 +160,7 @@ export const DOC_SOURCES = {
     dependencies: [
       "better-auth",
       "@better-auth/api-key",
+      "@better-auth/core",
       "@better-auth/oauth-provider",
     ],
     url: "https://better-auth.com/llms.txt",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -139,6 +139,7 @@
     "valibot": "catalog:"
   },
   "devDependencies": {
+    "@better-auth/core": "catalog:",
     "@electric-sql/pglite": "^0.5.4",
     "@faker-js/faker": "^10.6.0",
     "@modelcontextprotocol/client": "2.0.0",

--- a/apps/api/src/handlers/hosted-usage-webhook/dispatch.ts
+++ b/apps/api/src/handlers/hosted-usage-webhook/dispatch.ts
@@ -31,7 +31,7 @@ import type {
   HostedUsageEntitlementPayload,
 } from "@/api/lib/hosted-usage-provider/event-schemas";
 import { recordWebhookAuditEvent } from "@/api/lib/hosted-usage-provider/webhook-store";
-import { parseExternalOrganizationId } from "@/api/lib/safe-id-boundaries";
+import { parseAuthProviderId } from "@/api/lib/safe-id-boundaries";
 import {
   lockAssignmentCapacity,
   trimAssignmentsToCapacity,
@@ -429,7 +429,7 @@ export const handleHostedEntitlementUpsert = async ({
       if (metadataOrganizationId === null) {
         return { kind: "ignored", reason: "missing metadata.organization_id" };
       }
-      const organizationId = parseExternalOrganizationId(
+      const organizationId = parseAuthProviderId<"organization">(
         metadataOrganizationId,
       );
       if (organizationId === null) {
@@ -694,7 +694,7 @@ export const handleHostedAllocation = async ({
   if (!organizationIdRaw) {
     return { kind: "ignored", reason: "missing metadata.organization_id" };
   }
-  const organizationId = parseExternalOrganizationId(organizationIdRaw);
+  const organizationId = parseAuthProviderId<"organization">(organizationIdRaw);
   if (organizationId === null) {
     return { kind: "ignored", reason: "invalid metadata.organization_id" };
   }

--- a/apps/api/src/lib/dev-seed-session-store.ts
+++ b/apps/api/src/lib/dev-seed-session-store.ts
@@ -5,7 +5,7 @@ import { rootDb } from "@/api/db/root";
 import { env } from "@/api/env";
 import { sessionCookieName } from "@/api/lib/auth-cookie-name";
 import type { SafeId } from "@/api/lib/branded-types";
-import { parseExternalOrganizationId } from "@/api/lib/safe-id-boundaries";
+import { parseAuthProviderId } from "@/api/lib/safe-id-boundaries";
 
 const DEV_SEED_SESSION_LIFETIME_MS = 2 * 60 * 60 * 1000;
 
@@ -22,7 +22,8 @@ export const resolveMemberDevOrganization = async (
   organizationIdValue: string,
   userId: SafeId<"user">,
 ): Promise<SafeId<"organization"> | null> => {
-  const organizationId = parseExternalOrganizationId(organizationIdValue);
+  const organizationId =
+    parseAuthProviderId<"organization">(organizationIdValue);
   if (organizationId === null) {
     return null;
   }

--- a/apps/api/src/lib/safe-id-boundaries.test.ts
+++ b/apps/api/src/lib/safe-id-boundaries.test.ts
@@ -1,47 +1,53 @@
 import { describe, expect, test } from "bun:test";
 
+import { AUTH_DATABASE_ID_OPTIONS } from "@/api/lib/auth-adapter-options";
 import {
-  AUTH_GENERATED_ID_PATTERN,
-  parseExternalOrganizationId,
+  AUTH_PROVIDER_ID_PATTERN,
+  parseAuthProviderId,
 } from "@/api/lib/safe-id-boundaries";
+import { mintAuthProviderIdValue } from "@/api/tests/helpers/auth-provider-id";
 
-// Better Auth's default generator mints 32 characters of base62 text, which
-// is not a UUID and must survive every check that reads one of its ids.
-const AUTH_GENERATED_ID = "AuthGeneratedIdAuthGeneratedId12";
+const UUID_ID = "0191d14d-9a63-7d2e-a021-06053e542c85";
+const GENERATOR_SAMPLES = 500;
 
-describe("auth-generated id pattern", () => {
-  test("accepts the opaque text Better Auth mints", () => {
-    expect(AUTH_GENERATED_ID_PATTERN.test(AUTH_GENERATED_ID)).toBe(true);
+describe("auth-provider id pattern", () => {
+  test("the auth provider runs its default id generator", () => {
+    // The fixture generator in `tests/helpers/auth-provider-id.ts` mirrors the
+    // default. Configuring a generator here without updating that helper and
+    // this pattern would let fixtures drift from stored ids again.
+    expect("generateId" in AUTH_DATABASE_ID_OPTIONS).toBe(false);
   });
 
-  test("accepts UUID ids, which self-hosted generators may still produce", () => {
-    expect(
-      AUTH_GENERATED_ID_PATTERN.test("0191d14d-9a63-7d2e-a021-06053e542c85"),
-    ).toBe(true);
+  test("accepts every id the default generator mints", () => {
+    for (let index = 0; index < GENERATOR_SAMPLES; index += 1) {
+      const id = mintAuthProviderIdValue();
+      expect(AUTH_PROVIDER_ID_PATTERN.test(id), id).toBe(true);
+    }
+  });
+
+  test("accepts UUID ids, which a configured generator may produce", () => {
+    expect(AUTH_PROVIDER_ID_PATTERN.test(UUID_ID)).toBe(true);
   });
 
   test("rejects separators that could smuggle a second identifier", () => {
-    expect(AUTH_GENERATED_ID_PATTERN.test("not/an/id")).toBe(false);
-    expect(AUTH_GENERATED_ID_PATTERN.test("")).toBe(false);
+    expect(AUTH_PROVIDER_ID_PATTERN.test("not/an/id")).toBe(false);
+    expect(AUTH_PROVIDER_ID_PATTERN.test("")).toBe(false);
   });
 });
 
-describe("external organization id parsing", () => {
-  test("accepts UUID organization ids", () => {
-    expect(
-      String(
-        parseExternalOrganizationId("0191d14d-9a63-7d2e-a021-06053e542c85"),
-      ),
-    ).toBe("0191d14d-9a63-7d2e-a021-06053e542c85");
+describe("parseAuthProviderId", () => {
+  test("brands a generated organization id", () => {
+    const id = mintAuthProviderIdValue();
+    expect(String(parseAuthProviderId<"organization">(id))).toBe(id);
   });
 
-  test("accepts auth-generated organization ids", () => {
-    expect(String(parseExternalOrganizationId(AUTH_GENERATED_ID))).toBe(
-      AUTH_GENERATED_ID,
-    );
+  test("brands a UUID user id", () => {
+    expect(String(parseAuthProviderId<"user">(UUID_ID))).toBe(UUID_ID);
   });
 
   test("rejects malformed provider metadata before database access", () => {
-    expect(parseExternalOrganizationId("not/an/organization/id")).toBeNull();
+    expect(parseAuthProviderId<"organization">("not/an/organization/id")).toBe(
+      null,
+    );
   });
 });

--- a/apps/api/src/lib/safe-id-boundaries.ts
+++ b/apps/api/src/lib/safe-id-boundaries.ts
@@ -1,5 +1,5 @@
 import { toSafeId } from "@/api/lib/branded-types";
-import type { SafeId } from "@/api/lib/branded-types";
+import type { SafeId, SafeIdType } from "@/api/lib/branded-types";
 import { isUuid } from "@/api/lib/custom-schema";
 
 type ActorSessionIdentityInput = {
@@ -244,20 +244,36 @@ export const brandPersistedOrganizationId = (
 ): SafeId<"organization"> => toSafeId<"organization">(organizationId);
 
 /**
- * Shape of an id minted by Better Auth's default generator, which the `user`,
- * `organization`, and `member` tables store as opaque `text` rather than a
- * UUID. Every check on one of those ids reads this pattern so that no call
- * site can assume a narrower format than the columns actually hold.
+ * Id types minted by the auth provider rather than by `createSafeId`. Their
+ * columns are opaque text, never `uuid`: Better Auth's default generator
+ * (`AUTH_DATABASE_ID_OPTIONS` declares none) produces 32 base62 characters,
+ * and self-hosted deployments may configure a UUID generator instead. A
+ * predicate over one of these ids must therefore accept every shape the
+ * column can hold; `parseAuthProviderId` is the only way to build one, and
+ * its type parameter is closed over this list so a UUID-only parser cannot be
+ * pointed at an auth-provider id by mistake.
  */
-export const AUTH_GENERATED_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/u;
+export const AUTH_PROVIDER_ID_TYPES = [
+  "organization",
+  "user",
+] as const satisfies readonly SafeIdType[];
 
-/** Validate an organization id received from an external system before branding it. */
-export const parseExternalOrganizationId = (
-  organizationId: string,
-): SafeId<"organization"> | null =>
-  AUTH_GENERATED_ID_PATTERN.test(organizationId)
-    ? toSafeId<"organization">(organizationId)
-    : null;
+export type AuthProviderIdType = (typeof AUTH_PROVIDER_ID_TYPES)[number];
+
+/**
+ * Widest shape any supported auth id generator emits. Pinned against the real
+ * generator in `safe-id-boundaries.test.ts`.
+ */
+export const AUTH_PROVIDER_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/u;
+
+/**
+ * Validate an auth-provider id received from outside the database (webhook
+ * metadata, a dev seed, a row about to be branded) before branding it.
+ */
+export const parseAuthProviderId = <T extends AuthProviderIdType>(
+  value: string,
+): SafeId<T> | null =>
+  AUTH_PROVIDER_ID_PATTERN.test(value) ? toSafeId<T>(value) : null;
 
 export const brandValidatedWorkflowActorKey = ({
   organizationId,

--- a/apps/api/src/lib/validated-org-user-id.test.ts
+++ b/apps/api/src/lib/validated-org-user-id.test.ts
@@ -3,12 +3,13 @@ import { describe, expect, test } from "bun:test";
 import type { Transaction } from "@/api/db/root";
 import { toSafeId } from "@/api/lib/branded-types";
 import { validateOrgUserId } from "@/api/lib/validated-org-user-id";
+import { mintAuthProviderIdValue } from "@/api/tests/helpers/auth-provider-id";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 // `user.id` and `member.user_id` are text columns holding whatever the auth
-// provider mints. Better Auth's default generator produces base62 text, so
-// these two shapes are both stored ids, not just accepted input.
-const AUTH_GENERATED_ID = "AuthGeneratedIdAuthGeneratedId12";
+// provider mints. The default generator produces base62 text and a configured
+// one may produce UUIDs, so both shapes are stored ids, not just accepted input.
+const AUTH_GENERATED_ID = mintAuthProviderIdValue();
 const UUID_ID = "0191d14d-9a63-7d2e-a021-06053e542c85";
 
 const txReturning = (rows: { userId: string }[]) =>

--- a/apps/api/src/lib/validated-org-user-id.ts
+++ b/apps/api/src/lib/validated-org-user-id.ts
@@ -4,7 +4,7 @@ import * as v from "valibot";
 import { member } from "@/api/db/auth-schema";
 import type { Transaction } from "@/api/db/root";
 import type { SafeId } from "@/api/lib/branded-types";
-import { AUTH_GENERATED_ID_PATTERN } from "@/api/lib/safe-id-boundaries";
+import { parseAuthProviderId } from "@/api/lib/safe-id-boundaries";
 
 /**
  * A user ID that has been validated as belonging to the given organization.
@@ -15,12 +15,12 @@ import { AUTH_GENERATED_ID_PATTERN } from "@/api/lib/safe-id-boundaries";
  * The membership query is what establishes the guarantee; the predicate only
  * gates branding. It is parsed with `v.parse`, so it must accept every id the
  * `member.user_id` column can hold or a confirmed member throws instead of
- * branding.
+ * branding; `parseAuthProviderId` is the parser that knows that shape.
  */
 const validatedOrgUserIdSchema = v.pipe(
   v.custom<SafeId<"user">>(
     (value) =>
-      typeof value === "string" && AUTH_GENERATED_ID_PATTERN.test(value),
+      typeof value === "string" && parseAuthProviderId<"user">(value) !== null,
   ),
   v.brand("ValidatedOrgUserId"),
 );

--- a/apps/api/src/tests/helpers/auth-provider-id.ts
+++ b/apps/api/src/tests/helpers/auth-provider-id.ts
@@ -1,0 +1,18 @@
+import { generateId } from "@better-auth/core/utils/id";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import type { AuthProviderIdType } from "@/api/lib/safe-id-boundaries";
+
+// Better Auth's default id length; `AUTH_DATABASE_ID_OPTIONS` declares no
+// generator, so this is exactly what the `user`, `organization`, and `member`
+// rows in production hold. Fixtures mint auth-provider ids here rather than
+// with `Bun.randomUUIDv7()` so every suite exercises the stored shape; a UUID
+// fixture once hid a predicate that rejected every real member.
+const BETTER_AUTH_DEFAULT_ID_LENGTH = 32;
+
+export const mintAuthProviderIdValue = (): string =>
+  generateId(BETTER_AUTH_DEFAULT_ID_LENGTH);
+
+export const mintAuthProviderId = <T extends AuthProviderIdType>(): SafeId<T> =>
+  toSafeId<T>(mintAuthProviderIdValue());

--- a/apps/api/src/tests/security/rls-helpers.ts
+++ b/apps/api/src/tests/security/rls-helpers.ts
@@ -57,6 +57,10 @@ import { toSafeId } from "@/api/lib/branded-types";
 import type { SafeIdType } from "@/api/lib/branded-types";
 import type { ClauseBody } from "@/api/lib/clauses/types";
 import { cents } from "@/api/lib/money";
+import {
+  mintAuthProviderId,
+  mintAuthProviderIdValue,
+} from "@/api/tests/helpers/auth-provider-id";
 import type {
   TestDatabase,
   TestDatabaseTransaction,
@@ -66,25 +70,26 @@ import type {
 
 const tid = () => Bun.randomUUIDv7();
 const wsId = () => toSafeId<"workspace">(tid());
-const orgId = () => toSafeId<"organization">(tid());
 const id = <T extends SafeIdType>() => toSafeId<T>(tid());
 
 // ── Test data IDs ──────────────────────────────────────
 
+// Auth-provider rows (user, organization, member) carry the shape the auth
+// provider mints, not a UUID, so the suites exercise the stored id format.
 export const createTestIds = () => ({
-  orgA: orgId(),
-  orgB: orgId(),
-  userA1: toSafeId<"user">(tid()),
-  userA2: toSafeId<"user">(tid()),
-  userB1: toSafeId<"user">(tid()),
-  userAdmin: toSafeId<"user">(tid()),
+  orgA: mintAuthProviderId<"organization">(),
+  orgB: mintAuthProviderId<"organization">(),
+  userA1: mintAuthProviderId<"user">(),
+  userA2: mintAuthProviderId<"user">(),
+  userB1: mintAuthProviderId<"user">(),
+  userAdmin: mintAuthProviderId<"user">(),
   wsA1: wsId(),
   wsA2: wsId(),
   wsB1: wsId(),
-  memberA1org: tid(),
-  memberA2org: tid(),
-  memberB1org: tid(),
-  memberAdminOrg: tid(),
+  memberA1org: mintAuthProviderIdValue(),
+  memberA2org: mintAuthProviderIdValue(),
+  memberB1org: mintAuthProviderIdValue(),
+  memberAdminOrg: mintAuthProviderIdValue(),
   memberA1wsA1: id<"workspaceMember">(),
   memberA1wsA2: id<"workspaceMember">(),
   memberA2wsA2: id<"workspaceMember">(),

--- a/apps/web/e2e/helpers/network.ts
+++ b/apps/web/e2e/helpers/network.ts
@@ -804,16 +804,44 @@ export const WATERFALL_DEPTH_RESAMPLES = 2;
 export const baselineWaterfallDepth = (route: string): number | null =>
   readNetworkBaseline()?.[route]?.depth ?? null;
 
+const maxPerKey = (
+  left: Record<string, number>,
+  right: Record<string, number>,
+): Record<string, number> => {
+  const merged: Record<string, number> = { ...left };
+  for (const [key, value] of Object.entries(right)) {
+    merged[key] = Math.max(merged[key] ?? 0, value);
+  }
+  return Object.fromEntries(
+    Object.entries(merged).sort(([a], [b]) => a.localeCompare(b)),
+  );
+};
+
 /**
- * Keep the shallower of two samples of one route. Every other dimension
- * (request set, query counts, sizes) is compared upward per sample, so the
- * shallower sample stays a complete, self-consistent observation.
+ * Fold a re-measurement into the metrics of one route. Depth takes the
+ * minimum, because only jitter can push a sample above the true depth. Every
+ * other dimension takes the union or per-key maximum, so a regression the
+ * first sample caught (a new request, an N+1, an oversized body) survives a
+ * later sample that happened to read shallower.
  */
-export const shallowerSample = (
+export const mergeResampledMetrics = (
   current: RouteNetworkMetrics,
   candidate: RouteNetworkMetrics,
-): RouteNetworkMetrics =>
-  candidate.depth < current.depth ? candidate : current;
+): RouteNetworkMetrics => ({
+  requests: [...new Set([...current.requests, ...candidate.requests])].sort(),
+  requestCounts: maxPerKey(current.requestCounts, candidate.requestCounts),
+  depth: Math.min(current.depth, candidate.depth),
+  dbQueries: maxPerKey(current.dbQueries, candidate.dbQueries),
+  missingDbQueryCounts: maxPerKey(
+    current.missingDbQueryCounts,
+    candidate.missingDbQueryCounts,
+  ),
+  responseSizes: maxPerKey(current.responseSizes, candidate.responseSizes),
+  missingResponseSizeCounts: maxPerKey(
+    current.missingResponseSizeCounts,
+    candidate.missingResponseSizeCounts,
+  ),
+});
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);

--- a/apps/web/e2e/helpers/network.ts
+++ b/apps/web/e2e/helpers/network.ts
@@ -351,8 +351,15 @@ const REQUEST_SEQUENCE_GAP_MS = 500;
 // on a fast response stays hidden behind an unrelated slow one.
 //
 // Load-monotonicity is the property the guard rests on: neither a slower
-// response nor a uniformly stretched timeline can raise the result, so an extra
-// level always means an extra level. Two rules buy it:
+// response nor a uniformly stretched timeline can raise the result. The
+// converse does not hold: a FASTER response ends a busy block earlier, so an
+// unrelated request that used to overlap it now launches after it and reads
+// as one more level. A single lucky sample therefore over-reads by one on a
+// route that did not change, which is why the route-smoke suite re-measures a
+// route before treating a deeper reading as a regression
+// (`WATERFALL_DEPTH_RESAMPLES`). Timing alone cannot separate a dependent
+// launch from a coincidentally later one; sampling is the honest fix. Two
+// rules buy the monotonicity that does hold:
 //   1. The sequence split reads LAUNCH times only. Segment boundaries therefore
 //      cannot move when responses take longer, and a uniform slowdown widens
 //      launch gaps, which only splits a sequence further.
@@ -785,6 +792,28 @@ const readNetworkBaseline = (): NetworkBaseline | null => {
   }
   return parsed;
 };
+
+// How many extra measurements a route gets when its first sample reads deeper
+// than the committed budget. Depth is a timing lower bound that a fast sample
+// can over-read by one (see `waterfallDepth`); a real extra round shows up in
+// every sample, jitter does not. Only suspected regressions pay for the extra
+// navigations.
+export const WATERFALL_DEPTH_RESAMPLES = 2;
+
+/** Committed depth budget for a route, or null when it has no baseline entry. */
+export const baselineWaterfallDepth = (route: string): number | null =>
+  readNetworkBaseline()?.[route]?.depth ?? null;
+
+/**
+ * Keep the shallower of two samples of one route. Every other dimension
+ * (request set, query counts, sizes) is compared upward per sample, so the
+ * shallower sample stays a complete, self-consistent observation.
+ */
+export const shallowerSample = (
+  current: RouteNetworkMetrics,
+  candidate: RouteNetworkMetrics,
+): RouteNetworkMetrics =>
+  candidate.depth < current.depth ? candidate : current;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -21,9 +21,12 @@ import {
 import { createUploadedDocumentRoute } from "../helpers/document";
 import {
   type RouteNetworkMetrics,
+  WATERFALL_DEPTH_RESAMPLES,
   assertNetworkBaseline,
   assertNetworkBaselineCoverage,
+  baselineWaterfallDepth,
   createNetworkCollector,
+  shallowerSample,
   summarizeCapture,
 } from "../helpers/network";
 import { createBrowserErrorCollector } from "../helpers/test";
@@ -450,6 +453,41 @@ const smokeRouteTarget = async ({
   results: Map<string, RouteNetworkMetrics>;
   route: SmokeRoute;
 }) => {
+  // A deeper reading than the budget is either a regression or a fast sample
+  // over-reading by one; only more samples tell them apart. A regression
+  // survives every re-measurement, jitter does not. Samples run one at a time
+  // on purpose: a second page in flight would distort the timing being read.
+  const budget = baselineWaterfallDepth(route.template);
+  const resampleDeeperReading = async (
+    metrics: RouteNetworkMetrics,
+    remaining: number,
+  ): Promise<RouteNetworkMetrics> => {
+    if (budget === null || metrics.depth <= budget || remaining === 0) {
+      return metrics;
+    }
+    const again = await measureRouteTarget({ context, route });
+    return resampleDeeperReading(
+      shallowerSample(metrics, again),
+      remaining - 1,
+    );
+  };
+
+  const metrics = await resampleDeeperReading(
+    await measureRouteTarget({ context, route }),
+    WATERFALL_DEPTH_RESAMPLES,
+  );
+  // Stored under the template it received; redirect targets arrive as
+  // "<template> target".
+  results.set(route.template, metrics);
+};
+
+const measureRouteTarget = async ({
+  context,
+  route,
+}: {
+  context: BrowserContext;
+  route: SmokeRoute;
+}): Promise<RouteNetworkMetrics> => {
   const page = await context.newPage();
   const browserErrors = createBrowserErrorCollector({
     tolerateColdMountWarning: true,
@@ -469,9 +507,8 @@ const smokeRouteTarget = async ({
     assertFinalDestination(page, route);
     browserErrors.assertEmpty(`unexpected browser errors on ${route.template}`);
     // Captured after the route shell and tracked API work are ready, so the
-    // manifest reflects the fully-rendered route. Stored under the template
-    // it received; redirect targets arrive as "<template> target".
-    results.set(route.template, summarizeCapture(await network.capture()));
+    // manifest reflects the fully-rendered route.
+    return summarizeCapture(await network.capture());
   } finally {
     detachNetwork();
     detachPage();

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -26,7 +26,7 @@ import {
   assertNetworkBaselineCoverage,
   baselineWaterfallDepth,
   createNetworkCollector,
-  shallowerSample,
+  mergeResampledMetrics,
   summarizeCapture,
 } from "../helpers/network";
 import { createBrowserErrorCollector } from "../helpers/test";
@@ -467,7 +467,7 @@ const smokeRouteTarget = async ({
     }
     const again = await measureRouteTarget({ context, route });
     return resampleDeeperReading(
-      shallowerSample(metrics, again),
+      mergeResampledMetrics(metrics, again),
       remaining - 1,
     );
   };

--- a/apps/web/e2e/unit/network-metrics.test.ts
+++ b/apps/web/e2e/unit/network-metrics.test.ts
@@ -8,6 +8,7 @@ import {
   browserRequestInterval,
   diffNetworkBaseline,
   mergeNetworkBaseline,
+  mergeResampledMetrics,
   normalizeApiPath,
   responseSizeAllowance,
   waitForQuietPeriod,
@@ -99,6 +100,37 @@ describe("waterfallDepth", () => {
 
     expect(waterfallDepth(overlapping)).toBe(1);
     expect(waterfallDepth(firstAnsweredFaster)).toBe(2);
+  });
+
+  test("resampling keeps the shallowest depth but every other regression", () => {
+    const first: RouteNetworkMetrics = {
+      requests: ["GET /v1/a", "GET /v1/new"],
+      requestCounts: { "GET /v1/a": 2, "GET /v1/new": 1 },
+      depth: 4,
+      dbQueries: { "GET /v1/a": 40 },
+      missingDbQueryCounts: { "GET /v1/new": 1 },
+      responseSizes: { "GET /v1/a": 90_000 },
+      missingResponseSizeCounts: {},
+    };
+    const shallower: RouteNetworkMetrics = {
+      requests: ["GET /v1/a"],
+      requestCounts: { "GET /v1/a": 1 },
+      depth: 3,
+      dbQueries: { "GET /v1/a": 4 },
+      missingDbQueryCounts: {},
+      responseSizes: { "GET /v1/a": 1000 },
+      missingResponseSizeCounts: { "GET /v1/a": 1 },
+    };
+
+    expect(mergeResampledMetrics(first, shallower)).toEqual({
+      requests: ["GET /v1/a", "GET /v1/new"],
+      requestCounts: { "GET /v1/a": 2, "GET /v1/new": 1 },
+      depth: 3,
+      dbQueries: { "GET /v1/a": 40 },
+      missingDbQueryCounts: { "GET /v1/new": 1 },
+      responseSizes: { "GET /v1/a": 90_000 },
+      missingResponseSizeCounts: { "GET /v1/a": 1 },
+    });
   });
 
   test("an independent late request does not chain", () => {

--- a/apps/web/e2e/unit/network-metrics.test.ts
+++ b/apps/web/e2e/unit/network-metrics.test.ts
@@ -83,6 +83,24 @@ describe("waterfallDepth", () => {
     ).toBe(1);
   });
 
+  test("a faster response can raise the reading by one", () => {
+    // Pins the asymmetry the route-smoke resampling exists for: the same two
+    // requests read as one round or two depending only on how quickly the
+    // first one answered. Any change that makes this deterministic can drop
+    // WATERFALL_DEPTH_RESAMPLES.
+    const overlapping = [
+      { start: 0, end: 100 },
+      { start: 90, end: 200 },
+    ];
+    const firstAnsweredFaster = [
+      { start: 0, end: 80 },
+      { start: 90, end: 200 },
+    ];
+
+    expect(waterfallDepth(overlapping)).toBe(1);
+    expect(waterfallDepth(firstAnsweredFaster)).toBe(2);
+  });
+
   test("an independent late request does not chain", () => {
     // A quiet gap between launches makes this an idle prefetch, not another
     // route-load round.

--- a/bun.lock
+++ b/bun.lock
@@ -137,6 +137,7 @@
         "valibot": "catalog:",
       },
       "devDependencies": {
+        "@better-auth/core": "catalog:",
         "@electric-sql/pglite": "^0.5.4",
         "@faker-js/faker": "^10.6.0",
         "@modelcontextprotocol/client": "2.0.0",
@@ -928,6 +929,7 @@
     "@ag-ui/core": "0.1.1-canary.beta.0",
     "@base-ui/react": "1.7.0",
     "@better-auth/api-key": "1.7.1",
+    "@better-auth/core": "1.7.1",
     "@better-auth/oauth-provider": "1.7.1",
     "@libpdf/core": "0.4.1",
     "@mcp-ui/client": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "@ag-ui/core": "0.1.1-canary.beta.0",
     "@base-ui/react": "1.7.0",
     "@better-auth/api-key": "1.7.1",
+    "@better-auth/core": "1.7.1",
     "@better-auth/oauth-provider": "1.7.1",
     "@libpdf/core": "0.4.1",
     "@mcp-ui/client": "7.1.1",


### PR DESCRIPTION
## Proposed change

Follow-up to #2505, which fixed a UUID-only predicate that rejected every real org member. That defect passed the whole suite because every fixture minted `user` / `organization` / `member` ids with `Bun.randomUUIDv7()`, while the auth provider mints 32 base62 characters. This closes the class instead of the instance.

**Auth-provider id family (`apps/api/src/lib/safe-id-boundaries.ts`)**
- `AUTH_PROVIDER_ID_TYPES = ["organization", "user"] as const satisfies readonly SafeIdType[]` names the ids the auth provider owns; their columns are opaque text, never `uuid`.
- `parseAuthProviderId<T extends AuthProviderIdType>` is the one parser for that family. It replaces `parseExternalOrganizationId` (3 call sites) and the inline pattern in `validated-org-user-id.ts`. A UUID-only parser can no longer be pointed at a user or organization id: the type parameter refuses it.
- `AUTH_PROVIDER_ID_PATTERN` stays the widest shape any supported generator emits (default base62 or a configured UUID generator).

**Fixtures derive from the real generator**
- `apps/api/src/tests/helpers/auth-provider-id.ts` mints ids with Better Auth's own `generateId` (`@better-auth/core`, new devDependency on the catalog version), and `createTestIds` uses it for user, organization, and member rows. The RLS and cross-tenant suites now exercise the stored id shape.
- `safe-id-boundaries.test.ts` pins the pattern against 500 generated ids and asserts `AUTH_DATABASE_ID_OPTIONS` configures no custom generator, so a future generator change has to update the helper and the pattern together.

**Route-smoke waterfall guard (`apps/web/e2e`)**
- `waterfallDepth` is a timing lower bound: a slower response cannot raise it, but a faster one ends a busy block earlier and can raise the reading by one on an unchanged route. Two consecutive runs of the same SHA on #2505 failed on two different routes for exactly this reason.
- `smokeRouteTarget` now re-measures a route (up to `WATERFALL_DEPTH_RESAMPLES = 2`, sequential so a second page does not distort timing) only when the first sample reads deeper than the committed budget. Samples are folded together: depth takes the minimum, every other dimension the union or per-key maximum, so a regression the first sample caught survives a shallower later one. A regression survives every sample; jitter does not. No baseline rewrite: shallower readings are already a notice, not a failure.
- A unit test pins the asymmetry so the resampling can be dropped if the metric is ever made deterministic.

## Checklist

- [x] **BUILD ASSURANCE** | `oxlint --type-aware` and `oxfmt --check` clean on every changed file.
- [x] **TESTING** | `bun test src/lib/safe-id-boundaries.test.ts src/lib/validated-org-user-id.test.ts` (10 pass); `bun test e2e/unit/network-metrics.test.ts` (57 pass). Postgres suites that consume `createTestIds` run in CI.
- [ ] DARK MODE SUPPORT | Not applicable; no UI surface.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable.

https://claude.ai/code/session_01RU5otmbvfBDSz1yNmTiJgi

