### PR TITLE
fix(case-law): record the database cause on reconciliation failure sinks

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, expect, mock, test } from "bun:test";
 import { and, eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
@@ -190,6 +190,23 @@ const unwalkableSliceStub: SourceReconciliation = {
       });
     }
     return await Promise.resolve({ items: [], totalPages: 1 });
+  },
+};
+
+/**
+ * The same publisher, with a build that fails the way a database driver does:
+ * the whole failed statement in the outer message and the SQLSTATE one
+ * `cause` hop down, which is the shape a query wrapper produces.
+ */
+const drivenFailureStub: SourceReconciliation = {
+  ...stubReconciliation,
+  buildDecision: async () => {
+    const cause = Object.assign(new Error('column "reason" does not exist'), {
+      errno: "42703",
+    });
+    return await Promise.reject(
+      new Error(`Failed query: select ${"a, ".repeat(300)}from x`, { cause }),
+    );
   },
 };
 
@@ -1387,4 +1404,38 @@ test("the docket half of the identity index applies the same filter", async () =
     summary: { slice: OWED_SLICE, keyable: 2, heldBefore: 1, parked: 1 },
   });
   expect(builds).toHaveLength(1);
+});
+
+test("a failed item build records the database cause, not just the error tag", async () => {
+  // Parking stores the tag alone, so this log line is the only record of why
+  // a listed decision could not be built. A driver error spends its whole
+  // outer message on the failed statement and carries the SQLSTATE one
+  // `cause` hop down: a sink that reads the tag reports "DrizzleQueryError"
+  // and nothing an operator can act on.
+  const sourceId = await seedSource();
+  const realLoggerModule = await import("@/api/lib/observability/logger");
+  const warned: Record<string, unknown>[] = [];
+  await mock.module("@/api/lib/observability/logger", () => ({
+    logger: {
+      warn: (_event: string, attributes: Record<string, unknown>) => {
+        warned.push(attributes);
+      },
+      error: () => undefined,
+      info: () => undefined,
+    },
+  }));
+
+  try {
+    await runUnit(sourceId, drivenFailureStub);
+  } finally {
+    await mock.module("@/api/lib/observability/logger", () => realLoggerModule);
+  }
+
+  const failure = warned.find(
+    (attributes) => attributes["identityKey"] !== undefined,
+  );
+  expect(failure?.["error.cause.pg_code"]).toBe("42703");
+  // Bounded apart from the outer message: the statement alone would consume
+  // the whole budget and leave the cause truncated away.
+  expect(failure?.["error.detail"]).toContain('column "reason" does not exist');
 });

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -1406,12 +1406,14 @@ test("the docket half of the identity index applies the same filter", async () =
   expect(builds).toHaveLength(1);
 });
 
-test("a failed item build records the database cause, not just the error tag", async () => {
-  // Parking stores the tag alone, so this log line is the only record of why
-  // a listed decision could not be built. A driver error spends its whole
-  // outer message on the failed statement and carries the SQLSTATE one
-  // `cause` hop down: a sink that reads the tag reports "DrizzleQueryError"
-  // and nothing an operator can act on.
+test("a failed item build reports the SQLSTATE without logging any message text", async () => {
+  // Two halves of one invariant. Parking stores the tag alone, so this log
+  // line is the only record of why a listed decision could not be built, and
+  // a tag reading "DrizzleQueryError" is nothing an operator can act on: the
+  // SQLSTATE sits one `cause` hop down and has to be reported. But the
+  // logger's sanitizer is a key denylist, so any message text this sink
+  // emitted would reach telemetry verbatim, and a driver message quotes the
+  // statement and can quote the row that failed. Fixed vocabulary only.
   const sourceId = await seedSource();
   const realLoggerModule = await import("@/api/lib/observability/logger");
   const warned: Record<string, unknown>[] = [];
@@ -1435,7 +1437,10 @@ test("a failed item build records the database cause, not just the error tag", a
     (attributes) => attributes["identityKey"] !== undefined,
   );
   expect(failure?.["error.cause.pg_code"]).toBe("42703");
-  // Bounded apart from the outer message: the statement alone would consume
-  // the whole budget and leave the cause truncated away.
-  expect(failure?.["error.detail"]).toContain('column "reason" does not exist');
+  // Over every value, not a named key: the guard has to hold for a field
+  // added later, and the point is that no attribute carries message text.
+  for (const value of Object.values(failure ?? {})) {
+    expect(String(value)).not.toContain("Failed query");
+    expect(String(value)).not.toContain("does not exist");
+  }
 });

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.db.test.ts
@@ -1415,22 +1415,25 @@ test("a failed item build reports the SQLSTATE without logging any message text"
   // emitted would reach telemetry verbatim, and a driver message quotes the
   // statement and can quote the row that failed. Fixed vocabulary only.
   const sourceId = await seedSource();
-  const realLoggerModule = await import("@/api/lib/observability/logger");
+  const loggerModule = await import("@/api/lib/observability/logger");
   const warned: Record<string, unknown>[] = [];
+  // Spread both levels rather than redeclaring them: the module also exports
+  // `sanitizeLogAttributes`, and a mock that drops it is exactly what this
+  // suite's sibling guard forbids.
   await mock.module("@/api/lib/observability/logger", () => ({
+    ...loggerModule,
     logger: {
+      ...loggerModule.logger,
       warn: (_event: string, attributes: Record<string, unknown>) => {
         warned.push(attributes);
       },
-      error: () => undefined,
-      info: () => undefined,
     },
   }));
 
   try {
     await runUnit(sourceId, drivenFailureStub);
   } finally {
-    await mock.module("@/api/lib/observability/logger", () => realLoggerModule);
+    await mock.module("@/api/lib/observability/logger", () => loggerModule);
   }
 
   const failure = warned.find(

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
@@ -52,7 +52,6 @@ import {
   allocateSourceObservationOrder,
   PROCESS_DECISION_STATUS,
   processDecision,
-  wrappedErrorDetail,
 } from "@/api/handlers/case-law/ingestion/pipeline";
 import type {
   FailedSliceCandidate,
@@ -835,13 +834,15 @@ const ingestListedItem = async ({
       adapterKey,
       slice,
       identityKey: item.identityKey,
+      // The park below keeps only the tag, which cannot separate a publisher
+      // refusing one document from the corpus refusing to store it. These two
+      // carry that distinction as fixed vocabulary (driver and system codes,
+      // the SQLSTATE, the schema identifiers Postgres names) rather than as
+      // message text, which quotes the statement and can quote the row that
+      // failed; the logger's sanitizer is a key denylist, so text this sink
+      // emitted would reach telemetry verbatim.
       ...errorSystemFields(error),
       ...pgErrorFields(error),
-      // The park below keeps only the tag, which cannot separate a
-      // publisher refusing one document from the corpus refusing to store
-      // it. "message" is stripped by the logger sanitizer, so the reason
-      // travels under "error.detail". Case-law data is public, no PII concern.
-      "error.detail": wrappedErrorDetail(error),
     });
     await park(errorTag(error));
   }
@@ -1315,7 +1316,6 @@ export const runReconciliationWorkUnit = async ({
               reason: unit.reason,
               ...errorSystemFields(error),
               ...pgErrorFields(error),
-              "error.detail": wrappedErrorDetail(error),
             });
             throw error;
           }),

--- a/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
+++ b/apps/api/src/handlers/case-law/ingestion/reconciliation-engine.ts
@@ -52,6 +52,7 @@ import {
   allocateSourceObservationOrder,
   PROCESS_DECISION_STATUS,
   processDecision,
+  wrappedErrorDetail,
 } from "@/api/handlers/case-law/ingestion/pipeline";
 import type {
   FailedSliceCandidate,
@@ -69,7 +70,7 @@ import {
 } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import type { SafeId } from "@/api/lib/branded-types";
 import { AdapterFetchError } from "@/api/lib/errors/tagged-errors";
-import { errorTag } from "@/api/lib/errors/utils";
+import { errorSystemFields, errorTag } from "@/api/lib/errors/utils";
 import type { CaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
 import { acquireCaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
 import { storedObservationHasDetail } from "@/api/lib/legal-search/ingestion-normalization";
@@ -93,6 +94,7 @@ import {
   selectTrackedIdentityKeys,
 } from "@/api/lib/legal-search/reconciliation-store";
 import { logger } from "@/api/lib/observability/logger";
+import { pgErrorFields } from "@/api/lib/pg-error";
 
 /** Parked items rebuilt in one unit; each costs a publisher fetch. */
 const PARKED_RETRY_BATCH = 25;
@@ -833,7 +835,13 @@ const ingestListedItem = async ({
       adapterKey,
       slice,
       identityKey: item.identityKey,
-      "error.type": errorTag(error),
+      ...errorSystemFields(error),
+      ...pgErrorFields(error),
+      // The park below keeps only the tag, which cannot separate a
+      // publisher refusing one document from the corpus refusing to store
+      // it. "message" is stripped by the logger sanitizer, so the reason
+      // travels under "error.detail". Case-law data is public, no PII concern.
+      "error.detail": wrappedErrorDetail(error),
     });
     await park(errorTag(error));
   }
@@ -1305,7 +1313,9 @@ export const runReconciliationWorkUnit = async ({
               adapterKey,
               slice: unit.slice,
               reason: unit.reason,
-              "error.type": errorTag(error),
+              ...errorSystemFields(error),
+              ...pgErrorFields(error),
+              "error.detail": wrappedErrorDetail(error),
             });
             throw error;
           }),


### PR DESCRIPTION
## Proposed change

`case_law.reconciliation.item_failed` and `case_law.reconciliation.slice_failed`
log `"error.type": errorTag(error)` and nothing else.

For an item that is the whole record. The catch in `ingestListedItem` logs, then
calls `park(errorTag(error))`, so the parked row stores the same tag the log line
already carried: if the failure came from the database, both say
`DrizzleQueryError` and neither says why. A query wrapper reports its own class
name and keeps the driver's SQLSTATE one `.cause` hop down.

`slice_failed` has the same shape: `recordSliceWalkFailure` stores
`describeWalkError(error)`, which is the tag plus a bounded outer message, so a
wrapped driver error persists statement text and drops its SQLSTATE.

This adds the two fixed-vocabulary field sets to both sinks:

- `errorSystemFields(error)` — supersedes the bare `"error.type"` and adds the
  system `code`/`errno`/`syscall` that separate a timeout from a refusal, plus
  the cause's class and code.
- `pgErrorFields(error)` — walks the cause chain and reports
  `error.cause.pg_code` plus the schema identifiers Postgres names (constraint,
  table, column, schema, routine, severity). The same vocabulary
  `RequestErrorFingerprint` already uses for the request path.

Deliberately **not** the error message. `sanitizeLogAttributes` is a denylist over
attribute keys, so a key it does not match carries its value to telemetry
verbatim, and a driver message quotes the failed statement and can quote the row
that violated a constraint. The codes above are what the diagnosis needs.

`park` and `recordSliceWalkFailure` keep taking the tag; the durable columns are
unchanged. This is the log line only.

### Test

`reconciliation-engine.db.test.ts` drives a build that fails the way a driver
does, with the SQLSTATE on `.cause` and a long `Failed query:` outer message, and
pins both halves of the invariant: `error.cause.pg_code` is reported, and no
attribute in the emitted record carries message text. The second assertion runs
over every value rather than a named key, so a field added later cannot
reintroduce the leak. Reverting the source change fails it on the SQLSTATE;
re-adding a raw detail field fails it on the text guard.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no user-facing surface.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no user-facing surface.