### PR TITLE
fix: strengthen package validation guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1787,11 +1787,16 @@ jobs:
   # tolerance can stay tight:
   # baselines and comparison render on the same image.
   marketing-screenshots:
-    needs: ci-plan
+    # A bounded poll can expire while web-build is still waiting for a runner;
+    # declare the producer so artifact consumers start only after it succeeds.
+    needs: [ci-plan, web-build]
     if: >-
-      (needs.ci-plan.outputs.trusted == 'true'
-       || github.event_name == 'workflow_dispatch')
+      always()
+      && (needs.ci-plan.outputs.trusted == 'true'
+          || github.event_name == 'workflow_dispatch')
       && needs.ci-plan.outputs.marketing_screenshots_required == 'true'
+      && (needs.ci-plan.outputs.web_build_required != 'true'
+          || needs.web-build.result == 'success')
     uses: ./.github/workflows/marketing-screenshots.yml
     permissions:
       actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,9 +141,9 @@ jobs:
           package_checks_required=false
           for file in "${changed_files[@]}"; do
             case "$file" in
-              .github/workflows/ci.yml)
+              .github/workflows/ci.yml|.github/actions/setup-playwright/action.yml)
                 # This workflow owns package-check scheduling and the
-                # code-quality job itself, so its changes must exercise both.
+                # browser test setup, so either change must exercise both.
                 package_checks_required=true
                 ;;
               .github/*|.provenance.yml|provenance/*)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -878,6 +878,10 @@ jobs:
       # Its unit coverage is what keeps a malformed source map — a wildcard, a
       # conditions object, a target outside src, a missing root — out of a
       # publishable package.
+      - name: Test published export artifact guard
+        if: needs.ci-plan.outputs.package_checks_required == 'true'
+        run: bun test scripts/published-export-guards.test.ts
+
       - name: Test publish manifest transformation
         # scripts/publish-manifest.ts imports better-result, so this needs the
         # install above; a workflow-only PR skips both.

--- a/scripts/check-published-exports.ts
+++ b/scripts/check-published-exports.ts
@@ -20,6 +20,7 @@ import {
   isDistModuleEntry,
   toPublishedManifest,
 } from "./publish-manifest";
+import { isPublishedTestArtifact } from "./published-export-guards";
 
 const repoRoot = path.resolve(import.meta.dir, "..");
 
@@ -77,11 +78,7 @@ try {
       `tarball embeds ${embeddedDependencyFiles.length} dependency file(s) under dist/node_modules; declare the dependency in runtime or peer metadata (first: ${embeddedDependencyFiles.at(0)})`,
     );
   }
-  const testArtifacts = [...packed].filter((file) =>
-    /(?:^|\/)(?:fixtures\/|[^/]+\.(?:test|spec)\.[cm]?[jt]sx?$|[^/]+\.playwright\.[cm]?[jt]sx?$)/u.test(
-      file,
-    ),
-  );
+  const testArtifacts = [...packed].filter(isPublishedTestArtifact);
   if (testArtifacts.length > 0) {
     failures.push(
       `tarball includes ${testArtifacts.length} test or fixture artifact(s) (first: ${testArtifacts.at(0)})`,

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -336,7 +336,7 @@ describe("detect-e2e-changes", () => {
     const plan = workflowJob("ci-plan");
     const codeQuality = workflowJob("code-quality");
     expect(plan).toContain(
-      ".github/workflows/ci.yml)\n                # This workflow owns package-check scheduling and the\n                # code-quality job itself, so its changes must exercise both.\n                package_checks_required=true",
+      ".github/workflows/ci.yml|.github/actions/setup-playwright/action.yml)\n                # This workflow owns package-check scheduling and the\n                # browser test setup, so either change must exercise both.\n                package_checks_required=true",
     );
     expect(codeQuality).toContain(
       `EVENT_NAME: ${githubExpression("github.event_name")}`,

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -390,8 +390,13 @@ describe("detect-e2e-changes", () => {
     expect(plan).toContain('echo "marketing_screenshots_required=false"');
 
     const screenshots = workflowJob("marketing-screenshots");
+    expect(screenshots).toContain("needs: [ci-plan, web-build]");
+    expect(screenshots).toContain("always()");
     expect(screenshots).toContain(
       "needs.ci-plan.outputs.marketing_screenshots_required == 'true'",
+    );
+    expect(screenshots).toContain(
+      "needs.ci-plan.outputs.web_build_required != 'true'\n          || needs.web-build.result == 'success'",
     );
     expect(screenshots).toContain(
       "uses: ./.github/workflows/marketing-screenshots.yml",

--- a/scripts/published-export-guards.test.ts
+++ b/scripts/published-export-guards.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { isPublishedTestArtifact } from "./published-export-guards";
+
+describe("published export artifact guard", () => {
+  test.each([
+    "fixtures/board.tsx",
+    "dist/fixtures/card.tsx",
+    "dist/card.test.ts",
+    "dist/card.spec.tsx",
+    "dist/card.test.d.ts",
+    "dist/card.spec.d.ts",
+    "playwright.config.ts",
+    "dist/playwright.config.ts",
+    "dist/card.playwright.ts",
+  ])("rejects %s", (file) => {
+    expect(isPublishedTestArtifact(file)).toBe(true);
+  });
+
+  test.each(["dist/board.tsx", "dist/card.d.ts", "README.md"])(
+    "allows %s",
+    (file) => {
+      expect(isPublishedTestArtifact(file)).toBe(false);
+    },
+  );
+});

--- a/scripts/published-export-guards.ts
+++ b/scripts/published-export-guards.ts
@@ -1,0 +1,5 @@
+const testArtifactPattern =
+  /(?:^|\/)(?:fixtures\/|[^/]+\.(?:test|spec)\.(?:[cm]?[jt]sx?|d\.ts)$|[^/]+\.playwright\.[cm]?[jt]sx?$|playwright\.config\.[cm]?[jt]sx?$)/u;
+
+export const isPublishedTestArtifact = (file: string): boolean =>
+  testArtifactPattern.test(file);

--- a/scripts/published-export-guards.ts
+++ b/scripts/published-export-guards.ts
@@ -1,5 +1,5 @@
 const testArtifactPattern =
   /(?:^|\/)(?:fixtures\/|[^/]+\.(?:test|spec)\.(?:[cm]?[jt]sx?|d\.ts)$|[^/]+\.playwright\.[cm]?[jt]sx?$|playwright\.config\.[cm]?[jt]sx?$)/u;
 
-export const isPublishedTestArtifact = (file: string): boolean =>
+export const isPublishedTestArtifact = (file: string) =>
   testArtifactPattern.test(file);

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -268,6 +268,8 @@ run_step "Desktop release promotion self-test" bash \
   scripts/promote-desktop-release.test.sh
 run_step "Web container platform self-test" bun test \
   scripts/check-web-docker-platform.test.ts
+run_step "Published export artifact guard self-test" bun test \
+  scripts/published-export-guards.test.ts
 run_step "API release contract self-test" bun test \
   --preload ./apps/api/src/tests/setup-env.ts \
   scripts/check-api-cli-contract.test.ts \


### PR DESCRIPTION
Follow-up to #2502.

- Run package and browser checks when the shared Playwright setup action changes.
- Reject Playwright configuration and declaration test files from published package artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package checks to run when browser test setup changes, helping catch affected issues earlier.
  * Strengthened validation to distinguish test artefacts from production files in published exports.
  * Improved marketing screenshot checks by waiting for the web build and proceeding only when it succeeds or is unnecessary.

* **Tests**
  * Added automated coverage for test, fixture, and browser configuration artefacts.
  * Added verification of published export safeguards to continuous integration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->