### PR TITLE
chore(ci): allowlist the release deployer app in the CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -40,6 +40,6 @@ jobs:
       )
     uses: stella/.github/.github/workflows/cla.yml@7198083e27bdd963cacc0b7d70ca54fe3ec83393
     with:
-      allowlist: dependabot[bot],renovate[bot],github-actions[bot],google-labs-jules[bot],stella-provenance-updater[bot],cursoragent,claude
+      allowlist: dependabot[bot],renovate[bot],github-actions[bot],google-labs-jules[bot],stella-provenance-updater[bot],stella-release-deployer[bot],cursoragent,claude
     secrets:
       CLA_APP_PRIVATE_KEY: ${{ secrets.CLA_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Proposed change

`stella-release-deployer[bot]` authors the regenerated marketing screenshot commits that `marketing-screenshots-update.yml` pushes to a branch. The CLA check runs under `pull_request_target` from main and rejects those commits (#2519), so the allowlist gains the app alongside the other bots. Landing this separately because the check reads main's allowlist, not the PR's.

## Checklist

- [x] **BUILD ASSURANCE** | Workflow-only change.
- [ ] **TESTING** | CLA check on #2519 after merge.
- [ ] DARK MODE SUPPORT | Not applicable.
- [ ] ISSUE LINKED | No existing issue.
- [ ] SCREENSHOT INCLUDED | Not applicable.

https://claude.ai/code/session_01RU5otmbvfBDSz1yNmTiJgi