### PR TITLE
fix: stabilize clipboard edge navigation

### DIFF
--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -85,7 +85,7 @@ import {
   highlightClipboardText,
   isClipboardCopyShortcut,
   isClipboardNameInput,
-  nextClipboardIndex,
+  adjacentClipboardIndex,
   quickCopyIndex,
   shouldCopyFromClipboardInput,
 } from "./clipboard-logic";
@@ -359,7 +359,11 @@ const ClipboardCard = ({
         onClick={() => onCopy(item)}
         onContextMenu={(event) => onOpenMenu(event, item, index)}
         onFocus={() => onSelect(index)}
-        onMouseEnter={() => onSelect(index)}
+        onPointerMove={(event) => {
+          if (event.pointerType === "mouse") {
+            onSelect(index);
+          }
+        }}
         type="button"
       >
         <div className="relative min-h-0 flex-1 self-stretch overflow-hidden p-5">
@@ -1406,9 +1410,15 @@ const ClipboardApp = () => {
   };
 
   const navigate = (direction: "next" | "previous") => {
-    selectIndex(
-      nextClipboardIndex(activeIndex, direction, filteredItems.length),
+    const nextIndex = adjacentClipboardIndex(
+      activeIndex,
+      direction,
+      filteredItems.length,
     );
+    if (nextIndex === null) {
+      return;
+    }
+    selectIndex(nextIndex);
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -121,16 +121,17 @@ export const filterClipboardItems = (
   });
 };
 
-export const nextClipboardIndex = (
+export const adjacentClipboardIndex = (
   currentIndex: number,
   direction: "next" | "previous",
   itemCount: number,
 ) => {
   if (itemCount === 0) {
-    return 0;
+    return null;
   }
   const offset = direction === "next" ? 1 : -1;
-  return Math.max(0, Math.min(currentIndex + offset, itemCount - 1));
+  const nextIndex = currentIndex + offset;
+  return nextIndex < 0 || nextIndex >= itemCount ? null : nextIndex;
 };
 
 export const quickCopyIndex = (key: string, itemCount: number) => {

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  adjacentClipboardIndex,
   CLIPBOARD_ITEM_DRAG_TYPE,
   clipboardDraggedItemId,
   clipboardSourceTintIndex,
@@ -9,7 +10,6 @@ import {
   highlightClipboardText,
   isClipboardCopyShortcut,
   isClipboardNameInput,
-  nextClipboardIndex,
   quickCopyIndex,
   shouldCopyFromClipboardInput,
 } from "../src/clipboard/clipboard-logic";
@@ -142,11 +142,12 @@ test("source apps receive a stable tint from the bounded palette", () => {
 });
 
 describe("keyboard indexes", () => {
-  test("timeline navigation stops at either edge", () => {
-    expect(nextClipboardIndex(0, "next", 2)).toBe(1);
-    expect(nextClipboardIndex(1, "next", 2)).toBe(1);
-    expect(nextClipboardIndex(1, "previous", 2)).toBe(0);
-    expect(nextClipboardIndex(0, "previous", 2)).toBe(0);
+  test("timeline navigation has no target beyond either edge", () => {
+    expect(adjacentClipboardIndex(0, "next", 2)).toBe(1);
+    expect(adjacentClipboardIndex(1, "next", 2)).toBeNull();
+    expect(adjacentClipboardIndex(1, "previous", 2)).toBe(0);
+    expect(adjacentClipboardIndex(0, "previous", 2)).toBeNull();
+    expect(adjacentClipboardIndex(0, "next", 0)).toBeNull();
   });
 
   test("quick copy only accepts visible slots one through nine", () => {


### PR DESCRIPTION
## Summary

- ignore layout-driven hover changes while keyboard navigation scrolls the clipboard rail
- make navigation beyond either rail edge an explicit no-op
- cover edge and empty-history navigation targets

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard navigation so moving beyond the first or last item no longer selects an unintended entry.
  * Prevented navigation attempts when the clipboard list is empty.
  * Refined pointer-based selection to respond more reliably to mouse movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->