### PR TITLE
fix: align auth access transition

### DIFF
--- a/apps/api/drizzle/20260827150000_better_auth_access_transition/migration.sql
+++ b/apps/api/drizzle/20260827150000_better_auth_access_transition/migration.sql
@@ -1,0 +1,7 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5s';--> statement-breakpoint
+
+-- Align the legacy two-factor table with the denied auth-table access
+-- boundary. Better Auth uses the owner connection; scoped application reads
+-- were already rejected by the table's deny policy.
+REVOKE ALL PRIVILEGES ON TABLE "two_factor" FROM stella;


### PR DESCRIPTION
## Summary

- add an idempotent auth access transition
- preserve runtime compatibility
- keep the post-migration invariant enforced

CC on behalf of sok0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated database access controls for the legacy two-factor authentication table.
  * Added safeguards to limit lock wait and statement execution times during the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->