### PR TITLE
fix(ui): let application shell content shrink

### DIFF
--- a/.changeset/quiet-shells-shrink.md
+++ b/.changeset/quiet-shells-shrink.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": patch
+---
+
+Allow application shell content to shrink within its flex layout.

--- a/packages/ui/src/components/application-shell.test.tsx
+++ b/packages/ui/src/components/application-shell.test.tsx
@@ -30,7 +30,7 @@ describe("ApplicationShell", () => {
     expect(markup).toContain("flex min-h-svh w-full");
     expect(markup).toContain('data-slot="application-shell-main"');
     expect(markup).toContain(
-      "bg-background relative flex w-full flex-1 flex-col overflow-hidden",
+      "bg-background relative flex w-full min-w-0 flex-1 flex-col overflow-hidden",
     );
     expect(markup).toContain("md:peer-data-[variant=inset]:rounded-xl");
   });

--- a/packages/ui/src/components/application-shell.tsx
+++ b/packages/ui/src/components/application-shell.tsx
@@ -40,7 +40,7 @@ export const ApplicationShell = ({
     {sidebar}
     <main
       className={cn(
-        "bg-background relative flex w-full flex-1 flex-col overflow-hidden",
+        "bg-background relative flex w-full min-w-0 flex-1 flex-col overflow-hidden",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-2",
         mainClassName,
       )}


### PR DESCRIPTION
Allows the shared application shell content column to shrink when sibling navigation changes width, so route scroll surfaces reflow to the current layout boundary.

Adds regression coverage for the shell sizing invariant.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shell layout behaviour by allowing the main content area to shrink appropriately when side panels are open.
  * Prevented horizontal content overflow in narrower available spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->