### PR TITLE
perf(desktop): speed up clipboard timeline open and add startup timing

### DIFF
--- a/apps/desktop/fixtures/desktop-telemetry-contract.json
+++ b/apps/desktop/fixtures/desktop-telemetry-contract.json
@@ -31,5 +31,12 @@
     "unhandledError",
     "unhandledRejection",
     "windowLabelMismatch"
+  ],
+  "spans": [
+    "clipboardFirstPaint",
+    "clipboardHistoryReady",
+    "clipboardReopenPaint",
+    "clipboardShellCommit",
+    "clipboardSnapshotRequest"
   ]
 }

--- a/apps/desktop/src-tauri/capabilities/clipboard.json
+++ b/apps/desktop/src-tauri/capabilities/clipboard.json
@@ -22,6 +22,7 @@
     "allow-clipboard-copy-item",
     "allow-clipboard-hide",
     "allow-clipboard-open-stella",
-    "allow-desktop-report-error"
+    "allow-desktop-report-error",
+    "allow-desktop-report-timing"
   ]
 }

--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -10,6 +10,7 @@ use std::{
   collections::{HashMap, HashSet},
   io::Cursor,
   sync::{Arc, Mutex},
+  time::Instant,
 };
 use tauri::{AppHandle, Emitter};
 
@@ -19,7 +20,8 @@ use crate::{
   config::APP_DATA_DIR_NAME,
   desktop_telemetry::{
     DesktopErrorReport, DesktopTelemetry, DesktopTelemetryErrorCode,
-    DesktopTelemetryOperation, DesktopTelemetryWindow,
+    DesktopTelemetryOperation, DesktopTelemetrySpan, DesktopTelemetryWindow,
+    DesktopTimingReport,
   },
   keychain,
 };
@@ -42,6 +44,7 @@ use std::{
 use winsafe::{HPROCESS, HVERSIONINFO, HWND, co};
 
 const HISTORY_EVENT: &str = "clipboard-history-changed";
+const HISTORY_LOADING_ERROR: &str = "clipboard history is still loading";
 const INTERNAL_CLIPBOARD_FORMAT: &str = "legal.stella.desktop.clipboard";
 #[cfg(target_os = "windows")]
 const WINDOWS_CLIPBOARD_HISTORY_CONTROL_FORMAT: &str = "CanIncludeInClipboardHistory";
@@ -370,6 +373,13 @@ pub struct ClipboardSnapshot {
   pub welcome_status: ClipboardWelcomeStatus,
 }
 
+impl ClipboardSnapshot {
+  /// Content bytes crossing IPC for the items, before JSON framing.
+  pub fn history_bytes(&self) -> usize {
+    self.items.iter().map(ClipboardItem::byte_len).sum()
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistedClipboardState {
@@ -421,6 +431,91 @@ struct ClipboardManagerCheckpoint {
 
 pub type ClipboardAppState = Arc<Mutex<ClipboardManager>>;
 
+/// Durations of the blocking steps inside `load_persisted`; `None` when a step
+/// did not run.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ClipboardInitTimings {
+  pub keychain_read: Option<std::time::Duration>,
+  pub store_load: Option<std::time::Duration>,
+  pub loaded_items: Option<usize>,
+}
+
+/// Persistence resolved without holding the manager mutex.
+pub enum ClipboardLoad {
+  MemoryOnly,
+  DeletionOnly(std::path::PathBuf),
+  Encrypted {
+    store: ClipboardStore,
+    state: Option<PersistedClipboardState>,
+  },
+}
+
+/// Blocking keychain and encrypted-file work. Runs on the watcher thread
+/// before the manager is locked, so snapshot reads never queue behind it.
+pub fn load_persisted() -> (ClipboardLoad, ClipboardInitTimings) {
+  let mut timings = ClipboardInitTimings::default();
+  #[cfg(debug_assertions)]
+  if std::env::var_os(DEBUG_PERSISTENCE_ENV).is_none() {
+    tracing::info!(
+      "clipboard history is memory-only in debug builds; set \
+       STELLA_ENABLE_DEBUG_CLIPBOARD_PERSISTENCE=1 to test encrypted persistence"
+    );
+    return (ClipboardLoad::MemoryOnly, timings);
+  }
+
+  let Some(data_dir) = dirs::data_dir() else {
+    tracing::warn!(
+      "clipboard history is memory-only because no data directory is available"
+    );
+    return (ClipboardLoad::MemoryOnly, timings);
+  };
+  let store_path = data_dir
+    .join(APP_DATA_DIR_NAME)
+    .join("clipboard-history.json.enc");
+  let keychain_started = Instant::now();
+  let key = keychain::get_or_create_clipboard_key();
+  timings.keychain_read = Some(keychain_started.elapsed());
+  let key = match key {
+    Ok(key) => key,
+    Err(error) => {
+      tracing::warn!(error = %error, "clipboard history key is unavailable");
+      let load = if store_path.is_file() {
+        ClipboardLoad::DeletionOnly(store_path)
+      } else {
+        ClipboardLoad::MemoryOnly
+      };
+      return (load, timings);
+    }
+  };
+  let store = ClipboardStore::new(key, store_path.clone());
+  let load_started = Instant::now();
+  let loaded = store.load();
+  timings.store_load = Some(load_started.elapsed());
+  match loaded {
+    Ok(Some(mut state)) => {
+      timings.loaded_items = Some(state.items.len());
+      if prune_items(&mut state.items, state.retention, Utc::now())
+        && let Err(error) = store.persist(&state)
+      {
+        tracing::warn!(error = %error, "expired clipboard history could not be removed");
+        return (ClipboardLoad::DeletionOnly(store_path), timings);
+      }
+      (
+        ClipboardLoad::Encrypted {
+          store,
+          state: Some(state),
+        },
+        timings,
+      )
+    }
+    Ok(None) => (ClipboardLoad::Encrypted { store, state: None }, timings),
+    Err(error) => {
+      tracing::warn!(error = %error, "encrypted clipboard history is unavailable");
+      (ClipboardLoad::DeletionOnly(store_path), timings)
+    }
+  }
+}
+
 struct ClipboardCapture {
   copied_at: DateTime<Utc>,
   html: Option<String>,
@@ -443,62 +538,22 @@ impl ClipboardManager {
     }
   }
 
-  pub fn initialize(&mut self) {
-    #[cfg(debug_assertions)]
-    if std::env::var_os(DEBUG_PERSISTENCE_ENV).is_none() {
-      self.persistence = ClipboardPersistence::MemoryOnly;
-      tracing::info!(
-        "clipboard history is memory-only in debug builds; set \
-         STELLA_ENABLE_DEBUG_CLIPBOARD_PERSISTENCE=1 to test encrypted persistence"
-      );
-      return;
-    }
-
-    let Some(data_dir) = dirs::data_dir() else {
-      self.persistence = ClipboardPersistence::MemoryOnly;
-      tracing::warn!(
-        "clipboard history is memory-only because no data directory is available"
-      );
-      return;
-    };
-    let store_path = data_dir
-      .join(APP_DATA_DIR_NAME)
-      .join("clipboard-history.json.enc");
-    let key = match keychain::get_or_create_clipboard_key() {
-      Ok(key) => key,
-      Err(error) => {
-        self.persistence = if store_path.is_file() {
-          ClipboardPersistence::DeletionOnly(store_path)
-        } else {
-          ClipboardPersistence::MemoryOnly
-        };
-        tracing::warn!(error = %error, "clipboard history key is unavailable");
-        return;
-      }
-    };
-    let store = ClipboardStore::new(key, store_path.clone());
-    match store.load() {
-      Ok(Some(mut state)) => {
-        if prune_items(&mut state.items, state.retention, Utc::now())
-          && let Err(error) = store.persist(&state)
-        {
-          self.persistence = ClipboardPersistence::DeletionOnly(store_path);
-          tracing::warn!(error = %error, "expired clipboard history could not be removed");
-          return;
+  /// Applies a load resolved off the mutex. Mutations are rejected while the
+  /// manager is `Initializing`, so nothing in memory can be overwritten here.
+  pub fn install(&mut self, load: ClipboardLoad) {
+    self.persistence = match load {
+      ClipboardLoad::MemoryOnly => ClipboardPersistence::MemoryOnly,
+      ClipboardLoad::DeletionOnly(path) => ClipboardPersistence::DeletionOnly(path),
+      ClipboardLoad::Encrypted { store, state } => {
+        if let Some(state) = state {
+          self.capture_status = state.capture_status;
+          self.groups = state.groups;
+          self.items = state.items;
+          self.retention = state.retention;
         }
-        self.capture_status = state.capture_status;
-        self.groups = state.groups;
-        self.items = state.items;
-        self.retention = state.retention;
+        ClipboardPersistence::Encrypted(store)
       }
-      Ok(None) => {}
-      Err(error) => {
-        self.persistence = ClipboardPersistence::DeletionOnly(store_path);
-        tracing::warn!(error = %error, "encrypted clipboard history is unavailable");
-        return;
-      }
-    }
-    self.persistence = ClipboardPersistence::Encrypted(store);
+    };
   }
 
   pub fn snapshot(&self) -> ClipboardSnapshot {
@@ -829,8 +884,17 @@ impl ClipboardManager {
   }
 
   fn persist(&self) -> Result<(), String> {
-    let ClipboardPersistence::Encrypted(store) = &self.persistence else {
-      return Ok(());
+    let store = match &self.persistence {
+      // Rejecting the write makes `persist_or_restore` roll the mutation
+      // back, so `install` can never overwrite a change made before the
+      // persisted history arrived.
+      ClipboardPersistence::Initializing => {
+        return Err(HISTORY_LOADING_ERROR.to_string());
+      }
+      ClipboardPersistence::Encrypted(store) => store,
+      ClipboardPersistence::MemoryOnly | ClipboardPersistence::DeletionOnly(_) => {
+        return Ok(());
+      }
     };
     let state = PersistedClipboardState {
       capture_status: self.capture_status,
@@ -1307,13 +1371,45 @@ impl ClipboardHandler for HistoryClipboardHandler {
   }
 }
 
+fn report_init_timings(
+  telemetry: &DesktopTelemetry,
+  initialize: std::time::Duration,
+  timings: ClipboardInitTimings,
+) {
+  let spans = [
+    (DesktopTelemetrySpan::ClipboardInitialize, Some(initialize)),
+    (
+      DesktopTelemetrySpan::ClipboardKeychainRead,
+      timings.keychain_read,
+    ),
+    (DesktopTelemetrySpan::ClipboardStoreLoad, timings.store_load),
+  ];
+  for (span, duration) in spans {
+    let Some(duration) = duration else {
+      continue;
+    };
+    telemetry.capture_timing(DesktopTimingReport {
+      window: DesktopTelemetryWindow::Clipboard,
+      span,
+      duration,
+      open_kind: None,
+      item_count: timings.loaded_items,
+      payload_bytes: None,
+    });
+  }
+}
+
 pub fn initialize_and_watch(
   manager: ClipboardAppState,
   app: AppHandle,
   telemetry: DesktopTelemetry,
 ) {
+  let started = Instant::now();
+  let (load, timings) = load_persisted();
   if let Ok(mut manager) = manager.lock() {
-    manager.initialize();
+    manager.install(load);
+    drop(manager);
+    report_init_timings(&telemetry, started.elapsed(), timings);
   } else {
     tracing::error!("clipboard manager lock is poisoned during initialization");
     telemetry.capture(DesktopErrorReport {
@@ -1418,6 +1514,13 @@ pub fn write_item(item: &ClipboardItem, plain_text_only: bool) -> Result<(), Str
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  /// A manager past initialization; a fresh `new()` rejects mutations.
+  fn ready_manager() -> ClipboardManager {
+    let mut manager = ClipboardManager::new();
+    manager.install(ClipboardLoad::MemoryOnly);
+    manager
+  }
 
   fn text_item(copied_at: DateTime<Utc>, text: &str) -> ClipboardItem {
     ClipboardItem::Text {
@@ -1531,7 +1634,7 @@ mod tests {
   #[test]
   fn capture_deduplicates_and_moves_content_to_the_front() {
     let now = Utc::now();
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     manager.persistence = ClipboardPersistence::MemoryOnly;
 
     assert!(capture(&mut manager, "first", None, now));
@@ -1558,7 +1661,7 @@ mod tests {
         name: "Microsoft Word".to_string(),
       }),
     };
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     manager.items.push(original.clone());
 
     assert!(
@@ -1580,7 +1683,7 @@ mod tests {
   #[test]
   fn item_names_are_bounded_and_survive_recapture() {
     let now = Utc::now();
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     manager.persistence = ClipboardPersistence::MemoryOnly;
     assert!(capture(&mut manager, "Named content", None, now));
     let item_id = manager.items[0].id().to_string();
@@ -1608,7 +1711,7 @@ mod tests {
   #[test]
   fn renaming_reapplies_the_total_history_byte_limit() {
     let now = Utc::now();
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     manager.persistence = ClipboardPersistence::MemoryOnly;
     let target = text_item(now, "target");
     let target_id = target.id().to_string();
@@ -1650,7 +1753,7 @@ mod tests {
 
   #[test]
   fn duplicating_a_missing_item_does_not_change_history() {
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
 
     assert!(!manager.duplicate_item_at("missing", Utc::now()).unwrap());
     assert!(manager.items.is_empty());
@@ -1676,7 +1779,7 @@ mod tests {
   #[test]
   fn editing_reapplies_the_total_history_byte_limit() {
     let now = Utc::now();
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     manager.persistence = ClipboardPersistence::MemoryOnly;
     let large_text = "x".repeat(MAX_ITEM_TEXT_BYTES);
     for _ in 0..(MAX_HISTORY_BYTES / MAX_ITEM_TEXT_BYTES - 1) {
@@ -1713,7 +1816,7 @@ mod tests {
   fn persistence_failure_rolls_back_history_mutations() {
     let store_path = unique_store_path();
     std::fs::create_dir_all(&store_path).unwrap();
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     manager.persistence =
       ClipboardPersistence::Encrypted(ClipboardStore::new([7; 32], store_path.clone()));
     manager.items.push(text_item(Utc::now(), "must remain"));
@@ -1729,7 +1832,7 @@ mod tests {
   fn deletion_only_clear_removes_unreadable_encrypted_history() {
     let store_path = unique_store_path();
     std::fs::write(&store_path, b"encrypted history").unwrap();
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     manager.persistence = ClipboardPersistence::DeletionOnly(store_path.clone());
 
     manager.clear().unwrap();
@@ -1743,7 +1846,7 @@ mod tests {
 
   #[test]
   fn deletion_only_rejects_retention_changes() {
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     manager.persistence = ClipboardPersistence::DeletionOnly(unique_store_path());
 
     let result = manager.set_retention(ClipboardRetention::Week);
@@ -1768,7 +1871,7 @@ mod tests {
     };
     store.persist(&state).unwrap();
 
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     manager.items = state.items;
     manager.persistence = ClipboardPersistence::Encrypted(store);
 
@@ -1788,7 +1891,7 @@ mod tests {
   fn retention_choice_bounds_pruning_and_persists() {
     let store_path = unique_store_path();
     let now = Utc::now();
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     manager.items = vec![
       text_item(now - Duration::days(200), "old"),
       text_item(now - Duration::days(20), "recent"),
@@ -1844,7 +1947,7 @@ mod tests {
 
   #[test]
   fn paused_capture_does_not_record_content() {
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     manager
       .set_capture_status(ClipboardCaptureStatus::Paused)
       .unwrap();
@@ -1898,7 +2001,7 @@ mod tests {
 
   #[test]
   fn deleting_a_group_preserves_its_items() {
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     assert!(capture(&mut manager, "grouped", None, Utc::now()));
     let group_id = manager
       .create_group("Research", ClipboardGroupColor::Blue)
@@ -1917,7 +2020,7 @@ mod tests {
 
   #[test]
   fn group_count_and_names_are_bounded() {
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     for index in 0..MAX_GROUPS {
       manager
         .create_group(&format!("Group {index}"), ClipboardGroupColor::Gray)
@@ -1930,7 +2033,7 @@ mod tests {
         .is_err()
     );
 
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     assert!(
       manager
         .create_group(
@@ -1943,7 +2046,7 @@ mod tests {
 
   #[test]
   fn group_name_limit_counts_unicode_characters() {
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     let international_name = "界".repeat(MAX_GROUP_NAME_CHARACTERS);
 
     assert!(
@@ -1976,7 +2079,7 @@ mod tests {
   #[test]
   fn recopying_grouped_content_keeps_its_group() {
     let now = Utc::now();
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     assert!(capture(&mut manager, "grouped", None, now));
     let group_id = manager
       .create_group("Research", ClipboardGroupColor::Emerald)
@@ -1993,7 +2096,7 @@ mod tests {
 
   #[test]
   fn editing_formatted_text_produces_a_consistent_plain_text_item() {
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     assert!(capture(
       &mut manager,
       "old",
@@ -2009,7 +2112,7 @@ mod tests {
 
   #[test]
   fn editing_formatted_text_preserves_safe_formatting() {
-    let mut manager = ClipboardManager::new();
+    let mut manager = ready_manager();
     assert!(capture(&mut manager, "old", None, Utc::now()));
     let item_id = manager.items[0].id().to_string();
 

--- a/apps/desktop/src-tauri/src/clipboard_commands.rs
+++ b/apps/desktop/src-tauri/src/clipboard_commands.rs
@@ -1,5 +1,8 @@
 use serde::Serialize;
-use std::sync::{Arc, Mutex};
+use std::{
+  sync::{Arc, Mutex},
+  time::Instant,
+};
 use tauri::{AppHandle, Emitter, State, WebviewWindow};
 
 use crate::{
@@ -7,7 +10,10 @@ use crate::{
     ClipboardAppState, ClipboardCaptureStatus, ClipboardGroup, ClipboardGroupColor,
     ClipboardItem, ClipboardRetention, ClipboardSnapshot, write_item,
   },
-  clipboard_window,
+  clipboard_window::{self, ClipboardStartupTrace},
+  desktop_telemetry::{
+    DesktopTelemetry, DesktopTelemetrySpan, DesktopTelemetryWindow, DesktopTimingReport,
+  },
 };
 
 const HISTORY_EVENT: &str = "clipboard-history-changed";
@@ -31,10 +37,36 @@ fn lock_error() -> String {
 #[tauri::command]
 pub fn clipboard_get_snapshot(
   state: State<'_, ClipboardAppState>,
+  telemetry: State<'_, DesktopTelemetry>,
+  startup: State<'_, ClipboardStartupTrace>,
 ) -> Result<ClipboardSnapshot, String> {
+  let lock_requested = Instant::now();
   let mut manager = state.lock().map_err(|_| lock_error())?;
+  let lock_wait = lock_requested.elapsed();
+  let build_started = Instant::now();
   manager.prune_expired(chrono::Utc::now())?;
-  Ok(manager.snapshot())
+  let snapshot = manager.snapshot();
+  let build = build_started.elapsed();
+  drop(manager);
+
+  if let Some(open_kind) = startup.claim_snapshot() {
+    let item_count = Some(snapshot.items.len());
+    let payload_bytes = Some(snapshot.history_bytes());
+    for (span, duration) in [
+      (DesktopTelemetrySpan::ClipboardSnapshotLockWait, lock_wait),
+      (DesktopTelemetrySpan::ClipboardSnapshotBuild, build),
+    ] {
+      telemetry.capture_timing(DesktopTimingReport {
+        window: DesktopTelemetryWindow::Clipboard,
+        span,
+        duration,
+        open_kind: Some(open_kind),
+        item_count,
+        payload_bytes,
+      });
+    }
+  }
+  Ok(snapshot)
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/clipboard_window.rs
+++ b/apps/desktop/src-tauri/src/clipboard_window.rs
@@ -1,3 +1,7 @@
+use std::{
+  sync::Mutex,
+  time::{Duration, Instant},
+};
 use tauri::{
   AppHandle, LogicalPosition, LogicalSize, Manager, WebviewWindow,
   webview::PageLoadEvent,
@@ -5,8 +9,9 @@ use tauri::{
 };
 
 use crate::desktop_telemetry::{
-  DesktopErrorReport, DesktopTelemetry, DesktopTelemetryErrorCode,
-  DesktopTelemetryOperation, DesktopTelemetryWindow,
+  ClipboardOpenKind, DesktopErrorReport, DesktopTelemetry, DesktopTelemetryErrorCode,
+  DesktopTelemetryOperation, DesktopTelemetrySpan, DesktopTelemetryWindow,
+  DesktopTimingReport,
 };
 
 const CLIPBOARD_WINDOW_LABEL: &str = "clipboard";
@@ -14,6 +19,70 @@ const CLIPBOARD_EDITOR_WINDOW_LABEL: &str = "clipboard-editor";
 const CLIPBOARD_WINDOW_HEIGHT: f64 = 326.0;
 const CLIPBOARD_WINDOW_INSET: f64 = 18.0;
 const CLIPBOARD_WINDOW_RADIUS: f64 = 28.0;
+
+/// Timing anchor for the clipboard window's creation. Page load and frontend
+/// spans are measured against it, and the first snapshot read after creation
+/// claims its spans once so steady-state history reads stay unmeasured.
+#[derive(Default)]
+pub struct ClipboardStartupTrace(Mutex<Option<StartupTrace>>);
+
+struct StartupTrace {
+  started: Instant,
+  open_kind: ClipboardOpenKind,
+  snapshot_claimed: bool,
+}
+
+impl ClipboardStartupTrace {
+  fn begin(&self, started: Instant, open_kind: ClipboardOpenKind) {
+    if let Ok(mut trace) = self.0.lock() {
+      *trace = Some(StartupTrace {
+        started,
+        open_kind,
+        snapshot_claimed: false,
+      });
+    }
+  }
+
+  fn elapsed(&self) -> Option<(Duration, ClipboardOpenKind)> {
+    let trace = self.0.lock().ok()?;
+    let trace = trace.as_ref()?;
+    Some((trace.started.elapsed(), trace.open_kind))
+  }
+
+  pub fn open_kind(&self) -> Option<ClipboardOpenKind> {
+    self.0.lock().ok()?.as_ref().map(|trace| trace.open_kind)
+  }
+
+  /// Open kind for the first snapshot read after the window was created;
+  /// `None` for every later read.
+  pub fn claim_snapshot(&self) -> Option<ClipboardOpenKind> {
+    let mut trace = self.0.lock().ok()?;
+    let trace = trace.as_mut()?;
+    if trace.snapshot_claimed {
+      return None;
+    }
+    trace.snapshot_claimed = true;
+    Some(trace.open_kind)
+  }
+}
+
+fn capture_window_timing(
+  app: &AppHandle,
+  span: DesktopTelemetrySpan,
+  duration: Duration,
+  open_kind: ClipboardOpenKind,
+) {
+  if let Some(telemetry) = app.try_state::<DesktopTelemetry>() {
+    telemetry.capture_timing(DesktopTimingReport {
+      window: DesktopTelemetryWindow::Clipboard,
+      span,
+      duration,
+      open_kind: Some(open_kind),
+      item_count: None,
+      payload_bytes: None,
+    });
+  }
+}
 
 fn capture_window_error(
   app: &AppHandle,
@@ -139,6 +208,17 @@ fn position_window(app: &AppHandle, window: &WebviewWindow) {
 }
 
 pub fn show(app: &AppHandle) {
+  show_as(app, ClipboardOpenKind::FirstOpen);
+}
+
+pub fn show_on_launch(app: &AppHandle) {
+  show_as(app, ClipboardOpenKind::Launch);
+}
+
+/// `created_kind` labels the trace when the window has to be created; an
+/// existing window is always a reopen.
+fn show_as(app: &AppHandle, created_kind: ClipboardOpenKind) {
+  let requested = Instant::now();
   #[cfg(target_os = "macos")]
   let _ = app.show();
 
@@ -150,8 +230,19 @@ pub fn show(app: &AppHandle) {
         DesktopTelemetryOperation::ClipboardWindowOpen,
         DesktopTelemetryWindow::Clipboard,
       );
+      return;
     }
+    capture_window_timing(
+      app,
+      DesktopTelemetrySpan::ClipboardWindowShow,
+      requested.elapsed(),
+      ClipboardOpenKind::Reopen,
+    );
     return;
+  }
+
+  if let Some(trace) = app.try_state::<ClipboardStartupTrace>() {
+    trace.begin(requested, created_kind);
   }
 
   #[cfg(debug_assertions)]
@@ -188,18 +279,37 @@ pub fn show(app: &AppHandle) {
     if payload.event() != PageLoadEvent::Finished {
       return;
     }
-    position_window(window.app_handle(), &window);
+    let app = window.app_handle();
+    position_window(app, &window);
     if window.show().and_then(|()| window.set_focus()).is_err() {
       capture_window_error(
-        window.app_handle(),
+        app,
         DesktopTelemetryOperation::ClipboardWindowOpen,
         DesktopTelemetryWindow::Clipboard,
+      );
+      return;
+    }
+    if let Some((elapsed, open_kind)) = app
+      .try_state::<ClipboardStartupTrace>()
+      .and_then(|trace| trace.elapsed())
+    {
+      capture_window_timing(
+        app,
+        DesktopTelemetrySpan::ClipboardPageLoad,
+        elapsed,
+        open_kind,
       );
     }
   });
 
   match builder.build() {
     Ok(window) => {
+      capture_window_timing(
+        app,
+        DesktopTelemetrySpan::ClipboardWindowCreate,
+        requested.elapsed(),
+        created_kind,
+      );
       position_window(app, &window);
       let window_to_hide = window.clone();
       window.on_window_event(move |event| {

--- a/apps/desktop/src-tauri/src/command_manifest.rs
+++ b/apps/desktop/src-tauri/src/command_manifest.rs
@@ -37,6 +37,7 @@ macro_rules! with_stella_commands {
       clipboard_commands::clipboard_show => "clipboard_show",
       clipboard_commands::clipboard_open_stella => "clipboard_open_stella",
       desktop_telemetry::desktop_report_error => "desktop_report_error",
+      desktop_telemetry::desktop_report_timing => "desktop_report_timing",
     }
   };
 }

--- a/apps/desktop/src-tauri/src/desktop_telemetry.rs
+++ b/apps/desktop/src-tauri/src/desktop_telemetry.rs
@@ -457,12 +457,21 @@ pub fn desktop_report_timing(
   telemetry: State<'_, DesktopTelemetry>,
   startup: State<'_, ClipboardStartupTrace>,
 ) {
-  let open_kind = match report.window {
-    DesktopTelemetryWindow::Clipboard => startup.open_kind(),
-    DesktopTelemetryWindow::Main
-    | DesktopTelemetryWindow::ClipboardEditor
-    | DesktopTelemetryWindow::TakeoverDialog
-    | DesktopTelemetryWindow::SelfHostConnectDialog => None,
+  // The startup trace holds the kind the window was created with, so it only
+  // labels the initial-open spans. A reopen paint is a reopen by definition;
+  // reading the trace would misattribute it to launch or first open.
+  let open_kind = match (report.window, report.span) {
+    (DesktopTelemetryWindow::Clipboard, DesktopTelemetrySpan::ClipboardReopenPaint) => {
+      Some(ClipboardOpenKind::Reopen)
+    }
+    (DesktopTelemetryWindow::Clipboard, _) => startup.open_kind(),
+    (
+      DesktopTelemetryWindow::Main
+      | DesktopTelemetryWindow::ClipboardEditor
+      | DesktopTelemetryWindow::TakeoverDialog
+      | DesktopTelemetryWindow::SelfHostConnectDialog,
+      _,
+    ) => None,
   };
   telemetry.capture_timing(DesktopTimingReport {
     window: report.window,

--- a/apps/desktop/src-tauri/src/desktop_telemetry.rs
+++ b/apps/desktop/src-tauri/src/desktop_telemetry.rs
@@ -9,6 +9,8 @@ use std::{
 use tauri::State;
 use tokio::sync::mpsc;
 
+use crate::clipboard_window::ClipboardStartupTrace;
+
 const ANALYTICS_CAPTURE_PATH: &str = "capture/";
 const DEFAULT_ANALYTICS_HOST: &str = "https://eu.i.posthog.com/";
 const ANALYTICS_KEY_PREFIX: &str = "phc_";
@@ -135,10 +137,116 @@ pub struct DesktopErrorReport {
   pub code: DesktopTelemetryErrorCode,
 }
 
+/// Startup phases measured on the clipboard path. Spans carry durations and
+/// counts only: never clipboard content, source-app identities, or search text.
+// The `Clipboard` prefix is the wire namespace shared with the frontend
+// contract and mirrors `DesktopTelemetryOperation`; other windows will add
+// unprefixed spans, so the shared prefix is intentional, not redundant.
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DesktopTelemetrySpan {
+  /// Keychain read or key creation inside clipboard initialization.
+  ClipboardKeychainRead,
+  /// Encrypted history file read, decryption, and parsing.
+  ClipboardStoreLoad,
+  /// Whole initialization: the blocking load off the mutex plus install.
+  ClipboardInitialize,
+  /// Show request until the WebView window builder returned.
+  ClipboardWindowCreate,
+  /// Show request until the page finished loading and the window was shown.
+  ClipboardPageLoad,
+  /// Show request until an existing window was shown and focused.
+  ClipboardWindowShow,
+  /// Navigation start until the React shell committed.
+  ClipboardShellCommit,
+  /// Time the first snapshot command waited for the manager mutex.
+  ClipboardSnapshotLockWait,
+  /// Time the first snapshot command spent pruning and cloning history.
+  ClipboardSnapshotBuild,
+  /// Frontend round trip of the first snapshot request.
+  ClipboardSnapshotRequest,
+  /// Navigation start until the first frame after a snapshot was applied.
+  ClipboardFirstPaint,
+  /// Navigation start until a snapshot with settled persistence was applied.
+  ClipboardHistoryReady,
+  /// Window focus after a reopen until the next painted frame.
+  ClipboardReopenPaint,
+}
+
+impl DesktopTelemetrySpan {
+  fn as_str(self) -> &'static str {
+    match self {
+      Self::ClipboardKeychainRead => "clipboardKeychainRead",
+      Self::ClipboardStoreLoad => "clipboardStoreLoad",
+      Self::ClipboardInitialize => "clipboardInitialize",
+      Self::ClipboardWindowCreate => "clipboardWindowCreate",
+      Self::ClipboardPageLoad => "clipboardPageLoad",
+      Self::ClipboardWindowShow => "clipboardWindowShow",
+      Self::ClipboardShellCommit => "clipboardShellCommit",
+      Self::ClipboardSnapshotLockWait => "clipboardSnapshotLockWait",
+      Self::ClipboardSnapshotBuild => "clipboardSnapshotBuild",
+      Self::ClipboardSnapshotRequest => "clipboardSnapshotRequest",
+      Self::ClipboardFirstPaint => "clipboardFirstPaint",
+      Self::ClipboardHistoryReady => "clipboardHistoryReady",
+      Self::ClipboardReopenPaint => "clipboardReopenPaint",
+    }
+  }
+}
+
+/// How the clipboard window came to be shown. Each kind has its own startup
+/// profile and is analyzed separately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ClipboardOpenKind {
+  /// Revealed while the process started.
+  Launch,
+  /// Window created on demand by an already running process.
+  FirstOpen,
+  /// Existing hidden window shown again.
+  Reopen,
+}
+
+impl ClipboardOpenKind {
+  fn as_str(self) -> &'static str {
+    match self {
+      Self::Launch => "launch",
+      Self::FirstOpen => "firstOpen",
+      Self::Reopen => "reopen",
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DesktopTimingReport {
+  pub window: DesktopTelemetryWindow,
+  pub span: DesktopTelemetrySpan,
+  pub duration: Duration,
+  pub open_kind: Option<ClipboardOpenKind>,
+  pub item_count: Option<usize>,
+  pub payload_bytes: Option<usize>,
+}
+
+/// Timing the frontend may submit. Only the duration crosses the IPC boundary;
+/// the native side attaches the open kind from its own startup trace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct DesktopFrontendTimingReport {
+  pub window: DesktopTelemetryWindow,
+  pub span: DesktopTelemetrySpan,
+  pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DesktopTelemetryEvent {
+  Error(DesktopErrorReport),
+  Timing(DesktopTimingReport),
+}
+
 #[derive(Clone)]
 pub struct DesktopTelemetry {
   reported: Arc<Mutex<HashSet<DesktopErrorReport>>>,
-  sender: Option<mpsc::Sender<DesktopErrorReport>>,
+  sender: Option<mpsc::Sender<DesktopTelemetryEvent>>,
 }
 
 struct AnalyticsSinkConfig {
@@ -179,10 +287,27 @@ impl DesktopTelemetry {
       code = ?report.code,
       "desktop operation failed"
     );
+    self.enqueue(DesktopTelemetryEvent::Error(report));
+  }
+
+  pub fn capture_timing(&self, report: DesktopTimingReport) {
+    tracing::info!(
+      window = ?report.window,
+      span = ?report.span,
+      duration_ms = report.duration.as_millis(),
+      open_kind = ?report.open_kind,
+      item_count = report.item_count,
+      payload_bytes = report.payload_bytes,
+      "desktop timing"
+    );
+    self.enqueue(DesktopTelemetryEvent::Timing(report));
+  }
+
+  fn enqueue(&self, event: DesktopTelemetryEvent) {
     let Some(sender) = &self.sender else {
       return;
     };
-    if sender.try_send(report).is_err() {
+    if sender.try_send(event).is_err() {
       tracing::warn!("desktop telemetry queue is unavailable");
     }
   }
@@ -259,18 +384,51 @@ fn analytics_error_payload(
   })
 }
 
+fn analytics_timing_payload(
+  config: &AnalyticsSinkConfig,
+  report: DesktopTimingReport,
+) -> Value {
+  json!({
+    "api_key": config.key,
+    "event": "desktop_timing",
+    "properties": {
+      "$process_person_profile": false,
+      "app_commit": option_env!("STELLA_COMMIT_SHA"),
+      "app_version": env!("CARGO_PKG_VERSION"),
+      "desktop_window": report.window.as_str(),
+      "distinct_id": config.process_id,
+      "duration_ms": u64::try_from(report.duration.as_millis()).unwrap_or(u64::MAX),
+      "item_count": report.item_count,
+      "open_kind": report.open_kind.map(ClipboardOpenKind::as_str),
+      "payload_bytes": report.payload_bytes,
+      "service_name": "stella-desktop",
+      "span": report.span.as_str(),
+    }
+  })
+}
+
+fn analytics_payload(
+  config: &AnalyticsSinkConfig,
+  event: DesktopTelemetryEvent,
+) -> Value {
+  match event {
+    DesktopTelemetryEvent::Error(report) => analytics_error_payload(config, report),
+    DesktopTelemetryEvent::Timing(report) => analytics_timing_payload(config, report),
+  }
+}
+
 async fn run_observability_worker(
   config: AnalyticsSinkConfig,
-  mut receiver: mpsc::Receiver<DesktopErrorReport>,
+  mut receiver: mpsc::Receiver<DesktopTelemetryEvent>,
 ) {
   let Ok(client) = Client::builder().timeout(REQUEST_TIMEOUT).build() else {
     tracing::warn!("desktop telemetry client could not start");
     return;
   };
-  while let Some(report) = receiver.recv().await {
+  while let Some(event) = receiver.recv().await {
     let status = client
       .post(config.endpoint.clone())
-      .json(&analytics_error_payload(&config, report))
+      .json(&analytics_payload(&config, event))
       .send()
       .await
       .map(|response| response.status());
@@ -293,6 +451,29 @@ pub fn desktop_report_error(
   telemetry.capture(report);
 }
 
+#[tauri::command]
+pub fn desktop_report_timing(
+  report: DesktopFrontendTimingReport,
+  telemetry: State<'_, DesktopTelemetry>,
+  startup: State<'_, ClipboardStartupTrace>,
+) {
+  let open_kind = match report.window {
+    DesktopTelemetryWindow::Clipboard => startup.open_kind(),
+    DesktopTelemetryWindow::Main
+    | DesktopTelemetryWindow::ClipboardEditor
+    | DesktopTelemetryWindow::TakeoverDialog
+    | DesktopTelemetryWindow::SelfHostConnectDialog => None,
+  };
+  telemetry.capture_timing(DesktopTimingReport {
+    window: report.window,
+    span: report.span,
+    duration: Duration::from_millis(report.duration_ms),
+    open_kind,
+    item_count: None,
+    payload_bytes: None,
+  });
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -303,6 +484,7 @@ mod tests {
     windows: Vec<DesktopTelemetryWindow>,
     operations: Vec<DesktopTelemetryOperation>,
     error_codes: Vec<DesktopTelemetryErrorCode>,
+    spans: Vec<DesktopTelemetrySpan>,
   }
 
   fn config() -> AnalyticsSinkConfig {
@@ -383,6 +565,61 @@ mod tests {
         serde_json::to_value(error_code).unwrap(),
         json!(error_code.as_str())
       );
+    }
+    for span in contract.spans {
+      assert_eq!(serde_json::to_value(span).unwrap(), json!(span.as_str()));
+    }
+  }
+
+  #[test]
+  fn frontend_timing_report_rejects_content_fields() {
+    let value = json!({
+      "window": "clipboard",
+      "span": "clipboardFirstPaint",
+      "durationMs": 12,
+      "plainText": "must never be accepted",
+    });
+
+    assert!(serde_json::from_value::<DesktopFrontendTimingReport>(value).is_err());
+  }
+
+  #[test]
+  fn timing_payload_contains_only_allowlisted_diagnostics() {
+    let payload = analytics_timing_payload(
+      &config(),
+      DesktopTimingReport {
+        window: DesktopTelemetryWindow::Clipboard,
+        span: DesktopTelemetrySpan::ClipboardSnapshotBuild,
+        duration: Duration::from_millis(7),
+        open_kind: Some(ClipboardOpenKind::FirstOpen),
+        item_count: Some(3),
+        payload_bytes: Some(4096),
+      },
+    );
+    let properties = payload["properties"].as_object().unwrap();
+
+    assert_eq!(payload["event"], "desktop_timing");
+    assert_eq!(properties["span"], "clipboardSnapshotBuild");
+    assert_eq!(properties["duration_ms"], 7);
+    assert_eq!(properties["open_kind"], "firstOpen");
+    assert_eq!(properties["item_count"], 3);
+    assert_eq!(properties["payload_bytes"], 4096);
+    assert_eq!(properties["$process_person_profile"], false);
+    let allowed = [
+      "$process_person_profile",
+      "app_commit",
+      "app_version",
+      "desktop_window",
+      "distinct_id",
+      "duration_ms",
+      "item_count",
+      "open_kind",
+      "payload_bytes",
+      "service_name",
+      "span",
+    ];
+    for key in properties.keys() {
+      assert!(allowed.contains(&key.as_str()), "unexpected property {key}");
     }
   }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -102,6 +102,7 @@ pub fn run() {
     .manage::<AppState>(Arc::clone(&manager))
     .manage::<ClipboardAppState>(Arc::clone(&clipboard_manager))
     .manage::<ClipboardEditorState>(Arc::new(std::sync::Mutex::new(None)))
+    .manage(clipboard_window::ClipboardStartupTrace::default())
     .setup(move |app| {
       let handle = app.handle().clone();
       let initial_deep_links = app.deep_link().get_current()?;
@@ -166,7 +167,7 @@ pub fn run() {
       }
 
       if reveal_clipboard_on_launch {
-        clipboard_window::show(&handle);
+        clipboard_window::show_on_launch(&handle);
       }
 
       // Restore sessions and build the initial tray menu off the main thread.

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -1129,6 +1129,11 @@ const ClipboardApp = () => {
           return undefined;
         }
         stopListening = unlisten;
+        // Re-read once the subscription exists: the off-mutex initialization
+        // may have installed history and emitted its one-shot change event
+        // between the first read and this listener, which would otherwise
+        // leave the window stuck on the empty initializing snapshot.
+        readSnapshot();
         return undefined;
       })
       .catch(() => {

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -79,6 +79,7 @@ import {
 import {
   CLIPBOARD_ITEM_DRAG_TYPE,
   clipboardDraggedItemId,
+  clipboardRailWindow,
   clipboardSourceTintIndex,
   filterClipboardItems,
   formatClipboardAge,
@@ -89,6 +90,12 @@ import {
   quickCopyIndex,
   shouldCopyFromClipboardInput,
 } from "./clipboard-logic";
+import {
+  markClipboardShellCommit,
+  markClipboardSnapshotApplied,
+  measureClipboardSnapshotRequest,
+  observeClipboardReopens,
+} from "./clipboard-startup-timing";
 import { CLIPBOARD_RETENTIONS, isClipboardSnapshot } from "./clipboard-types";
 import type {
   ClipboardCaptureStatus,
@@ -99,6 +106,7 @@ import type {
   ClipboardSnapshot,
   ClipboardSourceAppVisual,
 } from "./clipboard-types";
+import { useRailViewport } from "./use-rail-viewport";
 
 const CLIPBOARD_GROUP_COLORS = [
   "gray",
@@ -127,6 +135,11 @@ const RETENTION_LABEL_KEYS = {
   year: "retentionYear",
 } as const satisfies Record<ClipboardRetention, string>;
 const CLIPBOARD_CARD_SELECTOR = "[data-clipboard-id]";
+// Must match the card's `w-[246px]` and the rail's `gap-3`.
+const CLIPBOARD_CARD_WIDTH = 246;
+const CLIPBOARD_CARD_GAP = 12;
+const CLIPBOARD_CARD_STRIDE = CLIPBOARD_CARD_WIDTH + CLIPBOARD_CARD_GAP;
+const CLIPBOARD_RAIL_OVERSCAN = 3;
 const CLIPBOARD_GROUP_DROP_SELECTOR = "[data-clipboard-group-id]";
 const CLIPBOARD_NO_GROUP_DROP_ID = "__no_group__";
 const PRIMARY_MODIFIER_LABEL = navigator.userAgent.includes("Mac")
@@ -1062,11 +1075,22 @@ const ClipboardApp = () => {
     (snapshot.welcomeStatus === "pending" && !welcomeDismissed);
 
   useEffect(() => {
+    if (snapshot === EMPTY_SNAPSHOT) {
+      return;
+    }
+    markClipboardSnapshotApplied(snapshot);
+  }, [snapshot]);
+
+  useEffect(() => {
+    markClipboardShellCommit();
+    const stopObservingReopens = observeClipboardReopens();
     let disposed = false;
     const readSnapshot = () => {
       const requestId = snapshotRequestIdRef.current + 1;
       snapshotRequestIdRef.current = requestId;
-      void invoke<unknown>("clipboard_get_snapshot")
+      void measureClipboardSnapshotRequest(
+        invoke<unknown>("clipboard_get_snapshot"),
+      )
         .then((value) => {
           if (disposed || requestId !== snapshotRequestIdRef.current) {
             return undefined;
@@ -1116,6 +1140,7 @@ const ClipboardApp = () => {
         setError({ message: errorReadHistory, source: "read" });
       });
     return () => {
+      stopObservingReopens();
       disposed = true;
       stopListening?.();
     };
@@ -1141,6 +1166,18 @@ const ClipboardApp = () => {
   );
   const activeItem = filteredItems.at(activeIndex);
   const activeItemId = activeItem?.id;
+  const railViewport = useRailViewport(
+    timelineRailRef,
+    filteredItems.length > 0,
+  );
+  const railWindow = clipboardRailWindow({
+    activeIndex,
+    itemCount: filteredItems.length,
+    overscan: CLIPBOARD_RAIL_OVERSCAN,
+    scrollLeft: railViewport.scrollLeft,
+    stride: CLIPBOARD_CARD_STRIDE,
+    viewportWidth: railViewport.width,
+  });
 
   const requestHide = () => {
     void invoke("clipboard_hide").catch(() => {
@@ -1392,6 +1429,8 @@ const ClipboardApp = () => {
     activeGroupId,
     applySnapshotCommand,
     query,
+    railWindow.end,
+    railWindow.start,
     snapshot.groups,
     snapshot.items,
   ]);
@@ -1635,43 +1674,73 @@ const ClipboardApp = () => {
             ref={timelineRailRef}
             role="list"
           >
-            {filteredItems.map((item, index) => {
-              const group = item.groupId
-                ? (groupsById.get(item.groupId) ?? null)
-                : null;
-              return (
-                <ClipboardCard
-                  active={index === activeIndex}
-                  ageReferenceTime={ageReferenceTime}
-                  dragging={
-                    dragState.type === "dragging" &&
-                    dragState.itemId === item.id
-                  }
-                  groupColor={group?.color ?? null}
-                  groupName={group?.name ?? null}
-                  index={index}
-                  item={item}
-                  key={item.id}
-                  onOpenMenu={openContextMenu}
-                  onCopy={copyItem}
-                  onRename={(id, name) =>
-                    applySnapshotCommand("clipboard_set_item_name", {
-                      id,
-                      name,
-                    })
-                  }
-                  onSelect={setSelectedIndex}
-                  query={query}
-                  sourceVisual={
-                    item.sourceApp
-                      ? (sourceAppVisuals.get(
-                          item.sourceApp.identifier ?? item.sourceApp.name,
-                        ) ?? null)
-                      : null
-                  }
-                />
-              );
-            })}
+            {railWindow.start > 0 ? (
+              <div
+                aria-hidden="true"
+                className="shrink-0"
+                style={{
+                  width:
+                    railWindow.start * CLIPBOARD_CARD_STRIDE -
+                    CLIPBOARD_CARD_GAP,
+                }}
+              />
+            ) : null}
+            {filteredItems
+              // Index-based filtering keeps the callback shape the React
+              // Compiler can memoize; slicing and re-deriving the index here
+              // made it drop the component's manual memoization.
+              .map((item, index) => {
+                if (index < railWindow.start || index >= railWindow.end) {
+                  return null;
+                }
+                const group = item.groupId
+                  ? (groupsById.get(item.groupId) ?? null)
+                  : null;
+                return (
+                  <ClipboardCard
+                    active={index === activeIndex}
+                    ageReferenceTime={ageReferenceTime}
+                    dragging={
+                      dragState.type === "dragging" &&
+                      dragState.itemId === item.id
+                    }
+                    groupColor={group?.color ?? null}
+                    groupName={group?.name ?? null}
+                    index={index}
+                    item={item}
+                    key={item.id}
+                    onOpenMenu={openContextMenu}
+                    onCopy={copyItem}
+                    onRename={(id, name) =>
+                      applySnapshotCommand("clipboard_set_item_name", {
+                        id,
+                        name,
+                      })
+                    }
+                    onSelect={setSelectedIndex}
+                    query={query}
+                    sourceVisual={
+                      item.sourceApp
+                        ? (sourceAppVisuals.get(
+                            item.sourceApp.identifier ?? item.sourceApp.name,
+                          ) ?? null)
+                        : null
+                    }
+                  />
+                );
+              })}
+            {railWindow.end < filteredItems.length ? (
+              <div
+                aria-hidden="true"
+                className="shrink-0"
+                style={{
+                  width:
+                    (filteredItems.length - railWindow.end) *
+                      CLIPBOARD_CARD_STRIDE -
+                    CLIPBOARD_CARD_GAP,
+                }}
+              />
+            ) : null}
           </div>
         )}
       </main>

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -101,6 +101,56 @@ export const clipboardSourceTintIndex = (sourceIdentity: string | null) => {
   return hash % CLIPBOARD_SOURCE_TINT_COUNT;
 };
 
+type ClipboardRailWindowOptions = {
+  activeIndex: number;
+  itemCount: number;
+  overscan: number;
+  scrollLeft: number;
+  /** Card width plus the gap that follows it. */
+  stride: number;
+  /** 0 before the rail has been measured. */
+  viewportWidth: number;
+};
+
+/** Half-open index range `[start, end)` of cards to keep mounted. */
+export type ClipboardRailWindow = { end: number; start: number };
+
+const UNMEASURED_VISIBLE_CARDS = 8;
+
+/**
+ * Cards mounted for a horizontal rail: the ones intersecting the viewport
+ * plus `overscan` on each side. When the active card is outside the viewport
+ * (keyboard navigation, jump to end) the window centers on it instead, so the
+ * card exists in the DOM for focus and scroll-into-view.
+ */
+export const clipboardRailWindow = ({
+  activeIndex,
+  itemCount,
+  overscan,
+  scrollLeft,
+  stride,
+  viewportWidth,
+}: ClipboardRailWindowOptions): ClipboardRailWindow => {
+  if (itemCount === 0) {
+    return { end: 0, start: 0 };
+  }
+  const visible =
+    viewportWidth > 0
+      ? Math.ceil(viewportWidth / stride) + 1
+      : UNMEASURED_VISIBLE_CARDS;
+  let start = Math.floor(Math.max(0, scrollLeft) / stride);
+  let end = start + visible;
+  const active = Math.min(Math.max(0, activeIndex), itemCount - 1);
+  if (active < start || active >= end) {
+    start = active - Math.floor(visible / 2);
+    end = start + visible;
+  }
+  return {
+    end: Math.min(itemCount, end + overscan),
+    start: Math.max(0, start - overscan),
+  };
+};
+
 export const filterClipboardItems = (
   items: readonly ClipboardItem[],
   query: string,

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -118,10 +118,11 @@ export type ClipboardRailWindow = { end: number; start: number };
 const UNMEASURED_VISIBLE_CARDS = 8;
 
 /**
- * Cards mounted for a horizontal rail: the ones intersecting the viewport
- * plus `overscan` on each side. When the active card is outside the viewport
- * (keyboard navigation, jump to end) the window centers on it instead, so the
- * card exists in the DOM for focus and scroll-into-view.
+ * Cards mounted for a horizontal rail: always the ones intersecting the
+ * viewport (from `scrollLeft`) plus `overscan` on each side, so pointer
+ * scrolling never reveals an unmounted region. The range is extended to
+ * include the active card when it sits outside the viewport (keyboard jump,
+ * focus after reopen) so it stays in the DOM for focus and scroll-into-view.
  */
 export const clipboardRailWindow = ({
   activeIndex,
@@ -138,13 +139,10 @@ export const clipboardRailWindow = ({
     viewportWidth > 0
       ? Math.ceil(viewportWidth / stride) + 1
       : UNMEASURED_VISIBLE_CARDS;
-  let start = Math.floor(Math.max(0, scrollLeft) / stride);
-  let end = start + visible;
+  const viewportStart = Math.floor(Math.max(0, scrollLeft) / stride);
   const active = Math.min(Math.max(0, activeIndex), itemCount - 1);
-  if (active < start || active >= end) {
-    start = active - Math.floor(visible / 2);
-    end = start + visible;
-  }
+  const start = Math.min(viewportStart, active);
+  const end = Math.max(viewportStart + visible, active + 1);
   return {
     end: Math.min(itemCount, end + overscan),
     start: Math.max(0, start - overscan),

--- a/apps/desktop/src/clipboard/clipboard-startup-timing.ts
+++ b/apps/desktop/src/clipboard/clipboard-startup-timing.ts
@@ -1,0 +1,107 @@
+import {
+  DESKTOP_TELEMETRY_SPANS,
+  DESKTOP_TELEMETRY_WINDOWS,
+  reportDesktopTiming,
+} from "../telemetry/desktop-telemetry";
+import type { DesktopTelemetrySpan } from "../telemetry/desktop-telemetry";
+import type { ClipboardSnapshot } from "./clipboard-types";
+
+// Each span is reported once per page load. Guards live at module level so
+// StrictMode double effects and hot reloads cannot duplicate a measurement.
+const reported = new Set<DesktopTelemetrySpan>();
+
+const claim = (span: DesktopTelemetrySpan) => {
+  if (reported.has(span)) {
+    return false;
+  }
+  reported.add(span);
+  return true;
+};
+
+const reportSinceNavigation = (span: DesktopTelemetrySpan) => {
+  reportDesktopTiming({
+    durationMs: performance.now(),
+    span,
+    window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
+  });
+};
+
+export const markClipboardShellCommit = () => {
+  if (claim(DESKTOP_TELEMETRY_SPANS.clipboardShellCommit)) {
+    reportSinceNavigation(DESKTOP_TELEMETRY_SPANS.clipboardShellCommit);
+  }
+};
+
+/** Measures the round trip of the first snapshot request only. */
+export const measureClipboardSnapshotRequest = async <T>(
+  request: Promise<T>,
+): Promise<T> => {
+  if (!claim(DESKTOP_TELEMETRY_SPANS.clipboardSnapshotRequest)) {
+    return request;
+  }
+  const started = performance.now();
+  try {
+    return await request;
+  } finally {
+    reportDesktopTiming({
+      durationMs: performance.now() - started,
+      span: DESKTOP_TELEMETRY_SPANS.clipboardSnapshotRequest,
+      window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
+    });
+  }
+};
+
+const afterNextPaint = (callback: () => void) => {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(callback);
+  });
+};
+
+/**
+ * Reports the delay users feel on Cmd+Shift+V with a running app: the hidden
+ * window regaining focus until the next painted frame. On macOS WebKit a
+ * window hide/show does not flip page visibility, but it does refire window
+ * focus. The first focus belongs to the initial open, which first paint
+ * already covers, so it is skipped.
+ */
+export const observeClipboardReopens = () => {
+  let seenFirstFocus = false;
+  const onFocus = () => {
+    if (!seenFirstFocus) {
+      seenFirstFocus = true;
+      return;
+    }
+    const shown = performance.now();
+    afterNextPaint(() => {
+      reportDesktopTiming({
+        durationMs: performance.now() - shown,
+        span: DESKTOP_TELEMETRY_SPANS.clipboardReopenPaint,
+        window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
+      });
+    });
+  };
+  window.addEventListener("focus", onFocus);
+  return () => {
+    window.removeEventListener("focus", onFocus);
+  };
+};
+
+/**
+ * Call after React committed a snapshot. First paint is the frame after the
+ * first applied snapshot; history ready is the first snapshot whose
+ * persistence has settled, which can arrive later when initialization was
+ * still running at the first read.
+ */
+export const markClipboardSnapshotApplied = (snapshot: ClipboardSnapshot) => {
+  if (claim(DESKTOP_TELEMETRY_SPANS.clipboardFirstPaint)) {
+    afterNextPaint(() => {
+      reportSinceNavigation(DESKTOP_TELEMETRY_SPANS.clipboardFirstPaint);
+    });
+  }
+  if (
+    snapshot.persistence.status !== "initializing" &&
+    claim(DESKTOP_TELEMETRY_SPANS.clipboardHistoryReady)
+  ) {
+    reportSinceNavigation(DESKTOP_TELEMETRY_SPANS.clipboardHistoryReady);
+  }
+};

--- a/apps/desktop/src/clipboard/use-rail-viewport.ts
+++ b/apps/desktop/src/clipboard/use-rail-viewport.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import type { RefObject } from "react";
+
+export type RailViewport = {
+  scrollLeft: number;
+  /** 0 until the rail has been measured. */
+  width: number;
+};
+
+const INITIAL_VIEWPORT: RailViewport = { scrollLeft: 0, width: 0 };
+
+/**
+ * Scroll offset and width of a horizontal rail, coalesced to one update per
+ * frame. `mounted` must flip when the rail element is (un)mounted so the
+ * listeners attach to the current node.
+ */
+export const useRailViewport = (
+  rail: RefObject<HTMLDivElement | null>,
+  mounted: boolean,
+): RailViewport => {
+  const [viewport, setViewport] = useState(INITIAL_VIEWPORT);
+
+  useEffect(() => {
+    const node = rail.current;
+    if (!mounted || !node) {
+      return () => undefined;
+    }
+    let frame = 0;
+    const measure = () => {
+      frame = 0;
+      setViewport((current) => {
+        const next = { scrollLeft: node.scrollLeft, width: node.clientWidth };
+        return current.scrollLeft === next.scrollLeft &&
+          current.width === next.width
+          ? current
+          : next;
+      });
+    };
+    const scheduleMeasure = () => {
+      if (frame === 0) {
+        frame = requestAnimationFrame(measure);
+      }
+    };
+    measure();
+    node.addEventListener("scroll", scheduleMeasure, { passive: true });
+    const observer = new ResizeObserver(scheduleMeasure);
+    observer.observe(node);
+    return () => {
+      node.removeEventListener("scroll", scheduleMeasure);
+      observer.disconnect();
+      if (frame !== 0) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  }, [mounted, rail]);
+
+  return viewport;
+};

--- a/apps/desktop/src/i18n/langs/cs.json
+++ b/apps/desktop/src/i18n/langs/cs.json
@@ -92,7 +92,7 @@
     "numberedList": "Číslovaný seznam",
     "strikethrough": "Přeškrtnuté",
     "underline": "Podtržené",
-    "unnamedClip": "Nepojmenovaný klip",
+    "unnamedClip": "Text",
     "allClips": "Všechny klipy",
     "cancel": "Zrušit",
     "capturePaused": "Ukládání pozastaveno",

--- a/apps/desktop/src/i18n/langs/de.json
+++ b/apps/desktop/src/i18n/langs/de.json
@@ -92,7 +92,7 @@
     "numberedList": "Nummerierte Liste",
     "strikethrough": "Durchgestrichen",
     "underline": "Unterstrichen",
-    "unnamedClip": "Unbenannter Clip",
+    "unnamedClip": "Text",
     "allClips": "Alle Clips",
     "cancel": "Abbrechen",
     "capturePaused": "Erfassung pausiert",

--- a/apps/desktop/src/i18n/langs/en.json
+++ b/apps/desktop/src/i18n/langs/en.json
@@ -94,7 +94,7 @@
     "numberedList": "Numbered list",
     "strikethrough": "Strikethrough",
     "underline": "Underline",
-    "unnamedClip": "Untitled clip",
+    "unnamedClip": "Text",
     "allClips": "All clips",
     "cancel": "Cancel",
     "capturePaused": "Capture paused",

--- a/apps/desktop/src/i18n/langs/es.json
+++ b/apps/desktop/src/i18n/langs/es.json
@@ -92,7 +92,7 @@
     "numberedList": "Lista numerada",
     "strikethrough": "Tachado",
     "underline": "Subrayado",
-    "unnamedClip": "Clip sin nombre",
+    "unnamedClip": "Texto",
     "allClips": "Todos los clips",
     "cancel": "Cancelar",
     "capturePaused": "Captura en pausa",

--- a/apps/desktop/src/i18n/langs/et.json
+++ b/apps/desktop/src/i18n/langs/et.json
@@ -92,7 +92,7 @@
     "numberedList": "Nummerdatud loend",
     "strikethrough": "Läbikriipsutus",
     "underline": "Allakriipsutus",
-    "unnamedClip": "Nimetu lõige",
+    "unnamedClip": "Tekst",
     "allClips": "Kõik lõiked",
     "cancel": "Loobu",
     "capturePaused": "Salvestamine peatatud",

--- a/apps/desktop/src/i18n/langs/fr.json
+++ b/apps/desktop/src/i18n/langs/fr.json
@@ -92,7 +92,7 @@
     "numberedList": "Liste numérotée",
     "strikethrough": "Barré",
     "underline": "Souligné",
-    "unnamedClip": "Extrait sans nom",
+    "unnamedClip": "Texte",
     "allClips": "Tous les extraits",
     "cancel": "Annuler",
     "capturePaused": "Capture en pause",

--- a/apps/desktop/src/i18n/langs/hu.json
+++ b/apps/desktop/src/i18n/langs/hu.json
@@ -92,7 +92,7 @@
     "numberedList": "Számozott lista",
     "strikethrough": "Áthúzott",
     "underline": "Aláhúzott",
-    "unnamedClip": "Névtelen elem",
+    "unnamedClip": "Szöveg",
     "allClips": "Összes vágólapelem",
     "cancel": "Mégse",
     "capturePaused": "Rögzítés szüneteltetve",

--- a/apps/desktop/src/i18n/langs/lt.json
+++ b/apps/desktop/src/i18n/langs/lt.json
@@ -92,7 +92,7 @@
     "numberedList": "Numeruotas sąrašas",
     "strikethrough": "Perbrauktas",
     "underline": "Pabrauktas",
-    "unnamedClip": "Bevardė iškarpa",
+    "unnamedClip": "Tekstas",
     "allClips": "Visos iškarpos",
     "cancel": "Atšaukti",
     "capturePaused": "Fiksavimas pristabdytas",

--- a/apps/desktop/src/i18n/langs/lv.json
+++ b/apps/desktop/src/i18n/langs/lv.json
@@ -92,7 +92,7 @@
     "numberedList": "Numurēts saraksts",
     "strikethrough": "Pārsvītrots",
     "underline": "Pasvītrots",
-    "unnamedClip": "Nenosaukts izgriezums",
+    "unnamedClip": "Teksts",
     "allClips": "Visi izgriezumi",
     "cancel": "Atcelt",
     "capturePaused": "Tveršana apturēta",

--- a/apps/desktop/src/i18n/langs/pl.json
+++ b/apps/desktop/src/i18n/langs/pl.json
@@ -92,7 +92,7 @@
     "numberedList": "Lista numerowana",
     "strikethrough": "Przekreślenie",
     "underline": "Podkreślenie",
-    "unnamedClip": "Wycinek bez nazwy",
+    "unnamedClip": "Tekst",
     "allClips": "Wszystkie wycinki",
     "cancel": "Anuluj",
     "capturePaused": "Przechwytywanie wstrzymane",

--- a/apps/desktop/src/i18n/langs/sk.json
+++ b/apps/desktop/src/i18n/langs/sk.json
@@ -92,7 +92,7 @@
     "numberedList": "Číslovaný zoznam",
     "strikethrough": "Prečiarknuté",
     "underline": "Podčiarknuté",
-    "unnamedClip": "Nepomenovaný klip",
+    "unnamedClip": "Text",
     "allClips": "Všetky klipy",
     "cancel": "Zrušiť",
     "capturePaused": "Ukladanie pozastavené",

--- a/apps/desktop/src/telemetry/desktop-telemetry.ts
+++ b/apps/desktop/src/telemetry/desktop-telemetry.ts
@@ -36,17 +36,52 @@ export const DESKTOP_TELEMETRY_ERROR_CODES = {
   windowLabelMismatch: "windowLabelMismatch",
 } as const;
 
+/**
+ * Startup spans the frontend measures. The native side owns the full list and
+ * attaches the open kind; only a duration crosses IPC.
+ */
+export const DESKTOP_TELEMETRY_SPANS = {
+  clipboardFirstPaint: "clipboardFirstPaint",
+  clipboardHistoryReady: "clipboardHistoryReady",
+  clipboardReopenPaint: "clipboardReopenPaint",
+  clipboardShellCommit: "clipboardShellCommit",
+  clipboardSnapshotRequest: "clipboardSnapshotRequest",
+} as const;
+
 type DesktopTelemetryWindow =
   (typeof DESKTOP_TELEMETRY_WINDOWS)[keyof typeof DESKTOP_TELEMETRY_WINDOWS];
 type DesktopTelemetryOperation =
   (typeof DESKTOP_TELEMETRY_OPERATIONS)[keyof typeof DESKTOP_TELEMETRY_OPERATIONS];
 type DesktopTelemetryErrorCode =
   (typeof DESKTOP_TELEMETRY_ERROR_CODES)[keyof typeof DESKTOP_TELEMETRY_ERROR_CODES];
+export type DesktopTelemetrySpan =
+  (typeof DESKTOP_TELEMETRY_SPANS)[keyof typeof DESKTOP_TELEMETRY_SPANS];
 
 export type DesktopErrorReport = {
   code: DesktopTelemetryErrorCode;
   operation: DesktopTelemetryOperation;
   window: DesktopTelemetryWindow;
+};
+
+export type DesktopTimingReport = {
+  durationMs: number;
+  span: DesktopTelemetrySpan;
+  window: DesktopTelemetryWindow;
+};
+
+export const reportDesktopTiming = ({
+  durationMs,
+  span,
+  window,
+}: DesktopTimingReport) => {
+  // The native command accepts a deny-unknown-fields record with an integer
+  // duration. Never attach clipboard data or search text.
+  const report = {
+    durationMs: Math.max(0, Math.round(durationMs)),
+    span,
+    window,
+  };
+  void invoke("desktop_report_timing", { report }).catch(() => undefined);
 };
 
 const reported = new Set<string>();

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -4,6 +4,7 @@ import {
   adjacentClipboardIndex,
   CLIPBOARD_ITEM_DRAG_TYPE,
   clipboardDraggedItemId,
+  clipboardRailWindow,
   clipboardSourceTintIndex,
   filterClipboardItems,
   formatClipboardAge,
@@ -230,6 +231,73 @@ describe("clipboard input keyboard handling", () => {
         key: "Enter",
       }),
     ).toBe(false);
+  });
+});
+
+describe("clipboardRailWindow", () => {
+  const base = { overscan: 2, stride: 100, viewportWidth: 450 };
+
+  test("mounts only the cards intersecting the viewport plus overscan", () => {
+    expect(
+      clipboardRailWindow({
+        ...base,
+        activeIndex: 0,
+        itemCount: 500,
+        scrollLeft: 0,
+      }),
+    ).toEqual({ end: 8, start: 0 });
+    expect(
+      clipboardRailWindow({
+        ...base,
+        activeIndex: 250,
+        itemCount: 500,
+        scrollLeft: 25_000,
+      }),
+    ).toEqual({ end: 258, start: 248 });
+  });
+
+  test("keeps the active card mounted when it is outside the viewport", () => {
+    const window = clipboardRailWindow({
+      ...base,
+      activeIndex: 499,
+      itemCount: 500,
+      scrollLeft: 0,
+    });
+    expect(window.start).toBeLessThanOrEqual(499);
+    expect(window.end).toBe(500);
+    expect(window.end - window.start).toBeLessThan(20);
+  });
+
+  test("is bounded for every scroll position and active index", () => {
+    for (let scrollLeft = 0; scrollLeft <= 50_000; scrollLeft += 731) {
+      for (const activeIndex of [0, 1, 7, 8, 9, 250, 498, 499, 900]) {
+        const window = clipboardRailWindow({
+          ...base,
+          activeIndex,
+          itemCount: 500,
+          scrollLeft,
+        });
+        expect(window.start).toBeGreaterThanOrEqual(0);
+        expect(window.end).toBeLessThanOrEqual(500);
+        expect(window.end - window.start).toBeLessThanOrEqual(6 + 2 * 2);
+        const active = Math.min(activeIndex, 499);
+        expect(active).toBeGreaterThanOrEqual(window.start);
+        expect(active).toBeLessThan(window.end);
+      }
+    }
+  });
+
+  test("renders a default window before the rail is measured", () => {
+    expect(
+      clipboardRailWindow({
+        activeIndex: 0,
+        itemCount: 3,
+        overscan: 2,
+        scrollLeft: 0,
+        stride: 100,
+        viewportWidth: 0,
+      }),
+    ).toEqual({ end: 3, start: 0 });
   });
 });
 

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -263,12 +263,15 @@ describe("clipboardRailWindow", () => {
       itemCount: 500,
       scrollLeft: 0,
     });
-    expect(window.start).toBeLessThanOrEqual(499);
+    // The viewport is at the head while the selection is at the tail, so the
+    // window spans both; the point is that neither is left unmounted.
+    expect(window.start).toBe(0);
     expect(window.end).toBe(500);
-    expect(window.end - window.start).toBeLessThan(20);
   });
 
-  test("is bounded for every scroll position and active index", () => {
+  test("always mounts the viewport and the active card", () => {
+    // The viewport range must stay mounted for every scroll offset, otherwise
+    // pointer scrolling reveals an unmounted (blank) region of the rail.
     for (let scrollLeft = 0; scrollLeft <= 50_000; scrollLeft += 731) {
       for (const activeIndex of [0, 1, 7, 8, 9, 250, 498, 499, 900]) {
         const window = clipboardRailWindow({
@@ -279,12 +282,32 @@ describe("clipboardRailWindow", () => {
         });
         expect(window.start).toBeGreaterThanOrEqual(0);
         expect(window.end).toBeLessThanOrEqual(500);
-        expect(window.end - window.start).toBeLessThanOrEqual(6 + 2 * 2);
+
+        const firstVisible = Math.floor(scrollLeft / base.stride);
+        const lastVisible = Math.min(
+          499,
+          firstVisible + Math.ceil(base.viewportWidth / base.stride),
+        );
+        expect(window.start).toBeLessThanOrEqual(firstVisible);
+        expect(window.end).toBeGreaterThan(lastVisible);
+
         const active = Math.min(activeIndex, 499);
         expect(active).toBeGreaterThanOrEqual(window.start);
         expect(active).toBeLessThan(window.end);
       }
     }
+  });
+
+  test("stays bounded to the viewport when the selection is in view", () => {
+    // Pointer scroll keeps the hovered card selected, so the common case keeps
+    // a small window even in a large history.
+    const window = clipboardRailWindow({
+      ...base,
+      activeIndex: 251,
+      itemCount: 500,
+      scrollLeft: 25_000,
+    });
+    expect(window.end - window.start).toBeLessThanOrEqual(6 + 2 * 2);
   });
 
   test("renders a default window before the rail is measured", () => {

--- a/apps/desktop/tests/desktop-telemetry-contract.test.ts
+++ b/apps/desktop/tests/desktop-telemetry-contract.test.ts
@@ -4,6 +4,7 @@ import contract from "../fixtures/desktop-telemetry-contract.json" with { type: 
 import {
   DESKTOP_TELEMETRY_ERROR_CODES,
   DESKTOP_TELEMETRY_OPERATIONS,
+  DESKTOP_TELEMETRY_SPANS,
   DESKTOP_TELEMETRY_WINDOWS,
 } from "../src/telemetry/desktop-telemetry";
 
@@ -16,5 +17,6 @@ describe("desktop telemetry contract", () => {
     expect(contract.errorCodes).toEqual(
       Object.values(DESKTOP_TELEMETRY_ERROR_CODES),
     );
+    expect(contract.spans).toEqual(Object.values(DESKTOP_TELEMETRY_SPANS));
   });
 });


### PR DESCRIPTION
## What

The clipboard timeline had a visible delay on open, and no timing existed to locate it. This instruments the open path and fixes the two dominant costs it revealed.

**Shorten the initialization lock.** Keychain access and encrypted-history loading now run off the clipboard manager mutex (`load_persisted` → `install`), so the first `clipboard_get_snapshot` returns immediately instead of queuing behind initialization. Mutations are rejected while the manager is still `Initializing`, so a change made before the persisted history arrives cannot be overwritten by the late load.

**Window the timeline rail.** Only the cards intersecting the viewport plus an overscan margin are mounted, and drag behavior is registered only for mounted cards. Opening a large history now mounts a bounded number of cards instead of every one. The active card stays mounted when it is off-screen so focus and scroll-into-view still work.

**Timing telemetry.** A `desktop_report_timing` command and `DesktopTelemetrySpan` cover the open path: window create, page load, shell commit, mutex wait, keychain read, store load, snapshot build, IPC round trip, and first paint, split by how the window was opened (launch, first open, reopen) with item and byte counts. Reports carry durations and counts only; a test rejects content fields and asserts the payload allowlist.

Also labels a clip with no name as its content type ("Text") instead of "Untitled clip", across all languages.

## Verification

- `apps/desktop/src-tauri`: `cargo test` (160), `cargo clippy -- -D warnings`, `cargo fmt --check`.
- `apps/desktop`: `bun test` (67), typecheck, oxlint, oxfmt.
- New coverage: a windowing property/fuzz test in `clipboard-logic.test.ts`; telemetry contract and payload-allowlist tests.

https://claude.ai/code/session_01QFKcnKe3LPSvx4x5HVZsS7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Clipboard history now loads and displays more efficiently, especially for large collections.
  * Scrolling through clipboard items is smoother, with only visible cards rendered.

* **Reliability**
  * Clipboard changes are protected while history is loading, helping prevent data from being overwritten.

* **Diagnostics**
  * Added startup timing measurements to improve visibility into clipboard launch, loading and reopening performance.

* **Translations**
  * Updated the unnamed clipboard item label to “Text” across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->