### PR TITLE
feat(ui): add inspector tab rail primitives

### DIFF
--- a/.changeset/inspector-tabs.md
+++ b/.changeset/inspector-tabs.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": minor
+---
+
+Add inspector tab primitives that share the dock rail's sizing and scroll ownership.

--- a/.changeset/inspector-tabs.md
+++ b/.changeset/inspector-tabs.md
@@ -2,4 +2,4 @@
 "@stll/ui": minor
 ---
 
-Add inspector tab primitives that share the dock rail's sizing and scroll ownership.
+Add reusable inspector tabs and compact application rails that share stella's dock sizing, scroll ownership, and sidebar control rhythm.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./accordion": "./src/components/accordion.tsx",
+    "./application-rail": "./src/components/application-rail.tsx",
     "./alert-dialog": "./src/components/alert-dialog.tsx",
     "./application-shell": "./src/components/application-shell.tsx",
     "./avatar": "./src/components/avatar.tsx",
@@ -102,6 +103,7 @@
     "./kanban": "./src/kanban/index.ts",
     "./theme.css": "./src/styles/theme.css",
     "./components/accordion": "./src/components/accordion.tsx",
+    "./components/application-rail": "./src/components/application-rail.tsx",
     "./components/alert-dialog": "./src/components/alert-dialog.tsx",
     "./components/application-shell": "./src/components/application-shell.tsx",
     "./components/avatar": "./src/components/avatar.tsx",

--- a/packages/ui/src/components/application-rail.test.tsx
+++ b/packages/ui/src/components/application-rail.test.tsx
@@ -7,6 +7,7 @@ import {
   ApplicationRailButton,
   ApplicationRailContent,
   ApplicationRailFooter,
+  APPLICATION_RAIL_BUTTON_SIZE,
   ApplicationRailHeader,
   ApplicationRailMenu,
   ApplicationRailSeparator,
@@ -47,17 +48,22 @@ describe("application rail", () => {
       expect.arrayContaining([APPLICATION_RAIL_WIDTH, "border-e", "md:flex"]),
     );
     expect(classesOf(markup, "application-rail-header")).toEqual(
-      expect.arrayContaining(["h-12", "border-b"]),
+      expect.arrayContaining(["h-12", "border-b", "p-0.5"]),
     );
     expect(classesOf(markup, "application-rail-menu")).toEqual(
-      expect.arrayContaining(["gap-1", "p-2"]),
+      expect.arrayContaining(["gap-0.5", "p-0.5"]),
     );
     expect(classesOf(markup, "application-rail-button")).toEqual(
-      expect.arrayContaining(["size-8", "rounded-md", "focus-visible:ring-2"]),
+      expect.arrayContaining([
+        APPLICATION_RAIL_BUTTON_SIZE,
+        "rounded-md",
+        "focus-visible:ring-2",
+      ]),
     );
     expect(APPLICATION_RAIL_ICON_SIZE).toBe("size-4");
+    expect(APPLICATION_RAIL_BUTTON_SIZE).toBe("size-11");
     expect(classesOf(markup, "application-rail-footer")).toEqual(
-      expect.arrayContaining(["mt-auto", "p-2"]),
+      expect.arrayContaining(["mt-auto", "p-0.5"]),
     );
   });
 });

--- a/packages/ui/src/components/application-rail.test.tsx
+++ b/packages/ui/src/components/application-rail.test.tsx
@@ -1,0 +1,63 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ApplicationRail,
+  ApplicationRailButton,
+  ApplicationRailContent,
+  ApplicationRailFooter,
+  ApplicationRailHeader,
+  ApplicationRailMenu,
+  ApplicationRailSeparator,
+  APPLICATION_RAIL_ICON_SIZE,
+  APPLICATION_RAIL_WIDTH,
+} from "./application-rail";
+
+const classesOf = (markup: string, slot: string) => {
+  const match = new RegExp(`<[^>]*data-slot="${slot}"[^>]*>`, "u").exec(markup);
+  const classAttribute = /class="([^"]*)"/u.exec(match?.[0] ?? "");
+  return classAttribute?.[1]?.split(/\s+/u) ?? [];
+};
+
+describe("application rail", () => {
+  test("keeps compact navigation and account controls inside stella's rail rhythm", () => {
+    const markup = renderToStaticMarkup(
+      <ApplicationRail aria-label="Application navigation">
+        <ApplicationRailHeader>
+          <ApplicationRailButton aria-label="Home">Home</ApplicationRailButton>
+        </ApplicationRailHeader>
+        <ApplicationRailContent>
+          <ApplicationRailMenu>
+            <ApplicationRailButton aria-label="Search">
+              Search
+            </ApplicationRailButton>
+          </ApplicationRailMenu>
+          <ApplicationRailSeparator />
+        </ApplicationRailContent>
+        <ApplicationRailFooter>
+          <ApplicationRailButton aria-label="Account">
+            Account
+          </ApplicationRailButton>
+        </ApplicationRailFooter>
+      </ApplicationRail>,
+    );
+
+    expect(classesOf(markup, "application-rail")).toEqual(
+      expect.arrayContaining([APPLICATION_RAIL_WIDTH, "border-e", "md:flex"]),
+    );
+    expect(classesOf(markup, "application-rail-header")).toEqual(
+      expect.arrayContaining(["h-12", "border-b"]),
+    );
+    expect(classesOf(markup, "application-rail-menu")).toEqual(
+      expect.arrayContaining(["gap-1", "p-2"]),
+    );
+    expect(classesOf(markup, "application-rail-button")).toEqual(
+      expect.arrayContaining(["size-8", "rounded-md", "focus-visible:ring-2"]),
+    );
+    expect(APPLICATION_RAIL_ICON_SIZE).toBe("size-4");
+    expect(classesOf(markup, "application-rail-footer")).toEqual(
+      expect.arrayContaining(["mt-auto", "p-2"]),
+    );
+  });
+});

--- a/packages/ui/src/components/application-rail.tsx
+++ b/packages/ui/src/components/application-rail.tsx
@@ -1,12 +1,10 @@
 import type * as React from "react";
 
-import {
-  SIDE_RAIL_ICON_BUTTON_SIZE,
-  TOOLBAR_ROW_HEIGHT,
-} from "../inspector/layout-tokens";
+import { TOOLBAR_ROW_HEIGHT } from "../inspector/layout-tokens";
 import { cn } from "../lib/utils";
 
 export const APPLICATION_RAIL_WIDTH = "w-12" as const;
+export const APPLICATION_RAIL_BUTTON_SIZE = "size-11" as const;
 export const APPLICATION_RAIL_ICON_SIZE = "size-4" as const;
 
 /**
@@ -36,7 +34,7 @@ export const ApplicationRailHeader = ({
 }: React.ComponentProps<"div">) => (
   <div
     className={cn(
-      "flex shrink-0 items-center justify-center border-b p-2",
+      "flex shrink-0 items-center justify-center border-b p-0.5",
       TOOLBAR_ROW_HEIGHT,
       className,
     )}
@@ -64,7 +62,7 @@ export const ApplicationRailMenu = ({
   ...props
 }: React.ComponentProps<"div">) => (
   <div
-    className={cn("flex flex-col gap-1 p-2", className)}
+    className={cn("flex flex-col gap-0.5 p-0.5", className)}
     data-slot="application-rail-menu"
     {...props}
   />
@@ -76,8 +74,8 @@ export const ApplicationRailButton = ({
 }: React.ComponentProps<"button">) => (
   <button
     className={cn(
-      "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground flex shrink-0 items-center justify-center rounded-md p-2 outline-hidden transition-colors focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50",
-      SIDE_RAIL_ICON_BUTTON_SIZE,
+      "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground flex shrink-0 items-center justify-center rounded-md outline-hidden transition-colors focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50",
+      APPLICATION_RAIL_BUTTON_SIZE,
       className,
     )}
     data-slot="application-rail-button"
@@ -103,7 +101,7 @@ export const ApplicationRailFooter = ({
   ...props
 }: React.ComponentProps<"div">) => (
   <div
-    className={cn("mt-auto flex shrink-0 flex-col gap-2 p-2", className)}
+    className={cn("mt-auto flex shrink-0 flex-col gap-0.5 p-0.5", className)}
     data-slot="application-rail-footer"
     {...props}
   />

--- a/packages/ui/src/components/application-rail.tsx
+++ b/packages/ui/src/components/application-rail.tsx
@@ -1,0 +1,110 @@
+import type * as React from "react";
+
+import {
+  SIDE_RAIL_ICON_BUTTON_SIZE,
+  TOOLBAR_ROW_HEIGHT,
+} from "../inspector/layout-tokens";
+import { cn } from "../lib/utils";
+
+export const APPLICATION_RAIL_WIDTH = "w-12" as const;
+export const APPLICATION_RAIL_ICON_SIZE = "size-4" as const;
+
+/**
+ * A compact application navigation rail. It preserves the same desktop width,
+ * button rhythm, separators, and account affordance as a collapsed app
+ * sidebar without bringing sidebar expansion or mobile-sheet state into hosts
+ * that only need a fixed rail.
+ */
+export const ApplicationRail = ({
+  className,
+  ...props
+}: React.ComponentProps<"nav">) => (
+  <nav
+    className={cn(
+      "bg-sidebar text-sidebar-foreground hidden h-full min-h-0 shrink-0 flex-col border-e md:flex",
+      APPLICATION_RAIL_WIDTH,
+      className,
+    )}
+    data-slot="application-rail"
+    {...props}
+  />
+);
+
+export const ApplicationRailHeader = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn(
+      "flex shrink-0 items-center justify-center border-b p-2",
+      TOOLBAR_ROW_HEIGHT,
+      className,
+    )}
+    data-slot="application-rail-header"
+    {...props}
+  />
+);
+
+export const ApplicationRailContent = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn(
+      "flex min-h-0 flex-1 [scrollbar-width:none] flex-col gap-2 overflow-x-hidden overflow-y-auto [&::-webkit-scrollbar]:hidden",
+      className,
+    )}
+    data-slot="application-rail-content"
+    {...props}
+  />
+);
+
+export const ApplicationRailMenu = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn("flex flex-col gap-1 p-2", className)}
+    data-slot="application-rail-menu"
+    {...props}
+  />
+);
+
+export const ApplicationRailButton = ({
+  className,
+  ...props
+}: React.ComponentProps<"button">) => (
+  <button
+    className={cn(
+      "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground flex shrink-0 items-center justify-center rounded-md p-2 outline-hidden transition-colors focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50",
+      SIDE_RAIL_ICON_BUTTON_SIZE,
+      className,
+    )}
+    data-slot="application-rail-button"
+    type="button"
+    {...props}
+  />
+);
+
+export const ApplicationRailSeparator = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn("bg-sidebar-border h-px shrink-0", className)}
+    data-slot="application-rail-separator"
+    role="separator"
+    {...props}
+  />
+);
+
+export const ApplicationRailFooter = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn("mt-auto flex shrink-0 flex-col gap-2 p-2", className)}
+    data-slot="application-rail-footer"
+    {...props}
+  />
+);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 export * from "./components/accordion";
+export * from "./components/application-rail";
 export * from "./components/alert-dialog";
 export * from "./components/application-shell";
 export * from "./components/avatar";

--- a/packages/ui/src/inspector/index.ts
+++ b/packages/ui/src/inspector/index.ts
@@ -30,6 +30,12 @@ export {
 } from "./chrome";
 export { InspectorDock } from "./dock";
 export {
+  InspectorTab,
+  InspectorTabList,
+  InspectorTabPanel,
+  InspectorTabs,
+} from "./tabs";
+export {
   PROPERTY_ROW_GRID,
   SIDE_RAIL_CONTAINER_CLASS,
   SIDE_RAIL_ICON_BUTTON_SIZE,

--- a/packages/ui/src/inspector/tabs.test.tsx
+++ b/packages/ui/src/inspector/tabs.test.tsx
@@ -36,10 +36,34 @@ describe("inspector tabs", () => {
     expect(classesOf(markup, "inspector-tab-list")).toContain(
       TOOLBAR_ROW_HEIGHT,
     );
-    expect(classesOf(markup, "inspector-tab")).toContain(TOOLBAR_ROW_HEIGHT);
+    expect(classesOf(markup, "inspector-tab")).toEqual(
+      expect.arrayContaining([
+        "size-12",
+        "shrink-0",
+        "focus-visible:ring-inset",
+      ]),
+    );
     expect(classesOf(markup, "inspector-tab-list")).toContain("md:w-12");
     expect(classesOf(markup, "inspector-tab-list")).toEqual(
       expect.arrayContaining(["overflow-x-auto", "md:overflow-y-auto"]),
+    );
+  });
+
+  test("preserves Base UI's state-aware className contract", () => {
+    const markup = renderToStaticMarkup(
+      <InspectorTabs
+        className={({ orientation }) => `orientation-${orientation}`}
+        defaultValue="overview"
+      >
+        <InspectorTabList>
+          <InspectorTab value="overview">Overview</InspectorTab>
+        </InspectorTabList>
+        <InspectorTabPanel value="overview">Content</InspectorTabPanel>
+      </InspectorTabs>,
+    );
+
+    expect(classesOf(markup, "inspector-tabs")).toContain(
+      "orientation-horizontal",
     );
   });
 

--- a/packages/ui/src/inspector/tabs.test.tsx
+++ b/packages/ui/src/inspector/tabs.test.tsx
@@ -8,6 +8,7 @@ import {
   InspectorTabList,
   InspectorTabPanel,
   InspectorTabs,
+  resolveInspectorTabOrientation,
 } from "./tabs";
 
 const classesOf = (markup: string, slot: string) => {
@@ -17,6 +18,11 @@ const classesOf = (markup: string, slot: string) => {
 };
 
 describe("inspector tabs", () => {
+  test("matches keyboard orientation to the responsive rail", () => {
+    expect(resolveInspectorTabOrientation(767)).toBe("horizontal");
+    expect(resolveInspectorTabOrientation(768)).toBe("vertical");
+  });
+
   test("shares the inspector's fixed-height rail rhythm", () => {
     const markup = renderToStaticMarkup(
       <InspectorTabs defaultValue="overview">
@@ -32,6 +38,9 @@ describe("inspector tabs", () => {
     );
     expect(classesOf(markup, "inspector-tab")).toContain(TOOLBAR_ROW_HEIGHT);
     expect(classesOf(markup, "inspector-tab-list")).toContain("md:w-12");
+    expect(classesOf(markup, "inspector-tab-list")).toEqual(
+      expect.arrayContaining(["overflow-x-auto", "md:overflow-y-auto"]),
+    );
   });
 
   test("keeps one scroll owner beside the desktop rail", () => {

--- a/packages/ui/src/inspector/tabs.test.tsx
+++ b/packages/ui/src/inspector/tabs.test.tsx
@@ -8,6 +8,7 @@ import {
   InspectorTabList,
   InspectorTabPanel,
   InspectorTabs,
+  INSPECTOR_RAIL_MEDIA_QUERY,
   resolveInspectorTabOrientation,
 } from "./tabs";
 
@@ -19,8 +20,9 @@ const classesOf = (markup: string, slot: string) => {
 
 describe("inspector tabs", () => {
   test("matches keyboard orientation to the responsive rail", () => {
-    expect(resolveInspectorTabOrientation(767)).toBe("horizontal");
-    expect(resolveInspectorTabOrientation(768)).toBe("vertical");
+    expect(INSPECTOR_RAIL_MEDIA_QUERY).toBe("(min-width: 48rem)");
+    expect(resolveInspectorTabOrientation(false)).toBe("horizontal");
+    expect(resolveInspectorTabOrientation(true)).toBe("vertical");
   });
 
   test("shares the inspector's fixed-height rail rhythm", () => {

--- a/packages/ui/src/inspector/tabs.test.tsx
+++ b/packages/ui/src/inspector/tabs.test.tsx
@@ -1,0 +1,51 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import { TOOLBAR_ROW_HEIGHT } from "./layout-tokens";
+import {
+  InspectorTab,
+  InspectorTabList,
+  InspectorTabPanel,
+  InspectorTabs,
+} from "./tabs";
+
+const classesOf = (markup: string, slot: string) => {
+  const match = new RegExp(`<[^>]*data-slot="${slot}"[^>]*>`, "u").exec(markup);
+  const classAttribute = /class="([^"]*)"/u.exec(match?.[0] ?? "");
+  return classAttribute?.[1]?.split(/\s+/u) ?? [];
+};
+
+describe("inspector tabs", () => {
+  test("shares the inspector's fixed-height rail rhythm", () => {
+    const markup = renderToStaticMarkup(
+      <InspectorTabs defaultValue="overview">
+        <InspectorTabList>
+          <InspectorTab value="overview">Overview</InspectorTab>
+        </InspectorTabList>
+        <InspectorTabPanel value="overview">Content</InspectorTabPanel>
+      </InspectorTabs>,
+    );
+
+    expect(classesOf(markup, "inspector-tab-list")).toContain(
+      TOOLBAR_ROW_HEIGHT,
+    );
+    expect(classesOf(markup, "inspector-tab")).toContain(TOOLBAR_ROW_HEIGHT);
+    expect(classesOf(markup, "inspector-tab-list")).toContain("md:w-12");
+  });
+
+  test("keeps one scroll owner beside the desktop rail", () => {
+    const markup = renderToStaticMarkup(
+      <InspectorTabs defaultValue="overview">
+        <InspectorTabList>
+          <InspectorTab value="overview">Overview</InspectorTab>
+        </InspectorTabList>
+        <InspectorTabPanel value="overview">Content</InspectorTabPanel>
+      </InspectorTabs>,
+    );
+
+    expect(classesOf(markup, "inspector-tab-panel")).toEqual(
+      expect.arrayContaining(["overflow-y-auto", "md:col-start-2"]),
+    );
+  });
+});

--- a/packages/ui/src/inspector/tabs.test.tsx
+++ b/packages/ui/src/inspector/tabs.test.tsx
@@ -57,4 +57,22 @@ describe("inspector tabs", () => {
       expect.arrayContaining(["overflow-y-auto", "md:col-start-2"]),
     );
   });
+
+  test("hides a scrolling rail's scrollbar without reducing tab hit areas", () => {
+    const markup = renderToStaticMarkup(
+      <InspectorTabs defaultValue="overview">
+        <InspectorTabList>
+          <InspectorTab value="overview">Overview</InspectorTab>
+        </InspectorTabList>
+        <InspectorTabPanel value="overview">Content</InspectorTabPanel>
+      </InspectorTabs>,
+    );
+
+    expect(classesOf(markup, "inspector-tab-list")).toEqual(
+      expect.arrayContaining([
+        "scrollbar-none",
+        "[&amp;::-webkit-scrollbar]:hidden",
+      ]),
+    );
+  });
 });

--- a/packages/ui/src/inspector/tabs.tsx
+++ b/packages/ui/src/inspector/tabs.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 
 import { useViewportWidth } from "../hooks/use-viewport-width";
@@ -39,7 +41,7 @@ export const InspectorTabList = ({
 }: TabsPrimitive.List.Props) => (
   <TabsPrimitive.List
     className={cn(
-      "bg-sidebar col-start-1 row-start-2 flex min-w-0 shrink-0 overflow-x-auto overflow-y-hidden border-b md:row-span-2 md:row-start-1 md:h-full md:flex-col md:overflow-x-hidden md:overflow-y-auto md:border-s md:border-e md:border-b-0",
+      "bg-sidebar col-start-1 row-start-2 flex min-w-0 shrink-0 scrollbar-none overflow-x-auto overflow-y-hidden overscroll-x-contain border-b md:row-span-2 md:row-start-1 md:h-full md:flex-col md:overflow-x-hidden md:overflow-y-auto md:overscroll-y-contain md:border-s md:border-e md:border-b-0 [&::-webkit-scrollbar]:hidden",
       TOOLBAR_ROW_HEIGHT,
       "md:w-12",
       className,

--- a/packages/ui/src/inspector/tabs.tsx
+++ b/packages/ui/src/inspector/tabs.tsx
@@ -1,20 +1,11 @@
 "use client";
 
+import * as React from "react";
+
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 
-import { useViewportWidth } from "../hooks/use-viewport-width";
 import { cn } from "../lib/utils";
 import { TOOLBAR_ROW_HEIGHT } from "./layout-tokens";
-
-const inspectorRailBreakpointPx = 768;
-
-export const resolveInspectorTabOrientation = (viewportWidth: number) =>
-  viewportWidth >= inspectorRailBreakpointPx ? "vertical" : "horizontal";
-
-const resolveClassName = <State,>(
-  value: string | ((state: State) => string | undefined) | undefined,
-  state: State,
-) => (typeof value === "function" ? value(state) : value);
 
 /**
  * A tabbed inspector keeps its content beside the same fixed-width rail as a
@@ -25,7 +16,7 @@ export const InspectorTabs = ({
   className,
   ...props
 }: Omit<TabsPrimitive.Root.Props, "orientation">) => {
-  const viewportWidth = useViewportWidth();
+  const isRailLayout = useInspectorRailLayout();
 
   return (
     <TabsPrimitive.Root
@@ -37,10 +28,38 @@ export const InspectorTabs = ({
       }
       data-slot="inspector-tabs"
       {...props}
-      orientation={resolveInspectorTabOrientation(viewportWidth)}
+      orientation={resolveInspectorTabOrientation(isRailLayout)}
     />
   );
 };
+
+export const INSPECTOR_RAIL_MEDIA_QUERY = "(min-width: 48rem)" as const;
+
+export const resolveInspectorTabOrientation = (isRailLayout: boolean) =>
+  isRailLayout ? "vertical" : "horizontal";
+
+const subscribeToInspectorRailLayout = (onChange: () => void) => {
+  const mediaQueryList = window.matchMedia(INSPECTOR_RAIL_MEDIA_QUERY);
+  mediaQueryList.addEventListener("change", onChange);
+  return () => mediaQueryList.removeEventListener("change", onChange);
+};
+
+const getInspectorRailLayoutSnapshot = () =>
+  window.matchMedia(INSPECTOR_RAIL_MEDIA_QUERY).matches;
+
+const getServerInspectorRailLayoutSnapshot = () => false;
+
+const useInspectorRailLayout = () =>
+  React.useSyncExternalStore(
+    subscribeToInspectorRailLayout,
+    getInspectorRailLayoutSnapshot,
+    getServerInspectorRailLayoutSnapshot,
+  );
+
+const resolveClassName = <State,>(
+  value: string | ((state: State) => string | undefined) | undefined,
+  state: State,
+) => (typeof value === "function" ? value(state) : value);
 
 export const InspectorTabList = ({
   className,

--- a/packages/ui/src/inspector/tabs.tsx
+++ b/packages/ui/src/inspector/tabs.tsx
@@ -1,7 +1,13 @@
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 
+import { useViewportWidth } from "../hooks/use-viewport-width";
 import { cn } from "../lib/utils";
 import { TOOLBAR_ROW_HEIGHT } from "./layout-tokens";
+
+const inspectorRailBreakpointPx = 768;
+
+export const resolveInspectorTabOrientation = (viewportWidth: number) =>
+  viewportWidth >= inspectorRailBreakpointPx ? "vertical" : "horizontal";
 
 /**
  * A tabbed inspector keeps its content beside the same fixed-width rail as a
@@ -11,16 +17,21 @@ import { TOOLBAR_ROW_HEIGHT } from "./layout-tokens";
 export const InspectorTabs = ({
   className,
   ...props
-}: TabsPrimitive.Root.Props) => (
-  <TabsPrimitive.Root
-    className={cn(
-      "grid h-full min-h-0 w-full grid-cols-1 grid-rows-[3rem_3rem_minmax(0,1fr)] overflow-hidden md:grid-cols-[3rem_minmax(0,1fr)] md:grid-rows-[3rem_minmax(0,1fr)]",
-      className,
-    )}
-    data-slot="inspector-tabs"
-    {...props}
-  />
-);
+}: Omit<TabsPrimitive.Root.Props, "orientation">) => {
+  const viewportWidth = useViewportWidth();
+
+  return (
+    <TabsPrimitive.Root
+      className={cn(
+        "grid h-full min-h-0 w-full grid-cols-1 grid-rows-[3rem_3rem_minmax(0,1fr)] overflow-hidden md:grid-cols-[3rem_minmax(0,1fr)] md:grid-rows-[3rem_minmax(0,1fr)]",
+        className,
+      )}
+      data-slot="inspector-tabs"
+      {...props}
+      orientation={resolveInspectorTabOrientation(viewportWidth)}
+    />
+  );
+};
 
 export const InspectorTabList = ({
   className,
@@ -28,7 +39,7 @@ export const InspectorTabList = ({
 }: TabsPrimitive.List.Props) => (
   <TabsPrimitive.List
     className={cn(
-      "bg-sidebar col-start-1 row-start-2 flex min-w-0 shrink-0 border-b md:row-span-2 md:row-start-1 md:h-full md:flex-col md:border-s md:border-e md:border-b-0",
+      "bg-sidebar col-start-1 row-start-2 flex min-w-0 shrink-0 overflow-x-auto overflow-y-hidden border-b md:row-span-2 md:row-start-1 md:h-full md:flex-col md:overflow-x-hidden md:overflow-y-auto md:border-s md:border-e md:border-b-0",
       TOOLBAR_ROW_HEIGHT,
       "md:w-12",
       className,

--- a/packages/ui/src/inspector/tabs.tsx
+++ b/packages/ui/src/inspector/tabs.tsx
@@ -11,6 +11,11 @@ const inspectorRailBreakpointPx = 768;
 export const resolveInspectorTabOrientation = (viewportWidth: number) =>
   viewportWidth >= inspectorRailBreakpointPx ? "vertical" : "horizontal";
 
+const resolveClassName = <State,>(
+  value: string | ((state: State) => string | undefined) | undefined,
+  state: State,
+) => (typeof value === "function" ? value(state) : value);
+
 /**
  * A tabbed inspector keeps its content beside the same fixed-width rail as a
  * docked inspector. The mobile layout moves the rail below the header rather
@@ -24,10 +29,12 @@ export const InspectorTabs = ({
 
   return (
     <TabsPrimitive.Root
-      className={cn(
-        "grid h-full min-h-0 w-full grid-cols-1 grid-rows-[3rem_3rem_minmax(0,1fr)] overflow-hidden md:grid-cols-[3rem_minmax(0,1fr)] md:grid-rows-[3rem_minmax(0,1fr)]",
-        className,
-      )}
+      className={(state) =>
+        cn(
+          "grid h-full min-h-0 w-full grid-cols-1 grid-rows-[3rem_3rem_minmax(0,1fr)] overflow-hidden md:grid-cols-[3rem_minmax(0,1fr)] md:grid-rows-[3rem_minmax(0,1fr)]",
+          resolveClassName(className, state),
+        )
+      }
       data-slot="inspector-tabs"
       {...props}
       orientation={resolveInspectorTabOrientation(viewportWidth)}
@@ -40,12 +47,14 @@ export const InspectorTabList = ({
   ...props
 }: TabsPrimitive.List.Props) => (
   <TabsPrimitive.List
-    className={cn(
-      "bg-sidebar col-start-1 row-start-2 flex min-w-0 shrink-0 scrollbar-none overflow-x-auto overflow-y-hidden overscroll-x-contain border-b md:row-span-2 md:row-start-1 md:h-full md:flex-col md:overflow-x-hidden md:overflow-y-auto md:overscroll-y-contain md:border-s md:border-e md:border-b-0 [&::-webkit-scrollbar]:hidden",
-      TOOLBAR_ROW_HEIGHT,
-      "md:w-12",
-      className,
-    )}
+    className={(state) =>
+      cn(
+        "bg-sidebar col-start-1 row-start-2 flex min-w-0 shrink-0 scrollbar-none overflow-x-auto overflow-y-hidden overscroll-x-contain border-b md:row-span-2 md:row-start-1 md:h-full md:flex-col md:overflow-x-hidden md:overflow-y-auto md:overscroll-y-contain md:border-s md:border-e md:border-b-0 [&::-webkit-scrollbar]:hidden",
+        TOOLBAR_ROW_HEIGHT,
+        "md:w-12",
+        resolveClassName(className, state),
+      )
+    }
     data-slot="inspector-tab-list"
     {...props}
   />
@@ -56,11 +65,12 @@ export const InspectorTab = ({
   ...props
 }: TabsPrimitive.Tab.Props) => (
   <TabsPrimitive.Tab
-    className={cn(
-      "group/tab text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-ring data-active:bg-background data-active:text-foreground data-active:before:bg-primary relative flex min-h-8 flex-1 cursor-pointer items-center justify-center border-e transition-colors outline-none before:absolute before:inset-x-0 before:bottom-0 before:hidden before:h-0.5 focus-visible:z-10 focus-visible:ring-2 data-active:before:block data-disabled:pointer-events-none data-disabled:opacity-60 md:w-full md:flex-none md:border-e-0 md:border-b md:before:inset-y-0 md:before:start-0 md:before:h-auto md:before:w-0.5",
-      TOOLBAR_ROW_HEIGHT,
-      className,
-    )}
+    className={(state) =>
+      cn(
+        "group/tab text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-ring data-active:bg-background data-active:text-foreground data-active:before:bg-primary relative flex size-12 shrink-0 cursor-pointer items-center justify-center border-e transition-colors outline-none before:absolute before:inset-x-0 before:bottom-0 before:hidden before:h-0.5 focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset data-active:before:block data-disabled:pointer-events-none data-disabled:opacity-60 md:w-full md:flex-none md:border-e-0 md:border-b md:before:inset-y-0 md:before:start-0 md:before:h-auto md:before:w-0.5",
+        resolveClassName(className, state),
+      )
+    }
     data-slot="inspector-tab"
     {...props}
   />
@@ -71,10 +81,12 @@ export const InspectorTabPanel = ({
   ...props
 }: TabsPrimitive.Panel.Props) => (
   <TabsPrimitive.Panel
-    className={cn(
-      "col-start-1 row-start-3 min-h-0 overflow-x-hidden overflow-y-auto overscroll-contain outline-none md:col-start-2 md:row-start-2",
-      className,
-    )}
+    className={(state) =>
+      cn(
+        "col-start-1 row-start-3 min-h-0 overflow-x-hidden overflow-y-auto overscroll-contain outline-none md:col-start-2 md:row-start-2",
+        resolveClassName(className, state),
+      )
+    }
     data-slot="inspector-tab-panel"
     {...props}
   />

--- a/packages/ui/src/inspector/tabs.tsx
+++ b/packages/ui/src/inspector/tabs.tsx
@@ -1,0 +1,68 @@
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+
+import { cn } from "../lib/utils";
+import { TOOLBAR_ROW_HEIGHT } from "./layout-tokens";
+
+/**
+ * A tabbed inspector keeps its content beside the same fixed-width rail as a
+ * docked inspector. The mobile layout moves the rail below the header rather
+ * than leaving a narrow column beside a full-screen sheet.
+ */
+export const InspectorTabs = ({
+  className,
+  ...props
+}: TabsPrimitive.Root.Props) => (
+  <TabsPrimitive.Root
+    className={cn(
+      "grid h-full min-h-0 w-full grid-cols-1 grid-rows-[3rem_3rem_minmax(0,1fr)] overflow-hidden md:grid-cols-[3rem_minmax(0,1fr)] md:grid-rows-[3rem_minmax(0,1fr)]",
+      className,
+    )}
+    data-slot="inspector-tabs"
+    {...props}
+  />
+);
+
+export const InspectorTabList = ({
+  className,
+  ...props
+}: TabsPrimitive.List.Props) => (
+  <TabsPrimitive.List
+    className={cn(
+      "bg-sidebar col-start-1 row-start-2 flex min-w-0 shrink-0 border-b md:row-span-2 md:row-start-1 md:h-full md:flex-col md:border-s md:border-e md:border-b-0",
+      TOOLBAR_ROW_HEIGHT,
+      "md:w-12",
+      className,
+    )}
+    data-slot="inspector-tab-list"
+    {...props}
+  />
+);
+
+export const InspectorTab = ({
+  className,
+  ...props
+}: TabsPrimitive.Tab.Props) => (
+  <TabsPrimitive.Tab
+    className={cn(
+      "group/tab text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-ring data-active:bg-background data-active:text-foreground data-active:before:bg-primary relative flex min-h-8 flex-1 cursor-pointer items-center justify-center border-e transition-colors outline-none before:absolute before:inset-x-0 before:bottom-0 before:hidden before:h-0.5 focus-visible:z-10 focus-visible:ring-2 data-active:before:block data-disabled:pointer-events-none data-disabled:opacity-60 md:w-full md:flex-none md:border-e-0 md:border-b md:before:inset-y-0 md:before:start-0 md:before:h-auto md:before:w-0.5",
+      TOOLBAR_ROW_HEIGHT,
+      className,
+    )}
+    data-slot="inspector-tab"
+    {...props}
+  />
+);
+
+export const InspectorTabPanel = ({
+  className,
+  ...props
+}: TabsPrimitive.Panel.Props) => (
+  <TabsPrimitive.Panel
+    className={cn(
+      "col-start-1 row-start-3 min-h-0 overflow-x-hidden overflow-y-auto overscroll-contain outline-none md:col-start-2 md:row-start-2",
+      className,
+    )}
+    data-slot="inspector-tab-panel"
+    {...props}
+  />
+);


### PR DESCRIPTION
Adds reusable compact application-rail and inspector-tab chrome: one fixed desktop rail width, sidebar-consistent controls and account footer, responsive tab semantics, and a single scroll owner. The API is generic and has no product-specific navigation or data dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reusable application navigation rail with header, content, menu, separators, buttons and footer areas.
  - Added responsive inspector tabs that display horizontally on smaller screens and vertically in desktop layouts.
  - Inspector tabs support tab panels, keyboard navigation and consistent sizing and scrolling.
  - New components are available through the UI package’s public exports.

- **Tests**
  - Added coverage for application rail styling, inspector tab layouts, orientation and scrolling behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->