### PR TITLE
fix: publish workspace subgroup view type

### DIFF
--- a/.changeset/publish-workspace-model-subgroup.md
+++ b/.changeset/publish-workspace-model-subgroup.md
@@ -1,0 +1,5 @@
+---
+"@stll/workspace-model": minor
+---
+
+Expose the Kanban sub-group property in the published workspace view model.


### PR DESCRIPTION
The grouped Kanban work added `subgroupByPropertyId` to the public workspace view model, but the package was omitted from its release changeset. Publish the additive view-model type so npm consumers receive the same contract as the repository source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The published workspace view now exposes Kanban sub-group information, improving visibility of workspace organisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->