### PR TITLE
fix(api): budget canary tool probes for reasoning models

### DIFF
--- a/apps/api/scripts/ai-provider-canary-config.test.ts
+++ b/apps/api/scripts/ai-provider-canary-config.test.ts
@@ -12,6 +12,7 @@ import {
   missingCanaryProviders,
   modelRoleMaxOutputTokens,
   structuredOutputModelRoleMaxOutputTokens,
+  TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS,
   WEEKLY_TOOL_SHAPES,
   weeklyCanaryRotation,
 } from "./ai-provider-canary-config";
@@ -30,6 +31,14 @@ describe("AI provider canary role budgets", () => {
     expect(modelRoleMaxOutputTokens("reasoning")).toBeGreaterThan(
       structuredOutputModelRoleMaxOutputTokens("reasoning"),
     );
+  });
+
+  test("budgets tool-execution probes above every short-reply role", () => {
+    for (const role of MODEL_ROLES) {
+      expect(TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS).toBeGreaterThanOrEqual(
+        modelRoleMaxOutputTokens(role),
+      );
+    }
   });
 });
 

--- a/apps/api/scripts/ai-provider-canary-config.test.ts
+++ b/apps/api/scripts/ai-provider-canary-config.test.ts
@@ -35,10 +35,16 @@ describe("AI provider canary role budgets", () => {
 
   test("budgets tool-execution probes above every short-reply role", () => {
     for (const role of MODEL_ROLES) {
-      expect(TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS).toBeGreaterThanOrEqual(
+      if (role === "reasoning") {
+        continue;
+      }
+      expect(TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS).toBeGreaterThan(
         modelRoleMaxOutputTokens(role),
       );
     }
+    // Amazon Nova v1 accepts at most 5,120 output tokens and takes part in
+    // the weekly rotation; a larger ceiling is rejected before the tool call.
+    expect(TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS).toBeLessThanOrEqual(5120);
   });
 });
 

--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -131,6 +131,13 @@ export const modelRoleMaxOutputTokens = (role: ModelRole) =>
 export const structuredOutputModelRoleMaxOutputTokens = (role: ModelRole) =>
   role === "reasoning" ? 20_000 : modelRoleMaxOutputTokens(role);
 
+// Tool-execution probes pay for a model's thinking tokens out of the same
+// output budget as the tool call. The chat role's ceiling is sized for a short
+// reply, so reasoning-capable chat models exhaust it and end the stream
+// `incomplete` before emitting a call; give these probes reasoning headroom.
+export const TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS =
+  MODEL_ROLE_MAX_OUTPUT_TOKENS.reasoning;
+
 export const isCanaryProvider = (value: string): value is CanaryProvider =>
   CANARY_PROVIDERS.some((provider) => provider === value);
 

--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -134,9 +134,11 @@ export const structuredOutputModelRoleMaxOutputTokens = (role: ModelRole) =>
 // Tool-execution probes pay for a model's thinking tokens out of the same
 // output budget as the tool call. The chat role's ceiling is sized for a short
 // reply, so reasoning-capable chat models exhaust it and end the stream
-// `incomplete` before emitting a call; give these probes reasoning headroom.
-export const TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS =
-  MODEL_ROLE_MAX_OUTPUT_TOKENS.reasoning;
+// `incomplete` before emitting a call. Give these probes reasoning headroom,
+// but stay under the smallest output ceiling of any offered model (Amazon Nova
+// v1: 5,120), because the weekly rotation runs the same probe on every model
+// and providers reject a ceiling above the model's limit before the call.
+export const TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS = 4096;
 
 export const isCanaryProvider = (value: string): value is CanaryProvider =>
   CANARY_PROVIDERS.some((provider) => provider === value);

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -33,6 +33,7 @@ import {
   structuredOutputModelRoleMaxOutputTokens,
   NEVER_MATCH_PATTERN,
   NULL_WIDENING_CANARY_PROVIDERS,
+  TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS,
   weeklyCanaryRotation,
 } from "./ai-provider-canary-config";
 import type {
@@ -1015,7 +1016,7 @@ const runToolCallRoundTripProbe = async ({
 
   await runToolProbe({
     context,
-    maxOutputTokens: modelRoleMaxOutputTokens(TOOL_CALL_ROLE),
+    maxOutputTokens: TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS,
     prompt: toolRoundTripPromptForProvider(context.provider),
     role: TOOL_CALL_ROLE,
     signal,
@@ -1090,7 +1091,7 @@ const runWeeklyToolShapeProbe = async ({
   );
   await runToolProbe({
     context: { config: context.rotatedConfig, provider: context.provider },
-    maxOutputTokens: modelRoleMaxOutputTokens(TOOL_CALL_ROLE),
+    maxOutputTokens: TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS,
     prompt,
     role: TOOL_CALL_ROLE,
     signal,

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -801,7 +801,6 @@ const capabilityProbes = [
     run: async (context, signal) => {
       const output = await runToolProbe({
         context,
-        maxOutputTokens: MAX_OUTPUT_TOKENS,
         prompt: TOOL_SCHEMA_PROMPT,
         role: CAPABILITY_ROLE,
         signal,
@@ -817,7 +816,6 @@ const capabilityProbes = [
     run: async (context, signal) => {
       const output = await runToolProbe({
         context,
-        maxOutputTokens: MAX_OUTPUT_TOKENS,
         prompt: TOOL_SCHEMA_PROMPT,
         role: CAPABILITY_ROLE,
         signal,

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -1016,7 +1016,6 @@ const runToolCallRoundTripProbe = async ({
 
   await runToolProbe({
     context,
-    maxOutputTokens: TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS,
     prompt: toolRoundTripPromptForProvider(context.provider),
     role: TOOL_CALL_ROLE,
     signal,
@@ -1091,7 +1090,6 @@ const runWeeklyToolShapeProbe = async ({
   );
   await runToolProbe({
     context: { config: context.rotatedConfig, provider: context.provider },
-    maxOutputTokens: TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS,
     prompt,
     role: TOOL_CALL_ROLE,
     signal,
@@ -1103,16 +1101,17 @@ const runWeeklyToolShapeProbe = async ({
 
 type RunToolProbeOptions = {
   context: CanaryContext;
-  maxOutputTokens: number;
   prompt: string;
   role: ModelRole;
   signal: AbortSignal;
   tool: AnyClientTool | AnyServerTool;
 };
 
+// Every tool-execution probe gets the reasoning budget here, not at the call
+// site, so a caller cannot hand a reasoning-capable model a short-reply budget
+// and turn a truncated stream into a false provider failure.
 const runToolProbe = async ({
   context: { config, provider },
-  maxOutputTokens,
   prompt,
   role,
   signal,
@@ -1140,7 +1139,7 @@ const runToolProbe = async ({
     modelOptions: mergeGenerationOptions({
       caching: NO_CACHING,
       model,
-      maxOutputTokens,
+      maxOutputTokens: TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS,
       serviceTier: "standard",
       temperature: 0,
     }),


### PR DESCRIPTION
## Proposed change

The OpenAI job of the AI provider canary has been red on `tool-call-round-trip`
for the last three runs
([118](https://github.com/stella/stella/actions/runs/33155074546),
[117](https://github.com/stella/stella/actions/runs/33146176655),
[116](https://github.com/stella/stella/actions/runs/33041212457)), each time
with `provider stream error before tool call (incomplete)`. Run 118 also ran the
weekly tier and failed `weekly-tool-nested-optional:gpt-5.5` the same way, while
every non-tool probe on the same models passed.

Both probes sized their output ceiling from the chat role's 512-token budget,
which exists for a short reply. A reasoning-capable chat model spends that
budget on thinking tokens and the stream ends `incomplete` before it can emit a
tool call, so the probe reports a provider contract failure that the provider
did not cause. The two schema-acceptance probes are unaffected: they prompt the
model not to call a tool, so 64 tokens is enough.

Give the tool-execution probes a 4,096-token ceiling: eight times the
short-reply budget, and below the smallest output limit of any offered model
(Amazon Nova v1: 5,120), since the weekly rotation runs the same probes on
every model. The budget is set inside `runToolProbe` rather than passed by
each call site, and the config test binds both bounds.

`bun --filter @stll/api typecheck` and the four `ai-provider-canary*` test files
pass.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no UI surface.
- [ ] ISSUE LINKED | No tracking issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI surface.

