### PR TITLE
fix: preserve Kanban drop axis types

### DIFF
--- a/.changeset/typed-kanban-drop-axes.md
+++ b/.changeset/typed-kanban-drop-axes.md
@@ -1,0 +1,6 @@
+---
+"@stll/ui": patch
+"@stll/workspace-ui": patch
+---
+
+Preserve a board's group identifier union through grouping, saved-view, picker, and atomic drop-intent APIs.

--- a/packages/ui/src/kanban/grouping.ts
+++ b/packages/ui/src/kanban/grouping.ts
@@ -38,9 +38,9 @@ export type KanbanGroup = {
  * built-in grouping is a data declaration rather than a branch this module has
  * to know about.
  */
-export type KanbanBuiltInGroup<TRow> = {
+export type KanbanBuiltInGroup<TRow, TGroupId extends string = string> = {
   /** Reserved group id, distinct from any property id. */
-  id: string;
+  id: TGroupId;
   /** Ordered columns, without the uncategorized bucket. */
   options: readonly KanbanGroupOption[];
   /**
@@ -57,42 +57,51 @@ export type KanbanBuiltInGroup<TRow> = {
  * which keeps the decision — and the property model it depends on — with the
  * caller.
  */
-export type KanbanSchema<TRow, TProperty> = {
-  builtInGroups: readonly KanbanBuiltInGroup<TRow>[];
+export type KanbanSchema<TRow, TProperty, TGroupId extends string = string> = {
+  builtInGroups: readonly KanbanBuiltInGroup<TRow, TGroupId>[];
   properties: readonly TProperty[];
-  getPropertyId: (property: TProperty) => string;
+  getPropertyId: (property: TProperty) => TGroupId;
   getPropertyOptions: (
     property: TProperty,
   ) => readonly KanbanGroupOption[] | null;
 };
 
-export type KanbanGrouping<TRow, TProperty> =
+export type KanbanGrouping<TRow, TProperty, TGroupId extends string = string> =
   | { type: "none" }
   | {
       type: "built-in";
-      propertyId: string;
-      group: KanbanBuiltInGroup<TRow>;
+      propertyId: TGroupId;
+      group: KanbanBuiltInGroup<TRow, TGroupId>;
     }
   | {
       type: "property";
-      propertyId: string;
+      propertyId: TGroupId;
       property: TProperty;
       options: readonly KanbanGroupOption[];
     };
 
-export type ResolveKanbanGroupingParams<TRow, TProperty> = {
+export type ResolveKanbanGroupingParams<
+  TRow,
+  TProperty,
+  TGroupId extends string = string,
+> = {
   /** The group-by id the view carries; empty means no grouping. */
-  groupBy: string;
-  schema: KanbanSchema<TRow, TProperty>;
+  groupBy: TGroupId | "";
+  schema: KanbanSchema<TRow, TProperty, TGroupId>;
 };
 
 /** Resolve a stored group-by id against a schema. */
-export const resolveKanbanGrouping = <TRow, TProperty>({
+export const resolveKanbanGrouping = <
+  TRow,
+  TProperty,
+  TGroupId extends string = string,
+>({
   groupBy,
   schema,
-}: ResolveKanbanGroupingParams<TRow, TProperty>): KanbanGrouping<
+}: ResolveKanbanGroupingParams<TRow, TProperty, TGroupId>): KanbanGrouping<
   TRow,
-  TProperty
+  TProperty,
+  TGroupId
 > => {
   if (groupBy === "") {
     return { type: "none" };
@@ -118,9 +127,13 @@ export const resolveKanbanGrouping = <TRow, TProperty>({
   };
 };
 
-export const getKanbanGroupingPropertyId = <TRow, TProperty>(
-  grouping: KanbanGrouping<TRow, TProperty>,
-): string | null => {
+export const getKanbanGroupingPropertyId = <
+  TRow,
+  TProperty,
+  TGroupId extends string = string,
+>(
+  grouping: KanbanGrouping<TRow, TProperty, TGroupId>,
+): TGroupId | null => {
   switch (grouping.type) {
     case "none":
       return null;
@@ -140,8 +153,12 @@ export const getKanbanGroupingPropertyId = <TRow, TProperty>(
  * be drawn; a property grouping always draws, even when the property has no
  * options yet, because rows still land in the uncategorized bucket.
  */
-export const isKanbanGroupingRenderable = <TRow, TProperty>(
-  grouping: KanbanGrouping<TRow, TProperty>,
+export const isKanbanGroupingRenderable = <
+  TRow,
+  TProperty,
+  TGroupId extends string = string,
+>(
+  grouping: KanbanGrouping<TRow, TProperty, TGroupId>,
 ): boolean => {
   switch (grouping.type) {
     case "none":
@@ -158,9 +175,13 @@ export const isKanbanGroupingRenderable = <TRow, TProperty>(
 };
 
 /** The rows a grouping can place on the board, in their incoming order. */
-export const selectKanbanRows = <TRow, TProperty>(
+export const selectKanbanRows = <
+  TRow,
+  TProperty,
+  TGroupId extends string = string,
+>(
   rows: readonly TRow[],
-  grouping: KanbanGrouping<TRow, TProperty>,
+  grouping: KanbanGrouping<TRow, TProperty, TGroupId>,
 ): TRow[] => {
   switch (grouping.type) {
     case "none":
@@ -179,8 +200,12 @@ export const selectKanbanRows = <TRow, TProperty>(
 };
 
 /** The static column options for a grouping, excluding uncategorized. */
-export const resolveKanbanGroupOptions = <TRow, TProperty>(
-  grouping: KanbanGrouping<TRow, TProperty>,
+export const resolveKanbanGroupOptions = <
+  TRow,
+  TProperty,
+  TGroupId extends string = string,
+>(
+  grouping: KanbanGrouping<TRow, TProperty, TGroupId>,
 ): readonly KanbanGroupOption[] => {
   switch (grouping.type) {
     case "none":

--- a/packages/ui/src/kanban/matrix.test.ts
+++ b/packages/ui/src/kanban/matrix.test.ts
@@ -1,17 +1,19 @@
 import { describe, expect, test } from "bun:test";
 
-import type { KanbanSchema } from "./grouping";
+import type { KanbanGrouping, KanbanSchema } from "./grouping";
 import { resolveKanbanGrouping } from "./grouping";
 import {
   buildKanbanBoardMatrix,
   createKanbanDropIntent,
   orderKanbanCellsByColumns,
 } from "./matrix";
+import type { ResolveKanbanGroupValueParams } from "./matrix";
 
 type Row = { id: string; owner: string | null; status: string | null };
-type Property = { id: string };
+type Property = { id: "owner" };
+type GroupId = "_empty" | "_status" | "owner";
 
-const schema: KanbanSchema<Row, Property> = {
+const schema: KanbanSchema<Row, Property, GroupId> = {
   builtInGroups: [
     {
       id: "_status",
@@ -22,13 +24,10 @@ const schema: KanbanSchema<Row, Property> = {
     },
   ],
   getPropertyId: (property) => property.id,
-  getPropertyOptions: (property) =>
-    property.id === "owner"
-      ? [
-          { label: "Ada", value: "ada" },
-          { label: "Lin", value: "lin" },
-        ]
-      : null,
+  getPropertyOptions: () => [
+    { label: "Ada", value: "ada" },
+    { label: "Lin", value: "lin" },
+  ],
   properties: [{ id: "owner" }],
 };
 
@@ -38,9 +37,12 @@ const nonRenderableBuiltIn = {
   type: "built-in" as const,
   propertyId: "_empty",
   group: { id: "_empty", options: [] },
-};
+} as const satisfies KanbanGrouping<Row, Property, GroupId>;
 
-const valueFor = ({ grouping, row }: { grouping: typeof group; row: Row }) => {
+const valueFor = ({
+  grouping,
+  row,
+}: ResolveKanbanGroupValueParams<Row, Property, GroupId>) => {
   switch (grouping.type) {
     case "built-in":
       return grouping.propertyId === "_status" ? row.status : null;
@@ -169,15 +171,18 @@ describe("kanban board matrix", () => {
     if (source === undefined || target === undefined) {
       throw new Error("fixture matrix must contain both cells");
     }
-    expect(
-      createKanbanDropIntent({
-        cardId: "one",
-        group,
-        source: source.coordinate,
-        subgroup,
-        target: target.coordinate,
-      }),
-    ).toEqual({
+    const intent = createKanbanDropIntent({
+      cardId: "one",
+      group,
+      source: source.coordinate,
+      subgroup,
+      target: target.coordinate,
+    });
+    const firstChange = intent?.changes.at(0);
+    const axis: GroupId | undefined = firstChange?.groupBy;
+
+    expect(axis).toBe("_status");
+    expect(intent).toEqual({
       cardId: "one",
       changes: [
         { groupBy: "_status", value: "done" },

--- a/packages/ui/src/kanban/matrix.ts
+++ b/packages/ui/src/kanban/matrix.ts
@@ -45,20 +45,28 @@ export type KanbanBoardMatrix<TRow> = {
   rows: TRow[];
 };
 
-export type ResolveKanbanGroupValueParams<TRow, TProperty> = {
-  grouping: KanbanGrouping<TRow, TProperty>;
+export type ResolveKanbanGroupValueParams<
+  TRow,
+  TProperty,
+  TGroupId extends string = string,
+> = {
+  grouping: KanbanGrouping<TRow, TProperty, TGroupId>;
   row: TRow;
 };
 
-export type BuildKanbanBoardMatrixParams<TRow, TProperty> = {
+export type BuildKanbanBoardMatrixParams<
+  TRow,
+  TProperty,
+  TGroupId extends string = string,
+> = {
   /** The vertical board columns. This must be a renderable grouping. */
-  group: KanbanGrouping<TRow, TProperty>;
+  group: KanbanGrouping<TRow, TProperty, TGroupId>;
   /** Optional horizontal swimlanes. `none` makes this a one-lane board. */
-  subgroup: KanbanGrouping<TRow, TProperty>;
+  subgroup: KanbanGrouping<TRow, TProperty, TGroupId>;
   rows: readonly TRow[];
   uncategorizedLabel: string;
   resolveGroupValue: (
-    params: ResolveKanbanGroupValueParams<TRow, TProperty>,
+    params: ResolveKanbanGroupValueParams<TRow, TProperty, TGroupId>,
   ) => string | null;
 };
 
@@ -104,8 +112,8 @@ const normalizeGroupValue = (
   value: string | null,
 ): string | null => (groupContainsValue(groups, value) ? value : null);
 
-const getRenderableGroups = <TRow, TProperty>(
-  grouping: KanbanGrouping<TRow, TProperty>,
+const getRenderableGroups = <TRow, TProperty, TGroupId extends string>(
+  grouping: KanbanGrouping<TRow, TProperty, TGroupId>,
   uncategorizedLabel: string,
 ): KanbanGroup[] => {
   if (!isKanbanGroupingRenderable(grouping)) {
@@ -117,8 +125,8 @@ const getRenderableGroups = <TRow, TProperty>(
   );
 };
 
-const makeLanes = <TRow, TProperty>(
-  subgroup: KanbanGrouping<TRow, TProperty>,
+const makeLanes = <TRow, TProperty, TGroupId extends string>(
+  subgroup: KanbanGrouping<TRow, TProperty, TGroupId>,
   uncategorizedLabel: string,
 ): KanbanBoardLane[] => {
   if (subgroup.type === "none") {
@@ -136,13 +144,21 @@ const makeLanes = <TRow, TProperty>(
  * A subgroup never filters the primary board scope. A row outside a subgroup's
  * declared values goes to its explicit No value lane, rather than disappearing.
  */
-export const buildKanbanBoardMatrix = <TRow, TProperty>({
+export const buildKanbanBoardMatrix = <
+  TRow,
+  TProperty,
+  TGroupId extends string = string,
+>({
   group,
   subgroup,
   rows,
   uncategorizedLabel,
   resolveGroupValue,
-}: BuildKanbanBoardMatrixParams<TRow, TProperty>): KanbanBoardMatrix<TRow> => {
+}: BuildKanbanBoardMatrixParams<
+  TRow,
+  TProperty,
+  TGroupId
+>): KanbanBoardMatrix<TRow> => {
   if (!isKanbanGroupingRenderable(group)) {
     return { cells: [], columns: [], lanes: [], rows: [] };
   }
@@ -212,23 +228,28 @@ export const buildKanbanBoardMatrix = <TRow, TProperty>({
   return { cells, columns, lanes, rows: scopedRows };
 };
 
-export type KanbanDropAxisChange = {
-  groupBy: string;
+export type KanbanDropAxisChange<TGroupId extends string = string> = {
+  groupBy: TGroupId;
   value: string | null;
 };
 
 /** A complete, atomic move request for a domain mutation adapter. */
-export type KanbanDropIntent<TCardId> = {
+export type KanbanDropIntent<TCardId, TGroupId extends string = string> = {
   cardId: TCardId;
-  changes: readonly KanbanDropAxisChange[];
+  changes: readonly KanbanDropAxisChange<TGroupId>[];
   type: "move";
 };
 
-export type CreateKanbanDropIntentParams<TRow, TProperty, TCardId> = {
+export type CreateKanbanDropIntentParams<
+  TRow,
+  TProperty,
+  TCardId,
+  TGroupId extends string = string,
+> = {
   cardId: TCardId;
-  group: KanbanGrouping<TRow, TProperty>;
+  group: KanbanGrouping<TRow, TProperty, TGroupId>;
   source: KanbanBoardCoordinate;
-  subgroup: KanbanGrouping<TRow, TProperty>;
+  subgroup: KanbanGrouping<TRow, TProperty, TGroupId>;
   target: KanbanBoardCoordinate;
 };
 
@@ -237,7 +258,12 @@ export type CreateKanbanDropIntentParams<TRow, TProperty, TCardId> = {
  * Diagonal drops carry both changes together; an adapter must commit this
  * intent atomically or reject it as a whole.
  */
-export const createKanbanDropIntent = <TRow, TProperty, TCardId>({
+export const createKanbanDropIntent = <
+  TRow,
+  TProperty,
+  TCardId,
+  TGroupId extends string = string,
+>({
   cardId,
   group,
   source,
@@ -246,15 +272,16 @@ export const createKanbanDropIntent = <TRow, TProperty, TCardId>({
 }: CreateKanbanDropIntentParams<
   TRow,
   TProperty,
-  TCardId
->): KanbanDropIntent<TCardId> | null => {
+  TCardId,
+  TGroupId
+>): KanbanDropIntent<TCardId, TGroupId> | null => {
   const groupBy = getKanbanGroupingPropertyId(group);
   const subgroupBy = getKanbanGroupingPropertyId(subgroup);
   if (groupBy === null || (subgroupBy !== null && subgroupBy === groupBy)) {
     return null;
   }
 
-  const changes: KanbanDropAxisChange[] = [];
+  const changes: KanbanDropAxisChange<TGroupId>[] = [];
   if (source.column.value !== target.column.value) {
     changes.push({ groupBy, value: target.column.value });
   }

--- a/packages/workspace-ui/src/kanban-grouping-picker.tsx
+++ b/packages/workspace-ui/src/kanban-grouping-picker.tsx
@@ -14,13 +14,16 @@ import {
 
 const NO_GROUPING_VALUE = "";
 
+const toSelectTransportValue = (value: string) => value;
+
 /**
  * Accessible picker shared by the board's Group and Sub-group controls. The
  * caller labels built-ins because only its domain owns their human names.
  */
 export const WorkspaceKanbanGroupingPicker = <
   TRow,
-  TProperty extends WorkspaceKanbanProperty,
+  TProperty extends WorkspaceKanbanProperty<TGroupId>,
+  TGroupId extends string = string,
 >({
   allowNone,
   excludedGroupBy,
@@ -29,7 +32,7 @@ export const WorkspaceKanbanGroupingPicker = <
   onValueChange,
   schema,
   value,
-}: WorkspaceKanbanGroupingPickerProps<TRow, TProperty>) => {
+}: WorkspaceKanbanGroupingPickerProps<TRow, TProperty, TGroupId>) => {
   const choices = getWorkspaceKanbanGroupingChoices({
     getBuiltInGroupLabel,
     schema,
@@ -37,6 +40,7 @@ export const WorkspaceKanbanGroupingPicker = <
   const selected = choices.find((choice) => choice.id === value);
   const display =
     selected?.label ?? (allowNone ? labels.none : labels.placeholder);
+  const selectedValue = toSelectTransportValue(value);
 
   return (
     <Select
@@ -44,9 +48,16 @@ export const WorkspaceKanbanGroupingPicker = <
         if (nextValue === null) {
           return;
         }
-        onValueChange(nextValue);
+        if (nextValue === NO_GROUPING_VALUE) {
+          onValueChange(NO_GROUPING_VALUE);
+          return;
+        }
+        const nextChoice = choices.find(({ id }) => id === nextValue);
+        if (nextChoice !== undefined) {
+          onValueChange(nextChoice.id);
+        }
       }}
-      value={value}
+      value={selectedValue}
     >
       <SelectTrigger aria-label={labels.control} size="sm">
         <SelectValue placeholder={labels.placeholder}>{display}</SelectValue>
@@ -56,7 +67,7 @@ export const WorkspaceKanbanGroupingPicker = <
           <SelectItem value={NO_GROUPING_VALUE}>{labels.none}</SelectItem>
         ) : null}
         {choices.map((choice) => (
-          <SelectItem key={choice.id} value={choice.id}>
+          <SelectItem key={choice.id} value={toSelectTransportValue(choice.id)}>
             {choice.label}
           </SelectItem>
         ))}

--- a/packages/workspace-ui/src/kanban-view.test.ts
+++ b/packages/workspace-ui/src/kanban-view.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { buildKanbanBoardMatrix } from "@stll/ui/kanban";
+import {
+  buildKanbanBoardMatrix,
+  getKanbanGroupingPropertyId,
+} from "@stll/ui/kanban";
 
 import {
   createWorkspaceKanbanSchema,
@@ -14,8 +17,9 @@ import type {
 } from "./kanban-view";
 
 type Row = { id: string; owner: string | null; status: string | null };
+type GroupId = "_status" | "owner";
 
-const properties: WorkspaceKanbanProperty[] = [
+const properties: WorkspaceKanbanProperty<GroupId>[] = [
   {
     content: {
       options: [
@@ -43,7 +47,7 @@ const schema = createWorkspaceKanbanSchema({
   properties,
 });
 
-const state: KanbanSavedViewState = {
+const state: KanbanSavedViewState<GroupId> = {
   group: {
     emptyGroups: "hide",
     groupBy: "_status",
@@ -75,6 +79,7 @@ describe("workspace kanban view adapter", () => {
 
   test("keeps group and subgroup independently persisted and presents ordered, collapsed lanes", () => {
     const view = resolveWorkspaceKanbanView({ schema, state });
+    const groupBy: GroupId | null = getKanbanGroupingPropertyId(view.group);
     const matrix = buildKanbanBoardMatrix({
       group: view.group,
       resolveGroupValue: ({
@@ -103,6 +108,7 @@ describe("workspace kanban view adapter", () => {
     });
     const presentation = presentKanbanBoard({ matrix, state });
 
+    expect(groupBy).toBe("_status");
     expect(presentation.columns.map((column) => column.value)).toEqual([
       "open",
     ]);

--- a/packages/workspace-ui/src/kanban-view.ts
+++ b/packages/workspace-ui/src/kanban-view.ts
@@ -28,39 +28,47 @@ export type KanbanSavedGroupReference =
   | { type: "option"; value: string }
   | { type: "uncategorized" };
 
-export type KanbanSavedAxisState = {
+export type KanbanSavedAxisState<TGroupId extends string = string> = {
   emptyGroups: KanbanEmptyGroupVisibility;
-  groupBy: string;
+  groupBy: TGroupId;
   hiddenGroups: readonly KanbanSavedGroupReference[];
   orderedGroups: readonly KanbanSavedGroupReference[];
 };
 
-export type KanbanSavedSubgroupState = KanbanSavedAxisState & {
-  collapsedGroups: readonly KanbanSavedGroupReference[];
-};
+export type KanbanSavedSubgroupState<TGroupId extends string = string> =
+  KanbanSavedAxisState<TGroupId> & {
+    collapsedGroups: readonly KanbanSavedGroupReference[];
+  };
 
 /**
  * View state is deliberately separate from the board's domain data. It may
  * change visibility, order, and collapse, but cannot change a card's cell.
  */
-export type KanbanSavedViewState = {
-  group: KanbanSavedAxisState;
-  subgroup: KanbanSavedSubgroupState | null;
+export type KanbanSavedViewState<TGroupId extends string = string> = {
+  group: KanbanSavedAxisState<TGroupId>;
+  subgroup: KanbanSavedSubgroupState<TGroupId> | null;
   version: 1;
 };
 
-export type WorkspaceKanbanProperty = GenericProperty & {
-  id: string;
-  name: string;
-};
+export type WorkspaceKanbanProperty<TGroupId extends string = string> =
+  GenericProperty & {
+    id: TGroupId;
+    name: string;
+  };
 
 export type CreateWorkspaceKanbanSchemaParams<
   TRow,
+  TBuiltInGroupId extends string,
   TProperty extends WorkspaceKanbanProperty,
 > = {
-  builtInGroups: readonly KanbanBuiltInGroup<TRow>[];
+  builtInGroups: readonly KanbanBuiltInGroup<TRow, TBuiltInGroupId>[];
   properties: readonly TProperty[];
 };
+
+type WorkspaceKanbanSchemaGroupId<
+  TBuiltInGroupId extends string,
+  TProperty extends WorkspaceKanbanProperty,
+> = TBuiltInGroupId | TProperty["id"];
 
 /**
  * Turns the authoritative workspace property model into board declarations.
@@ -68,13 +76,19 @@ export type CreateWorkspaceKanbanSchemaParams<
  */
 export const createWorkspaceKanbanSchema = <
   TRow,
+  TBuiltInGroupId extends string,
   TProperty extends WorkspaceKanbanProperty,
 >({
   builtInGroups,
   properties,
-}: CreateWorkspaceKanbanSchemaParams<TRow, TProperty>): KanbanSchema<
+}: CreateWorkspaceKanbanSchemaParams<
   TRow,
+  TBuiltInGroupId,
   TProperty
+>): KanbanSchema<
+  TRow,
+  TProperty,
+  WorkspaceKanbanSchemaGroupId<TBuiltInGroupId, TProperty>
 > => ({
   builtInGroups,
   getPropertyId: (property) => property.id,
@@ -91,28 +105,30 @@ export const createWorkspaceKanbanSchema = <
   properties,
 });
 
-export type WorkspaceKanbanGroupingChoice = {
-  id: string;
+export type WorkspaceKanbanGroupingChoice<TGroupId extends string = string> = {
+  id: TGroupId;
   label: string;
   type: "built-in" | "property";
 };
 
-export type WorkspaceKanbanBuiltInGroupLabel<TRow> = (
-  group: KanbanBuiltInGroup<TRow>,
-) => string;
+export type WorkspaceKanbanBuiltInGroupLabel<
+  TRow,
+  TGroupId extends string = string,
+> = (group: KanbanBuiltInGroup<TRow, TGroupId>) => string;
 
 /** Property-aware data for a Group or Sub-group picker. */
 export const getWorkspaceKanbanGroupingChoices = <
   TRow,
-  TProperty extends WorkspaceKanbanProperty,
+  TProperty extends WorkspaceKanbanProperty<TGroupId>,
+  TGroupId extends string = string,
 >({
   getBuiltInGroupLabel,
   schema,
 }: {
-  getBuiltInGroupLabel: WorkspaceKanbanBuiltInGroupLabel<TRow>;
-  schema: KanbanSchema<TRow, TProperty>;
-}): WorkspaceKanbanGroupingChoice[] => {
-  const choices: WorkspaceKanbanGroupingChoice[] = [];
+  getBuiltInGroupLabel: WorkspaceKanbanBuiltInGroupLabel<TRow, TGroupId>;
+  schema: KanbanSchema<TRow, TProperty, TGroupId>;
+}): WorkspaceKanbanGroupingChoice<TGroupId>[] => {
+  const choices: WorkspaceKanbanGroupingChoice<TGroupId>[] = [];
   for (const group of schema.builtInGroups) {
     choices.push({
       id: group.id,
@@ -137,38 +153,52 @@ export type WorkspaceKanbanGroupingPickerLabels = {
 
 export type WorkspaceKanbanGroupingPickerProps<
   TRow,
-  TProperty extends WorkspaceKanbanProperty,
+  TProperty extends WorkspaceKanbanProperty<TGroupId>,
+  TGroupId extends string = string,
 > = {
   allowNone: boolean;
-  excludedGroupBy?: string | undefined;
-  getBuiltInGroupLabel: WorkspaceKanbanBuiltInGroupLabel<TRow>;
+  excludedGroupBy?: TGroupId | undefined;
+  getBuiltInGroupLabel: WorkspaceKanbanBuiltInGroupLabel<TRow, TGroupId>;
   labels: WorkspaceKanbanGroupingPickerLabels;
-  onValueChange: (groupBy: string) => void;
-  schema: KanbanSchema<TRow, TProperty>;
-  value: string;
+  onValueChange: (groupBy: TGroupId | "") => void;
+  schema: KanbanSchema<TRow, TProperty, TGroupId>;
+  value: TGroupId | "";
 };
 
-export type ResolveWorkspaceKanbanViewParams<TRow, TProperty> = {
-  schema: KanbanSchema<TRow, TProperty>;
-  state: KanbanSavedViewState;
+export type ResolveWorkspaceKanbanViewParams<
+  TRow,
+  TProperty,
+  TGroupId extends string = string,
+> = {
+  schema: KanbanSchema<TRow, TProperty, TGroupId>;
+  state: KanbanSavedViewState<TGroupId>;
 };
 
-export type ResolvedWorkspaceKanbanView<TRow, TProperty> = {
-  group: KanbanGrouping<TRow, TProperty>;
-  subgroup: KanbanGrouping<TRow, TProperty>;
+export type ResolvedWorkspaceKanbanView<
+  TRow,
+  TProperty,
+  TGroupId extends string = string,
+> = {
+  group: KanbanGrouping<TRow, TProperty, TGroupId>;
+  subgroup: KanbanGrouping<TRow, TProperty, TGroupId>;
 };
 
 /**
  * A property cannot control both axes. Rejecting that configuration here means
  * a later diagonal drag never has two contradictory assignments for one field.
  */
-export const resolveWorkspaceKanbanView = <TRow, TProperty>({
+export const resolveWorkspaceKanbanView = <
+  TRow,
+  TProperty,
+  TGroupId extends string = string,
+>({
   schema,
   state,
 }: ResolveWorkspaceKanbanViewParams<
   TRow,
-  TProperty
->): ResolvedWorkspaceKanbanView<TRow, TProperty> => {
+  TProperty,
+  TGroupId
+>): ResolvedWorkspaceKanbanView<TRow, TProperty, TGroupId> => {
   const group = resolveKanbanGrouping({ groupBy: state.group.groupBy, schema });
   const subgroup =
     state.subgroup === null || state.subgroup.groupBy === state.group.groupBy


### PR DESCRIPTION
## Summary

- preserve the closed group identifier union through Kanban schemas and resolved grouping
- carry the same union through saved workspace presentation and grouping picker callbacks
- return typed axis identifiers from atomic drop intents instead of widening them to `string`
- reject picker values that are not declared choices before crossing the typed callback boundary

## Validation

- `git diff --check`
- `bun test packages/ui/src/kanban/matrix.test.ts` (5 passing)
- workspace adapter test could not collect locally because the reused install does not contain `@dnd-kit/core`; CI will install the declared workspace graph

## Security

No new trust boundary, transport, persistence, authentication, or secret handling. The picker now narrows runtime select values against declared choices before calling the typed consumer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Kanban grouping identifiers are now preserved consistently across boards, saved views, grouping pickers and drag-and-drop actions.
  - Enhanced type support helps prevent mismatched grouping values when configuring or integrating Kanban views.
  - Grouping pickers now ignore unrecognised values while continuing to support clearing the grouping selection.
- **Bug Fixes**
  - Improved reliability when resolving active grouping properties and saved Kanban view state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->