### PR TITLE
fix(api): name the reason a canary stream ends incomplete

### DIFF
--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -175,6 +175,57 @@ describe("AI provider canary error summaries", () => {
     ).toBe("provider stream error before tool call");
   });
 
+  // The OpenAI adapter reports a truncated or blocked response as this event
+  // shape, putting `incomplete_details.reason` in both message positions.
+  test("names the reason an incomplete stream carries", () => {
+    const signal = new AbortController().signal;
+
+    expect(
+      errorSummary(
+        new CanaryProviderRunError(
+          {
+            code: "incomplete",
+            message: "max_output_tokens",
+            error: { code: "incomplete", message: "max_output_tokens" },
+          },
+          "before-tool-call",
+        ),
+        signal,
+      ),
+    ).toBe(
+      "provider stream error before tool call (incomplete: max_output_tokens)",
+    );
+
+    expect(
+      errorSummary(
+        new CanaryProviderRunError(
+          { error: { code: "incomplete", message: "content_filter" } },
+          "before-tool-call",
+        ),
+        signal,
+      ),
+    ).toBe(
+      "provider stream error before tool call (incomplete: content_filter)",
+    );
+  });
+
+  test("keeps an unrecognized incomplete message out of the summary", () => {
+    const signal = new AbortController().signal;
+
+    expect(
+      errorSummary(
+        new CanaryProviderRunError(
+          {
+            code: "incomplete",
+            message: "Response ended incomplete: client matter name",
+          },
+          "before-tool-call",
+        ),
+        signal,
+      ),
+    ).toBe("provider stream error before tool call (incomplete)");
+  });
+
   test("prefers a numeric provider status without exposing the event", () => {
     const signal = new AbortController().signal;
     const error = new CanaryProviderRunError(

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -175,6 +175,17 @@ const RETRYABLE_PROVIDER_CODES = new Set([
   "timeout_error",
 ]);
 
+// A truncated or blocked response reaches the canary as a RUN_ERROR whose code
+// is `incomplete` and whose message is the provider's own reason (the OpenAI
+// adapter relays `incomplete_details.reason` verbatim). The code alone cannot
+// separate an exhausted output budget from a filtered response, which are
+// opposite findings: one is a probe budget to raise, the other is not. Keep the
+// reason, allowlisted like every other value this canary prints.
+const SAFE_INCOMPLETE_REASONS = new Set([
+  "content_filter",
+  "max_output_tokens",
+]);
+
 const RETRYABLE_TRANSPORT_CODES = new Set([
   "EAI_AGAIN",
   "ECONNABORTED",
@@ -282,6 +293,29 @@ const rawProviderCode = (error: unknown, depth = 0): string | null => {
 
 const safeProviderCode = (code: string | null): string | null =>
   code !== null && SAFE_PROVIDER_CODES.has(code) ? code : null;
+
+// Matched whole, never substring: an unrecognized message is provider prose and
+// stays out of the log.
+const safeIncompleteReason = (error: unknown, depth = 0): string | null => {
+  if (!isRecord(error)) {
+    return null;
+  }
+
+  const message = error["message"];
+  if (typeof message === "string" && SAFE_INCOMPLETE_REASONS.has(message)) {
+    return message;
+  }
+
+  if (depth < 3) {
+    for (const key of PROVIDER_ERROR_NESTED_KEYS) {
+      const nestedReason = safeIncompleteReason(error[key], depth + 1);
+      if (nestedReason !== null) {
+        return nestedReason;
+      }
+    }
+  }
+  return null;
+};
 
 const providerStatus = (error: unknown, depth = 0): number | null => {
   if (!isRecord(error)) {
@@ -465,6 +499,7 @@ const canaryEventFailure = (event: unknown): CanaryFailure => {
 export class CanaryProviderRunError extends TypeError {
   readonly code: string | null;
   readonly failure: CanaryFailure;
+  readonly incompleteReason: string | null;
   readonly retryCode: string | null;
   readonly retryable: boolean | null;
   readonly stage: CanaryRunStage;
@@ -478,6 +513,7 @@ export class CanaryProviderRunError extends TypeError {
     this.retryable = explicitRetryability(event);
     this.code = safeProviderCode(this.retryCode);
     this.failure = canaryEventFailure(event);
+    this.incompleteReason = safeIncompleteReason(event);
     this.stage = stage;
     this.status = providerStatus(event);
     this.terminalCode = terminalProviderCode(event);
@@ -1297,9 +1333,14 @@ export const errorSummary = (error: unknown, signal: AbortSignal): string => {
       return `provider HTTP ${error.status}`;
     }
     const stage = error.stage.replaceAll("-", " ");
-    return error.code === null
-      ? `provider stream error ${stage}`
-      : `provider stream error ${stage} (${error.code})`;
+    if (error.code === null) {
+      return `provider stream error ${stage}`;
+    }
+    const detail =
+      error.incompleteReason === null
+        ? error.code
+        : `${error.code}: ${error.incompleteReason}`;
+    return `provider stream error ${stage} (${detail})`;
   }
 
   if (


### PR DESCRIPTION
## Proposed change

The OpenAI job of the AI provider canary fails `tool-call-round-trip` and
`weekly-tool-nested-optional` as
`provider stream error before tool call (incomplete)`
([119](https://github.com/stella/stella/actions/runs/33160847974),
[118](https://github.com/stella/stella/actions/runs/33155074546)). The summary
stops at the code, and that code stands for two opposite findings: an exhausted
output ceiling, which is a probe budget to raise, and a filtered response, which
is not. Nothing in the log separates them, so #2560 had to pick one; run 119 ran
on that commit and fails identically, and time-to-failure did not move with the
eightfold ceiling (~1.1s per attempt at 512 tokens, ~0.75s at 4,096), which an
exhausted budget would not do.

The adapter already carries the answer. On `response.incomplete` the OpenAI
Responses adapter emits a RUN_ERROR whose code is `incomplete` and whose message
is `incomplete_details.reason` verbatim (`max_output_tokens` or
`content_filter`); `errorSummary` reads the code and drops the message.

Keep the reason and print it after the code:
`provider stream error before tool call (incomplete: max_output_tokens)`. It is
matched whole against an allowlist, like every other value this canary logs, so
an unrecognized message is still treated as provider prose and withheld. No
probe budget, timeout, or retry count changes here: this only makes the next run
say which failure it is.

`bun --filter @stll/api typecheck` and the four `ai-provider-canary*` test files
pass.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | Not applicable: no UI surface.
- [ ] ISSUE LINKED | No tracking issue.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI surface.

