### PR TITLE
fix(api): express impossible canary strings without an unsatisfiable regex

### DIFF
--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -49,13 +49,14 @@ export const NULL_WIDENING_CANARY_PROVIDERS = new Set(
   ),
 );
 
-// JSON Schema patterns have no regex flag channel. OpenAI strict Structured
-// Outputs supports `pattern`; `a^` cannot match any string. Used to make the
-// "omit or send this impossible value" duality deterministic: no real string
-// can validly satisfy the optional field, only omission (or, for
-// null-widening providers, the synthetic null their strict mode forces).
-// eslint-disable-next-line require-unicode-regexp
-export const NEVER_MATCH_PATTERN = /a^/;
+// The optional string fields in canary tool schemas must accept no real
+// string, so that "omit or send the synthetic null" is the only valid choice
+// for the model. An unsatisfiable regex (`a^`) expressed that until OpenAI's
+// strict-mode grammar compiler started dead-ending on it: the request ends
+// `incomplete` with zero output tokens before any tool call. `maxLength: 0`
+// says the same thing in a form every constrained decoder handles; a
+// hallucinated empty string still trips the probes' unexpected-argument check.
+export const IMPOSSIBLE_STRING_MAX_LENGTH = 0;
 
 export const CANARY_TIERS = ["daily", "weekly"] as const;
 export type CanaryTier = (typeof CANARY_TIERS)[number];
@@ -131,13 +132,10 @@ export const modelRoleMaxOutputTokens = (role: ModelRole) =>
 export const structuredOutputModelRoleMaxOutputTokens = (role: ModelRole) =>
   role === "reasoning" ? 20_000 : modelRoleMaxOutputTokens(role);
 
-// Tool-execution probes pay for a model's thinking tokens out of the same
-// output budget as the tool call. The chat role's ceiling is sized for a short
-// reply, so reasoning-capable chat models exhaust it and end the stream
-// `incomplete` before emitting a call. Give these probes reasoning headroom,
-// but stay under the smallest output ceiling of any offered model (Amazon Nova
-// v1: 5,120), because the weekly rotation runs the same probe on every model
-// and providers reject a ceiling above the model's limit before the call.
+// Tool-execution probes may spend thinking tokens before the call, so they
+// get more headroom than a short-reply role, while staying under the smallest
+// output ceiling of any offered model (Amazon Nova v1: 5,120) because the
+// weekly rotation runs the same probe on every model.
 export const TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS = 4096;
 
 export const isCanaryProvider = (value: string): value is CanaryProvider =>

--- a/apps/api/scripts/ai-provider-canary-weekly.ts
+++ b/apps/api/scripts/ai-provider-canary-weekly.ts
@@ -8,7 +8,7 @@ import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-sc
 // pattern the daily round-trip probe uses to make the omission-vs-null
 // duality deterministic (see ai-provider-canary.ts, #1194/#1196).
 import {
-  NEVER_MATCH_PATTERN,
+  IMPOSSIBLE_STRING_MAX_LENGTH,
   NULL_WIDENING_CANARY_PROVIDERS,
 } from "./ai-provider-canary-config";
 import type {
@@ -115,7 +115,7 @@ export const createWeeklyToolShapeDefinition = (
       const nestedOptionalInputSchema = v.strictObject({
         details: v.strictObject({
           optionalNote: v.optional(
-            v.pipe(v.string(), v.regex(NEVER_MATCH_PATTERN)),
+            v.pipe(v.string(), v.maxLength(IMPOSSIBLE_STRING_MAX_LENGTH)),
           ),
           value: v.literal("stella-weekly"),
         }),
@@ -172,7 +172,7 @@ export const createWeeklyToolShapeDefinition = (
           v.strictObject({
             id: v.literal("item-1"),
             optionalLabel: v.optional(
-              v.pipe(v.string(), v.regex(NEVER_MATCH_PATTERN)),
+              v.pipe(v.string(), v.maxLength(IMPOSSIBLE_STRING_MAX_LENGTH)),
             ),
           }),
         ),

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -107,7 +107,7 @@ describe("AI provider canary tool contract", () => {
       ].jsonSchema.input({ target: "draft-07" }),
     ).toMatchObject({
       properties: {
-        optionalNote: { pattern: "a^", type: "string" },
+        optionalNote: { maxLength: 0, type: "string" },
       },
       required: ["count", "value"],
     });

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -31,7 +31,7 @@ import {
   CANARY_PROVIDERS,
   modelRoleMaxOutputTokens,
   structuredOutputModelRoleMaxOutputTokens,
-  NEVER_MATCH_PATTERN,
+  IMPOSSIBLE_STRING_MAX_LENGTH,
   NULL_WIDENING_CANARY_PROVIDERS,
   TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS,
   weeklyCanaryRotation,
@@ -691,7 +691,9 @@ export const toolRoundTripInputSchema = v.strictObject({
   // optional string with null. The provider is asked for that synthetic null;
   // the adapter must remove it before the server validates and executes the
   // tool because null is deliberately invalid in this application schema.
-  optionalNote: v.optional(v.pipe(v.string(), v.regex(NEVER_MATCH_PATTERN))),
+  optionalNote: v.optional(
+    v.pipe(v.string(), v.maxLength(IMPOSSIBLE_STRING_MAX_LENGTH)),
+  ),
   value: v.literal(TOOL_ROUND_TRIP_VALUE),
 });
 


### PR DESCRIPTION
The OpenAI job of the AI provider canary has failed on `tool-call-round-trip` (and the weekly tool probe) since 2026-08-23 with `provider stream error before tool call (incomplete)`; with #2564 the line reads `(incomplete: max_output_tokens)`.

Reproduced against the API directly: the probe's optional string fields forbid any real string with the regex `a^`. OpenAI's strict-mode grammar compiler now dead-ends on that pattern (in both `type: ["string", "null"]` and `anyOf` form) and answers `incomplete` with `incomplete_details.reason = max_output_tokens`, zero output tokens and no function call. The same request with `maxLength: 0` completes with the expected tool call, so the output budget raised in #2560 was never the limiting factor.

- Replace `NEVER_MATCH_PATTERN` with `IMPOSSIBLE_STRING_MAX_LENGTH = 0` in the three canary schemas; a hallucinated empty string still trips the probes' unexpected-argument checks.
- Reword the tool-probe budget comment to match what the budget is for.

Verified with a funded key: all 22 OpenAI probes pass on the weekly tier, twice; the four `ai-provider-canary*` test files pass.

https://claude.ai/code/session_01NMnG9ntKwemcJMgkMB7k5v