### PR TITLE
test(api): track the query-client infinite method rename in the guardrail test

### DIFF
--- a/apps/api/src/tests/security/oxlint-guardrails.test.ts
+++ b/apps/api/src/tests/security/oxlint-guardrails.test.ts
@@ -292,7 +292,7 @@ describe("custom oxlint guardrails", () => {
     expect(pluginSource).toContain("useQueryClient().getQueryData");
     expect(pluginSource).toContain("abandoned pending renders");
     expect(reactQuerySource).toContain("ensureRouteInfiniteQueryData");
-    expect(reactQuerySource).toContain("fetchInfiniteQuery");
+    expect(reactQuerySource).toContain("queryClient.infiniteQuery(");
 
     expect(configSource).toContain(
       "./.oxlint-plugins/no-raw-route-query-client.ts",

--- a/apps/api/src/tests/security/oxlint-guardrails.test.ts
+++ b/apps/api/src/tests/security/oxlint-guardrails.test.ts
@@ -292,7 +292,24 @@ describe("custom oxlint guardrails", () => {
     expect(pluginSource).toContain("useQueryClient().getQueryData");
     expect(pluginSource).toContain("abandoned pending renders");
     expect(reactQuerySource).toContain("ensureRouteInfiniteQueryData");
-    expect(reactQuerySource).toContain("queryClient.infiniteQuery(");
+    // Scoped to the helper body: the non-critical prefetch also calls
+    // `infiniteQuery`, so a file-wide match would not notice the route-fresh
+    // helper drifting off it.
+    const routeInfiniteStart = reactQuerySource.indexOf(
+      "export const ensureRouteInfiniteQueryData",
+    );
+    expect(routeInfiniteStart).toBeGreaterThan(-1);
+    const routeInfiniteEnd = reactQuerySource.indexOf(
+      "\nexport const ",
+      routeInfiniteStart + 1,
+    );
+    const routeInfiniteHelper = reactQuerySource.slice(
+      routeInfiniteStart,
+      routeInfiniteEnd === -1 ? undefined : routeInfiniteEnd,
+    );
+    expect(routeInfiniteHelper).toContain(
+      "queryClient.infiniteQuery(routeQueryOptions(options))",
+    );
 
     expect(configSource).toContain(
       "./.oxlint-plugins/no-raw-route-query-client.ts",


### PR DESCRIPTION
#2553 moved `ensureRouteInfiniteQueryData` from `queryClient.fetchInfiniteQuery` to `queryClient.infiniteQuery`; the oxlint guardrail test still asserted the old literal, so every CI run on main since then fails `route loader query lint points at route-fresh helpers`. Assert the new method call instead.

https://claude.ai/code/session_01NMnG9ntKwemcJMgkMB7k5v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved security guardrail coverage for route-based infinite queries, ensuring validation checks the relevant helper logic precisely.
  * This strengthens protection against accidental query-handling regressions.
  * No user-facing functionality changes are included in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->