### PR TITLE
fix(api): clamp canary role budgets to each model's output limit

### DIFF
--- a/apps/api/scripts/ai-provider-canary-config.test.ts
+++ b/apps/api/scripts/ai-provider-canary-config.test.ts
@@ -18,18 +18,28 @@ import {
 } from "./ai-provider-canary-config";
 
 describe("AI provider canary role budgets", () => {
+  const model = "model";
+
   test("keeps structured probes within the provider timeout envelope", () => {
     for (const role of MODEL_ROLES) {
       expect(
-        structuredOutputModelRoleMaxOutputTokens(role),
-      ).toBeLessThanOrEqual(modelRoleMaxOutputTokens(role));
+        structuredOutputModelRoleMaxOutputTokens({ modelId: model, role }),
+      ).toBeLessThanOrEqual(modelRoleMaxOutputTokens({ modelId: model, role }));
     }
 
-    expect(structuredOutputModelRoleMaxOutputTokens("reasoning")).toBeLessThan(
-      21_000,
-    );
-    expect(modelRoleMaxOutputTokens("reasoning")).toBeGreaterThan(
-      structuredOutputModelRoleMaxOutputTokens("reasoning"),
+    expect(
+      structuredOutputModelRoleMaxOutputTokens({
+        modelId: model,
+        role: "reasoning",
+      }),
+    ).toBeLessThan(21_000);
+    expect(
+      modelRoleMaxOutputTokens({ modelId: model, role: "reasoning" }),
+    ).toBeGreaterThan(
+      structuredOutputModelRoleMaxOutputTokens({
+        modelId: model,
+        role: "reasoning",
+      }),
     );
   });
 
@@ -39,12 +49,27 @@ describe("AI provider canary role budgets", () => {
         continue;
       }
       expect(TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS).toBeGreaterThan(
-        modelRoleMaxOutputTokens(role),
+        modelRoleMaxOutputTokens({ modelId: model, role }),
       );
     }
-    // Amazon Nova v1 accepts at most 5,120 output tokens and takes part in
+    // Amazon Nova v1 accepts at most 10,000 output tokens and takes part in
     // the weekly rotation; a larger ceiling is rejected before the tool call.
-    expect(TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS).toBeLessThanOrEqual(5120);
+    expect(TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS).toBeLessThanOrEqual(10_000);
+  });
+
+  test("clamps role budgets to a model's output limit", () => {
+    const nova = "us.amazon.nova-lite-v1:0";
+    for (const role of MODEL_ROLES) {
+      expect(
+        modelRoleMaxOutputTokens({ modelId: nova, role }),
+      ).toBeLessThanOrEqual(10_000);
+      expect(
+        structuredOutputModelRoleMaxOutputTokens({ modelId: nova, role }),
+      ).toBeLessThanOrEqual(10_000);
+    }
+    expect(
+      modelRoleMaxOutputTokens({ modelId: model, role: "reasoning" }),
+    ).toBeGreaterThan(10_000);
   });
 });
 

--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -123,19 +123,49 @@ const MODEL_ROLE_MAX_OUTPUT_TOKENS = {
   pdf: 512,
 } as const satisfies Record<ModelRole, number>;
 
-export const modelRoleMaxOutputTokens = (role: ModelRole) =>
-  MODEL_ROLE_MAX_OUTPUT_TOKENS[role];
+// Providers reject a request whose ceiling exceeds the model's output limit
+// before generating anything (Bedrock: "The maximum tokens you requested
+// exceeds the model limit of 10000"). The weekly rotation runs every role
+// probe on every offered model, so role budgets are clamped to the limits
+// known to be below them; a model absent here takes the role budget as is.
+const MODEL_MAX_OUTPUT_TOKENS: ReadonlyMap<string, number> = new Map([
+  ["us.amazon.nova-pro-v1:0", 10_000],
+  ["us.amazon.nova-lite-v1:0", 10_000],
+  ["us.amazon.nova-micro-v1:0", 10_000],
+]);
+
+const clampToModelOutputLimit = (modelId: string, budget: number) => {
+  const limit = MODEL_MAX_OUTPUT_TOKENS.get(modelId);
+  return limit === undefined ? budget : Math.min(budget, limit);
+};
+
+type RoleBudgetOptions = {
+  modelId: string;
+  role: ModelRole;
+};
+
+export const modelRoleMaxOutputTokens = ({
+  modelId,
+  role,
+}: RoleBudgetOptions) =>
+  clampToModelOutputLimit(modelId, MODEL_ROLE_MAX_OUTPUT_TOKENS[role]);
 
 // Anthropic's SDK rejects non-streaming structured-output requests whose
 // ceiling can exceed its ten-minute window. Keep the reasoning probe below
 // the adapter's documented ~21K clamp while leaving streaming probes intact.
-export const structuredOutputModelRoleMaxOutputTokens = (role: ModelRole) =>
-  role === "reasoning" ? 20_000 : modelRoleMaxOutputTokens(role);
+export const structuredOutputModelRoleMaxOutputTokens = ({
+  modelId,
+  role,
+}: RoleBudgetOptions) =>
+  clampToModelOutputLimit(
+    modelId,
+    role === "reasoning" ? 20_000 : MODEL_ROLE_MAX_OUTPUT_TOKENS[role],
+  );
 
 // Tool-execution probes may spend thinking tokens before the call, so they
-// get more headroom than a short-reply role, while staying under the smallest
-// output ceiling of any offered model (Amazon Nova v1: 5,120) because the
-// weekly rotation runs the same probe on every model.
+// get more headroom than a short-reply role, while staying under every
+// per-model output limit above because the weekly rotation runs the same
+// probe on every model.
 export const TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS = 4096;
 
 export const isCanaryProvider = (value: string): value is CanaryProvider =>

--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -126,17 +126,30 @@ const MODEL_ROLE_MAX_OUTPUT_TOKENS = {
 // Providers reject a request whose ceiling exceeds the model's output limit
 // before generating anything (Bedrock: "The maximum tokens you requested
 // exceeds the model limit of 10000"). The weekly rotation runs every role
-// probe on every offered model, so role budgets are clamped to the limits
-// known to be below them; a model absent here takes the role budget as is.
-const MODEL_MAX_OUTPUT_TOKENS: ReadonlyMap<string, number> = new Map([
-  ["us.amazon.nova-pro-v1:0", 10_000],
-  ["us.amazon.nova-lite-v1:0", 10_000],
-  ["us.amazon.nova-micro-v1:0", 10_000],
-]);
+// probe on every offered Bedrock model, so the map is total over that
+// catalog: adding a model forces a decision here, `null` meaning its limit
+// is above every role budget and the budget is sent as is.
+type BedrockModelId = (typeof BYOK_MODEL_OPTIONS)["bedrock"][number];
+const MODEL_MAX_OUTPUT_TOKENS = {
+  "us.anthropic.claude-sonnet-4-5-20250929-v1:0": null,
+  "us.anthropic.claude-haiku-4-5-20251001-v1:0": null,
+  "us.amazon.nova-pro-v1:0": 10_000,
+  "us.amazon.nova-lite-v1:0": 10_000,
+  "us.amazon.nova-micro-v1:0": 10_000,
+  "openai.gpt-oss-120b-1:0": null,
+  "openai.gpt-oss-20b-1:0": null,
+  "us.deepseek.r1-v1:0": null,
+} as const satisfies Record<BedrockModelId, number | null>;
+
+const isBedrockModelId = (modelId: string): modelId is BedrockModelId =>
+  Object.hasOwn(MODEL_MAX_OUTPUT_TOKENS, modelId);
 
 const clampToModelOutputLimit = (modelId: string, budget: number) => {
-  const limit = MODEL_MAX_OUTPUT_TOKENS.get(modelId);
-  return limit === undefined ? budget : Math.min(budget, limit);
+  if (!isBedrockModelId(modelId)) {
+    return budget;
+  }
+  const limit = MODEL_MAX_OUTPUT_TOKENS[modelId];
+  return limit === null ? budget : Math.min(budget, limit);
 };
 
 type RoleBudgetOptions = {

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -942,7 +942,10 @@ const runModelRoleProbe = async ({
   const output = await generateTanStackTextForRole({
     abortSignal: signal,
     caching: NO_CACHING,
-    maxOutputTokens: modelRoleMaxOutputTokens(role),
+    maxOutputTokens: modelRoleMaxOutputTokens({
+      modelId: selection.modelId,
+      role,
+    }),
     ...(role === "pdf"
       ? { messages: createPdfCanaryMessages() }
       : { prompt: SYNTHETIC_PROMPT }),
@@ -956,14 +959,17 @@ const runModelRoleProbe = async ({
 };
 
 const runStructuredOutputModelRoleProbe = async ({
-  context: { config },
+  context: { config, provider },
   role,
   signal,
 }: RunModelRoleProbeOptions): Promise<void> => {
   await generateTanStackObjectForRole({
     abortSignal: signal,
     caching: NO_CACHING,
-    maxOutputTokens: structuredOutputModelRoleMaxOutputTokens(role),
+    maxOutputTokens: structuredOutputModelRoleMaxOutputTokens({
+      modelId: DEFAULT_MODELS[provider][role],
+      role,
+    }),
     organizationId: null,
     orgAIConfig: config,
     outputSchema: nestedStructuredOutputSchema,
@@ -997,7 +1003,10 @@ const runWeeklyModelRoleProbe = async ({
   const output = await generateTanStackTextForRole({
     abortSignal: signal,
     caching: NO_CACHING,
-    maxOutputTokens: modelRoleMaxOutputTokens(role),
+    maxOutputTokens: modelRoleMaxOutputTokens({
+      modelId: rotation.modelId,
+      role,
+    }),
     ...(role === "pdf"
       ? { messages: createPdfCanaryMessages() }
       : { prompt: SYNTHETIC_PROMPT }),
@@ -1011,14 +1020,17 @@ const runWeeklyModelRoleProbe = async ({
 };
 
 const runWeeklyStructuredOutputModelRoleProbe = async ({
-  context: { rotatedConfig },
+  context: { rotatedConfig, rotation },
   role,
   signal,
 }: RunWeeklyModelRoleProbeOptions): Promise<void> => {
   await generateTanStackObjectForRole({
     abortSignal: signal,
     caching: NO_CACHING,
-    maxOutputTokens: structuredOutputModelRoleMaxOutputTokens(role),
+    maxOutputTokens: structuredOutputModelRoleMaxOutputTokens({
+      modelId: rotation.modelId,
+      role,
+    }),
     organizationId: null,
     orgAIConfig: rotatedConfig,
     outputSchema: nestedStructuredOutputSchema,


### PR DESCRIPTION
The weekly Bedrock canary rotation fails whenever it lands on an Amazon Nova model (https://github.com/stella/stella/actions/runs/32686937091): the reasoning role sends a 25,000-token ceiling and the structured reasoning probe 20,000, and Bedrock rejects the request before generating: `The maximum tokens you requested exceeds the model limit of 10000`. The canary reported it as `provider HTTP 502`, which is the shared generate path's wrapper status.

Add a per-model output limit map to the canary config (Nova v1: 10,000) and clamp both role budget helpers to it, passing the selected model id from every probe. Models without a known limit keep the role budget. The config test asserts the clamp and the tool-probe bound now references the same limit.

The four `ai-provider-canary*` test files pass.

https://claude.ai/code/session_01NMnG9ntKwemcJMgkMB7k5v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - AI provider validation now respects each model’s maximum output-token limit.
  - Role-based and structured-output checks are capped automatically when configured budgets exceed a model’s supported limit.
  - Updated Amazon Nova token-limit handling, including coverage for Nova Lite.
  - Canary checks now apply the correct limits consistently across daily and weekly model evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->