### PR TITLE
fix: preserve bilingual DOCX formatting

### DIFF
--- a/apps/api/src/lib/bilingual/ai.test.ts
+++ b/apps/api/src/lib/bilingual/ai.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SafeDb } from "@/api/db/safe-db";
+import type { AIUsageMetering } from "@/api/lib/analytics/tanstack-ai";
+import type { BilingualAIContext } from "@/api/lib/bilingual/ai";
+import type { FormattedBilingualUnit } from "@/api/lib/bilingual/formatting";
+import { toSafeId } from "@/api/lib/branded-types";
+
+type GenerateOptions = { prompt: string };
+type FormattedOutput = {
+  items: { n: number; spans: { id: string; text: string }[] }[];
+};
+
+const outputs: FormattedOutput[] = [];
+const prompts: string[] = [];
+const generateObjectMock = mock(async ({ prompt }: GenerateOptions) => {
+  prompts.push(prompt);
+  const output = outputs.shift();
+  if (!output) {
+    throw new Error("test did not configure a model output");
+  }
+  return await Promise.resolve(output);
+});
+
+void mock.module("@/api/lib/tanstack-ai-generate", () => ({
+  generateTanStackObjectForRole: generateObjectMock,
+}));
+
+void mock.module("@/api/lib/analytics/tanstack-ai", () => ({
+  createTanStackAIAnalyticsCallbacks: () => ({}),
+}));
+
+const { translateFormattedBatch } = await import("@/api/lib/bilingual/ai");
+
+const organizationId = toSafeId<"organization">("organization-fixture");
+const workspaceId = toSafeId<"workspace">("workspace-fixture");
+const safeDb: SafeDb = async () => {
+  throw new Error("safeDb should not be called by this test");
+};
+const usageMetering = {
+  actionType: "doc_review",
+  organizationId,
+  safeDb,
+  serviceTier: "standard",
+  userId: toSafeId<"user">("user-fixture"),
+  workspaceId,
+} satisfies AIUsageMetering;
+const context = {
+  organizationId,
+  workspaceId,
+  orgAIConfig: null,
+  promptCachingEnabled: false,
+  usageMetering,
+  abortSignal: AbortSignal.timeout(10_000),
+  scopeKey: "document-version-fixture",
+} satisfies BilingualAIContext;
+
+const formattedUnit = (
+  ordinal: number,
+  spans: readonly { id: string; text: string }[],
+): FormattedBilingualUnit => ({
+  rowId: `row-${ordinal}`,
+  ordinal,
+  kind: "paragraph",
+  inTable: false,
+  sourceParaId: `source-${ordinal}`,
+  sourceText: spans.map((span) => span.text).join(""),
+  inline: spans.map((span) => ({ type: "text", ...span })),
+  spans,
+});
+
+describe("formatted bilingual AI boundary", () => {
+  beforeEach(() => {
+    outputs.length = 0;
+    prompts.length = 0;
+    generateObjectMock.mockClear();
+  });
+
+  test("retries only rows whose ordered span contract is invalid", async () => {
+    const accepted = formattedUnit(1, [
+      { id: "row-1:s0001", text: "Hello" },
+      { id: "row-1:s0002", text: " world" },
+    ]);
+    const repaired = formattedUnit(2, [
+      { id: "row-2:s0001", text: "Goodbye" },
+      { id: "row-2:s0002", text: " world" },
+    ]);
+    outputs.push(
+      {
+        items: [
+          {
+            n: 1,
+            spans: [
+              { id: "row-1:s0001", text: "Ahoj" },
+              { id: "row-1:s0002", text: " světe" },
+            ],
+          },
+          {
+            n: 2,
+            spans: [{ id: "wrong", text: "Neplatné" }],
+          },
+        ],
+      },
+      {
+        items: [
+          {
+            n: 2,
+            spans: [
+              { id: "row-2:s0001", text: "Sbohem" },
+              { id: "row-2:s0002", text: " světe" },
+            ],
+          },
+        ],
+      },
+    );
+
+    const result = await translateFormattedBatch(
+      { batch: [accepted, repaired], preceding: [], glossary: [] },
+      { sourceLang: "en", targetLang: "cs" },
+      context,
+    );
+
+    expect(generateObjectMock).toHaveBeenCalledTimes(2);
+    expect(prompts.at(1)).toContain("Contract repair:");
+    expect(prompts.at(1)).not.toContain("#1:");
+    expect(prompts.at(1)).toContain("#2:");
+    expect(result.get(1)).toEqual({
+      text: "Ahoj světe",
+      spans: [
+        { id: "row-1:s0001", text: "Ahoj" },
+        { id: "row-1:s0002", text: " světe" },
+      ],
+    });
+    expect(result.get(2)).toEqual({
+      text: "Sbohem světe",
+      spans: [
+        { id: "row-2:s0001", text: "Sbohem" },
+        { id: "row-2:s0002", text: " světe" },
+      ],
+    });
+  });
+
+  test("rejects pathological inline token counts before model dispatch", async () => {
+    const spans = Array.from({ length: 2049 }, (_unused, index) => ({
+      id: `row-1:s${index}`,
+      text: "",
+    }));
+
+    const translation = translateFormattedBatch(
+      { batch: [formattedUnit(1, spans)], preceding: [], glossary: [] },
+      { sourceLang: "en", targetLang: "cs" },
+      context,
+    );
+
+    const rejection = await translation.then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(rejection).toMatchObject({
+      _tag: "BilingualAIContractError",
+    });
+    expect(generateObjectMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects cumulative formatted row serialization before model dispatch", async () => {
+    const batch = Array.from({ length: 8 }, (_unusedBatch, batchIndex) => {
+      const ordinal = batchIndex + 1;
+      return formattedUnit(
+        ordinal,
+        Array.from({ length: 2048 }, (_unusedSpan, spanIndex) => ({
+          id: `row-${ordinal}:s${spanIndex}`,
+          text: spanIndex === 0 ? "x" : "",
+        })),
+      );
+    });
+
+    const translation = translateFormattedBatch(
+      { batch, preceding: [], glossary: [] },
+      { sourceLang: "en", targetLang: "cs" },
+      context,
+    );
+
+    const rejection = await translation.then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(rejection).toMatchObject({
+      _tag: "BilingualAIContractError",
+    });
+    expect(generateObjectMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/lib/bilingual/ai.test.ts
+++ b/apps/api/src/lib/bilingual/ai.test.ts
@@ -23,7 +23,14 @@ const generateObjectMock = mock(async ({ prompt }: GenerateOptions) => {
 });
 
 void mock.module("@/api/lib/tanstack-ai-generate", () => ({
+  abortControllerFromSignal: mock(),
   generateTanStackObjectForRole: generateObjectMock,
+  generateTanStackTextForRole: mock(),
+  mergeGenerationOptions: mock(),
+  resolveTanStackTextModel: mock(),
+  streamTanStackObjectForRole: mock(),
+  streamTanStackTextForRole: mock(),
+  systemPromptsPatch: mock(),
 }));
 
 void mock.module("@/api/lib/analytics/tanstack-ai", () => ({

--- a/apps/api/src/lib/bilingual/ai.ts
+++ b/apps/api/src/lib/bilingual/ai.ts
@@ -2,6 +2,7 @@
 // manifest (never the DOCX), addresses rows by ordinal, and is validated
 // against the known ordinals before anything is trusted.
 
+import { TaggedError } from "better-result";
 import * as v from "valibot";
 
 import type { ModelRole } from "@stll/ai-catalog";
@@ -38,6 +39,13 @@ const SERVICE_TIER = "standard" as const;
 const CALL_TIMEOUT_MS = 90_000;
 const PREVIEW_CHARS = 240;
 const GLOSSARY_SAMPLE_CHARS = 24_000;
+const FORMATTED_INLINE_TOKENS_MAX = 2048;
+const FORMATTED_ROWS_SERIALIZED_CHARS_MAX = 200_000;
+const FORMATTED_OUTPUT_ATTEMPTS = 2;
+
+class BilingualAIContractError extends TaggedError("BilingualAIContractError")<{
+  message: string;
+}> {}
 
 export type BilingualAIContext = {
   organizationId: SafeId<"organization">;
@@ -329,7 +337,7 @@ const TRANSLATION_SYSTEM = `You translate rows of a legal document for a two-col
 - Do not add explanations, notes or the source text. Return one item per row number.`;
 
 const FORMATTED_TRANSLATION_SYSTEM = `${TRANSLATION_SYSTEM}
-- Each formatted row is an ordered JSON array. Translate only text token values. Control tokens represent tabs, breaks, symbols, and fields; they are immutable and remain in place.
+- Each formatted row is an ordered JSON array. Translate only text token values. Control tokens represent tabs, breaks, hyphens, symbols, and fields; they are immutable and remain in place.
 - Return every text span exactly once, in its original order, with the same id. Keep text belonging to a styled source span in that span; an empty translated span is allowed when target-language word order requires it.`;
 
 export type TranslationContextRow = {
@@ -427,6 +435,59 @@ const hasExactSpanIds = (
   spans.length === unit.spans.length &&
   spans.every((span, index) => span.id === unit.spans.at(index)?.id);
 
+const serializeFormattedRows = (
+  batch: readonly FormattedBilingualUnit[],
+): string => {
+  const lines: string[] = [];
+  let serializedChars = 0;
+  for (const unit of batch) {
+    if (unit.inline.length > FORMATTED_INLINE_TOKENS_MAX) {
+      throw new BilingualAIContractError({
+        message: `Formatted bilingual row ${unit.rowId} exceeds the inline token limit`,
+      });
+    }
+    const serialized = JSON.stringify(unit.inline);
+    serializedChars += serialized.length;
+    if (serializedChars > FORMATTED_ROWS_SERIALIZED_CHARS_MAX) {
+      throw new BilingualAIContractError({
+        message: "Formatted bilingual batch exceeds the prompt size limit",
+      });
+    }
+    lines.push(`#${unit.ordinal}: ${serialized}`);
+  }
+  return lines.join("\n");
+};
+
+type FormattedTranslationOutput = v.InferOutput<
+  typeof formattedTranslationSchema
+>;
+
+const collectFormattedTranslations = (
+  batch: readonly FormattedBilingualUnit[],
+  output: FormattedTranslationOutput,
+  result: Map<number, BilingualFormattedTranslation>,
+): FormattedBilingualUnit[] => {
+  const byOrdinal = new Map(batch.map((unit) => [unit.ordinal, unit]));
+  for (const item of output.items) {
+    const unit = byOrdinal.get(item.n);
+    if (!unit || result.has(item.n) || !hasExactSpanIds(unit, item.spans)) {
+      continue;
+    }
+    const text = item.spans.map((span) => span.text).join("");
+    if (text.trim() === "") {
+      continue;
+    }
+    result.set(item.n, {
+      text,
+      spans: item.spans.map(({ id, text: spanText }) => ({
+        id,
+        text: spanText,
+      })),
+    });
+  }
+  return batch.filter((unit) => !result.has(unit.ordinal));
+};
+
 /** Translate a batch without flattening its styled DOCX runs to plain text. */
 export const translateFormattedBatch = async (
   { batch, preceding, glossary }: TranslateFormattedBatchInput,
@@ -448,46 +509,41 @@ export const translateFormattedBatch = async (
         `  ${row.sourceText}${row.targetText ? `\n  => ${row.targetText}` : ""}`,
     )
     .join("\n");
-  const rowLines = batch
-    .map((unit) => `#${unit.ordinal}: ${JSON.stringify(unit.inline)}`)
-    .join("\n");
-  const output = await generateTanStackObjectForRole({
-    role: TRANSLATION_ROLE,
-    orgAIConfig: context.orgAIConfig,
-    organizationId: context.organizationId,
-    analytics,
-    caching: resolveCaching({
-      promptCachingEnabled: context.promptCachingEnabled,
-      role: TRANSLATION_ROLE,
-      scopeKey: context.scopeKey,
-    }),
-    serviceTier: SERVICE_TIER,
-    tenantWorkspaceIds: [context.workspaceId],
-    system: FORMATTED_TRANSLATION_SYSTEM,
-    systemPromptOrigin: "embeds-untrusted",
-    prompt: `Source language: ${languages.sourceLang}. Target language: ${languages.targetLang}.\n\nGlossary:\n${glossaryLines || "(none)"}\n\nPreceding rows (context only):\n${contextLines || "(start of document)"}\n\nFormatted rows to translate:\n${rowLines}`,
-    abortSignal: callSignal(context),
-    outputSchema: formattedTranslationSchema,
-  });
-
-  const byOrdinal = new Map(batch.map((unit) => [unit.ordinal, unit]));
   const result = new Map<number, BilingualFormattedTranslation>();
-  for (const item of output.items) {
-    const unit = byOrdinal.get(item.n);
-    if (!unit || result.has(item.n) || !hasExactSpanIds(unit, item.spans)) {
-      continue;
-    }
-    const text = item.spans.map((span) => span.text).join("");
-    if (text.trim() === "") {
-      continue;
-    }
-    result.set(item.n, {
-      text,
-      spans: item.spans.map(({ id, text: spanText }) => ({
-        id,
-        text: spanText,
-      })),
+  const translateAttempt = async (
+    remaining: readonly FormattedBilingualUnit[],
+    attempt: number,
+  ): Promise<void> => {
+    const rowLines = serializeFormattedRows(remaining);
+    const repairInstruction =
+      attempt === 1
+        ? ""
+        : "\n\nContract repair: return every listed row with exactly the provided text span ids, once and in order.";
+    const output = await generateTanStackObjectForRole({
+      role: TRANSLATION_ROLE,
+      orgAIConfig: context.orgAIConfig,
+      organizationId: context.organizationId,
+      analytics,
+      caching: resolveCaching({
+        promptCachingEnabled: context.promptCachingEnabled,
+        role: TRANSLATION_ROLE,
+        scopeKey: context.scopeKey,
+      }),
+      serviceTier: SERVICE_TIER,
+      tenantWorkspaceIds: [context.workspaceId],
+      system: FORMATTED_TRANSLATION_SYSTEM,
+      systemPromptOrigin: "embeds-untrusted",
+      prompt: `Source language: ${languages.sourceLang}. Target language: ${languages.targetLang}.\n\nGlossary:\n${glossaryLines || "(none)"}\n\nPreceding rows (context only):\n${contextLines || "(start of document)"}\n\nFormatted rows to translate:\n${rowLines}${repairInstruction}`,
+      abortSignal: callSignal(context),
+      outputSchema: formattedTranslationSchema,
     });
+    const rejected = collectFormattedTranslations(remaining, output, result);
+    if (attempt < FORMATTED_OUTPUT_ATTEMPTS && rejected.length > 0) {
+      await translateAttempt(rejected, attempt + 1);
+    }
+  };
+  if (batch.length > 0) {
+    await translateAttempt(batch, 1);
   }
   return result;
 };

--- a/apps/api/src/lib/bilingual/ai.ts
+++ b/apps/api/src/lib/bilingual/ai.ts
@@ -19,6 +19,10 @@ import type {
   BilingualGlossaryEntry,
   BilingualRowDisposition,
 } from "@/api/lib/bilingual/contract";
+import type {
+  BilingualFormattedTranslation,
+  FormattedBilingualUnit,
+} from "@/api/lib/bilingual/formatting";
 import { defaultDisposition, ruleDisposition } from "@/api/lib/bilingual/rows";
 import type {
   BilingualUnit,
@@ -324,6 +328,10 @@ const TRANSLATION_SYSTEM = `You translate rows of a legal document for a two-col
 - Keep numbers, dates, amounts, currency, article and section references, party names and defined-term capitalisation unchanged.
 - Do not add explanations, notes or the source text. Return one item per row number.`;
 
+const FORMATTED_TRANSLATION_SYSTEM = `${TRANSLATION_SYSTEM}
+- Each formatted row is an ordered JSON array. Translate only text token values. Control tokens represent tabs, breaks, symbols, and fields; they are immutable and remain in place.
+- Return every text span exactly once, in its original order, with the same id. Keep text belonging to a styled source span in that span; an empty translated span is allowed when target-language word order requires it.`;
+
 export type TranslationContextRow = {
   sourceText: string;
   targetText: string | null;
@@ -388,6 +396,98 @@ export const translateBatch = async (
     if (known.has(item.n) && text !== "" && !result.has(item.n)) {
       result.set(item.n, text);
     }
+  }
+  return result;
+};
+
+const formattedTranslationSchema = v.object({
+  items: v.array(
+    v.object({
+      n: v.pipe(v.number(), v.integer(), v.minValue(1)),
+      spans: v.array(
+        v.object({
+          id: v.string(),
+          text: v.string(),
+        }),
+      ),
+    }),
+  ),
+});
+
+export type TranslateFormattedBatchInput = {
+  batch: readonly FormattedBilingualUnit[];
+  preceding: readonly TranslationContextRow[];
+  glossary: readonly BilingualGlossaryEntry[];
+};
+
+const hasExactSpanIds = (
+  unit: FormattedBilingualUnit,
+  spans: readonly { id: string }[],
+): boolean =>
+  spans.length === unit.spans.length &&
+  spans.every((span, index) => span.id === unit.spans.at(index)?.id);
+
+/** Translate a batch without flattening its styled DOCX runs to plain text. */
+export const translateFormattedBatch = async (
+  { batch, preceding, glossary }: TranslateFormattedBatchInput,
+  languages: Languages,
+  context: BilingualAIContext,
+): Promise<Map<number, BilingualFormattedTranslation>> => {
+  const analytics = analyticsFor(
+    context,
+    "bilingual.translate",
+    TRANSLATION_ROLE,
+  );
+  const glossaryLines = glossary
+    .filter((entry) => entry.target !== "")
+    .map((entry) => `- ${entry.source} -> ${entry.target}`)
+    .join("\n");
+  const contextLines = preceding
+    .map(
+      (row) =>
+        `  ${row.sourceText}${row.targetText ? `\n  => ${row.targetText}` : ""}`,
+    )
+    .join("\n");
+  const rowLines = batch
+    .map((unit) => `#${unit.ordinal}: ${JSON.stringify(unit.inline)}`)
+    .join("\n");
+  const output = await generateTanStackObjectForRole({
+    role: TRANSLATION_ROLE,
+    orgAIConfig: context.orgAIConfig,
+    organizationId: context.organizationId,
+    analytics,
+    caching: resolveCaching({
+      promptCachingEnabled: context.promptCachingEnabled,
+      role: TRANSLATION_ROLE,
+      scopeKey: context.scopeKey,
+    }),
+    serviceTier: SERVICE_TIER,
+    tenantWorkspaceIds: [context.workspaceId],
+    system: FORMATTED_TRANSLATION_SYSTEM,
+    systemPromptOrigin: "embeds-untrusted",
+    prompt: `Source language: ${languages.sourceLang}. Target language: ${languages.targetLang}.\n\nGlossary:\n${glossaryLines || "(none)"}\n\nPreceding rows (context only):\n${contextLines || "(start of document)"}\n\nFormatted rows to translate:\n${rowLines}`,
+    abortSignal: callSignal(context),
+    outputSchema: formattedTranslationSchema,
+  });
+
+  const byOrdinal = new Map(batch.map((unit) => [unit.ordinal, unit]));
+  const result = new Map<number, BilingualFormattedTranslation>();
+  for (const item of output.items) {
+    const unit = byOrdinal.get(item.n);
+    if (!unit || result.has(item.n) || !hasExactSpanIds(unit, item.spans)) {
+      continue;
+    }
+    const text = item.spans.map((span) => span.text).join("");
+    if (text.trim() === "") {
+      continue;
+    }
+    result.set(item.n, {
+      text,
+      spans: item.spans.map(({ id, text: spanText }) => ({
+        id,
+        text: spanText,
+      })),
+    });
   }
   return result;
 };

--- a/apps/api/src/lib/bilingual/formatting.ts
+++ b/apps/api/src/lib/bilingual/formatting.ts
@@ -126,6 +126,9 @@ const projectParagraph = (
       return;
     }
     if (isElement(node)) {
+      if (isWordElement(node, "pPr") || isWordElement(node, "rPr")) {
+        return;
+      }
       if (isWordElement(node, "delText")) {
         return;
       }

--- a/apps/api/src/lib/bilingual/formatting.ts
+++ b/apps/api/src/lib/bilingual/formatting.ts
@@ -1,0 +1,337 @@
+import { TaggedError } from "better-result";
+import * as slimdom from "slimdom";
+
+import type { StoredRow } from "@/api/lib/bilingual/operations";
+import type { BilingualUnit } from "@/api/lib/bilingual/rows";
+import { loadDocxArchive } from "@/api/lib/docx-archive";
+
+const DOCUMENT_PART = "word/document.xml";
+const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+const W14_NS = "http://schemas.microsoft.com/office/word/2010/wordml";
+const XML_NS = "http://www.w3.org/XML/1998/namespace";
+const INLINE_SEPARATOR = " / ";
+
+export type BilingualTextSpan = Readonly<{
+  id: string;
+  text: string;
+}>;
+
+export type BilingualInlineControl = Readonly<{
+  type: "control";
+  kind: "break" | "field" | "fieldInstruction" | "symbol" | "tab";
+}>;
+
+export type BilingualInlineToken =
+  | (BilingualTextSpan & Readonly<{ type: "text" }>)
+  | BilingualInlineControl;
+
+export type FormattedBilingualUnit = BilingualUnit & {
+  inline: readonly BilingualInlineToken[];
+  spans: readonly BilingualTextSpan[];
+};
+
+export type BilingualFormattedTranslation = Readonly<{
+  text: string;
+  spans: readonly BilingualTextSpan[];
+}>;
+
+type BilingualFormattingErrorReason =
+  | "invalid-spans"
+  | "malformed-xml"
+  | "missing-document"
+  | "missing-paragraph";
+
+export class BilingualFormattingError extends TaggedError(
+  "BilingualFormattingError",
+)<{
+  message: string;
+  reason: BilingualFormattingErrorReason;
+}> {}
+
+const fail = (
+  reason: BilingualFormattingErrorReason,
+  message: string,
+): never => {
+  throw new BilingualFormattingError({ message, reason });
+};
+
+const isElement = (node: slimdom.Node): node is slimdom.Element =>
+  node.nodeType === node.ELEMENT_NODE;
+
+const isWordElement = (node: slimdom.Node, localName: string): boolean =>
+  isElement(node) && node.namespaceURI === W_NS && node.localName === localName;
+
+const paragraphById = (
+  doc: slimdom.Document,
+): ReadonlyMap<string, slimdom.Element> => {
+  const result = new Map<string, slimdom.Element>();
+  for (const paragraph of doc.getElementsByTagNameNS(W_NS, "p")) {
+    const paraId = paragraph.getAttributeNS(W14_NS, "paraId");
+    if (paraId !== null) {
+      result.set(paraId, paragraph);
+    }
+  }
+  return result;
+};
+
+const controlKind = (
+  element: slimdom.Element,
+): BilingualInlineControl["kind"] | null => {
+  switch (element.localName) {
+    case "br":
+      return "break";
+    case "fldChar":
+      return "field";
+    case "instrText":
+      return "fieldInstruction";
+    case "sym":
+      return "symbol";
+    case "ptab":
+    case "tab":
+      return "tab";
+    default:
+      return null;
+  }
+};
+
+type ParagraphProjection = Readonly<{
+  inline: readonly BilingualInlineToken[];
+  spans: readonly BilingualTextSpan[];
+  textNodes: readonly slimdom.Element[];
+}>;
+
+const projectParagraph = (
+  paragraph: slimdom.Element,
+  rowId: string,
+): ParagraphProjection => {
+  const inline: BilingualInlineToken[] = [];
+  const spans: BilingualTextSpan[] = [];
+  const textNodes: slimdom.Element[] = [];
+  const walk = (node: slimdom.Node): void => {
+    if (node !== paragraph && isWordElement(node, "p")) {
+      return;
+    }
+    if (isElement(node)) {
+      if (isWordElement(node, "delText")) {
+        return;
+      }
+      if (isWordElement(node, "t")) {
+        const id = `${rowId}:s${String(spans.length + 1).padStart(4, "0")}`;
+        const text = node.textContent ?? "";
+        const span = Object.freeze({ id, text });
+        spans.push(span);
+        inline.push(Object.freeze({ type: "text" as const, ...span }));
+        textNodes.push(node);
+        return;
+      }
+      if (node.namespaceURI === W_NS) {
+        const kind = controlKind(node);
+        if (kind !== null) {
+          inline.push(Object.freeze({ type: "control" as const, kind }));
+          if (kind === "fieldInstruction") {
+            return;
+          }
+        }
+      }
+    }
+    for (const child of node.childNodes) {
+      walk(child);
+    }
+  };
+  walk(paragraph);
+  return Object.freeze({
+    inline: Object.freeze(inline),
+    spans: Object.freeze(spans),
+    textNodes: Object.freeze(textNodes),
+  });
+};
+
+const parseDocumentPart = (xml: string): slimdom.Document => {
+  try {
+    return slimdom.parseXmlDocument(xml);
+  } catch {
+    return fail("malformed-xml", "Bilingual DOCX has malformed document XML");
+  }
+};
+
+const loadDocumentPart = async (buffer: ArrayBuffer) => {
+  const archive = await loadDocxArchive(buffer);
+  const xml = await archive.readEntryString(DOCUMENT_PART);
+  if (xml === null) {
+    return fail(
+      "missing-document",
+      "Bilingual DOCX is missing word/document.xml",
+    );
+  }
+  return { archive, doc: parseDocumentPart(xml) };
+};
+
+/**
+ * Project each editable bilingual paragraph into ordered text spans plus
+ * immutable inline controls. The model translates the spans; tabs, breaks,
+ * symbols, and fields never cross the model boundary as editable content.
+ */
+export const extractFormattedBilingualUnits = async (
+  buffer: ArrayBuffer,
+  units: readonly BilingualUnit[],
+): Promise<FormattedBilingualUnit[]> => {
+  const { doc } = await loadDocumentPart(buffer);
+  const paragraphs = paragraphById(doc);
+  return units.map((unit) => {
+    const paragraph = paragraphs.get(unit.rowId);
+    if (!paragraph) {
+      return fail(
+        "missing-paragraph",
+        `Bilingual row ${unit.rowId} has no matching paragraph`,
+      );
+    }
+    const { inline, spans } = projectParagraph(paragraph, unit.rowId);
+    return { ...unit, inline, spans };
+  });
+};
+
+const validateTranslationSpans = (
+  rowId: string,
+  source: ParagraphProjection,
+  translation: BilingualFormattedTranslation,
+): void => {
+  if (source.spans.length !== translation.spans.length) {
+    fail(
+      "invalid-spans",
+      `Translation for ${rowId} has ${translation.spans.length} spans; expected ${source.spans.length}`,
+    );
+  }
+  if (
+    translation.text !== translation.spans.map((span) => span.text).join("")
+  ) {
+    fail(
+      "invalid-spans",
+      `Translation for ${rowId} has text that differs from its spans`,
+    );
+  }
+  for (const [index, sourceSpan] of source.spans.entries()) {
+    if (translation.spans.at(index)?.id !== sourceSpan.id) {
+      fail(
+        "invalid-spans",
+        `Translation for ${rowId} has missing, duplicate, or reordered spans`,
+      );
+    }
+  }
+};
+
+const replaceText = (
+  rowId: string,
+  paragraph: slimdom.Element,
+  translation: BilingualFormattedTranslation,
+): void => {
+  const source = projectParagraph(paragraph, rowId);
+  validateTranslationSpans(rowId, source, translation);
+  for (const [index, node] of source.textNodes.entries()) {
+    const span = translation.spans.at(index);
+    if (!span) {
+      return fail(
+        "invalid-spans",
+        `Translation for ${rowId} has no span ${index + 1}`,
+      );
+    }
+    const { text } = span;
+    node.textContent = text;
+    if (/^\s|\s$/u.test(text)) {
+      node.setAttributeNS(XML_NS, "xml:space", "preserve");
+    }
+  }
+};
+
+const createSeparatorRun = (doc: slimdom.Document): slimdom.Element => {
+  const run = doc.createElementNS(W_NS, "w:r");
+  const text = doc.createElementNS(W_NS, "w:t");
+  text.setAttributeNS(XML_NS, "xml:space", "preserve");
+  text.textContent = INLINE_SEPARATOR;
+  run.append(text);
+  return run;
+};
+
+const appendInlineContent = (
+  doc: slimdom.Document,
+  source: slimdom.Element,
+  translated: slimdom.Element,
+): void => {
+  source.append(createSeparatorRun(doc));
+  for (const child of [...translated.childNodes]) {
+    if (isWordElement(child, "pPr")) {
+      continue;
+    }
+    source.append(child.cloneNode(true));
+  }
+};
+
+const applyRow = (
+  doc: slimdom.Document,
+  paragraphs: ReadonlyMap<string, slimdom.Element>,
+  row: StoredRow,
+  translation: BilingualFormattedTranslation,
+): void => {
+  const target = paragraphs.get(row.rowId);
+  if (!target) {
+    return fail(
+      "missing-paragraph",
+      `Bilingual row ${row.rowId} has no matching paragraph`,
+    );
+  }
+  if (row.disposition === "translate") {
+    replaceText(row.rowId, target, translation);
+    return;
+  }
+  if (row.disposition !== "inline") {
+    return;
+  }
+  if (row.inTable) {
+    const translated = target.cloneNode(true);
+    if (!isElement(translated)) {
+      return fail(
+        "malformed-xml",
+        `Could not clone bilingual row ${row.rowId}`,
+      );
+    }
+    replaceText(row.rowId, translated, translation);
+    appendInlineContent(doc, target, translated);
+    return;
+  }
+  if (row.sourceParaId === null) {
+    return fail(
+      "missing-paragraph",
+      `Bilingual inline row ${row.rowId} has no source paragraph`,
+    );
+  }
+  const source = paragraphs.get(row.sourceParaId);
+  if (!source) {
+    return fail(
+      "missing-paragraph",
+      `Bilingual row ${row.rowId} has no matching source paragraph`,
+    );
+  }
+  replaceText(row.rowId, target, translation);
+  appendInlineContent(doc, source, target);
+};
+
+/**
+ * Apply translated spans to Folio's cloned right-hand paragraphs. Inline rows
+ * append that translated clone to the untouched source paragraph before the
+ * table cells are structurally merged.
+ */
+export const applyFormattedBilingualTranslations = async (
+  buffer: ArrayBuffer,
+  rows: readonly StoredRow[],
+  translations: ReadonlyMap<string, BilingualFormattedTranslation>,
+): Promise<ArrayBuffer> => {
+  const { archive, doc } = await loadDocumentPart(buffer);
+  const paragraphs = paragraphById(doc);
+  for (const row of rows) {
+    const translation = translations.get(row.rowId);
+    if (translation !== undefined) {
+      applyRow(doc, paragraphs, row, translation);
+    }
+  }
+  archive.zip.file(DOCUMENT_PART, slimdom.serializeToWellFormedString(doc));
+  return await archive.zip.generateAsync({ type: "arraybuffer" });
+};

--- a/apps/api/src/lib/bilingual/formatting.ts
+++ b/apps/api/src/lib/bilingual/formatting.ts
@@ -18,7 +18,15 @@ export type BilingualTextSpan = Readonly<{
 
 export type BilingualInlineControl = Readonly<{
   type: "control";
-  kind: "break" | "field" | "fieldInstruction" | "symbol" | "tab";
+  kind:
+    | "break"
+    | "carriageReturn"
+    | "field"
+    | "fieldInstruction"
+    | "noBreakHyphen"
+    | "softHyphen"
+    | "symbol"
+    | "tab";
 }>;
 
 export type BilingualInlineToken =
@@ -80,6 +88,8 @@ const controlKind = (
   switch (element.localName) {
     case "br":
       return "break";
+    case "cr":
+      return "carriageReturn";
     case "fldChar":
       return "field";
     case "instrText":
@@ -89,6 +99,10 @@ const controlKind = (
     case "ptab":
     case "tab":
       return "tab";
+    case "noBreakHyphen":
+      return "noBreakHyphen";
+    case "softHyphen":
+      return "softHyphen";
     default:
       return null;
   }

--- a/apps/api/src/lib/bilingual/operations.test.ts
+++ b/apps/api/src/lib/bilingual/operations.test.ts
@@ -110,6 +110,25 @@ const paragraphSignature = async (
 const wordElementCount = (xml: string, localName: string): number =>
   [...xml.matchAll(new RegExp(`<w:${localName}(?:\\s|/|>)`, "gu"))].length;
 
+const addExtendedInlineControls = async (
+  buffer: ArrayBuffer,
+): Promise<ArrayBuffer> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const xml = await zip.file("word/document.xml")?.async("string");
+  if (!xml) {
+    throw new Error("fixture has no document part");
+  }
+  const marker = /(<w:t\b[^>]*> italic<\/w:t>)/gu;
+  if (!marker.test(xml)) {
+    throw new Error("fixture has no italic text marker");
+  }
+  zip.file(
+    "word/document.xml",
+    xml.replaceAll(marker, "$1<w:cr/><w:noBreakHyphen/><w:softHyphen/>"),
+  );
+  return await zip.generateAsync({ type: "arraybuffer" });
+};
+
 /** A clause, a heading, a signature label, and a signature table. */
 const buildBilingual = async () => {
   const doc = createEmptyDocument({
@@ -259,9 +278,10 @@ describe("buildOperations applied to a bilingual document", () => {
         ],
       },
     ];
-    const { buffer } = await createBilingualDocx(await createDocx(doc), {
+    const bilingual = await createBilingualDocx(await createDocx(doc), {
       targetStyleSuffix: "en",
     });
+    const buffer = await addExtendedInlineControls(bilingual.buffer);
     const { units } = flattenBilingualRows(await readBilingualDocx(buffer));
     const clause = units.at(0);
     const signature = units.at(1);
@@ -330,6 +350,13 @@ describe("buildOperations applied to a bilingual document", () => {
       rows,
       richTranslations,
     );
+    const formattedTargetSignature = await paragraphSignature(
+      formattedBuffer,
+      clause.rowId,
+    );
+    for (const localName of ["cr", "noBreakHyphen", "softHyphen"]) {
+      expect(wordElementCount(formattedTargetSignature, localName)).toBe(1);
+    }
     const applied = await applyFolioAIEditsToBuffer(
       formattedBuffer,
       buildFormattingPreservingOperations(
@@ -361,6 +388,10 @@ describe("buildOperations applied to a bilingual document", () => {
     expect(targetClauseSignature).toContain("<w:highlight");
     expect(targetClauseSignature).toContain("<w:tab");
     expect(targetClauseSignature).toContain("<w:br");
+    // Folio canonicalizes carriage returns to breaks and hyphen controls to
+    // their OOXML text equivalents during the later structural edit pass.
+    expect(wordElementCount(targetClauseSignature, "br")).toBe(2);
+    expect(targetClauseSignature).toContain("‑­");
     expect(targetClauseSignature).toContain("<w:sym");
     expect(targetClauseSignature).toContain("<w:fldChar");
     expect(wordElementCount(targetClauseSignature, "tab")).toBe(1);
@@ -385,11 +416,17 @@ describe("buildOperations applied to a bilingual document", () => {
         wordElementCount(inlineSignature, localName),
       ).toBeGreaterThanOrEqual(2);
     }
-    for (const localName of ["tab", "br", "sym", "fldChar"]) {
+    for (const localName of ["tab", "sym", "fldChar"]) {
       expect(wordElementCount(inlineSignature, localName)).toBe(
         wordElementCount(sourceInlineSignature, localName) * 2,
       );
     }
+    expect(wordElementCount(inlineSignature, "br")).toBe(
+      (wordElementCount(sourceInlineSignature, "br") +
+        wordElementCount(sourceInlineSignature, "cr")) *
+        2,
+    );
+    expect(inlineSignature.match(/‑­/gu)).toHaveLength(2);
     const tableInlineSignature = await paragraphSignature(
       applied.buffer,
       tableLabel.rowId,
@@ -399,11 +436,17 @@ describe("buildOperations applied to a bilingual document", () => {
         wordElementCount(tableInlineSignature, localName),
       ).toBeGreaterThanOrEqual(2);
     }
-    for (const localName of ["tab", "br", "sym", "fldChar"]) {
+    for (const localName of ["tab", "sym", "fldChar"]) {
       expect(wordElementCount(tableInlineSignature, localName)).toBe(
         wordElementCount(sourceTableSignature, localName) * 2,
       );
     }
+    expect(wordElementCount(tableInlineSignature, "br")).toBe(
+      (wordElementCount(sourceTableSignature, "br") +
+        wordElementCount(sourceTableSignature, "cr")) *
+        2,
+    );
+    expect(tableInlineSignature.match(/‑­/gu)).toHaveLength(2);
   });
 
   test("rejects a reordered formatted translation span contract", async () => {
@@ -432,6 +475,7 @@ describe("buildOperations applied to a bilingual document", () => {
       status: "translated",
       targetText: "translated",
     };
+    const reversedSpans = formatted.spans.toReversed();
     const rejection = await applyFormattedBilingualTranslations(
       buffer,
       [row],
@@ -439,8 +483,8 @@ describe("buildOperations applied to a bilingual document", () => {
         [
           row.rowId,
           {
-            text: "translated",
-            spans: formatted.spans.toReversed(),
+            text: reversedSpans.map((span) => span.text).join(""),
+            spans: reversedSpans,
           },
         ],
       ]),

--- a/apps/api/src/lib/bilingual/operations.test.ts
+++ b/apps/api/src/lib/bilingual/operations.test.ts
@@ -129,6 +129,35 @@ const addExtendedInlineControls = async (
   return await zip.generateAsync({ type: "arraybuffer" });
 };
 
+const addParagraphPropertyTabStop = async (
+  buffer: ArrayBuffer,
+  paraId: string,
+): Promise<ArrayBuffer> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const xml = await zip.file("word/document.xml")?.async("string");
+  if (!xml) {
+    throw new Error("fixture has no document part");
+  }
+  const doc = slimdom.parseXmlDocument(xml);
+  const candidateParagraph = [...doc.getElementsByTagNameNS(W_NS, "p")].find(
+    (candidate) => candidate.getAttributeNS(W14_NS, "paraId") === paraId,
+  );
+  const paragraphProperties = candidateParagraph
+    ? [...candidateParagraph.getElementsByTagNameNS(W_NS, "pPr")].at(0)
+    : undefined;
+  if (!paragraphProperties) {
+    throw new Error(`fixture paragraph ${paraId} has no properties`);
+  }
+  const tabs = doc.createElementNS(W_NS, "w:tabs");
+  const tab = doc.createElementNS(W_NS, "w:tab");
+  tab.setAttributeNS(W_NS, "w:val", "left");
+  tab.setAttributeNS(W_NS, "w:pos", "720");
+  tabs.append(tab);
+  paragraphProperties.append(tabs);
+  zip.file("word/document.xml", slimdom.serializeToWellFormedString(doc));
+  return await zip.generateAsync({ type: "arraybuffer" });
+};
+
 /** A clause, a heading, a signature label, and a signature table. */
 const buildBilingual = async () => {
   const doc = createEmptyDocument({
@@ -494,6 +523,38 @@ describe("buildOperations applied to a bilingual document", () => {
     );
     expect(rejection).toBeInstanceOf(BilingualFormattingError);
     expect(rejection).toHaveProperty("reason", "invalid-spans");
+  });
+
+  test("does not project paragraph tab stops as inline controls", async () => {
+    const doc = createEmptyDocument({
+      preset: createStellaStyleDocumentPreset(),
+    });
+    doc.package.document.content = [mixedFormattingParagraph("Clause")];
+    const bilingual = await createBilingualDocx(await createDocx(doc), {
+      targetStyleSuffix: "en",
+    });
+    const { units } = flattenBilingualRows(
+      await readBilingualDocx(bilingual.buffer),
+    );
+    const unit = units.at(0);
+    if (!unit) {
+      throw new Error("fixture has no bilingual row");
+    }
+    const buffer = await addParagraphPropertyTabStop(
+      bilingual.buffer,
+      unit.rowId,
+    );
+    const formatted = (await extractFormattedBilingualUnits(buffer, units)).at(
+      0,
+    );
+    if (!formatted) {
+      throw new Error("fixture has no formatted row");
+    }
+    expect(
+      formatted.inline.filter(
+        (token) => token.type === "control" && token.kind === "tab",
+      ),
+    ).toHaveLength(1);
   });
 
   test("only builds operations for rows present in Folio's editable snapshot", async () => {

--- a/apps/api/src/lib/bilingual/operations.test.ts
+++ b/apps/api/src/lib/bilingual/operations.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+import * as slimdom from "slimdom";
 
 import type { Paragraph } from "@stll/docx-core/model";
 import {
@@ -13,7 +15,15 @@ import {
   readBilingualDocx,
 } from "@stll/folio-core/server";
 
-import { buildOperations } from "@/api/lib/bilingual/operations";
+import {
+  applyFormattedBilingualTranslations,
+  BilingualFormattingError,
+  extractFormattedBilingualUnits,
+} from "@/api/lib/bilingual/formatting";
+import {
+  buildFormattingPreservingOperations,
+  buildOperations,
+} from "@/api/lib/bilingual/operations";
 import type { StoredRow } from "@/api/lib/bilingual/operations";
 import { flattenBilingualRows } from "@/api/lib/bilingual/rows";
 
@@ -32,6 +42,73 @@ const structuralColumnBreak = (): Paragraph => ({
     },
   ],
 });
+
+const mixedFormattingParagraph = (label: string): Paragraph => ({
+  type: "paragraph",
+  formatting: { styleId: "Normal" },
+  content: [
+    {
+      type: "run",
+      formatting: { bold: true },
+      content: [{ type: "text", text: `${label} bold` }],
+    },
+    {
+      type: "run",
+      formatting: { italic: true },
+      content: [{ type: "text", text: " italic" }, { type: "tab" }],
+    },
+    {
+      type: "run",
+      formatting: {
+        highlight: "yellow",
+        underline: { style: "single" },
+      },
+      content: [
+        { type: "text", text: " underlined" },
+        { type: "break", breakType: "textWrapping" },
+        { type: "symbol", font: "Wingdings", char: "F0FC" },
+      ],
+    },
+    {
+      type: "run",
+      content: [
+        { type: "fieldChar", charType: "begin" },
+        { type: "instrText", text: " PAGE " },
+        { type: "fieldChar", charType: "separate" },
+        { type: "text", text: "1" },
+        { type: "fieldChar", charType: "end" },
+      ],
+    },
+  ],
+});
+
+const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+const W14_NS = "http://schemas.microsoft.com/office/word/2010/wordml";
+
+const paragraphSignature = async (
+  buffer: ArrayBuffer,
+  paraId: string,
+): Promise<string> => {
+  const zip = await JSZip.loadAsync(buffer);
+  const xml = await zip.file("word/document.xml")?.async("string");
+  if (!xml) {
+    throw new Error("fixture has no document part");
+  }
+  const doc = slimdom.parseXmlDocument(xml);
+  const candidateParagraph = [...doc.getElementsByTagNameNS(W_NS, "p")].find(
+    (candidate) => candidate.getAttributeNS(W14_NS, "paraId") === paraId,
+  );
+  if (!candidateParagraph) {
+    throw new Error(`fixture has no paragraph ${paraId}`);
+  }
+  return [...candidateParagraph.childNodes]
+    .filter((child) => child.nodeType === child.ELEMENT_NODE)
+    .map((child) => slimdom.serializeToWellFormedString(child))
+    .join("");
+};
+
+const wordElementCount = (xml: string, localName: string): number =>
+  [...xml.matchAll(new RegExp(`<w:${localName}(?:\\s|/|>)`, "gu"))].length;
 
 /** A clause, a heading, a signature label, and a signature table. */
 const buildBilingual = async () => {
@@ -158,6 +235,221 @@ describe("buildOperations applied to a bilingual document", () => {
     expect(
       buildOperations([{ ...row, disposition: "translate" }], new Map()),
     ).toEqual([]);
+  });
+
+  test("preserves mixed inline formatting and controls in translated and inline rows", async () => {
+    const doc = createEmptyDocument({
+      preset: createStellaStyleDocumentPreset(),
+    });
+    doc.package.document.content = [
+      mixedFormattingParagraph("Clause"),
+      mixedFormattingParagraph("Signature"),
+      {
+        type: "table",
+        rows: [
+          {
+            type: "tableRow",
+            cells: [
+              {
+                type: "tableCell",
+                content: [mixedFormattingParagraph("Name")],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const { buffer } = await createBilingualDocx(await createDocx(doc), {
+      targetStyleSuffix: "en",
+    });
+    const { units } = flattenBilingualRows(await readBilingualDocx(buffer));
+    const clause = units.at(0);
+    const signature = units.at(1);
+    const tableLabel = units.at(2);
+    if (
+      !clause ||
+      !signature ||
+      !tableLabel ||
+      signature.sourceParaId === null
+    ) {
+      throw new Error("fixture bilingual rows are incomplete");
+    }
+    const rows: StoredRow[] = [
+      {
+        ...clause,
+        disposition: "translate",
+        status: "translated",
+        targetText: "Clause translated",
+      },
+      {
+        ...signature,
+        disposition: "inline",
+        status: "translated",
+        targetText: "Signature translated",
+      },
+      {
+        ...tableLabel,
+        disposition: "inline",
+        status: "translated",
+        targetText: "Name translated",
+      },
+    ];
+    const plainTranslations = new Map([
+      [clause.rowId, "Clause translated"],
+      [signature.rowId, "Signature translated"],
+      [tableLabel.rowId, "Name translated"],
+    ]);
+    const legacy = await applyFolioAIEditsToBuffer(
+      buffer,
+      buildOperations(rows, plainTranslations),
+      { author: "test", mode: "direct" },
+    );
+    const legacyTargetSignature = await paragraphSignature(
+      legacy.buffer,
+      clause.rowId,
+    );
+    // Fault-boundary assertion: the old plain replaceBlock path reaches this
+    // fixture and loses the tab attached to the italic source run.
+    expect(legacyTargetSignature).not.toContain("<w:tab");
+
+    const formatted = await extractFormattedBilingualUnits(buffer, units);
+    const richTranslations = new Map(
+      formatted.map((unit) => [
+        unit.rowId,
+        {
+          text: unit.spans.map((_, index) => `translated-${index}`).join(""),
+          spans: unit.spans.map(({ id }, index) => ({
+            id,
+            text: `translated-${index}`,
+          })),
+        },
+      ]),
+    );
+    const formattedBuffer = await applyFormattedBilingualTranslations(
+      buffer,
+      rows,
+      richTranslations,
+    );
+    const applied = await applyFolioAIEditsToBuffer(
+      formattedBuffer,
+      buildFormattingPreservingOperations(
+        rows,
+        new Set(richTranslations.keys()),
+      ),
+      { author: "test", mode: "direct" },
+    );
+
+    const sourceClauseSignature = await paragraphSignature(
+      buffer,
+      clause.sourceParaId ?? "",
+    );
+    const sourceInlineSignature = await paragraphSignature(
+      buffer,
+      signature.sourceParaId,
+    );
+    const sourceTableSignature = await paragraphSignature(
+      buffer,
+      tableLabel.rowId,
+    );
+    const targetClauseSignature = await paragraphSignature(
+      applied.buffer,
+      clause.rowId,
+    );
+    expect(targetClauseSignature).toContain("<w:b");
+    expect(targetClauseSignature).toContain("<w:i");
+    expect(targetClauseSignature).toContain("<w:u");
+    expect(targetClauseSignature).toContain("<w:highlight");
+    expect(targetClauseSignature).toContain("<w:tab");
+    expect(targetClauseSignature).toContain("<w:br");
+    expect(targetClauseSignature).toContain("<w:sym");
+    expect(targetClauseSignature).toContain("<w:fldChar");
+    expect(wordElementCount(targetClauseSignature, "tab")).toBe(1);
+    expect(wordElementCount(targetClauseSignature, "fldChar")).toBe(3);
+    expect(sourceClauseSignature).toContain("<w:b");
+    const inlineSignature = await paragraphSignature(
+      applied.buffer,
+      signature.sourceParaId,
+    );
+    expect(inlineSignature).toContain("<w:b");
+    expect(inlineSignature).toContain("<w:i");
+    expect(inlineSignature).toContain("<w:u");
+    expect(inlineSignature).toContain("<w:highlight");
+    expect(inlineSignature).toContain("<w:tab");
+    expect(inlineSignature).toContain("<w:br");
+    expect(inlineSignature).toContain("<w:sym");
+    expect(inlineSignature).toContain("<w:fldChar");
+    // One complete source sequence plus one translated clone: the inline
+    // merge must retain both halves instead of flattening the source.
+    for (const localName of ["b", "i", "u", "highlight"]) {
+      expect(
+        wordElementCount(inlineSignature, localName),
+      ).toBeGreaterThanOrEqual(2);
+    }
+    for (const localName of ["tab", "br", "sym", "fldChar"]) {
+      expect(wordElementCount(inlineSignature, localName)).toBe(
+        wordElementCount(sourceInlineSignature, localName) * 2,
+      );
+    }
+    const tableInlineSignature = await paragraphSignature(
+      applied.buffer,
+      tableLabel.rowId,
+    );
+    for (const localName of ["b", "i", "u", "highlight"]) {
+      expect(
+        wordElementCount(tableInlineSignature, localName),
+      ).toBeGreaterThanOrEqual(2);
+    }
+    for (const localName of ["tab", "br", "sym", "fldChar"]) {
+      expect(wordElementCount(tableInlineSignature, localName)).toBe(
+        wordElementCount(sourceTableSignature, localName) * 2,
+      );
+    }
+  });
+
+  test("rejects a reordered formatted translation span contract", async () => {
+    const doc = createEmptyDocument({
+      preset: createStellaStyleDocumentPreset(),
+    });
+    doc.package.document.content = [mixedFormattingParagraph("Clause")];
+    const { buffer } = await createBilingualDocx(await createDocx(doc), {
+      targetStyleSuffix: "en",
+    });
+    const { units } = flattenBilingualRows(await readBilingualDocx(buffer));
+    const unit = units.at(0);
+    if (!unit) {
+      throw new Error("fixture has no bilingual row");
+    }
+    const formatted = (await extractFormattedBilingualUnits(buffer, units)).at(
+      0,
+    );
+    if (!formatted) {
+      throw new Error("fixture has no formatted row");
+    }
+    expect(formatted.spans.length).toBeGreaterThan(1);
+    const row: StoredRow = {
+      ...unit,
+      disposition: "translate",
+      status: "translated",
+      targetText: "translated",
+    };
+    const rejection = await applyFormattedBilingualTranslations(
+      buffer,
+      [row],
+      new Map([
+        [
+          row.rowId,
+          {
+            text: "translated",
+            spans: formatted.spans.toReversed(),
+          },
+        ],
+      ]),
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(rejection).toBeInstanceOf(BilingualFormattingError);
+    expect(rejection).toHaveProperty("reason", "invalid-spans");
   });
 
   test("only builds operations for rows present in Folio's editable snapshot", async () => {

--- a/apps/api/src/lib/bilingual/operations.ts
+++ b/apps/api/src/lib/bilingual/operations.ts
@@ -100,3 +100,40 @@ export const buildOperations = (
   }
   return operations;
 };
+
+/**
+ * Structural edits used after formatted translations have already been
+ * written into cloned runs. Text edits are deliberately absent: a Folio
+ * `replaceBlock` accepts plain text and cannot retain mixed run formatting.
+ */
+export const buildFormattingPreservingOperations = (
+  rows: readonly StoredRow[],
+  translatedRowIds: ReadonlySet<string>,
+): FolioAIEditOperation[] => {
+  const operations: FolioAIEditOperation[] = [];
+  let sequence = 0;
+  const nextId = (): string => {
+    sequence += 1;
+    return `bilingual-structure-${sequence}`;
+  };
+  for (const row of rows) {
+    if (row.inTable || row.sourceParaId === null) {
+      continue;
+    }
+    const shouldMerge =
+      row.disposition === BILINGUAL_ROW_DISPOSITION.KEEP ||
+      (row.disposition === BILINGUAL_ROW_DISPOSITION.INLINE &&
+        translatedRowIds.has(row.rowId));
+    if (!shouldMerge) {
+      continue;
+    }
+    operations.push({
+      id: nextId(),
+      type: "mergeTableCells",
+      blockId: row.sourceParaId,
+      endBlockId: row.rowId,
+    });
+    operations.push({ id: nextId(), type: "deleteBlock", blockId: row.rowId });
+  }
+  return operations;
+};

--- a/apps/api/src/lib/document-translation/run-queue.ts
+++ b/apps/api/src/lib/document-translation/run-queue.ts
@@ -26,7 +26,7 @@ import { createAuditRecorder } from "@/api/lib/audit-log";
 import {
   decideDispositions,
   proposeGlossary,
-  translateBatch,
+  translateFormattedBatch,
 } from "@/api/lib/bilingual/ai";
 import type {
   BilingualAIContext,
@@ -36,7 +36,15 @@ import {
   BILINGUAL_LIMITS,
   BILINGUAL_ROW_DISPOSITION,
 } from "@/api/lib/bilingual/contract";
-import { buildOperations } from "@/api/lib/bilingual/operations";
+import {
+  applyFormattedBilingualTranslations,
+  extractFormattedBilingualUnits,
+} from "@/api/lib/bilingual/formatting";
+import type {
+  BilingualFormattedTranslation,
+  FormattedBilingualUnit,
+} from "@/api/lib/bilingual/formatting";
+import { buildFormattingPreservingOperations } from "@/api/lib/bilingual/operations";
 import type { StoredRow } from "@/api/lib/bilingual/operations";
 import {
   detectGlossaryCandidates,
@@ -838,15 +846,23 @@ const translateBilingualWithAI = async (
   ) {
     return Result.err("unsupported_format");
   }
+  const formatted = await Result.tryPromise({
+    try: async () =>
+      await extractFormattedBilingualUnits(conversion.value.buffer, units),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(formatted)) {
+    return Result.err("unsupported_format");
+  }
   const languages = {
     sourceLang: run.sourceLang,
     targetLang: run.targetLang,
   };
-  const texts = units.map((unit) => unit.sourceText);
+  const texts = formatted.value.map((unit) => unit.sourceText);
   const prepared = await Result.tryPromise({
     try: async () => {
       const [rows, glossary] = await Promise.all([
-        decideDispositions(units, languages, context),
+        decideDispositions(formatted.value, languages, context),
         proposeGlossary(
           detectGlossaryCandidates(texts),
           texts,
@@ -896,6 +912,13 @@ const translateBilingualWithAI = async (
   await setTotal(actor, pending.length);
 
   const translated = new Map<string, string>();
+  const formattedTranslations = new Map<
+    string,
+    BilingualFormattedTranslation
+  >();
+  const formattedByRowId = new Map(
+    formatted.value.map((unit) => [unit.rowId, unit]),
+  );
   const translateNextBatch = async (
     index: number,
   ): Promise<Result<void, DocumentTranslationRunErrorCode>> => {
@@ -918,10 +941,22 @@ const translateBilingualWithAI = async (
         sourceText: row.sourceText,
         targetText: translated.get(row.rowId) ?? null,
       }));
+    const formattedBatch: FormattedBilingualUnit[] = [];
+    for (const row of batch) {
+      const formattedUnit = formattedByRowId.get(row.rowId);
+      if (!formattedUnit) {
+        return Result.err("translation_failed");
+      }
+      formattedBatch.push(formattedUnit);
+    }
     const result = await Result.tryPromise({
       try: async () =>
-        await translateBatch(
-          { batch, preceding, glossary: prepared.value.glossary },
+        await translateFormattedBatch(
+          {
+            batch: formattedBatch,
+            preceding,
+            glossary: prepared.value.glossary,
+          },
           languages,
           context,
         ),
@@ -932,11 +967,13 @@ const translateBilingualWithAI = async (
     }
     const updates: { unitKey: string; targetText: string }[] = [];
     for (const row of batch) {
-      const targetText = result.value.get(row.ordinal);
-      if (targetText === undefined) {
+      const formattedTranslation = result.value.get(row.ordinal);
+      if (formattedTranslation === undefined) {
         return Result.err("translation_failed");
       }
+      const targetText = formattedTranslation.text;
       translated.set(row.rowId, targetText);
+      formattedTranslations.set(row.rowId, formattedTranslation);
       updates.push({ unitKey: row.rowId, targetText });
     }
     await updateTranslatedUnits(actor, updates);
@@ -950,10 +987,26 @@ const translateBilingualWithAI = async (
   if (!(await transitionStage(actor, "translating", "assembling"))) {
     return Result.err("internal");
   }
-  const operations = buildOperations(rows, translated);
+  const formattedBuffer = await Result.tryPromise({
+    try: async () =>
+      await applyFormattedBilingualTranslations(
+        conversion.value.buffer,
+        rows,
+        formattedTranslations,
+      ),
+    catch: (cause) => cause,
+  });
+  if (Result.isError(formattedBuffer)) {
+    captureError(formattedBuffer.error, { runId: actor.runId });
+    return Result.err("format_validation_failed");
+  }
+  const operations = buildFormattingPreservingOperations(
+    rows,
+    new Set(formattedTranslations.keys()),
+  );
   const applied = await Result.tryPromise({
     try: async () =>
-      await applyFolioAIEditsToBuffer(conversion.value.buffer, operations, {
+      await applyFolioAIEditsToBuffer(formattedBuffer.value, operations, {
         author: "Stella",
         mode: "direct",
       }),


### PR DESCRIPTION
## Summary

- preserve run-level formatting and inline controls in AI bilingual translations
- validate ordered translation spans before applying them to cloned DOCX runs
- retain source formatting when inline bilingual rows and table labels are merged

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added formatting-preserving bilingual document translation.
  - Preserves styled text, inline controls, tables, fields, breaks and other document formatting.
  - Supports inline translated content while retaining the original document structure.

- **Bug Fixes**
  - Rejects invalid or malformed translation spans before applying changes.
  - Automatically retries translations that do not follow the required formatting structure.

- **Tests**
  - Added coverage for formatting preservation, inline merging, validation errors and oversized translation inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->