### PR TITLE
fix(api): summarise provider preflight rejections in the canary

### DIFF
--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -832,3 +832,35 @@ describe("AI provider weekly tool execution contract", () => {
     }
   });
 });
+
+describe("AI provider canary provider rejections", () => {
+  const signal = new AbortController().signal;
+  // Shapes the shared generate path produces from a Bedrock RUN_ERROR.
+  const limit = {
+    message:
+      "The maximum tokens you requested exceeds the model limit of 10000. Try again with a maximum tokens value that is lower than 10000.",
+    status: 502,
+  };
+  const access = {
+    message:
+      "Model access is denied due to IAM user or service role is not authorized to perform the required operation.",
+    status: 502,
+  };
+
+  test("summarises a wrapped preflight rejection with a fixed phrase", () => {
+    expect(errorSummary(limit, signal)).toBe(
+      "provider rejected request (output ceiling above model limit)",
+    );
+    expect(errorSummary(access, signal)).toBe(
+      "provider rejected request (model access denied)",
+    );
+    expect(errorSummary({ error: limit }, signal)).toBe(
+      "provider rejected request (output ceiling above model limit)",
+    );
+  });
+
+  test("does not retry a preflight rejection", () => {
+    expect(isRetryableCanaryError(limit, signal)).toBe(false);
+    expect(isRetryableCanaryError(access, signal)).toBe(false);
+  });
+});

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -863,4 +863,15 @@ describe("AI provider canary provider rejections", () => {
     expect(isRetryableCanaryError(limit, signal)).toBe(false);
     expect(isRetryableCanaryError(access, signal)).toBe(false);
   });
+
+  test("keeps the reason on a streamed run error from a tool probe", () => {
+    const streamed = new CanaryProviderRunError(
+      { error: limit, message: limit.message },
+      "before-tool-call",
+    );
+    expect(errorSummary(streamed, signal)).toBe(
+      "provider rejected request (output ceiling above model limit)",
+    );
+    expect(isRetryableCanaryError(streamed, signal)).toBe(false);
+  });
 });

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -475,6 +475,59 @@ const credentialRejectionSignature = (
   return null;
 };
 
+// Provider preflight rejections are deterministic for the request shape, so
+// retrying is waste, and the shared generate path wraps them in a 502 whose
+// status says nothing about the cause. Each signature is matched
+// case-insensitively against the message on the error chain and summarised
+// with a fixed phrase; the provider's own text never reaches the log.
+const PROVIDER_REJECTION_SIGNATURES = [
+  ["exceeds the model limit", "output ceiling above model limit"], // bedrock-converse
+  ["model access is denied", "model access denied"], // bedrock-converse
+] as const;
+type ProviderRejectionReason =
+  (typeof PROVIDER_REJECTION_SIGNATURES)[number][1];
+
+const providerRejectionSignature = (
+  value: unknown,
+): ProviderRejectionReason | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = value.toLowerCase();
+  return (
+    PROVIDER_REJECTION_SIGNATURES.find(([signature]) =>
+      normalized.includes(signature),
+    )?.[1] ?? null
+  );
+};
+
+export const providerRejectionReason = (
+  error: unknown,
+  depth = 0,
+): ProviderRejectionReason | null => {
+  const direct = providerRejectionSignature(error);
+  if (direct !== null) {
+    return direct;
+  }
+  if (!isRecord(error)) {
+    return null;
+  }
+  const message = providerRejectionSignature(error["message"]);
+  if (message !== null) {
+    return message;
+  }
+  if (depth >= 3) {
+    return null;
+  }
+  for (const key of PROVIDER_ERROR_NESTED_KEYS) {
+    const nested = providerRejectionReason(error[key], depth + 1);
+    if (nested !== null) {
+      return nested;
+    }
+  }
+  return null;
+};
+
 const credentialRejectionStatus = (
   status: number | null,
 ): CredentialRejectionReason | null => {
@@ -553,6 +606,11 @@ export const isRetryableCanaryError = (
 
   // A rejected credential fails every remaining attempt identically.
   if (classifyCanaryFailure(error).kind === "credential-rejected") {
+    return false;
+  }
+
+  // So does a preflight rejection of the request shape.
+  if (providerRejectionReason(error) !== null) {
     return false;
   }
 
@@ -1340,6 +1398,11 @@ export const errorSummary = (error: unknown, signal: AbortSignal): string => {
 
   if (classifyCanaryFailure(error).kind === "credential-rejected") {
     return "credential rejected";
+  }
+
+  const rejection = providerRejectionReason(error);
+  if (rejection !== null) {
+    return `provider rejected request (${rejection})`;
   }
 
   if (error instanceof CanaryProviderRunError) {

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -505,6 +505,9 @@ export const providerRejectionReason = (
   error: unknown,
   depth = 0,
 ): ProviderRejectionReason | null => {
+  if (error instanceof CanaryProviderRunError) {
+    return error.rejectionReason;
+  }
   const direct = providerRejectionSignature(error);
   if (direct !== null) {
     return direct;
@@ -553,6 +556,7 @@ export class CanaryProviderRunError extends TypeError {
   readonly code: string | null;
   readonly failure: CanaryFailure;
   readonly incompleteReason: string | null;
+  readonly rejectionReason: ProviderRejectionReason | null;
   readonly retryCode: string | null;
   readonly retryable: boolean | null;
   readonly stage: CanaryRunStage;
@@ -567,6 +571,7 @@ export class CanaryProviderRunError extends TypeError {
     this.code = safeProviderCode(this.retryCode);
     this.failure = canaryEventFailure(event);
     this.incompleteReason = safeIncompleteReason(event);
+    this.rejectionReason = providerRejectionReason(event);
     this.stage = stage;
     this.status = providerStatus(event);
     this.terminalCode = terminalProviderCode(event);


### PR DESCRIPTION
The shared generate path wraps a provider RUN_ERROR in a 502, so the canary summarised the weekly Bedrock failures as `provider HTTP 502` and retried them, while the real cause (`The maximum tokens you requested exceeds the model limit of 10000`, `Model access is denied due to IAM user or service role is not authorized`) only appeared in the adapter's fatal dump above the probe line (https://github.com/stella/stella/actions/runs/32686937091, https://github.com/stella/stella/actions/runs/31353899752).

Add an allowlist of provider preflight rejection signatures, matched on the error chain the way credential rejections are, that summarise as a fixed phrase (`provider rejected request (output ceiling above model limit)`, `(model access denied)`) and are not retried, since the request shape is what the provider refuses.

https://claude.ai/code/session_01NMnG9ntKwemcJMgkMB7k5v