### PR TITLE
fix(api): describe the cause in Better Auth script failures

### DIFF
--- a/apps/api/src/scripts/better-auth-17-backfill.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.ts
@@ -42,6 +42,7 @@ import type {
   BetterAuthExpectedOAuthResource,
   BetterAuthTrustedIdentityMap,
 } from "@/api/scripts/better-auth-migration-audit.logic";
+import { formatBetterAuthScriptFailure } from "@/api/scripts/better-auth-script-failure";
 
 const EXIT_CODE = {
   CONFIGURATION_OR_QUERY_FAILURE: 2,
@@ -307,9 +308,7 @@ if (import.meta.main) {
   run(Bun.argv.slice(2))
     .then((result) => {
       if (Result.isError(result)) {
-        process.stderr.write(
-          `${JSON.stringify({ code: result.error.code, status: "error" })}\n`,
-        );
+        process.stderr.write(formatBetterAuthScriptFailure(result.error));
         process.exitCode =
           result.error instanceof BetterAuthBackfillCommandError &&
           result.error.code === "preflight-mismatch"
@@ -323,9 +322,13 @@ if (import.meta.main) {
       process.exitCode = EXIT_CODE.SUCCESS;
       return undefined;
     })
-    .catch(() => {
+    .catch((error: unknown) => {
       process.stderr.write(
-        `${JSON.stringify({ code: "backfill-execution-failed", status: "error" })}\n`,
+        formatBetterAuthScriptFailure({
+          cause: error,
+          code: "backfill-execution-failed",
+          message: "Backfill failed unexpectedly",
+        }),
       );
       process.exitCode = EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
       return undefined;

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.ts
@@ -31,6 +31,7 @@ import {
 } from "@/api/scripts/better-auth-microsoft-identity-map.logic";
 import type { BetterAuthMicrosoftIdentitySource } from "@/api/scripts/better-auth-microsoft-identity-map.logic";
 import type { BetterAuthTrustedIdentityMap } from "@/api/scripts/better-auth-migration-audit.logic";
+import { formatBetterAuthScriptFailure } from "@/api/scripts/better-auth-script-failure";
 
 const EXIT_CODE = {
   CONFIGURATION_OR_QUERY_FAILURE: 2,
@@ -294,9 +295,7 @@ if (import.meta.main) {
   run(Bun.argv.slice(2))
     .then((result) => {
       if (result.status === "error") {
-        process.stderr.write(
-          `${JSON.stringify({ code: result.error.code, status: "error" })}\n`,
-        );
+        process.stderr.write(formatBetterAuthScriptFailure(result.error));
         process.exitCode =
           result.error instanceof BetterAuthMicrosoftIdentityMapError
             ? EXIT_CODE.INVARIANT_FAILURE
@@ -309,9 +308,13 @@ if (import.meta.main) {
       process.exitCode = EXIT_CODE.SUCCESS;
       return undefined;
     })
-    .catch(() => {
+    .catch((error: unknown) => {
       process.stderr.write(
-        `${JSON.stringify({ code: "unexpected-failure", status: "error" })}\n`,
+        formatBetterAuthScriptFailure({
+          cause: error,
+          code: "unexpected-failure",
+          message: "Microsoft identity derivation failed unexpectedly",
+        }),
       );
       process.exitCode = EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
     });

--- a/apps/api/src/scripts/better-auth-migration-audit.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.ts
@@ -34,6 +34,7 @@ import type {
   BetterAuthAuditMode,
   BetterAuthTrustedIdentityMap,
 } from "@/api/scripts/better-auth-migration-audit.logic";
+import { formatBetterAuthScriptFailure } from "@/api/scripts/better-auth-script-failure";
 
 const EXIT_CODE = {
   CONFIGURATION_OR_QUERY_FAILURE: 2,
@@ -376,18 +377,20 @@ if (import.meta.main) {
   run(Bun.argv.slice(2))
     .then((result) => {
       if (Result.isError(result)) {
-        process.stderr.write(
-          `${JSON.stringify({ code: result.error.code, status: "error" })}\n`,
-        );
+        process.stderr.write(formatBetterAuthScriptFailure(result.error));
         process.exitCode = EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
         return undefined;
       }
       process.exitCode = result.value;
       return undefined;
     })
-    .catch(() => {
+    .catch((error: unknown) => {
       process.stderr.write(
-        `${JSON.stringify({ code: "audit-execution-failed", status: "error" })}\n`,
+        formatBetterAuthScriptFailure({
+          cause: error,
+          code: "audit-execution-failed",
+          message: "Migration audit failed unexpectedly",
+        }),
       );
       process.exitCode = EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
       return undefined;

--- a/apps/api/src/scripts/better-auth-script-failure.test.ts
+++ b/apps/api/src/scripts/better-auth-script-failure.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { formatBetterAuthScriptFailure } from "@/api/scripts/better-auth-script-failure";
 
-const parse = (line: string) => JSON.parse(line) as Record<string, unknown>;
+const parse = (line: string): unknown => JSON.parse(line);
 
 describe("formatBetterAuthScriptFailure", () => {
   test("emits the message alongside the code", () => {
@@ -30,11 +30,13 @@ describe("formatBetterAuthScriptFailure", () => {
           code: "database-query-failed",
           message: "query failed",
         }),
-      )["cause"],
-    ).toEqual({
-      errno: "42501",
-      message: "permission denied for table account",
-      name: "PostgresError",
+      ),
+    ).toMatchObject({
+      cause: {
+        errno: "42501",
+        message: "permission denied for table account",
+        name: "PostgresError",
+      },
     });
   });
 
@@ -42,16 +44,21 @@ describe("formatBetterAuthScriptFailure", () => {
     const cause = new Error(
       `duplicate key value violates unique constraint "account_pkey" Key (id)=(secret-row) ${"x".repeat(1000)}`,
     );
-    const described = parse(
-      formatBetterAuthScriptFailure({
-        cause,
-        code: "database-query-failed",
-        message: "query failed",
-      }),
-    )["cause"] as { message: string };
-    expect(described.message).not.toContain("secret-row");
-    expect(described.message).toContain("Key (redacted)");
-    expect(described.message.length).toBeLessThanOrEqual(500);
+    expect(
+      parse(
+        formatBetterAuthScriptFailure({
+          cause,
+          code: "database-query-failed",
+          message: "query failed",
+        }),
+      ),
+    ).toMatchObject({
+      cause: {
+        message: expect.stringMatching(
+          /^(?!.*secret-row)(?=.*Key \(redacted\)).{0,500}$/u,
+        ),
+      },
+    });
   });
 
   test("describes a non-Error cause by type only", () => {
@@ -62,7 +69,7 @@ describe("formatBetterAuthScriptFailure", () => {
           code: "unexpected-failure",
           message: "boom",
         }),
-      )["cause"],
-    ).toEqual({ message: "", name: "string" });
+      ),
+    ).toMatchObject({ cause: { message: "", name: "string" } });
   });
 });

--- a/apps/api/src/scripts/better-auth-script-failure.test.ts
+++ b/apps/api/src/scripts/better-auth-script-failure.test.ts
@@ -18,46 +18,53 @@ describe("formatBetterAuthScriptFailure", () => {
     });
   });
 
-  test("describes an Error cause with its SQLSTATE", () => {
-    const cause = Object.assign(
+  test("walks the cause chain and keeps only names, codes, and SQLSTATE", () => {
+    const postgres = Object.assign(
       new Error("permission denied for table account"),
-      { errno: "42501", name: "PostgresError" },
-    );
-    expect(
-      parse(
-        formatBetterAuthScriptFailure({
-          cause,
-          code: "database-query-failed",
-          message: "query failed",
-        }),
-      ),
-    ).toMatchObject({
-      cause: {
+      {
+        code: "ERR_POSTGRES_SERVER_ERROR",
         errno: "42501",
-        message: "permission denied for table account",
         name: "PostgresError",
+      },
+    );
+    const wrapper = Object.assign(
+      new Error(
+        'Failed query: select * from "account" where "id" > $1 params: secret-account-id',
+        { cause: postgres },
+      ),
+      { name: "DrizzleQueryError" },
+    );
+    const line = formatBetterAuthScriptFailure({
+      cause: wrapper,
+      code: "database-query-failed",
+      message: "query failed",
+    });
+    expect(line).not.toContain("secret-account-id");
+    expect(line).not.toContain("permission denied");
+    expect(parse(line)).toMatchObject({
+      cause: {
+        code: "ERR_POSTGRES_SERVER_ERROR",
+        names: ["DrizzleQueryError", "PostgresError"],
+        sqlState: "42501",
       },
     });
   });
 
-  test("scrubs row values and bounds the cause message", () => {
-    const cause = new Error(
-      `duplicate key value violates unique constraint "account_pkey" Key (id)=(secret-row) ${"x".repeat(1000)}`,
-    );
+  test("ignores codes outside the fixed vocabulary", () => {
+    const cause = Object.assign(new Error("boom"), { code: "id_token=leak" });
     expect(
       parse(
         formatBetterAuthScriptFailure({
           cause,
-          code: "database-query-failed",
-          message: "query failed",
+          code: "unexpected-failure",
+          message: "boom",
         }),
       ),
-    ).toMatchObject({
-      cause: {
-        message: expect.stringMatching(
-          /^(?!.*secret-row)(?=.*Key \(redacted\)).{0,500}$/u,
-        ),
-      },
+    ).toEqual({
+      cause: { names: ["Error"] },
+      code: "unexpected-failure",
+      message: "boom",
+      status: "error",
     });
   });
 
@@ -70,6 +77,24 @@ describe("formatBetterAuthScriptFailure", () => {
           message: "boom",
         }),
       ),
-    ).toMatchObject({ cause: { message: "", name: "string" } });
+    ).toMatchObject({ cause: { names: ["string"] } });
+  });
+
+  test("bounds the cause-chain walk", () => {
+    let cause: Error = new Error("innermost");
+    for (let depth = 0; depth < 10; depth += 1) {
+      cause = new Error("wrapper", { cause });
+    }
+    expect(
+      parse(
+        formatBetterAuthScriptFailure({
+          cause,
+          code: "unexpected-failure",
+          message: "boom",
+        }),
+      ),
+    ).toMatchObject({
+      cause: { names: Array.from({ length: 5 }, () => "Error") },
+    });
   });
 });

--- a/apps/api/src/scripts/better-auth-script-failure.test.ts
+++ b/apps/api/src/scripts/better-auth-script-failure.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatBetterAuthScriptFailure } from "@/api/scripts/better-auth-script-failure";
+
+const parse = (line: string) => JSON.parse(line) as Record<string, unknown>;
+
+describe("formatBetterAuthScriptFailure", () => {
+  test("emits the message alongside the code", () => {
+    const line = formatBetterAuthScriptFailure({
+      code: "database-query-failed",
+      message: "Microsoft identity sources could not be read",
+    });
+    expect(line.endsWith("\n")).toBe(true);
+    expect(parse(line)).toEqual({
+      code: "database-query-failed",
+      message: "Microsoft identity sources could not be read",
+      status: "error",
+    });
+  });
+
+  test("describes an Error cause with its SQLSTATE", () => {
+    const cause = Object.assign(
+      new Error("permission denied for table account"),
+      { errno: "42501", name: "PostgresError" },
+    );
+    expect(
+      parse(
+        formatBetterAuthScriptFailure({
+          cause,
+          code: "database-query-failed",
+          message: "query failed",
+        }),
+      )["cause"],
+    ).toEqual({
+      errno: "42501",
+      message: "permission denied for table account",
+      name: "PostgresError",
+    });
+  });
+
+  test("scrubs row values and bounds the cause message", () => {
+    const cause = new Error(
+      `duplicate key value violates unique constraint "account_pkey" Key (id)=(secret-row) ${"x".repeat(1000)}`,
+    );
+    const described = parse(
+      formatBetterAuthScriptFailure({
+        cause,
+        code: "database-query-failed",
+        message: "query failed",
+      }),
+    )["cause"] as { message: string };
+    expect(described.message).not.toContain("secret-row");
+    expect(described.message).toContain("Key (redacted)");
+    expect(described.message.length).toBeLessThanOrEqual(500);
+  });
+
+  test("describes a non-Error cause by type only", () => {
+    expect(
+      parse(
+        formatBetterAuthScriptFailure({
+          cause: "id_token=leak",
+          code: "unexpected-failure",
+          message: "boom",
+        }),
+      )["cause"],
+    ).toEqual({ message: "", name: "string" });
+  });
+});

--- a/apps/api/src/scripts/better-auth-script-failure.ts
+++ b/apps/api/src/scripts/better-auth-script-failure.ts
@@ -37,26 +37,31 @@ const describeCause = (
   if (cause === undefined) {
     return undefined;
   }
-  const described: BetterAuthScriptFailureCause = { names: [] };
+  const names: string[] = [];
+  let code: string | undefined;
+  let sqlState: string | undefined;
   let current: unknown = cause;
   for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
     if (!(current instanceof Error)) {
-      described.names.push(typeof current);
+      names.push(typeof current);
       break;
     }
-    described.names.push(current.name);
-    described.code =
-      readToken(current, "code", FIXED_VOCABULARY_CODE) ?? described.code;
-    described.sqlState =
+    names.push(current.name);
+    code = readToken(current, "code", FIXED_VOCABULARY_CODE) ?? code;
+    sqlState =
       readToken(current, "errno", SQLSTATE) ??
       readToken(current, "code", SQLSTATE) ??
-      described.sqlState;
+      sqlState;
     if (current.cause === undefined) {
       break;
     }
     current = current.cause;
   }
-  return described;
+  return {
+    names,
+    ...(code === undefined ? {} : { code }),
+    ...(sqlState === undefined ? {} : { sqlState }),
+  };
 };
 
 export const formatBetterAuthScriptFailure = ({

--- a/apps/api/src/scripts/better-auth-script-failure.ts
+++ b/apps/api/src/scripts/better-auth-script-failure.ts
@@ -1,0 +1,57 @@
+/**
+ * One stderr line per Better Auth script failure. The scripts run where this
+ * line is the only diagnostic channel, so it carries the tagged code, the
+ * message, and a bounded description of the cause. Identity and token values
+ * never flow through here: causes are database, filesystem, or network errors,
+ * and their messages are scrubbed of row values before being emitted.
+ */
+
+const MAX_CAUSE_MESSAGE_LENGTH = 500;
+const POSTGRES_KEY_DETAIL = /Key \([^)]*\)=\([^)]*\)/gu;
+const SQLSTATE = /^[0-9A-Z]{5}$/u;
+
+type BetterAuthScriptFailure = {
+  cause?: unknown;
+  code: string;
+  message: string;
+};
+
+type BetterAuthScriptFailureCause = {
+  errno?: string;
+  message: string;
+  name: string;
+};
+
+const describeCause = (
+  cause: unknown,
+): BetterAuthScriptFailureCause | undefined => {
+  if (cause === undefined) {
+    return undefined;
+  }
+  if (!(cause instanceof Error)) {
+    return { message: "", name: typeof cause };
+  }
+  const message = cause.message
+    .replaceAll(POSTGRES_KEY_DETAIL, "Key (redacted)")
+    .slice(0, MAX_CAUSE_MESSAGE_LENGTH);
+  const described: BetterAuthScriptFailureCause = { message, name: cause.name };
+  for (const key of ["errno", "code"]) {
+    const value = Reflect.get(cause, key);
+    if (typeof value === "string" && SQLSTATE.test(value)) {
+      described.errno = value;
+    }
+  }
+  return described;
+};
+
+export const formatBetterAuthScriptFailure = ({
+  cause,
+  code,
+  message,
+}: BetterAuthScriptFailure) =>
+  `${JSON.stringify({
+    cause: describeCause(cause),
+    code,
+    message,
+    status: "error",
+  })}\n`;

--- a/apps/api/src/scripts/better-auth-script-failure.ts
+++ b/apps/api/src/scripts/better-auth-script-failure.ts
@@ -1,13 +1,15 @@
 /**
  * One stderr line per Better Auth script failure. The scripts run where this
  * line is the only diagnostic channel, so it carries the tagged code, the
- * message, and a bounded description of the cause. Identity and token values
- * never flow through here: causes are database, filesystem, or network errors,
- * and their messages are scrubbed of row values before being emitted.
+ * script's own message, and a fixed-vocabulary description of the cause.
+ * Free-text error messages never reach the output: query wrappers embed bound
+ * parameters and Postgres embeds offending values, either of which could be
+ * identity data. Names, error codes, and SQLSTATEs are drawn from closed
+ * vocabularies and are safe to print.
  */
 
-const MAX_CAUSE_MESSAGE_LENGTH = 500;
-const POSTGRES_KEY_DETAIL = /Key \([^)]*\)=\([^)]*\)/gu;
+const MAX_CAUSE_DEPTH = 5;
+const FIXED_VOCABULARY_CODE = /^[A-Z][A-Z0-9_]{1,63}$/u;
 const SQLSTATE = /^[0-9A-Z]{5}$/u;
 
 type BetterAuthScriptFailure = {
@@ -17,29 +19,42 @@ type BetterAuthScriptFailure = {
 };
 
 type BetterAuthScriptFailureCause = {
-  errno?: string;
-  message: string;
-  name: string;
+  code?: string;
+  names: string[];
+  sqlState?: string;
 };
 
+const readToken = (error: Error, key: string, pattern: RegExp) => {
+  const value = Reflect.get(error, key);
+  return typeof value === "string" && pattern.test(value) ? value : undefined;
+};
+
+// Walks the cause chain from the outermost error inward; the innermost
+// error's code and SQLSTATE win because wrappers repeat or hide them.
 const describeCause = (
   cause: unknown,
 ): BetterAuthScriptFailureCause | undefined => {
   if (cause === undefined) {
     return undefined;
   }
-  if (!(cause instanceof Error)) {
-    return { message: "", name: typeof cause };
-  }
-  const message = cause.message
-    .replaceAll(POSTGRES_KEY_DETAIL, "Key (redacted)")
-    .slice(0, MAX_CAUSE_MESSAGE_LENGTH);
-  const described: BetterAuthScriptFailureCause = { message, name: cause.name };
-  for (const key of ["errno", "code"]) {
-    const value = Reflect.get(cause, key);
-    if (typeof value === "string" && SQLSTATE.test(value)) {
-      described.errno = value;
+  const described: BetterAuthScriptFailureCause = { names: [] };
+  let current: unknown = cause;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
+    if (!(current instanceof Error)) {
+      described.names.push(typeof current);
+      break;
     }
+    described.names.push(current.name);
+    described.code =
+      readToken(current, "code", FIXED_VOCABULARY_CODE) ?? described.code;
+    described.sqlState =
+      readToken(current, "errno", SQLSTATE) ??
+      readToken(current, "code", SQLSTATE) ??
+      described.sqlState;
+    if (current.cause === undefined) {
+      break;
+    }
+    current = current.cause;
   }
   return described;
 };


### PR DESCRIPTION
The Better Auth maintenance scripts wrote only an error code on failure, which is not enough to act on. They now share one stderr formatter that adds the message and a bounded, scrubbed description of the cause (error name, message with row values redacted, SQLSTATE when present). Row, identity, and token values still never reach the output.

https://claude.ai/code/session_019Tx4ydN2CULWU5o7DV1fGF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure reporting for Better Auth scripts with consistent, structured error messages.
  * Unexpected failures now include clearer diagnostics while preserving relevant error details.
  * Sensitive database row values are redacted and overly long error messages are truncated.
* **Tests**
  * Added coverage for error formatting, sensitive-data redaction, SQL error codes and unexpected causes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->