### PR TITLE
feat(ui): support sortable virtual Kanban cells

### DIFF
--- a/.changeset/virtual-kanban-sortable-context.md
+++ b/.changeset/virtual-kanban-sortable-context.md
@@ -2,4 +2,4 @@
 "@stll/ui": minor
 ---
 
-Let virtual Kanban cells own their sortable context and use cross-cell collision defaults for board drag interactions.
+Let virtual Kanban cells own typed scroll-element drop targets and their sortable context. Add two-axis keyboard navigation, explicit item or handle activation, outside-board cancellation, overlay stacking, and pointer/touch auto-scroll defaults.

--- a/.changeset/virtual-kanban-sortable-context.md
+++ b/.changeset/virtual-kanban-sortable-context.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": minor
+---
+
+Let virtual Kanban cells own their sortable context and use cross-cell collision defaults for board drag interactions.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -194,6 +194,9 @@ vertical scroll container.
 />
 ```
 
+Use `useKanbanDropTarget` for an empty cell or terminal board destination.
+This keeps board presentation code independent of the underlying drag library.
+
 ## Styles
 
 No compiled CSS ships. The components carry Tailwind class names, so the

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -179,6 +179,21 @@ const matrix = buildKanbanBoardMatrix({
 />;
 ```
 
+When rows inside a virtual cell are sortable, give the cell its sortable
+identity directly. It owns the matching `SortableContext`, so the card stays a
+plain `useKanbanSortable` consumer and the virtualizer remains the only
+vertical scroll container.
+
+```tsx
+<KanbanVirtualCell
+  getRowKey={(row) => row.id}
+  pagination={{ type: "none" }}
+  renderRow={(row) => <Card row={row} />}
+  rows={cell.rows}
+  sortable={{ getRowId: (row) => row.id }}
+/>
+```
+
 ## Styles
 
 No compiled CSS ships. The components carry Tailwind class names, so the

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -116,10 +116,16 @@ import {
 } from "@stll/ui/kanban";
 
 const Card = ({ id }: { id: string }) => {
-  const { dragHandle, setNodeRef } = useKanbanSortable({ id });
+  const { activator, setNodeRef } = useKanbanSortable({
+    activation: { type: "handle" },
+    id,
+  });
+  if (activator.type !== "handle") {
+    return null;
+  }
   return (
     <article ref={setNodeRef}>
-      <KanbanDragHandle bindings={dragHandle} label="Move card" />
+      <KanbanDragHandle bindings={activator.bindings} label="Move card" />
     </article>
   );
 };
@@ -179,10 +185,9 @@ const matrix = buildKanbanBoardMatrix({
 />;
 ```
 
-When rows inside a virtual cell are sortable, give the cell its sortable
-identity directly. It owns the matching `SortableContext`, so the card stays a
-plain `useKanbanSortable` consumer and the virtualizer remains the only
-vertical scroll container.
+When rows inside a virtual cell are sortable, give the cell a unique drop target
+and its ordered matrix position. The cell registers its actual scroll element,
+including when `rows` is empty, and owns the matching `SortableContext`.
 
 ```tsx
 <KanbanVirtualCell
@@ -190,12 +195,21 @@ vertical scroll container.
   pagination={{ type: "none" }}
   renderRow={(row) => <Card row={row} />}
   rows={cell.rows}
-  sortable={{ getRowId: (row) => row.id }}
+  sortable={{
+    dropTarget: {
+      id: cellId,
+      position: { column: columnIndex, lane: laneIndex },
+    },
+    getRowId: (row) => row.id,
+  }}
 />
 ```
 
-Use `useKanbanDropTarget` for an empty cell or terminal board destination.
-This keeps board presentation code independent of the underlying drag library.
+The default keyboard coordinates move through items in their cell before
+crossing into adjacent columns or subgroup lanes; empty cells remain reachable.
+Pointer and touch drops outside registered board targets cancel. Choose an
+explicit `{ type: "handle" }` activation for the 44px handle, or `{ type:
+"item" }` when the whole item is the intended activation surface.
 
 ## Styles
 

--- a/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
@@ -11,34 +11,84 @@ import { KanbanVirtualCell } from "../virtual-cell";
 const fixtureStyles = `
   .touch-auto { touch-action: auto; }
   .touch-none { touch-action: none; }
-  [data-board] { block-size: 180px; display: flex; inline-size: 320px; overflow-x: auto; }
+  .size-11 { block-size: 44px; inline-size: 44px; }
+  [data-board] { block-size: 300px; display: flex; inline-size: 320px; overflow-x: auto; position: relative; }
   [data-column] { flex: 0 0 200px; }
   .kanban-test-list { block-size: 120px; max-block-size: 120px; overflow-y: auto; }
   [data-sortable-item] { block-size: 96px; }
 `;
 
-const firstColumnRows = [{ id: "first" }, { id: "third" }, { id: "fourth" }];
+const firstColumnRows = [
+  { id: "first" },
+  { id: "third" },
+  { id: "fourth" },
+  { id: "fifth" },
+  { id: "sixth" },
+];
 
-const secondColumnRows = [{ id: "second" }];
+const cells = [
+  { id: "cell-a", position: { column: 0, lane: 0 }, rows: firstColumnRows },
+  { id: "cell-b", position: { column: 1, lane: 0 }, rows: [] },
+  {
+    id: "cell-c",
+    position: { column: 0, lane: 1 },
+    rows: [{ id: "lane-second" }],
+  },
+  {
+    id: "cell-d",
+    position: { column: 1, lane: 1 },
+    rows: [{ id: "second" }, { id: "whole-item" }],
+  },
+] as const;
 
 const SortableItem = ({ id }: { id: string }) => {
-  const { dragHandle, setNodeRef, style } = useKanbanSortable({ id });
+  const { activator, setNodeRef, style } = useKanbanSortable({
+    activation: { type: id === "whole-item" ? "item" : "handle" },
+    id,
+  });
+
+  if (activator.type === "item") {
+    return (
+      <div
+        {...activator.attributes}
+        {...activator.listeners}
+        aria-label={`Move ${id}`}
+        data-sortable-item={id}
+        data-whole-item=""
+        ref={setNodeRef}
+        style={style}
+      >
+        {id}
+      </div>
+    );
+  }
 
   return (
     <div data-sortable-item={id} ref={setNodeRef} style={style}>
-      <KanbanDragHandle bindings={dragHandle} label={`Move ${id}`} />
+      <KanbanDragHandle bindings={activator.bindings} label={`Move ${id}`} />
     </div>
   );
 };
 
-const SortableVirtualCell = ({ rows }: { rows: readonly { id: string }[] }) => (
+const SortableVirtualCell = ({
+  id,
+  position,
+  rows,
+}: {
+  id: string;
+  position: { column: number; lane: number };
+  rows: readonly { id: string }[];
+}) => (
   <KanbanVirtualCell
     className="kanban-test-list"
-    getRowKey={({ id }) => id}
+    getRowKey={({ id: rowId }) => rowId}
     pagination={{ type: "none" }}
-    renderRow={({ id }) => <SortableItem id={id} />}
+    renderRow={({ id: rowId }) => <SortableItem id={rowId} />}
     rows={rows}
-    sortable={{ getRowId: ({ id }) => id }}
+    sortable={{
+      dropTarget: { id, position },
+      getRowId: ({ id: rowId }) => rowId,
+    }}
   />
 );
 
@@ -53,21 +103,27 @@ const SortableFixture = () => (
       document.documentElement.dataset["droppedOn"] =
         over === null ? "" : String(over.id);
     }}
+    onDragOver={({ over }) => {
+      document.documentElement.dataset["draggedOver"] =
+        over === null ? "" : String(over.id);
+    }}
     overlayProps={{ dropAnimation: null }}
     overlay={(activeId) =>
       activeId === null ? null : <output data-overlay="">{activeId}</output>
     }
   >
     <style>{fixtureStyles}</style>
-    <KanbanSortableColumns
-      data-board=""
-      items={["first-column", "second-column"]}
-    >
+    <KanbanSortableColumns data-board="" items={["column-a", "column-b"]}>
       <section data-column="first">
-        <SortableVirtualCell rows={firstColumnRows} />
+        <div data-board-chrome="" style={{ position: "sticky", zIndex: 20 }}>
+          First
+        </div>
+        <SortableVirtualCell {...cells[0]} />
+        <SortableVirtualCell {...cells[2]} />
       </section>
       <section data-column="second">
-        <SortableVirtualCell rows={secondColumnRows} />
+        <SortableVirtualCell {...cells[1]} />
+        <SortableVirtualCell {...cells[3]} />
       </section>
     </KanbanSortableColumns>
   </KanbanSortableBoard>

--- a/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
@@ -24,6 +24,9 @@ const firstColumnRows = [
   { id: "fourth" },
   { id: "fifth" },
   { id: "sixth" },
+  ...Array.from({ length: 20 }, (_, index) => ({
+    id: `virtual-${index + 1}`,
+  })),
 ];
 
 const cells = [

--- a/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
@@ -17,11 +17,7 @@ const fixtureStyles = `
   [data-sortable-item] { block-size: 96px; }
 `;
 
-const firstColumnRows = [
-  { id: "first" },
-  { id: "third" },
-  { id: "fourth" },
-];
+const firstColumnRows = [{ id: "first" }, { id: "third" }, { id: "fourth" }];
 
 const secondColumnRows = [{ id: "second" }];
 
@@ -35,11 +31,7 @@ const SortableItem = ({ id }: { id: string }) => {
   );
 };
 
-const SortableVirtualCell = ({
-  rows,
-}: {
-  rows: readonly { id: string }[];
-}) => (
+const SortableVirtualCell = ({ rows }: { rows: readonly { id: string }[] }) => (
   <KanbanVirtualCell
     className="kanban-test-list"
     getRowKey={({ id }) => id}

--- a/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
@@ -4,18 +4,26 @@ import {
   KanbanDragHandle,
   KanbanSortableBoard,
   KanbanSortableColumns,
-  KanbanSortableList,
   useKanbanSortable,
 } from "../sortable-interactions";
+import { KanbanVirtualCell } from "../virtual-cell";
 
 const fixtureStyles = `
   .touch-auto { touch-action: auto; }
   .touch-none { touch-action: none; }
   [data-board] { block-size: 180px; display: flex; inline-size: 320px; overflow-x: auto; }
-  [data-column] { flex: 0 0 500px; }
-  [data-list] { block-size: 120px; overflow-y: auto; }
+  [data-column] { flex: 0 0 200px; }
+  .kanban-test-list { block-size: 120px; max-block-size: 120px; overflow-y: auto; }
   [data-sortable-item] { block-size: 96px; }
 `;
+
+const firstColumnRows = [
+  { id: "first" },
+  { id: "third" },
+  { id: "fourth" },
+];
+
+const secondColumnRows = [{ id: "second" }];
 
 const SortableItem = ({ id }: { id: string }) => {
   const { dragHandle, setNodeRef, style } = useKanbanSortable({ id });
@@ -27,6 +35,21 @@ const SortableItem = ({ id }: { id: string }) => {
   );
 };
 
+const SortableVirtualCell = ({
+  rows,
+}: {
+  rows: readonly { id: string }[];
+}) => (
+  <KanbanVirtualCell
+    className="kanban-test-list"
+    getRowKey={({ id }) => id}
+    pagination={{ type: "none" }}
+    renderRow={({ id }) => <SortableItem id={id} />}
+    rows={rows}
+    sortable={{ getRowId: ({ id }) => id }}
+  />
+);
+
 const SortableFixture = () => (
   <KanbanSortableBoard
     onDragStart={() => {
@@ -34,19 +57,25 @@ const SortableFixture = () => (
         performance.now(),
       );
     }}
-    onDragEnd={() => undefined}
+    onDragEnd={({ over }) => {
+      document.documentElement.dataset["droppedOn"] =
+        over === null ? "" : String(over.id);
+    }}
     overlayProps={{ dropAnimation: null }}
     overlay={(activeId) =>
       activeId === null ? null : <output data-overlay="">{activeId}</output>
     }
   >
     <style>{fixtureStyles}</style>
-    <KanbanSortableColumns data-board="" items={["column"]}>
-      <section data-column="">
-        <KanbanSortableList data-list="" items={["first", "second"]}>
-          <SortableItem id="first" />
-          <SortableItem id="second" />
-        </KanbanSortableList>
+    <KanbanSortableColumns
+      data-board=""
+      items={["first-column", "second-column"]}
+    >
+      <section data-column="first">
+        <SortableVirtualCell rows={firstColumnRows} />
+      </section>
+      <section data-column="second">
+        <SortableVirtualCell rows={secondColumnRows} />
       </section>
     </KanbanSortableColumns>
   </KanbanSortableBoard>

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -25,6 +25,8 @@ export type {
   KanbanSortableBoardProps,
   KanbanSortableColumnsProps,
   KanbanSortableListProps,
+  KanbanVirtualScrollRequest,
+  KanbanCellVirtualNavigation,
   UseKanbanSortableOptions,
   UseKanbanDropTargetOptions,
 } from "./sortable-interactions";

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -24,6 +24,7 @@ export type {
 } from "./sortable-interactions";
 export {
   KANBAN_MOUSE_ACTIVATION_DISTANCE,
+  KANBAN_BOARD_COLLISION_DETECTION,
   KANBAN_TOUCH_ACTIVATION_CONSTRAINT,
   KanbanDragHandle,
   KanbanSortableBoard,
@@ -92,6 +93,7 @@ export { KanbanSubgroupBoard } from "./subgroup-board";
 export type {
   KanbanVirtualCellPagination,
   KanbanVirtualCellProps,
+  KanbanVirtualCellSortableContext,
 } from "./virtual-cell";
 export {
   KANBAN_VIRTUAL_CELL_PAGINATION,

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -18,7 +18,9 @@ export type {
   KanbanDragHandleProps,
   KanbanDragCancelEvent,
   KanbanDragEndEvent,
+  KanbanDragOverEvent,
   KanbanDragStartEvent,
+  KanbanSortableActivationMode,
   KanbanSortableBindings,
   KanbanSortableBoardProps,
   KanbanSortableColumnsProps,
@@ -27,9 +29,11 @@ export type {
   UseKanbanDropTargetOptions,
 } from "./sortable-interactions";
 export {
+  KANBAN_BOARD_AUTO_SCROLL_OPTIONS,
   KANBAN_MOUSE_ACTIVATION_DISTANCE,
   KANBAN_BOARD_COLLISION_DETECTION,
   KANBAN_DRAG_OVERLAY_Z_INDEX,
+  KANBAN_SORTABLE_ACTIVATION_MODES,
   KANBAN_TOUCH_ACTIVATION_CONSTRAINT,
   KanbanDragHandle,
   KanbanSortableBoard,
@@ -38,7 +42,9 @@ export {
   useKanbanSortable,
   useKanbanDropTarget,
   useKanbanSortableSensors,
+  kanbanKeyboardCoordinates,
 } from "./sortable-interactions";
+export type { KanbanSortableCellPosition } from "./sortable-interactions";
 export type { KanbanDirection, KanbanHorizontalEdge } from "./sortable-edge";
 export {
   getKanbanHorizontalEdge,

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -16,21 +16,27 @@ export type { KanbanColumnHeaderProps } from "./column-header";
 export { KanbanColumnHeader } from "./column-header";
 export type {
   KanbanDragHandleProps,
+  KanbanDragCancelEvent,
+  KanbanDragEndEvent,
+  KanbanDragStartEvent,
   KanbanSortableBindings,
   KanbanSortableBoardProps,
   KanbanSortableColumnsProps,
   KanbanSortableListProps,
   UseKanbanSortableOptions,
+  UseKanbanDropTargetOptions,
 } from "./sortable-interactions";
 export {
   KANBAN_MOUSE_ACTIVATION_DISTANCE,
   KANBAN_BOARD_COLLISION_DETECTION,
+  KANBAN_DRAG_OVERLAY_Z_INDEX,
   KANBAN_TOUCH_ACTIVATION_CONSTRAINT,
   KanbanDragHandle,
   KanbanSortableBoard,
   KanbanSortableColumns,
   KanbanSortableList,
   useKanbanSortable,
+  useKanbanDropTarget,
   useKanbanSortableSensors,
 } from "./sortable-interactions";
 export type { KanbanDirection, KanbanHorizontalEdge } from "./sortable-edge";

--- a/packages/ui/src/kanban/sortable-interactions.logic.test.ts
+++ b/packages/ui/src/kanban/sortable-interactions.logic.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getKanbanKeyboardTarget,
+  isKanbanCellDropData,
+} from "./sortable-interactions.logic";
+
+const cells = [
+  {
+    id: "lane-0-column-0",
+    itemIds: ["first", "second", "third"],
+    position: { column: 0, lane: 0 },
+    type: "kanban-cell",
+  },
+  {
+    id: "lane-0-column-1",
+    itemIds: [],
+    position: { column: 1, lane: 0 },
+    type: "kanban-cell",
+  },
+  {
+    id: "lane-1-column-0",
+    itemIds: ["fourth"],
+    position: { column: 0, lane: 1 },
+    type: "kanban-cell",
+  },
+  {
+    id: "lane-1-column-1",
+    itemIds: ["fifth", "sixth"],
+    position: { column: 1, lane: 1 },
+    type: "kanban-cell",
+  },
+] as const;
+
+describe("Kanban keyboard navigation", () => {
+  test("rejects invalid matrix positions at the drop boundary", () => {
+    expect(
+      isKanbanCellDropData({
+        itemIds: [],
+        position: { column: -1, lane: 0 },
+        type: "kanban-cell",
+      }),
+    ).toBe(false);
+  });
+
+  test("preserves item order before leaving a cell", () => {
+    expect(
+      getKanbanKeyboardTarget({
+        activeId: "first",
+        cells,
+        currentCellId: "lane-0-column-0",
+        currentOverId: "first",
+        direction: "down",
+      }),
+    ).toBe("second");
+    expect(
+      getKanbanKeyboardTarget({
+        activeId: "first",
+        cells,
+        currentCellId: "lane-0-column-0",
+        currentOverId: "second",
+        direction: "down",
+      }),
+    ).toBe("third");
+  });
+
+  test("reaches empty cells and continues through a two-axis matrix", () => {
+    expect(
+      getKanbanKeyboardTarget({
+        activeId: "first",
+        cells,
+        currentCellId: "lane-0-column-0",
+        currentOverId: "first",
+        direction: "right",
+      }),
+    ).toBe("lane-0-column-1");
+    expect(
+      getKanbanKeyboardTarget({
+        activeId: "first",
+        cells,
+        currentCellId: "lane-0-column-1",
+        currentOverId: "lane-0-column-1",
+        direction: "down",
+      }),
+    ).toBe("fifth");
+  });
+
+  test("uses the nearest item index when crossing columns", () => {
+    expect(
+      getKanbanKeyboardTarget({
+        activeId: "third",
+        cells,
+        currentCellId: "lane-1-column-1",
+        currentOverId: "sixth",
+        direction: "left",
+      }),
+    ).toBe("fourth");
+  });
+});

--- a/packages/ui/src/kanban/sortable-interactions.logic.test.ts
+++ b/packages/ui/src/kanban/sortable-interactions.logic.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  clearKanbanKeyboardTarget,
+  getKanbanKeyboardTargetState,
   getKanbanKeyboardTarget,
   isKanbanCellDropData,
 } from "./sortable-interactions.logic";
@@ -9,34 +11,55 @@ const cells = [
   {
     id: "lane-0-column-0",
     itemIds: ["first", "second", "third"],
+    navigation: { type: "static" },
     position: { column: 0, lane: 0 },
     type: "kanban-cell",
   },
   {
     id: "lane-0-column-1",
     itemIds: [],
+    navigation: { type: "static" },
     position: { column: 1, lane: 0 },
     type: "kanban-cell",
   },
   {
     id: "lane-1-column-0",
     itemIds: ["fourth"],
+    navigation: { type: "static" },
     position: { column: 0, lane: 1 },
     type: "kanban-cell",
   },
   {
     id: "lane-1-column-1",
     itemIds: ["fifth", "sixth"],
+    navigation: { type: "static" },
     position: { column: 1, lane: 1 },
     type: "kanban-cell",
   },
 ] as const;
 
 describe("Kanban keyboard navigation", () => {
+  test("keeps a stable navigation holder across virtual renders", () => {
+    const navigation = {
+      current: { targetId: "offscreen", type: "pending" },
+    };
+    const data = { navigation, type: "kanban-item" };
+
+    expect(getKanbanKeyboardTargetState(data)).toEqual({
+      targetId: "offscreen",
+      type: "pending",
+    });
+    clearKanbanKeyboardTarget(data);
+
+    expect(data.navigation).toBe(navigation);
+    expect(getKanbanKeyboardTargetState(data)).toEqual({ type: "idle" });
+  });
+
   test("rejects invalid matrix positions at the drop boundary", () => {
     expect(
       isKanbanCellDropData({
         itemIds: [],
+        navigation: { type: "static" as const },
         position: { column: -1, lane: 0 },
         type: "kanban-cell",
       }),

--- a/packages/ui/src/kanban/sortable-interactions.logic.ts
+++ b/packages/ui/src/kanban/sortable-interactions.logic.ts
@@ -1,0 +1,319 @@
+import {
+  closestCorners,
+  pointerWithin,
+  type CollisionDetection,
+  type DroppableContainer,
+  type KeyboardCoordinateGetter,
+  type UniqueIdentifier,
+} from "@dnd-kit/core";
+
+export const KANBAN_DROP_TARGET_TYPES = {
+  CELL: "kanban-cell",
+  ITEM: "kanban-item",
+} as const;
+
+export type KanbanSortableCellPosition = {
+  column: number;
+  lane: number;
+};
+
+export type KanbanCellDropData = {
+  itemIds: readonly UniqueIdentifier[];
+  position: KanbanSortableCellPosition;
+  type: "kanban-cell";
+};
+
+export type KanbanItemDropData = {
+  navigation:
+    | { type: "idle" }
+    | { targetId: UniqueIdentifier; type: "keyboard" };
+  type: "kanban-item";
+};
+
+type SortableData = {
+  containerId: UniqueIdentifier;
+  index: number;
+  items: readonly UniqueIdentifier[];
+};
+
+type NavigationCell = KanbanCellDropData & {
+  id: UniqueIdentifier;
+};
+
+const isRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isUniqueIdentifier = (value: unknown): value is UniqueIdentifier =>
+  typeof value === "string" || typeof value === "number";
+
+const isCellPosition = (value: unknown): value is KanbanSortableCellPosition =>
+  isRecord(value) &&
+  typeof value["column"] === "number" &&
+  typeof value["lane"] === "number" &&
+  Number.isInteger(value["column"]) &&
+  Number.isInteger(value["lane"]) &&
+  value["column"] >= 0 &&
+  value["lane"] >= 0;
+
+export const isKanbanCellDropData = (
+  value: unknown,
+): value is KanbanCellDropData =>
+  isRecord(value) &&
+  value["type"] === KANBAN_DROP_TARGET_TYPES.CELL &&
+  Array.isArray(value["itemIds"]) &&
+  value["itemIds"].every(isUniqueIdentifier) &&
+  isCellPosition(value["position"]);
+
+const isKanbanItemDropData = (value: unknown): value is KanbanItemDropData => {
+  if (!isRecord(value) || value["type"] !== KANBAN_DROP_TARGET_TYPES.ITEM) {
+    return false;
+  }
+  const navigation = value["navigation"];
+  return (
+    isRecord(navigation) &&
+    (navigation["type"] === "idle" ||
+      (navigation["type"] === "keyboard" &&
+        isUniqueIdentifier(navigation["targetId"])))
+  );
+};
+
+const getSortableData = (value: unknown): SortableData | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const sortable = value["sortable"];
+  if (
+    !isRecord(sortable) ||
+    !isUniqueIdentifier(sortable["containerId"]) ||
+    typeof sortable["index"] !== "number" ||
+    !Number.isInteger(sortable["index"]) ||
+    !Array.isArray(sortable["items"]) ||
+    !sortable["items"].every(isUniqueIdentifier)
+  ) {
+    return null;
+  }
+  return {
+    containerId: sortable["containerId"],
+    index: sortable["index"],
+    items: sortable["items"],
+  };
+};
+
+const isKanbanDroppable = ({ data }: DroppableContainer): boolean => {
+  const value: unknown = data.current;
+  return isKanbanCellDropData(value) || isKanbanItemDropData(value);
+};
+
+/**
+ * Pointer and touch input must be inside a registered board target. Once that
+ * boundary is established, closest corners gives stable ranking across cells.
+ */
+export const KANBAN_BOARD_COLLISION_DETECTION: CollisionDetection = (args) => {
+  const boardContainers = args.droppableContainers.filter(isKanbanDroppable);
+  if (args.pointerCoordinates === null) {
+    const activeData: unknown = args.active.data.current;
+    if (
+      isKanbanItemDropData(activeData) &&
+      activeData.navigation.type === "keyboard"
+    ) {
+      const { targetId } = activeData.navigation;
+      return boardContainers.some(({ id }) => id === targetId)
+        ? [{ id: targetId }]
+        : [];
+    }
+    return closestCorners({ ...args, droppableContainers: boardContainers });
+  }
+
+  const intersections = pointerWithin({
+    ...args,
+    droppableContainers: boardContainers,
+  });
+  if (intersections.length === 0) {
+    return [];
+  }
+  const intersectingIds = new Set(
+    intersections.map((intersection) => intersection.id),
+  );
+  return closestCorners({
+    ...args,
+    droppableContainers: boardContainers.filter(({ id }) =>
+      intersectingIds.has(id),
+    ),
+  });
+};
+
+type NavigationDirection = "down" | "left" | "right" | "up";
+
+type GetKeyboardTargetOptions = {
+  activeId: UniqueIdentifier;
+  cells: readonly NavigationCell[];
+  currentCellId: UniqueIdentifier;
+  currentOverId: UniqueIdentifier;
+  direction: NavigationDirection;
+};
+
+const getAdjacentCell = (
+  cells: readonly NavigationCell[],
+  current: NavigationCell,
+  direction: NavigationDirection,
+): NavigationCell | undefined => {
+  let columnOffset = 0;
+  let laneOffset = 0;
+  switch (direction) {
+    case "down":
+      laneOffset = 1;
+      break;
+    case "left":
+      columnOffset = -1;
+      break;
+    case "right":
+      columnOffset = 1;
+      break;
+    case "up":
+      laneOffset = -1;
+      break;
+  }
+  return cells.find(
+    ({ position }) =>
+      position.column === current.position.column + columnOffset &&
+      position.lane === current.position.lane + laneOffset,
+  );
+};
+
+export const getKanbanKeyboardTarget = ({
+  activeId,
+  cells,
+  currentCellId,
+  currentOverId,
+  direction,
+}: GetKeyboardTargetOptions): UniqueIdentifier | undefined => {
+  const currentCell = cells.find(({ id }) => id === currentCellId);
+  if (currentCell === undefined) {
+    return undefined;
+  }
+  const overIndex = currentCell.itemIds.indexOf(currentOverId);
+  const activeIndex = currentCell.itemIds.indexOf(activeId);
+  const currentIndex = overIndex !== -1 ? overIndex : activeIndex;
+
+  if (direction === "down" && currentIndex >= 0) {
+    const nextItem = currentCell.itemIds.at(currentIndex + 1);
+    if (nextItem !== undefined) {
+      return nextItem;
+    }
+  }
+  if (direction === "up" && currentIndex > 0) {
+    return currentCell.itemIds.at(currentIndex - 1);
+  }
+
+  const adjacentCell = getAdjacentCell(cells, currentCell, direction);
+  if (adjacentCell === undefined) {
+    return undefined;
+  }
+  if (adjacentCell.itemIds.length === 0) {
+    return adjacentCell.id;
+  }
+  if (direction === "down") {
+    return adjacentCell.itemIds.at(0);
+  }
+  if (direction === "up") {
+    return adjacentCell.itemIds.at(-1);
+  }
+  const targetIndex = Math.max(currentIndex, 0);
+  return (
+    adjacentCell.itemIds.at(
+      Math.min(targetIndex, adjacentCell.itemIds.length - 1),
+    ) ?? adjacentCell.id
+  );
+};
+
+const getDirection = (code: string): NavigationDirection | null => {
+  switch (code) {
+    case "ArrowDown":
+      return "down";
+    case "ArrowLeft":
+      return "left";
+    case "ArrowRight":
+      return "right";
+    case "ArrowUp":
+      return "up";
+    default:
+      return null;
+  }
+};
+
+const getCellId = (container: DroppableContainer): UniqueIdentifier | null => {
+  const data: unknown = container.data.current;
+  if (isKanbanCellDropData(data)) {
+    return container.id;
+  }
+  if (!isKanbanItemDropData(data)) {
+    return null;
+  }
+  return getSortableData(data)?.containerId ?? null;
+};
+
+/** Ordered two-dimensional navigation over item and empty-cell targets. */
+export const kanbanKeyboardCoordinates: KeyboardCoordinateGetter = (
+  event,
+  { active, context },
+) => {
+  const direction = getDirection(event.code);
+  if (direction === null) {
+    return undefined;
+  }
+  event.preventDefault();
+
+  const enabledContainers = context.droppableContainers.getEnabled();
+  const cellContainers = enabledContainers.filter(({ data }) => {
+    const value: unknown = data.current;
+    return isKanbanCellDropData(value);
+  });
+  const cells = cellContainers.flatMap((container): NavigationCell[] => {
+    const data: unknown = container.data.current;
+    return isKanbanCellDropData(data) ? [{ ...data, id: container.id }] : [];
+  });
+  const overId = context.over?.id ?? active;
+  const overContainer = context.droppableContainers.get(overId);
+  const activeContainer = context.droppableContainers.get(active);
+  const currentCellId =
+    (overContainer && getCellId(overContainer)) ??
+    (activeContainer && getCellId(activeContainer));
+  if (currentCellId === null || currentCellId === undefined) {
+    return undefined;
+  }
+
+  const targetId = getKanbanKeyboardTarget({
+    activeId: active,
+    cells,
+    currentCellId,
+    currentOverId: overId,
+    direction,
+  });
+  if (targetId === undefined) {
+    return undefined;
+  }
+  const targetContainer = context.droppableContainers.get(targetId);
+  const targetNode = targetContainer?.node.current;
+  if (targetNode === null || targetNode === undefined) {
+    return undefined;
+  }
+  const targetRect = context.droppableRects.get(targetId);
+  if (targetRect === undefined) {
+    return undefined;
+  }
+  const activeData: unknown = context.active?.data.current;
+  if (isKanbanItemDropData(activeData)) {
+    activeData.navigation = { targetId, type: "keyboard" };
+  }
+  // Commit the collision target before scrolling changes virtual measurements.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      targetNode.scrollIntoView({
+        behavior: "instant",
+        block: "nearest",
+        inline: "nearest",
+      });
+    });
+  });
+  return { x: targetRect.left, y: targetRect.top };
+};

--- a/packages/ui/src/kanban/sortable-interactions.logic.ts
+++ b/packages/ui/src/kanban/sortable-interactions.logic.ts
@@ -17,16 +17,34 @@ export type KanbanSortableCellPosition = {
   lane: number;
 };
 
+export type KanbanVirtualScrollRequest = {
+  itemId: UniqueIdentifier;
+  type: "item";
+};
+
+export type KanbanCellVirtualNavigation =
+  | { type: "static" }
+  | {
+      requestScroll: (request: KanbanVirtualScrollRequest) => void;
+      type: "virtual";
+    };
+
 export type KanbanCellDropData = {
   itemIds: readonly UniqueIdentifier[];
+  navigation: KanbanCellVirtualNavigation;
   position: KanbanSortableCellPosition;
   type: "kanban-cell";
 };
 
+type KanbanKeyboardTargetState =
+  | { type: "idle" }
+  | { targetId: UniqueIdentifier; type: "pending" }
+  | { targetId: UniqueIdentifier; type: "ready" };
+
 export type KanbanItemDropData = {
-  navigation:
-    | { type: "idle" }
-    | { targetId: UniqueIdentifier; type: "keyboard" };
+  navigation: {
+    current: KanbanKeyboardTargetState;
+  };
   type: "kanban-item";
 };
 
@@ -55,6 +73,14 @@ const isCellPosition = (value: unknown): value is KanbanSortableCellPosition =>
   value["column"] >= 0 &&
   value["lane"] >= 0;
 
+const isKanbanCellVirtualNavigation = (
+  value: unknown,
+): value is KanbanCellVirtualNavigation =>
+  isRecord(value) &&
+  (value["type"] === "static" ||
+    (value["type"] === "virtual" &&
+      typeof value["requestScroll"] === "function"));
+
 export const isKanbanCellDropData = (
   value: unknown,
 ): value is KanbanCellDropData =>
@@ -62,6 +88,7 @@ export const isKanbanCellDropData = (
   value["type"] === KANBAN_DROP_TARGET_TYPES.CELL &&
   Array.isArray(value["itemIds"]) &&
   value["itemIds"].every(isUniqueIdentifier) &&
+  isKanbanCellVirtualNavigation(value["navigation"]) &&
   isCellPosition(value["position"]);
 
 const isKanbanItemDropData = (value: unknown): value is KanbanItemDropData => {
@@ -69,12 +96,25 @@ const isKanbanItemDropData = (value: unknown): value is KanbanItemDropData => {
     return false;
   }
   const navigation = value["navigation"];
+  const current = isRecord(navigation) ? navigation["current"] : undefined;
   return (
     isRecord(navigation) &&
-    (navigation["type"] === "idle" ||
-      (navigation["type"] === "keyboard" &&
-        isUniqueIdentifier(navigation["targetId"])))
+    isRecord(current) &&
+    (current["type"] === "idle" ||
+      ((current["type"] === "ready" || current["type"] === "pending") &&
+        isUniqueIdentifier(current["targetId"])))
   );
+};
+
+export const getKanbanKeyboardTargetState = (
+  value: unknown,
+): KanbanKeyboardTargetState | undefined =>
+  isKanbanItemDropData(value) ? value.navigation.current : undefined;
+
+export const clearKanbanKeyboardTarget = (value: unknown): void => {
+  if (isKanbanItemDropData(value) && value.navigation.current.type !== "idle") {
+    value.navigation.current = { type: "idle" };
+  }
 };
 
 const getSortableData = (value: unknown): SortableData | null => {
@@ -112,11 +152,17 @@ export const KANBAN_BOARD_COLLISION_DETECTION: CollisionDetection = (args) => {
   const boardContainers = args.droppableContainers.filter(isKanbanDroppable);
   if (args.pointerCoordinates === null) {
     const activeData: unknown = args.active.data.current;
-    if (
-      isKanbanItemDropData(activeData) &&
-      activeData.navigation.type === "keyboard"
-    ) {
-      const { targetId } = activeData.navigation;
+    if (isKanbanItemDropData(activeData)) {
+      if (activeData.navigation.current.type === "pending") {
+        return [];
+      }
+      if (activeData.navigation.current.type !== "ready") {
+        return closestCorners({
+          ...args,
+          droppableContainers: boardContainers,
+        });
+      }
+      const { targetId } = activeData.navigation.current;
       return boardContainers.some(({ id }) => id === targetId)
         ? [{ id: targetId }]
         : [];
@@ -272,7 +318,12 @@ export const kanbanKeyboardCoordinates: KeyboardCoordinateGetter = (
     const data: unknown = container.data.current;
     return isKanbanCellDropData(data) ? [{ ...data, id: container.id }] : [];
   });
-  const overId = context.over?.id ?? active;
+  const activeData: unknown = context.active?.data.current;
+  const keyboardTarget = getKanbanKeyboardTargetState(activeData);
+  const overId =
+    keyboardTarget?.type === "ready"
+      ? keyboardTarget.targetId
+      : (context.over?.id ?? active);
   const overContainer = context.droppableContainers.get(overId);
   const activeContainer = context.droppableContainers.get(active);
   const currentCellId =
@@ -295,15 +346,25 @@ export const kanbanKeyboardCoordinates: KeyboardCoordinateGetter = (
   const targetContainer = context.droppableContainers.get(targetId);
   const targetNode = targetContainer?.node.current;
   if (targetNode === null || targetNode === undefined) {
+    const targetCell = cells.find(({ itemIds }) => itemIds.includes(targetId));
+    if (
+      isKanbanItemDropData(activeData) &&
+      targetCell?.navigation.type === "virtual"
+    ) {
+      activeData.navigation.current = {
+        targetId,
+        type: "pending",
+      };
+      targetCell.navigation.requestScroll({ itemId: targetId, type: "item" });
+    }
     return undefined;
   }
   const targetRect = context.droppableRects.get(targetId);
   if (targetRect === undefined) {
     return undefined;
   }
-  const activeData: unknown = context.active?.data.current;
   if (isKanbanItemDropData(activeData)) {
-    activeData.navigation = { targetId, type: "keyboard" };
+    activeData.navigation.current = { targetId, type: "ready" };
   }
   // Commit the collision target before scrolling changes virtual measurements.
   requestAnimationFrame(() => {

--- a/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
+++ b/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
@@ -101,7 +101,7 @@ const scrollWithTouch = async (
 test("preserves native board and list scrolling", async ({ page }) => {
   const handle = await openFixture(page);
   const board = page.locator("[data-board]");
-  const list = page.locator("[data-list]");
+  const list = page.locator(".kanban-test-list").first();
 
   await expect(board).toHaveCSS("touch-action", "auto");
   await expect(list).toHaveCSS("touch-action", "auto");
@@ -298,4 +298,46 @@ test("starts keyboard dragging from the handle", async ({ page }) => {
   await page.keyboard.press("Space");
 
   await expect(page.locator("[data-overlay]")).toHaveText("first");
+});
+
+test("drops a touch drag into an adjacent virtual cell", async ({ page }) => {
+  const handle = await openFixture(page);
+  const target = page.getByRole("button", { name: "Move second" });
+  const sourceCoordinates = await getTouchCoordinates(handle);
+  const targetCoordinates = await getTouchCoordinates(target);
+  const nativeTouch = await enableNativeTouch(page);
+
+  await dispatchNativeTouch(nativeTouch, "touchStart", [sourceCoordinates]);
+  await expect(page.locator("[data-overlay]")).toHaveText("first");
+  await dispatchNativeTouch(nativeTouch, "touchMove", [targetCoordinates]);
+  await endNativeTouch(nativeTouch);
+
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["droppedOn"] ?? "",
+        ),
+    )
+    .toBe("second");
+});
+
+test("drops a keyboard drag into an adjacent virtual cell", async ({
+  page,
+}) => {
+  const handle = await openFixture(page);
+
+  await handle.focus();
+  await page.keyboard.press("Space");
+  await page.keyboard.press("ArrowRight");
+  await page.keyboard.press("Space");
+
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["droppedOn"] ?? "",
+        ),
+    )
+    .toBe("second");
 });

--- a/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
+++ b/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
@@ -381,6 +381,39 @@ test("drops a touch drag into an adjacent virtual cell", async ({ page }) => {
     .toBe("second");
 });
 
+test("drops a whole-item touch drag across a virtual column", async ({
+  page,
+}) => {
+  await openFixture(page);
+  const wholeItem = page.getByRole("button", { name: "Move whole-item" });
+  const sourceCell = page.locator('[data-kanban-cell="cell-d"]');
+  await sourceCell.evaluate((element) => {
+    element.scrollTop = 96;
+  });
+  await expect
+    .poll(async () => await sourceCell.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(0);
+  const sourceCoordinates = await getTouchCoordinates(wholeItem);
+  const targetCoordinates = await getTouchCoordinates(
+    page.getByRole("button", { name: "Move lane-second" }),
+  );
+  const nativeTouch = await enableNativeTouch(page);
+
+  await dispatchNativeTouch(nativeTouch, "touchStart", [sourceCoordinates]);
+  await expect(page.locator("[data-overlay]")).toHaveText("whole-item");
+  await dispatchNativeTouch(nativeTouch, "touchMove", [targetCoordinates]);
+  await endNativeTouch(nativeTouch);
+
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["droppedOn"] ?? "",
+        ),
+    )
+    .toBe("lane-second");
+});
+
 test("drops pointer and touch input into an empty virtual cell", async ({
   page,
 }) => {
@@ -604,4 +637,50 @@ test("navigates items in order, then across matrix cells and lanes", async ({
         ),
     )
     .toBe("second");
+});
+
+test("keyboard navigation reaches rows beyond the virtualizer window", async ({
+  page,
+}) => {
+  const handle = await openFixture(page);
+  const sourceCell = page.locator('[data-kanban-cell="cell-a"]');
+  const targets = [
+    "third",
+    "fourth",
+    "fifth",
+    "sixth",
+    ...Array.from({ length: 12 }, (_, index) => `virtual-${index + 1}`),
+  ];
+
+  await handle.focus();
+  await page.keyboard.press("Space");
+  const moveToTarget = async (index: number): Promise<void> => {
+    const target = targets.at(index);
+    if (target === undefined) {
+      return;
+    }
+    await page.keyboard.press("ArrowDown");
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(
+            () => document.documentElement.dataset["draggedOver"] ?? "",
+          ),
+      )
+      .toBe(target);
+    await moveToTarget(index + 1);
+  };
+  await moveToTarget(0);
+  await expect
+    .poll(async () => await sourceCell.evaluate((node) => node.scrollTop))
+    .toBeGreaterThan(0);
+  await page.keyboard.press("Space");
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["droppedOn"] ?? "",
+        ),
+    )
+    .toBe("virtual-12");
 });

--- a/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
+++ b/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
@@ -16,6 +16,29 @@ const getTouchCoordinates = async (handle: Locator) => {
   return { clientX: box.x + 12, clientY: box.y + 12, id: 1 };
 };
 
+const getCenterCoordinates = async (target: Locator, id = 1) => {
+  const box = await target.boundingBox();
+  if (!box) {
+    throw new Error("Missing target bounds");
+  }
+  return {
+    clientX: box.x + box.width / 2,
+    clientY: box.y + box.height / 2,
+    id,
+  };
+};
+
+const startMouseDrag = async (page: Page, handle: Locator) => {
+  const box = await handle.boundingBox();
+  if (!box) {
+    throw new Error("Missing drag handle bounds");
+  }
+  await page.mouse.move(box.x + 12, box.y + 12);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 21, box.y + 12);
+  await expect(page.locator("[data-overlay]")).toBeVisible();
+};
+
 const enableNativeTouch = async (page: Page) => {
   const session = await page.context().newCDPSession(page);
   await session.send("Emulation.setTouchEmulationEnabled", {
@@ -300,6 +323,42 @@ test("starts keyboard dragging from the handle", async ({ page }) => {
   await expect(page.locator("[data-overlay]")).toHaveText("first");
 });
 
+test("exposes explicit whole-item and 44px handle activation surfaces", async ({
+  page,
+}) => {
+  const handle = await openFixture(page);
+  const wholeItem = page.getByRole("button", { name: "Move whole-item" });
+
+  await expect(handle).toHaveCSS("width", "44px");
+  await expect(handle).toHaveCSS("height", "44px");
+  await expect(handle).toHaveCSS("touch-action", "none");
+  await expect(
+    handle.locator("xpath=ancestor::*[@data-sortable-item]"),
+  ).toHaveCSS("touch-action", "auto");
+  await expect(wholeItem).toHaveCSS("touch-action", "none");
+
+  await wholeItem.focus();
+  await page.keyboard.press("Space");
+  await expect(page.locator("[data-overlay]")).toHaveText("whole-item");
+  await page.keyboard.press("Escape");
+});
+
+test("keeps the drag overlay above sticky board chrome", async ({ page }) => {
+  const handle = await openFixture(page);
+  await handle.focus();
+  await page.keyboard.press("Space");
+
+  const overlayZIndex = await page
+    .locator("[data-overlay]")
+    .evaluate((node) =>
+      Number(getComputedStyle(node.parentElement ?? node).zIndex),
+    );
+  const chromeZIndex = await page
+    .locator("[data-board-chrome]")
+    .evaluate((node) => Number(getComputedStyle(node).zIndex));
+  expect(overlayZIndex).toBeGreaterThan(chromeZIndex);
+});
+
 test("drops a touch drag into an adjacent virtual cell", async ({ page }) => {
   const handle = await openFixture(page);
   const target = page.getByRole("button", { name: "Move second" });
@@ -322,6 +381,144 @@ test("drops a touch drag into an adjacent virtual cell", async ({ page }) => {
     .toBe("second");
 });
 
+test("drops pointer and touch input into an empty virtual cell", async ({
+  page,
+}) => {
+  const handle = await openFixture(page);
+  const emptyCell = page.locator('[data-kanban-cell="cell-b"]');
+  const emptyCoordinates = await getCenterCoordinates(emptyCell);
+
+  await startMouseDrag(page, handle);
+  await page.mouse.move(emptyCoordinates.clientX, emptyCoordinates.clientY);
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["draggedOver"] ?? "",
+        ),
+    )
+    .toBe("cell-b");
+  await page.mouse.up();
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["droppedOn"] ?? "",
+        ),
+    )
+    .toBe("cell-b");
+
+  await page.reload();
+  const touchHandle = page.getByRole("button", { name: "Move first" });
+  const touchSource = await getTouchCoordinates(touchHandle);
+  const touchTarget = await getCenterCoordinates(
+    page.locator('[data-kanban-cell="cell-b"]'),
+  );
+  const nativeTouch = await enableNativeTouch(page);
+  await dispatchNativeTouch(nativeTouch, "touchStart", [touchSource]);
+  await expect(page.locator("[data-overlay]")).toHaveText("first");
+  await dispatchNativeTouch(nativeTouch, "touchMove", [touchTarget]);
+  await endNativeTouch(nativeTouch);
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["droppedOn"] ?? "",
+        ),
+    )
+    .toBe("cell-b");
+});
+
+test("cancels a pointer drop outside the registered board", async ({
+  page,
+}) => {
+  const handle = await openFixture(page);
+  await startMouseDrag(page, handle);
+  await page.mouse.move(1, 1);
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["draggedOver"] ?? "missing",
+        ),
+    )
+    .toBe("");
+  await page.mouse.up();
+
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["droppedOn"] ?? "missing",
+        ),
+    )
+    .toBe("");
+});
+
+test("auto-scrolls vertical cells and the horizontal board during a pointer drag", async ({
+  page,
+}) => {
+  const handle = await openFixture(page);
+  const sourceCell = page.locator('[data-kanban-cell="cell-a"]');
+  const board = page.locator("[data-board]");
+  const sourceBox = await sourceCell.boundingBox();
+  const boardBox = await board.boundingBox();
+  if (!sourceBox || !boardBox) {
+    throw new Error("Missing auto-scroll bounds");
+  }
+
+  await startMouseDrag(page, handle);
+  await page.mouse.move(
+    sourceBox.x + sourceBox.width / 2,
+    sourceBox.y + sourceBox.height - 2,
+  );
+  await expect
+    .poll(async () => await sourceCell.evaluate((node) => node.scrollTop))
+    .toBeGreaterThan(0);
+  await page.mouse.move(boardBox.x + boardBox.width - 2, boardBox.y + 40);
+  await expect
+    .poll(async () => await board.evaluate((node) => node.scrollLeft))
+    .toBeGreaterThan(0);
+  await page.mouse.up();
+});
+
+test("auto-scrolls during an active touch drag", async ({ page }) => {
+  const handle = await openFixture(page);
+  const sourceCell = page.locator('[data-kanban-cell="cell-a"]');
+  const board = page.locator("[data-board]");
+  const source = await getTouchCoordinates(handle);
+  const sourceBox = await sourceCell.boundingBox();
+  const boardBox = await board.boundingBox();
+  if (!sourceBox || !boardBox) {
+    throw new Error("Missing touch auto-scroll bounds");
+  }
+  const nativeTouch = await enableNativeTouch(page);
+
+  await dispatchNativeTouch(nativeTouch, "touchStart", [source]);
+  await expect(page.locator("[data-overlay]")).toHaveText("first");
+  await dispatchNativeTouch(nativeTouch, "touchMove", [
+    {
+      clientX: sourceBox.x + sourceBox.width / 2,
+      clientY: sourceBox.y + sourceBox.height - 2,
+      id: source.id,
+    },
+  ]);
+  await expect
+    .poll(async () => await sourceCell.evaluate((node) => node.scrollTop))
+    .toBeGreaterThan(0);
+  await dispatchNativeTouch(nativeTouch, "touchMove", [
+    {
+      clientX: boardBox.x + boardBox.width - 2,
+      clientY: boardBox.y + 40,
+      id: source.id,
+    },
+  ]);
+  await expect
+    .poll(async () => await board.evaluate((node) => node.scrollLeft))
+    .toBeGreaterThan(0);
+  await endNativeTouch(nativeTouch);
+});
+
 test("drops a keyboard drag into an adjacent virtual cell", async ({
   page,
 }) => {
@@ -330,8 +527,75 @@ test("drops a keyboard drag into an adjacent virtual cell", async ({
   await handle.focus();
   await page.keyboard.press("Space");
   await page.keyboard.press("ArrowRight");
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["draggedOver"] ?? "",
+        ),
+    )
+    .toBe("cell-b");
   await page.keyboard.press("Space");
 
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["droppedOn"] ?? "",
+        ),
+    )
+    .toBe("cell-b");
+});
+
+test("navigates items in order, then across matrix cells and lanes", async ({
+  page,
+}) => {
+  const handle = await openFixture(page);
+
+  await handle.focus();
+  await page.keyboard.press("Space");
+  await page.keyboard.press("ArrowDown");
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["draggedOver"] ?? "",
+        ),
+    )
+    .toBe("third");
+  await page.keyboard.press("Space");
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["droppedOn"] ?? "",
+        ),
+    )
+    .toBe("third");
+
+  await page.reload();
+  const reloadedHandle = page.getByRole("button", { name: "Move first" });
+  await reloadedHandle.focus();
+  await page.keyboard.press("Space");
+  await page.keyboard.press("ArrowRight");
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["draggedOver"] ?? "",
+        ),
+    )
+    .toBe("cell-b");
+  await page.keyboard.press("ArrowDown");
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["draggedOver"] ?? "",
+        ),
+    )
+    .toBe("second");
+  await page.keyboard.press("Space");
   await expect
     .poll(
       async () =>

--- a/packages/ui/src/kanban/sortable-interactions.test.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.test.tsx
@@ -125,7 +125,7 @@ describe("sortable board interactions", () => {
     expect(html).toContain("overflow-x-auto");
     expect(html).toContain("touch-auto");
     expect(html).toContain("overflow-y-auto");
-    expect(html).toContain("size-11 touch-none");
+    expect(html).toContain("size-11 min-h-11 min-w-11 touch-none sm:size-11");
     expect(html).toContain('aria-label="Move card"');
   });
 });

--- a/packages/ui/src/kanban/sortable-interactions.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { createPortal } from "react-dom";
 
 import {
-  closestCorners,
+  AutoScrollActivator,
   DndContext,
   DragOverlay,
   KeyboardSensor,
@@ -20,36 +20,53 @@ import type {
   DragCancelEvent,
   DragEndEvent,
   DragOverlayProps,
+  DragOverEvent,
   DragStartEvent,
   DndContextProps,
   KeyboardCoordinateGetter,
+  KeyboardSensorOptions,
+  SensorInstance,
   SensorProps,
   TouchSensorOptions,
   UniqueIdentifier,
 } from "@dnd-kit/core";
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-  useSortable,
-} from "@dnd-kit/sortable";
+import { SortableContext, useSortable } from "@dnd-kit/sortable";
 import type { SortableContextProps } from "@dnd-kit/sortable";
 import { GripVerticalIcon } from "lucide-react";
 
 import { Button } from "../components/button";
+import { BOARD_DRAG_OVERLAY_Z_INDEX } from "../lib/overlay-layer";
 import { cn } from "../lib/utils";
+import {
+  KANBAN_BOARD_COLLISION_DETECTION,
+  KANBAN_DROP_TARGET_TYPES,
+  kanbanKeyboardCoordinates,
+  type KanbanCellDropData,
+  type KanbanSortableCellPosition,
+} from "./sortable-interactions.logic";
 import { isActiveTouchChange } from "./touch-identity";
+
+export {
+  KANBAN_BOARD_COLLISION_DETECTION,
+  kanbanKeyboardCoordinates,
+} from "./sortable-interactions.logic";
+export type { KanbanSortableCellPosition } from "./sortable-interactions.logic";
 
 export const KANBAN_MOUSE_ACTIVATION_DISTANCE = 8;
 
-/**
- * The closest corners stay stable while a card crosses adjacent board cells.
- * Rectangle intersection instead tends to hold a card in its source list
- * until most of the preview has left that list.
- */
-export const KANBAN_BOARD_COLLISION_DETECTION = closestCorners;
-
 /** Above sticky board chrome, below app-level floating surfaces. */
-export const KANBAN_DRAG_OVERLAY_Z_INDEX = 75;
+export const KANBAN_DRAG_OVERLAY_Z_INDEX = BOARD_DRAG_OVERLAY_Z_INDEX;
+
+export const KANBAN_BOARD_AUTO_SCROLL_OPTIONS = {
+  acceleration: 10,
+  activator: AutoScrollActivator.Pointer,
+  threshold: { x: 0.15, y: 0.15 },
+} as const satisfies AutoScrollOptions;
+
+export const KANBAN_SORTABLE_ACTIVATION_MODES = {
+  HANDLE: "handle",
+  ITEM: "item",
+} as const;
 
 export const KANBAN_TOUCH_ACTIVATION_CONSTRAINT = {
   delay: 150,
@@ -58,9 +75,17 @@ export const KANBAN_TOUCH_ACTIVATION_CONSTRAINT = {
 
 export type KanbanDragCancelEvent = DragCancelEvent;
 export type KanbanDragEndEvent = DragEndEvent;
+export type KanbanDragOverEvent = DragOverEvent;
 export type KanbanDragStartEvent = DragStartEvent;
 
 type TouchSensorProps = SensorProps<TouchSensorOptions>;
+type KeyboardSensorProps = SensorProps<KeyboardSensorOptions>;
+
+const KANBAN_KEYBOARD_CODES = {
+  cancel: ["Escape"],
+  end: ["Space", "Enter", "Tab"],
+} as const;
+const KANBAN_KEYBOARD_LISTENER_DELAY_MS = 0;
 
 type TouchEventWithLists = Event & {
   changedTouches: TouchList;
@@ -175,6 +200,84 @@ class KanbanTouchSensor extends TouchSensor {
   };
 }
 
+/**
+ * Applies board coordinates without the stock sensor's one-dimensional source
+ * scroll clamping. The coordinate getter moves to the typed target and then
+ * scrolls that virtual item into view.
+ */
+class KanbanKeyboardSensor implements SensorInstance {
+  static activators = KeyboardSensor.activators;
+
+  autoScrollEnabled = false;
+
+  private readonly listeners = new AbortController();
+  private readonly props: KeyboardSensorProps;
+  private referenceCoordinates: { x: number; y: number } | null = null;
+
+  constructor(props: KeyboardSensorProps) {
+    this.props = props;
+    props.onStart({ x: 0, y: 0 });
+    const ownerDocument = getTouchDocument(props.event);
+    ownerDocument.addEventListener("visibilitychange", this.handleCancel, {
+      signal: this.listeners.signal,
+    });
+    ownerDocument.defaultView?.addEventListener("resize", this.handleCancel, {
+      signal: this.listeners.signal,
+    });
+    setTimeout(() => {
+      if (this.listeners.signal.aborted) {
+        return;
+      }
+      ownerDocument.addEventListener("keydown", this.handleKeyDown, {
+        signal: this.listeners.signal,
+      });
+    }, KANBAN_KEYBOARD_LISTENER_DELAY_MS);
+  }
+
+  private readonly handleCancel = () => {
+    if (this.listeners.signal.aborted) {
+      return;
+    }
+    this.listeners.abort();
+    this.props.onCancel();
+  };
+
+  private readonly handleKeyDown = (event: KeyboardEvent) => {
+    const keyboardCodes = this.props.options.keyboardCodes;
+    const cancelCodes = keyboardCodes?.cancel ?? KANBAN_KEYBOARD_CODES.cancel;
+    const endCodes = keyboardCodes?.end ?? KANBAN_KEYBOARD_CODES.end;
+    if (cancelCodes.some((code) => code === event.code)) {
+      event.preventDefault();
+      this.handleCancel();
+      return;
+    }
+    if (endCodes.some((code) => code === event.code)) {
+      event.preventDefault();
+      this.listeners.abort();
+      this.props.onEnd();
+      return;
+    }
+
+    const collisionRect = this.props.context.current.collisionRect;
+    const currentCoordinates = collisionRect
+      ? { x: collisionRect.left, y: collisionRect.top }
+      : { x: 0, y: 0 };
+    this.referenceCoordinates ??= currentCoordinates;
+    const coordinates = this.props.options.coordinateGetter?.(event, {
+      active: this.props.active,
+      context: this.props.context.current,
+      currentCoordinates,
+    });
+    if (coordinates === undefined) {
+      return;
+    }
+    this.props.onMove({
+      x: coordinates.x - this.referenceCoordinates.x,
+      y: coordinates.y - this.referenceCoordinates.y,
+    });
+  };
+}
+
 const getTouchDocument = (event: Event): Document => {
   if (event.target instanceof Node && event.target.ownerDocument) {
     return event.target.ownerDocument;
@@ -193,6 +296,7 @@ export type KanbanSortableBoardProps = {
   /** Overrides dnd-kit's screen-reader announcements when supplied. */
   accessibility?: DndContextProps["accessibility"] | undefined;
   onDragStart?: ((event: KanbanDragStartEvent) => void) | undefined;
+  onDragOver?: ((event: KanbanDragOverEvent) => void) | undefined;
   onDragCancel?: ((event: KanbanDragCancelEvent) => void) | undefined;
   /** Rendered in document.body while an item is active. */
   overlay?:
@@ -203,7 +307,9 @@ export type KanbanSortableBoardProps = {
 
 export type UseKanbanDropTargetOptions = {
   disabled?: boolean | undefined;
-  id: UniqueIdentifier;
+  id: string;
+  itemIds: readonly UniqueIdentifier[];
+  position: KanbanSortableCellPosition;
 };
 
 /**
@@ -216,8 +322,15 @@ export type UseKanbanDropTargetOptions = {
 export const useKanbanDropTarget = ({
   disabled,
   id,
+  itemIds,
+  position,
 }: UseKanbanDropTargetOptions) => {
   const dropTarget = useDroppable({
+    data: {
+      itemIds,
+      position,
+      type: KANBAN_DROP_TARGET_TYPES.CELL,
+    } satisfies KanbanCellDropData,
     ...(disabled === undefined ? {} : { disabled }),
     id,
   });
@@ -244,6 +357,7 @@ export const KanbanSortableBoard = ({
   sensors,
   accessibility,
   onDragStart,
+  onDragOver,
   onDragCancel,
   overlay,
   overlayProps,
@@ -268,13 +382,14 @@ export const KanbanSortableBoard = ({
 
   return (
     <DndContext
-      {...(autoScroll === undefined ? {} : { autoScroll })}
+      autoScroll={autoScroll ?? KANBAN_BOARD_AUTO_SCROLL_OPTIONS}
       {...(accessibility === undefined ? {} : { accessibility })}
       collisionDetection={
         collisionDetection ?? KANBAN_BOARD_COLLISION_DETECTION
       }
       onDragCancel={handleDragCancel}
       onDragEnd={handleDragEnd}
+      {...(onDragOver === undefined ? {} : { onDragOver })}
       onDragStart={handleDragStart}
       sensors={sensors ?? defaultSensors}
     >
@@ -295,7 +410,7 @@ export const KanbanSortableBoard = ({
 };
 
 export const useKanbanSortableSensors = (
-  keyboardCoordinates: KeyboardCoordinateGetter = sortableKeyboardCoordinates,
+  keyboardCoordinates: KeyboardCoordinateGetter = kanbanKeyboardCoordinates,
 ) =>
   useSensors(
     useSensor(MouseSensor, {
@@ -304,7 +419,7 @@ export const useKanbanSortableSensors = (
     useSensor(KanbanTouchSensor, {
       activationConstraint: KANBAN_TOUCH_ACTIVATION_CONSTRAINT,
     }),
-    useSensor(KeyboardSensor, { coordinateGetter: keyboardCoordinates }),
+    useSensor(KanbanKeyboardSensor, { coordinateGetter: keyboardCoordinates }),
   );
 
 export type KanbanSortableListProps = SortableContextProps &
@@ -374,7 +489,12 @@ export type KanbanSortableBindings = Pick<
   "attributes" | "listeners" | "setActivatorNodeRef"
 >;
 
+export type KanbanSortableActivationMode =
+  | { type: "handle" }
+  | { type: "item" };
+
 export type UseKanbanSortableOptions = {
+  activation: KanbanSortableActivationMode;
   id: UniqueIdentifier;
   disabled?: boolean | undefined;
 };
@@ -384,27 +504,60 @@ export type UseKanbanSortableOptions = {
  * item's content a touch-none activation surface.
  */
 export const useKanbanSortable = ({
+  activation,
   id,
   disabled,
 }: UseKanbanSortableOptions) => {
+  // dnd-kit keeps this mutable data ref for the lifetime of an active drag.
+  // Stable identity preserves the keyboard target across virtualizer renders.
+  const data = React.useMemo(
+    () => ({
+      navigation: { type: "idle" },
+      type: KANBAN_DROP_TARGET_TYPES.ITEM,
+    }),
+    [],
+  );
   const sortable = useSortable({
+    data,
     id,
     ...(disabled === undefined ? {} : { disabled }),
   });
 
+  const setNodeRef = (element: HTMLElement | null) => {
+    sortable.setNodeRef(element);
+    if (activation.type === KANBAN_SORTABLE_ACTIVATION_MODES.ITEM) {
+      sortable.setActivatorNodeRef(element);
+    }
+  };
+
+  const bindings = {
+    attributes: sortable.attributes,
+    listeners: sortable.listeners,
+    setActivatorNodeRef: sortable.setActivatorNodeRef,
+  };
+
+  const activator =
+    activation.type === KANBAN_SORTABLE_ACTIVATION_MODES.HANDLE
+      ? { bindings, type: KANBAN_SORTABLE_ACTIVATION_MODES.HANDLE }
+      : {
+          attributes: sortable.attributes,
+          listeners: sortable.listeners,
+          type: KANBAN_SORTABLE_ACTIVATION_MODES.ITEM,
+        };
+
   return {
+    activator,
     isDragging: sortable.isDragging,
-    setNodeRef: sortable.setNodeRef,
+    setNodeRef,
     style: {
+      touchAction:
+        activation.type === KANBAN_SORTABLE_ACTIVATION_MODES.ITEM
+          ? "none"
+          : undefined,
       transform: sortable.transform
         ? `translate3d(${sortable.transform.x}px, ${sortable.transform.y}px, 0)`
         : undefined,
       transition: sortable.transition,
-    },
-    dragHandle: {
-      attributes: sortable.attributes,
-      listeners: sortable.listeners,
-      setActivatorNodeRef: sortable.setActivatorNodeRef,
     },
   };
 };
@@ -433,7 +586,7 @@ export const KanbanDragHandle = ({
     {...bindings.attributes}
     {...bindings.listeners}
     aria-label={label}
-    className={cn("size-11 touch-none sm:size-11", className)}
+    className={cn("size-11 min-h-11 min-w-11 touch-none sm:size-11", className)}
     ref={(element) => bindings.setActivatorNodeRef(element)}
     size="icon-xl"
     tooltip={false}

--- a/packages/ui/src/kanban/sortable-interactions.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.tsx
@@ -38,13 +38,22 @@ import { Button } from "../components/button";
 import { BOARD_DRAG_OVERLAY_Z_INDEX } from "../lib/overlay-layer";
 import { cn } from "../lib/utils";
 import {
+  clearKanbanKeyboardTarget,
+  getKanbanKeyboardTargetState,
   KANBAN_BOARD_COLLISION_DETECTION,
   KANBAN_DROP_TARGET_TYPES,
   kanbanKeyboardCoordinates,
   type KanbanCellDropData,
+  type KanbanCellVirtualNavigation,
+  type KanbanItemDropData,
   type KanbanSortableCellPosition,
 } from "./sortable-interactions.logic";
 import { isActiveTouchChange } from "./touch-identity";
+
+export type {
+  KanbanCellVirtualNavigation,
+  KanbanVirtualScrollRequest,
+} from "./sortable-interactions.logic";
 
 export {
   KANBAN_BOARD_COLLISION_DETECTION,
@@ -78,14 +87,15 @@ export type KanbanDragEndEvent = DragEndEvent;
 export type KanbanDragOverEvent = DragOverEvent;
 export type KanbanDragStartEvent = DragStartEvent;
 
-type TouchSensorProps = SensorProps<TouchSensorOptions>;
-type KeyboardSensorProps = SensorProps<KeyboardSensorOptions>;
+type TouchSensorConstructorOptions = SensorProps<TouchSensorOptions>;
+type KeyboardSensorConstructorOptions = SensorProps<KeyboardSensorOptions>;
 
 const KANBAN_KEYBOARD_CODES = {
   cancel: ["Escape"],
   end: ["Space", "Enter", "Tab"],
 } as const;
 const KANBAN_KEYBOARD_LISTENER_DELAY_MS = 0;
+const KANBAN_KEYBOARD_TARGET_RETRY_LIMIT = 60;
 
 type TouchEventWithLists = Event & {
   changedTouches: TouchList;
@@ -131,7 +141,7 @@ class KanbanTouchSensor extends TouchSensor {
   private readonly ownerDocument: Document;
   private readonly touchIdentifier: number | null;
 
-  constructor(props: TouchSensorProps) {
+  constructor(props: TouchSensorConstructorOptions) {
     const identityListeners = new AbortController();
     super({
       ...props,
@@ -211,10 +221,11 @@ class KanbanKeyboardSensor implements SensorInstance {
   autoScrollEnabled = false;
 
   private readonly listeners = new AbortController();
-  private readonly props: KeyboardSensorProps;
+  private readonly props: KeyboardSensorConstructorOptions;
+  private moveSequence = 0;
   private referenceCoordinates: { x: number; y: number } | null = null;
 
-  constructor(props: KeyboardSensorProps) {
+  constructor(props: KeyboardSensorConstructorOptions) {
     this.props = props;
     props.onStart({ x: 0, y: 0 });
     const ownerDocument = getTouchDocument(props.event);
@@ -238,6 +249,8 @@ class KanbanKeyboardSensor implements SensorInstance {
     if (this.listeners.signal.aborted) {
       return;
     }
+    this.moveSequence += 1;
+    clearKanbanKeyboardTarget(this.props.context.current.active?.data.current);
     this.listeners.abort();
     this.props.onCancel();
   };
@@ -253,22 +266,52 @@ class KanbanKeyboardSensor implements SensorInstance {
     }
     if (endCodes.some((code) => code === event.code)) {
       event.preventDefault();
+      this.moveSequence += 1;
+      clearKanbanKeyboardTarget(
+        this.props.context.current.active?.data.current,
+      );
       this.listeners.abort();
       this.props.onEnd();
       return;
     }
 
-    const collisionRect = this.props.context.current.collisionRect;
+    this.moveSequence += 1;
+    this.move(event, this.moveSequence, 0);
+  };
+
+  private readonly move = (
+    event: KeyboardEvent,
+    sequence: number,
+    retryCount: number,
+  ) => {
+    const currentContext = this.props.context.current;
+    const collisionRect = currentContext.collisionRect;
     const currentCoordinates = collisionRect
       ? { x: collisionRect.left, y: collisionRect.top }
       : { x: 0, y: 0 };
     this.referenceCoordinates ??= currentCoordinates;
     const coordinates = this.props.options.coordinateGetter?.(event, {
       active: this.props.active,
-      context: this.props.context.current,
+      context: currentContext,
       currentCoordinates,
     });
     if (coordinates === undefined) {
+      if (
+        getKanbanKeyboardTargetState(currentContext.active?.data.current)
+          ?.type !== "pending"
+      ) {
+        return;
+      }
+      if (retryCount >= KANBAN_KEYBOARD_TARGET_RETRY_LIMIT) {
+        clearKanbanKeyboardTarget(currentContext.active?.data.current);
+        return;
+      }
+      requestAnimationFrame(() => {
+        if (this.listeners.signal.aborted || this.moveSequence !== sequence) {
+          return;
+        }
+        this.move(event, sequence, retryCount + 1);
+      });
       return;
     }
     this.props.onMove({
@@ -309,6 +352,7 @@ export type UseKanbanDropTargetOptions = {
   disabled?: boolean | undefined;
   id: string;
   itemIds: readonly UniqueIdentifier[];
+  navigation: KanbanCellVirtualNavigation;
   position: KanbanSortableCellPosition;
 };
 
@@ -323,11 +367,13 @@ export const useKanbanDropTarget = ({
   disabled,
   id,
   itemIds,
+  navigation,
   position,
 }: UseKanbanDropTargetOptions) => {
   const dropTarget = useDroppable({
     data: {
       itemIds,
+      navigation,
       position,
       type: KANBAN_DROP_TARGET_TYPES.CELL,
     } satisfies KanbanCellDropData,
@@ -508,13 +554,14 @@ export const useKanbanSortable = ({
   id,
   disabled,
 }: UseKanbanSortableOptions) => {
-  // dnd-kit keeps this mutable data ref for the lifetime of an active drag.
-  // Stable identity preserves the keyboard target across virtualizer renders.
+  // useSortable merges custom data into a new object after virtualizer renders.
+  // The stable nested holder preserves the current navigation branch.
   const data = React.useMemo(
-    () => ({
-      navigation: { type: "idle" },
-      type: KANBAN_DROP_TARGET_TYPES.ITEM,
-    }),
+    () =>
+      ({
+        navigation: { current: { type: "idle" } },
+        type: KANBAN_DROP_TARGET_TYPES.ITEM,
+      }) satisfies KanbanItemDropData,
     [],
   );
   const sortable = useSortable({

--- a/packages/ui/src/kanban/sortable-interactions.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { createPortal } from "react-dom";
 
 import {
+  closestCorners,
   DndContext,
   DragOverlay,
   KeyboardSensor,
@@ -38,6 +39,13 @@ import { cn } from "../lib/utils";
 import { isActiveTouchChange } from "./touch-identity";
 
 export const KANBAN_MOUSE_ACTIVATION_DISTANCE = 8;
+
+/**
+ * The closest corners stay stable while a card crosses adjacent board cells.
+ * Rectangle intersection instead tends to hold a card in its source list
+ * until most of the preview has left that list.
+ */
+export const KANBAN_BOARD_COLLISION_DETECTION = closestCorners;
 
 export const KANBAN_TOUCH_ACTIVATION_CONSTRAINT = {
   delay: 150,
@@ -227,7 +235,9 @@ export const KanbanSortableBoard = ({
     <DndContext
       {...(autoScroll === undefined ? {} : { autoScroll })}
       {...(accessibility === undefined ? {} : { accessibility })}
-      {...(collisionDetection === undefined ? {} : { collisionDetection })}
+      collisionDetection={
+        collisionDetection ?? KANBAN_BOARD_COLLISION_DETECTION
+      }
       onDragCancel={handleDragCancel}
       onDragEnd={handleDragEnd}
       onDragStart={handleDragStart}

--- a/packages/ui/src/kanban/sortable-interactions.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.tsx
@@ -10,6 +10,7 @@ import {
   KeyboardSensor,
   MouseSensor,
   TouchSensor,
+  useDroppable,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -47,10 +48,17 @@ export const KANBAN_MOUSE_ACTIVATION_DISTANCE = 8;
  */
 export const KANBAN_BOARD_COLLISION_DETECTION = closestCorners;
 
+/** Above sticky board chrome, below app-level floating surfaces. */
+export const KANBAN_DRAG_OVERLAY_Z_INDEX = 75;
+
 export const KANBAN_TOUCH_ACTIVATION_CONSTRAINT = {
   delay: 150,
   tolerance: 8,
 } as const;
+
+export type KanbanDragCancelEvent = DragCancelEvent;
+export type KanbanDragEndEvent = DragEndEvent;
+export type KanbanDragStartEvent = DragStartEvent;
 
 type TouchSensorProps = SensorProps<TouchSensorOptions>;
 
@@ -176,7 +184,7 @@ const getTouchDocument = (event: Event): Document => {
 
 export type KanbanSortableBoardProps = {
   children: React.ReactNode;
-  onDragEnd: (event: DragEndEvent) => void;
+  onDragEnd: (event: KanbanDragEndEvent) => void;
   collisionDetection?: CollisionDetection | undefined;
   keyboardCoordinates?: KeyboardCoordinateGetter | undefined;
   autoScroll?: boolean | AutoScrollOptions | undefined;
@@ -184,13 +192,40 @@ export type KanbanSortableBoardProps = {
   sensors?: DndContextProps["sensors"] | undefined;
   /** Overrides dnd-kit's screen-reader announcements when supplied. */
   accessibility?: DndContextProps["accessibility"] | undefined;
-  onDragStart?: ((event: DragStartEvent) => void) | undefined;
-  onDragCancel?: ((event: DragCancelEvent) => void) | undefined;
+  onDragStart?: ((event: KanbanDragStartEvent) => void) | undefined;
+  onDragCancel?: ((event: KanbanDragCancelEvent) => void) | undefined;
   /** Rendered in document.body while an item is active. */
   overlay?:
     | ((activeId: UniqueIdentifier | null) => React.ReactNode)
     | undefined;
   overlayProps?: Omit<DragOverlayProps, "children"> | undefined;
+};
+
+export type UseKanbanDropTargetOptions = {
+  disabled?: boolean | undefined;
+  id: UniqueIdentifier;
+};
+
+/**
+ * Register a board-level drop target such as an empty cell or terminal lane.
+ *
+ * Board consumers should not need to couple their presentation code to the
+ * underlying drag-and-drop library just to receive an item from a sortable
+ * context.
+ */
+export const useKanbanDropTarget = ({
+  disabled,
+  id,
+}: UseKanbanDropTargetOptions) => {
+  const dropTarget = useDroppable({
+    ...(disabled === undefined ? {} : { disabled }),
+    id,
+  });
+
+  return {
+    isOver: dropTarget.isOver,
+    setNodeRef: dropTarget.setNodeRef,
+  };
 };
 
 /**
@@ -246,7 +281,12 @@ export const KanbanSortableBoard = ({
       {children}
       {overlay && typeof document !== "undefined"
         ? createPortal(
-            <DragOverlay {...overlayProps}>{overlay(activeId)}</DragOverlay>,
+            <DragOverlay
+              {...overlayProps}
+              zIndex={overlayProps?.zIndex ?? KANBAN_DRAG_OVERLAY_Z_INDEX}
+            >
+              {overlay(activeId)}
+            </DragOverlay>,
             document.body,
           )
         : null}

--- a/packages/ui/src/kanban/virtual-cell.tsx
+++ b/packages/ui/src/kanban/virtual-cell.tsx
@@ -3,6 +3,7 @@ import {
   type ReactNode,
   type RefObject,
   type UIEvent,
+  useId,
   useRef,
 } from "react";
 
@@ -16,6 +17,10 @@ import {
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { cn } from "../lib/utils";
+import {
+  useKanbanDropTarget,
+  type UseKanbanDropTargetOptions,
+} from "./sortable-interactions";
 
 const DEFAULT_ESTIMATE_SIZE_PX = 128;
 const DEFAULT_OVERSCAN = 8;
@@ -44,9 +49,9 @@ export type KanbanVirtualCellPagination =
  * merely to support dnd-kit consumers.
  */
 export type KanbanVirtualCellSortableContext<TRow> = {
+  dropTarget: Omit<UseKanbanDropTargetOptions, "itemIds">;
   getRowId: (row: TRow) => UniqueIdentifier;
   disabled?: SortableContextProps["disabled"] | undefined;
-  id?: SortableContextProps["id"] | undefined;
   strategy?: SortingStrategy | undefined;
 };
 
@@ -83,8 +88,16 @@ export const KanbanVirtualCell = <TRow,>({
   className,
 }: KanbanVirtualCellProps<TRow>) => {
   const internalRef = useRef<HTMLDivElement>(null);
-  const scrollRef = containerRef ?? internalRef;
+  const fallbackDropTargetId = useId();
+  const scrollRef = internalRef;
   const requestedPageKeyRef = useRef<string | number | null>(null);
+  const itemIds = sortable ? rows.map(sortable.getRowId) : [];
+  const dropTarget = useKanbanDropTarget({
+    disabled: sortable?.dropTarget.disabled ?? sortable === undefined,
+    id: sortable?.dropTarget.id ?? fallbackDropTargetId,
+    itemIds,
+    position: sortable?.dropTarget.position ?? { column: -1, lane: -1 },
+  });
   const virtualizer = useVirtualizer({
     count: rows.length,
     estimateSize: () => estimateSize,
@@ -118,6 +131,14 @@ export const KanbanVirtualCell = <TRow,>({
     pagination.onRequestMore();
   };
 
+  const setScrollElement = (element: HTMLDivElement | null) => {
+    internalRef.current = element;
+    if (containerRef) {
+      containerRef.current = element;
+    }
+    dropTarget.setNodeRef(element);
+  };
+
   const content = (
     <div
       className={cn(
@@ -125,8 +146,9 @@ export const KanbanVirtualCell = <TRow,>({
         active && "bg-primary/5 ring-primary/50 ring-2",
         className,
       )}
+      data-kanban-cell={sortable?.dropTarget.id}
       onScroll={handleScroll}
-      ref={scrollRef}
+      ref={setScrollElement}
       style={backgroundColor ? { backgroundColor } : undefined}
     >
       <div className="relative" style={{ height: virtualizer.getTotalSize() }}>
@@ -161,8 +183,8 @@ export const KanbanVirtualCell = <TRow,>({
       {...(sortable.disabled === undefined
         ? {}
         : { disabled: sortable.disabled })}
-      {...(sortable.id === undefined ? {} : { id: sortable.id })}
-      items={rows.map(sortable.getRowId)}
+      id={sortable.dropTarget.id}
+      items={itemIds}
       strategy={sortable.strategy ?? verticalListSortingStrategy}
     >
       {content}

--- a/packages/ui/src/kanban/virtual-cell.tsx
+++ b/packages/ui/src/kanban/virtual-cell.tsx
@@ -6,6 +6,13 @@ import {
   useRef,
 } from "react";
 
+import type { UniqueIdentifier } from "@dnd-kit/core";
+import {
+  SortableContext,
+  type SortableContextProps,
+  type SortingStrategy,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { cn } from "../lib/utils";
@@ -29,11 +36,26 @@ export type KanbanVirtualCellPagination =
       onRequestMore: () => void;
     };
 
+/**
+ * Makes a virtual cell the canonical sortable context for its rendered rows.
+ *
+ * `getRowKey` remains responsible for React and virtualizer identity. A
+ * separate sortable identifier avoids narrowing an existing React key contract
+ * merely to support dnd-kit consumers.
+ */
+export type KanbanVirtualCellSortableContext<TRow> = {
+  getRowId: (row: TRow) => UniqueIdentifier;
+  disabled?: SortableContextProps["disabled"] | undefined;
+  id?: UniqueIdentifier | undefined;
+  strategy?: SortingStrategy | undefined;
+};
+
 export type KanbanVirtualCellProps<TRow> = {
   rows: readonly TRow[];
   getRowKey: (row: TRow) => Key;
   renderRow: (row: TRow) => ReactNode;
   pagination: KanbanVirtualCellPagination;
+  sortable?: KanbanVirtualCellSortableContext<TRow> | undefined;
   containerRef?: RefObject<HTMLDivElement | null> | undefined;
   active?: boolean | undefined;
   backgroundColor?: string | undefined;
@@ -50,6 +72,7 @@ export const KanbanVirtualCell = <TRow,>({
   getRowKey,
   renderRow,
   pagination,
+  sortable,
   containerRef,
   active = false,
   backgroundColor,
@@ -95,7 +118,7 @@ export const KanbanVirtualCell = <TRow,>({
     pagination.onRequestMore();
   };
 
-  return (
+  const content = (
     <div
       className={cn(
         "bg-muted/20 max-h-[min(60vh,40rem)] min-h-20 overflow-y-auto overscroll-y-contain rounded-xl p-2 transition-[background-color,outline-color]",
@@ -127,5 +150,22 @@ export const KanbanVirtualCell = <TRow,>({
       </div>
       {footer}
     </div>
+  );
+
+  if (sortable === undefined) {
+    return content;
+  }
+
+  return (
+    <SortableContext
+      {...(sortable.disabled === undefined
+        ? {}
+        : { disabled: sortable.disabled })}
+      {...(sortable.id === undefined ? {} : { id: sortable.id })}
+      items={rows.map(sortable.getRowId)}
+      strategy={sortable.strategy ?? verticalListSortingStrategy}
+    >
+      {content}
+    </SortableContext>
   );
 };

--- a/packages/ui/src/kanban/virtual-cell.tsx
+++ b/packages/ui/src/kanban/virtual-cell.tsx
@@ -46,7 +46,7 @@ export type KanbanVirtualCellPagination =
 export type KanbanVirtualCellSortableContext<TRow> = {
   getRowId: (row: TRow) => UniqueIdentifier;
   disabled?: SortableContextProps["disabled"] | undefined;
-  id?: UniqueIdentifier | undefined;
+  id?: SortableContextProps["id"] | undefined;
   strategy?: SortingStrategy | undefined;
 };
 

--- a/packages/ui/src/kanban/virtual-cell.tsx
+++ b/packages/ui/src/kanban/virtual-cell.tsx
@@ -7,24 +7,42 @@ import {
   useRef,
 } from "react";
 
-import type { UniqueIdentifier } from "@dnd-kit/core";
+import { useDndContext, type UniqueIdentifier } from "@dnd-kit/core";
 import {
   SortableContext,
   type SortableContextProps,
   type SortingStrategy,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  defaultRangeExtractor,
+  type Range,
+  useVirtualizer,
+} from "@tanstack/react-virtual";
 
 import { cn } from "../lib/utils";
 import {
   useKanbanDropTarget,
+  type KanbanVirtualScrollRequest,
   type UseKanbanDropTargetOptions,
 } from "./sortable-interactions";
 
 const DEFAULT_ESTIMATE_SIZE_PX = 128;
 const DEFAULT_OVERSCAN = 8;
 const DEFAULT_LOAD_MORE_THRESHOLD_PX = 200;
+
+const retainActiveSortableIndex = (
+  range: Range,
+  activeIndex: number,
+): number[] => {
+  const indexes = defaultRangeExtractor(range);
+  if (activeIndex < 0 || indexes.includes(activeIndex)) {
+    return indexes;
+  }
+  indexes.push(activeIndex);
+  indexes.sort((left, right) => left - right);
+  return indexes;
+};
 
 export const KANBAN_VIRTUAL_CELL_PAGINATION = {
   NONE: "none",
@@ -49,7 +67,7 @@ export type KanbanVirtualCellPagination =
  * merely to support dnd-kit consumers.
  */
 export type KanbanVirtualCellSortableContext<TRow> = {
-  dropTarget: Omit<UseKanbanDropTargetOptions, "itemIds">;
+  dropTarget: Omit<UseKanbanDropTargetOptions, "itemIds" | "navigation">;
   getRowId: (row: TRow) => UniqueIdentifier;
   disabled?: SortableContextProps["disabled"] | undefined;
   strategy?: SortingStrategy | undefined;
@@ -92,12 +110,9 @@ export const KanbanVirtualCell = <TRow,>({
   const scrollRef = internalRef;
   const requestedPageKeyRef = useRef<string | number | null>(null);
   const itemIds = sortable ? rows.map(sortable.getRowId) : [];
-  const dropTarget = useKanbanDropTarget({
-    disabled: sortable?.dropTarget.disabled ?? sortable === undefined,
-    id: sortable?.dropTarget.id ?? fallbackDropTargetId,
-    itemIds,
-    position: sortable?.dropTarget.position ?? { column: -1, lane: -1 },
-  });
+  const { active: activeDrag } = useDndContext();
+  const activeSortableIndex =
+    activeDrag === null ? -1 : itemIds.indexOf(activeDrag.id);
   const virtualizer = useVirtualizer({
     count: rows.length,
     estimateSize: () => estimateSize,
@@ -107,6 +122,24 @@ export const KanbanVirtualCell = <TRow,>({
     },
     getScrollElement: () => scrollRef.current,
     overscan,
+    rangeExtractor: (range) =>
+      retainActiveSortableIndex(range, activeSortableIndex),
+  });
+  const requestScroll = ({ itemId }: KanbanVirtualScrollRequest) => {
+    const index = itemIds.indexOf(itemId);
+    if (index !== -1) {
+      virtualizer.scrollToIndex(index, { align: "auto" });
+    }
+  };
+  const dropTarget = useKanbanDropTarget({
+    disabled: sortable?.dropTarget.disabled ?? sortable === undefined,
+    id: sortable?.dropTarget.id ?? fallbackDropTargetId,
+    itemIds,
+    navigation:
+      sortable === undefined
+        ? { type: "static" }
+        : { requestScroll, type: "virtual" },
+    position: sortable?.dropTarget.position ?? { column: -1, lane: -1 },
   });
 
   const handleScroll = ({ currentTarget }: UIEvent<HTMLDivElement>) => {

--- a/packages/ui/src/lib/overlay-layer.ts
+++ b/packages/ui/src/lib/overlay-layer.ts
@@ -7,6 +7,8 @@
 // composer and its veil) is NOT modal, so anything with a dimming backdrop has
 // to cover it. Dialogs sat at z-50 and lost that argument, which left the
 // composer painted on top of a dimmed template-check dialog.
+export const BOARD_DRAG_OVERLAY_Z_INDEX = 75;
+
 export const OVERLAY_LAYER_CLASS_NAMES = {
   /** Docked composer, suggestion chips, and other in-pane floating chrome. */
   chrome: "z-[80]",


### PR DESCRIPTION
## Summary

- let virtual Kanban cells own a typed sortable context for their rows
- prefer cross-cell collision detection for shared sortable boards
- cover touch and keyboard movement between virtual cells

## Validation

- `git diff --check`
- pre-commit secret scan
- format and lint deferred to CI: the isolated worktree lacks the repository binaries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added sortable virtual Kanban cells with explicit drop targets and improved drag-and-drop integration.
  - Added two-axis keyboard navigation across items, columns, lanes and empty cells.
  - Added configurable activation by whole item or drag handle.
  - Added automatic pointer and touch scrolling during drags.
  - Added cancellation when pointer or touch drops occur outside the board.
  - Improved drag overlays so they remain visible above board controls.

- **Documentation**
  - Updated sortable-board guidance and examples for the new activation and virtual-cell behaviours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->