### PR TITLE
fix(api): derive Microsoft identities from stored claims when the signing key is retired

### DIFF
--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
@@ -1,5 +1,5 @@
 import { Result, TaggedError } from "better-result";
-import { decodeJwt, decodeProtectedHeader, jwtVerify } from "jose";
+import { decodeJwt, decodeProtectedHeader, errors, jwtVerify } from "jose";
 import type { JWTVerifyGetKey } from "jose";
 
 import { MAX_MICROSOFT_IDENTITY_MAPPINGS } from "@/api/scripts/better-auth-migration-audit.logic";
@@ -63,6 +63,28 @@ type BetterAuthMicrosoftIdentityMapDerivationError =
 type VerifiedMicrosoftIdentity =
   BetterAuthTrustedIdentityMap["microsoftAccounts"][number];
 
+// How a source's `oid` was established. `signature` is the full check against
+// the provider's published keys. `stored-claims` applies when the token's
+// signing key has been retired by the provider: the token is a value this
+// server stored after a completed login, and every non-signature check
+// (issuer, audience, subject, tenant, lifetime) still applies.
+export const MICROSOFT_IDENTITY_VERIFICATION = {
+  SIGNATURE: "signature",
+  STORED_CLAIMS: "stored-claims",
+} as const;
+type MicrosoftIdentityVerification =
+  (typeof MICROSOFT_IDENTITY_VERIFICATION)[keyof typeof MICROSOFT_IDENTITY_VERIFICATION];
+
+export type BetterAuthMicrosoftIdentityMapDerivation = {
+  identityMap: BetterAuthTrustedIdentityMap;
+  verification: Record<MicrosoftIdentityVerification, number>;
+};
+
+type VerifiedSource = {
+  identity: VerifiedMicrosoftIdentity;
+  verification: MicrosoftIdentityVerification;
+};
+
 type DeriveBetterAuthMicrosoftIdentityMapOptions = {
   clientId: string;
   getSigningKey: JWTVerifyGetKey;
@@ -114,10 +136,7 @@ const verifySource = async ({
   source: BetterAuthMicrosoftIdentitySource;
   tenantId: string;
 }): Promise<
-  Result<
-    VerifiedMicrosoftIdentity,
-    BetterAuthMicrosoftIdentityMapDerivationError
-  >
+  Result<VerifiedSource, BetterAuthMicrosoftIdentityMapDerivationError>
 > => {
   if (
     source.accountRowId.length === 0 ||
@@ -176,6 +195,12 @@ const verifySource = async ({
   // issuer, audience, subject, and temporal-claim verification without
   // pretending an old login token is valid for a new authentication event.
   const verificationTime = new Date((notBefore + 1) * 1000);
+  const identity: VerifiedMicrosoftIdentity = {
+    accountId: objectId,
+    accountRowId: source.accountRowId,
+    issuer,
+    legacyAccountId: source.legacyAccountId,
+  };
   const verified = await Result.tryPromise({
     try: async () =>
       await jwtVerify(idToken, getSigningKey, {
@@ -187,31 +212,49 @@ const verifySource = async ({
         maxTokenAge: `${MICROSOFT_ID_TOKEN_MAX_LIFETIME_SECONDS}s`,
         requiredClaims: ["iss", "aud", "sub", "tid", "oid", "iat", "exp"],
       }),
-    catch: (cause) =>
-      cause instanceof BetterAuthMicrosoftIdentityMapInfrastructureError
-        ? cause
-        : new BetterAuthMicrosoftIdentityMapError({
-            cause,
-            code: "token-verification-failed",
-            message: "Microsoft identity token did not verify",
-          }),
+    catch: (cause) => cause,
   });
-  if (Result.isError(verified)) {
-    return verified;
+  if (Result.isOk(verified)) {
+    if (
+      verified.value.payload.sub !== source.legacyAccountId ||
+      verified.value.payload["oid"] !== objectId ||
+      verified.value.payload["tid"] !== tokenTenant
+    ) {
+      return invalidSourceState();
+    }
+    return Result.ok({
+      identity,
+      verification: MICROSOFT_IDENTITY_VERIFICATION.SIGNATURE,
+    });
   }
   if (
-    verified.value.payload.sub !== source.legacyAccountId ||
-    verified.value.payload["oid"] !== objectId ||
-    verified.value.payload["tid"] !== tokenTenant
+    verified.error instanceof BetterAuthMicrosoftIdentityMapInfrastructureError
   ) {
-    return invalidSourceState();
+    return Result.err(verified.error);
+  }
+  if (!(verified.error instanceof errors.JWKSNoMatchingKey)) {
+    return Result.err(
+      new BetterAuthMicrosoftIdentityMapError({
+        cause: verified.error,
+        code: "token-verification-failed",
+        message: "Microsoft identity token did not verify",
+      }),
+    );
   }
 
+  // The provider no longer publishes this token's signing key, so the
+  // signature cannot be checked. The provider rotates keys on a schedule far
+  // shorter than the age of a stored login token, which makes this the
+  // expected state for any account that has not signed in recently. Every
+  // claim that the signature check would have enforced is applied here
+  // against the decoded payload instead.
+  const audience = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+  if (audience.length !== 1 || audience[0] !== clientId) {
+    return invalidSourceState();
+  }
   return Result.ok({
-    accountId: objectId,
-    accountRowId: source.accountRowId,
-    issuer,
-    legacyAccountId: source.legacyAccountId,
+    identity,
+    verification: MICROSOFT_IDENTITY_VERIFICATION.STORED_CLAIMS,
   });
 };
 
@@ -223,7 +266,7 @@ export const deriveBetterAuthMicrosoftIdentityMap = async ({
   tenantId,
 }: DeriveBetterAuthMicrosoftIdentityMapOptions): Promise<
   Result<
-    BetterAuthTrustedIdentityMap,
+    BetterAuthMicrosoftIdentityMapDerivation,
     BetterAuthMicrosoftIdentityMapDerivationError
   >
 > => {
@@ -256,6 +299,8 @@ export const deriveBetterAuthMicrosoftIdentityMap = async ({
     [];
   const accountRows = new Set<string>();
   const identityKeys = new Set<string>();
+  const verification: BetterAuthMicrosoftIdentityMapDerivation["verification"] =
+    { signature: 0, "stored-claims": 0 };
   const sourceIterator = sources.values();
   const processNextSource = async (): Promise<
     Result<undefined, BetterAuthMicrosoftIdentityMapDerivationError>
@@ -280,7 +325,8 @@ export const deriveBetterAuthMicrosoftIdentityMap = async ({
     if (Result.isError(verified)) {
       return verified;
     }
-    const identityKey = `${verified.value.issuer}\0${verified.value.accountId}`;
+    const { identity, verification: sourceVerification } = verified.value;
+    const identityKey = `${identity.issuer}\0${identity.accountId}`;
     if (identityKeys.has(identityKey)) {
       return Result.err(
         new BetterAuthMicrosoftIdentityMapError({
@@ -290,7 +336,8 @@ export const deriveBetterAuthMicrosoftIdentityMap = async ({
       );
     }
     identityKeys.add(identityKey);
-    microsoftAccounts.push(verified.value);
+    microsoftAccounts.push(identity);
+    verification[sourceVerification] += 1;
     return processNextSource();
   };
   const processed = await processNextSource();
@@ -307,5 +354,8 @@ export const deriveBetterAuthMicrosoftIdentityMap = async ({
     }
     return 0;
   });
-  return Result.ok({ formatVersion: 1, microsoftAccounts });
+  return Result.ok({
+    identityMap: { formatVersion: 1, microsoftAccounts },
+    verification,
+  });
 };

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { errors, exportJWK, generateKeyPair, SignJWT } from "jose";
 import type { JWTVerifyGetKey } from "jose";
 
 import { parseBetterAuthMicrosoftIdentityMapArgs } from "@/api/scripts/better-auth-microsoft-identity-map";
@@ -67,15 +67,18 @@ describe("deriveBetterAuthMicrosoftIdentityMap", () => {
     expect(result.status).toBe("ok");
     if (result.status === "ok") {
       expect(result.value).toEqual({
-        formatVersion: 1,
-        microsoftAccounts: [
-          {
-            accountId: OBJECT_ID,
-            accountRowId: "account-row",
-            issuer: ISSUER,
-            legacyAccountId: "legacy-pairwise-subject",
-          },
-        ],
+        identityMap: {
+          formatVersion: 1,
+          microsoftAccounts: [
+            {
+              accountId: OBJECT_ID,
+              accountRowId: "account-row",
+              issuer: ISSUER,
+              legacyAccountId: "legacy-pairwise-subject",
+            },
+          ],
+        },
+        verification: { signature: 1, "stored-claims": 0 },
       });
     }
   });
@@ -168,8 +171,8 @@ describe("deriveBetterAuthMicrosoftIdentityMap", () => {
     expect(result.status).toBe("ok");
     if (result.status === "ok") {
       expect(result.value).toEqual({
-        formatVersion: 1,
-        microsoftAccounts: [],
+        identityMap: { formatVersion: 1, microsoftAccounts: [] },
+        verification: { signature: 0, "stored-claims": 0 },
       });
     }
   });
@@ -224,6 +227,143 @@ describe("deriveBetterAuthMicrosoftIdentityMap", () => {
     expect(result.status).toBe("error");
     if (result.status === "error") {
       expect(result.error).toBe(infrastructureError);
+    }
+  });
+
+  const retiredSigningKey = async () => {
+    throw new errors.JWKSNoMatchingKey();
+  };
+
+  test("derives the identity from stored claims when the signing key is retired", async () => {
+    const fixture = await createTokenFixture();
+    const result = await deriveBetterAuthMicrosoftIdentityMap({
+      clientId: CLIENT_ID,
+      getSigningKey: retiredSigningKey,
+      now: NOW,
+      sources: [
+        {
+          accountRowId: "account-row",
+          idToken: fixture.token,
+          legacyAccountId: "legacy-pairwise-subject",
+        },
+      ],
+      tenantId: "common",
+    });
+
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.value).toEqual({
+        identityMap: {
+          formatVersion: 1,
+          microsoftAccounts: [
+            {
+              accountId: OBJECT_ID,
+              accountRowId: "account-row",
+              issuer: ISSUER,
+              legacyAccountId: "legacy-pairwise-subject",
+            },
+          ],
+        },
+        verification: { signature: 0, "stored-claims": 1 },
+      });
+    }
+  });
+
+  test("counts signature and stored-claims sources separately", async () => {
+    const live = await createTokenFixture({
+      keyId: "live-key",
+      subject: "legacy-one",
+    });
+    const retired = await createTokenFixture({
+      keyId: "retired-key",
+      objectId: "44444444-4444-4444-8444-444444444444",
+      subject: "legacy-two",
+    });
+    const result = await deriveBetterAuthMicrosoftIdentityMap({
+      clientId: CLIENT_ID,
+      getSigningKey: async (header) => {
+        if (header.kid === "live-key") {
+          return PUBLIC_JWK;
+        }
+        throw new errors.JWKSNoMatchingKey();
+      },
+      now: NOW,
+      sources: [
+        {
+          accountRowId: "account-one",
+          idToken: live.token,
+          legacyAccountId: "legacy-one",
+        },
+        {
+          accountRowId: "account-two",
+          idToken: retired.token,
+          legacyAccountId: "legacy-two",
+        },
+      ],
+      tenantId: TENANT_ID,
+    });
+
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.value.verification).toEqual({
+        signature: 1,
+        "stored-claims": 1,
+      });
+      expect(result.value.identityMap.microsoftAccounts).toHaveLength(2);
+    }
+  });
+
+  test.each([
+    ["wrong audience", { audience: "other-client" }, "legacy-pairwise-subject"],
+    [
+      "wrong issuer",
+      { issuer: "https://issuer.example/v2.0" },
+      "legacy-pairwise-subject",
+    ],
+    ["wrong subject", {}, "different-subject"],
+  ])(
+    "still rejects %s when the signing key is retired",
+    async (_name, fixtureOverrides, legacyAccountId) => {
+      const fixture = await createTokenFixture(fixtureOverrides);
+      const result = await deriveBetterAuthMicrosoftIdentityMap({
+        clientId: CLIENT_ID,
+        getSigningKey: retiredSigningKey,
+        now: NOW,
+        sources: [
+          {
+            accountRowId: "account-row",
+            idToken: fixture.token,
+            legacyAccountId,
+          },
+        ],
+        tenantId: "common",
+      });
+
+      expect(result.status).toBe("error");
+    },
+  );
+
+  test("rejects a token whose signature fails against a published key", async () => {
+    const fixture = await createTokenFixture();
+    const { publicKey: otherPublicKey } = await generateKeyPair("RS256");
+    const otherJwk = await exportJWK(otherPublicKey);
+    const result = await deriveBetterAuthMicrosoftIdentityMap({
+      clientId: CLIENT_ID,
+      getSigningKey: async () => otherJwk,
+      now: NOW,
+      sources: [
+        {
+          accountRowId: "account-row",
+          idToken: fixture.token,
+          legacyAccountId: "legacy-pairwise-subject",
+        },
+      ],
+      tenantId: "common",
+    });
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error.code).toBe("token-verification-failed");
     }
   });
 });

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.ts
@@ -277,7 +277,7 @@ const run = async (args: readonly string[]) => {
       [customFetch]: microsoftJwksFetch,
     },
   );
-  const identityMap = await deriveBetterAuthMicrosoftIdentityMap({
+  const derivation = await deriveBetterAuthMicrosoftIdentityMap({
     clientId,
     getSigningKey: jwks,
     now: new Date(),
@@ -285,10 +285,17 @@ const run = async (args: readonly string[]) => {
     tenantId,
   });
   await client.end();
-  if (Result.isError(identityMap)) {
-    return identityMap;
+  if (Result.isError(derivation)) {
+    return derivation;
   }
-  return await persistIdentityMap(parsed.value.outputPath, identityMap.value);
+  const persisted = await persistIdentityMap(
+    parsed.value.outputPath,
+    derivation.value.identityMap,
+  );
+  if (Result.isError(persisted)) {
+    return persisted;
+  }
+  return Result.ok(derivation.value.verification);
 };
 
 if (import.meta.main) {
@@ -303,7 +310,11 @@ if (import.meta.main) {
         return undefined;
       }
       process.stdout.write(
-        `${JSON.stringify({ check: "microsoft-identity-map", status: "passed" })}\n`,
+        `${JSON.stringify({
+          check: "microsoft-identity-map",
+          status: "passed",
+          verification: result.value,
+        })}\n`,
       );
       process.exitCode = EXIT_CODE.SUCCESS;
       return undefined;


### PR DESCRIPTION
The Microsoft identity derivation verified every stored ID token against the provider's currently published signing keys and aborted on the first token whose key was no longer published. The provider rotates keys on a schedule shorter than the age of a typical stored login token, so any inventory with an account that has not signed in recently could never be derived.

When the key for a token has been retired (`JWKSNoMatchingKey`), the derivation now takes the `oid` from the stored claims while keeping every other check the signature path enforced: issuer, audience, subject, tenant, algorithm, and lifetime. A token whose key is published but whose signature fails still aborts. The derivation result carries per-path counts (`signature`, `stored-claims`), and the script prints them on success so the audit can see how each identity was established.

Tests cover the stored-claims path, mixed inventories, the retained claim checks under a retired key, and a signature failure against a published key.
