### PR TITLE
fix(api): accept personal-account Microsoft tokens in the identity derivation

### DIFF
--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
@@ -8,8 +8,9 @@ import type { BetterAuthTrustedIdentityMap } from "@/api/scripts/better-auth-mig
 const MICROSOFT_AUTHORITY = "https://login.microsoftonline.com";
 const MICROSOFT_ID_TOKEN_ALGORITHM = "RS256";
 // Work and school tokens live about an hour; personal-account tokens are
-// issued for a full day. Bound at the longer documented lifetime.
-const MICROSOFT_ID_TOKEN_MAX_LIFETIME_SECONDS = 24 * 60 * 60;
+// issued for a full day. Each class is bounded by its own documented lifetime.
+const MICROSOFT_ID_TOKEN_MAX_LIFETIME_SECONDS = 2 * 60 * 60;
+const MICROSOFT_CONSUMER_ID_TOKEN_MAX_LIFETIME_SECONDS = 24 * 60 * 60;
 const MICROSOFT_ID_TOKEN_CLOCK_TOLERANCE_SECONDS = 60;
 const MICROSOFT_TENANT = {
   COMMON: "common",
@@ -174,8 +175,20 @@ const verifySource = async ({
     header.kid.length === 0 ||
     typeof tokenTenant !== "string" ||
     !UUID_PATTERN.test(tokenTenant) ||
+    !isAllowedTokenTenant(tenantId, tokenTenant)
+  ) {
+    return invalidSourceState();
+  }
+  // Personal accounts carry a zero-prefixed object id and a day-long token;
+  // work and school tenants keep the RFC 4122 shape and the short lifetime.
+  const isConsumerToken = tokenTenant === MICROSOFT_CONSUMER_TENANT_ID;
+  const objectIdPattern = isConsumerToken ? OBJECT_ID_PATTERN : UUID_PATTERN;
+  const maxLifetimeSeconds = isConsumerToken
+    ? MICROSOFT_CONSUMER_ID_TOKEN_MAX_LIFETIME_SECONDS
+    : MICROSOFT_ID_TOKEN_MAX_LIFETIME_SECONDS;
+  if (
     typeof objectId !== "string" ||
-    !OBJECT_ID_PATTERN.test(objectId) ||
+    !objectIdPattern.test(objectId) ||
     typeof issuedAt !== "number" ||
     typeof notBefore !== "number" ||
     typeof expiresAt !== "number" ||
@@ -184,8 +197,7 @@ const verifySource = async ({
         MICROSOFT_ID_TOKEN_CLOCK_TOLERANCE_SECONDS ||
     notBefore < issuedAt - MICROSOFT_ID_TOKEN_CLOCK_TOLERANCE_SECONDS ||
     expiresAt <= notBefore ||
-    expiresAt - issuedAt > MICROSOFT_ID_TOKEN_MAX_LIFETIME_SECONDS ||
-    !isAllowedTokenTenant(tenantId, tokenTenant)
+    expiresAt - issuedAt > maxLifetimeSeconds
   ) {
     return invalidSourceState();
   }
@@ -215,7 +227,7 @@ const verifySource = async ({
         clockTolerance: MICROSOFT_ID_TOKEN_CLOCK_TOLERANCE_SECONDS,
         currentDate: verificationTime,
         issuer,
-        maxTokenAge: `${MICROSOFT_ID_TOKEN_MAX_LIFETIME_SECONDS}s`,
+        maxTokenAge: `${maxLifetimeSeconds}s`,
         requiredClaims: ["iss", "aud", "sub", "tid", "oid", "iat", "exp"],
       }),
     catch: (cause) => cause,

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
@@ -7,7 +7,9 @@ import type { BetterAuthTrustedIdentityMap } from "@/api/scripts/better-auth-mig
 
 const MICROSOFT_AUTHORITY = "https://login.microsoftonline.com";
 const MICROSOFT_ID_TOKEN_ALGORITHM = "RS256";
-const MICROSOFT_ID_TOKEN_MAX_LIFETIME_SECONDS = 2 * 60 * 60;
+// Work and school tokens live about an hour; personal-account tokens are
+// issued for a full day. Bound at the longer documented lifetime.
+const MICROSOFT_ID_TOKEN_MAX_LIFETIME_SECONDS = 24 * 60 * 60;
 const MICROSOFT_ID_TOKEN_CLOCK_TOLERANCE_SECONDS = 60;
 const MICROSOFT_TENANT = {
   COMMON: "common",
@@ -27,6 +29,10 @@ const MICROSOFT_CONSUMER_TENANT_ID = [
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+// Directory object ids share the UUID layout but personal accounts carry a
+// zero-prefixed form that is not RFC 4122, so only the shape is checked.
+const OBJECT_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 
 export type BetterAuthMicrosoftIdentitySource = {
   accountRowId: string;
@@ -169,7 +175,7 @@ const verifySource = async ({
     typeof tokenTenant !== "string" ||
     !UUID_PATTERN.test(tokenTenant) ||
     typeof objectId !== "string" ||
-    !UUID_PATTERN.test(objectId) ||
+    !OBJECT_ID_PATTERN.test(objectId) ||
     typeof issuedAt !== "number" ||
     typeof notBefore !== "number" ||
     typeof expiresAt !== "number" ||

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
@@ -25,23 +25,27 @@ const createTokenFixture = async ({
   audience = CLIENT_ID,
   issuer = ISSUER,
   keyId = "fixture-key",
+  lifetimeSeconds = 3600,
   objectId = OBJECT_ID,
   subject = "legacy-pairwise-subject",
+  tenant = TENANT_ID,
 }: {
   audience?: string;
   issuer?: string;
   keyId?: string;
+  lifetimeSeconds?: number;
   objectId?: string;
   subject?: string;
+  tenant?: string;
 } = {}) => {
-  const token = await new SignJWT({ oid: objectId, tid: TENANT_ID })
+  const token = await new SignJWT({ oid: objectId, tid: tenant })
     .setProtectedHeader({ alg: "RS256", kid: keyId })
     .setIssuer(issuer)
     .setAudience(audience)
     .setSubject(subject)
     .setIssuedAt(ISSUED_AT)
     .setNotBefore(ISSUED_AT)
-    .setExpirationTime(ISSUED_AT + 3600)
+    .setExpirationTime(ISSUED_AT + lifetimeSeconds)
     .sign(SIGNING_KEY);
   const getSigningKey: JWTVerifyGetKey = async () => PUBLIC_JWK;
   return { getSigningKey, token };
@@ -342,6 +346,61 @@ describe("deriveBetterAuthMicrosoftIdentityMap", () => {
       expect(result.status).toBe("error");
     },
   );
+
+  test("accepts a personal-account token with a day-long lifetime and non-RFC oid", async () => {
+    const consumerTenant = "9188040d-6c67-4c5b-b112-36a304b66dad";
+    const consumerObjectId = "00000000-0000-0000-1a2b-3c4d5e6f7a8b";
+    const fixture = await createTokenFixture({
+      issuer: `https://login.microsoftonline.com/${consumerTenant}/v2.0`,
+      lifetimeSeconds: 24 * 60 * 60,
+      objectId: consumerObjectId,
+      tenant: consumerTenant,
+    });
+    const result = await deriveBetterAuthMicrosoftIdentityMap({
+      clientId: CLIENT_ID,
+      getSigningKey: retiredSigningKey,
+      now: NOW,
+      sources: [
+        {
+          accountRowId: "account-row",
+          idToken: fixture.token,
+          legacyAccountId: "legacy-pairwise-subject",
+        },
+      ],
+      tenantId: "common",
+    });
+
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.value.identityMap.microsoftAccounts).toEqual([
+        {
+          accountId: consumerObjectId,
+          accountRowId: "account-row",
+          issuer: `https://login.microsoftonline.com/${consumerTenant}/v2.0`,
+          legacyAccountId: "legacy-pairwise-subject",
+        },
+      ]);
+    }
+  });
+
+  test("rejects a token whose lifetime exceeds a day", async () => {
+    const fixture = await createTokenFixture({ lifetimeSeconds: 25 * 60 * 60 });
+    const result = await deriveBetterAuthMicrosoftIdentityMap({
+      clientId: CLIENT_ID,
+      getSigningKey: fixture.getSigningKey,
+      now: NOW,
+      sources: [
+        {
+          accountRowId: "account-row",
+          idToken: fixture.token,
+          legacyAccountId: "legacy-pairwise-subject",
+        },
+      ],
+      tenantId: "common",
+    });
+
+    expect(result.status).toBe("error");
+  });
 
   test("rejects a token whose signature fails against a published key", async () => {
     const fixture = await createTokenFixture();

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
@@ -433,6 +433,9 @@ describe("deriveBetterAuthMicrosoftIdentityMap", () => {
     });
 
     expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.error.code).toBe("invalid-source-state");
+    }
   });
 
   test("rejects a token whose signature fails against a published key", async () => {

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
@@ -383,8 +383,41 @@ describe("deriveBetterAuthMicrosoftIdentityMap", () => {
     }
   });
 
-  test("rejects a token whose lifetime exceeds a day", async () => {
-    const fixture = await createTokenFixture({ lifetimeSeconds: 25 * 60 * 60 });
+  test.each([
+    ["a day-long lifetime", { lifetimeSeconds: 24 * 60 * 60 }],
+    [
+      "a non-RFC object id",
+      { objectId: "00000000-0000-0000-1a2b-3c4d5e6f7a8b" },
+    ],
+  ])(
+    "rejects a work or school token with %s",
+    async (_name, fixtureOverrides) => {
+      const fixture = await createTokenFixture(fixtureOverrides);
+      const result = await deriveBetterAuthMicrosoftIdentityMap({
+        clientId: CLIENT_ID,
+        getSigningKey: retiredSigningKey,
+        now: NOW,
+        sources: [
+          {
+            accountRowId: "account-row",
+            idToken: fixture.token,
+            legacyAccountId: "legacy-pairwise-subject",
+          },
+        ],
+        tenantId: "common",
+      });
+
+      expect(result.status).toBe("error");
+    },
+  );
+
+  test("rejects a personal-account token whose lifetime exceeds a day", async () => {
+    const consumerTenant = "9188040d-6c67-4c5b-b112-36a304b66dad";
+    const fixture = await createTokenFixture({
+      issuer: `https://login.microsoftonline.com/${consumerTenant}/v2.0`,
+      lifetimeSeconds: 25 * 60 * 60,
+      tenant: consumerTenant,
+    });
     const result = await deriveBetterAuthMicrosoftIdentityMap({
       clientId: CLIENT_ID,
       getSigningKey: fixture.getSigningKey,


### PR DESCRIPTION
The Microsoft identity derivation rejected personal-account tokens on two shape checks: it required an RFC 4122 `oid` (personal accounts carry a zero-prefixed form) and capped the token lifetime at two hours (personal-account tokens are issued for a day). Both are now bounded by the documented shapes: `oid` must have the UUID layout, and lifetime must not exceed a day. Tenant ids keep the RFC check.

Tests cover a personal-account token and a lifetime beyond a day.

https://claude.ai/code/session_019Tx4ydN2CULWU5o7DV1fGF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Microsoft account sign-in support for personal-account tokens with lifetimes of up to 24 hours.
  * Correctly handles valid personal-account directory identifiers that do not follow standard UUID formatting.
  * Rejects tokens whose lifetime exceeds the supported one-day limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->