### PR TITLE
fix(api): allow the provider's issuance padding on personal-account token lifetimes

### DIFF
--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.logic.ts
@@ -8,9 +8,13 @@ import type { BetterAuthTrustedIdentityMap } from "@/api/scripts/better-auth-mig
 const MICROSOFT_AUTHORITY = "https://login.microsoftonline.com";
 const MICROSOFT_ID_TOKEN_ALGORITHM = "RS256";
 // Work and school tokens live about an hour; personal-account tokens are
-// issued for a full day. Each class is bounded by its own documented lifetime.
+// issued for a full day. The provider pads both by five minutes of issuance
+// skew (`exp - iat` is 65 minutes and 24 hours 5 minutes respectively), so
+// each class is bounded by its documented lifetime plus that padding.
+const MICROSOFT_ID_TOKEN_ISSUANCE_SKEW_SECONDS = 5 * 60;
 const MICROSOFT_ID_TOKEN_MAX_LIFETIME_SECONDS = 2 * 60 * 60;
-const MICROSOFT_CONSUMER_ID_TOKEN_MAX_LIFETIME_SECONDS = 24 * 60 * 60;
+const MICROSOFT_CONSUMER_ID_TOKEN_MAX_LIFETIME_SECONDS =
+  24 * 60 * 60 + MICROSOFT_ID_TOKEN_ISSUANCE_SKEW_SECONDS;
 const MICROSOFT_ID_TOKEN_CLOCK_TOLERANCE_SECONDS = 60;
 const MICROSOFT_TENANT = {
   COMMON: "common",

--- a/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
+++ b/apps/api/src/scripts/better-auth-microsoft-identity-map.test.ts
@@ -352,7 +352,8 @@ describe("deriveBetterAuthMicrosoftIdentityMap", () => {
     const consumerObjectId = "00000000-0000-0000-1a2b-3c4d5e6f7a8b";
     const fixture = await createTokenFixture({
       issuer: `https://login.microsoftonline.com/${consumerTenant}/v2.0`,
-      lifetimeSeconds: 24 * 60 * 60,
+      // A day plus the provider's five-minute issuance padding.
+      lifetimeSeconds: 24 * 60 * 60 + 5 * 60,
       objectId: consumerObjectId,
       tenant: consumerTenant,
     });


### PR DESCRIPTION
Personal-account Microsoft tokens are issued for a day, but the provider pads `exp - iat` by five minutes of issuance skew (work and school tokens show the same padding on top of their hour). The day bound therefore rejected every personal-account token by five minutes. The consumer bound now includes the documented padding; the work and school bound is unchanged.

The accepted-token test uses the padded lifetime; the rejection at a day plus an hour is unchanged.

https://claude.ai/code/session_019Tx4ydN2CULWU5o7DV1fGF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sign-in reliability for personal Microsoft accounts by allowing for the small timing difference between token issuance and validation.
  - Preserved the existing validation window for work and school Microsoft accounts.
  - Updated automated coverage to reflect the adjusted personal-account token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->