### PR TITLE
fix: stabilize filesystem rename interactions

### DIFF
--- a/apps/web/e2e/specs/filesystem-rename.spec.ts
+++ b/apps/web/e2e/specs/filesystem-rename.spec.ts
@@ -1,0 +1,130 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { apiStatus, apiUploadDocx } from "../helpers/api";
+import { expect, test } from "../helpers/test";
+import {
+  type TestWorkspace,
+  createTestWorkspace,
+  deleteTestWorkspace,
+} from "../helpers/workspace";
+
+const DOCX_MIME =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+const DOCX_PATH = path.resolve(import.meta.dirname, "../fixtures/simple.docx");
+const LONG_BASE_NAME =
+  "Postmoney Safe - Valuation Cap Only v1.1 (Singapore)-b4ed2ab41662c2c996943b630306b02fcbb86e7f5ec6ecc958250285cfd68";
+
+test.describe("filesystem rename", () => {
+  let workspace: TestWorkspace | null = null;
+
+  test.beforeEach(async ({ request }) => {
+    workspace = await createTestWorkspace(request, "filesystem-rename");
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (workspace === null) {
+      return;
+    }
+
+    await deleteTestWorkspace(request, workspace.id);
+    workspace = null;
+  });
+
+  test("long names remain editable and update immediately on Enter", async ({
+    page,
+    request,
+  }) => {
+    const testWorkspace = workspace;
+    if (testWorkspace === null) {
+      throw new Error("Test workspace was not created");
+    }
+
+    await apiUploadDocx(
+      request,
+      testWorkspace.id,
+      testWorkspace.filePropertyId,
+      {
+        name: `${LONG_BASE_NAME}.docx`,
+        mimeType: DOCX_MIME,
+        buffer: await readFile(DOCX_PATH),
+      },
+    );
+
+    const { cookies } = await request.storageState();
+    await page.context().addCookies(cookies);
+    await expect
+      .poll(
+        async () =>
+          await apiStatus(page.request, `/workspaces/${testWorkspace.id}`),
+        { message: "browser context can read the created workspace" },
+      )
+      .toBe(200);
+
+    await page.goto(`/workspaces/${testWorkspace.id}/${testWorkspace.viewId}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.getByRole("tab", { exact: true, name: "Files" }).click();
+
+    const originalRow = page.getByRole("button", {
+      name: LONG_BASE_NAME,
+    });
+    await expect(originalRow).toBeVisible({ timeout: 30_000 });
+    await originalRow.click({ button: "right" });
+    await page.getByRole("menuitem", { exact: true, name: "Rename" }).click();
+
+    const input = page.getByRole("textbox");
+    await expect(input).toBeVisible();
+    expect(
+      await input.evaluate((element) => element.clientWidth),
+    ).toBeGreaterThan(300);
+    await expect(input.locator("xpath=ancestor::button")).toHaveCount(0);
+
+    const inputBox = await input.boundingBox();
+    if (inputBox === null) {
+      throw new Error("Rename input has no bounding box");
+    }
+    await page.mouse.move(
+      inputBox.x + inputBox.width * 0.2,
+      inputBox.y + inputBox.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      inputBox.x + inputBox.width * 0.8,
+      inputBox.y + inputBox.height / 2,
+    );
+    await page.mouse.up();
+    expect(
+      await input.evaluate(
+        (element) =>
+          element instanceof HTMLInputElement &&
+          element.selectionEnd !== element.selectionStart,
+      ),
+    ).toBe(true);
+
+    const renameRequest = Promise.withResolvers<undefined>();
+    await page.route("**/v1/entities/*/rename", async (route) => {
+      await renameRequest.promise;
+      await route.continue();
+    });
+
+    const renamedBase = `${LONG_BASE_NAME}-renamed`;
+    await input.fill(renamedBase);
+    const renameResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PATCH" &&
+        response.url().includes("/v1/entities/") &&
+        response.url().endsWith("/rename"),
+    );
+    await input.press("Enter");
+
+    const renamedRow = page.getByRole("button", {
+      name: renamedBase,
+    });
+    await expect(renamedRow).toBeVisible({ timeout: 1000 });
+
+    renameRequest.resolve(undefined);
+    expect((await renameResponse).status()).toBe(200);
+    await expect(renamedRow).toBeVisible();
+  });
+});

--- a/apps/web/e2e/specs/filesystem-rename.spec.ts
+++ b/apps/web/e2e/specs/filesystem-rename.spec.ts
@@ -66,11 +66,13 @@ test.describe("filesystem rename", () => {
     });
     await page.getByRole("tab", { exact: true, name: "Files" }).click();
 
-    const originalRow = page.getByRole("button", {
-      name: LONG_BASE_NAME,
+    const originalName = page.getByTitle(`${LONG_BASE_NAME}.docx`, {
+      exact: true,
     });
-    await expect(originalRow).toBeVisible({ timeout: 30_000 });
-    await originalRow.click({ button: "right" });
+    await expect(originalName).toBeVisible({ timeout: 30_000 });
+    await originalName.locator("xpath=ancestor::button[1]").click({
+      button: "right",
+    });
     await page.getByRole("menuitem", { exact: true, name: "Rename" }).click();
 
     const input = page.getByRole("textbox");
@@ -118,13 +120,13 @@ test.describe("filesystem rename", () => {
     );
     await input.press("Enter");
 
-    const renamedRow = page.getByRole("button", {
-      name: renamedBase,
+    const renamedName = page.getByTitle(`${renamedBase}.docx`, {
+      exact: true,
     });
-    await expect(renamedRow).toBeVisible({ timeout: 1000 });
+    await expect(renamedName).toBeVisible({ timeout: 1000 });
 
     renameRequest.resolve(undefined);
     expect((await renameResponse).status()).toBe(200);
-    await expect(renamedRow).toBeVisible();
+    await expect(renamedName).toBeVisible();
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -1337,7 +1337,6 @@ const FilesystemRow = ({
   const getCurrentAncestorIds = useLatestCallback((id: string) =>
     getAncestorIds(id),
   );
-  const canDrag = useLatestCallback(() => !isEditing);
   const toggleCurrentFolder = useLatestCallback(() => {
     onToggleFolder(node.entityId);
   });
@@ -1377,73 +1376,76 @@ const FilesystemRow = ({
       return undefined;
     }
     const cleanup = combine(
-      draggable({
-        element: el,
-        canDrag,
-        getInitialData: () => {
-          const sel = getCurrentSelectedIds();
-          const isMulti = sel.size > 1 && sel.has(node.entityId);
-          // When the dragged item is part of a multi-selection,
-          // include all selected entity IDs in the drag data.
-          const entityIds = isMulti ? [...sel] : [node.entityId];
-          // Include metadata for each entity so drop targets
-          // (e.g. the chat panel) can create mentions for all.
-          const entities = isMulti
-            ? getCurrentSelectedEntities(sel).map((e) => ({
-                entityId: e.entityId,
-                name: getEntityName(e),
-                kind: e.kind,
-                mimeType: getFirstFile(e)?.mimeType ?? null,
-                parentId: e.parentId ?? null,
-                ancestorIds: getCurrentAncestorIds(e.entityId),
-              }))
-            : [
-                {
-                  entityId: node.entityId,
-                  name,
-                  kind: node.kind,
-                  mimeType: file?.mimeType ?? null,
-                  parentId: node.parentId ?? null,
-                  ancestorIds: getCurrentAncestorIds(node.entityId),
-                },
-              ];
-          return withDragAnnouncementData(
-            {
-              type: ENTITY_DRAG_TYPE,
-              entityId: node.entityId,
-              entityIds,
-              entities,
-              parentId: node.parentId ?? null,
-              name,
-              kind: node.kind,
-              mimeType: file?.mimeType ?? null,
-            },
-            isMulti
-              ? t("common.dragAndDrop.selectedItems", {
-                  count: entityIds.length,
-                })
-              : name,
-            entityIds.length,
-          );
-        },
-        onGenerateDragPreview: ({ nativeSetDragImage }) => {
-          setCustomNativeDragPreview({
-            nativeSetDragImage,
-            render: ({ container }) => {
-              const sel = getCurrentSelectedIds();
-              if (sel.size > 1 && sel.has(node.entityId)) {
-                const items = getCurrentSelectedDragItems(sel);
-                return renderMultiDragPreview(container, items);
-              }
-              return renderDragPreview(container, {
-                name,
-                kind: node.kind,
-                mimeType: file?.mimeType ?? null,
-              });
-            },
-          });
-        },
-      }),
+      ...(!isEditing
+        ? [
+            draggable({
+              element: el,
+              getInitialData: () => {
+                const sel = getCurrentSelectedIds();
+                const isMulti = sel.size > 1 && sel.has(node.entityId);
+                // When the dragged item is part of a multi-selection,
+                // include all selected entity IDs in the drag data.
+                const entityIds = isMulti ? [...sel] : [node.entityId];
+                // Include metadata for each entity so drop targets
+                // (e.g. the chat panel) can create mentions for all.
+                const entities = isMulti
+                  ? getCurrentSelectedEntities(sel).map((e) => ({
+                      entityId: e.entityId,
+                      name: getEntityName(e),
+                      kind: e.kind,
+                      mimeType: getFirstFile(e)?.mimeType ?? null,
+                      parentId: e.parentId ?? null,
+                      ancestorIds: getCurrentAncestorIds(e.entityId),
+                    }))
+                  : [
+                      {
+                        entityId: node.entityId,
+                        name,
+                        kind: node.kind,
+                        mimeType: file?.mimeType ?? null,
+                        parentId: node.parentId ?? null,
+                        ancestorIds: getCurrentAncestorIds(node.entityId),
+                      },
+                    ];
+                return withDragAnnouncementData(
+                  {
+                    type: ENTITY_DRAG_TYPE,
+                    entityId: node.entityId,
+                    entityIds,
+                    entities,
+                    parentId: node.parentId ?? null,
+                    name,
+                    kind: node.kind,
+                    mimeType: file?.mimeType ?? null,
+                  },
+                  isMulti
+                    ? t("common.dragAndDrop.selectedItems", {
+                        count: entityIds.length,
+                      })
+                    : name,
+                  entityIds.length,
+                );
+              },
+              onGenerateDragPreview: ({ nativeSetDragImage }) => {
+                setCustomNativeDragPreview({
+                  nativeSetDragImage,
+                  render: ({ container }) => {
+                    const sel = getCurrentSelectedIds();
+                    if (sel.size > 1 && sel.has(node.entityId)) {
+                      const items = getCurrentSelectedDragItems(sel);
+                      return renderMultiDragPreview(container, items);
+                    }
+                    return renderDragPreview(container, {
+                      name,
+                      kind: node.kind,
+                      mimeType: file?.mimeType ?? null,
+                    });
+                  },
+                });
+              },
+            }),
+          ]
+        : []),
       // Only folders are drop targets.
       ...(isFolder
         ? [
@@ -1500,9 +1502,9 @@ const FilesystemRow = ({
     name,
     file?.mimeType,
     isFolder,
+    isEditing,
     workspaceId,
     scheduleAutoExpand,
-    canDrag,
     getCurrentSelectedDragItems,
     getCurrentSelectedEntities,
     isExpanded,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -948,10 +948,10 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
                         "tree-view.navigate-to-folder",
                       );
                     }}
-                    onRename={(entityId, name, { onError }) => {
+                    onRename={(entityId, name, { onError, onSuccess }) => {
                       renameEntity.mutate(
                         { workspaceId, entityId, name },
-                        { onError },
+                        { onError, onSuccess },
                       );
                     }}
                     onClearSelection={clearSelection}
@@ -1152,7 +1152,7 @@ type FilesystemRowProps = {
   onRename: (
     entityId: string,
     name: string,
-    callbacks: { onError: () => void },
+    callbacks: { onError: () => void; onSuccess: () => void },
   ) => void;
   onClearSelection: () => void;
   onSelect: (entityId: string, mods: { meta: boolean; shift: boolean }) => void;
@@ -1246,12 +1246,14 @@ const FilesystemRow = ({
     if (trimmed && fullName !== name) {
       const pendingRename = { previousName: name, name: fullName };
       setOptimisticRename(pendingRename);
+      const clearPendingRename = () => {
+        setOptimisticRename((current) =>
+          current === pendingRename ? null : current,
+        );
+      };
       onRename(node.entityId, fullName, {
-        onError: () => {
-          setOptimisticRename((current) =>
-            current === pendingRename ? null : current,
-          );
-        },
+        onError: clearPendingRename,
+        onSuccess: clearPendingRename,
       });
     }
   };
@@ -1598,6 +1600,9 @@ const FilesystemRow = ({
   );
 
   const openInInspector = (() => {
+    if (optimisticRename !== null) {
+      return undefined;
+    }
     if (isBulkSelected) {
       const entities = getSelectedEntities(selectedIds);
       const navigables: Omit<FileTab, "type">[] = [];

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -15,7 +15,7 @@ import {
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/utils/combine";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/utils/set-custom-native-drag-preview";
 import { useHotkey } from "@tanstack/react-hotkeys";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { ArrowDownIcon, ArrowUpIcon, EyeOffIcon, FileIcon } from "lucide-react";
@@ -304,6 +304,7 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
   const { data: properties } = useSuspenseQuery(propertiesOptions(workspaceId));
   const moveEntity = useMoveEntity();
   const renameEntity = useRenameEntity();
+  const queryClient = useQueryClient();
   const updateView = useUpdateView(workspaceId);
   const [editingEntityId, setEditingEntityId] = useState<string | null>(null);
   const [breadcrumbEditValue, setBreadcrumbEditValue] = useState("");
@@ -348,16 +349,15 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
 
   // Defers the key so useSuspenseQuery keeps showing stale data instead of
   // triggering the suspense boundary when filters or sorts change.
+  const filesystemQueryInput = useDeferredValue({
+    workspaceId,
+    filters,
+    sorts,
+    fieldMode: "visible",
+    fieldIds,
+  } satisfies Parameters<typeof filesystemEntitiesOptions>[0]);
   const { data: entityData } = useSuspenseQuery(
-    filesystemEntitiesOptions(
-      useDeferredValue({
-        workspaceId,
-        filters,
-        sorts,
-        fieldMode: "visible",
-        fieldIds,
-      }),
-    ),
+    filesystemEntitiesOptions(filesystemQueryInput),
   );
   const data = entityData.entities;
   // Parent links of ancestor folders the API backfills when a filter/search
@@ -951,7 +951,29 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
                     onRename={(entityId, name, { onError, onSuccess }) => {
                       renameEntity.mutate(
                         { workspaceId, entityId, name },
-                        { onError, onSuccess },
+                        {
+                          onError,
+                          onSuccess: () => {
+                            queryClient.setQueryData(
+                              filesystemEntitiesOptions(filesystemQueryInput)
+                                .queryKey,
+                              (current) => {
+                                if (!current) {
+                                  return current;
+                                }
+                                return {
+                                  ...current,
+                                  entities: current.entities.map((entity) =>
+                                    entity.entityId === entityId
+                                      ? { ...entity, name }
+                                      : entity,
+                                  ),
+                                };
+                              },
+                            );
+                            onSuccess();
+                          },
+                        },
                       );
                     }}
                     onClearSelection={clearSelection}
@@ -1235,6 +1257,9 @@ const FilesystemRow = ({
   const baseName = extIndex > 0 ? name.slice(0, extIndex) : name;
 
   const startEditing = () => {
+    if (optimisticRename !== null) {
+      return;
+    }
     setEditValue(baseName);
     onStartEditing(node.entityId);
   };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -1496,7 +1496,8 @@ const FilesystemRow = ({
     >
       {isEditing ? (
         <InlineEdit
-          inputClassName="w-48"
+          className="min-w-0 flex-1"
+          inputClassName="min-w-0 flex-1"
           onCancel={cancelEditing}
           onChange={setEditValue}
           onCommit={commitRename}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -948,12 +948,11 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
                         "tree-view.navigate-to-folder",
                       );
                     }}
-                    onRename={(entityId, newName) => {
-                      renameEntity.mutate({
-                        workspaceId,
-                        entityId,
-                        name: newName,
-                      });
+                    onRename={(entityId, name, { onError }) => {
+                      renameEntity.mutate(
+                        { workspaceId, entityId, name },
+                        { onError },
+                      );
                     }}
                     onClearSelection={clearSelection}
                     onSelect={handleSelect}
@@ -1150,7 +1149,11 @@ type FilesystemRowProps = {
   onToggleFolder: (folderId: string) => void;
   onNavigateToFolder: (folderId: string) => void;
   onStartEditing: (entityId: string | null) => void;
-  onRename: (entityId: string, newName: string) => void;
+  onRename: (
+    entityId: string,
+    name: string,
+    callbacks: { onError: () => void },
+  ) => void;
   onClearSelection: () => void;
   onSelect: (entityId: string, mods: { meta: boolean; shift: boolean }) => void;
   onSubfolderCreated: (entityId: string, parentId: string) => void;
@@ -1198,11 +1201,19 @@ const FilesystemRow = ({
   const contextAnchor =
     menuState.type === "context" ? menuState.anchor : undefined;
   const [editValue, setEditValue] = useState("");
+  const [optimisticRename, setOptimisticRename] = useState<{
+    previousName: string;
+    name: string;
+  } | null>(null);
   const isFolder = node.kind === "folder";
   const isEditing = editingEntityId === node.entityId;
   const isSelected = selectedIds.has(node.entityId);
   const expanded = isFolder && expandedIds.has(node.entityId);
-  const name = getEntityName(node);
+  const persistedName = getEntityName(node);
+  const name =
+    optimisticRename?.previousName === persistedName
+      ? optimisticRename.name
+      : persistedName;
   const formattedFolderSize = folderStatistics
     ? (() => {
         const size = getFileSizeDisplay(folderStatistics.totalSizeBytes);
@@ -1233,7 +1244,15 @@ const FilesystemRow = ({
     const trimmed = editValue.trim();
     const fullName = ext ? `${trimmed}${ext}` : trimmed;
     if (trimmed && fullName !== name) {
-      onRename(node.entityId, fullName);
+      const pendingRename = { previousName: name, name: fullName };
+      setOptimisticRename(pendingRename);
+      onRename(node.entityId, fullName, {
+        onError: () => {
+          setOptimisticRename((current) =>
+            current === pendingRename ? null : current,
+          );
+        },
+      });
     }
   };
 
@@ -1291,6 +1310,7 @@ const FilesystemRow = ({
   const getCurrentAncestorIds = useLatestCallback((id: string) =>
     getAncestorIds(id),
   );
+  const canDrag = useLatestCallback(() => !isEditing);
   const toggleCurrentFolder = useLatestCallback(() => {
     onToggleFolder(node.entityId);
   });
@@ -1332,6 +1352,7 @@ const FilesystemRow = ({
     const cleanup = combine(
       draggable({
         element: el,
+        canDrag,
         getInitialData: () => {
           const sel = getCurrentSelectedIds();
           const isMulti = sel.size > 1 && sel.has(node.entityId);
@@ -1454,6 +1475,7 @@ const FilesystemRow = ({
     isFolder,
     workspaceId,
     scheduleAutoExpand,
+    canDrag,
     getCurrentSelectedDragItems,
     getCurrentSelectedEntities,
     isExpanded,
@@ -1496,8 +1518,8 @@ const FilesystemRow = ({
     >
       {isEditing ? (
         <InlineEdit
-          className="min-w-0 flex-1"
-          inputClassName="min-w-0 flex-1"
+          className="max-w-full min-w-0"
+          inputClassName="min-w-48 [field-sizing:content]"
           onCancel={cancelEditing}
           onChange={setEditValue}
           onCommit={commitRename}
@@ -1655,6 +1677,59 @@ const FilesystemRow = ({
     </span>
   );
 
+  const contentControl = isEditing ? (
+    <div className={rowButtonCls} style={contentSpanStyle}>
+      {contentCells}
+    </div>
+  ) : (
+    <button
+      className={rowButtonCls}
+      onClick={(event) => {
+        if (!isFolder) {
+          onSelect(node.entityId, {
+            meta: event.metaKey || event.ctrlKey,
+            shift: event.shiftKey,
+          });
+          return;
+        }
+
+        // Shift extends a range like the file rows, taking priority
+        // over folder navigation/toggle.
+        if (event.shiftKey) {
+          onSelect(node.entityId, { meta: false, shift: true });
+          return;
+        }
+        const intent = getFolderClickIntent({
+          currentFolderId,
+          hasModifier: event.metaKey || event.ctrlKey,
+        });
+
+        if (intent.type === "toggle-selection") {
+          onSelect(node.entityId, { meta: true, shift: false });
+          return;
+        }
+
+        onClearSelection();
+        if (intent.type === "clear-and-navigate") {
+          onNavigateToFolder(node.entityId);
+        } else {
+          onToggleFolder(node.entityId);
+        }
+      }}
+      onDoubleClick={() => {
+        if (isFolder) {
+          onNavigateToFolder(node.entityId);
+          return;
+        }
+        openInInspector?.();
+      }}
+      style={contentSpanStyle}
+      type="button"
+    >
+      {contentCells}
+    </button>
+  );
+
   return (
     <>
       <div
@@ -1663,67 +1738,10 @@ const FilesystemRow = ({
         onContextMenu={containedEventHandler(handleContextMenu)}
         ref={rowRef}
       >
-        {isFolder ? (
-          <div
-            className={gridCls}
-            style={{ gridTemplateColumns: gridTemplate }}
-          >
-            <button
-              className={rowButtonCls}
-              onClick={(e) => {
-                // Shift extends a range like the file rows, taking priority
-                // over folder navigation/toggle.
-                if (e.shiftKey) {
-                  onSelect(node.entityId, { meta: false, shift: true });
-                  return;
-                }
-                const intent = getFolderClickIntent({
-                  currentFolderId,
-                  hasModifier: e.metaKey || e.ctrlKey,
-                });
-
-                if (intent.type === "toggle-selection") {
-                  onSelect(node.entityId, { meta: true, shift: false });
-                  return;
-                }
-
-                onClearSelection();
-                if (intent.type === "clear-and-navigate") {
-                  onNavigateToFolder(node.entityId);
-                } else {
-                  onToggleFolder(node.entityId);
-                }
-              }}
-              onDoubleClick={() => onNavigateToFolder(node.entityId)}
-              style={contentSpanStyle}
-              type="button"
-            >
-              {contentCells}
-            </button>
-            {rowActionsNode}
-          </div>
-        ) : (
-          <div
-            className={gridCls}
-            style={{ gridTemplateColumns: gridTemplate }}
-          >
-            <button
-              className={rowButtonCls}
-              onClick={(e) =>
-                onSelect(node.entityId, {
-                  meta: e.metaKey || e.ctrlKey,
-                  shift: e.shiftKey,
-                })
-              }
-              onDoubleClick={() => openInInspector?.()}
-              style={contentSpanStyle}
-              type="button"
-            >
-              {contentCells}
-            </button>
-            {rowActionsNode}
-          </div>
-        )}
+        <div className={gridCls} style={{ gridTemplateColumns: gridTemplate }}>
+          {contentControl}
+          {rowActionsNode}
+        </div>
       </div>
       {pendingDrop && (
         <VersionOrNewFileDialog


### PR DESCRIPTION
## Summary

- keep long filenames visible and selectable while inline editing
- disable row dragging during rename and move the editor outside the row button
- show the committed name immediately, with rollback when the request fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - File and folder renames now update immediately for a more responsive experience.
  - Rename fields expand to better accommodate long filenames.
  - File and folder rows remain consistently clickable and editable.

- **Bug Fixes**
  - Failed renames now restore the original filename.
  - Dragging is prevented while a filename is being edited.
  - Improved handling of long DOCX filenames during renaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->