### PR TITLE
fix: make document translation completion reliable

### DIFF
--- a/apps/api/src/handlers/bilingual-translations/prepare.ts
+++ b/apps/api/src/handlers/bilingual-translations/prepare.ts
@@ -14,7 +14,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { decideDispositions, proposeGlossary } from "@/api/lib/bilingual/ai";
-import type { BilingualAIContext } from "@/api/lib/bilingual/ai";
+import type { BilingualAIDocumentContext } from "@/api/lib/bilingual/ai";
 import { BILINGUAL_LIMITS } from "@/api/lib/bilingual/contract";
 import {
   detectGlossaryCandidates,
@@ -101,7 +101,7 @@ const prepareBilingualTranslation = createSafeHandler(
     }
 
     const organizationId = session.activeOrganizationId;
-    const context: BilingualAIContext = {
+    const context: BilingualAIDocumentContext = {
       organizationId,
       workspaceId,
       orgAIConfig,
@@ -111,6 +111,7 @@ const prepareBilingualTranslation = createSafeHandler(
         AbortSignal.timeout(PREPARE_TIMEOUT_MS),
       ]),
       scopeKey: loaded.entityVersionId,
+      sourceDocument: units,
       usageMetering: {
         actionType: "doc_review",
         organizationId,

--- a/apps/api/src/lib/bilingual/ai.test.ts
+++ b/apps/api/src/lib/bilingual/ai.test.ts
@@ -5,7 +5,7 @@ import type {
   AIUsageMetering,
   TanStackAIAnalyticsCallbacks,
 } from "@/api/lib/analytics/tanstack-ai";
-import type { BilingualAIContext } from "@/api/lib/bilingual/ai";
+import type { BilingualAIDocumentContext } from "@/api/lib/bilingual/ai";
 import type { FormattedBilingualUnit } from "@/api/lib/bilingual/formatting";
 import { toSafeId } from "@/api/lib/branded-types";
 import { installRecordingAnalytics } from "@/api/tests/helpers/recording-telemetry";
@@ -13,19 +13,19 @@ import type { RecordingAnalytics } from "@/api/tests/helpers/recording-telemetry
 
 type GenerateOptions = {
   analytics: TanStackAIAnalyticsCallbacks;
-  prompt: string;
+  messages: { content: { content: string; type: "text" }[] }[];
 };
 type FormattedOutput = {
   items: { n: number; spans: { id: string; text: string }[] }[];
 };
 
 const outputs: FormattedOutput[] = [];
-const prompts: string[] = [];
+const messages: GenerateOptions["messages"][] = [];
 const dispatchedCallbacks: TanStackAIAnalyticsCallbacks[] = [];
 const generateObjectMock = mock(
-  async ({ analytics, prompt }: GenerateOptions) => {
+  async ({ analytics, messages: request }: GenerateOptions) => {
     dispatchedCallbacks.push(analytics);
-    prompts.push(prompt);
+    messages.push(request);
     const output = outputs.shift();
     if (!output) {
       throw new Error("test did not configure a model output");
@@ -45,7 +45,11 @@ void mock.module("@/api/lib/tanstack-ai-generate", () => ({
   systemPromptsPatch: mock(),
 }));
 
-const { translateFormattedBatch } = await import("@/api/lib/bilingual/ai");
+const {
+  buildBilingualDocumentRequest,
+  SOURCE_DOCUMENT_CACHE_CHARS_MAX,
+  translateFormattedBatch,
+} = await import("@/api/lib/bilingual/ai");
 
 const organizationId = toSafeId<"organization">("organization-fixture");
 const workspaceId = toSafeId<"workspace">("workspace-fixture");
@@ -68,7 +72,17 @@ const context = {
   usageMetering,
   abortSignal: AbortSignal.timeout(10_000),
   scopeKey: "document-version-fixture",
-} satisfies BilingualAIContext;
+  sourceDocument: [
+    {
+      rowId: "source-row",
+      ordinal: 99,
+      kind: "paragraph",
+      inTable: false,
+      sourceParaId: "source-paragraph",
+      sourceText: "Stable source",
+    },
+  ],
+} satisfies BilingualAIDocumentContext;
 
 const formattedUnit = (
   ordinal: number,
@@ -89,7 +103,7 @@ describe("formatted bilingual AI boundary", () => {
 
   beforeEach(() => {
     outputs.length = 0;
-    prompts.length = 0;
+    messages.length = 0;
     dispatchedCallbacks.length = 0;
     generateObjectMock.mockClear();
     analytics = installRecordingAnalytics();
@@ -97,6 +111,63 @@ describe("formatted bilingual AI boundary", () => {
 
   afterEach(() => {
     analytics.restore();
+  });
+
+  test("marks the complete stable input before request-specific text", () => {
+    const request = buildBilingualDocumentRequest(
+      { ...context, promptCachingEnabled: true },
+      "chat",
+      "Translate rows 1 through 8",
+    );
+    const message = request.messages.at(0);
+    if (!message || !Array.isArray(message.content)) {
+      throw new Error("expected a multipart user message");
+    }
+    const source = message.content.at(0);
+    const variable = message.content.at(1);
+    if (source?.type !== "text" || variable?.type !== "text") {
+      throw new Error("expected text message parts");
+    }
+
+    expect(source.content).toContain("Input document:\n#99 [paragraph]");
+    expect(source.metadata).toEqual({
+      cache_control: { type: "ephemeral", ttl: "5m" },
+    });
+    expect(variable.content).toBe("Translate rows 1 through 8");
+    expect(request.caching).toEqual({
+      enabled: true,
+      ttl: "5m",
+      scopeKey: "document-version-fixture",
+    });
+  });
+
+  test("bounds the cached source region for unusually large documents", () => {
+    const sourceDocument = Array.from({ length: 4 }, (_unused, index) => ({
+      rowId: `large-row-${index}`,
+      ordinal: index + 1,
+      kind: "paragraph" as const,
+      inTable: false,
+      sourceParaId: `large-paragraph-${index}`,
+      sourceText: "x".repeat(20_000),
+    }));
+    const request = buildBilingualDocumentRequest(
+      { ...context, sourceDocument },
+      "chat",
+      "Translate one batch",
+    );
+    const message = request.messages.at(0);
+    if (!message || !Array.isArray(message.content)) {
+      throw new Error("expected a multipart user message");
+    }
+    const source = message.content.at(0);
+    if (source?.type !== "text") {
+      throw new Error("expected a text source part");
+    }
+
+    expect(source.content.length).toBeLessThanOrEqual(
+      "Input document:\n".length + SOURCE_DOCUMENT_CACHE_CHARS_MAX,
+    );
+    expect(source.content).toEndWith("[Cached input prefix truncated]");
   });
 
   test("retries only rows whose ordered span contract is invalid", async () => {
@@ -150,9 +221,12 @@ describe("formatted bilingual AI boundary", () => {
     expect(dispatchedCallbacks.at(0)?.middleware.name).toBe(
       "stella-tanstack-analytics",
     );
-    expect(prompts.at(1)).toContain("Contract repair:");
-    expect(prompts.at(1)).not.toContain("#1:");
-    expect(prompts.at(1)).toContain("#2:");
+    const firstContent = messages.at(0)?.at(0)?.content;
+    const retryContent = messages.at(1)?.at(0)?.content;
+    expect(firstContent?.at(0)?.content).toBe(retryContent?.at(0)?.content);
+    expect(retryContent?.at(1)?.content).toContain("Contract repair:");
+    expect(retryContent?.at(1)?.content).not.toContain("#1:");
+    expect(retryContent?.at(1)?.content).toContain("#2:");
     expect(result.get(1)).toEqual({
       text: "Ahoj světe",
       spans: [

--- a/apps/api/src/lib/bilingual/ai.ts
+++ b/apps/api/src/lib/bilingual/ai.ts
@@ -2,6 +2,8 @@
 // manifest (never the DOCX), addresses rows by ordinal, and is validated
 // against the known ordinals before anything is trusted.
 
+import type { ModelMessage, TextPart } from "@tanstack/ai";
+import type { AnthropicTextMetadata } from "@tanstack/ai-anthropic";
 import { TaggedError } from "better-result";
 import * as v from "valibot";
 
@@ -30,6 +32,7 @@ import type {
   DispositionedUnit,
 } from "@/api/lib/bilingual/rows";
 import type { SafeId } from "@/api/lib/branded-types";
+import { markTanStackCacheBreakpoint } from "@/api/lib/tanstack-ai-caching";
 import { generateTanStackObjectForRole } from "@/api/lib/tanstack-ai-generate";
 
 const DISPOSITION_ROLE = "fast" as const;
@@ -42,6 +45,8 @@ const GLOSSARY_SAMPLE_CHARS = 24_000;
 const FORMATTED_INLINE_TOKENS_MAX = 2048;
 const FORMATTED_ROWS_SERIALIZED_CHARS_MAX = 200_000;
 const FORMATTED_OUTPUT_ATTEMPTS = 2;
+export const SOURCE_DOCUMENT_CACHE_CHARS_MAX = 64_000;
+const SOURCE_DOCUMENT_TRUNCATED = "\n[Cached input prefix truncated]";
 
 class BilingualAIContractError extends TaggedError("BilingualAIContractError")<{
   message: string;
@@ -56,6 +61,11 @@ export type BilingualAIContext = {
   abortSignal: AbortSignal;
   /** Stable key for prompt-cache scoping, typically the entity version id. */
   scopeKey: string;
+};
+
+export type BilingualAIDocumentContext = BilingualAIContext & {
+  /** Source rows from which the stable cached prefix is derived. */
+  sourceDocument: readonly BilingualUnit[];
 };
 
 type Languages = { sourceLang: string; targetLang: string };
@@ -82,6 +92,63 @@ const callSignal = (context: BilingualAIContext): AbortSignal =>
 
 const preview = (text: string): string =>
   text.length > PREVIEW_CHARS ? `${text.slice(0, PREVIEW_CHARS)}…` : text;
+
+const serializeSourceDocument = (units: readonly BilingualUnit[]): string => {
+  const lines: string[] = [];
+  let chars = 0;
+  for (const unit of units) {
+    const place = unit.inTable ? "table" : unit.kind;
+    const separator = lines.length === 0 ? "" : "\n";
+    const line = `${separator}#${unit.ordinal} [${place}] ${unit.sourceText}`;
+    const available =
+      SOURCE_DOCUMENT_CACHE_CHARS_MAX -
+      SOURCE_DOCUMENT_TRUNCATED.length -
+      chars;
+    if (line.length > available) {
+      lines.push(line.slice(0, Math.max(0, available)));
+      lines.push(SOURCE_DOCUMENT_TRUNCATED);
+      return lines.join("");
+    }
+    lines.push(line);
+    chars += line.length;
+  }
+  return lines.join("");
+};
+
+/**
+ * Put a stable input-document region before anything that changes per request.
+ * Normal documents fit in full; the prefix is bounded because provider prompt
+ * caches do not remove cached tokens from the model's context-window limit.
+ * The boundary is explicit for Anthropic; OpenAI uses the same prefix plus the
+ * stable scope key to route repeated translation batches to one cache shard.
+ */
+export const buildBilingualDocumentRequest = (
+  context: BilingualAIDocumentContext,
+  role: ModelRole,
+  request: string,
+): { caching: ReturnType<typeof resolveCaching>; messages: ModelMessage[] } => {
+  const caching = resolveCaching({
+    promptCachingEnabled: context.promptCachingEnabled,
+    role,
+    scopeKey: context.scopeKey,
+  });
+  const source: TextPart<AnthropicTextMetadata> = {
+    type: "text",
+    content: `Input document:\n${serializeSourceDocument(context.sourceDocument)}`,
+  };
+  return {
+    caching,
+    messages: [
+      {
+        role: "user",
+        content: [
+          markTanStackCacheBreakpoint(source, { decision: caching }),
+          { type: "text", content: request },
+        ],
+      },
+    ],
+  };
+};
 
 // ----------------------------------------------------------------------------
 // Dispositions
@@ -124,7 +191,7 @@ const formatDispositionRows = (
 export const decideDispositions = async (
   units: readonly BilingualUnit[],
   languages: Languages,
-  context: BilingualAIContext,
+  context: BilingualAIDocumentContext,
 ): Promise<DispositionedUnit[]> => {
   const decided = new Map<number, BilingualRowDisposition>();
   for (const unit of units) {
@@ -154,21 +221,22 @@ export const decideDispositions = async (
       }
       const slice = units.slice(start, start + chunk);
       if (!slice.every((unit) => decided.has(unit.ordinal))) {
+        const request = buildBilingualDocumentRequest(
+          context,
+          DISPOSITION_ROLE,
+          `Source language: ${languages.sourceLang}. Target language: ${languages.targetLang}.\n\n${formatDispositionRows(slice, decided)}`,
+        );
         const output = await generateTanStackObjectForRole({
           role: DISPOSITION_ROLE,
           orgAIConfig: context.orgAIConfig,
           organizationId: context.organizationId,
           analytics,
-          caching: resolveCaching({
-            promptCachingEnabled: context.promptCachingEnabled,
-            role: DISPOSITION_ROLE,
-            scopeKey: context.scopeKey,
-          }),
+          caching: request.caching,
           serviceTier: SERVICE_TIER,
           tenantWorkspaceIds: [context.workspaceId],
           system: DISPOSITION_SYSTEM,
           systemPromptOrigin: "embeds-untrusted",
-          prompt: `Source language: ${languages.sourceLang}. Target language: ${languages.targetLang}.\n\n${formatDispositionRows(slice, decided)}`,
+          messages: request.messages,
           abortSignal: callSignal(context),
           outputSchema: dispositionSchema,
         });
@@ -251,7 +319,7 @@ export const proposeGlossary = async (
   candidates: readonly string[],
   texts: readonly string[],
   languages: Languages,
-  context: BilingualAIContext,
+  context: BilingualAIDocumentContext,
 ): Promise<BilingualGlossaryEntry[]> => {
   const analytics = analyticsFor(context, "bilingual.glossary", GLOSSARY_ROLE);
   let sample = "";
@@ -261,21 +329,22 @@ export const proposeGlossary = async (
     }
     sample += `${text}\n`;
   }
+  const request = buildBilingualDocumentRequest(
+    context,
+    GLOSSARY_ROLE,
+    `Source language: ${languages.sourceLang}. Target language: ${languages.targetLang}.\n\nDefined terms found:\n${candidates.map((term) => `- ${term}`).join("\n") || "(none)"}\n\nDocument sample:\n${sample}`,
+  );
   const output = await generateTanStackObjectForRole({
     role: GLOSSARY_ROLE,
     orgAIConfig: context.orgAIConfig,
     organizationId: context.organizationId,
     analytics,
-    caching: resolveCaching({
-      promptCachingEnabled: context.promptCachingEnabled,
-      role: GLOSSARY_ROLE,
-      scopeKey: context.scopeKey,
-    }),
+    caching: request.caching,
     serviceTier: SERVICE_TIER,
     tenantWorkspaceIds: [context.workspaceId],
     system: GLOSSARY_SYSTEM,
     systemPromptOrigin: "embeds-untrusted",
-    prompt: `Source language: ${languages.sourceLang}. Target language: ${languages.targetLang}.\n\nDefined terms found:\n${candidates.map((term) => `- ${term}`).join("\n") || "(none)"}\n\nDocument sample:\n${sample}`,
+    messages: request.messages,
     abortSignal: callSignal(context),
     outputSchema: glossarySchema,
   });
@@ -357,7 +426,7 @@ export type TranslateBatchInput = {
 export const translateBatch = async (
   { batch, preceding, glossary }: TranslateBatchInput,
   languages: Languages,
-  context: BilingualAIContext,
+  context: BilingualAIDocumentContext,
 ): Promise<Map<number, string>> => {
   const analytics = analyticsFor(
     context,
@@ -378,21 +447,22 @@ export const translateBatch = async (
     .map((unit) => `#${unit.ordinal}: ${unit.sourceText}`)
     .join("\n");
 
+  const request = buildBilingualDocumentRequest(
+    context,
+    TRANSLATION_ROLE,
+    `Source language: ${languages.sourceLang}. Target language: ${languages.targetLang}.\n\nGlossary:\n${glossaryLines || "(none)"}\n\nPreceding rows (context only):\n${contextLines || "(start of document)"}\n\nRows to translate:\n${rowLines}`,
+  );
   const output = await generateTanStackObjectForRole({
     role: TRANSLATION_ROLE,
     orgAIConfig: context.orgAIConfig,
     organizationId: context.organizationId,
     analytics,
-    caching: resolveCaching({
-      promptCachingEnabled: context.promptCachingEnabled,
-      role: TRANSLATION_ROLE,
-      scopeKey: context.scopeKey,
-    }),
+    caching: request.caching,
     serviceTier: SERVICE_TIER,
     tenantWorkspaceIds: [context.workspaceId],
     system: TRANSLATION_SYSTEM,
     systemPromptOrigin: "embeds-untrusted",
-    prompt: `Source language: ${languages.sourceLang}. Target language: ${languages.targetLang}.\n\nGlossary:\n${glossaryLines || "(none)"}\n\nPreceding rows (context only):\n${contextLines || "(start of document)"}\n\nRows to translate:\n${rowLines}`,
+    messages: request.messages,
     abortSignal: callSignal(context),
     outputSchema: translationSchema,
   });
@@ -492,7 +562,7 @@ const collectFormattedTranslations = (
 export const translateFormattedBatch = async (
   { batch, preceding, glossary }: TranslateFormattedBatchInput,
   languages: Languages,
-  context: BilingualAIContext,
+  context: BilingualAIDocumentContext,
 ): Promise<Map<number, BilingualFormattedTranslation>> => {
   const analytics = analyticsFor(
     context,
@@ -519,21 +589,22 @@ export const translateFormattedBatch = async (
       attempt === 1
         ? ""
         : "\n\nContract repair: return every listed row with exactly the provided text span ids, once and in order.";
+    const request = buildBilingualDocumentRequest(
+      context,
+      TRANSLATION_ROLE,
+      `Source language: ${languages.sourceLang}. Target language: ${languages.targetLang}.\n\nGlossary:\n${glossaryLines || "(none)"}\n\nPreceding rows (context only):\n${contextLines || "(start of document)"}\n\nFormatted rows to translate:\n${rowLines}${repairInstruction}`,
+    );
     const output = await generateTanStackObjectForRole({
       role: TRANSLATION_ROLE,
       orgAIConfig: context.orgAIConfig,
       organizationId: context.organizationId,
       analytics,
-      caching: resolveCaching({
-        promptCachingEnabled: context.promptCachingEnabled,
-        role: TRANSLATION_ROLE,
-        scopeKey: context.scopeKey,
-      }),
+      caching: request.caching,
       serviceTier: SERVICE_TIER,
       tenantWorkspaceIds: [context.workspaceId],
       system: FORMATTED_TRANSLATION_SYSTEM,
       systemPromptOrigin: "embeds-untrusted",
-      prompt: `Source language: ${languages.sourceLang}. Target language: ${languages.targetLang}.\n\nGlossary:\n${glossaryLines || "(none)"}\n\nPreceding rows (context only):\n${contextLines || "(start of document)"}\n\nFormatted rows to translate:\n${rowLines}${repairInstruction}`,
+      messages: request.messages,
       abortSignal: callSignal(context),
       outputSchema: formattedTranslationSchema,
     });

--- a/apps/api/src/lib/bilingual/run-queue.ts
+++ b/apps/api/src/lib/bilingual/run-queue.ts
@@ -32,7 +32,7 @@ import { captureError } from "@/api/lib/analytics/capture";
 import { createAuditRecorder } from "@/api/lib/audit-log";
 import { translateBatch } from "@/api/lib/bilingual/ai";
 import type {
-  BilingualAIContext,
+  BilingualAIDocumentContext,
   TranslationContextRow,
 } from "@/api/lib/bilingual/ai";
 import {
@@ -357,13 +357,15 @@ const executeRun = async (
     return "ai_unavailable";
   }
 
-  const context: BilingualAIContext = {
+  const rows = await loadRows(actor);
+  const context: BilingualAIDocumentContext = {
     organizationId: actor.organizationId,
     workspaceId: actor.workspaceId,
     orgAIConfig: config.value.orgAIConfig,
     promptCachingEnabled: config.value.promptCachingEnabled,
     abortSignal: AbortSignal.timeout(RUN_TIMEOUT_MS),
     scopeKey: run.entityVersionId,
+    sourceDocument: rows,
     usageMetering: {
       actionType: "doc_review",
       organizationId: actor.organizationId,
@@ -374,7 +376,6 @@ const executeRun = async (
     },
   };
 
-  const rows = await loadRows(actor);
   const languages = { sourceLang: run.sourceLang, targetLang: run.targetLang };
   const translated = new Map<string, string>(
     rows.flatMap((row) =>

--- a/apps/api/src/lib/document-translation/bilingual-batch-runner.test.ts
+++ b/apps/api/src/lib/document-translation/bilingual-batch-runner.test.ts
@@ -1,0 +1,62 @@
+import { Result } from "better-result";
+import { expect, test } from "bun:test";
+
+import {
+  DOCUMENT_TRANSLATION_BATCH_SIZE,
+  runBilingualTranslationBatches,
+} from "./bilingual-batch-runner";
+
+const rows = Array.from(
+  { length: DOCUMENT_TRANSLATION_BATCH_SIZE * 5 },
+  (_, index) => index,
+);
+
+test("preserves translated context between larger ordered batches", async () => {
+  const started: number[][] = [];
+  const translated = new Set<number>();
+  const precedingTargets: (number | null)[] = [];
+
+  const outcome = await runBilingualTranslationBatches({
+    items: rows,
+    translate: async (batch) => {
+      started.push([...batch]);
+      const first = batch.at(0);
+      if (first !== undefined) {
+        precedingTargets.push(
+          first === 0 || !translated.has(first - 1) ? null : first - 1,
+        );
+      }
+      for (const row of batch) {
+        translated.add(row);
+      }
+      return Result.ok();
+    },
+  });
+
+  expect(Result.isOk(outcome)).toBe(true);
+  expect(started).toHaveLength(5);
+  expect(precedingTargets).toEqual([
+    null,
+    DOCUMENT_TRANSLATION_BATCH_SIZE - 1,
+    DOCUMENT_TRANSLATION_BATCH_SIZE * 2 - 1,
+    DOCUMENT_TRANSLATION_BATCH_SIZE * 3 - 1,
+    DOCUMENT_TRANSLATION_BATCH_SIZE * 4 - 1,
+  ]);
+  expect(started.flat()).toEqual(rows);
+});
+
+test("does not start another wave after a translation batch fails", async () => {
+  const started: number[][] = [];
+  const outcome = await runBilingualTranslationBatches({
+    items: rows,
+    translate: async (batch) => {
+      started.push([...batch]);
+      return batch.at(0) === DOCUMENT_TRANSLATION_BATCH_SIZE
+        ? Result.err("provider_failed" as const)
+        : Result.ok();
+    },
+  });
+
+  expect(outcome).toEqual(Result.err("provider_failed"));
+  expect(started).toHaveLength(2);
+});

--- a/apps/api/src/lib/document-translation/bilingual-batch-runner.ts
+++ b/apps/api/src/lib/document-translation/bilingual-batch-runner.ts
@@ -1,8 +1,8 @@
 import { panic, Result } from "better-result";
 
-/** Larger than the interactive flow's batch because formatted-output repair
- *  can retry individual rejected rows without replaying the accepted ones. */
-export const DOCUMENT_TRANSLATION_BATCH_SIZE = 16;
+/** Eight rows stay below the formatted prompt's 200k serialized-character cap
+ *  even at the per-row input limit, while keeping target context ordered. */
+export const DOCUMENT_TRANSLATION_BATCH_SIZE = 8;
 
 type RunBilingualTranslationBatchesOptions<TItem, TError> = {
   items: readonly TItem[];

--- a/apps/api/src/lib/document-translation/bilingual-batch-runner.ts
+++ b/apps/api/src/lib/document-translation/bilingual-batch-runner.ts
@@ -1,8 +1,10 @@
 import { panic, Result } from "better-result";
 
+import { BILINGUAL_LIMITS } from "@/api/lib/bilingual/contract";
+
 /** Eight rows stay below the formatted prompt's 200k serialized-character cap
  *  even at the per-row input limit, while keeping target context ordered. */
-export const DOCUMENT_TRANSLATION_BATCH_SIZE = 8;
+export const DOCUMENT_TRANSLATION_BATCH_SIZE = BILINGUAL_LIMITS.batchSize;
 
 type RunBilingualTranslationBatchesOptions<TItem, TError> = {
   items: readonly TItem[];

--- a/apps/api/src/lib/document-translation/bilingual-batch-runner.ts
+++ b/apps/api/src/lib/document-translation/bilingual-batch-runner.ts
@@ -1,0 +1,48 @@
+import { panic, Result } from "better-result";
+
+/** Larger than the interactive flow's batch because formatted-output repair
+ *  can retry individual rejected rows without replaying the accepted ones. */
+export const DOCUMENT_TRANSLATION_BATCH_SIZE = 16;
+
+type RunBilingualTranslationBatchesOptions<TItem, TError> = {
+  items: readonly TItem[];
+  translate: (batch: readonly TItem[]) => Promise<Result<void, TError>>;
+};
+
+/**
+ * Translate bounded row batches in document order. Each call can therefore
+ * use the preceding call's target text as legal and terminological context.
+ * A failure fences every later batch so retries do not multiply metered work.
+ */
+export const runBilingualTranslationBatches = async <TItem, TError>({
+  items,
+  translate,
+}: RunBilingualTranslationBatchesOptions<TItem, TError>): Promise<
+  Result<void, TError>
+> => {
+  const batches: TItem[][] = [];
+  for (
+    let index = 0;
+    index < items.length;
+    index += DOCUMENT_TRANSLATION_BATCH_SIZE
+  ) {
+    batches.push(items.slice(index, index + DOCUMENT_TRANSLATION_BATCH_SIZE));
+  }
+
+  const runBatch = async (index: number): Promise<Result<void, TError>> => {
+    if (index >= batches.length) {
+      return Result.ok();
+    }
+    const batch = batches.at(index);
+    if (!batch) {
+      panic("Bilingual translation batch index is out of bounds");
+    }
+    const outcome = await translate(batch);
+    if (Result.isError(outcome)) {
+      return outcome;
+    }
+    return await runBatch(index + 1);
+  };
+
+  return await runBatch(0);
+};

--- a/apps/api/src/lib/document-translation/run-queue.ts
+++ b/apps/api/src/lib/document-translation/run-queue.ts
@@ -57,6 +57,7 @@ import { createLazyBullMqQueue } from "@/api/lib/bullmq-queue";
 import { decryptContent } from "@/api/lib/content-encryption";
 import { translateDocument, translateTextBatches } from "@/api/lib/deepl/deepl";
 import { translateTaggedSegments } from "@/api/lib/document-translation/ai";
+import { runBilingualTranslationBatches } from "@/api/lib/document-translation/bilingual-batch-runner";
 import {
   commentTaggedText,
   unwrapCommentTranslation,
@@ -854,6 +855,10 @@ const translateBilingualWithAI = async (
   if (Result.isError(formatted)) {
     return Result.err("unsupported_format");
   }
+  const documentContext = {
+    ...context,
+    sourceDocument: formatted.value,
+  };
   const languages = {
     sourceLang: run.sourceLang,
     targetLang: run.targetLang,
@@ -862,12 +867,12 @@ const translateBilingualWithAI = async (
   const prepared = await Result.tryPromise({
     try: async () => {
       const [rows, glossary] = await Promise.all([
-        decideDispositions(formatted.value, languages, context),
+        decideDispositions(formatted.value, languages, documentContext),
         proposeGlossary(
           detectGlossaryCandidates(texts),
           texts,
           languages,
-          context,
+          documentContext,
         ),
       ]);
       return { rows, glossary };
@@ -919,13 +924,9 @@ const translateBilingualWithAI = async (
   const formattedByRowId = new Map(
     formatted.value.map((unit) => [unit.rowId, unit]),
   );
-  const translateNextBatch = async (
-    index: number,
+  const translateBatch = async (
+    batch: readonly StoredRow[],
   ): Promise<Result<void, DocumentTranslationRunErrorCode>> => {
-    if (index >= pending.length) {
-      return Result.ok();
-    }
-    const batch = pending.slice(index, index + BILINGUAL_LIMITS.batchSize);
     const first = batch.at(0);
     if (!first) {
       return Result.ok();
@@ -958,7 +959,7 @@ const translateBilingualWithAI = async (
             glossary: prepared.value.glossary,
           },
           languages,
-          context,
+          documentContext,
         ),
       catch: (cause) => cause,
     });
@@ -977,9 +978,12 @@ const translateBilingualWithAI = async (
       updates.push({ unitKey: row.rowId, targetText });
     }
     await updateTranslatedUnits(actor, updates);
-    return await translateNextBatch(index + BILINGUAL_LIMITS.batchSize);
+    return Result.ok();
   };
-  const translation = await translateNextBatch(0);
+  const translation = await runBilingualTranslationBatches({
+    items: pending,
+    translate: translateBatch,
+  });
   if (Result.isError(translation)) {
     return translation;
   }

--- a/apps/web/src/components/document-translation-queries.test.ts
+++ b/apps/web/src/components/document-translation-queries.test.ts
@@ -1,0 +1,37 @@
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { describe, expect, test } from "bun:test";
+
+import { invalidateDocumentTranslationOutputQueries } from "@/components/document-translation-queries";
+import { entitiesKeys } from "@/lib/workspaces/queries/entities";
+
+describe("document translation output invalidation", () => {
+  test("marks entity projections stale without refetching the open document", async () => {
+    const queryClient = new QueryClient();
+    const activeDocumentKey = entitiesKeys.detail(
+      "workspace-a",
+      "source-entity",
+    );
+    let fetches = 0;
+    const observer = new QueryObserver(queryClient, {
+      queryKey: activeDocumentKey,
+      queryFn: async () => {
+        fetches += 1;
+        return { id: "source-entity" };
+      },
+      staleTime: Number.POSITIVE_INFINITY,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+    await observer.refetch();
+
+    await invalidateDocumentTranslationOutputQueries(
+      queryClient,
+      "workspace-a",
+    );
+
+    expect(fetches).toBe(1);
+    expect(queryClient.getQueryState(activeDocumentKey)?.isInvalidated).toBe(
+      true,
+    );
+    unsubscribe();
+  });
+});

--- a/apps/web/src/components/document-translation-queries.test.ts
+++ b/apps/web/src/components/document-translation-queries.test.ts
@@ -5,7 +5,7 @@ import { invalidateDocumentTranslationOutputQueries } from "@/components/documen
 import { entitiesKeys } from "@/lib/workspaces/queries/entities";
 
 describe("document translation output invalidation", () => {
-  test("marks entity projections stale without refetching the open document", async () => {
+  test("refetches active projections without refetching the open document", async () => {
     const queryClient = new QueryClient();
     const activeDocumentKey = entitiesKeys.detail(
       "workspace-a",
@@ -20,18 +20,32 @@ describe("document translation output invalidation", () => {
       },
       staleTime: Number.POSITIVE_INFINITY,
     });
+    const collectionKey = [...entitiesKeys.all("workspace-a"), "collection"];
+    let collectionFetches = 0;
+    const collectionObserver = new QueryObserver(queryClient, {
+      queryKey: collectionKey,
+      queryFn: async () => {
+        collectionFetches += 1;
+        return [];
+      },
+    });
     const unsubscribe = observer.subscribe(() => undefined);
+    const unsubscribeCollection = collectionObserver.subscribe(() => undefined);
     await observer.refetch();
+    await collectionObserver.refetch();
 
     await invalidateDocumentTranslationOutputQueries(
       queryClient,
       "workspace-a",
+      "source-entity",
     );
 
     expect(fetches).toBe(1);
+    expect(collectionFetches).toBe(3);
     expect(queryClient.getQueryState(activeDocumentKey)?.isInvalidated).toBe(
-      true,
+      false,
     );
     unsubscribe();
+    unsubscribeCollection();
   });
 });

--- a/apps/web/src/components/document-translation-queries.ts
+++ b/apps/web/src/components/document-translation-queries.ts
@@ -143,11 +143,17 @@ export const documentTranslationRunOptions = (ref: DocumentTranslationRunRef) =>
 export const invalidateDocumentTranslationOutputQueries = async (
   queryClient: QueryClient,
   workspaceId: string,
-) =>
-  await queryClient.invalidateQueries({
+  sourceEntityId: string,
+) => {
+  const sourceKey = entitiesKeys.detail(workspaceId, sourceEntityId);
+  return await queryClient.invalidateQueries({
     queryKey: entitiesKeys.all(workspaceId),
-    refetchType: "none",
+    refetchType: "active",
+    predicate: (query) =>
+      query.queryKey.length !== sourceKey.length ||
+      query.queryKey.some((part, index) => part !== sourceKey[index]),
   });
+};
 
 const runPollInterval = (
   status: DocumentTranslationRunStatus,

--- a/apps/web/src/components/document-translation-queries.ts
+++ b/apps/web/src/components/document-translation-queries.ts
@@ -146,7 +146,7 @@ export const invalidateDocumentTranslationOutputQueries = async (
   sourceEntityId: string,
 ) => {
   const sourceKey = entitiesKeys.detail(workspaceId, sourceEntityId);
-  return await queryClient.invalidateQueries({
+  await queryClient.invalidateQueries({
     queryKey: entitiesKeys.all(workspaceId),
     refetchType: "active",
     predicate: (query) =>

--- a/apps/web/src/components/document-translation-queries.ts
+++ b/apps/web/src/components/document-translation-queries.ts
@@ -1,8 +1,10 @@
 import { queryOptions } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import { shouldRetryAPIRequest, unwrapEden } from "@/lib/errors/api";
 import { toSafeId } from "@/lib/safe-id";
+import { entitiesKeys } from "@/lib/workspaces/queries/entities";
 
 const RUN_POLL_INTERVAL_MS = 2000;
 
@@ -129,6 +131,22 @@ export const documentTranslationRunOptions = (ref: DocumentTranslationRunRef) =>
         ? RUN_POLL_INTERVAL_MS
         : false;
     },
+  });
+
+/**
+ * Mark matter entity projections stale after a translation creates its output.
+ * The active source document must not refetch in place: that reloads Folio and
+ * every active entity projection while the completion action is being used.
+ * Collection views fetch the marked data when they are next shown; realtime
+ * invalidation can still refresh them sooner when connected.
+ */
+export const invalidateDocumentTranslationOutputQueries = async (
+  queryClient: QueryClient,
+  workspaceId: string,
+) =>
+  await queryClient.invalidateQueries({
+    queryKey: entitiesKeys.all(workspaceId),
+    refetchType: "none",
   });
 
 const runPollInterval = (

--- a/apps/web/src/components/translate-document-dialog.logic.test.ts
+++ b/apps/web/src/components/translate-document-dialog.logic.test.ts
@@ -164,20 +164,22 @@ describe("document translation output handoff", () => {
     let navigated = false;
     let closed = false;
 
-    expect(
-      openDocumentTranslationOutput({
-        closeDialog: () => {
-          closed = true;
-        },
-        prepareDestination: async () => {
-          throw new Error("destination unavailable");
-        },
-        navigate: async () => {
-          navigated = true;
-        },
-      }),
-    ).rejects.toThrow("destination unavailable");
+    const rejection = await openDocumentTranslationOutput({
+      closeDialog: () => {
+        closed = true;
+      },
+      prepareDestination: async () => {
+        throw new Error("destination unavailable");
+      },
+      navigate: async () => {
+        navigated = true;
+      },
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
 
+    expect(rejection).toMatchObject({ message: "destination unavailable" });
     expect(navigated).toBeFalse();
     expect(closed).toBeFalse();
   });

--- a/apps/web/src/components/translate-document-dialog.logic.test.ts
+++ b/apps/web/src/components/translate-document-dialog.logic.test.ts
@@ -162,10 +162,13 @@ describe("document translation output handoff", () => {
 
   test("does not navigate when the destination cannot be prepared", async () => {
     let navigated = false;
+    let closed = false;
 
     expect(
       openDocumentTranslationOutput({
-        closeDialog: () => undefined,
+        closeDialog: () => {
+          closed = true;
+        },
         prepareDestination: async () => {
           throw new Error("destination unavailable");
         },
@@ -176,5 +179,6 @@ describe("document translation output handoff", () => {
     ).rejects.toThrow("destination unavailable");
 
     expect(navigated).toBeFalse();
+    expect(closed).toBeFalse();
   });
 });

--- a/apps/web/src/components/translate-document-dialog.logic.test.ts
+++ b/apps/web/src/components/translate-document-dialog.logic.test.ts
@@ -6,6 +6,7 @@ import {
   canStartDocumentTranslation,
   commentPolicyStateForSource,
   documentTranslationRunFailureKey,
+  openDocumentTranslationOutput,
   resolvedDocumentTranslationSource,
 } from "./translate-document-dialog.logic";
 
@@ -137,5 +138,43 @@ describe("document translation comment policy ownership", () => {
         fieldId,
       }),
     ).toEqual({ type: "unchecked" });
+  });
+});
+
+describe("document translation output handoff", () => {
+  test("closes the dialog and prepares the destination before navigation", async () => {
+    const events: string[] = [];
+
+    await openDocumentTranslationOutput({
+      closeDialog: () => {
+        events.push("closed");
+      },
+      prepareDestination: async () => {
+        events.push("prepared");
+      },
+      navigate: async () => {
+        events.push("navigated");
+      },
+    });
+
+    expect(events).toEqual(["closed", "prepared", "navigated"]);
+  });
+
+  test("does not navigate when the destination cannot be prepared", async () => {
+    let navigated = false;
+
+    expect(
+      openDocumentTranslationOutput({
+        closeDialog: () => undefined,
+        prepareDestination: async () => {
+          throw new Error("destination unavailable");
+        },
+        navigate: async () => {
+          navigated = true;
+        },
+      }),
+    ).rejects.toThrow("destination unavailable");
+
+    expect(navigated).toBeFalse();
   });
 });

--- a/apps/web/src/components/translate-document-dialog.logic.test.ts
+++ b/apps/web/src/components/translate-document-dialog.logic.test.ts
@@ -157,7 +157,7 @@ describe("document translation output handoff", () => {
       },
     });
 
-    expect(events).toEqual(["closed", "prepared", "navigated"]);
+    expect(events).toEqual(["prepared", "closed", "navigated"]);
   });
 
   test("does not navigate when the destination cannot be prepared", async () => {

--- a/apps/web/src/components/translate-document-dialog.logic.ts
+++ b/apps/web/src/components/translate-document-dialog.logic.ts
@@ -139,7 +139,7 @@ export const openDocumentTranslationOutput = async ({
   navigate,
   prepareDestination,
 }: OpenDocumentTranslationOutputOptions) => {
-  closeDialog();
   await prepareDestination();
+  closeDialog();
   await navigate();
 };

--- a/apps/web/src/components/translate-document-dialog.logic.ts
+++ b/apps/web/src/components/translate-document-dialog.logic.ts
@@ -126,3 +126,20 @@ export const canStartDocumentTranslation = ({
   (!requiresCommentPolicy || hasCommentPolicy) &&
   !sameLanguage &&
   !isRunning;
+
+type OpenDocumentTranslationOutputOptions = {
+  closeDialog: () => void;
+  navigate: () => Promise<unknown>;
+  prepareDestination: () => Promise<unknown>;
+};
+
+/** Keep route pending UI out from behind the completion dialog. */
+export const openDocumentTranslationOutput = async ({
+  closeDialog,
+  navigate,
+  prepareDestination,
+}: OpenDocumentTranslationOutputOptions) => {
+  closeDialog();
+  await prepareDestination();
+  await navigate();
+};

--- a/apps/web/src/components/translate-document-dialog.tsx
+++ b/apps/web/src/components/translate-document-dialog.tsx
@@ -10,7 +10,7 @@ import { useRef, useState } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useRouteContext } from "@tanstack/react-router";
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 import { LanguagesIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -39,6 +39,7 @@ import {
 } from "@/components/document-language-picker";
 import {
   documentTranslationPreparationOptions,
+  invalidateDocumentTranslationOutputQueries,
   documentTranslationRunOptions,
   isDocumentTranslationRunActive,
   type DocumentTranslationRun,
@@ -47,6 +48,7 @@ import {
   canStartDocumentTranslation,
   commentPolicyStateForSource,
   documentTranslationRunFailureKey,
+  openDocumentTranslationOutput,
   resolvedDocumentTranslationSource,
   type DocumentTranslationCommentPolicy,
   type DocumentTranslationCommentPolicyState,
@@ -62,8 +64,9 @@ import { deepLAvailabilityOptions } from "@/lib/deepl/queries";
 import { detached } from "@/lib/detached";
 import { unwrapEden } from "@/lib/errors/api";
 import { userErrorFromThrown } from "@/lib/errors/user-safe";
+import { ensureRouteQueryData } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
-import { entitiesKeys } from "@/lib/workspaces/queries/entities";
+import { entityOptions } from "@/lib/workspaces/queries/entities";
 
 type TranslationChoice = "bilingual:ai" | "translated:ai" | "translated:deepl";
 
@@ -227,18 +230,40 @@ export const TranslateDocumentDialog = (
     enabled: runId !== null,
   });
 
-  const openOutput = useLatestCallback((run: DocumentTranslationRun) => {
-    if (!run.outputEntityId || !run.outputFieldId) {
+  const openOutput = useLatestCallback(async (run: DocumentTranslationRun) => {
+    const { outputEntityId, outputFieldId } = run;
+    if (!outputEntityId || !outputFieldId) {
       return;
     }
-    detached(
-      navigate({
-        to: "/workspaces/$workspaceId/$viewId/document",
-        params: { workspaceId, viewId },
-        search: { entity: run.outputEntityId, field: run.outputFieldId },
-      }),
-      "translate-document-dialog.navigate",
+
+    const result = await Result.tryPromise(
+      async () =>
+        await openDocumentTranslationOutput({
+          closeDialog: () => setDialogOpen(false),
+          prepareDestination: async () =>
+            await ensureRouteQueryData(
+              queryClient,
+              entityOptions(workspaceId, outputEntityId),
+            ),
+          navigate: async () =>
+            await navigate({
+              to: "/workspaces/$workspaceId/$viewId/document",
+              params: { workspaceId, viewId },
+              search: { entity: outputEntityId, field: outputFieldId },
+            }),
+        }),
     );
+    if (!Result.isError(result)) {
+      return;
+    }
+
+    analytics.captureError(result.error);
+    stellaToast.add({
+      title: t("translate.error.title"),
+      description: userErrorFromThrown(result.error, t("errors.actionFailed")),
+      type: "error",
+    });
+    setDialogOpen(true);
   });
 
   useExternalSyncEffect(() => {
@@ -284,15 +309,15 @@ export const TranslateDocumentDialog = (
           ? {
               action: {
                 label: t("common.open"),
-                onClick: () => openOutput(run),
+                onClick: () => {
+                  detached(openOutput(run), "translate-document-dialog.open");
+                },
               },
             }
           : {}),
       });
       detached(
-        queryClient.invalidateQueries({
-          queryKey: entitiesKeys.all(workspaceId),
-        }),
+        invalidateDocumentTranslationOutputQueries(queryClient, workspaceId),
         "translate-document-dialog.invalidate-entities",
       );
       return;
@@ -474,7 +499,11 @@ export const TranslateDocumentDialog = (
                 })}
               </p>
               {run.status === "completed" && run.outputEntityId ? (
-                <Button onClick={() => openOutput(run)}>
+                <Button
+                  onClick={() => {
+                    detached(openOutput(run), "translate-document-dialog.open");
+                  }}
+                >
                   {t("common.open")}
                 </Button>
               ) : null}

--- a/apps/web/src/components/translate-document-dialog.tsx
+++ b/apps/web/src/components/translate-document-dialog.tsx
@@ -317,7 +317,11 @@ export const TranslateDocumentDialog = (
           : {}),
       });
       detached(
-        invalidateDocumentTranslationOutputQueries(queryClient, workspaceId),
+        invalidateDocumentTranslationOutputQueries(
+          queryClient,
+          workspaceId,
+          entityId,
+        ),
         "translate-document-dialog.invalidate-entities",
       );
       return;
@@ -332,6 +336,7 @@ export const TranslateDocumentDialog = (
     }
   }, [
     analytics,
+    entityId,
     openOutput,
     preparationQuery.error,
     runQuery.data,

--- a/apps/web/src/components/translate-document-dialog.tsx
+++ b/apps/web/src/components/translate-document-dialog.tsx
@@ -503,7 +503,9 @@ export const TranslateDocumentDialog = (
                   total: String(run.total),
                 })}
               </p>
-              {run.status === "completed" && run.outputEntityId ? (
+              {run.status === "completed" &&
+              run.outputEntityId &&
+              run.outputFieldId ? (
                 <Button
                   onClick={() => {
                     detached(openOutput(run), "translate-document-dialog.open");


### PR DESCRIPTION
## Summary
- bound and cache stable bilingual document input while preserving ordered translation context
- open completed translation outputs after destination data is ready
- invalidate entity projections without refetching the active source document

## Validation
- `bun run verify` (completed repository checks via pre-push hook)
- focused API and web translation tests
- API and web typechecks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved bilingual translation consistency by preserving document context across translation batches.
  * Translation requests now use bounded document context to improve caching efficiency.
  * Failed translation batches stop promptly, avoiding unnecessary additional processing.
  * Translation output updates refresh related document views without unnecessarily reloading the source document.

* **Bug Fixes**
  * Opening translated output now prepares the destination before closing the dialog and navigating.
  * Errors during output preparation keep the dialog open and display a helpful notification.

* **Tests**
  * Added coverage for batching, error handling, caching, query updates and output handoff behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->