### PR TITLE
fix: open every selected item in the inspector

### DIFF
--- a/apps/web/src/components/chat/entity-open.ts
+++ b/apps/web/src/components/chat/entity-open.ts
@@ -5,6 +5,11 @@ import {
   isFileActiveInMainRoute,
 } from "@/components/chat/entity-route-detect";
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
+import {
+  definedFields,
+  type FileTabSourceField,
+  toFileTab,
+} from "@/components/inspector/open-entities.logic";
 import { getTranslator } from "@/i18n/i18n-store";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
@@ -14,19 +19,7 @@ import type { EmailCitationSource } from "@/lib/files/email-citations";
 import type { OfficeCitationSource } from "@/lib/files/office-citations";
 import { toSafeId } from "@/lib/safe-id";
 import { isFileDisplayable } from "@/lib/types";
-import type {
-  FieldId,
-  PropertyId,
-  WorkspaceEntity,
-  WorkspaceField,
-  WorkspaceFieldContent,
-} from "@/lib/types";
-
-type EntityFileField = {
-  id: FieldId;
-  propertyId?: PropertyId | undefined;
-  content: WorkspaceFieldContent;
-};
+import type { WorkspaceEntity } from "@/lib/types";
 
 const openDisplayableFile = ({
   entityId,
@@ -36,45 +29,33 @@ const openDisplayableFile = ({
   openInPreview = false,
 }: {
   entityId: string;
-  fields: Iterable<EntityFileField>;
+  fields: Iterable<FileTabSourceField>;
   label: string;
   workspaceId: string;
   openInPreview?: boolean | undefined;
 }) => {
-  const sameAsMainRoute = isEntityActiveInMainRoute(entityId, workspaceId);
-
-  for (const field of fields) {
-    if (field.content.type !== "file" || !isFileDisplayable(field.content)) {
-      continue;
-    }
-
-    useInspectorTabsStore.getState().openFile({
-      id: field.id,
-      entityId,
-      label,
-      fileName: field.content.fileName,
-      mimeType: field.content.mimeType,
-      pdfFileId: field.content.pdfFileId,
-      propertyId: field.propertyId,
-      workspaceId,
-      // The file is already in the main view; don't compete with
-      // it — open the inspector to its metadata view so the
-      // mention click reveals fields/properties instead of
-      // re-rendering the same document.
-      ...(sameAsMainRoute && !openInPreview
-        ? { metadataLane: "expanded" as const }
-        : {}),
-    });
-    return true;
+  const tab = toFileTab({ entityId, fields, label, workspaceId });
+  if (tab === null) {
+    return false;
   }
-
-  return false;
+  const sameAsMainRoute = isEntityActiveInMainRoute(entityId, workspaceId);
+  useInspectorTabsStore.getState().openFile({
+    ...tab,
+    // The file is already in the main view; don't compete with
+    // it — open the inspector to its metadata view so the
+    // mention click reveals fields/properties instead of
+    // re-rendering the same document.
+    ...(sameAsMainRoute && !openInPreview
+      ? { metadataLane: "expanded" as const }
+      : {}),
+  });
+  return true;
 };
 
 type OpenEntityFileFieldArgs = {
   entityId: string;
   fieldId: string;
-  fields: Iterable<EntityFileField>;
+  fields: Iterable<FileTabSourceField>;
   label: string;
   workspaceId: string;
 };
@@ -107,15 +88,6 @@ export const openEntityFileFieldInInspector = ({
   }
   return false;
 };
-
-const toEntityFileFields = (entity: WorkspaceEntity): EntityFileField[] =>
-  Object.values(entity.fields)
-    .filter((field): field is WorkspaceField => field !== undefined)
-    .map((field) => ({
-      id: field.id,
-      propertyId: field.propertyId,
-      content: field.content,
-    }));
 
 type OpenEntityResult =
   | { type: "opened" }
@@ -173,7 +145,7 @@ export const openEntityInInspector = async (
 
     openDisplayableFile({
       entityId,
-      fields: toEntityFileFields(entity),
+      fields: definedFields(entity),
       label,
       workspaceId,
     });

--- a/apps/web/src/components/inspector/inspector-actions.ts
+++ b/apps/web/src/components/inspector/inspector-actions.ts
@@ -1,7 +1,9 @@
 import { useInspectorCommandStore } from "@/components/inspector/inspector-command-store";
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
-import { planInspectorOpen } from "@/components/inspector/open-entities.logic";
-import type { WorkspaceEntity } from "@/lib/types";
+import {
+  type InspectorOpenArgs,
+  planInspectorOpen,
+} from "@/components/inspector/open-entities.logic";
 
 /** Activate a tab, then queue its rename command for the lazy tab consumer. */
 export const requestInspectorRename = (tabId: string): void => {
@@ -9,21 +11,12 @@ export const requestInspectorRename = (tabId: string): void => {
   useInspectorCommandStore.getState().requestRename(tabId);
 };
 
-type InspectorOpenSelectionArgs = {
-  entities: readonly WorkspaceEntity[];
-  /** The row the user acted on; its tab takes focus. */
-  anchor: WorkspaceEntity;
-  workspaceId: string;
-};
-
 /** The open handler for a selection, or undefined when nothing in it can
  *  open (which is what hides the Preview action). */
-export const openInspectorSelection = ({
-  entities,
-  anchor,
-  workspaceId,
-}: InspectorOpenSelectionArgs): (() => void) | undefined => {
-  const plan = planInspectorOpen({ entities, anchor, workspaceId });
+export const openInspectorSelection = (
+  args: InspectorOpenArgs,
+): (() => void) | undefined => {
+  const plan = planInspectorOpen(args);
   if (plan === null) {
     return undefined;
   }

--- a/apps/web/src/components/inspector/inspector-actions.ts
+++ b/apps/web/src/components/inspector/inspector-actions.ts
@@ -1,8 +1,31 @@
 import { useInspectorCommandStore } from "@/components/inspector/inspector-command-store";
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
+import { planInspectorOpen } from "@/components/inspector/open-entities.logic";
+import type { WorkspaceEntity } from "@/lib/types";
 
 /** Activate a tab, then queue its rename command for the lazy tab consumer. */
 export const requestInspectorRename = (tabId: string): void => {
   useInspectorTabsStore.getState().setActive(tabId);
   useInspectorCommandStore.getState().requestRename(tabId);
+};
+
+type InspectorOpenSelectionArgs = {
+  entities: readonly WorkspaceEntity[];
+  /** The row the user acted on; its tab takes focus. */
+  anchor: WorkspaceEntity;
+  workspaceId: string;
+};
+
+/** The open handler for a selection, or undefined when nothing in it can
+ *  open (which is what hides the Preview action). */
+export const openInspectorSelection = ({
+  entities,
+  anchor,
+  workspaceId,
+}: InspectorOpenSelectionArgs): (() => void) | undefined => {
+  const plan = planInspectorOpen({ entities, anchor, workspaceId });
+  if (plan === null) {
+    return undefined;
+  }
+  return () => useInspectorTabsStore.getState().openTabs(plan);
 };

--- a/apps/web/src/components/inspector/inspector-store-types.ts
+++ b/apps/web/src/components/inspector/inspector-store-types.ts
@@ -120,6 +120,9 @@ export type InspectorTab =
   | SkillResourceTab
   | GenericTab;
 
+/** A tab shape `openTabs` can materialize: the kinds a workspace entity maps to. */
+export type InspectorOpenTarget = FileTab | TaskTab;
+
 export type DocumentTextSelection = {
   text: string;
   seq: number;
@@ -197,6 +200,13 @@ export type FileFieldReplacement = {
   propertyId?: string | undefined;
 };
 
+/** `activeId` must name one of `targets`; the caller picks the focused tab
+ *  because "first in the selection" differs between the table and the tree. */
+export type OpenTabsArgs = {
+  targets: readonly InspectorOpenTarget[];
+  activeId: string;
+};
+
 export type InspectorTabsActions = {
   openFile: (tab: Omit<FileTab, "type">) => void;
   openFileForEntity: (tab: Omit<FileTab, "type">) => void;
@@ -207,6 +217,7 @@ export type InspectorTabsActions = {
     isNew?: boolean;
   }) => void;
   openPendingTask: (args: { workspaceId: string; label?: string }) => string;
+  openTabs: (args: OpenTabsArgs) => void;
   resolvePendingTask: (args: { pendingTaskId: string; taskId: string }) => void;
   openExternal: (args: {
     url: string;

--- a/apps/web/src/components/inspector/inspector-tabs-slice.ts
+++ b/apps/web/src/components/inspector/inspector-tabs-slice.ts
@@ -9,6 +9,7 @@ import type {
   InspectorTabsSet,
   InspectorTabsStore,
   MatterTabId,
+  OpenTabsArgs,
   SkillResourceTabId,
   TaskTab,
 } from "@/components/inspector/inspector-store-types";
@@ -76,11 +77,14 @@ const normalizeFileTabFacet = (tab: Draft<FileTab>): void => {
   }
 };
 
+/** Focus-neutral: the caller owns `activeId`. Returns the id the matching
+ *  tab had before this upsert, or null when a tab was inserted, so callers
+ *  that follow focus across an id replacement can do so. */
 const upsertFileTab = (
   state: Draft<InspectorTabsStore>,
   tab: Omit<FileTab, "type">,
   { renderIdPolicy }: UpsertFileTabOptions,
-) => {
+): string | null => {
   const matchIndex = state.tabs.findIndex(
     (candidate) =>
       candidate.type === "pdf" &&
@@ -88,13 +92,12 @@ const upsertFileTab = (
   );
   if (matchIndex === -1) {
     state.tabs.push({ type: "pdf", renderId: uuidv7(), ...tab });
-    state.activeId = tab.id;
-    return;
+    return null;
   }
 
   const existing = state.tabs[matchIndex];
   if (existing?.type !== "pdf") {
-    return;
+    return null;
   }
 
   const previousId = existing.id;
@@ -127,17 +130,17 @@ const upsertFileTab = (
         (candidate.entityId === tab.entityId || candidate.id === tab.id)
       ),
   );
-  if (state.activeId === previousId) {
-    state.activeId = tab.id;
-  }
+  return previousId;
 };
 
-/** Mirror of `upsertFileTab` for task tabs. Leaves `activeId` alone so the
- *  caller owns focus, and keeps an existing tab's `creationStatus`. */
+/** Mirror of `upsertFileTab` for task tabs: focus-neutral, and keeps an
+ *  existing tab's `creationStatus`. */
 const upsertTaskTab = (state: Draft<InspectorTabsStore>, tab: TaskTab) => {
   const existing = state.tabs.find((candidate) => candidate.id === tab.id);
   if (!existing) {
-    state.tabs.push(tab);
+    // Copy so the store never aliases (and immer never freezes) the
+    // caller's object.
+    state.tabs.push({ ...tab });
     return;
   }
   if (existing.type !== "task") {
@@ -152,6 +155,39 @@ const upsertTaskTab = (state: Draft<InspectorTabsStore>, tab: TaskTab) => {
   existing.workspaceId = tab.workspaceId;
 };
 
+// One user action, one activation: opening a selection must leave focus on
+// the tab the caller names, not on whichever target happened to come last.
+// `openFile` and `openTask` are the single-target form of the same call.
+const openTabs = (
+  set: InspectorTabsSet,
+  { targets, activeId }: OpenTabsArgs,
+) => {
+  if (!targets.some((target) => target.id === activeId)) {
+    panic("openTabs was given an activeId outside its targets");
+  }
+  set((state) => {
+    for (const target of targets) {
+      switch (target.type) {
+        case "pdf":
+          upsertFileTab(state, target, {
+            renderIdPolicy: FILE_TAB_RENDER_ID_POLICY.whenIdChanges,
+          });
+          dropSupersededFileSuggestion(state, target);
+          break;
+        case "task":
+          upsertTaskTab(state, target);
+          break;
+        default:
+          target satisfies never;
+          panic("Unhandled inspector open target");
+      }
+    }
+    state.activeId = activeId;
+    state.activationSeq += 1;
+    state.minimized = false;
+  });
+};
+
 export const createInspectorTabsSlice = (
   set: InspectorTabsSet,
 ): InspectorTabsStore => ({
@@ -164,72 +200,42 @@ export const createInspectorTabsSlice = (
   reviveSuggestion: null,
 
   openFile: (tab) =>
-    set((state) => {
-      upsertFileTab(state, tab, {
-        renderIdPolicy: FILE_TAB_RENDER_ID_POLICY.whenIdChanges,
-      });
-      state.activeId = tab.id;
-      state.activationSeq += 1;
-      state.minimized = false;
-      dropSupersededFileSuggestion(state, tab);
+    openTabs(set, {
+      targets: [{ type: "pdf", ...tab }],
+      activeId: tab.id,
     }),
 
   openFileForEntity: (tab) =>
     set((state) => {
-      upsertFileTab(state, tab, {
+      const previousId = upsertFileTab(state, tab, {
         renderIdPolicy: FILE_TAB_RENDER_ID_POLICY.always,
       });
+      // Focus follows only a fresh tab or the tab that was already focused;
+      // an entity-driven refresh must not steal focus from another tab.
+      if (previousId === null || state.activeId === previousId) {
+        state.activeId = tab.id;
+      }
       state.activationSeq += 1;
       state.minimized = false;
       dropSupersededFileSuggestion(state, tab);
     }),
 
   openTask: ({ taskId, workspaceId, label = "", isNew = false }) =>
-    set((state) => {
-      upsertTaskTab(state, {
-        type: "task",
-        id: taskId,
-        creationStatus: "ready",
-        label,
-        isNew,
-        workspaceId,
-      });
-      state.activeId = taskId;
-      state.activationSeq += 1;
-      state.minimized = false;
+    openTabs(set, {
+      targets: [
+        {
+          type: "task",
+          id: taskId,
+          creationStatus: "ready",
+          label,
+          isNew,
+          workspaceId,
+        },
+      ],
+      activeId: taskId,
     }),
 
-  // One user action, one activation: opening a selection must leave focus on
-  // the tab the caller names, not on whichever target happened to come last.
-  openTabs: ({ targets, activeId }) => {
-    if (targets.length === 0) {
-      return;
-    }
-    if (!targets.some((target) => target.id === activeId)) {
-      panic("openTabs was given an activeId outside its targets");
-    }
-    set((state) => {
-      for (const target of targets) {
-        switch (target.type) {
-          case "pdf":
-            upsertFileTab(state, target, {
-              renderIdPolicy: FILE_TAB_RENDER_ID_POLICY.whenIdChanges,
-            });
-            dropSupersededFileSuggestion(state, target);
-            break;
-          case "task":
-            upsertTaskTab(state, target);
-            break;
-          default:
-            target satisfies never;
-            panic("Unhandled inspector open target");
-        }
-      }
-      state.activeId = activeId;
-      state.activationSeq += 1;
-      state.minimized = false;
-    });
-  },
+  openTabs: (args) => openTabs(set, args),
 
   openPendingTask: ({ workspaceId, label = "" }) => {
     const pendingTaskId = `pending-task:${uuidv7()}`;

--- a/apps/web/src/components/inspector/inspector-tabs-slice.ts
+++ b/apps/web/src/components/inspector/inspector-tabs-slice.ts
@@ -1,3 +1,4 @@
+import { panic } from "better-result";
 import { current, type Draft } from "immer";
 import { v7 as uuidv7 } from "uuid";
 
@@ -9,6 +10,7 @@ import type {
   InspectorTabsStore,
   MatterTabId,
   SkillResourceTabId,
+  TaskTab,
 } from "@/components/inspector/inspector-store-types";
 import { getInspectorView } from "@/components/inspector/view-registry";
 import { normalizeOptionalArray } from "@/lib/arrays";
@@ -130,6 +132,24 @@ const upsertFileTab = (
   }
 };
 
+const upsertTaskTab = (state: Draft<InspectorTabsStore>, tab: TaskTab) => {
+  const existing = state.tabs.find((candidate) => candidate.id === tab.id);
+  if (!existing) {
+    state.tabs.push(tab);
+    return;
+  }
+  if (existing.type !== "task") {
+    return;
+  }
+  if (tab.label) {
+    existing.label = tab.label;
+  }
+  if (tab.isNew) {
+    existing.isNew = true;
+  }
+  existing.workspaceId = tab.workspaceId;
+};
+
 export const createInspectorTabsSlice = (
   set: InspectorTabsSet,
 ): InspectorTabsStore => ({
@@ -164,29 +184,50 @@ export const createInspectorTabsSlice = (
 
   openTask: ({ taskId, workspaceId, label = "", isNew = false }) =>
     set((state) => {
-      const existing = state.tabs.find((tab) => tab.id === taskId);
-      if (!existing) {
-        state.tabs.push({
-          type: "task",
-          id: taskId,
-          creationStatus: "ready",
-          label,
-          isNew,
-          workspaceId,
-        });
-      } else if (existing.type === "task") {
-        if (label) {
-          existing.label = label;
-        }
-        if (isNew) {
-          existing.isNew = true;
-        }
-        existing.workspaceId = workspaceId;
-      }
+      upsertTaskTab(state, {
+        type: "task",
+        id: taskId,
+        creationStatus: "ready",
+        label,
+        isNew,
+        workspaceId,
+      });
       state.activeId = taskId;
       state.activationSeq += 1;
       state.minimized = false;
     }),
+
+  // One user action, one activation: opening a selection must leave focus on
+  // the tab the caller names, not on whichever target happened to come last.
+  openTabs: ({ targets, activeId }) => {
+    if (targets.length === 0) {
+      return;
+    }
+    if (!targets.some((target) => target.id === activeId)) {
+      panic("openTabs was given an activeId outside its targets");
+    }
+    set((state) => {
+      for (const target of targets) {
+        switch (target.type) {
+          case "pdf":
+            upsertFileTab(state, target, {
+              renderIdPolicy: FILE_TAB_RENDER_ID_POLICY.whenIdChanges,
+            });
+            dropSupersededFileSuggestion(state, target);
+            break;
+          case "task":
+            upsertTaskTab(state, target);
+            break;
+          default:
+            target satisfies never;
+            panic("Unhandled inspector open target");
+        }
+      }
+      state.activeId = activeId;
+      state.activationSeq += 1;
+      state.minimized = false;
+    });
+  },
 
   openPendingTask: ({ workspaceId, label = "" }) => {
     const pendingTaskId = `pending-task:${uuidv7()}`;

--- a/apps/web/src/components/inspector/inspector-tabs-slice.ts
+++ b/apps/web/src/components/inspector/inspector-tabs-slice.ts
@@ -155,8 +155,9 @@ const upsertTaskTab = (state: Draft<InspectorTabsStore>, tab: TaskTab) => {
   existing.workspaceId = tab.workspaceId;
 };
 
-// One user action, one activation: opening a selection must leave focus on
-// the tab the caller names, not on whichever target happened to come last.
+// Bulk open: adds a tab for every target in a single store update, then
+// focuses the one the caller names. Opening a selection one tab at a time
+// would re-render per tab and leave focus on whichever came last.
 // `openFile` and `openTask` are the single-target form of the same call.
 const openTabs = (
   set: InspectorTabsSet,

--- a/apps/web/src/components/inspector/inspector-tabs-slice.ts
+++ b/apps/web/src/components/inspector/inspector-tabs-slice.ts
@@ -132,6 +132,8 @@ const upsertFileTab = (
   }
 };
 
+/** Mirror of `upsertFileTab` for task tabs. Leaves `activeId` alone so the
+ *  caller owns focus, and keeps an existing tab's `creationStatus`. */
 const upsertTaskTab = (state: Draft<InspectorTabsStore>, tab: TaskTab) => {
   const existing = state.tabs.find((candidate) => candidate.id === tab.id);
   if (!existing) {

--- a/apps/web/src/components/inspector/inspector-tabs-store.test.ts
+++ b/apps/web/src/components/inspector/inspector-tabs-store.test.ts
@@ -264,19 +264,6 @@ describe("openTabs", () => {
     ]);
   });
 
-  test("leaves the inspector untouched when nothing can be opened", () => {
-    useInspectorTabsStore.setState({ minimized: true });
-
-    useInspectorTabsStore.getState().openTabs({ targets: [], activeId: "" });
-
-    expect(useInspectorTabsStore.getState()).toMatchObject({
-      activeId: null,
-      activationSeq: 0,
-      minimized: true,
-      tabs: [],
-    });
-  });
-
   test("rejects a focus target that is not being opened", () => {
     expect(() =>
       useInspectorTabsStore.getState().openTabs({

--- a/apps/web/src/components/inspector/inspector-tabs-store.test.ts
+++ b/apps/web/src/components/inspector/inspector-tabs-store.test.ts
@@ -187,6 +187,106 @@ describe("optimistic task creation", () => {
   });
 });
 
+describe("openTabs", () => {
+  const fileTarget = (suffix: string) =>
+    ({
+      type: "pdf",
+      id: `field-${suffix}`,
+      entityId: `entity-${suffix}`,
+      label: `Document ${suffix}`,
+      fileName: `Document ${suffix}.pdf`,
+      mimeType: "application/pdf",
+      pdfFileId: `pdf-${suffix}`,
+      propertyId: "property-1",
+      workspaceId: "workspace-1",
+    }) as const;
+
+  test("opens every target in order and focuses the one named, not the last", () => {
+    useInspectorTabsStore.setState({ minimized: true });
+
+    useInspectorTabsStore.getState().openTabs({
+      targets: [fileTarget("a"), fileTarget("b"), fileTarget("c")],
+      activeId: "field-b",
+    });
+
+    expect(useInspectorTabsStore.getState()).toMatchObject({
+      activeId: "field-b",
+      activationSeq: 1,
+      minimized: false,
+    });
+    expect(useInspectorTabsStore.getState().tabs.map((tab) => tab.id)).toEqual([
+      "field-a",
+      "field-b",
+      "field-c",
+    ]);
+  });
+
+  test("opens a mixed selection of files and tasks", () => {
+    useInspectorTabsStore.getState().openTabs({
+      targets: [
+        fileTarget("a"),
+        {
+          type: "task",
+          id: "task-1",
+          creationStatus: "ready",
+          label: "Serve notice",
+          isNew: false,
+          workspaceId: "workspace-1",
+        },
+      ],
+      activeId: "task-1",
+    });
+
+    expect(useInspectorTabsStore.getState()).toMatchObject({
+      activeId: "task-1",
+      tabs: [
+        { type: "pdf", id: "field-a" },
+        { type: "task", id: "task-1", creationStatus: "ready" },
+      ],
+    });
+  });
+
+  test("reuses an already-open tab and still honours the requested focus", () => {
+    useInspectorTabsStore.getState().openFile(fileTarget("a"));
+
+    useInspectorTabsStore.getState().openTabs({
+      targets: [fileTarget("a"), fileTarget("b")],
+      activeId: "field-a",
+    });
+
+    expect(useInspectorTabsStore.getState()).toMatchObject({
+      activeId: "field-a",
+      activationSeq: 2,
+    });
+    expect(useInspectorTabsStore.getState().tabs.map((tab) => tab.id)).toEqual([
+      "field-a",
+      "field-b",
+    ]);
+  });
+
+  test("leaves the inspector untouched when nothing can be opened", () => {
+    useInspectorTabsStore.setState({ minimized: true });
+
+    useInspectorTabsStore.getState().openTabs({ targets: [], activeId: "" });
+
+    expect(useInspectorTabsStore.getState()).toMatchObject({
+      activeId: null,
+      activationSeq: 0,
+      minimized: true,
+      tabs: [],
+    });
+  });
+
+  test("rejects a focus target that is not being opened", () => {
+    expect(() =>
+      useInspectorTabsStore.getState().openTabs({
+        targets: [fileTarget("a")],
+        activeId: "field-b",
+      }),
+    ).toThrow("activeId outside its targets");
+  });
+});
+
 describe("openChat", () => {
   test("creates a workspace-scoped tab when workspaceId is provided", () => {
     const threadId = toChatThreadId("thread-A");

--- a/apps/web/src/components/inspector/open-entities.logic.test.ts
+++ b/apps/web/src/components/inspector/open-entities.logic.test.ts
@@ -1,12 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
+import type { InspectorOpenTarget } from "@/components/inspector/inspector-store-types";
 import { toSafeId } from "@/lib/safe-id";
 import type { WorkspaceEntity } from "@/lib/types";
 
-import {
-  planInspectorOpen,
-  toInspectorOpenTargets,
-} from "./open-entities.logic";
+import { planInspectorOpen } from "./open-entities.logic";
 
 const WORKSPACE_ID = "workspace-1";
 
@@ -99,9 +97,21 @@ const pdfEntity = (entityId: string) =>
     }),
   );
 
+/** The targets a selection opens; every entity is its own anchor here
+ *  because these tests are about which tabs open, not which one focuses. */
+const targetsOf = (
+  entities: readonly WorkspaceEntity[],
+  workspaceId: string,
+): readonly InspectorOpenTarget[] =>
+  planInspectorOpen({
+    entities,
+    anchor: entities[0] ?? entity("none", "document", {}),
+    workspaceId,
+  })?.targets ?? [];
+
 describe("projecting a selection onto inspector tabs", () => {
   test("keeps the caller's order so the tab strip matches the selection", () => {
-    const targets = toInspectorOpenTargets(
+    const targets = targetsOf(
       [pdfEntity("b"), pdfEntity("a"), pdfEntity("c")],
       WORKSPACE_ID,
     );
@@ -125,13 +135,56 @@ describe("projecting a selection onto inspector tabs", () => {
     );
 
     // The fixture must actually be unrenderable, or the assertion is vacuous.
-    expect(toInspectorOpenTargets([unrenderable], WORKSPACE_ID)).toEqual([]);
+    expect(targetsOf([unrenderable], WORKSPACE_ID)).toEqual([]);
     expect(
-      toInspectorOpenTargets(
+      targetsOf(
         [entity("folder", "folder"), unrenderable, pdfEntity("doc")],
         WORKSPACE_ID,
       ).map((target) => target.id),
     ).toEqual(["field-doc"]);
+  });
+
+  test("opens the first displayable file, not the first file", () => {
+    const zipPropertyId = toSafeId<"property">("property-zip");
+    const pdfPropertyId = toSafeId<"property">("property-pdf");
+    const mixed = entity("mixed", "document", {
+      [zipPropertyId]: {
+        id: toSafeId<"field">("field-zip"),
+        propertyId: zipPropertyId,
+        entityId: toSafeId<"entity">("mixed"),
+        content: {
+          type: "file",
+          version: 1,
+          id: "file-zip",
+          fileName: "archive.zip",
+          mimeType: "application/zip",
+          sizeBytes: 1,
+          encrypted: false,
+          sha256Hex: "a".repeat(64),
+          pdfFileId: null,
+        },
+      },
+      [pdfPropertyId]: {
+        id: toSafeId<"field">("field-pdf"),
+        propertyId: pdfPropertyId,
+        entityId: toSafeId<"entity">("mixed"),
+        content: {
+          type: "file",
+          version: 1,
+          id: "file-pdf",
+          fileName: "brief.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 1,
+          encrypted: false,
+          sha256Hex: "b".repeat(64),
+          pdfFileId: null,
+        },
+      },
+    });
+
+    expect(targetsOf([mixed], WORKSPACE_ID).map((target) => target.id)).toEqual(
+      ["field-pdf"],
+    );
   });
 
   test("opens a converted file on its PDF derivative", () => {
@@ -146,7 +199,7 @@ describe("projecting a selection onto inspector tabs", () => {
       }),
     );
 
-    expect(toInspectorOpenTargets([converted], WORKSPACE_ID)).toEqual([
+    expect(targetsOf([converted], WORKSPACE_ID)).toEqual([
       {
         type: "pdf",
         id: "field-docx",
@@ -162,9 +215,7 @@ describe("projecting a selection onto inspector tabs", () => {
   });
 
   test("maps a task to a ready task tab", () => {
-    expect(
-      toInspectorOpenTargets([entity("t1", "task")], WORKSPACE_ID),
-    ).toEqual([
+    expect(targetsOf([entity("t1", "task")], WORKSPACE_ID)).toEqual([
       {
         type: "task",
         id: "t1",

--- a/apps/web/src/components/inspector/open-entities.logic.test.ts
+++ b/apps/web/src/components/inspector/open-entities.logic.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from "bun:test";
+
+import { toSafeId } from "@/lib/safe-id";
+import type { WorkspaceEntity } from "@/lib/types";
+
+import {
+  planInspectorOpen,
+  toInspectorOpenTargets,
+} from "./open-entities.logic";
+
+const WORKSPACE_ID = "workspace-1";
+
+const entity = (
+  entityId: string,
+  kind: WorkspaceEntity["kind"],
+  fields: WorkspaceEntity["fields"] = {},
+): WorkspaceEntity => ({
+  entityId: toSafeId<"entity">(entityId),
+  kind,
+  name: entityId,
+  parentId: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  createdBy: null,
+  createdByUserId: null,
+  createdByImage: null,
+  createdByDeletedAt: null,
+  updatedAt: null,
+  version: 1,
+  status: null,
+  priority: null,
+  listItemType: null,
+  dueDate: null,
+  agendaKind: "task",
+  startAt: null,
+  endAt: null,
+  occurredAt: null,
+  remindAt: null,
+  allDay: false,
+  timeZone: null,
+  location: null,
+  onlineMeetingUrl: null,
+  availability: null,
+  sensitivity: null,
+  organizer: null,
+  attendees: null,
+  recurrence: null,
+  agendaSource: "manual",
+  externalSource: null,
+  externalId: null,
+  externalChangeKey: null,
+  externalICalUid: null,
+  readOnly: false,
+  sortOrder: null,
+  activeEditBy: null,
+  cellMetadata: {},
+  fields,
+});
+
+const fileFields = ({
+  entityId,
+  fileName,
+  mimeType,
+  pdfFileId = null,
+}: {
+  entityId: string;
+  fileName: string;
+  mimeType: string;
+  pdfFileId?: string | null;
+}): WorkspaceEntity["fields"] => {
+  const propertyId = toSafeId<"property">(`property-${entityId}`);
+  return {
+    [propertyId]: {
+      id: toSafeId<"field">(`field-${entityId}`),
+      propertyId,
+      entityId: toSafeId<"entity">(entityId),
+      content: {
+        type: "file",
+        version: 1,
+        id: `file-${entityId}`,
+        fileName,
+        mimeType,
+        sizeBytes: 1,
+        encrypted: false,
+        sha256Hex: "a".repeat(64),
+        pdfFileId,
+      },
+    },
+  };
+};
+
+const pdfEntity = (entityId: string) =>
+  entity(
+    entityId,
+    "document",
+    fileFields({
+      entityId,
+      fileName: `${entityId}.pdf`,
+      mimeType: "application/pdf",
+    }),
+  );
+
+describe("projecting a selection onto inspector tabs", () => {
+  test("keeps the caller's order so the tab strip matches the selection", () => {
+    const targets = toInspectorOpenTargets(
+      [pdfEntity("b"), pdfEntity("a"), pdfEntity("c")],
+      WORKSPACE_ID,
+    );
+
+    expect(targets.map((target) => target.id)).toEqual([
+      "field-b",
+      "field-a",
+      "field-c",
+    ]);
+  });
+
+  test("skips folders and files the inspector cannot render", () => {
+    const unrenderable = entity(
+      "raw",
+      "document",
+      fileFields({
+        entityId: "raw",
+        fileName: "archive.zip",
+        mimeType: "application/zip",
+      }),
+    );
+
+    // The fixture must actually be unrenderable, or the assertion is vacuous.
+    expect(toInspectorOpenTargets([unrenderable], WORKSPACE_ID)).toEqual([]);
+    expect(
+      toInspectorOpenTargets(
+        [entity("folder", "folder"), unrenderable, pdfEntity("doc")],
+        WORKSPACE_ID,
+      ).map((target) => target.id),
+    ).toEqual(["field-doc"]);
+  });
+
+  test("opens a converted file on its PDF derivative", () => {
+    const converted = entity(
+      "docx",
+      "document",
+      fileFields({
+        entityId: "docx",
+        fileName: "brief.docx",
+        mimeType: "application/octet-stream",
+        pdfFileId: "pdf-docx",
+      }),
+    );
+
+    expect(toInspectorOpenTargets([converted], WORKSPACE_ID)).toEqual([
+      {
+        type: "pdf",
+        id: "field-docx",
+        entityId: "docx",
+        label: "docx",
+        fileName: "brief.docx",
+        mimeType: "application/octet-stream",
+        pdfFileId: "pdf-docx",
+        propertyId: "property-docx",
+        workspaceId: WORKSPACE_ID,
+      },
+    ]);
+  });
+
+  test("maps a task to a ready task tab", () => {
+    expect(
+      toInspectorOpenTargets([entity("t1", "task")], WORKSPACE_ID),
+    ).toEqual([
+      {
+        type: "task",
+        id: "t1",
+        creationStatus: "ready",
+        label: "t1",
+        isNew: false,
+        workspaceId: WORKSPACE_ID,
+      },
+    ]);
+  });
+});
+
+describe("planning which tab a selection focuses", () => {
+  test("focuses the anchor rather than the last target opened", () => {
+    const anchor = pdfEntity("b");
+
+    expect(
+      planInspectorOpen({
+        entities: [pdfEntity("a"), anchor, pdfEntity("c")],
+        anchor,
+        workspaceId: WORKSPACE_ID,
+      }),
+    ).toMatchObject({ activeId: "field-b" });
+  });
+
+  test("falls back to the first target when the anchor cannot open", () => {
+    const folder = entity("folder", "folder");
+
+    expect(
+      planInspectorOpen({
+        entities: [folder, pdfEntity("a")],
+        anchor: folder,
+        workspaceId: WORKSPACE_ID,
+      }),
+    ).toMatchObject({ activeId: "field-a" });
+  });
+
+  test("has no plan when nothing in the selection can open", () => {
+    expect(
+      planInspectorOpen({
+        entities: [entity("folder", "folder")],
+        anchor: entity("folder", "folder"),
+        workspaceId: WORKSPACE_ID,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/components/inspector/open-entities.logic.ts
+++ b/apps/web/src/components/inspector/open-entities.logic.ts
@@ -90,7 +90,9 @@ const toInspectorOpenTarget = (
 
 export type InspectorOpenArgs = {
   entities: readonly WorkspaceEntity[];
-  /** The row the user acted on; its tab takes focus. */
+  /** The row the user acted on; its tab takes focus, rather than the first
+   *  target, so every surface follows one rule: double-clicking the third of
+   *  three selected rows focuses that row, as right-clicking it does. */
   anchor: WorkspaceEntity;
   workspaceId: string;
 };

--- a/apps/web/src/components/inspector/open-entities.logic.ts
+++ b/apps/web/src/components/inspector/open-entities.logic.ts
@@ -1,0 +1,69 @@
+import type {
+  InspectorOpenTarget,
+  OpenTabsArgs,
+} from "@/components/inspector/inspector-store-types";
+import {
+  getEntityName,
+  getFirstFile,
+} from "@/components/workspaces/entity-utils";
+import { isFileDisplayable, type WorkspaceEntity } from "@/lib/types";
+
+/** Project a selection onto the inspector tabs it can open, in the order
+ *  given. Folders and files the inspector cannot render are dropped. */
+export const toInspectorOpenTargets = (
+  entities: readonly WorkspaceEntity[],
+  workspaceId: string,
+): readonly InspectorOpenTarget[] => {
+  const targets: InspectorOpenTarget[] = [];
+  for (const entity of entities) {
+    if (entity.kind === "task") {
+      targets.push({
+        type: "task",
+        id: entity.entityId,
+        creationStatus: "ready",
+        label: getEntityName(entity),
+        isNew: false,
+        workspaceId,
+      });
+      continue;
+    }
+    const file = getFirstFile(entity);
+    if (!file || !isFileDisplayable(file)) {
+      continue;
+    }
+    targets.push({
+      type: "pdf",
+      id: file.fieldId,
+      entityId: file.entityId,
+      label: getEntityName(entity),
+      fileName: file.fileName,
+      mimeType: file.mimeType,
+      pdfFileId: file.pdfFileId,
+      propertyId: file.propertyId,
+      workspaceId,
+    });
+  }
+  return targets;
+};
+
+type InspectorOpenPlanArgs = {
+  entities: readonly WorkspaceEntity[];
+  /** The row the user acted on; its tab takes focus. */
+  anchor: WorkspaceEntity;
+  workspaceId: string;
+};
+
+/** The `openTabs` call for a selection, or null when nothing in it opens.
+ *  Both the table and the tree route through here so the two surfaces
+ *  cannot drift on which entities open or which tab ends up focused. */
+export const planInspectorOpen = ({
+  entities,
+  anchor,
+  workspaceId,
+}: InspectorOpenPlanArgs): OpenTabsArgs | null => {
+  const targets = toInspectorOpenTargets(entities, workspaceId);
+  const anchorId = toInspectorOpenTargets([anchor], workspaceId).at(0)?.id;
+  const activeId =
+    targets.find((target) => target.id === anchorId)?.id ?? targets.at(0)?.id;
+  return activeId === undefined ? null : { targets, activeId };
+};

--- a/apps/web/src/components/inspector/open-entities.logic.ts
+++ b/apps/web/src/components/inspector/open-entities.logic.ts
@@ -1,52 +1,94 @@
 import type {
+  FileTab,
   InspectorOpenTarget,
   OpenTabsArgs,
 } from "@/components/inspector/inspector-store-types";
+import { getEntityName } from "@/components/workspaces/entity-utils";
 import {
-  getEntityName,
-  getFirstFile,
-} from "@/components/workspaces/entity-utils";
-import { isFileDisplayable, type WorkspaceEntity } from "@/lib/types";
+  isFileDisplayable,
+  type WorkspaceEntity,
+  type WorkspaceFieldContent,
+} from "@/lib/types";
 
-/** Project a selection onto the inspector tabs it can open, in the order
- *  given. Folders and files the inspector cannot render are dropped. */
-export const toInspectorOpenTargets = (
-  entities: readonly WorkspaceEntity[],
-  workspaceId: string,
-): readonly InspectorOpenTarget[] => {
-  const targets: InspectorOpenTarget[] = [];
-  for (const entity of entities) {
-    if (entity.kind === "task") {
-      targets.push({
-        type: "task",
-        id: entity.entityId,
-        creationStatus: "ready",
-        label: getEntityName(entity),
-        isNew: false,
-        workspaceId,
-      });
-      continue;
-    }
-    const file = getFirstFile(entity);
-    if (!file || !isFileDisplayable(file)) {
-      continue;
-    }
-    targets.push({
-      type: "pdf",
-      id: file.fieldId,
-      entityId: file.entityId,
-      label: getEntityName(entity),
-      fileName: file.fileName,
-      mimeType: file.mimeType,
-      pdfFileId: file.pdfFileId,
-      propertyId: file.propertyId,
-      workspaceId,
-    });
-  }
-  return targets;
+/** The subset of a field the projection needs; `entityId` is passed
+ *  separately because chat mentions carry fields without it. */
+export type FileTabSourceField = {
+  id: string;
+  propertyId?: string | undefined;
+  content: WorkspaceFieldContent;
 };
 
-type InspectorOpenPlanArgs = {
+type ToFileTabArgs = {
+  entityId: string;
+  fields: Iterable<FileTabSourceField>;
+  label: string;
+  workspaceId: string;
+};
+
+/** The file tab for an entity's first displayable file field, or null when
+ *  it has none. The single owner of the entity-to-file-tab projection: a
+ *  non-displayable file ahead of a displayable one does not hide the latter. */
+export const toFileTab = ({
+  entityId,
+  fields,
+  label,
+  workspaceId,
+}: ToFileTabArgs): Omit<FileTab, "type"> | null => {
+  for (const field of fields) {
+    if (field.content.type !== "file" || !isFileDisplayable(field.content)) {
+      continue;
+    }
+    return {
+      id: field.id,
+      entityId,
+      label,
+      fileName: field.content.fileName,
+      mimeType: field.content.mimeType,
+      pdfFileId: field.content.pdfFileId,
+      propertyId: field.propertyId,
+      workspaceId,
+    };
+  }
+  return null;
+};
+
+export const definedFields = (
+  entity: WorkspaceEntity,
+): FileTabSourceField[] => {
+  const fields: FileTabSourceField[] = [];
+  for (const field of Object.values(entity.fields)) {
+    if (field) {
+      fields.push(field);
+    }
+  }
+  return fields;
+};
+
+const toInspectorOpenTarget = (
+  entity: WorkspaceEntity,
+  workspaceId: string,
+): InspectorOpenTarget | null => {
+  const label = getEntityName(entity);
+  if (entity.kind === "task") {
+    return {
+      type: "task",
+      id: entity.entityId,
+      creationStatus: "ready",
+      label,
+      isNew: false,
+      workspaceId,
+    };
+  }
+  const fileTab = toFileTab({
+    entityId: entity.entityId,
+    fields: definedFields(entity),
+    label,
+    workspaceId,
+  });
+  return fileTab === null ? null : { type: "pdf", ...fileTab };
+};
+
+export type InspectorOpenArgs = {
   entities: readonly WorkspaceEntity[];
   /** The row the user acted on; its tab takes focus. */
   anchor: WorkspaceEntity;
@@ -60,10 +102,19 @@ export const planInspectorOpen = ({
   entities,
   anchor,
   workspaceId,
-}: InspectorOpenPlanArgs): OpenTabsArgs | null => {
-  const targets = toInspectorOpenTargets(entities, workspaceId);
-  const anchorId = toInspectorOpenTargets([anchor], workspaceId).at(0)?.id;
-  const activeId =
-    targets.find((target) => target.id === anchorId)?.id ?? targets.at(0)?.id;
+}: InspectorOpenArgs): OpenTabsArgs | null => {
+  const targets: InspectorOpenTarget[] = [];
+  let anchorTargetId: string | undefined;
+  for (const entity of entities) {
+    const target = toInspectorOpenTarget(entity, workspaceId);
+    if (target === null) {
+      continue;
+    }
+    targets.push(target);
+    if (entity.entityId === anchor.entityId) {
+      anchorTargetId = target.id;
+    }
+  }
+  const activeId = anchorTargetId ?? targets.at(0)?.id;
   return activeId === undefined ? null : { targets, activeId };
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { getFolderClickIntent } from "./tree-view-selection.logic";
+import {
+  getFolderClickIntent,
+  orderSelectedIds,
+} from "./tree-view-selection.logic";
 
 describe("folder row clicks", () => {
   test("modifier-click toggles selection without navigation", () => {
@@ -28,5 +31,25 @@ describe("folder row clicks", () => {
         hasModifier: false,
       }),
     ).toEqual({ type: "clear-and-toggle" });
+  });
+});
+
+describe("ordering a selection for bulk open", () => {
+  test("follows visible order, not click order", () => {
+    expect(
+      orderSelectedIds(new Set(["c", "a", "b"]), ["a", "b", "c", "d"]),
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  test("keeps ids outside the visible order, after it, in selection order", () => {
+    expect(
+      orderSelectedIds(new Set(["hidden-2", "b", "hidden-1", "a"]), ["a", "b"]),
+    ).toEqual(["a", "b", "hidden-2", "hidden-1"]);
+  });
+
+  test("is a fixed point on an already ordered selection", () => {
+    const ordered = ["a", "b", "c"];
+    const once = orderSelectedIds(new Set(["a", "b", "c"]), ordered);
+    expect(orderSelectedIds(new Set(once), ordered)).toEqual(once);
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  getFileRowClickIntent,
   getFolderClickIntent,
   orderSelectedIds,
 } from "./tree-view-selection.logic";
@@ -51,5 +52,38 @@ describe("ordering a selection for bulk open", () => {
     const ordered = ["a", "b", "c"];
     const once = orderSelectedIds(new Set(["a", "b", "c"]), ordered);
     expect(orderSelectedIds(new Set(once), ordered)).toEqual(once);
+  });
+});
+
+describe("file row clicks", () => {
+  test("a plain click always selects, so the range anchor cannot go stale", () => {
+    expect(
+      getFileRowClickIntent({ clickCount: 1, hasMeta: false, hasShift: false }),
+    ).toEqual({
+      type: "select",
+      meta: false,
+      shift: false,
+      snapshotSelection: true,
+    });
+  });
+
+  test("a modifier click selects without snapshotting: it collapses nothing", () => {
+    for (const mods of [
+      { hasMeta: true, hasShift: false },
+      { hasMeta: false, hasShift: true },
+    ]) {
+      expect(getFileRowClickIntent({ clickCount: 1, ...mods })).toEqual({
+        type: "select",
+        meta: mods.hasMeta,
+        shift: mods.hasShift,
+        snapshotSelection: false,
+      });
+    }
+  });
+
+  test("the closing click of a double-click leaves the selection alone", () => {
+    expect(
+      getFileRowClickIntent({ clickCount: 2, hasMeta: false, hasShift: false }),
+    ).toEqual({ type: "keep-selection" });
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic.ts
@@ -22,3 +22,25 @@ export const getFolderClickIntent = ({
 
   return { type: "clear-and-toggle" };
 };
+
+/** Selected ids in visible (flattened tree) order, so a bulk open produces
+ *  the same tab order as the table. Ids outside the visible order (rows in
+ *  collapsed folders picked up by select-all) follow in selection order. */
+export const orderSelectedIds = (
+  selectedIds: ReadonlySet<string>,
+  orderedEntityIds: readonly string[],
+): string[] => {
+  const ordered: string[] = [];
+  for (const id of orderedEntityIds) {
+    if (selectedIds.has(id)) {
+      ordered.push(id);
+    }
+  }
+  const listed = new Set(ordered);
+  for (const id of selectedIds) {
+    if (!listed.has(id)) {
+      ordered.push(id);
+    }
+  }
+  return ordered;
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic.ts
@@ -23,6 +23,47 @@ export const getFolderClickIntent = ({
   return { type: "clear-and-toggle" };
 };
 
+type FileRowClickOptions = {
+  /** `MouseEvent.detail`: 1 for the click that may begin a double-click. */
+  clickCount: number;
+  hasMeta: boolean;
+  hasShift: boolean;
+};
+
+export type FileRowClickIntent =
+  | {
+      type: "select";
+      meta: boolean;
+      shift: boolean;
+      /** Record the multi-row selection this click is about to collapse, so a
+       *  `dblclick` still opens the set the user had. */
+      snapshotSelection: boolean;
+    }
+  /** The closing click of a double-click: the opening one already ran the
+   *  transition, so repeating it would toggle a sole selection back off. */
+  | { type: "keep-selection" };
+
+/** What a click on a file row does to the selection. The opening click of a
+ *  double-click must still run its transition; suppressing it to protect the
+ *  set the double-click opens leaves the selection uncollapsed and the range
+ *  anchor stale, so a later shift-click extends from the wrong row. */
+export const getFileRowClickIntent = ({
+  clickCount,
+  hasMeta,
+  hasShift,
+}: FileRowClickOptions): FileRowClickIntent => {
+  if (clickCount > 1) {
+    return { type: "keep-selection" };
+  }
+  return {
+    type: "select",
+    meta: hasMeta,
+    shift: hasShift,
+    // Only a plain click collapses the selection, so only it needs a snapshot.
+    snapshotSelection: !hasMeta && !hasShift,
+  };
+};
+
 /** Selected ids in visible (flattened tree) order, so a bulk open produces
  *  the same tab order as the table. Ids outside the visible order (rows in
  *  collapsed folders picked up by select-all) follow in selection order. */

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -92,6 +92,7 @@ import { EmptyState } from "@/routes/_protected.workspaces/$workspaceId/-compone
 import { calculateFolderStatistics } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic";
 import type { FolderStatistics } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic";
 import {
+  getFileRowClickIntent,
   getFolderClickIntent,
   orderSelectedIds,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic";
@@ -1626,6 +1627,10 @@ const FilesystemRow = ({
     </>
   );
 
+  // `click` fires before `dblclick` and collapses a multi-row selection onto
+  // this row, so the opening click records the set it is about to collapse.
+  const dblClickSelectionRef = useRef<WorkspaceEntity[] | undefined>(undefined);
+
   // Double-click opens the whole selection, focusing the node clicked. The
   // context menu takes the same path through RowActions' `selectedEntities`.
   const openInInspector = () => {
@@ -1633,7 +1638,8 @@ const FilesystemRow = ({
       return;
     }
     openInspectorSelection({
-      entities: getBulkSelectedEntities() ?? [node],
+      entities: dblClickSelectionRef.current ??
+        getBulkSelectedEntities() ?? [node],
       anchor: node,
       workspaceId,
     })?.();
@@ -1674,15 +1680,27 @@ const FilesystemRow = ({
       className={rowButtonCls}
       onClick={(event) => {
         if (!isFolder) {
-          const meta = event.metaKey || event.ctrlKey;
-          // A plain click on a member of a multi-row selection keeps
-          // it, mirroring right-click, so the `click` before `dblclick`
-          // cannot collapse the selection the double-click opens.
-          if (isBulkSelected && !meta && !event.shiftKey) {
-            return;
+          const intent = getFileRowClickIntent({
+            clickCount: event.detail,
+            hasMeta: event.metaKey || event.ctrlKey,
+            hasShift: event.shiftKey,
+          });
+          switch (intent.type) {
+            case "select":
+              dblClickSelectionRef.current = intent.snapshotSelection
+                ? getBulkSelectedEntities()
+                : undefined;
+              onSelect(node.entityId, {
+                meta: intent.meta,
+                shift: intent.shift,
+              });
+              return;
+            case "keep-selection":
+              return;
+            default:
+              intent satisfies never;
+              return;
           }
-          onSelect(node.entityId, { meta, shift: event.shiftKey });
-          return;
         }
 
         // Shift extends a range like the file rows, taking priority

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -47,8 +47,7 @@ import {
 import type { DragPreviewData } from "@/components/drag-preview";
 import { FileTreeNameCell } from "@/components/file-tree/file-tree";
 import { InlineEdit } from "@/components/inline-edit";
-import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
-import type { FileTab } from "@/components/inspector/inspector-tabs-store";
+import { openInspectorSelection } from "@/components/inspector/inspector-actions";
 import Tooltip from "@/components/tooltip";
 import { resolveAncestorIds } from "@/components/workspaces/copy-to-matter-dialog.logic";
 import { EntityKindIcon } from "@/components/workspaces/entity-kind-icon";
@@ -69,7 +68,6 @@ import { detached } from "@/lib/detached";
 import { getFileSizeDisplay } from "@/lib/file-size";
 import { toSafeId } from "@/lib/safe-id";
 import { readStoredJson, writeStoredJson } from "@/lib/stored-json";
-import { isFileDisplayable } from "@/lib/types";
 import type {
   WorkspaceEntity,
   WorkspaceProperty,
@@ -1249,7 +1247,6 @@ const FilesystemRow = ({
     : null;
 
   const file = isFolder ? null : getFirstFile(node);
-  const navigable = file !== null && isFileDisplayable(file);
 
   // Preserve file extension during rename
   const extIndex = isFolder ? -1 : name.lastIndexOf(".");
@@ -1626,61 +1623,16 @@ const FilesystemRow = ({
     </>
   );
 
-  const openInInspector = (() => {
-    if (optimisticRename !== null) {
-      return undefined;
-    }
-    if (isBulkSelected) {
-      const entities = getSelectedEntities(selectedIds);
-      const navigables: Omit<FileTab, "type">[] = [];
-      for (const entity of entities) {
-        const candidateFile = getFirstFile(entity);
-        if (!candidateFile || !isFileDisplayable(candidateFile)) {
-          continue;
-        }
-
-        navigables.push({
-          id: candidateFile.fieldId,
-          entityId: entity.entityId,
-          label: getEntityName(entity),
-          fileName: candidateFile.fileName,
-          mimeType: candidateFile.mimeType,
-          pdfFileId: candidateFile.pdfFileId,
-          propertyId: candidateFile.propertyId,
+  // Double-click opens the whole selection, focusing the node clicked. The
+  // context menu takes the same path through RowActions' `selectedEntities`.
+  const openInInspector =
+    optimisticRename === null
+      ? openInspectorSelection({
+          entities: isBulkSelected ? getSelectedEntities(selectedIds) : [node],
+          anchor: node,
           workspaceId,
-        });
-      }
-      if (navigables.length === 0) {
-        return undefined;
-      }
-      return () => {
-        const store = useInspectorTabsStore.getState();
-        for (const tab of navigables) {
-          store.openFile(tab);
-        }
-      };
-    }
-    if (node.kind === "task") {
-      return () =>
-        useInspectorTabsStore
-          .getState()
-          .openTask({ taskId: node.entityId, workspaceId, label: name });
-    }
-    if (navigable) {
-      return () =>
-        useInspectorTabsStore.getState().openFile({
-          id: file.fieldId,
-          entityId: file.entityId,
-          label: name,
-          fileName: file.fileName,
-          mimeType: file.mimeType,
-          pdfFileId: file.pdfFileId,
-          propertyId: file.propertyId,
-          workspaceId,
-        });
-    }
-    return undefined;
-  })();
+        })
+      : undefined;
 
   const rowActionsNode = (
     <span className="flex justify-end">
@@ -1688,7 +1640,6 @@ const FilesystemRow = ({
         anchor={contextAnchor}
         entity={node}
         getAncestorIds={getAncestorIds}
-        onOpen={openInInspector}
         onOpenChange={(o) => {
           if (!o) {
             setMenuState({ type: "closed" });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -91,7 +91,10 @@ import { AddEntityMenu } from "@/routes/_protected.workspaces/$workspaceId/-comp
 import { EmptyState } from "@/routes/_protected.workspaces/$workspaceId/-components/empty-state";
 import { calculateFolderStatistics } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic";
 import type { FolderStatistics } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/folder-statistics.logic";
-import { getFolderClickIntent } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic";
+import {
+  getFolderClickIntent,
+  orderSelectedIds,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic";
 import { flattenFilesystemRows } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-virtualization";
 import {
   AuthorCell,
@@ -422,20 +425,6 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     [entityMap],
   );
 
-  const getSelectedEntities = useCallback(
-    (ids: Set<string>): WorkspaceEntity[] => {
-      const entities: WorkspaceEntity[] = [];
-      for (const id of ids) {
-        const entity = treeNodeMap.get(id);
-        if (entity) {
-          entities.push(entity);
-        }
-      }
-      return entities;
-    },
-    [treeNodeMap],
-  );
-
   // Drill-down navigation (persisted in URL search params)
   const currentFolderId = useSearch({
     from: "/_protected/workspaces/$workspaceId/$viewId",
@@ -617,6 +606,20 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
   const orderedEntityIds = useMemo(
     () => flattenedRows.map((row) => row.node.entityId),
     [flattenedRows],
+  );
+
+  const getSelectedEntities = useCallback(
+    (ids: Set<string>): WorkspaceEntity[] => {
+      const entities: WorkspaceEntity[] = [];
+      for (const id of orderSelectedIds(ids, orderedEntityIds)) {
+        const entity = treeNodeMap.get(id);
+        if (entity) {
+          entities.push(entity);
+        }
+      }
+      return entities;
+    },
+    [treeNodeMap, orderedEntityIds],
   );
 
   // meta = cmd/ctrl (toggle a single row); shift = extend a contiguous range
@@ -1625,14 +1628,16 @@ const FilesystemRow = ({
 
   // Double-click opens the whole selection, focusing the node clicked. The
   // context menu takes the same path through RowActions' `selectedEntities`.
-  const openInInspector =
-    optimisticRename === null
-      ? openInspectorSelection({
-          entities: isBulkSelected ? getSelectedEntities(selectedIds) : [node],
-          anchor: node,
-          workspaceId,
-        })
-      : undefined;
+  const openInInspector = () => {
+    if (optimisticRename !== null) {
+      return;
+    }
+    openInspectorSelection({
+      entities: getBulkSelectedEntities() ?? [node],
+      anchor: node,
+      workspaceId,
+    })?.();
+  };
 
   const rowActionsNode = (
     <span className="flex justify-end">
@@ -1669,10 +1674,14 @@ const FilesystemRow = ({
       className={rowButtonCls}
       onClick={(event) => {
         if (!isFolder) {
-          onSelect(node.entityId, {
-            meta: event.metaKey || event.ctrlKey,
-            shift: event.shiftKey,
-          });
+          const meta = event.metaKey || event.ctrlKey;
+          // A plain click on a member of a multi-row selection keeps
+          // it, mirroring right-click, so the `click` before `dblclick`
+          // cannot collapse the selection the double-click opens.
+          if (isBulkSelected && !meta && !event.shiftKey) {
+            return;
+          }
+          onSelect(node.entityId, { meta, shift: event.shiftKey });
           return;
         }
 
@@ -1704,7 +1713,7 @@ const FilesystemRow = ({
           onNavigateToFolder(node.entityId);
           return;
         }
-        openInInspector?.();
+        openInInspector();
       }}
       style={contentSpanStyle}
       type="button"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
@@ -12,6 +12,7 @@ import { cn } from "@stll/ui/utils";
 
 import { withDragAnnouncementData } from "@/components/drag-and-drop-live-region.logic";
 import { InlineEdit } from "@/components/inline-edit";
+import { openInspectorSelection } from "@/components/inspector/inspector-actions";
 import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
 import { UserIdentity } from "@/components/user-avatar";
 import { EditableField } from "@/components/workspaces/editable-field";
@@ -37,7 +38,6 @@ import { normalizeOptionalArray } from "@/lib/arrays";
 import { detached } from "@/lib/detached";
 import { formatRelativeTime } from "@/lib/relative-time";
 import { toSafeId } from "@/lib/safe-id";
-import { isFileDisplayable } from "@/lib/types";
 import type {
   WorkspaceEntity,
   WorkspaceFieldContent,
@@ -72,7 +72,6 @@ export const KanbanCard = ({
 }: KanbanCardProps) => {
   const name = getEntityName(entity);
   const file = getFirstFile(entity);
-  const navigable = file !== null && isFileDisplayable(file);
   const isActivePeek = useInspectorTabsStore((s) => {
     if (!s.activeId) {
       return false;
@@ -265,30 +264,11 @@ export const KanbanCard = ({
   const cardRef = useRef<HTMLDivElement>(null);
   useInspectorFlash(entity.entityId, cardRef);
 
-  const openCard = (() => {
-    if (isTask) {
-      return () =>
-        useInspectorTabsStore.getState().openTask({
-          taskId: entity.entityId,
-          workspaceId,
-          label: name,
-        });
-    }
-    if (navigable) {
-      return () =>
-        useInspectorTabsStore.getState().openFile({
-          id: file.fieldId,
-          entityId: file.entityId,
-          label: name,
-          fileName: file.fileName,
-          mimeType: file.mimeType,
-          pdfFileId: file.pdfFileId,
-          propertyId: file.propertyId,
-          workspaceId,
-        });
-    }
-    return undefined;
-  })();
+  const openCard = openInspectorSelection({
+    entities: [entity],
+    anchor: entity,
+    workspaceId,
+  });
 
   return (
     <KanbanCardShell

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -367,8 +367,9 @@ export const RowActions = ({
       }
     : undefined;
 
-  // Preview opens every selected entity the inspector can render and
-  // focuses the row the menu was opened on.
+  // Preview opens every selected entity the inspector can render and focuses
+  // the row the menu was opened on, not the first of the selection: the tab
+  // that takes focus is the row the user acted on, on every surface.
   const resolvedOnOpen = openInspectorSelection({
     entities: bulkTargets,
     anchor: entity,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -55,7 +55,7 @@ import { cn } from "@stll/ui/utils";
 
 import { buildEntityMentionOption } from "@/components/chat-mention-helpers";
 import { useRequestChatAbout } from "@/components/chat/use-request-chat-about";
-import { useInspectorTabsStore } from "@/components/inspector/inspector-tabs-store";
+import { openInspectorSelection } from "@/components/inspector/inspector-actions";
 import Tooltip from "@/components/tooltip";
 import { TranslateDocumentDialog } from "@/components/translate-document-dialog";
 import { CopyToMatterDialog } from "@/components/workspaces/copy-to-matter-dialog";
@@ -102,7 +102,6 @@ import type {
   WorkspaceCellMetadata,
   WorkspaceEntity,
 } from "@/lib/types";
-import { isFileDisplayable } from "@/lib/types";
 import { downloadFile } from "@/lib/utils";
 import {
   useCreateEntities,
@@ -370,35 +369,13 @@ export const RowActions = ({
       }
     : undefined;
 
-  // Derive a default open handler when the caller doesn't
-  // provide one. Tasks open in the inspector; displayable
-  // files open in the PDF peek viewer.
-  const resolvedOnOpen =
-    onOpen ??
-    (() => {
-      if (entity.kind === "task") {
-        return () =>
-          useInspectorTabsStore.getState().openTask({
-            taskId: entity.entityId,
-            workspaceId,
-            label: name,
-          });
-      }
-      if (file && isFileDisplayable(file)) {
-        return () =>
-          useInspectorTabsStore.getState().openFile({
-            id: file.fieldId,
-            entityId: file.entityId,
-            label: name,
-            fileName: file.fileName,
-            mimeType: file.mimeType,
-            pdfFileId: file.pdfFileId,
-            propertyId: file.propertyId,
-            workspaceId,
-          });
-      }
-      return undefined;
-    })();
+  const resolvedOnOpen = resolvePreviewHandler({
+    anchor: entity,
+    entities: bulkTargets,
+    isBulk,
+    onOpen,
+    workspaceId,
+  });
 
   const hasPdfConversion =
     file !== null && file.pdfFileId !== null && file.mimeType !== PDF_MIME_TYPE;
@@ -1006,6 +983,30 @@ export const RowActions = ({
       )}
     </Menu>
   );
+};
+
+type ResolvePreviewHandlerArgs = {
+  anchor: WorkspaceEntity;
+  entities: readonly WorkspaceEntity[];
+  isBulk: boolean;
+  onOpen: (() => void) | undefined;
+  workspaceId: string;
+};
+
+/** Preview opens every selected entity the inspector can render and focuses
+ *  the row the menu was opened on. `onOpen` overrides a single-entity menu
+ *  only; a bulk selection always opens as a whole. */
+const resolvePreviewHandler = ({
+  anchor,
+  entities,
+  isBulk,
+  onOpen,
+  workspaceId,
+}: ResolvePreviewHandlerArgs): (() => void) | undefined => {
+  if (!isBulk && onOpen) {
+    return onOpen;
+  }
+  return openInspectorSelection({ entities, anchor, workspaceId });
 };
 
 const RowOpenMenuActions = ({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -143,7 +143,6 @@ type RowActionsProps = {
   workspaceId: string;
   open?: boolean | undefined;
   onOpenChange?: ((open: boolean) => void) | undefined;
-  onOpen?: (() => void) | undefined;
   onRename?: (() => void) | undefined;
   onSubfolderCreated?:
     | ((entityId: string, parentId: string) => void)
@@ -244,7 +243,6 @@ export const RowActions = ({
   workspaceId,
   open,
   onOpenChange,
-  onOpen,
   onRename,
   onSubfolderCreated,
   triggerClassName,
@@ -369,11 +367,11 @@ export const RowActions = ({
       }
     : undefined;
 
-  const resolvedOnOpen = resolvePreviewHandler({
-    anchor: entity,
+  // Preview opens every selected entity the inspector can render and
+  // focuses the row the menu was opened on.
+  const resolvedOnOpen = openInspectorSelection({
     entities: bulkTargets,
-    isBulk,
-    onOpen,
+    anchor: entity,
     workspaceId,
   });
 
@@ -983,30 +981,6 @@ export const RowActions = ({
       )}
     </Menu>
   );
-};
-
-type ResolvePreviewHandlerArgs = {
-  anchor: WorkspaceEntity;
-  entities: readonly WorkspaceEntity[];
-  isBulk: boolean;
-  onOpen: (() => void) | undefined;
-  workspaceId: string;
-};
-
-/** Preview opens every selected entity the inspector can render and focuses
- *  the row the menu was opened on. `onOpen` overrides a single-entity menu
- *  only; a bulk selection always opens as a whole. */
-const resolvePreviewHandler = ({
-  anchor,
-  entities,
-  isBulk,
-  onOpen,
-  workspaceId,
-}: ResolvePreviewHandlerArgs): (() => void) | undefined => {
-  if (!isBulk && onOpen) {
-    return onOpen;
-  }
-  return openInspectorSelection({ entities, anchor, workspaceId });
 };
 
 const RowOpenMenuActions = ({


### PR DESCRIPTION
## Proposed change

Closes #1671

In table view, Preview on a multi-row selection opened only the anchor row. Now every selected entity the inspector can render opens as a tab, in visible order, with the row the user acted on focused. From the toolbar menu (no anchor row) the first item in the selection is focused.

**Cause:** the Preview handler in row actions opened only the row the menu belonged to and ignored the rest of the selection. It now builds the list of tabs to open from every selected row and hands it to a new store action, `openTabs`, which adds all the tabs in one update and focuses the anchor.

The tree's context-menu Preview did loop over the selection, unlike the table, but with one store update per file, so it re-rendered per file and focus landed on whichever file came last. It uses `openTabs` now too and behaves the same.

One shared function (`planInspectorOpen`, built on `toFileTab`) decides which inspector tab an entity turns into: a task tab for tasks, a file tab for the first file the inspector can render, nothing for folders. Before, table row actions, the filesystem tree, kanban cards, and chat mentions each had their own copy of that logic, which is how the table and tree drifted apart. All four now call the shared function.

Side effect: if an entity's first file is something the inspector cannot render (a `.zip`, say) but a later file is a PDF, the PDF opens. The old copies looked at the first file only and gave up.

### Filesystem tree double-click (bundled, not in the issue)

Double-clicking a multi-selection in the tree also opened only one file, for a different reason. A double-click fires `click` first, then `dblclick`. The `click` handler selected only the clicked row, wiping the multi-selection, so by the time `dblclick` ran there was nothing bulk to open. A plain click (no Cmd/Ctrl/Shift) on a row already in a multi-selection now leaves the selection alone, as right-click already did. Modifier clicks still toggle or extend.

Selected tree rows also open in on-screen order rather than click order (the selection is a `Set`), so the tab strip matches the table.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [x] DARK MODE SUPPORT | No visual changes.
- [x] ISSUE LINKED | Closes #1671
- [ ] SCREENSHOT INCLUDED | n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QPKvNiLZFgDqYQ98G635s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Open multiple selected files and tasks together in the inspector.
  - Keep selected items in visible tree order while focusing the intended item.
  - Double-clicking a selected file opens the full selection.
  - Preview actions skip folders and unsupported files.
  - Converted files open using their available PDF version.
- **Improvements**
  - Unified opening behaviour across file rows, task cards, and row actions.
  - Existing inspector tabs are reused while preserving the requested focus.
  - File renames update immediately and remain consistent after saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->