### PR TITLE
fix(api): project untyped OAuth clients as web in the Better Auth audit and backfill

### DIFF
--- a/apps/api/src/scripts/better-auth-17-backfill.db.test.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.db.test.ts
@@ -45,6 +45,7 @@ test("the Better Auth bridge backfill is exact, bounded, and reaches a fixed poi
       const microsoftIssuer =
         "https://login.microsoftonline.com/3a893563-0d4e-4309-9a31-b6e4e9f64479/v2.0";
       const clientId = `backfill-client-${suffix}`;
+      const untypedClientId = `backfill-untyped-client-${suffix}`;
 
       // The shared test schema represents the final 1.7 state. Relax only the
       // final constraint inside this rollback-only transaction to recreate the
@@ -73,6 +74,16 @@ test("the Better Auth bridge backfill is exact, bounded, and reaches a fixed poi
         redirectUris: ["https://client.example.invalid/callback"],
         scopes: ["openid", "offline_access", "stella:read"],
         type: "web",
+      });
+      // A dynamically registered client that never declared its type.
+      await transaction.insert(oauthClient).values({
+        clientId: untypedClientId,
+        grantTypes: ["authorization_code", "refresh_token"],
+        id: `backfill-untyped-client-row-${suffix}`,
+        public: true,
+        redirectUris: ["https://untyped.example.invalid/callback"],
+        scopes: ["openid", "offline_access", "stella:read"],
+        type: null,
       });
 
       const backfillDatabase = {
@@ -160,6 +171,15 @@ test("the Better Auth bridge backfill is exact, bounded, and reaches a fixed poi
             ({ identifier }) => identifier,
           ).toSorted(),
         },
+      ]);
+      const untypedClientPolicy = await transaction.execute(sql`
+        SELECT application_type AS "applicationType",
+               client_credentials_scopes AS "clientCredentialsScopes"
+          FROM oauth_client
+         WHERE client_id = ${untypedClientId}
+      `);
+      expect(untypedClientPolicy.rows).toEqual([
+        { applicationType: "web", clientCredentialsScopes: [] },
       ]);
 
       await transaction

--- a/apps/api/src/scripts/better-auth-17-backfill.logic.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.logic.ts
@@ -3,7 +3,7 @@ import { sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 import { isRecord } from "@/api/lib/type-guards";
-import { DEFAULT_OAUTH_APPLICATION_TYPE } from "@/api/scripts/better-auth-migration-audit.logic";
+import { readOAuthApplicationType } from "@/api/scripts/better-auth-migration-audit.logic";
 import type {
   BetterAuthExpectedOAuthResource,
   BetterAuthTrustedIdentityMap,
@@ -460,8 +460,7 @@ const backfillOAuthClientPage = async ({
   for (const row of selected.value) {
     const clientId = isRecord(row) ? requiredString(row["clientId"]) : null;
     const applicationType = isRecord(row)
-      ? (requiredString(row["applicationType"]) ??
-        DEFAULT_OAUTH_APPLICATION_TYPE)
+      ? readOAuthApplicationType(row)
       : null;
     const scopes = isRecord(row) ? optionalStringArray(row["scopes"]) : null;
     const grantTypes = isRecord(row)

--- a/apps/api/src/scripts/better-auth-17-backfill.logic.ts
+++ b/apps/api/src/scripts/better-auth-17-backfill.logic.ts
@@ -3,6 +3,7 @@ import { sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 import { isRecord } from "@/api/lib/type-guards";
+import { DEFAULT_OAUTH_APPLICATION_TYPE } from "@/api/scripts/better-auth-migration-audit.logic";
 import type {
   BetterAuthExpectedOAuthResource,
   BetterAuthTrustedIdentityMap,
@@ -459,7 +460,8 @@ const backfillOAuthClientPage = async ({
   for (const row of selected.value) {
     const clientId = isRecord(row) ? requiredString(row["clientId"]) : null;
     const applicationType = isRecord(row)
-      ? requiredString(row["applicationType"])
+      ? (requiredString(row["applicationType"]) ??
+        DEFAULT_OAUTH_APPLICATION_TYPE)
       : null;
     const scopes = isRecord(row) ? optionalStringArray(row["scopes"]) : null;
     const grantTypes = isRecord(row)

--- a/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
@@ -102,6 +102,16 @@ test("pre-migration audit is repeatable and rejects ownership corruption and an 
         updatedAt: new Date(),
         userId,
       });
+      // A dynamically registered client that never declared its type must
+      // project as a valid policy row.
+      await transaction.insert(oauthClient).values({
+        id: `audit-untyped-client-row-${suffix}`,
+        clientId: `audit-untyped-client-${suffix}`,
+        public: true,
+        redirectUris: [`https://untyped-${suffix}.example.invalid/callback`],
+        tokenEndpointAuthMethod: "none",
+        type: null,
+      });
 
       const auditDatabase = {
         execute: async (statement: Parameters<typeof transaction.execute>[0]) =>

--- a/apps/api/src/scripts/better-auth-migration-audit.logic.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.logic.ts
@@ -1061,6 +1061,13 @@ const OAUTH_POLICY_PAGE_SIZE = 1000;
 // stored policy matches the provider's own reading of the row.
 export const DEFAULT_OAUTH_APPLICATION_TYPE = "web";
 
+// Only a genuine SQL NULL takes the default; an absent or malformed value
+// stays invalid so validation still rejects it.
+export const readOAuthApplicationType = (row: Record<string, unknown>) =>
+  row["applicationType"] === null
+    ? DEFAULT_OAUTH_APPLICATION_TYPE
+    : requiredString(row["applicationType"]);
+
 const OAUTH_PROTOCOL_SCOPES = new Set([
   "email",
   "offline_access",
@@ -1152,8 +1159,7 @@ const readProjectedOAuthPolicy = async (
     for (const row of queried.value) {
       const clientId = isRecord(row) ? requiredString(row["clientId"]) : null;
       const applicationType = isRecord(row)
-        ? (requiredString(row["applicationType"]) ??
-          DEFAULT_OAUTH_APPLICATION_TYPE)
+        ? readOAuthApplicationType(row)
         : null;
       const scopes = isRecord(row) ? optionalStringArray(row["scopes"]) : null;
       const grantTypes = isRecord(row)

--- a/apps/api/src/scripts/better-auth-migration-audit.logic.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.logic.ts
@@ -1056,6 +1056,11 @@ type OAuthPolicyProjection =
   };
 
 const OAUTH_POLICY_PAGE_SIZE = 1000;
+// A client registered without an application type is treated by the provider
+// as a web client; the audit and backfill project the same default so the
+// stored policy matches the provider's own reading of the row.
+export const DEFAULT_OAUTH_APPLICATION_TYPE = "web";
+
 const OAUTH_PROTOCOL_SCOPES = new Set([
   "email",
   "offline_access",
@@ -1147,7 +1152,8 @@ const readProjectedOAuthPolicy = async (
     for (const row of queried.value) {
       const clientId = isRecord(row) ? requiredString(row["clientId"]) : null;
       const applicationType = isRecord(row)
-        ? requiredString(row["applicationType"])
+        ? (requiredString(row["applicationType"]) ??
+          DEFAULT_OAUTH_APPLICATION_TYPE)
         : null;
       const scopes = isRecord(row) ? optionalStringArray(row["scopes"]) : null;
       const grantTypes = isRecord(row)


### PR DESCRIPTION
The migration audit and backfill required every `oauth_client` row to carry an explicit `native` or `web` type, while the provider treats the type as optional and reads a missing value as `web`. A dynamically registered client that never declared its type therefore failed the pre-migration policy check and would have aborted the backfill.

Both now project a missing type as the provider's default (`web`) through one shared constant, so the stored policy matches how the provider already interprets the row. DB tests cover an untyped client in the pre-migration audit and in the backfill.

https://claude.ai/code/session_019Tx4ydN2CULWU5o7DV1fGF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - OAuth clients without an explicitly defined application type are now recognised as web applications by migration checks and backfill processes.
  - Prevented valid dynamically registered clients from being incorrectly flagged as invalid during migration audits.
  - Ensured generated OAuth policies remain consistent when application type information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->