### PR TITLE
fix: repair the nightly guard workflows and the canary's failure summaries

### DIFF
--- a/.changeset/mistral-chat-default.md
+++ b/.changeset/mistral-chat-default.md
@@ -1,0 +1,5 @@
+---
+"@stll/ai-catalog": patch
+---
+
+Default the Mistral chat role to `mistral-medium-latest`; `mistral-large-latest` is gated behind a higher subscription tier.

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -122,6 +122,9 @@ jobs:
   marketing-screenshots:
     uses: ./.github/workflows/marketing-screenshots.yml
     permissions:
+      # The check job polls the calling run's artifacts; a caller that grants
+      # less than the callee requests fails at startup, before any job runs.
+      actions: read
       contents: read
     with:
       mode: check

--- a/.github/workflows/scheduled-run-alerts.yml
+++ b/.github/workflows/scheduled-run-alerts.yml
@@ -23,7 +23,7 @@ jobs:
   notify:
     if: >-
       github.event_name == 'workflow_dispatch'
-      || github.event.workflow_run.conclusion == 'failure'
+      || contains(fromJSON('["failure", "startup_failure", "timed_out"]'), github.event.workflow_run.conclusion)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -54,8 +54,10 @@ export const NULL_WIDENING_CANARY_PROVIDERS = new Set(
 // for the model. An unsatisfiable regex (`a^`) expressed that until OpenAI's
 // strict-mode grammar compiler started dead-ending on it: the request ends
 // `incomplete` with zero output tokens before any tool call. `maxLength: 0`
-// says the same thing in a form every constrained decoder handles; a
-// hallucinated empty string still trips the probes' unexpected-argument check.
+// says the same thing in a form every constrained decoder handles. It still
+// admits the empty string, which non-strict models do emit for a field the
+// prompt told them to omit; the round-trip probe accepts that as a model
+// choice and fails only on the synthetic null the adapter must strip.
 export const IMPOSSIBLE_STRING_MAX_LENGTH = 0;
 
 export const CANARY_TIERS = ["daily", "weekly"] as const;

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@stll/ai-catalog";
 
 import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
 import {
   CanaryCredentialRejectedError,
@@ -873,5 +874,64 @@ describe("AI provider canary provider rejections", () => {
       "provider rejected request (output ceiling above model limit)",
     );
     expect(isRetryableCanaryError(streamed, signal)).toBe(false);
+  });
+});
+
+// The shared generate path rethrows provider RUN_ERRORs as a HandlerError
+// whose 502 is the handler's own status; the canary must read the wrapped
+// evidence instead of printing that wrapper.
+describe("AI provider canary wrapped generate errors", () => {
+  const signal = new AbortController().signal;
+
+  test("names an Anthropic output-ceiling cut-off instead of the wrapper 502", () => {
+    const cutOff = new HandlerError({
+      status: 502,
+      code: "max_tokens",
+      message:
+        "The response was cut off because the maximum token limit was reached.",
+    });
+
+    expect(errorSummary(cutOff, signal)).toBe("provider error (max_tokens)");
+    expect(isRetryableCanaryError(cutOff, signal)).toBe(false);
+  });
+
+  test("reads a prefixed provider body for its status and rejection", () => {
+    const tier = new HandlerError({
+      status: 502,
+      message:
+        'Mistral API error 403: {"object":"error","message":"This model is not available in your subscription tier","type":"tier_not_allowed","param":null,"code":"1910","raw_status_code":403}',
+    });
+
+    expect(errorSummary(tier, signal)).toBe(
+      "provider rejected request (model outside subscription tier)",
+    );
+    expect(isRetryableCanaryError(tier, signal)).toBe(false);
+    expect(
+      errorSummary(
+        new HandlerError({
+          status: 502,
+          message:
+            'Mistral API error 503: {"object":"error","message":"busy","type":"service_unavailable","raw_status_code":503}',
+        }),
+        signal,
+      ),
+    ).toBe("provider HTTP 503");
+  });
+
+  test("keeps a wrapped Anthropic overload retryable with its class named", () => {
+    const overloaded = new HandlerError({
+      status: 502,
+      code: "529",
+      message: "529 Overloaded",
+      cause: {
+        type: "error",
+        error: { type: "overloaded_error", message: "Overloaded" },
+      },
+    });
+
+    expect(errorSummary(overloaded, signal)).toBe(
+      "provider HTTP 529 (overloaded_error)",
+    );
+    expect(isRetryableCanaryError(overloaded, signal)).toBe(true);
   });
 });

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -918,6 +918,16 @@ describe("AI provider canary wrapped generate errors", () => {
     ).toBe("provider HTTP 503");
   });
 
+  test("treats a terminal class carried in `type` as terminal despite a retryable status", () => {
+    const cutOff = new CanaryProviderRunError(
+      { rawEvent: { type: "max_tokens", raw_status_code: 503 } },
+      "before-tool-call",
+    );
+
+    expect(isRetryableCanaryError(cutOff, signal)).toBe(false);
+    expect(errorSummary(cutOff, signal)).toBe("provider HTTP 503 (max_tokens)");
+  });
+
   test("keeps a wrapped Anthropic overload retryable with its class named", () => {
     const overloaded = new HandlerError({
       status: 502,

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -398,9 +398,11 @@ const terminalProviderCode = (error: unknown, depth = 0): string | null => {
     return null;
   }
 
-  const code = error["code"];
-  if (typeof code === "string" && isTerminalProviderCode(code)) {
-    return code;
+  for (const key of ["code", "type"] as const) {
+    const value = error[key];
+    if (typeof value === "string" && isTerminalProviderCode(value)) {
+      return value;
+    }
   }
 
   if (depth < 3) {

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -15,6 +15,7 @@ import type { ModelRole } from "@stll/ai-catalog";
 
 import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
 import type { CachingDecision, OrgAIConfig } from "@/api/lib/ai-config";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { providerSafeJsonSchemaOptionsForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
 import {
   abortControllerFromSignal,
@@ -44,7 +45,6 @@ import { createWeeklyToolShapeDefinition } from "./ai-provider-canary-weekly";
 
 const CAPABILITY_ROLE = "fast" satisfies ModelRole;
 const TOOL_CALL_ROLE = "chat" satisfies ModelRole;
-const MAX_OUTPUT_TOKENS = 64;
 const CAPABILITY_PROBE_TIMEOUT_MS = 20_000;
 const MODEL_ROLE_PROBE_TIMEOUT_MS = 30_000;
 const TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS = 45_000;
@@ -82,7 +82,6 @@ const SAFE_CANARY_ERROR_MESSAGES = new Set([
   "Canary resolved an unexpected provider model.",
   "Provider did not execute the canary tool exactly once.",
   "Provider adapter preserved a synthetic null tool argument.",
-  "Provider generated an unexpected optional tool argument.",
   "Provider returned unexpected canary tool arguments.",
   "Provider did not execute the weekly canary tool exactly once.",
   "Provider returned unexpected weekly canary tool arguments.",
@@ -148,6 +147,7 @@ const SAFE_PROVIDER_CODES = new Set([
   "invalid_prompt",
   "invalid_request",
   "invalid_request_error",
+  "max_tokens", // ai-anthropic: stream cut off at the output ceiling
   "not_found_error",
   "overloaded_error",
   "parse-error",
@@ -157,6 +157,7 @@ const SAFE_PROVIDER_CODES = new Set([
   "rate_limit_exceeded",
   "refusal",
   "server_error",
+  "tier_not_allowed", // ai-mistral: model outside the key's subscription tier
   "timeout",
   "timeout_error",
 ]);
@@ -217,10 +218,13 @@ const providerErrorBodyFromMessage = (
   if (message.length > PROVIDER_ERROR_MESSAGE_MAX_LENGTH) {
     return null;
   }
-  const body = message.trimStart();
-  if (!body.startsWith("{")) {
+  // Adapters prefix the body ("Mistral API error 403: {...}"); the JSON object
+  // is the provider's, whatever precedes it is the adapter's.
+  const bodyStart = message.indexOf("{");
+  if (bodyStart === -1) {
     return null;
   }
+  const body = message.slice(bodyStart);
 
   const parsed = Result.try((): unknown => JSON.parse(body));
   if (Result.isError(parsed) || !isRecord(parsed.value)) {
@@ -288,7 +292,12 @@ const rawProviderCode = (error: unknown, depth = 0): string | null => {
   }
 
   const code = error["code"];
-  return typeof code === "string" ? code : null;
+  if (typeof code === "string") {
+    return code;
+  }
+  // Anthropic and Mistral bodies name the failure class in `type`, not `code`.
+  const type = error["type"];
+  return typeof type === "string" ? type : null;
 };
 
 const safeProviderCode = (code: string | null): string | null =>
@@ -317,6 +326,16 @@ const safeIncompleteReason = (error: unknown, depth = 0): string | null => {
   return null;
 };
 
+// The shared generate path rethrows every provider RUN_ERROR as a HandlerError
+// whose 502 answers the handler's own HTTP caller and says nothing about the
+// provider; the wrapper's code, message, and cause are the provider evidence.
+// Read those, never the wrapper's status, or an Anthropic `max_tokens` cut-off
+// and a Mistral 403 both print as "provider HTTP 502".
+const providerEvidence = (error: unknown): unknown =>
+  error instanceof HandlerError
+    ? { code: error.code, message: error.message, cause: error.cause }
+    : error;
+
 const providerStatus = (error: unknown, depth = 0): number | null => {
   if (!isRecord(error)) {
     return null;
@@ -338,15 +357,25 @@ const providerStatus = (error: unknown, depth = 0): number | null => {
     }
   }
 
-  for (const key of ["status", "statusCode", "code"] as const) {
+  for (const key of [
+    "status",
+    "statusCode",
+    "raw_status_code",
+    "code",
+  ] as const) {
     const value = error[key];
+    // Adapters relay an SDK status as `code: String(err.status)`.
+    const numeric =
+      typeof value === "string" && /^\d{3}$/u.test(value)
+        ? Number(value)
+        : value;
     if (
-      typeof value === "number" &&
-      Number.isInteger(value) &&
-      value >= 100 &&
-      value <= 599
+      typeof numeric === "number" &&
+      Number.isInteger(numeric) &&
+      numeric >= 100 &&
+      numeric <= 599
     ) {
-      return value;
+      return numeric;
     }
   }
   return null;
@@ -483,6 +512,10 @@ const credentialRejectionSignature = (
 const PROVIDER_REJECTION_SIGNATURES = [
   ["exceeds the model limit", "output ceiling above model limit"], // bedrock-converse
   ["model access is denied", "model access denied"], // bedrock-converse
+  [
+    "not available in your subscription tier",
+    "model outside subscription tier",
+  ], // ai-mistral
 ] as const;
 type ProviderRejectionReason =
   (typeof PROVIDER_REJECTION_SIGNATURES)[number][1];
@@ -632,15 +665,16 @@ export const isRetryableCanaryError = (
     return error.retryCode === null || isRetryableProviderCode(error.retryCode);
   }
 
-  const code = rawProviderCode(error);
-  if (terminalProviderCode(error) !== null) {
+  const evidence = providerEvidence(error);
+  const code = rawProviderCode(evidence);
+  if (terminalProviderCode(evidence) !== null) {
     return false;
   }
-  const retryable = explicitRetryability(error);
+  const retryable = explicitRetryability(evidence);
   if (retryable !== null) {
     return retryable;
   }
-  const status = providerStatus(error);
+  const status = providerStatus(evidence);
   if (status !== null) {
     return isRetryableProviderStatus(status);
   }
@@ -880,11 +914,14 @@ const capabilityProbes = [
     type: "capability",
     name: "structured-output",
     timeoutMs: CAPABILITY_PROBE_TIMEOUT_MS,
-    run: async ({ config }, signal) => {
+    run: async ({ config, provider }, signal) => {
       await generateTanStackObjectForRole({
         abortSignal: signal,
         caching: NO_CACHING,
-        maxOutputTokens: MAX_OUTPUT_TOKENS,
+        maxOutputTokens: structuredOutputModelRoleMaxOutputTokens({
+          modelId: DEFAULT_MODELS[provider][CAPABILITY_ROLE],
+          role: CAPABILITY_ROLE,
+        }),
         organizationId: null,
         orgAIConfig: config,
         outputSchema: structuredOutputSchema,
@@ -937,11 +974,14 @@ const capabilityProbes = [
     type: "capability",
     name: "prompt-caching",
     timeoutMs: CAPABILITY_PROBE_TIMEOUT_MS,
-    run: async ({ config }, signal) => {
+    run: async ({ config, provider }, signal) => {
       const output = await generateTanStackTextForRole({
         abortSignal: signal,
         caching: CANARY_CACHING,
-        maxOutputTokens: MAX_OUTPUT_TOKENS,
+        maxOutputTokens: modelRoleMaxOutputTokens({
+          modelId: DEFAULT_MODELS[provider][CAPABILITY_ROLE],
+          role: CAPABILITY_ROLE,
+        }),
         organizationId: null,
         orgAIConfig: config,
         prompt: SYNTHETIC_PROMPT,
@@ -1146,14 +1186,12 @@ const runToolCallRoundTripProbe = async ({
   ) {
     throw new TypeError("Provider returned unexpected canary tool arguments.");
   }
-  if ("optionalNote" in observedInput) {
-    if (observedInput["optionalNote"] === null) {
-      throw new TypeError(
-        "Provider adapter preserved a synthetic null tool argument.",
-      );
-    }
+  // Only the synthetic null is the adapter's defect. An empty string is a
+  // model choice the application schema accepts (maxLength 0), so it is not a
+  // provider-contract finding.
+  if (observedInput["optionalNote"] === null) {
     throw new TypeError(
-      "Provider generated an unexpected optional tool argument.",
+      "Provider adapter preserved a synthetic null tool argument.",
     );
   }
 };
@@ -1412,7 +1450,7 @@ export const errorSummary = (error: unknown, signal: AbortSignal): string => {
 
   if (error instanceof CanaryProviderRunError) {
     if (error.status !== null) {
-      return `provider HTTP ${error.status}`;
+      return withProviderCode(`provider HTTP ${error.status}`, error.code);
     }
     const stage = error.stage.replaceAll("-", " ");
     if (error.code === null) {
@@ -1432,9 +1470,16 @@ export const errorSummary = (error: unknown, signal: AbortSignal): string => {
     return error.message;
   }
 
-  const status = providerStatus(error);
-  return status === null ? "provider error" : `provider HTTP ${status}`;
+  const evidence = providerEvidence(error);
+  const status = providerStatus(evidence);
+  return withProviderCode(
+    status === null ? "provider error" : `provider HTTP ${status}`,
+    safeProviderCode(rawProviderCode(evidence)),
+  );
 };
+
+const withProviderCode = (summary: string, code: string | null): string =>
+  code === null ? summary : `${summary} (${code})`;
 
 const probeLabel = (context: CanaryContext, probe: Probe): string => {
   if (probe.type === "capability") {

--- a/apps/web/src/components/ai-config-role-models.logic.test.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.test.ts
@@ -52,7 +52,7 @@ describe("BYOK provider and model configuration", () => {
 
   test("does not default PDF flows to Mistral", () => {
     expect(createDefaultRoleModels(["mistral", "openai"])).toEqual({
-      chat: { provider: "mistral", modelId: "mistral-large-latest" },
+      chat: { provider: "mistral", modelId: "mistral-medium-latest" },
       fast: { provider: "mistral", modelId: "mistral-small-latest" },
       reasoning: {
         provider: "mistral",

--- a/packages/ai-catalog/src/index.ts
+++ b/packages/ai-catalog/src/index.ts
@@ -169,7 +169,7 @@ export const BYOK_DEFAULT_MODELS = {
   },
   mistral: {
     fast: "mistral-small-latest",
-    chat: "mistral-large-latest",
+    chat: "mistral-medium-latest",
     reasoning: "magistral-medium-latest",
     pdf: "mistral-large-latest",
   },


### PR DESCRIPTION
## Summary

- \`nightly-test.yml\`: the reusable marketing-screenshots check job requests \`actions: read\` since #2519; the nightly caller granted only \`contents: read\`, so the scheduled run has ended in \`startup_failure\` (https://github.com/stella/stella/actions/runs/33233858844). Grant the permission, and alert on \`startup_failure\` and \`timed_out\` conclusions as well as \`failure\`.
- AI provider canary: the shared generate path rethrows provider RUN_ERRORs as a \`HandlerError\` whose 502 is its own status, so an Anthropic \`max_tokens\` cut-off and a Mistral 403 both printed as \`provider HTTP 502\` (https://github.com/stella/stella/actions/runs/33231363266). Read the wrapper's code, message and cause instead, parse a prefixed provider body, and append the allowlisted failure class to the summary.
- Give the prompt-caching and structured-output probes the role-level output budget their sibling probes use; the 64-token cap cut off the reply on some attempts.
- Summarise a model outside the key's subscription tier as a preflight rejection and skip the retry.
- Accept an empty optional string in the round-trip probe: \`maxLength: 0\` admits it, and only the synthetic null is an adapter defect.
- Default the Mistral chat role to \`mistral-medium-latest\`; \`mistral-large-latest\` answers 403 \`tier_not_allowed\` on plans below its tier.

## Test plan

- [x] \`bun test\` for the canary and ai-catalog suites (116 tests)
- [x] canary daily tier run locally against anthropic, mistral, openrouter: all probes pass
- [ ] next scheduled Nightly Full Test starts

https://claude.ai/code/session_01BQpJEeXyY5N5frkfMaWPgt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mistral chat now defaults to `mistral-medium-latest`, providing broader availability across subscription tiers.
  - `mistral-large-latest` remains available where the required higher subscription tier is supported.

- **Bug Fixes**
  - Improved handling of provider errors, including clearer recognition of temporary failures, capacity issues and subscription restrictions.
  - AI provider checks now better support model-specific output limits and valid empty-string responses.

- **Chores**
  - Scheduled workflow alerts now also report startup failures and timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->