### PR TITLE
fix(api): accept already-projected Microsoft rows in the identity mapping audit

### DIFF
--- a/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.db.test.ts
@@ -397,6 +397,28 @@ test("post phases require resource links, final constraints, and the exact basel
          WHERE id = ${microsoftAccountRowId}
       `);
 
+      // The backfill's second pass re-runs the pre-migration audit over rows
+      // it has already rewritten; the projection must be a fixed point.
+      const preMigrationAfterBackfill = await runBetterAuthMigrationAudit({
+        baseline: null,
+        database: auditDatabase,
+        expectedOAuthResources: TEST_OAUTH_RESOURCES,
+        mode: BETTER_AUTH_AUDIT_MODES.PRE_MIGRATION,
+        trustedIdentityMap,
+      });
+      if (preMigrationAfterBackfill.status === "error") {
+        throw preMigrationAfterBackfill.error;
+      }
+      expect(
+        checkStatus(
+          preMigrationAfterBackfill,
+          BETTER_AUTH_AUDIT_CHECKS.ACCOUNT_IDENTITY_MAPPING_COMPLETE,
+        ),
+      ).toBe("passed");
+      expect(
+        preMigrationAfterBackfill.value.baseline.accountIdentityProjection,
+      ).toEqual(preMigration.value.baseline.accountIdentityProjection);
+
       const postBackfill = await runBetterAuthMigrationAudit({
         baseline: preMigration.value.baseline,
         database: auditDatabase,

--- a/apps/api/src/scripts/better-auth-migration-audit.logic.ts
+++ b/apps/api/src/scripts/better-auth-migration-audit.logic.ts
@@ -931,9 +931,13 @@ const readProjectedAccountIdentities = async (
           }
           break;
         case AUTH_PROVIDER_IDS.MICROSOFT:
+          // A row is mapped whether it still carries the legacy subject or
+          // already the projected identity; the backfill is a fixed point and
+          // its second pass audits rows it has already rewritten.
           if (
             microsoftIdentity === undefined ||
-            microsoftIdentity.legacyAccountId !== currentAccountId
+            (microsoftIdentity.legacyAccountId !== currentAccountId &&
+              microsoftIdentity.accountId !== currentAccountId)
           ) {
             mappingComplete = false;
             break;


### PR DESCRIPTION
The pre-migration audit marked a Microsoft account row as mapped only while it still carried the legacy subject. The backfill is a fixed point and its second pass runs the same audit over rows it has already rewritten to the projected identity, so any inventory with Microsoft rows failed the second pass with `preflight-mismatch`.

A row now counts as mapped when it carries either the legacy subject or the projected identity from the trusted map; the projected issuer and identity are unchanged in both states, so the baseline digest is stable across passes. The DB test re-runs the pre-migration audit after the rewrite and asserts the mapping check passes and the projection matches the original baseline.

https://claude.ai/code/session_019Tx4ydN2CULWU5o7DV1fGF
