### PR TITLE
chore: package collaboration runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
                 ;;
             esac
             case "$file" in
-              apps/api/*|apps/legal-atlas-runner/*|packages/*|patches/*|bun.lock|bunfig.toml|package.json|.npmrc|turbo.json|.github/workflows/ci.yml)
+              apps/api/*|apps/collab/*|apps/legal-atlas-runner/*|packages/*|patches/*|bun.lock|bunfig.toml|package.json|.npmrc|turbo.json|.github/workflows/ci.yml)
                 api_image_deps_required=true
                 ;;
             esac
@@ -2005,14 +2005,14 @@ jobs:
             echo "Browser checks were cancelled; a newer run is authoritative."
           fi
 
-  # Image dependency guard. The API and legal-atlas-runner Dockerfiles use
+  # Image dependency guard. The API image and legal-atlas-runner Dockerfile use
   # Turbo only for pruned source overlays; dependency installs come from the
   # committed root bun.lock plus every workspace package.json so Bun remains
   # the lockfile source of truth. Mirror that install path here so deploy-time
   # lockfile drift fails the PR instead of the deploy.
   #
-  # The job then compiles the API entrypoints and runs the legal atlas runner
-  # production smoke against those Docker-style dependency trees.
+  # The job then compiles the API and collaboration entrypoints and runs the
+  # legal atlas runner production smoke against those dependency trees.
   api-image-deps:
     needs: ci-plan
     if: >-
@@ -2051,7 +2051,7 @@ jobs:
             -exec cp --parents -t install-json/ {} +
 
       - name: Prune monorepo for API image source
-        run: turbo prune @stll/api @stll/legal-atlas-runner --docker
+        run: turbo prune @stll/api @stll/collab @stll/legal-atlas-runner --docker
 
       - name: Install API image deps with frozen root lockfile
         run: |
@@ -2059,7 +2059,7 @@ jobs:
           rm -rf api-install
           cp -a install-json api-install
           cd api-install
-          bun install --filter @stll/api --filter @stll/legal-atlas-runner --frozen-lockfile --ignore-scripts
+          bun install --filter @stll/api --filter @stll/collab --filter @stll/legal-atlas-runner --frozen-lockfile --ignore-scripts
         env:
           NPM_TOKEN: ""
 
@@ -2080,6 +2080,13 @@ jobs:
             --target bun \
             --outfile /tmp/server \
             apps/api/src/server.ts
+          bun build \
+            --compile \
+            --no-compile-autoload-dotenv \
+            --target bun \
+            --outfile /tmp/collab \
+            apps/collab/src/index.ts
+          test -x /tmp/collab
           bun build \
             --target bun \
             --outfile apps/api/src/db/migrate.js \

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -16,13 +16,13 @@ RUN mkdir -p /json && \
       -not -path '*/node_modules/*' \
       -exec cp --parents -t /json/ {} +
 
-# Prune the monorepo for the API
+# Prune the monorepo for the API image entrypoints.
 FROM base AS pruner
 COPY package.json .
 RUN --mount=type=cache,target=/root/.bun/install/cache \
     bun install -g "turbo@$(bun -p 'require("./package.json").devDependencies.turbo')"
 COPY . .
-RUN turbo prune @stll/api @stll/legal-atlas-runner --docker
+RUN turbo prune @stll/api @stll/collab @stll/legal-atlas-runner --docker
 
 # Install dependencies using only package manifests (cached layer)
 FROM base AS deps
@@ -30,7 +30,7 @@ COPY --from=install-inputs /json/ .
 # The cache mount is detached after this layer, so packages must be
 # materialized under /app instead of linked into the global virtual store.
 RUN --mount=type=cache,target=/root/.bun/install/cache \
-    BUN_INSTALL_GLOBAL_STORE=0 bun install --filter @stll/api --filter @stll/legal-atlas-runner --frozen-lockfile --ignore-scripts --network-concurrency=8
+    BUN_INSTALL_GLOBAL_STORE=0 bun install --filter @stll/api --filter @stll/collab --filter @stll/legal-atlas-runner --frozen-lockfile --ignore-scripts --network-concurrency=8
 
 # Copy source code and compile the API to a Bun binary.
 #
@@ -51,6 +51,14 @@ RUN bun build \
     --target bun \
     --outfile /app/server \
     apps/api/src/server.ts
+# Dedicated Hocuspocus collaboration service. The infrastructure runs this
+# binary from the same immutable image with command override ["/app/collab"].
+RUN bun build \
+    --compile \
+    --no-compile-autoload-dotenv \
+    --target bun \
+    --outfile /app/collab \
+    apps/collab/src/index.ts
 # One-off maintenance tool: assigns public slugs to legacy case-law rows that
 # predate slug-at-ingest. Bundled to a single JS file (like the workers above,
 # not --compile) so it reuses the container's Bun runtime instead of embedding
@@ -200,6 +208,7 @@ ENV TEMPLATE_PACKS_CONTENT_DIR=/app/template-packs-content
 RUN groupadd --system --gid 1001 stella && \
     useradd --system --uid 1001 --gid stella --no-create-home stella
 COPY --chown=stella:stella --from=builder /app/server /app/server
+COPY --chown=stella:stella --from=builder /app/collab /app/collab
 COPY --chown=stella:stella --from=builder /app/backfill.js /app/backfill.js
 COPY --chown=stella:stella --from=builder /app/better-auth-migration-audit.js /app/better-auth-migration-audit.js
 COPY --chown=stella:stella --from=builder /app/better-auth-microsoft-identity-map.js /app/better-auth-microsoft-identity-map.js
@@ -235,7 +244,7 @@ COPY --chown=stella:stella --from=install-inputs \
 WORKDIR /app/apps/api
 
 USER stella
-EXPOSE 3001
+EXPOSE 3001 3002
 CMD ["/app/server"]
 
 # Throwaway verification stage: run the runtime-asset probe on the exact


### PR DESCRIPTION
## Summary

- compile the collaboration server into the existing API image as `/app/collab`
- include the collaboration workspace in the pruned dependency closure
- extend the image dependency CI smoke to compile the collaboration entrypoint
- schedule the image check whenever `apps/collab` changes

The collaboration ECS service can reuse the API image digest with a `/app/collab` command override, avoiding a second image publication path.

## Validation

- `bun --filter @stll/collab typecheck`
- `bun --filter @stll/collab test`
- standalone compiled-binary smoke
- `bun scripts/ratchet.ts --check`

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated collaboration service to the API container.
  - The collaboration service is built and available on port 3002.

- **Bug Fixes**
  - Updated continuous integration checks to detect collaboration changes and validate the collaboration service during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->