### PR TITLE
fix: configure collaboration Valkey TLS

### DIFF
--- a/apps/collab/.env.example
+++ b/apps/collab/.env.example
@@ -22,3 +22,9 @@ STELLA_API_URL="http://localhost:3001"
 # [secret] Required. Bearer credential used by the collaboration service for
 # snapshot load and store requests.
 STELLA_COLLAB_SERVICE_TOKEN="local-collab-service-token-at-least-32-chars"
+
+# [internal] Optional with a default. Whether a rediss:// connection verifies
+# the server certificate chain. Leave on unless the endpoint presents a
+# certificate no trust anchor can validate and the private network is the
+# boundary instead.
+# REDIS_TLS_REJECT_UNAUTHORIZED="true"

--- a/apps/collab/src/env-schema.test.ts
+++ b/apps/collab/src/env-schema.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import * as v from "valibot";
 
 import {
   collabEnvInvariantViolation,
+  envCollabServerSchema,
   isSecureCollabRedisUrl,
   isSecureStellaApiUrl,
 } from "./env-schema";
@@ -25,6 +27,15 @@ describe("Stella API transport", () => {
 });
 
 describe("Redis transport", () => {
+  test("verifies TLS certificates unless the deployment opts out", () => {
+    expect(
+      v.parse(envCollabServerSchema.REDIS_TLS_REJECT_UNAUTHORIZED, undefined),
+    ).toBe(true);
+    expect(
+      v.parse(envCollabServerSchema.REDIS_TLS_REJECT_UNAUTHORIZED, "false"),
+    ).toBe(false);
+  });
+
   test.each([
     "rediss://redis.example.test:6379",
     "rediss://redis.example.test:6379/0",

--- a/apps/collab/src/env-schema.ts
+++ b/apps/collab/src/env-schema.ts
@@ -80,4 +80,13 @@ export const envCollabServerSchema = {
   ),
   STELLA_COLLAB_REDIS_URL: v.optional(v.pipe(v.string(), v.url())),
   STELLA_COLLAB_SERVICE_TOKEN: v.pipe(v.string(), v.minLength(32)),
+  /**
+   * Whether a `rediss://` connection verifies the server certificate chain.
+   * Leave enabled unless a private endpoint presents a certificate with no
+   * trusted chain and the network is the peer-authentication boundary.
+   */
+  REDIS_TLS_REJECT_UNAUTHORIZED: v.optional(
+    v.pipe(v.string(), v.parseBoolean()),
+    "true",
+  ),
 };

--- a/apps/collab/src/index.ts
+++ b/apps/collab/src/index.ts
@@ -22,6 +22,7 @@ const startCollabServer = async () => {
     apiUrl: env.STELLA_API_URL,
     mode: "redis",
     port: env.STELLA_COLLAB_PORT,
+    redisTlsRejectUnauthorized: env.REDIS_TLS_REJECT_UNAUTHORIZED,
     redisUrl,
     serviceToken: env.STELLA_COLLAB_SERVICE_TOKEN,
   });

--- a/apps/collab/src/redis-options.test.ts
+++ b/apps/collab/src/redis-options.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { collabRedisConnectionOptions } from "./redis-options";
+
+describe("collaboration Redis connection options", () => {
+  test("verifies the certificate chain on a TLS URL by default", () => {
+    expect(
+      collabRedisConnectionOptions("rediss://valkey.example.internal:6379"),
+    ).toEqual({ tls: { rejectUnauthorized: true } });
+  });
+
+  test("skips verification only when the deployment asks for it", () => {
+    expect(
+      collabRedisConnectionOptions("rediss://10.0.0.5:6379", false),
+    ).toEqual({ tls: { rejectUnauthorized: false } });
+  });
+
+  test("adds no TLS options to a plaintext loopback URL", () => {
+    expect(
+      collabRedisConnectionOptions("redis://localhost:6379", false),
+    ).toEqual({});
+  });
+});

--- a/apps/collab/src/redis-options.ts
+++ b/apps/collab/src/redis-options.ts
@@ -1,0 +1,14 @@
+import type { RedisOptions } from "ioredis";
+
+/**
+ * ioredis does not infer a deployment's certificate policy from `rediss://`.
+ * Verification stays on unless the deployment explicitly opts out for a
+ * private endpoint whose certificate has no trusted chain.
+ */
+export const collabRedisConnectionOptions = (
+  url: string,
+  rejectUnauthorized = true,
+): RedisOptions =>
+  url.toLowerCase().startsWith("rediss://")
+    ? { tls: { rejectUnauthorized } }
+    : {};

--- a/apps/collab/src/server-test-process.ts
+++ b/apps/collab/src/server-test-process.ts
@@ -15,6 +15,7 @@ const collabServer = await createCollabServer({
   maxDebounceMs: 100,
   mode: "redis",
   port: 0,
+  redisTlsRejectUnauthorized: env.REDIS_TLS_REJECT_UNAUTHORIZED,
   redisUrl,
   serviceToken: env.STELLA_COLLAB_SERVICE_TOKEN,
 });

--- a/apps/collab/src/server.ts
+++ b/apps/collab/src/server.ts
@@ -23,6 +23,7 @@ import { FetchBoundaryError } from "@stll/errors";
 
 import { isSecureCollabRedisUrl, isSecureStellaApiUrl } from "./env-schema";
 import { logCollabEvent } from "./log";
+import { collabRedisConnectionOptions } from "./redis-options";
 
 type CollabAuthContext = {
   roomId: string;
@@ -71,8 +72,16 @@ type CreateCollabServerBaseOptions = {
 
 type CreateCollabServerOptions = CreateCollabServerBaseOptions &
   (
-    | { mode: "redis"; redisUrl: string }
-    | { mode?: "single-process"; redisUrl?: never }
+    | {
+        mode: "redis";
+        redisTlsRejectUnauthorized?: boolean;
+        redisUrl: string;
+      }
+    | {
+        mode?: "single-process";
+        redisTlsRejectUnauthorized?: never;
+        redisUrl?: never;
+      }
   );
 
 const authorizeResponseSchema = v.strictObject({
@@ -289,7 +298,14 @@ export const createCollabServer = async (
     options.mode === "redis"
       ? new RedisExtension({
           awaitInitialSyncTimeout: REDIS_INITIAL_SYNC_TIMEOUT_MS,
-          createClient: () => new RedisClient(options.redisUrl),
+          createClient: () =>
+            new RedisClient(
+              options.redisUrl,
+              collabRedisConnectionOptions(
+                options.redisUrl,
+                options.redisTlsRejectUnauthorized,
+              ),
+            ),
           lockTimeout: REDIS_LOCK_TIMEOUT_MS,
           prefix: FOLIO_COLLAB_REDIS_SCOPE,
         })


### PR DESCRIPTION
## Summary

- keep certificate verification enabled by default for collaboration `rediss://` connections
- allow an explicit deployment setting for private Valkey endpoints whose certificate has no trusted chain
- pass the policy to both ioredis clients created by the Hocuspocus Redis extension
- generate the collaboration environment example and cover secure defaults, explicit opt-out, and plaintext loopback behavior

## Validation

- `bun --filter @stll/collab typecheck`
- `bun --filter @stll/collab test src/env-schema.test.ts src/redis-options.test.ts src/server.test.ts` (35 passed, Redis integration skipped without its external test URL)
- `bun --filter @stll/collab format --check`
- type-aware oxlint on affected files
- `bun run env:check`

This is required by the infrastructure Valkey endpoint, which uses encrypted transport with a private self-signed certificate. The infrastructure opts out explicitly; every other deployment retains verification.

CC on behalf of jan-kubica