### PR TITLE
feat(api): migration rehearsals

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -85,6 +85,12 @@ RUN bun build \
     --target bun \
     --outfile /app/better-auth-17-backfill.js \
     apps/api/src/scripts/better-auth-17-backfill.ts
+# Whole-database census (counts, digests, foreign-key orphans) recorded before
+# a migration rehearsal and compared after it.
+RUN bun build \
+    --target bun \
+    --outfile /app/database-census.js \
+    apps/api/src/scripts/database-census.ts
 # Dedicated durable document-processing worker. Deploy the same image with
 # command override ["bun", "/app/document-processing-worker.js"]. OCR runs
 # in-image through the isolated local ONNX worker.
@@ -192,6 +198,7 @@ COPY --chown=stella:stella --from=builder /app/backfill.js /app/backfill.js
 COPY --chown=stella:stella --from=builder /app/better-auth-migration-audit.js /app/better-auth-migration-audit.js
 COPY --chown=stella:stella --from=builder /app/better-auth-microsoft-identity-map.js /app/better-auth-microsoft-identity-map.js
 COPY --chown=stella:stella --from=builder /app/better-auth-17-backfill.js /app/better-auth-17-backfill.js
+COPY --chown=stella:stella --from=builder /app/database-census.js /app/database-census.js
 COPY --chown=stella:stella --from=builder /app/document-processing-worker.js /app/document-processing-worker.js
 COPY --chown=stella:stella --from=builder /app/apps/legal-atlas-runner/dist/index.js /app/legal-atlas.js
 # Bundled migration task entrypoint:

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -91,6 +91,12 @@ RUN bun build \
     --target bun \
     --outfile /app/database-census.js \
     apps/api/src/scripts/database-census.ts
+# Replays stored sign-ins and sessions against a migrated database with the
+# provider served locally; counts only.
+RUN bun build \
+    --target bun \
+    --outfile /app/better-auth-sign-in-replay.js \
+    apps/api/src/scripts/better-auth-sign-in-replay.ts
 # Dedicated durable document-processing worker. Deploy the same image with
 # command override ["bun", "/app/document-processing-worker.js"]. OCR runs
 # in-image through the isolated local ONNX worker.
@@ -199,6 +205,7 @@ COPY --chown=stella:stella --from=builder /app/better-auth-migration-audit.js /a
 COPY --chown=stella:stella --from=builder /app/better-auth-microsoft-identity-map.js /app/better-auth-microsoft-identity-map.js
 COPY --chown=stella:stella --from=builder /app/better-auth-17-backfill.js /app/better-auth-17-backfill.js
 COPY --chown=stella:stella --from=builder /app/database-census.js /app/database-census.js
+COPY --chown=stella:stella --from=builder /app/better-auth-sign-in-replay.js /app/better-auth-sign-in-replay.js
 COPY --chown=stella:stella --from=builder /app/document-processing-worker.js /app/document-processing-worker.js
 COPY --chown=stella:stella --from=builder /app/apps/legal-atlas-runner/dist/index.js /app/legal-atlas.js
 # Bundled migration task entrypoint:

--- a/apps/api/src/scripts/better-auth-sign-in-replay.test.ts
+++ b/apps/api/src/scripts/better-auth-sign-in-replay.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseBetterAuthSignInReplayArgs } from "@/api/scripts/better-auth-sign-in-replay";
+
+describe("parseBetterAuthSignInReplayArgs", () => {
+  test("accepts an https origin and a non-negative sample size", () => {
+    const parsed = parseBetterAuthSignInReplayArgs([
+      "--oauth-base-url",
+      "https://api.example.invalid/",
+      "--session-sample",
+      "200",
+    ]);
+    expect(parsed.status).toBe("ok");
+    if (parsed.status === "ok") {
+      expect(parsed.value).toEqual({
+        oauthBaseUrl: "https://api.example.invalid",
+        sessionSample: 200,
+      });
+    }
+  });
+
+  test.each([
+    [[]],
+    [
+      [
+        "--oauth-base-url",
+        "http://api.example.invalid",
+        "--session-sample",
+        "1",
+      ],
+    ],
+    [
+      [
+        "--oauth-base-url",
+        "https://api.example.invalid/path",
+        "--session-sample",
+        "1",
+      ],
+    ],
+    [
+      [
+        "--oauth-base-url",
+        "https://api.example.invalid",
+        "--session-sample",
+        "-1",
+      ],
+    ],
+    [
+      [
+        "--oauth-base-url",
+        "https://api.example.invalid",
+        "--session-sample",
+        "many",
+      ],
+    ],
+    [
+      [
+        "--oauth-base-url",
+        "https://api.example.invalid",
+        "--session-sample",
+        "1",
+        "extra",
+      ],
+    ],
+  ])("rejects %j", (args) => {
+    expect(parseBetterAuthSignInReplayArgs(args).status).toBe("error");
+  });
+});

--- a/apps/api/src/scripts/better-auth-sign-in-replay.test.ts
+++ b/apps/api/src/scripts/better-auth-sign-in-replay.test.ts
@@ -58,6 +58,14 @@ describe("parseBetterAuthSignInReplayArgs", () => {
         "--oauth-base-url",
         "https://api.example.invalid",
         "--session-sample",
+        "1001",
+      ],
+    ],
+    [
+      [
+        "--oauth-base-url",
+        "https://api.example.invalid",
+        "--session-sample",
         "1",
         "extra",
       ],

--- a/apps/api/src/scripts/better-auth-sign-in-replay.ts
+++ b/apps/api/src/scripts/better-auth-sign-in-replay.ts
@@ -241,7 +241,7 @@ const run = async (
   // token exchange and key discovery; both are served locally and every
   // other destination is refused, so the replay never leaves the process.
   const localProviderFetch = async (
-    input: RequestInfo | URL,
+    input: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> => {
     const request = new Request(input, init);

--- a/apps/api/src/scripts/better-auth-sign-in-replay.ts
+++ b/apps/api/src/scripts/better-auth-sign-in-replay.ts
@@ -1,0 +1,453 @@
+/**
+ * Usage:
+ *   bun src/scripts/better-auth-sign-in-replay.ts --oauth-base-url <https-origin> --session-sample <n>
+ *
+ * Replays, against a migrated database, what the auth runtime will do on the
+ * first sign-in of every stored Microsoft account and on the next request of
+ * a sample of stored sessions. The provider is not contacted: the token
+ * exchange and signing keys are served locally, so the replay proves only the
+ * runtime's resolution of stored rows. Every replayed sign-in must resolve to
+ * the account's existing user without creating a user or account row, and
+ * every sampled session must resolve to its stored user. Output is counts
+ * only.
+ */
+
+import { betterAuth } from "better-auth";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { bearer } from "better-auth/plugins";
+import { Result, TaggedError } from "better-result";
+import { SQL } from "bun";
+import { drizzle } from "drizzle-orm/bun-sql";
+import { decodeJwt, exportJWK, generateKeyPair, SignJWT } from "jose";
+
+import { hasSecureDatabaseTransport, resolveDatabaseUrl } from "@/api/db-url";
+import { AUTH_DATABASE_ADAPTER_OPTIONS } from "@/api/lib/auth-adapter-options";
+import { isRecord } from "@/api/lib/type-guards";
+import { normalizeBetterAuthOAuthBaseUrl } from "@/api/mcp/resource-policy-contract";
+import { formatBetterAuthScriptFailure } from "@/api/scripts/better-auth-script-failure";
+
+const EXIT_CODE = {
+  CONFIGURATION_OR_QUERY_FAILURE: 2,
+  INVARIANT_FAILURE: 1,
+  SUCCESS: 0,
+} as const;
+const MICROSOFT_AUTHORITY = "https://login.microsoftonline.com";
+const SIGNING_KEY_ID = "replay-key";
+const MAX_SIGN_IN_ROWS = 1000;
+
+class BetterAuthSignInReplayError extends TaggedError(
+  "BetterAuthSignInReplayError",
+)<{
+  cause?: unknown;
+  code:
+    | "database-query-failed"
+    | "invalid-arguments"
+    | "replay-failed"
+    | "session-resolution-failed"
+    | "sign-in-resolution-failed";
+  message: string;
+}> {}
+
+type ReplayArgs = { oauthBaseUrl: string; sessionSample: number };
+
+export const parseBetterAuthSignInReplayArgs = (
+  args: readonly string[],
+): Result<ReplayArgs, BetterAuthSignInReplayError> => {
+  const oauthBaseUrl =
+    args.at(0) === "--oauth-base-url" && args.at(1)
+      ? normalizeBetterAuthOAuthBaseUrl(args[1] ?? "")
+      : null;
+  const sessionSample = Number(args.at(3));
+  if (
+    oauthBaseUrl === null ||
+    args.at(2) !== "--session-sample" ||
+    !Number.isSafeInteger(sessionSample) ||
+    sessionSample < 0 ||
+    args.length !== 4
+  ) {
+    return Result.err(
+      new BetterAuthSignInReplayError({
+        code: "invalid-arguments",
+        message:
+          "Usage: better-auth-sign-in-replay --oauth-base-url <https-origin> --session-sample <n>",
+      }),
+    );
+  }
+  return Result.ok({ oauthBaseUrl, sessionSample });
+};
+
+type MicrosoftRow = {
+  accountId: string;
+  email: string;
+  idToken: string;
+  userId: string;
+};
+
+type SessionRow = { token: string; userId: string };
+
+const queryFailed = (cause: unknown) =>
+  new BetterAuthSignInReplayError({
+    cause,
+    code: "database-query-failed",
+    message: "Sign-in replay could not read the stored rows",
+  });
+
+const readRows = async (client: SQL) => {
+  const queried = await Result.tryPromise({
+    try: async () => ({
+      microsoft: await client`
+        SELECT a.account_id AS "accountId", a.id_token AS "idToken",
+               a.user_id AS "userId", u.email AS "email"
+          FROM account a JOIN "user" u ON u.id = a.user_id
+         WHERE a.provider_id = 'microsoft'
+         ORDER BY a.id
+         LIMIT ${MAX_SIGN_IN_ROWS + 1}
+      `,
+      sessions: await client`
+        SELECT token, user_id AS "userId"
+          FROM session
+         WHERE expires_at > now()
+         ORDER BY expires_at DESC
+         LIMIT 1000
+      `,
+      userCount: await client`SELECT count(*)::text AS "count" FROM "user"`,
+      accountCount: await client`SELECT count(*)::text AS "count" FROM account`,
+    }),
+    catch: queryFailed,
+  });
+  if (Result.isError(queried)) {
+    return queried;
+  }
+  const microsoft: MicrosoftRow[] = [];
+  for (const row of queried.value.microsoft) {
+    const accountId = isRecord(row) ? row["accountId"] : null;
+    const idToken = isRecord(row) ? row["idToken"] : null;
+    const userId = isRecord(row) ? row["userId"] : null;
+    const email = isRecord(row) ? row["email"] : null;
+    if (
+      typeof accountId !== "string" ||
+      typeof idToken !== "string" ||
+      typeof userId !== "string" ||
+      typeof email !== "string"
+    ) {
+      return Result.err(queryFailed(undefined));
+    }
+    microsoft.push({ accountId, email, idToken, userId });
+  }
+  if (microsoft.length > MAX_SIGN_IN_ROWS) {
+    return Result.err(queryFailed(undefined));
+  }
+  const sessions: SessionRow[] = [];
+  for (const row of queried.value.sessions) {
+    const token = isRecord(row) ? row["token"] : null;
+    const userId = isRecord(row) ? row["userId"] : null;
+    if (typeof token !== "string" || typeof userId !== "string") {
+      return Result.err(queryFailed(undefined));
+    }
+    sessions.push({ token, userId });
+  }
+  const userCount = queried.value.userCount.at(0);
+  const accountCount = queried.value.accountCount.at(0);
+  if (
+    !isRecord(userCount) ||
+    typeof userCount["count"] !== "string" ||
+    !isRecord(accountCount) ||
+    typeof accountCount["count"] !== "string"
+  ) {
+    return Result.err(queryFailed(undefined));
+  }
+  return Result.ok({
+    accountCount: accountCount["count"],
+    microsoft,
+    sessions,
+    userCount: userCount["count"],
+  });
+};
+
+const cookieHeader = (response: Response) =>
+  response.headers
+    .getSetCookie()
+    .map((cookie) => cookie.split(";")[0] ?? "")
+    .join("; ");
+
+type ReplayOutcome = "resolved" | "rejected" | "created" | "mismatched";
+
+const run = async (args: readonly string[]) => {
+  const parsed = parseBetterAuthSignInReplayArgs(args);
+  if (Result.isError(parsed)) {
+    return parsed;
+  }
+  const clientId = process.env["MICROSOFT_AUTH_CLIENT_ID"];
+  const tenantId = process.env["MICROSOFT_AUTH_TENANT_ID"];
+  const databaseUrl = resolveDatabaseUrl();
+  if (
+    !clientId ||
+    !tenantId ||
+    !databaseUrl ||
+    !hasSecureDatabaseTransport(databaseUrl)
+  ) {
+    return Result.err(
+      new BetterAuthSignInReplayError({
+        code: "invalid-arguments",
+        message:
+          "Sign-in replay requires provider configuration and a secure database connection",
+      }),
+    );
+  }
+  const { oauthBaseUrl, sessionSample } = parsed.value;
+  const client = new SQL({ max: 1, url: databaseUrl });
+  const rows = await readRows(client);
+  if (Result.isError(rows)) {
+    await client.end();
+    return rows;
+  }
+
+  const { privateKey, publicKey } = await generateKeyPair("RS256");
+  const jwk = {
+    ...(await exportJWK(publicKey)),
+    alg: "RS256",
+    kid: SIGNING_KEY_ID,
+    use: "sig",
+  };
+  const database = drizzle({ client });
+  const auth = betterAuth({
+    baseURL: oauthBaseUrl,
+    // A throwaway secret: nothing signed here outlives the replay.
+    secret: Bun.randomUUIDv7() + Bun.randomUUIDv7(),
+    database: drizzleAdapter(database, AUTH_DATABASE_ADAPTER_OPTIONS),
+    trustedOrigins: [oauthBaseUrl],
+    socialProviders: {
+      microsoft: {
+        clientId,
+        clientSecret: "replay",
+        disableProfilePhoto: true,
+        tenantId,
+      },
+    },
+    plugins: [bearer()],
+  });
+
+  let currentIdToken = "";
+  const realFetch = globalThis.fetch;
+  // The runtime's only outbound calls during a sign-in are the provider's
+  // token exchange and key discovery; both are served locally and every
+  // other destination is refused, so the replay never leaves the process.
+  const localProviderFetch: typeof fetch = async (input, init) => {
+    const request = new Request(input, init);
+    if (
+      request.url.startsWith(`${MICROSOFT_AUTHORITY}/`) &&
+      request.url.includes("/oauth2/v2.0/token")
+    ) {
+      const exchange = new URLSearchParams(await request.text());
+      if (exchange.get("code") !== "replay") {
+        return new Response("refused by replay", { status: 599 });
+      }
+      return Response.json({
+        access_token: "replay-access",
+        expires_in: 3600,
+        id_token: currentIdToken,
+        scope: "openid profile email",
+        token_type: "Bearer",
+      });
+    }
+    if (
+      request.url.startsWith(`${MICROSOFT_AUTHORITY}/`) &&
+      request.url.includes("/discovery/v2.0/keys")
+    ) {
+      return Response.json({ keys: [jwk] });
+    }
+    return new Response("refused by replay", { status: 599 });
+  };
+
+  const outcomes: Record<ReplayOutcome, number> = {
+    created: 0,
+    mismatched: 0,
+    rejected: 0,
+    resolved: 0,
+  };
+  globalThis.fetch = localProviderFetch;
+  const replayed = await Result.tryPromise({
+    try: async () => {
+      const rowIterator = rows.value.microsoft.values();
+      const replayNext = async (): Promise<void> => {
+        const next = rowIterator.next();
+        if (next.done) {
+          return;
+        }
+        const row = next.value;
+        const claims = decodeJwt(row.idToken);
+        const start = await auth.handler(
+          new Request(`${oauthBaseUrl}/api/auth/sign-in/social`, {
+            body: JSON.stringify({
+              callbackURL: "/replay",
+              provider: "microsoft",
+            }),
+            headers: {
+              "content-type": "application/json",
+              origin: oauthBaseUrl,
+            },
+            method: "POST",
+          }),
+        );
+        const startBody: unknown = await start.json();
+        const authorizeUrl = new URL(
+          isRecord(startBody) && typeof startBody["url"] === "string"
+            ? startBody["url"]
+            : "about:blank",
+        );
+        const state = authorizeUrl.searchParams.get("state") ?? "";
+        const nonce = authorizeUrl.searchParams.get("nonce");
+        const now = Math.floor(Date.now() / 1000);
+        const tid =
+          typeof claims["tid"] === "string" ? claims["tid"] : tenantId;
+        currentIdToken = await new SignJWT({
+          email: row.email,
+          name: row.email,
+          oid: claims["oid"],
+          preferred_username: row.email,
+          tid,
+          ...(nonce ? { nonce } : {}),
+        })
+          .setProtectedHeader({ alg: "RS256", kid: SIGNING_KEY_ID })
+          .setIssuer(`${MICROSOFT_AUTHORITY}/${tid}/v2.0`)
+          .setAudience(clientId)
+          .setSubject(typeof claims.sub === "string" ? claims.sub : "")
+          .setIssuedAt(now)
+          .setExpirationTime(now + 3600)
+          .sign(privateKey);
+        const callback = await auth.handler(
+          new Request(
+            `${oauthBaseUrl}/api/auth/callback/microsoft?code=replay&state=${encodeURIComponent(state)}`,
+            { headers: { cookie: cookieHeader(start) } },
+          ),
+        );
+        const location = callback.headers.get("location") ?? "";
+        if (location.includes("error=")) {
+          outcomes.rejected += 1;
+          return replayNext();
+        }
+        const session = await auth.handler(
+          new Request(`${oauthBaseUrl}/api/auth/get-session`, {
+            headers: { cookie: cookieHeader(callback) },
+          }),
+        );
+        const sessionBody: unknown = await session.json();
+        const resolvedUserId =
+          isRecord(sessionBody) && isRecord(sessionBody["user"])
+            ? sessionBody["user"]["id"]
+            : null;
+        if (resolvedUserId === row.userId) {
+          outcomes.resolved += 1;
+        } else {
+          outcomes.mismatched += 1;
+        }
+        return replayNext();
+      };
+      await replayNext();
+    },
+    catch: (cause) =>
+      new BetterAuthSignInReplayError({
+        cause,
+        code: "replay-failed",
+        message: "Sign-in replay did not complete",
+      }),
+  });
+  globalThis.fetch = realFetch;
+
+  const sessionOutcomes = { resolved: 0, unresolved: 0 };
+  if (Result.isOk(replayed)) {
+    const sampled = rows.value.sessions.slice(0, sessionSample).values();
+    const resolveNext = async (): Promise<void> => {
+      const next = sampled.next();
+      if (next.done) {
+        return;
+      }
+      const response = await auth.handler(
+        new Request(`${oauthBaseUrl}/api/auth/get-session`, {
+          headers: { authorization: `Bearer ${next.value.token}` },
+        }),
+      );
+      const body: unknown = await response.json();
+      const resolvedUserId =
+        isRecord(body) && isRecord(body["user"]) ? body["user"]["id"] : null;
+      if (resolvedUserId === next.value.userId) {
+        sessionOutcomes.resolved += 1;
+      } else {
+        sessionOutcomes.unresolved += 1;
+      }
+      return resolveNext();
+    };
+    await resolveNext();
+  }
+
+  const after = await readRows(client);
+  await client.end();
+  if (Result.isError(replayed)) {
+    return replayed;
+  }
+  if (Result.isError(after)) {
+    return after;
+  }
+  if (
+    after.value.userCount !== rows.value.userCount ||
+    after.value.accountCount !== rows.value.accountCount
+  ) {
+    outcomes.created += 1;
+  }
+  const summary = {
+    accounts: rows.value.microsoft.length,
+    sessions: sessionOutcomes,
+    signIns: outcomes,
+  };
+  if (
+    outcomes.rejected > 0 ||
+    outcomes.mismatched > 0 ||
+    outcomes.created > 0
+  ) {
+    return Result.err(
+      new BetterAuthSignInReplayError({
+        code: "sign-in-resolution-failed",
+        message: `Sign-in replay: ${JSON.stringify(summary)}`,
+      }),
+    );
+  }
+  if (sessionOutcomes.unresolved > 0) {
+    return Result.err(
+      new BetterAuthSignInReplayError({
+        code: "session-resolution-failed",
+        message: `Sign-in replay: ${JSON.stringify(summary)}`,
+      }),
+    );
+  }
+  return Result.ok(summary);
+};
+
+if (import.meta.main) {
+  run(Bun.argv.slice(2))
+    .then((result) => {
+      if (Result.isError(result)) {
+        process.stderr.write(formatBetterAuthScriptFailure(result.error));
+        process.exitCode =
+          result.error.code === "sign-in-resolution-failed" ||
+          result.error.code === "session-resolution-failed"
+            ? EXIT_CODE.INVARIANT_FAILURE
+            : EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
+        return undefined;
+      }
+      process.stdout.write(
+        `${JSON.stringify({ check: "sign-in-replay", status: "passed", ...result.value })}\n`,
+      );
+      process.exitCode = EXIT_CODE.SUCCESS;
+      return undefined;
+    })
+    .catch((error: unknown) => {
+      process.stderr.write(
+        formatBetterAuthScriptFailure({
+          cause: error,
+          code: "unexpected-failure",
+          message: "Sign-in replay failed unexpectedly",
+        }),
+      );
+      process.exitCode = EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
+    });
+}

--- a/apps/api/src/scripts/better-auth-sign-in-replay.ts
+++ b/apps/api/src/scripts/better-auth-sign-in-replay.ts
@@ -263,12 +263,20 @@ const run = async (
   // The runtime's only outbound calls during a sign-in are the provider's
   // token exchange and key discovery; both are served locally and every
   // other destination is refused, so the replay never leaves the process.
+  const requestUrl = (input: string | URL | Request) => {
+    if (typeof input === "string") {
+      return input;
+    }
+    if (input instanceof URL) {
+      return input.href;
+    }
+    return input.url;
+  };
   const localProviderFetch = async (
     input: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> => {
-    const request =
-      init === undefined ? new Request(input) : new Request(input, init);
+    const request = new Request(requestUrl(input), init ?? {});
     if (
       request.url.startsWith(`${MICROSOFT_AUTHORITY}/`) &&
       request.url.includes("/oauth2/v2.0/token")

--- a/apps/api/src/scripts/better-auth-sign-in-replay.ts
+++ b/apps/api/src/scripts/better-auth-sign-in-replay.ts
@@ -19,6 +19,7 @@ import { Result, TaggedError } from "better-result";
 import { SQL } from "bun";
 import { drizzle } from "drizzle-orm/bun-sql";
 import { decodeJwt, exportJWK, generateKeyPair, SignJWT } from "jose";
+import * as v from "valibot";
 
 import { hasSecureDatabaseTransport, resolveDatabaseUrl } from "@/api/db-url";
 import { AUTH_DATABASE_ADAPTER_OPTIONS } from "@/api/lib/auth-adapter-options";
@@ -34,6 +35,8 @@ const EXIT_CODE = {
 const MICROSOFT_AUTHORITY = "https://login.microsoftonline.com";
 const SIGNING_KEY_ID = "replay-key";
 const MAX_SIGN_IN_ROWS = 1000;
+const MAX_SESSION_ROWS = 1000;
+const DATABASE_CONNECTION_TIMEOUT_SECONDS = 30;
 
 class BetterAuthSignInReplayError extends TaggedError(
   "BetterAuthSignInReplayError",
@@ -50,30 +53,40 @@ class BetterAuthSignInReplayError extends TaggedError(
 
 type ReplayArgs = { oauthBaseUrl: string; sessionSample: number };
 
+const commandArgsSchema = v.strictTuple([
+  v.literal("--oauth-base-url"),
+  v.pipe(
+    v.string(),
+    v.transform(normalizeBetterAuthOAuthBaseUrl),
+    v.string("The OAuth base URL must be an https origin"),
+  ),
+  v.literal("--session-sample"),
+  v.pipe(
+    v.string(),
+    v.decimal(),
+    v.transform(Number),
+    v.integer(),
+    v.minValue(0),
+    v.maxValue(MAX_SESSION_ROWS),
+  ),
+]);
+
 export const parseBetterAuthSignInReplayArgs = (
   args: readonly string[],
 ): Result<ReplayArgs, BetterAuthSignInReplayError> => {
-  const oauthBaseUrl =
-    args.at(0) === "--oauth-base-url" && args.at(1)
-      ? normalizeBetterAuthOAuthBaseUrl(args[1] ?? "")
-      : null;
-  const sessionSample = Number(args.at(3));
-  if (
-    oauthBaseUrl === null ||
-    args.at(2) !== "--session-sample" ||
-    !Number.isSafeInteger(sessionSample) ||
-    sessionSample < 0 ||
-    args.length !== 4
-  ) {
+  const parsed = v.safeParse(commandArgsSchema, args);
+  if (!parsed.success) {
     return Result.err(
       new BetterAuthSignInReplayError({
         code: "invalid-arguments",
-        message:
-          "Usage: better-auth-sign-in-replay --oauth-base-url <https-origin> --session-sample <n>",
+        message: `Usage: better-auth-sign-in-replay --oauth-base-url <https-origin> --session-sample <0..${MAX_SESSION_ROWS}>`,
       }),
     );
   }
-  return Result.ok({ oauthBaseUrl, sessionSample });
+  return Result.ok({
+    oauthBaseUrl: parsed.output[1],
+    sessionSample: parsed.output[3],
+  });
 };
 
 type MicrosoftRow = {
@@ -108,10 +121,11 @@ const readRows = async (client: SQL) => {
           FROM session
          WHERE expires_at > now()
          ORDER BY expires_at DESC
-         LIMIT 1000
+         LIMIT ${MAX_SESSION_ROWS}
       `,
       userCount: await client`SELECT count(*)::text AS "count" FROM "user"`,
       accountCount: await client`SELECT count(*)::text AS "count" FROM account`,
+      sessionCount: await client`SELECT count(*)::text AS "count" FROM session`,
     }),
     catch: queryFailed,
   });
@@ -148,17 +162,21 @@ const readRows = async (client: SQL) => {
   }
   const userCount = queried.value.userCount.at(0);
   const accountCount = queried.value.accountCount.at(0);
+  const sessionCount = queried.value.sessionCount.at(0);
   if (
     !isRecord(userCount) ||
     typeof userCount["count"] !== "string" ||
     !isRecord(accountCount) ||
-    typeof accountCount["count"] !== "string"
+    typeof accountCount["count"] !== "string" ||
+    !isRecord(sessionCount) ||
+    typeof sessionCount["count"] !== "string"
   ) {
     return Result.err(queryFailed(undefined));
   }
   return Result.ok({
     accountCount: accountCount["count"],
     microsoft,
+    sessionCount: sessionCount["count"],
     sessions,
     userCount: userCount["count"],
   });
@@ -203,7 +221,12 @@ const run = async (
     );
   }
   const { oauthBaseUrl, sessionSample } = parsed.value;
-  const client = new SQL({ max: 1, url: databaseUrl });
+  const client = new SQL({
+    connectionTimeout: DATABASE_CONNECTION_TIMEOUT_SECONDS,
+    max: 1,
+    url: databaseUrl,
+  });
+  const replayStartedAt = new Date();
   const rows = await readRows(client);
   if (Result.isError(rows)) {
     await client.end();
@@ -244,7 +267,8 @@ const run = async (
     input: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> => {
-    const request = new Request(input, init);
+    const request =
+      init === undefined ? new Request(input) : new Request(input, init);
     if (
       request.url.startsWith(`${MICROSOFT_AUTHORITY}/`) &&
       request.url.includes("/oauth2/v2.0/token")
@@ -393,7 +417,26 @@ const run = async (
     await resolveNext();
   }
 
-  const after = await readRows(client);
+  // Every replayed sign-in mints a session row; remove them so the database
+  // ends exactly as it started, and prove it by count.
+  const replayedUserIds = rows.value.microsoft.map(({ userId }) => userId);
+  const cleaned = await Result.tryPromise({
+    try: async () =>
+      replayedUserIds.length === 0
+        ? undefined
+        : await client`
+            DELETE FROM session
+             WHERE created_at >= ${replayStartedAt.toISOString()}::timestamptz
+               AND user_id IN ${client(replayedUserIds)}
+          `,
+    catch: (cause) =>
+      new BetterAuthSignInReplayError({
+        cause,
+        code: "database-query-failed",
+        message: "Sign-in replay could not remove its session rows",
+      }),
+  });
+  const after = Result.isError(cleaned) ? cleaned : await readRows(client);
   await client.end();
   if (Result.isError(replayed)) {
     return Result.err(replayed.error);
@@ -403,7 +446,8 @@ const run = async (
   }
   if (
     after.value.userCount !== rows.value.userCount ||
-    after.value.accountCount !== rows.value.accountCount
+    after.value.accountCount !== rows.value.accountCount ||
+    after.value.sessionCount !== rows.value.sessionCount
   ) {
     outcomes.created += 1;
   }

--- a/apps/api/src/scripts/better-auth-sign-in-replay.ts
+++ b/apps/api/src/scripts/better-auth-sign-in-replay.ts
@@ -172,10 +172,18 @@ const cookieHeader = (response: Response) =>
 
 type ReplayOutcome = "resolved" | "rejected" | "created" | "mismatched";
 
-const run = async (args: readonly string[]) => {
+type ReplaySummary = {
+  accounts: number;
+  sessions: { resolved: number; unresolved: number };
+  signIns: Record<ReplayOutcome, number>;
+};
+
+const run = async (
+  args: readonly string[],
+): Promise<Result<ReplaySummary, BetterAuthSignInReplayError>> => {
   const parsed = parseBetterAuthSignInReplayArgs(args);
   if (Result.isError(parsed)) {
-    return parsed;
+    return Result.err(parsed.error);
   }
   const clientId = process.env["MICROSOFT_AUTH_CLIENT_ID"];
   const tenantId = process.env["MICROSOFT_AUTH_TENANT_ID"];
@@ -199,7 +207,7 @@ const run = async (args: readonly string[]) => {
   const rows = await readRows(client);
   if (Result.isError(rows)) {
     await client.end();
-    return rows;
+    return Result.err(rows.error);
   }
 
   const { privateKey, publicKey } = await generateKeyPair("RS256");
@@ -232,7 +240,10 @@ const run = async (args: readonly string[]) => {
   // The runtime's only outbound calls during a sign-in are the provider's
   // token exchange and key discovery; both are served locally and every
   // other destination is refused, so the replay never leaves the process.
-  const localProviderFetch: typeof fetch = async (input, init) => {
+  const localProviderFetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
     const request = new Request(input, init);
     if (
       request.url.startsWith(`${MICROSOFT_AUTHORITY}/`) &&
@@ -265,7 +276,9 @@ const run = async (args: readonly string[]) => {
     rejected: 0,
     resolved: 0,
   };
-  globalThis.fetch = localProviderFetch;
+  globalThis.fetch = Object.assign(localProviderFetch, {
+    preconnect: realFetch.preconnect,
+  });
   const replayed = await Result.tryPromise({
     try: async () => {
       const rowIterator = rows.value.microsoft.values();
@@ -383,10 +396,10 @@ const run = async (args: readonly string[]) => {
   const after = await readRows(client);
   await client.end();
   if (Result.isError(replayed)) {
-    return replayed;
+    return Result.err(replayed.error);
   }
   if (Result.isError(after)) {
-    return after;
+    return Result.err(after.error);
   }
   if (
     after.value.userCount !== rows.value.userCount ||

--- a/apps/api/src/scripts/database-census.test.ts
+++ b/apps/api/src/scripts/database-census.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  compareCensus,
+  parseDatabaseCensusArgs,
+} from "@/api/scripts/database-census";
+
+const census = (
+  tables: Record<string, { digest: string | null; rowCount: string }>,
+  foreignKeyOrphans: Record<string, string> = {},
+) => ({ foreignKeyOrphans, formatVersion: 1 as const, tables });
+
+describe("parseDatabaseCensusArgs", () => {
+  test("accepts snapshot and compare with an optional exclusion list", () => {
+    const snapshot = parseDatabaseCensusArgs([
+      "snapshot",
+      "--output",
+      "/tmp/census.json",
+    ]);
+    expect(snapshot.status).toBe("ok");
+    if (snapshot.status === "ok") {
+      expect(snapshot.value).toEqual({
+        exclude: new Set(),
+        mode: "snapshot",
+        outputPath: "/tmp/census.json",
+      });
+    }
+    const compare = parseDatabaseCensusArgs([
+      "compare",
+      "--baseline",
+      "/tmp/census.json",
+      "--exclude",
+      "account,oauth_client",
+    ]);
+    expect(compare.status).toBe("ok");
+    if (compare.status === "ok") {
+      expect(compare.value).toEqual({
+        baselinePath: "/tmp/census.json",
+        exclude: new Set(["account", "oauth_client"]),
+        mode: "compare",
+      });
+    }
+  });
+
+  test.each([
+    [[]],
+    [["snapshot"]],
+    [["snapshot", "--baseline", "/tmp/x"]],
+    [["compare", "--output", "/tmp/x"]],
+    [["compare", "--baseline", "/tmp/x", "--exclude"]],
+    [["compare", "--baseline", "/tmp/x", "--other", "a"]],
+  ])("rejects %j", (args) => {
+    expect(parseDatabaseCensusArgs(args).status).toBe("error");
+  });
+});
+
+describe("compareCensus", () => {
+  const baseline = census(
+    {
+      account: { digest: "a1", rowCount: "11" },
+      document: { digest: "d1", rowCount: "5" },
+      huge: { digest: null, rowCount: "9000000" },
+    },
+    { fk_session_user: "0" },
+  );
+
+  test("reports no differences for an identical census", () => {
+    expect(compareCensus(baseline, baseline, new Set())).toEqual({
+      foreignKeyOrphans: [],
+      tables: [],
+    });
+  });
+
+  test("ignores excluded tables and names the metric that changed elsewhere", () => {
+    const current = census(
+      {
+        account: { digest: "a2", rowCount: "11" },
+        document: { digest: "d2", rowCount: "5" },
+        huge: { digest: null, rowCount: "9000001" },
+      },
+      { fk_session_user: "0" },
+    );
+    expect(compareCensus(baseline, current, new Set(["account"]))).toEqual({
+      foreignKeyOrphans: [],
+      tables: [
+        { metric: "digest", table: "document" },
+        { metric: "rowCount", table: "huge" },
+      ],
+    });
+  });
+
+  test("reports tables that appeared or vanished and foreign keys with orphans", () => {
+    const current = census(
+      {
+        account: { digest: "a1", rowCount: "11" },
+        document: { digest: "d1", rowCount: "5" },
+      },
+      { fk_session_user: "3" },
+    );
+    expect(compareCensus(baseline, current, new Set())).toEqual({
+      foreignKeyOrphans: ["fk_session_user"],
+      tables: [{ metric: "presence", table: "huge" }],
+    });
+  });
+});

--- a/apps/api/src/scripts/database-census.ts
+++ b/apps/api/src/scripts/database-census.ts
@@ -28,6 +28,7 @@ const EXIT_CODE = {
 // scan the whole table on the clone.
 const DIGEST_ROW_BOUND = 500_000;
 const STATEMENT_TIMEOUT = "30min";
+const DATABASE_CONNECTION_TIMEOUT_SECONDS = 30;
 
 const censusSchema = v.strictObject({
   formatVersion: v.literal(1),
@@ -214,23 +215,32 @@ const readCensus = async (
       typeof row["childTable"] !== "string" ||
       typeof row["parentTable"] !== "string" ||
       !Array.isArray(row["childColumns"]) ||
-      !Array.isArray(row["parentColumns"])
+      !Array.isArray(row["parentColumns"]) ||
+      row["childColumns"].length === 0 ||
+      row["childColumns"].length !== row["parentColumns"].length
     ) {
       return Result.err(queryFailed(undefined));
     }
     const childColumns = row["childColumns"].map(String);
     const parentColumns = row["parentColumns"].map(String);
+    const columnPairs = childColumns.flatMap((child, index) => {
+      const parent = parentColumns[index];
+      return parent === undefined ? [] : [{ child, parent }];
+    });
+    if (columnPairs.length !== childColumns.length) {
+      return Result.err(queryFailed(undefined));
+    }
     const childTable = row["childTable"];
     const parentTable = row["parentTable"];
     const orphans = await Result.tryPromise({
       try: async () => {
-        const notNull = childColumns
-          .map((column) => `c.${quoteIdentifier(column)} IS NOT NULL`)
+        const notNull = columnPairs
+          .map(({ child }) => `c.${quoteIdentifier(child)} IS NOT NULL`)
           .join(" AND ");
-        const join = childColumns
+        const join = columnPairs
           .map(
-            (column, index) =>
-              `p.${quoteIdentifier(parentColumns[index] ?? column)} = c.${quoteIdentifier(column)}`,
+            ({ child, parent }) =>
+              `p.${quoteIdentifier(parent)} = c.${quoteIdentifier(child)}`,
           )
           .join(" AND ");
         return await sql.unsafe(
@@ -318,7 +328,11 @@ const run = async (
       }),
     );
   }
-  const sql = new SQL({ max: 1, url: databaseUrl });
+  const sql = new SQL({
+    connectionTimeout: DATABASE_CONNECTION_TIMEOUT_SECONDS,
+    max: 1,
+    url: databaseUrl,
+  });
   // One snapshot for the whole census, so counts, digests, and the orphan
   // sweep describe a single database state.
   const census = await Result.tryPromise({

--- a/apps/api/src/scripts/database-census.ts
+++ b/apps/api/src/scripts/database-census.ts
@@ -24,7 +24,7 @@ const EXIT_CODE = {
   DIFFERENCE: 1,
   SUCCESS: 0,
 } as const;
-// Tables above this estimated size get a count only; a content digest would
+// Tables above this exact row count get a count only; a content digest would
 // scan the whole table on the clone.
 const DIGEST_ROW_BOUND = 500_000;
 const STATEMENT_TIMEOUT = "30min";
@@ -132,31 +132,41 @@ const readCensus = async (
       return Result.err(queryFailed(undefined));
     }
     const name = row["name"];
-    const estimate = Number(row["estimate"]);
-    const digestWanted = estimate >= 0 && estimate <= DIGEST_ROW_BOUND;
+    // The exact count decides whether the digest is affordable; planner
+    // estimates can be stale or absent for a never-analyzed table.
     const measured = await Result.tryPromise({
-      try: async () =>
-        digestWanted
-          ? await sql`
-              SELECT count(*)::text AS "rowCount",
-                     md5(coalesce(string_agg(md5(t::text), '' ORDER BY md5(t::text)), '')) AS "digest"
-                FROM ${sql(name)} t
-            `
-          : await sql`SELECT count(*)::text AS "rowCount", NULL AS "digest" FROM ${sql(name)}`,
+      try: async () => {
+        const counted: unknown[] =
+          await sql`SELECT count(*)::text AS "rowCount" FROM ${sql(name)}`;
+        const countRow: unknown = counted.at(0);
+        const rowCount =
+          isRecord(countRow) && typeof countRow["rowCount"] === "string"
+            ? countRow["rowCount"]
+            : null;
+        if (rowCount === null) {
+          return null;
+        }
+        if (Number(rowCount) > DIGEST_ROW_BOUND) {
+          return { digest: null, rowCount };
+        }
+        const digested: unknown[] = await sql`
+          SELECT md5(coalesce(string_agg(md5(t::text), '' ORDER BY md5(t::text)), '')) AS "digest"
+            FROM ${sql(name)} t
+        `;
+        const digestRow: unknown = digested.at(0);
+        return isRecord(digestRow) && typeof digestRow["digest"] === "string"
+          ? { digest: digestRow["digest"], rowCount }
+          : null;
+      },
       catch: queryFailed,
     });
     if (Result.isError(measured)) {
       return measured;
     }
-    const first: unknown = measured.value.at(0);
-    if (
-      !isRecord(first) ||
-      typeof first["rowCount"] !== "string" ||
-      (first["digest"] !== null && typeof first["digest"] !== "string")
-    ) {
+    if (measured.value === null) {
       return Result.err(queryFailed(undefined));
     }
-    tables[name] = { digest: first["digest"], rowCount: first["rowCount"] };
+    tables[name] = measured.value;
     return measureNextTable();
   };
   const tablesMeasured = await measureNextTable();
@@ -236,7 +246,8 @@ const readCensus = async (
     if (!isRecord(first) || typeof first["orphans"] !== "string") {
       return Result.err(queryFailed(undefined));
     }
-    foreignKeyOrphans[row["name"]] = first["orphans"];
+    // Constraint names are unique per table, not per schema.
+    foreignKeyOrphans[`${childTable}.${row["name"]}`] = first["orphans"];
     return sweepNextForeignKey();
   };
   const foreignKeysSwept = await sweepNextForeignKey();
@@ -308,20 +319,33 @@ const run = async (
     );
   }
   const sql = new SQL({ max: 1, url: databaseUrl });
-  const census = await readCensus(sql);
+  // One snapshot for the whole census, so counts, digests, and the orphan
+  // sweep describe a single database state.
+  const census = await Result.tryPromise({
+    try: async () =>
+      await sql.begin(async (transaction) => {
+        await transaction`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`;
+        return await readCensus(transaction);
+      }),
+    catch: queryFailed,
+  });
   await sql.end();
   if (Result.isError(census)) {
     return census;
   }
+  if (Result.isError(census.value)) {
+    return census.value;
+  }
+  const current = census.value.value;
   const command = parsed.value;
   if (command.mode === "snapshot") {
     const written = await Result.tryPromise({
       try: async () =>
-        await writeFile(
-          command.outputPath,
-          `${JSON.stringify(census.value)}\n`,
-          { encoding: "utf-8", flag: "wx", mode: 0o600 },
-        ),
+        await writeFile(command.outputPath, `${JSON.stringify(current)}\n`, {
+          encoding: "utf-8",
+          flag: "wx",
+          mode: 0o600,
+        }),
       catch: (cause) =>
         new DatabaseCensusError({
           cause,
@@ -347,9 +371,7 @@ const run = async (
   if (Result.isError(baseline)) {
     return baseline;
   }
-  return Result.ok(
-    compareCensus(baseline.value, census.value, command.exclude),
-  );
+  return Result.ok(compareCensus(baseline.value, current, command.exclude));
 };
 
 if (import.meta.main) {

--- a/apps/api/src/scripts/database-census.ts
+++ b/apps/api/src/scripts/database-census.ts
@@ -1,0 +1,394 @@
+/**
+ * Usage:
+ *   bun src/scripts/database-census.ts snapshot --output <path> [--exclude <table,...>]
+ *   bun src/scripts/database-census.ts compare --baseline <path> [--exclude <table,...>]
+ *
+ * Records, for every table in the public schema, the row count and (for
+ * tables below a size bound) an order-independent content digest, plus a
+ * referential-integrity sweep over every foreign key. `compare` fails when
+ * any table outside the exclusion set differs from the baseline or any
+ * foreign key has orphans. Only table names, counts, and digests are
+ * emitted; no row content leaves the database.
+ */
+
+import { Result, TaggedError } from "better-result";
+import { SQL } from "bun";
+import { writeFile } from "node:fs/promises";
+import * as v from "valibot";
+
+import { hasSecureDatabaseTransport, resolveDatabaseUrl } from "@/api/db-url";
+import { formatBetterAuthScriptFailure } from "@/api/scripts/better-auth-script-failure";
+
+const EXIT_CODE = {
+  CONFIGURATION_OR_QUERY_FAILURE: 2,
+  DIFFERENCE: 1,
+  SUCCESS: 0,
+} as const;
+// Tables above this estimated size get a count only; a content digest would
+// scan the whole table on the clone.
+const DIGEST_ROW_BOUND = 500_000;
+const STATEMENT_TIMEOUT = "30min";
+
+const censusSchema = v.strictObject({
+  formatVersion: v.literal(1),
+  foreignKeyOrphans: v.record(v.string(), v.string()),
+  tables: v.record(
+    v.string(),
+    v.strictObject({
+      digest: v.nullable(v.string()),
+      rowCount: v.string(),
+    }),
+  ),
+});
+type Census = v.InferOutput<typeof censusSchema>;
+
+class DatabaseCensusError extends TaggedError("DatabaseCensusError")<{
+  cause?: unknown;
+  code:
+    | "baseline-unreadable"
+    | "database-query-failed"
+    | "invalid-arguments"
+    | "output-write-failed";
+  message: string;
+}> {}
+
+type CensusCommand =
+  | { exclude: ReadonlySet<string>; mode: "snapshot"; outputPath: string }
+  | { baselinePath: string; exclude: ReadonlySet<string>; mode: "compare" };
+
+export const parseDatabaseCensusArgs = (
+  args: readonly string[],
+): Result<CensusCommand, DatabaseCensusError> => {
+  const invalid = () =>
+    Result.err(
+      new DatabaseCensusError({
+        code: "invalid-arguments",
+        message:
+          "Usage: database-census snapshot --output <path> [--exclude a,b] | compare --baseline <path> [--exclude a,b]",
+      }),
+    );
+  const [mode, pathFlag, path, ...rest] = args;
+  if (!path || (rest.length !== 0 && rest.length !== 2)) {
+    return invalid();
+  }
+  let exclude: ReadonlySet<string> = new Set();
+  if (rest.length === 2) {
+    if (rest[0] !== "--exclude" || !rest[1]) {
+      return invalid();
+    }
+    exclude = new Set(rest[1].split(",").filter((name) => name.length > 0));
+  }
+  if (mode === "snapshot" && pathFlag === "--output") {
+    return Result.ok({ exclude, mode, outputPath: path });
+  }
+  if (mode === "compare" && pathFlag === "--baseline") {
+    return Result.ok({ baselinePath: path, exclude, mode });
+  }
+  return invalid();
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const queryFailed = (cause: unknown) =>
+  new DatabaseCensusError({
+    cause,
+    code: "database-query-failed",
+    message: "Database census query failed",
+  });
+
+const readCensus = async (
+  sql: SQL,
+): Promise<Result<Census, DatabaseCensusError>> => {
+  const tablesQueried = await Result.tryPromise({
+    try: async () => {
+      await sql`SELECT set_config('statement_timeout', ${STATEMENT_TIMEOUT}, false)`;
+      return await sql`
+        SELECT c.relname AS "name", c.reltuples::bigint AS "estimate"
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public' AND c.relkind = 'r'
+         ORDER BY c.relname
+      `;
+    },
+    catch: queryFailed,
+  });
+  if (Result.isError(tablesQueried)) {
+    return tablesQueried;
+  }
+  // One connection, one table at a time: the digest scans are the heavy part
+  // and must not contend with each other on the clone.
+  const tables: Census["tables"] = {};
+  const tableRows = tablesQueried.value.values();
+  const measureNextTable = async (): Promise<
+    Result<undefined, DatabaseCensusError>
+  > => {
+    const next = tableRows.next();
+    if (next.done) {
+      return Result.ok(undefined);
+    }
+    const row: unknown = next.value;
+    if (!isRecord(row) || typeof row["name"] !== "string") {
+      return Result.err(queryFailed(undefined));
+    }
+    const name = row["name"];
+    const estimate = Number(row["estimate"]);
+    const digestWanted = estimate >= 0 && estimate <= DIGEST_ROW_BOUND;
+    const measured = await Result.tryPromise({
+      try: async () =>
+        digestWanted
+          ? await sql`
+              SELECT count(*)::text AS "rowCount",
+                     md5(coalesce(string_agg(md5(t::text), '' ORDER BY md5(t::text)), '')) AS "digest"
+                FROM ${sql(name)} t
+            `
+          : await sql`SELECT count(*)::text AS "rowCount", NULL AS "digest" FROM ${sql(name)}`,
+      catch: queryFailed,
+    });
+    if (Result.isError(measured)) {
+      return measured;
+    }
+    const first: unknown = measured.value.at(0);
+    if (
+      !isRecord(first) ||
+      typeof first["rowCount"] !== "string" ||
+      (first["digest"] !== null && typeof first["digest"] !== "string")
+    ) {
+      return Result.err(queryFailed(undefined));
+    }
+    tables[name] = { digest: first["digest"], rowCount: first["rowCount"] };
+    return measureNextTable();
+  };
+  const tablesMeasured = await measureNextTable();
+  if (Result.isError(tablesMeasured)) {
+    return tablesMeasured;
+  }
+
+  const foreignKeysQueried = await Result.tryPromise({
+    try: async () =>
+      await sql`
+      SELECT con.conname AS "name",
+             child.relname AS "childTable",
+             parent.relname AS "parentTable",
+             array_agg(childCol.attname ORDER BY ord.n) AS "childColumns",
+             array_agg(parentCol.attname ORDER BY ord.n) AS "parentColumns"
+        FROM pg_constraint con
+        JOIN pg_class child ON child.oid = con.conrelid
+        JOIN pg_class parent ON parent.oid = con.confrelid
+        JOIN pg_namespace n ON n.oid = child.relnamespace
+        JOIN LATERAL unnest(con.conkey, con.confkey) WITH ORDINALITY AS ord(childAttnum, parentAttnum, n) ON true
+        JOIN pg_attribute childCol ON childCol.attrelid = child.oid AND childCol.attnum = ord.childAttnum
+        JOIN pg_attribute parentCol ON parentCol.attrelid = parent.oid AND parentCol.attnum = ord.parentAttnum
+       WHERE con.contype = 'f' AND n.nspname = 'public'
+       GROUP BY con.conname, child.relname, parent.relname
+       ORDER BY con.conname
+    `,
+    catch: queryFailed,
+  });
+  if (Result.isError(foreignKeysQueried)) {
+    return foreignKeysQueried;
+  }
+  const foreignKeyOrphans: Census["foreignKeyOrphans"] = {};
+  const foreignKeyRows = foreignKeysQueried.value.values();
+  const sweepNextForeignKey = async (): Promise<
+    Result<undefined, DatabaseCensusError>
+  > => {
+    const next = foreignKeyRows.next();
+    if (next.done) {
+      return Result.ok(undefined);
+    }
+    const row: unknown = next.value;
+    if (
+      !isRecord(row) ||
+      typeof row["name"] !== "string" ||
+      typeof row["childTable"] !== "string" ||
+      typeof row["parentTable"] !== "string" ||
+      !Array.isArray(row["childColumns"]) ||
+      !Array.isArray(row["parentColumns"])
+    ) {
+      return Result.err(queryFailed(undefined));
+    }
+    const childColumns = row["childColumns"].map(String);
+    const parentColumns = row["parentColumns"].map(String);
+    const childTable = row["childTable"];
+    const parentTable = row["parentTable"];
+    const orphans = await Result.tryPromise({
+      try: async () => {
+        const notNull = childColumns
+          .map((column) => `c.${quoteIdentifier(column)} IS NOT NULL`)
+          .join(" AND ");
+        const join = childColumns
+          .map(
+            (column, index) =>
+              `p.${quoteIdentifier(parentColumns[index] ?? column)} = c.${quoteIdentifier(column)}`,
+          )
+          .join(" AND ");
+        return await sql.unsafe(
+          `SELECT count(*)::text AS "orphans" FROM ${quoteIdentifier(childTable)} c WHERE ${notNull} AND NOT EXISTS (SELECT 1 FROM ${quoteIdentifier(parentTable)} p WHERE ${join})`,
+        );
+      },
+      catch: queryFailed,
+    });
+    if (Result.isError(orphans)) {
+      return orphans;
+    }
+    const first = orphans.value.at(0);
+    if (!isRecord(first) || typeof first["orphans"] !== "string") {
+      return Result.err(queryFailed(undefined));
+    }
+    foreignKeyOrphans[row["name"]] = first["orphans"];
+    return sweepNextForeignKey();
+  };
+  const foreignKeysSwept = await sweepNextForeignKey();
+  if (Result.isError(foreignKeysSwept)) {
+    return foreignKeysSwept;
+  }
+
+  return Result.ok({ foreignKeyOrphans, formatVersion: 1, tables });
+};
+
+// Identifiers come from the catalog, never from input, and are still quoted
+// so a table named with unusual characters cannot alter the statement.
+const quoteIdentifier = (identifier: string) =>
+  `"${identifier.replaceAll('"', '""')}"`;
+
+type CensusDifference = {
+  foreignKeyOrphans: string[];
+  tables: { metric: "digest" | "rowCount" | "presence"; table: string }[];
+};
+
+export const compareCensus = (
+  baseline: Census,
+  current: Census,
+  exclude: ReadonlySet<string>,
+): CensusDifference => {
+  const differences: CensusDifference = { foreignKeyOrphans: [], tables: [] };
+  const names = new Set([
+    ...Object.keys(baseline.tables),
+    ...Object.keys(current.tables),
+  ]);
+  for (const table of [...names].toSorted()) {
+    if (exclude.has(table)) {
+      continue;
+    }
+    const before = baseline.tables[table];
+    const after = current.tables[table];
+    if (before === undefined || after === undefined) {
+      differences.tables.push({ metric: "presence", table });
+      continue;
+    }
+    if (before.rowCount !== after.rowCount) {
+      differences.tables.push({ metric: "rowCount", table });
+    } else if (before.digest !== after.digest) {
+      differences.tables.push({ metric: "digest", table });
+    }
+  }
+  for (const [name, orphans] of Object.entries(current.foreignKeyOrphans)) {
+    if (orphans !== "0") {
+      differences.foreignKeyOrphans.push(name);
+    }
+  }
+  return differences;
+};
+
+const run = async (
+  args: readonly string[],
+): Promise<Result<CensusDifference | undefined, DatabaseCensusError>> => {
+  const parsed = parseDatabaseCensusArgs(args);
+  if (Result.isError(parsed)) {
+    return parsed;
+  }
+  const databaseUrl = resolveDatabaseUrl();
+  if (!databaseUrl || !hasSecureDatabaseTransport(databaseUrl)) {
+    return Result.err(
+      new DatabaseCensusError({
+        code: "invalid-arguments",
+        message: "Database census requires a secure database connection",
+      }),
+    );
+  }
+  const sql = new SQL({ max: 1, url: databaseUrl });
+  const census = await readCensus(sql);
+  await sql.end();
+  if (Result.isError(census)) {
+    return census;
+  }
+  const command = parsed.value;
+  if (command.mode === "snapshot") {
+    const written = await Result.tryPromise({
+      try: async () =>
+        await writeFile(
+          command.outputPath,
+          `${JSON.stringify(census.value)}\n`,
+          { encoding: "utf-8", flag: "wx", mode: 0o600 },
+        ),
+      catch: (cause) =>
+        new DatabaseCensusError({
+          cause,
+          code: "output-write-failed",
+          message: "Database census could not be written",
+        }),
+    });
+    if (Result.isError(written)) {
+      return written;
+    }
+    return Result.ok(undefined);
+  }
+  const baseline = await Result.tryPromise({
+    try: async () =>
+      v.parse(censusSchema, await Bun.file(command.baselinePath).json()),
+    catch: (cause) =>
+      new DatabaseCensusError({
+        cause,
+        code: "baseline-unreadable",
+        message: "Database census baseline is unreadable",
+      }),
+  });
+  if (Result.isError(baseline)) {
+    return baseline;
+  }
+  return Result.ok(
+    compareCensus(baseline.value, census.value, command.exclude),
+  );
+};
+
+if (import.meta.main) {
+  run(Bun.argv.slice(2))
+    .then((result) => {
+      if (Result.isError(result)) {
+        process.stderr.write(formatBetterAuthScriptFailure(result.error));
+        process.exitCode = EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
+        return undefined;
+      }
+      const differences = result.value;
+      if (differences === undefined) {
+        process.stdout.write(
+          `${JSON.stringify({ check: "database-census", status: "recorded" })}\n`,
+        );
+        process.exitCode = EXIT_CODE.SUCCESS;
+        return undefined;
+      }
+      const clean =
+        differences.tables.length === 0 &&
+        differences.foreignKeyOrphans.length === 0;
+      process.stdout.write(
+        `${JSON.stringify({
+          check: "database-census",
+          differences,
+          status: clean ? "passed" : "failed",
+        })}\n`,
+      );
+      process.exitCode = clean ? EXIT_CODE.SUCCESS : EXIT_CODE.DIFFERENCE;
+      return undefined;
+    })
+    .catch((error: unknown) => {
+      process.stderr.write(
+        formatBetterAuthScriptFailure({
+          cause: error,
+          code: "unexpected-failure",
+          message: "Database census failed unexpectedly",
+        }),
+      );
+      process.exitCode = EXIT_CODE.CONFIGURATION_OR_QUERY_FAILURE;
+    });
+}


### PR DESCRIPTION
Two scripts for checking a migrated database before it is trusted, both bundled into the API image:

- `database-census` records, for every table in the public schema, the row count and an order-independent content digest (count only above a size bound), plus an orphan sweep over every foreign key, and compares a later census against the recorded one. Tables named in an exclusion list are ignored in the comparison so a migration can be checked for touching nothing else. Only table names, counts, and digests are emitted.
- `better-auth-sign-in-replay` boots the auth runtime against the database and replays the first sign-in of every stored Microsoft account and the next request of a session sample. The provider is served locally (token exchange and signing keys), so nothing leaves the process; every sign-in must resolve to the account's existing user without creating a user or account row, and every sampled session must resolve to its stored user. Counts only.

Unit tests cover argument parsing and the census comparison; both scripts were exercised against a development database.

https://claude.ai/code/session_019Tx4ydN2CULWU5o7DV1fGF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a database census utility to capture and compare table metrics, content fingerprints and referential-integrity results without exposing row data.
  - Added a sign-in/session replay utility to validate migrated authentication data without contacting the external identity provider.
  - Both utilities are available in the runtime deployment image and provide clear success, difference and failure results.

- **Tests**
  - Added coverage for valid and invalid command arguments, census comparisons, schema changes and orphaned references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->