### PR TITLE
chore: version published packages

### DIFF
--- a/.changeset/cli-env-injection.md
+++ b/.changeset/cli-env-injection.md
@@ -1,4 +1,0 @@
----
----
-
-Internal only: `@stll/cli` reads its server-URL and API-key environment variables through the documented constants and injects them in tests; no behaviour change.

--- a/.changeset/mistral-chat-default.md
+++ b/.changeset/mistral-chat-default.md
@@ -1,5 +1,0 @@
----
-"@stll/ai-catalog": patch
----
-
-Default the Mistral chat role to `mistral-medium-latest`; `mistral-large-latest` is gated behind a higher subscription tier.

--- a/.changeset/smart-shells-listen.md
+++ b/.changeset/smart-shells-listen.md
@@ -1,5 +1,0 @@
----
-"@stll/ui": minor
----
-
-Replace the partial application frame with a complete fixed-viewport workspace shell and permanent typed end rail. This pre-1.0 breaking minor requires navigation, sticky top chrome, and an inline-end dock; chat must be wired or explicitly unavailable.

--- a/.changeset/tricky-chefs-talk.md
+++ b/.changeset/tricky-chefs-talk.md
@@ -1,5 +1,0 @@
----
-"@stll/ai-catalog": patch
----
-
-Expose the GPT-5.6 model family

--- a/bun.lock
+++ b/bun.lock
@@ -445,7 +445,7 @@
     },
     "packages/ai-catalog": {
       "name": "@stll/ai-catalog",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "valibot": "catalog:",
       },
@@ -817,7 +817,7 @@
     },
     "packages/ui": {
       "name": "@stll/ui",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "dependencies": {
         "better-result": "catalog:",
         "class-variance-authority": "^0.7.1",
@@ -871,7 +871,7 @@
     },
     "packages/workspace-ui": {
       "name": "@stll/workspace-ui",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@stll/calculations": "workspace:^",
         "@stll/conditions": "workspace:^",

--- a/packages/ai-catalog/CHANGELOG.md
+++ b/packages/ai-catalog/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @stll/ai-catalog
 
+## 0.1.4
+
+### Patch Changes
+
+- [#2584](https://github.com/stella/stella/pull/2584) [`c918286`](https://github.com/stella/stella/commit/c9182860575e40ae1ad3b6f81bfc7e85362f8b62) Thanks [@jan-kubica](https://github.com/jan-kubica)! - Default the Mistral chat role to `mistral-medium-latest`; `mistral-large-latest` is gated behind a higher subscription tier.
+
+- [#2568](https://github.com/stella/stella/pull/2568) [`760149f`](https://github.com/stella/stella/commit/760149f073adf3b8e45a9ece4df179d7ef8c7bd2) Thanks [@jan-kubica](https://github.com/jan-kubica)! - Expose the GPT-5.6 model family
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/ai-catalog/package.json
+++ b/packages/ai-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stll/ai-catalog",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Provider-neutral AI model roles, capabilities, and curated model metadata.",
   "keywords": [
     "ai",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @stll/ui
 
+## 0.10.0
+
+### Minor Changes
+
+- [#2594](https://github.com/stella/stella/pull/2594) [`37b6437`](https://github.com/stella/stella/commit/37b64377f9806be3da0a9cf9b33e7b984e46ed1a) Thanks [@jan-kubica](https://github.com/jan-kubica)! - Replace the partial application frame with a complete fixed-viewport workspace shell and permanent typed end rail. This pre-1.0 breaking minor requires navigation, sticky top chrome, and an inline-end dock; chat must be wired or explicitly unavailable.
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stll/ui",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Stella's design system: bidi-aware React primitives built on Base UI, the dockable inspector pane, and the Tailwind v4 theme they are styled with.",
   "keywords": [
     "base-ui",

--- a/packages/workspace-ui/CHANGELOG.md
+++ b/packages/workspace-ui/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @stll/workspace-ui
 
+## 0.4.2
+
+### Patch Changes
+
+- Updated dependencies [[`37b6437`](https://github.com/stella/stella/commit/37b64377f9806be3da0a9cf9b33e7b984e46ed1a)]:
+  - @stll/ui@0.10.0
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/workspace-ui/package.json
+++ b/packages/workspace-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stll/workspace-ui",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Reusable workspace presentation components and view helpers for Stella.",
   "keywords": [
     "calculations",


### PR DESCRIPTION
## Summary

- release `@stll/ui` 0.10.0 with the complete workspace shell contract
- update `@stll/workspace-ui` to 0.4.2 for the new UI dependency
- publish the pending `@stll/ai-catalog` patches as 0.1.4

## Validation

- Changesets generated package versions, changelogs, and workspace lock entries
- focused builds passed for all three published packages
- manifest and diff review found only generated release changes

## CI policy

The release commit carries `[skip ci]` to avoid GitHub-hosted build runners. Administrative merge uses the focused local package-build evidence above; npm publication remains a separate explicit step.