### PR TITLE
feat: own compact workspace navigation

### DIFF
--- a/.changeset/bright-shells-fold.md
+++ b/.changeset/bright-shells-fold.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": minor
+---
+
+Make responsive navigation ownership explicit in `WorkspaceShell`, with a shell-managed compact sheet contract for hosts that do not already provide responsive navigation.

--- a/apps/web/src/components/public-workspace-shell.tsx
+++ b/apps/web/src/components/public-workspace-shell.tsx
@@ -125,8 +125,8 @@ export const PublicWorkspaceShell = ({
       <SidebarProvider>
         <WorkspaceShell
           endDock={inspector ?? defaultInspector}
-          navigation={
-            authStatus.isAuthenticated ? (
+          navigation={{
+            content: authStatus.isAuthenticated ? (
               <Suspense
                 fallback={
                   <PublicSidebar
@@ -142,9 +142,10 @@ export const PublicWorkspaceShell = ({
                 authStatus={authStatus}
                 requestAuth={requestAuth}
               />
-            )
-          }
-          topBar={topBar}
+            ),
+            mode: "responsive",
+          }}
+          topBar={() => topBar}
         >
           <Outlet />
         </WorkspaceShell>

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -362,8 +362,8 @@ function ProtectedComponent() {
               <DragAndDropLiveRegion />
               <WorkspaceShell
                 endDock={<WorkspaceInspectorSidePanel />}
-                navigation={<AppSidebar />}
-                topBar={<ProtectedContent />}
+                navigation={{ content: <AppSidebar />, mode: "responsive" }}
+                topBar={() => <ProtectedContent />}
               >
                 <Outlet />
               </WorkspaceShell>

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -53,11 +53,38 @@ import { WorkspaceEndRail, WorkspaceShell } from "@stll/ui/workspace-shell";
       topAction={<InspectorToggle />}
     />
   }
-  navigation={<Navigation />}
-  topBar={<WorkspaceHeader />}
+  navigation={{ content: <Navigation />, mode: "responsive" }}
+  topBar={() => <WorkspaceHeader />}
 >
   <Workspace />
 </WorkspaceShell>;
+```
+
+Applications without their own responsive navigation use the shell-managed
+contract. Stella then owns the desktop/compact cutoff, sheet portal, backdrop,
+Escape and viewport-close behavior; the top-bar callback places the supplied
+trigger in product-specific chrome.
+
+```tsx
+<WorkspaceShell
+  endDock={<WorkspaceInspector />}
+  navigation={{
+    compact: {
+      content: <Navigation expanded />,
+      label: "Open navigation",
+      onOpenChange: setNavigationOpen,
+      open: navigationOpen,
+      trigger: <button type="button">Menu</button>,
+    },
+    desktop: <NavigationRail />,
+    mode: "shell-managed",
+  }}
+  topBar={({ compactNavigationTrigger }) => (
+    <WorkspaceHeader navigationTrigger={compactNavigationTrigger} />
+  )}
+>
+  <Workspace />
+</WorkspaceShell>
 ```
 
 `WorkspaceEndRail` owns the 48px rail, 44px touch targets, scrolling tab

--- a/packages/ui/src/components/workspace-shell.test.tsx
+++ b/packages/ui/src/components/workspace-shell.test.tsx
@@ -9,8 +9,11 @@ describe("WorkspaceShell", () => {
     const markup = renderToStaticMarkup(
       <WorkspaceShell
         endDock={<aside data-test="end-dock">Inspector</aside>}
-        navigation={<nav data-test="navigation">Navigation</nav>}
-        topBar={<header data-test="top-bar">Header</header>}
+        navigation={{
+          content: <nav data-test="navigation">Navigation</nav>,
+          mode: "responsive",
+        }}
+        topBar={() => <header data-test="top-bar">Header</header>}
       >
         <article data-test="content">Content</article>
       </WorkspaceShell>,
@@ -24,6 +27,36 @@ describe("WorkspaceShell", () => {
     expect(markup).toContain("sticky top-0 z-20 shrink-0");
     expect(markup).toContain('data-slot="workspace-shell-content"');
     expect(markup).toContain("min-h-0 flex-1 overflow-auto overscroll-contain");
+  });
+
+  test("owns a controlled compact navigation without mounting its portal on desktop", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceShell
+        endDock={<aside>Inspector</aside>}
+        navigation={{
+          compact: {
+            content: <nav>Compact navigation</nav>,
+            label: "Open navigation",
+            onOpenChange: () => undefined,
+            open: true,
+            trigger: <button type="button">Menu</button>,
+          },
+          desktop: <nav data-test="desktop-navigation">Desktop</nav>,
+          mode: "shell-managed",
+        }}
+        topBar={({ compactNavigationTrigger }) => (
+          <header>{compactNavigationTrigger}Header</header>
+        )}
+      >
+        <article>Content</article>
+      </WorkspaceShell>,
+    );
+
+    expect(markup).toContain('data-test="desktop-navigation"');
+    expect(markup).toContain('aria-label="Open navigation"');
+    expect(markup).toContain("Menu");
+    expect(markup).not.toContain("Compact navigation");
+    expect(markup).not.toContain('data-slot="sheet-backdrop"');
   });
 });
 

--- a/packages/ui/src/components/workspace-shell.tsx
+++ b/packages/ui/src/components/workspace-shell.tsx
@@ -1,7 +1,11 @@
+"use client";
+
+import { useEffect } from "react";
 import type { ReactElement, ReactNode } from "react";
 
 import { MessageSquarePlusIcon } from "lucide-react";
 
+import { useIsMobile } from "../hooks/use-mobile";
 import {
   InspectorRail,
   InspectorRailCell,
@@ -10,12 +14,44 @@ import {
   InspectorRailIconButton,
 } from "../inspector/chrome";
 import { cn } from "../lib/utils";
+import { Sheet, SheetPopup, SheetTitle, SheetTrigger } from "./sheet";
+
+type WorkspaceCompactNavigation = {
+  /** Navigation content rendered inside Stella's compact sheet. */
+  content: ReactElement;
+  /** Accessible name shared by the trigger and sheet. */
+  label: string;
+  /** Controlled sheet state owned by the host application. */
+  open: boolean;
+  /** Receives close gestures, Escape, backdrop presses, and viewport changes. */
+  onOpenChange: (open: boolean) => void;
+  /** Host-styled button; Stella supplies trigger behavior and accessibility. */
+  trigger: ReactElement;
+};
+
+type WorkspaceNavigation =
+  | {
+      /** The host already owns its complete responsive navigation behavior. */
+      content: ReactElement;
+      mode: "responsive";
+    }
+  | {
+      /** Stella owns the desktop/compact cutoff and compact navigation sheet. */
+      compact: WorkspaceCompactNavigation;
+      desktop: ReactElement;
+      mode: "shell-managed";
+    };
+
+type WorkspaceTopBarContext = {
+  /** Place this in compact chrome; null when navigation is host-responsive. */
+  compactNavigationTrigger: ReactElement | null;
+};
 
 type WorkspaceShellProps = {
-  /** Product navigation in Stella's inline-start application column. */
-  navigation: ReactElement;
-  /** Sticky route chrome above the sole scrolling content surface. */
-  topBar: ReactElement;
+  /** Product navigation with one explicit responsive ownership mode. */
+  navigation: WorkspaceNavigation;
+  /** Sticky route chrome; managed navigation exposes its compact trigger here. */
+  topBar: (context: WorkspaceTopBarContext) => ReactElement;
   /** Permanent inline-end rail or inspector dock. */
   endDock: ReactElement;
   /** Active route content. */
@@ -32,35 +68,89 @@ export const WorkspaceShell = ({
   endDock,
   navigation,
   topBar,
-}: WorkspaceShellProps) => (
-  <div
-    className="flex h-dvh min-h-0 w-full overflow-hidden"
-    data-slot="workspace-shell"
-  >
-    {navigation}
-    <main
-      className={cn(
-        "bg-background relative flex w-full min-w-0 flex-1 flex-col overflow-hidden",
-        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-2",
-      )}
-      data-slot="workspace-shell-main"
+}: WorkspaceShellProps) => {
+  const isCompact = useIsMobile();
+  const compactNavigation =
+    navigation.mode === "shell-managed" ? navigation.compact : null;
+  const compactNavigationOpen = compactNavigation?.open ?? false;
+  const onCompactNavigationOpenChange = compactNavigation?.onOpenChange;
+
+  useEffect(() => {
+    if (!isCompact && compactNavigationOpen) {
+      onCompactNavigationOpenChange?.(false);
+    }
+  }, [compactNavigationOpen, isCompact, onCompactNavigationOpenChange]);
+
+  const compactNavigationTrigger =
+    compactNavigation === null ? null : (
+      <span className="contents md:hidden">
+        <SheetTrigger
+          aria-label={compactNavigation.label}
+          render={compactNavigation.trigger}
+        />
+      </span>
+    );
+
+  const frame = (
+    <div
+      className="flex h-dvh min-h-0 w-full overflow-hidden"
+      data-slot="workspace-shell"
     >
-      <div
-        className="bg-background sticky top-0 z-20 shrink-0"
-        data-slot="workspace-shell-top-bar"
+      {navigation.mode === "responsive"
+        ? navigation.content
+        : navigation.desktop}
+      <main
+        className={cn(
+          "bg-background relative flex w-full min-w-0 flex-1 flex-col overflow-hidden",
+          "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-2",
+        )}
+        data-slot="workspace-shell-main"
       >
-        {topBar}
-      </div>
-      <div
-        className="min-h-0 flex-1 overflow-auto overscroll-contain"
-        data-slot="workspace-shell-content"
-      >
-        {children}
-      </div>
-    </main>
-    {endDock}
-  </div>
-);
+        <div
+          className="bg-background sticky top-0 z-20 shrink-0"
+          data-slot="workspace-shell-top-bar"
+        >
+          {topBar({ compactNavigationTrigger })}
+        </div>
+        <div
+          className="min-h-0 flex-1 overflow-auto overscroll-contain"
+          data-slot="workspace-shell-content"
+        >
+          {children}
+        </div>
+      </main>
+      {endDock}
+    </div>
+  );
+
+  if (compactNavigation === null) {
+    return frame;
+  }
+
+  return (
+    <Sheet
+      open={isCompact && compactNavigation.open}
+      onOpenChange={compactNavigation.onOpenChange}
+    >
+      {frame}
+      {isCompact ? (
+        <SheetPopup
+          className="w-[min(20rem,100vw)]"
+          showCloseButton={false}
+          side="inline-start"
+        >
+          <SheetTitle className="sr-only">{compactNavigation.label}</SheetTitle>
+          <div
+            className="bg-background flex h-full min-h-0 flex-col overflow-y-auto [padding-inline:max(0.75rem,env(safe-area-inset-left))_max(0.75rem,env(safe-area-inset-right))] [padding-block:max(0.75rem,env(safe-area-inset-top))_max(0.75rem,env(safe-area-inset-bottom))]"
+            data-slot="workspace-compact-navigation"
+          >
+            {compactNavigation.content}
+          </div>
+        </SheetPopup>
+      ) : null}
+    </Sheet>
+  );
+};
 
 type WorkspaceEndRailChatAction =
   | {
@@ -131,7 +221,10 @@ export const WorkspaceEndRail = ({
 );
 
 export type {
+  WorkspaceCompactNavigation,
   WorkspaceEndRailChatAction,
   WorkspaceEndRailProps,
+  WorkspaceNavigation,
   WorkspaceShellProps,
+  WorkspaceTopBarContext,
 };


### PR DESCRIPTION
## Summary

- make responsive navigation ownership explicit in `WorkspaceShell`
- add a controlled shell-managed compact sheet with typed trigger/content/state slots
- close compact navigation when crossing to desktop and keep the backdrop out of desktop markup
- migrate current in-repo consumers to the explicit host-responsive branch

## Local evidence

- 5 focused workspace-shell/application-rail tests pass
- `@stll/ui` typecheck passes
- `@stll/ui` build passes
- touched-file oxlint and oxfmt pass
- staged secret scan passes

## Merge policy

The commit includes `[skip ci]` to avoid hosted build workflows. After the single metadata/review cycle settles, this is eligible for administrative merge using the focused local evidence above; no workflow reruns are requested.