### PR TITLE
feat: generate desktop RPC types from Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -874,8 +874,10 @@ jobs:
       # script itself is caught immediately, not on the next desktop
       # bridge change. Always runs (no `if:` gate) — it's seconds
       # and has no deps.
-      - name: Test bridge-version guard script
-        run: bash scripts/check-bridge-version.test.sh
+      - name: Test desktop bridge CI guards
+        run: |
+          bash scripts/check-bridge-version.test.sh
+          bash scripts/detect-tauri-rust-changes.test.sh
 
       # Self-test the release-channel script. The desktop release
       # pipeline relies on three independent steps deriving the

--- a/apps/desktop/fixtures/rpc/app-snapshot.json
+++ b/apps/desktop/fixtures/rpc/app-snapshot.json
@@ -1,6 +1,6 @@
 {
   "bridgePort": 45901,
-  "bridgeVersion": 9,
+  "bridgeVersion": 10,
   "capabilities": ["office-edit.v1", "self-host.connect"],
   "linkedAccount": {
     "email": "counsel@example.com",

--- a/apps/desktop/fixtures/rpc/open-handoff-request.json
+++ b/apps/desktop/fixtures/rpc/open-handoff-request.json
@@ -1,0 +1,23 @@
+{
+  "apiBaseUrl": "https://api.example.com",
+  "entityId": "11111111-1111-4111-8111-111111111111",
+  "handoffId": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+  "linkedAccount": {
+    "email": "counsel@example.com",
+    "name": "Jane Counsel",
+    "verifiedAt": "2026-07-01T09:30:00Z"
+  },
+  "propertyId": "22222222-2222-4222-8222-222222222222",
+  "remoteSession": {
+    "baseVersionNumber": 2,
+    "downloadUrl": "https://s3.example.com/doc.docx?sig=abc123",
+    "fileType": "docx",
+    "fileName": "motion.docx",
+    "lastCheckpointAt": null,
+    "resumedFromCheckpoint": false,
+    "sessionId": "e8400e29-1d4a-4716-8a3a-2c83de7ab2e6",
+    "sessionToken": "sess-tok-abc123",
+    "tookOverExistingSession": false
+  },
+  "workspaceId": "33333333-3333-4333-8333-333333333333"
+}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,8 @@
     "format": "oxfmt -c ../../.oxfmtrc.json .",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware apps/desktop",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/desktop",
+    "rpc:check": "cargo test --manifest-path src-tauri/Cargo.toml --locked types::rpc_codegen_tests::generated_desktop_rpc_bindings_are_current -- --exact",
+    "rpc:generate": "cargo test --manifest-path src-tauri/Cargo.toml --locked types::rpc_codegen_tests::generate_desktop_rpc_bindings -- --ignored --exact",
     "test": "bun test --pass-with-no-tests",
     "typecheck": "bun ../../packages/scripts/src/tsc-native.ts --noEmit && bun ../../packages/scripts/src/tsc-native.ts --noEmit -p tsconfig.test.json"
   },

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4658,6 +4658,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "ts-rs",
  "uuid",
  "windows-icons",
  "windows-native-keyring-store",
@@ -5306,6 +5307,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5750,6 +5760,28 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ts-rs"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756050066659291d47a554a9f558125db17428b073c5ffce1daf5dcb0f7231d8"
+dependencies = [
+ "thiserror 2.0.20",
+ "ts-rs-macros",
+]
+
+[[package]]
+name = "ts-rs-macros"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d90eea51bc7988ef9e674bf80a85ba6804739e535e9cab48e4bb34a8b652aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "termcolor",
+]
 
 [[package]]
 name = "typed-path"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -127,3 +127,4 @@ winsafe = { version = "0.0.28", features = ["kernel", "user", "version"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
+ts-rs = "12.0.1"

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -113,11 +113,12 @@ pub fn build_tray_menu(
   // Check for updates
   builder = builder.item(
     &MenuItemBuilder::with_id(CHECK_FOR_UPDATES_ACTION, t("tray.checkForUpdates"))
-      .enabled(
-        snapshot.update.status != "checking"
-          && snapshot.update.status != "downloading"
-          && snapshot.update.status != "applying",
-      )
+      .enabled(!matches!(
+        snapshot.update.status,
+        crate::types::DesktopUpdateStatus::Checking
+          | crate::types::DesktopUpdateStatus::Downloading
+          | crate::types::DesktopUpdateStatus::Applying
+      ))
       .build(app)?,
   );
 

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -11,6 +11,7 @@ pub const PPTX_MIME_TYPE: &str =
 macro_rules! define_desktop_edit_file_types {
   ($($variant:ident => $wire_name:literal),+ $(,)?) => {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+    #[cfg_attr(test, derive(ts_rs::TS))]
     pub enum DesktopEditFileType {
       $(
         #[serde(rename = $wire_name)]
@@ -72,6 +73,7 @@ impl DesktopEditFileType {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
 #[serde(rename_all = "lowercase")]
 pub enum SessionStatus {
   Opening,
@@ -82,8 +84,10 @@ pub enum SessionStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 pub struct SessionSnapshot {
+  #[cfg_attr(test, ts(type = "number"))]
   pub base_version_number: i64,
   pub entity_id: String,
   pub file_type: DesktopEditFileType,
@@ -100,6 +104,7 @@ pub struct SessionSnapshot {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 pub struct DesktopNotificationPreferences {
   pub document_ready: bool,
@@ -118,6 +123,7 @@ impl Default for DesktopNotificationPreferences {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 pub struct LinkedAccountSnapshot {
   pub email: String,
@@ -126,8 +132,10 @@ pub struct LinkedAccountSnapshot {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 pub struct OpenFileRemoteSession {
+  #[cfg_attr(test, ts(type = "number"))]
   pub base_version_number: i64,
   pub download_url: String,
   pub file_type: DesktopEditFileType,
@@ -139,7 +147,23 @@ pub struct OpenFileRemoteSession {
   pub took_over_existing_session: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
+#[serde(rename_all = "snake_case")]
+pub enum DesktopUpdateStatus {
+  Idle,
+  Checking,
+  Available,
+  Downloading,
+  Ready,
+  Applying,
+  UpToDate,
+  Error,
+  Disabled,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 pub struct DesktopUpdateSnapshot {
   pub base_url: Option<String>,
@@ -149,7 +173,7 @@ pub struct DesktopUpdateSnapshot {
   pub last_checked_at: Option<String>,
   pub latest_hash: Option<String>,
   pub latest_version: Option<String>,
-  pub status: String,
+  pub status: DesktopUpdateStatus,
   pub status_message: String,
   pub update_available: bool,
   pub update_ready: bool,
@@ -169,7 +193,7 @@ impl Default for DesktopUpdateSnapshot {
       last_checked_at: None,
       latest_hash: None,
       latest_version: None,
-      status: "disabled".to_string(),
+      status: DesktopUpdateStatus::Disabled,
       status_message: "Updates will appear here once configured.".to_string(),
       update_available: false,
       update_ready: false,
@@ -178,6 +202,7 @@ impl Default for DesktopUpdateSnapshot {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 pub struct TrustedSelfHostConnection {
   pub api_base_url: String,
@@ -188,13 +213,14 @@ pub struct TrustedSelfHostConnection {
 /// Monotonic bridge contract revision. Increment whenever the bridge
 /// surface changes so the web app can require a minimum revision without
 /// coupling to the desktop's literal app version.
-pub const BRIDGE_VERSION: u32 = 9;
+pub const BRIDGE_VERSION: u32 = 10;
 
 /// Versioned contracts advertised to the web app. A client requires the
 /// capability it uses; breaking semantics receive a new capability id.
 pub const BRIDGE_CAPABILITIES: &[&str] = &["office-edit.v1", "self-host.connect"];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 pub struct AppSnapshot {
   pub bridge_port: u16,
@@ -211,11 +237,12 @@ pub struct AppSnapshot {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 pub struct OpenFileRequest {
   pub api_base_url: String,
   pub entity_id: String,
-  #[serde(default)]
+  #[serde(default, skip_serializing_if = "Option::is_none")]
   pub handoff_id: Option<String>,
   pub linked_account: Option<LinkedAccountSnapshot>,
   pub property_id: String,
@@ -249,6 +276,7 @@ pub fn is_safe_session_id(value: &str) -> bool {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(ts_rs::TS))]
 #[serde(rename_all = "camelCase")]
 pub struct OpenFileResponse {
   pub already_open: bool,
@@ -539,15 +567,133 @@ mod tests {
   }
 }
 
-/// Golden-fixture contract shared with the TypeScript bridge types.
+#[cfg(test)]
+mod rpc_codegen_tests {
+  use super::*;
+  use std::any::TypeId;
+  use std::collections::HashSet;
+  use std::path::Path;
+  use ts_rs::{Config, TS, TypeVisitor};
+
+  const GENERATED_PATH: &str = "../src/shared/rpc.gen.ts";
+  const COMMITTED_BINDINGS: &str = include_str!("../../src/shared/rpc.gen.ts");
+  const GENERATED_HEADER: &str = "// Generated from apps/desktop/src-tauri/src/types.rs.\n// Regenerate from the repository root with `bun --filter @stll/desktop rpc:generate`.\n// Do not edit by hand.\n\n";
+
+  type DesktopRpcContract = (AppSnapshot, OpenFileRequest, OpenFileResponse);
+
+  struct DeclarationVisitor<'a> {
+    config: &'a Config,
+    declarations: Vec<String>,
+    seen: HashSet<TypeId>,
+  }
+
+  impl TypeVisitor for DeclarationVisitor<'_> {
+    fn visit<T: TS + 'static + ?Sized>(&mut self) {
+      if !self.seen.insert(TypeId::of::<T>()) {
+        return;
+      }
+
+      if T::output_path().is_some() {
+        self
+          .declarations
+          .push(use_bracket_array_syntax(T::decl(self.config)));
+      }
+      T::visit_dependencies(self);
+      T::visit_generics(self);
+    }
+  }
+
+  fn use_bracket_array_syntax(mut declaration: String) -> String {
+    while let Some(start) = declaration.rfind("Array<") {
+      let inner_start = start + "Array<".len();
+      let mut depth = 1_u32;
+      let mut end = None;
+      for (offset, character) in declaration[inner_start..].char_indices() {
+        match character {
+          '<' => depth += 1,
+          '>' => {
+            depth -= 1;
+            if depth == 0 {
+              end = Some(inner_start + offset);
+              break;
+            }
+          }
+          _ => {}
+        }
+      }
+      let end = end.unwrap_or_else(|| panic!("unclosed Array type in {declaration}"));
+      let inner = &declaration[inner_start..end];
+      let replacement = if inner.contains(" | ") || inner.contains(" & ") {
+        format!("({inner})[]")
+      } else {
+        format!("{inner}[]")
+      };
+      declaration.replace_range(start..=end, &replacement);
+    }
+    declaration
+      .lines()
+      .map(str::trim_end)
+      .collect::<Vec<_>>()
+      .join("\n")
+  }
+
+  fn render_desktop_rpc_bindings() -> String {
+    let config = Config::default();
+    let mut visitor = DeclarationVisitor {
+      config: &config,
+      declarations: Vec::new(),
+      seen: HashSet::new(),
+    };
+    DesktopRpcContract::visit_generics(&mut visitor);
+    visitor.declarations.sort();
+
+    let mut output = String::from(GENERATED_HEADER);
+    for declaration in visitor.declarations {
+      output.push_str("export ");
+      output.push_str(&declaration);
+      output.push_str("\n\n");
+    }
+    let content_end = output.trim_end().len();
+    output.truncate(content_end);
+    output.push('\n');
+    output
+  }
+
+  #[test]
+  fn generated_desktop_rpc_bindings_are_current() {
+    assert_eq!(
+      COMMITTED_BINDINGS,
+      render_desktop_rpc_bindings(),
+      "desktop RPC bindings are stale; run `bun --filter @stll/desktop rpc:generate`",
+    );
+  }
+
+  #[test]
+  fn generated_arrays_follow_repository_typescript_syntax() {
+    assert_eq!(
+      use_bracket_array_syntax("type Nested = Array<Array<string>>;".to_string()),
+      "type Nested = string[][];"
+    );
+    assert_eq!(
+      use_bracket_array_syntax("type Nullable = Array<string | null>;".to_string()),
+      "type Nullable = (string | null)[];"
+    );
+  }
+
+  #[test]
+  #[ignore = "writes the committed TypeScript bindings"]
+  fn generate_desktop_rpc_bindings() {
+    std::fs::write(Path::new(GENERATED_PATH), render_desktop_rpc_bindings())
+      .expect("generated desktop RPC bindings are writable");
+  }
+}
+
+/// Golden-fixture compatibility checks for the generated bridge types.
 ///
-/// The JSON files under `apps/desktop/fixtures/rpc/` are the single
-/// source of truth for every message that crosses the web <-> desktop
-/// bridge. `src/shared/rpc.golden.test.ts` validates the same files
-/// against the TypeScript `rpc.ts` types; this module validates the Rust
-/// serde types. A field renamed, retyped, or dropped on either side
-/// without updating the fixtures fails one of the two suites, so
-/// TS/Rust message-shape drift cannot land silently.
+/// Rust serde DTOs are the source for `src/shared/rpc.gen.ts`. The JSON files
+/// under `apps/desktop/fixtures/rpc/` independently pin representative wire
+/// payloads, and `tests/rpc.golden.test.ts` validates those same fixtures
+/// against the generated declarations.
 ///
 /// The fixtures are embedded with `include_str!` (path relative to this
 /// source file), the same mechanism `i18n.rs` uses for bundled language
@@ -569,6 +715,8 @@ mod fixture_tests {
     include_str!("../../fixtures/rpc/open-pptx-request.json");
   const OPEN_DOCX_RESPONSE: &str =
     include_str!("../../fixtures/rpc/open-docx-response.json");
+  const OPEN_HANDOFF_REQUEST: &str =
+    include_str!("../../fixtures/rpc/open-handoff-request.json");
   const LINKED_ACCOUNT: &str = include_str!("../../fixtures/rpc/linked-account.json");
   const DESKTOP_UPDATE: &str = include_str!("../../fixtures/rpc/desktop-update.json");
   const TRUSTED_SELF_HOST: &str =
@@ -643,16 +791,11 @@ mod fixture_tests {
     assert_roundtrip::<DesktopNotificationPreferences>(NOTIFICATION_PREFERENCES);
   }
 
-  /// `OpenFileRequest` is intentionally deserialize-only here: the Rust
-  /// struct carries a `#[serde(default)] handoff_id` that the TypeScript
-  /// `OpenFileRequest` type (and the HTTP bridge payload the web sends)
-  /// omit. Since the field has no `skip_serializing_if`, re-serializing
-  /// injects `"handoffId": null`, which the shared fixture deliberately
-  /// does not contain, so a strict round-trip would not hold. We assert
-  /// the fixture deserializes and the required fields decode correctly;
-  /// the asymmetry is documented rather than papered over.
   #[test]
-  fn open_file_request_fixture_deserializes() {
+  fn open_file_request_fixtures_roundtrip_both_handoff_forms() {
+    assert_roundtrip::<OpenFileRequest>(OPEN_DOCX_REQUEST);
+    assert_roundtrip::<OpenFileRequest>(OPEN_HANDOFF_REQUEST);
+
     let request: OpenFileRequest =
       serde_json::from_str(OPEN_DOCX_REQUEST).expect("fixture deserializes");
     assert_eq!(request.api_base_url, "https://api.example.com");
@@ -666,6 +809,13 @@ mod fixture_tests {
     assert_eq!(request.remote_session.file_name, "motion.docx");
     let linked = request.linked_account.expect("linked account present");
     assert_eq!(linked.email, "counsel@example.com");
+
+    let handoff_request: OpenFileRequest =
+      serde_json::from_str(OPEN_HANDOFF_REQUEST).expect("handoff fixture deserializes");
+    assert_eq!(
+      handoff_request.handoff_id.as_deref(),
+      Some("cccccccc-cccc-4ccc-8ccc-cccccccccccc")
+    );
   }
 
   #[test]

--- a/apps/desktop/src/shared/rpc.gen.ts
+++ b/apps/desktop/src/shared/rpc.gen.ts
@@ -1,0 +1,35 @@
+// Generated from apps/desktop/src-tauri/src/types.rs.
+// Regenerate from the repository root with `bun --filter @stll/desktop rpc:generate`.
+// Do not edit by hand.
+
+export type AppSnapshot = { bridgePort: number,
+/**
+ * See [`BRIDGE_VERSION`].
+ */
+bridgeVersion: number,
+/**
+ * See [`BRIDGE_CAPABILITIES`].
+ */
+capabilities: string[], linkedAccount: LinkedAccountSnapshot | null, notificationPreferences: DesktopNotificationPreferences, runningSince: string, sessions: SessionSnapshot[], trustedSelfHostConnections: TrustedSelfHostConnection[], update: DesktopUpdateSnapshot, };
+
+export type DesktopEditFileType = "docx" | "xlsx" | "pptx";
+
+export type DesktopNotificationPreferences = { documentReady: boolean, revisionCreated: boolean, syncIssues: boolean, };
+
+export type DesktopUpdateSnapshot = { baseUrl: string | null, channel: string | null, currentHash: string | null, currentVersion: string | null, lastCheckedAt: string | null, latestHash: string | null, latestVersion: string | null, status: DesktopUpdateStatus, statusMessage: string, updateAvailable: boolean, updateReady: boolean, };
+
+export type DesktopUpdateStatus = "idle" | "checking" | "available" | "downloading" | "ready" | "applying" | "up_to_date" | "error" | "disabled";
+
+export type LinkedAccountSnapshot = { email: string, name: string | null, verifiedAt: string, };
+
+export type OpenFileRemoteSession = { baseVersionNumber: number, downloadUrl: string, fileType: DesktopEditFileType, fileName: string, lastCheckpointAt: string | null, resumedFromCheckpoint: boolean, sessionId: string, sessionToken: string, tookOverExistingSession: boolean, };
+
+export type OpenFileRequest = { apiBaseUrl: string, entityId: string, handoffId?: string | null, linkedAccount: LinkedAccountSnapshot | null, propertyId: string, remoteSession: OpenFileRemoteSession, workspaceId: string, };
+
+export type OpenFileResponse = { alreadyOpen: boolean, filePath: string, sessionId: string, };
+
+export type SessionSnapshot = { baseVersionNumber: number, entityId: string, fileType: DesktopEditFileType, fileName: string, filePath: string, id: string, lastError: string | null, lastCheckpointAt: string | null, pendingFinalize: boolean, propertyId: string, status: SessionStatus, takeoverDetected: boolean, workspaceId: string, };
+
+export type SessionStatus = "opening" | "ready" | "syncing" | "finalizing" | "error";
+
+export type TrustedSelfHostConnection = { apiBaseUrl: string, trustedAt: string, webOrigin: string, };

--- a/apps/desktop/src/shared/rpc.ts
+++ b/apps/desktop/src/shared/rpc.ts
@@ -2,126 +2,28 @@ import {
   DESKTOP_EDIT_FILE_TYPE_CONFIG,
   isDesktopEditFileType,
 } from "@stll/api-contract";
-import type { DesktopEditFileType } from "@stll/api-contract";
+
+import type { AppSnapshot } from "./rpc.gen";
 
 export const DEFAULT_STELLA_DESKTOP_BRIDGE_PORT = 45_901;
 export const DOCX_MIME_TYPE = DESKTOP_EDIT_FILE_TYPE_CONFIG.docx.mimeType;
 export const XLSX_MIME_TYPE = DESKTOP_EDIT_FILE_TYPE_CONFIG.xlsx.mimeType;
 export const PPTX_MIME_TYPE = DESKTOP_EDIT_FILE_TYPE_CONFIG.pptx.mimeType;
 export { DESKTOP_EDIT_FILE_TYPE_CONFIG as DESKTOP_EDIT_FILE_TYPES };
-export type { DesktopEditFileType } from "@stll/api-contract";
-
-export type SessionStatus =
-  | "opening"
-  | "ready"
-  | "syncing"
-  | "finalizing"
-  | "error";
-
-export type SessionSnapshot = {
-  baseVersionNumber: number;
-  entityId: string;
-  fileType: DesktopEditFileType;
-  fileName: string;
-  filePath: string;
-  id: string;
-  lastError: string | null;
-  lastCheckpointAt: string | null;
-  pendingFinalize: boolean;
-  propertyId: string;
-  status: SessionStatus;
-  takeoverDetected: boolean;
-  workspaceId: string;
-};
-
-export type DesktopNotificationPreferences = {
-  documentReady: boolean;
-  revisionCreated: boolean;
-  syncIssues: boolean;
-};
-
-export type LinkedAccountSnapshot = {
-  email: string;
-  name: string | null;
-  verifiedAt: string;
-};
-
-export type OpenFileRemoteSession = {
-  baseVersionNumber: number;
-  downloadUrl: string;
-  fileType: DesktopEditFileType;
-  fileName: string;
-  lastCheckpointAt: string | null;
-  resumedFromCheckpoint: boolean;
-  sessionId: string;
-  sessionToken: string;
-  tookOverExistingSession: boolean;
-};
-
-export type DesktopUpdateSnapshot = {
-  baseUrl: string | null;
-  channel: string | null;
-  currentHash: string | null;
-  currentVersion: string | null;
-  lastCheckedAt: string | null;
-  latestHash: string | null;
-  latestVersion: string | null;
-  status:
-    | "idle"
-    | "checking"
-    | "available"
-    | "downloading"
-    | "ready"
-    | "applying"
-    | "up_to_date"
-    | "error"
-    | "disabled";
-  statusMessage: string;
-  updateAvailable: boolean;
-  updateReady: boolean;
-};
-
-export type TrustedSelfHostConnection = {
-  apiBaseUrl: string;
-  trustedAt: string;
-  webOrigin: string;
-};
-
-export type AppSnapshot = {
-  bridgePort: number;
-  /**
-   * Monotonic bridge contract revision. Web code gates on a minimum
-   * revision and required capability instead of coupling to the
-   * desktop's literal app version.
-   */
-  bridgeVersion: number;
-  /**
-   * Versioned contracts advertised by the desktop. Breaking semantics
-   * receive a new capability id.
-   */
-  capabilities: string[];
-  linkedAccount: LinkedAccountSnapshot | null;
-  notificationPreferences: DesktopNotificationPreferences;
-  runningSince: string;
-  sessions: SessionSnapshot[];
-  trustedSelfHostConnections: TrustedSelfHostConnection[];
-  update: DesktopUpdateSnapshot;
-};
-
-export type OpenFileRequest = {
-  apiBaseUrl: string;
-  entityId: string;
-  linkedAccount: LinkedAccountSnapshot | null;
-  propertyId: string;
-  remoteSession: OpenFileRemoteSession;
-  workspaceId: string;
-};
-
-export type OpenFileResponse = {
-  alreadyOpen: boolean;
-  filePath: string;
-  sessionId: string;
-};
+export type {
+  AppSnapshot,
+  DesktopEditFileType,
+  DesktopNotificationPreferences,
+  DesktopUpdateSnapshot,
+  DesktopUpdateStatus,
+  LinkedAccountSnapshot,
+  OpenFileRemoteSession,
+  OpenFileRequest,
+  OpenFileResponse,
+  SessionSnapshot,
+  SessionStatus,
+  TrustedSelfHostConnection,
+} from "./rpc.gen";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);

--- a/apps/desktop/tests/rpc.golden.test.ts
+++ b/apps/desktop/tests/rpc.golden.test.ts
@@ -18,11 +18,9 @@ import {
 
 // Golden-fixture contract for the desktop bridge RPC surface.
 //
-// `rpc.ts` (TypeScript) and `src-tauri/src/types.rs` (Rust serde) each
-// own a copy of every message that crosses the web <-> desktop bridge.
-// The bug class this suite guards against is silent drift between those
-// two definitions: a field renamed on one side, a `rename_all` dropped,
-// an optional made required, a new field added to one side only.
+// Rust serde DTOs generate the TypeScript declarations for every message
+// crossing the web <-> desktop bridge. These fixtures protect the stable wire
+// representation independently of that generation path.
 //
 // The fixtures under `apps/desktop/fixtures/rpc/*.json` are the single
 // shared source of truth. This test asserts the TypeScript side:
@@ -36,9 +34,9 @@ import {
 //   4. the shipped `isAppSnapshot` runtime guard accepts the canonical
 //      snapshot and rejects structurally broken variants.
 //
-// The Rust counterpart (`types.rs` `mod fixture_tests`) deserializes the
-// same files via serde, so a change on either side that is not mirrored
-// in the fixtures fails one of the two suites.
+// The Rust counterpart (`types.rs` `mod fixture_tests`) round-trips the same
+// files through serde. The separate codegen test compares exact generated
+// bytes, so neither wire drift nor a stale declaration can land silently.
 
 const FIXTURE_DIR = path.join(import.meta.dir, "../fixtures/rpc");
 
@@ -48,13 +46,15 @@ const readFixture = (name: string): unknown =>
 // Fixtures are hand-authored JSON objects (never arrays or primitives); this
 // guard narrows the parsed `unknown` before mutating tests spread/drop keys,
 // rather than asserting the shape blind.
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 const readFixtureRecord = (name: string): Record<string, unknown> => {
   const parsed = readFixture(name);
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+  if (!isRecord(parsed)) {
     throw new TypeError(`fixture ${name} is not a JSON object`);
   }
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowed above: plain JSON object, not null/array
-  return parsed as Record<string, unknown>;
+  return parsed;
 };
 
 const collectKeys = (value: unknown, keys: string[] = []): string[] => {
@@ -80,7 +80,7 @@ const CAMEL_CASE = /^[a-z][a-zA-Z0-9]*$/u;
 // runtime `toEqual` is the on-disk half.
 const appSnapshot = {
   bridgePort: 45_901,
-  bridgeVersion: 9,
+  bridgeVersion: 10,
   capabilities: ["office-edit.v1", "self-host.connect"],
   linkedAccount: {
     email: "counsel@example.com",
@@ -195,6 +195,11 @@ const openDocxResponse = {
   sessionId: "e8400e29-1d4a-4716-8a3a-2c83de7ab2e6",
 } as const satisfies OpenFileResponse;
 
+const openHandoffRequest = {
+  ...openDocxRequest,
+  handoffId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+} as const satisfies OpenFileRequest;
+
 const openXlsxRequest = {
   apiBaseUrl: "https://api.example.com",
   entityId: "11111111-1111-4111-8111-111111111111",
@@ -278,6 +283,11 @@ const cases: { expected: unknown; file: string; name: string }[] = [
     expected: openDocxResponse,
     file: "open-docx-response.json",
     name: "OpenFileResponse",
+  },
+  {
+    expected: openHandoffRequest,
+    file: "open-handoff-request.json",
+    name: "OpenFileRequest (handoff)",
   },
   {
     expected: openXlsxRequest,

--- a/scripts/check-bridge-version.sh
+++ b/scripts/check-bridge-version.sh
@@ -33,6 +33,7 @@ bridge_files=(
   apps/desktop/src-tauri/src/types.rs
   apps/desktop/src/shared/rpc.gen.ts
   apps/desktop/src/shared/rpc.ts
+  packages/api-contract/src/desktop-edit-file-types.ts
 )
 
 bridge_changed=false
@@ -97,6 +98,7 @@ the web app talks to has shifted:
   - apps/desktop/src-tauri/src/types.rs
   - apps/desktop/src/shared/rpc.gen.ts
   - apps/desktop/src/shared/rpc.ts
+  - packages/api-contract/src/desktop-edit-file-types.ts
 
 Bump BRIDGE_VERSION in $types_path to a value greater than $old_version
 (and add a string to BRIDGE_CAPABILITIES if you added a new endpoint)

--- a/scripts/check-bridge-version.sh
+++ b/scripts/check-bridge-version.sh
@@ -31,6 +31,7 @@ bridge_files=(
   apps/desktop/src-tauri/src/bridge.rs
   apps/desktop/src-tauri/src/commands.rs
   apps/desktop/src-tauri/src/types.rs
+  apps/desktop/src/shared/rpc.gen.ts
   apps/desktop/src/shared/rpc.ts
 )
 
@@ -94,6 +95,7 @@ the web app talks to has shifted:
   - apps/desktop/src-tauri/src/bridge.rs
   - apps/desktop/src-tauri/src/commands.rs
   - apps/desktop/src-tauri/src/types.rs
+  - apps/desktop/src/shared/rpc.gen.ts
   - apps/desktop/src/shared/rpc.ts
 
 Bump BRIDGE_VERSION in $types_path to a value greater than $old_version

--- a/scripts/check-bridge-version.test.sh
+++ b/scripts/check-bridge-version.test.sh
@@ -38,6 +38,7 @@ setup_repo() {
   printf '%s\n' "$TYPES_RS" > apps/desktop/src-tauri/src/types.rs
   echo "// initial bridge" > apps/desktop/src-tauri/src/bridge.rs
   echo "// initial commands" > apps/desktop/src-tauri/src/commands.rs
+  echo "// initial generated rpc" > apps/desktop/src/shared/rpc.gen.ts
   echo "// initial rpc" > apps/desktop/src/shared/rpc.ts
   echo "// other" > apps/desktop/src/unrelated.ts
   git add -A
@@ -118,27 +119,33 @@ echo "// new field" >> apps/desktop/src/shared/rpc.ts
 git commit -aq -m "rpc field"
 run_case "rpc.ts changed, version unchanged → 1" 1
 
-# 6. bridge.rs changed AND version bumped → OK.
+# 6. rpc.gen.ts changed, version not bumped → FAIL.
+setup_repo
+echo "// generated field" >> apps/desktop/src/shared/rpc.gen.ts
+git commit -aq -m "generated rpc field"
+run_case "rpc.gen.ts changed, version unchanged → 1" 1
+
+# 7. bridge.rs changed AND version bumped → OK.
 setup_repo
 echo "// new endpoint" >> apps/desktop/src-tauri/src/bridge.rs
 bump_version
 git commit -aq -m "add bridge route + bump"
 run_case "bridge.rs + version both changed → 0" 0
 
-# 7. rpc.ts changed AND version bumped → OK.
+# 8. rpc.ts changed AND version bumped → OK.
 setup_repo
 echo "// new field" >> apps/desktop/src/shared/rpc.ts
 bump_version
 git commit -aq -m "rpc field + bump"
 run_case "rpc.ts + version both changed → 0" 0
 
-# 8. Only version bumped (no bridge files touched) → OK.
+# 9. Only version bumped (no bridge files touched) → OK.
 setup_repo
 bump_version
 git commit -aq -m "bump only"
 run_case "only version changed → 0" 0
 
-# 9. bridge.rs changed but only a non-version line in types.rs
+# 10. bridge.rs changed but only a non-version line in types.rs
 #    edited → FAIL (catches "I touched types.rs but not the
 #    version line").
 setup_repo
@@ -147,7 +154,7 @@ echo "// stray comment" >> apps/desktop/src-tauri/src/types.rs
 git commit -aq -m "bridge + non-version types edit"
 run_case "bridge + non-version types edit → 1" 1
 
-# 10. Multiple bridge files changed AND version bumped → OK.
+# 11. Multiple bridge files changed AND version bumped → OK.
 setup_repo
 echo "// new endpoint" >> apps/desktop/src-tauri/src/bridge.rs
 echo "// new field" >> apps/desktop/src/shared/rpc.ts
@@ -155,7 +162,7 @@ bump_version
 git commit -aq -m "multi-file bridge change + bump"
 run_case "multiple bridge files + version → 0" 0
 
-# 11. bridge.rs changed AND BRIDGE_VERSION line edited but integer
+# 12. bridge.rs changed AND BRIDGE_VERSION line edited but integer
 #     unchanged (e.g. trailing comment) → FAIL. Old line-diff
 #     check would have passed this; strict-increase must reject.
 setup_repo
@@ -164,7 +171,7 @@ reformat_version_line
 git commit -aq -m "bridge + comment-only edit on version line"
 run_case "bridge + comment-only version line edit → 1" 1
 
-# 12. bridge.rs changed AND BRIDGE_VERSION decreased → FAIL.
+# 13. bridge.rs changed AND BRIDGE_VERSION decreased → FAIL.
 #     A negative bump is never a valid compatibility signal.
 setup_repo
 echo "// new endpoint" >> apps/desktop/src-tauri/src/bridge.rs
@@ -172,7 +179,7 @@ unbump_version
 git commit -aq -m "bridge + version decrease"
 run_case "bridge + version decreased → 1" 1
 
-# 13. Only a non-version line in types.rs changed (no bump) → FAIL.
+# 14. Only a non-version line in types.rs changed (no bump) → FAIL.
 #     types.rs is part of the wire surface (AppSnapshot lives
 #     there); a change to its contents must force a bump just
 #     like the other bridge files.
@@ -181,7 +188,7 @@ echo "// new struct field" >> apps/desktop/src-tauri/src/types.rs
 git commit -aq -m "types.rs edit, no version bump"
 run_case "types.rs edit, no bump → 1" 1
 
-# 14. types.rs serialized-shape change AND version bumped → OK.
+# 15. types.rs serialized-shape change AND version bumped → OK.
 setup_repo
 sed -i.bak 's|BRIDGE_VERSION: u32 = 1;|BRIDGE_VERSION: u32 = 2;\npub struct Extra {}|' \
   apps/desktop/src-tauri/src/types.rs

--- a/scripts/check-bridge-version.test.sh
+++ b/scripts/check-bridge-version.test.sh
@@ -34,12 +34,13 @@ setup_repo() {
   git init -q -b main
   git config user.email test@example.invalid
   git config user.name test
-  mkdir -p apps/desktop/src-tauri/src apps/desktop/src/shared
+  mkdir -p apps/desktop/src-tauri/src apps/desktop/src/shared packages/api-contract/src
   printf '%s\n' "$TYPES_RS" > apps/desktop/src-tauri/src/types.rs
   echo "// initial bridge" > apps/desktop/src-tauri/src/bridge.rs
   echo "// initial commands" > apps/desktop/src-tauri/src/commands.rs
   echo "// initial generated rpc" > apps/desktop/src/shared/rpc.gen.ts
   echo "// initial rpc" > apps/desktop/src/shared/rpc.ts
+  echo "// initial shared file types" > packages/api-contract/src/desktop-edit-file-types.ts
   echo "// other" > apps/desktop/src/unrelated.ts
   git add -A
   git commit -q -m "initial"
@@ -125,27 +126,34 @@ echo "// generated field" >> apps/desktop/src/shared/rpc.gen.ts
 git commit -aq -m "generated rpc field"
 run_case "rpc.gen.ts changed, version unchanged → 1" 1
 
-# 7. bridge.rs changed AND version bumped → OK.
+# 7. packages/api-contract/src/desktop-edit-file-types.ts changed,
+#    version not bumped → FAIL.
+setup_repo
+echo "// add file type" >> packages/api-contract/src/desktop-edit-file-types.ts
+git commit -aq -m "shared desktop file types"
+run_case "shared desktop file types changed, version unchanged → 1" 1
+
+# 8. bridge.rs changed AND version bumped → OK.
 setup_repo
 echo "// new endpoint" >> apps/desktop/src-tauri/src/bridge.rs
 bump_version
 git commit -aq -m "add bridge route + bump"
 run_case "bridge.rs + version both changed → 0" 0
 
-# 8. rpc.ts changed AND version bumped → OK.
+# 9. rpc.ts changed AND version bumped → OK.
 setup_repo
 echo "// new field" >> apps/desktop/src/shared/rpc.ts
 bump_version
 git commit -aq -m "rpc field + bump"
 run_case "rpc.ts + version both changed → 0" 0
 
-# 9. Only version bumped (no bridge files touched) → OK.
+# 10. Only version bumped (no bridge files touched) → OK.
 setup_repo
 bump_version
 git commit -aq -m "bump only"
 run_case "only version changed → 0" 0
 
-# 10. bridge.rs changed but only a non-version line in types.rs
+# 11. bridge.rs changed but only a non-version line in types.rs
 #    edited → FAIL (catches "I touched types.rs but not the
 #    version line").
 setup_repo
@@ -154,7 +162,7 @@ echo "// stray comment" >> apps/desktop/src-tauri/src/types.rs
 git commit -aq -m "bridge + non-version types edit"
 run_case "bridge + non-version types edit → 1" 1
 
-# 11. Multiple bridge files changed AND version bumped → OK.
+# 12. Multiple bridge files changed AND version bumped → OK.
 setup_repo
 echo "// new endpoint" >> apps/desktop/src-tauri/src/bridge.rs
 echo "// new field" >> apps/desktop/src/shared/rpc.ts
@@ -162,7 +170,7 @@ bump_version
 git commit -aq -m "multi-file bridge change + bump"
 run_case "multiple bridge files + version → 0" 0
 
-# 12. bridge.rs changed AND BRIDGE_VERSION line edited but integer
+# 13. bridge.rs changed AND BRIDGE_VERSION line edited but integer
 #     unchanged (e.g. trailing comment) → FAIL. Old line-diff
 #     check would have passed this; strict-increase must reject.
 setup_repo
@@ -171,7 +179,7 @@ reformat_version_line
 git commit -aq -m "bridge + comment-only edit on version line"
 run_case "bridge + comment-only version line edit → 1" 1
 
-# 13. bridge.rs changed AND BRIDGE_VERSION decreased → FAIL.
+# 14. bridge.rs changed AND BRIDGE_VERSION decreased → FAIL.
 #     A negative bump is never a valid compatibility signal.
 setup_repo
 echo "// new endpoint" >> apps/desktop/src-tauri/src/bridge.rs
@@ -179,7 +187,7 @@ unbump_version
 git commit -aq -m "bridge + version decrease"
 run_case "bridge + version decreased → 1" 1
 
-# 14. Only a non-version line in types.rs changed (no bump) → FAIL.
+# 15. Only a non-version line in types.rs changed (no bump) → FAIL.
 #     types.rs is part of the wire surface (AppSnapshot lives
 #     there); a change to its contents must force a bump just
 #     like the other bridge files.
@@ -188,7 +196,7 @@ echo "// new struct field" >> apps/desktop/src-tauri/src/types.rs
 git commit -aq -m "types.rs edit, no version bump"
 run_case "types.rs edit, no bump → 1" 1
 
-# 15. types.rs serialized-shape change AND version bumped → OK.
+# 16. types.rs serialized-shape change AND version bumped → OK.
 setup_repo
 sed -i.bak 's|BRIDGE_VERSION: u32 = 1;|BRIDGE_VERSION: u32 = 2;\npub struct Extra {}|' \
   apps/desktop/src-tauri/src/types.rs

--- a/scripts/detect-tauri-rust-changes.sh
+++ b/scripts/detect-tauri-rust-changes.sh
@@ -8,7 +8,7 @@ desktop_rust_checks_required=false
 
 for file in "$@"; do
   case "$file" in
-    apps/desktop/src-tauri/*|apps/desktop/src/i18n/langs/*)
+    apps/desktop/src-tauri/*|apps/desktop/src/i18n/langs/*|apps/desktop/src/shared/rpc.gen.ts)
       desktop_rust_checks_required=true
       break
       ;;

--- a/scripts/detect-tauri-rust-changes.sh
+++ b/scripts/detect-tauri-rust-changes.sh
@@ -8,7 +8,7 @@ desktop_rust_checks_required=false
 
 for file in "$@"; do
   case "$file" in
-    apps/desktop/src-tauri/*|apps/desktop/src/i18n/langs/*|apps/desktop/src/shared/rpc.gen.ts)
+    apps/desktop/src-tauri/*|apps/desktop/src/i18n/langs/*|apps/desktop/src/shared/rpc.gen.ts|packages/api-contract/src/desktop-edit-file-types.ts)
       desktop_rust_checks_required=true
       break
       ;;

--- a/scripts/detect-tauri-rust-changes.test.sh
+++ b/scripts/detect-tauri-rust-changes.test.sh
@@ -18,6 +18,7 @@ assert_detection() {
 assert_detection true apps/desktop/src-tauri/src/types.rs
 assert_detection true apps/desktop/src/i18n/langs/en.json
 assert_detection true apps/desktop/src/shared/rpc.gen.ts
+assert_detection true packages/api-contract/src/desktop-edit-file-types.ts
 assert_detection false apps/desktop/src/shared/rpc.ts
 assert_detection false apps/web/src/lib/desktop-bridge.ts
 

--- a/scripts/detect-tauri-rust-changes.test.sh
+++ b/scripts/detect-tauri-rust-changes.test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+detector="$script_dir/detect-tauri-rust-changes.sh"
+
+assert_detection() {
+  local expected="$1"
+  shift
+  local actual
+  actual=$(bash "$detector" "$@")
+  if [[ "$actual" != "$expected" ]]; then
+    echo "Expected $expected for $*, received $actual" >&2
+    exit 1
+  fi
+}
+
+assert_detection true apps/desktop/src-tauri/src/types.rs
+assert_detection true apps/desktop/src/i18n/langs/en.json
+assert_detection true apps/desktop/src/shared/rpc.gen.ts
+assert_detection false apps/desktop/src/shared/rpc.ts
+assert_detection false apps/web/src/lib/desktop-bridge.ts
+
+echo "Desktop Rust change detector tests passed."

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -238,6 +238,8 @@ run_step "Marketing recording verification self-test" bun test \
 run_step "Environment tooling self-test" bun test scripts/env-tool.test.ts
 run_step "Migration ordering self-test" bun test scripts/check-migration-order.test.ts
 run_step "Merge-bar gate self-test" bun test scripts/merge-bar.test.ts
+run_step "Desktop Rust change detector self-test" bash \
+  scripts/detect-tauri-rust-changes.test.sh
 run_step "Self-host production contract self-test" bun test \
   scripts/selfhost-contract.test.ts
 run_step "Self-host production contract" bun run selfhost:check


### PR DESCRIPTION
## Summary

- derive the desktop bridge TypeScript contract recursively from Rust serde DTOs
- keep exact generated-output and shared golden-fixture guards, including both handoff forms
- route generated contract changes through desktop Rust CI and bump the bridge contract revision

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent desktop RPC data exchange, including support for open handoff requests and responses.
  - Desktop integration types are now synchronised automatically between the app and its native layer.

- **Bug Fixes**
  - Improved update-menu behaviour so “Check for updates” is unavailable while an update is in progress.
  - Strengthened safeguards that detect and validate desktop integration changes before release.
  - Expanded collaboration end-to-end coverage to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->