### PR TITLE
fix(api): reserve the Anthropic thinking budget in max_tokens

### DIFF
--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -843,10 +843,19 @@ describe("Anthropic extended-thinking budgets", () => {
             }),
           };
 
-          const budget =
-            modelOptions.thinking?.type === "enabled"
-              ? modelOptions.thinking.budget_tokens
-              : 0;
+          let budget = 0;
+          if (modelOptions.thinking?.type === "enabled") {
+            const currentThinking: object = modelOptions.thinking;
+            if (
+              !("budget_tokens" in currentThinking) ||
+              typeof currentThinking["budget_tokens"] !== "number"
+            ) {
+              throw new TypeError(
+                "Expected enabled Anthropic thinking to carry a token budget",
+              );
+            }
+            budget = currentThinking["budget_tokens"];
+          }
           expect(merged["max_tokens"]).toBeGreaterThan(budget);
         }
       }

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -10,6 +10,12 @@ import {
 } from "bun:test";
 import * as v from "valibot";
 
+import {
+  BYOK_MODEL_OPTIONS,
+  MODEL_ROLES,
+  REASONING_EFFORTS,
+} from "@stll/ai-catalog";
+
 import type { CachingDecision } from "@/api/lib/ai-config";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
@@ -319,6 +325,37 @@ describe("TanStack AI structured output generation", () => {
     expect(options).toEqual({
       max_tokens: 1000,
       thinking: { type: "adaptive" },
+    });
+  });
+
+  test("reserves the Anthropic thinking budget on top of the output allowance", () => {
+    // The budget form spends reasoning and visible output from one
+    // `max_tokens`, and `budget_tokens` must stay below it. The caller's
+    // allowance sizes the reply alone, so the reservation is added to it:
+    // forwarding the allowance on its own both starves the reply and, below
+    // the budget, describes a request Anthropic cannot serve.
+    // SAFETY: mergeGenerationOptions only reads provider/modelOptions/modelId.
+    // The adapter is irrelevant for this pure option-merge test.
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion -- focused pure helper test
+    const model = {
+      adapter: {},
+      keySource: "instance",
+      modelId: "claude-haiku-4-5-20251001",
+      modelOptions: { thinking: { type: "enabled", budget_tokens: 10_000 } },
+      provider: "anthropic",
+    } as ResolvedTanStackTextModel;
+
+    const options = mergeGenerationOptions({
+      caching: noCaching,
+      maxOutputTokens: 1800,
+      model,
+      serviceTier: "standard",
+      temperature: undefined,
+    });
+
+    expect(options).toEqual({
+      max_tokens: 11_800,
+      thinking: { type: "enabled", budget_tokens: 10_000 },
     });
   });
 
@@ -759,6 +796,61 @@ describe("TanStack AI text generation", () => {
       message: "OpenAI rate limit exceeded.",
       status: 502,
     });
+  });
+});
+
+describe("Anthropic extended-thinking budgets", () => {
+  // Two modules decide the halves of one constraint: the role builder picks
+  // `thinking.budget_tokens`, the merge picks `max_tokens`, and a budget that
+  // reaches `max_tokens` describes a request Anthropic cannot serve. Walking
+  // every offered model, role, and effort binds them, so a model added to the
+  // budget form cannot drift back past the smallest allowance a caller asks
+  // for.
+  const SMALLEST_CALLER_ALLOWANCE = 1;
+
+  test("keeps every emitted budget under the merged max_tokens", () => {
+    for (const modelId of BYOK_MODEL_OPTIONS.anthropic) {
+      for (const role of MODEL_ROLES) {
+        for (const reasoningEffort of [undefined, ...REASONING_EFFORTS]) {
+          const modelOptions = realTanStackAIModels.tanStackModelOptionsForRole(
+            {
+              modelId,
+              organizationId: null,
+              provider: "anthropic",
+              reasoningEffort,
+              role,
+            },
+          );
+          // SAFETY: mergeGenerationOptions only reads
+          // provider/modelOptions/modelId. The adapter is irrelevant for this
+          // pure option-merge invariant.
+          // eslint-disable-next-line typescript/no-unsafe-type-assertion -- focused pure helper test
+          const model = {
+            adapter: {},
+            keySource: "byok",
+            modelId,
+            modelOptions,
+            provider: "anthropic",
+          } as ResolvedTanStackTextModel;
+
+          const merged: Record<string, unknown> = {
+            ...mergeGenerationOptions({
+              caching: noCaching,
+              maxOutputTokens: SMALLEST_CALLER_ALLOWANCE,
+              model,
+              serviceTier: "standard",
+              temperature: undefined,
+            }),
+          };
+
+          const budget =
+            modelOptions.thinking?.type === "enabled"
+              ? modelOptions.thinking.budget_tokens
+              : 0;
+          expect(merged["max_tokens"]).toBeGreaterThan(budget);
+        }
+      }
+    }
   });
 });
 

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -726,6 +726,26 @@ export const systemPromptsPatch = ({
   };
 };
 
+type AnthropicThinkingOption = Extract<
+  ResolvedTanStackTextModel,
+  { provider: "anthropic" }
+>["modelOptions"]["thinking"];
+
+/**
+ * Extended-thinking tokens an Anthropic request must carry on top of its
+ * output allowance.
+ *
+ * `max_tokens` bounds reasoning and visible output together, and the budget
+ * form is only valid while `budget_tokens` stays below it. Callers size
+ * `maxOutputTokens` for the reply alone, so the reservation is added to that
+ * allowance instead of being taken out of it. The adaptive form reserves
+ * nothing: it declares no budget, and the model sizes its own reasoning
+ * inside `max_tokens`.
+ */
+const anthropicThinkingReservation = (
+  thinking: AnthropicThinkingOption,
+): number => (thinking?.type === "enabled" ? thinking.budget_tokens : 0);
+
 export const mergeGenerationOptions = ({
   caching,
   model,
@@ -772,7 +792,11 @@ export const mergeGenerationOptions = ({
         ...model.modelOptions,
         ...(maxOutputTokens === undefined
           ? {}
-          : { max_tokens: maxOutputTokens }),
+          : {
+              max_tokens:
+                maxOutputTokens +
+                anthropicThinkingReservation(model.modelOptions.thinking),
+            }),
       };
       return { ...anthropicOptions, ...temperatureOverride };
     }

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -7,6 +7,7 @@ import type {
   SystemPrompt,
 } from "@tanstack/ai";
 import type { OpenAITextProviderOptions } from "@tanstack/ai-openai";
+import { panic } from "better-result";
 import * as v from "valibot";
 
 import type { ModelRole, ReasoningEffort } from "@stll/ai-catalog";
@@ -744,7 +745,22 @@ type AnthropicThinkingOption = Extract<
  */
 const anthropicThinkingReservation = (
   thinking: AnthropicThinkingOption,
-): number => (thinking?.type === "enabled" ? thinking.budget_tokens : 0);
+): number => {
+  if (thinking?.type !== "enabled") {
+    return 0;
+  }
+  // The SDK deprecates this field for newer adaptive-thinking models, but its
+  // enabled branch still requires it for older models. Widen before checking
+  // the external option shape so using that supported branch needs no waiver.
+  const enabledThinking: object = thinking;
+  if (
+    !("budget_tokens" in enabledThinking) ||
+    typeof enabledThinking["budget_tokens"] !== "number"
+  ) {
+    return panic("Enabled Anthropic thinking requires a numeric token budget");
+  }
+  return enabledThinking["budget_tokens"];
+};
 
 export const mergeGenerationOptions = ({
   caching,


### PR DESCRIPTION
## Proposed change

`mergeGenerationOptions` passes a caller's `maxOutputTokens` straight through as Anthropic's `max_tokens`. Under the budget form of extended thinking (`thinking: { type: "enabled", budget_tokens }`) that field bounds reasoning and visible output together; the adapter's own type documents the constraint as "must be ≥1024 and less than max_tokens".

`anthropicThinkingForModel` emits that form for every Anthropic model outside `ANTHROPIC_ADAPTIVE_THINKING_MODELS`, reserving `ANTHROPIC_LEGACY_THINKING_BUDGET_TOKENS` (10,000). Of the offered ids that is `claude-haiku-4-5-20251001`, which an org can pin to the reasoning role; env overrides can name others. Call sites size `maxOutputTokens` for the reply alone: a compaction summary asks for 1,800 (`MAX_SUMMARY_OUTPUT_TOKENS`), a thread recap 256, autocomplete 96. Merged with the budget form, each describes a request whose reasoning reservation is larger than the whole allowance.

The merge now adds the emitted budget to the caller's allowance, so the reply keeps the tokens it asked for and the budget stays under `max_tokens`. The adaptive form is untouched: it declares no budget, and the model sizes its own reasoning inside `max_tokens`.

The role builder and the merge decide the two halves of this constraint in modules that never see each other, so the second test walks every offered Anthropic model, role, and reasoning effort and asserts the merged `max_tokens` exceeds whatever budget the builder emitted. Both new tests fail against the previous merge and pass against this one.

## Checklist

- [x] **BUILD ASSURANCE** | Code builds correctly and without any errors or warnings.
- [x] **TESTING** | `bun --filter @stll/api typecheck`, `bun run lint`, `bun run format`, plus the `tanstack-ai-generate`, `tanstack-ai-models`, `ai-error`, `bilingual/ai` and `ai-provider-canary` suites.
- [ ] DARK MODE SUPPORT | Not applicable: no user-facing surface, this is a provider request shape in `apps/api`.
- [ ] ISSUE LINKED | No issue.
- [ ] SCREENSHOT INCLUDED | Not applicable.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XNZQiBp4NLtLz5RFYpjh4b)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Anthropic extended-thinking requests by reserving sufficient output capacity when fixed thinking budgets are enabled.
  * Adaptive and disabled thinking modes continue to avoid unnecessary token reservations.
  * Ensured generated requests remain within valid token limits across supported models, roles and reasoning settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->