### PR TITLE
chore: version workspace shell and chat packages

### DIFF
--- a/.changeset/bright-shells-fold.md
+++ b/.changeset/bright-shells-fold.md
@@ -1,5 +1,0 @@
----
-"@stll/ui": minor
----
-
-Make responsive navigation ownership explicit in `WorkspaceShell`, with a shell-managed compact sheet contract for hosts that do not already provide responsive navigation.

--- a/.changeset/publish-chat-primitives.md
+++ b/.changeset/publish-chat-primitives.md
@@ -1,6 +1,0 @@
----
-"@stll/chat": minor
----
-
-Publish typed chat composer, stream, model selector, and runtime primitives for
-downstream shells.

--- a/packages/chat/CHANGELOG.md
+++ b/packages/chat/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @stll/chat
+
+## 0.1.0
+
+### Minor Changes
+
+- [#2599](https://github.com/stella/stella/pull/2599) [`6d9e479`](https://github.com/stella/stella/commit/6d9e479878fff8eb25c633a397c9cc9e59a65656) Thanks [@jan-kubica](https://github.com/jan-kubica)! - Publish typed chat composer, stream, model selector, and runtime primitives for
+  downstream shells.
+
+### Patch Changes
+
+- Updated dependencies [[`c56a0c7`](https://github.com/stella/stella/commit/c56a0c7e97ef276b1353a7621e4658b2d9f2ada0)]:
+  - @stll/ui@0.11.0

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stll/chat",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Typed React chat composer, message stream, model selector, and transport runtime primitives.",
   "keywords": [
     "ai",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @stll/ui
 
+## 0.11.0
+
+### Minor Changes
+
+- [#2596](https://github.com/stella/stella/pull/2596) [`c56a0c7`](https://github.com/stella/stella/commit/c56a0c7e97ef276b1353a7621e4658b2d9f2ada0) Thanks [@jan-kubica](https://github.com/jan-kubica)! - Make responsive navigation ownership explicit in `WorkspaceShell`, with a shell-managed compact sheet contract for hosts that do not already provide responsive navigation.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stll/ui",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Stella's design system: bidi-aware React primitives built on Base UI, the dockable inspector pane, and the Tailwind v4 theme they are styled with.",
   "keywords": [
     "base-ui",

--- a/packages/workspace-ui/CHANGELOG.md
+++ b/packages/workspace-ui/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @stll/workspace-ui
 
+## 0.4.3
+
+### Patch Changes
+
+- Updated dependencies [[`c56a0c7`](https://github.com/stella/stella/commit/c56a0c7e97ef276b1353a7621e4658b2d9f2ada0)]:
+  - @stll/ui@0.11.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/workspace-ui/package.json
+++ b/packages/workspace-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stll/workspace-ui",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Reusable workspace presentation components and view helpers for Stella.",
   "keywords": [
     "calculations",


### PR DESCRIPTION
Apply the pending Changesets releases for the responsive workspace shell and reusable chat package.

Versions: `@stll/ui@0.11.0`, `@stll/workspace-ui@0.4.3`, and `@stll/chat@0.1.0`. Generated manifests and changelogs pass focused formatting, diff, and staged-secret checks.