### PR TITLE
fix: synchronize released workspace versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -564,7 +564,7 @@
     },
     "packages/chat": {
       "name": "@stll/chat",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@stll/ai-catalog": "workspace:^",
         "@stll/ui": "workspace:^",
@@ -844,7 +844,7 @@
     },
     "packages/ui": {
       "name": "@stll/ui",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "better-result": "catalog:",
         "class-variance-authority": "^0.7.1",
@@ -898,7 +898,7 @@
     },
     "packages/workspace-ui": {
       "name": "@stll/workspace-ui",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@stll/calculations": "workspace:^",
         "@stll/conditions": "workspace:^",


### PR DESCRIPTION
Synchronize the three newly released workspace self-versions into `bun.lock`. This keeps `workspace:^` dependency ranges correct when Bun packs dependent packages.

The existing lockfile workspace-version guard passes, and dry-run tarballs resolve `@stll/ui` to `^0.11.0`.