### PR TITLE
fix: make the full Files viewport a drop target

### DIFF
--- a/apps/web/e2e/specs/workspace-file-drop.spec.ts
+++ b/apps/web/e2e/specs/workspace-file-drop.spec.ts
@@ -104,7 +104,7 @@ test.describe("workspace file drop", () => {
     });
 
     await expect(
-      page.getByRole("button", { exact: true, name: "simple.docx" }),
+      shellContent.getByRole("button", { name: /^simple\.docx\b/u }),
     ).toBeVisible({ timeout: 60_000 });
   });
 });

--- a/apps/web/e2e/specs/workspace-file-drop.spec.ts
+++ b/apps/web/e2e/specs/workspace-file-drop.spec.ts
@@ -1,0 +1,110 @@
+import path from "node:path";
+
+import { apiStatus } from "../helpers/api";
+import { expect, test } from "../helpers/test";
+import {
+  type TestWorkspace,
+  createTestWorkspace,
+  deleteTestWorkspace,
+} from "../helpers/workspace";
+
+const DOCX_PATH = path.resolve(import.meta.dirname, "../fixtures/simple.docx");
+
+test.describe("workspace file drop", () => {
+  let workspace: TestWorkspace | null = null;
+
+  test.beforeEach(async ({ request }) => {
+    workspace = await createTestWorkspace(request, "workspace-file-drop");
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (workspace === null) {
+      return;
+    }
+
+    await deleteTestWorkspace(request, workspace.id);
+    workspace = null;
+  });
+
+  test("the complete Files viewport accepts native file drops", async ({
+    page,
+    request,
+  }) => {
+    test.slow();
+
+    const testWorkspace = workspace;
+    if (testWorkspace === null) {
+      throw new Error("Test workspace was not created");
+    }
+
+    const { cookies } = await request.storageState();
+    await page.context().addCookies(cookies);
+    await expect
+      .poll(
+        async () =>
+          await apiStatus(page.request, `/workspaces/${testWorkspace.id}`),
+        {
+          message: "browser context can read the created workspace",
+          timeout: 10_000,
+        },
+      )
+      .toBe(200);
+
+    await page.goto(`/workspaces/${testWorkspace.id}/${testWorkspace.viewId}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.getByRole("tab", { exact: true, name: "Files" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Upload your first documents" }),
+    ).toBeVisible({ timeout: 30_000 });
+
+    const shellContent = page.locator('[data-slot="workspace-shell-content"]');
+    const dropZone = shellContent.locator(
+      ':scope > [data-slot="file-drop-zone"]',
+    );
+    await expect(dropZone).toHaveCount(1);
+
+    const shellBox = await shellContent.boundingBox();
+    const dropZoneBox = await dropZone.boundingBox();
+    if (shellBox === null || dropZoneBox === null) {
+      throw new Error("Workspace file drop geometry is unavailable");
+    }
+
+    expect(dropZoneBox.x).toBeCloseTo(shellBox.x, 0);
+    expect(dropZoneBox.y).toBeCloseTo(shellBox.y, 0);
+    expect(dropZoneBox.width).toBeCloseTo(shellBox.width, 0);
+    expect(dropZoneBox.height).toBeGreaterThanOrEqual(shellBox.height);
+
+    const cdp = await page.context().newCDPSession(page);
+    const dragData = {
+      dragOperationsMask: 1,
+      files: [DOCX_PATH],
+      items: [],
+    };
+    const x = shellBox.x + shellBox.width / 2;
+    const y = shellBox.y + shellBox.height - 16;
+
+    await cdp.send("Input.dispatchDragEvent", {
+      type: "dragEnter",
+      x,
+      y,
+      data: dragData,
+    });
+    await cdp.send("Input.dispatchDragEvent", {
+      type: "dragOver",
+      x,
+      y,
+      data: dragData,
+    });
+    await cdp.send("Input.dispatchDragEvent", {
+      type: "drop",
+      x,
+      y,
+      data: dragData,
+    });
+
+    await expect(
+      page.getByRole("button", { exact: true, name: "simple.docx" }),
+    ).toBeVisible({ timeout: 60_000 });
+  });
+});

--- a/apps/web/src/components/file-drop-zone.tsx
+++ b/apps/web/src/components/file-drop-zone.tsx
@@ -7,6 +7,19 @@ import { cn } from "@stll/ui/utils";
 import type { DroppedFileTree } from "@/hooks/external-file-drop.logic";
 import { useExternalFileDrop } from "@/hooks/use-external-file-drop";
 
+const FILE_DROP_ZONE_COVERAGE = {
+  CONTENT: "content",
+  VIEWPORT: "viewport",
+} as const;
+
+type FileDropZoneCoverage =
+  (typeof FILE_DROP_ZONE_COVERAGE)[keyof typeof FILE_DROP_ZONE_COVERAGE];
+
+const FILE_DROP_ZONE_COVERAGE_CLASSES = {
+  [FILE_DROP_ZONE_COVERAGE.CONTENT]: "min-h-0",
+  [FILE_DROP_ZONE_COVERAGE.VIEWPORT]: "min-h-full",
+} as const satisfies Record<FileDropZoneCoverage, string>;
+
 type FileDropZoneProps = PropsWithChildren<{
   /** Files dropped onto the zone (folders are flattened to their files). */
   onDrop: (files: File[]) => void;
@@ -14,6 +27,8 @@ type FileDropZoneProps = PropsWithChildren<{
   onDropTree?: (tree: DroppedFileTree) => void;
   /** Overlay copy shown while a drag is over the zone. */
   label: string;
+  /** Whether the zone follows its content or covers its scroll viewport. */
+  coverage: FileDropZoneCoverage;
   enabled?: boolean;
   className?: string;
 }>;
@@ -27,6 +42,7 @@ export const FileDropZone = ({
   onDrop,
   onDropTree,
   label,
+  coverage,
   enabled,
   className,
   children,
@@ -40,7 +56,12 @@ export const FileDropZone = ({
 
   return (
     <div
-      className={cn("relative flex min-h-0 flex-1 flex-col", className)}
+      className={cn(
+        "relative flex flex-1 flex-col",
+        FILE_DROP_ZONE_COVERAGE_CLASSES[coverage],
+        className,
+      )}
+      data-slot="file-drop-zone"
       ref={ref}
     >
       {children}

--- a/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/skill-editor.tsx
@@ -753,6 +753,7 @@ export function SkillEditor({ skillId }: SkillEditorProps) {
           in the inspector. */}
       <FileDropZone
         className="p-3"
+        coverage="content"
         label={t("workspaces.dropToUploadFiles")}
         onDrop={(files) => {
           handleUploadFiles(files);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/workspace-drop-zone.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/workspace-drop-zone.tsx
@@ -36,6 +36,7 @@ export const WorkspaceDropZone = ({
 
   return (
     <FileDropZone
+      coverage="viewport"
       label={t("workspaces.dropToUploadFiles")}
       onDrop={(files) => {
         if (isPending) {


### PR DESCRIPTION
## Summary

- require shared file drop zones to declare content or viewport coverage
- make the workspace drop target fill the shell content viewport
- cover bottom-edge native file drops with a browser geometry and upload invariant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - File uploads can now be dropped anywhere across the workspace Files viewport.
  - Added end-to-end coverage for native DOCX file drops and confirmation that uploaded files appear correctly.

- **Bug Fixes**
  - Improved file-drop coverage so skill editor uploads remain limited to the content area, while workspace uploads cover the full viewport.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->