### PR TITLE
fix: retry transient catalogue downloads

### DIFF
--- a/packages/catalogue/scripts/check-pinned-content.ts
+++ b/packages/catalogue/scripts/check-pinned-content.ts
@@ -17,7 +17,7 @@
  * header on the contents API). Network is required; run in CI or with
  * connectivity, not on the offline verify path.
  */
-import { TaggedError } from "better-result";
+import { Result, TaggedError } from "better-result";
 
 import {
   isAllowedResourcePath,
@@ -36,11 +36,12 @@ import { catalogueLicensesMatch } from "../src/schema";
 import type { CatalogueLicense } from "../src/schema";
 
 /** Expected per-entry failure while fetching upstream content. */
-class PinnedContentError extends TaggedError("PinnedContentError")<{
+export class PinnedContentError extends TaggedError("PinnedContentError")<{
   message: string;
 }> {}
 
 const FETCH_TIMEOUT_MS = 10_000;
+const FETCH_RETRY_DELAYS_MS = [200, 800] as const;
 const SKILL_FILE_NAME = "SKILL.md";
 const GITHUB_CONTENTS_LISTING_LIMIT = 1000;
 
@@ -68,6 +69,40 @@ type GithubContentItem = {
   path: string;
   size: number | null;
   type: string;
+};
+
+type FetchWithBoundedRetryOptions<T> = {
+  fetchValue: () => Promise<T>;
+  sleep?: (delayMs: number) => Promise<void>;
+};
+
+const sleep = async (delayMs: number): Promise<void> => {
+  await Bun.sleep(delayMs);
+};
+
+/** Retry rejected transports twice; tagged response failures stay single-pass. */
+export const fetchWithBoundedRetry = async <T>({
+  fetchValue,
+  sleep: wait = sleep,
+}: FetchWithBoundedRetryOptions<T>): Promise<T> => {
+  const attempt = async (retryIndex: number): Promise<T> => {
+    const fetched = await Result.tryPromise({
+      try: fetchValue,
+      catch: (cause) => cause,
+    });
+    if (Result.isOk(fetched)) {
+      return fetched.value;
+    }
+
+    const delayMs = FETCH_RETRY_DELAYS_MS.at(retryIndex);
+    if (fetched.error instanceof PinnedContentError || delayMs === undefined) {
+      throw fetched.error;
+    }
+    await wait(delayMs);
+    return await attempt(retryIndex + 1);
+  };
+
+  return await attempt(0);
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -143,35 +178,45 @@ const fetchPinnedTextFile = async ({
   repoRelativePath,
   target,
 }: FetchPinnedTextFileOptions): Promise<PinnedTextFile | null> => {
-  const response = await fetch(rawContentUrl(target, repoRelativePath), {
-    headers: githubHeaders("text/plain"),
-    redirect: "error",
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  const file = await fetchWithBoundedRetry({
+    fetchValue: async () => {
+      const response = await fetch(rawContentUrl(target, repoRelativePath), {
+        headers: githubHeaders("text/plain"),
+        redirect: "error",
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      if (response.status === 404 && allowNotFound) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new PinnedContentError({
+          message: `${label} fetch returned HTTP ${response.status}`,
+        });
+      }
+      if (!response.body) {
+        throw new PinnedContentError({
+          message: `${label} response has no body`,
+        });
+      }
+      const declaredLength = Number(response.headers.get("content-length"));
+      if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+        throw new PinnedContentError({
+          message: `${label} is larger than ${maxBytes} bytes`,
+        });
+      }
+      const bytes = await readCappedBytes(response.body, maxBytes);
+      if (bytes === null) {
+        throw new PinnedContentError({
+          message: `${label} is larger than ${maxBytes} bytes`,
+        });
+      }
+      return bytes;
+    },
   });
-  if (response.status === 404 && allowNotFound) {
+  if (file === null) {
     return null;
   }
-  if (!response.ok) {
-    throw new PinnedContentError({
-      message: `${label} fetch returned HTTP ${response.status}`,
-    });
-  }
-  if (!response.body) {
-    throw new PinnedContentError({ message: `${label} response has no body` });
-  }
-  const declaredLength = Number(response.headers.get("content-length"));
-  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
-    throw new PinnedContentError({
-      message: `${label} is larger than ${maxBytes} bytes`,
-    });
-  }
-  const bytes = await readCappedBytes(response.body, maxBytes);
-  if (bytes === null) {
-    throw new PinnedContentError({
-      message: `${label} is larger than ${maxBytes} bytes`,
-    });
-  }
-  return { byteLength: bytes.byteLength, content: UTF8_DECODER.decode(bytes) };
+  return { byteLength: file.byteLength, content: UTF8_DECODER.decode(file) };
 };
 
 /**
@@ -194,23 +239,31 @@ const fetchDirectoryContents = async (
   target: GithubTarget,
   repoRelativePath: string,
 ): Promise<GithubContentItem[]> => {
-  const response = await fetch(contentsApiUrl(target, repoRelativePath), {
-    headers: githubHeaders("application/vnd.github+json"),
-    redirect: "error",
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  const body = await fetchWithBoundedRetry({
+    fetchValue: async () => {
+      const response = await fetch(contentsApiUrl(target, repoRelativePath), {
+        headers: githubHeaders("application/vnd.github+json"),
+        redirect: "error",
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      // A missing resource directory is not an error: the skill simply has
+      // no files under that root.
+      if (response.status === 404) {
+        return null;
+      }
+      if (!response.ok) {
+        throw new PinnedContentError({
+          message: `GitHub contents API returned HTTP ${response.status} for ${repoRelativePath || "<root>"}`,
+        });
+      }
+      return await response.text();
+    },
   });
-  // A missing resource directory is not an error: the skill simply has
-  // no files under that root.
-  if (response.status === 404) {
+  if (body === null) {
     return [];
   }
-  if (!response.ok) {
-    throw new PinnedContentError({
-      message: `GitHub contents API returned HTTP ${response.status} for ${repoRelativePath || "<root>"}`,
-    });
-  }
 
-  const payload: unknown = await response.json();
+  const payload: unknown = JSON.parse(body);
   const items = toContentItems(payload);
   const parsed: GithubContentItem[] = [];
   for (const item of items) {

--- a/packages/catalogue/scripts/check-pinned-content.ts
+++ b/packages/catalogue/scripts/check-pinned-content.ts
@@ -71,9 +71,12 @@ type GithubContentItem = {
   type: string;
 };
 
+type Fetcher = (...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>;
+type RetrySleep = (delayMs: number) => Promise<void>;
+
 type FetchWithBoundedRetryOptions<T> = {
   fetchValue: () => Promise<T>;
-  sleep?: (delayMs: number) => Promise<void>;
+  sleep?: RetrySleep;
 };
 
 const sleep = async (delayMs: number): Promise<void> => {
@@ -160,9 +163,11 @@ const contentsApiUrl = (
 
 type FetchPinnedTextFileOptions = {
   allowNotFound?: boolean;
+  fetcher?: Fetcher;
   label: string;
   maxBytes: number;
   repoRelativePath: string;
+  sleep?: RetrySleep;
   target: GithubTarget;
 };
 
@@ -171,47 +176,51 @@ type PinnedTextFile = {
   content: string;
 };
 
-const fetchPinnedTextFile = async ({
+export const fetchPinnedTextFile = async ({
   allowNotFound = false,
+  fetcher = fetch,
   label,
   maxBytes,
   repoRelativePath,
+  sleep: wait = sleep,
   target,
 }: FetchPinnedTextFileOptions): Promise<PinnedTextFile | null> => {
-  const file = await fetchWithBoundedRetry({
-    fetchValue: async () => {
-      const response = await fetch(rawContentUrl(target, repoRelativePath), {
-        headers: githubHeaders("text/plain"),
-        redirect: "error",
-        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  const fetchValue = async () => {
+    const response = await fetcher(rawContentUrl(target, repoRelativePath), {
+      headers: githubHeaders("text/plain"),
+      redirect: "error",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (response.status === 404 && allowNotFound) {
+      return null;
+    }
+    if (!response.ok) {
+      throw new PinnedContentError({
+        message: `${label} fetch returned HTTP ${response.status}`,
       });
-      if (response.status === 404 && allowNotFound) {
-        return null;
-      }
-      if (!response.ok) {
-        throw new PinnedContentError({
-          message: `${label} fetch returned HTTP ${response.status}`,
-        });
-      }
-      if (!response.body) {
-        throw new PinnedContentError({
-          message: `${label} response has no body`,
-        });
-      }
-      const declaredLength = Number(response.headers.get("content-length"));
-      if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
-        throw new PinnedContentError({
-          message: `${label} is larger than ${maxBytes} bytes`,
-        });
-      }
-      const bytes = await readCappedBytes(response.body, maxBytes);
-      if (bytes === null) {
-        throw new PinnedContentError({
-          message: `${label} is larger than ${maxBytes} bytes`,
-        });
-      }
-      return bytes;
-    },
+    }
+    if (!response.body) {
+      throw new PinnedContentError({
+        message: `${label} response has no body`,
+      });
+    }
+    const declaredLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+      throw new PinnedContentError({
+        message: `${label} is larger than ${maxBytes} bytes`,
+      });
+    }
+    const bytes = await readCappedBytes(response.body, maxBytes);
+    if (bytes === null) {
+      throw new PinnedContentError({
+        message: `${label} is larger than ${maxBytes} bytes`,
+      });
+    }
+    return bytes;
+  };
+  const file = await fetchWithBoundedRetry({
+    fetchValue,
+    sleep: wait,
   });
   if (file === null) {
     return null;
@@ -235,29 +244,40 @@ const fetchSkillFile = async (
     target,
   });
 
-const fetchDirectoryContents = async (
-  target: GithubTarget,
-  repoRelativePath: string,
-): Promise<GithubContentItem[]> => {
-  const body = await fetchWithBoundedRetry({
-    fetchValue: async () => {
-      const response = await fetch(contentsApiUrl(target, repoRelativePath), {
-        headers: githubHeaders("application/vnd.github+json"),
-        redirect: "error",
-        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+type FetchDirectoryContentsOptions = {
+  fetcher?: Fetcher;
+  repoRelativePath: string;
+  sleep?: RetrySleep;
+  target: GithubTarget;
+};
+
+export const fetchDirectoryContents = async ({
+  fetcher = fetch,
+  repoRelativePath,
+  sleep: wait = sleep,
+  target,
+}: FetchDirectoryContentsOptions): Promise<GithubContentItem[]> => {
+  const fetchValue = async () => {
+    const response = await fetcher(contentsApiUrl(target, repoRelativePath), {
+      headers: githubHeaders("application/vnd.github+json"),
+      redirect: "error",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    // A missing resource directory is not an error: the skill simply has
+    // no files under that root.
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      throw new PinnedContentError({
+        message: `GitHub contents API returned HTTP ${response.status} for ${repoRelativePath || "<root>"}`,
       });
-      // A missing resource directory is not an error: the skill simply has
-      // no files under that root.
-      if (response.status === 404) {
-        return null;
-      }
-      if (!response.ok) {
-        throw new PinnedContentError({
-          message: `GitHub contents API returned HTTP ${response.status} for ${repoRelativePath || "<root>"}`,
-        });
-      }
-      return await response.text();
-    },
+    }
+    return await response.text();
+  };
+  const body = await fetchWithBoundedRetry({
+    fetchValue,
+    sleep: wait,
   });
   if (body === null) {
     return [];
@@ -681,7 +701,10 @@ const checkResources = async (
     if (directory === undefined) {
       return;
     }
-    const items = await fetchDirectoryContents(target, directory);
+    const items = await fetchDirectoryContents({
+      repoRelativePath: directory,
+      target,
+    });
     const shouldContinue = await processItems(items, 0);
     if (!shouldContinue) {
       return;

--- a/packages/catalogue/src/check-pinned-content.test.ts
+++ b/packages/catalogue/src/check-pinned-content.test.ts
@@ -6,11 +6,83 @@ import {
   archiveSizeLimitError,
   assertCompleteGithubContentsListing,
   checkFrontmatterLimits,
+  fetchWithBoundedRetry,
+  PinnedContentError,
   pinnedLicenseMismatchError,
   registerResourcePath,
   resourceContentLimitError,
   resourcePathLimitError,
 } from "../scripts/check-pinned-content";
+
+describe("pinned content fetch retry", () => {
+  test("retries rejected transports with bounded backoff", async () => {
+    let attempts = 0;
+    const delays: number[] = [];
+
+    const result = await fetchWithBoundedRetry({
+      fetchValue: async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new TypeError("socket closed");
+        }
+        return "ok";
+      },
+      sleep: async (delayMs) => {
+        delays.push(delayMs);
+      },
+    });
+
+    expect(result).toBe("ok");
+    expect(attempts).toBe(3);
+    expect(delays).toEqual([200, 800]);
+  });
+
+  test("stops after three rejected transport attempts", async () => {
+    const failure = new TypeError("socket stayed closed");
+    let attempts = 0;
+
+    const response = fetchWithBoundedRetry({
+      fetchValue: async () => {
+        attempts += 1;
+        throw failure;
+      },
+      sleep: async () => {},
+    });
+
+    // Bun types declare `.rejects.toBe` as void; capture explicitly so
+    // type-aware lint and the runtime agree.
+    const rejection: unknown = await response.then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBe(failure);
+    expect(attempts).toBe(3);
+  });
+
+  test("does not retry tagged HTTP failures", async () => {
+    const failure = new PinnedContentError({
+      message: "fetch returned HTTP 503",
+    });
+    let attempts = 0;
+
+    const response = fetchWithBoundedRetry({
+      fetchValue: async () => {
+        attempts += 1;
+        throw failure;
+      },
+      sleep: async () => {},
+    });
+
+    const rejection: unknown = await response.then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(rejection).toBe(failure);
+    expect(attempts).toBe(1);
+  });
+});
 
 describe("pinned skill install-limit preflight", () => {
   test("rejects GitHub Contents listings that may have hit the API ceiling", () => {

--- a/packages/catalogue/src/check-pinned-content.test.ts
+++ b/packages/catalogue/src/check-pinned-content.test.ts
@@ -6,6 +6,8 @@ import {
   archiveSizeLimitError,
   assertCompleteGithubContentsListing,
   checkFrontmatterLimits,
+  fetchDirectoryContents,
+  fetchPinnedTextFile,
   fetchWithBoundedRetry,
   PinnedContentError,
   pinnedLicenseMismatchError,
@@ -13,6 +15,23 @@ import {
   resourceContentLimitError,
   resourcePathLimitError,
 } from "../scripts/check-pinned-content";
+
+const GITHUB_TARGET = {
+  directory: "skills/example",
+  license: "MIT",
+  repo: "example/skills",
+  rev: "a".repeat(40),
+  slug: "example",
+} as const;
+
+const closedSocketResponse = (): Response =>
+  new Response(
+    new ReadableStream({
+      pull: (controller) => {
+        controller.error(new TypeError("socket closed during body read"));
+      },
+    }),
+  );
 
 describe("pinned content fetch retry", () => {
   test("retries rejected transports with bounded backoff", async () => {
@@ -81,6 +100,64 @@ describe("pinned content fetch retry", () => {
 
     expect(rejection).toBe(failure);
     expect(attempts).toBe(1);
+  });
+
+  test("retries a body-read failure through the pinned-file path", async () => {
+    let attempts = 0;
+    const delays: number[] = [];
+
+    const file = await fetchPinnedTextFile({
+      fetcher: async () => {
+        attempts += 1;
+        return attempts === 1
+          ? closedSocketResponse()
+          : new Response("pinned content");
+      },
+      label: "SKILL.md",
+      maxBytes: 1024,
+      repoRelativePath: "skills/example/SKILL.md",
+      sleep: async (delayMs) => {
+        delays.push(delayMs);
+      },
+      target: GITHUB_TARGET,
+    });
+
+    expect(file).toEqual({
+      byteLength: 14,
+      content: "pinned content",
+    });
+    expect(attempts).toBe(2);
+    expect(delays).toEqual([200]);
+  });
+
+  test("retries a body-read failure through the contents path", async () => {
+    let attempts = 0;
+    const delays: number[] = [];
+    const contents = [
+      {
+        path: "skills/example/references/source.md",
+        size: 12,
+        type: "file",
+      },
+    ];
+
+    const result = await fetchDirectoryContents({
+      fetcher: async () => {
+        attempts += 1;
+        return attempts === 1
+          ? closedSocketResponse()
+          : new Response(JSON.stringify(contents));
+      },
+      repoRelativePath: "skills/example/references",
+      sleep: async (delayMs) => {
+        delays.push(delayMs);
+      },
+      target: GITHUB_TARGET,
+    });
+
+    expect(result).toEqual(contents);
+    expect(attempts).toBe(2);
+    expect(delays).toEqual([200]);
   });
 });
 


### PR DESCRIPTION
## Summary

- retry rejected GitHub fetch and body-read transports up to three attempts with bounded backoff
- keep HTTP, size, and content failures single-pass
- test retry success, exhaustion, and fail-fast behavior

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when checking pinned content during temporary network failures.
  * Added bounded retries with increasing delays for recoverable connection errors.
  * Prevented retries for permanent HTTP-related failures, allowing errors to surface promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->