### PR TITLE
chore: retire the auth release marker

### DIFF
--- a/.github/actions/promote-dispatch/action.yml
+++ b/.github/actions/promote-dispatch/action.yml
@@ -55,10 +55,6 @@ inputs:
       main-<sha> refs; for tagged releases the tag is the checkout target.
     required: false
     default: ""
-  better-auth-cutover-authorization:
-    description: One-time Better Auth 1.7 production cutover authorization
-    required: false
-    default: blocked
 
 runs:
   using: composite
@@ -77,7 +73,6 @@ runs:
         IMAGE_DIGEST: ${{ inputs.image-digest }}
         WEB_IMAGE_DIGEST: ${{ inputs.web-image-digest }}
         GIT_SHA: ${{ inputs.git-sha }}
-        BETTER_AUTH_CUTOVER_AUTHORIZATION: ${{ inputs.better-auth-cutover-authorization }}
       run: |
         set -euo pipefail
 
@@ -184,7 +179,6 @@ runs:
           -f "inputs[target_environment]=${TARGET_ENV}"
           -f "inputs[run_migrations]=${RUN_MIGRATIONS}"
           -f "inputs[frontend]=${FRONTEND}"
-          -f "inputs[better_auth_cutover_authorization]=${BETTER_AUTH_CUTOVER_AUTHORIZATION}"
         )
         # Only sent when set: promote-release.yml rejects git_sha on tagged
         # releases, where a populated value would silently swap the checked-out

--- a/.github/cutovers/better-auth-17-required
+++ b/.github/cutovers/better-auth-17-required
@@ -1,5 +1,0 @@
-The Better Auth 1.7 production cutover has not completed.
-
-Stable releases containing this marker require the explicit Better Auth
-cutover authorization. Remove the marker in a reviewed follow-up only after
-the production cutover and canaries have completed successfully.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,6 @@ on:
         description: "Git tag to publish, for example v1.2.3 or v1.2.3-rc.1"
         required: true
         type: string
-      better_auth_cutover_authorization:
-        description: "Authorize the one-time Better Auth 1.7 production cutover"
-        required: true
-        default: blocked
-        type: choice
-        options:
-          - blocked
-          - approved
 
 # Every job declares its own least-privilege block.
 permissions: {}
@@ -107,22 +99,6 @@ jobs:
           file_version="$(tr -d '[:space:]' < VERSION)"
           if [[ "$file_version" != "$VERSION" ]]; then
             echo "::error::VERSION ($file_version) does not match $RELEASE_REF"
-            exit 1
-          fi
-
-      - name: Guard Better Auth production cutover
-        env:
-          CUTOVER_AUTHORIZATION: ${{ github.event_name == 'workflow_dispatch' && inputs.better_auth_cutover_authorization || 'blocked' }}
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_REF: ${{ steps.release.outputs.ref }}
-        run: |
-          if [[ "$RELEASE_REF" == *-* ]] \
-              || [[ ! -f .github/cutovers/better-auth-17-required ]]; then
-            exit 0
-          fi
-          if [[ "$EVENT_NAME" != "workflow_dispatch" \
-              || "$CUTOVER_AUTHORIZATION" != "approved" ]]; then
-            echo "::error::This stable tag is the Better Auth 1.7 production cutover. Re-run this workflow manually with explicit cutover authorization after every rehearsal gate is green."
             exit 1
           fi
 
@@ -984,7 +960,6 @@ jobs:
           release-ref: ${{ needs.resolve.outputs.release_ref }}
           target-environment: production
           web-image-digest: ${{ needs.prepare-web-image.outputs.digest }}
-          better-auth-cutover-authorization: ${{ inputs.better_auth_cutover_authorization || 'blocked' }}
 
       # Swap the workspace to the release being promoted: the verification
       # script must come from that revision, not from the workflow's.

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -362,49 +362,6 @@ describe("API deployment health receipt", () => {
     expect(desktopCarry).toContain("bash scripts/promote-desktop-release.sh");
   });
 
-  test("requires an explicit Better Auth production cutover dispatch", async () => {
-    const [releaseWorkflow, promoteAction, cutoverMarker] = await Promise.all([
-      Bun.file(
-        new URL("../.github/workflows/release.yml", import.meta.url),
-      ).text(),
-      Bun.file(
-        new URL(
-          "../.github/actions/promote-dispatch/action.yml",
-          import.meta.url,
-        ),
-      ).text(),
-      Bun.file(
-        new URL("../.github/cutovers/better-auth-17-required", import.meta.url),
-      ).text(),
-    ]);
-    const guardStart = releaseWorkflow.indexOf(
-      "- name: Guard Better Auth production cutover",
-    );
-    const receiptStart = releaseWorkflow.indexOf(
-      "- name: Write trusted release receipt",
-    );
-
-    expect(cutoverMarker).toContain(
-      "Better Auth 1.7 production cutover has not completed",
-    );
-    expect(releaseWorkflow).toContain("better_auth_cutover_authorization:");
-    expect(releaseWorkflow).toContain("default: blocked");
-    expect(releaseWorkflow).toContain(`EVENT_NAME: \${{ github.event_name }}`);
-    expect(releaseWorkflow).toContain(
-      `[[ "$EVENT_NAME" != "workflow_dispatch"`,
-    );
-    expect(releaseWorkflow).toContain(`"$CUTOVER_AUTHORIZATION" != "approved"`);
-    expect(guardStart).toBeGreaterThanOrEqual(0);
-    expect(receiptStart).toBeGreaterThan(guardStart);
-    expect(releaseWorkflow).toContain(
-      `better-auth-cutover-authorization: \${{ inputs.better_auth_cutover_authorization || 'blocked' }}`,
-    );
-    expect(promoteAction).toContain("better-auth-cutover-authorization:");
-    expect(promoteAction).toContain(
-      `inputs[better_auth_cutover_authorization]=\${BETTER_AUTH_CUTOVER_AUTHORIZATION}`,
-    );
-  });
-
   test("gates API releases on readiness", async () => {
     const [deploymentScript, releaseWorkflow, publishWorkflow] =
       await Promise.all([


### PR DESCRIPTION
The one-time release guard has served its purpose; stable tags no longer need manual authorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the Better Auth 1.7 cutover marker, indicating that the production cutover is complete.
  * Stable releases no longer carry the previous cutover restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->