### PR TITLE
fix(api): keep the sign-in replay exempt from runtime rate limiting

### DIFF
--- a/apps/api/src/scripts/better-auth-sign-in-replay.ts
+++ b/apps/api/src/scripts/better-auth-sign-in-replay.ts
@@ -246,6 +246,10 @@ const run = async (
     // A throwaway secret: nothing signed here outlives the replay.
     secret: Bun.randomUUIDv7() + Bun.randomUUIDv7(),
     database: drizzleAdapter(database, AUTH_DATABASE_ADAPTER_OPTIONS),
+    // The replay issues every request in-process from one address-less
+    // client; rate limiting would throttle the sample into false rejections
+    // instead of exercising sign-in resolution.
+    rateLimit: { enabled: false },
     trustedOrigins: [oauthBaseUrl],
     socialProviders: {
       microsoft: {


### PR DESCRIPTION
## Summary

- the replay drives sign-ins in-process from a single address-less client, so the runtime limiter throttles the sample and reports false rejections
- disable rate limiting on the replay's own auth instance; the strict resolution gate is unchanged

## Testing

- `bun test src/scripts/better-auth-sign-in-replay.test.ts`