### PR TITLE
fix(scripts): treat a missing baseline ref like a source archive

### DIFF
--- a/packages/scripts/src/workspace-app-boundaries.ts
+++ b/packages/scripts/src/workspace-app-boundaries.ts
@@ -540,10 +540,24 @@ const readBaselineExceptions = (
     }
   });
   if (baseRevision === undefined) {
-    // A checkout without a main ref (single-commit deploy clones, tag
-    // checkouts) has the same information as a source archive: no baseline
-    // to ratchet against. The ledger's absolute rules still apply through
-    // the filesystem path; the ratchet is enforced where the refs exist.
+    if (configuredBase !== undefined) {
+      // A pull-request context names its base; a checkout that cannot
+      // resolve it is misconfigured, and skipping would let an exception
+      // land without the ratchet comparison.
+      return {
+        exceptions: [],
+        issues: [
+          {
+            message: "app-boundary ledger baseline branch is unavailable",
+            path: APP_BOUNDARY_LEDGER_PATH,
+          },
+        ],
+      };
+    }
+    // Outside pull requests, a checkout without a main ref (single-commit
+    // deploy clones, tag checkouts) has the same information as a source
+    // archive: no baseline to ratchet against. The ledger's absolute rules
+    // still apply through the filesystem path.
     return null;
   }
 

--- a/packages/scripts/src/workspace-app-boundaries.ts
+++ b/packages/scripts/src/workspace-app-boundaries.ts
@@ -540,15 +540,11 @@ const readBaselineExceptions = (
     }
   });
   if (baseRevision === undefined) {
-    return {
-      exceptions: [],
-      issues: [
-        {
-          message: "app-boundary ledger baseline branch is unavailable",
-          path: APP_BOUNDARY_LEDGER_PATH,
-        },
-      ],
-    };
+    // A checkout without a main ref (single-commit deploy clones, tag
+    // checkouts) has the same information as a source archive: no baseline
+    // to ratchet against. The ledger's absolute rules still apply through
+    // the filesystem path; the ratchet is enforced where the refs exist.
+    return null;
   }
 
   let mergeBase: string;


### PR DESCRIPTION
## Summary

- deploy clones of a single commit and tag checkouts carry a git directory but no main ref; the app-boundary check made `bun install` fail there (postinstall → `lint:ws`) instead of taking the filesystem path source archives already use
- the ratchet still enforces wherever a baseline ref exists (PR and main CI checkouts)

## Testing

- `bun test src/workspace-app-boundaries.test.ts`