### PR TITLE
fix(scripts): treat an empty base ref as no pull-request context

### DIFF
--- a/packages/scripts/src/workspace-app-boundaries.ts
+++ b/packages/scripts/src/workspace-app-boundaries.ts
@@ -525,7 +525,9 @@ const readBaselineExceptions = (
     return null;
   }
 
-  const configuredBase = process.env["GITHUB_BASE_REF"];
+  // Actions defines GITHUB_BASE_REF as an empty string outside pull
+  // requests; only a non-empty value marks a pull-request context.
+  const configuredBase = process.env["GITHUB_BASE_REF"] || undefined;
   const baseCandidates = [
     configuredBase === undefined ? null : `origin/${configuredBase}`,
     "origin/main",


### PR DESCRIPTION
## Summary

- Actions defines `GITHUB_BASE_REF` as an empty string outside pull requests, so the previous fallback never engaged in deploy clones; only a non-empty value now marks a pull-request context
- verified against a ref-less clone fixture: an empty base ref takes the archive fallback, a named unresolvable base stays a hard error

## Testing

- `bun test src/workspace-app-boundaries.test.ts`