### PR TITLE
refactor: derive both work-obligation lifecycle paths from one transition table

### DIFF
--- a/apps/api/src/handlers/work-obligations/transition.ts
+++ b/apps/api/src/handlers/work-obligations/transition.ts
@@ -4,70 +4,27 @@ import { t } from "elysia";
 
 import {
   entities,
-  WORK_OBLIGATION_EVENT_TYPE,
   WORK_OBLIGATION_STATUS,
   workObligationEvents,
   workObligations,
 } from "@/api/db/schema";
-import type { WorkObligationStatus } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
-import { TASK_STATUS } from "@/api/lib/entity-constants";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { lockWorkObligation } from "@/api/lib/work-obligations/lock-work-obligation";
-
-const TRANSITION_ACTION = {
-  COMPLETE: "complete",
-  CANCEL: "cancel",
-  REOPEN: "reopen",
-} as const;
-
-type TransitionAction =
-  (typeof TRANSITION_ACTION)[keyof typeof TRANSITION_ACTION];
+import {
+  resolveWorkObligationTransition,
+  WORK_OBLIGATION_TRANSITION_ACTION,
+  WORK_OBLIGATION_TRANSITION_ACTIONS,
+} from "@/api/lib/work-obligations/transitions";
 
 const transitionParams = workspaceParams({ entityId: tSafeId("entity") });
 const transitionBody = t.Object({
-  action: t.UnionEnum([
-    TRANSITION_ACTION.COMPLETE,
-    TRANSITION_ACTION.CANCEL,
-    TRANSITION_ACTION.REOPEN,
-  ]),
+  action: t.UnionEnum(WORK_OBLIGATION_TRANSITION_ACTIONS),
   reason: t.Optional(t.String({ minLength: 1, maxLength: 1000 })),
 });
-
-type TransitionDefinition = {
-  from: readonly WorkObligationStatus[];
-  to: WorkObligationStatus;
-  eventType: "completed" | "cancelled" | "reopened";
-  taskStatus: "done" | "cancelled" | "in_progress";
-};
-
-const TRANSITIONS = {
-  complete: {
-    from: [WORK_OBLIGATION_STATUS.ACTIVE],
-    to: WORK_OBLIGATION_STATUS.COMPLETED,
-    eventType: WORK_OBLIGATION_EVENT_TYPE.COMPLETED,
-    taskStatus: TASK_STATUS.DONE,
-  },
-  cancel: {
-    from: [
-      WORK_OBLIGATION_STATUS.UNASSIGNED,
-      WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
-      WORK_OBLIGATION_STATUS.ACTIVE,
-    ],
-    to: WORK_OBLIGATION_STATUS.CANCELLED,
-    eventType: WORK_OBLIGATION_EVENT_TYPE.CANCELLED,
-    taskStatus: TASK_STATUS.CANCELLED,
-  },
-  reopen: {
-    from: [WORK_OBLIGATION_STATUS.COMPLETED, WORK_OBLIGATION_STATUS.CANCELLED],
-    to: WORK_OBLIGATION_STATUS.ACTIVE,
-    eventType: WORK_OBLIGATION_EVENT_TYPE.REOPENED,
-    taskStatus: TASK_STATUS.IN_PROGRESS,
-  },
-} as const satisfies Record<TransitionAction, TransitionDefinition>;
 
 const transitionWorkObligation = createSafeHandler(
   {
@@ -86,7 +43,6 @@ const transitionWorkObligation = createSafeHandler(
     body,
     recordAuditEvent,
   }) {
-    const transition = TRANSITIONS[body.action];
     const reason = body.reason?.trim();
     const result = yield* Result.await(
       safeDb(async (tx) => {
@@ -97,17 +53,21 @@ const transitionWorkObligation = createSafeHandler(
         if (!existing) {
           return { status: "not_found" as const };
         }
-        if (!transition.from.some((status) => status === existing.status)) {
+        const transition = resolveWorkObligationTransition(
+          body.action,
+          existing,
+        );
+        if (transition.type === "invalid_status") {
           return { status: "invalid_status" as const };
         }
         if (
-          body.action === TRANSITION_ACTION.COMPLETE &&
+          body.action === WORK_OBLIGATION_TRANSITION_ACTION.COMPLETE &&
           existing.ownerUserId !== user.id
         ) {
           return { status: "not_owner" as const };
         }
         if (
-          body.action === TRANSITION_ACTION.CANCEL &&
+          body.action === WORK_OBLIGATION_TRANSITION_ACTION.CANCEL &&
           existing.status !== WORK_OBLIGATION_STATUS.UNASSIGNED &&
           !reason
         ) {
@@ -115,18 +75,7 @@ const transitionWorkObligation = createSafeHandler(
         }
 
         const now = new Date();
-        let reopenedStatus: WorkObligationStatus;
-        if (existing.ownerUserId === null) {
-          reopenedStatus = WORK_OBLIGATION_STATUS.UNASSIGNED;
-        } else if (existing.acknowledgedAt === null) {
-          reopenedStatus = WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT;
-        } else {
-          reopenedStatus = WORK_OBLIGATION_STATUS.ACTIVE;
-        }
-        const nextStatus =
-          body.action === TRANSITION_ACTION.REOPEN
-            ? reopenedStatus
-            : transition.to;
+        const { nextStatus } = transition;
         const acknowledgementReset =
           nextStatus === WORK_OBLIGATION_STATUS.UNASSIGNED
             ? { acknowledgedAt: null, acknowledgedByUserId: null }
@@ -173,7 +122,7 @@ const transitionWorkObligation = createSafeHandler(
         });
         await recordAuditEvent(tx, {
           action:
-            body.action === TRANSITION_ACTION.CANCEL
+            body.action === WORK_OBLIGATION_TRANSITION_ACTION.CANCEL
               ? AUDIT_ACTION.CANCEL
               : AUDIT_ACTION.UPDATE,
           resourceType: AUDIT_RESOURCE_TYPE.WORK_OBLIGATION,

--- a/apps/api/src/lib/tasks/update-task.ts
+++ b/apps/api/src/lib/tasks/update-task.ts
@@ -39,6 +39,13 @@ import { includes } from "@/api/lib/type-guards";
 import { isWorkObligationEligible } from "@/api/lib/work-obligations/eligibility";
 import { ensureLegacyWorkObligation } from "@/api/lib/work-obligations/legacy-work-obligation";
 import { lockWorkObligation } from "@/api/lib/work-obligations/lock-work-obligation";
+import {
+  nextWorkObligationStatus,
+  WORK_OBLIGATION_TRANSITION_ACTION,
+  WORK_OBLIGATION_TRANSITIONS,
+  workObligationIntentForTaskStatus,
+} from "@/api/lib/work-obligations/transitions";
+import type { WorkObligationTransitionAction } from "@/api/lib/work-obligations/transitions";
 
 const agendaDateTimeSchema = t.Nullable(t.String({ format: "date-time" }));
 const agendaParticipantSchema = t.Object({
@@ -375,74 +382,78 @@ type ResolveWorkflowStatusTransitionOptions = {
   workflowReason: string | undefined;
 };
 
-const reopenedWorkflowStatus = (workflow: LockedWorkObligation) => {
-  if (workflow.ownerUserId === null) {
-    return WORK_OBLIGATION_STATUS.UNASSIGNED;
-  }
-  if (workflow.acknowledgedAt === null) {
-    return WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT;
-  }
-  return WORK_OBLIGATION_STATUS.ACTIVE;
+type WorkflowStatusPolicyOptions = ResolveWorkflowStatusTransitionOptions & {
+  action: WorkObligationTransitionAction;
 };
 
-const resolveWorkflowStatusTransition = ({
+/**
+ * A legacy status write carries no explicit intent, so the guards the
+ * transition endpoint applies per action are re-applied here. They stay at this
+ * call site: the shared table owns which move a status implies, not who may
+ * make it.
+ *
+ * Ungoverned workspaces keep writing task statuses freely; the obligation row
+ * only mirrors them.
+ */
+const assertWorkflowStatusPolicy = ({
+  action,
   governedWorkflow,
-  requestedStatus,
   userId,
   workflow,
   workflowReason,
-}: ResolveWorkflowStatusTransitionOptions) => {
-  if (requestedStatus === "done" && workflow.status !== "completed") {
-    if (
-      governedWorkflow &&
-      (workflow.status !== WORK_OBLIGATION_STATUS.ACTIVE ||
-        workflow.ownerUserId !== userId)
-    ) {
-      throw new HandlerError({
-        status: 409,
-        message:
-          "Only the acknowledged accountable owner can complete this work",
-      });
-    }
-    return {
-      eventType: WORK_OBLIGATION_EVENT_TYPE.COMPLETED,
-      status: WORK_OBLIGATION_STATUS.COMPLETED,
-    };
+}: WorkflowStatusPolicyOptions): void => {
+  if (!governedWorkflow) {
+    return;
   }
-
-  if (
-    requestedStatus === "cancelled" &&
-    workflow.status !== WORK_OBLIGATION_STATUS.CANCELLED
-  ) {
-    if (
-      governedWorkflow &&
-      workflow.status !== WORK_OBLIGATION_STATUS.UNASSIGNED &&
-      !workflowReason
-    ) {
-      throw new HandlerError({
-        status: 400,
-        message: "A reason is required when cancelling assigned work",
-      });
+  switch (action) {
+    case WORK_OBLIGATION_TRANSITION_ACTION.COMPLETE:
+      if (
+        workflow.status !== WORK_OBLIGATION_STATUS.ACTIVE ||
+        workflow.ownerUserId !== userId
+      ) {
+        throw new HandlerError({
+          status: 409,
+          message:
+            "Only the acknowledged accountable owner can complete this work",
+        });
+      }
+      return;
+    case WORK_OBLIGATION_TRANSITION_ACTION.CANCEL:
+      if (
+        workflow.status !== WORK_OBLIGATION_STATUS.UNASSIGNED &&
+        !workflowReason
+      ) {
+        throw new HandlerError({
+          status: 400,
+          message: "A reason is required when cancelling assigned work",
+        });
+      }
+      return;
+    case WORK_OBLIGATION_TRANSITION_ACTION.REOPEN:
+      return;
+    default: {
+      const exhaustive: never = action;
+      return exhaustive;
     }
-    return {
-      eventType: WORK_OBLIGATION_EVENT_TYPE.CANCELLED,
-      status: WORK_OBLIGATION_STATUS.CANCELLED,
-    };
   }
+};
 
-  const reopensClosedWorkflow =
-    requestedStatus !== undefined &&
-    requestedStatus !== "done" &&
-    requestedStatus !== "cancelled" &&
-    (workflow.status === WORK_OBLIGATION_STATUS.COMPLETED ||
-      workflow.status === WORK_OBLIGATION_STATUS.CANCELLED);
-  if (!reopensClosedWorkflow) {
+const resolveWorkflowStatusTransition = (
+  options: ResolveWorkflowStatusTransitionOptions,
+) => {
+  const { requestedStatus, workflow } = options;
+  const intent = workObligationIntentForTaskStatus({
+    currentStatus: workflow.status,
+    requestedTaskStatus: requestedStatus,
+  });
+  if (intent.type === "none") {
     return { eventType: undefined, status: workflow.status };
   }
 
+  assertWorkflowStatusPolicy({ ...options, action: intent.action });
   return {
-    eventType: WORK_OBLIGATION_EVENT_TYPE.REOPENED,
-    status: reopenedWorkflowStatus(workflow),
+    eventType: WORK_OBLIGATION_TRANSITIONS[intent.action].eventType,
+    status: nextWorkObligationStatus(intent.action, workflow),
   };
 };
 

--- a/apps/api/src/lib/work-obligations/transitions.test.ts
+++ b/apps/api/src/lib/work-obligations/transitions.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  WORK_OBLIGATION_STATUS,
+  WORK_OBLIGATION_STATUSES,
+} from "@/api/db/schema";
+import type { WorkObligationStatus } from "@/api/db/schema";
+import { TASK_STATUSES } from "@/api/lib/entity-constants";
+import {
+  nextWorkObligationStatus,
+  reopenedWorkObligationStatus,
+  resolveWorkObligationTransition,
+  WORK_OBLIGATION_TRANSITION_ACTION,
+  WORK_OBLIGATION_TRANSITION_ACTIONS,
+  WORK_OBLIGATION_TRANSITIONS,
+  workObligationIntentForTaskStatus,
+} from "@/api/lib/work-obligations/transitions";
+
+const CLOSED_STATUSES = WORK_OBLIGATION_TRANSITIONS.reopen.from;
+const isClosed = (status: WorkObligationStatus) =>
+  CLOSED_STATUSES.some((closed) => closed === status);
+
+/** The task statuses that name a lifecycle action outright, read off the table. */
+const closingTaskStatuses = WORK_OBLIGATION_TRANSITION_ACTIONS.filter(
+  (action) => isClosed(WORK_OBLIGATION_TRANSITIONS[action].to),
+).map((action) => WORK_OBLIGATION_TRANSITIONS[action].taskStatus);
+
+const OWNERSHIP_STATES = [
+  { acknowledgedAt: null, ownerUserId: null },
+  { acknowledgedAt: null, ownerUserId: "user_1" },
+  { acknowledgedAt: new Date(), ownerUserId: "user_1" },
+];
+
+describe("work obligation transition table", () => {
+  test("every action moves work somewhere it can leave again", () => {
+    for (const action of WORK_OBLIGATION_TRANSITION_ACTIONS) {
+      const { from, to } = WORK_OBLIGATION_TRANSITIONS[action];
+
+      expect(from.length).toBeGreaterThan(0);
+      expect(from).not.toContain(to);
+      expect(
+        WORK_OBLIGATION_TRANSITION_ACTIONS.some((other) =>
+          WORK_OBLIGATION_TRANSITIONS[other].from.some(
+            (status) => status === to,
+          ),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("no status is a dead end", () => {
+    for (const status of WORK_OBLIGATION_STATUSES) {
+      expect(
+        WORK_OBLIGATION_TRANSITION_ACTIONS.some((action) =>
+          WORK_OBLIGATION_TRANSITIONS[action].from.some(
+            (from) => from === status,
+          ),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("the mirrored legacy statuses are real task statuses", () => {
+    for (const action of WORK_OBLIGATION_TRANSITION_ACTIONS) {
+      expect(TASK_STATUSES).toContain(
+        WORK_OBLIGATION_TRANSITIONS[action].taskStatus,
+      );
+    }
+  });
+});
+
+describe("resolveWorkObligationTransition", () => {
+  test("admits exactly the source statuses the table lists", () => {
+    for (const action of WORK_OBLIGATION_TRANSITION_ACTIONS) {
+      const { from } = WORK_OBLIGATION_TRANSITIONS[action];
+      for (const status of WORK_OBLIGATION_STATUSES) {
+        const resolution = resolveWorkObligationTransition(action, {
+          acknowledgedAt: null,
+          ownerUserId: null,
+          status,
+        });
+
+        expect(resolution.type).toBe(
+          from.some((allowed) => allowed === status)
+            ? "allowed"
+            : "invalid_status",
+        );
+      }
+    }
+  });
+
+  test("carries the table's target, event and legacy status", () => {
+    const resolution = resolveWorkObligationTransition(
+      WORK_OBLIGATION_TRANSITION_ACTION.COMPLETE,
+      {
+        acknowledgedAt: new Date(),
+        ownerUserId: "user_1",
+        status: WORK_OBLIGATION_STATUS.ACTIVE,
+      },
+    );
+
+    expect(resolution).toEqual({
+      type: "allowed",
+      eventType: WORK_OBLIGATION_TRANSITIONS.complete.eventType,
+      from: WORK_OBLIGATION_TRANSITIONS.complete.from,
+      nextStatus: WORK_OBLIGATION_TRANSITIONS.complete.to,
+      taskStatus: WORK_OBLIGATION_TRANSITIONS.complete.taskStatus,
+    });
+  });
+
+  test("reopening follows ownership instead of the table's target", () => {
+    for (const ownership of OWNERSHIP_STATES) {
+      for (const status of CLOSED_STATUSES) {
+        const resolution = resolveWorkObligationTransition(
+          WORK_OBLIGATION_TRANSITION_ACTION.REOPEN,
+          { ...ownership, status },
+        );
+
+        expect(resolution).toEqual({
+          type: "allowed",
+          eventType: WORK_OBLIGATION_TRANSITIONS.reopen.eventType,
+          from: WORK_OBLIGATION_TRANSITIONS.reopen.from,
+          nextStatus: reopenedWorkObligationStatus(ownership),
+          taskStatus: WORK_OBLIGATION_TRANSITIONS.reopen.taskStatus,
+        });
+      }
+    }
+  });
+
+  test("reopened work always leaves the closed set", () => {
+    for (const ownership of OWNERSHIP_STATES) {
+      expect(isClosed(reopenedWorkObligationStatus(ownership))).toBe(false);
+    }
+  });
+
+  test("only reopening depends on ownership", () => {
+    for (const action of WORK_OBLIGATION_TRANSITION_ACTIONS) {
+      const statuses = OWNERSHIP_STATES.map((ownership) =>
+        nextWorkObligationStatus(action, ownership),
+      );
+      const fixed = statuses.every(
+        (status) => status === WORK_OBLIGATION_TRANSITIONS[action].to,
+      );
+
+      expect(fixed).toBe(action !== WORK_OBLIGATION_TRANSITION_ACTION.REOPEN);
+    }
+  });
+});
+
+describe("workObligationIntentForTaskStatus", () => {
+  test("round-trips every action through its own legacy status", () => {
+    for (const action of WORK_OBLIGATION_TRANSITION_ACTIONS) {
+      const { from, taskStatus } = WORK_OBLIGATION_TRANSITIONS[action];
+      for (const currentStatus of from) {
+        expect(
+          workObligationIntentForTaskStatus({
+            currentStatus,
+            requestedTaskStatus: taskStatus,
+          }),
+        ).toEqual({ type: "transition", action });
+      }
+    }
+  });
+
+  test("writing the status the work already carries changes nothing", () => {
+    for (const action of WORK_OBLIGATION_TRANSITION_ACTIONS) {
+      const { taskStatus, to } = WORK_OBLIGATION_TRANSITIONS[action];
+      if (!isClosed(to)) {
+        continue;
+      }
+
+      expect(
+        workObligationIntentForTaskStatus({
+          currentStatus: to,
+          requestedTaskStatus: taskStatus,
+        }),
+      ).toEqual({ type: "none" });
+    }
+  });
+
+  test("an open status only means something to closed work", () => {
+    const openTaskStatuses = TASK_STATUSES.filter(
+      (taskStatus) => !closingTaskStatuses.some((it) => it === taskStatus),
+    );
+
+    for (const requestedTaskStatus of openTaskStatuses) {
+      for (const currentStatus of WORK_OBLIGATION_STATUSES) {
+        expect(
+          workObligationIntentForTaskStatus({
+            currentStatus,
+            requestedTaskStatus,
+          }),
+        ).toEqual(
+          isClosed(currentStatus)
+            ? {
+                type: "transition",
+                action: WORK_OBLIGATION_TRANSITION_ACTION.REOPEN,
+              }
+            : { type: "none" },
+        );
+      }
+    }
+  });
+
+  test("an untouched task status implies nothing", () => {
+    for (const currentStatus of WORK_OBLIGATION_STATUSES) {
+      expect(
+        workObligationIntentForTaskStatus({
+          currentStatus,
+          requestedTaskStatus: undefined,
+        }),
+      ).toEqual({ type: "none" });
+    }
+  });
+});

--- a/apps/api/src/lib/work-obligations/transitions.ts
+++ b/apps/api/src/lib/work-obligations/transitions.ts
@@ -1,0 +1,207 @@
+import {
+  WORK_OBLIGATION_EVENT_TYPE,
+  WORK_OBLIGATION_STATUS,
+} from "@/api/db/schema";
+import type { WorkObligationStatus } from "@/api/db/schema";
+import { TASK_STATUS } from "@/api/lib/entity-constants";
+import type { TaskStatus } from "@/api/lib/entity-constants";
+
+/**
+ * The governed-work lifecycle, declared once.
+ *
+ * Two entry points move an obligation: the explicit transition endpoint, and a
+ * legacy task-status write (task API or `save_task`) that implies one. Both
+ * read this table, so the allowed source statuses, the target status, the
+ * lifecycle event and the mirrored legacy task status cannot drift apart.
+ * Permissions, reason requirements, locking and event emission stay with each
+ * caller: this module owns the transition data and the pure resolution only.
+ */
+export const WORK_OBLIGATION_TRANSITION_ACTION = {
+  COMPLETE: "complete",
+  CANCEL: "cancel",
+  REOPEN: "reopen",
+} as const;
+
+export type WorkObligationTransitionAction =
+  (typeof WORK_OBLIGATION_TRANSITION_ACTION)[keyof typeof WORK_OBLIGATION_TRANSITION_ACTION];
+
+const defineTransitionActions = <
+  const TActions extends readonly [
+    WorkObligationTransitionAction,
+    ...WorkObligationTransitionAction[],
+  ],
+>(
+  actions: Exclude<
+    WorkObligationTransitionAction,
+    TActions[number]
+  > extends never
+    ? TActions
+    : never,
+) => Object.freeze(actions);
+
+/** Non-empty ordered actions for iteration and request schemas. */
+export const WORK_OBLIGATION_TRANSITION_ACTIONS = defineTransitionActions([
+  WORK_OBLIGATION_TRANSITION_ACTION.COMPLETE,
+  WORK_OBLIGATION_TRANSITION_ACTION.CANCEL,
+  WORK_OBLIGATION_TRANSITION_ACTION.REOPEN,
+]);
+
+type LifecycleEventType =
+  | typeof WORK_OBLIGATION_EVENT_TYPE.COMPLETED
+  | typeof WORK_OBLIGATION_EVENT_TYPE.CANCELLED
+  | typeof WORK_OBLIGATION_EVENT_TYPE.REOPENED;
+
+type WorkObligationTransition = {
+  from: readonly WorkObligationStatus[];
+  to: WorkObligationStatus;
+  eventType: LifecycleEventType;
+  taskStatus: TaskStatus;
+};
+
+export const WORK_OBLIGATION_TRANSITIONS = {
+  complete: {
+    from: [WORK_OBLIGATION_STATUS.ACTIVE],
+    to: WORK_OBLIGATION_STATUS.COMPLETED,
+    eventType: WORK_OBLIGATION_EVENT_TYPE.COMPLETED,
+    taskStatus: TASK_STATUS.DONE,
+  },
+  cancel: {
+    from: [
+      WORK_OBLIGATION_STATUS.UNASSIGNED,
+      WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
+      WORK_OBLIGATION_STATUS.ACTIVE,
+    ],
+    to: WORK_OBLIGATION_STATUS.CANCELLED,
+    eventType: WORK_OBLIGATION_EVENT_TYPE.CANCELLED,
+    taskStatus: TASK_STATUS.CANCELLED,
+  },
+  reopen: {
+    from: [WORK_OBLIGATION_STATUS.COMPLETED, WORK_OBLIGATION_STATUS.CANCELLED],
+    to: WORK_OBLIGATION_STATUS.ACTIVE,
+    eventType: WORK_OBLIGATION_EVENT_TYPE.REOPENED,
+    taskStatus: TASK_STATUS.IN_PROGRESS,
+  },
+} as const satisfies Record<
+  WorkObligationTransitionAction,
+  WorkObligationTransition
+>;
+
+/** Closed work is exactly the work reopening exists to bring back. */
+const isClosedStatus = (status: WorkObligationStatus): boolean =>
+  WORK_OBLIGATION_TRANSITIONS.reopen.from.some((from) => from === status);
+
+/**
+ * Ownership state decides where reopened work lands: the obligation returns to
+ * the queue its owner and acknowledgement put it in, not to a fixed status.
+ */
+type WorkObligationOwnershipState = {
+  acknowledgedAt: Date | null;
+  ownerUserId: string | null;
+};
+
+export const reopenedWorkObligationStatus = ({
+  acknowledgedAt,
+  ownerUserId,
+}: WorkObligationOwnershipState): WorkObligationStatus => {
+  if (ownerUserId === null) {
+    return WORK_OBLIGATION_STATUS.UNASSIGNED;
+  }
+  if (acknowledgedAt === null) {
+    return WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT;
+  }
+  return WORK_OBLIGATION_STATUS.ACTIVE;
+};
+
+export const nextWorkObligationStatus = (
+  action: WorkObligationTransitionAction,
+  ownership: WorkObligationOwnershipState,
+): WorkObligationStatus => {
+  switch (action) {
+    case WORK_OBLIGATION_TRANSITION_ACTION.COMPLETE:
+    case WORK_OBLIGATION_TRANSITION_ACTION.CANCEL:
+      return WORK_OBLIGATION_TRANSITIONS[action].to;
+    case WORK_OBLIGATION_TRANSITION_ACTION.REOPEN:
+      return reopenedWorkObligationStatus(ownership);
+    default: {
+      const exhaustive: never = action;
+      return exhaustive;
+    }
+  }
+};
+
+type WorkObligationState = WorkObligationOwnershipState & {
+  status: WorkObligationStatus;
+};
+
+export type WorkObligationTransitionResolution =
+  | {
+      type: "allowed";
+      eventType: LifecycleEventType;
+      from: readonly WorkObligationStatus[];
+      nextStatus: WorkObligationStatus;
+      taskStatus: TaskStatus;
+    }
+  | { type: "invalid_status" };
+
+export const resolveWorkObligationTransition = (
+  action: WorkObligationTransitionAction,
+  obligation: WorkObligationState,
+): WorkObligationTransitionResolution => {
+  const transition = WORK_OBLIGATION_TRANSITIONS[action];
+  if (!transition.from.some((status) => status === obligation.status)) {
+    return { type: "invalid_status" };
+  }
+  return {
+    type: "allowed",
+    eventType: transition.eventType,
+    from: transition.from,
+    nextStatus: nextWorkObligationStatus(action, obligation),
+    taskStatus: transition.taskStatus,
+  };
+};
+
+/**
+ * A closing action is one whose target status can only be left by reopening,
+ * so writing its legacy task status names that action outright. Every other
+ * task status is an open one: it only means something to an obligation that is
+ * currently closed, where it reads as a reopen.
+ */
+const closingActionForTaskStatus = (
+  taskStatus: string,
+): WorkObligationTransitionAction | undefined =>
+  WORK_OBLIGATION_TRANSITION_ACTIONS.find((action) => {
+    const transition = WORK_OBLIGATION_TRANSITIONS[action];
+    return (
+      transition.taskStatus === taskStatus && isClosedStatus(transition.to)
+    );
+  });
+
+export type WorkObligationStatusIntent =
+  | { type: "transition"; action: WorkObligationTransitionAction }
+  | { type: "none" };
+
+type WorkObligationStatusIntentOptions = {
+  currentStatus: WorkObligationStatus;
+  requestedTaskStatus: string | undefined;
+};
+
+/** The lifecycle action a legacy task-status write implies, if any. */
+export const workObligationIntentForTaskStatus = ({
+  currentStatus,
+  requestedTaskStatus,
+}: WorkObligationStatusIntentOptions): WorkObligationStatusIntent => {
+  if (requestedTaskStatus === undefined) {
+    return { type: "none" };
+  }
+  const closingAction = closingActionForTaskStatus(requestedTaskStatus);
+  if (closingAction) {
+    // Writing the status the obligation already carries is a no-op, not a
+    // repeat transition, so it emits no event.
+    return currentStatus === WORK_OBLIGATION_TRANSITIONS[closingAction].to
+      ? { type: "none" }
+      : { type: "transition", action: closingAction };
+  }
+  return isClosedStatus(currentStatus)
+    ? { type: "transition", action: WORK_OBLIGATION_TRANSITION_ACTION.REOPEN }
+    : { type: "none" };
+};


### PR DESCRIPTION
The governed-work lifecycle rules (complete / cancel / reopen) lived twice: the transition endpoint's table and the legacy task-status path's re-implementation. Nothing bound them, so a rule change in one place could silently diverge in the other.

One shared module (`lib/work-obligations/transitions.ts`) now owns the transition table, the reopen status recompute (the two copies were already identical), and the reverse task-status → action lookup, which is derived from the table rather than hand-listed. Both call sites consume it; policy (authorization, reason requirements, locking, events, audit) stays where it was, in the same order.

No behavior changes: every existing test passes with zero expectation edits. The two paths do disagree today in several pre-existing ways (for example, `completed → cancelled` succeeds through the task API but the transition endpoint rejects it, and the endpoint enforces the `from` list while the legacy path does not). Those divergences are preserved verbatim and now visible side by side in one file; deciding them is deliberately out of scope here.

A new coherence test asserts the table's invariants from the table itself: no dead-end status, every status escapable, mirrored task statuses valid, the reverse lookup round-trips every action, reopen never lands back in the closed set.

https://claude.ai/code/session_01GckBYzFkS2k17FTRN8d6MX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced consistent handling for completing, cancelling and reopening work obligations.
  * Reopening now selects the appropriate status based on ownership.
  * Task status updates and work-obligation transitions now follow the same rules.
* **Bug Fixes**
  * Improved validation of allowed status changes and cancellation reasons.
  * Repeated closing statuses are handled safely without unnecessary transitions.
* **Tests**
  * Added comprehensive coverage for valid transitions, reopening behaviour and status mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->