### PR TITLE
feat: scope corpus projection work to exact subjects

### DIFF
--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -15,6 +15,7 @@ import {
   classifyTestBatch,
   composeTestBatches,
   dbTestBatchSize,
+  hasModuleScopeProcessEnvMutation,
   isDbTest,
   TEST_BATCH_KIND,
 } from "./test-batch-plan";
@@ -191,7 +192,8 @@ for (const { source, testPath } of classifiedTests) {
     dbBacked: isDbTest(testPath, source),
     heavyLogic:
       HEAVY_LOGIC_SOURCE_MARKERS.some((marker) => source.includes(marker)) ||
-      HEAVY_LOGIC_PATH_MARKERS.some((marker) => testPath.includes(marker)),
+      HEAVY_LOGIC_PATH_MARKERS.some((marker) => testPath.includes(marker)) ||
+      hasModuleScopeProcessEnvMutation(testPath, source),
     installsModuleMock: installsModuleMock(source),
     propertyOnly,
   });

--- a/apps/api/scripts/test-batch-plan.ts
+++ b/apps/api/scripts/test-batch-plan.ts
@@ -84,6 +84,42 @@ const DB_TEST_MARKERS = [
 ] as const;
 const DB_TEST_PATH_RE = /\.(?:integration|db)\.test\.tsx?$/u;
 
+const isProcessEnvExpression = (expression: ts.Expression): boolean =>
+  ts.isPropertyAccessExpression(expression) &&
+  ts.isIdentifier(expression.expression) &&
+  expression.expression.text === "process" &&
+  expression.name.text === "env";
+
+const isProcessEnvMember = (expression: ts.Expression): boolean =>
+  (ts.isElementAccessExpression(expression) ||
+    ts.isPropertyAccessExpression(expression)) &&
+  isProcessEnvExpression(expression.expression);
+
+/**
+ * Module-scope environment writes must run in a fresh process. Bun's module
+ * cache survives between files in a shared batch, so setting an env value
+ * after another file imported its reader cannot change the cached contract.
+ */
+export const hasModuleScopeProcessEnvMutation = (
+  testPath: string,
+  source: string,
+): boolean => {
+  const sourceFile = ts.createSourceFile(
+    testPath,
+    source,
+    ts.ScriptTarget.Latest,
+    false,
+    testPath.endsWith("x") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  return sourceFile.statements.some(
+    (statement) =>
+      ts.isExpressionStatement(statement) &&
+      ts.isBinaryExpression(statement.expression) &&
+      statement.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      isProcessEnvMember(statement.expression.left),
+  );
+};
+
 const isRuntimeImport = (statement: ts.ImportDeclaration) => {
   const { importClause } = statement;
   if (importClause === undefined) {

--- a/apps/api/scripts/test-batch-plan.ts
+++ b/apps/api/scripts/test-batch-plan.ts
@@ -120,15 +120,11 @@ const immediatelyInvokedBody = (node: ts.Node): ts.ConciseBody | null => {
 };
 
 const isAssignmentOperator = (kind: ts.SyntaxKind): boolean =>
-  kind >= ts.SyntaxKind.FirstAssignment &&
-  kind <= ts.SyntaxKind.LastAssignment;
+  kind >= ts.SyntaxKind.FirstAssignment && kind <= ts.SyntaxKind.LastAssignment;
 
 const hasEvaluatedProcessEnvMutation = (node: ts.Node): boolean => {
   const invokedBody = immediatelyInvokedBody(node);
-  if (
-    invokedBody !== null &&
-    hasEvaluatedProcessEnvMutation(invokedBody)
-  ) {
+  if (invokedBody !== null && hasEvaluatedProcessEnvMutation(invokedBody)) {
     return true;
   }
   if (isDeferredFunction(node)) {

--- a/apps/api/scripts/test-batch-plan.ts
+++ b/apps/api/scripts/test-batch-plan.ts
@@ -95,6 +95,33 @@ const isProcessEnvMember = (expression: ts.Expression): boolean =>
     ts.isPropertyAccessExpression(expression)) &&
   isProcessEnvExpression(expression.expression);
 
+const isDeferredFunction = (node: ts.Node): boolean =>
+  ts.isArrowFunction(node) ||
+  ts.isConstructorDeclaration(node) ||
+  ts.isFunctionDeclaration(node) ||
+  ts.isFunctionExpression(node) ||
+  ts.isGetAccessorDeclaration(node) ||
+  ts.isMethodDeclaration(node) ||
+  ts.isSetAccessorDeclaration(node);
+
+const hasEvaluatedProcessEnvMutation = (node: ts.Node): boolean => {
+  if (isDeferredFunction(node)) {
+    return false;
+  }
+  if (
+    ts.isBinaryExpression(node) &&
+    node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    isProcessEnvMember(node.left)
+  ) {
+    return true;
+  }
+  return (
+    ts.forEachChild(node, (child) =>
+      hasEvaluatedProcessEnvMutation(child) ? true : undefined,
+    ) === true
+  );
+};
+
 /**
  * Module-scope environment writes must run in a fresh process. Bun's module
  * cache survives between files in a shared batch, so setting an env value
@@ -111,13 +138,7 @@ export const hasModuleScopeProcessEnvMutation = (
     false,
     testPath.endsWith("x") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
   );
-  return sourceFile.statements.some(
-    (statement) =>
-      ts.isExpressionStatement(statement) &&
-      ts.isBinaryExpression(statement.expression) &&
-      statement.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-      isProcessEnvMember(statement.expression.left),
-  );
+  return sourceFile.statements.some(hasEvaluatedProcessEnvMutation);
 };
 
 const isRuntimeImport = (statement: ts.ImportDeclaration) => {

--- a/apps/api/scripts/test-batch-plan.ts
+++ b/apps/api/scripts/test-batch-plan.ts
@@ -104,13 +104,39 @@ const isDeferredFunction = (node: ts.Node): boolean =>
   ts.isMethodDeclaration(node) ||
   ts.isSetAccessorDeclaration(node);
 
+const unwrapParentheses = (expression: ts.Expression): ts.Expression =>
+  ts.isParenthesizedExpression(expression)
+    ? unwrapParentheses(expression.expression)
+    : expression;
+
+const immediatelyInvokedBody = (node: ts.Node): ts.ConciseBody | null => {
+  if (!ts.isCallExpression(node)) {
+    return null;
+  }
+  const callee = unwrapParentheses(node.expression);
+  return ts.isArrowFunction(callee) || ts.isFunctionExpression(callee)
+    ? callee.body
+    : null;
+};
+
+const isAssignmentOperator = (kind: ts.SyntaxKind): boolean =>
+  kind >= ts.SyntaxKind.FirstAssignment &&
+  kind <= ts.SyntaxKind.LastAssignment;
+
 const hasEvaluatedProcessEnvMutation = (node: ts.Node): boolean => {
+  const invokedBody = immediatelyInvokedBody(node);
+  if (
+    invokedBody !== null &&
+    hasEvaluatedProcessEnvMutation(invokedBody)
+  ) {
+    return true;
+  }
   if (isDeferredFunction(node)) {
     return false;
   }
   if (
     ts.isBinaryExpression(node) &&
-    node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    isAssignmentOperator(node.operatorToken.kind) &&
     isProcessEnvMember(node.left)
   ) {
     return true;

--- a/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
@@ -22,6 +22,11 @@ import {
   readCorpusProjectionDeleteSettlement,
 } from "@/api/lib/legal-search/corpus-index-projection-engine";
 import {
+  CORPUS_PROJECTION_GENERATION_SCOPE,
+  entityIdsForCorpusProjectionWorkScope,
+  type CorpusProjectionWorkScope,
+} from "@/api/lib/legal-search/corpus-index-projection-scope";
+import {
   CORPUS_PROJECTION_LEASE_MAX_MS,
   CORPUS_PROJECTION_LEASE_MIN_MS,
 } from "@/api/lib/legal-search/corpus-index-projection-store";
@@ -94,6 +99,7 @@ type ClaimCorpusProjectionCleanupOptions = {
   indexId: string;
   limit: number;
   leaseMs: number;
+  scope?: CorpusProjectionWorkScope;
   testNow?: Date;
   newLeaseToken?: () => string;
 };
@@ -106,12 +112,14 @@ export const claimCorpusProjectionCleanupTx = async (
     indexId,
     limit: requestedLimit,
     leaseMs: requestedLeaseMs,
+    scope = CORPUS_PROJECTION_GENERATION_SCOPE,
     testNow,
     newLeaseToken = () => Bun.randomUUIDv7(),
   }: ClaimCorpusProjectionCleanupOptions,
 ): Promise<CorpusProjectionCleanupLease[]> => {
   const limit = validateCleanupBatchSize(requestedLimit);
   const leaseMs = validateLeaseMs(requestedLeaseMs);
+  const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
   await readRegisteredCorpusProjectionManifestForCleanup(
     tx,
     family,
@@ -128,6 +136,9 @@ export const claimCorpusProjectionCleanupTx = async (
         eq(corpusIndexProjectionIntents.family, family),
         eq(corpusIndexProjectionIntents.generation, generation),
         eq(corpusIndexProjectionIntents.indexId, indexId),
+        scopedEntityIds === null
+          ? undefined
+          : inArray(corpusIndexProjectionIntents.entityId, scopedEntityIds),
         eq(corpusIndexProjectionIntents.status, "cleanup_pending"),
         sql`${corpusIndexProjectionIntents.cleanupNotBefore} <= clock_timestamp()`,
         or(
@@ -301,6 +312,7 @@ type ClaimCorpusProjectionCleanupSettlementOptions = {
   indexId: string;
   limit: number;
   leaseMs: number;
+  scope?: CorpusProjectionWorkScope;
   /** Deterministic database-test clock; production expiry uses PostgreSQL. */
   testNow?: Date;
   newLeaseToken?: () => string;
@@ -314,12 +326,14 @@ export const claimCorpusProjectionCleanupSettlementTx = async (
     indexId,
     limit: requestedLimit,
     leaseMs: requestedLeaseMs,
+    scope = CORPUS_PROJECTION_GENERATION_SCOPE,
     testNow,
     newLeaseToken = () => Bun.randomUUIDv7(),
   }: ClaimCorpusProjectionCleanupSettlementOptions,
 ): Promise<CorpusProjectionCleanupSettlementLease | null> => {
   const limit = validateCleanupBatchSize(requestedLimit);
   const leaseMs = validateLeaseMs(requestedLeaseMs);
+  const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
   await readRegisteredCorpusProjectionManifestForCleanup(
     tx,
     family,
@@ -333,6 +347,9 @@ export const claimCorpusProjectionCleanupSettlementTx = async (
         eq(corpusIndexProjectionIntents.family, family),
         eq(corpusIndexProjectionIntents.generation, generation),
         eq(corpusIndexProjectionIntents.indexId, indexId),
+        scopedEntityIds === null
+          ? undefined
+          : inArray(corpusIndexProjectionIntents.entityId, scopedEntityIds),
         eq(corpusIndexProjectionIntents.status, "cleanup_committed"),
         or(
           isNull(corpusIndexProjectionIntents.leaseExpiresAt),
@@ -361,6 +378,9 @@ export const claimCorpusProjectionCleanupSettlementTx = async (
         eq(corpusIndexProjectionIntents.family, family),
         eq(corpusIndexProjectionIntents.generation, generation),
         eq(corpusIndexProjectionIntents.indexId, indexId),
+        scopedEntityIds === null
+          ? undefined
+          : inArray(corpusIndexProjectionIntents.entityId, scopedEntityIds),
         eq(corpusIndexProjectionIntents.status, "cleanup_committed"),
         eq(corpusIndexProjectionIntents.deleteOpstamp, deleteOpstamp),
         or(
@@ -735,6 +755,7 @@ type RecoverExpiredCorpusProjectionIntentsOptions = {
   family: CorpusFamily;
   generation: string;
   limit: number;
+  scope?: CorpusProjectionWorkScope;
   testNow?: Date;
 };
 
@@ -749,10 +770,12 @@ export const recoverExpiredCorpusProjectionIntentsTx = async (
     family,
     generation,
     limit: requestedLimit,
+    scope = CORPUS_PROJECTION_GENERATION_SCOPE,
     testNow,
   }: RecoverExpiredCorpusProjectionIntentsOptions,
 ): Promise<CorpusProjectionExpiredIntent[]> => {
   const limit = validateCleanupBatchSize(requestedLimit);
+  const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
   const manifest = await readRegisteredCorpusProjectionManifestForCleanup(
     tx,
     family,
@@ -769,6 +792,9 @@ export const recoverExpiredCorpusProjectionIntentsTx = async (
       and(
         eq(corpusIndexProjectionIntents.family, family),
         eq(corpusIndexProjectionIntents.generation, generation),
+        scopedEntityIds === null
+          ? undefined
+          : inArray(corpusIndexProjectionIntents.entityId, scopedEntityIds),
         inArray(corpusIndexProjectionIntents.status, [
           "reserved",
           "append_started",

--- a/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
@@ -24,7 +24,7 @@ import {
 import {
   CORPUS_PROJECTION_GENERATION_SCOPE,
   entityIdsForCorpusProjectionWorkScope,
-  type CorpusProjectionWorkScope,
+  type CorpusProjectionScopedWorkOptions,
 } from "@/api/lib/legal-search/corpus-index-projection-scope";
 import {
   CORPUS_PROJECTION_LEASE_MAX_MS,
@@ -93,18 +93,19 @@ export type CorpusProjectionCleanupLease = {
   leaseToken: string;
 };
 
-type ClaimCorpusProjectionCleanupOptions = {
-  family: CorpusFamily;
-  generation: string;
-  indexId: string;
-  limit: number;
-  leaseMs: number;
-  scope?: CorpusProjectionWorkScope;
-  testNow?: Date;
-  newLeaseToken?: () => string;
-};
+type ClaimCorpusProjectionCleanupOptions<Family extends CorpusFamily> =
+  CorpusProjectionScopedWorkOptions<Family> & {
+    generation: string;
+    indexId: string;
+    limit: number;
+    leaseMs: number;
+    testNow?: Date;
+    newLeaseToken?: () => string;
+  };
 
-export const claimCorpusProjectionCleanupTx = async (
+export const claimCorpusProjectionCleanupTx = async <
+  Family extends CorpusFamily,
+>(
   tx: Transaction,
   {
     family,
@@ -115,7 +116,7 @@ export const claimCorpusProjectionCleanupTx = async (
     scope = CORPUS_PROJECTION_GENERATION_SCOPE,
     testNow,
     newLeaseToken = () => Bun.randomUUIDv7(),
-  }: ClaimCorpusProjectionCleanupOptions,
+  }: ClaimCorpusProjectionCleanupOptions<Family>,
 ): Promise<CorpusProjectionCleanupLease[]> => {
   const limit = validateCleanupBatchSize(requestedLimit);
   const leaseMs = validateLeaseMs(requestedLeaseMs);
@@ -306,19 +307,21 @@ export type CorpusProjectionCleanupSettlementLease = {
   leaseToken: string;
 };
 
-type ClaimCorpusProjectionCleanupSettlementOptions = {
-  family: CorpusFamily;
+type ClaimCorpusProjectionCleanupSettlementOptions<
+  Family extends CorpusFamily,
+> = CorpusProjectionScopedWorkOptions<Family> & {
   generation: string;
   indexId: string;
   limit: number;
   leaseMs: number;
-  scope?: CorpusProjectionWorkScope;
   /** Deterministic database-test clock; production expiry uses PostgreSQL. */
   testNow?: Date;
   newLeaseToken?: () => string;
 };
 
-export const claimCorpusProjectionCleanupSettlementTx = async (
+export const claimCorpusProjectionCleanupSettlementTx = async <
+  Family extends CorpusFamily,
+>(
   tx: Transaction,
   {
     family,
@@ -329,7 +332,7 @@ export const claimCorpusProjectionCleanupSettlementTx = async (
     scope = CORPUS_PROJECTION_GENERATION_SCOPE,
     testNow,
     newLeaseToken = () => Bun.randomUUIDv7(),
-  }: ClaimCorpusProjectionCleanupSettlementOptions,
+  }: ClaimCorpusProjectionCleanupSettlementOptions<Family>,
 ): Promise<CorpusProjectionCleanupSettlementLease | null> => {
   const limit = validateCleanupBatchSize(requestedLimit);
   const leaseMs = validateLeaseMs(requestedLeaseMs);
@@ -751,20 +754,21 @@ export type CorpusProjectionExpiredIntent = {
   >;
 };
 
-type RecoverExpiredCorpusProjectionIntentsOptions = {
-  family: CorpusFamily;
-  generation: string;
-  limit: number;
-  scope?: CorpusProjectionWorkScope;
-  testNow?: Date;
-};
+type RecoverExpiredCorpusProjectionIntentsOptions<Family extends CorpusFamily> =
+  CorpusProjectionScopedWorkOptions<Family> & {
+    generation: string;
+    limit: number;
+    testNow?: Date;
+  };
 
 /**
  * Recover only states whose external outcome is known from the recorded phase:
  * an expired reservation is cancelled, an expired append is assumed written,
  * and an expired delete is retried exactly.
  */
-export const recoverExpiredCorpusProjectionIntentsTx = async (
+export const recoverExpiredCorpusProjectionIntentsTx = async <
+  Family extends CorpusFamily,
+>(
   tx: Transaction,
   {
     family,
@@ -772,7 +776,7 @@ export const recoverExpiredCorpusProjectionIntentsTx = async (
     limit: requestedLimit,
     scope = CORPUS_PROJECTION_GENERATION_SCOPE,
     testNow,
-  }: RecoverExpiredCorpusProjectionIntentsOptions,
+  }: RecoverExpiredCorpusProjectionIntentsOptions<Family>,
 ): Promise<CorpusProjectionExpiredIntent[]> => {
   const limit = validateCleanupBatchSize(requestedLimit);
   const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);

--- a/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
@@ -14,7 +14,7 @@ import { corpusIndexUnknownAppendBarrierAt } from "@/api/lib/legal-search/corpus
 import {
   CORPUS_PROJECTION_GENERATION_SCOPE,
   entityIdsForCorpusProjectionWorkScope,
-  type CorpusProjectionWorkScope,
+  type CorpusProjectionScopedWorkOptions,
 } from "@/api/lib/legal-search/corpus-index-projection-scope";
 
 export const CORPUS_PROJECTION_ERASURE_MAX_BATCH_SIZE = 256;
@@ -22,13 +22,12 @@ export const CORPUS_PROJECTION_ERASURE_MAX_REVISIONS = 1024;
 
 type ProjectionIntentId = SafeId<"corpusIndexProjectionIntent">;
 
-type AdvanceCorpusProjectionErasuresOptions = {
-  family: CorpusFamily;
-  generation: string;
-  limit: number;
-  scope?: CorpusProjectionWorkScope;
-  testNow?: Date;
-};
+type AdvanceCorpusProjectionErasuresOptions<Family extends CorpusFamily> =
+  CorpusProjectionScopedWorkOptions<Family> & {
+    generation: string;
+    limit: number;
+    testNow?: Date;
+  };
 
 export type AdvanceCorpusProjectionErasuresResult = {
   claimedCount: number;
@@ -55,7 +54,9 @@ const validateLimit = (limit: number): number => {
  * exact revision is terminal. Engine I/O happens in the separate cleanup
  * phase; this transaction only advances durable state.
  */
-export const advanceCorpusProjectionErasuresTx = async (
+export const advanceCorpusProjectionErasuresTx = async <
+  Family extends CorpusFamily,
+>(
   tx: Transaction,
   {
     family,
@@ -63,7 +64,7 @@ export const advanceCorpusProjectionErasuresTx = async (
     limit: requestedLimit,
     scope = CORPUS_PROJECTION_GENERATION_SCOPE,
     testNow,
-  }: AdvanceCorpusProjectionErasuresOptions,
+  }: AdvanceCorpusProjectionErasuresOptions<Family>,
 ): Promise<AdvanceCorpusProjectionErasuresResult> => {
   const limit = validateLimit(requestedLimit);
   const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);

--- a/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
@@ -11,6 +11,11 @@ import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-cont
 import { CORPUS_INDEX_APPEND_PRODUCING_INTENT_STATUSES } from "@/api/lib/legal-search/corpus-index-projection-contract";
 import { readRegisteredCorpusProjectionManifestForCleanup } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import { corpusIndexUnknownAppendBarrierAt } from "@/api/lib/legal-search/corpus-index-projection-engine";
+import {
+  CORPUS_PROJECTION_GENERATION_SCOPE,
+  entityIdsForCorpusProjectionWorkScope,
+  type CorpusProjectionWorkScope,
+} from "@/api/lib/legal-search/corpus-index-projection-scope";
 
 export const CORPUS_PROJECTION_ERASURE_MAX_BATCH_SIZE = 256;
 export const CORPUS_PROJECTION_ERASURE_MAX_REVISIONS = 1024;
@@ -21,6 +26,7 @@ type AdvanceCorpusProjectionErasuresOptions = {
   family: CorpusFamily;
   generation: string;
   limit: number;
+  scope?: CorpusProjectionWorkScope;
   testNow?: Date;
 };
 
@@ -55,10 +61,12 @@ export const advanceCorpusProjectionErasuresTx = async (
     family,
     generation,
     limit: requestedLimit,
+    scope = CORPUS_PROJECTION_GENERATION_SCOPE,
     testNow,
   }: AdvanceCorpusProjectionErasuresOptions,
 ): Promise<AdvanceCorpusProjectionErasuresResult> => {
   const limit = validateLimit(requestedLimit);
+  const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
   const manifest = await readRegisteredCorpusProjectionManifestForCleanup(
     tx,
     family,
@@ -74,6 +82,9 @@ export const advanceCorpusProjectionErasuresTx = async (
       and(
         eq(corpusIndexProjectionStates.family, family),
         eq(corpusIndexProjectionStates.generation, generation),
+        scopedEntityIds === null
+          ? undefined
+          : inArray(corpusIndexProjectionStates.entityId, scopedEntityIds),
         eq(corpusIndexProjectionStates.desiredAction, "erase"),
         sql`(
           ${corpusIndexProjectionStates.appliedAction} IS DISTINCT FROM 'erase'

--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
@@ -14,7 +14,7 @@ import {
   readReservedCorpusProjectionMaterialsTx,
   type CorpusProjectionMaterial,
 } from "@/api/lib/legal-search/corpus-index-projection-materials";
-import type { CorpusProjectionWorkScope } from "@/api/lib/legal-search/corpus-index-projection-scope";
+import type { CorpusProjectionScopedWorkSelection } from "@/api/lib/legal-search/corpus-index-projection-scope";
 import {
   abandonCorpusProjectionAppendTx,
   cancelCorpusProjectionReservationTx,
@@ -57,12 +57,12 @@ const mapSequentially = async <Input, Output>(
 
 export const CORPUS_PROJECTION_PAYLOAD_READ_CONCURRENCY_MAX = 32;
 
-type ExecuteCorpusProjectionAppendCycleOptions = {
+type ExecuteCorpusProjectionAppendCycleOptions<
+  Family extends CorpusProjectionIntentLease["family"],
+> = CorpusProjectionScopedWorkSelection<Family> & {
   runInTransaction: ProjectionTransactionRunner;
   client: ProjectionAppendClient;
-  family: CorpusProjectionIntentLease["family"];
   generation: string;
-  scope: CorpusProjectionWorkScope;
   limit: number;
   leaseMs: number;
   payloadReadConcurrency: number;
@@ -661,7 +661,9 @@ const processPreparedWindows = async ({
  * Execute one bounded append cycle. Plane chooses scope, cadence, limits, and
  * concurrency; this primitive owns durable ordering and exact outcomes.
  */
-export const executeCorpusProjectionAppendCycle = async ({
+export const executeCorpusProjectionAppendCycle = async <
+  Family extends CorpusProjectionIntentLease["family"],
+>({
   runInTransaction,
   client,
   family,
@@ -672,7 +674,7 @@ export const executeCorpusProjectionAppendCycle = async ({
   payloadReadConcurrency,
   retryDelayMs,
   payloadRetryLimit,
-}: ExecuteCorpusProjectionAppendCycleOptions): Promise<CorpusProjectionAppendCycleResult> => {
+}: ExecuteCorpusProjectionAppendCycleOptions<Family>): Promise<CorpusProjectionAppendCycleResult> => {
   validateExecutorPolicy(
     payloadReadConcurrency,
     retryDelayMs,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
@@ -29,6 +29,9 @@ import {
   type CorpusProjectionReservationFailure,
   type CorpusProjectionIntentLease,
 } from "@/api/lib/legal-search/corpus-index-projection-store";
+import type {
+  CorpusProjectionWorkScope,
+} from "@/api/lib/legal-search/corpus-index-projection-scope";
 import {
   readCorpusAst,
   readCorpusAtAuthoritativePointer,
@@ -61,6 +64,7 @@ type ExecuteCorpusProjectionAppendCycleOptions = {
   client: ProjectionAppendClient;
   family: CorpusProjectionIntentLease["family"];
   generation: string;
+  scope: CorpusProjectionWorkScope;
   limit: number;
   leaseMs: number;
   payloadReadConcurrency: number;
@@ -664,6 +668,7 @@ export const executeCorpusProjectionAppendCycle = async ({
   client,
   family,
   generation,
+  scope,
   limit,
   leaseMs,
   payloadReadConcurrency,
@@ -679,11 +684,13 @@ export const executeCorpusProjectionAppendCycle = async ({
     replacements: await prepareCorpusProjectionReplacementsTx(tx, {
       family,
       generation,
+      scope,
       limit,
     }),
     leases: await reserveCorpusProjectionIntentsTx(tx, {
       family,
       generation,
+      scope,
       limit,
       leaseMs,
     }),

--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
@@ -14,9 +14,7 @@ import {
   readReservedCorpusProjectionMaterialsTx,
   type CorpusProjectionMaterial,
 } from "@/api/lib/legal-search/corpus-index-projection-materials";
-import type {
-  CorpusProjectionWorkScope,
-} from "@/api/lib/legal-search/corpus-index-projection-scope";
+import type { CorpusProjectionWorkScope } from "@/api/lib/legal-search/corpus-index-projection-scope";
 import {
   abandonCorpusProjectionAppendTx,
   cancelCorpusProjectionReservationTx,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
@@ -14,6 +14,9 @@ import {
   readReservedCorpusProjectionMaterialsTx,
   type CorpusProjectionMaterial,
 } from "@/api/lib/legal-search/corpus-index-projection-materials";
+import type {
+  CorpusProjectionWorkScope,
+} from "@/api/lib/legal-search/corpus-index-projection-scope";
 import {
   abandonCorpusProjectionAppendTx,
   cancelCorpusProjectionReservationTx,
@@ -29,9 +32,6 @@ import {
   type CorpusProjectionReservationFailure,
   type CorpusProjectionIntentLease,
 } from "@/api/lib/legal-search/corpus-index-projection-store";
-import type {
-  CorpusProjectionWorkScope,
-} from "@/api/lib/legal-search/corpus-index-projection-scope";
 import {
   readCorpusAst,
   readCorpusAtAuthoritativePointer,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-scope.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-scope.test.ts
@@ -1,17 +1,40 @@
 import { expect, test } from "bun:test";
+import { expectTypeOf } from "expect-type";
 
-import { toSafeId } from "@/api/lib/branded-types";
+import { toSafeId, type SafeId } from "@/api/lib/branded-types";
 
 import {
   CORPUS_PROJECTION_GENERATION_SCOPE,
   CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT,
   entityIdsForCorpusProjectionWorkScope,
+  type CorpusProjectionScopedWorkOptions,
 } from "./corpus-index-projection-scope";
 
 const DECISION_ID = toSafeId<"caseLawDecision">(
   "0198e331-e578-7000-8000-000000000202",
 );
 const SCOPE_ERROR = `must contain 1 to ${CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT} unique entities`;
+const distinctDecisionIds = Array.from(
+  { length: CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT + 1 },
+  (_, index) =>
+    toSafeId<"caseLawDecision">(
+      `0198e331-e578-7000-8000-${index.toString(16).padStart(12, "0")}`,
+    ),
+);
+
+type MismatchedCaseLawScope = {
+  family: "case_law";
+  scope: {
+    type: "subjects";
+    entityIds: readonly SafeId<"legislationDocument">[];
+  };
+};
+
+test("a subject scope couples entity identities to its family", () => {
+  expectTypeOf<MismatchedCaseLawScope>().not.toExtend<
+    CorpusProjectionScopedWorkOptions<"case_law">
+  >();
+});
 
 test("a generation scope has no entity predicate", () => {
   expect(
@@ -44,10 +67,16 @@ test("a subject scope rejects empty, duplicate, and oversized sets", () => {
   expect(() =>
     entityIdsForCorpusProjectionWorkScope({
       type: "subjects",
-      entityIds: Array.from(
-        { length: CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT + 1 },
-        () => DECISION_ID,
-      ),
+      entityIds: distinctDecisionIds,
     }),
   ).toThrow(SCOPE_ERROR);
+  expect(
+    entityIdsForCorpusProjectionWorkScope({
+      type: "subjects",
+      entityIds: distinctDecisionIds.slice(
+        0,
+        CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT,
+      ),
+    }),
+  ).toHaveLength(CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT);
 });

--- a/apps/api/src/lib/legal-search/corpus-index-projection-scope.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-scope.test.ts
@@ -11,14 +11,11 @@ import {
 const DECISION_ID = toSafeId<"caseLawDecision">(
   "0198e331-e578-7000-8000-000000000202",
 );
-const SCOPE_ERROR =
-  `must contain 1 to ${CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT} unique entities`;
+const SCOPE_ERROR = `must contain 1 to ${CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT} unique entities`;
 
 test("a generation scope has no entity predicate", () => {
   expect(
-    entityIdsForCorpusProjectionWorkScope(
-      CORPUS_PROJECTION_GENERATION_SCOPE,
-    ),
+    entityIdsForCorpusProjectionWorkScope(CORPUS_PROJECTION_GENERATION_SCOPE),
   ).toBeNull();
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-projection-scope.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-scope.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+
+import {
+  CORPUS_PROJECTION_GENERATION_SCOPE,
+  CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT,
+  entityIdsForCorpusProjectionWorkScope,
+} from "./corpus-index-projection-scope";
+
+const DECISION_ID = toSafeId<"caseLawDecision">(
+  "0198e331-e578-7000-8000-000000000202",
+);
+const SCOPE_ERROR =
+  `must contain 1 to ${CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT} unique entities`;
+
+test("a generation scope has no entity predicate", () => {
+  expect(
+    entityIdsForCorpusProjectionWorkScope(
+      CORPUS_PROJECTION_GENERATION_SCOPE,
+    ),
+  ).toBeNull();
+});
+
+test("a subject scope preserves its exact identities", () => {
+  expect(
+    entityIdsForCorpusProjectionWorkScope({
+      type: "subjects",
+      entityIds: [DECISION_ID],
+    }),
+  ).toEqual([DECISION_ID]);
+});
+
+test("a subject scope rejects empty, duplicate, and oversized sets", () => {
+  expect(() =>
+    entityIdsForCorpusProjectionWorkScope({
+      type: "subjects",
+      entityIds: [],
+    }),
+  ).toThrow(SCOPE_ERROR);
+  expect(() =>
+    entityIdsForCorpusProjectionWorkScope({
+      type: "subjects",
+      entityIds: [DECISION_ID, DECISION_ID],
+    }),
+  ).toThrow(SCOPE_ERROR);
+  expect(() =>
+    entityIdsForCorpusProjectionWorkScope({
+      type: "subjects",
+      entityIds: Array.from(
+        { length: CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT + 1 },
+        () => DECISION_ID,
+      ),
+    }),
+  ).toThrow(SCOPE_ERROR);
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-scope.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-scope.ts
@@ -1,32 +1,46 @@
 import { panic } from "better-result";
 
-import type { SafeId } from "@/api/lib/branded-types";
+import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
+import type { CorpusIndexProjectionSubject } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 
 export const CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT = 256;
-
-export type CorpusProjectionEntityId =
-  | SafeId<"caseLawDecision">
-  | SafeId<"legislationDocument">;
 
 export const CORPUS_PROJECTION_GENERATION_SCOPE = {
   type: "generation",
 } as const;
 
-export type CorpusProjectionWorkScope =
+type CorpusProjectionEntityId<Family extends CorpusFamily> = Extract<
+  CorpusIndexProjectionSubject,
+  { family: Family }
+>["entityId"];
+
+export type CorpusProjectionWorkScope<Family extends CorpusFamily> =
   | typeof CORPUS_PROJECTION_GENERATION_SCOPE
   | {
       type: "subjects";
-      entityIds: readonly CorpusProjectionEntityId[];
+      entityIds: readonly CorpusProjectionEntityId<Family>[];
     };
+
+export type CorpusProjectionScopedWorkSelection<Family extends CorpusFamily> = {
+  family: Family;
+  scope: CorpusProjectionWorkScope<NoInfer<Family>>;
+};
+
+export type CorpusProjectionScopedWorkOptions<Family extends CorpusFamily> = {
+  family: Family;
+  scope?: CorpusProjectionWorkScope<NoInfer<Family>>;
+};
 
 /**
  * Return null for a generation walk or the exact bounded subject set. Callers
  * place the returned IDs in the same SQL statement that claims work, so an
  * allowlist check can never race a later broad claim.
  */
-export const entityIdsForCorpusProjectionWorkScope = (
-  scope: CorpusProjectionWorkScope,
-): CorpusProjectionEntityId[] | null => {
+export const entityIdsForCorpusProjectionWorkScope = <
+  Family extends CorpusFamily,
+>(
+  scope: CorpusProjectionWorkScope<Family>,
+): CorpusProjectionEntityId<Family>[] | null => {
   switch (scope.type) {
     case "generation":
       return null;

--- a/apps/api/src/lib/legal-search/corpus-index-projection-scope.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-scope.ts
@@ -1,0 +1,48 @@
+import { panic } from "better-result";
+
+import type { SafeId } from "@/api/lib/branded-types";
+
+export const CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT = 256;
+
+export type CorpusProjectionEntityId =
+  | SafeId<"caseLawDecision">
+  | SafeId<"legislationDocument">;
+
+export const CORPUS_PROJECTION_GENERATION_SCOPE = {
+  type: "generation",
+} as const;
+
+export type CorpusProjectionWorkScope =
+  | typeof CORPUS_PROJECTION_GENERATION_SCOPE
+  | {
+      type: "subjects";
+      entityIds: readonly CorpusProjectionEntityId[];
+    };
+
+/**
+ * Return null for a generation walk or the exact bounded subject set. Callers
+ * place the returned IDs in the same SQL statement that claims work, so an
+ * allowlist check can never race a later broad claim.
+ */
+export const entityIdsForCorpusProjectionWorkScope = (
+  scope: CorpusProjectionWorkScope,
+): CorpusProjectionEntityId[] | null => {
+  switch (scope.type) {
+    case "generation":
+      return null;
+    case "subjects":
+      if (
+        scope.entityIds.length === 0 ||
+        scope.entityIds.length >
+          CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT ||
+        new Set(scope.entityIds).size !== scope.entityIds.length
+      ) {
+        return panic(
+          `Corpus projection subject scope must contain 1 to ${CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT} unique entities`,
+        );
+      }
+      return [...scope.entityIds];
+    default:
+      return scope satisfies never;
+  }
+};

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -270,9 +270,7 @@ test("a subject-scoped reservation cannot claim another pending decision", async
       }),
   );
 
-  expect(leases.map(({ entityId }) => entityId)).toEqual([
-    ERASE_DECISION_ID,
-  ]);
+  expect(leases.map(({ entityId }) => entityId)).toEqual([ERASE_DECISION_ID]);
   expect(
     await db
       .select({ entityId: corpusIndexProjectionIntents.entityId })
@@ -550,15 +548,12 @@ test("subject-scoped replacement cannot retire another applied revision", async 
 
   const replacements = await db.transaction(
     async (tx) =>
-      await prepareCorpusProjectionReplacementsTx(
-        asTestRaw<Transaction>(tx),
-        {
-          family: "case_law",
-          generation: "case_law_v5",
-          scope: { type: "subjects", entityIds: [ERASE_DECISION_ID] },
-          limit: 10,
-        },
-      ),
+      await prepareCorpusProjectionReplacementsTx(asTestRaw<Transaction>(tx), {
+        family: "case_law",
+        generation: "case_law_v5",
+        scope: { type: "subjects", entityIds: [ERASE_DECISION_ID] },
+        limit: 10,
+      }),
   );
 
   expect(replacements.map(({ intentId }) => intentId)).toEqual([

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -301,6 +301,7 @@ test("a subject-scoped erasure cannot apply another erased decision", async () =
     .update(corpusIndexProjectionStates)
     .set({
       desiredAction: "erase",
+      desiredEpoch: 2n,
       desiredFingerprint: null,
       desiredIndexId: null,
     })
@@ -333,6 +334,29 @@ test("a subject-scoped erasure cannot apply another erased decision", async () =
 
 test("subject-scoped cleanup and settlement cannot claim another revision", async () => {
   const cleanupAt = new Date("2026-08-25T00:00:00.000Z");
+  await db.insert(caseLawDecisions).values({
+    id: ERASE_DECISION_ID,
+    sourceId: SOURCE_ID,
+    caseNumber: "2 A 2/2026",
+    court: "Test court",
+    country: "CZE",
+    language: "cs",
+    contentHash: "d".repeat(64),
+    projectionEpoch: 1n,
+  });
+  await db.insert(corpusIndexProjectionStates).values({
+    family: "case_law",
+    generation: "case_law_v5",
+    entityId: ERASE_DECISION_ID,
+    desiredAction: "upsert",
+    desiredEpoch: 1n,
+    desiredFingerprint: SECOND_FINGERPRINT,
+    desiredIndexId: INDEX_ID,
+    updatedAt: INITIAL_RUNNABLE_AT,
+  });
+  await db.execute(
+    sql`ALTER TABLE corpus_index_projection_intents DISABLE TRIGGER corpus_index_projection_intents_insert_guard`,
+  );
   await db.insert(corpusIndexProjectionIntents).values([
     {
       id: FIRST_INTENT_ID,
@@ -361,6 +385,9 @@ test("subject-scoped cleanup and settlement cannot claim another revision", asyn
       cleanupNotBefore: cleanupAt,
     },
   ]);
+  await db.execute(
+    sql`ALTER TABLE corpus_index_projection_intents ENABLE TRIGGER corpus_index_projection_intents_insert_guard`,
+  );
 
   const cleanup = await db.transaction(
     async (tx) =>
@@ -417,6 +444,26 @@ test("subject-scoped cleanup and settlement cannot claim another revision", asyn
 
 test("subject-scoped recovery cannot cancel another expired reservation", async () => {
   const expiredAt = new Date("2026-08-25T00:00:00.000Z");
+  await db.insert(caseLawDecisions).values({
+    id: ERASE_DECISION_ID,
+    sourceId: SOURCE_ID,
+    caseNumber: "2 A 2/2026",
+    court: "Test court",
+    country: "CZE",
+    language: "cs",
+    contentHash: "d".repeat(64),
+    projectionEpoch: 1n,
+  });
+  await db.insert(corpusIndexProjectionStates).values({
+    family: "case_law",
+    generation: "case_law_v5",
+    entityId: ERASE_DECISION_ID,
+    desiredAction: "upsert",
+    desiredEpoch: 1n,
+    desiredFingerprint: SECOND_FINGERPRINT,
+    desiredIndexId: INDEX_ID,
+    updatedAt: INITIAL_RUNNABLE_AT,
+  });
   await db.insert(corpusIndexProjectionIntents).values([
     {
       id: FIRST_INTENT_ID,
@@ -486,6 +533,9 @@ test("subject-scoped replacement cannot retire another applied revision", async 
     contentHash: "d".repeat(64),
     projectionEpoch: 2n,
   });
+  await db.execute(
+    sql`ALTER TABLE corpus_index_projection_intents DISABLE TRIGGER corpus_index_projection_intents_insert_guard`,
+  );
   await db.insert(corpusIndexProjectionIntents).values([
     {
       id: FIRST_INTENT_ID,
@@ -516,6 +566,9 @@ test("subject-scoped replacement cannot retire another applied revision", async 
       appliedAt,
     },
   ]);
+  await db.execute(
+    sql`ALTER TABLE corpus_index_projection_intents ENABLE TRIGGER corpus_index_projection_intents_insert_guard`,
+  );
   await db
     .update(corpusIndexProjectionStates)
     .set({

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -235,6 +235,349 @@ afterEach(async () => {
   await client.close();
 });
 
+test("a subject-scoped reservation cannot claim another pending decision", async () => {
+  await db.insert(caseLawDecisions).values({
+    id: ERASE_DECISION_ID,
+    sourceId: SOURCE_ID,
+    caseNumber: "2 A 2/2026",
+    court: "Test court",
+    country: "CZE",
+    language: "cs",
+    contentHash: "d".repeat(64),
+    projectionEpoch: 1n,
+  });
+  await db.insert(corpusIndexProjectionStates).values({
+    family: "case_law",
+    generation: "case_law_v5",
+    entityId: ERASE_DECISION_ID,
+    desiredAction: "upsert",
+    desiredEpoch: 1n,
+    desiredFingerprint: SECOND_FINGERPRINT,
+    desiredIndexId: INDEX_ID,
+    updatedAt: INITIAL_RUNNABLE_AT,
+  });
+
+  const leases = await db.transaction(
+    async (tx) =>
+      await reserveCorpusProjectionIntentsTx(asTestRaw<Transaction>(tx), {
+        family: "case_law",
+        generation: "case_law_v5",
+        scope: { type: "subjects", entityIds: [ERASE_DECISION_ID] },
+        limit: 10,
+        leaseMs: 60_000,
+        newIntentId: () => FIRST_INTENT_ID,
+        newLeaseToken: () => FIRST_LEASE_TOKEN,
+      }),
+  );
+
+  expect(leases.map(({ entityId }) => entityId)).toEqual([
+    ERASE_DECISION_ID,
+  ]);
+  expect(
+    await db
+      .select({ entityId: corpusIndexProjectionIntents.entityId })
+      .from(corpusIndexProjectionIntents),
+  ).toEqual([{ entityId: ERASE_DECISION_ID }]);
+});
+
+test("a subject-scoped erasure cannot apply another erased decision", async () => {
+  await db.insert(caseLawDecisions).values({
+    id: ERASE_DECISION_ID,
+    sourceId: SOURCE_ID,
+    caseNumber: "2 A 2/2026",
+    court: "Test court",
+    country: "CZE",
+    language: "cs",
+    contentHash: "d".repeat(64),
+    projectionEpoch: 1n,
+  });
+  await db.insert(corpusIndexProjectionStates).values({
+    family: "case_law",
+    generation: "case_law_v5",
+    entityId: ERASE_DECISION_ID,
+    desiredAction: "erase",
+    desiredEpoch: 1n,
+    updatedAt: INITIAL_RUNNABLE_AT,
+  });
+  await db
+    .update(corpusIndexProjectionStates)
+    .set({
+      desiredAction: "erase",
+      desiredFingerprint: null,
+      desiredIndexId: null,
+    })
+    .where(eq(corpusIndexProjectionStates.entityId, DECISION_ID));
+
+  const result = await db.transaction(
+    async (tx) =>
+      await advanceCorpusProjectionErasuresTx(asTestRaw<Transaction>(tx), {
+        family: "case_law",
+        generation: "case_law_v5",
+        scope: { type: "subjects", entityIds: [ERASE_DECISION_ID] },
+        limit: 10,
+      }),
+  );
+
+  expect(result.appliedEntityIds).toEqual([ERASE_DECISION_ID]);
+  expect(
+    await db
+      .select({
+        entityId: corpusIndexProjectionStates.entityId,
+        appliedAction: corpusIndexProjectionStates.appliedAction,
+      })
+      .from(corpusIndexProjectionStates)
+      .orderBy(corpusIndexProjectionStates.entityId),
+  ).toEqual([
+    { entityId: DECISION_ID, appliedAction: null },
+    { entityId: ERASE_DECISION_ID, appliedAction: "erase" },
+  ]);
+});
+
+test("subject-scoped cleanup and settlement cannot claim another revision", async () => {
+  const cleanupAt = new Date("2026-08-25T00:00:00.000Z");
+  await db.insert(corpusIndexProjectionIntents).values([
+    {
+      id: FIRST_INTENT_ID,
+      family: "case_law",
+      generation: "case_law_v5",
+      entityId: DECISION_ID,
+      epoch: 1n,
+      fingerprint: FIRST_FINGERPRINT,
+      indexId: INDEX_ID,
+      status: "cleanup_pending",
+      appendStartedAt: cleanupAt,
+      appendPublishBarrierAt: cleanupAt,
+      cleanupNotBefore: cleanupAt,
+    },
+    {
+      id: SECOND_INTENT_ID,
+      family: "case_law",
+      generation: "case_law_v5",
+      entityId: ERASE_DECISION_ID,
+      epoch: 1n,
+      fingerprint: SECOND_FINGERPRINT,
+      indexId: INDEX_ID,
+      status: "cleanup_pending",
+      appendStartedAt: cleanupAt,
+      appendPublishBarrierAt: cleanupAt,
+      cleanupNotBefore: cleanupAt,
+    },
+  ]);
+
+  const cleanup = await db.transaction(
+    async (tx) =>
+      await claimCorpusProjectionCleanupTx(asTestRaw<Transaction>(tx), {
+        family: "case_law",
+        generation: "case_law_v5",
+        indexId: INDEX_ID,
+        scope: { type: "subjects", entityIds: [ERASE_DECISION_ID] },
+        limit: 10,
+        leaseMs: 60_000,
+        newLeaseToken: () => CLEANUP_LEASE_TOKEN,
+      }),
+  );
+  expect(cleanup.map(({ intentId }) => intentId)).toEqual([SECOND_INTENT_ID]);
+  await db.transaction(
+    async (tx) =>
+      await recordCorpusProjectionDeleteTx(asTestRaw<Transaction>(tx), {
+        intentIds: [SECOND_INTENT_ID],
+        indexId: INDEX_ID,
+        leaseToken: CLEANUP_LEASE_TOKEN,
+        deleteOpstamp: 42,
+      }),
+  );
+
+  const settlement = await db.transaction(
+    async (tx) =>
+      await claimCorpusProjectionCleanupSettlementTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          indexId: INDEX_ID,
+          scope: { type: "subjects", entityIds: [ERASE_DECISION_ID] },
+          limit: 10,
+          leaseMs: 60_000,
+          newLeaseToken: () => ERASE_CLEANUP_TOKEN,
+        },
+      ),
+  );
+  expect(settlement?.intentIds).toEqual([SECOND_INTENT_ID]);
+  expect(
+    await db
+      .select({
+        id: corpusIndexProjectionIntents.id,
+        status: corpusIndexProjectionIntents.status,
+      })
+      .from(corpusIndexProjectionIntents)
+      .orderBy(corpusIndexProjectionIntents.id),
+  ).toEqual([
+    { id: FIRST_INTENT_ID, status: "cleanup_pending" },
+    { id: SECOND_INTENT_ID, status: "cleanup_committed" },
+  ]);
+});
+
+test("subject-scoped recovery cannot cancel another expired reservation", async () => {
+  const expiredAt = new Date("2026-08-25T00:00:00.000Z");
+  await db.insert(corpusIndexProjectionIntents).values([
+    {
+      id: FIRST_INTENT_ID,
+      family: "case_law",
+      generation: "case_law_v5",
+      entityId: DECISION_ID,
+      epoch: 1n,
+      fingerprint: FIRST_FINGERPRINT,
+      indexId: INDEX_ID,
+      status: "reserved",
+      leaseToken: FIRST_LEASE_TOKEN,
+      leaseExpiresAt: expiredAt,
+    },
+    {
+      id: SECOND_INTENT_ID,
+      family: "case_law",
+      generation: "case_law_v5",
+      entityId: ERASE_DECISION_ID,
+      epoch: 1n,
+      fingerprint: SECOND_FINGERPRINT,
+      indexId: INDEX_ID,
+      status: "reserved",
+      leaseToken: SECOND_LEASE_TOKEN,
+      leaseExpiresAt: expiredAt,
+    },
+  ]);
+
+  const recovered = await db.transaction(
+    async (tx) =>
+      await recoverExpiredCorpusProjectionIntentsTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          scope: { type: "subjects", entityIds: [ERASE_DECISION_ID] },
+          limit: 10,
+        },
+      ),
+  );
+
+  expect(recovered).toEqual([
+    { intentId: SECOND_INTENT_ID, status: "reserved" },
+  ]);
+  expect(
+    await db
+      .select({
+        id: corpusIndexProjectionIntents.id,
+        status: corpusIndexProjectionIntents.status,
+      })
+      .from(corpusIndexProjectionIntents)
+      .orderBy(corpusIndexProjectionIntents.id),
+  ).toEqual([
+    { id: FIRST_INTENT_ID, status: "reserved" },
+    { id: SECOND_INTENT_ID, status: "cancelled" },
+  ]);
+});
+
+test("subject-scoped replacement cannot retire another applied revision", async () => {
+  const appliedAt = new Date("2026-08-25T00:00:00.000Z");
+  await db.insert(caseLawDecisions).values({
+    id: ERASE_DECISION_ID,
+    sourceId: SOURCE_ID,
+    caseNumber: "2 A 2/2026",
+    court: "Test court",
+    country: "CZE",
+    language: "cs",
+    contentHash: "d".repeat(64),
+    projectionEpoch: 2n,
+  });
+  await db.insert(corpusIndexProjectionIntents).values([
+    {
+      id: FIRST_INTENT_ID,
+      family: "case_law",
+      generation: "case_law_v5",
+      entityId: DECISION_ID,
+      epoch: 1n,
+      fingerprint: FIRST_FINGERPRINT,
+      indexId: INDEX_ID,
+      status: "applied",
+      appendStartedAt: appliedAt,
+      appendCommittedAt: appliedAt,
+      expectedDocumentCount: 1,
+      appliedAt,
+    },
+    {
+      id: SECOND_INTENT_ID,
+      family: "case_law",
+      generation: "case_law_v5",
+      entityId: ERASE_DECISION_ID,
+      epoch: 1n,
+      fingerprint: FIRST_FINGERPRINT,
+      indexId: INDEX_ID,
+      status: "applied",
+      appendStartedAt: appliedAt,
+      appendCommittedAt: appliedAt,
+      expectedDocumentCount: 1,
+      appliedAt,
+    },
+  ]);
+  await db
+    .update(corpusIndexProjectionStates)
+    .set({
+      desiredEpoch: 2n,
+      desiredFingerprint: SECOND_FINGERPRINT,
+      appliedAction: "upsert",
+      appliedEpoch: 1n,
+      appliedRevision: FIRST_INTENT_ID,
+      appliedFingerprint: FIRST_FINGERPRINT,
+      appliedIndexId: INDEX_ID,
+      appliedAt,
+    })
+    .where(eq(corpusIndexProjectionStates.entityId, DECISION_ID));
+  await db.insert(corpusIndexProjectionStates).values({
+    family: "case_law",
+    generation: "case_law_v5",
+    entityId: ERASE_DECISION_ID,
+    desiredAction: "upsert",
+    desiredEpoch: 2n,
+    desiredFingerprint: SECOND_FINGERPRINT,
+    desiredIndexId: INDEX_ID,
+    appliedAction: "upsert",
+    appliedEpoch: 1n,
+    appliedRevision: SECOND_INTENT_ID,
+    appliedFingerprint: FIRST_FINGERPRINT,
+    appliedIndexId: INDEX_ID,
+    appliedAt,
+    updatedAt: INITIAL_RUNNABLE_AT,
+  });
+
+  const replacements = await db.transaction(
+    async (tx) =>
+      await prepareCorpusProjectionReplacementsTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          scope: { type: "subjects", entityIds: [ERASE_DECISION_ID] },
+          limit: 10,
+        },
+      ),
+  );
+
+  expect(replacements.map(({ intentId }) => intentId)).toEqual([
+    SECOND_INTENT_ID,
+  ]);
+  expect(
+    await db
+      .select({
+        id: corpusIndexProjectionIntents.id,
+        status: corpusIndexProjectionIntents.status,
+      })
+      .from(corpusIndexProjectionIntents)
+      .orderBy(corpusIndexProjectionIntents.id),
+  ).toEqual([
+    { id: FIRST_INTENT_ID, status: "applied" },
+    { id: SECOND_INTENT_ID, status: "cleanup_pending" },
+  ]);
+});
+
 test("retry classification defers poison work, then blocks the exhausted desired state", async () => {
   const startedAt = new Date("2026-08-25T12:00:00.000Z");
   await db.insert(caseLawDecisions).values({

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -298,6 +298,10 @@ test("a subject-scoped erasure cannot apply another erased decision", async () =
     updatedAt: INITIAL_RUNNABLE_AT,
   });
   await db
+    .update(caseLawDecisions)
+    .set({ projectionEpoch: 2n })
+    .where(eq(caseLawDecisions.id, DECISION_ID));
+  await db
     .update(corpusIndexProjectionStates)
     .set({
       desiredAction: "erase",
@@ -569,6 +573,10 @@ test("subject-scoped replacement cannot retire another applied revision", async 
   await db.execute(
     sql`ALTER TABLE corpus_index_projection_intents ENABLE TRIGGER corpus_index_projection_intents_insert_guard`,
   );
+  await db
+    .update(caseLawDecisions)
+    .set({ projectionEpoch: 2n })
+    .where(eq(caseLawDecisions.id, DECISION_ID));
   await db
     .update(corpusIndexProjectionStates)
     .set({

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
@@ -21,7 +21,7 @@ import {
 import {
   CORPUS_PROJECTION_GENERATION_SCOPE,
   entityIdsForCorpusProjectionWorkScope,
-  type CorpusProjectionWorkScope,
+  type CorpusProjectionScopedWorkOptions,
 } from "@/api/lib/legal-search/corpus-index-projection-scope";
 import { corpusIndexProjectionNeedsWork } from "@/api/lib/legal-search/corpus-index-projection-sql";
 
@@ -44,17 +44,16 @@ export type CorpusProjectionIntentLease = {
   leaseExpiresAt: Date;
 };
 
-type ReserveCorpusProjectionIntentsOptions = {
-  family: CorpusFamily;
-  generation: string;
-  limit: number;
-  leaseMs: number;
-  scope?: CorpusProjectionWorkScope;
-  /** Deterministic database-test clock; production expiry uses PostgreSQL. */
-  testNow?: Date;
-  newIntentId?: () => ProjectionIntentId;
-  newLeaseToken?: () => string;
-};
+type ReserveCorpusProjectionIntentsOptions<Family extends CorpusFamily> =
+  CorpusProjectionScopedWorkOptions<Family> & {
+    generation: string;
+    limit: number;
+    leaseMs: number;
+    /** Deterministic database-test clock; production expiry uses PostgreSQL. */
+    testNow?: Date;
+    newIntentId?: () => ProjectionIntentId;
+    newLeaseToken?: () => string;
+  };
 
 const validateBatchSize = (limit: number): number => {
   if (
@@ -121,7 +120,9 @@ const noOutstandingIntent = sql`NOT EXISTS (
  * entity is terminal. This enforces delete-old, settle, then append-new; Plane
  * controls how often and how broadly this bounded primitive runs.
  */
-export const reserveCorpusProjectionIntentsTx = async (
+export const reserveCorpusProjectionIntentsTx = async <
+  Family extends CorpusFamily,
+>(
   tx: Transaction,
   {
     family,
@@ -132,7 +133,7 @@ export const reserveCorpusProjectionIntentsTx = async (
     testNow,
     newIntentId = () => createSafeId<"corpusIndexProjectionIntent">(),
     newLeaseToken = () => Bun.randomUUIDv7(),
-  }: ReserveCorpusProjectionIntentsOptions,
+  }: ReserveCorpusProjectionIntentsOptions<Family>,
 ): Promise<CorpusProjectionIntentLease[]> => {
   const limit = validateBatchSize(requestedLimit);
   const leaseMs = validateLeaseMs(requestedLeaseMs);
@@ -286,20 +287,21 @@ export type CorpusProjectionReplacementCleanup = {
   indexId: string;
 };
 
-type PrepareCorpusProjectionReplacementsOptions = {
-  family: CorpusFamily;
-  generation: string;
-  limit: number;
-  scope?: CorpusProjectionWorkScope;
-  testNow?: Date;
-};
+type PrepareCorpusProjectionReplacementsOptions<Family extends CorpusFamily> =
+  CorpusProjectionScopedWorkOptions<Family> & {
+    generation: string;
+    limit: number;
+    testNow?: Date;
+  };
 
 /**
  * Move current but superseded revisions to cleanup before a replacement can
  * be reserved. Applied revisions are known published, so no unknown-append
  * delay is needed; delete settlement remains mandatory.
  */
-export const prepareCorpusProjectionReplacementsTx = async (
+export const prepareCorpusProjectionReplacementsTx = async <
+  Family extends CorpusFamily,
+>(
   tx: Transaction,
   {
     family,
@@ -307,7 +309,7 @@ export const prepareCorpusProjectionReplacementsTx = async (
     limit: requestedLimit,
     scope = CORPUS_PROJECTION_GENERATION_SCOPE,
     testNow,
-  }: PrepareCorpusProjectionReplacementsOptions,
+  }: PrepareCorpusProjectionReplacementsOptions<Family>,
 ): Promise<CorpusProjectionReplacementCleanup[]> => {
   const limit = validateBatchSize(requestedLimit);
   const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
@@ -18,6 +18,11 @@ import {
   CORPUS_PROJECTION_APPEND_MAX_REVISIONS,
   corpusIndexUnknownAppendBarrierAt,
 } from "@/api/lib/legal-search/corpus-index-projection-engine";
+import {
+  CORPUS_PROJECTION_GENERATION_SCOPE,
+  entityIdsForCorpusProjectionWorkScope,
+  type CorpusProjectionWorkScope,
+} from "@/api/lib/legal-search/corpus-index-projection-scope";
 import { corpusIndexProjectionNeedsWork } from "@/api/lib/legal-search/corpus-index-projection-sql";
 
 export const CORPUS_PROJECTION_STORE_MAX_BATCH_SIZE =
@@ -44,6 +49,7 @@ type ReserveCorpusProjectionIntentsOptions = {
   generation: string;
   limit: number;
   leaseMs: number;
+  scope?: CorpusProjectionWorkScope;
   /** Deterministic database-test clock; production expiry uses PostgreSQL. */
   testNow?: Date;
   newIntentId?: () => ProjectionIntentId;
@@ -122,6 +128,7 @@ export const reserveCorpusProjectionIntentsTx = async (
     generation,
     limit: requestedLimit,
     leaseMs: requestedLeaseMs,
+    scope = CORPUS_PROJECTION_GENERATION_SCOPE,
     testNow,
     newIntentId = () => createSafeId<"corpusIndexProjectionIntent">(),
     newLeaseToken = () => Bun.randomUUIDv7(),
@@ -129,6 +136,7 @@ export const reserveCorpusProjectionIntentsTx = async (
 ): Promise<CorpusProjectionIntentLease[]> => {
   const limit = validateBatchSize(requestedLimit);
   const leaseMs = validateLeaseMs(requestedLeaseMs);
+  const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
   await readActiveCorpusProjectionManifest(tx, family, generation, true);
   const eligibilityAt = testNow ?? (await readPostgresClock(tx));
   const runnableAt = sql<Date>`coalesce(
@@ -158,6 +166,9 @@ export const reserveCorpusProjectionIntentsTx = async (
       and(
         eq(corpusIndexProjectionStates.family, family),
         eq(corpusIndexProjectionStates.generation, generation),
+        scopedEntityIds === null
+          ? undefined
+          : inArray(corpusIndexProjectionStates.entityId, scopedEntityIds),
         eq(corpusIndexProjectionStates.desiredAction, "upsert"),
         inArray(corpusIndexProjectionStates.workStatus, [
           "eligible",
@@ -279,6 +290,7 @@ type PrepareCorpusProjectionReplacementsOptions = {
   family: CorpusFamily;
   generation: string;
   limit: number;
+  scope?: CorpusProjectionWorkScope;
   testNow?: Date;
 };
 
@@ -293,10 +305,12 @@ export const prepareCorpusProjectionReplacementsTx = async (
     family,
     generation,
     limit: requestedLimit,
+    scope = CORPUS_PROJECTION_GENERATION_SCOPE,
     testNow,
   }: PrepareCorpusProjectionReplacementsOptions,
 ): Promise<CorpusProjectionReplacementCleanup[]> => {
   const limit = validateBatchSize(requestedLimit);
+  const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
   await readActiveCorpusProjectionManifest(tx, family, generation, true);
   const candidates = await tx
     .select({
@@ -309,6 +323,9 @@ export const prepareCorpusProjectionReplacementsTx = async (
       and(
         eq(corpusIndexProjectionStates.family, family),
         eq(corpusIndexProjectionStates.generation, generation),
+        scopedEntityIds === null
+          ? undefined
+          : inArray(corpusIndexProjectionStates.entityId, scopedEntityIds),
         eq(corpusIndexProjectionStates.desiredAction, "upsert"),
         eq(corpusIndexProjectionStates.appliedAction, "upsert"),
         isNotNull(corpusIndexProjectionStates.appliedRevision),

--- a/apps/api/src/tests/test-batch-plan.test.ts
+++ b/apps/api/src/tests/test-batch-plan.test.ts
@@ -123,12 +123,16 @@ describe("API test batch planning", () => {
     for (const source of [
       'process.env["REDIS_URL"] = "redis://127.0.0.1:1";',
       'process.env.REDIS_URL = "redis://127.0.0.1:1";',
+      'if (enabled) { process.env.REDIS_URL = "redis://127.0.0.1:1"; }',
+      'const configured = (process.env.REDIS_URL = "redis://127.0.0.1:1");',
     ]) {
       expect(hasModuleScopeProcessEnvMutation(testPath, source)).toBe(true);
     }
     for (const source of [
       'const value = process.env["REDIS_URL"];',
       'test("scoped", () => { process.env["REDIS_URL"] = "value"; });',
+      'const deferred = () => { process.env.REDIS_URL = "value"; };',
+      'function deferred() { process.env.REDIS_URL = "value"; }',
       '// process.env["REDIS_URL"] = "value";',
     ]) {
       expect(hasModuleScopeProcessEnvMutation(testPath, source)).toBe(false);

--- a/apps/api/src/tests/test-batch-plan.test.ts
+++ b/apps/api/src/tests/test-batch-plan.test.ts
@@ -123,8 +123,12 @@ describe("API test batch planning", () => {
     for (const source of [
       'process.env["REDIS_URL"] = "redis://127.0.0.1:1";',
       'process.env.REDIS_URL = "redis://127.0.0.1:1";',
+      'process.env.REDIS_URL ??= "redis://127.0.0.1:1";',
+      'process.env.REDIS_URL += "?isolated=true";',
       'if (enabled) { process.env.REDIS_URL = "redis://127.0.0.1:1"; }',
       'const configured = (process.env.REDIS_URL = "redis://127.0.0.1:1");',
+      '(() => { process.env.REDIS_URL = "redis://127.0.0.1:1"; })();',
+      '(function () { process.env.REDIS_URL = "redis://127.0.0.1:1"; })();',
     ]) {
       expect(hasModuleScopeProcessEnvMutation(testPath, source)).toBe(true);
     }

--- a/apps/api/src/tests/test-batch-plan.test.ts
+++ b/apps/api/src/tests/test-batch-plan.test.ts
@@ -5,6 +5,7 @@ import {
   classifyTestBatch,
   composeTestBatches,
   dbTestBatchSize,
+  hasModuleScopeProcessEnvMutation,
   isDbTest,
   TEST_BATCH_KIND,
 } from "../../scripts/test-batch-plan";
@@ -115,5 +116,22 @@ describe("API test batch planning", () => {
     }
 
     expect(isDbTest("src/example.db.test.ts", "")).toBe(true);
+  });
+
+  test("isolates only module-scope process environment mutations", () => {
+    const testPath = "src/example.test.ts";
+    for (const source of [
+      'process.env["REDIS_URL"] = "redis://127.0.0.1:1";',
+      'process.env.REDIS_URL = "redis://127.0.0.1:1";',
+    ]) {
+      expect(hasModuleScopeProcessEnvMutation(testPath, source)).toBe(true);
+    }
+    for (const source of [
+      'const value = process.env["REDIS_URL"];',
+      'test("scoped", () => { process.env["REDIS_URL"] = "value"; });',
+      '// process.env["REDIS_URL"] = "value";',
+    ]) {
+      expect(hasModuleScopeProcessEnvMutation(testPath, source)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
Adds an explicit generation-or-subject projection scope. Exact subject IDs are included in the same locking SQL statements that reserve appends, retire replacements, advance erasures, recover expired work, and claim cleanup or settlement, so scoped callers cannot race into unrelated work.

The top-level append executor now requires callers to choose a scope. Database tests keep an unselected document pending through each scoped lifecycle phase. Family-generic scopes derive their ID brand from the projection subject union, so mismatched corpus IDs do not type-check.

The API test batcher also isolates files that mutate `process.env` at module scope. This prevents a previously imported environment reader from leaking cached configuration into those tests.

CC on behalf of sok0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added scoped processing for corpus projections, allowing operations to target specific subjects or run across the full generation.
  - Added safeguards limiting subject-scoped batches to 256 unique subjects.

- **Bug Fixes**
  - Prevented projection work from affecting entities outside the selected scope, including reservation, erasure, cleanup, settlement and recovery operations.

- **Tests**
  - Added coverage for scoped processing, validation rules and environment-sensitive test batching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->