### PR TITLE
fix: enforce the transition table on governed legacy status writes

### DIFF
--- a/apps/api/src/handlers/tasks/update.test.ts
+++ b/apps/api/src/handlers/tasks/update.test.ts
@@ -419,7 +419,7 @@ describe("updateTaskHandler governed lifecycle", () => {
 
   test("lets the owner complete from every status the table admits", async () => {
     const runs = await Promise.all(
-      WORK_OBLIGATION_TRANSITIONS.complete.from.map((status) =>
+      WORK_OBLIGATION_TRANSITIONS.complete.from.map(async (status) =>
         runStatusWrite({
           governedWorkflow: true,
           owner: "caller",

--- a/apps/api/src/handlers/tasks/update.test.ts
+++ b/apps/api/src/handlers/tasks/update.test.ts
@@ -9,8 +9,12 @@ import {
   workObligationEvents,
   workObligations,
 } from "@/api/db/schema";
+import type { WorkObligationStatus } from "@/api/db/schema";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { AuditAction, AuditRecorder } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import { updateTaskHandler } from "@/api/lib/tasks/update-task";
+import { WORK_OBLIGATION_TRANSITIONS } from "@/api/lib/work-obligations/transitions";
 import { mintAuthProviderId } from "@/api/tests/helpers/auth-provider-id";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
@@ -267,5 +271,213 @@ describe("updateTaskHandler legacy deadline compatibility", () => {
         }),
       ]),
     );
+  });
+});
+
+type StatusWriteOptions = {
+  governedWorkflow: boolean;
+  owner: "caller" | "other" | "none";
+  requestedStatus: string;
+  status: WorkObligationStatus;
+  workflowReason?: string;
+};
+
+/**
+ * Drive one legacy task-status write against an obligation in a known state,
+ * and report what the obligation row and the audit trail received.
+ */
+const runStatusWrite = async ({
+  governedWorkflow,
+  owner,
+  requestedStatus,
+  status,
+  workflowReason,
+}: StatusWriteOptions) => {
+  const taskId = createSafeId<"entity">();
+  const workspaceId = createSafeId<"workspace">();
+  const userId = mintAuthProviderId<"user">();
+  const workflowUpdates: Record<string, unknown>[] = [];
+  const auditActions: AuditAction[] = [];
+  const workflow = {
+    entityId: taskId,
+    workspaceId,
+    type: WORK_OBLIGATION_TYPE.TASK,
+    status,
+    ownerUserId: {
+      caller: userId,
+      other: mintAuthProviderId<"user">(),
+      none: null,
+    }[owner],
+    acknowledgedAt: new Date("2026-01-01T00:00:00Z"),
+    workingTargetDate: null,
+    hardDeadlineDate: null,
+  };
+  const { safeDb } = createScopedDbMock({
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => ({ for: async () => [workflow] }) }),
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (values: Record<string, unknown>) => {
+        if (table === workObligations) {
+          workflowUpdates.push(values);
+        }
+        return {
+          where: () => ({
+            returning: async () =>
+              table === entities ? [{ id: taskId }] : [{ entityId: taskId }],
+          }),
+        };
+      },
+    }),
+    insert: () => ({ values: async () => {} }),
+  });
+  const recordAuditEvent: AuditRecorder = async (_tx, event) => {
+    for (const entry of Array.isArray(event) ? event : [event]) {
+      if (entry.resourceType === AUDIT_RESOURCE_TYPE.WORK_OBLIGATION) {
+        auditActions.push(entry.action);
+      }
+    }
+  };
+
+  const result = await Result.gen(() =>
+    updateTaskHandler({
+      safeDb,
+      workspaceId,
+      userId,
+      recordAuditEvent,
+      body: {
+        taskId,
+        status: requestedStatus,
+        ...(workflowReason === undefined ? {} : { workflowReason }),
+      },
+      features: { governedWorkflow, legalLists: true },
+    }),
+  );
+
+  return { auditActions, result, workflowUpdates };
+};
+
+describe("updateTaskHandler governed lifecycle", () => {
+  test("refuses to cancel completed work", async () => {
+    const { result, workflowUpdates } = await runStatusWrite({
+      governedWorkflow: true,
+      owner: "caller",
+      requestedStatus: "cancelled",
+      status: WORK_OBLIGATION_STATUS.COMPLETED,
+      workflowReason: "superseded",
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error).toMatchObject({
+        status: 409,
+        message:
+          "Work that is completed must be reopened before it can be cancelled",
+      });
+    }
+    expect(workflowUpdates).toEqual([]);
+  });
+
+  test("refuses to complete cancelled work", async () => {
+    const { result, workflowUpdates } = await runStatusWrite({
+      governedWorkflow: true,
+      owner: "caller",
+      requestedStatus: "done",
+      status: WORK_OBLIGATION_STATUS.CANCELLED,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error).toMatchObject({
+        status: 409,
+        message:
+          "Work that is cancelled must be reopened before it can be completed",
+      });
+    }
+    expect(workflowUpdates).toEqual([]);
+  });
+
+  test("refuses completion by anyone but the accountable owner", async () => {
+    const { result, workflowUpdates } = await runStatusWrite({
+      governedWorkflow: true,
+      owner: "other",
+      requestedStatus: "done",
+      status: WORK_OBLIGATION_STATUS.ACTIVE,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error).toMatchObject({
+        status: 409,
+        message: "Only the accountable owner can complete this work",
+      });
+    }
+    expect(workflowUpdates).toEqual([]);
+  });
+
+  test("lets the owner complete from every status the table admits", async () => {
+    const runs = await Promise.all(
+      WORK_OBLIGATION_TRANSITIONS.complete.from.map((status) =>
+        runStatusWrite({
+          governedWorkflow: true,
+          owner: "caller",
+          requestedStatus: "done",
+          status,
+        }),
+      ),
+    );
+
+    for (const { auditActions, result, workflowUpdates } of runs) {
+      expect(Result.isOk(result)).toBe(true);
+      expect(workflowUpdates).toEqual([
+        expect.objectContaining({ status: WORK_OBLIGATION_STATUS.COMPLETED }),
+      ]);
+      expect(auditActions).toEqual([AUDIT_ACTION.UPDATE]);
+    }
+  });
+
+  test("audits a cancellation as a cancellation", async () => {
+    const { auditActions, result, workflowUpdates } = await runStatusWrite({
+      governedWorkflow: true,
+      owner: "caller",
+      requestedStatus: "cancelled",
+      status: WORK_OBLIGATION_STATUS.ACTIVE,
+      workflowReason: "client withdrew the instruction",
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(workflowUpdates).toEqual([
+      expect.objectContaining({ status: WORK_OBLIGATION_STATUS.CANCELLED }),
+    ]);
+    expect(auditActions).toEqual([AUDIT_ACTION.CANCEL]);
+  });
+
+  test("ungoverned deployments keep flipping closed work freely", async () => {
+    const cancelled = await runStatusWrite({
+      governedWorkflow: false,
+      owner: "none",
+      requestedStatus: "cancelled",
+      status: WORK_OBLIGATION_STATUS.COMPLETED,
+    });
+
+    expect(Result.isOk(cancelled.result)).toBe(true);
+    expect(cancelled.workflowUpdates).toEqual([
+      expect.objectContaining({ status: WORK_OBLIGATION_STATUS.CANCELLED }),
+    ]);
+    expect(cancelled.auditActions).toEqual([AUDIT_ACTION.CANCEL]);
+
+    const completed = await runStatusWrite({
+      governedWorkflow: false,
+      owner: "none",
+      requestedStatus: "done",
+      status: WORK_OBLIGATION_STATUS.CANCELLED,
+    });
+
+    expect(Result.isOk(completed.result)).toBe(true);
+    expect(completed.workflowUpdates).toEqual([
+      expect.objectContaining({ status: WORK_OBLIGATION_STATUS.COMPLETED }),
+    ]);
   });
 });

--- a/apps/api/src/handlers/work-obligations/transition.ts
+++ b/apps/api/src/handlers/work-obligations/transition.ts
@@ -9,7 +9,7 @@ import {
   workObligations,
 } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
-import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import { AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
@@ -18,6 +18,7 @@ import {
   resolveWorkObligationTransition,
   WORK_OBLIGATION_TRANSITION_ACTION,
   WORK_OBLIGATION_TRANSITION_ACTIONS,
+  WORK_OBLIGATION_TRANSITION_AUDIT_ACTION,
 } from "@/api/lib/work-obligations/transitions";
 
 const transitionParams = workspaceParams({ entityId: tSafeId("entity") });
@@ -121,10 +122,7 @@ const transitionWorkObligation = createSafeHandler(
           occurredAt: now,
         });
         await recordAuditEvent(tx, {
-          action:
-            body.action === WORK_OBLIGATION_TRANSITION_ACTION.CANCEL
-              ? AUDIT_ACTION.CANCEL
-              : AUDIT_ACTION.UPDATE,
+          action: WORK_OBLIGATION_TRANSITION_AUDIT_ACTION[body.action],
           resourceType: AUDIT_RESOURCE_TYPE.WORK_OBLIGATION,
           resourceId: params.entityId,
           changes: {

--- a/apps/api/src/lib/tasks/update-task.ts
+++ b/apps/api/src/lib/tasks/update-task.ts
@@ -15,9 +15,13 @@ import {
   workObligationEvents,
   workObligations,
 } from "@/api/db/schema";
-import type { ListItemType } from "@/api/db/schema";
+import type { ListItemType, WorkObligationStatus } from "@/api/db/schema";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
-import type { AuditRecorder, FieldDiffs } from "@/api/lib/audit-log";
+import type {
+  AuditAction,
+  AuditRecorder,
+  FieldDiffs,
+} from "@/api/lib/audit-log";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
@@ -40,8 +44,11 @@ import { isWorkObligationEligible } from "@/api/lib/work-obligations/eligibility
 import { ensureLegacyWorkObligation } from "@/api/lib/work-obligations/legacy-work-obligation";
 import { lockWorkObligation } from "@/api/lib/work-obligations/lock-work-obligation";
 import {
+  isClosedWorkObligationStatus,
   nextWorkObligationStatus,
+  resolveWorkObligationTransition,
   WORK_OBLIGATION_TRANSITION_ACTION,
+  WORK_OBLIGATION_TRANSITION_AUDIT_ACTION,
   WORK_OBLIGATION_TRANSITIONS,
   workObligationIntentForTaskStatus,
 } from "@/api/lib/work-obligations/transitions";
@@ -382,39 +389,53 @@ type ResolveWorkflowStatusTransitionOptions = {
   workflowReason: string | undefined;
 };
 
-type WorkflowStatusPolicyOptions = ResolveWorkflowStatusTransitionOptions & {
+type WorkflowStatusPolicyOptions = {
   action: WorkObligationTransitionAction;
+  userId: SafeId<"user">;
+  workflow: LockedWorkObligation;
+  workflowReason: string | undefined;
+};
+
+/** The move each action names, for the message a refusal has to explain. */
+const BLOCKED_MOVE = {
+  complete: "completed",
+  cancel: "cancelled",
+  reopen: "reopened",
+} as const satisfies Record<WorkObligationTransitionAction, string>;
+
+/**
+ * Closed work has exactly one way back, so say so; every other refused source
+ * status simply is not one the lifecycle admits for that move.
+ */
+const blockedTransitionMessage = (
+  action: WorkObligationTransitionAction,
+  status: WorkObligationStatus,
+): string => {
+  const current = `Work that is ${status.replaceAll("_", " ")}`;
+  return isClosedWorkObligationStatus(status)
+    ? `${current} must be reopened before it can be ${BLOCKED_MOVE[action]}`
+    : `${current} cannot be ${BLOCKED_MOVE[action]}`;
 };
 
 /**
  * A legacy status write carries no explicit intent, so the guards the
  * transition endpoint applies per action are re-applied here. They stay at this
  * call site: the shared table owns which move a status implies, not who may
- * make it.
- *
- * Ungoverned workspaces keep writing task statuses freely; the obligation row
- * only mirrors them.
+ * make it, and the source statuses it admits are already settled before this
+ * runs.
  */
 const assertWorkflowStatusPolicy = ({
   action,
-  governedWorkflow,
   userId,
   workflow,
   workflowReason,
 }: WorkflowStatusPolicyOptions): void => {
-  if (!governedWorkflow) {
-    return;
-  }
   switch (action) {
     case WORK_OBLIGATION_TRANSITION_ACTION.COMPLETE:
-      if (
-        workflow.status !== WORK_OBLIGATION_STATUS.ACTIVE ||
-        workflow.ownerUserId !== userId
-      ) {
+      if (workflow.ownerUserId !== userId) {
         throw new HandlerError({
           status: 409,
-          message:
-            "Only the acknowledged accountable owner can complete this work",
+          message: "Only the accountable owner can complete this work",
         });
       }
       return;
@@ -438,22 +459,50 @@ const assertWorkflowStatusPolicy = ({
   }
 };
 
-const resolveWorkflowStatusTransition = (
-  options: ResolveWorkflowStatusTransitionOptions,
-) => {
-  const { requestedStatus, workflow } = options;
+/**
+ * Governed deployments resolve the implied move through the shared table, so a
+ * task-status write can only reach the obligation states the endpoint would
+ * reach. Ungoverned deployments keep legacy freedom: the obligation row mirrors
+ * whatever status the write asks for.
+ */
+const resolveWorkflowStatusTransition = ({
+  governedWorkflow,
+  requestedStatus,
+  userId,
+  workflow,
+  workflowReason,
+}: ResolveWorkflowStatusTransitionOptions) => {
   const intent = workObligationIntentForTaskStatus({
     currentStatus: workflow.status,
     requestedTaskStatus: requestedStatus,
   });
   if (intent.type === "none") {
-    return { eventType: undefined, status: workflow.status };
+    return { type: "none" as const };
+  }
+  const { action } = intent;
+
+  if (!governedWorkflow) {
+    return {
+      type: "transition" as const,
+      action,
+      eventType: WORK_OBLIGATION_TRANSITIONS[action].eventType,
+      nextStatus: nextWorkObligationStatus(action, workflow),
+    };
   }
 
-  assertWorkflowStatusPolicy({ ...options, action: intent.action });
+  const resolution = resolveWorkObligationTransition(action, workflow);
+  if (resolution.type === "invalid_status") {
+    throw new HandlerError({
+      status: 409,
+      message: blockedTransitionMessage(action, workflow.status),
+    });
+  }
+  assertWorkflowStatusPolicy({ action, userId, workflow, workflowReason });
   return {
-    eventType: WORK_OBLIGATION_TRANSITIONS[intent.action].eventType,
-    status: nextWorkObligationStatus(intent.action, workflow),
+    type: "transition" as const,
+    action,
+    eventType: resolution.eventType,
+    nextStatus: resolution.nextStatus,
   };
 };
 
@@ -565,6 +614,7 @@ export const updateTaskHandler = async function* ({
       const workflowSet: Partial<typeof workObligations.$inferInsert> = {};
       const workflowEvents: (typeof workObligationEvents.$inferInsert)[] = [];
       const workflowChanges: FieldDiffs = {};
+      let workflowAuditAction: AuditAction = AUDIT_ACTION.UPDATE;
       const now = new Date();
 
       if (workflow && eligibility.type !== "removes_obligation") {
@@ -576,35 +626,36 @@ export const updateTaskHandler = async function* ({
         const nextLegacyHardDeadlineDate = updatesLegacyDeadline
           ? body.dueDate
           : undefined;
-        const { eventType: workflowEventType, status: nextWorkflowStatus } =
-          resolveWorkflowStatusTransition({
-            governedWorkflow: features.governedWorkflow,
-            requestedStatus: body.status,
-            userId,
-            workflow,
-            workflowReason,
-          });
+        const statusTransition = resolveWorkflowStatusTransition({
+          governedWorkflow: features.governedWorkflow,
+          requestedStatus: body.status,
+          userId,
+          workflow,
+          workflowReason,
+        });
 
-        if (nextWorkflowStatus !== workflow.status && workflowEventType) {
-          workflowSet.status = nextWorkflowStatus;
-          if (nextWorkflowStatus === WORK_OBLIGATION_STATUS.UNASSIGNED) {
+        if (statusTransition.type === "transition") {
+          const { action, eventType, nextStatus } = statusTransition;
+          workflowAuditAction = WORK_OBLIGATION_TRANSITION_AUDIT_ACTION[action];
+          workflowSet.status = nextStatus;
+          if (nextStatus === WORK_OBLIGATION_STATUS.UNASSIGNED) {
             workflowSet.acknowledgedAt = null;
             workflowSet.acknowledgedByUserId = null;
           }
           workflowChanges["status"] = {
             old: workflow.status,
-            new: nextWorkflowStatus,
+            new: nextStatus,
           };
           workflowEvents.push({
             id: createSafeId<"workObligationEvent">(),
             workspaceId,
             obligationEntityId: body.taskId,
             actorUserId: userId,
-            type: workflowEventType,
+            type: eventType,
             details: {
               type: "status_changed",
               previousStatus: workflow.status,
-              nextStatus: nextWorkflowStatus,
+              nextStatus,
             },
             reason: workflowReason ?? null,
             occurredAt: now,
@@ -739,7 +790,7 @@ export const updateTaskHandler = async function* ({
           }
           await tx.insert(workObligationEvents).values(workflowEvents);
           await recordAuditEvent(tx, {
-            action: AUDIT_ACTION.UPDATE,
+            action: workflowAuditAction,
             resourceType: AUDIT_RESOURCE_TYPE.WORK_OBLIGATION,
             resourceId: body.taskId,
             changes: workflowChanges,

--- a/apps/api/src/lib/work-obligations/transitions.ts
+++ b/apps/api/src/lib/work-obligations/transitions.ts
@@ -3,6 +3,8 @@ import {
   WORK_OBLIGATION_STATUS,
 } from "@/api/db/schema";
 import type { WorkObligationStatus } from "@/api/db/schema";
+import { AUDIT_ACTION } from "@/api/lib/audit-log.constants";
+import type { AuditAction } from "@/api/lib/audit-log.constants";
 import { TASK_STATUS } from "@/api/lib/entity-constants";
 import type { TaskStatus } from "@/api/lib/entity-constants";
 
@@ -12,9 +14,23 @@ import type { TaskStatus } from "@/api/lib/entity-constants";
  * Two entry points move an obligation: the explicit transition endpoint, and a
  * legacy task-status write (task API or `save_task`) that implies one. Both
  * read this table, so the allowed source statuses, the target status, the
- * lifecycle event and the mirrored legacy task status cannot drift apart.
- * Permissions, reason requirements, locking and event emission stay with each
- * caller: this module owns the transition data and the pure resolution only.
+ * lifecycle event, the mirrored legacy task status and the audit action cannot
+ * drift apart. Permissions, reason requirements, locking and event emission
+ * stay with each caller: this module owns the transition data and the pure
+ * resolution only.
+ *
+ * Where the two surfaces still differ, they differ on purpose:
+ * - Ungoverned deployments bypass this table's source-status check entirely;
+ *   the obligation only mirrors whatever status the task write asks for.
+ * - Writing a status the obligation already carries is an idempotent no-op on
+ *   the legacy path, while the endpoint answers 409 for the repeat transition.
+ * - Reopening through the legacy path keeps the caller's explicit open task
+ *   status; the endpoint writes the table's `taskStatus` (`in_progress`).
+ * - Concurrency guards differ: the endpoint re-checks the source statuses in
+ *   its `UPDATE` and reports a conflict, the legacy path holds the row lock it
+ *   read under and panics if the row moved.
+ * - Error codes follow each surface's convention: the endpoint distinguishes
+ *   403 for ownership from 409 for status, the legacy task write answers 409.
  */
 export const WORK_OBLIGATION_TRANSITION_ACTION = {
   COMPLETE: "complete",
@@ -86,8 +102,20 @@ export const WORK_OBLIGATION_TRANSITIONS = {
   WorkObligationTransition
 >;
 
+/**
+ * How each lifecycle move reads in the audit trail. Cancellation is its own
+ * audited action; the rest are ordinary updates to the obligation.
+ */
+export const WORK_OBLIGATION_TRANSITION_AUDIT_ACTION = {
+  complete: AUDIT_ACTION.UPDATE,
+  cancel: AUDIT_ACTION.CANCEL,
+  reopen: AUDIT_ACTION.UPDATE,
+} as const satisfies Record<WorkObligationTransitionAction, AuditAction>;
+
 /** Closed work is exactly the work reopening exists to bring back. */
-const isClosedStatus = (status: WorkObligationStatus): boolean =>
+export const isClosedWorkObligationStatus = (
+  status: WorkObligationStatus,
+): boolean =>
   WORK_OBLIGATION_TRANSITIONS.reopen.from.some((from) => from === status);
 
 /**
@@ -172,7 +200,8 @@ const closingActionForTaskStatus = (
   WORK_OBLIGATION_TRANSITION_ACTIONS.find((action) => {
     const transition = WORK_OBLIGATION_TRANSITIONS[action];
     return (
-      transition.taskStatus === taskStatus && isClosedStatus(transition.to)
+      transition.taskStatus === taskStatus &&
+      isClosedWorkObligationStatus(transition.to)
     );
   });
 
@@ -201,7 +230,7 @@ export const workObligationIntentForTaskStatus = ({
       ? { type: "none" }
       : { type: "transition", action: closingAction };
   }
-  return isClosedStatus(currentStatus)
+  return isClosedWorkObligationStatus(currentStatus)
     ? { type: "transition", action: WORK_OBLIGATION_TRANSITION_ACTION.REOPEN }
     : { type: "none" };
 };

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -9,6 +9,11 @@ import {
 } from "bun:test";
 import JSZip from "jszip";
 
+import {
+  entities,
+  WORK_OBLIGATION_STATUS,
+  workObligations,
+} from "@/api/db/schema";
 import { env } from "@/api/env";
 import { envBase } from "@/api/env-base";
 import type { AuditRecorder } from "@/api/lib/audit-log";
@@ -36,7 +41,7 @@ import type { FakeS3 } from "@/api/tests/helpers/fake-s3";
 import { installRecordingAnalytics } from "@/api/tests/helpers/recording-telemetry";
 import type { RecordingAnalytics } from "@/api/tests/helpers/recording-telemetry";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
-import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
+import { createScopedDbMock, toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
 /**
  * Minimal DOCX with a Heading1 paragraph, a two-row table, and a body
@@ -3956,6 +3961,84 @@ describe("OpenAI-compatible MCP tools", () => {
       isError: true,
     });
     expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  // save_task writes task status through the same handler as the task API, so
+  // the governed lifecycle binds it too. Governed enforcement is off in this
+  // deployment, so the legacy freedom to complete cancelled work has to
+  // survive: the shared transition table is not consulted at all.
+  const createTaskStatusScopedDb = () => {
+    const workflowUpdates: Record<string, unknown>[] = [];
+    const { scopedDb } = createScopedDbMock({
+      query: {
+        entities: {
+          findFirst: async () => ({
+            kind: "task",
+            readOnly: false,
+            workspaceId: "ws_1",
+          }),
+        },
+      },
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: () => ({
+              for: async () => [
+                {
+                  entityId: "task_1",
+                  workspaceId: "ws_1",
+                  type: "task",
+                  status: WORK_OBLIGATION_STATUS.CANCELLED,
+                  ownerUserId: null,
+                  acknowledgedAt: null,
+                  workingTargetDate: null,
+                  hardDeadlineDate: null,
+                },
+              ],
+            }),
+          }),
+        }),
+      }),
+      update: (table: unknown) => ({
+        set: (values: Record<string, unknown>) => {
+          if (table === workObligations) {
+            workflowUpdates.push(values);
+          }
+          return {
+            where: () => ({
+              returning: async () =>
+                table === entities
+                  ? [{ id: "task_1" }]
+                  : [{ entityId: "task_1" }],
+            }),
+          };
+        },
+      }),
+      insert: () => ({ values: async () => {} }),
+    });
+    return { scopedDb, workflowUpdates };
+  };
+
+  test("save_task completes cancelled work while governed enforcement is off", async () => {
+    const { scopedDb, workflowUpdates } = createTaskStatusScopedDb();
+
+    const result = await handleMcpToolCall({
+      args: { task_id: "task_1", status: "done" },
+      context: createContext({ scopedDb }),
+      toolName: "save_task",
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ taskId: "task_1", updated: true }),
+        },
+      ],
+    });
+    expect(workflowUpdates).toEqual([
+      expect.objectContaining({ status: WORK_OBLIGATION_STATUS.COMPLETED }),
+    ]);
   });
 
   // link_matter_contact accepts contact_id as an unlink selector, but a contact


### PR DESCRIPTION
Resolves the behavioral divergences #2619 made visible, under one principle: governed rules bind every surface when the governed-workflow feature is on; ungoverned deployments keep legacy freedom.

- The legacy task-status path (task API and `save_task`) now resolves an implied lifecycle transition through the shared table when governed: moves the transition endpoint rejects are rejected here too, with a 409 naming the blocked move ("Work that is completed must be reopened before it can be cancelled"). Previously `completed → cancelled` and `cancelled → done` succeeded silently on this path only.
- Complete is guarded by accountable ownership exactly as the endpoint defines it (the extra active-status requirement is gone; the `from` list decides admissibility). Each surface keeps its error-code convention (403 endpoint, 409 legacy).
- Lifecycle audit events record the real action (cancel records cancel) on both paths, via a total action → audit-action map on the shared module. This applies in both modes: the obligation transition genuinely occurs either way, and a flag-shaped audit label would reintroduce the divergence class.
- The remaining per-surface differences are now documented as intended on the shared module: legacy repeat writes stay idempotent no-ops (imports and sync must not error) while the endpoint 409s; legacy reopen honors the caller's explicit open status while the endpoint writes `in_progress`; the concurrency guards differ per transaction structure.

New coverage: governed blocked moves 409 and write nothing; non-owner complete 409s; the owner completes from every status in `complete.from` (derived from the table); governed cancel audits as cancel; ungoverned flips remain unrestricted, asserted explicitly for both previously divergent moves and for the MCP surface.

https://claude.ai/code/session_01GckBYzFkS2k17FTRN8d6MX
