### PR TITLE
fix: prevent Postgres health-check recovery loops

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,9 @@ services:
       - pgdata:/var/lib/postgresql
       - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      # Exec directly: if Docker times out a shell health check, its orphaned
+      # child can be reaped by the Postgres PID 1 as a failed server process.
+      test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

- run the local Postgres readiness probe directly instead of through a shell
- prevent timed-out health checks from leaving an orphan process that Postgres treats as a failed child

## Validation

- `docker compose --profile dev config --quiet`
- `bun run lint:ws`
- live health-check timeout reproduction: direct probes no longer trigger Postgres recovery
- `bun run verify` was started; completed checks passed, then it was interrupted to restore the local development server