### PR TITLE
fix: preserve deleted file icons in activity

### DIFF
--- a/apps/api/src/handlers/entities/delete-file-snapshot.test.ts
+++ b/apps/api/src/handlers/entities/delete-file-snapshot.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+
+import type { FieldContent } from "@/api/db/schema-validators";
+
+import {
+  selectCanonicalFileContents,
+  type DeletionFileFieldRow,
+} from "./delete-file-snapshot";
+
+const fileContent = (
+  fileName: string,
+): Extract<FieldContent, { type: "file" }> => ({
+  encrypted: false,
+  fileName,
+  id: "00000000-0000-0000-0000-000000000001",
+  mimeType: "application/pdf",
+  pdfFileId: null,
+  sha256Hex: "0".repeat(64),
+  sizeBytes: 1,
+  type: "file",
+  version: 1,
+});
+
+test("selects the lowest-ID current-version file regardless of row order", () => {
+  const fieldRows: DeletionFileFieldRow[] = [
+    {
+      content: fileContent("secondary.pdf"),
+      entityVersionId: "version-1",
+      id: "00000000-0000-0000-0000-000000000002",
+    },
+    {
+      content: fileContent("primary.pdf"),
+      entityVersionId: "version-1",
+      id: "00000000-0000-0000-0000-000000000001",
+    },
+  ];
+
+  expect(
+    selectCanonicalFileContents(
+      fieldRows,
+      new Map([["version-1", "entity-1"]]),
+    ).get("entity-1")?.fileName,
+  ).toBe("primary.pdf");
+});

--- a/apps/api/src/handlers/entities/delete-file-snapshot.ts
+++ b/apps/api/src/handlers/entities/delete-file-snapshot.ts
@@ -1,0 +1,38 @@
+import type { FieldContent } from "@/api/db/schema-validators";
+
+type FileFieldContent = Extract<FieldContent, { type: "file" }>;
+
+export type DeletionFileFieldRow = {
+  content: FieldContent;
+  entityVersionId: string;
+  id: string;
+};
+
+/**
+ * Selects the same canonical file field as activity reads: the first file by
+ * field ID on each entity's current version. The input is sorted here as well
+ * as in the database query so the invariant is independent of row order.
+ */
+export const selectCanonicalFileContents = (
+  fieldRows: readonly DeletionFileFieldRow[],
+  entityIdByCurrentVersionId: ReadonlyMap<string, string>,
+): Map<string, FileFieldContent> => {
+  const currentFileByEntityId = new Map<string, FileFieldContent>();
+  const orderedFieldRows = fieldRows.toSorted((left, right) =>
+    left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
+  );
+
+  for (const { content, entityVersionId } of orderedFieldRows) {
+    const entityId = entityIdByCurrentVersionId.get(entityVersionId);
+    if (
+      content.type !== "file" ||
+      entityId === undefined ||
+      currentFileByEntityId.has(entityId)
+    ) {
+      continue;
+    }
+    currentFileByEntityId.set(entityId, content);
+  }
+
+  return currentFileByEntityId;
+};

--- a/apps/api/src/handlers/entities/delete-file-snapshot.ts
+++ b/apps/api/src/handlers/entities/delete-file-snapshot.ts
@@ -18,9 +18,15 @@ export const selectCanonicalFileContents = (
   entityIdByCurrentVersionId: ReadonlyMap<string, string>,
 ): Map<string, FileFieldContent> => {
   const currentFileByEntityId = new Map<string, FileFieldContent>();
-  const orderedFieldRows = fieldRows.toSorted((left, right) =>
-    left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
-  );
+  const orderedFieldRows = fieldRows.toSorted((left, right) => {
+    if (left.id < right.id) {
+      return -1;
+    }
+    if (left.id > right.id) {
+      return 1;
+    }
+    return 0;
+  });
 
   for (const { content, entityVersionId } of orderedFieldRows) {
     const entityId = entityIdByCurrentVersionId.get(entityVersionId);

--- a/apps/api/src/handlers/entities/delete.test.ts
+++ b/apps/api/src/handlers/entities/delete.test.ts
@@ -47,3 +47,16 @@ test("routes cleanup dispatch through the bounded hand-off", () => {
   expect(source).toContain("handoffCommittedEntityDeletionCleanupBatch(");
   expect(source).not.toContain("Promise.all(");
 });
+
+test("records the canonical file field in the deletion snapshot", () => {
+  const fieldSelect = source.indexOf("id: fields.id");
+  const fieldOrder = source.indexOf(".orderBy(asc(fields.id))", fieldSelect);
+  const firstFileGuard = source.indexOf(
+    "currentFileByEntityId.has(entityId)",
+    fieldOrder,
+  );
+
+  expect(fieldSelect).toBeGreaterThan(-1);
+  expect(fieldOrder).toBeGreaterThan(fieldSelect);
+  expect(firstFileGuard).toBeGreaterThan(fieldOrder);
+});

--- a/apps/api/src/handlers/entities/delete.test.ts
+++ b/apps/api/src/handlers/entities/delete.test.ts
@@ -47,16 +47,3 @@ test("routes cleanup dispatch through the bounded hand-off", () => {
   expect(source).toContain("handoffCommittedEntityDeletionCleanupBatch(");
   expect(source).not.toContain("Promise.all(");
 });
-
-test("records the canonical file field in the deletion snapshot", () => {
-  const fieldSelect = source.indexOf("id: fields.id");
-  const fieldOrder = source.indexOf(".orderBy(asc(fields.id))", fieldSelect);
-  const firstFileGuard = source.indexOf(
-    "currentFileByEntityId.has(entityId)",
-    fieldOrder,
-  );
-
-  expect(fieldSelect).toBeGreaterThan(-1);
-  expect(fieldOrder).toBeGreaterThan(fieldSelect);
-  expect(firstFileGuard).toBeGreaterThan(fieldOrder);
-});

--- a/apps/api/src/handlers/entities/delete.ts
+++ b/apps/api/src/handlers/entities/delete.ts
@@ -41,6 +41,8 @@ import {
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { getSearchProvider } from "@/api/lib/search/provider";
 
+import { selectCanonicalFileContents } from "./delete-file-snapshot";
+
 const deleteEntitiesBodySchema = t.Object({
   entityIds: t.Array(tSafeId("entity"), {
     minItems: 1,
@@ -189,21 +191,10 @@ export const deleteEntitiesHandler = async function* ({
           currentVersionId === null ? [] : [[currentVersionId, id] as const],
         ),
       );
-      const currentFileByEntityId = new Map<
-        string,
-        Extract<(typeof fieldRows)[number]["content"], { type: "file" }>
-      >();
-      for (const { content, entityVersionId } of fieldRows) {
-        const entityId = entityIdByCurrentVersionId.get(entityVersionId);
-        if (
-          content.type !== "file" ||
-          entityId === undefined ||
-          currentFileByEntityId.has(entityId)
-        ) {
-          continue;
-        }
-        currentFileByEntityId.set(entityId, content);
-      }
+      const currentFileByEntityId = selectCanonicalFileContents(
+        fieldRows,
+        entityIdByCurrentVersionId,
+      );
 
       const fileRefs = fieldRows.flatMap((row) =>
         extractFieldFileRefs(row.content),

--- a/apps/api/src/handlers/entities/delete.ts
+++ b/apps/api/src/handlers/entities/delete.ts
@@ -38,6 +38,7 @@ import {
   ocrDerivativeCursorFilter,
   ocrDerivativePageOrder,
 } from "@/api/lib/ocr-derivative-pages";
+import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { getSearchProvider } from "@/api/lib/search/provider";
 
 const deleteEntitiesBodySchema = t.Object({
@@ -116,7 +117,11 @@ export const deleteEntitiesHandler = async function* ({
       // fence; storage cleanup happens later from a durable request, never
       // while this transaction owns locks.
       const lockedEntities = await tx
-        .select({ id: entities.id, readOnly: entities.readOnly })
+        .select({
+          currentVersionId: entities.currentVersionId,
+          id: entities.id,
+          readOnly: entities.readOnly,
+        })
         .from(entities)
         .where(
           and(
@@ -170,9 +175,26 @@ export const deleteEntitiesHandler = async function* ({
         );
 
       const fieldRows = await tx
-        .select({ content: fields.content })
+        .select({
+          content: fields.content,
+          entityVersionId: fields.entityVersionId,
+        })
         .from(fields)
         .where(inArray(fields.entityVersionId, entityVersionIds));
+
+      const entityIdByCurrentVersionId = new Map(
+        lockedEntities.flatMap(({ currentVersionId, id }) =>
+          currentVersionId === null ? [] : [[currentVersionId, id] as const],
+        ),
+      );
+      const currentFileByEntityId = new Map(
+        fieldRows.flatMap(({ content, entityVersionId }) => {
+          const entityId = entityIdByCurrentVersionId.get(entityVersionId);
+          return content.type === "file" && entityId !== undefined
+            ? [[entityId, content] as const]
+            : [];
+        }),
+      );
 
       const fileRefs = fieldRows.flatMap((row) =>
         extractFieldFileRefs(row.content),
@@ -271,21 +293,30 @@ export const deleteEntitiesHandler = async function* ({
 
       await recordAuditEvent(
         tx,
-        deleted.map((entity) => ({
-          action: AUDIT_ACTION.DELETE,
-          resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
-          resourceId: entity.id,
-          changes: {
-            deleted: {
-              old: {
-                kind: entity.kind,
-                name: entity.name,
-                parentId: entity.parentId,
+        deleted.map((entity) => {
+          const file = currentFileByEntityId.get(entity.id);
+          return {
+            action: AUDIT_ACTION.DELETE,
+            resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
+            resourceId: entity.id,
+            changes: {
+              deleted: {
+                old: {
+                  kind: entity.kind,
+                  name: entity.name,
+                  parentId: entity.parentId,
+                  ...(file
+                    ? {
+                        fileName: sanitizeFilename(file.fileName),
+                        mimeType: file.mimeType,
+                      }
+                    : {}),
+                },
+                new: null,
               },
-              new: null,
             },
-          },
-        })),
+          };
+        }),
       );
 
       return {

--- a/apps/api/src/handlers/entities/delete.ts
+++ b/apps/api/src/handlers/entities/delete.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
 
@@ -183,8 +183,7 @@ export const deleteEntitiesHandler = async function* ({
           id: fields.id,
         })
         .from(fields)
-        .where(inArray(fields.entityVersionId, entityVersionIds))
-        .orderBy(asc(fields.id));
+        .where(inArray(fields.entityVersionId, entityVersionIds));
 
       const entityIdByCurrentVersionId = new Map(
         lockedEntities.flatMap(({ currentVersionId, id }) =>

--- a/apps/api/src/handlers/entities/delete.ts
+++ b/apps/api/src/handlers/entities/delete.ts
@@ -178,23 +178,32 @@ export const deleteEntitiesHandler = async function* ({
         .select({
           content: fields.content,
           entityVersionId: fields.entityVersionId,
+          id: fields.id,
         })
         .from(fields)
-        .where(inArray(fields.entityVersionId, entityVersionIds));
+        .where(inArray(fields.entityVersionId, entityVersionIds))
+        .orderBy(asc(fields.id));
 
       const entityIdByCurrentVersionId = new Map(
         lockedEntities.flatMap(({ currentVersionId, id }) =>
           currentVersionId === null ? [] : [[currentVersionId, id] as const],
         ),
       );
-      const currentFileByEntityId = new Map(
-        fieldRows.flatMap(({ content, entityVersionId }) => {
-          const entityId = entityIdByCurrentVersionId.get(entityVersionId);
-          return content.type === "file" && entityId !== undefined
-            ? [[entityId, content] as const]
-            : [];
-        }),
-      );
+      const currentFileByEntityId = new Map<
+        string,
+        Extract<(typeof fieldRows)[number]["content"], { type: "file" }>
+      >();
+      for (const { content, entityVersionId } of fieldRows) {
+        const entityId = entityIdByCurrentVersionId.get(entityVersionId);
+        if (
+          content.type !== "file" ||
+          entityId === undefined ||
+          currentFileByEntityId.has(entityId)
+        ) {
+          continue;
+        }
+        currentFileByEntityId.set(entityId, content);
+      }
 
       const fileRefs = fieldRows.flatMap((row) =>
         extractFieldFileRefs(row.content),

--- a/apps/api/src/handlers/entities/delete.ts
+++ b/apps/api/src/handlers/entities/delete.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
 

--- a/apps/api/src/handlers/workspaces/read-overview-activity.integration.test.ts
+++ b/apps/api/src/handlers/workspaces/read-overview-activity.integration.test.ts
@@ -138,7 +138,12 @@ type ActivityPerformer = {
 type ActivityItem = {
   id: SafeId<"auditLog">;
   performer: ActivityPerformer;
-  target: { deleted: boolean; kind: string; name: string | null };
+  target: {
+    deleted: boolean;
+    kind: string;
+    mimeType: string | null;
+    name: string | null;
+  };
 };
 
 beforeAll(async () => {
@@ -351,6 +356,41 @@ describe("matter overview activity", () => {
     expect(
       items.find((activityItem) => activityItem.id === folderDeleteId)?.target,
     ).toMatchObject({ deleted: true, kind: "folder", name: "Pleadings" });
+  });
+
+  test("a deleted document keeps its MIME type via the audit snapshot", async () => {
+    const documentId = Bun.randomUUIDv7();
+    const documentDeleteId = await seedActivity({
+      action: AUDIT_ACTION.DELETE,
+      changes: {
+        deleted: {
+          old: {
+            kind: "document",
+            mimeType:
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            name: "Agreement.docx",
+          },
+          new: null,
+        },
+      },
+      organizationId: ids.orgA,
+      resourceId: documentId,
+      workspaceId: ids.wsA1,
+      userId: ids.userA1,
+    });
+
+    const items = await readActivityOfWorkspaceA1();
+
+    expect(
+      items.find((activityItem) => activityItem.id === documentDeleteId)
+        ?.target,
+    ).toMatchObject({
+      deleted: true,
+      kind: "document",
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      name: "Agreement.docx",
+    });
   });
 
   test("pages historical performers from authorized activity, not current matter membership", async () => {

--- a/apps/api/src/handlers/workspaces/read-overview-activity.integration.test.ts
+++ b/apps/api/src/handlers/workspaces/read-overview-activity.integration.test.ts
@@ -368,7 +368,8 @@ describe("matter overview activity", () => {
             kind: "document",
             mimeType:
               "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            name: "Agreement.docx",
+            fileName: "Agreement.docx",
+            name: "Agreement",
           },
           new: null,
         },

--- a/apps/api/src/handlers/workspaces/read-overview-activity.query.ts
+++ b/apps/api/src/handlers/workspaces/read-overview-activity.query.ts
@@ -231,7 +231,14 @@ const auditEntityNameSnapshot = () => sql<string | null>`coalesce(
   ${auditLogs.metadata} ->> 'fileName',
   ${auditLogs.changes} -> 'created' -> 'new' ->> 'name',
   ${auditLogs.changes} -> 'created' -> 'new' ->> 'fileName',
-  ${auditLogs.changes} -> 'deleted' -> 'old' ->> 'name'
+  ${auditLogs.changes} -> 'deleted' -> 'old' ->> 'name',
+  ${auditLogs.changes} -> 'deleted' -> 'old' ->> 'fileName'
+)`;
+
+const auditEntityMimeTypeSnapshot = () => sql<string | null>`coalesce(
+  ${auditLogs.metadata} ->> 'mimeType',
+  ${auditLogs.changes} -> 'created' -> 'new' ->> 'mimeType',
+  ${auditLogs.changes} -> 'deleted' -> 'old' ->> 'mimeType'
 )`;
 
 const siblingVersionEntityNameSnapshot = () => sql<string | null>`(
@@ -279,6 +286,18 @@ const siblingDeletedEntityName = () => sql<string | null>`(
     and ${entitySnapshotAuditLogs.resourceType} = ${AUDIT_RESOURCE_TYPE.ENTITY}
     and ${entitySnapshotAuditLogs.resourceId} = ${resolvedAuditEntityIdSnapshot()}
     and ${entitySnapshotAuditLogs.changes} -> 'deleted' -> 'old' ->> 'name' is not null
+  order by ${entitySnapshotAuditLogs.createdAt} desc, ${entitySnapshotAuditLogs.id} desc
+  limit 1
+)`;
+
+const siblingDeletedEntityMimeType = () => sql<string | null>`(
+  select ${entitySnapshotAuditLogs.changes} -> 'deleted' -> 'old' ->> 'mimeType'
+  from ${auditLogs} as "entity_snapshot_audit_logs"
+  where ${entitySnapshotAuditLogs.organizationId} = ${auditLogs.organizationId}
+    and ${entitySnapshotAuditLogs.workspaceId} = ${auditLogs.workspaceId}
+    and ${entitySnapshotAuditLogs.resourceType} = ${AUDIT_RESOURCE_TYPE.ENTITY}
+    and ${entitySnapshotAuditLogs.resourceId} = ${resolvedAuditEntityIdSnapshot()}
+    and ${entitySnapshotAuditLogs.changes} -> 'deleted' -> 'old' ->> 'mimeType' is not null
   order by ${entitySnapshotAuditLogs.createdAt} desc, ${entitySnapshotAuditLogs.id} desc
   limit 1
 )`;
@@ -664,6 +683,10 @@ export const readOverviewActivityPage = async ({
             createdAt: auditLogs.createdAt,
             createdAtCursor: activityCursor.cursorValue.as("created_at_cursor"),
             entityIdSnapshot: resolvedAuditEntityIdSnapshot(),
+            entityMimeTypeSnapshot: sql<string | null>`coalesce(
+              ${auditEntityMimeTypeSnapshot()},
+              ${siblingDeletedEntityMimeType()}
+            )`,
             entityNameSnapshot: sql<string | null>`coalesce(
               ${auditEntityNameSnapshot()},
               ${siblingDeletedEntityName()},
@@ -928,6 +951,7 @@ export const readOverviewActivityPage = async ({
             entityMap,
             entityIdSnapshot: row.entityIdSnapshot,
             entityKindSnapshot: row.legacyKind,
+            entityMimeTypeSnapshot: row.entityMimeTypeSnapshot,
             entityNameSnapshot: row.entityNameSnapshot,
             fieldVersionMap,
             matterColor: result.workspace?.color ?? null,
@@ -993,6 +1017,7 @@ type TargetForRowOptions = {
   entityMap: Map<string, EntityTarget>;
   entityIdSnapshot: string | null;
   entityKindSnapshot: string | null;
+  entityMimeTypeSnapshot: string | null;
   entityNameSnapshot: string | null;
   fieldVersionMap: Map<string, string>;
   matterColor: string | null;
@@ -1008,6 +1033,7 @@ const targetForRow = ({
   entityMap,
   entityIdSnapshot,
   entityKindSnapshot,
+  entityMimeTypeSnapshot,
   entityNameSnapshot,
   fieldVersionMap,
   matterColor,
@@ -1024,6 +1050,7 @@ const targetForRow = ({
         category,
         id: resourceId,
         kindSnapshot: entityKindSnapshot,
+        mimeType: entityMimeTypeSnapshot,
         name: entityNameSnapshot,
       })
     );
@@ -1037,6 +1064,7 @@ const targetForRow = ({
           category,
           id: entityId,
           kindSnapshot: entityKindSnapshot,
+          mimeType: entityMimeTypeSnapshot,
           name: entityNameSnapshot,
         })
       );
@@ -1054,6 +1082,7 @@ const targetForRow = ({
           category,
           id: entityId,
           kindSnapshot: entityKindSnapshot,
+          mimeType: entityMimeTypeSnapshot,
           name: entityNameSnapshot,
         })
       );
@@ -1110,6 +1139,7 @@ type DeletedEntityTargetOptions = {
   id: string;
   /** Kind recorded in the audit snapshot; the entity row itself is gone. */
   kindSnapshot?: string | null;
+  mimeType?: string | null;
   name?: string | null;
 };
 
@@ -1127,6 +1157,7 @@ const deletedEntityTarget = ({
   category = "documents",
   id,
   kindSnapshot = null,
+  mimeType = null,
   name = null,
 }: DeletedEntityTargetOptions): EntityTarget => ({
   color: null,
@@ -1136,7 +1167,7 @@ const deletedEntityTarget = ({
   fieldId: null,
   id,
   kind: deletedEntityKind(category, kindSnapshot),
-  mimeType: null,
+  mimeType,
   name,
   pdfFileId: null,
   propertyId: null,

--- a/apps/api/src/handlers/workspaces/read-overview-activity.query.ts
+++ b/apps/api/src/handlers/workspaces/read-overview-activity.query.ts
@@ -231,8 +231,8 @@ const auditEntityNameSnapshot = () => sql<string | null>`coalesce(
   ${auditLogs.metadata} ->> 'fileName',
   ${auditLogs.changes} -> 'created' -> 'new' ->> 'name',
   ${auditLogs.changes} -> 'created' -> 'new' ->> 'fileName',
-  ${auditLogs.changes} -> 'deleted' -> 'old' ->> 'name',
-  ${auditLogs.changes} -> 'deleted' -> 'old' ->> 'fileName'
+  ${auditLogs.changes} -> 'deleted' -> 'old' ->> 'fileName',
+  ${auditLogs.changes} -> 'deleted' -> 'old' ->> 'name'
 )`;
 
 const auditEntityMimeTypeSnapshot = () => sql<string | null>`coalesce(
@@ -247,6 +247,7 @@ const siblingVersionEntityNameSnapshot = () => sql<string | null>`(
     ${versionSnapshotAuditLogs.metadata} ->> 'fileName',
     ${versionSnapshotAuditLogs.changes} -> 'created' -> 'new' ->> 'name',
     ${versionSnapshotAuditLogs.changes} -> 'created' -> 'new' ->> 'fileName',
+    ${versionSnapshotAuditLogs.changes} -> 'deleted' -> 'old' ->> 'fileName',
     ${versionSnapshotAuditLogs.changes} -> 'deleted' -> 'old' ->> 'name'
   )
   from ${auditLogs} as "version_snapshot_audit_logs"
@@ -260,6 +261,7 @@ const siblingVersionEntityNameSnapshot = () => sql<string | null>`(
       ${versionSnapshotAuditLogs.metadata} ->> 'fileName',
       ${versionSnapshotAuditLogs.changes} -> 'created' -> 'new' ->> 'name',
       ${versionSnapshotAuditLogs.changes} -> 'created' -> 'new' ->> 'fileName',
+      ${versionSnapshotAuditLogs.changes} -> 'deleted' -> 'old' ->> 'fileName',
       ${versionSnapshotAuditLogs.changes} -> 'deleted' -> 'old' ->> 'name'
     ) is not null
   order by ${versionSnapshotAuditLogs.createdAt}, ${versionSnapshotAuditLogs.id}
@@ -279,13 +281,19 @@ const siblingDeletedEntityKind = () => sql<string | null>`(
 )`;
 
 const siblingDeletedEntityName = () => sql<string | null>`(
-  select ${entitySnapshotAuditLogs.changes} -> 'deleted' -> 'old' ->> 'name'
+  select coalesce(
+    ${entitySnapshotAuditLogs.changes} -> 'deleted' -> 'old' ->> 'fileName',
+    ${entitySnapshotAuditLogs.changes} -> 'deleted' -> 'old' ->> 'name'
+  )
   from ${auditLogs} as "entity_snapshot_audit_logs"
   where ${entitySnapshotAuditLogs.organizationId} = ${auditLogs.organizationId}
     and ${entitySnapshotAuditLogs.workspaceId} = ${auditLogs.workspaceId}
     and ${entitySnapshotAuditLogs.resourceType} = ${AUDIT_RESOURCE_TYPE.ENTITY}
     and ${entitySnapshotAuditLogs.resourceId} = ${resolvedAuditEntityIdSnapshot()}
-    and ${entitySnapshotAuditLogs.changes} -> 'deleted' -> 'old' ->> 'name' is not null
+    and coalesce(
+      ${entitySnapshotAuditLogs.changes} -> 'deleted' -> 'old' ->> 'fileName',
+      ${entitySnapshotAuditLogs.changes} -> 'deleted' -> 'old' ->> 'name'
+    ) is not null
   order by ${entitySnapshotAuditLogs.createdAt} desc, ${entitySnapshotAuditLogs.id} desc
   limit 1
 )`;

--- a/apps/web/src/components/document-icon.logic.test.ts
+++ b/apps/web/src/components/document-icon.logic.test.ts
@@ -4,6 +4,7 @@ import { PDF_MIME_TYPE } from "@/consts";
 import { DOCX_MIME, EML_MIME, MSG_MIME, PPTX_MIME } from "@/lib/consts";
 
 import { getDocumentIconKind } from "./document-icon.logic";
+import type { DocumentIconKind } from "./document-icon.logic";
 
 describe("document icon MIME classification", () => {
   test("uses the email icon for EML and Outlook MSG files", () => {
@@ -25,6 +26,30 @@ describe("document icon MIME classification", () => {
       "powerpoint",
     );
     expect(getDocumentIconKind("text/plain")).toBe("text");
+  });
+
+  test("recovers supported document kinds from historical filenames without MIME metadata", () => {
+    const historicalFiles = [
+      ["agreement.docx", "word"],
+      ["legacy.doc", "word"],
+      ["evidence.pdf", "pdf"],
+      ["schedule.xlsx", "excel"],
+      ["legacy.xls", "excel"],
+      ["hearing.pptx", "powerpoint"],
+      ["legacy.ppt", "powerpoint"],
+      ["notes.rtf", "rtf"],
+      ["filing.odt", "openDocumentText"],
+      ["ledger.ods", "openDocumentSheet"],
+      ["export.csv", "csv"],
+      ["scan.PNG", "image"],
+      ["message.eml", "email"],
+      ["readme.md", "markdown"],
+      ["notes.txt", "text"],
+    ] as const satisfies readonly (readonly [string, DocumentIconKind])[];
+
+    for (const [fileName, expectedKind] of historicalFiles) {
+      expect(getDocumentIconKind(null, fileName)).toBe(expectedKind);
+    }
   });
 
   // text/csv also matches the generic text/ prefix, so it must be classified

--- a/apps/web/src/components/document-icon.logic.ts
+++ b/apps/web/src/components/document-icon.logic.ts
@@ -60,58 +60,104 @@ export type DocumentIconKind =
   | "text"
   | "file";
 
+const DOCUMENT_ICON_KIND_BY_EXTENSION = {
+  ".csv": "csv",
+  ".doc": "word",
+  ".docx": "word",
+  ".eml": "email",
+  ".gif": "image",
+  ".jpeg": "image",
+  ".jpg": "image",
+  ".md": "markdown",
+  ".msg": "email",
+  ".ods": "openDocumentSheet",
+  ".odt": "openDocumentText",
+  ".pdf": "pdf",
+  ".png": "image",
+  ".ppt": "powerpoint",
+  ".pptx": "powerpoint",
+  ".rtf": "rtf",
+  ".txt": "text",
+  ".webp": "image",
+  ".xls": "excel",
+  ".xlsx": "excel",
+} as const satisfies Record<string, DocumentIconKind>;
+
+const documentIconKindForFileName = (
+  fileName: string | null | undefined,
+): DocumentIconKind | null => {
+  const normalizedFileName = fileName?.trim().toLowerCase();
+  if (!normalizedFileName) {
+    return null;
+  }
+  for (const [extension, iconKind] of Object.entries(
+    DOCUMENT_ICON_KIND_BY_EXTENSION,
+  )) {
+    if (normalizedFileName.endsWith(extension)) {
+      return iconKind;
+    }
+  }
+  return null;
+};
+
 export const getDocumentIconKind = (
-  mimeType: string,
+  mimeType: string | null | undefined,
   fileName?: string | null,
 ): DocumentIconKind => {
-  if (mimeType === PDF_MIME_TYPE) {
+  const normalizedMimeType = mimeType ?? "";
+  if (normalizedMimeType === PDF_MIME_TYPE) {
     return "pdf";
   }
 
-  if (Object.hasOwn(wordMimeTypes, mimeType)) {
+  if (Object.hasOwn(wordMimeTypes, normalizedMimeType)) {
     return "word";
   }
 
-  if (Object.hasOwn(rtfMimeTypes, mimeType)) {
+  if (Object.hasOwn(rtfMimeTypes, normalizedMimeType)) {
     return "rtf";
   }
 
-  if (Object.hasOwn(openDocumentTextMimeTypes, mimeType)) {
+  if (Object.hasOwn(openDocumentTextMimeTypes, normalizedMimeType)) {
     return "openDocumentText";
   }
 
-  if (Object.hasOwn(excelMimeTypes, mimeType)) {
+  if (Object.hasOwn(excelMimeTypes, normalizedMimeType)) {
     return "excel";
   }
 
-  if (Object.hasOwn(powerpointMimeTypes, mimeType)) {
+  if (Object.hasOwn(powerpointMimeTypes, normalizedMimeType)) {
     return "powerpoint";
   }
 
-  if (Object.hasOwn(openDocumentSheetMimeTypes, mimeType)) {
+  if (Object.hasOwn(openDocumentSheetMimeTypes, normalizedMimeType)) {
     return "openDocumentSheet";
   }
 
-  if (Object.hasOwn(csvMimeTypes, mimeType)) {
+  if (Object.hasOwn(csvMimeTypes, normalizedMimeType)) {
     return "csv";
   }
 
-  if (Object.hasOwn(imageMimeTypes, mimeType)) {
+  if (Object.hasOwn(imageMimeTypes, normalizedMimeType)) {
     return "image";
   }
 
   if (
-    Object.hasOwn(emailMimeTypes, mimeType) ||
-    isEmailFile({ fileName, mimeType })
+    Object.hasOwn(emailMimeTypes, normalizedMimeType) ||
+    isEmailFile({ fileName, mimeType: normalizedMimeType })
   ) {
     return "email";
   }
 
-  if (isMarkdownFile({ fileName, mimeType })) {
+  if (isMarkdownFile({ fileName, mimeType: normalizedMimeType })) {
     return "markdown";
   }
 
-  if (mimeType.startsWith("text/")) {
+  const fileNameIconKind = documentIconKindForFileName(fileName);
+  if (fileNameIconKind !== null) {
+    return fileNameIconKind;
+  }
+
+  if (normalizedMimeType.startsWith("text/")) {
     return "text";
   }
 

--- a/apps/web/src/components/document-icon.tsx
+++ b/apps/web/src/components/document-icon.tsx
@@ -490,7 +490,7 @@ const PdfIcon = ({ className }: PdfIconProps) => (
 );
 
 type DocumentIconProps = {
-  mimeType: string;
+  mimeType?: string | null | undefined;
   fileName?: string | null | undefined;
   className?: string | undefined;
 };

--- a/apps/web/src/components/workspaces/entity-kind-icon.tsx
+++ b/apps/web/src/components/workspaces/entity-kind-icon.tsx
@@ -125,7 +125,7 @@ export const EntityKindIcon = ({
     case "link":
       return <LinkIcon className={className} />;
     case "document":
-      return mimeType ? (
+      return mimeType || fileName ? (
         <DocumentIcon
           className={className}
           fileName={fileName}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/activity/activity-panel.tsx
@@ -1818,7 +1818,10 @@ const targetIcon = (item: MatterActivityItem) => {
 };
 
 const activityTargetIcon = (item: MatterActivityItem) => {
-  if (item.target.kind === "document" && item.target.mimeType) {
+  if (
+    item.target.kind === "document" &&
+    (item.target.mimeType || item.target.name)
+  ) {
     return (
       <DocumentIcon
         className="size-3.5"


### PR DESCRIPTION
## Summary

- retain filename and MIME metadata in new document deletion audit snapshots
- render deleted Activity documents from the preserved MIME type
- recover icons for historical deletion records from supported filename extensions

## Validation

- `bun test src/components/document-icon.logic.test.ts --bail` in `apps/web`
- `bun run test src/handlers/workspaces/read-overview-activity.integration.test.ts --bail` in `apps/api`
- affected API/web lint and typecheck
- pre-push format and i18n checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted documents in workspace activity now retain their file name and file type information.
  * Document icons now display correctly when MIME type information is unavailable, using the file name extension as a fallback.
  * Improved consistency when identifying document file types across activity history and workspace views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->