### PR TITLE
fix: recover auth routes from API outages

### DIFF
--- a/apps/web/src/components/route-components.logic.test.ts
+++ b/apps/web/src/components/route-components.logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { APIError } from "@/lib/errors/api";
+import { AuthClientError } from "@/lib/errors/auth";
 import { CriticalQueryTimeoutError } from "@/lib/react-query";
 
 import {
@@ -93,12 +94,21 @@ describe("route network error classification", () => {
     expect(isNetworkError(new TypeError("Load failed"))).toBe(true);
   });
 
-  test("treats APIError status 0 as transient network failure", () => {
+  test("treats status 0 API and auth errors as transient network failures", () => {
     expect(
       isNetworkError(
         new APIError({
           status: 0,
           message: "Storage fetch failed before response (purpose=display)",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isNetworkError(
+        new AuthClientError({
+          message: "Unknown error",
+          status: 0,
+          statusText: "",
         }),
       ),
     ).toBe(true);

--- a/apps/web/src/components/route-components.logic.ts
+++ b/apps/web/src/components/route-components.logic.ts
@@ -1,4 +1,5 @@
 import { APIError } from "@/lib/errors/api";
+import { AuthClientError } from "@/lib/errors/auth";
 import { CriticalQueryTimeoutError } from "@/lib/react-query";
 
 /** Network errors that indicate a transient connectivity
@@ -123,7 +124,7 @@ export const isNetworkError = (error: unknown): boolean => {
   if (CriticalQueryTimeoutError.is(error)) {
     return true;
   }
-  if (APIError.is(error)) {
+  if (APIError.is(error) || AuthClientError.is(error)) {
     return error.status === 0;
   }
   return (

--- a/apps/web/src/lib/auth-queries.ts
+++ b/apps/web/src/lib/auth-queries.ts
@@ -13,10 +13,9 @@ export const rootKeys = {
  * at before anything renders. The QueryClient sets no `retry`, i.e. the
  * TanStack default of 3 attempts with exponential backoff — which would turn
  * one stalled connection into roughly four auth-request budgets plus backoff
- * before `beforeLoad` settles. On the boot path, failing fast and letting the
- * caller degrade (redirect to `/auth`, or mount chrome without role-gated
- * affordances) beats a minute-long pending component. Retries stay on for
- * everything downstream of boot.
+ * before `beforeLoad` settles. On the boot path, failing fast into the route
+ * error boundary's bounded recovery beats a minute-long pending component.
+ * Retries stay on for everything downstream of boot.
  */
 const BOOT_QUERY_RETRY = false;
 

--- a/apps/web/src/routes/-auth-context.ts
+++ b/apps/web/src/routes/-auth-context.ts
@@ -6,15 +6,15 @@ import { ensureRouteQueryData } from "@/lib/react-query";
 
 export const loadAuthContext = async (queryClient: QueryClient) => {
   // An unauthenticated visitor is not an error here: `getSession` resolves
-  // with no session. A rejection means the session could not be read at all,
-  // which this guard still has to report as signed-out; capture it, or a brief
-  // API outage looks exactly like everyone signing out at once.
+  // with no session. A rejection means the session could not be read at all;
+  // preserve that distinction so route recovery handles an outage instead of
+  // redirecting an authenticated user to sign-in.
   const sessionData = await ensureRouteQueryData(
     queryClient,
     sessionOptions,
   ).catch((error: unknown) => {
     getAnalytics().captureError(error);
-    return null;
+    throw error;
   });
 
   return {
@@ -22,3 +22,14 @@ export const loadAuthContext = async (queryClient: QueryClient) => {
     user: sessionData?.user ?? null,
   };
 };
+
+// The root route dispatches from a mounted async effect, outside the router's
+// loader error boundary. Keep its explicit signed-out fallback local; every
+// route loader uses loadAuthContext and therefore preserves read failures.
+export const loadAuthContextForRootRedirect = async (
+  queryClient: QueryClient,
+) =>
+  await loadAuthContext(queryClient).catch(() => ({
+    session: null,
+    user: null,
+  }));

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { DefaultPendingComponent } from "@/components/route-components";
 import { useMountEffect } from "@/hooks/use-effect";
 import { detached } from "@/lib/detached";
-import { loadAuthContext } from "@/routes/-auth-context";
+import { loadAuthContextForRootRedirect } from "@/routes/-auth-context";
 
 export const Route = createFileRoute("/")({
   component: RootRedirect,
@@ -30,10 +30,7 @@ function RootRedirect() {
 
     detached(
       (async () => {
-        // loadAuthContext swallows its own errors (returns a null session), so
-        // this never rejects; a failed session simply routes to /auth below.
-
-        const authContext = await loadAuthContext(queryClient);
+        const authContext = await loadAuthContextForRootRedirect(queryClient);
         if (run.cancelled) {
           return;
         }


### PR DESCRIPTION
## Summary

- preserve the distinction between an unauthenticated session and a failed session read
- send transient auth transport failures through the existing bounded route recovery instead of redirecting to sign-in
- classify status-zero auth client failures as retryable network errors

## Validation

- `bun test src/components/route-components.logic.test.ts --bail` in `apps/web`
- web lint and typecheck
- pre-push format and i18n checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of authentication service outages so they are recognised as temporary network failures.
  - Preserved error details during session checks, preventing service outages from being incorrectly treated as signed-out states.
  - Improved route recovery behaviour when authentication services are unavailable, while maintaining the expected redirect flow for the root route.

- **Documentation**
  - Clarified authentication loading and recovery behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->