### PR TITLE
fix(ui): support whole-card drag surfaces

### DIFF
--- a/.changeset/reliable-card-surface-drag.md
+++ b/.changeset/reliable-card-surface-drag.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": minor
+---
+
+Add a card drag surface that preserves embedded controls and scrolling while supporting whole-card drag activation.

--- a/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
@@ -114,6 +114,9 @@ const SortableFixture = () => (
       document.documentElement.dataset["draggedOver"] =
         over === null ? "" : String(over.id);
     }}
+    onInteractionReady={() => {
+      document.documentElement.dataset["kanbanInteractionReady"] = "true";
+    }}
     overlayProps={{ dropAnimation: null }}
     overlay={(activeId) =>
       activeId === null ? null : <output data-overlay="">{activeId}</output>

--- a/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
@@ -1,6 +1,9 @@
 import { createRoot } from "react-dom/client";
 
+import { panic } from "better-result";
+
 import {
+  KanbanCardDragSurface,
   KanbanDragHandle,
   KanbanSortableBoard,
   KanbanSortableColumns,
@@ -46,31 +49,32 @@ const cells = [
 
 const SortableItem = ({ id }: { id: string }) => {
   const { activator, setNodeRef, style } = useKanbanSortable({
-    activation: { type: id === "whole-item" ? "item" : "handle" },
+    activation: { type: id === "whole-item" ? "card" : "handle" },
     id,
   });
 
-  if (activator.type === "item") {
+  if (activator.type === "card") {
     return (
-      <div
-        {...activator.attributes}
-        {...activator.listeners}
-        aria-label={`Move ${id}`}
-        data-sortable-item={id}
-        data-whole-item=""
-        ref={setNodeRef}
-        style={style}
-      >
-        {id}
+      <div data-sortable-item={id} ref={setNodeRef} style={style}>
+        <KanbanCardDragSurface bindings={activator.bindings}>
+          <p data-card-content="">{id}</p>
+          <button data-card-control="" type="button">
+            Keep {id} control interactive
+          </button>
+        </KanbanCardDragSurface>
       </div>
     );
   }
 
-  return (
-    <div data-sortable-item={id} ref={setNodeRef} style={style}>
-      <KanbanDragHandle bindings={activator.bindings} label={`Move ${id}`} />
-    </div>
-  );
+  if (activator.type === "handle") {
+    return (
+      <div data-sortable-item={id} ref={setNodeRef} style={style}>
+        <KanbanDragHandle bindings={activator.bindings} label={`Move ${id}`} />
+      </div>
+    );
+  }
+
+  return panic("fixture cards use card or handle activation");
 };
 
 const SortableVirtualCell = ({

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -15,6 +15,7 @@ export { KanbanCardShell } from "./card-shell";
 export type { KanbanColumnHeaderProps } from "./column-header";
 export { KanbanColumnHeader } from "./column-header";
 export type {
+  KanbanCardDragSurfaceProps,
   KanbanDragHandleProps,
   KanbanDragCancelEvent,
   KanbanDragEndEvent,
@@ -37,6 +38,7 @@ export {
   KANBAN_DRAG_OVERLAY_Z_INDEX,
   KANBAN_SORTABLE_ACTIVATION_MODES,
   KANBAN_TOUCH_ACTIVATION_CONSTRAINT,
+  KanbanCardDragSurface,
   KanbanDragHandle,
   KanbanSortableBoard,
   KanbanSortableColumns,

--- a/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
+++ b/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
@@ -339,7 +339,7 @@ test("exposes explicit whole-item and 44px handle activation surfaces", async ({
   page,
 }) => {
   const handle = await openFixture(page);
-  const wholeItem = page.getByRole("button", { name: "Move whole-item" });
+  const wholeItem = page.locator('[data-card-content=""]');
 
   await expect(handle).toHaveCSS("width", "44px");
   await expect(handle).toHaveCSS("height", "44px");
@@ -347,12 +347,19 @@ test("exposes explicit whole-item and 44px handle activation surfaces", async ({
   await expect(
     handle.locator("xpath=ancestor::*[@data-sortable-item]"),
   ).toHaveCSS("touch-action", "auto");
-  await expect(wholeItem).toHaveCSS("touch-action", "none");
-
-  await wholeItem.focus();
-  await page.keyboard.press("Space");
-  await expect(page.locator("[data-overlay]")).toHaveText("whole-item");
-  await page.keyboard.press("Escape");
+  await expect(wholeItem).toHaveCSS("touch-action", "auto");
+  const control = page.getByRole("button", {
+    name: "Keep whole-item control interactive",
+  });
+  const controlBox = await control.boundingBox();
+  if (!controlBox) {
+    throw new Error("Missing whole-card control bounds");
+  }
+  await page.mouse.move(controlBox.x + 4, controlBox.y + 4);
+  await page.mouse.down();
+  await page.mouse.move(controlBox.x + 16, controlBox.y + 4);
+  await page.mouse.up();
+  await expect(page.locator("[data-overlay]")).toHaveCount(0);
 });
 
 test("keeps the drag overlay above sticky board chrome", async ({ page }) => {
@@ -405,10 +412,10 @@ test("drops a whole-item touch drag across a virtual column", async ({
   page,
 }) => {
   await openFixture(page);
-  const wholeItem = page.getByRole("button", { name: "Move whole-item" });
+  const wholeItem = page.locator('[data-card-content=""]');
   const sourceCell = page.locator('[data-kanban-cell="cell-d"]');
   await sourceCell.evaluate((element) => {
-    element.scrollTop = 96;
+    element.scrollTop = element.scrollHeight;
   });
   await expect
     .poll(async () => await sourceCell.evaluate((element) => element.scrollTop))
@@ -431,6 +438,38 @@ test("drops a whole-item touch drag across a virtual column", async ({
     )
     .toBe("lane-second");
   await endNativeTouch(nativeTouch);
+
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["droppedOn"] ?? "",
+        ),
+    )
+    .toBe("lane-second");
+});
+
+test("drops a whole-card pointer drag across a virtual column", async ({
+  page,
+}) => {
+  await openFixture(page);
+  const cardContent = page.locator('[data-card-content=""]');
+  await page.locator('[data-kanban-cell="cell-d"]').evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+  });
+  const target = page.getByRole("button", { name: "Move lane-second" });
+  const sourceBox = await cardContent.boundingBox();
+  const targetBox = await target.boundingBox();
+  if (!sourceBox || !targetBox) {
+    throw new Error("Missing whole-card drag bounds");
+  }
+
+  await page.mouse.move(sourceBox.x + 4, sourceBox.y + 4);
+  await page.mouse.down();
+  await page.mouse.move(sourceBox.x + 16, sourceBox.y + 4);
+  await expect(page.locator("[data-overlay]")).toHaveText("whole-item");
+  await page.mouse.move(targetBox.x + 12, targetBox.y + 12);
+  await page.mouse.up();
 
   await expect
     .poll(

--- a/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
+++ b/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
@@ -5,6 +5,15 @@ const fixturePath = "/src/kanban/fixtures/sortable-interactions.fixture.html";
 
 const openFixture = async (page: Page) => {
   await page.goto(fixturePath);
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () =>
+            document.documentElement.dataset["kanbanInteractionReady"] ?? "",
+        ),
+    )
+    .toBe("true");
   return page.getByRole("button", { name: "Move first" });
 };
 

--- a/packages/ui/src/kanban/sortable-interactions.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.tsx
@@ -75,6 +75,7 @@ export const KANBAN_BOARD_AUTO_SCROLL_OPTIONS = {
 } as const satisfies AutoScrollOptions;
 
 export const KANBAN_SORTABLE_ACTIVATION_MODES = {
+  CARD: "card",
   HANDLE: "handle",
   ITEM: "item",
 } as const;
@@ -98,7 +99,6 @@ const KANBAN_KEYBOARD_CODES = {
   cancel: ["Escape"],
   end: ["Space", "Enter", "Tab"],
 } as const;
-const KANBAN_KEYBOARD_LISTENER_DELAY_MS = 0;
 const KANBAN_KEYBOARD_TARGET_RETRY_LIMIT = 60;
 /** A render commit, not a virtual scroll, so the budget stays short. */
 const KANBAN_DROP_SETTLE_FRAME_LIMIT = 10;
@@ -287,14 +287,9 @@ class KanbanKeyboardSensor implements SensorInstance {
     ownerDocument.defaultView?.addEventListener("resize", this.handleCancel, {
       signal: this.listeners.signal,
     });
-    setTimeout(() => {
-      if (this.listeners.signal.aborted) {
-        return;
-      }
-      ownerDocument.addEventListener("keydown", this.handleKeyDown, {
-        signal: this.listeners.signal,
-      });
-    }, KANBAN_KEYBOARD_LISTENER_DELAY_MS);
+    ownerDocument.addEventListener("keydown", this.handleKeyDown, {
+      signal: this.listeners.signal,
+    });
   }
 
   private readonly handleCancel = () => {
@@ -315,6 +310,17 @@ class KanbanKeyboardSensor implements SensorInstance {
   };
 
   private readonly handleKeyDown = (event: KeyboardEvent) => {
+    // The sensor can be constructed while the activation key is still
+    // bubbling. Ignore that exact native event even when React has wrapped it
+    // before passing it to the sensor; the next key must be observed without
+    // waiting for another task.
+    if (
+      event === this.props.event ||
+      (event.target === this.props.event.target &&
+        event.timeStamp === this.props.event.timeStamp)
+    ) {
+      return;
+    }
     const keyboardCodes = this.props.options.keyboardCodes;
     const cancelCodes = keyboardCodes?.cancel ?? KANBAN_KEYBOARD_CODES.cancel;
     const endCodes = keyboardCodes?.end ?? KANBAN_KEYBOARD_CODES.end;
@@ -640,6 +646,7 @@ export type KanbanSortableBindings = Pick<
 >;
 
 export type KanbanSortableActivationMode =
+  | { type: "card" }
   | { type: "handle" }
   | { type: "item" };
 
@@ -648,6 +655,21 @@ export type UseKanbanSortableOptions = {
   id: UniqueIdentifier;
   disabled?: boolean | undefined;
 };
+
+type KanbanSortableActivator =
+  | {
+      bindings: KanbanSortableBindings;
+      type: typeof KANBAN_SORTABLE_ACTIVATION_MODES.HANDLE;
+    }
+  | {
+      bindings: KanbanSortableBindings;
+      type: typeof KANBAN_SORTABLE_ACTIVATION_MODES.CARD;
+    }
+  | {
+      attributes: ReturnType<typeof useSortable>["attributes"];
+      listeners: ReturnType<typeof useSortable>["listeners"];
+      type: typeof KANBAN_SORTABLE_ACTIVATION_MODES.ITEM;
+    };
 
 /**
  * Connect a sortable item and its separate drag handle without making the
@@ -687,14 +709,18 @@ export const useKanbanSortable = ({
     setActivatorNodeRef: sortable.setActivatorNodeRef,
   };
 
-  const activator =
-    activation.type === KANBAN_SORTABLE_ACTIVATION_MODES.HANDLE
-      ? { bindings, type: KANBAN_SORTABLE_ACTIVATION_MODES.HANDLE }
-      : {
-          attributes: sortable.attributes,
-          listeners: sortable.listeners,
-          type: KANBAN_SORTABLE_ACTIVATION_MODES.ITEM,
-        };
+  let activator: KanbanSortableActivator;
+  if (activation.type === KANBAN_SORTABLE_ACTIVATION_MODES.HANDLE) {
+    activator = { bindings, type: KANBAN_SORTABLE_ACTIVATION_MODES.HANDLE };
+  } else if (activation.type === KANBAN_SORTABLE_ACTIVATION_MODES.CARD) {
+    activator = { bindings, type: KANBAN_SORTABLE_ACTIVATION_MODES.CARD };
+  } else {
+    activator = {
+      attributes: sortable.attributes,
+      listeners: sortable.listeners,
+      type: KANBAN_SORTABLE_ACTIVATION_MODES.ITEM,
+    };
+  }
 
   return {
     activator,
@@ -747,3 +773,71 @@ export const KanbanDragHandle = ({
     <GripVerticalIcon aria-hidden="true" />
   </Button>
 );
+
+const KANBAN_CARD_DRAG_SURFACE_INTERACTIVE_SELECTOR =
+  "a,button,input,select,textarea,[contenteditable=true],[role=button],[data-kanban-drag-exempt]";
+
+const isKanbanCardDragSurfaceInteractiveTarget = (
+  target: EventTarget | null,
+  activator: EventTarget | null,
+) => {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  const interactiveTarget = target.closest(
+    KANBAN_CARD_DRAG_SURFACE_INTERACTIVE_SELECTOR,
+  );
+  return interactiveTarget !== null && interactiveTarget !== activator;
+};
+
+const getKanbanCardDragSurfaceAttributes = ({
+  "aria-describedby": _describedBy,
+  "aria-disabled": _disabled,
+  "aria-pressed": _pressed,
+  "aria-roledescription": _roleDescription,
+  role: _role,
+  tabIndex: _tabIndex,
+  ...attributes
+}: KanbanSortableBindings["attributes"]) => attributes;
+
+const stopKanbanCardDragAtInteractiveDescendant = (
+  event: React.SyntheticEvent<HTMLDivElement>,
+) => {
+  if (
+    isKanbanCardDragSurfaceInteractiveTarget(event.target, event.currentTarget)
+  ) {
+    event.stopPropagation();
+  }
+};
+
+export type KanbanCardDragSurfaceProps = {
+  bindings: KanbanSortableBindings;
+} & Omit<React.ComponentProps<"div">, "ref">;
+
+/** A whole-card drag activator that preserves descendant controls and scrolling. */
+export const KanbanCardDragSurface = ({
+  bindings,
+  className,
+  ...props
+}: KanbanCardDragSurfaceProps) => {
+  const { setActivatorNodeRef: setCardActivatorNodeRef } = bindings;
+  const setActivatorNodeRef = React.useCallback(
+    (element: HTMLDivElement | null) => {
+      setCardActivatorNodeRef(element);
+    },
+    [setCardActivatorNodeRef],
+  );
+
+  return (
+    <div
+      {...props}
+      {...getKanbanCardDragSurfaceAttributes(bindings.attributes)}
+      {...bindings.listeners}
+      className={cn("touch-auto", className)}
+      onMouseDownCapture={stopKanbanCardDragAtInteractiveDescendant}
+      onPointerDownCapture={stopKanbanCardDragAtInteractiveDescendant}
+      onTouchStartCapture={stopKanbanCardDragAtInteractiveDescendant}
+      ref={setActivatorNodeRef}
+    />
+  );
+};

--- a/packages/ui/src/kanban/sortable-interactions.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.tsx
@@ -311,14 +311,9 @@ class KanbanKeyboardSensor implements SensorInstance {
 
   private readonly handleKeyDown = (event: KeyboardEvent) => {
     // The sensor can be constructed while the activation key is still
-    // bubbling. Ignore that exact native event even when React has wrapped it
-    // before passing it to the sensor; the next key must be observed without
-    // waiting for another task.
-    if (
-      event === this.props.event ||
-      (event.target === this.props.event.target &&
-        event.timeStamp === this.props.event.timeStamp)
-    ) {
+    // bubbling. Ignore that exact native event; distinct keys may share a
+    // timestamp in a fast browser session and must never be coalesced.
+    if (event === this.props.event) {
       return;
     }
     const keyboardCodes = this.props.options.keyboardCodes;
@@ -395,25 +390,37 @@ class KanbanKeyboardSensor implements SensorInstance {
     retryCount: number,
   ) => {
     const currentContext = this.props.context.current;
+    // onStart enters dnd-kit's React state machine. A key pressed immediately
+    // after Space can reach this native listener before that active context is
+    // committed. Preserve that real input until the context has registered the
+    // active item; processing it earlier would navigate from an incomplete
+    // target set and silently drop the key.
+    if (currentContext.active?.id !== this.props.active) {
+      requestAnimationFrame(() => {
+        if (this.listeners.signal.aborted || this.moveSequence !== sequence) {
+          return;
+        }
+        this.move(event, sequence, retryCount);
+      });
+      return;
+    }
     const collisionRect = currentContext.collisionRect;
     const currentCoordinates = collisionRect
       ? { x: collisionRect.left, y: collisionRect.top }
       : { x: 0, y: 0 };
     this.referenceCoordinates ??= currentCoordinates;
+    const activeData = currentContext.active.data.current;
     const coordinates = this.props.options.coordinateGetter?.(event, {
       active: this.props.active,
       context: currentContext,
       currentCoordinates,
     });
     if (coordinates === undefined) {
-      if (
-        getKanbanKeyboardTargetState(currentContext.active?.data.current)
-          ?.type !== "pending"
-      ) {
+      if (getKanbanKeyboardTargetState(activeData)?.type !== "pending") {
         return;
       }
       if (retryCount >= KANBAN_KEYBOARD_TARGET_RETRY_LIMIT) {
-        clearKanbanKeyboardTarget(currentContext.active?.data.current);
+        clearKanbanKeyboardTarget(activeData);
         return;
       }
       requestAnimationFrame(() => {
@@ -451,6 +458,8 @@ export type KanbanSortableBoardProps = {
   onDragStart?: ((event: KanbanDragStartEvent) => void) | undefined;
   onDragOver?: ((event: KanbanDragOverEvent) => void) | undefined;
   onDragCancel?: ((event: KanbanDragCancelEvent) => void) | undefined;
+  /** Called once mounted child drop targets can safely receive input. */
+  onInteractionReady?: (() => void) | undefined;
   /** Rendered in document.body while an item is active. */
   overlay?:
     | ((activeId: UniqueIdentifier | null) => React.ReactNode)
@@ -466,6 +475,11 @@ export type UseKanbanDropTargetOptions = {
   position: KanbanSortableCellPosition;
 };
 
+// Keep sensor descriptors stable while child sortable and virtual-cell effects
+// register with dnd-kit. Components used outside a KanbanSortableBoard retain
+// their existing behavior through the ready default.
+const KanbanInteractionReadinessContext = React.createContext(true);
+
 /**
  * Register a board-level drop target such as an empty cell or terminal lane.
  *
@@ -480,6 +494,7 @@ export const useKanbanDropTarget = ({
   navigation,
   position,
 }: UseKanbanDropTargetOptions) => {
+  const interactionReady = React.useContext(KanbanInteractionReadinessContext);
   const dropTarget = useDroppable({
     data: {
       itemIds,
@@ -487,7 +502,7 @@ export const useKanbanDropTarget = ({
       position,
       type: KANBAN_DROP_TARGET_TYPES.CELL,
     } satisfies KanbanCellDropData,
-    ...(disabled === undefined ? {} : { disabled }),
+    disabled: !interactionReady || disabled === true,
     id,
   });
 
@@ -515,11 +530,34 @@ export const KanbanSortableBoard = ({
   onDragStart,
   onDragOver,
   onDragCancel,
+  onInteractionReady,
   overlay,
   overlayProps,
 }: KanbanSortableBoardProps) => {
   const [activeId, setActiveId] = React.useState<UniqueIdentifier | null>(null);
+  const [interactionReady, setInteractionReady] = React.useState(false);
+  const interactionReadyNotified = React.useRef(false);
   const defaultSensors = useKanbanSortableSensors(keyboardCoordinates);
+
+  // dnd-kit registers child droppables after commit. Keep the sensor list
+  // stable, but hold sortable sources and virtual cells disabled until that
+  // registration pass has completed.
+  React.useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      setInteractionReady(true);
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (!interactionReady || interactionReadyNotified.current) {
+      return;
+    }
+    interactionReadyNotified.current = true;
+    onInteractionReady?.();
+  }, [interactionReady, onInteractionReady]);
 
   const handleDragStart = (event: DragStartEvent) => {
     setActiveId(event.active.id);
@@ -537,31 +575,33 @@ export const KanbanSortableBoard = ({
   };
 
   return (
-    <DndContext
-      autoScroll={autoScroll ?? KANBAN_BOARD_AUTO_SCROLL_OPTIONS}
-      {...(accessibility === undefined ? {} : { accessibility })}
-      collisionDetection={
-        collisionDetection ?? KANBAN_BOARD_COLLISION_DETECTION
-      }
-      onDragCancel={handleDragCancel}
-      onDragEnd={handleDragEnd}
-      {...(onDragOver === undefined ? {} : { onDragOver })}
-      onDragStart={handleDragStart}
-      sensors={sensors ?? defaultSensors}
-    >
-      {children}
-      {overlay && typeof document !== "undefined"
-        ? createPortal(
-            <DragOverlay
-              {...overlayProps}
-              zIndex={overlayProps?.zIndex ?? KANBAN_DRAG_OVERLAY_Z_INDEX}
-            >
-              {overlay(activeId)}
-            </DragOverlay>,
-            document.body,
-          )
-        : null}
-    </DndContext>
+    <KanbanInteractionReadinessContext value={interactionReady}>
+      <DndContext
+        autoScroll={autoScroll ?? KANBAN_BOARD_AUTO_SCROLL_OPTIONS}
+        {...(accessibility === undefined ? {} : { accessibility })}
+        collisionDetection={
+          collisionDetection ?? KANBAN_BOARD_COLLISION_DETECTION
+        }
+        onDragCancel={handleDragCancel}
+        onDragEnd={handleDragEnd}
+        {...(onDragOver === undefined ? {} : { onDragOver })}
+        onDragStart={handleDragStart}
+        sensors={sensors ?? defaultSensors}
+      >
+        {children}
+        {overlay && typeof document !== "undefined"
+          ? createPortal(
+              <DragOverlay
+                {...overlayProps}
+                zIndex={overlayProps?.zIndex ?? KANBAN_DRAG_OVERLAY_Z_INDEX}
+              >
+                {overlay(activeId)}
+              </DragOverlay>,
+              document.body,
+            )
+          : null}
+      </DndContext>
+    </KanbanInteractionReadinessContext>
   );
 };
 
@@ -680,6 +720,7 @@ export const useKanbanSortable = ({
   id,
   disabled,
 }: UseKanbanSortableOptions) => {
+  const interactionReady = React.useContext(KanbanInteractionReadinessContext);
   // useSortable merges custom data into a new object after virtualizer renders.
   // The stable nested holder preserves the current navigation branch.
   const data = React.useMemo(
@@ -692,8 +733,8 @@ export const useKanbanSortable = ({
   );
   const sortable = useSortable({
     data,
+    disabled: !interactionReady || disabled === true,
     id,
-    ...(disabled === undefined ? {} : { disabled }),
   });
 
   const setNodeRef = (element: HTMLElement | null) => {


### PR DESCRIPTION
Adds a reusable whole-card drag surface for sortable boards. It keeps nested controls and scrolling available, and covers pointer and touch drops across virtual columns.

CC on behalf of jankubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added whole-card dragging for Kanban items.
  - Preserved interactive controls and touch scrolling within draggable cards.
  - Added card-based drag activation alongside handle and item modes.
  - Improved keyboard drag activation for more reliable interaction.

- **Bug Fixes**
  - Prevented embedded controls from unintentionally starting a drag.
  - Improved dragging across virtual columns and drop-target detection.
  - Ensured drag interactions begin only after Kanban items are ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->