### PR TITLE
fix(ui): settle the published drop target before ending a Kanban drag

### DIFF
--- a/.changeset/kanban-keyboard-drop-settles.md
+++ b/.changeset/kanban-keyboard-drop-settles.md
@@ -2,4 +2,4 @@
 "@stll/ui": patch
 ---
 
-Drop a Kanban keyboard drag on the cell or item the user navigated to. The board committed its keyboard target inside the coordinate getter, but dnd-kit resolves the drop from the target it has published to the sensor context, which trails by one render; an end key pressed before that publication landed the item on the previous target. The keyboard sensor now waits for the published target to match the navigated one before ending the drag.
+Drop a Kanban drag on the cell or item the pointer, touch, or keyboard actually reached. dnd-kit computes collisions while rendering but publishes the resulting drop target a render later, and resolves a drop from that published value; because a single move produces a single render, a drag that ended right after its last move landed the item on the previous target. Every board sensor now waits for the published target to match the computed collision before ending the drag.

--- a/.changeset/kanban-keyboard-drop-settles.md
+++ b/.changeset/kanban-keyboard-drop-settles.md
@@ -3,3 +3,5 @@
 ---
 
 Drop a Kanban drag on the cell or item the pointer, touch, or keyboard actually reached. dnd-kit computes collisions while rendering but publishes the resulting drop target a render later, and resolves a drop from that published value; because a single move produces a single render, a drag that ended right after its last move landed the item on the previous target. Every board sensor now waits for the published target to match the computed collision before ending the drag.
+
+Keyboard navigation to a row a virtual cell has not mounted yet is held to the same rule: ending while that row is still being scrolled into view waits for it rather than committing the row the drag had left, and cancels instead of dropping somewhere the user never navigated to if the board cannot reach it.

--- a/.changeset/kanban-keyboard-drop-settles.md
+++ b/.changeset/kanban-keyboard-drop-settles.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": patch
+---
+
+Drop a Kanban keyboard drag on the cell or item the user navigated to. The board committed its keyboard target inside the coordinate getter, but dnd-kit resolves the drop from the target it has published to the sensor context, which trails by one render; an end key pressed before that publication landed the item on the previous target. The keyboard sensor now waits for the published target to match the navigated one before ending the drag.

--- a/packages/ui/src/kanban/sortable-interactions.logic.test.ts
+++ b/packages/ui/src/kanban/sortable-interactions.logic.test.ts
@@ -5,7 +5,7 @@ import {
   getKanbanKeyboardTargetState,
   getKanbanKeyboardTarget,
   isKanbanCellDropData,
-  isKanbanKeyboardDropSettled,
+  isKanbanDropSettled,
 } from "./sortable-interactions.logic";
 
 const cells = [
@@ -39,6 +39,13 @@ const cells = [
   },
 ] as const;
 
+const publishedOver = (id: string) => ({
+  data: { current: undefined },
+  disabled: false,
+  id,
+  rect: { bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0 },
+});
+
 describe("Kanban keyboard navigation", () => {
   test("keeps a stable navigation holder across virtual renders", () => {
     const navigation = {
@@ -56,42 +63,27 @@ describe("Kanban keyboard navigation", () => {
     expect(getKanbanKeyboardTargetState(data)).toEqual({ type: "idle" });
   });
 
-  test("holds a keyboard drop until the navigated target is published", () => {
-    const navigated = {
-      navigation: { current: { targetId: "cell-b", type: "ready" } },
-      type: "kanban-item",
-    };
-
+  test("holds a drop until the computed collision has been published", () => {
     expect(
-      isKanbanKeyboardDropSettled({ activeData: navigated, overId: "first" }),
+      isKanbanDropSettled({
+        collisions: [{ id: "lane-second" }, { id: "cell-c" }],
+        over: publishedOver("whole-item"),
+      }),
     ).toBe(false);
     expect(
-      isKanbanKeyboardDropSettled({ activeData: navigated, overId: "cell-b" }),
+      isKanbanDropSettled({
+        collisions: [{ id: "lane-second" }, { id: "cell-c" }],
+        over: publishedOver("lane-second"),
+      }),
     ).toBe(true);
   });
 
-  test("drops immediately when no keyboard target is awaiting publication", () => {
+  test("settles a drop when nothing is under the drag", () => {
+    expect(isKanbanDropSettled({ collisions: [], over: null })).toBe(true);
+    expect(isKanbanDropSettled({ collisions: null, over: null })).toBe(true);
     expect(
-      isKanbanKeyboardDropSettled({
-        activeData: {
-          navigation: { current: { type: "idle" } },
-          type: "kanban-item",
-        },
-        overId: "first",
-      }),
-    ).toBe(true);
-    expect(
-      isKanbanKeyboardDropSettled({
-        activeData: {
-          navigation: { current: { targetId: "offscreen", type: "pending" } },
-          type: "kanban-item",
-        },
-        overId: undefined,
-      }),
-    ).toBe(true);
-    expect(
-      isKanbanKeyboardDropSettled({ activeData: undefined, overId: "first" }),
-    ).toBe(true);
+      isKanbanDropSettled({ collisions: [], over: publishedOver("first") }),
+    ).toBe(false);
   });
 
   test("rejects invalid matrix positions at the drop boundary", () => {

--- a/packages/ui/src/kanban/sortable-interactions.logic.test.ts
+++ b/packages/ui/src/kanban/sortable-interactions.logic.test.ts
@@ -46,6 +46,15 @@ const publishedOver = (id: string) => ({
   rect: { bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0 },
 });
 
+const navigatingItem = (current: {
+  targetId: string;
+  type: "pending" | "ready";
+}) => ({
+  data: { current: { navigation: { current }, type: "kanban-item" } },
+  id: "first",
+  rect: { current: { initial: null, translated: null } },
+});
+
 describe("Kanban keyboard navigation", () => {
   test("keeps a stable navigation holder across virtual renders", () => {
     const navigation = {
@@ -66,23 +75,64 @@ describe("Kanban keyboard navigation", () => {
   test("holds a drop until the computed collision has been published", () => {
     expect(
       isKanbanDropSettled({
+        active: null,
         collisions: [{ id: "lane-second" }, { id: "cell-c" }],
         over: publishedOver("whole-item"),
       }),
     ).toBe(false);
     expect(
       isKanbanDropSettled({
+        active: null,
         collisions: [{ id: "lane-second" }, { id: "cell-c" }],
         over: publishedOver("lane-second"),
       }),
     ).toBe(true);
   });
 
-  test("settles a drop when nothing is under the drag", () => {
-    expect(isKanbanDropSettled({ collisions: [], over: null })).toBe(true);
-    expect(isKanbanDropSettled({ collisions: null, over: null })).toBe(true);
+  test("holds a drop while a virtual row is still being mounted", () => {
+    // The board asked for an offscreen row, so the agreeing collision and
+    // published target both describe where the drag has already left.
     expect(
-      isKanbanDropSettled({ collisions: [], over: publishedOver("first") }),
+      isKanbanDropSettled({
+        active: navigatingItem({ targetId: "virtual-12", type: "pending" }),
+        collisions: [{ id: "third" }],
+        over: publishedOver("third"),
+      }),
+    ).toBe(false);
+    expect(
+      isKanbanDropSettled({
+        active: navigatingItem({ targetId: "virtual-12", type: "ready" }),
+        collisions: [{ id: "virtual-12" }],
+        over: publishedOver("virtual-12"),
+      }),
+    ).toBe(true);
+  });
+
+  test("holds a navigated drop that the board has not published", () => {
+    // A row that is briefly unmounted collides with nothing, which must not
+    // read as the drag having left the board.
+    expect(
+      isKanbanDropSettled({
+        active: navigatingItem({ targetId: "third", type: "ready" }),
+        collisions: [],
+        over: null,
+      }),
+    ).toBe(false);
+  });
+
+  test("settles a drop when nothing is under the drag", () => {
+    expect(
+      isKanbanDropSettled({ active: null, collisions: [], over: null }),
+    ).toBe(true);
+    expect(
+      isKanbanDropSettled({ active: null, collisions: null, over: null }),
+    ).toBe(true);
+    expect(
+      isKanbanDropSettled({
+        active: null,
+        collisions: [],
+        over: publishedOver("first"),
+      }),
     ).toBe(false);
   });
 

--- a/packages/ui/src/kanban/sortable-interactions.logic.test.ts
+++ b/packages/ui/src/kanban/sortable-interactions.logic.test.ts
@@ -5,6 +5,7 @@ import {
   getKanbanKeyboardTargetState,
   getKanbanKeyboardTarget,
   isKanbanCellDropData,
+  isKanbanKeyboardDropSettled,
 } from "./sortable-interactions.logic";
 
 const cells = [
@@ -53,6 +54,44 @@ describe("Kanban keyboard navigation", () => {
 
     expect(data.navigation).toBe(navigation);
     expect(getKanbanKeyboardTargetState(data)).toEqual({ type: "idle" });
+  });
+
+  test("holds a keyboard drop until the navigated target is published", () => {
+    const navigated = {
+      navigation: { current: { targetId: "cell-b", type: "ready" } },
+      type: "kanban-item",
+    };
+
+    expect(
+      isKanbanKeyboardDropSettled({ activeData: navigated, overId: "first" }),
+    ).toBe(false);
+    expect(
+      isKanbanKeyboardDropSettled({ activeData: navigated, overId: "cell-b" }),
+    ).toBe(true);
+  });
+
+  test("drops immediately when no keyboard target is awaiting publication", () => {
+    expect(
+      isKanbanKeyboardDropSettled({
+        activeData: {
+          navigation: { current: { type: "idle" } },
+          type: "kanban-item",
+        },
+        overId: "first",
+      }),
+    ).toBe(true);
+    expect(
+      isKanbanKeyboardDropSettled({
+        activeData: {
+          navigation: { current: { targetId: "offscreen", type: "pending" } },
+          type: "kanban-item",
+        },
+        overId: undefined,
+      }),
+    ).toBe(true);
+    expect(
+      isKanbanKeyboardDropSettled({ activeData: undefined, overId: "first" }),
+    ).toBe(true);
   });
 
   test("rejects invalid matrix positions at the drop boundary", () => {

--- a/packages/ui/src/kanban/sortable-interactions.logic.ts
+++ b/packages/ui/src/kanban/sortable-interactions.logic.ts
@@ -111,6 +111,27 @@ export const getKanbanKeyboardTargetState = (
 ): KanbanKeyboardTargetState | undefined =>
   isKanbanItemDropData(value) ? value.navigation.current : undefined;
 
+export type KanbanKeyboardDropOptions = {
+  activeData: unknown;
+  overId: UniqueIdentifier | undefined;
+};
+
+/**
+ * dnd-kit publishes a collision target to its sensor context one render after
+ * the coordinate getter commits it, and resolves a drop from that published
+ * value. A keyboard drop that finalizes earlier lands on the previous target.
+ */
+export const isKanbanKeyboardDropSettled = ({
+  activeData,
+  overId,
+}: KanbanKeyboardDropOptions): boolean => {
+  const target = getKanbanKeyboardTargetState(activeData);
+  if (target?.type !== "ready") {
+    return true;
+  }
+  return overId === target.targetId;
+};
+
 export const clearKanbanKeyboardTarget = (value: unknown): void => {
   if (isKanbanItemDropData(value) && value.navigation.current.type !== "idle") {
     value.navigation.current = { type: "idle" };

--- a/packages/ui/src/kanban/sortable-interactions.logic.ts
+++ b/packages/ui/src/kanban/sortable-interactions.logic.ts
@@ -1,9 +1,11 @@
 import {
   closestCorners,
+  getFirstCollision,
   pointerWithin,
   type CollisionDetection,
   type DroppableContainer,
   type KeyboardCoordinateGetter,
+  type SensorContext,
   type UniqueIdentifier,
 } from "@dnd-kit/core";
 
@@ -111,26 +113,18 @@ export const getKanbanKeyboardTargetState = (
 ): KanbanKeyboardTargetState | undefined =>
   isKanbanItemDropData(value) ? value.navigation.current : undefined;
 
-export type KanbanKeyboardDropOptions = {
-  activeData: unknown;
-  overId: UniqueIdentifier | undefined;
-};
-
 /**
- * dnd-kit publishes a collision target to its sensor context one render after
- * the coordinate getter commits it, and resolves a drop from that published
- * value. A keyboard drop that finalizes earlier lands on the previous target.
+ * dnd-kit computes collisions while rendering but publishes the resulting drop
+ * target to its sensor context a render later, and resolves a drop from that
+ * published value. A drag that ends before the two agree, which every input
+ * can do because a single move produces a single render, drops the item on the
+ * previously published target.
  */
-export const isKanbanKeyboardDropSettled = ({
-  activeData,
-  overId,
-}: KanbanKeyboardDropOptions): boolean => {
-  const target = getKanbanKeyboardTargetState(activeData);
-  if (target?.type !== "ready") {
-    return true;
-  }
-  return overId === target.targetId;
-};
+export const isKanbanDropSettled = ({
+  collisions,
+  over,
+}: Pick<SensorContext, "collisions" | "over">): boolean =>
+  getFirstCollision(collisions, "id") === (over?.id ?? null);
 
 export const clearKanbanKeyboardTarget = (value: unknown): void => {
   if (isKanbanItemDropData(value) && value.navigation.current.type !== "idle") {

--- a/packages/ui/src/kanban/sortable-interactions.logic.ts
+++ b/packages/ui/src/kanban/sortable-interactions.logic.ts
@@ -119,12 +119,27 @@ export const getKanbanKeyboardTargetState = (
  * published value. A drag that ends before the two agree, which every input
  * can do because a single move produces a single render, drops the item on the
  * previously published target.
+ *
+ * Keyboard navigation names its target outright, so it is compared directly: a
+ * pending target is still waiting for a virtual cell to mount an offscreen row
+ * and has produced no collision at all, and a ready one is only settled once it
+ * is the published target. Until then both the collisions and the published
+ * target still describe where the board was before the user navigated away.
  */
 export const isKanbanDropSettled = ({
+  active,
   collisions,
   over,
-}: Pick<SensorContext, "collisions" | "over">): boolean =>
-  getFirstCollision(collisions, "id") === (over?.id ?? null);
+}: Pick<SensorContext, "active" | "collisions" | "over">): boolean => {
+  const target = getKanbanKeyboardTargetState(active?.data.current);
+  if (target?.type === "pending") {
+    return false;
+  }
+  if (target?.type === "ready") {
+    return over?.id === target.targetId;
+  }
+  return getFirstCollision(collisions, "id") === (over?.id ?? null);
+};
 
 export const clearKanbanKeyboardTarget = (value: unknown): void => {
   if (isKanbanItemDropData(value) && value.navigation.current.type !== "idle") {

--- a/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
+++ b/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
@@ -723,3 +723,46 @@ test("keyboard navigation reaches rows beyond the virtualizer window", async ({
     )
     .toBe("virtual-12");
 });
+
+test("drops on a row the keyboard reached while it was still offscreen", async ({
+  page,
+}) => {
+  const handle = await openFixture(page);
+  const sourceCell = page.locator('[data-kanban-cell="cell-a"]');
+  const draggedOver = async () =>
+    await page.evaluate(
+      () => document.documentElement.dataset["draggedOver"] ?? "",
+    );
+
+  await handle.focus();
+  await page.keyboard.press("Space");
+  await expectDragActivated(page);
+  // Pin the drop target to the dragged item so scrolling the cell away cannot
+  // drift it onto a row that happens to stay mounted.
+  await page.keyboard.press("ArrowDown");
+  await expect.poll(draggedOver).toBe("third");
+  await page.keyboard.press("ArrowUp");
+  await expect.poll(draggedOver).toBe("first");
+
+  await sourceCell.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+  });
+  await expect
+    .poll(
+      async () => await page.locator('[data-sortable-item="third"]').count(),
+    )
+    .toBe(0);
+
+  // The next row is unmounted, so this arrow only requests a virtual scroll.
+  // Ending before that scroll resolves must still drop on the requested row.
+  await page.keyboard.press("ArrowDown");
+  await page.keyboard.press("Space");
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["droppedOn"] ?? "",
+        ),
+    )
+    .toBe("third");
+});

--- a/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
+++ b/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
@@ -381,6 +381,14 @@ test("drops a touch drag into an adjacent virtual cell", async ({ page }) => {
   await dispatchNativeTouch(nativeTouch, "touchStart", [sourceCoordinates]);
   await expect(page.locator("[data-overlay]")).toHaveText("first");
   await dispatchNativeTouch(nativeTouch, "touchMove", [targetCoordinates]);
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["draggedOver"] ?? "",
+        ),
+    )
+    .toBe("second");
   await endNativeTouch(nativeTouch);
 
   await expect
@@ -414,6 +422,14 @@ test("drops a whole-item touch drag across a virtual column", async ({
   await dispatchNativeTouch(nativeTouch, "touchStart", [sourceCoordinates]);
   await expect(page.locator("[data-overlay]")).toHaveText("whole-item");
   await dispatchNativeTouch(nativeTouch, "touchMove", [targetCoordinates]);
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["draggedOver"] ?? "",
+        ),
+    )
+    .toBe("lane-second");
   await endNativeTouch(nativeTouch);
 
   await expect
@@ -463,6 +479,14 @@ test("drops pointer and touch input into an empty virtual cell", async ({
   await dispatchNativeTouch(nativeTouch, "touchStart", [touchSource]);
   await expect(page.locator("[data-overlay]")).toHaveText("first");
   await dispatchNativeTouch(nativeTouch, "touchMove", [touchTarget]);
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["draggedOver"] ?? "",
+        ),
+    )
+    .toBe("cell-b");
   await endNativeTouch(nativeTouch);
   await expect
     .poll(

--- a/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
+++ b/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
@@ -8,6 +8,18 @@ const openFixture = async (page: Page) => {
   return page.getByRole("button", { name: "Move first" });
 };
 
+/** Keyboard navigation must work once the drag is live, not only in the same tick. */
+const expectDragActivated = async (page: Page) => {
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["dragStartedAt"] ?? "",
+        ),
+    )
+    .not.toBe("");
+};
+
 const getTouchCoordinates = async (handle: Locator) => {
   const box = await handle.boundingBox();
   if (!box) {
@@ -559,6 +571,7 @@ test("drops a keyboard drag into an adjacent virtual cell", async ({
 
   await handle.focus();
   await page.keyboard.press("Space");
+  await expectDragActivated(page);
   await page.keyboard.press("ArrowRight");
   await expect
     .poll(
@@ -587,6 +600,7 @@ test("navigates items in order, then across matrix cells and lanes", async ({
 
   await handle.focus();
   await page.keyboard.press("Space");
+  await expectDragActivated(page);
   await page.keyboard.press("ArrowDown");
   await expect
     .poll(
@@ -610,6 +624,7 @@ test("navigates items in order, then across matrix cells and lanes", async ({
   const reloadedHandle = page.getByRole("button", { name: "Move first" });
   await reloadedHandle.focus();
   await page.keyboard.press("Space");
+  await expectDragActivated(page);
   await page.keyboard.press("ArrowRight");
   await expect
     .poll(

--- a/packages/ui/src/kanban/sortable-interactions.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.tsx
@@ -266,7 +266,13 @@ class KanbanKeyboardSensor implements SensorInstance {
 
   autoScrollEnabled = false;
 
+  /** Input handling, released as soon as a drag stops accepting keys. */
   private readonly listeners = new AbortController();
+  /**
+   * The drag itself, released only once it resolves. Ending must not stop the
+   * queued retry that still has to bring a pending virtual target into view.
+   */
+  private readonly lifetime = new AbortController();
   private readonly props: KeyboardSensorConstructorOptions;
   private moveSequence = 0;
   private referenceCoordinates: { x: number; y: number } | null = null;
@@ -292,13 +298,20 @@ class KanbanKeyboardSensor implements SensorInstance {
   }
 
   private readonly handleCancel = () => {
-    if (this.listeners.signal.aborted) {
+    if (this.lifetime.signal.aborted) {
       return;
     }
     this.moveSequence += 1;
-    clearKanbanKeyboardTarget(this.props.context.current.active?.data.current);
     this.listeners.abort();
-    this.props.onCancel();
+    this.finish(() => {
+      this.props.onCancel();
+    });
+  };
+
+  private readonly finish = (resolve: () => void) => {
+    clearKanbanKeyboardTarget(this.props.context.current.active?.data.current);
+    this.lifetime.abort();
+    resolve();
   };
 
   private readonly handleKeyDown = (event: KeyboardEvent) => {
@@ -312,19 +325,62 @@ class KanbanKeyboardSensor implements SensorInstance {
     }
     if (endCodes.some((code) => code === event.code)) {
       event.preventDefault();
-      this.moveSequence += 1;
+      // The move sequence and the lifetime signal stay untouched so a queued
+      // virtual-scroll retry can still resolve the target this drop needs.
       this.listeners.abort();
-      endWhenDropTargetSettled(this.props.context, () => {
-        clearKanbanKeyboardTarget(
-          this.props.context.current.active?.data.current,
-        );
-        this.props.onEnd();
-      });
+      this.endWhenNavigationResolves(0);
       return;
     }
 
     this.moveSequence += 1;
     this.move(event, this.moveSequence, 0);
+  };
+
+  /**
+   * A pending target has asked a virtual cell to mount an offscreen row and has
+   * published nothing, so the queued move retry, not this keypress, decides
+   * where the item lands. Cancel when that retry gives up: the board never
+   * reached the row the user navigated to, and the target still published is
+   * the one they navigated away from.
+   */
+  private readonly endWhenNavigationResolves = (framesWaited: number) => {
+    if (this.lifetime.signal.aborted) {
+      return;
+    }
+    const target = getKanbanKeyboardTargetState(
+      this.props.context.current.active?.data.current,
+    );
+    if (target?.type === "pending") {
+      if (framesWaited >= KANBAN_KEYBOARD_TARGET_RETRY_LIMIT) {
+        this.finish(() => {
+          this.props.onCancel();
+        });
+        return;
+      }
+      requestAnimationFrame(() => {
+        this.endWhenNavigationResolves(framesWaited + 1);
+      });
+      return;
+    }
+    if (framesWaited > 0 && target?.type !== "ready") {
+      this.finish(() => {
+        this.props.onCancel();
+      });
+      return;
+    }
+    endWhenDropTargetSettled(this.props.context, () => {
+      // The wait is bounded, so it can stop without the board ever publishing
+      // the navigated target. Committing whatever is published instead would
+      // drop the item somewhere the user never asked for.
+      const settled = isKanbanDropSettled(this.props.context.current);
+      this.finish(() => {
+        if (settled) {
+          this.props.onEnd();
+          return;
+        }
+        this.props.onCancel();
+      });
+    });
   };
 
   private readonly move = (
@@ -355,7 +411,7 @@ class KanbanKeyboardSensor implements SensorInstance {
         return;
       }
       requestAnimationFrame(() => {
-        if (this.listeners.signal.aborted || this.moveSequence !== sequence) {
+        if (this.lifetime.signal.aborted || this.moveSequence !== sequence) {
           return;
         }
         this.move(event, sequence, retryCount + 1);

--- a/packages/ui/src/kanban/sortable-interactions.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.tsx
@@ -25,6 +25,7 @@ import type {
   DndContextProps,
   KeyboardCoordinateGetter,
   KeyboardSensorOptions,
+  MouseSensorOptions,
   SensorInstance,
   SensorProps,
   TouchSensorOptions,
@@ -40,7 +41,7 @@ import { cn } from "../lib/utils";
 import {
   clearKanbanKeyboardTarget,
   getKanbanKeyboardTargetState,
-  isKanbanKeyboardDropSettled,
+  isKanbanDropSettled,
   KANBAN_BOARD_COLLISION_DETECTION,
   KANBAN_DROP_TARGET_TYPES,
   kanbanKeyboardCoordinates,
@@ -88,8 +89,10 @@ export type KanbanDragEndEvent = DragEndEvent;
 export type KanbanDragOverEvent = DragOverEvent;
 export type KanbanDragStartEvent = DragStartEvent;
 
+type MouseSensorConstructorOptions = SensorProps<MouseSensorOptions>;
 type TouchSensorConstructorOptions = SensorProps<TouchSensorOptions>;
 type KeyboardSensorConstructorOptions = SensorProps<KeyboardSensorOptions>;
+type KanbanSensorContext = SensorProps<never>["context"];
 
 const KANBAN_KEYBOARD_CODES = {
   cancel: ["Escape"],
@@ -98,7 +101,31 @@ const KANBAN_KEYBOARD_CODES = {
 const KANBAN_KEYBOARD_LISTENER_DELAY_MS = 0;
 const KANBAN_KEYBOARD_TARGET_RETRY_LIMIT = 60;
 /** A render commit, not a virtual scroll, so the budget stays short. */
-const KANBAN_KEYBOARD_DROP_RETRY_LIMIT = 10;
+const KANBAN_DROP_SETTLE_FRAME_LIMIT = 10;
+
+/**
+ * Defers a drop until dnd-kit has published the collision target it computed.
+ * Every sensor ends a drag from a single input event, so without this wait the
+ * drop resolves against the target published before that event.
+ */
+const endWhenDropTargetSettled = (
+  context: KanbanSensorContext,
+  end: () => void,
+) => {
+  let framesWaited = 0;
+  const attempt = () => {
+    if (
+      framesWaited >= KANBAN_DROP_SETTLE_FRAME_LIMIT ||
+      isKanbanDropSettled(context.current)
+    ) {
+      end();
+      return;
+    }
+    framesWaited += 1;
+    requestAnimationFrame(attempt);
+  };
+  attempt();
+};
 
 type TouchEventWithLists = Event & {
   changedTouches: TouchList;
@@ -158,7 +185,9 @@ class KanbanTouchSensor extends TouchSensor {
       },
       onEnd: () => {
         identityListeners.abort();
-        props.onEnd();
+        endWhenDropTargetSettled(props.context, () => {
+          props.onEnd();
+        });
       },
     });
     this.identityListeners = identityListeners;
@@ -211,6 +240,20 @@ class KanbanTouchSensor extends TouchSensor {
   private readonly detachIdentityListeners = () => {
     this.identityListeners.abort();
   };
+}
+
+/** The stock mouse sensor, holding its drop until the board target settles. */
+class KanbanMouseSensor extends MouseSensor {
+  constructor(props: MouseSensorConstructorOptions) {
+    super({
+      ...props,
+      onEnd: () => {
+        endWhenDropTargetSettled(props.context, () => {
+          props.onEnd();
+        });
+      },
+    });
+  }
 }
 
 /**
@@ -271,37 +314,17 @@ class KanbanKeyboardSensor implements SensorInstance {
       event.preventDefault();
       this.moveSequence += 1;
       this.listeners.abort();
-      this.end(0);
+      endWhenDropTargetSettled(this.props.context, () => {
+        clearKanbanKeyboardTarget(
+          this.props.context.current.active?.data.current,
+        );
+        this.props.onEnd();
+      });
       return;
     }
 
     this.moveSequence += 1;
     this.move(event, this.moveSequence, 0);
-  };
-
-  /**
-   * The board commits its navigated target inside the coordinate getter, but
-   * dnd-kit resolves the drop from the target it has published to the sensor
-   * context, which trails by one render. Ending before those agree drops the
-   * item on the previously published target.
-   */
-  private readonly end = (retryCount: number) => {
-    const currentContext = this.props.context.current;
-    const activeData = currentContext.active?.data.current;
-    if (
-      retryCount < KANBAN_KEYBOARD_DROP_RETRY_LIMIT &&
-      !isKanbanKeyboardDropSettled({
-        activeData,
-        overId: currentContext.over?.id,
-      })
-    ) {
-      requestAnimationFrame(() => {
-        this.end(retryCount + 1);
-      });
-      return;
-    }
-    clearKanbanKeyboardTarget(activeData);
-    this.props.onEnd();
   };
 
   private readonly move = (
@@ -484,7 +507,7 @@ export const useKanbanSortableSensors = (
   keyboardCoordinates: KeyboardCoordinateGetter = kanbanKeyboardCoordinates,
 ) =>
   useSensors(
-    useSensor(MouseSensor, {
+    useSensor(KanbanMouseSensor, {
       activationConstraint: { distance: KANBAN_MOUSE_ACTIVATION_DISTANCE },
     }),
     useSensor(KanbanTouchSensor, {

--- a/packages/ui/src/kanban/sortable-interactions.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.tsx
@@ -40,6 +40,7 @@ import { cn } from "../lib/utils";
 import {
   clearKanbanKeyboardTarget,
   getKanbanKeyboardTargetState,
+  isKanbanKeyboardDropSettled,
   KANBAN_BOARD_COLLISION_DETECTION,
   KANBAN_DROP_TARGET_TYPES,
   kanbanKeyboardCoordinates,
@@ -96,6 +97,8 @@ const KANBAN_KEYBOARD_CODES = {
 } as const;
 const KANBAN_KEYBOARD_LISTENER_DELAY_MS = 0;
 const KANBAN_KEYBOARD_TARGET_RETRY_LIMIT = 60;
+/** A render commit, not a virtual scroll, so the budget stays short. */
+const KANBAN_KEYBOARD_DROP_RETRY_LIMIT = 10;
 
 type TouchEventWithLists = Event & {
   changedTouches: TouchList;
@@ -267,16 +270,38 @@ class KanbanKeyboardSensor implements SensorInstance {
     if (endCodes.some((code) => code === event.code)) {
       event.preventDefault();
       this.moveSequence += 1;
-      clearKanbanKeyboardTarget(
-        this.props.context.current.active?.data.current,
-      );
       this.listeners.abort();
-      this.props.onEnd();
+      this.end(0);
       return;
     }
 
     this.moveSequence += 1;
     this.move(event, this.moveSequence, 0);
+  };
+
+  /**
+   * The board commits its navigated target inside the coordinate getter, but
+   * dnd-kit resolves the drop from the target it has published to the sensor
+   * context, which trails by one render. Ending before those agree drops the
+   * item on the previously published target.
+   */
+  private readonly end = (retryCount: number) => {
+    const currentContext = this.props.context.current;
+    const activeData = currentContext.active?.data.current;
+    if (
+      retryCount < KANBAN_KEYBOARD_DROP_RETRY_LIMIT &&
+      !isKanbanKeyboardDropSettled({
+        activeData,
+        overId: currentContext.over?.id,
+      })
+    ) {
+      requestAnimationFrame(() => {
+        this.end(retryCount + 1);
+      });
+      return;
+    }
+    clearKanbanKeyboardTarget(activeData);
+    this.props.onEnd();
   };
 
   private readonly move = (


### PR DESCRIPTION
Ending a Kanban drag could drop the item on the wrong target. The board computes collisions inline during render, but dnd-kit sets `over` from an effect keyed on `[overId]` and only the *following* commit writes it into the sensor context, from which `DragEnd` resolves the drop. Every sensor ends a drag from a single input event, and a single move produces a single render, so an end event arriving before that follow-up commit resolves against the previously published target: a keyboard drag across virtual cells landed on the item itself, and a touch drag across a virtual column landed on `whole-item` instead of the lane it was over. Reproduced deterministically at 20× CPU throttling (the shape of a loaded CI runner): 6 of 6 runs failed, touch and keyboard alike; the merged tests passed only because the end event raced into the same tick as the last move.

The fix is one predicate, `isKanbanDropSettled({ collisions, over })`, comparing dnd-kit's own first collision with the published `over` (typed as `Pick<SensorContext, "collisions" | "over">`, so it cannot drift from the shape it mirrors), and one shared `endWhenDropTargetSettled` that waits, bounded by `KANBAN_DROP_SETTLE_FRAME_LIMIT` animation frames, before ending. It is wired into the touch sensor, the keyboard sensor (whose bespoke end path is deleted), and a new `KanbanMouseSensor` wrapper. The Playwright touch drops gain explicit `draggedOver` waits after each move and the keyboard tests an activation wait, so the specs pin each stage rather than depend on tick timing; the production fix alone closes the throttled failure with no test wait present.

Verified: throttled repro 6/6 pass, touch drop ×10 and keyboard tests ×10, full 18-test spec twice, 190 unit tests, typecheck, lint.

https://claude.ai/code/session_01GckBYzFkS2k17FTRN8d6MX