### PR TITLE
feat: emit attention signals for stuck and at-risk governed work

### DIFF
--- a/apps/api/drizzle/20260831090000_signals_work_attention_kinds/migration.sql
+++ b/apps/api/drizzle/20260831090000_signals_work_attention_kinds/migration.sql
@@ -1,0 +1,25 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5s';--> statement-breakpoint
+
+-- The `work.attention` scout adds `work.unacknowledged` and
+-- `work.deadline_at_risk` to SIGNAL_KINDS, both with `source` origin. The
+-- schema builds both CHECKs from that list, so the constraints the database
+-- enforces have to be widened in step or every signal the scout emits is
+-- rejected.
+--
+-- NOT VALID: both statements only widen the accepted set, so every stored row
+-- already satisfies the new constraint and there is nothing to scan; they still
+-- apply to every later INSERT and UPDATE. Each constraint is dropped by name
+-- and re-added in one statement so no running API task observes the column
+-- unconstrained, and a second run re-records the same constraint.
+-- stella-migration-safety: reviewed drop-constraint - drops only this check constraint by name and re-adds it with the two work kinds added in the same statement; no row data is touched. Rollback is the same statement without those kinds, which is safe once no row holds them.
+ALTER TABLE "signals"
+  DROP CONSTRAINT IF EXISTS "signals_kind_check",
+  ADD CONSTRAINT "signals_kind_check"
+  CHECK ("kind" in ('request.submitted', 'hearing.changed', 'deadline.detected', 'contract.reviewed', 'work.unacknowledged', 'work.deadline_at_risk')) NOT VALID;--> statement-breakpoint
+
+-- stella-migration-safety: reviewed drop-constraint - drops only this check constraint by name and re-adds it with the two work kinds pinned to `source` origin in the same statement; no row data is touched. Rollback is the same statement without those kinds, which is safe once no row holds them.
+ALTER TABLE "signals"
+  DROP CONSTRAINT IF EXISTS "signals_kind_origin_check",
+  ADD CONSTRAINT "signals_kind_origin_check"
+  CHECK (("kind" = 'request.submitted' AND "origin" = 'manual') OR ("kind" = 'hearing.changed' AND "origin" = 'source') OR ("kind" = 'deadline.detected' AND "origin" = 'model') OR ("kind" = 'contract.reviewed' AND "origin" = 'model') OR ("kind" = 'work.unacknowledged' AND "origin" = 'source') OR ("kind" = 'work.deadline_at_risk' AND "origin" = 'source')) NOT VALID;

--- a/apps/api/src/handlers/signals/acceptances/create.ts
+++ b/apps/api/src/handlers/signals/acceptances/create.ts
@@ -59,6 +59,11 @@ const SIGNAL_WORK_OBLIGATION_SOURCE = {
   [SIGNAL_KIND.HEARING_CHANGED]: "court",
   [SIGNAL_KIND.DEADLINE_DETECTED]: "document",
   [SIGNAL_KIND.CONTRACT_REVIEWED]: "document",
+  // The work-attention kinds carry no task or deadline suggestion, so these
+  // entries only decide provenance if one is ever added. They report on work
+  // a person already created inside Stella, which is `manual`.
+  [SIGNAL_KIND.WORK_UNACKNOWLEDGED]: "manual",
+  [SIGNAL_KIND.WORK_DEADLINE_AT_RISK]: "manual",
 } as const satisfies Record<SignalKind, WorkObligationSource>;
 
 export type AcceptSignalDependencies = {

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -444,6 +444,10 @@ export const LIMITS = {
   infoSoudRelatedCasesMax: 50,
   infoSoudAgendaImportItemsMax: 1000,
   infoSoudTrackedCasesSyncBatch: 50,
+  /** Obligations the work-attention scout reads per tick. The sweep is a
+   *  keyset cycle over open governed work, so the page size bounds one tick's
+   *  cost rather than the corpus it eventually covers. */
+  workAttentionObligationsPage: 500,
   agendaAttendeesMax: 500,
   /** Max chat context file attachment size per file. */
   chatContextFileMaxChars: 16_000,

--- a/apps/api/src/lib/scheduler/jobs.ts
+++ b/apps/api/src/lib/scheduler/jobs.ts
@@ -27,6 +27,7 @@ import { REPAIR_CHAT_SEARCH_INDEX_TASK } from "@/api/lib/scheduler/tasks/search-
 import { REPAIR_SEARCH_PROJECTIONS_TASK } from "@/api/lib/scheduler/tasks/search-projection-repair";
 import { REPAIR_SEARCH_SEMANTIC_TIMESTAMPS_TASK } from "@/api/lib/scheduler/tasks/search-semantic-timestamps";
 import { CLEAN_TEMPLATE_DELETION_OBJECTS_TASK } from "@/api/lib/scheduler/tasks/template-deletion-cleanup";
+import { WORK_ATTENTION_SCOUT_TASK } from "@/api/lib/scheduler/tasks/work-attention-scout";
 import { BACKFILL_WORK_OBLIGATIONS_TASK } from "@/api/lib/scheduler/tasks/work-obligation-backfill";
 
 type SchedulerJobDefinition = {
@@ -190,6 +191,15 @@ export const DECLARED_SCHEDULER_JOBS = [
     payloadUpdate: "preserve",
     schedule: { type: "interval", everyMs: 60 * 1000 },
     task: BACKFILL_WORK_OBLIGATIONS_TASK,
+  },
+  {
+    description: "Surface stuck and at-risk governed work as inbox signals",
+    enabled: env.FEATURE_GOVERNED_WORKFLOW,
+    id: "workObligations.attentionScout.hourly",
+    mode: "recurring",
+    payloadUpdate: "preserve",
+    schedule: { type: "interval", everyMs: 60 * 60 * 1000 },
+    task: WORK_ATTENTION_SCOUT_TASK,
   },
   {
     description: "Repair stale chat search projections",

--- a/apps/api/src/lib/scheduler/registry.ts
+++ b/apps/api/src/lib/scheduler/registry.ts
@@ -64,6 +64,10 @@ import {
   cleanTemplateDeletionObjects,
 } from "@/api/lib/scheduler/tasks/template-deletion-cleanup";
 import {
+  WORK_ATTENTION_SCOUT_TASK,
+  runWorkAttentionScoutTask,
+} from "@/api/lib/scheduler/tasks/work-attention-scout";
+import {
   BACKFILL_WORK_OBLIGATIONS_TASK,
   backfillWorkObligations,
 } from "@/api/lib/scheduler/tasks/work-obligation-backfill";
@@ -92,6 +96,7 @@ const SCHEDULER_TASKS = {
   [REPAIR_SEARCH_PROJECTIONS_TASK]: repairSearchProjections,
   [CHAT_THREAD_COMPACTOR_TASK]: compactChatThreads,
   [BACKFILL_WORK_OBLIGATIONS_TASK]: backfillWorkObligations,
+  [WORK_ATTENTION_SCOUT_TASK]: runWorkAttentionScoutTask,
   [REPAIR_SEARCH_SEMANTIC_TIMESTAMPS_TASK]: repairSearchSemanticTimestampsTask,
   [MEMORY_CURATOR_TASK]: curateAiMemories,
   [MEMORY_EXTRACTOR_TASK]: extractMemoriesFromCompactions,

--- a/apps/api/src/lib/scheduler/tasks/work-attention-scout.ts
+++ b/apps/api/src/lib/scheduler/tasks/work-attention-scout.ts
@@ -1,0 +1,68 @@
+import { panic } from "better-result";
+import { and, eq } from "drizzle-orm";
+
+import { rootDb } from "@/api/db/root";
+import { schedulerJobs } from "@/api/db/schema";
+import { env } from "@/api/env";
+import type { SafeId } from "@/api/lib/branded-types";
+import { isUuid } from "@/api/lib/custom-schema";
+import { brandPersistedEntityId } from "@/api/lib/safe-id-boundaries";
+import type { SchedulerTask } from "@/api/lib/scheduler/types";
+import { runWorkAttentionScout } from "@/api/lib/scouts/work-attention";
+
+export const WORK_ATTENTION_SCOUT_TASK =
+  "workObligations.attentionScout" as const;
+
+const scoutCursor = (
+  payload: Record<string, unknown> | null,
+): SafeId<"entity"> | null => {
+  const cursor = payload?.["cursor"];
+  if (cursor === undefined || cursor === null) {
+    return null;
+  }
+  if (typeof cursor !== "string" || !isUuid(cursor)) {
+    return panic("Work-attention scout cursor must be a UUID");
+  }
+  return brandPersistedEntityId(cursor);
+};
+
+/**
+ * Sweep one bounded page of governed work for signals a supervisor should see.
+ * The cursor advances only after the page's signals are committed, so a failed
+ * tick replays the page and the scout's dedupe keys absorb the repeat.
+ */
+export const runWorkAttentionScoutTask: SchedulerTask = async ({
+  job,
+  logger,
+  signal,
+}) => {
+  if (!env.FEATURE_GOVERNED_WORKFLOW) {
+    return;
+  }
+
+  signal.throwIfAborted();
+  const leaseToken =
+    job.lockedBy ?? panic("Work-attention scout requires a scheduler lease");
+  const outcome = await runWorkAttentionScout({
+    cursor: scoutCursor(job.payload),
+  });
+
+  signal.throwIfAborted();
+  await rootDb
+    .update(schedulerJobs)
+    .set({ payload: { cursor: outcome.nextCursor } })
+    .where(
+      and(eq(schedulerJobs.id, job.id), eq(schedulerJobs.lockedBy, leaseToken)),
+    );
+
+  // audit: skip — an observation sweep over durable work state; the signals it
+  // emits carry their own scout_runs census and signal_events trail.
+  logger.info("scheduler.work_attention_scanned", {
+    "workAttention.emitted": outcome.emitted,
+    "workAttention.inserted": outcome.inserted,
+    "workAttention.organizations": outcome.organizations,
+    "workAttention.organizationsWithoutMember":
+      outcome.organizationsWithoutMember,
+    "workAttention.scanned": outcome.scanned,
+  });
+};

--- a/apps/api/src/lib/scouts/work-attention.integration.test.ts
+++ b/apps/api/src/lib/scouts/work-attention.integration.test.ts
@@ -1,0 +1,354 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { SCOUT_KEY, SIGNAL_KIND } from "@stll/api-contract/signals";
+import { WORK_OBLIGATION_STATUS } from "@stll/api-contract/workflow-status";
+import type { WorkObligationStatus } from "@stll/api-contract/workflow-status";
+import { DAY_IN_MS } from "@stll/time";
+
+import type { rootDb } from "@/api/db/root";
+import type { ScopedDb } from "@/api/db/safe-db";
+import {
+  entities,
+  scoutRuns,
+  signals,
+  WORK_OBLIGATION_EVENT_TYPE,
+  workObligationEvents,
+  workObligations,
+} from "@/api/db/schema";
+import { createScopedDb } from "@/api/db/scoped";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { brandPersistedEntityId } from "@/api/lib/safe-id-boundaries";
+import { runWorkAttentionScout } from "@/api/lib/scouts/work-attention";
+import type { WorkAttentionScoutDependencies } from "@/api/lib/scouts/work-attention";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import {
+  getRlsFixture,
+  releaseRlsFixture,
+} from "@/api/tests/security/rls-fixture";
+import type { TestIds } from "@/api/tests/security/rls-helpers";
+import type { TestDatabase } from "@/api/tests/security/test-utils";
+
+setDefaultTimeout(120_000);
+
+const NOW = new Date("2026-03-01T09:00:00.000Z");
+
+const dateOffset = (days: number): string =>
+  new Date(NOW.getTime() + days * DAY_IN_MS).toISOString().slice(0, 10);
+
+const instantOffset = (days: number): Date =>
+  new Date(NOW.getTime() + days * DAY_IN_MS);
+
+let testDb: TestDatabase;
+let ids: TestIds;
+const seededEntityIds: SafeId<"entity">[] = [];
+
+type SeedWork = {
+  label: string;
+  status: WorkObligationStatus;
+  hardDeadlineDate: string | null;
+  /** Days before `NOW` the row itself was created. */
+  createdDaysAgo: number;
+  /** Days before `NOW` an `owner_assigned` event was recorded, if any. */
+  assignedDaysAgo: number | null;
+};
+
+/**
+ * One row per decision the scout has to make: how long an assignment has gone
+ * unanswered, whether the waiting clock comes from an event or from the row's
+ * own creation, how close a hard deadline is, and whether closed work is out
+ * of scope at all.
+ */
+const SEED: SeedWork[] = [
+  {
+    label: "awaiting, assigned five days ago",
+    status: WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
+    hardDeadlineDate: null,
+    createdDaysAgo: 30,
+    assignedDaysAgo: 5,
+  },
+  {
+    label: "awaiting, assigned yesterday on an old row",
+    status: WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
+    hardDeadlineDate: null,
+    createdDaysAgo: 30,
+    assignedDaysAgo: 1,
+  },
+  {
+    label: "awaiting, backfilled without an assignment event",
+    status: WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
+    hardDeadlineDate: null,
+    createdDaysAgo: 10,
+    assignedDaysAgo: null,
+  },
+  {
+    label: "active, hard deadline passed",
+    status: WORK_OBLIGATION_STATUS.ACTIVE,
+    hardDeadlineDate: dateOffset(-1),
+    createdDaysAgo: 20,
+    assignedDaysAgo: 20,
+  },
+  {
+    label: "active, hard deadline a month out",
+    status: WORK_OBLIGATION_STATUS.ACTIVE,
+    hardDeadlineDate: dateOffset(30),
+    createdDaysAgo: 20,
+    assignedDaysAgo: 20,
+  },
+  {
+    label: "completed, hard deadline passed",
+    status: WORK_OBLIGATION_STATUS.COMPLETED,
+    hardDeadlineDate: dateOffset(-1),
+    createdDaysAgo: 20,
+    assignedDaysAgo: 20,
+  },
+];
+
+const seeded = new Map<string, SafeId<"entity">>();
+
+const entityIdOf = (label: string) =>
+  seeded.get(label) ?? expect.unreachable(`missing fixture row: ${label}`);
+
+const seedWork = async (work: SeedWork) => {
+  const entityId = createSafeId<"entity">();
+  seededEntityIds.push(entityId);
+  seeded.set(work.label, entityId);
+  const acknowledged = work.status === WORK_OBLIGATION_STATUS.ACTIVE;
+  await testDb.insert(entities).values({
+    id: entityId,
+    workspaceId: ids.wsA1,
+    kind: "task",
+    name: work.label,
+    status: "open",
+    createdBy: ids.userA1,
+  });
+  await testDb.insert(workObligations).values({
+    entityId,
+    workspaceId: ids.wsA1,
+    ownerUserId: ids.userA1,
+    status: work.status,
+    acknowledgedAt: acknowledged ? instantOffset(-1) : null,
+    acknowledgedByUserId: acknowledged ? ids.userA1 : null,
+    hardDeadlineDate: work.hardDeadlineDate,
+    createdByUserId: ids.userA1,
+    createdAt: instantOffset(-work.createdDaysAgo),
+  });
+  if (work.assignedDaysAgo !== null) {
+    await testDb.insert(workObligationEvents).values({
+      id: createSafeId<"workObligationEvent">(),
+      workspaceId: ids.wsA1,
+      obligationEntityId: entityId,
+      actorUserId: ids.userA1,
+      type: WORK_OBLIGATION_EVENT_TYPE.OWNER_ASSIGNED,
+      details: {
+        type: "ownership_changed",
+        previousOwnerUserId: null,
+        nextOwnerUserId: ids.userA1,
+      },
+      occurredAt: instantOffset(-work.assignedDaysAgo),
+    });
+  }
+};
+
+const dependencies = (): WorkAttentionScoutDependencies => ({
+  db: asTestRaw<typeof rootDb>(testDb),
+  createScopedDb: ({ organizationId, userId, workspaceIds }) =>
+    asTestRaw<ScopedDb>(
+      createScopedDb(testDb, workspaceIds, organizationId, userId),
+    ),
+});
+
+const seededSignals = async () =>
+  await testDb
+    .select({
+      kind: signals.kind,
+      severity: signals.severity,
+      origin: signals.origin,
+      confidence: signals.confidence,
+      workspaceId: signals.workspaceId,
+      dedupeKey: signals.dedupeKey,
+      subject: signals.subject,
+      evidence: signals.evidence,
+    })
+    .from(signals)
+    .where(eq(signals.scoutKey, SCOUT_KEY.WORK_ATTENTION));
+
+const signalsFor = async (label: string) => {
+  const entityId = entityIdOf(label);
+  const rows = await seededSignals();
+  return rows.filter((row) =>
+    row.evidence.kind === SIGNAL_KIND.WORK_UNACKNOWLEDGED ||
+    row.evidence.kind === SIGNAL_KIND.WORK_DEADLINE_AT_RISK
+      ? row.evidence.obligationEntityId === entityId
+      : false,
+  );
+};
+
+beforeAll(async () => {
+  const fixture = await getRlsFixture();
+  testDb = fixture.testDb;
+  ids = fixture.ids;
+  for (const work of SEED) {
+    // oxlint-disable-next-line no-await-in-loop -- sequential seeding keeps the insert order readable
+    await seedWork(work);
+  }
+});
+
+afterAll(async () => {
+  try {
+    await testDb
+      .delete(signals)
+      .where(eq(signals.scoutKey, SCOUT_KEY.WORK_ATTENTION));
+    await testDb
+      .delete(scoutRuns)
+      .where(eq(scoutRuns.scoutKey, SCOUT_KEY.WORK_ATTENTION));
+    if (seededEntityIds.length > 0) {
+      await testDb
+        .delete(entities)
+        .where(inArray(entities.id, seededEntityIds));
+    }
+  } finally {
+    await releaseRlsFixture();
+  }
+});
+
+describe("work attention scout", () => {
+  test("emits once per stuck obligation and records the run", async () => {
+    const outcome = await runWorkAttentionScout({
+      cursor: null,
+      now: NOW,
+      dependencies: dependencies(),
+    });
+
+    expect(outcome.nextCursor).not.toBeNull();
+    expect(outcome.inserted).toBeGreaterThan(0);
+
+    expect(
+      (await signalsFor("awaiting, assigned five days ago")).map(
+        ({ kind, severity, origin, confidence }) => ({
+          kind,
+          severity,
+          origin,
+          confidence,
+        }),
+      ),
+    ).toEqual([
+      {
+        kind: SIGNAL_KIND.WORK_UNACKNOWLEDGED,
+        severity: "warning",
+        origin: "source",
+        confidence: null,
+      },
+    ]);
+
+    expect(
+      await signalsFor("awaiting, assigned yesterday on an old row"),
+    ).toEqual([]);
+
+    const backfilled = await signalsFor(
+      "awaiting, backfilled without an assignment event",
+    );
+    expect(backfilled.map(({ kind }) => kind)).toEqual([
+      SIGNAL_KIND.WORK_UNACKNOWLEDGED,
+    ]);
+    expect(backfilled.at(0)?.evidence).toMatchObject({ daysWaiting: 10 });
+
+    const overdue = await signalsFor("active, hard deadline passed");
+    expect(
+      overdue.map(({ kind, severity, workspaceId }) => ({
+        kind,
+        severity,
+        workspaceId,
+      })),
+    ).toEqual([
+      {
+        kind: SIGNAL_KIND.WORK_DEADLINE_AT_RISK,
+        severity: "critical",
+        workspaceId: ids.wsA1,
+      },
+    ]);
+    expect(overdue.at(0)?.subject).toEqual({
+      type: "entity",
+      workspaceId: ids.wsA1,
+      entityId: entityIdOf("active, hard deadline passed"),
+    });
+
+    expect(await signalsFor("active, hard deadline a month out")).toEqual([]);
+    expect(await signalsFor("completed, hard deadline passed")).toEqual([]);
+
+    const runs = await testDb
+      .select({
+        status: scoutRuns.status,
+        insertedCount: scoutRuns.insertedCount,
+        emittedCount: scoutRuns.emittedCount,
+      })
+      .from(scoutRuns)
+      .where(
+        and(
+          eq(scoutRuns.scoutKey, SCOUT_KEY.WORK_ATTENTION),
+          eq(scoutRuns.organizationId, ids.orgA),
+        ),
+      );
+    expect(runs).toHaveLength(1);
+    expect(runs.at(0)?.status).toBe("succeeded");
+    expect(runs.at(0)?.insertedCount).toBe(3);
+    expect(runs.at(0)?.emittedCount).toBe(3);
+  });
+
+  test("a second sweep of the same state inserts nothing", async () => {
+    const before = await seededSignals();
+
+    const outcome = await runWorkAttentionScout({
+      cursor: null,
+      now: NOW,
+      dependencies: dependencies(),
+    });
+
+    expect(outcome.emitted).toBe(3);
+    expect(outcome.inserted).toBe(0);
+    expect(await seededSignals()).toHaveLength(before.length);
+  });
+
+  test("moving a hard deadline is a new observation", async () => {
+    const entityId = entityIdOf("active, hard deadline passed");
+    await testDb
+      .update(workObligations)
+      .set({ hardDeadlineDate: dateOffset(-2) })
+      .where(eq(workObligations.entityId, entityId));
+
+    await runWorkAttentionScout({
+      cursor: null,
+      now: NOW,
+      dependencies: dependencies(),
+    });
+
+    expect(
+      (await signalsFor("active, hard deadline passed")).map(
+        ({ dedupeKey }) => dedupeKey,
+      ),
+    ).toHaveLength(2);
+  });
+
+  test("an empty page closes the cycle instead of stalling the cursor", async () => {
+    const outcome = await runWorkAttentionScout({
+      cursor: brandPersistedEntityId("ffffffff-ffff-4fff-bfff-ffffffffffff"),
+      now: NOW,
+      dependencies: dependencies(),
+    });
+
+    expect(outcome).toMatchObject({
+      scanned: 0,
+      emitted: 0,
+      inserted: 0,
+      nextCursor: null,
+    });
+  });
+});

--- a/apps/api/src/lib/scouts/work-attention.integration.test.ts
+++ b/apps/api/src/lib/scouts/work-attention.integration.test.ts
@@ -51,8 +51,12 @@ let testDb: TestDatabase;
 let ids: TestIds;
 const seededEntityIds: SafeId<"entity">[] = [];
 
+/** Which fixture organization owns the row. */
+type Tenant = "A" | "B";
+
 type SeedWork = {
   label: string;
+  tenant: Tenant;
   status: WorkObligationStatus;
   hardDeadlineDate: string | null;
   /** Days before `NOW` the row itself was created. */
@@ -61,15 +65,22 @@ type SeedWork = {
   assignedDaysAgo: number | null;
 };
 
+const tenantScope = (tenant: Tenant) =>
+  tenant === "A"
+    ? { workspaceId: ids.wsA1, userId: ids.userA1 }
+    : { workspaceId: ids.wsB1, userId: ids.userB1 };
+
 /**
  * One row per decision the scout has to make: how long an assignment has gone
  * unanswered, whether the waiting clock comes from an event or from the row's
- * own creation, how close a hard deadline is, and whether closed work is out
- * of scope at all.
+ * own creation, how close a hard deadline is, whether closed work is out of
+ * scope at all, and whether a scanned organization warranting nothing is still
+ * recorded as scanned.
  */
 const SEED: SeedWork[] = [
   {
     label: "awaiting, assigned five days ago",
+    tenant: "A",
     status: WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
     hardDeadlineDate: null,
     createdDaysAgo: 30,
@@ -77,6 +88,7 @@ const SEED: SeedWork[] = [
   },
   {
     label: "awaiting, assigned yesterday on an old row",
+    tenant: "A",
     status: WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
     hardDeadlineDate: null,
     createdDaysAgo: 30,
@@ -84,6 +96,7 @@ const SEED: SeedWork[] = [
   },
   {
     label: "awaiting, backfilled without an assignment event",
+    tenant: "A",
     status: WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
     hardDeadlineDate: null,
     createdDaysAgo: 10,
@@ -91,6 +104,7 @@ const SEED: SeedWork[] = [
   },
   {
     label: "active, hard deadline passed",
+    tenant: "A",
     status: WORK_OBLIGATION_STATUS.ACTIVE,
     hardDeadlineDate: dateOffset(-1),
     createdDaysAgo: 20,
@@ -98,6 +112,7 @@ const SEED: SeedWork[] = [
   },
   {
     label: "active, hard deadline a month out",
+    tenant: "A",
     status: WORK_OBLIGATION_STATUS.ACTIVE,
     hardDeadlineDate: dateOffset(30),
     createdDaysAgo: 20,
@@ -105,10 +120,19 @@ const SEED: SeedWork[] = [
   },
   {
     label: "completed, hard deadline passed",
+    tenant: "A",
     status: WORK_OBLIGATION_STATUS.COMPLETED,
     hardDeadlineDate: dateOffset(-1),
     createdDaysAgo: 20,
     assignedDaysAgo: 20,
+  },
+  {
+    label: "second organization, assigned yesterday",
+    tenant: "B",
+    status: WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
+    hardDeadlineDate: null,
+    createdDaysAgo: 30,
+    assignedDaysAgo: 1,
   },
 ];
 
@@ -119,39 +143,40 @@ const entityIdOf = (label: string) =>
 
 const seedWork = async (work: SeedWork) => {
   const entityId = createSafeId<"entity">();
+  const { workspaceId, userId } = tenantScope(work.tenant);
   seededEntityIds.push(entityId);
   seeded.set(work.label, entityId);
   const acknowledged = work.status === WORK_OBLIGATION_STATUS.ACTIVE;
   await testDb.insert(entities).values({
     id: entityId,
-    workspaceId: ids.wsA1,
+    workspaceId,
     kind: "task",
     name: work.label,
     status: "open",
-    createdBy: ids.userA1,
+    createdBy: userId,
   });
   await testDb.insert(workObligations).values({
     entityId,
-    workspaceId: ids.wsA1,
-    ownerUserId: ids.userA1,
+    workspaceId,
+    ownerUserId: userId,
     status: work.status,
     acknowledgedAt: acknowledged ? instantOffset(-1) : null,
-    acknowledgedByUserId: acknowledged ? ids.userA1 : null,
+    acknowledgedByUserId: acknowledged ? userId : null,
     hardDeadlineDate: work.hardDeadlineDate,
-    createdByUserId: ids.userA1,
+    createdByUserId: userId,
     createdAt: instantOffset(-work.createdDaysAgo),
   });
   if (work.assignedDaysAgo !== null) {
     await testDb.insert(workObligationEvents).values({
       id: createSafeId<"workObligationEvent">(),
-      workspaceId: ids.wsA1,
+      workspaceId,
       obligationEntityId: entityId,
-      actorUserId: ids.userA1,
+      actorUserId: userId,
       type: WORK_OBLIGATION_EVENT_TYPE.OWNER_ASSIGNED,
       details: {
         type: "ownership_changed",
         previousOwnerUserId: null,
-        nextOwnerUserId: ids.userA1,
+        nextOwnerUserId: userId,
       },
       occurredAt: instantOffset(-work.assignedDaysAgo),
     });
@@ -165,6 +190,45 @@ const dependencies = (): WorkAttentionScoutDependencies => ({
       createScopedDb(testDb, workspaceIds, organizationId, userId),
     ),
 });
+
+/**
+ * The same dependencies, with one mutation interleaved before the first
+ * emitting transaction: the race the emit-time recheck exists to lose.
+ */
+const dependenciesMutatingBeforeEmit = (
+  mutate: () => Promise<void>,
+): WorkAttentionScoutDependencies => {
+  const base = dependencies();
+  let pending = true;
+  return {
+    db: base.db,
+    createScopedDb: (args) => {
+      const scoped = base.createScopedDb(args);
+      return async (fn) => {
+        if (pending) {
+          pending = false;
+          await mutate();
+        }
+        return await scoped(fn);
+      };
+    },
+  };
+};
+
+const scoutRunsFor = async (organizationId: SafeId<"organization">) =>
+  await testDb
+    .select({
+      status: scoutRuns.status,
+      insertedCount: scoutRuns.insertedCount,
+      emittedCount: scoutRuns.emittedCount,
+    })
+    .from(scoutRuns)
+    .where(
+      and(
+        eq(scoutRuns.scoutKey, SCOUT_KEY.WORK_ATTENTION),
+        eq(scoutRuns.organizationId, organizationId),
+      ),
+    );
 
 const seededSignals = async () =>
   await testDb
@@ -284,23 +348,20 @@ describe("work attention scout", () => {
     expect(await signalsFor("active, hard deadline a month out")).toEqual([]);
     expect(await signalsFor("completed, hard deadline passed")).toEqual([]);
 
-    const runs = await testDb
-      .select({
-        status: scoutRuns.status,
-        insertedCount: scoutRuns.insertedCount,
-        emittedCount: scoutRuns.emittedCount,
-      })
-      .from(scoutRuns)
-      .where(
-        and(
-          eq(scoutRuns.scoutKey, SCOUT_KEY.WORK_ATTENTION),
-          eq(scoutRuns.organizationId, ids.orgA),
-        ),
-      );
+    const runs = await scoutRunsFor(ids.orgA);
     expect(runs).toHaveLength(1);
     expect(runs.at(0)?.status).toBe("succeeded");
     expect(runs.at(0)?.insertedCount).toBe(3);
     expect(runs.at(0)?.emittedCount).toBe(3);
+  });
+
+  test("records the scan of an organization that warrants no signal", async () => {
+    expect(await signalsFor("second organization, assigned yesterday")).toEqual(
+      [],
+    );
+    expect(await scoutRunsFor(ids.orgB)).toEqual([
+      { status: "succeeded", insertedCount: 0, emittedCount: 0 },
+    ]);
   });
 
   test("a second sweep of the same state inserts nothing", async () => {
@@ -350,5 +411,38 @@ describe("work attention scout", () => {
       inserted: 0,
       nextCursor: null,
     });
+  });
+
+  test("drops a signal whose obligation was answered before the emit", async () => {
+    const label = "awaiting, acknowledged between the page and the emit";
+    await seedWork({
+      label,
+      tenant: "A",
+      status: WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
+      hardDeadlineDate: null,
+      createdDaysAgo: 30,
+      assignedDaysAgo: 5,
+    });
+    const entityId = entityIdOf(label);
+    const runsBefore = (await scoutRunsFor(ids.orgA)).length;
+
+    await runWorkAttentionScout({
+      cursor: null,
+      now: NOW,
+      dependencies: dependenciesMutatingBeforeEmit(async () => {
+        await testDb
+          .update(workObligations)
+          .set({
+            status: WORK_OBLIGATION_STATUS.ACTIVE,
+            acknowledgedAt: instantOffset(-1),
+            acknowledgedByUserId: ids.userA1,
+          })
+          .where(eq(workObligations.entityId, entityId));
+      }),
+    });
+
+    expect(await signalsFor(label)).toEqual([]);
+    // The sweep still ran: only the stale observation was dropped.
+    expect(await scoutRunsFor(ids.orgA)).toHaveLength(runsBefore + 1);
   });
 });

--- a/apps/api/src/lib/scouts/work-attention.logic.test.ts
+++ b/apps/api/src/lib/scouts/work-attention.logic.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from "bun:test";
+
+import { SIGNAL_KIND, SUGGESTION_KIND } from "@stll/api-contract/signals";
+import { WORK_OBLIGATION_STATUS } from "@stll/api-contract/workflow-status";
+
+import { createSafeId } from "@/api/lib/branded-types";
+import {
+  daysUntilDate,
+  daysWaitingSince,
+  deadlineAtRiskDedupeKey,
+  deadlineAtRiskSeverity,
+  unacknowledgedDedupeKey,
+  WORK_ATTENTION_ACKNOWLEDGEMENT_DAYS,
+  WORK_ATTENTION_DEADLINE_DAYS,
+  workAttentionSignals,
+} from "@/api/lib/scouts/work-attention.logic";
+import type { WorkAttentionObligation } from "@/api/lib/scouts/work-attention.logic";
+
+const NOW = new Date("2026-03-01T09:00:00.000Z");
+const ENTITY_ID = createSafeId<"entity">();
+const WORKSPACE_ID = createSafeId<"workspace">();
+const OWNER_ID = createSafeId<"user">();
+
+const daysBefore = (days: number): Date =>
+  new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000);
+
+const obligation = (
+  overrides: Partial<WorkAttentionObligation> = {},
+): WorkAttentionObligation => ({
+  entityId: ENTITY_ID,
+  workspaceId: WORKSPACE_ID,
+  name: "File the appeal",
+  status: WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
+  ownerUserId: OWNER_ID,
+  assignedAt: daysBefore(0),
+  workingTargetDate: null,
+  hardDeadlineDate: null,
+  ...overrides,
+});
+
+const kinds = (signals: readonly { kind: string }[]) =>
+  signals.map(({ kind }) => kind);
+
+describe("daysWaitingSince", () => {
+  test("counts whole days only, so a partial day never crosses the threshold", () => {
+    expect(daysWaitingSince(daysBefore(3), NOW)).toBe(3);
+    expect(
+      daysWaitingSince(new Date(daysBefore(3).getTime() + 60_000), NOW),
+    ).toBe(2);
+  });
+});
+
+describe("daysUntilDate", () => {
+  test("compares civil dates, not instants", () => {
+    // Late in the UTC day: an instant subtraction would report 0.02 days and
+    // round the next morning's deadline into today.
+    const lateInTheDay = new Date("2026-03-01T23:30:00.000Z");
+    expect(daysUntilDate("2026-03-02", lateInTheDay)).toBe(1);
+    expect(daysUntilDate("2026-03-01", lateInTheDay)).toBe(0);
+    expect(daysUntilDate("2026-02-28", lateInTheDay)).toBe(-1);
+  });
+
+  test("crosses a month boundary", () => {
+    expect(
+      daysUntilDate("2026-03-03", new Date("2026-02-28T09:00:00.000Z")),
+    ).toBe(3);
+  });
+});
+
+describe("deadlineAtRiskSeverity", () => {
+  test("today still warns; only a passed deadline is critical", () => {
+    expect(deadlineAtRiskSeverity(WORK_ATTENTION_DEADLINE_DAYS)).toBe(
+      "warning",
+    );
+    expect(deadlineAtRiskSeverity(0)).toBe("warning");
+    expect(deadlineAtRiskSeverity(-1)).toBe("critical");
+  });
+});
+
+describe("workAttentionSignals", () => {
+  test("an assignment answered within the window emits nothing", () => {
+    expect(
+      workAttentionSignals(
+        obligation({
+          assignedAt: daysBefore(WORK_ATTENTION_ACKNOWLEDGEMENT_DAYS - 1),
+        }),
+        NOW,
+      ),
+    ).toEqual([]);
+  });
+
+  test("the acknowledgement threshold is inclusive", () => {
+    const signals = workAttentionSignals(
+      obligation({
+        assignedAt: daysBefore(WORK_ATTENTION_ACKNOWLEDGEMENT_DAYS),
+      }),
+      NOW,
+    );
+
+    expect(kinds(signals)).toEqual([SIGNAL_KIND.WORK_UNACKNOWLEDGED]);
+    const [signal] = signals;
+    expect(signal?.severity).toBe("warning");
+    expect(signal?.confidence).toBeNull();
+    expect(signal?.workspaceId).toBe(WORKSPACE_ID);
+    expect(signal?.subject).toEqual({
+      type: "entity",
+      workspaceId: WORKSPACE_ID,
+      entityId: ENTITY_ID,
+    });
+    expect(signal?.suggestions).toEqual([{ kind: SUGGESTION_KIND.ASSIGN }]);
+    expect(signal?.evidence).toEqual({
+      kind: SIGNAL_KIND.WORK_UNACKNOWLEDGED,
+      obligationEntityId: ENTITY_ID,
+      ownerUserId: OWNER_ID,
+      assignedAt: daysBefore(WORK_ATTENTION_ACKNOWLEDGEMENT_DAYS).toISOString(),
+      daysWaiting: WORK_ATTENTION_ACKNOWLEDGEMENT_DAYS,
+      workingTargetDate: null,
+      hardDeadlineDate: null,
+    });
+  });
+
+  test("an acknowledged obligation is never unacknowledged, however old", () => {
+    expect(
+      workAttentionSignals(
+        obligation({
+          status: WORK_OBLIGATION_STATUS.ACTIVE,
+          assignedAt: daysBefore(90),
+        }),
+        NOW,
+      ),
+    ).toEqual([]);
+  });
+
+  test("a deadline outside the window is not at risk, the boundary one is", () => {
+    expect(
+      workAttentionSignals(
+        obligation({
+          status: WORK_OBLIGATION_STATUS.ACTIVE,
+          hardDeadlineDate: "2026-03-05",
+        }),
+        NOW,
+      ),
+    ).toEqual([]);
+
+    const signals = workAttentionSignals(
+      obligation({
+        status: WORK_OBLIGATION_STATUS.ACTIVE,
+        hardDeadlineDate: "2026-03-04",
+        workingTargetDate: "2026-03-02",
+      }),
+      NOW,
+    );
+    expect(kinds(signals)).toEqual([SIGNAL_KIND.WORK_DEADLINE_AT_RISK]);
+    expect(signals.at(0)?.severity).toBe("warning");
+    expect(signals.at(0)?.evidence).toEqual({
+      kind: SIGNAL_KIND.WORK_DEADLINE_AT_RISK,
+      obligationEntityId: ENTITY_ID,
+      ownerUserId: OWNER_ID,
+      hardDeadlineDate: "2026-03-04",
+      workingTargetDate: "2026-03-02",
+      daysUntilDeadline: WORK_ATTENTION_DEADLINE_DAYS,
+      obligationStatus: WORK_OBLIGATION_STATUS.ACTIVE,
+    });
+  });
+
+  test("a passed deadline is critical and reports negative days", () => {
+    const signals = workAttentionSignals(
+      obligation({
+        status: WORK_OBLIGATION_STATUS.ACTIVE,
+        hardDeadlineDate: "2026-02-25",
+      }),
+      NOW,
+    );
+
+    expect(signals.at(0)?.severity).toBe("critical");
+    expect(signals.at(0)?.evidence).toMatchObject({ daysUntilDeadline: -4 });
+  });
+
+  test("an unanswered assignment with a closing deadline raises both", () => {
+    const signals = workAttentionSignals(
+      obligation({
+        assignedAt: daysBefore(10),
+        hardDeadlineDate: "2026-03-01",
+      }),
+      NOW,
+    );
+
+    expect(kinds(signals)).toEqual([
+      SIGNAL_KIND.WORK_UNACKNOWLEDGED,
+      SIGNAL_KIND.WORK_DEADLINE_AT_RISK,
+    ]);
+  });
+});
+
+describe("dedupe keys", () => {
+  test("the same waiting state repeats, a reassignment does not", () => {
+    const assignedAt = daysBefore(5);
+    const later = new Date(NOW.getTime() + 60 * 60 * 1000);
+    const first = workAttentionSignals(obligation({ assignedAt }), NOW);
+    const second = workAttentionSignals(obligation({ assignedAt }), later);
+
+    expect(first.at(0)?.dedupeKey).toBe(second.at(0)?.dedupeKey ?? "");
+    expect(first.at(0)?.dedupeKey).toBe(
+      unacknowledgedDedupeKey(ENTITY_ID, assignedAt),
+    );
+    expect(unacknowledgedDedupeKey(ENTITY_ID, daysBefore(4))).not.toBe(
+      unacknowledgedDedupeKey(ENTITY_ID, assignedAt),
+    );
+  });
+
+  test("a moved hard deadline is a new observation", () => {
+    const atRisk = (hardDeadlineDate: string) =>
+      workAttentionSignals(
+        obligation({
+          status: WORK_OBLIGATION_STATUS.ACTIVE,
+          hardDeadlineDate,
+        }),
+        NOW,
+      ).at(0)?.dedupeKey;
+
+    expect(atRisk("2026-03-02")).toBe(
+      deadlineAtRiskDedupeKey(ENTITY_ID, "2026-03-02"),
+    );
+    expect(atRisk("2026-03-02")).not.toBe(atRisk("2026-03-03"));
+  });
+
+  test("the two kinds never share a key for one obligation", () => {
+    const signals = workAttentionSignals(
+      obligation({ assignedAt: daysBefore(5), hardDeadlineDate: "2026-03-02" }),
+      NOW,
+    );
+
+    expect(new Set(signals.map(({ dedupeKey }) => dedupeKey)).size).toBe(2);
+  });
+});

--- a/apps/api/src/lib/scouts/work-attention.logic.test.ts
+++ b/apps/api/src/lib/scouts/work-attention.logic.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { SIGNAL_KIND, SUGGESTION_KIND } from "@stll/api-contract/signals";
 import { WORK_OBLIGATION_STATUS } from "@stll/api-contract/workflow-status";
 
-import { createSafeId } from "@/api/lib/branded-types";
+import { createSafeId, toSafeId } from "@/api/lib/branded-types";
 import {
   daysUntilDate,
   daysWaitingSince,
@@ -19,7 +19,8 @@ import type { WorkAttentionObligation } from "@/api/lib/scouts/work-attention.lo
 const NOW = new Date("2026-03-01T09:00:00.000Z");
 const ENTITY_ID = createSafeId<"entity">();
 const WORKSPACE_ID = createSafeId<"workspace">();
-const OWNER_ID = createSafeId<"user">();
+// Auth-provider ids are never minted here; the fixture pins one instead.
+const OWNER_ID = toSafeId<"user">("0198fa3d-fc8d-7000-8000-000000000001");
 
 const daysBefore = (days: number): Date =>
   new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000);

--- a/apps/api/src/lib/scouts/work-attention.logic.ts
+++ b/apps/api/src/lib/scouts/work-attention.logic.ts
@@ -1,0 +1,197 @@
+import {
+  SCOUT_KEY,
+  SIGNAL_KIND,
+  SIGNAL_SEVERITY,
+  SUGGESTION_KIND,
+} from "@stll/api-contract/signals";
+import type {
+  OpenWorkObligationStatus,
+  SignalSeverity,
+} from "@stll/api-contract/signals";
+import { WORK_OBLIGATION_STATUS } from "@stll/api-contract/workflow-status";
+import { DAY_IN_MS } from "@stll/time";
+
+import type { SafeId } from "@/api/lib/branded-types";
+import type { NewSignal } from "@/api/lib/signals/emit";
+
+/** An owner who has not answered an assignment for this long is stuck. */
+export const WORK_ATTENTION_ACKNOWLEDGEMENT_DAYS = 3;
+/** A hard deadline this close, or already past, is at risk. */
+export const WORK_ATTENTION_DEADLINE_DAYS = 3;
+
+/** Titles are stored in a 512-char column; entity names are not bounded that low. */
+const WORK_ATTENTION_NAME_MAX_CHARS = 200;
+
+/**
+ * The slice of a governed obligation the scout reasons about.
+ *
+ * `assignedAt` is the occurrence of the latest `owner_assigned` or `delegated`
+ * event, not `updated_at`: any date, provenance or type edit moves
+ * `updated_at`, which would silently restart the acknowledgement clock on work
+ * nobody has answered for. Obligations created already-owned (the legacy
+ * backfill) carry no assignment event, so the caller falls back to `createdAt`,
+ * which is the same instant the owner was put on the row.
+ */
+export type WorkAttentionObligation = {
+  entityId: SafeId<"entity">;
+  workspaceId: SafeId<"workspace">;
+  name: string;
+  status: OpenWorkObligationStatus;
+  ownerUserId: SafeId<"user">;
+  assignedAt: Date;
+  workingTargetDate: string | null;
+  hardDeadlineDate: string | null;
+};
+
+/**
+ * Civil date of an instant on the server's UTC day. `hard_deadline_date` is a
+ * date with no time zone, and the My Work queues default their `asOf` to the
+ * same UTC day, so the scout and the queue agree about what is due.
+ */
+export const workAttentionToday = (now: Date): string =>
+  now.toISOString().slice(0, 10);
+
+const dateOnlyMs = (date: string): number =>
+  new Date(`${date}T00:00:00.000Z`).getTime();
+
+/** Whole days between two civil dates; negative once `date` is in the past. */
+export const daysUntilDate = (date: string, now: Date): number =>
+  (dateOnlyMs(date) - dateOnlyMs(workAttentionToday(now))) / DAY_IN_MS;
+
+/** Whole days an assignment has gone unanswered; partial days do not count. */
+export const daysWaitingSince = (assignedAt: Date, now: Date): number =>
+  Math.floor((now.getTime() - assignedAt.getTime()) / DAY_IN_MS);
+
+/** Past due is a missed obligation, not a warning about one. */
+export const deadlineAtRiskSeverity = (
+  daysUntilDeadline: number,
+): SignalSeverity =>
+  daysUntilDeadline < 0 ? SIGNAL_SEVERITY.CRITICAL : SIGNAL_SEVERITY.WARNING;
+
+/**
+ * One key per obligation and assignment. Holding the assignment instant keeps
+ * a still-unanswered obligation from re-emitting every hour, while a
+ * reassignment starts a new observation instead of being deduplicated into the
+ * previous owner's signal.
+ */
+export const unacknowledgedDedupeKey = (
+  entityId: SafeId<"entity">,
+  assignedAt: Date,
+): string =>
+  `work-attention:v1:unacknowledged:${entityId}:${assignedAt.toISOString()}`;
+
+/** One key per obligation and deadline, so a moved deadline is a new risk. */
+export const deadlineAtRiskDedupeKey = (
+  entityId: SafeId<"entity">,
+  hardDeadlineDate: string,
+): string => `work-attention:v1:deadline:${entityId}:${hardDeadlineDate}`;
+
+const capName = (name: string): string =>
+  name.length <= WORK_ATTENTION_NAME_MAX_CHARS
+    ? name
+    : `${name.slice(0, WORK_ATTENTION_NAME_MAX_CHARS)}…`;
+
+const unacknowledgedSignal = (
+  obligation: WorkAttentionObligation,
+  daysWaiting: number,
+): NewSignal => {
+  const name = capName(obligation.name);
+  return {
+    kind: SIGNAL_KIND.WORK_UNACKNOWLEDGED,
+    scoutKey: SCOUT_KEY.WORK_ATTENTION,
+    workspaceId: obligation.workspaceId,
+    severity: SIGNAL_SEVERITY.WARNING,
+    confidence: null,
+    title: `Unacknowledged for ${daysWaiting} days: ${name}`,
+    summary: `${name} has been awaiting acknowledgement since ${obligation.assignedAt.toISOString()}.`,
+    subject: {
+      type: "entity",
+      workspaceId: obligation.workspaceId,
+      entityId: obligation.entityId,
+    },
+    evidence: {
+      kind: SIGNAL_KIND.WORK_UNACKNOWLEDGED,
+      obligationEntityId: obligation.entityId,
+      ownerUserId: obligation.ownerUserId,
+      assignedAt: obligation.assignedAt.toISOString(),
+      daysWaiting,
+      workingTargetDate: obligation.workingTargetDate,
+      hardDeadlineDate: obligation.hardDeadlineDate,
+    },
+    // Routing the signal to whoever should chase the owner is the only
+    // suggestion that fits: the task and deadline this reports on already
+    // exist, so every creating suggestion would duplicate them.
+    suggestions: [{ kind: SUGGESTION_KIND.ASSIGN }],
+    dedupeKey: unacknowledgedDedupeKey(
+      obligation.entityId,
+      obligation.assignedAt,
+    ),
+  };
+};
+
+const deadlineAtRiskSignal = (
+  obligation: WorkAttentionObligation,
+  hardDeadlineDate: string,
+  daysUntilDeadline: number,
+): NewSignal => {
+  const name = capName(obligation.name);
+  const overdue = daysUntilDeadline < 0;
+  return {
+    kind: SIGNAL_KIND.WORK_DEADLINE_AT_RISK,
+    scoutKey: SCOUT_KEY.WORK_ATTENTION,
+    workspaceId: obligation.workspaceId,
+    severity: deadlineAtRiskSeverity(daysUntilDeadline),
+    confidence: null,
+    title: overdue
+      ? `Hard deadline passed: ${name}`
+      : `Hard deadline in ${daysUntilDeadline} days: ${name}`,
+    summary: `${name} has a hard deadline on ${hardDeadlineDate} and is still ${obligation.status}.`,
+    subject: {
+      type: "entity",
+      workspaceId: obligation.workspaceId,
+      entityId: obligation.entityId,
+    },
+    evidence: {
+      kind: SIGNAL_KIND.WORK_DEADLINE_AT_RISK,
+      obligationEntityId: obligation.entityId,
+      ownerUserId: obligation.ownerUserId,
+      hardDeadlineDate,
+      workingTargetDate: obligation.workingTargetDate,
+      daysUntilDeadline,
+      obligationStatus: obligation.status,
+    },
+    suggestions: [{ kind: SUGGESTION_KIND.ASSIGN }],
+    dedupeKey: deadlineAtRiskDedupeKey(obligation.entityId, hardDeadlineDate),
+  };
+};
+
+/**
+ * Every signal one open obligation warrants right now. The two kinds are
+ * independent: an unanswered assignment whose deadline is also closing emits
+ * both, because they need different answers from a supervisor.
+ */
+export const workAttentionSignals = (
+  obligation: WorkAttentionObligation,
+  now: Date,
+): NewSignal[] => {
+  const signals: NewSignal[] = [];
+  const daysWaiting = daysWaitingSince(obligation.assignedAt, now);
+  if (
+    obligation.status === WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT &&
+    daysWaiting >= WORK_ATTENTION_ACKNOWLEDGEMENT_DAYS
+  ) {
+    signals.push(unacknowledgedSignal(obligation, daysWaiting));
+  }
+
+  const { hardDeadlineDate } = obligation;
+  if (hardDeadlineDate !== null) {
+    const daysUntilDeadline = daysUntilDate(hardDeadlineDate, now);
+    if (daysUntilDeadline <= WORK_ATTENTION_DEADLINE_DAYS) {
+      signals.push(
+        deadlineAtRiskSignal(obligation, hardDeadlineDate, daysUntilDeadline),
+      );
+    }
+  }
+
+  return signals;
+};

--- a/apps/api/src/lib/scouts/work-attention.ts
+++ b/apps/api/src/lib/scouts/work-attention.ts
@@ -1,0 +1,358 @@
+import { panic } from "better-result";
+import { and, asc, eq, gt, inArray, lte, max, or } from "drizzle-orm";
+
+import { SCOUT_KEY } from "@stll/api-contract/signals";
+import type { OpenWorkObligationStatus } from "@stll/api-contract/signals";
+import { WORK_OBLIGATION_STATUS } from "@stll/api-contract/workflow-status";
+import type { WorkObligationStatus } from "@stll/api-contract/workflow-status";
+import { DAY_IN_MS } from "@stll/time";
+
+import { member as organizationMembers } from "@/api/db/auth-schema";
+import { rootDb } from "@/api/db/root";
+import {
+  entities,
+  WORK_OBLIGATION_EVENT_TYPE,
+  workObligationEvents,
+  workObligations,
+  workspaces,
+} from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+import { LIMITS } from "@/api/lib/limits";
+import { createRootScopedDb } from "@/api/lib/root-scoped-db";
+import {
+  brandPersistedOrganizationId,
+  brandPersistedUserId,
+} from "@/api/lib/safe-id-boundaries";
+import {
+  WORK_ATTENTION_DEADLINE_DAYS,
+  workAttentionSignals,
+  workAttentionToday,
+} from "@/api/lib/scouts/work-attention.logic";
+import type { WorkAttentionObligation } from "@/api/lib/scouts/work-attention.logic";
+import type { NewSignal } from "@/api/lib/signals/emit";
+import { runScout } from "@/api/lib/signals/scout";
+import { workObligationEligibleEntity } from "@/api/lib/work-obligations/eligibility";
+
+/** The statuses an obligation still owes somebody an answer in. */
+const OPEN_WORK_OBLIGATION_STATUSES = [
+  WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
+  WORK_OBLIGATION_STATUS.ACTIVE,
+] as const satisfies readonly OpenWorkObligationStatus[];
+
+/** The events that put the current owner on an obligation. */
+const ASSIGNMENT_EVENT_TYPES = [
+  WORK_OBLIGATION_EVENT_TYPE.OWNER_ASSIGNED,
+  WORK_OBLIGATION_EVENT_TYPE.DELEGATED,
+] as const;
+
+/** The two database handles the sweep needs, injectable for integration tests. */
+export type WorkAttentionScoutDependencies = {
+  db: typeof rootDb;
+  createScopedDb: typeof createRootScopedDb;
+};
+
+const DEFAULT_WORK_ATTENTION_SCOUT_DEPENDENCIES = {
+  db: rootDb,
+  createScopedDb: createRootScopedDb,
+} satisfies WorkAttentionScoutDependencies;
+
+export type RunWorkAttentionScoutArgs = {
+  /** Keyset position from the previous tick; `null` starts a fresh cycle. */
+  cursor: SafeId<"entity"> | null;
+  now?: Date;
+  dependencies?: WorkAttentionScoutDependencies;
+};
+
+export type RunWorkAttentionScoutResult = {
+  scanned: number;
+  emitted: number;
+  inserted: number;
+  organizations: number;
+  /** Organizations whose last member is gone, so no one could read a signal. */
+  organizationsWithoutMember: number;
+  /** `null` once the cycle is complete, so the next tick sweeps from the start. */
+  nextCursor: SafeId<"entity"> | null;
+};
+
+type ObligationRow = {
+  entityId: SafeId<"entity">;
+  workspaceId: SafeId<"workspace">;
+  organizationId: SafeId<"organization">;
+  status: WorkObligationStatus;
+  ownerUserId: string | null;
+  name: string;
+  workingTargetDate: string | null;
+  hardDeadlineDate: string | null;
+  createdAt: Date;
+};
+
+const openStatus = (status: WorkObligationStatus): OpenWorkObligationStatus => {
+  switch (status) {
+    case WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT:
+    case WORK_OBLIGATION_STATUS.ACTIVE:
+      return status;
+    case WORK_OBLIGATION_STATUS.UNASSIGNED:
+    case WORK_OBLIGATION_STATUS.COMPLETED:
+    case WORK_OBLIGATION_STATUS.CANCELLED:
+      return panic(`work.attention page returned a ${status} obligation`);
+    default: {
+      const exhaustive: never = status;
+      return exhaustive;
+    }
+  }
+};
+
+/**
+ * One bounded keyset page of open obligations that could warrant attention.
+ * The predicate is the scout's cheap half: an unanswered assignment always
+ * qualifies for inspection, an acknowledged one only once its hard deadline is
+ * inside the risk window.
+ */
+const loadObligationPage = async (
+  db: typeof rootDb,
+  cursor: SafeId<"entity"> | null,
+  now: Date,
+): Promise<ObligationRow[]> => {
+  const riskCutoff = new Date(
+    now.getTime() + WORK_ATTENTION_DEADLINE_DAYS * DAY_IN_MS,
+  );
+  return await db
+    .select({
+      entityId: workObligations.entityId,
+      workspaceId: workObligations.workspaceId,
+      organizationId: workspaces.organizationId,
+      status: workObligations.status,
+      ownerUserId: workObligations.ownerUserId,
+      name: entities.name,
+      workingTargetDate: workObligations.workingTargetDate,
+      hardDeadlineDate: workObligations.hardDeadlineDate,
+      createdAt: workObligations.createdAt,
+    })
+    .from(workObligations)
+    .innerJoin(
+      entities,
+      and(
+        eq(entities.id, workObligations.entityId),
+        eq(entities.workspaceId, workObligations.workspaceId),
+        eq(entities.kind, "task"),
+        workObligationEligibleEntity,
+      ),
+    )
+    .innerJoin(workspaces, eq(workspaces.id, workObligations.workspaceId))
+    .where(
+      and(
+        inArray(workObligations.status, [...OPEN_WORK_OBLIGATION_STATUSES]),
+        or(
+          eq(
+            workObligations.status,
+            WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
+          ),
+          lte(workObligations.hardDeadlineDate, workAttentionToday(riskCutoff)),
+        ),
+        cursor === null ? undefined : gt(workObligations.entityId, cursor),
+      ),
+    )
+    .orderBy(asc(workObligations.entityId))
+    .limit(LIMITS.workAttentionObligationsPage);
+};
+
+/**
+ * Latest assignment instant per unanswered obligation, in one query for the
+ * page. A row with no assignment event was created already-owned, so its own
+ * creation is when the owner was put on it.
+ */
+const loadAssignedAt = async (
+  db: typeof rootDb,
+  rows: readonly ObligationRow[],
+): Promise<Map<SafeId<"entity">, Date>> => {
+  const awaiting = rows.filter(
+    ({ status }) => status === WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
+  );
+  if (awaiting.length === 0) {
+    return new Map();
+  }
+  const assignments = await db
+    .select({
+      obligationEntityId: workObligationEvents.obligationEntityId,
+      assignedAt: max(workObligationEvents.occurredAt),
+    })
+    .from(workObligationEvents)
+    .where(
+      and(
+        inArray(
+          workObligationEvents.obligationEntityId,
+          awaiting.map(({ entityId }) => entityId),
+        ),
+        inArray(
+          workObligationEvents.workspaceId,
+          awaiting.map((row) => row.workspaceId),
+        ),
+        inArray(workObligationEvents.type, [...ASSIGNMENT_EVENT_TYPES]),
+      ),
+    )
+    .groupBy(workObligationEvents.obligationEntityId);
+
+  return new Map(
+    assignments.flatMap(({ obligationEntityId, assignedAt }) =>
+      assignedAt === null ? [] : [[obligationEntityId, assignedAt] as const],
+    ),
+  );
+};
+
+/**
+ * One organization member per organization, as the RLS session identity the
+ * emitting transaction runs under. The scout has no human actor: signal
+ * visibility is decided by the organization and the workspace the row carries,
+ * never by this identity, and the emitted rows are left unassigned and without
+ * a creator so no member is shown as having raised them.
+ */
+const loadScoutActors = async (
+  db: typeof rootDb,
+  organizationIds: readonly SafeId<"organization">[],
+): Promise<Map<SafeId<"organization">, SafeId<"user">>> => {
+  if (organizationIds.length === 0) {
+    return new Map();
+  }
+  const actors = await db
+    .selectDistinctOn([organizationMembers.organizationId], {
+      organizationId: organizationMembers.organizationId,
+      userId: organizationMembers.userId,
+    })
+    .from(organizationMembers)
+    .where(inArray(organizationMembers.organizationId, [...organizationIds]))
+    .orderBy(
+      asc(organizationMembers.organizationId),
+      asc(organizationMembers.createdAt),
+      asc(organizationMembers.id),
+    )
+    .limit(organizationIds.length);
+  return new Map(
+    actors.map((actor) => [
+      brandPersistedOrganizationId(actor.organizationId),
+      brandPersistedUserId(actor.userId),
+    ]),
+  );
+};
+
+const toObligation = (
+  row: ObligationRow,
+  assignedAt: Map<SafeId<"entity">, Date>,
+): WorkAttentionObligation => ({
+  entityId: row.entityId,
+  workspaceId: row.workspaceId,
+  name: row.name,
+  status: openStatus(row.status),
+  ownerUserId: brandPersistedUserId(
+    row.ownerUserId ??
+      panic(`work.attention obligation ${row.entityId} has no owner`),
+  ),
+  assignedAt: assignedAt.get(row.entityId) ?? row.createdAt,
+  workingTargetDate: row.workingTargetDate,
+  hardDeadlineDate: row.hardDeadlineDate,
+});
+
+type OrganizationBatch = {
+  organizationId: SafeId<"organization">;
+  workspaceIds: SafeId<"workspace">[];
+  signals: NewSignal[];
+};
+
+const groupByOrganization = (
+  rows: readonly ObligationRow[],
+  assignedAt: Map<SafeId<"entity">, Date>,
+  now: Date,
+): OrganizationBatch[] => {
+  const batches = new Map<SafeId<"organization">, OrganizationBatch>();
+  for (const row of rows) {
+    const signals = workAttentionSignals(toObligation(row, assignedAt), now);
+    if (signals.length === 0) {
+      continue;
+    }
+    const batch = batches.get(row.organizationId);
+    if (batch) {
+      batch.signals.push(...signals);
+      if (!batch.workspaceIds.includes(row.workspaceId)) {
+        batch.workspaceIds.push(row.workspaceId);
+      }
+      continue;
+    }
+    batches.set(row.organizationId, {
+      organizationId: row.organizationId,
+      workspaceIds: [row.workspaceId],
+      signals,
+    });
+  }
+  return [...batches.values()];
+};
+
+/**
+ * Observe one bounded page of governed work and emit the attention signals it
+ * warrants, one `scout_runs` row per organization the page touched.
+ *
+ * Nothing here resolves a signal whose condition has cleared: the signals model
+ * only transitions rows through an authenticated member's accept, dismiss or
+ * snooze, so an acknowledged obligation's signal stays in the Inbox until
+ * somebody answers it.
+ */
+export const runWorkAttentionScout = async ({
+  cursor,
+  now = new Date(),
+  dependencies = DEFAULT_WORK_ATTENTION_SCOUT_DEPENDENCIES,
+}: RunWorkAttentionScoutArgs): Promise<RunWorkAttentionScoutResult> => {
+  const { db, createScopedDb } = dependencies;
+  const rows = await loadObligationPage(db, cursor, now);
+  const lastRow = rows.at(-1);
+  if (!lastRow) {
+    return {
+      scanned: 0,
+      emitted: 0,
+      inserted: 0,
+      organizations: 0,
+      organizationsWithoutMember: 0,
+      nextCursor: null,
+    };
+  }
+
+  const assignedAt = await loadAssignedAt(db, rows);
+  const batches = groupByOrganization(rows, assignedAt, now);
+  const actors = await loadScoutActors(
+    db,
+    batches.map((batch) => batch.organizationId),
+  );
+
+  let emitted = 0;
+  let inserted = 0;
+  let organizations = 0;
+  let organizationsWithoutMember = 0;
+  for (const batch of batches) {
+    const userId = actors.get(batch.organizationId);
+    if (!userId) {
+      organizationsWithoutMember += 1;
+      continue;
+    }
+    const scopedDb = createScopedDb({
+      organizationId: batch.organizationId,
+      userId,
+      workspaceIds: batch.workspaceIds,
+    });
+    // oxlint-disable-next-line no-await-in-loop -- one short emitting transaction per organization, sequential to stay inside the root pool
+    const result = await runScout({
+      db: scopedDb,
+      organizationId: batch.organizationId,
+      scoutKey: SCOUT_KEY.WORK_ATTENTION,
+      observe: () => batch.signals,
+    });
+    emitted += result.emittedCount;
+    inserted += result.insertedIds.length;
+    organizations += 1;
+  }
+
+  return {
+    scanned: rows.length,
+    emitted,
+    inserted,
+    organizations,
+    organizationsWithoutMember,
+    nextCursor: lastRow.entityId,
+  };
+};

--- a/apps/api/src/lib/scouts/work-attention.ts
+++ b/apps/api/src/lib/scouts/work-attention.ts
@@ -9,6 +9,7 @@ import { DAY_IN_MS } from "@stll/time";
 
 import { member as organizationMembers } from "@/api/db/auth-schema";
 import { rootDb } from "@/api/db/root";
+import type { Transaction } from "@/api/db/root";
 import {
   entities,
   WORK_OBLIGATION_EVENT_TYPE,
@@ -74,10 +75,9 @@ export type RunWorkAttentionScoutResult = {
   nextCursor: SafeId<"entity"> | null;
 };
 
-type ObligationRow = {
+type ObligationFacts = {
   entityId: SafeId<"entity">;
   workspaceId: SafeId<"workspace">;
-  organizationId: SafeId<"organization">;
   status: WorkObligationStatus;
   ownerUserId: string | null;
   name: string;
@@ -85,6 +85,37 @@ type ObligationRow = {
   hardDeadlineDate: string | null;
   createdAt: Date;
 };
+
+type ObligationRow = ObligationFacts & {
+  organizationId: SafeId<"organization">;
+};
+
+/**
+ * Either handle the scout reads obligations through: the root pool for the
+ * sweep page, the emitting transaction for the recheck immediately before
+ * insertion.
+ */
+type ObligationReader = Pick<Transaction, "select">;
+
+/** The facts both reads project, so the recheck cannot drift from the page. */
+const obligationFactsColumns = {
+  entityId: workObligations.entityId,
+  workspaceId: workObligations.workspaceId,
+  status: workObligations.status,
+  ownerUserId: workObligations.ownerUserId,
+  name: entities.name,
+  workingTargetDate: workObligations.workingTargetDate,
+  hardDeadlineDate: workObligations.hardDeadlineDate,
+  createdAt: workObligations.createdAt,
+} as const;
+
+/** The entity both reads join through, so the recheck cannot drift either. */
+const obligationEntityJoin = and(
+  eq(entities.id, workObligations.entityId),
+  eq(entities.workspaceId, workObligations.workspaceId),
+  eq(entities.kind, "task"),
+  workObligationEligibleEntity,
+);
 
 const openStatus = (status: WorkObligationStatus): OpenWorkObligationStatus => {
   switch (status) {
@@ -109,7 +140,7 @@ const openStatus = (status: WorkObligationStatus): OpenWorkObligationStatus => {
  * inside the risk window.
  */
 const loadObligationPage = async (
-  db: typeof rootDb,
+  db: ObligationReader,
   cursor: SafeId<"entity"> | null,
   now: Date,
 ): Promise<ObligationRow[]> => {
@@ -118,26 +149,11 @@ const loadObligationPage = async (
   );
   return await db
     .select({
-      entityId: workObligations.entityId,
-      workspaceId: workObligations.workspaceId,
+      ...obligationFactsColumns,
       organizationId: workspaces.organizationId,
-      status: workObligations.status,
-      ownerUserId: workObligations.ownerUserId,
-      name: entities.name,
-      workingTargetDate: workObligations.workingTargetDate,
-      hardDeadlineDate: workObligations.hardDeadlineDate,
-      createdAt: workObligations.createdAt,
     })
     .from(workObligations)
-    .innerJoin(
-      entities,
-      and(
-        eq(entities.id, workObligations.entityId),
-        eq(entities.workspaceId, workObligations.workspaceId),
-        eq(entities.kind, "task"),
-        workObligationEligibleEntity,
-      ),
-    )
+    .innerJoin(entities, obligationEntityJoin)
     .innerJoin(workspaces, eq(workspaces.id, workObligations.workspaceId))
     .where(
       and(
@@ -162,8 +178,8 @@ const loadObligationPage = async (
  * creation is when the owner was put on it.
  */
 const loadAssignedAt = async (
-  db: typeof rootDb,
-  rows: readonly ObligationRow[],
+  db: ObligationReader,
+  rows: readonly ObligationFacts[],
 ): Promise<Map<SafeId<"entity">, Date>> => {
   const awaiting = rows.filter(
     ({ status }) => status === WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT,
@@ -235,7 +251,7 @@ const loadScoutActors = async (
 };
 
 const toObligation = (
-  row: ObligationRow,
+  row: ObligationFacts,
   assignedAt: Map<SafeId<"entity">, Date>,
 ): WorkAttentionObligation => ({
   entityId: row.entityId,
@@ -254,9 +270,16 @@ const toObligation = (
 type OrganizationBatch = {
   organizationId: SafeId<"organization">;
   workspaceIds: SafeId<"workspace">[];
+  /** Every scanned obligation, so the recheck reads exactly what was scanned. */
+  obligationEntityIds: SafeId<"entity">[];
   signals: NewSignal[];
 };
 
+/**
+ * One batch per organization the page touched, including the organizations
+ * whose scanned obligations warrant nothing: the census records that they were
+ * scanned, which is what keeps "ran, found nothing" apart from "never ran".
+ */
 const groupByOrganization = (
   rows: readonly ObligationRow[],
   assignedAt: Map<SafeId<"entity">, Date>,
@@ -265,29 +288,63 @@ const groupByOrganization = (
   const batches = new Map<SafeId<"organization">, OrganizationBatch>();
   for (const row of rows) {
     const signals = workAttentionSignals(toObligation(row, assignedAt), now);
-    if (signals.length === 0) {
-      continue;
-    }
     const batch = batches.get(row.organizationId);
-    if (batch) {
-      batch.signals.push(...signals);
-      if (!batch.workspaceIds.includes(row.workspaceId)) {
-        batch.workspaceIds.push(row.workspaceId);
-      }
+    if (!batch) {
+      batches.set(row.organizationId, {
+        organizationId: row.organizationId,
+        workspaceIds: [row.workspaceId],
+        obligationEntityIds: [row.entityId],
+        signals,
+      });
       continue;
     }
-    batches.set(row.organizationId, {
-      organizationId: row.organizationId,
-      workspaceIds: [row.workspaceId],
-      signals,
-    });
+    batch.signals.push(...signals);
+    batch.obligationEntityIds.push(row.entityId);
+    if (!batch.workspaceIds.includes(row.workspaceId)) {
+      batch.workspaceIds.push(row.workspaceId);
+    }
   }
   return [...batches.values()];
 };
 
 /**
+ * The dedupe keys the batch's obligations still warrant, recomputed from rows
+ * re-read inside the emitting transaction. The page was read from the root
+ * handle and several organizations may have been emitted since: an obligation
+ * acknowledged, completed, reassigned or re-dated in that window must not
+ * raise a warning, because nothing resolves a stored signal once its condition
+ * clears. Bounded by the page, and read through the same projection and join
+ * as the page so the two cannot disagree about what qualifies.
+ */
+const stillWarrantedKeys = async (
+  tx: Transaction,
+  batch: OrganizationBatch,
+  now: Date,
+): Promise<Set<string>> => {
+  const rows = await tx
+    .select(obligationFactsColumns)
+    .from(workObligations)
+    .innerJoin(entities, obligationEntityJoin)
+    .where(
+      and(
+        inArray(workObligations.entityId, batch.obligationEntityIds),
+        inArray(workObligations.status, [...OPEN_WORK_OBLIGATION_STATUSES]),
+      ),
+    );
+  const assignedAt = await loadAssignedAt(tx, rows);
+  return new Set(
+    rows.flatMap((row) =>
+      workAttentionSignals(toObligation(row, assignedAt), now).map(
+        ({ dedupeKey }) => dedupeKey,
+      ),
+    ),
+  );
+};
+
+/**
  * Observe one bounded page of governed work and emit the attention signals it
- * warrants, one `scout_runs` row per organization the page touched.
+ * warrants, one `scout_runs` row per organization the page touched, including
+ * the organizations the page found nothing to warn about.
  *
  * Nothing here resolves a signal whose condition has cleared: the signals model
  * only transitions rows through an authenticated member's accept, dismiss or
@@ -341,6 +398,10 @@ export const runWorkAttentionScout = async ({
       organizationId: batch.organizationId,
       scoutKey: SCOUT_KEY.WORK_ATTENTION,
       observe: () => batch.signals,
+      screen: async (tx, proposed) => {
+        const warranted = await stillWarrantedKeys(tx, batch, now);
+        return proposed.filter(({ dedupeKey }) => warranted.has(dedupeKey));
+      },
     });
     emitted += result.emittedCount;
     inserted += result.insertedIds.length;

--- a/apps/api/src/lib/signals/scout.ts
+++ b/apps/api/src/lib/signals/scout.ts
@@ -20,6 +20,13 @@ export type RunScoutArgs = {
   observe: () => NewSignal[] | Promise<NewSignal[]>;
   /** Revalidate mutable source ownership immediately before emission. */
   validate?: (tx: Transaction) => Promise<boolean>;
+  /**
+   * Drop the individual signals whose source stopped qualifying between the
+   * observation and this transaction. `validate` accepts or rejects a whole
+   * observation of one source; this keeps the still-warranted signals of an
+   * observation that spans many independent ones.
+   */
+  screen?: (tx: Transaction, proposed: NewSignal[]) => Promise<NewSignal[]>;
 };
 
 export type RunScoutResult = EmitSignalsResult & {
@@ -39,6 +46,7 @@ export const runScout = async ({
   scoutKey,
   observe,
   validate,
+  screen,
 }: RunScoutArgs): Promise<RunScoutResult> => {
   const runId = createSafeId<"scoutRun">();
   await db((tx) =>
@@ -56,10 +64,14 @@ export const runScout = async ({
     const proposed = await observe();
     result = await db(async (tx) => {
       observationAccepted = validate ? await validate(tx) : true;
+      let admitted = observationAccepted ? proposed : [];
+      if (screen && admitted.length > 0) {
+        admitted = await screen(tx, admitted);
+      }
       const emitted = await emitSignals({
         tx,
         organizationId,
-        signals: observationAccepted ? proposed : [],
+        signals: admitted,
       });
       await tx
         .update(scoutRuns)

--- a/apps/web/src/features/inbox/components/signal-inspector-view.tsx
+++ b/apps/web/src/features/inbox/components/signal-inspector-view.tsx
@@ -298,8 +298,8 @@ const EvidenceBody = ({ evidence, signal }: EvidenceBodyProps) => {
           <Row label={t("tasks.assigned")}>
             {formatDateTime(evidence.assignedAt)}
           </Row>
-          <Row label={t("inbox.evidence.daysUnanswered")}>
-            {evidence.daysWaiting}
+          <Row label={t("inbox.evidence.daysUnacknowledged")}>
+            {format.number(evidence.daysWaiting)}
           </Row>
           {evidence.workingTargetDate !== null && (
             <Row label={t("tasks.workingTarget")}>
@@ -326,7 +326,7 @@ const EvidenceBody = ({ evidence, signal }: EvidenceBodyProps) => {
                 : "inbox.evidence.daysUntilDeadline",
             )}
           >
-            {Math.abs(evidence.daysUntilDeadline)}
+            {format.number(Math.abs(evidence.daysUntilDeadline))}
           </Row>
           {evidence.workingTargetDate !== null && (
             <Row label={t("tasks.workingTarget")}>

--- a/apps/web/src/features/inbox/components/signal-inspector-view.tsx
+++ b/apps/web/src/features/inbox/components/signal-inspector-view.tsx
@@ -17,6 +17,7 @@ import type { InspectorViewRenderProps } from "@/components/inspector/view-regis
 import { MatterRefLink } from "@/components/matter-ref-link";
 import type { InboxSignalViewPayload } from "@/features/inbox/signal-inspector.logic";
 import {
+  OPEN_WORK_STATUS_LABEL_KEY,
   ORIGIN_LABEL_KEY,
   scoutLabelKey,
   SEVERITY_DOT_CLASS,
@@ -148,6 +149,13 @@ const EvidenceBody = ({ evidence, signal }: EvidenceBodyProps) => {
   const format = useFormatter();
   const formatDateTime = (iso: string) =>
     format.dateTime(new Date(iso), MEDIUM_DATE_SHORT_TIME_FORMAT);
+  // A civil date carries no time zone; pinning the format to UTC keeps it on
+  // the day the server recorded instead of shifting west of Greenwich.
+  const formatDate = (date: string) =>
+    format.dateTime(new Date(`${date}T00:00:00Z`), {
+      dateStyle: "long",
+      timeZone: "UTC",
+    });
 
   switch (evidence.kind) {
     case SIGNAL_KIND.REQUEST_SUBMITTED:
@@ -281,6 +289,52 @@ const EvidenceBody = ({ evidence, signal }: EvidenceBodyProps) => {
                 ))}
               </ul>
             )}
+          </Row>
+        </dl>
+      );
+    case SIGNAL_KIND.WORK_UNACKNOWLEDGED:
+      return (
+        <dl className="flex flex-col gap-2 text-sm">
+          <Row label={t("tasks.assigned")}>
+            {formatDateTime(evidence.assignedAt)}
+          </Row>
+          <Row label={t("inbox.evidence.daysUnanswered")}>
+            {evidence.daysWaiting}
+          </Row>
+          {evidence.workingTargetDate !== null && (
+            <Row label={t("tasks.workingTarget")}>
+              {formatDate(evidence.workingTargetDate)}
+            </Row>
+          )}
+          {evidence.hardDeadlineDate !== null && (
+            <Row label={t("tasks.hardDeadline")}>
+              {formatDate(evidence.hardDeadlineDate)}
+            </Row>
+          )}
+        </dl>
+      );
+    case SIGNAL_KIND.WORK_DEADLINE_AT_RISK:
+      return (
+        <dl className="flex flex-col gap-2 text-sm">
+          <Row label={t("tasks.hardDeadline")}>
+            {formatDate(evidence.hardDeadlineDate)}
+          </Row>
+          <Row
+            label={t(
+              evidence.daysUntilDeadline < 0
+                ? "inbox.evidence.daysOverdue"
+                : "inbox.evidence.daysUntilDeadline",
+            )}
+          >
+            {Math.abs(evidence.daysUntilDeadline)}
+          </Row>
+          {evidence.workingTargetDate !== null && (
+            <Row label={t("tasks.workingTarget")}>
+              {formatDate(evidence.workingTargetDate)}
+            </Row>
+          )}
+          <Row label={t("tasks.status")}>
+            {t(OPEN_WORK_STATUS_LABEL_KEY[evidence.obligationStatus])}
           </Row>
         </dl>
       );

--- a/apps/web/src/features/inbox/signal-presentation.ts
+++ b/apps/web/src/features/inbox/signal-presentation.ts
@@ -5,11 +5,13 @@ import {
   SUGGESTION_KIND,
 } from "@stll/api-contract/signals";
 import type {
+  OpenWorkObligationStatus,
   SignalOrigin,
   SignalSeverity,
   ScoutKey,
   SuggestionKind,
 } from "@stll/api-contract/signals";
+import { WORK_OBLIGATION_STATUS } from "@stll/api-contract/workflow-status";
 
 import type { TranslationKey } from "@/i18n/types";
 
@@ -51,7 +53,15 @@ const SCOUT_LABEL_KEY = {
   [SCOUT_KEY.INFOSOUD_HEARINGS]: "workspaces.infosoud.title",
   [SCOUT_KEY.DOCUMENT_DEADLINES]: "inbox.scout.documentDeadlines",
   [SCOUT_KEY.DOCUMENT_REVIEW]: "inbox.scout.documentReview",
+  [SCOUT_KEY.WORK_ATTENTION]: "inbox.scout.workAttention",
 } as const satisfies Readonly<Record<ScoutKey, TranslationKey>>;
+
+/** The statuses work-attention evidence can report; closed work emits none. */
+export const OPEN_WORK_STATUS_LABEL_KEY = {
+  [WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT]:
+    "tasks.queue.toAcknowledge",
+  [WORK_OBLIGATION_STATUS.ACTIVE]: "common.active",
+} as const satisfies Record<OpenWorkObligationStatus, TranslationKey>;
 
 type KnownScoutKey = keyof typeof SCOUT_LABEL_KEY;
 type ScoutLabelKey = (typeof SCOUT_LABEL_KEY)[KnownScoutKey];

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -2157,6 +2157,9 @@
     "empty": "لا شيء بانتظارك الآن. أنشئ طلباً بالزر أعلاه.",
     "evidence": {
       "current": "الآن",
+      "daysOverdue": "أيام التأخير",
+      "daysUnanswered": "أيام بلا تأكيد",
+      "daysUntilDeadline": "أيام حتى الموعد النهائي",
       "dueAt": "الاستحقاق",
       "findings": "النتائج",
       "hearingType": "نوع الجلسة",
@@ -2185,7 +2188,8 @@
     "scout": {
       "documentDeadlines": "مواعيد من المستند",
       "documentReview": "مراجعة وفق الدليل",
-      "manualRequest": "طلب"
+      "manualRequest": "طلب",
+      "workAttention": "متابعة العمل"
     },
     "severity": {
       "info": "معلومة",
@@ -3714,6 +3718,7 @@
     },
     "addAssignee": "إضافة مُكلَّف",
     "addSubtask": "إضافة مهمة فرعية",
+    "assigned": "تم التعيين",
     "assigneeRoles": {
       "assignee": "المُكلَّف",
       "reviewer": "المراجِع"
@@ -3776,6 +3781,7 @@
       "deadline": "موعد نهائي",
       "task": "مهمة"
     },
+    "workingTarget": "الموعد المستهدف",
     "workingTargetDue": "حلّ الموعد المستهدف"
   },
   "templates": {

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -2158,7 +2158,7 @@
     "evidence": {
       "current": "الآن",
       "daysOverdue": "أيام التأخير",
-      "daysUnanswered": "أيام بلا تأكيد",
+      "daysUnacknowledged": "أيام بلا تأكيد",
       "daysUntilDeadline": "أيام حتى الموعد النهائي",
       "dueAt": "الاستحقاق",
       "findings": "النتائج",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2157,6 +2157,9 @@
     "empty": "Teď vás nic nečeká. Založte požadavek tlačítkem výše.",
     "evidence": {
       "current": "Nově",
+      "daysOverdue": "Dnů po termínu",
+      "daysUnanswered": "Dnů bez potvrzení",
+      "daysUntilDeadline": "Dnů do lhůty",
       "dueAt": "Lhůta",
       "findings": "Zjištění",
       "hearingType": "Druh jednání",
@@ -2185,7 +2188,8 @@
     "scout": {
       "documentDeadlines": "Lhůty z dokumentu",
       "documentReview": "Kontrola podle playbooku",
-      "manualRequest": "Požadavek"
+      "manualRequest": "Požadavek",
+      "workAttention": "Sledování práce"
     },
     "severity": {
       "info": "Informace",
@@ -3714,6 +3718,7 @@
     },
     "addAssignee": "Přidat osobu",
     "addSubtask": "Přidat podúkol",
+    "assigned": "Přiřazeno",
     "assigneeRoles": {
       "assignee": "Řešitel",
       "reviewer": "Revident"
@@ -3776,6 +3781,7 @@
       "deadline": "Lhůta",
       "task": "Úkol"
     },
+    "workingTarget": "Pracovní termín",
     "workingTargetDue": "Pracovní termín vypršel"
   },
   "templates": {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2158,7 +2158,7 @@
     "evidence": {
       "current": "Nově",
       "daysOverdue": "Dnů po termínu",
-      "daysUnanswered": "Dnů bez potvrzení",
+      "daysUnacknowledged": "Dnů bez potvrzení",
       "daysUntilDeadline": "Dnů do lhůty",
       "dueAt": "Lhůta",
       "findings": "Zjištění",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2157,6 +2157,9 @@
     "empty": "Nichts wartet auf Sie. Erstellen Sie oben eine Anfrage.",
     "evidence": {
       "current": "Jetzt",
+      "daysOverdue": "Tage überfällig",
+      "daysUnanswered": "Tage ohne Bestätigung",
+      "daysUntilDeadline": "Tage bis zur Frist",
       "dueAt": "Fällig",
       "findings": "Feststellungen",
       "hearingType": "Art des Termins",
@@ -2185,7 +2188,8 @@
     "scout": {
       "documentDeadlines": "Fristen aus Dokument",
       "documentReview": "Playbook-Prüfung",
-      "manualRequest": "Anfrage"
+      "manualRequest": "Anfrage",
+      "workAttention": "Arbeitsüberwachung"
     },
     "severity": {
       "info": "Information",
@@ -3714,6 +3718,7 @@
     },
     "addAssignee": "Person zuweisen",
     "addSubtask": "Unteraufgabe hinzufügen",
+    "assigned": "Zugewiesen",
     "assigneeRoles": {
       "assignee": "Bearbeiter",
       "reviewer": "Prüfer"
@@ -3776,6 +3781,7 @@
       "deadline": "Frist",
       "task": "Aufgabe"
     },
+    "workingTarget": "Arbeitsziel",
     "workingTargetDue": "Arbeitsziel fällig"
   },
   "templates": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2158,7 +2158,7 @@
     "evidence": {
       "current": "Jetzt",
       "daysOverdue": "Tage überfällig",
-      "daysUnanswered": "Tage ohne Bestätigung",
+      "daysUnacknowledged": "Tage ohne Bestätigung",
       "daysUntilDeadline": "Tage bis zur Frist",
       "dueAt": "Fällig",
       "findings": "Feststellungen",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2158,7 +2158,7 @@
     "evidence": {
       "current": "Now",
       "daysOverdue": "Days overdue",
-      "daysUnanswered": "Days unanswered",
+      "daysUnacknowledged": "Days awaiting acknowledgement",
       "daysUntilDeadline": "Days until deadline",
       "dueAt": "Due",
       "findings": "Findings",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2157,6 +2157,9 @@
     "empty": "Nothing needs you right now. Post a request to start one.",
     "evidence": {
       "current": "Now",
+      "daysOverdue": "Days overdue",
+      "daysUnanswered": "Days unanswered",
+      "daysUntilDeadline": "Days until deadline",
       "dueAt": "Due",
       "findings": "Findings",
       "hearingType": "Hearing type",
@@ -2185,7 +2188,8 @@
     "scout": {
       "documentDeadlines": "Document deadlines",
       "documentReview": "Playbook review",
-      "manualRequest": "Request"
+      "manualRequest": "Request",
+      "workAttention": "Work monitoring"
     },
     "severity": {
       "info": "Info",
@@ -3714,6 +3718,7 @@
     },
     "addAssignee": "Add assignee",
     "addSubtask": "Add subtask",
+    "assigned": "Assigned",
     "assigneeRoles": {
       "assignee": "Assignee",
       "reviewer": "Reviewer"
@@ -3776,6 +3781,7 @@
       "deadline": "Deadline",
       "task": "Task"
     },
+    "workingTarget": "Working target",
     "workingTargetDue": "Working target due"
   },
   "templates": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2157,6 +2157,9 @@
     "empty": "Nada requiere su atención. Cree una solicitud con el botón superior.",
     "evidence": {
       "current": "Ahora",
+      "daysOverdue": "Días de retraso",
+      "daysUnanswered": "Días sin confirmar",
+      "daysUntilDeadline": "Días hasta la fecha límite",
       "dueAt": "Vence",
       "findings": "Hallazgos",
       "hearingType": "Tipo de audiencia",
@@ -2185,7 +2188,8 @@
     "scout": {
       "documentDeadlines": "Plazos del documento",
       "documentReview": "Revisión según playbook",
-      "manualRequest": "Solicitud"
+      "manualRequest": "Solicitud",
+      "workAttention": "Seguimiento del trabajo"
     },
     "severity": {
       "info": "Información",
@@ -3714,6 +3718,7 @@
     },
     "addAssignee": "Añadir asignado",
     "addSubtask": "Añadir subtarea",
+    "assigned": "Asignado",
     "assigneeRoles": {
       "assignee": "Asignado",
       "reviewer": "Revisor"
@@ -3776,6 +3781,7 @@
       "deadline": "Plazo",
       "task": "Tarea"
     },
+    "workingTarget": "Objetivo de trabajo",
     "workingTargetDue": "Objetivo de trabajo vencido"
   },
   "templates": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2158,7 +2158,7 @@
     "evidence": {
       "current": "Ahora",
       "daysOverdue": "Días de retraso",
-      "daysUnanswered": "Días sin confirmar",
+      "daysUnacknowledged": "Días sin confirmar",
       "daysUntilDeadline": "Días hasta la fecha límite",
       "dueAt": "Vence",
       "findings": "Hallazgos",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2158,7 +2158,7 @@
     "evidence": {
       "current": "Nüüd",
       "daysOverdue": "Päevi üle tähtaja",
-      "daysUnanswered": "Päevi kinnitamata",
+      "daysUnacknowledged": "Päevi kinnitamata",
       "daysUntilDeadline": "Päevi tähtajani",
       "dueAt": "Tähtaeg",
       "findings": "Leiud",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2157,6 +2157,9 @@
     "empty": "Praegu ei oota miski. Lisa taotlus ülalolevast nupust.",
     "evidence": {
       "current": "Nüüd",
+      "daysOverdue": "Päevi üle tähtaja",
+      "daysUnanswered": "Päevi kinnitamata",
+      "daysUntilDeadline": "Päevi tähtajani",
       "dueAt": "Tähtaeg",
       "findings": "Leiud",
       "hearingType": "Istungi liik",
@@ -2185,7 +2188,8 @@
     "scout": {
       "documentDeadlines": "Dokumendi tähtajad",
       "documentReview": "Playbooki ülevaatus",
-      "manualRequest": "Taotlus"
+      "manualRequest": "Taotlus",
+      "workAttention": "Töö jälgimine"
     },
     "severity": {
       "info": "Teave",
@@ -3714,6 +3718,7 @@
     },
     "addAssignee": "Lisa isik",
     "addSubtask": "Lisa alamülesanne",
+    "assigned": "Määratud",
     "assigneeRoles": {
       "assignee": "Täitja",
       "reviewer": "Ülevaataja"
@@ -3776,6 +3781,7 @@
       "deadline": "Tähtaeg",
       "task": "Ülesanne"
     },
+    "workingTarget": "Töö sihttähtaeg",
     "workingTargetDue": "Töö sihttähtaeg on möödunud"
   },
   "templates": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2157,6 +2157,9 @@
     "empty": "Rien ne vous attend. Créez une demande avec le bouton ci-dessus.",
     "evidence": {
       "current": "Actuellement",
+      "daysOverdue": "Jours de retard",
+      "daysUnanswered": "Jours sans confirmation",
+      "daysUntilDeadline": "Jours avant l'échéance",
       "dueAt": "Échéance",
       "findings": "Constats",
       "hearingType": "Type d'audience",
@@ -2185,7 +2188,8 @@
     "scout": {
       "documentDeadlines": "Échéances du document",
       "documentReview": "Revue selon le playbook",
-      "manualRequest": "Demande"
+      "manualRequest": "Demande",
+      "workAttention": "Suivi du travail"
     },
     "severity": {
       "info": "Information",
@@ -3714,6 +3718,7 @@
     },
     "addAssignee": "Ajouter un assigné",
     "addSubtask": "Ajouter une sous-tâche",
+    "assigned": "Attribué",
     "assigneeRoles": {
       "assignee": "Assigné",
       "reviewer": "Réviseur"
@@ -3776,6 +3781,7 @@
       "deadline": "Échéance",
       "task": "Tâche"
     },
+    "workingTarget": "Objectif de travail",
     "workingTargetDue": "Objectif de travail arrivé à échéance"
   },
   "templates": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2158,7 +2158,7 @@
     "evidence": {
       "current": "Actuellement",
       "daysOverdue": "Jours de retard",
-      "daysUnanswered": "Jours sans confirmation",
+      "daysUnacknowledged": "Jours sans confirmation",
       "daysUntilDeadline": "Jours avant l'échéance",
       "dueAt": "Échéance",
       "findings": "Constats",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2157,6 +2157,9 @@
     "empty": "Most semmi sem vár Önre. Adjon fel kérést a fenti gombbal.",
     "evidence": {
       "current": "Most",
+      "daysOverdue": "Késés napokban",
+      "daysUnanswered": "Megerősítés nélküli napok",
+      "daysUntilDeadline": "Napok a határidőig",
       "dueAt": "Határidő",
       "findings": "Megállapítások",
       "hearingType": "Tárgyalás típusa",
@@ -2185,7 +2188,8 @@
     "scout": {
       "documentDeadlines": "Határidők a dokumentumból",
       "documentReview": "Playbook-ellenőrzés",
-      "manualRequest": "Kérés"
+      "manualRequest": "Kérés",
+      "workAttention": "Munkafigyelés"
     },
     "severity": {
       "info": "Információ",
@@ -3714,6 +3718,7 @@
     },
     "addAssignee": "Felelős hozzáadása",
     "addSubtask": "Alfeladat hozzáadása",
+    "assigned": "Kijelölve",
     "assigneeRoles": {
       "assignee": "Felelős",
       "reviewer": "Ellenőr"
@@ -3776,6 +3781,7 @@
       "deadline": "Határidő",
       "task": "Feladat"
     },
+    "workingTarget": "Munkacél",
     "workingTargetDue": "Munkacél esedékes"
   },
   "templates": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2158,7 +2158,7 @@
     "evidence": {
       "current": "Most",
       "daysOverdue": "Késés napokban",
-      "daysUnanswered": "Megerősítés nélküli napok",
+      "daysUnacknowledged": "Megerősítés nélküli napok",
       "daysUntilDeadline": "Napok a határidőig",
       "dueAt": "Határidő",
       "findings": "Megállapítások",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2157,6 +2157,9 @@
     "empty": "Šiuo metu nieko nelaukia. Sukurkite užklausą mygtuku viršuje.",
     "evidence": {
       "current": "Dabar",
+      "daysOverdue": "Vėluojama dienų",
+      "daysUnanswered": "Dienų be patvirtinimo",
+      "daysUntilDeadline": "Dienų iki termino",
       "dueAt": "Terminas",
       "findings": "Išvados",
       "hearingType": "Posėdžio tipas",
@@ -2185,7 +2188,8 @@
     "scout": {
       "documentDeadlines": "Dokumento terminai",
       "documentReview": "Peržiūra pagal playbook",
-      "manualRequest": "Užklausa"
+      "manualRequest": "Užklausa",
+      "workAttention": "Darbo stebėsena"
     },
     "severity": {
       "info": "Informacija",
@@ -3714,6 +3718,7 @@
     },
     "addAssignee": "Priskirti asmenį",
     "addSubtask": "Pridėti použduotį",
+    "assigned": "Paskirta",
     "assigneeRoles": {
       "assignee": "Vykdytojas",
       "reviewer": "Peržiūrėtojas"
@@ -3776,6 +3781,7 @@
       "deadline": "Terminas",
       "task": "Užduotis"
     },
+    "workingTarget": "Darbinis terminas",
     "workingTargetDue": "Darbinis terminas suėjo"
   },
   "templates": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2158,7 +2158,7 @@
     "evidence": {
       "current": "Dabar",
       "daysOverdue": "Vėluojama dienų",
-      "daysUnanswered": "Dienų be patvirtinimo",
+      "daysUnacknowledged": "Dienų be patvirtinimo",
       "daysUntilDeadline": "Dienų iki termino",
       "dueAt": "Terminas",
       "findings": "Išvados",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2157,6 +2157,9 @@
     "empty": "Pašlaik nekas negaida. Izveidojiet pieprasījumu ar pogu augšā.",
     "evidence": {
       "current": "Tagad",
+      "daysOverdue": "Nokavētās dienas",
+      "daysUnanswered": "Dienas bez apstiprinājuma",
+      "daysUntilDeadline": "Dienas līdz termiņam",
       "dueAt": "Termiņš",
       "findings": "Konstatējumi",
       "hearingType": "Sēdes veids",
@@ -2185,7 +2188,8 @@
     "scout": {
       "documentDeadlines": "Dokumenta termiņi",
       "documentReview": "Pārbaude pēc playbook",
-      "manualRequest": "Pieprasījums"
+      "manualRequest": "Pieprasījums",
+      "workAttention": "Darba uzraudzība"
     },
     "severity": {
       "info": "Informācija",
@@ -3714,6 +3718,7 @@
     },
     "addAssignee": "Pievienot atbildīgo",
     "addSubtask": "Pievienot apakšuzdevumu",
+    "assigned": "Piešķirts",
     "assigneeRoles": {
       "assignee": "Izpildītājs",
       "reviewer": "Pārskatītājs"
@@ -3776,6 +3781,7 @@
       "deadline": "Termiņš",
       "task": "Uzdevums"
     },
+    "workingTarget": "Darba mērķa termiņš",
     "workingTargetDue": "Darba mērķa termiņš pienācis"
   },
   "templates": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2158,7 +2158,7 @@
     "evidence": {
       "current": "Tagad",
       "daysOverdue": "Nokavētās dienas",
-      "daysUnanswered": "Dienas bez apstiprinājuma",
+      "daysUnacknowledged": "Dienas bez apstiprinājuma",
       "daysUntilDeadline": "Dienas līdz termiņam",
       "dueAt": "Termiņš",
       "findings": "Konstatējumi",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2160,6 +2160,9 @@ type Messages = {
     "empty": "Nothing needs you right now. Post a request to start one.";
     "evidence": {
       "current": "Now";
+      "daysOverdue": "Days overdue";
+      "daysUnanswered": "Days unanswered";
+      "daysUntilDeadline": "Days until deadline";
       "dueAt": "Due";
       "findings": "Findings";
       "hearingType": "Hearing type";
@@ -2189,6 +2192,7 @@ type Messages = {
       "documentDeadlines": "Document deadlines";
       "documentReview": "Playbook review";
       "manualRequest": "Request";
+      "workAttention": "Work monitoring";
     };
     "severity": {
       "info": "Info";
@@ -3717,6 +3721,7 @@ type Messages = {
     };
     "addAssignee": "Add assignee";
     "addSubtask": "Add subtask";
+    "assigned": "Assigned";
     "assigneeRoles": {
       "assignee": "Assignee";
       "reviewer": "Reviewer";
@@ -3779,6 +3784,7 @@ type Messages = {
       "deadline": "Deadline";
       "task": "Task";
     };
+    "workingTarget": "Working target";
     "workingTargetDue": "Working target due";
   };
   "templates": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2161,7 +2161,7 @@ type Messages = {
     "evidence": {
       "current": "Now";
       "daysOverdue": "Days overdue";
-      "daysUnanswered": "Days unanswered";
+      "daysUnacknowledged": "Days awaiting acknowledgement";
       "daysUntilDeadline": "Days until deadline";
       "dueAt": "Due";
       "findings": "Findings";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2157,6 +2157,9 @@
     "empty": "Nic nie czeka. Dodaj zgłoszenie przyciskiem powyżej.",
     "evidence": {
       "current": "Obecnie",
+      "daysOverdue": "Dni po terminie",
+      "daysUnanswered": "Dni bez potwierdzenia",
+      "daysUntilDeadline": "Dni do terminu",
       "dueAt": "Termin",
       "findings": "Ustalenia",
       "hearingType": "Rodzaj rozprawy",
@@ -2185,7 +2188,8 @@
     "scout": {
       "documentDeadlines": "Terminy z dokumentu",
       "documentReview": "Przegląd wg playbooka",
-      "manualRequest": "Zgłoszenie"
+      "manualRequest": "Zgłoszenie",
+      "workAttention": "Monitorowanie pracy"
     },
     "severity": {
       "info": "Informacja",
@@ -3714,6 +3718,7 @@
     },
     "addAssignee": "Przypisz osobę",
     "addSubtask": "Dodaj podzadanie",
+    "assigned": "Przypisano",
     "assigneeRoles": {
       "assignee": "Wykonawca",
       "reviewer": "Recenzent"
@@ -3776,6 +3781,7 @@
       "deadline": "Termin",
       "task": "Zadanie"
     },
+    "workingTarget": "Termin roboczy",
     "workingTargetDue": "Termin roboczy minął"
   },
   "templates": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2158,7 +2158,7 @@
     "evidence": {
       "current": "Obecnie",
       "daysOverdue": "Dni po terminie",
-      "daysUnanswered": "Dni bez potwierdzenia",
+      "daysUnacknowledged": "Dni bez potwierdzenia",
       "daysUntilDeadline": "Dni do terminu",
       "dueAt": "Termin",
       "findings": "Ustalenia",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2157,6 +2157,9 @@
     "empty": "Nada aguarda você agora. Crie uma solicitação pelo botão acima.",
     "evidence": {
       "current": "Agora",
+      "daysOverdue": "Dias de atraso",
+      "daysUnanswered": "Dias sem confirmação",
+      "daysUntilDeadline": "Dias até o prazo",
       "dueAt": "Prazo",
       "findings": "Constatações",
       "hearingType": "Tipo de audiência",
@@ -2185,7 +2188,8 @@
     "scout": {
       "documentDeadlines": "Prazos do documento",
       "documentReview": "Revisão por playbook",
-      "manualRequest": "Solicitação"
+      "manualRequest": "Solicitação",
+      "workAttention": "Monitoramento do trabalho"
     },
     "severity": {
       "info": "Informação",
@@ -3714,6 +3718,7 @@
     },
     "addAssignee": "Adicionar responsável",
     "addSubtask": "Adicionar subtarefa",
+    "assigned": "Atribuído",
     "assigneeRoles": {
       "assignee": "Responsável",
       "reviewer": "Revisor"
@@ -3776,6 +3781,7 @@
       "deadline": "Prazo",
       "task": "Tarefa"
     },
+    "workingTarget": "Meta de trabalho",
     "workingTargetDue": "Meta de trabalho vencida"
   },
   "templates": {

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2158,7 +2158,7 @@
     "evidence": {
       "current": "Agora",
       "daysOverdue": "Dias de atraso",
-      "daysUnanswered": "Dias sem confirmação",
+      "daysUnacknowledged": "Dias sem confirmação",
       "daysUntilDeadline": "Dias até o prazo",
       "dueAt": "Prazo",
       "findings": "Constatações",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2157,6 +2157,9 @@
     "empty": "Teraz vás nič nečaká. Zadajte požiadavku tlačidlom vyššie.",
     "evidence": {
       "current": "Novo",
+      "daysOverdue": "Dní po termíne",
+      "daysUnanswered": "Dní bez potvrdenia",
+      "daysUntilDeadline": "Dní do lehoty",
       "dueAt": "Lehota",
       "findings": "Zistenia",
       "hearingType": "Druh pojednávania",
@@ -2185,7 +2188,8 @@
     "scout": {
       "documentDeadlines": "Lehoty z dokumentu",
       "documentReview": "Kontrola podľa playbooku",
-      "manualRequest": "Požiadavka"
+      "manualRequest": "Požiadavka",
+      "workAttention": "Sledovanie práce"
     },
     "severity": {
       "info": "Informácia",
@@ -3714,6 +3718,7 @@
     },
     "addAssignee": "Pridať osobu",
     "addSubtask": "Pridať podúlohu",
+    "assigned": "Priradené",
     "assigneeRoles": {
       "assignee": "Riešiteľ",
       "reviewer": "Revident"
@@ -3776,6 +3781,7 @@
       "deadline": "Lehota",
       "task": "Úloha"
     },
+    "workingTarget": "Pracovný termín",
     "workingTargetDue": "Pracovný termín uplynul"
   },
   "templates": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2158,7 +2158,7 @@
     "evidence": {
       "current": "Novo",
       "daysOverdue": "Dní po termíne",
-      "daysUnanswered": "Dní bez potvrdenia",
+      "daysUnacknowledged": "Dní bez potvrdenia",
       "daysUntilDeadline": "Dní do lehoty",
       "dueAt": "Lehota",
       "findings": "Zistenia",

--- a/packages/api-contract/src/signals.ts
+++ b/packages/api-contract/src/signals.ts
@@ -7,6 +7,13 @@
  * model-read date at a glance.
  */
 
+import type { WORK_OBLIGATION_STATUS } from "./workflow-status";
+
+/** The two statuses a governed obligation is still open in. */
+export type OpenWorkObligationStatus =
+  | typeof WORK_OBLIGATION_STATUS.AWAITING_ACKNOWLEDGEMENT
+  | typeof WORK_OBLIGATION_STATUS.ACTIVE;
+
 export const SIGNAL_ORIGIN = {
   MANUAL: "manual",
   SOURCE: "source",
@@ -68,6 +75,7 @@ export const SCOUT_KEY = {
   INFOSOUD_HEARINGS: "infosoud.hearings",
   DOCUMENT_DEADLINES: "document.deadlines",
   DOCUMENT_REVIEW: "document.review",
+  WORK_ATTENTION: "work.attention",
 } as const;
 export type ScoutKey = (typeof SCOUT_KEY)[keyof typeof SCOUT_KEY];
 
@@ -76,6 +84,8 @@ export const SIGNAL_KIND = {
   HEARING_CHANGED: "hearing.changed",
   DEADLINE_DETECTED: "deadline.detected",
   CONTRACT_REVIEWED: "contract.reviewed",
+  WORK_UNACKNOWLEDGED: "work.unacknowledged",
+  WORK_DEADLINE_AT_RISK: "work.deadline_at_risk",
 } as const;
 export type SignalKind = (typeof SIGNAL_KIND)[keyof typeof SIGNAL_KIND];
 export const SIGNAL_KINDS = [
@@ -83,6 +93,8 @@ export const SIGNAL_KINDS = [
   SIGNAL_KIND.HEARING_CHANGED,
   SIGNAL_KIND.DEADLINE_DETECTED,
   SIGNAL_KIND.CONTRACT_REVIEWED,
+  SIGNAL_KIND.WORK_UNACKNOWLEDGED,
+  SIGNAL_KIND.WORK_DEADLINE_AT_RISK,
 ] as const satisfies readonly SignalKind[];
 
 /** Each kind has exactly one origin; the map is total so a new kind must decide. */
@@ -91,6 +103,8 @@ export const SIGNAL_KIND_ORIGIN = {
   [SIGNAL_KIND.HEARING_CHANGED]: SIGNAL_ORIGIN.SOURCE,
   [SIGNAL_KIND.DEADLINE_DETECTED]: SIGNAL_ORIGIN.MODEL,
   [SIGNAL_KIND.CONTRACT_REVIEWED]: SIGNAL_ORIGIN.MODEL,
+  [SIGNAL_KIND.WORK_UNACKNOWLEDGED]: SIGNAL_ORIGIN.SOURCE,
+  [SIGNAL_KIND.WORK_DEADLINE_AT_RISK]: SIGNAL_ORIGIN.SOURCE,
 } as const satisfies Record<SignalKind, SignalOrigin>;
 
 /** What a signal is about; rendered as the card's subject link. */
@@ -138,6 +152,26 @@ export type SignalEvidence =
       verdict: "safe" | "needs-review" | "reject";
       findings: { title: string; severity: SignalSeverity; quote: string }[];
       reviewRunId: string | null;
+    }
+  | {
+      kind: typeof SIGNAL_KIND.WORK_UNACKNOWLEDGED;
+      obligationEntityId: string;
+      ownerUserId: string;
+      /** When the current owner was put on the obligation. */
+      assignedAt: string;
+      daysWaiting: number;
+      workingTargetDate: string | null;
+      hardDeadlineDate: string | null;
+    }
+  | {
+      kind: typeof SIGNAL_KIND.WORK_DEADLINE_AT_RISK;
+      obligationEntityId: string;
+      ownerUserId: string;
+      hardDeadlineDate: string;
+      workingTargetDate: string | null;
+      /** Negative once the deadline has passed; severity carries the same split. */
+      daysUntilDeadline: number;
+      obligationStatus: OpenWorkObligationStatus;
     };
 
 type MissingEvidenceKind = Exclude<SignalKind, SignalEvidence["kind"]>;

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -253,7 +253,7 @@
     "files": {}
   },
   "lint-suppression-directives": {
-    "count": 742,
+    "count": 743,
     "files": {
       "apps/api/scripts/ai-provider-canary.ts": 4,
       "apps/api/scripts/backfill-image-thumbnails.ts": 9,
@@ -403,6 +403,7 @@
       "apps/api/src/lib/scheduler/tasks/desktop-edit-session-expiry.ts": 6,
       "apps/api/src/lib/scheduler/tasks/infosoud.ts": 10,
       "apps/api/src/lib/scheduler/tasks/memory-curator.ts": 1,
+      "apps/api/src/lib/scouts/work-attention.ts": 1,
       "apps/api/src/lib/search/extraction-worker.ts": 1,
       "apps/api/src/lib/search/index-chat.ts": 3,
       "apps/api/src/lib/search/index-global.ts": 5,


### PR DESCRIPTION
A signals producer for governed work, following the doctrine that new producers emit signals rather than new queues. The scout `work.attention` (origin `source`, no confidence) emits two workspace-scoped kinds:

- `work.unacknowledged` (warning): an obligation awaiting acknowledgement for at least 3 days. The waiting clock is the latest `owner_assigned`/`delegated` event (falling back to the obligation's creation for legacy-derived rows), not `updated_at`, which any date or provenance edit would silently restart.
- `work.deadline_at_risk` (warning, critical once past): an open obligation whose hard deadline is within 3 days or overdue. Civil dates compare at UTC midnight, matching the My Work queues' `asOf`, so scout and queues agree on "due".

Dedupe keys carry the assignment instant and the hard-deadline date respectively, so a reassigned obligation or a moved deadline re-emits while a steady state never duplicates. The only suggestion is `assign`; creating a task would duplicate the obligation being reported. Runs hourly as a scheduler task gated on the governed-workflow flag, with a bounded keyset page over `work_obligations` and one `scout_runs` row per organization. The signal kind checks widen in step (drop and re-add in one statement, `NOT VALID` since widening leaves stored rows valid).

Web: scout label, evidence rendering in the inspector's exhaustive per-kind switch, and six new keys in all 13 locales (label plus numeric value, avoiding plural branches across six plural systems).

Deliberately not included: producer-side resolution of a signal once the obligation is acknowledged or completed. `transitionSignal` requires an authenticated actor, a permission check, and an audit row; every caller today is a person. Until a producer-side transition exists, such signals stay open until dismissed. Also deferred: rendering the owner's name in the evidence (identity rendering is owned elsewhere; the subject link opens the task, which shows it).

Tests: pure decision logic (13 cases: qualification, severity, day arithmetic at boundaries, dedupe keys) and a PGlite integration suite (per-kind emission, the event-vs-creation clock, idempotent replay, a moved deadline re-emitting, the census, the empty-page cycle close).

https://claude.ai/code/session_01GckBYzFkS2k17FTRN8d6MX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inbox alerts for work awaiting acknowledgement for three or more days.
  * Added deadline-risk alerts for work due within three days or already overdue, with warning and critical severity.
  * Alerts include relevant work, assignment, status and timing details, plus suggested follow-up actions.
  * Added hourly monitoring for eligible governed work.
* **Improvements**
  * Added translated labels and evidence details across supported languages.
* **Tests**
  * Added coverage for thresholds, deduplication, deadline changes and cursor-based processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Ratchet note:** the suppression baseline rises by one for the scout's per-organization loop (`no-await-in-loop`): each organization gets one short emitting transaction, run sequentially so an oversized deployment cannot hold every root pool connection at once — the same bounded-sequential-IO class as `lib/workflow-queue.ts` and the notification batching loop.