### PR TITLE
fix(ui): preserve card interactions

### DIFF
--- a/.changeset/steady-card-drag-access.md
+++ b/.changeset/steady-card-drag-access.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": patch
+---
+
+Restore keyboard card dragging and preserve nested control input events.

--- a/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
@@ -56,9 +56,19 @@ const SortableItem = ({ id }: { id: string }) => {
   if (activator.type === "card") {
     return (
       <div data-sortable-item={id} ref={setNodeRef} style={style}>
-        <KanbanCardDragSurface bindings={activator.bindings}>
+        <KanbanCardDragSurface
+          bindings={activator.bindings}
+          data-card-drag-surface=""
+        >
           <p data-card-content="">{id}</p>
-          <button data-card-control="" type="button">
+          <button
+            data-card-control=""
+            onPointerDown={() => {
+              document.documentElement.dataset["cardControlPointerDown"] =
+                "seen";
+            }}
+            type="button"
+          >
             Keep {id} control interactive
           </button>
         </KanbanCardDragSurface>

--- a/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
+++ b/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
@@ -348,7 +348,7 @@ test("exposes explicit whole-item and 44px handle activation surfaces", async ({
   page,
 }) => {
   const handle = await openFixture(page);
-  const wholeItem = page.locator('[data-card-content=""]');
+  const wholeItem = page.locator('[data-card-drag-surface=""]');
 
   await expect(handle).toHaveCSS("width", "44px");
   await expect(handle).toHaveCSS("height", "44px");
@@ -357,6 +357,10 @@ test("exposes explicit whole-item and 44px handle activation surfaces", async ({
     handle.locator("xpath=ancestor::*[@data-sortable-item]"),
   ).toHaveCSS("touch-action", "auto");
   await expect(wholeItem).toHaveCSS("touch-action", "auto");
+  await wholeItem.focus();
+  await page.keyboard.press("Space");
+  await expect(page.locator("[data-overlay]")).toHaveText("whole-item");
+  await page.keyboard.press("Escape");
   const control = page.getByRole("button", {
     name: "Keep whole-item control interactive",
   });
@@ -369,6 +373,14 @@ test("exposes explicit whole-item and 44px handle activation surfaces", async ({
   await page.mouse.move(controlBox.x + 16, controlBox.y + 4);
   await page.mouse.up();
   await expect(page.locator("[data-overlay]")).toHaveCount(0);
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(
+          () => document.documentElement.dataset["cardControlPointerDown"],
+        ),
+    )
+    .toBe("seen");
 });
 
 test("keeps the drag overlay above sticky board chrome", async ({ page }) => {

--- a/packages/ui/src/kanban/sortable-interactions.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.tsx
@@ -837,18 +837,69 @@ const getKanbanCardDragSurfaceAttributes = ({
   "aria-pressed": _pressed,
   "aria-roledescription": _roleDescription,
   role: _role,
-  tabIndex: _tabIndex,
+  tabIndex,
   ...attributes
-}: KanbanSortableBindings["attributes"]) => attributes;
+}: KanbanSortableBindings["attributes"]) => ({ ...attributes, tabIndex });
 
-const stopKanbanCardDragAtInteractiveDescendant = (
+type KanbanCardDragSurfaceListener = (
   event: React.SyntheticEvent<HTMLDivElement>,
+) => void;
+
+const isKanbanCardDragSurfaceListener = (
+  listener: unknown,
+): listener is KanbanCardDragSurfaceListener => typeof listener === "function";
+
+const getKanbanCardDragSurfaceListeners = (
+  listeners: NonNullable<KanbanSortableBindings["listeners"]>,
 ) => {
-  if (
-    isKanbanCardDragSurfaceInteractiveTarget(event.target, event.currentTarget)
-  ) {
-    event.stopPropagation();
-  }
+  const { onKeyDown, onMouseDown, onPointerDown, onTouchStart, ...rest } =
+    listeners;
+
+  const shouldActivate = (event: React.SyntheticEvent<HTMLDivElement>) =>
+    !isKanbanCardDragSurfaceInteractiveTarget(
+      event.target,
+      event.currentTarget,
+    );
+
+  return {
+    ...rest,
+    ...(!isKanbanCardDragSurfaceListener(onKeyDown)
+      ? {}
+      : {
+          onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
+            if (shouldActivate(event)) {
+              onKeyDown(event);
+            }
+          },
+        }),
+    ...(!isKanbanCardDragSurfaceListener(onMouseDown)
+      ? {}
+      : {
+          onMouseDown: (event: React.MouseEvent<HTMLDivElement>) => {
+            if (shouldActivate(event)) {
+              onMouseDown(event);
+            }
+          },
+        }),
+    ...(!isKanbanCardDragSurfaceListener(onPointerDown)
+      ? {}
+      : {
+          onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => {
+            if (shouldActivate(event)) {
+              onPointerDown(event);
+            }
+          },
+        }),
+    ...(!isKanbanCardDragSurfaceListener(onTouchStart)
+      ? {}
+      : {
+          onTouchStart: (event: React.TouchEvent<HTMLDivElement>) => {
+            if (shouldActivate(event)) {
+              onTouchStart(event);
+            }
+          },
+        }),
+  };
 };
 
 export type KanbanCardDragSurfaceProps = {
@@ -861,7 +912,7 @@ export const KanbanCardDragSurface = ({
   className,
   ...props
 }: KanbanCardDragSurfaceProps) => {
-  const { setActivatorNodeRef: setCardActivatorNodeRef } = bindings;
+  const { listeners, setActivatorNodeRef: setCardActivatorNodeRef } = bindings;
   const setActivatorNodeRef = React.useCallback(
     (element: HTMLDivElement | null) => {
       setCardActivatorNodeRef(element);
@@ -873,11 +924,10 @@ export const KanbanCardDragSurface = ({
     <div
       {...props}
       {...getKanbanCardDragSurfaceAttributes(bindings.attributes)}
-      {...bindings.listeners}
+      {...(listeners === undefined
+        ? {}
+        : getKanbanCardDragSurfaceListeners(listeners))}
       className={cn("touch-auto", className)}
-      onMouseDownCapture={stopKanbanCardDragAtInteractiveDescendant}
-      onPointerDownCapture={stopKanbanCardDragAtInteractiveDescendant}
-      onTouchStartCapture={stopKanbanCardDragAtInteractiveDescendant}
       ref={setActivatorNodeRef}
     />
   );


### PR DESCRIPTION
Preserves keyboard activation for card drag surfaces and leaves nested control input events intact.

Validation:
- `bun --filter @stll/ui typecheck`
- `bun --filter @stll/ui lint`
- `bun --filter @stll/ui test -- --runInBand`
- `bun --filter @stll/ui test:browser -- sortable-interactions.playwright.spec.ts`