### PR TITLE
fix: restore matter visibility and browser analytics

### DIFF
--- a/.github/actions/build-web-image/action.yml
+++ b/.github/actions/build-web-image/action.yml
@@ -12,9 +12,8 @@ inputs:
     description: Public browser configuration to compile (production or staging).
     required: true
   posthog-key:
-    description: Browser-visible PostHog project key; passed separately so it is never committed.
-    required: false
-    default: ""
+    description: Browser-visible PostHog project key required for official Stella builds; passed separately so it is never committed.
+    required: true
   source-path:
     description: Checkout containing the exact source commit to build.
     required: false
@@ -37,10 +36,15 @@ runs:
       env:
         RELEASE_REF: ${{ inputs.release-ref }}
         RELEASE_SHA: ${{ inputs.release-sha }}
+        POSTHOG_KEY: ${{ inputs.posthog-key }}
         SOURCE_PATH: ${{ inputs.source-path }}
         TARGET_ENV: ${{ inputs.target-environment }}
       run: |
         set -euo pipefail
+        if [[ ! "$POSTHOG_KEY" =~ ^phc_[A-Za-z0-9_-]{20,}$ ]]; then
+          echo "::error::A valid PostHog project key is required for official stella web builds."
+          exit 1
+        fi
         if [[ ! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
           echo "::error::release-sha must be a full lowercase commit SHA."
           exit 1

--- a/apps/web/src/stores/config-store.test.ts
+++ b/apps/web/src/stores/config-store.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CONFIG_STORE_VERSION,
+  migratePersistedConfigState,
+  toPersistedConfigState,
+  useConfigStore,
+} from "@/stores/config-store";
+
+describe("persisted Matter preferences", () => {
+  test("retains presentation preferences without organization-scoped visibility", () => {
+    const state = useConfigStore.getState();
+    const persisted = toPersistedConfigState({
+      ...state,
+      matters: {
+        ...state.matters,
+        clientFilter: "client_previous_organization",
+        collapsedGroups: ["client_previous_organization"],
+        filters: {
+          client: ["client_previous_organization"],
+          team: ["user_previous_organization"],
+        },
+        hiddenColumns: ["team"],
+        sortDesc: false,
+        sortKey: "name",
+        viewMode: "table",
+      },
+    });
+
+    expect(CONFIG_STORE_VERSION).toBe(2);
+    expect(persisted.matters).toMatchObject({
+      clientFilter: null,
+      collapsedGroups: [],
+      filters: {},
+      hiddenColumns: ["team"],
+      sortDesc: false,
+      sortKey: "name",
+      viewMode: "table",
+    });
+  });
+
+  test("migrates legacy preferences without stale visibility state", () => {
+    const migrated = migratePersistedConfigState({
+      matters: {
+        clientFilter: "client_previous_organization",
+        collapsedGroups: ["client_previous_organization"],
+        filters: { team: ["user_previous_organization"] },
+        groupBy: "none",
+        hiddenColumns: ["team", "not-a-column"],
+        sortDesc: false,
+        sortKey: "name",
+        viewMode: "table",
+      },
+    });
+
+    expect(migrated.matters).toEqual({
+      clientFilter: null,
+      collapsedGroups: [],
+      filters: {},
+      groupBy: "none",
+      hiddenColumns: ["team"],
+      sortDesc: false,
+      sortKey: "name",
+      viewMode: "table",
+    });
+  });
+});

--- a/apps/web/src/stores/config-store.ts
+++ b/apps/web/src/stores/config-store.ts
@@ -7,7 +7,7 @@ import type {
   MattersFilters,
   MattersSortKey,
 } from "@/lib/workspaces/types";
-import { ALL_COLUMNS } from "@/lib/workspaces/types";
+import { ALL_COLUMNS, MATTERS_SORT_KEYS } from "@/lib/workspaces/types";
 
 const isRecord = (v: unknown): v is Record<string, unknown> =>
   typeof v === "object" && v !== null;
@@ -49,6 +49,56 @@ type ConfigState = {
   toggleMattersColumn: (id: MattersColumnId) => void;
   toggleGroupCollapsed: (groupId: string) => void;
 };
+
+export const CONFIG_STORE_VERSION = 2;
+
+const isMattersColumnId = (value: unknown): value is MattersColumnId =>
+  typeof value === "string" &&
+  ALL_COLUMNS.some((columnId) => columnId === value);
+
+const isMattersSortKey = (value: unknown): value is MattersSortKey =>
+  typeof value === "string" &&
+  MATTERS_SORT_KEYS.some((sortKey) => sortKey === value);
+
+const readPersistedMatters = (persisted: unknown): MattersConfig => {
+  if (!isRecord(persisted)) {
+    return DEFAULT_MATTERS;
+  }
+
+  return {
+    viewMode:
+      persisted["viewMode"] === "grid" || persisted["viewMode"] === "table"
+        ? persisted["viewMode"]
+        : DEFAULT_MATTERS.viewMode,
+    sortKey: isMattersSortKey(persisted["sortKey"])
+      ? persisted["sortKey"]
+      : DEFAULT_MATTERS.sortKey,
+    sortDesc:
+      typeof persisted["sortDesc"] === "boolean"
+        ? persisted["sortDesc"]
+        : DEFAULT_MATTERS.sortDesc,
+    groupBy:
+      persisted["groupBy"] === "none" || persisted["groupBy"] === "client"
+        ? persisted["groupBy"]
+        : DEFAULT_MATTERS.groupBy,
+    hiddenColumns: Array.isArray(persisted["hiddenColumns"])
+      ? persisted["hiddenColumns"].filter(isMattersColumnId)
+      : DEFAULT_MATTERS.hiddenColumns,
+    clientFilter: null,
+    collapsedGroups: [],
+    filters: {},
+  };
+};
+
+export const toPersistedConfigState = (state: ConfigState) => ({
+  matters: readPersistedMatters(state.matters),
+});
+
+export const migratePersistedConfigState = (persisted: unknown) => ({
+  matters: readPersistedMatters(
+    isRecord(persisted) ? persisted["matters"] : null,
+  ),
+});
 
 export const useConfigStore = create<ConfigState>()(
   persist(
@@ -113,16 +163,14 @@ export const useConfigStore = create<ConfigState>()(
     }),
     {
       name: getStorageKey("config"),
-      version: 1,
-      migrate: () => null,
+      version: CONFIG_STORE_VERSION,
+      migrate: migratePersistedConfigState,
+      partialize: toPersistedConfigState,
       merge: (persisted, current) => {
-        if (!isRecord(persisted)) {
-          return current;
-        }
-        const prev = isRecord(persisted["matters"]) ? persisted["matters"] : {};
+        const { matters } = migratePersistedConfigState(persisted);
         return {
           ...current,
-          matters: { ...DEFAULT_MATTERS, ...prev },
+          matters,
         };
       },
     },

--- a/scripts/check-api-deployment.test.ts
+++ b/scripts/check-api-deployment.test.ts
@@ -133,6 +133,13 @@ describe("API deployment health receipt", () => {
     expect(action).toContain(
       "Release source predates the public web build contract",
     );
+    expect(action).toContain(
+      "A valid PostHog project key is required for official stella web builds",
+    );
+    expect(action).toMatch(/POSTHOG_KEY: \$\{\{ inputs\.posthog-key \}\}/u);
+    expect(action).toContain(
+      'if [[ ! "$POSTHOG_KEY" =~ ^phc_[A-Za-z0-9_-]{20,}$ ]]; then',
+    );
     expect(action).toContain("type=registry,ref=ghcr.io/");
     expect(action).not.toContain("type=gha");
     expect(action).not.toContain("toJSON(vars)");


### PR DESCRIPTION
## Proposed change

Prevent organization-scoped Matter filters and collapsed groups from surviving browser reloads while preserving valid view, sort, grouping, and column preferences. Require a valid PostHog project key in Stella's official web-image builds so browser analytics cannot be compiled out silently; source and self-hosted builds remain optional.

Add regression coverage for preference migration and the official build contract.

## Checklist

- [x] BUILD ASSURANCE | Focused checks and repository pre-commit guards pass; full verification runs in CI.
- [x] TESTING | Matter persistence, filter pipeline, and deployment contract tests pass.
- [x] DARK MODE SUPPORT | Not applicable; no visual styling changed.
- [ ] ISSUE LINKED | No linked issue.
- [ ] SCREENSHOT INCLUDED | Not applicable; this fixes persistence and build configuration.
