### PR TITLE
feat: scope corpus projection appends by route

### DIFF
--- a/apps/api/drizzle/20260831100000_corpus_projection_route_scope/migration.sql
+++ b/apps/api/drizzle/20260831100000_corpus_projection_route_scope/migration.sql
@@ -1,0 +1,51 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Route-scoped workers claim by desired physical index and then by runnable
+-- age. Keep the generation-wide queue index too: broad recovery remains a
+-- supported primitive, while this access path lets disjoint route workers
+-- avoid scanning and contending on another route's backlog.
+--
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY outside one. Split the transaction and
+-- restore it for the migrator's bookkeeping row after the online build.
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+
+-- stella-migration-safety: reviewed destructive-change - retry cleanup only;
+-- a cancelled concurrent build can leave an INVALID index with this name.
+DROP INDEX CONCURRENTLY IF EXISTS "corpus_index_projection_states_pending_route_idx";
+--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "corpus_index_projection_states_pending_route_idx"
+  ON "corpus_index_projection_states" (
+    "family",
+    "generation",
+    "desired_index_id",
+    (coalesce("retry_not_before", "updated_at")),
+    "entity_id"
+  )
+  WHERE "work_status" = 'repair_scheduled'
+    OR (
+      "work_status" IN ('eligible', 'retry_scheduled')
+      AND (
+        "applied_action" IS NULL
+        OR "applied_action" IS DISTINCT FROM "desired_action"
+        OR "applied_epoch" IS DISTINCT FROM "desired_epoch"
+        OR "applied_fingerprint" IS DISTINCT FROM "desired_fingerprint"
+        OR "applied_index_id" IS DISTINCT FROM "desired_index_id"
+      )
+    );
+--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/drizzle/20260831100000_corpus_projection_route_scope/migration.sql
+++ b/apps/api/drizzle/20260831100000_corpus_projection_route_scope/migration.sql
@@ -17,7 +17,6 @@ SET statement_timeout = 0;
 SET lock_timeout = 0;
 --> statement-breakpoint
 
--- stella-migration-safety: reviewed drop-object - retry cleanup only;
 -- a cancelled concurrent build can leave an INVALID index with this name.
 DROP INDEX CONCURRENTLY IF EXISTS "corpus_index_projection_states_pending_route_idx";
 --> statement-breakpoint
@@ -47,7 +46,6 @@ CREATE INDEX CONCURRENTLY "corpus_index_projection_states_pending_route_idx"
 -- an already published older revision remains required even when the newer
 -- projection exhausted its append retries. That broader predicate cannot use
 -- the pending-work index, so give route workers their exact sparse queue.
--- stella-migration-safety: reviewed drop-object - retry cleanup only; a
 -- cancelled concurrent build can leave an INVALID index with this name.
 DROP INDEX CONCURRENTLY IF EXISTS "corpus_index_projection_states_replacement_route_idx";
 --> statement-breakpoint

--- a/apps/api/drizzle/20260831100000_corpus_projection_route_scope/migration.sql
+++ b/apps/api/drizzle/20260831100000_corpus_projection_route_scope/migration.sql
@@ -17,7 +17,7 @@ SET statement_timeout = 0;
 SET lock_timeout = 0;
 --> statement-breakpoint
 
--- stella-migration-safety: reviewed destructive-change - retry cleanup only;
+-- stella-migration-safety: reviewed drop-object - retry cleanup only;
 -- a cancelled concurrent build can leave an INVALID index with this name.
 DROP INDEX CONCURRENTLY IF EXISTS "corpus_index_projection_states_pending_route_idx";
 --> statement-breakpoint
@@ -41,6 +41,30 @@ CREATE INDEX CONCURRENTLY "corpus_index_projection_states_pending_route_idx"
         OR "applied_index_id" IS DISTINCT FROM "desired_index_id"
       )
     );
+--> statement-breakpoint
+
+-- Replacement claims intentionally include blocked desired work: cleanup of
+-- an already published older revision remains required even when the newer
+-- projection exhausted its append retries. That broader predicate cannot use
+-- the pending-work index, so give route workers their exact sparse queue.
+-- stella-migration-safety: reviewed drop-object - retry cleanup only; a
+-- cancelled concurrent build can leave an INVALID index with this name.
+DROP INDEX CONCURRENTLY IF EXISTS "corpus_index_projection_states_replacement_route_idx";
+--> statement-breakpoint
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "corpus_index_projection_states_replacement_route_idx"
+  ON "corpus_index_projection_states" (
+    "family",
+    "generation",
+    "desired_index_id",
+    "updated_at",
+    "entity_id"
+  )
+  WHERE "desired_action" = 'upsert'
+    AND "applied_action" = 'upsert'
+    AND "applied_revision" IS NOT NULL
+    AND "applied_index_id" IS NOT NULL
+    AND "desired_epoch" > "applied_epoch";
 --> statement-breakpoint
 
 SET statement_timeout = '5s';

--- a/apps/api/src/db/schema/corpus-index-projections.ts
+++ b/apps/api/src/db/schema/corpus-index-projections.ts
@@ -403,6 +403,16 @@ export const corpusIndexProjectionStates = p.pgTable(
       )
       .where(corpusIndexProjectionNeedsWork(t)),
     p
+      .index("corpus_index_projection_states_pending_route_idx")
+      .on(
+        t.family,
+        t.generation,
+        t.desiredIndexId,
+        sql`coalesce(${t.retryNotBefore}, ${t.updatedAt})`,
+        t.entityId,
+      )
+      .where(corpusIndexProjectionNeedsWork(t)),
+    p
       .index("corpus_index_projection_states_blocked_idx")
       .on(t.family, t.generation, t.entityId)
       .where(corpusIndexProjectionIsBlocked(t.workStatus)),

--- a/apps/api/src/db/schema/corpus-index-projections.ts
+++ b/apps/api/src/db/schema/corpus-index-projections.ts
@@ -414,13 +414,7 @@ export const corpusIndexProjectionStates = p.pgTable(
       .where(corpusIndexProjectionNeedsWork(t)),
     p
       .index("corpus_index_projection_states_replacement_route_idx")
-      .on(
-        t.family,
-        t.generation,
-        t.desiredIndexId,
-        t.updatedAt,
-        t.entityId,
-      )
+      .on(t.family, t.generation, t.desiredIndexId, t.updatedAt, t.entityId)
       .where(
         sql`${t.desiredAction} = 'upsert'
           AND ${t.appliedAction} = 'upsert'

--- a/apps/api/src/db/schema/corpus-index-projections.ts
+++ b/apps/api/src/db/schema/corpus-index-projections.ts
@@ -413,6 +413,22 @@ export const corpusIndexProjectionStates = p.pgTable(
       )
       .where(corpusIndexProjectionNeedsWork(t)),
     p
+      .index("corpus_index_projection_states_replacement_route_idx")
+      .on(
+        t.family,
+        t.generation,
+        t.desiredIndexId,
+        t.updatedAt,
+        t.entityId,
+      )
+      .where(
+        sql`${t.desiredAction} = 'upsert'
+          AND ${t.appliedAction} = 'upsert'
+          AND ${t.appliedRevision} IS NOT NULL
+          AND ${t.appliedIndexId} IS NOT NULL
+          AND ${t.desiredEpoch} > ${t.appliedEpoch}`,
+      ),
+    p
       .index("corpus_index_projection_states_blocked_idx")
       .on(t.family, t.generation, t.entityId)
       .where(corpusIndexProjectionIsBlocked(t.workStatus)),

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
@@ -6,6 +6,7 @@ import {
   corpusIndexConfigFromManifest,
   corpusIndexIdFromManifest,
   corpusIndexManifestDigest,
+  requireCorpusIndexIdForManifest,
   requireCorpusIndexManifest,
 } from "@/api/lib/legal-search/corpus-index-manifest";
 
@@ -123,6 +124,39 @@ test("manifest routing is exact and case-law additions fail closed", () => {
   expect(() =>
     corpusIndexIdFromManifest(CORPUS_INDEX_MANIFESTS.legislation_v2, "cz;drop"),
   ).toThrow("Invalid corpus jurisdiction");
+});
+
+test("physical route validation is exact for closed and open manifests", () => {
+  expect(
+    requireCorpusIndexIdForManifest(
+      CORPUS_INDEX_MANIFESTS.case_law_v5,
+      "case_law_v5_cs_sk",
+    ),
+  ).toBe("case_law_v5_cs_sk");
+  expect(() =>
+    requireCorpusIndexIdForManifest(
+      CORPUS_INDEX_MANIFESTS.case_law_v5,
+      "case_law_v5_hun",
+    ),
+  ).toThrow("Corpus index id is not a manifest route");
+  expect(
+    requireCorpusIndexIdForManifest(
+      CORPUS_INDEX_MANIFESTS.legislation_v2,
+      "legislation_v2_cze",
+    ),
+  ).toBe("legislation_v2_cze");
+  expect(() =>
+    requireCorpusIndexIdForManifest(
+      CORPUS_INDEX_MANIFESTS.legislation_v2,
+      "legislation_v2_CZE",
+    ),
+  ).toThrow("Corpus index id is not a manifest route");
+  expect(() =>
+    requireCorpusIndexIdForManifest(
+      CORPUS_INDEX_MANIFESTS.legislation_v2,
+      "case_law_v5_cze",
+    ),
+  ).toThrow("Corpus index id is not a manifest route");
 });
 
 test("v5 removes stale and repeated physical fields", () => {

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -403,3 +403,41 @@ export const corpusIndexIdFromManifest = (
     ? indexId
     : panic(`Corpus index id exceeds storage limit: ${indexId}`);
 };
+
+/**
+ * Assert that a physical index id is one route of this immutable manifest.
+ * Callers must not accept an arbitrary generation-prefixed string: grouped
+ * case-law routes are closed, while legislation routes are the manifest's
+ * canonical jurisdiction spelling.
+ */
+export const requireCorpusIndexIdForManifest = (
+  manifest: CorpusIndexManifest,
+  indexId: string,
+): string => {
+  switch (manifest.route.type) {
+    case "case_law_group": {
+      const matches = Object.values(manifest.route.byJurisdiction).some(
+        (suffix) => `${manifest.generation}_${suffix}` === indexId,
+      );
+      return matches
+        ? indexId
+        : panic(
+            `Corpus index id is not a manifest route: ${manifest.generation}/${indexId}`,
+          );
+    }
+    case "jurisdiction": {
+      const prefix = `${manifest.generation}_`;
+      const jurisdiction = indexId.startsWith(prefix)
+        ? indexId.slice(prefix.length)
+        : "";
+      return jurisdiction !== "" &&
+        corpusIndexIdFromManifest(manifest, jurisdiction) === indexId
+        ? indexId
+        : panic(
+            `Corpus index id is not a manifest route: ${manifest.generation}/${indexId}`,
+          );
+    }
+    default:
+      return manifest.route satisfies never;
+  }
+};

--- a/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-executor.ts
@@ -18,7 +18,7 @@ import {
   readReservedCorpusProjectionMaterialsTx,
   type CorpusProjectionMaterial,
 } from "@/api/lib/legal-search/corpus-index-projection-materials";
-import type { CorpusProjectionScopedWorkSelection } from "@/api/lib/legal-search/corpus-index-projection-scope";
+import type { CorpusProjectionAppendScopedWorkSelection } from "@/api/lib/legal-search/corpus-index-projection-scope";
 import {
   abandonCorpusProjectionAppendTx,
   cancelCorpusProjectionReservationTx,
@@ -64,7 +64,7 @@ export const CORPUS_PROJECTION_PAYLOAD_READ_CONCURRENCY_MAX = 32;
 
 type ExecuteCorpusProjectionAppendCycleOptions<
   Family extends CorpusProjectionIntentLease["family"],
-> = CorpusProjectionScopedWorkSelection<Family> & {
+> = CorpusProjectionAppendScopedWorkSelection<Family> & {
   runInTransaction: ProjectionTransactionRunner;
   client: ProjectionAppendClient;
   generation: string;

--- a/apps/api/src/lib/legal-search/corpus-index-projection-scope.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-scope.test.ts
@@ -2,11 +2,14 @@ import { expect, test } from "bun:test";
 import { expectTypeOf } from "expect-type";
 
 import { toSafeId, type SafeId } from "@/api/lib/branded-types";
+import { CORPUS_INDEX_MANIFESTS } from "@/api/lib/legal-search/corpus-index-manifest";
 
 import {
   CORPUS_PROJECTION_GENERATION_SCOPE,
   CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT,
   entityIdsForCorpusProjectionWorkScope,
+  indexIdForCorpusProjectionWorkScope,
+  type CorpusProjectionAppendScopedWorkOptions,
   type CorpusProjectionScopedWorkOptions,
 } from "./corpus-index-projection-scope";
 
@@ -36,10 +39,41 @@ test("a subject scope couples entity identities to its family", () => {
   >();
 });
 
+type RouteScope = {
+  family: "case_law";
+  scope: { type: "route"; indexId: string };
+};
+
+test("route scope is available only to append work", () => {
+  expectTypeOf<RouteScope>().toExtend<
+    CorpusProjectionAppendScopedWorkOptions<"case_law">
+  >();
+  expectTypeOf<RouteScope>().not.toExtend<
+    CorpusProjectionScopedWorkOptions<"case_law">
+  >();
+});
+
 test("a generation scope has no entity predicate", () => {
   expect(
     entityIdsForCorpusProjectionWorkScope(CORPUS_PROJECTION_GENERATION_SCOPE),
   ).toBeNull();
+});
+
+test("a route scope has one manifest-validated physical predicate", () => {
+  const scope = { type: "route", indexId: "case_law_v5_pol" } as const;
+  expect(entityIdsForCorpusProjectionWorkScope(scope)).toBeNull();
+  expect(
+    indexIdForCorpusProjectionWorkScope(
+      scope,
+      CORPUS_INDEX_MANIFESTS.case_law_v5,
+    ),
+  ).toBe("case_law_v5_pol");
+  expect(() =>
+    indexIdForCorpusProjectionWorkScope(
+      { type: "route", indexId: "case_law_v5_hun" },
+      CORPUS_INDEX_MANIFESTS.case_law_v5,
+    ),
+  ).toThrow("Corpus index id is not a manifest route");
 });
 
 test("a subject scope preserves its exact identities", () => {

--- a/apps/api/src/lib/legal-search/corpus-index-projection-scope.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-scope.ts
@@ -1,6 +1,10 @@
 import { panic } from "better-result";
 
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
+import {
+  type CorpusIndexManifest,
+  requireCorpusIndexIdForManifest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
 import type { CorpusIndexProjectionSubject } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 
 export const CORPUS_PROJECTION_WORK_SCOPE_MAX_ENTITY_COUNT = 256;
@@ -21,9 +25,18 @@ export type CorpusProjectionWorkScope<Family extends CorpusFamily> =
       entityIds: readonly CorpusProjectionEntityId<Family>[];
     };
 
-export type CorpusProjectionScopedWorkSelection<Family extends CorpusFamily> = {
+export type CorpusProjectionAppendWorkScope<Family extends CorpusFamily> =
+  | CorpusProjectionWorkScope<Family>
+  | {
+      type: "route";
+      indexId: string;
+    };
+
+export type CorpusProjectionAppendScopedWorkSelection<
+  Family extends CorpusFamily,
+> = {
   family: Family;
-  scope: CorpusProjectionWorkScope<NoInfer<Family>>;
+  scope: CorpusProjectionAppendWorkScope<NoInfer<Family>>;
 };
 
 export type CorpusProjectionScopedWorkOptions<Family extends CorpusFamily> = {
@@ -31,18 +44,26 @@ export type CorpusProjectionScopedWorkOptions<Family extends CorpusFamily> = {
   scope?: CorpusProjectionWorkScope<NoInfer<Family>>;
 };
 
+export type CorpusProjectionAppendScopedWorkOptions<
+  Family extends CorpusFamily,
+> = {
+  family: Family;
+  scope?: CorpusProjectionAppendWorkScope<NoInfer<Family>>;
+};
+
 /**
- * Return null for a generation walk or the exact bounded subject set. Callers
- * place the returned IDs in the same SQL statement that claims work, so an
- * allowlist check can never race a later broad claim.
+ * Return null for generation and route walks, or the exact bounded subject
+ * set. Callers place the returned IDs in the same SQL statement that claims
+ * work, so an allowlist check can never race a later broad claim.
  */
 export const entityIdsForCorpusProjectionWorkScope = <
   Family extends CorpusFamily,
 >(
-  scope: CorpusProjectionWorkScope<Family>,
+  scope: CorpusProjectionAppendWorkScope<Family>,
 ): CorpusProjectionEntityId<Family>[] | null => {
   switch (scope.type) {
     case "generation":
+    case "route":
       return null;
     case "subjects":
       if (
@@ -56,6 +77,29 @@ export const entityIdsForCorpusProjectionWorkScope = <
         );
       }
       return [...scope.entityIds];
+    default:
+      return scope satisfies never;
+  }
+};
+
+/**
+ * Return the manifest-validated route predicate, or null when the scope is
+ * not physical-route scoped. Validation runs against the registered manifest
+ * read in the claiming transaction; Plane can select policy, but cannot
+ * invent a physical index id.
+ */
+export const indexIdForCorpusProjectionWorkScope = <
+  Family extends CorpusFamily,
+>(
+  scope: CorpusProjectionAppendWorkScope<Family>,
+  manifest: CorpusIndexManifest,
+): string | null => {
+  switch (scope.type) {
+    case "generation":
+    case "subjects":
+      return null;
+    case "route":
+      return requireCorpusIndexIdForManifest(manifest, scope.indexId);
     default:
       return scope satisfies never;
   }

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -71,6 +71,13 @@ const SECOND_LEASE_TOKEN = "0198e331-e578-7000-8000-000000000207";
 const ERASE_DECISION_ID = toSafeId<"caseLawDecision">(
   "0198e331-e578-7000-8000-000000000208",
 );
+const POL_DECISION_ID = toSafeId<"caseLawDecision">(
+  "0198e331-e578-7000-8000-000000000214",
+);
+const POL_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000215",
+);
+const POL_LEASE_TOKEN = "0198e331-e578-7000-8000-000000000216";
 const ERASE_READY_DECISION_ID = toSafeId<"caseLawDecision">(
   "0198e331-e578-7000-8000-000000000213",
 );
@@ -82,6 +89,7 @@ const ERASE_CLEANUP_TOKEN = "0198e331-e578-7000-8000-000000000211";
 const FIRST_FINGERPRINT = "a".repeat(64);
 const SECOND_FINGERPRINT = "b".repeat(64);
 const INDEX_ID = "case_law_v5_cs_sk";
+const POL_INDEX_ID = "case_law_v5_pol";
 const INITIAL_RUNNABLE_AT = new Date("2026-08-25T00:00:00.000Z");
 const DRIZZLE_DIR = new URL("../../../drizzle/", import.meta.url);
 
@@ -276,6 +284,67 @@ test("a subject-scoped reservation cannot claim another pending decision", async
       .select({ entityId: corpusIndexProjectionIntents.entityId })
       .from(corpusIndexProjectionIntents),
   ).toEqual([{ entityId: ERASE_DECISION_ID }]);
+});
+
+test("a route-scoped reservation claims only its desired physical index", async () => {
+  await db.insert(caseLawDecisions).values({
+    id: POL_DECISION_ID,
+    sourceId: SOURCE_ID,
+    caseNumber: "III SA/Wa 1/2026",
+    court: "Test court",
+    country: "POL",
+    language: "pl",
+    contentHash: "d".repeat(64),
+    projectionEpoch: 1n,
+  });
+  await db.insert(corpusIndexProjectionStates).values({
+    family: "case_law",
+    generation: "case_law_v5",
+    entityId: POL_DECISION_ID,
+    desiredAction: "upsert",
+    desiredEpoch: 1n,
+    desiredFingerprint: SECOND_FINGERPRINT,
+    desiredIndexId: POL_INDEX_ID,
+    updatedAt: INITIAL_RUNNABLE_AT,
+  });
+
+  const leases = await db.transaction(
+    async (tx) =>
+      await reserveCorpusProjectionIntentsTx(asTestRaw<Transaction>(tx), {
+        family: "case_law",
+        generation: "case_law_v5",
+        scope: { type: "route", indexId: POL_INDEX_ID },
+        limit: 10,
+        leaseMs: 60_000,
+        newIntentId: () => POL_INTENT_ID,
+        newLeaseToken: () => POL_LEASE_TOKEN,
+      }),
+  );
+
+  expect(
+    leases.map(({ entityId, indexId }) => ({ entityId, indexId })),
+  ).toEqual([{ entityId: POL_DECISION_ID, indexId: POL_INDEX_ID }]);
+  expect(
+    await db
+      .select({ entityId: corpusIndexProjectionIntents.entityId })
+      .from(corpusIndexProjectionIntents),
+  ).toEqual([{ entityId: POL_DECISION_ID }]);
+});
+
+test("an unregistered route fails before reservation mutates state", async () => {
+  await expect(
+    db.transaction(
+      async (tx) =>
+        await reserveCorpusProjectionIntentsTx(asTestRaw<Transaction>(tx), {
+          family: "case_law",
+          generation: "case_law_v5",
+          scope: { type: "route", indexId: "case_law_v5_hun" },
+          limit: 10,
+          leaseMs: 60_000,
+        }),
+    ),
+  ).rejects.toThrow("Corpus index id is not a manifest route");
+  expect(await db.select().from(corpusIndexProjectionIntents)).toEqual([]);
 });
 
 test("a subject-scoped erasure cannot apply another erased decision", async () => {
@@ -632,6 +701,69 @@ test("subject-scoped replacement cannot retire another applied revision", async 
     { id: FIRST_INTENT_ID, status: "applied" },
     { id: SECOND_INTENT_ID, status: "cleanup_pending" },
   ]);
+});
+
+test("a rerouted replacement is owned by its desired route", async () => {
+  const appliedAt = new Date("2026-08-25T00:00:00.000Z");
+  await db.execute(
+    sql`ALTER TABLE corpus_index_projection_intents DISABLE TRIGGER corpus_index_projection_intents_insert_guard`,
+  );
+  await db.insert(corpusIndexProjectionIntents).values({
+    id: FIRST_INTENT_ID,
+    family: "case_law",
+    generation: "case_law_v5",
+    entityId: DECISION_ID,
+    epoch: 1n,
+    fingerprint: FIRST_FINGERPRINT,
+    indexId: INDEX_ID,
+    status: "applied",
+    appendStartedAt: appliedAt,
+    appendCommittedAt: appliedAt,
+    expectedDocumentCount: 1,
+    appliedAt,
+  });
+  await db.execute(
+    sql`ALTER TABLE corpus_index_projection_intents ENABLE TRIGGER corpus_index_projection_intents_insert_guard`,
+  );
+  await db
+    .update(corpusIndexProjectionStates)
+    .set({
+      desiredEpoch: 2n,
+      desiredFingerprint: SECOND_FINGERPRINT,
+      desiredIndexId: POL_INDEX_ID,
+      appliedAction: "upsert",
+      appliedEpoch: 1n,
+      appliedRevision: FIRST_INTENT_ID,
+      appliedFingerprint: FIRST_FINGERPRINT,
+      appliedIndexId: INDEX_ID,
+      appliedAt,
+    })
+    .where(eq(corpusIndexProjectionStates.entityId, DECISION_ID));
+
+  const replacements = await db.transaction(
+    async (tx) =>
+      await prepareCorpusProjectionReplacementsTx(asTestRaw<Transaction>(tx), {
+        family: "case_law",
+        generation: "case_law_v5",
+        scope: { type: "route", indexId: POL_INDEX_ID },
+        limit: 10,
+      }),
+  );
+
+  expect(replacements).toEqual([
+    {
+      intentId: FIRST_INTENT_ID,
+      family: "case_law",
+      generation: "case_law_v5",
+      entityId: DECISION_ID,
+      indexId: INDEX_ID,
+    },
+  ]);
+  expect(
+    await db
+      .select({ status: corpusIndexProjectionIntents.status })
+      .from(corpusIndexProjectionIntents),
+  ).toEqual([{ status: "cleanup_pending" }]);
 });
 
 test("retry classification defers poison work, then blocks the exhausted desired state", async () => {

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -332,18 +332,25 @@ test("a route-scoped reservation claims only its desired physical index", async 
 });
 
 test("an unregistered route fails before reservation mutates state", async () => {
-  await expect(
-    db.transaction(
-      async (tx) =>
-        reserveCorpusProjectionIntentsTx(asTestRaw<Transaction>(tx), {
-          family: "case_law",
-          generation: "case_law_v5",
-          scope: { type: "route", indexId: "case_law_v5_hun" },
-          limit: 10,
-          leaseMs: 60_000,
-        }),
-    ),
-  ).rejects.toThrow("Corpus index id is not a manifest route");
+  // bun-types declares `.rejects.toThrow` as void, so awaiting it trips
+  // type-aware lint; capture the rejection explicitly instead.
+  const rejection: unknown = await db
+    .transaction(async (tx) =>
+      reserveCorpusProjectionIntentsTx(asTestRaw<Transaction>(tx), {
+        family: "case_law",
+        generation: "case_law_v5",
+        scope: { type: "route", indexId: "case_law_v5_hun" },
+        limit: 10,
+        leaseMs: 60_000,
+      }),
+    )
+    .then(
+      () => null,
+      (error: unknown) => error,
+    );
+  expect(rejection).toMatchObject({
+    message: "Corpus index id is not a manifest route",
+  });
   expect(await db.select().from(corpusIndexProjectionIntents)).toEqual([]);
 });
 

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -335,7 +335,7 @@ test("an unregistered route fails before reservation mutates state", async () =>
   await expect(
     db.transaction(
       async (tx) =>
-        await reserveCorpusProjectionIntentsTx(asTestRaw<Transaction>(tx), {
+        reserveCorpusProjectionIntentsTx(asTestRaw<Transaction>(tx), {
           family: "case_law",
           generation: "case_law_v5",
           scope: { type: "route", indexId: "case_law_v5_hun" },

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -655,10 +655,6 @@ test("subject-scoped replacement cannot retire another applied revision", async 
     .set({ projectionEpoch: 2n })
     .where(eq(caseLawDecisions.id, DECISION_ID));
   await db
-    .update(caseLawDecisions)
-    .set({ projectionEpoch: 2n })
-    .where(eq(caseLawDecisions.id, DECISION_ID));
-  await db
     .update(corpusIndexProjectionStates)
     .set({
       desiredEpoch: 2n,
@@ -737,6 +733,10 @@ test("a rerouted replacement is owned by its desired route", async () => {
   await db.execute(
     sql`ALTER TABLE corpus_index_projection_intents ENABLE TRIGGER corpus_index_projection_intents_insert_guard`,
   );
+  await db
+    .update(caseLawDecisions)
+    .set({ projectionEpoch: 2n })
+    .where(eq(caseLawDecisions.id, DECISION_ID));
   await db
     .update(corpusIndexProjectionStates)
     .set({

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -349,7 +349,8 @@ test("an unregistered route fails before reservation mutates state", async () =>
       (error: unknown) => error,
     );
   expect(rejection).toMatchObject({
-    message: "Corpus index id is not a manifest route",
+    message:
+      "Corpus index id is not a manifest route: case_law_v5/case_law_v5_hun",
   });
   expect(await db.select().from(corpusIndexProjectionIntents)).toEqual([]);
 });
@@ -649,6 +650,10 @@ test("subject-scoped replacement cannot retire another applied revision", async 
   await db.execute(
     sql`ALTER TABLE corpus_index_projection_intents ENABLE TRIGGER corpus_index_projection_intents_insert_guard`,
   );
+  await db
+    .update(caseLawDecisions)
+    .set({ projectionEpoch: 2n })
+    .where(eq(caseLawDecisions.id, DECISION_ID));
   await db
     .update(caseLawDecisions)
     .set({ projectionEpoch: 2n })

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
@@ -21,7 +21,8 @@ import {
 import {
   CORPUS_PROJECTION_GENERATION_SCOPE,
   entityIdsForCorpusProjectionWorkScope,
-  type CorpusProjectionScopedWorkOptions,
+  indexIdForCorpusProjectionWorkScope,
+  type CorpusProjectionAppendScopedWorkOptions,
 } from "@/api/lib/legal-search/corpus-index-projection-scope";
 import { corpusIndexProjectionNeedsWork } from "@/api/lib/legal-search/corpus-index-projection-sql";
 
@@ -45,7 +46,7 @@ export type CorpusProjectionIntentLease = {
 };
 
 type ReserveCorpusProjectionIntentsOptions<Family extends CorpusFamily> =
-  CorpusProjectionScopedWorkOptions<Family> & {
+  CorpusProjectionAppendScopedWorkOptions<Family> & {
     generation: string;
     limit: number;
     leaseMs: number;
@@ -138,7 +139,13 @@ export const reserveCorpusProjectionIntentsTx = async <
   const limit = validateBatchSize(requestedLimit);
   const leaseMs = validateLeaseMs(requestedLeaseMs);
   const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
-  await readActiveCorpusProjectionManifest(tx, family, generation, true);
+  const manifest = await readActiveCorpusProjectionManifest(
+    tx,
+    family,
+    generation,
+    true,
+  );
+  const scopedIndexId = indexIdForCorpusProjectionWorkScope(scope, manifest);
   const eligibilityAt = testNow ?? (await readPostgresClock(tx));
   const runnableAt = sql<Date>`coalesce(
     ${corpusIndexProjectionStates.retryNotBefore},
@@ -170,6 +177,9 @@ export const reserveCorpusProjectionIntentsTx = async <
         scopedEntityIds === null
           ? undefined
           : inArray(corpusIndexProjectionStates.entityId, scopedEntityIds),
+        scopedIndexId === null
+          ? undefined
+          : eq(corpusIndexProjectionStates.desiredIndexId, scopedIndexId),
         eq(corpusIndexProjectionStates.desiredAction, "upsert"),
         inArray(corpusIndexProjectionStates.workStatus, [
           "eligible",
@@ -288,7 +298,7 @@ export type CorpusProjectionReplacementCleanup = {
 };
 
 type PrepareCorpusProjectionReplacementsOptions<Family extends CorpusFamily> =
-  CorpusProjectionScopedWorkOptions<Family> & {
+  CorpusProjectionAppendScopedWorkOptions<Family> & {
     generation: string;
     limit: number;
     testNow?: Date;
@@ -313,7 +323,13 @@ export const prepareCorpusProjectionReplacementsTx = async <
 ): Promise<CorpusProjectionReplacementCleanup[]> => {
   const limit = validateBatchSize(requestedLimit);
   const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
-  await readActiveCorpusProjectionManifest(tx, family, generation, true);
+  const manifest = await readActiveCorpusProjectionManifest(
+    tx,
+    family,
+    generation,
+    true,
+  );
+  const scopedIndexId = indexIdForCorpusProjectionWorkScope(scope, manifest);
   const candidates = await tx
     .select({
       intentId: corpusIndexProjectionStates.appliedRevision,
@@ -328,6 +344,9 @@ export const prepareCorpusProjectionReplacementsTx = async <
         scopedEntityIds === null
           ? undefined
           : inArray(corpusIndexProjectionStates.entityId, scopedEntityIds),
+        scopedIndexId === null
+          ? undefined
+          : eq(corpusIndexProjectionStates.desiredIndexId, scopedIndexId),
         eq(corpusIndexProjectionStates.desiredAction, "upsert"),
         eq(corpusIndexProjectionStates.appliedAction, "upsert"),
         isNotNull(corpusIndexProjectionStates.appliedRevision),


### PR DESCRIPTION
## Summary

- add manifest-validated physical-route scope to corpus projection append and replacement claims
- keep route scope unavailable to erasure and cleanup primitives
- add an online partial queue index for route-scoped claims
- prove route isolation, fail-closed validation, and reroute cleanup ownership

## Validation

- targeted manifest and scope tests: 14 passed
- staged format, lint, and secret checks passed
- full affected checks delegated to CI

CC on behalf of sok0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added route-specific processing for corpus index updates, allowing work to target a selected physical index.
  - Added validation to ensure only recognised manifest routes can be selected.
  - Improved handling of rerouted content so records associated with a previous index are correctly marked for cleanup.

- **Performance**
  - Improved processing efficiency by prioritising pending updates for the requested route and retry age.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->