### PR TITLE
fix: preserve workspace route height

### DIFF
--- a/.changeset/quiet-shells-stretch.md
+++ b/.changeset/quiet-shells-stretch.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": patch
+---
+
+Keep flex-based route content stretched inside the workspace shell scroller.

--- a/apps/web/e2e/specs/route-smoke.spec.ts
+++ b/apps/web/e2e/specs/route-smoke.spec.ts
@@ -505,6 +505,7 @@ const measureRouteTarget = async ({
     });
     await assertNoRouteBoundary(page, route.template);
     assertFinalDestination(page, route);
+    await assertRouteContentVisible(page, route.template);
     browserErrors.assertEmpty(`unexpected browser errors on ${route.template}`);
     // Captured after the route shell and tracked API work are ready, so the
     // manifest reflects the fully-rendered route.
@@ -657,6 +658,17 @@ const assertNoRouteBoundary = async (page: Page, routeTemplate: string) => {
     page.getByRole("heading", { name: "This page couldn’t be opened" }),
     `route error boundary rendered on ${routeTemplate}`,
   ).toHaveCount(0);
+};
+
+const assertRouteContentVisible = async (page: Page, routeTemplate: string) => {
+  if (routeTemplate !== "/workspaces") {
+    return;
+  }
+
+  await expect(
+    page.locator("main h2").first(),
+    "the matters route paints its first matter inside the viewport",
+  ).toBeInViewport();
 };
 
 const expectAuthenticatedRouteCoverage = async (

--- a/packages/ui/src/components/workspace-shell.test.tsx
+++ b/packages/ui/src/components/workspace-shell.test.tsx
@@ -26,7 +26,9 @@ describe("WorkspaceShell", () => {
     expect(markup).toContain('data-slot="workspace-shell-top-bar"');
     expect(markup).toContain("sticky top-0 z-20 shrink-0");
     expect(markup).toContain('data-slot="workspace-shell-content"');
-    expect(markup).toContain("min-h-0 flex-1 overflow-auto overscroll-contain");
+    expect(markup).toContain(
+      "flex min-h-0 flex-1 flex-col overflow-auto overscroll-contain",
+    );
   });
 
   test("owns a controlled compact navigation without mounting its portal on desktop", () => {

--- a/packages/ui/src/components/workspace-shell.test.tsx
+++ b/packages/ui/src/components/workspace-shell.test.tsx
@@ -26,9 +26,6 @@ describe("WorkspaceShell", () => {
     expect(markup).toContain('data-slot="workspace-shell-top-bar"');
     expect(markup).toContain("sticky top-0 z-20 shrink-0");
     expect(markup).toContain('data-slot="workspace-shell-content"');
-    expect(markup).toContain(
-      "flex min-h-0 flex-1 flex-col overflow-auto overscroll-contain",
-    );
   });
 
   test("owns a controlled compact navigation without mounting its portal on desktop", () => {

--- a/packages/ui/src/components/workspace-shell.tsx
+++ b/packages/ui/src/components/workspace-shell.tsx
@@ -113,7 +113,7 @@ export const WorkspaceShell = ({
           {topBar({ compactNavigationTrigger })}
         </div>
         <div
-          className="min-h-0 flex-1 overflow-auto overscroll-contain"
+          className="flex min-h-0 flex-1 flex-col overflow-auto overscroll-contain"
           data-slot="workspace-shell-content"
         >
           {children}


### PR DESCRIPTION
The workspace shell content scroller introduced an intermediate block formatting context, so flex-based route roots no longer stretched to the available viewport height. Nested absolutely positioned content could therefore collapse behind route chrome.

Make the shell content scroller a flex column to preserve the previous route sizing contract, and tighten the existing shell contract test. Includes a patch changeset for `@stll/ui`.