### PR TITLE
fix: scope migration merge gate to Stella

### DIFF
--- a/scripts/merge-bar.test.ts
+++ b/scripts/merge-bar.test.ts
@@ -50,7 +50,7 @@ const failedGate = (snapshot: MergeBarSnapshot) => {
 };
 
 describe("merge bar", () => {
-  test("applies Stella's migration-order gate only to its owning repository", () => {
+  test("applies stella's migration-order gate only to its owning repository", () => {
     expect(mergeBarMigrationDirectory("stella/stella")).toBe(
       "apps/api/drizzle",
     );

--- a/scripts/merge-bar.test.ts
+++ b/scripts/merge-bar.test.ts
@@ -54,6 +54,9 @@ describe("merge bar", () => {
     expect(mergeBarMigrationDirectory("stella/stella")).toBe(
       "apps/api/drizzle",
     );
+    expect(mergeBarMigrationDirectory("Stella/Stella")).toBe(
+      "apps/api/drizzle",
+    );
     expect(mergeBarMigrationDirectory("stella/stella-infra")).toBeNull();
     expect(mergeBarMigrationDirectory("stella/stella-plane")).toBeNull();
   });

--- a/scripts/merge-bar.test.ts
+++ b/scripts/merge-bar.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { evaluateMergeBar, type MergeBarSnapshot } from "./merge-bar";
+import {
+  evaluateMergeBar,
+  mergeBarMigrationDirectory,
+  type MergeBarSnapshot,
+} from "./merge-bar";
 
 const HEAD_SHA = "1f0c3a7d9e5b4c2a8d6f0e1b3c5a7d9e5b4c2a8d";
 const OTHER_SHA = "9e5b4c2a8d6f0e1b3c5a7d9e5b4c2a8d6f0e1b3c";
@@ -46,6 +50,14 @@ const failedGate = (snapshot: MergeBarSnapshot) => {
 };
 
 describe("merge bar", () => {
+  test("applies Stella's migration-order gate only to its owning repository", () => {
+    expect(mergeBarMigrationDirectory("stella/stella")).toBe(
+      "apps/api/drizzle",
+    );
+    expect(mergeBarMigrationDirectory("stella/stella-infra")).toBeNull();
+    expect(mergeBarMigrationDirectory("stella/stella-plane")).toBeNull();
+  });
+
   test("merges when every gate is positively satisfied", () => {
     const verdict = evaluateMergeBar(passingSnapshot());
 

--- a/scripts/merge-bar.ts
+++ b/scripts/merge-bar.ts
@@ -68,6 +68,9 @@ const MERGE_COMMIT_POLL_ATTEMPTS = 5;
 const CONTENTS_ENDPOINT_ENTRY_LIMIT = 1000;
 const PULL_NUMBER_PATTERN = /^\d+$/u;
 
+export const mergeBarMigrationDirectory = (repo: string): string | null =>
+  repo === DEFAULT_REPO ? MIGRATION_DIRECTORY : null;
+
 // --- Gate model -------------------------------------------------------------
 
 const GATE_IDS = [
@@ -674,9 +677,13 @@ const createGhGateway = ({
         ),
         "sha",
       );
+      const migrationDirectory = mergeBarMigrationDirectory(repo);
+      if (migrationDirectory === null) {
+        return { baseDirectories: [], addedDirectories: [], baseSha };
+      }
       const baseDirectories = runGh([
         "api",
-        `repos/${repo}/contents/${MIGRATION_DIRECTORY}?ref=${baseSha}`,
+        `repos/${repo}/contents/${migrationDirectory}?ref=${baseSha}`,
         "--jq",
         '.[] | select(.type == "dir") | .name',
       ])
@@ -687,7 +694,7 @@ const createGhGateway = ({
       // pass on the exact ordering it exists to catch, so refuse instead.
       if (baseDirectories.length >= CONTENTS_ENDPOINT_ENTRY_LIMIT) {
         panic(
-          `${MIGRATION_DIRECTORY} has ${baseDirectories.length} entries at ` +
+          `${migrationDirectory} has ${baseDirectories.length} entries at ` +
             `${baseSha}, at or past the contents endpoint's ` +
             `${CONTENTS_ENDPOINT_ENTRY_LIMIT}-entry limit. The listing may be ` +
             "truncated; switch this gate to the git tree API before merging.",
@@ -704,7 +711,7 @@ const createGhGateway = ({
         .split("\n")
         .filter(
           (file) =>
-            file.startsWith(`${MIGRATION_DIRECTORY}/`) &&
+            file.startsWith(`${migrationDirectory}/`) &&
             file.endsWith("/migration.sql"),
         )
         .map((file) => file.slice(0, file.lastIndexOf("/")));

--- a/scripts/merge-bar.ts
+++ b/scripts/merge-bar.ts
@@ -69,7 +69,7 @@ const CONTENTS_ENDPOINT_ENTRY_LIMIT = 1000;
 const PULL_NUMBER_PATTERN = /^\d+$/u;
 
 export const mergeBarMigrationDirectory = (repo: string): string | null =>
-  repo === DEFAULT_REPO ? MIGRATION_DIRECTORY : null;
+  repo.toLowerCase() === DEFAULT_REPO ? MIGRATION_DIRECTORY : null;
 
 // --- Gate model -------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- keep the migration-order gate bound to the repository that owns `apps/api/drizzle`
- preserve base/head stability, checks, and review-thread gates for `--repo` targets
- cover Stella, Plane, and infra repository selection

## Validation

- targeted `oxfmt`
- `git diff --check`
- remote CI is authoritative for the focused Bun test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Migration-order checks now run only for the repository that owns the migration files.
  - Infrastructure and deployment repositories are no longer incorrectly evaluated against application migration directories.
  - This prevents unrelated repositories from producing misleading migration warnings or failures.
- **Tests**
  - Added coverage to verify correct repository-specific behaviour and ensure non-owning repositories are skipped safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->