### PR TITLE
feat: publish responsive workspace toolbar

### DIFF
--- a/.changeset/strong-toolbar-slots.md
+++ b/.changeset/strong-toolbar-slots.md
@@ -3,4 +3,5 @@
 "@stll/ui": patch
 ---
 
-Expose the responsive action toolbar for compact workspace controls.
+Expose the responsive action toolbar for compact workspace controls and allow
+single-purpose shells to omit a compact navigation trigger.

--- a/.changeset/strong-toolbar-slots.md
+++ b/.changeset/strong-toolbar-slots.md
@@ -1,0 +1,5 @@
+---
+"@stll/workspace-ui": minor
+---
+
+Expose the responsive action toolbar for compact workspace controls.

--- a/.changeset/strong-toolbar-slots.md
+++ b/.changeset/strong-toolbar-slots.md
@@ -1,5 +1,6 @@
 ---
 "@stll/workspace-ui": minor
+"@stll/ui": patch
 ---
 
 Expose the responsive action toolbar for compact workspace controls.

--- a/apps/web/src/components/responsive-action-toolbar.tsx
+++ b/apps/web/src/components/responsive-action-toolbar.tsx
@@ -1,37 +1,5 @@
-import type * as React from "react";
-
-import { cn } from "@stll/ui/utils";
-
-export type ResponsiveActionToolbarSlot = "primary" | "secondary" | "action";
-
-const RESPONSIVE_ACTION_TOOLBAR_SLOT_CLASS = {
-  primary:
-    "order-1 min-w-0 basis-full sm:order-none sm:min-w-56 sm:basis-0 sm:flex-1",
-  secondary: "order-2 min-w-0 flex-1 sm:order-none sm:flex-none",
-  action: "order-3 shrink-0 sm:order-none",
-} as const satisfies Record<ResponsiveActionToolbarSlot, string>;
-
-export const ResponsiveActionToolbar = ({
-  className,
-  ...props
-}: React.ComponentProps<"div">) => (
-  <div
-    className={cn("flex flex-wrap items-center gap-2", className)}
-    {...props}
-  />
-);
-
-type ResponsiveActionToolbarItemProps = React.PropsWithChildren<{
-  slot: ResponsiveActionToolbarSlot;
-  className?: string | undefined;
-}>;
-
-export const ResponsiveActionToolbarItem = ({
-  slot,
-  className,
-  children,
-}: ResponsiveActionToolbarItemProps) => (
-  <div className={cn(RESPONSIVE_ACTION_TOOLBAR_SLOT_CLASS[slot], className)}>
-    {children}
-  </div>
-);
+export {
+  ResponsiveActionToolbar,
+  ResponsiveActionToolbarItem,
+} from "@stll/workspace-ui/responsive-action-toolbar";
+export type { ResponsiveActionToolbarSlot } from "@stll/workspace-ui/responsive-action-toolbar";

--- a/packages/ui/src/components/workspace-shell.test.tsx
+++ b/packages/ui/src/components/workspace-shell.test.tsx
@@ -57,6 +57,34 @@ describe("WorkspaceShell", () => {
     expect(markup).not.toContain("Compact navigation");
     expect(markup).not.toContain('data-slot="sheet-backdrop"');
   });
+
+  test("does not render a dead compact trigger when the host has no compact navigation", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceShell
+        endDock={<aside>Inspector</aside>}
+        navigation={{
+          compact: {
+            content: <nav>Compact navigation</nav>,
+            label: "Open navigation",
+            onOpenChange: () => undefined,
+            open: false,
+            trigger: null,
+          },
+          desktop: <nav data-test="desktop-navigation">Desktop</nav>,
+          mode: "shell-managed",
+        }}
+        topBar={({ compactNavigationTrigger }) => (
+          <header>{compactNavigationTrigger}Header</header>
+        )}
+      >
+        <article>Content</article>
+      </WorkspaceShell>,
+    );
+
+    expect(markup).toContain('data-test="desktop-navigation"');
+    expect(markup).toContain("Header");
+    expect(markup).not.toContain('aria-label="Open navigation"');
+  });
 });
 
 describe("WorkspaceEndRail", () => {

--- a/packages/ui/src/components/workspace-shell.tsx
+++ b/packages/ui/src/components/workspace-shell.tsx
@@ -25,8 +25,8 @@ type WorkspaceCompactNavigation = {
   open: boolean;
   /** Receives close gestures, Escape, backdrop presses, and viewport changes. */
   onOpenChange: (open: boolean) => void;
-  /** Host-styled button; Stella supplies trigger behavior and accessibility. */
-  trigger: ReactElement;
+  /** Host-styled button; null disables compact navigation for single-purpose hosts. */
+  trigger: ReactElement | null;
 };
 
 type WorkspaceNavigation =
@@ -82,7 +82,7 @@ export const WorkspaceShell = ({
   }, [compactNavigationOpen, isCompact, onCompactNavigationOpenChange]);
 
   const compactNavigationTrigger =
-    compactNavigation === null ? null : (
+    compactNavigation === null || compactNavigation.trigger === null ? null : (
       <span className="contents md:hidden">
         <SheetTrigger
           aria-label={compactNavigation.label}

--- a/packages/ui/src/components/workspace-shell.tsx
+++ b/packages/ui/src/components/workspace-shell.tsx
@@ -82,7 +82,7 @@ export const WorkspaceShell = ({
   }, [compactNavigationOpen, isCompact, onCompactNavigationOpenChange]);
 
   const compactNavigationTrigger =
-    compactNavigation === null || compactNavigation.trigger === null ? null : (
+    compactNavigation?.trigger === null || compactNavigation === null ? null : (
       <span className="contents md:hidden">
         <SheetTrigger
           aria-label={compactNavigation.label}

--- a/packages/workspace-ui/README.md
+++ b/packages/workspace-ui/README.md
@@ -26,10 +26,16 @@ import { ConditionBuilder } from "@stll/workspace-ui/conditions";
 import { FieldValue } from "@stll/workspace-ui/field-value";
 import { SortChips } from "@stll/workspace-ui/sorts";
 import { WorkspaceViewSwitcher } from "@stll/workspace-ui/view-switcher";
+import {
+  ResponsiveActionToolbar,
+  ResponsiveActionToolbarItem,
+} from "@stll/workspace-ui/responsive-action-toolbar";
 ```
 
 The package also exposes a root entry for code that uses several workspace
-surfaces together. The subpaths remain the clearest way to declare a module's
+surfaces together. Focused modules, including the responsive action toolbar,
+are intentionally available through explicit subpaths; use those subpaths to
+declare a module's
 boundary.
 
 ## Development

--- a/packages/workspace-ui/package.json
+++ b/packages/workspace-ui/package.json
@@ -39,6 +39,7 @@
     "./kanban-grouping-picker": "./src/kanban-grouping-picker.tsx",
     "./kanban-view": "./src/kanban-view.ts",
     "./property-icon": "./src/property-icon.tsx",
+    "./responsive-action-toolbar": "./src/responsive-action-toolbar.tsx",
     "./sorts": "./src/sorts.tsx",
     "./table-skeleton-rows": "./src/table-skeleton-rows.tsx",
     "./types": "./src/types.ts",

--- a/packages/workspace-ui/src/index.ts
+++ b/packages/workspace-ui/src/index.ts
@@ -113,6 +113,11 @@ export type {
 } from "./kanban-view";
 export { WorkspaceKanbanGroupingPicker } from "./kanban-grouping-picker";
 export { WorkspaceViewSwitcher } from "./view-switcher";
+export {
+  ResponsiveActionToolbar,
+  ResponsiveActionToolbarItem,
+} from "./responsive-action-toolbar";
+export type { ResponsiveActionToolbarSlot } from "./responsive-action-toolbar";
 export type {
   WorkspaceViewSwitcherEditing,
   WorkspaceViewSwitcherItem,

--- a/packages/workspace-ui/src/index.ts
+++ b/packages/workspace-ui/src/index.ts
@@ -113,11 +113,6 @@ export type {
 } from "./kanban-view";
 export { WorkspaceKanbanGroupingPicker } from "./kanban-grouping-picker";
 export { WorkspaceViewSwitcher } from "./view-switcher";
-export {
-  ResponsiveActionToolbar,
-  ResponsiveActionToolbarItem,
-} from "./responsive-action-toolbar";
-export type { ResponsiveActionToolbarSlot } from "./responsive-action-toolbar";
 export type {
   WorkspaceViewSwitcherEditing,
   WorkspaceViewSwitcherItem,

--- a/packages/workspace-ui/src/responsive-action-toolbar.test.tsx
+++ b/packages/workspace-ui/src/responsive-action-toolbar.test.tsx
@@ -1,0 +1,33 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ResponsiveActionToolbar,
+  ResponsiveActionToolbarItem,
+} from "./responsive-action-toolbar";
+
+describe("ResponsiveActionToolbar", () => {
+  test("keeps primary, secondary, and action slots in one responsive row", () => {
+    const markup = renderToStaticMarkup(
+      <ResponsiveActionToolbar aria-label="Workspace actions">
+        <ResponsiveActionToolbarItem slot="primary">
+          <input aria-label="Search" />
+        </ResponsiveActionToolbarItem>
+        <ResponsiveActionToolbarItem slot="secondary">
+          <button type="button">Filter</button>
+        </ResponsiveActionToolbarItem>
+        <ResponsiveActionToolbarItem slot="action">
+          <button type="button">More</button>
+        </ResponsiveActionToolbarItem>
+      </ResponsiveActionToolbar>,
+    );
+
+    expect(markup).toContain('aria-label="Workspace actions"');
+    expect(markup).toContain("basis-full");
+    expect(markup).toContain("sm:flex-none");
+    expect(markup).toContain("Search");
+    expect(markup).toContain("Filter");
+    expect(markup).toContain("More");
+  });
+});

--- a/packages/workspace-ui/src/responsive-action-toolbar.test.tsx
+++ b/packages/workspace-ui/src/responsive-action-toolbar.test.tsx
@@ -24,8 +24,8 @@ describe("ResponsiveActionToolbar", () => {
     );
 
     expect(markup).toContain('aria-label="Workspace actions"');
-    expect(markup).toContain("basis-full");
-    expect(markup).toContain("sm:flex-none");
+    expect(markup).toContain("flex-nowrap");
+    expect(markup).toContain("overflow-x-auto");
     expect(markup).toContain("Search");
     expect(markup).toContain("Filter");
     expect(markup).toContain("More");

--- a/packages/workspace-ui/src/responsive-action-toolbar.tsx
+++ b/packages/workspace-ui/src/responsive-action-toolbar.tsx
@@ -5,10 +5,9 @@ import { cn } from "@stll/ui/utils";
 export type ResponsiveActionToolbarSlot = "primary" | "secondary" | "action";
 
 const RESPONSIVE_ACTION_TOOLBAR_SLOT_CLASS = {
-  primary:
-    "order-1 min-w-0 basis-full sm:order-none sm:min-w-56 sm:basis-0 sm:flex-1",
-  secondary: "order-2 min-w-0 flex-1 sm:order-none sm:flex-none",
-  action: "order-3 shrink-0 sm:order-none",
+  primary: "min-w-56 flex-1 shrink-0",
+  secondary: "min-w-0 shrink-0",
+  action: "shrink-0",
 } as const satisfies Record<ResponsiveActionToolbarSlot, string>;
 
 export const ResponsiveActionToolbar = ({
@@ -16,7 +15,10 @@ export const ResponsiveActionToolbar = ({
   ...props
 }: React.ComponentProps<"div">) => (
   <div
-    className={cn("flex flex-wrap items-center gap-2", className)}
+    className={cn(
+      "flex min-w-0 flex-nowrap items-center gap-2 overflow-x-auto",
+      className,
+    )}
     {...props}
   />
 );

--- a/packages/workspace-ui/src/responsive-action-toolbar.tsx
+++ b/packages/workspace-ui/src/responsive-action-toolbar.tsx
@@ -1,0 +1,37 @@
+import type * as React from "react";
+
+import { cn } from "@stll/ui/utils";
+
+export type ResponsiveActionToolbarSlot = "primary" | "secondary" | "action";
+
+const RESPONSIVE_ACTION_TOOLBAR_SLOT_CLASS = {
+  primary:
+    "order-1 min-w-0 basis-full sm:order-none sm:min-w-56 sm:basis-0 sm:flex-1",
+  secondary: "order-2 min-w-0 flex-1 sm:order-none sm:flex-none",
+  action: "order-3 shrink-0 sm:order-none",
+} as const satisfies Record<ResponsiveActionToolbarSlot, string>;
+
+export const ResponsiveActionToolbar = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn("flex flex-wrap items-center gap-2", className)}
+    {...props}
+  />
+);
+
+type ResponsiveActionToolbarItemProps = React.PropsWithChildren<{
+  slot: ResponsiveActionToolbarSlot;
+  className?: string | undefined;
+}>;
+
+export const ResponsiveActionToolbarItem = ({
+  slot,
+  className,
+  children,
+}: ResponsiveActionToolbarItemProps) => (
+  <div className={cn(RESPONSIVE_ACTION_TOOLBAR_SLOT_CLASS[slot], className)}>
+    {children}
+  </div>
+);


### PR DESCRIPTION
## Summary
- publish the responsive action toolbar from workspace-ui
- keep the web app consuming the package export
- cover the primary, secondary, and action slot contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive action toolbar for compact workspace controls.
  * Toolbar items support primary, secondary and action slots, adapting their layout across screen sizes.
  * The toolbar is now available through the workspace UI package.

* **Documentation**
  * Added usage guidance and import examples for the responsive action toolbar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->