### PR TITLE
fix: refresh stale clients after navigation

### DIFF
--- a/apps/web/src/components/api-version-mismatch-banner.logic.test.ts
+++ b/apps/web/src/components/api-version-mismatch-banner.logic.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldRefreshAfterNavigation } from "./api-version-mismatch-banner.logic";
+
+describe("version refresh boundary", () => {
+  test("keeps the update user-controlled on the working route", () => {
+    expect(
+      shouldRefreshAfterNavigation({
+        currentPathname: "/workspaces/active-matter",
+        detectedPathname: "/workspaces/active-matter",
+      }),
+    ).toBe(false);
+  });
+
+  test("refreshes after the router accepts navigation to another route", () => {
+    expect(
+      shouldRefreshAfterNavigation({
+        currentPathname: "/workspaces",
+        detectedPathname: "/workspaces/active-matter",
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/components/api-version-mismatch-banner.logic.ts
+++ b/apps/web/src/components/api-version-mismatch-banner.logic.ts
@@ -1,0 +1,14 @@
+type VersionRefreshBoundary = {
+  currentPathname: string;
+  detectedPathname: string;
+};
+
+/**
+ * A pathname change means TanStack Router accepted the navigation after any
+ * route-owned unsaved-work blockers ran. Query and hash changes stay within
+ * the current working surface and are not sufficient reload boundaries.
+ */
+export const shouldRefreshAfterNavigation = ({
+  currentPathname,
+  detectedPathname,
+}: VersionRefreshBoundary): boolean => currentPathname !== detectedPathname;

--- a/apps/web/src/components/api-version-mismatch-banner.route-boundary.test.ts
+++ b/apps/web/src/components/api-version-mismatch-banner.route-boundary.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import nodePath from "node:path";
+
+describe("version refresh route boundary", () => {
+  test("keeps the refresh provider mounted above the root outlet", async () => {
+    const rootRoutePath = nodePath.resolve(
+      import.meta.dir,
+      "../routes/__root.tsx",
+    );
+    const rootRouteSource = await Bun.file(rootRoutePath).text();
+
+    expect(rootRouteSource).toMatch(
+      /<ApiVersionMismatchProvider>\s*<Outlet \/>/u,
+    );
+  });
+});

--- a/apps/web/src/components/api-version-mismatch-banner.tsx
+++ b/apps/web/src/components/api-version-mismatch-banner.tsx
@@ -1,6 +1,8 @@
-import { useState } from "react";
+import { createContext, use, useState } from "react";
+import type { PropsWithChildren } from "react";
 
 import { useRouterState } from "@tanstack/react-router";
+import { panic } from "better-result";
 import { RefreshCwIcon, XIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 import * as v from "valibot";
@@ -21,6 +23,9 @@ import { shouldRefreshAfterNavigation } from "./api-version-mismatch-banner.logi
 
 const FIVE_MIN_MS = 5 * 60 * 1000;
 const DISMISSED_KEY_PREFIX = "stella:api-version-mismatch-dismissed:";
+const ApiVersionMismatchContext = createContext<string | null | undefined>(
+  undefined,
+);
 
 const healthSchema = v.object({
   status: v.literal("ok"),
@@ -31,22 +36,48 @@ const handleRefresh = () => {
   window.location.reload();
 };
 
-type AvailableVersionBannerProps = {
-  installedVersion: string;
-  pathname: string;
-  serverVersion: string;
+const useAvailableServerVersion = (): string | null => {
+  // Selfhost has its own GitHub-release-driven banner. Skip there
+  // so the two don't fight for the same slot.
+  const enabled = !env.VITE_SELFHOST;
+  const installedVersion = __APP_VERSION__;
+  const { data: serverVersion } = useChromeQuery({
+    queryKey: ["api-version-check"],
+    enabled,
+    staleTime: FIVE_MIN_MS,
+    refetchInterval: FIVE_MIN_MS,
+    refetchIntervalInBackground: false,
+    retry: false,
+    queryFn: async ({ signal }): Promise<string | null> => {
+      const response = await fetchWithTimeout(browserApiRootUrl("/health"), {
+        cache: "no-store",
+        signal,
+        timeoutMs: 8000,
+      });
+      if (!response.ok) {
+        return null;
+      }
+      const json: unknown = await response.json();
+      const parsed = v.safeParse(healthSchema, json);
+      return parsed.success ? parsed.output.version : null;
+    },
+  });
+
+  if (!enabled || !serverVersion) {
+    return null;
+  }
+
+  return compareSemver(serverVersion, installedVersion) > 0
+    ? serverVersion
+    : null;
 };
 
-const AvailableVersionBanner = ({
-  installedVersion,
-  pathname,
-  serverVersion,
-}: AvailableVersionBannerProps) => {
-  const t = useTranslations();
+type VersionRefreshObserverProps = {
+  pathname: string;
+};
+
+const VersionRefreshObserver = ({ pathname }: VersionRefreshObserverProps) => {
   const [detectedPathname] = useState(pathname);
-  const [dismissed, setDismissed] = useState(false);
-  const dismissedKey = `${DISMISSED_KEY_PREFIX}${serverVersion}`;
-  const isPersistedDismissal = useLocalStorageFlag(dismissedKey);
   const refreshAfterNavigation = shouldRefreshAfterNavigation({
     currentPathname: pathname,
     detectedPathname,
@@ -59,6 +90,49 @@ const AvailableVersionBanner = ({
       handleRefresh();
     }
   }, [refreshAfterNavigation]);
+
+  return null;
+};
+
+export const ApiVersionMismatchProvider = ({ children }: PropsWithChildren) => {
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const serverVersion = useAvailableServerVersion();
+
+  return (
+    <ApiVersionMismatchContext value={serverVersion}>
+      {serverVersion ? (
+        <VersionRefreshObserver key={serverVersion} pathname={pathname} />
+      ) : null}
+      {children}
+    </ApiVersionMismatchContext>
+  );
+};
+
+const useVersionMismatch = (): string | null => {
+  const serverVersion = use(ApiVersionMismatchContext);
+  if (serverVersion === undefined) {
+    return panic(
+      "ApiVersionMismatchBanner must be used within ApiVersionMismatchProvider",
+    );
+  }
+  return serverVersion;
+};
+
+type AvailableVersionBannerProps = {
+  installedVersion: string;
+  serverVersion: string;
+};
+
+const AvailableVersionBanner = ({
+  installedVersion,
+  serverVersion,
+}: AvailableVersionBannerProps) => {
+  const t = useTranslations();
+  const [dismissed, setDismissed] = useState(false);
+  const dismissedKey = `${DISMISSED_KEY_PREFIX}${serverVersion}`;
+  const isPersistedDismissal = useLocalStorageFlag(dismissedKey);
 
   if (dismissed || isPersistedDismissal) {
     return null;
@@ -114,42 +188,9 @@ const AvailableVersionBanner = ({
 };
 
 export const ApiVersionMismatchBanner = () => {
-  const pathname = useRouterState({
-    select: (state) => state.location.pathname,
-  });
-
-  // Selfhost has its own GitHub-release-driven banner. Skip there
-  // so the two don't fight for the same slot.
-  const enabled = !env.VITE_SELFHOST;
   const installedVersion = __APP_VERSION__;
-
-  const { data: serverVersion } = useChromeQuery({
-    queryKey: ["api-version-check"],
-    enabled,
-    staleTime: FIVE_MIN_MS,
-    refetchInterval: FIVE_MIN_MS,
-    refetchIntervalInBackground: false,
-    retry: false,
-    queryFn: async ({ signal }): Promise<string | null> => {
-      const response = await fetchWithTimeout(browserApiRootUrl("/health"), {
-        cache: "no-store",
-        signal,
-        timeoutMs: 8000,
-      });
-      if (!response.ok) {
-        return null;
-      }
-      const json: unknown = await response.json();
-      const parsed = v.safeParse(healthSchema, json);
-      return parsed.success ? parsed.output.version : null;
-    },
-  });
-
-  if (!enabled || !serverVersion) {
-    return null;
-  }
-
-  if (compareSemver(serverVersion, installedVersion) <= 0) {
+  const serverVersion = useVersionMismatch();
+  if (!serverVersion) {
     return null;
   }
 
@@ -157,7 +198,6 @@ export const ApiVersionMismatchBanner = () => {
     <AvailableVersionBanner
       installedVersion={installedVersion}
       key={serverVersion}
-      pathname={pathname}
       serverVersion={serverVersion}
     />
   );

--- a/apps/web/src/components/api-version-mismatch-banner.tsx
+++ b/apps/web/src/components/api-version-mismatch-banner.tsx
@@ -1,16 +1,23 @@
 import { useState } from "react";
 
+import { useRouterState } from "@tanstack/react-router";
 import { RefreshCwIcon, XIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
+import { cn } from "@stll/ui/utils";
+
 import Tooltip from "@/components/tooltip";
 import { env } from "@/env";
 import { useChromeQuery } from "@/hooks/use-chrome-query";
+import { useExternalSyncEffect } from "@/hooks/use-effect";
 import { useLocalStorageFlag } from "@/hooks/use-local-storage-flag";
 import { browserApiRootUrl } from "@/lib/api-url";
+import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { fetchWithTimeout } from "@/lib/fetch";
 import { compareSemver } from "@/lib/semver-compare";
+
+import { shouldRefreshAfterNavigation } from "./api-version-mismatch-banner.logic";
 
 const FIVE_MIN_MS = 5 * 60 * 1000;
 const DISMISSED_KEY_PREFIX = "stella:api-version-mismatch-dismissed:";
@@ -24,9 +31,92 @@ const handleRefresh = () => {
   window.location.reload();
 };
 
-export const ApiVersionMismatchBanner = () => {
+type AvailableVersionBannerProps = {
+  installedVersion: string;
+  pathname: string;
+  serverVersion: string;
+};
+
+const AvailableVersionBanner = ({
+  installedVersion,
+  pathname,
+  serverVersion,
+}: AvailableVersionBannerProps) => {
   const t = useTranslations();
-  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
+  const [detectedPathname] = useState(pathname);
+  const [dismissed, setDismissed] = useState(false);
+  const dismissedKey = `${DISMISSED_KEY_PREFIX}${serverVersion}`;
+  const isPersistedDismissal = useLocalStorageFlag(dismissedKey);
+  const refreshAfterNavigation = shouldRefreshAfterNavigation({
+    currentPathname: pathname,
+    detectedPathname,
+  });
+
+  // A completed SPA navigation is a safe update boundary: route blockers have
+  // already saved, discarded, or refused local-only work before this changes.
+  useExternalSyncEffect(() => {
+    if (refreshAfterNavigation) {
+      handleRefresh();
+    }
+  }, [refreshAfterNavigation]);
+
+  if (dismissed || isPersistedDismissal) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(dismissedKey, "1");
+    }
+    setDismissed(true);
+  };
+
+  return (
+    <div
+      className={cn(
+        "bg-accent text-foreground shrink-0 border-b px-4 text-sm",
+        TOOLBAR_ROW_HEIGHT,
+      )}
+    >
+      <div className="flex h-full items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate">
+            {t("app.versionMismatch.message", {
+              installed: installedVersion,
+              latest: serverVersion,
+            })}
+          </span>
+          <button
+            className="relative inline-flex shrink-0 items-center gap-1 underline underline-offset-2 after:absolute after:min-h-11 after:min-w-11 hover:no-underline"
+            onClick={handleRefresh}
+            type="button"
+          >
+            <RefreshCwIcon className="size-3" />
+            {t("app.versionMismatch.refresh")}
+          </button>
+        </div>
+        <Tooltip
+          content={t("app.versionMismatch.dismiss")}
+          render={
+            <button
+              aria-label={t("app.versionMismatch.dismiss")}
+              className="hover:bg-accent-foreground/10 relative -me-1 shrink-0 rounded-sm p-1 after:absolute after:inset-1/2 after:min-h-11 after:min-w-11 after:-translate-x-1/2 after:-translate-y-1/2"
+              onClick={handleDismiss}
+              type="button"
+            />
+          }
+        >
+          <XIcon className="size-4" />
+        </Tooltip>
+      </div>
+    </div>
+  );
+};
+
+export const ApiVersionMismatchBanner = () => {
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
 
   // Selfhost has its own GitHub-release-driven banner. Skip there
   // so the two don't fight for the same slot.
@@ -54,8 +144,6 @@ export const ApiVersionMismatchBanner = () => {
       return parsed.success ? parsed.output.version : null;
     },
   });
-  const dismissedKey = `${DISMISSED_KEY_PREFIX}${serverVersion ?? ""}`;
-  const isPersistedDismissal = useLocalStorageFlag(dismissedKey);
 
   if (!enabled || !serverVersion) {
     return null;
@@ -65,53 +153,12 @@ export const ApiVersionMismatchBanner = () => {
     return null;
   }
 
-  // Per-version dismissal so dismissing 0.0.8 doesn't suppress
-  // the banner when 0.0.9 ships.
-  if (dismissedVersion === serverVersion) {
-    return null;
-  }
-  if (isPersistedDismissal) {
-    return null;
-  }
-
-  const handleDismiss = () => {
-    if (typeof localStorage !== "undefined") {
-      localStorage.setItem(dismissedKey, "1");
-    }
-    setDismissedVersion(serverVersion);
-  };
-
   return (
-    <div className="bg-accent text-foreground border-b px-4 py-2 text-sm">
-      <div className="flex items-center justify-between gap-3">
-        <span>
-          {t("app.versionMismatch.message", {
-            installed: installedVersion,
-            latest: serverVersion,
-          })}{" "}
-          <button
-            className="inline-flex items-center gap-1 underline underline-offset-2 hover:no-underline"
-            onClick={handleRefresh}
-            type="button"
-          >
-            <RefreshCwIcon className="size-3" />
-            {t("app.versionMismatch.refresh")}
-          </button>
-        </span>
-        <Tooltip
-          content={t("app.versionMismatch.dismiss")}
-          render={
-            <button
-              aria-label={t("app.versionMismatch.dismiss")}
-              className="hover:bg-accent-foreground/10 -me-1 rounded-sm p-1"
-              onClick={handleDismiss}
-              type="button"
-            />
-          }
-        >
-          <XIcon className="size-4" />
-        </Tooltip>
-      </div>
-    </div>
+    <AvailableVersionBanner
+      installedVersion={installedVersion}
+      key={serverVersion}
+      pathname={pathname}
+      serverVersion={serverVersion}
+    />
   );
 };

--- a/apps/web/src/components/api-version-mismatch-banner.tsx
+++ b/apps/web/src/components/api-version-mismatch-banner.tsx
@@ -21,6 +21,38 @@ import { compareSemver } from "@/lib/semver-compare";
 
 import { shouldRefreshAfterNavigation } from "./api-version-mismatch-banner.logic";
 
+export const ApiVersionMismatchProvider = ({ children }: PropsWithChildren) => {
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const serverVersion = useAvailableServerVersion();
+
+  return (
+    <ApiVersionMismatchContext value={serverVersion}>
+      {serverVersion ? (
+        <VersionRefreshObserver key={serverVersion} pathname={pathname} />
+      ) : null}
+      {children}
+    </ApiVersionMismatchContext>
+  );
+};
+
+export const ApiVersionMismatchBanner = () => {
+  const installedVersion = __APP_VERSION__;
+  const serverVersion = useVersionMismatch();
+  if (!serverVersion) {
+    return null;
+  }
+
+  return (
+    <AvailableVersionBanner
+      installedVersion={installedVersion}
+      key={serverVersion}
+      serverVersion={serverVersion}
+    />
+  );
+};
+
 const FIVE_MIN_MS = 5 * 60 * 1000;
 const DISMISSED_KEY_PREFIX = "stella:api-version-mismatch-dismissed:";
 const ApiVersionMismatchContext = createContext<string | null | undefined>(
@@ -92,22 +124,6 @@ const VersionRefreshObserver = ({ pathname }: VersionRefreshObserverProps) => {
   }, [refreshAfterNavigation]);
 
   return null;
-};
-
-export const ApiVersionMismatchProvider = ({ children }: PropsWithChildren) => {
-  const pathname = useRouterState({
-    select: (state) => state.location.pathname,
-  });
-  const serverVersion = useAvailableServerVersion();
-
-  return (
-    <ApiVersionMismatchContext value={serverVersion}>
-      {serverVersion ? (
-        <VersionRefreshObserver key={serverVersion} pathname={pathname} />
-      ) : null}
-      {children}
-    </ApiVersionMismatchContext>
-  );
 };
 
 const useVersionMismatch = (): string | null => {
@@ -184,21 +200,5 @@ const AvailableVersionBanner = ({
         </Tooltip>
       </div>
     </div>
-  );
-};
-
-export const ApiVersionMismatchBanner = () => {
-  const installedVersion = __APP_VERSION__;
-  const serverVersion = useVersionMismatch();
-  if (!serverVersion) {
-    return null;
-  }
-
-  return (
-    <AvailableVersionBanner
-      installedVersion={installedVersion}
-      key={serverVersion}
-      serverVersion={serverVersion}
-    />
   );
 };

--- a/apps/web/src/components/api-version-mismatch-banner.tsx
+++ b/apps/web/src/components/api-version-mismatch-banner.tsx
@@ -25,21 +25,29 @@ export const ApiVersionMismatchProvider = ({ children }: PropsWithChildren) => {
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
-  const serverVersion = useAvailableServerVersion();
+  const [serverVersion, setServerVersion] = useState<string | null>(null);
 
   return (
-    <ApiVersionMismatchContext value={serverVersion}>
+    <ApiVersionMismatchReporterContext value={setServerVersion}>
       {serverVersion ? (
         <VersionRefreshObserver key={serverVersion} pathname={pathname} />
       ) : null}
       {children}
-    </ApiVersionMismatchContext>
+    </ApiVersionMismatchReporterContext>
   );
 };
 
 export const ApiVersionMismatchBanner = () => {
   const installedVersion = __APP_VERSION__;
-  const serverVersion = useVersionMismatch();
+  const serverVersion = useAvailableServerVersion();
+  const reportServerVersion = useVersionMismatchReporter();
+
+  // Keep the mismatch in the root provider after this protected-route banner
+  // unmounts, so the persistent observer can refresh at the new pathname.
+  useExternalSyncEffect(() => {
+    reportServerVersion(serverVersion);
+  }, [reportServerVersion, serverVersion]);
+
   if (!serverVersion) {
     return null;
   }
@@ -55,9 +63,9 @@ export const ApiVersionMismatchBanner = () => {
 
 const FIVE_MIN_MS = 5 * 60 * 1000;
 const DISMISSED_KEY_PREFIX = "stella:api-version-mismatch-dismissed:";
-const ApiVersionMismatchContext = createContext<string | null | undefined>(
-  undefined,
-);
+const ApiVersionMismatchReporterContext = createContext<
+  ((serverVersion: string | null) => void) | undefined
+>(undefined);
 
 const healthSchema = v.object({
   status: v.literal("ok"),
@@ -126,14 +134,14 @@ const VersionRefreshObserver = ({ pathname }: VersionRefreshObserverProps) => {
   return null;
 };
 
-const useVersionMismatch = (): string | null => {
-  const serverVersion = use(ApiVersionMismatchContext);
-  if (serverVersion === undefined) {
+const useVersionMismatchReporter = () => {
+  const reportServerVersion = use(ApiVersionMismatchReporterContext);
+  if (reportServerVersion === undefined) {
     return panic(
       "ApiVersionMismatchBanner must be used within ApiVersionMismatchProvider",
     );
   }
-  return serverVersion;
+  return reportServerVersion;
 };
 
 type AvailableVersionBannerProps = {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -11,6 +11,7 @@ import {
 } from "@tanstack/react-router";
 
 import { AppProviders } from "@/app-providers";
+import { ApiVersionMismatchProvider } from "@/components/api-version-mismatch-banner";
 import {
   DefaultErrorComponent,
   DefaultPendingComponent,
@@ -104,14 +105,16 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
 function RootApp() {
   return (
     <div className="flex h-dvh w-full flex-col" id="app">
-      <Outlet />
-      {DevRoot ? (
-        <ClientOnly>
-          <Suspense fallback={null}>
-            <DevRoot />
-          </Suspense>
-        </ClientOnly>
-      ) : null}
+      <ApiVersionMismatchProvider>
+        <Outlet />
+        {DevRoot ? (
+          <ClientOnly>
+            <Suspense fallback={null}>
+              <DevRoot />
+            </Suspense>
+          </ClientOnly>
+        ) : null}
+      </ApiVersionMismatchProvider>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- keep version updates user-controlled on the active route
- refresh stale clients after the router accepts navigation to another route
- align the update banner with the shared 48px toolbar row and preserve compact accessible controls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API version mismatch handling after in-app navigation.
  * The page now refreshes when navigation reaches a different route, while query-string and hash changes are ignored.
  * Version banner dismissal remains specific to each available version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->