### PR TITLE
fix: serialize corpus projection mutations

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
@@ -13,11 +13,10 @@ import {
   legislationSources,
 } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
-import type { CorpusIndexManifest } from "@/api/lib/legal-search/corpus-index-manifest";
 import { deriveCorpusIndexProjectionDescriptor } from "@/api/lib/legal-search/corpus-index-projection-descriptor";
 import {
   buildCorpusIndexProjectionDesiredStateValues,
-  readActiveCorpusProjectionManifest,
+  lockActiveCorpusProjectionManifestForMutation,
   type CorpusIndexProjectionSubject,
 } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import { isRedistributable } from "@/api/lib/legal-search/corpus-source";
@@ -208,7 +207,6 @@ const bootstrapCaseLaw = async (
   generation: string,
   limit: number,
   afterEntityId: SafeId<"caseLawDecision"> | undefined,
-  manifest: CorpusIndexManifest,
 ): Promise<CorpusIndexProjectionBootstrapResult> => {
   const conditions = [
     isNull(corpusIndexProjectionStates.entityId),
@@ -341,8 +339,12 @@ const bootstrapCaseLaw = async (
   }
 
   // Recheck the generation after claiming canonical rows. Retirement waits on
-  // this share lock, and a changed status rolls back the whole bounded claim.
-  await readActiveCorpusProjectionManifest(tx, "case_law", generation, true);
+  // this mutation fence, and a changed status rolls back the bounded claim.
+  const manifest = await lockActiveCorpusProjectionManifestForMutation(
+    tx,
+    "case_law",
+    generation,
+  );
   await setZeroCaseLawProjectionEpochs(tx, entityIds);
 
   const values = rows.map((row: BootstrapCaseLawRow) =>
@@ -407,7 +409,6 @@ const bootstrapLegislation = async (
   generation: string,
   limit: number,
   afterEntityId: SafeId<"legislationDocument"> | undefined,
-  manifest: CorpusIndexManifest,
 ): Promise<CorpusIndexProjectionBootstrapResult> => {
   const conditions = [
     isNull(corpusIndexProjectionStates.entityId),
@@ -501,7 +502,11 @@ const bootstrapLegislation = async (
     ]),
   );
 
-  await readActiveCorpusProjectionManifest(tx, "legislation", generation, true);
+  const manifest = await lockActiveCorpusProjectionManifestForMutation(
+    tx,
+    "legislation",
+    generation,
+  );
   await setZeroLegislationProjectionEpochs(tx, entityIds);
 
   const values = rows.map((row: BootstrapLegislationRow) =>
@@ -569,12 +574,6 @@ export const bootstrapCorpusProjectionDesiredStateBatchTx = async (
   options: CorpusIndexProjectionBootstrapOptions,
 ): Promise<CorpusIndexProjectionBootstrapResult> => {
   const limit = validateBootstrapLimit(options.limit);
-  const manifest = await readActiveCorpusProjectionManifest(
-    tx,
-    options.family,
-    options.generation,
-    false,
-  );
   switch (options.family) {
     case "case_law":
       return await bootstrapCaseLaw(
@@ -582,7 +581,6 @@ export const bootstrapCorpusProjectionDesiredStateBatchTx = async (
         options.generation,
         limit,
         options.afterEntityId,
-        manifest,
       );
     case "legislation":
       return await bootstrapLegislation(
@@ -590,7 +588,6 @@ export const bootstrapCorpusProjectionDesiredStateBatchTx = async (
         options.generation,
         limit,
         options.afterEntityId,
-        manifest,
       );
     default:
       return options satisfies never;

--- a/apps/api/src/lib/legal-search/corpus-index-projection-census-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-census-store.ts
@@ -9,7 +9,10 @@ import {
 import type { SafeId } from "@/api/lib/branded-types";
 import { isUuid } from "@/api/lib/custom-schema";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
-import { readRegisteredCorpusProjectionManifestForCleanup } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
+import {
+  lockRegisteredCorpusProjectionManifestForMutation,
+  readRegisteredCorpusProjectionManifestForCleanup,
+} from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import { CORPUS_PROJECTION_DELETE_MAX_REVISIONS } from "@/api/lib/legal-search/corpus-index-projection-engine";
 import { brandValidatedCorpusIndexProjectionIntentId } from "@/api/lib/safe-id-boundaries";
 
@@ -208,7 +211,7 @@ export const repairAppliedCorpusProjectionDriftTx = async (
   ) {
     return panic("Corpus projection census repair batch is invalid");
   }
-  await readRegisteredCorpusProjectionManifestForCleanup(
+  await lockRegisteredCorpusProjectionManifestForMutation(
     tx,
     options.family,
     options.generation,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-cleanup-store.ts
@@ -14,13 +14,14 @@ import type {
   CorpusIndexError,
 } from "@/api/lib/legal-search/corpus-index-client";
 import type { CorpusIndexIntentStatus } from "@/api/lib/legal-search/corpus-index-projection-contract";
-import { readRegisteredCorpusProjectionManifestForCleanup } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
+import { lockRegisteredCorpusProjectionManifestForMutation } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import {
   CORPUS_PROJECTION_DELETE_MAX_REVISIONS,
   corpusIndexUnknownAppendBarrierAt,
   countCorpusProjectionRevisions,
   readCorpusProjectionDeleteSettlement,
 } from "@/api/lib/legal-search/corpus-index-projection-engine";
+import { lockCorpusIndexProjectionIntentMutationsTx } from "@/api/lib/legal-search/corpus-index-projection-revision";
 import {
   CORPUS_PROJECTION_GENERATION_SCOPE,
   entityIdsForCorpusProjectionWorkScope,
@@ -121,7 +122,7 @@ export const claimCorpusProjectionCleanupTx = async <
   const limit = validateCleanupBatchSize(requestedLimit);
   const leaseMs = validateLeaseMs(requestedLeaseMs);
   const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
-  await readRegisteredCorpusProjectionManifestForCleanup(
+  await lockRegisteredCorpusProjectionManifestForMutation(
     tx,
     family,
     generation,
@@ -222,6 +223,7 @@ export const recordCorpusProjectionDeleteTx = async (
   ) {
     return panic("Corpus projection delete receipt is invalid");
   }
+  await lockCorpusIndexProjectionIntentMutationsTx(tx, intentIds);
   await lockCorpusProjectionIntentsById(tx, intentIds);
   const transitionAt = testNow ?? sql<Date>`clock_timestamp()`;
   const rows = await tx
@@ -270,6 +272,7 @@ export const retryCorpusProjectionCleanupTx = async (
   if (intentIds.length === 0) {
     return 0;
   }
+  await lockCorpusIndexProjectionIntentMutationsTx(tx, intentIds);
   await lockCorpusProjectionIntentsById(tx, intentIds);
   const transitionAt = testNow ?? sql<Date>`clock_timestamp()`;
   const rows = await tx
@@ -337,7 +340,7 @@ export const claimCorpusProjectionCleanupSettlementTx = async <
   const limit = validateCleanupBatchSize(requestedLimit);
   const leaseMs = validateLeaseMs(requestedLeaseMs);
   const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
-  await readRegisteredCorpusProjectionManifestForCleanup(
+  await lockRegisteredCorpusProjectionManifestForMutation(
     tx,
     family,
     generation,
@@ -534,6 +537,7 @@ export const releaseCorpusProjectionCleanupSettlementTx = async (
   tx: Transaction,
   { lease, testNow }: ReleaseCorpusProjectionCleanupSettlementOptions,
 ): Promise<number> => {
+  await lockCorpusIndexProjectionIntentMutationsTx(tx, lease.intentIds);
   await lockCorpusProjectionIntentsById(tx, lease.intentIds);
   const transitionAt = testNow ?? sql<Date>`clock_timestamp()`;
   const rows = await tx
@@ -569,6 +573,7 @@ export const settleCorpusProjectionCleanupTx = async (
   tx: Transaction,
   { proof, testNow }: SettleCorpusProjectionCleanupOptions,
 ): Promise<number> => {
+  await lockCorpusIndexProjectionIntentMutationsTx(tx, proof.intentIds);
   await lockCorpusProjectionIntentsById(tx, proof.intentIds);
   const transitionAt = testNow ?? sql<Date>`clock_timestamp()`;
   const rows = await tx
@@ -624,6 +629,7 @@ export const reopenCorpusProjectionCleanupTx = async (
   ) {
     return panic("Corpus projection cleanup reopen request is invalid");
   }
+  await lockCorpusIndexProjectionIntentMutationsTx(tx, intentIds);
   const identities = await tx
     .select({
       family: corpusIndexProjectionIntents.family,
@@ -780,7 +786,7 @@ export const recoverExpiredCorpusProjectionIntentsTx = async <
 ): Promise<CorpusProjectionExpiredIntent[]> => {
   const limit = validateCleanupBatchSize(requestedLimit);
   const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
-  const manifest = await readRegisteredCorpusProjectionManifestForCleanup(
+  const manifest = await lockRegisteredCorpusProjectionManifestForMutation(
     tx,
     family,
     generation,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
@@ -354,7 +354,7 @@ const activeManifests = async (
     )
     .orderBy(asc(corpusIndexGenerations.generation))
     .limit(CORPUS_INDEX_MANIFEST_COUNT + 1)
-    .for("share");
+    .for("update");
   if (rows.length > CORPUS_INDEX_MANIFEST_COUNT) {
     return panic(`Active corpus generation registry exceeds its manifest set`);
   }
@@ -368,7 +368,6 @@ export const readActiveCorpusProjectionManifest = async (
   tx: Transaction,
   family: CorpusIndexProjectionSubject["family"],
   generation: string,
-  lock: boolean,
 ): Promise<CorpusIndexManifest> => {
   const query = tx
     .select()
@@ -384,7 +383,42 @@ export const readActiveCorpusProjectionManifest = async (
       ),
     )
     .limit(1);
-  const rows = lock ? await query.for("share") : await query;
+  const rows = await query;
+  const row = rows.at(0);
+  if (row === undefined) {
+    return panic(
+      `Active corpus generation is not registered: ${family}/${generation}`,
+    );
+  }
+  return requireRegisteredCorpusIndexManifest(row);
+};
+
+/**
+ * Validate an active manifest while taking the generation-local mutation
+ * fence. Every projection state or intent mutation must take this lock before
+ * its first projection-row lock so statement-trigger revision bumps cannot
+ * deadlock while upgrading shared generation locks.
+ */
+export const lockActiveCorpusProjectionManifestForMutation = async (
+  tx: Transaction,
+  family: CorpusIndexProjectionSubject["family"],
+  generation: string,
+): Promise<CorpusIndexManifest> => {
+  const rows = await tx
+    .select()
+    .from(corpusIndexGenerations)
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, family),
+        eq(corpusIndexGenerations.generation, generation),
+        or(
+          eq(corpusIndexGenerations.status, "building"),
+          eq(corpusIndexGenerations.status, "serving"),
+        ),
+      ),
+    )
+    .limit(1)
+    .for("update");
   const row = rows.at(0);
   if (row === undefined) {
     return panic(
@@ -419,6 +453,32 @@ export const readRegisteredCorpusProjectionManifestForCleanup = async (
   if (row === undefined) {
     return panic(
       `Corpus generation is not registered for cleanup: ${family}/${generation}`,
+    );
+  }
+  return requireRegisteredCorpusIndexManifest(row);
+};
+
+/** Lock a registered generation before mutating cleanup or retirement state. */
+export const lockRegisteredCorpusProjectionManifestForMutation = async (
+  tx: Transaction,
+  family: CorpusIndexProjectionSubject["family"],
+  generation: string,
+): Promise<CorpusIndexManifest> => {
+  const rows = await tx
+    .select()
+    .from(corpusIndexGenerations)
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, family),
+        eq(corpusIndexGenerations.generation, generation),
+      ),
+    )
+    .limit(1)
+    .for("update");
+  const row = rows.at(0);
+  if (row === undefined) {
+    return panic(
+      `Corpus generation is not registered for mutation: ${family}/${generation}`,
     );
   }
   return requireRegisteredCorpusIndexManifest(row);
@@ -643,7 +703,7 @@ export const ensureCorpusProjectionDesiredStateTx = async (
       ),
     )
     .limit(1)
-    .for("share");
+    .for("update");
   const generationRow = generationRows.at(0);
   if (generationRow === undefined) {
     return panic(

--- a/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-erasure-store.ts
@@ -9,7 +9,7 @@ import {
 import type { SafeId } from "@/api/lib/branded-types";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
 import { CORPUS_INDEX_APPEND_PRODUCING_INTENT_STATUSES } from "@/api/lib/legal-search/corpus-index-projection-contract";
-import { readRegisteredCorpusProjectionManifestForCleanup } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
+import { lockRegisteredCorpusProjectionManifestForMutation } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import { corpusIndexUnknownAppendBarrierAt } from "@/api/lib/legal-search/corpus-index-projection-engine";
 import {
   CORPUS_PROJECTION_GENERATION_SCOPE,
@@ -68,7 +68,7 @@ export const advanceCorpusProjectionErasuresTx = async <
 ): Promise<AdvanceCorpusProjectionErasuresResult> => {
   const limit = validateLimit(requestedLimit);
   const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
-  const manifest = await readRegisteredCorpusProjectionManifestForCleanup(
+  const manifest = await lockRegisteredCorpusProjectionManifestForMutation(
     tx,
     family,
     generation,

--- a/apps/api/src/lib/legal-search/corpus-index-projection-materials.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-materials.ts
@@ -355,7 +355,6 @@ export const readReservedCorpusProjectionMaterialsTx = async (
     tx,
     family,
     generation,
-    false,
   );
   const intentIds = leases.map(({ intentId }) => intentId);
   const entityIds = leases.map(({ entityId }) => entityId);

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.db.test.ts
@@ -13,6 +13,8 @@ import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
 import {
+  lockCorpusIndexProjectionIntentMutationsTx,
+  lockCorpusIndexProjectionMutationsTx,
   lockCorpusIndexProjectionPromotionTx,
   lockCorpusIndexProjectionRevisionTx,
   readCorpusIndexProjectionRevisionTx,
@@ -29,6 +31,13 @@ const ENTITY_IDS = [
 const INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
   "0198e331-e578-7000-8000-000000000503",
 );
+const MUTATION_INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000504",
+);
+const LEGISLATION_TARGET = {
+  family: "legislation",
+  generation: "legislation_v2",
+} as const;
 const MIGRATION_URL = new URL(
   "../../../drizzle/20260826004100_corpus_projection_revision_fence/migration.sql",
   import.meta.url,
@@ -164,4 +173,35 @@ test("the typed read and proof boundaries return the current revision", async ()
   expect(read).toBe(await revision());
   expect(locked).toBe(read);
   expect(promotion).toBe(read);
+});
+
+test("mutation fences lock registered generations in a stable order", async () => {
+  await db.insert(corpusIndexGenerations).values({
+    ...LEGISLATION_TARGET,
+    cluster: "q09",
+    manifestDigest: "c".repeat(64),
+    status: "building",
+  });
+  await db.insert(corpusIndexProjectionIntents).values({
+    id: MUTATION_INTENT_ID,
+    ...TARGET,
+    entityId: ENTITY_IDS[1],
+    epoch: 1n,
+    fingerprint: "d".repeat(64),
+    indexId: "case_law_v5_cs_sk",
+    status: "cancelled",
+    cancelledAt: new Date("2026-08-26T00:00:04.000Z"),
+  });
+
+  await db.transaction(async (tx) => {
+    const transaction = asTestRaw<Transaction>(tx);
+    await lockCorpusIndexProjectionMutationsTx(transaction, [
+      LEGISLATION_TARGET,
+      TARGET,
+      LEGISLATION_TARGET,
+    ]);
+    await lockCorpusIndexProjectionIntentMutationsTx(transaction, [
+      MUTATION_INTENT_ID,
+    ]);
+  });
 });

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
@@ -1,0 +1,214 @@
+import { SQL } from "bun";
+import { describe, expect, test } from "bun:test";
+import { and, eq, inArray, or, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sql";
+
+import { databaseRelations } from "@/api/db/database-relations";
+import {
+  caseLawDecisions,
+  caseLawSources,
+  corpusIndexGenerations,
+  corpusIndexProjectionStates,
+  legislationDocuments,
+  legislationSources,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+
+import { lockCorpusIndexProjectionMutationsTx } from "./corpus-index-projection-revision";
+
+const databaseUrl = process.env["DATABASE_URL"];
+const runPostgresTests = process.env["STELLA_RUN_POSTGRES_TESTS"] === "true";
+
+if (!databaseUrl || !runPostgresTests) {
+  describe.skip("corpus projection mutation fence (postgres)", () => {
+    test("requires STELLA_RUN_POSTGRES_TESTS=true and DATABASE_URL", () => {
+      expect(true).toBe(true);
+    });
+  });
+} else {
+  describe("corpus projection mutation fence (postgres)", () => {
+    test("opposite target orders serialize without deadlocking", async () => {
+      const firstClient = new SQL({ url: databaseUrl, max: 1 });
+      const secondClient = new SQL({ url: databaseUrl, max: 1 });
+      const firstDb = drizzle({
+        client: firstClient,
+        relations: databaseRelations,
+      });
+      const secondDb = drizzle({
+        client: secondClient,
+        relations: databaseRelations,
+      });
+      const suffix = Date.now();
+      const caseLawTarget = {
+        family: "case_law",
+        generation: `case_law_v${suffix}`,
+      } as const;
+      const legislationTarget = {
+        family: "legislation",
+        generation: `legislation_v${suffix}`,
+      } as const;
+      const targets = [caseLawTarget, legislationTarget] as const;
+      const caseLawSourceId = toSafeId<"caseLawSource">(Bun.randomUUIDv7());
+      const legislationSourceId = toSafeId<"legislationSource">(
+        Bun.randomUUIDv7(),
+      );
+      const caseLawEntityIds = [
+        toSafeId<"caseLawDecision">(Bun.randomUUIDv7()),
+        toSafeId<"caseLawDecision">(Bun.randomUUIDv7()),
+      ] as const;
+      const legislationEntityIds = [
+        toSafeId<"legislationDocument">(Bun.randomUUIDv7()),
+        toSafeId<"legislationDocument">(Bun.randomUUIDv7()),
+      ] as const;
+      const generationPredicate = or(
+        ...targets.map(({ family, generation }) =>
+          and(
+            eq(corpusIndexGenerations.family, family),
+            eq(corpusIndexGenerations.generation, generation),
+          ),
+        ),
+      );
+      const statePredicate = or(
+        ...targets.map(({ family, generation }) =>
+          and(
+            eq(corpusIndexProjectionStates.family, family),
+            eq(corpusIndexProjectionStates.generation, generation),
+          ),
+        ),
+      );
+      const firstFenceAcquired = Promise.withResolvers<undefined>();
+      const releaseFirstFence = Promise.withResolvers<undefined>();
+      const secondFenceAttempted = Promise.withResolvers<undefined>();
+      const secondFenceAcquired = Promise.withResolvers<undefined>();
+
+      try {
+        await firstDb.insert(caseLawSources).values({
+          id: caseLawSourceId,
+          adapterKey: `projection-fence-case-law-${suffix}`,
+          name: "Projection fence case law",
+        });
+        await firstDb.insert(caseLawDecisions).values(
+          caseLawEntityIds.map((id, index) => ({
+            id,
+            sourceId: caseLawSourceId,
+            caseNumber: `projection-fence-${suffix}-${index}`,
+            court: "Projection fence court",
+            country: "CZE",
+            language: "cs",
+            projectionEpoch: 1n,
+          })),
+        );
+        await firstDb.insert(legislationSources).values({
+          id: legislationSourceId,
+          adapterKey: `projection-fence-legislation-${suffix}`,
+          name: "Projection fence legislation",
+        });
+        await firstDb.insert(legislationDocuments).values(
+          legislationEntityIds.map((id, index) => ({
+            id,
+            sourceId: legislationSourceId,
+            eli: `eli/test/projection-fence/${suffix}/${index}`,
+            title: `Projection fence legislation ${index}`,
+            country: "CZE",
+            language: "cs",
+            projectionEpoch: 1n,
+          })),
+        );
+        await firstDb.insert(corpusIndexGenerations).values([
+          {
+            ...caseLawTarget,
+            cluster: "q09",
+            manifestDigest: "e".repeat(64),
+            status: "building",
+          },
+          {
+            ...legislationTarget,
+            cluster: "q09",
+            manifestDigest: "e".repeat(64),
+            status: "building",
+          },
+        ]);
+
+        const firstMutation = firstDb.transaction(async (tx) => {
+          await tx.execute(sql`SET LOCAL statement_timeout = '5s'`);
+          await lockCorpusIndexProjectionMutationsTx(tx, targets);
+          firstFenceAcquired.resolve(undefined);
+          await releaseFirstFence.promise;
+          await tx.insert(corpusIndexProjectionStates).values({
+            ...caseLawTarget,
+            entityId: caseLawEntityIds[0],
+            desiredAction: "erase",
+            desiredEpoch: 1n,
+          });
+          await tx.insert(corpusIndexProjectionStates).values({
+            ...legislationTarget,
+            entityId: legislationEntityIds[0],
+            desiredAction: "erase",
+            desiredEpoch: 1n,
+          });
+        });
+        await firstFenceAcquired.promise;
+
+        const secondMutation = secondDb.transaction(async (tx) => {
+          await tx.execute(sql`SET LOCAL statement_timeout = '5s'`);
+          secondFenceAttempted.resolve(undefined);
+          await lockCorpusIndexProjectionMutationsTx(tx, [
+            legislationTarget,
+            caseLawTarget,
+          ]);
+          secondFenceAcquired.resolve(undefined);
+          await tx.insert(corpusIndexProjectionStates).values({
+            ...legislationTarget,
+            entityId: legislationEntityIds[1],
+            desiredAction: "erase",
+            desiredEpoch: 1n,
+          });
+          await tx.insert(corpusIndexProjectionStates).values({
+            ...caseLawTarget,
+            entityId: caseLawEntityIds[1],
+            desiredAction: "erase",
+            desiredEpoch: 1n,
+          });
+        });
+        await secondFenceAttempted.promise;
+
+        const acquiredWhileFirstHeld = await Promise.race([
+          secondFenceAcquired.promise.then(() => true),
+          Bun.sleep(100).then(() => false),
+        ]);
+        expect(acquiredWhileFirstHeld).toBe(false);
+
+        releaseFirstFence.resolve(undefined);
+        const results = await Promise.allSettled([
+          firstMutation,
+          secondMutation,
+        ]);
+        expect(results).toEqual([
+          { status: "fulfilled", value: undefined },
+          { status: "fulfilled", value: undefined },
+        ]);
+      } finally {
+        releaseFirstFence.resolve(undefined);
+        await firstDb
+          .update(corpusIndexGenerations)
+          .set({ status: "retired" })
+          .where(generationPredicate);
+        await firstDb.delete(corpusIndexProjectionStates).where(statePredicate);
+        await firstDb
+          .delete(caseLawDecisions)
+          .where(inArray(caseLawDecisions.id, caseLawEntityIds));
+        await firstDb
+          .delete(legislationDocuments)
+          .where(inArray(legislationDocuments.id, legislationEntityIds));
+        await firstDb
+          .delete(caseLawSources)
+          .where(eq(caseLawSources.id, caseLawSourceId));
+        await firstDb
+          .delete(legislationSources)
+          .where(eq(legislationSources.id, legislationSourceId));
+        await firstDb.delete(corpusIndexGenerations).where(generationPredicate);
+        await Promise.all([firstClient.close(), secondClient.close()]);
+      }
+    });
+  });
+}

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.ts
@@ -1,13 +1,34 @@
 import { panic } from "better-result";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq, inArray, or } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
-import { corpusIndexGenerations } from "@/api/db/schema";
+import {
+  corpusIndexGenerations,
+  corpusIndexProjectionIntents,
+} from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
 
 type CorpusProjectionRevisionTarget = {
   family: CorpusFamily;
   generation: string;
+};
+
+const targetKey = ({ family, generation }: CorpusProjectionRevisionTarget) =>
+  `${family}/${generation}`;
+
+const uniqueOrderedTargets = (
+  targets: readonly CorpusProjectionRevisionTarget[],
+): CorpusProjectionRevisionTarget[] => {
+  const byKey = new Map(targets.map((target) => [targetKey(target), target]));
+  return [...byKey.values()].toSorted((left, right) => {
+    const leftKey = targetKey(left);
+    const rightKey = targetKey(right);
+    if (leftKey === rightKey) {
+      return 0;
+    }
+    return leftKey < rightKey ? -1 : 1;
+  });
 };
 
 const projectionRevisionQuery = (
@@ -48,6 +69,78 @@ export const readCorpusIndexProjectionRevisionTx = async (
   target: CorpusProjectionRevisionTarget,
 ): Promise<number> =>
   requireProjectionRevision(await projectionRevisionQuery(tx, target), target);
+
+/**
+ * Acquire generation mutation fences in one stable order before any projection
+ * state or intent row is locked. Revision triggers then update rows already
+ * owned by the transaction instead of attempting a deadlock-prone lock upgrade.
+ */
+export const lockCorpusIndexProjectionMutationsTx = async (
+  tx: Transaction,
+  targets: readonly CorpusProjectionRevisionTarget[],
+): Promise<void> => {
+  const ordered = uniqueOrderedTargets(targets);
+  if (ordered.length === 0) {
+    return panic("Corpus projection mutation requires a generation target");
+  }
+  const predicate = or(
+    ...ordered.map(({ family, generation }) =>
+      and(
+        eq(corpusIndexGenerations.family, family),
+        eq(corpusIndexGenerations.generation, generation),
+      ),
+    ),
+  );
+  if (predicate === undefined) {
+    return panic("Corpus projection mutation target predicate is empty");
+  }
+  const locked = await tx
+    .select({
+      family: corpusIndexGenerations.family,
+      generation: corpusIndexGenerations.generation,
+    })
+    .from(corpusIndexGenerations)
+    .where(predicate)
+    .orderBy(
+      asc(corpusIndexGenerations.family),
+      asc(corpusIndexGenerations.generation),
+    )
+    .limit(ordered.length)
+    .for("update");
+  if (
+    locked.length !== ordered.length ||
+    locked.some((target, index) => {
+      const expected = ordered.at(index);
+      return (
+        expected === undefined || targetKey(target) !== targetKey(expected)
+      );
+    })
+  ) {
+    return panic("Corpus projection mutation generation is not registered");
+  }
+};
+
+export const lockCorpusIndexProjectionIntentMutationsTx = async (
+  tx: Transaction,
+  intentIds: readonly SafeId<"corpusIndexProjectionIntent">[],
+): Promise<void> => {
+  const uniqueIds = new Set(intentIds);
+  if (uniqueIds.size === 0 || uniqueIds.size !== intentIds.length) {
+    return panic("Corpus projection mutation intent ids must be unique");
+  }
+  const identities = await tx
+    .select({
+      id: corpusIndexProjectionIntents.id,
+      family: corpusIndexProjectionIntents.family,
+      generation: corpusIndexProjectionIntents.generation,
+    })
+    .from(corpusIndexProjectionIntents)
+    .where(inArray(corpusIndexProjectionIntents.id, [...uniqueIds]));
+  if (identities.length !== uniqueIds.size) {
+    return panic("Corpus projection mutation intent identity changed");
+  }
+  await lockCorpusIndexProjectionMutationsTx(tx, identities);
+};
 
 /**
  * Fence a generation's desired/applied state at one exact mutation revision.

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.ts
@@ -11,13 +11,14 @@ import { createSafeId, type SafeId } from "@/api/lib/branded-types";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
 import type { CorpusIndexProjectionFailureKind } from "@/api/lib/legal-search/corpus-index-projection-contract";
 import {
-  readActiveCorpusProjectionManifest,
-  readRegisteredCorpusProjectionManifestForCleanup,
+  lockActiveCorpusProjectionManifestForMutation,
+  lockRegisteredCorpusProjectionManifestForMutation,
 } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import {
   CORPUS_PROJECTION_APPEND_MAX_REVISIONS,
   corpusIndexUnknownAppendBarrierAt,
 } from "@/api/lib/legal-search/corpus-index-projection-engine";
+import { lockCorpusIndexProjectionMutationsTx } from "@/api/lib/legal-search/corpus-index-projection-revision";
 import {
   CORPUS_PROJECTION_GENERATION_SCOPE,
   entityIdsForCorpusProjectionWorkScope,
@@ -139,11 +140,10 @@ export const reserveCorpusProjectionIntentsTx = async <
   const limit = validateBatchSize(requestedLimit);
   const leaseMs = validateLeaseMs(requestedLeaseMs);
   const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
-  const manifest = await readActiveCorpusProjectionManifest(
+  const manifest = await lockActiveCorpusProjectionManifestForMutation(
     tx,
     family,
     generation,
-    true,
   );
   const scopedIndexId = indexIdForCorpusProjectionWorkScope(scope, manifest);
   const eligibilityAt = testNow ?? (await readPostgresClock(tx));
@@ -323,11 +323,10 @@ export const prepareCorpusProjectionReplacementsTx = async <
 ): Promise<CorpusProjectionReplacementCleanup[]> => {
   const limit = validateBatchSize(requestedLimit);
   const scopedEntityIds = entityIdsForCorpusProjectionWorkScope(scope);
-  const manifest = await readActiveCorpusProjectionManifest(
+  const manifest = await lockActiveCorpusProjectionManifestForMutation(
     tx,
     family,
     generation,
-    true,
   );
   const scopedIndexId = indexIdForCorpusProjectionWorkScope(scope, manifest);
   const candidates = await tx
@@ -453,11 +452,10 @@ export const startCorpusProjectionAppendTx = async (
   if (identity === undefined) {
     return "lease_lost";
   }
-  await readActiveCorpusProjectionManifest(
+  await lockActiveCorpusProjectionManifestForMutation(
     tx,
     identity.family,
     identity.generation,
-    true,
   );
   await tx
     .select({ entityId: corpusIndexProjectionStates.entityId })
@@ -579,11 +577,10 @@ export const startCorpusProjectionAppendBatchTx = async (
       "Corpus projection append-start leases must be unique and scoped",
     );
   }
-  await readActiveCorpusProjectionManifest(
+  await lockActiveCorpusProjectionManifestForMutation(
     tx,
     first.family,
     first.generation,
-    true,
   );
   const entityIdList = [...entityIds];
   await tx
@@ -728,7 +725,7 @@ export const abandonCorpusProjectionAppendTx = async (
   if (identity === undefined) {
     return "lease_lost";
   }
-  const manifest = await readRegisteredCorpusProjectionManifestForCleanup(
+  const manifest = await lockRegisteredCorpusProjectionManifestForMutation(
     tx,
     identity.family,
     identity.generation,
@@ -808,7 +805,7 @@ export const commitCorpusProjectionAppendTx = async (
   if (identity === undefined) {
     return { status: "lease_lost" };
   }
-  await readRegisteredCorpusProjectionManifestForCleanup(
+  await lockRegisteredCorpusProjectionManifestForMutation(
     tx,
     identity.family,
     identity.generation,
@@ -955,6 +952,19 @@ export const cancelCorpusProjectionReservationTx = async (
     errorMessage,
   }: CancelCorpusProjectionReservationOptions,
 ): Promise<"cancelled" | "lease_lost"> => {
+  const identities = await tx
+    .select({
+      family: corpusIndexProjectionIntents.family,
+      generation: corpusIndexProjectionIntents.generation,
+    })
+    .from(corpusIndexProjectionIntents)
+    .where(eq(corpusIndexProjectionIntents.id, intentId))
+    .limit(1);
+  const identity = identities.at(0);
+  if (identity === undefined) {
+    return "lease_lost";
+  }
+  await lockCorpusIndexProjectionMutationsTx(tx, [identity]);
   const locked = await tx
     .select({ id: corpusIndexProjectionIntents.id })
     .from(corpusIndexProjectionIntents)
@@ -1073,6 +1083,7 @@ export const classifyCorpusProjectionReservationFailureTx = async (
   if (identity === undefined) {
     return "lease_lost";
   }
+  await lockCorpusIndexProjectionMutationsTx(tx, [identity]);
   const states = await tx
     .select()
     .from(corpusIndexProjectionStates)


### PR DESCRIPTION
## Summary

- acquire the generation mutation fence before projection state or intent row locks
- keep manifest-only reads non-exclusive while making mutation boundaries explicit
- lock multi-generation intent batches in stable order and cover the boundary with database tests

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when updating, cleaning up, repairing, and erasing legal search index projections.
  - Reduced conflicts and database deadlocks during concurrent projection operations.
  - Ensured projection changes are applied consistently across batch, recovery, and settlement workflows.
  - Strengthened coordination between case-law and legislation index updates.

- **Tests**
  - Added coverage for concurrent projection updates, mutation ordering, lock coordination, and deadlock prevention across case-law and legislation data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->