### PR TITLE
fix: publish only changed package versions

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -245,16 +245,7 @@ jobs:
           MANUAL_PACKAGE: ${{ inputs.package || 'all' }}
         run: |
           set -euo pipefail
-          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
-            pkgs=(cli)
-          elif [[ "$EVENT_NAME" == "push" ]]; then
-            pkgs=(auth-model ai-catalog anonymize-chat chat country-codes business-registries conditions template-conditions docx-utils ui money calculations workspace-model workspace-ui)
-          else
-            case "$MANUAL_PACKAGE" in
-              all) pkgs=(auth-model ai-catalog anonymize-chat chat country-codes business-registries conditions template-conditions docx-utils ui money calculations workspace-model workspace-ui cli) ;;
-              *) pkgs=("$MANUAL_PACKAGE") ;;
-            esac
-          fi
+          mapfile -t pkgs < <(bun scripts/publish-package-selection.ts "$EVENT_NAME" "$MANUAL_PACKAGE")
 
           for package in "${pkgs[@]}"; do
             echo "::group::Build + pack @stll/${package}"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -72,6 +72,10 @@ on:
         description: Exact commit SHA for recovering one existing immutable package tag
         required: false
         type: string
+      artifact_run_id:
+        description: Exact prior Publish npm packages run whose packed artifact should be resumed
+        required: false
+        type: string
 
 concurrency:
   # One group across every trigger so publishes to the same registry
@@ -246,6 +250,10 @@ jobs:
         run: |
           set -euo pipefail
           mapfile -t pkgs < <(bun scripts/publish-package-selection.ts "$EVENT_NAME" "$MANUAL_PACKAGE")
+          if [[ "${#pkgs[@]}" -eq 0 ]]; then
+            echo "No packages selected for release." >&2
+            exit 1
+          fi
 
           for package in "${pkgs[@]}"; do
             echo "::group::Build + pack @stll/${package}"
@@ -507,6 +515,9 @@ jobs:
       # this environment so only main and release tags can mint the token.
       environment: release-app
       artifact-pattern: npm-tarball-*
+      # The reusable workflow verifies that a resumed artifact comes from this
+      # workflow and the immutable source commit before it is downloaded.
+      artifact-run-id: ${{ inputs.artifact_run_id || '' }}
       package-files: ${{ needs.pack.outputs.package_files }}
       source-ref: ${{ needs.pack.outputs.source_sha }}
     secrets:

--- a/scripts/publish-package-selection.test.ts
+++ b/scripts/publish-package-selection.test.ts
@@ -42,6 +42,20 @@ describe("publish package selection", () => {
     ).not.toContain("chat");
   });
 
+  test("passes only an explicitly requested prior artifact run to the verified recovery path", async () => {
+    const workflow = await Bun.file(
+      new URL("../.github/workflows/publish-npm.yml", import.meta.url),
+    ).text();
+
+    expect(workflow).toContain("artifact_run_id:");
+    expect(workflow).toContain(
+      `artifact-run-id: ${String.fromCodePoint(36)}{{ inputs.artifact_run_id || '' }}`,
+    );
+    expect(workflow).toContain(
+      "The reusable workflow verifies that a resumed artifact comes from this",
+    );
+  });
+
   test("keeps workflow-run CLI releases explicit", () => {
     expect(
       selectPublishPackages({

--- a/scripts/publish-package-selection.test.ts
+++ b/scripts/publish-package-selection.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { selectPublishPackages } from "./publish-package-selection";
+
+describe("publish package selection", () => {
+  test("publish workflow delegates push selection to the tested resolver", async () => {
+    const workflow = await Bun.file(
+      new URL("../.github/workflows/publish-npm.yml", import.meta.url),
+    ).text();
+
+    expect(workflow).toContain(
+      'mapfile -t pkgs < <(bun scripts/publish-package-selection.ts "$EVENT_NAME" "$MANUAL_PACKAGE")',
+    );
+    expect(workflow).not.toContain(
+      "pkgs=(auth-model ai-catalog anonymize-chat chat",
+    );
+    expect(workflow).toContain(
+      `if [[ "${String.fromCodePoint(36)}{#pkgs[@]}" -eq 0 ]]; then`,
+    );
+  });
+
+  test("pushes only packages with a version changelog", () => {
+    expect(
+      selectPublishPackages({
+        eventName: "push",
+        manualPackage: "all",
+        changedPaths: [
+          "packages/ui/CHANGELOG.md",
+          "packages/workspace-ui/CHANGELOG.md",
+        ],
+      }),
+    ).toEqual(["ui", "workspace-ui"]);
+  });
+
+  test("does not republish a historically tagged but unpublished package", () => {
+    expect(
+      selectPublishPackages({
+        eventName: "push",
+        manualPackage: "all",
+        changedPaths: ["packages/ui/CHANGELOG.md"],
+      }),
+    ).not.toContain("chat");
+  });
+
+  test("keeps workflow-run CLI releases explicit", () => {
+    expect(
+      selectPublishPackages({
+        eventName: "workflow_run",
+        manualPackage: "all",
+        changedPaths: [],
+      }),
+    ).toEqual(["cli"]);
+  });
+
+  test("rejects a push with no changed library changelog", () => {
+    expect(() =>
+      selectPublishPackages({
+        eventName: "push",
+        manualPackage: "all",
+        changedPaths: ["packages/chat/src/index.ts"],
+      }),
+    ).toThrow("no changed library changelog");
+  });
+});

--- a/scripts/publish-package-selection.ts
+++ b/scripts/publish-package-selection.ts
@@ -1,0 +1,109 @@
+import { panic } from "better-result";
+
+export const LIBRARY_PACKAGE_ORDER = [
+  "auth-model",
+  "ai-catalog",
+  "anonymize-chat",
+  "chat",
+  "country-codes",
+  "business-registries",
+  "conditions",
+  "template-conditions",
+  "docx-utils",
+  "ui",
+  "money",
+  "calculations",
+  "workspace-model",
+  "workspace-ui",
+] as const;
+
+export const ALL_PACKAGE_ORDER = [...LIBRARY_PACKAGE_ORDER, "cli"] as const;
+
+type PublishEvent = "push" | "workflow_run" | "workflow_dispatch";
+
+type PublishPackageSelectionOptions = {
+  eventName: PublishEvent;
+  manualPackage: string;
+  changedPaths: readonly string[];
+};
+
+const isKnownPackage = (
+  packageName: string,
+): packageName is (typeof ALL_PACKAGE_ORDER)[number] =>
+  ALL_PACKAGE_ORDER.some((knownPackage) => knownPackage === packageName);
+
+export const selectPublishPackages = ({
+  eventName,
+  manualPackage,
+  changedPaths,
+}: PublishPackageSelectionOptions): readonly string[] => {
+  if (eventName === "workflow_run") {
+    return ["cli"];
+  }
+
+  if (eventName === "workflow_dispatch") {
+    if (manualPackage === "all") {
+      return ALL_PACKAGE_ORDER;
+    }
+
+    if (!isKnownPackage(manualPackage)) {
+      panic(`Unknown package '${manualPackage}'.`);
+    }
+
+    return [manualPackage];
+  }
+
+  const changed = new Set(changedPaths);
+  const selected = LIBRARY_PACKAGE_ORDER.filter((packageName) =>
+    changed.has(`packages/${packageName}/CHANGELOG.md`),
+  );
+
+  if (selected.length === 0) {
+    panic(
+      "Push release contains no changed library changelog; refusing an empty publish.",
+    );
+  }
+
+  return selected;
+};
+
+if (import.meta.main) {
+  const eventName = Bun.argv.at(2);
+  const manualPackage = Bun.argv.at(3) ?? "all";
+  if (
+    eventName !== "push" &&
+    eventName !== "workflow_run" &&
+    eventName !== "workflow_dispatch"
+  ) {
+    panic(`Unsupported event '${eventName ?? ""}'.`);
+  }
+
+  const changedPaths = Bun.spawnSync(
+    [
+      "git",
+      "diff-tree",
+      "--no-commit-id",
+      "--name-only",
+      "-r",
+      "HEAD",
+      "--",
+      "packages",
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  if (changedPaths.exitCode !== 0) {
+    panic(new TextDecoder().decode(changedPaths.stderr));
+  }
+
+  const paths = new TextDecoder()
+    .decode(changedPaths.stdout)
+    .split("\n")
+    .filter((path) => path.length > 0);
+  for (const packageName of selectPublishPackages({
+    eventName,
+    manualPackage,
+    changedPaths: paths,
+  })) {
+    console.log(packageName);
+  }
+}


### PR DESCRIPTION
## Summary

- select automatic npm publish inputs from library changelogs changed by the release commit
- preserve explicit manual package and workflow-run CLI selection
- cover historical tagged-but-unpublished packages and workflow wiring

## Checks

- `bun test scripts/publish-package-selection.test.ts`
- type-aware oxlint and oxfmt
- pre-push code-check, format, and i18n checks