### PR TITLE
fix: preserve tombstoned citation relationships

### DIFF
--- a/apps/api/src/handlers/case-law/provisions/citing-decisions.ts
+++ b/apps/api/src/handlers/case-law/provisions/citing-decisions.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { status, t } from "elysia";
 import type { Static } from "elysia";
@@ -43,6 +43,8 @@ export const listCitingDecisionsQuerySchema = t.Object({
    * authority signal is refreshed in place, so it cannot key a walk.
    */
   sort: t.Optional(t.Union([t.Literal("newest"), t.Literal("authority")])),
+  /** Require a readable excerpt rather than relationship metadata alone. */
+  excerpt: t.Optional(t.Literal("required")),
 });
 
 type ListCitingDecisionsQuery = Static<typeof listCitingDecisionsQuerySchema>;
@@ -136,6 +138,9 @@ export const listCitingDecisionsHandler = async (
   if (query.anchor !== undefined) {
     conditions.push(eq(caseLawProvisionCitations.anchor, query.anchor));
   }
+  if (query.excerpt === "required") {
+    conditions.push(isNull(caseLawDecisions.redactedAt));
+  }
 
   if (query.cursor) {
     const cursor = decodeCitingDecisionsCursor(query.cursor);
@@ -170,7 +175,13 @@ export const listCitingDecisionsHandler = async (
         country: caseLawDecisions.country,
         decisionDate: caseLawDecisions.decisionDate,
         citationAuthority: caseLawDecisions.citationAuthority,
-        sentenceText: caseLawProvisionCitations.sentenceText,
+        // Keep the public citation relationship when its source decision is
+        // tombstoned, but do not return a verbatim excerpt from removed text.
+        sentenceText: sql<string | null>`CASE
+          WHEN ${caseLawDecisions.redactedAt} IS NULL
+          THEN ${caseLawProvisionCitations.sentenceText}
+          ELSE NULL
+        END`.as("sentence_text"),
         spanStart: caseLawProvisionCitations.spanStart,
         spanEnd: caseLawProvisionCitations.spanEnd,
         anchor: caseLawProvisionCitations.anchor,

--- a/apps/api/src/handlers/case-law/provisions/reads.db.test.ts
+++ b/apps/api/src/handlers/case-law/provisions/reads.db.test.ts
@@ -27,6 +27,7 @@ const JURISDICTION = "CZE";
 /** The display citation a decision's own text states. */
 const WORK = "89/2012 Sb.";
 const WORK_ELI = "/eli/cz/sb/2012/89";
+const REDACTED_WORK = "123/2020 Sb.";
 /** A work the corpus does not hold: cited by number, with no ELI to key on. */
 const UNHELD_WORK = "99/1963 Sb.";
 const ANCHOR_A = "s1";
@@ -37,6 +38,7 @@ const closedSourceId = createSafeId<"caseLawSource">();
 const highAuthorityId = createSafeId<"caseLawDecision">();
 const lowAuthorityId = createSafeId<"caseLawDecision">();
 const closedDecisionId = createSafeId<"caseLawDecision">();
+const redactedDecisionId = createSafeId<"caseLawDecision">();
 
 let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
@@ -153,6 +155,16 @@ beforeAll(
         id: closedDecisionId,
         sourceId: closedSourceId,
       }),
+      {
+        ...decisionRow({
+          caseNumber: "redacted",
+          citationAuthority: 200,
+          decisionDate: "2026-02-01",
+          id: redactedDecisionId,
+          sourceId: openSourceId,
+        }),
+        redactedAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
     ]);
 
     await db.insert(caseLawProvisionCitations).values([
@@ -185,6 +197,22 @@ beforeAll(
         decisionDate: "2026-01-01",
         decisionId: closedDecisionId,
         spanStart: 50,
+      }),
+      provisionRow({
+        anchor: ANCHOR_A,
+        decisionDate: "2026-02-01",
+        decisionId: redactedDecisionId,
+        spanStart: 55,
+        workEli: null,
+        workIdentifier: REDACTED_WORK,
+      }),
+      provisionRow({
+        anchor: ANCHOR_A,
+        decisionDate: "2025-01-01",
+        decisionId: lowAuthorityId,
+        spanStart: 65,
+        workEli: null,
+        workIdentifier: REDACTED_WORK,
       }),
       // Cited by number only: the corpus does not hold this act, so the row
       // carries no ELI and no reader can arrive at it from a statute page.
@@ -232,7 +260,9 @@ type CitingDecisionsQuery = {
   anchor?: string;
   cursor?: string;
   eli?: string;
+  excerpt?: "required";
   limit: number;
+  sort?: "authority" | "newest";
   work?: string;
 };
 
@@ -240,7 +270,9 @@ const readCitingDecisions = async ({
   anchor,
   cursor,
   eli,
+  excerpt,
   limit,
+  sort,
   work,
 }: CitingDecisionsQuery) =>
   await listCitingDecisionsHandler(
@@ -250,6 +282,8 @@ const readCitingDecisions = async ({
       ...(anchor === undefined ? {} : { anchor }),
       ...(cursor === undefined ? {} : { cursor }),
       ...(eli === undefined ? {} : { eli }),
+      ...(excerpt === undefined ? {} : { excerpt }),
+      ...(sort === undefined ? {} : { sort }),
       ...(work === undefined ? {} : { work }),
     },
     caseLawDb,
@@ -312,6 +346,32 @@ test("citing decisions order by decision date, newest first", async () => {
   expect(page.items.map((item) => item.decisionId)).not.toContain(
     closedDecisionId,
   );
+});
+
+test("a tombstoned decision keeps its citation edge without its excerpt", async () => {
+  const page = await citingDecisions({ limit: 10, work: REDACTED_WORK });
+
+  expect(page.items).toHaveLength(2);
+  expect(page.items.at(0)).toMatchObject({
+    caseNumber: "redacted",
+    decisionId: redactedDecisionId,
+    sentenceText: null,
+  });
+});
+
+test("excerpt-required authority reads fill their budget before limiting", async () => {
+  const page = await citingDecisions({
+    excerpt: "required",
+    limit: 1,
+    sort: "authority",
+    work: REDACTED_WORK,
+  });
+
+  expect(page.items).toHaveLength(1);
+  expect(page.items.at(0)).toMatchObject({
+    caseNumber: "low",
+    sentenceText: `sentence ${ANCHOR_A} 65`,
+  });
 });
 
 test("citing decisions page through a stable cursor", async () => {

--- a/apps/web/src/features/statutes/components/provision-ask-actions.tsx
+++ b/apps/web/src/features/statutes/components/provision-ask-actions.tsx
@@ -21,7 +21,7 @@ type AskPassage = {
   caseNumber: string;
   court: string;
   decisionDate: string | null;
-  sentenceText: string;
+  sentenceText: string | null;
 };
 
 type ProvisionAskActionsProps = {
@@ -61,20 +61,22 @@ export const ProvisionAskActions = ({
           statute: payload.statuteTitle,
         });
   const label = provisionTabLabel(payload);
+  const passageLines = passages.flatMap((passage) => {
+    if (passage.sentenceText === null) {
+      return [];
+    }
+    const decided = formatValidityDate(passage.decisionDate, format);
+    const source =
+      decided === null
+        ? `${passage.caseNumber} (${passage.court})`
+        : `${passage.caseNumber} (${passage.court}, ${decided})`;
+    return [`- ${source}: ${passage.sentenceText}`];
+  });
   const context =
-    passages.length === 0
+    passageLines.length === 0
       ? ""
       : t("statutes.provisionAskContextPrompt", {
-          passages: passages
-            .map((passage) => {
-              const decided = formatValidityDate(passage.decisionDate, format);
-              const source =
-                decided === null
-                  ? `${passage.caseNumber} (${passage.court})`
-                  : `${passage.caseNumber} (${passage.court}, ${decided})`;
-              return `- ${source}: ${passage.sentenceText}`;
-            })
-            .join("\n"),
+          passages: passageLines.join("\n"),
         });
 
   const summarize = () => {

--- a/apps/web/src/features/statutes/components/provision-citing-decisions.tsx
+++ b/apps/web/src/features/statutes/components/provision-citing-decisions.tsx
@@ -22,7 +22,7 @@ export type CitingDecisionRow = {
   court: string;
   decisionDate: string | null;
   decisionId: string;
-  sentenceText: string;
+  sentenceText: string | null;
   slug: string | null;
 };
 
@@ -53,9 +53,11 @@ export const CitingDecisionItem = ({
       <span className="text-muted-foreground text-[0.7rem]">
         {decided === null ? decision.court : `${decision.court} · ${decided}`}
       </span>
-      <span className="text-foreground-strong-muted line-clamp-3 text-[0.72rem] leading-snug">
-        {decision.sentenceText}
-      </span>
+      {decision.sentenceText === null ? null : (
+        <span className="text-foreground-strong-muted line-clamp-3 text-[0.72rem] leading-snug">
+          {decision.sentenceText}
+        </span>
+      )}
     </CitedDecisionLink>
   );
 };

--- a/apps/web/src/features/statutes/provision-inspector.logic.test.ts
+++ b/apps/web/src/features/statutes/provision-inspector.logic.test.ts
@@ -188,4 +188,17 @@ describe("filterCitingDecisions", () => {
     ]);
     expect(filterCitingDecisions(decisions, "no such court")).toEqual([]);
   });
+
+  test("a citation without an excerpt remains searchable by its metadata", () => {
+    const rows = [
+      {
+        caseNumber: "4 As 3/2008",
+        court: "Nejvyšší správní soud",
+        sentenceText: null,
+      },
+    ];
+
+    expect(filterCitingDecisions(rows, "správní")).toEqual(rows);
+    expect(filterCitingDecisions(rows, "null")).toEqual([]);
+  });
 });

--- a/apps/web/src/features/statutes/provision-inspector.logic.ts
+++ b/apps/web/src/features/statutes/provision-inspector.logic.ts
@@ -117,7 +117,7 @@ export const submitsOnEnter = ({
 type CitingDecisionRow = {
   caseNumber: string;
   court: string;
-  sentenceText: string;
+  sentenceText: string | null;
 };
 
 const foldForFilter = (value: string): string =>
@@ -139,7 +139,7 @@ export const filterCitingDecisions = <T extends CitingDecisionRow>(
 
   return decisions.filter((decision) =>
     foldForFilter(
-      `${decision.caseNumber} ${decision.court} ${decision.sentenceText}`,
+      `${decision.caseNumber} ${decision.court} ${decision.sentenceText ?? ""}`,
     ).includes(needle),
   );
 };

--- a/apps/web/src/features/statutes/queries/citing-decisions.ts
+++ b/apps/web/src/features/statutes/queries/citing-decisions.ts
@@ -51,6 +51,7 @@ export const topCitingDecisionsOptions = (key: CitingDecisionsKey) =>
         query: {
           anchor: key.anchor,
           eli: key.eli,
+          excerpt: "required",
           jurisdiction: key.jurisdiction,
           limit: TOP_CITING_LIMIT,
           sort: "authority",


### PR DESCRIPTION
Keep provision-citation edges and decision metadata after an explicit source tombstone. The reverse-citation reader omits only the verbatim excerpt, and the viewer, filters, and AI context handle that nullable excerpt without hiding the relationship.