### PR TITLE
fix: preserve historical npm recovery

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -249,7 +249,16 @@ jobs:
           MANUAL_PACKAGE: ${{ inputs.package || 'all' }}
         run: |
           set -euo pipefail
-          mapfile -t pkgs < <(bun scripts/publish-package-selection.ts "$EVENT_NAME" "$MANUAL_PACKAGE")
+          # A historical source checkout predates this selector. Recovery is
+          # always one named non-CLI package, so resolve it from the workflow
+          # input instead of asking the old source to run new tooling.
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            pkgs=(cli)
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" && "$MANUAL_PACKAGE" != "all" ]]; then
+            pkgs=("$MANUAL_PACKAGE")
+          else
+            mapfile -t pkgs < <(bun scripts/publish-package-selection.ts "$EVENT_NAME" "$MANUAL_PACKAGE")
+          fi
           if [[ "${#pkgs[@]}" -eq 0 ]]; then
             echo "No packages selected for release." >&2
             exit 1

--- a/scripts/publish-package-selection.test.ts
+++ b/scripts/publish-package-selection.test.ts
@@ -56,6 +56,20 @@ describe("publish package selection", () => {
     );
   });
 
+  test("selects an explicit historical recovery package without requiring new tooling in old source", async () => {
+    const workflow = await Bun.file(
+      new URL("../.github/workflows/publish-npm.yml", import.meta.url),
+    ).text();
+
+    expect(workflow).toContain(
+      'elif [[ "$EVENT_NAME" == "workflow_dispatch" && "$MANUAL_PACKAGE" != "all" ]]; then',
+    );
+    expect(workflow).toContain('pkgs=("$MANUAL_PACKAGE")');
+    expect(workflow).toContain(
+      "Recovery is\n          # always one named non-CLI package",
+    );
+  });
+
   test("keeps workflow-run CLI releases explicit", () => {
     expect(
       selectPublishPackages({


### PR DESCRIPTION
Allows an explicit one-package workflow dispatch to use the historical source without requiring the newly introduced selector script. This preserves the exact-artifact recovery path for a pre-existing immutable package tag.