### PR TITLE
fix: render rich clipboard clips cleanly

### DIFF
--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -975,8 +975,9 @@ fn sanitized_html(raw_html: &str) -> Option<String> {
   ]);
   let html = HtmlSanitizer::new()
     .tags(allowed_tags)
-    .clean(raw_html)
+    .clean(&without_word_list_spacers(raw_html))
     .to_string();
+  let html = collapse_html_whitespace(&html);
   let has_formatting = [
     "b",
     "blockquote",
@@ -992,17 +993,103 @@ fn sanitized_html(raw_html: &str) -> Option<String> {
     "ul",
   ]
   .iter()
-  .any(|tag| contains_opening_tag(&html, tag));
+  .any(|tag| find_opening_tag(&html, tag).is_some());
   if has_formatting { Some(html) } else { None }
 }
 
-fn contains_opening_tag(html: &str, tag: &str) -> bool {
+/// Word separates an auto-numbered list label from its paragraph with a span in
+/// this font holding a run of `&nbsp;`; the run is layout, not text.
+const WORD_LIST_SPACER_FONTS: [&str; 2] = [
+  "font:7.0pt \"Times New Roman\"",
+  "font:7.0pt &quot;Times New Roman&quot;",
+];
+
+fn without_word_list_spacers(raw_html: &str) -> String {
+  let mut output = String::with_capacity(raw_html.len());
+  let mut rest = raw_html;
+  while let Some((start, end)) = next_word_list_spacer(rest) {
+    output.push_str(&rest[..start]);
+    output.push(' ');
+    rest = &rest[end..];
+  }
+  output.push_str(rest);
+  output
+}
+
+/// Byte range of the next spacer `<span>` whose content is only `&nbsp;` and
+/// whitespace. Every index used to slice lands on ASCII, so the slices are valid.
+fn next_word_list_spacer(html: &str) -> Option<(usize, usize)> {
+  let mut search_from = 0;
+  while let Some(offset) = WORD_LIST_SPACER_FONTS
+    .iter()
+    .filter_map(|font| html[search_from..].find(font))
+    .min()
+  {
+    let font_index = search_from + offset;
+    search_from = font_index + 1;
+    let Some(span_start) = html[..font_index].rfind("<span") else {
+      continue;
+    };
+    if html[span_start..font_index].contains('>') {
+      continue;
+    }
+    let content_start = font_index + html[font_index..].find('>')? + 1;
+    let content_len = html[content_start..].find("</span>")?;
+    let content = &html[content_start..content_start + content_len];
+    if content
+      .split("&nbsp;")
+      .all(|chunk| chunk.chars().all(char::is_whitespace))
+    {
+      return Some((span_start, content_start + content_len + "</span>".len()));
+    }
+  }
+  None
+}
+
+/// Collapses source whitespace outside `<pre>` the way HTML renders it, so
+/// previews and derived plain text never inherit the source line wrapping that
+/// Word and browsers put in clipboard HTML.
+fn collapse_html_whitespace(html: &str) -> String {
+  let mut output = String::with_capacity(html.len());
+  let mut rest = html;
+  while let Some(pre_start) = find_opening_tag(rest, "pre") {
+    let pre_end = rest[pre_start..]
+      .find("</pre>")
+      .map_or(rest.len(), |index| pre_start + index + "</pre>".len());
+    push_collapsed_whitespace(&mut output, &rest[..pre_start]);
+    output.push_str(&rest[pre_start..pre_end]);
+    rest = &rest[pre_end..];
+  }
+  push_collapsed_whitespace(&mut output, rest);
+  output.trim().to_string()
+}
+
+fn push_collapsed_whitespace(output: &mut String, html: &str) {
+  let mut pending_space = false;
+  for character in html.chars() {
+    if character.is_ascii_whitespace() {
+      pending_space = true;
+      continue;
+    }
+    if pending_space {
+      output.push(' ');
+      pending_space = false;
+    }
+    output.push(character);
+  }
+  if pending_space {
+    output.push(' ');
+  }
+}
+
+fn find_opening_tag(html: &str, tag: &str) -> Option<usize> {
   let prefix = format!("<{tag}");
-  html.match_indices(&prefix).any(|(index, _)| {
+  html.match_indices(&prefix).find_map(|(index, _)| {
     html
       .as_bytes()
       .get(index + prefix.len())
       .is_some_and(|byte| *byte == b'>' || byte.is_ascii_whitespace())
+      .then_some(index)
   })
 }
 
@@ -1576,6 +1663,66 @@ mod tests {
     assert_eq!(sanitized_html("<span>plain</span>"), None);
     assert_eq!(sanitized_html("line<br>break"), None);
     assert!(sanitized_html("<strong>bold</strong>").is_some());
+  }
+
+  /// Shape of the HTML Word puts on the clipboard: document chrome before the
+  /// fragment, source lines wrapped at ~72 columns, and an auto-numbered list
+  /// label followed by a tiny-font `&nbsp;` spacer.
+  const WORD_CLIPBOARD_HTML: &str = concat!(
+    "<html xmlns:o=\"urn:schemas-microsoft-com:office:office\"\n",
+    "xmlns=\"http://www.w3.org/TR/REC-html40\">\n\n<head>\n",
+    "<meta http-equiv=Content-Type content=\"text/html; charset=utf-8\">\n",
+    "<meta name=Generator content=\"Microsoft Word 15\">\n",
+    "<!--[if gte mso 9]><xml>\n <o:OfficeDocumentSettings>\n",
+    " </o:OfficeDocumentSettings>\n</xml><![endif]-->\n",
+    "<style>\n<!--\n@list l0:level1\n\t{mso-level-tab-stop:none;}\n-->\n</style>\n",
+    "</head>\n\n<body lang=EN-US style='tab-interval:.5in'>\n",
+    "<!--StartFragment-->\n\n",
+    "<p class=MsoListParagraph style='margin-left:.5in;text-indent:-.25in;\n",
+    "mso-list:l0 level1 lfo1'><![if !supportLists]><b><span\n",
+    "style='mso-list:Ignore'>11.<span style='font:7.0pt \"Times New Roman\"'>",
+    "&nbsp;&nbsp;&nbsp;&nbsp; </span></span></b><![endif]><b>General</b>. ",
+    "Neither party has an obligation\nunder this MNDA to disclose ",
+    "Confidential Information to the other or proceed with\nany proposed ",
+    "transaction.</p>\n\n<!--EndFragment-->\n</body>\n\n</html>\n",
+  );
+
+  #[test]
+  fn sanitizer_collapses_word_document_chrome_and_source_line_wrapping() {
+    let html = sanitized_html(WORD_CLIPBOARD_HTML).unwrap();
+
+    assert!(html.starts_with("<p>"), "{html}");
+    assert!(!html.contains('\n'), "{html}");
+    assert!(
+      html.contains("Neither party has an obligation under this MNDA"),
+      "{html}"
+    );
+    assert!(html.contains("<b>General</b>. Neither"), "{html}");
+  }
+
+  #[test]
+  fn sanitizer_replaces_word_list_spacers_with_a_single_space() {
+    let html = sanitized_html(WORD_CLIPBOARD_HTML).unwrap();
+
+    assert!(!html.contains("&nbsp;"), "{html}");
+    assert!(html.contains("11. </span></b><b>General</b>"), "{html}");
+  }
+
+  #[test]
+  fn sanitizer_keeps_meaningful_non_breaking_spaces() {
+    let html = sanitized_html(
+      "<p><b>Section</b>&nbsp;5 <span style='font:7.0pt \"Times New Roman\"'>kept</span></p>",
+    )
+    .unwrap();
+
+    assert_eq!(html, "<p><b>Section</b>&nbsp;5 <span>kept</span></p>");
+  }
+
+  #[test]
+  fn sanitizer_preserves_preformatted_whitespace() {
+    let html = sanitized_html("<p>a\n\n  b</p>\n<pre>a\n  b</pre>\n").unwrap();
+
+    assert_eq!(html, "<p>a b</p> <pre>a\n  b</pre>");
   }
 
   #[test]

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -1214,6 +1214,9 @@ const ClipboardApp = () => {
     };
     const handleWindowFocus = () => {
       setAgeReferenceTime(Date.now());
+      // The pointer may have moved while the window was hidden; the next
+      // pointer move only seeds the position.
+      railPointerRef.current = null;
       if (welcomeOpen) {
         return;
       }

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -1473,7 +1473,7 @@ const ClipboardApp = () => {
       return;
     }
     const index = event.target.closest<HTMLElement>("[data-clipboard-index]")
-      ?.dataset.clipboardIndex;
+      ?.dataset["clipboardIndex"];
     if (index !== undefined) {
       setSelectedIndex(Number(index));
     }

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   CSSProperties,
   MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
   ReactNode,
 } from "react";
 
@@ -80,6 +81,7 @@ import {
   adjacentClipboardIndex,
   CLIPBOARD_ITEM_DRAG_TYPE,
   clipboardDraggedItemId,
+  clipboardPointerMoved,
   clipboardRailScrollDelta,
   clipboardRailWindow,
   clipboardSourceTintIndex,
@@ -92,6 +94,7 @@ import {
   quickCopyIndex,
   shouldCopyFromClipboardInput,
 } from "./clipboard-logic";
+import type { ClipboardPointerPosition } from "./clipboard-logic";
 import {
   markClipboardShellCommit,
   markClipboardSnapshotApplied,
@@ -271,10 +274,13 @@ const ClipboardCard = ({
   const sourceStyle: ClipboardCardStyle | undefined = accent
     ? { "--clipboard-source-accent": accent }
     : undefined;
+  const rendersHtml = item.type === "formattedText" && !query;
   const previewClassName = cn(
-    "text-foreground line-clamp-[8] text-sm leading-5 text-pretty break-words whitespace-pre-wrap",
-    item.type === "formattedText" &&
-      "[&_blockquote]:border-s-2 [&_blockquote]:ps-3 [&_code]:font-mono [&_li]:ms-4 [&_ol]:list-decimal [&_strong]:font-semibold [&_ul]:list-disc",
+    "text-foreground line-clamp-[8] text-sm leading-5 text-pretty break-words",
+    // HTML collapses its source whitespace; only plain text (and <pre>) keeps it.
+    rendersHtml
+      ? "[&_blockquote]:border-s-2 [&_blockquote]:ps-3 [&_code]:font-mono [&_li]:ms-4 [&_ol]:list-decimal [&_pre]:whitespace-pre-wrap [&_strong]:font-semibold [&_ul]:list-disc"
+      : "whitespace-pre-wrap",
   );
   const highlightedText = highlightClipboardText(item.plainText, query);
   let previewContent: ReactNode = (
@@ -282,7 +288,7 @@ const ClipboardCard = ({
       {item.plainText}
     </div>
   );
-  if (item.type === "formattedText" && !query) {
+  if (rendersHtml) {
     previewContent = (
       <div
         className={previewClassName}
@@ -366,6 +372,7 @@ const ClipboardCard = ({
         active ? "opacity-100" : "opacity-86 hover:opacity-100",
       )}
       data-clipboard-id={item.id}
+      data-clipboard-index={index}
       data-dragging={dragging ? "" : undefined}
       data-source-tint={sourceTintIndex ?? undefined}
       role="listitem"
@@ -378,11 +385,6 @@ const ClipboardCard = ({
         onClick={() => onCopy(item)}
         onContextMenu={(event) => onOpenMenu(event, item, index)}
         onFocus={() => onSelect(index)}
-        onPointerMove={(event) => {
-          if (event.pointerType === "mouse") {
-            onSelect(index);
-          }
-        }}
         type="button"
       >
         <div className="relative min-h-0 flex-1 self-stretch overflow-hidden p-5">
@@ -1056,6 +1058,7 @@ const ClipboardApp = () => {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const timelineRef = useRef<HTMLDivElement>(null);
   const timelineRailRef = useRef<HTMLDivElement>(null);
+  const railPointerRef = useRef<ClipboardPointerPosition | null>(null);
   const contextMenuTriggerRef = useRef<HTMLElement>(null);
   const snapshotRequestIdRef = useRef(0);
   const [snapshot, setSnapshot] = useState<ClipboardSnapshot>(EMPTY_SNAPSHOT);
@@ -1459,6 +1462,23 @@ const ClipboardApp = () => {
     }
   };
 
+  const handleRailPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.pointerType !== "mouse") {
+      return;
+    }
+    const position = { x: event.screenX, y: event.screenY };
+    const moved = clipboardPointerMoved(railPointerRef.current, position);
+    railPointerRef.current = position;
+    if (!moved || !(event.target instanceof Element)) {
+      return;
+    }
+    const index = event.target.closest<HTMLElement>("[data-clipboard-index]")
+      ?.dataset.clipboardIndex;
+    if (index !== undefined) {
+      setSelectedIndex(Number(index));
+    }
+  };
+
   const navigate = (direction: "next" | "previous") => {
     const nextIndex = adjacentClipboardIndex(
       activeIndex,
@@ -1683,6 +1703,7 @@ const ClipboardApp = () => {
           <div
             aria-label={t("timeline")}
             className="absolute inset-0 flex scrollbar-none items-stretch gap-3 overflow-x-auto overscroll-x-none px-5 py-1"
+            onPointerMove={handleRailPointerMove}
             ref={timelineRailRef}
             role="list"
           >

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -219,7 +219,8 @@ export type ClipboardPointerPosition = {
 export const clipboardPointerMoved = (
   previous: ClipboardPointerPosition | null,
   current: ClipboardPointerPosition,
-) => previous !== null && (previous.x !== current.x || previous.y !== current.y);
+) =>
+  previous !== null && (previous.x !== current.x || previous.y !== current.y);
 
 export const adjacentClipboardIndex = (
   currentIndex: number,

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -213,12 +213,13 @@ export type ClipboardPointerPosition = {
  * Browsers replay a pointer move at the unchanged screen position after a
  * scroll so hover state follows the content; only a pointer that actually
  * moved may change the selection, or arrow-key scrolling would hand it back to
- * the card that slid under the cursor.
+ * the card that slid under the cursor. The first event after (re)opening only
+ * seeds the position: a pointer resting over the rail has not moved either.
  */
 export const clipboardPointerMoved = (
   previous: ClipboardPointerPosition | null,
   current: ClipboardPointerPosition,
-) => previous === null || previous.x !== current.x || previous.y !== current.y;
+) => previous !== null && (previous.x !== current.x || previous.y !== current.y);
 
 export const adjacentClipboardIndex = (
   currentIndex: number,

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -204,6 +204,22 @@ export const filterClipboardItems = (
   });
 };
 
+export type ClipboardPointerPosition = {
+  x: number;
+  y: number;
+};
+
+/**
+ * Browsers replay a pointer move at the unchanged screen position after a
+ * scroll so hover state follows the content; only a pointer that actually
+ * moved may change the selection, or arrow-key scrolling would hand it back to
+ * the card that slid under the cursor.
+ */
+export const clipboardPointerMoved = (
+  previous: ClipboardPointerPosition | null,
+  current: ClipboardPointerPosition,
+) => previous === null || previous.x !== current.x || previous.y !== current.y;
+
 export const adjacentClipboardIndex = (
   currentIndex: number,
   direction: "next" | "previous",

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -4,6 +4,7 @@ import {
   adjacentClipboardIndex,
   CLIPBOARD_ITEM_DRAG_TYPE,
   clipboardDraggedItemId,
+  clipboardPointerMoved,
   clipboardTimelineKeyAction,
   clipboardRailScrollDelta,
   clipboardRailWindow,
@@ -158,6 +159,16 @@ describe("keyboard indexes", () => {
     expect(adjacentClipboardIndex(1, "previous", 2)).toBe(0);
     expect(adjacentClipboardIndex(0, "previous", 2)).toBeNull();
     expect(adjacentClipboardIndex(0, "next", 0)).toBeNull();
+  });
+
+  test("a pointer move replayed after a scroll does not count as movement", () => {
+    expect(clipboardPointerMoved(null, { x: 10, y: 20 })).toBe(true);
+    expect(clipboardPointerMoved({ x: 10, y: 20 }, { x: 10, y: 20 })).toBe(
+      false,
+    );
+    expect(clipboardPointerMoved({ x: 10, y: 20 }, { x: 11, y: 20 })).toBe(
+      true,
+    );
   });
 
   test("quick copy only accepts visible slots one through nine", () => {

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -162,7 +162,7 @@ describe("keyboard indexes", () => {
   });
 
   test("a pointer move replayed after a scroll does not count as movement", () => {
-    expect(clipboardPointerMoved(null, { x: 10, y: 20 })).toBe(true);
+    expect(clipboardPointerMoved(null, { x: 10, y: 20 })).toBe(false);
     expect(clipboardPointerMoved({ x: 10, y: 20 }, { x: 10, y: 20 })).toBe(
       false,
     );


### PR DESCRIPTION
## Summary

- Office clipboard HTML carries document chrome, source lines wrapped at ~72 columns, and list labels padded with a tiny-font run of `&nbsp;`. Sanitizing kept the surrounding whitespace and the card preview rendered it with `pre-wrap`, so the first eight lines were blank and the clamp showed only an ellipsis; the spacer became visible spaces on paste.
- `sanitized_html` now replaces the list-label spacer span with a single space before sanitizing and collapses source whitespace outside `<pre>` afterwards. HTML previews render with normal whitespace (`<pre>` keeps `pre-wrap`); plain-text and search-highlight previews are unchanged, so already-persisted clips render correctly too.
- Cards are selected on real pointer movement only. Browsers replay a pointer move at the unchanged screen position after a scroll, which handed arrow-key selection back to whichever card slid under the cursor.

Tests: Office-shaped HTML fixture for the sanitizer (chrome, line wrapping, spacer, `<pre>`, meaningful `&nbsp;`), and the replayed-pointer guard.

https://claude.ai/code/session_01EWxA43hVUX6fADA4B6bgjM
