### PR TITLE
fix: open the clipboard window on the newest clip in the system font

### DIFF
--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -1240,11 +1240,18 @@ const ClipboardApp = () => {
       timelineRef.current?.focus();
     };
     window.addEventListener("focus", handleWindowFocus);
+    // A card other than the active one holds focus when a snapshot landed
+    // after an open (a clip copied right before it slid in at the front);
+    // focus follows the selection.
+    const focusedCardId =
+      document.activeElement?.closest<HTMLElement>("[data-clipboard-id]")
+        ?.dataset["clipboardId"] ?? null;
     if (
       !welcomeOpen &&
       document.hasFocus() &&
       (document.activeElement === document.body ||
-        document.activeElement === timelineRef.current)
+        document.activeElement === timelineRef.current ||
+        (focusedCardId !== null && focusedCardId !== activeItemId))
     ) {
       focusActiveCard();
     }

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -5,6 +5,7 @@ import type {
   PointerEvent as ReactPointerEvent,
   ReactNode,
 } from "react";
+import { flushSync } from "react-dom";
 
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import {
@@ -1212,6 +1213,9 @@ const ClipboardApp = () => {
       }
       timelineRef.current?.focus();
     };
+    // The window hides on blur, so a focus event is always an open, and every
+    // open starts on the newest clip. flushSync commits the reset first so the
+    // newest card is in the DOM (the rail is virtualized) before it is focused.
     const handleWindowFocus = () => {
       setAgeReferenceTime(Date.now());
       // The pointer may have moved while the window was hidden; the next
@@ -1220,7 +1224,20 @@ const ClipboardApp = () => {
       if (welcomeOpen) {
         return;
       }
-      focusActiveCard();
+      flushSync(() => {
+        setQuery("");
+        setSelectedIndex(0);
+      });
+      const newestItem = filterClipboardItems(
+        snapshot.items,
+        "",
+        activeGroupId,
+      ).at(0);
+      if (newestItem) {
+        focusCard(timelineRailRef.current, newestItem.id);
+        return;
+      }
+      timelineRef.current?.focus();
     };
     window.addEventListener("focus", handleWindowFocus);
     if (
@@ -1232,7 +1249,7 @@ const ClipboardApp = () => {
       focusActiveCard();
     }
     return () => window.removeEventListener("focus", handleWindowFocus);
-  }, [activeItemId, welcomeOpen]);
+  }, [activeGroupId, activeItemId, snapshot.items, welcomeOpen]);
 
   const nextGroupColor =
     CLIPBOARD_GROUP_COLORS.at(

--- a/apps/desktop/src/mainview/index.css
+++ b/apps/desktop/src/mainview/index.css
@@ -37,6 +37,24 @@ body:has(.clipboard-editor-window) {
   overflow: hidden;
 }
 
+/* The clipboard windows are OS utilities: they use the system typeface, not
+ * the product one. `.font-sans` is inlined by the design system's theme, so
+ * it is overridden here too. */
+body:has(.clipboard-window),
+body:has(.clipboard-editor-window),
+body:has(.clipboard-window) .font-sans,
+body:has(.clipboard-editor-window) .font-sans {
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    sans-serif,
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    "Noto Color Emoji";
+}
+
 .clipboard-window {
   --clipboard-search-placeholder: var(--foreground-placeholder);
   --clipboard-search-text: var(--foreground);


### PR DESCRIPTION
## Summary

Stacked on #2684.

- The webview survives hide/show, so the selection and search query from the previous open leaked into the next one, and the "current" card drifted as new clips were inserted at the front. The window hides on blur, so a `focus` event is always an open: the handler now resets the query and selection, commits that with `flushSync` (the rail is virtualized, so the newest card must exist before it can be focused), and focuses the newest card, which also scrolls the rail back to the start.
- Clipboard windows are OS utilities: they now render in the system typeface (`system-ui`, Segoe UI on Windows) instead of the product one, including the design system's inlined `.font-sans` shortcut hints.

https://claude.ai/code/session_01EWxA43hVUX6fADA4B6bgjM
