### PR TITLE
feat(landing): date sitemap entries from git history

### DIFF
--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -8,6 +8,7 @@ import stllAnonymizeWasm from "@stll/anonymize-wasm/vite";
 import { UI_LOCALES } from "@stll/locales";
 
 import { ogCards } from "./src/integrations/og-cards";
+import { sitemapLastmod } from "./src/integrations/sitemap-lastmod";
 
 // Keep this aligned with the production CDN response-headers policy.
 // `wasm-unsafe-eval` permits WebAssembly compilation without enabling
@@ -28,6 +29,14 @@ const astroLocales = UI_LOCALES.map((tag) =>
 const sitemapLocales = Object.fromEntries(
   UI_LOCALES.map((tag) => [tag === "en" ? "en" : tag.toLowerCase(), tag]),
 );
+const lastmod = sitemapLastmod({
+  localeTagByPath: new Map(
+    UI_LOCALES.filter((tag) => tag !== "en").map((tag) => [
+      tag.toLowerCase(),
+      tag,
+    ]),
+  ),
+});
 
 export default defineConfig({
   site: "https://stll.app",
@@ -50,12 +59,8 @@ export default defineConfig({
   // adjacent inline elements (footer "·" separators, inline link runs).
   // Keep the v6 behavior so existing spacing renders unchanged.
   compressHTML: true,
-  // `lastmod` is intentionally omitted: stamping every URL with the
-  // build timestamp would lie about which pages actually changed and
-  // train crawlers to discount the field site-wide. Add per-URL lastmod
-  // via @astrojs/sitemap's serialize() once there is real content to
-  // source dates from.
   integrations: [
+    lastmod.integration,
     // Docs live under /docs (every entry sits in src/content/docs/docs/),
     // English-only, structured by Diátaxis (get started / how-to /
     // reference / explanation). The landing keeps its own 404 page.
@@ -92,7 +97,6 @@ export default defineConfig({
       ],
     }),
     sitemap({
-      changefreq: "weekly",
       // The /changelog/<release> stubs are noindex link-preview redirect pages;
       // Starlight also emits fallback copies of the English-only docs under
       // every configured locale. Keep both classes of noindex page out of the
@@ -114,6 +118,12 @@ export default defineConfig({
       i18n: {
         defaultLocale: "en",
         locales: sitemapLocales,
+      },
+      // <lastmod> from the newest commit touching each page's sources; a
+      // shallow checkout emits none rather than a fabricated date.
+      serialize: (item) => {
+        const date = lastmod.lastmodFor(item.url);
+        return date === undefined ? item : { ...item, lastmod: date };
       },
     }),
     react(),

--- a/apps/landing/src/integrations/sitemap-lastmod.test.ts
+++ b/apps/landing/src/integrations/sitemap-lastmod.test.ts
@@ -15,11 +15,13 @@ const sources = (pathname: string) =>
   sitemapSources({ pathname, localeTagByPath });
 
 describe("sitemapSources", () => {
-  test("home pages date from the home component and their locale catalog", () => {
+  test("home pages date from the home component, locale catalog and the releases they show", () => {
     expect(sources("/")).toEqual([
       "apps/landing/src/components/HomePage.astro",
       "apps/landing/src/data/product-story.ts",
       "apps/landing/src/i18n/messages/en.json",
+      "apps/landing/src/data/changelog-release-dates.json",
+      "docs/changelog/",
     ]);
     expect(sources("/pt-br/")).toContain(
       "apps/landing/src/i18n/messages/pt-BR.json",

--- a/apps/landing/src/integrations/sitemap-lastmod.test.ts
+++ b/apps/landing/src/integrations/sitemap-lastmod.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  lastmodFromDates,
+  parseGitLog,
+  sitemapSources,
+} from "./sitemap-lastmod";
+
+const localeTagByPath = new Map([
+  ["cs", "cs"],
+  ["pt-br", "pt-BR"],
+]);
+
+const sources = (pathname: string) =>
+  sitemapSources({ pathname, localeTagByPath });
+
+describe("sitemapSources", () => {
+  test("home pages date from the home component and their locale catalog", () => {
+    expect(sources("/")).toEqual([
+      "apps/landing/src/components/HomePage.astro",
+      "apps/landing/src/data/product-story.ts",
+      "apps/landing/src/i18n/messages/en.json",
+    ]);
+    expect(sources("/pt-br/")).toContain(
+      "apps/landing/src/i18n/messages/pt-BR.json",
+    );
+  });
+
+  test("product pages date from their product module and locale catalog", () => {
+    expect(sources("/cs/product/editor/")).toEqual([
+      "apps/landing/src/data/products/editor.ts",
+      "apps/landing/src/components/ProductPage.astro",
+      "apps/landing/src/i18n/product-copy.ts",
+      "apps/landing/src/i18n/messages/cs.json",
+    ]);
+  });
+
+  test("docs pages try both markdown extensions", () => {
+    expect(sources("/docs/")).toEqual([
+      "apps/landing/src/content/docs/docs/index.md",
+      "apps/landing/src/content/docs/docs/index.mdx",
+    ]);
+    expect(sources("/docs/get-started/cli/")).toEqual([
+      "apps/landing/src/content/docs/docs/get-started/cli.md",
+      "apps/landing/src/content/docs/docs/get-started/cli.mdx",
+    ]);
+  });
+
+  test("blog posts date from their content file, the index from the directory", () => {
+    expect(sources("/blog/relicensing-to-apache-2-0/")).toEqual([
+      "apps/landing/src/content/blog/relicensing-to-apache-2-0.md",
+    ]);
+    expect(sources("/blog/")).toContain("apps/landing/src/content/blog/");
+  });
+
+  test("utility pages are mapped explicitly", () => {
+    expect(sources("/changelog/")).toContain("docs/changelog/");
+    expect(sources("/security/")).toContain(
+      "apps/landing/src/data/security-controls.ts",
+    );
+  });
+
+  test("unmapped pages panic instead of inheriting a date", () => {
+    expect(() => sources("/nowhere/")).toThrow("no source mapping");
+    expect(() => sources("/cs/docs/")).toThrow("localized page");
+    expect(() => sources("/product/editor/extra/")).toThrow(
+      "no source mapping",
+    );
+  });
+});
+
+describe("lastmodFromDates", () => {
+  const dates = new Map([
+    ["a.ts", "2026-08-01T10:00:00+02:00"],
+    ["b.ts", "2026-08-01T09:30:00Z"],
+    ["dir/x.md", "2026-07-01T00:00:00Z"],
+    ["dir/y.md", "2026-07-15T00:00:00Z"],
+  ]);
+
+  test("picks the newest instant, comparing across offsets", () => {
+    expect(lastmodFromDates(["a.ts", "b.ts"], dates)).toBe(
+      "2026-08-01T09:30:00.000Z",
+    );
+  });
+
+  test("skips absent candidates and expands directories", () => {
+    expect(lastmodFromDates(["missing.md", "dir/"], dates)).toBe(
+      "2026-07-15T00:00:00.000Z",
+    );
+  });
+
+  test("panics when no source has history", () => {
+    expect(() => lastmodFromDates(["missing.md"], dates)).toThrow(
+      "none of the sources exist",
+    );
+  });
+});
+
+describe("parseGitLog", () => {
+  test("keeps the first (newest) date per path", () => {
+    const log = [
+      "2026-08-30T12:00:00+02:00",
+      "",
+      "apps/landing/src/pages/press.astro",
+      "docs/changelog/v0.7.31.md",
+      "",
+      "2026-08-01T12:00:00+02:00",
+      "",
+      "apps/landing/src/pages/press.astro",
+      "apps/landing/src/data/ai-facts.ts",
+    ].join("\n");
+    const parsed = parseGitLog(log);
+    expect(parsed.get("apps/landing/src/pages/press.astro")).toBe(
+      "2026-08-30T12:00:00+02:00",
+    );
+    expect(parsed.get("apps/landing/src/data/ai-facts.ts")).toBe(
+      "2026-08-01T12:00:00+02:00",
+    );
+    expect(parsed.size).toBe(3);
+  });
+});

--- a/apps/landing/src/integrations/sitemap-lastmod.ts
+++ b/apps/landing/src/integrations/sitemap-lastmod.ts
@@ -1,0 +1,226 @@
+// Gives every sitemap entry a truthful <lastmod>: the newest commit that
+// touched the sources a page renders from. A build without history (a
+// shallow checkout) emits no <lastmod> at all rather than stamping today's
+// date on 134 unchanged pages, which crawlers learn to ignore.
+import type { AstroIntegration } from "astro";
+import { panic } from "better-result";
+import { execFileSync } from "node:child_process";
+
+const SRC = "apps/landing/src";
+const MESSAGES = `${SRC}/i18n/messages`;
+const DOCS = `${SRC}/content/docs/docs`;
+const BLOG = `${SRC}/content/blog`;
+const CHANGELOG = "docs/changelog";
+
+// A trailing slash marks a directory: any file below it counts.
+const UTILITY_SOURCES: ReadonlyMap<string, readonly string[]> = new Map([
+  ["ai-info", [`${SRC}/pages/ai-info.astro`, `${SRC}/data/ai-facts.ts`]],
+  [
+    "security",
+    [`${SRC}/pages/security.astro`, `${SRC}/data/security-controls.ts`],
+  ],
+  [
+    "changelog",
+    [
+      `${SRC}/pages/changelog.astro`,
+      `${SRC}/data/changelog-release-dates.json`,
+      `${CHANGELOG}/`,
+    ],
+  ],
+  ["press", [`${SRC}/pages/press.astro`]],
+  ["privacy", [`${SRC}/pages/privacy.astro`]],
+  ["terms", [`${SRC}/pages/terms.astro`]],
+  ["imprint", [`${SRC}/pages/imprint.astro`]],
+  ["docx-editor", [`${SRC}/pages/docx-editor.astro`]],
+  ["blog", [`${SRC}/pages/blog/index.astro`, `${BLOG}/`]],
+]);
+
+type SitemapSourcesOptions = {
+  pathname: string;
+  // URL path prefix → locale tag, default locale excluded (it sits at root).
+  localeTagByPath: ReadonlyMap<string, string>;
+};
+
+// Repo-relative paths whose last change dates the page. Unknown pages panic:
+// a new page type must decide what dates it, not inherit a guess.
+export const sitemapSources = ({
+  pathname,
+  localeTagByPath,
+}: SitemapSourcesOptions): readonly string[] => {
+  const segments = pathname.split("/").filter((segment) => segment !== "");
+  const first = segments.at(0);
+  const localeTag =
+    first === undefined ? undefined : localeTagByPath.get(first);
+  const rest = localeTag === undefined ? segments : segments.slice(1);
+  const head = rest.at(0);
+  const tail = rest.slice(1);
+  const messages = `${MESSAGES}/${localeTag ?? "en"}.json`;
+
+  if (head === undefined) {
+    return [
+      `${SRC}/components/HomePage.astro`,
+      `${SRC}/data/product-story.ts`,
+      messages,
+    ];
+  }
+  const slug = tail.at(0);
+  if (head === "product" && slug !== undefined && tail.length === 1) {
+    return [
+      `${SRC}/data/products/${slug}.ts`,
+      `${SRC}/components/ProductPage.astro`,
+      `${SRC}/i18n/product-copy.ts`,
+      messages,
+    ];
+  }
+  if (localeTag !== undefined) {
+    return panic(
+      `sitemap lastmod: localized page without a source mapping: ${pathname}`,
+    );
+  }
+  if (head === "docs") {
+    const entry = tail.length === 0 ? "index" : tail.join("/");
+    return [`${DOCS}/${entry}.md`, `${DOCS}/${entry}.mdx`];
+  }
+  if (head === "blog" && slug !== undefined && tail.length === 1) {
+    return [`${BLOG}/${slug}.md`];
+  }
+  const utility = tail.length === 0 ? UTILITY_SOURCES.get(head) : undefined;
+  if (utility !== undefined) {
+    return utility;
+  }
+  return panic(`sitemap lastmod: no source mapping for ${pathname}`);
+};
+
+// Newest commit date across the sources, as an ISO-8601 instant. Missing
+// sources are skipped (a candidate that does not exist, an .md beside an
+// .mdx); no date at all means the mapping is wrong and panics.
+export const lastmodFromDates = (
+  sources: readonly string[],
+  dateBySource: ReadonlyMap<string, string>,
+): string => {
+  let latest: number | undefined;
+  for (const source of sources) {
+    const candidates = source.endsWith("/")
+      ? [...dateBySource]
+          .filter(([path]) => path.startsWith(source))
+          .map(([, date]) => date)
+      : [dateBySource.get(source)];
+    for (const candidate of candidates) {
+      if (candidate === undefined) {
+        continue;
+      }
+      const instant = Date.parse(candidate);
+      if (latest === undefined || instant > latest) {
+        latest = instant;
+      }
+    }
+  }
+  if (latest === undefined) {
+    return panic(
+      `sitemap lastmod: none of the sources exist in history: ${sources.join(", ")}`,
+    );
+  }
+  return new Date(latest).toISOString();
+};
+
+// ASCII record separator: cannot occur in a path, so it marks the date lines.
+const RECORD_SEPARATOR = "";
+
+// One `git log` over the landing sources; the first time a path appears is
+// its newest commit because the log is newest-first.
+export const parseGitLog = (log: string): ReadonlyMap<string, string> => {
+  const dateBySource = new Map<string, string>();
+  let current: string | undefined;
+  for (const line of log.split("\n")) {
+    if (line.startsWith(RECORD_SEPARATOR)) {
+      current = line.slice(RECORD_SEPARATOR.length);
+      continue;
+    }
+    if (line === "" || current === undefined || dateBySource.has(line)) {
+      continue;
+    }
+    dateBySource.set(line, current);
+  }
+  return dateBySource;
+};
+
+const GIT_LOG_MAX_BYTES = 64 * 1024 * 1024;
+
+const git = (args: readonly string[], cwd?: string): string =>
+  execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    maxBuffer: GIT_LOG_MAX_BYTES,
+  }).trim();
+
+// undefined = no usable history (shallow checkout).
+const readGitDates = (): ReadonlyMap<string, string> | undefined => {
+  if (git(["rev-parse", "--is-shallow-repository"]) === "true") {
+    return undefined;
+  }
+  const root = git(["rev-parse", "--show-toplevel"]);
+  return parseGitLog(
+    git(
+      [
+        "log",
+        `--format=${RECORD_SEPARATOR}%cI`,
+        "--name-only",
+        "--",
+        SRC,
+        CHANGELOG,
+      ],
+      root,
+    ),
+  );
+};
+
+type SitemapLastmodOptions = {
+  localeTagByPath: ReadonlyMap<string, string>;
+};
+
+type SitemapLastmod = {
+  // Reads history once when the build starts, so the sitemap's serialize()
+  // (which runs in its own build:done hook) never touches git itself.
+  integration: AstroIntegration;
+  // lastmod for a sitemap URL; undefined when history is unavailable.
+  lastmodFor: (url: string) => string | undefined;
+};
+
+export const sitemapLastmod = ({
+  localeTagByPath,
+}: SitemapLastmodOptions): SitemapLastmod => {
+  let history:
+    | { dateBySource: ReadonlyMap<string, string> | undefined }
+    | undefined;
+  return {
+    integration: {
+      name: "sitemap-lastmod",
+      hooks: {
+        "astro:build:start": ({ logger }) => {
+          const dateBySource = readGitDates();
+          if (dateBySource === undefined) {
+            logger.warn(
+              "shallow checkout: the sitemap will carry no <lastmod>",
+            );
+          }
+          history = { dateBySource };
+        },
+      },
+    },
+    lastmodFor: (url) => {
+      if (history === undefined) {
+        return panic(
+          "sitemap lastmod: asked for a date before the build started",
+        );
+      }
+      if (history.dateBySource === undefined) {
+        return undefined;
+      }
+      const sources = sitemapSources({
+        pathname: new URL(url).pathname,
+        localeTagByPath,
+      });
+      return lastmodFromDates(sources, history.dateBySource);
+    },
+  };
+};

--- a/apps/landing/src/integrations/sitemap-lastmod.ts
+++ b/apps/landing/src/integrations/sitemap-lastmod.ts
@@ -4,7 +4,7 @@
 // date on 134 unchanged pages, which crawlers learn to ignore.
 import type { AstroIntegration } from "astro";
 import { panic } from "better-result";
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 
 const SRC = "apps/landing/src";
 const MESSAGES = `${SRC}/i18n/messages`;
@@ -13,20 +13,20 @@ const BLOG = `${SRC}/content/blog`;
 const CHANGELOG = "docs/changelog";
 
 // A trailing slash marks a directory: any file below it counts.
+// Release notes and their dates feed both the changelog page and the
+// homepage's latest-release badge and grid (src/lib/changelog.ts).
+const CHANGELOG_SOURCES = [
+  `${SRC}/data/changelog-release-dates.json`,
+  `${CHANGELOG}/`,
+] as const;
+
 const UTILITY_SOURCES: ReadonlyMap<string, readonly string[]> = new Map([
   ["ai-info", [`${SRC}/pages/ai-info.astro`, `${SRC}/data/ai-facts.ts`]],
   [
     "security",
     [`${SRC}/pages/security.astro`, `${SRC}/data/security-controls.ts`],
   ],
-  [
-    "changelog",
-    [
-      `${SRC}/pages/changelog.astro`,
-      `${SRC}/data/changelog-release-dates.json`,
-      `${CHANGELOG}/`,
-    ],
-  ],
+  ["changelog", [`${SRC}/pages/changelog.astro`, ...CHANGELOG_SOURCES]],
   ["press", [`${SRC}/pages/press.astro`]],
   ["privacy", [`${SRC}/pages/privacy.astro`]],
   ["terms", [`${SRC}/pages/terms.astro`]],
@@ -61,6 +61,7 @@ export const sitemapSources = ({
       `${SRC}/components/HomePage.astro`,
       `${SRC}/data/product-story.ts`,
       messages,
+      ...CHANGELOG_SOURCES,
     ];
   }
   const slug = tail.at(0);
@@ -146,32 +147,41 @@ export const parseGitLog = (log: string): ReadonlyMap<string, string> => {
 
 const GIT_LOG_MAX_BYTES = 64 * 1024 * 1024;
 
-const git = (args: readonly string[], cwd?: string): string =>
-  execFileSync("git", args, {
+// undefined when git is not installed or the command fails (for example a
+// build from a source archive with no repository).
+const git = (args: readonly string[], cwd?: string): string | undefined => {
+  const result = spawnSync("git", args, {
     cwd,
     encoding: "utf-8",
     maxBuffer: GIT_LOG_MAX_BYTES,
-  }).trim();
+  });
+  return result.error === undefined && result.status === 0
+    ? result.stdout.trim()
+    : undefined;
+};
 
-// undefined = no usable history (shallow checkout).
+// undefined = no usable history: no git, no repository, or a shallow clone.
 const readGitDates = (): ReadonlyMap<string, string> | undefined => {
-  if (git(["rev-parse", "--is-shallow-repository"]) === "true") {
+  const shallow = git(["rev-parse", "--is-shallow-repository"]);
+  if (shallow === undefined || shallow === "true") {
     return undefined;
   }
   const root = git(["rev-parse", "--show-toplevel"]);
-  return parseGitLog(
-    git(
-      [
-        "log",
-        `--format=${RECORD_SEPARATOR}%cI`,
-        "--name-only",
-        "--",
-        SRC,
-        CHANGELOG,
-      ],
-      root,
-    ),
+  if (root === undefined) {
+    return undefined;
+  }
+  const log = git(
+    [
+      "log",
+      `--format=${RECORD_SEPARATOR}%cI`,
+      "--name-only",
+      "--",
+      SRC,
+      CHANGELOG,
+    ],
+    root,
   );
+  return log === undefined ? undefined : parseGitLog(log);
 };
 
 type SitemapLastmodOptions = {
@@ -200,7 +210,7 @@ export const sitemapLastmod = ({
           const dateBySource = readGitDates();
           if (dateBySource === undefined) {
             logger.warn(
-              "shallow checkout: the sitemap will carry no <lastmod>",
+              "no usable git history: the sitemap will carry no <lastmod>",
             );
           }
           history = { dateBySource };


### PR DESCRIPTION
## What

- New `sitemap-lastmod` integration: reads one `git log --name-only` over `apps/landing/src` and `docs/changelog` at `astro:build:start`; the sitemap's `serialize` maps each URL to the sources it renders from (home, product, docs, blog, utility pages) and emits the newest commit date as `<lastmod>`.
- A shallow checkout emits no `<lastmod>` (logged as a warning) rather than a fabricated date. An unmapped URL panics so a new page type has to decide what dates it.
- Drops the uniform `changefreq: weekly`.

## Verification

- Unit tests for the URL → sources mapping, date selection across offsets and directories, and the `git log` parser.
- `astro build` completes; on a shallow checkout the sitemap has 134 URLs, no `changefreq`, no `lastmod`, as designed.

https://claude.ai/code/session_011c2nbUzLifSs2ajSrb7Qjo