### PR TITLE
fix(desktop): clipboard reopen latency, search focus and previews, source icons

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4642,6 +4642,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "stella-desktop-macos",
  "sys-locale",
  "tauri",
  "tauri-build",
@@ -4665,6 +4666,15 @@ dependencies = [
  "winsafe",
  "zbus-secret-service-keyring-store",
  "zip 8.6.0",
+]
+
+[[package]]
+name = "stella-desktop-macos"
+version = "0.0.1"
+dependencies = [
+ "objc2",
+ "objc2-app-kit",
+ "tauri",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -40,6 +40,11 @@ used_underscore_binding = "warn"
 [lints.rust]
 unsafe_code = "forbid"
 
+# The raw AppKit/WebKit calls this crate cannot express without `unsafe` live
+# in the workspace member below, behind a safe API.
+[workspace]
+members = ["crates/macos-park"]
+
 [lints.rustdoc]
 bare_urls = "deny"
 broken_intra_doc_links = "deny"
@@ -111,7 +116,6 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
   "NSEvent",
   "NSRunningApplication",
   "NSScreen",
-  "NSWindow",
   "NSWorkspace",
   "libc",
 ] }
@@ -120,6 +124,7 @@ objc2-foundation = { version = "0.3", default-features = false, features = [
   "NSURL",
 ] }
 plist = "1.10"
+stella-desktop-macos = { path = "crates/macos-park" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-icons = "0.4.0"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -124,7 +124,7 @@ objc2-foundation = { version = "0.3", default-features = false, features = [
   "NSURL",
 ] }
 plist = "1.10"
-stella-desktop-macos = { path = "crates/macos-park" }
+stella-desktop-macos = { path = "crates/macos-park", version = "0.0.1" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-icons = "0.4.0"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -111,6 +111,7 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
   "NSEvent",
   "NSRunningApplication",
   "NSScreen",
+  "NSWindow",
   "NSWorkspace",
   "libc",
 ] }

--- a/apps/desktop/src-tauri/crates/macos-park/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/macos-park/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "stella-desktop-macos"
+version = "0.0.1"
+edition = "2024"
+description = "Safe wrappers over the raw AppKit/WebKit calls behind clipboard window parking"
+license = "Apache-2.0"
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+undocumented_unsafe_blocks = "deny"
+
+[lints.rustdoc]
+bare_urls = "deny"
+broken_intra_doc_links = "deny"
+
+[dependencies]
+tauri = "2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3", default-features = false, features = [
+  "NSResponder",
+  "NSWindow",
+] }

--- a/apps/desktop/src-tauri/crates/macos-park/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/macos-park/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 edition = "2024"
 description = "Safe wrappers over the raw AppKit/WebKit calls behind clipboard window parking"
 license = "Apache-2.0"
+publish = false
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/apps/desktop/src-tauri/crates/macos-park/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/macos-park/src/lib.rs
@@ -1,0 +1,12 @@
+//! Safe wrappers over the raw AppKit/WebKit calls behind clipboard window
+//! parking. The desktop crate forbids `unsafe` code, so the pointer derefs
+//! and the private-selector call live here behind a minimal API that owns
+//! their soundness (pointers are obtained from live Tauri windows, and the
+//! main thread is verified before any AppKit call).
+//!
+//! Everything is a no-op off macOS; the crate is empty there.
+
+#[cfg(target_os = "macos")]
+mod park;
+#[cfg(target_os = "macos")]
+pub use park::{disable_occlusion_detection, set_window_parked};

--- a/apps/desktop/src-tauri/crates/macos-park/src/park.rs
+++ b/apps/desktop/src-tauri/crates/macos-park/src/park.rs
@@ -1,0 +1,46 @@
+use objc2::MainThreadMarker;
+use objc2::runtime::AnyObject;
+use objc2::{msg_send, sel};
+use objc2_app_kit::NSWindow;
+use tauri::{Runtime, WebviewWindow};
+
+/// Makes the window fully transparent and click-through (parked) or restores
+/// it. Returns false when the change could not be applied (not on the main
+/// thread, or no window handle); the caller then falls back to hiding.
+pub fn set_window_parked<R: Runtime>(window: &WebviewWindow<R>, parked: bool) -> bool {
+  if MainThreadMarker::new().is_none() {
+    return false;
+  }
+  let Ok(ns_window) = window.ns_window() else {
+    return false;
+  };
+  if ns_window.is_null() {
+    return false;
+  }
+  // SAFETY: `ns_window` returns a valid pointer to the live window's NSWindow
+  // and the main thread was verified above.
+  let ns_window = unsafe { &*ns_window.cast::<NSWindow>() };
+  ns_window.setAlphaValue(if parked { 0.0 } else { 1.0 });
+  ns_window.setIgnoresMouseEvents(parked);
+  true
+}
+
+/// Stops the webview from tracking window occlusion, so a parked window
+/// (alpha 0) is never reported occluded, which would suspend WebKit's
+/// rendering and defeat the parking. Private WebKit setter, hence the
+/// `respondsToSelector` guard; a WebKit without it keeps the default.
+pub fn disable_occlusion_detection<R: Runtime>(window: &WebviewWindow<R>) {
+  let _ = window.with_webview(|webview| {
+    // SAFETY: `inner` returns a valid WKWebView pointer for the lifetime of
+    // the closure, which Tauri runs on the main thread. The selector is only
+    // messaged when the instance responds to it, and it takes one BOOL.
+    unsafe {
+      let webview = &*webview.inner().cast::<AnyObject>();
+      let selector = sel!(_setWindowOcclusionDetectionEnabled:);
+      let responds: bool = msg_send![webview, respondsToSelector: selector];
+      if responds {
+        let () = msg_send![webview, _setWindowOcclusionDetectionEnabled: false];
+      }
+    }
+  });
+}

--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -586,13 +586,22 @@ impl ClipboardManager {
         if let Some(state) = state {
           self.capture_status = state.capture_status;
           self.groups = state.groups;
-          self.items = state.items;
           self.retention = state.retention;
+          // Retention pruning during load can leave the persisted visuals
+          // stale; only those still backing an item may occupy the capped
+          // map, or they would block icons for new source apps.
+          let referenced_keys: HashSet<&str> = state
+            .items
+            .iter()
+            .filter_map(ClipboardItem::source_visual_key)
+            .collect();
           self.source_app_visuals = state
             .source_app_visuals
             .into_iter()
+            .filter(|visual| referenced_keys.contains(visual.key.as_str()))
             .map(|visual| (visual.key.clone(), visual))
             .collect();
+          self.items = state.items;
         }
         ClipboardPersistence::Encrypted(store)
       }
@@ -933,30 +942,31 @@ impl ClipboardManager {
     Ok(())
   }
 
-  fn persist(&self) -> Result<(), String> {
-    let store = match &self.persistence {
-      // Rejecting the write makes `persist_or_restore` roll the mutation
-      // back, so `install` can never overwrite a change made before the
-      // persisted history arrived.
-      ClipboardPersistence::Initializing => {
-        return Err(HISTORY_LOADING_ERROR.to_string());
-      }
-      ClipboardPersistence::Encrypted(store) => store,
-      ClipboardPersistence::MemoryOnly | ClipboardPersistence::DeletionOnly(_) => {
-        return Ok(());
-      }
-    };
+  fn persist(&mut self) -> Result<(), String> {
+    // Rejecting the write makes `persist_or_restore` roll the mutation
+    // back, so `install` can never overwrite a change made before the
+    // persisted history arrived.
+    if matches!(self.persistence, ClipboardPersistence::Initializing) {
+      return Err(HISTORY_LOADING_ERROR.to_string());
+    }
+    // Visuals whose source app no longer backs any item leave the capped map
+    // on every persisted mutation; stale entries would otherwise block icons
+    // for new source apps once the cap fills. A failed store write restores
+    // them through the caller's checkpoint.
     let referenced_keys: HashSet<&str> = self
       .items
       .iter()
       .filter_map(ClipboardItem::source_visual_key)
       .collect();
-    let mut source_app_visuals: Vec<ClipboardSourceAppVisual> = self
+    self
       .source_app_visuals
-      .values()
-      .filter(|visual| referenced_keys.contains(visual.key.as_str()))
-      .cloned()
-      .collect();
+      .retain(|key, _| referenced_keys.contains(key.as_str()));
+    let ClipboardPersistence::Encrypted(store) = &self.persistence else {
+      // MemoryOnly and DeletionOnly keep nothing on disk.
+      return Ok(());
+    };
+    let mut source_app_visuals: Vec<ClipboardSourceAppVisual> =
+      self.source_app_visuals.values().cloned().collect();
     source_app_visuals.sort_by(|left, right| left.key.cmp(&right.key));
     let state = PersistedClipboardState {
       capture_status: self.capture_status,
@@ -2187,6 +2197,9 @@ mod tests {
     let id = manager.items[0].id().to_string();
     assert!(manager.delete_item(&id).unwrap());
 
+    // The in-memory map is capped, so the stale entry must leave it too or it
+    // would eventually block icons for new source apps.
+    assert!(manager.source_app_visuals.is_empty());
     let persisted = ClipboardStore::new([9; 32], store_path.clone())
       .load()
       .unwrap()
@@ -2194,6 +2207,27 @@ mod tests {
     assert!(persisted.source_app_visuals.is_empty());
 
     std::fs::remove_file(store_path).unwrap();
+  }
+
+  #[test]
+  fn install_drops_source_app_visuals_without_a_backing_item() {
+    let mut manager = ClipboardManager::new();
+    manager.install(ClipboardLoad::Encrypted {
+      store: ClipboardStore::new([9; 32], unique_store_path()),
+      state: Some(PersistedClipboardState {
+        capture_status: ClipboardCaptureStatus::Active,
+        groups: Vec::new(),
+        items: Vec::new(),
+        retention: ClipboardRetention::Month,
+        source_app_visuals: vec![ClipboardSourceAppVisual {
+          color: None,
+          icon_data_url: Some("data:image/png;base64,QUJD".to_string()),
+          key: "com.example.expired".to_string(),
+        }],
+      }),
+    });
+
+    assert!(manager.source_app_visuals.is_empty());
   }
 
   #[test]

--- a/apps/desktop/src-tauri/src/clipboard.rs
+++ b/apps/desktop/src-tauri/src/clipboard.rs
@@ -123,7 +123,7 @@ pub struct ClipboardSourceApp {
   pub name: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClipboardSourceAppVisual {
   pub color: Option<String>,
@@ -250,6 +250,14 @@ impl ClipboardItem {
         source_app.as_ref()
       }
     }
+  }
+
+  /// Key of the item's entry in the source-app visual map; mirrors the
+  /// lookup key built in `frontmost_source_app`.
+  fn source_visual_key(&self) -> Option<&str> {
+    self
+      .source_app()
+      .map(|source_app| source_app.identifier.as_deref().unwrap_or(&source_app.name))
   }
 
   fn set_group_id(&mut self, new_group_id: Option<String>) {
@@ -416,6 +424,8 @@ pub struct PersistedClipboardState {
   pub items: Vec<ClipboardItem>,
   #[serde(default)]
   pub retention: ClipboardRetention,
+  #[serde(default)]
+  pub source_app_visuals: Vec<ClipboardSourceAppVisual>,
 }
 
 pub struct ClipboardManager {
@@ -578,6 +588,11 @@ impl ClipboardManager {
           self.groups = state.groups;
           self.items = state.items;
           self.retention = state.retention;
+          self.source_app_visuals = state
+            .source_app_visuals
+            .into_iter()
+            .map(|visual| (visual.key.clone(), visual))
+            .collect();
         }
         ClipboardPersistence::Encrypted(store)
       }
@@ -931,11 +946,24 @@ impl ClipboardManager {
         return Ok(());
       }
     };
+    let referenced_keys: HashSet<&str> = self
+      .items
+      .iter()
+      .filter_map(ClipboardItem::source_visual_key)
+      .collect();
+    let mut source_app_visuals: Vec<ClipboardSourceAppVisual> = self
+      .source_app_visuals
+      .values()
+      .filter(|visual| referenced_keys.contains(visual.key.as_str()))
+      .cloned()
+      .collect();
+    source_app_visuals.sort_by(|left, right| left.key.cmp(&right.key));
     let state = PersistedClipboardState {
       capture_status: self.capture_status,
       groups: self.groups.clone(),
       items: self.items.clone(),
       retention: self.retention,
+      source_app_visuals,
     };
     store.persist(&state).map_err(|error| {
       tracing::warn!(error = %error, "clipboard history persistence failed");
@@ -2080,6 +2108,7 @@ mod tests {
         text_item(now, "current"),
       ],
       retention: ClipboardRetention::Month,
+      source_app_visuals: Vec::new(),
     };
     store.persist(&state).unwrap();
 
@@ -2095,6 +2124,74 @@ mod tests {
       .unwrap();
     assert_eq!(persisted.items.len(), 1);
     assert_eq!(persisted.items[0].plain_text(), "current");
+
+    std::fs::remove_file(store_path).unwrap();
+  }
+
+  fn editor_capture() -> ClipboardCapture {
+    ClipboardCapture {
+      copied_at: Utc::now(),
+      html: None,
+      plain_text: "clause".to_string(),
+      rtf: None,
+      source_app: Some(ClipboardSourceApp {
+        identifier: Some("com.example.editor".to_string()),
+        name: "Editor".to_string(),
+      }),
+      source_app_visual: Some(ClipboardSourceAppVisual {
+        color: Some("#336699".to_string()),
+        icon_data_url: Some("data:image/png;base64,QUJD".to_string()),
+        key: "com.example.editor".to_string(),
+      }),
+    }
+  }
+
+  #[test]
+  fn source_app_visuals_survive_a_restart() {
+    let store_path = unique_store_path();
+    let mut manager = ClipboardManager::new();
+    manager.install(ClipboardLoad::Encrypted {
+      store: ClipboardStore::new([9; 32], store_path.clone()),
+      state: None,
+    });
+    assert!(manager.capture(editor_capture()).unwrap());
+
+    let store = ClipboardStore::new([9; 32], store_path.clone());
+    let state = store.load().unwrap().unwrap();
+    let mut restarted = ClipboardManager::new();
+    restarted.install(ClipboardLoad::Encrypted {
+      store,
+      state: Some(state),
+    });
+
+    let snapshot = restarted.snapshot();
+    assert_eq!(snapshot.source_app_visuals.len(), 1);
+    assert_eq!(snapshot.source_app_visuals[0].key, "com.example.editor");
+    assert_eq!(
+      snapshot.source_app_visuals[0].icon_data_url.as_deref(),
+      Some("data:image/png;base64,QUJD")
+    );
+
+    std::fs::remove_file(store_path).unwrap();
+  }
+
+  #[test]
+  fn unreferenced_source_app_visuals_are_not_persisted() {
+    let store_path = unique_store_path();
+    let mut manager = ClipboardManager::new();
+    manager.install(ClipboardLoad::Encrypted {
+      store: ClipboardStore::new([9; 32], store_path.clone()),
+      state: None,
+    });
+    assert!(manager.capture(editor_capture()).unwrap());
+    let id = manager.items[0].id().to_string();
+    assert!(manager.delete_item(&id).unwrap());
+
+    let persisted = ClipboardStore::new([9; 32], store_path.clone())
+      .load()
+      .unwrap()
+      .unwrap();
+    assert!(persisted.source_app_visuals.is_empty());
 
     std::fs::remove_file(store_path).unwrap();
   }

--- a/apps/desktop/src-tauri/src/clipboard_store.rs
+++ b/apps/desktop/src-tauri/src/clipboard_store.rs
@@ -141,6 +141,7 @@ mod tests {
         source_app: None,
       }],
       retention: ClipboardRetention::Month,
+      source_app_visuals: Vec::new(),
     };
 
     store.persist(&state).unwrap();
@@ -162,6 +163,7 @@ mod tests {
         groups: Vec::new(),
         items: Vec::new(),
         retention: ClipboardRetention::Month,
+        source_app_visuals: Vec::new(),
       })
       .unwrap();
 

--- a/apps/desktop/src-tauri/src/clipboard_window.rs
+++ b/apps/desktop/src-tauri/src/clipboard_window.rs
@@ -20,6 +20,47 @@ const CLIPBOARD_WINDOW_HEIGHT: f64 = 326.0;
 const CLIPBOARD_WINDOW_INSET: f64 = 18.0;
 const CLIPBOARD_WINDOW_RADIUS: f64 = 28.0;
 
+/// Whether the clipboard window is parked and which app held focus before the
+/// window last took it. Parking keeps the window on screen fully transparent
+/// and click-through instead of ordering it out: WebKit reclaims a hidden
+/// page's graphics caches within seconds and its compiled JS within minutes,
+/// which made the next open after an idle spell paint its content 200-600ms
+/// late. A parked page stays warm, so reopening paints immediately.
+#[derive(Default)]
+pub struct ClipboardWindowPark(Mutex<ParkState>);
+
+#[derive(Default)]
+struct ParkState {
+  parked: bool,
+  #[cfg(target_os = "macos")]
+  previous_app_pid: Option<i32>,
+}
+
+impl ClipboardWindowPark {
+  fn is_parked(&self) -> bool {
+    self.0.lock().map(|state| state.parked).unwrap_or(false)
+  }
+
+  #[cfg(target_os = "macos")]
+  fn set_parked(&self, parked: bool) {
+    if let Ok(mut state) = self.0.lock() {
+      state.parked = parked;
+    }
+  }
+
+  #[cfg(target_os = "macos")]
+  fn remember_previous_app(&self, pid: i32) {
+    if let Ok(mut state) = self.0.lock() {
+      state.previous_app_pid = Some(pid);
+    }
+  }
+
+  #[cfg(target_os = "macos")]
+  fn previous_app_pid(&self) -> Option<i32> {
+    self.0.lock().ok().and_then(|state| state.previous_app_pid)
+  }
+}
+
 /// Timing anchor for the clipboard window's creation. Page load and frontend
 /// spans are measured against it, and the first snapshot read after creation
 /// claims its spans once so steady-state history reads stay unmeasured.
@@ -207,6 +248,127 @@ fn position_window(app: &AppHandle, window: &WebviewWindow) {
   let _ = window.set_position(LogicalPosition::new(x, y));
 }
 
+#[cfg(target_os = "macos")]
+fn remember_previous_app(app: &AppHandle) {
+  use objc2::MainThreadMarker;
+  use objc2_app_kit::NSWorkspace;
+
+  if MainThreadMarker::new().is_none() {
+    let handle = app.clone();
+    let _ = app.run_on_main_thread(move || remember_previous_app(&handle));
+    return;
+  }
+  let Some(park) = app.try_state::<ClipboardWindowPark>() else {
+    return;
+  };
+  let Some(frontmost) = NSWorkspace::sharedWorkspace().frontmostApplication() else {
+    return;
+  };
+  let pid = frontmost.processIdentifier();
+  // Reopening while the window already holds focus keeps the earlier target.
+  if pid != std::process::id() as i32 {
+    park.remember_previous_app(pid);
+  }
+}
+
+#[cfg(target_os = "macos")]
+enum ParkFocusHandoff {
+  /// The window holds focus (Escape, copy): hand it back to the app that had
+  /// it before the window opened, or fall back to a real hide.
+  PreviousApp,
+  /// Focus already moved elsewhere (hide on blur): leave activation alone.
+  None,
+}
+
+/// Parks the window instead of hiding it. Returns false when parking is not
+/// possible (no main thread, no window handle, no app to hand focus to); the
+/// caller then falls back to ordering the window out.
+#[cfg(target_os = "macos")]
+fn park_window(window: &WebviewWindow, handoff: ParkFocusHandoff) -> bool {
+  use objc2::MainThreadMarker;
+
+  if MainThreadMarker::new().is_some() {
+    return park_window_on_main(window, handoff);
+  }
+  let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+  let cloned = window.clone();
+  if window
+    .app_handle()
+    .run_on_main_thread(move || {
+      let _ = sender.send(park_window_on_main(&cloned, handoff));
+    })
+    .is_err()
+  {
+    return false;
+  }
+  receiver
+    .recv_timeout(Duration::from_secs(1))
+    .unwrap_or(false)
+}
+
+// `ActivateIgnoringOtherApps` is a no-op on macOS 14+ (activation from the
+// active app is already cooperative there) but required before it.
+#[allow(deprecated)]
+#[cfg(target_os = "macos")]
+fn park_window_on_main(window: &WebviewWindow, handoff: ParkFocusHandoff) -> bool {
+  use objc2_app_kit::{NSApplicationActivationOptions, NSRunningApplication, NSWindow};
+
+  let app = window.app_handle();
+  let Some(park) = app.try_state::<ClipboardWindowPark>() else {
+    return false;
+  };
+  if park.is_parked() {
+    return true;
+  }
+  let Ok(ns_window) = window.ns_window() else {
+    return false;
+  };
+  if let ParkFocusHandoff::PreviousApp = handoff {
+    let activated = park
+      .previous_app_pid()
+      .and_then(NSRunningApplication::runningApplicationWithProcessIdentifier)
+      .is_some_and(|previous| {
+        previous.activateWithOptions(
+          NSApplicationActivationOptions::ActivateIgnoringOtherApps,
+        )
+      });
+    if !activated {
+      return false;
+    }
+  }
+  // SAFETY: `ns_window` returns a valid NSWindow pointer for a live window and
+  // this runs on the main thread.
+  let ns_window = unsafe { &*ns_window.cast::<NSWindow>() };
+  ns_window.setAlphaValue(0.0);
+  ns_window.setIgnoresMouseEvents(true);
+  park.set_parked(true);
+  true
+}
+
+#[cfg(target_os = "macos")]
+fn unpark_window(window: &WebviewWindow) {
+  use objc2::MainThreadMarker;
+  use objc2_app_kit::NSWindow;
+
+  if MainThreadMarker::new().is_none() {
+    let cloned = window.clone();
+    let _ = window
+      .app_handle()
+      .run_on_main_thread(move || unpark_window(&cloned));
+    return;
+  }
+  let Ok(ns_window) = window.ns_window() else {
+    return;
+  };
+  // SAFETY: as in `park_window_on_main`.
+  let ns_window = unsafe { &*ns_window.cast::<NSWindow>() };
+  ns_window.setAlphaValue(1.0);
+  ns_window.setIgnoresMouseEvents(false);
+  if let Some(park) = window.app_handle().try_state::<ClipboardWindowPark>() {
+    park.set_parked(false);
+  }
+}
+
 pub fn show(app: &AppHandle) {
   show_as(app, ClipboardOpenKind::FirstOpen);
 }
@@ -220,10 +382,15 @@ pub fn show_on_launch(app: &AppHandle) {
 fn show_as(app: &AppHandle, created_kind: ClipboardOpenKind) {
   let requested = Instant::now();
   #[cfg(target_os = "macos")]
-  let _ = app.show();
+  {
+    let _ = app.show();
+    remember_previous_app(app);
+  }
 
   if let Some(window) = app.get_webview_window(CLIPBOARD_WINDOW_LABEL) {
     position_window(app, &window);
+    #[cfg(target_os = "macos")]
+    unpark_window(&window);
     if window.show().and_then(|()| window.set_focus()).is_err() {
       capture_window_error(
         app,
@@ -311,10 +478,28 @@ fn show_as(app: &AppHandle, created_kind: ClipboardOpenKind) {
         created_kind,
       );
       position_window(app, &window);
+      #[cfg(target_os = "macos")]
+      let _ = window.with_webview(|webview| {
+        // A parked window (alpha 0) may be reported occluded, which would put
+        // WebKit back to sleep and defeat the parking; occlusion tracking is
+        // irrelevant for an always-on-top panel, so it is turned off. Private
+        // WebKit API, hence the respondsToSelector guard.
+        // SAFETY: `inner` returns a valid WKWebView pointer and the closure
+        // runs on the main thread.
+        unsafe {
+          use objc2::{msg_send, runtime::AnyObject, sel};
+          let webview = &*webview.inner().cast::<AnyObject>();
+          let selector = sel!(_setWindowOcclusionDetectionEnabled:);
+          let responds: bool = msg_send![webview, respondsToSelector: selector];
+          if responds {
+            let () = msg_send![webview, _setWindowOcclusionDetectionEnabled: false];
+          }
+        }
+      });
       let window_to_hide = window.clone();
       window.on_window_event(move |event| {
         if matches!(event, tauri::WindowEvent::Focused(false))
-          && hide(&window_to_hide).is_err()
+          && hide_on_blur(&window_to_hide).is_err()
         {
           capture_window_error(
             window_to_hide.app_handle(),
@@ -337,7 +522,11 @@ fn show_as(app: &AppHandle, created_kind: ClipboardOpenKind) {
 }
 
 pub fn toggle(app: &AppHandle) {
-  if let Some(window) = app.get_webview_window(CLIPBOARD_WINDOW_LABEL)
+  let parked = app
+    .try_state::<ClipboardWindowPark>()
+    .is_some_and(|park| park.is_parked());
+  if !parked
+    && let Some(window) = app.get_webview_window(CLIPBOARD_WINDOW_LABEL)
     && window.is_visible().unwrap_or(false)
   {
     if hide(&window).is_err() {
@@ -352,7 +541,27 @@ pub fn toggle(app: &AppHandle) {
   show(app);
 }
 
+/// Dismissal while the window holds focus: park it and hand focus back to the
+/// previously focused app, or order it out when that is not possible.
 pub fn hide(window: &WebviewWindow) -> Result<(), String> {
+  #[cfg(target_os = "macos")]
+  if park_window(window, ParkFocusHandoff::PreviousApp) {
+    return Ok(());
+  }
+  order_out(window)
+}
+
+/// Hide after the window lost focus on its own: whatever the user focused
+/// keeps it, so parking must not re-activate the previously focused app.
+fn hide_on_blur(window: &WebviewWindow) -> Result<(), String> {
+  #[cfg(target_os = "macos")]
+  if park_window(window, ParkFocusHandoff::None) {
+    return Ok(());
+  }
+  order_out(window)
+}
+
+fn order_out(window: &WebviewWindow) -> Result<(), String> {
   window.hide().map_err(|error| {
     tracing::warn!(error = %error, "clipboard window could not be hidden");
     "clipboard window could not be hidden".to_string()

--- a/apps/desktop/src-tauri/src/clipboard_window.rs
+++ b/apps/desktop/src-tauri/src/clipboard_window.rs
@@ -311,7 +311,7 @@ fn park_window(window: &WebviewWindow, handoff: ParkFocusHandoff) -> bool {
 #[allow(deprecated)]
 #[cfg(target_os = "macos")]
 fn park_window_on_main(window: &WebviewWindow, handoff: ParkFocusHandoff) -> bool {
-  use objc2_app_kit::{NSApplicationActivationOptions, NSRunningApplication, NSWindow};
+  use objc2_app_kit::{NSApplicationActivationOptions, NSRunningApplication};
 
   let app = window.app_handle();
   let Some(park) = app.try_state::<ClipboardWindowPark>() else {
@@ -320,9 +320,6 @@ fn park_window_on_main(window: &WebviewWindow, handoff: ParkFocusHandoff) -> boo
   if park.is_parked() {
     return true;
   }
-  let Ok(ns_window) = window.ns_window() else {
-    return false;
-  };
   if let ParkFocusHandoff::PreviousApp = handoff {
     let activated = park
       .previous_app_pid()
@@ -336,11 +333,9 @@ fn park_window_on_main(window: &WebviewWindow, handoff: ParkFocusHandoff) -> boo
       return false;
     }
   }
-  // SAFETY: `ns_window` returns a valid NSWindow pointer for a live window and
-  // this runs on the main thread.
-  let ns_window = unsafe { &*ns_window.cast::<NSWindow>() };
-  ns_window.setAlphaValue(0.0);
-  ns_window.setIgnoresMouseEvents(true);
+  if !stella_desktop_macos::set_window_parked(window, true) {
+    return false;
+  }
   park.set_parked(true);
   true
 }
@@ -348,7 +343,6 @@ fn park_window_on_main(window: &WebviewWindow, handoff: ParkFocusHandoff) -> boo
 #[cfg(target_os = "macos")]
 fn unpark_window(window: &WebviewWindow) {
   use objc2::MainThreadMarker;
-  use objc2_app_kit::NSWindow;
 
   if MainThreadMarker::new().is_none() {
     let cloned = window.clone();
@@ -357,13 +351,9 @@ fn unpark_window(window: &WebviewWindow) {
       .run_on_main_thread(move || unpark_window(&cloned));
     return;
   }
-  let Ok(ns_window) = window.ns_window() else {
+  if !stella_desktop_macos::set_window_parked(window, false) {
     return;
-  };
-  // SAFETY: as in `park_window_on_main`.
-  let ns_window = unsafe { &*ns_window.cast::<NSWindow>() };
-  ns_window.setAlphaValue(1.0);
-  ns_window.setIgnoresMouseEvents(false);
+  }
   if let Some(park) = window.app_handle().try_state::<ClipboardWindowPark>() {
     park.set_parked(false);
   }
@@ -478,24 +468,10 @@ fn show_as(app: &AppHandle, created_kind: ClipboardOpenKind) {
         created_kind,
       );
       position_window(app, &window);
+      // A parked window (alpha 0) may be reported occluded, which would put
+      // WebKit back to sleep and defeat the parking.
       #[cfg(target_os = "macos")]
-      let _ = window.with_webview(|webview| {
-        // A parked window (alpha 0) may be reported occluded, which would put
-        // WebKit back to sleep and defeat the parking; occlusion tracking is
-        // irrelevant for an always-on-top panel, so it is turned off. Private
-        // WebKit API, hence the respondsToSelector guard.
-        // SAFETY: `inner` returns a valid WKWebView pointer and the closure
-        // runs on the main thread.
-        unsafe {
-          use objc2::{msg_send, runtime::AnyObject, sel};
-          let webview = &*webview.inner().cast::<AnyObject>();
-          let selector = sel!(_setWindowOcclusionDetectionEnabled:);
-          let responds: bool = msg_send![webview, respondsToSelector: selector];
-          if responds {
-            let () = msg_send![webview, _setWindowOcclusionDetectionEnabled: false];
-          }
-        }
-      });
+      stella_desktop_macos::disable_occlusion_detection(&window);
       let window_to_hide = window.clone();
       window.on_window_event(move |event| {
         if matches!(event, tauri::WindowEvent::Focused(false))

--- a/apps/desktop/src-tauri/src/desktop_telemetry.rs
+++ b/apps/desktop/src-tauri/src/desktop_telemetry.rs
@@ -400,6 +400,10 @@ fn analytics_timing_payload(
       "duration_ms": u64::try_from(report.duration.as_millis()).unwrap_or(u64::MAX),
       "item_count": report.item_count,
       "open_kind": report.open_kind.map(ClipboardOpenKind::as_str),
+      // Splits latency spans by platform: fixes like clipboard window
+      // parking are platform-specific, and their effect must be readable
+      // per OS.
+      "os": std::env::consts::OS,
       "payload_bytes": report.payload_bytes,
       "service_name": "stella-desktop",
       "span": report.span.as_str(),
@@ -614,6 +618,7 @@ mod tests {
     assert_eq!(properties["item_count"], 3);
     assert_eq!(properties["payload_bytes"], 4096);
     assert_eq!(properties["$process_person_profile"], false);
+    assert_eq!(properties["os"], std::env::consts::OS);
     let allowed = [
       "$process_person_profile",
       "app_commit",
@@ -623,6 +628,7 @@ mod tests {
       "duration_ms",
       "item_count",
       "open_kind",
+      "os",
       "payload_bytes",
       "service_name",
       "span",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -103,6 +103,7 @@ pub fn run() {
     .manage::<ClipboardAppState>(Arc::clone(&clipboard_manager))
     .manage::<ClipboardEditorState>(Arc::new(std::sync::Mutex::new(None)))
     .manage(clipboard_window::ClipboardStartupTrace::default())
+    .manage(clipboard_window::ClipboardWindowPark::default())
     .setup(move |app| {
       let handle = app.handle().clone();
       let initial_deep_links = app.deep_link().get_current()?;

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -85,6 +85,7 @@ import {
   clipboardPointerMoved,
   clipboardRailScrollDelta,
   clipboardRailWindow,
+  clipboardSearchPreviewText,
   clipboardSourceTintIndex,
   clipboardTimelineKeyAction,
   filterClipboardItems,
@@ -284,7 +285,6 @@ const ClipboardCard = ({
       ? "[&_blockquote]:border-s-2 [&_blockquote]:ps-3 [&_code]:font-mono [&_li]:ms-4 [&_ol]:list-decimal [&_pre]:whitespace-pre-wrap [&_strong]:font-semibold [&_ul]:list-disc"
       : "whitespace-pre-wrap",
   );
-  const highlightedText = highlightClipboardText(item.plainText, query);
   let previewContent: ReactNode = (
     <div className={previewClassName} dir="auto">
       {item.plainText}
@@ -303,8 +303,15 @@ const ClipboardCard = ({
     );
   }
   if (query) {
+    const searchPreview = clipboardSearchPreviewText(item.plainText, query);
+    const highlightedText = highlightClipboardText(searchPreview.text, query);
     previewContent = (
       <div className={previewClassName} dir="auto">
+        {searchPreview.truncated ? (
+          <span aria-hidden="true" className="text-muted-foreground">
+            {"… "}
+          </span>
+        ) : null}
         {highlightedText.map((segment, segmentIndex) =>
           segment.match ? (
             <mark

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -94,6 +94,7 @@ import {
   isClipboardNameInput,
   quickCopyIndex,
   shouldCopyFromClipboardInput,
+  shouldReturnToTimelineFromInput,
 } from "./clipboard-logic";
 import type { ClipboardPointerPosition } from "./clipboard-logic";
 import {
@@ -1541,16 +1542,17 @@ const ClipboardApp = () => {
       }
     }
     if (event.target instanceof HTMLInputElement) {
-      if (
-        activeItem &&
-        shouldCopyFromClipboardInput({
-          dataset: event.target.dataset,
-          isComposing: event.isComposing,
-          key: event.key,
-        })
-      ) {
+      const inputKey = {
+        dataset: event.target.dataset,
+        isComposing: event.isComposing,
+        key: event.key,
+      };
+      if (activeItem && shouldCopyFromClipboardInput(inputKey)) {
         event.preventDefault();
         copyItem(activeItem);
+      } else if (activeItem && shouldReturnToTimelineFromInput(inputKey)) {
+        event.preventDefault();
+        selectIndex(activeIndex);
       }
       return;
     }

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -82,15 +82,20 @@ export const clipboardDraggedItemId = (
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 
-export const highlightClipboardText = (text: string, query: string) => {
+/** Deduplicated query terms, longest first so overlapping terms match whole. */
+const clipboardQueryTerms = (query: string) => {
   const normalizedTerms = query
     .trim()
     .split(/\s+/u)
     .map((term) => term.toLocaleLowerCase())
     .filter(Boolean);
-  const terms = Array.from(new Set(normalizedTerms)).sort(
+  return Array.from(new Set(normalizedTerms)).sort(
     (left, right) => right.length - left.length,
   );
+};
+
+export const highlightClipboardText = (text: string, query: string) => {
+  const terms = clipboardQueryTerms(query);
   if (terms.length === 0) {
     return [{ match: false, text }] satisfies ClipboardTextSegment[];
   }
@@ -113,6 +118,53 @@ export const highlightClipboardText = (text: string, query: string) => {
     segments.push({ match: false, text: text.slice(cursor) });
   }
   return segments;
+};
+
+// The card preview clamps at eight lines of roughly forty characters; a first
+// match past either budget would be clipped out of view.
+const SEARCH_PREVIEW_PREFIX_CHARACTERS = 96;
+const SEARCH_PREVIEW_PREFIX_LINES = 4;
+/** Context kept ahead of a distant first match. */
+const SEARCH_PREVIEW_LEAD_CHARACTERS = 24;
+
+export type ClipboardSearchPreview = { text: string; truncated: boolean };
+
+/**
+ * Text to render for a searched clip: the full text while the first match
+ * falls inside the clamped preview, otherwise a window that starts one word
+ * boundary ahead of the first match so the highlighted hit is visible.
+ */
+export const clipboardSearchPreviewText = (
+  text: string,
+  query: string,
+): ClipboardSearchPreview => {
+  const terms = clipboardQueryTerms(query);
+  if (terms.length === 0) {
+    return { text, truncated: false };
+  }
+  const matcher = new RegExp(terms.map(escapeRegExp).join("|"), "iu");
+  const matchIndex = text.search(matcher);
+  if (matchIndex === -1) {
+    return { text, truncated: false };
+  }
+  const prefixLines = text.slice(0, matchIndex).split("\n").length - 1;
+  if (
+    matchIndex <= SEARCH_PREVIEW_PREFIX_CHARACTERS &&
+    prefixLines < SEARCH_PREVIEW_PREFIX_LINES
+  ) {
+    return { text, truncated: false };
+  }
+  // Start at the match's line when it is short enough, otherwise at the first
+  // word boundary inside the lead window; without one the fragment of a long
+  // word is dropped and the preview starts at the match itself.
+  const lineStart = text.lastIndexOf("\n", matchIndex - 1) + 1;
+  let start = lineStart;
+  if (matchIndex - lineStart > SEARCH_PREVIEW_LEAD_CHARACTERS) {
+    const windowStart = matchIndex - SEARCH_PREVIEW_LEAD_CHARACTERS;
+    const boundary = text.slice(windowStart, matchIndex).search(/\s\S/u);
+    start = boundary === -1 ? matchIndex : windowStart + boundary + 1;
+  }
+  return { text: text.slice(start).trimStart(), truncated: true };
 };
 
 export const clipboardSourceTintIndex = (sourceIdentity: string | null) => {

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -37,6 +37,18 @@ export const shouldCopyFromClipboardInput = ({
 }: ClipboardInputKey) =>
   !isClipboardNameInput(dataset) && key === "Enter" && !isComposing;
 
+/**
+ * ArrowUp in the search field hands focus back to the selected card (the rail
+ * sits above the search bar). Composition keeps ArrowUp for the IME's
+ * candidate list, and a clip name editor keeps its caret.
+ */
+export const shouldReturnToTimelineFromInput = ({
+  dataset,
+  isComposing,
+  key,
+}: ClipboardInputKey) =>
+  !isClipboardNameInput(dataset) && key === "ArrowUp" && !isComposing;
+
 export const isClipboardCopyShortcut = (shortcut: ClipboardCopyShortcut) =>
   (shortcut.metaKey || shortcut.ctrlKey) &&
   !shortcut.altKey &&

--- a/apps/desktop/src/mainview/index.css
+++ b/apps/desktop/src/mainview/index.css
@@ -157,6 +157,14 @@ body:has(.clipboard-editor-window) .font-sans {
   opacity: 1;
 }
 
+/* macOS-convention inactive selection: while the search field holds focus,
+ * the selected card stays the Enter target but drops the active accent. */
+.clipboard-window:has(.clipboard-search-input:focus)
+  .clipboard-card[aria-current="true"]::after {
+  border-color: color-mix(in srgb, var(--foreground) 26%, transparent);
+  box-shadow: none;
+}
+
 .dark .clipboard-card {
   background-color: color-mix(in srgb, var(--card) 84%, transparent);
   box-shadow:

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -8,6 +8,7 @@ import {
   clipboardTimelineKeyAction,
   clipboardRailScrollDelta,
   clipboardRailWindow,
+  clipboardSearchPreviewText,
   clipboardSourceTintIndex,
   filterClipboardItems,
   formatClipboardAge,
@@ -101,6 +102,50 @@ describe("clipboard search highlighting", () => {
     expect(highlightClipboardText("Closing date", "  ")).toEqual([
       { match: false, text: "Closing date" },
     ]);
+  });
+});
+
+describe("clipboardSearchPreviewText", () => {
+  test("keeps the full text when the first match is near the start", () => {
+    const text = "Purchase price is payable at closing.";
+    expect(clipboardSearchPreviewText(text, "closing")).toEqual({
+      text,
+      truncated: false,
+    });
+  });
+
+  test("windows a distant match to a word boundary with leading context", () => {
+    const text = `${"lorem ipsum dolor sit amet ".repeat(8)}indemnity cap applies`;
+    const preview = clipboardSearchPreviewText(text, "indemnity");
+
+    expect(preview.truncated).toBe(true);
+    expect(preview.text.startsWith("ipsum dolor sit amet indemnity cap")).toBe(
+      true,
+    );
+  });
+
+  test("windows a match hidden below the clamped line count", () => {
+    const text = `a\nb\nc\nd\ne\nf\ng\nh\ni\nfinal clause`;
+    const preview = clipboardSearchPreviewText(text, "clause");
+
+    expect(preview.truncated).toBe(true);
+    expect(preview.text.startsWith("final clause")).toBe(true);
+  });
+
+  test("keeps the full text when only the clip name matched", () => {
+    const text = "Body without the term.";
+    expect(clipboardSearchPreviewText(text, "acquisition")).toEqual({
+      text,
+      truncated: false,
+    });
+  });
+
+  test("matches case-insensitively when windowing", () => {
+    const text = `${"x".repeat(200)} INDEMNITY tail`;
+    const preview = clipboardSearchPreviewText(text, "indemnity");
+
+    expect(preview.truncated).toBe(true);
+    expect(preview.text.startsWith("INDEMNITY tail")).toBe(true);
   });
 });
 

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -16,6 +16,7 @@ import {
   isClipboardNameInput,
   quickCopyIndex,
   shouldCopyFromClipboardInput,
+  shouldReturnToTimelineFromInput,
 } from "../src/clipboard/clipboard-logic";
 import type { ClipboardItem } from "../src/clipboard/clipboard-types";
 
@@ -249,6 +250,37 @@ describe("clipboard input keyboard handling", () => {
         dataset: {},
         isComposing: true,
         key: "Enter",
+      }),
+    ).toBe(false);
+  });
+
+  test("ArrowUp in search returns focus to the timeline", () => {
+    expect(
+      shouldReturnToTimelineFromInput({
+        dataset: {},
+        isComposing: false,
+        key: "ArrowUp",
+      }),
+    ).toBe(true);
+    expect(
+      shouldReturnToTimelineFromInput({
+        dataset: {},
+        isComposing: true,
+        key: "ArrowUp",
+      }),
+    ).toBe(false);
+    expect(
+      shouldReturnToTimelineFromInput({
+        dataset: { clipboardNameInput: "" },
+        isComposing: false,
+        key: "ArrowUp",
+      }),
+    ).toBe(false);
+    expect(
+      shouldReturnToTimelineFromInput({
+        dataset: {},
+        isComposing: false,
+        key: "ArrowDown",
       }),
     ).toBe(false);
   });


### PR DESCRIPTION
Four clipboard-timeline fixes, one commit each.

## Reopen latency after idle (macOS)

Reopen telemetry showed content painting 200-600ms late when the window had
been hidden for 30s+, versus 30-70ms for back-to-back reopens: WebKit
reclaims an ordered-out page's graphics caches within seconds and its
compiled JS within minutes, then rebuilds both on the next open while the
vibrancy panel is already visible.

The window is now parked instead of hidden: kept on screen fully transparent
and click-through, so the page stays warm. Focus is handed back to the app
that was frontmost before the window opened (captured at show); if no such
app is known or activation fails, the window falls back to a real hide.
Occlusion detection is disabled on the webview (private WebKit setter behind
a `respondsToSelector` guard) so the transparent window is not reported
occluded, which would put WebKit back to sleep. The existing
`clipboardReopenPaint` span will show the effect in the field.

## Search focus vs. card selection

ArrowDown moves focus to the search field, but the selected card kept its
active blue ring and no key led back to the rail. While the search field
holds focus, the ring now drops to a neutral inactive-selection accent (the
card remains the Enter target), and ArrowUp returns focus to the selected
card.

## Search previews with distant matches

A match past the preview's eight clamped lines was highlighted off screen,
so a result card showed no visible hit. The preview now windows to the first
match (the match's line, or one word boundary ahead inside a long line) with
a leading ellipsis.

## Source-app provenance lost on restart

Source-app visuals (icon, accent color) lived only in memory, so a restart
kept clip app names but dropped their icons. The visual map is now persisted
in the encrypted store, pruned to keys still referenced by an item, and
restored on load.

Rust unit tests cover persistence round-trip and pruning; bun tests cover
the ArrowUp helper and preview windowing. The parking behavior needs a
manual smoke test on macOS before merge (reopen after idle, focus returning
to the previous app on Escape/copy, blur-hide keeping the clicked app's
focus).

https://claude.ai/code/session_01H85qJUESnafY8WbwhLswcc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clipboard source-app visuals now persist across app restarts.
  * Clipboard search previews now show relevant matching text with clearer truncation and ellipses.
  * Pressing Arrow Up in search returns focus to the clipboard timeline when appropriate.
  * Desktop telemetry now records the host operating system.
* **Bug Fixes**
  * Improved macOS clipboard window hiding to keep it responsive while remaining unobtrusive.
  * Refined selected-card styling while the search field is focused.
* **Tests**
  * Added coverage for search previews, keyboard navigation, persisted visual metadata, and telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->