### PR TITLE
fix(ci): dispatch trusted product media publisher

### DIFF
--- a/.github/workflows/publish-product-media.yml
+++ b/.github/workflows/publish-product-media.yml
@@ -1,14 +1,14 @@
 name: Publish product media
 
 # Bootstrap and recovery publisher for immutable landing-page recordings.
-# It only runs trusted workflow code from main, and only reads source files
-# from main. Routine reshoots use the same checked-in publisher with a locally
-# assumed deploy role before committing the updated manifest.
+# The public repository cannot assume the deployment role from main, so this
+# dispatches the private publisher and watches the resulting run.
 
 on:
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: publish-product-media
@@ -18,35 +18,68 @@ jobs:
   publish:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     environment: release-app
     permissions:
       contents: read
-      id-token: write
     steps:
-      - name: Checkout trusted main
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Mint App token for the private workflows repo
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          persist-credentials: false
-          ref: main
+          client-id: ${{ vars.STELLA_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: private-workflows
+          permission-actions: write
+          permission-contents: read
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version-file: package.json
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEPLOY }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Mask storage identifier
+      - name: Dispatch and watch private publisher
         env:
-          BUCKET: ${{ vars.DOWNLOADS_BUCKET }}
-        run: echo "::add-mask::$BUCKET"
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PRIVATE_WORKFLOWS_REPO: ${{ github.repository_owner }}/private-workflows
+          SOURCE_REF: ${{ github.ref }}
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.sha }}
+          AWS_ROLE_ARN_DEPLOY: ${{ secrets.AWS_ROLE_ARN_DEPLOY }}
+          DOWNLOADS_BUCKET: ${{ vars.DOWNLOADS_BUCKET }}
+        run: |
+          echo "::add-mask::$AWS_ROLE_ARN_DEPLOY"
+          echo "::add-mask::$DOWNLOADS_BUCKET"
+          dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          expected_title="Publish product media ${SOURCE_SHA}"
+          gh workflow run publish-product-media.yml \
+            --repo "$PRIVATE_WORKFLOWS_REPO" \
+            --field source_repository="$SOURCE_REPOSITORY" \
+            --field source_ref="$SOURCE_REF" \
+            --field source_sha="$SOURCE_SHA" \
+            --field aws_role_arn_deploy="$AWS_ROLE_ARN_DEPLOY" \
+            --field downloads_bucket="$DOWNLOADS_BUCKET"
 
-      - name: Publish immutable product media
-        env:
-          PRODUCT_MEDIA_S3_BUCKET: ${{ vars.DOWNLOADS_BUCKET }}
-        run: bun run marketing:media:publish
+          run_id=""
+          for _ in {1..30}; do
+            run_id="$(
+              gh run list \
+                --repo "$PRIVATE_WORKFLOWS_REPO" \
+                --workflow publish-product-media.yml \
+                --event workflow_dispatch \
+                --json databaseId,createdAt,displayTitle \
+                --jq ".[] | select(.createdAt >= \"$dispatched_at\") | select(.displayTitle == \"$expected_title\") | .databaseId" \
+                --limit 10 \
+                | head -n 1
+            )"
+            if [[ -n "$run_id" ]]; then
+              break
+            fi
+            sleep 2
+          done
+
+          if [[ -z "$run_id" ]]; then
+            echo "Could not find the dispatched product media workflow run." >&2
+            exit 1
+          fi
+
+          gh run watch "$run_id" \
+            --repo "$PRIVATE_WORKFLOWS_REPO" \
+            --compact \
+            --exit-status


### PR DESCRIPTION
Route product-media publication through the existing private deployment trust boundary.

The public workflow mints a scoped App token, dispatches the main-only private publisher with the exact source SHA, and waits for its result.