### PR TITLE
fix: synchronize corpus projection writes

### DIFF
--- a/apps/api/src/handlers/case-law/erasure.ts
+++ b/apps/api/src/handlers/case-law/erasure.ts
@@ -24,6 +24,11 @@ import {
 } from "@/api/lib/legal-search/case-law-corpus-upload-intents";
 import { removeDecisionFromIndex } from "@/api/lib/legal-search/case-law-search-index";
 import { CorpusIndexError } from "@/api/lib/legal-search/corpus-index-client";
+import {
+  CorpusIndexProjectionSubjectMissingError,
+  lockActiveCorpusProjectionSourceTx,
+  synchronizeLockedCorpusProjectionDesiredStateTx,
+} from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import { formatCorpusLocation } from "@/api/lib/legal-search/corpus-location";
 import { deleteCorpusDocument } from "@/api/lib/legal-search/corpus-storage";
 import {
@@ -172,6 +177,22 @@ export const redactCaseLawDecision = async ({
     throw error;
   }
   const fenced = await scopedDb(async (tx) => {
+    const sourceLock = await Result.tryPromise({
+      try: async () =>
+        await lockActiveCorpusProjectionSourceTx(tx, {
+          family: "case_law",
+          entityId: decisionId,
+        }),
+      catch: (cause) => cause,
+    });
+    if (Result.isError(sourceLock)) {
+      if (
+        sourceLock.error instanceof CorpusIndexProjectionSubjectMissingError
+      ) {
+        return null;
+      }
+      throw sourceLock.error;
+    }
     const decision = (
       await tx
         .select({
@@ -210,6 +231,12 @@ export const redactCaseLawDecision = async ({
       decisionId,
       tx,
     });
+    if (sourceLock.value !== null) {
+      await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+        lock: sourceLock.value,
+        subject: { family: "case_law", entityId: decisionId },
+      });
+    }
     return { cancelledIntents, decision };
   });
 

--- a/apps/api/src/handlers/case-law/ingestion/pipeline-canonical.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline-canonical.test.ts
@@ -178,26 +178,39 @@ const scopedDb: ScopedDb = async (callback) => {
       },
     },
     select: (selection: Record<string, unknown>) => ({
-      from: (table: unknown) => ({
-        where: () => {
-          const rows = async () => {
-            if (table === caseLawCorpusUploadIntents) {
-              return [{ status: intentStatus }];
-            }
-            if ("redactedAt" in selection) {
-              return [{ redactedAt: null }];
-            }
-            if ("id" in selection) {
-              return [{ id: "decision-id" }];
-            }
-            return [];
-          };
-          return {
+      from: (table: unknown) => {
+        const rows = async () => {
+          if (table === caseLawSources && "sourceDescriptor" in selection) {
+            return [
+              {
+                sourceId:
+                  insertedRows.at(0)?.["sourceId"] ??
+                  existingDecision?.["sourceId"],
+                sourceDescriptor: null,
+              },
+            ];
+          }
+          if (table === caseLawCorpusUploadIntents) {
+            return [{ status: intentStatus }];
+          }
+          if ("redactedAt" in selection) {
+            return [{ redactedAt: null }];
+          }
+          if ("id" in selection) {
+            return [{ id: "decision-id" }];
+          }
+          return [];
+        };
+        return {
+          innerJoin: () => ({
+            where: () => ({ limit: () => ({ for: rows }) }),
+          }),
+          where: () => ({
             limit: rows,
             for: () => ({ limit: rows }),
-          };
-        },
-      }),
+          }),
+        };
+      },
     }),
     insert: (table: unknown) => ({
       values: (values: Record<string, unknown>) => {

--- a/apps/api/src/handlers/case-law/ingestion/pipeline-projection.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline-projection.db.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { and, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import { authRelationsPart } from "@/api/db/auth-schema";
+import type { ScopedDb } from "@/api/db/safe-db";
+import {
+  caseLawDecisions,
+  caseLawSources,
+  corpusIndexGenerations,
+  corpusIndexProjectionStates,
+  relations,
+} from "@/api/db/schema";
+import type { IngestionResult } from "@/api/handlers/case-law/ingestion/adapter";
+import {
+  processDecision,
+  type CaseLawCorpusDependencies,
+} from "@/api/handlers/case-law/ingestion/pipeline";
+import { createSafeId } from "@/api/lib/branded-types";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import { planCorpusDocumentWrite } from "@/api/lib/legal-search/corpus-storage";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+let scopedDb: ScopedDb;
+
+const sourceId = createSafeId<"caseLawSource">();
+
+const corpusWrite: CaseLawCorpusDependencies["write"] = async (input) => {
+  const plan = planCorpusDocumentWrite(input);
+  switch (plan.type) {
+    case "put":
+      return await Promise.resolve({ type: "written", written: plan.written });
+    case "skipped-empty":
+    case "skipped-unchanged":
+      return await Promise.resolve(plan);
+    default:
+      return plan satisfies never;
+  }
+};
+
+const corpus = {
+  mode: "canonical",
+  write: corpusWrite,
+} satisfies CaseLawCorpusDependencies;
+
+const input = (court: string, rawHash: string): IngestionResult => ({
+  caseNumber: "4 As 3/2008",
+  court,
+  country: "CZE",
+  language: "cs",
+  decisionDate: "2008-12-18",
+  decisionType: "rozsudek",
+  fulltext: "Nejvyšší správní soud rozhodl v právní věci žalobkyně.",
+  metadata: {},
+  rawHash,
+  documentAst: {},
+});
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client, relations: { ...relations, ...authRelationsPart } });
+  scopedDb = async (callback) =>
+    await db.transaction(async (tx) => await callback(tx));
+
+  await db.insert(caseLawSources).values({
+    id: sourceId,
+    adapterKey: "projection-ingestion-test",
+    name: "Projection ingestion test",
+  });
+  await db.insert(corpusIndexGenerations).values({
+    family: "case_law",
+    generation: "case_law_v5",
+    cluster: "q09",
+    manifestDigest: corpusIndexManifestDigest(
+      CORPUS_INDEX_MANIFESTS.case_law_v5,
+    ),
+    status: "building",
+  });
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("a settled case-law write advances desired state and dedup replay repairs to a fixed point", async () => {
+  await processDecision({
+    input: input("Nejvyšší správní soud", "publisher-v1"),
+    observationOrder: 1n,
+    sourceId,
+    scopedDb,
+    observedAt: new Date("2026-08-31T12:00:00.000Z"),
+    corpus,
+  });
+  const decision = (
+    await db
+      .select({ id: caseLawDecisions.id })
+      .from(caseLawDecisions)
+      .where(
+        and(
+          eq(caseLawDecisions.sourceId, sourceId),
+          eq(caseLawDecisions.caseNumber, "4 As 3/2008"),
+        ),
+      )
+  ).at(0);
+  if (decision === undefined) {
+    throw new Error("expected stored case-law decision");
+  }
+  const initialState = (
+    await db
+      .select({
+        epoch: corpusIndexProjectionStates.desiredEpoch,
+        fingerprint: corpusIndexProjectionStates.desiredFingerprint,
+      })
+      .from(corpusIndexProjectionStates)
+      .where(eq(corpusIndexProjectionStates.entityId, decision.id))
+  ).at(0);
+
+  const refreshed = input("Ústavní soud", "publisher-v2");
+  await processDecision({
+    input: refreshed,
+    observationOrder: 2n,
+    sourceId,
+    scopedDb,
+    observedAt: new Date("2026-08-31T12:00:01.000Z"),
+    corpus,
+  });
+  const refreshedState = (
+    await db
+      .select({
+        epoch: corpusIndexProjectionStates.desiredEpoch,
+        fingerprint: corpusIndexProjectionStates.desiredFingerprint,
+      })
+      .from(corpusIndexProjectionStates)
+      .where(eq(corpusIndexProjectionStates.entityId, decision.id))
+  ).at(0);
+
+  await processDecision({
+    input: refreshed,
+    observationOrder: 3n,
+    sourceId,
+    scopedDb,
+    observedAt: new Date("2026-08-31T12:00:02.000Z"),
+    corpus,
+  });
+  const replay = (
+    await db
+      .select({
+        court: caseLawDecisions.court,
+        epoch: caseLawDecisions.projectionEpoch,
+      })
+      .from(caseLawDecisions)
+      .where(eq(caseLawDecisions.id, decision.id))
+  ).at(0);
+
+  expect(initialState?.epoch).toBe(1n);
+  expect(initialState?.fingerprint).not.toBeNull();
+  expect(refreshedState?.epoch).toBe(2n);
+  expect(refreshedState?.fingerprint).not.toBe(initialState?.fingerprint);
+  expect(replay).toEqual({ court: "Ústavní soud", epoch: 2n });
+});

--- a/apps/api/src/handlers/case-law/ingestion/pipeline-projection.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline-projection.db.test.ts
@@ -22,6 +22,7 @@ import {
   corpusIndexManifestDigest,
 } from "@/api/lib/legal-search/corpus-index-manifest";
 import { planCorpusDocumentWrite } from "@/api/lib/legal-search/corpus-storage";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
 let client: Awaited<ReturnType<typeof createTestPglite>>;
@@ -65,7 +66,7 @@ beforeAll(async () => {
   client = await createTestPglite();
   db = drizzle({ client, relations: { ...relations, ...authRelationsPart } });
   scopedDb = async (callback) =>
-    await db.transaction(async (tx) => await callback(tx));
+    await db.transaction(async (tx) => await callback(asTestRaw(tx)));
 
   await db.insert(caseLawSources).values({
     id: sourceId,

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -657,6 +657,7 @@ describe("processDecision — corpus storage off", () => {
       sourceRawS3Key: null,
       sourceRawContentType: null,
     };
+    const sourceId = createSafeId<"caseLawSource">();
 
     let updated: Record<string, unknown> | undefined;
     const scopedDb: ScopedDb = async (callback) => {
@@ -665,9 +666,14 @@ describe("processDecision — corpus storage off", () => {
         // write. This suite asserts the decision row, so it reports no prior
         // identity and the citation-graph branch stays out of the way.
         select: () => ({
-          from: () => ({
+          from: (table: unknown) => ({
             where: () => ({
-              for: () => ({ limit: async () => await Promise.resolve([]) }),
+              for: () => ({
+                limit: async () =>
+                  await Promise.resolve(
+                    table === caseLawSources ? [{ id: sourceId }] : [],
+                  ),
+              }),
               limit: async () => await Promise.resolve([]),
             }),
           }),
@@ -715,7 +721,7 @@ describe("processDecision — corpus storage off", () => {
         documentAst: EMPTY_AST,
       },
       observationOrder: 1n,
-      sourceId: createSafeId<"caseLawSource">(),
+      sourceId,
       scopedDb,
       observedAt: new Date("2026-07-31T12:00:00.000Z"),
     });
@@ -745,6 +751,7 @@ describe("processDecision — decision date on an existing row", () => {
       sourceRawS3Key: null,
       sourceRawContentType: null,
     };
+    const sourceId = createSafeId<"caseLawSource">();
 
     let updated: Record<string, unknown> | undefined;
     const scopedDb: ScopedDb = async (callback) => {
@@ -753,9 +760,14 @@ describe("processDecision — decision date on an existing row", () => {
         // write. This suite asserts the decision row, so it reports no prior
         // identity and the citation-graph branch stays out of the way.
         select: () => ({
-          from: () => ({
+          from: (table: unknown) => ({
             where: () => ({
-              for: () => ({ limit: async () => await Promise.resolve([]) }),
+              for: () => ({
+                limit: async () =>
+                  await Promise.resolve(
+                    table === caseLawSources ? [{ id: sourceId }] : [],
+                  ),
+              }),
               limit: async () => await Promise.resolve([]),
             }),
           }),
@@ -804,7 +816,7 @@ describe("processDecision — decision date on an existing row", () => {
         documentAst: EMPTY_AST,
       },
       observationOrder: 1n,
-      sourceId: createSafeId<"caseLawSource">(),
+      sourceId,
       scopedDb,
       observedAt: new Date("2026-07-31T12:00:00.000Z"),
     });

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -74,6 +74,12 @@ import {
   writeReservedCaseLawCorpusUpload,
 } from "@/api/lib/legal-search/case-law-corpus-upload-intents";
 import type { CaseLawSourceIngestionLease } from "@/api/lib/legal-search/case-law-source-ingestion-lease";
+import {
+  type ActiveCorpusProjectionSourceLock,
+  lockActiveCorpusProjectionSourceByIdTx,
+  lockActiveCorpusProjectionSourceTx,
+  synchronizeLockedCorpusProjectionDesiredStateTx,
+} from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import type {
   CorpusPayload,
   WriteCorpusResult,
@@ -959,6 +965,43 @@ const processDecisionAttempt = async ({
     };
   }
 
+  const synchronizeSettledProjection = async (): Promise<void> => {
+    if (existing === undefined) {
+      return;
+    }
+    await scopedDb(async (tx) => {
+      const projectionLock = await lockActiveCorpusProjectionSourceTx(tx, {
+        family: "case_law",
+        entityId: existing.id,
+      });
+      if (projectionLock === null) {
+        return;
+      }
+      const current = (
+        await tx
+          .select({
+            corpusMirrorStatus: caseLawDecisions.corpusMirrorStatus,
+            redactedAt: caseLawDecisions.redactedAt,
+          })
+          .from(caseLawDecisions)
+          .where(eq(caseLawDecisions.id, existing.id))
+          .for("update")
+          .limit(1)
+      ).at(0);
+      if (
+        current === undefined ||
+        current.redactedAt !== null ||
+        current.corpusMirrorStatus !== CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED
+      ) {
+        return;
+      }
+      await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+        lock: projectionLock,
+        subject: { family: "case_law", entityId: existing.id },
+      });
+    });
+  };
+
   const storedPartialObservation = existing
     ? partialObservationFromMetadata(existing.metadata)
     : { caseNumberIsPlaceholder: false, isListingOnly: false };
@@ -984,8 +1027,12 @@ const processDecisionAttempt = async ({
         const watermarkAdvanced = await scopedDb(
           // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
           async (tx) => {
+            const projectionActive = await lockActiveCorpusProjectionSourceTx(
+              tx,
+              { family: "case_law", entityId: existing.id },
+            );
             // audit: skip — background case-law observation watermark; public data
-            return (
+            const advanced = (
               await tx
                 .update(caseLawDecisions)
                 .set({
@@ -1007,6 +1054,13 @@ const processDecisionAttempt = async ({
                 )
                 .returning({ id: caseLawDecisions.id })
             ).at(0);
+            if (advanced !== undefined && projectionActive !== null) {
+              await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+                lock: projectionActive,
+                subject: { family: "case_law", entityId: existing.id },
+              });
+            }
+            return advanced;
           },
         );
         if (!watermarkAdvanced) {
@@ -1042,6 +1096,9 @@ const processDecisionAttempt = async ({
             (current.sourceObservationOrder !== null &&
               current.sourceObservationOrder >= observationOrder)
           ) {
+            if (current !== undefined) {
+              await synchronizeSettledProjection();
+            }
             return {
               status: PROCESS_DECISION_STATUS.COMPLETE,
               inserted: false,
@@ -1091,8 +1148,12 @@ const processDecisionAttempt = async ({
         const watermarkAdvanced = await scopedDb(
           // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
           async (tx) => {
+            const projectionActive = await lockActiveCorpusProjectionSourceTx(
+              tx,
+              { family: "case_law", entityId: existing.id },
+            );
             // audit: skip — background case-law ingestion ordering metadata; public case-law data, not user actions
-            return (
+            const advanced = (
               await tx
                 .update(caseLawDecisions)
                 .set({
@@ -1118,6 +1179,13 @@ const processDecisionAttempt = async ({
                 )
                 .returning({ id: caseLawDecisions.id })
             ).at(0);
+            if (advanced !== undefined && projectionActive !== null) {
+              await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+                lock: projectionActive,
+                subject: { family: "case_law", entityId: existing.id },
+              });
+            }
+            return advanced;
           },
         );
         if (!watermarkAdvanced) {
@@ -1153,6 +1221,9 @@ const processDecisionAttempt = async ({
             (current.sourceObservationOrder !== null &&
               current.sourceObservationOrder >= observationOrder)
           ) {
+            if (current !== undefined) {
+              await synchronizeSettledProjection();
+            }
             return {
               status: PROCESS_DECISION_STATUS.COMPLETE,
               inserted: false,
@@ -1618,11 +1689,33 @@ const processDecisionAttempt = async ({
     );
   };
 
+  const reconcileStableProjection = async (
+    tx: Transaction,
+    id: SafeId<"caseLawDecision">,
+    projectionLock: ActiveCorpusProjectionSourceLock | null,
+  ): Promise<void> => {
+    if (
+      projectionLock === null ||
+      corpusPlan.type === "postgres-mirrored" ||
+      corpusPlan.type === "object-storage"
+    ) {
+      return;
+    }
+    await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+      lock: projectionLock,
+      subject: { family: "case_law", entityId: id },
+    });
+  };
+
   const writeDecisionRow = async (
     slug?: string,
   ): Promise<DecisionRowWriteStatus> =>
     await scopedDb(async (tx) => {
       // audit: skip — background case-law ingestion pipeline; public case-law data, not user actions
+      const projectionLock = await lockActiveCorpusProjectionSourceByIdTx(tx, {
+        family: "case_law",
+        sourceId,
+      });
       if (existing) {
         // A refresh with no document of its own may not overwrite one.
         // Ordinary empty refreshes therefore guard a separate payload
@@ -1811,6 +1904,7 @@ const processDecisionAttempt = async ({
         // Citations are read out of the document, so a refresh that
         // carries no document has nothing to say about them either.
         if (!incomingCarriesDocument) {
+          await reconcileStableProjection(tx, existing.id, projectionLock);
           return DECISION_ROW_WRITE_STATUS.APPLIED;
         }
 
@@ -1835,6 +1929,7 @@ const processDecisionAttempt = async ({
           await resolveCitationsForDecision(tx, existing.id);
         }
 
+        await reconcileStableProjection(tx, existing.id, projectionLock);
         return DECISION_ROW_WRITE_STATUS.APPLIED;
       }
 
@@ -1901,6 +1996,7 @@ const processDecisionAttempt = async ({
         // standing walk to come round, and the citator trails the crawl.
         await resolveCitationsForDecision(tx, decisionRow.id);
       }
+      await reconcileStableProjection(tx, decisionRow.id, projectionLock);
       return DECISION_ROW_WRITE_STATUS.APPLIED;
     });
 
@@ -2056,8 +2152,8 @@ const processDecisionAttempt = async ({
           : sql`NOT ${pgPayloadCarriesDocument}`,
       );
       const upload = await writeReservedCaseLawCorpusUpload({
-        apply: async ({ tx, written }) => ({
-          type: (await settleCaseLawCorpusMirrorTx({
+        apply: async ({ projectionLock, tx, written }) => {
+          const applied = await settleCaseLawCorpusMirrorTx({
             decisionId,
             persistedSourceHash,
             observationOrder,
@@ -2065,10 +2161,18 @@ const processDecisionAttempt = async ({
             mode: corpus.mode,
             tx,
             written,
-          }))
-            ? "applied"
-            : "superseded",
-        }),
+          });
+          if (!applied) {
+            return { type: "superseded" };
+          }
+          if (projectionLock !== null) {
+            await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+              lock: projectionLock,
+              subject: { family: "case_law", entityId: decisionId },
+            });
+          }
+          return { type: "applied" };
+        },
         decisionId,
         intentId: intent.intentId,
         preflight: async (tx) =>

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.ts
@@ -1024,45 +1024,42 @@ const processDecisionAttempt = async ({
         // or payload fields would make a temporary publisher regression durable.
         // A pending corpus mirror deliberately continues below: it must replay
         // the stored payload before this source page is allowed to advance.
-        const watermarkAdvanced = await scopedDb(
-          // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-          async (tx) => {
-            const projectionActive = await lockActiveCorpusProjectionSourceTx(
-              tx,
-              { family: "case_law", entityId: existing.id },
-            );
-            // audit: skip — background case-law observation watermark; public data
-            const advanced = (
-              await tx
-                .update(caseLawDecisions)
-                .set({
-                  sourceObservedAt: observedAt,
-                  sourceObservationOrder: observationOrder,
-                  sourceObservationHash: result.rawHash,
-                  updatedAt: sql`${caseLawDecisions.updatedAt}`,
-                })
-                .where(
-                  and(
-                    eq(caseLawDecisions.id, existing.id),
-                    storedObservationPrecedes({ order: observationOrder }),
-                    isNull(caseLawDecisions.redactedAt),
-                    eq(
-                      caseLawDecisions.corpusMirrorStatus,
-                      CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED,
-                    ),
+        const watermarkAdvanced = await scopedDb(async (tx) => {
+          const projectionActive = await lockActiveCorpusProjectionSourceTx(
+            tx,
+            { family: "case_law", entityId: existing.id },
+          );
+          // audit: skip — background case-law observation watermark; public data
+          const advanced = (
+            await tx
+              .update(caseLawDecisions)
+              .set({
+                sourceObservedAt: observedAt,
+                sourceObservationOrder: observationOrder,
+                sourceObservationHash: result.rawHash,
+                updatedAt: sql`${caseLawDecisions.updatedAt}`,
+              })
+              .where(
+                and(
+                  eq(caseLawDecisions.id, existing.id),
+                  storedObservationPrecedes({ order: observationOrder }),
+                  isNull(caseLawDecisions.redactedAt),
+                  eq(
+                    caseLawDecisions.corpusMirrorStatus,
+                    CASE_LAW_CORPUS_MIRROR_STATUS.SETTLED,
                   ),
-                )
-                .returning({ id: caseLawDecisions.id })
-            ).at(0);
-            if (advanced !== undefined && projectionActive !== null) {
-              await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
-                lock: projectionActive,
-                subject: { family: "case_law", entityId: existing.id },
-              });
-            }
-            return advanced;
-          },
-        );
+                ),
+              )
+              .returning({ id: caseLawDecisions.id })
+          ).at(0);
+          if (advanced !== undefined && projectionActive !== null) {
+            await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+              lock: projectionActive,
+              subject: { family: "case_law", entityId: existing.id },
+            });
+          }
+          return advanced;
+        });
         if (!watermarkAdvanced) {
           const current = await scopedDb((tx) =>
             tx.query.caseLawDecisions.findFirst({
@@ -1145,49 +1142,46 @@ const processDecisionAttempt = async ({
           incomingUsesSourceRawBytes: result.sourceRawBytes !== undefined,
         })
       ) {
-        const watermarkAdvanced = await scopedDb(
-          // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-          async (tx) => {
-            const projectionActive = await lockActiveCorpusProjectionSourceTx(
-              tx,
-              { family: "case_law", entityId: existing.id },
-            );
-            // audit: skip — background case-law ingestion ordering metadata; public case-law data, not user actions
-            const advanced = (
-              await tx
-                .update(caseLawDecisions)
-                .set({
-                  sourceObservedAt: observedAt,
-                  sourceObservationOrder: observationOrder,
-                  sourceObservationHash: result.rawHash,
-                  // Drizzle applies the schema's on-update value unless this column is
-                  // explicit. A watermark-only replay is not a content modification.
-                  updatedAt: sql`${caseLawDecisions.updatedAt}`,
-                })
-                .where(
-                  and(
-                    eq(caseLawDecisions.id, existing.id),
-                    storedObservationPrecedes({ order: observationOrder }),
-                    isNull(caseLawDecisions.redactedAt),
-                    sql`${caseLawDecisions.sourceHash} IS NOT DISTINCT FROM ${existing.sourceHash}`,
-                    // `::text::jsonb`, never a bare `::jsonb`: the cast fixes the
-                    // bind parameter's type, and the driver then JSON-encodes the
-                    // already-serialized string, so the comparison sees a jsonb
-                    // *string* rather than the object and never matches.
-                    sql`${caseLawDecisions.metadata} IS NOT DISTINCT FROM ${JSON.stringify(existing.metadata)}::text::jsonb`,
-                  ),
-                )
-                .returning({ id: caseLawDecisions.id })
-            ).at(0);
-            if (advanced !== undefined && projectionActive !== null) {
-              await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
-                lock: projectionActive,
-                subject: { family: "case_law", entityId: existing.id },
-              });
-            }
-            return advanced;
-          },
-        );
+        const watermarkAdvanced = await scopedDb(async (tx) => {
+          const projectionActive = await lockActiveCorpusProjectionSourceTx(
+            tx,
+            { family: "case_law", entityId: existing.id },
+          );
+          // audit: skip — background case-law ingestion ordering metadata; public case-law data, not user actions
+          const advanced = (
+            await tx
+              .update(caseLawDecisions)
+              .set({
+                sourceObservedAt: observedAt,
+                sourceObservationOrder: observationOrder,
+                sourceObservationHash: result.rawHash,
+                // Drizzle applies the schema's on-update value unless this column is
+                // explicit. A watermark-only replay is not a content modification.
+                updatedAt: sql`${caseLawDecisions.updatedAt}`,
+              })
+              .where(
+                and(
+                  eq(caseLawDecisions.id, existing.id),
+                  storedObservationPrecedes({ order: observationOrder }),
+                  isNull(caseLawDecisions.redactedAt),
+                  sql`${caseLawDecisions.sourceHash} IS NOT DISTINCT FROM ${existing.sourceHash}`,
+                  // `::text::jsonb`, never a bare `::jsonb`: the cast fixes the
+                  // bind parameter's type, and the driver then JSON-encodes the
+                  // already-serialized string, so the comparison sees a jsonb
+                  // *string* rather than the object and never matches.
+                  sql`${caseLawDecisions.metadata} IS NOT DISTINCT FROM ${JSON.stringify(existing.metadata)}::text::jsonb`,
+                ),
+              )
+              .returning({ id: caseLawDecisions.id })
+          ).at(0);
+          if (advanced !== undefined && projectionActive !== null) {
+            await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+              lock: projectionActive,
+              subject: { family: "case_law", entityId: existing.id },
+            });
+          }
+          return advanced;
+        });
         if (!watermarkAdvanced) {
           const current = await scopedDb((tx) =>
             tx.query.caseLawDecisions.findFirst({

--- a/apps/api/src/handlers/legislation/ingestion-projection.db.test.ts
+++ b/apps/api/src/handlers/legislation/ingestion-projection.db.test.ts
@@ -1,0 +1,199 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { ScopedDb } from "@/api/db/safe-db";
+import {
+  corpusIndexGenerations,
+  corpusIndexProjectionStates,
+  legislationDocuments,
+  legislationSources,
+} from "@/api/db/schema";
+import {
+  processLegislationDocument,
+  type LegislationCorpusDependencies,
+} from "@/api/handlers/legislation/ingestion";
+import { createSafeId } from "@/api/lib/branded-types";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import {
+  planCorpusDocumentWrite,
+  type CorpusWriteOutcome,
+} from "@/api/lib/legal-search/corpus-storage";
+import type { LegislationDocumentInput } from "@/api/lib/legal-search/legislation-ingestion-types";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+let scopedDb: ScopedDb;
+
+const sourceId = createSafeId<"legislationSource">();
+
+const corpusWrite: LegislationCorpusDependencies["write"] = async (input) => {
+  const plan = planCorpusDocumentWrite(input);
+  switch (plan.type) {
+    case "put":
+      return await Promise.resolve({ type: "written", written: plan.written });
+    case "skipped-empty":
+    case "skipped-unchanged":
+      return await Promise.resolve(plan);
+    default:
+      return plan satisfies never;
+  }
+};
+
+const corpus = {
+  mode: "dual-write",
+  write: corpusWrite,
+} satisfies LegislationCorpusDependencies;
+
+const input = (
+  status: LegislationDocumentInput["status"],
+): LegislationDocumentInput => ({
+  sourceId,
+  eli: "eli/cz/sb/2012/89",
+  title: "Občanský zákoník",
+  country: "CZE",
+  language: "cs",
+  documentType: "act",
+  status,
+  effectiveDate: "2014-01-01",
+  fulltext: "§ 1 Soukromé právo chrání důstojnost a svobodu člověka.",
+  rawHash: `publisher-${status}`,
+});
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+  scopedDb = async (callback) =>
+    await db.transaction(async (tx) => await callback(tx));
+
+  await db.insert(legislationSources).values({
+    id: sourceId,
+    adapterKey: "projection-ingestion-test",
+    name: "Projection ingestion test",
+  });
+  await db.insert(corpusIndexGenerations).values({
+    family: "legislation",
+    generation: "legislation_v2",
+    cluster: "q09",
+    manifestDigest: corpusIndexManifestDigest(
+      CORPUS_INDEX_MANIFESTS.legislation_v2,
+    ),
+    status: "building",
+  });
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("a settled legislation write advances desired state and replay is a fixed point", async () => {
+  const first = await processLegislationDocument(input("current"), scopedDb, {
+    corpus,
+  });
+  if (first.type !== "stored") {
+    throw new Error(`expected stored legislation, got ${first.type}`);
+  }
+  const initialState = (
+    await db
+      .select({
+        epoch: corpusIndexProjectionStates.desiredEpoch,
+        fingerprint: corpusIndexProjectionStates.desiredFingerprint,
+      })
+      .from(corpusIndexProjectionStates)
+      .where(eq(corpusIndexProjectionStates.entityId, first.id))
+  ).at(0);
+
+  const refreshedInput = input("repealed");
+  await processLegislationDocument(refreshedInput, scopedDb, { corpus });
+  const refreshedState = (
+    await db
+      .select({
+        action: corpusIndexProjectionStates.desiredAction,
+        epoch: corpusIndexProjectionStates.desiredEpoch,
+        fingerprint: corpusIndexProjectionStates.desiredFingerprint,
+      })
+      .from(corpusIndexProjectionStates)
+      .where(eq(corpusIndexProjectionStates.entityId, first.id))
+  ).at(0);
+
+  await processLegislationDocument(refreshedInput, scopedDb, { corpus });
+  const replay = (
+    await db
+      .select({
+        epoch: legislationDocuments.projectionEpoch,
+        status: legislationDocuments.status,
+      })
+      .from(legislationDocuments)
+      .where(eq(legislationDocuments.id, first.id))
+  ).at(0);
+
+  expect(initialState?.epoch).toBe(1n);
+  expect(initialState?.fingerprint).not.toBeNull();
+  expect(refreshedState?.action).toBe("upsert");
+  expect(refreshedState?.epoch).toBe(2n);
+  expect(refreshedState?.fingerprint).not.toBe(initialState?.fingerprint);
+  expect(replay).toEqual({ epoch: 2n, status: "repealed" });
+});
+
+test("a failed corpus refresh advances erase state and a retry restores upsert", async () => {
+  const first = await processLegislationDocument(
+    { ...input("current"), eli: "eli/cz/sb/2012/90" },
+    scopedDb,
+    { corpus },
+  );
+  if (first.type !== "stored") {
+    throw new Error(`expected stored legislation, got ${first.type}`);
+  }
+
+  const failingCorpus = {
+    ...corpus,
+    write: async (): Promise<CorpusWriteOutcome> =>
+      await Promise.reject(new Error("object storage unavailable")),
+  } satisfies LegislationCorpusDependencies;
+  const changed = {
+    ...input("current"),
+    eli: "eli/cz/sb/2012/90",
+    fulltext: "§ 1 Nové znění.",
+    rawHash: "publisher-changed",
+  };
+  const failed = await processLegislationDocument(changed, scopedDb, {
+    corpus: failingCorpus,
+  });
+  const erased = (
+    await db
+      .select({
+        action: corpusIndexProjectionStates.desiredAction,
+        epoch: corpusIndexProjectionStates.desiredEpoch,
+      })
+      .from(corpusIndexProjectionStates)
+      .where(eq(corpusIndexProjectionStates.entityId, first.id))
+  ).at(0);
+
+  const retried = await processLegislationDocument(changed, scopedDb, {
+    corpus,
+  });
+  const restored = (
+    await db
+      .select({
+        action: corpusIndexProjectionStates.desiredAction,
+        epoch: corpusIndexProjectionStates.desiredEpoch,
+      })
+      .from(corpusIndexProjectionStates)
+      .where(eq(corpusIndexProjectionStates.entityId, first.id))
+  ).at(0);
+
+  expect(failed).toMatchObject({
+    type: "stored",
+    corpusWriteFailed: true,
+  });
+  expect(erased).toEqual({ action: "erase", epoch: 2n });
+  expect(retried).toMatchObject({
+    type: "stored",
+    corpusWriteFailed: false,
+  });
+  expect(restored).toEqual({ action: "upsert", epoch: 3n });
+});

--- a/apps/api/src/handlers/legislation/ingestion-projection.db.test.ts
+++ b/apps/api/src/handlers/legislation/ingestion-projection.db.test.ts
@@ -23,6 +23,7 @@ import {
   type CorpusWriteOutcome,
 } from "@/api/lib/legal-search/corpus-storage";
 import type { LegislationDocumentInput } from "@/api/lib/legal-search/legislation-ingestion-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
 let client: Awaited<ReturnType<typeof createTestPglite>>;
@@ -50,7 +51,7 @@ const corpus = {
 } satisfies LegislationCorpusDependencies;
 
 const input = (
-  status: LegislationDocumentInput["status"],
+  status: NonNullable<LegislationDocumentInput["status"]>,
 ): LegislationDocumentInput => ({
   sourceId,
   eli: "eli/cz/sb/2012/89",
@@ -68,7 +69,7 @@ beforeAll(async () => {
   client = await createTestPglite();
   db = drizzle({ client });
   scopedDb = async (callback) =>
-    await db.transaction(async (tx) => await callback(tx));
+    await db.transaction(async (tx) => await callback(asTestRaw(tx)));
 
   await db.insert(legislationSources).values({
     id: sourceId,

--- a/apps/api/src/handlers/legislation/ingestion.ts
+++ b/apps/api/src/handlers/legislation/ingestion.ts
@@ -396,18 +396,16 @@ export const processLegislationDocument = async (
         });
   const corpusAlreadySettled =
     corpus.mode === "off"
-      ? existing !== undefined &&
-        existing.contentHash === null &&
-        existing.textS3Key === null &&
-        existing.normalizedS3Key === null &&
-        existing.astS3Key === null
+      ? existing?.contentHash === null &&
+        existing?.textS3Key === null &&
+        existing?.normalizedS3Key === null &&
+        existing?.astS3Key === null
       : existingCorpusPlan?.type === "skipped-unchanged" ||
         (existingCorpusPlan?.type === "skipped-empty" &&
-          existing !== undefined &&
-          existing.contentHash === expectedContentHash &&
-          existing.textS3Key === null &&
-          existing.normalizedS3Key === null &&
-          existing.astS3Key === null);
+          existing?.contentHash === expectedContentHash &&
+          existing?.textS3Key === null &&
+          existing?.normalizedS3Key === null &&
+          existing?.astS3Key === null);
   if (existing?.sourceHash === sourceHash && corpusAlreadySettled) {
     await settleLegislationCorpusProjection({
       documentId: existing.id,

--- a/apps/api/src/handlers/legislation/ingestion.ts
+++ b/apps/api/src/handlers/legislation/ingestion.ts
@@ -396,7 +396,8 @@ export const processLegislationDocument = async (
         });
   const corpusAlreadySettled =
     corpus.mode === "off"
-      ? existing?.contentHash === null &&
+      ? existing !== undefined &&
+        existing.contentHash === null &&
         existing.textS3Key === null &&
         existing.normalizedS3Key === null &&
         existing.astS3Key === null

--- a/apps/api/src/handlers/legislation/ingestion.ts
+++ b/apps/api/src/handlers/legislation/ingestion.ts
@@ -397,15 +397,15 @@ export const processLegislationDocument = async (
   const corpusAlreadySettled =
     corpus.mode === "off"
       ? existing?.contentHash === null &&
-        existing?.textS3Key === null &&
-        existing?.normalizedS3Key === null &&
-        existing?.astS3Key === null
+        existing.textS3Key === null &&
+        existing.normalizedS3Key === null &&
+        existing.astS3Key === null
       : existingCorpusPlan?.type === "skipped-unchanged" ||
         (existingCorpusPlan?.type === "skipped-empty" &&
           existing?.contentHash === expectedContentHash &&
-          existing?.textS3Key === null &&
-          existing?.normalizedS3Key === null &&
-          existing?.astS3Key === null);
+          existing.textS3Key === null &&
+          existing.normalizedS3Key === null &&
+          existing.astS3Key === null);
   if (existing?.sourceHash === sourceHash && corpusAlreadySettled) {
     await settleLegislationCorpusProjection({
       documentId: existing.id,

--- a/apps/api/src/handlers/legislation/ingestion.ts
+++ b/apps/api/src/handlers/legislation/ingestion.ts
@@ -12,14 +12,22 @@ import {
   CORPUS_SOURCE_TYPE,
   INGESTION_CHECKPOINT_STATUS,
 } from "@/api/lib/corpus-ingestion-checkpoint";
+import type { CorpusStorageMode } from "@/api/lib/corpus-storage-mode";
+import {
+  lockActiveCorpusProjectionSourceTx,
+  synchronizeLockedCorpusProjectionDesiredStateTx,
+} from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import {
   sanitizeMetadata,
   stripDangerousChars,
 } from "@/api/lib/legal-search/corpus-sanitize";
 import {
+  corpusContentHash,
+  planCorpusDocumentWrite,
   storedCorpusWrite,
   writeCorpusDocument,
 } from "@/api/lib/legal-search/corpus-storage";
+import type { CorpusWriteOutcome } from "@/api/lib/legal-search/corpus-storage";
 import {
   ADAPTER_TIMEOUT,
   MAX_CYCLE_MS,
@@ -105,11 +113,14 @@ const preserveLegislationCorpusWriteRetry = async ({
   // Keep the next ingestion pass from treating this document as unchanged
   // after a failed object-storage write. Clear corpus-derived pointers so
   // reads use the fresh Postgres columns until S3 succeeds.
-  // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-  await scopedDb((tx) => {
+  await scopedDb(async (tx) => {
+    const projectionLock = await lockActiveCorpusProjectionSourceTx(tx, {
+      family: "legislation",
+      entityId: documentId,
+    });
     // audit: skip — background corpus storage retry bookkeeping; derived state
-    return (
-      tx
+    const reset = (
+      await tx
         .update(legislationDocuments)
         .set({
           sourceHash: previousSourceHash,
@@ -129,9 +140,80 @@ const preserveLegislationCorpusWriteRetry = async ({
             sql`${legislationDocuments.sourceHash} IS NOT DISTINCT FROM ${expectedSourceHash}`,
           ),
         )
-    );
+        .returning({ id: legislationDocuments.id })
+    ).at(0);
+    if (reset === undefined) {
+      return;
+    }
+    if (projectionLock !== null) {
+      await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+        lock: projectionLock,
+        subject: { family: "legislation", entityId: documentId },
+      });
+    }
   });
 };
+
+type SettleLegislationCorpusProjectionInput = {
+  documentId: SafeId<"legislationDocument">;
+  expectedSourceHash: string;
+  outcome: CorpusWriteOutcome | null;
+  scopedDb: ScopedDb;
+};
+
+/** Settle corpus pointers and the matching desired projection as one CAS. */
+const settleLegislationCorpusProjection = async ({
+  documentId,
+  expectedSourceHash,
+  outcome,
+  scopedDb,
+}: SettleLegislationCorpusProjectionInput): Promise<boolean> =>
+  await scopedDb(async (tx) => {
+    const projectionLock = await lockActiveCorpusProjectionSourceTx(tx, {
+      family: "legislation",
+      entityId: documentId,
+    });
+    const ownerPredicate = and(
+      eq(legislationDocuments.id, documentId),
+      sql`${legislationDocuments.sourceHash} IS NOT DISTINCT FROM ${expectedSourceHash}`,
+    );
+    // audit: skip — background corpus pointer and projection settlement; derived state
+    const owned =
+      outcome === null || outcome.type === "skipped-unchanged"
+        ? (
+            await tx
+              .select({ id: legislationDocuments.id })
+              .from(legislationDocuments)
+              .where(ownerPredicate)
+              .limit(1)
+              .for("update")
+          ).at(0)
+        : (
+            await tx
+              .update(legislationDocuments)
+              .set({
+                textS3Key: outcome.written?.textKey ?? null,
+                normalizedS3Key: outcome.written?.sectionsKey ?? null,
+                astS3Key: outcome.written?.astKey ?? null,
+                contentHash:
+                  outcome.type === "skipped-empty"
+                    ? outcome.contentHash
+                    : outcome.written.contentHash,
+              })
+              .where(ownerPredicate)
+              .returning({ id: legislationDocuments.id })
+          ).at(0);
+    if (owned === undefined) {
+      return false;
+    }
+    if (projectionLock !== null) {
+      await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+        lock: projectionLock,
+        subject: { family: "legislation", entityId: documentId },
+      });
+    }
+    return true;
+  });
 
 /**
  * Hash over every persisted, search-visible field — not just the corpus
@@ -233,7 +315,18 @@ const storeSourceRaw = async ({
   return { sourceRawS3Key: written.value, sourceRawContentType: contentType };
 };
 
+export type LegislationCorpusDependencies = {
+  mode: CorpusStorageMode;
+  write: typeof writeCorpusDocument;
+};
+
+const LEGISLATION_CORPUS_DEPENDENCIES: LegislationCorpusDependencies = {
+  mode: corpusStorageMode,
+  write: writeCorpusDocument,
+};
+
 type ProcessLegislationDocumentOptions = {
+  corpus?: LegislationCorpusDependencies | undefined;
   /** Test seam; production writes through the object-storage client. */
   writeSourceRaw?: WriteRawSourcePayload | undefined;
 };
@@ -244,14 +337,14 @@ type ProcessLegislationDocumentOptions = {
  * re-ingest is skipped. The publisher's payload is stored first,
  * because a row written without it would dedup-skip forever. When corpus
  * storage is on, the canonical payload is written to object storage (outside
- * the tx) and the row's S3 keys + content hash are recorded so the indexers
- * pick it up. The pg-fts and corpus index projections are maintained by the
- * backfill loops (not inline), matching the case-law pipeline.
+ * the tx). Its row pointers and desired corpus projection settle together;
+ * the PostgreSQL full-text projection remains asynchronous.
  */
 export const processLegislationDocument = async (
   raw: LegislationDocumentInput,
   scopedDb: ScopedDb,
   {
+    corpus = LEGISLATION_CORPUS_DEPENDENCIES,
     writeSourceRaw = writeRawSourcePayload,
   }: ProcessLegislationDocumentOptions = {},
 ): Promise<ProcessLegislationResult> => {
@@ -260,6 +353,7 @@ export const processLegislationDocument = async (
   const sections = input.sections ?? null;
   const ast = input.ast ?? null;
   const sourceHash = legislationSourceHash(input);
+  const expectedContentHash = corpusContentHash({ text, sections, ast });
 
   const versionMatch = sql`${legislationDocuments.versionValidFrom} IS NOT DISTINCT FROM ${input.versionValidFrom ?? null}`;
 
@@ -289,7 +383,36 @@ export const processLegislationDocument = async (
       .limit(1),
   );
 
-  if (existing?.sourceHash === sourceHash) {
+  const existingCorpusPlan =
+    existing === undefined
+      ? null
+      : planCorpusDocumentWrite({
+          documentId: existing.id,
+          jurisdiction: input.country,
+          text,
+          sections,
+          ast,
+          stored: storedCorpusWrite(existing),
+        });
+  const corpusAlreadySettled =
+    corpus.mode === "off"
+      ? existing?.contentHash === null &&
+        existing.textS3Key === null &&
+        existing.normalizedS3Key === null &&
+        existing.astS3Key === null
+      : existingCorpusPlan?.type === "skipped-unchanged" ||
+        (existingCorpusPlan?.type === "skipped-empty" &&
+          existing.contentHash === expectedContentHash &&
+          existing.textS3Key === null &&
+          existing.normalizedS3Key === null &&
+          existing.astS3Key === null);
+  if (existing?.sourceHash === sourceHash && corpusAlreadySettled) {
+    await settleLegislationCorpusProjection({
+      documentId: existing.id,
+      expectedSourceHash: sourceHash,
+      outcome: null,
+      scopedDb,
+    });
     return {
       type: "stored",
       id: existing.id,
@@ -323,6 +446,14 @@ export const processLegislationDocument = async (
     metadata: input.metadata ?? {},
     sourceHash,
     ...sourceRaw,
+    ...(corpus.mode === "off"
+      ? {
+          textS3Key: null,
+          normalizedS3Key: null,
+          astS3Key: null,
+          contentHash: null,
+        }
+      : {}),
   };
 
   const id = await scopedDb(async (tx) => {
@@ -354,9 +485,9 @@ export const processLegislationDocument = async (
   // Postgres columns, and its readers key off row state, which stays correct
   // either way. Treating `canonical` as `dual-write` here is the scope
   // decision, not an oversight.
-  if (corpusStorageMode !== "off") {
+  if (corpus.mode !== "off") {
     try {
-      const outcome = await writeCorpusDocument({
+      const outcome = await corpus.write({
         documentId: id,
         jurisdiction: input.country,
         text,
@@ -371,37 +502,17 @@ export const processLegislationDocument = async (
       // stale scans require a non-null content hash, so a row whose indexed
       // document refreshed to empty must stay visible to them — with a null
       // hash the previously indexed text would remain searchable forever.
-      if (outcome.type !== "skipped-unchanged") {
-        // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-        await scopedDb((tx) => {
-          // audit: skip — background corpus storage; derived state
-          return (
-            tx
-              .update(legislationDocuments)
-              .set({
-                textS3Key: outcome.written?.textKey ?? null,
-                normalizedS3Key: outcome.written?.sectionsKey ?? null,
-                astS3Key: outcome.written?.astKey ?? null,
-                contentHash:
-                  outcome.type === "skipped-empty"
-                    ? outcome.contentHash
-                    : outcome.written.contentHash,
-              })
-              // Only while the row still carries this run's sourceHash: a
-              // slower run must not overwrite a concurrent newer refresh.
-              .where(
-                and(
-                  eq(legislationDocuments.id, id),
-                  sql`${legislationDocuments.sourceHash} IS NOT DISTINCT FROM ${sourceHash}`,
-                ),
-              )
-          );
-        });
-      }
+      await settleLegislationCorpusProjection({
+        documentId: id,
+        expectedSourceHash: sourceHash,
+        outcome,
+        scopedDb,
+      });
     } catch (error) {
       corpusWriteFailed = true;
       captureError(error, {
         documentId: id,
+        sourceId: input.sourceId,
         step: "processLegislationDocument.corpusWrite",
       });
       await preserveLegislationCorpusWriteRetry({
@@ -411,6 +522,13 @@ export const processLegislationDocument = async (
         scopedDb,
       });
     }
+  } else {
+    await settleLegislationCorpusProjection({
+      documentId: id,
+      expectedSourceHash: sourceHash,
+      outcome: null,
+      scopedDb,
+    });
   }
 
   return {

--- a/apps/api/src/handlers/legislation/ingestion.ts
+++ b/apps/api/src/handlers/legislation/ingestion.ts
@@ -403,6 +403,7 @@ export const processLegislationDocument = async (
         existing.astS3Key === null
       : existingCorpusPlan?.type === "skipped-unchanged" ||
         (existingCorpusPlan?.type === "skipped-empty" &&
+          existing !== undefined &&
           existing.contentHash === expectedContentHash &&
           existing.textS3Key === null &&
           existing.normalizedS3Key === null &&

--- a/apps/api/src/lib/legal-search/case-law-corpus-upload-intents.ts
+++ b/apps/api/src/lib/legal-search/case-law-corpus-upload-intents.ts
@@ -14,6 +14,11 @@ import { captureError } from "@/api/lib/analytics/capture";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createSafeId } from "@/api/lib/branded-types";
 import {
+  type ActiveCorpusProjectionSourceLock,
+  CorpusIndexProjectionSubjectMissingError,
+  lockActiveCorpusProjectionSourceTx,
+} from "@/api/lib/legal-search/corpus-index-projection-desired-state";
+import {
   corpusKeys,
   deleteCorpusDocument,
 } from "@/api/lib/legal-search/corpus-storage";
@@ -208,6 +213,7 @@ type WriteReservedCaseLawCorpusUploadOptions = {
    * settles the mirror with null pointers instead of keys.
    */
   apply: (args: {
+    projectionLock: ActiveCorpusProjectionSourceLock | null;
     tx: Transaction;
     written: WriteCorpusResult | null;
   }) => Promise<CaseLawCorpusUploadApplyResult>;
@@ -247,6 +253,22 @@ export const writeReservedCaseLawCorpusUpload = async ({
   try {
     return await scopedDb(async (tx) => {
       signal?.throwIfAborted();
+      const sourceLock = await Result.tryPromise({
+        try: async () =>
+          await lockActiveCorpusProjectionSourceTx(tx, {
+            family: "case_law",
+            entityId: decisionId,
+          }),
+        catch: (cause) => cause,
+      });
+      if (Result.isError(sourceLock)) {
+        if (
+          sourceLock.error instanceof CorpusIndexProjectionSubjectMissingError
+        ) {
+          return { type: "redacted-or-missing" };
+        }
+        throw sourceLock.error;
+      }
       const decision = (
         await tx
           .select({ redactedAt: caseLawDecisions.redactedAt })
@@ -313,7 +335,11 @@ export const writeReservedCaseLawCorpusUpload = async ({
           message: "Reserved corpus upload failed",
         });
       }
-      const outcome = await apply({ tx, written: writeOutcome.written });
+      const outcome = await apply({
+        projectionLock: sourceLock.value,
+        tx,
+        written: writeOutcome.written,
+      });
       if (outcome.type === "superseded") {
         await tx
           .update(caseLawCorpusUploadIntents)

--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
@@ -2,7 +2,11 @@ import { panic } from "better-result";
 import { and, eq, or, sql } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
-import { corpusIndexGenerations } from "@/api/db/schema";
+import {
+  caseLawSources,
+  corpusIndexGenerations,
+  legislationSources,
+} from "@/api/db/schema";
 import {
   corpusIndexClusterForGeneration,
   type CorpusFamily,
@@ -26,6 +30,27 @@ export type ServingCorpusIndexGeneration = {
   family: CorpusFamily;
   generation: string;
   cluster: QuickwitCluster;
+};
+
+/**
+ * Fence activation against canonical writers. Writers share-lock their source
+ * before checking the registry; the short table fence also covers a source
+ * inserted concurrently with first activation.
+ */
+const lockCorpusIndexGenerationActivationTx = async (
+  tx: Transaction,
+  family: CorpusFamily,
+): Promise<void> => {
+  switch (family) {
+    case "case_law":
+      await tx.execute(sql`LOCK TABLE ${caseLawSources} IN EXCLUSIVE MODE`);
+      return;
+    case "legislation":
+      await tx.execute(sql`LOCK TABLE ${legislationSources} IN EXCLUSIVE MODE`);
+      return;
+    default:
+      return family satisfies never;
+  }
 };
 
 type CorpusIndexGenerationReadTransaction = Pick<Transaction, "select">;
@@ -133,6 +158,7 @@ export const resumeRetiringCorpusIndexGenerationTx = async (
   tx: Transaction,
   target: { family: CorpusFamily; generation: string },
 ): Promise<void> => {
+  await lockCorpusIndexGenerationActivationTx(tx, target.family);
   const rows = await tx
     .select()
     .from(corpusIndexGenerations)
@@ -172,6 +198,30 @@ export const registerCorpusIndexGenerationTx = async (
   target: CorpusIndexGenerationTarget,
 ): Promise<CorpusIndexManifest> => {
   const manifest = requireCorpusIndexManifest(target.family, target.generation);
+  const registered = (
+    await tx
+      .select()
+      .from(corpusIndexGenerations)
+      .where(
+        and(
+          eq(corpusIndexGenerations.family, manifest.family),
+          eq(corpusIndexGenerations.generation, manifest.generation),
+        ),
+      )
+      .limit(1)
+  ).at(0);
+  if (
+    registered !== undefined &&
+    (registered.status === "building" || registered.status === "serving")
+  ) {
+    return requireRegisteredCorpusIndexManifest(registered);
+  }
+  if (registered !== undefined) {
+    return panic(
+      `Active corpus generation registration failed: ${target.family}/${target.generation}`,
+    );
+  }
+  await lockCorpusIndexGenerationActivationTx(tx, manifest.family);
   await tx
     .insert(corpusIndexGenerations)
     .values({

--- a/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.test.ts
@@ -7,6 +7,7 @@ import {
   type CaseLawV5ProjectionInput,
   type LegislationV2ProjectionInput,
 } from "@/api/lib/legal-search/corpus-index-projection-descriptor";
+import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/lib/legal-search/corpus-storage";
 
 const CASE_LAW_INPUT = {
   family: "case_law",
@@ -79,7 +80,7 @@ test("every projected metadata change invalidates the input fingerprint", () => 
   expect(changed).not.toEqual(first);
 });
 
-test("redaction, missing payload, and redistribution revocation erase", () => {
+test("redaction, missing or empty payload, and redistribution revocation erase", () => {
   for (const input of [
     { ...CASE_LAW_INPUT, redacted: true },
     { ...CASE_LAW_INPUT, contentHash: null },
@@ -89,6 +90,14 @@ test("redaction, missing payload, and redistribution revocation erase", () => {
       deriveCorpusIndexProjectionDescriptor(
         CORPUS_INDEX_MANIFESTS.case_law_v5,
         input,
+      ),
+    ).toEqual({ action: "erase" });
+  }
+  for (const contentHash of EMPTY_CORPUS_CONTENT_HASHES) {
+    expect(
+      deriveCorpusIndexProjectionDescriptor(
+        CORPUS_INDEX_MANIFESTS.case_law_v5,
+        { ...CASE_LAW_INPUT, contentHash },
       ),
     ).toEqual({ action: "erase" });
   }

--- a/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-descriptor.ts
@@ -7,6 +7,7 @@ import {
   corpusIndexManifestDigest,
   type CorpusIndexManifest,
 } from "@/api/lib/legal-search/corpus-index-manifest";
+import { EMPTY_CORPUS_CONTENT_HASHES } from "@/api/lib/legal-search/corpus-storage";
 
 type ProjectionInputBase = {
   documentId: string;
@@ -89,6 +90,7 @@ export const deriveCorpusIndexProjectionDescriptor = (
   }
   if (
     input.contentHash === null ||
+    EMPTY_CORPUS_CONTENT_HASHES.includes(input.contentHash) ||
     !input.redistributionEligible ||
     (input.family === "case_law" && input.redacted)
   ) {

--- a/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
@@ -40,6 +40,27 @@ export type CorpusIndexProjectionSubject =
       entityId: SafeId<"legislationDocument">;
     };
 
+export type CorpusIndexProjectionSource =
+  | { family: "case_law"; sourceId: SafeId<"caseLawSource"> }
+  | { family: "legislation"; sourceId: SafeId<"legislationSource"> };
+
+const ACTIVE_CORPUS_PROJECTION_SOURCE_LOCK = Symbol(
+  "active-corpus-projection-source-lock",
+);
+
+/** Opaque proof that the active-generation check and source lock both passed. */
+export type ActiveCorpusProjectionSourceLock = {
+  readonly [ACTIVE_CORPUS_PROJECTION_SOURCE_LOCK]: true;
+  readonly family: CorpusIndexProjectionSubject["family"];
+};
+
+const activeCorpusProjectionSourceLock = (
+  family: CorpusIndexProjectionSubject["family"],
+): ActiveCorpusProjectionSourceLock => ({
+  [ACTIVE_CORPUS_PROJECTION_SOURCE_LOCK]: true,
+  family,
+});
+
 export class CorpusIndexProjectionSubjectMissingError extends TaggedError(
   "CorpusIndexProjectionSubjectMissingError",
 )<{ message: string; subject: CorpusIndexProjectionSubject }> {}
@@ -47,6 +68,16 @@ export class CorpusIndexProjectionSubjectMissingError extends TaggedError(
 type LockedProjectionInput = {
   epoch: bigint;
   input: CorpusIndexProjectionInput;
+};
+
+type LockedCaseLawProjectionSource = {
+  sourceId: SafeId<"caseLawSource">;
+  sourceDescriptor: Parameters<typeof isRedistributable>[0];
+};
+
+type LockedLegislationProjectionSource = {
+  sourceId: SafeId<"legislationSource">;
+  sourceDescriptor: Parameters<typeof isRedistributable>[0];
 };
 
 export type CaseLawProjectionCanonicalInput = {
@@ -143,14 +174,11 @@ export const legislationProjectionInputFromCanonical = ({
   eli,
 });
 
-const lockCaseLawProjectionInput = async (
+const lockCaseLawProjectionSource = async (
   tx: Transaction,
   subject: Extract<CorpusIndexProjectionSubject, { family: "case_law" }>,
-): Promise<LockedProjectionInput> => {
-  // Source-policy writers own the source row before walking its documents.
-  // Take the compatible source lock first so per-document projection never
-  // inverts that order or exclusively serializes every decision in a source.
-  const sourceRows = await tx
+): Promise<LockedCaseLawProjectionSource> => {
+  const rows = await tx
     .select({
       sourceId: caseLawSources.id,
       sourceDescriptor: caseLawSources.descriptor,
@@ -163,13 +191,159 @@ const lockCaseLawProjectionInput = async (
     .where(eq(caseLawDecisions.id, subject.entityId))
     .limit(1)
     .for("share", { of: caseLawSources });
-  const source = sourceRows.at(0);
+  const source = rows.at(0);
   if (source === undefined) {
     throw new CorpusIndexProjectionSubjectMissingError({
       message: `Case-law projection subject does not exist: ${subject.entityId}`,
       subject,
     });
   }
+  return source;
+};
+
+const lockLegislationProjectionSource = async (
+  tx: Transaction,
+  subject: Extract<CorpusIndexProjectionSubject, { family: "legislation" }>,
+): Promise<LockedLegislationProjectionSource> => {
+  const rows = await tx
+    .select({
+      sourceId: legislationSources.id,
+      sourceDescriptor: legislationSources.descriptor,
+    })
+    .from(legislationSources)
+    .innerJoin(
+      legislationDocuments,
+      eq(legislationDocuments.sourceId, legislationSources.id),
+    )
+    .where(eq(legislationDocuments.id, subject.entityId))
+    .limit(1)
+    .for("share", { of: legislationSources });
+  const source = rows.at(0);
+  if (source === undefined) {
+    throw new CorpusIndexProjectionSubjectMissingError({
+      message: `Legislation projection subject does not exist: ${subject.entityId}`,
+      subject,
+    });
+  }
+  return source;
+};
+
+/** Take the source-policy half of the canonical projection lock order. */
+export const lockCorpusProjectionSourceTx = async (
+  tx: Transaction,
+  subject: CorpusIndexProjectionSubject,
+): Promise<void> => {
+  switch (subject.family) {
+    case "case_law":
+      await lockCaseLawProjectionSource(tx, subject);
+      return;
+    case "legislation":
+      await lockLegislationProjectionSource(tx, subject);
+      return;
+    default:
+      return subject satisfies never;
+  }
+};
+
+/** Lock source policy before inserting a canonical subject that has no row yet. */
+export const lockCorpusProjectionSourceByIdTx = async (
+  tx: Transaction,
+  source: CorpusIndexProjectionSource,
+): Promise<void> => {
+  switch (source.family) {
+    case "case_law": {
+      const row = (
+        await tx
+          .select({ id: caseLawSources.id })
+          .from(caseLawSources)
+          .where(eq(caseLawSources.id, source.sourceId))
+          .for("share")
+          .limit(1)
+      ).at(0);
+      if (row === undefined) {
+        return panic(
+          `Case-law projection source does not exist: ${source.sourceId}`,
+        );
+      }
+      return;
+    }
+    case "legislation": {
+      const row = (
+        await tx
+          .select({ id: legislationSources.id })
+          .from(legislationSources)
+          .where(eq(legislationSources.id, source.sourceId))
+          .for("share")
+          .limit(1)
+      ).at(0);
+      if (row === undefined) {
+        return panic(
+          `Legislation projection source does not exist: ${source.sourceId}`,
+        );
+      }
+      return;
+    }
+    default:
+      return source satisfies never;
+  }
+};
+
+const hasActiveCorpusProjectionTx = async (
+  tx: Transaction,
+  family: CorpusIndexProjectionSubject["family"],
+): Promise<boolean> =>
+  (
+    await tx
+      .select({ generation: corpusIndexGenerations.generation })
+      .from(corpusIndexGenerations)
+      .where(
+        and(
+          eq(corpusIndexGenerations.family, family),
+          or(
+            eq(corpusIndexGenerations.status, "building"),
+            eq(corpusIndexGenerations.status, "serving"),
+          ),
+        ),
+      )
+      .limit(1)
+  ).length > 0;
+
+/**
+ * Take source policy first only while this family has an active projection.
+ * A null result stays null for the caller's transaction: registration
+ * bootstrap covers a generation that becomes visible after this check.
+ */
+export const lockActiveCorpusProjectionSourceTx = async (
+  tx: Transaction,
+  subject: CorpusIndexProjectionSubject,
+): Promise<ActiveCorpusProjectionSourceLock | null> => {
+  if (!(await hasActiveCorpusProjectionTx(tx, subject.family))) {
+    return null;
+  }
+  await lockCorpusProjectionSourceTx(tx, subject);
+  return activeCorpusProjectionSourceLock(subject.family);
+};
+
+/** Source-id variant for inserts whose canonical subject row does not exist yet. */
+export const lockActiveCorpusProjectionSourceByIdTx = async (
+  tx: Transaction,
+  source: CorpusIndexProjectionSource,
+): Promise<ActiveCorpusProjectionSourceLock | null> => {
+  if (!(await hasActiveCorpusProjectionTx(tx, source.family))) {
+    return null;
+  }
+  await lockCorpusProjectionSourceByIdTx(tx, source);
+  return activeCorpusProjectionSourceLock(source.family);
+};
+
+const lockCaseLawProjectionInput = async (
+  tx: Transaction,
+  subject: Extract<CorpusIndexProjectionSubject, { family: "case_law" }>,
+): Promise<LockedProjectionInput> => {
+  // Source-policy writers own the source row before walking its documents.
+  // Take the compatible source lock first so per-document projection never
+  // inverts that order or exclusively serializes every decision in a source.
+  const source = await lockCaseLawProjectionSource(tx, subject);
   const rows = await tx
     .select({
       documentId: caseLawDecisions.id,
@@ -233,26 +407,7 @@ const lockLegislationProjectionInput = async (
   tx: Transaction,
   subject: Extract<CorpusIndexProjectionSubject, { family: "legislation" }>,
 ): Promise<LockedProjectionInput> => {
-  const sourceRows = await tx
-    .select({
-      sourceId: legislationSources.id,
-      sourceDescriptor: legislationSources.descriptor,
-    })
-    .from(legislationSources)
-    .innerJoin(
-      legislationDocuments,
-      eq(legislationDocuments.sourceId, legislationSources.id),
-    )
-    .where(eq(legislationDocuments.id, subject.entityId))
-    .limit(1)
-    .for("share", { of: legislationSources });
-  const source = sourceRows.at(0);
-  if (source === undefined) {
-    throw new CorpusIndexProjectionSubjectMissingError({
-      message: `Legislation projection subject does not exist: ${subject.entityId}`,
-      subject,
-    });
-  }
+  const source = await lockLegislationProjectionSource(tx, subject);
   const rows = await tx
     .select({
       documentId: legislationDocuments.id,
@@ -680,6 +835,25 @@ export const reconcileCorpusProjectionDesiredStateTx = async (
     changed: values.length > 0,
     generationCount: manifests.length,
   };
+};
+
+/** Reconcile after a canonical mutation while retaining its source-lock proof. */
+export const synchronizeLockedCorpusProjectionDesiredStateTx = async (
+  tx: Transaction,
+  {
+    lock,
+    subject,
+  }: {
+    lock: ActiveCorpusProjectionSourceLock;
+    subject: CorpusIndexProjectionSubject;
+  },
+): Promise<void> => {
+  if (lock.family !== subject.family) {
+    return panic(
+      `Corpus projection source lock family ${lock.family} cannot synchronize ${subject.family}`,
+    );
+  }
+  await reconcileCorpusProjectionDesiredStateTx(tx, subject);
 };
 
 /** Seed one newly registered generation without invalidating existing ones. */

--- a/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
@@ -1,5 +1,5 @@
 import { panic, TaggedError } from "better-result";
-import { and, asc, eq, or, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, or, sql } from "drizzle-orm";
 
 import { DECISION_IDENTIFIER_MAX_COUNT } from "@stll/legal-ast/decision-identifier";
 
@@ -29,6 +29,13 @@ import {
 import { isRedistributable } from "@/api/lib/legal-search/corpus-source";
 
 const CORPUS_INDEX_MANIFEST_COUNT = Object.keys(CORPUS_INDEX_MANIFESTS).length;
+
+const projectionGenerationsForFamily = (
+  family: CorpusIndexProjectionSubject["family"],
+): string[] =>
+  Object.values(CORPUS_INDEX_MANIFESTS).flatMap((manifest) =>
+    manifest.family === family ? [manifest.generation] : [],
+  );
 
 export type CorpusIndexProjectionSubject =
   | {
@@ -299,6 +306,10 @@ const hasActiveCorpusProjectionTx = async (
       .where(
         and(
           eq(corpusIndexGenerations.family, family),
+          inArray(
+            corpusIndexGenerations.generation,
+            projectionGenerationsForFamily(family),
+          ),
           or(
             eq(corpusIndexGenerations.status, "building"),
             eq(corpusIndexGenerations.status, "serving"),
@@ -309,18 +320,18 @@ const hasActiveCorpusProjectionTx = async (
   ).length > 0;
 
 /**
- * Take source policy first only while this family has an active projection.
- * A null result stays null for the caller's transaction: registration
- * bootstrap covers a generation that becomes visible after this check.
+ * Share-lock source policy before checking activation. Registration takes a
+ * conflicting source-table fence before publishing a building generation, so
+ * a null result remains authoritative until this transaction commits.
  */
 export const lockActiveCorpusProjectionSourceTx = async (
   tx: Transaction,
   subject: CorpusIndexProjectionSubject,
 ): Promise<ActiveCorpusProjectionSourceLock | null> => {
+  await lockCorpusProjectionSourceTx(tx, subject);
   if (!(await hasActiveCorpusProjectionTx(tx, subject.family))) {
     return null;
   }
-  await lockCorpusProjectionSourceTx(tx, subject);
   return activeCorpusProjectionSourceLock(subject.family);
 };
 
@@ -329,10 +340,10 @@ export const lockActiveCorpusProjectionSourceByIdTx = async (
   tx: Transaction,
   source: CorpusIndexProjectionSource,
 ): Promise<ActiveCorpusProjectionSourceLock | null> => {
+  await lockCorpusProjectionSourceByIdTx(tx, source);
   if (!(await hasActiveCorpusProjectionTx(tx, source.family))) {
     return null;
   }
-  await lockCorpusProjectionSourceByIdTx(tx, source);
   return activeCorpusProjectionSourceLock(source.family);
 };
 
@@ -501,6 +512,10 @@ const activeManifests = async (
     .where(
       and(
         eq(corpusIndexGenerations.family, family),
+        inArray(
+          corpusIndexGenerations.generation,
+          projectionGenerationsForFamily(family),
+        ),
         or(
           eq(corpusIndexGenerations.status, "building"),
           eq(corpusIndexGenerations.status, "serving"),

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
@@ -307,6 +307,18 @@ if (!databaseUrl || !runPostgresTests) {
       } finally {
         releaseWriter.resolve(undefined);
         await writerDb
+          .update(corpusIndexGenerations)
+          .set({ status: "retired" })
+          .where(
+            and(
+              eq(corpusIndexGenerations.family, "case_law"),
+              inArray(corpusIndexGenerations.generation, [
+                legacyGeneration,
+                "case_law_v5",
+              ]),
+            ),
+          );
+        await writerDb
           .delete(corpusIndexProjectionStates)
           .where(eq(corpusIndexProjectionStates.entityId, decisionId));
         await writerDb

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
@@ -240,8 +240,22 @@ if (!databaseUrl || !runPostgresTests) {
       const releaseWriter = Promise.withResolvers<undefined>();
       const writerLocked = Promise.withResolvers<undefined>();
       const activationAttempted = Promise.withResolvers<undefined>();
+      let targetGenerationCreated = false;
 
       try {
+        const existingTarget = (
+          await writerDb
+            .select({ generation: corpusIndexGenerations.generation })
+            .from(corpusIndexGenerations)
+            .where(
+              and(
+                eq(corpusIndexGenerations.family, target.family),
+                eq(corpusIndexGenerations.generation, target.generation),
+              ),
+            )
+            .limit(1)
+        ).at(0);
+        expect(existingTarget).toBeUndefined();
         await writerDb.insert(caseLawSources).values({
           id: sourceId,
           adapterKey: `projection-activation-${suffix}`,
@@ -297,7 +311,9 @@ if (!databaseUrl || !runPostgresTests) {
 
         releaseWriter.resolve(undefined);
         await writer;
-        expect(await activation).toEqual({ epoch: 1n, created: true });
+        const activationResult = await activation;
+        targetGenerationCreated = true;
+        expect(activationResult).toEqual({ epoch: 1n, created: true });
         expect(
           await writerDb.transaction(
             async (tx) =>
@@ -306,16 +322,16 @@ if (!databaseUrl || !runPostgresTests) {
         ).toEqual({ epoch: 1n, changed: false, generationCount: 1 });
       } finally {
         releaseWriter.resolve(undefined);
+        const createdGenerations = targetGenerationCreated
+          ? [legacyGeneration, target.generation]
+          : [legacyGeneration];
         await writerDb
           .update(corpusIndexGenerations)
           .set({ status: "retired" })
           .where(
             and(
               eq(corpusIndexGenerations.family, "case_law"),
-              inArray(corpusIndexGenerations.generation, [
-                legacyGeneration,
-                "case_law_v5",
-              ]),
+              inArray(corpusIndexGenerations.generation, createdGenerations),
             ),
           );
         await writerDb
@@ -332,10 +348,7 @@ if (!databaseUrl || !runPostgresTests) {
           .where(
             and(
               eq(corpusIndexGenerations.family, "case_law"),
-              inArray(corpusIndexGenerations.generation, [
-                legacyGeneration,
-                "case_law_v5",
-              ]),
+              inArray(corpusIndexGenerations.generation, createdGenerations),
             ),
           );
         await Promise.all([writerClient.close(), activationClient.close()]);

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
@@ -235,6 +235,7 @@ if (!databaseUrl || !runPostgresTests) {
         family: "case_law",
         generation: "case_law_v5",
       } as const;
+      const legacyGeneration = `case_law_v${suffix}`;
       const subject = { family: "case_law", entityId: decisionId } as const;
       const releaseWriter = Promise.withResolvers<undefined>();
       const writerLocked = Promise.withResolvers<undefined>();
@@ -257,7 +258,7 @@ if (!databaseUrl || !runPostgresTests) {
         });
         await writerDb.insert(corpusIndexGenerations).values({
           family: "case_law",
-          generation: "case_law_v2",
+          generation: legacyGeneration,
           cluster: "q08",
           manifestDigest: "a".repeat(64),
           status: "serving",
@@ -320,7 +321,7 @@ if (!databaseUrl || !runPostgresTests) {
             and(
               eq(corpusIndexGenerations.family, "case_law"),
               inArray(corpusIndexGenerations.generation, [
-                "case_law_v2",
+                legacyGeneration,
                 "case_law_v5",
               ]),
             ),

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
@@ -296,7 +296,7 @@ if (!databaseUrl || !runPostgresTests) {
         expect(activatedWhileWriterHeld).toBe(false);
 
         releaseWriter.resolve(undefined);
-        expect(await writer).toBeUndefined();
+        await writer;
         expect(await activation).toEqual({ epoch: 1n, created: true });
         expect(
           await writerDb.transaction(

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
@@ -261,7 +261,7 @@ if (!databaseUrl || !runPostgresTests) {
           generation: legacyGeneration,
           cluster: "q08",
           manifestDigest: "a".repeat(64),
-          status: "serving",
+          status: "building",
         });
 
         const writer = writerDb.transaction(async (tx) => {

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
@@ -13,6 +13,12 @@ import {
   legislationSources,
 } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
+import { registerCorpusIndexGenerationTx } from "@/api/lib/legal-search/corpus-index-generation-store";
+import {
+  ensureCorpusProjectionDesiredStateTx,
+  lockActiveCorpusProjectionSourceTx,
+  reconcileCorpusProjectionDesiredStateTx,
+} from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 
 import { lockCorpusIndexProjectionMutationsTx } from "./corpus-index-projection-revision";
 
@@ -208,6 +214,118 @@ if (!databaseUrl || !runPostgresTests) {
           .where(eq(legislationSources.id, legislationSourceId));
         await firstDb.delete(corpusIndexGenerations).where(generationPredicate);
         await Promise.all([firstClient.close(), secondClient.close()]);
+      }
+    });
+
+    test("generation activation cannot overtake a canonical mutation", async () => {
+      const writerClient = new SQL({ url: databaseUrl, max: 1 });
+      const activationClient = new SQL({ url: databaseUrl, max: 1 });
+      const writerDb = drizzle({
+        client: writerClient,
+        relations: databaseRelations,
+      });
+      const activationDb = drizzle({
+        client: activationClient,
+        relations: databaseRelations,
+      });
+      const suffix = Date.now();
+      const sourceId = toSafeId<"caseLawSource">(Bun.randomUUIDv7());
+      const decisionId = toSafeId<"caseLawDecision">(Bun.randomUUIDv7());
+      const target = {
+        family: "case_law",
+        generation: "case_law_v5",
+      } as const;
+      const subject = { family: "case_law", entityId: decisionId } as const;
+      const releaseWriter = Promise.withResolvers<undefined>();
+      const writerLocked = Promise.withResolvers<undefined>();
+      const activationAttempted = Promise.withResolvers<undefined>();
+
+      try {
+        await writerDb.insert(caseLawSources).values({
+          id: sourceId,
+          adapterKey: `projection-activation-${suffix}`,
+          name: "Projection activation",
+        });
+        await writerDb.insert(caseLawDecisions).values({
+          id: decisionId,
+          sourceId,
+          caseNumber: `projection-activation-${suffix}`,
+          court: "Court before activation",
+          country: "CZE",
+          language: "cs",
+          contentHash: "a".repeat(64),
+        });
+        await writerDb.insert(corpusIndexGenerations).values({
+          family: "case_law",
+          generation: "case_law_v2",
+          cluster: "q08",
+          manifestDigest: "a".repeat(64),
+          status: "serving",
+        });
+
+        const writer = writerDb.transaction(async (tx) => {
+          await tx.execute(sql`SET LOCAL statement_timeout = '5s'`);
+          const lock = await lockActiveCorpusProjectionSourceTx(tx, subject);
+          expect(lock).toBeNull();
+          await tx
+            .update(caseLawDecisions)
+            .set({ court: "Court committed before activation" })
+            .where(eq(caseLawDecisions.id, decisionId));
+          writerLocked.resolve(undefined);
+          await releaseWriter.promise;
+        });
+        await writerLocked.promise;
+
+        const activation = activationDb.transaction(async (tx) => {
+          await tx.execute(sql`SET LOCAL statement_timeout = '5s'`);
+          activationAttempted.resolve(undefined);
+          await registerCorpusIndexGenerationTx(tx, target);
+          return await ensureCorpusProjectionDesiredStateTx(
+            tx,
+            subject,
+            target.generation,
+          );
+        });
+        await activationAttempted.promise;
+
+        const activatedWhileWriterHeld = await Promise.race([
+          activation.then(() => true),
+          Bun.sleep(100).then(() => false),
+        ]);
+        expect(activatedWhileWriterHeld).toBe(false);
+
+        releaseWriter.resolve(undefined);
+        expect(await writer).toBeUndefined();
+        expect(await activation).toEqual({ epoch: 1n, created: true });
+        expect(
+          await writerDb.transaction(
+            async (tx) =>
+              await reconcileCorpusProjectionDesiredStateTx(tx, subject),
+          ),
+        ).toEqual({ epoch: 1n, changed: false, generationCount: 1 });
+      } finally {
+        releaseWriter.resolve(undefined);
+        await writerDb
+          .delete(corpusIndexProjectionStates)
+          .where(eq(corpusIndexProjectionStates.entityId, decisionId));
+        await writerDb
+          .delete(caseLawDecisions)
+          .where(eq(caseLawDecisions.id, decisionId));
+        await writerDb
+          .delete(caseLawSources)
+          .where(eq(caseLawSources.id, sourceId));
+        await writerDb
+          .delete(corpusIndexGenerations)
+          .where(
+            and(
+              eq(corpusIndexGenerations.family, "case_law"),
+              inArray(corpusIndexGenerations.generation, [
+                "case_law_v2",
+                "case_law_v5",
+              ]),
+            ),
+          );
+        await Promise.all([writerClient.close(), activationClient.close()]);
       }
     });
   });

--- a/apps/api/src/lib/legal-search/sk-document-backfill.ts
+++ b/apps/api/src/lib/legal-search/sk-document-backfill.ts
@@ -57,6 +57,11 @@ import {
 } from "@/api/lib/legal-search/case-law-corpus-upload-intents";
 import { indexDecision } from "@/api/lib/legal-search/case-law-search-index";
 import {
+  type ActiveCorpusProjectionSourceLock,
+  lockActiveCorpusProjectionSourceTx,
+  synchronizeLockedCorpusProjectionDesiredStateTx,
+} from "@/api/lib/legal-search/corpus-index-projection-desired-state";
+import {
   corpusContentHash,
   corpusMirrorColumns,
   corpusPayloadDisposition,
@@ -632,6 +637,7 @@ export const storeBackfilledDocument = async ({
   const applyStoredPayload = async (
     tx: Transaction,
     written: WriteCorpusResult | null,
+    projectionLock: ActiveCorpusProjectionSourceLock | null,
   ): Promise<boolean> => {
     // Under canonical storage the payload this store just wrote to object
     // storage is the one readers get, so persisting it into the columns as
@@ -656,12 +662,24 @@ export const storeBackfilledDocument = async ({
       })
       .where(ownerPredicate)
       .returning({ id: caseLawDecisions.id });
+    if (applied.length > 0 && projectionLock !== null) {
+      await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+        lock: projectionLock,
+        subject: { family: "case_law", entityId: decision.id },
+      });
+    }
     return applied.length > 0;
   };
 
   let stored: boolean;
   if (writeCorpus === null) {
-    stored = await scopedDb(async (tx) => await applyStoredPayload(tx, null));
+    stored = await scopedDb(async (tx) => {
+      const projectionLock = await lockActiveCorpusProjectionSourceTx(tx, {
+        family: "case_law",
+        entityId: decision.id,
+      });
+      return await applyStoredPayload(tx, null, projectionLock);
+    });
   } else {
     const intent = await reserveCaseLawCorpusUploadIntent({
       contentHash: corpusContentHash(payload),
@@ -673,8 +691,8 @@ export const storeBackfilledDocument = async ({
       return "superseded";
     }
     const outcome = await writeReservedCaseLawCorpusUpload({
-      apply: async ({ tx, written }) => ({
-        type: (await applyStoredPayload(tx, written))
+      apply: async ({ projectionLock, tx, written }) => ({
+        type: (await applyStoredPayload(tx, written, projectionLock))
           ? "applied"
           : "superseded",
       }),
@@ -838,8 +856,12 @@ export const markDocumentUnavailable = async (
   scopedDb: ScopedDb,
 ): Promise<void> => {
   await scopedDb(async (tx) => {
+    const projectionLock = await lockActiveCorpusProjectionSourceTx(tx, {
+      family: "case_law",
+      entityId: decisionId,
+    });
     // audit: skip — queue backfill of public case-law text; no user action
-    await tx
+    const updated = await tx
       .update(caseLawDecisions)
       .set({
         fulltext: "",
@@ -855,7 +877,14 @@ export const markDocumentUnavailable = async (
           isNull(caseLawDecisions.fulltext),
           storesNoCorpusDocument,
         ),
-      );
+      )
+      .returning({ id: caseLawDecisions.id });
+    if (updated.length > 0 && projectionLock !== null) {
+      await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+        lock: projectionLock,
+        subject: { family: "case_law", entityId: decisionId },
+      });
+    }
   });
 };
 

--- a/apps/api/src/scripts/backfill-corpus-storage.ts
+++ b/apps/api/src/scripts/backfill-corpus-storage.ts
@@ -51,6 +51,7 @@ import {
   reserveCaseLawCorpusUploadIntent,
   writeReservedCaseLawCorpusUpload,
 } from "@/api/lib/legal-search/case-law-corpus-upload-intents";
+import { synchronizeLockedCorpusProjectionDesiredStateTx } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import {
   corpusContentHash,
   corpusMirrorColumns,
@@ -148,7 +149,7 @@ const backfillRow = async (row: BackfillRow): Promise<void> => {
       timestampMatchesCasToken(caseLawDecisions.updatedAt, row.updatedAtToken),
     );
     const outcome = await writeReservedCaseLawCorpusUpload({
-      apply: async ({ tx, written: uploaded }) => {
+      apply: async ({ projectionLock, tx, written: uploaded }) => {
         // audit: skip — one-time corpus storage repair; derived state
         const recorded = await tx
           .update(caseLawDecisions)
@@ -160,6 +161,12 @@ const backfillRow = async (row: BackfillRow): Promise<void> => {
           )
           .where(ownerPredicate)
           .returning({ id: caseLawDecisions.id });
+        if (recorded.length > 0 && projectionLock !== null) {
+          await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+            lock: projectionLock,
+            subject: { family: "case_law", entityId: row.id },
+          });
+        }
         return { type: recorded.length > 0 ? "applied" : "superseded" };
       },
       decisionId: row.id,

--- a/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
@@ -18,10 +18,6 @@ import {
 } from "@/api/lib/db/timestamp-cas";
 import { ConcurrentModificationError } from "@/api/lib/errors/tagged-errors";
 import { legacyOperationalCorpusGeneration } from "@/api/lib/legal-search/corpus-family";
-import {
-  lockActiveCorpusProjectionSourceTx,
-  synchronizeLockedCorpusProjectionDesiredStateTx,
-} from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import { writeCorpusDocument } from "@/api/lib/legal-search/corpus-storage";
 import type {
   DecisionSection,
@@ -220,12 +216,8 @@ const backfillRow = async (
     }
     const result = outcome.written;
 
-    const recorded = await ingestionDb(async (tx) => {
-      const projectionLock = await lockActiveCorpusProjectionSourceTx(tx, {
-        family: "case_law",
-        entityId: row.id,
-      });
-      const rows = await tx
+    const recorded = await ingestionDb((tx) =>
+      tx
         .update(caseLawDecisions)
         .set({
           textS3Key: result.textKey,
@@ -247,15 +239,8 @@ const backfillRow = async (
             ),
           ),
         )
-        .returning({ id: caseLawDecisions.id });
-      if (rows.length > 0 && projectionLock !== null) {
-        await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
-          lock: projectionLock,
-          subject: { family: "case_law", entityId: row.id },
-        });
-      }
-      return rows;
-    });
+        .returning({ id: caseLawDecisions.id }),
+    );
 
     // A refused CAS is not success: the objects exist but the row still
     // points nowhere, and only the recording makes the work durable.
@@ -310,12 +295,8 @@ const backfillLegislationRow = async (
     }
     const result = outcome.written;
 
-    const recorded = await ingestionDb(async (tx) => {
-      const projectionLock = await lockActiveCorpusProjectionSourceTx(tx, {
-        family: "legislation",
-        entityId: row.id,
-      });
-      const rows = await tx
+    const recorded = await ingestionDb((tx) =>
+      tx
         .update(legislationDocuments)
         .set({
           textS3Key: result.textKey,
@@ -337,15 +318,8 @@ const backfillLegislationRow = async (
             ),
           ),
         )
-        .returning({ id: legislationDocuments.id });
-      if (rows.length > 0 && projectionLock !== null) {
-        await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
-          lock: projectionLock,
-          subject: { family: "legislation", entityId: row.id },
-        });
-      }
-      return rows;
-    });
+        .returning({ id: legislationDocuments.id }),
+    );
 
     return recorded.length > 0 ? "written" : "skipped";
   } catch (error) {

--- a/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
+++ b/apps/legal-atlas-runner/src/runners/case-law-corpus-storage-backfill.ts
@@ -18,6 +18,10 @@ import {
 } from "@/api/lib/db/timestamp-cas";
 import { ConcurrentModificationError } from "@/api/lib/errors/tagged-errors";
 import { legacyOperationalCorpusGeneration } from "@/api/lib/legal-search/corpus-family";
+import {
+  lockActiveCorpusProjectionSourceTx,
+  synchronizeLockedCorpusProjectionDesiredStateTx,
+} from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 import { writeCorpusDocument } from "@/api/lib/legal-search/corpus-storage";
 import type {
   DecisionSection,
@@ -216,8 +220,12 @@ const backfillRow = async (
     }
     const result = outcome.written;
 
-    const recorded = await ingestionDb((tx) =>
-      tx
+    const recorded = await ingestionDb(async (tx) => {
+      const projectionLock = await lockActiveCorpusProjectionSourceTx(tx, {
+        family: "case_law",
+        entityId: row.id,
+      });
+      const rows = await tx
         .update(caseLawDecisions)
         .set({
           textS3Key: result.textKey,
@@ -239,8 +247,15 @@ const backfillRow = async (
             ),
           ),
         )
-        .returning({ id: caseLawDecisions.id }),
-    );
+        .returning({ id: caseLawDecisions.id });
+      if (rows.length > 0 && projectionLock !== null) {
+        await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+          lock: projectionLock,
+          subject: { family: "case_law", entityId: row.id },
+        });
+      }
+      return rows;
+    });
 
     // A refused CAS is not success: the objects exist but the row still
     // points nowhere, and only the recording makes the work durable.
@@ -295,8 +310,12 @@ const backfillLegislationRow = async (
     }
     const result = outcome.written;
 
-    const recorded = await ingestionDb((tx) =>
-      tx
+    const recorded = await ingestionDb(async (tx) => {
+      const projectionLock = await lockActiveCorpusProjectionSourceTx(tx, {
+        family: "legislation",
+        entityId: row.id,
+      });
+      const rows = await tx
         .update(legislationDocuments)
         .set({
           textS3Key: result.textKey,
@@ -318,8 +337,15 @@ const backfillLegislationRow = async (
             ),
           ),
         )
-        .returning({ id: legislationDocuments.id }),
-    );
+        .returning({ id: legislationDocuments.id });
+      if (rows.length > 0 && projectionLock !== null) {
+        await synchronizeLockedCorpusProjectionDesiredStateTx(tx, {
+          lock: projectionLock,
+          subject: { family: "legislation", entityId: row.id },
+        });
+      }
+      return rows;
+    });
 
     return recorded.length > 0 ? "written" : "skipped";
   } catch (error) {


### PR DESCRIPTION
## Summary

- advance case-law and legislation desired projection state in the same transaction that settles canonical writes
- preserve crash-replay behavior for legislation object-storage writes and repair unchanged replays to a fixed point
- carry an opaque source-lock token through write callbacks so projection reconciliation cannot invert the source/canonical lock order
- classify empty canonical payload hashes as erase projections
- cover settled, metadata-only, failed-write, retry, and replay transitions with database tests

## Validation

- focused Bun 1.4 API tests for projection descriptors, desired state, case-law canonical ingestion, legislation ingestion, erasure, and upload intents
- staged format, lint, and secret checks

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved synchronisation between case-law and legislation updates and their searchable corpus indexes.
  * Added safer handling for redacted, unavailable, empty, or missing content.
  * Improved retry and recovery behaviour for corpus updates.

* **Bug Fixes**
  * Prevented index generation changes from overtaking in-progress source updates.
  * Ensured repeated ingestion produces stable, idempotent results.
  * Corrected projection updates when documents are refreshed, erased, or restored.

* **Tests**
  * Added coverage for ingestion refreshes, retries, replayed documents, locking, and projection consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->