### PR TITLE
feat(ui): configure Kanban mouse drag activation

### DIFF
--- a/.changeset/bright-boards-drag.md
+++ b/.changeset/bright-boards-drag.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": minor
+---
+
+Allow sortable Kanban boards to configure mouse drag activation distance while preserving the default touch and keyboard behavior.

--- a/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
+++ b/packages/ui/src/kanban/fixtures/sortable-interactions.fixture.tsx
@@ -109,8 +109,15 @@ const SortableVirtualCell = ({
   />
 );
 
+const mouseActivationDistance =
+  new URLSearchParams(window.location.search).get("mouseActivationDistance") ===
+  "1"
+    ? 1
+    : undefined;
+
 const SortableFixture = () => (
   <KanbanSortableBoard
+    mouseActivationDistance={mouseActivationDistance}
     onDragStart={() => {
       document.documentElement.dataset["dragStartedAt"] = String(
         performance.now(),

--- a/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
+++ b/packages/ui/src/kanban/sortable-interactions.playwright.spec.ts
@@ -3,8 +3,8 @@ import type { CDPSession, Locator, Page } from "@playwright/test";
 
 const fixturePath = "/src/kanban/fixtures/sortable-interactions.fixture.html";
 
-const openFixture = async (page: Page) => {
-  await page.goto(fixturePath);
+const openFixture = async (page: Page, path = fixturePath) => {
+  await page.goto(path);
   await expect
     .poll(
       async () =>
@@ -191,6 +191,23 @@ test("activates a mouse drag only after its distance threshold", async ({
   await page.mouse.move(box.x + 19, box.y + 12);
   await expect(page.locator("[data-overlay]")).toHaveCount(0);
   await page.mouse.move(box.x + 21, box.y + 12);
+  await expect(page.locator("[data-overlay]")).toHaveText("first");
+  await page.mouse.up();
+});
+
+test("honors a shorter mouse activation distance", async ({ page }) => {
+  const handle = await openFixture(
+    page,
+    `${fixturePath}?mouseActivationDistance=1`,
+  );
+  const box = await handle.boundingBox();
+  if (!box) {
+    throw new Error("Missing drag handle bounds");
+  }
+
+  await page.mouse.move(box.x + 12, box.y + 12);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 14, box.y + 12);
   await expect(page.locator("[data-overlay]")).toHaveText("first");
   await page.mouse.up();
 });

--- a/packages/ui/src/kanban/sortable-interactions.test.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.test.tsx
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { describe, expect, test } from "bun:test";
@@ -32,20 +31,6 @@ describe("sortable board interactions", () => {
       delay: 150,
       tolerance: 8,
     });
-  });
-
-  test("exposes a typed mouse activation override without changing touch behavior", () => {
-    const source = readFileSync(
-      new URL("./sortable-interactions.tsx", import.meta.url),
-      "utf8",
-    );
-
-    expect(source).toContain("mouseActivationDistance?: number | undefined");
-    expect(source).toContain("mouseActivationDistance,");
-    expect(source).toContain(
-      "mouseActivationDistance: number = KANBAN_MOUSE_ACTIVATION_DISTANCE",
-    );
-    expect(source).toContain("delay: 150");
   });
 
   test("uses the current mouse or touch coordinate to resolve the insertion edge", () => {

--- a/packages/ui/src/kanban/sortable-interactions.test.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { describe, expect, test } from "bun:test";
@@ -31,6 +32,20 @@ describe("sortable board interactions", () => {
       delay: 150,
       tolerance: 8,
     });
+  });
+
+  test("exposes a typed mouse activation override without changing touch behavior", () => {
+    const source = readFileSync(
+      new URL("./sortable-interactions.tsx", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain("mouseActivationDistance?: number | undefined");
+    expect(source).toContain("mouseActivationDistance,");
+    expect(source).toContain(
+      "mouseActivationDistance: number = KANBAN_MOUSE_ACTIVATION_DISTANCE",
+    );
+    expect(source).toContain("delay: 150");
   });
 
   test("uses the current mouse or touch coordinate to resolve the insertion edge", () => {

--- a/packages/ui/src/kanban/sortable-interactions.tsx
+++ b/packages/ui/src/kanban/sortable-interactions.tsx
@@ -448,6 +448,8 @@ const getTouchDocument = (event: Event): Document => {
 export type KanbanSortableBoardProps = {
   children: React.ReactNode;
   onDragEnd: (event: KanbanDragEndEvent) => void;
+  /** Minimum pointer movement before a mouse drag activates. */
+  mouseActivationDistance?: number | undefined;
   collisionDetection?: CollisionDetection | undefined;
   keyboardCoordinates?: KeyboardCoordinateGetter | undefined;
   autoScroll?: boolean | AutoScrollOptions | undefined;
@@ -522,6 +524,7 @@ export const useKanbanDropTarget = ({
 export const KanbanSortableBoard = ({
   children,
   onDragEnd,
+  mouseActivationDistance,
   collisionDetection,
   keyboardCoordinates,
   autoScroll,
@@ -537,7 +540,10 @@ export const KanbanSortableBoard = ({
   const [activeId, setActiveId] = React.useState<UniqueIdentifier | null>(null);
   const [interactionReady, setInteractionReady] = React.useState(false);
   const interactionReadyNotified = React.useRef(false);
-  const defaultSensors = useKanbanSortableSensors(keyboardCoordinates);
+  const defaultSensors = useKanbanSortableSensors(
+    keyboardCoordinates,
+    mouseActivationDistance,
+  );
 
   // dnd-kit registers child droppables after commit. Keep the sensor list
   // stable, but hold sortable sources and virtual cells disabled until that
@@ -607,10 +613,11 @@ export const KanbanSortableBoard = ({
 
 export const useKanbanSortableSensors = (
   keyboardCoordinates: KeyboardCoordinateGetter = kanbanKeyboardCoordinates,
+  mouseActivationDistance: number = KANBAN_MOUSE_ACTIVATION_DISTANCE,
 ) =>
   useSensors(
     useSensor(KanbanMouseSensor, {
-      activationConstraint: { distance: KANBAN_MOUSE_ACTIVATION_DISTANCE },
+      activationConstraint: { distance: mouseActivationDistance },
     }),
     useSensor(KanbanTouchSensor, {
       activationConstraint: KANBAN_TOUCH_ACTIVATION_CONSTRAINT,


### PR DESCRIPTION
Allow sortable Kanban boards to override the mouse movement threshold while preserving existing mouse defaults and touch/keyboard behavior.

Adds browser coverage for both the default threshold and a shorter configured threshold; mutation verification confirmed the new browser test fails when the override is not wired.

Scoped UI lint, typecheck, unit tests, browser test, formatting, and security review pass. Full `bun run verify` reached the repository test suite; an unrelated Open Graph rendering test timed out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Kanban boards can now configure how far the mouse must move before dragging begins.
  - Touch and keyboard interactions retain their existing behaviour.
  - The default mouse activation distance remains unchanged.

- **Bug Fixes**
  - Improved support for initiating mouse drag interactions at shorter distances when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->