### PR TITLE
fix(desktop): fast, diacritic-insensitive clipboard search

### DIFF
--- a/apps/api/src/handlers/contacts/search.ts
+++ b/apps/api/src/handlers/contacts/search.ts
@@ -2,7 +2,7 @@ import { Result } from "better-result";
 import { and, eq, ilike, or, sql } from "drizzle-orm";
 import { t } from "elysia";
 
-import { normalizeSearchText } from "@stll/text-normalize";
+import { arabicNormalize } from "@stll/text-normalize";
 
 import { contacts } from "@/api/db/schema";
 import { contactTypeSchema } from "@/api/handlers/contacts/schema";
@@ -30,7 +30,7 @@ const searchContacts = createSafeRootHandler(
     query: searchContactsQuerySchema,
   },
   async function* ({ safeDb, session, query }) {
-    const normalized = normalizeSearchText(query.q);
+    const normalized = arabicNormalize(query.q);
     if (normalized.length === 0) {
       return Result.ok({ items: [] });
     }

--- a/apps/api/src/lib/db/arabic-normalize.test.ts
+++ b/apps/api/src/lib/db/arabic-normalize.test.ts
@@ -3,7 +3,7 @@ import { sql } from "drizzle-orm";
 import { readFileSync } from "node:fs";
 import nodePath from "node:path";
 
-import { normalizeSearchText } from "@stll/text-normalize";
+import { arabicNormalize } from "@stll/text-normalize";
 
 import { getTestDb, releaseTestDb } from "@/api/tests/security/test-utils";
 import type { TestDatabase } from "@/api/tests/security/test-utils";
@@ -21,7 +21,7 @@ const ARABIC_NORMALIZE_MIGRATION_PATHS = [
 ];
 
 // The shared search-key contract: the SQL arabic_normalize() must produce
-// the same match key as the TS normalizeSearchText for every input. The
+// the same match key as the TS arabicNormalize for every input. The
 // presentation-form inputs also empirically confirm that Postgres
 // normalize(NFKC) folds them the same way String.normalize("NFKC") does.
 const VECTORS: readonly string[] = [
@@ -73,13 +73,13 @@ afterAll(async () => {
 });
 
 describe("arabic_normalize SQL function", () => {
-  test("matches normalizeSearchText for every vector", async () => {
+  test("matches arabicNormalize for every vector", async () => {
     for (const input of VECTORS) {
       // oxlint-disable-next-line no-await-in-loop -- sequential queries on one PGlite connection
       const result = await testDb.execute<{ out: string | null }>(
         sql`SELECT arabic_normalize(${input}) AS out`,
       );
-      expect(result.rows.at(0)?.out).toBe(normalizeSearchText(input));
+      expect(result.rows.at(0)?.out).toBe(arabicNormalize(input));
     }
   });
 });

--- a/apps/api/src/lib/search/highlight.ts
+++ b/apps/api/src/lib/search/highlight.ts
@@ -2,7 +2,7 @@ import {
   applyArabicFolds,
   applyArabicFoldsWithOffsets,
   foldToAscii,
-  normalizeSearchText,
+  arabicNormalize,
 } from "@stll/text-normalize";
 
 // Non-HTML delimiters injected by ts_headline / pdb.snippet(). Keep these
@@ -68,7 +68,7 @@ type NormalizedSource = {
 // so the local scaffold has to fold the same way; a plain mark strip leaves
 // `ł` standing where the stored text holds `l`.
 const normalizePreviewUnit = (text: string, useUnaccent: boolean): string => {
-  const normalized = normalizeSearchText(text);
+  const normalized = arabicNormalize(text);
   return useUnaccent ? foldToAscii(normalized) : normalized;
 };
 

--- a/apps/api/src/lib/search/query.ts
+++ b/apps/api/src/lib/search/query.ts
@@ -4,7 +4,7 @@ import type { SQL } from "drizzle-orm";
 import {
   applyArabicFolds,
   foldToAscii,
-  normalizeSearchText,
+  arabicNormalize,
 } from "@stll/text-normalize";
 
 const PREFIX_QUERY_TOKEN_LIMIT = 8;
@@ -659,7 +659,7 @@ const buildPlainSearchTsQueryParts = (
   }: PlainSearchTsQueryOptions,
 ) => {
   const legacyVariants = expandArabicFoldTargetVariants(query);
-  const normalized = normalizeSearchText(query);
+  const normalized = arabicNormalize(query);
   const plainQueries = legacyVariants.map(
     (variant) =>
       sql`plainto_tsquery(${regconfig}, ${plainSearchText(variant, useUnaccent)})`,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "catalog:",
     "@stll/api-contract": "workspace:*",
+    "@stll/text-normalize": "workspace:*",
     "@stll/ui": "workspace:*",
     "@tauri-apps/api": "^2.11.1",
     "better-result": "catalog:",

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import type {
   CSSProperties,
   MouseEvent as ReactMouseEvent,
@@ -80,6 +86,7 @@ import {
 } from "../telemetry/desktop-telemetry";
 import {
   adjacentClipboardIndex,
+  CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS,
   CLIPBOARD_ITEM_DRAG_TYPE,
   clipboardDraggedItemId,
   clipboardPointerMoved,
@@ -287,7 +294,7 @@ const ClipboardCard = ({
   );
   let previewContent: ReactNode = (
     <div className={previewClassName} dir="auto">
-      {item.plainText}
+      {item.plainText.slice(0, CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS)}
     </div>
   );
   if (rendersHtml) {
@@ -1174,9 +1181,15 @@ const ClipboardApp = () => {
   )
     ? selectedGroupId
     : null;
+  // Typing must never wait on filtering and card re-render: the rail catches
+  // up in a deferred render that further keystrokes interrupt. Clearing stays
+  // synchronous (the empty filter is free) so the reopen reset can focus the
+  // newest card in the same flushSync commit.
+  const deferredQuery = useDeferredValue(query);
+  const filterQuery = query === "" ? query : deferredQuery;
   const filteredItems = filterClipboardItems(
     snapshot.items,
-    query,
+    filterQuery,
     activeGroupId,
   );
   const groupsById = new Map(snapshot.groups.map((group) => [group.id, group]));
@@ -1271,7 +1284,7 @@ const ClipboardApp = () => {
       snapshot.groups.length % CLIPBOARD_GROUP_COLORS.length,
     ) ?? "gray";
   let emptyStateTitle = t("emptyTitle");
-  if (query) {
+  if (filterQuery) {
     emptyStateTitle = t("noResults");
   } else if (activeGroupId) {
     emptyStateTitle = t("groupEmpty");
@@ -1477,7 +1490,7 @@ const ClipboardApp = () => {
   }, [
     activeGroupId,
     applySnapshotCommand,
-    query,
+    filterQuery,
     railWindow.end,
     railWindow.start,
     snapshot.groups,
@@ -1725,14 +1738,16 @@ const ClipboardApp = () => {
         {filteredItems.length === 0 ? (
           <div className="text-foreground absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center">
             <span className="bg-foreground/6 text-foreground/70 grid size-11 place-items-center rounded-2xl shadow-sm/5">
-              {query ? (
+              {filterQuery ? (
                 <SearchIcon aria-hidden="true" className="size-5" />
               ) : (
                 <ClipboardIcon aria-hidden="true" className="size-5" />
               )}
             </span>
             <p className="text-foreground/82 text-wrap-balance max-w-sm text-sm font-medium">
-              {query || activeGroupId ? emptyStateTitle : t("emptyDescription")}
+              {filterQuery || activeGroupId
+                ? emptyStateTitle
+                : t("emptyDescription")}
             </p>
           </div>
         ) : (
@@ -1787,7 +1802,7 @@ const ClipboardApp = () => {
                       })
                     }
                     onSelect={setSelectedIndex}
-                    query={query}
+                    query={filterQuery}
                     sourceVisual={
                       item.sourceApp
                         ? (sourceAppVisuals.get(

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -310,7 +310,7 @@ const ClipboardCard = ({
     );
   }
   if (query) {
-    const searchPreview = clipboardSearchPreviewText(item.plainText, query);
+    const searchPreview = clipboardSearchPreviewText(item, query);
     const highlightedText = highlightClipboardText(searchPreview.text, query);
     previewContent = (
       <div className={previewClassName} dir="auto">

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -1202,6 +1202,17 @@ const ClipboardApp = () => {
   );
   const activeItem = filteredItems.at(activeIndex);
   const activeItemId = activeItem?.id;
+  // Copy and delete act on the list the current query produces: while the
+  // deferred render is pending the rail still shows the previous query's
+  // list, and acting on it would hand over the wrong clip. Cheap thanks to
+  // the per-item fold cache; identical to the rendered list once settled.
+  const actionItems =
+    query === filterQuery
+      ? filteredItems
+      : filterClipboardItems(snapshot.items, query, activeGroupId);
+  const actionItem = actionItems.at(
+    Math.min(selectedIndex, Math.max(0, actionItems.length - 1)),
+  );
   const railViewport = useRailViewport(
     timelineRailRef,
     filteredItems.length > 0,
@@ -1551,10 +1562,10 @@ const ClipboardApp = () => {
       return;
     }
     if (primaryModifier) {
-      const quickIndex = quickCopyIndex(event.key, filteredItems.length);
+      const quickIndex = quickCopyIndex(event.key, actionItems.length);
       if (quickIndex !== null) {
         event.preventDefault();
-        const item = filteredItems.at(quickIndex);
+        const item = actionItems.at(quickIndex);
         if (item) {
           copyItem(item);
         }
@@ -1567,18 +1578,18 @@ const ClipboardApp = () => {
         isComposing: event.isComposing,
         key: event.key,
       };
-      if (activeItem && shouldCopyFromClipboardInput(inputKey)) {
+      if (actionItem && shouldCopyFromClipboardInput(inputKey)) {
         event.preventDefault();
-        copyItem(activeItem);
+        copyItem(actionItem);
       } else if (activeItem && shouldReturnToTimelineFromInput(inputKey)) {
         event.preventDefault();
         selectIndex(activeIndex);
       }
       return;
     }
-    if (isClipboardCopyShortcut(event) && activeItem) {
+    if (isClipboardCopyShortcut(event) && actionItem) {
       event.preventDefault();
-      copyItem(activeItem);
+      copyItem(actionItem);
       return;
     }
     if (
@@ -1622,14 +1633,14 @@ const ClipboardApp = () => {
       navigate(keyAction);
       return;
     }
-    if (event.key === "Enter" && activeItem) {
+    if (event.key === "Enter" && actionItem) {
       event.preventDefault();
-      copyItem(activeItem);
+      copyItem(actionItem);
       return;
     }
-    if ((event.key === "Backspace" || event.key === "Delete") && activeItem) {
+    if ((event.key === "Backspace" || event.key === "Delete") && actionItem) {
       event.preventDefault();
-      applySnapshotCommand("clipboard_delete_item", { id: activeItem.id });
+      applySnapshotCommand("clipboard_delete_item", { id: actionItem.id });
     }
   };
 

--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -1204,15 +1204,17 @@ const ClipboardApp = () => {
   const activeItemId = activeItem?.id;
   // Copy and delete act on the list the current query produces: while the
   // deferred render is pending the rail still shows the previous query's
-  // list, and acting on it would hand over the wrong clip. Cheap thanks to
-  // the per-item fold cache; identical to the rendered list once settled.
-  const actionItems =
+  // list, and acting on it would hand over the wrong clip. Resolved on
+  // demand inside the key handlers so the keystroke render itself never
+  // pays for a filter; identical to the rendered list once settled.
+  const resolveActionItems = () =>
     query === filterQuery
       ? filteredItems
       : filterClipboardItems(snapshot.items, query, activeGroupId);
-  const actionItem = actionItems.at(
-    Math.min(selectedIndex, Math.max(0, actionItems.length - 1)),
-  );
+  const resolveActionItem = () => {
+    const items = resolveActionItems();
+    return items.at(Math.min(selectedIndex, Math.max(0, items.length - 1)));
+  };
   const railViewport = useRailViewport(
     timelineRailRef,
     filteredItems.length > 0,
@@ -1562,6 +1564,7 @@ const ClipboardApp = () => {
       return;
     }
     if (primaryModifier) {
+      const actionItems = resolveActionItems();
       const quickIndex = quickCopyIndex(event.key, actionItems.length);
       if (quickIndex !== null) {
         event.preventDefault();
@@ -1578,19 +1581,25 @@ const ClipboardApp = () => {
         isComposing: event.isComposing,
         key: event.key,
       };
-      if (actionItem && shouldCopyFromClipboardInput(inputKey)) {
-        event.preventDefault();
-        copyItem(actionItem);
+      if (shouldCopyFromClipboardInput(inputKey)) {
+        const item = resolveActionItem();
+        if (item) {
+          event.preventDefault();
+          copyItem(item);
+        }
       } else if (activeItem && shouldReturnToTimelineFromInput(inputKey)) {
         event.preventDefault();
         selectIndex(activeIndex);
       }
       return;
     }
-    if (isClipboardCopyShortcut(event) && actionItem) {
-      event.preventDefault();
-      copyItem(actionItem);
-      return;
+    if (isClipboardCopyShortcut(event)) {
+      const item = resolveActionItem();
+      if (item) {
+        event.preventDefault();
+        copyItem(item);
+        return;
+      }
     }
     if (
       event.target instanceof HTMLTextAreaElement ||
@@ -1633,14 +1642,20 @@ const ClipboardApp = () => {
       navigate(keyAction);
       return;
     }
-    if (event.key === "Enter" && actionItem) {
-      event.preventDefault();
-      copyItem(actionItem);
+    if (event.key === "Enter") {
+      const item = resolveActionItem();
+      if (item) {
+        event.preventDefault();
+        copyItem(item);
+      }
       return;
     }
-    if ((event.key === "Backspace" || event.key === "Delete") && actionItem) {
-      event.preventDefault();
-      applySnapshotCommand("clipboard_delete_item", { id: actionItem.id });
+    if (event.key === "Backspace" || event.key === "Delete") {
+      const item = resolveActionItem();
+      if (item) {
+        event.preventDefault();
+        applySnapshotCommand("clipboard_delete_item", { id: item.id });
+      }
     }
   };
 

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -1,3 +1,10 @@
+import {
+  findSearchMatchRanges,
+  foldSearchMatchText,
+  foldSearchMatchTextWithOffsets,
+} from "@stll/text-normalize";
+import type { FoldedSearchText, SearchMatchRange } from "@stll/text-normalize";
+
 import type { ClipboardItem } from "./clipboard-types";
 
 const CLIPBOARD_SOURCE_TINT_COUNT = 6;
@@ -79,15 +86,14 @@ export const clipboardDraggedItemId = (
   return typeof itemId === "string" && itemIds.has(itemId) ? itemId : null;
 };
 
-const escapeRegExp = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-
-/** Deduplicated query terms, longest first so overlapping terms match whole. */
+/**
+ * Deduplicated diacritic-folded query terms, longest first so overlapping
+ * terms match whole. The whole query is folded before splitting because
+ * compatibility decomposition can itself produce whitespace (NBSP).
+ */
 const clipboardQueryTerms = (query: string) => {
-  const normalizedTerms = query
-    .trim()
+  const normalizedTerms = foldSearchMatchText(query)
     .split(/\s+/u)
-    .map((term) => term.toLocaleLowerCase())
     .filter(Boolean);
   return Array.from(new Set(normalizedTerms)).sort(
     (left, right) => right.length - left.length,
@@ -100,19 +106,27 @@ export const highlightClipboardText = (text: string, query: string) => {
     return [{ match: false, text }] satisfies ClipboardTextSegment[];
   }
 
-  const matcher = new RegExp(terms.map(escapeRegExp).join("|"), "giu");
+  const foldedText = foldSearchMatchTextWithOffsets(text);
+  const ranges: SearchMatchRange[] = [];
+  for (const term of terms) {
+    ranges.push(...findSearchMatchRanges(foldedText, term));
+  }
+  // Same start prefers the longer term; a range starting inside an already
+  // highlighted one is dropped.
+  ranges.sort(
+    (left, right) => left.start - right.start || right.end - left.end,
+  );
   const segments: ClipboardTextSegment[] = [];
   let cursor = 0;
-  for (const match of text.matchAll(matcher)) {
-    const matchedText = match.at(0);
-    if (!matchedText) {
+  for (const range of ranges) {
+    if (range.start < cursor) {
       continue;
     }
-    if (match.index > cursor) {
-      segments.push({ match: false, text: text.slice(cursor, match.index) });
+    if (range.start > cursor) {
+      segments.push({ match: false, text: text.slice(cursor, range.start) });
     }
-    segments.push({ match: true, text: matchedText });
-    cursor = match.index + matchedText.length;
+    segments.push({ match: true, text: text.slice(range.start, range.end) });
+    cursor = range.end;
   }
   if (cursor < text.length) {
     segments.push({ match: false, text: text.slice(cursor) });
@@ -136,23 +150,55 @@ export const CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS = 1000;
 
 export type ClipboardSearchPreview = { text: string; truncated: boolean };
 
+type ClipboardSearchPreviewSource = Pick<ClipboardItem, "plainText">;
+
+/**
+ * Folding a 64 KiB clip character by character is the expensive step of the
+ * windowed preview, and every rendered card repeats it per query change.
+ * Keyed weakly by the item object: a snapshot replaces its items wholesale,
+ * so stale entries fall away with the old snapshot.
+ */
+const foldedPlainTextCache = new WeakMap<
+  ClipboardSearchPreviewSource,
+  FoldedSearchText
+>();
+
+const foldedPlainText = (item: ClipboardSearchPreviewSource) => {
+  const cached = foldedPlainTextCache.get(item);
+  if (cached) {
+    return cached;
+  }
+  const folded = foldSearchMatchTextWithOffsets(item.plainText);
+  foldedPlainTextCache.set(item, folded);
+  return folded;
+};
+
 /**
  * Text to render for a searched clip: the full text while the first match
  * falls inside the clamped preview, otherwise a window that starts one word
  * boundary ahead of the first match so the highlighted hit is visible.
  */
 export const clipboardSearchPreviewText = (
-  text: string,
+  item: ClipboardSearchPreviewSource,
   query: string,
 ): ClipboardSearchPreview => {
+  const { plainText: text } = item;
   const cap = (value: string) =>
     value.slice(0, CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS);
   const terms = clipboardQueryTerms(query);
   if (terms.length === 0) {
     return { text: cap(text), truncated: false };
   }
-  const matcher = new RegExp(terms.map(escapeRegExp).join("|"), "iu");
-  const matchIndex = text.search(matcher);
+  const foldedText = foldedPlainText(item);
+  let matchIndex = -1;
+  for (const term of terms) {
+    const first = findSearchMatchRanges(foldedText, term, {
+      maxMatches: 1,
+    }).at(0);
+    if (first && (matchIndex === -1 || first.start < matchIndex)) {
+      matchIndex = first.start;
+    }
+  }
   if (matchIndex === -1) {
     return { text: cap(text), truncated: false };
   }
@@ -258,8 +304,8 @@ export const clipboardRailWindow = ({
 };
 
 /**
- * The filter runs on every keystroke over every clip; lowercasing megabytes
- * of history each time dominated search latency. Keyed weakly by the item
+ * The filter runs on every keystroke over every clip; folding megabytes of
+ * history each time dominated search latency. Keyed weakly by the item
  * object: a snapshot replaces its items wholesale, so stale entries fall away
  * with the old snapshot, and an item's text only changes via a new snapshot.
  */
@@ -270,8 +316,9 @@ const clipboardSearchableText = (item: ClipboardItem) => {
   if (cached !== undefined) {
     return cached;
   }
-  const searchableText =
-    `${item.name ?? ""}\n${item.plainText}`.toLocaleLowerCase();
+  const searchableText = foldSearchMatchText(
+    `${item.name ?? ""}\n${item.plainText}`,
+  );
   searchableTextCache.set(item, searchableText);
   return searchableText;
 };
@@ -284,11 +331,10 @@ export const filterClipboardItems = (
   const groupedItems = groupId
     ? items.filter((item) => item.groupId === groupId)
     : items;
-  const normalizedQuery = query.trim().toLocaleLowerCase();
-  if (!normalizedQuery) {
+  const terms = clipboardQueryTerms(query);
+  if (terms.length === 0) {
     return groupedItems;
   }
-  const terms = normalizedQuery.split(/\s+/u);
   return groupedItems.filter((item) => {
     const searchableText = clipboardSearchableText(item);
     return terms.every((term) => searchableText.includes(term));

--- a/apps/desktop/src/clipboard/clipboard-logic.ts
+++ b/apps/desktop/src/clipboard/clipboard-logic.ts
@@ -127,6 +127,13 @@ const SEARCH_PREVIEW_PREFIX_LINES = 4;
 /** Context kept ahead of a distant first match. */
 const SEARCH_PREVIEW_LEAD_CHARACTERS = 24;
 
+/**
+ * The clamped preview shows ~320 characters at most; text past this budget can
+ * never become visible, while rendering a full 64 KiB clip into every card
+ * (one highlight span per match) made search repaints crawl.
+ */
+export const CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS = 1000;
+
 export type ClipboardSearchPreview = { text: string; truncated: boolean };
 
 /**
@@ -138,21 +145,23 @@ export const clipboardSearchPreviewText = (
   text: string,
   query: string,
 ): ClipboardSearchPreview => {
+  const cap = (value: string) =>
+    value.slice(0, CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS);
   const terms = clipboardQueryTerms(query);
   if (terms.length === 0) {
-    return { text, truncated: false };
+    return { text: cap(text), truncated: false };
   }
   const matcher = new RegExp(terms.map(escapeRegExp).join("|"), "iu");
   const matchIndex = text.search(matcher);
   if (matchIndex === -1) {
-    return { text, truncated: false };
+    return { text: cap(text), truncated: false };
   }
   const prefixLines = text.slice(0, matchIndex).split("\n").length - 1;
   if (
     matchIndex <= SEARCH_PREVIEW_PREFIX_CHARACTERS &&
     prefixLines < SEARCH_PREVIEW_PREFIX_LINES
   ) {
-    return { text, truncated: false };
+    return { text: cap(text), truncated: false };
   }
   // Start at the match's line when it is short enough, otherwise at the first
   // word boundary inside the lead window; without one the fragment of a long
@@ -164,7 +173,7 @@ export const clipboardSearchPreviewText = (
     const boundary = text.slice(windowStart, matchIndex).search(/\s\S/u);
     start = boundary === -1 ? matchIndex : windowStart + boundary + 1;
   }
-  return { text: text.slice(start).trimStart(), truncated: true };
+  return { text: cap(text.slice(start).trimStart()), truncated: true };
 };
 
 export const clipboardSourceTintIndex = (sourceIdentity: string | null) => {
@@ -248,6 +257,25 @@ export const clipboardRailWindow = ({
   };
 };
 
+/**
+ * The filter runs on every keystroke over every clip; lowercasing megabytes
+ * of history each time dominated search latency. Keyed weakly by the item
+ * object: a snapshot replaces its items wholesale, so stale entries fall away
+ * with the old snapshot, and an item's text only changes via a new snapshot.
+ */
+const searchableTextCache = new WeakMap<ClipboardItem, string>();
+
+const clipboardSearchableText = (item: ClipboardItem) => {
+  const cached = searchableTextCache.get(item);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const searchableText =
+    `${item.name ?? ""}\n${item.plainText}`.toLocaleLowerCase();
+  searchableTextCache.set(item, searchableText);
+  return searchableText;
+};
+
 export const filterClipboardItems = (
   items: readonly ClipboardItem[],
   query: string,
@@ -262,8 +290,7 @@ export const filterClipboardItems = (
   }
   const terms = normalizedQuery.split(/\s+/u);
   return groupedItems.filter((item) => {
-    const searchableText =
-      `${item.name ?? ""}\n${item.plainText}`.toLocaleLowerCase();
+    const searchableText = clipboardSearchableText(item);
     return terms.every((term) => searchableText.includes(term));
   });
 };

--- a/apps/desktop/src/mainview/index.css
+++ b/apps/desktop/src/mainview/index.css
@@ -144,25 +144,28 @@ body:has(.clipboard-editor-window) .font-sans {
   transition: opacity 120ms ease-out;
 }
 
-.clipboard-card[aria-current="true"] {
+/* While the search field holds focus the selected card stays the Enter
+ * target but renders exactly like its siblings: the highlight would read as
+ * a competing focus. It returns when ArrowUp hands focus back to the rail. */
+.clipboard-window:not(:has(.clipboard-search-input:focus))
+  .clipboard-card[aria-current="true"] {
   box-shadow:
     inset 0 0 0 1.5px color-mix(in srgb, var(--foreground) 30%, transparent),
     0 12px 30px rgb(23 28 38 / 0.16);
 }
 
-.clipboard-card[aria-current="true"]::after {
+.clipboard-window:not(:has(.clipboard-search-input:focus))
+  .clipboard-card[aria-current="true"]::after {
   border-color: var(--option-blue);
   box-shadow: inset 0 0 0 1px
     color-mix(in srgb, var(--color-white) 34%, transparent);
   opacity: 1;
 }
 
-/* macOS-convention inactive selection: while the search field holds focus,
- * the selected card stays the Enter target but drops the active accent. */
+/* Match the resting opacity of unselected cards (opacity-86, full on hover). */
 .clipboard-window:has(.clipboard-search-input:focus)
-  .clipboard-card[aria-current="true"]::after {
-  border-color: color-mix(in srgb, var(--foreground) 26%, transparent);
-  box-shadow: none;
+  .clipboard-card[aria-current="true"]:not(:hover) {
+  opacity: 0.86;
 }
 
 .dark .clipboard-card {
@@ -192,7 +195,9 @@ body:has(.clipboard-editor-window) .font-sans {
     color-mix(in srgb, var(--color-white) 8%, transparent);
 }
 
-.dark .clipboard-card[aria-current="true"] {
+.dark
+  .clipboard-window:not(:has(.clipboard-search-input:focus))
+  .clipboard-card[aria-current="true"] {
   box-shadow:
     inset 0 0 0 1.5px color-mix(in srgb, var(--color-white) 32%, transparent),
     0 14px 32px rgb(0 0 0 / 0.3);

--- a/apps/desktop/src/mainview/index.css
+++ b/apps/desktop/src/mainview/index.css
@@ -262,6 +262,13 @@ body:has(.clipboard-editor-window) .font-sans {
     inset 0 1px 0 color-mix(in srgb, var(--color-white) 8%, transparent);
 }
 
+/* The input group paints an unfocused hairline through a ::before overlay
+ * whose radius stays at the group's lg default; inside this pill the smaller
+ * corners show as stray shading, and the pill draws its own inset highlight. */
+.clipboard-search::before {
+  content: none;
+}
+
 .clipboard-search-input::placeholder {
   color: var(--clipboard-search-placeholder) !important;
   opacity: 1;

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -109,7 +109,7 @@ describe("clipboard search highlighting", () => {
 describe("clipboardSearchPreviewText", () => {
   test("keeps the full text when the first match is near the start", () => {
     const text = "Purchase price is payable at closing.";
-    expect(clipboardSearchPreviewText(text, "closing")).toEqual({
+    expect(clipboardSearchPreviewText({ plainText: text }, "closing")).toEqual({
       text,
       truncated: false,
     });
@@ -117,7 +117,10 @@ describe("clipboardSearchPreviewText", () => {
 
   test("windows a distant match to a word boundary with leading context", () => {
     const text = `${"lorem ipsum dolor sit amet ".repeat(8)}indemnity cap applies`;
-    const preview = clipboardSearchPreviewText(text, "indemnity");
+    const preview = clipboardSearchPreviewText(
+      { plainText: text },
+      "indemnity",
+    );
 
     expect(preview.truncated).toBe(true);
     expect(preview.text.startsWith("ipsum dolor sit amet indemnity cap")).toBe(
@@ -127,7 +130,7 @@ describe("clipboardSearchPreviewText", () => {
 
   test("windows a match hidden below the clamped line count", () => {
     const text = `a\nb\nc\nd\ne\nf\ng\nh\ni\nfinal clause`;
-    const preview = clipboardSearchPreviewText(text, "clause");
+    const preview = clipboardSearchPreviewText({ plainText: text }, "clause");
 
     expect(preview.truncated).toBe(true);
     expect(preview.text.startsWith("final clause")).toBe(true);
@@ -135,7 +138,9 @@ describe("clipboardSearchPreviewText", () => {
 
   test("keeps the full text when only the clip name matched", () => {
     const text = "Body without the term.";
-    expect(clipboardSearchPreviewText(text, "acquisition")).toEqual({
+    expect(
+      clipboardSearchPreviewText({ plainText: text }, "acquisition"),
+    ).toEqual({
       text,
       truncated: false,
     });
@@ -143,7 +148,10 @@ describe("clipboardSearchPreviewText", () => {
 
   test("matches case-insensitively when windowing", () => {
     const text = `${"x".repeat(200)} INDEMNITY tail`;
-    const preview = clipboardSearchPreviewText(text, "indemnity");
+    const preview = clipboardSearchPreviewText(
+      { plainText: text },
+      "indemnity",
+    );
 
     expect(preview.truncated).toBe(true);
     expect(preview.text.startsWith("INDEMNITY tail")).toBe(true);
@@ -152,21 +160,59 @@ describe("clipboardSearchPreviewText", () => {
   test("caps the preview past what the clamped card can show", () => {
     const text = `intro clause ${"filler ".repeat(20_000)}`;
 
-    expect(clipboardSearchPreviewText(text, "clause").text).toHaveLength(
-      CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS,
-    );
-    expect(clipboardSearchPreviewText(text, "").text).toHaveLength(
-      CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS,
-    );
+    expect(
+      clipboardSearchPreviewText({ plainText: text }, "clause").text,
+    ).toHaveLength(CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS);
+    expect(
+      clipboardSearchPreviewText({ plainText: text }, "").text,
+    ).toHaveLength(CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS);
   });
 
   test("caps a windowed distant match", () => {
     const text = `${"filler ".repeat(100)}indemnity ${"tail ".repeat(20_000)}`;
-    const preview = clipboardSearchPreviewText(text, "indemnity");
+    const preview = clipboardSearchPreviewText(
+      { plainText: text },
+      "indemnity",
+    );
 
     expect(preview.truncated).toBe(true);
     expect(preview.text).toHaveLength(CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS);
     expect(preview.text).toContain("indemnity");
+  });
+
+  test("windows to a match found across diacritics", () => {
+    const text = `${"x".repeat(200)} rozsudek Čapek v. Novák`;
+    const preview = clipboardSearchPreviewText({ plainText: text }, "capek");
+
+    expect(preview.truncated).toBe(true);
+    expect(preview.text).toContain("Čapek");
+  });
+});
+
+describe("diacritic-insensitive search", () => {
+  const ACCENTED_ITEM = {
+    copiedAt: "2026-08-23T10:02:00Z",
+    groupId: null,
+    id: "three",
+    name: null,
+    plainText: "Karel Čapek, Uherské Hradiště",
+    sourceApp: null,
+    type: "text",
+  } satisfies ClipboardItem;
+
+  test("a plain query matches accented text and vice versa", () => {
+    expect(filterClipboardItems([ACCENTED_ITEM], "capek hradiste")).toEqual([
+      ACCENTED_ITEM,
+    ]);
+    expect(filterClipboardItems([TEXT_ITEM], "půrchase")).toEqual([TEXT_ITEM]);
+    expect(filterClipboardItems([TEXT_ITEM], "puerchase")).toEqual([]);
+  });
+
+  test("highlights the accented original for a plain query", () => {
+    expect(highlightClipboardText("Karel Čapek", "capek")).toEqual([
+      { match: false, text: "Karel " },
+      { match: true, text: "Čapek" },
+    ]);
   });
 });
 

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   adjacentClipboardIndex,
+  CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS,
   CLIPBOARD_ITEM_DRAG_TYPE,
   clipboardDraggedItemId,
   clipboardPointerMoved,
@@ -146,6 +147,26 @@ describe("clipboardSearchPreviewText", () => {
 
     expect(preview.truncated).toBe(true);
     expect(preview.text.startsWith("INDEMNITY tail")).toBe(true);
+  });
+
+  test("caps the preview past what the clamped card can show", () => {
+    const text = `intro clause ${"filler ".repeat(20_000)}`;
+
+    expect(clipboardSearchPreviewText(text, "clause").text).toHaveLength(
+      CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS,
+    );
+    expect(clipboardSearchPreviewText(text, "").text).toHaveLength(
+      CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS,
+    );
+  });
+
+  test("caps a windowed distant match", () => {
+    const text = `${"filler ".repeat(100)}indemnity ${"tail ".repeat(20_000)}`;
+    const preview = clipboardSearchPreviewText(text, "indemnity");
+
+    expect(preview.truncated).toBe(true);
+    expect(preview.text).toHaveLength(CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS);
+    expect(preview.text).toContain("indemnity");
   });
 });
 

--- a/apps/desktop/tests/clipboard-logic.test.ts
+++ b/apps/desktop/tests/clipboard-logic.test.ts
@@ -204,6 +204,12 @@ describe("diacritic-insensitive search", () => {
     expect(filterClipboardItems([ACCENTED_ITEM], "capek hradiste")).toEqual([
       ACCENTED_ITEM,
     ]);
+    expect(
+      filterClipboardItems(
+        [{ ...ACCENTED_ITEM, plainText: "soud ve Wrocławi" }],
+        "wroclawi",
+      ),
+    ).toHaveLength(1);
     expect(filterClipboardItems([TEXT_ITEM], "půrchase")).toEqual([TEXT_ITEM]);
     expect(filterClipboardItems([TEXT_ITEM], "puerchase")).toEqual([]);
   });

--- a/apps/web/src/components/document-language-picker.logic.ts
+++ b/apps/web/src/components/document-language-picker.logic.ts
@@ -66,7 +66,7 @@ export const defaultTargetLanguage = (
 /**
  * Match key for the picker's typeahead.
  *
- * `foldToAscii` rather than the highlighter's `normalizeSearchText`: mark
+ * `foldToAscii` rather than the highlighter's `foldSearchMatchText`: mark
  * stripping alone leaves Polish `ł` standing, so typing "lotewski" would miss
  * "Łotewski" in the pl catalog. Folding also keeps Greek, Cyrillic and Arabic
  * names matchable in their own script.

--- a/apps/web/src/components/legal-reader/reader-search.ts
+++ b/apps/web/src/components/legal-reader/reader-search.ts
@@ -28,7 +28,7 @@ type NormalizedText = {
   text: string;
 };
 
-const normalizeSearchText = (text: string): NormalizedText => {
+const normalizeReaderSearchText = (text: string): NormalizedText => {
   const normalizedChars: string[] = [];
   const startMap: number[] = [];
   const endMap: number[] = [];
@@ -154,7 +154,7 @@ const normalizeSearchText = (text: string): NormalizedText => {
 };
 
 const normalizeQuery = (query: string): string =>
-  normalizeSearchText(query).text.trim();
+  normalizeReaderSearchText(query).text.trim();
 
 export const buildSearchResults = ({
   pieces,
@@ -172,7 +172,7 @@ export const buildSearchResults = ({
   let matchCount = 0;
 
   for (const piece of pieces) {
-    const normalizedPiece = normalizeSearchText(piece.text);
+    const normalizedPiece = normalizeReaderSearchText(piece.text);
     if (normalizedPiece.text.length === 0) {
       continue;
     }

--- a/apps/web/src/lib/document-search.test.ts
+++ b/apps/web/src/lib/document-search.test.ts
@@ -1,15 +1,17 @@
 import { describe, expect, test } from "bun:test";
 
 import { createEmptyDocument } from "@stll/folio-core";
+import {
+  findSearchMatchRanges,
+  foldSearchMatchText,
+} from "@stll/text-normalize";
 
 import {
   findDocumentSearchResult,
   findDocumentSearchMatches,
-  findNormalizedSearchTextMatches,
   findSearchTextMatches,
-  getSearchTextCandidates,
-  normalizeSearchText,
 } from "@/lib/document-search";
+import { getSearchTextCandidates } from "@/lib/search-text";
 
 describe("document search highlighting", () => {
   test("uses the native document find behavior across text runs", () => {
@@ -27,9 +29,7 @@ describe("document search highlighting", () => {
     expect(findSearchTextMatches("準拠法", "法")).toEqual([
       { start: 2, end: 3 },
     ]);
-    expect(findNormalizedSearchTextMatches("Š", "s")).toEqual([
-      { start: 0, end: 1 },
-    ]);
+    expect(findSearchMatchRanges("Š", "s")).toEqual([{ start: 0, end: 1 }]);
   });
 
   test("falls back to web-search terms when an exact query is absent", () => {
@@ -82,27 +82,25 @@ describe("document search highlighting", () => {
   });
 
   test("maps a diacritic-insensitive match back to original offsets", () => {
-    expect(
-      findNormalizedSearchTextMatches("zápis odštepení", "odštěpení"),
-    ).toEqual([{ start: 6, end: 15 }]);
-    expect(normalizeSearchText("ODŠTĚPENÍ")).toBe("odstepeni");
+    expect(findSearchMatchRanges("zápis odštepení", "odštěpení")).toEqual([
+      { start: 6, end: 15 },
+    ]);
+    expect(foldSearchMatchText("ODŠTĚPENÍ")).toBe("odstepeni");
   });
 
   test("preserves contextual case folding while mapping source offsets", () => {
-    expect(normalizeSearchText("ΟΣ")).toBe("ος");
-    expect(findNormalizedSearchTextMatches("ΟΣ", "ος")).toEqual([
-      { start: 0, end: 2 },
-    ]);
+    expect(foldSearchMatchText("ΟΣ")).toBe("ος");
+    expect(findSearchMatchRanges("ΟΣ", "ος")).toEqual([{ start: 0, end: 2 }]);
   });
 
   test("uses canonical Arabic folds while preserving source offsets", () => {
-    expect(findNormalizedSearchTextMatches("مدرسة", "مدرسه")).toEqual([
+    expect(findSearchMatchRanges("مدرسة", "مدرسه")).toEqual([
       { start: 0, end: 5 },
     ]);
-    expect(findNormalizedSearchTextMatches("مـحـمـد", "محمد")).toEqual([
+    expect(findSearchMatchRanges("مـحـمـد", "محمد")).toEqual([
       { start: 0, end: 7 },
     ]);
-    expect(findNormalizedSearchTextMatches("٢٠٢٤", "2024")).toEqual([
+    expect(findSearchMatchRanges("٢٠٢٤", "2024")).toEqual([
       { start: 0, end: 4 },
     ]);
   });

--- a/apps/web/src/lib/document-search.test.ts
+++ b/apps/web/src/lib/document-search.test.ts
@@ -88,9 +88,10 @@ describe("document search highlighting", () => {
     expect(foldSearchMatchText("ODŠTĚPENÍ")).toBe("odstepeni");
   });
 
-  test("preserves contextual case folding while mapping source offsets", () => {
-    expect(foldSearchMatchText("ΟΣ")).toBe("ος");
+  test("case-folds final sigma while mapping source offsets", () => {
+    expect(foldSearchMatchText("ΟΣ")).toBe("οσ");
     expect(findSearchMatchRanges("ΟΣ", "ος")).toEqual([{ start: 0, end: 2 }]);
+    expect(findSearchMatchRanges("ΟΣ", "σ")).toEqual([{ start: 1, end: 2 }]);
   });
 
   test("uses canonical Arabic folds while preserving source offsets", () => {

--- a/apps/web/src/lib/document-search.ts
+++ b/apps/web/src/lib/document-search.ts
@@ -6,19 +6,13 @@ import {
   findInParagraph,
 } from "@stll/folio-core/utils/findReplace";
 import type { FindMatch } from "@stll/folio-core/utils/findReplace";
+import { findSearchMatchRanges } from "@stll/text-normalize";
 
 import {
-  findNormalizedSearchTextMatches,
   getSearchTextCandidates,
   selectNonOverlappingSearchMatches,
 } from "@/lib/search-text";
 import type { SearchTextMatch, SearchTextQuery } from "@/lib/search-text";
-
-export {
-  findNormalizedSearchTextMatches,
-  getSearchTextCandidates,
-  normalizeSearchText,
-} from "@/lib/search-text";
 
 const documentSearchOptions = createDefaultFindOptions();
 
@@ -46,7 +40,7 @@ const findTextCandidateMatches = ({
   content,
   maxMatches,
 }: FindTextCandidateMatchesOptions) =>
-  findNormalizedSearchTextMatches(content, candidate, { maxMatches });
+  findSearchMatchRanges(content, candidate, { maxMatches });
 
 type FindSearchTextMatchesOptions = {
   maxMatches?: number | undefined;
@@ -162,7 +156,7 @@ const findDocumentCandidateMatches = ({
       for (const match of getNativeMatches(candidate).values()) {
         candidateMatches.set(documentMatchKey(match), match);
       }
-      const normalizedMatches = findNormalizedSearchTextMatches(
+      const normalizedMatches = findSearchMatchRanges(
         paragraphText,
         candidate,
         { maxMatches: paragraphLimit },

--- a/apps/web/src/lib/document-search.ts
+++ b/apps/web/src/lib/document-search.ts
@@ -7,20 +7,21 @@ import {
 } from "@stll/folio-core/utils/findReplace";
 import type { FindMatch } from "@stll/folio-core/utils/findReplace";
 import { findSearchMatchRanges } from "@stll/text-normalize";
+import type { SearchMatchRange } from "@stll/text-normalize";
 
 import {
   getSearchTextCandidates,
   selectNonOverlappingSearchMatches,
 } from "@/lib/search-text";
-import type { SearchTextMatch, SearchTextQuery } from "@/lib/search-text";
+import type { SearchTextQuery } from "@/lib/search-text";
 
 const documentSearchOptions = createDefaultFindOptions();
 
-const searchTextMatchKey = ({ end, start }: SearchTextMatch) =>
+const searchTextMatchKey = ({ end, start }: SearchMatchRange) =>
   `${String(start)}:${String(end)}`;
 
 const selectNonOverlappingSearchTextMatches = (
-  matches: Iterable<SearchTextMatch>,
+  matches: Iterable<SearchMatchRange>,
   maxMatches: number,
 ) =>
   selectNonOverlappingSearchMatches({
@@ -60,7 +61,7 @@ export const findSearchTextMatches = (
   }
   const candidates = getSearchTextCandidates(searchText);
   if (typeof searchText !== "string") {
-    const matches = new Map<string, SearchTextMatch>();
+    const matches = new Map<string, SearchMatchRange>();
     for (const candidate of candidates) {
       for (const match of findTextCandidateMatches({
         candidate,
@@ -84,7 +85,7 @@ export const findSearchTextMatches = (
     return phraseMatches;
   }
 
-  const matches = new Map<string, SearchTextMatch>();
+  const matches = new Map<string, SearchMatchRange>();
   for (const candidate of candidates.slice(1)) {
     for (const match of findTextCandidateMatches({
       candidate,

--- a/apps/web/src/lib/pdf/pdf-search.ts
+++ b/apps/web/src/lib/pdf/pdf-search.ts
@@ -1,9 +1,10 @@
 import type { PDF, PDFPage } from "@libpdf/core";
 
+import { findSearchMatchRanges } from "@stll/text-normalize";
+
 import type { PageViewport } from "@/lib/pdf/pdfjs-loader";
 import { MAX_SEARCH_PREVIEW_MATCHES } from "@/lib/search-match-navigation";
 import {
-  findNormalizedSearchTextMatches,
   getSearchTextCandidates,
   selectNonOverlappingSearchMatches,
 } from "@/lib/search-text";
@@ -187,7 +188,7 @@ const findNormalizedPageMatches = ({
   pageIndex,
   pageSearchText,
 }: FindNormalizedPageMatchesOptions): PDFSearchMatch[] =>
-  findNormalizedSearchTextMatches(pageSearchText.text, candidate, {
+  findSearchMatchRanges(pageSearchText.text, candidate, {
     maxMatches,
   })
     .map(({ end, start }) =>

--- a/apps/web/src/lib/search-text.ts
+++ b/apps/web/src/lib/search-text.ts
@@ -1,16 +1,11 @@
-import type { SearchMatchRange as FoldedMatchRange } from "@stll/text-normalize";
+import type { SearchMatchRange } from "@stll/text-normalize";
 
 const SINGLE_SEARCH_TERM = /^[\p{L}\p{N}]$/u;
 
-// The folding core with original-index mapping lives in @stll/text-normalize
-// (search-match.ts) so the desktop clipboard search shares one behavior with
-// the web previews.
-export type SearchTextMatch = FoldedMatchRange;
-
-type SearchMatchRange = SearchTextMatch & { group: number };
+type GroupedSearchMatchRange = SearchMatchRange & { group: number };
 
 type SelectNonOverlappingSearchMatchesOptions<T> = {
-  getRange: (match: T) => SearchMatchRange;
+  getRange: (match: T) => GroupedSearchMatchRange;
   matches: Iterable<T>;
   maxMatches: number;
 };

--- a/apps/web/src/lib/search-text.ts
+++ b/apps/web/src/lib/search-text.ts
@@ -1,15 +1,10 @@
 import type { SearchMatchRange as FoldedMatchRange } from "@stll/text-normalize";
 
-// The folding core with original-index mapping lives in @stll/text-normalize
-// (search-match.ts) so the desktop clipboard search shares one behavior with
-// the web previews; the legacy names below cover this module's consumers.
-export {
-  findSearchMatchRanges as findNormalizedSearchTextMatches,
-  foldSearchMatchText as normalizeSearchText,
-} from "@stll/text-normalize";
-
 const SINGLE_SEARCH_TERM = /^[\p{L}\p{N}]$/u;
 
+// The folding core with original-index mapping lives in @stll/text-normalize
+// (search-match.ts) so the desktop clipboard search shares one behavior with
+// the web previews.
 export type SearchTextMatch = FoldedMatchRange;
 
 type SearchMatchRange = SearchTextMatch & { group: number };

--- a/apps/web/src/lib/search-text.ts
+++ b/apps/web/src/lib/search-text.ts
@@ -1,12 +1,16 @@
-import { applyArabicFolds } from "@stll/text-normalize";
+import type { SearchMatchRange as FoldedMatchRange } from "@stll/text-normalize";
 
-const COMBINING_MARKS = /\p{M}+/gu;
+// The folding core with original-index mapping lives in @stll/text-normalize
+// (search-match.ts) so the desktop clipboard search shares one behavior with
+// the web previews; the legacy names below cover this module's consumers.
+export {
+  findSearchMatchRanges as findNormalizedSearchTextMatches,
+  foldSearchMatchText as normalizeSearchText,
+} from "@stll/text-normalize";
+
 const SINGLE_SEARCH_TERM = /^[\p{L}\p{N}]$/u;
 
-export type SearchTextMatch = {
-  start: number;
-  end: number;
-};
+export type SearchTextMatch = FoldedMatchRange;
 
 type SearchMatchRange = SearchTextMatch & { group: number };
 
@@ -56,67 +60,6 @@ export type SearchTextQuery =
   | string
   | { type: "separate-terms"; terms: readonly string[] };
 
-type FindNormalizedSearchTextMatchesOptions = {
-  maxMatches?: number;
-};
-
-type NormalizedSearchTextWithOffsets = {
-  originalRanges: SearchTextMatch[];
-  text: string;
-};
-
-const normalizeSearchTextBeforeCase = (value: string): string =>
-  applyArabicFolds(value.normalize("NFKD").replace(COMBINING_MARKS, ""));
-
-export const normalizeSearchText = (value: string): string =>
-  normalizeSearchTextBeforeCase(value).toLowerCase();
-
-const normalizeSearchTextWithOffsets = (
-  content: string,
-): NormalizedSearchTextWithOffsets => {
-  const units: { range: SearchTextMatch; text: string }[] = [];
-  let originalOffset = 0;
-
-  for (const character of content) {
-    const start = originalOffset;
-    originalOffset += character.length;
-    units.push({
-      range: { start, end: originalOffset },
-      text: normalizeSearchTextBeforeCase(character),
-    });
-  }
-
-  const beforeCase = units.map(({ text }) => text).join("");
-  const contextualLowercase = beforeCase.toLowerCase();
-  if (contextualLowercase.length === beforeCase.length) {
-    const originalRanges: SearchTextMatch[] = [];
-    for (const unit of units) {
-      let codeUnit = 0;
-      while (codeUnit < unit.text.length) {
-        originalRanges.push(unit.range);
-        codeUnit += 1;
-      }
-    }
-    return {
-      text: contextualLowercase,
-      originalRanges,
-    };
-  }
-
-  const loweredParts: string[] = [];
-  const originalRanges: SearchTextMatch[] = [];
-  for (const unit of units) {
-    const lowered = unit.text.toLowerCase();
-    loweredParts.push(lowered);
-    let codeUnit = 0;
-    while (codeUnit < lowered.length) {
-      originalRanges.push(unit.range);
-      codeUnit += 1;
-    }
-  }
-  return { text: loweredParts.join(""), originalRanges };
-};
-
 export const searchTextQueryKey = (query: SearchTextQuery): string =>
   typeof query === "string"
     ? `query:${JSON.stringify(query)}`
@@ -150,48 +93,4 @@ export const getSearchTextCandidates = (
       (candidate.length > 1 || SINGLE_SEARCH_TERM.test(candidate)) &&
       candidates.indexOf(candidate) === index,
   );
-};
-
-export const findNormalizedSearchTextMatches = (
-  content: string,
-  searchText: string,
-  options: FindNormalizedSearchTextMatchesOptions = {},
-): SearchTextMatch[] => {
-  const maxMatches = Math.max(
-    0,
-    Math.floor(options.maxMatches ?? Number.MAX_SAFE_INTEGER),
-  );
-  if (maxMatches === 0) {
-    return [];
-  }
-
-  const normalizedContent = normalizeSearchTextWithOffsets(content);
-  const normalizedQuery = normalizeSearchText(searchText.trim());
-  if (normalizedQuery.length === 0) {
-    return [];
-  }
-
-  const matches: SearchTextMatch[] = [];
-  let searchFrom = 0;
-  while (searchFrom <= normalizedContent.text.length - normalizedQuery.length) {
-    const normalizedStart = normalizedContent.text.indexOf(
-      normalizedQuery,
-      searchFrom,
-    );
-    if (normalizedStart === -1) {
-      break;
-    }
-    const normalizedEnd = normalizedStart + normalizedQuery.length;
-    const firstRange = normalizedContent.originalRanges.at(normalizedStart);
-    const lastRange = normalizedContent.originalRanges.at(normalizedEnd - 1);
-    if (firstRange && lastRange) {
-      matches.push({ start: firstRange.start, end: lastRange.end });
-      if (matches.length >= maxMatches) {
-        break;
-      }
-    }
-    searchFrom = normalizedEnd;
-  }
-
-  return matches;
 };

--- a/apps/web/src/routes/tools/-components/public-tools-index.logic.ts
+++ b/apps/web/src/routes/tools/-components/public-tools-index.logic.ts
@@ -1,3 +1,5 @@
+import { foldSearchMatchText } from "@stll/text-normalize";
+
 import {
   filterToolEntries,
   type ToolFilterEntry,
@@ -50,22 +52,16 @@ export type PublicToolBrowseFilters = ToolFilters & {
   task: PublicToolTask | null;
 };
 
-const normalizeSearchText = (value: string): string =>
-  value
-    .normalize("NFKD")
-    .replace(/\p{Mark}/gu, "")
-    .toLocaleLowerCase("en");
-
 const matchesSearchQuery = (
   entry: PublicToolBrowseEntry,
   query: string,
 ): boolean => {
-  const terms = normalizeSearchText(query).trim().split(/\s+/u).filter(Boolean);
+  const terms = foldSearchMatchText(query).trim().split(/\s+/u).filter(Boolean);
   if (terms.length === 0) {
     return true;
   }
 
-  const haystack = normalizeSearchText(
+  const haystack = foldSearchMatchText(
     [
       entry.displayName,
       entry.description,

--- a/bun.lock
+++ b/bun.lock
@@ -181,6 +181,7 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "catalog:",
         "@stll/api-contract": "workspace:*",
+        "@stll/text-normalize": "workspace:*",
         "@stll/ui": "workspace:*",
         "@tauri-apps/api": "^2.11.1",
         "better-result": "catalog:",

--- a/packages/text-normalize/README.md
+++ b/packages/text-normalize/README.md
@@ -9,7 +9,7 @@ the original text.
 
 ## Arabic
 
-`normalizeSearchText` folds the orthographic variants that make Arabic
+`arabicNormalize` folds the orthographic variants that make Arabic
 search miss otherwise-identical words:
 
 - alef variants and alef-wasla (`أ إ آ ٱ`) to bare alef `ا`
@@ -28,9 +28,9 @@ and cross-checked against CAMeL Tools (MIT), extended for the classes
 Lucene omits.
 
 ```ts
-import { normalizeSearchText } from "@stll/text-normalize";
+import { arabicNormalize } from "@stll/text-normalize";
 
-normalizeSearchText("أحمد") === normalizeSearchText("احمد"); // true
+arabicNormalize("أحمد") === arabicNormalize("احمد"); // true
 ```
 
 The same fold must be reproduced by the PostgreSQL `arabic_normalize()`
@@ -58,6 +58,17 @@ compatibility characters (ligatures, full-width forms, superscripts) fold
 to their base before a `[a-z0-9]` slug filter runs. Slugs are persisted,
 public URL segments; this variant pins the exact form existing slugs were
 generated with.
+
+## Substring matching with highlight offsets
+
+`foldSearchMatchText` is the client-side match key for interactive
+filtering: NFKD, the `unaccent()`-parity ASCII folds, mark strip, Arabic
+folds, lowercase — `capek` matches `Čapek` and `wroclaw` matches
+`Wrocław`, both ways. `findSearchMatchRanges` finds a folded query in
+folded content and returns ranges into the **original** string, so
+highlights wrap the text the user sees even where folding changes string
+length; it accepts content pre-folded with `foldSearchMatchTextWithOffsets`
+so repeated queries against the same text fold it once.
 
 ## Spaced letters
 

--- a/packages/text-normalize/src/ascii-fold.ts
+++ b/packages/text-normalize/src/ascii-fold.ts
@@ -23,6 +23,15 @@ const ASCII_FOLD_RE = new RegExp(
 );
 
 /**
+ * The replace step of `foldToAscii`, for callers that decompose themselves
+ * (`foldSearchMatchText` decomposes with NFKD and per character). The input
+ * must already be decomposed or table-only characters would hide inside
+ * precomposed letters.
+ */
+export const applyAsciiFolds = (decomposed: string): string =>
+  decomposed.replace(ASCII_FOLD_RE, (char) => ASCII_FOLD_TABLE[char] ?? "");
+
+/**
  * Fold text to its ASCII search key.
  *
  * The contract is parity with `unaccent()` for Latin-script characters: for
@@ -33,6 +42,4 @@ const ASCII_FOLD_RE = new RegExp(
  * the input was Latin, and folding is idempotent.
  */
 export const foldToAscii = (text: string): string =>
-  text
-    .normalize("NFD")
-    .replace(ASCII_FOLD_RE, (char) => ASCII_FOLD_TABLE[char] ?? "");
+  applyAsciiFolds(text.normalize("NFD"));

--- a/packages/text-normalize/src/index.ts
+++ b/packages/text-normalize/src/index.ts
@@ -9,7 +9,7 @@ export type { FoldedText } from "./arabic.js";
 export { foldToAscii } from "./ascii-fold.js";
 export { ASCII_FOLD_TABLE } from "./ascii-fold-table.js";
 export { stripDiacritics, stripDiacriticsForSlug } from "./diacritics.js";
-export { normalizeSearchText } from "./normalize.js";
+export { arabicNormalize } from "./normalize.js";
 export {
   findSearchMatchRanges,
   foldSearchMatchText,

--- a/packages/text-normalize/src/index.ts
+++ b/packages/text-normalize/src/index.ts
@@ -11,6 +11,12 @@ export { ASCII_FOLD_TABLE } from "./ascii-fold-table.js";
 export { stripDiacritics, stripDiacriticsForSlug } from "./diacritics.js";
 export { normalizeSearchText } from "./normalize.js";
 export {
+  findSearchMatchRanges,
+  foldSearchMatchText,
+  foldSearchMatchTextWithOffsets,
+} from "./search-match.js";
+export type { FoldedSearchText, SearchMatchRange } from "./search-match.js";
+export {
   collapseSpacedLetters,
   spacedLetterRunRegex,
 } from "./spaced-letters.js";

--- a/packages/text-normalize/src/normalize.test.ts
+++ b/packages/text-normalize/src/normalize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { normalizeSearchText } from "./normalize.js";
+import { arabicNormalize } from "./normalize.js";
 
 // Each group lists spellings a user might type for the same word. After
 // normalization they must all collapse to a single search key.
@@ -41,16 +41,16 @@ const GOLDEN: readonly (readonly [string, string])[] = [
   ["a\u2007b\u3000c", "a b c"], // Unicode space separators collapsed
 ];
 
-describe("normalizeSearchText", () => {
+describe("arabicNormalize", () => {
   test("each equivalence group collapses to one key", () => {
     for (const group of EQUIVALENCE_GROUPS) {
-      const keys = new Set(group.map(normalizeSearchText));
+      const keys = new Set(group.map(arabicNormalize));
       expect(keys.size).toBe(1);
     }
   });
 
   test.each(GOLDEN)("normalize(%p) === %p", (input, expected) => {
-    expect(normalizeSearchText(input)).toBe(expected);
+    expect(arabicNormalize(input)).toBe(expected);
   });
 
   test("is idempotent", () => {
@@ -60,12 +60,12 @@ describe("normalizeSearchText", () => {
       "Hello World",
     ];
     for (const sample of samples) {
-      const once = normalizeSearchText(sample);
-      expect(normalizeSearchText(once)).toBe(once);
+      const once = arabicNormalize(sample);
+      expect(arabicNormalize(once)).toBe(once);
     }
   });
 
   test("leaves fold targets (bare alef, waw, yeh, heh) stable", () => {
-    expect(normalizeSearchText("اويه")).toBe("اويه");
+    expect(arabicNormalize("اويه")).toBe("اويه");
   });
 });

--- a/packages/text-normalize/src/normalize.ts
+++ b/packages/text-normalize/src/normalize.ts
@@ -17,11 +17,13 @@ const foldSearchCase = (text: string): string =>
   });
 
 /**
- * Canonical search match-key normalizer. Folds Arabic orthographic
- * variants so a query matches regardless of how the text was typed
- * (alef/hamza/teh-marbuta/yeh variants, tashkeel, tatweel, Arabic-Indic
- * digits), then applies locale-stable ASCII case folding for mixed-script
- * names.
+ * TypeScript mirror of the SQL `arabic_normalize()` function. Folds Arabic
+ * orthographic variants so a query matches regardless of how the text was
+ * typed (alef/hamza/teh-marbuta/yeh variants, tashkeel, tatweel,
+ * Arabic-Indic digits), then applies locale-stable ASCII case folding for
+ * mixed-script names. It must NOT strip Latin diacritics — the stored match
+ * keys don't; client-side diacritic-insensitive matching is
+ * `foldSearchMatchText` (search-match.ts).
  *
  * NFKC runs first so presentation forms (U+FB50–FDFF, U+FE70–FEFF) fold
  * to their canonical letters before the explicit folds apply.
@@ -29,7 +31,7 @@ const foldSearchCase = (text: string): string =>
  * This MUST stay consistent with the SQL `arabic_normalize()` function;
  * the golden vectors in normalize.test.ts pin the contract for both.
  */
-export const normalizeSearchText = (text: string): string =>
+export const arabicNormalize = (text: string): string =>
   foldSearchCase(applyArabicFolds(text.normalize("NFKC")))
     .replace(SEARCH_WHITESPACE_RE, " ")
     .trim();

--- a/packages/text-normalize/src/search-match.test.ts
+++ b/packages/text-normalize/src/search-match.test.ts
@@ -77,6 +77,19 @@ describe("findSearchMatchRanges", () => {
     expect(findSearchMatchRanges("Čapek", "  ")).toEqual([]);
   });
 
+  test("reports an expanding fold once and reaches later hits", () => {
+    expect(findSearchMatchRanges("ßs", "s")).toEqual([
+      { start: 0, end: 1 },
+      { start: 1, end: 2 },
+    ]);
+    expect(findSearchMatchRanges("ßs", "s", { maxMatches: 2 })).toHaveLength(2);
+  });
+
+  test("treats final and medial sigma alike", () => {
+    expect(findSearchMatchRanges("ΟΣ", "σ")).toEqual([{ start: 1, end: 2 }]);
+    expect(findSearchMatchRanges("οσ", "ς")).toEqual([{ start: 1, end: 2 }]);
+  });
+
   test("ranges cover expanding folds", () => {
     const content = "sídlo: Wrocław, Straße 7";
     const [wroclaw] = findSearchMatchRanges(content, "wroclaw");

--- a/packages/text-normalize/src/search-match.test.ts
+++ b/packages/text-normalize/src/search-match.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  findSearchMatchRanges,
+  foldSearchMatchText,
+  foldSearchMatchTextWithOffsets,
+} from "./search-match.js";
+
+describe("foldSearchMatchText", () => {
+  test("strips diacritics and lowercases", () => {
+    expect(foldSearchMatchText("Čapek")).toBe("capek");
+    expect(foldSearchMatchText("Uherské Hradiště")).toBe("uherske hradiste");
+  });
+
+  test("folds decomposed input to the same key as precomposed", () => {
+    expect(foldSearchMatchText("C\u030Capek")).toBe(
+      foldSearchMatchText("\u010Capek"),
+    );
+  });
+
+  test("folds compatibility characters", () => {
+    expect(foldSearchMatchText("ﬁling")).toBe("filing");
+  });
+});
+
+describe("findSearchMatchRanges", () => {
+  test("matches a plain query against accented text", () => {
+    expect(findSearchMatchRanges("Karel Čapek", "capek")).toEqual([
+      { start: 6, end: 11 },
+    ]);
+  });
+
+  test("matches an accented query against plain text", () => {
+    expect(findSearchMatchRanges("karel capek", "Čapek")).toEqual([
+      { start: 6, end: 11 },
+    ]);
+  });
+
+  test("ranges cover the original characters when folding changes length", () => {
+    const content = "smlouva – ﬁnal Čapek";
+    const [match] = findSearchMatchRanges(content, "final");
+    expect(match).toBeDefined();
+    if (match) {
+      expect(content.slice(match.start, match.end)).toBe("ﬁnal");
+    }
+  });
+
+  test("returns non-overlapping occurrences in order", () => {
+    expect(findSearchMatchRanges("řada řad neřadí", "řad")).toEqual([
+      { start: 0, end: 3 },
+      { start: 5, end: 8 },
+      { start: 11, end: 14 },
+    ]);
+  });
+
+  test("respects maxMatches", () => {
+    expect(findSearchMatchRanges("a b a b a", "a", { maxMatches: 2 })).toEqual([
+      { start: 0, end: 1 },
+      { start: 4, end: 5 },
+    ]);
+  });
+
+  test("accepts pre-folded content", () => {
+    const folded = foldSearchMatchTextWithOffsets("Judikát NS");
+    expect(findSearchMatchRanges(folded, "judikat")).toEqual([
+      { start: 0, end: 7 },
+    ]);
+  });
+
+  test("returns nothing for an empty query", () => {
+    expect(findSearchMatchRanges("Čapek", "  ")).toEqual([]);
+  });
+});

--- a/packages/text-normalize/src/search-match.test.ts
+++ b/packages/text-normalize/src/search-match.test.ts
@@ -21,6 +21,12 @@ describe("foldSearchMatchText", () => {
   test("folds compatibility characters", () => {
     expect(foldSearchMatchText("ﬁling")).toBe("filing");
   });
+
+  test("folds letters without a canonical decomposition", () => {
+    expect(foldSearchMatchText("Wrocław")).toBe("wroclaw");
+    expect(foldSearchMatchText("Søren Đorđe")).toBe("soren dorde");
+    expect(foldSearchMatchText("Straße")).toBe("strasse");
+  });
 });
 
 describe("findSearchMatchRanges", () => {
@@ -69,5 +75,15 @@ describe("findSearchMatchRanges", () => {
 
   test("returns nothing for an empty query", () => {
     expect(findSearchMatchRanges("Čapek", "  ")).toEqual([]);
+  });
+
+  test("ranges cover expanding folds", () => {
+    const content = "sídlo: Wrocław, Straße 7";
+    const [wroclaw] = findSearchMatchRanges(content, "wroclaw");
+    const [strasse] = findSearchMatchRanges(content, "strasse");
+    expect(wroclaw && content.slice(wroclaw.start, wroclaw.end)).toBe(
+      "Wrocław",
+    );
+    expect(strasse && content.slice(strasse.start, strasse.end)).toBe("Straße");
   });
 });

--- a/packages/text-normalize/src/search-match.ts
+++ b/packages/text-normalize/src/search-match.ts
@@ -1,0 +1,140 @@
+/**
+ * Diacritic-insensitive substring matching with original-index mapping.
+ *
+ * `foldSearchMatchText` builds the client-side match key: NFKD
+ * decomposition, combining-mark strip, Arabic orthographic folds, then
+ * lowercase — so a `capek` query matches `Čapek` and vice versa. It is
+ * deliberately distinct from `normalizeSearchText` (normalize.ts), which is
+ * pinned to the SQL `arabic_normalize()` contract and must not strip Latin
+ * diacritics. Letters without a canonical decomposition (`ł`, `ø`, `đ`) are
+ * not folded here; that is `foldToAscii`'s contract.
+ *
+ * `findSearchMatchRanges` locates a folded query inside folded content and
+ * reports matches as ranges into the ORIGINAL string, so highlights wrap the
+ * text the user actually sees. Folding changes string length (per-character
+ * decomposition, mark removal, contextual lowercasing), so the folded form
+ * carries a per-code-unit map back to the originating character's range.
+ */
+
+import { applyArabicFolds } from "./arabic.js";
+
+const COMBINING_MARKS = /\p{M}+/gu;
+
+export type SearchMatchRange = {
+  end: number;
+  start: number;
+};
+
+export type FoldedSearchText = {
+  /** Original-string character range for each folded UTF-16 code unit. */
+  originalRanges: SearchMatchRange[];
+  text: string;
+};
+
+const foldSearchMatchTextBeforeCase = (value: string): string =>
+  applyArabicFolds(value.normalize("NFKD").replace(COMBINING_MARKS, ""));
+
+export const foldSearchMatchText = (value: string): string =>
+  foldSearchMatchTextBeforeCase(value).toLowerCase();
+
+export const foldSearchMatchTextWithOffsets = (
+  content: string,
+): FoldedSearchText => {
+  const units: { range: SearchMatchRange; text: string }[] = [];
+  let originalOffset = 0;
+
+  for (const character of content) {
+    const start = originalOffset;
+    originalOffset += character.length;
+    units.push({
+      range: { start, end: originalOffset },
+      text: foldSearchMatchTextBeforeCase(character),
+    });
+  }
+
+  const beforeCase = units.map(({ text }) => text).join("");
+  const contextualLowercase = beforeCase.toLowerCase();
+  if (contextualLowercase.length === beforeCase.length) {
+    const originalRanges: SearchMatchRange[] = [];
+    for (const unit of units) {
+      let codeUnit = 0;
+      while (codeUnit < unit.text.length) {
+        originalRanges.push(unit.range);
+        codeUnit += 1;
+      }
+    }
+    return {
+      text: contextualLowercase,
+      originalRanges,
+    };
+  }
+
+  // Lowercasing changed the length (e.g. İ gains a combining dot), so the
+  // whole-string result cannot be aligned with the per-character units;
+  // lowercase each unit separately instead.
+  const loweredParts: string[] = [];
+  const originalRanges: SearchMatchRange[] = [];
+  for (const unit of units) {
+    const lowered = unit.text.toLowerCase();
+    loweredParts.push(lowered);
+    let codeUnit = 0;
+    while (codeUnit < lowered.length) {
+      originalRanges.push(unit.range);
+      codeUnit += 1;
+    }
+  }
+  return { text: loweredParts.join(""), originalRanges };
+};
+
+type FindSearchMatchRangesOptions = {
+  maxMatches?: number;
+};
+
+/**
+ * Non-overlapping occurrences of the folded query in the content, as ranges
+ * into the original string. Accepts pre-folded content so callers matching
+ * many queries against the same text fold it once.
+ */
+export const findSearchMatchRanges = (
+  content: string | FoldedSearchText,
+  query: string,
+  options: FindSearchMatchRangesOptions = {},
+): SearchMatchRange[] => {
+  const maxMatches = Math.max(
+    0,
+    Math.floor(options.maxMatches ?? Number.MAX_SAFE_INTEGER),
+  );
+  if (maxMatches === 0) {
+    return [];
+  }
+
+  const foldedContent =
+    typeof content === "string"
+      ? foldSearchMatchTextWithOffsets(content)
+      : content;
+  const foldedQuery = foldSearchMatchText(query.trim());
+  if (foldedQuery.length === 0) {
+    return [];
+  }
+
+  const matches: SearchMatchRange[] = [];
+  let searchFrom = 0;
+  while (searchFrom <= foldedContent.text.length - foldedQuery.length) {
+    const foldedStart = foldedContent.text.indexOf(foldedQuery, searchFrom);
+    if (foldedStart === -1) {
+      break;
+    }
+    const foldedEnd = foldedStart + foldedQuery.length;
+    const firstRange = foldedContent.originalRanges.at(foldedStart);
+    const lastRange = foldedContent.originalRanges.at(foldedEnd - 1);
+    if (firstRange && lastRange) {
+      matches.push({ start: firstRange.start, end: lastRange.end });
+      if (matches.length >= maxMatches) {
+        break;
+      }
+    }
+    searchFrom = foldedEnd;
+  }
+
+  return matches;
+};

--- a/packages/text-normalize/src/search-match.ts
+++ b/packages/text-normalize/src/search-match.ts
@@ -20,6 +20,12 @@ import { applyArabicFolds } from "./arabic.js";
 import { applyAsciiFolds } from "./ascii-fold.js";
 
 const COMBINING_MARKS = /\p{M}+/gu;
+// `toLowerCase` keeps the positional final sigma that Unicode case folding
+// maps to σ; a lone `σ` query would otherwise miss the end of `ΟΣ`. Same
+// length, so offsets are unaffected; a full `toUpperCase().toLowerCase()`
+// fold is not used because it changes lengths (ß → SS) and the ASCII table
+// already covers those letters.
+const FINAL_SIGMA = /ς/gu;
 
 export type SearchMatchRange = {
   end: number;
@@ -37,8 +43,11 @@ const foldSearchMatchTextBeforeCase = (value: string): string =>
     applyAsciiFolds(value.normalize("NFKD")).replace(COMBINING_MARKS, ""),
   );
 
+const caseFold = (value: string): string =>
+  value.toLowerCase().replace(FINAL_SIGMA, "σ");
+
 export const foldSearchMatchText = (value: string): string =>
-  foldSearchMatchTextBeforeCase(value).toLowerCase();
+  caseFold(foldSearchMatchTextBeforeCase(value));
 
 export const foldSearchMatchTextWithOffsets = (
   content: string,
@@ -56,7 +65,7 @@ export const foldSearchMatchTextWithOffsets = (
   }
 
   const beforeCase = units.map(({ text }) => text).join("");
-  const contextualLowercase = beforeCase.toLowerCase();
+  const contextualLowercase = caseFold(beforeCase);
   if (contextualLowercase.length === beforeCase.length) {
     const originalRanges: SearchMatchRange[] = [];
     for (const unit of units) {
@@ -78,7 +87,7 @@ export const foldSearchMatchTextWithOffsets = (
   const loweredParts: string[] = [];
   const originalRanges: SearchMatchRange[] = [];
   for (const unit of units) {
-    const lowered = unit.text.toLowerCase();
+    const lowered = caseFold(unit.text);
     loweredParts.push(lowered);
     let codeUnit = 0;
     while (codeUnit < lowered.length) {
@@ -130,13 +139,23 @@ export const findSearchMatchRanges = (
     const foldedEnd = foldedStart + foldedQuery.length;
     const firstRange = foldedContent.originalRanges.at(foldedStart);
     const lastRange = foldedContent.originalRanges.at(foldedEnd - 1);
-    if (firstRange && lastRange) {
-      matches.push({ start: firstRange.start, end: lastRange.end });
-      if (matches.length >= maxMatches) {
-        break;
-      }
+    if (!firstRange || !lastRange) {
+      break;
     }
+    matches.push({ start: firstRange.start, end: lastRange.end });
+    if (matches.length >= maxMatches) {
+      break;
+    }
+    // An expanding fold (ß → ss) maps several folded units to one original
+    // character; resume after the last unit inside the matched characters so
+    // that character is reported once and the budget reaches later hits.
     searchFrom = foldedEnd;
+    while (
+      (foldedContent.originalRanges.at(searchFrom)?.start ?? Infinity) <
+      lastRange.end
+    ) {
+      searchFrom += 1;
+    }
   }
 
   return matches;

--- a/packages/text-normalize/src/search-match.ts
+++ b/packages/text-normalize/src/search-match.ts
@@ -2,12 +2,12 @@
  * Diacritic-insensitive substring matching with original-index mapping.
  *
  * `foldSearchMatchText` builds the client-side match key: NFKD
- * decomposition, combining-mark strip, Arabic orthographic folds, then
- * lowercase — so a `capek` query matches `Čapek` and vice versa. It is
- * deliberately distinct from `normalizeSearchText` (normalize.ts), which is
- * pinned to the SQL `arabic_normalize()` contract and must not strip Latin
- * diacritics. Letters without a canonical decomposition (`ł`, `ø`, `đ`) are
- * not folded here; that is `foldToAscii`'s contract.
+ * decomposition, the `unaccent()`-parity ASCII folds (letters with no
+ * decomposition: `ł`, `ø`, `đ`, `ß`), combining-mark strip, Arabic
+ * orthographic folds, then lowercase — so a `capek` query matches `Čapek`
+ * and `wroclaw` matches `Wrocław`, both ways. It is deliberately distinct
+ * from `arabicNormalize` (normalize.ts), which is pinned to the SQL
+ * `arabic_normalize()` contract and must not strip Latin diacritics.
  *
  * `findSearchMatchRanges` locates a folded query inside folded content and
  * reports matches as ranges into the ORIGINAL string, so highlights wrap the
@@ -17,6 +17,7 @@
  */
 
 import { applyArabicFolds } from "./arabic.js";
+import { applyAsciiFolds } from "./ascii-fold.js";
 
 const COMBINING_MARKS = /\p{M}+/gu;
 
@@ -32,7 +33,9 @@ export type FoldedSearchText = {
 };
 
 const foldSearchMatchTextBeforeCase = (value: string): string =>
-  applyArabicFolds(value.normalize("NFKD").replace(COMBINING_MARKS, ""));
+  applyArabicFolds(
+    applyAsciiFolds(value.normalize("NFKD")).replace(COMBINING_MARKS, ""),
+  );
 
 export const foldSearchMatchText = (value: string): string =>
   foldSearchMatchTextBeforeCase(value).toLowerCase();


### PR DESCRIPTION
## Clipboard search performance

Typing in the clipboard manager's search stalled behind the search itself:

- The filter ran synchronously on every keystroke and lowercased every clip's full text each time (up to 500 clips x 64 KiB). The folded searchable text is now cached per item in a `WeakMap`, computed once per snapshot.
- Each visible card rendered the clip's entire text (one highlight span per match) under an eight-line clamp that can only show ~320 characters. Previews now cap at `CLIPBOARD_CARD_PREVIEW_MAX_CHARACTERS` (1000).
- The query filters through `useDeferredValue`: the input repaints immediately and the rail catches up in an interruptible deferred render. Clearing stays synchronous so the reopen reset can focus the newest card inside its `flushSync` commit.

## Diacritic-insensitive matching, one shared core

`capek` now matches `Čapek`, `wroclaw` matches `Wrocław`, `strasse` matches `Straße` — both directions — in the clipboard filter, highlight marks, and windowed preview.

The folding core with original-index mapping moves from `apps/web/src/lib/search-text.ts` into `@stll/text-normalize` (`foldSearchMatchText`, `foldSearchMatchTextWithOffsets`, `findSearchMatchRanges`) so desktop and web share one behavior. `findSearchMatchRanges` accepts pre-folded content, letting the clipboard fold each clip once and reuse it across keystrokes. The fold now also applies the `unaccent()`-parity ASCII table (via `applyAsciiFolds`, split out of `foldToAscii`), so web search highlighting can finally highlight the lexemes an unaccent index returns for letters with no canonical decomposition.

## Naming: one meaning per name

`normalizeSearchText` meant two different things (the export pinned to SQL `arabic_normalize()`, and the web diacritic-stripping fold). The former is now `arabicNormalize`, named for the SQL function it mirrors; the latter is the `foldSearchMatchText` family. No aliases remain: consumers are repointed, the `SearchTextMatch` alias is replaced by the package's `SearchMatchRange`, the public tools filter drops its private fold for the shared one, and the legal reader's offset-mapped normalizer is renamed `normalizeReaderSearchText`. The `@stll/text-normalize` export rename warrants a minor version bump at next publish.

## UI fixes

- The unfocused search pill showed stray corner shading: the input group paints its unfocused hairline through a `::before` overlay pinned to the group's `lg` radius, which mismatches the `rounded-full` override. The overlay is disabled for the pill, which draws its own inset highlight.
- While the search field holds focus, the selected card now renders exactly like its siblings (it previously kept a dimmed inactive-selection ring) while silently remaining the Enter target; the highlight returns when ArrowUp hands focus back to the rail.

https://claude.ai/code/session_01AfAopdzBEiJV64MUnZRJz2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now matches more reliably across accents, diacritics, Arabic variants and other character forms.
  * Search highlights remain aligned with the original text.
  * Clipboard previews are generated from complete item content and capped at 1,000 characters.
* **Performance**
  * Clipboard filtering stays responsive while typing.
* **Bug Fixes**
  * Improved selected-card and search-field visual states.
  * Removed stray shading from the clipboard search field.
* **Documentation**
  * Updated text-normalisation guidance and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->