### PR TITLE
perf: bound projection bootstrap state scans

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.db.test.ts
@@ -281,3 +281,59 @@ test("bootstrap locks source policy before canonical rows for every family", asy
   assertSourceBeforeDocument("case_law_sources", "case_law_decisions");
   assertSourceBeforeDocument("legislation_sources", "legislation_documents");
 });
+
+test("cursor pages seek both canonical and projection primary keys", async () => {
+  const statements: string[] = [];
+  const loggedDb = drizzle({
+    client,
+    logger: {
+      logQuery(query) {
+        statements.push(query);
+      },
+    },
+  });
+  await loggedDb.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "case_law",
+          generation: "case_law_v5",
+          limit: 1,
+          afterEntityId: CASE_LAW_DECISION_ID,
+        },
+      ),
+  );
+  await loggedDb.transaction(
+    async (tx) =>
+      await bootstrapCorpusProjectionDesiredStateBatchTx(
+        asTestRaw<Transaction>(tx),
+        {
+          family: "legislation",
+          generation: "legislation_v2",
+          limit: 1,
+          afterEntityId: LEGISLATION_DOCUMENT_ID,
+        },
+      ),
+  );
+
+  const assertCursorBound = (
+    canonicalTable: string,
+    canonicalId: string,
+  ): void => {
+    const queries = statements.filter(
+      (query) =>
+        query.includes(`from "${canonicalTable}"`) &&
+        query.includes('left join "corpus_index_projection_states"'),
+    );
+    expect(queries).toHaveLength(2);
+    for (const query of queries) {
+      expect(query).toContain(`"${canonicalTable}"."${canonicalId}" > $`);
+      expect(query).toContain(
+        '"corpus_index_projection_states"."entity_id" > $',
+      );
+    }
+  };
+  assertCursorBound("case_law_decisions", "id");
+  assertCursorBound("legislation_documents", "id");
+});

--- a/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-bootstrap.ts
@@ -214,6 +214,14 @@ const bootstrapCaseLaw = async (
       ? []
       : [gt(caseLawDecisions.id, afterEntityId)]),
   ];
+  const projectionConditions = [
+    eq(corpusIndexProjectionStates.family, "case_law"),
+    eq(corpusIndexProjectionStates.generation, generation),
+    eq(corpusIndexProjectionStates.entityId, caseLawDecisions.id),
+    ...(afterEntityId === undefined
+      ? []
+      : [gt(corpusIndexProjectionStates.entityId, afterEntityId)]),
+  ];
   const candidates = await tx
     .select({
       documentId: caseLawDecisions.id,
@@ -222,14 +230,7 @@ const bootstrapCaseLaw = async (
     })
     .from(caseLawDecisions)
     .innerJoin(caseLawSources, eq(caseLawSources.id, caseLawDecisions.sourceId))
-    .leftJoin(
-      corpusIndexProjectionStates,
-      and(
-        eq(corpusIndexProjectionStates.family, "case_law"),
-        eq(corpusIndexProjectionStates.generation, generation),
-        eq(corpusIndexProjectionStates.entityId, caseLawDecisions.id),
-      ),
-    )
+    .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
     .where(and(...conditions))
     .orderBy(asc(caseLawDecisions.id))
     .limit(limit)
@@ -264,14 +265,7 @@ const bootstrapCaseLaw = async (
       projectionEpoch: caseLawDecisions.projectionEpoch,
     })
     .from(caseLawDecisions)
-    .leftJoin(
-      corpusIndexProjectionStates,
-      and(
-        eq(corpusIndexProjectionStates.family, "case_law"),
-        eq(corpusIndexProjectionStates.generation, generation),
-        eq(corpusIndexProjectionStates.entityId, caseLawDecisions.id),
-      ),
-    )
+    .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
     .where(and(...conditions, inArray(caseLawDecisions.id, candidateIds)))
     .orderBy(asc(caseLawDecisions.id))
     .limit(limit)
@@ -416,6 +410,14 @@ const bootstrapLegislation = async (
       ? []
       : [gt(legislationDocuments.id, afterEntityId)]),
   ];
+  const projectionConditions = [
+    eq(corpusIndexProjectionStates.family, "legislation"),
+    eq(corpusIndexProjectionStates.generation, generation),
+    eq(corpusIndexProjectionStates.entityId, legislationDocuments.id),
+    ...(afterEntityId === undefined
+      ? []
+      : [gt(corpusIndexProjectionStates.entityId, afterEntityId)]),
+  ];
   const candidates = await tx
     .select({
       documentId: legislationDocuments.id,
@@ -427,14 +429,7 @@ const bootstrapLegislation = async (
       legislationSources,
       eq(legislationSources.id, legislationDocuments.sourceId),
     )
-    .leftJoin(
-      corpusIndexProjectionStates,
-      and(
-        eq(corpusIndexProjectionStates.family, "legislation"),
-        eq(corpusIndexProjectionStates.generation, generation),
-        eq(corpusIndexProjectionStates.entityId, legislationDocuments.id),
-      ),
-    )
+    .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
     .where(and(...conditions))
     .orderBy(asc(legislationDocuments.id))
     .limit(limit)
@@ -468,14 +463,7 @@ const bootstrapLegislation = async (
       projectionEpoch: legislationDocuments.projectionEpoch,
     })
     .from(legislationDocuments)
-    .leftJoin(
-      corpusIndexProjectionStates,
-      and(
-        eq(corpusIndexProjectionStates.family, "legislation"),
-        eq(corpusIndexProjectionStates.generation, generation),
-        eq(corpusIndexProjectionStates.entityId, legislationDocuments.id),
-      ),
-    )
+    .leftJoin(corpusIndexProjectionStates, and(...projectionConditions))
     .where(and(...conditions, inArray(legislationDocuments.id, candidateIds)))
     .orderBy(asc(legislationDocuments.id))
     .limit(limit)


### PR DESCRIPTION
Bounds projection-state anti-joins to the same keyset cursor as canonical rows, so each bootstrap page seeks the composite primary key instead of revisiting the completed prefix.

Adds a generated-SQL regression guard for both corpus families.

Validation:
- focused bootstrap database suite: 4 passed
- mutation check: guard fails when the projection cursor predicate is removed
- scoped commit hooks: format, lint, secrets

CC on behalf of jan-kubica