### PR TITLE
fix(desktop): handle rejections from Tauri event subscriptions

### DIFF
--- a/apps/desktop/src/clipboard/ClipboardApp.tsx
+++ b/apps/desktop/src/clipboard/ClipboardApp.tsx
@@ -21,7 +21,6 @@ import {
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
 import { preserveOffsetOnSource } from "@atlaskit/pragmatic-drag-and-drop/utils/preserve-offset-on-source";
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
 import {
   ClipboardIcon,
   CircleHelpIcon,
@@ -78,6 +77,7 @@ import {
 import { StellaMark } from "@stll/ui/stella-mark";
 import { cn } from "@stll/ui/utils";
 
+import { subscribeDesktopEvent } from "../shared/desktop-events";
 import {
   DESKTOP_TELEMETRY_ERROR_CODES,
   DESKTOP_TELEMETRY_OPERATIONS,
@@ -1146,33 +1146,27 @@ const ClipboardApp = () => {
         });
     };
     readSnapshot();
-    let stopListening: (() => void) | undefined;
-    void listen("clipboard-history-changed", readSnapshot)
-      .then((unlisten) => {
-        if (disposed) {
-          unlisten();
-          return undefined;
-        }
-        stopListening = unlisten;
-        // Re-read once the subscription exists: the off-mutex initialization
-        // may have installed history and emitted its one-shot change event
-        // between the first read and this listener, which would otherwise
-        // leave the window stuck on the empty initializing snapshot.
-        readSnapshot();
-        return undefined;
-      })
-      .catch(() => {
+    const stopListening = subscribeDesktopEvent({
+      event: "clipboard-history-changed",
+      handler: readSnapshot,
+      onError: () => {
         reportDesktopError({
           code: DESKTOP_TELEMETRY_ERROR_CODES.eventSubscriptionFailed,
           operation: DESKTOP_TELEMETRY_OPERATIONS.clipboardHistorySubscribe,
           window: DESKTOP_TELEMETRY_WINDOWS.clipboard,
         });
         setError({ message: errorReadHistory, source: "read" });
-      });
+      },
+      // Re-read once the subscription exists: the off-mutex initialization
+      // may have installed history and emitted its one-shot change event
+      // between the first read and this listener, which would otherwise
+      // leave the window stuck on the empty initializing snapshot.
+      onSubscribed: readSnapshot,
+    });
     return () => {
       stopObservingReopens();
       disposed = true;
-      stopListening?.();
+      stopListening();
     };
   }, [errorReadHistory]);
 

--- a/apps/desktop/src/mainview/App.tsx
+++ b/apps/desktop/src/mainview/App.tsx
@@ -1,7 +1,6 @@
 import { startTransition, useEffect, useState } from "react";
 
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
 import { useFormatter, useLocale, useTranslations } from "use-intl";
 
 import { Avatar, AvatarFallback } from "@stll/ui/avatar";
@@ -28,6 +27,7 @@ import {
   SUPPORTED_LANGUAGES,
 } from "../i18n";
 import type { SupportedLanguage } from "../i18n";
+import { subscribeDesktopEvent } from "../shared/desktop-events";
 import { isAppSnapshot } from "../shared/rpc";
 import type {
   AppSnapshot,
@@ -35,6 +35,12 @@ import type {
   DesktopUpdateSnapshot,
   LinkedAccountSnapshot,
 } from "../shared/rpc";
+import {
+  DESKTOP_TELEMETRY_ERROR_CODES,
+  DESKTOP_TELEMETRY_OPERATIONS,
+  DESKTOP_TELEMETRY_WINDOWS,
+  reportDesktopError,
+} from "../telemetry/desktop-telemetry";
 import stellaFavicon from "./stella-favicon.svg";
 
 const DEFAULT_NOTIFICATION_PREFERENCES = {
@@ -78,6 +84,14 @@ const isMacDesktop = navigator.userAgent.includes("Mac");
 
 const isPreferencesTab = (value: string | null): value is PreferencesTab =>
   value !== null && (PREFERENCES_TABS as readonly string[]).includes(value);
+
+const reportSubscriptionFailure = () => {
+  reportDesktopError({
+    code: DESKTOP_TELEMETRY_ERROR_CODES.eventSubscriptionFailed,
+    operation: DESKTOP_TELEMETRY_OPERATIONS.runtime,
+    window: DESKTOP_TELEMETRY_WINDOWS.main,
+  });
+};
 
 const getInitialTab = (): PreferencesTab => {
   const tab = window.location.hash.replace(/^#/u, "");
@@ -455,46 +469,45 @@ const App = () => {
   }, [activeTab]);
 
   // Listen for tab activation from Rust backend
-  useEffect(() => {
-    let cleanup: (() => void) | undefined;
-
-    void listen<{ tab: string }>("activate-tab", (event) => {
-      const nextTab = event.payload.tab;
-      if (isPreferencesTab(nextTab)) {
-        setActiveTab(nextTab);
-      }
-    }).then((unlisten) => {
-      cleanup = unlisten;
-      return;
-    });
-
-    return () => {
-      cleanup?.();
-    };
-  }, []);
+  useEffect(
+    () =>
+      subscribeDesktopEvent<{ tab: string }>({
+        event: "activate-tab",
+        handler: (event) => {
+          const nextTab = event.payload.tab;
+          if (isPreferencesTab(nextTab)) {
+            setActiveTab(nextTab);
+          }
+        },
+        onError: reportSubscriptionFailure,
+      }),
+    [],
+  );
 
   // Listen for state changes from Rust backend + initial fetch
   useEffect(() => {
     let disposed = false;
-    let cleanup: (() => void) | undefined;
 
-    void listen<AppSnapshot>("state-changed", (event) => {
-      if (disposed) {
-        return;
-      }
+    const stopListening = subscribeDesktopEvent<AppSnapshot>({
+      event: "state-changed",
+      handler: (event) => {
+        // Unsubscribing is itself an IPC round trip, so an event can still
+        // arrive after the effect was cleaned up.
+        if (disposed) {
+          return;
+        }
 
-      const detail = event.payload;
-      if (!isAppSnapshot(detail)) {
-        return;
-      }
+        const detail = event.payload;
+        if (!isAppSnapshot(detail)) {
+          return;
+        }
 
-      startTransition(() => {
-        setError(null);
-        setState(detail);
-      });
-    }).then((unlisten) => {
-      cleanup = unlisten;
-      return;
+        startTransition(() => {
+          setError(null);
+          setState(detail);
+        });
+      },
+      onError: reportSubscriptionFailure,
     });
 
     const syncState = async () => {
@@ -525,7 +538,7 @@ const App = () => {
 
     return () => {
       disposed = true;
-      cleanup?.();
+      stopListening();
     };
   }, [t]);
 

--- a/apps/desktop/src/mainview/main.tsx
+++ b/apps/desktop/src/mainview/main.tsx
@@ -2,7 +2,6 @@ import { lazy, StrictMode, Suspense, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import type { Root as ReactRoot } from "react-dom/client";
 
-import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { panic } from "better-result";
 
@@ -16,6 +15,7 @@ import {
   loadMessages,
 } from "../i18n";
 import type { DesktopMessages } from "../i18n";
+import { subscribeDesktopEvent } from "../shared/desktop-events";
 import { useSystemTheme } from "../shared/use-system-theme";
 import {
   DESKTOP_TELEMETRY_ERROR_CODES,
@@ -58,24 +58,25 @@ const Root = () => {
     };
   }, [language]);
 
-  useEffect(() => {
-    let cleanup: (() => void) | undefined;
-    void listen<{ language: string }>(
-      DESKTOP_LANGUAGE_CHANGED_EVENT,
-      ({ payload }) => {
-        if (isSupportedLanguage(payload.language)) {
-          setLanguage(payload.language);
-        }
-      },
-    ).then((unlisten) => {
-      cleanup = unlisten;
-      return;
-    });
-
-    return () => {
-      cleanup?.();
-    };
-  }, []);
+  useEffect(
+    () =>
+      subscribeDesktopEvent<{ language: string }>({
+        event: DESKTOP_LANGUAGE_CHANGED_EVENT,
+        handler: ({ payload }) => {
+          if (isSupportedLanguage(payload.language)) {
+            setLanguage(payload.language);
+          }
+        },
+        onError: () => {
+          reportDesktopError({
+            code: DESKTOP_TELEMETRY_ERROR_CODES.eventSubscriptionFailed,
+            operation: DESKTOP_TELEMETRY_OPERATIONS.runtime,
+            window: telemetryWindow,
+          });
+        },
+      }),
+    [],
+  );
 
   const windowLabel = getCurrentWindow().label;
   let content = <App />;

--- a/apps/desktop/src/shared/desktop-events.ts
+++ b/apps/desktop/src/shared/desktop-events.ts
@@ -1,0 +1,59 @@
+import { listen } from "@tauri-apps/api/event";
+import type { EventCallback, EventName } from "@tauri-apps/api/event";
+
+/**
+ * Tauri types the unlisten function it resolves as `() => void`, although
+ * calling it awaits an IPC round trip that can fail. The wider type is what
+ * lets that rejection be handled instead of dropped.
+ */
+type StopListening = () => void | Promise<void>;
+
+type SubscribeDesktopEventOptions<T> = {
+  event: EventName;
+  handler: EventCallback<T>;
+  /** Runs when the subscription or its teardown fails. */
+  onError: () => void;
+  /** Runs once the subscription is live, before any event reaches `handler`. */
+  onSubscribed?: () => void;
+};
+
+/**
+ * Subscribes to a Tauri event and returns the canceller an effect cleanup calls.
+ *
+ * Both halves of a subscription cross IPC and can reject: `listen` itself, and
+ * the unlisten function it resolves. A rejection dropped from either has
+ * nowhere to go but the global unhandled-rejection handler, so both reach
+ * `onError` here.
+ *
+ * Cancelling before the subscription resolves unsubscribes as soon as it does,
+ * so a listener cannot outlive the effect that installed it.
+ */
+export const subscribeDesktopEvent = <T>({
+  event,
+  handler,
+  onError,
+  onSubscribed,
+}: SubscribeDesktopEventOptions<T>) => {
+  let unlisten: StopListening | undefined;
+  let cancelled = false;
+  const unsubscribe = (stopListening: StopListening) => {
+    Promise.resolve(stopListening()).catch(onError);
+  };
+  listen<T>(event, handler)
+    .then((stopListening) => {
+      if (cancelled) {
+        unsubscribe(stopListening);
+        return undefined;
+      }
+      unlisten = stopListening;
+      onSubscribed?.();
+      return undefined;
+    })
+    .catch(onError);
+  return () => {
+    cancelled = true;
+    if (unlisten) {
+      unsubscribe(unlisten);
+    }
+  };
+};

--- a/apps/desktop/tests/desktop-events.test.ts
+++ b/apps/desktop/tests/desktop-events.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const listenMock = mock();
+
+await mock.module("@tauri-apps/api/event", () => ({ listen: listenMock }));
+
+const { subscribeDesktopEvent } = await import("../src/shared/desktop-events");
+
+const EVENT = "clipboard-history-changed";
+const noop = () => {};
+
+/** Lets the subscription promise and any teardown promise settle. */
+const settle = async () => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+};
+
+describe("subscribeDesktopEvent", () => {
+  test("reports a subscription that never comes up", async () => {
+    listenMock.mockRejectedValue(new Error("event.listen not allowed"));
+    const onError = mock(noop);
+
+    subscribeDesktopEvent({ event: EVENT, handler: noop, onError });
+    await settle();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  test("reports a teardown that fails", async () => {
+    const unlisten = mock(async () => {
+      await Promise.reject(new Error("window is gone"));
+    });
+    listenMock.mockResolvedValue(unlisten);
+    const onError = mock(noop);
+
+    const stopListening = subscribeDesktopEvent({
+      event: EVENT,
+      handler: noop,
+      onError,
+    });
+    await settle();
+    stopListening();
+    await settle();
+
+    expect(unlisten).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  test("runs onSubscribed once the subscription is live", async () => {
+    listenMock.mockResolvedValue(mock(noop));
+    const onSubscribed = mock(noop);
+
+    subscribeDesktopEvent({
+      event: EVENT,
+      handler: noop,
+      onError: mock(noop),
+      onSubscribed,
+    });
+
+    expect(onSubscribed).not.toHaveBeenCalled();
+    await settle();
+    expect(onSubscribed).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribes when cancelled before the subscription resolves", async () => {
+    const unlisten = mock(noop);
+    listenMock.mockResolvedValue(unlisten);
+    const onSubscribed = mock(noop);
+
+    const stopListening = subscribeDesktopEvent({
+      event: EVENT,
+      handler: noop,
+      onError: mock(noop),
+      onSubscribed,
+    });
+    stopListening();
+    await settle();
+
+    expect(unlisten).toHaveBeenCalledTimes(1);
+    expect(onSubscribed).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Proposed change

`listen()` from `@tauri-apps/api/event` returns a promise, and resolves an unlisten function typed `() => void` although the implementation is `async () => _unlisten(...)`, which awaits a second IPC round trip. Both halves of a subscription can reject.

Every event subscription in the desktop frontend detached both halves:

- `mainview/main.tsx` (language changes) and `mainview/App.tsx` (`activate-tab`, `state-changed`) used `void listen(...).then((unlisten) => ...)` with no rejection handler, and called `unlisten()` in the effect cleanup without looking at what it returns.
- `clipboard/ClipboardApp.tsx` reported a failed subscription, but dropped the teardown promise the same way.

A rejection from either half then has nowhere to go but the window's global unhandled-rejection handler, even though the frontend already carries an `eventSubscriptionFailed` code for this failure. The two `mainview` sites also leaked the listener when an effect was cleaned up before `listen()` resolved: `cleanup` is still undefined at that point, and the subscription that lands afterwards is never torn down.

This adds `subscribeDesktopEvent` in `src/shared/desktop-events.ts` and routes the four subscriptions through it:

- rejections from `listen()` and from the unlisten call both reach the call site's `onError`, which reports `eventSubscriptionFailed`;
- cancelling before the subscription resolves unsubscribes as soon as it does, so a listener cannot outlive its effect;
- `ClipboardApp` keeps its re-read after subscribing, as `onSubscribed`.

`apps/desktop` is outside the `no-detached-void` and `no-swallowed-rejection` scopes in `oxlint.config.ts`, which is why the pattern survived here. Extending those scopes needs a desktop equivalent of `detached()` on top of the enum-only telemetry command, so it is left out of this change.

## Checklist

- [x] BUILD ASSURANCE | `typecheck` (both tsconfigs), type-aware `lint` and `test` pass for `@stll/desktop`; `bun run format` is clean.
- [ ] TESTING | `tests/desktop-events.test.ts` covers a subscription that never comes up, a teardown that fails, and cancellation before the subscription resolves. No behavior visible to the user changes.
- [ ] DARK MODE SUPPORT | Not applicable: no UI changes.
- [ ] ISSUE LINKED | Not applicable.
- [ ] SCREENSHOT INCLUDED | Not applicable: no UI changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sp8PU6ZhRxJf7qLakEmGbh)_