### PR TITLE
fix: allow concurrent corpus projection mutations

### DIFF
--- a/apps/api/drizzle/20260901060000_concurrent_corpus_projection_revision_fence/migration.sql
+++ b/apps/api/drizzle/20260901060000_concurrent_corpus_projection_revision_fence/migration.sql
@@ -1,12 +1,15 @@
 SET LOCAL lock_timeout = '1s';--> statement-breakpoint
 SET LOCAL statement_timeout = '5s';--> statement-breakpoint
 
--- Projection revisions are append-only transaction observations. They avoid
--- turning the generation registry into a row-lock mutex for every writer.
+-- Projection revisions are append-only mutation observations. The identity
+-- sequence orders mutation statements; the transaction id only coalesces
+-- repeated statements for one generation inside the same transaction.
 CREATE TABLE "corpus_index_projection_revisions" (
   "family" text NOT NULL,
   "generation" varchar(32) NOT NULL,
-  "revision" bigint NOT NULL,
+  "revision" bigint GENERATED ALWAYS AS IDENTITY
+    (SEQUENCE NAME "corpus_index_projection_revisions_revision_seq" CACHE 1) NOT NULL,
+  "transaction_id" bigint NOT NULL,
   "created_at" timestamptz DEFAULT now() NOT NULL,
   CONSTRAINT "corpus_index_projection_revisions_pkey"
     PRIMARY KEY ("family", "generation", "revision"),
@@ -14,6 +17,8 @@ CREATE TABLE "corpus_index_projection_revisions" (
     FOREIGN KEY ("family", "generation")
     REFERENCES "corpus_index_generations" ("family", "generation")
     ON DELETE CASCADE,
+  CONSTRAINT "corpus_index_projection_revisions_transaction_unique"
+    UNIQUE ("family", "generation", "transaction_id"),
   CONSTRAINT "corpus_index_projection_revisions_family_values"
     CHECK ("family" IN ('case_law','legislation')),
   CONSTRAINT "corpus_index_projection_revisions_revision_positive"
@@ -33,6 +38,8 @@ CREATE POLICY "case_law_ingestion_access"
 GRANT SELECT ON TABLE "corpus_index_projection_revisions" TO stella;--> statement-breakpoint
 GRANT SELECT, INSERT, DELETE ON TABLE "corpus_index_projection_revisions"
   TO stella_ingestion;--> statement-breakpoint
+GRANT USAGE, SELECT ON SEQUENCE
+  "corpus_index_projection_revisions_revision_seq" TO stella_ingestion;--> statement-breakpoint
 
 -- Writers share one transaction lock. Final proof and promotion take its
 -- exclusive counterpart, which waits for in-flight writers and blocks new
@@ -111,9 +118,9 @@ CREATE TRIGGER "corpus_index_generations_projection_lifecycle_fence"
   FOR EACH STATEMENT
   EXECUTE FUNCTION "fence_corpus_projection_generation_lifecycle"();--> statement-breakpoint
 
--- Existing statement triggers keep their names, but now append the current
--- transaction id once per changed generation instead of updating one shared
--- registry row. ON CONFLICT folds multiple statements in one transaction.
+-- Existing statement triggers keep their names. The sequence is deliberately
+-- CACHE 1: a proof under the exclusive fence observes a watermark that every
+-- later mutation must exceed, even when its transaction id was assigned first.
 CREATE OR REPLACE FUNCTION "bump_corpus_projection_revision_from_new"()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -122,7 +129,7 @@ SET search_path = pg_catalog, public
 AS $$
 BEGIN
   INSERT INTO public."corpus_index_projection_revisions"
-    ("family", "generation", "revision")
+    ("family", "generation", "transaction_id")
   SELECT DISTINCT
     changed."family",
     changed."generation",
@@ -141,7 +148,7 @@ SET search_path = pg_catalog, public
 AS $$
 BEGIN
   INSERT INTO public."corpus_index_projection_revisions"
-    ("family", "generation", "revision")
+    ("family", "generation", "transaction_id")
   SELECT DISTINCT
     changed."family",
     changed."generation",
@@ -160,7 +167,7 @@ SET search_path = pg_catalog, public
 AS $$
 BEGIN
   INSERT INTO public."corpus_index_projection_revisions"
-    ("family", "generation", "revision")
+    ("family", "generation", "transaction_id")
   SELECT DISTINCT
     changed."family",
     changed."generation",
@@ -184,7 +191,7 @@ SET search_path = pg_catalog, public
 AS $$
 BEGIN
   INSERT INTO public."corpus_index_projection_revisions"
-    ("family", "generation", "revision")
+    ("family", "generation", "transaction_id")
   VALUES (
     NEW."family",
     NEW."generation",
@@ -204,7 +211,7 @@ CREATE TRIGGER "corpus_index_generations_projection_revision_seed"
 
 -- stella-migration-safety: reviewed insert-select - the source is the closed, single-digit generation registry; rollback drops the new table
 INSERT INTO "corpus_index_projection_revisions"
-  ("family", "generation", "revision")
+  ("family", "generation", "transaction_id")
 SELECT
   generation."family",
   generation."generation",

--- a/apps/api/drizzle/20260901060000_concurrent_corpus_projection_revision_fence/migration.sql
+++ b/apps/api/drizzle/20260901060000_concurrent_corpus_projection_revision_fence/migration.sql
@@ -1,0 +1,213 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5s';--> statement-breakpoint
+
+-- Projection revisions are append-only transaction observations. They avoid
+-- turning the generation registry into a row-lock mutex for every writer.
+CREATE TABLE "corpus_index_projection_revisions" (
+  "family" text NOT NULL,
+  "generation" varchar(32) NOT NULL,
+  "revision" bigint NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "corpus_index_projection_revisions_pkey"
+    PRIMARY KEY ("family", "generation", "revision"),
+  CONSTRAINT "corpus_index_projection_revisions_generation_fk"
+    FOREIGN KEY ("family", "generation")
+    REFERENCES "corpus_index_generations" ("family", "generation")
+    ON DELETE CASCADE,
+  CONSTRAINT "corpus_index_projection_revisions_family_values"
+    CHECK ("family" IN ('case_law','legislation')),
+  CONSTRAINT "corpus_index_projection_revisions_revision_positive"
+    CHECK ("revision" > 0)
+);--> statement-breakpoint
+
+ALTER TABLE "corpus_index_projection_revisions"
+  ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "case_law_global_access"
+  ON "corpus_index_projection_revisions"
+  AS PERMISSIVE FOR SELECT TO stella USING (true);--> statement-breakpoint
+CREATE POLICY "case_law_ingestion_access"
+  ON "corpus_index_projection_revisions"
+  AS PERMISSIVE FOR ALL TO stella_ingestion
+  USING (true) WITH CHECK (true);--> statement-breakpoint
+
+GRANT SELECT ON TABLE "corpus_index_projection_revisions" TO stella;--> statement-breakpoint
+GRANT SELECT, INSERT, DELETE ON TABLE "corpus_index_projection_revisions"
+  TO stella_ingestion;--> statement-breakpoint
+
+-- Writers share one transaction lock. Final proof and promotion take its
+-- exclusive counterpart, which waits for in-flight writers and blocks new
+-- projection mutations until their transaction commits.
+CREATE FUNCTION "lock_corpus_projection_mutations_shared"()
+RETURNS void
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT pg_catalog.pg_advisory_xact_lock_shared(1937007986, 1);
+$$;--> statement-breakpoint
+
+CREATE FUNCTION "lock_corpus_projection_mutations_exclusive"()
+RETURNS void
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT pg_catalog.pg_advisory_xact_lock(1937007986, 1);
+$$;--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION "lock_corpus_projection_mutations_shared"()
+  FROM PUBLIC;--> statement-breakpoint
+REVOKE ALL ON FUNCTION "lock_corpus_projection_mutations_exclusive"()
+  FROM PUBLIC;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION "lock_corpus_projection_mutations_shared"()
+  TO stella_ingestion;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION "lock_corpus_projection_mutations_exclusive"()
+  TO stella_ingestion;--> statement-breakpoint
+
+CREATE FUNCTION "fence_corpus_projection_mutation"()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  PERFORM public."lock_corpus_projection_mutations_shared"();
+  RETURN NULL;
+END;
+$$;--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION "fence_corpus_projection_mutation"()
+  FROM PUBLIC;--> statement-breakpoint
+
+CREATE TRIGGER "corpus_projection_states_mutation_fence"
+  BEFORE INSERT OR UPDATE OR DELETE ON "corpus_index_projection_states"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION "fence_corpus_projection_mutation"();--> statement-breakpoint
+
+CREATE TRIGGER "corpus_projection_intents_mutation_fence"
+  BEFORE INSERT OR UPDATE OR DELETE ON "corpus_index_projection_intents"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION "fence_corpus_projection_mutation"();--> statement-breakpoint
+
+-- Generation lifecycle changes are the opposing side of the same fence. The
+-- trigger keeps direct SQL transitions from overtaking an in-flight writer.
+CREATE FUNCTION "fence_corpus_projection_generation_lifecycle"()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  PERFORM public."lock_corpus_projection_mutations_exclusive"();
+  RETURN NULL;
+END;
+$$;--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION "fence_corpus_projection_generation_lifecycle"()
+  FROM PUBLIC;--> statement-breakpoint
+
+CREATE TRIGGER "corpus_index_generations_projection_lifecycle_fence"
+  BEFORE INSERT OR UPDATE OR DELETE ON "corpus_index_generations"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION "fence_corpus_projection_generation_lifecycle"();--> statement-breakpoint
+
+-- Existing statement triggers keep their names, but now append the current
+-- transaction id once per changed generation instead of updating one shared
+-- registry row. ON CONFLICT folds multiple statements in one transaction.
+CREATE OR REPLACE FUNCTION "bump_corpus_projection_revision_from_new"()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  INSERT INTO public."corpus_index_projection_revisions"
+    ("family", "generation", "revision")
+  SELECT DISTINCT
+    changed."family",
+    changed."generation",
+    pg_catalog.pg_current_xact_id()::text::bigint
+  FROM new_rows changed
+  ON CONFLICT DO NOTHING;
+  RETURN NULL;
+END;
+$$;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION "bump_corpus_projection_revision_from_old"()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  INSERT INTO public."corpus_index_projection_revisions"
+    ("family", "generation", "revision")
+  SELECT DISTINCT
+    changed."family",
+    changed."generation",
+    pg_catalog.pg_current_xact_id()::text::bigint
+  FROM old_rows changed
+  ON CONFLICT DO NOTHING;
+  RETURN NULL;
+END;
+$$;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION "bump_corpus_projection_revision_from_update"()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  INSERT INTO public."corpus_index_projection_revisions"
+    ("family", "generation", "revision")
+  SELECT DISTINCT
+    changed."family",
+    changed."generation",
+    pg_catalog.pg_current_xact_id()::text::bigint
+  FROM (
+    SELECT "family", "generation" FROM old_rows
+    UNION
+    SELECT "family", "generation" FROM new_rows
+  ) changed
+  ON CONFLICT DO NOTHING;
+  RETURN NULL;
+END;
+$$;--> statement-breakpoint
+
+-- New generation registration creates the initial readable revision.
+CREATE FUNCTION "seed_corpus_projection_revision"()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  INSERT INTO public."corpus_index_projection_revisions"
+    ("family", "generation", "revision")
+  VALUES (
+    NEW."family",
+    NEW."generation",
+    pg_catalog.pg_current_xact_id()::text::bigint
+  );
+  RETURN NULL;
+END;
+$$;--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION "seed_corpus_projection_revision"()
+  FROM PUBLIC;--> statement-breakpoint
+
+CREATE TRIGGER "corpus_index_generations_projection_revision_seed"
+  AFTER INSERT ON "corpus_index_generations"
+  FOR EACH ROW
+  EXECUTE FUNCTION "seed_corpus_projection_revision"();--> statement-breakpoint
+
+-- stella-migration-safety: reviewed insert-select - the source is the closed, single-digit generation registry; rollback drops the new table
+INSERT INTO "corpus_index_projection_revisions"
+  ("family", "generation", "revision")
+SELECT
+  generation."family",
+  generation."generation",
+  pg_catalog.pg_current_xact_id()::text::bigint
+FROM "corpus_index_generations" generation
+ON CONFLICT DO NOTHING;

--- a/apps/api/drizzle/20260901060000_concurrent_corpus_projection_revision_fence/migration.sql
+++ b/apps/api/drizzle/20260901060000_concurrent_corpus_projection_revision_fence/migration.sql
@@ -217,4 +217,8 @@ SELECT
   generation."generation",
   pg_catalog.pg_current_xact_id()::text::bigint
 FROM "corpus_index_generations" generation
-ON CONFLICT DO NOTHING;
+ON CONFLICT DO NOTHING;--> statement-breakpoint
+
+-- stella-migration-safety: reviewed drop-column - pre-revision projection binaries are quiesced for this clean cutover; retaining the stale scalar permits unsafe proofs
+ALTER TABLE "corpus_index_generations"
+  DROP COLUMN "projection_revision";

--- a/apps/api/src/db/schema/corpus-index-generations.ts
+++ b/apps/api/src/db/schema/corpus-index-generations.ts
@@ -90,8 +90,8 @@ export const corpusIndexGenerations = p.pgTable(
 );
 
 /**
- * Transaction revisions for projection mutations. Writers append at most one
- * row per generation and transaction, so revision reads do not serialize
+ * Sequence-ordered revisions for projection mutations. Writers append at most
+ * one row per generation and transaction, so revision reads do not serialize
  * unrelated projection work on the generation registry row.
  */
 export const corpusIndexProjectionRevisions = p.pgTable(
@@ -101,7 +101,13 @@ export const corpusIndexProjectionRevisions = p.pgTable(
     generation: p
       .varchar({ length: CORPUS_INDEX_GENERATION_MAX_LENGTH })
       .notNull(),
-    revision: p.bigint({ mode: "number" }).notNull(),
+    revision: p
+      .bigint({ mode: "number" })
+      .generatedAlwaysAsIdentity({
+        name: "corpus_index_projection_revisions_revision_seq",
+        cache: 1,
+      }),
+    transactionId: p.bigint("transaction_id", { mode: "number" }).notNull(),
     createdAt: timestamptz("created_at").defaultNow().notNull(),
   },
   (t) => [
@@ -119,6 +125,9 @@ export const corpusIndexProjectionRevisions = p.pgTable(
         ],
       })
       .onDelete("cascade"),
+    p
+      .unique("corpus_index_projection_revisions_transaction_unique")
+      .on(t.family, t.generation, t.transactionId),
     p.check(
       "corpus_index_projection_revisions_family_values",
       sql`${t.family} IN (${sqlValues(CORPUS_FAMILIES)})`,

--- a/apps/api/src/db/schema/corpus-index-generations.ts
+++ b/apps/api/src/db/schema/corpus-index-generations.ts
@@ -35,6 +35,8 @@ export const corpusIndexGenerations = p.pgTable(
     cluster: p.text({ enum: QUICKWIT_CLUSTERS }).notNull(),
     manifestDigest: p.varchar("manifest_digest", { length: 64 }).notNull(),
     status: p.text({ enum: CORPUS_INDEX_GENERATION_STATUSES }).notNull(),
+    // Compatibility for pre-transaction-revision readers during rollout.
+    // Drop after those binaries have left the rollback window.
     projectionRevision: p
       .bigint("projection_revision", { mode: "number" })
       .default(1)
@@ -84,5 +86,47 @@ export const corpusIndexGenerations = p.pgTable(
     ),
     ...globalCaseLawPolicies(),
     ...publicLawReaderPolicies(),
+  ],
+);
+
+/**
+ * Transaction revisions for projection mutations. Writers append at most one
+ * row per generation and transaction, so revision reads do not serialize
+ * unrelated projection work on the generation registry row.
+ */
+export const corpusIndexProjectionRevisions = p.pgTable(
+  "corpus_index_projection_revisions",
+  {
+    family: p.text({ enum: CORPUS_FAMILIES }).notNull(),
+    generation: p
+      .varchar({ length: CORPUS_INDEX_GENERATION_MAX_LENGTH })
+      .notNull(),
+    revision: p.bigint({ mode: "number" }).notNull(),
+    createdAt: timestamptz("created_at").defaultNow().notNull(),
+  },
+  (t) => [
+    p.primaryKey({
+      name: "corpus_index_projection_revisions_pkey",
+      columns: [t.family, t.generation, t.revision],
+    }),
+    p
+      .foreignKey({
+        name: "corpus_index_projection_revisions_generation_fk",
+        columns: [t.family, t.generation],
+        foreignColumns: [
+          corpusIndexGenerations.family,
+          corpusIndexGenerations.generation,
+        ],
+      })
+      .onDelete("cascade"),
+    p.check(
+      "corpus_index_projection_revisions_family_values",
+      sql`${t.family} IN (${sqlValues(CORPUS_FAMILIES)})`,
+    ),
+    p.check(
+      "corpus_index_projection_revisions_revision_positive",
+      sql`${t.revision} > 0`,
+    ),
+    ...globalCaseLawPolicies(),
   ],
 );

--- a/apps/api/src/db/schema/corpus-index-generations.ts
+++ b/apps/api/src/db/schema/corpus-index-generations.ts
@@ -35,12 +35,6 @@ export const corpusIndexGenerations = p.pgTable(
     cluster: p.text({ enum: QUICKWIT_CLUSTERS }).notNull(),
     manifestDigest: p.varchar("manifest_digest", { length: 64 }).notNull(),
     status: p.text({ enum: CORPUS_INDEX_GENERATION_STATUSES }).notNull(),
-    // Compatibility for pre-transaction-revision readers during rollout.
-    // Drop after those binaries have left the rollback window.
-    projectionRevision: p
-      .bigint("projection_revision", { mode: "number" })
-      .default(1)
-      .notNull(),
     createdAt: timestamptz("created_at").defaultNow().notNull(),
     updatedAt: timestamptz("updated_at")
       .defaultNow()
@@ -71,10 +65,6 @@ export const corpusIndexGenerations = p.pgTable(
     p.check(
       "corpus_index_generations_manifest_digest_shape",
       sql`${t.manifestDigest} ~ '^[0-9a-f]{64}$'`,
-    ),
-    p.check(
-      "corpus_index_generations_projection_revision_positive",
-      sql`${t.projectionRevision} > 0`,
     ),
     p.check(
       "corpus_index_generations_name_matches_family",

--- a/apps/api/src/db/schema/corpus-index-generations.ts
+++ b/apps/api/src/db/schema/corpus-index-generations.ts
@@ -91,12 +91,10 @@ export const corpusIndexProjectionRevisions = p.pgTable(
     generation: p
       .varchar({ length: CORPUS_INDEX_GENERATION_MAX_LENGTH })
       .notNull(),
-    revision: p
-      .bigint({ mode: "number" })
-      .generatedAlwaysAsIdentity({
-        name: "corpus_index_projection_revisions_revision_seq",
-        cache: 1,
-      }),
+    revision: p.bigint({ mode: "number" }).generatedAlwaysAsIdentity({
+      name: "corpus_index_projection_revisions_revision_seq",
+      cache: 1,
+    }),
     transactionId: p.bigint("transaction_id", { mode: "number" }).notNull(),
     createdAt: timestamptz("created_at").defaultNow().notNull(),
   },

--- a/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-desired-state.ts
@@ -26,6 +26,7 @@ import {
   type CorpusIndexProjectionInput,
   type LegislationV2ProjectionInput,
 } from "@/api/lib/legal-search/corpus-index-projection-descriptor";
+import { lockCorpusIndexProjectionWriterTx } from "@/api/lib/legal-search/corpus-index-projection-revision";
 import { isRedistributable } from "@/api/lib/legal-search/corpus-source";
 
 const CORPUS_INDEX_MANIFEST_COUNT = Object.keys(CORPUS_INDEX_MANIFESTS).length;
@@ -506,6 +507,7 @@ const activeManifests = async (
   tx: Transaction,
   family: CorpusIndexProjectionSubject["family"],
 ): Promise<RegisteredManifest[]> => {
+  await lockCorpusIndexProjectionWriterTx(tx);
   const rows = await tx
     .select()
     .from(corpusIndexGenerations)
@@ -523,8 +525,7 @@ const activeManifests = async (
       ),
     )
     .orderBy(asc(corpusIndexGenerations.generation))
-    .limit(CORPUS_INDEX_MANIFEST_COUNT + 1)
-    .for("update");
+    .limit(CORPUS_INDEX_MANIFEST_COUNT + 1);
   if (rows.length > CORPUS_INDEX_MANIFEST_COUNT) {
     return panic(`Active corpus generation registry exceeds its manifest set`);
   }
@@ -564,16 +565,15 @@ export const readActiveCorpusProjectionManifest = async (
 };
 
 /**
- * Validate an active manifest while taking the generation-local mutation
- * fence. Every projection state or intent mutation must take this lock before
- * its first projection-row lock so statement-trigger revision bumps cannot
- * deadlock while upgrading shared generation locks.
+ * Validate an active manifest while joining the transaction-scoped mutation
+ * fence. The database triggers enforce the same fence at the write boundary.
  */
 export const lockActiveCorpusProjectionManifestForMutation = async (
   tx: Transaction,
   family: CorpusIndexProjectionSubject["family"],
   generation: string,
 ): Promise<CorpusIndexManifest> => {
+  await lockCorpusIndexProjectionWriterTx(tx);
   const rows = await tx
     .select()
     .from(corpusIndexGenerations)
@@ -587,8 +587,7 @@ export const lockActiveCorpusProjectionManifestForMutation = async (
         ),
       ),
     )
-    .limit(1)
-    .for("update");
+    .limit(1);
   const row = rows.at(0);
   if (row === undefined) {
     return panic(
@@ -600,8 +599,8 @@ export const lockActiveCorpusProjectionManifestForMutation = async (
 
 /**
  * Cleanup outlives serving eligibility. Retiring generations can still carry
- * unknown append outcomes, so cleanup verifies and share-locks their immutable
- * registered manifest without requiring an active lifecycle status.
+ * unknown append outcomes, so cleanup verifies their immutable registered
+ * manifest without requiring an active lifecycle status.
  */
 export const readRegisteredCorpusProjectionManifestForCleanup = async (
   tx: Transaction,
@@ -617,8 +616,7 @@ export const readRegisteredCorpusProjectionManifestForCleanup = async (
         eq(corpusIndexGenerations.generation, generation),
       ),
     )
-    .limit(1)
-    .for("share");
+    .limit(1);
   const row = rows.at(0);
   if (row === undefined) {
     return panic(
@@ -628,12 +626,13 @@ export const readRegisteredCorpusProjectionManifestForCleanup = async (
   return requireRegisteredCorpusIndexManifest(row);
 };
 
-/** Lock a registered generation before mutating cleanup or retirement state. */
+/** Validate a registered generation while joining the mutation fence. */
 export const lockRegisteredCorpusProjectionManifestForMutation = async (
   tx: Transaction,
   family: CorpusIndexProjectionSubject["family"],
   generation: string,
 ): Promise<CorpusIndexManifest> => {
+  await lockCorpusIndexProjectionWriterTx(tx);
   const rows = await tx
     .select()
     .from(corpusIndexGenerations)
@@ -643,8 +642,7 @@ export const lockRegisteredCorpusProjectionManifestForMutation = async (
         eq(corpusIndexGenerations.generation, generation),
       ),
     )
-    .limit(1)
-    .for("update");
+    .limit(1);
   const row = rows.at(0);
   if (row === undefined) {
     return panic(
@@ -878,6 +876,7 @@ export const ensureCorpusProjectionDesiredStateTx = async (
   generation: string,
 ): Promise<{ epoch: bigint; created: boolean }> => {
   const locked = await lockProjectionInput(tx, subject);
+  await lockCorpusIndexProjectionWriterTx(tx);
   const generationRows = await tx
     .select()
     .from(corpusIndexGenerations)
@@ -891,8 +890,7 @@ export const ensureCorpusProjectionDesiredStateTx = async (
         ),
       ),
     )
-    .limit(1)
-    .for("update");
+    .limit(1);
   const generationRow = generationRows.at(0);
   if (generationRow === undefined) {
     return panic(

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.db.test.ts
@@ -6,6 +6,7 @@ import type { Transaction } from "@/api/db/root";
 import {
   corpusIndexGenerations,
   corpusIndexProjectionIntents,
+  corpusIndexProjectionRevisions,
   corpusIndexProjectionStates,
 } from "@/api/db/schema";
 import { toSafeId } from "@/api/lib/branded-types";
@@ -38,19 +39,16 @@ const LEGISLATION_TARGET = {
   family: "legislation",
   generation: "legislation_v2",
 } as const;
-const MIGRATION_URL = new URL(
-  "../../../drizzle/20260826004100_corpus_projection_revision_fence/migration.sql",
-  import.meta.url,
-);
-
 let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
 
 const revision = async (): Promise<number> => {
   const rows = await db
-    .select({ value: corpusIndexGenerations.projectionRevision })
-    .from(corpusIndexGenerations)
-    .where(eq(corpusIndexGenerations.generation, TARGET.generation));
+    .select({ value: corpusIndexProjectionRevisions.revision })
+    .from(corpusIndexProjectionRevisions)
+    .where(eq(corpusIndexProjectionRevisions.generation, TARGET.generation))
+    .orderBy(sql`${corpusIndexProjectionRevisions.revision} DESC`)
+    .limit(1);
   return rows.at(0)?.value ?? 0;
 };
 
@@ -58,19 +56,6 @@ beforeAll(
   async () => {
     client = await createTestPglite();
     db = drizzle({ client });
-    const migration = await Bun.file(MIGRATION_URL).text();
-    for (const statement of migration.split("--> statement-breakpoint")) {
-      const ddl = statement.trim();
-      if (
-        !/(?:^|\n)\s*CREATE FUNCTION\b/u.test(ddl) &&
-        !/(?:^|\n)\s*REVOKE ALL ON FUNCTION\b/u.test(ddl) &&
-        !/(?:^|\n)\s*CREATE TRIGGER\b/u.test(ddl)
-      ) {
-        continue;
-      }
-      // oxlint-disable-next-line no-await-in-loop -- each trigger depends on its preceding production function and privilege statement
-      await db.execute(sql.raw(ddl));
-    }
     await db.insert(corpusIndexGenerations).values({
       ...TARGET,
       cluster: "q09",
@@ -85,8 +70,9 @@ afterAll(async () => {
   await client.close();
 });
 
-test("projection mutations advance one durable revision per statement", async () => {
-  expect(await revision()).toBe(1);
+test("projection mutations advance one durable revision per transaction", async () => {
+  const initialRevision = await revision();
+  expect(initialRevision).toBeGreaterThan(0);
 
   await db.insert(corpusIndexProjectionStates).values([
     {
@@ -102,7 +88,8 @@ test("projection mutations advance one durable revision per statement", async ()
       desiredEpoch: 1n,
     },
   ]);
-  expect(await revision()).toBe(2);
+  const stateRevision = await revision();
+  expect(stateRevision).toBeGreaterThan(initialRevision);
 
   await db.insert(corpusIndexProjectionIntents).values({
     id: INTENT_ID,
@@ -114,18 +101,21 @@ test("projection mutations advance one durable revision per statement", async ()
     status: "cancelled",
     cancelledAt: new Date("2026-08-26T00:00:00.000Z"),
   });
-  expect(await revision()).toBe(3);
+  const intentRevision = await revision();
+  expect(intentRevision).toBeGreaterThan(stateRevision);
 
   await db
     .update(corpusIndexProjectionStates)
     .set({ updatedAt: new Date("2026-08-26T00:00:01.000Z") })
     .where(eq(corpusIndexProjectionStates.family, TARGET.family));
-  expect(await revision()).toBe(4);
+  const updateRevision = await revision();
+  expect(updateRevision).toBeGreaterThan(intentRevision);
 
   await db
     .delete(corpusIndexProjectionIntents)
     .where(eq(corpusIndexProjectionIntents.id, INTENT_ID));
-  expect(await revision()).toBe(5);
+  const deleteRevision = await revision();
+  expect(deleteRevision).toBeGreaterThan(updateRevision);
 
   await db
     .update(corpusIndexProjectionStates)
@@ -136,7 +126,28 @@ test("projection mutations advance one durable revision per statement", async ()
         "0198e331-e578-7000-8000-000000000599",
       ),
     );
-  expect(await revision()).toBe(5);
+  expect(await revision()).toBe(deleteRevision);
+});
+
+test("multiple statements in one transaction share one revision", async () => {
+  const before = await revision();
+  await db.transaction(async (tx) => {
+    await tx
+      .update(corpusIndexProjectionStates)
+      .set({ updatedAt: new Date("2026-08-26T00:00:03.000Z") })
+      .where(eq(corpusIndexProjectionStates.entityId, ENTITY_IDS[0]));
+    await tx
+      .update(corpusIndexProjectionStates)
+      .set({ updatedAt: new Date("2026-08-26T00:00:04.000Z") })
+      .where(eq(corpusIndexProjectionStates.entityId, ENTITY_IDS[1]));
+  });
+  const after = await revision();
+  expect(after).toBeGreaterThan(before);
+  const rows = await db
+    .select({ revision: corpusIndexProjectionRevisions.revision })
+    .from(corpusIndexProjectionRevisions)
+    .where(eq(corpusIndexProjectionRevisions.generation, TARGET.generation));
+  expect(rows.filter(({ revision: value }) => value === after)).toHaveLength(1);
 });
 
 test("the revision shares the projection mutation transaction", async () => {
@@ -147,7 +158,7 @@ test("the revision shares the projection mutation transaction", async () => {
     .transaction(async (tx) => {
       await tx
         .update(corpusIndexProjectionStates)
-        .set({ updatedAt: new Date("2026-08-26T00:00:03.000Z") })
+        .set({ updatedAt: new Date("2026-08-26T00:00:05.000Z") })
         .where(eq(corpusIndexProjectionStates.entityId, ENTITY_IDS[0]));
       throw new Error("roll back revision fixture");
     })
@@ -159,6 +170,18 @@ test("the revision shares the projection mutation transaction", async () => {
   expect(rejection).toBeInstanceOf(Error);
   expect(rejection).toMatchObject({ message: "roll back revision fixture" });
   expect(await revision()).toBe(beforeRollback);
+});
+
+test("the ingestion role records revisions through the trigger boundary", async () => {
+  const before = await revision();
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL ROLE stella_ingestion`);
+    await tx
+      .update(corpusIndexProjectionStates)
+      .set({ updatedAt: new Date("2026-08-26T00:00:06.000Z") })
+      .where(eq(corpusIndexProjectionStates.entityId, ENTITY_IDS[0]));
+  });
+  expect(await revision()).toBeGreaterThan(before);
 });
 
 test("the typed read and proof boundaries return the current revision", async () => {
@@ -173,9 +196,15 @@ test("the typed read and proof boundaries return the current revision", async ()
   expect(read).toBe(await revision());
   expect(locked).toBe(read);
   expect(promotion).toBe(read);
+  expect(
+    await db
+      .select({ revision: corpusIndexProjectionRevisions.revision })
+      .from(corpusIndexProjectionRevisions)
+      .where(eq(corpusIndexProjectionRevisions.generation, TARGET.generation)),
+  ).toHaveLength(1);
 });
 
-test("mutation fences lock registered generations in a stable order", async () => {
+test("mutation fences validate registered targets in any caller order", async () => {
   await db.insert(corpusIndexGenerations).values({
     ...LEGISLATION_TARGET,
     cluster: "q09",
@@ -190,7 +219,7 @@ test("mutation fences lock registered generations in a stable order", async () =
     fingerprint: "d".repeat(64),
     indexId: "case_law_v5_cs_sk",
     status: "cancelled",
-    cancelledAt: new Date("2026-08-26T00:00:04.000Z"),
+    cancelledAt: new Date("2026-08-26T00:00:07.000Z"),
   });
 
   await db.transaction(async (tx) => {

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   lockCorpusIndexProjectionMutationsTx,
   lockCorpusIndexProjectionPromotionTx,
+  readCorpusIndexProjectionRevisionTx,
 } from "./corpus-index-projection-revision";
 
 const databaseUrl = process.env["DATABASE_URL"];
@@ -326,6 +327,168 @@ if (!databaseUrl || !runPostgresTests) {
             ),
           );
         await Promise.all([writerClient.close(), promotionClient.close()]);
+      }
+    });
+
+    test("a transaction with an older id cannot hide a post-proof mutation", async () => {
+      const olderClient = new SQL({ url: databaseUrl, max: 1 });
+      const newerClient = new SQL({ url: databaseUrl, max: 1 });
+      const proofClient = new SQL({ url: databaseUrl, max: 1 });
+      const olderDb = drizzle({
+        client: olderClient,
+        relations: databaseRelations,
+      });
+      const newerDb = drizzle({
+        client: newerClient,
+        relations: databaseRelations,
+      });
+      const proofDb = drizzle({
+        client: proofClient,
+        relations: databaseRelations,
+      });
+      const suffix = Date.now();
+      const target = {
+        family: "case_law",
+        generation: `case_law_v${suffix}`,
+      } as const;
+      const sourceId = toSafeId<"caseLawSource">(Bun.randomUUIDv7());
+      const entityIds = [
+        toSafeId<"caseLawDecision">(Bun.randomUUIDv7()),
+        toSafeId<"caseLawDecision">(Bun.randomUUIDv7()),
+      ] as const;
+      const allowOlderMutation = Promise.withResolvers<undefined>();
+      const olderIdAssigned = Promise.withResolvers<number>();
+      const olderMutationAttempted = Promise.withResolvers<undefined>();
+      const olderMutationFinished = Promise.withResolvers<undefined>();
+      const releaseProof = Promise.withResolvers<undefined>();
+      const proofLocked = Promise.withResolvers<undefined>();
+      const activeTransactions = new Set<Promise<unknown>>();
+
+      try {
+        await olderDb.insert(caseLawSources).values({
+          id: sourceId,
+          adapterKey: `projection-revision-order-${suffix}`,
+          name: "Projection revision order",
+        });
+        await olderDb.insert(caseLawDecisions).values(
+          entityIds.map((id, index) => ({
+            id,
+            sourceId,
+            caseNumber: `projection-revision-order-${suffix}-${index}`,
+            court: "Projection revision court",
+            country: "CZE",
+            language: "cs",
+            projectionEpoch: 1n,
+          })),
+        );
+        await olderDb.insert(corpusIndexGenerations).values({
+          ...target,
+          cluster: "q09",
+          manifestDigest: "1".repeat(64),
+          status: "building",
+        });
+
+        const olderMutation = olderDb.transaction(async (tx) => {
+          await tx.execute(sql`SET LOCAL statement_timeout = '5s'`);
+          const [row] = await tx.execute(sql<{ transactionId: string }>`
+            SELECT pg_current_xact_id()::text AS "transactionId"
+          `);
+          const transactionId = Number(row?.transactionId);
+          expect(Number.isSafeInteger(transactionId)).toBe(true);
+          olderIdAssigned.resolve(transactionId);
+          await allowOlderMutation.promise;
+          olderMutationAttempted.resolve(undefined);
+          await tx.insert(corpusIndexProjectionStates).values({
+            ...target,
+            entityId: entityIds[1],
+            desiredAction: "erase",
+            desiredEpoch: 1n,
+          });
+          olderMutationFinished.resolve(undefined);
+        });
+        activeTransactions.add(olderMutation);
+        const olderTransactionId = await olderIdAssigned.promise;
+
+        const newerTransactionId = await newerDb.transaction(async (tx) => {
+          const [row] = await tx.execute(sql<{ transactionId: string }>`
+            SELECT pg_current_xact_id()::text AS "transactionId"
+          `);
+          await tx.insert(corpusIndexProjectionStates).values({
+            ...target,
+            entityId: entityIds[0],
+            desiredAction: "erase",
+            desiredEpoch: 1n,
+          });
+          return Number(row?.transactionId);
+        });
+        expect(newerTransactionId).toBeGreaterThan(olderTransactionId);
+
+        const proof = proofDb.transaction(async (tx) => {
+          await tx.execute(sql`SET LOCAL statement_timeout = '5s'`);
+          const proofRevision = await lockCorpusIndexProjectionPromotionTx(
+            tx,
+            target,
+          );
+          proofLocked.resolve(undefined);
+          await releaseProof.promise;
+          return proofRevision;
+        });
+        activeTransactions.add(proof);
+        await proofLocked.promise;
+        allowOlderMutation.resolve(undefined);
+        await olderMutationAttempted.promise;
+        const mutationOvertookProof = await Promise.race([
+          olderMutationFinished.promise.then(() => true),
+          Bun.sleep(100).then(() => false),
+        ]);
+        expect(mutationOvertookProof).toBe(false);
+
+        releaseProof.resolve(undefined);
+        const [proofRevision] = await Promise.all([proof, olderMutation]);
+        const finalRevision = await proofDb.transaction(
+          async (tx) => await readCorpusIndexProjectionRevisionTx(tx, target),
+        );
+        expect(finalRevision).toBeGreaterThan(proofRevision);
+      } finally {
+        allowOlderMutation.resolve(undefined);
+        releaseProof.resolve(undefined);
+        await Promise.allSettled(activeTransactions);
+        await olderDb
+          .update(corpusIndexGenerations)
+          .set({ status: "retired" })
+          .where(
+            and(
+              eq(corpusIndexGenerations.family, target.family),
+              eq(corpusIndexGenerations.generation, target.generation),
+            ),
+          );
+        await olderDb
+          .delete(corpusIndexProjectionStates)
+          .where(
+            and(
+              eq(corpusIndexProjectionStates.family, target.family),
+              eq(corpusIndexProjectionStates.generation, target.generation),
+            ),
+          );
+        await olderDb
+          .delete(caseLawDecisions)
+          .where(inArray(caseLawDecisions.id, entityIds));
+        await olderDb
+          .delete(caseLawSources)
+          .where(eq(caseLawSources.id, sourceId));
+        await olderDb
+          .delete(corpusIndexGenerations)
+          .where(
+            and(
+              eq(corpusIndexGenerations.family, target.family),
+              eq(corpusIndexGenerations.generation, target.generation),
+            ),
+          );
+        await Promise.all([
+          olderClient.close(),
+          newerClient.close(),
+          proofClient.close(),
+        ]);
       }
     });
 

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
@@ -8,7 +8,6 @@ import {
   caseLawDecisions,
   caseLawSources,
   corpusIndexGenerations,
-  corpusIndexProjectionIntents,
   corpusIndexProjectionStates,
   legislationDocuments,
   legislationSources,
@@ -236,16 +235,28 @@ if (!databaseUrl || !runPostgresTests) {
         family: "case_law",
         generation: `case_law_v${Date.now()}`,
       } as const;
+      const sourceId = toSafeId<"caseLawSource">(Bun.randomUUIDv7());
       const entityId = toSafeId<"caseLawDecision">(Bun.randomUUIDv7());
-      const intentId = toSafeId<"corpusIndexProjectionIntent">(
-        Bun.randomUUIDv7(),
-      );
       const writerLocked = Promise.withResolvers<undefined>();
       const releaseWriter = Promise.withResolvers<undefined>();
       const promotionAttempted = Promise.withResolvers<undefined>();
       const promotionLocked = Promise.withResolvers<undefined>();
 
       try {
+        await writerDb.insert(caseLawSources).values({
+          id: sourceId,
+          adapterKey: `projection-promotion-fence-${Date.now()}`,
+          name: "Projection promotion fence",
+        });
+        await writerDb.insert(caseLawDecisions).values({
+          id: entityId,
+          sourceId,
+          caseNumber: `projection-promotion-fence-${Date.now()}`,
+          court: "Projection fence court",
+          country: "CZE",
+          language: "cs",
+          projectionEpoch: 1n,
+        });
         await writerDb.insert(corpusIndexGenerations).values({
           ...target,
           cluster: "q09",
@@ -254,15 +265,11 @@ if (!databaseUrl || !runPostgresTests) {
         });
         const writer = writerDb.transaction(async (tx) => {
           await tx.execute(sql`SET LOCAL statement_timeout = '5s'`);
-          await tx.insert(corpusIndexProjectionIntents).values({
+          await tx.insert(corpusIndexProjectionStates).values({
             ...target,
-            id: intentId,
             entityId,
-            epoch: 1n,
-            fingerprint: "a".repeat(64),
-            indexId: "case_law_v5_cs_sk",
-            status: "cancelled",
-            cancelledAt: new Date("2026-09-01T00:00:00.000Z"),
+            desiredAction: "erase",
+            desiredEpoch: 1n,
           });
           writerLocked.resolve(undefined);
           await releaseWriter.promise;
@@ -288,8 +295,28 @@ if (!databaseUrl || !runPostgresTests) {
       } finally {
         releaseWriter.resolve(undefined);
         await writerDb
-          .delete(corpusIndexProjectionIntents)
-          .where(eq(corpusIndexProjectionIntents.id, intentId));
+          .update(corpusIndexGenerations)
+          .set({ status: "retired" })
+          .where(
+            and(
+              eq(corpusIndexGenerations.family, target.family),
+              eq(corpusIndexGenerations.generation, target.generation),
+            ),
+          );
+        await writerDb
+          .delete(corpusIndexProjectionStates)
+          .where(
+            and(
+              eq(corpusIndexProjectionStates.family, target.family),
+              eq(corpusIndexProjectionStates.generation, target.generation),
+            ),
+          );
+        await writerDb
+          .delete(caseLawDecisions)
+          .where(eq(caseLawDecisions.id, entityId));
+        await writerDb
+          .delete(caseLawSources)
+          .where(eq(caseLawSources.id, sourceId));
         await writerDb
           .delete(corpusIndexGenerations)
           .where(

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
@@ -20,7 +20,10 @@ import {
   reconcileCorpusProjectionDesiredStateTx,
 } from "@/api/lib/legal-search/corpus-index-projection-desired-state";
 
-import { lockCorpusIndexProjectionMutationsTx } from "./corpus-index-projection-revision";
+import {
+  lockCorpusIndexProjectionMutationsTx,
+  lockCorpusIndexProjectionPromotionTx,
+} from "./corpus-index-projection-revision";
 
 const databaseUrl = process.env["DATABASE_URL"];
 const runPostgresTests = process.env["STELLA_RUN_POSTGRES_TESTS"] === "true";
@@ -33,7 +36,7 @@ if (!databaseUrl || !runPostgresTests) {
   });
 } else {
   describe("corpus projection mutation fence (postgres)", () => {
-    test("opposite target orders serialize without deadlocking", async () => {
+    test("opposite target orders can mutate concurrently", async () => {
       const firstClient = new SQL({ url: databaseUrl, max: 1 });
       const secondClient = new SQL({ url: databaseUrl, max: 1 });
       const firstDb = drizzle({
@@ -182,7 +185,7 @@ if (!databaseUrl || !runPostgresTests) {
           secondFenceAcquired.promise.then(() => true),
           Bun.sleep(100).then(() => false),
         ]);
-        expect(acquiredWhileFirstHeld).toBe(false);
+        expect(acquiredWhileFirstHeld).toBe(true);
 
         releaseFirstFence.resolve(undefined);
         const results = await Promise.allSettled([
@@ -214,6 +217,80 @@ if (!databaseUrl || !runPostgresTests) {
           .where(eq(legislationSources.id, legislationSourceId));
         await firstDb.delete(corpusIndexGenerations).where(generationPredicate);
         await Promise.all([firstClient.close(), secondClient.close()]);
+      }
+    });
+
+    test("promotion waits for every in-flight mutation", async () => {
+      const writerClient = new SQL({ url: databaseUrl, max: 1 });
+      const promotionClient = new SQL({ url: databaseUrl, max: 1 });
+      const writerDb = drizzle({
+        client: writerClient,
+        relations: databaseRelations,
+      });
+      const promotionDb = drizzle({
+        client: promotionClient,
+        relations: databaseRelations,
+      });
+      const target = {
+        family: "case_law",
+        generation: `case_law_v${Date.now()}`,
+      } as const;
+      const entityId = toSafeId<"caseLawDecision">(Bun.randomUUIDv7());
+      const writerLocked = Promise.withResolvers<undefined>();
+      const releaseWriter = Promise.withResolvers<undefined>();
+      const promotionAttempted = Promise.withResolvers<undefined>();
+      const promotionLocked = Promise.withResolvers<undefined>();
+
+      try {
+        await writerDb.insert(corpusIndexGenerations).values({
+          ...target,
+          cluster: "q09",
+          manifestDigest: "f".repeat(64),
+          status: "building",
+        });
+        const writer = writerDb.transaction(async (tx) => {
+          await tx.execute(sql`SET LOCAL statement_timeout = '5s'`);
+          await tx.insert(corpusIndexProjectionStates).values({
+            ...target,
+            entityId,
+            desiredAction: "erase",
+            desiredEpoch: 1n,
+          });
+          writerLocked.resolve(undefined);
+          await releaseWriter.promise;
+        });
+        await writerLocked.promise;
+
+        const promotion = promotionDb.transaction(async (tx) => {
+          await tx.execute(sql`SET LOCAL statement_timeout = '5s'`);
+          promotionAttempted.resolve(undefined);
+          await lockCorpusIndexProjectionPromotionTx(tx, target);
+          promotionLocked.resolve(undefined);
+        });
+        await promotionAttempted.promise;
+
+        const overtookWriter = await Promise.race([
+          promotionLocked.promise.then(() => true),
+          Bun.sleep(100).then(() => false),
+        ]);
+        expect(overtookWriter).toBe(false);
+
+        releaseWriter.resolve(undefined);
+        await Promise.all([writer, promotion]);
+      } finally {
+        releaseWriter.resolve(undefined);
+        await writerDb
+          .delete(corpusIndexProjectionStates)
+          .where(eq(corpusIndexProjectionStates.entityId, entityId));
+        await writerDb
+          .delete(corpusIndexGenerations)
+          .where(
+            and(
+              eq(corpusIndexGenerations.family, target.family),
+              eq(corpusIndexGenerations.generation, target.generation),
+            ),
+          );
+        await Promise.all([writerClient.close(), promotionClient.close()]);
       }
     });
 

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
@@ -393,7 +393,7 @@ if (!databaseUrl || !runPostgresTests) {
           const [row] = await tx.execute(sql<{ transactionId: string }>`
             SELECT pg_current_xact_id()::text AS "transactionId"
           `);
-          const transactionId = Number(row?.transactionId);
+          const transactionId = Number(row?.["transactionId"]);
           expect(Number.isSafeInteger(transactionId)).toBe(true);
           olderIdAssigned.resolve(transactionId);
           await allowOlderMutation.promise;
@@ -419,7 +419,7 @@ if (!databaseUrl || !runPostgresTests) {
             desiredAction: "erase",
             desiredEpoch: 1n,
           });
-          return Number(row?.transactionId);
+          return Number(row?.["transactionId"]);
         });
         expect(newerTransactionId).toBeGreaterThan(olderTransactionId);
 

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.postgres.test.ts
@@ -8,6 +8,7 @@ import {
   caseLawDecisions,
   caseLawSources,
   corpusIndexGenerations,
+  corpusIndexProjectionIntents,
   corpusIndexProjectionStates,
   legislationDocuments,
   legislationSources,
@@ -236,6 +237,9 @@ if (!databaseUrl || !runPostgresTests) {
         generation: `case_law_v${Date.now()}`,
       } as const;
       const entityId = toSafeId<"caseLawDecision">(Bun.randomUUIDv7());
+      const intentId = toSafeId<"corpusIndexProjectionIntent">(
+        Bun.randomUUIDv7(),
+      );
       const writerLocked = Promise.withResolvers<undefined>();
       const releaseWriter = Promise.withResolvers<undefined>();
       const promotionAttempted = Promise.withResolvers<undefined>();
@@ -250,11 +254,15 @@ if (!databaseUrl || !runPostgresTests) {
         });
         const writer = writerDb.transaction(async (tx) => {
           await tx.execute(sql`SET LOCAL statement_timeout = '5s'`);
-          await tx.insert(corpusIndexProjectionStates).values({
+          await tx.insert(corpusIndexProjectionIntents).values({
             ...target,
+            id: intentId,
             entityId,
-            desiredAction: "erase",
-            desiredEpoch: 1n,
+            epoch: 1n,
+            fingerprint: "a".repeat(64),
+            indexId: "case_law_v5_cs_sk",
+            status: "cancelled",
+            cancelledAt: new Date("2026-09-01T00:00:00.000Z"),
           });
           writerLocked.resolve(undefined);
           await releaseWriter.promise;
@@ -280,8 +288,8 @@ if (!databaseUrl || !runPostgresTests) {
       } finally {
         releaseWriter.resolve(undefined);
         await writerDb
-          .delete(corpusIndexProjectionStates)
-          .where(eq(corpusIndexProjectionStates.entityId, entityId));
+          .delete(corpusIndexProjectionIntents)
+          .where(eq(corpusIndexProjectionIntents.id, intentId));
         await writerDb
           .delete(corpusIndexGenerations)
           .where(

--- a/apps/api/src/lib/legal-search/corpus-index-projection-revision.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-revision.ts
@@ -1,10 +1,11 @@
 import { panic } from "better-result";
-import { and, asc, eq, inArray, or } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, or, sql } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db/root";
 import {
   corpusIndexGenerations,
   corpusIndexProjectionIntents,
+  corpusIndexProjectionRevisions,
 } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import type { CorpusFamily } from "@/api/lib/legal-search/corpus-generation-contract";
@@ -13,6 +14,8 @@ type CorpusProjectionRevisionTarget = {
   family: CorpusFamily;
   generation: string;
 };
+
+const CORPUS_PROJECTION_REVISION_PRUNE_LIMIT = 1000;
 
 const targetKey = ({ family, generation }: CorpusProjectionRevisionTarget) =>
   `${family}/${generation}`;
@@ -36,14 +39,15 @@ const projectionRevisionQuery = (
   target: CorpusProjectionRevisionTarget,
 ) =>
   tx
-    .select({ projectionRevision: corpusIndexGenerations.projectionRevision })
-    .from(corpusIndexGenerations)
+    .select({ projectionRevision: corpusIndexProjectionRevisions.revision })
+    .from(corpusIndexProjectionRevisions)
     .where(
       and(
-        eq(corpusIndexGenerations.family, target.family),
-        eq(corpusIndexGenerations.generation, target.generation),
+        eq(corpusIndexProjectionRevisions.family, target.family),
+        eq(corpusIndexProjectionRevisions.generation, target.generation),
       ),
     )
+    .orderBy(desc(corpusIndexProjectionRevisions.revision))
     .limit(1);
 
 const requireProjectionRevision = (
@@ -63,17 +67,26 @@ const requireProjectionRevision = (
   return revision;
 };
 
-/** Read the mutation clock without holding its row lock across engine I/O. */
+/** Read the latest committed mutation without holding a proof fence. */
 export const readCorpusIndexProjectionRevisionTx = async (
   tx: Transaction,
   target: CorpusProjectionRevisionTarget,
 ): Promise<number> =>
   requireProjectionRevision(await projectionRevisionQuery(tx, target), target);
 
+/** Join the database-enforced writer side of the projection mutation fence. */
+export const lockCorpusIndexProjectionWriterTx = async (
+  tx: Transaction,
+): Promise<void> => {
+  await tx.execute(
+    sql`SELECT public.lock_corpus_projection_mutations_shared()`,
+  );
+};
+
 /**
- * Acquire generation mutation fences in one stable order before any projection
- * state or intent row is locked. Revision triggers then update rows already
- * owned by the transaction instead of attempting a deadlock-prone lock upgrade.
+ * Join the shared mutation fence, then validate every target without locking
+ * the generation registry. Projection-table triggers enforce the same fence
+ * for writes that do not pass through this helper.
  */
 export const lockCorpusIndexProjectionMutationsTx = async (
   tx: Transaction,
@@ -83,6 +96,7 @@ export const lockCorpusIndexProjectionMutationsTx = async (
   if (ordered.length === 0) {
     return panic("Corpus projection mutation requires a generation target");
   }
+  await lockCorpusIndexProjectionWriterTx(tx);
   const predicate = or(
     ...ordered.map(({ family, generation }) =>
       and(
@@ -94,7 +108,7 @@ export const lockCorpusIndexProjectionMutationsTx = async (
   if (predicate === undefined) {
     return panic("Corpus projection mutation target predicate is empty");
   }
-  const locked = await tx
+  const registered = await tx
     .select({
       family: corpusIndexGenerations.family,
       generation: corpusIndexGenerations.generation,
@@ -105,11 +119,10 @@ export const lockCorpusIndexProjectionMutationsTx = async (
       asc(corpusIndexGenerations.family),
       asc(corpusIndexGenerations.generation),
     )
-    .limit(ordered.length)
-    .for("update");
+    .limit(ordered.length);
   if (
-    locked.length !== ordered.length ||
-    locked.some((target, index) => {
+    registered.length !== ordered.length ||
+    registered.some((target, index) => {
       const expected = ordered.at(index);
       return (
         expected === undefined || targetKey(target) !== targetKey(expected)
@@ -118,6 +131,40 @@ export const lockCorpusIndexProjectionMutationsTx = async (
   ) {
     return panic("Corpus projection mutation generation is not registered");
   }
+};
+
+const pruneCorpusIndexProjectionRevisionsTx = async (
+  tx: Transaction,
+  target: CorpusProjectionRevisionTarget,
+  currentRevision: number,
+): Promise<void> => {
+  await tx.execute(sql`
+    DELETE FROM ${corpusIndexProjectionRevisions} revision
+    WHERE revision.ctid IN (
+      SELECT candidate.ctid
+      FROM ${corpusIndexProjectionRevisions} candidate
+      WHERE candidate.family = ${target.family}
+        AND candidate.generation = ${target.generation}
+        AND candidate.revision < ${currentRevision}
+      ORDER BY candidate.revision
+      LIMIT ${CORPUS_PROJECTION_REVISION_PRUNE_LIMIT}
+    )
+  `);
+};
+
+const lockCorpusIndexProjectionExclusiveTx = async (
+  tx: Transaction,
+  target: CorpusProjectionRevisionTarget,
+): Promise<number> => {
+  await tx.execute(
+    sql`SELECT public.lock_corpus_projection_mutations_exclusive()`,
+  );
+  const revision = requireProjectionRevision(
+    await projectionRevisionQuery(tx, target),
+    target,
+  );
+  await pruneCorpusIndexProjectionRevisionsTx(tx, target, revision);
+  return revision;
 };
 
 export const lockCorpusIndexProjectionIntentMutationsTx = async (
@@ -143,29 +190,19 @@ export const lockCorpusIndexProjectionIntentMutationsTx = async (
 };
 
 /**
- * Fence a generation's desired/applied state at one exact mutation revision.
- * Projection-table statement triggers need an exclusive lock on this row, so
- * they cannot commit across a transaction that holds this proof through flip.
+ * Fence desired/applied state at one exact mutation revision. The exclusive
+ * transaction fence waits for every writer and prevents a new projection
+ * mutation from committing across the proof transaction.
  */
 export const lockCorpusIndexProjectionRevisionTx = async (
   tx: Transaction,
   target: CorpusProjectionRevisionTarget,
-): Promise<number> =>
-  requireProjectionRevision(
-    await projectionRevisionQuery(tx, target).for("share"),
-    target,
-  );
+): Promise<number> => await lockCorpusIndexProjectionExclusiveTx(tx, target);
 
 /**
- * Serialize explicit promotion before its final proof and serving flip. This
- * avoids two operators taking shared proofs and deadlocking while both try to
- * upgrade the generation row for the transition.
+ * Serialize explicit promotion before its final proof and serving flip.
  */
 export const lockCorpusIndexProjectionPromotionTx = async (
   tx: Transaction,
   target: CorpusProjectionRevisionTarget,
-): Promise<number> =>
-  requireProjectionRevision(
-    await projectionRevisionQuery(tx, target).for("update"),
-    target,
-  );
+): Promise<number> => await lockCorpusIndexProjectionExclusiveTx(tx, target);

--- a/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-projection-store.db.test.ts
@@ -171,7 +171,9 @@ const installProjectionMigrationDdl = async (): Promise<void> => {
     ...new Bun.Glob("*corpus*projection*/migration.sql").scanSync(
       Bun.fileURLToPath(DRIZZLE_DIR),
     ),
-  ].sort();
+  ]
+    .filter((migration) => !migration.includes("projection_revision"))
+    .sort();
   const migrations = await Promise.all(
     projectionMigrations.map(
       async (migration) =>

--- a/apps/api/src/tests/pglite-schema.ts
+++ b/apps/api/src/tests/pglite-schema.ts
@@ -28,6 +28,18 @@ const AGENT_SKILL_REVISIONS_MIGRATION_PATH = nodePath.join(
   "20260827080000_agent_skill_revisions",
   "migration.sql",
 );
+const CORPUS_PROJECTION_REVISION_MIGRATION_PATHS = [
+  nodePath.join(
+    DRIZZLE_DIR,
+    "20260826004100_corpus_projection_revision_fence",
+    "migration.sql",
+  ),
+  nodePath.join(
+    DRIZZLE_DIR,
+    "20260901060000_concurrent_corpus_projection_revision_fence",
+    "migration.sql",
+  ),
+] as const;
 
 type PgliteSchemaDb = {
   execute: (query: SQL) => Promise<unknown>;
@@ -159,6 +171,32 @@ export const installPgliteAgentSkillRevisionTrigger = async (
   for (const statement of statements) {
     // oxlint-disable-next-line no-await-in-loop -- function/trigger DDL must execute in source order
     await db.execute(sql.raw(statement));
+  }
+};
+
+const CORPUS_PROJECTION_REVISION_STATEMENT_PREFIXES = [
+  "CREATE FUNCTION",
+  "CREATE OR REPLACE FUNCTION",
+  "REVOKE ALL ON FUNCTION",
+  "GRANT EXECUTE ON FUNCTION",
+  "CREATE TRIGGER",
+] as const;
+
+/** Install the projection mutation fence omitted by declarative schema push. */
+export const installPgliteCorpusProjectionRevisionFence = async (
+  db: PgliteSchemaDb,
+): Promise<void> => {
+  for (const migrationPath of CORPUS_PROJECTION_REVISION_MIGRATION_PATHS) {
+    const statements = readMigrationStatements(migrationPath).filter(
+      (statement) =>
+        CORPUS_PROJECTION_REVISION_STATEMENT_PREFIXES.some((prefix) =>
+          executableSql(statement).startsWith(prefix),
+        ),
+    );
+    for (const statement of statements) {
+      // oxlint-disable-next-line no-await-in-loop -- function/trigger DDL must execute in source order
+      await db.execute(sql.raw(statement));
+    }
   }
 };
 

--- a/apps/api/src/tests/pglite-test-db.ts
+++ b/apps/api/src/tests/pglite-test-db.ts
@@ -286,8 +286,8 @@ const ROLE_GRANT_STATEMENTS = [
     TO stella_ingestion
   `,
   `
-    GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public
-    TO stella_ingestion
+    GRANT USAGE, SELECT ON SEQUENCE
+      "corpus_index_projection_revisions_revision_seq" TO stella_ingestion
   `,
   // Preserve the v0.7.22 reader contract until its rollback window closes.
   `

--- a/apps/api/src/tests/pglite-test-db.ts
+++ b/apps/api/src/tests/pglite-test-db.ts
@@ -18,6 +18,7 @@ import {
 import {
   createSchemaPglite,
   installPgliteAgentSkillRevisionTrigger,
+  installPgliteCorpusProjectionRevisionFence,
   installPgliteSchemaPrerequisites,
   installPgliteWorkspaceAccessObjects,
 } from "@/api/tests/pglite-schema";
@@ -102,6 +103,10 @@ const CORPUS_PROJECTION_HISTORY_TABLES_SQL = [
   .map(getTableName)
   .map(quoteSqlIdentifier)
   .join(", ");
+
+const CORPUS_PROJECTION_REVISION_TABLE_SQL = quoteSqlIdentifier(
+  getTableName(schema.corpusIndexProjectionRevisions),
+);
 
 // The snapshot bakes in the superset every suite needs: RLS roles, schema,
 // workspace-access objects, and the role grants. Suites that never SET ROLE
@@ -251,13 +256,15 @@ const ROLE_GRANT_STATEMENTS = [
   `
     REVOKE INSERT, UPDATE, DELETE ON TABLE
       "corpus_index_generations",
-      ${CORPUS_PROJECTION_HISTORY_TABLES_SQL}
+      ${CORPUS_PROJECTION_HISTORY_TABLES_SQL},
+      ${CORPUS_PROJECTION_REVISION_TABLE_SQL}
     FROM stella
   `,
   `
     GRANT SELECT ON TABLE
       "corpus_index_generations",
-      ${CORPUS_PROJECTION_HISTORY_TABLES_SQL}
+      ${CORPUS_PROJECTION_HISTORY_TABLES_SQL},
+      ${CORPUS_PROJECTION_REVISION_TABLE_SQL}
     TO stella_ingestion
   `,
   `
@@ -271,6 +278,11 @@ const ROLE_GRANT_STATEMENTS = [
   `
     GRANT INSERT, UPDATE ON TABLE
       ${CORPUS_PROJECTION_HISTORY_TABLES_SQL}
+    TO stella_ingestion
+  `,
+  `
+    GRANT INSERT, DELETE ON TABLE
+      ${CORPUS_PROJECTION_REVISION_TABLE_SQL}
     TO stella_ingestion
   `,
   // Preserve the v0.7.22 reader contract until its rollback window closes.
@@ -328,6 +340,7 @@ export const buildFullTestPglite = async (): Promise<PGlite> => {
   }
   await installPgliteWorkspaceAccessObjects(db);
   await installPgliteAgentSkillRevisionTrigger(db);
+  await installPgliteCorpusProjectionRevisionFence(db);
 
   for (const statement of ROLE_GRANT_STATEMENTS) {
     // oxlint-disable-next-line no-await-in-loop -- grants run sequentially on one test DB connection

--- a/apps/api/src/tests/pglite-test-db.ts
+++ b/apps/api/src/tests/pglite-test-db.ts
@@ -285,6 +285,10 @@ const ROLE_GRANT_STATEMENTS = [
       ${CORPUS_PROJECTION_REVISION_TABLE_SQL}
     TO stella_ingestion
   `,
+  `
+    GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public
+    TO stella_ingestion
+  `,
   // Preserve the v0.7.22 reader contract until its rollback window closes.
   `
     GRANT USAGE ON SCHEMA public TO stella_caselaw_reader

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -103,6 +103,9 @@ const POST_BOOTSTRAP_SELECT_ONLY_TABLES = new Set([
   // Corpus-index generation identity is immutable control-plane state. The
   // request role resolves serving generations but never mutates the registry.
   "corpus_index_generations",
+  // Mutation revisions are appended and pruned only by ingestion triggers;
+  // request code may read the current proof watermark.
+  "corpus_index_projection_revisions",
   // Final-generation desired/applied state and append intents are durable
   // control-plane records. Request handlers may observe them; ingestion alone
   // mutates the state machine.


### PR DESCRIPTION
## Summary

- record projection mutation revisions once per generation and transaction
- let projection writers share a database-enforced fence while final proofs and lifecycle transitions remain exclusive
- bound revision retention and keep schema-built test databases aligned with migration-owned triggers
- prove concurrent writers, promotion fencing, rollback behavior, and ingestion-role access

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added durable revision tracking for corpus index projections.
  - Added transaction-safe coordination for projection updates, promotions and lifecycle changes.
  - Added automatic revision creation, initial backfilling and cleanup of stale revision records.

- **Bug Fixes**
  - Improved concurrency handling to prevent projection updates from overtaking one another.
  - Ensured multiple changes within a transaction share a consistent revision.

- **Tests**
  - Expanded coverage for transactional revisions, ingestion updates and concurrent projection operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->