### PR TITLE
fix: preserve workspace action toolbar layout

### DIFF
--- a/.changeset/steady-views-align.md
+++ b/.changeset/steady-views-align.md
@@ -1,0 +1,5 @@
+---
+"@stll/workspace-ui": patch
+---
+
+Keep actions attached to a workspace view tab aligned with its label.

--- a/packages/workspace-ui/src/responsive-action-toolbar.test.tsx
+++ b/packages/workspace-ui/src/responsive-action-toolbar.test.tsx
@@ -26,6 +26,8 @@ describe("ResponsiveActionToolbar", () => {
     expect(markup).toContain('aria-label="Workspace actions"');
     expect(markup).toContain("flex-nowrap");
     expect(markup).toContain("overflow-x-auto");
+    expect(markup).toContain("scrollbar-none");
+    expect(markup).toContain("webkit-scrollbar");
     expect(markup).toContain("Search");
     expect(markup).toContain("Filter");
     expect(markup).toContain("More");

--- a/packages/workspace-ui/src/responsive-action-toolbar.tsx
+++ b/packages/workspace-ui/src/responsive-action-toolbar.tsx
@@ -16,7 +16,7 @@ export const ResponsiveActionToolbar = ({
 }: React.ComponentProps<"div">) => (
   <div
     className={cn(
-      "flex min-w-0 flex-nowrap items-center gap-2 overflow-x-auto",
+      "flex min-w-0 scrollbar-none flex-nowrap items-center gap-2 overflow-x-auto [&::-webkit-scrollbar]:hidden",
       className,
     )}
     {...props}

--- a/packages/workspace-ui/src/view-switcher.test.tsx
+++ b/packages/workspace-ui/src/view-switcher.test.tsx
@@ -33,6 +33,7 @@ describe("WorkspaceViewSwitcher", () => {
     expect(markup).toContain("Deadlines");
     expect(markup).toContain("Add view");
     expect(markup).toContain("Actions");
+    expect(markup).toContain('class="relative flex items-center"');
   });
 
   test("applies the drop direction to the rendered switcher", () => {

--- a/packages/workspace-ui/src/view-switcher.tsx
+++ b/packages/workspace-ui/src/view-switcher.tsx
@@ -299,7 +299,7 @@ const WorkspaceViewTab = <View extends WorkspaceViewSwitcherItem>({
   ]);
 
   return (
-    <div className="relative" ref={setTabContainer}>
+    <div className="relative flex items-center" ref={setTabContainer}>
       {dropPosition !== null && (
         <span
           aria-hidden="true"


### PR DESCRIPTION
## Summary

- keep view-tab actions aligned with their corresponding label
- make responsive action toolbars keep one scrollable row without native scrollbar chrome
- cover both layout contracts with focused component tests

## Verification

- `bun run test -- --bail -t "WorkspaceViewSwitcher|ResponsiveActionToolbar"`
- `bun run typecheck`
- `bun run lint`
- `bun run format -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Workspace view tabs now keep their actions better aligned with tab labels.
  - Improved tab layout provides more consistent positioning for content and indicators.
  - Horizontal action toolbars remain scrollable while their scrollbars are hidden for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->