### PR TITLE
fix: preserve responsive toolbar overflow

### DIFF
--- a/.changeset/quiet-toolbars-scroll.md
+++ b/.changeset/quiet-toolbars-scroll.md
@@ -1,0 +1,5 @@
+---
+"@stll/workspace-ui": patch
+---
+
+Hide native scrollbar chrome while retaining horizontal overflow in responsive action toolbars.

--- a/packages/workspace-ui/src/responsive-action-toolbar.test.tsx
+++ b/packages/workspace-ui/src/responsive-action-toolbar.test.tsx
@@ -28,7 +28,7 @@ describe("ResponsiveActionToolbar", () => {
     expect(markup).toContain("overflow-x-auto");
     expect(markup).toContain("scrollbar-width:none");
     expect(markup).toContain("-ms-overflow-style:none");
-    expect(markup).toContain("webkit-scrollbar");
+    expect(markup).toContain("webkit-scrollbar]:hidden");
     expect(markup).toContain("Search");
     expect(markup).toContain("Filter");
     expect(markup).toContain("More");

--- a/packages/workspace-ui/src/responsive-action-toolbar.test.tsx
+++ b/packages/workspace-ui/src/responsive-action-toolbar.test.tsx
@@ -26,7 +26,8 @@ describe("ResponsiveActionToolbar", () => {
     expect(markup).toContain('aria-label="Workspace actions"');
     expect(markup).toContain("flex-nowrap");
     expect(markup).toContain("overflow-x-auto");
-    expect(markup).toContain("scrollbar-none");
+    expect(markup).toContain("scrollbar-width:none");
+    expect(markup).toContain("-ms-overflow-style:none");
     expect(markup).toContain("webkit-scrollbar");
     expect(markup).toContain("Search");
     expect(markup).toContain("Filter");

--- a/packages/workspace-ui/src/responsive-action-toolbar.tsx
+++ b/packages/workspace-ui/src/responsive-action-toolbar.tsx
@@ -16,7 +16,7 @@ export const ResponsiveActionToolbar = ({
 }: React.ComponentProps<"div">) => (
   <div
     className={cn(
-      "flex min-w-0 scrollbar-none flex-nowrap items-center gap-2 overflow-x-auto [&::-webkit-scrollbar]:hidden",
+      "flex min-w-0 [scrollbar-width:none] flex-nowrap items-center gap-2 overflow-x-auto [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary

- use explicit cross-browser scrollbar suppression for responsive action toolbars
- retain horizontal overflow without native scrollbar chrome
- assert the emitted cross-browser properties in the component test

## Verification

- `bun run test -- --bail -t "WorkspaceViewSwitcher|ResponsiveActionToolbar"`
- `bun run typecheck`
- `bun run lint`
- `bun run format -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive action toolbars by hiding scrollbar chrome while preserving horizontal scrolling.
  * Enhanced compatibility across browsers using standard and vendor-specific scrollbar styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->