### PR TITLE
fix: make desktop language picker searchable

### DIFF
--- a/apps/desktop/src/i18n/langs/cs.json
+++ b/apps/desktop/src/i18n/langs/cs.json
@@ -72,6 +72,7 @@
     "language": "Jazyk",
     "languageDescription": "Zvolte jazyk desktopové aplikace.",
     "managedOfficeEditing": "Spravované úpravy souborů Office pro stella.",
+    "noLanguagesFound": "Žádné odpovídající jazyky",
     "notAvailableYet": "Zatím nedostupné",
     "notConnected": "Nepřipojeno",
     "notificationDocumentReady": "Dokument připraven",

--- a/apps/desktop/src/i18n/langs/de.json
+++ b/apps/desktop/src/i18n/langs/de.json
@@ -72,6 +72,7 @@
     "language": "Sprache",
     "languageDescription": "Wählen Sie die Sprache der Desktop-App.",
     "managedOfficeEditing": "Verwaltete Office-Dateibearbeitung für stella.",
+    "noLanguagesFound": "Keine passenden Sprachen",
     "notAvailableYet": "Noch nicht verfügbar",
     "notConnected": "Nicht verbunden",
     "notificationDocumentReady": "Dokument bereit",

--- a/apps/desktop/src/i18n/langs/en.json
+++ b/apps/desktop/src/i18n/langs/en.json
@@ -74,6 +74,7 @@
     "language": "Language",
     "languageDescription": "Choose the language used by the desktop app.",
     "managedOfficeEditing": "Managed Office file editing for stella.",
+    "noLanguagesFound": "No matching languages",
     "notConnected": "Not connected",
     "notAvailableYet": "Not available yet",
     "notifications": "Notifications",

--- a/apps/desktop/src/i18n/langs/es.json
+++ b/apps/desktop/src/i18n/langs/es.json
@@ -72,6 +72,7 @@
     "language": "Idioma",
     "languageDescription": "Elija el idioma de la aplicación de escritorio.",
     "managedOfficeEditing": "Edición gestionada de archivos Office para stella.",
+    "noLanguagesFound": "No hay idiomas coincidentes",
     "notAvailableYet": "Aún no disponible",
     "notConnected": "No conectado",
     "notificationDocumentReady": "Documento listo",

--- a/apps/desktop/src/i18n/langs/et.json
+++ b/apps/desktop/src/i18n/langs/et.json
@@ -72,6 +72,7 @@
     "language": "Keel",
     "languageDescription": "Valige töölauarakenduse keel.",
     "managedOfficeEditing": "Hallatud Office'i failide muutmine stella jaoks.",
+    "noLanguagesFound": "Sobivaid keeli pole",
     "notAvailableYet": "Pole veel saadaval",
     "notConnected": "Ühendamata",
     "notificationDocumentReady": "Dokument valmis",

--- a/apps/desktop/src/i18n/langs/fr.json
+++ b/apps/desktop/src/i18n/langs/fr.json
@@ -72,6 +72,7 @@
     "language": "Langue",
     "languageDescription": "Choisissez la langue de l’application desktop.",
     "managedOfficeEditing": "Modification de fichiers Office gérée pour stella.",
+    "noLanguagesFound": "Aucune langue correspondante",
     "notAvailableYet": "Pas encore disponible",
     "notConnected": "Non connecté",
     "notificationDocumentReady": "Document prêt",

--- a/apps/desktop/src/i18n/langs/hu.json
+++ b/apps/desktop/src/i18n/langs/hu.json
@@ -72,6 +72,7 @@
     "language": "Nyelv",
     "languageDescription": "Válassza ki a desktop alkalmazás nyelvét.",
     "managedOfficeEditing": "Felügyelt Office-fájl szerkesztés a stella számára.",
+    "noLanguagesFound": "Nincs megfelelő nyelv",
     "notAvailableYet": "Még nem érhető el",
     "notConnected": "Nincs csatlakozva",
     "notificationDocumentReady": "Dokumentum kész",

--- a/apps/desktop/src/i18n/langs/lt.json
+++ b/apps/desktop/src/i18n/langs/lt.json
@@ -72,6 +72,7 @@
     "language": "Kalba",
     "languageDescription": "Pasirinkite desktop programos kalbą.",
     "managedOfficeEditing": "Valdomas Office failų redagavimas stella programai.",
+    "noLanguagesFound": "Atitinkančių kalbų nėra",
     "notAvailableYet": "Dar nepasiekiama",
     "notConnected": "Neprisijungta",
     "notificationDocumentReady": "Dokumentas paruoštas",

--- a/apps/desktop/src/i18n/langs/lv.json
+++ b/apps/desktop/src/i18n/langs/lv.json
@@ -72,6 +72,7 @@
     "language": "Valoda",
     "languageDescription": "Izvēlieties desktop lietotnes valodu.",
     "managedOfficeEditing": "Pārvaldīta Office failu rediģēšana stella vajadzībām.",
+    "noLanguagesFound": "Nav atbilstošu valodu",
     "notAvailableYet": "Vēl nav pieejams",
     "notConnected": "Nav savienots",
     "notificationDocumentReady": "Dokuments gatavs",

--- a/apps/desktop/src/i18n/langs/pl.json
+++ b/apps/desktop/src/i18n/langs/pl.json
@@ -72,6 +72,7 @@
     "language": "Język",
     "languageDescription": "Wybierz język aplikacji desktop.",
     "managedOfficeEditing": "Zarządzana edycja plików Office dla stella.",
+    "noLanguagesFound": "Brak pasujących języków",
     "notAvailableYet": "Jeszcze niedostępne",
     "notConnected": "Niepołączono",
     "notificationDocumentReady": "Dokument gotowy",

--- a/apps/desktop/src/i18n/langs/sk.json
+++ b/apps/desktop/src/i18n/langs/sk.json
@@ -72,6 +72,7 @@
     "language": "Jazyk",
     "languageDescription": "Zvoľte jazyk desktopovej aplikácie.",
     "managedOfficeEditing": "Spravované úpravy súborov Office pre stella.",
+    "noLanguagesFound": "Žiadne zodpovedajúce jazyky",
     "notAvailableYet": "Zatiaľ nedostupné",
     "notConnected": "Nepripojené",
     "notificationDocumentReady": "Dokument pripravený",

--- a/apps/desktop/src/mainview/App.tsx
+++ b/apps/desktop/src/mainview/App.tsx
@@ -333,7 +333,11 @@ const GeneralPane = ({
             }}
             value={language}
           >
-            <ComboboxInput className="w-40" id="desktop-language" />
+            <ComboboxInput
+              className="w-40"
+              id="desktop-language"
+              showTrigger={false}
+            />
             <ComboboxPopup align="end">
               <ComboboxList>
                 {(supportedLanguage: SupportedLanguage) => (

--- a/apps/desktop/src/mainview/App.tsx
+++ b/apps/desktop/src/mainview/App.tsx
@@ -6,16 +6,17 @@ import { useFormatter, useLocale, useTranslations } from "use-intl";
 import { Avatar, AvatarFallback } from "@stll/ui/avatar";
 import { Button } from "@stll/ui/button";
 import { Checkbox } from "@stll/ui/checkbox";
+import {
+  Combobox,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxPopup,
+} from "@stll/ui/combobox";
 import { FramePanel } from "@stll/ui/frame";
 import { Label } from "@stll/ui/label";
 import { ScrollArea } from "@stll/ui/scroll-area";
-import {
-  Select,
-  SelectItem,
-  SelectPopup,
-  SelectTrigger,
-  SelectValue,
-} from "@stll/ui/select";
 import { Separator } from "@stll/ui/separator";
 import { Tabs, TabsList, TabsPanel, TabsTab } from "@stll/ui/tabs";
 import { cn } from "@stll/ui/utils";
@@ -319,25 +320,34 @@ const GeneralPane = ({
               {t("languageDescription")}
             </p>
           </div>
-          <Select
+          <Combobox<SupportedLanguage>
+            autoHighlight
+            items={SUPPORTED_LANGUAGES}
+            itemToStringLabel={(supportedLanguage) =>
+              LANGUAGE_LABELS[supportedLanguage]
+            }
             onValueChange={(value) => {
-              if (value && isSupportedLanguage(value)) {
+              if (value !== null) {
                 onLanguageChange(value);
               }
             }}
             value={language}
           >
-            <SelectTrigger className="w-40" id="desktop-language">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectPopup align="end">
-              {SUPPORTED_LANGUAGES.map((supportedLanguage) => (
-                <SelectItem key={supportedLanguage} value={supportedLanguage}>
-                  {LANGUAGE_LABELS[supportedLanguage]}
-                </SelectItem>
-              ))}
-            </SelectPopup>
-          </Select>
+            <ComboboxInput className="w-40" id="desktop-language" />
+            <ComboboxPopup align="end">
+              <ComboboxList>
+                {(supportedLanguage: SupportedLanguage) => (
+                  <ComboboxItem
+                    key={supportedLanguage}
+                    value={supportedLanguage}
+                  >
+                    {LANGUAGE_LABELS[supportedLanguage]}
+                  </ComboboxItem>
+                )}
+              </ComboboxList>
+              <ComboboxEmpty>{t("noLanguagesFound")}</ComboboxEmpty>
+            </ComboboxPopup>
+          </Combobox>
         </div>
       </PanelGroup>
     </div>


### PR DESCRIPTION
Replace the desktop settings language select with the shared combobox so the popup remains usable in the preferences window and users can filter by native language name.

Add a localized empty state for every supported desktop locale.

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the General settings language selector with a searchable combobox for easier language selection.
  * Added a clear “no matching languages” message when searches return no results.
* **Localisation**
  * Added translations for the new message in Czech, German, English, Spanish, Estonian, French, Hungarian, Lithuanian, Latvian, Polish and Slovak.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->