### PR TITLE
feat: add final generation rebuild boundary

### DIFF
--- a/apps/api/drizzle/20260901070000_final_corpus_projection_rebuild/migration.sql
+++ b/apps/api/drizzle/20260901070000_final_corpus_projection_rebuild/migration.sql
@@ -1,0 +1,136 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '5s';--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION "guard_corpus_index_projection_history_delete"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  generation_status text;
+  rebuild_fenced boolean;
+BEGIN
+  SELECT generation."status"
+  INTO generation_status
+  FROM "corpus_index_generations" generation
+  WHERE generation."family" = OLD."family"
+    AND generation."generation" = OLD."generation";
+
+  IF generation_status NOT IN ('retiring', 'retired') THEN
+    RAISE EXCEPTION 'corpus index projection history requires a retiring or retired generation';
+  END IF;
+
+  IF generation_status = 'retiring' THEN
+    SELECT EXISTS (
+      SELECT 1
+      FROM pg_catalog.pg_locks held
+      WHERE held."locktype" = 'advisory'
+        AND held."pid" = pg_catalog.pg_backend_pid()
+        AND held."classid" = 1937007986::oid
+        AND held."objid" = 1::oid
+        AND held."objsubid" = 2
+        AND held."mode" = 'ExclusiveLock'
+        AND held."granted"
+    ) INTO rebuild_fenced;
+    IF NOT rebuild_fenced THEN
+      RAISE EXCEPTION 'retiring corpus index projection history requires the rebuild fence';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF TG_TABLE_NAME = 'corpus_index_projection_intents'
+     AND (to_jsonb(OLD)->>'status') NOT IN ('settled', 'cancelled') THEN
+    RAISE EXCEPTION 'nonterminal corpus index projection intent cannot be deleted';
+  END IF;
+
+  IF TG_TABLE_NAME = 'corpus_index_projection_states' AND EXISTS (
+    SELECT 1
+    FROM "corpus_index_projection_intents" intent
+    WHERE intent."family" = OLD."family"
+      AND intent."generation" = OLD."generation"
+      AND intent."entity_id" = OLD."entity_id"
+      AND intent."status" NOT IN ('settled', 'cancelled')
+  ) THEN
+    RAISE EXCEPTION 'projection state with nonterminal intents cannot be deleted';
+  END IF;
+
+  RETURN OLD;
+END;
+$$;--> statement-breakpoint
+
+-- stella-migration-safety: reviewed security-definer - fixed search_path, retiring q09 generation check, exclusive mutation fence, and 10000-entity ceiling preserve least privilege; the dedicated rebuild boundary discards all history only after the caller has removed the physical indexes
+CREATE FUNCTION "purge_rebuilding_corpus_index_projection_history"(
+  target_family text,
+  target_generation text,
+  max_entities integer
+)
+RETURNS TABLE (
+  deleted_state_count integer,
+  deleted_intent_count integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  selected_entities uuid[];
+  state_count integer;
+  intent_count integer;
+BEGIN
+  IF max_entities IS NULL OR max_entities < 1 OR max_entities > 10000 THEN
+    RAISE EXCEPTION 'projection rebuild purge batch must be between 1 and 10000 entities';
+  END IF;
+
+  PERFORM public."lock_corpus_projection_mutations_exclusive"();
+
+  PERFORM 1
+  FROM public."corpus_index_generations" generation
+  WHERE generation."family" = target_family
+    AND generation."generation" = target_generation
+    AND generation."cluster" = 'q09'
+    AND generation."status" = 'retiring'
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'projection rebuild purge requires a retiring q09 generation';
+  END IF;
+
+  SELECT array_agg(candidate."entity_id" ORDER BY candidate."entity_id")
+  INTO selected_entities
+  FROM (
+    SELECT state."entity_id"
+    FROM public."corpus_index_projection_states" state
+    WHERE state."family" = target_family
+      AND state."generation" = target_generation
+    UNION
+    SELECT intent."entity_id"
+    FROM public."corpus_index_projection_intents" intent
+    WHERE intent."family" = target_family
+      AND intent."generation" = target_generation
+    ORDER BY "entity_id"
+    LIMIT max_entities
+  ) candidate;
+
+  IF selected_entities IS NULL THEN
+    RETURN QUERY SELECT 0, 0;
+    RETURN;
+  END IF;
+
+  DELETE FROM public."corpus_index_projection_states" state
+  WHERE state."family" = target_family
+    AND state."generation" = target_generation
+    AND state."entity_id" = ANY(selected_entities);
+  GET DIAGNOSTICS state_count = ROW_COUNT;
+
+  DELETE FROM public."corpus_index_projection_intents" intent
+  WHERE intent."family" = target_family
+    AND intent."generation" = target_generation
+    AND intent."entity_id" = ANY(selected_entities);
+  GET DIAGNOSTICS intent_count = ROW_COUNT;
+
+  RETURN QUERY SELECT state_count, intent_count;
+END;
+$$;--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION "purge_rebuilding_corpus_index_projection_history"(text, text, integer)
+  FROM PUBLIC;--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION "purge_rebuilding_corpus_index_projection_history"(text, text, integer)
+  TO stella_ingestion;

--- a/apps/api/src/lib/legal-search/corpus-index-generation-rebuild.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-rebuild.db.test.ts
@@ -42,10 +42,6 @@ const MIGRATION_URLS = [
     import.meta.url,
   ),
   new URL(
-    "../../../drizzle/20260901060000_concurrent_corpus_projection_revision_fence/migration.sql",
-    import.meta.url,
-  ),
-  new URL(
     "../../../drizzle/20260901070000_final_corpus_projection_rebuild/migration.sql",
     import.meta.url,
   ),
@@ -73,8 +69,6 @@ beforeAll(async () => {
         !ddl.includes("guard_corpus_index_projection_history_delete") &&
         !ddl.includes("corpus_index_projection_intents_delete_guard") &&
         !ddl.includes("corpus_index_projection_states_delete_guard") &&
-        !ddl.includes("lock_corpus_projection_mutations_shared") &&
-        !ddl.includes("lock_corpus_projection_mutations_exclusive") &&
         !ddl.includes("purge_rebuilding_corpus_index_projection_history")
       ) {
         continue;

--- a/apps/api/src/lib/legal-search/corpus-index-generation-rebuild.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-rebuild.db.test.ts
@@ -57,6 +57,16 @@ const runInTransaction = async <Value>(
     async (tx) => await operation(asTestRaw<Transaction>(tx)),
   );
 
+const errorMessageChain = (error: unknown): string => {
+  const messages: string[] = [];
+  let current = error;
+  while (current instanceof Error) {
+    messages.push(current.message);
+    current = current.cause;
+  }
+  return messages.join(" | ");
+};
+
 beforeAll(async () => {
   client = await createTestPglite();
   db = drizzle({ client });
@@ -130,11 +140,9 @@ test("replaces only an empty non-serving generation", async () => {
       () => null,
       (error: unknown) => error,
     );
-  expect(unfencedDelete).toMatchObject({
-    message: expect.stringContaining(
-      "retiring corpus index projection history requires the rebuild fence",
-    ),
-  });
+  expect(errorMessageChain(unfencedDelete)).toContain(
+    "retiring corpus index projection history requires the rebuild fence",
+  );
   expect(
     await runInTransaction(
       async (tx) =>

--- a/apps/api/src/lib/legal-search/corpus-index-generation-rebuild.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-rebuild.db.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import type { Transaction } from "@/api/db/root";
@@ -31,6 +31,25 @@ const ENTITY_ID = toSafeId<"legislationDocument">(
 const INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
   "0198e331-e578-7000-8000-000000000902",
 );
+const LEASE_TOKEN = "0198e331-e578-7000-8000-000000000903";
+const MIGRATION_URLS = [
+  new URL(
+    "../../../drizzle/20260825142000_corpus_index_projection_intents/migration.sql",
+    import.meta.url,
+  ),
+  new URL(
+    "../../../drizzle/20260825211300_corpus_projection_delete_guard_record/migration.sql",
+    import.meta.url,
+  ),
+  new URL(
+    "../../../drizzle/20260901060000_concurrent_corpus_projection_revision_fence/migration.sql",
+    import.meta.url,
+  ),
+  new URL(
+    "../../../drizzle/20260901070000_final_corpus_projection_rebuild/migration.sql",
+    import.meta.url,
+  ),
+] as const;
 
 let client: Awaited<ReturnType<typeof createTestPglite>>;
 let db: ReturnType<typeof drizzle>;
@@ -45,6 +64,25 @@ const runInTransaction = async <Value>(
 beforeAll(async () => {
   client = await createTestPglite();
   db = drizzle({ client });
+  for (const migrationUrl of MIGRATION_URLS) {
+    // oxlint-disable-next-line no-await-in-loop -- migration-owned functions and their triggers must install in production order
+    const migration = await Bun.file(migrationUrl).text();
+    for (const statement of migration.split("--> statement-breakpoint")) {
+      const ddl = statement.trim();
+      if (
+        !ddl.includes("guard_corpus_index_projection_history_delete") &&
+        !ddl.includes("corpus_index_projection_intents_delete_guard") &&
+        !ddl.includes("corpus_index_projection_states_delete_guard") &&
+        !ddl.includes("lock_corpus_projection_mutations_shared") &&
+        !ddl.includes("lock_corpus_projection_mutations_exclusive") &&
+        !ddl.includes("purge_rebuilding_corpus_index_projection_history")
+      ) {
+        continue;
+      }
+      // oxlint-disable-next-line no-await-in-loop -- each trigger depends on the preceding migration-owned function
+      await db.execute(sql.raw(ddl));
+    }
+  }
   await db.insert(corpusIndexGenerations).values({
     ...TARGET,
     cluster: "q09",
@@ -66,8 +104,10 @@ beforeAll(async () => {
     epoch: 1n,
     fingerprint: "a".repeat(64),
     indexId: "legislation_v2_cze",
-    status: "cancelled",
-    cancelledAt: new Date(),
+    status: "append_started",
+    leaseToken: LEASE_TOKEN,
+    leaseExpiresAt: new Date("2026-09-01T12:00:00.000Z"),
+    appendStartedAt: new Date("2026-09-01T11:59:00.000Z"),
   });
 });
 
@@ -89,18 +129,28 @@ test("replaces only an empty non-serving generation", async () => {
     message:
       "Corpus generation rebuild state is not empty: legislation/legislation_v2",
   });
+  const unfencedDelete: unknown = await db
+    .delete(corpusIndexProjectionStates)
+    .where(eq(corpusIndexProjectionStates.entityId, ENTITY_ID))
+    .then(
+      () => null,
+      (error: unknown) => error,
+    );
+  expect(unfencedDelete).toMatchObject({
+    message: expect.stringContaining(
+      "retiring corpus index projection history requires the rebuild fence",
+    ),
+  });
   expect(
     await runInTransaction(
       async (tx) =>
         await deleteCorpusIndexGenerationProjectionBatchTx(tx, TARGET, 1),
     ),
-  ).toEqual({ status: "deleted_states", count: 1 });
-  expect(
-    await runInTransaction(
-      async (tx) =>
-        await deleteCorpusIndexGenerationProjectionBatchTx(tx, TARGET, 1),
-    ),
-  ).toEqual({ status: "deleted_intents", count: 1 });
+  ).toEqual({
+    status: "deleted_history",
+    stateCount: 1,
+    intentCount: 1,
+  });
   expect(
     await runInTransaction(
       async (tx) =>

--- a/apps/api/src/lib/legal-search/corpus-index-generation-rebuild.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-rebuild.db.test.ts
@@ -1,0 +1,130 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+
+import type { Transaction } from "@/api/db/root";
+import {
+  corpusIndexGenerations,
+  corpusIndexProjectionIntents,
+  corpusIndexProjectionStates,
+} from "@/api/db/schema";
+import { toSafeId } from "@/api/lib/branded-types";
+import {
+  beginCorpusIndexGenerationRebuildTx,
+  completeCorpusIndexGenerationRebuildTx,
+  deleteCorpusIndexGenerationProjectionBatchTx,
+} from "@/api/lib/legal-search/corpus-index-generation-store";
+import {
+  CORPUS_INDEX_MANIFESTS,
+  corpusIndexManifestDigest,
+} from "@/api/lib/legal-search/corpus-index-manifest";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const TARGET = {
+  family: "legislation",
+  generation: "legislation_v2",
+} as const;
+const ENTITY_ID = toSafeId<"legislationDocument">(
+  "0198e331-e578-7000-8000-000000000901",
+);
+const INTENT_ID = toSafeId<"corpusIndexProjectionIntent">(
+  "0198e331-e578-7000-8000-000000000902",
+);
+
+let client: Awaited<ReturnType<typeof createTestPglite>>;
+let db: ReturnType<typeof drizzle>;
+
+const runInTransaction = async <Value>(
+  operation: (tx: Transaction) => Promise<Value>,
+): Promise<Value> =>
+  await db.transaction(
+    async (tx) => await operation(asTestRaw<Transaction>(tx)),
+  );
+
+beforeAll(async () => {
+  client = await createTestPglite();
+  db = drizzle({ client });
+  await db.insert(corpusIndexGenerations).values({
+    ...TARGET,
+    cluster: "q09",
+    manifestDigest: corpusIndexManifestDigest(
+      CORPUS_INDEX_MANIFESTS.legislation_v2,
+    ),
+    status: "building",
+  });
+  await db.insert(corpusIndexProjectionStates).values({
+    ...TARGET,
+    entityId: ENTITY_ID,
+    desiredAction: "erase",
+    desiredEpoch: 1n,
+  });
+  await db.insert(corpusIndexProjectionIntents).values({
+    id: INTENT_ID,
+    ...TARGET,
+    entityId: ENTITY_ID,
+    epoch: 1n,
+    fingerprint: "a".repeat(64),
+    indexId: "legislation_v2_cze",
+    status: "cancelled",
+    cancelledAt: new Date(),
+  });
+});
+
+afterAll(async () => {
+  await client.close();
+});
+
+test("replaces only an empty non-serving generation", async () => {
+  await runInTransaction(
+    async (tx) => await beginCorpusIndexGenerationRebuildTx(tx, TARGET),
+  );
+  const prematureCompletion: unknown = await runInTransaction(
+    async (tx) => await completeCorpusIndexGenerationRebuildTx(tx, TARGET),
+  ).then(
+    () => null,
+    (error: unknown) => error,
+  );
+  expect(prematureCompletion).toMatchObject({
+    message:
+      "Corpus generation rebuild state is not empty: legislation/legislation_v2",
+  });
+  expect(
+    await runInTransaction(
+      async (tx) =>
+        await deleteCorpusIndexGenerationProjectionBatchTx(tx, TARGET, 1),
+    ),
+  ).toEqual({ status: "deleted_states", count: 1 });
+  expect(
+    await runInTransaction(
+      async (tx) =>
+        await deleteCorpusIndexGenerationProjectionBatchTx(tx, TARGET, 1),
+    ),
+  ).toEqual({ status: "deleted_intents", count: 1 });
+  expect(
+    await runInTransaction(
+      async (tx) =>
+        await deleteCorpusIndexGenerationProjectionBatchTx(tx, TARGET, 1),
+    ),
+  ).toEqual({ status: "empty", count: 0 });
+  await runInTransaction(
+    async (tx) => await completeCorpusIndexGenerationRebuildTx(tx, TARGET),
+  );
+
+  expect(
+    await db
+      .select({
+        manifestDigest: corpusIndexGenerations.manifestDigest,
+        status: corpusIndexGenerations.status,
+      })
+      .from(corpusIndexGenerations)
+      .where(eq(corpusIndexGenerations.generation, TARGET.generation)),
+  ).toEqual([
+    {
+      manifestDigest: corpusIndexManifestDigest(
+        CORPUS_INDEX_MANIFESTS.legislation_v2,
+      ),
+      status: "building",
+    },
+  ]);
+});

--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
@@ -397,7 +397,7 @@ export const beginCorpusIndexGenerationRebuildTx = async (
   }
 };
 
-export type CorpusIndexGenerationRebuildStep =
+type CorpusIndexGenerationRebuildStep =
   | { status: "deleted_history"; stateCount: number; intentCount: number }
   | { status: "empty"; count: 0 };
 

--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
@@ -398,11 +398,10 @@ export const beginCorpusIndexGenerationRebuildTx = async (
 };
 
 export type CorpusIndexGenerationRebuildStep =
-  | { status: "deleted_states"; count: number }
-  | { status: "deleted_intents"; count: number }
+  | { status: "deleted_history"; stateCount: number; intentCount: number }
   | { status: "empty"; count: 0 };
 
-/** Delete one bounded projection-state page from a retiring generation. */
+/** Delete one bounded projection-history page from a retiring generation. */
 export const deleteCorpusIndexGenerationProjectionBatchTx = async (
   tx: Transaction,
   target: CorpusIndexGenerationTarget,
@@ -410,37 +409,24 @@ export const deleteCorpusIndexGenerationProjectionBatchTx = async (
 ): Promise<CorpusIndexGenerationRebuildStep> => {
   const limit = validateRebuildBatchSize(requestedLimit);
   await requireRebuildTarget(tx, target, "retiring");
-  const deletedStates = await tx.execute(sql`
-    DELETE FROM ${corpusIndexProjectionStates} state
-     WHERE state.ctid IN (
-       SELECT candidate.ctid
-         FROM ${corpusIndexProjectionStates} candidate
-        WHERE candidate.family = ${target.family}
-          AND candidate.generation = ${target.generation}
-        ORDER BY candidate.entity_id
-        LIMIT ${limit}
-     )
-    RETURNING state.entity_id
+  const purged = await tx.execute(sql`
+    SELECT deleted_state_count, deleted_intent_count
+      FROM public.purge_rebuilding_corpus_index_projection_history(
+        ${target.family}, ${target.generation}, ${limit}
+      )
   `);
-  const stateCount = rebuildRowsOf(deletedStates).length;
-  if (stateCount > 0) {
-    return { status: "deleted_states", count: stateCount };
+  const row = rebuildRowsOf(purged).at(0);
+  if (
+    !isRecord(row) ||
+    typeof row["deleted_state_count"] !== "number" ||
+    typeof row["deleted_intent_count"] !== "number"
+  ) {
+    return panic("Corpus generation rebuild purge result is malformed");
   }
-  const deletedIntents = await tx.execute(sql`
-    DELETE FROM ${corpusIndexProjectionIntents} intent
-     WHERE intent.ctid IN (
-       SELECT candidate.ctid
-         FROM ${corpusIndexProjectionIntents} candidate
-        WHERE candidate.family = ${target.family}
-          AND candidate.generation = ${target.generation}
-        ORDER BY candidate.created_at, candidate.id
-        LIMIT ${limit}
-     )
-    RETURNING intent.id
-  `);
-  const intentCount = rebuildRowsOf(deletedIntents).length;
-  return intentCount > 0
-    ? { status: "deleted_intents", count: intentCount }
+  const stateCount = row["deleted_state_count"];
+  const intentCount = row["deleted_intent_count"];
+  return stateCount > 0 || intentCount > 0
+    ? { status: "deleted_history", stateCount, intentCount }
     : { status: "empty", count: 0 };
 };
 
@@ -449,6 +435,7 @@ export const completeCorpusIndexGenerationRebuildTx = async (
   tx: Transaction,
   target: CorpusIndexGenerationTarget,
 ): Promise<void> => {
+  await lockCorpusIndexGenerationActivationTx(tx, target.family);
   await requireRebuildTarget(tx, target, "retiring");
   const remaining = await tx.execute(sql`
     SELECT EXISTS (

--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
@@ -5,6 +5,8 @@ import type { Transaction } from "@/api/db/root";
 import {
   caseLawSources,
   corpusIndexGenerations,
+  corpusIndexProjectionIntents,
+  corpusIndexProjectionStates,
   legislationSources,
 } from "@/api/db/schema";
 import {
@@ -17,6 +19,7 @@ import {
   requireCorpusIndexManifest,
   type CorpusIndexManifest,
 } from "@/api/lib/legal-search/corpus-index-manifest";
+import { isRecord } from "@/api/lib/type-guards";
 
 type GenerationTargetFor<TManifest extends CorpusIndexManifest> =
   TManifest extends CorpusIndexManifest
@@ -317,4 +320,169 @@ export const setServingCorpusIndexGenerationTx = async (
     );
   }
   return requireServingCorpusIndexGeneration(promotedRow, target.family);
+};
+
+const CORPUS_INDEX_GENERATION_REBUILD_MAX_BATCH_SIZE = 10_000;
+
+const rebuildRowsOf = (result: unknown): unknown[] => {
+  if (Array.isArray(result)) {
+    return result;
+  }
+  return isRecord(result) && Array.isArray(result["rows"])
+    ? result["rows"]
+    : [];
+};
+
+const validateRebuildBatchSize = (limit: number): number => {
+  if (
+    !Number.isSafeInteger(limit) ||
+    limit < 1 ||
+    limit > CORPUS_INDEX_GENERATION_REBUILD_MAX_BATCH_SIZE
+  ) {
+    return panic(
+      `Corpus generation rebuild limit must be 1..${CORPUS_INDEX_GENERATION_REBUILD_MAX_BATCH_SIZE}`,
+    );
+  }
+  return limit;
+};
+
+const requireRebuildTarget = async (
+  tx: Transaction,
+  target: CorpusIndexGenerationTarget,
+  status: "building" | "retiring",
+) => {
+  const row = (
+    await tx
+      .select()
+      .from(corpusIndexGenerations)
+      .where(
+        and(
+          eq(corpusIndexGenerations.family, target.family),
+          eq(corpusIndexGenerations.generation, target.generation),
+        ),
+      )
+      .limit(1)
+      .for("update")
+  ).at(0);
+  if (row?.status !== status || row.cluster !== "q09") {
+    return panic(
+      `Corpus generation rebuild requires q09 ${status}: ${target.family}/${target.generation}`,
+    );
+  }
+  return row;
+};
+
+/** Remove one non-serving generation from the active projection set. */
+export const beginCorpusIndexGenerationRebuildTx = async (
+  tx: Transaction,
+  target: CorpusIndexGenerationTarget,
+): Promise<void> => {
+  const row = await requireRebuildTarget(tx, target, "building");
+  requireRegisteredCorpusIndexManifest(row);
+  const retired = await tx
+    .update(corpusIndexGenerations)
+    .set({ status: "retiring", updatedAt: sql`clock_timestamp()` })
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, target.family),
+        eq(corpusIndexGenerations.generation, target.generation),
+        eq(corpusIndexGenerations.status, "building"),
+      ),
+    )
+    .returning({ generation: corpusIndexGenerations.generation });
+  if (retired.length !== 1) {
+    return panic(
+      `Corpus generation rebuild lost its target: ${target.family}/${target.generation}`,
+    );
+  }
+};
+
+export type CorpusIndexGenerationRebuildStep =
+  | { status: "deleted_states"; count: number }
+  | { status: "deleted_intents"; count: number }
+  | { status: "empty"; count: 0 };
+
+/** Delete one bounded projection-state page from a retiring generation. */
+export const deleteCorpusIndexGenerationProjectionBatchTx = async (
+  tx: Transaction,
+  target: CorpusIndexGenerationTarget,
+  requestedLimit: number,
+): Promise<CorpusIndexGenerationRebuildStep> => {
+  const limit = validateRebuildBatchSize(requestedLimit);
+  await requireRebuildTarget(tx, target, "retiring");
+  const deletedStates = await tx.execute(sql`
+    DELETE FROM ${corpusIndexProjectionStates} state
+     WHERE state.ctid IN (
+       SELECT candidate.ctid
+         FROM ${corpusIndexProjectionStates} candidate
+        WHERE candidate.family = ${target.family}
+          AND candidate.generation = ${target.generation}
+        ORDER BY candidate.entity_id
+        LIMIT ${limit}
+     )
+    RETURNING state.entity_id
+  `);
+  const stateCount = rebuildRowsOf(deletedStates).length;
+  if (stateCount > 0) {
+    return { status: "deleted_states", count: stateCount };
+  }
+  const deletedIntents = await tx.execute(sql`
+    DELETE FROM ${corpusIndexProjectionIntents} intent
+     WHERE intent.ctid IN (
+       SELECT candidate.ctid
+         FROM ${corpusIndexProjectionIntents} candidate
+        WHERE candidate.family = ${target.family}
+          AND candidate.generation = ${target.generation}
+        ORDER BY candidate.created_at, candidate.id
+        LIMIT ${limit}
+     )
+    RETURNING intent.id
+  `);
+  const intentCount = rebuildRowsOf(deletedIntents).length;
+  return intentCount > 0
+    ? { status: "deleted_intents", count: intentCount }
+    : { status: "empty", count: 0 };
+};
+
+/** Replace one empty, non-serving registration with its current manifest. */
+export const completeCorpusIndexGenerationRebuildTx = async (
+  tx: Transaction,
+  target: CorpusIndexGenerationTarget,
+): Promise<void> => {
+  await requireRebuildTarget(tx, target, "retiring");
+  const remaining = await tx.execute(sql`
+    SELECT EXISTS (
+      SELECT 1
+        FROM ${corpusIndexProjectionStates}
+       WHERE family = ${target.family}
+         AND generation = ${target.generation}
+    ) OR EXISTS (
+      SELECT 1
+        FROM ${corpusIndexProjectionIntents}
+       WHERE family = ${target.family}
+         AND generation = ${target.generation}
+    ) AS present
+  `);
+  const remainingRow = rebuildRowsOf(remaining).at(0);
+  if (!isRecord(remainingRow) || remainingRow["present"] !== false) {
+    return panic(
+      `Corpus generation rebuild state is not empty: ${target.family}/${target.generation}`,
+    );
+  }
+  const removed = await tx
+    .delete(corpusIndexGenerations)
+    .where(
+      and(
+        eq(corpusIndexGenerations.family, target.family),
+        eq(corpusIndexGenerations.generation, target.generation),
+        eq(corpusIndexGenerations.status, "retiring"),
+      ),
+    )
+    .returning({ generation: corpusIndexGenerations.generation });
+  if (removed.length !== 1) {
+    return panic(
+      `Corpus generation rebuild lost its registration: ${target.family}/${target.generation}`,
+    );
+  }
+  await registerCorpusIndexGenerationTx(tx, target);
 };


### PR DESCRIPTION
## Summary

- move one registered non-serving final generation from `building` to `retiring`
- delete its projection states before intents in bounded batches
- require empty projection state before replacing the immutable registration with the current manifest
- reuse the existing registration path so source activation and manifest validation remain centralized

## Tests

- registration stays non-serving throughout replacement
- completion fails while projection state remains
- states and intents are removed in dependency order
- the replacement is registered as a fresh `building` generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a controlled rebuild workflow for corpus indexes, including staged retirement, bounded cleanup, and final re-registration.
  * Rebuild progress now reports deleted records in batches, supporting safer processing of large indexes.
  * Added safeguards to prevent incomplete or unauthorised history removal during rebuilds.

* **Bug Fixes**
  * Prevented index rebuilds from completing while projection history remains.

* **Tests**
  * Added coverage for rebuild completion, deletion safeguards, batch cleanup, and successful finalisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->