### PR TITLE
fix(web): keep the case reader inspector dock above the law shell header

### DIFF
--- a/apps/web/src/components/authenticated-case-law-workspace.tsx
+++ b/apps/web/src/components/authenticated-case-law-workspace.tsx
@@ -16,6 +16,7 @@ import { DecisionWorkspace } from "@/features/case-law/components/case-viewer/de
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
 import { AuthenticatedUserProvider } from "@/lib/authenticated-user-context";
 import type { AuthenticatedUser } from "@/lib/authenticated-user-context";
+import { LAW_END_DOCK_WIDTH_VAR } from "@/lib/law-end-dock";
 import type { SafeId } from "@/lib/safe-id";
 
 type AuthenticatedCaseLawWorkspaceProps = {
@@ -102,12 +103,16 @@ const CaseLawInspector = ({
       "--folio-find-replace-right",
       widthPx,
     );
+    // The law shell's top bar spans the full window; it pads its inline-end
+    // by this width so its actions stay visible beside the dock.
+    document.documentElement.style.setProperty(LAW_END_DOCK_WIDTH_VAR, widthPx);
 
     return () => {
       document.documentElement.style.removeProperty(TOAST_RIGHT_OFFSET_VAR);
       document.documentElement.style.removeProperty(
         "--folio-find-replace-right",
       );
+      document.documentElement.style.removeProperty(LAW_END_DOCK_WIDTH_VAR);
     };
   }, [widthPx]);
 
@@ -120,8 +125,12 @@ const CaseLawInspector = ({
         data-state={showPaneContent ? "expanded" : "collapsed"}
       >
         <div className="bg-sidebar relative" style={{ width: widthPx }} />
+        {/* Full-height, above the shell top bar (sticky z-20): the dock's own
+            h-12 header owns the top row for its width, as in the workspace
+            chrome. The bar pads its inline-end by LAW_END_DOCK_WIDTH_VAR so
+            its actions are not covered. */}
         <div
-          className="fixed inset-y-0 end-0 z-10 hidden h-svh md:flex"
+          className="fixed inset-y-0 end-0 z-30 hidden h-svh md:flex"
           style={{ width: widthPx }}
         >
           {showPaneContent && (

--- a/apps/web/src/lib/law-end-dock.ts
+++ b/apps/web/src/lib/law-end-dock.ts
@@ -1,0 +1,6 @@
+/**
+ * Width of the case reader's docked inspector, published on the root element
+ * while the dock is mounted. The law shell's full-window top bar pads its
+ * inline-end by it so bar actions stay visible beside the dock.
+ */
+export const LAW_END_DOCK_WIDTH_VAR = "--law-end-dock-width";

--- a/apps/web/src/lib/law-end-dock.ts
+++ b/apps/web/src/lib/law-end-dock.ts
@@ -2,5 +2,9 @@
  * Width of the case reader's docked inspector, published on the root element
  * while the dock is mounted. The law shell's full-window top bar pads its
  * inline-end by it so bar actions stay visible beside the dock.
+ *
+ * The consuming Tailwind class in public-law-shell.tsx repeats the literal
+ * name (statically scanned classes cannot interpolate this constant); a
+ * rename must update both.
  */
 export const LAW_END_DOCK_WIDTH_VAR = "--law-end-dock-width";

--- a/apps/web/src/routes/law/-components/public-law-shell.tsx
+++ b/apps/web/src/routes/law/-components/public-law-shell.tsx
@@ -7,6 +7,7 @@ import { PublicWorkspaceShell } from "@/components/public-workspace-shell";
 import { SidebarTrigger, useSidebar } from "@/components/sidebar";
 import { TopBarCitations } from "@/features/case-law/components/top-bar-citations";
 import { ChromeHeaderActionsSlot } from "@/lib/chrome-header-actions";
+import { LAW_END_DOCK_WIDTH_VAR } from "@/lib/law-end-dock";
 import { toStatuteCountrySegment } from "@/lib/statute-route";
 import { PublicLawInspector } from "@/routes/law/-components/public-law-inspector";
 
@@ -67,7 +68,15 @@ function PublicLawTopBar() {
   });
 
   return (
-    <header className="bg-sidebar flex h-12 shrink-0 items-center gap-2 overflow-hidden border-b px-4">
+    <header
+      className="bg-sidebar flex h-12 shrink-0 items-center gap-2 overflow-hidden border-b px-4"
+      // The case reader's docked inspector overlays the bar's inline-end for
+      // its width (it owns the top row there); keep the bar's actions beside
+      // it rather than beneath it.
+      style={{
+        paddingInlineEnd: `calc(1rem + var(${LAW_END_DOCK_WIDTH_VAR}, 0px))`,
+      }}
+    >
       {isMobile && (
         <>
           <SidebarTrigger className="-ms-1" />

--- a/apps/web/src/routes/law/-components/public-law-shell.tsx
+++ b/apps/web/src/routes/law/-components/public-law-shell.tsx
@@ -7,7 +7,6 @@ import { PublicWorkspaceShell } from "@/components/public-workspace-shell";
 import { SidebarTrigger, useSidebar } from "@/components/sidebar";
 import { TopBarCitations } from "@/features/case-law/components/top-bar-citations";
 import { ChromeHeaderActionsSlot } from "@/lib/chrome-header-actions";
-import { LAW_END_DOCK_WIDTH_VAR } from "@/lib/law-end-dock";
 import { toStatuteCountrySegment } from "@/lib/statute-route";
 import { PublicLawInspector } from "@/routes/law/-components/public-law-inspector";
 
@@ -69,13 +68,12 @@ function PublicLawTopBar() {
 
   return (
     <header
-      className="bg-sidebar flex h-12 shrink-0 items-center gap-2 overflow-hidden border-b px-4"
       // The case reader's docked inspector overlays the bar's inline-end for
       // its width (it owns the top row there); keep the bar's actions beside
-      // it rather than beneath it.
-      style={{
-        paddingInlineEnd: `calc(1rem + var(${LAW_END_DOCK_WIDTH_VAR}, 0px))`,
-      }}
+      // it rather than beneath it. The dock renders from `md` up only, so
+      // the padding is scoped the same way — below `md` the plain px-4
+      // applies and the published width is ignored.
+      className="bg-sidebar flex h-12 shrink-0 items-center gap-2 overflow-hidden border-b px-4 md:pe-[calc(1rem+var(--law-end-dock-width,0px))]"
     >
       {isMobile && (
         <>


### PR DESCRIPTION
The law shell renders its header across the full window, unlike the workspace chrome, which stops at the content column. The case reader's docked inspector copied the workspace geometry (fixed, full height, z-10), so the shell header covered the dock's own header row: the tab close button and the rail toggle were rendered but hidden underneath it.

The dock now stacks above the bar and publishes its width as a CSS custom property; the bar pads its inline-end by that width so its own actions stay visible beside the dock.

https://claude.ai/code/session_01HkFVj9TLAggYEsdsfZhad8