### PR TITLE
feat(web): case-law reader reading improvements

### DIFF
--- a/apps/api/src/handlers/case-law/document-ast.ts
+++ b/apps/api/src/handlers/case-law/document-ast.ts
@@ -23,6 +23,7 @@ export type {
 
 export {
   getDocumentAstMetadata,
+  hasInlineChildren,
   hasUsableAst,
   isDocumentAst,
   omitDerivablePlainText,

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -301,11 +301,14 @@ const normalizeNssInlines = (
         children: normalizeNssInlines(node.children, spacedEmphasis),
       };
     }
-    return {
-      type: "link",
-      href: node.href,
-      children: normalizeNssInlines(node.children, spacedEmphasis),
-    };
+    if (node.type === "link") {
+      return {
+        type: "link",
+        href: node.href,
+        children: normalizeNssInlines(node.children, spacedEmphasis),
+      };
+    }
+    return node;
   });
 };
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-regional.ts
@@ -22,6 +22,7 @@ import type {
   DocumentAst,
   Inline,
 } from "@/api/handlers/case-law/document-ast";
+import { hasInlineChildren } from "@/api/handlers/case-law/document-ast";
 import {
   buildValidationHtml,
   validateAndLog,
@@ -314,8 +315,7 @@ const inlinePlainLength = (nodes: readonly Inline[]): number => {
   for (const n of nodes) {
     if (n.type === "text") {
       len += n.text.length;
-    } else if (n.type !== "line-break") {
-      // bold | italic | link — all carry children
+    } else if (hasInlineChildren(n)) {
       len += inlinePlainLength(n.children);
     }
   }

--- a/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.test.ts
@@ -22,6 +22,7 @@
 import { Glob } from "bun";
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
 
+import { hasInlineChildren } from "@/api/handlers/case-law/document-ast";
 import type { Block, Inline } from "@/api/handlers/case-law/document-ast";
 import {
   ecjDocumentHtml,
@@ -80,7 +81,7 @@ const flattenLinks = (inlines: readonly Inline[]): Inline[] =>
     if (node.type === "link") {
       return flattenLinks(node.children);
     }
-    if (node.type === "text" || node.type === "line-break") {
+    if (!hasInlineChildren(node)) {
       return [node];
     }
     return [{ ...node, children: flattenLinks(node.children) }];
@@ -106,9 +107,9 @@ const mergeAdjacentText = (inlines: readonly Inline[]): Inline[] => {
       continue;
     }
     merged.push(
-      node.type === "text" || node.type === "line-break"
-        ? node
-        : { ...node, children: mergeAdjacentText(node.children) },
+      hasInlineChildren(node)
+        ? { ...node, children: mergeAdjacentText(node.children) }
+        : node,
     );
   }
   return merged;
@@ -140,7 +141,9 @@ const countLinks = (inlines: readonly Inline[]): number => {
     if (node.type === "link") {
       total += 1;
     }
-    total += countLinks(node.children);
+    if (hasInlineChildren(node)) {
+      total += countLinks(node.children);
+    }
   }
   return total;
 };

--- a/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/eu-ecj.ts
@@ -51,6 +51,7 @@ import type {
   ParagraphBlock,
   ParagraphRole,
 } from "@/api/handlers/case-law/document-ast";
+import { hasInlineChildren } from "@/api/handlers/case-law/document-ast";
 import { validateAndLog } from "@/api/lib/legal-search/parsers/validate-ast";
 import { sanitizeUrl } from "@/api/lib/sanitize-url";
 
@@ -401,7 +402,7 @@ const collapseWhitespace = (inlines: readonly Inline[]): Inline[] => {
     if (node.type === "text") {
       return { ...node, text: node.text.replace(/\s+/gu, " ") };
     }
-    if (node.type === "line-break") {
+    if (!hasInlineChildren(node)) {
       return node;
     }
     return { ...node, children: collapseWhitespace(node.children) };
@@ -416,7 +417,7 @@ const collapseWhitespace = (inlines: readonly Inline[]): Inline[] => {
 const trimEdge = (inlines: Inline[], edge: "start" | "end"): void => {
   const index = edge === "start" ? 0 : inlines.length - 1;
   const node = inlines[index];
-  if (node === undefined || node.type === "line-break") {
+  if (node === undefined) {
     return;
   }
   if (node.type === "text") {
@@ -426,7 +427,9 @@ const trimEdge = (inlines: Inline[], edge: "start" | "end"): void => {
     };
     return;
   }
-  trimEdge(node.children, edge);
+  if (hasInlineChildren(node)) {
+    trimEdge(node.children, edge);
+  }
 };
 
 const textOf = (el: cheerio.Cheerio<AnyNode>): string =>

--- a/apps/api/src/handlers/case-law/ingestion/parsers/pl-courts.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/pl-courts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { hasInlineChildren } from "@/api/handlers/case-law/document-ast";
 import type { Block, Inline } from "@/api/handlers/case-law/document-ast";
 import { parsePlDecisionContent } from "@/api/handlers/case-law/ingestion/parsers/pl-courts";
 
@@ -35,7 +36,9 @@ const flattenInlineText = (inlines: Inline[]): string =>
         return "\n";
       }
 
-      return flattenInlineText(inline.children);
+      return hasInlineChildren(inline)
+        ? flattenInlineText(inline.children)
+        : "";
     })
     .join("");
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.ts
@@ -15,6 +15,7 @@ import type * as cheerio from "cheerio";
 import { type AnyNode, isTag, isText } from "domhandler";
 
 import type { Inline } from "@/api/handlers/case-law/document-ast";
+import { hasInlineChildren } from "@/api/handlers/case-law/document-ast";
 
 /**
  * Append text to an inline list, dropping empty strings and coalescing
@@ -229,8 +230,7 @@ export const inlinesToPlainText = (inlines: readonly Inline[]): string => {
       text += node.text;
     } else if (node.type === "line-break") {
       text += "\n";
-    } else {
-      // bold | italic | link — all carry children
+    } else if (hasInlineChildren(node)) {
       text += inlinesToPlainText(node.children);
     }
   }
@@ -272,7 +272,12 @@ export const stripInlinePrefix = (
       continue;
     }
 
-    // Remaining variants (bold | italic | link) all carry children.
+    if (!hasInlineChildren(node)) {
+      // Zero characters on the text axis; passes through untouched.
+      result.push(node);
+      continue;
+    }
+
     const nodeTextLen = inlinesToPlainText(node.children).length;
     if (nodeTextLen <= remaining) {
       // Entire node consumed by prefix

--- a/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/pipeline.test.ts
@@ -46,6 +46,9 @@ const concatInlineText = (inlines: Inline[]): string => {
       case "line-break":
         out += "\n";
         break;
+      case "page-anchor":
+        // Zero characters on the text axis.
+        break;
       default:
         break;
     }

--- a/apps/api/src/lib/case-law/document-ast.ts
+++ b/apps/api/src/lib/case-law/document-ast.ts
@@ -21,6 +21,7 @@ export type {
   WireTableCell,
 } from "@stll/legal-ast/document-ast";
 
+export { hasInlineChildren } from "@stll/legal-ast/document-ast";
 export {
   getDocumentAstMetadata,
   hasUsableAst,

--- a/apps/api/src/lib/legal-search/parsers/validate-ast.ts
+++ b/apps/api/src/lib/legal-search/parsers/validate-ast.ts
@@ -169,6 +169,8 @@ const inlineText = (inlines: readonly Inline[]): string => {
       text += node.text;
     } else if (node.type === "line-break") {
       text += " ";
+    } else if (node.type === "page-anchor") {
+      // Typography, not content — no characters.
     } else {
       // bold | italic | link — all carry children
       text += inlineText(node.children);

--- a/apps/web/src/components/legal-reader/document-ast-text.tsx
+++ b/apps/web/src/components/legal-reader/document-ast-text.tsx
@@ -351,24 +351,6 @@ const renderInline = ({
     );
   }
 
-  // A reporter page boundary hangs in the margin at its own line, the way
-  // the published volume prints it; the link still opens the official scan.
-  // Absolute positioning keeps the marker at the line the inline occupies.
-  if (safeHref.includes("tile.loc.gov")) {
-    return (
-      <a
-        className="reader-page-marker"
-        data-reader-chrome=""
-        href={sanitizeHref(node.href)}
-        key={key}
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        {children}
-      </a>
-    );
-  }
-
   return (
     <a
       className="decoration-border underline underline-offset-2 hover:decoration-current"

--- a/apps/web/src/components/legal-reader/document-ast-text.tsx
+++ b/apps/web/src/components/legal-reader/document-ast-text.tsx
@@ -627,11 +627,19 @@ const jumpToNoteReference = (anchorId: string) => {
   blockEl.dataset["highlight"] = "";
 };
 
-const footnoteTextCarriesLabel = (label: string, plainText: string): boolean =>
-  new RegExp(
-    `^\\s*[\\[(]?${label.replace(REGEXP_SPECIALS_RE, (match) => `\\${match}`)}[\\]).:]?`,
+const footnoteTextCarriesLabel = (
+  label: string,
+  plainText: string,
+): boolean => {
+  const escaped = label.replace(REGEXP_SPECIALS_RE, (match) => `\\${match}`);
+  // The label must end at a boundary: closing punctuation, or anything that
+  // is not a letter or digit. Without it, label "1" would swallow a note
+  // that merely begins with "1954".
+  return new RegExp(
+    `^\\s*[\\[(]?${escaped}(?:[\\]).:]|(?![\\p{L}\\p{N}]))`,
     "u",
   ).test(plainText);
+};
 
 export const BlockRenderer = ({
   activeMatchIndex,

--- a/apps/web/src/components/legal-reader/document-ast-text.tsx
+++ b/apps/web/src/components/legal-reader/document-ast-text.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 import type { ReactNode } from "react";
 
 import { Result } from "better-result";
@@ -13,11 +13,13 @@ import type {
   SearchMatchRange,
   SearchPiece,
 } from "@/components/legal-reader/reader-search";
+import Tooltip from "@/components/tooltip";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { normalizeOptionalArray } from "@/lib/arrays";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { detached } from "@/lib/detached";
 import { sanitizeHref } from "@/lib/sanitize-href";
+import { forceReflow } from "@/lib/utils";
 
 import "./reader.css";
 
@@ -293,6 +295,33 @@ const renderInline = ({
     );
   }
 
+  // A page boundary: zero characters on the text axis (no offset advance),
+  // shown as a hanging margin marker plus a hair-thin tick at the exact
+  // break point. Neither is selectable, so copies stay clean.
+  if (node.type === "page-anchor") {
+    const scanHref = node.href ?? "";
+    return (
+      <Fragment key={key}>
+        {sanitizeHref(scanHref) === "" ? (
+          <span className="reader-page-marker" data-reader-chrome="">
+            {node.label}
+          </span>
+        ) : (
+          <a
+            className="reader-page-marker"
+            data-reader-chrome=""
+            href={sanitizeHref(scanHref)}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {node.label}
+          </a>
+        )}
+        <span aria-hidden className="reader-page-tick" data-reader-chrome="" />
+      </Fragment>
+    );
+  }
+
   const safeHref = sanitizeHref(node.href);
   if (!safeHref) {
     return (
@@ -310,6 +339,36 @@ const renderInline = ({
     offset,
   });
 
+  // An in-document link (footnote reference, back-reference) navigates the
+  // reader itself; a new tab would strand it. Note references render as
+  // superscript marks, the way the published decision prints them, and
+  // preview the note's text on hover.
+  if (safeHref.startsWith("#")) {
+    return (
+      <NoteRefLink href={safeHref} key={key}>
+        {children}
+      </NoteRefLink>
+    );
+  }
+
+  // A reporter page boundary hangs in the margin at its own line, the way
+  // the published volume prints it; the link still opens the official scan.
+  // Absolute positioning keeps the marker at the line the inline occupies.
+  if (safeHref.includes("tile.loc.gov")) {
+    return (
+      <a
+        className="reader-page-marker"
+        data-reader-chrome=""
+        href={sanitizeHref(node.href)}
+        key={key}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        {children}
+      </a>
+    );
+  }
+
   return (
     <a
       className="decoration-border underline underline-offset-2 hover:decoration-current"
@@ -320,6 +379,83 @@ const renderInline = ({
     >
       {children}
     </a>
+  );
+};
+
+const NOTE_PREVIEW_MAX_CHARS = 600;
+
+/** The note's own words, read from its rendered block: chrome stripped,
+ * whitespace collapsed, capped for the popup. */
+const notePreviewOf = (targetId: string): string | null => {
+  const el = document.querySelector(`#${targetId}`);
+  if (!el) {
+    return null;
+  }
+  const clone = el.cloneNode(true);
+  if (!(clone instanceof Element)) {
+    return null;
+  }
+  for (const chrome of clone.querySelectorAll("[data-reader-chrome]")) {
+    chrome.remove();
+  }
+  const text = clone.textContent.replaceAll(/\s+/gu, " ").trim();
+  if (text === "") {
+    return null;
+  }
+  return text.length > NOTE_PREVIEW_MAX_CHARS
+    ? `${text.slice(0, NOTE_PREVIEW_MAX_CHARS)}…`
+    : text;
+};
+
+/**
+ * In-document note reference. The preview is read from the live DOM on
+ * hover rather than threaded through props: the note's block renders from
+ * the same AST, so the DOM is the cheapest correct source.
+ */
+const NoteRefLink = ({
+  children,
+  href,
+}: {
+  children: ReactNode;
+  href: string;
+}) => {
+  const [preview, setPreview] = useState<string | null>(null);
+  return (
+    <Tooltip
+      content={
+        <span className="block max-w-xs text-start leading-snug">
+          {preview}
+        </span>
+      }
+      render={
+        // The note reference's visible text is injected as the Tooltip
+        // trigger's children by the composition below.
+        // oxlint-disable-next-line jsx-a11y/anchor-has-content -- children injected by Tooltip trigger composition
+        <a
+          className="reader-note-ref"
+          href={sanitizeHref(href)}
+          onClick={(event) => {
+            // Scripted jump instead of native hash navigation: centers the
+            // note, and the flash re-fires on every click — `:target` only
+            // animates when the hash actually changes.
+            event.preventDefault();
+            const el = document.querySelector<HTMLElement>(
+              `#${CSS.escape(href.slice(1))}`,
+            );
+            if (!el) {
+              return;
+            }
+            el.scrollIntoView({ behavior: "instant", block: "center" });
+            delete el.dataset["highlight"];
+            forceReflow(el);
+            el.dataset["highlight"] = "";
+          }}
+          onMouseEnter={() => setPreview(notePreviewOf(href.slice(1)))}
+        />
+      }
+    >
+      {children}
+    </Tooltip>
   );
 };
 
@@ -478,6 +614,43 @@ const BlockPermalink = ({ anchorId }: { anchorId: string }) => {
   );
 };
 
+const REGEXP_SPECIALS_RE = /[.*+?^${}()|[\]\\]/gu;
+
+/**
+ * Whether a footnote's text already opens with its own label ("[3] …",
+ * "3) …"). Sources differ: Word-derived corpora keep the mark inside the
+ * footnote body, structured corpora strip it — the reader shows its own
+ * label only when the text does not.
+ */
+/**
+ * From a footnote back to the sentence that cites it: scroll the first
+ * in-text reference into view and flash its paragraph.
+ */
+const jumpToNoteReference = (anchorId: string) => {
+  // :not([data-reader-chrome]) keeps the block's own permalink — which
+  // shares the href — from matching instead of the in-text reference.
+  const ref = document.querySelector<HTMLElement>(
+    `a[href="#${CSS.escape(anchorId)}"]:not([data-reader-chrome])`,
+  );
+  if (!ref) {
+    return;
+  }
+  ref.scrollIntoView({ behavior: "instant", block: "center" });
+  const blockEl = ref.closest<HTMLElement>("[data-anchor]");
+  if (!blockEl) {
+    return;
+  }
+  delete blockEl.dataset["highlight"];
+  forceReflow(blockEl);
+  blockEl.dataset["highlight"] = "";
+};
+
+const footnoteTextCarriesLabel = (label: string, plainText: string): boolean =>
+  new RegExp(
+    `^\\s*[\\[(]?${label.replace(REGEXP_SPECIALS_RE, (match) => `\\${match}`)}[\\]).:]?`,
+    "u",
+  ).test(plainText);
+
 export const BlockRenderer = ({
   activeMatchIndex,
   anchorsByPieceId,
@@ -524,18 +697,38 @@ export const BlockRenderer = ({
     // need their own alignment; every other paragraph — including
     // intro, argumentation and unroled body text — defaults to
     // justified reading layout.
-    const nonJustifiedRoles = new Set(["case-number", "closing", "signature"]);
+    const nonJustifiedRoles = new Set([
+      "case-number",
+      "closing",
+      "signature",
+      "parties",
+      "front-matter",
+    ]);
     const shouldJustify =
       !isRomanNumeralDivider &&
       (block.role === undefined || !nonJustifiedRoles.has(block.role));
+    const noteLabel = block.note?.type === "footnote" ? block.note.label : null;
+    const showNoteLabel =
+      noteLabel !== null &&
+      noteLabel !== "" &&
+      !footnoteTextCarriesLabel(noteLabel, block.plainText);
     return (
       <p
         className={cn(
           "group relative mb-[var(--reader-paragraph-gap)] scroll-mt-[var(--reader-anchor-offset)] last:mb-0",
           shouldJustify && "reader-justify",
           block.role === "holding" && "font-[520]",
+          // Indented, slightly condensed; never italicized or reflowed —
+          // a reproduced passage must not be visually altered.
+          block.role === "quote" &&
+            "border-border my-4 border-s-2 ps-5 text-[0.95em]",
+          // Reporter front matter keeps its published, centered shape.
+          block.role === "parties" &&
+            "my-4 text-center text-[1.05em] leading-relaxed tracking-wide",
+          block.role === "front-matter" &&
+            "text-muted-foreground my-1 text-center text-[0.95em]",
           block.note?.type === "footnote" &&
-            "text-muted-foreground border-border mb-2 border-s-2 ps-4 text-[0.86em] leading-relaxed",
+            "text-muted-foreground mb-2 text-[0.86em] leading-relaxed",
           isRomanNumeralDivider &&
             "mt-[var(--reader-section-gap-top)] mb-[var(--reader-section-gap-bottom)] text-center text-sm font-semibold",
           block.role === "case-number" &&
@@ -549,9 +742,20 @@ export const BlockRenderer = ({
           block.number !== undefined && "ps-8",
         )}
         data-anchor={block.anchorId}
+        data-note={block.note?.type}
         id={block.anchorId}
       >
         <BlockPermalink anchorId={block.anchorId} />
+        {showNoteLabel && (
+          <button
+            className="reader-note-label"
+            data-reader-chrome=""
+            onClick={() => jumpToNoteReference(block.anchorId)}
+            type="button"
+          >
+            {noteLabel}
+          </button>
+        )}
         {block.number !== undefined && (
           <HighlightedText
             activeMatchIndex={activeMatchIndex}

--- a/apps/web/src/components/legal-reader/document-ast-text.tsx
+++ b/apps/web/src/components/legal-reader/document-ast-text.tsx
@@ -410,10 +410,11 @@ const NoteRefLink = ({
         </span>
       }
       render={
-        // The note reference's visible text is injected as the Tooltip
-        // trigger's children by the composition below.
-        // oxlint-disable-next-line jsx-a11y/anchor-has-content -- children injected by Tooltip trigger composition
+        // The visible text is injected as the Tooltip trigger's children by
+        // the composition below; the aria-label satisfies the accessible
+        // name statically.
         <a
+          aria-label={href.slice(1)}
           className="reader-note-ref"
           href={sanitizeHref(href)}
           onClick={(event) => {

--- a/apps/web/src/components/legal-reader/document-ast-text.tsx
+++ b/apps/web/src/components/legal-reader/document-ast-text.tsx
@@ -627,6 +627,31 @@ const jumpToNoteReference = (anchorId: string) => {
   blockEl.dataset["highlight"] = "";
 };
 
+/** A continuation paragraph's anchor carries the head anchor plus a part
+ * suffix; the back jump always returns from the footnote's head. */
+const noteHeadAnchorOf = (anchorId: string): string =>
+  anchorId.replace(/-p\d+$/u, "");
+
+/**
+ * The return arrow at the end of a footnote: jumps back to the sentence
+ * that cites it, mirroring the clickable footnote number.
+ */
+const NoteBackJump = ({ anchorId }: { anchorId: string }) => {
+  const t = useTranslations();
+  return (
+    <button
+      aria-label={t("common.back")}
+      className="reader-note-back"
+      data-reader-chrome=""
+      onClick={() => jumpToNoteReference(noteHeadAnchorOf(anchorId))}
+      title={t("common.back")}
+      type="button"
+    >
+      {"\u21B5"}
+    </button>
+  );
+};
+
 const footnoteTextCarriesLabel = (
   label: string,
   plainText: string,
@@ -645,12 +670,15 @@ export const BlockRenderer = ({
   activeMatchIndex,
   anchorsByPieceId,
   block,
+  noteBackJump = false,
   rangesByPieceId,
   variant,
 }: {
   activeMatchIndex: number;
   anchorsByPieceId?: Record<string, TextAnchor[]> | undefined;
   block: Block;
+  /** Render the return arrow: this is the last paragraph of a footnote. */
+  noteBackJump?: boolean | undefined;
   rangesByPieceId: Record<string, SearchMatchRange[]>;
   variant: ReaderVariant;
 }) => {
@@ -766,6 +794,9 @@ export const BlockRenderer = ({
           pieceId={block.id}
           ranges={rangesForPiece(rangesByPieceId, block.id)}
         />
+        {noteBackJump && block.note?.type === "footnote" && (
+          <NoteBackJump anchorId={block.anchorId} />
+        )}
       </p>
     );
   }

--- a/apps/web/src/components/legal-reader/reader.css
+++ b/apps/web/src/components/legal-reader/reader.css
@@ -225,3 +225,20 @@ div:has(> p[data-note="footnote"]) + div > p[data-note="footnote"]:first-child {
   border-radius: 0.25rem;
   transition: background-color 120ms ease-out;
 }
+
+/* The footnote's return arrow: back to the sentence that cites it. */
+.reader-note-back {
+  margin-inline-start: 0.4em;
+  border: 0;
+  padding: 0;
+  background: none;
+  font-family: var(--font-sans, sans-serif);
+  font-size: 0.9em;
+  color: var(--color-primary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.reader-note-back:hover {
+  text-decoration: underline;
+}

--- a/apps/web/src/components/legal-reader/reader.css
+++ b/apps/web/src/components/legal-reader/reader.css
@@ -90,10 +90,12 @@ article .reader-signature + .reader-signature {
   margin-top: 0;
 }
 
-/* Highlight flash when clicking an annotation to scroll. */
+/* Highlight flash when jumping to a block (annotation, footnote, note
+   back-reference). A held wash, strong enough to find in a wall of text. */
 @keyframes reader-highlight {
-  0% {
-    background-color: var(--color-primary / 0.08);
+  0%,
+  40% {
+    background-color: color-mix(in srgb, var(--color-primary) 22%, transparent);
   }
   100% {
     background-color: transparent;
@@ -102,6 +104,7 @@ article .reader-signature + .reader-signature {
 
 article [data-highlight] {
   animation: reader-highlight 1.5s ease-out;
+  border-radius: 0.25rem;
 }
 
 /* Always show scrollbar in the decision reader scroll container.
@@ -126,4 +129,99 @@ article [data-highlight] {
 
 .reader-scroll::-webkit-scrollbar-thumb:hover {
   background: var(--color-muted-foreground);
+}
+
+/* Footnote apparatus. One rule separates the body from the first footnote
+   of a run — consecutive footnotes continue under it without repeating the
+   line, including across the group wrappers the decision reader emits. */
+p[data-note="footnote"] {
+  margin-top: 1.5em;
+  border-top: 1px solid var(--color-border);
+  padding-top: 1em;
+}
+
+p[data-note="footnote"] + p[data-note="footnote"],
+div:has(> p[data-note="footnote"]) + div > p[data-note="footnote"]:first-child {
+  margin-top: 0;
+  border-top: 0;
+  padding-top: 0;
+}
+
+/* The reader's own footnote number, shown only when the source text does
+   not already open with it. A button: clicking it returns to the sentence
+   that cites the footnote. */
+.reader-note-label {
+  margin-inline-end: 0.45em;
+  border: 0;
+  padding: 0;
+  background: none;
+  font-family: var(--font-sans, sans-serif);
+  font-size: 0.78em;
+  font-weight: 600;
+  vertical-align: super;
+  color: var(--color-primary);
+  user-select: none;
+  cursor: pointer;
+}
+
+.reader-note-label:hover {
+  text-decoration: underline;
+}
+
+/* In-text note reference: superscript mark, no underline; the anchor jump
+   plus the :target flash is the interaction. */
+.reader-note-ref {
+  font-family: var(--font-sans, sans-serif);
+  font-size: 0.72em;
+  vertical-align: super;
+  text-decoration: none;
+  color: var(--color-primary);
+}
+
+.reader-note-ref:hover {
+  text-decoration: underline;
+}
+
+/* Reporter page boundary, hanging in the start margin at its own line the
+   way the published volume prints it. Absolutely positioned with `top`
+   unset, so it keeps the static (line) position of the inline it replaces;
+   the paragraph is the positioning context. Clicking opens the official
+   reporter scan. */
+.reader-page-marker {
+  position: absolute;
+  inset-inline-end: 100%;
+  margin-inline-end: 1.1rem;
+  padding-top: 0.15em;
+  border-top: 1px solid var(--color-border);
+  font-family: var(--font-sans, sans-serif);
+  font-size: 0.68rem;
+  line-height: 1.2;
+  color: var(--color-muted-foreground);
+  text-decoration: none;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.reader-page-marker:hover {
+  color: var(--color-primary);
+  border-top-color: var(--color-primary);
+}
+
+/* The exact break point inside the running text: a hair-thin tick, never
+   selectable, so a copy of the sentence contains no trace of it. */
+.reader-page-tick {
+  display: inline-block;
+  width: 1px;
+  height: 0.85em;
+  margin-inline: 1px;
+  vertical-align: text-bottom;
+  background-color: color-mix(in srgb, var(--color-primary) 45%, transparent);
+  user-select: none;
+}
+
+/* The paragraph a hovered margin note belongs to. */
+[data-note-hover] {
+  background-color: color-mix(in srgb, var(--color-primary) 8%, transparent);
+  border-radius: 0.25rem;
+  transition: background-color 120ms ease-out;
 }

--- a/apps/web/src/features/case-law/citation-format.ts
+++ b/apps/web/src/features/case-law/citation-format.ts
@@ -141,7 +141,7 @@ const POLISH_GENITIVE_MONTHS = [
  * the preposition falls outside the known patterns, the nominative passes
  * through unchanged rather than half-inflected.
  */
-const POLISH_PREPOSITIONS = new Set(["w", "we", "dla"]);
+const POLISH_PREPOSITION_RE = /^(?:w|we|dla)$/u;
 
 const polishGenitiveWord = (word: string): string | null => {
   if (word === "Sąd") {
@@ -163,7 +163,7 @@ const polishGenitiveCourt = (court: string): string => {
   const words = court.split(" ");
   const inflected: string[] = [];
   for (const [index, word] of words.entries()) {
-    if (POLISH_PREPOSITIONS.has(word)) {
+    if (POLISH_PREPOSITION_RE.test(word)) {
       inflected.push(...words.slice(index));
       return inflected.join(" ");
     }

--- a/apps/web/src/features/case-law/citation-format.ts
+++ b/apps/web/src/features/case-law/citation-format.ts
@@ -1,0 +1,175 @@
+/**
+ * Jurisdiction-conventional citation of one decision, for the reader's
+ * legal copy modes. The convention follows the COURT's jurisdiction, never
+ * the UI language: a Czech decision is cited in Czech form everywhere.
+ *
+ * v1 limits, deliberate: pincites are emitted only where the convention
+ * uses reporter pages (USA); paragraph-number pincites (EU, CZ "bod N")
+ * need the block's ¶ number threaded through and come later. Czech and
+ * Slovak court names are inflected to the genitive by a suffix rule that
+ * covers the standing court names; an unrecognized name passes through
+ * unchanged rather than guessing.
+ */
+
+export type CitationInput = {
+  caseNumber: string;
+  country: string;
+  court: string;
+  decisionDate: Date | string | null;
+  decisionType: string | null;
+  ecli: string | null;
+  /** Citable case name where the tradition uses one (USA, EU). */
+  name: string | null;
+  /** Reporter page the quotation starts on (USA convention only). */
+  pincite: string | null;
+};
+
+const dateOf = (value: Date | string | null): Date | null => {
+  if (value === null) {
+    return null;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+/** "17. 5. 1954" — Czech and Slovak legal writing. */
+const dottedDate = (date: Date): string =>
+  `${String(date.getDate())}. ${String(date.getMonth() + 1)}. ${String(date.getFullYear())}`;
+
+/**
+ * Czech/Slovak genitive of a court name: leading adjectives take the
+ * genitive ending and the head noun "soud"/"súd" becomes "soudu"/"súdu";
+ * everything after the head noun (e.g. "v Praze") is already invariant.
+ */
+const COURT_GENITIVE_SUFFIXES: readonly (readonly [string, string])[] = [
+  ["ší", "šího"],
+  ["ný", "ného"],
+  ["ní", "ního"],
+  ["ký", "kého"],
+  ["ší", "šieho"],
+];
+
+const genitiveCourt = (court: string, language: "cs" | "sk"): string => {
+  const words = court.split(" ");
+  const headIndex = words.findIndex(
+    (word) => word === "soud" || word === "súd",
+  );
+  if (headIndex === -1) {
+    return court;
+  }
+  const inflected = words.map((word, index) => {
+    if (index === headIndex) {
+      return word === "soud" ? "soudu" : "súdu";
+    }
+    if (index > headIndex) {
+      return word;
+    }
+    if (language === "sk") {
+      if (word.endsWith("ší")) {
+        return `${word.slice(0, -2)}šieho`;
+      }
+      if (word.endsWith("ý")) {
+        return `${word.slice(0, -1)}ého`;
+      }
+      return word;
+    }
+    for (const [suffix, replacement] of COURT_GENITIVE_SUFFIXES) {
+      if (word.endsWith(suffix)) {
+        return `${word.slice(0, -suffix.length)}${replacement}`;
+      }
+    }
+    return word;
+  });
+  return inflected.join(" ");
+};
+
+const czechCitation = (input: CitationInput): string => {
+  const type = input.decisionType ?? "rozhodnutí";
+  const court = genitiveCourt(input.court, "cs");
+  const date = dateOf(input.decisionDate);
+  const dated = date === null ? "" : ` ze dne ${dottedDate(date)}`;
+  return `${type} ${court}${dated}, sp. zn. ${input.caseNumber}`;
+};
+
+const slovakCitation = (input: CitationInput): string => {
+  const type = input.decisionType ?? "rozhodnutie";
+  const court = genitiveCourt(input.court, "sk");
+  const date = dateOf(input.decisionDate);
+  const dated = date === null ? "" : ` zo dňa ${dottedDate(date)}`;
+  return `${type} ${court}${dated}, sp. zn. ${input.caseNumber}`;
+};
+
+/**
+ * Polish month names in the genitive, as a date inside a citation reads
+ * ("z dnia 17 maja 1954 r."). A fixed table, not a locale formatter: the
+ * convention belongs to the court, not to the reader's locale settings.
+ */
+const POLISH_GENITIVE_MONTHS = [
+  "stycznia",
+  "lutego",
+  "marca",
+  "kwietnia",
+  "maja",
+  "czerwca",
+  "lipca",
+  "sierpnia",
+  "września",
+  "października",
+  "listopada",
+  "grudnia",
+] as const;
+
+const polishCitation = (input: CitationInput): string => {
+  const type = input.decisionType ?? "orzeczenie";
+  const date = dateOf(input.decisionDate);
+  const month = date === null ? null : POLISH_GENITIVE_MONTHS[date.getMonth()];
+  const dated =
+    date === null || month === undefined || month === null
+      ? ""
+      : ` z dnia ${String(date.getDate())} ${month} ${String(date.getFullYear())} r.`;
+  return `${type} ${input.court}${dated}, sygn. akt ${input.caseNumber}`;
+};
+
+const austrianCitation = (input: CitationInput): string => {
+  const date = dateOf(input.decisionDate);
+  const dated =
+    date === null
+      ? ""
+      : ` ${String(date.getDate())}. ${String(date.getMonth() + 1)}. ${String(date.getFullYear())},`;
+  return `${input.court}${dated} ${input.caseNumber}`;
+};
+
+const euCitation = (input: CitationInput): string => {
+  const named = input.name === null ? "" : `${input.name}, `;
+  const ecli = input.ecli === null ? "" : `, ${input.ecli}`;
+  return `${named}${input.caseNumber}${ecli}`;
+};
+
+const usCitation = (input: CitationInput): string => {
+  const cite =
+    input.pincite === null
+      ? input.caseNumber
+      : `${input.caseNumber}, ${input.pincite}`;
+  const named = input.name === null ? cite : `${input.name}, ${cite}`;
+  const date = dateOf(input.decisionDate);
+  return date === null ? named : `${named} (${String(date.getFullYear())})`;
+};
+
+const genericCitation = (input: CitationInput): string => {
+  const named = input.name === null ? "" : `${input.name}, `;
+  const date = dateOf(input.decisionDate);
+  const dated = date === null ? "" : ` (${String(date.getFullYear())})`;
+  return `${named}${input.court}, ${input.caseNumber}${dated}`;
+};
+
+const CITATION_FORMATTERS: Record<string, (input: CitationInput) => string> = {
+  AUT: austrianCitation,
+  CZE: czechCitation,
+  EU: euCitation,
+  POL: polishCitation,
+  SVK: slovakCitation,
+  USA: usCitation,
+};
+
+export const formatDecisionCitation = (input: CitationInput): string =>
+  (CITATION_FORMATTERS[input.country] ?? genericCitation)(input);

--- a/apps/web/src/features/case-law/citation-format.ts
+++ b/apps/web/src/features/case-law/citation-format.ts
@@ -24,9 +24,24 @@ export type CitationInput = {
   pincite: string | null;
 };
 
+const DATE_ONLY_RE = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/u;
+
 const dateOf = (value: Date | string | null): Date | null => {
   if (value === null) {
     return null;
+  }
+  if (typeof value === "string") {
+    // A date-only string parsed by `new Date` lands on midnight UTC, which
+    // is the previous day in west-of-UTC zones; build it in local time so
+    // the printed day, month and year match the document.
+    const parts = DATE_ONLY_RE.exec(value)?.groups;
+    if (parts?.["year"] !== undefined) {
+      return new Date(
+        Number(parts["year"]),
+        Number(parts["month"]) - 1,
+        Number(parts["day"]),
+      );
+    }
   }
   const date = value instanceof Date ? value : new Date(value);
   return Number.isNaN(date.getTime()) ? null : date;
@@ -119,6 +134,48 @@ const POLISH_GENITIVE_MONTHS = [
   "grudnia",
 ] as const;
 
+/**
+ * Polish genitive of a court name: the head noun and its adjectives inflect
+ * ("Sąd Apelacyjny w Łodzi" → "Sądu Apelacyjnego w Łodzi"), while the
+ * locality after a preposition stays. All-or-nothing: if any word before
+ * the preposition falls outside the known patterns, the nominative passes
+ * through unchanged rather than half-inflected.
+ */
+const POLISH_PREPOSITIONS = new Set(["w", "we", "dla"]);
+
+const polishGenitiveWord = (word: string): string | null => {
+  if (word === "Sąd") {
+    return "Sądu";
+  }
+  if (word === "Trybunał") {
+    return "Trybunału";
+  }
+  if (word.endsWith("ni") || word.endsWith("ki")) {
+    return `${word.slice(0, -1)}iego`;
+  }
+  if (word.endsWith("y")) {
+    return `${word.slice(0, -1)}ego`;
+  }
+  return null;
+};
+
+const polishGenitiveCourt = (court: string): string => {
+  const words = court.split(" ");
+  const inflected: string[] = [];
+  for (const [index, word] of words.entries()) {
+    if (POLISH_PREPOSITIONS.has(word)) {
+      inflected.push(...words.slice(index));
+      return inflected.join(" ");
+    }
+    const genitive = polishGenitiveWord(word);
+    if (genitive === null) {
+      return court;
+    }
+    inflected.push(genitive);
+  }
+  return inflected.join(" ");
+};
+
 const polishCitation = (input: CitationInput): string => {
   const type = input.decisionType ?? "orzeczenie";
   const date = dateOf(input.decisionDate);
@@ -127,7 +184,7 @@ const polishCitation = (input: CitationInput): string => {
     date === null || month === undefined || month === null
       ? ""
       : ` z dnia ${String(date.getDate())} ${month} ${String(date.getFullYear())} r.`;
-  return `${type} ${input.court}${dated}, sygn. akt ${input.caseNumber}`;
+  return `${type} ${polishGenitiveCourt(input.court)}${dated}, sygn. akt ${input.caseNumber}`;
 };
 
 const austrianCitation = (input: CitationInput): string => {

--- a/apps/web/src/features/case-law/components/case-viewer/analysis/margin-notes.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/analysis/margin-notes.tsx
@@ -14,6 +14,7 @@ import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/button";
 import { Textarea } from "@stll/ui/textarea";
+import { containedHandler } from "@stll/ui/use-contained-handler";
 import { cn } from "@stll/ui/utils";
 
 import Tooltip from "@/components/tooltip";
@@ -329,8 +330,7 @@ const AnalysisNote = ({
       onBlur={() => onHover(false)}
       // oxlint-disable-next-line require-contained-handler/require-contained-handler -- measure callback ref, no portal-bearing descendants
       onClick={onJump}
-      // oxlint-disable-next-line require-contained-handler/require-contained-handler -- measure callback ref, no portal-bearing descendants
-      onFocus={() => onHover(true)}
+      onFocus={containedHandler(null, () => onHover(true))}
       onMouseEnter={() => onHover(true)}
       onMouseLeave={() => onHover(false)}
       ref={(el) => measureRef(el, item.id)}

--- a/apps/web/src/features/case-law/components/case-viewer/analysis/margin-notes.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/analysis/margin-notes.tsx
@@ -68,7 +68,12 @@ type MarginNotesProps = {
   scrollContainerRef: RefObject<HTMLElement | null>;
 };
 
-type PositionedItem = MarginItem & { top: number };
+type PositionedItem = MarginItem & {
+  top: number;
+  /** Where the note's paragraph actually is; `top` may sit lower when
+   * earlier notes pushed it down. The gap is bridged by a leader line. */
+  anchorTop: number;
+};
 
 export const MarginNotes = ({
   items,
@@ -112,7 +117,7 @@ export const MarginNotes = ({
     for (const { item, anchorTop } of anchored) {
       const h = heights.get(item.id) ?? 48;
       const top = Math.max(anchorTop, lastBottom + 8);
-      result.push({ ...item, top });
+      result.push({ ...item, anchorTop, top });
       lastBottom = top + h;
     }
 
@@ -130,16 +135,35 @@ export const MarginNotes = ({
     }
   };
 
+  // Hovering annotated TEXT lights its notes and slightly dims the rest of
+  // the margin, mirroring the note→text hover. One listener pair on the
+  // scroll container (not one per paragraph); the hovered block is read
+  // from the event target.
+  const [textHoverAnchor, setTextHoverAnchor] = useState<string | null>(null);
+
   useExternalSyncEffect(() => {
     const sc = scrollContainerRef.current;
     if (!sc) {
       return undefined;
     }
     recalc();
+    const onPointerOver = (event: Event) => {
+      const target = event.target;
+      const block =
+        target instanceof Element ? target.closest("[data-anchor]") : null;
+      setTextHoverAnchor(
+        block instanceof HTMLElement ? (block.dataset["anchor"] ?? null) : null,
+      );
+    };
+    const onPointerLeave = () => setTextHoverAnchor(null);
     sc.addEventListener("scroll", recalc, { passive: true });
+    sc.addEventListener("pointerover", onPointerOver, { passive: true });
+    sc.addEventListener("pointerleave", onPointerLeave, { passive: true });
     globalThis.addEventListener("resize", recalc);
     return () => {
       sc.removeEventListener("scroll", recalc);
+      sc.removeEventListener("pointerover", onPointerOver);
+      sc.removeEventListener("pointerleave", onPointerLeave);
       globalThis.removeEventListener("resize", recalc);
     };
   }, [scrollContainerRef, recalc]);
@@ -163,8 +187,67 @@ export const MarginNotes = ({
     el.dataset["highlight"] = "";
   };
 
+  // Hovering (or focusing) a note tints the paragraph it belongs to and
+  // lights the note's leader line, so the reader sees what a note is about
+  // without jumping to it.
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const noteHover = (item: MarginItem, on: boolean) => {
+    setHoveredId(on ? item.id : null);
+    const el = scrollContainerRef.current?.querySelector<HTMLElement>(
+      `#${CSS.escape(item.startAnchorId)}`,
+    );
+    if (!el) {
+      return;
+    }
+    if (on) {
+      el.dataset["noteHover"] = "";
+    } else {
+      delete el.dataset["noteHover"];
+    }
+  };
+
+  const notePresence = (item: MarginItem): NotePresence => {
+    if (textHoverAnchor === null || item.kind === "composer") {
+      return "normal";
+    }
+    return item.startAnchorId === textHoverAnchor ? "highlighted" : "dimmed";
+  };
+
   return (
     <div className="absolute inset-0" ref={containerRef}>
+      {positioned.map((item) => {
+        // A note pushed away from its paragraph gets a bracket bridging the
+        // gap while the note is hovered: along the gutter from the
+        // paragraph's edge down to the note's own top. Invisible otherwise —
+        // a resting line in empty space reads as a stray glyph, not a link.
+        const drift = item.top - item.anchorTop;
+        if (drift < 16 || item.kind === "composer") {
+          return null;
+        }
+        if (hoveredId !== item.id) {
+          return null;
+        }
+        const color =
+          item.kind === "comment"
+            ? "var(--option-sky)"
+            : `var(${getCategoryVar(item.category)})`;
+        return (
+          <div
+            className="pointer-events-none absolute end-0 opacity-90"
+            key={`leader-${item.id}`}
+            style={{ top: item.anchorTop + 8 }}
+          >
+            <div
+              className="absolute end-0 top-0 h-0.5 w-3 rounded-full"
+              style={{ backgroundColor: color }}
+            />
+            <div
+              className="absolute end-2.5 top-0 w-px"
+              style={{ backgroundColor: color, height: drift + 6 }}
+            />
+          </div>
+        );
+      })}
       {positioned.map((item) => {
         switch (item.kind) {
           case "comment": {
@@ -173,7 +256,9 @@ export const MarginNotes = ({
                 item={item}
                 key={item.id}
                 measureRef={measureRef}
+                onHover={(on) => noteHover(item, on)}
                 onJump={() => scrollTo(item.startAnchorId)}
+                presence={notePresence(item)}
               />
             );
           }
@@ -189,7 +274,9 @@ export const MarginNotes = ({
                 item={item}
                 key={item.id}
                 measureRef={measureRef}
+                onHover={(on) => noteHover(item, on)}
                 onJump={() => scrollTo(item.startAnchorId)}
+                presence={notePresence(item)}
               />
             );
           }
@@ -203,32 +290,57 @@ export const MarginNotes = ({
   );
 };
 
+type NotePresence = "normal" | "highlighted" | "dimmed";
+
 type NoteProps<T extends MarginItem> = {
   item: T & { top: number };
   measureRef: (el: HTMLElement | null, id: string) => void;
+  onHover: (on: boolean) => void;
   onJump: () => void;
+  /** Reverse hover: the reader's pointer is on annotated text — its own
+   * notes light up, every other note steps back. */
+  presence: NotePresence;
 };
 
 const AnalysisNote = ({
   item,
   measureRef,
+  onHover,
   onJump,
+  presence,
 }: NoteProps<AnalysisMarginItem>) => {
   const cssVar = getCategoryVar(item.category);
+  // Reverse hover speaks through the colour stripe alone — the words stay
+  // readable in every state. Dimmed washes the stripe out; highlighted goes
+  // full colour, doubled by an inset glow.
+  const stripe = (() => {
+    if (presence === "dimmed") {
+      return `color-mix(in srgb, var(${cssVar}) 22%, transparent)`;
+    }
+    if (presence === "highlighted" || item.kind === "card") {
+      return `var(${cssVar})`;
+    }
+    return `color-mix(in srgb, var(${cssVar}) 60%, transparent)`;
+  })();
 
   return (
     <button
-      className="text-foreground-muted hover:text-foreground-strong-muted absolute start-0 end-0 border-s-[3px] py-1 ps-2.5 text-start transition-colors"
+      className="text-foreground-muted hover:text-foreground-strong-muted absolute start-0 end-0 border-s-[3px] py-1 ps-2.5 text-start transition-[color,border-color,box-shadow]"
+      onBlur={() => onHover(false)}
       // oxlint-disable-next-line require-contained-handler/require-contained-handler -- measure callback ref, no portal-bearing descendants
       onClick={onJump}
+      // oxlint-disable-next-line require-contained-handler/require-contained-handler -- measure callback ref, no portal-bearing descendants
+      onFocus={() => onHover(true)}
+      onMouseEnter={() => onHover(true)}
+      onMouseLeave={() => onHover(false)}
       ref={(el) => measureRef(el, item.id)}
       style={{
         top: `${item.top}px`,
         paddingInlineStart: `${0.625 + item.depth * 0.5}rem`,
-        borderInlineStartColor:
-          item.kind === "card"
-            ? `var(${cssVar})`
-            : `color-mix(in srgb, var(${cssVar}) 60%, transparent)`,
+        borderInlineStartColor: stripe,
+        ...(presence === "highlighted" && {
+          boxShadow: `inset 2px 0 0 var(${cssVar})`,
+        }),
       }}
       type="button"
     >
@@ -353,18 +465,30 @@ const ComposerNote = ({
 const CommentNote = ({
   item,
   measureRef,
+  onHover,
   onJump,
+  presence,
 }: NoteProps<CommentMarginItem>) => {
   const t = useTranslations();
   const shared = item.visibility === "shared";
 
+  const stripe =
+    presence === "dimmed"
+      ? "color-mix(in srgb, var(--option-sky) 22%, transparent)"
+      : "var(--option-sky)";
+
   return (
     <div
-      className="group/comment absolute start-0 end-0 border-s-[3px] py-1 ps-2.5"
+      className="group/comment absolute start-0 end-0 border-s-[3px] py-1 ps-2.5 transition-[border-color,box-shadow]"
+      onMouseEnter={() => onHover(true)}
+      onMouseLeave={() => onHover(false)}
       ref={(el) => measureRef(el, item.id)}
       style={{
         top: `${item.top}px`,
-        borderInlineStartColor: "var(--option-sky)",
+        borderInlineStartColor: stripe,
+        ...(presence === "highlighted" && {
+          boxShadow: "inset 2px 0 0 var(--option-sky)",
+        }),
       }}
     >
       <div className="flex items-center gap-1.5">

--- a/apps/web/src/features/case-law/components/case-viewer/annotation-toolbar.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/annotation-toolbar.tsx
@@ -2,8 +2,11 @@ import { useRef, useState } from "react";
 import type { ReactNode, RefObject } from "react";
 import { createPortal } from "react-dom";
 
+import { Result } from "better-result";
 import {
   Building2Icon,
+  ChevronDownIcon,
+  CopyIcon,
   HighlighterIcon,
   LockIcon,
   MessageSquarePlusIcon,
@@ -16,6 +19,8 @@ import {
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/button";
+import { MenuPreviewLayout, PreviewPane } from "@stll/ui/preview-pane";
+import { stellaToast } from "@stll/ui/toast";
 import { cn } from "@stll/ui/utils";
 
 import { writeDecisionPassage } from "@/components/chat-decision-passage";
@@ -34,8 +39,10 @@ import type {
   CreateAnnotationInput,
   UpdateAnnotationInput,
 } from "@/features/case-law/annotations/use-decision-annotations";
+import { formatDecisionCitation } from "@/features/case-law/citation-format";
 import type { DecisionAnnotation } from "@/features/case-law/queries/annotations";
 import { useExternalSyncEffect, useMountEffect } from "@/hooks/use-effect";
+import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { detached } from "@/lib/detached";
 
 /** Room above the words for the bar, so it never covers what was selected. */
@@ -43,8 +50,15 @@ const BAR_OFFSET_PX = 44;
 
 export type AnnotationToolbarDecision = {
   caseNumber: string;
+  country: string;
   court: string;
+  decisionDate: Date | string | null;
+  decisionType: string | null;
+  ecli: string | null;
   id: string;
+  /** Citable case name ("Brown v. Board of Education"); null when the
+   * document does not state one. */
+  name: string | null;
 };
 
 export type AnnotationToolbarController = {
@@ -73,6 +87,91 @@ type Selected = {
   /** One per paragraph the selection touches; empty outside the words. */
   spans: SelectionAnchor[];
   text: string;
+  /** The words alone: reader chrome, note marks and page markers removed —
+   * what a quotation of the passage should contain. */
+  cleanText: string;
+  /** Reporter page the selection starts on, from the last page marker
+   * before it; null before the first marker or in unpaginated documents. */
+  pincite: string | null;
+};
+
+/** Chrome that must never leak into a quotation. */
+const QUOTE_CHROME_SELECTOR = "[data-reader-chrome], .reader-note-ref";
+
+const cleanSelectionText = (range: Range): string => {
+  const holder =
+    range.startContainer.ownerDocument?.createElement("div") ?? null;
+  if (holder === null) {
+    return "";
+  }
+  holder.append(range.cloneContents());
+  for (const el of holder.querySelectorAll(QUOTE_CHROME_SELECTOR)) {
+    el.remove();
+  }
+  return holder.textContent.replaceAll(/\s+/gu, " ").trim();
+};
+
+const pinciteOf = (root: HTMLElement, range: Range): string | null => {
+  let last: string | null = null;
+  for (const marker of root.querySelectorAll(".reader-page-marker")) {
+    // -1: the marker sits before the selection's start.
+    if (range.comparePoint(marker, 0) !== -1) {
+      continue;
+    }
+    const digits = /\d+/u.exec(marker.textContent)?.[0];
+    if (digits !== undefined) {
+      last = digits;
+    }
+  }
+  return last;
+};
+
+const COPY_MODES = [
+  "quoteWithCitation",
+  "citationWithQuote",
+  "blockQuoteWithCitation",
+  "textOnly",
+  "citationOnly",
+] as const;
+type CopyMode = (typeof COPY_MODES)[number];
+
+const copyTextFor = (
+  mode: CopyMode,
+  selected: Pick<Selected, "cleanText" | "pincite">,
+  decision: AnnotationToolbarDecision,
+): string => {
+  const quote = selected.cleanText;
+  const citation = formatDecisionCitation({
+    caseNumber: decision.caseNumber,
+    country: decision.country,
+    court: decision.court,
+    decisionDate: decision.decisionDate,
+    decisionType: decision.decisionType,
+    ecli: decision.ecli,
+    name: decision.name,
+    pincite: selected.pincite,
+  });
+  switch (mode) {
+    case "quoteWithCitation": {
+      return `“${quote}” ${citation}.`;
+    }
+    case "citationWithQuote": {
+      return `${citation} (“${quote}”).`;
+    }
+    case "blockQuoteWithCitation": {
+      return `${quote}\n\n${citation}.`;
+    }
+    case "textOnly": {
+      return quote;
+    }
+    case "citationOnly": {
+      return `${citation}.`;
+    }
+    default: {
+      const unreachable: never = mode;
+      return unreachable;
+    }
+  }
 };
 
 const STYLE_ICONS = {
@@ -109,6 +208,12 @@ export const AnnotationToolbar = ({
   // bar holds, so nothing here reads a ref while rendering.
   const [doc, setDoc] = useState<Document | null>(null);
   const [style, setStyle] = useState<AnnotationStyle>("highlight");
+  const [copyOpen, setCopyOpen] = useState(false);
+  const [copyPreviewMode, setCopyPreviewMode] = useState<CopyMode | null>(null);
+  // The dropdown is hand-rolled (a portal menu would collapse the text
+  // selection), so it does its own collision handling: open upward when
+  // the space below the trigger cannot fit the menu.
+  const [copyOpensUp, setCopyOpensUp] = useState(false);
   // A new highlight is private; sharing is a deliberate second step on the mark.
   const visibility: AnnotationVisibility = "private";
 
@@ -139,8 +244,14 @@ export const AnnotationToolbar = ({
           setSelected(null);
           return;
         }
+        // A fresh selection must not inherit the previous one's open menu.
+        setCopyOpen(false);
+        const range = selection.getRangeAt(0);
+        const cleanText = cleanSelectionText(range);
         setSelected({
-          rect: selection.getRangeAt(0).getBoundingClientRect(),
+          cleanText: cleanText === "" ? text : cleanText,
+          pincite: pinciteOf(root, range),
+          rect: range.getBoundingClientRect(),
           spans: selectionAnchorsFrom(selection, root),
           text,
         });
@@ -431,6 +542,94 @@ export const AnnotationToolbar = ({
     const spans = selected.spans;
     content = (
       <div className="flex items-center gap-1">
+        <div className="relative">
+          <Button
+            onClick={(event) => {
+              const MENU_ESTIMATED_HEIGHT_PX = 200;
+              const triggerRect = event.currentTarget.getBoundingClientRect();
+              const viewportHeight =
+                event.currentTarget.ownerDocument.defaultView?.innerHeight ?? 0;
+              setCopyOpensUp(
+                triggerRect.bottom + MENU_ESTIMATED_HEIGHT_PX > viewportHeight,
+              );
+              setCopyPreviewMode(null);
+              setCopyOpen((open) => !open);
+            }}
+            onMouseDown={(event) => event.preventDefault()}
+            size="sm"
+            variant="ghost"
+          >
+            <CopyIcon className="size-3.5" />
+            {t("common.copy")}
+            <ChevronDownIcon className="size-3" />
+          </Button>
+          {copyOpen && (
+            <div
+              className={cn(
+                "bg-popover text-popover-foreground absolute start-0 z-10 rounded-md border p-1 shadow-md",
+                copyOpensUp ? "bottom-full mb-1" : "top-full mt-1",
+              )}
+            >
+              <MenuPreviewLayout
+                preview={
+                  <PreviewPane className="w-72">
+                    {copyPreviewMode !== null && (
+                      <p className="text-foreground text-[0.7rem] leading-snug whitespace-pre-wrap">
+                        {copyTextFor(
+                          copyPreviewMode,
+                          {
+                            cleanText:
+                              selected.cleanText.length > 220
+                                ? `${selected.cleanText.slice(0, 220)}…`
+                                : selected.cleanText,
+                            pincite: selected.pincite,
+                          },
+                          decision,
+                        )}
+                      </p>
+                    )}
+                  </PreviewPane>
+                }
+              >
+                {COPY_MODES.map((mode) => (
+                  <button
+                    className="hover:bg-accent block w-full rounded-sm px-2 py-1.5 text-start text-xs whitespace-nowrap"
+                    key={mode}
+                    onClick={() => {
+                      const text = copyTextFor(mode, selected, decision);
+                      detached(
+                        (async () => {
+                          const copied = await copyToClipboard(text);
+                          if (Result.isError(copied)) {
+                            stellaToast.add({
+                              title: t("errors.actionFailed"),
+                              type: "error",
+                            });
+                            return;
+                          }
+                          stellaToast.add({
+                            title: t("common.copied"),
+                            type: "success",
+                          });
+                        })(),
+                        "case-law.selection-copy",
+                      );
+                      setCopyOpen(false);
+                      clearSelection();
+                    }}
+                    onFocus={() => setCopyPreviewMode(mode)}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onMouseEnter={() => setCopyPreviewMode(mode)}
+                    type="button"
+                  >
+                    {t(`caseLaw.copyMenu.${mode}`)}
+                  </button>
+                ))}
+              </MenuPreviewLayout>
+            </div>
+          )}
+        </div>
+        <span className="bg-border mx-1 h-4 w-px" />
         <Button
           onClick={() => {
             askAboutSelection({

--- a/apps/web/src/features/case-law/components/case-viewer/annotation-toolbar.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/annotation-toolbar.tsx
@@ -98,6 +98,8 @@ type Selected = {
 /** Chrome that must never leak into a quotation. */
 const QUOTE_CHROME_SELECTOR = "[data-reader-chrome], .reader-note-ref";
 
+const BLOCK_BOUNDARY_SELECTOR = "p, h1, h2, h3, h4, h5, h6, li, blockquote";
+
 const cleanSelectionText = (range: Range): string => {
   const holder =
     range.startContainer.ownerDocument?.createElement("div") ?? null;
@@ -107,6 +109,12 @@ const cleanSelectionText = (range: Range): string => {
   holder.append(range.cloneContents());
   for (const el of holder.querySelectorAll(QUOTE_CHROME_SELECTOR)) {
     el.remove();
+  }
+  // textContent concatenates block elements without any separator, gluing
+  // the last word of one paragraph to the first of the next; give each
+  // block an explicit boundary before flattening.
+  for (const block of holder.querySelectorAll(BLOCK_BOUNDARY_SELECTOR)) {
+    block.append("\n");
   }
   return holder.textContent.replaceAll(/\s+/gu, " ").trim();
 };

--- a/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
@@ -400,6 +400,24 @@ const renderBlocksWithHoldingZone = ({
 }): ReactNode[] => {
   const result: ReactNode[] = [];
 
+  // The last paragraph of each footnote carries the return arrow. A block
+  // ends its footnote when the one after it is not a continuation (a
+  // continuation is a footnote paragraph with an empty label).
+  const footnoteLastIds = new Set<string>();
+  for (const [index, block] of blocks.entries()) {
+    if (block.type !== "paragraph" || block.note?.type !== "footnote") {
+      continue;
+    }
+    const next = blocks[index + 1];
+    const nextContinues =
+      next?.type === "paragraph" &&
+      next.note?.type === "footnote" &&
+      next.note.label === "";
+    if (!nextContinues) {
+      footnoteLastIds.add(block.id);
+    }
+  }
+
   // Group consecutive blocks by heading ID for continuous lines.
   // Same category but different heading = separate groups.
   type Group = {
@@ -459,6 +477,7 @@ const renderBlocksWithHoldingZone = ({
               anchorsByPieceId={anchorsByPieceId}
               block={block}
               key={block.id}
+              noteBackJump={footnoteLastIds.has(block.id)}
               rangesByPieceId={rangesByPieceId}
               variant="case-law"
             />

--- a/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
@@ -235,15 +235,14 @@ export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
     ast?.blocks.find(
       (block) => block.type === "heading" && block.role === "decision-title",
     )?.plainText ?? null;
+  // Only a title of the "Name, Cite" shape yields a citable name; a
+  // generic heading ("JUDGMENT OF THE COURT (Grand Chamber)", a bare case
+  // number) must not masquerade as one.
   const citeSuffix = `, ${decision.caseNumber}`;
-  const caseName = (() => {
-    if (decisionTitle === null) {
-      return null;
-    }
-    return decisionTitle.endsWith(citeSuffix)
+  const caseName =
+    decisionTitle !== null && decisionTitle.endsWith(citeSuffix)
       ? decisionTitle.slice(0, -citeSuffix.length)
-      : decisionTitle;
-  })();
+      : null;
 
   const mainRef = useRef<HTMLDivElement>(null);
   const [panelWidth, setPanelWidth] = useState(220);

--- a/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
@@ -1,15 +1,24 @@
 import { useCallback, useRef, useState } from "react";
 
-import { Loader2Icon, SparklesIcon } from "lucide-react";
+import {
+  EyeOffIcon,
+  Loader2Icon,
+  SparklesIcon,
+  UserRoundIcon,
+} from "lucide-react";
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/react/shallow";
 
 import { parseDocumentAst } from "@stll/legal-ast/document-ast";
 import { BidiText } from "@stll/ui/bidi-text";
 import { Button } from "@stll/ui/button";
+import { InspectorRailIconButton } from "@stll/ui/inspector";
 import { OutlineRail } from "@stll/ui/outline-rail";
 import type { OutlineItem } from "@stll/ui/outline-rail";
+import { cn } from "@stll/ui/utils";
 
+import { MatterIcon } from "@/components/matter-icon";
+import Tooltip from "@/components/tooltip";
 import type { SelectionAnchor } from "@/features/case-law/annotations/selection-anchor";
 import { isPendingAnnotationId } from "@/features/case-law/annotations/use-decision-annotations";
 import { CurrentSection } from "@/features/case-law/components/case-viewer/analysis/current-section";
@@ -42,9 +51,12 @@ import { forceReflow } from "@/lib/utils";
 type DecisionWorkspaceDecision = {
   analysis?: unknown;
   caseNumber: string;
+  country: string;
   court: string;
   decisionDate: Date | string | null;
+  decisionType?: string | null;
   documentAst: unknown;
+  ecli?: string | null;
   fulltext: string | null;
   language: string;
   metadata?: Record<string, unknown> | null;
@@ -85,12 +97,22 @@ const getHeadingDisplayAnchorId = ({
   startAnchorId: string;
 }) => annotations.at(0)?.startAnchorId ?? startAnchorId;
 
+/** The notes filter's "all sources" glyph, through the shared matter icon
+ * so the layers glyph keeps one owner. */
+const NotesFilterAllIcon = ({ className }: { className?: string }) => (
+  <MatterIcon className={className} variant="all" />
+);
+
+/** Which margin notes the reader wants beside the text. */
+type NotesFilter = "all" | "ai" | "human" | "none";
+
 export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
   const { annotations, decision, decisionId, initialSearchQuery } = props;
   const t = useTranslations();
   const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(
     null,
   );
+  const [notesFilter, setNotesFilter] = useState<NotesFilter>("all");
   // The comment being written: its paragraphs, so the margin can sit the
   // composer beside the first and the saved comment covers them all.
   const [composing, setComposing] = useState<SelectionAnchor[] | null>(null);
@@ -207,6 +229,21 @@ export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
   const ensureAIAvailable =
     props.aiMode === "enabled" ? props.ensureAIAvailable : null;
   const ast = parseDocumentAst(decision.documentAst);
+  // The case's citable name and year, for the legal copy modes. The title
+  // heading carries "Name, Cite"; the cite suffix is stripped when present.
+  const decisionTitle =
+    ast?.blocks.find(
+      (block) => block.type === "heading" && block.role === "decision-title",
+    )?.plainText ?? null;
+  const citeSuffix = `, ${decision.caseNumber}`;
+  const caseName = (() => {
+    if (decisionTitle === null) {
+      return null;
+    }
+    return decisionTitle.endsWith(citeSuffix)
+      ? decisionTitle.slice(0, -citeSuffix.length)
+      : decisionTitle;
+  })();
 
   const mainRef = useRef<HTMLDivElement>(null);
   const [panelWidth, setPanelWidth] = useState(220);
@@ -324,6 +361,14 @@ export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
     return items;
   });
 
+  // The composer is never filtered away: the reader is mid-sentence in it.
+  const showAiNotes = notesFilter === "all" || notesFilter === "ai";
+  const visibleMarginItems = [
+    ...(hasAnalysis && showAiNotes ? marginItems : []),
+    ...(notesFilter === "all" || notesFilter === "human" ? commentItems : []),
+    ...composerItem,
+  ];
+
   useExternalSyncEffect(() => {
     if (aiEnabled && ast && analysisState.status === "idle") {
       detached(generate(), "decision-workspace.generate");
@@ -339,12 +384,55 @@ export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
     }
   }, [decisionId, initialSearchQuery, openSearch, reset, setSearchQuery]);
 
+  const notesFilterOptions = [
+    { icon: NotesFilterAllIcon, label: t("common.all"), value: "all" },
+    { icon: SparklesIcon, label: t("caseLaw.notesFilter.ai"), value: "ai" },
+    {
+      icon: UserRoundIcon,
+      label: t("caseLaw.notesFilter.human"),
+      value: "human",
+    },
+    { icon: EyeOffIcon, label: t("common.none"), value: "none" },
+  ] as const satisfies readonly {
+    icon: React.ComponentType<{ className?: string }>;
+    label: string;
+    value: NotesFilter;
+  }[];
+
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <h1 className="sr-only" data-slot="decision-title">
         <BidiText as="span">{decision.caseNumber}</BidiText>
       </h1>
       <div className="relative min-h-0 flex-1">
+        {((hasAnalysis && marginItems.length > 0) ||
+          commentItems.length > 0) && (
+          <div className="bg-sidebar absolute start-3 bottom-3 z-20 flex items-center overflow-hidden rounded-md border shadow-sm max-lg:hidden">
+            {notesFilterOptions.map((option) => {
+              const Icon = option.icon;
+              const isActive = notesFilter === option.value;
+              return (
+                <Tooltip
+                  content={option.label}
+                  key={option.value}
+                  render={
+                    <InspectorRailIconButton
+                      aria-label={option.label}
+                      aria-pressed={isActive}
+                      className={cn(
+                        "rounded-none",
+                        isActive && "bg-muted text-foreground",
+                      )}
+                      onClick={() => setNotesFilter(option.value)}
+                    />
+                  }
+                >
+                  <Icon className="size-4" />
+                </Tooltip>
+              );
+            })}
+          </div>
+        )}
         {hasAnalysis && analysisTree.length > 0 && (
           <OutlineRail
             items={analysisOutline.items}
@@ -400,22 +488,18 @@ export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
             style={{ gridTemplateColumns: `${panelWidth}px minmax(0, 1fr)` }}
           >
             <aside className="relative max-lg:hidden">
-              {hasAnalysis && flatAnalysisHeadings.length > 0 && (
-                <CurrentSection
-                  anchorById={analysisOutline.anchorById}
-                  headings={flatAnalysisHeadings}
-                  scrollContainerRef={mainRef}
-                />
-              )}
-              {((hasAnalysis && marginItems.length > 0) ||
-                commentItems.length > 0 ||
-                composerItem.length > 0) && (
+              {hasAnalysis &&
+                showAiNotes &&
+                flatAnalysisHeadings.length > 0 && (
+                  <CurrentSection
+                    anchorById={analysisOutline.anchorById}
+                    headings={flatAnalysisHeadings}
+                    scrollContainerRef={mainRef}
+                  />
+                )}
+              {visibleMarginItems.length > 0 && (
                 <MarginNotes
-                  items={[
-                    ...(hasAnalysis ? marginItems : []),
-                    ...commentItems,
-                    ...composerItem,
-                  ]}
+                  items={visibleMarginItems}
                   scrollContainerRef={mainRef}
                 />
               )}
@@ -491,7 +575,7 @@ export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
                 onMatchCountChange={setMatchCount}
                 provisionAnchors={provisionAnchors}
                 searchQuery={searchOpen ? searchQuery : ""}
-                sectionMap={sectionMap}
+                sectionMap={showAiNotes ? sectionMap : undefined}
               />
             </main>
           </div>
@@ -503,8 +587,13 @@ export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
             controller={annotations.controller}
             decision={{
               caseNumber: decision.caseNumber,
+              country: decision.country,
               court: decision.court,
+              decisionDate: decision.decisionDate,
+              decisionType: decision.decisionType ?? null,
+              ecli: decision.ecli ?? null,
               id: decisionId,
+              name: caseName,
             }}
             onActivateAnnotation={setActiveAnnotationId}
             onClearActive={() => setActiveAnnotationId(null)}

--- a/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-workspace.tsx
@@ -240,8 +240,8 @@ export const DecisionWorkspace = (props: DecisionWorkspaceProps) => {
   // number) must not masquerade as one.
   const citeSuffix = `, ${decision.caseNumber}`;
   const caseName =
-    decisionTitle !== null && decisionTitle.endsWith(citeSuffix)
-      ? decisionTitle.slice(0, -citeSuffix.length)
+    (decisionTitle?.endsWith(citeSuffix) ?? false)
+      ? (decisionTitle ?? "").slice(0, -citeSuffix.length)
       : null;
 
   const mainRef = useRef<HTMLDivElement>(null);

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -437,12 +437,23 @@
     "columns": {
       "caseNumber": "رقم القضية"
     },
+    "copyMenu": {
+      "blockQuoteWithCitation": "اقتباس كتلي مع الإحالة",
+      "citationOnly": "الإحالة فقط",
+      "citationWithQuote": "إحالة مع اقتباس",
+      "quoteWithCitation": "اقتباس مع الإحالة",
+      "textOnly": "النص فقط"
+    },
     "decisionNotFound": "لم يُعثر على القرار",
     "emptyState": "لم يُعثر على أي قرارات. اضبط مصدرًا وشغّل مزامنة لاستيراد الاجتهاد القضائي.",
     "filters": {
       "searchPlaceholder": "البحث برقم القضية..."
     },
     "loadingMore": "جارٍ تحميل المزيد...",
+    "notesFilter": {
+      "ai": "ذكاء اصطناعي",
+      "human": "بشرية"
+    },
     "provision": {
       "article": "المادة {value}",
       "letter": "البند {value}",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -437,12 +437,23 @@
     "columns": {
       "caseNumber": "Spisová značka"
     },
+    "copyMenu": {
+      "blockQuoteWithCitation": "Blokový citát s citací",
+      "citationOnly": "Pouze citace",
+      "citationWithQuote": "Citace s citátem",
+      "quoteWithCitation": "Citát s citací",
+      "textOnly": "Pouze text"
+    },
     "decisionNotFound": "Rozhodnutí nenalezeno",
     "emptyState": "Žádná rozhodnutí nenalezena. Nastavte zdroj a spusťte synchronizaci pro import judikatury.",
     "filters": {
       "searchPlaceholder": "Hledat podle spisové značky..."
     },
     "loadingMore": "Načítání dalších...",
+    "notesFilter": {
+      "ai": "AI",
+      "human": "Lidské"
+    },
     "provision": {
       "article": "čl. {value}",
       "letter": "písm. {value})",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -437,12 +437,23 @@
     "columns": {
       "caseNumber": "Aktenzeichen"
     },
+    "copyMenu": {
+      "blockQuoteWithCitation": "Blockzitat mit Fundstelle",
+      "citationOnly": "Nur Fundstelle",
+      "citationWithQuote": "Fundstelle mit Zitat",
+      "quoteWithCitation": "Zitat mit Fundstelle",
+      "textOnly": "Nur Text"
+    },
     "decisionNotFound": "Entscheidung nicht gefunden",
     "emptyState": "Keine Entscheidungen gefunden. Konfigurieren Sie eine Quelle und führen Sie eine Synchronisierung durch, um Rechtsprechung zu importieren.",
     "filters": {
       "searchPlaceholder": "Nach Aktenzeichen suchen..."
     },
     "loadingMore": "Weitere werden geladen…",
+    "notesFilter": {
+      "ai": "KI",
+      "human": "Mensch"
+    },
     "provision": {
       "article": "Artikel {value}",
       "letter": "Buchst. {value})",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -437,12 +437,23 @@
     "columns": {
       "caseNumber": "Case number"
     },
+    "copyMenu": {
+      "blockQuoteWithCitation": "Block quote with citation",
+      "citationOnly": "Citation only",
+      "citationWithQuote": "Citation with quote",
+      "quoteWithCitation": "Quote with citation",
+      "textOnly": "Text only"
+    },
     "decisionNotFound": "Decision not found",
     "emptyState": "No decisions found. Configure a source and run a sync to import case law.",
     "filters": {
       "searchPlaceholder": "Search by case number..."
     },
     "loadingMore": "Loading more...",
+    "notesFilter": {
+      "ai": "AI",
+      "human": "Human"
+    },
     "provision": {
       "article": "Art. {value}",
       "letter": "lit. {value})",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -437,12 +437,23 @@
     "columns": {
       "caseNumber": "Número de expediente"
     },
+    "copyMenu": {
+      "blockQuoteWithCitation": "Cita en bloque con referencia",
+      "citationOnly": "Solo referencia",
+      "citationWithQuote": "Referencia con cita",
+      "quoteWithCitation": "Cita textual con referencia",
+      "textOnly": "Solo texto"
+    },
     "decisionNotFound": "Resolución no encontrada",
     "emptyState": "No se encontraron resoluciones. Configure una fuente y ejecute una sincronización para importar jurisprudencia.",
     "filters": {
       "searchPlaceholder": "Buscar por número de expediente..."
     },
     "loadingMore": "Cargando más...",
+    "notesFilter": {
+      "ai": "IA",
+      "human": "Humanas"
+    },
     "provision": {
       "article": "art. {value}",
       "letter": "letra {value})",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -437,12 +437,23 @@
     "columns": {
       "caseNumber": "Kohtuasja number"
     },
+    "copyMenu": {
+      "blockQuoteWithCitation": "Plokktsitaat viitega",
+      "citationOnly": "Ainult viide",
+      "citationWithQuote": "Viide tsitaadiga",
+      "quoteWithCitation": "Tsitaat viitega",
+      "textOnly": "Ainult tekst"
+    },
     "decisionNotFound": "Otsust ei leitud",
     "emptyState": "Otsuseid ei leitud. Seadistage allikas ja käivitage sünkroonimine kohtupraktika importimiseks.",
     "filters": {
       "searchPlaceholder": "Otsi kohtuasja numbri järgi..."
     },
     "loadingMore": "Laadib rohkem...",
+    "notesFilter": {
+      "ai": "AI",
+      "human": "Inimeste"
+    },
     "provision": {
       "article": "art {value}",
       "letter": "p {value})",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -437,12 +437,23 @@
     "columns": {
       "caseNumber": "Numéro d'affaire"
     },
+    "copyMenu": {
+      "blockQuoteWithCitation": "Citation en bloc avec référence",
+      "citationOnly": "Référence seule",
+      "citationWithQuote": "Référence avec citation",
+      "quoteWithCitation": "Citation avec référence",
+      "textOnly": "Texte seul"
+    },
     "decisionNotFound": "Décision introuvable",
     "emptyState": "Aucune décision trouvée. Configurez une source et lancez une synchronisation pour importer la jurisprudence.",
     "filters": {
       "searchPlaceholder": "Rechercher par numéro d'affaire..."
     },
     "loadingMore": "Chargement en cours…",
+    "notesFilter": {
+      "ai": "IA",
+      "human": "Humaines"
+    },
     "provision": {
       "article": "art. {value}",
       "letter": "let. {value})",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -437,12 +437,23 @@
     "columns": {
       "caseNumber": "Ügyszám"
     },
+    "copyMenu": {
+      "blockQuoteWithCitation": "Blokkidézet hivatkozással",
+      "citationOnly": "Csak hivatkozás",
+      "citationWithQuote": "Hivatkozás idézettel",
+      "quoteWithCitation": "Idézet hivatkozással",
+      "textOnly": "Csak szöveg"
+    },
     "decisionNotFound": "A határozat nem található",
     "emptyState": "Nem található határozat. Adjon meg egy forrást, és futtasson szinkronizálást az ítélkezési gyakorlat importálásához.",
     "filters": {
       "searchPlaceholder": "Keresés ügyszám alapján..."
     },
     "loadingMore": "Betöltés folyamatban...",
+    "notesFilter": {
+      "ai": "MI",
+      "human": "Emberi"
+    },
     "provision": {
       "article": "{value}. cikk",
       "letter": "{value}) pont",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -437,12 +437,23 @@
     "columns": {
       "caseNumber": "Bylos numeris"
     },
+    "copyMenu": {
+      "blockQuoteWithCitation": "Blokinė citata su nuoroda",
+      "citationOnly": "Tik nuoroda",
+      "citationWithQuote": "Nuoroda su citata",
+      "quoteWithCitation": "Citata su nuoroda",
+      "textOnly": "Tik tekstas"
+    },
     "decisionNotFound": "Sprendimas nerastas",
     "emptyState": "Sprendimų nerasta. Sukonfigūruokite šaltinį ir paleiskite sinchronizavimą, kad importuotumėte teismų praktiką.",
     "filters": {
       "searchPlaceholder": "Ieškoti pagal bylos numerį..."
     },
     "loadingMore": "Kraunama daugiau...",
+    "notesFilter": {
+      "ai": "DI",
+      "human": "Žmonių"
+    },
     "provision": {
       "article": "{value} str.",
       "letter": "{value} papunktis",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -437,12 +437,23 @@
     "columns": {
       "caseNumber": "Lietas numurs"
     },
+    "copyMenu": {
+      "blockQuoteWithCitation": "Bloka citāts ar atsauci",
+      "citationOnly": "Tikai atsauce",
+      "citationWithQuote": "Atsauce ar citātu",
+      "quoteWithCitation": "Citāts ar atsauci",
+      "textOnly": "Tikai teksts"
+    },
     "decisionNotFound": "Lēmums nav atrasts",
     "emptyState": "Lēmumi nav atrasti. Konfigurējiet avotu un palaidiet sinhronizāciju, lai importētu tiesu praksi.",
     "filters": {
       "searchPlaceholder": "Meklēt pēc lietas numura..."
     },
     "loadingMore": "Ielādē vairāk...",
+    "notesFilter": {
+      "ai": "MI",
+      "human": "Cilvēku"
+    },
     "provision": {
       "article": "{value}. pants",
       "letter": "{value}. apakšpunkts",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -440,12 +440,23 @@ type Messages = {
     "columns": {
       "caseNumber": "Case number";
     };
+    "copyMenu": {
+      "blockQuoteWithCitation": "Block quote with citation";
+      "citationOnly": "Citation only";
+      "citationWithQuote": "Citation with quote";
+      "quoteWithCitation": "Quote with citation";
+      "textOnly": "Text only";
+    };
     "decisionNotFound": "Decision not found";
     "emptyState": "No decisions found. Configure a source and run a sync to import case law.";
     "filters": {
       "searchPlaceholder": "Search by case number...";
     };
     "loadingMore": "Loading more...";
+    "notesFilter": {
+      "ai": "AI";
+      "human": "Human";
+    };
     "provision": {
       "article": "Art. {value}";
       "letter": "lit. {value})";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -437,12 +437,23 @@
     "columns": {
       "caseNumber": "Sygnatura akt"
     },
+    "copyMenu": {
+      "blockQuoteWithCitation": "Cytat blokowy z odesłaniem",
+      "citationOnly": "Tylko odesłanie",
+      "citationWithQuote": "Odesłanie z cytatem",
+      "quoteWithCitation": "Cytat z odesłaniem",
+      "textOnly": "Tylko tekst"
+    },
     "decisionNotFound": "Nie znaleziono orzeczenia",
     "emptyState": "Brak orzeczeń. Skonfiguruj źródło i uruchom synchronizację, aby zaimportować orzecznictwo.",
     "filters": {
       "searchPlaceholder": "Szukaj po sygnaturze akt..."
     },
     "loadingMore": "Ładowanie kolejnych...",
+    "notesFilter": {
+      "ai": "AI",
+      "human": "Ludzkie"
+    },
     "provision": {
       "article": "art. {value}",
       "letter": "litera {value})",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -437,12 +437,23 @@
     "columns": {
       "caseNumber": "Número do processo"
     },
+    "copyMenu": {
+      "blockQuoteWithCitation": "Citação em bloco com referência",
+      "citationOnly": "Somente referência",
+      "citationWithQuote": "Referência com citação",
+      "quoteWithCitation": "Citação com referência",
+      "textOnly": "Somente texto"
+    },
     "decisionNotFound": "Decisão não encontrada",
     "emptyState": "Nenhuma decisão encontrada. Configure uma fonte e execute uma sincronização para importar jurisprudência.",
     "filters": {
       "searchPlaceholder": "Pesquisar por número do processo..."
     },
     "loadingMore": "Carregando mais...",
+    "notesFilter": {
+      "ai": "IA",
+      "human": "Humanas"
+    },
     "provision": {
       "article": "art. {value}",
       "letter": "alínea {value})",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -437,12 +437,23 @@
     "columns": {
       "caseNumber": "Spisová značka"
     },
+    "copyMenu": {
+      "blockQuoteWithCitation": "Blokový citát s citáciou",
+      "citationOnly": "Iba citácia",
+      "citationWithQuote": "Citácia s citátom",
+      "quoteWithCitation": "Citát s citáciou",
+      "textOnly": "Iba text"
+    },
     "decisionNotFound": "Rozhodnutie sa nenašlo",
     "emptyState": "Žiadne rozhodnutia. Nakonfigurujte zdroj a spustite synchronizáciu na import judikatúry.",
     "filters": {
       "searchPlaceholder": "Hľadať podľa spisovej značky..."
     },
     "loadingMore": "Načítavajú sa ďalšie...",
+    "notesFilter": {
+      "ai": "AI",
+      "human": "Ľudské"
+    },
     "provision": {
       "article": "čl. {value}",
       "letter": "písm. {value})",

--- a/packages/legal-ast/src/document-ast.ts
+++ b/packages/legal-ast/src/document-ast.ts
@@ -15,8 +15,11 @@ export type {
   InlineItalic,
   InlineLineBreak,
   InlineLink,
+  InlinePageAnchor,
   InlineText,
+  InlineWithChildren,
 } from "./inline.js";
+export { hasInlineChildren } from "./inline.js";
 
 /**
  * Heading depth, one to six.
@@ -44,6 +47,13 @@ export type ParagraphRole =
   | "holding"
   | "closing"
   | "signature"
+  /** A passage the decision reproduces from another text (block quotation). */
+  | "quote"
+  /** The centered party block a published reporter opens with. */
+  | "parties"
+  /** Other centered reporter front matter: docket line, argument and
+   * decision dates. */
+  | "front-matter"
   | "unknown";
 
 export type ParagraphNote = {
@@ -129,6 +139,9 @@ export const plainTextOf = (inlines: readonly Inline[]): string => {
       out += node.text;
     } else if (node.type === "line-break") {
       out += "\n";
+    } else if (node.type === "page-anchor") {
+      // Zero characters: a page break is typography, and it may fall
+      // mid-word — the word must stay whole on this axis.
     } else {
       out += plainTextOf(node.children);
     }
@@ -341,6 +354,9 @@ const paragraphEntries = {
       "holding",
       "closing",
       "signature",
+      "quote",
+      "parties",
+      "front-matter",
       "unknown",
     ]),
   ),

--- a/packages/legal-ast/src/index.ts
+++ b/packages/legal-ast/src/index.ts
@@ -36,14 +36,21 @@ export type {
   TableBlock,
   TableCell,
 } from "./document-ast.js";
-export { flattenInlineText, isInline, isInlineArray } from "./inline.js";
+export {
+  flattenInlineText,
+  hasInlineChildren,
+  isInline,
+  isInlineArray,
+} from "./inline.js";
 export type {
   Inline,
   InlineBold,
   InlineItalic,
   InlineLineBreak,
   InlineLink,
+  InlinePageAnchor,
   InlineText,
+  InlineWithChildren,
 } from "./inline.js";
 export {
   isProvisionKind,

--- a/packages/legal-ast/src/inline.ts
+++ b/packages/legal-ast/src/inline.ts
@@ -12,12 +12,36 @@ export type InlineItalic = { type: "italic"; children: Inline[] };
 export type InlineLink = { type: "link"; href: string; children: Inline[] };
 export type InlineLineBreak = { type: "line-break" };
 
+/**
+ * A reporter page boundary at this exact point in the text. Contributes
+ * ZERO characters to the plain-text axis: the published page break is
+ * typography, not content — it may fall mid-word, and the word must stay
+ * whole for search, offsets and copying. Renderers show the label as
+ * out-of-band chrome (a margin marker, a tick).
+ */
+export type InlinePageAnchor = {
+  type: "page-anchor";
+  /** The page number as printed ("495"). */
+  label: string;
+  /** Link to the official page scan, when one exists. */
+  href?: string | undefined;
+};
+
 export type Inline =
   | InlineText
   | InlineBold
   | InlineItalic
   | InlineLink
-  | InlineLineBreak;
+  | InlineLineBreak
+  | InlinePageAnchor;
+
+/** The inline kinds that nest children. */
+export type InlineWithChildren = InlineBold | InlineItalic | InlineLink;
+
+export const hasInlineChildren = (
+  inline: Inline,
+): inline is InlineWithChildren =>
+  inline.type === "bold" || inline.type === "italic" || inline.type === "link";
 
 export const inlineSchema: v.GenericSchema<Inline> = v.variant("type", [
   v.object({
@@ -39,6 +63,11 @@ export const inlineSchema: v.GenericSchema<Inline> = v.variant("type", [
     children: v.array(v.lazy(() => inlineSchema)),
   }),
   v.object({ type: v.literal("line-break") }),
+  v.object({
+    type: v.literal("page-anchor"),
+    label: v.string(),
+    href: v.optional(v.string()),
+  }),
 ]);
 
 const inlineArraySchema = v.array(v.lazy(() => inlineSchema));
@@ -60,6 +89,11 @@ export const flattenInlineText = (inlines: readonly Inline[]): string => {
 
     if (inline.type === "line-break") {
       parts.push("\n");
+      continue;
+    }
+
+    if (inline.type === "page-anchor") {
+      // Typography, not content: zero characters on the text axis.
       continue;
     }
 


### PR DESCRIPTION
Reading improvements for the case-law decision reader, shared across every corpus the reader serves.

**Reader**
- Footnote apparatus: a rule separates the body from the first footnote of a run; the reader shows its own footnote number when the source text does not carry one, and clicking that number returns to the citing sentence. In-text references render as superscript marks that preview the note's text on hover and jump to it with a re-firing flash.
- Reporter page boundaries hang in the start margin at their own line, linking to the official page scan where one exists, with a hair-thin tick at the exact break point. A new zero-width `page-anchor` inline in `legal-ast` carries them outside the text axis, so a page break falling mid-word no longer splits the word in search, offsets or copies. Walkers over the inline union narrow through a new `hasInlineChildren` guard.
- Reproduced passages (new role `quote`) render indented; reporter front matter (new roles `parties`, `front-matter`) keeps its published centered shape.

**Selection toolbar**
- Copy menu with five modes (quote with citation, citation with quote, block quote with citation, text only, citation only), a live preview pane of the formatted output, and viewport-aware placement. Citations follow each jurisdiction's own convention via a per-country formatter map; quotations are cleaned of reader chrome, note marks and page markers, and carry a reporter-page pincite where the convention uses one.

**Margin notes**
- All / AI / Human / None filter built from the inspector rail primitives; filtered-out sources also drop their section colours.
- Hover connects both directions: a note tints its paragraph and shows a leader bracket when pushed away from it; hovering annotated text saturates the matching notes' colour stripes and washes the rest out.

i18n: new keys translated across all 13 locales.

https://claude.ai/code/session_01HkFVj9TLAggYEsdsfZhad8