### PR TITLE
fix(api): keep word gaps when collapsing letter-spaced emphasis in cz-nss

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.test.ts
@@ -30,6 +30,45 @@ const findAllByRole = (blocks: Block[], role: string) =>
 const findAllByType = (blocks: Block[], type: string) =>
   blocks.filter((b) => b.type === type);
 
+const bold = (text: string): string =>
+  `<p style="text-align:center"><span style="font-weight:bold">${text}</span></p>`;
+
+const TRAILING_PUNCTUATION_RE = /[,:;.!?]$/u;
+
+const splitTrailingPunctuation = (
+  sentence: string,
+): { body: string; punctuation: string } => {
+  const punctuation = TRAILING_PUNCTUATION_RE.exec(sentence)?.[0] ?? "";
+  return {
+    body: punctuation ? sentence.slice(0, -punctuation.length) : sentence,
+    punctuation,
+  };
+};
+
+/** Render a sentence the way a publisher letter-spaces it for emphasis. */
+const letterSpace = (sentence: string, gap: string): string => {
+  const { body, punctuation } = splitTrailingPunctuation(sentence);
+  const spaced = body
+    .split(" ")
+    .map((word) => word.split("").join(" "))
+    .join(gap);
+  return punctuation ? `${spaced} ${punctuation}` : spaced;
+};
+
+/** One emphasis wrapper per letter, the shape Aspose exports. */
+const perLetterWrappers = (sentence: string, wordGap: () => string): string => {
+  const letterGap = `<span style="font-weight:bold">&nbsp;</span>`;
+  return sentence
+    .split(" ")
+    .map((word) =>
+      word
+        .split("")
+        .map((letter) => `<span style="font-weight:bold">${letter}</span>`)
+        .join(letterGap),
+    )
+    .join(wordGap());
+};
+
 // ── Minimal decision HTML ───────────────────────────────────
 
 const minimalHtml = `
@@ -808,6 +847,143 @@ describe("parseNssDecisionHtml", () => {
       expect(new Set(footnotes.map((footnote) => footnote.anchorId)).size).toBe(
         footnotes.length,
       );
+    });
+  });
+
+  // ── Letter-spaced emphasis ──────────────────────────────
+
+  describe("letter-spaced emphasis", () => {
+    const rulingOf = (verdictHtml: string): string => {
+      const html = `<html><body><p style="text-align:center">10 A 46/2015 - 66</p>${bold("ROZSUDEK")}${bold("JMÉNEM REPUBLIKY")}<p>Krajský soud v Českých Budějovicích rozhodl v senátě ve věci žalobce proti žalovanému o žalobě proti rozhodnutí žalovaného ze dne 1. 1. 2015,</p><p style="text-align:center"><span style="font-weight:bold;letter-spacing:3pt">t a k t o :</span></p>${verdictHtml}${bold("Odůvodnění:")}<p>[1] Krajský soud přezkoumal napadené rozhodnutí.</p></body></html>`;
+
+      const { documentAst } = parseNssDecisionHtml(
+        baseInput(html, { caseNumber: "10 A 46/2015" }),
+      );
+      // The verdict is whatever follows the "takto:" separator, so the
+      // locator stays independent of the sentence under test.
+      const taktoIndex = documentAst.blocks.findIndex(
+        (block) => block.plainText === "takto:",
+      );
+      return documentAst.blocks.at(taktoIndex + 1)?.plainText ?? "";
+    };
+
+    // The reported defect: KSČB 10 A 46/2015 - 66 rendered
+    // "Žaloba sez amítá." because the word gap between two emphasized
+    // runs was an Aspose spacer span, which the walker dropped. With the
+    // gap gone the run stopped looking letter-spaced, and the fallback
+    // collapse re-cut the word boundaries one letter off.
+    test("collapses a verdict whose word gaps are Aspose spacer spans", () => {
+      const spacer = `<span style="font-weight:bold; -aw-import:spaces">&nbsp;&nbsp;&nbsp;</span>`;
+      const verdict = `<p><span style="font-weight:bold">Ž a l o b a</span>${spacer}<span style="font-weight:bold">s e</span>${spacer}<span style="font-weight:bold">z a m í t á .</span></p>`;
+
+      expect(rulingOf(verdict)).toBe("Žaloba se zamítá.");
+    });
+
+    test.each([
+      [
+        "-aw-import:spaces",
+        `<span style="font-weight:bold; -aw-import:spaces">&nbsp;&nbsp;&nbsp;</span>`,
+      ],
+      [
+        "-aw-import:ignore",
+        `<span style="font-weight:bold; -aw-import:ignore">   </span>`,
+      ],
+      [
+        "display:inline-block",
+        `<span style="font-weight:bold; display:inline-block; width:12pt">&nbsp;</span>`,
+      ],
+      [
+        "empty inline-block",
+        `<span style="font-weight:bold; display:inline-block; width:12pt"></span>`,
+      ],
+    ])("treats a %s spacer span as a word boundary", (_style, spacer) => {
+      const verdict = `<p><span style="font-weight:bold">Ž a l o b a</span>${spacer}<span style="font-weight:bold">s e</span>${spacer}<span style="font-weight:bold">z a m í t á .</span></p>`;
+
+      expect(rulingOf(verdict)).toBe("Žaloba se zamítá.");
+    });
+
+    test("collapses per-letter wrappers separated by a spacer span", () => {
+      const verdict = `<p>${perLetterWrappers("Žaloba se zamítá", () => `<span style="font-weight:bold; -aw-import:spaces">&nbsp;&nbsp;</span>`)}<span style="font-weight:bold">.</span></p>`;
+
+      expect(rulingOf(verdict)).toBe("Žaloba se zamítá.");
+    });
+
+    // A word gap split across two adjacent inlines: the spacer span
+    // lands beside the ordinary letter separator rather than replacing
+    // it, so neither node carries the whole boundary on its own.
+    test("collapses a word gap split across adjacent inlines", () => {
+      const gap = `<span style="font-weight:bold; -aw-import:spaces">&nbsp;</span><span style="font-weight:bold">&nbsp;</span>`;
+      const verdict = `<p>${perLetterWrappers("Žaloba se zamítá", () => gap)}<span style="font-weight:bold">.</span></p>`;
+
+      expect(rulingOf(verdict)).toBe("Žaloba se zamítá.");
+    });
+
+    // Indentation between two wrappers is source formatting: HTML
+    // collapses it, so it must not widen a letter separator into a word
+    // boundary.
+    test("ignores pretty-printer indentation between wrappers", () => {
+      const verdict = `<p>\n  ${perLetterWrappers("Žaloba se zamítá", () => `<span style="font-weight:bold">&nbsp;&nbsp;&nbsp;&nbsp;</span>`).replaceAll("</span><span", "</span>\n  <span")}.\n</p>`;
+
+      expect(rulingOf(verdict)).toBe("Žaloba se zamítá.");
+    });
+
+    // Round trip: letter-space a sentence with every gap width the
+    // publisher emits, in every markup shape, and require the original
+    // sentence back verbatim. The parser may join the letter-spacing and
+    // nothing else — the reader never rewrites court text.
+    describe("round trip", () => {
+      const sentences = [
+        "Žaloba se zamítá.",
+        "Kasační stížnost se zamítá.",
+        "Rozsudek krajského soudu se zrušuje.",
+        "Věc se vrací žalovanému k dalšímu řízení.",
+        "Žádný z účastníků nemá právo na náhradu nákladů řízení.",
+      ] as const;
+
+      const gaps = {
+        "two spaces": "  ",
+        "three spaces": "   ",
+        "two non-breaking spaces": "\u00a0\u00a0",
+        "four non-breaking spaces": "\u00a0\u00a0\u00a0\u00a0",
+        "mixed space and non-breaking space": " \u00a0",
+      } as const;
+
+      for (const sentence of sentences) {
+        for (const [gapName, gap] of Object.entries(gaps)) {
+          test(`one wrapper, ${gapName}: ${sentence}`, () => {
+            const verdict = `<p><span style="font-weight:bold;letter-spacing:3pt">${letterSpace(sentence, gap)}</span></p>`;
+
+            expect(rulingOf(verdict)).toBe(sentence);
+          });
+        }
+
+        test(`spacer-span gaps: ${sentence}`, () => {
+          const spacer = `<span style="font-weight:bold; -aw-import:spaces">&nbsp;&nbsp;&nbsp;</span>`;
+          const { body, punctuation } = splitTrailingPunctuation(sentence);
+          const verdict = `<p>${body
+            .split(" ")
+            .map(
+              (word) =>
+                `<span style="font-weight:bold">${word.split("").join(" ")}</span>`,
+            )
+            .join(
+              spacer,
+            )}<span style="font-weight:bold"> ${punctuation}</span></p>`;
+
+          expect(rulingOf(verdict)).toBe(sentence);
+        });
+
+        test(`per-letter wrappers: ${sentence}`, () => {
+          const { body, punctuation } = splitTrailingPunctuation(sentence);
+          const verdict = `<p>${perLetterWrappers(
+            body,
+            () =>
+              `<span style="font-weight:bold; -aw-import:spaces">&nbsp;&nbsp;</span>`,
+          )}<span style="font-weight:bold">${punctuation}</span></p>`;
+
+          expect(rulingOf(verdict)).toBe(sentence);
+        });
+      }
     });
   });
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-nss.ts
@@ -155,6 +155,28 @@ type SpacedBoldRun = {
   endIndex: number;
 };
 
+/**
+ * Applied to whitespace-only text, this matches every character HTML
+ * collapses: U+00A0 is the one it renders at its written width.
+ */
+const COLLAPSIBLE_WHITESPACE_RE = /[^\u00a0]/gu;
+
+/**
+ * Carry the part of a stepped-over whitespace node that belongs to the
+ * gap between two letters. Only the non-breaking spaces count: HTML
+ * collapses ordinary whitespace, so the newline and indentation a
+ * pretty-printed export puts between two wrappers paint nothing and must
+ * not widen a letter separator into a word boundary. Whatever survives is
+ * appended as a fresh node, because the caller merges text nodes by
+ * mutating them in place.
+ */
+const appendNonCollapsibleGap = (step: Inline[], text: string): void => {
+  const gap = text.replace(COLLAPSIBLE_WHITESPACE_RE, "");
+  if (gap.length > 0) {
+    step.push({ type: "text", text: gap });
+  }
+};
+
 const collectSpacedBoldRun = (
   source: readonly Inline[],
   startIndex: number,
@@ -173,12 +195,14 @@ const collectSpacedBoldRun = (
   let endIndex = startIndex;
 
   while (endIndex + 1 < source.length) {
+    const step: Inline[] = [];
     let separatorIndex = endIndex + 1;
     const gapBeforeSeparator = source.at(separatorIndex);
     if (
       gapBeforeSeparator?.type === "text" &&
       gapBeforeSeparator.text.trim().length === 0
     ) {
+      appendNonCollapsibleGap(step, gapBeforeSeparator.text);
       separatorIndex += 1;
     }
 
@@ -189,6 +213,7 @@ const collectSpacedBoldRun = (
     ) {
       break;
     }
+    step.push(...separator.children);
 
     let letterIndex = separatorIndex + 1;
     const gapBeforeLetter = source.at(letterIndex);
@@ -196,6 +221,7 @@ const collectSpacedBoldRun = (
       gapBeforeLetter?.type === "text" &&
       gapBeforeLetter.text.trim().length === 0
     ) {
+      appendNonCollapsibleGap(step, gapBeforeLetter.text);
       letterIndex += 1;
     }
 
@@ -208,7 +234,7 @@ const collectSpacedBoldRun = (
       break;
     }
 
-    children.push(...separator.children, ...letter.children);
+    children.push(...step, ...letter.children);
     endIndex = letterIndex;
   }
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.test.ts
@@ -3,6 +3,7 @@ import * as cheerio from "cheerio";
 
 import type { Inline } from "@/api/handlers/case-law/document-ast";
 import {
+  ASPOSE_SPACER_GAP,
   inlinesToPlainText,
   stripInlinePrefix,
   walkInlines,
@@ -69,15 +70,19 @@ describe("walkInlines", () => {
     expect(walk("<img alt='Header'>")).toEqual([]);
   });
 
-  test("parseSpanStyle reads emphasis and skips empty spacer spans", () => {
+  test("parseSpanStyle reads emphasis and turns spacer spans into a gap", () => {
     expect(
       walk("<span style='font-weight:bold'>x</span>", { parseSpanStyle: true }),
     ).toEqual([{ type: "bold", children: [{ type: "text", text: "x" }] }]);
-    expect(
-      walk("<span style='-aw-import:spaces'>   </span>", {
-        parseSpanStyle: true,
-      }),
-    ).toEqual([]);
+    for (const spacer of [
+      "<span style='-aw-import:spaces'>&nbsp;&nbsp;&nbsp;</span>",
+      "<span style='-aw-import:ignore'>   </span>",
+      "<span style='display:inline-block; width:36pt'></span>",
+    ]) {
+      expect(walk(spacer, { parseSpanStyle: true })).toEqual([
+        { type: "text", text: ASPOSE_SPACER_GAP },
+      ]);
+    }
   });
 
   test("anonymization spans mark text and coalesce", () => {

--- a/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/shared-inlines.ts
@@ -49,6 +49,22 @@ export const appendTextInline = (
   });
 };
 
+/**
+ * What a whitespace-only Aspose spacer span contributes to the inline
+ * tree. The span's own glyphs do not encode the gap it paints — the
+ * width lives in CSS (`width:36pt`) or in an `&nbsp;` run of arbitrary
+ * length — so every such span yields the same canonical gap.
+ *
+ * Two characters, because cz-nss's letter-spacing reassembly reads one
+ * space as a letter separator and two or more as a word boundary. Both
+ * are U+00A0 rather than U+0020: HTML collapses runs of ordinary
+ * whitespace, so an ordinary-space gap would be indistinguishable from
+ * the indentation a pretty-printed export puts between two spans. Every
+ * consumer folds the pair back to a single space through
+ * `collapseSpacedLetters`.
+ */
+export const ASPOSE_SPACER_GAP = "\u00a0\u00a0";
+
 export type WalkInlinesOptions = {
   /**
    * Map/validate `<a>` hrefs (e.g. `sanitizeUrl`, which returns
@@ -120,9 +136,14 @@ export const walkInlines = (
       if (options.parseSpanStyle && tag === "span") {
         const style = $child.attr("style") ?? "";
 
-        // Skip Aspose spacer spans only when they contain no meaningful
-        // text. Modern exports use these for tab stops and invisible
-        // fills, but older conversions sometimes place real words inside.
+        // Aspose spacer spans carry horizontal space rather than words:
+        // tab stops, alignment fills, and the gap between two
+        // letter-spaced words. Emit that gap instead of dropping the
+        // span; dropping it welds the neighbouring words together and
+        // leaves the letter-spacing reassembly to guess a boundary that
+        // is no longer in the text. Older conversions sometimes put real
+        // words inside these spans, so only whitespace-only spans become
+        // a gap.
         if (
           style.includes("-aw-import:ignore") ||
           style.includes("-aw-import:spaces") ||
@@ -130,6 +151,7 @@ export const walkInlines = (
         ) {
           const innerText = $child.text().trim();
           if (!innerText) {
+            appendTextInline(inlines, ASPOSE_SPACER_GAP, childAnon);
             return;
           }
         }


### PR DESCRIPTION
Aspose expresses an emphasized run as one span per letter, with the gap between words carried by a whitespace-only spacer span (`-aw-import:spaces`, `-aw-import:ignore`, or `display:inline-block`). The shared inline walker dropped those spans, so adjacent words merged (`Ž a l o b a` + `s e` + `z a m í t á` ran together), the spaced-emphasis pattern no longer matched, and the fallback collapser re-cut word boundaries one letter off: "Žaloba se zamítá." rendered as "Žalob as ez amítá."

- `shared-inlines`: a whitespace-only spacer span now emits a non-collapsible gap instead of vanishing.
- `cz-nss`: `collectSpacedBoldRun` carries stepped-over whitespace into the run, so a gap split across adjacent inlines survives.

Both gaps use no-break spaces deliberately: HTML collapses ordinary whitespace, so an ordinary-space gap would be indistinguishable from pretty-printer indentation.

Tests: the reported sentence, each spacer-span variant, a gap split across inlines, pretty-printer indentation, and a round-trip property over Czech sentences × gap widths × markup shapes (35 new assertions; committed fixtures previously hid the defect because their pretty-printed newlines supplied the missing whitespace).

https://claude.ai/code/session_01HkFVj9TLAggYEsdsfZhad8