### PR TITLE
feat: statutes entry resolves act numbers and aliases, lists newest first

### DIFF
--- a/apps/api/drizzle/20260901130000_legislation_title_fold/migration.sql
+++ b/apps/api/drizzle/20260901130000_legislation_title_fold/migration.sql
@@ -1,0 +1,63 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- The statute list matches titles the way a lawyer types them: without
+-- diacritics and in any case. `unaccent()` is only STABLE, so it cannot back an
+-- index directly; this wrapper pins the dictionary and declares the result
+-- immutable, which it is for a fixed dictionary. Keep it byte-equal to
+-- `lower(unaccent(...))`: the query side folds through the same function, and
+-- the pglite test double is generated from the same fold table
+-- (@stll/text-normalize ASCII_FOLD_TABLE) that the unaccent parity test pins.
+CREATE OR REPLACE FUNCTION legislation_title_fold(input text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+STRICT
+PARALLEL SAFE
+AS $$
+  SELECT lower(public.unaccent('public.unaccent'::regdictionary, $1))
+$$;
+--> statement-breakpoint
+
+-- Drizzle wraps pending migrations in one transaction, while PostgreSQL
+-- requires CREATE INDEX CONCURRENTLY to run outside a transaction block.
+-- Split the migrator transaction, lift the timeouts for the concurrent builds
+-- (which take no lock those timeouts guard), then restore and reopen a
+-- transaction for Drizzle's migration row. Same shape as
+-- 20260729010000_corpus_index_pending_partial_indexes.
+SET statement_timeout = 0;
+--> statement-breakpoint
+SET lock_timeout = 0;
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting
+COMMIT;
+--> statement-breakpoint
+
+-- Drops only this migration's own index by name before recreating it. A
+-- cancelled concurrent build leaves an INVALID index behind, and IF NOT
+-- EXISTS would then skip recreating it.
+DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_title_fold_trgm_idx";
+--> statement-breakpoint
+-- Diacritics-insensitive contains/prefix matching on the title.
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "legislation_documents_title_fold_trgm_idx"
+  ON "legislation_documents" USING gin (legislation_title_fold("title") gin_trgm_ops);
+--> statement-breakpoint
+
+-- Same reasoning as the index above, for the recency walk.
+DROP INDEX CONCURRENTLY IF EXISTS "legislation_documents_country_valid_from_id_idx";
+--> statement-breakpoint
+-- The default listing walks a country's works newest consolidation first and
+-- stops at the page limit; the expression is the handler's own sort key, so
+-- the walk is an index range read backwards rather than a sort of the corpus.
+-- squawk-ignore prefer-robust-stmts
+CREATE INDEX CONCURRENTLY "legislation_documents_country_valid_from_id_idx"
+  ON "legislation_documents" ("country", coalesce("version_valid_from", DATE '0001-01-01'), "id");
+--> statement-breakpoint
+
+SET statement_timeout = '5s';
+--> statement-breakpoint
+SET lock_timeout = '1s';
+--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/db/schema/legislation.ts
+++ b/apps/api/src/db/schema/legislation.ts
@@ -46,6 +46,24 @@ export const LEGISLATION_TITLE_SORT_KEY_CHARS = 52;
 export const legislationTitleSortKey = (title: SQLWrapper) =>
   sql<string>`left(${title}, ${sql.raw(String(LEGISLATION_TITLE_SORT_KEY_CHARS))})`;
 
+/**
+ * The title as a lawyer types it: lower-case, diacritics folded. Migration
+ * `20260901130000_legislation_title_fold` owns the function; the query side
+ * folds its input (a bound string) through the same function so both sides
+ * cannot drift.
+ */
+export const legislationTitleFold = (value: SQLWrapper | string) =>
+  sql<string>`legislation_title_fold(${value})`;
+
+/**
+ * The name part of an official title. Czech titles open with the number and
+ * collection (`89/2012 Sb., občanský zákoník`); Slovak titles carry the name
+ * alone. Matching a typed name against this rather than the full title is
+ * what lets the code itself outrank the acts amending it.
+ */
+export const legislationTitleName = (title: SQLWrapper) =>
+  sql<string>`regexp_replace(${title}, '^[0-9]+/[0-9]{4} [^,]*, ', '')`;
+
 export const legislationSources = p.pgTable(
   "legislation_sources",
   {
@@ -164,6 +182,20 @@ export const legislationDocuments = p.pgTable(
     p
       .index("legislation_documents_eli_trgm_idx")
       .using("gin", sql`${t.eli} gin_trgm_ops`),
+    // Diacritics-insensitive title matching, on the fold the handler queries
+    // through (see `legislationTitleFold`).
+    p
+      .index("legislation_documents_title_fold_trgm_idx")
+      .using("gin", sql`legislation_title_fold(${t.title}) gin_trgm_ops`),
+    // The default listing walks a country newest consolidation first; the
+    // expression is the handler's sort key, so the walk is an index range.
+    p
+      .index("legislation_documents_country_valid_from_id_idx")
+      .on(
+        t.country,
+        sql`coalesce(${t.versionValidFrom}, DATE '0001-01-01')`,
+        t.id,
+      ),
     p.index("legislation_documents_status_idx").on(t.status),
     p.index("legislation_documents_effective_date_idx").on(t.effectiveDate),
     p.index("legislation_documents_created_at_idx").on(t.createdAt),

--- a/apps/api/src/handlers/legislation/list.ts
+++ b/apps/api/src/handlers/legislation/list.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, ilike, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, ilike, or, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { status, t } from "elysia";
 import type { Static } from "elysia";
@@ -7,6 +7,8 @@ import {
   LEGISLATION_TITLE_SORT_KEY_CHARS,
   legislationDocuments,
   legislationSources,
+  legislationTitleFold,
+  legislationTitleName,
   legislationTitleSortKey,
 } from "@/api/db/schema";
 import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
@@ -23,13 +25,23 @@ import {
   createCursorPage,
   decodePaginationCursor,
   encodePaginationCursor,
+  isDateOnlyPaginationCursorPart,
   isUuidPaginationCursorPart,
 } from "@/api/lib/pagination";
 import { brandPersistedLegislationDocumentId } from "@/api/lib/safe-id-boundaries";
 
+/** `<number>/<year>` as a collection prints it: `89/2012`. */
+export const ACT_NUMBER_PATTERN = /^([0-9]{1,5})\/([0-9]{4})$/u;
+/** A publisher collection segment of an ELI: `sb`, `ul1`, `zz`. */
+const COLLECTION_PATTERN = /^[a-z0-9]{1,8}$/u;
+
 export const listStatutesQuerySchema = t.Object({
   country: t.String({ minLength: 2, maxLength: 3 }),
   query: t.Optional(t.String({ maxLength: 256 })),
+  /** An act's own number, `<number>/<year>`; the request asks for that work. */
+  number: t.Optional(t.String({ pattern: ACT_NUMBER_PATTERN.source })),
+  /** The collection the number was published in, when the caller knows it. */
+  collection: t.Optional(t.String({ pattern: COLLECTION_PATTERN.source })),
   language: t.Optional(t.String({ maxLength: 8 })),
   limit: t.Optional(tPaginationLimit(LIMITS.legislationListPageSizeMax)),
   cursor: t.Optional(tPaginationCursor()),
@@ -37,23 +49,59 @@ export const listStatutesQuerySchema = t.Object({
 
 type ListStatutesQuery = Static<typeof listStatutesQuerySchema>;
 
-export const LEGISLATION_TITLE_CURSOR_KIND = "title-prefix-v1";
+/**
+ * The two orderings the list serves, each with its own cursor protocol. A
+ * cursor from one cannot continue the other: the sort keys differ.
+ */
+export const LEGISLATION_LIST_CURSOR_KIND = {
+  /** No text: newest consolidation first. */
+  recent: "recent-v1",
+  /** A typed name: works named by it first, then works mentioning it. */
+  search: "search-v1",
+} as const;
 
-type TitlePrefixIdCursor = {
-  type: typeof LEGISLATION_TITLE_CURSOR_KIND;
-  titleSortKey: string;
-  id: SafeId<"legislationDocument">;
-};
+type ListCursor =
+  | {
+      type: typeof LEGISLATION_LIST_CURSOR_KIND.recent;
+      validFrom: string;
+      id: SafeId<"legislationDocument">;
+    }
+  | {
+      type: typeof LEGISLATION_LIST_CURSOR_KIND.search;
+      rank: "0" | "1";
+      titleSortKey: string;
+      id: SafeId<"legislationDocument">;
+    };
 
 const titleSortKey = legislationTitleSortKey(legislationDocuments.title);
+const validFromKey = versionSortKey(legislationDocuments.versionValidFrom);
 
-const decodeTitleCursor = (cursor: string): TitlePrefixIdCursor | null => {
+const decodeListCursor = (cursor: string): ListCursor | null => {
   const parts = decodePaginationCursor(cursor);
+  if (parts === null) {
+    return null;
+  }
+  const [kind, ...rest] = parts;
 
-  if (parts?.length === 3) {
-    const [kind, key, id] = parts;
+  if (kind === LEGISLATION_LIST_CURSOR_KIND.recent && rest.length === 2) {
+    const [validFrom, id] = rest;
     if (
-      kind !== LEGISLATION_TITLE_CURSOR_KIND ||
+      !isDateOnlyPaginationCursorPart(validFrom) ||
+      !isUuidPaginationCursorPart(id)
+    ) {
+      return null;
+    }
+    return {
+      type: LEGISLATION_LIST_CURSOR_KIND.recent,
+      validFrom,
+      id: brandPersistedLegislationDocumentId(id),
+    };
+  }
+
+  if (kind === LEGISLATION_LIST_CURSOR_KIND.search && rest.length === 3) {
+    const [rank, key, id] = rest;
+    if (
+      (rank !== "0" && rank !== "1") ||
       typeof key !== "string" ||
       Array.from(key).length > LEGISLATION_TITLE_SORT_KEY_CHARS ||
       !isUuidPaginationCursorPart(id)
@@ -61,7 +109,8 @@ const decodeTitleCursor = (cursor: string): TitlePrefixIdCursor | null => {
       return null;
     }
     return {
-      type: LEGISLATION_TITLE_CURSOR_KIND,
+      type: LEGISLATION_LIST_CURSOR_KIND.search,
+      rank,
       titleSortKey: key,
       id: brandPersistedLegislationDocumentId(id),
     };
@@ -93,13 +142,54 @@ const isCurrentVersionOfWork = sql`NOT EXISTS (
     )
 )`;
 
+/**
+ * The work an act number names. ELIs end in `/<collection>/<year>/<number>`
+ * (`/eli/cz/sb/2012/89`), so the number is matched on that tail: a suffix
+ * match the trigram index serves, made exact by the anchored pattern so
+ * `/2012/89` cannot answer for `/2012/189`. Without a collection every
+ * collection of the jurisdiction qualifies; the caller shows the candidates
+ * rather than picking one.
+ */
+const actNumberCondition = (
+  number: string,
+  collection: string | undefined,
+): SQL | null => {
+  const match = ACT_NUMBER_PATTERN.exec(number);
+  const ordinal = match?.[1];
+  const year = match?.[2];
+  if (ordinal === undefined || year === undefined) {
+    return null;
+  }
+  const tail = `${year}/${ordinal}`;
+  const anchored =
+    collection === undefined ? `(^|/)${tail}$` : `/${collection}/${tail}$`;
+  return sql`(
+    ${legislationDocuments.eli} LIKE ${`%${tail}`}
+    AND ${legislationDocuments.eli} ~ ${anchored}
+  )`;
+};
+
+/**
+ * 0 for a work whose name starts with the typed text, 1 for one that merely
+ * mentions it: `občanský zákoník` must rank the code above the acts amending
+ * it (`kterým se mění zákon č. 89/2012 Sb., občanský zákoník`). Both sides
+ * fold through `legislation_title_fold`, so a query typed without diacritics
+ * ranks the same as one typed with them.
+ */
+const titleRank = (trimmedQuery: string): SQL<number> => sql<number>`(CASE
+  WHEN ${legislationTitleFold(legislationTitleName(legislationDocuments.title))}
+    LIKE ${legislationTitleFold(escapeLike(trimmedQuery))} || '%'
+  THEN 0
+  ELSE 1
+END)`;
+
 export const listStatutesHandler = async (
   query: ListStatutesQuery,
   legislationDb: LegislationReadDb,
 ) => {
   const limit = query.limit ?? LIMITS.legislationListPageSizeDefault;
   const cursor =
-    query.cursor === undefined ? null : decodeTitleCursor(query.cursor);
+    query.cursor === undefined ? null : decodeListCursor(query.cursor);
   if (query.cursor !== undefined && cursor === null) {
     return status(400, { message: "Invalid cursor" });
   }
@@ -117,32 +207,51 @@ export const listStatutesHandler = async (
     conditions.push(eq(legislationDocuments.language, query.language));
   }
 
-  const trimmedQuery = query.query?.trim();
+  if (query.number !== undefined) {
+    const byNumber = actNumberCondition(query.number, query.collection);
+    if (byNumber === null) {
+      return status(400, { message: "Invalid act number" });
+    }
+    conditions.push(byNumber);
+  }
 
-  if (trimmedQuery) {
-    const pattern = `%${escapeLike(trimmedQuery)}%`;
+  const trimmedQuery = query.query?.trim() || null;
+
+  if (trimmedQuery !== null) {
     const titleOrEli = or(
-      ilike(legislationDocuments.title, pattern),
-      ilike(legislationDocuments.eli, pattern),
+      sql`${legislationTitleFold(legislationDocuments.title)} LIKE '%' || ${legislationTitleFold(escapeLike(trimmedQuery))} || '%'`,
+      ilike(legislationDocuments.eli, `%${escapeLike(trimmedQuery)}%`),
     );
-
     if (titleOrEli) {
       conditions.push(titleOrEli);
     }
   }
 
-  if (cursor !== null) {
-    const keyset = or(
-      gt(titleSortKey, cursor.titleSortKey),
-      and(
-        eq(titleSortKey, cursor.titleSortKey),
-        gt(legislationDocuments.id, cursor.id),
-      ),
-    );
+  const ordering =
+    trimmedQuery === null
+      ? {
+          type: LEGISLATION_LIST_CURSOR_KIND.recent,
+          orderBy: [desc(validFromKey), desc(legislationDocuments.id)],
+        }
+      : {
+          type: LEGISLATION_LIST_CURSOR_KIND.search,
+          rank: titleRank(trimmedQuery),
+          orderBy: [
+            asc(titleRank(trimmedQuery)),
+            asc(titleSortKey),
+            asc(legislationDocuments.id),
+          ],
+        };
 
-    if (keyset) {
-      conditions.push(keyset);
+  if (cursor !== null) {
+    if (cursor.type !== ordering.type) {
+      return status(400, { message: "Invalid cursor" });
     }
+    conditions.push(
+      cursor.type === LEGISLATION_LIST_CURSOR_KIND.recent
+        ? sql`(${validFromKey}, ${legislationDocuments.id}) < (${cursor.validFrom}::date, ${cursor.id}::uuid)`
+        : sql`(${titleRank(trimmedQuery ?? "")}, ${titleSortKey}, ${legislationDocuments.id}) > (${cursor.rank}::int, ${cursor.titleSortKey}, ${cursor.id}::uuid)`,
+    );
   }
 
   const rows = await legislationDb(
@@ -153,6 +262,11 @@ export const listStatutesHandler = async (
           eli: legislationDocuments.eli,
           title: legislationDocuments.title,
           titleSortKey,
+          validFromKey: sql<string>`${validFromKey}::text`.as("valid_from_key"),
+          rank:
+            ordering.type === LEGISLATION_LIST_CURSOR_KIND.search
+              ? sql<number>`${ordering.rank}`.as("title_rank")
+              : sql<number>`0`.as("title_rank"),
           country: legislationDocuments.country,
           language: legislationDocuments.language,
           documentType: legislationDocuments.documentType,
@@ -169,7 +283,7 @@ export const listStatutesHandler = async (
           eq(legislationSources.id, legislationDocuments.sourceId),
         )
         .where(and(...conditions))
-        .orderBy(asc(titleSortKey), asc(legislationDocuments.id))
+        .orderBy(...ordering.orderBy)
         .limit(limit + 1),
   );
 
@@ -177,15 +291,29 @@ export const listStatutesHandler = async (
     rows,
     limit,
     cursorForItem: (item) =>
-      encodePaginationCursor([
-        LEGISLATION_TITLE_CURSOR_KIND,
-        item.titleSortKey,
-        item.id,
-      ]),
+      ordering.type === LEGISLATION_LIST_CURSOR_KIND.recent
+        ? encodePaginationCursor([
+            LEGISLATION_LIST_CURSOR_KIND.recent,
+            item.validFromKey,
+            item.id,
+          ])
+        : encodePaginationCursor([
+            LEGISLATION_LIST_CURSOR_KIND.search,
+            String(item.rank),
+            item.titleSortKey,
+            item.id,
+          ]),
   });
 
   return {
     ...page,
-    items: page.items.map(({ titleSortKey: _titleSortKey, ...item }) => item),
+    items: page.items.map(
+      ({
+        rank: _rank,
+        titleSortKey: _titleSortKey,
+        validFromKey: _validFromKey,
+        ...item
+      }) => item,
+    ),
   };
 };

--- a/apps/api/src/handlers/legislation/public-reads.db.test.ts
+++ b/apps/api/src/handlers/legislation/public-reads.db.test.ts
@@ -1,7 +1,11 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
+import fc from "fast-check";
 
 import type { Block, DocumentAst } from "@stll/legal-ast/document-ast";
+import { propertyConfig } from "@stll/property-testing";
+import { foldToAscii } from "@stll/text-normalize";
 
 import {
   LEGISLATION_TITLE_SORT_KEY_CHARS,
@@ -14,7 +18,7 @@ import {
   readPublicLegislationHandler,
 } from "@/api/handlers/legislation/get";
 import {
-  LEGISLATION_TITLE_CURSOR_KIND,
+  LEGISLATION_LIST_CURSOR_KIND,
   listStatutesHandler,
 } from "@/api/handlers/legislation/list";
 import { readProvisionHistoryHandler } from "@/api/handlers/legislation/provision-history";
@@ -56,6 +60,24 @@ const longTitleAct = createSafeId<"legislationDocument">();
 const registerAct = createSafeId<"legislationDocument">();
 const sunsetAct = createSafeId<"legislationDocument">();
 const withheldAct = createSafeId<"legislationDocument">();
+const czechCivilCode = createSafeId<"legislationDocument">();
+const czechCivilCodeAmendment = createSafeId<"legislationDocument">();
+const corporationsAct = createSafeId<"legislationDocument">();
+
+/**
+ * The default listing, newest consolidation first, ties broken by id
+ * descending. The two civil code languages open on the same day, so their
+ * mutual order is whatever the generated ids say.
+ */
+const recencyOrder = [
+  corporationsAct,
+  ...[civilCodeCurrent, civilCodeEnglish].toSorted((a, b) => (a < b ? 1 : -1)),
+  czechCivilCodeAmendment,
+  czechCivilCode,
+  labourCode,
+  longTitleAct,
+  registerAct,
+];
 const enumeratedAmendments = Array.from(
   { length: 1000 },
   (_, index) => `act-${index.toString(36).padStart(4, "0")}`,
@@ -294,6 +316,36 @@ beforeAll(
         versionValidFrom: "2000-01-01",
         versionValidTo: null,
       }),
+      // A code and the act amending it, titled the way the publisher titles
+      // them: the amendment's title contains the code's name, the code's own
+      // name starts with it. Its number shares a suffix with 89/2012.
+      seedDocument({
+        id: czechCivilCode,
+        sourceId: openSourceId,
+        eli: "CZ/2012/1089",
+        title: "1089/2012 Sb., občanský zákoník",
+        versionValidFrom: "2014-01-01",
+        versionValidTo: null,
+      }),
+      seedDocument({
+        id: czechCivilCodeAmendment,
+        sourceId: openSourceId,
+        eli: "CZ/2016/460",
+        title:
+          "460/2016 Sb., kterým se mění zákon č. 1089/2012 Sb., občanský zákoník",
+        versionValidFrom: "2017-02-28",
+        versionValidTo: null,
+      }),
+      // A publisher-shaped ELI, so the collection segment is there to match.
+      seedDocument({
+        id: corporationsAct,
+        sourceId: openSourceId,
+        eli: "https://www.e-sbirka.cz/eli/cz/sb/2012/90",
+        title:
+          "90/2012 Sb., o obchodních společnostech a družstvech (zákon o obchodních korporacích)",
+        versionValidFrom: "2021-01-01",
+        versionValidTo: null,
+      }),
     ]);
 
     workspaceDb = async (read) =>
@@ -401,21 +453,20 @@ describe("public statute list", () => {
     expect(ids).not.toContain(civilCodeFuture);
   });
 
-  test("returns one row per work, ordered by title", async () => {
+  test("returns one row per work, newest consolidation first", async () => {
     const page = expectPage(
       await listStatutesHandler({ country: "CZE" }, legislationDb),
     );
 
     expect(longOfficialTitle.length).toBeGreaterThan(1024);
-    expect(page.items.map((item) => item.title)).toEqual([
-      "Civil Code",
-      "Civil Code (English)",
-      "Labour Code",
-      longOfficialTitle,
-      "Public Registers Act",
-    ]);
+    expect(page.items.map((item) => item.id)).toEqual(recencyOrder);
     expect(
-      page.items.every((item) => !Object.hasOwn(item, "titleSortKey")),
+      page.items.every(
+        (item) =>
+          !Object.hasOwn(item, "titleSortKey") &&
+          !Object.hasOwn(item, "validFromKey") &&
+          !Object.hasOwn(item, "rank"),
+      ),
     ).toBe(true);
   });
 
@@ -473,11 +524,77 @@ describe("public statute list", () => {
     expect(byEli.items.map((item) => item.id)).toEqual([registerAct]);
   });
 
-  test("walks every work exactly once across cursor pages", async () => {
+  test("matches a title typed without diacritics or case", async () => {
+    // The fixture differs from the query before folding, so the match below
+    // is the fold's doing and not a coincidence of the seed.
+    expect("občanský zákoník".normalize("NFC")).not.toBe("OBCANSKY zakonik");
+    const page = expectPage(
+      await listStatutesHandler(
+        { country: "CZE", query: "OBCANSKY zakonik" },
+        legislationDb,
+      ),
+    );
+
+    expect(page.items.map((item) => item.id)).toEqual([
+      czechCivilCode,
+      czechCivilCodeAmendment,
+    ]);
+  });
+
+  test("ranks the act named by the text above the acts amending it", async () => {
+    const page = expectPage(
+      await listStatutesHandler(
+        { country: "CZE", query: "občanský zákoník" },
+        legislationDb,
+      ),
+    );
+
+    // Both titles contain the term; only the code's own name starts with it.
+    expect(page.items.map((item) => item.id)).toEqual([
+      czechCivilCode,
+      czechCivilCodeAmendment,
+    ]);
+  });
+
+  test("resolves an act by its number across the work's languages", async () => {
+    const page = expectPage(
+      await listStatutesHandler(
+        { country: "CZE", number: "89/2012" },
+        legislationDb,
+      ),
+    );
+
+    // The tail is anchored: 1089/2012 shares a suffix and must stay out.
+    expect(new Set(page.items.map((item) => item.id))).toEqual(
+      new Set([civilCodeCurrent, civilCodeEnglish]),
+    );
+  });
+
+  test("resolves an act by number within a named collection only", async () => {
+    const inCollection = expectPage(
+      await listStatutesHandler(
+        { country: "CZE", collection: "sb", number: "90/2012" },
+        legislationDb,
+      ),
+    );
+    const elsewhere = expectPage(
+      await listStatutesHandler(
+        { country: "CZE", collection: "ul1", number: "90/2012" },
+        legislationDb,
+      ),
+    );
+
+    expect(inCollection.items.map((item) => item.id)).toEqual([
+      corporationsAct,
+    ]);
+    expect(elsewhere.items).toEqual([]);
+  });
+
+  test("walks every work exactly once across recency cursor pages", async () => {
     const seen: string[] = [];
     let cursor: string | null = null;
 
-    for (let request = 0; request < 5; request += 1) {
+    for (let request = 0; request < 10; request += 1) {
       // Cursor pagination is sequential by construction: each request needs
       // the cursor the previous one returned.
       const page: StatutePage = expectPage(
@@ -501,8 +618,42 @@ describe("public statute list", () => {
       expect(cursor.length).toBeLessThanOrEqual(PAGINATION_CURSOR_MAX_CHARS);
       const cursorParts = decodePaginationCursor(cursor);
       expect(cursorParts).toHaveLength(3);
-      expect(cursorParts?.at(0)).toBe(LEGISLATION_TITLE_CURSOR_KIND);
-      const sortKey = cursorParts?.at(1);
+      expect(cursorParts?.at(0)).toBe(LEGISLATION_LIST_CURSOR_KIND.recent);
+      expect(cursorParts?.at(1)).toMatch(/^\d{4}-\d{2}-\d{2}$/u);
+    }
+
+    expect(cursor).toBeNull();
+    expect(seen).toEqual(recencyOrder);
+  });
+
+  test("walks every search hit exactly once across search cursor pages", async () => {
+    const seen: string[] = [];
+    let cursor: string | null = null;
+
+    for (let request = 0; request < 10; request += 1) {
+      const page: StatutePage = expectPage(
+        // eslint-disable-next-line eslint/no-await-in-loop -- keyset walk
+        await listStatutesHandler(
+          {
+            country: "CZE",
+            limit: 1,
+            query: "code",
+            ...(cursor === null ? {} : { cursor }),
+          },
+          legislationDb,
+        ),
+      );
+
+      seen.push(...page.items.map((item) => item.id));
+      cursor = page.nextCursor;
+
+      if (cursor === null) {
+        break;
+      }
+      const cursorParts = decodePaginationCursor(cursor);
+      expect(cursorParts).toHaveLength(4);
+      expect(cursorParts?.at(0)).toBe(LEGISLATION_LIST_CURSOR_KIND.search);
+      const sortKey = cursorParts?.at(2);
       expect(typeof sortKey).toBe("string");
       if (typeof sortKey !== "string") {
         throw new TypeError("Expected a title sort key in the tagged cursor");
@@ -513,19 +664,15 @@ describe("public statute list", () => {
     }
 
     expect(cursor).toBeNull();
-    expect(seen).toEqual([
-      civilCodeCurrent,
-      civilCodeEnglish,
-      labourCode,
-      longTitleAct,
-      registerAct,
-    ]);
+    // Nothing is named "code", so every hit ranks alike and title order rules.
+    expect(seen).toEqual([civilCodeCurrent, civilCodeEnglish, labourCode]);
   });
 
-  test("rejects the retired full-title cursor protocol", async () => {
+  test("rejects the retired title cursor protocol", async () => {
     const legacyCursor = encodePaginationCursor([
-      "Civil Code (English)",
-      civilCodeEnglish,
+      "title-prefix-v1",
+      "Labour Code",
+      labourCode,
     ]);
     const result = await listStatutesHandler(
       { country: "CZE", cursor: legacyCursor, limit: 1 },
@@ -539,41 +686,15 @@ describe("public statute list", () => {
     });
   });
 
-  test("accepts and preserves the next release's bounded cursor protocol", async () => {
-    const maximumEscapedCursor = encodePaginationCursor([
-      LEGISLATION_TITLE_CURSOR_KIND,
-      "\u0001".repeat(LEGISLATION_TITLE_SORT_KEY_CHARS),
-      longTitleAct,
-    ]);
-    expect(maximumEscapedCursor.length).toBeLessThanOrEqual(
-      PAGINATION_CURSOR_MAX_CHARS,
-    );
-
-    const boundedCursor = encodePaginationCursor([
-      LEGISLATION_TITLE_CURSOR_KIND,
+  test("rejects a cursor from the other ordering", async () => {
+    const searchCursor = encodePaginationCursor([
+      LEGISLATION_LIST_CURSOR_KIND.search,
+      "1",
       "Labour Code",
       labourCode,
     ]);
-    const page = expectPage(
-      await listStatutesHandler(
-        { country: "CZE", cursor: boundedCursor, limit: 1 },
-        legislationDb,
-      ),
-    );
-
-    expect(page.items.map((item) => item.id)).toEqual([longTitleAct]);
-    expect(decodePaginationCursor(page.nextCursor ?? "")).toEqual([
-      LEGISLATION_TITLE_CURSOR_KIND,
-      Array.from(longOfficialTitle)
-        .slice(0, LEGISLATION_TITLE_SORT_KEY_CHARS)
-        .join(""),
-      longTitleAct,
-    ]);
-  });
-
-  test("rejects a cursor outside the bounded title protocol", async () => {
     const result = await listStatutesHandler(
-      { country: "CZE", cursor: "not-a-cursor" },
+      { country: "CZE", cursor: searchCursor, limit: 1 },
       legislationDb,
     );
 
@@ -582,6 +703,54 @@ describe("public statute list", () => {
       code: 400,
       response: { message: "Invalid cursor" },
     });
+  });
+
+  test("rejects a cursor outside either protocol", async () => {
+    // A date that is well-formed but not a calendar day would otherwise
+    // reach the `::date` cast and surface as a server error.
+    const forgedDate = encodePaginationCursor([
+      LEGISLATION_LIST_CURSOR_KIND.recent,
+      "2026-99-99",
+      labourCode,
+    ]);
+    for (const cursor of ["not-a-cursor", forgedDate]) {
+      // eslint-disable-next-line eslint/no-await-in-loop -- each cursor is its own request
+      const result = await listStatutesHandler(
+        { country: "CZE", cursor },
+        legislationDb,
+      );
+
+      expect(result).not.toHaveProperty("items");
+      expect(result).toMatchObject({
+        code: 400,
+        response: { message: "Invalid cursor" },
+      });
+    }
+  });
+
+  test("the title fold agrees with the client-side fold", async () => {
+    const latinText = fc.string({
+      unit: fc.constantFrom(
+        ..."aábcčdďeéěfghiíjklľĺmnňoóôöőpqrřsštťuúůüűvwxyýzžAÁČĎÉĚÍŇÓŘŠŤÚŮÝŽłŁßøØæÆ 0123456789/.,()-".split(
+          "",
+        ),
+      ),
+      maxLength: 40,
+    });
+    await fc.assert(
+      fc.asyncProperty(latinText, async (text) => {
+        const folded = await legislationDb(async (tx) => {
+          const [row] = await tx
+            .select({ folded: sql<string>`legislation_title_fold(${text})` })
+            .from(legislationSources)
+            .limit(1);
+          return row?.folded;
+        });
+
+        expect(folded).toBe(foldToAscii(text).toLowerCase());
+      }),
+      propertyConfig({ numRuns: 40 }),
+    );
   });
 });
 

--- a/apps/api/src/tests/pglite-schema.ts
+++ b/apps/api/src/tests/pglite-schema.ts
@@ -5,6 +5,8 @@ import { sql, type SQL } from "drizzle-orm";
 import { readdirSync, readFileSync } from "node:fs";
 import nodePath from "node:path";
 
+import { ASCII_FOLD_TABLE } from "@stll/text-normalize";
+
 import { WORKSPACE_ACCESS_VIEW_NAME } from "@/api/db/rls";
 
 const DRIZZLE_DIR = nodePath.resolve(import.meta.dir, "../../drizzle");
@@ -57,11 +59,41 @@ const readMigrationStatements = (migrationPath: string): string[] =>
 const executableSql = (statement: string): string =>
   statement.replace(/^[ \t]*--[^\n]*/gmu, "").trim();
 
+/**
+ * PGlite ships no `unaccent`, so the production `legislation_title_fold`
+ * (migration 20260901130000) cannot be installed verbatim. This double is
+ * generated from the fold table the unaccent parity test pins against the
+ * real extension: NFD plus combining-mark removal for everything Unicode can
+ * decompose, then the table's rules for the letters it cannot (`ł`, `ß`, `ø`).
+ */
+const legislationTitleFoldPgliteSql = (): string => {
+  const entries = Object.entries(ASCII_FOLD_TABLE);
+  const singles = entries.filter(([, folded]) => folded.length === 1);
+  const multis = entries.filter(([, folded]) => folded.length !== 1);
+  const quote = (value: string): string => `$fold$${value}$fold$`;
+  let expression =
+    "regexp_replace(normalize($1, NFD), '[\\u0300-\\u036f]', '', 'g')";
+  expression = `translate(${expression}, ${quote(singles.map(([from]) => from).join(""))}, ${quote(singles.map(([, to]) => to).join(""))})`;
+  for (const [from, to] of multis) {
+    expression = `replace(${expression}, ${quote(from)}, ${quote(to)})`;
+  }
+  return `CREATE OR REPLACE FUNCTION legislation_title_fold(input text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+STRICT
+PARALLEL SAFE
+AS $body$
+  SELECT lower(${expression})
+$body$`;
+};
+
 export const installPgliteSchemaPrerequisites = async (
   db: PgliteSchemaDb,
 ): Promise<void> => {
   await db.execute(sql.raw("CREATE EXTENSION IF NOT EXISTS pg_trgm"));
   await db.execute(sql.raw(arabicNormalizeFunctionSql()));
+  await db.execute(sql.raw(legislationTitleFoldPgliteSql()));
   // Drizzle emits policies that reference this view before its backing tables
   // exist. Install a harmless shape-compatible stub for schema creation; the
   // security test database replaces it after pushSchema finishes.

--- a/apps/web/src/components/inspector/playbook-facet.tsx
+++ b/apps/web/src/components/inspector/playbook-facet.tsx
@@ -3855,7 +3855,7 @@ const ReviewCardActions = ({
         variant="ghost"
       >
         <MessageSquareIcon className="me-1 size-3.5" />
-        {t("inspector.review.askInChat")}
+        {t("common.askInChat")}
       </Button>
     </section>
   );

--- a/apps/web/src/features/statutes/components/statute-list-row.tsx
+++ b/apps/web/src/features/statutes/components/statute-list-row.tsx
@@ -1,0 +1,111 @@
+import type { ReactNode } from "react";
+
+import { Link } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+
+import { Skeleton } from "@stll/ui/skeleton";
+import { cn } from "@stll/ui/utils";
+
+import { StatuteStatusPill } from "@/features/statutes/components/statute-status-pill";
+import {
+  EM_DASH,
+  formatValidityDate,
+} from "@/features/statutes/statute-format";
+import { useFormatter } from "@/i18n/formatting-context";
+import { toStatuteCountrySegment } from "@/lib/statute-route";
+
+export type StatuteListItem = {
+  country: string;
+  documentType: string | null;
+  effectiveDate: string | null;
+  id: string;
+  status: string;
+  title: string;
+  versionValidFrom: string | null;
+};
+
+/**
+ * One entry of the statutes list: the title a lawyer recognises the act by,
+ * then its lifecycle and when the current wording took effect. The loading
+ * row below renders the same shell, so the list cannot shift when data lands.
+ */
+export const StatuteListRow = ({ statute }: { statute: StatuteListItem }) => {
+  const t = useTranslations();
+  const format = useFormatter();
+
+  return (
+    <RowShell
+      meta={
+        <>
+          <StatuteStatusPill status={statute.status} />
+          {statute.documentType !== null && <span>{statute.documentType}</span>}
+          <span>
+            {t("statutes.inForceSince", {
+              date:
+                formatValidityDate(statute.versionValidFrom, format) ??
+                formatValidityDate(statute.effectiveDate, format) ??
+                EM_DASH,
+            })}
+          </span>
+        </>
+      }
+      title={statute.title}
+      to={{
+        country: toStatuteCountrySegment(statute.country),
+        documentId: statute.id,
+      }}
+    />
+  );
+};
+
+export const StatuteListRowSkeleton = () => (
+  <RowShell
+    meta={
+      <>
+        <Skeleton className="h-4 w-14" />
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-4 w-32" />
+      </>
+    }
+    title={<Skeleton className="h-5 w-3/5" />}
+    to={null}
+  />
+);
+
+const ROW_CLASS = "block rounded-md border px-4 py-3";
+
+const RowShell = ({
+  meta,
+  title,
+  to,
+}: {
+  meta: ReactNode;
+  title: ReactNode;
+  to: { country: string; documentId: string } | null;
+}) => {
+  // Block containers: the loading row puts block skeletons here, and a block
+  // inside an inline element is markup the browser would reparse, which a
+  // server-rendered public page then fails to hydrate.
+  const body = (
+    <>
+      <div className="text-foreground font-medium">{title}</div>
+      <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+        {meta}
+      </div>
+    </>
+  );
+
+  if (to === null) {
+    return <div className={ROW_CLASS}>{body}</div>;
+  }
+
+  return (
+    <Link
+      className={cn(ROW_CLASS, "hover:bg-muted/50 transition-colors")}
+      params={to}
+      to="/law/$country/statutes/$documentId"
+    >
+      {body}
+    </Link>
+  );
+};

--- a/apps/web/src/features/statutes/components/statute-search.tsx
+++ b/apps/web/src/features/statutes/components/statute-search.tsx
@@ -1,0 +1,144 @@
+import { useRouterState } from "@tanstack/react-router";
+import { MessageSquareTextIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/button";
+import { Input } from "@stll/ui/input";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@stll/ui/select";
+
+import { usePublicSignInRequest } from "@/components/public-sign-in-request";
+import { openProvisionChat } from "@/features/statutes/provision-ask";
+import { useFormatter } from "@/i18n/formatting-context";
+import { useMaybeAuthenticatedUser } from "@/lib/authenticated-user-context";
+import {
+  isStatuteCountry,
+  STATUTE_COUNTRIES,
+  type StatuteCountry,
+} from "@/lib/statute-route";
+
+type StatuteSearchProps = {
+  country: string;
+  maxLength: number;
+  onCountryChange: (country: StatuteCountry) => void;
+  onQueryChange: (value: string) => void;
+  /** Submitted: open what the entry names, when it names one thing. */
+  onSubmit: () => void;
+  query: string;
+};
+
+/**
+ * The one box of the statutes browser: an act number, an alias or a title,
+ * scoped by the jurisdiction pill beside it. A form so Enter submits the way
+ * the browser already knows how to.
+ */
+export const StatuteSearch = ({
+  country,
+  maxLength,
+  onCountryChange,
+  onQueryChange,
+  onSubmit,
+  query,
+}: StatuteSearchProps) => {
+  const t = useTranslations();
+  const format = useFormatter();
+
+  return (
+    <form
+      className="flex flex-wrap items-center gap-2"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit();
+      }}
+      role="search"
+    >
+      <Select
+        onValueChange={(value: string | null) => {
+          if (value !== null && isStatuteCountry(value) && value !== country) {
+            onCountryChange(value);
+          }
+        }}
+        value={country}
+      >
+        <SelectTrigger aria-label={t("common.country")} className="w-36">
+          <SelectValue placeholder={t("common.country")} />
+        </SelectTrigger>
+        <SelectPopup>
+          {Object.entries(STATUTE_COUNTRIES).map(([segment, { region }]) => (
+            <SelectItem key={segment} value={segment}>
+              {format.displayName(region, { type: "region" })}
+            </SelectItem>
+          ))}
+        </SelectPopup>
+      </Select>
+      <Input
+        aria-label={t("statutes.searchLabel")}
+        className="min-w-64 flex-1 sm:max-w-md"
+        maxLength={maxLength}
+        onChange={(event) => onQueryChange(event.currentTarget.value)}
+        placeholder={t("statutes.searchPlaceholder")}
+        type="search"
+        value={query}
+      />
+      {query.trim().length > 0 && (
+        <AskInChat country={country} query={query.trim()} />
+      )}
+    </form>
+  );
+};
+
+/**
+ * Hands the entry to a chat with the corpus tools, scoped to the jurisdiction
+ * the box is set to: `OZ` is a different act in each. The chat is an account
+ * feature: a visitor is sent to sign in and comes back to the same list.
+ */
+const AskInChat = ({ country, query }: { country: string; query: string }) => {
+  const t = useTranslations();
+  const format = useFormatter();
+  const user = useMaybeAuthenticatedUser();
+  const requestSignIn = usePublicSignInRequest();
+  const currentHref = useRouterState({
+    select: (state) => state.location.href,
+  });
+
+  const ask = () => {
+    if (user === null) {
+      if (requestSignIn !== null) {
+        requestSignIn(currentHref);
+      }
+      return;
+    }
+    const region = isStatuteCountry(country)
+      ? STATUTE_COUNTRIES[country].region
+      : country.toUpperCase();
+    openProvisionChat({
+      label: query,
+      prompt: t("statutes.searchAskPrompt", {
+        country: format.displayName(region, { type: "region" }),
+        query,
+      }),
+    });
+  };
+
+  if (user === null && requestSignIn === null) {
+    return null;
+  }
+
+  return (
+    <Button
+      className="text-muted-foreground text-xs"
+      onClick={ask}
+      size="sm"
+      type="button"
+      variant="ghost"
+    >
+      <MessageSquareTextIcon aria-hidden="true" className="size-3.5" />
+      {t("common.askInChat")}
+    </Button>
+  );
+};

--- a/apps/web/src/features/statutes/queries/statutes.ts
+++ b/apps/web/src/features/statutes/queries/statutes.ts
@@ -20,8 +20,12 @@ const VERSIONS_PAGE_SIZE = 200;
 const VERSIONS_MAX_PAGES = 5;
 
 export type StatuteListFilters = {
+  /** Narrows an act-number lookup to one publisher collection (`sb`, `zz`). */
+  collection?: string;
   country: string;
   language?: string;
+  /** An act number, `<number>/<year>`: the list resolves that work. */
+  number?: string;
   query?: string;
 };
 
@@ -41,8 +45,10 @@ export const statuteKeys = {
     ...statuteKeys.all,
     "list",
     {
+      collection: filters.collection,
       country: filters.country,
       language: filters.language,
+      number: filters.number,
       query: filters.query,
     },
   ],
@@ -69,7 +75,11 @@ export const statutesInfiniteOptions = (filters: StatuteListFilters) =>
           country: filters.country,
           limit: DEFAULT_PAGE_SIZE,
           ...(pageParam !== null && { cursor: pageParam }),
+          ...(filters.collection !== undefined && {
+            collection: filters.collection,
+          }),
           ...(filters.language !== undefined && { language: filters.language }),
+          ...(filters.number !== undefined && { number: filters.number }),
           ...(filters.query !== undefined && { query: filters.query }),
         },
         fetch: { signal },

--- a/apps/web/src/features/statutes/statute-aliases.ts
+++ b/apps/web/src/features/statutes/statute-aliases.ts
@@ -1,0 +1,120 @@
+import type { StatuteCountry } from "@/lib/statute-route";
+
+/**
+ * An act an alias names: its number in the collection that published it,
+ * and the short name a reader recognises it by.
+ */
+export type StatuteAliasTarget = {
+  collection: string;
+  label: string;
+  number: string;
+  year: string;
+};
+
+const act = (
+  number: string,
+  year: string,
+  collection: string,
+  label: string,
+): StatuteAliasTarget => ({ collection, label, number, year });
+
+// Keys are already folded (lower-case, diacritics removed); the matcher folds
+// the input the same way, so `OSŘ`, `osř` and `osr` are one key.
+const CZE_ACTS = {
+  civilCode: act("89", "2012", "sb", "Občanský zákoník"),
+  corporations: act("90", "2012", "sb", "Zákon o obchodních korporacích"),
+  labourCode: act("262", "2006", "sb", "Zákoník práce"),
+  criminalCode: act("40", "2009", "sb", "Trestní zákoník"),
+  criminalProcedure: act("141", "1961", "sb", "Trestní řád"),
+  civilProcedure: act("99", "1963", "sb", "Občanský soudní řád"),
+  administrativeJustice: act("150", "2002", "sb", "Soudní řád správní"),
+  administrativeProcedure: act("500", "2004", "sb", "Správní řád"),
+  insolvency: act("182", "2006", "sb", "Insolvenční zákon"),
+  incomeTax: act("586", "1992", "sb", "Zákon o daních z příjmů"),
+  vat: act("235", "2004", "sb", "Zákon o dani z přidané hodnoty"),
+  constitution: act("1", "1993", "sb", "Ústava České republiky"),
+  charter: act("2", "1993", "sb", "Listina základních práv a svobod"),
+  trades: act("455", "1991", "sb", "Živnostenský zákon"),
+  specialProceedings: act(
+    "292",
+    "2013",
+    "sb",
+    "Zákon o zvláštních řízeních soudních",
+  ),
+  building: act("283", "2021", "sb", "Stavební zákon"),
+} as const;
+
+const SVK_ACTS = {
+  civilCode: act("40", "1964", "zz", "Občiansky zákonník"),
+  commercialCode: act("513", "1991", "zz", "Obchodný zákonník"),
+  labourCode: act("311", "2001", "zz", "Zákonník práce"),
+  criminalCode: act("300", "2005", "zz", "Trestný zákon"),
+  civilDisputes: act("160", "2015", "zz", "Civilný sporový poriadok"),
+  administrativeProcedure: act("71", "1967", "zz", "Správny poriadok"),
+} as const;
+
+/**
+ * What lawyers type instead of a number, per jurisdiction. Every target was
+ * checked against the corpus: the number opens the act the label names.
+ * `oz` is the civil code in both jurisdictions and a different act in each;
+ * the jurisdiction the reader is in decides.
+ */
+export const STATUTE_ALIASES = {
+  cze: {
+    oz: CZE_ACTS.civilCode,
+    noz: CZE_ACTS.civilCode,
+    obcz: CZE_ACTS.civilCode,
+    "obc. zak.": CZE_ACTS.civilCode,
+    "obc zak": CZE_ACTS.civilCode,
+    "obcansky zakonik": CZE_ACTS.civilCode,
+    obcansky: CZE_ACTS.civilCode,
+    obcan: CZE_ACTS.civilCode,
+    zok: CZE_ACTS.corporations,
+    "zakon o obchodnich korporacich": CZE_ACTS.corporations,
+    zp: CZE_ACTS.labourCode,
+    "zakonik prace": CZE_ACTS.labourCode,
+    tz: CZE_ACTS.criminalCode,
+    "trestni zakonik": CZE_ACTS.criminalCode,
+    tr: CZE_ACTS.criminalProcedure,
+    "trestni rad": CZE_ACTS.criminalProcedure,
+    osr: CZE_ACTS.civilProcedure,
+    "obcansky soudni rad": CZE_ACTS.civilProcedure,
+    srs: CZE_ACTS.administrativeJustice,
+    "soudni rad spravni": CZE_ACTS.administrativeJustice,
+    sr: CZE_ACTS.administrativeProcedure,
+    "spravni rad": CZE_ACTS.administrativeProcedure,
+    insz: CZE_ACTS.insolvency,
+    iz: CZE_ACTS.insolvency,
+    "insolvencni zakon": CZE_ACTS.insolvency,
+    zdp: CZE_ACTS.incomeTax,
+    dph: CZE_ACTS.vat,
+    ustava: CZE_ACTS.constitution,
+    lzps: CZE_ACTS.charter,
+    listina: CZE_ACTS.charter,
+    "zivnostensky zakon": CZE_ACTS.trades,
+    zrs: CZE_ACTS.specialProceedings,
+    "stavebni zakon": CZE_ACTS.building,
+  },
+  svk: {
+    oz: SVK_ACTS.civilCode,
+    "obciansky zakonnik": SVK_ACTS.civilCode,
+    obchz: SVK_ACTS.commercialCode,
+    obz: SVK_ACTS.commercialCode,
+    "obchodny zakonnik": SVK_ACTS.commercialCode,
+    zp: SVK_ACTS.labourCode,
+    "zakonnik prace": SVK_ACTS.labourCode,
+    tz: SVK_ACTS.criminalCode,
+    "trestny zakon": SVK_ACTS.criminalCode,
+    csp: SVK_ACTS.civilDisputes,
+    "civilny sporovy poriadok": SVK_ACTS.civilDisputes,
+    "spravny poriadok": SVK_ACTS.administrativeProcedure,
+  },
+} as const satisfies Record<StatuteCountry, Record<string, StatuteAliasTarget>>;
+
+export const resolveStatuteAlias = (
+  country: StatuteCountry,
+  foldedText: string,
+): StatuteAliasTarget | null => {
+  const aliases: Record<string, StatuteAliasTarget> = STATUTE_ALIASES[country];
+  return aliases[foldedText] ?? null;
+};

--- a/apps/web/src/features/statutes/statute-query-intent.test.ts
+++ b/apps/web/src/features/statutes/statute-query-intent.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { propertyConfig } from "@stll/property-testing";
+
+import { STATUTE_ALIASES } from "@/features/statutes/statute-aliases";
+import {
+  foldStatuteQuery,
+  parseStatuteQuery,
+} from "@/features/statutes/statute-query-intent";
+import { STATUTE_COUNTRIES, type StatuteCountry } from "@/lib/statute-route";
+
+const countries = Object.keys(STATUTE_COUNTRIES).filter(
+  (country): country is StatuteCountry => country in STATUTE_COUNTRIES,
+);
+
+const SPACES = [" ", "  ", " ", "　", "\t", ""] as const;
+
+const number = fc.integer({ min: 1, max: 99_999 });
+const year = fc.integer({ min: 1918, max: 2026 });
+const space = fc.constantFrom(...SPACES);
+const prefix = fc.constantFrom(
+  "",
+  "č. ",
+  "zákon ",
+  "zákon č. ",
+  "z. ",
+  "zák. ",
+  "vyhláška ",
+  "ZÁKON Č. ",
+);
+const czechSuffix = fc.constantFrom(
+  ["", null],
+  ["Sb.", "sb"],
+  ["Sb", "sb"],
+  ["sb.", "sb"],
+  ["SB.", "sb"],
+  ["Ú. l.", null],
+  ["Ú.l. I", null],
+);
+const slovakSuffix = fc.constantFrom(
+  ["", null],
+  ["Zb.", "zz"],
+  ["Z. z.", "zz"],
+  ["Z.z.", "zz"],
+  ["z. z", "zz"],
+  ["ZB", "zz"],
+);
+
+const spelled = (parts: readonly string[], spaces: readonly string[]): string =>
+  parts.map((part, index) => `${part}${spaces[index] ?? ""}`).join("");
+
+describe("reading an act number", () => {
+  test("every lenient spelling of a Czech number names the same act", () => {
+    fc.assert(
+      fc.property(
+        number,
+        year,
+        prefix,
+        czechSuffix,
+        fc.array(space, { minLength: 4, maxLength: 4 }),
+        (n, y, pre, [suffix, collection], spaces) => {
+          const raw = spelled([pre, String(n), "/", String(y), suffix], spaces);
+
+          expect(parseStatuteQuery("cze", raw)).toEqual({
+            type: "act",
+            collection,
+            label: null,
+            number: String(n),
+            provision: null,
+            year: String(y),
+          });
+        },
+      ),
+      propertyConfig(),
+    );
+  });
+
+  test("every lenient spelling of a Slovak number names the same act", () => {
+    fc.assert(
+      fc.property(
+        number,
+        year,
+        slovakSuffix,
+        fc.array(space, { minLength: 3, maxLength: 3 }),
+        (n, y, [suffix, collection], spaces) => {
+          const raw = spelled([String(n), "/", String(y), suffix], spaces);
+
+          expect(parseStatuteQuery("svk", raw)).toEqual({
+            type: "act",
+            collection,
+            label: null,
+            number: String(n),
+            provision: null,
+            year: String(y),
+          });
+        },
+      ),
+      propertyConfig(),
+    );
+  });
+
+  test("full-width digits and leading zeros read as the same number", () => {
+    expect(parseStatuteQuery("cze", "０８９／２０１２")).toMatchObject({
+      type: "act",
+      number: "89",
+      year: "2012",
+    });
+  });
+
+  test("a provision ahead of the number is kept as a jump target", () => {
+    expect(parseStatuteQuery("cze", "§ 2079 zákona č. 89/2012 Sb.")).toEqual({
+      type: "act",
+      collection: "sb",
+      label: null,
+      number: "89",
+      provision: "§ 2079",
+      year: "2012",
+    });
+    expect(parseStatuteQuery("cze", "§2079 odst. 1 OZ")).toMatchObject({
+      type: "act",
+      number: "89",
+      provision: "§ 2079",
+      label: "Občanský zákoník",
+    });
+    expect(parseStatuteQuery("cze", "čl. 10 ústava")).toMatchObject({
+      type: "act",
+      number: "1",
+      provision: "cl. 10",
+    });
+  });
+
+  test("text that is not a reference searches titles verbatim", () => {
+    expect(parseStatuteQuery("cze", "  občanský zákoník 2012 ")).toEqual({
+      type: "text",
+      text: "občanský zákoník 2012",
+    });
+    expect(parseStatuteQuery("cze", "89/12")).toEqual({
+      type: "text",
+      text: "89/12",
+    });
+    // A collection the jurisdiction does not publish must not widen the
+    // number to every collection: 40/1964 Sb. is a different act.
+    expect(parseStatuteQuery("cze", "40/1964 Z. z.")).toEqual({
+      type: "text",
+      text: "40/1964 Z. z.",
+    });
+    expect(parseStatuteQuery("svk", "89/2012 Sb.")).toEqual({
+      type: "text",
+      text: "89/2012 Sb.",
+    });
+    expect(parseStatuteQuery("cze", "")).toEqual({ type: "empty" });
+    expect(parseStatuteQuery("cze", "§ 2079")).toEqual({
+      type: "text",
+      text: "§ 2079",
+    });
+  });
+});
+
+describe("reading an alias", () => {
+  test("every alias of every jurisdiction resolves to its act, however cased", () => {
+    for (const country of countries) {
+      for (const [alias, target] of Object.entries(STATUTE_ALIASES[country])) {
+        // Aliases are stored folded; a stored key that is not its own fold
+        // could never be typed.
+        expect(foldStatuteQuery(alias)).toBe(alias);
+        for (const typed of [alias, alias.toUpperCase(), ` ${alias} `]) {
+          expect(parseStatuteQuery(country, typed)).toEqual({
+            type: "act",
+            collection: target.collection,
+            label: target.label,
+            number: target.number,
+            provision: null,
+            year: target.year,
+          });
+        }
+      }
+    }
+  });
+
+  test("the same alias opens a different act per jurisdiction", () => {
+    expect(parseStatuteQuery("cze", "OZ")).toMatchObject({
+      number: "89",
+      year: "2012",
+    });
+    expect(parseStatuteQuery("svk", "OZ")).toMatchObject({
+      number: "40",
+      year: "1964",
+    });
+  });
+
+  test("diacritics and abbreviation dots are not required", () => {
+    expect(parseStatuteQuery("cze", "Občanský zákoník")).toMatchObject({
+      number: "89",
+      year: "2012",
+    });
+    expect(parseStatuteQuery("cze", "obc. zak.")).toMatchObject({
+      number: "89",
+    });
+    expect(parseStatuteQuery("cze", "OSŘ")).toMatchObject({ number: "99" });
+    expect(parseStatuteQuery("cze", "sřs")).toMatchObject({ number: "150" });
+    expect(parseStatuteQuery("svk", "Obchodný zákonník")).toMatchObject({
+      number: "513",
+    });
+  });
+});

--- a/apps/web/src/features/statutes/statute-query-intent.ts
+++ b/apps/web/src/features/statutes/statute-query-intent.ts
@@ -1,0 +1,183 @@
+import { foldToAscii } from "@stll/text-normalize";
+
+import {
+  resolveStatuteAlias,
+  type StatuteAliasTarget,
+} from "@/features/statutes/statute-aliases";
+import type { StatuteCountry } from "@/lib/statute-route";
+
+/**
+ * What a statute box entry asks for. An act is addressed by number (with the
+ * collection when the entry names one) or by an alias the jurisdiction knows;
+ * anything else is text to search titles by.
+ */
+export type StatuteQueryIntent =
+  | { type: "empty" }
+  | {
+      type: "act";
+      collection: string | null;
+      /** The alias's short name, when the entry used one instead of a number. */
+      label: string | null;
+      number: string;
+      /**
+       * The provision designation the entry named ahead of the act
+       * (`§ 2079` in `§ 2079 89/2012`), in the form the reader's jump field
+       * parses.
+       */
+      provision: string | null;
+      year: string;
+    }
+  | { type: "text"; text: string };
+
+/**
+ * The comparison form of an entry: compatibility-normalised (full-width
+ * digits and spaces), diacritics folded the way the title index folds them,
+ * lower-case, runs of any whitespace collapsed to one space.
+ */
+export const foldStatuteQuery = (raw: string): string =>
+  foldToAscii(raw.normalize("NFKC")).toLowerCase().replace(/\s+/gu, " ").trim();
+
+/**
+ * Publisher collections as lawyers abbreviate them, mapped to the collection
+ * segment of the publisher's ELI. The Czech official gazette (`Ú. l.`) was
+ * split into two ELI collections, so its abbreviation names no single one.
+ */
+const COLLECTION_BY_ABBREVIATION = {
+  cze: { sb: "sb", ul: null },
+  svk: { zb: "zz", zz: "zz" },
+} as const satisfies Record<StatuteCountry, Record<string, string | null>>;
+
+/** `Sb.`, `Z. z.`, `Ú.l. I` → `sb`, `zz`, `ul`: dots, spaces and series dropped. */
+const canonicalCollectionAbbreviation = (suffix: string): string =>
+  suffix.replace(/ i{1,2}$/u, "").replaceAll(/[.\s]/gu, "");
+
+// The patterns below run on folded text, where every whitespace run is one
+// space, so they spell spaces literally instead of with `\s*` runs: two
+// adjacent unbounded quantifiers are what makes a regex backtrack
+// super-linearly, and the ratchet forbids them.
+
+// `§ 2079`, `par. 3`, `cl. 10`, optionally followed by a paragraph and a
+// letter, then the act. The designation (marker and number) is kept as the
+// reader's jump field expects it; the paragraph is not addressable there.
+const PROVISION_PREFIX_RE =
+  /^(§|par\.?|cl\.?|art\.?) ?(\d+[a-z]*)(?: odst\.? ?\d+[a-z]*)?(?: pism\.? ?[a-z]\)?)? (.+)$/u;
+
+// One word that may precede a number: the act word, the ordinal word, the
+// "č." sign. Stripped one at a time, so `zákon č. 89/2012` sheds two.
+const ACT_PREFIX_WORD_RE =
+  /^(?:c\.|zakon[a-z]*|zak\.|z\.|vyhlaska|vyhl\.|narizeni|nariadenie|nar\.) ?/u;
+const ACT_PREFIX_WORDS_MAX = 4;
+
+const ACT_NUMBER_RE =
+  /^(\d{1,5}) ?\/ ?(\d{4})(?: ?(sb\.?|zb\.?|z\. ?z\.?|u\. ?l\.(?: i{1,2})?))?$/u;
+
+const stripActPrefixWords = (folded: string): string => {
+  let rest = folded;
+  for (let words = 0; words < ACT_PREFIX_WORDS_MAX; words += 1) {
+    const next = rest.replace(ACT_PREFIX_WORD_RE, "");
+    if (next === rest) {
+      break;
+    }
+    rest = next;
+  }
+  return rest;
+};
+
+const actFromNumber = (
+  country: StatuteCountry,
+  folded: string,
+  provision: string | null,
+): StatuteQueryIntent | null => {
+  const match = ACT_NUMBER_RE.exec(stripActPrefixWords(folded));
+  const ordinal = match?.[1];
+  const year = match?.[2];
+  if (ordinal === undefined || year === undefined) {
+    return null;
+  }
+  const suffix = match?.[3];
+  const collections: Record<string, string | null> =
+    COLLECTION_BY_ABBREVIATION[country];
+  let collection: string | null = null;
+  if (suffix !== undefined) {
+    const abbreviation = canonicalCollectionAbbreviation(suffix);
+    // A collection this jurisdiction does not publish (`Z. z.` while reading
+    // Czech law) is not a reference into it; widening it to "any collection"
+    // would open a different act under the same number.
+    if (!Object.hasOwn(collections, abbreviation)) {
+      return null;
+    }
+    collection = collections[abbreviation] ?? null;
+  }
+
+  return {
+    type: "act",
+    collection,
+    label: null,
+    number: String(Number(ordinal)),
+    provision,
+    year,
+  };
+};
+
+const actFromAlias = (
+  target: StatuteAliasTarget,
+  provision: string | null,
+): StatuteQueryIntent => ({
+  type: "act",
+  collection: target.collection,
+  label: target.label,
+  number: target.number,
+  provision,
+  year: target.year,
+});
+
+const actIntent = (
+  country: StatuteCountry,
+  folded: string,
+  provision: string | null,
+): StatuteQueryIntent | null => {
+  const byNumber = actFromNumber(country, folded, provision);
+  if (byNumber !== null) {
+    return byNumber;
+  }
+  const alias = resolveStatuteAlias(country, folded);
+  return alias === null ? null : actFromAlias(alias, provision);
+};
+
+/**
+ * Read an entry as an act reference where it is one. Number grammar is lenient
+ * about spacing and about the words around the number; aliases are matched
+ * whole after folding, so `OSŘ` and `osr` name the same act. Anything the
+ * grammar does not claim is a title search, verbatim.
+ */
+export const parseStatuteQuery = (
+  country: StatuteCountry,
+  raw: string,
+): StatuteQueryIntent => {
+  const text = raw.trim();
+  if (text.length === 0) {
+    return { type: "empty" };
+  }
+  const folded = foldStatuteQuery(text);
+
+  const provisionMatch = PROVISION_PREFIX_RE.exec(folded);
+  const marker = provisionMatch?.[1];
+  const provisionNumber = provisionMatch?.[2];
+  const afterProvision = provisionMatch?.[3];
+  if (
+    marker !== undefined &&
+    provisionNumber !== undefined &&
+    afterProvision !== undefined
+  ) {
+    const act = actIntent(
+      country,
+      stripActPrefixWords(afterProvision),
+      `${marker} ${provisionNumber}`,
+    );
+    if (act !== null) {
+      return act;
+    }
+  }
+
+  return actIntent(country, folded, null) ?? { type: "text", text };
+};

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -1026,6 +1026,7 @@
     "archive": "أرشفة",
     "ask": "اسأل",
     "askAI": "اسأل AI",
+    "askInChat": "السؤال في الدردشة",
     "author": "الكاتب",
     "back": "رجوع",
     "cancel": "إلغاء",
@@ -2321,7 +2322,6 @@
       "addReference": "إضافة {name} كمرجع",
       "addTopic": "إضافة موضوع",
       "allDecided": "تم البت في كل النتائج هنا.",
-      "askInChat": "السؤال في الدردشة",
       "assessment": {
         "additionalInTarget": "إضافة في المستند المستهدف",
         "aligned": "منسجم",
@@ -3688,8 +3688,11 @@
     "provisionHistoryUnavailable": "تعذّر تحميل سجل هذه المادة.",
     "provisionPromptSubject": "{provision} من {statute} ({eli}) بصيغتها النافذة منذ {date}",
     "provisionPromptSubjectUndated": "{provision} من {statute} ({eli})",
+    "recentlyAmended": "المعدَّلة مؤخرًا",
+    "resolvedAlias": "تم التعرف عليه باسم {label}",
+    "searchAskPrompt": "{query} (تشريعات {country})",
     "searchLabel": "البحث في التشريعات",
-    "searchPlaceholder": "ابحث بالعنوان أو الرقم...",
+    "searchPlaceholder": "الرقم أو الاسم أو العنوان، مثل 89/2012 Sb.",
     "showInText": "عرض في النص",
     "status": {
       "current": "نافذ",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1026,6 +1026,7 @@
     "archive": "Archivovat",
     "ask": "Zeptat se",
     "askAI": "Zeptat se AI",
+    "askInChat": "Zeptat se v chatu",
     "author": "Autor",
     "back": "Zpět",
     "cancel": "Zrušit",
@@ -2321,7 +2322,6 @@
       "addReference": "Přidat {name} jako referenci",
       "addTopic": "Přidat téma",
       "allDecided": "Všechna zjištění zde jsou rozhodnutá.",
-      "askInChat": "Zeptat se v chatu",
       "assessment": {
         "additionalInTarget": "Navíc v cílovém dokumentu",
         "aligned": "Shodné",
@@ -3688,8 +3688,11 @@
     "provisionHistoryUnavailable": "Historii tohoto ustanovení se nepodařilo načíst.",
     "provisionPromptSubject": "{provision} předpisu {statute} ({eli}) ve znění účinném od {date}",
     "provisionPromptSubjectUndated": "{provision} předpisu {statute} ({eli})",
+    "recentlyAmended": "Naposledy novelizované",
+    "resolvedAlias": "Rozpoznáno jako {label}",
+    "searchAskPrompt": "{query} (právní předpisy: {country})",
     "searchLabel": "Hledat v právních předpisech",
-    "searchPlaceholder": "Hledat podle názvu nebo čísla...",
+    "searchPlaceholder": "Číslo, zkratka nebo název, např. 89/2012 Sb.",
     "showInText": "Zobrazit v textu",
     "status": {
       "current": "Účinné",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1026,6 +1026,7 @@
     "archive": "Archivieren",
     "ask": "Fragen",
     "askAI": "KI fragen",
+    "askInChat": "Im Chat fragen",
     "author": "Autor",
     "back": "Zurück",
     "cancel": "Abbrechen",
@@ -2321,7 +2322,6 @@
       "addReference": "{name} als Referenz hinzufügen",
       "addTopic": "Thema hinzufügen",
       "allDecided": "Alle Ergebnisse hier sind entschieden.",
-      "askInChat": "Im Chat fragen",
       "assessment": {
         "additionalInTarget": "Zusätzlich im Zieldokument",
         "aligned": "Übereinstimmend",
@@ -3688,8 +3688,11 @@
     "provisionHistoryUnavailable": "Der Verlauf dieser Vorschrift konnte nicht geladen werden.",
     "provisionPromptSubject": "{provision} von {statute} ({eli}) in der seit {date} geltenden Fassung",
     "provisionPromptSubjectUndated": "{provision} von {statute} ({eli})",
+    "recentlyAmended": "Zuletzt geändert",
+    "resolvedAlias": "Erkannt als {label}",
+    "searchAskPrompt": "{query} (Rechtsvorschriften: {country})",
     "searchLabel": "Rechtsvorschriften durchsuchen",
-    "searchPlaceholder": "Nach Titel oder Nummer suchen...",
+    "searchPlaceholder": "Nummer, Kurzname oder Titel, z. B. 89/2012 Sb.",
     "showInText": "Im Text anzeigen",
     "status": {
       "current": "In Kraft",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1026,6 +1026,7 @@
     "archive": "Archive",
     "ask": "Ask",
     "askAI": "Ask AI",
+    "askInChat": "Ask in chat",
     "author": "Author",
     "back": "Back",
     "cancel": "Cancel",
@@ -2321,7 +2322,6 @@
       "addReference": "Add {name} as a reference",
       "addTopic": "Add topic",
       "allDecided": "Every finding here has been decided.",
-      "askInChat": "Ask in chat",
       "assessment": {
         "additionalInTarget": "Additional in target",
         "aligned": "Consistent with references",
@@ -3688,8 +3688,11 @@
     "provisionHistoryUnavailable": "This provision's history could not be loaded.",
     "provisionPromptSubject": "{provision} of {statute} ({eli}), in the wording in force since {date}",
     "provisionPromptSubjectUndated": "{provision} of {statute} ({eli})",
+    "recentlyAmended": "Recently amended",
+    "resolvedAlias": "Recognized as {label}",
+    "searchAskPrompt": "{query} (legislation of {country})",
     "searchLabel": "Search statutes",
-    "searchPlaceholder": "Search by title or number...",
+    "searchPlaceholder": "Number, name or title, e.g. 89/2012 Sb.",
     "showInText": "Show in the text",
     "status": {
       "current": "In force",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1026,6 +1026,7 @@
     "archive": "Archivar",
     "ask": "Preguntar",
     "askAI": "Preguntar a la IA",
+    "askInChat": "Preguntar en el chat",
     "author": "Autor",
     "back": "Volver",
     "cancel": "Cancelar",
@@ -2321,7 +2322,6 @@
       "addReference": "Añadir {name} como referencia",
       "addTopic": "Añadir tema",
       "allDecided": "Todos los hallazgos aquí están decididos.",
-      "askInChat": "Preguntar en el chat",
       "assessment": {
         "additionalInTarget": "Adicional en el documento objetivo",
         "aligned": "Alineado",
@@ -3688,8 +3688,11 @@
     "provisionHistoryUnavailable": "No se ha podido cargar el historial de este precepto.",
     "provisionPromptSubject": "{provision} de {statute} ({eli}), en la redacción vigente desde el {date}",
     "provisionPromptSubjectUndated": "{provision} de {statute} ({eli})",
+    "recentlyAmended": "Modificadas recientemente",
+    "resolvedAlias": "Reconocido como {label}",
+    "searchAskPrompt": "{query} (legislación de {country})",
     "searchLabel": "Buscar en la legislación",
-    "searchPlaceholder": "Buscar por título o número...",
+    "searchPlaceholder": "Número, nombre o título, p. ej. 89/2012 Sb.",
     "showInText": "Ver en el texto",
     "status": {
       "current": "En vigor",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1026,6 +1026,7 @@
     "archive": "Arhiveeri",
     "ask": "Küsi",
     "askAI": "Küsi AI-lt",
+    "askInChat": "Küsi vestluses",
     "author": "Autor",
     "back": "Tagasi",
     "cancel": "Tühista",
@@ -2321,7 +2322,6 @@
       "addReference": "Lisa {name} võrdlusena",
       "addTopic": "Lisa teema",
       "allDecided": "Kõik siinsed leiud on otsustatud.",
-      "askInChat": "Küsi vestluses",
       "assessment": {
         "additionalInTarget": "Sihtdokumendis lisaks",
         "aligned": "Kooskõlas",
@@ -3688,8 +3688,11 @@
     "provisionHistoryUnavailable": "Selle sätte ajalugu ei õnnestunud laadida.",
     "provisionPromptSubject": "{statute} ({eli}) {provision} redaktsioonis, mis kehtib alates {date}",
     "provisionPromptSubjectUndated": "{statute} ({eli}) {provision}",
+    "recentlyAmended": "Viimati muudetud",
+    "resolvedAlias": "Tuvastatud kui {label}",
+    "searchAskPrompt": "{query} ({country} õigusaktid)",
     "searchLabel": "Otsi õigusaktidest",
-    "searchPlaceholder": "Otsi pealkirja või numbri järgi...",
+    "searchPlaceholder": "Number, lühinimi või pealkiri, nt 89/2012 Sb.",
     "showInText": "Näita tekstis",
     "status": {
       "current": "Kehtiv",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1026,6 +1026,7 @@
     "archive": "Archiver",
     "ask": "Demander",
     "askAI": "Demander à l’IA",
+    "askInChat": "Demander dans le chat",
     "author": "Auteur",
     "back": "Retour",
     "cancel": "Annuler",
@@ -2321,7 +2322,6 @@
       "addReference": "Ajouter {name} comme référence",
       "addTopic": "Ajouter un thème",
       "allDecided": "Tous les constats ici ont été traités.",
-      "askInChat": "Demander dans le chat",
       "assessment": {
         "additionalInTarget": "Supplémentaire dans le document cible",
         "aligned": "Cohérent",
@@ -3688,8 +3688,11 @@
     "provisionHistoryUnavailable": "Impossible de charger l'historique de cette disposition.",
     "provisionPromptSubject": "{provision} de {statute} ({eli}), dans sa rédaction en vigueur depuis le {date}",
     "provisionPromptSubjectUndated": "{provision} de {statute} ({eli})",
+    "recentlyAmended": "Modifiés récemment",
+    "resolvedAlias": "Reconnu comme {label}",
+    "searchAskPrompt": "{query} (législation : {country})",
     "searchLabel": "Rechercher dans la législation",
-    "searchPlaceholder": "Rechercher par titre ou numéro...",
+    "searchPlaceholder": "Numéro, nom ou intitulé, p. ex. 89/2012 Sb.",
     "showInText": "Afficher dans le texte",
     "status": {
       "current": "En vigueur",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1026,6 +1026,7 @@
     "archive": "Archiválás",
     "ask": "Kérdezés",
     "askAI": "AI megkérdezése",
+    "askInChat": "Kérdezze meg a chatben",
     "author": "Szerző",
     "back": "Vissza",
     "cancel": "Mégse",
@@ -2321,7 +2322,6 @@
       "addReference": "{name} hozzáadása referenciaként",
       "addTopic": "Téma hozzáadása",
       "allDecided": "Itt minden megállapítás eldöntve.",
-      "askInChat": "Kérdezze meg a chatben",
       "assessment": {
         "additionalInTarget": "További elem a céldokumentumban",
         "aligned": "Összhangban",
@@ -3688,8 +3688,11 @@
     "provisionHistoryUnavailable": "A rendelkezés története nem tölthető be.",
     "provisionPromptSubject": "{statute} ({eli}) {provision}, a {date} napjától hatályos szöveg szerint",
     "provisionPromptSubjectUndated": "{statute} ({eli}) {provision}",
+    "recentlyAmended": "Legutóbb módosított",
+    "resolvedAlias": "Felismerve: {label}",
+    "searchAskPrompt": "{query} ({country} jogszabályai)",
     "searchLabel": "Keresés a jogszabályok között",
-    "searchPlaceholder": "Keresés cím vagy szám alapján...",
+    "searchPlaceholder": "Szám, rövid név vagy cím, pl. 89/2012 Sb.",
     "showInText": "Megjelenítés a szövegben",
     "status": {
       "current": "Hatályos",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1026,6 +1026,7 @@
     "archive": "Archyvuoti",
     "ask": "Klausti",
     "askAI": "Klausti DI",
+    "askInChat": "Klausti pokalbyje",
     "author": "Autorius",
     "back": "Atgal",
     "cancel": "Atšaukti",
@@ -2321,7 +2322,6 @@
       "addReference": "Pridėti {name} kaip referenciją",
       "addTopic": "Pridėti temą",
       "allDecided": "Visos čia esančios išvados nuspręstos.",
-      "askInChat": "Klausti pokalbyje",
       "assessment": {
         "additionalInTarget": "Papildomai tiksliniame dokumente",
         "aligned": "Suderinta",
@@ -3688,8 +3688,11 @@
     "provisionHistoryUnavailable": "Nepavyko įkelti šios nuostatos istorijos.",
     "provisionPromptSubject": "{statute} ({eli}) {provision}, redakcija, galiojanti nuo {date}",
     "provisionPromptSubjectUndated": "{statute} ({eli}) {provision}",
+    "recentlyAmended": "Neseniai pakeisti",
+    "resolvedAlias": "Atpažinta kaip {label}",
+    "searchAskPrompt": "{query} ({country} teisės aktai)",
     "searchLabel": "Ieškoti teisės aktų",
-    "searchPlaceholder": "Ieškoti pagal pavadinimą arba numerį...",
+    "searchPlaceholder": "Numeris, pavadinimas arba antraštė, pvz. 89/2012 Sb.",
     "showInText": "Rodyti tekste",
     "status": {
       "current": "Galiojantis",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1026,6 +1026,7 @@
     "archive": "Arhivēt",
     "ask": "Jautāt",
     "askAI": "Jautāt AI",
+    "askInChat": "Jautāt tērzēšanā",
     "author": "Autors",
     "back": "Atpakaļ",
     "cancel": "Atcelt",
@@ -2321,7 +2322,6 @@
       "addReference": "Pievienot {name} kā atsauci",
       "addTopic": "Pievienot tēmu",
       "allDecided": "Par visiem šeit redzamajiem secinājumiem ir pieņemts lēmums.",
-      "askInChat": "Jautāt tērzēšanā",
       "assessment": {
         "additionalInTarget": "Papildus mērķa dokumentā",
         "aligned": "Saskaņots",
@@ -3688,8 +3688,11 @@
     "provisionHistoryUnavailable": "Neizdevās ielādēt šīs normas vēsturi.",
     "provisionPromptSubject": "{statute} ({eli}) {provision} redakcijā, kas ir spēkā kopš {date}",
     "provisionPromptSubjectUndated": "{statute} ({eli}) {provision}",
+    "recentlyAmended": "Nesen grozītie",
+    "resolvedAlias": "Atpazīts kā {label}",
+    "searchAskPrompt": "{query} ({country} tiesību akti)",
     "searchLabel": "Meklēt tiesību aktos",
-    "searchPlaceholder": "Meklēt pēc nosaukuma vai numura...",
+    "searchPlaceholder": "Numurs, nosaukums vai virsraksts, piem. 89/2012 Sb.",
     "showInText": "Rādīt tekstā",
     "status": {
       "current": "Spēkā",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1029,6 +1029,7 @@ type Messages = {
     "archive": "Archive";
     "ask": "Ask";
     "askAI": "Ask AI";
+    "askInChat": "Ask in chat";
     "author": "Author";
     "back": "Back";
     "cancel": "Cancel";
@@ -2324,7 +2325,6 @@ type Messages = {
       "addReference": "Add {name} as a reference";
       "addTopic": "Add topic";
       "allDecided": "Every finding here has been decided.";
-      "askInChat": "Ask in chat";
       "assessment": {
         "additionalInTarget": "Additional in target";
         "aligned": "Consistent with references";
@@ -3691,8 +3691,11 @@ type Messages = {
     "provisionHistoryUnavailable": "This provision's history could not be loaded.";
     "provisionPromptSubject": "{provision} of {statute} ({eli}), in the wording in force since {date}";
     "provisionPromptSubjectUndated": "{provision} of {statute} ({eli})";
+    "recentlyAmended": "Recently amended";
+    "resolvedAlias": "Recognized as {label}";
+    "searchAskPrompt": "{query} (legislation of {country})";
     "searchLabel": "Search statutes";
-    "searchPlaceholder": "Search by title or number...";
+    "searchPlaceholder": "Number, name or title, e.g. 89/2012 Sb.";
     "showInText": "Show in the text";
     "status": {
       "current": "In force";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1026,6 +1026,7 @@
     "archive": "Archiwizuj",
     "ask": "Zapytaj",
     "askAI": "Zapytaj AI",
+    "askInChat": "Zapytaj w czacie",
     "author": "Autor",
     "back": "Wstecz",
     "cancel": "Anuluj",
@@ -2321,7 +2322,6 @@
       "addReference": "Dodaj {name} jako referencję",
       "addTopic": "Dodaj temat",
       "allDecided": "Wszystkie ustalenia zostały rozstrzygnięte.",
-      "askInChat": "Zapytaj w czacie",
       "assessment": {
         "additionalInTarget": "Dodatkowe w dokumencie docelowym",
         "aligned": "Spójne",
@@ -3688,8 +3688,11 @@
     "provisionHistoryUnavailable": "Nie udało się wczytać historii tego przepisu.",
     "provisionPromptSubject": "{provision} aktu {statute} ({eli}) w brzmieniu obowiązującym od {date}",
     "provisionPromptSubjectUndated": "{provision} aktu {statute} ({eli})",
+    "recentlyAmended": "Ostatnio zmienione",
+    "resolvedAlias": "Rozpoznano jako {label}",
+    "searchAskPrompt": "{query} (ustawodawstwo: {country})",
     "searchLabel": "Szukaj w aktach prawnych",
-    "searchPlaceholder": "Szukaj według tytułu lub numeru...",
+    "searchPlaceholder": "Numer, skrót lub tytuł, np. 89/2012 Sb.",
     "showInText": "Pokaż w tekście",
     "status": {
       "current": "Obowiązujący",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1026,6 +1026,7 @@
     "archive": "Arquivar",
     "ask": "Perguntar",
     "askAI": "Perguntar à IA",
+    "askInChat": "Perguntar no chat",
     "author": "Autor",
     "back": "Voltar",
     "cancel": "Cancelar",
@@ -2321,7 +2322,6 @@
       "addReference": "Adicionar {name} como referência",
       "addTopic": "Adicionar tópico",
       "allDecided": "Todas as constatações aqui foram decididas.",
-      "askInChat": "Perguntar no chat",
       "assessment": {
         "additionalInTarget": "Adicional no documento-alvo",
         "aligned": "Alinhado",
@@ -3688,8 +3688,11 @@
     "provisionHistoryUnavailable": "Não foi possível carregar o histórico deste dispositivo.",
     "provisionPromptSubject": "{provision} de {statute} ({eli}), na redação em vigor desde {date}",
     "provisionPromptSubjectUndated": "{provision} de {statute} ({eli})",
+    "recentlyAmended": "Alteradas recentemente",
+    "resolvedAlias": "Reconhecido como {label}",
+    "searchAskPrompt": "{query} (legislação: {country})",
     "searchLabel": "Buscar na legislação",
-    "searchPlaceholder": "Buscar por título ou número...",
+    "searchPlaceholder": "Número, nome ou título, ex.: 89/2012 Sb.",
     "showInText": "Mostrar no texto",
     "status": {
       "current": "Em vigor",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1026,6 +1026,7 @@
     "archive": "Archivovať",
     "ask": "Opýtať sa",
     "askAI": "Opýtať sa AI",
+    "askInChat": "Opýtať sa v chate",
     "author": "Autor",
     "back": "Späť",
     "cancel": "Zrušiť",
@@ -2321,7 +2322,6 @@
       "addReference": "Pridať {name} ako referenciu",
       "addTopic": "Pridať tému",
       "allDecided": "Všetky zistenia sú rozhodnuté.",
-      "askInChat": "Opýtať sa v chate",
       "assessment": {
         "additionalInTarget": "Navyše v cieľovom dokumente",
         "aligned": "Zhodné",
@@ -3688,8 +3688,11 @@
     "provisionHistoryUnavailable": "Históriu tohto ustanovenia sa nepodarilo načítať.",
     "provisionPromptSubject": "{provision} predpisu {statute} ({eli}) v znení účinnom od {date}",
     "provisionPromptSubjectUndated": "{provision} predpisu {statute} ({eli})",
+    "recentlyAmended": "Naposledy novelizované",
+    "resolvedAlias": "Rozpoznané ako {label}",
+    "searchAskPrompt": "{query} (právne predpisy: {country})",
     "searchLabel": "Hľadať v právnych predpisoch",
-    "searchPlaceholder": "Hľadať podľa názvu alebo čísla...",
+    "searchPlaceholder": "Číslo, skratka alebo názov, napr. 40/1964 Zb.",
     "showInText": "Zobraziť v texte",
     "status": {
       "current": "Účinné",

--- a/apps/web/src/lib/statute-route.ts
+++ b/apps/web/src/lib/statute-route.ts
@@ -4,6 +4,20 @@
  */
 export const STATUTES_DEFAULT_COUNTRY = "cze";
 
+/**
+ * Jurisdictions the statutes browser covers, as route segments, with the
+ * region code their names are rendered from. Order is the picker's order.
+ */
+export const STATUTE_COUNTRIES = {
+  cze: { region: "CZ" },
+  svk: { region: "SK" },
+} as const satisfies Record<string, { region: string }>;
+
+export type StatuteCountry = keyof typeof STATUTE_COUNTRIES;
+
+export const isStatuteCountry = (value: string): value is StatuteCountry =>
+  Object.hasOwn(STATUTE_COUNTRIES, value);
+
 const COUNTRY_SEGMENT_PATTERN = /^[a-z]{2,3}$/u;
 
 /** Country segment for a statutes URL: lower-case ISO code, or the default. */

--- a/apps/web/src/routes/law/$country/statutes/$documentId.tsx
+++ b/apps/web/src/routes/law/$country/statutes/$documentId.tsx
@@ -36,6 +36,7 @@ import {
   EM_DASH,
   formatValidityDate,
 } from "@/features/statutes/statute-format";
+import { useMountEffect } from "@/hooks/use-effect";
 import { useFormatter } from "@/i18n/formatting-context";
 import { detached } from "@/lib/detached";
 import { pageTitleLiteral } from "@/lib/page-title";
@@ -71,6 +72,19 @@ const searchSchema = v.object({
       v.string(),
       v.trim(),
       v.transform((value) => (isCalendarDate(value) ? value : undefined)),
+    ),
+  ),
+  /**
+   * A provision designation to open at (`§ 2079`), as the statutes box sends
+   * it. Read by the outline's jump field; anything it cannot parse just
+   * narrows nothing.
+   */
+  jump: v.optional(
+    v.pipe(
+      v.string(),
+      v.trim(),
+      v.maxLength(32),
+      v.transform((value) => (value.length > 0 ? value : undefined)),
     ),
   ),
 });
@@ -239,6 +253,7 @@ const StatuteReader = ({
   const navigate = Route.useNavigate();
   const asOfLabelId = useId();
   const asOf = Route.useSearch({ select: (search) => search.asOf });
+  const requestedJump = Route.useSearch({ select: (search) => search.jump });
   const readerRef = useRef<HTMLDivElement>(null);
 
   const header = statute ?? work;
@@ -277,7 +292,7 @@ const StatuteReader = ({
     [documentId, goTo],
   );
 
-  const [jumpValue, setJumpValue] = useState("");
+  const [jumpValue, setJumpValue] = useState(requestedJump ?? "");
   // An unparseable or absent AST is a real state: the reader then renders
   // the plain fulltext instead of blocks.
   const ast = statute ? parseDocumentAst(statute.documentAst) : null;
@@ -286,6 +301,22 @@ const StatuteReader = ({
   const jump = parseOutlineJump(jumpValue);
   const visibleOutline = filterOutlineItems(outline, jump);
   const jumpAnchorId = findProvisionAnchorId(outline, jump);
+
+  // A jump named in the URL is honoured once, when the reader mounts with
+  // the text already loaded; after that the field is the reader's own.
+  useMountEffect(() => {
+    const container = readerRef.current;
+
+    if (
+      requestedJump === undefined ||
+      jumpAnchorId === null ||
+      container === null
+    ) {
+      return;
+    }
+
+    jumpToAnchor(jumpAnchorId, container);
+  });
 
   // The keys a provision's incoming citations are filed under. Both come off
   // the document itself: nothing about the work is inferred here.

--- a/apps/web/src/routes/law/$country/statutes/index.tsx
+++ b/apps/web/src/routes/law/$country/statutes/index.tsx
@@ -1,23 +1,29 @@
 import { useCallback, useState } from "react";
 
-import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
 import { useDebouncedCallback } from "use-debounce";
 import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
 import { Button } from "@stll/ui/button";
-import { Input } from "@stll/ui/input";
 import { Skeleton } from "@stll/ui/skeleton";
 
-import { StatuteStatusPill } from "@/features/statutes/components/statute-status-pill";
+import {
+  StatuteListRow,
+  StatuteListRowSkeleton,
+} from "@/features/statutes/components/statute-list-row";
+import { StatuteSearch } from "@/features/statutes/components/statute-search";
 import { statutesInfiniteOptions } from "@/features/statutes/queries/statutes";
 import type { StatuteListFilters } from "@/features/statutes/queries/statutes";
 import {
-  EM_DASH,
-  formatValidityDate,
-} from "@/features/statutes/statute-format";
-import { useFormatter } from "@/i18n/formatting-context";
+  parseStatuteQuery,
+  type StatuteQueryIntent,
+} from "@/features/statutes/statute-query-intent";
 import { detached } from "@/lib/detached";
 import { pageTitle } from "@/lib/page-title";
 import {
@@ -29,11 +35,15 @@ import { ensureRouteInfiniteQueryData } from "@/lib/react-query";
 import {
   createStatuteIndexPath,
   createStatutePath,
+  isStatuteCountry,
   toStatuteCountrySegment,
 } from "@/lib/statute-route";
 
 /** What the route accepts in `q`, and therefore what the field may hold. */
 const MAX_QUERY_LENGTH = 256;
+
+// Stable keys so loading rows never fall back to array-index keys.
+const SKELETON_ROW_KEYS = ["a", "b", "c", "d", "e", "f"] as const;
 
 const searchSchema = v.object({
   q: v.optional(
@@ -48,13 +58,46 @@ const searchSchema = v.object({
 
 type StatutesIndexSearch = v.InferOutput<typeof searchSchema>;
 
+/**
+ * What an entry asks for in this jurisdiction. A country the grammar does
+ * not know reads every entry as text.
+ */
+const readIntent = (
+  country: string,
+  q: string | undefined,
+): StatuteQueryIntent => {
+  if (q === undefined) {
+    return { type: "empty" };
+  }
+  return isStatuteCountry(country)
+    ? parseStatuteQuery(country, q)
+    : { type: "text", text: q };
+};
+
 const createStatuteFilters = (
   country: string,
-  { q }: StatutesIndexSearch,
-): StatuteListFilters => ({
-  country: country.toUpperCase(),
-  ...(q ? { query: q } : {}),
-});
+  intent: StatuteQueryIntent,
+): StatuteListFilters => {
+  const scope = { country: country.toUpperCase() };
+  switch (intent.type) {
+    case "empty":
+      return scope;
+    case "act":
+      return {
+        ...scope,
+        number: `${intent.number}/${intent.year}`,
+        ...(intent.collection === null
+          ? {}
+          : { collection: intent.collection }),
+      };
+    case "text":
+      return { ...scope, query: intent.text };
+    default: {
+      const exhaustive: never = intent;
+      return exhaustive;
+    }
+  }
+};
 
 const createStatutesIndexPath = (
   country: string,
@@ -71,7 +114,12 @@ export const Route = createFileRoute("/law/$country/statutes/")({
   loader: async ({ context: { queryClient }, deps, params }) => {
     const pages = await ensureRouteInfiniteQueryData(
       queryClient,
-      statutesInfiniteOptions(createStatuteFilters(params.country, deps)),
+      statutesInfiniteOptions(
+        createStatuteFilters(
+          params.country,
+          readIntent(params.country, deps.q),
+        ),
+      ),
     );
 
     const firstPage = pages.pages.at(0);
@@ -113,25 +161,59 @@ export const Route = createFileRoute("/law/$country/statutes/")({
   pendingComponent: PublicStatutesIndexPending,
 });
 
+/**
+ * What the list under the box is: the recency shelf when nothing was typed,
+ * the alias the entry was read as, nothing for a plain search or a number.
+ */
+function ListHeading({ intent }: { intent: StatuteQueryIntent }) {
+  const t = useTranslations();
+
+  if (intent.type === "empty") {
+    return <ListHeadingText>{t("statutes.recentlyAmended")}</ListHeadingText>;
+  }
+  if (intent.type === "act" && intent.label !== null) {
+    return (
+      <ListHeadingText>
+        {t("statutes.resolvedAlias", { label: intent.label })}
+      </ListHeadingText>
+    );
+  }
+  return null;
+}
+
+function ListHeadingText({ children }: { children: string }) {
+  return (
+    <h2 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+      {children}
+    </h2>
+  );
+}
+
 function PublicStatutesIndexPending() {
   const t = useTranslations();
 
   return (
     <main className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
       <h1 className="text-lg font-semibold">{t("statutes.title")}</h1>
-      <Skeleton className="h-9 w-full max-w-xs rounded-md" />
-      <div className="flex flex-col gap-2">
-        <Skeleton className="h-14 w-full rounded-md" />
-        <Skeleton className="h-14 w-full rounded-md" />
-        <Skeleton className="h-14 w-full rounded-md" />
+      <div className="flex flex-wrap items-center gap-2">
+        <Skeleton className="h-9 w-36 rounded-md" />
+        <Skeleton className="h-9 w-full max-w-md flex-1 rounded-md" />
       </div>
+      <Skeleton className="h-4 w-40" />
+      <ul className="flex flex-col gap-2">
+        {SKELETON_ROW_KEYS.map((key) => (
+          <li key={key}>
+            <StatuteListRowSkeleton />
+          </li>
+        ))}
+      </ul>
     </main>
   );
 }
 
 function PublicStatutesIndex() {
   const t = useTranslations();
-  const format = useFormatter();
+  const queryClient = useQueryClient();
   const country = Route.useParams({ select: (params) => params.country });
   const search = Route.useSearch({ select: ({ q }) => ({ q }) });
   const navigate = Route.useNavigate();
@@ -172,25 +254,76 @@ function PublicStatutesIndex() {
     }
   }
 
+  const intent = readIntent(country, search.q);
+  const filters = createStatuteFilters(country, intent);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     useInfiniteQuery({
-      ...statutesInfiniteOptions(createStatuteFilters(country, search)),
+      ...statutesInfiniteOptions(filters),
       placeholderData: keepPreviousData,
     });
 
   const statutes = data ? data.pages.flatMap((page) => page.items) : [];
 
+  // Enter on an act reference opens the act when exactly one work answers
+  // to it. Several (the same number in two collections) stay listed, so the
+  // reader picks; nothing is guessed. The field's value is read directly:
+  // the debounced URL write may still be pending.
+  const openSingleMatch = () => {
+    const submitted = readIntent(country, queryInput.trim() || undefined);
+    if (submitted.type !== "act") {
+      return;
+    }
+    writeQuery.flush();
+    detached(
+      (async () => {
+        const pages = await ensureRouteInfiniteQueryData(
+          queryClient,
+          statutesInfiniteOptions(createStatuteFilters(country, submitted)),
+        );
+        const firstPage = pages.pages.at(0);
+        if (firstPage?.items.length !== 1) {
+          return;
+        }
+        const only = firstPage.items.at(0);
+        if (only === undefined) {
+          return;
+        }
+        await navigate({
+          params: {
+            country: toStatuteCountrySegment(only.country),
+            documentId: only.id,
+          },
+          search:
+            submitted.provision === null ? {} : { jump: submitted.provision },
+          to: "/law/$country/statutes/$documentId",
+        });
+      })(),
+      "statutes.open-match",
+    );
+  };
+
   return (
     <main className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
       <h1 className="text-lg font-semibold">{t("statutes.title")}</h1>
-      <Input
-        aria-label={t("statutes.searchLabel")}
-        className="max-w-xs"
+      <StatuteSearch
+        country={country}
         maxLength={MAX_QUERY_LENGTH}
-        onChange={(event) => handleQueryChange(event.currentTarget.value)}
-        placeholder={t("statutes.searchPlaceholder")}
-        value={queryInput}
+        onCountryChange={(nextCountry) => {
+          detached(
+            navigate({
+              params: { country: nextCountry },
+              search: (previous) => previous,
+              to: "/law/$country/statutes",
+            }),
+            "statutes.switch-country",
+          );
+        }}
+        onQueryChange={handleQueryChange}
+        onSubmit={openSingleMatch}
+        query={queryInput}
       />
+
+      <ListHeading intent={intent} />
 
       {statutes.length === 0 && !isLoading ? (
         <p className="text-muted-foreground text-sm">
@@ -198,34 +331,17 @@ function PublicStatutesIndex() {
         </p>
       ) : (
         <ul className="flex flex-col gap-2">
-          {statutes.map((statute) => (
-            <li key={statute.id}>
-              <Link
-                className="hover:bg-muted/50 block rounded-md border px-4 py-3 transition-colors"
-                params={{
-                  country: toStatuteCountrySegment(statute.country),
-                  documentId: statute.id,
-                }}
-                to="/law/$country/statutes/$documentId"
-              >
-                <span className="text-foreground block font-medium">
-                  {statute.title}
-                </span>
-                <span className="text-muted-foreground mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs">
-                  <span>{statute.eli}</span>
-                  <StatuteStatusPill status={statute.status} />
-                  <span>
-                    {t("statutes.inForceSince", {
-                      date:
-                        formatValidityDate(statute.versionValidFrom, format) ??
-                        formatValidityDate(statute.effectiveDate, format) ??
-                        EM_DASH,
-                    })}
-                  </span>
-                </span>
-              </Link>
-            </li>
-          ))}
+          {isLoading
+            ? SKELETON_ROW_KEYS.map((key) => (
+                <li key={key}>
+                  <StatuteListRowSkeleton />
+                </li>
+              ))
+            : statutes.map((statute) => (
+                <li key={statute.id}>
+                  <StatuteListRow statute={statute} />
+                </li>
+              ))}
         </ul>
       )}
 


### PR DESCRIPTION
## What changes

**API (`GET /law/statutes`)**

- Default order is newest consolidation first (`coalesce(version_valid_from, '0001-01-01') DESC, id DESC`) instead of alphabetical title, with its own keyset cursor (`recent-v1`). A jurisdiction no longer opens on its oldest decrees.
- A typed query matches titles on a diacritics-insensitive, lower-case fold and ranks works whose *name* starts with the term above works that merely mention it, so `občanský zákoník` lists the code before the acts amending it. The name is the title minus its `<number>/<year> <collection>, ` prefix, which Czech titles carry and Slovak titles do not. Ordering: rank, title sort key, id, cursor `search-v1`. A cursor from one ordering is rejected by the other; the previous `title-prefix-v1` protocol is retired.
- New `number` (`<n>/<year>`) and optional `collection` query parameters resolve a work by the tail of its ELI (`/eli/cz/sb/2012/89`). The match is a trigram-served suffix `LIKE` made exact by an anchored regex, so `2012/89` cannot answer for `2012/189`.
- Migration `20260901130000_legislation_title_fold`: an IMMUTABLE `legislation_title_fold(text)` wrapping `unaccent` with a pinned dictionary, a concurrent trigram index on that fold of the title, and a concurrent `(country, valid-from key, id)` index for the recency walk. Same concurrent-build shape as `20260729010000`. Measured before the index on the production-sized corpus (72k rows for CZ): the folded title filter was a parallel seq scan at ~1.3 s cold, which is why the expression index exists.
- Tie-breaks fall to the title: `citation_count` is outside the public-law reader's column allowlist and `citation_authority` is zero for every legislation row.
- PGlite ships no `unaccent`, so the test schema installs a `legislation_title_fold` generated from `@stll/text-normalize`'s `ASCII_FOLD_TABLE`, the table the unaccent parity test pins against the real extension. A property test in `public-reads.db.test.ts` checks the SQL fold against `foldToAscii` over Czech, Slovak, Polish and Latin-1 letters.

**Web (`/law/$country/statutes`)**

- One search box with a jurisdiction pill (CZ, SK; region names via the formatter). The entry is parsed by `statute-query-intent.ts`:
  - act numbers with lenient spacing and surrounding words: `89/2012`, `89 / 2012 Sb.`, `č. 89/2012 Sb`, `zákon 89/2012`, `40/1964 Zb.`, `160/2015 Z. z.`, full-width digits; the collection abbreviation maps to the ELI collection segment when it names exactly one;
  - a provision ahead of the act (`§ 2079 89/2012`, `§2079 odst. 1 OZ`) is parsed and the act opened; jumping to the provision is a follow-up, the reader has no URL parameter for it yet;
  - per-jurisdiction aliases (`oz`, `noz`, `obč. zák.`, `občanský zákoník`, `obcansky`, `zok`, `zp`, `tz`, `tř`, `osř`, `sřs`, `sř`, `insz`, `zdp`, `dph`, `ústava`, `lzps`, `živnostenský zákon`, `zřs`, `stavební zákon`; SK `oz`, `obchz`, `zp`, `tz`, `csp`, `správny poriadok`), matched whole after folding, so `OSŘ`, `osř` and `osr` are one key. Every alias target was checked against the corpus: the number opens the act the label names. `oz` resolves to 89/2012 Sb. in CZ and 40/1964 Zb. in SK.
  - anything else searches titles verbatim.
- Enter on an act reference opens the work when exactly one answers; several (the same number in two collections) stay listed. A resolved alias is shown as a heading ("Recognized as Občanský zákoník").
- Rows drop the ELI line and show title, status, document type and the date the current wording took effect. The loading rows render the same shell.
- With nothing typed the list is headed "Recently amended". An "Ask in chat" button hands the entry to a chat; visitors are offered sign-in. The key moved to `common.askInChat` (it was `inspector.review.askInChat`) so both call sites share it.
- Translations added for all locales; `i18n:sync` and `i18n:check` pass.

## Verification

- `apps/api`: `public-reads.db.test.ts` (37 tests: recency order and walk, search rank and walk, number resolution with and without collection, retired/mismatched cursor rejection, fold parity), `public-routes.test.ts`.
- `apps/web`: `statute-query-intent.test.ts` (property tests over spellings of numbers and every alias of every jurisdiction), `statute-version-switcher.test.tsx`.
- Mutation checked: with the `regexp_replace` name prefix removed from the rank expression, the amending act ties with the code and the "ranks the act named by the text above the acts amending it" test fails; with the `^`/`$` anchors removed from the number match, `2012/1089` answers for `89/2012` and the number test fails.
- Lint on changed files is clean; the full typecheck is left to CI.

## Not in this change

- Provision deep link from the box into the reader.
- Slovak acts absent from the corpus have no alias (Trestný poriadok 301/2005, CMP 161/2015, SSP 162/2015, Ústava 460/1992, ZDP 595/2003).
