### PR TITLE
fix(api): split the sheet number from spaced case references and keep it on cz-nss

### DIFF
--- a/apps/api/src/handlers/case-law/case-number.test.ts
+++ b/apps/api/src/handlers/case-law/case-number.test.ts
@@ -10,6 +10,31 @@ describe("splitCaseReference", () => {
     });
   });
 
+  test("takes the sheet number off however the court spaces the separator", () => {
+    for (const reference of [
+      "10 A 46/2015-66",
+      "10 A 46/2015 - 66",
+      "10 A 46/2015 -66",
+      "10 A 46/2015- 66",
+    ]) {
+      expect(splitCaseReference(reference)).toEqual({
+        caseNumber: "10 A 46/2015",
+        sheetNumber: "66",
+      });
+    }
+  });
+
+  test("keeps a dash inside the docket itself", () => {
+    expect(splitCaseReference("C-123/20-5")).toEqual({
+      caseNumber: "C-123/20",
+      sheetNumber: "5",
+    });
+    expect(splitCaseReference("C-123/20 - 5")).toEqual({
+      caseNumber: "C-123/20",
+      sheetNumber: "5",
+    });
+  });
+
   test("leaves references that carry no sheet number", () => {
     for (const reference of [
       "0T/42/2019",
@@ -30,7 +55,7 @@ describe("splitCaseReference", () => {
    * every reference must reduce to the same docket whatever sheet it carries.
    */
   test("references differing only by sheet share one docket", () => {
-    const sheets = ["-1", "-28", "-145", ""];
+    const sheets = ["-1", "-28", " - 28", " -145", "- 145", ""];
     const dockets = new Set(
       sheets.map(
         (sheet) => splitCaseReference(`11 C 153/2025${sheet}`).caseNumber,
@@ -41,8 +66,36 @@ describe("splitCaseReference", () => {
   });
 
   test("is idempotent", () => {
-    const once = splitCaseReference("11 C 153/2025-28").caseNumber;
+    for (const reference of ["11 C 153/2025-28", "11 C 153/2025 - 28"]) {
+      const once = splitCaseReference(reference).caseNumber;
 
-    expect(splitCaseReference(once).caseNumber).toBe(once);
+      expect(splitCaseReference(once).caseNumber).toBe(once);
+    }
+  });
+
+  /**
+   * Adapters store the reference exactly as published beside the split halves,
+   * so the split has to be a read of that string and nothing else: the docket
+   * opens it, the sheet closes it, and only the separator lies between them.
+   * A docket that kept the spacing would break that read.
+   */
+  test("splits a published reference into its own two ends", () => {
+    for (const published of [
+      "11 C 153/2025-28",
+      "10 A 46/2015 - 66",
+      "10 A 46/2015 -66",
+    ]) {
+      const { caseNumber, sheetNumber } = splitCaseReference(published);
+
+      expect(published.startsWith(caseNumber)).toBe(true);
+      expect(published.endsWith(sheetNumber ?? "")).toBe(true);
+      expect(caseNumber.trim()).toBe(caseNumber);
+      expect(
+        published.slice(
+          caseNumber.length,
+          published.length - (sheetNumber ?? "").length,
+        ),
+      ).toMatch(/^ ?- ?$/u);
+    }
   });
 });

--- a/apps/api/src/handlers/case-law/case-number.ts
+++ b/apps/api/src/handlers/case-law/case-number.ts
@@ -15,8 +15,14 @@
  * number for another reason: Slovak `0T/42/2019` and Polish `II AKa 198/23`
  * have no trailing group to take, while `11 C 153/2025-28` does. Anchored at
  * the end so an internal dash (`ECLI:CZ:...`) is untouched.
+ *
+ * Czech courts set the separator either tight or spaced, and the same court
+ * does both: a citation line prints `10 A 46/2015-66` where the decision's own
+ * header prints `10 A 46/2015 - 66`. A single space on either side is part of
+ * the suffix, not of the docket, so both forms reduce to one docket. The
+ * docket group ends on a digit, so no spacing can survive into what is stored.
  */
-const SHEET_SUFFIX = /^(?<docket>.*\/\d{2,4})-(?<sheet>\d+)$/u;
+const SHEET_SUFFIX = /^(?<docket>.*\/\d{2,4}) ?- ?(?<sheet>\d+)$/u;
 
 type CaseReference = {
   caseNumber: string;

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -405,13 +405,35 @@ describe("cz-nss listing rows", () => {
   test("reads the docket, the document id and the date off a row", () => {
     const rows = parseResultRows(rowBlock(MUNICIPAL_ROW));
     expect(rows).toHaveLength(1);
-    // The sheet number is dropped: a citation names the docket alone.
+    // The sheet number comes off the docket, because a citation names the
+    // docket alone, and is kept beside it rather than dropped.
     expect(rows.at(0)?.caseNumber).toBe("1 Az 4/2026");
+    expect(rows.at(0)?.publishedCaseNumber).toBe("1 Az 4/2026-79");
     expect(rows.at(0)?.documentId).toBe("784237");
     expect(rows.at(0)?.documentUrl).toBe(
       `${BASE_URL}/DokumentDetail/Index/784237`,
     );
     expect(rows.at(0)?.decisionDate).toBe("10.06.2026");
+  });
+
+  test("reads a docket the citation spaces off its sheet number", () => {
+    // The portal's citations are tight, its documents spaced; both forms name
+    // one case, so both have to reduce to one docket.
+    const rows = parseResultRows(
+      rowBlock({ ...MUNICIPAL_ROW, citedCaseNumber: "1 Az 4/2026 - 79" }),
+    );
+
+    expect(rows.at(0)?.caseNumber).toBe("1 Az 4/2026");
+    expect(rows.at(0)?.publishedCaseNumber).toBe("1 Az 4/2026 - 79");
+  });
+
+  test("keeps a docket the citation states with no sheet number", () => {
+    const rows = parseResultRows(
+      rowBlock({ ...MUNICIPAL_ROW, citedCaseNumber: "1 Az 4/2026" }),
+    );
+
+    expect(rows.at(0)?.caseNumber).toBe("1 Az 4/2026");
+    expect(rows.at(0)?.publishedCaseNumber).toBe("1 Az 4/2026");
   });
 
   test("skips blocks that carry no citation", () => {
@@ -478,6 +500,7 @@ describe("cz-nss listing rows", () => {
   test("a row the portal lists without a document link has nothing to key on", () => {
     const row: ParsedRow = {
       caseNumber: "1 Az 4/2026",
+      publishedCaseNumber: undefined,
       decisionDate: undefined,
       decisionType: undefined,
       outcome: undefined,
@@ -618,6 +641,9 @@ describe("cz-nss listSlicePage", () => {
     // The loop parks the payload as JSONB, so the round trip is the contract.
     expect(throughJsonb(payload)).toEqual({
       caseNumber: "1 Az 4/2026",
+      // Parked with the row, because the sheet is only recoverable from the
+      // reference as published and the build runs days after the listing.
+      publishedCaseNumber: "1 Az 4/2026-79",
       decisionDate: "10.06.2026",
       // The results table states no decision type of its own, so the row's
       // heuristic picks up the displayed reference, non-breaking spaces and
@@ -962,6 +988,12 @@ describe("cz-nss buildDecision", () => {
       return;
     }
     expect(built.decision.caseNumber).toBe("1 Az 4/2026");
+    // The sheet is stored beside the docket, with the reference as published,
+    // so nothing has to guess how the court set the two together.
+    expect(built.decision.sheetNumber).toBe("79");
+    expect(built.decision.metadata["publishedCaseNumber"]).toBe(
+      "1 Az 4/2026-79",
+    );
     expect(built.decision.language).toBe("cs");
     // The portal lists the city court's decision; the ECLI names the court,
     // so the row is stored under it rather than under the portal's own.
@@ -986,6 +1018,32 @@ describe("cz-nss buildDecision", () => {
     expect(built.decision.sourceUrl).toBe(
       `${BASE_URL}/DokumentDetail/Index/${MUNICIPAL_ROW.documentId}`,
     );
+  });
+
+  test("a payload parked before the sheet was kept still builds", async () => {
+    // Rows the loop parked under an older parser carry no published
+    // reference. They build with the sheet they were listed with, which is
+    // none, rather than being refused for a field they could not have stated.
+    const legacy: ParsedRow = {
+      caseNumber: "1 Az 4/2026",
+      publishedCaseNumber: undefined,
+      decisionDate: "10.06.2026",
+      decisionType: undefined,
+      outcome: undefined,
+      documentUrl: `${BASE_URL}/DokumentDetail/Index/${MUNICIPAL_ROW.documentId}`,
+      documentId: MUNICIPAL_ROW.documentId,
+    };
+    installStub({ search: [] });
+
+    const built = await reconciliation.buildDecision(throughJsonb(legacy));
+
+    expect(built.type).toBe("built");
+    if (built.type !== "built") {
+      return;
+    }
+    expect(built.decision.caseNumber).toBe("1 Az 4/2026");
+    expect(built.decision.sheetNumber).toBeUndefined();
+    expect(built.decision.metadata["publishedCaseNumber"]).toBe("1 Az 4/2026");
   });
 
   test("replays stored HTML to the same result without contacting the court", async () => {
@@ -1026,6 +1084,10 @@ describe("cz-nss buildDecision", () => {
       return;
     }
     expect(outcome.result).toEqual(decision);
+    // Named as well as covered by the equality above: the replay reads the
+    // sheet back off the stored reference, and a replay that dropped it would
+    // clear the column on every row it touched.
+    expect(outcome.result.sheetNumber).toBe("79");
   });
 
   test("refuses to write a row whose document the court did not serve", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.test.ts
@@ -35,6 +35,7 @@ import {
 } from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
 import type { ParsedRow } from "@/api/handlers/case-law/ingestion/adapters/cz-nss";
 import { requireReconciliation } from "@/api/handlers/case-law/ingestion/adapters/test-utils";
+import { hashContent } from "@/api/handlers/case-law/ingestion/adapters/utils";
 import { tipWindowSlices } from "@/api/handlers/case-law/ingestion/reconciliation-plan";
 import {
   listingIdentityKey,
@@ -977,6 +978,32 @@ describe("cz-nss buildDecision", () => {
     return throughJsonb(payload);
   };
 
+  /** Crawl one decision whose citation states the reference given. */
+  const crawledWithCitation = async (citedCaseNumber: string) => {
+    installStub({
+      search: [
+        htmlResponse(
+          searchPage({
+            statedCount: 1,
+            rows: [{ ...MUNICIPAL_ROW, citedCaseNumber }],
+          }),
+        ),
+      ],
+    });
+    const listed = await reconciliation.listSlicePage({
+      slice: SLICE,
+      page: 0,
+    });
+    installStub({ search: [] });
+    const built = await reconciliation.buildDecision(
+      throughJsonb(listed.items.at(0)?.payload),
+    );
+    if (built.type !== "built") {
+      throw new TypeError("Expected the fixture decision to build");
+    }
+    return built.decision;
+  };
+
   test("builds a decision from a listed payload", async () => {
     const payload = await listedRow();
     installStub({ search: [] });
@@ -1046,6 +1073,45 @@ describe("cz-nss buildDecision", () => {
     expect(built.decision.metadata["publishedCaseNumber"]).toBe("1 Az 4/2026");
   });
 
+  /**
+   * The refresh check skips a row whose source hash stands still, so a row
+   * stored before the sheet was read has to hash differently once its listing
+   * states one. Without this the recovered sheet never reaches the row.
+   */
+  test("a citation that states a sheet number moves the source hash", async () => {
+    const withSheet = await crawledWithCitation("1 Az 4/2026-79");
+    const withoutSheet = await crawledWithCitation("1 Az 4/2026");
+
+    expect(withSheet.sheetNumber).toBe("79");
+    expect(withoutSheet.sheetNumber).toBeUndefined();
+    expect(withSheet.rawHash).not.toBe(withoutSheet.rawHash);
+  });
+
+  /**
+   * The other half of that bargain: a row the court states no sheet for gains
+   * nothing from this change and must not be rewritten for it. The literal is
+   * the hash's pre-existing input, so re-hashing the sheetless corpus cannot
+   * happen without editing this line.
+   */
+  test("a citation with no sheet number hashes as it did before", async () => {
+    const decision = await crawledWithCitation("1 Az 4/2026");
+
+    expect(decision.rawHash).toBe(
+      hashContent("1 Az 4/2026|2026-06-10|rozsudek"),
+    );
+  });
+
+  test("the court's spacing does not move the source hash", async () => {
+    const tight = await crawledWithCitation("1 Az 4/2026-79");
+    const spaced = await crawledWithCitation("1 Az 4/2026 - 79");
+
+    // Spacing is typography, not the document moving. Were it hashed, a court
+    // re-spacing its citations would rewrite its whole corpus, and a legacy
+    // row would never agree with the crawl that re-reads it.
+    expect(spaced.rawHash).toBe(tight.rawHash);
+    expect(spaced.metadata["publishedCaseNumber"]).toBe("1 Az 4/2026 - 79");
+  });
+
   test("replays stored HTML to the same result without contacting the court", async () => {
     const payload = await listedRow();
     installStub({ search: [] });
@@ -1088,6 +1154,97 @@ describe("cz-nss buildDecision", () => {
     // sheet back off the stored reference, and a replay that dropped it would
     // clear the column on every row it touched.
     expect(outcome.result.sheetNumber).toBe("79");
+  });
+
+  /** Replay one stored row, stated as the database holds it. */
+  const replayStored = async ({
+    caseNumber,
+    metadata,
+  }: {
+    caseNumber: string;
+    metadata: Record<string, unknown>;
+  }) => {
+    const decision = await crawledWithCitation("1 Az 4/2026-79");
+    const reparse = czNssAdapter.reparseStoredRaw;
+    if (reparse === undefined) {
+      throw new TypeError("Expected cz-nss to implement stored-raw replay");
+    }
+    globalThis.fetch = asFetchMock(() => {
+      throw new TypeError("Stored-raw replay must not contact the publisher");
+    });
+
+    const outcome = await reparse({
+      raw: new TextEncoder().encode(decision.sourceRaw ?? ""),
+      contentType: decision.sourceRawContentType ?? null,
+      caseNumber,
+      sourceDocumentId: decision.sourceDocumentId ?? null,
+      language: decision.language,
+      court: decision.court,
+      ecli: decision.ecli ?? null,
+      decisionDate: decision.decisionDate ?? null,
+      decisionType: decision.decisionType ?? null,
+      sourceUrl: decision.sourceUrl ?? null,
+      documentUrl: decision.documentUrl ?? null,
+      metadata,
+    } satisfies StoredRawReparseInput);
+
+    return { crawled: decision, outcome };
+  };
+
+  /**
+   * The shape the backfill leaves a legacy row in: the docket in its own
+   * column, the sheet in its own, and the reference as the court published it
+   * surviving nowhere but the metadata the older ingest wrote.
+   */
+  test("a replay recovers the published reference a legacy row keeps in metadata", async () => {
+    const { crawled, outcome } = await replayStored({
+      caseNumber: "1 Az 4/2026",
+      metadata: { caseNumber: "1 Az 4/2026 - 79" },
+    });
+
+    expect(outcome.type).toBe("parsed");
+    if (outcome.type !== "parsed") {
+      return;
+    }
+    expect(outcome.result.sheetNumber).toBe("79");
+    expect(outcome.result.metadata["publishedCaseNumber"]).toBe(
+      "1 Az 4/2026 - 79",
+    );
+    // The reference is stored as the court set it, spacing and all, and the
+    // row still hashes as the crawl that re-reads it would hash it.
+    expect(outcome.result.rawHash).toBe(crawled.rawHash);
+  });
+
+  test("a replay reads the sheet off a legacy row the backfill has not reached", async () => {
+    const { outcome } = await replayStored({
+      caseNumber: "1 Az 4/2026 - 79",
+      metadata: { caseNumber: "1 Az 4/2026 - 79" },
+    });
+
+    expect(outcome.type).toBe("parsed");
+    if (outcome.type !== "parsed") {
+      return;
+    }
+    // The case number is left exactly as stored: the replay's identity check
+    // compares it against the row, and the backfill owns that rewrite.
+    expect(outcome.result.caseNumber).toBe("1 Az 4/2026 - 79");
+    expect(outcome.result.sheetNumber).toBe("79");
+  });
+
+  test("a replay leaves a metadata reference naming another case alone", async () => {
+    const { outcome } = await replayStored({
+      caseNumber: "1 Az 4/2026",
+      metadata: { caseNumber: "9 As 9/2026-12" },
+    });
+
+    expect(outcome.type).toBe("parsed");
+    if (outcome.type !== "parsed") {
+      return;
+    }
+    // Metadata is the publisher's, not ours: a field naming another docket
+    // buys this row no sheet.
+    expect(outcome.result.sheetNumber).toBeUndefined();
+    expect(outcome.result.metadata["publishedCaseNumber"]).toBe("1 Az 4/2026");
   });
 
   test("refuses to write a row whose document the court did not serve", async () => {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -557,17 +557,40 @@ const nonEmptyString = (value: unknown): string | undefined =>
 
 type CzNssSourceHashOptions = {
   caseNumber: string;
+  sheetNumber: string | undefined;
   decisionDate: string | undefined;
   decisionType: string | undefined;
 };
 
-/** Stable source-side fields shared by a crawl and a stored-raw replay. */
+/**
+ * Stable source-side fields shared by a crawl and a stored-raw replay.
+ *
+ * The sheet is one of them, and has to be: the refresh check skips a row whose
+ * source hash did not move, so a row stored before the sheet was read would
+ * see its listing state one and still be skipped, and the sheet would never
+ * land. A row gains a sheet exactly when this hash moves.
+ *
+ * Both halves are normalized to the tight form before hashing, so the same
+ * decision hashes the same however it reached us: through a listing that
+ * prints `10 A 46/2015-66`, through a legacy row whose case number still
+ * carries ` - 66`, or through a court that re-spaces its own citations.
+ * Spacing is typography, not a document changing, and a hash that tracked it
+ * would rewrite rows for it and would leave crawl and replay disagreeing.
+ */
 const czNssSourceHash = ({
   caseNumber,
+  sheetNumber,
   decisionDate,
   decisionType,
-}: CzNssSourceHashOptions): string =>
-  hashContent(`${caseNumber}|${decisionDate ?? ""}|${decisionType ?? ""}`);
+}: CzNssSourceHashOptions): string => {
+  const { caseNumber: docket, sheetNumber: carried } =
+    splitCaseReference(caseNumber);
+  const sheet = sheetNumber ?? carried;
+  const reference = sheet === undefined ? docket : `${docket}-${sheet}`;
+  return hashContent(
+    `${reference}|${decisionDate ?? ""}|${decisionType ?? ""}`,
+  );
+};
 
 /**
  * Fetch rich HTML from /DokumentOriginal/Html/{id} and parse
@@ -875,6 +898,7 @@ const rowToResult = (
     // crawl and replay converge on the same source hash after parser changes.
     rawHash: czNssSourceHash({
       caseNumber: row.caseNumber,
+      sheetNumber,
       decisionDate,
       decisionType,
     }),
@@ -883,6 +907,48 @@ const rowToResult = (
     sourceRaw: content.sourceRaw,
     sourceRawContentType: "text/html",
   };
+};
+
+/**
+ * The reference as published for a stored row, read back from the row itself.
+ *
+ * Three shapes reach this, and only the first states the reference outright:
+ *
+ * - Rows written since the sheet was kept carry `publishedCaseNumber`.
+ * - Rows written before it carry the reference in `metadata.caseNumber`,
+ *   which held whatever the row's case number held at the time. Once the
+ *   backfill moves the sheet out of `case_number`, that metadata field is the
+ *   only place the published form survives, so a replay that read the column
+ *   alone would rebuild the row without it for good.
+ * - Rows the backfill has not reached yet still carry the sheet on
+ *   `case_number` itself, which splits like any other reference.
+ *
+ * A candidate is adopted only where it names this row's docket. Metadata is
+ * the publisher's, not ours, and a field naming some other case must not
+ * become this row's reference. Nothing here reconstructs a reference from the
+ * docket and the sheet: the spacing between them is the court's, and inventing
+ * one would store a reference no court ever published.
+ */
+const storedPublishedCaseNumber = ({
+  caseNumber,
+  metadata,
+}: Pick<StoredRawReparseInput, "caseNumber" | "metadata">): string => {
+  const docket = splitCaseReference(caseNumber).caseNumber;
+  const candidates = [
+    nonEmptyString(metadata["publishedCaseNumber"]),
+    nonEmptyString(metadata["caseNumber"]),
+  ];
+
+  for (const candidate of candidates) {
+    if (
+      candidate !== undefined &&
+      splitCaseReference(candidate).caseNumber === docket
+    ) {
+      return candidate;
+    }
+  }
+
+  return caseNumber;
 };
 
 /** Rebuild one NSS decision from the exact HTML the crawl stored. */
@@ -926,12 +992,8 @@ const reparseStoredRaw = (
 
   const citation = nonEmptyString(stored.metadata["citation"]);
   const sourceDocumentId = stored.sourceDocumentId ?? undefined;
-  // The row stores the published reference beside the docket, which is what
-  // makes the sheet recoverable here: rebuilt without it, a replay would write
-  // the sheet column back to null on every row it touched.
-  const { sheetNumber } = splitCaseReference(
-    nonEmptyString(stored.metadata["publishedCaseNumber"]) ?? stored.caseNumber,
-  );
+  const publishedCaseNumber = storedPublishedCaseNumber(stored);
+  const { sheetNumber } = splitCaseReference(publishedCaseNumber);
 
   return {
     type: "parsed",
@@ -961,9 +1023,14 @@ const reparseStoredRaw = (
       fulltext: parsed.fulltext,
       sourceUrl,
       documentUrl: stored.documentUrl ?? undefined,
-      metadata: stored.metadata,
+      // Written back rather than passed through: a legacy row states the
+      // reference only in `metadata.caseNumber`, and a replay that left the
+      // metadata as it found it would leave the split unreversible for good.
+      // For a row stored since, these are the values already there.
+      metadata: { ...stored.metadata, sheetNumber, publishedCaseNumber },
       rawHash: czNssSourceHash({
         caseNumber: stored.caseNumber,
+        sheetNumber,
         decisionDate,
         decisionType,
       }),

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-nss.ts
@@ -2,6 +2,7 @@ import { panic, Result } from "better-result";
 
 import { DECISION_IDENTIFIER_TYPES } from "@stll/legal-ast/decision-identifier";
 
+import { splitCaseReference } from "@/api/handlers/case-law/case-number";
 import {
   ADAPTER_KEYS,
   ADAPTER_TIMEOUT,
@@ -413,7 +414,17 @@ const todayIso = (): string => {
  * anything a row carries has to survive a round trip through JSONB.
  */
 export type ParsedRow = {
+  /** The docket alone, which is what a citation names and what rows key on. */
   caseNumber: string;
+  /**
+   * The reference exactly as the portal's citation states it, sheet number
+   * included, so the split back into docket and sheet stays reversible from
+   * what gets stored.
+   *
+   * Absent on rows a version of this parser before the sheet was kept parked
+   * as JSONB; those replay with no sheet, as they did when they were listed.
+   */
+  publishedCaseNumber: string | undefined;
   decisionDate: string | undefined;
   decisionType: string | undefined;
   outcome: string | undefined;
@@ -467,22 +478,26 @@ export const parseResultRows = (html: string): ParsedRow[] => {
 
     // č may appear as literal or HTML entity (&#x10D; &#x10d; &#269;)
     // Stop at comma to exclude publication reference (e.g. ", č. 421/2004 Sb. NSS")
+    // The sheet number the citation appends is taken by the capture and split
+    // off below, not discarded here: dropped at the regex, the sheet is gone
+    // from the row and nothing downstream can state where the document sits.
     const citMatch =
-      /title="Citace:[^"]*?(?:čj\.|č\.\s*j\.|&#x10[dD];j\.|&#26[89];j\.)[\s]*(?<caseNumber>[^",\s][^",]*?)(?:-\d+)?[",]/iu.exec(
+      /title="Citace:[^"]*?(?:čj\.|č\.\s*j\.|&#x10[dD];j\.|&#26[89];j\.)[\s]*(?<reference>[^",\s][^",]*?)[",]/iu.exec(
         block,
       );
-    const caseNumber = citMatch?.groups?.["caseNumber"]?.trim();
-    if (!caseNumber || caseNumber.length > 100) {
+    const publishedCaseNumber = citMatch?.groups?.["reference"]?.trim();
+    if (!publishedCaseNumber || publishedCaseNumber.length > 100) {
       // Skip malformed or overly long case numbers
-      if (caseNumber) {
+      if (publishedCaseNumber) {
         logger.warn("case_law.ingestion.malformed_case_number_skipped", {
           adapterKey: ADAPTER_KEYS.CZ_NSS,
-          caseNumberLength: caseNumber.length,
-          caseNumberSample: caseNumber.slice(0, 50),
+          caseNumberLength: publishedCaseNumber.length,
+          caseNumberSample: publishedCaseNumber.slice(0, 50),
         });
       }
       continue;
     }
+    const { caseNumber } = splitCaseReference(publishedCaseNumber);
 
     const detailMatch =
       /href="\/DokumentDetail\/Index\/(?<documentId>\d+)"/u.exec(block);
@@ -517,6 +532,7 @@ export const parseResultRows = (html: string): ParsedRow[] => {
 
     rows.push({
       caseNumber,
+      publishedCaseNumber,
       decisionDate,
       decisionType,
       outcome: undefined,
@@ -795,9 +811,13 @@ const rowToResult = (
     return undefined;
   })();
   const decisionType = (detail.decisionType ?? row.decisionType)?.toLowerCase();
+  // This source publishes the docket with the sheet number appended.
+  const publishedCaseNumber = row.publishedCaseNumber ?? row.caseNumber;
+  const { sheetNumber } = splitCaseReference(publishedCaseNumber);
 
   return {
     caseNumber: row.caseNumber,
+    sheetNumber,
     ...(detail.citation === undefined
       ? {}
       : {
@@ -833,6 +853,10 @@ const rowToResult = (
     documentUrl: row.documentUrl,
     metadata: {
       caseNumber: row.caseNumber,
+      sheetNumber,
+      // The reference exactly as the court publishes it, docket and sheet
+      // together, so the split stays reversible from what we stored.
+      publishedCaseNumber,
       court,
       ecli: detail.ecli,
       judge: detail.judge,
@@ -902,11 +926,18 @@ const reparseStoredRaw = (
 
   const citation = nonEmptyString(stored.metadata["citation"]);
   const sourceDocumentId = stored.sourceDocumentId ?? undefined;
+  // The row stores the published reference beside the docket, which is what
+  // makes the sheet recoverable here: rebuilt without it, a replay would write
+  // the sheet column back to null on every row it touched.
+  const { sheetNumber } = splitCaseReference(
+    nonEmptyString(stored.metadata["publishedCaseNumber"]) ?? stored.caseNumber,
+  );
 
   return {
     type: "parsed",
     result: {
       caseNumber: stored.caseNumber,
+      sheetNumber,
       ...(citation === undefined
         ? {}
         : {
@@ -1448,6 +1479,7 @@ const isOptionalString = (value: unknown): value is string | undefined =>
 const isCzNssListingRow = (value: unknown): value is ParsedRow =>
   isRecord(value) &&
   typeof value["caseNumber"] === "string" &&
+  isOptionalString(value["publishedCaseNumber"]) &&
   isOptionalString(value["decisionDate"]) &&
   isOptionalString(value["decisionType"]) &&
   isOptionalString(value["outcome"]) &&

--- a/apps/api/src/handlers/case-law/ingestion/publisher-document-identity.db.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/publisher-document-identity.db.test.ts
@@ -144,6 +144,7 @@ const NSS_SESSION = {
 const czNssRow = (documentId: string) =>
   ({
     caseNumber: "1 Az 4/2026",
+    publishedCaseNumber: "1 Az 4/2026-79",
     decisionDate: "10.06.2026",
     decisionType: "Rozsudek",
     outcome: undefined,

--- a/apps/api/src/scripts/normalize-case-numbers-sql.ts
+++ b/apps/api/src/scripts/normalize-case-numbers-sql.ts
@@ -23,8 +23,14 @@ import {
  * shape `splitCaseReference` applies at ingest, expressed in SQL so a batch is
  * one statement. The year is what keeps references that merely end in a number
  * (`0T/42/2019`) from being split.
+ *
+ * The optional space on either side of the dash mirrors the split's, and has
+ * to: rows stored before the ingest read the spaced form carry it in
+ * `case_number`, and a pattern the ingest accepts but the backfill does not
+ * leaves exactly those rows behind. Group 1 ends on a digit, so the docket
+ * this writes back carries no trailing space.
  */
-export const SHEET_PATTERN = String.raw`^(.*/\d{2,4})-(\d+)$`;
+export const SHEET_PATTERN = String.raw`^(.*/\d{2,4}) ?- ?(\d+)$`;
 
 /** How many rows carry a sheet number, and how many of them can be split. */
 export const sheetNumberSurveyStatement = (): SQL => sql`

--- a/apps/api/src/scripts/normalize-case-numbers.db.test.ts
+++ b/apps/api/src/scripts/normalize-case-numbers.db.test.ts
@@ -31,6 +31,7 @@ let db: ReturnType<typeof drizzle>;
 
 const sourceId = createSafeId<"caseLawSource">();
 const withSheet = createSafeId<"caseLawDecision">();
+const withSpacedSheet = createSafeId<"caseLawDecision">();
 const withoutIdentity = createSafeId<"caseLawDecision">();
 const citing = createSafeId<"caseLawDecision">();
 const edge = createSafeId<"caseLawCitation">();
@@ -62,6 +63,19 @@ beforeAll(
         decisionDate: "2025-03-01",
         slug: "with-sheet",
         languageGroupKey: "with-sheet",
+      },
+      {
+        // The same suffix as the court sets it in the document itself. Stored
+        // before the ingest read that form, so the backfill is the only thing
+        // that can reach it.
+        ...base,
+        id: withSpacedSheet,
+        caseNumber: "10 A 46/2015 - 66",
+        citationKey: "10a/46/2015 - 66",
+        sourceDocumentId: "doc-3",
+        decisionDate: "2025-03-03",
+        slug: "with-spaced-sheet",
+        languageGroupKey: "with-spaced-sheet",
       },
       {
         // No publisher id, so it is still identified by its case number and
@@ -137,13 +151,13 @@ const firstRow = (result: unknown): Record<string, unknown> => {
 
 test("the survey counts what can and cannot be split", async () => {
   const row = firstRow(await db.execute(sheetNumberSurveyStatement()));
-  expect(row["ready"]).toBe(1);
+  expect(row["ready"]).toBe(2);
   expect(row["blocked"]).toBe(1);
 });
 
 test("the normalization splits the docket and retracts its edges", async () => {
   const row = firstRow(await db.execute(normalizeSheetNumbersStatement(100)));
-  expect(row["normalized"]).toBe(1);
+  expect(row["normalized"]).toBe(2);
   // Clearing the key retracts the edge drawn to it: what the citation matched
   // was a docket carrying a sheet number, which was never the docket.
   expect(row["reopened"]).toBe(2);
@@ -161,6 +175,17 @@ test("the normalization splits the docket and retracts its edges", async () => {
     sheetNumber: "28",
     citationKey: null,
   });
+
+  const [spaced] = await db
+    .select({
+      caseNumber: caseLawDecisions.caseNumber,
+      sheetNumber: caseLawDecisions.sheetNumber,
+    })
+    .from(caseLawDecisions)
+    .where(eq(caseLawDecisions.id, withSpacedSheet));
+  // The spacing belongs to the suffix, not the docket: a docket left holding
+  // a trailing space matches no citation and is a second key for one case.
+  expect(spaced).toEqual({ caseNumber: "10 A 46/2015", sheetNumber: "66" });
 
   const [reopened] = await db
     .select({


### PR DESCRIPTION
Czech courts pair a docket with a sheet number and print the reference in several spacings. Two defects around that:

1. `SHEET_SUFFIX` only matched the unspaced form (`10 A 46/2015-66`), so the routinely printed spaced form (`10 A 46/2015 - 66`) never split: the sheet stayed on the docket and references fragmented per sheet — exactly what the split exists to prevent. The pattern now accepts optional single spaces around the hyphen; the docket group still ends on a digit, so spacing cannot reach the stored docket. The same rule lives in SQL in the operator backfill script and is widened identically, with a spaced row added to its PGlite test.

2. The cz-nss adapter's citation pattern used a non-capturing suffix group, so NSS-sourced rows kept neither `sheet_number` nor the published reference (the same regex both dropped and fragmented, depending on the court's spacing). The adapter now takes the reference whole, derives the docket via `splitCaseReference`, and persists `sheetNumber` plus `metadata.publishedCaseNumber` verbatim — mirroring the cz-regional shape. The stored-raw replay reads the sheet back from metadata so a replay cannot null the column.

Tests: spaced/unspaced/no-left-space/no-suffix/hyphenated-docket splits, reversibility via the stored published reference, adapter rows and replay (+6 new; 60 pass across the touched suites).

Known follow-ups, deliberately not here: rows whose sheet the old pattern discarded need a listing re-crawl (or ECLI-derived backfill, unverified) to recover it; the reader's fallback display does not yet spend `publishedCaseNumber`; the NSS decisionType cell heuristic mis-picks the reference cell and is documented by an existing test — changing it churns every row's rawHash and belongs in its own change.

https://claude.ai/code/session_01HkFVj9TLAggYEsdsfZhad8