### PR TITLE
feat: expose typed Kanban cell counts and destinations

### DIFF
--- a/.changeset/bright-kanbans-count.md
+++ b/.changeset/bright-kanbans-count.md
@@ -1,0 +1,6 @@
+---
+"@stll/ui": patch
+---
+
+Expose each Kanban swimlane cell's row count to the typed render-cell
+primitive, including explicit zero counts for empty intersections.

--- a/.changeset/bright-kanbans-count.md
+++ b/.changeset/bright-kanbans-count.md
@@ -3,4 +3,5 @@
 ---
 
 Expose each Kanban swimlane cell's row count to the typed render-cell
-primitive, including explicit zero counts for empty intersections.
+primitive, including explicit zero counts for empty intersections. Add typed
+terminal destination columns to the matrix and drop intent contract.

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-subgroup-board.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-subgroup-board.tsx
@@ -110,7 +110,8 @@ export const KanbanSubgroupBoard = ({
       renderCell={({ cell, laneValue }) => (
         <WorkspaceKanbanSubgroupCell
           canCreateTask={
-            cell.coordinate.column.value !== null &&
+            cell.coordinate.column.type === "group" &&
+            cell.coordinate.column.group.value !== null &&
             canCreateTaskInLane(laneValue)
           }
           canMoveCards={canMoveCards}
@@ -129,16 +130,20 @@ export const KanbanSubgroupBoard = ({
           workspaceId={workspaceId}
         />
       )}
-      renderColumnHeader={({ column, count }) => (
-        <WorkspaceKanbanColumnHeading
-          column={column}
-          count={count}
-          onChangeColor={onChangeColumnColor}
-          onHide={onHideColumn}
-          onRename={onRenameColumn}
-          onReorder={onReorderColumn}
-        />
-      )}
+      renderColumnHeader={({ column, count }) =>
+        column.type === "group" ? (
+          <WorkspaceKanbanColumnHeading
+            column={column.group}
+            count={count}
+            onChangeColor={onChangeColumnColor}
+            onHide={onHideColumn}
+            onRename={onRenameColumn}
+            onReorder={onReorderColumn}
+          />
+        ) : (
+          <KanbanColumnHeader title={column.destination.label} meta={count} />
+        )
+      }
       renderLaneIdentity={({ group }) => <SubgroupIdentity group={group} />}
     />
   );
@@ -184,11 +189,14 @@ const WorkspaceKanbanSubgroupCell = ({
   workspaceId,
 }: WorkspaceKanbanSubgroupCellProps) => {
   const cellRef = useRef<HTMLDivElement>(null);
-  const columnValue = cell.coordinate.column.value;
+  const columnValue =
+    cell.coordinate.column.type === "group"
+      ? cell.coordinate.column.group.value
+      : null;
   const isDragOver = useKanbanEntityDropTarget({
     elementRef: cellRef,
     enabled: canMoveCards,
-    name: `${cell.coordinate.column.label}, ${cell.coordinate.lane.type === "group" ? cell.coordinate.lane.group.label : ""}`,
+    name: `${cell.coordinate.column.type === "group" ? cell.coordinate.column.group.label : cell.coordinate.column.destination.label}, ${cell.coordinate.lane.type === "group" ? cell.coordinate.lane.group.label : ""}`,
     onDrop: (entityId) => {
       if (columnValue !== null) {
         onDropCard(entityId, columnValue, laneValue);
@@ -200,8 +208,9 @@ const WorkspaceKanbanSubgroupCell = ({
     <KanbanVirtualCell
       active={isDragOver}
       backgroundColor={
-        cell.coordinate.column.colorBg
-          ? `color-mix(in srgb, ${cell.coordinate.column.colorBg} 26%, transparent)`
+        cell.coordinate.column.type === "group" &&
+        cell.coordinate.column.group.colorBg
+          ? `color-mix(in srgb, ${cell.coordinate.column.group.colorBg} 26%, transparent)`
           : undefined
       }
       containerRef={cellRef}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
@@ -881,10 +881,16 @@ export const KanbanView = ({ view, workspaceId }: KanbanViewProps) => {
       ? null
       : {
           ...subgroupMatrix,
-          columns: visibleGroups,
+          columns: visibleGroups.map((group) => ({
+            group,
+            type: "group" as const,
+          })),
           cells: orderKanbanCellsByColumns({
             cells: subgroupMatrix.cells,
-            columns: visibleGroups,
+            columns: visibleGroups.map((group) => ({
+              group,
+              type: "group" as const,
+            })),
           }),
         };
 

--- a/packages/ui/src/kanban/grouping.ts
+++ b/packages/ui/src/kanban/grouping.ts
@@ -29,6 +29,8 @@ export type KanbanGroup = {
   color?: string | undefined;
   colorBg?: string | undefined;
   optionColor?: OptionColor | undefined;
+  /** Present when this group is a terminal destination, not a data option. */
+  destination?: { id: string; label: string } | undefined;
 };
 
 /**

--- a/packages/ui/src/kanban/grouping.ts
+++ b/packages/ui/src/kanban/grouping.ts
@@ -29,8 +29,6 @@ export type KanbanGroup = {
   color?: string | undefined;
   colorBg?: string | undefined;
   optionColor?: OptionColor | undefined;
-  /** Present when this group is a terminal destination, not a data option. */
-  destination?: { id: string; label: string } | undefined;
 };
 
 /**

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -84,6 +84,7 @@ export type {
   BuildKanbanBoardMatrixParams,
   CreateKanbanDropIntentParams,
   KanbanBoardDestination,
+  KanbanBoardColumn,
   KanbanBoardAxis,
   KanbanBoardCell,
   KanbanBoardCoordinate,

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -83,6 +83,7 @@ export {
 export type {
   BuildKanbanBoardMatrixParams,
   CreateKanbanDropIntentParams,
+  KanbanBoardDestination,
   KanbanBoardAxis,
   KanbanBoardCell,
   KanbanBoardCoordinate,

--- a/packages/ui/src/kanban/matrix.test.ts
+++ b/packages/ui/src/kanban/matrix.test.ts
@@ -5,6 +5,8 @@ import { resolveKanbanGrouping } from "./grouping";
 import {
   buildKanbanBoardMatrix,
   createKanbanDropIntent,
+  getKanbanBoardColumnIdentity,
+  getKanbanBoardLaneIdentity,
   orderKanbanCellsByColumns,
 } from "./matrix";
 import type {
@@ -146,6 +148,36 @@ describe("kanban board matrix", () => {
       matrix.cells.flatMap((cell) => cell.rows).map((row) => row.id),
     ).toEqual(["one", "three", "two"]);
     expect(matrix.cells.at(0)?.rows.map((row) => row.id)).toEqual(["one"]);
+  });
+
+  test("keeps subgroup fallback values out of the group-column domain", () => {
+    const matrix = buildKanbanBoardMatrix({
+      group: {
+        type: "built-in",
+        propertyId: "_status",
+        group: {
+          id: "_status",
+          options: [{ label: "Unassigned", value: "unassigned" }],
+        },
+      },
+      resolveGroupValue: valueFor,
+      rows: [{ id: "one", owner: "unassigned", status: "unassigned" }],
+      subgroup,
+      uncategorizedLabel: "No value",
+    });
+
+    expect(matrix.columns.map(columnValue)).toEqual(["unassigned", null]);
+    expect(
+      matrix.lanes.map((lane) =>
+        lane.type === "group" ? lane.group.value : null,
+      ),
+    ).toEqual(["ada", "lin", null]);
+    const columnKeys = new Set(
+      matrix.columns.map(getKanbanBoardColumnIdentity),
+    );
+    const laneKeys = new Set(matrix.lanes.map(getKanbanBoardLaneIdentity));
+    expect([...columnKeys].filter((key) => laneKeys.has(key))).toEqual([]);
+    expect(matrix.cells.filter((cell) => cell.rows.length > 0)).toHaveLength(1);
   });
 
   test("a diagonal move carries both changed axes in one intent", () => {

--- a/packages/ui/src/kanban/matrix.test.ts
+++ b/packages/ui/src/kanban/matrix.test.ts
@@ -188,7 +188,46 @@ describe("kanban board matrix", () => {
         { groupBy: "_status", value: "done" },
         { groupBy: "owner", value: "lin" },
       ],
+      destination: null,
       type: "move",
     });
+  });
+
+  test("keeps terminal destinations as real matrix columns and drop targets", () => {
+    const matrix = buildKanbanBoardMatrix({
+      destinations: [{ id: "archive", label: "Archive" }],
+      group,
+      resolveGroupValue: valueFor,
+      rows: [{ id: "one", owner: "ada", status: "open" }],
+      subgroup,
+      uncategorizedLabel: "No value",
+    });
+    const destination = matrix.columns.at(-1);
+    if (destination === undefined) {
+      throw new Error("Expected a terminal destination column");
+    }
+    expect(destination.label).toBe("Archive");
+    expect(
+      matrix.cells.filter(
+        (cell) => cell.coordinate.column.value === destination.value,
+      ),
+    ).toHaveLength(3);
+    const sourceCell = matrix.cells.at(0);
+    const sourceLane = matrix.lanes.at(0);
+    if (sourceCell === undefined || sourceLane === undefined) {
+      throw new Error("Expected a source matrix cell and lane");
+    }
+    const intent = createKanbanDropIntent({
+      cardId: "one",
+      group,
+      source: sourceCell.coordinate,
+      subgroup,
+      target: {
+        column: destination,
+        lane: sourceLane,
+      },
+    });
+    expect(intent?.destination).toEqual({ id: "archive", label: "Archive" });
+    expect(intent?.changes).toEqual([]);
   });
 });

--- a/packages/ui/src/kanban/matrix.test.ts
+++ b/packages/ui/src/kanban/matrix.test.ts
@@ -244,4 +244,20 @@ describe("kanban board matrix", () => {
       type: "destination",
     });
   });
+
+  test("rejects duplicate terminal destination identities", () => {
+    expect(() =>
+      buildKanbanBoardMatrix({
+        destinations: [
+          { id: "archive", label: "Archive" },
+          { id: "archive", label: "Archive again" },
+        ],
+        group,
+        resolveGroupValue: valueFor,
+        rows: [],
+        subgroup,
+        uncategorizedLabel: "No value",
+      }),
+    ).toThrow("Duplicate Kanban board column identity");
+  });
 });

--- a/packages/ui/src/kanban/matrix.test.ts
+++ b/packages/ui/src/kanban/matrix.test.ts
@@ -207,6 +207,10 @@ describe("kanban board matrix", () => {
       throw new Error("Expected a terminal destination column");
     }
     expect(destination.label).toBe("Archive");
+    expect(destination.destination).toEqual({
+      id: "archive",
+      label: "Archive",
+    });
     expect(
       matrix.cells.filter(
         (cell) => cell.coordinate.column.value === destination.value,

--- a/packages/ui/src/kanban/matrix.test.ts
+++ b/packages/ui/src/kanban/matrix.test.ts
@@ -7,11 +7,16 @@ import {
   createKanbanDropIntent,
   orderKanbanCellsByColumns,
 } from "./matrix";
-import type { ResolveKanbanGroupValueParams } from "./matrix";
+import type {
+  KanbanBoardColumn,
+  ResolveKanbanGroupValueParams,
+} from "./matrix";
 
 type Row = { id: string; owner: string | null; status: string | null };
 type Property = { id: "owner" };
 type GroupId = "_empty" | "_status" | "owner";
+const columnValue = (column: KanbanBoardColumn) =>
+  column.type === "group" ? column.group.value : column.destination.id;
 
 const schema: KanbanSchema<Row, Property, GroupId> = {
   builtInGroups: [
@@ -87,7 +92,7 @@ describe("kanban board matrix", () => {
       matrix.cells
         .filter((cell) => cell.rows.length > 0)
         .map((cell) => [
-          cell.coordinate.column.value,
+          columnValue(cell.coordinate.column),
           cell.rows.map((row) => row.id),
         ]),
     ).toEqual([
@@ -117,7 +122,7 @@ describe("kanban board matrix", () => {
       orderKanbanCellsByColumns({
         cells: adaCells,
         columns: matrix.columns.toReversed(),
-      }).map((cell) => cell.coordinate.column.value),
+      }).map((cell) => columnValue(cell.coordinate.column)),
     ).toEqual([null, "done", "open"]);
   });
 
@@ -135,11 +140,7 @@ describe("kanban board matrix", () => {
       uncategorizedLabel: "No value",
     });
 
-    expect(matrix.columns.map((column) => column.value)).toEqual([
-      "open",
-      "done",
-      null,
-    ]);
+    expect(matrix.columns.map(columnValue)).toEqual(["open", "done", null]);
     expect(matrix.lanes).toHaveLength(3);
     expect(
       matrix.cells.flatMap((cell) => cell.rows).map((row) => row.id),
@@ -157,13 +158,13 @@ describe("kanban board matrix", () => {
     });
     const source = matrix.cells.find(
       (cell) =>
-        cell.coordinate.column.value === "open" &&
+        columnValue(cell.coordinate.column) === "open" &&
         cell.coordinate.lane.type === "group" &&
         cell.coordinate.lane.group.value === "ada",
     );
     const target = matrix.cells.find(
       (cell) =>
-        cell.coordinate.column.value === "done" &&
+        columnValue(cell.coordinate.column) === "done" &&
         cell.coordinate.lane.type === "group" &&
         cell.coordinate.lane.group.value === "lin",
     );
@@ -178,7 +179,10 @@ describe("kanban board matrix", () => {
       subgroup,
       target: target.coordinate,
     });
-    const firstChange = intent?.changes.at(0);
+    if (intent?.type !== "move") {
+      throw new Error("Expected a move intent");
+    }
+    const firstChange = intent.changes.at(0);
     const axis: GroupId | undefined = firstChange?.groupBy;
 
     expect(axis).toBe("_status");
@@ -188,7 +192,6 @@ describe("kanban board matrix", () => {
         { groupBy: "_status", value: "done" },
         { groupBy: "owner", value: "lin" },
       ],
-      destination: null,
       type: "move",
     });
   });
@@ -206,14 +209,18 @@ describe("kanban board matrix", () => {
     if (destination === undefined) {
       throw new Error("Expected a terminal destination column");
     }
-    expect(destination.label).toBe("Archive");
+    expect(destination.type).toBe("destination");
+    if (destination.type !== "destination") {
+      throw new Error("Expected a destination column");
+    }
     expect(destination.destination).toEqual({
       id: "archive",
       label: "Archive",
     });
     expect(
       matrix.cells.filter(
-        (cell) => cell.coordinate.column.value === destination.value,
+        (cell) =>
+          columnValue(cell.coordinate.column) === columnValue(destination),
       ),
     ).toHaveLength(3);
     const sourceCell = matrix.cells.at(0);
@@ -231,7 +238,10 @@ describe("kanban board matrix", () => {
         lane: sourceLane,
       },
     });
-    expect(intent?.destination).toEqual({ id: "archive", label: "Archive" });
-    expect(intent?.changes).toEqual([]);
+    expect(intent).toEqual({
+      cardId: "one",
+      destination: { id: "archive", label: "Archive" },
+      type: "destination",
+    });
   });
 });

--- a/packages/ui/src/kanban/matrix.ts
+++ b/packages/ui/src/kanban/matrix.ts
@@ -101,7 +101,7 @@ const assertUniqueColumnIdentities = (
   for (const column of columns) {
     const identity = columnIdentity(column);
     if (identities.has(identity)) {
-      throw new Error(`Duplicate Kanban board column identity: ${identity}`);
+      return panic(`Duplicate Kanban board column identity: ${identity}`);
     }
     identities.add(identity);
   }

--- a/packages/ui/src/kanban/matrix.ts
+++ b/packages/ui/src/kanban/matrix.ts
@@ -94,6 +94,19 @@ const columnIdentity = (column: KanbanBoardColumn): string =>
     ? `group:${optionValueKey(column.group.value)}`
     : `destination:${column.destination.id}`;
 
+const assertUniqueColumnIdentities = (
+  columns: readonly KanbanBoardColumn[],
+): void => {
+  const identities = new Set<string>();
+  for (const column of columns) {
+    const identity = columnIdentity(column);
+    if (identities.has(identity)) {
+      throw new Error(`Duplicate Kanban board column identity: ${identity}`);
+    }
+    identities.add(identity);
+  }
+};
+
 /** Apply the visible header order to any lane's cells. */
 export const orderKanbanCellsByColumns = <TRow>({
   cells,
@@ -185,6 +198,7 @@ export const buildKanbanBoardMatrix = <
       type: "destination",
     });
   }
+  assertUniqueColumnIdentities(columns);
   const scopedRows = selectKanbanRows(rows, group);
   const hasRenderableSubgroup = isKanbanGroupingRenderable(subgroup);
   const lanes = hasRenderableSubgroup

--- a/packages/ui/src/kanban/matrix.ts
+++ b/packages/ui/src/kanban/matrix.ts
@@ -175,6 +175,7 @@ export const buildKanbanBoardMatrix = <
   const columns = getRenderableGroups(group, uncategorizedLabel);
   for (const destination of destinations) {
     columns.push({
+      destination,
       value: `${destinationValuePrefix}${destination.id}`,
       label: destination.label,
     });
@@ -299,12 +300,7 @@ export const createKanbanDropIntent = <
   }
 
   const changes: KanbanDropAxisChange<TGroupId>[] = [];
-  const destination = target.column.value.startsWith(destinationValuePrefix)
-    ? {
-        id: target.column.value.slice(destinationValuePrefix.length),
-        label: target.column.label,
-      }
-    : null;
+  const destination = target.column.destination ?? null;
   if (destination === null && source.column.value !== target.column.value) {
     changes.push({ groupBy, value: target.column.value });
   }

--- a/packages/ui/src/kanban/matrix.ts
+++ b/packages/ui/src/kanban/matrix.ts
@@ -33,6 +33,12 @@ export type KanbanBoardCell<TRow> = {
   rows: TRow[];
 };
 
+/** A non-grouping destination rendered as a terminal board column. */
+export type KanbanBoardDestination = {
+  id: string;
+  label: string;
+};
+
 /**
  * The full, ordered cartesian board. Presentation may hide or collapse parts
  * of it, but it must not derive cards independently: every board row is in
@@ -63,6 +69,8 @@ export type BuildKanbanBoardMatrixParams<
   group: KanbanGrouping<TRow, TProperty, TGroupId>;
   /** Optional horizontal swimlanes. `none` makes this a one-lane board. */
   subgroup: KanbanGrouping<TRow, TProperty, TGroupId>;
+  /** Terminal columns, rendered after grouping columns and empty by default. */
+  destinations?: readonly KanbanBoardDestination[];
   rows: readonly TRow[];
   uncategorizedLabel: string;
   resolveGroupValue: (
@@ -72,6 +80,7 @@ export type BuildKanbanBoardMatrixParams<
 
 const optionValueKey = (value: string | null): string =>
   value === null ? "null" : `string:${value.length}:${value}`;
+const destinationValuePrefix = "@destination:";
 
 export type OrderKanbanCellsByColumnsParams<TRow> = {
   cells: readonly KanbanBoardCell<TRow>[];
@@ -151,6 +160,7 @@ export const buildKanbanBoardMatrix = <
 >({
   group,
   subgroup,
+  destinations = [],
   rows,
   uncategorizedLabel,
   resolveGroupValue,
@@ -163,6 +173,12 @@ export const buildKanbanBoardMatrix = <
     return { cells: [], columns: [], lanes: [], rows: [] };
   }
   const columns = getRenderableGroups(group, uncategorizedLabel);
+  for (const destination of destinations) {
+    columns.push({
+      value: `${destinationValuePrefix}${destination.id}`,
+      label: destination.label,
+    });
+  }
   const scopedRows = selectKanbanRows(rows, group);
   const hasRenderableSubgroup = isKanbanGroupingRenderable(subgroup);
   const lanes = hasRenderableSubgroup
@@ -237,6 +253,7 @@ export type KanbanDropAxisChange<TGroupId extends string = string> = {
 export type KanbanDropIntent<TCardId, TGroupId extends string = string> = {
   cardId: TCardId;
   changes: readonly KanbanDropAxisChange<TGroupId>[];
+  destination: KanbanBoardDestination | null;
   type: "move";
 };
 
@@ -282,7 +299,13 @@ export const createKanbanDropIntent = <
   }
 
   const changes: KanbanDropAxisChange<TGroupId>[] = [];
-  if (source.column.value !== target.column.value) {
+  const destination = target.column.value.startsWith(destinationValuePrefix)
+    ? {
+        id: target.column.value.slice(destinationValuePrefix.length),
+        label: target.column.label,
+      }
+    : null;
+  if (destination === null && source.column.value !== target.column.value) {
     changes.push({ groupBy, value: target.column.value });
   }
   if (
@@ -294,8 +317,8 @@ export const createKanbanDropIntent = <
     changes.push({ groupBy: subgroupBy, value: target.lane.group.value });
   }
 
-  if (changes.length === 0) {
+  if (changes.length === 0 && destination === null) {
     return null;
   }
-  return { cardId, changes, type: "move" };
+  return { cardId, changes, destination, type: "move" };
 };

--- a/packages/ui/src/kanban/matrix.ts
+++ b/packages/ui/src/kanban/matrix.ts
@@ -89,17 +89,26 @@ export type OrderKanbanCellsByColumnsParams<TRow> = {
   columns: readonly KanbanBoardColumn[];
 };
 
-const columnIdentity = (column: KanbanBoardColumn): string =>
+/** Stable identity for a visible board column; group and destination domains stay distinct. */
+export const getKanbanBoardColumnIdentity = (
+  column: KanbanBoardColumn,
+): string =>
   column.type === "group"
     ? `group:${optionValueKey(column.group.value)}`
     : `destination:${column.destination.id}`;
+
+/** Stable identity for a swimlane; it can never alias a visible column. */
+export const getKanbanBoardLaneIdentity = (lane: KanbanBoardLane): string =>
+  lane.type === "none"
+    ? "lane:none"
+    : `lane:${optionValueKey(lane.group.value)}`;
 
 const assertUniqueColumnIdentities = (
   columns: readonly KanbanBoardColumn[],
 ): void => {
   const identities = new Set<string>();
   for (const column of columns) {
-    const identity = columnIdentity(column);
+    const identity = getKanbanBoardColumnIdentity(column);
     if (identities.has(identity)) {
       return panic(`Duplicate Kanban board column identity: ${identity}`);
     }
@@ -113,19 +122,26 @@ export const orderKanbanCellsByColumns = <TRow>({
   columns,
 }: OrderKanbanCellsByColumnsParams<TRow>): KanbanBoardCell<TRow>[] => {
   const orderByValue = new Map(
-    columns.map((column, index) => [columnIdentity(column), index]),
+    columns.map((column, index) => [
+      getKanbanBoardColumnIdentity(column),
+      index,
+    ]),
   );
   const getColumnOrder = (cell: KanbanBoardCell<TRow>) => {
-    const order = orderByValue.get(columnIdentity(cell.coordinate.column));
+    const order = orderByValue.get(
+      getKanbanBoardColumnIdentity(cell.coordinate.column),
+    );
     return order ?? panic("Visible Kanban cell has no column order");
   };
   return cells
-    .filter((cell) => orderByValue.has(columnIdentity(cell.coordinate.column)))
+    .filter((cell) =>
+      orderByValue.has(getKanbanBoardColumnIdentity(cell.coordinate.column)),
+    )
     .toSorted((left, right) => getColumnOrder(left) - getColumnOrder(right));
 };
 
 const cellKey = ({ column, lane }: KanbanBoardCoordinate): string =>
-  `${columnIdentity(column)}|${lane.type === "none" ? "none" : optionValueKey(lane.group.value)}`;
+  `${getKanbanBoardColumnIdentity(column)}|${getKanbanBoardLaneIdentity(lane)}`;
 
 const groupContainsValue = (
   groups: readonly KanbanGroup[],

--- a/packages/ui/src/kanban/matrix.ts
+++ b/packages/ui/src/kanban/matrix.ts
@@ -24,7 +24,7 @@ export type KanbanBoardLane =
   | { group: KanbanGroup; type: "group" };
 
 export type KanbanBoardCoordinate = {
-  column: KanbanGroup;
+  column: KanbanBoardColumn;
   lane: KanbanBoardLane;
 };
 
@@ -39,6 +39,10 @@ export type KanbanBoardDestination = {
   label: string;
 };
 
+export type KanbanBoardColumn =
+  | { group: KanbanGroup; type: "group" }
+  | { destination: KanbanBoardDestination; type: "destination" };
+
 /**
  * The full, ordered cartesian board. Presentation may hide or collapse parts
  * of it, but it must not derive cards independently: every board row is in
@@ -46,7 +50,7 @@ export type KanbanBoardDestination = {
  */
 export type KanbanBoardMatrix<TRow> = {
   cells: KanbanBoardCell<TRow>[];
-  columns: KanbanGroup[];
+  columns: KanbanBoardColumn[];
   lanes: KanbanBoardLane[];
   rows: TRow[];
 };
@@ -80,12 +84,15 @@ export type BuildKanbanBoardMatrixParams<
 
 const optionValueKey = (value: string | null): string =>
   value === null ? "null" : `string:${value.length}:${value}`;
-const destinationValuePrefix = "@destination:";
-
 export type OrderKanbanCellsByColumnsParams<TRow> = {
   cells: readonly KanbanBoardCell<TRow>[];
-  columns: readonly KanbanGroup[];
+  columns: readonly KanbanBoardColumn[];
 };
+
+const columnIdentity = (column: KanbanBoardColumn): string =>
+  column.type === "group"
+    ? `group:${optionValueKey(column.group.value)}`
+    : `destination:${column.destination.id}`;
 
 /** Apply the visible header order to any lane's cells. */
 export const orderKanbanCellsByColumns = <TRow>({
@@ -93,23 +100,19 @@ export const orderKanbanCellsByColumns = <TRow>({
   columns,
 }: OrderKanbanCellsByColumnsParams<TRow>): KanbanBoardCell<TRow>[] => {
   const orderByValue = new Map(
-    columns.map((column, index) => [optionValueKey(column.value), index]),
+    columns.map((column, index) => [columnIdentity(column), index]),
   );
   const getColumnOrder = (cell: KanbanBoardCell<TRow>) => {
-    const order = orderByValue.get(
-      optionValueKey(cell.coordinate.column.value),
-    );
+    const order = orderByValue.get(columnIdentity(cell.coordinate.column));
     return order ?? panic("Visible Kanban cell has no column order");
   };
   return cells
-    .filter((cell) =>
-      orderByValue.has(optionValueKey(cell.coordinate.column.value)),
-    )
+    .filter((cell) => orderByValue.has(columnIdentity(cell.coordinate.column)))
     .toSorted((left, right) => getColumnOrder(left) - getColumnOrder(right));
 };
 
 const cellKey = ({ column, lane }: KanbanBoardCoordinate): string =>
-  `${optionValueKey(column.value)}|${lane.type === "none" ? "none" : optionValueKey(lane.group.value)}`;
+  `${columnIdentity(column)}|${lane.type === "none" ? "none" : optionValueKey(lane.group.value)}`;
 
 const groupContainsValue = (
   groups: readonly KanbanGroup[],
@@ -172,12 +175,14 @@ export const buildKanbanBoardMatrix = <
   if (!isKanbanGroupingRenderable(group)) {
     return { cells: [], columns: [], lanes: [], rows: [] };
   }
-  const columns = getRenderableGroups(group, uncategorizedLabel);
+  const columns: KanbanBoardColumn[] = getRenderableGroups(
+    group,
+    uncategorizedLabel,
+  ).map((column) => ({ group: column, type: "group" }));
   for (const destination of destinations) {
     columns.push({
       destination,
-      value: `${destinationValuePrefix}${destination.id}`,
-      label: destination.label,
+      type: "destination",
     });
   }
   const scopedRows = selectKanbanRows(rows, group);
@@ -199,7 +204,12 @@ export const buildKanbanBoardMatrix = <
 
   for (const row of scopedRows) {
     const columnValue = normalizeGroupValue(
-      columns,
+      columns
+        .filter(
+          (column): column is { group: KanbanGroup; type: "group" } =>
+            column.type === "group",
+        )
+        .map((column) => column.group),
       resolveGroupValue({ grouping: group, row }),
     );
     const lane = !hasRenderableSubgroup
@@ -221,7 +231,10 @@ export const buildKanbanBoardMatrix = <
           },
           type: "group" as const,
         };
-    const column = columns.find((candidate) => candidate.value === columnValue);
+    const column = columns.find(
+      (candidate) =>
+        candidate.type === "group" && candidate.group.value === columnValue,
+    );
     const resolvedLane =
       lane.type === "none"
         ? lane
@@ -251,12 +264,20 @@ export type KanbanDropAxisChange<TGroupId extends string = string> = {
 };
 
 /** A complete, atomic move request for a domain mutation adapter. */
-export type KanbanDropIntent<TCardId, TGroupId extends string = string> = {
-  cardId: TCardId;
-  changes: readonly KanbanDropAxisChange<TGroupId>[];
-  destination: KanbanBoardDestination | null;
-  type: "move";
-};
+export type KanbanDropIntent<TCardId, TGroupId extends string = string> =
+  | {
+      cardId: TCardId;
+      changes: readonly [
+        KanbanDropAxisChange<TGroupId>,
+        ...KanbanDropAxisChange<TGroupId>[],
+      ];
+      type: "move";
+    }
+  | {
+      cardId: TCardId;
+      destination: KanbanBoardDestination;
+      type: "destination";
+    };
 
 export type CreateKanbanDropIntentParams<
   TRow,
@@ -299,10 +320,19 @@ export const createKanbanDropIntent = <
     return null;
   }
 
+  if (target.column.type === "destination") {
+    return {
+      cardId,
+      destination: target.column.destination,
+      type: "destination",
+    };
+  }
   const changes: KanbanDropAxisChange<TGroupId>[] = [];
-  const destination = target.column.destination ?? null;
-  if (destination === null && source.column.value !== target.column.value) {
-    changes.push({ groupBy, value: target.column.value });
+  if (
+    source.column.type !== "group" ||
+    source.column.group.value !== target.column.group.value
+  ) {
+    changes.push({ groupBy, value: target.column.group.value });
   }
   if (
     subgroupBy !== null &&
@@ -313,8 +343,16 @@ export const createKanbanDropIntent = <
     changes.push({ groupBy: subgroupBy, value: target.lane.group.value });
   }
 
-  if (changes.length === 0 && destination === null) {
+  if (changes.length === 0) {
     return null;
   }
-  return { cardId, changes, destination, type: "move" };
+  const firstChange = changes.at(0);
+  if (firstChange === undefined) {
+    return null;
+  }
+  return {
+    cardId,
+    changes: [firstChange, ...changes.slice(1)],
+    type: "move",
+  };
 };

--- a/packages/ui/src/kanban/subgroup-board.test.tsx
+++ b/packages/ui/src/kanban/subgroup-board.test.tsx
@@ -53,14 +53,9 @@ const renderBoard = (expandEmptyLanes = false) =>
           }
         : {})}
       matrix={matrix}
-      renderCell={({ cell, laneValue }) => (
+      renderCell={({ cell, count, laneValue }) => (
         <span>
-          {testLabel(
-            "cell",
-            laneValue,
-            cell.coordinate.column.value,
-            cell.rows.length,
-          )}
+          {testLabel("cell", laneValue, cell.coordinate.column.value, count)}
         </span>
       )}
       renderColumnHeader={({ column, count }) => (

--- a/packages/ui/src/kanban/subgroup-board.test.tsx
+++ b/packages/ui/src/kanban/subgroup-board.test.tsx
@@ -55,11 +55,26 @@ const renderBoard = (expandEmptyLanes = false) =>
       matrix={matrix}
       renderCell={({ cell, count, laneValue }) => (
         <span>
-          {testLabel("cell", laneValue, cell.coordinate.column.value, count)}
+          {testLabel(
+            "cell",
+            laneValue,
+            cell.coordinate.column.type === "group"
+              ? cell.coordinate.column.group.value
+              : cell.coordinate.column.destination.id,
+            count,
+          )}
         </span>
       )}
       renderColumnHeader={({ column, count }) => (
-        <span>{testLabel("column", column.value, count)}</span>
+        <span>
+          {testLabel(
+            "column",
+            column.type === "group"
+              ? column.group.value
+              : column.destination.id,
+            count,
+          )}
+        </span>
       )}
       renderLaneIdentity={({ group: lane, count }) => (
         <span>{testLabel("lane", lane.value, count)}</span>
@@ -83,9 +98,12 @@ describe("KanbanSubgroupBoard", () => {
     const expanded = renderBoard(true);
 
     expect(collapsed).toContain("lane:lin:0");
+    expect(collapsed).toContain('data-kanban-lane-column-count="1"');
+    expect(collapsed).toContain('data-kanban-lane-column-count="0"');
     expect(collapsed).not.toContain("cell:lin:open:0");
     expect(collapsed).toContain('aria-expanded="false"');
     expect(expanded).toContain("cell:lin:open:0");
     expect(expanded).toContain("cell:lin:done:0");
+    expect(expanded).toContain('data-kanban-lane-column-count="0"');
   });
 });

--- a/packages/ui/src/kanban/subgroup-board.tsx
+++ b/packages/ui/src/kanban/subgroup-board.tsx
@@ -23,6 +23,8 @@ export type KanbanSubgroupLaneIdentityContext = {
 
 export type KanbanSubgroupCellContext<TRow> = {
   cell: KanbanBoardCell<TRow>;
+  /** Number of rows in this lane/column intersection, including zero. */
+  count: number;
   laneValue: string | null;
 };
 
@@ -189,7 +191,11 @@ export const KanbanSubgroupBoard = <TRow,>({
                       className="w-[300px] shrink-0"
                       key={groupValueKey(cell.coordinate.column.value)}
                     >
-                      {renderCell({ cell, laneValue: group.value })}
+                      {renderCell({
+                        cell,
+                        count: cell.rows.length,
+                        laneValue: group.value,
+                      })}
                     </div>
                   ))}
                 </div>

--- a/packages/ui/src/kanban/subgroup-board.tsx
+++ b/packages/ui/src/kanban/subgroup-board.tsx
@@ -6,13 +6,21 @@ import { ChevronDownIcon } from "lucide-react";
 import { DirectionalIcon } from "../components/directional-icon";
 import { cn } from "../lib/utils";
 import type { KanbanGroup } from "./grouping";
-import type { KanbanBoardCell, KanbanBoardMatrix } from "./matrix";
+import type {
+  KanbanBoardCell,
+  KanbanBoardColumn,
+  KanbanBoardMatrix,
+} from "./matrix";
 
 const groupValueKey = (value: string | null): string =>
   value === null ? "null" : `value:${value.length}:${value}`;
+const columnKey = (column: KanbanBoardColumn): string =>
+  column.type === "group"
+    ? `group:${groupValueKey(column.group.value)}`
+    : `destination:${column.destination.id}`;
 
 export type KanbanSubgroupColumnHeaderContext = {
-  column: KanbanGroup;
+  column: KanbanBoardColumn;
   count: number;
 };
 
@@ -68,13 +76,10 @@ export const KanbanSubgroupBoard = <TRow,>({
   );
   const { cellsByLaneValue, countByColumnValue } = useMemo(() => {
     const laneCells = new Map<string | null, KanbanBoardCell<TRow>[]>();
-    const columnCounts = new Map<string | null, number>();
+    const columnCounts = new Map<string, number>();
     for (const cell of matrix.cells) {
-      columnCounts.set(
-        cell.coordinate.column.value,
-        (columnCounts.get(cell.coordinate.column.value) ?? 0) +
-          cell.rows.length,
-      );
+      const key = columnKey(cell.coordinate.column);
+      columnCounts.set(key, (columnCounts.get(key) ?? 0) + cell.rows.length);
       if (cell.coordinate.lane.type === "none") {
         continue;
       }
@@ -130,13 +135,10 @@ export const KanbanSubgroupBoard = <TRow,>({
       <div className="min-w-max">
         <div className="bg-background sticky top-0 z-20 flex gap-3 pt-4 pb-3">
           {matrix.columns.map((column) => (
-            <div
-              className="w-[300px] shrink-0"
-              key={groupValueKey(column.value)}
-            >
+            <div className="w-[300px] shrink-0" key={columnKey(column)}>
               {renderColumnHeader({
                 column,
-                count: countByColumnValue.get(column.value) ?? 0,
+                count: countByColumnValue.get(columnKey(column)) ?? 0,
               })}
             </div>
           ))}
@@ -184,12 +186,26 @@ export const KanbanSubgroupBoard = <TRow,>({
                 </button>
               </div>
 
+              <div className="flex gap-3" aria-label="Lane column counts">
+                {cells.map((cell) => (
+                  <div
+                    className="w-[300px] shrink-0 px-3"
+                    data-kanban-lane-column-count={cell.rows.length}
+                    key={columnKey(cell.coordinate.column)}
+                  >
+                    <span className="text-muted-foreground text-xs tabular-nums">
+                      {formatCount(cell.rows.length)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+
               {!collapsed && (
                 <div className="flex gap-3 pb-1">
                   {cells.map((cell) => (
                     <div
                       className="w-[300px] shrink-0"
-                      key={groupValueKey(cell.coordinate.column.value)}
+                      key={columnKey(cell.coordinate.column)}
                     >
                       {renderCell({
                         cell,

--- a/packages/workspace-ui/src/kanban-view.test.ts
+++ b/packages/workspace-ui/src/kanban-view.test.ts
@@ -109,9 +109,11 @@ describe("workspace kanban view adapter", () => {
     const presentation = presentKanbanBoard({ matrix, state });
 
     expect(groupBy).toBe("_status");
-    expect(presentation.columns.map((column) => column.value)).toEqual([
-      "open",
-    ]);
+    expect(
+      presentation.columns
+        .filter((column) => column.type === "group")
+        .map((column) => column.group.value),
+    ).toEqual(["open"]);
     expect(
       presentation.lanes.map((lane) => ({
         collapsed: lane.collapsed,

--- a/packages/workspace-ui/src/kanban-view.ts
+++ b/packages/workspace-ui/src/kanban-view.ts
@@ -4,6 +4,7 @@ import {
   orderKanbanCellsByColumns,
   resolveKanbanGrouping,
   type KanbanBoardCell,
+  type KanbanBoardColumn,
   type KanbanBoardLane,
   type KanbanBoardMatrix,
   type KanbanBuiltInGroup,
@@ -248,12 +249,19 @@ const orderGroups = (
 };
 
 const isGroupEmpty = <TRow>(
-  group: KanbanGroup,
+  group: KanbanBoardColumn,
   matrix: KanbanBoardMatrix<TRow>,
 ): boolean =>
   matrix.cells.every(
     (cell) =>
-      cell.coordinate.column.value !== group.value || cell.rows.length === 0,
+      cell.coordinate.column.type !== group.type ||
+      (group.type === "group" &&
+        cell.coordinate.column.type === "group" &&
+        cell.coordinate.column.group.value !== group.group.value) ||
+      (group.type === "destination" &&
+        cell.coordinate.column.type === "destination" &&
+        cell.coordinate.column.destination.id !== group.destination.id) ||
+      cell.rows.length === 0,
   );
 
 const isLaneEmpty = <TRow>(
@@ -276,7 +284,7 @@ export type KanbanPresentedLane<TRow> = {
 };
 
 export type KanbanBoardPresentation<TRow> = {
-  columns: KanbanGroup[];
+  columns: KanbanBoardColumn[];
   lanes: KanbanPresentedLane<TRow>[];
   matrix: KanbanBoardMatrix<TRow>;
 };
@@ -293,11 +301,24 @@ export const presentKanbanBoard = <TRow>({
   matrix: KanbanBoardMatrix<TRow>;
   state: KanbanSavedViewState;
 }): KanbanBoardPresentation<TRow> => {
-  const columns = orderGroups(matrix.columns, state.group.orderedGroups).filter(
-    (group) =>
-      !refersToGroup(state.group.hiddenGroups, group) &&
-      (state.group.emptyGroups === "show" || !isGroupEmpty(group, matrix)),
-  );
+  const columns: KanbanBoardColumn[] = [
+    ...orderGroups(
+      matrix.columns
+        .filter(
+          (column): column is { group: KanbanGroup; type: "group" } =>
+            column.type === "group",
+        )
+        .map((column) => column.group),
+      state.group.orderedGroups,
+    )
+      .map((group) => ({ group, type: "group" as const }))
+      .filter(
+        (column) =>
+          !refersToGroup(state.group.hiddenGroups, column.group) &&
+          (state.group.emptyGroups === "show" || !isGroupEmpty(column, matrix)),
+      ),
+    ...matrix.columns.filter((column) => column.type === "destination"),
+  ];
   const subgroupState = state.subgroup;
   const orderedLanes =
     subgroupState === null || matrix.lanes.some((lane) => lane.type === "none")


### PR DESCRIPTION
Adds typed per-cell counts to the reusable Kanban subgroup primitive and models terminal destinations as real matrix columns with destination-aware drop intents. Empty intersections remain explicit zero-count cells, and destinations remain aligned across every lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Kanban boards can now include terminal destination columns as drop targets.
  - Drop actions report the selected destination, including when no group changes are required.
  - Cell renderers now receive each cell’s row count, including zero for empty cells.
  - Added typed support for configuring and consuming Kanban destinations.

- **Bug Fixes**
  - Empty destination and matrix cells now produce consistent drop and count information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->