### PR TITLE
test: scale legislation property setup timeout

### DIFF
--- a/apps/api/src/handlers/legislation/public-reads.db.test.ts
+++ b/apps/api/src/handlers/legislation/public-reads.db.test.ts
@@ -4,7 +4,10 @@ import { drizzle } from "drizzle-orm/pglite";
 import fc from "fast-check";
 
 import type { Block, DocumentAst } from "@stll/legal-ast/document-ast";
-import { propertyConfig } from "@stll/property-testing";
+import {
+  propertyConfig,
+  propertyTestTimeout,
+} from "@stll/property-testing";
 import { foldToAscii } from "@stll/text-normalize";
 
 import {
@@ -370,7 +373,7 @@ beforeAll(
       );
     legislationDb = readDb;
   },
-  { timeout: 30_000 },
+  { timeout: propertyTestTimeout(30_000) },
 );
 
 afterAll(async () => {

--- a/apps/api/src/handlers/legislation/public-reads.db.test.ts
+++ b/apps/api/src/handlers/legislation/public-reads.db.test.ts
@@ -4,10 +4,7 @@ import { drizzle } from "drizzle-orm/pglite";
 import fc from "fast-check";
 
 import type { Block, DocumentAst } from "@stll/legal-ast/document-ast";
-import {
-  propertyConfig,
-  propertyTestTimeout,
-} from "@stll/property-testing";
+import { propertyConfig, propertyTestTimeout } from "@stll/property-testing";
 import { foldToAscii } from "@stll/text-normalize";
 
 import {


### PR DESCRIPTION
## Summary\n- apply the shared property-test timeout scaling helper to legislation fixture setup\n- keep the timeout aligned with nightly property-run scaling\n\n## Validation\n- \n- local focused tests/checks are unavailable in the isolated worktree because dependencies are not installed\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test timeout handling to make legislation read tests more reliable.
  * No user-facing functionality has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->