### PR TITLE
feat(web): fold reporter apparatus behind a disclosure

### DIFF
--- a/apps/web/src/components/legal-reader/reader.css
+++ b/apps/web/src/components/legal-reader/reader.css
@@ -242,3 +242,25 @@ div:has(> p[data-note="footnote"]) + div > p[data-note="footnote"]:first-child {
 .reader-note-back:hover {
   text-decoration: underline;
 }
+
+/* Reporter apparatus disclosure: quiet, one line, out of the reading flow
+   until asked for. */
+.reader-apparatus {
+  margin-block: 0.75em;
+}
+
+.reader-apparatus-summary {
+  cursor: pointer;
+  font-family: var(--font-sans, sans-serif);
+  font-size: 0.78rem;
+  color: var(--color-muted-foreground);
+  user-select: none;
+}
+
+.reader-apparatus-summary:hover {
+  color: var(--color-foreground);
+}
+
+.reader-apparatus[open] > .reader-apparatus-summary {
+  margin-bottom: 0.5em;
+}

--- a/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { Fragment, useRef } from "react";
 import type { CSSProperties, ReactElement, ReactNode } from "react";
 
 import { useTranslations } from "use-intl";
@@ -74,6 +74,49 @@ type DecisionTextProps = {
 const SUPPLEMENT_LEGAL_SENTENCE_ID = "supplement-legal-sentence";
 const SUPPLEMENT_ABSTRACT_ID = "supplement-abstract";
 const DECISION_REFERENCE_ID = "decision-reference";
+
+/**
+ * Wrap runs of apparatus blocks in one collapsed disclosure while leaving
+ * every other block inline. The callback renders a single block exactly as
+ * the caller always did.
+ */
+const groupApparatusWrap = (
+  blocks: readonly Block[],
+  apparatusIds: ReadonlySet<string>,
+  apparatusLabel: string,
+  renderBlock: (block: Block) => ReactNode,
+): ReactNode[] => {
+  const out: ReactNode[] = [];
+  let run: Block[] = [];
+  const flush = () => {
+    if (run.length === 0) {
+      return;
+    }
+    const runBlocks = run;
+    run = [];
+    out.push(
+      <details
+        className="reader-apparatus"
+        key={`apparatus-${runBlocks[0]?.id ?? String(out.length)}`}
+      >
+        <summary className="reader-apparatus-summary">{apparatusLabel}</summary>
+        {runBlocks.map((block) => (
+          <Fragment key={block.id}>{renderBlock(block)}</Fragment>
+        ))}
+      </details>,
+    );
+  };
+  for (const block of blocks) {
+    if (apparatusIds.has(block.id)) {
+      run.push(block);
+      continue;
+    }
+    flush();
+    out.push(<Fragment key={block.id}>{renderBlock(block)}</Fragment>);
+  }
+  flush();
+  return out;
+};
 
 const isHoldingBlock = (block: Block): boolean =>
   block.type === "paragraph" && block.role === "holding";
@@ -388,17 +431,30 @@ const buildAnchorsByPieceId = ({
 const renderBlocksWithHoldingZone = ({
   activeMatchIndex,
   anchorsByPieceId,
+  apparatusLabel,
   blocks,
   rangesByPieceId,
   sectionMap,
 }: {
   activeMatchIndex: number;
   anchorsByPieceId: Record<string, TextAnchor[]>;
+  /** Translated label for the folded reporter-apparatus disclosure. */
+  apparatusLabel: string;
   blocks: Block[];
   rangesByPieceId: Record<string, SearchMatchRange[]>;
   sectionMap?: Map<string, { cssVar: string; headingId: string }> | undefined;
 }): ReactNode[] => {
   const result: ReactNode[] = [];
+
+  // Reporter apparatus (counsel appearances, syllabus, headnotes) folds
+  // behind a disclosure, the way dedicated reporter apps treat CAP head
+  // matter: not the court's words, one click away rather than gone.
+  const apparatusIds = new Set<string>();
+  for (const block of blocks) {
+    if (block.type === "paragraph" && block.role === "apparatus") {
+      apparatusIds.add(block.id);
+    }
+  }
 
   // The last paragraph of each footnote carries the return arrow. A block
   // ends its footnote when the one after it is not a continuation (a
@@ -460,28 +516,32 @@ const renderBlocksWithHoldingZone = ({
         key={`section-${group.blocks.at(0)?.id}`}
         style={borderStyle}
       >
-        {group.blocks.map((block) =>
-          isHoldingBlock(block) ? (
-            <div className="font-[520]" key={block.id}>
+        {groupApparatusWrap(
+          group.blocks,
+          apparatusIds,
+          apparatusLabel,
+          (block) =>
+            isHoldingBlock(block) ? (
+              <div className="font-[520]" key={block.id}>
+                <BlockRenderer
+                  activeMatchIndex={activeMatchIndex}
+                  anchorsByPieceId={anchorsByPieceId}
+                  block={block}
+                  rangesByPieceId={rangesByPieceId}
+                  variant="case-law"
+                />
+              </div>
+            ) : (
               <BlockRenderer
                 activeMatchIndex={activeMatchIndex}
                 anchorsByPieceId={anchorsByPieceId}
                 block={block}
+                key={block.id}
+                noteBackJump={footnoteLastIds.has(block.id)}
                 rangesByPieceId={rangesByPieceId}
                 variant="case-law"
               />
-            </div>
-          ) : (
-            <BlockRenderer
-              activeMatchIndex={activeMatchIndex}
-              anchorsByPieceId={anchorsByPieceId}
-              block={block}
-              key={block.id}
-              noteBackJump={footnoteLastIds.has(block.id)}
-              rangesByPieceId={rangesByPieceId}
-              variant="case-law"
-            />
-          ),
+            ),
         )}
       </div>,
     );
@@ -644,6 +704,7 @@ export const DecisionText = ({
         )}
         {renderBlocksWithHoldingZone({
           activeMatchIndex,
+          apparatusLabel: t("caseLaw.reader.headMatter"),
           anchorsByPieceId: buildAnchorsByPieceId({
             annotations: hydrated ? annotationAnchors : NO_ANNOTATION_ANCHORS,
             blocks: visibleBlocks,

--- a/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
+++ b/apps/web/src/features/case-law/components/case-viewer/decision-text.tsx
@@ -649,8 +649,22 @@ export const DecisionText = ({
     const activeMatch = articleRef.current?.querySelector<HTMLElement>(
       `[data-reader-match-index="${activeMatchIndex}"]`,
     );
+    if (!activeMatch) {
+      return;
+    }
 
-    activeMatch?.scrollIntoView({
+    // A match inside the folded reporter apparatus is invisible while its
+    // <details> stays closed, and scrolling to a hidden descendant reveals
+    // nothing: open every enclosing disclosure first.
+    for (
+      let disclosure = activeMatch.closest("details");
+      disclosure !== null;
+      disclosure = disclosure.parentElement?.closest("details") ?? null
+    ) {
+      disclosure.open = true;
+    }
+
+    activeMatch.scrollIntoView({
       behavior: "smooth",
       block: "center",
       inline: "nearest",

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -487,6 +487,9 @@
         "publishedOnWeb": "منشور على الويب"
       },
       "statutes": "النصوص التشريعية المطبَّقة"
+    },
+    "reader": {
+      "headMatter": "الديباجة"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -466,6 +466,9 @@
       "sentence": "الجملة {value}",
       "subsection": "الفقرة {value}"
     },
+    "reader": {
+      "headMatter": "الديباجة"
+    },
     "seo": {
       "browse": "تصفّح الاجتهاد القضائي",
       "countries": "الدول",
@@ -487,9 +490,6 @@
         "publishedOnWeb": "منشور على الويب"
       },
       "statutes": "النصوص التشريعية المطبَّقة"
-    },
-    "reader": {
-      "headMatter": "الديباجة"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -466,6 +466,9 @@
       "sentence": "věta {value}",
       "subsection": "odst. {value}"
     },
+    "reader": {
+      "headMatter": "Úvodní část"
+    },
     "seo": {
       "browse": "Procházet judikaturu",
       "countries": "Země",
@@ -487,9 +490,6 @@
         "publishedOnWeb": "Zveřejněno na webu"
       },
       "statutes": "Dotčené předpisy"
-    },
-    "reader": {
-      "headMatter": "Úvodní část"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -487,6 +487,9 @@
         "publishedOnWeb": "Zveřejněno na webu"
       },
       "statutes": "Dotčené předpisy"
+    },
+    "reader": {
+      "headMatter": "Úvodní část"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -466,6 +466,9 @@
       "sentence": "Satz {value}",
       "subsection": "Abs. {value}"
     },
+    "reader": {
+      "headMatter": "Rubrum"
+    },
     "seo": {
       "browse": "Rechtsprechung durchsuchen",
       "countries": "Länder",
@@ -487,9 +490,6 @@
         "publishedOnWeb": "Im Web veröffentlicht"
       },
       "statutes": "Anwendbare Vorschriften"
-    },
-    "reader": {
-      "headMatter": "Rubrum"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -487,6 +487,9 @@
         "publishedOnWeb": "Im Web veröffentlicht"
       },
       "statutes": "Anwendbare Vorschriften"
+    },
+    "reader": {
+      "headMatter": "Rubrum"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -466,6 +466,9 @@
       "sentence": "sentence {value}",
       "subsection": "para. {value}"
     },
+    "reader": {
+      "headMatter": "Head matter"
+    },
     "seo": {
       "browse": "Browse case law",
       "countries": "Countries",
@@ -487,9 +490,6 @@
         "publishedOnWeb": "Published on web"
       },
       "statutes": "Applicable statutes"
-    },
-    "reader": {
-      "headMatter": "Head matter"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -487,6 +487,9 @@
         "publishedOnWeb": "Published on web"
       },
       "statutes": "Applicable statutes"
+    },
+    "reader": {
+      "headMatter": "Head matter"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -466,6 +466,9 @@
       "sentence": "frase {value}",
       "subsection": "apdo. {value}"
     },
+    "reader": {
+      "headMatter": "Encabezamiento"
+    },
     "seo": {
       "browse": "Explorar jurisprudencia",
       "countries": "Países",
@@ -487,9 +490,6 @@
         "publishedOnWeb": "Publicado en la web"
       },
       "statutes": "Normas aplicables"
-    },
-    "reader": {
-      "headMatter": "Encabezamiento"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -487,6 +487,9 @@
         "publishedOnWeb": "Publicado en la web"
       },
       "statutes": "Normas aplicables"
+    },
+    "reader": {
+      "headMatter": "Encabezamiento"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -466,6 +466,9 @@
       "sentence": "lause {value}",
       "subsection": "lg {value}"
     },
+    "reader": {
+      "headMatter": "Päis"
+    },
     "seo": {
       "browse": "Sirvi kohtupraktikat",
       "countries": "Riigid",
@@ -487,9 +490,6 @@
         "publishedOnWeb": "Veebis avaldatud"
       },
       "statutes": "Kohaldatavad õigusaktid"
-    },
-    "reader": {
-      "headMatter": "Päis"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -487,6 +487,9 @@
         "publishedOnWeb": "Veebis avaldatud"
       },
       "statutes": "Kohaldatavad õigusaktid"
+    },
+    "reader": {
+      "headMatter": "Päis"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -487,6 +487,9 @@
         "publishedOnWeb": "Publié sur le web"
       },
       "statutes": "Textes applicables"
+    },
+    "reader": {
+      "headMatter": "En-tête"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -466,6 +466,9 @@
       "sentence": "phrase {value}",
       "subsection": "al. {value}"
     },
+    "reader": {
+      "headMatter": "En-tête"
+    },
     "seo": {
       "browse": "Parcourir la jurisprudence",
       "countries": "Pays",
@@ -487,9 +490,6 @@
         "publishedOnWeb": "Publié sur le web"
       },
       "statutes": "Textes applicables"
-    },
-    "reader": {
-      "headMatter": "En-tête"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -487,6 +487,9 @@
         "publishedOnWeb": "Weben közzétéve"
       },
       "statutes": "Alkalmazandó jogszabályok"
+    },
+    "reader": {
+      "headMatter": "Fejrész"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -466,6 +466,9 @@
       "sentence": "{value}. mondat",
       "subsection": "({value}) bekezdés"
     },
+    "reader": {
+      "headMatter": "Fejrész"
+    },
     "seo": {
       "browse": "Ítélkezési gyakorlat böngészése",
       "countries": "Országok",
@@ -487,9 +490,6 @@
         "publishedOnWeb": "Weben közzétéve"
       },
       "statutes": "Alkalmazandó jogszabályok"
-    },
-    "reader": {
-      "headMatter": "Fejrész"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -466,6 +466,9 @@
       "sentence": "{value} sakinys",
       "subsection": "{value} d."
     },
+    "reader": {
+      "headMatter": "Antraštinė dalis"
+    },
     "seo": {
       "browse": "Naršyti teismų praktiką",
       "countries": "Šalys",
@@ -487,9 +490,6 @@
         "publishedOnWeb": "Paskelbta internete"
       },
       "statutes": "Taikomi teisės aktai"
-    },
-    "reader": {
-      "headMatter": "Antraštinė dalis"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -487,6 +487,9 @@
         "publishedOnWeb": "Paskelbta internete"
       },
       "statutes": "Taikomi teisės aktai"
+    },
+    "reader": {
+      "headMatter": "Antraštinė dalis"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -487,6 +487,9 @@
         "publishedOnWeb": "Publicēts tīmeklī"
       },
       "statutes": "Piemērojamie tiesību akti"
+    },
+    "reader": {
+      "headMatter": "Ievaddaļa"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -466,6 +466,9 @@
       "sentence": "{value}. teikums",
       "subsection": "{value}. daļa"
     },
+    "reader": {
+      "headMatter": "Ievaddaļa"
+    },
     "seo": {
       "browse": "Pārlūkot judikatūru",
       "countries": "Valstis",
@@ -487,9 +490,6 @@
         "publishedOnWeb": "Publicēts tīmeklī"
       },
       "statutes": "Piemērojamie tiesību akti"
-    },
-    "reader": {
-      "headMatter": "Ievaddaļa"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -469,6 +469,9 @@ type Messages = {
       "sentence": "sentence {value}";
       "subsection": "para. {value}";
     };
+    "reader": {
+      "headMatter": "Head matter";
+    };
     "seo": {
       "browse": "Browse case law";
       "countries": "Countries";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -466,6 +466,9 @@
       "sentence": "zdanie {value}",
       "subsection": "ust. {value}"
     },
+    "reader": {
+      "headMatter": "Część wstępna"
+    },
     "seo": {
       "browse": "Przeglądaj orzecznictwo",
       "countries": "Kraje",
@@ -487,9 +490,6 @@
         "publishedOnWeb": "Opublikowano w sieci"
       },
       "statutes": "Powołane przepisy"
-    },
-    "reader": {
-      "headMatter": "Część wstępna"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -487,6 +487,9 @@
         "publishedOnWeb": "Opublikowano w sieci"
       },
       "statutes": "Powołane przepisy"
+    },
+    "reader": {
+      "headMatter": "Część wstępna"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -466,6 +466,9 @@
       "sentence": "frase {value}",
       "subsection": "par. {value}"
     },
+    "reader": {
+      "headMatter": "Cabeçalho"
+    },
     "seo": {
       "browse": "Explorar jurisprudência",
       "countries": "Países",
@@ -487,9 +490,6 @@
         "publishedOnWeb": "Publicado na web"
       },
       "statutes": "Normas aplicáveis"
-    },
-    "reader": {
-      "headMatter": "Cabeçalho"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -487,6 +487,9 @@
         "publishedOnWeb": "Publicado na web"
       },
       "statutes": "Normas aplicáveis"
+    },
+    "reader": {
+      "headMatter": "Cabeçalho"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -466,6 +466,9 @@
       "sentence": "veta {value}",
       "subsection": "ods. {value}"
     },
+    "reader": {
+      "headMatter": "Úvodná časť"
+    },
     "seo": {
       "browse": "Prehliadať judikatúru",
       "countries": "Krajiny",
@@ -487,9 +490,6 @@
         "publishedOnWeb": "Zverejnené na webe"
       },
       "statutes": "Aplikované predpisy"
-    },
-    "reader": {
-      "headMatter": "Úvodná časť"
     }
   },
   "catalogue": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -487,6 +487,9 @@
         "publishedOnWeb": "Zverejnené na webe"
       },
       "statutes": "Aplikované predpisy"
+    },
+    "reader": {
+      "headMatter": "Úvodná časť"
     }
   },
   "catalogue": {

--- a/packages/legal-ast/src/document-ast.ts
+++ b/packages/legal-ast/src/document-ast.ts
@@ -54,6 +54,10 @@ export type ParagraphRole =
   /** Other centered reporter front matter: docket line, argument and
    * decision dates. */
   | "front-matter"
+  /** Reporter-authored apparatus around the decision: counsel appearances,
+   * syllabus, headnotes, the panel line. Not the court's own words —
+   * readers may fold it away. */
+  | "apparatus"
   | "unknown";
 
 export type ParagraphNote = {
@@ -357,6 +361,7 @@ const paragraphEntries = {
       "quote",
       "parties",
       "front-matter",
+      "apparatus",
       "unknown",
     ]),
   ),


### PR DESCRIPTION
Counsel appearances, syllabus and headnotes are the reporter's apparatus around a decision, not the court's own words. A new `apparatus` paragraph role lets parsers mark them, and the reader folds each run behind a quiet one-line disclosure ("Head matter", translated), expanded in one click. Other roles are untouched, so corpora whose opening paragraphs are substantive text keep rendering inline.

https://claude.ai/code/session_01HkFVj9TLAggYEsdsfZhad8