### PR TITLE
fix(api): read a wrapped provider status from the run-error code

### DIFF
--- a/apps/api/src/lib/ai-error.test.ts
+++ b/apps/api/src/lib/ai-error.test.ts
@@ -33,6 +33,16 @@ const tanStackRunError = (code: number) =>
     message: `provider responded ${code}`,
   }) satisfies Record<string, unknown>;
 
+// The transport wrapper the AI stack raises for a provider RUN_ERROR: its own
+// status is a fixed 502 and the provider's status rides on `code`. An adapter
+// forwards the structured body as `rawEvent` only when the SDK exception
+// exposes one, so the code is often all the wrapper carries.
+const wrappedRunError = (code: number) =>
+  new HandlerError({
+    ...tanStackRunError(code),
+    status: 502,
+  });
+
 const providerErrorBody = (code: number, status: string) =>
   ({
     error: {
@@ -166,6 +176,28 @@ describe("classifyAIError", () => {
     expect(classifyAIError(tanStackProviderError(503))).toBe(
       "provider_unavailable",
     );
+  });
+
+  test("names the provider status the transport wrapper carries as its code", () => {
+    expect(classifyAIError(wrappedRunError(429))).toBe("quota_exhausted");
+    expect(classifyAIError(wrappedRunError(402))).toBe("provider_billing");
+    expect(classifyAIError(wrappedRunError(404))).toBe("model_unavailable");
+    expect(classifyAIError(wrappedRunError(401))).toBe(
+      "provider_credentials_rejected",
+    );
+    expect(classifyAIError(wrappedRunError(503))).toBe("provider_unavailable");
+  });
+
+  test("does not read the transport wrapper's own status as the provider's", () => {
+    // The 502 is this service's, chosen for any run error alike, so it is
+    // evidence of nothing: naming it would report a provider outage for a
+    // failure that never said what went wrong.
+    const error = new HandlerError({
+      message: "generation failed",
+      status: 502,
+    });
+
+    expect(classifyAIError(error)).toBe("unknown");
   });
 
   test("reads the status from a nested provider error body", () => {
@@ -352,6 +384,9 @@ describe("providerStatusFields", () => {
       [apiCallError(503), "503"],
       [tanStackProviderError(429), "429"],
       [providerErrorBody(404, "NOT_FOUND"), "404"],
+      // The wrapper's fixed 502 would report an outage for an unmapped
+      // provider status; the code it carries is the one the classifier read.
+      [wrappedRunError(403), "403"],
     ] as const) {
       expect(providerStatusFields(error)).toEqual({
         "error.provider.status": status,

--- a/apps/api/src/lib/ai-error.ts
+++ b/apps/api/src/lib/ai-error.ts
@@ -58,18 +58,24 @@ const providerStatusCode = (error: unknown): number | null => {
     return null;
   }
 
-  // Range-checked like the nested body fields below: an integer outside the
-  // HTTP range is not a status, and treating one as one both mis-names the
-  // failure (>= 500 would read as a provider outage) and puts a meaningless
-  // number in the failure log.
-  const statusCode = error["statusCode"];
-  if (isHttpStatus(statusCode)) {
-    return statusCode;
-  }
+  // A `HandlerError` answers with a status of this service's own: the AI stack
+  // wraps a provider failure in a fixed 502 and keeps the provider's status in
+  // `code`. Reading `status` off one names every wrapped failure by the
+  // wrapper, so only the provider-owned fields below are read for it.
+  if (!HandlerError.is(error)) {
+    // Range-checked like the nested body fields below: an integer outside the
+    // HTTP range is not a status, and treating one as one both mis-names the
+    // failure (>= 500 would read as a provider outage) and puts a meaningless
+    // number in the failure log.
+    const statusCode = error["statusCode"];
+    if (isHttpStatus(statusCode)) {
+      return statusCode;
+    }
 
-  const status = error["status"];
-  if (isHttpStatus(status)) {
-    return status;
+    const status = error["status"];
+    if (isHttpStatus(status)) {
+      return status;
+    }
   }
 
   // TanStack's RUN_ERROR contract carries `code` as a string. Its adapters
@@ -193,14 +199,13 @@ const classifyAIErrorInternal = (
     // retrying won't help.
     //
     // Only a provider status or explicit provider-owned credential marker
-    // counts: `HandlerError` carries a `status` of its own, and this service
-    // raises its own 401 refusals, whose curated copy this would otherwise
-    // replace. A provider 403 stays unmapped because it is ambiguous
-    // (permission, region, or account state) where a 401 is not.
+    // counts, which is what keeps a 401 this service raised itself out of
+    // here: its curated copy would otherwise be replaced by the provider's.
+    // A provider 403 stays unmapped because it is ambiguous (permission,
+    // region, or account state) where a 401 is not.
     if (
-      (statusCode === 401 ||
-        (statusCode === null && isProviderCredentialRejection(error))) &&
-      !HandlerError.is(error)
+      statusCode === 401 ||
+      (statusCode === null && isProviderCredentialRejection(error))
     ) {
       return "provider_credentials_rejected";
     }
@@ -284,10 +289,9 @@ const isChatTerminalError = (error: unknown): boolean =>
  * configuration state the caller can act on (no key for the role, 403; a
  * provider or model that does not serve it, 400). They are invisible to
  * `classifyAIError`, which names failures from provider HTTP statuses and
- * explicit provider-owned markers; `HandlerError` carries a `status` of its
- * own, so a 403 reaches the classifier looking like a provider error, matches
- * none of the mapped statuses, and falls through to `unknown`: "a shape this
- * code does not anticipate", the exact opposite of what it is.
+ * explicit provider-owned markers, and a status this service chose is neither:
+ * such a refusal falls through to `unknown`, "a shape this code does not
+ * anticipate", the exact opposite of what it is.
  *
  * A `ChatTerminalError` is invisible to the classifier for the same reason,
  * and carries no status at all to fall back on: the chat stream constructs it

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -17,6 +17,7 @@ import {
 } from "@stll/ai-catalog";
 
 import type { CachingDecision } from "@/api/lib/ai-config";
+import { classifyAIError } from "@/api/lib/ai-error";
 import { toSafeId } from "@/api/lib/branded-types";
 import {
   generateTanStackObjectForRole,
@@ -776,6 +777,30 @@ describe("TanStack AI text generation", () => {
       message: "OpenAI rejected the request.",
       status: 502,
     });
+  });
+
+  test("classifies provider statuses after the run-error boundary", async () => {
+    capturedChatOptions.length = 0;
+    nextChatResult = createRunErrorStream({
+      code: "429",
+      message: "OpenAI rate limit exceeded.",
+    });
+
+    const caught = await generateTextForTestModel({
+      caching: noCaching,
+      organizationId: null,
+      orgAIConfig: null,
+      prompt: "Say hello.",
+      role: "chat",
+      serviceTier: "standard",
+      tenantWorkspaceIds: [],
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(caught).toMatchObject({ code: "429", status: 502 });
+    expect(classifyAIError(caught)).toBe("quota_exhausted");
   });
 
   test("propagates provider run errors from streaming text", async () => {


### PR DESCRIPTION
## Proposed change

`classifyAIError` names an AI failure from the provider's HTTP status. The AI stack wraps a provider `RUN_ERROR` in a `HandlerError` with a fixed 502 and keeps the provider's own status in `code` (`tanStackRunError`, `apps/api/src/lib/tanstack-ai-generate.ts`), but `providerStatusCode` read `status` before `code`. The wrapper's 502 therefore shadowed the provider status on the one shape that carries it: an exhausted quota (429), a provider billing problem (402) and a retired model (404) all read back as 502 and were named `provider_unavailable`, so a caller going through `aiHandlerError` answered "the provider is temporarily unavailable, try again shortly" for a failure retrying cannot clear. The cause walk does not cover this either: an adapter forwards the structured body as `rawEvent` only when the SDK exception exposes one, and without it the wrapper holds nothing but the code.

The fix reads the two kinds of status apart. A `HandlerError`'s `status`/`statusCode` is a status this service chose, never a provider's, so `providerStatusCode` skips those fields for one and reads the provider-owned `code` and nested error body instead. That also retires the `!HandlerError.is(error)` guard on the 401 branch, which was there to undo the same shadowing for a single status: a 401 this service raised itself no longer reaches the branch at all, while a provider 401 forwarded on the code now does.

One consequence worth naming: a wrapper that carries no provider evidence (no code, no cause) now classifies as `unknown` instead of `provider_unavailable`. Its 502 is the same 502 every run error gets, so it was never evidence of an outage; `providerStatusFields` keeps reporting whatever status such a failure does carry.

Covered by unit tests over the wrapper shape (each provider status on the code, and the bare wrapper), plus the existing cause-chain and self-raised-refusal cases.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode. (not applicable: server-side error classification, no UI surface)
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (not applicable)


---
_Generated by [Claude Code](https://claude.ai/code/session_012ABonTmgsxMHCYddm6obLh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of AI service errors so provider responses are classified using the correct status.
  - Prevented internal service gateway errors from being incorrectly reported as provider outages.
  - Improved recognition of quota, authentication, payment, not-found and availability errors.
  - AI requests affected by provider rate limits now surface consistently as a 502 error with quota-related classification.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->