### PR TITLE
fix(web): keep non-V8 stack frames when redacting stacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       mobile_build_required: ${{ steps.changed-files.outputs.mobile_build_required }}
       package_checks_required: ${{ steps.changed-files.outputs.package_checks_required }}
       release_typecheck_required: ${{ steps.changed-files.outputs.release_typecheck_required }}
+      stack_redaction_browsers_required: ${{ steps.changed-files.outputs.stack_redaction_browsers_required }}
       web_build_required: ${{ steps.changed-files.outputs.web_build_required }}
       web_image_smoke_required: ${{ steps.changed-files.outputs.web_image_smoke_required }}
       windows_scripts_required: ${{ steps.changed-files.outputs.windows_scripts_required }}
@@ -106,6 +107,7 @@ jobs:
               echo "mobile_build_required=true"
               echo "package_checks_required=true"
               echo "release_typecheck_required=false"
+              echo "stack_redaction_browsers_required=true"
               echo "web_build_required=true"
               echo "web_image_smoke_required=true"
               echo "windows_scripts_required=true"
@@ -130,6 +132,7 @@ jobs:
               echo "mobile_build_required=false"
               echo "package_checks_required=true"
               echo "release_typecheck_required=false"
+              echo "stack_redaction_browsers_required=false"
               echo "web_build_required=false"
               echo "web_image_smoke_required=false"
               echo "windows_scripts_required=false"
@@ -165,6 +168,7 @@ jobs:
           legal_atlas_image_required=false
           mobile_build_required=false
           release_typecheck_required=false
+          stack_redaction_browsers_required=false
           web_build_required=false
           web_image_smoke_required=false
           windows_scripts_required=false
@@ -175,6 +179,11 @@ jobs:
             case "$file" in
               .github/workflows/agent-sandbox-canary.yml|.github/workflows/ci.yml|packages/agent-engine/*|package.json|bun.lock|scripts/bun-ci-retry.sh)
                 agent_sandbox_docker_required=true
+                ;;
+            esac
+            case "$file" in
+              apps/web/src/lib/analytics/posthog.ts|apps/web/src/lib/analytics/stack-redaction.ts|apps/web/src/lib/analytics/error-diagnostics.ts|apps/web/e2e/stack-redaction/*|apps/web/e2e/playwright.stack-redaction.config.ts|apps/web/e2e/tsconfig.json|apps/web/tsconfig.json|apps/web/package.json|scripts/bun-ci-retry.sh|bunfig.toml|package.json|bun.lock|.npmrc|.github/workflows/ci.yml)
+                stack_redaction_browsers_required=true
                 ;;
             esac
             case "$file" in
@@ -247,6 +256,7 @@ jobs:
             echo "mobile_build_required=$mobile_build_required"
             echo "package_checks_required=$package_checks_required"
             echo "release_typecheck_required=$release_typecheck_required"
+            echo "stack_redaction_browsers_required=$stack_redaction_browsers_required"
             echo "web_build_required=$web_build_required"
             echo "web_image_smoke_required=$web_image_smoke_required"
             echo "windows_scripts_required=$windows_scripts_required"
@@ -1629,6 +1639,36 @@ jobs:
             /tmp/web-production.log
           retention-days: 7
 
+  stack-redaction-browsers:
+    needs: ci-plan
+    if: >-
+      (needs.ci-plan.outputs.trusted == 'true'
+       || github.event_name == 'workflow_dispatch')
+      && needs.ci-plan.outputs.stack_redaction_browsers_required == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: stella/.github/actions/setup-bun-cached@2703e4d3ed115089e593e4ca5cc749be4a5d8cee
+
+      - name: Install dependencies
+        run: bash scripts/bun-ci-retry.sh --ignore-scripts
+        env:
+          NPM_TOKEN: ""
+
+      - name: Install Firefox and WebKit
+        run: bunx playwright install --with-deps firefox webkit
+
+      - name: Test browser stack redaction
+        run: bun --filter @stll/web test:e2e:stack-redaction
+
   e2e-vite-canary:
     needs: ci-plan
     if: >-
@@ -2291,6 +2331,7 @@ jobs:
         landing-build,
         marketing-screenshots,
         e2e,
+        stack-redaction-browsers,
         api-image-deps,
         legal-atlas-image,
         windows-scripts,
@@ -2319,6 +2360,7 @@ jobs:
           PLAN_RESULT: ${{ needs.ci-plan.result }}
           POSTGRES_SUITES_RESULT: ${{ needs.postgres-suites.result }}
           RELEASE_TYPECHECK_RESULT: ${{ needs.release-typecheck.result }}
+          STACK_REDACTION_BROWSERS_RESULT: ${{ needs.stack-redaction-browsers.result }}
           TYPECHECK_BASELINE_RESULT: ${{ needs.typecheck-baseline.result }}
           WEB_RESULT: ${{ needs.web-build.result }}
           WEB_IMAGE_SMOKE_RESULT: ${{ needs.web-image-smoke.result }}
@@ -2338,6 +2380,7 @@ jobs:
                   || "$CODE_QUALITY_RESULT" == "failure" || "$CODE_QUALITY_RESULT" == "cancelled" \
                   || "$POSTGRES_SUITES_RESULT" == "failure" || "$POSTGRES_SUITES_RESULT" == "cancelled" \
                   || "$RELEASE_TYPECHECK_RESULT" == "failure" || "$RELEASE_TYPECHECK_RESULT" == "cancelled" \
+                  || "$STACK_REDACTION_BROWSERS_RESULT" == "failure" || "$STACK_REDACTION_BROWSERS_RESULT" == "cancelled" \
                   || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" \
                   || "$WEB_RESULT" == "failure" || "$WEB_RESULT" == "cancelled" \
                   || "$WEB_IMAGE_SMOKE_RESULT" == "failure" || "$WEB_IMAGE_SMOKE_RESULT" == "cancelled" \
@@ -2375,12 +2418,12 @@ jobs:
 
           # "cancelled" means cancel-in-progress replaced this
           # run with a newer one; the newer run is authoritative.
-          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "cancelled" || "$CI_RESULT" == "cancelled" || "$COLLAB_REDIS_RESULT" == "cancelled" || "$CODE_QUALITY_RESULT" == "cancelled" || "$POSTGRES_SUITES_RESULT" == "cancelled" || "$RELEASE_TYPECHECK_RESULT" == "cancelled" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" || "$WEB_RESULT" == "cancelled" || "$WEB_IMAGE_SMOKE_RESULT" == "cancelled" || "$MOBILE_RESULT" == "cancelled" || "$LANDING_RESULT" == "cancelled" || "$MARKETING_SCREENSHOTS_RESULT" == "cancelled" || "$E2E_RESULT" == "cancelled" || "$API_IMAGE_DEPS_RESULT" == "cancelled" || "$LEGAL_ATLAS_IMAGE_RESULT" == "cancelled" || "$WINDOWS_SCRIPTS_RESULT" == "cancelled" || "$CHANGESET_RESULT" == "cancelled" || "$DESKTOP_CLIPPY_RESULT" == "cancelled" ]]; then
+          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "cancelled" || "$CI_RESULT" == "cancelled" || "$COLLAB_REDIS_RESULT" == "cancelled" || "$CODE_QUALITY_RESULT" == "cancelled" || "$POSTGRES_SUITES_RESULT" == "cancelled" || "$RELEASE_TYPECHECK_RESULT" == "cancelled" || "$STACK_REDACTION_BROWSERS_RESULT" == "cancelled" || "$TYPECHECK_BASELINE_RESULT" == "cancelled" || "$WEB_RESULT" == "cancelled" || "$WEB_IMAGE_SMOKE_RESULT" == "cancelled" || "$MOBILE_RESULT" == "cancelled" || "$LANDING_RESULT" == "cancelled" || "$MARKETING_SCREENSHOTS_RESULT" == "cancelled" || "$E2E_RESULT" == "cancelled" || "$API_IMAGE_DEPS_RESULT" == "cancelled" || "$LEGAL_ATLAS_IMAGE_RESULT" == "cancelled" || "$WINDOWS_SCRIPTS_RESULT" == "cancelled" || "$CHANGESET_RESULT" == "cancelled" || "$DESKTOP_CLIPPY_RESULT" == "cancelled" ]]; then
             echo "CI run was superseded by a newer run (cancel-in-progress). Passing."
             exit 0
           fi
 
-          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "failure" || "$CI_RESULT" == "failure" || "$COLLAB_REDIS_RESULT" == "failure" || "$CODE_QUALITY_RESULT" == "failure" || "$POSTGRES_SUITES_RESULT" == "failure" || "$RELEASE_TYPECHECK_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$WEB_RESULT" == "failure" || "$WEB_IMAGE_SMOKE_RESULT" == "failure" || "$MOBILE_RESULT" == "failure" || "$LANDING_RESULT" == "failure" || "$MARKETING_SCREENSHOTS_RESULT" == "failure" || "$E2E_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "failure" || "$LEGAL_ATLAS_IMAGE_RESULT" == "failure" || "$WINDOWS_SCRIPTS_RESULT" == "failure" || "$CHANGESET_RESULT" == "failure" || "$DESKTOP_CLIPPY_RESULT" == "failure" ]]; then
+          if [[ "$AGENT_SANDBOX_DOCKER_RESULT" == "failure" || "$CI_RESULT" == "failure" || "$COLLAB_REDIS_RESULT" == "failure" || "$CODE_QUALITY_RESULT" == "failure" || "$POSTGRES_SUITES_RESULT" == "failure" || "$RELEASE_TYPECHECK_RESULT" == "failure" || "$STACK_REDACTION_BROWSERS_RESULT" == "failure" || "$TYPECHECK_BASELINE_RESULT" == "failure" || "$WEB_RESULT" == "failure" || "$WEB_IMAGE_SMOKE_RESULT" == "failure" || "$MOBILE_RESULT" == "failure" || "$LANDING_RESULT" == "failure" || "$MARKETING_SCREENSHOTS_RESULT" == "failure" || "$E2E_RESULT" == "failure" || "$API_IMAGE_DEPS_RESULT" == "failure" || "$LEGAL_ATLAS_IMAGE_RESULT" == "failure" || "$WINDOWS_SCRIPTS_RESULT" == "failure" || "$CHANGESET_RESULT" == "failure" || "$DESKTOP_CLIPPY_RESULT" == "failure" ]]; then
             echo "::error::CI checks failed."
             exit 1
           fi

--- a/apps/web/e2e/playwright.stack-redaction.config.ts
+++ b/apps/web/e2e/playwright.stack-redaction.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const BASE_URL = "http://127.0.0.1:4176";
+const IS_CI = process.env["CI"] !== undefined;
+
+export default defineConfig({
+  testDir: "./stack-redaction",
+  testMatch: "stack-redaction.spec.ts",
+  fullyParallel: true,
+  workers: 2,
+  retries: 0,
+  reporter: IS_CI ? [["github"], ["list"]] : [["list"]],
+  timeout: 30_000,
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "firefox-stack-redaction",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit-stack-redaction",
+      use: { ...devices["Desktop Safari"] },
+    },
+  ],
+  webServer: {
+    command: "bun --bun vite --config stack-redaction/vite.config.ts",
+    url: BASE_URL,
+    reuseExistingServer: !IS_CI,
+    timeout: 30_000,
+  },
+});

--- a/apps/web/e2e/stack-redaction/capture-source.ts
+++ b/apps/web/e2e/stack-redaction/capture-source.ts
@@ -1,0 +1,33 @@
+import { captureRedactedException } from "../../src/lib/analytics/stack-redaction";
+
+const PRIVATE_ERROR_MESSAGE = "Privileged matter client name";
+
+type CapturedStack = {
+  name: string;
+  message: string;
+  originalMessage: string;
+  originalStack: string | undefined;
+  redactedStack: string | undefined;
+};
+
+export const captureBrowserError = (): CapturedStack => {
+  const error = new TypeError(PRIVATE_ERROR_MESSAGE);
+  if (typeof error.stack === "string") {
+    error.stack = error.stack.replace(
+      /(?=:\d+:\d+(?:\n|$))/u,
+      "?matter=private#client",
+    );
+  }
+  let redacted: Error | undefined;
+  captureRedactedException(error, (captured) => {
+    redacted = captured;
+  });
+
+  return {
+    name: redacted?.name ?? "",
+    message: redacted?.message ?? "",
+    originalMessage: error.message,
+    originalStack: error.stack,
+    redactedStack: redacted?.stack,
+  };
+};

--- a/apps/web/e2e/stack-redaction/index.html
+++ b/apps/web/e2e/stack-redaction/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Stack redaction browser harness</title>
+  </head>
+  <body>
+    <script type="module" src="/main.ts"></script>
+  </body>
+</html>

--- a/apps/web/e2e/stack-redaction/main.ts
+++ b/apps/web/e2e/stack-redaction/main.ts
@@ -1,0 +1,10 @@
+import { captureBrowserError } from "./capture-source";
+
+declare global {
+  // oxlint-disable-next-line consistent-type-definitions -- global Window augmentation requires interface declaration merging
+  interface Window {
+    captureBrowserError: typeof captureBrowserError;
+  }
+}
+
+window.captureBrowserError = captureBrowserError;

--- a/apps/web/e2e/stack-redaction/stack-redaction.spec.ts
+++ b/apps/web/e2e/stack-redaction/stack-redaction.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+
+const hasOnlyDecimalDigits = (value: string): boolean => {
+  if (value === "") {
+    return false;
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.codePointAt(index);
+    if (code === undefined || code < 48 || code > 57) {
+      return false;
+    }
+  }
+  return true;
+};
+
+test("retains Firefox and WebKit frames without URL metadata", async ({
+  page,
+}) => {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  const captured = await page.evaluate(() => window.captureBrowserError());
+
+  expect(captured.originalMessage).toBe("Privileged matter client name");
+  expect(captured.originalStack).toContain("?matter=private#client");
+  expect(captured.name).toBe("TypeError");
+  expect(captured.message).toBe("");
+  if (captured.redactedStack === undefined) {
+    throw new TypeError("Expected a redacted browser stack");
+  }
+  const [header, ...frames] = captured.redactedStack.split("\n");
+  expect(header).toBe("TypeError:");
+  expect(frames.length).toBeGreaterThan(0);
+  for (const frame of frames) {
+    const symbolSeparator = frame.indexOf("@");
+    const columnSeparator = frame.lastIndexOf(":");
+    const lineSeparator = frame.lastIndexOf(":", columnSeparator - 1);
+    const line = frame.slice(lineSeparator + 1, columnSeparator);
+    const column = frame.slice(columnSeparator + 1);
+    expect(symbolSeparator).toBeGreaterThanOrEqual(0);
+    expect(lineSeparator).toBeGreaterThan(symbolSeparator);
+    expect(columnSeparator).toBeGreaterThan(lineSeparator);
+    expect(hasOnlyDecimalDigits(line)).toBe(true);
+    expect(hasOnlyDecimalDigits(column)).toBe(true);
+  }
+  expect(captured.redactedStack).toContain("captureBrowserError@");
+  expect(captured.redactedStack).not.toContain("Privileged matter client name");
+  expect(captured.redactedStack).not.toContain("matter=private");
+  expect(captured.redactedStack).not.toContain("client");
+});

--- a/apps/web/e2e/stack-redaction/vite.config.ts
+++ b/apps/web/e2e/stack-redaction/vite.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { defineConfig } from "vite";
+
+const ROOT = import.meta.dirname;
+
+export default defineConfig({
+  root: ROOT,
+  server: {
+    host: "127.0.0.1",
+    port: 4176,
+    strictPort: true,
+    fs: { allow: [path.resolve(ROOT, "../..")] },
+  },
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "test:timings": "mkdir -p .cache && bun test --parallel=2 --timings=.cache/e2e-unit-timings.json --update-timings e2e/unit",
     "test:property": "bun test --preload @stll/property-testing/preload $(grep -rlF 'fc.assert' src --include='*.test.ts' --include='*.test.tsx')",
     "test:e2e": "playwright test --config e2e/playwright.config.ts",
+    "test:e2e:stack-redaction": "playwright test --config e2e/playwright.stack-redaction.config.ts",
     "test:e2e:collab": "playwright test --config e2e/playwright.collab.config.ts",
     "test:e2e:ui-playground": "playwright test --config e2e/playwright.ui-playground.config.ts",
     "test:e2e:ui-playground:update": "playwright test --config e2e/playwright.ui-playground.config.ts --update-snapshots=all",

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -569,6 +569,29 @@ describe("PostHog browser analytics adapter", () => {
     expect(captured.stack).toBeUndefined();
   });
 
+  test("captureError cannot infer callsite syntax from a V8 header", () => {
+    const { analytics } = createPostHogAnalytics({
+      host: "https://posthog.test",
+      key: "phc_test",
+    });
+    const injectedFrame =
+      "clientName@https://stella.test/assets/private.js:20:5";
+    const actualFrame =
+      "    at renderMatter (https://stella.test/assets/index.js:10:15)";
+    const error = new Error(
+      `renderMatter@https://stella.test/assets/a.js:1:2\n${injectedFrame}`,
+    );
+    error.stack = [`Error: ${error.message}`, actualFrame].join("\n");
+
+    analytics.captureError(error);
+
+    const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
+    if (!(captured instanceof Error)) {
+      throw new TypeError("Expected a redacted Error");
+    }
+    expect(captured.stack).toBe(["Error:", actualFrame].join("\n"));
+  });
+
   test("captureError survives a cyclic cause chain", () => {
     const { analytics } = createPostHogAnalytics({
       host: "https://posthog.test",

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -344,7 +344,7 @@ describe("PostHog browser analytics adapter", () => {
                 {
                   platform: "web:javascript",
                   filename:
-                    "https://my.stll.app/assets/app.js?token=private-token",
+                    "https://my.stll.app/assets/app.js#access_token=private-token",
                   function: "renderMatter",
                   in_app: true,
                   lineno: 42,
@@ -448,15 +448,26 @@ describe("PostHog browser analytics adapter", () => {
     },
   );
 
-  const QUERY_STRING_FRAMES = {
-    callsite: {
+  const URL_METADATA_FRAMES = {
+    callsiteQuery: {
       frame:
         "renderMatter@https://stella.test/assets/index.js?token=private:10:15",
       safeFrame: "renderMatter@https://stella.test/assets/index.js:10:15",
     },
-    indented: {
+    callsiteFragment: {
+      frame:
+        "renderMatter@https://stella.test/assets/index.js#access_token=private:10:15",
+      safeFrame: "renderMatter@https://stella.test/assets/index.js:10:15",
+    },
+    indentedQuery: {
       frame:
         "    at renderMatter (https://stella.test/assets/index.js?token=private:10:15)",
+      safeFrame:
+        "    at renderMatter (https://stella.test/assets/index.js:10:15)",
+    },
+    indentedFragment: {
+      frame:
+        "    at renderMatter (https://stella.test/assets/index.js#access_token=private:10:15)",
       safeFrame:
         "    at renderMatter (https://stella.test/assets/index.js:10:15)",
     },
@@ -468,8 +479,8 @@ describe("PostHog browser analytics adapter", () => {
     },
   } as const;
 
-  test.each(Object.entries(QUERY_STRING_FRAMES))(
-    "captureError removes query strings from %s frames",
+  test.each(Object.entries(URL_METADATA_FRAMES))(
+    "captureError removes URL metadata from %s frames",
     (_syntax, { frame, safeFrame }) => {
       const { analytics } = createPostHogAnalytics({
         host: "https://posthog.test",

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -592,6 +592,28 @@ describe("PostHog browser analytics adapter", () => {
     expect(captured.stack).toBe(["Error:", actualFrame].join("\n"));
   });
 
+  test("captureError cannot treat an empty-name V8 header as a callsite", () => {
+    const { analytics } = createPostHogAnalytics({
+      host: "https://posthog.test",
+      key: "phc_test",
+    });
+    const injectedFrame =
+      "clientName@https://stella.test/assets/private.js:20:5";
+    const actualFrame =
+      "    at renderMatter (https://stella.test/assets/index.js:10:15)";
+    const error = new Error(injectedFrame);
+    error.name = "";
+    error.stack = [error.message, actualFrame].join("\n");
+
+    analytics.captureError(error);
+
+    const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
+    if (!(captured instanceof Error)) {
+      throw new TypeError("Expected a redacted Error");
+    }
+    expect(captured.stack).toBe(["UnknownError:", actualFrame].join("\n"));
+  });
+
   test("captureError survives a cyclic cause chain", () => {
     const { analytics } = createPostHogAnalytics({
       host: "https://posthog.test",

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -410,6 +410,41 @@ describe("PostHog browser analytics adapter", () => {
     expect(captured.stack).toContain("    at ");
   });
 
+  // Frame syntax is engine-specific, so the redaction has to hold for each
+  // one: every frame survives, and the header carrying the message does not.
+  const ENGINE_FRAMES = {
+    callsite: [
+      "renderMatter@https://stella.test/assets/index.js:10:15",
+      "handleClick/<@https://stella.test/assets/index.js:22:3",
+    ],
+    indented: [
+      "    at renderMatter (https://stella.test/assets/index.js:10:15)",
+      "    at handleClick (https://stella.test/assets/index.js:22:3)",
+    ],
+  } as const satisfies Record<string, readonly string[]>;
+
+  test.each(Object.entries(ENGINE_FRAMES))(
+    "captureError keeps %s frames and drops the message",
+    (_syntax, frames) => {
+      const { analytics } = createPostHogAnalytics({
+        host: "https://posthog.test",
+        key: "phc_test",
+      });
+      const error = new RangeError("Privileged document name");
+      error.stack = ["RangeError: Privileged document name", ...frames].join(
+        "\n",
+      );
+
+      analytics.captureError(error);
+
+      const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
+      if (!(captured instanceof Error)) {
+        throw new TypeError("Expected a redacted Error");
+      }
+      expect(captured.stack).toBe(["RangeError:", ...frames].join("\n"));
+    },
+  );
+
   test("captureError survives a cyclic cause chain", () => {
     const { analytics } = createPostHogAnalytics({
       host: "https://posthog.test",

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -418,6 +418,7 @@ describe("PostHog browser analytics adapter", () => {
       "handleClick/<@https://stella.test/assets/index.js:22:3",
       "async*renderMatter@https://stella.test/assets/index.js:26:5",
       "Async*@https://stella.test/assets/index.js:28:6",
+      "calculÉchéance@https://stella.test/assets/index.js:29:6",
       "global code@https://stella.test/assets/index.js:30:7",
     ],
     indented: [
@@ -434,9 +435,10 @@ describe("PostHog browser analytics adapter", () => {
         key: "phc_test",
       });
       const error = new RangeError("Privileged document name");
-      error.stack = ["RangeError: Privileged document name", ...frames].join(
-        "\n",
-      );
+      error.stack =
+        _syntax === "callsite"
+          ? frames.join("\n")
+          : ["RangeError: Privileged document name", ...frames].join("\n");
 
       analytics.captureError(error);
 
@@ -487,7 +489,9 @@ describe("PostHog browser analytics adapter", () => {
         key: "phc_test",
       });
       const error = new Error("Privileged document name");
-      error.stack = [`Error: ${error.message}`, frame].join("\n");
+      error.stack = frame.startsWith("    at ")
+        ? [`Error: ${error.message}`, frame].join("\n")
+        : frame;
 
       analytics.captureError(error);
 
@@ -507,7 +511,7 @@ describe("PostHog browser analytics adapter", () => {
     const injectedFrame =
       "clientName@https://stella.test/assets/private.js:20:5";
     const actualFrame =
-      "renderMatter@https://stella.test/assets/index.js:10:15";
+      "    at renderMatter (https://stella.test/assets/index.js:10:15)";
     const error = new Error(`Privileged document name\n${injectedFrame}`);
     error.stack = [`Error: ${error.message}`, actualFrame].join("\n");
 
@@ -543,6 +547,26 @@ describe("PostHog browser analytics adapter", () => {
     expect(captured.stack).toBe(
       ["ClientTelemetryError:", actualFrame].join("\n"),
     );
+  });
+
+  test("captureError cannot partially remove a stale serialized header", () => {
+    const { analytics } = createPostHogAnalytics({
+      host: "https://posthog.test",
+      key: "phc_test",
+    });
+    const injectedFrame =
+      "clientName@https://stella.test/assets/private.js:20:5";
+    const error = new Error(`Public summary\n${injectedFrame}`);
+    error.stack = `Error: ${error.message}`;
+    error.message = "Public summary";
+
+    analytics.captureError(error);
+
+    const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
+    if (!(captured instanceof Error)) {
+      throw new TypeError("Expected a redacted Error");
+    }
+    expect(captured.stack).toBeUndefined();
   });
 
   test("captureError survives a cyclic cause chain", () => {

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -83,8 +83,8 @@ void mock.module("posthog-js", () => ({
   posthog: posthogMock,
 }));
 
-const { createPostHogAnalytics, redactTelemetryStack } =
-  await import("./posthog");
+const { createPostHogAnalytics } = await import("./posthog");
+const { redactTelemetryStack } = await import("./stack-redaction");
 const { sanitizeRouteErrorLifecycleEvent } =
   await import("./posthog-route-error");
 
@@ -396,9 +396,12 @@ describe("PostHog browser analytics adapter", () => {
       host: "https://posthog.test",
       key: "phc_test",
     });
-    analytics.captureError(
-      new TypeError("Privileged document name and server payload"),
-    );
+    const error = new TypeError("Privileged document name and server payload");
+    error.stack = [
+      `TypeError: ${error.message}`,
+      "    at renderMatter (https://stella.test/assets/index.js:10:15)",
+    ].join("\n");
+    analytics.captureError(error);
 
     const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
     expect(captured).toBeInstanceOf(Error);
@@ -408,7 +411,7 @@ describe("PostHog browser analytics adapter", () => {
     }
     expect(captured.stack).toStartWith("TypeError:\n");
     expect(captured.stack).not.toContain("Privileged document name");
-    expect(captured.stack).toContain("    at ");
+    expect(captured.stack).toContain("    at renderMatter");
   });
 
   // Frame syntax is engine-specific, so the redaction has to hold for each
@@ -487,6 +490,29 @@ describe("PostHog browser analytics adapter", () => {
           syntax: frame.startsWith("    at ") ? "v8" : "callsite",
         }),
       ).toBe(["Error:", safeFrame].join("\n"));
+    },
+  );
+
+  const UNSAFE_SOURCE_FRAMES = {
+    callsiteData:
+      "renderMatter@data:text/javascript,throw%20new%20Error(%22PrivilegedMatterName%22):1:1",
+    indentedData:
+      "    at renderMatter (data:text/javascript,throw%20new%20Error(%22PrivilegedMatterName%22):1:1)",
+    callsiteBlob: "renderMatter@blob:https://stella.test/private-token:1:1",
+    indentedCredentials:
+      "    at renderMatter (https://client:secret@stella.test/index.js:1:1)",
+  } as const;
+
+  test.each(Object.entries(UNSAFE_SOURCE_FRAMES))(
+    "stack redaction drops unsafe %s locations",
+    (_kind, frame) => {
+      expect(
+        redactTelemetryStack({
+          errorType: "Error",
+          stack: frame,
+          syntax: frame.startsWith("    at ") ? "v8" : "callsite",
+        }),
+      ).toBeUndefined();
     },
   );
 
@@ -680,9 +706,12 @@ describe("PostHog browser analytics adapter", () => {
     });
     wrapper.name = "ClientTelemetryError";
     // Distinguishable stacks: the wrapper's own stack must not win.
-    wrapper.stack = "Error: Privileged wrapper message\n    at boundary";
+    wrapper.stack = [
+      "Error: Privileged wrapper message",
+      "    at boundary (https://stella.test/assets/boundary.js:1:2)",
+    ].join("\n");
     original.stack =
-      "RangeError: Privileged original message\n    at failureSite";
+      "RangeError: Privileged original message\n    at failureSite (https://stella.test/assets/failure.js:3:4)";
     analytics.captureError(wrapper);
 
     const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
@@ -690,7 +719,9 @@ describe("PostHog browser analytics adapter", () => {
       throw new TypeError("Expected a redacted Error");
     }
     expect(captured.name).toBe("ClientTelemetryError");
-    expect(captured.stack).toBe("ClientTelemetryError:\n    at failureSite");
+    expect(captured.stack).toBe(
+      "ClientTelemetryError:\n    at failureSite (https://stella.test/assets/failure.js:3:4)",
+    );
   });
 
   test("captureError attaches the telemetry area slug and nothing free-form", () => {

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -416,6 +416,8 @@ describe("PostHog browser analytics adapter", () => {
     callsite: [
       "renderMatter@https://stella.test/assets/index.js:10:15",
       "handleClick/<@https://stella.test/assets/index.js:22:3",
+      "async*renderMatter@https://stella.test/assets/index.js:26:5",
+      "Async*@https://stella.test/assets/index.js:28:6",
       "global code@https://stella.test/assets/index.js:30:7",
     ],
     indented: [
@@ -455,6 +457,12 @@ describe("PostHog browser analytics adapter", () => {
     indented: {
       frame:
         "    at renderMatter (https://stella.test/assets/index.js?token=private:10:15)",
+      safeFrame:
+        "    at renderMatter (https://stella.test/assets/index.js:10:15)",
+    },
+    indentedWithQueryParentheses: {
+      frame:
+        "    at renderMatter (https://stella.test/assets/index.js?token=private(value):10:15)",
       safeFrame:
         "    at renderMatter (https://stella.test/assets/index.js:10:15)",
     },

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -509,6 +509,31 @@ describe("PostHog browser analytics adapter", () => {
     expect(captured.stack).toBe(["Error:", actualFrame].join("\n"));
   });
 
+  test("captureError ignores a serialized header after error fields change", () => {
+    const { analytics } = createPostHogAnalytics({
+      host: "https://posthog.test",
+      key: "phc_test",
+    });
+    const injectedFrame =
+      "clientName@https://stella.test/assets/private.js:20:5";
+    const actualFrame =
+      "    at renderMatter (https://stella.test/assets/index.js:10:15)";
+    const error = new Error(`Privileged document name\n${injectedFrame}`);
+    error.stack = [`Error: ${error.message}`, actualFrame].join("\n");
+    error.name = "ClientTelemetryError";
+    error.message = "Changed after stack serialization";
+
+    analytics.captureError(error);
+
+    const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
+    if (!(captured instanceof Error)) {
+      throw new TypeError("Expected a redacted Error");
+    }
+    expect(captured.stack).toBe(
+      ["ClientTelemetryError:", actualFrame].join("\n"),
+    );
+  });
+
   test("captureError survives a cyclic cause chain", () => {
     const { analytics } = createPostHogAnalytics({
       host: "https://posthog.test",

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -416,6 +416,7 @@ describe("PostHog browser analytics adapter", () => {
     callsite: [
       "renderMatter@https://stella.test/assets/index.js:10:15",
       "handleClick/<@https://stella.test/assets/index.js:22:3",
+      "global code@https://stella.test/assets/index.js:30:7",
     ],
     indented: [
       "    at renderMatter (https://stella.test/assets/index.js:10:15)",
@@ -444,6 +445,61 @@ describe("PostHog browser analytics adapter", () => {
       expect(captured.stack).toBe(["RangeError:", ...frames].join("\n"));
     },
   );
+
+  const QUERY_STRING_FRAMES = {
+    callsite: {
+      frame:
+        "renderMatter@https://stella.test/assets/index.js?token=private:10:15",
+      safeFrame: "renderMatter@https://stella.test/assets/index.js:10:15",
+    },
+    indented: {
+      frame:
+        "    at renderMatter (https://stella.test/assets/index.js?token=private:10:15)",
+      safeFrame:
+        "    at renderMatter (https://stella.test/assets/index.js:10:15)",
+    },
+  } as const;
+
+  test.each(Object.entries(QUERY_STRING_FRAMES))(
+    "captureError removes query strings from %s frames",
+    (_syntax, { frame, safeFrame }) => {
+      const { analytics } = createPostHogAnalytics({
+        host: "https://posthog.test",
+        key: "phc_test",
+      });
+      const error = new Error("Privileged document name");
+      error.stack = [`Error: ${error.message}`, frame].join("\n");
+
+      analytics.captureError(error);
+
+      const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
+      if (!(captured instanceof Error)) {
+        throw new TypeError("Expected a redacted Error");
+      }
+      expect(captured.stack).toBe(["Error:", safeFrame].join("\n"));
+    },
+  );
+
+  test("captureError cannot treat a multiline message as a stack frame", () => {
+    const { analytics } = createPostHogAnalytics({
+      host: "https://posthog.test",
+      key: "phc_test",
+    });
+    const injectedFrame =
+      "clientName@https://stella.test/assets/private.js:20:5";
+    const actualFrame =
+      "renderMatter@https://stella.test/assets/index.js:10:15";
+    const error = new Error(`Privileged document name\n${injectedFrame}`);
+    error.stack = [`Error: ${error.message}`, actualFrame].join("\n");
+
+    analytics.captureError(error);
+
+    const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
+    if (!(captured instanceof Error)) {
+      throw new TypeError("Expected a redacted Error");
+    }
+    expect(captured.stack).toBe(["Error:", actualFrame].join("\n"));
+  });
 
   test("captureError survives a cyclic cause chain", () => {
     const { analytics } = createPostHogAnalytics({

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -83,7 +83,8 @@ void mock.module("posthog-js", () => ({
   posthog: posthogMock,
 }));
 
-const { createPostHogAnalytics } = await import("./posthog");
+const { createPostHogAnalytics, redactTelemetryStack } =
+  await import("./posthog");
 const { sanitizeRouteErrorLifecycleEvent } =
   await import("./posthog-route-error");
 
@@ -428,25 +429,20 @@ describe("PostHog browser analytics adapter", () => {
   } as const satisfies Record<string, readonly string[]>;
 
   test.each(Object.entries(ENGINE_FRAMES))(
-    "captureError keeps %s frames and drops the message",
+    "stack redaction keeps %s frames and drops the message",
     (_syntax, frames) => {
-      const { analytics } = createPostHogAnalytics({
-        host: "https://posthog.test",
-        key: "phc_test",
-      });
-      const error = new RangeError("Privileged document name");
-      error.stack =
+      const stack =
         _syntax === "callsite"
           ? frames.join("\n")
           : ["RangeError: Privileged document name", ...frames].join("\n");
 
-      analytics.captureError(error);
-
-      const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
-      if (!(captured instanceof Error)) {
-        throw new TypeError("Expected a redacted Error");
-      }
-      expect(captured.stack).toBe(["RangeError:", ...frames].join("\n"));
+      expect(
+        redactTelemetryStack({
+          errorType: "RangeError",
+          stack,
+          syntax: _syntax === "callsite" ? "callsite" : "v8",
+        }),
+      ).toBe(["RangeError:", ...frames].join("\n"));
     },
   );
 
@@ -482,24 +478,15 @@ describe("PostHog browser analytics adapter", () => {
   } as const;
 
   test.each(Object.entries(URL_METADATA_FRAMES))(
-    "captureError removes URL metadata from %s frames",
+    "stack redaction removes URL metadata from %s frames",
     (_syntax, { frame, safeFrame }) => {
-      const { analytics } = createPostHogAnalytics({
-        host: "https://posthog.test",
-        key: "phc_test",
-      });
-      const error = new Error("Privileged document name");
-      error.stack = frame.startsWith("    at ")
-        ? [`Error: ${error.message}`, frame].join("\n")
-        : frame;
-
-      analytics.captureError(error);
-
-      const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
-      if (!(captured instanceof Error)) {
-        throw new TypeError("Expected a redacted Error");
-      }
-      expect(captured.stack).toBe(["Error:", safeFrame].join("\n"));
+      expect(
+        redactTelemetryStack({
+          errorType: "Error",
+          stack: frame,
+          syntax: frame.startsWith("    at ") ? "v8" : "callsite",
+        }),
+      ).toBe(["Error:", safeFrame].join("\n"));
     },
   );
 
@@ -612,6 +599,27 @@ describe("PostHog browser analytics adapter", () => {
       throw new TypeError("Expected a redacted Error");
     }
     expect(captured.stack).toBe(["UnknownError:", actualFrame].join("\n"));
+  });
+
+  test("captureError drops a frameless empty-name V8 stack", () => {
+    const { analytics } = createPostHogAnalytics({
+      host: "https://posthog.test",
+      key: "phc_test",
+    });
+    const error = new Error("Privileged message");
+    error.name = "";
+    error.stack = [
+      "renderMatter@https://stella.test/assets/a.js:1:2",
+      "clientName@https://stella.test/assets/private.js:20:5",
+    ].join("\n");
+
+    analytics.captureError(error);
+
+    const captured = captureExceptionMock.mock.calls.at(-1)?.[0];
+    if (!(captured instanceof Error)) {
+      throw new TypeError("Expected a redacted Error");
+    }
+    expect(captured.stack).toBeUndefined();
   });
 
   test("captureError survives a cyclic cause chain", () => {

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -3,14 +3,12 @@ import { posthog } from "posthog-js";
 import type { CaptureResult, SupportedWebVitalsMetrics } from "posthog-js";
 
 import { env } from "@/env";
-import {
-  normalizeTelemetryErrorTypeName,
-  telemetryErrorType,
-} from "@/lib/analytics/error-diagnostics";
+import { normalizeTelemetryErrorTypeName } from "@/lib/analytics/error-diagnostics";
 import { isErrorReference } from "@/lib/analytics/error-reference";
 import { fingerprintExceptionEvent } from "@/lib/analytics/exception-fingerprint";
 import { pickIngestionRequired } from "@/lib/analytics/posthog-ingestion";
 import type { sanitizeRouteErrorLifecycleEvent } from "@/lib/analytics/posthog-route-error";
+import { captureRedactedException } from "@/lib/analytics/stack-redaction";
 import { WEB_ANALYTICS_EVENTS } from "@/lib/analytics/types";
 import type {
   Analytics,
@@ -91,146 +89,6 @@ const telemetryAreaProperty = (
   return typeof area === "string" && TELEMETRY_AREA.test(area)
     ? { area }
     : undefined;
-};
-
-// The deepest error in a `cause` chain carries the stack of the original
-// failure site; wrapper classes (boundary telemetry errors) only record
-// where they were constructed. `cause` is writable, so third-party code can
-// hand us a cycle; the visited set bounds the walk.
-const deepestCause = (error: Error): Error => {
-  let current = error;
-  const seen = new Set<Error>([error]);
-  while (current.cause instanceof Error && !seen.has(current.cause)) {
-    current = current.cause;
-    seen.add(current);
-  }
-  return current;
-};
-
-// Engines disagree on frame syntax: V8 indents frames with `at ` under a
-// `<name>: <message>` header, while SpiderMonkey and JavaScriptCore write
-// bare `<symbol>@<url>:<line>:<column>` lines and no header at all. Known JSC
-// engine labels contain spaces; other callsite labels stay symbol-shaped so
-// free-form text cannot ride along as a frame.
-const V8_STACK_FRAME_SYNTAX = /^\s+at /u;
-const CALLSITE_STACK_FRAME_SYNTAX =
-  /^(?:[Aa]sync\*)?(?:[\p{ID_Continue}$.<>[\]#~/]{0,120}|(?:global|module|eval) code)@\S+:\d+:\d+$/u;
-type StackFrameSyntax = "callsite" | "v8";
-
-const hasOnlyDecimalDigits = (
-  value: string,
-  start: number,
-  end: number,
-): boolean => {
-  if (start >= end) {
-    return false;
-  }
-  for (let index = start; index < end; index += 1) {
-    const code = value.codePointAt(index);
-    if (code === undefined || code < 48 || code > 57) {
-      return false;
-    }
-  }
-  return true;
-};
-
-const stripStackFrameUrlMetadata = (frame: string): string => {
-  const frameEnd = frame.endsWith(")") ? frame.length - 1 : frame.length;
-  const columnSeparator = frame.lastIndexOf(":", frameEnd - 1);
-  const lineSeparator = frame.lastIndexOf(":", columnSeparator - 1);
-  if (
-    lineSeparator === -1 ||
-    !hasOnlyDecimalDigits(frame, lineSeparator + 1, columnSeparator) ||
-    !hasOnlyDecimalDigits(frame, columnSeparator + 1, frameEnd)
-  ) {
-    return frame;
-  }
-
-  const v8Prefix = frame.trimStart().startsWith("at ")
-    ? frame.indexOf("at ") + 3
-    : -1;
-  let urlStart = frame.indexOf("@") + 1;
-  if (v8Prefix !== -1) {
-    const locationSeparator = frame.indexOf(" (", v8Prefix);
-    urlStart =
-      locationSeparator === -1 || locationSeparator > lineSeparator
-        ? v8Prefix
-        : locationSeparator + 2;
-  }
-  let urlEnd = lineSeparator;
-  for (const terminator of ["?", "#"] as const) {
-    const index = frame.indexOf(terminator, urlStart);
-    if (index !== -1 && index < urlEnd) {
-      urlEnd = index;
-    }
-  }
-  if (urlEnd === lineSeparator) {
-    return frame;
-  }
-  return `${frame.slice(0, urlEnd)}${frame.slice(lineSeparator)}`;
-};
-
-const runtimeStackFrameSyntax = (): StackFrameSyntax | undefined => {
-  const stack = new Error("stack syntax probe").stack;
-  if (typeof stack !== "string") {
-    return undefined;
-  }
-  const lines = stack.split("\n").filter((line) => line.length > 0);
-  if (lines.some((line) => V8_STACK_FRAME_SYNTAX.test(line))) {
-    return "v8";
-  }
-  return lines.some((line) => CALLSITE_STACK_FRAME_SYNTAX.test(line))
-    ? "callsite"
-    : undefined;
-};
-
-type RedactTelemetryStackOptions = {
-  errorType: string;
-  stack: string;
-  syntax: StackFrameSyntax;
-};
-
-export const redactTelemetryStack = ({
-  errorType,
-  stack,
-  syntax,
-}: RedactTelemetryStackOptions): string | undefined => {
-  const frameSyntax =
-    syntax === "callsite" ? CALLSITE_STACK_FRAME_SYNTAX : V8_STACK_FRAME_SYNTAX;
-  const frames = stack
-    .split("\n")
-    .filter((line) => frameSyntax.test(line))
-    .map(stripStackFrameUrlMetadata);
-  if (frames.length === 0) {
-    return undefined;
-  }
-  return [`${errorType}:`, ...frames].join("\n");
-};
-
-const redactedStack = (error: Error): string | undefined => {
-  const { stack } = deepestCause(error);
-  const syntax = runtimeStackFrameSyntax();
-  if (typeof stack !== "string" || syntax === undefined) {
-    return undefined;
-  }
-  return redactTelemetryStack({
-    errorType: telemetryErrorType(error),
-    stack,
-    syntax,
-  });
-};
-
-const toRedactedTelemetryError = (error: unknown): Error => {
-  // eslint-disable-next-line unicorn/error-message -- the original message is intentionally dropped so telemetry cannot leak PII from the underlying error; the error class is carried in `.name` instead.
-  const redacted = new Error("");
-  redacted.name = telemetryErrorType(error);
-  const stack = error instanceof Error ? redactedStack(error) : undefined;
-  if (stack === undefined) {
-    Reflect.deleteProperty(redacted, "stack");
-  } else {
-    redacted.stack = stack;
-  }
-  return redacted;
 };
 
 // Structural frame fields only: code locations and symbol names from the
@@ -694,9 +552,11 @@ export const createPostHogAnalytics = ({
         return;
       }
       logDevError(error, devErrorContext(context));
-      posthog.captureException(toRedactedTelemetryError(error), {
-        ...errorContextProperties(context),
-        ...telemetryAreaProperty(error),
+      captureRedactedException(error, (redacted) => {
+        posthog.captureException(redacted, {
+          ...errorContextProperties(context),
+          ...telemetryAreaProperty(error),
+        });
       });
     },
     capturePageViewed: ({ path }) => {

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -115,6 +115,7 @@ const deepestCause = (error: Error): Error => {
 const V8_STACK_FRAME_SYNTAX = /^\s+at /u;
 const CALLSITE_STACK_FRAME_SYNTAX =
   /^(?:[Aa]sync\*)?(?:[\p{ID_Continue}$.<>[\]#~/]{0,120}|(?:global|module|eval) code)@\S+:\d+:\d+$/u;
+type StackFrameSyntax = "callsite" | "v8";
 
 const hasOnlyDecimalDigits = (
   value: string,
@@ -169,27 +170,54 @@ const stripStackFrameUrlMetadata = (frame: string): string => {
   return `${frame.slice(0, urlEnd)}${frame.slice(lineSeparator)}`;
 };
 
-const redactedStack = (error: Error): string | undefined => {
-  const source = deepestCause(error);
-  const { stack } = source;
+const runtimeStackFrameSyntax = (): StackFrameSyntax | undefined => {
+  const stack = new Error("stack syntax probe").stack;
   if (typeof stack !== "string") {
     return undefined;
   }
   const lines = stack.split("\n").filter((line) => line.length > 0);
-  // Callsite engines start with a bare frame and never mix in V8 frames. V8
-  // can serialize an empty name, making its message look like a callsite.
-  const hasV8Frames = lines.some((line) => V8_STACK_FRAME_SYNTAX.test(line));
+  if (lines.some((line) => V8_STACK_FRAME_SYNTAX.test(line))) {
+    return "v8";
+  }
+  return lines.some((line) => CALLSITE_STACK_FRAME_SYNTAX.test(line))
+    ? "callsite"
+    : undefined;
+};
+
+type RedactTelemetryStackOptions = {
+  errorType: string;
+  stack: string;
+  syntax: StackFrameSyntax;
+};
+
+export const redactTelemetryStack = ({
+  errorType,
+  stack,
+  syntax,
+}: RedactTelemetryStackOptions): string | undefined => {
   const frameSyntax =
-    !hasV8Frames && CALLSITE_STACK_FRAME_SYNTAX.test(lines.at(0) ?? "")
-      ? CALLSITE_STACK_FRAME_SYNTAX
-      : V8_STACK_FRAME_SYNTAX;
-  const frames = lines
+    syntax === "callsite" ? CALLSITE_STACK_FRAME_SYNTAX : V8_STACK_FRAME_SYNTAX;
+  const frames = stack
+    .split("\n")
     .filter((line) => frameSyntax.test(line))
     .map(stripStackFrameUrlMetadata);
   if (frames.length === 0) {
     return undefined;
   }
-  return [`${telemetryErrorType(error)}:`, ...frames].join("\n");
+  return [`${errorType}:`, ...frames].join("\n");
+};
+
+const redactedStack = (error: Error): string | undefined => {
+  const { stack } = deepestCause(error);
+  const syntax = runtimeStackFrameSyntax();
+  if (typeof stack !== "string" || syntax === undefined) {
+    return undefined;
+  }
+  return redactTelemetryStack({
+    errorType: telemetryErrorType(error),
+    stack,
+    syntax,
+  });
 };
 
 const toRedactedTelemetryError = (error: unknown): Error => {

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -109,24 +109,43 @@ const deepestCause = (error: Error): Error => {
 
 // Engines disagree on frame syntax: V8 indents frames with `at ` under a
 // `<name>: <message>` header, while SpiderMonkey and JavaScriptCore write
-// bare `<symbol>@<url>:<line>:<column>` lines and no header at all. Matching
-// both shapes keeps the frames, which name bundled assets and minified
-// symbols, and drops everything else, including the header whose message can
-// carry PII. A callsite line carries no message: its symbol runs up to the
-// `@`, so a header (`<name>: <message>`, always spaced) cannot match it.
-const STACK_FRAME_SYNTAX: readonly RegExp[] = [
+// bare `<symbol>@<url>:<line>:<column>` lines and no header at all. Known JSC
+// engine labels contain spaces; other callsite labels stay symbol-shaped so
+// free-form text cannot ride along as a frame.
+const STACK_FRAME_SYNTAX = [
   /^\s+at /u,
-  /^[^\s@]*@\S+:\d+:\d+$/u,
-];
+  /^(?:[\w$.<>[\]#~/]{0,120}|(?:global|module|eval) code)@\S+:\d+:\d+$/u,
+] as const;
+const STACK_FRAME_QUERY = /\?[^\s)]*(?=:\d+:\d+\)?$)/u;
+
+const serializedErrorHeader = (error: Error): string => {
+  const name = typeof error.name === "string" ? error.name : "Error";
+  const message = typeof error.message === "string" ? error.message : "";
+  if (name.length === 0) {
+    return message;
+  }
+  return message.length === 0 ? name : `${name}: ${message}`;
+};
+
+const stackWithoutHeader = (error: Error, stack: string): string => {
+  const header = serializedErrorHeader(error);
+  if (stack === header) {
+    return "";
+  }
+  const prefix = `${header}\n`;
+  return stack.startsWith(prefix) ? stack.slice(prefix.length) : stack;
+};
 
 const redactedStack = (error: Error): string | undefined => {
-  const { stack } = deepestCause(error);
+  const source = deepestCause(error);
+  const { stack } = source;
   if (typeof stack !== "string") {
     return undefined;
   }
-  const frames = stack
+  const frames = stackWithoutHeader(source, stack)
     .split("\n")
-    .filter((line) => STACK_FRAME_SYNTAX.some((syntax) => syntax.test(line)));
+    .filter((line) => STACK_FRAME_SYNTAX.some((syntax) => syntax.test(line)))
+    .map((line) => line.replace(STACK_FRAME_QUERY, ""));
   if (frames.length === 0) {
     return undefined;
   }

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -112,10 +112,9 @@ const deepestCause = (error: Error): Error => {
 // bare `<symbol>@<url>:<line>:<column>` lines and no header at all. Known JSC
 // engine labels contain spaces; other callsite labels stay symbol-shaped so
 // free-form text cannot ride along as a frame.
-const STACK_FRAME_SYNTAX = [
-  /^\s+at /u,
-  /^(?:[Aa]sync\*)?(?:[\w$.<>[\]#~/]{0,120}|(?:global|module|eval) code)@\S+:\d+:\d+$/u,
-] as const;
+const V8_STACK_FRAME_SYNTAX = /^\s+at /u;
+const CALLSITE_STACK_FRAME_SYNTAX =
+  /^(?:[Aa]sync\*)?(?:[\w$.<>[\]#~/]{0,120}|(?:global|module|eval) code)@\S+:\d+:\d+$/u;
 
 const hasOnlyDecimalDigits = (
   value: string,
@@ -188,9 +187,18 @@ const redactedStack = (error: Error): string | undefined => {
   if (typeof stack !== "string") {
     return undefined;
   }
-  const frames = stackWithoutHeader(source, stack)
+  const lines = stackWithoutHeader(source, stack)
     .split("\n")
-    .filter((line) => STACK_FRAME_SYNTAX.some((syntax) => syntax.test(line)))
+    .filter((line) => line.length > 0);
+  // Callsite engines serialize only frames. Any other line means this is a
+  // V8-style stack whose header may no longer match mutable Error fields.
+  const frameSyntax = lines.every((line) =>
+    CALLSITE_STACK_FRAME_SYNTAX.test(line),
+  )
+    ? CALLSITE_STACK_FRAME_SYNTAX
+    : V8_STACK_FRAME_SYNTAX;
+  const frames = lines
+    .filter((line) => frameSyntax.test(line))
     .map(stripStackFrameQuery);
   if (frames.length === 0) {
     return undefined;

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -176,11 +176,13 @@ const redactedStack = (error: Error): string | undefined => {
     return undefined;
   }
   const lines = stack.split("\n").filter((line) => line.length > 0);
-  // Callsite engines start with a bare frame; V8 starts with its serialized
-  // error header. Classify from that immutable text, not mutable Error fields.
-  const frameSyntax = CALLSITE_STACK_FRAME_SYNTAX.test(lines.at(0) ?? "")
-    ? CALLSITE_STACK_FRAME_SYNTAX
-    : V8_STACK_FRAME_SYNTAX;
+  // Callsite engines start with a bare frame and never mix in V8 frames. V8
+  // can serialize an empty name, making its message look like a callsite.
+  const hasV8Frames = lines.some((line) => V8_STACK_FRAME_SYNTAX.test(line));
+  const frameSyntax =
+    !hasV8Frames && CALLSITE_STACK_FRAME_SYNTAX.test(lines.at(0) ?? "")
+      ? CALLSITE_STACK_FRAME_SYNTAX
+      : V8_STACK_FRAME_SYNTAX;
   const frames = lines
     .filter((line) => frameSyntax.test(line))
     .map(stripStackFrameUrlMetadata);

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -133,7 +133,7 @@ const hasOnlyDecimalDigits = (
   return true;
 };
 
-const stripStackFrameQuery = (frame: string): string => {
+const stripStackFrameUrlMetadata = (frame: string): string => {
   const frameEnd = frame.endsWith(")") ? frame.length - 1 : frame.length;
   const columnSeparator = frame.lastIndexOf(":", frameEnd - 1);
   const lineSeparator = frame.lastIndexOf(":", columnSeparator - 1);
@@ -156,11 +156,17 @@ const stripStackFrameQuery = (frame: string): string => {
         ? v8Prefix
         : locationSeparator + 2;
   }
-  const query = frame.indexOf("?", urlStart);
-  if (query === -1 || query > lineSeparator) {
+  let urlEnd = lineSeparator;
+  for (const terminator of ["?", "#"] as const) {
+    const index = frame.indexOf(terminator, urlStart);
+    if (index !== -1 && index < urlEnd) {
+      urlEnd = index;
+    }
+  }
+  if (urlEnd === lineSeparator) {
     return frame;
   }
-  return `${frame.slice(0, query)}${frame.slice(lineSeparator)}`;
+  return `${frame.slice(0, urlEnd)}${frame.slice(lineSeparator)}`;
 };
 
 const serializedErrorHeader = (error: Error): string => {
@@ -199,7 +205,7 @@ const redactedStack = (error: Error): string | undefined => {
     : V8_STACK_FRAME_SYNTAX;
   const frames = lines
     .filter((line) => frameSyntax.test(line))
-    .map(stripStackFrameQuery);
+    .map(stripStackFrameUrlMetadata);
   if (frames.length === 0) {
     return undefined;
   }
@@ -236,9 +242,9 @@ type SanitizedFrame = {
 // beyond identifier punctuation is treated as untrusted and dropped.
 const FRAME_SYMBOL = /^[\w$.<>[\]#~]{1,120}$/u;
 
-const stripQuery = (url: string): string => {
-  const queryIndex = url.indexOf("?");
-  return queryIndex === -1 ? url : url.slice(0, queryIndex);
+const stripUrlMetadata = (url: string): string => {
+  const terminator = url.search(/[?#]/u);
+  return terminator === -1 ? url : url.slice(0, terminator);
 };
 
 const sanitizeFrame = (frame: unknown): SanitizedFrame => {
@@ -253,8 +259,10 @@ const sanitizeFrame = (frame: unknown): SanitizedFrame => {
   const colno = frame["colno"];
   return {
     ...(typeof platform === "string" ? { platform } : {}),
-    // Query strings on asset URLs can carry tokens; keep only the path.
-    ...(typeof filename === "string" ? { filename: stripQuery(filename) } : {}),
+    // URL metadata on asset URLs can carry tokens; keep only the path.
+    ...(typeof filename === "string"
+      ? { filename: stripUrlMetadata(filename) }
+      : {}),
     ...(typeof functionName === "string" && FRAME_SYMBOL.test(functionName)
       ? { function: functionName }
       : {}),

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -133,16 +133,6 @@ const hasOnlyDecimalDigits = (
   return true;
 };
 
-const hasCallsiteStackSyntax = (line: string): boolean => {
-  const columnSeparator = line.lastIndexOf(":");
-  const lineSeparator = line.lastIndexOf(":", columnSeparator - 1);
-  return (
-    line.lastIndexOf("@", lineSeparator - 1) !== -1 &&
-    hasOnlyDecimalDigits(line, lineSeparator + 1, columnSeparator) &&
-    hasOnlyDecimalDigits(line, columnSeparator + 1, line.length)
-  );
-};
-
 const stripStackFrameUrlMetadata = (frame: string): string => {
   const frameEnd = frame.endsWith(")") ? frame.length - 1 : frame.length;
   const columnSeparator = frame.lastIndexOf(":", frameEnd - 1);
@@ -188,7 +178,7 @@ const redactedStack = (error: Error): string | undefined => {
   const lines = stack.split("\n").filter((line) => line.length > 0);
   // Callsite engines start with a bare frame; V8 starts with its serialized
   // error header. Classify from that immutable text, not mutable Error fields.
-  const frameSyntax = hasCallsiteStackSyntax(lines.at(0) ?? "")
+  const frameSyntax = CALLSITE_STACK_FRAME_SYNTAX.test(lines.at(0) ?? "")
     ? CALLSITE_STACK_FRAME_SYNTAX
     : V8_STACK_FRAME_SYNTAX;
   const frames = lines

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -114,7 +114,7 @@ const deepestCause = (error: Error): Error => {
 // free-form text cannot ride along as a frame.
 const V8_STACK_FRAME_SYNTAX = /^\s+at /u;
 const CALLSITE_STACK_FRAME_SYNTAX =
-  /^(?:[Aa]sync\*)?(?:[\w$.<>[\]#~/]{0,120}|(?:global|module|eval) code)@\S+:\d+:\d+$/u;
+  /^(?:[Aa]sync\*)?(?:[\p{ID_Continue}$.<>[\]#~/]{0,120}|(?:global|module|eval) code)@\S+:\d+:\d+$/u;
 
 const hasOnlyDecimalDigits = (
   value: string,
@@ -131,6 +131,16 @@ const hasOnlyDecimalDigits = (
     }
   }
   return true;
+};
+
+const hasCallsiteStackSyntax = (line: string): boolean => {
+  const columnSeparator = line.lastIndexOf(":");
+  const lineSeparator = line.lastIndexOf(":", columnSeparator - 1);
+  return (
+    line.lastIndexOf("@", lineSeparator - 1) !== -1 &&
+    hasOnlyDecimalDigits(line, lineSeparator + 1, columnSeparator) &&
+    hasOnlyDecimalDigits(line, columnSeparator + 1, line.length)
+  );
 };
 
 const stripStackFrameUrlMetadata = (frame: string): string => {
@@ -169,38 +179,16 @@ const stripStackFrameUrlMetadata = (frame: string): string => {
   return `${frame.slice(0, urlEnd)}${frame.slice(lineSeparator)}`;
 };
 
-const serializedErrorHeader = (error: Error): string => {
-  const name = typeof error.name === "string" ? error.name : "Error";
-  const message = typeof error.message === "string" ? error.message : "";
-  if (name.length === 0) {
-    return message;
-  }
-  return message.length === 0 ? name : `${name}: ${message}`;
-};
-
-const stackWithoutHeader = (error: Error, stack: string): string => {
-  const header = serializedErrorHeader(error);
-  if (stack === header) {
-    return "";
-  }
-  const prefix = `${header}\n`;
-  return stack.startsWith(prefix) ? stack.slice(prefix.length) : stack;
-};
-
 const redactedStack = (error: Error): string | undefined => {
   const source = deepestCause(error);
   const { stack } = source;
   if (typeof stack !== "string") {
     return undefined;
   }
-  const lines = stackWithoutHeader(source, stack)
-    .split("\n")
-    .filter((line) => line.length > 0);
-  // Callsite engines serialize only frames. Any other line means this is a
-  // V8-style stack whose header may no longer match mutable Error fields.
-  const frameSyntax = lines.every((line) =>
-    CALLSITE_STACK_FRAME_SYNTAX.test(line),
-  )
+  const lines = stack.split("\n").filter((line) => line.length > 0);
+  // Callsite engines start with a bare frame; V8 starts with its serialized
+  // error header. Classify from that immutable text, not mutable Error fields.
+  const frameSyntax = hasCallsiteStackSyntax(lines.at(0) ?? "")
     ? CALLSITE_STACK_FRAME_SYNTAX
     : V8_STACK_FRAME_SYNTAX;
   const frames = lines

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -114,7 +114,7 @@ const deepestCause = (error: Error): Error => {
 // free-form text cannot ride along as a frame.
 const STACK_FRAME_SYNTAX = [
   /^\s+at /u,
-  /^(?:[\w$.<>[\]#~/]{0,120}|(?:global|module|eval) code)@\S+:\d+:\d+$/u,
+  /^(?:[Aa]sync\*)?(?:[\w$.<>[\]#~/]{0,120}|(?:global|module|eval) code)@\S+:\d+:\d+$/u,
 ] as const;
 
 const hasOnlyDecimalDigits = (
@@ -149,10 +149,14 @@ const stripStackFrameQuery = (frame: string): string => {
   const v8Prefix = frame.trimStart().startsWith("at ")
     ? frame.indexOf("at ") + 3
     : -1;
-  const urlStart =
-    v8Prefix === -1
-      ? frame.indexOf("@") + 1
-      : Math.max(v8Prefix, frame.lastIndexOf("(", lineSeparator) + 1);
+  let urlStart = frame.indexOf("@") + 1;
+  if (v8Prefix !== -1) {
+    const locationSeparator = frame.indexOf(" (", v8Prefix);
+    urlStart =
+      locationSeparator === -1 || locationSeparator > lineSeparator
+        ? v8Prefix
+        : locationSeparator + 2;
+  }
   const query = frame.indexOf("?", urlStart);
   if (query === -1 || query > lineSeparator) {
     return frame;

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -116,7 +116,49 @@ const STACK_FRAME_SYNTAX = [
   /^\s+at /u,
   /^(?:[\w$.<>[\]#~/]{0,120}|(?:global|module|eval) code)@\S+:\d+:\d+$/u,
 ] as const;
-const STACK_FRAME_QUERY = /\?[^\s)]*(?=:\d+:\d+\)?$)/u;
+
+const hasOnlyDecimalDigits = (
+  value: string,
+  start: number,
+  end: number,
+): boolean => {
+  if (start >= end) {
+    return false;
+  }
+  for (let index = start; index < end; index += 1) {
+    const code = value.codePointAt(index);
+    if (code < 48 || code > 57) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const stripStackFrameQuery = (frame: string): string => {
+  const frameEnd = frame.endsWith(")") ? frame.length - 1 : frame.length;
+  const columnSeparator = frame.lastIndexOf(":", frameEnd - 1);
+  const lineSeparator = frame.lastIndexOf(":", columnSeparator - 1);
+  if (
+    lineSeparator === -1 ||
+    !hasOnlyDecimalDigits(frame, lineSeparator + 1, columnSeparator) ||
+    !hasOnlyDecimalDigits(frame, columnSeparator + 1, frameEnd)
+  ) {
+    return frame;
+  }
+
+  const v8Prefix = frame.trimStart().startsWith("at ")
+    ? frame.indexOf("at ") + 3
+    : -1;
+  const urlStart =
+    v8Prefix === -1
+      ? frame.indexOf("@") + 1
+      : Math.max(v8Prefix, frame.lastIndexOf("(", lineSeparator) + 1);
+  const query = frame.indexOf("?", urlStart);
+  if (query === -1 || query > lineSeparator) {
+    return frame;
+  }
+  return `${frame.slice(0, query)}${frame.slice(lineSeparator)}`;
+};
 
 const serializedErrorHeader = (error: Error): string => {
   const name = typeof error.name === "string" ? error.name : "Error";
@@ -145,7 +187,7 @@ const redactedStack = (error: Error): string | undefined => {
   const frames = stackWithoutHeader(source, stack)
     .split("\n")
     .filter((line) => STACK_FRAME_SYNTAX.some((syntax) => syntax.test(line)))
-    .map((line) => line.replace(STACK_FRAME_QUERY, ""));
+    .map(stripStackFrameQuery);
   if (frames.length === 0) {
     return undefined;
   }

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -107,15 +107,26 @@ const deepestCause = (error: Error): Error => {
   return current;
 };
 
-// A V8 stack begins with `<name>: <message>`; the message can carry PII, so
-// keep only the frame lines (`    at …`), which name bundled assets and
-// minified symbols but never user content.
+// Engines disagree on frame syntax: V8 indents frames with `at ` under a
+// `<name>: <message>` header, while SpiderMonkey and JavaScriptCore write
+// bare `<symbol>@<url>:<line>:<column>` lines and no header at all. Matching
+// both shapes keeps the frames, which name bundled assets and minified
+// symbols, and drops everything else, including the header whose message can
+// carry PII. A callsite line carries no message: its symbol runs up to the
+// `@`, so a header (`<name>: <message>`, always spaced) cannot match it.
+const STACK_FRAME_SYNTAX: readonly RegExp[] = [
+  /^\s+at /u,
+  /^[^\s@]*@\S+:\d+:\d+$/u,
+];
+
 const redactedStack = (error: Error): string | undefined => {
   const { stack } = deepestCause(error);
   if (typeof stack !== "string") {
     return undefined;
   }
-  const frames = stack.split("\n").filter((line) => /^\s+at /u.test(line));
+  const frames = stack
+    .split("\n")
+    .filter((line) => STACK_FRAME_SYNTAX.some((syntax) => syntax.test(line)));
   if (frames.length === 0) {
     return undefined;
   }

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -127,7 +127,7 @@ const hasOnlyDecimalDigits = (
   }
   for (let index = start; index < end; index += 1) {
     const code = value.codePointAt(index);
-    if (code < 48 || code > 57) {
+    if (code === undefined || code < 48 || code > 57) {
       return false;
     }
   }

--- a/apps/web/src/lib/analytics/stack-redaction.ts
+++ b/apps/web/src/lib/analytics/stack-redaction.ts
@@ -1,0 +1,188 @@
+import { telemetryErrorType } from "./error-diagnostics";
+
+// The deepest error in a `cause` chain carries the stack of the original
+// failure site; wrapper classes (boundary telemetry errors) only record
+// where they were constructed. `cause` is writable, so third-party code can
+// hand us a cycle; the visited set bounds the walk.
+const deepestCause = (error: Error): Error => {
+  let current = error;
+  const seen = new Set<Error>([error]);
+  while (current.cause instanceof Error && !seen.has(current.cause)) {
+    current = current.cause;
+    seen.add(current);
+  }
+  return current;
+};
+
+// Engines disagree on frame syntax: V8 indents frames with `at ` under a
+// `<name>: <message>` header, while SpiderMonkey and JavaScriptCore write
+// bare `<symbol>@<url>:<line>:<column>` lines and no header at all. Known JSC
+// engine labels contain spaces; other callsite labels stay symbol-shaped so
+// free-form text cannot ride along as a frame.
+const V8_STACK_FRAME_SYNTAX = /^\s+at /u;
+const CALLSITE_STACK_FRAME_SYNTAX =
+  /^(?:[Aa]sync\*)?(?:[\p{ID_Continue}$.<>[\]#~/]{0,120}|(?:global|module|eval) code)@\S+:\d+:\d+$/u;
+type StackFrameSyntax = "callsite" | "v8";
+
+const hasOnlyDecimalDigits = (
+  value: string,
+  start: number,
+  end: number,
+): boolean => {
+  if (start >= end) {
+    return false;
+  }
+  for (let index = start; index < end; index += 1) {
+    const code = value.codePointAt(index);
+    if (code === undefined || code < 48 || code > 57) {
+      return false;
+    }
+  }
+  return true;
+};
+
+type StackFrameLocation = {
+  lineSeparator: number;
+  urlStart: number;
+};
+
+const stackFrameLocation = (frame: string): StackFrameLocation | undefined => {
+  const frameEnd = frame.endsWith(")") ? frame.length - 1 : frame.length;
+  const columnSeparator = frame.lastIndexOf(":", frameEnd - 1);
+  const lineSeparator = frame.lastIndexOf(":", columnSeparator - 1);
+  if (
+    lineSeparator === -1 ||
+    !hasOnlyDecimalDigits(frame, lineSeparator + 1, columnSeparator) ||
+    !hasOnlyDecimalDigits(frame, columnSeparator + 1, frameEnd)
+  ) {
+    return undefined;
+  }
+
+  const v8Prefix = frame.trimStart().startsWith("at ")
+    ? frame.indexOf("at ") + 3
+    : -1;
+  let urlStart = frame.indexOf("@") + 1;
+  if (v8Prefix !== -1) {
+    const locationSeparator = frame.indexOf(" (", v8Prefix);
+    urlStart =
+      locationSeparator === -1 || locationSeparator > lineSeparator
+        ? v8Prefix
+        : locationSeparator + 2;
+  }
+  return { lineSeparator, urlStart };
+};
+
+const sanitizeStackFrame = (frame: string): string | undefined => {
+  const location = stackFrameLocation(frame);
+  if (location === undefined) {
+    return undefined;
+  }
+  const { lineSeparator, urlStart } = location;
+  const serializedUrl = frame.slice(urlStart, lineSeparator);
+  if (!URL.canParse(serializedUrl)) {
+    return undefined;
+  }
+  const url = new URL(serializedUrl);
+  if (
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    url.username !== "" ||
+    url.password !== ""
+  ) {
+    return undefined;
+  }
+
+  let urlEnd = lineSeparator;
+  for (const terminator of ["?", "#"] as const) {
+    const index = frame.indexOf(terminator, urlStart);
+    if (index !== -1 && index < urlEnd) {
+      urlEnd = index;
+    }
+  }
+  if (urlEnd === lineSeparator) {
+    return frame;
+  }
+  return `${frame.slice(0, urlEnd)}${frame.slice(lineSeparator)}`;
+};
+
+const runtimeStackFrameSyntax = (): StackFrameSyntax | undefined => {
+  const stack = new Error("stack syntax probe").stack;
+  if (typeof stack !== "string") {
+    return undefined;
+  }
+  const lines = stack.split("\n").filter((line) => line.length > 0);
+  if (lines.some((line) => V8_STACK_FRAME_SYNTAX.test(line))) {
+    return "v8";
+  }
+  return lines.some((line) => CALLSITE_STACK_FRAME_SYNTAX.test(line))
+    ? "callsite"
+    : undefined;
+};
+
+type RedactTelemetryStackOptions = {
+  errorType: string;
+  stack: string;
+  syntax: StackFrameSyntax;
+};
+
+export const redactTelemetryStack = ({
+  errorType,
+  stack,
+  syntax,
+}: RedactTelemetryStackOptions): string | undefined => {
+  const frameSyntax =
+    syntax === "callsite" ? CALLSITE_STACK_FRAME_SYNTAX : V8_STACK_FRAME_SYNTAX;
+  const frames: string[] = [];
+  for (const line of stack.split("\n")) {
+    if (!frameSyntax.test(line)) {
+      continue;
+    }
+    const sanitized = sanitizeStackFrame(line);
+    if (sanitized !== undefined) {
+      frames.push(sanitized);
+    }
+  }
+  if (frames.length === 0) {
+    return undefined;
+  }
+  return [`${errorType}:`, ...frames].join("\n");
+};
+
+const redactedStack = (error: Error): string | undefined => {
+  const { stack } = deepestCause(error);
+  const syntax = runtimeStackFrameSyntax();
+  if (typeof stack !== "string" || syntax === undefined) {
+    return undefined;
+  }
+  return redactTelemetryStack({
+    errorType: telemetryErrorType(error),
+    stack,
+    syntax,
+  });
+};
+
+const toRedactedTelemetryError = (error: unknown): Error => {
+  // eslint-disable-next-line unicorn/error-message -- the original message is intentionally dropped so telemetry cannot leak PII from the underlying error; the error class is carried in `.name` instead.
+  const redacted = new Error("");
+  redacted.name = telemetryErrorType(error);
+  const stack = error instanceof Error ? redactedStack(error) : undefined;
+  if (stack === undefined) {
+    // Firefox exposes a lazy stack accessor after deleting the own property.
+    // Shadow it explicitly so an unknown engine cannot regenerate an
+    // unsanitized stack at SDK read time.
+    Object.defineProperty(redacted, "stack", {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+  } else {
+    redacted.stack = stack;
+  }
+  return redacted;
+};
+
+export const captureRedactedException = (
+  error: unknown,
+  captureException: (redacted: Error) => void,
+): void => {
+  captureException(toRedactedTelemetryError(error));
+};

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -653,6 +653,38 @@ describe("detect-e2e-changes", () => {
     expect(playwrightSetup).toContain("bunx playwright install-deps chromium");
   });
 
+  test("isolates cross-engine stack redaction from Chromium E2E", () => {
+    const plan = workflowJob("ci-plan");
+    const stackRedaction = workflowJob("stack-redaction-browsers");
+    const result = workflowJob("ci-result");
+
+    expect(plan).toContain("stack_redaction_browsers_required:");
+    for (const owningPath of [
+      "apps/web/src/lib/analytics/stack-redaction.ts",
+      "apps/web/e2e/stack-redaction/*",
+      "apps/web/e2e/playwright.stack-redaction.config.ts",
+      "apps/web/e2e/tsconfig.json",
+      "apps/web/tsconfig.json",
+      "scripts/bun-ci-retry.sh",
+      "bunfig.toml",
+      ".npmrc",
+    ]) {
+      expect(plan).toContain(owningPath);
+    }
+    expect(stackRedaction).toContain(
+      "needs.ci-plan.outputs.stack_redaction_browsers_required == 'true'",
+    );
+    expect(stackRedaction).toContain(
+      "bunx playwright install --with-deps firefox webkit",
+    );
+    expect(stackRedaction).toContain(
+      "bun --filter @stll/web test:e2e:stack-redaction",
+    );
+    expect(stackRedaction).not.toContain("setup-playwright");
+    expect(result).toContain("stack-redaction-browsers");
+    expect(result).toContain("STACK_REDACTION_BROWSERS_RESULT");
+  });
+
   test("mints the release App token only inside its deployment environment", () => {
     // The key is an environment secret of `release-app`, whose deployment
     // policy is main and release tags. A job that reads it without declaring


### PR DESCRIPTION
## Proposed change

`redactedStack` in `apps/web/src/lib/analytics/posthog.ts` keeps only stack lines matching `/^\s+at /`. That is V8's frame syntax. SpiderMonkey and JavaScriptCore emit no `<name>: <message>` header and write frames as `symbol@url:line:column`, so on those engines the filter matches nothing, `redactedStack` returns `undefined`, and `toRedactedTelemetryError` deletes `stack` outright: the error reaches `captureException` with no frames at all.

Frames are also the only grouping component `fingerprintExceptionEvent` has beyond the error class and the boundary area, so every frameless capture of a class shares one fingerprint.

The filter now matches either frame syntax. Redaction is unchanged:

- The `<name>: <message>` header still never passes. It cannot match the callsite pattern either, since the header always carries a space before any `@`, and a callsite line has no message of its own (the symbol runs up to the `@`).
- `sanitizeFrame` still holds frame function names to `FRAME_SYMBOL` and strips query strings from filenames, so nothing free-form rides in on the newly kept lines.

The new test drives the redaction over both frame syntaxes and asserts the same invariant for each: every frame survives, the message does not. It fails on `main` for the callsite syntax with `stack === undefined`.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings. `bun --bun oxlint … apps/web/src/lib/analytics` and `bun ../../packages/scripts/src/tsc-native.ts --noEmit` are clean.
- [x] TESTING | `bun test src/lib/analytics` in `apps/web` (39 tests in `posthog.test.ts`, 78 across the directory).
- [ ] DARK MODE SUPPORT | n/a, no UI surface.
- [ ] ISSUE LINKED | n/a.
- [ ] SCREENSHOT INCLUDED | n/a.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LDMKGeJHHXdvuqoJWywSFa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error-reporting privacy by preserving useful stack-trace frames across different browsers while removing sensitive error messages and URL query parameters or fragments.
  * Prevented incomplete or frameless errors from exposing unsanitised stack details.
* **Tests**
  * Added browser coverage to verify consistent stack redaction across Firefox, WebKit, and multiple stack-trace formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->