### PR TITLE
fix(web): reject hand-assembled callsite stacks

### DIFF
--- a/apps/web/e2e/stack-redaction/capture-source.ts
+++ b/apps/web/e2e/stack-redaction/capture-source.ts
@@ -10,14 +10,7 @@ type CapturedStack = {
   redactedStack: string | undefined;
 };
 
-export const captureBrowserError = (): CapturedStack => {
-  const error = new TypeError(PRIVATE_ERROR_MESSAGE);
-  if (typeof error.stack === "string") {
-    error.stack = error.stack.replace(
-      /(?=:\d+:\d+(?:\n|$))/u,
-      "?matter=private#client",
-    );
-  }
+const capture = (error: Error): CapturedStack => {
   let redacted: Error | undefined;
   captureRedactedException(error, (captured) => {
     redacted = captured;
@@ -30,4 +23,23 @@ export const captureBrowserError = (): CapturedStack => {
     originalStack: error.stack,
     redactedStack: redacted?.stack,
   };
+};
+
+export const captureBrowserError = (): CapturedStack => {
+  const error = new TypeError(PRIVATE_ERROR_MESSAGE);
+  if (typeof error.stack === "string") {
+    error.stack = error.stack.replace(
+      /(?=:\d+:\d+(?:\n|$))/u,
+      "?matter=private#client",
+    );
+  }
+  return capture(error);
+};
+
+// The engine never writes a header, so a stack that opens with message text
+// was assembled by hand; every frame under it must be dropped.
+export const captureHeaderInjectedError = (): CapturedStack => {
+  const error = new TypeError(PRIVATE_ERROR_MESSAGE);
+  error.stack = [PRIVATE_ERROR_MESSAGE, error.stack ?? ""].join("\n");
+  return capture(error);
 };

--- a/apps/web/e2e/stack-redaction/main.ts
+++ b/apps/web/e2e/stack-redaction/main.ts
@@ -1,10 +1,15 @@
-import { captureBrowserError } from "./capture-source";
+import {
+  captureBrowserError,
+  captureHeaderInjectedError,
+} from "./capture-source";
 
 declare global {
   // oxlint-disable-next-line consistent-type-definitions -- global Window augmentation requires interface declaration merging
   interface Window {
     captureBrowserError: typeof captureBrowserError;
+    captureHeaderInjectedError: typeof captureHeaderInjectedError;
   }
 }
 
 window.captureBrowserError = captureBrowserError;
+window.captureHeaderInjectedError = captureHeaderInjectedError;

--- a/apps/web/e2e/stack-redaction/stack-redaction.spec.ts
+++ b/apps/web/e2e/stack-redaction/stack-redaction.spec.ts
@@ -47,3 +47,19 @@ test("retains Firefox and WebKit frames without URL metadata", async ({
   expect(captured.redactedStack).not.toContain("matter=private");
   expect(captured.redactedStack).not.toContain("client");
 });
+
+test("drops Firefox and WebKit stacks that open with message text", async ({
+  page,
+}) => {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  const captured = await page.evaluate(() =>
+    window.captureHeaderInjectedError(),
+  );
+
+  expect(captured.originalStack).toMatch(/^Privileged matter client name\n/u);
+  expect(captured.originalStack).toContain("captureHeaderInjectedError@");
+  expect(captured.name).toBe("TypeError");
+  expect(captured.message).toBe("");
+  expect(captured.redactedStack).toBeUndefined();
+});

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -449,6 +449,46 @@ describe("PostHog browser analytics adapter", () => {
     },
   );
 
+  test("stack redaction drops a callsite stack that starts with message text", () => {
+    expect(
+      redactTelemetryStack({
+        errorType: "Error",
+        stack: [
+          "Privileged document name",
+          "clientName@https://stella.test/assets/private.js:20:5",
+        ].join("\n"),
+        syntax: "callsite",
+      }),
+    ).toBeUndefined();
+  });
+
+  // A header whose message is frame-shaped is still a header: no engine
+  // may read it as a frame, with or without frames beneath it.
+  test.each(["callsite", "v8"] as const)(
+    "stack redaction drops a frame-shaped header under %s syntax",
+    (syntax) => {
+      expect(
+        redactTelemetryStack({
+          errorType: "TypeError",
+          stack:
+            "TypeError: notify jane@https://my.stll.app/matters/Client-Smith:1:2",
+          syntax,
+        }),
+      ).toBeUndefined();
+    },
+  );
+
+  test("stack redaction keeps callsite frames under a native built-in frame", () => {
+    const frame = "renderMatter@https://stella.test/assets/index.js:10:15";
+    expect(
+      redactTelemetryStack({
+        errorType: "SyntaxError",
+        stack: ["parse@[native code]", frame].join("\n"),
+        syntax: "callsite",
+      }),
+    ).toBe(["SyntaxError:", frame].join("\n"));
+  });
+
   const URL_METADATA_FRAMES = {
     callsiteQuery: {
       frame:

--- a/apps/web/src/lib/analytics/stack-redaction.ts
+++ b/apps/web/src/lib/analytics/stack-redaction.ts
@@ -22,7 +22,24 @@ const deepestCause = (error: Error): Error => {
 const V8_STACK_FRAME_SYNTAX = /^\s+at /u;
 const CALLSITE_STACK_FRAME_SYNTAX =
   /^(?:[Aa]sync\*)?(?:[\p{ID_Continue}$.<>[\]#~/]{0,120}|(?:global|module|eval) code)@\S+:\d+:\d+$/u;
+// JavaScriptCore reports built-ins as `<symbol>@[native code]`: no location
+// to keep, but a genuine stack start.
+const CALLSITE_NATIVE_FRAME_SYNTAX =
+  /^(?:[Aa]sync\*)?[\p{ID_Continue}$.<>[\]#~/]{0,120}@\[native code\]$/u;
 type StackFrameSyntax = "callsite" | "v8";
+
+// Neither callsite engine writes a header, so a stack whose first line is not
+// a frame was assembled by hand (a copied message, a rehydrated V8 stack).
+// Callsite-shaped lines below such a line are indistinguishable from message
+// content, so the whole stack is untrusted.
+const startsWithCallsiteFrame = (lines: readonly string[]): boolean => {
+  const first = lines.find((line) => line.length > 0);
+  return (
+    first !== undefined &&
+    (CALLSITE_STACK_FRAME_SYNTAX.test(first) ||
+      CALLSITE_NATIVE_FRAME_SYNTAX.test(first))
+  );
+};
 
 const hasOnlyDecimalDigits = (
   value: string,
@@ -129,10 +146,14 @@ export const redactTelemetryStack = ({
   stack,
   syntax,
 }: RedactTelemetryStackOptions): string | undefined => {
+  const lines = stack.split("\n");
+  if (syntax === "callsite" && !startsWithCallsiteFrame(lines)) {
+    return undefined;
+  }
   const frameSyntax =
     syntax === "callsite" ? CALLSITE_STACK_FRAME_SYNTAX : V8_STACK_FRAME_SYNTAX;
   const frames: string[] = [];
-  for (const line of stack.split("\n")) {
+  for (const line of lines) {
     if (!frameSyntax.test(line)) {
       continue;
     }

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -680,18 +680,35 @@ describe("detect-e2e-changes", () => {
     const result = workflowJob("ci-result");
 
     expect(plan).toContain("stack_redaction_browsers_required:");
-    for (const owningPath of [
-      "apps/web/src/lib/analytics/stack-redaction.ts",
-      "apps/web/e2e/stack-redaction/*",
-      "apps/web/e2e/playwright.stack-redaction.config.ts",
-      "apps/web/e2e/tsconfig.json",
-      "apps/web/tsconfig.json",
-      "scripts/bun-ci-retry.sh",
-      "bunfig.toml",
-      ".npmrc",
-    ]) {
-      expect(plan).toContain(owningPath);
+    // The selector is the complete owner set of the Firefox/WebKit guard:
+    // production redaction, the harness, and everything that shapes how the
+    // harness is built or installed. Set equality in both directions, so a
+    // dropped owner fails here instead of silently skipping the job.
+    const selector =
+      /\n *([^\n)]+)\)\n *stack_redaction_browsers_required=true\n/u.exec(
+        plan,
+      )?.[1];
+    if (selector === undefined) {
+      throw new Error("ci-plan has no stack-redaction path selector");
     }
+    expect(new Set(selector.split("|"))).toEqual(
+      new Set([
+        "apps/web/src/lib/analytics/posthog.ts",
+        "apps/web/src/lib/analytics/stack-redaction.ts",
+        "apps/web/src/lib/analytics/error-diagnostics.ts",
+        "apps/web/e2e/stack-redaction/*",
+        "apps/web/e2e/playwright.stack-redaction.config.ts",
+        "apps/web/e2e/tsconfig.json",
+        "apps/web/tsconfig.json",
+        "apps/web/package.json",
+        "scripts/bun-ci-retry.sh",
+        "bunfig.toml",
+        "package.json",
+        "bun.lock",
+        ".npmrc",
+        ".github/workflows/ci.yml",
+      ]),
+    );
     expect(stackRedaction).toContain(
       "needs.ci-plan.outputs.stack_redaction_browsers_required == 'true'",
     );


### PR DESCRIPTION
## Proposed change

Follow-up to #2744, which retains SpiderMonkey and JavaScriptCore frames when redacting telemetry stacks.

Neither callsite engine writes a `<name>: <message>` header, so a callsite stack whose first non-empty line is not a frame was assembled from text (a copied message, a rehydrated V8 stack). Callsite-shaped lines under such a line cannot be told apart from message content. `redactTelemetryStack` now returns `undefined` for callsite syntax unless the stack opens with a callsite frame or a JavaScriptCore `<symbol>@[native code]` built-in frame; V8 handling is unchanged.

The workflow test for the Firefox/WebKit guard now parses the ci-plan selector and asserts set equality with the complete owner list in both directions, so a dropped owner fails the test instead of silently skipping the job.

## Tests

- Unit: a message line above a callsite-shaped line yields no stack; a frame-shaped header (`TypeError: notify jane@https://…:1:2`) yields no stack under both syntaxes; frames under a native built-in frame survive. Disabling the guard fails the first test.
- Browser harness (native Firefox and WebKit): prepending message text to a live stack yields no redacted stack; the existing frame-retention case still passes.
- Workflow: removing an owner from the ci.yml selector fails the census test.

https://claude.ai/code/session_01ScmEtmrqPZUhzmtxFRZgEt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved telemetry stack redaction across Firefox, WebKit and Chromium.
  - Invalid or manually assembled error stacks are now discarded instead of being submitted as misleading data.
  - Valid callsite frames continue to be retained, including stacks containing native browser frames.

- **Tests**
  - Added coverage for browser-specific stack formats and edge cases.
  - Expanded safeguards to ensure all relevant stack-redaction changes trigger the appropriate cross-browser checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->