### PR TITLE
fix: harden OAuth UI redirects for CDN compatibility

### DIFF
--- a/apps/api/src/handlers/auth/ui-routes.ts
+++ b/apps/api/src/handlers/auth/ui-routes.ts
@@ -6,6 +6,7 @@ import {
   OAUTH_UI_LOGIN_PATH,
   OAUTH_UI_ORGANIZATION_PATH,
 } from "@/api/lib/auth-paths";
+import { bridgeOauthUiRedirect } from "@/api/lib/oauth-ui-fragment";
 
 export {
   OAUTH_UI_CONSENT_PATH,
@@ -14,8 +15,6 @@ export {
 } from "@/api/lib/auth-paths";
 
 const OAUTH_SIGNATURE_PARAM = "sig";
-const OAUTH_QUERY_HASH_PARAM = "oauth_query";
-
 const redirectToFrontend = ({
   path,
   request,
@@ -27,9 +26,14 @@ const redirectToFrontend = ({
   const redirectUrl = new URL(path, `${env.FRONTEND_URL.replace(/\/$/u, "")}/`);
 
   if (url.searchParams.has(OAUTH_SIGNATURE_PARAM)) {
-    const fragment = new URLSearchParams();
-    fragment.set(OAUTH_QUERY_HASH_PARAM, url.search.slice(1));
-    redirectUrl.hash = fragment.toString();
+    const bridged = bridgeOauthUiRedirect({
+      authOrigin: url.origin,
+      frontendUrl: env.FRONTEND_URL,
+      location: url.toString(),
+    });
+    if (bridged) {
+      return Response.redirect(bridged, 302);
+    }
   } else {
     redirectUrl.search = url.search;
   }

--- a/apps/api/src/lib/auth.test.ts
+++ b/apps/api/src/lib/auth.test.ts
@@ -853,6 +853,17 @@ describe("OAuth resource provisioning", () => {
 
     expect(oauthPlugin.options.resourceSeedMode).toBe("none");
   });
+
+  test("the fragment bridge runs after the OAuth provider", () => {
+    const pluginIds = getAuth().options.plugins.map((plugin) => plugin.id);
+    const oauthProviderIndex = pluginIds.indexOf("oauth-provider");
+    const fragmentBridgeIndex = pluginIds.indexOf(
+      "stella-oauth-ui-fragment-bridge",
+    );
+
+    expect(oauthProviderIndex).toBeGreaterThanOrEqual(0);
+    expect(fragmentBridgeIndex).toBeGreaterThan(oauthProviderIndex);
+  });
 });
 
 describe("organization lifecycle hook wiring", () => {

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -775,12 +775,12 @@ const oauthUiFragmentBridgePlugin = {
       {
         matcher: (ctx: HookEndpointContext) =>
           ctx.path?.startsWith("/oauth2/") ?? false,
-        // eslint-disable-next-line typescript/require-await -- createAuthMiddleware requires a Promise-returning handler; bridging mutates Better Auth's synchronous response boundary only.
         handler: createAuthMiddleware(async (ctx) => {
           bridgeOauthUiInteraction(ctx.context, {
             authOrigin: env.BETTER_AUTH_URL,
             frontendUrl: env.FRONTEND_URL,
           });
+          await Promise.resolve();
         }),
       },
     ],

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -89,6 +89,7 @@ import {
 } from "@/api/lib/machine-api-key-config";
 import { isMemberRole } from "@/api/lib/member-roles";
 import { getBetterAuthOAuthResources } from "@/api/lib/oauth-resource-policy";
+import { bridgeOauthUiInteraction } from "@/api/lib/oauth-ui-fragment";
 import {
   enrichRequestContext,
   getRequestContext,
@@ -762,6 +763,30 @@ const socialSignInTwoFactorRedirectPlugin = {
   },
 } satisfies BetterAuthPlugin;
 
+/**
+ * Keeps signed OAuth interaction state, including native-client loopback URIs,
+ * out of CDN-visible URLs. It must run after the OAuth provider so it can
+ * rewrite both its navigation response and its fetch-mode redirect object.
+ */
+const oauthUiFragmentBridgePlugin = {
+  id: "stella-oauth-ui-fragment-bridge",
+  hooks: {
+    after: [
+      {
+        matcher: (ctx: HookEndpointContext) =>
+          ctx.path?.startsWith("/oauth2/") ?? false,
+        // eslint-disable-next-line typescript/require-await -- createAuthMiddleware requires a Promise-returning handler; bridging mutates Better Auth's synchronous response boundary only.
+        handler: createAuthMiddleware(async (ctx) => {
+          bridgeOauthUiInteraction(ctx.context, {
+            authOrigin: env.BETTER_AUTH_URL,
+            frontendUrl: env.FRONTEND_URL,
+          });
+        }),
+      },
+    ],
+  },
+} satisfies BetterAuthPlugin;
+
 // Lazy singleton: `betterAuth()` eagerly resolves the
 // database adapter, which accesses `rootDb`. Deferring to
 // first use prevents the TDZ error when the test runner
@@ -1267,6 +1292,7 @@ const createAuth = () => {
           org_id: referenceId,
         }),
       }),
+      oauthUiFragmentBridgePlugin,
     ],
     hooks: {
       before: createAuthMiddleware(async (ctx) => {

--- a/apps/api/src/lib/oauth-ui-fragment.test.ts
+++ b/apps/api/src/lib/oauth-ui-fragment.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  OAUTH_UI_CONSENT_PATH,
+  OAUTH_UI_LOGIN_PATH,
+  OAUTH_UI_ORGANIZATION_PATH,
+} from "@/api/lib/auth-paths";
+import {
+  bridgeOauthUiInteraction,
+  bridgeOauthUiRedirect,
+} from "@/api/lib/oauth-ui-fragment";
+
+const authOrigin = "https://api.stella.example";
+const frontendUrl = "https://app.stella.example";
+const rawQuery =
+  "client_id=cli&ba_param=redirect_uri&ba_param=scope&redirect_uri=http%3A%2F%2F127.0.0.1%3A54321%2Fcallback&scope=openid%20stella%3Aread&sig=signed%2Bvalue%3D";
+
+describe("OAuth UI fragment bridge", () => {
+  test.each([
+    [OAUTH_UI_LOGIN_PATH, "/auth"],
+    [OAUTH_UI_ORGANIZATION_PATH, "/auth/organization"],
+    [OAUTH_UI_CONSENT_PATH, "/consent"],
+  ])(
+    "keeps signed interaction state off the network for %s",
+    (apiPath, frontendPath) => {
+      const bridged = bridgeOauthUiRedirect({
+        authOrigin,
+        frontendUrl,
+        location: `${apiPath}?${rawQuery}`,
+      });
+
+      expect(bridged).not.toBeNull();
+      const redirect = new URL(bridged ?? "http://invalid");
+      expect(`${redirect.origin}${redirect.pathname}`).toBe(
+        `${frontendUrl}${frontendPath}`,
+      );
+      expect(redirect.search).toBe("");
+      expect(
+        new URLSearchParams(redirect.hash.slice(1)).get("oauth_query"),
+      ).toBe(rawQuery);
+    },
+  );
+
+  test("rewrites the browser redirect before a CDN can inspect its query", () => {
+    const responseHeaders = new Headers({
+      location: `${OAUTH_UI_LOGIN_PATH}?${rawQuery}`,
+    });
+    const interaction = { responseHeaders, returned: undefined };
+
+    bridgeOauthUiInteraction(interaction, { authOrigin, frontendUrl });
+
+    const location = responseHeaders.get("location");
+    expect(location).not.toBeNull();
+    const redirect = new URL(location ?? "http://invalid");
+    expect(redirect.search).toBe("");
+    expect(redirect.hash).toContain("oauth_query=");
+  });
+
+  test("rewrites fetch-mode redirects used between organization and consent", () => {
+    const interaction: {
+      responseHeaders: Headers | undefined;
+      returned: unknown;
+    } = {
+      responseHeaders: undefined,
+      returned: {
+        redirect: true,
+        url: `${OAUTH_UI_CONSENT_PATH}?${rawQuery}`,
+      },
+    };
+
+    bridgeOauthUiInteraction(interaction, { authOrigin, frontendUrl });
+
+    expect(interaction.returned).toEqual({
+      redirect: true,
+      url: expect.stringContaining(`${frontendUrl}/consent#oauth_query=`),
+    });
+  });
+
+  test.each([
+    [
+      "unsigned interaction",
+      `${OAUTH_UI_LOGIN_PATH}?redirect_uri=http://127.0.0.1/callback`,
+    ],
+    [
+      "unrelated client redirect",
+      "http://127.0.0.1:54321/callback?code=secret&sig=value",
+    ],
+    [
+      "lookalike external route",
+      `https://attacker.example${OAUTH_UI_LOGIN_PATH}?${rawQuery}`,
+    ],
+  ])("does not rewrite %s", (_name, location) => {
+    expect(
+      bridgeOauthUiRedirect({ authOrigin, frontendUrl, location }),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/lib/oauth-ui-fragment.ts
+++ b/apps/api/src/lib/oauth-ui-fragment.ts
@@ -1,0 +1,107 @@
+import {
+  OAUTH_UI_CONSENT_PATH,
+  OAUTH_UI_LOGIN_PATH,
+  OAUTH_UI_ORGANIZATION_PATH,
+} from "@/api/lib/auth-paths";
+
+const OAUTH_SIGNATURE_PARAM = "sig";
+const OAUTH_QUERY_HASH_PARAM = "oauth_query";
+
+const OAUTH_UI_FRONTEND_PATHS = {
+  [OAUTH_UI_CONSENT_PATH]: "/consent",
+  [OAUTH_UI_LOGIN_PATH]: "/auth",
+  [OAUTH_UI_ORGANIZATION_PATH]: "/auth/organization",
+} as const satisfies Record<
+  | typeof OAUTH_UI_CONSENT_PATH
+  | typeof OAUTH_UI_LOGIN_PATH
+  | typeof OAUTH_UI_ORGANIZATION_PATH,
+  string
+>;
+
+type BridgeOauthUiRedirectOptions = {
+  authOrigin: string;
+  frontendUrl: string;
+  location: string;
+};
+
+const isOauthUiPath = (
+  path: string,
+): path is keyof typeof OAUTH_UI_FRONTEND_PATHS =>
+  Object.hasOwn(OAUTH_UI_FRONTEND_PATHS, path);
+
+/**
+ * Moves Better Auth's signed interaction query into a browser fragment.
+ *
+ * The signed value contains the OAuth client's loopback redirect URI. Keeping
+ * it in a query makes CDNs and WAFs inspect (and commonly block) the navigation
+ * before Stella can render the login page. Fragments never cross the network;
+ * the web client returns the unchanged signed query in `oauth_query` when it
+ * continues the flow, so signature verification remains the trust boundary.
+ */
+export const bridgeOauthUiRedirect = ({
+  authOrigin,
+  frontendUrl,
+  location,
+}: BridgeOauthUiRedirectOptions): string | null => {
+  const trustedAuthOrigin = new URL(authOrigin).origin;
+  const source = new URL(location, `${trustedAuthOrigin}/`);
+
+  if (
+    source.origin !== trustedAuthOrigin ||
+    !isOauthUiPath(source.pathname) ||
+    !source.searchParams.has(OAUTH_SIGNATURE_PARAM)
+  ) {
+    return null;
+  }
+
+  const redirect = new URL(
+    OAUTH_UI_FRONTEND_PATHS[source.pathname],
+    `${frontendUrl.replace(/\/$/u, "")}/`,
+  );
+  const fragment = new URLSearchParams();
+  fragment.set(OAUTH_QUERY_HASH_PARAM, source.search.slice(1));
+  redirect.hash = fragment.toString();
+  return redirect.toString();
+};
+
+type OauthUiInteraction = {
+  responseHeaders?: Headers | undefined;
+  returned?: unknown;
+};
+
+const isJsonRedirect = (
+  value: unknown,
+): value is { redirect: true; url: string } =>
+  typeof value === "object" &&
+  value !== null &&
+  "redirect" in value &&
+  value.redirect === true &&
+  "url" in value &&
+  typeof value.url === "string";
+
+/** Rewrites both browser 302s and Better Auth's fetch-mode redirect object. */
+export const bridgeOauthUiInteraction = (
+  interaction: OauthUiInteraction,
+  options: Omit<BridgeOauthUiRedirectOptions, "location">,
+): void => {
+  if (isJsonRedirect(interaction.returned)) {
+    const url = bridgeOauthUiRedirect({
+      ...options,
+      location: interaction.returned.url,
+    });
+    if (url) {
+      interaction.returned = { redirect: true, url };
+    }
+    return;
+  }
+
+  const location = interaction.responseHeaders?.get("location");
+  if (!location) {
+    return;
+  }
+
+  const bridged = bridgeOauthUiRedirect({ ...options, location });
+  if (bridged) {
+    interaction.responseHeaders?.set("location", bridged);
+  }
+};

--- a/apps/web/e2e/specs/oauth-ui-redirect.spec.ts
+++ b/apps/web/e2e/specs/oauth-ui-redirect.spec.ts
@@ -81,6 +81,9 @@ test("the real OAuth authorization redirect keeps its signed query in the fragme
 
     await page.goto(authorizeUrl.toString(), { waitUntil: "commit" });
     const authorizeResponse = await authorizeResponsePromise;
+    await expect(page.getByRole("heading", { name: /sign in/iu })).toBeVisible({
+      timeout: 30_000,
+    });
     const locationHeader = authorizeResponse.headers()["location"];
     expect(locationHeader).toBeDefined();
 

--- a/apps/web/e2e/specs/oauth-ui-redirect.spec.ts
+++ b/apps/web/e2e/specs/oauth-ui-redirect.spec.ts
@@ -1,0 +1,117 @@
+import {
+  type APIRequestContext,
+  request as playwrightRequest,
+} from "@playwright/test";
+import { createHash, randomUUID } from "node:crypto";
+
+import { expect, test } from "../helpers/test";
+
+const API_BASE_URL = process.env["E2E_API_URL"] ?? "http://localhost:3001";
+const WEB_BASE_URL = process.env["E2E_WEB_URL"] ?? "http://localhost:3000";
+const AUTH_BASE_URL = `${API_BASE_URL}/api/auth`;
+const redirectUriFor = (token: string) =>
+  `http://127.0.0.1:54321/callback/${token}`;
+
+const readClientId = (value: unknown): string => {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("client_id" in value) ||
+    typeof value.client_id !== "string"
+  ) {
+    throw new Error("OAuth registration response did not include client_id");
+  }
+  return value.client_id;
+};
+
+const registerBrowserClient = async (
+  request: APIRequestContext,
+  token: string,
+): Promise<string> => {
+  const response = await request.post(`${AUTH_BASE_URL}/oauth2/register`, {
+    data: {
+      application_type: "native",
+      client_name: `OAuth redirect browser test ${token}`,
+      grant_types: ["authorization_code"],
+      redirect_uris: [redirectUriFor(token)],
+      require_pkce: true,
+      response_types: ["code"],
+      scope: "openid profile",
+      token_endpoint_auth_method: "none",
+    },
+  });
+  expect(response.ok(), await response.text()).toBe(true);
+  return readClientId(await response.json());
+};
+
+test("the real OAuth authorization redirect keeps its signed query in the fragment", async ({
+  page,
+}) => {
+  const token = randomUUID().replaceAll("-", "");
+  const verifier = `oauth-browser-${token}`;
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  const apiRequest = await playwrightRequest.newContext({
+    extraHTTPHeaders: { origin: new URL(WEB_BASE_URL).origin },
+  });
+
+  try {
+    const clientId = await registerBrowserClient(apiRequest, token);
+    const authorizeUrl = new URL(`${AUTH_BASE_URL}/oauth2/authorize`);
+    authorizeUrl.searchParams.set("client_id", clientId);
+    authorizeUrl.searchParams.set("code_challenge", challenge);
+    authorizeUrl.searchParams.set("code_challenge_method", "S256");
+    authorizeUrl.searchParams.set("redirect_uri", redirectUriFor(token));
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("scope", "openid profile");
+    authorizeUrl.searchParams.set("state", `state-${token}`);
+
+    await page.context().clearCookies();
+    const authorizeResponsePromise = page.waitForResponse((response) => {
+      const responseUrl = new URL(response.url());
+      return (
+        response.status() === 302 &&
+        responseUrl.origin === authorizeUrl.origin &&
+        responseUrl.pathname === authorizeUrl.pathname
+      );
+    });
+    const requestUrls: string[] = [];
+    page.on("request", (request) => {
+      requestUrls.push(request.url());
+    });
+
+    await page.goto(authorizeUrl.toString(), { waitUntil: "commit" });
+    const authorizeResponse = await authorizeResponsePromise;
+    const locationHeader = authorizeResponse.headers()["location"];
+    expect(locationHeader).toBeDefined();
+
+    const redirect = new URL(locationHeader ?? "http://invalid");
+    const frontendAuthUrl = new URL("/auth", `${WEB_BASE_URL}/`);
+    expect(`${redirect.origin}${redirect.pathname}`).toBe(
+      `${frontendAuthUrl.origin}${frontendAuthUrl.pathname}`,
+    );
+    expect(redirect.search).toBe("");
+    const bridgedQuery = new URLSearchParams(redirect.hash.slice(1)).get(
+      "oauth_query",
+    );
+    expect(bridgedQuery).not.toBeNull();
+    const bridgedParams = new URLSearchParams(bridgedQuery ?? "");
+    expect(bridgedParams.get("client_id")).toBe(clientId);
+    expect(bridgedParams.get("code_challenge")).toBe(challenge);
+    expect(bridgedParams.get("redirect_uri")).toBe(redirectUriFor(token));
+    expect(bridgedParams.get("scope")).toBe("openid profile");
+    expect(bridgedParams.get("state")).toBe(`state-${token}`);
+    expect(bridgedParams.get("sig")).not.toBeNull();
+
+    const signedRequestUrls = requestUrls.filter((url) => {
+      try {
+        return new URL(url).searchParams.has("sig");
+      } catch {
+        return false;
+      }
+    });
+    expect(signedRequestUrls).toEqual([]);
+    expect(new URL(page.url()).hash).toBe(redirect.hash);
+  } finally {
+    await apiRequest.dispose();
+  }
+});


### PR DESCRIPTION
## Summary

- move signed OAuth interaction state into the URL fragment at the auth response boundary
- preserve the signed payload exactly across browser and fetch-mode redirects
- reuse one guarded bridge for OAuth UI fallback routes and enforce plugin ordering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Improvements**
  - OAuth redirect details are now kept in the browser URL fragment instead of the query string, reducing exposure to CDNs and web application firewalls.
  - Applies consistently across login, organisation, consent, browser redirects, and fetch-based OAuth flows.

- **Bug Fixes**
  - Improved validation ensures only trusted OAuth redirects are rewritten.

- **Tests**
  - Added coverage for OAuth redirect handling, security checks, and end-to-end authorisation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->