### PR TITLE
fix: keep review edits in the document language and repair contradicted answers

### DIFF
--- a/apps/api/src/lib/document-review/reference-grade-ai.test.ts
+++ b/apps/api/src/lib/document-review/reference-grade-ai.test.ts
@@ -1,9 +1,12 @@
 /**
  * The model-dispatch boundary of reference grading: what tenant scope reaches
- * model ingress, and what a provider failure reports. The derivation itself is
- * covered by `reference-grade.test.ts`.
+ * model ingress, what a provider failure reports, and when a batch is sent
+ * back for repair. The derivation itself is covered by
+ * `reference-grade.test.ts`, the repair rules by
+ * `reference-grade-repair.test.ts`.
  */
 
+import type { ModelMessage } from "@tanstack/ai";
 import { Result } from "better-result";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -25,12 +28,39 @@ import type {
 
 type CapturedGenerateOptions = {
   tenantWorkspaceIds: readonly SafeId<"workspace">[];
+  messages: readonly ModelMessage[];
 };
 
+const POSITION_ID = "11111111-1111-4111-8111-111111111111";
+
+const answer = (blockId: string) => ({
+  positionId: POSITION_ID,
+  assessment: "different" as const,
+  consensus: "single" as const,
+  rationale: "The target differs.",
+  recommendation: "",
+  impact: "unknown" as const,
+  direction: "unknown" as const,
+  delta: {
+    targetValue: null,
+    standardValue: null,
+    items: [],
+    term: "",
+    inTarget: false,
+    inStandard: false,
+  },
+  proposedText: null,
+  targetCitations: [{ blockId }],
+});
+
 const capturedGenerateOptions: CapturedGenerateOptions[] = [];
+/** Answers the mock hands back in order; a call past the queue answers
+ *  nothing. Queued rather than `mockResolvedValueOnce`, which would skip the
+ *  capture above. */
+const queuedAnswers: { findings: ReturnType<typeof answer>[] }[] = [];
 const generateObjectMock = mock(async (options: CapturedGenerateOptions) => {
   capturedGenerateOptions.push(options);
-  return await Promise.resolve({ findings: [] });
+  return await Promise.resolve(queuedAnswers.shift() ?? { findings: [] });
 });
 // SAFETY: This suite only dispatches the reference-grading schema and
 // configures outputs matching that schema; Bun's mock type cannot express that
@@ -61,7 +91,7 @@ const grade = async () =>
     perspective: NEUTRAL_PERSPECTIVE,
     positions: [
       {
-        sourceId: "11111111-1111-4111-8111-111111111111",
+        sourceId: POSITION_ID,
         issue: "Payment timing",
         termKind: "language",
         passages: [
@@ -86,6 +116,7 @@ const grade = async () =>
       simplifiedName: "F0",
       blocks: [{ id: "target-block", kind: "paragraph", text: "Alpha term" }],
     },
+    targetLanguage: null,
     targetEntityVersionId: toSafeId<"entityVersion">("target-version-fixture"),
     referenceEntityVersionIds: [
       toSafeId<"entityVersion">("reference-version-fixture"),
@@ -105,6 +136,8 @@ describe("reference grading AI boundary", () => {
   let logs: RecordingLogger;
 
   beforeEach(() => {
+    capturedGenerateOptions.length = 0;
+    queuedAnswers.length = 0;
     analytics = installRecordingAnalytics();
     logs = installRecordingLogger();
   });
@@ -115,7 +148,7 @@ describe("reference grading AI boundary", () => {
   });
 
   test("passes the authorized workspace scope to model ingress", async () => {
-    capturedGenerateOptions.length = 0;
+    queuedAnswers.push({ findings: [answer("target-block")] });
 
     const result = await grade();
 
@@ -124,6 +157,52 @@ describe("reference grading AI boundary", () => {
       workspaceId,
     ]);
     expect(analytics.exceptions()).toEqual([]);
+  });
+
+  test("a batch that checks out is one call", async () => {
+    queuedAnswers.push({ findings: [answer("target-block")] });
+
+    await grade();
+
+    expect(capturedGenerateOptions).toHaveLength(1);
+  });
+
+  test("an answer the documents contradict is re-asked once, with the batch shown back", async () => {
+    queuedAnswers.push(
+      { findings: [answer("no-such-block")] },
+      { findings: [answer("target-block")] },
+    );
+
+    const result = await grade();
+
+    expect(capturedGenerateOptions).toHaveLength(2);
+    const repair = capturedGenerateOptions.at(1)?.messages ?? [];
+    expect(repair.map(({ role }) => role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+    ]);
+    expect(repair.at(0)).toEqual(capturedGenerateOptions.at(0)?.messages.at(0));
+    expect(repair.at(1)?.content).toContain("no-such-block");
+    expect(repair.at(2)?.content).toContain(`positionId=${POSITION_ID}`);
+    expect(repair.at(2)?.content).toContain("cites no-such-block");
+    expect(
+      Result.isOk(result) ? result.value.get(POSITION_ID)?.citations : null,
+    ).toEqual([{ blockId: "target-block", text: "Alpha term" }]);
+  });
+
+  test("an answer that still fails after repair is dropped, not re-asked", async () => {
+    queuedAnswers.push(
+      { findings: [answer("no-such-block")] },
+      { findings: [answer("no-such-block")] },
+    );
+
+    const result = await grade();
+
+    expect(capturedGenerateOptions).toHaveLength(2);
+    expect(
+      Result.isOk(result) ? result.value.get(POSITION_ID)?.explanation : null,
+    ).toEqual({ type: "insufficient-evidence" });
   });
 
   test("reports a provider failure under the reference review feature", async () => {

--- a/apps/api/src/lib/document-review/reference-grade-ai.test.ts
+++ b/apps/api/src/lib/document-review/reference-grade-ai.test.ts
@@ -25,6 +25,7 @@ import type {
   RecordingAnalytics,
   RecordingLogger,
 } from "@/api/tests/helpers/recording-telemetry";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 type CapturedGenerateOptions = {
   tenantWorkspaceIds: readonly SafeId<"workspace">[];
@@ -62,11 +63,8 @@ const generateObjectMock = mock(async (options: CapturedGenerateOptions) => {
   capturedGenerateOptions.push(options);
   return await Promise.resolve(queuedAnswers.shift() ?? { findings: [] });
 });
-// SAFETY: This suite only dispatches the reference-grading schema and
-// configures outputs matching that schema; Bun's mock type cannot express that
-// generic tie.
 const generateObjectForTest =
-  generateObjectMock as typeof generateTanStackObjectForRole;
+  asTestRaw<typeof generateTanStackObjectForRole>(generateObjectMock);
 
 const organizationId = toSafeId<"organization">("organization-fixture");
 const workspaceId = toSafeId<"workspace">("workspace-fixture");

--- a/apps/api/src/lib/document-review/reference-grade-repair.test.ts
+++ b/apps/api/src/lib/document-review/reference-grade-repair.test.ts
@@ -1,0 +1,196 @@
+/**
+ * What a grading batch is sent back for. Each rule names a mistake the
+ * documents can prove, so the tests are one proven mistake each, plus the
+ * merge that decides which answer survives.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildRepairMessage,
+  findGradingViolations,
+  mergeRepairedFindings,
+} from "@/api/lib/document-review/reference-grade-repair";
+
+const TARGET_BLOCK =
+  "Nároky musí být oznámeny do 12 (dvanácti) měsíců od dokončení díla, jinak zanikají.";
+const STANDARD_BLOCK =
+  "Nároky musí být oznámeny do 6 (šesti) měsíců od dokončení díla, jinak zanikají.";
+
+const targetBlocks = new Map([["p-1", TARGET_BLOCK]]);
+
+const position = (sourceId = "pos-1") => ({
+  sourceId,
+  passages: [{ blockId: "r-9", text: STANDARD_BLOCK }],
+});
+
+const emptyDelta = {
+  targetValue: null,
+  standardValue: null,
+  items: [],
+};
+
+const finding = (overrides: Record<string, unknown> = {}) => ({
+  positionId: "pos-1",
+  proposedText: null,
+  targetCitations: [{ blockId: "p-1" }],
+  delta: emptyDelta,
+  ...overrides,
+});
+
+const violations = (
+  findings: readonly ReturnType<typeof finding>[],
+  positions = [position()],
+) =>
+  findGradingViolations({
+    positions,
+    findings,
+    targetBlocks,
+    targetLanguage: "CS",
+  });
+
+describe("findGradingViolations", () => {
+  test("a batch that checks out has nothing to repair", () => {
+    expect(
+      violations([
+        finding({
+          proposedText: STANDARD_BLOCK,
+          delta: {
+            ...emptyDelta,
+            targetValue: { text: "12 (dvanácti) měsíců", blockId: "p-1" },
+            standardValue: { text: "6 (šesti) měsíců", blockId: "r-9" },
+          },
+        }),
+      ]),
+    ).toEqual([]);
+  });
+
+  test("a position without an answer is asked again", () => {
+    expect(violations([])).toEqual([
+      {
+        positionId: "pos-1",
+        reasons: ["no answer was given for this position."],
+      },
+    ]);
+  });
+
+  test("a block id the target does not have is named, once", () => {
+    const [violation] = violations([
+      finding({
+        targetCitations: [{ blockId: "p-1" }, { blockId: "p-404" }],
+        delta: {
+          ...emptyDelta,
+          targetValue: { text: "12 (dvanácti) měsíců", blockId: "p-404" },
+        },
+      }),
+    ]);
+    expect(violation?.reasons).toEqual([
+      "cites p-404, which the target document has no block for; cite only block ids of the target.",
+    ]);
+  });
+
+  test("a standard value outside the position's passages is named", () => {
+    const [violation] = violations([
+      finding({
+        delta: {
+          ...emptyDelta,
+          standardValue: { text: "6 (šesti) měsíců", blockId: "r-1" },
+        },
+      }),
+    ]);
+    expect(violation?.reasons).toEqual([
+      "delta.standardValue cites r-1, which is not one of this position's standard passages.",
+    ]);
+  });
+
+  test("a term the block does not write that way is a misquote", () => {
+    const [violation] = violations([
+      finding({
+        delta: {
+          ...emptyDelta,
+          targetValue: { text: "12 měsíců", blockId: "p-1" },
+          standardValue: { text: "6 měsíců", blockId: "r-9" },
+        },
+      }),
+    ]);
+    expect(violation?.reasons).toEqual([
+      "delta.targetValue.text is not written in block p-1 as given; copy the term character for character.",
+      "delta.standardValue.text is not written in block r-9 as given; copy the term character for character.",
+    ]);
+  });
+
+  test("wording in another language names both languages", () => {
+    const [violation] = violations([
+      finding({
+        proposedText:
+          "Claims must be notified within 6 months of completion, failing which they lapse.",
+      }),
+    ]);
+    expect(violation?.reasons).toEqual([
+      "proposedText is written in British English; the target document is written in Czech. Rewrite it in Czech, keeping the standard's meaning.",
+    ]);
+  });
+
+  test("only the first answer for a position is checked", () => {
+    expect(
+      violations([
+        finding(),
+        finding({ targetCitations: [{ blockId: "p-404" }] }),
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("buildRepairMessage", () => {
+  test("lists each position with its reasons in the model's field names", () => {
+    expect(
+      buildRepairMessage([
+        { positionId: "pos-1", reasons: ["first reason.", "second reason."] },
+        {
+          positionId: "pos-2",
+          reasons: ["no answer was given for this position."],
+        },
+      ]),
+    ).toBe(
+      [
+        "These answers do not check out against the documents. Answer the positions below again, once each, following the same rules; leave every other position out.",
+        "- positionId=pos-1",
+        "  - first reason.",
+        "  - second reason.",
+        "- positionId=pos-2",
+        "  - no answer was given for this position.",
+      ].join("\n"),
+    );
+  });
+});
+
+describe("mergeRepairedFindings", () => {
+  test("a repaired answer replaces the one it corrects and nothing else", () => {
+    const merged = mergeRepairedFindings({
+      findings: [
+        { positionId: "pos-1", mark: "original" },
+        { positionId: "pos-2", mark: "original" },
+      ],
+      repaired: [
+        { positionId: "pos-2", mark: "repaired" },
+        { positionId: "pos-2", mark: "repaired again" },
+        { positionId: "pos-3", mark: "unasked" },
+      ],
+      violations: [{ positionId: "pos-2", reasons: ["reason."] }],
+    });
+    expect(merged).toEqual([
+      { positionId: "pos-1", mark: "original" },
+      { positionId: "pos-2", mark: "repaired" },
+    ]);
+  });
+
+  test("an answer the repair did not return stays absent", () => {
+    expect(
+      mergeRepairedFindings({
+        findings: [{ positionId: "pos-1" }],
+        repaired: [],
+        violations: [{ positionId: "pos-1", reasons: ["reason."] }],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/apps/api/src/lib/document-review/reference-grade-repair.ts
+++ b/apps/api/src/lib/document-review/reference-grade-repair.ts
@@ -1,0 +1,199 @@
+/**
+ * The second look a grading batch gets when an answer does not check out.
+ *
+ * Every rule here names a mistake the documents can prove: a position left
+ * unanswered, a block id the target does not have, a term not written the way
+ * its block writes it, wording in a language the target is not in. The model
+ * is shown its own batch with those answers named and asked to correct only
+ * them. One round: whatever still fails is dropped by normalization the way
+ * it always was, and a repair never repairs a repair.
+ *
+ * Structural input types rather than the grading schema's own, so this module
+ * sits under `reference-grade` without importing from it; the call site's
+ * findings must still satisfy them, so a schema change that removes a field
+ * read here fails to compile.
+ */
+
+import {
+  languageDisplayName,
+  foreignLanguageOf,
+} from "@/api/lib/document-review/target-language";
+import type { ReviewTargetLanguage } from "@/api/lib/document-review/target-language";
+
+type RepairablePosition = {
+  sourceId: string;
+  passages: readonly { blockId: string; text: string }[];
+};
+
+type RepairableValue = { text: string; blockId: string } | null;
+
+type RepairableFinding = {
+  positionId: string;
+  proposedText: string | null;
+  targetCitations: readonly { blockId: string }[];
+  delta: {
+    targetValue: RepairableValue;
+    standardValue: RepairableValue;
+    items: readonly { blockId: string | null }[];
+  };
+};
+
+export type GradingViolation = { positionId: string; reasons: string[] };
+
+type FindGradingViolationsArgs = {
+  positions: readonly RepairablePosition[];
+  findings: readonly RepairableFinding[];
+  targetBlocks: ReadonlyMap<string, string>;
+  targetLanguage: ReviewTargetLanguage;
+};
+
+/** Every block id the finding claims the target has. */
+const citedTargetBlockIds = (finding: RepairableFinding): string[] => {
+  const ids = finding.targetCitations.map(({ blockId }) => blockId);
+  if (finding.delta.targetValue !== null) {
+    ids.push(finding.delta.targetValue.blockId);
+  }
+  for (const { blockId } of finding.delta.items) {
+    if (blockId !== null) {
+      ids.push(blockId);
+    }
+  }
+  return ids;
+};
+
+/** A term must be written exactly as its block writes it, or no fix can find
+ *  it. A missing block is reported as such, not as a misquoted term. */
+const misquotedTerm = (
+  field: string,
+  value: RepairableValue,
+  blocks: ReadonlyMap<string, string>,
+): string | null => {
+  if (value === null) {
+    return null;
+  }
+  const block = blocks.get(value.blockId);
+  if (block === undefined || block.includes(value.text.trim())) {
+    return null;
+  }
+  return `${field}.text is not written in block ${value.blockId} as given; copy the term character for character.`;
+};
+
+const findingViolations = (
+  finding: RepairableFinding,
+  position: RepairablePosition,
+  { targetBlocks, targetLanguage }: FindGradingViolationsArgs,
+): string[] => {
+  const reasons: string[] = [];
+
+  const unknownTargetIds = [
+    ...new Set(
+      citedTargetBlockIds(finding).filter((id) => !targetBlocks.has(id)),
+    ),
+  ];
+  if (unknownTargetIds.length > 0) {
+    reasons.push(
+      `cites ${unknownTargetIds.join(", ")}, which the target document has no block for; cite only block ids of the target.`,
+    );
+  }
+
+  const standardBlocks = new Map(
+    position.passages.map(({ blockId, text }) => [blockId, text]),
+  );
+  const standardValue = finding.delta.standardValue;
+  if (standardValue !== null && !standardBlocks.has(standardValue.blockId)) {
+    reasons.push(
+      `delta.standardValue cites ${standardValue.blockId}, which is not one of this position's standard passages.`,
+    );
+  }
+
+  const targetTerm = misquotedTerm(
+    "delta.targetValue",
+    finding.delta.targetValue,
+    targetBlocks,
+  );
+  if (targetTerm !== null) {
+    reasons.push(targetTerm);
+  }
+  const standardTerm = misquotedTerm(
+    "delta.standardValue",
+    standardValue,
+    standardBlocks,
+  );
+  if (standardTerm !== null) {
+    reasons.push(standardTerm);
+  }
+
+  const foreign =
+    finding.proposedText === null || targetLanguage === null
+      ? null
+      : foreignLanguageOf(finding.proposedText, targetLanguage);
+  if (foreign !== null && targetLanguage !== null) {
+    reasons.push(
+      `proposedText is written in ${languageDisplayName(foreign)}; the target document is written in ${languageDisplayName(targetLanguage)}. Rewrite it in ${languageDisplayName(targetLanguage)}, keeping the standard's meaning.`,
+    );
+  }
+
+  return reasons;
+};
+
+/** What in a batch's answers the documents contradict, per position. */
+export const findGradingViolations = (
+  args: FindGradingViolationsArgs,
+): GradingViolation[] => {
+  const findingById = new Map<string, RepairableFinding>();
+  for (const finding of args.findings) {
+    if (!findingById.has(finding.positionId)) {
+      findingById.set(finding.positionId, finding);
+    }
+  }
+
+  const violations: GradingViolation[] = [];
+  for (const position of args.positions) {
+    const finding = findingById.get(position.sourceId);
+    const reasons =
+      finding === undefined
+        ? ["no answer was given for this position."]
+        : findingViolations(finding, position, args);
+    if (reasons.length > 0) {
+      violations.push({ positionId: position.sourceId, reasons });
+    }
+  }
+  return violations;
+};
+
+/** The follow-up turn: the answers that failed, and why, in the model's own
+ *  field names so the correction lands where the check reads. */
+export const buildRepairMessage = (
+  violations: readonly GradingViolation[],
+): string => {
+  const listed = violations
+    .map(
+      ({ positionId, reasons }) =>
+        `- positionId=${positionId}\n${reasons.map((reason) => `  - ${reason}`).join("\n")}`,
+    )
+    .join("\n");
+  return `These answers do not check out against the documents. Answer the positions below again, once each, following the same rules; leave every other position out.\n${listed}`;
+};
+
+/** The batch after repair: a repaired answer replaces the one it corrects,
+ *  and an answer the repair was not asked for is ignored. */
+export const mergeRepairedFindings = <T extends { positionId: string }>({
+  findings,
+  repaired,
+  violations,
+}: {
+  findings: readonly T[];
+  repaired: readonly T[];
+  violations: readonly GradingViolation[];
+}): T[] => {
+  const asked = new Set(violations.map(({ positionId }) => positionId));
+  const merged = findings.filter(({ positionId }) => !asked.has(positionId));
+  const seen = new Set<string>();
+  for (const finding of repaired) {
+    if (asked.has(finding.positionId) && !seen.has(finding.positionId)) {
+      seen.add(finding.positionId);
+      merged.push(finding);
+    }
+  }
+  return merged;
+};

--- a/apps/api/src/lib/document-review/reference-grade.test.ts
+++ b/apps/api/src/lib/document-review/reference-grade.test.ts
@@ -225,6 +225,7 @@ describe("normalizeReferenceGrading", () => {
       }),
       position: position("parameter"),
       targetBlocks,
+      targetLanguage: "EN-GB",
       perspective: buyer,
     });
 
@@ -284,6 +285,7 @@ describe("normalizeReferenceGrading", () => {
         raw: raw({ delta: answerForEveryKind }),
         position: position(termKind),
         targetBlocks,
+        targetLanguage: "EN-GB",
         perspective: buyer,
       });
 
@@ -316,6 +318,7 @@ describe("normalizeReferenceGrading", () => {
       }),
       position: position("parameter"),
       targetBlocks,
+      targetLanguage: "EN-GB",
       perspective: buyer,
     });
 
@@ -336,6 +339,7 @@ describe("normalizeReferenceGrading", () => {
         }),
         position: position(termKind),
         targetBlocks,
+        targetLanguage: "EN-GB",
         perspective: buyer,
       });
 
@@ -377,6 +381,7 @@ describe("normalizeReferenceGrading", () => {
       }),
       position: position("parameter"),
       targetBlocks,
+      targetLanguage: "EN-GB",
       perspective: buyer,
     });
 
@@ -394,6 +399,7 @@ describe("normalizeReferenceGrading", () => {
         }),
         position: position("language"),
         targetBlocks,
+        targetLanguage: "EN-GB",
         perspective: buyer,
       });
 
@@ -410,6 +416,7 @@ describe("normalizeReferenceGrading", () => {
       }),
       position: position("language"),
       targetBlocks,
+      targetLanguage: "EN-GB",
       perspective: buyer,
     });
 
@@ -422,6 +429,7 @@ describe("normalizeReferenceGrading", () => {
       raw: raw({ targetCitations: [{ blockId: "unknown-block" }] }),
       position: position(),
       targetBlocks,
+      targetLanguage: "EN-GB",
       perspective: buyer,
     });
 
@@ -437,6 +445,7 @@ describe("normalizeReferenceGrading", () => {
       raw: raw({ assessment: "missing-from-target", targetCitations: [] }),
       position: position(),
       targetBlocks,
+      targetLanguage: "EN-GB",
       perspective: buyer,
     });
 
@@ -449,6 +458,7 @@ describe("normalizeReferenceGrading", () => {
       raw: raw({ impact: "unfavourable" }),
       position: position("language"),
       targetBlocks,
+      targetLanguage: "EN-GB",
       perspective: { type: "neutral" },
     });
 

--- a/apps/api/src/lib/document-review/reference-grade.ts
+++ b/apps/api/src/lib/document-review/reference-grade.ts
@@ -16,6 +16,7 @@
  * (`deriveParameterImpact`).
  */
 
+import type { ModelMessage } from "@tanstack/ai";
 import { Result } from "better-result";
 import * as v from "valibot";
 
@@ -36,6 +37,11 @@ import type {
   ReferenceImpact,
   ReviewPerspective,
 } from "@/api/lib/document-review/contract";
+import {
+  buildRepairMessage,
+  findGradingViolations,
+  mergeRepairedFindings,
+} from "@/api/lib/document-review/reference-grade-repair";
 import type { PinnedReferencePassage } from "@/api/lib/document-review/reference-passages";
 import {
   deriveParameterImpact,
@@ -53,6 +59,8 @@ import {
   reviewDocumentsScopeKey,
 } from "@/api/lib/document-review/review-document-messages";
 import type { DocxFolioCitation } from "@/api/lib/document-review/review-extract";
+import { languageDisplayName } from "@/api/lib/document-review/target-language";
+import type { ReviewTargetLanguage } from "@/api/lib/document-review/target-language";
 import { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
 import { buildGroundedReviewFix } from "@/api/lib/grounded-review-fix";
 import type { GroundedReviewFix } from "@/api/lib/grounded-review-fix";
@@ -341,12 +349,14 @@ const referenceFix = ({
   verdict,
   raw,
   citations,
+  targetLanguage,
 }: {
   delta: ReviewDelta;
   termKind: PositionTermKind;
   verdict: VerdictTier;
   raw: RawFinding;
   citations: readonly DocxFolioCitation[];
+  targetLanguage: ReviewTargetLanguage;
 }): GroundedReviewFix | null => {
   if (!VERDICT_IS_ACTIONABLE[verdict]) {
     return null;
@@ -359,6 +369,7 @@ const referenceFix = ({
     proposedText: raw.proposedText,
     supportingEvidenceVerified: true,
     targetAnchors: citations,
+    targetLanguage,
   });
 };
 
@@ -476,6 +487,7 @@ type NormalizeArgs = {
   position: ReferenceStandardPosition;
   targetBlocks: BlockLookup;
   perspective: ReviewPerspective;
+  targetLanguage: ReviewTargetLanguage;
 };
 
 export const normalizeReferenceGrading = ({
@@ -483,6 +495,7 @@ export const normalizeReferenceGrading = ({
   position,
   targetBlocks,
   perspective,
+  targetLanguage,
 }: NormalizeArgs): ReferenceGrading => {
   const citations = verifiedTargetCitations(raw.targetCitations, targetBlocks);
   const grounded = isGrounded(raw.assessment, citations.length > 0);
@@ -521,6 +534,7 @@ export const normalizeReferenceGrading = ({
       verdict,
       raw,
       citations,
+      targetLanguage,
     }),
   };
 };
@@ -545,7 +559,7 @@ direction applies to a parameter only: whether a HIGHER or a LOWER value of that
 
 impact applies to the other kinds: unfavourable when the target leaves the drafter's side worse off than the standard does, favourable when better off, neutral when it makes no difference, unknown when no side was named.
 
-proposedText is wording taken from or grounded in the standard's passages, and only when they directly support a concrete edit; otherwise null. It is ignored for a parameter, where the term itself is replaced, and it must be null when the clauses are not comparable.`;
+proposedText is wording taken from or grounded in the standard's passages, and only when they directly support a concrete edit; otherwise null. It is written in the language of the target document: a standard in another language is carried over in meaning, never quoted. It is ignored for a parameter, where the term itself is replaced, and it must be null when the clauses are not comparable.`;
 
 const NEUTRAL_PERSPECTIVE_LINE = "No side is named; report impact as unknown.";
 
@@ -560,12 +574,22 @@ const perspectiveLine = (perspective: ReviewPerspective): string => {
   }
 };
 
+const targetLanguageLine = (targetLanguage: ReviewTargetLanguage): string =>
+  targetLanguage === null
+    ? "Write proposedText in the language the target document is written in."
+    : `The target document is written in ${languageDisplayName(targetLanguage)}; write proposedText in ${languageDisplayName(targetLanguage)}.`;
+
 /** The positions region: what changes between calls, so it is placed after the
  *  cached target document rather than before it. */
-const buildPositionsPart = (
-  positions: readonly ReferenceStandardPosition[],
-  perspective: ReviewPerspective,
-): string => {
+const buildPositionsPart = ({
+  positions,
+  perspective,
+  targetLanguage,
+}: {
+  positions: readonly ReferenceStandardPosition[];
+  perspective: ReviewPerspective;
+  targetLanguage: ReviewTargetLanguage;
+}): string => {
   const guide = positions
     .map((position) => {
       const passages = position.passages
@@ -581,12 +605,13 @@ const buildPositionsPart = (
       return `- positionId=${position.sourceId}\n  termKind=${position.termKind}\n  issue=${position.issue}${guidance}\n  standard passages:\n${passages}`;
     })
     .join("\n");
-  return `${perspectiveLine(perspective)}\n\nPositions:\n${guide}`;
+  return `${perspectiveLine(perspective)}\n${targetLanguageLine(targetLanguage)}\n\nPositions:\n${guide}`;
 };
 
 export type GradeReferencePositionsArgs = {
   positions: readonly ReferenceStandardPosition[];
   target: PreparedDocxFile;
+  targetLanguage: ReviewTargetLanguage;
   perspective: ReviewPerspective;
   targetEntityVersionId: SafeId<"entityVersion">;
   referenceEntityVersionIds: readonly SafeId<"entityVersion">[];
@@ -607,6 +632,7 @@ export type GradeReferencePositionsArgs = {
 export const gradeReferencePositions = async ({
   positions,
   target,
+  targetLanguage,
   perspective,
   targetEntityVersionId,
   referenceEntityVersionIds,
@@ -642,44 +668,71 @@ export const gradeReferencePositions = async ({
     usageMetering,
   });
 
+  const request: ModelMessage = {
+    role: "user",
+    content: [
+      ...buildReviewDocumentParts({ target, references: [], caching }),
+      {
+        type: "text",
+        content: buildPositionsPart({ positions, perspective, targetLanguage }),
+      },
+    ],
+  };
+  const generate = async (messages: ModelMessage[]) =>
+    await generateObjectForRole({
+      role: REFERENCE_GRADE_ROLE,
+      orgAIConfig,
+      organizationId,
+      analytics: aiAnalytics,
+      caching,
+      serviceTier,
+      tenantWorkspaceIds: [workspaceId],
+      system: SYSTEM_PROMPT,
+      messages,
+      abortSignal: AbortSignal.any([
+        abortSignal,
+        AbortSignal.timeout(REFERENCE_GRADE_TIMEOUT_MS),
+      ]),
+      outputSchema: referenceGradeSchema,
+    });
+
   return await Result.tryPromise({
     try: async () => {
-      const output = await generateObjectForRole({
-        role: REFERENCE_GRADE_ROLE,
-        orgAIConfig,
-        organizationId,
-        analytics: aiAnalytics,
-        caching,
-        serviceTier,
-        tenantWorkspaceIds: [workspaceId],
-        system: SYSTEM_PROMPT,
-        messages: [
-          {
-            role: "user",
-            content: [
-              ...buildReviewDocumentParts({ target, references: [], caching }),
-              {
-                type: "text",
-                content: buildPositionsPart(positions, perspective),
-              },
-            ],
-          },
-        ],
-        abortSignal: AbortSignal.any([
-          abortSignal,
-          AbortSignal.timeout(REFERENCE_GRADE_TIMEOUT_MS),
-        ]),
-        outputSchema: referenceGradeSchema,
-      });
-
       const targetBlocks = new Map(
         target.blocks.map((block) => [block.id, block.text]),
       );
+      const output = await generate([request]);
+
+      // One repair round for the answers the documents contradict: the batch
+      // is shown back with those answers named, and only they are re-asked.
+      // The documents region is byte-identical, so the second call reads it
+      // from the prompt cache.
+      const violations = findGradingViolations({
+        positions,
+        findings: output.findings,
+        targetBlocks,
+        targetLanguage,
+      });
+      const findings =
+        violations.length === 0
+          ? output.findings
+          : mergeRepairedFindings({
+              findings: output.findings,
+              repaired: (
+                await generate([
+                  request,
+                  { role: "assistant", content: JSON.stringify(output) },
+                  { role: "user", content: buildRepairMessage(violations) },
+                ])
+              ).findings,
+              violations,
+            });
+
       const positionById = new Map(
         positions.map((position) => [position.sourceId, position]),
       );
       const graded = new Map<string, ReferenceGrading>();
-      for (const raw of output.findings) {
+      for (const raw of findings) {
         const position = positionById.get(raw.positionId);
         if (position === undefined || graded.has(raw.positionId)) {
           continue;
@@ -691,6 +744,7 @@ export const gradeReferencePositions = async ({
             position,
             targetBlocks,
             perspective,
+            targetLanguage,
           }),
         );
       }

--- a/apps/api/src/lib/document-review/review-grade.ts
+++ b/apps/api/src/lib/document-review/review-grade.ts
@@ -27,6 +27,8 @@ import type {
   AskExtraction,
   DocxFolioCitation,
 } from "@/api/lib/document-review/review-extract";
+import { resolveReviewTargetLanguage } from "@/api/lib/document-review/target-language";
+import type { ReviewTargetLanguage } from "@/api/lib/document-review/target-language";
 import {
   buildGroundedReviewFix,
   type GroundedReviewFix,
@@ -162,16 +164,19 @@ type GradingOutcome =
  * ideal language: the difference is wording, so the delta is `language` and
  * the op is a whole-block replacement. A missing clause has no semantically
  * verified insertion anchor, so it stays a finding until a reviewer chooses
- * where it belongs.
+ * where it belongs. Ideal language is authored, not generated, so one written
+ * in another language than the document's yields a finding without a fix.
  */
 const buildTierFix = ({
   verdict,
   citations,
   ideal,
+  targetLanguage,
 }: {
   verdict: VerdictTier | null;
   citations: readonly DocxFolioCitation[];
   ideal: string | undefined;
+  targetLanguage: ReviewTargetLanguage;
 }): ReviewFix | null => {
   if (verdict !== "deviation") {
     return null;
@@ -181,6 +186,7 @@ const buildTierFix = ({
     proposedText: ideal,
     supportingEvidenceVerified: true,
     targetAnchors: citations,
+    targetLanguage,
   });
 };
 
@@ -413,6 +419,7 @@ const runBatchesWithConcurrency = async <Batch>({
 const gradeReferenceStandards = async ({
   pairs,
   target,
+  targetLanguage,
   perspective,
   referenceEntityVersionIds,
   deps,
@@ -421,6 +428,7 @@ const gradeReferenceStandards = async ({
 }: {
   pairs: readonly ReferencePair[];
   target: PreparedDocxFile;
+  targetLanguage: ReviewTargetLanguage;
   perspective: ReviewPerspective;
   referenceEntityVersionIds: readonly SafeId<"entityVersion">[];
   deps: AiGradingDeps;
@@ -446,6 +454,7 @@ const gradeReferenceStandards = async ({
       const outcome = await gradeReferencePositionsForReview({
         positions: batch.map((pair) => pair.reference),
         target,
+        targetLanguage,
         perspective,
         targetEntityVersionId: deps.entityVersionId,
         referenceEntityVersionIds,
@@ -478,6 +487,7 @@ type ProjectGradingArgs = {
   grading: GradingOutcome;
   citations: readonly DocxFolioCitation[];
   ideal: string | undefined;
+  targetLanguage: ReviewTargetLanguage;
 };
 
 type ProjectedGrading = Pick<
@@ -489,6 +499,7 @@ const projectGrading = ({
   grading,
   citations,
   ideal,
+  targetLanguage,
 }: ProjectGradingArgs): ProjectedGrading => {
   switch (grading.status) {
     case "graded":
@@ -498,7 +509,12 @@ const projectGrading = ({
         ...(grading.matchedRef === undefined
           ? {}
           : { matchedRef: grading.matchedRef }),
-        fix: buildTierFix({ verdict: grading.verdict, citations, ideal }),
+        fix: buildTierFix({
+          verdict: grading.verdict,
+          citations,
+          ideal,
+          targetLanguage,
+        }),
       };
     case "ungraded":
       return {
@@ -590,6 +606,7 @@ export const buildFindings = async ({
   // pass is finished.
   const modelVerdicts = new Map<string, GradingOutcome>();
   const referenceGradings = new Map<string, ReferenceGrading>();
+  const targetLanguage = resolveReviewTargetLanguage(target);
   const project = (position: Position): ReviewFinding =>
     projectFinding({
       position,
@@ -599,6 +616,7 @@ export const buildFindings = async ({
       decided,
       modelVerdicts,
       referenceGradings,
+      targetLanguage,
     });
   const emit = async (batch: readonly Position[]): Promise<void> => {
     await onGraded(batch.map(project));
@@ -616,6 +634,7 @@ export const buildFindings = async ({
     gradeReferenceStandards({
       pairs: referencePairs,
       target,
+      targetLanguage,
       perspective,
       referenceEntityVersionIds,
       deps,
@@ -635,6 +654,7 @@ type ProjectFindingArgs = {
   decided: ReadonlyMap<string, GradingOutcome>;
   modelVerdicts: ReadonlyMap<string, GradingOutcome>;
   referenceGradings: ReadonlyMap<string, ReferenceGrading>;
+  targetLanguage: ReviewTargetLanguage;
 };
 
 /** One position plus whatever has been decided about it, as the single
@@ -648,6 +668,7 @@ const projectFinding = ({
   decided,
   modelVerdicts,
   referenceGradings,
+  targetLanguage,
 }: ProjectFindingArgs): ReviewFinding => {
   const pair = referencePair(position, passageTextById);
   if (pair !== null) {
@@ -678,6 +699,7 @@ const projectFinding = ({
     grading,
     citations,
     ideal: tiers?.ideal,
+    targetLanguage,
   });
 
   return {

--- a/apps/api/src/lib/document-review/target-language.test.ts
+++ b/apps/api/src/lib/document-review/target-language.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import {
+  foreignLanguageOf,
+  languageDisplayName,
+  resolveReviewTargetLanguage,
+} from "@/api/lib/document-review/target-language";
+import type { PreparedDocxFile } from "@/api/lib/workflow/generate-batch";
+
+const document = (texts: readonly string[]): PreparedDocxFile => ({
+  kind: "docx",
+  fileFieldId: toSafeId<"field">("field-fixture"),
+  fileId: "file-fixture",
+  simplifiedName: "F0",
+  blocks: texts.map((text, index) => ({
+    id: `p-${String(index)}`,
+    kind: "paragraph",
+    text,
+  })),
+});
+
+const CZECH_CLAUSE =
+  "Poskytovatel odpovídá za škodu způsobenou porušením této smlouvy a nahradí ji objednateli.";
+const ENGLISH_CLAUSE =
+  "The provider is liable for damage caused by a breach of this agreement and shall compensate the customer.";
+
+describe("resolveReviewTargetLanguage", () => {
+  test("reads the document as a whole, not one block", () => {
+    expect(
+      resolveReviewTargetLanguage(
+        document([
+          "Smlouva o dílo",
+          "Tato smlouva se řídí právním řádem České republiky.",
+          "Smluvní strany se zavazují řešit veškeré spory přednostně smírnou cestou.",
+          CZECH_CLAUSE,
+          "Objednatel je povinen uhradit cenu díla do třiceti dnů ode dne doručení faktury.",
+        ]),
+      ),
+    ).toBe("CS");
+  });
+
+  test("a document with too little text has no resolved language", () => {
+    expect(resolveReviewTargetLanguage(document(["Schedule 1"]))).toBeNull();
+  });
+});
+
+describe("foreignLanguageOf", () => {
+  test("names the language of text confidently written in another", () => {
+    expect(foreignLanguageOf(ENGLISH_CLAUSE, "CS")).toBe("EN-GB");
+  });
+
+  test("text in the target's language is not foreign", () => {
+    expect(foreignLanguageOf(CZECH_CLAUSE, "CS")).toBeNull();
+  });
+
+  // A short term carries too little evidence; the prompt, not the guard, keeps
+  // it in line.
+  test("text too short to detect is not foreign", () => {
+    expect(foreignLanguageOf("6 months", "CS")).toBeNull();
+  });
+
+  test("no resolved target language means nothing is foreign", () => {
+    expect(foreignLanguageOf(ENGLISH_CLAUSE, null)).toBeNull();
+  });
+});
+
+describe("languageDisplayName", () => {
+  test("names a language the way a prompt reads it", () => {
+    expect(languageDisplayName("CS")).toBe("Czech");
+    expect(languageDisplayName("PT-PT")).toBe("European Portuguese");
+  });
+});

--- a/apps/api/src/lib/document-review/target-language.ts
+++ b/apps/api/src/lib/document-review/target-language.ts
@@ -1,0 +1,51 @@
+/**
+ * The language a review writes its edits in.
+ *
+ * Resolved once per target document from its whole text, so no finding has
+ * to guess from the few blocks it cites. `null` means the document did not
+ * resolve to one language (too little text, or a close call such as Czech
+ * against Slovak); the language guard then stands down rather than reject
+ * edits on a guess.
+ */
+
+import type { DocumentTranslationSourceLanguageCode } from "@stll/api-contract/document-translation";
+
+import { detectDocumentTranslationSourceLanguage } from "@/api/lib/document-translation/source-language";
+import type { PreparedDocxFile } from "@/api/lib/workflow/generate-batch";
+
+export type ReviewTargetLanguage = DocumentTranslationSourceLanguageCode | null;
+
+export const resolveReviewTargetLanguage = (
+  target: PreparedDocxFile,
+): ReviewTargetLanguage => {
+  const detection = detectDocumentTranslationSourceLanguage(
+    target.blocks.map((block) => block.text).join("\n"),
+  );
+  return detection.type === "detected" ? detection.language : null;
+};
+
+/**
+ * The language `text` is confidently written in, when that is not the
+ * target's; `null` otherwise. Text too short or too mixed to detect passes:
+ * the guard rejects only what it can prove, and the prompt is what keeps a
+ * short term in line.
+ */
+export const foreignLanguageOf = (
+  text: string,
+  targetLanguage: ReviewTargetLanguage,
+): DocumentTranslationSourceLanguageCode | null => {
+  if (targetLanguage === null) {
+    return null;
+  }
+  const detection = detectDocumentTranslationSourceLanguage(text);
+  return detection.type === "detected" && detection.language !== targetLanguage
+    ? detection.language
+    : null;
+};
+
+const displayNames = new Intl.DisplayNames(["en"], { type: "language" });
+
+/** The language as a prompt names it: "Czech", not "CS". */
+export const languageDisplayName = (
+  code: DocumentTranslationSourceLanguageCode,
+): string => displayNames.of(code) ?? code;

--- a/apps/api/src/lib/grounded-review-fix.test.ts
+++ b/apps/api/src/lib/grounded-review-fix.test.ts
@@ -150,6 +150,46 @@ describe("buildGroundedReviewFix", () => {
     });
   });
 
+  test("does not insert a standard written in another language", () => {
+    const czechTarget = [
+      {
+        blockId: "p-1",
+        text: "Poskytovatel odpovídá za škodu způsobenou porušením této smlouvy a nahradí ji objednateli.",
+      },
+    ];
+
+    expect(
+      buildGroundedReviewFix({
+        delta: { kind: "language" },
+        proposedText:
+          "The provider is liable for damage caused by a breach of this agreement and shall compensate the customer.",
+        supportingEvidenceVerified: true,
+        targetAnchors: czechTarget,
+      }),
+    ).toBeNull();
+  });
+
+  test("allows a cross-language replacement only when explicitly requested", () => {
+    expect(
+      buildGroundedReviewFix({
+        delta: { kind: "language" },
+        proposedText: "The provider is liable for damage caused by a breach.",
+        supportingEvidenceVerified: true,
+        targetAnchors: [
+          {
+            blockId: "p-1",
+            text: "Poskytovatel odpovídá za škodu způsobenou porušením této smlouvy a nahradí ji objednateli.",
+          },
+        ],
+        translationRequested: true,
+      }),
+    ).toEqual({
+      kind: "replaceBlock",
+      blockId: "p-1",
+      text: "The provider is liable for damage caused by a breach.",
+    });
+  });
+
   test("an ungrounded conclusion never becomes an executable edit", () => {
     expect(
       buildGroundedReviewFix({

--- a/apps/api/src/lib/grounded-review-fix.test.ts
+++ b/apps/api/src/lib/grounded-review-fix.test.ts
@@ -11,13 +11,17 @@ import { buildGroundedReviewFix } from "@/api/lib/grounded-review-fix";
 
 const BLOCK_TEXT =
   "Claims must be notified within 12 months of Completion, failing which they lapse.";
+const CZECH_BLOCK_TEXT =
+  "Poskytovatel odpovídá za škodu způsobenou porušením této smlouvy a nahradí ji objednateli.";
 
 const anchors = [{ blockId: "p-1", text: BLOCK_TEXT }];
+const czechAnchors = [{ blockId: "p-1", text: CZECH_BLOCK_TEXT }];
 
 const parameterDelta = (
   targetText: string,
   standardText: string,
   blockText = BLOCK_TEXT,
+  standardBlockText = "within 6 months of Completion",
 ): ReviewDelta => ({
   kind: "parameter",
   target: {
@@ -30,7 +34,7 @@ const parameterDelta = (
     text: standardText,
     value: 6,
     unit: "months",
-    citation: { blockId: "p-9", text: "within 6 months of Completion" },
+    citation: { blockId: "p-9", text: standardBlockText },
   },
 });
 
@@ -42,6 +46,7 @@ describe("buildGroundedReviewFix", () => {
         proposedText: null,
         supportingEvidenceVerified: true,
         targetAnchors: anchors,
+        targetLanguage: "EN-GB",
       }),
     ).toEqual({
       kind: "replaceInBlock",
@@ -64,6 +69,7 @@ describe("buildGroundedReviewFix", () => {
         proposedText: null,
         supportingEvidenceVerified: true,
         targetAnchors: anchors,
+        targetLanguage: "EN-GB",
       }),
     ).toBeNull();
   });
@@ -75,6 +81,7 @@ describe("buildGroundedReviewFix", () => {
         proposedText: null,
         supportingEvidenceVerified: true,
         targetAnchors: anchors,
+        targetLanguage: "EN-GB",
       }),
     ).toBeNull();
   });
@@ -86,6 +93,27 @@ describe("buildGroundedReviewFix", () => {
         proposedText: "within 6 months",
         supportingEvidenceVerified: true,
         targetAnchors: anchors,
+        targetLanguage: "EN-GB",
+      }),
+    ).toBeNull();
+  });
+
+  // The term is copied verbatim from the standard, so a standard in another
+  // language would splice that language into the document. The term itself is
+  // too short to tell; the block it was copied from is not.
+  test("a term copied from a standard in another language yields no fix", () => {
+    expect(
+      buildGroundedReviewFix({
+        delta: parameterDelta(
+          "12 months",
+          "6 měsíců",
+          BLOCK_TEXT,
+          "Nároky musí být oznámeny do 6 měsíců od dokončení, jinak zanikají.",
+        ),
+        proposedText: null,
+        supportingEvidenceVerified: true,
+        targetAnchors: anchors,
+        targetLanguage: "EN-GB",
       }),
     ).toBeNull();
   });
@@ -107,6 +135,7 @@ describe("buildGroundedReviewFix", () => {
         proposedText: "(e) any management fees paid to a Seller Group company;",
         supportingEvidenceVerified: true,
         targetAnchors: anchors,
+        targetLanguage: "EN-GB",
       }),
     ).toEqual({
       kind: "insertAfterBlock",
@@ -127,6 +156,7 @@ describe("buildGroundedReviewFix", () => {
         proposedText: '"Losses" means all losses, liabilities and costs.',
         supportingEvidenceVerified: true,
         targetAnchors: anchors,
+        targetLanguage: "EN-GB",
       }),
     ).toEqual({
       kind: "insertAfterBlock",
@@ -142,6 +172,7 @@ describe("buildGroundedReviewFix", () => {
         proposedText: "Fairly Disclosed means disclosed in sufficient detail.",
         supportingEvidenceVerified: true,
         targetAnchors: anchors,
+        targetLanguage: "EN-GB",
       }),
     ).toEqual({
       kind: "replaceBlock",
@@ -150,38 +181,29 @@ describe("buildGroundedReviewFix", () => {
     });
   });
 
-  test("does not insert a standard written in another language", () => {
-    const czechTarget = [
-      {
-        blockId: "p-1",
-        text: "Poskytovatel odpovídá za škodu způsobenou porušením této smlouvy a nahradí ji objednateli.",
-      },
-    ];
-
+  test("wording in another language than the document's is not an edit", () => {
     expect(
       buildGroundedReviewFix({
         delta: { kind: "language" },
         proposedText:
           "The provider is liable for damage caused by a breach of this agreement and shall compensate the customer.",
         supportingEvidenceVerified: true,
-        targetAnchors: czechTarget,
+        targetAnchors: czechAnchors,
+        targetLanguage: "CS",
       }),
     ).toBeNull();
   });
 
-  test("allows a cross-language replacement only when explicitly requested", () => {
+  // No resolved language means no claim to enforce; the guard stands down
+  // rather than reject on a guess.
+  test("a document with no resolved language gets no language guard", () => {
     expect(
       buildGroundedReviewFix({
         delta: { kind: "language" },
         proposedText: "The provider is liable for damage caused by a breach.",
         supportingEvidenceVerified: true,
-        targetAnchors: [
-          {
-            blockId: "p-1",
-            text: "Poskytovatel odpovídá za škodu způsobenou porušením této smlouvy a nahradí ji objednateli.",
-          },
-        ],
-        translationRequested: true,
+        targetAnchors: czechAnchors,
+        targetLanguage: null,
       }),
     ).toEqual({
       kind: "replaceBlock",
@@ -197,6 +219,7 @@ describe("buildGroundedReviewFix", () => {
         proposedText: "Some replacement.",
         supportingEvidenceVerified: false,
         targetAnchors: anchors,
+        targetLanguage: "EN-GB",
       }),
     ).toBeNull();
   });
@@ -208,6 +231,7 @@ describe("buildGroundedReviewFix", () => {
         proposedText: "Some replacement.",
         supportingEvidenceVerified: true,
         targetAnchors: [],
+        targetLanguage: "EN-GB",
       }),
     ).toBeNull();
     expect(
@@ -216,6 +240,7 @@ describe("buildGroundedReviewFix", () => {
         proposedText: "   ",
         supportingEvidenceVerified: true,
         targetAnchors: anchors,
+        targetLanguage: "EN-GB",
       }),
     ).toBeNull();
   });

--- a/apps/api/src/lib/grounded-review-fix.ts
+++ b/apps/api/src/lib/grounded-review-fix.ts
@@ -11,6 +11,7 @@
 
 import type { ReviewDelta } from "@/api/lib/document-review/review-delta";
 import type { DocxFolioCitation } from "@/api/lib/document-review/review-extract";
+import { detectDocumentTranslationSourceLanguage } from "@/api/lib/document-translation/source-language";
 
 export type GroundedReviewFix =
   | { kind: "replaceInBlock"; blockId: string; find: string; replace: string }
@@ -29,6 +30,20 @@ type BuildGroundedReviewFixArgs = {
   /** Verified target citations, in the order the engine cited them. The first
    *  is the semantic anchor; this boundary never invents one from position. */
   targetAnchors: readonly DocxFolioCitation[];
+  /** Translation is an explicit user action; review fixes preserve the target
+   * document's language by default, even when the standard is multilingual. */
+  translationRequested?: boolean;
+};
+
+const matchesTargetLanguage = (
+  targetText: string,
+  proposedText: string,
+): boolean => {
+  const target = detectDocumentTranslationSourceLanguage(targetText);
+  const proposed = detectDocumentTranslationSourceLanguage(proposedText);
+  return target.type !== "detected" || proposed.type !== "detected"
+    ? true
+    : target.language === proposed.language;
 };
 
 /** Occurrences of `needle` in `haystack`; `needle` is never empty here. */
@@ -51,6 +66,7 @@ const countOccurrences = (haystack: string, needle: string): number => {
 const buildParameterFix = (
   delta: Extract<ReviewDelta, { kind: "parameter" }>,
   proposedText: string | null | undefined,
+  translationRequested: boolean,
 ): GroundedReviewFix | null => {
   const target = delta.target;
   if (target === null) {
@@ -62,6 +78,12 @@ const buildParameterFix = (
     return null;
   }
   if (countOccurrences(target.citation.text, find) !== 1) {
+    return null;
+  }
+  if (
+    !translationRequested &&
+    !matchesTargetLanguage(target.citation.text, replace)
+  ) {
     return null;
   }
   return {
@@ -81,17 +103,27 @@ export const buildGroundedReviewFix = ({
   proposedText,
   supportingEvidenceVerified,
   targetAnchors,
+  translationRequested = false,
 }: BuildGroundedReviewFixArgs): GroundedReviewFix | null => {
   if (!supportingEvidenceVerified) {
     return null;
   }
   if (delta.kind === "parameter") {
-    return buildParameterFix(delta, proposedText);
+    return buildParameterFix(delta, proposedText, translationRequested);
   }
 
   const text = proposedText?.trim();
   const blockId = targetAnchors.at(0)?.blockId;
   if (!text || blockId === undefined) {
+    return null;
+  }
+  if (
+    !translationRequested &&
+    !matchesTargetLanguage(
+      targetAnchors.map(({ text: value }) => value).join("\n"),
+      text,
+    )
+  ) {
     return null;
   }
   switch (delta.kind) {

--- a/apps/api/src/lib/grounded-review-fix.ts
+++ b/apps/api/src/lib/grounded-review-fix.ts
@@ -11,7 +11,8 @@
 
 import type { ReviewDelta } from "@/api/lib/document-review/review-delta";
 import type { DocxFolioCitation } from "@/api/lib/document-review/review-extract";
-import { detectDocumentTranslationSourceLanguage } from "@/api/lib/document-translation/source-language";
+import { foreignLanguageOf } from "@/api/lib/document-review/target-language";
+import type { ReviewTargetLanguage } from "@/api/lib/document-review/target-language";
 
 export type GroundedReviewFix =
   | { kind: "replaceInBlock"; blockId: string; find: string; replace: string }
@@ -30,20 +31,10 @@ type BuildGroundedReviewFixArgs = {
   /** Verified target citations, in the order the engine cited them. The first
    *  is the semantic anchor; this boundary never invents one from position. */
   targetAnchors: readonly DocxFolioCitation[];
-  /** Translation is an explicit user action; review fixes preserve the target
-   * document's language by default, even when the standard is multilingual. */
-  translationRequested?: boolean;
-};
-
-const matchesTargetLanguage = (
-  targetText: string,
-  proposedText: string,
-): boolean => {
-  const target = detectDocumentTranslationSourceLanguage(targetText);
-  const proposed = detectDocumentTranslationSourceLanguage(proposedText);
-  return target.type !== "detected" || proposed.type !== "detected"
-    ? true
-    : target.language === proposed.language;
+  /** The language the document is written in, resolved once per review. An
+   *  edit in another language is a translation, not an edit, and this
+   *  boundary never produces one. */
+  targetLanguage: ReviewTargetLanguage;
 };
 
 /** Occurrences of `needle` in `haystack`; `needle` is never empty here. */
@@ -57,17 +48,23 @@ const countOccurrences = (haystack: string, needle: string): number => {
   return count;
 };
 
+type BuildParameterFixArgs = {
+  delta: Extract<ReviewDelta, { kind: "parameter" }>;
+  proposedText: string | null | undefined;
+  targetLanguage: ReviewTargetLanguage;
+};
+
 /**
  * A parameter edit rewrites the term, not the paragraph, so the term must be
  * locatable in the cited block without ambiguity: exactly one occurrence, or
  * no fix at all. Two occurrences mean the engine cannot say which one the
  * finding is about, and an editor must.
  */
-const buildParameterFix = (
-  delta: Extract<ReviewDelta, { kind: "parameter" }>,
-  proposedText: string | null | undefined,
-  translationRequested: boolean,
-): GroundedReviewFix | null => {
+const buildParameterFix = ({
+  delta,
+  proposedText,
+  targetLanguage,
+}: BuildParameterFixArgs): GroundedReviewFix | null => {
   const target = delta.target;
   if (target === null) {
     return null;
@@ -80,10 +77,10 @@ const buildParameterFix = (
   if (countOccurrences(target.citation.text, find) !== 1) {
     return null;
   }
-  if (
-    !translationRequested &&
-    !matchesTargetLanguage(target.citation.text, replace)
-  ) {
+  // The replacement is copied from the standard, so it carries the standard's
+  // language. The term alone is too short to tell; its block is not.
+  const replacementSource = delta.standard?.citation.text ?? replace;
+  if (foreignLanguageOf(replacementSource, targetLanguage) !== null) {
     return null;
   }
   return {
@@ -103,13 +100,13 @@ export const buildGroundedReviewFix = ({
   proposedText,
   supportingEvidenceVerified,
   targetAnchors,
-  translationRequested = false,
+  targetLanguage,
 }: BuildGroundedReviewFixArgs): GroundedReviewFix | null => {
   if (!supportingEvidenceVerified) {
     return null;
   }
   if (delta.kind === "parameter") {
-    return buildParameterFix(delta, proposedText, translationRequested);
+    return buildParameterFix({ delta, proposedText, targetLanguage });
   }
 
   const text = proposedText?.trim();
@@ -117,13 +114,7 @@ export const buildGroundedReviewFix = ({
   if (!text || blockId === undefined) {
     return null;
   }
-  if (
-    !translationRequested &&
-    !matchesTargetLanguage(
-      targetAnchors.map(({ text: value }) => value).join("\n"),
-      text,
-    )
-  ) {
+  if (foreignLanguageOf(text, targetLanguage) !== null) {
     return null;
   }
   switch (delta.kind) {


### PR DESCRIPTION
## Summary

- resolve the target document's language once per review, from the whole text, and tell the grader to write `proposedText` in it
- after each grading batch, name the answers the documents contradict (an unanswered position, a block id the target lacks, a term not written as its block writes it, wording in another language) and re-ask once for those alone, with the batch shown back; whatever still fails is dropped by normalization as before, and a repair never repairs a repair
- keep a language guard in the fix builder as a backstop against the resolved language, for generated wording and for a parameter term copied from a standard in another language
- drop the `translationRequested` opt-in; nothing set it

The documents region of the repair call is byte-identical to the first call, so it reads from the prompt cache.

https://claude.ai/code/session_013yK4aFw6Qyo4ZgAMr5UFPm
