### PR TITLE
fix: align corpus source lock privileges

### DIFF
--- a/apps/api/drizzle/20260901181000_corpus_source_lock_grants/migration.sql
+++ b/apps/api/drizzle/20260901181000_corpus_source_lock_grants/migration.sql
@@ -1,0 +1,7 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Corpus generation activation takes a short table lock while it changes the
+-- generation registry. MAINTAIN permits that lock without broadening the
+-- ingestion role's column-scoped source writes.
+GRANT MAINTAIN ON TABLE "legislation_sources" TO stella_ingestion;--> statement-breakpoint

--- a/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
+++ b/apps/api/src/handlers/case-law/corpus-index-query-guard.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { getTableName } from "drizzle-orm";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import nodePath from "node:path";
 
@@ -6,6 +7,7 @@ import {
   CASE_LAW_CORPUS_INDEX_BACKFILL_STATUSES,
   CASE_LAW_CORPUS_INDEX_PROJECTION_ACTIONS,
 } from "@/api/db/schema";
+import { CORPUS_INDEX_SOURCE_TABLES } from "@/api/lib/legal-search/corpus-index-generation-store";
 import { CORPUS_LICENSES } from "@/api/lib/legal-search/corpus-source";
 
 const caseLawCorpusIndexSource = new URL("corpus-index.ts", import.meta.url);
@@ -128,6 +130,12 @@ const ingestionLockPrivileges = (table: string): string[] => {
 
   return [...held];
 };
+
+test("every corpus source activation lock has an ingestion-role privilege", () => {
+  for (const table of Object.values(CORPUS_INDEX_SOURCE_TABLES)) {
+    expect(ingestionLockPrivileges(getTableName(table))).not.toHaveLength(0);
+  }
+});
 
 const GENERATION_STATE_TABLES = [
   "case_law_corpus_index_backfills",

--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.db.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.db.test.ts
@@ -1,10 +1,12 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 
 import type { Transaction } from "@/api/db/root";
 import { corpusIndexGenerations } from "@/api/db/schema";
+import { CORPUS_FAMILIES } from "@/api/lib/legal-search/corpus-generation-contract";
 import {
+  lockCorpusIndexGenerationActivationTx,
   readServingCorpusIndexGenerationTx,
   registerCorpusIndexGenerationTx,
   resumeRetiringCorpusIndexGenerationTx,
@@ -42,6 +44,19 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await client.close();
+});
+
+test("the ingestion role can fence every corpus source family", async () => {
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL ROLE stella_ingestion`);
+    for (const family of CORPUS_FAMILIES) {
+      // oxlint-disable-next-line no-await-in-loop -- one transaction proves the role can acquire every source fence
+      await lockCorpusIndexGenerationActivationTx(
+        asTestRaw<Transaction>(tx),
+        family,
+      );
+    }
+  });
 });
 
 test("generation registration is idempotent and manifest-derived", async () => {

--- a/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-generation-store.ts
@@ -35,25 +35,26 @@ export type ServingCorpusIndexGeneration = {
   cluster: QuickwitCluster;
 };
 
+export const CORPUS_INDEX_SOURCE_TABLES = {
+  case_law: caseLawSources,
+  legislation: legislationSources,
+} as const satisfies Record<
+  CorpusFamily,
+  typeof caseLawSources | typeof legislationSources
+>;
+
 /**
  * Fence activation against canonical writers. Writers share-lock their source
  * before checking the registry; the short table fence also covers a source
  * inserted concurrently with first activation.
  */
-const lockCorpusIndexGenerationActivationTx = async (
+export const lockCorpusIndexGenerationActivationTx = async (
   tx: Transaction,
   family: CorpusFamily,
 ): Promise<void> => {
-  switch (family) {
-    case "case_law":
-      await tx.execute(sql`LOCK TABLE ${caseLawSources} IN EXCLUSIVE MODE`);
-      return;
-    case "legislation":
-      await tx.execute(sql`LOCK TABLE ${legislationSources} IN EXCLUSIVE MODE`);
-      return;
-    default:
-      return family satisfies never;
-  }
+  await tx.execute(
+    sql`LOCK TABLE ${CORPUS_INDEX_SOURCE_TABLES[family]} IN EXCLUSIVE MODE`,
+  );
 };
 
 type CorpusIndexGenerationReadTransaction = Pick<Transaction, "select">;

--- a/apps/api/src/tests/pglite-test-db.ts
+++ b/apps/api/src/tests/pglite-test-db.ts
@@ -192,6 +192,9 @@ const ROLE_GRANT_STATEMENTS = [
       ON TABLE "case_law_sources"
       TO stella_ingestion
   `,
+  `
+    GRANT MAINTAIN ON TABLE "case_law_sources" TO stella_ingestion
+  `,
   // case_law_index_jobs is append-only: ingestion appends audit rows
   // but never updates or deletes them.
   `
@@ -224,6 +227,9 @@ const ROLE_GRANT_STATEMENTS = [
     GRANT UPDATE (sync_cursor, last_sync_at, updated_at)
       ON TABLE "legislation_sources"
       TO stella_ingestion
+  `,
+  `
+    GRANT MAINTAIN ON TABLE "legislation_sources" TO stella_ingestion
   `,
   `
     GRANT INSERT ON TABLE "legislation_index_jobs" TO stella_ingestion


### PR DESCRIPTION
Adds the lock-conferring `MAINTAIN` privilege for legislation sources and derives activation locks from an exhaustive corpus-family map.

Tests bind both the reduced ingestion role and applied migration grants to every registered corpus family.