### PR TITLE
fix: select one workspace inspector presentation

### DIFF
--- a/.changeset/quiet-taxis-frame.md
+++ b/.changeset/quiet-taxis-frame.md
@@ -1,0 +1,5 @@
+---
+"@stll/workspace-ui": patch
+---
+
+Render one responsive inspector presentation at a time in the complete workspace frame.

--- a/packages/workspace-ui/src/workspace-frame.logic.test.ts
+++ b/packages/workspace-ui/src/workspace-frame.logic.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveWorkspaceInspectorPresentation } from "./workspace-frame.logic";
+
+describe("workspace inspector presentation", () => {
+  test.each([
+    [false, false, "desktop"],
+    [false, true, "desktop"],
+    [true, false, "desktop"],
+    [true, true, "mobile"],
+  ] as const)(
+    "selects exactly one presentation (mobile=%s, compact=%s)",
+    (hasMobilePresentation, isCompact, expected) => {
+      expect(
+        resolveWorkspaceInspectorPresentation({
+          hasMobilePresentation,
+          isCompact,
+        }),
+      ).toBe(expected);
+    },
+  );
+});

--- a/packages/workspace-ui/src/workspace-frame.logic.ts
+++ b/packages/workspace-ui/src/workspace-frame.logic.ts
@@ -1,0 +1,8 @@
+export const resolveWorkspaceInspectorPresentation = ({
+  hasMobilePresentation,
+  isCompact,
+}: {
+  hasMobilePresentation: boolean;
+  isCompact: boolean;
+}): "desktop" | "mobile" =>
+  hasMobilePresentation && isCompact ? "mobile" : "desktop";

--- a/packages/workspace-ui/src/workspace-frame.tsx
+++ b/packages/workspace-ui/src/workspace-frame.tsx
@@ -182,24 +182,30 @@ export const WorkspaceFrame = (props: WorkspaceFrameProps) => {
     </WorkspaceShell>
   );
 
-  if (inspector?.mobile === undefined || inspectorPresentation === "desktop") {
+  if (inspector?.mobile === undefined) {
     return frame;
   }
 
   return (
     <Sheet
-      open={inspector.mobile.open}
-      onOpenChange={inspector.mobile.onOpenChange}
+      open={inspectorPresentation === "mobile" && inspector.mobile.open}
+      onOpenChange={(open) => {
+        if (inspectorPresentation === "mobile") {
+          inspector.mobile?.onOpenChange(open);
+        }
+      }}
     >
       {frame}
-      <SheetPopup
-        className="h-dvh w-full max-w-none border-0 p-0 md:hidden"
-        showCloseButton={false}
-        side="inline-end"
-      >
-        <SheetTitle className="sr-only">{inspector.mobile.label}</SheetTitle>
-        {inspector.mobile.content}
-      </SheetPopup>
+      {inspectorPresentation === "mobile" ? (
+        <SheetPopup
+          className="h-dvh w-full max-w-none border-0 p-0"
+          showCloseButton={false}
+          side="inline-end"
+        >
+          <SheetTitle className="sr-only">{inspector.mobile.label}</SheetTitle>
+          {inspector.mobile.content}
+        </SheetPopup>
+      ) : null}
     </Sheet>
   );
 };

--- a/packages/workspace-ui/src/workspace-frame.tsx
+++ b/packages/workspace-ui/src/workspace-frame.tsx
@@ -88,14 +88,17 @@ export type WorkspaceFrameTopBar = {
   actions?: ReactNode;
 };
 
+type DescribedWorkspaceFrameProps = Extract<
+  WorkspaceFrameProps,
+  { composition: "described" }
+>;
+
 /**
  * Stella's complete workspace frame. Hosts provide route descriptors and
  * actions; this component owns the shell, application rail, end rail, and
  * desktop inspector footprint.
  */
 export const WorkspaceFrame = (props: WorkspaceFrameProps) => {
-  const isCompact = useIsMobile();
-
   if (props.composition === "host-responsive") {
     return (
       <WorkspaceShell
@@ -108,7 +111,17 @@ export const WorkspaceFrame = (props: WorkspaceFrameProps) => {
     );
   }
 
-  const { children, endRail, inspector, navigation, topBar } = props;
+  return <DescribedWorkspaceFrame {...props} />;
+};
+
+const DescribedWorkspaceFrame = ({
+  children,
+  endRail,
+  inspector,
+  navigation,
+  topBar,
+}: DescribedWorkspaceFrameProps) => {
+  const isCompact = useIsMobile();
   const inspectorPresentation = resolveWorkspaceInspectorPresentation({
     hasMobilePresentation: inspector?.mobile !== undefined,
     isCompact,

--- a/packages/workspace-ui/src/workspace-frame.tsx
+++ b/packages/workspace-ui/src/workspace-frame.tsx
@@ -12,8 +12,11 @@ import {
 } from "@stll/ui/application-rail";
 import { InspectorDock, TOOLBAR_ROW_HEIGHT } from "@stll/ui/inspector";
 import { Sheet, SheetPopup, SheetTitle } from "@stll/ui/sheet";
+import { useIsMobile } from "@stll/ui/use-mobile";
 import { cn } from "@stll/ui/utils";
 import { WorkspaceEndRail, WorkspaceShell } from "@stll/ui/workspace-shell";
+
+import { resolveWorkspaceInspectorPresentation } from "./workspace-frame.logic";
 
 export type WorkspaceFrameNavigationItem = {
   id: string;
@@ -91,6 +94,8 @@ export type WorkspaceFrameTopBar = {
  * desktop inspector footprint.
  */
 export const WorkspaceFrame = (props: WorkspaceFrameProps) => {
+  const isCompact = useIsMobile();
+
   if (props.composition === "host-responsive") {
     return (
       <WorkspaceShell
@@ -104,6 +109,10 @@ export const WorkspaceFrame = (props: WorkspaceFrameProps) => {
   }
 
   const { children, endRail, inspector, navigation, topBar } = props;
+  const inspectorPresentation = resolveWorkspaceInspectorPresentation({
+    hasMobilePresentation: inspector?.mobile !== undefined,
+    isCompact,
+  });
   const desktopNavigation = (
     <ApplicationRail aria-label={navigation.label}>
       <ApplicationRailHeader>{navigation.header}</ApplicationRailHeader>
@@ -129,20 +138,21 @@ export const WorkspaceFrame = (props: WorkspaceFrameProps) => {
     </ApplicationRail>
   );
 
-  const endDock = inspector ? (
-    <InspectorDock
-      rail={<WorkspaceEndRail {...endRail} />}
-      resizeHandleLabel={inspector.resizeHandleLabel}
-      resizeHandleProps={inspector.resizeHandleProps}
-      showPaneContent={inspector.showPaneContent}
-      width={inspector.width}
-      onResetWidth={inspector.onResetWidth}
-    >
-      {inspector.pane}
-    </InspectorDock>
-  ) : (
-    <WorkspaceEndRail {...endRail} />
-  );
+  const endDock =
+    inspector && inspectorPresentation === "desktop" ? (
+      <InspectorDock
+        rail={<WorkspaceEndRail {...endRail} />}
+        resizeHandleLabel={inspector.resizeHandleLabel}
+        resizeHandleProps={inspector.resizeHandleProps}
+        showPaneContent={inspector.showPaneContent}
+        width={inspector.width}
+        onResetWidth={inspector.onResetWidth}
+      >
+        {inspector.pane}
+      </InspectorDock>
+    ) : (
+      <WorkspaceEndRail {...endRail} />
+    );
 
   const frame = (
     <WorkspaceShell
@@ -172,7 +182,7 @@ export const WorkspaceFrame = (props: WorkspaceFrameProps) => {
     </WorkspaceShell>
   );
 
-  if (inspector?.mobile === undefined) {
+  if (inspector?.mobile === undefined || inspectorPresentation === "desktop") {
     return frame;
   }
 


### PR DESCRIPTION
## Summary

- select the responsive inspector presentation before composing the complete workspace frame
- keep the permanent end rail while mounting only one detail surface
- cover the complete compact/desktop decision matrix

## Validation

- `bun run --filter @stll/workspace-ui test`
- `bun run --filter @stll/workspace-ui lint`

CC on behalf of jan-kubica