### PR TITLE
fix: render boards without subgroups

### DIFF
--- a/.changeset/calm-rivers-board.md
+++ b/.changeset/calm-rivers-board.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": patch
+---
+
+Render Kanban boards without a subgroup as a single row of typed cells.

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -98,6 +98,8 @@ export type {
 export {
   buildKanbanBoardMatrix,
   createKanbanDropIntent,
+  getKanbanBoardColumnIdentity,
+  getKanbanBoardLaneIdentity,
   KANBAN_BOARD_AXES,
   orderKanbanCellsByColumns,
 } from "./matrix";

--- a/packages/ui/src/kanban/subgroup-board.test.tsx
+++ b/packages/ui/src/kanban/subgroup-board.test.tsx
@@ -33,7 +33,7 @@ const schema: KanbanSchema<Row, Property> = {
 
 const group = resolveKanbanGrouping({ groupBy: "_status", schema });
 const subgroup = resolveKanbanGrouping({ groupBy: "owner", schema });
-const noSubgroup = resolveKanbanGrouping({ groupBy: null, schema });
+const noSubgroup = resolveKanbanGrouping({ groupBy: "", schema });
 const testLabel = (...values: readonly unknown[]) => values.join(":");
 const matrix = buildKanbanBoardMatrix({
   group,

--- a/packages/ui/src/kanban/subgroup-board.test.tsx
+++ b/packages/ui/src/kanban/subgroup-board.test.tsx
@@ -33,6 +33,7 @@ const schema: KanbanSchema<Row, Property> = {
 
 const group = resolveKanbanGrouping({ groupBy: "_status", schema });
 const subgroup = resolveKanbanGrouping({ groupBy: "owner", schema });
+const noSubgroup = resolveKanbanGrouping({ groupBy: null, schema });
 const testLabel = (...values: readonly unknown[]) => values.join(":");
 const matrix = buildKanbanBoardMatrix({
   group,
@@ -43,7 +44,7 @@ const matrix = buildKanbanBoardMatrix({
     grouping.type === "built-in" ? row.status : row.owner,
 });
 
-const renderBoard = (expandEmptyLanes = false) =>
+const renderBoard = (boardMatrix = matrix, expandEmptyLanes = false) =>
   renderToStaticMarkup(
     <KanbanSubgroupBoard
       {...(expandEmptyLanes
@@ -52,7 +53,7 @@ const renderBoard = (expandEmptyLanes = false) =>
             onLaneCollapsedChange: () => undefined,
           }
         : {})}
-      matrix={matrix}
+      matrix={boardMatrix}
       renderCell={({ cell, count, laneValue }) => (
         <span>
           {testLabel(
@@ -95,7 +96,7 @@ describe("KanbanSubgroupBoard", () => {
 
   test("collapses empty lanes by default and supports controlled expansion", () => {
     const collapsed = renderBoard();
-    const expanded = renderBoard(true);
+    const expanded = renderBoard(matrix, true);
 
     expect(collapsed).toContain("lane:lin:0");
     expect(collapsed).toContain('data-kanban-lane-column-count="1"');
@@ -105,5 +106,21 @@ describe("KanbanSubgroupBoard", () => {
     expect(expanded).toContain("cell:lin:open:0");
     expect(expanded).toContain("cell:lin:done:0");
     expect(expanded).toContain('data-kanban-lane-column-count="0"');
+  });
+
+  test("renders one board row when subgrouping is absent", () => {
+    const singleLaneMatrix = buildKanbanBoardMatrix({
+      group,
+      subgroup: noSubgroup,
+      rows: [{ id: "one", owner: "ada", status: "open" }],
+      uncategorizedLabel: "No value",
+      resolveGroupValue: ({ grouping, row }) =>
+        grouping.type === "built-in" ? row.status : row.owner,
+    });
+    const markup = renderBoard(singleLaneMatrix);
+
+    expect(markup).toContain("column:open:1");
+    expect(markup).toContain("cell::open:1");
+    expect(markup).not.toContain("lane:");
   });
 });

--- a/packages/ui/src/kanban/subgroup-board.tsx
+++ b/packages/ui/src/kanban/subgroup-board.tsx
@@ -74,28 +74,32 @@ export const KanbanSubgroupBoard = <TRow,>({
   const [expandedEmptyLaneValues, setExpandedEmptyLaneValues] = useState(
     () => new Set<string | null>(),
   );
-  const { cellsByLaneValue, countByColumnValue } = useMemo(() => {
-    const laneCells = new Map<string | null, KanbanBoardCell<TRow>[]>();
-    const columnCounts = new Map<string, number>();
-    for (const cell of matrix.cells) {
-      const key = columnKey(cell.coordinate.column);
-      columnCounts.set(key, (columnCounts.get(key) ?? 0) + cell.rows.length);
-      if (cell.coordinate.lane.type === "none") {
-        continue;
+  const { cellsByLaneValue, countByColumnValue, ungroupedCells } =
+    useMemo(() => {
+      const laneCells = new Map<string | null, KanbanBoardCell<TRow>[]>();
+      const columnCounts = new Map<string, number>();
+      const cellsWithoutLane: KanbanBoardCell<TRow>[] = [];
+      for (const cell of matrix.cells) {
+        const key = columnKey(cell.coordinate.column);
+        columnCounts.set(key, (columnCounts.get(key) ?? 0) + cell.rows.length);
+        if (cell.coordinate.lane.type === "none") {
+          cellsWithoutLane.push(cell);
+          continue;
+        }
+        const laneValue = cell.coordinate.lane.group.value;
+        const currentLaneCells = laneCells.get(laneValue);
+        if (currentLaneCells) {
+          currentLaneCells.push(cell);
+        } else {
+          laneCells.set(laneValue, [cell]);
+        }
       }
-      const laneValue = cell.coordinate.lane.group.value;
-      const currentLaneCells = laneCells.get(laneValue);
-      if (currentLaneCells) {
-        currentLaneCells.push(cell);
-      } else {
-        laneCells.set(laneValue, [cell]);
-      }
-    }
-    return {
-      cellsByLaneValue: laneCells,
-      countByColumnValue: columnCounts,
-    };
-  }, [matrix.cells]);
+      return {
+        cellsByLaneValue: laneCells,
+        countByColumnValue: columnCounts,
+        ungroupedCells: cellsWithoutLane,
+      };
+    }, [matrix.cells]);
 
   const setLaneCollapsed = (
     group: KanbanGroup,
@@ -143,6 +147,23 @@ export const KanbanSubgroupBoard = <TRow,>({
             </div>
           ))}
         </div>
+
+        {ungroupedCells.length === 0 ? null : (
+          <div className="flex gap-3 pb-1">
+            {ungroupedCells.map((cell) => (
+              <div
+                className="w-[300px] shrink-0"
+                key={columnKey(cell.coordinate.column)}
+              >
+                {renderCell({
+                  cell,
+                  count: cell.rows.length,
+                  laneValue: null,
+                })}
+              </div>
+            ))}
+          </div>
+        )}
 
         {matrix.lanes.map((lane) => {
           if (lane.type === "none") {


### PR DESCRIPTION
## Summary

- render the explicit no-subgroup lane instead of dropping it from the board
- preserve the same typed cell renderer for optional grouping
- cover the single-row matrix contract

## Validation

- `bun test packages/ui/src/kanban/subgroup-board.test.tsx`
- `bun run --filter @stll/ui lint`

CC on behalf of jan-kubica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Kanban boards without a subgroup now display as a single row of typed cells.
  - Added support for identifying Kanban board columns and lanes through the public interface.

- **Bug Fixes**
  - Ungrouped Kanban cells are now rendered correctly instead of being omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->