### PR TITLE
fix: serialize production e2e artifact handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1519,7 +1519,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
-      actions: read
       contents: read
     strategy:
       fail-fast: false

--- a/scripts/detect-e2e-changes.test.ts
+++ b/scripts/detect-e2e-changes.test.ts
@@ -555,16 +555,37 @@ describe("detect-e2e-changes", () => {
   });
 
   test("builds the production web artifact once per workflow run", () => {
+    const plan = workflowJob("ci-plan");
+    expect(plan).toContain(
+      [
+        'if [[ "$e2e_core_required" == "true" ]]; then',
+        "            web_build_required=true",
+        "          fi",
+      ].join("\n"),
+    );
+
     const webBuild = workflowJob("web-build");
     expect(webBuild).toContain("needs: ci-plan");
     expect(webBuild).toContain("Upload production E2E web build");
     expect(webBuild).toContain("VITE_FEATURE_TIME_BILLING");
 
     const production = workflowJob("e2e-production-shard");
+    const productionHeader = production.slice(
+      0,
+      production.indexOf("\n    runs-on:"),
+    );
+    expect(productionHeader).toContain(
+      [
+        "    needs: [ci-plan, web-build]",
+        "    if: >-",
+        "      always()",
+        "      && (needs.ci-plan.outputs.trusted == 'true'",
+        "          || github.event_name == 'workflow_dispatch')",
+        "      && needs.ci-plan.outputs.e2e_core_required == 'true'",
+        "      && needs.web-build.result == 'success'",
+      ].join("\n"),
+    );
     expect(production).not.toContain("Build web for route checks");
-    expect(production).toContain("needs: [ci-plan, web-build]");
-    expect(production).toContain("always()");
-    expect(production).toContain("needs.web-build.result == 'success'");
     expect(production).not.toContain("Wait for production web build");
     expect(production).toContain("Download production web build");
     expect(production).toContain("Validate production web build");


### PR DESCRIPTION
Production E2E shards currently poll for an artifact from an independently scheduled web build. Runner contention can exhaust the polling window before the producer starts.

Make the producer an explicit job dependency, gate the shards on its success, and remove the timing-based polling path. Keep skipped build plans skipped through the job-level condition, and bind the producer/consumer contract in the workflow invariant test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production end-to-end test reliability by ensuring tests run only after the web build completes successfully.
  * Removed unnecessary waiting during production test setup, reducing delays and avoiding failures caused by delayed build-artifact detection.

* **Tests**
  * Updated automated checks to verify build dependencies, execution conditions and the streamlined production test flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->