### PR TITLE
fix(desktop): relaunch through LaunchServices after a macOS update

### DIFF
--- a/apps/desktop/src-tauri/src/autostart.rs
+++ b/apps/desktop/src-tauri/src/autostart.rs
@@ -1,0 +1,59 @@
+// Login-item registration. The autostart plugin writes the native
+// registration; on macOS the launch agent it produces needs one more key
+// than the plugin's template offers.
+
+use tauri::AppHandle;
+use tauri_plugin_autostart::ManagerExt;
+
+pub fn enable(app: &AppHandle) -> Result<(), String> {
+  app
+    .autolaunch()
+    .enable()
+    .map_err(|err| format!("autostart enable failed: {err}"))?;
+
+  #[cfg(target_os = "macos")]
+  launch_agent::abandon_process_group(app)?;
+
+  Ok(())
+}
+
+#[cfg(target_os = "macos")]
+mod launch_agent {
+  use std::path::PathBuf;
+
+  use tauri::AppHandle;
+
+  const ABANDON_PROCESS_GROUP_KEY: &str = "AbandonProcessGroup";
+
+  // launchd kills every process still in a job's process group when the
+  // job exits. The post-update relaunch helper already runs in its own
+  // group; this keeps any other child of a login-launched app from being
+  // reaped alongside it.
+  pub fn abandon_process_group(app: &AppHandle) -> Result<(), String> {
+    let path = plist_path(app)?;
+    let mut agent = plist::Value::from_file(&path)
+      .map_err(|err| format!("launch agent {} unreadable: {err}", path.display()))?
+      .into_dictionary()
+      .ok_or_else(|| format!("launch agent {} is not a dictionary", path.display()))?;
+
+    agent.insert(
+      ABANDON_PROCESS_GROUP_KEY.to_string(),
+      plist::Value::Boolean(true),
+    );
+
+    plist::to_file_xml(&path, &agent)
+      .map_err(|err| format!("launch agent {} not writable: {err}", path.display()))
+  }
+
+  // Mirrors the autostart plugin's launch agent location:
+  // `~/Library/LaunchAgents/<package name>.plist`.
+  fn plist_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or("home directory unavailable")?;
+    Ok(
+      home
+        .join("Library")
+        .join("LaunchAgents")
+        .join(format!("{}.plist", app.package_info().name)),
+    )
+  }
+}

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -165,13 +165,11 @@ pub async fn set_autostart(
   app: tauri::AppHandle,
 ) -> Result<bool, String> {
   use tauri_plugin_autostart::ManagerExt;
-  let autostart = app.autolaunch();
   if enabled {
-    autostart
-      .enable()
-      .map_err(|e| format!("autostart enable failed: {e}"))?;
+    crate::autostart::enable(&app)?;
   } else {
-    autostart
+    app
+      .autolaunch()
       .disable()
       .map_err(|e| format!("autostart disable failed: {e}"))?;
   }

--- a/apps/desktop/src-tauri/src/deep_link.rs
+++ b/apps/desktop/src-tauri/src/deep_link.rs
@@ -169,6 +169,9 @@ pub fn handle_url(
           updater::CheckOutcome::UpToDate => {
             tracing::debug!("deep link updater check: up to date");
           }
+          updater::CheckOutcome::Installed { version } => {
+            tracing::info!(version = %version, "deep link update installed, relaunching");
+          }
           updater::CheckOutcome::Failed(error) => {
             tracing::warn!(error = %error, "deep link updater check failed");
           }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod app_lifecycle;
+mod autostart;
 mod bridge;
 mod clipboard;
 mod clipboard_commands;
@@ -14,6 +15,7 @@ mod diagnostics;
 mod e2e;
 mod i18n;
 mod keychain;
+mod relaunch;
 mod session_manager;
 mod session_store;
 mod sse;
@@ -262,6 +264,9 @@ pub fn run() {
                       tracing::warn!(error = %err, "up-to-date notification failed");
                     }
                   }
+                  updater::CheckOutcome::Installed { version } => {
+                    tracing::info!(version = %version, "tray-triggered update installed, relaunching");
+                  }
                   updater::CheckOutcome::Failed(msg) => {
                     tracing::warn!(error = %msg, "tray-triggered updater check failed");
                   }
@@ -329,10 +334,9 @@ pub fn run() {
       // configured background-launch argument. Enabling overwrites the
       // existing registration without changing one the user disabled.
       {
-        let autostart = handle.autolaunch();
-        match autostart.is_enabled() {
+        match handle.autolaunch().is_enabled() {
           Ok(true) => {
-            if let Err(error) = autostart.enable() {
+            if let Err(error) = autostart::enable(&handle) {
               tracing::warn!(error = %error, "auto-start registration could not be refreshed");
             }
           }

--- a/apps/desktop/src-tauri/src/relaunch.rs
+++ b/apps/desktop/src-tauri/src/relaunch.rs
@@ -1,0 +1,147 @@
+// Relaunch after an in-place update.
+//
+// `AppHandle::restart` spawns the new binary as a child in the current
+// process group and exits. When the app was started by its login launch
+// agent, launchd owns that process group and signals every member as soon
+// as the job exits, so the freshly spawned binary dies while still blocked
+// in exec behind Gatekeeper's rescan of the replaced bundle.
+//
+// On macOS the relaunch therefore runs from a detached helper that outlives
+// this process, waits for it to exit, and asks LaunchServices to open the
+// bundle: a Gatekeeper-evaluated launch that belongs to no old job. Windows
+// never reaches this module; the updater plugin hands off to the installer,
+// which relaunches the app itself.
+
+#[cfg(target_os = "macos")]
+pub use macos::after_update;
+
+#[cfg(not(target_os = "macos"))]
+pub fn after_update(handle: &tauri::AppHandle) -> Result<(), String> {
+  handle.restart()
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+  use std::ffi::{OsStr, OsString};
+  use std::os::unix::process::CommandExt;
+  use std::path::{Path, PathBuf};
+  use std::process::{Command, Stdio};
+
+  use tauri::{AppHandle, Manager};
+
+  // Positional parameters: $1 = pid to wait for, $2 = bundle path, the
+  // rest = arguments for the relaunched app. Waiting for the old process
+  // keeps the single-instance socket free for the new one.
+  const RELAUNCH_SCRIPT: &str = r#"
+i=0
+while kill -0 "$1" 2>/dev/null; do
+  i=$((i + 1))
+  if [ "$i" -ge 300 ]; then exit 1; fi
+  sleep 0.1
+done
+bundle="$2"
+shift 2
+if [ "$#" -gt 0 ]; then exec /usr/bin/open "$bundle" --args "$@"; fi
+exec /usr/bin/open "$bundle"
+"#;
+
+  pub fn after_update(handle: &AppHandle) -> Result<(), String> {
+    let env = handle.env();
+    let binary = tauri::process::current_binary(&env)
+      .map_err(|err| format!("current binary path unavailable: {err}"))?;
+    let bundle = bundle_root(&binary)
+      .ok_or_else(|| format!("{} is not inside an app bundle", binary.display()))?;
+
+    relaunch_command(
+      std::process::id(),
+      &bundle,
+      env.args_os.iter().skip(1).cloned(),
+    )
+    .spawn()
+    .map_err(|err| format!("relaunch helper could not be spawned: {err}"))?;
+
+    handle.exit(0);
+    Ok(())
+  }
+
+  fn relaunch_command(
+    pid: u32,
+    bundle: &Path,
+    args: impl IntoIterator<Item = OsString>,
+  ) -> Command {
+    let mut command = Command::new("/bin/sh");
+    command
+      .arg("-c")
+      .arg(RELAUNCH_SCRIPT)
+      .arg("stella-relaunch")
+      .arg(pid.to_string())
+      .arg(bundle)
+      .args(args)
+      // Own process group: launchd's teardown of the exiting job must not
+      // reach the helper.
+      .process_group(0)
+      .stdin(Stdio::null())
+      .stdout(Stdio::null())
+      .stderr(Stdio::null());
+    command
+  }
+
+  fn bundle_root(binary: &Path) -> Option<PathBuf> {
+    let macos_dir = binary
+      .parent()
+      .filter(|dir| dir.file_name() == Some(OsStr::new("MacOS")))?;
+    let contents_dir = macos_dir
+      .parent()
+      .filter(|dir| dir.file_name() == Some(OsStr::new("Contents")))?;
+    let bundle = contents_dir.parent()?;
+    (bundle.extension() == Some(OsStr::new("app"))).then(|| bundle.to_path_buf())
+  }
+
+  #[cfg(test)]
+  mod tests {
+    use super::*;
+
+    #[test]
+    fn bundle_root_requires_the_bundle_layout() {
+      assert_eq!(
+        bundle_root(Path::new(
+          "/Applications/stella desktop.app/Contents/MacOS/stella-desktop"
+        )),
+        Some(PathBuf::from("/Applications/stella desktop.app"))
+      );
+      assert_eq!(
+        bundle_root(Path::new("/tmp/build/target/release/stella-desktop")),
+        None
+      );
+      assert_eq!(
+        bundle_root(Path::new(
+          "/tmp/stella desktop/Contents/MacOS/stella-desktop"
+        )),
+        None
+      );
+    }
+
+    #[test]
+    fn relaunch_command_forwards_pid_bundle_and_launch_arguments() {
+      let command = relaunch_command(
+        4242,
+        Path::new("/Applications/stella desktop.app"),
+        [OsString::from("--stella-background-launch")],
+      );
+
+      assert_eq!(command.get_program(), OsStr::new("/bin/sh"));
+      let args: Vec<&OsStr> = command.get_args().collect();
+      assert_eq!(
+        args,
+        [
+          OsStr::new("-c"),
+          OsStr::new(RELAUNCH_SCRIPT),
+          OsStr::new("stella-relaunch"),
+          OsStr::new("4242"),
+          OsStr::new("/Applications/stella desktop.app"),
+          OsStr::new("--stella-background-launch"),
+        ]
+      );
+    }
+  }
+}

--- a/apps/desktop/src-tauri/src/relaunch.rs
+++ b/apps/desktop/src-tauri/src/relaunch.rs
@@ -31,18 +31,27 @@ mod macos {
 
   // Positional parameters: $1 = pid to wait for, $2 = bundle path, the
   // rest = arguments for the relaunched app. Waiting for the old process
-  // keeps the single-instance socket free for the new one.
+  // keeps the single-instance socket free for the new one. Nothing
+  // observes the helper after this process exits, so the helper posts
+  // the fallback notification itself when the relaunch does not happen.
   const RELAUNCH_SCRIPT: &str = r#"
+fallback() {
+  /usr/bin/osascript -e 'display notification "Quit and reopen Stella to finish updating." with title "Stella update installed"' >/dev/null 2>&1
+  exit 1
+}
 i=0
 while kill -0 "$1" 2>/dev/null; do
   i=$((i + 1))
-  if [ "$i" -ge 300 ]; then exit 1; fi
+  if [ "$i" -ge 300 ]; then fallback; fi
   sleep 0.1
 done
 bundle="$2"
 shift 2
-if [ "$#" -gt 0 ]; then exec /usr/bin/open "$bundle" --args "$@"; fi
-exec /usr/bin/open "$bundle"
+if [ "$#" -gt 0 ]; then
+  /usr/bin/open "$bundle" --args "$@" || fallback
+else
+  /usr/bin/open "$bundle" || fallback
+fi
 "#;
 
   pub fn after_update(handle: &AppHandle) -> Result<(), String> {

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -243,7 +243,7 @@ pub struct TrustedSelfHostConnection {
 /// Monotonic bridge contract revision. Increment whenever the bridge
 /// surface changes so the web app can require a minimum revision without
 /// coupling to the desktop's literal app version.
-pub const BRIDGE_VERSION: u32 = 11;
+pub const BRIDGE_VERSION: u32 = 12;
 
 /// Versioned contracts advertised to the web app. A client requires the
 /// capability it uses; breaking semantics receive a new capability id.

--- a/apps/desktop/src-tauri/src/updater.rs
+++ b/apps/desktop/src-tauri/src/updater.rs
@@ -11,9 +11,9 @@
 // - When the tray "Check for updates" item is clicked, run the same
 //   check synchronously and notify whether an update was found.
 // - When an update is found and no desktop edit sessions are
-//   active, download + install + restart. The installer handles
-//   the binary swap; tauri_plugin_process is required for the
-//   post-install restart to work cross-platform.
+//   active, download + install + relaunch. The installer handles
+//   the binary swap; `crate::relaunch` owns the hand-over to the
+//   new binary.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -28,14 +28,13 @@ use crate::session_manager::SessionManager;
 const STARTUP_CHECK_DELAY: Duration = Duration::from_secs(10);
 const BACKGROUND_CHECK_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
 
-// Outcome of an update check that *did not* apply an update. The
-// "update applied" path doesn't appear here because the install
-// step calls `AppHandle::restart()`, which exits the current
-// process and never returns.
+// `Installed` means the exit of this process has been requested and
+// the relaunch is under way; callers must not schedule further work.
 #[derive(Debug)]
 pub enum CheckOutcome {
   Deferred { version: String },
   UpToDate,
+  Installed { version: String },
   Failed(String),
 }
 
@@ -63,6 +62,10 @@ pub fn schedule_startup_check(handle: AppHandle, manager: Arc<Mutex<SessionManag
         }
         CheckOutcome::UpToDate => {
           tracing::debug!("background updater: up to date");
+        }
+        CheckOutcome::Installed { version } => {
+          tracing::info!(version = %version, "background updater: installed, relaunching");
+          return;
         }
         CheckOutcome::Failed(err) => {
           tracing::warn!(error = %err, "background updater check failed");
@@ -111,10 +114,20 @@ pub async fn run_check(handle: &AppHandle, active_edit_sessions: bool) -> CheckO
     return CheckOutcome::Failed(msg);
   }
 
-  // Restart so the new binary takes over. `restart` exits the
-  // current process and never returns; the type-level `!` coerces
-  // to `CheckOutcome` to satisfy the signature.
-  handle.restart()
+  // On Windows the plugin has already handed off to the installer and
+  // exited; this line only runs where the bundle was swapped in place.
+  if let Err(err) = crate::relaunch::after_update(handle) {
+    notify(
+      handle,
+      "Stella update installed",
+      "Quit and reopen Stella to finish updating.",
+    );
+    return CheckOutcome::Failed(format!(
+      "v{version} installed but the relaunch failed: {err}"
+    ));
+  }
+
+  CheckOutcome::Installed { version }
 }
 
 fn notify(handle: &AppHandle, title: &str, body: &str) {


### PR DESCRIPTION
## Problem

After the updater swaps the bundle in place on macOS, `AppHandle::restart` spawns the new binary as a child in the current process group and exits. When the app was started by its login launch agent, launchd owns that process group and signals every remaining member as soon as the job exits. The new binary is still blocked in exec while Gatekeeper rescans the replaced bundle, takes the signal, and never starts. The app then stays down until opened by hand. Manually launched instances are not affected, so this only shows up with "start at login" enabled.

## Change

- `relaunch.rs`: on macOS, spawn a detached helper (own process group) that waits for this process to exit and then asks LaunchServices to `open` the bundle with the original arguments; then request exit. This is the same pattern Zed, Sparkle and Squirrel.Mac use. Other platforms keep `AppHandle::restart`. Windows never reaches this code: the updater plugin hands off to the NSIS installer with `/P /R /UPDATE /ARGS`, which relaunches the app itself.
- `autostart.rs`: enabling autostart now also writes `AbandonProcessGroup` into the launch agent, so launchd no longer reaps other children of a login-launched instance. Takes effect at the next login.
- `updater.rs`: report an installed update as `CheckOutcome::Installed` instead of assuming the process is gone; a failed relaunch notifies the user to reopen the app.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, crate unit tests (two new tests cover bundle-path derivation and helper arguments).
- Dry run of the helper script: waits for the watched pid, then hands the bundle to `open`; the bounded wait exits without launching.

https://claude.ai/code/session_01MfrYpR77ib97QtKLf6KeUa
