### PR TITLE
fix: canonicalize Quickwit duration syntax

### DIFF
--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -97,7 +97,7 @@ type CorpusIndexMaturationPeriod =
 /** Render the manifest value exactly as Quickwit's metadata API does. */
 export const canonicalCorpusIndexMaturationPeriod = (
   value: CorpusIndexMaturationPeriod,
-): string => QUICKWIT_CANONICAL_MATURATION_PERIOD[value];
+) => QUICKWIT_CANONICAL_MATURATION_PERIOD[value];
 
 /** Merge policy retained by the legacy generation helpers. */
 export const CORPUS_INDEX_MERGE_POLICY = {

--- a/apps/api/src/lib/legal-search/corpus-index-config.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-config.ts
@@ -78,11 +78,26 @@ type CorpusIndexFieldMapping = {
 
 type CorpusIndexMergePolicy = {
   type: "stable_log";
-  maturation_period: string;
+  maturation_period: CorpusIndexMaturationPeriod;
   merge_factor: number;
   max_merge_factor: number;
   min_level_num_docs: number;
 };
+
+const QUICKWIT_CANONICAL_MATURATION_PERIOD = {
+  "4h": "4h",
+  "4hours": "4h",
+  "7d": "7d",
+  "7days": "7d",
+} as const;
+
+type CorpusIndexMaturationPeriod =
+  keyof typeof QUICKWIT_CANONICAL_MATURATION_PERIOD;
+
+/** Render the manifest value exactly as Quickwit's metadata API does. */
+export const canonicalCorpusIndexMaturationPeriod = (
+  value: CorpusIndexMaturationPeriod,
+): string => QUICKWIT_CANONICAL_MATURATION_PERIOD[value];
 
 /** Merge policy retained by the legacy generation helpers. */
 export const CORPUS_INDEX_MERGE_POLICY = {

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.test.ts
@@ -89,10 +89,24 @@ test("physical index ids are deployment state, not manifest identity", () => {
   expect(csSkConfig).toEqual({
     ...manifest.engine.indexConfig,
     index_id: "case_law_v5_cs_sk",
+    indexing_settings: {
+      ...manifest.engine.indexConfig.indexing_settings,
+      merge_policy: {
+        ...manifest.engine.indexConfig.indexing_settings.merge_policy,
+        maturation_period: "4h",
+      },
+    },
   });
   expect(corpusIndexConfigFromManifest(manifest, "case_law_v5_pol")).toEqual({
     ...manifest.engine.indexConfig,
     index_id: "case_law_v5_pol",
+    indexing_settings: {
+      ...manifest.engine.indexConfig.indexing_settings,
+      merge_policy: {
+        ...manifest.engine.indexConfig.indexing_settings.merge_policy,
+        maturation_period: "4h",
+      },
+    },
   });
   expect(corpusIndexManifestDigest(manifest)).toBe(
     EXPECTED_DIGESTS.case_law_v5,

--- a/apps/api/src/lib/legal-search/corpus-index-manifest.ts
+++ b/apps/api/src/lib/legal-search/corpus-index-manifest.ts
@@ -15,6 +15,7 @@ import {
   CORPUS_INDEX_DATE_INPUT_FORMATS,
   DECISION_TIMESTAMP_FIELD,
   FOLDED_TOKENIZER,
+  canonicalCorpusIndexMaturationPeriod,
   type CorpusIndexConfig,
 } from "@/api/lib/legal-search/corpus-index-config";
 import { QUICKWIT_V09_BINARY_VERSION } from "@/api/lib/legal-search/corpus-index-engine-version";
@@ -363,7 +364,19 @@ export const corpusIndexConfigFromManifest = (
   indexId: string,
 ): CorpusIndexConfig => {
   const config = structuredClone(manifest.engine.indexConfig);
-  return { ...config, index_id: indexId };
+  return {
+    ...config,
+    index_id: indexId,
+    indexing_settings: {
+      ...config.indexing_settings,
+      merge_policy: {
+        ...config.indexing_settings.merge_policy,
+        maturation_period: canonicalCorpusIndexMaturationPeriod(
+          config.indexing_settings.merge_policy.maturation_period,
+        ),
+      },
+    },
+  };
 };
 
 /**


### PR DESCRIPTION
## Summary

- preserve the published generation manifests and their digests
- render manifest durations in Quickwit’s compact wire form
- keep strict create/read configuration attestation exact

## Validation

- `git diff --check`
- `bun test apps/api/src/lib/legal-search/corpus-index-manifest.test.ts`

CC on behalf of jan-kubica