### PR TITLE
feat: share the kanban cell add action

### DIFF
--- a/.changeset/kanban-cell-action.md
+++ b/.changeset/kanban-cell-action.md
@@ -1,0 +1,5 @@
+---
+"@stll/ui": minor
+---
+
+Add `KanbanCellAction`, the shared full-width ghost row that ends a kanban cell with its add action, so every board renders the same footer.

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-subgroup-board.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-subgroup-board.tsx
@@ -1,12 +1,13 @@
 import { useRef, useState } from "react";
 
 import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
-import { GripVerticalIcon, PlusIcon, Rows3Icon } from "lucide-react";
+import { GripVerticalIcon, Rows3Icon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/button";
 import {
   KANBAN_VIRTUAL_CELL_PAGINATION,
+  KanbanCellAction,
   KanbanColumnHeader,
   KanbanSubgroupBoard as KanbanSubgroupLayout,
   KanbanVirtualCell,
@@ -267,15 +268,12 @@ const CreateTaskButton = ({
   const t = useTranslations();
 
   return (
-    <Button
-      className="text-muted-foreground hover:text-foreground min-h-11 w-full justify-start gap-1.5"
+    <KanbanCellAction
       disabled={disabled}
       onClick={() => onCreate(columnValue, laneValue)}
-      variant="ghost"
     >
-      <PlusIcon className="size-3.5" />
       {t("tasks.newTask")}
-    </Button>
+    </KanbanCellAction>
   );
 };
 

--- a/packages/ui/src/kanban/cell-action.test.tsx
+++ b/packages/ui/src/kanban/cell-action.test.tsx
@@ -1,0 +1,44 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { describe, expect, test } from "bun:test";
+
+import { KanbanCellAction } from "./cell-action";
+
+// Static markup carries no layout; these tests pin the structure and the
+// utilities that give every cell the same ending row.
+
+const readButton = (markup: string) => {
+  const match = /<button[^>]*data-slot="kanban-cell-action"[^>]*>/u.exec(
+    markup,
+  );
+
+  if (!match) {
+    throw new Error("no cell action in the rendered markup");
+  }
+
+  return match[0];
+};
+
+describe("KanbanCellAction", () => {
+  test("renders one full-width ghost row on the card rhythm", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanCellAction>New card</KanbanCellAction>,
+    );
+    const classes = /class="([^"]*)"/u.exec(readButton(markup))?.[1] ?? "";
+
+    expect(classes.split(" ")).toEqual(
+      expect.arrayContaining(["min-h-11", "w-full", "justify-start"]),
+    );
+    expect(markup.indexOf("<svg")).toBeLessThan(markup.indexOf("New card"));
+  });
+
+  test("forwards disabled and click wiring to the button", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanCellAction disabled onClick={() => undefined}>
+        New card
+      </KanbanCellAction>,
+    );
+
+    expect(readButton(markup)).toContain("disabled");
+  });
+});

--- a/packages/ui/src/kanban/cell-action.tsx
+++ b/packages/ui/src/kanban/cell-action.tsx
@@ -1,0 +1,38 @@
+import type { ComponentProps } from "react";
+
+import { PlusIcon } from "lucide-react";
+
+import { Button } from "../components/button";
+import { cn } from "../lib/utils";
+
+export type KanbanCellActionProps = Omit<
+  ComponentProps<typeof Button>,
+  "variant"
+>;
+
+/**
+ * The quiet action at the end of a cell: a full-width ghost row that adds a
+ * card to that column and lane.
+ *
+ * Every board rendered its own copy of this row and the copies drifted in
+ * height, tone, and icon size. One primitive keeps the footer of every cell on
+ * the same rhythm as a card, so an empty cell and a full one end the same way.
+ */
+export const KanbanCellAction = ({
+  children,
+  className,
+  ...props
+}: KanbanCellActionProps) => (
+  <Button
+    className={cn(
+      "text-muted-foreground hover:text-foreground min-h-11 w-full justify-start gap-1.5",
+      className,
+    )}
+    data-slot="kanban-cell-action"
+    {...props}
+    variant="ghost"
+  >
+    <PlusIcon className="size-3.5" />
+    {children}
+  </Button>
+);

--- a/packages/ui/src/kanban/index.ts
+++ b/packages/ui/src/kanban/index.ts
@@ -12,6 +12,8 @@ export type { KanbanCardFieldSelection } from "./card-properties";
 export { selectKanbanCardFieldIds } from "./card-properties";
 export type { KanbanCardShellProps } from "./card-shell";
 export { KanbanCardShell } from "./card-shell";
+export type { KanbanCellActionProps } from "./cell-action";
+export { KanbanCellAction } from "./cell-action";
 export type { KanbanColumnHeaderProps } from "./column-header";
 export { KanbanColumnHeader } from "./column-header";
 export type {


### PR DESCRIPTION
## Change

- `@stll/ui/kanban` exports `KanbanCellAction`: the full-width ghost row on the card rhythm (`min-h-11`, muted until hover, leading plus icon) that ends a cell with its add action. `variant` is fixed to ghost; everything else forwards to `Button`.
- The workspace board's `CreateTaskButton` consumes it instead of carrying its own copy of the classes.

## Why

Every board rendered its own version of this row and they drifted in height, tone, and icon size. One primitive keeps the footer of every cell on the same rhythm as a card, so an empty cell and a full one end the same way.

## Verification

- `bun test packages/ui/src/kanban/cell-action.test.tsx`: 2 pass (structure, forwarded props, icon before label).
- `oxlint --type-aware` on `packages/ui` and the touched board file: clean.
- `packages/ui` typecheck: clean. `oxfmt --check`: clean.
- Changeset: `@stll/ui` minor.