### PR TITLE
fix(ui): keep the inspector rail on the pane's inline-start edge

### DIFF
--- a/.changeset/inspector-rail-placement.md
+++ b/.changeset/inspector-rail-placement.md
@@ -1,0 +1,9 @@
+---
+"@stll/ui": patch
+---
+
+`InspectorDock` keeps the permanent rail on the pane's inline-start edge, the
+same order as the workspace inspector panel. Collapsed, the rail is still the
+whole dock on the viewport edge; expanded, the pane now opens beyond the rail
+instead of between the content and the rail, so the rail's tabs and toggle
+stay beside the content they describe.

--- a/packages/ui/src/inspector/chrome.test.tsx
+++ b/packages/ui/src/inspector/chrome.test.tsx
@@ -221,6 +221,29 @@ describe("dock", () => {
     expect(markup).not.toContain("rtl:flex-row-reverse");
   });
 
+  // The regression this guards: the rail rendered after the pane, so an
+  // expanded pane opened between the content and the rail and the rail's
+  // tabs and toggle jumped to the far edge of the screen. The workspace
+  // inspector panel orders rail, then pane; the dock must match it.
+  test("keeps the rail on the pane's inline-start edge when expanded", () => {
+    const markup = renderToStaticMarkup(
+      <InspectorDock
+        rail={<InspectorRail />}
+        resizeHandleLabel="Resize"
+        resizeHandleProps={noopHandlers}
+        showPaneContent
+        width={512}
+      >
+        <Inspector />
+      </InspectorDock>,
+    );
+    const order = [
+      ...markup.matchAll(/data-slot="(inspector-rail|inspector)"/gu),
+    ].map((match) => match[1]);
+
+    expect(order).toEqual(["inspector-rail", "inspector"]);
+  });
+
   test("keeps the permanent rail when pane content is collapsed", () => {
     const markup = renderToStaticMarkup(
       <InspectorDock

--- a/packages/ui/src/inspector/dock.tsx
+++ b/packages/ui/src/inspector/dock.tsx
@@ -18,6 +18,12 @@ import { INSPECTOR_RAIL_WIDTH } from "./pane-width";
  * which is exactly the failure the spacer exists to prevent. With the width
  * on the root, the dock reserves the same footprint in a flex row, a grid
  * track, or a plain block.
+ *
+ * The permanent rail sits on the pane's inline-start edge, the same order
+ * the workspace inspector panel uses: collapsed, the rail is the whole dock
+ * on the viewport edge; expanded, the pane opens beyond the rail, so the
+ * rail keeps its place beside the content and its tabs and toggle stay next
+ * to the pane they drive instead of jumping to the far edge of the screen.
  */
 
 type InspectorResizeHandleProps = {
@@ -37,7 +43,7 @@ type InspectorResizeHandleProps = {
 type InspectorDockProps = {
   children: ReactNode;
   className?: string | undefined;
-  /** Permanent inline-end rail shown beside the pane, or by itself when collapsed. */
+  /** Permanent rail on the pane's inline-start edge, or by itself when collapsed. */
   rail?: ReactNode | undefined;
   /** Accessible name for the drag handle. */
   resizeHandleLabel: string;
@@ -104,8 +110,8 @@ export const InspectorDock = ({
         )}
         {showPaneContent || rail === undefined ? (
           <div className="bg-sidebar flex h-full w-full flex-row">
-            <div className="min-w-0 flex-1">{children}</div>
             {rail}
+            <div className="min-w-0 flex-1">{children}</div>
           </div>
         ) : (
           rail


### PR DESCRIPTION
## Summary

`InspectorDock` rendered the permanent rail *after* the pane, so an expanded pane opened between the content and the rail and the rail's tabs and toggle jumped to the far edge of the screen. The workspace inspector panel (`InspectorPanel`) orders the rail first, then the pane content, which keeps the rail beside the content when a tab opens. The extracted primitive had drifted from that.

This puts the dock back in the panel's order: collapsed, the rail is still the whole dock on the viewport edge; expanded, the pane opens beyond the rail. No API change; `WorkspaceFrame` inherits the fix.

## Tests

`chrome.test.tsx` pins the expanded order (rail, then pane) alongside the existing footprint, collapse, and rail-omitted cases.

`packages/ui`: tests, typecheck, lint, and format pass locally.
