### PR TITLE
feat(chat): return the compiler report from create-document and add a drafting eval

### DIFF
--- a/apps/api/evals/README.md
+++ b/apps/api/evals/README.md
@@ -1,0 +1,37 @@
+# Evals
+
+Model-in-the-loop checks of Stella's AI surfaces. An eval hands a model the
+production tool definitions and prompts, then scores what comes back with
+deterministic code, so a prompt or tool-contract change can be judged on
+what models actually do rather than on intuition.
+
+Evals live next to the API because they import the same tool definitions
+the chat registers. They call paid models, so they run on demand, never in
+CI, and they resolve models from the instance credentials in `.env`.
+
+## Running
+
+```sh
+cd apps/api
+bun run eval:create-document
+bun run eval:create-document -- --models claude-haiku-4-5-20251001,openrouter::google/gemini-2.5-flash --runs 3
+bun run eval:create-document -- --task en-nda --json /tmp/out.json --sources-dir /tmp/sources
+```
+
+Model ids take the `provider::modelId` form or a bare id resolved through
+the default provider chain (see `getTanStackTextModelById`).
+
+## Conventions
+
+- One file per eval, named after the surface it measures.
+- Prompts are fixed and multilingual; the scoring is code, not a judge
+  model, so a regression is reproducible.
+- Print a Markdown table per model plus a one-line summary; `--json` keeps
+  the full record (including the raw model output) for offline analysis.
+- Keep results out of the repository.
+
+## Evals
+
+- `create-document-drafting.ts`: can a model write legal source the
+  docx-core compiler accepts, how much does the compiler normalize, and does
+  literal markdown leak into the document.

--- a/apps/api/evals/create-document-drafting.ts
+++ b/apps/api/evals/create-document-drafting.ts
@@ -35,6 +35,7 @@ import type { TokenUsage } from "@tanstack/ai";
 import { panic } from "better-result";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import * as v from "valibot";
 
 import { compileLegalSourceToDocument } from "@stll/docx-core";
 import type {
@@ -44,7 +45,10 @@ import type {
   Paragraph,
 } from "@stll/docx-core";
 
-import { createCreateDocumentTool } from "@/api/handlers/chat/tools/create-document-tool";
+import {
+  createCreateDocumentTool,
+  createDocumentToolInputSchema,
+} from "@/api/handlers/chat/tools/create-document-tool";
 import { resolveCaching } from "@/api/lib/ai-config";
 import {
   mergeGenerationOptions,
@@ -58,6 +62,8 @@ import { tokenUsageFromRunFinishedChunk } from "@/api/lib/tanstack-ai-usage";
 // Anthropic so a non-Anthropic default provider cannot claim them.
 const DEFAULT_MODELS = ["gpt-5.4-nano", "anthropic::claude-sonnet-5"];
 const DEFAULT_RUNS = 1;
+// Every run is a paid request; keep a typo from turning into a bill.
+const MAX_RUNS = 20;
 const MAX_OUTPUT_TOKENS = 6000;
 // A whole draft can take a minute on a slow model; a stalled provider must
 // not hang the run.
@@ -68,16 +74,44 @@ const SYSTEM_PROMPT =
   "a document, call the create-document tool once with the complete source. " +
   "Write in the language the user writes in.";
 
-type ExpectedBlockType = Extract<
-  LegalDraftBlock["type"],
-  "list" | "signatures" | "table"
->;
+/** A structural property the request calls for, checked on the draft blocks. */
+type StructuralExpectation = {
+  label: string;
+  holds: (blocks: readonly LegalDraftBlock[]) => boolean;
+};
+
+const signatures: StructuralExpectation = {
+  label: "signatures",
+  holds: (blocks) => blocks.some((block) => block.type === "signatures"),
+};
+
+const orderedList: StructuralExpectation = {
+  label: "ordered list",
+  holds: (blocks) =>
+    blocks.some((block) => block.type === "list" && block.ordered),
+};
+
+const bulletList: StructuralExpectation = {
+  label: "bullet list",
+  holds: (blocks) =>
+    blocks.some((block) => block.type === "list" && !block.ordered),
+};
+
+const tableWithColumns = (columns: number): StructuralExpectation => ({
+  label: `table with ${String(columns)} columns`,
+  holds: (blocks) =>
+    blocks.some(
+      (block) =>
+        block.type === "table" &&
+        block.table.headers.length === columns &&
+        block.table.rows.every((row) => row.length === columns),
+    ),
+});
 
 type EvalTask = {
   id: string;
   prompt: string;
-  /** Draft block types the request calls for. */
-  expects: readonly ExpectedBlockType[];
+  expects: readonly StructuralExpectation[];
 };
 
 const TASKS: readonly EvalTask[] = [
@@ -87,7 +121,7 @@ const TASKS: readonly EvalTask[] = [
       "Připrav plnou moc, kterou Jan Novák (nar. 1. 2. 1980, bytem Praha 5) " +
       "zmocňuje advokáta Mgr. Petra Svobodu k zastupování ve sporu s firmou " +
       "Alfa s.r.o. o zaplacení 250 000 Kč. Česky, s podpisovým blokem.",
-    expects: ["signatures"],
+    expects: [signatures],
   },
   {
     id: "en-nda",
@@ -96,7 +130,7 @@ const TASKS: readonly EvalTask[] = [
       "Republic) for evaluating a software partnership: definitions, a " +
       "three-year term, a table listing the categories of confidential " +
       "information with their handling rules, and signature blocks.",
-    expects: ["table", "signatures"],
+    expects: [tableWithColumns(2), signatures],
   },
   {
     id: "de-kuendigung",
@@ -113,7 +147,7 @@ const TASKS: readonly EvalTask[] = [
       "(two columns, Czech left, English right) between Gamma a.s. as client " +
       "and Delta Consulting s.r.o. as provider: scope, fees of 50 000 CZK per " +
       "month, three-month notice, Czech governing law. Signatures for both.",
-    expects: ["table", "signatures"],
+    expects: [tableWithColumns(2), signatures],
   },
   {
     id: "checklist-closing",
@@ -121,7 +155,7 @@ const TASKS: readonly EvalTask[] = [
       "Make a closing checklist for a share purchase deal: board approvals, " +
       "regulatory consents, funds flow, escrow release, post-closing filings. " +
       "Checkbox items the team can tick off.",
-    expects: ["list"],
+    expects: [bulletList],
   },
   {
     id: "sk-memo",
@@ -129,7 +163,7 @@ const TASKS: readonly EvalTask[] = [
       "Napíš krátke interné memo pre vedenie o povinnostiach zamestnávateľa " +
       "pri práci z domu podľa slovenského Zákonníka práce, s očíslovaným " +
       "zoznamom povinností a odporúčaniami na záver.",
-    expects: ["list"],
+    expects: [orderedList],
   },
   {
     id: "markdown-pressure",
@@ -137,7 +171,7 @@ const TASKS: readonly EvalTask[] = [
       "Write a consultancy agreement between Acme Inc. and Jane Roe. Use " +
       "markdown: headings for each section, bullet lists for the " +
       "obligations, bold every defined term, and italicize the recitals.",
-    expects: ["list"],
+    expects: [bulletList],
   },
 ];
 
@@ -147,6 +181,14 @@ type CliOptions = {
   taskFilter: string | null;
   jsonPath: string | null;
   sourcesDir: string | null;
+};
+
+const parseRuns = (value: string): number => {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    return DEFAULT_RUNS;
+  }
+  return Math.min(MAX_RUNS, parsed);
 };
 
 const parseArgs = (argv: readonly string[]): CliOptions => {
@@ -169,7 +211,7 @@ const parseArgs = (argv: readonly string[]): CliOptions => {
         index += 1;
         break;
       case "--runs":
-        options.runs = Math.max(1, Number.parseInt(value, 10) || DEFAULT_RUNS);
+        options.runs = parseRuns(value);
         index += 1;
         break;
       case "--task":
@@ -291,18 +333,13 @@ const parseJsonOrNull = (text: string): unknown => {
   }
 };
 
+// The same schema the chat tool validates with, so `bad-input` means what
+// production would reject.
 const readToolInput = (
   input: unknown,
 ): { name: string; source: string } | null => {
-  if (typeof input !== "object" || input === null) {
-    return null;
-  }
-  const name = Reflect.get(input, "name");
-  const source = Reflect.get(input, "source");
-  if (typeof name !== "string" || typeof source !== "string") {
-    return null;
-  }
-  return { name, source };
+  const parsed = v.safeParse(createDocumentToolInputSchema, input);
+  return parsed.success ? parsed.output : null;
 };
 
 const BODY_STYLE_IDS = new Set([
@@ -395,7 +432,7 @@ type RunScore = {
   leaks: string[];
   wholeBoldParagraphs: number;
   blockTypes: Record<string, number>;
-  missing: ExpectedBlockType[];
+  missing: string[];
   placeholders: number;
 };
 
@@ -413,7 +450,9 @@ const scoreCompiled = (
   source: string,
 ): RunScore => {
   const blockTypes = countBy(compiled.draft.blocks.map((block) => block.type));
-  const missing = task.expects.filter((type) => !(type in blockTypes));
+  const missing = task.expects
+    .filter((expectation) => !expectation.holds(compiled.draft.blocks))
+    .map((expectation) => expectation.label);
   const placeholders = source.match(/\[\[[^\]]+\]\]/gu)?.length ?? 0;
   if (compiled.status !== "ok") {
     return {

--- a/apps/api/evals/create-document-drafting.ts
+++ b/apps/api/evals/create-document-drafting.ts
@@ -60,7 +60,7 @@ import { tokenUsageFromRunFinishedChunk } from "@/api/lib/tanstack-ai-usage";
 // A bare id resolves through whichever configured provider rates it (GPT
 // models may come from OpenAI or OpenRouter); Claude ids are pinned to
 // Anthropic so a non-Anthropic default provider cannot claim them.
-const DEFAULT_MODELS = ["gpt-5.4-nano", "anthropic::claude-sonnet-5"];
+const DEFAULT_MODELS = ["gpt-5.4-mini", "anthropic::claude-sonnet-5"];
 const DEFAULT_RUNS = 1;
 // Every run is a paid request; keep a typo from turning into a bill.
 const MAX_RUNS = 20;

--- a/apps/api/evals/create-document-drafting.ts
+++ b/apps/api/evals/create-document-drafting.ts
@@ -24,7 +24,7 @@
  *
  * Usage (from apps/api):
  *   bun run eval:create-document
- *   bun run eval:create-document -- --models gpt-5.4-mini,anthropic::claude-sonnet-5
+ *   bun run eval:create-document -- --models gpt-5.6-luna,anthropic::claude-sonnet-5
  *   bun run eval:create-document -- --runs 3 --task en-nda --json out.json --sources-dir out/sources
  *
  * Model ids use `provider::modelId` or a bare id resolved through the
@@ -60,7 +60,7 @@ import { tokenUsageFromRunFinishedChunk } from "@/api/lib/tanstack-ai-usage";
 // A bare id resolves through whichever configured provider rates it (GPT
 // models may come from OpenAI or OpenRouter); Claude ids are pinned to
 // Anthropic so a non-Anthropic default provider cannot claim them.
-const DEFAULT_MODELS = ["gpt-5.4-mini", "anthropic::claude-sonnet-5"];
+const DEFAULT_MODELS = ["gpt-5.6-luna", "anthropic::claude-sonnet-5"];
 const DEFAULT_RUNS = 1;
 // Every run is a paid request; keep a typo from turning into a bill.
 const MAX_RUNS = 20;

--- a/apps/api/evals/create-document-drafting.ts
+++ b/apps/api/evals/create-document-drafting.ts
@@ -1,0 +1,641 @@
+/**
+ * create-document drafting benchmark: can a (cheap) model write legal
+ * source the docx-core compiler accepts, and how much does the compiler
+ * have to normalize?
+ *
+ * Each task is one user request. The model gets the production
+ * `create-document` tool definition (the same description and schema the
+ * chat registers) and a minimal system prompt; the script captures the
+ * `source` it hands the tool, compiles it with `compileLegalSourceToDocument`,
+ * and scores:
+ *
+ *   outcome      ok / repair (compile errors) / no-call (tool never called) /
+ *                bad-input (tool called with an unusable payload) / error
+ *                (the provider refused the request)
+ *   errors       compile error codes, or the provider error
+ *   fixes        normalizations the compiler applied (fix codes)
+ *   warnings     kept-but-suspect constructs
+ *   leaks        literal markdown left in document text (`**`, backticks,
+ *                `#` headings, unhighlighted `[[`)
+ *   whole-bold   body paragraphs bold from end to end
+ *   missing      structure the task asked for that the draft lacks
+ *
+ * No dev stack needed; models resolve from instance credentials (.env).
+ *
+ * Usage (from apps/api):
+ *   bun run eval:create-document
+ *   bun run eval:create-document -- --models claude-haiku-4-5-20251001,claude-sonnet-5
+ *   bun run eval:create-document -- --runs 3 --task en-nda --json out.json --sources-dir out/sources
+ *
+ * Model ids use `provider::modelId` or a bare id resolved through the
+ * default provider chain (see `getTanStackTextModelById`).
+ */
+import { EventType, chat, maxIterations } from "@tanstack/ai";
+import type { TokenUsage } from "@tanstack/ai";
+import { panic } from "better-result";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { compileLegalSourceToDocument } from "@stll/docx-core";
+import type {
+  BlockContent,
+  LegalDraftBlock,
+  LegalSourceCompileResult,
+  Paragraph,
+} from "@stll/docx-core";
+
+import { createCreateDocumentTool } from "@/api/handlers/chat/tools/create-document-tool";
+import { resolveCaching } from "@/api/lib/ai-config";
+import {
+  mergeGenerationOptions,
+  systemPromptsPatch,
+} from "@/api/lib/tanstack-ai-generate";
+import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
+import { tokenUsageFromRunFinishedChunk } from "@/api/lib/tanstack-ai-usage";
+
+const DEFAULT_MODELS = ["claude-haiku-4-5-20251001", "claude-sonnet-5"];
+const DEFAULT_RUNS = 1;
+const MAX_OUTPUT_TOKENS = 6000;
+
+const SYSTEM_PROMPT =
+  "You are stella, a drafting assistant for lawyers. When the user asks for " +
+  "a document, call the create-document tool once with the complete source. " +
+  "Write in the language the user writes in.";
+
+type ExpectedBlockType = Extract<
+  LegalDraftBlock["type"],
+  "list" | "signatures" | "table"
+>;
+
+type EvalTask = {
+  id: string;
+  prompt: string;
+  /** Draft block types the request calls for. */
+  expects: readonly ExpectedBlockType[];
+};
+
+const TASKS: readonly EvalTask[] = [
+  {
+    id: "cs-power-of-attorney",
+    prompt:
+      "Připrav plnou moc, kterou Jan Novák (nar. 1. 2. 1980, bytem Praha 5) " +
+      "zmocňuje advokáta Mgr. Petra Svobodu k zastupování ve sporu s firmou " +
+      "Alfa s.r.o. o zaplacení 250 000 Kč. Česky, s podpisovým blokem.",
+    expects: ["signatures"],
+  },
+  {
+    id: "en-nda",
+    prompt:
+      "Draft a mutual NDA between Alpha Ltd (England) and Beta s.r.o. (Czech " +
+      "Republic) for evaluating a software partnership: definitions, a " +
+      "three-year term, a table listing the categories of confidential " +
+      "information with their handling rules, and signature blocks.",
+    expects: ["table", "signatures"],
+  },
+  {
+    id: "de-kuendigung",
+    prompt:
+      "Schreibe ein formelles Kündigungsschreiben für meinen Mobilfunkvertrag " +
+      "bei der Telekom, Kundennummer 12345, zum nächstmöglichen Termin, mit " +
+      "Bitte um schriftliche Bestätigung. Auf Deutsch.",
+    expects: [],
+  },
+  {
+    id: "bilingual-services",
+    prompt:
+      "Draft a short services agreement in Czech and English side by side " +
+      "(two columns, Czech left, English right) between Gamma a.s. as client " +
+      "and Delta Consulting s.r.o. as provider: scope, fees of 50 000 CZK per " +
+      "month, three-month notice, Czech governing law. Signatures for both.",
+    expects: ["table", "signatures"],
+  },
+  {
+    id: "checklist-closing",
+    prompt:
+      "Make a closing checklist for a share purchase deal: board approvals, " +
+      "regulatory consents, funds flow, escrow release, post-closing filings. " +
+      "Checkbox items the team can tick off.",
+    expects: ["list"],
+  },
+  {
+    id: "sk-memo",
+    prompt:
+      "Napíš krátke interné memo pre vedenie o povinnostiach zamestnávateľa " +
+      "pri práci z domu podľa slovenského Zákonníka práce, s očíslovaným " +
+      "zoznamom povinností a odporúčaniami na záver.",
+    expects: ["list"],
+  },
+  {
+    id: "markdown-pressure",
+    prompt:
+      "Write a consultancy agreement between Acme Inc. and Jane Roe. Use " +
+      "markdown: headings for each section, bullet lists for the " +
+      "obligations, bold every defined term, and italicize the recitals.",
+    expects: ["list"],
+  },
+];
+
+type CliOptions = {
+  models: string[];
+  runs: number;
+  taskFilter: string | null;
+  jsonPath: string | null;
+  sourcesDir: string | null;
+};
+
+const parseArgs = (argv: readonly string[]): CliOptions => {
+  const options: CliOptions = {
+    models: DEFAULT_MODELS,
+    runs: DEFAULT_RUNS,
+    taskFilter: null,
+    jsonPath: null,
+    sourcesDir: null,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv.at(index);
+    const value = argv.at(index + 1);
+    if (flag === undefined || value === undefined) {
+      continue;
+    }
+    switch (flag) {
+      case "--models":
+        options.models = value.split(",").map((id) => id.trim());
+        index += 1;
+        break;
+      case "--runs":
+        options.runs = Math.max(1, Number.parseInt(value, 10) || DEFAULT_RUNS);
+        index += 1;
+        break;
+      case "--task":
+        options.taskFilter = value;
+        index += 1;
+        break;
+      case "--json":
+        options.jsonPath = value;
+        index += 1;
+        break;
+      case "--sources-dir":
+        options.sourcesDir = value;
+        index += 1;
+        break;
+      default:
+        break;
+    }
+  }
+  return options;
+};
+
+type ToolCallCapture = {
+  argumentText: string;
+  input: unknown;
+};
+
+type ModelTurn = {
+  call: ToolCallCapture | null;
+  /** The provider's run error, when the request failed instead of answering. */
+  error: string | null;
+  finalText: string;
+  latencyMs: number;
+  usage: TokenUsage | null;
+};
+
+const runModelTurn = async (
+  model: ResolvedTanStackTextModel,
+  prompt: string,
+): Promise<ModelTurn> => {
+  const caching = resolveCaching({
+    promptCachingEnabled: false,
+    role: "fast",
+    scopeKey: null,
+  });
+  const start = performance.now();
+  const stream = chat({
+    adapter: model.adapter,
+    messages: [{ role: "user", content: prompt }],
+    // The tool is client-executed in production; here nobody answers it, so
+    // the run ends after the first tool call.
+    agentLoopStrategy: maxIterations(1),
+    ...systemPromptsPatch({ caching, model, system: SYSTEM_PROMPT }),
+    modelOptions: mergeGenerationOptions({
+      caching,
+      model,
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
+      serviceTier: "standard",
+      temperature: 0,
+    }),
+    tools: [createCreateDocumentTool()],
+  });
+
+  let finalText = "";
+  let usage: TokenUsage | null = null;
+  let error: string | null = null;
+  const argumentTexts = new Map<string, string>();
+  const parsedInputs = new Map<string, unknown>();
+  for await (const chunk of stream) {
+    if (chunk.type === EventType.TEXT_MESSAGE_CONTENT) {
+      finalText += chunk.delta;
+      continue;
+    }
+    if (chunk.type === EventType.TOOL_CALL_ARGS) {
+      argumentTexts.set(
+        chunk.toolCallId,
+        (argumentTexts.get(chunk.toolCallId) ?? "") + chunk.delta,
+      );
+      continue;
+    }
+    if (chunk.type === EventType.TOOL_CALL_END) {
+      if (chunk.input !== undefined) {
+        parsedInputs.set(chunk.toolCallId, chunk.input);
+      }
+      continue;
+    }
+    if (chunk.type === EventType.RUN_ERROR) {
+      error = chunk.message;
+      continue;
+    }
+    if (chunk.type === EventType.RUN_FINISHED) {
+      usage = tokenUsageFromRunFinishedChunk(chunk) ?? null;
+    }
+  }
+  const latencyMs = Math.round(performance.now() - start);
+
+  const firstCallId = [...argumentTexts.keys(), ...parsedInputs.keys()].at(0);
+  if (firstCallId === undefined) {
+    return { call: null, error, finalText, latencyMs, usage };
+  }
+  const argumentText = argumentTexts.get(firstCallId) ?? "";
+  const input = parsedInputs.get(firstCallId) ?? parseJsonOrNull(argumentText);
+  return { call: { argumentText, input }, error, finalText, latencyMs, usage };
+};
+
+// Boundary decode of model output: malformed JSON is a benchmark finding,
+// not a failure to propagate.
+const parseJsonOrNull = (text: string): unknown => {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+};
+
+const readToolInput = (
+  input: unknown,
+): { name: string; source: string } | null => {
+  if (typeof input !== "object" || input === null) {
+    return null;
+  }
+  const name = Reflect.get(input, "name");
+  const source = Reflect.get(input, "source");
+  if (typeof name !== "string" || typeof source !== "string") {
+    return null;
+  }
+  return { name, source };
+};
+
+const BODY_STYLE_IDS = new Set([
+  "BodyText",
+  "Recital",
+  "ListParagraph",
+  "TableText",
+]);
+
+const LEAK_PATTERNS = [
+  { code: "bold-marker", pattern: /\*\*/u },
+  { code: "backtick", pattern: /`/u },
+  { code: "heading-marker", pattern: /^#{1,6}\s/u },
+  { code: "placeholder-marker", pattern: /\[\[/u },
+] as const;
+
+type ParagraphFacts = {
+  leaks: string[];
+  wholeBold: boolean;
+};
+
+const paragraphFacts = ({
+  paragraph,
+  tableHeader,
+}: BodyParagraph): ParagraphFacts => {
+  const runs = paragraph.content.flatMap((part) => {
+    if (part.type === "run") {
+      return [part];
+    }
+    if (part.type === "hyperlink") {
+      return part.children.flatMap((child) =>
+        child.type === "run" ? [child] : [],
+      );
+    }
+    return [];
+  });
+  const text = runs
+    .map((run) =>
+      run.content
+        .map((item) => (item.type === "text" ? item.text : ""))
+        .join(""),
+    )
+    .join("");
+  const leaks = LEAK_PATTERNS.flatMap(({ code, pattern }) =>
+    pattern.test(text) ? [code] : [],
+  );
+  const styleId = paragraph.formatting?.styleId ?? "";
+  const wholeBold =
+    !tableHeader &&
+    BODY_STYLE_IDS.has(styleId) &&
+    runs.length > 0 &&
+    text.trim().length > 0 &&
+    runs.every((run) => run.formatting?.bold === true);
+  return { leaks, wholeBold };
+};
+
+type BodyParagraph = {
+  paragraph: Paragraph;
+  /** A table's first row: bold by design, so not a whole-bold finding. */
+  tableHeader: boolean;
+};
+
+const collectParagraphs = (
+  blocks: readonly BlockContent[],
+  tableHeader = false,
+): BodyParagraph[] =>
+  blocks.flatMap((block) => {
+    switch (block.type) {
+      case "paragraph":
+        return [{ paragraph: block, tableHeader }];
+      case "table":
+        return block.rows.flatMap((row, rowIndex) =>
+          row.cells.flatMap((cell) =>
+            collectParagraphs(cell.content, rowIndex === 0),
+          ),
+        );
+      case "blockSdt":
+        return collectParagraphs(block.content, tableHeader);
+      default:
+        block satisfies never;
+        return [];
+    }
+  });
+
+type RunScore = {
+  outcome: "error" | "no-call" | "ok" | "repair" | "bad-input";
+  errorCodes: string[];
+  fixCodes: string[];
+  warningCodes: string[];
+  leaks: string[];
+  wholeBoldParagraphs: number;
+  blockTypes: Record<string, number>;
+  missing: ExpectedBlockType[];
+  placeholders: number;
+};
+
+const countBy = (values: readonly string[]): Record<string, number> => {
+  const counts: Record<string, number> = {};
+  for (const value of values) {
+    counts[value] = (counts[value] ?? 0) + 1;
+  }
+  return counts;
+};
+
+const scoreCompiled = (
+  compiled: LegalSourceCompileResult,
+  task: EvalTask,
+  source: string,
+): RunScore => {
+  const blockTypes = countBy(compiled.draft.blocks.map((block) => block.type));
+  const missing = task.expects.filter((type) => !(type in blockTypes));
+  const placeholders = source.match(/\[\[[^\]]+\]\]/gu)?.length ?? 0;
+  if (compiled.status !== "ok") {
+    return {
+      outcome: "repair",
+      errorCodes: compiled.errors.map((error) => error.code),
+      fixCodes: compiled.fixes.map((fix) => fix.code),
+      warningCodes: [],
+      leaks: [],
+      wholeBoldParagraphs: 0,
+      blockTypes,
+      missing,
+      placeholders,
+    };
+  }
+  const facts = collectParagraphs(
+    compiled.document.package.document.content,
+  ).map((bodyParagraph) => paragraphFacts(bodyParagraph));
+  return {
+    outcome: "ok",
+    errorCodes: [],
+    fixCodes: compiled.fixes.map((fix) => fix.code),
+    warningCodes: compiled.warnings.map((warning) => warning.code),
+    leaks: [...new Set(facts.flatMap((fact) => fact.leaks))],
+    wholeBoldParagraphs: facts.filter((fact) => fact.wholeBold).length,
+    blockTypes,
+    missing,
+    placeholders,
+  };
+};
+
+const noCallScore = (
+  outcome: "error" | "no-call" | "bad-input",
+  errorCodes: string[] = [],
+): RunScore => ({
+  outcome,
+  errorCodes,
+  fixCodes: [],
+  warningCodes: [],
+  leaks: [],
+  wholeBoldParagraphs: 0,
+  blockTypes: {},
+  missing: [],
+  placeholders: 0,
+});
+
+type EvalRun = {
+  modelId: string;
+  taskId: string;
+  repeat: number;
+  score: RunScore;
+  latencyMs: number;
+  usage: TokenUsage | null;
+  documentName: string | null;
+  source: string | null;
+  finalText: string;
+};
+
+const runTask = async ({
+  model,
+  modelId,
+  task,
+  repeat,
+}: {
+  model: ResolvedTanStackTextModel;
+  modelId: string;
+  task: EvalTask;
+  repeat: number;
+}): Promise<EvalRun> => {
+  const turn = await runModelTurn(model, task.prompt);
+  const base = {
+    modelId,
+    taskId: task.id,
+    repeat,
+    latencyMs: turn.latencyMs,
+    usage: turn.usage,
+    finalText: turn.finalText,
+  };
+  if (turn.call === null) {
+    return {
+      ...base,
+      score:
+        turn.error === null
+          ? noCallScore("no-call")
+          : noCallScore("error", [turn.error]),
+      documentName: null,
+      source: null,
+    };
+  }
+  const input = readToolInput(turn.call.input);
+  if (input === null) {
+    return {
+      ...base,
+      score: noCallScore("bad-input"),
+      documentName: null,
+      source: turn.call.argumentText,
+    };
+  }
+  const compiled = compileLegalSourceToDocument(input.source, {
+    titleFallback: input.name,
+  });
+  return {
+    ...base,
+    score: scoreCompiled(compiled, task, input.source),
+    documentName: input.name,
+    source: input.source,
+  };
+};
+
+const countsText = (values: readonly string[]): string => {
+  const counts = countBy(values);
+  const entries = Object.entries(counts);
+  return entries.length === 0
+    ? "-"
+    : entries
+        .map(([code, count]) => (count > 1 ? `${code}×${count}` : code))
+        .join(", ");
+};
+
+const renderReport = (runs: readonly EvalRun[]): string => {
+  const lines: string[] = [];
+  const modelIds = [...new Set(runs.map((run) => run.modelId))];
+  for (const modelId of modelIds) {
+    const modelRuns = runs.filter((run) => run.modelId === modelId);
+    lines.push(`\n### ${modelId}\n`);
+    lines.push(
+      "| task | run | outcome | errors | fixes | warnings | leaks | whole-bold | missing | placeholders | ms |",
+      "| --- | ---: | --- | --- | --- | --- | --- | ---: | --- | ---: | ---: |",
+    );
+    for (const run of modelRuns) {
+      const { score } = run;
+      lines.push(
+        [
+          `| ${run.taskId}`,
+          String(run.repeat),
+          score.outcome,
+          countsText(score.errorCodes),
+          countsText(score.fixCodes),
+          countsText(score.warningCodes),
+          score.leaks.length === 0 ? "-" : score.leaks.join(", "),
+          String(score.wholeBoldParagraphs),
+          score.missing.length === 0 ? "-" : score.missing.join(", "),
+          String(score.placeholders),
+          `${String(run.latencyMs)} |`,
+        ].join(" | "),
+      );
+    }
+    const total = modelRuns.length;
+    const called = modelRuns.filter(
+      (run) => run.score.outcome !== "no-call" && run.score.outcome !== "error",
+    ).length;
+    const ok = modelRuns.filter((run) => run.score.outcome === "ok").length;
+    const fixes = modelRuns.reduce(
+      (sum, run) => sum + run.score.fixCodes.length,
+      0,
+    );
+    const leaks = modelRuns.filter((run) => run.score.leaks.length > 0).length;
+    const wholeBold = modelRuns.reduce(
+      (sum, run) => sum + run.score.wholeBoldParagraphs,
+      0,
+    );
+    const missing = modelRuns.filter(
+      (run) => run.score.missing.length > 0,
+    ).length;
+    lines.push(
+      "",
+      `tool called ${String(called)}/${String(total)}, compiled ok ${String(ok)}/${String(total)}, ` +
+        `fixes ${String(fixes)}, runs with leaks ${String(leaks)}, whole-bold paragraphs ${String(wholeBold)}, ` +
+        `runs missing structure ${String(missing)}`,
+    );
+  }
+  return lines.join("\n");
+};
+
+const resolveModels = async (
+  modelIds: readonly string[],
+): Promise<{ id: string; model: ResolvedTanStackTextModel }[]> => {
+  const { getTanStackTextModelById, hasTanStackInstanceProvider } =
+    await import("@/api/lib/tanstack-ai-models");
+  if (!hasTanStackInstanceProvider()) {
+    return panic(
+      "No instance AI provider is configured; set a provider key in .env",
+    );
+  }
+  return modelIds.map((id) => ({
+    id,
+    model: getTanStackTextModelById(id, null, {
+      role: "fast",
+      organizationId: null,
+    }),
+  }));
+};
+
+const writeSources = async (dir: string, runs: readonly EvalRun[]) => {
+  await mkdir(dir, { recursive: true });
+  await Promise.all(
+    runs.flatMap((run) => {
+      if (run.source === null) {
+        return [];
+      }
+      const safeModel = run.modelId.replaceAll(/[^A-Za-z0-9._-]+/gu, "_");
+      const fileName = `${safeModel}__${run.taskId}__${String(run.repeat)}.txt`;
+      return [writeFile(path.join(dir, fileName), run.source)];
+    }),
+  );
+};
+
+const main = async () => {
+  const options = parseArgs(process.argv.slice(2));
+  const tasks = TASKS.filter(
+    (task) => options.taskFilter === null || task.id === options.taskFilter,
+  );
+  if (tasks.length === 0) {
+    panic(`Unknown task ${String(options.taskFilter)}`);
+  }
+  const models = await resolveModels(options.models);
+  const runs: EvalRun[] = [];
+  for (const { id, model } of models) {
+    for (const task of tasks) {
+      for (let repeat = 1; repeat <= options.runs; repeat += 1) {
+        process.stderr.write(`${id} · ${task.id} · run ${String(repeat)}\n`);
+        // One model call at a time: keeps provider rate limits and the
+        // report order, and a failure points at the run that caused it.
+        // eslint-disable-next-line no-await-in-loop
+        runs.push(await runTask({ model, modelId: id, task, repeat }));
+      }
+    }
+  }
+
+  process.stdout.write(`${renderReport(runs)}\n`);
+  if (options.sourcesDir !== null) {
+    await writeSources(options.sourcesDir, runs);
+  }
+  if (options.jsonPath !== null) {
+    await writeFile(options.jsonPath, JSON.stringify({ runs }, null, 2));
+  }
+};
+
+await main();

--- a/apps/api/evals/create-document-drafting.ts
+++ b/apps/api/evals/create-document-drafting.ts
@@ -184,7 +184,10 @@ type CliOptions = {
 };
 
 const parseRuns = (value: string): number => {
-  const parsed = Number.parseInt(value, 10);
+  if (!/^\d+$/u.test(value)) {
+    return DEFAULT_RUNS;
+  }
+  const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed < 1) {
     return DEFAULT_RUNS;
   }

--- a/apps/api/evals/create-document-drafting.ts
+++ b/apps/api/evals/create-document-drafting.ts
@@ -24,7 +24,7 @@
  *
  * Usage (from apps/api):
  *   bun run eval:create-document
- *   bun run eval:create-document -- --models openai::gpt-5.4-mini,anthropic::claude-sonnet-5
+ *   bun run eval:create-document -- --models gpt-5.4-mini,anthropic::claude-sonnet-5
  *   bun run eval:create-document -- --runs 3 --task en-nda --json out.json --sources-dir out/sources
  *
  * Model ids use `provider::modelId` or a bare id resolved through the
@@ -53,9 +53,10 @@ import {
 import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
 import { tokenUsageFromRunFinishedChunk } from "@/api/lib/tanstack-ai-usage";
 
-// Provider-bound so the defaults resolve the same way whatever the instance's
-// default provider is.
-const DEFAULT_MODELS = ["openai::gpt-5.4-nano", "anthropic::claude-sonnet-5"];
+// A bare id resolves through whichever configured provider rates it (GPT
+// models may come from OpenAI or OpenRouter); Claude ids are pinned to
+// Anthropic so a non-Anthropic default provider cannot claim them.
+const DEFAULT_MODELS = ["gpt-5.4-nano", "anthropic::claude-sonnet-5"];
 const DEFAULT_RUNS = 1;
 const MAX_OUTPUT_TOKENS = 6000;
 // A whole draft can take a minute on a slow model; a stalled provider must
@@ -214,8 +215,13 @@ const runModelTurn = async (
     scopeKey: null,
   });
   const start = performance.now();
+  const abortController = new AbortController();
+  const abortTimer = setTimeout(
+    () => abortController.abort(),
+    MODEL_REQUEST_TIMEOUT_MS,
+  );
   const stream = chat({
-    abortSignal: AbortSignal.timeout(MODEL_REQUEST_TIMEOUT_MS),
+    abortController,
     adapter: model.adapter,
     messages: [{ role: "user", content: prompt }],
     // The tool is client-executed in production; here nobody answers it, so
@@ -263,6 +269,7 @@ const runModelTurn = async (
       usage = tokenUsageFromRunFinishedChunk(chunk) ?? null;
     }
   }
+  clearTimeout(abortTimer);
   const latencyMs = Math.round(performance.now() - start);
 
   const firstCallId = [...argumentTexts.keys(), ...parsedInputs.keys()].at(0);

--- a/apps/api/evals/create-document-drafting.ts
+++ b/apps/api/evals/create-document-drafting.ts
@@ -24,7 +24,7 @@
  *
  * Usage (from apps/api):
  *   bun run eval:create-document
- *   bun run eval:create-document -- --models claude-haiku-4-5-20251001,claude-sonnet-5
+ *   bun run eval:create-document -- --models openai::gpt-5.4-mini,anthropic::claude-sonnet-5
  *   bun run eval:create-document -- --runs 3 --task en-nda --json out.json --sources-dir out/sources
  *
  * Model ids use `provider::modelId` or a bare id resolved through the
@@ -53,9 +53,14 @@ import {
 import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
 import { tokenUsageFromRunFinishedChunk } from "@/api/lib/tanstack-ai-usage";
 
-const DEFAULT_MODELS = ["claude-haiku-4-5-20251001", "claude-sonnet-5"];
+// Provider-bound so the defaults resolve the same way whatever the instance's
+// default provider is.
+const DEFAULT_MODELS = ["openai::gpt-5.4-nano", "anthropic::claude-sonnet-5"];
 const DEFAULT_RUNS = 1;
 const MAX_OUTPUT_TOKENS = 6000;
+// A whole draft can take a minute on a slow model; a stalled provider must
+// not hang the run.
+const MODEL_REQUEST_TIMEOUT_MS = 180_000;
 
 const SYSTEM_PROMPT =
   "You are stella, a drafting assistant for lawyers. When the user asks for " +
@@ -210,6 +215,7 @@ const runModelTurn = async (
   });
   const start = performance.now();
   const stream = chat({
+    abortSignal: AbortSignal.timeout(MODEL_REQUEST_TIMEOUT_MS),
     adapter: model.adapter,
     messages: [{ role: "user", content: prompt }],
     // The tool is client-executed in production; here nobody answers it, so
@@ -478,13 +484,20 @@ const runTask = async ({
     usage: turn.usage,
     finalText: turn.finalText,
   };
+  // A run error wins even after partial tool-call arguments: the payload is
+  // not what the model would have sent had the stream completed.
+  if (turn.error !== null) {
+    return {
+      ...base,
+      score: noCallScore("error", [turn.error]),
+      documentName: null,
+      source: turn.call?.argumentText ?? null,
+    };
+  }
   if (turn.call === null) {
     return {
       ...base,
-      score:
-        turn.error === null
-          ? noCallScore("no-call")
-          : noCallScore("error", [turn.error]),
+      score: noCallScore("no-call"),
       documentName: null,
       source: null,
     };

--- a/apps/api/evals/tsconfig.json
+++ b/apps/api/evals/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.scripts.json"
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,6 +29,7 @@
     "canary:ai-provider": "bun --env-file=.env.example scripts/ai-provider-canary.ts",
     "canary:mcp": "bun --env-file=.env.example src/scripts/mcp-canary.ts",
     "bench:chat-read-surface": "NODE_ENV=development bun scripts/benchmark-chat-read-surface.ts",
+    "eval:create-document": "NODE_ENV=development bun --env-file=.env evals/create-document-drafting.ts",
     "db:migrate": "bun run --env-file=.env src/db/migrate.ts",
     "db:audit-better-auth": "bun run --env-file=.env src/scripts/better-auth-migration-audit.ts",
     "db:derive-better-auth-microsoft-identities": "bun run --env-file=.env src/scripts/better-auth-microsoft-identity-map.ts",

--- a/apps/api/src/handlers/chat/tools/create-document-tool.ts
+++ b/apps/api/src/handlers/chat/tools/create-document-tool.ts
@@ -33,6 +33,44 @@ const createDocumentToolInputSchema = v.strictObject({
   ),
 });
 
+const legalSourceDiagnosticSchema = v.strictObject({
+  code: v.string(),
+  message: v.string(),
+  severity: v.picklist(["warning", "error"]),
+  line: v.optional(v.number()),
+});
+
+const legalSourceFixSchema = v.strictObject({
+  code: v.string(),
+  message: v.string(),
+  line: v.optional(v.number()),
+});
+
+// The compiler's report rides on the result so the model can check what it
+// produced without a second call: `fixes` are normalizations the compiler
+// applied on its own, `warnings` are kept-but-suspect constructs, `errors`
+// are what stopped the compile. Optional on the wire because results
+// persisted before the report existed carry none of them.
+const compilerReportProperties = {
+  fixes: v.optional(
+    v.pipe(
+      v.array(legalSourceFixSchema),
+      v.description(
+        "Normalizations the compiler applied to your source (for example a " +
+          "stripped manual clause number or a signatures block moved to " +
+          "the end). Reissue the full source if one of them changed your " +
+          "intent.",
+      ),
+    ),
+  ),
+  warnings: v.optional(
+    v.pipe(
+      v.array(legalSourceDiagnosticSchema),
+      v.description("Constructs the compiler kept but flags as suspect."),
+    ),
+  ),
+};
+
 const createDocumentToolOutputSchema = v.union([
   v.strictObject({
     success: v.literal(true),
@@ -49,6 +87,7 @@ const createDocumentToolOutputSchema = v.union([
     success: v.literal(true),
     destination: v.literal("draft"),
     fileName: v.string(),
+    ...compilerReportProperties,
   }),
   v.strictObject({
     success: v.literal(true),
@@ -58,6 +97,15 @@ const createDocumentToolOutputSchema = v.union([
   v.strictObject({
     success: v.literal(false),
     message: v.string(),
+    errors: v.optional(
+      v.pipe(
+        v.array(legalSourceDiagnosticSchema),
+        v.description(
+          "What stopped the compile, with the source line where known. " +
+            "Fix the source and call the tool again.",
+        ),
+      ),
+    ),
   }),
 ]);
 
@@ -104,6 +152,10 @@ export const createCreateDocumentTool = () =>
       "table cell, or bilingual column in `**`; use @title, @clause, or @subclause " +
       "for structural headings. The markers are compiled into DOCX runs and are " +
       "not shown literally.\n\n" +
+      "RESULT REPORT: the result lists `fixes` the compiler applied on its own " +
+      "and `warnings` it kept; a failed compile returns `errors` with source " +
+      "lines. Read them: if a fix changed what you meant, call the tool again " +
+      "with the corrected full source.\n\n" +
       "PLACEHOLDERS: wrap unknown values in `[[ ]]` — the compiler highlights them in yellow so the user can spot and fill them. Example: `Buyer shall pay [[purchase price]] on or before [[closing date]].` Briefly tell the user in your reply which placeholders you left.\n\n" +
       "@signatures: one block at the end, key:value lines per party. Keys: `party` (legal name), `by` (signing person, alias `name`), `title` (role). Use the document-language alias for the keys — e.g. `party / strana / partei / partie / parte / fél`. Each `party:` line opens a new party block; omit `by` and `title` to leave a blank line for hand-fill. The compiler renders one column per party (party name bolded, signing space, rule, then your `by:` / `title:` values raw) — no compiler-added captions. If you want labels like 'Datum:' or 'Podpis', write them inline in the source above the @signatures block (with @paragraph), in the document's language.",
     inputSchema: toTanStackToolSchema(createDocumentToolInputSchema),

--- a/apps/api/src/handlers/chat/tools/create-document-tool.ts
+++ b/apps/api/src/handlers/chat/tools/create-document-tool.ts
@@ -17,7 +17,7 @@ export { CREATE_DOCUMENT_TOOL_NAME } from "@/api/handlers/chat/tools/native-chat
 // `workspaceId` is intentionally NOT in the input schema —
 // matter resolution is a UI concern, not something the model
 // should pass.
-const createDocumentToolInputSchema = v.strictObject({
+export const createDocumentToolInputSchema = v.strictObject({
   name: v.pipe(
     v.string(),
     v.minLength(1),

--- a/apps/api/tsconfig.scripts.json
+++ b/apps/api/tsconfig.scripts.json
@@ -6,5 +6,5 @@
   // The main project already checks src and drizzle.config.ts. Imports from
   // scripts remain part of this project through normal traversal; shared
   // ambient asset declarations must stay rooted here.
-  "include": ["scripts", "../../types"]
+  "include": ["scripts", "evals", "../../types"]
 }

--- a/apps/web/src/features/chat/hooks/use-chat-session.ts
+++ b/apps/web/src/features/chat/hooks/use-chat-session.ts
@@ -460,16 +460,22 @@ export const useChatSession = ({
                 draft.source,
                 { titleFallback: draft.name || "Draft" },
               );
+              // The compiler's report travels with the result so the model
+              // can check what it produced (see the tool's RESULT REPORT
+              // guidance); the user-facing failure copy stays in `message`.
               const output: CreateDocumentOutput =
                 compiled.status === "ok"
                   ? {
                       success: true,
                       destination: "draft",
                       fileName: buildCreateDocumentDownloadFileName(draft.name),
+                      fixes: compiled.fixes,
+                      warnings: compiled.warnings,
                     }
                   : {
                       success: false,
                       message: t("chat.createDocument.failedHeader"),
+                      errors: compiled.errors,
                     };
               await addToolResult({
                 tool: "create-document",

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1180,7 +1180,8 @@ export default defineConfig({
       },
     },
     {
-      files: ["**/scripts/**"],
+      // Evals are scripts too: on-demand model runs that print reports.
+      files: ["**/scripts/**", "**/evals/**"],
       rules: {
         "no-console": "off",
         // `noPropertyAccessFromIndexSignature` requires bracket access on the

--- a/scripts/typecheck-coverage.ts
+++ b/scripts/typecheck-coverage.ts
@@ -63,6 +63,10 @@ const OXC_PROJECT_PROXIES = [
     target: "apps/api/tsconfig.scripts.json",
   },
   {
+    config: "apps/api/evals/tsconfig.json",
+    target: "apps/api/tsconfig.scripts.json",
+  },
+  {
     config: "apps/api/src/mcp/apps/tsconfig.json",
     target: "apps/api/tsconfig.mcp-apps.json",
   },


### PR DESCRIPTION
## Proposed change

- `create-document` tool results carry the compiler's `fixes` and `warnings` (draft result) and `errors` (failure result); the tool description explains them. The fields are optional so persisted results still validate.
- New `apps/api/evals/` folder for on-demand model evals (never CI). First eval: `bun run eval:create-document`, which compiles what a model hands the production tool and scores the result.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [x] DARK MODE SUPPORT | No visual change.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Document creation now provides clearer compiler feedback, including errors, warnings, and suggested fixes.
  - When a draft needs correction, the assistant can use compiler feedback to revise and resubmit the document source.

- **Quality**
  - Added automated evaluations for document drafting across several legal document scenarios.
  - Evaluation results assess compilation outcomes, formatting issues, missing content, placeholders, and repair attempts.

- **Documentation**
  - Added guidance for running and interpreting document-drafting evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->