### PR TITLE
fix(api): probe every catalog model id in the AI provider canary

### DIFF
--- a/.github/workflows/ai-provider-canary.yml
+++ b/.github/workflows/ai-provider-canary.yml
@@ -40,7 +40,7 @@ jobs:
     # A weekly run can spend 650 seconds on first attempts. One bounded retry
     # per transient failure can double that budget; leave room for backoff,
     # runner setup, and dependency installation.
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
     strategy:

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -15,6 +15,7 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   CanaryCredentialRejectedError,
   CanaryProviderRunError,
+  CATALOG_SWEEP_BUDGET_MS,
   catalogModelIds,
   classifyCanaryFailure,
   createPdfCanaryMessages,
@@ -27,6 +28,7 @@ import {
   requireWeeklyToolExecution,
   runCanaryProbe,
   runCanaryProbeSequence,
+  runCatalogCanaryProbes,
   toolRoundTripInputSchema,
   toolRoundTripInputSchemaForProvider,
   toolRoundTripPromptForProvider,
@@ -34,7 +36,7 @@ import {
 import { CANARY_PROVIDERS } from "./ai-provider-canary-config";
 
 describe("AI provider catalog canary coverage", () => {
-  test("probes every selectable model id of a provider exactly once", () => {
+  test("declares every selectable model id of a provider exactly once", () => {
     for (const provider of CANARY_PROVIDERS) {
       const ids = catalogModelIds(provider);
       expect(new Set(ids).size).toBe(ids.length);
@@ -45,6 +47,48 @@ describe("AI provider catalog canary coverage", () => {
         expect(ids).toContain(modelId);
       }
     }
+  });
+
+  test("the sweep probes exactly the declared ids, each once", async () => {
+    for (const provider of CANARY_PROVIDERS) {
+      const probed: string[] = [];
+      // oxlint-disable-next-line no-await-in-loop -- providers run one at a time so the recorded order stays deterministic.
+      const failures = await runCatalogCanaryProbes(
+        {
+          apiKey: "test-key",
+          provider,
+          probeModel: async ({ modelId, provider: probedProvider }) => {
+            expect(probedProvider).toBe(provider);
+            probed.push(modelId);
+          },
+        },
+        0,
+      );
+      expect(failures).toBe(0);
+      expect(probed).toEqual(catalogModelIds(provider));
+    }
+  });
+
+  test("ids left when the sweep budget runs out fail instead of going unprobed", async () => {
+    const provider = CANARY_PROVIDERS[0];
+    const ids = catalogModelIds(provider);
+    const probed: string[] = [];
+    let clock = 0;
+    const failures = await runCatalogCanaryProbes(
+      {
+        apiKey: "test-key",
+        provider,
+        now: () => clock,
+        probeModel: async ({ modelId }) => {
+          probed.push(modelId);
+          // The first probe consumes the whole budget.
+          clock += CATALOG_SWEEP_BUDGET_MS;
+        },
+      },
+      0,
+    );
+    expect(probed).toEqual(ids.slice(0, 1));
+    expect(failures).toBe(ids.length - 1);
   });
 });
 

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -48,6 +48,28 @@ describe("AI provider catalog canary coverage", () => {
   });
 });
 
+describe("AI provider canary overload backoff", () => {
+  test("waits longer before each further attempt and gives an overloaded provider three tries", async () => {
+    const waits: number[] = [];
+    let attempts = 0;
+    const result = await runCanaryProbe({
+      retryDelayMs: 5000,
+      run: async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new ProviderStatusError(503);
+        }
+      },
+      timeoutMs: 1000,
+      wait: async (delayMs) => {
+        waits.push(delayMs);
+      },
+    });
+    expect(result).toEqual({ attempts: 3, status: "passed" });
+    expect(waits).toEqual([5000, 20_000]);
+  });
+});
+
 describe("AI provider PDF canary contract", () => {
   test("sends a real inline PDF rather than a text-only pdf-role probe", () => {
     const message = createPdfCanaryMessages().at(0);
@@ -304,8 +326,8 @@ describe("AI provider canary retry contract", () => {
       })),
     ).toEqual(
       statuses.map(({ retryable, status }) => ({
-        attempts: retryable ? 2 : 1,
-        calls: retryable ? 2 : 1,
+        attempts: retryable ? 3 : 1,
+        calls: retryable ? 3 : 1,
         retryable,
         status,
       })),

--- a/apps/api/scripts/ai-provider-canary.test.ts
+++ b/apps/api/scripts/ai-provider-canary.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from "bun:test";
 import * as v from "valibot";
 
 import {
+  BYOK_MODEL_OPTIONS,
   CHAT_PDF_ATTACHMENT_MODEL_OPTIONS,
   DEFAULT_MODELS,
   isBYOKProviderRoleSupported,
+  MODEL_ROLES,
 } from "@stll/ai-catalog";
 
 import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-schema";
@@ -13,6 +15,7 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   CanaryCredentialRejectedError,
   CanaryProviderRunError,
+  catalogModelIds,
   classifyCanaryFailure,
   createPdfCanaryMessages,
   CREDENTIAL_REJECTION_SIGNATURES,
@@ -29,6 +32,21 @@ import {
   toolRoundTripPromptForProvider,
 } from "./ai-provider-canary";
 import { CANARY_PROVIDERS } from "./ai-provider-canary-config";
+
+describe("AI provider catalog canary coverage", () => {
+  test("probes every selectable model id of a provider exactly once", () => {
+    for (const provider of CANARY_PROVIDERS) {
+      const ids = catalogModelIds(provider);
+      expect(new Set(ids).size).toBe(ids.length);
+      for (const role of MODEL_ROLES) {
+        expect(ids).toContain(DEFAULT_MODELS[provider][role]);
+      }
+      for (const modelId of BYOK_MODEL_OPTIONS[provider]) {
+        expect(ids).toContain(modelId);
+      }
+    }
+  });
+});
 
 describe("AI provider PDF canary contract", () => {
   test("sends a real inline PDF rather than a text-only pdf-role probe", () => {

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -49,8 +49,12 @@ const TOOL_CALL_ROLE = "chat" satisfies ModelRole;
 const CAPABILITY_PROBE_TIMEOUT_MS = 20_000;
 const MODEL_ROLE_PROBE_TIMEOUT_MS = 30_000;
 const TOOL_ROUND_TRIP_PROBE_TIMEOUT_MS = 45_000;
-const CANARY_PROBE_MAX_ATTEMPTS = 2;
+// A provider's overload response ("high demand", 503) or a slow first
+// answer must not read as a capability regression: three attempts, with the
+// wait growing from 5s to 20s so a short capacity spike has time to pass.
+const CANARY_PROBE_MAX_ATTEMPTS = 3;
 const CANARY_PROBE_RETRY_DELAY_MS = 5000;
+const CANARY_PROBE_RETRY_BACKOFF = 4;
 const PROVIDER_ERROR_MESSAGE_MAX_LENGTH = 16_384;
 const MILLISECONDS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
 const SYNTHETIC_PROMPT = "Reply with exactly OK.";
@@ -720,7 +724,7 @@ export const runCanaryProbe = async ({
         return { attempts: attempt, error, signal, status: "failed" };
       }
       // oxlint-disable-next-line no-await-in-loop -- bounded backoff separates sequential provider attempts.
-      await wait(retryDelayMs);
+      await wait(retryDelayMs * CANARY_PROBE_RETRY_BACKOFF ** (attempt - 1));
     }
   }
 

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -1695,7 +1695,11 @@ const runCatalogModelProbe = async ({
   provider,
   signal,
 }: RunCatalogModelProbeOptions): Promise<void> => {
-  const config = createCanaryConfig({ apiKey, provider, rotatedModelId: modelId });
+  const config = createCanaryConfig({
+    apiKey,
+    provider,
+    rotatedModelId: modelId,
+  });
   const model = resolveTanStackTextModel({
     organizationId: null,
     orgAIConfig: config,

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -5,6 +5,7 @@ import { isDeepStrictEqual } from "node:util";
 import * as v from "valibot";
 
 import {
+  BYOK_MODEL_OPTIONS,
   CHAT_PDF_ATTACHMENT_MODEL_OPTIONS,
   DEFAULT_MODELS,
   isBYOKModelRoleSupported,
@@ -1344,6 +1345,27 @@ const modelSelections = (provider: CanaryProvider, rotatedModelId?: string) => {
   };
 };
 
+/**
+ * Every model id the catalog can put in front of a user for a provider: the
+ * default of each role plus the whole BYOK list, in catalog order, once
+ * each. The catalog probe below exercises all of them on every run, so a
+ * model a provider retires is caught the next night rather than whenever the
+ * weekly rotation happens to reach it.
+ */
+export const catalogModelIds = (provider: CanaryProvider): string[] => {
+  const ids = new Set<string>();
+  for (const role of MODEL_ROLES) {
+    ids.add(DEFAULT_MODELS[provider][role]);
+  }
+  for (const modelId of BYOK_MODEL_OPTIONS[provider]) {
+    ids.add(modelId);
+  }
+  return [...ids];
+};
+
+// The cheapest role: a short reply, no reasoning budget, no attachment.
+const CATALOG_PROBE_ROLE = "fast" satisfies ModelRole;
+
 type CreateCanaryConfigOptions = {
   apiKey: string;
   provider: CanaryProvider;
@@ -1589,6 +1611,7 @@ const run = async (): Promise<void> => {
     probeRuns: canaryProbeRuns(context),
     provider,
   });
+  failures = await runCatalogCanaryProbes({ apiKey, provider }, failures);
 
   if (args.tier === "weekly") {
     const rotation = weeklyCanaryRotation({
@@ -1651,6 +1674,75 @@ const canaryProbeRuns = (context: CanaryContext): CanaryProbeRun[] => {
     });
   }
   return probeRuns;
+};
+
+type RunCatalogModelProbeOptions = {
+  apiKey: string;
+  modelId: string;
+  provider: CanaryProvider;
+  signal: AbortSignal;
+};
+
+// One minimal generation through the same resolution path the app uses, so
+// the probe fails exactly when a user selecting this id would.
+const runCatalogModelProbe = async ({
+  apiKey,
+  modelId,
+  provider,
+  signal,
+}: RunCatalogModelProbeOptions): Promise<void> => {
+  const config = createCanaryConfig({ apiKey, provider, rotatedModelId: modelId });
+  const model = resolveTanStackTextModel({
+    organizationId: null,
+    orgAIConfig: config,
+    role: CATALOG_PROBE_ROLE,
+  });
+  if (model.provider !== provider || model.modelId !== modelId) {
+    throw new TypeError("Canary resolved an unexpected catalog model.");
+  }
+
+  const output = await generateTanStackTextForRole({
+    abortSignal: signal,
+    caching: NO_CACHING,
+    maxOutputTokens: modelRoleMaxOutputTokens({
+      modelId,
+      role: CATALOG_PROBE_ROLE,
+    }),
+    prompt: SYNTHETIC_PROMPT,
+    organizationId: null,
+    orgAIConfig: config,
+    role: CATALOG_PROBE_ROLE,
+    serviceTier: "standard",
+    tenantWorkspaceIds: NO_TENANT_SCOPE,
+  });
+  requireNonEmptyText(output);
+};
+
+type RunCatalogCanaryProbesOptions = {
+  apiKey: string;
+  provider: CanaryProvider;
+};
+
+const runCatalogCanaryProbes = async (
+  { apiKey, provider }: RunCatalogCanaryProbesOptions,
+  failures: number,
+): Promise<number> => {
+  let totalFailures = failures;
+  for (const modelId of catalogModelIds(provider)) {
+    // oxlint-disable-next-line no-await-in-loop -- catalog probes share the provider quota and must remain sequential.
+    const result = await runCanaryProbe({
+      run: async (signal) => {
+        await runCatalogModelProbe({ apiKey, modelId, provider, signal });
+      },
+      timeoutMs: MODEL_ROLE_PROBE_TIMEOUT_MS,
+    });
+    totalFailures += recordProbeResult({
+      label: `catalog:${modelId}`,
+      provider,
+      result,
+    });
+  }
+  return totalFailures;
 };
 
 const runWeeklyCanaryProbes = async (

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -1,6 +1,6 @@
 import { chat, EventType, maxIterations, toolDefinition } from "@tanstack/ai";
 import type { AnyClientTool, AnyServerTool, ModelMessage } from "@tanstack/ai";
-import { panic, Result } from "better-result";
+import { panic, Result, TaggedError } from "better-result";
 import { isDeepStrictEqual } from "node:util";
 import * as v from "valibot";
 
@@ -1369,6 +1369,11 @@ export const catalogModelIds = (provider: CanaryProvider): string[] => {
 
 // The cheapest role: a short reply, no reasoning budget, no attachment.
 const CATALOG_PROBE_ROLE = "fast" satisfies ModelRole;
+// The catalog sweep is sequential (one provider quota) and each id may retry
+// with backoff, so the whole sweep gets one aggregate budget: ids left when
+// it runs out are reported as failures rather than silently unprobed, and the
+// job stays inside the workflow timeout on a degraded provider.
+export const CATALOG_SWEEP_BUDGET_MS = 10 * 60 * 1000;
 
 type CreateCanaryConfigOptions = {
   apiKey: string;
@@ -1729,26 +1734,56 @@ const runCatalogModelProbe = async ({
 type RunCatalogCanaryProbesOptions = {
   apiKey: string;
   provider: CanaryProvider;
+  /** Seam for tests: the per-model probe. */
+  probeModel?: (options: RunCatalogModelProbeOptions) => Promise<void>;
+  /** Seam for tests: the sweep clock. */
+  now?: () => number;
+  runProbe?: (options: RunCanaryProbeOptions) => Promise<CanaryProbeResult>;
 };
 
-const runCatalogCanaryProbes = async (
-  { apiKey, provider }: RunCatalogCanaryProbesOptions,
+export class CanaryCatalogSweepBudgetError extends TaggedError(
+  "CanaryCatalogSweepBudgetError",
+)<{ message: string; modelId: string }> {}
+
+export const runCatalogCanaryProbes = async (
+  {
+    apiKey,
+    provider,
+    probeModel = runCatalogModelProbe,
+    now = () => Date.now(),
+    runProbe = runCanaryProbe,
+  }: RunCatalogCanaryProbesOptions,
   failures: number,
 ): Promise<number> => {
   let totalFailures = failures;
+  const deadline = now() + CATALOG_SWEEP_BUDGET_MS;
   for (const modelId of catalogModelIds(provider)) {
+    const label = `catalog:${modelId}`;
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0) {
+      totalFailures += recordProbeResult({
+        label,
+        provider,
+        result: {
+          attempts: 0,
+          error: new CanaryCatalogSweepBudgetError({
+            message: "catalog sweep budget exhausted before this id was probed",
+            modelId,
+          }),
+          signal: new AbortController().signal,
+          status: "failed",
+        },
+      });
+      continue;
+    }
     // oxlint-disable-next-line no-await-in-loop -- catalog probes share the provider quota and must remain sequential.
-    const result = await runCanaryProbe({
+    const result = await runProbe({
       run: async (signal) => {
-        await runCatalogModelProbe({ apiKey, modelId, provider, signal });
+        await probeModel({ apiKey, modelId, provider, signal });
       },
-      timeoutMs: MODEL_ROLE_PROBE_TIMEOUT_MS,
+      timeoutMs: Math.min(MODEL_ROLE_PROBE_TIMEOUT_MS, remainingMs),
     });
-    totalFailures += recordProbeResult({
-      label: `catalog:${modelId}`,
-      provider,
-      result,
-    });
+    totalFailures += recordProbeResult({ label, provider, result });
   }
   return totalFailures;
 };


### PR DESCRIPTION
## Proposed change

The AI provider canary now probes every catalog model id for the provider on every run (defaults for each role plus the BYOK list), with one minimal generation each through the app's resolution path. Before, non-default ids were only reached by the weekly one-model rotation.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [x] DARK MODE SUPPORT | Not applicable.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)
