### PR TITLE
feat(mcp): snake_case tool inputs at every depth

### DIFF
--- a/.changeset/mcp-snake-case-nested-inputs.md
+++ b/.changeset/mcp-snake-case-nested-inputs.md
@@ -1,0 +1,5 @@
+---
+"@stll/cli": minor
+---
+
+Every tool input is snake_case at every depth. `clause save` body paragraphs take `list_kind`, `list_level`, `is_directive`, `directive_kind`, `directive_expression`; `template save` field overlays take `input_type`, `options_from`, `ai_prompt`, `ai_adapt`, `ai_sees_document`, `date_format`, `parts[].input_type` and `validation.min_length`/`max_length`/`min_items`/`max_items`; `organization set-jurisdictions` takes `country_code` and `is_primary`. The former camelCase spellings are rejected.

--- a/.changeset/mcp-snake-case-nested-inputs.md
+++ b/.changeset/mcp-snake-case-nested-inputs.md
@@ -2,4 +2,4 @@
 "@stll/cli": minor
 ---
 
-Every tool input is snake_case at every depth. `clause save` body paragraphs take `list_kind`, `list_level`, `is_directive`, `directive_kind`, `directive_expression`; `template save` field overlays take `input_type`, `options_from`, `ai_prompt`, `ai_adapt`, `ai_sees_document`, `date_format`, `parts[].input_type` and `validation.min_length`/`max_length`/`min_items`/`max_items`; `organization set-jurisdictions` takes `country_code` and `is_primary`. The former camelCase spellings are rejected.
+Every tool input is snake_case at every depth. `clause save` body paragraphs take `list_kind`, `list_level`, `is_directive`, `directive_kind`, `directive_expression`; `template save` field overlays take `input_type`, `options_from`, `ai_prompt`, `ai_adapt`, `ai_sees_document`, `date_format`, `parts[].input_type` and `validation.min_length`/`max_length`/`min_items`/`max_items`; `organization set-jurisdictions` takes `country_code` and `is_primary`. The former camelCase spellings are rejected. `date-time` inputs admit a leap second only as `23:59:60`.

--- a/apps/api/src/lib/docx/types.ts
+++ b/apps/api/src/lib/docx/types.ts
@@ -349,32 +349,37 @@ export const fieldDateFormatSchema = v.pipe(
   v.description("Date rendering config"),
 );
 
+/** Shared with the snake_case MCP mirror in `mcp/template-field-input.ts`, so
+ *  both surfaces advertise the same line. */
+export const FIELD_VALIDATION_DESCRIPTION = "Field-level value constraints";
+export const FIELD_PARTS_DESCRIPTION = "Composite field parts";
+
+export const fieldValidationObjectSchema = v.strictObject({
+  required: v.optional(v.pipe(v.boolean(), v.description("Value is required"))),
+  minLength: v.optional(
+    v.pipe(v.number(), v.finite(), v.description("Minimum string length")),
+  ),
+  maxLength: v.optional(
+    v.pipe(v.number(), v.finite(), v.description("Maximum string length")),
+  ),
+  min: v.optional(
+    v.pipe(v.number(), v.finite(), v.description("Minimum numeric value")),
+  ),
+  max: v.optional(
+    v.pipe(v.number(), v.finite(), v.description("Maximum numeric value")),
+  ),
+  pattern: v.optional(describedString("Regex for the whole value")),
+  minItems: v.optional(
+    v.pipe(v.number(), v.finite(), v.description("Minimum repeated items")),
+  ),
+  maxItems: v.optional(
+    v.pipe(v.number(), v.finite(), v.description("Maximum repeated items")),
+  ),
+});
+
 export const fieldValidationSchema = v.pipe(
-  v.strictObject({
-    required: v.optional(
-      v.pipe(v.boolean(), v.description("Value is required")),
-    ),
-    minLength: v.optional(
-      v.pipe(v.number(), v.finite(), v.description("Minimum string length")),
-    ),
-    maxLength: v.optional(
-      v.pipe(v.number(), v.finite(), v.description("Maximum string length")),
-    ),
-    min: v.optional(
-      v.pipe(v.number(), v.finite(), v.description("Minimum numeric value")),
-    ),
-    max: v.optional(
-      v.pipe(v.number(), v.finite(), v.description("Maximum numeric value")),
-    ),
-    pattern: v.optional(describedString("Regex for the whole value")),
-    minItems: v.optional(
-      v.pipe(v.number(), v.finite(), v.description("Minimum repeated items")),
-    ),
-    maxItems: v.optional(
-      v.pipe(v.number(), v.finite(), v.description("Maximum repeated items")),
-    ),
-  }),
-  v.description("Field-level value constraints"),
+  fieldValidationObjectSchema,
+  v.description(FIELD_VALIDATION_DESCRIPTION),
 );
 
 type DerivedSourceMode =
@@ -386,6 +391,8 @@ type DerivedSourceMode =
   | "parts"
   | "source";
 
+/** `lookup`, `parts` and `source` are only presence-checked, so the parts shape
+ *  stays open: the snake_case MCP mirror passes its own part objects. */
 type DerivedSourceFields = {
   aiAdapt?: boolean | undefined;
   aiPrompt?: string | undefined;
@@ -393,7 +400,7 @@ type DerivedSourceFields = {
   conditionAst?: ConditionNode | undefined;
   formula?: string | undefined;
   lookup?: FieldLookup | undefined;
-  parts?: FieldPart[] | undefined;
+  parts?: readonly unknown[] | undefined;
   source?: FieldSource | undefined;
 };
 
@@ -432,8 +439,9 @@ const activeDerivedSourceModes = ({
   return modes;
 };
 
-const hasCompatibleDerivedSources = (fields: DerivedSourceFields): boolean =>
-  activeDerivedSourceModes(fields).length <= 1;
+export const hasCompatibleDerivedSources = (
+  fields: DerivedSourceFields,
+): boolean => activeDerivedSourceModes(fields).length <= 1;
 
 const FIELD_SOURCE_DESCRIPTION = "Who fills = matter or contact data";
 
@@ -470,7 +478,7 @@ const fieldMetaObjectSchema = v.strictObject({
     v.pipe(
       v.array(fieldPartSchema),
       v.minLength(1),
-      v.description("Composite field parts"),
+      v.description(FIELD_PARTS_DESCRIPTION),
     ),
   ),
   format: v.optional(describedString("Join template over the part keys")),
@@ -492,12 +500,12 @@ const fieldMetaObjectSchema = v.strictObject({
   dateFormat: v.optional(fieldDateFormatSchema),
 });
 
-const hasCompleteCompositeField = ({
+export const hasCompleteCompositeField = ({
   format,
   parts,
 }: {
   format?: string | undefined;
-  parts?: FieldPart[] | undefined;
+  parts?: readonly unknown[] | undefined;
 }): boolean => (parts === undefined) === (format === undefined);
 
 export const fieldMetaSchema = v.pipe(
@@ -517,7 +525,7 @@ export const fieldMetaSchema = v.pipe(
 /** Model-facing subset: conditionAst is the persisted canonical form, not an
  * authoring input. This schema derives its public fields from the persisted
  * object schema and applies the same named invariant predicates. */
-const fieldMetaToolInputObjectSchema = v.strictObject({
+export const fieldMetaToolInputObjectSchema = v.strictObject({
   ...v.omit(fieldMetaObjectSchema, ["conditionAst"]).entries,
   source: v.optional(
     v.pipe(fieldSourceToolInputSchema, v.description(FIELD_SOURCE_DESCRIPTION)),

--- a/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
+++ b/apps/api/src/mcp/__snapshots__/registry-quality.test.ts.snap
@@ -311,7 +311,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "set_practice_jurisdictions",
     "scope": "stella:onboarding",
     "access": "write",
-    "description": "Set the practice jurisdictions for the user's stella organization. Call this when the org's practice jurisdictions are empty (e.g., the user signed up via an OAuth client and skipped onboarding). Pass an array of {countryCode, isPrimary}; exactly one entry should be primary.",
+    "description": "Set the practice jurisdictions for the user's stella organization. Call this when the org's practice jurisdictions are empty (e.g., the user signed up via an OAuth client and skipped onboarding). Pass an array of {country_code, is_primary}; exactly one entry should be primary.",
     "annotations": {
       "title": "Set practice jurisdictions",
       "idempotentHint": false,
@@ -329,7 +329,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
           "items": {
             "type": "object",
             "properties": {
-              "countryCode": {
+              "country_code": {
                 "enum": [
                   "AD",
                   "AE",
@@ -585,20 +585,20 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                 "type": "string",
                 "description": "ISO 3166-1 alpha-2 country code"
               },
-              "isPrimary": {
+              "is_primary": {
                 "type": "boolean",
                 "description": "Whether this is the organization's primary jurisdiction"
               }
             },
             "required": [
-              "countryCode",
-              "isPrimary"
+              "country_code",
+              "is_primary"
             ],
             "additionalProperties": false
           },
           "minItems": 1,
           "maxItems": 12,
-          "description": "Practice jurisdictions for this organization. countryCode is an ISO 3166-1 alpha-2 code; exactly one entry should set isPrimary to true."
+          "description": "Practice jurisdictions for this organization. country_code is an ISO 3166-1 alpha-2 code; exactly one entry should set is_primary to true."
         }
       }
     }
@@ -607,7 +607,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "list_templates",
     "scope": "stella:templates",
     "access": "read",
-    "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration, in the shape save_template's fields overlay takes (see stella://reference/template-fields), plus its named conditions and formula fields. Omitted optional scalar placeholders render blank.",
+    "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration, in the shape the field reference documents (see stella://reference/template-fields), plus its named conditions and formula fields. Omitted optional scalar placeholders render blank.",
     "annotations": {
       "title": "List templates",
       "readOnlyHint": true,
@@ -787,7 +787,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                 "type": "string",
                 "description": "Fill hint for the person filling"
               },
-              "inputType": {
+              "input_type": {
                 "enum": [
                   "text",
                   "number",
@@ -812,11 +812,11 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                     "type": "boolean",
                     "description": "Value is required"
                   },
-                  "minLength": {
+                  "min_length": {
                     "type": "number",
                     "description": "Minimum string length"
                   },
-                  "maxLength": {
+                  "max_length": {
                     "type": "number",
                     "description": "Maximum string length"
                   },
@@ -832,11 +832,11 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                     "type": "string",
                     "description": "Regex for the whole value"
                   },
-                  "minItems": {
+                  "min_items": {
                     "type": "number",
                     "description": "Minimum repeated items"
                   },
-                  "maxItems": {
+                  "max_items": {
                     "type": "number",
                     "description": "Maximum repeated items"
                   }
@@ -849,15 +849,15 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                 "type": "boolean",
                 "description": "Value is required"
               },
-              "aiPrompt": {
+              "ai_prompt": {
                 "type": "string",
                 "description": "Who fills = AI: drafting instruction"
               },
-              "aiAdapt": {
+              "ai_adapt": {
                 "type": "boolean",
                 "description": "Who fills = person + AI"
               },
-              "aiSeesDocument": {
+              "ai_sees_document": {
                 "type": "boolean",
                 "description": "AI field also sees the document"
               },
@@ -874,7 +874,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                       "type": "string",
                       "description": "Part label"
                     },
-                    "inputType": {
+                    "input_type": {
                       "enum": [
                         "text",
                         "select"
@@ -896,7 +896,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                   },
                   "required": [
                     "key",
-                    "inputType"
+                    "input_type"
                   ],
                   "additionalProperties": false
                 },
@@ -907,7 +907,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                 "type": "string",
                 "description": "Join template over the part keys"
               },
-              "optionsFrom": {
+              "options_from": {
                 "type": "string",
                 "description": "Dependent select: source field path"
               },
@@ -1145,7 +1145,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                 "type": "string",
                 "description": "Boolean rule for an {{#if}} marker"
               },
-              "dateFormat": {
+              "date_format": {
                 "type": "object",
                 "properties": {
                   "locale": {
@@ -2250,7 +2250,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
     "name": "save_clause",
     "scope": "stella:knowledge_write",
     "access": "write",
-    "description": "Create or update a clause in the organization's clause library. Omit clause_id to create (title and body required); pass clause_id to update. body is an ordered array of paragraphs, each with text and optional formatting. category_id, language, description, usage_notes, and metadata accept null to clear them on update. Set snapshot_version true on an update to also append a version snapshot of the body. Returns the clause id.",
+    "description": "Create or update a clause in the organization's clause library. Omit clause_id to create (title and body required); pass clause_id to update. body is an ordered array of paragraphs, each with text and optional style, level, runs, list_kind, list_level, is_directive, directive_kind, and directive_expression. category_id, language, description, usage_notes, and metadata accept null to clear them on update. Set snapshot_version true on an update to also append a version snapshot of the body. Returns the clause id.",
     "annotations": {
       "title": "Save clause",
       "idempotentHint": false,
@@ -2314,7 +2314,7 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                 },
                 "description": "Optional inline formatting runs whose text concatenates to the paragraph"
               },
-              "listKind": {
+              "list_kind": {
                 "enum": [
                   "bullet",
                   "ordered"
@@ -2322,15 +2322,15 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                 "type": "string",
                 "description": "List item kind when the paragraph is a list item"
               },
-              "listLevel": {
+              "list_level": {
                 "type": "integer",
                 "description": "0-based list nesting depth for a list item"
               },
-              "isDirective": {
+              "is_directive": {
                 "type": "boolean",
                 "description": "Whether the paragraph is a template directive marker"
               },
-              "directiveKind": {
+              "directive_kind": {
                 "enum": [
                   "if",
                   "elseif",
@@ -2340,9 +2340,9 @@ exports[`MCP registry quality (default surface) tool surface snapshot (name, sco
                   "endeach"
                 ],
                 "type": "string",
-                "description": "Directive kind when isDirective is set"
+                "description": "Directive kind when is_directive is set"
               },
-              "directiveExpression": {
+              "directive_expression": {
                 "type": "string",
                 "description": "Directive expression for an if/each directive"
               }
@@ -3537,7 +3537,7 @@ exports[`MCP registry quality (anonymized surface) tool surface snapshot (name, 
     "name": "list_templates",
     "scope": "stella:templates_anonymized",
     "access": "read",
-    "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration, in the shape save_template's fields overlay takes (see stella://reference/template-fields), plus its named conditions and formula fields. Omitted optional scalar placeholders render blank.",
+    "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration, in the shape the field reference documents (see stella://reference/template-fields), plus its named conditions and formula fields. Omitted optional scalar placeholders render blank.",
     "annotations": {
       "title": "List templates",
       "readOnlyHint": true,

--- a/apps/api/src/mcp/knowledge-tools.test.ts
+++ b/apps/api/src/mcp/knowledge-tools.test.ts
@@ -83,6 +83,35 @@ const createPlaybookScopedDb = (playbook: unknown) =>
     ),
   );
 
+/**
+ * A scopedDb standing in for the clause-create write path, capturing every
+ * body `createClauseHandler` hands the insert so the persisted shape can be
+ * asserted against the snake_case MCP input.
+ */
+const createClauseWriteScopedDb = () => {
+  const insertedBodies: unknown[] = [];
+  const scopedDb = asTestRaw<
+    McpRequestContext["scopedDb"] & ReturnType<typeof mock>
+  >(
+    mock(async (run: (tx: unknown) => unknown) => {
+      const tx = {
+        $count: async () => 0,
+        insert: () => ({
+          values: (row: { body?: unknown }) => {
+            if (row.body !== undefined) {
+              insertedBodies.push(row.body);
+            }
+            return { returning: async () => [{ id: "c1" }] };
+          },
+        }),
+        update: () => ({ set: () => ({ where: async () => undefined }) }),
+      };
+      return await run(tx);
+    }),
+  );
+  return { insertedBodies, scopedDb };
+};
+
 /** A scopedDb whose clauses.findFirst resolves to `clause` (detail mode). */
 const createClauseDetailScopedDb = (clause: unknown) =>
   asTestRaw<McpRequestContext["scopedDb"] & ReturnType<typeof mock>>(
@@ -230,6 +259,66 @@ describe("MCP knowledge tools", () => {
     });
     // The malformed body must never reach the payload, anonymized or not.
     expect(JSON.stringify(response)).not.toContain("SECRET_UNREDACTED_MARKER");
+  });
+
+  test("save_clause refuses a camelCase body paragraph key", async () => {
+    const result = await handleMcpToolCall({
+      args: {
+        title: "Indemnity",
+        body: [{ text: "The Supplier shall indemnify.", listKind: "bullet" }],
+      },
+      context: createContext(),
+      toolName: "save_clause",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseToolPayload(result)).toMatchObject({
+      error: {
+        code: "validation_error",
+        issues: expect.arrayContaining([
+          expect.objectContaining({ path: "body.0.listKind" }),
+        ]),
+      },
+    });
+  });
+
+  test("save_clause maps snake_case paragraph keys onto the persisted body", async () => {
+    const { insertedBodies, scopedDb } = createClauseWriteScopedDb();
+
+    const result = await handleMcpToolCall({
+      args: {
+        title: "Indemnity",
+        body: [
+          {
+            text: "The Supplier shall indemnify.",
+            runs: [{ text: "The Supplier shall indemnify.", bold: true }],
+            list_kind: "bullet",
+            list_level: 1,
+            is_directive: true,
+            directive_kind: "if",
+            directive_expression: "party.isSupplier",
+          },
+        ],
+      },
+      context: createContext({ scopedDb }),
+      toolName: "save_clause",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(insertedBodies).not.toBeEmpty();
+    for (const body of insertedBodies) {
+      expect(body).toEqual([
+        {
+          text: "The Supplier shall indemnify.",
+          runs: [{ text: "The Supplier shall indemnify.", bold: true }],
+          listKind: "bullet",
+          listLevel: 1,
+          isDirective: true,
+          directiveKind: "if",
+          directiveExpression: "party.isSupplier",
+        },
+      ]);
+    }
   });
 
   test("save_clause rejects an update that changes nothing", async () => {

--- a/apps/api/src/mcp/knowledge-tools.ts
+++ b/apps/api/src/mcp/knowledge-tools.ts
@@ -33,6 +33,7 @@ import type {
 import {
   CLAUSE_LIST_KINDS,
   type ClauseBody,
+  type ClauseParagraph,
   type ClauseRun,
   isClauseBody,
 } from "@/api/lib/clauses/types";
@@ -938,37 +939,76 @@ const clauseParagraphArgSchema = v.strictObject({
       ),
     ),
   ),
-  listKind: v.optional(
+  list_kind: v.optional(
     v.pipe(
       v.picklist(CLAUSE_LIST_KINDS),
       v.description("List item kind when the paragraph is a list item"),
     ),
   ),
-  listLevel: v.optional(
+  list_level: v.optional(
     v.pipe(
       v.number(),
       v.integer(),
       v.description("0-based list nesting depth for a list item"),
     ),
   ),
-  isDirective: v.optional(
+  is_directive: v.optional(
     v.pipe(
       v.boolean(),
       v.description("Whether the paragraph is a template directive marker"),
     ),
   ),
-  directiveKind: v.optional(
+  directive_kind: v.optional(
     v.pipe(
       v.picklist(BLOCK_DIRECTIVE_KINDS),
-      v.description("Directive kind when isDirective is set"),
+      v.description("Directive kind when is_directive is set"),
     ),
   ),
-  directiveExpression: v.optional(
+  directive_expression: v.optional(
     v.pipe(
       v.string(),
       v.description("Directive expression for an if/each directive"),
     ),
   ),
+});
+
+const toClauseRun = (
+  run: v.InferOutput<typeof clauseRunArgSchema>,
+): ClauseRun => ({
+  text: run.text,
+  ...(run.bold === undefined ? {} : { bold: run.bold }),
+  ...(run.italic === undefined ? {} : { italic: run.italic }),
+});
+
+/**
+ * The MCP surface is snake_case; the persisted `ClauseParagraph` is camelCase.
+ * Every target key is listed explicitly so a new schema key cannot reach the
+ * persisted shape without a decision here.
+ */
+const toClauseParagraph = (
+  paragraph: v.InferOutput<typeof clauseParagraphArgSchema>,
+): ClauseParagraph => ({
+  text: paragraph.text,
+  ...(paragraph.style === undefined ? {} : { style: paragraph.style }),
+  ...(paragraph.level === undefined ? {} : { level: paragraph.level }),
+  ...(paragraph.runs === undefined
+    ? {}
+    : { runs: paragraph.runs.map(toClauseRun) }),
+  ...(paragraph.list_kind === undefined
+    ? {}
+    : { listKind: paragraph.list_kind }),
+  ...(paragraph.list_level === undefined
+    ? {}
+    : { listLevel: paragraph.list_level }),
+  ...(paragraph.is_directive === undefined
+    ? {}
+    : { isDirective: paragraph.is_directive }),
+  ...(paragraph.directive_kind === undefined
+    ? {}
+    : { directiveKind: paragraph.directive_kind }),
+  ...(paragraph.directive_expression === undefined
+    ? {}
+    : { directiveExpression: paragraph.directive_expression }),
 });
 
 const clauseBodyArgSchema = v.pipe(
@@ -1103,21 +1143,7 @@ const handleSaveClauseTool: TypedMcpToolHandler<
   }
   const input = parsed.output;
 
-  // The clause body is validated structurally with isClauseBody so it narrows
-  // to the ClauseBody the backing handlers expect without an unchecked cast.
-  let clauseBody: ClauseBody | undefined;
-  if (input.body !== undefined) {
-    if (!isClauseBody(input.body)) {
-      return structuredErrorResult({
-        code: "validation_error",
-        message: "Invalid input: body must be a non-empty paragraph array",
-        issues: [
-          { path: "body", message: "Expected a non-empty paragraph array" },
-        ],
-      });
-    }
-    clauseBody = input.body;
-  }
+  const clauseBody = input.body?.map(toClauseParagraph);
 
   const organizationId = context.organizationId;
 
@@ -1127,9 +1153,8 @@ const handleSaveClauseTool: TypedMcpToolHandler<
       return errorResult("Forbidden");
     }
     // The schema guarantees title and body are present on create. Bind title
-    // in the narrowed scope (mirroring clauseBody above): inside the closure
-    // below TypeScript would otherwise widen input.title back to
-    // string | undefined.
+    // in the narrowed scope: inside the closure below TypeScript would
+    // otherwise widen input.title back to string | undefined.
     const { title } = input;
     if (title === undefined) {
       return structuredErrorResult({
@@ -1571,7 +1596,9 @@ export const KNOWLEDGE_TOOL_DEFINITIONS = [
       "Create or update a clause in the organization's clause library. Omit " +
       "clause_id to create (title and body required); pass clause_id to update. " +
       "body is an ordered array of paragraphs, each with text and optional " +
-      "formatting. category_id, language, description, usage_notes, and metadata " +
+      "style, level, runs, list_kind, list_level, is_directive, directive_kind, " +
+      "and directive_expression. " +
+      "category_id, language, description, usage_notes, and metadata " +
       "accept null to clear them on update. Set snapshot_version true on an " +
       "update to also append a version snapshot of the body. Returns the clause id.",
     inputSchema: saveClauseArgsSchema,

--- a/apps/api/src/mcp/onboarding.test.ts
+++ b/apps/api/src/mcp/onboarding.test.ts
@@ -197,8 +197,8 @@ describe("set_practice_jurisdictions MCP tool", () => {
     const result = await handleMcpToolCall({
       args: {
         jurisdictions: [
-          { countryCode: "CZ", isPrimary: true },
-          { countryCode: "SK", isPrimary: false },
+          { country_code: "CZ", is_primary: true },
+          { country_code: "SK", is_primary: false },
         ],
       },
       context,
@@ -247,7 +247,7 @@ describe("set_practice_jurisdictions MCP tool", () => {
 
     const result = await handleMcpToolCall({
       args: {
-        jurisdictions: [{ countryCode: "CZ", isPrimary: true }],
+        jurisdictions: [{ country_code: "CZ", is_primary: true }],
       },
       context,
       toolName: "set_practice_jurisdictions",
@@ -269,8 +269,8 @@ describe("set_practice_jurisdictions MCP tool", () => {
     const result = await handleMcpToolCall({
       args: {
         jurisdictions: [
-          { countryCode: "CZ", isPrimary: false },
-          { countryCode: "SK", isPrimary: false },
+          { country_code: "CZ", is_primary: false },
+          { country_code: "SK", is_primary: false },
         ],
       },
       context,
@@ -291,8 +291,8 @@ describe("set_practice_jurisdictions MCP tool", () => {
     const result = await handleMcpToolCall({
       args: {
         jurisdictions: [
-          { countryCode: "CZ", isPrimary: true },
-          { countryCode: "SK", isPrimary: true },
+          { country_code: "CZ", is_primary: true },
+          { country_code: "SK", is_primary: true },
         ],
       },
       context,
@@ -312,13 +312,32 @@ describe("set_practice_jurisdictions MCP tool", () => {
 
     const result = await handleMcpToolCall({
       args: {
-        jurisdictions: [{ countryCode: "ZZZ", isPrimary: true }],
+        jurisdictions: [{ country_code: "ZZZ", is_primary: true }],
       },
       context,
       toolName: "set_practice_jurisdictions",
     });
 
     expect(result.isError).toBe(true);
+  });
+
+  test("rejects camelCase jurisdiction keys", async () => {
+    const context = createContext();
+
+    const result = await handleMcpToolCall({
+      args: {
+        jurisdictions: [{ countryCode: "CZ", isPrimary: true }],
+      },
+      context,
+      toolName: "set_practice_jurisdictions",
+    });
+
+    expect(result.isError).toBe(true);
+    const item = result.content.at(0);
+    expect(item?.type).toBe("text");
+    if (item?.type === "text") {
+      expect(item.text).toContain("jurisdictions.0.country_code");
+    }
   });
 
   test("rejects empty jurisdictions input", async () => {

--- a/apps/api/src/mcp/registry-quality.test.ts
+++ b/apps/api/src/mcp/registry-quality.test.ts
@@ -370,36 +370,16 @@ describe("MCP registry annotation coherence", () => {
  * Advertised input property names. The anonymized surface is a projection of
  * the same definitions, so checking the default surface covers both.
  *
- * The nested paths below are the remaining camelCase debt: object and array
- * payloads that mirror internal document/field models (`knowledge-tools.ts`,
- * `stella-tools.ts`, `template-tools.ts`). The set is exact, so a new
- * camelCase name fails here and fixing one of these requires shrinking the
- * constant. Every TOP-LEVEL name (the surface an agent types) must already be
- * snake_case: none is listed, so any drift there fails immediately.
+ * The set is exact and empty: every advertised name, at every depth, must be
+ * snake_case. Payloads that mirror internal camelCase models (`save_clause`
+ * body paragraphs, `save_template` field overlays) carry their own snake_case
+ * input schema and map onto the model at the tool boundary, so a new
+ * camelCase name anywhere in an input fails here.
  */
-const CAMEL_CASE_INPUT_PROPERTY_DEBT = [
-  "save_clause.body[].directiveExpression",
-  "save_clause.body[].directiveKind",
-  "save_clause.body[].isDirective",
-  "save_clause.body[].listKind",
-  "save_clause.body[].listLevel",
-  "save_template.fields[].aiAdapt",
-  "save_template.fields[].aiPrompt",
-  "save_template.fields[].aiSeesDocument",
-  "save_template.fields[].dateFormat",
-  "save_template.fields[].inputType",
-  "save_template.fields[].optionsFrom",
-  "save_template.fields[].parts[].inputType",
-  "save_template.fields[].validation.maxItems",
-  "save_template.fields[].validation.maxLength",
-  "save_template.fields[].validation.minItems",
-  "save_template.fields[].validation.minLength",
-  "set_practice_jurisdictions.jurisdictions[].countryCode",
-  "set_practice_jurisdictions.jurisdictions[].isPrimary",
-];
+const CAMEL_CASE_INPUT_PROPERTY_DEBT: string[] = [];
 
 describe("MCP registry input naming", () => {
-  test("input property names are snake_case, bar the recorded debt", () => {
+  test("input property names are snake_case at every depth", () => {
     const issues: string[] = [];
     for (const tool of defaultTools) {
       collectNonSnakeCaseProperties(tool.inputSchema, tool.name, issues);

--- a/apps/api/src/mcp/resources.test.ts
+++ b/apps/api/src/mcp/resources.test.ts
@@ -56,7 +56,7 @@ describe("MCP resources", () => {
     // the field, the dependent-select rule, the lookup format addressing, and
     // the binding kinds with their allowed keys.
     expect(content.text).toContain("Who fills = AI");
-    expect(content.text).toContain("`optionsFrom`");
+    expect(content.text).toContain("`options_from`");
     expect(content.text).toContain("{{path.key}}");
     expect(content.text).toContain('`kind: "party"`');
     expect(content.text).toContain("dataBox");

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -660,11 +660,11 @@ const readContactArgsSchema = v.strictObject({
 });
 
 const practiceJurisdictionInputSchema = v.strictObject({
-  countryCode: v.pipe(
+  country_code: v.pipe(
     v.picklist(COUNTRY_CODES),
     v.description("ISO 3166-1 alpha-2 country code"),
   ),
-  isPrimary: v.pipe(
+  is_primary: v.pipe(
     v.boolean(),
     v.description("Whether this is the organization's primary jurisdiction"),
   ),
@@ -676,11 +676,24 @@ const setPracticeJurisdictionsArgsSchema = v.strictObject({
     v.minLength(1),
     v.maxLength(LIMITS.practiceJurisdictionsPerOrganization),
     v.description(
-      "Practice jurisdictions for this organization. countryCode is an " +
-        "ISO 3166-1 alpha-2 code; exactly one entry should set isPrimary " +
+      "Practice jurisdictions for this organization. country_code is an " +
+        "ISO 3166-1 alpha-2 code; exactly one entry should set is_primary " +
         "to true.",
     ),
   ),
+});
+
+// MCP tool inputs are snake_case; the persisted jurisdiction shape is
+// camelCase.
+type PracticeJurisdictionHandlerInput = Parameters<
+  typeof normalizePracticeJurisdictions
+>[0][number];
+
+const toPracticeJurisdiction = (
+  jurisdiction: v.InferOutput<typeof practiceJurisdictionInputSchema>,
+): PracticeJurisdictionHandlerInput => ({
+  countryCode: jurisdiction.country_code,
+  isPrimary: jurisdiction.is_primary,
 });
 
 export const STELLA_TOOL_DEFINITIONS = [
@@ -813,7 +826,8 @@ export const STELLA_TOOL_DEFINITIONS = [
       "Set the practice jurisdictions for the user's stella organization. " +
       "Call this when the org's practice jurisdictions are empty (e.g., the " +
       "user signed up via an OAuth client and skipped onboarding). Pass an " +
-      "array of {countryCode, isPrimary}; exactly one entry should be primary.",
+      "array of {country_code, is_primary}; exactly one entry should be " +
+      "primary.",
     inputSchema: setPracticeJurisdictionsArgsSchema,
     // Not idempotent: the handler records a fresh audit event and bumps
     // updatedAt on every call even when the jurisdictions are unchanged, so a
@@ -846,7 +860,7 @@ const loadPracticeJurisdictions = async (
 const buildOnboardingHintText = () =>
   `Your stella organization has not configured its practice jurisdictions ` +
   `yet. Call \`set_practice_jurisdictions\` (input: array of ` +
-  `\`{ countryCode, isPrimary }\`) to enable jurisdiction-aware tools, or ` +
+  `\`{ country_code, is_primary }\`) to enable jurisdiction-aware tools, or ` +
   `have the user complete onboarding at ${getAppBaseUrl()}.`;
 
 const withOnboardingHintIfApplicable = async <TData>({
@@ -1949,14 +1963,14 @@ const handleSetPracticeJurisdictionsTool: TypedMcpToolHandler<
   }
 
   const primaryCount = parsed.output.jurisdictions.filter(
-    (jurisdiction) => jurisdiction.isPrimary,
+    (jurisdiction) => jurisdiction.is_primary,
   ).length;
   if (primaryCount > 1) {
     return errorResult("Only one jurisdiction can be primary");
   }
 
   const practiceJurisdictions = normalizePracticeJurisdictions(
-    parsed.output.jurisdictions,
+    parsed.output.jurisdictions.map(toPracticeJurisdiction),
   );
 
   await context.scopedDb(async (tx) => {

--- a/apps/api/src/mcp/template-field-input.test.ts
+++ b/apps/api/src/mcp/template-field-input.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import * as v from "valibot";
+
+import { fieldMetaToolInputSchema } from "@/api/lib/docx/types";
+import { fieldSourceToolInputSchema } from "@/api/lib/template-binding/binding-sources";
+import {
+  templateFieldInputSchema,
+  toFieldMetaToolInput,
+} from "@/api/mcp/template-field-input";
+
+const sortedKeys = (entries: object): string[] => Object.keys(entries).sort();
+
+const camelize = (key: string): string =>
+  key.replace(/_(.)/gu, (_match: string, letter: string) =>
+    letter.toUpperCase(),
+  );
+
+const sortedCamelKeys = (entries: object): string[] =>
+  Object.keys(entries).map(camelize).sort();
+
+const advertised = templateFieldInputSchema.pipe[0].entries;
+const persisted = fieldMetaToolInputSchema.pipe[0].entries;
+
+describe("template field input schema", () => {
+  test("advertises the persisted tool-input keys in snake_case", () => {
+    expect(sortedCamelKeys(advertised)).toEqual(sortedKeys(persisted));
+  });
+
+  test("advertises the persisted validation keys in snake_case", () => {
+    expect(
+      sortedCamelKeys(advertised.validation.wrapped.pipe[0].entries),
+    ).toEqual(sortedKeys(persisted.validation.wrapped.pipe[0].entries));
+  });
+
+  test("advertises the persisted part keys in snake_case", () => {
+    expect(
+      sortedCamelKeys(advertised.parts.wrapped.pipe[0].item.entries),
+    ).toEqual(sortedKeys(persisted.parts.wrapped.pipe[0].item.entries));
+  });
+
+  test("maps every advertised key onto its persisted spelling", () => {
+    const mapped = toFieldMetaToolInput({
+      path: "company",
+      label: "Company",
+      hint: "Enter the registry number",
+      input_type: "select",
+      options: ["director", "proxy"],
+      validation: {
+        required: true,
+        min_length: 1,
+        max_length: 64,
+        min: 0,
+        max: 12,
+        pattern: "^.+$",
+        min_items: 1,
+        max_items: 3,
+      },
+      required: true,
+      ai_prompt: "Draft the scope",
+      ai_adapt: true,
+      ai_sees_document: true,
+      parts: [
+        {
+          key: "title",
+          label: "Title",
+          input_type: "select",
+          options: ["Mr", "Ms"],
+          pattern: "^.+$",
+        },
+      ],
+      format: "{{title}} {{name}}",
+      options_from: "parties",
+      lookup: {
+        registry: "krs",
+        formats: [{ key: "default", template: "[name]" }],
+      },
+      // Parsed rather than written inline: the advertised source union is a
+      // provider-portable `anyOf`, so a bare literal has no discriminant to
+      // narrow against.
+      source: v.parse(fieldSourceToolInputSchema, {
+        kind: "contact",
+        field: "displayName",
+      }),
+      formula: "rent * 12",
+      condition: "type == 'corp'",
+      date_format: { locale: "cs", style: "long" },
+    });
+
+    expect(sortedKeys(mapped)).toEqual(sortedKeys(persisted));
+    expect(sortedKeys(mapped.validation ?? {})).toEqual(
+      sortedKeys(persisted.validation.wrapped.pipe[0].entries),
+    );
+    expect(sortedKeys(mapped.parts?.at(0) ?? {})).toEqual(
+      sortedKeys(persisted.parts.wrapped.pipe[0].item.entries),
+    );
+  });
+
+  test("omits absent optional keys instead of writing undefined", () => {
+    expect(toFieldMetaToolInput({ path: "company" })).toEqual({
+      path: "company",
+    });
+  });
+
+  test("round-trips a parsed field into the persisted tool input", () => {
+    const parsed = v.parse(templateFieldInputSchema, {
+      path: "company",
+      label: "Company",
+      input_type: "select",
+      options_from: "parties",
+      ai_sees_document: false,
+      validation: { required: true, min_length: 2, max_items: 4 },
+      parts: [{ key: "title", input_type: "text" }],
+      format: "{{title}}",
+      date_format: { locale: "cs", style: "long" },
+    });
+
+    const mapped = toFieldMetaToolInput(parsed);
+
+    expect(v.parse(fieldMetaToolInputSchema, mapped)).toEqual({
+      path: "company",
+      label: "Company",
+      inputType: "select",
+      optionsFrom: "parties",
+      aiSeesDocument: false,
+      validation: { required: true, minLength: 2, maxItems: 4 },
+      parts: [{ key: "title", inputType: "text" }],
+      format: "{{title}}",
+      dateFormat: { locale: "cs", style: "long" },
+    });
+  });
+
+  test("rejects the persisted camelCase spellings", () => {
+    const result = v.safeParse(templateFieldInputSchema, {
+      path: "company",
+      inputType: "text",
+    });
+
+    expect(result.success).toBe(false);
+    expect(
+      result.issues?.some((issue) => issue.path?.at(0)?.key === "inputType"),
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/mcp/template-field-input.ts
+++ b/apps/api/src/mcp/template-field-input.ts
@@ -1,0 +1,177 @@
+/**
+ * Snake_case MCP surface for `save_template`'s `fields` overlay. Advertised
+ * tool inputs are snake_case, while the persisted field model is camelCase and
+ * shared with the rest of the API and web, so the two cannot be the same
+ * schema. Leaf validators, picklists and descriptions are reused from the
+ * persisted schemas; only the key spelling differs.
+ */
+
+import * as v from "valibot";
+
+import type {
+  FieldPart,
+  FieldValidation,
+  fieldMetaToolInputSchema,
+} from "@/api/lib/docx/types";
+import {
+  FIELD_PARTS_DESCRIPTION,
+  FIELD_VALIDATION_DESCRIPTION,
+  fieldMetaToolInputObjectSchema,
+  fieldPartSchema,
+  fieldValidationObjectSchema,
+  hasCompatibleDerivedSources,
+  hasCompleteCompositeField,
+} from "@/api/lib/docx/types";
+
+const { entries: fieldEntries } = fieldMetaToolInputObjectSchema;
+const { entries: partEntries } = fieldPartSchema;
+const { entries: validationEntries } = fieldValidationObjectSchema;
+
+const templateFieldValidationInputSchema = v.pipe(
+  v.strictObject({
+    required: validationEntries.required,
+    min_length: validationEntries.minLength,
+    max_length: validationEntries.maxLength,
+    min: validationEntries.min,
+    max: validationEntries.max,
+    pattern: validationEntries.pattern,
+    min_items: validationEntries.minItems,
+    max_items: validationEntries.maxItems,
+  }),
+  v.description(FIELD_VALIDATION_DESCRIPTION),
+);
+
+const templateFieldPartInputSchema = v.strictObject({
+  key: partEntries.key,
+  label: partEntries.label,
+  input_type: partEntries.inputType,
+  options: partEntries.options,
+  pattern: partEntries.pattern,
+});
+
+const templateFieldInputObjectSchema = v.strictObject({
+  path: fieldEntries.path,
+  label: fieldEntries.label,
+  hint: fieldEntries.hint,
+  input_type: fieldEntries.inputType,
+  options: fieldEntries.options,
+  validation: v.optional(templateFieldValidationInputSchema),
+  required: fieldEntries.required,
+  ai_prompt: fieldEntries.aiPrompt,
+  ai_adapt: fieldEntries.aiAdapt,
+  ai_sees_document: fieldEntries.aiSeesDocument,
+  parts: v.optional(
+    v.pipe(
+      v.array(templateFieldPartInputSchema),
+      v.minLength(1),
+      v.description(FIELD_PARTS_DESCRIPTION),
+    ),
+  ),
+  format: fieldEntries.format,
+  options_from: fieldEntries.optionsFrom,
+  lookup: fieldEntries.lookup,
+  source: fieldEntries.source,
+  formula: fieldEntries.formula,
+  condition: fieldEntries.condition,
+  date_format: fieldEntries.dateFormat,
+});
+
+export const templateFieldInputSchema = v.pipe(
+  templateFieldInputObjectSchema,
+  v.check(
+    (field: v.InferOutput<typeof templateFieldInputObjectSchema>) =>
+      hasCompleteCompositeField(field),
+    "parts and format must be provided together",
+  ),
+  v.check(
+    ({
+      ai_adapt,
+      ai_prompt,
+      condition,
+      formula,
+      lookup,
+      parts,
+      source,
+    }: v.InferOutput<typeof templateFieldInputObjectSchema>) =>
+      hasCompatibleDerivedSources({
+        aiAdapt: ai_adapt,
+        aiPrompt: ai_prompt,
+        condition,
+        formula,
+        lookup,
+        parts,
+        source,
+      }),
+    "Derived field sources are mutually exclusive",
+  ),
+);
+
+type TemplateFieldInput = v.InferOutput<typeof templateFieldInputSchema>;
+type TemplateFieldPartInput = v.InferOutput<
+  typeof templateFieldPartInputSchema
+>;
+type TemplateFieldValidationInput = v.InferOutput<
+  typeof templateFieldValidationInputSchema
+>;
+
+const toFieldPart = (part: TemplateFieldPartInput): FieldPart => ({
+  key: part.key,
+  ...(part.label === undefined ? {} : { label: part.label }),
+  inputType: part.input_type,
+  ...(part.options === undefined ? {} : { options: part.options }),
+  ...(part.pattern === undefined ? {} : { pattern: part.pattern }),
+});
+
+const toFieldValidation = (
+  validation: TemplateFieldValidationInput,
+): FieldValidation => ({
+  ...(validation.required === undefined
+    ? {}
+    : { required: validation.required }),
+  ...(validation.min_length === undefined
+    ? {}
+    : { minLength: validation.min_length }),
+  ...(validation.max_length === undefined
+    ? {}
+    : { maxLength: validation.max_length }),
+  ...(validation.min === undefined ? {} : { min: validation.min }),
+  ...(validation.max === undefined ? {} : { max: validation.max }),
+  ...(validation.pattern === undefined ? {} : { pattern: validation.pattern }),
+  ...(validation.min_items === undefined
+    ? {}
+    : { minItems: validation.min_items }),
+  ...(validation.max_items === undefined
+    ? {}
+    : { maxItems: validation.max_items }),
+});
+
+/** The declared return type is the drift guard: a key added to the persisted
+ *  tool input has no snake_case source here until it is mapped. */
+export const toFieldMetaToolInput = (
+  field: TemplateFieldInput,
+): v.InferOutput<typeof fieldMetaToolInputSchema> => ({
+  path: field.path,
+  ...(field.label === undefined ? {} : { label: field.label }),
+  ...(field.hint === undefined ? {} : { hint: field.hint }),
+  ...(field.input_type === undefined ? {} : { inputType: field.input_type }),
+  ...(field.options === undefined ? {} : { options: field.options }),
+  ...(field.validation === undefined
+    ? {}
+    : { validation: toFieldValidation(field.validation) }),
+  ...(field.required === undefined ? {} : { required: field.required }),
+  ...(field.ai_prompt === undefined ? {} : { aiPrompt: field.ai_prompt }),
+  ...(field.ai_adapt === undefined ? {} : { aiAdapt: field.ai_adapt }),
+  ...(field.ai_sees_document === undefined
+    ? {}
+    : { aiSeesDocument: field.ai_sees_document }),
+  ...(field.parts === undefined ? {} : { parts: field.parts.map(toFieldPart) }),
+  ...(field.format === undefined ? {} : { format: field.format }),
+  ...(field.options_from === undefined
+    ? {}
+    : { optionsFrom: field.options_from }),
+  ...(field.lookup === undefined ? {} : { lookup: field.lookup }),
+  ...(field.source === undefined ? {} : { source: field.source }),
+  ...(field.formula === undefined ? {} : { formula: field.formula }),
+  ...(field.condition === undefined ? {} : { condition: field.condition }),
+  ...(field.date_format === undefined ? {} : { dateFormat: field.date_format }),
+});

--- a/apps/api/src/mcp/template-field-reference.ts
+++ b/apps/api/src/mcp/template-field-reference.ts
@@ -1,6 +1,5 @@
 import type * as v from "valibot";
 
-import type { fieldMetaToolInputSchema } from "@/api/lib/docx/types";
 import {
   DATE_FORMAT_STYLES,
   INPUT_TYPES,
@@ -18,6 +17,7 @@ import {
   USER_FIELDS,
   WORKSPACE_CONTACT_ROLES,
 } from "@/api/lib/template-binding/binding-sources";
+import type { templateFieldInputSchema } from "@/api/mcp/template-field-input";
 import { TEMPLATE_MARKER_REFERENCE_URI } from "@/api/mcp/template-marker-reference";
 
 /**
@@ -27,7 +27,7 @@ import { TEMPLATE_MARKER_REFERENCE_URI } from "@/api/mcp/template-marker-referen
  * carries the structure plus one short line per property.
  *
  * Both inventories below are keyed by their source of truth
- * ({@link fieldMetaToolInputSchema}'s own keys, {@link BindingSourceKind}), so
+ * ({@link templateFieldInputSchema}'s own keys, {@link BindingSourceKind}), so
  * a new field property or binding kind is a compile error here until it is
  * documented. Value lists (input types, registries, contact fields) render
  * from the same constants the schema validates against, never a hand-copied
@@ -42,27 +42,27 @@ import { TEMPLATE_MARKER_REFERENCE_URI } from "@/api/mcp/template-marker-referen
 export const TEMPLATE_FIELD_REFERENCE_URI =
   "stella://reference/template-fields";
 
-type FieldConfigProperty = keyof v.InferInput<typeof fieldMetaToolInputSchema>;
+type FieldConfigProperty = keyof v.InferInput<typeof templateFieldInputSchema>;
 
 const FIELD_PROPERTY_DOCS = {
   path: "Must match a `{{marker}}` in the DOCX. Identical paths anywhere in the document are one field and one question.",
   label: "Question label shown to the person filling the field.",
   hint: "Short fill guidance shown with the input.",
-  inputType: `Input control: ${INPUT_TYPES.join(", ")}. Defaults to text.`,
+  input_type: `Input control: ${INPUT_TYPES.join(", ")}. Defaults to text.`,
   options: "Allowed values for a select field.",
-  optionsFrom:
+  options_from:
     "Dependent select: the path of another field whose entered values supply this field's options. Use instead of `options`.",
   validation:
-    "Constraints checked at fill time: `required`, `minLength`/`maxLength`, `min`/`max`, `pattern` (a regex matched against the complete value), `minItems`/`maxItems` for repeated fields.",
+    "Constraints checked at fill time: `required`, `min_length`/`max_length`, `min`/`max`, `pattern` (a regex matched against the complete value), `min_items`/`max_items` for repeated fields.",
   required: "Whether the fill form rejects an empty value.",
-  aiPrompt:
+  ai_prompt:
     "Who fills = AI. The instruction the model follows to draft the value at fill time; the fill form shows no input for the field.",
-  aiAdapt:
+  ai_adapt:
     "Who fills = person + AI. The entered value is a stub the model rewrites for each occurrence in the document.",
-  aiSeesDocument:
+  ai_sees_document:
     "Include the rendered document in this AI field's prompt. It costs tokens per fill, so set it only when the value depends on the surrounding text.",
   parts:
-    "Composite field: one entry per sub-input (`key`, `label`, `inputType` text or select, `options`, `pattern`). Set `format` alongside it.",
+    "Composite field: one entry per sub-input (`key`, `label`, `input_type` text or select, `options`, `pattern`). Set `format` alongside it.",
   format:
     "Join template over the composite part keys, for example `{{title}} {{name}}`. Required with `parts`, meaningless without.",
   lookup: `Who fills = business-registry lookup. \`registry\` is one of: ${LOOKUP_REGISTRIES.join(", ")}. The person filling enters only the registry number; the company is resolved at fill time and rendered through \`formats\`.`,
@@ -72,7 +72,7 @@ const FIELD_PROPERTY_DOCS = {
     "Who fills = arithmetic derived from other fields, for example `base_rent * 12`.",
   condition:
     "Boolean rule expression for a field referenced by a `{{#if field_path}}` marker. A boolean field without a condition is asked as a yes/no question instead.",
-  dateFormat: `Locale-aware rendering for a date field: \`locale\` is a BCP-47 tag (\`cs\`, \`de\`, \`pl\`), \`style\` is one of ${DATE_FORMAT_STYLES.join(", ")}.`,
+  date_format: `Locale-aware rendering for a date field: \`locale\` is a BCP-47 tag (\`cs\`, \`de\`, \`pl\`), \`style\` is one of ${DATE_FORMAT_STYLES.join(", ")}.`,
 } as const satisfies Record<FieldConfigProperty, string>;
 
 type BindingSourceDoc = {
@@ -147,7 +147,7 @@ export const buildFieldReference = (): string => {
     propertyLines,
     "",
     "Who fills a field: a person, unless the field says otherwise. " +
-      "`aiPrompt`, `aiAdapt`, `condition`, `formula`, `lookup`, `parts`, and " +
+      "`ai_prompt`, `ai_adapt`, `condition`, `formula`, `lookup`, `parts`, and " +
       "`source` are mutually exclusive — at most one per field.",
     "",
     "Registry lookup formats: each `formats` entry renders the same resolved " +

--- a/apps/api/src/mcp/template-tools.test.ts
+++ b/apps/api/src/mcp/template-tools.test.ts
@@ -355,7 +355,7 @@ describe("MCP template tools", () => {
       createContext(),
     );
     expect(listTemplates?.description).toContain(TEMPLATE_FIELD_REFERENCE_URI);
-    expect(listTemplates?.description).not.toContain("optionsFrom");
+    expect(listTemplates?.description).not.toContain("options_from");
   });
 
   test("save_template advertises the fields overlay pointing at the resource", async () => {
@@ -1446,7 +1446,7 @@ describe("MCP template tools", () => {
           {
             path: "company",
             label: "Company",
-            inputType: "text",
+            input_type: "text",
             required: true,
             lookup: {
               registry: "krs",
@@ -1490,8 +1490,8 @@ describe("MCP template tools", () => {
       args: {
         name: "NDA",
         docx_base64: docxBase64,
-        // formula is mutually exclusive with aiPrompt, so isFieldMeta rejects it.
-        fields: [{ path: "fee", formula: "rent * 12", aiPrompt: "draft it" }],
+        // formula is mutually exclusive with ai_prompt, so isFieldMeta rejects it.
+        fields: [{ path: "fee", formula: "rent * 12", ai_prompt: "draft it" }],
       },
       context: createContext(),
       toolName: "save_template",
@@ -1512,7 +1512,7 @@ describe("MCP template tools", () => {
         fields: [
           {
             path: "company",
-            aiPrompt: "Draft the company details",
+            ai_prompt: "Draft the company details",
             lookup: {
               registry: "krs",
               formats: [{ key: "default", template: "[name]" }],

--- a/apps/api/src/mcp/template-tools.ts
+++ b/apps/api/src/mcp/template-tools.ts
@@ -24,7 +24,6 @@ import {
   buildAiOccurrenceAdapter,
 } from "@/api/lib/docx/ai-field-generator";
 import type { FieldMeta, FieldPart } from "@/api/lib/docx/types";
-import { fieldMetaToolInputSchema } from "@/api/lib/docx/types";
 import { validateDocxBuffer } from "@/api/lib/entity-versions/validate-docx-buffer";
 import { FILE_SIZE_LIMIT_BYTES, LIMITS } from "@/api/lib/limits";
 import {
@@ -60,6 +59,10 @@ import {
 import { withTimeout } from "@/api/lib/with-timeout";
 import type { McpRequestContext } from "@/api/mcp/context";
 import { hasEffectiveAuthority } from "@/api/mcp/effective-authority";
+import {
+  templateFieldInputSchema,
+  toFieldMetaToolInput,
+} from "@/api/mcp/template-field-input";
 import { TEMPLATE_FIELD_REFERENCE_URI } from "@/api/mcp/template-field-reference";
 import { TEMPLATE_MARKER_REFERENCE_URI } from "@/api/mcp/template-marker-reference";
 import {
@@ -144,7 +147,7 @@ const saveTemplateArgsSchema = v.pipe(
     ),
     fields: v.optional(
       v.pipe(
-        v.array(fieldMetaToolInputSchema),
+        v.array(templateFieldInputSchema),
         v.description(
           `Field configuration overlay; see ${TEMPLATE_FIELD_REFERENCE_URI}`,
         ),
@@ -425,7 +428,7 @@ export const TEMPLATE_TOOL_DEFINITIONS = [
       "tags, and usage guidance (whenToUse / whenNotToUse); prefer a template " +
       "whose whenToUse matches the request and skip any whose whenNotToUse " +
       "applies. Pass template_id to return that template's full field " +
-      "configuration, in the shape save_template's fields overlay takes " +
+      "configuration, in the shape the field reference documents " +
       `(see ${TEMPLATE_FIELD_REFERENCE_URI}), plus its named conditions and ` +
       "formula fields. Omitted optional scalar placeholders render blank.",
     inputSchema: {
@@ -1583,6 +1586,7 @@ const handleSaveTemplateTool: TypedMcpToolHandler<
     return validationErrorResult(parsed.issues);
   }
   const input = parsed.output;
+  const fields = input.fields?.map(toFieldMetaToolInput);
 
   // Configure branch: template_id (no docx_base64) overlays field config onto an
   // existing template. The schema guarantees fields is present here.
@@ -1590,7 +1594,7 @@ const handleSaveTemplateTool: TypedMcpToolHandler<
     return await configureExistingTemplate({
       context,
       fields:
-        input.fields ??
+        fields ??
         panic(
           "save_template configure branch reached without a fields overlay",
         ),
@@ -1604,7 +1608,7 @@ const handleSaveTemplateTool: TypedMcpToolHandler<
     docxBase64:
       input.docx_base64 ??
       panic("save_template create branch reached without docx_base64"),
-    fields: input.fields,
+    fields,
     name:
       input.name ?? panic("save_template create branch reached without name"),
   });

--- a/packages/cli/src/generated/registry-snapshot.json
+++ b/packages/cli/src/generated/registry-snapshot.json
@@ -315,7 +315,7 @@
       "scope": "onboarding"
     },
     "name": "set_practice_jurisdictions",
-    "description": "Set the practice jurisdictions for the user's stella organization. Call this when the org's practice jurisdictions are empty (e.g., the user signed up via an OAuth client and skipped onboarding). Pass an array of {countryCode, isPrimary}; exactly one entry should be primary.",
+    "description": "Set the practice jurisdictions for the user's stella organization. Call this when the org's practice jurisdictions are empty (e.g., the user signed up via an OAuth client and skipped onboarding). Pass an array of {country_code, is_primary}; exactly one entry should be primary.",
     "inputSchema": {
       "type": "object",
       "required": ["jurisdictions"],
@@ -326,7 +326,7 @@
           "items": {
             "type": "object",
             "properties": {
-              "countryCode": {
+              "country_code": {
                 "enum": [
                   "AD",
                   "AE",
@@ -582,17 +582,17 @@
                 "type": "string",
                 "description": "ISO 3166-1 alpha-2 country code"
               },
-              "isPrimary": {
+              "is_primary": {
                 "type": "boolean",
                 "description": "Whether this is the organization's primary jurisdiction"
               }
             },
-            "required": ["countryCode", "isPrimary"],
+            "required": ["country_code", "is_primary"],
             "additionalProperties": false
           },
           "minItems": 1,
           "maxItems": 12,
-          "description": "Practice jurisdictions for this organization. countryCode is an ISO 3166-1 alpha-2 code; exactly one entry should set isPrimary to true."
+          "description": "Practice jurisdictions for this organization. country_code is an ISO 3166-1 alpha-2 code; exactly one entry should set is_primary to true."
         }
       }
     },
@@ -611,7 +611,7 @@
       "singleReadWhen": "template_id"
     },
     "name": "list_templates",
-    "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration, in the shape save_template's fields overlay takes (see stella://reference/template-fields), plus its named conditions and formula fields. Omitted optional scalar placeholders render blank.",
+    "description": "List the document templates in this organization (NDAs, powers of attorney, leases), or describe one template's fillable fields. Omit template_id to list templates: each template's id, name, field count, tags, and usage guidance (whenToUse / whenNotToUse); prefer a template whose whenToUse matches the request and skip any whose whenNotToUse applies. Pass template_id to return that template's full field configuration, in the shape the field reference documents (see stella://reference/template-fields), plus its named conditions and formula fields. Omitted optional scalar placeholders render blank.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -823,7 +823,7 @@
                 "type": "string",
                 "description": "Fill hint for the person filling"
               },
-              "inputType": {
+              "input_type": {
                 "enum": ["text", "number", "boolean", "date", "select"],
                 "type": "string",
                 "description": "Input control type"
@@ -842,11 +842,11 @@
                     "type": "boolean",
                     "description": "Value is required"
                   },
-                  "minLength": {
+                  "min_length": {
                     "type": "number",
                     "description": "Minimum string length"
                   },
-                  "maxLength": {
+                  "max_length": {
                     "type": "number",
                     "description": "Maximum string length"
                   },
@@ -862,11 +862,11 @@
                     "type": "string",
                     "description": "Regex for the whole value"
                   },
-                  "minItems": {
+                  "min_items": {
                     "type": "number",
                     "description": "Minimum repeated items"
                   },
-                  "maxItems": {
+                  "max_items": {
                     "type": "number",
                     "description": "Maximum repeated items"
                   }
@@ -879,15 +879,15 @@
                 "type": "boolean",
                 "description": "Value is required"
               },
-              "aiPrompt": {
+              "ai_prompt": {
                 "type": "string",
                 "description": "Who fills = AI: drafting instruction"
               },
-              "aiAdapt": {
+              "ai_adapt": {
                 "type": "boolean",
                 "description": "Who fills = person + AI"
               },
-              "aiSeesDocument": {
+              "ai_sees_document": {
                 "type": "boolean",
                 "description": "AI field also sees the document"
               },
@@ -904,7 +904,7 @@
                       "type": "string",
                       "description": "Part label"
                     },
-                    "inputType": {
+                    "input_type": {
                       "enum": ["text", "select"],
                       "type": "string",
                       "description": "Part input control"
@@ -921,7 +921,7 @@
                       "description": "Regex for the whole part value"
                     }
                   },
-                  "required": ["key", "inputType"],
+                  "required": ["key", "input_type"],
                   "additionalProperties": false
                 },
                 "minItems": 1,
@@ -931,7 +931,7 @@
                 "type": "string",
                 "description": "Join template over the part keys"
               },
-              "optionsFrom": {
+              "options_from": {
                 "type": "string",
                 "description": "Dependent select: source field path"
               },
@@ -1127,7 +1127,7 @@
                 "type": "string",
                 "description": "Boolean rule for an {{#if}} marker"
               },
-              "dateFormat": {
+              "date_format": {
                 "type": "object",
                 "properties": {
                   "locale": {
@@ -2200,7 +2200,7 @@
       "scope": "knowledge_write"
     },
     "name": "save_clause",
-    "description": "Create or update a clause in the organization's clause library. Omit clause_id to create (title and body required); pass clause_id to update. body is an ordered array of paragraphs, each with text and optional formatting. category_id, language, description, usage_notes, and metadata accept null to clear them on update. Set snapshot_version true on an update to also append a version snapshot of the body. Returns the clause id.",
+    "description": "Create or update a clause in the organization's clause library. Omit clause_id to create (title and body required); pass clause_id to update. body is an ordered array of paragraphs, each with text and optional style, level, runs, list_kind, list_level, is_directive, directive_kind, and directive_expression. category_id, language, description, usage_notes, and metadata accept null to clear them on update. Set snapshot_version true on an update to also append a version snapshot of the body. Returns the clause id.",
     "inputSchema": {
       "type": "object",
       "required": [],
@@ -2257,25 +2257,25 @@
                 },
                 "description": "Optional inline formatting runs whose text concatenates to the paragraph"
               },
-              "listKind": {
+              "list_kind": {
                 "enum": ["bullet", "ordered"],
                 "type": "string",
                 "description": "List item kind when the paragraph is a list item"
               },
-              "listLevel": {
+              "list_level": {
                 "type": "integer",
                 "description": "0-based list nesting depth for a list item"
               },
-              "isDirective": {
+              "is_directive": {
                 "type": "boolean",
                 "description": "Whether the paragraph is a template directive marker"
               },
-              "directiveKind": {
+              "directive_kind": {
                 "enum": ["if", "elseif", "else", "endif", "each", "endeach"],
                 "type": "string",
-                "description": "Directive kind when isDirective is set"
+                "description": "Directive kind when is_directive is set"
               },
-              "directiveExpression": {
+              "directive_expression": {
                 "type": "string",
                 "description": "Directive expression for an if/each directive"
               }

--- a/packages/cli/src/generated/route-map.ts
+++ b/packages/cli/src/generated/route-map.ts
@@ -1632,7 +1632,7 @@ export const generatedRouteMap: RouteNode = {
                   items: {
                     type: "object",
                     properties: {
-                      countryCode: {
+                      country_code: {
                         enum: [
                           "AD",
                           "AE",
@@ -1888,19 +1888,19 @@ export const generatedRouteMap: RouteNode = {
                         type: "string",
                         description: "ISO 3166-1 alpha-2 country code",
                       },
-                      isPrimary: {
+                      is_primary: {
                         type: "boolean",
                         description:
                           "Whether this is the organization's primary jurisdiction",
                       },
                     },
-                    required: ["countryCode", "isPrimary"],
+                    required: ["country_code", "is_primary"],
                     additionalProperties: false,
                   },
                   minItems: 1,
                   maxItems: 12,
                   description:
-                    "Practice jurisdictions for this organization. countryCode is an ISO 3166-1 alpha-2 code; exactly one entry should set isPrimary to true.",
+                    "Practice jurisdictions for this organization. country_code is an ISO 3166-1 alpha-2 code; exactly one entry should set is_primary to true.",
                 },
               },
             },
@@ -2617,7 +2617,7 @@ export const generatedRouteMap: RouteNode = {
                         type: "string",
                         description: "Fill hint for the person filling",
                       },
-                      inputType: {
+                      input_type: {
                         enum: ["text", "number", "boolean", "date", "select"],
                         type: "string",
                         description: "Input control type",
@@ -2636,11 +2636,11 @@ export const generatedRouteMap: RouteNode = {
                             type: "boolean",
                             description: "Value is required",
                           },
-                          minLength: {
+                          min_length: {
                             type: "number",
                             description: "Minimum string length",
                           },
-                          maxLength: {
+                          max_length: {
                             type: "number",
                             description: "Maximum string length",
                           },
@@ -2656,11 +2656,11 @@ export const generatedRouteMap: RouteNode = {
                             type: "string",
                             description: "Regex for the whole value",
                           },
-                          minItems: {
+                          min_items: {
                             type: "number",
                             description: "Minimum repeated items",
                           },
-                          maxItems: {
+                          max_items: {
                             type: "number",
                             description: "Maximum repeated items",
                           },
@@ -2673,15 +2673,15 @@ export const generatedRouteMap: RouteNode = {
                         type: "boolean",
                         description: "Value is required",
                       },
-                      aiPrompt: {
+                      ai_prompt: {
                         type: "string",
                         description: "Who fills = AI: drafting instruction",
                       },
-                      aiAdapt: {
+                      ai_adapt: {
                         type: "boolean",
                         description: "Who fills = person + AI",
                       },
-                      aiSeesDocument: {
+                      ai_sees_document: {
                         type: "boolean",
                         description: "AI field also sees the document",
                       },
@@ -2698,7 +2698,7 @@ export const generatedRouteMap: RouteNode = {
                               type: "string",
                               description: "Part label",
                             },
-                            inputType: {
+                            input_type: {
                               enum: ["text", "select"],
                               type: "string",
                               description: "Part input control",
@@ -2715,7 +2715,7 @@ export const generatedRouteMap: RouteNode = {
                               description: "Regex for the whole part value",
                             },
                           },
-                          required: ["key", "inputType"],
+                          required: ["key", "input_type"],
                           additionalProperties: false,
                         },
                         minItems: 1,
@@ -2725,7 +2725,7 @@ export const generatedRouteMap: RouteNode = {
                         type: "string",
                         description: "Join template over the part keys",
                       },
-                      optionsFrom: {
+                      options_from: {
                         type: "string",
                         description: "Dependent select: source field path",
                       },
@@ -2924,7 +2924,7 @@ export const generatedRouteMap: RouteNode = {
                         type: "string",
                         description: "Boolean rule for an {{#if}} marker",
                       },
-                      dateFormat: {
+                      date_format: {
                         type: "object",
                         properties: {
                           locale: {
@@ -3550,23 +3550,23 @@ export const generatedRouteMap: RouteNode = {
                         description:
                           "Optional inline formatting runs whose text concatenates to the paragraph",
                       },
-                      listKind: {
+                      list_kind: {
                         enum: ["bullet", "ordered"],
                         type: "string",
                         description:
                           "List item kind when the paragraph is a list item",
                       },
-                      listLevel: {
+                      list_level: {
                         type: "integer",
                         description:
                           "0-based list nesting depth for a list item",
                       },
-                      isDirective: {
+                      is_directive: {
                         type: "boolean",
                         description:
                           "Whether the paragraph is a template directive marker",
                       },
-                      directiveKind: {
+                      directive_kind: {
                         enum: [
                           "if",
                           "elseif",
@@ -3576,9 +3576,9 @@ export const generatedRouteMap: RouteNode = {
                           "endeach",
                         ],
                         type: "string",
-                        description: "Directive kind when isDirective is set",
+                        description: "Directive kind when is_directive is set",
                       },
-                      directiveExpression: {
+                      directive_expression: {
                         type: "string",
                         description:
                           "Directive expression for an if/each directive",

--- a/packages/cli/src/json-schema-validate.test.ts
+++ b/packages/cli/src/json-schema-validate.test.ts
@@ -598,6 +598,9 @@ describe("format", () => {
       "2026-01-01T00:00:00.250z",
       "2026-01-01T23:59:59+02:00",
       "2026-06-30T23:59:60Z",
+      // RFC 3339 §5.7: the UTC leap second seen from another offset.
+      "1990-12-31T15:59:60-08:00",
+      "2026-07-01T01:29:60+01:30",
     ]) {
       expect(validateAgainstSchema(schema, { at }).valid).toBe(true);
     }
@@ -609,8 +612,9 @@ describe("format", () => {
       "2026-01-01T00:00:00",
       "2026-02-30T00:00:00Z",
       "2026-01-01T25:00:00Z",
-      // A leap second exists only at the end of the day.
+      // A leap second exists only at the end of the UTC day.
       "2026-01-01T00:00:60Z",
+      "2026-06-30T23:59:60+02:00",
       "yesterday",
     ]) {
       const result = validateAgainstSchema(schema, { at });

--- a/packages/cli/src/json-schema-validate.test.ts
+++ b/packages/cli/src/json-schema-validate.test.ts
@@ -597,6 +597,7 @@ describe("format", () => {
       "2026-01-01T00:00:00Z",
       "2026-01-01T00:00:00.250z",
       "2026-01-01T23:59:59+02:00",
+      "2026-06-30T23:59:60Z",
     ]) {
       expect(validateAgainstSchema(schema, { at }).valid).toBe(true);
     }
@@ -608,6 +609,8 @@ describe("format", () => {
       "2026-01-01T00:00:00",
       "2026-02-30T00:00:00Z",
       "2026-01-01T25:00:00Z",
+      // A leap second exists only at the end of the day.
+      "2026-01-01T00:00:60Z",
       "yesterday",
     ]) {
       const result = validateAgainstSchema(schema, { at });

--- a/packages/cli/src/json-schema-validate.ts
+++ b/packages/cli/src/json-schema-validate.ts
@@ -57,13 +57,62 @@ const STRING_ASSERTION_KEYWORDS = [
 const FULL_DATE = /^\d{4}-\d{2}-\d{2}$/u;
 
 /**
- * RFC 3339 §5.6 date-time: full date, `T`, full time with in-range fields
- * (the leap second only as `23:59:60`), and an offset. `Date.parse` alone
- * also admits a bare date, an offset-less local time, and out-of-range
- * fields.
+ * RFC 3339 §5.6 date-time: full date, `T`, full time with in-range fields,
+ * and an offset. `Date.parse` alone also admits a bare date, an offset-less
+ * local time, and out-of-range fields. Second 60 is admitted here and
+ * settled by {@link isUtcLeapSecond}.
  */
 const RFC3339_DATE_TIME =
-  /^\d{4}-\d{2}-\d{2}[Tt](?:(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:[Zz]|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/u;
+  /^\d{4}-\d{2}-\d{2}[Tt](?<hour>[01]\d|2[0-3]):(?<minute>[0-5]\d):(?<second>[0-5]\d|60)(?:\.\d+)?(?<offset>[Zz]|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/u;
+
+const MINUTES_PER_DAY = 24 * 60;
+const LAST_UTC_MINUTE = 23 * 60 + 59;
+
+/**
+ * A leap second exists only as the last second of a UTC day (RFC 3339 §5.7:
+ * `15:59:60-08:00` is `23:59:60Z`), so a second-60 timestamp is valid exactly
+ * when its local time minus its offset lands on 23:59 UTC.
+ */
+const isUtcLeapSecond = (fields: RFC3339TimeFields): boolean => {
+  if (fields.second !== "60") {
+    return true;
+  }
+  const local = Number(fields.hour) * 60 + Number(fields.minute);
+  const offset = fields.offset.toLowerCase();
+  const offsetMinutes =
+    offset === "z"
+      ? 0
+      : (offset.startsWith("-") ? -1 : 1) *
+        (Number(offset.slice(1, 3)) * 60 + Number(offset.slice(4, 6)));
+  const utc =
+    (((local - offsetMinutes) % MINUTES_PER_DAY) + MINUTES_PER_DAY) %
+    MINUTES_PER_DAY;
+  return utc === LAST_UTC_MINUTE;
+};
+
+type RFC3339TimeFields = {
+  hour: string;
+  minute: string;
+  second: string;
+  offset: string;
+};
+
+const rfc3339TimeFields = (value: string): RFC3339TimeFields | undefined => {
+  const groups = RFC3339_DATE_TIME.exec(value)?.groups;
+  const hour = groups?.["hour"];
+  const minute = groups?.["minute"];
+  const second = groups?.["second"];
+  const offset = groups?.["offset"];
+  if (
+    hour === undefined ||
+    minute === undefined ||
+    second === undefined ||
+    offset === undefined
+  ) {
+    return undefined;
+  }
+  return { hour, minute, second, offset };
+};
 
 /**
  * Whether a `YYYY-MM-DD` names a day the calendar has. `Date.parse` rolls an
@@ -83,8 +132,14 @@ const isCalendarDay = (day: string): boolean => {
  */
 const KNOWN_STRING_FORMATS = {
   date: (value: string) => FULL_DATE.test(value) && isCalendarDay(value),
-  "date-time": (value: string) =>
-    RFC3339_DATE_TIME.test(value) && isCalendarDay(value.slice(0, 10)),
+  "date-time": (value: string) => {
+    const fields = rfc3339TimeFields(value);
+    return (
+      fields !== undefined &&
+      isUtcLeapSecond(fields) &&
+      isCalendarDay(value.slice(0, 10))
+    );
+  },
   uuid: (value: string) =>
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(
       value,

--- a/packages/cli/src/json-schema-validate.ts
+++ b/packages/cli/src/json-schema-validate.ts
@@ -58,11 +58,12 @@ const FULL_DATE = /^\d{4}-\d{2}-\d{2}$/u;
 
 /**
  * RFC 3339 §5.6 date-time: full date, `T`, full time with in-range fields
- * (a leap second allowed), and an offset. `Date.parse` alone also admits a
- * bare date, an offset-less local time, and out-of-range fields.
+ * (the leap second only as `23:59:60`), and an offset. `Date.parse` alone
+ * also admits a bare date, an offset-less local time, and out-of-range
+ * fields.
  */
 const RFC3339_DATE_TIME =
-  /^\d{4}-\d{2}-\d{2}[Tt](?:[01]\d|2[0-3]):[0-5]\d:(?:[0-5]\d|60)(?:\.\d+)?(?:[Zz]|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/u;
+  /^\d{4}-\d{2}-\d{2}[Tt](?:(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:[Zz]|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/u;
 
 /**
  * Whether a `YYYY-MM-DD` names a day the calendar has. `Date.parse` rolls an


### PR DESCRIPTION
Closes the camelCase nested-input debt recorded in `registry-quality.test.ts`: every advertised MCP tool input is now snake_case at every depth, and the debt list is empty so a new camelCase name anywhere in an input fails the naming test.

## Renamed inputs (clean cutover; the old spellings are rejected)

- `save_clause` body paragraphs: `list_kind`, `list_level`, `is_directive`, `directive_kind`, `directive_expression`.
- `save_template` field overlay: `input_type`, `options_from`, `ai_prompt`, `ai_adapt`, `ai_sees_document`, `date_format`, `parts[].input_type`, `validation.min_length` / `max_length` / `min_items` / `max_items`.
- `set_practice_jurisdictions`: `country_code`, `is_primary`.

## Shape

Payloads keep mirroring the persisted camelCase models; only inputs change. Each tool carries its own snake_case input schema and maps onto the model at the tool boundary through a function whose return type is the model type, so the mapping is total at compile time. `save_template`'s overlay lives in `template-field-input.ts` with a drift test binding its key set (recursively) to the persisted tool-input schema, plus a round-trip and a rejection test. The `template-fields` reference resource keys off the new schema and documents the new names.

## Also

- CLI `date-time` admits a leap second only as `23:59:60` (from the review on #2785).
- Regenerated tool-surface snapshot and CLI registry files; `@stll/cli` minor changeset.
