### PR TITLE
refactor(web): dock the workspace inspector through InspectorDock

### DIFF
--- a/apps/web/e2e/staging/staging-smoke.spec.ts
+++ b/apps/web/e2e/staging/staging-smoke.spec.ts
@@ -199,7 +199,7 @@ test.describe("public hydration", () => {
     await expect(decisionTitle).toHaveCount(1);
     await expect(decisionTitle).toHaveText(/\S/u);
     const routeErrorTitle = page.locator("#route-error-title");
-    const inspector = page.locator('[data-side="right"]');
+    const inspector = page.locator('[data-slot="inspector-dock"]');
     await expect(routeErrorTitle).toHaveCount(0);
     await expect(inspector).toHaveAttribute("data-state", "expanded");
     await expect(page.locator('[data-slot="sidebar"]').first()).toHaveAttribute(

--- a/apps/web/src/i18n/langs/ar.json
+++ b/apps/web/src/i18n/langs/ar.json
@@ -2391,6 +2391,7 @@
     },
     "openChat": "فتح المحادثة",
     "reopenTab": "إعادة فتح {name}",
+    "resizePane": "تغيير حجم اللوحة",
     "review": {
       "actionNeeded": "تحتاج إلى إجراء",
       "addComment": "إضافة كتعليق",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2391,6 +2391,7 @@
     },
     "openChat": "Otevřít chat",
     "reopenTab": "Znovu otevřít {name}",
+    "resizePane": "Změnit šířku panelu",
     "review": {
       "actionNeeded": "K řešení",
       "addComment": "Přidat jako komentář",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2391,6 +2391,7 @@
     },
     "openChat": "Chat öffnen",
     "reopenTab": "{name} erneut öffnen",
+    "resizePane": "Bereich in der Größe ändern",
     "review": {
       "actionNeeded": "Handlungsbedarf",
       "addComment": "Als Kommentar hinzufügen",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2391,6 +2391,7 @@
     },
     "openChat": "Open chat",
     "reopenTab": "Reopen {name}",
+    "resizePane": "Resize pane",
     "review": {
       "actionNeeded": "Action needed",
       "addComment": "Add as comment",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2391,6 +2391,7 @@
     },
     "openChat": "Abrir chat",
     "reopenTab": "Reabrir {name}",
+    "resizePane": "Cambiar el tamaño del panel",
     "review": {
       "actionNeeded": "Requiere acción",
       "addComment": "Añadir como comentario",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2391,6 +2391,7 @@
     },
     "openChat": "Ava vestlus",
     "reopenTab": "Ava {name} uuesti",
+    "resizePane": "Muuda paneeli suurust",
     "review": {
       "actionNeeded": "Vajab tegutsemist",
       "addComment": "Lisa kommentaarina",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2391,6 +2391,7 @@
     },
     "openChat": "Ouvrir la conversation",
     "reopenTab": "Rouvrir {name}",
+    "resizePane": "Redimensionner le volet",
     "review": {
       "actionNeeded": "Action requise",
       "addComment": "Ajouter comme commentaire",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2391,6 +2391,7 @@
     },
     "openChat": "Chat megnyitása",
     "reopenTab": "{name} újranyitása",
+    "resizePane": "Panel átméretezése",
     "review": {
       "actionNeeded": "Teendő",
       "addComment": "Hozzáadás megjegyzésként",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2391,6 +2391,7 @@
     },
     "openChat": "Atidaryti pokalbį",
     "reopenTab": "Iš naujo atidaryti {name}",
+    "resizePane": "Keisti polangio dydį",
     "review": {
       "actionNeeded": "Reikia veiksmų",
       "addComment": "Pridėti kaip komentarą",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2391,6 +2391,7 @@
     },
     "openChat": "Atvērt tērzēšanu",
     "reopenTab": "Atkārtoti atvērt {name}",
+    "resizePane": "Mainīt paneļa izmēru",
     "review": {
       "actionNeeded": "Nepieciešama rīcība",
       "addComment": "Pievienot kā komentāru",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2394,6 +2394,7 @@ type Messages = {
     };
     "openChat": "Open chat";
     "reopenTab": "Reopen {name}";
+    "resizePane": "Resize pane";
     "review": {
       "actionNeeded": "Action needed";
       "addComment": "Add as comment";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2391,6 +2391,7 @@
     },
     "openChat": "Otwórz czat",
     "reopenTab": "Otwórz ponownie {name}",
+    "resizePane": "Zmień rozmiar panelu",
     "review": {
       "actionNeeded": "Wymaga działania",
       "addComment": "Dodaj jako komentarz",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2391,6 +2391,7 @@
     },
     "openChat": "Abrir bate-papo",
     "reopenTab": "Reabrir {name}",
+    "resizePane": "Redimensionar painel",
     "review": {
       "actionNeeded": "Requer ação",
       "addComment": "Adicionar como comentário",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2391,6 +2391,7 @@
     },
     "openChat": "Otvoriť chat",
     "reopenTab": "Znova otvoriť {name}",
+    "resizePane": "Zmeniť veľkosť panela",
     "review": {
       "actionNeeded": "Na riešenie",
       "addComment": "Pridať ako komentár",

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useRef, useState } from "react";
-import type { MouseEvent, PointerEvent } from "react";
+import type { MouseEvent } from "react";
 
 import { useHotkey } from "@tanstack/react-hotkeys";
 import {
@@ -19,8 +19,11 @@ import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/button";
 import {
+  INSPECTOR_RAIL_WIDTH,
+  InspectorDock,
   SIDE_RAIL_ICON_BUTTON_SIZE,
   SIDE_RAIL_WIDTH,
+  useInspectorPaneWidth,
 } from "@stll/ui/inspector";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "@stll/ui/menu";
 import { Separator } from "@stll/ui/separator";
@@ -80,11 +83,7 @@ import {
 import { useEffectiveHotkey } from "@/lib/use-effective-shortcuts";
 import { workspaceOptions } from "@/lib/workspaces/queries";
 import { loadAuthContext } from "@/routes/-auth-context";
-import {
-  INSPECTOR_PANE_DEFAULT_WIDTH,
-  resolveInspectorPaneWidth,
-  shouldForceSidebarCollapsed,
-} from "@/routes/-inspector-pane-width";
+import { shouldForceSidebarCollapsed } from "@/routes/-inspector-pane-width";
 
 const MEMORY_ROUTE_PATH = "/settings/account/memory";
 
@@ -603,12 +602,6 @@ function ProtectedContent() {
   );
 }
 
-// Matches SIDE_RAIL_WIDTH (`w-12` = 48px) so the wrapper width
-// equals the rail's actual rendered width. Earlier this was 40,
-// leaving the rail 8px wider than its wrapper and pushing the
-// toast / find-replace right-offset CSS vars under the visible rail.
-const INSPECTOR_RAIL_WIDTH = 48;
-
 type InspectorWorkspaceResolutionInput = {
   activeId: string | null;
   routeWorkspaceId: string | undefined;
@@ -699,52 +692,24 @@ function WorkspaceInspectorSidePanel() {
     routeWorkspaceId,
     tabs,
   });
-  // The width the user dragged to. What actually renders is this clamped
-  // against the room left beside the sidebar, so shrinking the window or
-  // expanding the sidebar takes space back from the pane instead of
-  // crushing the content column.
-  const [desiredWidth, setDesiredWidth] = useState(
-    INSPECTOR_PANE_DEFAULT_WIDTH,
-  );
+  // The pane's width policy (the dragged width, its clamp against the room
+  // left beside the sidebar, pointer and keyboard resizing) is the shared
+  // inspector's; this panel only supplies the sidebar's inline size.
   const sidebarWidth = useSidebarInlineSize();
   const viewportWidth = useViewportWidth();
-  const width = resolveInspectorPaneWidth({
-    desiredWidth,
+  const { resetWidth, resizeHandleProps, width } = useInspectorPaneWidth({
     sidebarWidth,
     viewportWidth,
   });
-  const isDragging = useRef(false);
   // Re-run the offset effect once the new bundle applies: `loadedLang` (not
   // `lang`) is what flips document.documentElement.dir, so depending on it
   // reads the correct direction.
   const loadedLang = useI18nStore((s) => s.loadedLang);
 
-  const handlePointerDown = (e: PointerEvent<HTMLElement>) => {
-    e.preventDefault();
-    isDragging.current = true;
-    e.currentTarget.setPointerCapture(e.pointerId);
-  };
-
-  const handlePointerMove = (e: PointerEvent<HTMLElement>) => {
-    if (!isDragging.current) {
-      return;
-    }
-    // The pane docks to the inline-end edge: that's the right in LTR
-    // (width = distance from the right) and the left in RTL (width =
-    // distance from the left). Without the RTL branch the delta is
-    // inverted and the drag oscillates.
-    const isRtl = document.documentElement.dir === "rtl";
-    setDesiredWidth(isRtl ? e.clientX : window.innerWidth - e.clientX);
-  };
-
-  const handlePointerUp = () => {
-    isDragging.current = false;
-  };
-
   // Rail is always shown; only when there are real tabs and the
   // user hasn't minimized do we widen to the full pane width.
-  const widthPx = `${showPaneContent ? width : INSPECTOR_RAIL_WIDTH}px`;
-  const reservedInlineEndWidthPx = isMobile ? "0px" : widthPx;
+  const dockWidth = showPaneContent ? width : INSPECTOR_RAIL_WIDTH;
+  const reservedInlineEndWidthPx = isMobile ? "0px" : `${dockWidth}px`;
 
   useExternalSyncEffect(() => {
     // The toast offset is consumed via a logical `end-` utility, so the same
@@ -812,31 +777,20 @@ function WorkspaceInspectorSidePanel() {
     );
   }
 
+  // The panel owns its rail (the tab strip lives inside `InspectorPanel`), so
+  // the dock gets the whole panel as its content and no `rail` of its own;
+  // the collapsed width is the rail's, passed in as the dock's width.
   return (
-    <div
-      className="text-sidebar-foreground hidden md:block"
-      data-side="right"
-      data-state={showPaneContent ? "expanded" : "collapsed"}
+    <InspectorDock
+      resizeHandleLabel={t("inspector.resizePane")}
+      resizeHandleProps={resizeHandleProps}
+      showPaneContent={showPaneContent}
+      width={dockWidth}
+      onResetWidth={resetWidth}
     >
-      <div className="bg-sidebar relative" style={{ width: widthPx }} />
-      <div
-        className="fixed inset-y-0 end-0 z-10 hidden h-svh md:flex"
-        style={{ width: widthPx }}
-      >
-        {showPaneContent && (
-          <div
-            className="hover:bg-border active:bg-border absolute inset-y-0 -start-px z-20 flex w-1 cursor-col-resize items-center justify-center border-s"
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={handlePointerUp}
-          />
-        )}
-        <div className="bg-sidebar flex h-full w-full flex-col">
-          <Suspense fallback={<InspectorRailFallback />}>
-            <LazyInspectorPanel workspaceId={activeWorkspaceId} />
-          </Suspense>
-        </div>
-      </div>
-    </div>
+      <Suspense fallback={<InspectorRailFallback />}>
+        <LazyInspectorPanel workspaceId={activeWorkspaceId} />
+      </Suspense>
+    </InspectorDock>
   );
 }


### PR DESCRIPTION
## Summary

First slice of moving the app's hand-rolled inspector docks onto the `@stll/ui` inspector primitives.

`WorkspaceInspectorSidePanel` in `_protected.tsx` kept its own copy of the dock: the in-flow spacer plus fixed overlay, a `desiredWidth` state clamped through the package's width policy, and pointer-only drag handlers on a bare `div`. The package already owns all of it. The panel now renders `InspectorDock` with `useInspectorPaneWidth`, supplying only the sidebar's inline size and the collapsed rail width.

What changes for users:

- The resize handle is a focusable `separator` with its ARIA range, so the pane is resizable by keyboard (arrows, Home/End, Page keys) and announced properly; before it was a bare div with pointer handlers only.
- A drag that ends without `pointerup` (touch taken over by scrolling, a context menu, capture lost) no longer leaves the pane following the pointer.
- Double-clicking the handle restores the default width.

What stays in the panel, as host concerns: the toast and find/replace inline-end offsets, the minimized store, the mobile sheet, the lazy rail fallback, and the panel's own rail (the tab strip lives inside `InspectorPanel`, so the dock gets the whole panel as content and the rail width as its collapsed width).

The dock reports `data-side="inline-end"` and `data-slot="inspector-dock"`; the staging smoke test that located the pane by `data-side="right"` now uses the slot. New key `inspector.resizePane` for the handle's accessible name, translated in every locale.

No visual change: the same spacer-and-overlay geometry, widths, and logical edges.

## Next slices

`PublicInspectorDock` (public law inspector) and the case-law workspace dock, then a source contract forbidding `fixed inset-y-0 end-0` outside the package.

## Checks

`apps/web` typecheck (app and e2e tsconfigs) and lint report nothing in the touched files; `oxfmt` clean; locale catalogs synced and message types regenerated.
