### PR TITLE
fix: autofix Dependabot dev dependency changesets

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "bun.lock"
-      - "packages/ui/**"
+      - "packages/*/package.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     env:
-      EMPTY_CHANGESET_PATH: .changeset/dependabot-ui-${{ github.event.pull_request.number }}.md
+      EMPTY_CHANGESET_PATH: .changeset/dependabot-dev-dependencies-${{ github.event.pull_request.number }}.md
       # autofix-ci/action v1.3.4 declares Node 24 support, but its action
       # metadata still names node20 for compatibility with older runners.
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -48,40 +48,37 @@ jobs:
       - name: Dedupe lockfile
         run: bun --no-env-file dedupe --lockfile-only --ignore-scripts
 
-      - name: Add missing empty @stll/ui changeset
+      - name: Verify trusted autofix sources
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          git diff --quiet "$BASE_SHA" "$HEAD_SHA" --
+          scripts/dependabot-empty-changeset.ts
+          scripts/changeset-guard.ts
+          scripts/changeset-policy.json
+
+      - name: Add missing empty dev dependency changeset
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          bun --no-install --no-env-file scripts/dependabot-empty-changeset.ts
+          --base "$BASE_SHA" --head "$HEAD_SHA" --output "$EMPTY_CHANGESET_PATH"
+
+      - name: Restrict generated changes
+        env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         shell: bash
         run: |
           set -euo pipefail
 
-          ui_files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" -- packages/ui)"
-          if [[ -z "$ui_files" ]]; then
-            exit 0
-          fi
-
-          added_changesets="$(git diff --name-only --diff-filter=A \
-            "${BASE_SHA}...${HEAD_SHA}" -- \
-            ".changeset/*.md" \
-            ":(exclude).changeset/README.md")"
-          if [[ -n "$added_changesets" ]]; then
-            exit 0
-          fi
-
-          if [[ -e "$EMPTY_CHANGESET_PATH" || -L "$EMPTY_CHANGESET_PATH" ]]; then
-            echo "::error::Refusing to overwrite $EMPTY_CHANGESET_PATH."
+          if [[ "$(git rev-parse HEAD)" != "$HEAD_SHA" ]]; then
+            echo "::error::Autofix moved HEAD away from $HEAD_SHA."
             exit 1
           fi
 
-          printf '%s\n' "---" "---" > "$EMPTY_CHANGESET_PATH"
-
-      - name: Restrict generated changes
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          unexpected_tracked="$(git diff --name-only -- . ':(exclude)bun.lock' ":(exclude)$EMPTY_CHANGESET_PATH")"
+          unexpected_tracked="$(git diff --name-only "$HEAD_SHA" -- . ':(exclude)bun.lock' ":(exclude)$EMPTY_CHANGESET_PATH")"
           unexpected_untracked="$(git ls-files --others --exclude-standard -- . ":(exclude)$EMPTY_CHANGESET_PATH")"
           if [[ -n "${unexpected_tracked}${unexpected_untracked}" ]]; then
             echo "::error::Autofix changed files outside bun.lock and $EMPTY_CHANGESET_PATH."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1002,6 +1002,7 @@ jobs:
           bun test
           scripts/detect-e2e-changes.test.ts
           scripts/autofix-workflow.test.ts
+          scripts/dependabot-empty-changeset.test.ts
 
       - name: Test affected code-check planner
         if: needs.ci-plan.outputs.package_checks_required == 'true'

--- a/scripts/autofix-workflow.test.ts
+++ b/scripts/autofix-workflow.test.ts
@@ -52,29 +52,27 @@ describe("Dependabot Bun autofix boundary", () => {
     );
   });
 
-  test("adds a deterministic empty changeset for @stll/ui updates that lack one", async () => {
+  test("adds a deterministic empty changeset for published dev dependency updates", async () => {
     const workflow = await Bun.file(WORKFLOW_URL).text();
     const changesetStep = workflow.indexOf(
-      "- name: Add missing empty @stll/ui changeset",
+      "- name: Add missing empty dev dependency changeset",
     );
     const restrictionStep = workflow.indexOf(
       "- name: Restrict generated changes",
     );
     const pushStep = workflow.indexOf("- name: Push autofixes");
 
-    expect(workflow).toContain('- "packages/ui/**"');
+    expect(workflow).toContain('- "packages/*/package.json"');
+    expect(workflow).not.toContain('- "packages/ui/**"');
     expect(workflow).toContain(
-      `EMPTY_CHANGESET_PATH: .changeset/dependabot-ui-\${{ github.event.pull_request.number }}.md`,
+      `EMPTY_CHANGESET_PATH: .changeset/dependabot-dev-dependencies-\${{ github.event.pull_request.number }}.md`,
     );
     expect(workflow).toContain("fetch-depth: 0");
     expect(workflow).toContain(
-      `git diff --name-only "\${BASE_SHA}...\${HEAD_SHA}" -- packages/ui`,
+      "bun --no-env-file scripts/dependabot-empty-changeset.ts",
     );
-    expect(workflow).toContain("git diff --name-only --diff-filter=A");
-    expect(workflow).toContain(`".changeset/*.md"`);
-    expect(workflow).toContain(`":(exclude).changeset/README.md"`);
     expect(workflow).toContain(
-      `printf '%s\\n' "---" "---" > "$EMPTY_CHANGESET_PATH"`,
+      `--base "$BASE_SHA" --head "$HEAD_SHA" --output "$EMPTY_CHANGESET_PATH"`,
     );
     expect(workflow).toContain(
       `cmp -s <(printf '%s\\n' "---" "---") "$EMPTY_CHANGESET_PATH"`,

--- a/scripts/autofix-workflow.test.ts
+++ b/scripts/autofix-workflow.test.ts
@@ -4,12 +4,20 @@ const WORKFLOW_URL = new URL(
   "../.github/workflows/autofix.yml",
   import.meta.url,
 );
+const HELPER_URL = new URL(
+  "./dependabot-empty-changeset.ts",
+  import.meta.url,
+);
+const CHANGESET_GUARD_URL = new URL("./changeset-guard.ts", import.meta.url);
 
 describe("Dependabot Bun autofix boundary", () => {
   test("keeps the runner read-only and hands off only verified autofixes", async () => {
     const workflow = await Bun.file(WORKFLOW_URL).text();
     const restrictionStep = workflow.indexOf(
       "- name: Restrict generated changes",
+    );
+    const trustedSourcesStep = workflow.indexOf(
+      "- name: Verify trusted autofix sources",
     );
     const pushStep = workflow.indexOf("- name: Push autofixes");
 
@@ -40,16 +48,35 @@ describe("Dependabot Bun autofix boundary", () => {
       "bun --no-env-file dedupe --lockfile-only --ignore-scripts",
     );
     expect(workflow).toContain(
-      `git diff --name-only -- . ':(exclude)bun.lock' ":(exclude)$EMPTY_CHANGESET_PATH"`,
+      `git diff --name-only "$HEAD_SHA" -- . ':(exclude)bun.lock' ":(exclude)$EMPTY_CHANGESET_PATH"`,
     );
     expect(workflow).toContain(
       `git ls-files --others --exclude-standard -- . ":(exclude)$EMPTY_CHANGESET_PATH"`,
     );
     expect(restrictionStep).toBeGreaterThanOrEqual(0);
+    expect(trustedSourcesStep).toBeGreaterThanOrEqual(0);
+    expect(restrictionStep).toBeGreaterThan(trustedSourcesStep);
     expect(pushStep).toBeGreaterThan(restrictionStep);
     expect(workflow).toContain(
       "autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4",
     );
+    expect(workflow).toContain("- name: Verify trusted autofix sources");
+    expect(workflow).toContain(
+      `git diff --quiet "$BASE_SHA" "$HEAD_SHA" --`,
+    );
+    expect(workflow).toContain(
+      `if [[ "$(git rev-parse HEAD)" != "$HEAD_SHA" ]]; then`,
+    );
+    expect(workflow).toContain(
+      "bun --no-install --no-env-file scripts/dependabot-empty-changeset.ts",
+    );
+
+    const [helper, changesetGuard] = await Promise.all([
+      Bun.file(HELPER_URL).text(),
+      Bun.file(CHANGESET_GUARD_URL).text(),
+    ]);
+    expect(helper).not.toContain('from "better-result"');
+    expect(changesetGuard).not.toContain('from "better-result"');
   });
 
   test("adds a deterministic empty changeset for published dev dependency updates", async () => {
@@ -69,7 +96,7 @@ describe("Dependabot Bun autofix boundary", () => {
     );
     expect(workflow).toContain("fetch-depth: 0");
     expect(workflow).toContain(
-      "bun --no-env-file scripts/dependabot-empty-changeset.ts",
+      "bun --no-install --no-env-file scripts/dependabot-empty-changeset.ts",
     );
     expect(workflow).toContain(
       `--base "$BASE_SHA" --head "$HEAD_SHA" --output "$EMPTY_CHANGESET_PATH"`,

--- a/scripts/autofix-workflow.test.ts
+++ b/scripts/autofix-workflow.test.ts
@@ -5,10 +5,10 @@ const WORKFLOW_URL = new URL(
   import.meta.url,
 );
 const HELPER_URL = new URL(
-  "./dependabot-empty-changeset.ts",
+  "dependabot-empty-changeset.ts",
   import.meta.url,
 );
-const CHANGESET_GUARD_URL = new URL("./changeset-guard.ts", import.meta.url);
+const CHANGESET_GUARD_URL = new URL("changeset-guard.ts", import.meta.url);
 
 describe("Dependabot Bun autofix boundary", () => {
   test("keeps the runner read-only and hands off only verified autofixes", async () => {

--- a/scripts/changeset-guard.ts
+++ b/scripts/changeset-guard.ts
@@ -26,6 +26,11 @@ import path from "node:path";
 // This module is also imported by the no-install Dependabot autofix runner.
 class ChangesetPolicyError extends Error {
   readonly _tag = "ChangesetPolicyError";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ChangesetPolicyError";
+  }
 }
 
 const panic = (message: string): never => {

--- a/scripts/changeset-guard.ts
+++ b/scripts/changeset-guard.ts
@@ -70,7 +70,7 @@ const isChangesetPolicy = (value: unknown): value is ChangesetPolicy =>
 export const parseChangesetPolicy = (text: string): ChangesetPolicy => {
   const parsed: unknown = JSON.parse(text);
   if (!isChangesetPolicy(parsed)) {
-    panic(
+    return panic(
       `${POLICY_FILE} must hold releasePaths, generatedPaths and packageFiles as string arrays.`,
     );
   }
@@ -248,7 +248,7 @@ const parseArgs = (args: readonly string[]): { readonly base: string } => {
     }
     const value = args.at(index + 1);
     if (value === undefined) {
-      panic("--base requires a git ref");
+      return panic("--base requires a git ref");
     }
     base = value;
     index += 1;

--- a/scripts/changeset-guard.ts
+++ b/scripts/changeset-guard.ts
@@ -20,9 +20,17 @@
 //
 //   bun scripts/changeset-guard.ts [--base origin/main]
 
-import { panic } from "better-result";
 import { readFileSync } from "node:fs";
 import path from "node:path";
+
+// This module is also imported by the no-install Dependabot autofix runner.
+class ChangesetPolicyError extends Error {
+  readonly _tag = "ChangesetPolicyError";
+}
+
+const panic = (message: string): never => {
+  throw new ChangesetPolicyError(message);
+};
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "..");
 const POLICY_FILE = "scripts/changeset-policy.json";

--- a/scripts/dependabot-empty-changeset.test.ts
+++ b/scripts/dependabot-empty-changeset.test.ts
@@ -406,7 +406,7 @@ describe("Dependabot empty changeset CLI boundary", () => {
     const fixture = makeGitFixture("bump");
 
     expect(runFixture(fixture)).toBe(0);
-    expect(readFileSync(path.join(fixture.root, fixture.output))).toBe(
+    expect(readFileSync(path.join(fixture.root, fixture.output), "utf-8")).toBe(
       "---\n---\n",
     );
   });

--- a/scripts/dependabot-empty-changeset.test.ts
+++ b/scripts/dependabot-empty-changeset.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "bun:test";
+
+import { decideDependabotEmptyChangeset } from "./dependabot-empty-changeset";
+
+const policy = {
+  releasePaths: [
+    "packages/workspace-ui/package.json",
+    "packages/workspace-ui/README.md",
+    "packages/workspace-ui/src/**",
+    "packages/ui/package.json",
+    "packages/ui/README.md",
+    "packages/ui/src/**",
+  ],
+  generatedPaths: [],
+  packageFiles: [
+    "packages/workspace-ui/package.json",
+    "packages/ui/package.json",
+  ],
+} as const;
+
+const workspaceUiManifest = "packages/workspace-ui/package.json";
+const uiManifest = "packages/ui/package.json";
+
+const manifest = (
+  packagePath: string,
+  base: string,
+  head: string,
+) => ({ packagePath, base, head });
+
+const json = (value: unknown): string => JSON.stringify(value);
+
+const basePackage = {
+  name: "@stll/workspace-ui",
+  version: "0.6.2",
+  dependencies: { "@stll/ui": "workspace:^" },
+  peerDependencies: { react: ">=19" },
+  devDependencies: { "@tanstack/react-table": "9.2.2" },
+};
+
+const decide = (
+  input: Partial<Parameters<typeof decideDependabotEmptyChangeset>[0]> = {},
+) =>
+  decideDependabotEmptyChangeset({
+    policy,
+    changedFiles: [],
+    addedChangesetFiles: [],
+    manifests: [],
+    ...input,
+  });
+
+describe("Dependabot empty changeset decision", () => {
+  test("does nothing when no release-gated path changed", () => {
+    expect(
+      decide({ changedFiles: ["bun.lock", "apps/web/src/routes.tsx"] }),
+    ).toEqual({ status: "noop", reason: "no-release-paths" });
+  });
+
+  test("does nothing when a changeset already exists", () => {
+    expect(
+      decide({
+        changedFiles: [workspaceUiManifest],
+        addedChangesetFiles: [".changeset/quiet-bears-wave.md"],
+      }),
+    ).toEqual({ status: "noop", reason: "existing-changeset" });
+  });
+
+  test("creates one empty changeset for semantic devDependency-only manifest changes", () => {
+    const head = {
+      ...basePackage,
+      devDependencies: { "@tanstack/react-table": "9.2.3" },
+    };
+
+    expect(
+      decide({
+        changedFiles: [workspaceUiManifest],
+        manifests: [manifest(workspaceUiManifest, json(basePackage), json(head))],
+      }),
+    ).toEqual({
+      status: "create",
+      packages: ["@stll/workspace-ui"],
+    });
+  });
+
+  test("derives all eligible published package names from the policy manifests", () => {
+    const uiBase = { ...basePackage, name: "@stll/ui" };
+    const uiHead = {
+      ...uiBase,
+      devDependencies: { ...uiBase.devDependencies, react: "19.1.0" },
+    };
+
+    expect(
+      decide({
+        changedFiles: [workspaceUiManifest, uiManifest],
+        manifests: [
+          manifest(
+            workspaceUiManifest,
+            json(basePackage),
+            json({
+              ...basePackage,
+              devDependencies: {
+                "@tanstack/react-table": "9.2.3",
+              },
+            }),
+          ),
+          manifest(uiManifest, json(uiBase), json(uiHead)),
+        ],
+      }),
+    ).toEqual({
+      status: "create",
+      packages: ["@stll/workspace-ui", "@stll/ui"],
+    });
+  });
+
+  test.each([
+    [
+      "runtime dependency changes",
+      {
+        ...basePackage,
+        dependencies: { "@stll/ui": "workspace:^", zod: "^4.0.0" },
+      },
+      "runtime-change",
+    ],
+    [
+      "peer dependency changes",
+      { ...basePackage, peerDependencies: { react: ">=20" } },
+      "peer-change",
+    ],
+    [
+      "source changes",
+      basePackage,
+      "source-change",
+    ],
+  ] as const)("refuses %s", (_label, head, reason) => {
+    const changedFiles =
+      reason === "source-change"
+        ? [workspaceUiManifest, "packages/workspace-ui/src/table.tsx"]
+        : [workspaceUiManifest];
+
+    expect(
+      decide({
+        changedFiles,
+        manifests: [manifest(workspaceUiManifest, json(basePackage), json(head))],
+      }),
+    ).toEqual({ status: "refuse", reason });
+  });
+
+  test("refuses a group mixing an eligible devDependency change with a runtime change", () => {
+    const runtimeBase = { ...basePackage, name: "@stll/ui" };
+    const runtimeHead = {
+      ...runtimeBase,
+      dependencies: { ...runtimeBase.dependencies, zod: "^4.0.0" },
+    };
+
+    expect(
+      decide({
+        changedFiles: [workspaceUiManifest, uiManifest],
+        manifests: [
+          manifest(
+            workspaceUiManifest,
+            json(basePackage),
+            json({
+              ...basePackage,
+              devDependencies: {
+                "@tanstack/react-table": "9.2.3",
+              },
+            }),
+          ),
+          manifest(uiManifest, json(runtimeBase), json(runtimeHead)),
+        ],
+      }),
+    ).toEqual({ status: "refuse", reason: "mixed-change" });
+  });
+
+  test("refuses formatting-only manifest changes", () => {
+    expect(
+      decide({
+        changedFiles: [workspaceUiManifest],
+        manifests: [
+          manifest(
+            workspaceUiManifest,
+            json(basePackage),
+            JSON.stringify(basePackage, null, 2),
+          ),
+        ],
+      }),
+    ).toEqual({ status: "refuse", reason: "format-only" });
+  });
+
+  test.each([
+    ["invalid JSON", manifest(workspaceUiManifest, json(basePackage), "{")],
+    ["missing manifest pair", undefined],
+  ] as const)("refuses a malformed manifest pair: %s", (_label, pair) => {
+    expect(
+      decide({
+        changedFiles: [workspaceUiManifest],
+        manifests: pair === undefined ? [] : [pair],
+      }),
+    ).toEqual({ status: "refuse", reason: "malformed-manifest" });
+  });
+});

--- a/scripts/dependabot-empty-changeset.test.ts
+++ b/scripts/dependabot-empty-changeset.test.ts
@@ -426,7 +426,7 @@ describe("Dependabot empty changeset CLI boundary", () => {
         ],
         fixture.root,
       ),
-    ).toThrow(/checked-out HEAD .* does not match/u);
+    ).toThrow(/Checked-out HEAD .* does not match/u);
   });
 
   test("refuses to overwrite an existing output file", () => {

--- a/scripts/dependabot-empty-changeset.test.ts
+++ b/scripts/dependabot-empty-changeset.test.ts
@@ -135,7 +135,7 @@ const makeGitFixture = (change: GitFixtureChange): GitFixture => {
   runGit(root, ["config", "user.name", "Test"]);
 
   if (change !== "added") {
-    writeFileSync(manifestPath, JSON.stringify(baseManifest) + "\n");
+    writeFileSync(manifestPath, `${JSON.stringify(baseManifest)}\n`);
   }
   runGit(root, ["add", "."]);
   runGit(root, ["commit", "--quiet", "-m", "base"]);
@@ -145,7 +145,7 @@ const makeGitFixture = (change: GitFixtureChange): GitFixture => {
     rmSync(manifestPath);
     runGit(root, ["add", "-u", "."]);
   } else {
-    writeFileSync(manifestPath, JSON.stringify(headManifest) + "\n");
+    writeFileSync(manifestPath, `${JSON.stringify(headManifest)}\n`);
     if (change === "executable") {
       chmodSync(manifestPath, 0o755);
     }
@@ -436,7 +436,7 @@ describe("Dependabot empty changeset CLI boundary", () => {
     writeFileSync(outputPath, "keep this file\n");
 
     expect(() => runFixture(fixture)).toThrow(/overwrite/u);
-    expect(readFileSync(outputPath, "utf8")).toBe("keep this file\n");
+    expect(readFileSync(outputPath, "utf-8")).toBe("keep this file\n");
   });
 
   test("refuses to follow a symlink at the output path", () => {
@@ -449,7 +449,7 @@ describe("Dependabot empty changeset CLI boundary", () => {
 
     expect(() => runFixture(fixture)).toThrow(/overwrite/u);
     expect(lstatSync(outputPath).isSymbolicLink()).toBe(true);
-    expect(readFileSync(targetPath, "utf8")).toBe("keep the target\n");
+    expect(readFileSync(targetPath, "utf-8")).toBe("keep the target\n");
   });
 
   test.each([

--- a/scripts/dependabot-empty-changeset.test.ts
+++ b/scripts/dependabot-empty-changeset.test.ts
@@ -1,6 +1,23 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { panic } from "better-result";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
-import { decideDependabotEmptyChangeset } from "./dependabot-empty-changeset";
+import {
+  decideDependabotEmptyChangeset,
+  runDependabotEmptyChangeset,
+} from "./dependabot-empty-changeset";
 
 const policy = {
   releasePaths: [
@@ -21,11 +38,17 @@ const policy = {
 const workspaceUiManifest = "packages/workspace-ui/package.json";
 const uiManifest = "packages/ui/package.json";
 
-const manifest = (
-  packagePath: string,
-  base: string,
-  head: string,
-) => ({ packagePath, base, head });
+type ManifestFixture = {
+  readonly packagePath: string;
+  readonly base: string;
+  readonly head: string;
+};
+
+const manifest = ({ packagePath, base, head }: ManifestFixture) => ({
+  packagePath,
+  base,
+  head,
+});
 
 const json = (value: unknown): string => JSON.stringify(value);
 
@@ -47,6 +70,113 @@ const decide = (
     manifests: [],
     ...input,
   });
+
+const testRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of testRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+const runGit = (root: string, args: readonly string[]): string => {
+  const result = Bun.spawnSync(["git", ...args], {
+    cwd: root,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  if (result.exitCode !== 0) {
+    return panic(
+      `git ${args.join(" ")} failed: ${result.stderr.toString()}`,
+    );
+  }
+  return result.stdout.toString().trim();
+};
+
+type GitFixtureChange = "bump" | "added" | "deleted" | "executable";
+
+type GitFixture = {
+  readonly root: string;
+  readonly base: string;
+  readonly head: string;
+  readonly output: string;
+};
+
+const makeGitFixture = (change: GitFixtureChange): GitFixture => {
+  const root = mkdtempSync(path.join(tmpdir(), "stella-dependabot-empty-"));
+  testRoots.push(root);
+
+  const packagePath = "packages/sample/package.json";
+  mkdirSync(path.join(root, ".changeset"), { recursive: true });
+  mkdirSync(path.join(root, "scripts"), { recursive: true });
+  mkdirSync(path.join(root, "packages/sample"), { recursive: true });
+  writeFileSync(
+    path.join(root, "scripts/changeset-policy.json"),
+    JSON.stringify({
+      releasePaths: [packagePath, "packages/sample/src/**"],
+      generatedPaths: [],
+      packageFiles: [packagePath],
+    }),
+  );
+
+  const baseManifest = {
+    name: "@stll/sample",
+    version: "0.1.0",
+    devDependencies: { vitest: "^3.0.0" },
+  };
+  const headManifest = {
+    ...baseManifest,
+    devDependencies: { vitest: "^3.1.0" },
+  };
+  const manifestPath = path.join(root, packagePath);
+
+  runGit(root, ["init", "--quiet"]);
+  runGit(root, ["config", "user.email", "test@example.com"]);
+  runGit(root, ["config", "user.name", "Test"]);
+
+  if (change !== "added") {
+    writeFileSync(manifestPath, JSON.stringify(baseManifest) + "\n");
+  }
+  runGit(root, ["add", "."]);
+  runGit(root, ["commit", "--quiet", "-m", "base"]);
+  const base = runGit(root, ["rev-parse", "HEAD"]);
+
+  if (change === "deleted") {
+    rmSync(manifestPath);
+    runGit(root, ["add", "-u", "."]);
+  } else {
+    writeFileSync(manifestPath, JSON.stringify(headManifest) + "\n");
+    if (change === "executable") {
+      chmodSync(manifestPath, 0o755);
+    }
+    runGit(root, ["add", "."]);
+    if (change === "executable") {
+      runGit(root, ["update-index", "--chmod=+x", packagePath]);
+    }
+  }
+  runGit(root, ["commit", "--quiet", "-m", "head"]);
+  const head = runGit(root, ["rev-parse", "HEAD"]);
+
+  return {
+    root,
+    base,
+    head,
+    output: ".changeset/dependabot-dev-dependencies-123.md",
+  };
+};
+
+const runFixture = (fixture: GitFixture) =>
+  runDependabotEmptyChangeset(
+    [
+      "--base",
+      fixture.base,
+      "--head",
+      fixture.head,
+      "--output",
+      fixture.output,
+    ],
+    fixture.root,
+  );
 
 describe("Dependabot empty changeset decision", () => {
   test("does nothing when no release-gated path changed", () => {
@@ -73,7 +203,13 @@ describe("Dependabot empty changeset decision", () => {
     expect(
       decide({
         changedFiles: [workspaceUiManifest],
-        manifests: [manifest(workspaceUiManifest, json(basePackage), json(head))],
+        manifests: [
+          manifest({
+            packagePath: workspaceUiManifest,
+            base: json(basePackage),
+            head: json(head),
+          }),
+        ],
       }),
     ).toEqual({
       status: "create",
@@ -92,17 +228,21 @@ describe("Dependabot empty changeset decision", () => {
       decide({
         changedFiles: [workspaceUiManifest, uiManifest],
         manifests: [
-          manifest(
-            workspaceUiManifest,
-            json(basePackage),
-            json({
+          manifest({
+            packagePath: workspaceUiManifest,
+            base: json(basePackage),
+            head: json({
               ...basePackage,
               devDependencies: {
                 "@tanstack/react-table": "9.2.3",
               },
             }),
-          ),
-          manifest(uiManifest, json(uiBase), json(uiHead)),
+          }),
+          manifest({
+            packagePath: uiManifest,
+            base: json(uiBase),
+            head: json(uiHead),
+          }),
         ],
       }),
     ).toEqual({
@@ -139,7 +279,13 @@ describe("Dependabot empty changeset decision", () => {
     expect(
       decide({
         changedFiles,
-        manifests: [manifest(workspaceUiManifest, json(basePackage), json(head))],
+        manifests: [
+          manifest({
+            packagePath: workspaceUiManifest,
+            base: json(basePackage),
+            head: json(head),
+          }),
+        ],
       }),
     ).toEqual({ status: "refuse", reason });
   });
@@ -155,17 +301,21 @@ describe("Dependabot empty changeset decision", () => {
       decide({
         changedFiles: [workspaceUiManifest, uiManifest],
         manifests: [
-          manifest(
-            workspaceUiManifest,
-            json(basePackage),
-            json({
+          manifest({
+            packagePath: workspaceUiManifest,
+            base: json(basePackage),
+            head: json({
               ...basePackage,
               devDependencies: {
                 "@tanstack/react-table": "9.2.3",
               },
             }),
-          ),
-          manifest(uiManifest, json(runtimeBase), json(runtimeHead)),
+          }),
+          manifest({
+            packagePath: uiManifest,
+            base: json(runtimeBase),
+            head: json(runtimeHead),
+          }),
         ],
       }),
     ).toEqual({ status: "refuse", reason: "mixed-change" });
@@ -176,19 +326,34 @@ describe("Dependabot empty changeset decision", () => {
       decide({
         changedFiles: [workspaceUiManifest],
         manifests: [
-          manifest(
-            workspaceUiManifest,
-            json(basePackage),
-            JSON.stringify(basePackage, null, 2),
-          ),
+          manifest({
+            packagePath: workspaceUiManifest,
+            base: json(basePackage),
+            head: JSON.stringify(basePackage, null, 2),
+          }),
         ],
       }),
     ).toEqual({ status: "refuse", reason: "format-only" });
   });
 
   test.each([
-    ["invalid JSON", manifest(workspaceUiManifest, json(basePackage), "{")],
+    [
+      "invalid JSON",
+      manifest({
+        packagePath: workspaceUiManifest,
+        base: json(basePackage),
+        head: "{",
+      }),
+    ],
     ["missing manifest pair", undefined],
+    [
+      "non-string devDependency",
+      manifest({
+        packagePath: workspaceUiManifest,
+        base: json(basePackage),
+        head: json({ ...basePackage, devDependencies: { react: 19 } }),
+      }),
+    ],
   ] as const)("refuses a malformed manifest pair: %s", (_label, pair) => {
     expect(
       decide({
@@ -196,5 +361,105 @@ describe("Dependabot empty changeset decision", () => {
         manifests: pair === undefined ? [] : [pair],
       }),
     ).toEqual({ status: "refuse", reason: "malformed-manifest" });
+  });
+
+  test("refuses non-manifest files even when they are outside release paths", () => {
+    expect(
+      decide({
+        changedFiles: [workspaceUiManifest, "apps/web/src/routes.tsx"],
+        manifests: [
+          manifest({
+            packagePath: workspaceUiManifest,
+            base: json(basePackage),
+            head: json({
+              ...basePackage,
+              devDependencies: {
+                "@tanstack/react-table": "9.2.3",
+              },
+            }),
+          }),
+        ],
+      }),
+    ).toEqual({ status: "refuse", reason: "source-change" });
+  });
+});
+
+describe("Dependabot empty changeset CLI boundary", () => {
+  test.each([
+    ".changeset/../outside.md",
+    ".changeset/dependabot-dev-dependencies-0.md",
+    ".changeset/dependabot-dev-dependencies-not-a-number.md",
+  ])("rejects an invalid output path: %s", (output) => {
+    expect(() =>
+      runDependabotEmptyChangeset([
+        "--base",
+        "0".repeat(40),
+        "--head",
+        "1".repeat(40),
+        "--output",
+        output,
+      ]),
+    ).toThrow(/invalid empty changeset output path/iu);
+  });
+
+  test("writes exactly an empty changeset for an eligible devDependency bump", () => {
+    const fixture = makeGitFixture("bump");
+
+    expect(runFixture(fixture)).toBe(0);
+    expect(readFileSync(path.join(fixture.root, fixture.output))).toBe(
+      "---\n---\n",
+    );
+  });
+
+  test("rejects a checked-out repository whose HEAD differs from --head", () => {
+    const fixture = makeGitFixture("bump");
+
+    expect(() =>
+      runDependabotEmptyChangeset(
+        [
+          "--base",
+          fixture.base,
+          "--head",
+          fixture.base,
+          "--output",
+          fixture.output,
+        ],
+        fixture.root,
+      ),
+    ).toThrow(/checked-out HEAD .* does not match/u);
+  });
+
+  test("refuses to overwrite an existing output file", () => {
+    const fixture = makeGitFixture("bump");
+    const outputPath = path.join(fixture.root, fixture.output);
+    mkdirSync(path.dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, "keep this file\n");
+
+    expect(() => runFixture(fixture)).toThrow(/overwrite/u);
+    expect(readFileSync(outputPath, "utf8")).toBe("keep this file\n");
+  });
+
+  test("refuses to follow a symlink at the output path", () => {
+    const fixture = makeGitFixture("bump");
+    const outputPath = path.join(fixture.root, fixture.output);
+    const targetPath = path.join(fixture.root, "target.md");
+    mkdirSync(path.dirname(outputPath), { recursive: true });
+    writeFileSync(targetPath, "keep the target\n");
+    symlinkSync(targetPath, outputPath);
+
+    expect(() => runFixture(fixture)).toThrow(/overwrite/u);
+    expect(lstatSync(outputPath).isSymbolicLink()).toBe(true);
+    expect(readFileSync(targetPath, "utf8")).toBe("keep the target\n");
+  });
+
+  test.each([
+    ["added", "added"],
+    ["deleted", "deleted"],
+    ["executable", "executable mode"],
+  ] as const)("refuses a %s manifest without creating output", (change) => {
+    const fixture = makeGitFixture(change);
+
+    expect(runFixture(fixture)).toBe(0);
+    expect(existsSync(path.join(fixture.root, fixture.output))).toBe(false);
   });
 });

--- a/scripts/dependabot-empty-changeset.ts
+++ b/scripts/dependabot-empty-changeset.ts
@@ -19,6 +19,11 @@ const COMMIT_SHA = /^[0-9a-f]{40}$/u;
 
 class DependabotChangesetError extends Error {
   readonly _tag = "DependabotChangesetError";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "DependabotChangesetError";
+  }
 }
 
 const panic = (message: string): never => {

--- a/scripts/dependabot-empty-changeset.ts
+++ b/scripts/dependabot-empty-changeset.ts
@@ -1,0 +1,396 @@
+#!/usr/bin/env bun
+
+import { lstatSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+import {
+  decideChangesetGate,
+  isChangesetEntry,
+  loadChangesetPolicy,
+  type ChangesetPolicy,
+} from "./changeset-guard";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const EMPTY_CHANGESET = "---\n---\n";
+const OUTPUT_PATH = /^\.changeset\/dependabot-dev-dependencies-[1-9]\d*\.md$/u;
+const DEV_DEPENDENCIES = "devDependencies";
+const COMMIT_SHA = /^[0-9a-f]{40}$/u;
+
+class DependabotChangesetError extends Error {
+  readonly _tag = "DependabotChangesetError";
+}
+
+const panic = (message: string): never => {
+  throw new DependabotChangesetError(message);
+};
+
+type ManifestPair = {
+  readonly packagePath: string;
+  readonly base: string;
+  readonly head: string;
+};
+
+type DependabotEmptyChangesetInput = {
+  readonly policy: ChangesetPolicy;
+  readonly changedFiles: readonly string[];
+  readonly addedChangesetFiles: readonly string[];
+  readonly manifests: readonly ManifestPair[];
+};
+
+type RefusalReason =
+  | "runtime-change"
+  | "peer-change"
+  | "source-change"
+  | "mixed-change"
+  | "format-only"
+  | "malformed-manifest"
+  | "manifest-change";
+
+export type DependabotEmptyChangesetDecision =
+  | { readonly status: "create"; readonly packages: readonly string[] }
+  | {
+      readonly status: "noop";
+      readonly reason: "no-release-paths" | "existing-changeset";
+    }
+  | { readonly status: "refuse"; readonly reason: RefusalReason };
+
+type JsonObject = Readonly<Record<string, unknown>>;
+
+const isJsonObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isDependencyMap = (value: unknown): boolean =>
+  value === undefined ||
+  (isJsonObject(value) &&
+    Object.values(value).every((dependency) => typeof dependency === "string"));
+
+const parseManifest = (text: string): JsonObject | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  return isJsonObject(parsed) ? parsed : null;
+};
+
+type ManifestInspection =
+  | { readonly status: "eligible"; readonly packageName: string }
+  | { readonly status: "refuse"; readonly reason: RefusalReason };
+
+const inspectManifest = ({ base, head }: ManifestPair): ManifestInspection => {
+  const baseManifest = parseManifest(base);
+  const headManifest = parseManifest(head);
+  if (baseManifest === null || headManifest === null) {
+    return { status: "refuse", reason: "malformed-manifest" };
+  }
+
+  const packageName = headManifest["name"];
+  if (typeof packageName !== "string") {
+    return { status: "refuse", reason: "malformed-manifest" };
+  }
+
+  const keys = new Set([
+    ...Object.keys(baseManifest),
+    ...Object.keys(headManifest),
+  ]);
+  const changedKeys = [...keys].filter(
+    (key) => !isDeepStrictEqual(baseManifest[key], headManifest[key]),
+  );
+  if (changedKeys.length === 0) {
+    return { status: "refuse", reason: "format-only" };
+  }
+  if (changedKeys.length === 1 && changedKeys.at(0) === DEV_DEPENDENCIES) {
+    if (
+      !isDependencyMap(baseManifest[DEV_DEPENDENCIES]) ||
+      !isDependencyMap(headManifest[DEV_DEPENDENCIES])
+    ) {
+      return { status: "refuse", reason: "malformed-manifest" };
+    }
+    return { status: "eligible", packageName };
+  }
+  if (changedKeys.includes(DEV_DEPENDENCIES)) {
+    return { status: "refuse", reason: "mixed-change" };
+  }
+  if (changedKeys.includes("peerDependencies")) {
+    return { status: "refuse", reason: "peer-change" };
+  }
+  if (
+    changedKeys.some((key) =>
+      [
+        "dependencies",
+        "optionalDependencies",
+        "bundledDependencies",
+        "bundleDependencies",
+      ].includes(key),
+    )
+  ) {
+    return { status: "refuse", reason: "runtime-change" };
+  }
+  return { status: "refuse", reason: "manifest-change" };
+};
+
+export const decideDependabotEmptyChangeset = ({
+  policy,
+  changedFiles,
+  addedChangesetFiles,
+  manifests,
+}: DependabotEmptyChangesetInput): DependabotEmptyChangesetDecision => {
+  const gate = decideChangesetGate({
+    changedFiles,
+    addedFiles: addedChangesetFiles,
+    releasePaths: policy.releasePaths,
+  });
+  switch (gate.status) {
+    case "not-required":
+      return { status: "noop", reason: "no-release-paths" };
+    case "satisfied":
+      return { status: "noop", reason: "existing-changeset" };
+    case "missing": {
+      const hasNonManifestChange = changedFiles.some(
+        (file) =>
+          file !== "bun.lock" &&
+          file !== "package.json" &&
+          !file.endsWith("/package.json") &&
+          !isChangesetEntry(file),
+      );
+      if (hasNonManifestChange) {
+        return { status: "refuse", reason: "source-change" };
+      }
+
+      const packageFiles = new Set(policy.packageFiles);
+      if (gate.releaseFiles.some((file) => !packageFiles.has(file))) {
+        return { status: "refuse", reason: "source-change" };
+      }
+
+      const manifestByPath = new Map(
+        manifests.map((pair) => [pair.packagePath, pair]),
+      );
+      const inspections = [...new Set(gate.releaseFiles)].map((packagePath) => {
+        const pair = manifestByPath.get(packagePath);
+        if (pair === undefined) {
+          return {
+            status: "refuse",
+            reason: "malformed-manifest",
+          } satisfies ManifestInspection;
+        }
+        return inspectManifest(pair);
+      });
+      const refusals = inspections.filter(
+        (inspection) => inspection.status === "refuse",
+      );
+      if (refusals.length > 0) {
+        const eligibleCount = inspections.length - refusals.length;
+        return {
+          status: "refuse",
+          reason:
+            eligibleCount > 0 || refusals.length > 1
+              ? "mixed-change"
+              : refusals.at(0)?.reason ?? "malformed-manifest",
+        };
+      }
+
+      return {
+        status: "create",
+        packages: inspections.map((inspection) => {
+          if (inspection.status === "refuse") {
+            return panic("eligible manifest set contained a refusal");
+          }
+          return inspection.packageName;
+        }),
+      };
+    }
+    default: {
+      const unreachable: never = gate;
+      return unreachable;
+    }
+  }
+};
+
+type GitResult = { readonly ok: boolean; readonly stdout: string };
+
+const git = (args: readonly string[], root: string): GitResult => {
+  const result = Bun.spawnSync(["git", ...args], {
+    cwd: root,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return { ok: result.exitCode === 0, stdout: result.stdout.toString() };
+};
+
+const gitOutput = (args: readonly string[], root: string): string => {
+  const result = git(args, root);
+  if (!result.ok) {
+    return panic(`git ${args.join(" ")} failed`);
+  }
+  return result.stdout;
+};
+
+const gitPaths = (args: readonly string[], root: string): string[] =>
+  gitOutput(args, root).split("\0").filter(Boolean);
+
+type ReadRegularBlobOptions = {
+  readonly root: string;
+  readonly ref: string;
+  readonly packagePath: string;
+};
+
+const readRegularBlob = ({
+  root,
+  ref,
+  packagePath,
+}: ReadRegularBlobOptions): string | null => {
+  const entry = gitOutput(["ls-tree", "-z", ref, "--", packagePath], root);
+  const mode = entry.slice(0, entry.indexOf(" "));
+  if (mode !== "100644") {
+    return null;
+  }
+  return gitOutput(["show", `${ref}:${packagePath}`], root);
+};
+
+type CliOptions = {
+  readonly base: string;
+  readonly head: string;
+  readonly output: string;
+};
+
+const parseArgs = (args: readonly string[]): CliOptions => {
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args.at(index);
+    const value = args.at(index + 1);
+    if (flag === undefined || value === undefined || value === "") {
+      return panic(
+        "Usage: dependabot-empty-changeset.ts --base <sha> --head <sha> --output <path>",
+      );
+    }
+    switch (flag) {
+      case "--base":
+      case "--head":
+      case "--output":
+        break;
+      default:
+        return panic(`Unknown argument: ${flag}`);
+    }
+    if (values.has(flag)) {
+      return panic(`Duplicate argument: ${flag}`);
+    }
+    values.set(flag, value);
+  }
+
+  const base = values.get("--base");
+  const head = values.get("--head");
+  const output = values.get("--output");
+  if (base === undefined || head === undefined || output === undefined) {
+    return panic(
+      "Usage: dependabot-empty-changeset.ts --base <sha> --head <sha> --output <path>",
+    );
+  }
+  if (!OUTPUT_PATH.test(output)) {
+    return panic(`Invalid empty changeset output path: ${output}`);
+  }
+  if (!COMMIT_SHA.test(base) || !COMMIT_SHA.test(head)) {
+    return panic("Dependabot changeset refs must be full commit SHAs");
+  }
+  return { base, head, output };
+};
+
+export const runDependabotEmptyChangeset = (
+  args: readonly string[],
+  root: string = REPO_ROOT,
+): number => {
+  const { base, head, output } = parseArgs(args);
+  const checkedOutHead = gitOutput(["rev-parse", "HEAD"], root).trim();
+  const exactHead = gitOutput(["rev-parse", `${head}^{commit}`], root).trim();
+  if (checkedOutHead !== exactHead) {
+    panic(`Checked-out HEAD ${checkedOutHead} does not match ${exactHead}`);
+  }
+  const exactBase = gitOutput(["rev-parse", `${base}^{commit}`], root).trim();
+  const mergeBase = gitOutput(
+    ["merge-base", exactBase, exactHead],
+    root,
+  ).trim();
+  if (mergeBase === "") {
+    panic(`No merge base between ${exactBase} and ${exactHead}`);
+  }
+
+  const changedFiles = gitPaths(
+    [
+      "diff",
+      "--name-only",
+      "-z",
+      "--diff-filter=ACMRD",
+      mergeBase,
+      exactHead,
+    ],
+    root,
+  );
+  const addedChangesetFiles = gitPaths(
+    [
+      "diff",
+      "--name-only",
+      "-z",
+      "--diff-filter=A",
+      mergeBase,
+      exactHead,
+      "--",
+      ".changeset/*.md",
+    ],
+    root,
+  );
+  const policy = loadChangesetPolicy(root);
+  const changedSet = new Set(changedFiles);
+  const manifests = policy.packageFiles.flatMap((packagePath) => {
+    if (!changedSet.has(packagePath)) {
+      return [];
+    }
+    const baseManifest = readRegularBlob({
+      root,
+      ref: mergeBase,
+      packagePath,
+    });
+    const headManifest = readRegularBlob({
+      root,
+      ref: exactHead,
+      packagePath,
+    });
+    return baseManifest === null || headManifest === null
+      ? []
+      : [{ packagePath, base: baseManifest, head: headManifest }];
+  });
+
+  const decision = decideDependabotEmptyChangeset({
+    policy,
+    changedFiles,
+    addedChangesetFiles,
+    manifests,
+  });
+  switch (decision.status) {
+    case "noop":
+      process.stdout.write(`dependabot changeset: ${decision.reason}\n`);
+      return 0;
+    case "refuse":
+      process.stdout.write(`dependabot changeset: refused ${decision.reason}\n`);
+      return 0;
+    case "create": {
+      const absoluteOutput = path.join(root, output);
+      if (lstatSync(absoluteOutput, { throwIfNoEntry: false }) !== undefined) {
+        panic(`Refusing to overwrite ${output}`);
+      }
+      writeFileSync(absoluteOutput, EMPTY_CHANGESET, { flag: "wx" });
+      process.stdout.write(
+        `dependabot changeset: created ${output} for ${decision.packages.join(", ")}\n`,
+      );
+      return 0;
+    }
+    default: {
+      const unreachable: never = decision;
+      return unreachable;
+    }
+  }
+};
+
+if (import.meta.main) {
+  process.exit(runDependabotEmptyChangeset(process.argv.slice(2)));
+}

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -292,7 +292,8 @@ run_step "Maintenance release preparation self-test" bun test \
   scripts/prepare-maintenance-release.property.test.ts
 run_step "Desktop-release-changes self-test" bash scripts/detect-desktop-release-changes.test.sh
 run_step "Dependabot Bun autofix self-test" bun test \
-  scripts/autofix-workflow.test.ts
+  scripts/autofix-workflow.test.ts \
+  scripts/dependabot-empty-changeset.test.ts
 run_step "Bridge-version guard" bash scripts/check-bridge-version.sh
 
 echo


### PR DESCRIPTION
Generalize the Dependabot Bun autofix boundary to cover published package manifests from the release policy. Only semantically devDependency-only changes receive an empty changeset; consumer-visible and ambiguous changes remain gated for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated handling for eligible development-dependency updates by generating an empty Changeset.
  * Added safeguards to reject unsafe, malformed, or unsupported dependency changes.

* **Bug Fixes**
  * Improved autofix validation to verify trusted workflow sources, commit state, output paths, and existing files.

* **Tests**
  * Expanded CI and self-test coverage for dependency changeset generation and autofix workflow safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->