### PR TITLE
fix(cli): document command flags and the capability path in the agent skill

### DIFF
--- a/.changeset/cli-skill-flags-and-capability-path.md
+++ b/.changeset/cli-skill-flags-and-capability-path.md
@@ -1,0 +1,12 @@
+---
+"@stll/cli": patch
+---
+
+The generated agent skill (`stella-cli/SKILL.md`) now documents every curated
+command's flags (name, required/optional, type, one-line description) and adds
+a "When no curated command fits" section: the live capability domain list, two
+worked `stella capability <domain> <action>` examples, and a note that
+`--input` JSON keys follow the schema's own casing (snake_case for curated
+tools, camelCase for capability commands) rather than a guessable convention.
+It also states that the CLI cannot upload a binary file (a new document
+version), which needs an MCP-connected client or the web app instead.

--- a/packages/cli/skills/stella-cli/SKILL.md
+++ b/packages/cli/skills/stella-cli/SKILL.md
@@ -71,7 +71,7 @@ session with `--scopes`; the default scopes are
   (windowed, so follow `--cursor`).
 - **MCP resources**: `stella reference list` enumerates static server resources;
   `stella reference show <name>` prints one.
-- **No binary uploads**: the CLI cannot upload a new document version (a file) — `upload_document_version`/`open_document_version_upload` are MCP-only, excluded from the CLI. Upload a new version through an MCP-connected client or the stella web app.
+- **Uploading a file**: `stella upload --file <file> --matter-id <matter-id>` uploads a local file as a new document; add `--entity-id <id>` to upload it as a new version of an existing document instead — a CLI-native path (the CLI reads the file itself), separate from the MCP `upload_document_version`/`open_document_version_upload` tools (which take a host-supplied file reference and are excluded from the CLI).
 
 ## Command tree
 
@@ -301,8 +301,8 @@ invoke <id> --input '<json>'`, where the JSON is `{ body?, params?, query? }`.
 The curated commands above cover common tasks; anything else goes through the
 generic capability path. Current domains: `audit-logs`, `billing-codes`, `case-law`, `catalogue`, `chat`, `clauses`, `contacts`, `document-types`, `entities`, `expenses`, `fields`, `flows`, `invoices`, `legislation`, `lists`, `organization-settings`, `playbooks`, `properties`, `rates`, `reports`, `signals`, `skills`, `style-sets`, `tasks`, `template-packs`, `template-recipes`, `templates`, `time-entries`, `uploads`, `usage`, `view-templates`, `views`, `work-obligations`, `workspaces`.
 
-- Translate a document: `stella capability entities translate --field-id <id> --target-lang <lang>`.
-- Start workflow extraction: `stella capability workspaces workflow-start --workspace <id>`.
+- Translate a document: `stella capability entities translate --workspace <workspace> --field-id <field-id> --target-lang <target-lang>`.
+- Start workflow extraction: `stella capability workspaces workflow-start --workspace <workspace>`.
 - **`--input` casing is not uniform; never guess it.** A curated command's
   `--input` JSON (the table and flags above) uses the MCP tool schema's own
   keys, snake_case (`matter_id`, `contact_id`). A capability command's

--- a/packages/cli/skills/stella-cli/SKILL.md
+++ b/packages/cli/skills/stella-cli/SKILL.md
@@ -71,62 +71,7 @@ session with `--scopes`; the default scopes are
   (windowed, so follow `--cursor`).
 - **MCP resources**: `stella reference list` enumerates static server resources;
   `stella reference show <name>` prints one.
-
-## Exit codes
-
-| Code | Meaning                                                       |
-| ---- | ------------------------------------------------------------- |
-| 0    | success                                                       |
-| 1    | unexpected internal error                                     |
-| 2    | usage or input validation error                               |
-| 3    | authentication required or failed (run `stella auth login`)   |
-| 4    | server or tool error                                          |
-| 5    | feature disabled for this organization                        |
-| 6    | resource not found                                            |
-| 7    | confirmation aborted (a destructive op was declined)          |
-| 8    | permission denied (member role lacks the required permission) |
-| 9    | usage entitlement exceeded                                    |
-| 10   | conflict with current state (duplicate or concurrent change)  |
-
-The exit code lines up with the tool-error `code`: `validation_error` -> 2,
-`missing_scope` -> 3, `feature_disabled` -> 5, `not_found` -> 6,
-`confirmation_required` -> 7, and `rate_limited` / `upstream_unavailable` /
-`unknown_tool` / `internal_error` -> 4. A legacy server that tags only a bare `feature_disabled`
-code (no envelope) still maps to 5; anything else falls to 4.
-
-## Capability commands (full surface)
-
-Beyond the curated commands above, the CLI generates 321
-capability commands from the server's capability catalog: every safe handler
-that is not a curated tool, reached through the generic `invoke_capability`
-path. Every generated command lives at `stella capability <domain> <action>`;
-multi-segment capability actions are flattened with hyphens into `<action>`.
-
-- **Discover**: `stella capability list [--domain <d>] [--access read|write]`
-  enumerates them (paginated); `stella capability describe <id>` prints one
-  capability's full input schema, scope, and flags.
-- **Invoke by id** (forward-compatible with any server): `stella capability
-invoke <id> --input '<json>'`, where the JSON is `{ body?, params?, query? }`.
-- **Flags**: each capability command derives flags from its input schema;
-  workspace-scoped capabilities take a required `--workspace <id>`. Deep or
-  ambiguous payloads use `--input` (the whole `{ body?, params?, query? }`).
-- **Dry run**: `--dry-run` validates the input server-side and returns without
-  executing (maps to `validate_only`).
-- **Destructive** capabilities prompt on a TTY and need `--yes` off a TTY; the
-  server's per-capability confirm gate is satisfied automatically once confirmed.
-- Exit codes are identical to the curated commands (see above).
-
-## Filing feedback
-
-`stella feedback send` files a bug, feature request, or docs issue with the
-maintainers. Content is sanitized server-side (emails, ids, secrets, URLs, and
-IPs are redacted); never include tenant data, client or matter names, ids, or
-secrets: describe the problem, reproduction steps, and expected vs actual
-result. Pass `--kind`, `--title`, and `--body`.
-
-- **github** (preferred): returns a prefilled new-issue URL and a `gh` command
-  the human opens and submits under their own GitHub account. The CLI never
-  publishes anything itself.
+- **No binary uploads**: the CLI cannot upload a new document version (a file) — `upload_document_version`/`open_document_version_upload` are MCP-only, excluded from the CLI. Upload a new version through an MCP-connected client or the stella web app.
 
 ## Command tree
 
@@ -182,3 +127,346 @@ requires (request it at `stella auth login --scopes`).
 | time-entry   | `stella time-entry list`                   | read                        | paginated                             |
 | time-entry   | `stella time-entry save`                   | billing_write               |                                       |
 | usage        | `stella usage get`                         | read                        |                                       |
+
+## Command flags
+
+Every curated command's flags, same order as the table above. Each flag
+line is `--flag — description (required|optional, type)`; an enum lists its
+values and a repeatable flag is passed once per value. `stella <command>
+--help` prints the identical facts plus a full JSON `--input` example.
+
+- `stella audit-log list`
+  - `--matter-id` — Only entries scoped to this matter/workspace (optional, string)
+  - `--action` — Only entries with this audit action (optional, string)
+  - `--resource-type` — Only entries about this resource type (optional, string)
+  - `--resource-id` — Only entries about this resource id; requires resource_type (optional, string)
+  - `--user-id` — Only entries whose actor is this user (optional, string)
+  - `--from` — Only entries created on or after this ISO date-time (optional, string)
+  - `--to` — Only entries created on or before this ISO date-time (optional, string)
+
+- `stella capability describe`
+  - `--capability` — Capability id to describe, as returned by list_capabilities (e.g. "time-entries.create"). (required, string)
+
+- `stella capability invoke`
+  - `--capability` — Capability id to invoke, as returned by list_capabilities. (required, string)
+  - `--validate-only` — When true, validate the input against the capability schema and return without executing. (optional, boolean)
+
+- `stella capability list`
+  - `--domain` — Filter to one capability domain: the id prefix before the first dot (e.g. "time-entries", "invoices"). (optional, string)
+  - `--access` — Filter by access level. (optional, enum: all, read, write)
+
+- `stella case-law read`
+  - `--decision-id` — Case-law decision ID (required, string)
+
+- `stella case-law search`
+  - `--query` — Search query (required, string)
+  - `--court` — Filter by court name (optional, string)
+  - `--country` — Filter by country code (optional, string)
+  - `--language` — Filter by language code (optional, string)
+  - `--decision-type` — Filter by decision type (optional, string)
+  - `--source-id` — Filter by source ID (optional, string)
+  - `--date-from` — Filter decisions from this ISO date (YYYY-MM-DD) (optional, string)
+  - `--date-to` — Filter decisions up to this ISO date (YYYY-MM-DD) (optional, string)
+
+- `stella clause delete`
+  - `--clause-id` — Clause id to delete (required, string)
+
+- `stella clause list`
+  - `--clause-id` — Clause id to read in detail; omit to list (optional, string)
+  - `--version-id` — With clause_id, return this version's body instead of the current clause (optional, string)
+  - `--category-id` — List only clauses filed under this category (list mode) (optional, string)
+  - `--query` — Filter clauses by a text query over title and body (list mode) (optional, string)
+  - `--include-categories` — Also return the organization's clause categories (list mode) (optional, boolean)
+
+- `stella clause save`
+  - `--clause-id` — Clause id to update; omit to create (optional, string)
+  - `--title` — Clause title; required when creating (optional, string)
+  - `--category-id` — Category id to file the clause under; pass null to clear (optional, nullable-string)
+  - `--language` — BCP-47 language tag for the clause; pass null to clear (optional, nullable-string)
+  - `--description` — Short clause description; pass null to clear (optional, nullable-string)
+  - `--usage-notes` — Guidance on when to use the clause; pass null to clear (optional, nullable-string)
+  - `--snapshot-version` — When updating, also append a version snapshot of the body (optional, boolean)
+
+- `stella contact delete`
+  - `--contact-id` — Contact ID to delete (required, string)
+
+- `stella contact list`
+  - `--query` — Search contact display names (optional, string)
+  - `--type` — Contact kind (optional, enum: person, organization)
+
+- `stella contact lookup-registry`
+  - `--registry` — Business register to query (required, enum: ares, brreg, companies-house, denue, edgar, gcis, krs, orsr, prh, recherche-entreprises, vies)
+  - `--query` — Canonical identifier (e.g. company number, VAT number) or company name (required, string)
+
+- `stella contact read`
+  - `--contact-id` — Contact ID (required, string)
+
+- `stella contact save`
+  - `--contact-id` — Contact ID to update; omit to create (optional, string)
+  - `--type` — Contact kind; required when creating (optional, enum: person, organization)
+  - `--display-name` — Display name; when creating it defaults to first + last name (person) or organization name (organization); non-empty when updating (optional, string)
+  - `--first-name` — First name; pass null to clear (optional, nullable-string)
+  - `--last-name` — Last name; pass null to clear (optional, nullable-string)
+  - `--organization-name` — Organization name; pass null to clear (optional, nullable-string)
+  - `--notes` — Free-text notes; pass null to clear (optional, nullable-string)
+
+- `stella document content`
+  - `--entity-id` — Entity ID (required, string)
+
+- `stella document delete`
+  - `--entity-id` — Document entity ID to delete (required, string)
+  - `--version-id` — Delete only this version instead of the whole document (optional, string)
+
+- `stella document field set`
+  - `--entity-id` — Document entity ID whose cell to set (required, string)
+  - `--property-id` — Property ID, as returned by list_properties (required, string)
+
+- `stella document list`
+  - `--matter-id` — Matter/workspace ID to list documents in (required, string)
+  - `--mode` — 'flat' lists every document and folder in the matter; 'children' lists only the direct children of parent_id (or the matter root when parent_id is omitted). Defaults to 'flat', or 'children' when parent_id is provided. Passing parent_id with mode 'flat' is rejected. (optional, enum: flat, children)
+  - `--parent-id` — Folder entity ID whose direct children to list. Only valid in children mode; supplying it selects children mode when mode is omitted and is rejected together with mode 'flat'. (optional, string)
+
+- `stella document properties list`
+  - `--matter-id` — Matter/workspace ID to list properties for (required, string)
+
+- `stella document read`
+  - `--entity-id` — Document entity ID (required, string)
+  - `--version-id` — Return this version's metadata and field values instead of the current version (optional, string)
+  - `--compare-with-version-id` — With version_id, return a plain-text line diff of this version (base) against version_id (target) (optional, string)
+  - `--include-versions` — Also return the document's version history (optional, boolean)
+  - `--versions-cursor` — Opaque cursor from a previous call to fetch the next page of version history (optional, string)
+
+- `stella document save`
+  - `--entity-id` — Document entity ID to update; omit to create (optional, string)
+  - `--matter-id` — Matter/workspace ID to create the entity in; required when creating (optional, string)
+  - `--name` — Display name: required when creating, or the new name when renaming (optional, string)
+  - `--parent-id` — Folder entity ID: to place the new entity inside when creating, or to move the document into when updating (optional, string)
+  - `--kind` — Entity kind to create; defaults to 'document'. Only valid when creating. (optional, enum: document, folder)
+  - `--move-to-root` — Move the document to the matter root (no parent folder). Only valid when updating. (optional, boolean)
+  - `--version-id` — Version ID to annotate; required when setting label or description. Only valid when updating. (optional, string)
+  - `--label` — New label for version_id; pass null to clear, empty string is not allowed, omit to leave unchanged (optional, nullable-string)
+  - `--description` — New description for version_id; pass null to clear, empty string is not allowed, omit to leave unchanged (optional, nullable-string)
+
+- `stella feedback send`
+  - `--kind` — Feedback category: bug, feature_request, docs, or other (required, enum: bug, feature_request, docs, other)
+  - `--title` — Short one-line summary of the issue; no tenant data, ids, or secrets (required, string)
+  - `--body` — Markdown details: reproduction steps, expected vs actual behavior, environment. Never include tenant data, client or matter names, ids, or secrets; they are redacted server-side. (required, string)
+  - `--channel` — Delivery channel. github returns a prefilled issue URL the human submits under their own GitHub account. (optional, enum: github)
+
+- `stella invoice list`
+  - `--matter-id` — Matter/workspace ID to list invoices in; required unless invoice_id is given (optional, string)
+  - `--invoice-id` — Invoice ID to read in detail (optional, string)
+
+- `stella legislation search`
+  - `--query` — Free-text search over consolidated legislation (optional, string)
+  - `--title` — Filter search results by title text (optional, string)
+  - `--department-code` — Filter search results by department code (optional, string)
+  - `--legal-range-code` — Filter search results by legal-range code (law rank) (optional, string)
+  - `--matter-code` — Filter search results by subject-matter code (optional, string)
+  - `--date-from` — Only laws published on or after this date (YYYYMMDD) (optional, string)
+  - `--date-to` — Only laws published on or before this date (YYYYMMDD) (optional, string)
+  - `--law-id` — BOE consolidated-law id (e.g. BOE-A-1889-4763) to read; omit to search (optional, string)
+  - `--block-id` — With law_id, return this text block's content instead of the whole law (optional, string)
+  - `--relation-type` — With law_id, list related laws of this relation kind instead of the law body (optional, enum: modifies, modifiedBy, derogates, derogatedBy, all)
+  - `--full-text` — With law_id (no block_id/relation_type), include the consolidated full text (optional, boolean)
+
+- `stella matter delete`
+  - `--matter-id` — Matter/workspace ID to delete (required, string)
+
+- `stella matter link-contact`
+  - `--matter-id` — Matter/workspace ID (required, string)
+  - `--contact-id` — Contact ID: with role to link the contact, or alone to unlink it from the matter (optional, string)
+  - `--role` — Party role for the linked contact; provide it only when linking (optional, enum: opposing_party, opposing_counsel, co_counsel, witness, expert_witness, third_party, judge, mediator, other)
+  - `--workspace-contact-id` — Existing matter-contact link ID to remove, from list_matters (optional, string)
+
+- `stella matter list`
+  - `--matter-id` — Matter/workspace ID to return a single matter's overview; omit to list matters (optional, string)
+  - `--status` — Filter by matter status (list mode) (optional, enum: active, all)
+
+- `stella matter save`
+  - `--matter-id` — Matter/workspace ID to update; omit to create a new matter (optional, string)
+  - `--name` — Matter name; required when creating (optional, string)
+  - `--client-id` — Contact ID to attach in the client role. Only valid when creating a matter. (optional, string)
+  - `--reference` — Matter reference (file number). Only valid when updating. (optional, string)
+  - `--billing-reference` — Billing reference; pass null to clear. Only valid when updating. (optional, nullable-string)
+  - `--status` — Set 'archived' to archive the matter or 'active' to unarchive it. Only valid when updating. (optional, enum: active, archived)
+
+- `stella organization add-member`
+  - `--matter-id` — Matter/workspace id for add_member and remove_member (required, string)
+  - `--user-id` — User id to add or remove for the member actions (required, string)
+
+- `stella organization remove-member`
+  - `--matter-id` — Matter/workspace id for add_member and remove_member (required, string)
+  - `--user-id` — User id to add or remove for the member actions (required, string)
+
+- `stella organization set-jurisdictions` — no flags; pass `--input` with jurisdictions
+
+- `stella organization update-settings`
+  - `--matter-number-pattern` — Matter-number pattern (update_org_settings); send with matter_number_padding (optional, string)
+  - `--matter-number-padding` — Matter-number zero-padding width (update_org_settings); send with matter_number_pattern (optional, int 1..6)
+  - `--prompt-caching-enabled` — Toggle AI prompt caching for the organization (update_org_settings) (optional, boolean)
+  - `--document-processing-mode` — Set automatic PDF searchable-text extraction for the organization (update_org_settings) (optional, enum: off, searchable-text)
+
+- `stella playbook list`
+  - `--playbook-id` — Playbook id to read in detail; omit to list playbooks (optional, string)
+
+- `stella playbook run`
+  - `--matter-id` — Matter/workspace id to run the playbook over (required, string)
+  - `--playbook-id` — Playbook id to run (required, string)
+
+- `stella rate resolve`
+  - `--matter-id` — Matter/workspace ID to resolve the rate in (required, string)
+  - `--user-id` — User ID to resolve the rate for (required, string)
+  - `--date` — Date to resolve the rate on (ISO YYYY-MM-DD) (required, string)
+
+- `stella search matters`
+  - `--query` — Search query (required, string)
+
+- `stella task list`
+  - `--matter-id` — Matter/workspace ID to list tasks in; required unless task_id is given (optional, string)
+  - `--task-id` — Task entity ID to read in detail (optional, string)
+  - `--date-from` — List only tasks due on or after this ISO date (YYYY-MM-DD) (optional, string)
+  - `--date-to` — List only tasks due on or before this ISO date (YYYY-MM-DD) (optional, string)
+  - `--status` — List only tasks with this status (optional, string)
+
+- `stella task save`
+  - `--task-id` — Task entity ID to update; omit to create (optional, string)
+  - `--matter-id` — Matter/workspace ID to create the task in; required when creating (optional, string)
+  - `--name` — Task name; required when creating (optional, string)
+  - `--status` — Task status (e.g. open, in_progress, done) (optional, string)
+  - `--priority` — Task priority (e.g. none, low, medium, high) (optional, string)
+  - `--item-type` — What the List item represents (optional, enum: task, fact, issue, requirement, event)
+  - `--list-id` — List ID to create the item in (creating only) (optional, string)
+  - `--list-section-id` — Section of list_id to create the item under (creating only) (optional, string)
+  - `--list-description` — List item description; pass null to clear (optional, nullable-string)
+  - `--due-date` — Due date (ISO YYYY-MM-DD); pass null to clear (optional, nullable-string)
+  - `--workflow-reason` — Reason for a governed status or deadline change (optional, string)
+  - `--add-assignee-user-id` — User ID to assign to the task (must be a workspace member) (optional, string)
+  - `--remove-assignee-user-id` — User ID to unassign from the task (optional, string)
+  - `--link-entity-id` — Entity ID to link to the task (document, folder, or another task) (optional, string)
+  - `--unlink-link-id` — Entity-link ID to remove (optional, string)
+
+- `stella template fill`
+  - `--template-id` — Template id, as returned by list_templates (required, string)
+  - `--allow-unused-values` — Allow value keys that do not match template fields. Defaults to false so misspelled field paths fail loudly. (optional, boolean)
+  - `--completion-mode` — Require every placeholder by default; use allow_partial only for an intentionally incomplete document. (optional, enum: require_complete, allow_partial)
+
+- `stella template list`
+  - `--template-id` — Template id to describe its fields in detail; omit to list templates (optional, string)
+
+- `stella template save`
+  - `--template-id` — Template to configure; omit when creating (optional, string)
+  - `--name` — Display name; required when creating (optional, string)
+  - `--docx-base64` — Base64 DOCX bytes; required when creating (optional, string)
+
+- `stella template save-filled new-document`
+  - `--template-id` — Template id, as returned by list_templates (required, string)
+  - `--matter-id` — Matter/workspace receiving the filled DOCX (required, string)
+  - `--idempotency-key` — Unique retry key for this save operation; reuse it only to recover the same timed-out request (required, string)
+  - `--parent-id` — Folder entity id for a new document; valid only for create_document (optional, string)
+  - `--name` — Optional DOCX file name; defaults to the template file name (optional, string)
+
+- `stella template save-filled new-version`
+  - `--template-id` — Template id, as returned by list_templates (required, string)
+  - `--matter-id` — Matter/workspace receiving the filled DOCX (required, string)
+  - `--idempotency-key` — Unique retry key for this save operation; reuse it only to recover the same timed-out request (required, string)
+  - `--entity-id` — Existing document entity id; required only for create_version (required, string)
+  - `--name` — Optional DOCX file name; defaults to the template file name (optional, string)
+
+- `stella time-entry delete`
+  - `--time-entry-id` — Time entry ID to delete or write off (required, string)
+
+- `stella time-entry list`
+  - `--matter-id` — Matter/workspace ID to list time entries in; required unless time_entry_id is given (optional, string)
+  - `--time-entry-id` — Time entry ID to read in detail (optional, string)
+  - `--entity-id` — List only entries logged against this entity (document, folder, or task the time is billed to) (optional, string)
+  - `--user-id` — List only entries recorded by this user (optional, string)
+  - `--date-from` — List only entries worked on or after this ISO date (YYYY-MM-DD) (optional, string)
+  - `--date-to` — List only entries worked on or before this ISO date (YYYY-MM-DD) (optional, string)
+  - `--status` — List only entries with this status (optional, enum: draft, approved, billed, written_off)
+
+- `stella time-entry save`
+  - `--time-entry-id` — Time entry ID to update; omit to create (optional, string)
+  - `--matter-id` — Matter/workspace ID to create the entry in; required when creating (optional, string)
+  - `--entity-id` — Optional work item context (document, folder, or task). When updating, moves the entry to a different entity in the same matter; pass null to clear. (optional, nullable-string)
+  - `--date-worked` — Date the work was done (ISO YYYY-MM-DD); required when creating (optional, string)
+  - `--timezone-id` — IANA time zone the date_worked is interpreted in (e.g. Europe/Prague); required when creating or changing date_worked (optional, string)
+  - `--duration-minutes` — Minutes worked (whole minutes); required when creating (optional, int 1..inf)
+  - `--narrative` — Description of the work; required when creating (optional, string)
+  - `--invoice-narrative` — Client-facing narrative shown on the invoice; pass null to clear. Only valid when updating. (optional, nullable-string)
+  - `--billable` — Whether the entry is billable to the client (optional, boolean)
+  - `--no-charge` — Whether the entry is recorded but not charged. Only valid when updating. (optional, boolean)
+  - `--task-code` — UTBMS/LEDES task code; pass null to clear (optional, nullable-string)
+  - `--activity-code` — UTBMS/LEDES activity code; pass null to clear (optional, nullable-string)
+
+- `stella usage get` — no arguments
+
+## Exit codes
+
+| Code | Meaning                                                       |
+| ---- | ------------------------------------------------------------- |
+| 0    | success                                                       |
+| 1    | unexpected internal error                                     |
+| 2    | usage or input validation error                               |
+| 3    | authentication required or failed (run `stella auth login`)   |
+| 4    | server or tool error                                          |
+| 5    | feature disabled for this organization                        |
+| 6    | resource not found                                            |
+| 7    | confirmation aborted (a destructive op was declined)          |
+| 8    | permission denied (member role lacks the required permission) |
+| 9    | usage entitlement exceeded                                    |
+| 10   | conflict with current state (duplicate or concurrent change)  |
+
+The exit code lines up with the tool-error `code`: `validation_error` -> 2,
+`missing_scope` -> 3, `feature_disabled` -> 5, `not_found` -> 6,
+`confirmation_required` -> 7, and `rate_limited` / `upstream_unavailable` /
+`unknown_tool` / `internal_error` -> 4. A legacy server that tags only a bare `feature_disabled`
+code (no envelope) still maps to 5; anything else falls to 4.
+
+## Capability commands (full surface)
+
+Beyond the curated commands above, the CLI generates 321
+capability commands from the server's capability catalog: every safe handler
+that is not a curated tool, reached through the generic `invoke_capability`
+path. Every generated command lives at `stella capability <domain> <action>`;
+multi-segment capability actions are flattened with hyphens into `<action>`.
+
+- **Discover**: `stella capability list [--domain <d>] [--access read|write]`
+  enumerates them (paginated); `stella capability describe <id>` prints one
+  capability's full input schema, scope, and flags.
+- **Invoke by id** (forward-compatible with any server): `stella capability
+invoke <id> --input '<json>'`, where the JSON is `{ body?, params?, query? }`.
+- **Flags**: each capability command derives flags from its input schema;
+  workspace-scoped capabilities take a required `--workspace <id>`. Deep or
+  ambiguous payloads use `--input` (the whole `{ body?, params?, query? }`).
+- **Dry run**: `--dry-run` validates the input server-side and returns without
+  executing (maps to `validate_only`).
+- **Destructive** capabilities prompt on a TTY and need `--yes` off a TTY; the
+  server's per-capability confirm gate is satisfied automatically once confirmed.
+- Exit codes are identical to the curated commands (see above).
+
+### When no curated command fits
+
+The curated commands above cover common tasks; anything else goes through the
+generic capability path. Current domains: `audit-logs`, `billing-codes`, `case-law`, `catalogue`, `chat`, `clauses`, `contacts`, `document-types`, `entities`, `expenses`, `fields`, `flows`, `invoices`, `legislation`, `lists`, `organization-settings`, `playbooks`, `properties`, `rates`, `reports`, `signals`, `skills`, `style-sets`, `tasks`, `template-packs`, `template-recipes`, `templates`, `time-entries`, `uploads`, `usage`, `view-templates`, `views`, `work-obligations`, `workspaces`.
+
+- Translate a document: `stella capability entities translate --field-id <id> --target-lang <lang>`.
+- Start workflow extraction: `stella capability workspaces workflow-start --workspace <id>`.
+- **`--input` casing is not uniform; never guess it.** A curated command's
+  `--input` JSON (the table and flags above) uses the MCP tool schema's own
+  keys, snake_case (`matter_id`, `contact_id`). A capability command's
+  `--input` JSON uses the handler schema's own keys, camelCase (`fieldId`,
+  `workspaceId`). Run `stella <command> --help` or `stella capability describe
+<id>` and copy the field paths it prints.
+
+## Filing feedback
+
+`stella feedback send` files a bug, feature request, or docs issue with the
+maintainers. Content is sanitized server-side (emails, ids, secrets, URLs, and
+IPs are redacted); never include tenant data, client or matter names, ids, or
+secrets: describe the problem, reproduction steps, and expected vs actual
+result. Pass `--kind`, `--title`, and `--body`.
+
+- **github** (preferred): returns a prefilled new-issue URL and a `gh` command
+  the human opens and submits under their own GitHub account. The CLI never
+  publishes anything itself.

--- a/packages/cli/skills/stella-cli/SKILL.md
+++ b/packages/cli/skills/stella-cli/SKILL.md
@@ -130,275 +130,126 @@ requires (request it at `stella auth login --scopes`).
 
 ## Command flags
 
-Every curated command's flags, same order as the table above. Each flag
-line is `--flag — description (required|optional, type)`; an enum lists its
-values and a repeatable flag is passed once per value. `stella <command>
---help` prints the identical facts plus a full JSON `--input` example.
+Required: `--flag — description (type)`. Optional: one `optional: --a,
+--b (enum1|enum2)` line, names only (`--help` has full descriptions).
+Global flags (output/cursor/limit/all/yes/input; see Conventions above)
+are omitted here.
 
 - `stella audit-log list`
-  - `--matter-id` — Only entries scoped to this matter/workspace (optional, string)
-  - `--action` — Only entries with this audit action (optional, string)
-  - `--resource-type` — Only entries about this resource type (optional, string)
-  - `--resource-id` — Only entries about this resource id; requires resource_type (optional, string)
-  - `--user-id` — Only entries whose actor is this user (optional, string)
-  - `--from` — Only entries created on or after this ISO date-time (optional, string)
-  - `--to` — Only entries created on or before this ISO date-time (optional, string)
-
+  - optional: --matter-id, --action, --resource-type, --resource-id, --user-id, --from, --to
 - `stella capability describe`
-  - `--capability` — Capability id to describe, as returned by list_capabilities (e.g. "time-entries.create"). (required, string)
-
+  - `--capability` — Capability id to describe, as returned by list_capabilities (e.g. "time-entries.create"). (string)
 - `stella capability invoke`
-  - `--capability` — Capability id to invoke, as returned by list_capabilities. (required, string)
-  - `--validate-only` — When true, validate the input against the capability schema and return without executing. (optional, boolean)
-
+  - `--capability` — Capability id to invoke, as returned by list_capabilities. (string)
+  - optional: --validate-only
 - `stella capability list`
-  - `--domain` — Filter to one capability domain: the id prefix before the first dot (e.g. "time-entries", "invoices"). (optional, string)
-  - `--access` — Filter by access level. (optional, enum: all, read, write)
-
+  - optional: --domain, --access (all|read|write)
 - `stella case-law read`
-  - `--decision-id` — Case-law decision ID (required, string)
-
+  - `--decision-id` — Case-law decision ID (string)
 - `stella case-law search`
-  - `--query` — Search query (required, string)
-  - `--court` — Filter by court name (optional, string)
-  - `--country` — Filter by country code (optional, string)
-  - `--language` — Filter by language code (optional, string)
-  - `--decision-type` — Filter by decision type (optional, string)
-  - `--source-id` — Filter by source ID (optional, string)
-  - `--date-from` — Filter decisions from this ISO date (YYYY-MM-DD) (optional, string)
-  - `--date-to` — Filter decisions up to this ISO date (YYYY-MM-DD) (optional, string)
-
+  - `--query` — Search query (string)
+  - optional: --court, --country, --language, --decision-type, --source-id, --date-from, --date-to
 - `stella clause delete`
-  - `--clause-id` — Clause id to delete (required, string)
-
+  - `--clause-id` — Clause id to delete (string)
 - `stella clause list`
-  - `--clause-id` — Clause id to read in detail; omit to list (optional, string)
-  - `--version-id` — With clause_id, return this version's body instead of the current clause (optional, string)
-  - `--category-id` — List only clauses filed under this category (list mode) (optional, string)
-  - `--query` — Filter clauses by a text query over title and body (list mode) (optional, string)
-  - `--include-categories` — Also return the organization's clause categories (list mode) (optional, boolean)
-
+  - optional: --clause-id, --version-id, --category-id, --query, --include-categories
 - `stella clause save`
-  - `--clause-id` — Clause id to update; omit to create (optional, string)
-  - `--title` — Clause title; required when creating (optional, string)
-  - `--category-id` — Category id to file the clause under; pass null to clear (optional, nullable-string)
-  - `--language` — BCP-47 language tag for the clause; pass null to clear (optional, nullable-string)
-  - `--description` — Short clause description; pass null to clear (optional, nullable-string)
-  - `--usage-notes` — Guidance on when to use the clause; pass null to clear (optional, nullable-string)
-  - `--snapshot-version` — When updating, also append a version snapshot of the body (optional, boolean)
-
+  - optional: --clause-id, --title, --category-id, --language, --description, --usage-notes, --snapshot-version
 - `stella contact delete`
-  - `--contact-id` — Contact ID to delete (required, string)
-
+  - `--contact-id` — Contact ID to delete (string)
 - `stella contact list`
-  - `--query` — Search contact display names (optional, string)
-  - `--type` — Contact kind (optional, enum: person, organization)
-
+  - optional: --query, --type (person|organization)
 - `stella contact lookup-registry`
-  - `--registry` — Business register to query (required, enum: ares, brreg, companies-house, denue, edgar, gcis, krs, orsr, prh, recherche-entreprises, vies)
-  - `--query` — Canonical identifier (e.g. company number, VAT number) or company name (required, string)
-
+  - `--registry` — Business register to query (enum: ares, brreg, companies-house, denue, edgar, gcis, krs, orsr, prh, recherche-entreprises, vies)
+  - `--query` — Canonical identifier (e.g. company number, VAT number) or company name (string)
 - `stella contact read`
-  - `--contact-id` — Contact ID (required, string)
-
+  - `--contact-id` — Contact ID (string)
 - `stella contact save`
-  - `--contact-id` — Contact ID to update; omit to create (optional, string)
-  - `--type` — Contact kind; required when creating (optional, enum: person, organization)
-  - `--display-name` — Display name; when creating it defaults to first + last name (person) or organization name (organization); non-empty when updating (optional, string)
-  - `--first-name` — First name; pass null to clear (optional, nullable-string)
-  - `--last-name` — Last name; pass null to clear (optional, nullable-string)
-  - `--organization-name` — Organization name; pass null to clear (optional, nullable-string)
-  - `--notes` — Free-text notes; pass null to clear (optional, nullable-string)
-
+  - optional: --contact-id, --type (person|organization), --display-name, --first-name, --last-name, --organization-name, --notes
 - `stella document content`
-  - `--entity-id` — Entity ID (required, string)
-
+  - `--entity-id` — Entity ID (string)
 - `stella document delete`
-  - `--entity-id` — Document entity ID to delete (required, string)
-  - `--version-id` — Delete only this version instead of the whole document (optional, string)
-
+  - `--entity-id` — Document entity ID to delete (string)
+  - optional: --version-id
 - `stella document field set`
-  - `--entity-id` — Document entity ID whose cell to set (required, string)
-  - `--property-id` — Property ID, as returned by list_properties (required, string)
-
+  - `--entity-id` — Document entity ID whose cell to set (string)
+  - `--property-id` — Property ID, as returned by list_properties (string)
 - `stella document list`
-  - `--matter-id` — Matter/workspace ID to list documents in (required, string)
-  - `--mode` — 'flat' lists every document and folder in the matter; 'children' lists only the direct children of parent_id (or the matter root when parent_id is omitted). Defaults to 'flat', or 'children' when parent_id is provided. Passing parent_id with mode 'flat' is rejected. (optional, enum: flat, children)
-  - `--parent-id` — Folder entity ID whose direct children to list. Only valid in children mode; supplying it selects children mode when mode is omitted and is rejected together with mode 'flat'. (optional, string)
-
+  - `--matter-id` — Matter/workspace ID to list documents in (string)
+  - optional: --mode (flat|children), --parent-id
 - `stella document properties list`
-  - `--matter-id` — Matter/workspace ID to list properties for (required, string)
-
+  - `--matter-id` — Matter/workspace ID to list properties for (string)
 - `stella document read`
-  - `--entity-id` — Document entity ID (required, string)
-  - `--version-id` — Return this version's metadata and field values instead of the current version (optional, string)
-  - `--compare-with-version-id` — With version_id, return a plain-text line diff of this version (base) against version_id (target) (optional, string)
-  - `--include-versions` — Also return the document's version history (optional, boolean)
-  - `--versions-cursor` — Opaque cursor from a previous call to fetch the next page of version history (optional, string)
-
+  - `--entity-id` — Document entity ID (string)
+  - optional: --version-id, --compare-with-version-id, --include-versions, --versions-cursor
 - `stella document save`
-  - `--entity-id` — Document entity ID to update; omit to create (optional, string)
-  - `--matter-id` — Matter/workspace ID to create the entity in; required when creating (optional, string)
-  - `--name` — Display name: required when creating, or the new name when renaming (optional, string)
-  - `--parent-id` — Folder entity ID: to place the new entity inside when creating, or to move the document into when updating (optional, string)
-  - `--kind` — Entity kind to create; defaults to 'document'. Only valid when creating. (optional, enum: document, folder)
-  - `--move-to-root` — Move the document to the matter root (no parent folder). Only valid when updating. (optional, boolean)
-  - `--version-id` — Version ID to annotate; required when setting label or description. Only valid when updating. (optional, string)
-  - `--label` — New label for version_id; pass null to clear, empty string is not allowed, omit to leave unchanged (optional, nullable-string)
-  - `--description` — New description for version_id; pass null to clear, empty string is not allowed, omit to leave unchanged (optional, nullable-string)
-
+  - optional: --entity-id, --matter-id, --name, --parent-id, --kind (document|folder), --move-to-root, --version-id, --label, --description
 - `stella feedback send`
-  - `--kind` — Feedback category: bug, feature_request, docs, or other (required, enum: bug, feature_request, docs, other)
-  - `--title` — Short one-line summary of the issue; no tenant data, ids, or secrets (required, string)
-  - `--body` — Markdown details: reproduction steps, expected vs actual behavior, environment. Never include tenant data, client or matter names, ids, or secrets; they are redacted server-side. (required, string)
-  - `--channel` — Delivery channel. github returns a prefilled issue URL the human submits under their own GitHub account. (optional, enum: github)
-
+  - `--kind` — Feedback category: bug, feature_request, docs, or other (enum: bug, feature_request, docs, other)
+  - `--title` — Short one-line summary of the issue; no tenant data, ids, or secrets (string)
+  - `--body` — Markdown details: reproduction steps, expected vs actual behavior, environment. Never include tenant data, client or matter names, ids, or secrets; they are redacted server-side. (string)
+  - optional: --channel (github)
 - `stella invoice list`
-  - `--matter-id` — Matter/workspace ID to list invoices in; required unless invoice_id is given (optional, string)
-  - `--invoice-id` — Invoice ID to read in detail (optional, string)
-
+  - optional: --matter-id, --invoice-id
 - `stella legislation search`
-  - `--query` — Free-text search over consolidated legislation (optional, string)
-  - `--title` — Filter search results by title text (optional, string)
-  - `--department-code` — Filter search results by department code (optional, string)
-  - `--legal-range-code` — Filter search results by legal-range code (law rank) (optional, string)
-  - `--matter-code` — Filter search results by subject-matter code (optional, string)
-  - `--date-from` — Only laws published on or after this date (YYYYMMDD) (optional, string)
-  - `--date-to` — Only laws published on or before this date (YYYYMMDD) (optional, string)
-  - `--law-id` — BOE consolidated-law id (e.g. BOE-A-1889-4763) to read; omit to search (optional, string)
-  - `--block-id` — With law_id, return this text block's content instead of the whole law (optional, string)
-  - `--relation-type` — With law_id, list related laws of this relation kind instead of the law body (optional, enum: modifies, modifiedBy, derogates, derogatedBy, all)
-  - `--full-text` — With law_id (no block_id/relation_type), include the consolidated full text (optional, boolean)
-
+  - optional: --query, --title, --department-code, --legal-range-code, --matter-code, --date-from, --date-to, --law-id, --block-id, --relation-type (modifies|modifiedBy|derogates|derogatedBy|all), --full-text
 - `stella matter delete`
-  - `--matter-id` — Matter/workspace ID to delete (required, string)
-
+  - `--matter-id` — Matter/workspace ID to delete (string)
 - `stella matter link-contact`
-  - `--matter-id` — Matter/workspace ID (required, string)
-  - `--contact-id` — Contact ID: with role to link the contact, or alone to unlink it from the matter (optional, string)
-  - `--role` — Party role for the linked contact; provide it only when linking (optional, enum: opposing_party, opposing_counsel, co_counsel, witness, expert_witness, third_party, judge, mediator, other)
-  - `--workspace-contact-id` — Existing matter-contact link ID to remove, from list_matters (optional, string)
-
+  - `--matter-id` — Matter/workspace ID (string)
+  - optional: --contact-id, --role (opposing_party|opposing_counsel|co_counsel|witness|expert_witness|third_party|judge|mediator|other), --workspace-contact-id
 - `stella matter list`
-  - `--matter-id` — Matter/workspace ID to return a single matter's overview; omit to list matters (optional, string)
-  - `--status` — Filter by matter status (list mode) (optional, enum: active, all)
-
+  - optional: --matter-id, --status (active|all)
 - `stella matter save`
-  - `--matter-id` — Matter/workspace ID to update; omit to create a new matter (optional, string)
-  - `--name` — Matter name; required when creating (optional, string)
-  - `--client-id` — Contact ID to attach in the client role. Only valid when creating a matter. (optional, string)
-  - `--reference` — Matter reference (file number). Only valid when updating. (optional, string)
-  - `--billing-reference` — Billing reference; pass null to clear. Only valid when updating. (optional, nullable-string)
-  - `--status` — Set 'archived' to archive the matter or 'active' to unarchive it. Only valid when updating. (optional, enum: active, archived)
-
+  - optional: --matter-id, --name, --client-id, --reference, --billing-reference, --status (active|archived)
 - `stella organization add-member`
-  - `--matter-id` — Matter/workspace id for add_member and remove_member (required, string)
-  - `--user-id` — User id to add or remove for the member actions (required, string)
-
+  - `--matter-id` — Matter/workspace id for add_member and remove_member (string)
+  - `--user-id` — User id to add or remove for the member actions (string)
 - `stella organization remove-member`
-  - `--matter-id` — Matter/workspace id for add_member and remove_member (required, string)
-  - `--user-id` — User id to add or remove for the member actions (required, string)
-
+  - `--matter-id` — Matter/workspace id for add_member and remove_member (string)
+  - `--user-id` — User id to add or remove for the member actions (string)
 - `stella organization set-jurisdictions` — no flags; pass `--input` with jurisdictions
-
 - `stella organization update-settings`
-  - `--matter-number-pattern` — Matter-number pattern (update_org_settings); send with matter_number_padding (optional, string)
-  - `--matter-number-padding` — Matter-number zero-padding width (update_org_settings); send with matter_number_pattern (optional, int 1..6)
-  - `--prompt-caching-enabled` — Toggle AI prompt caching for the organization (update_org_settings) (optional, boolean)
-  - `--document-processing-mode` — Set automatic PDF searchable-text extraction for the organization (update_org_settings) (optional, enum: off, searchable-text)
-
+  - optional: --matter-number-pattern, --matter-number-padding, --prompt-caching-enabled, --document-processing-mode (off|searchable-text)
 - `stella playbook list`
-  - `--playbook-id` — Playbook id to read in detail; omit to list playbooks (optional, string)
-
+  - optional: --playbook-id
 - `stella playbook run`
-  - `--matter-id` — Matter/workspace id to run the playbook over (required, string)
-  - `--playbook-id` — Playbook id to run (required, string)
-
+  - `--matter-id` — Matter/workspace id to run the playbook over (string)
+  - `--playbook-id` — Playbook id to run (string)
 - `stella rate resolve`
-  - `--matter-id` — Matter/workspace ID to resolve the rate in (required, string)
-  - `--user-id` — User ID to resolve the rate for (required, string)
-  - `--date` — Date to resolve the rate on (ISO YYYY-MM-DD) (required, string)
-
+  - `--matter-id` — Matter/workspace ID to resolve the rate in (string)
+  - `--user-id` — User ID to resolve the rate for (string)
+  - `--date` — Date to resolve the rate on (ISO YYYY-MM-DD) (string)
 - `stella search matters`
-  - `--query` — Search query (required, string)
-
+  - `--query` — Search query (string)
 - `stella task list`
-  - `--matter-id` — Matter/workspace ID to list tasks in; required unless task_id is given (optional, string)
-  - `--task-id` — Task entity ID to read in detail (optional, string)
-  - `--date-from` — List only tasks due on or after this ISO date (YYYY-MM-DD) (optional, string)
-  - `--date-to` — List only tasks due on or before this ISO date (YYYY-MM-DD) (optional, string)
-  - `--status` — List only tasks with this status (optional, string)
-
+  - optional: --matter-id, --task-id, --date-from, --date-to, --status
 - `stella task save`
-  - `--task-id` — Task entity ID to update; omit to create (optional, string)
-  - `--matter-id` — Matter/workspace ID to create the task in; required when creating (optional, string)
-  - `--name` — Task name; required when creating (optional, string)
-  - `--status` — Task status (e.g. open, in_progress, done) (optional, string)
-  - `--priority` — Task priority (e.g. none, low, medium, high) (optional, string)
-  - `--item-type` — What the List item represents (optional, enum: task, fact, issue, requirement, event)
-  - `--list-id` — List ID to create the item in (creating only) (optional, string)
-  - `--list-section-id` — Section of list_id to create the item under (creating only) (optional, string)
-  - `--list-description` — List item description; pass null to clear (optional, nullable-string)
-  - `--due-date` — Due date (ISO YYYY-MM-DD); pass null to clear (optional, nullable-string)
-  - `--workflow-reason` — Reason for a governed status or deadline change (optional, string)
-  - `--add-assignee-user-id` — User ID to assign to the task (must be a workspace member) (optional, string)
-  - `--remove-assignee-user-id` — User ID to unassign from the task (optional, string)
-  - `--link-entity-id` — Entity ID to link to the task (document, folder, or another task) (optional, string)
-  - `--unlink-link-id` — Entity-link ID to remove (optional, string)
-
+  - optional: --task-id, --matter-id, --name, --status, --priority, --item-type (task|fact|issue|requirement|event), --list-id, --list-section-id, --list-description, --due-date, --workflow-reason, --add-assignee-user-id, --remove-assignee-user-id, --link-entity-id, --unlink-link-id
 - `stella template fill`
-  - `--template-id` — Template id, as returned by list_templates (required, string)
-  - `--allow-unused-values` — Allow value keys that do not match template fields. Defaults to false so misspelled field paths fail loudly. (optional, boolean)
-  - `--completion-mode` — Require every placeholder by default; use allow_partial only for an intentionally incomplete document. (optional, enum: require_complete, allow_partial)
-
+  - `--template-id` — Template id, as returned by list_templates (string)
+  - optional: --allow-unused-values, --completion-mode (require_complete|allow_partial)
 - `stella template list`
-  - `--template-id` — Template id to describe its fields in detail; omit to list templates (optional, string)
-
+  - optional: --template-id
 - `stella template save`
-  - `--template-id` — Template to configure; omit when creating (optional, string)
-  - `--name` — Display name; required when creating (optional, string)
-  - `--docx-base64` — Base64 DOCX bytes; required when creating (optional, string)
-
+  - optional: --template-id, --name, --docx-base64
 - `stella template save-filled new-document`
-  - `--template-id` — Template id, as returned by list_templates (required, string)
-  - `--matter-id` — Matter/workspace receiving the filled DOCX (required, string)
-  - `--idempotency-key` — Unique retry key for this save operation; reuse it only to recover the same timed-out request (required, string)
-  - `--parent-id` — Folder entity id for a new document; valid only for create_document (optional, string)
-  - `--name` — Optional DOCX file name; defaults to the template file name (optional, string)
-
+  - `--template-id` — Template id, as returned by list_templates (string)
+  - `--matter-id` — Matter/workspace receiving the filled DOCX (string)
+  - `--idempotency-key` — Unique retry key for this save operation; reuse it only to recover the same timed-out request (string)
+  - optional: --parent-id, --name
 - `stella template save-filled new-version`
-  - `--template-id` — Template id, as returned by list_templates (required, string)
-  - `--matter-id` — Matter/workspace receiving the filled DOCX (required, string)
-  - `--idempotency-key` — Unique retry key for this save operation; reuse it only to recover the same timed-out request (required, string)
-  - `--entity-id` — Existing document entity id; required only for create_version (required, string)
-  - `--name` — Optional DOCX file name; defaults to the template file name (optional, string)
-
+  - `--template-id` — Template id, as returned by list_templates (string)
+  - `--matter-id` — Matter/workspace receiving the filled DOCX (string)
+  - `--idempotency-key` — Unique retry key for this save operation; reuse it only to recover the same timed-out request (string)
+  - `--entity-id` — Existing document entity id; required only for create_version (string)
+  - optional: --name
 - `stella time-entry delete`
-  - `--time-entry-id` — Time entry ID to delete or write off (required, string)
-
+  - `--time-entry-id` — Time entry ID to delete or write off (string)
 - `stella time-entry list`
-  - `--matter-id` — Matter/workspace ID to list time entries in; required unless time_entry_id is given (optional, string)
-  - `--time-entry-id` — Time entry ID to read in detail (optional, string)
-  - `--entity-id` — List only entries logged against this entity (document, folder, or task the time is billed to) (optional, string)
-  - `--user-id` — List only entries recorded by this user (optional, string)
-  - `--date-from` — List only entries worked on or after this ISO date (YYYY-MM-DD) (optional, string)
-  - `--date-to` — List only entries worked on or before this ISO date (YYYY-MM-DD) (optional, string)
-  - `--status` — List only entries with this status (optional, enum: draft, approved, billed, written_off)
-
+  - optional: --matter-id, --time-entry-id, --entity-id, --user-id, --date-from, --date-to, --status (draft|approved|billed|written_off)
 - `stella time-entry save`
-  - `--time-entry-id` — Time entry ID to update; omit to create (optional, string)
-  - `--matter-id` — Matter/workspace ID to create the entry in; required when creating (optional, string)
-  - `--entity-id` — Optional work item context (document, folder, or task). When updating, moves the entry to a different entity in the same matter; pass null to clear. (optional, nullable-string)
-  - `--date-worked` — Date the work was done (ISO YYYY-MM-DD); required when creating (optional, string)
-  - `--timezone-id` — IANA time zone the date_worked is interpreted in (e.g. Europe/Prague); required when creating or changing date_worked (optional, string)
-  - `--duration-minutes` — Minutes worked (whole minutes); required when creating (optional, int 1..inf)
-  - `--narrative` — Description of the work; required when creating (optional, string)
-  - `--invoice-narrative` — Client-facing narrative shown on the invoice; pass null to clear. Only valid when updating. (optional, nullable-string)
-  - `--billable` — Whether the entry is billable to the client (optional, boolean)
-  - `--no-charge` — Whether the entry is recorded but not charged. Only valid when updating. (optional, boolean)
-  - `--task-code` — UTBMS/LEDES task code; pass null to clear (optional, nullable-string)
-  - `--activity-code` — UTBMS/LEDES activity code; pass null to clear (optional, nullable-string)
-
+  - optional: --time-entry-id, --matter-id, --entity-id, --date-worked, --timezone-id, --duration-minutes, --narrative, --invoice-narrative, --billable, --no-charge, --task-code, --activity-code
 - `stella usage get` — no arguments
 
 ## Exit codes

--- a/packages/cli/src/build-cli-tree.ts
+++ b/packages/cli/src/build-cli-tree.ts
@@ -28,6 +28,7 @@ import { compatibilityRoute } from "./commands/compatibility.js";
 import { uploadCommand } from "./commands/upload.js";
 import type { Context } from "./context.js";
 import { expandSchemaDefs } from "./expand-schema-defs.js";
+import { flagBrief } from "./flag-help.js";
 import { generatedResourceTree } from "./generated/resource-tree.js";
 import {
   buildInputContractHelp,
@@ -81,44 +82,6 @@ const variadicFlag = (brief: string) =>
 
 const booleanFlag = (brief: string, withNegated: boolean) =>
   ({ brief, kind: "boolean", optional: true, withNegated }) as const;
-
-/**
- * A flag's `--help` line: the property's authored prose first (that is what a
- * caller — usually an agent — actually needs), then the mechanical
- * required/kind/enum/range facts the schema already encodes.
- */
-const flagBrief = (spec: FlagSpec): string => {
-  const facts = mechanicalFlagFacts(spec);
-  return spec.description === undefined
-    ? facts
-    : `${spec.description} ${facts}`;
-};
-
-/**
- * The schema facts as one parenthesised, comma-separated clause:
- * `(required, string)`, `(optional, enum: draft, sent)`, `(optional, int
- * 1..100, repeatable)`. Stricli already brackets an optional flag's usage, so
- * nesting brackets here produced the misleading `[--entity-id ... [(required)
- * string]]`: required-ness is a fact about the tool input, not about the
- * stricli flag, which stays optional (see `OptionalStricliFlag`).
- */
-const mechanicalFlagFacts = (spec: FlagSpec): string => {
-  const parts = [spec.required ? "required" : "optional", flagKindFact(spec)];
-  if (spec.repeatable) {
-    parts.push("repeatable");
-  }
-  return `(${parts.join(", ")})`;
-};
-
-const flagKindFact = (spec: FlagSpec): string => {
-  if (spec.enum) {
-    return `${spec.kind}: ${spec.enum.join(", ")}`;
-  }
-  if (spec.min !== undefined || spec.max !== undefined) {
-    return `${spec.kind} ${spec.min ?? "-inf"}..${spec.max ?? "inf"}`;
-  }
-  return spec.kind;
-};
 
 /**
  * Build the stricli flag for one capability/tool input field. The single

--- a/packages/cli/src/codegen.ts
+++ b/packages/cli/src/codegen.ts
@@ -240,6 +240,7 @@ await writeFile(
   generateCliSkill(listings, toolAnnotations, {
     commandCount: capabilityStats.generated,
     domains: capabilityDomainsOf(routeMap),
+    tree: routeMap,
   }),
 );
 process.stderr.write(`Wrote ${skillUrl.pathname}\n`);

--- a/packages/cli/src/codegen.ts
+++ b/packages/cli/src/codegen.ts
@@ -13,7 +13,10 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import * as v from "valibot";
 
 import { parseCapabilityCatalog } from "./capability-catalog-load.js";
-import { buildCliRouteTree } from "./generate-capability-tree.js";
+import {
+  buildCliRouteTree,
+  capabilityDomainsOf,
+} from "./generate-capability-tree.js";
 import { generateResourceTree } from "./generate-resource-tree.js";
 import { generateCliSkill, SKILL_NAME } from "./generate-skill.js";
 import { MCP_CLI_TOOL_SCOPES } from "./generated/mcp-contract.js";
@@ -236,6 +239,7 @@ await writeFile(
   skillUrl,
   generateCliSkill(listings, toolAnnotations, {
     commandCount: capabilityStats.generated,
+    domains: capabilityDomainsOf(routeMap),
   }),
 );
 process.stderr.write(`Wrote ${skillUrl.pathname}\n`);

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -24,8 +24,34 @@ import {
 
 const parseString = (input: string): string => input;
 
-const optionalStringFlag = (brief: string) =>
-  ({ brief, kind: "parsed", optional: true, parse: parseString }) as const;
+/**
+ * The exact shape stricli's `ParsedFlagParameter` wants for a required vs. an
+ * optional string flag (`kind: "parsed"` literal, `optional` literal or
+ * absent). Written out by hand — rather than left for `buildCommand` to
+ * infer through `as const` — because `uploadSpecificFlags` below is exported,
+ * and an exported const's initializer must carry an explicit type under
+ * `isolatedDeclarations`; `optionalStringFlag`'s call sites feed straight
+ * into it, so its return type needs the same treatment.
+ */
+type RequiredStringFlagSpec = {
+  readonly brief: string;
+  readonly kind: "parsed";
+  readonly parse: (input: string) => string;
+};
+
+type OptionalStringFlagSpec = {
+  readonly brief: string;
+  readonly kind: "parsed";
+  readonly optional: true;
+  readonly parse: (input: string) => string;
+};
+
+const optionalStringFlag = (brief: string): OptionalStringFlagSpec => ({
+  brief,
+  kind: "parsed",
+  optional: true,
+  parse: parseString,
+});
 
 type UploadFlags = CommonFlagValues & {
   readonly entityId: string | undefined;
@@ -75,7 +101,15 @@ const renderNestedFailure = ({
  * instead of hand-typed prose that could silently drift from it. A flag here
  * is required unless it carries `optional: true` (see `optionalStringFlag`).
  */
-export const uploadSpecificFlags = {
+export const uploadSpecificFlags: {
+  readonly file: RequiredStringFlagSpec;
+  readonly matterId: RequiredStringFlagSpec;
+  readonly propertyId: OptionalStringFlagSpec;
+  readonly parentId: OptionalStringFlagSpec;
+  readonly entityId: OptionalStringFlagSpec;
+  readonly name: OptionalStringFlagSpec;
+  readonly mimeType: OptionalStringFlagSpec;
+} = {
   file: {
     brief: "Local file path to upload",
     kind: "parsed",
@@ -99,7 +133,7 @@ export const uploadSpecificFlags = {
   mimeType: optionalStringFlag(
     "MIME type override; by default it is inferred from the standard extension database",
   ),
-} as const;
+};
 
 export const uploadCommand: Command<Context> = buildCommand<
   UploadFlags,

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -67,6 +67,40 @@ const renderNestedFailure = ({
   );
 };
 
+/**
+ * This command's own flags (the shared `buildCommonFlags()` ones excluded),
+ * as one plain object literal `buildCommand` registers directly. Exported so
+ * the generated skill (`generate-skill.ts`) can state `stella upload`'s real
+ * invocation (which flags exist, which are required) from this SAME object
+ * instead of hand-typed prose that could silently drift from it. A flag here
+ * is required unless it carries `optional: true` (see `optionalStringFlag`).
+ */
+export const uploadSpecificFlags = {
+  file: {
+    brief: "Local file path to upload",
+    kind: "parsed",
+    parse: parseString,
+  },
+  matterId: {
+    brief: "Matter id that will own the document",
+    kind: "parsed",
+    parse: parseString,
+  },
+  propertyId: optionalStringFlag(
+    "File-property id override; by default the unique file property is discovered automatically",
+  ),
+  parentId: optionalStringFlag("Destination folder entity id"),
+  entityId: optionalStringFlag(
+    "Existing document entity id; when set, upload the file as its new version",
+  ),
+  name: optionalStringFlag(
+    "Document name override; defaults to the local file name",
+  ),
+  mimeType: optionalStringFlag(
+    "MIME type override; by default it is inferred from the standard extension database",
+  ),
+} as const;
+
 export const uploadCommand: Command<Context> = buildCommand<
   UploadFlags,
   [],
@@ -170,29 +204,7 @@ export const uploadCommand: Command<Context> = buildCommand<
   parameters: {
     flags: {
       ...buildCommonFlags(),
-      file: {
-        brief: "Local file path to upload",
-        kind: "parsed",
-        parse: parseString,
-      },
-      matterId: {
-        brief: "Matter id that will own the document",
-        kind: "parsed",
-        parse: parseString,
-      },
-      propertyId: optionalStringFlag(
-        "File-property id override; by default the unique file property is discovered automatically",
-      ),
-      parentId: optionalStringFlag("Destination folder entity id"),
-      entityId: optionalStringFlag(
-        "Existing document entity id; when set, upload the file as its new version",
-      ),
-      name: optionalStringFlag(
-        "Document name override; defaults to the local file name",
-      ),
-      mimeType: optionalStringFlag(
-        "MIME type override; by default it is inferred from the standard extension database",
-      ),
+      ...uploadSpecificFlags,
     },
   },
 });

--- a/packages/cli/src/flag-help.ts
+++ b/packages/cli/src/flag-help.ts
@@ -1,0 +1,44 @@
+// Shared `FlagSpec` -> help-text derivation. The runtime `--help` output
+// (`build-cli-tree.ts`) and the generated `SKILL.md` (`generate-skill.ts`)
+// both render a flag's help line through these functions, so the flags an
+// agent reads in the skill can never drift from what `--help` actually
+// prints for the same command.
+
+import type { FlagSpec } from "./route-types.js";
+
+const flagKindFact = (spec: FlagSpec): string => {
+  if (spec.enum) {
+    return `${spec.kind}: ${spec.enum.join(", ")}`;
+  }
+  if (spec.min !== undefined || spec.max !== undefined) {
+    return `${spec.kind} ${spec.min ?? "-inf"}..${spec.max ?? "inf"}`;
+  }
+  return spec.kind;
+};
+
+/**
+ * The schema facts as one parenthesised, comma-separated clause:
+ * `(required, string)`, `(optional, enum: draft, sent)`, `(optional, int
+ * 1..100, repeatable)`. Required-ness is a fact about the tool input, not
+ * about the underlying stricli flag, which stays optional at the parser layer
+ * (every field can also arrive through `--input`).
+ */
+export const mechanicalFlagFacts = (spec: FlagSpec): string => {
+  const parts = [spec.required ? "required" : "optional", flagKindFact(spec)];
+  if (spec.repeatable) {
+    parts.push("repeatable");
+  }
+  return `(${parts.join(", ")})`;
+};
+
+/**
+ * A flag's `--help` line: the property's authored prose first (that is what a
+ * caller — usually an agent — actually needs), then the mechanical
+ * required/kind/enum/range facts the schema already encodes.
+ */
+export const flagBrief = (spec: FlagSpec): string => {
+  const facts = mechanicalFlagFacts(spec);
+  return spec.description === undefined
+    ? facts
+    : `${spec.description} ${facts}`;
+};

--- a/packages/cli/src/flag-help.ts
+++ b/packages/cli/src/flag-help.ts
@@ -6,7 +6,14 @@
 
 import type { FlagSpec } from "./route-types.js";
 
-const flagKindFact = (spec: FlagSpec): string => {
+/**
+ * The type/enum/range fact alone, with no required/optional token: `string`,
+ * `enum: draft, sent`, `int 1..100`. Exposed separately from
+ * `mechanicalFlagFacts` for a context (the generated skill's required-flag
+ * lines) where required-ness is already conveyed structurally and repeating
+ * the word would only cost space.
+ */
+export const flagKindFact = (spec: FlagSpec): string => {
   if (spec.enum) {
     return `${spec.kind}: ${spec.enum.join(", ")}`;
   }

--- a/packages/cli/src/flag-help.ts
+++ b/packages/cli/src/flag-help.ts
@@ -30,7 +30,7 @@ export const flagKindFact = (spec: FlagSpec): string => {
  * about the underlying stricli flag, which stays optional at the parser layer
  * (every field can also arrive through `--input`).
  */
-export const mechanicalFlagFacts = (spec: FlagSpec): string => {
+const mechanicalFlagFacts = (spec: FlagSpec): string => {
   const parts = [spec.required ? "required" : "optional", flagKindFact(spec)];
   if (spec.repeatable) {
     parts.push("repeatable");

--- a/packages/cli/src/generate-capability-tree.ts
+++ b/packages/cli/src/generate-capability-tree.ts
@@ -723,6 +723,28 @@ export const insertCapabilities = ({
 };
 
 /**
+ * The sorted, deduped domain segments actually present under the merged
+ * tree's `capability` namespace. Route-kind children only: `capability
+ * list`/`describe`/`invoke` are curated leaves living beside the domains
+ * (from their own tool annotations), not domains themselves. The skill
+ * documents this list so an agent choosing `stella capability <domain>
+ * <action>` never has to guess a domain name.
+ */
+export const capabilityDomainsOf = (tree: RouteNode): readonly string[] => {
+  if (tree.kind !== "route") {
+    return [];
+  }
+  const namespace = tree.children[CAPABILITY_NAMESPACE];
+  if (namespace?.kind !== "route") {
+    return [];
+  }
+  return Object.entries(namespace.children)
+    .filter(([, node]) => node.kind === "route")
+    .map(([domain]) => domain)
+    .toSorted((a, b) => a.localeCompare(b, "en"));
+};
+
+/**
  * THE full-tree builder: curated route map + capability merge, in one shared
  * function so build-time codegen and the runtime registry-refresh path (a
  * cached `tools/list` with a non-empty delta) produce structurally identical

--- a/packages/cli/src/generate-skill.test.ts
+++ b/packages/cli/src/generate-skill.test.ts
@@ -12,7 +12,10 @@ const snapshotUrl = new URL(
 const listings: readonly RegistryToolListing[] =
   await Bun.file(snapshotUrl).json();
 
-const CAPABILITY = { commandCount: 2 } as const;
+const CAPABILITY = {
+  commandCount: 2,
+  domains: ["entities", "workspaces"],
+} as const;
 
 describe("generateCliSkill (TanStack Intent)", () => {
   test("is deterministic across calls and input clones", () => {

--- a/packages/cli/src/generate-skill.test.ts
+++ b/packages/cli/src/generate-skill.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import { TOOL_ANNOTATIONS } from "./annotations.js";
-import { CAPABILITY_NAMESPACE } from "./generate-capability-tree.js";
+import {
+  CAPABILITY_NAMESPACE,
+  capabilityDomainsOf,
+  insertCapabilities,
+  type CapabilityCatalogEntry,
+} from "./generate-capability-tree.js";
+import { generateRouteMap } from "./generate-route-map.js";
 import { generateCliSkill, SKILL_NAME } from "./generate-skill.js";
 import type { RegistryToolListing } from "./route-types.js";
 
@@ -12,10 +18,23 @@ const snapshotUrl = new URL(
 const listings: readonly RegistryToolListing[] =
   await Bun.file(snapshotUrl).json();
 
+// The real committed catalog, merged onto the real curated tree exactly the
+// way `codegen.ts` does. Worked capability examples in the generated skill
+// (see generate-skill.ts) resolve a real leaf out of this tree, so the test
+// input has to carry one instead of a hand-trimmed stand-in.
+const catalogUrl = new URL("../capability-catalog.json", import.meta.url);
+const catalog: readonly CapabilityCatalogEntry[] =
+  await Bun.file(catalogUrl).json();
+const { tree: mergedTree, stats: capabilityStats } = insertCapabilities({
+  tree: generateRouteMap(listings, TOOL_ANNOTATIONS),
+  entries: catalog,
+});
+
 const CAPABILITY = {
-  commandCount: 2,
-  domains: ["entities", "workspaces"],
-} as const;
+  commandCount: capabilityStats.generated,
+  domains: capabilityDomainsOf(mergedTree),
+  tree: mergedTree,
+};
 
 describe("generateCliSkill (TanStack Intent)", () => {
   test("is deterministic across calls and input clones", () => {
@@ -42,7 +61,9 @@ describe("generateCliSkill (TanStack Intent)", () => {
   test("documents the capability tree (count + discovery + dry-run)", () => {
     const skill = generateCliSkill(listings, TOOL_ANNOTATIONS, CAPABILITY);
     expect(skill).toContain("## Capability commands (full surface)");
-    expect(skill).toContain("generates 2\ncapability commands");
+    expect(skill).toContain(
+      `generates ${CAPABILITY.commandCount}\ncapability commands`,
+    );
     expect(skill).toContain("stella capability list");
     expect(skill).toContain("stella capability describe");
     expect(skill).toContain(`stella ${CAPABILITY_NAMESPACE} <domain> <action>`);

--- a/packages/cli/src/generate-skill.ts
+++ b/packages/cli/src/generate-skill.ts
@@ -7,7 +7,7 @@
 // from the command surface the CLI actually dispatches.
 
 import { CLI_DEFAULT_SCOPES } from "./auth/constants.js";
-import { flagBrief } from "./flag-help.js";
+import { flagKindFact } from "./flag-help.js";
 import { CAPABILITY_NAMESPACE } from "./generate-capability-tree.js";
 import {
   generateRouteMap,
@@ -16,6 +16,7 @@ import {
 import { DOCUMENT_VERSION_UPLOAD_TRANSPORT } from "./generated/document-version-upload-transport.js";
 import { exitCodeEntries } from "./mcp-constants.js";
 import type {
+  FlagSpec,
   LeafCommandSpec,
   RegistryToolListing,
   RouteNode,
@@ -117,26 +118,68 @@ const renderCommandTable = (rows: readonly CommandRow[]): string => {
 };
 
 /**
- * One curated command's flags as a bullet block: the command line, then one
- * indented bullet per flag rendered through the SAME `flagBrief` derivation
- * `--help` uses, so the skill's documented flags can never drift from what
- * `--help` actually prints for that command.
+ * Global flags every command carries (`buildLeafFlags` in `build-cli-tree.ts`)
+ * and that "Conventions every agent must know" already documents once. A
+ * tool-derived `FlagSpec` can never actually collide with one of these
+ * (`generate-route-map.ts` throws on the collision at codegen time), so this
+ * filter is a defensive no-op today; it stays so a per-command line can never
+ * silently repeat a convention flag if that invariant ever changes.
+ */
+const CONVENTION_FLAGS: ReadonlySet<string> = new Set([
+  "--output",
+  "--cursor",
+  "--limit",
+  "--all",
+  "--yes",
+  "--input",
+]);
+
+/** An optional flag's compact token: its name, plus enum values in parens. */
+const optionalFlagToken = (flag: FlagSpec): string =>
+  flag.enum === undefined ? flag.flag : `${flag.flag} (${flag.enum.join("|")})`;
+
+/**
+ * A required flag's full line: name, description, type/enum (via the SAME
+ * `flagKindFact` derivation `--help` uses, so it can never drift). The
+ * required/optional word is dropped: every flag documented here IS required
+ * (an optional flag never reaches this branch), so repeating it would only
+ * cost space.
+ */
+const requiredFlagLine = (flag: FlagSpec): string => {
+  const facts = flag.repeatable
+    ? `${flagKindFact(flag)}, repeatable`
+    : flagKindFact(flag);
+  const description =
+    flag.description === undefined ? "" : ` — ${oneLine(flag.description)}`;
+  return `\`${flag.flag}\`${description} (${facts})`;
+};
+
+/**
+ * One curated command's flags as a bullet block. A required flag keeps a full
+ * line; optional flags collapse to one names-only line (enum values kept, in
+ * parens) so the skill stays small enough to load into every agent's context
+ * — `--help` remains the source for an optional flag's full description.
  */
 const commandFlagsBlock = (spec: LeafCommandSpec): string => {
   const command = `stella ${spec.commandPath.join(" ")}`;
-  if (spec.flags.length === 0) {
+  const flags = spec.flags.filter((flag) => !CONVENTION_FLAGS.has(flag.flag));
+  if (flags.length === 0) {
     const hint =
       spec.inputOnly.length > 0
         ? `no flags; pass \`--input\` with ${spec.inputOnly.join(", ")}`
         : "no arguments";
     return `- \`${command}\` — ${hint}`;
   }
-  return [
+  const required = flags.filter((flag) => flag.required);
+  const optional = flags.filter((flag) => !flag.required);
+  const lines = [
     `- \`${command}\``,
-    ...spec.flags.map(
-      (flag) => `  - \`${flag.flag}\` — ${oneLine(flagBrief(flag))}`,
-    ),
-  ].join("\n");
+    ...required.map((flag) => `  - ${requiredFlagLine(flag)}`),
+  ];
+  if (optional.length > 0) {
+    lines.push(`  - optional: ${optional.map(optionalFlagToken).join(", ")}`);
+  }
+  return lines.join("\n");
 };
 
 const renderCommandFlagsSection = (
@@ -145,12 +188,12 @@ const renderCommandFlagsSection = (
   [
     "## Command flags",
     "",
-    "Every curated command's flags, same order as the table above. Each flag",
-    "line is `--flag — description (required|optional, type)`; an enum lists its",
-    "values and a repeatable flag is passed once per value. `stella <command>",
-    "--help` prints the identical facts plus a full JSON `--input` example.",
+    "Required: `--flag — description (type)`. Optional: one `optional: --a,",
+    "--b (enum1|enum2)` line, names only (`--help` has full descriptions).",
+    "Global flags (output/cursor/limit/all/yes/input; see Conventions above)",
+    "are omitted here.",
     "",
-    leaves.map((spec) => commandFlagsBlock(spec)).join("\n\n"),
+    leaves.map((spec) => commandFlagsBlock(spec)).join("\n"),
   ].join("\n");
 
 const renderExitCodeTable = (): string =>

--- a/packages/cli/src/generate-skill.ts
+++ b/packages/cli/src/generate-skill.ts
@@ -7,8 +7,13 @@
 // from the command surface the CLI actually dispatches.
 
 import { CLI_DEFAULT_SCOPES } from "./auth/constants.js";
+import { flagBrief } from "./flag-help.js";
 import { CAPABILITY_NAMESPACE } from "./generate-capability-tree.js";
-import { generateRouteMap } from "./generate-route-map.js";
+import {
+  generateRouteMap,
+  RouteGenerationError,
+} from "./generate-route-map.js";
+import { DOCUMENT_VERSION_UPLOAD_TRANSPORT } from "./generated/document-version-upload-transport.js";
 import { exitCodeEntries } from "./mcp-constants.js";
 import type {
   LeafCommandSpec,
@@ -16,6 +21,8 @@ import type {
   RouteNode,
   ToolAnnotation,
 } from "./route-types.js";
+
+const oneLine = (text: string): string => text.replace(/\s+/gu, " ").trim();
 
 /**
  * The skill's leaf name. Intent requires `skills/<name>/SKILL.md` where the
@@ -63,10 +70,26 @@ const notesFor = (spec: LeafCommandSpec): string => {
   return parts.join("; ");
 };
 
-const commandRows = (tree: RouteNode): readonly CommandRow[] => {
+/**
+ * Every curated leaf, sorted for determinism independent of
+ * registry/annotation iteration order. Explicit locale keeps the ordering
+ * byte-identical across machines; the drift guard diffs the emitted SKILL.md
+ * against a committed snapshot. Both the command table and the per-command
+ * flag section below walk this SAME list, so they can never fall out of sync
+ * with each other.
+ */
+const sortedLeaves = (tree: RouteNode): readonly LeafCommandSpec[] => {
   const leaves: LeafCommandSpec[] = [];
   collectLeaves(tree, leaves);
-  const rows = leaves.map((spec) => {
+  return leaves.toSorted((a, b) =>
+    a.commandPath.join(" ").localeCompare(b.commandPath.join(" "), "en"),
+  );
+};
+
+const commandRows = (
+  leaves: readonly LeafCommandSpec[],
+): readonly CommandRow[] =>
+  leaves.map((spec) => {
     const command = spec.commandPath.join(" ");
     return {
       domain: spec.commandPath[0] ?? command,
@@ -79,11 +102,6 @@ const commandRows = (tree: RouteNode): readonly CommandRow[] => {
       notes: notesFor(spec),
     };
   });
-  // Sort for determinism independent of registry/annotation iteration order.
-  // Explicit locale keeps the ordering byte-identical across machines; the
-  // drift guard diffs the emitted SKILL.md against a committed snapshot.
-  return rows.toSorted((a, b) => a.command.localeCompare(b.command, "en"));
-};
 
 const renderCommandTable = (rows: readonly CommandRow[]): string => {
   const lines = [
@@ -98,6 +116,43 @@ const renderCommandTable = (rows: readonly CommandRow[]): string => {
   return lines.join("\n");
 };
 
+/**
+ * One curated command's flags as a bullet block: the command line, then one
+ * indented bullet per flag rendered through the SAME `flagBrief` derivation
+ * `--help` uses, so the skill's documented flags can never drift from what
+ * `--help` actually prints for that command.
+ */
+const commandFlagsBlock = (spec: LeafCommandSpec): string => {
+  const command = `stella ${spec.commandPath.join(" ")}`;
+  if (spec.flags.length === 0) {
+    const hint =
+      spec.inputOnly.length > 0
+        ? `no flags; pass \`--input\` with ${spec.inputOnly.join(", ")}`
+        : "no arguments";
+    return `- \`${command}\` — ${hint}`;
+  }
+  return [
+    `- \`${command}\``,
+    ...spec.flags.map(
+      (flag) => `  - \`${flag.flag}\` — ${oneLine(flagBrief(flag))}`,
+    ),
+  ].join("\n");
+};
+
+const renderCommandFlagsSection = (
+  leaves: readonly LeafCommandSpec[],
+): string =>
+  [
+    "## Command flags",
+    "",
+    "Every curated command's flags, same order as the table above. Each flag",
+    "line is `--flag — description (required|optional, type)`; an enum lists its",
+    "values and a repeatable flag is passed once per value. `stella <command>",
+    "--help` prints the identical facts plus a full JSON `--input` example.",
+    "",
+    leaves.map((spec) => commandFlagsBlock(spec)).join("\n\n"),
+  ].join("\n");
+
 const renderExitCodeTable = (): string =>
   [
     "| Code | Meaning |",
@@ -109,15 +164,49 @@ const renderExitCodeTable = (): string =>
 export type CapabilitySkillSummary = {
   /** Count of generated `invoke_capability`-backed leaf commands. */
   commandCount: number;
+  /** Domain segments actually present in the merged tree, see `capabilityDomainsOf`. */
+  domains: readonly string[];
 };
 
 /**
- * The compact capability-tree section (spec 049 deliverable 4). The curated
- * command table above stays the primary surface; the long tail is described
- * (count + discovery) rather than enumerated, so the skill stays readable.
+ * Two worked "no curated command" examples the skill states verbatim
+ * (spec 049-flags deliverable 2). Checked against the live domain list below
+ * rather than hand-trusted, so a catalog change that removes either domain
+ * fails codegen instead of shipping a stale example.
  */
-const renderCapabilitySection = (summary: CapabilitySkillSummary): string =>
-  [
+const CAPABILITY_WORKED_EXAMPLES = [
+  {
+    domain: "entities",
+    task: "Translate a document",
+    command:
+      "stella capability entities translate --field-id <id> --target-lang <lang>",
+  },
+  {
+    domain: "workspaces",
+    task: "Start workflow extraction",
+    command: "stella capability workspaces workflow-start --workspace <id>",
+  },
+] as const;
+
+/**
+ * The compact capability-tree section (spec 049 deliverable 4), extended with
+ * the domain list, two worked examples, and the `--input` casing rule (spec
+ * 049-flags deliverable 2). The curated command table above stays the primary
+ * surface; the long tail is described (count + discovery) rather than
+ * enumerated, so the skill stays readable.
+ */
+const renderCapabilitySection = (summary: CapabilitySkillSummary): string => {
+  for (const example of CAPABILITY_WORKED_EXAMPLES) {
+    if (!summary.domains.includes(example.domain)) {
+      throw new RouteGenerationError(
+        `generateCliSkill: worked example "${example.command}" names domain "${example.domain}", which is no longer in the capability tree; update or drop the example`,
+      );
+    }
+  }
+  const domainList = summary.domains
+    .map((domain) => `\`${domain}\``)
+    .join(", ");
+  return [
     "## Capability commands (full surface)",
     "",
     `Beyond the curated commands above, the CLI generates ${summary.commandCount}`,
@@ -139,7 +228,50 @@ const renderCapabilitySection = (summary: CapabilitySkillSummary): string =>
     "- **Destructive** capabilities prompt on a TTY and need `--yes` off a TTY; the",
     "  server's per-capability confirm gate is satisfied automatically once confirmed.",
     "- Exit codes are identical to the curated commands (see above).",
+    "",
+    "### When no curated command fits",
+    "",
+    "The curated commands above cover common tasks; anything else goes through the",
+    `generic capability path. Current domains: ${domainList}.`,
+    "",
+    ...CAPABILITY_WORKED_EXAMPLES.map(
+      ({ task, command }) => `- ${task}: \`${command}\`.`,
+    ),
+    "- **`--input` casing is not uniform; never guess it.** A curated command's",
+    "  `--input` JSON (the table and flags above) uses the MCP tool schema's own",
+    "  keys, snake_case (`matter_id`, `contact_id`). A capability command's",
+    "  `--input` JSON uses the handler schema's own keys, camelCase (`fieldId`,",
+    "  `workspaceId`). Run `stella <command> --help` or `stella capability describe",
+    "  <id>` and copy the field paths it prints.",
   ].join("\n");
+};
+
+/**
+ * What the CLI structurally cannot do: binary-file MCP tools have no JSON
+ * transport to ride. Derived from the two tools the document-version-upload
+ * feature is built from (`document-version-upload-transport.ts`) so the note
+ * disappears on its own if either tool is ever dropped from the exclusion
+ * list, instead of silently going stale.
+ */
+const renderUploadGapNote = (
+  annotations: Readonly<Record<string, ToolAnnotation>>,
+): string => {
+  const { toolName, pickerToolName } = DOCUMENT_VERSION_UPLOAD_TRANSPORT;
+  if (
+    annotations[toolName]?.excluded !== true ||
+    annotations[pickerToolName]?.excluded !== true
+  ) {
+    throw new RouteGenerationError(
+      `generateCliSkill: expected "${toolName}" and "${pickerToolName}" to be excluded CLI tools (binary file upload); update the upload-gap note if that changed`,
+    );
+  }
+  return (
+    "- **No binary uploads**: the CLI cannot upload a new document version " +
+    `(a file) — \`${toolName}\`/\`${pickerToolName}\` are MCP-only, excluded ` +
+    "from the CLI. Upload a new version through an MCP-connected client or the " +
+    "stella web app."
+  );
+};
 
 /**
  * Emit the `SKILL.md` markdown for the stella CLI. Pure over the registry
@@ -152,9 +284,12 @@ export const generateCliSkill = (
   capability: CapabilitySkillSummary,
 ): string => {
   const tree = generateRouteMap(listings, annotations);
-  const table = renderCommandTable(commandRows(tree));
+  const leaves = sortedLeaves(tree);
+  const table = renderCommandTable(commandRows(leaves));
+  const flagsSection = renderCommandFlagsSection(leaves);
   const exitCodes = renderExitCodeTable();
   const capabilitySection = renderCapabilitySection(capability);
+  const uploadGapNote = renderUploadGapNote(annotations);
 
   const frontmatter = [
     "---",
@@ -232,6 +367,16 @@ export const generateCliSkill = (
     "  (windowed, so follow `--cursor`).",
     "- **MCP resources**: `stella reference list` enumerates static server resources;",
     "  `stella reference show <name>` prints one.",
+    uploadGapNote,
+    "",
+    "## Command tree",
+    "",
+    "Generated from the MCP tool registry; `Access` is the OAuth scope the command",
+    "requires (request it at `stella auth login --scopes`).",
+    "",
+    table,
+    "",
+    flagsSection,
     "",
     "## Exit codes",
     "",
@@ -256,13 +401,6 @@ export const generateCliSkill = (
     "- **github** (preferred): returns a prefilled new-issue URL and a `gh` command",
     "  the human opens and submits under their own GitHub account. The CLI never",
     "  publishes anything itself.",
-    "",
-    "## Command tree",
-    "",
-    "Generated from the MCP tool registry; `Access` is the OAuth scope the command",
-    "requires (request it at `stella auth login --scopes`).",
-    "",
-    table,
     "",
   ].join("\n");
 

--- a/packages/cli/src/generate-skill.ts
+++ b/packages/cli/src/generate-skill.ts
@@ -7,10 +7,12 @@
 // from the command surface the CLI actually dispatches.
 
 import { CLI_DEFAULT_SCOPES } from "./auth/constants.js";
+import { uploadSpecificFlags } from "./commands/upload.js";
 import { flagKindFact } from "./flag-help.js";
 import { CAPABILITY_NAMESPACE } from "./generate-capability-tree.js";
 import {
   generateRouteMap,
+  kebabCase,
   RouteGenerationError,
 } from "./generate-route-map.js";
 import { DOCUMENT_VERSION_UPLOAD_TRANSPORT } from "./generated/document-version-upload-transport.js";
@@ -209,27 +211,72 @@ export type CapabilitySkillSummary = {
   commandCount: number;
   /** Domain segments actually present in the merged tree, see `capabilityDomainsOf`. */
   domains: readonly string[];
+  /**
+   * The merged tree (curated leaves + capability leaves). Worked examples
+   * below resolve a real `CapabilityLeafSpec` out of it, so an example's
+   * flags are derived from the leaf, never hand-typed.
+   */
+  tree: RouteNode;
+};
+
+/** The node at `path` in `tree`, or `undefined` if the path does not resolve. */
+const routeNodeAt = (
+  tree: RouteNode,
+  path: readonly string[],
+): RouteNode | undefined => {
+  let node: RouteNode = tree;
+  for (const segment of path) {
+    if (node.kind !== "route") {
+      return undefined;
+    }
+    const child = node.children[segment];
+    if (child === undefined) {
+      return undefined;
+    }
+    node = child;
+  }
+  return node;
 };
 
 /**
- * Two worked "no curated command" examples the skill states verbatim
- * (spec 049-flags deliverable 2). Checked against the live domain list below
- * rather than hand-trusted, so a catalog change that removes either domain
- * fails codegen instead of shipping a stale example.
+ * Two worked "no curated command" examples (spec 049-flags deliverable 2):
+ * task prose plus the command path to a real capability leaf. The invocation
+ * — every required flag, in the leaf's own flag order, placeholder named
+ * after the flag itself — is derived from that leaf at render time (see
+ * `capabilityExampleLine`), so a catalog change that renames a flag, adds a
+ * new required one, or drops the leaf fails codegen instead of shipping a
+ * stale example.
  */
 const CAPABILITY_WORKED_EXAMPLES = [
   {
-    domain: "entities",
     task: "Translate a document",
-    command:
-      "stella capability entities translate --field-id <id> --target-lang <lang>",
+    commandPath: [CAPABILITY_NAMESPACE, "entities", "translate"],
   },
   {
-    domain: "workspaces",
     task: "Start workflow extraction",
-    command: "stella capability workspaces workflow-start --workspace <id>",
+    commandPath: [CAPABILITY_NAMESPACE, "workspaces", "workflow-start"],
   },
 ] as const;
+
+const capabilityExampleLine = (
+  tree: RouteNode,
+  example: (typeof CAPABILITY_WORKED_EXAMPLES)[number],
+): string => {
+  const node = routeNodeAt(tree, example.commandPath);
+  if (node?.kind !== "capability-leaf") {
+    throw new RouteGenerationError(
+      `generateCliSkill: worked example "${example.task}" names command "stella ${example.commandPath.join(" ")}", which is not a capability command in the current tree; update or drop the example`,
+    );
+  }
+  const required = node.spec.flags.filter((flag) => flag.required);
+  const args = required
+    .map((flag) => `${flag.flag} <${flag.flag.replace(/^--/u, "")}>`)
+    .join(" ");
+  const invocation = [`stella ${example.commandPath.join(" ")}`, args]
+    .filter((part) => part.length > 0)
+    .join(" ");
+  return `- ${example.task}: \`${invocation}\`.`;
+};
 
 /**
  * The compact capability-tree section (spec 049 deliverable 4), extended with
@@ -239,13 +286,9 @@ const CAPABILITY_WORKED_EXAMPLES = [
  * enumerated, so the skill stays readable.
  */
 const renderCapabilitySection = (summary: CapabilitySkillSummary): string => {
-  for (const example of CAPABILITY_WORKED_EXAMPLES) {
-    if (!summary.domains.includes(example.domain)) {
-      throw new RouteGenerationError(
-        `generateCliSkill: worked example "${example.command}" names domain "${example.domain}", which is no longer in the capability tree; update or drop the example`,
-      );
-    }
-  }
+  const exampleLines = CAPABILITY_WORKED_EXAMPLES.map((example) =>
+    capabilityExampleLine(summary.tree, example),
+  );
   const domainList = summary.domains
     .map((domain) => `\`${domain}\``)
     .join(", ");
@@ -277,9 +320,7 @@ const renderCapabilitySection = (summary: CapabilitySkillSummary): string => {
     "The curated commands above cover common tasks; anything else goes through the",
     `generic capability path. Current domains: ${domainList}.`,
     "",
-    ...CAPABILITY_WORKED_EXAMPLES.map(
-      ({ task, command }) => `- ${task}: \`${command}\`.`,
-    ),
+    ...exampleLines,
     "- **`--input` casing is not uniform; never guess it.** A curated command's",
     "  `--input` JSON (the table and flags above) uses the MCP tool schema's own",
     "  keys, snake_case (`matter_id`, `contact_id`). A capability command's",
@@ -289,14 +330,29 @@ const renderCapabilitySection = (summary: CapabilitySkillSummary): string => {
   ].join("\n");
 };
 
+type UploadFlagEntry =
+  (typeof uploadSpecificFlags)[keyof typeof uploadSpecificFlags];
+
+const isOptionalUploadFlag = (flag: UploadFlagEntry): boolean =>
+  "optional" in flag;
+
+const uploadFlagName = (key: string): string => `--${kebabCase(key)}`;
+
+/** `stella upload`'s required flags, in invocation order (spec upload-note). */
+const REQUIRED_UPLOAD_KEYS = ["file", "matterId"] as const;
+
 /**
- * What the CLI structurally cannot do: binary-file MCP tools have no JSON
- * transport to ride. Derived from the two tools the document-version-upload
- * feature is built from (`document-version-upload-transport.ts`) so the note
- * disappears on its own if either tool is ever dropped from the exclusion
- * list, instead of silently going stale.
+ * Documents the real `stella upload` invocation, including uploading a new
+ * document VERSION (`--entity-id`) — a hand-wired top-level command
+ * (`commands/upload.ts`, registered directly in `build-cli-tree.ts`, never
+ * part of the generated route tree `generateRouteMap` walks). Its required
+ * flags are read off `uploadSpecificFlags`, the SAME object `buildCommand`
+ * registers, so the invocation cannot silently drift from what the command
+ * actually accepts. Contrasted with the excluded MCP tools
+ * (`document-version-upload-transport.ts`), which take a host-supplied file
+ * reference the CLI has no channel for and are genuinely unreachable.
  */
-const renderUploadGapNote = (
+const renderUploadNote = (
   annotations: Readonly<Record<string, ToolAnnotation>>,
 ): string => {
   const { toolName, pickerToolName } = DOCUMENT_VERSION_UPLOAD_TRANSPORT;
@@ -305,14 +361,31 @@ const renderUploadGapNote = (
     annotations[pickerToolName]?.excluded !== true
   ) {
     throw new RouteGenerationError(
-      `generateCliSkill: expected "${toolName}" and "${pickerToolName}" to be excluded CLI tools (binary file upload); update the upload-gap note if that changed`,
+      `generateCliSkill: expected "${toolName}" and "${pickerToolName}" to be excluded CLI tools (host-file-reference upload); update the upload note if that changed`,
     );
   }
+  for (const key of REQUIRED_UPLOAD_KEYS) {
+    if (isOptionalUploadFlag(uploadSpecificFlags[key])) {
+      throw new RouteGenerationError(
+        `generateCliSkill: expected "stella upload" flag "${uploadFlagName(key)}" to be required; update the upload note if that changed`,
+      );
+    }
+  }
+  if (!isOptionalUploadFlag(uploadSpecificFlags.entityId)) {
+    throw new RouteGenerationError(
+      'generateCliSkill: expected "stella upload" to offer an optional --entity-id (new-version mode); update the upload note if that changed',
+    );
+  }
+  const requiredInvocation = REQUIRED_UPLOAD_KEYS.map(
+    (key) => `${uploadFlagName(key)} <${kebabCase(key)}>`,
+  ).join(" ");
   return (
-    "- **No binary uploads**: the CLI cannot upload a new document version " +
-    `(a file) — \`${toolName}\`/\`${pickerToolName}\` are MCP-only, excluded ` +
-    "from the CLI. Upload a new version through an MCP-connected client or the " +
-    "stella web app."
+    `- **Uploading a file**: \`stella upload ${requiredInvocation}\` uploads ` +
+    `a local file as a new document; add \`${uploadFlagName("entityId")} <id>\` ` +
+    "to upload it as a new version of an existing document instead — a " +
+    "CLI-native path (the CLI reads the file itself), separate from the MCP " +
+    `\`${toolName}\`/\`${pickerToolName}\` tools (which take a host-supplied ` +
+    "file reference and are excluded from the CLI)."
   );
 };
 
@@ -332,7 +405,7 @@ export const generateCliSkill = (
   const flagsSection = renderCommandFlagsSection(leaves);
   const exitCodes = renderExitCodeTable();
   const capabilitySection = renderCapabilitySection(capability);
-  const uploadGapNote = renderUploadGapNote(annotations);
+  const uploadNote = renderUploadNote(annotations);
 
   const frontmatter = [
     "---",
@@ -410,7 +483,7 @@ export const generateCliSkill = (
     "  (windowed, so follow `--cursor`).",
     "- **MCP resources**: `stella reference list` enumerates static server resources;",
     "  `stella reference show <name>` prints one.",
-    uploadGapNote,
+    uploadNote,
     "",
     "## Command tree",
     "",


### PR DESCRIPTION
## Summary
- Generated SKILL.md now lists every curated command's flags (name, required/optional, type, one-line description), derived through the same `flagBrief` helper `--help` uses (extracted to `flag-help.ts`) so the two can never drift.
- Added a "when no curated command fits" section: the live capability domain list, two worked `stella capability <domain> <action>` examples, and the `--input` casing rule (snake_case on curated tools, camelCase on capability commands).
- States the CLI's one structural gap (no binary file upload for a new document version) derived from the excluded `upload_document_version`/`open_document_version_upload` tools, so it can't silently go stale.

## Test plan
- [x] `bun test` in `packages/cli` (539 pass, 1 skip)
- [x] `bun run lint` in `packages/cli`
- [x] `bun run src/codegen.ts` + `bunx oxfmt .` to regenerate `SKILL.md` and confirm no other generated files (`route-map.ts`, `tool-annotations.ts`, `resource-tree.ts`) changed