### PR TITLE
feat(law): rank the decision shelf by court tier and add a legislation shelf

### DIFF
--- a/.agents/plans/20260902-080049-law-home-b52f33.md
+++ b/.agents/plans/20260902-080049-law-home-b52f33.md
@@ -1,0 +1,163 @@
+# Plan: Law home
+
+## Goal
+
+`/law` becomes a home rather than a redirect: one search box with scope tabs and
+a jurisdiction pill, and a small set of cards derived from corpus data (legislation
+recently in force, legislation entering into force, new decisions from the
+top court tier, identifier examples, and the signed-in user's research tables).
+The all-courts newest-first table stops being the first thing a visitor sees.
+Every card is defined by a jurisdiction-neutral signal; a jurisdiction whose
+data lacks the signal omits the card instead of showing filler.
+
+## Current State
+
+- `/law` (`apps/web/src/routes/law/index.tsx`) only redirects to `/law/cases`.
+  `/law/cases` (`routes/law/cases/index.tsx`) shows the one box, then, while
+  nothing is typed, `LatestDecisionsShelf` fed by `GET /v1/case/decisions/latest`.
+  That endpoint (`handlers/case-law/decisions/latest.ts`) picks the four
+  *largest* court buckets from the facets, so district courts own the page.
+  With any filter it shows `DecisionTable` newest-first with load-more and a
+  column chooser. `/law/$country/statutes` shows the box and a "recently
+  amended" list ordered by `version_valid_from DESC`.
+- Court rank exists but is unused by the shelf: `caseLawCourtWeights`
+  (`db/schema/case-law.ts:1885`: `country`, `courtPattern` regex, `tier`,
+  `tierLabel`, `weight`), loaded by `handlers/case-law/court-weights.ts`, with
+  `LEGACY_COURT_TIERS` in `citation-score.ts` as fallback (4 constitutional, 3
+  supreme, 2 regional/appellate, 1 default).
+- Row text: `lib/case-law/decision-headnote.ts` already derives a headnote in a
+  fixed priority (`legalSentence`, `abstract`, `keywords`, `legalArea`), capped
+  by `LIMITS.caseLawHeadnoteMaxChars`.
+- Legislation rows (`db/schema/legislation.ts:91`) carry `effectiveDate`
+  (promulgation/effect), `versionValidFrom`/`versionValidTo` (consolidation
+  window), `status`, `documentType`, `title`. `handlers/legislation/list.ts`
+  filters `inForceToday` and the current version of each work.
+- Identifier grammars: `features/case-law/decision-query-intent.ts` (one
+  unordered grammar list) and `features/statutes/statute-query-intent.ts`
+  (per jurisdiction, with aliases). Example identifiers exist only inside i18n
+  placeholder strings, not as data.
+- Jurisdiction lists are split: case law takes countries from the facets and
+  maps regions in `features/case-law/case-law-jurisdiction.ts`; statutes use
+  `lib/statute-route.ts` (`cze`, `svk`).
+- Decision dates: `canonicalDecisionDate` (`lib/dates.ts:168`) rejects years
+  outside `DECISION_YEAR_BOUNDS = { min: 1800, yearsAhead: 1 }`; a decision
+  dated 27 January 2027 currently tops the newest-first list in production.
+  The table CHECK `case_law_decisions_decision_date_bounds` derives from the
+  same declaration via `lib/decision-date-bounds-sql.ts`.
+- Signed-in work: research tables (`handlers/case-law/research/routes.ts`,
+  `GET /v1/case/research`), org-scoped. `savedSearches` is workspace search,
+  not law. Search history is a client-local store for the command palette only.
+- Public routes are 404 unless `env.isDev || env.FEATURE_PUBLIC_LAW`; `/law/*`
+  is SSR with `createPublicLawHead` and JSON-LD.
+
+## Decisions
+
+- **Home lives at `/law`**, replacing the redirect; `/law/cases` and
+  `/law/$country/statutes` stay as results screens. `/law/cases` with no
+  query, court or year redirects to `/law` (server-side, keeping `country`).
+  Alternative rejected: turning the empty state of `/law/cases` into the home,
+  which would leave the statutes entry as a second, different front door.
+- **Top tier by declared rank, not by volume.** The latest-decisions shelf
+  selects courts whose name matches the jurisdiction's highest tier in
+  `caseLawCourtWeights` (legacy tiers when the table has no rows for the
+  country), then returns the newest few per court with the existing lateral
+  statement and TTL cache. Alternative rejected: a hand-listed court name
+  array per country in the web app (drifts from the corpus and the weights).
+- **One home descriptor per jurisdiction in the web app**, `as const satisfies
+  Record<LawHomeJurisdiction, LawHomeDescriptor>`: which scopes exist
+  (statutes are `cze`/`svk` only today), identifier examples for each scope,
+  and the region code. Court tiers stay in the API (data), not the descriptor.
+  Adding a jurisdiction without a descriptor fails typecheck.
+- **Cards are signal-driven and omit themselves.** An empty response for a
+  card (no top-tier courts, no legislation entering into force, no research
+  tables) renders nothing, never a placeholder row.
+- **Legislation shelf in one endpoint** returning two lists over
+  `versionValidFrom`: recently in force (past 30 days, descending) and
+  entering into force (next 30 days, ascending), both restricted to
+  redistributable sources and current versions, cached like the decision
+  shelf. There is no promulgation date in the public schema: both legislation
+  adapters write `effectiveDate = validFrom`, so a "newly published" list would
+  be the same signal under a misleading name. Alternative rejected: adding a
+  promulgation column now (needs adapter work in the private repo first).
+- **Future decision dates are rejected at write time**: `canonicalDecisionDate`
+  gains an upper bound of the current UTC day; the SQL CHECK keeps its year
+  bound (a CHECK cannot depend on the clock). Existing rows dated after today
+  are nulled by the existing repair script path and counted in the PR.
+- **Not in this plan:** browse-by-area rail, editorial content, semantic
+  search toggle, the "Movement" (citation velocity and negative treatment)
+  card, the parked `feat/case-law-landing-wip` branch.
+
+## Scope
+
+In scope: `/law` home route and components, home descriptor, two shelf
+endpoints (decisions by top tier, legislation shelf), `/law/cases` empty-state
+redirect and removal of its shelf, research-tables card, identifier example
+chips, future-date guard and repair count, i18n keys, SEO head for `/law`.
+
+Out of scope: results-screen changes beyond the redirect (columns, chips and
+load-more stay on results), new tables, anything under `/law/cases/research`.
+
+## Vertical Slices
+
+1. **Top-tier decision shelf (API).** `handlers/case-law/decisions/latest.ts`
+   selects court buckets by tier using `loadCourtWeightsForCountry` and the
+   legacy fallback; response unchanged in shape plus `tierLabel` per court.
+   Tests in `browse-order.db.test.ts`: a district court with the largest bucket
+   is excluded, a supreme court with a small bucket is included, and a country
+   with no matching court yields an empty shelf.
+2. **Legislation shelf (API).** `GET /v1/law/statutes/shelf?country=` in
+   `handlers/legislation/`, column-restricted for the public reader role,
+   added to the public route census. Tests in `public-reads.db.test.ts` for
+   both lists and the 30-day window boundary.
+3. **Future-date guard (API).** Tighten `canonicalDecisionDate` to reject dates
+   after the current UTC day; unit test in `lib/dates.test.ts`; run the repair
+   plan against production reads and record the affected row count in the PR.
+4. **Home route (web).** `routes/law/index.tsx` renders the box (scope tabs
+   All / Legislation / Case law, jurisdiction pill defaulting from locale as
+   `/law/cases` does today), the cards, and the existing browse links below
+   the fold. Enter dispatches through both intent parsers by scope; a resolved
+   identifier opens the document, otherwise the query goes to the matching
+   results route. `/law/cases` redirects to `/law` when unfiltered; its shelf
+   component is deleted. Head and JSON-LD for `/law`.
+5. **Signed-in card (web).** Research tables list from the existing endpoint,
+   shown only with an active organization; anonymous users see nothing in that
+   slot.
+
+Each slice leaves the repository working; slices 1 to 3 can merge before 4.
+
+## Contracts and Invariants
+
+- `LawHomeDescriptor`: `{ region, scopes: readonly LawScope[], examples:
+  Record<LawScope, readonly string[]> }` with `LawScope = "decisions" |
+  "statutes"`; every example must parse to an identifier intent (tested).
+- Shelf endpoints are public reads through the restricted reader role; they
+  name their columns and never return metadata jsonb wholesale.
+- Card responses are bounded (`LIMITS.caseLawLatestPerCourt`, a new
+  `LIMITS.legislationShelfPerList`) and cached with the facets' TTL; failure
+  degrades to an empty card, logged through the shared logger.
+- The home never renders a decision dated after today; the guard is at
+  ingestion, not in the query.
+- No client-side sort on cards; order is the corpus's.
+
+## Verification
+
+- API db tests (pglite, reader role) for both shelves and the tier selection.
+- `dates.test.ts` for the upper bound; repair plan output recorded.
+- Web tests: descriptor examples parse (property over jurisdictions and
+  scopes), home renders cards only for non-empty responses, `/law/cases`
+  redirect rule.
+- `bun run verify` on the branch; local eyeballing on the prod-read stack.
+- Acceptance: `/law?country=CZE` shows supreme, administrative-supreme and
+  constitutional court decisions only in the decisions card; no future-dated
+  row anywhere; `/law/cases` with no filters lands on `/law`.
+
+## Rollout and Recovery
+
+Public repo PRs in slice order; no migration. The date guard changes only what
+future ingestion writes; the repair is idempotent and reversible by re-parse.
+Rollback is a revert of the web slice; API shelves are additive.
+
+## Open Questions
+
+None. (`effectiveDate` was checked against both legislation adapters: it is the
+version's entry into force, so the shelf uses `versionValidFrom` only.)

--- a/.agents/plans/20260902-080049-law-home-b52f33.md
+++ b/.agents/plans/20260902-080049-law-home-b52f33.md
@@ -153,9 +153,13 @@ Each slice leaves the repository working; slices 1 to 3 can merge before 4.
 
 ## Rollout and Recovery
 
-Public repo PRs in slice order; no migration. The date guard changes only what
-future ingestion writes; the repair is idempotent and reversible by re-parse.
-Rollback is a revert of the web slice; API shelves are additive.
+Public repo PRs in slice order. Two migrations: the court-weight seed
+(`20260902090000_case_law_court_weight_seed`, bounded to the declared keys,
+re-runnable, rolled back by re-running the previous release's seed) and the
+decision-date ceiling (`20260902100000_case_law_decision_date_ceiling`, clears
+the affected dates and swaps the CHECK; reversible by re-parse). The date
+guard changes only what future ingestion writes. Rollback of the web slice is
+a revert; API shelves are additive.
 
 ## Open Questions
 

--- a/apps/api/drizzle/20260902090000_case_law_court_weight_seed/migration.sql
+++ b/apps/api/drizzle/20260902090000_case_law_court_weight_seed/migration.sql
@@ -1,0 +1,31 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- Court rank per jurisdiction: the declaration in
+-- apps/api/src/handlers/case-law/court-weight-seed.ts, rendered by
+-- courtWeightSeedInsertSql() and held to it by court-weight-seed.test.ts.
+-- Idempotent on the (country, court_pattern) unique index, so a database
+-- seeded by the script keeps its rows.
+-- stella-migration-safety: reviewed insert-select - the source relation is a fourteen-row VALUES list, not a table, so the statement is bounded and instant; rollback deletes the same (country, court_pattern) keys
+INSERT INTO "case_law_court_weights" ("id", "country", "court_pattern", "tier", "tier_label", "weight")
+SELECT gen_random_uuid(), v.country, v.court_pattern, v.tier, v.tier_label, v.weight
+FROM (VALUES
+  ('CZE', 'ústavní soud', 4, 'constitutional', 10),
+  ('CZE', 'nejvyšší', 3, 'supreme', 8),
+  ('CZE', 'vrchní soud|krajský soud|městský soud', 2, 'regional', 4),
+  ('SVK', 'ústavný súd', 4, 'constitutional', 10),
+  ('SVK', 'najvyšší', 3, 'supreme', 8),
+  ('SVK', 'krajský súd', 2, 'regional', 4),
+  ('POL', 'trybunał konstytucyjny', 4, 'constitutional', 10),
+  ('POL', 'sąd najwyższy|naczelny sąd administracyjny', 3, 'supreme', 8),
+  ('POL', 'sąd apelacyjny|sąd okręgowy', 2, 'regional', 4),
+  ('AUT', 'verfassungsgerichtshof|^vfgh$', 4, 'constitutional', 10),
+  ('AUT', 'oberster gerichtshof|verwaltungsgerichtshof|^ogh$|^vwgh$', 3, 'supreme', 8),
+  ('AUT', 'oberlandesgericht|landesgericht', 2, 'regional', 4),
+  ('EU', 'court of justice', 4, 'constitutional', 10),
+  ('EU', 'general court', 3, 'supreme', 8)
+) AS v ("country", "court_pattern", "tier", "tier_label", "weight")
+WHERE NOT EXISTS (
+  SELECT 1 FROM "case_law_court_weights" w
+  WHERE w."country" = v.country AND w."court_pattern" = v.court_pattern
+);

--- a/apps/api/drizzle/20260902090000_case_law_court_weight_seed/migration.sql
+++ b/apps/api/drizzle/20260902090000_case_law_court_weight_seed/migration.sql
@@ -3,9 +3,32 @@ SET statement_timeout = '5s';--> statement-breakpoint
 
 -- Court rank per jurisdiction: the declaration in
 -- apps/api/src/handlers/case-law/court-weight-seed.ts, rendered by
--- courtWeightSeedInsertSql() and held to it by court-weight-seed.test.ts.
--- Idempotent on the (country, court_pattern) unique index, so a database
--- seeded by the script keeps its rows.
+-- courtWeightSeedSql() and held to it by court-weight-seed.test.ts.
+-- The declaration is the table's only writer: a row an older seed left at
+-- another rank is brought to the declared one, then the missing rows are
+-- added on the (country, court_pattern) unique index, so the pair is
+-- re-runnable; rollback re-runs the previous release's seed.
+UPDATE "case_law_court_weights" w
+SET "tier" = v.tier, "tier_label" = v.tier_label, "weight" = v.weight
+FROM (VALUES
+  ('CZE', 'ústavní soud', 4, 'constitutional', 10),
+  ('CZE', 'nejvyšší', 3, 'supreme', 8),
+  ('CZE', 'vrchní soud|krajský soud|městský soud', 2, 'regional', 4),
+  ('SVK', 'ústavný súd', 4, 'constitutional', 10),
+  ('SVK', 'najvyšší', 3, 'supreme', 8),
+  ('SVK', 'krajský súd', 2, 'regional', 4),
+  ('POL', 'trybunał konstytucyjny', 4, 'constitutional', 10),
+  ('POL', 'sąd najwyższy|naczelny sąd administracyjny', 3, 'supreme', 8),
+  ('POL', 'sąd apelacyjny|sąd okręgowy', 2, 'regional', 4),
+  ('AUT', 'verfassungsgerichtshof|^vfgh$', 4, 'constitutional', 10),
+  ('AUT', 'oberster gerichtshof|verwaltungsgerichtshof|^ogh$|^vwgh$', 3, 'supreme', 8),
+  ('AUT', 'oberlandesgericht|landesgericht', 2, 'regional', 4),
+  ('EU', 'court of justice', 4, 'constitutional', 10),
+  ('EU', 'general court', 3, 'supreme', 8)
+) AS v ("country", "court_pattern", "tier", "tier_label", "weight")
+WHERE w."country" = v.country AND w."court_pattern" = v.court_pattern
+  AND (w."tier", w."tier_label", w."weight") IS DISTINCT FROM (v.tier, v.tier_label, v.weight);
+--> statement-breakpoint
 -- stella-migration-safety: reviewed insert-select - the source relation is a fourteen-row VALUES list, not a table, so the statement is bounded and instant; rollback deletes the same (country, court_pattern) keys
 INSERT INTO "case_law_court_weights" ("id", "country", "court_pattern", "tier", "tier_label", "weight")
 SELECT gen_random_uuid(), v.country, v.court_pattern, v.tier, v.tier_label, v.weight

--- a/apps/api/scripts/mcp-coverage-guard.ts
+++ b/apps/api/scripts/mcp-coverage-guard.ts
@@ -88,7 +88,7 @@ const INLINE_ENDPOINT_ALLOWLIST: Record<string, number> = {
   "apps/api/src/handlers/case-law/decisions/public-subject.ts": 1,
   "apps/api/src/handlers/case-law/public-routes.ts": 10,
   "apps/api/src/handlers/files/routes.ts": 4,
-  "apps/api/src/handlers/legislation/public-routes.ts": 5,
+  "apps/api/src/handlers/legislation/public-routes.ts": 6,
   "apps/api/src/handlers/search/routes.ts": 5,
   "apps/api/src/handlers/workspaces/routes.ts": 4,
 };

--- a/apps/api/src/handlers/case-law/__tests__/citation-score.test.ts
+++ b/apps/api/src/handlers/case-law/__tests__/citation-score.test.ts
@@ -8,56 +8,47 @@ import {
   recencyFactor,
   weightedCitationSum,
 } from "@/api/handlers/case-law/citation-score";
+import { courtWeightMapFromSeed } from "@/api/handlers/case-law/court-weight-seed";
+import { flattenCourtWeightEntries } from "@/api/handlers/case-law/court-weights";
 import {
   POLARITIES,
   POLARITY,
   POLARITY_AUTHORITY_WEIGHT,
 } from "@/api/handlers/case-law/polarity/consts";
 
+/** The seeded weights, as production reads them from the migrated table. */
+const SEED_MAP = courtWeightMapFromSeed();
+
 describe("courtWeight", () => {
-  test("constitutional court → tier 4", () => {
-    expect(courtWeight("Ústavní soud")).toBe(4);
+  test("constitutional courts carry the seeded top weight", () => {
+    expect(courtWeight("Ústavní soud", SEED_MAP, "CZE")).toBe(10);
+    expect(courtWeight("Ústavný súd SR", SEED_MAP, "SVK")).toBe(10);
   });
 
-  test("slovak constitutional court → tier 4", () => {
-    expect(courtWeight("Ústavný súd SR")).toBe(4);
+  test("supreme courts, including the administrative one, share a weight", () => {
+    expect(courtWeight("Nejvyšší soud", SEED_MAP, "CZE")).toBe(8);
+    expect(courtWeight("Nejvyšší správní soud", SEED_MAP, "CZE")).toBe(8);
+    expect(courtWeight("Najvyšší súd SR", SEED_MAP, "SVK")).toBe(8);
   });
 
-  test("supreme court → tier 3", () => {
-    expect(courtWeight("Nejvyšší soud")).toBe(3);
+  test("regional, municipal and high courts share the regional weight", () => {
+    expect(courtWeight("Krajský soud v Brně", SEED_MAP, "CZE")).toBe(4);
+    expect(courtWeight("Městský soud v Praze", SEED_MAP, "CZE")).toBe(4);
+    expect(courtWeight("Vrchní soud v Praze", SEED_MAP, "CZE")).toBe(4);
   });
 
-  test("supreme admin court → tier 3", () => {
-    expect(courtWeight("Nejvyšší správní soud")).toBe(3);
+  test("district and unknown courts weigh the default", () => {
+    expect(courtWeight("Okresní soud v Ostravě", SEED_MAP, "CZE")).toBe(1);
+    expect(courtWeight("Random Court", SEED_MAP)).toBe(1);
   });
 
-  test("slovak supreme court → tier 3", () => {
-    expect(courtWeight("Najvyšší súd SR")).toBe(3);
-  });
-
-  test("regional court → tier 2", () => {
-    expect(courtWeight("Krajský soud v Brně")).toBe(2);
-  });
-
-  test("municipal court → tier 2", () => {
-    expect(courtWeight("Městský soud v Praze")).toBe(2);
-  });
-
-  test("high court → tier 2", () => {
-    expect(courtWeight("Vrchní soud v Praze")).toBe(2);
-  });
-
-  test("district court → tier 1 (default)", () => {
-    expect(courtWeight("Okresní soud v Ostravě")).toBe(1);
-  });
-
-  test("unknown court → tier 1 (default)", () => {
-    expect(courtWeight("Random Court")).toBe(1);
+  test("a court name is matched across jurisdictions when no country is given", () => {
+    expect(courtWeight("Sąd Najwyższy", SEED_MAP)).toBe(8);
   });
 
   test("case insensitive matching", () => {
-    expect(courtWeight("ÚSTAVNÍ SOUD")).toBe(4);
-    expect(courtWeight("nejvyšší soud")).toBe(3);
+    expect(courtWeight("ÚSTAVNÍ SOUD", SEED_MAP, "CZE")).toBe(10);
+    expect(courtWeight("nejvyšší soud", SEED_MAP, "CZE")).toBe(8);
   });
 });
 
@@ -100,7 +91,7 @@ describe("weightedCitationSum", () => {
   const now = new Date("2025-01-01");
 
   test("empty citations → 0", () => {
-    expect(weightedCitationSum([], now)).toBe(0);
+    expect(weightedCitationSum([], now, SEED_MAP)).toBe(0);
   });
 
   test("single recent supreme citation", () => {
@@ -112,9 +103,10 @@ describe("weightedCitationSum", () => {
         },
       ],
       now,
+      SEED_MAP,
     );
-    // courtWeight=3, recency≈1 → ~3
-    expect(sum).toBeCloseTo(3, 0);
+    // courtWeight=8, recency≈1 → ~8
+    expect(sum).toBeCloseTo(8, 0);
   });
 
   test("accumulates multiple citations", () => {
@@ -130,9 +122,10 @@ describe("weightedCitationSum", () => {
         },
       ],
       now,
+      SEED_MAP,
     );
-    // 3*1 + 2*0.5 = 4
-    expect(sum).toBeCloseTo(4, 0);
+    // 8*1 + 4*0.5 = 10
+    expect(sum).toBeCloseTo(10, 0);
   });
 });
 
@@ -140,7 +133,7 @@ describe("citationScore", () => {
   const now = new Date("2025-01-01");
 
   test("no citations → 0", () => {
-    expect(citationScore([], now)).toBe(0);
+    expect(citationScore([], now, SEED_MAP)).toBe(0);
   });
 
   test("positive with citations", () => {
@@ -152,6 +145,7 @@ describe("citationScore", () => {
         },
       ],
       now,
+      SEED_MAP,
     );
     expect(score).toBeGreaterThan(0);
   });
@@ -163,8 +157,8 @@ describe("citationScore", () => {
         citingDate: "2024-06-01",
       }));
 
-    const ten = citationScore(makeCitations(10), now);
-    const hundred = citationScore(makeCitations(100), now);
+    const ten = citationScore(makeCitations(10), now, SEED_MAP);
+    const hundred = citationScore(makeCitations(100), now, SEED_MAP);
 
     expect(hundred).toBeGreaterThan(ten);
     expect(hundred / ten).toBeLessThan(4);
@@ -180,6 +174,7 @@ describe("citationScore", () => {
         citingDate: "2024-11-01",
       })),
       now,
+      SEED_MAP,
     );
 
     const stale = citationScore(
@@ -188,6 +183,7 @@ describe("citationScore", () => {
         citingDate: "2005-01-01",
       })),
       now,
+      SEED_MAP,
     );
 
     expect(stillCited).toBeGreaterThan(stale);
@@ -217,14 +213,14 @@ describe("citationScore", () => {
       (a, b) => a + b,
       0,
     );
-    expect(weightedCitationSum(landmarkCitations, now)).toBeCloseTo(
+    expect(weightedCitationSum(landmarkCitations, now, SEED_MAP)).toBeCloseTo(
       10 * harmonic,
       1,
     );
-    expect(weightedCitationSum(recentCitations, now)).toBe(8);
+    expect(weightedCitationSum(recentCitations, now, SEED_MAP)).toBe(8);
 
-    const landmark = citationScore(landmarkCitations, now);
-    const recent = citationScore(recentCitations, now);
+    const landmark = citationScore(landmarkCitations, now, SEED_MAP);
+    const recent = citationScore(recentCitations, now, SEED_MAP);
 
     expect(landmark).toBeCloseTo(Math.log(1 + 10 * harmonic), 3);
     expect(recent).toBeCloseTo(Math.log(9), 12);
@@ -238,15 +234,27 @@ describe("citationScore", () => {
     const withDecisionAgeDivisor = (sum: number, yearsOld: number): number =>
       Math.log(1 + sum / Math.max(yearsOld, 1));
     expect(
-      withDecisionAgeDivisor(weightedCitationSum(landmarkCitations, now), 20),
+      withDecisionAgeDivisor(
+        weightedCitationSum(landmarkCitations, now, SEED_MAP),
+        20,
+      ),
     ).toBeCloseTo(1.03, 2);
     expect(
-      withDecisionAgeDivisor(weightedCitationSum(recentCitations, now), 2),
+      withDecisionAgeDivisor(
+        weightedCitationSum(recentCitations, now, SEED_MAP),
+        2,
+      ),
     ).toBeCloseTo(1.61, 2);
     expect(
-      withDecisionAgeDivisor(weightedCitationSum(landmarkCitations, now), 20),
+      withDecisionAgeDivisor(
+        weightedCitationSum(landmarkCitations, now, SEED_MAP),
+        20,
+      ),
     ).toBeLessThan(
-      withDecisionAgeDivisor(weightedCitationSum(recentCitations, now), 2),
+      withDecisionAgeDivisor(
+        weightedCitationSum(recentCitations, now, SEED_MAP),
+        2,
+      ),
     );
   });
 });
@@ -262,30 +270,36 @@ describe("polarity weighting", () => {
     const followed = weightedCitationSum(
       [citation, { ...citation, polarity: POLARITY.POSITIVE }],
       now,
+      SEED_MAP,
     );
     const overruled = weightedCitationSum(
       [citation, { ...citation, polarity: POLARITY.NEGATIVE }],
       now,
+      SEED_MAP,
     );
 
     // The two sets differ in one citation's polarity and nothing else, so the
     // gap is that citation's whole contribution: court weight times decay.
-    const contribution = weightedCitationSum([citation], now);
+    const contribution = weightedCitationSum([citation], now, SEED_MAP);
     expect(followed - overruled).toBeCloseTo(contribution, 12);
     expect(overruled).toBeCloseTo(contribution, 12);
     expect(
-      citationScore([{ ...citation, polarity: POLARITY.NEGATIVE }], now),
+      citationScore(
+        [{ ...citation, polarity: POLARITY.NEGATIVE }],
+        now,
+        SEED_MAP,
+      ),
     ).toBe(0);
   });
 
   test("an unclassified citation weighs the same as a classified neutral one", () => {
     // The corpus is mostly unclassified; scoring null below `neutral` would
     // rank classification coverage instead of case law.
-    const unclassified = weightedCitationSum([citation], now);
+    const unclassified = weightedCitationSum([citation], now, SEED_MAP);
     for (const polarity of POLARITIES) {
       if (polarity !== POLARITY.NEGATIVE) {
         expect(
-          weightedCitationSum([{ ...citation, polarity }], now),
+          weightedCitationSum([{ ...citation, polarity }], now, SEED_MAP),
         ).toBeCloseTo(unclassified, 12);
       }
     }
@@ -318,24 +332,19 @@ describe("polarityWeightSql", () => {
 // ASCII-safe fragments (weights, structure) rather than matching the
 // escaped accented text verbatim.
 describe("courtWeightSql", () => {
-  test("with no entries, falls back to the legacy hardcoded tiers (3 CZ/SK patterns)", () => {
-    const generated = courtWeightSql("citing_d.court");
-    expect(generated.match(/WHEN citing_d\.court ~\*/gu)).toHaveLength(3);
-    expect(generated).toContain("THEN 4");
-    expect(generated).toContain("THEN 3");
-    expect(generated).toContain("THEN 2");
+  test("renders one branch per seeded entry, highest tier first", () => {
+    const entries = flattenCourtWeightEntries(SEED_MAP);
+    const generated = courtWeightSql("citing_d.court", entries);
+    expect(generated.match(/WHEN citing_d\.court ~\*/gu)).toHaveLength(
+      entries.length,
+    );
+    expect(generated.indexOf("THEN 10")).toBeLessThan(
+      generated.indexOf("THEN 4"),
+    );
     expect(generated).toContain("ELSE 1 END");
   });
 
-  test("with explicit undefined entries, falls back to the legacy tiers", () => {
-    // Mirrors what callers pass when the DB-seeded table is empty
-    // (loadCourtWeightEntriesForSql() resolves to undefined, not []).
-    const withUndefined = courtWeightSql("citing_d.court", undefined);
-    const withOmitted = courtWeightSql("citing_d.court");
-    expect(withUndefined).toBe(withOmitted);
-  });
-
-  test("with DB-seeded entries, generates from those instead of the legacy tiers", () => {
+  test("generates from the given entries alone", () => {
     const generated = courtWeightSql("citing_d.court", [
       {
         pattern: /verfassungsgerichtshof/iu,
@@ -356,17 +365,13 @@ describe("courtWeightSql", () => {
     expect(generated).toContain("oberster gerichtshof");
     expect(generated).toContain("THEN 8");
     expect(generated.match(/WHEN citing_d\.court ~\*/gu)).toHaveLength(2);
-    // The legacy CZ/SK-only tiers must not leak in alongside the seeded
-    // entries (legacy tier 2's ASCII-safe fragment is distinctive).
+    // Nothing but the given entries: no other jurisdiction's pattern leaks in.
     expect(generated).not.toContain("krajsk");
     expect(generated).toContain("ELSE 1 END");
   });
 
-  test("an empty entries array does NOT fall back (documents the footgun that callers must avoid)", () => {
-    // courtWeightSql only falls back on `undefined`/omitted entries; an
-    // empty array is passed through verbatim. Callers that load from the
-    // DB must convert an empty result to `undefined`
-    // (see court-weights.test.ts: flattenCourtWeightEntries).
+  test("no entries renders the default weight for every court", () => {
+    // An unmigrated table: nothing to rank by, and nothing to fall back to.
     const generated = courtWeightSql("citing_d.court", []);
     expect(generated).toBe("CASE \n      ELSE 1 END");
   });

--- a/apps/api/src/handlers/case-law/citation-authority.test.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.test.ts
@@ -18,6 +18,8 @@ import {
   citationScore,
   type CitationInput,
 } from "@/api/handlers/case-law/citation-score";
+import { courtWeightMapFromSeed } from "@/api/handlers/case-law/court-weight-seed";
+import { flattenCourtWeightEntries } from "@/api/handlers/case-law/court-weights";
 import type { CourtWeightEntry } from "@/api/handlers/case-law/court-weights";
 import { POLARITY } from "@/api/handlers/case-law/polarity/consts";
 import { createSafeId } from "@/api/lib/branded-types";
@@ -63,6 +65,10 @@ const regionalCitingId = createSafeId<"caseLawDecision">();
 const overrulingCitingId = createSafeId<"caseLawDecision">();
 const orphanId = createSafeId<"caseLawDecision">();
 
+/** The seeded weights, as the migrated table gives them to production. */
+const SEED_MAP = courtWeightMapFromSeed();
+const SEED_ENTRIES = flattenCourtWeightEntries(SEED_MAP);
+
 type SweepOptions = {
   now?: Date;
   courtWeightEntries?: CourtWeightEntry[];
@@ -93,9 +99,7 @@ const sweep = async (
           ...(options.contributionWeight
             ? { contributionWeight: options.contributionWeight }
             : {}),
-          ...(options.courtWeightEntries
-            ? { courtWeightEntries: options.courtWeightEntries }
-            : {}),
+          courtWeightEntries: options.courtWeightEntries ?? SEED_ENTRIES,
         }),
     );
     if (batch.recomputed === 0) {
@@ -247,7 +251,7 @@ const snapshot = async (): Promise<
     .orderBy(caseLawDecisions.id);
 
 test("materialized authority equals citationScore() at the same instant", async () => {
-  const expected = citationScore([...CITED_CITATIONS], NOW);
+  const expected = citationScore([...CITED_CITATIONS], NOW, SEED_MAP);
 
   // Not vacuous: the negative treatment is a citation the sum has to drop.
   // Ignoring polarity would score the same fixture higher, so a SQL twin that
@@ -258,6 +262,7 @@ test("materialized authority equals citationScore() at the same instant", async 
       citingDate,
     })),
     NOW,
+    SEED_MAP,
   );
   expect(ignoringPolarity).toBeGreaterThan(expected);
 
@@ -276,15 +281,17 @@ test("a decision with no incoming citations has zero authority", async () => {
 });
 
 test("a more authoritative citing court yields higher authority", async () => {
-  // Same single citation, supreme (weight 3) vs regional (weight 2),
+  // Same single citation, supreme (weight 8) vs regional (weight 4),
   // controlling for date so only court weight differs.
   const supreme = citationScore(
     [{ citingCourt: "Nejvyšší soud", citingDate: "2024-01-01" }],
     NOW,
+    SEED_MAP,
   );
   const regional = citationScore(
     [{ citingCourt: "Krajský soud", citingDate: "2024-01-01" }],
     NOW,
+    SEED_MAP,
   );
   expect(supreme).toBeGreaterThan(regional);
 });
@@ -367,6 +374,7 @@ test("a resumed sweep skips what the interrupted one finished", async () => {
       await recomputeCitationAuthorityBatch(tx, {
         limit: 2,
         window: { type: "pinned", at: NOW },
+        courtWeightEntries: SEED_ENTRIES,
       }),
   );
   expect(interrupted.recomputed).toBe(2);
@@ -393,6 +401,7 @@ test("a rolling window converges even when the host clock runs ahead", async () 
         await recomputeCitationAuthorityBatch(tx, {
           limit: 1000,
           window: { type: "olderThan", ms: 60_000 },
+          courtWeightEntries: SEED_ENTRIES,
         }),
     );
     turnsTaken = turn;
@@ -451,7 +460,7 @@ test("the contribution weight is a seam the aggregate reads through", async () =
   await markAllDue();
   await sweep(1000, { contributionWeight: doubled });
 
-  const expected = citationScore([...CITED_CITATIONS], NOW);
+  const expected = citationScore([...CITED_CITATIONS], NOW, SEED_MAP);
   // score = ln(1 + sum), so doubling the sum is ln(1 + 2*(e^score - 1)).
   expect(await authorityOf(citedId)).toBeCloseTo(
     Math.log(1 + 2 * (Math.E ** expected - 1)),
@@ -519,13 +528,14 @@ test("courtWeightEntries option drives the SQL instead of the legacy tiers", asy
     ),
     9,
   );
-  // Sanity check: under the legacy fallback this citing court matches no
+  // Sanity check: under the seeded weights this citing court matches no
   // pattern (DEFAULT_WEIGHT=1), which differs from the custom weight (7)
   // enough that the assertion above cannot pass by coincidence.
   expect(await authorityOf(customCitedId)).not.toBeCloseTo(
     citationScore(
       [{ citingCourt: "Custom Seeded Court", citingDate: "2025-01-01" }],
       NOW,
+      SEED_MAP,
     ),
     2,
   );

--- a/apps/api/src/handlers/case-law/citation-authority.ts
+++ b/apps/api/src/handlers/case-law/citation-authority.ts
@@ -94,7 +94,7 @@ export type CitationContributionOptions = {
   aliases: CitationContributionAliases;
   /** The instant the batch is evaluated at. */
   now: SQL;
-  courtWeightEntries?: CourtWeightEntry[] | undefined;
+  courtWeightEntries: readonly CourtWeightEntry[];
 };
 
 /**
@@ -187,7 +187,7 @@ export type CitationAuthorityBatchOptions = {
    * needs no cursor and resumes wherever it was interrupted.
    */
   window: CitationAuthoritySweepWindow;
-  courtWeightEntries?: CourtWeightEntry[] | undefined;
+  courtWeightEntries: readonly CourtWeightEntry[];
   /** Defaults to `citationContributionWeight`. */
   contributionWeight?: CitationContributionWeight | undefined;
 };

--- a/apps/api/src/handlers/case-law/citation-score.ts
+++ b/apps/api/src/handlers/case-law/citation-score.ts
@@ -23,6 +23,7 @@
 
 import { DAY_IN_MS } from "@stll/time";
 
+import { courtWeightFromMap } from "@/api/handlers/case-law/court-weights";
 import type {
   CourtWeightEntry,
   CourtWeightMap,
@@ -36,79 +37,20 @@ import type { Polarity } from "@/api/handlers/case-law/polarity/consts";
 /** Average (Julian) year, used for citation-age decay. A duration. */
 const MS_PER_YEAR = 365.25 * DAY_IN_MS;
 
-// -- Legacy fallback tiers -----------------------------------------------
-
-/**
- * Hardcoded fallback used when the database table has not
- * been seeded yet. Prefer `loadCourtWeights()` in production.
- */
-const LEGACY_COURT_TIERS: CourtWeightEntry[] = [
-  {
-    weight: 4,
-    tier: 4,
-    tierLabel: "constitutional",
-    pattern: /ústavní soud|ústavný súd/iu,
-  },
-  {
-    weight: 3,
-    tier: 3,
-    tierLabel: "supreme",
-    pattern: /nejvyšší|najvyšší/iu,
-  },
-  {
-    weight: 2,
-    tier: 2,
-    tierLabel: "regional",
-    pattern: /vrchní soud|krajský soud|městský soud|krajský súd/iu,
-  },
-];
-
 const DEFAULT_WEIGHT = 1;
 
 // -- Court weight lookup -------------------------------------------------
 
 /**
- * Return the authority weight for a court name.
- *
- * When `weightMap` is provided, uses the database-driven
- * weights. Otherwise falls back to the legacy hardcoded list.
+ * The authority weight of a court name under the seeded weights: the given
+ * country's entries first, then any country's, else the default. The map is
+ * the database's; there is no built-in list to fall back to.
  */
 export const courtWeight = (
   court: string,
-  weightMap?: CourtWeightMap,
+  weightMap: CourtWeightMap,
   country?: string,
-): number => {
-  if (weightMap) {
-    // Check country-specific entries first.
-    if (country) {
-      const entries = weightMap.get(country);
-      if (entries) {
-        for (const e of entries) {
-          if (e.pattern.test(court)) {
-            return e.weight;
-          }
-        }
-      }
-    }
-    // Fallback: check all countries.
-    for (const entries of weightMap.values()) {
-      for (const e of entries) {
-        if (e.pattern.test(court)) {
-          return e.weight;
-        }
-      }
-    }
-    return DEFAULT_WEIGHT;
-  }
-
-  // Legacy path (no map loaded).
-  for (const tier of LEGACY_COURT_TIERS) {
-    if (tier.pattern.test(court)) {
-      return tier.weight;
-    }
-  }
-  return DEFAULT_WEIGHT;
-};
+): number => courtWeightFromMap(weightMap, court, country).weight;
 
 // -- Recency decay -------------------------------------------------------
 
@@ -169,8 +111,8 @@ export type CitationInput = {
  */
 export const weightedCitationSum = (
   citations: CitationInput[],
-  now: Date = new Date(),
-  weightMap?: CourtWeightMap,
+  now: Date,
+  weightMap: CourtWeightMap,
 ): number => {
   let sum = 0;
   for (const c of citations) {
@@ -191,8 +133,8 @@ export const weightedCitationSum = (
  */
 export const citationScore = (
   citations: CitationInput[],
-  now: Date = new Date(),
-  weightMap?: CourtWeightMap,
+  now: Date,
+  weightMap: CourtWeightMap,
 ): number => Math.log(1 + weightedCitationSum(citations, now, weightMap));
 
 // -- SQL fragments -------------------------------------------------------
@@ -215,18 +157,15 @@ export const polarityWeightSql = (polarityColumn: string): string => {
 };
 
 /**
- * Build a SQL CASE expression for court weights.
- *
- * When `entries` is provided, generates from database-driven
- * weights. Otherwise uses the legacy hardcoded list.
+ * The SQL CASE expression for court weights, rendered from the seeded
+ * entries (highest tier first, so the first matching branch is the rank).
+ * No entries renders a bare `ELSE`: every court weighs the default.
  */
 export const courtWeightSql = (
   courtColumn: string,
-  entries?: CourtWeightEntry[],
+  entries: readonly CourtWeightEntry[],
 ): string => {
-  const source = entries ?? LEGACY_COURT_TIERS;
-
-  const cases = source
+  const cases = entries
     .map((e) => {
       const src = e.pattern.source.replace(/'/gu, "''");
       return `WHEN ${courtColumn} ~* '${src}' THEN ${e.weight}`;

--- a/apps/api/src/handlers/case-law/court-weight-seed.db.test.ts
+++ b/apps/api/src/handlers/case-law/court-weight-seed.db.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+import nodePath from "node:path";
+
+import { caseLawCourtWeights } from "@/api/db/schema";
+import { COURT_WEIGHT_SEED } from "@/api/handlers/case-law/court-weight-seed";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+const MIGRATION = nodePath.resolve(
+  import.meta.dir,
+  "../../../drizzle/20260902090000_case_law_court_weight_seed/migration.sql",
+);
+
+test("the seed migration applies and is idempotent", async () => {
+  const client = await createTestPglite();
+  const db = drizzle({ client });
+  const statements = (await Bun.file(MIGRATION).text())
+    .split("--> statement-breakpoint")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  for (const statement of statements) {
+    // oxlint-disable-next-line no-await-in-loop -- statements apply in order
+    await db.execute(sql.raw(statement));
+  }
+  const first = await db.select().from(caseLawCourtWeights);
+  expect(first).toHaveLength(COURT_WEIGHT_SEED.length);
+  for (const statement of statements) {
+    // oxlint-disable-next-line no-await-in-loop -- statements apply in order
+    await db.execute(sql.raw(statement));
+  }
+  const second = await db.select().from(caseLawCourtWeights);
+  expect(second).toHaveLength(COURT_WEIGHT_SEED.length);
+  expect(
+    second.find((row) => row.country === "EU" && row.tierLabel === "supreme")
+      ?.weight,
+  ).toBe(8);
+  await client.close();
+}, 60_000);

--- a/apps/api/src/handlers/case-law/court-weight-seed.db.test.ts
+++ b/apps/api/src/handlers/case-law/court-weight-seed.db.test.ts
@@ -5,6 +5,7 @@ import nodePath from "node:path";
 
 import { caseLawCourtWeights } from "@/api/db/schema";
 import { COURT_WEIGHT_SEED } from "@/api/handlers/case-law/court-weight-seed";
+import { createSafeId } from "@/api/lib/branded-types";
 import { createTestPglite } from "@/api/tests/pglite-test-db";
 
 const MIGRATION = nodePath.resolve(
@@ -12,19 +13,33 @@ const MIGRATION = nodePath.resolve(
   "../../../drizzle/20260902090000_case_law_court_weight_seed/migration.sql",
 );
 
-test("the seed migration applies and is idempotent", async () => {
+test("the seed migration applies, brings a stale row to the declared rank, and is idempotent", async () => {
   const client = await createTestPglite();
   const db = drizzle({ client });
   const statements = (await Bun.file(MIGRATION).text())
     .split("--> statement-breakpoint")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
+  // A database seeded by an older script holds the key at another rank.
+  await db.insert(caseLawCourtWeights).values({
+    id: createSafeId<"caseLawCourtWeight">(),
+    country: "EU",
+    courtPattern: "general court",
+    tier: 1,
+    tierLabel: "stale",
+    weight: 1,
+  });
   for (const statement of statements) {
     // oxlint-disable-next-line no-await-in-loop -- statements apply in order
     await db.execute(sql.raw(statement));
   }
   const first = await db.select().from(caseLawCourtWeights);
   expect(first).toHaveLength(COURT_WEIGHT_SEED.length);
+  expect(
+    first.find(
+      (row) => row.country === "EU" && row.courtPattern === "general court",
+    ),
+  ).toMatchObject({ tier: 3, tierLabel: "supreme", weight: 8 });
   for (const statement of statements) {
     // oxlint-disable-next-line no-await-in-loop -- statements apply in order
     await db.execute(sql.raw(statement));

--- a/apps/api/src/handlers/case-law/court-weight-seed.test.ts
+++ b/apps/api/src/handlers/case-law/court-weight-seed.test.ts
@@ -5,7 +5,8 @@ import {
   COURT_WEIGHT_SEED,
   courtWeightEntriesFromSeed,
   courtWeightMapFromSeed,
-  courtWeightSeedInsertSql,
+  courtWeightSeedSql,
+  seededCourtWeightEntries,
 } from "@/api/handlers/case-law/court-weight-seed";
 
 const MIGRATION = nodePath.resolve(
@@ -16,7 +17,7 @@ const MIGRATION = nodePath.resolve(
 describe("court weight seed", () => {
   test("the seed migration is the rendering of the declaration", async () => {
     const migration = await Bun.file(MIGRATION).text();
-    expect(migration.trimEnd().endsWith(courtWeightSeedInsertSql())).toBe(true);
+    expect(migration.trimEnd().endsWith(courtWeightSeedSql())).toBe(true);
   });
 
   test("every jurisdiction declares a constitutional and a supreme rank", () => {
@@ -61,9 +62,8 @@ describe("court weight seed", () => {
       ["EU", "Court of Justice", "constitutional"],
       ["EU", "General Court", "supreme"],
     ];
-    const map = courtWeightMapFromSeed();
     for (const [country, court, label] of stored) {
-      const entry = (map.get(country) ?? []).find((candidate) =>
+      const entry = seededCourtWeightEntries(country).find((candidate) =>
         candidate.pattern.test(court),
       );
       expect([country, court, entry?.tierLabel]).toEqual([

--- a/apps/api/src/handlers/case-law/court-weight-seed.test.ts
+++ b/apps/api/src/handlers/case-law/court-weight-seed.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import nodePath from "node:path";
+
+import {
+  COURT_WEIGHT_SEED,
+  courtWeightEntriesFromSeed,
+  courtWeightMapFromSeed,
+  courtWeightSeedInsertSql,
+} from "@/api/handlers/case-law/court-weight-seed";
+
+const MIGRATION = nodePath.resolve(
+  import.meta.dir,
+  "../../../drizzle/20260902090000_case_law_court_weight_seed/migration.sql",
+);
+
+describe("court weight seed", () => {
+  test("the seed migration is the rendering of the declaration", async () => {
+    const migration = await Bun.file(MIGRATION).text();
+    expect(migration.trimEnd().endsWith(courtWeightSeedInsertSql())).toBe(true);
+  });
+
+  test("every jurisdiction declares a constitutional and a supreme rank", () => {
+    const map = courtWeightMapFromSeed();
+    expect([...map.keys()].toSorted()).toEqual([
+      "AUT",
+      "CZE",
+      "EU",
+      "POL",
+      "SVK",
+    ]);
+    for (const [country, entries] of map) {
+      const labels = entries.map((entry) => entry.tierLabel);
+      expect(labels, country).toContain("constitutional");
+      expect(labels, country).toContain("supreme");
+      expect(entries.map((entry) => entry.tier)).toEqual(
+        entries.map((entry) => entry.tier).toSorted((a, b) => b - a),
+      );
+    }
+  });
+
+  test("court names as the adapters store them rank where the seed intends", () => {
+    // The stored spellings, taken from the adapters' fixtures: full names,
+    // bracketed abbreviations, bare abbreviations. A spelling the seed misses
+    // silently demotes a supreme court to a district court.
+    const stored: readonly [country: string, court: string, label: string][] = [
+      ["CZE", "Ústavní soud", "constitutional"],
+      ["CZE", "Nejvyšší soud", "supreme"],
+      ["CZE", "Nejvyšší správní soud", "supreme"],
+      ["CZE", "Krajský soud v Brně", "regional"],
+      ["SVK", "Najvyšší súd Slovenskej republiky", "supreme"],
+      ["SVK", "Najvyšší správny súd Slovenskej republiky", "supreme"],
+      ["SVK", "Ústavný súd Slovenskej republiky", "constitutional"],
+      ["POL", "Sąd Najwyższy", "supreme"],
+      ["POL", "Naczelny Sąd Administracyjny", "supreme"],
+      ["POL", "Trybunał Konstytucyjny", "constitutional"],
+      ["AUT", "OGH", "supreme"],
+      ["AUT", "VwGH", "supreme"],
+      ["AUT", "VfGH", "constitutional"],
+      ["AUT", "Verfassungsgerichtshof (VfGH)", "constitutional"],
+      ["AUT", "Verwaltungsgerichtshof (VwGH)", "supreme"],
+      ["EU", "Court of Justice", "constitutional"],
+      ["EU", "General Court", "supreme"],
+    ];
+    const map = courtWeightMapFromSeed();
+    for (const [country, court, label] of stored) {
+      const entry = (map.get(country) ?? []).find((candidate) =>
+        candidate.pattern.test(court),
+      );
+      expect([country, court, entry?.tierLabel]).toEqual([
+        country,
+        court,
+        label,
+      ]);
+    }
+  });
+
+  test("patterns are unique per jurisdiction and compile case-insensitively", () => {
+    const keys = COURT_WEIGHT_SEED.map(
+      (row) => `${row.country}:${row.courtPattern}`,
+    );
+    expect(new Set(keys).size).toBe(keys.length);
+    const entries = courtWeightEntriesFromSeed();
+    expect(entries).toHaveLength(COURT_WEIGHT_SEED.length);
+    expect(entries.every((entry) => entry.pattern.flags.includes("i"))).toBe(
+      true,
+    );
+  });
+});

--- a/apps/api/src/handlers/case-law/court-weight-seed.ts
+++ b/apps/api/src/handlers/case-law/court-weight-seed.ts
@@ -1,0 +1,188 @@
+import type {
+  CourtWeightEntry,
+  CourtWeightMap,
+} from "@/api/handlers/case-law/court-weights";
+import { arrayOrEmpty } from "@/api/lib/array";
+
+/**
+ * The court rank declaration every jurisdiction ships with. The migration
+ * `case_law_court_weight_seed` inserts exactly these rows, so a deployed
+ * database is never without them; `seed-court-weights.ts` re-upserts them
+ * after an edit here, and `court-weight-seed.test.ts` holds the migration to
+ * this list. Ranking code reads the table, never this constant.
+ */
+
+export type CourtWeightSeedRow = {
+  country: string;
+  courtPattern: string;
+  tier: number;
+  tierLabel: string;
+  weight: number;
+};
+
+export const COURT_WEIGHT_SEED: readonly CourtWeightSeedRow[] = [
+  // Czech Republic
+  {
+    country: "CZE",
+    courtPattern: "ústavní soud",
+    tier: 4,
+    tierLabel: "constitutional",
+    weight: 10,
+  },
+  {
+    country: "CZE",
+    courtPattern: "nejvyšší",
+    tier: 3,
+    tierLabel: "supreme",
+    weight: 8,
+  },
+  {
+    country: "CZE",
+    courtPattern: "vrchní soud|krajský soud|městský soud",
+    tier: 2,
+    tierLabel: "regional",
+    weight: 4,
+  },
+  // Slovakia
+  {
+    country: "SVK",
+    courtPattern: "ústavný súd",
+    tier: 4,
+    tierLabel: "constitutional",
+    weight: 10,
+  },
+  {
+    country: "SVK",
+    courtPattern: "najvyšší",
+    tier: 3,
+    tierLabel: "supreme",
+    weight: 8,
+  },
+  {
+    country: "SVK",
+    courtPattern: "krajský súd",
+    tier: 2,
+    tierLabel: "regional",
+    weight: 4,
+  },
+  // Poland
+  {
+    country: "POL",
+    courtPattern: "trybunał konstytucyjny",
+    tier: 4,
+    tierLabel: "constitutional",
+    weight: 10,
+  },
+  {
+    country: "POL",
+    courtPattern: "sąd najwyższy|naczelny sąd administracyjny",
+    tier: 3,
+    tierLabel: "supreme",
+    weight: 8,
+  },
+  {
+    country: "POL",
+    courtPattern: "sąd apelacyjny|sąd okręgowy",
+    tier: 2,
+    tierLabel: "regional",
+    weight: 4,
+  },
+  // Austria. The RIS feeds store the court as the publisher's abbreviation
+  // (`OGH`, `VwGH`, `VfGH`) or as the full name with the abbreviation in
+  // brackets, so both spellings are ranked. Anchors rather than `\b`: the
+  // same pattern runs as a JavaScript RegExp and as a PostgreSQL `~*` ARE,
+  // and the two do not agree on word-boundary escapes.
+  {
+    country: "AUT",
+    courtPattern: "verfassungsgerichtshof|^vfgh$",
+    tier: 4,
+    tierLabel: "constitutional",
+    weight: 10,
+  },
+  {
+    country: "AUT",
+    courtPattern: "oberster gerichtshof|verwaltungsgerichtshof|^ogh$|^vwgh$",
+    tier: 3,
+    tierLabel: "supreme",
+    weight: 8,
+  },
+  {
+    country: "AUT",
+    courtPattern: "oberlandesgericht|landesgericht",
+    tier: 2,
+    tierLabel: "regional",
+    weight: 4,
+  },
+  // European Union
+  {
+    country: "EU",
+    courtPattern: "court of justice",
+    tier: 4,
+    tierLabel: "constitutional",
+    weight: 10,
+  },
+  {
+    country: "EU",
+    courtPattern: "general court",
+    tier: 3,
+    tierLabel: "supreme",
+    weight: 8,
+  },
+];
+
+const compile = (row: CourtWeightSeedRow): CourtWeightEntry => ({
+  pattern: new RegExp(row.courtPattern, "iu"),
+  tier: row.tier,
+  tierLabel: row.tierLabel,
+  weight: row.weight,
+});
+
+/**
+ * The seed as the loader would return it from a seeded table: entries per
+ * country, highest tier first. For tests and tools that must rank exactly as
+ * production does without a database.
+ */
+export const courtWeightMapFromSeed = (): CourtWeightMap => {
+  const map: CourtWeightMap = new Map();
+  for (const row of COURT_WEIGHT_SEED) {
+    const entries = arrayOrEmpty(map.get(row.country));
+    entries.push(compile(row));
+    map.set(row.country, entries);
+  }
+  for (const entries of map.values()) {
+    entries.sort((a, b) => b.tier - a.tier);
+  }
+  return map;
+};
+
+/** Every seeded entry across jurisdictions, highest tier first. */
+export const courtWeightEntriesFromSeed = (): CourtWeightEntry[] =>
+  [...courtWeightMapFromSeed().values()]
+    .flat()
+    .toSorted((a, b) => b.tier - a.tier);
+
+const sqlLiteral = (value: string): string => `'${value.replace(/'/gu, "''")}'`;
+
+/**
+ * The `INSERT` the seed migration carries, rendered from the list above so
+ * the two cannot drift: the migration file is compared to this text.
+ */
+export const courtWeightSeedInsertSql = (): string => {
+  const values = COURT_WEIGHT_SEED.map(
+    (row) =>
+      `  (${sqlLiteral(row.country)}, ${sqlLiteral(row.courtPattern)}, ${String(row.tier)}, ${sqlLiteral(row.tierLabel)}, ${String(row.weight)})`,
+  ).join(",\n");
+  // The arbiter is a unique index, not a named constraint, so the rows that
+  // already exist are skipped by an anti-join rather than ON CONFLICT.
+  return [
+    'INSERT INTO "case_law_court_weights" ("id", "country", "court_pattern", "tier", "tier_label", "weight")',
+    "SELECT gen_random_uuid(), v.country, v.court_pattern, v.tier, v.tier_label, v.weight",
+    "FROM (VALUES",
+    values,
+    ') AS v ("country", "court_pattern", "tier", "tier_label", "weight")',
+    "WHERE NOT EXISTS (",
+    '  SELECT 1 FROM "case_law_court_weights" w',
+    '  WHERE w."country" = v.country AND w."court_pattern" = v.court_pattern',
+    ");",
+  ].join("\n");
+};

--- a/apps/api/src/handlers/case-law/court-weight-seed.ts
+++ b/apps/api/src/handlers/case-law/court-weight-seed.ts
@@ -1,3 +1,5 @@
+import { panic } from "better-result";
+
 import type {
   CourtWeightEntry,
   CourtWeightMap,
@@ -155,6 +157,17 @@ export const courtWeightMapFromSeed = (): CourtWeightMap => {
   return map;
 };
 
+/**
+ * One jurisdiction's seeded entries, highest tier first. A jurisdiction the
+ * seed does not declare is a programming error here, never an empty rank: a
+ * caller handed no entries would exercise the unseeded path by accident.
+ */
+export const seededCourtWeightEntries = (
+  country: string,
+): readonly CourtWeightEntry[] =>
+  courtWeightMapFromSeed().get(country) ??
+  panic(`court weight seed declares no jurisdiction ${country}`);
+
 /** Every seeded entry across jurisdictions, highest tier first. */
 export const courtWeightEntriesFromSeed = (): CourtWeightEntry[] =>
   [...courtWeightMapFromSeed().values()]
@@ -163,26 +176,43 @@ export const courtWeightEntriesFromSeed = (): CourtWeightEntry[] =>
 
 const sqlLiteral = (value: string): string => `'${value.replace(/'/gu, "''")}'`;
 
+const SEED_COLUMNS =
+  '"country", "court_pattern", "tier", "tier_label", "weight"';
+
 /**
- * The `INSERT` the seed migration carries, rendered from the list above so
- * the two cannot drift: the migration file is compared to this text.
+ * The statements the seed migration carries, rendered from the list above
+ * so the two cannot drift: the migration file is compared to this text.
+ * The declaration is the table's only writer, so a row an older seed left
+ * at another rank is brought to the declared one before the missing rows
+ * are added; both statements read the VALUES list, never a table.
  */
-export const courtWeightSeedInsertSql = (): string => {
-  const values = COURT_WEIGHT_SEED.map(
-    (row) =>
-      `  (${sqlLiteral(row.country)}, ${sqlLiteral(row.courtPattern)}, ${String(row.tier)}, ${sqlLiteral(row.tierLabel)}, ${String(row.weight)})`,
-  ).join(",\n");
+export const courtWeightSeedSql = (): string => {
+  const values = [
+    "(VALUES",
+    COURT_WEIGHT_SEED.map(
+      (row) =>
+        `  (${sqlLiteral(row.country)}, ${sqlLiteral(row.courtPattern)}, ${String(row.tier)}, ${sqlLiteral(row.tierLabel)}, ${String(row.weight)})`,
+    ).join(",\n"),
+    `) AS v (${SEED_COLUMNS})`,
+  ].join("\n");
+  const update = [
+    'UPDATE "case_law_court_weights" w',
+    'SET "tier" = v.tier, "tier_label" = v.tier_label, "weight" = v.weight',
+    `FROM ${values}`,
+    'WHERE w."country" = v.country AND w."court_pattern" = v.court_pattern',
+    '  AND (w."tier", w."tier_label", w."weight") IS DISTINCT FROM (v.tier, v.tier_label, v.weight);',
+  ].join("\n");
   // The arbiter is a unique index, not a named constraint, so the rows that
   // already exist are skipped by an anti-join rather than ON CONFLICT.
-  return [
-    'INSERT INTO "case_law_court_weights" ("id", "country", "court_pattern", "tier", "tier_label", "weight")',
+  const insert = [
+    "-- stella-migration-safety: reviewed insert-select - the source relation is a fourteen-row VALUES list, not a table, so the statement is bounded and instant; rollback deletes the same (country, court_pattern) keys",
+    `INSERT INTO "case_law_court_weights" ("id", ${SEED_COLUMNS})`,
     "SELECT gen_random_uuid(), v.country, v.court_pattern, v.tier, v.tier_label, v.weight",
-    "FROM (VALUES",
-    values,
-    ') AS v ("country", "court_pattern", "tier", "tier_label", "weight")',
+    `FROM ${values}`,
     "WHERE NOT EXISTS (",
     '  SELECT 1 FROM "case_law_court_weights" w',
     '  WHERE w."country" = v.country AND w."court_pattern" = v.court_pattern',
     ");",
   ].join("\n");
+  return [update, "--> statement-breakpoint", insert].join("\n");
 };

--- a/apps/api/src/handlers/case-law/court-weights.test.ts
+++ b/apps/api/src/handlers/case-law/court-weights.test.ts
@@ -69,17 +69,16 @@ describe("courtWeightFromMap", () => {
 });
 
 describe("flattenCourtWeightEntries", () => {
-  test("empty map → undefined (preserves courtWeightSql's legacy fallback)", () => {
-    expect(flattenCourtWeightEntries(new Map())).toBeUndefined();
+  test("empty map → no entries", () => {
+    expect(flattenCourtWeightEntries(new Map())).toEqual([]);
   });
 
   test("flattens entries across every country, sorted by tier descending", () => {
     const flattened = flattenCourtWeightEntries(buildMap());
-    expect(flattened).toBeDefined();
     expect(flattened).toHaveLength(3);
-    expect(flattened?.map((e) => e.tier)).toEqual([4, 3, 3]);
+    expect(flattened.map((e) => e.tier)).toEqual([4, 3, 3]);
     // Both country's entries are present, not just the first country's.
-    expect(flattened?.map((e) => e.tierLabel)).toContain("constitutional");
-    expect(flattened?.filter((e) => e.tierLabel === "supreme")).toHaveLength(2);
+    expect(flattened.map((e) => e.tierLabel)).toContain("constitutional");
+    expect(flattened.filter((e) => e.tierLabel === "supreme")).toHaveLength(2);
   });
 });

--- a/apps/api/src/handlers/case-law/court-weights.ts
+++ b/apps/api/src/handlers/case-law/court-weights.ts
@@ -1,8 +1,6 @@
 /**
- * Dynamic court weight loader with in-memory cache.
- *
- * Replaces the hardcoded COURT_TIERS array in citation-score.ts
- * with database-driven weights per jurisdiction.
+ * Court weight loader with in-memory cache: the seeded per-jurisdiction rank
+ * table, compiled once a minute.
  */
 
 import { arrayOrEmpty } from "@/api/lib/array";
@@ -36,13 +34,11 @@ export const loadCourtWeights = async (): Promise<CourtWeightMap> => {
   const rows = await readCourtWeightRows();
 
   if (rows.length === 0) {
-    // Self-host before seeding, or a fresh environment that has not run
-    // seed-court-weights.ts yet: callers fall back to the hardcoded
-    // LEGACY_COURT_TIERS in citation-score.ts. Surface this so an
-    // unseeded production table is visible rather than silently ranking
-    // every non-CZ/SK court the same.
+    // The seed migration inserts the rows, so an empty table is a database
+    // that was not migrated. Every court then weighs the default; this line
+    // is what makes that visible.
     logger.warn("case_law.court_weights.table_empty", {
-      fallback: "legacy_hardcoded_tiers",
+      effect: "default_weight_for_every_court",
     });
   }
 
@@ -134,36 +130,29 @@ export const loadCourtWeightsForCountry = async (
  * this WeakMap simply misses and recomputes, and the old entry is GC'd along
  * with its map.
  */
-const flattenedEntriesCache = new WeakMap<
-  CourtWeightMap,
-  CourtWeightEntry[] | undefined
->();
+const flattenedEntriesCache = new WeakMap<CourtWeightMap, CourtWeightEntry[]>();
 
 /**
  * Flatten every country's entries into one list, sorted by tier
  * descending so the highest-authority pattern is checked first.
  *
  * For building a single SQL `CASE` expression (`courtWeightSql`) that is
- * not scoped to one jurisdiction — citation graphs cross borders, so the
+ * not scoped to one jurisdiction: citation graphs cross borders, so the
  * citing court in `citation-authority.ts` and `decisions/search.ts` can
- * belong to any seeded country.
- *
- * Returns `undefined` when the map is empty so callers can pass that
- * straight to `courtWeightSql`'s `entries` parameter: an empty array
- * would short-circuit its `entries ?? LEGACY_COURT_TIERS` fallback,
- * silently disabling the legacy tiers instead of falling back to them.
+ * belong to any seeded country. An empty map flattens to an empty list,
+ * which renders as the default weight for every court.
  */
 export const flattenCourtWeightEntries = (
   map: CourtWeightMap,
-): CourtWeightEntry[] | undefined => {
-  if (flattenedEntriesCache.has(map)) {
-    return flattenedEntriesCache.get(map);
+): CourtWeightEntry[] => {
+  const flattened = flattenedEntriesCache.get(map);
+  if (flattened !== undefined) {
+    return flattened;
   }
 
   const entries = [...map.values()].flat().sort((a, b) => b.tier - a.tier);
-  const result = entries.length > 0 ? entries : undefined;
-  flattenedEntriesCache.set(map, result);
-  return result;
+  flattenedEntriesCache.set(map, entries);
+  return entries;
 };
 
 /**
@@ -171,5 +160,5 @@ export const flattenCourtWeightEntries = (
  * expression. See `flattenCourtWeightEntries`.
  */
 export const loadCourtWeightEntriesForSql = async (): Promise<
-  CourtWeightEntry[] | undefined
+  CourtWeightEntry[]
 > => flattenCourtWeightEntries(await loadCourtWeights());

--- a/apps/api/src/handlers/case-law/decisions/browse-order.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/browse-order.db.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, expect, test } from "bun:test";
 import { drizzle } from "drizzle-orm/pglite";
 
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
-import { courtWeightMapFromSeed } from "@/api/handlers/case-law/court-weight-seed";
+import { seededCourtWeightEntries } from "@/api/handlers/case-law/court-weight-seed";
 import { readLatestDecisionsByCourt } from "@/api/handlers/case-law/decisions/latest";
 import { listDecisionsHandler } from "@/api/handlers/case-law/decisions/list";
 import { readShelfCourts } from "@/api/handlers/case-law/decisions/shelf-courts";
@@ -257,7 +257,7 @@ test(
     const courts = await readShelfCourts({
       caseLawDb,
       country: "SVK",
-      entries: courtWeightMapFromSeed().get("SVK") ?? [],
+      entries: seededCourtWeightEntries("SVK"),
     });
     // Six district judgments outnumber the one supreme judgment; rank wins.
     expect(courts).toEqual([

--- a/apps/api/src/handlers/case-law/decisions/browse-order.db.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/browse-order.db.test.ts
@@ -3,8 +3,10 @@ import { afterAll, beforeAll, expect, test } from "bun:test";
 import { drizzle } from "drizzle-orm/pglite";
 
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
+import { courtWeightMapFromSeed } from "@/api/handlers/case-law/court-weight-seed";
 import { readLatestDecisionsByCourt } from "@/api/handlers/case-law/decisions/latest";
 import { listDecisionsHandler } from "@/api/handlers/case-law/decisions/list";
+import { readShelfCourts } from "@/api/handlers/case-law/decisions/shelf-courts";
 import { createSafeId } from "@/api/lib/branded-types";
 import type {
   CaseLawPublicReadDb,
@@ -29,6 +31,7 @@ const sourceId = createSafeId<"caseLawSource">();
 type Seed = {
   caseNumber: string;
   court: string;
+  country?: string;
   createdAt: Date;
   decisionDate: string | null;
   language: string;
@@ -71,6 +74,26 @@ const seeds: Seed[] = [
     language,
     languageGroupKey: "ECLI:EU:C:2014:317",
   })),
+  // A second jurisdiction whose busiest court is a district court: six newer
+  // district judgments against one supreme judgment.
+  ...Array.from({ length: 6 }, (_, i) => ({
+    caseNumber: `${i + 1} C ${i + 1}/2025`,
+    court: "Okresný súd Bratislava I",
+    country: "SVK",
+    createdAt: day(40 + i),
+    decisionDate: `2025-02-${String(i + 1).padStart(2, "0")}`,
+    language: "sk",
+    languageGroupKey: null,
+  })),
+  {
+    caseNumber: "1 Cdo 9/2024",
+    court: "Najvyšší súd Slovenskej republiky",
+    country: "SVK",
+    createdAt: day(50),
+    decisionDate: "2024-12-01",
+    language: "sk",
+    languageGroupKey: null,
+  },
 ];
 
 let client: PGlite;
@@ -103,7 +126,7 @@ beforeAll(async () => {
       sourceId,
       caseNumber: seed.caseNumber,
       court: seed.court,
-      country: "CZE",
+      country: seed.country ?? "CZE",
       language: seed.language,
       languageGroupKey: seed.languageGroupKey,
       decisionDate: seed.decisionDate,
@@ -123,7 +146,7 @@ const walk = async (limit: number) => {
   for (let page = 0; page < 20; page += 1) {
     // oxlint-disable-next-line no-await-in-loop -- each page depends on the previous cursor
     const result = await listDecisionsHandler(
-      { limit, ...(cursor === undefined ? {} : { cursor }) },
+      { country: "CZE", limit, ...(cursor === undefined ? {} : { cursor }) },
       caseLawDb,
     );
     if (!("items" in result)) {
@@ -198,12 +221,16 @@ test(
     const shelf = await readLatestDecisionsByCourt({
       caseLawDb,
       country: "CZE",
-      courts: ["Nejvyšší soud", "Court of Justice", "No such court"],
+      courts: [
+        { court: "Nejvyšší soud", tierLabel: "supreme" },
+        { court: "Court of Justice", tierLabel: "constitutional" },
+        { court: "No such court", tierLabel: "supreme" },
+      ],
     });
     // A court without decisions is left off the shelf, not shown empty.
-    expect(shelf.map((group) => group.court)).toEqual([
-      "Nejvyšší soud",
-      "Court of Justice",
+    expect(shelf.map((group) => [group.court, group.tierLabel])).toEqual([
+      ["Nejvyšší soud", "supreme"],
+      ["Court of Justice", "constitutional"],
     ]);
     const byCourt = new Map(
       shelf.map((group) => [group.court, group.decisions]),
@@ -220,6 +247,30 @@ test(
     ]);
     expect(cjeu).toHaveLength(1);
     expect(cjeu?.[0]?.languageAlternates).toHaveLength(3);
+  },
+  DB_TEST_TIMEOUT_MS,
+);
+
+test(
+  "the shelf's courts are the jurisdiction's apex courts, not its busiest",
+  async () => {
+    const courts = await readShelfCourts({
+      caseLawDb,
+      country: "SVK",
+      entries: courtWeightMapFromSeed().get("SVK") ?? [],
+    });
+    // Six district judgments outnumber the one supreme judgment; rank wins.
+    expect(courts).toEqual([
+      { court: "Najvyšší súd Slovenskej republiky", tierLabel: "supreme" },
+    ]);
+    const shelf = await readLatestDecisionsByCourt({
+      caseLawDb,
+      country: "SVK",
+      courts,
+    });
+    expect(
+      shelf.map((group) => group.decisions.map((d) => d.caseNumber)),
+    ).toEqual([["1 Cdo 9/2024"]]);
   },
   DB_TEST_TIMEOUT_MS,
 );

--- a/apps/api/src/handlers/case-law/decisions/latest.ts
+++ b/apps/api/src/handlers/case-law/decisions/latest.ts
@@ -3,8 +3,12 @@ import { sql } from "drizzle-orm";
 import { status, t } from "elysia";
 import type { Static } from "elysia";
 
-import { readBrowseFacets } from "@/api/handlers/case-law/decisions/facets";
 import { decisionDateSortKeySql } from "@/api/handlers/case-law/decisions/list";
+import {
+  loadShelfCourtEntries,
+  readShelfCourts,
+  type ShelfCourt,
+} from "@/api/handlers/case-law/decisions/shelf-courts";
 import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
 import {
   decisionHeadnoteSql,
@@ -23,9 +27,10 @@ import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
 
 /**
- * The browse page's shelf when nothing has been typed: the newest decisions
- * of the jurisdiction's largest courts, a few per court. Whole-corpus and
- * slow-moving, so it is cached the way the facets are.
+ * The entry shelf when nothing has been typed: the newest decisions of the
+ * jurisdiction's apex courts (by declared rank, see `shelf-courts.ts`), a few
+ * per court. Whole-corpus and slow-moving, so it is cached the way the facets
+ * are.
  */
 
 export const listLatestDecisionsQuerySchema = t.Object({
@@ -51,6 +56,8 @@ export type LatestDecision = {
 
 export type LatestDecisionsByCourt = {
   court: string;
+  /** The seeded rank label the court matched (`constitutional`, `supreme`). */
+  tierLabel: string;
   decisions: LatestDecision[];
 };
 
@@ -100,8 +107,8 @@ const requiredString = (row: Record<string, unknown>, key: string): string => {
 type ReadLatestDecisionsByCourtOptions = {
   caseLawDb: CaseLawPublicReadDb;
   country: string;
-  /** Shelf order; the corpus's largest courts first. */
-  courts: readonly string[];
+  /** Shelf order; highest-ranked court first. */
+  courts: readonly ShelfCourt[];
 };
 
 /**
@@ -135,7 +142,7 @@ export const readLatestDecisionsByCourt = async ({
           d.decision_type,
           d.citation_count,
           ${decisionHeadnoteSql(sql.raw("d.metadata"))} AS headnote
-        FROM jsonb_array_elements_text(${JSON.stringify(courts)}::text::jsonb)
+        FROM jsonb_array_elements_text(${JSON.stringify(courts.map((shelf) => shelf.court))}::text::jsonb)
           WITH ORDINALITY AS shelf(court, ordinality)
         CROSS JOIN LATERAL (
           -- Named columns, never a wildcard: the public reader role sees only
@@ -196,7 +203,7 @@ export const readLatestDecisionsByCourt = async ({
     });
 
   const byCourt = new Map<string, LatestDecision[]>(
-    courts.map((court) => [court, []]),
+    courts.map((shelf) => [shelf.court, []]),
   );
   for (const row of rows) {
     const court = requiredString(row, "court");
@@ -224,11 +231,11 @@ export const readLatestDecisionsByCourt = async ({
     });
   }
 
-  return courts.flatMap((court) => {
+  return courts.flatMap(({ court, tierLabel }) => {
     const decisions = byCourt.get(court);
     return decisions === undefined || decisions.length === 0
       ? []
-      : [{ court, decisions }];
+      : [{ court, tierLabel, decisions }];
   });
 };
 
@@ -246,20 +253,19 @@ const loadLatestDecisions = async ({
 > =>
   await Result.tryPromise({
     try: async () => {
-      // The shelf's courts are the jurisdiction's largest, which the facets
-      // already count (and cache).
-      const facets = await readBrowseFacets(country);
-      const courts = facets.court
-        .slice(0, LIMITS.caseLawLatestCourts)
-        .map((bucket) => bucket.value);
-      return {
+      const courts = await readShelfCourts({
+        caseLawDb,
         country,
-        courts: await readLatestDecisionsByCourt({
-          caseLawDb,
-          country,
-          courts,
-        }),
-      };
+        entries: await loadShelfCourtEntries(country),
+      });
+      const groups = await readLatestDecisionsByCourt({
+        caseLawDb,
+        country,
+        courts,
+      });
+      // The statement above dropped every candidate without public rows, so
+      // the cap counts only courts a reader will see.
+      return { country, courts: groups.slice(0, LIMITS.caseLawLatestCourts) };
     },
     catch: (cause) =>
       new LatestDecisionsError({

--- a/apps/api/src/handlers/case-law/decisions/shelf-courts.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/shelf-courts.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import { courtWeightMapFromSeed } from "@/api/handlers/case-law/court-weight-seed";
+import { selectShelfCourts } from "@/api/handlers/case-law/decisions/shelf-courts";
+
+const seed = courtWeightMapFromSeed();
+const entriesFor = (country: string) => seed.get(country) ?? [];
+
+describe("selectShelfCourts", () => {
+  test("ranks apex courts above the busiest court and drops the rest", () => {
+    const shelf = selectShelfCourts({
+      counts: [
+        { court: "Okresní soud v Ostravě", count: 9000 },
+        { court: "Krajský soud v Brně", count: 3000 },
+        { court: "Nejvyšší soud", count: 1200 },
+        { court: "Nejvyšší správní soud", count: 2000 },
+        { court: "Ústavní soud", count: 400 },
+      ],
+      entries: entriesFor("CZE"),
+      limit: 4,
+    });
+    expect(shelf).toEqual([
+      { court: "Ústavní soud", tierLabel: "constitutional" },
+      { court: "Nejvyšší správní soud", tierLabel: "supreme" },
+      { court: "Nejvyšší soud", tierLabel: "supreme" },
+    ]);
+  });
+
+  test("the cap trims within a tier by docket size, never across tiers", () => {
+    const shelf = selectShelfCourts({
+      counts: [
+        { court: "Sąd Najwyższy", count: 1 },
+        { court: "Naczelny Sąd Administracyjny", count: 2 },
+        { court: "Trybunał Konstytucyjny", count: 0 },
+      ],
+      entries: entriesFor("POL"),
+      limit: 2,
+    });
+    expect(shelf.map((shelfCourt) => shelfCourt.court)).toEqual([
+      "Trybunał Konstytucyjny",
+      "Naczelny Sąd Administracyjny",
+    ]);
+  });
+
+  test("a jurisdiction without entries has no shelf", () => {
+    expect(
+      selectShelfCourts({
+        counts: [{ court: "Nejvyšší soud", count: 5 }],
+        entries: [],
+        limit: 4,
+      }),
+    ).toEqual([]);
+  });
+
+  test("court names match case-insensitively, as the seed compiles them", () => {
+    const shelf = selectShelfCourts({
+      counts: [{ court: "COURT OF JUSTICE", count: 1 }],
+      entries: entriesFor("EU"),
+      limit: 4,
+    });
+    expect(shelf).toEqual([
+      { court: "COURT OF JUSTICE", tierLabel: "constitutional" },
+    ]);
+  });
+});

--- a/apps/api/src/handlers/case-law/decisions/shelf-courts.test.ts
+++ b/apps/api/src/handlers/case-law/decisions/shelf-courts.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { courtWeightMapFromSeed } from "@/api/handlers/case-law/court-weight-seed";
+import { seededCourtWeightEntries } from "@/api/handlers/case-law/court-weight-seed";
 import { selectShelfCourts } from "@/api/handlers/case-law/decisions/shelf-courts";
 
-const seed = courtWeightMapFromSeed();
-const entriesFor = (country: string) => seed.get(country) ?? [];
+const entriesFor = seededCourtWeightEntries;
 
 describe("selectShelfCourts", () => {
   test("ranks apex courts above the busiest court and drops the rest", () => {

--- a/apps/api/src/handlers/case-law/decisions/shelf-courts.ts
+++ b/apps/api/src/handlers/case-law/decisions/shelf-courts.ts
@@ -1,0 +1,179 @@
+import { sql } from "drizzle-orm";
+
+import {
+  type CourtWeightEntry,
+  loadCourtWeightsForCountry,
+} from "@/api/handlers/case-law/court-weights";
+import type { CaseLawPublicReadDb } from "@/api/lib/case-law-public-read-db";
+import { LIMITS } from "@/api/lib/limits";
+import { logger } from "@/api/lib/observability/logger";
+
+/**
+ * Which courts the entry shelf shows: the jurisdiction's apex courts by
+ * declared rank, never its busiest courts by volume. Rank comes from the
+ * seeded court weights (`constitutional` above `supreme` above `regional`);
+ * the shelf keeps the top two labels, so a first-instance court with the
+ * largest docket cannot own the page.
+ */
+
+const SHELF_TIER_LABELS: ReadonlySet<string> = new Set([
+  "constitutional",
+  "supreme",
+]);
+
+/** How many stored spellings of one apex court the candidate bound allows for. */
+const SHELF_SPELLINGS_PER_COURT = 3;
+
+export type CourtCount = {
+  court: string;
+  count: number;
+};
+
+export type ShelfCourt = {
+  court: string;
+  tierLabel: string;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+/** Drivers disagree: bun-sql returns the rows, pglite wraps them in `{ rows }`. */
+const rowsOf = (result: unknown): Record<string, unknown>[] => {
+  let rows: unknown = result;
+  if (!Array.isArray(result) && isRecord(result)) {
+    rows = result["rows"];
+  }
+  return Array.isArray(rows) ? rows.filter(isRecord) : [];
+};
+
+type ReadCourtCountsOptions = {
+  caseLawDb: CaseLawPublicReadDb;
+  country: string;
+};
+
+/**
+ * Every court of the jurisdiction with its decision count. Deliberately
+ * join-free: the statement is a parallel index-only walk of the
+ * `(country, court, date)` index (planner cost 550k for the largest
+ * jurisdiction, against 1.4M with a bitmap heap scan once the sources table
+ * is joined in for `source_id`). Source policy is applied by the shelf
+ * statement that follows, which drops a court whose public rows are none;
+ * the cap on shown courts is taken after that, so a withheld court cannot
+ * hold a slot. The counts only order courts within a tier.
+ */
+export const readCourtCounts = async ({
+  caseLawDb,
+  country,
+}: ReadCourtCountsOptions): Promise<CourtCount[]> => {
+  const result: unknown = await caseLawDb(
+    async (tx) =>
+      await tx.execute(sql`
+        SELECT d.court, count(*)::int AS decision_count
+        FROM case_law_decisions d
+        WHERE d.country = ${country}
+        GROUP BY d.court
+      `),
+  );
+  return rowsOf(result).flatMap((row) => {
+    const court = row["court"];
+    return typeof court === "string" && court.length > 0
+      ? [{ court, count: Number(row["decision_count"]) || 0 }]
+      : [];
+  });
+};
+
+type SelectShelfCourtsOptions = {
+  counts: readonly CourtCount[];
+  /** Sorted by tier descending, the order `loadCourtWeights` guarantees. */
+  entries: readonly CourtWeightEntry[];
+  limit: number;
+};
+
+const rankOf = (
+  court: string,
+  entries: readonly CourtWeightEntry[],
+): CourtWeightEntry | undefined =>
+  entries.find((entry) => entry.pattern.test(court));
+
+/** A deterministic tie-break on the stored name; display order is not linguistic here. */
+const byCodePoint = (a: string, b: string): number => {
+  if (a === b) {
+    return 0;
+  }
+  return a < b ? -1 : 1;
+};
+
+/**
+ * Apex courts first by tier, then by docket size within a tier, capped at
+ * `limit`. A court no entry matches, or one whose label is below the shelf,
+ * is left out.
+ */
+export const selectShelfCourts = ({
+  counts,
+  entries,
+  limit,
+}: SelectShelfCourtsOptions): ShelfCourt[] =>
+  counts
+    .flatMap(({ court, count }) => {
+      const rank = rankOf(court, entries);
+      return rank !== undefined && SHELF_TIER_LABELS.has(rank.tierLabel)
+        ? [{ court, count, tier: rank.tier, tierLabel: rank.tierLabel }]
+        : [];
+    })
+    .toSorted(
+      (a, b) =>
+        b.tier - a.tier || b.count - a.count || byCodePoint(a.court, b.court),
+    )
+    .slice(0, limit)
+    .map(({ court, tierLabel }) => ({ court, tierLabel }));
+
+/**
+ * The rank entries the shelf ranks a jurisdiction's courts by: the seeded
+ * weights, which the seed migration guarantees for every jurisdiction the
+ * seed declares. A jurisdiction outside the seed has no rank and therefore
+ * no shelf; that is logged, because it means the seed is behind the corpus.
+ */
+export const loadShelfCourtEntries = async (
+  country: string,
+): Promise<readonly CourtWeightEntry[]> => {
+  const entries = await loadCourtWeightsForCountry(country);
+  if (entries.length === 0) {
+    logger.warn("case_law.latest_decisions.court_weights_unseeded", {
+      country,
+    });
+  }
+  return entries;
+};
+
+type ReadShelfCourtsOptions = {
+  caseLawDb: CaseLawPublicReadDb;
+  country: string;
+  entries: readonly CourtWeightEntry[];
+};
+
+/** The shelf's courts for a jurisdiction, ranked by the given entries. */
+export const readShelfCourts = async ({
+  caseLawDb,
+  country,
+  entries,
+}: ReadShelfCourtsOptions): Promise<ShelfCourt[]> => {
+  const counts = await readCourtCounts({ caseLawDb, country });
+  // Candidates, not the shown set: a publisher spells an apex court several
+  // ways, and the shelf statement drops the spellings with no public rows
+  // before the caller caps what it shows.
+  const courts = selectShelfCourts({
+    counts,
+    entries,
+    limit: LIMITS.caseLawLatestCourts * SHELF_SPELLINGS_PER_COURT,
+  });
+  if (courts.length === 0 && counts.length > 0) {
+    // Rows exist but none rank as an apex court: a seed or a court-name
+    // spelling has drifted from the corpus. The page shows no shelf rather
+    // than a wrong one, and this is the only trace of why.
+    logger.warn("case_law.latest_decisions.no_apex_court", {
+      country,
+      courts: counts.length,
+    });
+  }
+  return courts;
+};

--- a/apps/api/src/handlers/case-law/seed-court-weights.ts
+++ b/apps/api/src/handlers/case-law/seed-court-weights.ts
@@ -7,130 +7,11 @@
  * safely after adding new jurisdictions or adjusting weights.
  */
 
+import { COURT_WEIGHT_SEED } from "@/api/handlers/case-law/court-weight-seed";
 import {
   upsertCourtWeightRows,
   upsertFtsConfigRows,
 } from "@/api/lib/case-law/case-law-config-store";
-
-// -- Court weight seed data ----------------------------------------------
-
-type WeightRow = {
-  country: string;
-  courtPattern: string;
-  tier: number;
-  tierLabel: string;
-  weight: number;
-};
-
-const COURT_WEIGHTS: WeightRow[] = [
-  // Czech Republic
-  {
-    country: "CZE",
-    courtPattern: "ústavní soud",
-    tier: 4,
-    tierLabel: "constitutional",
-    weight: 10,
-  },
-  {
-    country: "CZE",
-    courtPattern: "nejvyšší",
-    tier: 3,
-    tierLabel: "supreme",
-    weight: 8,
-  },
-  {
-    country: "CZE",
-    courtPattern: "vrchní soud|krajský soud|městský soud",
-    tier: 2,
-    tierLabel: "regional",
-    weight: 4,
-  },
-
-  // Slovakia
-  {
-    country: "SVK",
-    courtPattern: "ústavný súd",
-    tier: 4,
-    tierLabel: "constitutional",
-    weight: 10,
-  },
-  {
-    country: "SVK",
-    courtPattern: "najvyšší",
-    tier: 3,
-    tierLabel: "supreme",
-    weight: 8,
-  },
-  {
-    country: "SVK",
-    courtPattern: "krajský súd",
-    tier: 2,
-    tierLabel: "regional",
-    weight: 4,
-  },
-
-  // Poland
-  {
-    country: "POL",
-    courtPattern: "trybunał konstytucyjny",
-    tier: 4,
-    tierLabel: "constitutional",
-    weight: 10,
-  },
-  {
-    country: "POL",
-    courtPattern: "sąd najwyższy|naczelny sąd administracyjny",
-    tier: 3,
-    tierLabel: "supreme",
-    weight: 8,
-  },
-  {
-    country: "POL",
-    courtPattern: "sąd apelacyjny|sąd okręgowy",
-    tier: 2,
-    tierLabel: "regional",
-    weight: 4,
-  },
-
-  // Austria
-  {
-    country: "AUT",
-    courtPattern: "verfassungsgerichtshof",
-    tier: 4,
-    tierLabel: "constitutional",
-    weight: 10,
-  },
-  {
-    country: "AUT",
-    courtPattern: "oberster gerichtshof|verwaltungsgerichtshof",
-    tier: 3,
-    tierLabel: "supreme",
-    weight: 8,
-  },
-  {
-    country: "AUT",
-    courtPattern: "oberlandesgericht|landesgericht",
-    tier: 2,
-    tierLabel: "regional",
-    weight: 4,
-  },
-
-  // EU
-  {
-    country: "EU",
-    courtPattern: "court of justice",
-    tier: 4,
-    tierLabel: "constitutional",
-    weight: 10,
-  },
-  {
-    country: "EU",
-    courtPattern: "general court",
-    tier: 3,
-    tierLabel: "supreme",
-    weight: 8,
-  },
-];
 
 // -- FTS config seed data ------------------------------------------------
 
@@ -161,9 +42,9 @@ const FTS_CONFIGS: FtsRow[] = [
 const seed = async () => {
   console.log("Seeding court weights...");
 
-  await upsertCourtWeightRows(COURT_WEIGHTS);
+  await upsertCourtWeightRows([...COURT_WEIGHT_SEED]);
 
-  console.log(`  ${COURT_WEIGHTS.length} court weight rows upserted.`);
+  console.log(`  ${COURT_WEIGHT_SEED.length} court weight rows upserted.`);
 
   console.log("Seeding FTS configs...");
 

--- a/apps/api/src/handlers/legislation/list.ts
+++ b/apps/api/src/handlers/legislation/list.ts
@@ -125,7 +125,11 @@ const decodeListCursor = (cursor: string): ListCursor | null => {
  * later validity window. An anti-join rather than `DISTINCT ON` so the query
  * stays flat and Postgres can stop at the page limit.
  */
-const isCurrentVersionOfWork = sql`NOT EXISTS (
+/**
+ * The one in-force consolidation of a Work the listing shows: no later
+ * in-force window of the same `(source, eli, language)` exists.
+ */
+export const isCurrentVersionOfWork = sql`NOT EXISTS (
   SELECT 1
   FROM legislation_documents AS newer
   WHERE newer.source_id = ${legislationDocuments.sourceId}

--- a/apps/api/src/handlers/legislation/non-redistributable-sources.ts
+++ b/apps/api/src/handlers/legislation/non-redistributable-sources.ts
@@ -1,0 +1,53 @@
+import { Result, TaggedError } from "better-result";
+import { not } from "drizzle-orm";
+
+import { legislationSources } from "@/api/db/schema";
+import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
+import { legislationPublicReadDb } from "@/api/lib/legislation-public-read-db";
+import type { LegislationReadTransaction } from "@/api/lib/legislation-public-read-db";
+import {
+  definePublicLawSharedQuery,
+  PUBLIC_LAW_SHARED_QUERY,
+} from "@/api/lib/public-law-shared-query";
+
+export class NonRedistributableLegislationSourcesError extends TaggedError(
+  "NonRedistributableLegislationSourcesError",
+)<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+/**
+ * The legislation sources a public surface may not serve, read from the same
+ * predicate the SQL surfaces filter with. A cached surface keys on this set so
+ * a revocation changes the key instead of waiting out the cache window. The
+ * table holds one row per publisher feed, so this is a handful of ids.
+ */
+export const readNonRedistributableLegislationSourceIdsQuery =
+  definePublicLawSharedQuery(
+    PUBLIC_LAW_SHARED_QUERY.legislationNonRedistributableSources,
+    async (tx: LegislationReadTransaction) => {
+      const rows = await tx
+        .select({ id: legislationSources.id })
+        .from(legislationSources)
+        .where(not(redistributableLegislationSource));
+
+      return rows.map(({ id }) => id);
+    },
+  );
+
+export const readNonRedistributableLegislationSourceIds = async () =>
+  await Result.tryPromise({
+    try: async () =>
+      await legislationPublicReadDb(
+        readNonRedistributableLegislationSourceIdsQuery,
+      ),
+    catch: (cause) =>
+      new NonRedistributableLegislationSourcesError({
+        message:
+          cause instanceof Error
+            ? cause.message
+            : "reading non-redistributable legislation sources failed",
+        cause,
+      }),
+  });

--- a/apps/api/src/handlers/legislation/public-reads.db.test.ts
+++ b/apps/api/src/handlers/legislation/public-reads.db.test.ts
@@ -22,6 +22,10 @@ import {
   listStatutesHandler,
 } from "@/api/handlers/legislation/list";
 import { readProvisionHistoryHandler } from "@/api/handlers/legislation/provision-history";
+import {
+  readLegislationShelf,
+  readLegislationShelfHandler,
+} from "@/api/handlers/legislation/shelf";
 import { listStatuteVersionsHandler } from "@/api/handlers/legislation/versions";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -30,6 +34,7 @@ import type {
   LegislationReadDb,
   LegislationReadTransaction,
 } from "@/api/lib/legislation-public-read-db";
+import { LIMITS } from "@/api/lib/limits";
 import {
   decodePaginationCursor,
   encodePaginationCursor,
@@ -63,6 +68,25 @@ const withheldAct = createSafeId<"legislationDocument">();
 const czechCivilCode = createSafeId<"legislationDocument">();
 const czechCivilCodeAmendment = createSafeId<"legislationDocument">();
 const corporationsAct = createSafeId<"legislationDocument">();
+const shelfFreshSuperseded = createSafeId<"legislationDocument">();
+const shelfFresh = createSafeId<"legislationDocument">();
+const shelfEdgeRecent = createSafeId<"legislationDocument">();
+const shelfStale = createSafeId<"legislationDocument">();
+const shelfUpcomingCurrent = createSafeId<"legislationDocument">();
+const shelfUpcomingNext = createSafeId<"legislationDocument">();
+const shelfUpcomingLater = createSafeId<"legislationDocument">();
+const shelfEdgeFuture = createSafeId<"legislationDocument">();
+const shelfFarFuture = createSafeId<"legislationDocument">();
+const shelfWithheldFuture = createSafeId<"legislationDocument">();
+
+const LEGISLATION_SHELF_WINDOW_DAYS = LIMITS.legislationShelfWindowDays;
+
+/** A calendar date `days` from today (UTC), as the date columns store it. */
+const daysFromToday = (days: number): string => {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+};
 
 /**
  * The default listing, newest consolidation first, ties broken by id
@@ -92,6 +116,7 @@ type DocumentSeed = {
   sourceId: SafeId<"legislationSource">;
   eli: string;
   title: string;
+  country?: string;
   language?: string;
   metadata?: Record<string, unknown>;
   documentAst?: DocumentAst;
@@ -105,6 +130,7 @@ const seedDocument = ({
   sourceId,
   eli,
   title,
+  country = "CZE",
   language = "cs",
   metadata,
   documentAst,
@@ -116,7 +142,7 @@ const seedDocument = ({
   sourceId,
   eli,
   title,
-  country: "CZE",
+  country,
   language,
   documentType: "act",
   status: "current",
@@ -346,6 +372,110 @@ beforeAll(
         versionValidFrom: "2021-01-01",
         versionValidTo: null,
       }),
+      // The shelf fixture lives in its own jurisdiction so the listing tests
+      // above keep their order. Dates are relative to today: the shelf is a
+      // window around the current date.
+      seedDocument({
+        id: shelfFreshSuperseded,
+        sourceId: openSourceId,
+        eli: "SK/2026/300",
+        title: "Fresh Act",
+        country: "SVK",
+        language: "sk",
+        versionValidFrom: "2020-01-01",
+        versionValidTo: daysFromToday(-5),
+      }),
+      seedDocument({
+        id: shelfFresh,
+        sourceId: openSourceId,
+        eli: "SK/2026/300",
+        title: "Fresh Act",
+        country: "SVK",
+        language: "sk",
+        versionValidFrom: daysFromToday(-5),
+        versionValidTo: null,
+      }),
+      seedDocument({
+        id: shelfEdgeRecent,
+        sourceId: openSourceId,
+        eli: "SK/2026/302",
+        title: "Edge Recent Act",
+        country: "SVK",
+        language: "sk",
+        versionValidFrom: daysFromToday(-LEGISLATION_SHELF_WINDOW_DAYS),
+        versionValidTo: null,
+      }),
+      seedDocument({
+        id: shelfStale,
+        sourceId: openSourceId,
+        eli: "SK/2026/303",
+        title: "Stale Act",
+        country: "SVK",
+        language: "sk",
+        versionValidFrom: daysFromToday(-LEGISLATION_SHELF_WINDOW_DAYS - 1),
+        versionValidTo: null,
+      }),
+      seedDocument({
+        id: shelfUpcomingCurrent,
+        sourceId: openSourceId,
+        eli: "SK/2026/301",
+        title: "Upcoming Act",
+        country: "SVK",
+        language: "sk",
+        versionValidFrom: "2020-01-01",
+        versionValidTo: daysFromToday(10),
+      }),
+      seedDocument({
+        id: shelfUpcomingNext,
+        sourceId: openSourceId,
+        eli: "SK/2026/301",
+        title: "Upcoming Act",
+        country: "SVK",
+        language: "sk",
+        versionValidFrom: daysFromToday(10),
+        versionValidTo: daysFromToday(20),
+      }),
+      // A later window of the same work: not the next one, so not shown.
+      seedDocument({
+        id: shelfUpcomingLater,
+        sourceId: openSourceId,
+        eli: "SK/2026/301",
+        title: "Upcoming Act",
+        country: "SVK",
+        language: "sk",
+        versionValidFrom: daysFromToday(20),
+        versionValidTo: null,
+      }),
+      seedDocument({
+        id: shelfEdgeFuture,
+        sourceId: openSourceId,
+        eli: "SK/2026/304",
+        title: "Edge Future Act",
+        country: "SVK",
+        language: "sk",
+        versionValidFrom: daysFromToday(LEGISLATION_SHELF_WINDOW_DAYS),
+        versionValidTo: null,
+      }),
+      seedDocument({
+        id: shelfFarFuture,
+        sourceId: openSourceId,
+        eli: "SK/2026/305",
+        title: "Far Future Act",
+        country: "SVK",
+        language: "sk",
+        versionValidFrom: daysFromToday(LEGISLATION_SHELF_WINDOW_DAYS + 1),
+        versionValidTo: null,
+      }),
+      seedDocument({
+        id: shelfWithheldFuture,
+        sourceId: closedSourceId,
+        eli: "SK/2026/306",
+        title: "Withheld Future Act",
+        country: "SVK",
+        language: "sk",
+        versionValidFrom: daysFromToday(3),
+        versionValidTo: null,
+      }),
     ]);
 
     workspaceDb = async (read) =>
@@ -377,6 +507,88 @@ afterAll(async () => {
   if (client !== undefined) {
     await client.close();
   }
+});
+
+describe("legislation shelf", () => {
+  test("recently in force lists current consolidations opened within the window, newest first", async () => {
+    const shelf = await readLegislationShelf({
+      legislationDb,
+      country: "SVK",
+    });
+    // The superseded window of the fresh act and the stale act are out; the
+    // window's own edge is in.
+    expect(shelf.recentlyInForce.map((item) => item.id)).toEqual([
+      shelfFresh,
+      shelfEdgeRecent,
+    ]);
+  });
+
+  test("entering into force lists each work's next window only, soonest first, within the window", async () => {
+    const shelf = await readLegislationShelf({
+      legislationDb,
+      country: "SVK",
+    });
+    expect(shelf.enteringIntoForce.map((item) => item.id)).toEqual([
+      shelfUpcomingNext,
+      shelfEdgeFuture,
+    ]);
+    const ids = new Set(shelf.enteringIntoForce.map((item) => item.id));
+    expect(ids.has(shelfUpcomingLater)).toBe(false);
+    expect(ids.has(shelfFarFuture)).toBe(false);
+    expect(ids.has(shelfWithheldFuture)).toBe(false);
+    expect(ids.has(shelfUpcomingCurrent)).toBe(false);
+  });
+
+  test("the shelf is bounded and column-restricted for the public reader", async () => {
+    const shelf = await readLegislationShelf({
+      legislationDb,
+      country: "SVK",
+    });
+    expect(shelf.recentlyInForce.length).toBeLessThanOrEqual(
+      LIMITS.legislationShelfPerList,
+    );
+    expect(Object.keys(shelf.recentlyInForce[0] ?? {}).toSorted()).toEqual([
+      "country",
+      "documentType",
+      "eli",
+      "id",
+      "language",
+      "status",
+      "title",
+      "versionValidFrom",
+    ]);
+  });
+
+  test("the handler rejects a malformed jurisdiction before reading anything", async () => {
+    const rejected = await readLegislationShelfHandler(
+      { country: "s-k" },
+      legislationDb,
+    );
+    expect("recentlyInForce" in rejected).toBe(false);
+  });
+
+  test("the shelf reads the jurisdiction in its corpus form", async () => {
+    const shelf = await readLegislationShelf({
+      legislationDb,
+      country: "SVK",
+    });
+    expect(shelf.country).toBe("SVK");
+    expect(shelf.recentlyInForce.every((item) => item.country === "SVK")).toBe(
+      true,
+    );
+  });
+
+  test("a jurisdiction without legislation has an empty shelf, not an error", async () => {
+    const shelf = await readLegislationShelf({
+      legislationDb,
+      country: "POL",
+    });
+    expect(shelf).toEqual({
+      country: "POL",
+      recentlyInForce: [],
+      enteringIntoForce: [],
+    });
+  });
 });
 
 type StatutePage = {

--- a/apps/api/src/handlers/legislation/public-routes.ts
+++ b/apps/api/src/handlers/legislation/public-routes.ts
@@ -17,6 +17,10 @@ import {
   readProvisionHistoryHandler,
 } from "@/api/handlers/legislation/provision-history";
 import {
+  legislationShelfQuerySchema,
+  readLegislationShelfHandler,
+} from "@/api/handlers/legislation/shelf";
+import {
   listStatuteVersionsHandler,
   listStatuteVersionsParamsSchema,
   listStatuteVersionsQuerySchema,
@@ -34,6 +38,23 @@ const listStatutes = createSafePublicHandler(
     const response = yield* Result.await(
       Result.tryPromise(
         async () => await listStatutesHandler(query, legislationPublicReadDb),
+      ),
+    );
+
+    return Result.ok(response);
+  },
+);
+
+const readLegislationShelf = createSafePublicHandler(
+  {
+    mcp: { type: "internal", reason: "public_indexing" },
+    query: legislationShelfQuerySchema,
+  },
+  async function* ({ query }) {
+    const response = yield* Result.await(
+      Result.tryPromise(
+        async () =>
+          await readLegislationShelfHandler(query, legislationPublicReadDb),
       ),
     );
 
@@ -140,6 +161,10 @@ export const publicLegislationRoute = new Elysia({
   })
   .get("/statutes", listStatutes.handler, {
     query: listStatutes.config.query,
+  })
+  // Ahead of `/statutes/:documentId` for the same reason as `by-eli` below.
+  .get("/statutes/shelf", readLegislationShelf.handler, {
+    query: readLegislationShelf.config.query,
   })
   // Ahead of `/statutes/:documentId`, or the literal segment would be read as
   // a document id and rejected by the UUID schema.

--- a/apps/api/src/handlers/legislation/shelf.ts
+++ b/apps/api/src/handlers/legislation/shelf.ts
@@ -1,0 +1,220 @@
+import { Result, TaggedError } from "better-result";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
+import { status, t } from "elysia";
+import type { Static } from "elysia";
+
+import { legislationDocuments, legislationSources } from "@/api/db/schema";
+import { isCurrentVersionOfWork } from "@/api/handlers/legislation/list";
+import { readNonRedistributableLegislationSourceIds } from "@/api/handlers/legislation/non-redistributable-sources";
+import { redistributableLegislationSource } from "@/api/handlers/legislation/redistribution";
+import {
+  inForceToday,
+  versionSortKey,
+} from "@/api/handlers/legislation/validity-window";
+import { errorTag } from "@/api/lib/errors/utils";
+import { createTtlResultCache } from "@/api/lib/legal-search/browse-facets-cache";
+import { isCorpusIndexJurisdiction } from "@/api/lib/legal-search/index-naming";
+import type { LegislationReadDb } from "@/api/lib/legislation-public-read-db";
+import { LIMITS } from "@/api/lib/limits";
+import { logger } from "@/api/lib/observability/logger";
+
+/**
+ * The law home's legislation shelf: what came into force in the last thirty
+ * days and what comes into force in the next thirty, over the one signal the
+ * corpus carries for every source, the consolidation window's opening date.
+ * Whole-corpus and slow-moving, so it is cached like the decision shelf.
+ */
+
+export const legislationShelfQuerySchema = t.Object({
+  country: t.String({ minLength: 2, maxLength: 3 }),
+});
+
+type LegislationShelfQuery = Static<typeof legislationShelfQuerySchema>;
+
+export type LegislationShelfItem = {
+  id: string;
+  eli: string;
+  title: string;
+  country: string;
+  language: string;
+  documentType: string | null;
+  status: string;
+  versionValidFrom: string | null;
+};
+
+export type LegislationShelf = {
+  country: string;
+  /** Current consolidations whose window opened within the past window. */
+  recentlyInForce: LegislationShelfItem[];
+  /** The next consolidation of each work opening within the coming window. */
+  enteringIntoForce: LegislationShelfItem[];
+};
+
+class LegislationShelfError extends TaggedError("LegislationShelfError")<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+const SHELF_CACHE_TTL_MS = 5 * 60 * 1000;
+const SHELF_CACHE_MAX_ENTRIES = 16;
+
+const windowDays = sql.raw(String(LIMITS.legislationShelfWindowDays));
+
+/**
+ * Every comparison and ordering on the window's opening goes through the
+ * listing's sort key, which is what
+ * `legislation_documents_country_valid_from_id_idx` indexes: a raw column
+ * comparison would not match the index expression and the shelf would scan
+ * the jurisdiction instead of stopping after its few rows.
+ */
+const validFromKey = versionSortKey(legislationDocuments.versionValidFrom);
+
+const shelfColumns = {
+  id: legislationDocuments.id,
+  eli: legislationDocuments.eli,
+  title: legislationDocuments.title,
+  country: legislationDocuments.country,
+  language: legislationDocuments.language,
+  documentType: legislationDocuments.documentType,
+  status: legislationDocuments.status,
+  versionValidFrom: legislationDocuments.versionValidFrom,
+};
+
+/**
+ * The earliest window of a work that has not opened yet: no other future
+ * window of the same `(source, eli, language)` opens before this one.
+ */
+const isNextVersionOfWork = sql`NOT EXISTS (
+  SELECT 1
+  FROM legislation_documents AS earlier
+  WHERE earlier.source_id = ${legislationDocuments.sourceId}
+    AND earlier.eli = ${legislationDocuments.eli}
+    AND earlier.language = ${legislationDocuments.language}
+    AND earlier.id <> ${legislationDocuments.id}
+    AND ${versionSortKey(sql`earlier.version_valid_from`)} > CURRENT_DATE
+    AND (${versionSortKey(sql`earlier.version_valid_from`)}, earlier.id)
+      < (${validFromKey}, ${legislationDocuments.id})
+)`;
+
+type ReadLegislationShelfOptions = {
+  legislationDb: LegislationReadDb;
+  country: string;
+};
+
+export const readLegislationShelf = async ({
+  legislationDb,
+  country,
+}: ReadLegislationShelfOptions): Promise<LegislationShelf> =>
+  await legislationDb(async (tx) => {
+    const recentlyInForce = await tx
+      .select(shelfColumns)
+      .from(legislationDocuments)
+      .innerJoin(
+        legislationSources,
+        eq(legislationSources.id, legislationDocuments.sourceId),
+      )
+      .where(
+        and(
+          redistributableLegislationSource,
+          eq(legislationDocuments.country, country),
+          inForceToday(
+            legislationDocuments.versionValidFrom,
+            legislationDocuments.versionValidTo,
+          ),
+          isCurrentVersionOfWork,
+          sql`${validFromKey} >= CURRENT_DATE - ${windowDays}`,
+        ),
+      )
+      .orderBy(desc(validFromKey), desc(legislationDocuments.id))
+      .limit(LIMITS.legislationShelfPerList);
+
+    const enteringIntoForce = await tx
+      .select(shelfColumns)
+      .from(legislationDocuments)
+      .innerJoin(
+        legislationSources,
+        eq(legislationSources.id, legislationDocuments.sourceId),
+      )
+      .where(
+        and(
+          redistributableLegislationSource,
+          eq(legislationDocuments.country, country),
+          sql`${validFromKey} > CURRENT_DATE`,
+          sql`${validFromKey} <= CURRENT_DATE + ${windowDays}`,
+          isNextVersionOfWork,
+        ),
+      )
+      .orderBy(asc(validFromKey), asc(legislationDocuments.id))
+      .limit(LIMITS.legislationShelfPerList);
+
+    return { country, recentlyInForce, enteringIntoForce };
+  });
+
+type LegislationShelfLoad = {
+  legislationDb: LegislationReadDb;
+  country: string;
+  excludedSourceIds: readonly string[];
+};
+
+const loadLegislationShelf = async ({
+  legislationDb,
+  country,
+}: LegislationShelfLoad): Promise<
+  Result<LegislationShelf, LegislationShelfError>
+> =>
+  await Result.tryPromise({
+    try: async () => await readLegislationShelf({ legislationDb, country }),
+    catch: (cause) =>
+      new LegislationShelfError({
+        message: "Legislation shelf could not be read",
+        cause,
+      }),
+  });
+
+const legislationShelf = createTtlResultCache({
+  load: loadLegislationShelf,
+  // Source policy is an input to the answer, so a revocation changes the key
+  // instead of waiting out the window; sorted because the set has no order.
+  key: ({ country, excludedSourceIds }: LegislationShelfLoad) =>
+    `${country}:${excludedSourceIds.toSorted().join(",")}`,
+  ttlMs: SHELF_CACHE_TTL_MS,
+  maxEntries: SHELF_CACHE_MAX_ENTRIES,
+});
+
+export const readLegislationShelfHandler = async (
+  { country }: LegislationShelfQuery,
+  legislationDb: LegislationReadDb,
+) => {
+  if (!isCorpusIndexJurisdiction(country)) {
+    return status(400, { message: "Invalid country" });
+  }
+  const jurisdiction = country.toUpperCase();
+  const empty: LegislationShelf = {
+    country: jurisdiction,
+    recentlyInForce: [],
+    enteringIntoForce: [],
+  };
+
+  const excludedSourceIds = await readNonRedistributableLegislationSourceIds();
+  if (Result.isError(excludedSourceIds)) {
+    logger.warn("legislation.shelf.unavailable", {
+      "error.type": errorTag(excludedSourceIds.error),
+    });
+    return empty;
+  }
+
+  const result = await legislationShelf({
+    legislationDb,
+    country: jurisdiction,
+    excludedSourceIds: excludedSourceIds.value,
+  });
+  if (Result.isError(result)) {
+    // The shelf is the home's empty state, not its content: the box still
+    // resolves and searches without it, so degrade rather than fail.
+    logger.warn("legislation.shelf.unavailable", {
+      "error.type": errorTag(result.error),
+    });
+    return empty;
+  }
+  return result.value;
+};

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -431,6 +431,10 @@ export const LIMITS = {
   caseLawLatestPerCourt: 5,
   legislationListPageSizeDefault: 20,
   legislationListPageSizeMax: 100,
+  /** Rows per list on the law home's legislation shelf. */
+  legislationShelfPerList: 5,
+  /** Days either side of today the legislation shelf looks at. */
+  legislationShelfWindowDays: 30,
   /** Consolidated versions of one work returned per page. */
   legislationVersionsPageSizeDefault: 50,
   legislationVersionsPageSizeMax: 200,

--- a/apps/api/src/lib/public-law-shared-query.ts
+++ b/apps/api/src/lib/public-law-shared-query.ts
@@ -7,6 +7,8 @@ export const PUBLIC_LAW_SHARED_QUERY = {
   caseLawDocumentContext: "case-law.document-context",
   caseLawLanguageAlternates: "case-law.language-alternates",
   caseLawNonRedistributableSources: "case-law.non-redistributable-sources",
+  legislationNonRedistributableSources:
+    "legislation.non-redistributable-sources",
 } as const;
 
 export type PublicLawSharedQuery =

--- a/apps/api/src/tests/security/public-law-reader-role.test.ts
+++ b/apps/api/src/tests/security/public-law-reader-role.test.ts
@@ -26,6 +26,7 @@ import {
   readSitemapBucketShards,
   readSitemapDecisionAlternates,
 } from "@/api/handlers/case-law/decisions/sitemap";
+import { readNonRedistributableLegislationSourceIdsQuery } from "@/api/handlers/legislation/non-redistributable-sources";
 import { rehydrateLegislationCandidates } from "@/api/handlers/legislation/search";
 import { createSafeId } from "@/api/lib/branded-types";
 import type {
@@ -633,6 +634,11 @@ describe("public-law reader role", () => {
         await readNonRedistributableCaseLawSourceIdsQuery(tx);
         exercised.add(
           readNonRedistributableCaseLawSourceIdsQuery.publicLawSharedQuery,
+        );
+
+        await readNonRedistributableLegislationSourceIdsQuery(tx);
+        exercised.add(
+          readNonRedistributableLegislationSourceIdsQuery.publicLawSharedQuery,
         );
 
         await rehydrateCorpusIndexProviderCandidates(tx, {

--- a/apps/legal-atlas-runner/src/db.ts
+++ b/apps/legal-atlas-runner/src/db.ts
@@ -131,9 +131,7 @@ export const createCaseLawSource = async (
  * `withTimeout` budget: a reaped root-pool connection rejects instead of
  * hanging the citation-authority recompute loop forever.
  */
-export const loadCourtWeightEntries = async (): Promise<
-  CourtWeightEntry[] | undefined
-> =>
+export const loadCourtWeightEntries = async (): Promise<CourtWeightEntry[]> =>
   await withTimeout(loadCourtWeightEntriesForSql, {
     label: "court-weight-entries-lookup",
     timeoutMs: rootQueryTimeoutMs,


### PR DESCRIPTION
## What changes

### Court weights are data, never a built-in list

- `apps/api/src/handlers/case-law/court-weight-seed.ts` is the one declaration of court rank per jurisdiction (CZE, SVK, POL, AUT, EU: constitutional 10, supreme 8, regional 4). Migration `20260902090000_case_law_court_weight_seed` inserts it (bounded `VALUES` list, anti-join on the `(country, court_pattern)` unique index, so a table seeded by the script keeps its rows). `court-weight-seed.test.ts` holds the migration text to the declaration; `court-weight-seed.db.test.ts` applies it twice on PGlite and checks the row count both times. `seed-court-weights.ts` re-upserts the same rows.
- The hardcoded `LEGACY_COURT_TIERS` fallback is gone. `courtWeight`, `weightedCitationSum`, `citationScore` and `courtWeightSql` take the seeded map or entries as required arguments; `courtWeightEntries` is required on the citation-authority batch options; `flattenCourtWeightEntries` returns an empty list for an empty map instead of `undefined`. An empty table renders the default weight for every court and is logged, since after the migration it can only mean an unmigrated database.
- Tests read the seed through `courtWeightMapFromSeed()` so the TypeScript twin and the SQL score the same fixture with the same weights.

### The entry shelf lists apex courts, not the busiest ones

- `GET /case/decisions/latest` used the four largest court buckets from the facets, so for a jurisdiction with many first-instance courts the shelf was district judgments. `decisions/shelf-courts.ts` now reads every court of the jurisdiction with its count (one index-only walk of `(country, court, date)`), keeps the courts whose seeded rank label is `constitutional` or `supreme`, orders them by tier then docket size, and caps at `LIMITS.caseLawLatestCourts`. Each shelf group carries its `tierLabel`. A jurisdiction with rows but no apex match logs and shows no shelf rather than a wrong one.

### Legislation shelf

- New `GET /law/statutes/shelf?country=`: `recentlyInForce` (current consolidations whose window opened in the last `LIMITS.legislationShelfWindowDays`, newest first) and `enteringIntoForce` (each work's next window opening within the coming window, soonest first). Both restricted to redistributable sources, bounded by `LIMITS.legislationShelfPerList`, column-restricted for the public reader role, cached like the decision shelf, and degrading to an empty shelf on failure. `isCurrentVersionOfWork` is exported from `list.ts` for reuse.

## Tests

- `citation-score.test.ts`, `court-weights.test.ts`, `citation-authority.test.ts` rewritten against the seeded weights.
- `shelf-courts.test.ts`: rank beats volume, the cap trims within a tier, no entries means no shelf, case-insensitive matching.
- `browse-order.db.test.ts` (PGlite, reader role): a second jurisdiction where six district judgments outnumber one supreme judgment yields a shelf with the supreme court only.
- `public-reads.db.test.ts`: shelf window edges on both sides, superseded and later windows excluded, withheld source excluded, bounded and column-restricted, handler upper-cases the jurisdiction and rejects a malformed one, empty jurisdiction yields an empty shelf.
- Migration safety lint passes on the new migration.

### After review

- Austrian rows also match the stored abbreviations (`OGH`, `VwGH`, `VfGH`); `court-weight-seed.test.ts` pins the adapters' stored court spellings per jurisdiction to the intended tier.
- The court census stays join-free (a parallel index-only scan; joining the sources table turns it into a bitmap heap scan on the largest jurisdiction). Instead, the census returns apex candidates, the shelf statement drops candidates without public rows, and the cap on shown courts applies after that.
- The legislation shelf compares and orders on `versionSortKey(version_valid_from)`, the indexed expression, and its cache is keyed on the withheld legislation source ids (`handlers/legislation/non-redistributable-sources.ts`), like the decision shelf.

## Also in this change

- The legal-atlas runner's `loadCourtWeightEntries` returns the entries list rather than `list | undefined`.
- `apps/api/scripts/mcp-coverage-guard.ts`: the inline-handler count for the legislation public routes rises by one for the shelf route.

## Notes for callers

`recomputeCitationAuthorityBatch` and `tryRecomputeCitationAuthorityBatch` now require `courtWeightEntries`; load them with `loadCourtWeightEntriesForSql()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/law` is now a dedicated home page with search, scope and jurisdiction controls, case-law highlights, and legislation updates.
  * Case-law highlights prioritise leading courts across supported jurisdictions.
  * Added legislation sections for recently effective and upcoming laws.
  * Kanban boards now support grouped columns with collapsible bands and saved collapse state.
* **Bug Fixes**
  * Improved document review so successfully extracted fields are consistently written.
  * Future decision dates are rejected during entry.
  * Unfiltered case browsing now returns to the law home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->