### PR TITLE
fix(api): let extraction answer null and surface invalid select answers

### DIFF
--- a/apps/api/src/lib/document-review/review-extract.ts
+++ b/apps/api/src/lib/document-review/review-extract.ts
@@ -12,8 +12,10 @@ import { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
 import { createDefaultTool } from "@/api/lib/properties/create-schema";
 import { brandDerivedPropertyId } from "@/api/lib/safe-id-boundaries";
 import { generateWorkflowData } from "@/api/lib/workflow/ai-generate-batch";
-import { validateAIOutput } from "@/api/lib/workflow/ai-validators";
-import type { ValidatedResult } from "@/api/lib/workflow/ai-validators";
+import {
+  fieldContentFromValidated,
+  validateAIOutput,
+} from "@/api/lib/workflow/ai-validators";
 import {
   buildJustificationFilenames,
   fetchAndPrepareFiles,
@@ -113,30 +115,6 @@ const buildAiTool = (question: string): AIBatchProperty["tool"] => {
     return panic("createDefaultTool returned a non ai-model tool for an ASK");
   }
   return tool;
-};
-
-const validatedToFieldContent = (validated: ValidatedResult): FieldContent => {
-  switch (validated.type) {
-    case "text":
-      return { version: 1, type: "text", value: validated.value };
-    case "single-select":
-      return { version: 1, type: "single-select", value: validated.value };
-    case "multi-select":
-      return { version: 1, type: "multi-select", value: validated.value };
-    case "date":
-      return { version: 1, type: "date", value: validated.value };
-    case "int":
-      return {
-        version: 1,
-        type: "int",
-        value: validated.value,
-        currency: validated.currency,
-      };
-    default: {
-      validated satisfies never;
-      return panic("Unexpected validated ASK content type");
-    }
-  }
 };
 
 export const collectReviewCitations = (
@@ -330,6 +308,14 @@ export const extractAskContents = async ({
         );
       }
 
+      const content = fieldContentFromValidated(validated.value);
+      if (content === null) {
+        // The model reported no value for this text/int ASK. Leave the
+        // position unextracted so presence grading reads it as absent
+        // rather than a fabricated answer.
+        continue;
+      }
+
       const justification = normalizeJustification({
         justification: propertyResult.justification,
         filenames,
@@ -342,7 +328,7 @@ export const extractAskContents = async ({
         : [];
 
       contentBySourceId.set(sourceId, {
-        content: validatedToFieldContent(validated.value),
+        content,
         citations,
       });
     }

--- a/apps/api/src/lib/workflow/ai-prompts.test.ts
+++ b/apps/api/src/lib/workflow/ai-prompts.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import * as v from "valibot";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import { buildBatchSchema } from "@/api/lib/workflow/ai-prompts";
+import type { BatchProperty } from "@/api/lib/workflow/get-execution-plan";
+import type { JustificationFilenames } from "@/api/lib/workflow/parse-justifications";
+
+const noFilenames: JustificationFilenames = [];
+
+const aiModelTool = {
+  version: 1 as const,
+  type: "ai-model" as const,
+  prompt: "test",
+};
+
+const textProperty: BatchProperty = {
+  id: toSafeId<"property">("prop-text"),
+  status: "stale",
+  content: { version: 1, type: "text" },
+  dependencies: [],
+  tool: aiModelTool,
+};
+
+const intProperty: BatchProperty = {
+  id: toSafeId<"property">("prop-int"),
+  status: "stale",
+  content: { version: 1, type: "int" },
+  dependencies: [],
+  tool: aiModelTool,
+};
+
+const selectProperty: BatchProperty = {
+  id: toSafeId<"property">("prop-select"),
+  status: "stale",
+  content: {
+    version: 1,
+    type: "single-select",
+    options: [
+      { color: "red", value: "Yes" },
+      { color: "green", value: "No" },
+    ],
+    fallback: null,
+  },
+  dependencies: [],
+  tool: aiModelTool,
+};
+
+const multiSelectProperty: BatchProperty = {
+  id: toSafeId<"property">("prop-multi"),
+  status: "stale",
+  content: {
+    version: 1,
+    type: "multi-select",
+    options: [
+      { color: "red", value: "A" },
+      { color: "green", value: "B" },
+    ],
+    fallback: null,
+  },
+  dependencies: [],
+  tool: aiModelTool,
+};
+
+describe("buildBatchSchema — absent answers", () => {
+  test("accepts a null answer for a text property", () => {
+    const schema = buildBatchSchema([textProperty], noFilenames);
+    const output = v.parse(schema, {
+      [textProperty.id]: { answer: null, justification: [] },
+    });
+    expect(output[textProperty.id]?.answer).toBeNull();
+  });
+
+  test("accepts a null answer for an int property", () => {
+    const schema = buildBatchSchema([intProperty], noFilenames);
+    const output = v.parse(schema, {
+      [intProperty.id]: { answer: null, justification: [] },
+    });
+    expect(output[intProperty.id]?.answer).toBeNull();
+  });
+
+  test("still accepts a real amount for an int property", () => {
+    const schema = buildBatchSchema([intProperty], noFilenames);
+    const output = v.parse(schema, {
+      [intProperty.id]: {
+        answer: { amount: 1500, currency: "USD" },
+        justification: [],
+      },
+    });
+    expect(output[intProperty.id]?.answer).toEqual({
+      amount: 1500,
+      currency: "USD",
+    });
+  });
+});
+
+describe("buildBatchSchema — select answers pass through for downstream validation", () => {
+  // The picklist is guidance in the description, not a JSON Schema enum: an
+  // out-of-picklist answer must reach `validateAIOutput` as a visible
+  // validation error, so parsing it here must not throw and must not
+  // silently rewrite it to null (see ai-validators.test.ts for the
+  // validation-error assertion).
+  test("does not reject or null out an out-of-picklist single-select answer", () => {
+    const schema = buildBatchSchema([selectProperty], noFilenames);
+    const output = v.parse(schema, {
+      [selectProperty.id]: { answer: "Maybe", justification: [] },
+    });
+    expect(output[selectProperty.id]?.answer).toBe("Maybe");
+  });
+
+  test("does not reject or null out an out-of-picklist multi-select answer", () => {
+    const schema = buildBatchSchema([multiSelectProperty], noFilenames);
+    const output = v.parse(schema, {
+      [multiSelectProperty.id]: { answer: ["A", "Z"], justification: [] },
+    });
+    expect(output[multiSelectProperty.id]?.answer).toEqual(["A", "Z"]);
+  });
+});

--- a/apps/api/src/lib/workflow/ai-prompts.ts
+++ b/apps/api/src/lib/workflow/ai-prompts.ts
@@ -21,6 +21,8 @@ export const WORKFLOW_SYSTEM_PROMPT =
   "propertyIds and values contain the answer and justification " +
   "for each propertyId. The justification schema for the current " +
   "batch tells you exactly how to cite each source. " +
+  "When the source does not state a property's value, answer null " +
+  "for that property; never invent or guess a value. " +
   "DOCX block text may contain review tags: " +
   `${DOCX_REVIEW_MARKUP_EXAMPLES.insertion}, ` +
   `${DOCX_REVIEW_MARKUP_EXAMPLES.deletion}, and ` +
@@ -55,19 +57,22 @@ const context = {
   text: {
     description:
       "Answer for property. Keep it plain text, keep it " +
-      "short and concise, less than 100 characters",
-    examples: ["Contract for sale of goods"],
+      "short and concise, less than 100 characters. Answer null if the " +
+      "source does not state this value; never guess.",
+    examples: ["Contract for sale of goods", null],
   },
   singleSelect: {
     description:
-      "Answer for property. Select exactly one option or " +
-      "null if none applicable",
+      "Answer for property. Select exactly one option from the list " +
+      "below, or null if the source does not state this value or no " +
+      "option applies; never guess.",
     examples: [null],
   },
   multiSelect: {
     description:
-      "Answer for property. Select one or more options, " +
-      "or null if none applicable",
+      "Answer for property. Select one or more options from the list " +
+      "below, or null if the source does not state this value or no " +
+      "option applies; never guess.",
     examples: [null],
   },
   date: {
@@ -77,6 +82,9 @@ const context = {
     examples: ["2024-03-15", null],
   },
   int: {
+    description:
+      "Answer for property, or null if the source does not state this " +
+      "value; never guess.",
     amount: {
       description: "The integer amount extracted from the document",
       examples: [1500],
@@ -90,8 +98,13 @@ const context = {
   },
 };
 
+const describeOptions = (options: string[]): string =>
+  `Valid options: ${options.join(", ")}.`;
+
 // --------------- Schema builders ---------------
 
+// `null` is an explicit "the source does not state this" answer, valid for
+// every property type — not just date/select, which supported it already.
 export type Answer =
   | string
   | string[]
@@ -225,7 +238,7 @@ export const buildBatchSchema = (
       case "text": {
         schemaShape[property.id] = v.strictObject({
           answer: v.pipe(
-            v.string(),
+            v.nullable(v.string()),
             v.description(context.text.description),
             v.examples(context.text.examples),
           ),
@@ -236,10 +249,18 @@ export const buildBatchSchema = (
       case "single-select": {
         const options = content.options.map((opt) => opt.value);
         if (options.length > 0) {
+          // The picklist isn't enforced as a JSON Schema enum: a model
+          // deviation would otherwise fail `v.parse` for the whole batch
+          // object, not just this property. The raw string passes through
+          // to `validateAIOutput`, which checks membership against
+          // `content.options` and reports a property-scoped
+          // `WorkflowValidationError` instead of a silent null.
           schemaShape[property.id] = v.strictObject({
             answer: v.pipe(
-              v.fallback(v.nullable(v.picklist(options)), null),
-              v.description(context.singleSelect.description),
+              v.nullable(v.string()),
+              v.description(
+                `${context.singleSelect.description} ${describeOptions(options)}`,
+              ),
               v.examples(context.singleSelect.examples),
             ),
             justification: justificationSchema,
@@ -250,13 +271,16 @@ export const buildBatchSchema = (
       case "multi-select": {
         const options = content.options.map((opt) => opt.value);
         if (options.length > 0) {
+          // See the single-select case above: options pass through as raw
+          // strings so an out-of-picklist answer surfaces as a validation
+          // error on this property, not a silent null or a whole-batch parse
+          // failure.
           schemaShape[property.id] = v.strictObject({
             answer: v.pipe(
-              v.fallback(
-                v.nullable(v.pipe(v.array(v.picklist(options)), v.nonEmpty())),
-                null,
+              v.nullable(v.pipe(v.array(v.string()), v.nonEmpty())),
+              v.description(
+                `${context.multiSelect.description} ${describeOptions(options)}`,
               ),
-              v.description(context.multiSelect.description),
               v.examples(context.multiSelect.examples),
             ),
             justification: justificationSchema,
@@ -277,19 +301,24 @@ export const buildBatchSchema = (
       }
       case "int": {
         schemaShape[property.id] = v.strictObject({
-          answer: v.strictObject({
-            amount: v.pipe(
-              v.number(),
-              v.integer(),
-              v.description(context.int.amount.description),
-              v.examples(context.int.amount.examples),
+          answer: v.pipe(
+            v.nullable(
+              v.strictObject({
+                amount: v.pipe(
+                  v.number(),
+                  v.integer(),
+                  v.description(context.int.amount.description),
+                  v.examples(context.int.amount.examples),
+                ),
+                currency: v.pipe(
+                  v.nullable(v.string()),
+                  v.description(context.int.currency.description),
+                  v.examples(context.int.currency.examples),
+                ),
+              }),
             ),
-            currency: v.pipe(
-              v.nullable(v.string()),
-              v.description(context.int.currency.description),
-              v.examples(context.int.currency.examples),
-            ),
-          }),
+            v.description(context.int.description),
+          ),
           justification: justificationSchema,
         });
         break;

--- a/apps/api/src/lib/workflow/ai-validators.test.ts
+++ b/apps/api/src/lib/workflow/ai-validators.test.ts
@@ -1,0 +1,208 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+import { WorkflowValidationError } from "@/api/lib/errors/tagged-errors";
+import {
+  fieldContentFromValidated,
+  validateAIOutput,
+} from "@/api/lib/workflow/ai-validators";
+import type { BatchProperty } from "@/api/lib/workflow/get-execution-plan";
+import type { AIJustificationOutput } from "@/api/lib/workflow/parse-justifications";
+
+const justification: AIJustificationOutput = [];
+
+const aiModelTool = {
+  version: 1 as const,
+  type: "ai-model" as const,
+  prompt: "test",
+};
+
+const textProperty: BatchProperty = {
+  id: toSafeId<"property">("prop-text"),
+  status: "stale",
+  content: { version: 1, type: "text" },
+  dependencies: [],
+  tool: aiModelTool,
+};
+
+const intProperty: BatchProperty = {
+  id: toSafeId<"property">("prop-int"),
+  status: "stale",
+  content: { version: 1, type: "int" },
+  dependencies: [],
+  tool: aiModelTool,
+};
+
+const selectPropertyWithFallback = (
+  fallback: string | null,
+): BatchProperty => ({
+  id: toSafeId<"property">("prop-select"),
+  status: "stale",
+  content: {
+    version: 1,
+    type: "single-select",
+    options: [
+      { color: "red", value: "Yes" },
+      { color: "green", value: "No" },
+    ],
+    fallback,
+  },
+  dependencies: [],
+  tool: aiModelTool,
+});
+
+const multiSelectProperty: BatchProperty = {
+  id: toSafeId<"property">("prop-multi"),
+  status: "stale",
+  content: {
+    version: 1,
+    type: "multi-select",
+    options: [
+      { color: "red", value: "A" },
+      { color: "green", value: "B" },
+    ],
+    fallback: null,
+  },
+  dependencies: [],
+  tool: aiModelTool,
+};
+
+describe("validateAIOutput — absent answers", () => {
+  test("a null text answer validates as absent, not a fabricated string", () => {
+    const result = validateAIOutput({
+      aiResult: { answer: null, justification },
+      property: textProperty,
+    }).unwrap();
+
+    expect(result).toEqual({ type: "text", value: null, justification });
+  });
+
+  test("a null int answer validates as absent, not a fabricated amount", () => {
+    const result = validateAIOutput({
+      aiResult: { answer: null, justification },
+      property: intProperty,
+    }).unwrap();
+
+    expect(result).toEqual({
+      type: "int",
+      value: null,
+      currency: null,
+      justification,
+    });
+  });
+
+  test("an absent text/int answer maps to no field content to persist", () => {
+    expect(
+      fieldContentFromValidated({
+        type: "text",
+        value: null,
+        justification,
+      }),
+    ).toBeNull();
+    expect(
+      fieldContentFromValidated({
+        type: "int",
+        value: null,
+        currency: null,
+        justification,
+      }),
+    ).toBeNull();
+  });
+
+  test("a present text/int answer still maps to field content", () => {
+    expect(
+      fieldContentFromValidated({
+        type: "text",
+        value: "Cash",
+        justification,
+      }),
+    ).toEqual({ version: 1, type: "text", value: "Cash" });
+    expect(
+      fieldContentFromValidated({
+        type: "int",
+        value: 1500,
+        currency: "USD",
+        justification,
+      }),
+    ).toEqual({ version: 1, type: "int", value: 1500, currency: "USD" });
+  });
+});
+
+describe("validateAIOutput — select answers", () => {
+  test("an out-of-picklist single-select answer is a visible validation error, not null", () => {
+    const result = validateAIOutput({
+      aiResult: { answer: "Maybe", justification },
+      property: selectPropertyWithFallback(null),
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error).toBeInstanceOf(WorkflowValidationError);
+    }
+  });
+
+  test("a valid single-select answer passes through", () => {
+    const result = validateAIOutput({
+      aiResult: { answer: "Yes", justification },
+      property: selectPropertyWithFallback(null),
+    }).unwrap();
+
+    expect(result).toEqual({
+      type: "single-select",
+      value: "Yes",
+      justification,
+    });
+  });
+
+  test("a null single-select answer applies the configured fallback", () => {
+    const result = validateAIOutput({
+      aiResult: { answer: null, justification },
+      property: selectPropertyWithFallback("No"),
+    }).unwrap();
+
+    expect(result).toEqual({
+      type: "single-select",
+      value: "No",
+      justification,
+    });
+  });
+
+  test("a null single-select answer with no fallback stays absent", () => {
+    const result = validateAIOutput({
+      aiResult: { answer: null, justification },
+      property: selectPropertyWithFallback(null),
+    }).unwrap();
+
+    expect(result).toEqual({
+      type: "single-select",
+      value: null,
+      justification,
+    });
+  });
+
+  test("a multi-select answer containing an out-of-picklist option is a visible validation error", () => {
+    const result = validateAIOutput({
+      aiResult: { answer: ["A", "Z"], justification },
+      property: multiSelectProperty,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error).toBeInstanceOf(WorkflowValidationError);
+    }
+  });
+
+  test("a valid multi-select answer passes through deduplicated", () => {
+    const result = validateAIOutput({
+      aiResult: { answer: ["A", "A", "B"], justification },
+      property: multiSelectProperty,
+    }).unwrap();
+
+    expect(result).toEqual({
+      type: "multi-select",
+      value: ["A", "B"],
+      justification,
+    });
+  });
+});

--- a/apps/api/src/lib/workflow/ai-validators.ts
+++ b/apps/api/src/lib/workflow/ai-validators.ts
@@ -1,5 +1,6 @@
 import { Result } from "better-result";
 
+import type { FieldContent } from "@/api/db/schema-validators";
 import {
   Unreachable,
   WorkflowValidationError,
@@ -10,7 +11,7 @@ import type { AIJustificationOutput } from "@/api/lib/workflow/parse-justificati
 
 type TextValidatedResult = {
   type: "text";
-  value: string;
+  value: string | null;
   justification: AIJustificationOutput;
 };
 
@@ -34,7 +35,7 @@ type DateValidatedResult = {
 
 type IntValidatedResult = {
   type: "int";
-  value: number;
+  value: number | null;
   currency: string | null;
   justification: AIJustificationOutput;
 };
@@ -63,7 +64,7 @@ const validateTextResult = ({
   answer: Answer;
   justification: AIJustificationOutput;
 }): ValidateResult => {
-  if (typeof answer === "string") {
+  if (typeof answer === "string" || answer === null) {
     return Result.ok({
       type: "text",
       value: answer,
@@ -87,7 +88,7 @@ const validateSingleSelectResult = ({
   justification: AIJustificationOutput;
   content: SelectContent;
 }): ValidateResult => {
-  if (answer === null && content.fallback !== null) {
+  if (answer === null) {
     return Result.ok({
       type: "single-select",
       value: content.fallback,
@@ -95,19 +96,30 @@ const validateSingleSelectResult = ({
     });
   }
 
-  if (typeof answer === "string" || answer === null) {
-    return Result.ok({
-      type: "single-select",
-      value: answer,
-      justification,
-    });
+  if (typeof answer !== "string") {
+    return Result.err(
+      new WorkflowValidationError({
+        message: "Single select answer is invalid",
+      }),
+    );
   }
 
-  return Result.err(
-    new WorkflowValidationError({
-      message: "Single select answer is invalid",
-    }),
+  const isConfiguredOption = content.options.some(
+    (option) => option.value === answer,
   );
+  if (!isConfiguredOption) {
+    return Result.err(
+      new WorkflowValidationError({
+        message: `Single select answer "${answer}" is not one of the configured options`,
+      }),
+    );
+  }
+
+  return Result.ok({
+    type: "single-select",
+    value: answer,
+    justification,
+  });
 };
 
 const validateMultiSelectResult = ({
@@ -127,19 +139,31 @@ const validateMultiSelectResult = ({
     });
   }
 
-  if (isStringArray(answer)) {
-    return Result.ok({
-      type: "multi-select",
-      value: [...new Set(answer)],
-      justification,
-    });
+  if (!isStringArray(answer)) {
+    return Result.err(
+      new WorkflowValidationError({
+        message: "Multi select answer is invalid",
+      }),
+    );
   }
 
-  return Result.err(
-    new WorkflowValidationError({
-      message: "Multi select answer is invalid",
-    }),
+  const configuredValues = new Set(
+    content.options.map((option) => option.value),
   );
+  const invalidValues = answer.filter((value) => !configuredValues.has(value));
+  if (invalidValues.length > 0) {
+    return Result.err(
+      new WorkflowValidationError({
+        message: `Multi select answer contains options not in the configured list: ${invalidValues.join(", ")}`,
+      }),
+    );
+  }
+
+  return Result.ok({
+    type: "multi-select",
+    value: [...new Set(answer)],
+    justification,
+  });
 };
 
 const validateDateResult = ({
@@ -171,7 +195,16 @@ const validateIntResult = ({
   answer: Answer;
   justification: AIJustificationOutput;
 }): ValidateResult => {
-  if (!Array.isArray(answer) && typeof answer === "object" && answer !== null) {
+  if (answer === null) {
+    return Result.ok({
+      type: "int",
+      value: null,
+      currency: null,
+      justification,
+    });
+  }
+
+  if (!Array.isArray(answer) && typeof answer === "object") {
     return Result.ok({
       type: "int",
       value: answer.amount,
@@ -230,5 +263,46 @@ export const validateAIOutput = ({
       throw new Unreachable({
         message: "Property type not matched",
       });
+  }
+};
+
+// The cell content a validated answer produces. Text and int intentionally
+// have no "answered: absent" content variant yet, so a null value maps to
+// `null` here rather than a fabricated placeholder; callers must leave the
+// cell unwritten in that case instead of persisting it.
+type ValidatedFieldContent = Extract<
+  FieldContent,
+  { type: "text" | "single-select" | "multi-select" | "date" | "int" }
+>;
+
+export const fieldContentFromValidated = (
+  validated: ValidatedResult,
+): ValidatedFieldContent | null => {
+  switch (validated.type) {
+    case "text":
+      return validated.value === null
+        ? null
+        : { version: 1, type: "text", value: validated.value };
+    case "single-select":
+      return { version: 1, type: "single-select", value: validated.value };
+    case "multi-select":
+      return { version: 1, type: "multi-select", value: validated.value };
+    case "date":
+      return { version: 1, type: "date", value: validated.value };
+    case "int":
+      return validated.value === null
+        ? null
+        : {
+            version: 1,
+            type: "int",
+            value: validated.value,
+            currency: validated.currency,
+          };
+    default: {
+      validated satisfies never;
+      throw new Unreachable({
+        message: "Validated result type not matched",
+      });
+    }
   }
 };

--- a/apps/api/src/lib/workflow/generate-batch.ts
+++ b/apps/api/src/lib/workflow/generate-batch.ts
@@ -5,10 +5,7 @@ import { FolioDocxReviewer, type FolioAIBlock } from "@stll/folio-core/server";
 
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
-import {
-  Unreachable,
-  WorkflowIntegrationError,
-} from "@/api/lib/errors/tagged-errors";
+import { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
 import { createFileKey } from "@/api/lib/files/utils";
 import { readS3ArrayBuffer } from "@/api/lib/s3";
 import { extractFileTextResult } from "@/api/lib/search/extract-content";
@@ -17,7 +14,10 @@ import {
   isAISupportedFile,
 } from "@/api/lib/workflow/ai-file-support";
 import { generateWorkflowData } from "@/api/lib/workflow/ai-generate-batch";
-import { validateAIOutput } from "@/api/lib/workflow/ai-validators";
+import {
+  fieldContentFromValidated,
+  validateAIOutput,
+} from "@/api/lib/workflow/ai-validators";
 import {
   fetchInputFieldsForBatch,
   prepareBatchInput,
@@ -355,6 +355,13 @@ export const generateBatch = async (
         property,
       });
 
+      const content = fieldContentFromValidated(validated);
+      if (content === null) {
+        // The model reported no value for this text/int property. Leave the
+        // cell unwritten rather than persist a fabricated placeholder.
+        continue;
+      }
+
       const fieldId = createSafeId<"field">();
 
       const justification = yield* normalizeJustification({
@@ -371,73 +378,11 @@ export const generateBatch = async (
         });
       }
 
-      switch (validated.type) {
-        case "text": {
-          aiResults.push({
-            fieldId,
-            propertyId: property.id,
-            content: {
-              type: "text",
-              version: 1,
-              value: validated.value,
-            },
-          });
-          break;
-        }
-        case "single-select": {
-          aiResults.push({
-            fieldId,
-            propertyId: property.id,
-            content: {
-              type: "single-select",
-              version: 1,
-              value: validated.value,
-            },
-          });
-          break;
-        }
-        case "multi-select": {
-          aiResults.push({
-            fieldId,
-            propertyId: property.id,
-            content: {
-              type: "multi-select",
-              version: 1,
-              value: validated.value,
-            },
-          });
-          break;
-        }
-        case "date": {
-          aiResults.push({
-            fieldId,
-            propertyId: property.id,
-            content: {
-              type: "date",
-              version: 1,
-              value: validated.value,
-            },
-          });
-          break;
-        }
-        case "int": {
-          aiResults.push({
-            fieldId,
-            propertyId: property.id,
-            content: {
-              type: "int",
-              version: 1,
-              value: validated.value,
-              currency: validated.currency,
-            },
-          });
-          break;
-        }
-        default:
-          throw new Unreachable({
-            message: "Property type not matched",
-          });
-      }
+      aiResults.push({
+        fieldId,
+        propertyId: property.id,
+        content,
+      });
     }
 
     return Result.ok({


### PR DESCRIPTION
## Summary
- Text and int extraction answers can now be `null`; a model can say the source doesn't state a value instead of fabricating one, and the cell stays unwritten rather than persisting a placeholder.
- Single/multi-select answers are validated against the property's configured options instead of silently defaulting an out-of-picklist answer to `null`; an invalid option now returns a `WorkflowValidationError`.
- Added unit tests in `ai-prompts.test.ts` and `ai-validators.test.ts` covering absent text/int answers and invalid select answers.

## Test plan
- [x] `bun test src/lib/workflow/ai-prompts.test.ts src/lib/workflow/ai-validators.test.ts`
- [x] `bun test src/lib/workflow/ src/lib/document-review/` (no regressions)
- [x] `bun run lint` (apps/api, type-aware)