### PR TITLE
fix(api): bound structured-output schemas per provider and split workflow batches to fit

### DIFF
--- a/apps/api/src/lib/structured-output-budget.property.test.ts
+++ b/apps/api/src/lib/structured-output-budget.property.test.ts
@@ -13,6 +13,7 @@ import {
   checkStructuredOutputBudget,
   splitPropertiesForBudget,
 } from "@/api/lib/structured-output-budget";
+import type { StructuredOutputTarget } from "@/api/lib/structured-output-budget";
 import { structuredOutputWireJsonSchema } from "@/api/lib/tanstack-ai-generate";
 import { buildBatchSchema } from "@/api/lib/workflow/ai-prompts";
 import type { AIBatchProperty } from "@/api/lib/workflow/get-execution-plan";
@@ -77,15 +78,19 @@ const propertyForKind = (
   },
 });
 
-// `size: "max"` because fast-check's default array size would keep every
-// generated batch far below the workspace maximum, and the sizes that matter
-// here are the ones a real workspace reaches.
+// The batch length is drawn uniformly over the whole workspace range first:
+// fast-check's default array sizing would keep every generated batch far
+// below the workspace maximum, and the sizes that matter here are the ones a
+// real workspace reaches.
 const propertiesArbitrary = fc
-  .array(fc.constantFrom(...CONTENT_KINDS), {
-    minLength: 1,
-    maxLength: PROPERTIES_PER_WORKSPACE_MAX,
-    size: "max",
-  })
+  .integer({ min: 1, max: PROPERTIES_PER_WORKSPACE_MAX })
+  .chain((length) =>
+    fc.array(fc.constantFrom(...CONTENT_KINDS), {
+      minLength: length,
+      maxLength: length,
+      size: "max",
+    }),
+  )
   .map((kinds) => kinds.map(propertyForKind));
 
 const FILENAMES = [
@@ -101,15 +106,46 @@ const wireSchemaFor = (
     provider,
   });
 
+/**
+ * `compiler` is stated here rather than read back from
+ * `resolveStructuredOutputBudget`, so a resolver that ignored an OpenRouter
+ * id's upstream prefix fails this property instead of agreeing with it.
+ */
+type BudgetTarget = StructuredOutputTarget & {
+  compiler: TanStackAIProvider;
+};
+
+// Every provider once, plus the two OpenRouter ids that proxy to a provider
+// with its own budget: the id, not the addressed provider, decides which
+// grammar compiler sees the schema.
+const TARGETS: readonly BudgetTarget[] = [
+  ...TANSTACK_AI_PROVIDERS.map((provider) => ({
+    provider,
+    modelId: `${provider}-model`,
+    compiler: provider,
+  })),
+  {
+    provider: "openrouter",
+    modelId: "anthropic/claude-sonnet-5",
+    compiler: "anthropic",
+  },
+  {
+    provider: "openrouter",
+    modelId: "openai/gpt-5.6-luna",
+    compiler: "openai",
+  },
+];
+
 describe("splitting a workflow batch for the provider's schema budget", () => {
   test("every chunk fits its provider and the chunks partition the batch in order", () => {
     fc.assert(
       fc.property(
-        fc.constantFrom(...TANSTACK_AI_PROVIDERS),
+        fc.constantFrom(...TARGETS),
         propertiesArbitrary,
-        (provider, properties) => {
+        ({ provider, modelId, compiler }, properties) => {
           const split = splitPropertiesForBudget({
             provider,
+            modelId,
             properties,
             buildSchema: (chunk) => wireSchemaFor(provider, chunk),
           });
@@ -126,11 +162,12 @@ describe("splitting a workflow batch for the provider's schema budget", () => {
               Result.isError(
                 checkStructuredOutputBudget({
                   provider,
+                  modelId,
                   schema: wireSchemaFor(provider, chunk),
                 }),
               ),
             ).toBe(false);
-            if (provider === "anthropic") {
+            if (compiler === "anthropic") {
               expect(chunk.length).toBeLessThanOrEqual(
                 ANTHROPIC_MAX_PROPERTIES_PER_CHUNK,
               );

--- a/apps/api/src/lib/structured-output-budget.property.test.ts
+++ b/apps/api/src/lib/structured-output-budget.property.test.ts
@@ -17,6 +17,7 @@ import type { StructuredOutputTarget } from "@/api/lib/structured-output-budget"
 import { structuredOutputWireJsonSchema } from "@/api/lib/tanstack-ai-generate";
 import { buildBatchSchema } from "@/api/lib/workflow/ai-prompts";
 import type { AIBatchProperty } from "@/api/lib/workflow/get-execution-plan";
+import type { JustificationFilenames } from "@/api/lib/workflow/parse-justifications";
 
 // Anthropic accepted a 6-property text batch and rejected a 7-property one, so
 // no chunk may ever exceed six. See STRUCTURED_OUTPUT_BUDGETS.
@@ -93,9 +94,16 @@ const propertiesArbitrary = fc
   )
   .map((kinds) => kinds.map(propertyForKind));
 
-const FILENAMES = [
-  { kind: "pdf-bates", simplified: "F0" },
-] as const satisfies Parameters<typeof buildBatchSchema>[1];
+// One citable PDF source, so the batch carries the fuller justification
+// schema a real extraction sends rather than the empty-citation variant.
+const FILENAMES: JustificationFilenames = [
+  {
+    kind: "pdf-bates",
+    original: "services-agreement.pdf",
+    simplified: "F0",
+    fileFieldId: toSafeId<"field">("file_field_0"),
+  },
+];
 
 const wireSchemaFor = (
   provider: TanStackAIProvider,

--- a/apps/api/src/lib/structured-output-budget.property.test.ts
+++ b/apps/api/src/lib/structured-output-budget.property.test.ts
@@ -1,0 +1,144 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import { TANSTACK_AI_PROVIDERS } from "@stll/ai-catalog";
+import type { TanStackAIProvider } from "@stll/ai-catalog";
+import { PROPERTIES_PER_WORKSPACE_MAX } from "@stll/api-contract";
+import { propertyConfig } from "@stll/property-testing";
+
+import type { AiExtractablePropertyContent } from "@/api/db/schema-validators";
+import { toSafeId } from "@/api/lib/branded-types";
+import {
+  checkStructuredOutputBudget,
+  splitPropertiesForBudget,
+} from "@/api/lib/structured-output-budget";
+import { structuredOutputWireJsonSchema } from "@/api/lib/tanstack-ai-generate";
+import { buildBatchSchema } from "@/api/lib/workflow/ai-prompts";
+import type { AIBatchProperty } from "@/api/lib/workflow/get-execution-plan";
+
+// Anthropic accepted a 6-property text batch and rejected a 7-property one, so
+// no chunk may ever exceed six. See STRUCTURED_OUTPUT_BUDGETS.
+const ANTHROPIC_MAX_PROPERTIES_PER_CHUNK = 6;
+
+const OPTION_VALUES = [
+  "Delaware",
+  "England and Wales",
+  "New York",
+  "California",
+  "Singapore",
+] as const;
+
+const CONTENT_KINDS = [
+  "text",
+  "date",
+  "int",
+  "single-select",
+  "multi-select",
+] as const;
+
+type ContentKind = (typeof CONTENT_KINDS)[number];
+
+const contentForKind = (kind: ContentKind): AiExtractablePropertyContent => {
+  switch (kind) {
+    case "text":
+      return { version: 1, type: "text" };
+    case "date":
+      return { version: 1, type: "date" };
+    case "int":
+      return { version: 1, type: "int" };
+    case "single-select":
+    case "multi-select":
+      return {
+        version: 1,
+        type: kind,
+        options: OPTION_VALUES.map((value) => ({ color: "blue", value })),
+        fallback: null,
+      };
+    default: {
+      const exhaustive: never = kind;
+      throw new TypeError(`Unhandled content kind: ${String(exhaustive)}`);
+    }
+  }
+};
+
+const propertyForKind = (
+  kind: ContentKind,
+  index: number,
+): AIBatchProperty => ({
+  id: toSafeId<"property">(`property_${index}`),
+  status: "stale",
+  content: contentForKind(kind),
+  dependencies: [],
+  tool: {
+    version: 1,
+    type: "ai-model",
+    prompt: `Extract the ${kind} value for field ${index} from the documents.`,
+  },
+});
+
+// `size: "max"` because fast-check's default array size would keep every
+// generated batch far below the workspace maximum, and the sizes that matter
+// here are the ones a real workspace reaches.
+const propertiesArbitrary = fc
+  .array(fc.constantFrom(...CONTENT_KINDS), {
+    minLength: 1,
+    maxLength: PROPERTIES_PER_WORKSPACE_MAX,
+    size: "max",
+  })
+  .map((kinds) => kinds.map(propertyForKind));
+
+const FILENAMES = [
+  { kind: "pdf-bates", simplified: "F0" },
+] as const satisfies Parameters<typeof buildBatchSchema>[1];
+
+const wireSchemaFor = (
+  provider: TanStackAIProvider,
+  properties: readonly AIBatchProperty[],
+): unknown =>
+  structuredOutputWireJsonSchema({
+    outputSchema: buildBatchSchema(properties, FILENAMES),
+    provider,
+  });
+
+describe("splitting a workflow batch for the provider's schema budget", () => {
+  test("every chunk fits its provider and the chunks partition the batch in order", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...TANSTACK_AI_PROVIDERS),
+        propertiesArbitrary,
+        (provider, properties) => {
+          const split = splitPropertiesForBudget({
+            provider,
+            properties,
+            buildSchema: (chunk) => wireSchemaFor(provider, chunk),
+          });
+          if (Result.isError(split)) {
+            throw split.error;
+          }
+
+          // Partition, in order: concatenating the chunks reproduces the batch.
+          expect(split.value.flat()).toEqual(properties);
+          expect(split.value.every((chunk) => chunk.length > 0)).toBe(true);
+
+          for (const chunk of split.value) {
+            expect(
+              Result.isError(
+                checkStructuredOutputBudget({
+                  provider,
+                  schema: wireSchemaFor(provider, chunk),
+                }),
+              ),
+            ).toBe(false);
+            if (provider === "anthropic") {
+              expect(chunk.length).toBeLessThanOrEqual(
+                ANTHROPIC_MAX_PROPERTIES_PER_CHUNK,
+              );
+            }
+          }
+        },
+      ),
+      propertyConfig({ numRuns: 30 }),
+    );
+  });
+});

--- a/apps/api/src/lib/structured-output-budget.property.test.ts
+++ b/apps/api/src/lib/structured-output-budget.property.test.ts
@@ -19,8 +19,11 @@ import { buildBatchSchema } from "@/api/lib/workflow/ai-prompts";
 import type { AIBatchProperty } from "@/api/lib/workflow/get-execution-plan";
 import type { JustificationFilenames } from "@/api/lib/workflow/parse-justifications";
 
-// Anthropic accepted a 6-property text batch and rejected a 7-property one, so
-// no chunk may ever exceed six. See STRUCTURED_OUTPUT_BUDGETS.
+// A ceiling, not the expected chunk size: six is the largest batch Anthropic
+// was ever measured to compile, so a chunk above it would be one the provider
+// has already rejected. How many properties actually fit depends on the schema
+// each one projects to (four, for the shape `buildBatchSchema` emits today),
+// which is why the budget itself is stated in bytes rather than a count.
 const ANTHROPIC_MAX_PROPERTIES_PER_CHUNK = 6;
 
 const OPTION_VALUES = [

--- a/apps/api/src/lib/structured-output-budget.test.ts
+++ b/apps/api/src/lib/structured-output-budget.test.ts
@@ -4,9 +4,13 @@ import { describe, expect, test } from "bun:test";
 import {
   checkStructuredOutputBudget,
   measureStructuredOutputSchema,
+  resolveStructuredOutputBudget,
   splitPropertiesForBudget,
   STRUCTURED_OUTPUT_BUDGETS,
 } from "@/api/lib/structured-output-budget";
+
+const ANTHROPIC_MODEL_ID = "claude-sonnet-5";
+const OPENAI_MODEL_ID = "gpt-5.6-luna";
 
 const expectError = <TValue, TError>(
   result: Result<TValue, TError>,
@@ -70,11 +74,68 @@ describe("measuring a projected structured-output schema", () => {
   });
 });
 
+describe("resolving which provider's budget applies", () => {
+  test("uses the addressed provider when it compiles the grammar itself", () => {
+    expect(
+      resolveStructuredOutputBudget({
+        provider: "anthropic",
+        modelId: ANTHROPIC_MODEL_ID,
+      }),
+    ).toEqual({
+      provider: "anthropic",
+      budget: STRUCTURED_OUTPUT_BUDGETS.anthropic,
+    });
+  });
+
+  test("holds an OpenRouter id routed to Anthropic to the Anthropic budget", () => {
+    expect(
+      resolveStructuredOutputBudget({
+        provider: "openrouter",
+        modelId: `anthropic/${ANTHROPIC_MODEL_ID}`,
+      }),
+    ).toEqual({
+      provider: "anthropic",
+      budget: STRUCTURED_OUTPUT_BUDGETS.anthropic,
+    });
+  });
+
+  test("holds an OpenRouter id routed to OpenAI to the OpenAI budget", () => {
+    expect(
+      resolveStructuredOutputBudget({
+        provider: "openrouter",
+        modelId: `openai/${OPENAI_MODEL_ID}`,
+      }),
+    ).toEqual({
+      provider: "openai",
+      budget: STRUCTURED_OUTPUT_BUDGETS.openai,
+    });
+  });
+
+  test("falls back to the OpenRouter placeholder for an unrecognized upstream", () => {
+    expect(
+      resolveStructuredOutputBudget({
+        provider: "openrouter",
+        modelId: "some-lab/experimental-1",
+      }),
+    ).toEqual({
+      provider: "openrouter",
+      budget: STRUCTURED_OUTPUT_BUDGETS.openrouter,
+    });
+    expect(
+      resolveStructuredOutputBudget({
+        provider: "openrouter",
+        modelId: "unprefixed-model",
+      }).provider,
+    ).toBe("openrouter");
+  });
+});
+
 describe("checking a schema against a provider budget", () => {
   test("accepts a schema inside the budget and reports what it measured", () => {
     const measured = expectValue(
       checkStructuredOutputBudget({
         provider: "anthropic",
+        modelId: ANTHROPIC_MODEL_ID,
         schema: { type: "object", properties: { answer: { type: "string" } } },
       }),
     );
@@ -94,7 +155,11 @@ describe("checking a schema against a provider budget", () => {
     };
 
     const error = expectError(
-      checkStructuredOutputBudget({ provider: "anthropic", schema: oversized }),
+      checkStructuredOutputBudget({
+        provider: "anthropic",
+        modelId: ANTHROPIC_MODEL_ID,
+        schema: oversized,
+      }),
     );
 
     expect(error.provider).toBe("anthropic");
@@ -118,7 +183,11 @@ describe("checking a schema against a provider budget", () => {
       STRUCTURED_OUTPUT_BUDGETS.anthropic.maxSchemaBytes,
     );
     const error = expectError(
-      checkStructuredOutputBudget({ provider: "anthropic", schema }),
+      checkStructuredOutputBudget({
+        provider: "anthropic",
+        modelId: ANTHROPIC_MODEL_ID,
+        schema,
+      }),
     );
 
     expect(error.measured.unionParameters).toBe(
@@ -137,12 +206,49 @@ describe("checking a schema against a provider budget", () => {
 
     expect(
       Result.isError(
-        checkStructuredOutputBudget({ provider: "anthropic", schema }),
+        checkStructuredOutputBudget({
+          provider: "anthropic",
+          modelId: ANTHROPIC_MODEL_ID,
+          schema,
+        }),
       ),
     ).toBe(true);
     expect(
       Result.isError(
-        checkStructuredOutputBudget({ provider: "openai", schema }),
+        checkStructuredOutputBudget({
+          provider: "openai",
+          modelId: OPENAI_MODEL_ID,
+          schema,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects an OpenRouter request whose upstream is Anthropic", () => {
+    const schema = {
+      type: "object",
+      description: "x".repeat(
+        STRUCTURED_OUTPUT_BUDGETS.anthropic.maxSchemaBytes,
+      ),
+    };
+
+    const error = expectError(
+      checkStructuredOutputBudget({
+        provider: "openrouter",
+        modelId: `anthropic/${ANTHROPIC_MODEL_ID}`,
+        schema,
+      }),
+    );
+
+    // The budget names the compiler, not the proxy the request was sent to.
+    expect(error.provider).toBe("anthropic");
+    expect(
+      Result.isError(
+        checkStructuredOutputBudget({
+          provider: "openrouter",
+          modelId: `openai/${OPENAI_MODEL_ID}`,
+          schema,
+        }),
       ),
     ).toBe(false);
   });
@@ -167,6 +273,7 @@ describe("splitting properties to fit a provider budget", () => {
     const chunks = expectValue(
       splitPropertiesForBudget({
         provider: "anthropic",
+        modelId: ANTHROPIC_MODEL_ID,
         properties,
         buildSchema: fixedSizeSchema,
       }),
@@ -179,6 +286,7 @@ describe("splitting properties to fit a provider budget", () => {
         Result.isError(
           checkStructuredOutputBudget({
             provider: "anthropic",
+            modelId: ANTHROPIC_MODEL_ID,
             schema: fixedSizeSchema(chunk),
           }),
         ),
@@ -193,10 +301,35 @@ describe("splitting properties to fit a provider budget", () => {
     ).toBe(true);
   });
 
+  test("splits an OpenRouter batch by its upstream's budget, not the placeholder", () => {
+    const properties = Array.from({ length: 20 }, (_, index) => `p${index}`);
+
+    const viaAnthropic = expectValue(
+      splitPropertiesForBudget({
+        provider: "openrouter",
+        modelId: `anthropic/${ANTHROPIC_MODEL_ID}`,
+        properties,
+        buildSchema: fixedSizeSchema,
+      }),
+    );
+    const viaUnknownUpstream = expectValue(
+      splitPropertiesForBudget({
+        provider: "openrouter",
+        modelId: "some-lab/experimental-1",
+        properties,
+        buildSchema: fixedSizeSchema,
+      }),
+    );
+
+    expect(viaAnthropic.length).toBeGreaterThan(viaUnknownUpstream.length);
+    expect(viaAnthropic.flat()).toEqual(properties);
+  });
+
   test("reports the property that cannot fit alone instead of looping forever", () => {
     const error = expectError(
       splitPropertiesForBudget({
         provider: "anthropic",
+        modelId: ANTHROPIC_MODEL_ID,
         properties: ["fits", "never-fits", "fits-too"],
         buildSchema: (properties) =>
           properties.includes("never-fits")
@@ -220,6 +353,7 @@ describe("splitting properties to fit a provider budget", () => {
       expectValue(
         splitPropertiesForBudget({
           provider: "anthropic",
+          modelId: ANTHROPIC_MODEL_ID,
           properties: [],
           buildSchema: fixedSizeSchema,
         }),

--- a/apps/api/src/lib/structured-output-budget.test.ts
+++ b/apps/api/src/lib/structured-output-budget.test.ts
@@ -64,6 +64,30 @@ describe("measuring a projected structured-output schema", () => {
     expect(measured.unionParameters).toBe(3);
   });
 
+  test("counts non-ASCII option labels as the UTF-8 bytes they occupy", () => {
+    // A workspace's own select options are embedded in the schema, so a CJK
+    // or emoji label costs more on the wire than its UTF-16 length suggests.
+    const schema = {
+      enum: ["契約書", "解約通知", "秘密保持契約", "🇨🇿 smlouva"],
+    };
+    const serialized = JSON.stringify(schema);
+
+    // The fixture must actually differ, or the assertion below is vacuous.
+    expect(serialized.length).toBeLessThan(
+      Buffer.byteLength(serialized, "utf-8"),
+    );
+    expect(measureStructuredOutputSchema(schema).bytes).toBe(
+      Buffer.byteLength(serialized, "utf-8"),
+    );
+  });
+
+  test("admits an ASCII schema at exactly the same size either way", () => {
+    const schema = { enum: ["contract", "termination-notice"] };
+    const serialized = JSON.stringify(schema);
+
+    expect(measureStructuredOutputSchema(schema).bytes).toBe(serialized.length);
+  });
+
   test("counts no union in a schema that has none", () => {
     expect(
       measureStructuredOutputSchema({
@@ -127,6 +151,50 @@ describe("resolving which provider's budget applies", () => {
         modelId: "unprefixed-model",
       }).provider,
     ).toBe("openrouter");
+  });
+
+  test("holds a Bedrock-hosted Claude to the Anthropic budget", () => {
+    // Bedrock names the vendor after an optional region, separated by dots.
+    expect(
+      resolveStructuredOutputBudget({
+        provider: "bedrock",
+        modelId: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      }),
+    ).toEqual({
+      provider: "anthropic",
+      budget: STRUCTURED_OUTPUT_BUDGETS.anthropic,
+    });
+    expect(
+      resolveStructuredOutputBudget({
+        provider: "bedrock",
+        modelId: "openai.gpt-oss-120b-1:0",
+      }).provider,
+    ).toBe("openai");
+    // A vendor with no budget of its own keeps Bedrock's.
+    expect(
+      resolveStructuredOutputBudget({
+        provider: "bedrock",
+        modelId: "us.amazon.nova-pro-v1:0",
+      }).provider,
+    ).toBe("bedrock");
+  });
+
+  test("never reads a vendor out of a first-party model id", () => {
+    // A first-party provider compiles the schema itself, so its own id is
+    // never parsed — an id that happened to contain another vendor's name
+    // must not redirect the budget.
+    expect(
+      resolveStructuredOutputBudget({
+        provider: "mistral",
+        modelId: "mistral-large-latest",
+      }).provider,
+    ).toBe("mistral");
+    expect(
+      resolveStructuredOutputBudget({
+        provider: "google",
+        modelId: "gemini-3.7-flash",
+      }).provider,
+    ).toBe("google");
   });
 });
 
@@ -222,6 +290,41 @@ describe("checking a schema against a provider budget", () => {
         }),
       ),
     ).toBe(false);
+  });
+
+  test("rejects a non-ASCII schema that only fits when counted as UTF-16", () => {
+    // Sized so the string length lands under Anthropic's budget while the
+    // UTF-8 payload the provider receives is over it: counting code units
+    // would admit a request the compiler then rejects.
+    const label = "契約書類";
+    const schema = {
+      enum: Array.from(
+        {
+          length: Math.ceil(
+            STRUCTURED_OUTPUT_BUDGETS.anthropic.maxSchemaBytes / 16,
+          ),
+        },
+        (_, index) => `${label}${index}`,
+      ),
+    };
+    const serialized = JSON.stringify(schema);
+
+    expect(serialized.length).toBeLessThan(
+      STRUCTURED_OUTPUT_BUDGETS.anthropic.maxSchemaBytes,
+    );
+    expect(Buffer.byteLength(serialized, "utf-8")).toBeGreaterThan(
+      STRUCTURED_OUTPUT_BUDGETS.anthropic.maxSchemaBytes,
+    );
+
+    expect(
+      Result.isError(
+        checkStructuredOutputBudget({
+          provider: "anthropic",
+          modelId: ANTHROPIC_MODEL_ID,
+          schema,
+        }),
+      ),
+    ).toBe(true);
   });
 
   test("rejects an OpenRouter request whose upstream is Anthropic", () => {

--- a/apps/api/src/lib/structured-output-budget.test.ts
+++ b/apps/api/src/lib/structured-output-budget.test.ts
@@ -1,0 +1,229 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import {
+  checkStructuredOutputBudget,
+  measureStructuredOutputSchema,
+  splitPropertiesForBudget,
+  STRUCTURED_OUTPUT_BUDGETS,
+} from "@/api/lib/structured-output-budget";
+
+const expectError = <TValue, TError>(
+  result: Result<TValue, TError>,
+): TError => {
+  if (!Result.isError(result)) {
+    throw new TypeError("Expected an error result.");
+  }
+  return result.error;
+};
+
+const expectValue = <TValue, TError>(
+  result: Result<TValue, TError>,
+): TValue => {
+  if (Result.isError(result)) {
+    throw new TypeError(`Expected an ok result, got ${String(result.error)}`);
+  }
+  return result.value;
+};
+
+describe("measuring a projected structured-output schema", () => {
+  test("reports the serialized size the provider compiles", () => {
+    const schema = {
+      type: "object",
+      properties: { answer: { type: "string" } },
+    };
+
+    expect(measureStructuredOutputSchema(schema).bytes).toBe(
+      JSON.stringify(schema).length,
+    );
+  });
+
+  test("counts a union anywhere in the tree, however it is spelled", () => {
+    const measured = measureStructuredOutputSchema({
+      type: "object",
+      properties: {
+        // `type` as an array.
+        answer: { type: ["string", "null"] },
+        // `anyOf` nested under an array's items.
+        citations: {
+          type: "array",
+          items: { anyOf: [{ type: "string" }, { type: "number" }] },
+        },
+        // `oneOf` nested two objects deep.
+        justification: {
+          type: "object",
+          properties: { source: { oneOf: [{ type: "string" }] } },
+        },
+      },
+    });
+
+    expect(measured.unionParameters).toBe(3);
+  });
+
+  test("counts no union in a schema that has none", () => {
+    expect(
+      measureStructuredOutputSchema({
+        type: "object",
+        properties: { answer: { type: "string" } },
+      }).unionParameters,
+    ).toBe(0);
+  });
+});
+
+describe("checking a schema against a provider budget", () => {
+  test("accepts a schema inside the budget and reports what it measured", () => {
+    const measured = expectValue(
+      checkStructuredOutputBudget({
+        provider: "anthropic",
+        schema: { type: "object", properties: { answer: { type: "string" } } },
+      }),
+    );
+
+    expect(measured.bytes).toBeLessThan(
+      STRUCTURED_OUTPUT_BUDGETS.anthropic.maxSchemaBytes,
+    );
+    expect(measured.unionParameters).toBe(0);
+  });
+
+  test("rejects a schema over the byte budget with the measurement and the budget", () => {
+    const oversized = {
+      type: "object",
+      description: "x".repeat(
+        STRUCTURED_OUTPUT_BUDGETS.anthropic.maxSchemaBytes,
+      ),
+    };
+
+    const error = expectError(
+      checkStructuredOutputBudget({ provider: "anthropic", schema: oversized }),
+    );
+
+    expect(error.provider).toBe("anthropic");
+    expect(error.measured.bytes).toBeGreaterThan(
+      STRUCTURED_OUTPUT_BUDGETS.anthropic.maxSchemaBytes,
+    );
+    expect(error.budget).toEqual(STRUCTURED_OUTPUT_BUDGETS.anthropic);
+    expect(error.message).toContain("schema bytes over the");
+  });
+
+  test("rejects too many union parameters even when the schema is small", () => {
+    const unions = Object.fromEntries(
+      Array.from(
+        { length: STRUCTURED_OUTPUT_BUDGETS.anthropic.maxUnionParameters + 1 },
+        (_, index) => [`f${index}`, { type: ["string", "null"] }],
+      ),
+    );
+    const schema = { type: "object", properties: unions };
+
+    expect(JSON.stringify(schema).length).toBeLessThan(
+      STRUCTURED_OUTPUT_BUDGETS.anthropic.maxSchemaBytes,
+    );
+    const error = expectError(
+      checkStructuredOutputBudget({ provider: "anthropic", schema }),
+    );
+
+    expect(error.measured.unionParameters).toBe(
+      STRUCTURED_OUTPUT_BUDGETS.anthropic.maxUnionParameters + 1,
+    );
+    expect(error.message).toContain("union parameters over the");
+  });
+
+  test("accepts on OpenAI what it rejects on Anthropic", () => {
+    const schema = {
+      type: "object",
+      description: "x".repeat(
+        STRUCTURED_OUTPUT_BUDGETS.anthropic.maxSchemaBytes,
+      ),
+    };
+
+    expect(
+      Result.isError(
+        checkStructuredOutputBudget({ provider: "anthropic", schema }),
+      ),
+    ).toBe(true);
+    expect(
+      Result.isError(
+        checkStructuredOutputBudget({ provider: "openai", schema }),
+      ),
+    ).toBe(false);
+  });
+});
+
+// A stand-in schema builder: one property costs a fixed number of bytes, so a
+// chunk's size is exactly predictable from the budget. The real projection is
+// exercised by the property test next to this file.
+const FIXED_BYTES_PER_PROPERTY = 1000;
+
+const fixedSizeSchema = (properties: readonly string[]) => ({
+  properties: properties.map((name) => ({
+    name,
+    filler: "x".repeat(FIXED_BYTES_PER_PROPERTY),
+  })),
+});
+
+describe("splitting properties to fit a provider budget", () => {
+  test("fills each chunk up to the budget and keeps the input order", () => {
+    const properties = Array.from({ length: 20 }, (_, index) => `p${index}`);
+
+    const chunks = expectValue(
+      splitPropertiesForBudget({
+        provider: "anthropic",
+        properties,
+        buildSchema: fixedSizeSchema,
+      }),
+    );
+
+    expect(chunks.flat()).toEqual(properties);
+    expect(chunks.every((chunk) => chunk.length > 0)).toBe(true);
+    for (const chunk of chunks) {
+      expect(
+        Result.isError(
+          checkStructuredOutputBudget({
+            provider: "anthropic",
+            schema: fixedSizeSchema(chunk),
+          }),
+        ),
+      ).toBe(false);
+    }
+    // Every chunk but the last is full: the split is greedy, not one-per-call.
+    const chunkSizes = chunks.map((chunk) => chunk.length);
+    const fullChunkSize = chunkSizes.at(0) ?? 0;
+    expect(fullChunkSize).toBeGreaterThan(1);
+    expect(
+      chunkSizes.slice(0, -1).every((size) => size === fullChunkSize),
+    ).toBe(true);
+  });
+
+  test("reports the property that cannot fit alone instead of looping forever", () => {
+    const error = expectError(
+      splitPropertiesForBudget({
+        provider: "anthropic",
+        properties: ["fits", "never-fits", "fits-too"],
+        buildSchema: (properties) =>
+          properties.includes("never-fits")
+            ? {
+                filler: "x".repeat(
+                  STRUCTURED_OUTPUT_BUDGETS.anthropic.maxSchemaBytes,
+                ),
+              }
+            : fixedSizeSchema(properties),
+      }),
+    );
+
+    expect(error.provider).toBe("anthropic");
+    expect(error.measured.bytes).toBeGreaterThan(
+      STRUCTURED_OUTPUT_BUDGETS.anthropic.maxSchemaBytes,
+    );
+  });
+
+  test("returns no chunks for no properties", () => {
+    expect(
+      expectValue(
+        splitPropertiesForBudget({
+          provider: "anthropic",
+          properties: [],
+          buildSchema: fixedSizeSchema,
+        }),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/apps/api/src/lib/structured-output-budget.ts
+++ b/apps/api/src/lib/structured-output-budget.ts
@@ -1,6 +1,9 @@
 import { Result, TaggedError } from "better-result";
 
-import { TANSTACK_AI_PROVIDERS } from "@stll/ai-catalog";
+import {
+  MODEL_CATALOG_PROVIDER_KIND,
+  TANSTACK_AI_PROVIDERS,
+} from "@stll/ai-catalog";
 import type { TanStackAIProvider } from "@stll/ai-catalog";
 
 /**
@@ -60,23 +63,39 @@ export type ResolvedStructuredOutputBudget = {
   budget: StructuredOutputBudget;
 };
 
-// Derived from the catalogue's own provider list, so a new TanStack provider
-// is recognized as an OpenRouter upstream without a second list to update.
+// An aggregator or platform id names its upstream vendor in the id itself,
+// separated by "/" on OpenRouter (`anthropic/claude-sonnet-5`) and by "." on
+// Bedrock, after an optional region (`us.anthropic.claude-sonnet-4-5-...`).
+// Matching against the catalogue's own provider list means a new TanStack
+// provider is recognized as an upstream without a second list to update.
+const MODEL_ID_VENDOR_SEPARATOR = /[/.]/u;
+
 const upstreamProviderFromModelId = (
   modelId: string,
 ): TanStackAIProvider | undefined => {
-  const prefix = modelId.split("/").at(0);
-  return TANSTACK_AI_PROVIDERS.find((provider) => provider === prefix);
+  const segments = new Set(modelId.split(MODEL_ID_VENDOR_SEPARATOR));
+  return TANSTACK_AI_PROVIDERS.find((provider) => segments.has(provider));
 };
 
+/**
+ * Which provider's grammar compiler a request reaches, and the budget it
+ * must fit.
+ *
+ * A first-party provider compiles the schema itself. An aggregator or
+ * platform proxies to a vendor named in the model id, so a routed Claude
+ * (`anthropic/claude-sonnet-5` on OpenRouter, `us.anthropic.claude-*` on
+ * Bedrock) is held to Anthropic's measured budget rather than the proxy's
+ * placeholder. An id naming no known vendor keeps the proxy's own budget:
+ * nothing better is known about it.
+ */
 export const resolveStructuredOutputBudget = ({
   provider,
   modelId,
 }: StructuredOutputTarget): ResolvedStructuredOutputBudget => {
   const compiler =
-    provider === "openrouter"
-      ? (upstreamProviderFromModelId(modelId) ?? "openrouter")
-      : provider;
+    MODEL_CATALOG_PROVIDER_KIND[provider] === "first-party"
+      ? provider
+      : (upstreamProviderFromModelId(modelId) ?? provider);
   return { provider: compiler, budget: STRUCTURED_OUTPUT_BUDGETS[compiler] };
 };
 
@@ -117,6 +136,8 @@ const countUnionParameters = (node: unknown): number => {
  * Measures a projected JSON schema the way the providers do: the serialized
  * size they compile, and the number of union-typed nodes anywhere in it.
  */
+const schemaUtf8Encoder = new TextEncoder();
+
 export const measureStructuredOutputSchema = (
   schema: unknown,
 ): StructuredOutputMeasure => {
@@ -124,7 +145,12 @@ export const measureStructuredOutputSchema = (
     return { bytes: 0, unionParameters: 0 };
   }
   return {
-    bytes: JSON.stringify(schema).length,
+    // UTF-8 bytes, not string length: the limit is on the wire payload, and a
+    // workspace's own option labels go into the schema. One CJK character is
+    // a single UTF-16 code unit but three bytes, so measuring `.length` would
+    // under-report a non-ASCII workspace's schema and admit a request the
+    // provider then rejects.
+    bytes: schemaUtf8Encoder.encode(JSON.stringify(schema)).byteLength,
     unionParameters: countUnionParameters(schema),
   };
 };

--- a/apps/api/src/lib/structured-output-budget.ts
+++ b/apps/api/src/lib/structured-output-budget.ts
@@ -1,5 +1,6 @@
 import { Result, TaggedError } from "better-result";
 
+import { TANSTACK_AI_PROVIDERS } from "@stll/ai-catalog";
 import type { TanStackAIProvider } from "@stll/ai-catalog";
 
 /**
@@ -31,14 +32,53 @@ export const STRUCTURED_OUTPUT_BUDGETS = {
   openai: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
   // Placeholders. No schema-size or union limit is published for these
   // providers, so these values only stop a runaway schema rather than
-  // encoding a known ceiling. An OpenRouter model id in particular resolves
-  // to an arbitrary upstream (Anthropic included), so its placeholder can
-  // under-constrain; tighten it from a measurement, not a guess.
+  // encoding a known ceiling; tighten one from a measurement, not a guess.
+  // OpenRouter's applies only to an id whose upstream is unknown:
+  // `resolveStructuredOutputBudget` reads the upstream off the id first.
   bedrock: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
   google: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
   mistral: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
   openrouter: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
 } as const satisfies Record<TanStackAIProvider, StructuredOutputBudget>;
+
+/**
+ * Which provider a request is addressed to, and which model it names.
+ *
+ * The model id matters because the addressed provider is not always the one
+ * that compiles the grammar: OpenRouter proxies to an upstream named by the
+ * id's prefix, so `anthropic/claude-sonnet-5` hits Anthropic's compiler and
+ * must be held to Anthropic's budget, not OpenRouter's placeholder.
+ */
+export type StructuredOutputTarget = {
+  provider: TanStackAIProvider;
+  modelId: string;
+};
+
+export type ResolvedStructuredOutputBudget = {
+  /** The provider whose grammar compiler sees the schema. */
+  provider: TanStackAIProvider;
+  budget: StructuredOutputBudget;
+};
+
+// Derived from the catalogue's own provider list, so a new TanStack provider
+// is recognized as an OpenRouter upstream without a second list to update.
+const upstreamProviderFromModelId = (
+  modelId: string,
+): TanStackAIProvider | undefined => {
+  const prefix = modelId.split("/").at(0);
+  return TANSTACK_AI_PROVIDERS.find((provider) => provider === prefix);
+};
+
+export const resolveStructuredOutputBudget = ({
+  provider,
+  modelId,
+}: StructuredOutputTarget): ResolvedStructuredOutputBudget => {
+  const compiler =
+    provider === "openrouter"
+      ? (upstreamProviderFromModelId(modelId) ?? "openrouter")
+      : provider;
+  return { provider: compiler, budget: STRUCTURED_OUTPUT_BUDGETS[compiler] };
+};
 
 export type StructuredOutputMeasure = {
   bytes: number;
@@ -89,6 +129,10 @@ export const measureStructuredOutputSchema = (
   };
 };
 
+/**
+ * `provider` is the one whose budget was applied, which for an OpenRouter
+ * request is the upstream that compiles the grammar rather than OpenRouter.
+ */
 export class StructuredOutputBudgetError extends TaggedError(
   "StructuredOutputBudgetError",
 )<{
@@ -98,19 +142,22 @@ export class StructuredOutputBudgetError extends TaggedError(
   budget: StructuredOutputBudget;
 }> {}
 
-type CheckStructuredOutputBudgetOptions = {
-  provider: TanStackAIProvider;
+type CheckStructuredOutputBudgetOptions = StructuredOutputTarget & {
   schema: unknown;
 };
 
 export const checkStructuredOutputBudget = ({
   provider,
+  modelId,
   schema,
 }: CheckStructuredOutputBudgetOptions): Result<
   StructuredOutputMeasure,
   StructuredOutputBudgetError
 > => {
-  const budget = STRUCTURED_OUTPUT_BUDGETS[provider];
+  const { provider: compiler, budget } = resolveStructuredOutputBudget({
+    provider,
+    modelId,
+  });
   const measured = measureStructuredOutputSchema(schema);
 
   const violations: string[] = [];
@@ -131,19 +178,18 @@ export const checkStructuredOutputBudget = ({
 
   return Result.err(
     new StructuredOutputBudgetError({
-      message: `Structured-output schema exceeds the ${provider} budget: ${violations.join("; ")}`,
-      provider,
+      message: `Structured-output schema exceeds the ${compiler} budget: ${violations.join("; ")}`,
+      provider: compiler,
       measured,
       budget,
     }),
   );
 };
 
-type SplitPropertiesForBudgetOptions<TProperty> = {
+type SplitPropertiesForBudgetOptions<TProperty> = StructuredOutputTarget & {
   /** Projects the JSON schema a request carrying exactly these properties would send. */
   buildSchema: (properties: readonly TProperty[]) => unknown;
   properties: readonly TProperty[];
-  provider: TanStackAIProvider;
 };
 
 /**
@@ -155,6 +201,7 @@ export const splitPropertiesForBudget = <TProperty>({
   buildSchema,
   properties,
   provider,
+  modelId,
 }: SplitPropertiesForBudgetOptions<TProperty>): Result<
   TProperty[][],
   StructuredOutputBudgetError
@@ -166,6 +213,7 @@ export const splitPropertiesForBudget = <TProperty>({
     current.push(property);
     const withProperty = checkStructuredOutputBudget({
       provider,
+      modelId,
       schema: buildSchema(current),
     });
     if (Result.isOk(withProperty)) {
@@ -180,6 +228,7 @@ export const splitPropertiesForBudget = <TProperty>({
     current = [property];
     const alone = checkStructuredOutputBudget({
       provider,
+      modelId,
       schema: buildSchema(current),
     });
     if (Result.isError(alone)) {

--- a/apps/api/src/lib/structured-output-budget.ts
+++ b/apps/api/src/lib/structured-output-budget.ts
@@ -1,0 +1,195 @@
+import { Result, TaggedError } from "better-result";
+
+import type { TanStackAIProvider } from "@stll/ai-catalog";
+
+/**
+ * What one structured-output request may put on the wire for a provider.
+ *
+ * Providers compile a strict output schema into a decoding grammar and reject
+ * the request outright once that grammar is too large. The rejection is an
+ * HTTP 400 from the provider, so it cannot be retried or recovered from: the
+ * schema has to be smaller before it is sent.
+ */
+export type StructuredOutputBudget = {
+  maxSchemaBytes: number;
+  maxUnionParameters: number;
+};
+
+export const STRUCTURED_OUTPUT_BUDGETS = {
+  // Measured 2026-09-02 against claude-sonnet-5 through the workflow batch
+  // path: a 5726-byte projected schema was accepted, a 6668-byte one was
+  // rejected with HTTP 400 "The compiled grammar is too large, which would
+  // cause performance issues. Simplify your tool schemas or reduce the number
+  // of strict tools." The byte cap sits under the largest accepted size.
+  // The union cap is quoted by Anthropic's second rejection: "limit: 16
+  // parameters with unions". Sharing sub-schemas through `$defs`/`$ref` does
+  // not help; the grammar is compiled from the inlined schema either way.
+  anthropic: { maxSchemaBytes: 5600, maxUnionParameters: 16 },
+  // Documented: OpenAI's strict structured outputs allow 120 000 total
+  // characters across the schema. 100_000 keeps headroom for request framing.
+  // The union cap is a placeholder; OpenAI publishes no union-parameter limit.
+  openai: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
+  // Placeholders. No schema-size or union limit is published for these
+  // providers, so these values only stop a runaway schema rather than
+  // encoding a known ceiling. An OpenRouter model id in particular resolves
+  // to an arbitrary upstream (Anthropic included), so its placeholder can
+  // under-constrain; tighten it from a measurement, not a guess.
+  bedrock: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
+  google: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
+  mistral: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
+  openrouter: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
+} as const satisfies Record<TanStackAIProvider, StructuredOutputBudget>;
+
+export type StructuredOutputMeasure = {
+  bytes: number;
+  unionParameters: number;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+// Anthropic counts a "parameter with a union type" as any schema node whose
+// `type` is an array or that carries `anyOf`. `oneOf` is counted with it:
+// the provider-safe projection can emit either, and both compile to a
+// branching grammar node.
+const isUnionNode = (node: Record<string, unknown>): boolean =>
+  Array.isArray(node["type"]) ||
+  node["anyOf"] !== undefined ||
+  node["oneOf"] !== undefined;
+
+const countUnionParameters = (node: unknown): number => {
+  if (Array.isArray(node)) {
+    return node.reduce<number>(
+      (total, item) => total + countUnionParameters(item),
+      0,
+    );
+  }
+  if (!isRecord(node)) {
+    return 0;
+  }
+  return Object.values(node).reduce<number>(
+    (total, value) => total + countUnionParameters(value),
+    isUnionNode(node) ? 1 : 0,
+  );
+};
+
+/**
+ * Measures a projected JSON schema the way the providers do: the serialized
+ * size they compile, and the number of union-typed nodes anywhere in it.
+ */
+export const measureStructuredOutputSchema = (
+  schema: unknown,
+): StructuredOutputMeasure => {
+  if (schema === undefined) {
+    return { bytes: 0, unionParameters: 0 };
+  }
+  return {
+    bytes: JSON.stringify(schema).length,
+    unionParameters: countUnionParameters(schema),
+  };
+};
+
+export class StructuredOutputBudgetError extends TaggedError(
+  "StructuredOutputBudgetError",
+)<{
+  message: string;
+  provider: TanStackAIProvider;
+  measured: StructuredOutputMeasure;
+  budget: StructuredOutputBudget;
+}> {}
+
+type CheckStructuredOutputBudgetOptions = {
+  provider: TanStackAIProvider;
+  schema: unknown;
+};
+
+export const checkStructuredOutputBudget = ({
+  provider,
+  schema,
+}: CheckStructuredOutputBudgetOptions): Result<
+  StructuredOutputMeasure,
+  StructuredOutputBudgetError
+> => {
+  const budget = STRUCTURED_OUTPUT_BUDGETS[provider];
+  const measured = measureStructuredOutputSchema(schema);
+
+  const violations: string[] = [];
+  if (measured.bytes > budget.maxSchemaBytes) {
+    violations.push(
+      `${measured.bytes} schema bytes over the ${budget.maxSchemaBytes} limit`,
+    );
+  }
+  if (measured.unionParameters > budget.maxUnionParameters) {
+    violations.push(
+      `${measured.unionParameters} union parameters over the ${budget.maxUnionParameters} limit`,
+    );
+  }
+
+  if (violations.length === 0) {
+    return Result.ok(measured);
+  }
+
+  return Result.err(
+    new StructuredOutputBudgetError({
+      message: `Structured-output schema exceeds the ${provider} budget: ${violations.join("; ")}`,
+      provider,
+      measured,
+      budget,
+    }),
+  );
+};
+
+type SplitPropertiesForBudgetOptions<TProperty> = {
+  /** Projects the JSON schema a request carrying exactly these properties would send. */
+  buildSchema: (properties: readonly TProperty[]) => unknown;
+  properties: readonly TProperty[];
+  provider: TanStackAIProvider;
+};
+
+/**
+ * Partitions properties, in order, into the largest consecutive groups whose
+ * schema still fits the provider budget. A single property that cannot fit
+ * alone is an error: no split of the batch would make that request legal.
+ */
+export const splitPropertiesForBudget = <TProperty>({
+  buildSchema,
+  properties,
+  provider,
+}: SplitPropertiesForBudgetOptions<TProperty>): Result<
+  TProperty[][],
+  StructuredOutputBudgetError
+> => {
+  const chunks: TProperty[][] = [];
+  let current: TProperty[] = [];
+
+  for (const property of properties) {
+    current.push(property);
+    const withProperty = checkStructuredOutputBudget({
+      provider,
+      schema: buildSchema(current),
+    });
+    if (Result.isOk(withProperty)) {
+      continue;
+    }
+    if (current.length === 1) {
+      return Result.err(withProperty.error);
+    }
+
+    current.pop();
+    chunks.push(current);
+    current = [property];
+    const alone = checkStructuredOutputBudget({
+      provider,
+      schema: buildSchema(current),
+    });
+    if (Result.isError(alone)) {
+      return Result.err(alone.error);
+    }
+  }
+
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+
+  return Result.ok(chunks);
+};

--- a/apps/api/src/lib/tanstack-ai-generate.test.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.test.ts
@@ -19,6 +19,7 @@ import {
 import type { CachingDecision } from "@/api/lib/ai-config";
 import { classifyAIError } from "@/api/lib/ai-error";
 import { toSafeId } from "@/api/lib/branded-types";
+import { StructuredOutputBudgetError } from "@/api/lib/structured-output-budget";
 import {
   generateTanStackObjectForRole,
   generateTanStackTextForRole,
@@ -264,6 +265,75 @@ describe("TanStack AI structured output generation", () => {
     expect(captured.stream).toBe(true);
     expect(captured.outputSchema).not.toBe(rawSchema);
     expectHasTanStackJsonSchema(captured.outputSchema);
+  });
+
+  // The test model is an OpenAI one, so the schema has to clear the widest
+  // budget in the table. Every provider's budget is enforced at the same seam.
+  const overBudgetSchema = () =>
+    v.strictObject(
+      Object.fromEntries(
+        Array.from({ length: 600 }, (_, index) => [
+          `field_${index}`,
+          v.pipe(
+            v.string(),
+            v.description(
+              `Field ${index}: ${"a long instruction repeated to inflate the projected schema. ".repeat(3)}`,
+            ),
+          ),
+        ]),
+      ),
+    );
+
+  test("refuses an over-budget structured-output schema before it reaches the provider", async () => {
+    capturedChatOptions.length = 0;
+
+    const failure = await generateObjectForTestModel({
+      caching: noCaching,
+      organizationId: null,
+      orgAIConfig: null,
+      outputSchema: overBudgetSchema(),
+      prompt: "Extract the answer.",
+      role: "pdf",
+      serviceTier: "standard",
+      tenantWorkspaceIds: [],
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(StructuredOutputBudgetError);
+    expect(String(failure)).toContain("exceeds the openai budget");
+    expect(capturedChatOptions).toHaveLength(0);
+  });
+
+  test("refuses an over-budget structured-output schema before it starts streaming", async () => {
+    capturedChatOptions.length = 0;
+
+    const events: unknown[] = [];
+    const drain = async () => {
+      for await (const event of streamObjectForTestModel({
+        caching: noCaching,
+        organizationId: null,
+        orgAIConfig: null,
+        outputSchema: overBudgetSchema(),
+        prompt: "Extract the answer.",
+        role: "pdf",
+        serviceTier: "standard",
+        tenantWorkspaceIds: [],
+      })) {
+        events.push(event);
+      }
+    };
+
+    const failure = await drain().then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(StructuredOutputBudgetError);
+    expect(String(failure)).toContain("exceeds the openai budget");
+    expect(events).toEqual([]);
+    expect(capturedChatOptions).toHaveLength(0);
   });
 
   test("validates final objects with the original Valibot schema", async () => {

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -461,6 +461,7 @@ const guardStructuredOutputBudget = ({
 
   const budget = checkStructuredOutputBudget({
     provider: model.provider,
+    modelId: model.modelId,
     schema: structuredOutputWireJsonSchema({
       outputSchema,
       provider: model.provider,

--- a/apps/api/src/lib/tanstack-ai-generate.ts
+++ b/apps/api/src/lib/tanstack-ai-generate.ts
@@ -1,4 +1,9 @@
-import { EventType, chat, parsePartialJSON } from "@tanstack/ai";
+import {
+  EventType,
+  chat,
+  convertSchemaToJsonSchema,
+  parsePartialJSON,
+} from "@tanstack/ai";
 import type {
   ModelMessage,
   RunErrorEvent,
@@ -7,10 +12,14 @@ import type {
   SystemPrompt,
 } from "@tanstack/ai";
 import type { OpenAITextProviderOptions } from "@tanstack/ai-openai";
-import { panic } from "better-result";
+import { Result, panic } from "better-result";
 import * as v from "valibot";
 
-import type { ModelRole, ReasoningEffort } from "@stll/ai-catalog";
+import type {
+  ModelRole,
+  ReasoningEffort,
+  TanStackAIProvider,
+} from "@stll/ai-catalog";
 
 import type {
   AIRequestServiceTier,
@@ -35,6 +44,7 @@ import {
   providerSafeJsonSchemaOptionsForTanStackProvider,
   type ProviderSafeJsonSchemaProjectionOptions,
 } from "@/api/lib/provider-safe-json-schema";
+import { checkStructuredOutputBudget } from "@/api/lib/structured-output-budget";
 import { tanStackCacheControl } from "@/api/lib/tanstack-ai-caching";
 import {
   getTanStackTextModelById,
@@ -407,6 +417,60 @@ const structuredOutputProjectionOptions = (
     isMockTextAdapterActive() ? "mock-structured-output" : "structured-output",
   );
 
+type StructuredOutputWireJsonSchemaOptions = {
+  outputSchema: v.GenericSchema;
+  provider: TanStackAIProvider;
+};
+
+/**
+ * The JSON Schema a structured-output request actually sends. `@tanstack/ai`
+ * runs this exact conversion on the schema handed to `chat`, so sizing a
+ * request against anything else would drift from what the provider compiles.
+ */
+export const structuredOutputWireJsonSchema = ({
+  outputSchema,
+  provider,
+}: StructuredOutputWireJsonSchemaOptions): unknown =>
+  convertSchemaToJsonSchema(
+    toTanStackValibotSchema(
+      outputSchema,
+      structuredOutputProjectionOptions(provider),
+    ),
+    { forStructuredOutput: true },
+  );
+
+/**
+ * The one seam every structured-output request in this API passes through, so
+ * a schema over the provider's grammar budget cannot reach a provider and come
+ * back as an unrecoverable HTTP 400. Callers that can shrink their request
+ * (the workflow batch splitter) size it before dispatch; this is the backstop
+ * for the ones that cannot.
+ */
+const guardStructuredOutputBudget = ({
+  model,
+  outputSchema,
+}: {
+  model: ResolvedTanStackTextModel;
+  outputSchema: v.GenericSchema;
+}): void => {
+  // The mock adapter answers locally: no provider compiles the grammar, and
+  // its projection deliberately keeps keywords the wire schema drops.
+  if (isMockTextAdapterActive()) {
+    return;
+  }
+
+  const budget = checkStructuredOutputBudget({
+    provider: model.provider,
+    schema: structuredOutputWireJsonSchema({
+      outputSchema,
+      provider: model.provider,
+    }),
+  });
+  if (Result.isError(budget)) {
+    throw budget.error;
+  }
+};
+
 export const generateTanStackObjectForRole = async <
   TSchema extends v.GenericSchema,
 >({
@@ -420,6 +484,7 @@ export const generateTanStackObjectForRole = async <
   const abortController = options.abortSignal
     ? abortControllerFromSignal(options.abortSignal)
     : undefined;
+  guardStructuredOutputBudget({ model, outputSchema });
   const tanStackOutputSchema = toTanStackValibotSchema(
     outputSchema,
     structuredOutputProjectionOptions(model.provider),
@@ -508,6 +573,7 @@ const streamTanStackStructuredOutput = async function* <
 }): AsyncIterable<TanStackStructuredOutputEvent<v.InferOutput<TSchema>>> {
   let completed = false;
   let rawJson = "";
+  guardStructuredOutputBudget({ model, outputSchema });
   const tanStackOutputSchema = toTanStackValibotSchema(
     outputSchema,
     structuredOutputProjectionOptions(model.provider),

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -1580,17 +1580,17 @@ const processOneBatch = async ({
         ...batch,
         properties: aiModelProperties,
       };
-      // generateBatch returns a Result<T, E> directly. The combined
-      // signal aborts when EITHER the per-batch AI timeout fires OR the
-      // worker-level per-job timeout does, so TanStack AI actually cancels
-      // the in-flight request.
+      // generateBatch returns a Result<T, E> directly. Only the worker-level
+      // per-job timeout is applied here: a batch is no longer one model
+      // request, because `generateWorkflowData` splits it into as many
+      // requests as the provider's schema budget allows. It applies the
+      // per-request AI timeout to each of those, which is the only place the
+      // request count is known; applying it to the whole batch here would
+      // abort a large batch partway through its first minutes.
       const batchResult = await runWorkflowBatchGenerationWithRetry({
         generate: async () =>
           await generateFn({
-            abortSignal: AbortSignal.any([
-              AbortSignal.timeout(getWorkflowBatchAITimeoutMs(serviceTier)),
-              signal,
-            ]),
+            abortSignal: signal,
             batch: aiBatch,
             entityVersionId,
             organizationId,

--- a/apps/api/src/lib/workflow/ai-generate-batch.ts
+++ b/apps/api/src/lib/workflow/ai-generate-batch.ts
@@ -35,6 +35,7 @@ import type {
   AIJustificationOutput,
   JustificationFilenames,
 } from "@/api/lib/workflow/parse-justifications";
+import { getWorkflowBatchAITimeoutMs } from "@/api/lib/workflow/run-logic";
 import {
   consumePartialAnswers,
   consumeTanStackPartialAnswer,
@@ -283,6 +284,16 @@ export const generateWorkflowData = async ({
       { type: "text", content: buildPromptsMessage(chunkProperties) },
     ];
 
+    // Each chunk is one model request, so it gets the per-request budget;
+    // before the batch was split, the caller applied that same budget once
+    // because a batch *was* one request. The caller's signal (the worker's
+    // per-job timeout) still bounds the batch as a whole, so a stalled chunk
+    // fails on its own instead of consuming what the remaining chunks need.
+    const chunkAbortSignal = AbortSignal.any([
+      abortSignal,
+      AbortSignal.timeout(getWorkflowBatchAITimeoutMs(serviceTier)),
+    ]);
+
     return await Result.tryPromise({
       try: async () => {
         const stream = streamTanStackObjectForRole({
@@ -295,7 +306,7 @@ export const generateWorkflowData = async ({
           serviceTier,
           messages: [{ role: "user", content: chunkContent }],
           system: WORKFLOW_SYSTEM_PROMPT,
-          abortSignal,
+          abortSignal: chunkAbortSignal,
           outputSchema: buildBatchSchema(chunkProperties, filenames),
         });
 

--- a/apps/api/src/lib/workflow/ai-generate-batch.ts
+++ b/apps/api/src/lib/workflow/ai-generate-batch.ts
@@ -167,10 +167,11 @@ export const generateWorkflowData = async ({
   if (Result.isError(model)) {
     return Result.err(model.error);
   }
-  const { provider } = model.value;
+  const { provider, modelId } = model.value;
 
   const chunks = splitPropertiesForBudget({
     provider,
+    modelId,
     properties,
     buildSchema: (chunkProperties) =>
       structuredOutputWireJsonSchema({

--- a/apps/api/src/lib/workflow/ai-generate-batch.ts
+++ b/apps/api/src/lib/workflow/ai-generate-batch.ts
@@ -12,8 +12,13 @@ import type { AIUsageMetering } from "@/api/lib/analytics/tanstack-ai";
 import type { SafeId } from "@/api/lib/branded-types";
 import { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
 import { sanitizeForPrompt, untrustedText } from "@/api/lib/prompt-safety";
+import { splitPropertiesForBudget } from "@/api/lib/structured-output-budget";
 import { markTanStackCacheBreakpoint } from "@/api/lib/tanstack-ai-caching";
-import { streamTanStackObjectForRole } from "@/api/lib/tanstack-ai-generate";
+import {
+  resolveTanStackTextModel,
+  streamTanStackObjectForRole,
+  structuredOutputWireJsonSchema,
+} from "@/api/lib/tanstack-ai-generate";
 import {
   buildBatchSchema,
   buildDocxBlocksMessage,
@@ -147,7 +152,42 @@ export const generateWorkflowData = async ({
 }: GenerateWorkflowDataProps): Promise<
   Result<WorkflowDataOutput, WorkflowIntegrationError>
 > => {
-  const schema = buildBatchSchema(properties, filenames);
+  // Resolved up front because the schema budget is a property of the provider,
+  // not of the batch: the planner groups properties by dependency signature
+  // and cannot know how many of them one request may carry.
+  const model = Result.try({
+    try: () =>
+      resolveTanStackTextModel({ role: "pdf", orgAIConfig, organizationId }),
+    catch: (error) =>
+      new WorkflowIntegrationError({
+        message: "Workflow AI model resolution failed",
+        cause: error,
+      }),
+  });
+  if (Result.isError(model)) {
+    return Result.err(model.error);
+  }
+  const { provider } = model.value;
+
+  const chunks = splitPropertiesForBudget({
+    provider,
+    properties,
+    buildSchema: (chunkProperties) =>
+      structuredOutputWireJsonSchema({
+        outputSchema: buildBatchSchema(chunkProperties, filenames),
+        provider,
+      }),
+  });
+  if (Result.isError(chunks)) {
+    return Result.err(
+      new WorkflowIntegrationError({
+        message:
+          "A single workflow property does not fit the provider's structured-output budget",
+        cause: chunks.error,
+      }),
+    );
+  }
+
   const cachingDecision = resolveCaching({
     promptCachingEnabled,
     role: "pdf",
@@ -220,84 +260,103 @@ export const generateWorkflowData = async ({
     }
   }
 
-  messageContent.push({
-    type: "text",
-    content: buildPromptsMessage(properties),
-  });
-
-  const aiAnalytics = createTanStackAIAnalyticsCallbacks(
-    buildWorkflowAIAnalyticsProps({
-      entityVersionId,
-      organizationId,
-      orgAIConfig: orgAIConfig ?? null,
-      propertyCount: properties.length,
-      usageMetering,
-      workspaceId,
-    }),
-  );
-
-  return await Result.tryPromise({
-    try: async () => {
-      const stream = streamTanStackObjectForRole({
-        role: "pdf",
-        orgAIConfig,
+  // Every chunk sends the same `messageContent` prefix, so the cache
+  // breakpoint above is warmed once and reused; only the prompt list and the
+  // output schema narrow to the chunk.
+  const runChunk = async (
+    chunkProperties: AIBatchProperty[],
+  ): Promise<Result<WorkflowDataOutput, WorkflowIntegrationError>> => {
+    const aiAnalytics = createTanStackAIAnalyticsCallbacks(
+      buildWorkflowAIAnalyticsProps({
+        entityVersionId,
         organizationId,
-        tenantWorkspaceIds: [workspaceId],
-        analytics: aiAnalytics,
-        caching: cachingDecision,
-        serviceTier,
-        messages: [{ role: "user", content: messageContent }],
-        system: WORKFLOW_SYSTEM_PROMPT,
-        abortSignal,
-        outputSchema: schema,
-      });
+        orgAIConfig: orgAIConfig ?? null,
+        propertyCount: chunkProperties.length,
+        usageMetering,
+        workspaceId,
+      }),
+    );
 
-      let rawJson = "";
-      let output: WorkflowDataOutput | undefined;
-      const propertyIds = properties.map((property) => property.id);
+    const chunkContent: WorkflowMessagePart[] = [
+      ...messageContent,
+      { type: "text", content: buildPromptsMessage(chunkProperties) },
+    ];
 
-      for await (const event of stream) {
-        if (event.type === "complete") {
-          output = event.object;
-          continue;
-        }
+    return await Result.tryPromise({
+      try: async () => {
+        const stream = streamTanStackObjectForRole({
+          role: "pdf",
+          orgAIConfig,
+          organizationId,
+          tenantWorkspaceIds: [workspaceId],
+          analytics: aiAnalytics,
+          caching: cachingDecision,
+          serviceTier,
+          messages: [{ role: "user", content: chunkContent }],
+          system: WORKFLOW_SYSTEM_PROMPT,
+          abortSignal,
+          outputSchema: buildBatchSchema(chunkProperties, filenames),
+        });
 
-        if (!onPartialAnswer) {
-          continue;
-        }
+        let rawJson = "";
+        let output: WorkflowDataOutput | undefined;
+        const propertyIds = chunkProperties.map((property) => property.id);
 
-        if (event.type === "partial") {
-          await consumePartialAnswers({
-            partialOutputs: [event.partial],
+        for await (const event of stream) {
+          if (event.type === "complete") {
+            output = event.object;
+            continue;
+          }
+
+          if (!onPartialAnswer) {
+            continue;
+          }
+
+          if (event.type === "partial") {
+            await consumePartialAnswers({
+              partialOutputs: [event.partial],
+              propertyIds,
+              onPartialAnswer,
+            });
+            continue;
+          }
+
+          rawJson += event.delta;
+          await consumeTanStackPartialAnswer({
+            rawJson,
             propertyIds,
             onPartialAnswer,
           });
-          continue;
         }
 
-        rawJson += event.delta;
-        await consumeTanStackPartialAnswer({
-          rawJson,
-          propertyIds,
-          onPartialAnswer,
+        if (output === undefined) {
+          throw new WorkflowIntegrationError({
+            message: "Workflow AI generation did not return structured output",
+          });
+        }
+
+        return output;
+      },
+      catch: (error) => {
+        aiAnalytics.captureError(error);
+
+        return new WorkflowIntegrationError({
+          message: "Workflow AI generation failed",
+          cause: error,
         });
-      }
+      },
+    });
+  };
 
-      if (output === undefined) {
-        throw new WorkflowIntegrationError({
-          message: "Workflow AI generation did not return structured output",
-        });
-      }
+  const merged: WorkflowDataOutput = {};
+  for (const chunkProperties of chunks.value) {
+    // oxlint-disable-next-line no-await-in-loop -- chunks share one prompt prefix, so running them in order caches it once instead of paying for it per chunk, and the first failure stops the batch
+    const chunkOutput = await runChunk(chunkProperties);
+    if (Result.isError(chunkOutput)) {
+      return chunkOutput;
+    }
+    Object.assign(merged, chunkOutput.value);
+  }
 
-      return output;
-    },
-    catch: (error) => {
-      aiAnalytics.captureError(error);
-
-      return new WorkflowIntegrationError({
-        message: "Workflow AI generation failed",
-        cause: error,
-      });
-    },
-  });
+  return Result.ok(merged);
 };

--- a/apps/api/src/lib/workflow/ai-generate-batch.ts
+++ b/apps/api/src/lib/workflow/ai-generate-batch.ts
@@ -349,15 +349,28 @@ export const generateWorkflowData = async ({
     });
   };
 
-  const merged: WorkflowDataOutput = {};
-  for (const chunkProperties of chunks.value) {
-    // oxlint-disable-next-line no-await-in-loop -- chunks share one prompt prefix, so running them in order caches it once instead of paying for it per chunk, and the first failure stops the batch
+  // Recursion rather than a loop because the chunks must run strictly in
+  // order, and only one at a time: the first chunk writes the shared prompt
+  // prefix into the provider's cache and the rest read it, so overlapping
+  // them would pay for that prefix once per chunk. Answers from earlier
+  // chunks accumulate into `merged`; the first failure ends the batch.
+  const chunkBatches = chunks.value;
+  const runFromChunk = async (
+    index: number,
+    merged: WorkflowDataOutput,
+  ): Promise<Result<WorkflowDataOutput, WorkflowIntegrationError>> => {
+    const chunkProperties = chunkBatches.at(index);
+    if (chunkProperties === undefined) {
+      return Result.ok(merged);
+    }
+
     const chunkOutput = await runChunk(chunkProperties);
     if (Result.isError(chunkOutput)) {
       return chunkOutput;
     }
     Object.assign(merged, chunkOutput.value);
-  }
+    return await runFromChunk(index + 1, merged);
+  };
 
-  return Result.ok(merged);
+  return await runFromChunk(0, {});
 };

--- a/apps/api/src/lib/workflow/ai-prompts.ts
+++ b/apps/api/src/lib/workflow/ai-prompts.ts
@@ -221,7 +221,7 @@ const createJustificationSchema = (filenames: JustificationFilenames) => {
 };
 
 export const buildBatchSchema = (
-  properties: BatchProperty[],
+  properties: readonly BatchProperty[],
   filenames: JustificationFilenames,
 ) => {
   const justificationSchema = createJustificationSchema(filenames);


### PR DESCRIPTION
- `generateWorkflowData` sent one structured-output request per dependency batch with no size cap. Anthropic compiles a strict output schema into a decoding grammar and returns HTTP 400 "The compiled grammar is too large" once it is too big, so batches past a handful of properties could never complete.
- Measured against `claude-sonnet-5` on 2026-09-02: a 5726-byte projected schema (6 text properties) is accepted, 6668 bytes (7) is rejected. A second limit is quoted by the API: "limit: 16 parameters with unions". Sharing sub-schemas via `$defs`/`$ref` only moved the ceiling to ~13 mixed properties, so the budget is `{ maxSchemaBytes: 5600, maxUnionParameters: 16 }` for anthropic; the other providers carry documented (OpenAI: 120 000 characters, taken as 100 000) or placeholder values, labelled as such in the table.
- New `apps/api/src/lib/structured-output-budget.ts` measures the JSON schema `@tanstack/ai` actually puts on the wire (bytes plus union-typed nodes) and checks it against the provider budget. `generateTanStackObjectForRole` and `streamTanStackObjectForRole` run that check before dispatch, so no structured-output request in the API can reach a provider over budget.
- `generateWorkflowData` now resolves the model first, splits properties in order into the largest chunks that fit that provider, runs them sequentially on the shared abort signal and shared prompt prefix, and merges the answers; `buildLevelBatches` is unchanged. Verified live against `anthropic::claude-sonnet-5` at 7, 20 and 40 mixed properties (all answered).
