### PR TITLE
fix(case-law): refuse decision dates after tomorrow

### DIFF
--- a/apps/api/drizzle/20260902100000_case_law_decision_date_ceiling/migration.sql
+++ b/apps/api/drizzle/20260902100000_case_law_decision_date_ceiling/migration.sql
@@ -1,0 +1,90 @@
+SET lock_timeout = '1s';--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+
+-- The decision-date ceiling moves from "the end of next year" to "tomorrow
+-- (UTC)": a decision cannot have been issued in the future, and the old
+-- ceiling let publisher parsing artifacts dated months ahead sort to the top
+-- of every newest-first list. The floor is unchanged.
+--
+-- Rows dated past the new ceiling cannot survive the constraint (NOT VALID
+-- is enforced on every later UPDATE of such a row, and VALIDATE fails while
+-- one remains), so they are cleared first the way 20260818090000 and
+-- `repair-decision-dates.ts` clear them: `decision_date` to NULL,
+-- `indexed_hash` cleared so the search projection is rebuilt. The script
+-- additionally reopens citation edges decided under the old date and is the
+-- intended pre-step for an operator; this statement is the floor. Bounded by
+-- "case_law_decisions_date_idx": only rows past the ceiling are visited
+-- (21 rows in production at authoring time).
+--
+-- The citation graph is told first. The resolver filters candidates on
+-- `decision_date`, so edges decided under the old date, and citations whose
+-- key names one of these decisions, are put back to pending for the standing
+-- walk, which only revisits unsettled rows. This is the coarse form of what
+-- `reopenCitationsFrom` and `reopenCitationsForDecisionKey` do per decision:
+-- every non-pending citation touching an affected decision or sharing its
+-- key, without the per-jurisdiction reach filter. Reopening more than the
+-- script would costs the walk a re-resolution; reopening less would leave a
+-- stale edge, which is the fault being repaired. Under the walk's own
+-- advisory lock, as the helpers take it.
+SELECT pg_advisory_xact_lock(hashtext('case_law'), hashtext('citation_resolution_walk'));--> statement-breakpoint
+WITH affected AS (
+  SELECT "id", "citation_key"
+    FROM "case_law_decisions"
+   WHERE "decision_date" >= ((now() AT TIME ZONE 'UTC')::date + 2)
+)
+UPDATE "case_law_citations" c
+   SET "resolution_status" = 'pending',
+       "cited_decision_id" = NULL,
+       "resolution_rule_id" = NULL
+ WHERE c."resolution_status" <> 'pending'
+   AND (
+        c."citing_decision_id" IN (SELECT "id" FROM affected)
+     OR c."cited_decision_id" IN (SELECT "id" FROM affected)
+     OR c."citation_key" IN (
+          SELECT "citation_key" FROM affected WHERE "citation_key" IS NOT NULL
+        )
+   );--> statement-breakpoint
+UPDATE "case_law_decisions"
+   SET "decision_date" = NULL,
+       "indexed_hash" = NULL
+ WHERE "decision_date" >= ((now() AT TIME ZONE 'UTC')::date + 2);--> statement-breakpoint
+
+-- Replace the CHECK with the tightened ceiling. The expression below is the
+-- rendering of `decisionDateWithinBoundsSql` (apps/api/src/lib/decision-date-bounds-sql.ts),
+-- which `decision-date-bounds-sql.db.test.ts` compares against this file.
+-- NOT VALID here, VALIDATE below, for the same reason as 20260818090000:
+-- adding a validating CHECK scans every row under ACCESS EXCLUSIVE.
+--
+-- Re-runnable as a pair: a second run drops the validated constraint, adds
+-- it NOT VALID again and validates it below; the outcome is the same.
+-- stella-migration-safety: reviewed drop-constraint - the same constraint is re-added NOT VALID by the next statement with a stricter ceiling; the drop exists only so the expression can change, and no row is written between the two
+ALTER TABLE "case_law_decisions"
+  DROP CONSTRAINT IF EXISTS "case_law_decisions_decision_date_bounds";--> statement-breakpoint
+ALTER TABLE "case_law_decisions"
+  ADD CONSTRAINT "case_law_decisions_decision_date_bounds"
+  CHECK (
+    "decision_date" IS NULL OR (
+      "decision_date" >= make_date(1800, 1, 1)
+      AND "decision_date" < ((now() AT TIME ZONE 'UTC')::date
+             + 2)
+    )
+  ) NOT VALID;--> statement-breakpoint
+
+-- Validate outside Drizzle's migration transaction so PostgreSQL does not
+-- hold the ADD CONSTRAINT lock for the duration of the table scan. VALIDATE
+-- takes SHARE UPDATE EXCLUSIVE, which concurrent readers and writers do not
+-- wait on, and is a no-op on an already validated constraint. Same shape as
+-- 20260818090000.
+-- squawk-ignore transaction-nesting
+COMMIT;--> statement-breakpoint
+SET statement_timeout = 0;--> statement-breakpoint
+SET lock_timeout = 0;--> statement-breakpoint
+-- Re-runnable as it stands: the guarded block above is skipped once the
+-- tightened constraint exists, and validating a validated constraint changes
+-- nothing.
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE "case_law_decisions" VALIDATE CONSTRAINT "case_law_decisions_decision_date_bounds";--> statement-breakpoint
+SET statement_timeout = '5s';--> statement-breakpoint
+SET lock_timeout = '1s';--> statement-breakpoint
+-- squawk-ignore transaction-nesting, ban-uncommitted-transaction
+BEGIN;

--- a/apps/api/src/db/schema/case-law.ts
+++ b/apps/api/src/db/schema/case-law.ts
@@ -471,8 +471,8 @@ export const caseLawDecisions = p.pgTable(
       "case_law_decisions_redacted_payload_erased",
       sql`${t.redactedAt} IS NULL OR (${t.fulltext} IS NULL AND ${t.sections} IS NULL AND ${t.documentAst} IS NULL AND ${t.contentHash} IS NULL)`,
     ),
-    // The year bounds `canonicalDecisionDate` enforces on the write path,
-    // enforced at the table as well; both derive from `DECISION_YEAR_BOUNDS`.
+    // The bounds `canonicalDecisionDate` enforces on the write path,
+    // enforced at the table as well; both derive from `DECISION_DATE_BOUNDS`.
     // A NULL date is allowed: it is how a decision without a usable date is
     // stored.
     p.check(

--- a/apps/api/src/lib/dates.test.ts
+++ b/apps/api/src/lib/dates.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 import {
   addDays,
@@ -6,6 +13,7 @@ import {
   canonicalDecisionDate,
   isIsoDateString,
   parseIsoDateLocal,
+  toUtcDateString,
 } from "./dates";
 
 // Date's local-time methods read `process.env.TZ` on every call in Bun (and
@@ -96,13 +104,23 @@ describe("canonicalDecisionDate", () => {
     expect(canonicalDecisionDate("1800-01-01")).toBe("1800-01-01");
   });
 
-  test("accepts next year but not the one after", () => {
-    const currentYear = new Date().getUTCFullYear();
+  test("accepts today and tomorrow (UTC) but not the day after", () => {
+    // Pinned just before a UTC midnight: the guard reads its own clock, so
+    // an unpinned test could compute the fixture on one day and be judged on
+    // the next.
+    const now = new Date("2026-03-01T23:59:59.500Z");
+    setSystemTime(now);
+    try {
+      const day = (offset: number) => toUtcDateString(addUtcDays(now, offset));
 
-    expect(canonicalDecisionDate(`${currentYear + 1}-06-15`)).toBe(
-      `${currentYear + 1}-06-15`,
-    );
-    expect(canonicalDecisionDate(`${currentYear + 2}-06-15`)).toBeNull();
+      expect(canonicalDecisionDate(day(-1))).toBe("2026-02-28");
+      expect(canonicalDecisionDate(day(0))).toBe("2026-03-01");
+      expect(canonicalDecisionDate(day(1))).toBe("2026-03-02");
+      expect(canonicalDecisionDate(day(2))).toBeNull();
+      expect(canonicalDecisionDate(day(400))).toBeNull();
+    } finally {
+      setSystemTime();
+    }
   });
 
   test("rejects a far-future year", () => {

--- a/apps/api/src/lib/dates.ts
+++ b/apps/api/src/lib/dates.ts
@@ -77,19 +77,21 @@ export const parseIsoDateLocal = (value: string): Date | null => {
 const ISO_DATE_LENGTH = 10;
 
 /**
- * Year range a decision date may fall in. The floor predates any court whose
+ * Range a decision date may fall in. The floor year predates any court whose
  * decisions are published as machine-readable records, so a lower year is a
  * transcription or parsing artifact rather than a real date. The ceiling is
- * relative to the current year because a publisher may date a decision
- * slightly ahead; a fixed upper year would go stale.
+ * the current UTC day plus `daysAhead`: a decision cannot have been issued in
+ * the future, and one calendar day of slack covers a court whose local date is
+ * already ahead of UTC when it publishes. Anything later is a parsing
+ * artifact, and a newest-first list would show it first.
  *
  * Exported because the same bounds have to hold in SQL:
  * `decision-date-bounds-sql.ts` derives the table's CHECK constraint and the
  * repair predicate from this declaration rather than restating the numbers.
  */
-export const DECISION_YEAR_BOUNDS = {
-  min: 1800,
-  yearsAhead: 1,
+export const DECISION_DATE_BOUNDS = {
+  minYear: 1800,
+  daysAhead: 1,
 } as const;
 
 /**
@@ -161,9 +163,10 @@ export const isoCalendarDay = (raw: string): string | null => {
  * the value cannot be one.
  *
  * Accepts a bare calendar date or an ISO datetime, and rejects anything that
- * is not a real calendar day (e.g. "2024-02-30") or whose year falls outside
- * `DECISION_YEAR_BOUNDS`. A date column takes a malformed year as readily as
- * a correct one, so callers writing to one need this in front of the write.
+ * is not a real calendar day (e.g. "2024-02-30") or that falls outside
+ * `DECISION_DATE_BOUNDS`. A date column takes a malformed year or a future
+ * day as readily as a correct one, so callers writing to one need this in
+ * front of the write.
  */
 export const canonicalDecisionDate = (raw: string): string | null => {
   const candidate = isoCalendarDay(raw);
@@ -171,8 +174,15 @@ export const canonicalDecisionDate = (raw: string): string | null => {
     return null;
   }
   const year = Number(candidate.slice(0, 4));
-  const maxYear = new Date().getUTCFullYear() + DECISION_YEAR_BOUNDS.yearsAhead;
-  if (year < DECISION_YEAR_BOUNDS.min || year > maxYear) {
+  if (year < DECISION_DATE_BOUNDS.minYear) {
+    return null;
+  }
+  // ISO dates compare correctly as text, and the ceiling is a UTC day so the
+  // host's time zone cannot move it.
+  const ceiling = toUtcDateString(
+    addUtcDays(new Date(), DECISION_DATE_BOUNDS.daysAhead),
+  );
+  if (candidate > ceiling) {
     return null;
   }
   return candidate;

--- a/apps/api/src/lib/decision-date-bounds-sql.db.test.ts
+++ b/apps/api/src/lib/decision-date-bounds-sql.db.test.ts
@@ -7,7 +7,11 @@ import nodePath from "node:path";
 
 import { caseLawDecisions, caseLawSources } from "@/api/db/schema";
 import { createSafeId } from "@/api/lib/branded-types";
-import { canonicalDecisionDate } from "@/api/lib/dates";
+import {
+  addUtcDays,
+  canonicalDecisionDate,
+  toUtcDateString,
+} from "@/api/lib/dates";
 import {
   CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT,
   decisionDateOutOfBoundsSql,
@@ -24,7 +28,7 @@ import { createTestPglite } from "@/api/tests/pglite-test-db";
 
 const MIGRATION_PATH = nodePath.resolve(
   import.meta.dir,
-  "../../drizzle/20260818090000_case_law_decision_date_bounds/migration.sql",
+  "../../drizzle/20260902100000_case_law_decision_date_ceiling/migration.sql",
 );
 
 let client: Awaited<ReturnType<typeof createTestPglite>>;
@@ -32,6 +36,7 @@ let db: ReturnType<typeof drizzle>;
 
 const sourceId = createSafeId<"caseLawSource">();
 const currentYear = new Date().getUTCFullYear();
+const day = (offset: number) => toUtcDateString(addUtcDays(new Date(), offset));
 
 /** Both sides of both bounds, plus dates far outside them. */
 const BOUNDARY_DATES: readonly string[] = [
@@ -41,10 +46,12 @@ const BOUNDARY_DATES: readonly string[] = [
   "1800-01-01",
   "1800-01-02",
   "2000-06-15",
-  `${String(currentYear)}-12-31`,
-  `${String(currentYear + 1)}-01-01`,
+  day(-1),
+  day(0),
+  day(1),
+  day(2),
+  day(30),
   `${String(currentYear + 1)}-12-31`,
-  `${String(currentYear + 2)}-01-01`,
   "2944-04-30",
   "9999-12-31",
 ];

--- a/apps/api/src/lib/decision-date-bounds-sql.ts
+++ b/apps/api/src/lib/decision-date-bounds-sql.ts
@@ -1,19 +1,20 @@
 /**
- * `canonicalDecisionDate`'s year bounds, in SQL.
+ * `canonicalDecisionDate`'s bounds, in SQL.
  *
- * Both fragments are derived from `DECISION_YEAR_BOUNDS`, the same declaration
+ * Both fragments are derived from `DECISION_DATE_BOUNDS`, the same declaration
  * the write-path guard reads, so the runtimes cannot drift into disagreeing
  * about which stored dates are impossible. `decision-date-bounds-sql.db.test.ts`
  * proves the agreement executably rather than by inspection, and proves the two
  * fragments are each other's negation.
  *
- * The ceiling is expressed as the first excluded day (1 January of
- * `currentYear + yearsAhead + 1`) rather than a year comparison, so a predicate
- * built from it stays a pair of range scans over `case_law_decisions_date_idx`
- * instead of a sequential scan behind `extract(...)`.
+ * The ceiling is expressed as the first excluded day (the current UTC day plus
+ * `daysAhead + 1`) rather than a comparison on parts of the date, so a
+ * predicate built from it stays a pair of range scans over
+ * `case_law_decisions_date_idx` instead of a sequential scan behind
+ * `extract(...)`.
  *
- * `now()` is read in UTC to match the guard's `getUTCFullYear()`: a session
- * time zone must not decide whether a stored date is corrupt.
+ * `now()` is read in UTC to match the guard's UTC day: a session time zone
+ * must not decide whether a stored date is corrupt.
  *
  * Written with `sql.raw` for the two integers so the fragment is literal SQL
  * with no bind parameters, which is what lets the same text serve in DDL (a
@@ -24,20 +25,18 @@
 import type { SQL, SQLWrapper } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 
-import { DECISION_YEAR_BOUNDS } from "@/api/lib/dates";
+import { DECISION_DATE_BOUNDS } from "@/api/lib/dates";
 
 /** The `case_law_decisions` CHECK that holds `decisionDateWithinBoundsSql`. */
 export const CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT =
   "case_law_decisions_decision_date_bounds";
 
 /** First day the bounds admit. */
-const floorSql = sql`make_date(${sql.raw(String(DECISION_YEAR_BOUNDS.min))}, 1, 1)`;
+const floorSql = sql`make_date(${sql.raw(String(DECISION_DATE_BOUNDS.minYear))}, 1, 1)`;
 
-/** First day past the ceiling, relative to the current UTC year. */
-const ceilingSql = sql`make_date(
-       extract(year from (now() AT TIME ZONE 'UTC'))::int
-         + ${sql.raw(String(DECISION_YEAR_BOUNDS.yearsAhead + 1))},
-       1, 1)`;
+/** First day past the ceiling, relative to the current UTC day. */
+const ceilingSql = sql`((now() AT TIME ZONE 'UTC')::date
+         + ${sql.raw(String(DECISION_DATE_BOUNDS.daysAhead + 1))})`;
 
 /** True for a date the write-path guard would refuse; NULL for a NULL date. */
 export const decisionDateOutOfBoundsSql = (column: SQLWrapper): SQL => sql`(

--- a/apps/api/src/lib/decision-date-ceiling-migration.db.test.ts
+++ b/apps/api/src/lib/decision-date-ceiling-migration.db.test.ts
@@ -1,0 +1,188 @@
+import { expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+import nodePath from "node:path";
+
+import {
+  caseLawCitations,
+  caseLawDecisions,
+  caseLawSources,
+} from "@/api/db/schema";
+import { createSafeId } from "@/api/lib/branded-types";
+import { addUtcDays, toUtcDateString } from "@/api/lib/dates";
+import { CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT } from "@/api/lib/decision-date-bounds-sql";
+import { isRecord } from "@/api/lib/type-guards";
+import { createTestPglite } from "@/api/tests/pglite-test-db";
+
+/**
+ * The ceiling migration against a table still carrying the previous
+ * constraint: it clears the rows the new ceiling refuses, swaps the CHECK,
+ * and is a no-op the second time.
+ */
+
+const MIGRATION_PATH = nodePath.resolve(
+  import.meta.dir,
+  "../../drizzle/20260902100000_case_law_decision_date_ceiling/migration.sql",
+);
+
+const PREVIOUS_CONSTRAINT = `
+  ALTER TABLE "case_law_decisions"
+    ADD CONSTRAINT "${CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT}"
+    CHECK (
+      "decision_date" IS NULL
+      OR (
+        "decision_date" >= make_date(1800, 1, 1)
+        AND "decision_date" < make_date(
+          extract(year from (now() AT TIME ZONE 'UTC'))::int + 2, 1, 1)
+      )
+    )`;
+
+const day = (offset: number) => toUtcDateString(addUtcDays(new Date(), offset));
+
+const constraintDefinition = async (
+  db: ReturnType<typeof drizzle>,
+): Promise<string | null> => {
+  const result: unknown = await db.execute(sql`
+    SELECT pg_get_constraintdef(oid) AS definition, convalidated
+      FROM pg_constraint
+     WHERE conname = ${CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT}
+       AND conrelid = 'case_law_decisions'::regclass
+  `);
+  let rows: unknown[] = [];
+  if (Array.isArray(result)) {
+    rows = result;
+  } else if (isRecord(result) && Array.isArray(result["rows"])) {
+    rows = result["rows"];
+  }
+  const row = rows.at(0);
+  if (!isRecord(row) || typeof row["definition"] !== "string") {
+    return null;
+  }
+  expect(row["convalidated"]).toBe(true);
+  return row["definition"];
+};
+
+test("the ceiling migration clears future rows, swaps the CHECK, and is idempotent", async () => {
+  const client = await createTestPglite();
+  const db = drizzle({ client });
+  // Start from the previous constraint, the state a deployed table is in.
+  await db.execute(
+    sql.raw(
+      `ALTER TABLE "case_law_decisions" DROP CONSTRAINT "${CASE_LAW_DECISION_DATE_BOUNDS_CONSTRAINT}"`,
+    ),
+  );
+  await db.execute(sql.raw(PREVIOUS_CONSTRAINT));
+  expect(await constraintDefinition(db)).toMatch(/extract\(year/iu);
+
+  const sourceId = createSafeId<"caseLawSource">();
+  await db
+    .insert(caseLawSources)
+    .values([{ id: sourceId, adapterKey: "cz-regional", name: "cz" }]);
+  const keptId = createSafeId<"caseLawDecision">();
+  const clearedId = createSafeId<"caseLawDecision">();
+  const citingId = createSafeId<"caseLawDecision">();
+  await db.insert(caseLawDecisions).values([
+    {
+      id: keptId,
+      sourceId,
+      caseNumber: "1 C 1/2026",
+      court: "Okresní soud",
+      country: "CZE",
+      language: "cs",
+      decisionDate: day(1),
+      indexedHash: "kept",
+    },
+    {
+      id: clearedId,
+      sourceId,
+      caseNumber: "2 C 2/2026",
+      court: "Okresní soud",
+      country: "CZE",
+      language: "cs",
+      // Admitted by the previous ceiling, refused by the new one.
+      decisionDate: day(40),
+      indexedHash: "stale",
+    },
+    {
+      id: citingId,
+      sourceId,
+      caseNumber: "3 C 3/2026",
+      court: "Okresní soud",
+      country: "CZE",
+      language: "cs",
+      decisionDate: day(0),
+    },
+  ]);
+  // An edge resolved under the future date, and one that never touched it.
+  await db.insert(caseLawCitations).values([
+    {
+      citingDecisionId: citingId,
+      citedDecisionId: clearedId,
+      citationText: "2 C 2/2026",
+      resolutionStatus: "resolved",
+    },
+    {
+      citingDecisionId: citingId,
+      citedDecisionId: keptId,
+      citationText: "1 C 1/2026",
+      resolutionStatus: "resolved",
+    },
+  ]);
+
+  const statements = (await Bun.file(MIGRATION_PATH).text())
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
+  const apply = async () => {
+    for (const statement of statements) {
+      // oxlint-disable-next-line no-await-in-loop -- statements apply in order
+      await db.execute(sql.raw(statement));
+    }
+  };
+
+  await apply();
+  expect(await constraintDefinition(db)).toContain("::date + 2");
+  const rows = await db
+    .select({
+      id: caseLawDecisions.id,
+      decisionDate: caseLawDecisions.decisionDate,
+      indexedHash: caseLawDecisions.indexedHash,
+    })
+    .from(caseLawDecisions);
+  expect(rows.find((row) => row.id === keptId)).toEqual({
+    id: keptId,
+    decisionDate: day(1),
+    indexedHash: "kept",
+  });
+  expect(rows.find((row) => row.id === clearedId)).toEqual({
+    id: clearedId,
+    decisionDate: null,
+    indexedHash: null,
+  });
+  // The edge decided under the cleared date is back on the walk's plate;
+  // the untouched edge keeps its resolution.
+  const citations = await db
+    .select({
+      citedDecisionId: caseLawCitations.citedDecisionId,
+      citationText: caseLawCitations.citationText,
+      resolutionStatus: caseLawCitations.resolutionStatus,
+    })
+    .from(caseLawCitations)
+    .orderBy(caseLawCitations.citationText);
+  expect(citations).toEqual([
+    {
+      citedDecisionId: keptId,
+      citationText: "1 C 1/2026",
+      resolutionStatus: "resolved",
+    },
+    {
+      citedDecisionId: null,
+      citationText: "2 C 2/2026",
+      resolutionStatus: "pending",
+    },
+  ]);
+
+  await apply();
+  expect(await constraintDefinition(db)).toContain("::date + 2");
+  await client.close();
+}, 120_000);

--- a/apps/api/src/scripts/repair-decision-dates.ts
+++ b/apps/api/src/scripts/repair-decision-dates.ts
@@ -36,8 +36,8 @@
  * running at the same time cannot deadlock against the repair.
  *
  * **The bounds are also a CHECK constraint.** `case_law_decisions_decision_date_bounds`
- * (migration 20260818090000) holds the same predicate, derived from the same
- * `DECISION_YEAR_BOUNDS`. Its `VALIDATE CONSTRAINT` fails while a corrupt row
+ * (migrations 20260818090000 and 20260902100000) holds the same predicate,
+ * derived from the same `DECISION_DATE_BOUNDS`. Its `VALIDATE CONSTRAINT` fails while a corrupt row
  * survives, and until then `ADD CONSTRAINT … NOT VALID` makes any unrelated
  * write touching such a row — a citation authority refresh, a corpus mirror
  * update, an index hash — fail on a column it never mentioned. So this runs


### PR DESCRIPTION
## What changes

The decision-date ceiling was the end of next year, so a publisher parsing artifact dated months ahead passed the write guard and the table CHECK, and a newest-first list showed it first. The ceiling is now the current UTC day plus one (one day of slack for a court whose local date is already ahead of UTC when it publishes); the floor is unchanged.

- `DECISION_DATE_BOUNDS = { minYear: 1800, daysAhead: 1 }` replaces `DECISION_YEAR_BOUNDS` in `apps/api/src/lib/dates.ts`. `canonicalDecisionDate` compares the ISO day against the UTC ceiling as text.
- `decision-date-bounds-sql.ts` renders the same ceiling as the first excluded day, `(now() AT TIME ZONE 'UTC')::date + 2`, so the repair predicate and the CHECK stay a range over `case_law_decisions_date_idx`.
- Migration `20260902100000_case_law_decision_date_ceiling`: clears rows past the new ceiling (`decision_date` and `indexed_hash` to NULL, the same floor as 20260818090000), swaps the CHECK to the new expression NOT VALID, then VALIDATEs outside the migration transaction. Re-runnable: a second run drops and re-adds the same constraint and validates it again. In production this touches 21 rows (cz-regional and pl-courts, latest 2027-01-27); `repair-decision-dates.ts` remains the operator pre-step that also reopens their citation edges.

## Tests

- `dates.test.ts`: today and tomorrow (UTC) accepted, the day after and beyond refused.
- `decision-date-bounds-sql.db.test.ts` (PGlite): boundary set now spans yesterday to today+30 plus the old far-future cases; the SQL fragments stay each other's negation and agree with the guard; the migration's CHECK text equals the schema's expression.
- New `decision-date-ceiling-migration.db.test.ts`: applies the migration to a table carrying the previous constraint, checks the future row is cleared and the in-window row kept, checks the swapped CHECK is validated, and applies it again.
- Migration safety lint passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Case-law decision dates are now validated against the current UTC date, with a one-day allowance, while retaining the minimum supported year.
  - Existing decisions dated beyond the permitted ceiling, along with their search hashes, are cleared during the database update.
  - Date-boundary handling now remains consistent across application and database validation.

- **Tests**
  - Added coverage for date boundaries, migration behaviour, data cleanup, and repeated migration execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->