### PR TITLE
fix(kanban): band captions take one line and folded names move into the body

### DIFF
--- a/.changeset/kanban-band-caption-density.md
+++ b/.changeset/kanban-band-caption-density.md
@@ -1,0 +1,11 @@
+---
+"@stll/ui": patch
+---
+
+Kanban column bands take a caption's height, not a panel's. The band line is
+one 28px row (toggle, swatch, name, count) over a hairline instead of a boxed
+header, bands no longer stretch to the tallest one, and a folded band shows
+only its toggle in that line while its name is set vertically in the narrow
+column body over the count. A folded band peeks open on pointer movement
+inside its slot rather than on entering it, so a band folded under a resting
+pointer stays folded.

--- a/.changeset/kanban-band-caption-density.md
+++ b/.changeset/kanban-band-caption-density.md
@@ -8,4 +8,5 @@ header, bands no longer stretch to the tallest one, and a folded band shows
 only its toggle in that line while its name is set vertically in the narrow
 column body over the count. A folded band peeks open on pointer movement
 inside its slot rather than on entering it, so a band folded under a resting
-pointer stays folded.
+pointer stays folded; while it peeks, its caption keeps reporting the band
+collapsed and the toggle pins it open instead of closing it again.

--- a/packages/ui/src/kanban/column-band-header.tsx
+++ b/packages/ui/src/kanban/column-band-header.tsx
@@ -22,11 +22,10 @@ export type KanbanColumnBandHeaderProps = {
 };
 
 /**
- * The band header row above a run of columns: the same rhythm as
- * `KanbanColumnHeader` (swatch, name, count, controls), plus the collapse
- * toggle that folds the run into one narrow lane. Collapsed, the header is
- * the only thing left of the band, so it also carries the band's identity on
- * `aria-expanded` for the columns it hides.
+ * The band line above a run of columns: one 28px row of toggle, swatch, name,
+ * and count, so a band costs the board a caption's height and nothing more.
+ * Folded, only the toggle remains in this line; the band's name moves down
+ * into the narrow column body, where the height is already there.
  */
 export const KanbanColumnBandHeader = ({
   title,
@@ -39,8 +38,8 @@ export const KanbanColumnBandHeader = ({
 }: KanbanColumnBandHeaderProps) => (
   <div
     className={cn(
-      "flex items-center gap-2 py-2",
-      collapsed ? "flex-col px-1" : "px-3",
+      "flex h-7 items-center gap-1",
+      collapsed ? "justify-center" : "pe-1",
     )}
     data-collapsed={collapsed ? "" : undefined}
     data-slot="kanban-column-band-header"
@@ -48,30 +47,33 @@ export const KanbanColumnBandHeader = ({
     <button
       aria-expanded={!collapsed}
       aria-label={toggleLabel}
-      className="hover:bg-muted/60 text-muted-foreground hover:text-foreground flex size-8 shrink-0 items-center justify-center rounded-md transition-[background-color]"
+      className="hover:bg-muted/60 text-muted-foreground hover:text-foreground flex size-6 shrink-0 items-center justify-center rounded-md transition-[background-color]"
       onClick={() => onCollapsedChange(!collapsed)}
+      title={toggleLabel}
       type="button"
     >
       <DirectionalIcon
-        className={cn("size-4 transition-transform", collapsed && "-rotate-90")}
+        className={cn(
+          "size-3.5 transition-transform",
+          collapsed && "-rotate-90",
+        )}
         flip={collapsed}
         icon={ChevronDownIcon}
       />
     </button>
-    {swatch}
-    <span
-      className={cn(
-        "flex min-w-0 items-center gap-1.5 text-sm font-medium",
-        collapsed ? "rotate-180 [writing-mode:vertical-rl]" : "flex-1 truncate",
-      )}
-    >
-      {title}
-      {meta !== undefined && (
-        <span className="text-muted-foreground text-xs tabular-nums">
-          {meta}
+    {collapsed ? null : (
+      <>
+        {swatch}
+        <span className="flex min-w-0 flex-1 items-baseline gap-1.5 truncate text-xs font-medium">
+          {title}
+          {meta !== undefined && (
+            <span className="text-muted-foreground font-normal tabular-nums">
+              {meta}
+            </span>
+          )}
         </span>
-      )}
-    </span>
-    {collapsed ? null : actions}
+        {actions}
+      </>
+    )}
   </div>
 );

--- a/packages/ui/src/kanban/column-band-header.tsx
+++ b/packages/ui/src/kanban/column-band-header.tsx
@@ -12,8 +12,14 @@ export type KanbanColumnBandHeaderProps = {
   swatch?: ReactNode;
   /** Short text after the name, such as the band's card count. */
   meta?: ReactNode;
-  /** Whether the band's columns are shown; drives the toggle and its icon. */
+  /** The band's persisted state; drives the toggle, its icon, and its label. */
   collapsed: boolean;
+  /**
+   * Render only the toggle, for the narrow slot of a folded band. Defaults to
+   * `collapsed`; a board that peeks a collapsed band open passes `false` so
+   * the caption shows the name while the toggle still offers to pin it open.
+   */
+  compact?: boolean | undefined;
   /** Accessible name for the toggle, such as "Collapse To do". */
   toggleLabel: string;
   onCollapsedChange: (collapsed: boolean) => void;
@@ -32,6 +38,7 @@ export const KanbanColumnBandHeader = ({
   swatch,
   meta,
   collapsed,
+  compact = collapsed,
   toggleLabel,
   onCollapsedChange,
   actions,
@@ -39,9 +46,10 @@ export const KanbanColumnBandHeader = ({
   <div
     className={cn(
       "flex h-7 items-center gap-1",
-      collapsed ? "justify-center" : "pe-1",
+      compact ? "justify-center" : "pe-1",
     )}
     data-collapsed={collapsed ? "" : undefined}
+    data-compact={compact ? "" : undefined}
     data-slot="kanban-column-band-header"
   >
     <button
@@ -61,7 +69,7 @@ export const KanbanColumnBandHeader = ({
         icon={ChevronDownIcon}
       />
     </button>
-    {collapsed ? null : (
+    {compact ? null : (
       <>
         {swatch}
         <span className="flex min-w-0 flex-1 items-baseline gap-1.5 truncate text-xs font-medium">

--- a/packages/ui/src/kanban/subgroup-board.test.tsx
+++ b/packages/ui/src/kanban/subgroup-board.test.tsx
@@ -223,6 +223,39 @@ describe("KanbanSubgroupBoard with column bands", () => {
     expect(markup).toContain("cell:ada:done:1");
   });
 
+  test("keeps the band line one caption tall and moves a folded name into the body", () => {
+    const open = renderBanded(false);
+    const folded = renderToStaticMarkup(
+      <KanbanSubgroupBoard
+        isBandCollapsed={(band) => band.id === "todo"}
+        isLaneCollapsed={() => false}
+        matrix={bandedMatrix}
+        renderCell={() => <span>cell</span>}
+        renderColumnHeader={() => <span>column</span>}
+        renderLaneIdentity={() => <span>lane</span>}
+        onBandCollapsedChange={() => undefined}
+        onLaneCollapsedChange={() => undefined}
+      />,
+    );
+
+    // The caption line is a fixed 28px row with a hairline, not a boxed panel.
+    expect(open).toContain('data-slot="kanban-column-band-header"');
+    expect(open).toMatch(
+      /class="[^"]*\bh-7\b[^"]*"[^>]*data-slot="kanban-column-band-header"/u,
+    );
+    expect(open).not.toContain("rounded-lg border");
+    // Folded, the caption keeps only the toggle; the name sits vertically in
+    // the default body slot with the count under it.
+    const foldedHeader =
+      /<div[^>]*data-slot="kanban-column-band-header"[^>]*>[\s\S]*?<\/div>/u.exec(
+        folded,
+      )?.[0] ?? "";
+    expect(foldedHeader).toContain('aria-expanded="false"');
+    expect(foldedHeader).not.toContain(">To do<");
+    expect(folded).toContain("[writing-mode:vertical-rl]");
+    expect(folded).toContain('data-kanban-collapsed-band-count="2"');
+  });
+
   test("folds a collapsed band into one slot per row and keeps its cells reachable", () => {
     const markup = renderBanded(true);
 

--- a/packages/ui/src/kanban/subgroup-board.test.tsx
+++ b/packages/ui/src/kanban/subgroup-board.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { describe, expect, test } from "bun:test";
 
+import { KanbanColumnBandHeader } from "./column-band-header";
 import type { KanbanSchema } from "./grouping";
 import { resolveKanbanGrouping } from "./grouping";
 import { buildKanbanBoardMatrix } from "./matrix";
@@ -126,6 +127,43 @@ describe("KanbanSubgroupBoard", () => {
 
   test("renders no band chrome when no column carries a band", () => {
     expect(renderBoard()).not.toContain("data-kanban-band");
+  });
+});
+
+describe("KanbanColumnBandHeader", () => {
+  // A collapsed band that peeks open under the pointer keeps reporting
+  // itself collapsed: its toggle offers to pin it open, never to close it,
+  // so a click on a peeked band does not fold it straight back.
+  test("shows the full caption for a peeked band with an expand toggle", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanColumnBandHeader
+        collapsed
+        compact={false}
+        meta="2"
+        title="To do"
+        toggleLabel="Expand To do"
+        onCollapsedChange={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain('aria-label="Expand To do"');
+    expect(markup).toContain(">To do<");
+    expect(markup).not.toContain('data-compact=""');
+  });
+
+  test("keeps only the toggle in the narrow slot of a folded band", () => {
+    const markup = renderToStaticMarkup(
+      <KanbanColumnBandHeader
+        collapsed
+        title="To do"
+        toggleLabel="Expand To do"
+        onCollapsedChange={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('data-compact=""');
+    expect(markup).not.toContain(">To do<");
   });
 });
 

--- a/packages/ui/src/kanban/subgroup-board.tsx
+++ b/packages/ui/src/kanban/subgroup-board.tsx
@@ -61,7 +61,14 @@ export type KanbanSubgroupBandHeaderContext = {
   columns: KanbanBoardColumn[];
   /** Rows across the band's columns, every lane included. */
   count: number;
+  /** The persisted state the toggle reports and flips. */
   collapsed: boolean;
+  /**
+   * Whether the band renders as one narrow slot right now. False while a
+   * collapsed band peeks open under the pointer, so a caption can show its
+   * name and offer to pin the band open.
+   */
+  folded: boolean;
   onCollapsedChange: (collapsed: boolean) => void;
 };
 
@@ -228,14 +235,16 @@ export const KanbanSubgroupBoard = <TRow,>({
     });
   };
 
-  const isBandFolded = (band: KanbanColumnBand): boolean => {
-    if (peekingBandId === band.id) {
-      return false;
-    }
-    return isBandCollapsed
-      ? isBandCollapsed(band)
-      : collapsedBandIds.has(band.id);
-  };
+  /** The band's persisted state: what the toggle reports and flips. */
+  const isBandCollapsedNow = (band: KanbanColumnBand): boolean =>
+    isBandCollapsed ? isBandCollapsed(band) : collapsedBandIds.has(band.id);
+  /**
+   * Whether the band renders folded right now. A peek opens the layout
+   * without changing the persisted state, so a peeked band still reports
+   * itself collapsed and its toggle pins it open rather than closing it.
+   */
+  const isBandFolded = (band: KanbanColumnBand): boolean =>
+    peekingBandId !== band.id && isBandCollapsedNow(band);
   const setBandCollapsed = (band: KanbanColumnBand, collapsed: boolean) => {
     setPeekingBandId(null);
     if (onBandCollapsedChange) {
@@ -330,12 +339,14 @@ export const KanbanSubgroupBoard = <TRow,>({
     band: KanbanColumnBand,
     span: KanbanColumnBandSpan,
   ): Rendered => {
-    const collapsed = isBandFolded(band);
+    const collapsed = isBandCollapsedNow(band);
+    const folded = isBandFolded(band);
     const context: KanbanSubgroupBandHeaderContext = {
       band,
       collapsed,
       columns: span.columns,
       count: span.columns.reduce((sum, column) => sum + columnCount(column), 0),
+      folded,
       onCollapsedChange: (next) => setBandCollapsed(band, next),
     };
     if (renderBandHeader) {
@@ -344,6 +355,7 @@ export const KanbanSubgroupBoard = <TRow,>({
     return (
       <KanbanColumnBandHeader
         collapsed={collapsed}
+        compact={folded}
         meta={formatCount(context.count)}
         title={band.label}
         toggleLabel={

--- a/packages/ui/src/kanban/subgroup-board.tsx
+++ b/packages/ui/src/kanban/subgroup-board.tsx
@@ -93,15 +93,16 @@ export type KanbanSubgroupBoardProps<TRow> = {
   renderLaneIdentity: (context: KanbanSubgroupLaneIdentityContext) => ReactNode;
   renderCell: (context: KanbanSubgroupCellContext<TRow>) => ReactNode;
   /**
-   * The header above a band's columns. Defaults to `KanbanColumnBandHeader`
+   * The line above a band's columns. Defaults to `KanbanColumnBandHeader`
    * with the band's label and count.
    */
   renderBandHeader?:
     | ((context: KanbanSubgroupBandHeaderContext) => ReactNode)
     | undefined;
   /**
-   * A lane's slot while its band is collapsed. Defaults to the count alone;
-   * a host that accepts drops into a collapsed band renders its target here.
+   * A lane's slot while its band is collapsed. Defaults to the band's name
+   * set vertically over the count; a host that accepts drops into a collapsed
+   * band renders its target here.
    */
   renderCollapsedBandCell?:
     | ((context: KanbanSubgroupCollapsedBandCellContext<TRow>) => ReactNode)
@@ -126,12 +127,14 @@ export type KanbanSubgroupBoardProps<TRow> = {
 /**
  * Reusable swimlane layout over the canonical two-axis Kanban matrix.
  *
- * Columns that carry band metadata render under a band header and can be
- * collapsed as a run: the band folds into one narrow slot in every row, whose
- * cells stay reachable (a host renders its drop target in them), and peeks
- * open while a pointer rests on it, so a drag can still land on a specific
- * column inside. Every row is laid out span by span with the same widths,
- * which is what keeps headers, counts, and cells aligned in every state.
+ * Columns that carry band metadata render under a one-line band caption and
+ * can be collapsed as a run: the band folds into one narrow slot in every
+ * row, whose cells stay reachable (a host renders its drop target in them),
+ * and peeks open while a pointer rests on it, so a drag can still land on a
+ * specific column inside. Every row is laid out span by span with the same
+ * widths, which is what keeps captions, headers, counts, and cells aligned
+ * in every state; the caption line never grows past its own height, so a
+ * folded band costs no vertical space.
  */
 export const KanbanSubgroupBoard = <TRow,>({
   matrix,
@@ -375,10 +378,13 @@ export const KanbanSubgroupBoard = <TRow,>({
     }
     return (
       <div
-        className="text-muted-foreground flex justify-center px-1 py-2 text-xs tabular-nums"
+        className="text-muted-foreground flex flex-col items-center gap-2 py-2 text-xs"
         data-kanban-collapsed-band-count={count}
       >
-        {formatCount(count)}
+        <span className="max-h-40 truncate font-medium [writing-mode:vertical-rl]">
+          {band.label}
+        </span>
+        <span className="tabular-nums">{formatCount(count)}</span>
       </div>
     );
   };
@@ -405,7 +411,10 @@ export const KanbanSubgroupBoard = <TRow,>({
       <div className="min-w-max">
         <div className="bg-background sticky top-0 z-20 pt-4 pb-3">
           {hasBands ? (
-            <div className="flex gap-3 pb-2" data-kanban-band-row="">
+            <div
+              className="flex items-end gap-3 pb-1.5"
+              data-kanban-band-row=""
+            >
               {spans.map((span) => {
                 const band = span.band;
                 if (band === null) {
@@ -422,7 +431,7 @@ export const KanbanSubgroupBoard = <TRow,>({
                     <FoldedBandSlot
                       band={band}
                       className={cn(
-                        "border-border/60 bg-muted/40 rounded-lg border",
+                        "border-border/60 border-b",
                         KANBAN_COLLAPSED_BAND_WIDTH_CLASS,
                       )}
                       key={spanKey(span)}
@@ -435,7 +444,7 @@ export const KanbanSubgroupBoard = <TRow,>({
                 }
                 return (
                   <div
-                    className="border-border/60 bg-muted/40 shrink-0 rounded-lg border"
+                    className="border-border/60 shrink-0 border-b"
                     data-kanban-band={band.id}
                     key={spanKey(span)}
                     style={{ width: `${String(spanWidth(span))}px` }}
@@ -586,6 +595,8 @@ type FoldedBandSlotProps = {
  * The narrow slot a folded band occupies in a row. A pointer resting on it
  * for `KANBAN_BAND_PEEK_DELAY_MS` peeks the band open; leaving ends the peek
  * and cancels a pending one, so a drag passing over it does not unfold it.
+ * The pointer must enter the slot after it appeared: a band folded under a
+ * resting pointer does not peek straight back open.
  */
 const FoldedBandSlot = ({
   band,
@@ -609,9 +620,12 @@ const FoldedBandSlot = ({
       className={className}
       data-kanban-band={band.id}
       data-kanban-band-collapsed=""
-      onPointerEnter={() => {
+      // The peek arms on movement inside the slot, not on entering it: a
+      // browser reports an enter for a slot that appears under a resting
+      // pointer (the band the user just folded), and that must stay folded.
+      onPointerMove={() => {
         if (timer.current !== null) {
-          clearTimeout(timer.current);
+          return;
         }
         timer.current = setTimeout(() => {
           timer.current = null;


### PR DESCRIPTION
## Summary

Follow-up to #2794. The first band strip cost far more height than it carried: `KanbanColumnBandHeader` rendered as a bordered panel, and a folded band set its name vertically *inside* that panel, so the band row stretched every open band to the folded one's height (~130px of mostly empty box per band).

- The band line is one 28px caption: toggle, swatch, name, count, over a hairline. No box. The row aligns `items-end`, so no band stretches to another.
- Folded, only the toggle stays in the caption (name as `title`/`aria-label`); the band's name is set vertically in the default narrow body slot, above the count, where a column's height already exists.
- A folded band now peeks open on pointer *movement* inside its slot, not on entering it. Browsers report an enter for a slot that appears under a resting pointer (the band the user just folded), which re-opened it a moment after folding.

## Tests

`subgroup-board.test.tsx`: the caption is a fixed-height row without a boxed border; folded, the caption keeps only the toggle and the name is in the vertical body slot with the count. Existing band tests unchanged.

`packages/ui`: tests, typecheck, lint, format pass locally.
