### PR TITLE
fix(kanban): cards land on flat columns and totals fit the view's kinds

### DIFF
--- a/apps/api/src/handlers/properties/list.ts
+++ b/apps/api/src/handlers/properties/list.ts
@@ -50,6 +50,7 @@ const readProperties = createSafeHandler(
               ...property.tool,
               dependencies,
             }),
+            kinds: property.kinds,
             role: property.role,
             createdAt: property.createdAt,
           };
@@ -62,6 +63,7 @@ const readProperties = createSafeHandler(
             status: property.status,
             content: property.content,
             tool: { ...property.tool, dependencies },
+            kinds: property.kinds,
             role: property.role,
             createdAt: property.createdAt,
           };
@@ -85,6 +87,7 @@ const readProperties = createSafeHandler(
             askPropertyId: property.tool.askPropertyId,
             dependencies,
           },
+          kinds: property.kinds,
           role: property.role,
           createdAt: property.createdAt,
         };

--- a/apps/web/src/components/workspaces/create-property.tsx
+++ b/apps/web/src/components/workspaces/create-property.tsx
@@ -601,6 +601,7 @@ const PropertyComposerBody = ({
               name: trimmedName,
               createdAt: new Date(),
               status: "stale",
+              kinds: null,
               content: buildContent(contentType, options, effectiveFallback),
               tool: {
                 version: 1,

--- a/apps/web/src/components/workspaces/table/group-columns.test.ts
+++ b/apps/web/src/components/workspaces/table/group-columns.test.ts
@@ -16,6 +16,7 @@ const property = ({
   workspaceId: toSafeId<"workspace">("workspace-1"),
   name: id,
   status: "fresh",
+  kinds: null,
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   content: { version: 1, type: "text" },
   tool,

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -121,6 +121,11 @@ export type WorkspaceProperty = {
   createdAt: Date;
   workspaceId: WorkspaceId;
   status: "stale" | "fresh";
+  /**
+   * The entity kinds the property applies to; null means every kind. A view
+   * scoped to one kind offers only the properties that apply to it.
+   */
+  kinds: EntityKind[] | null;
   content:
     | {
         version: 1;

--- a/apps/web/src/lib/workspaces/calculations.test.ts
+++ b/apps/web/src/lib/workspaces/calculations.test.ts
@@ -9,6 +9,7 @@ import { toSafeId } from "@/lib/safe-id";
 import type { WorkspaceField, WorkspaceFieldContent } from "@/lib/types";
 import {
   calculationKindsForProperty,
+  propertyAppliesToKinds,
   toCalculationValue,
 } from "@/lib/workspaces/calculations";
 
@@ -113,6 +114,7 @@ describe("calculationKindsForProperty", () => {
         ? ({ version: 1, type: "int", value: 0, currency: null } as const)
         : ({ version: 1, type: "text", value: "" } as const),
     tool: { version: 1, type: "manual-input" } as const,
+    kinds: null,
   });
 
   test("only a numeric property offers a sum", () => {
@@ -128,6 +130,31 @@ describe("calculationKindsForProperty", () => {
     expect(calculationKindsForProperty(property("int"))).not.toContain(
       "percent-of-total",
     );
+  });
+});
+
+describe("propertyAppliesToKinds", () => {
+  // The defect this guards: a board of tasks offered totals over properties
+  // only documents carry, because the picker never asked which kinds a
+  // property applies to.
+  test("a document-only property is not offered on a task view", () => {
+    expect(propertyAppliesToKinds({ kinds: ["document"] }, ["task"])).toBe(
+      false,
+    );
+  });
+
+  test("a property shared by one of the view's kinds is offered", () => {
+    expect(
+      propertyAppliesToKinds({ kinds: ["document", "task"] }, ["task"]),
+    ).toBe(true);
+  });
+
+  test("an unscoped property applies everywhere", () => {
+    expect(propertyAppliesToKinds({ kinds: null }, ["task"])).toBe(true);
+  });
+
+  test("an unrestricted view offers every property", () => {
+    expect(propertyAppliesToKinds({ kinds: ["document"] }, null)).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/workspaces/calculations.ts
+++ b/apps/web/src/lib/workspaces/calculations.ts
@@ -11,7 +11,11 @@ import { NUMERIC_CALCULATION_KINDS } from "@stll/calculations";
 import { unsafeCents } from "@stll/money";
 import { currencyMinorUnitDigits } from "@stll/workspace-ui/calculation-format";
 
-import type { WorkspaceField, WorkspaceProperty } from "@/lib/types";
+import type {
+  EntityKind,
+  WorkspaceField,
+  WorkspaceProperty,
+} from "@/lib/types";
 
 /** Reductions that count rows, which every property type supports. */
 const COUNTING_KINDS = [
@@ -44,6 +48,20 @@ export const calculationKindsForProperty = (
 /** A property whose values can be reduced at all is worth offering. */
 export const isCalculableProperty = (property: WorkspaceProperty): boolean =>
   property.content.type !== "file";
+
+/**
+ * Whether a property applies to any of the kinds a view shows. A property
+ * with no kind scope applies everywhere; a view with no kind restriction
+ * shows everything. A board of tasks must not offer a totals column for a
+ * property that only documents carry: the column would count nothing.
+ */
+export const propertyAppliesToKinds = (
+  property: Pick<WorkspaceProperty, "kinds">,
+  kinds: readonly EntityKind[] | null,
+): boolean =>
+  kinds === null ||
+  property.kinds === null ||
+  property.kinds.some((kind) => kinds.includes(kind));
 
 export const toCalculationValue = (
   field: WorkspaceField | undefined,

--- a/apps/web/src/lib/workspaces/playbook-verdicts.test.ts
+++ b/apps/web/src/lib/workspaces/playbook-verdicts.test.ts
@@ -17,6 +17,7 @@ const baseProperty = (id: string, name: string) => ({
   createdAt: new Date("2026-01-01T00:00:00Z"),
   workspaceId: toSafeId<"workspace">("ws"),
   status: "fresh" as const,
+  kinds: null,
   content: { version: 1 as const, type: "text" as const },
 });
 

--- a/apps/web/src/lib/workspaces/queries/entities.test.ts
+++ b/apps/web/src/lib/workspaces/queries/entities.test.ts
@@ -26,6 +26,7 @@ const property = (
   createdAt: new Date("2025-01-01T00:00:00.000Z"),
   workspaceId: toSafeId<"workspace">("workspace-1"),
   status: "fresh",
+  kinds: null,
   content: propertyContent(type),
   tool: { version: 1, type: "manual-input" },
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
@@ -182,8 +182,14 @@ export const KanbanColumn = ({
   }, [entities.length, hasMore, isLoadingMore, onLoadMore]);
 
   const isDraggable = columnValue !== null && onReorderColumn !== undefined;
+  // The card target sits on the card body, not the column root: the column
+  // root already carries the column-reorder target below, and the element
+  // adapter keeps one target per element, so a second registration on the
+  // same node replaces the first and cards can no longer land (or highlight)
+  // there. Nested targets compose: a card drag matches the body, a column
+  // drag falls through to the root.
   const isEntityDragOver = useKanbanEntityDropTarget({
-    elementRef: columnRef,
+    elementRef: scrollRef,
     name: title,
     onDrop,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic.test.ts
@@ -70,6 +70,7 @@ const singleSelectProperty = (id: string): WorkspaceProperty => ({
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   workspaceId: toSafeId<"workspace">("workspace-1"),
   status: "fresh",
+  kinds: null,
   content: {
     version: 1,
     type: "single-select",
@@ -85,6 +86,7 @@ const personProperty = (id: string): WorkspaceProperty => ({
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   workspaceId: toSafeId<"workspace">("workspace-1"),
   status: "fresh",
+  kinds: null,
   content: { version: 1, type: "person" },
   tool: { version: 1, type: "manual-input" },
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
@@ -42,6 +42,7 @@ import type { EntityKind, WorkspaceView } from "@/lib/types";
 import {
   calculationKindsForProperty,
   isCalculableProperty,
+  propertyAppliesToKinds,
 } from "@/lib/workspaces/calculations";
 // -- Auto-scrolling board container with forgiving column drop --
 import { COLUMN_DRAG_TYPE } from "@/lib/workspaces/drag-constants";
@@ -78,6 +79,7 @@ import {
   resolveWorkspaceKanbanSubgroup,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic";
 import { useWorkspaceKanbanSchema } from "@/routes/_protected.workspaces/$workspaceId/-components/kanban/use-kanban-schema";
+import { viewEntityKinds } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters";
 import {
   uploadFileEntitiesBatched,
   useBatchUploadLabels,
@@ -350,12 +352,17 @@ export const KanbanView = ({ view, workspaceId }: KanbanViewProps) => {
     t,
   ]);
 
+  // A view scoped to a kind (a task list, a message board) only ever shows
+  // that kind, so it offers totals only over the properties that kind
+  // carries; a document-only property would count nothing here.
+  const viewKinds = viewEntityKinds(view.layout.filters);
   const calculations: KanbanCalculations = {
     selections: view.layout.calculations,
     properties: properties
       .filter(
         (property) =>
           isCalculableProperty(property) &&
+          propertyAppliesToKinds(property, viewKinds) &&
           !hiddenProperties.includes(property.id),
       )
       .map((property) => ({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.logic.test.ts
@@ -65,6 +65,7 @@ const aiProperty = (id: string): AIExtractionProperty => ({
   createdAt: new Date("2026-06-12T00:00:00.000Z"),
   workspaceId: toSafeId<"workspace">("workspace-1"),
   status: "fresh",
+  kinds: null,
   content: { version: 1, type: "text" },
   tool: {
     version: 1,
@@ -83,6 +84,7 @@ const manualProperty = (
   createdAt: new Date("2026-06-12T00:00:00.000Z"),
   workspaceId: toSafeId<"workspace">("workspace-1"),
   status: "fresh",
+  kinds: null,
   content,
   tool: { version: 1, type: "manual-input" },
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-schema.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-schema.test.ts
@@ -31,6 +31,7 @@ const property = (id: string): WorkspaceProperty => ({
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   workspaceId: toSafeId<"workspace">("workspace-1"),
   status: "fresh",
+  kinds: null,
   content: { version: 1, type: "text" },
   tool: { version: 1, type: "manual-input" },
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.test.ts
@@ -1,6 +1,53 @@
 import { describe, expect, test } from "bun:test";
 
-import { includesListItems } from "./view-kind-filters";
+import { includesListItems, viewEntityKinds } from "./view-kind-filters";
+
+describe("view entity kinds", () => {
+  test("reads the kinds a view admits, nested groups included", () => {
+    expect(
+      viewEntityKinds([
+        {
+          type: "group",
+          combinator: "and",
+          children: [
+            {
+              type: "predicate",
+              operand: { type: "kind" },
+              op: "in",
+              value: ["task", "message"],
+            },
+          ],
+        },
+      ]),
+    ).toEqual(["task", "message"]);
+  });
+
+  test("is null for a view that does not restrict the kind", () => {
+    expect(viewEntityKinds([])).toBeNull();
+    expect(
+      viewEntityKinds([
+        {
+          type: "predicate",
+          operand: { type: "kind" },
+          op: "is_not_empty",
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  test("ignores values that are not entity kinds", () => {
+    expect(
+      viewEntityKinds([
+        {
+          type: "predicate",
+          operand: { type: "kind" },
+          op: "in",
+          value: ["task", "spreadsheet"],
+        },
+      ]),
+    ).toEqual(["task"]);
+  });
+});
 
 describe("List view detection", () => {
   test("recognizes an explicit task kind filter", () => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
@@ -1,5 +1,8 @@
+import { isEntityKind } from "@stll/api-contract";
 import { conditionIncludesKind } from "@stll/conditions";
 import type { ConditionNode } from "@stll/conditions";
+
+import type { EntityKind } from "@/lib/types";
 
 /**
  * A task kind filter marks a saved view as a List, including predicates nested
@@ -7,3 +10,46 @@ import type { ConditionNode } from "@stll/conditions";
  */
 export const includesListItems = (filters: readonly ConditionNode[]): boolean =>
   conditionIncludesKind(filters, "task");
+
+/**
+ * The entity kinds a view's filters admit, read from its `kind in […]`
+ * predicates (nested groups included), or `null` when the view does not
+ * restrict the kind. A view that names kinds only ever shows those entities,
+ * so anything offered per property (calculations, columns) can be scoped to
+ * the properties those kinds carry.
+ */
+export const viewEntityKinds = (
+  filters: readonly ConditionNode[],
+): readonly EntityKind[] | null => {
+  const kinds = new Set<EntityKind>();
+  return collectViewKinds(filters, kinds) ? [...kinds] : null;
+};
+
+/** Adds every admitted kind to `kinds`; true when some predicate restricts it. */
+const collectViewKinds = (
+  nodes: readonly ConditionNode[],
+  kinds: Set<EntityKind>,
+): boolean => {
+  let restricted = false;
+  for (const node of nodes) {
+    if (node.type === "group") {
+      restricted = collectViewKinds(node.children, kinds) || restricted;
+      continue;
+    }
+    if (
+      node.type !== "predicate" ||
+      node.operand.type !== "kind" ||
+      node.op !== "in" ||
+      !Array.isArray(node.value)
+    ) {
+      continue;
+    }
+    restricted = true;
+    for (const value of node.value) {
+      if (typeof value === "string" && isEntityKind(value)) {
+        kinds.add(value);
+      }
+    }
+  }
+  return restricted;
+};


### PR DESCRIPTION
## Summary

- **Flat boards never highlighted the drop column.** `useKanbanEntityDropTarget` and `useKanbanColumnDrag` both registered on the column root element. pragmatic-drag-and-drop keeps one element target per element, so the second registration replaced the first. The card target now sits on the column body (`scrollRef`), nested inside the reorder target; nested targets compose, so a column drag still falls through to the root.
- **The Σ (calculation) picker offered properties the view cannot hold.** The property list handler never projected `kinds`, and the web `WorkspaceProperty` type had no such field, so a task board listed document-only properties. The handler now projects `kinds`, `WorkspaceProperty.kinds` is required, `viewEntityKinds` reads the kinds a view's filters admit, and `propertyAppliesToKinds` scopes the picker.

## Tests

- `viewEntityKinds`: nested groups, unrestricted views, non-kind values.
- `propertyAppliesToKinds`: document-only vs task view, shared kinds, unscoped property, unrestricted view.
- Existing property fixtures gained `kinds: null`.

## Verification

- `bun test` on the touched suites, type-aware oxlint and oxfmt on the changed files, web typecheck.