### PR TITLE
chore(kanban): make silent drop-target and projection drift a build error

### DIFF
--- a/apps/api/src/handlers/properties/list.ts
+++ b/apps/api/src/handlers/properties/list.ts
@@ -1,9 +1,99 @@
 import { Result } from "better-result";
 
+import type { properties, propertyDependencies } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { LIMITS } from "@/api/lib/limits";
 import { deserializeAITool } from "@/api/lib/markdown/ai-tool";
+
+type PropertyRow = typeof properties.$inferSelect;
+
+type PropertyDependencyProjection = Pick<
+  typeof propertyDependencies.$inferSelect,
+  "dependsOnPropertyId" | "condition"
+>;
+
+// Columns intentionally not sent to the client. A new schema column must
+// either be projected by `toPropertyListItem` below or added here with a
+// reason, or the totality check further down fails to typecheck. This guard
+// exists because `kinds` once shipped on the table with no branch here
+// projecting it, so the web client silently had no way to scope properties
+// by entity kind.
+const UNPROJECTED_PROPERTY_COLUMNS = [
+  // Internal bookkeeping flag; not part of the client-facing contract.
+  "system",
+  // Playbook provenance: server-only correlation ids the client never reads.
+  "playbookSourceId",
+  "playbookDefinitionId",
+] as const satisfies readonly (keyof PropertyRow)[];
+
+type UnprojectedPropertyColumn = (typeof UNPROJECTED_PROPERTY_COLUMNS)[number];
+
+const toPropertyListItem = (
+  property: PropertyRow,
+  dependencies: PropertyDependencyProjection[],
+) => {
+  const projected = {
+    id: property.id,
+    workspaceId: property.workspaceId,
+    name: property.name,
+    status: property.status,
+    content: property.content,
+    kinds: property.kinds,
+    role: property.role,
+    createdAt: property.createdAt,
+  };
+
+  if (property.tool.type === "ai-model") {
+    return {
+      ...projected,
+      tool: deserializeAITool({ ...property.tool, dependencies }),
+    };
+  }
+
+  if (property.tool.type === "manual-input") {
+    return { ...projected, tool: { ...property.tool, dependencies } };
+  }
+
+  // The only remaining tool type is the playbook verdict. The web
+  // client has first-class read-only support for it, pairing each
+  // verdict onto its ASK column via `tool.askPropertyId`; masking it as
+  // manual-input would render verdicts as editable single-select
+  // columns. The grading inputs (rule/severity/standard) stay
+  // server-side. The view-templates and update-by-id masking are
+  // separate contracts.
+  return {
+    ...projected,
+    tool: {
+      version: property.tool.version,
+      type: property.tool.type,
+      askPropertyId: property.tool.askPropertyId,
+      dependencies,
+    },
+  };
+};
+
+type PropertyListItem = ReturnType<typeof toPropertyListItem>;
+
+type ProjectedPropertyColumn = Exclude<
+  keyof PropertyRow,
+  UnprojectedPropertyColumn
+>;
+
+// Totality guard, bidirectional: every schema column must be projected onto
+// the response or explicitly excused above, and the projection cannot carry
+// a field that traces back to no real column.
+type MissingProjectedPropertyColumn = Exclude<
+  ProjectedPropertyColumn,
+  keyof PropertyListItem
+>;
+type UnexpectedProjectedPropertyColumn = Exclude<
+  keyof PropertyListItem,
+  ProjectedPropertyColumn
+>;
+
+true satisfies MissingProjectedPropertyColumn extends never ? true : never;
+true satisfies UnexpectedProjectedPropertyColumn extends never ? true : never;
 
 const config = {
   description:
@@ -38,60 +128,9 @@ const readProperties = createSafeHandler(
     );
 
     return Result.ok(
-      propertiesResult.map(({ dependencies, ...property }) => {
-        if (property.tool.type === "ai-model") {
-          return {
-            id: property.id,
-            workspaceId,
-            name: property.name,
-            status: property.status,
-            content: property.content,
-            tool: deserializeAITool({
-              ...property.tool,
-              dependencies,
-            }),
-            kinds: property.kinds,
-            role: property.role,
-            createdAt: property.createdAt,
-          };
-        }
-        if (property.tool.type === "manual-input") {
-          return {
-            id: property.id,
-            workspaceId,
-            name: property.name,
-            status: property.status,
-            content: property.content,
-            tool: { ...property.tool, dependencies },
-            kinds: property.kinds,
-            role: property.role,
-            createdAt: property.createdAt,
-          };
-        }
-        // The only remaining tool type is the playbook verdict. The web
-        // client has first-class read-only support for it, pairing each
-        // verdict onto its ASK column via `tool.askPropertyId`; masking it as
-        // manual-input would render verdicts as editable single-select
-        // columns. The grading inputs (rule/severity/standard) stay
-        // server-side. The view-templates and update-by-id masking are
-        // separate contracts.
-        return {
-          id: property.id,
-          workspaceId,
-          name: property.name,
-          status: property.status,
-          content: property.content,
-          tool: {
-            version: property.tool.version,
-            type: property.tool.type,
-            askPropertyId: property.tool.askPropertyId,
-            dependencies,
-          },
-          kinds: property.kinds,
-          role: property.role,
-          createdAt: property.createdAt,
-        };
-      }),
+      propertiesResult.map(({ dependencies, ...property }) =>
+        toPropertyListItem(property, dependencies),
+      ),
     );
   },
 );

--- a/apps/web/e2e/specs/kanban-card-drag.spec.ts
+++ b/apps/web/e2e/specs/kanban-card-drag.spec.ts
@@ -1,0 +1,131 @@
+import type { APIRequestContext } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+
+import { apiGet, apiPut, apiStatus } from "../helpers/api";
+import { expect, test } from "../helpers/test";
+import {
+  type TestWorkspace,
+  createTestWorkspace,
+  deleteTestWorkspace,
+} from "../helpers/workspace";
+
+// Every workspace seeds a "Todos"/"Lists" kanban view alongside its
+// overview, table, and files views (apps/api/src/lib/views.ts). Its
+// `groupByPropertyId` is the built-in task status, whose declaration order
+// (packages/api-contract/src/entity-options.ts: open, in_progress,
+// in_review, done, cancelled) is the board's column order, so a plain task
+// always lands in the first ("Open") column and the second column is
+// always "In progress" — no view or property setup is needed beyond
+// creating the workspace and one task.
+type ViewSummary = {
+  id: string;
+  layout: { type: string };
+};
+
+type CreatedTask = { entityId: string };
+
+const findKanbanViewId = async (
+  request: APIRequestContext,
+  workspaceId: string,
+): Promise<string> => {
+  const views = await apiGet<ViewSummary[]>(request, `/views/${workspaceId}`);
+  const kanbanView = views.find((view) => view.layout.type === "kanban");
+  if (!kanbanView) {
+    throw new Error(
+      `workspace ${workspaceId} has no kanban view: ${JSON.stringify(views)}`,
+    );
+  }
+  return kanbanView.id;
+};
+
+test.describe("kanban card drag", () => {
+  let workspace: TestWorkspace | null = null;
+
+  test.afterEach(async ({ request }) => {
+    if (workspace === null) {
+      return;
+    }
+    await deleteTestWorkspace(request, workspace.id);
+    workspace = null;
+  });
+
+  test("dragging a card into another column moves it there", async ({
+    page,
+    request,
+  }) => {
+    test.slow();
+
+    workspace = await createTestWorkspace(request, "kanban-card-drag");
+    const testWorkspace = workspace;
+
+    const kanbanViewId = await findKanbanViewId(request, testWorkspace.id);
+    const cardName = `kanban-drag-${randomUUID().slice(0, 8)}`;
+    await apiPut<CreatedTask>(request, `/tasks/${testWorkspace.id}`, {
+      name: cardName,
+    });
+
+    const { cookies } = await request.storageState();
+    await page.context().addCookies(cookies);
+    await expect
+      .poll(
+        async () =>
+          await apiStatus(page.request, `/workspaces/${testWorkspace.id}`),
+        {
+          message: "browser context can read the created workspace",
+          timeout: 10_000,
+        },
+      )
+      .toBe(200);
+
+    await page.goto(`/workspaces/${testWorkspace.id}/${kanbanViewId}`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    const column = (label: string) =>
+      page.locator("[data-drag-over]").filter({ hasText: label });
+
+    const openColumn = column("Open");
+    const inProgressColumn = column("In progress");
+    await expect(openColumn).toBeVisible({ timeout: 30_000 });
+    await expect(inProgressColumn).toBeVisible();
+
+    const card = openColumn.getByText(cardName, { exact: true });
+    await expect(card).toBeVisible();
+
+    const cardBox = await card.boundingBox();
+    const targetBox = await inProgressColumn.boundingBox();
+    if (cardBox === null || targetBox === null) {
+      throw new Error("Kanban drag geometry is unavailable");
+    }
+
+    const sourceX = cardBox.x + cardBox.width / 2;
+    const sourceY = cardBox.y + cardBox.height / 2;
+    const targetX = targetBox.x + targetBox.width / 2;
+    const targetY = targetBox.y + targetBox.height / 2;
+
+    // pragmatic-drag-and-drop's element adapter drives the browser's native
+    // HTML5 drag-and-drop (the card element gets `draggable=true`), which
+    // only starts once the pointer has moved past a small threshold while
+    // pressed. A single coarse jump (as `page.dragAndDrop`/`locator.dragTo`
+    // perform) does not reliably cross that threshold or keep the drag
+    // "live" long enough for the library's drag-over feedback to fire; a
+    // real, multi-step pointer gesture does. Hence: move onto the card,
+    // press, nudge a few steps to start the native drag, then step across
+    // to the target column and hover before releasing.
+    await page.mouse.move(sourceX, sourceY);
+    await page.mouse.down();
+    await page.mouse.move(sourceX + 10, sourceY + 4, { steps: 5 });
+    await page.mouse.move(targetX, targetY, { steps: 20 });
+
+    await expect(inProgressColumn).toHaveAttribute("data-drag-over", "true");
+
+    await page.mouse.up();
+
+    await expect(
+      inProgressColumn.getByText(cardName, { exact: true }),
+    ).toBeVisible();
+    await expect(openColumn.getByText(cardName, { exact: true })).toHaveCount(
+      0,
+    );
+  });
+});

--- a/apps/web/src/lib/api-contract.ts
+++ b/apps/web/src/lib/api-contract.ts
@@ -34,6 +34,11 @@ type ViewTemplatesResponse =
   WebApiRoutes["view-templates"][":workspaceId"]["get"]["response"][200];
 
 export type GlobalSearchHit = SearchResponse["hits"][number];
+// The wire shape of one property list item, straight off the Eden response.
+// `WorkspaceProperty` in `@/lib/types` derives from this so a column the API
+// starts or stops projecting shows up there as a type error instead of
+// silently drifting.
+export type WorkspacePropertyWire = PropertiesResponse[number];
 export type PropertyContent = PropertiesResponse[number]["content"];
 export type PropertyContentType = PropertyContent["type"];
 export type OptionColor = Extract<

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -20,6 +20,7 @@ import type {
   ViewLayout,
   ViewLayoutType,
   SafeId,
+  WorkspacePropertyWire,
 } from "@/lib/api-contract";
 import {
   DOCX_MIME,
@@ -115,17 +116,22 @@ type PlaybookVerdictTool = {
   dependencies: PropertyDependency[];
 };
 
-export type WorkspaceProperty = {
+// Derived from the wire shape (`WorkspacePropertyWire`) rather than
+// hand-listed: a column the API starts projecting appears here without an
+// edit, and a field named here that the API stops sending becomes a type
+// error at the one place (`toWorkspaceProperty`) that builds this type from
+// the response, instead of silently drifting out of sync.
+export type WorkspaceProperty = Omit<
+  WorkspacePropertyWire,
+  "id" | "workspaceId" | "tool" | "kinds" | "role" | "content"
+> & {
   id: PropertyId;
-  name: string;
-  createdAt: Date;
   workspaceId: WorkspaceId;
-  status: "stale" | "fresh";
   /**
    * The entity kinds the property applies to; null means every kind. A view
    * scoped to one kind offers only the properties that apply to it.
    */
-  kinds: EntityKind[] | null;
+  kinds: WorkspacePropertyWire["kinds"];
   content:
     | {
         version: 1;
@@ -168,7 +174,7 @@ export type WorkspaceProperty = {
   // rather than by the literal name "Document Type" (mirrors the server
   // `properties.role` column). Optional because not every property source
   // carries it; absent/null means an ordinary property.
-  role?: "document-type-classifier" | null;
+  role?: WorkspacePropertyWire["role"];
 };
 
 export type WorkspacePropertyOption = {

--- a/apps/web/src/lib/workspaces/queries/properties.ts
+++ b/apps/web/src/lib/workspaces/queries/properties.ts
@@ -1,6 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
+import type { WorkspacePropertyWire } from "@/lib/api-contract";
 import { unwrapEden } from "@/lib/errors/api";
 import { ROUTE_QUERY_STALE_TIME_MS } from "@/lib/react-query";
 import { propertiesQueryRoot } from "@/lib/resource-query-roots.logic";
@@ -25,8 +26,11 @@ export const propertiesOptions = (workspaceId: string) =>
     staleTime: ROUTE_QUERY_STALE_TIME_MS,
   });
 
+// Derived from the Eden response type rather than from `WorkspaceProperty`:
+// a field the API projects but this file's mapping doesn't handle (or vice
+// versa) surfaces as a type error here instead of silently drifting.
 type RawWorkspaceProperty = Omit<
-  WorkspaceProperty,
+  WorkspacePropertyWire,
   "id" | "workspaceId" | "tool"
 > & {
   id: string;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
@@ -252,6 +252,9 @@ export const KanbanColumn = ({
           "bg-primary/5 ring-primary/50 ring-2",
         isDragging && "opacity-40",
       )}
+      // A stable hook for the card drag-over state that does not depend on
+      // the Tailwind classes above (which also flip for a file drag).
+      data-drag-over={isEntityDragOver ? "true" : "false"}
       ref={columnRef}
       style={
         colorBg

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/use-kanban-drop-targets.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/use-kanban-drop-targets.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// The real `dropTargetForElements`/`draggable` reach into DOM APIs
+// (addEventListener, dataset, ...) that this bun:test process has no DOM
+// for. These tests only exercise the conflict registry in
+// `attachElementDropTarget`, so those two are replaced with a no-op
+// stand-in before importing the module under test. Every other export
+// (notably `monitorForElements`, which `@stll/ui/kanban`'s auto-scroll
+// wiring calls as a module-load side effect) is passed through untouched
+// so unrelated kanban tests sharing this bun:test process are unaffected.
+const realAdapter =
+  await import("@atlaskit/pragmatic-drag-and-drop/element/adapter");
+void mock.module("@atlaskit/pragmatic-drag-and-drop/element/adapter", () => ({
+  ...realAdapter,
+  dropTargetForElements: () => () => undefined,
+  draggable: () => () => undefined,
+}));
+
+const { attachElementDropTarget } = await import("./use-kanban-drop-targets");
+
+// SAFETY: attachElementDropTarget only ever uses `element` as a WeakMap key
+// in these tests; the adapter above is mocked to a no-op, so no DOM API on
+// this stand-in element is ever invoked.
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test double for a DOM Element; see the SAFETY note above.
+const stubElement = (): Element => ({}) as unknown as Element;
+
+describe("attachElementDropTarget", () => {
+  test("throws when a second target registers on the same element", () => {
+    const element = stubElement();
+    const cleanupCard = attachElementDropTarget({ element, name: "card" });
+
+    expect(() =>
+      attachElementDropTarget({ element, name: "column-reorder" }),
+    ).toThrow(/card/u);
+    expect(() =>
+      attachElementDropTarget({ element, name: "column-reorder" }),
+    ).toThrow(/column-reorder/u);
+
+    cleanupCard();
+  });
+
+  test("allows the same element to register again once the prior target cleans up", () => {
+    const element = stubElement();
+    const cleanupCard = attachElementDropTarget({ element, name: "card" });
+    cleanupCard();
+
+    expect(() => {
+      const cleanupReorder = attachElementDropTarget({
+        element,
+        name: "column-reorder",
+      });
+      cleanupReorder();
+    }).not.toThrow();
+  });
+
+  test("allows distinct targets on a parent and its child element", () => {
+    const parent = stubElement();
+    const child = stubElement();
+
+    expect(() => {
+      const cleanupParent = attachElementDropTarget({
+        element: parent,
+        name: "column-reorder",
+      });
+      const cleanupChild = attachElementDropTarget({
+        element: child,
+        name: "card",
+      });
+      cleanupChild();
+      cleanupParent();
+    }).not.toThrow();
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/use-kanban-drop-targets.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/use-kanban-drop-targets.ts
@@ -44,9 +44,7 @@ const liveElementDropTargets = new WeakMap<Element, string>();
  * pre-existing "second call silently wins" behaviour is kept there instead.
  */
 const isDropTargetRegistryGuarded = (): boolean =>
-  import.meta.env.DEV ||
-  import.meta.env.MODE === "test" ||
-  import.meta.env.NODE_ENV === "test";
+  import.meta.env.DEV || import.meta.env.NODE_ENV === "test";
 
 type AttachElementDropTargetParams = Parameters<
   typeof dropTargetForElements

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/use-kanban-drop-targets.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/use-kanban-drop-targets.ts
@@ -11,6 +11,7 @@ import {
   draggable,
   dropTargetForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { panic } from "better-result";
 
 import {
   withDragAnnouncementData,
@@ -22,6 +23,71 @@ import {
   COLUMN_DRAG_TYPE,
   ENTITY_DRAG_TYPE,
 } from "@/lib/workspaces/drag-constants";
+
+/**
+ * Which named drop target currently lives on a given element, so a second
+ * registration on the same node can be caught instead of silently replacing
+ * the first. Keyed by element (not by name) because pragmatic-drag-and-drop's
+ * own element adapter keeps exactly one live drop target per element the
+ * same way — a `WeakMap<Element, ...>` registry — so a second
+ * `dropTargetForElements` call on a node that already has one quietly
+ * overwrites it, with no error anywhere. That is exactly how the flat-column
+ * card target once went dark: both the card target and the column-reorder
+ * target were registered on the column root, and only the second survived.
+ */
+const liveElementDropTargets = new WeakMap<Element, string>();
+
+/**
+ * Whether double-registration on one element should throw. On in local dev
+ * and under test so the mistake is caught before it ships; off in
+ * production builds so a reader never sees a thrown error for it — the
+ * pre-existing "second call silently wins" behaviour is kept there instead.
+ */
+const isDropTargetRegistryGuarded = (): boolean =>
+  import.meta.env.DEV ||
+  import.meta.env.MODE === "test" ||
+  import.meta.env.NODE_ENV === "test";
+
+type AttachElementDropTargetParams = Parameters<
+  typeof dropTargetForElements
+>[0] & {
+  /** Identifies this target in the conflict error; not sent anywhere. */
+  name: string;
+};
+
+/**
+ * The one place every kanban element drop target must be registered
+ * through. Guarded environments throw when `element` already carries a live
+ * target rather than letting the registration silently replace it; the
+ * returned cleanup un-registers the element regardless of environment so a
+ * later, legitimate registration on the same node (a re-render, a different
+ * column reusing a recycled node) is never mistaken for a conflict.
+ */
+export const attachElementDropTarget = ({
+  name,
+  ...params
+}: AttachElementDropTargetParams): (() => void) => {
+  const { element } = params;
+
+  if (isDropTargetRegistryGuarded()) {
+    const existing = liveElementDropTargets.get(element);
+    if (existing !== undefined) {
+      panic(
+        `Kanban drop target conflict: "${existing}" is already registered on this element. Registering "${name}" on the same element would silently replace it — pragmatic-drag-and-drop keeps only one live drop target per element. Attach each target to a distinct element instead.`,
+      );
+    }
+    liveElementDropTargets.set(element, name);
+  }
+
+  const cleanup = dropTargetForElements(params);
+
+  return () => {
+    cleanup();
+    if (liveElementDropTargets.get(element) === name) {
+      liveElementDropTargets.delete(element);
+    }
+  };
+};
 
 type UseKanbanEntityDropTargetParams<TElement extends HTMLElement> = {
   elementRef: RefObject<TElement | null>;
@@ -46,8 +112,9 @@ export const useKanbanEntityDropTarget = <TElement extends HTMLElement>({
       return undefined;
     }
 
-    return dropTargetForElements({
+    return attachElementDropTarget({
       element,
+      name,
       canDrop: ({ source }) => source.data["type"] === ENTITY_DRAG_TYPE,
       getData: () => withDropAnnouncementData({}, { type: "container", name }),
       onDragEnter: () => setIsDragOver(true),
@@ -105,8 +172,9 @@ export const useKanbanColumnDrag = <TElement extends HTMLElement>({
     }
 
     return combine(
-      dropTargetForElements({
+      attachElementDropTarget({
         element,
+        name,
         canDrop: ({ source }) =>
           source.data["type"] === COLUMN_DRAG_TYPE &&
           source.data["columnValue"] !== columnValue,


### PR DESCRIPTION
## Summary

Follow-up to #2807. Both defects it fixed had passed lint, typecheck and the test suites; this PR makes each class of mistake fail at build or test time.

- **Drop-target registry guard.** `attachElementDropTarget` is now the single path for `dropTargetForElements` in the kanban hooks. In dev and test it throws (naming both targets) when an element already carries a live target; in production it keeps the previous behaviour. Unit test covers same-element conflict, re-registration after cleanup, and parent/child nesting.
- **Property projection totality.** `handlers/properties/list.ts` projects rows through one `toPropertyListItem`; `UNPROJECTED_PROPERTY_COLUMNS` lists the columns deliberately kept server-side, and two `satisfies ... extends never` checks fail typecheck when a schema column is neither projected nor excused, or when the projection carries a key no column backs.
- **Web type derived from the wire.** `WorkspacePropertyWire` (from the Eden response) is the base of both `RawWorkspaceProperty` and `WorkspaceProperty`, so a field the API starts or stops sending is a type error at `toWorkspaceProperty` instead of silent drift. Branded ids and the parsed `tool` stay hand-typed.
- **Kanban drag e2e.** `kanban-card-drag.spec.ts` drags a task card from *Open* to *In progress* with stepped pointer moves, asserts the target column reports `data-drag-over="true"` while hovering, and asserts the card moved. The column root gained a stable `data-drag-over` attribute for this.

## Verification

- Removing `kinds:` from the projection, or adding a bogus key, fails the API typecheck with `Type 'true' does not satisfy the expected type 'never'`; adding a field to `WorkspaceProperty` that the API does not send fails the web typecheck.
- Type-aware oxlint, oxfmt, web/API typecheck on the touched files; kanban unit tests (24 pass).
- The e2e spec was not run locally; CI runs it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kanban columns now expose a stable drag-over state for improved interaction feedback and testing.
  * Duplicate Kanban drop-target registrations are detected in development and test environments.

* **Bug Fixes**
  * Improved consistency between property API responses and workspace property data.

* **Tests**
  * Added end-to-end coverage for moving Kanban cards between columns.
  * Added coverage for Kanban drop-target registration and cleanup behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->