### PR TITLE
fix(properties): scope AI-extracted properties to documents

### DIFF
--- a/apps/api/drizzle/20260902090000_properties_kinds_ai_backfill/migration.sql
+++ b/apps/api/drizzle/20260902090000_properties_kinds_ai_backfill/migration.sql
@@ -1,0 +1,19 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '60s';--> statement-breakpoint
+
+-- `properties.kinds` says which entity kinds a property applies to; NULL
+-- means every kind. Every property written before this release left it NULL,
+-- including `ai-model` and `playbook-verdict` columns, whose values only
+-- extraction ever produces. Extraction only ever runs over documents (see
+-- the `eq(entities.kind, "document")` filter in
+-- apps/api/src/lib/document-review/table-run-create.ts), so those two tool
+-- types can never hold a value on a task, message, link, or folder. Restrict
+-- them to `{document}` retroactively so `kinds` matches what the write path
+-- now derives for new and updated properties
+-- (apps/api/src/lib/properties/property-kinds.ts). Rows already carrying a
+-- non-NULL `kinds` are untouched: NULL is the only value that predates this
+-- rule, so "already NULL" is exactly "never set".
+UPDATE "properties"
+   SET "kinds" = ARRAY['document']::varchar(64)[]
+ WHERE "kinds" IS NULL
+   AND "tool"->>'type' IN ('ai-model', 'playbook-verdict');

--- a/apps/api/src/handlers/properties/create-batch.ts
+++ b/apps/api/src/handlers/properties/create-batch.ts
@@ -16,6 +16,7 @@ import {
   createPropertyBodySchema,
   isDocumentTypeClassifierProperty,
 } from "@/api/lib/properties/create-schema";
+import { propertyKindsForTool } from "@/api/lib/properties/property-kinds";
 import { lockWorkspacePropertyWrites } from "@/api/lib/properties/property-lock";
 
 const config = {
@@ -136,6 +137,7 @@ const createPropertiesBatch = createSafeHandler(
               name,
               content,
               tool,
+              kinds: propertyKindsForTool(tool),
               role,
               status: initialStatus,
             })

--- a/apps/api/src/handlers/properties/create.ts
+++ b/apps/api/src/handlers/properties/create.ts
@@ -13,6 +13,7 @@ import {
   createPropertyBodySchema,
   isDocumentTypeClassifierProperty,
 } from "@/api/lib/properties/create-schema";
+import { propertyKindsForTool } from "@/api/lib/properties/property-kinds";
 import { lockWorkspacePropertyWrites } from "@/api/lib/properties/property-lock";
 
 const config = {
@@ -112,6 +113,7 @@ const createProperty = createSafeHandler(
             name: body.name,
             content,
             tool,
+            kinds: propertyKindsForTool(tool),
             role,
             status: initialStatus,
           })

--- a/apps/api/src/handlers/properties/update.ts
+++ b/apps/api/src/handlers/properties/update.ts
@@ -36,6 +36,7 @@ import {
   PROPERTY_DEPENDENCY_LIMITS,
   propertyDependencyReadLimit,
 } from "@/api/lib/properties/dependency-limits";
+import { propertyKindsForTool } from "@/api/lib/properties/property-kinds";
 import { lockWorkspacePropertyWrites } from "@/api/lib/properties/property-lock";
 
 type PropertyWithDeps = {
@@ -459,6 +460,7 @@ const updateProperty = createSafeHandler(
             name,
             content,
             tool: dbTool,
+            kinds: propertyKindsForTool(dbTool),
             role: nextRole,
             status: isStale ? "stale" : "fresh",
           })

--- a/apps/api/src/lib/properties/property-kinds.test.ts
+++ b/apps/api/src/lib/properties/property-kinds.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { propertyKindsForTool } from "@/api/lib/properties/property-kinds";
+
+// PropertyTool (apps/api/src/db/schema-validators.ts) is a union of three
+// TypeBox object schemas, not a const array of tool types, so there is no
+// `keyof typeof` or mapped-array source to derive this list from. Each case
+// below is asserted explicitly instead; a fourth tool type added to the
+// union will fail the helper's `never` exhaustiveness check at compile time,
+// not here.
+describe("propertyKindsForTool", () => {
+  test("ai-model is restricted to documents: extraction only ever runs over documents", () => {
+    expect(propertyKindsForTool({ type: "ai-model" })).toEqual(["document"]);
+  });
+
+  test("playbook-verdict is restricted to documents: it grades an ai-model ASK value", () => {
+    expect(propertyKindsForTool({ type: "playbook-verdict" })).toEqual([
+      "document",
+    ]);
+  });
+
+  test("manual-input applies to every kind", () => {
+    expect(propertyKindsForTool({ type: "manual-input" })).toBeNull();
+  });
+});

--- a/apps/api/src/lib/properties/property-kinds.ts
+++ b/apps/api/src/lib/properties/property-kinds.ts
@@ -1,0 +1,31 @@
+import type { EntityKind } from "@stll/api-contract";
+
+import type { PropertyTool } from "@/api/db/schema-validators";
+
+/**
+ * Which entity kinds a property's tool can ever hold a value for; `null`
+ * means every kind (`properties.kinds` in
+ * `apps/api/src/db/schema/properties.ts`).
+ *
+ * AI extraction only ever runs over documents: see the
+ * `eq(entities.kind, "document")` filter in
+ * `apps/api/src/lib/document-review/table-run-create.ts`. An `ai-model`
+ * property is populated by that extraction, and a `playbook-verdict`
+ * property grades an `ai-model` ASK property's extracted value, so neither
+ * can ever hold a value on a task, message, link, or folder. A
+ * `manual-input` value has no such constraint: a person can set it by hand
+ * on any entity kind.
+ */
+export const propertyKindsForTool = (
+  tool: Pick<PropertyTool, "type">,
+): EntityKind[] | null => {
+  switch (tool.type) {
+    case "ai-model":
+    case "playbook-verdict":
+      return ["document"];
+    case "manual-input":
+      return null;
+    default:
+      return tool.type satisfies never;
+  }
+};

--- a/apps/api/src/lib/workflow/materialize-playbook-run.ts
+++ b/apps/api/src/lib/workflow/materialize-playbook-run.ts
@@ -17,6 +17,7 @@ import { remapNodePropertyIds } from "@/api/lib/conditions/ast-utils";
 import { LIMITS } from "@/api/lib/limits";
 import { createDefaultTool } from "@/api/lib/properties/create-schema";
 import { deletePlaybookColumns } from "@/api/lib/properties/delete-playbook-columns";
+import { propertyKindsForTool } from "@/api/lib/properties/property-kinds";
 import { lockWorkspacePropertyWrites } from "@/api/lib/properties/property-lock";
 import type {
   PlaybookScope,
@@ -384,6 +385,7 @@ export const materializePlaybookRun = async ({
       name: position.issue,
       content: ask.content,
       tool: askTool,
+      kinds: propertyKindsForTool(askTool),
       status: askTool.type === "ai-model" ? "stale" : "fresh",
       playbookSourceId: position.sourceId,
       playbookDefinitionId: playbookId,
@@ -429,18 +431,20 @@ export const materializePlaybookRun = async ({
     }
     verdictPropertyIds.push(verdictId);
 
+    const verdictTool = buildVerdictTool({
+      askPropertyId: askId,
+      sourceId: gradedPosition.sourceId,
+      rule: gradedPositionRule(gradedPosition),
+      severity: gradedPosition.severity,
+      tiers: resolveTiers(gradedPosition, clauseSnapshots),
+    });
     verdictRows.push({
       id: verdictId,
       workspaceId,
       name: `${position.issue} (verdict)`.slice(0, 256),
       content: buildVerdictContent(),
-      tool: buildVerdictTool({
-        askPropertyId: askId,
-        sourceId: gradedPosition.sourceId,
-        rule: gradedPositionRule(gradedPosition),
-        severity: gradedPosition.severity,
-        tiers: resolveTiers(gradedPosition, clauseSnapshots),
-      }),
+      tool: verdictTool,
+      kinds: propertyKindsForTool(verdictTool),
       status: "stale",
       playbookSourceId: position.sourceId,
       playbookDefinitionId: playbookId,
@@ -484,6 +488,7 @@ export const materializePlaybookRun = async ({
           name: sql`excluded.name`,
           content: sql`excluded.content`,
           tool: sql`excluded.tool`,
+          kinds: sql`excluded.kinds`,
           status: sql`excluded.status`,
           playbookDefinitionId: sql`excluded.playbook_definition_id`,
         },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.test.ts
@@ -47,6 +47,118 @@ describe("view entity kinds", () => {
       ]),
     ).toEqual(["task"]);
   });
+
+  test("is null for an or group with one non-kind child", () => {
+    expect(
+      viewEntityKinds([
+        {
+          type: "group",
+          combinator: "or",
+          children: [
+            {
+              type: "predicate",
+              operand: { type: "kind" },
+              op: "in",
+              value: ["task"],
+            },
+            {
+              type: "predicate",
+              operand: { type: "property", propertyId: "status" },
+              op: "is_not_empty",
+            },
+          ],
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  test("unions the kinds an or group's children each admit", () => {
+    expect(
+      viewEntityKinds([
+        {
+          type: "group",
+          combinator: "or",
+          children: [
+            {
+              type: "predicate",
+              operand: { type: "kind" },
+              op: "in",
+              value: ["task"],
+            },
+            {
+              type: "predicate",
+              operand: { type: "kind" },
+              op: "in",
+              value: ["message"],
+            },
+          ],
+        },
+      ]),
+    ).toEqual(["task", "message"]);
+  });
+
+  test("is null for a negated group", () => {
+    expect(
+      viewEntityKinds([
+        {
+          type: "group",
+          combinator: "and",
+          negated: true,
+          children: [
+            {
+              type: "predicate",
+              operand: { type: "kind" },
+              op: "in",
+              value: ["task"],
+            },
+          ],
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  test("intersects the kinds an and group's predicates each admit", () => {
+    expect(
+      viewEntityKinds([
+        {
+          type: "group",
+          combinator: "and",
+          children: [
+            {
+              type: "predicate",
+              operand: { type: "kind" },
+              op: "in",
+              value: ["task", "message"],
+            },
+            {
+              type: "predicate",
+              operand: { type: "kind" },
+              op: "in",
+              value: ["message", "document"],
+            },
+          ],
+        },
+      ]),
+    ).toEqual(["message"]);
+  });
+
+  test("ignores an unrelated predicate anded with a kind filter", () => {
+    expect(
+      viewEntityKinds([
+        {
+          type: "predicate",
+          operand: { type: "kind" },
+          op: "in",
+          value: ["task"],
+        },
+        {
+          type: "predicate",
+          operand: { type: "property", propertyId: "status" },
+          op: "is_not_empty",
+        },
+      ]),
+    ).toEqual(["task"]);
+  });
 });
 
 describe("List view detection", () => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
@@ -1,6 +1,6 @@
 import { isEntityKind } from "@stll/api-contract";
 import { conditionIncludesKind } from "@stll/conditions";
-import type { ConditionNode } from "@stll/conditions";
+import type { ConditionNode, GroupNode, PredicateNode } from "@stll/conditions";
 
 import type { EntityKind } from "@/lib/types";
 
@@ -13,43 +13,110 @@ export const includesListItems = (filters: readonly ConditionNode[]): boolean =>
 
 /**
  * The entity kinds a view's filters admit, read from its `kind in […]`
- * predicates (nested groups included), or `null` when the view does not
- * restrict the kind. A view that names kinds only ever shows those entities,
- * so anything offered per property (calculations, columns) can be scoped to
- * the properties those kinds carry.
+ * predicates, or `null` when the view does not provably restrict the kind.
+ * An `and` intersects the sets its restricted children admit (an unrestricted
+ * child is ignored, not treated as "everything"); an `or` is restricted only
+ * when every child is, and is then their union. A negated group, and any
+ * predicate or compare node other than `kind in […]`, is treated as
+ * unrestricted: we do not compute the complement a negation would admit.
  */
 export const viewEntityKinds = (
   filters: readonly ConditionNode[],
 ): readonly EntityKind[] | null => {
-  const kinds = new Set<EntityKind>();
-  return collectViewKinds(filters, kinds) ? [...kinds] : null;
+  const kinds = admittedKindsForAnd(filters);
+  return kinds ? [...kinds] : null;
 };
 
-/** Adds every admitted kind to `kinds`; true when some predicate restricts it. */
-const collectViewKinds = (
-  nodes: readonly ConditionNode[],
-  kinds: Set<EntityKind>,
-): boolean => {
-  let restricted = false;
-  for (const node of nodes) {
-    if (node.type === "group") {
-      restricted = collectViewKinds(node.children, kinds) || restricted;
-      continue;
-    }
-    if (
-      node.type !== "predicate" ||
-      node.operand.type !== "kind" ||
-      node.op !== "in" ||
-      !Array.isArray(node.value)
-    ) {
-      continue;
-    }
-    restricted = true;
-    for (const value of node.value) {
-      if (typeof value === "string" && isEntityKind(value)) {
-        kinds.add(value);
-      }
+/** The kinds a single condition node admits, or `null` when unrestricted. */
+const admittedKinds = (node: ConditionNode): ReadonlySet<EntityKind> | null => {
+  switch (node.type) {
+    case "compare":
+      return null;
+    case "predicate":
+      return admittedKindsForPredicate(node);
+    case "group":
+      return admittedKindsForGroup(node);
+    default:
+      return node satisfies never;
+  }
+};
+
+const admittedKindsForPredicate = (
+  node: PredicateNode,
+): ReadonlySet<EntityKind> | null => {
+  if (
+    node.operand.type !== "kind" ||
+    node.op !== "in" ||
+    !Array.isArray(node.value)
+  ) {
+    return null;
+  }
+  const kinds = new Set<EntityKind>();
+  for (const value of node.value) {
+    if (isEntityKind(value)) {
+      kinds.add(value);
     }
   }
-  return restricted;
+  return kinds;
+};
+
+const admittedKindsForGroup = (
+  node: GroupNode,
+): ReadonlySet<EntityKind> | null => {
+  if (node.negated) {
+    return null;
+  }
+  switch (node.combinator) {
+    case "and":
+      return admittedKindsForAnd(node.children);
+    case "or":
+      return admittedKindsForOr(node.children);
+    default:
+      return node.combinator satisfies never;
+  }
+};
+
+/** Intersection of restricted children; unrestricted children are ignored. */
+const admittedKindsForAnd = (
+  nodes: readonly ConditionNode[],
+): ReadonlySet<EntityKind> | null => {
+  let result: ReadonlySet<EntityKind> | null = null;
+  for (const node of nodes) {
+    const childKinds = admittedKinds(node);
+    if (!childKinds) {
+      continue;
+    }
+    result = result ? intersect(result, childKinds) : childKinds;
+  }
+  return result;
+};
+
+/** Union of children, but only when every child is itself restricted. */
+const admittedKindsForOr = (
+  nodes: readonly ConditionNode[],
+): ReadonlySet<EntityKind> | null => {
+  const kinds = new Set<EntityKind>();
+  for (const node of nodes) {
+    const childKinds = admittedKinds(node);
+    if (!childKinds) {
+      return null;
+    }
+    for (const kind of childKinds) {
+      kinds.add(kind);
+    }
+  }
+  return kinds;
+};
+
+const intersect = (
+  a: ReadonlySet<EntityKind>,
+  b: ReadonlySet<EntityKind>,
+): ReadonlySet<EntityKind> => {
+  const result = new Set<EntityKind>();
+  for (const kind of a) {
+    if (b.has(kind)) {
+      result.add(kind);
+    }
+  }
+  return result;
 };


### PR DESCRIPTION
## Summary

Follow-up to #2807, which scoped the column-totals picker by `properties.kinds` but found the column was never written: every user-created property is `kinds = null` ("every kind"), so a task board still offered totals over `Governing law`-style properties that only documents can hold.

- **One rule for a property's kinds.** `propertyKindsForTool` returns `["document"]` for `ai-model` and `playbook-verdict` tools (extraction only ever runs over documents, see the `entities.kind = "document"` filter in `document-review/table-run-create.ts`) and `null` for `manual-input`. Exhaustive `switch`, unit-tested per tool type.
- **Every writer uses it:** `properties/create`, `create-batch`, `update` (re-derived whenever the tool is written) and playbook materialization (`materialize-playbook-run.ts`, including the upsert's `excluded.kinds`). The system file property (`workspaces/create`) and duplication are unchanged.
- **Backfill migration** `20260902090000_properties_kinds_ai_backfill` sets `kinds = ARRAY['document']` where `kinds IS NULL AND tool->>'type' IN ('ai-model', 'playbook-verdict')`. `check-migration-safety`, `squawk`, and `drizzle-kit check` are clean.
- **Codex finding on #2807 addressed:** `viewEntityKinds` now follows the filter's boolean semantics. `and` intersects restricted children, `or` is restricted only when every child is (then unions), a negated group and any non-`kind in` node prove nothing. Ten unit tests.

## Verification

- API and web typechecks clean for the touched files; type-aware oxlint and oxfmt clean.
- `bun test`: property-kinds, create-schema, update-by-id, dependency-limits, open-playbook-run (playbook materialization), view-kind-filters.
- The migration was not applied to a live database locally (no local Postgres on the configured port); it is a bounded `UPDATE` and CI applies migrations.