### PR TITLE
feat(canary): probe each provider at its structured-output budget edge

### DIFF
--- a/apps/api/scripts/ai-provider-canary-config.ts
+++ b/apps/api/scripts/ai-provider-canary-config.ts
@@ -183,6 +183,28 @@ export const structuredOutputModelRoleMaxOutputTokens = ({
 // probe on every model.
 export const TOOL_CALL_PROBE_MAX_OUTPUT_TOKENS = 4096;
 
+// The structured-output-budget-edge probe answers every property in its
+// schema (`null` answer, empty justification), so its output grows with the
+// property count `buildBudgetEdgeSchema` found — up to ~75 properties for a
+// 100 000-byte documented budget. The fixed "fast"-role ceiling above (512
+// tokens, sized for a one-line canary reply) truncates that response well
+// before it finishes; this scales headroom with the schema actually sent.
+const BUDGET_EDGE_PROBE_OUTPUT_TOKENS_BASE = 256;
+const BUDGET_EDGE_PROBE_OUTPUT_TOKENS_PER_PROPERTY = 50;
+
+export const structuredOutputBudgetEdgeMaxOutputTokens = ({
+  modelId,
+  propertyCount,
+}: {
+  modelId: string;
+  propertyCount: number;
+}) =>
+  clampToModelOutputLimit(
+    modelId,
+    BUDGET_EDGE_PROBE_OUTPUT_TOKENS_BASE +
+      propertyCount * BUDGET_EDGE_PROBE_OUTPUT_TOKENS_PER_PROPERTY,
+  );
+
 export const isCanaryProvider = (value: string): value is CanaryProvider =>
   CANARY_PROVIDERS.some((provider) => provider === value);
 

--- a/apps/api/scripts/ai-provider-canary.ts
+++ b/apps/api/scripts/ai-provider-canary.ts
@@ -18,6 +18,7 @@ import { toTanStackToolSchema } from "@/api/handlers/chat/tools/tanstack-tool-sc
 import type { CachingDecision, OrgAIConfig } from "@/api/lib/ai-config";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { providerSafeJsonSchemaOptionsForTanStackProvider } from "@/api/lib/provider-safe-json-schema";
+import { buildBudgetEdgeSchema } from "@/api/lib/structured-output-budget-probe";
 import {
   abortControllerFromSignal,
   generateTanStackObjectForRole,
@@ -32,6 +33,7 @@ import {
   CANARY_TIERS,
   CANARY_PROVIDERS,
   modelRoleMaxOutputTokens,
+  structuredOutputBudgetEdgeMaxOutputTokens,
   structuredOutputModelRoleMaxOutputTokens,
   IMPOSSIBLE_STRING_MAX_LENGTH,
   NULL_WIDENING_CANARY_PROVIDERS,
@@ -933,6 +935,46 @@ const capabilityProbes = [
         orgAIConfig: config,
         outputSchema: structuredOutputSchema,
         prompt: "Return an object whose ok field is true.",
+        role: CAPABILITY_ROLE,
+        serviceTier: "standard",
+        tenantWorkspaceIds: NO_TENANT_SCOPE,
+      });
+    },
+  },
+  {
+    // A schema sized to the widest a provider currently accepts for this
+    // application's own workflow-batch shape (see
+    // `buildBudgetEdgeSchema`/`STRUCTURED_OUTPUT_BUDGETS`), rather than the
+    // trivial one-field schema the "structured-output" probe above sends.
+    // The daily edge probe exists to catch a provider tightening its
+    // constrained-decoding grammar limits here, not in a user's workflow run.
+    type: "capability",
+    name: "structured-output-budget-edge",
+    timeoutMs: CAPABILITY_PROBE_TIMEOUT_MS,
+    run: async ({ config, provider }, signal) => {
+      const modelId = DEFAULT_MODELS[provider][CAPABILITY_ROLE];
+      const edge = buildBudgetEdgeSchema({ provider, modelId });
+      console.log(
+        `[ai-canary] ${provider}/structured-output-budget-edge: ` +
+          `${edge.propertyCount} properties, ${edge.measured.bytes}/` +
+          `${edge.budget.maxSchemaBytes} bytes, ` +
+          `${edge.measured.unionParameters}/${edge.budget.maxUnionParameters} ` +
+          `union parameters (${edge.budget.basis} budget, compiler=${edge.compiler})`,
+      );
+      await generateTanStackObjectForRole({
+        abortSignal: signal,
+        caching: NO_CACHING,
+        maxOutputTokens: structuredOutputBudgetEdgeMaxOutputTokens({
+          modelId,
+          propertyCount: edge.propertyCount,
+        }),
+        organizationId: null,
+        orgAIConfig: config,
+        outputSchema: edge.outputSchema,
+        prompt:
+          "Return an object with one entry per property key in the " +
+          'schema. For each, set "answer" to null and "justification" to ' +
+          "an empty array.",
         role: CAPABILITY_ROLE,
         serviceTier: "standard",
         tenantWorkspaceIds: NO_TENANT_SCOPE,

--- a/apps/api/src/lib/structured-output-budget-probe.test.ts
+++ b/apps/api/src/lib/structured-output-budget-probe.test.ts
@@ -1,0 +1,125 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import { TANSTACK_AI_PROVIDERS } from "@stll/ai-catalog";
+import type { TanStackAIProvider } from "@stll/ai-catalog";
+
+import { checkStructuredOutputBudget } from "@/api/lib/structured-output-budget";
+import { buildBudgetEdgeSchema } from "@/api/lib/structured-output-budget-probe";
+import { structuredOutputWireJsonSchema } from "@/api/lib/tanstack-ai-generate";
+
+// A whole synthetic property costs roughly 1-1.5 KB projected, so growth
+// moves in coarse steps; "just under the budget" cannot mean "within 5% of
+// it" to the byte for every provider. A measured or documented budget
+// (Anthropic, OpenAI) is expected to land in the top 10%: close enough that
+// one more property would have crossed it, per `buildBudgetEdgeSchema`'s own
+// stopping condition.
+const REAL_BUDGET_TOLERANCE = 0.9;
+
+// Placeholder-budget providers are capped well under their published
+// 100 000-byte ceiling (see `PLACEHOLDER_BUDGET_PROBE_MAX_BYTES`); the probe
+// only has to land close to that self-imposed cap, not the real ceiling.
+const PLACEHOLDER_PROBE_CAP_BYTES = 20_000;
+const PLACEHOLDER_PROBE_TOLERANCE = 0.85;
+
+type Target = { provider: TanStackAIProvider; modelId: string };
+
+const NATIVE_TARGETS: readonly Target[] = TANSTACK_AI_PROVIDERS.map(
+  (provider) => ({ provider, modelId: `${provider}-canary-model` }),
+);
+
+// Two ids routed through an aggregator/platform to a provider with its own
+// (real) budget: the edge these produce should match Anthropic's directly,
+// not OpenRouter's or Bedrock's own placeholder.
+const ROUTED_TARGETS: readonly Target[] = [
+  { provider: "openrouter", modelId: "anthropic/claude-sonnet-5" },
+  {
+    provider: "bedrock",
+    modelId: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+  },
+];
+
+describe("buildBudgetEdgeSchema", () => {
+  test.each([...NATIVE_TARGETS, ...ROUTED_TARGETS])(
+    "builds a schema that fits the resolved budget for %j",
+    (target) => {
+      const result = buildBudgetEdgeSchema(target);
+
+      expect(result.propertyCount).toBeGreaterThan(0);
+
+      // The builder's own stopping condition, re-verified through the exact
+      // seam production requests pass through: the schema it hands back must
+      // actually clear `checkStructuredOutputBudget`.
+      const wireSchema = structuredOutputWireJsonSchema({
+        outputSchema: result.outputSchema,
+        provider: target.provider,
+      });
+      const check = checkStructuredOutputBudget({
+        provider: target.provider,
+        modelId: target.modelId,
+        schema: wireSchema,
+      });
+      expect(Result.isOk(check)).toBe(true);
+      expect(result.measured.unionParameters).toBeLessThanOrEqual(
+        result.budget.maxUnionParameters,
+      );
+
+      if (result.budget.basis === "placeholder") {
+        expect(result.measured.bytes).toBeLessThanOrEqual(
+          PLACEHOLDER_PROBE_CAP_BYTES,
+        );
+        expect(result.measured.bytes).toBeGreaterThan(
+          PLACEHOLDER_PROBE_CAP_BYTES * PLACEHOLDER_PROBE_TOLERANCE,
+        );
+        return;
+      }
+
+      expect(result.measured.bytes).toBeLessThanOrEqual(
+        result.budget.maxSchemaBytes,
+      );
+      expect(result.measured.bytes).toBeGreaterThan(
+        result.budget.maxSchemaBytes * REAL_BUDGET_TOLERANCE,
+      );
+    },
+  );
+
+  test("an OpenRouter id naming Anthropic resolves the same edge as calling Anthropic directly", () => {
+    const routed = buildBudgetEdgeSchema({
+      provider: "openrouter",
+      modelId: "anthropic/claude-sonnet-5",
+    });
+    const direct = buildBudgetEdgeSchema({
+      provider: "anthropic",
+      modelId: "claude-sonnet-5",
+    });
+
+    expect(routed.compiler).toBe("anthropic");
+    expect(routed.propertyCount).toBe(direct.propertyCount);
+    expect(routed.budget).toEqual(direct.budget);
+  });
+
+  test("a Bedrock id naming Anthropic resolves the same edge as calling Anthropic directly", () => {
+    const routed = buildBudgetEdgeSchema({
+      provider: "bedrock",
+      modelId: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    });
+    const direct = buildBudgetEdgeSchema({
+      provider: "anthropic",
+      modelId: "claude-sonnet-5",
+    });
+
+    expect(routed.compiler).toBe("anthropic");
+    expect(routed.propertyCount).toBe(direct.propertyCount);
+    expect(routed.budget).toEqual(direct.budget);
+  });
+
+  test("an OpenRouter id naming no known vendor keeps OpenRouter's own placeholder", () => {
+    const result = buildBudgetEdgeSchema({
+      provider: "openrouter",
+      modelId: "some-vendor/unlisted-model",
+    });
+
+    expect(result.compiler).toBe("openrouter");
+    expect(result.budget.basis).toBe("placeholder");
+  });
+});

--- a/apps/api/src/lib/structured-output-budget-probe.ts
+++ b/apps/api/src/lib/structured-output-budget-probe.ts
@@ -1,0 +1,173 @@
+import { panic, Result } from "better-result";
+
+import type { AiExtractablePropertyContent } from "@/api/db/schema-validators";
+import { brandDerivedPropertyId } from "@/api/lib/safe-id-boundaries";
+import {
+  checkStructuredOutputBudget,
+  resolveStructuredOutputBudget,
+  type StructuredOutputMeasure,
+  type StructuredOutputTarget,
+} from "@/api/lib/structured-output-budget";
+import { structuredOutputWireJsonSchema } from "@/api/lib/tanstack-ai-generate";
+import { buildBatchSchema } from "@/api/lib/workflow/ai-prompts";
+import type { AIBatchProperty } from "@/api/lib/workflow/get-execution-plan";
+
+// A provider without a measured or documented ceiling (see `basis` on
+// `StructuredOutputBudget`) carries a large placeholder so a runaway schema
+// still gets rejected somewhere. Probing that placeholder's actual edge would
+// mean sending a six-figure-byte schema on a guess every day; the probe caps
+// there instead, at a size that is still "large enough to say the placeholder
+// is not wildly wrong" without being sized on nothing.
+const PLACEHOLDER_BUDGET_PROBE_MAX_BYTES = 20_000;
+
+const BATCH_CONTENT_KINDS = [
+  "text",
+  "date",
+  "int",
+  "single-select",
+  "multi-select",
+] as const;
+type BatchContentKind = (typeof BATCH_CONTENT_KINDS)[number];
+
+const OPTION_VALUES = [
+  "Delaware",
+  "England and Wales",
+  "New York",
+  "California",
+  "Singapore",
+] as const;
+
+const contentForKind = (
+  kind: BatchContentKind,
+): AiExtractablePropertyContent => {
+  switch (kind) {
+    case "text":
+      return { version: 1, type: "text" };
+    case "date":
+      return { version: 1, type: "date" };
+    case "int":
+      return { version: 1, type: "int" };
+    case "single-select":
+    case "multi-select":
+      return {
+        version: 1,
+        type: kind,
+        options: OPTION_VALUES.map((value) => ({ color: "blue", value })),
+        fallback: null,
+      };
+    default: {
+      const exhaustive: never = kind;
+      return panic(`Unhandled batch content kind: ${String(exhaustive)}`);
+    }
+  }
+};
+
+// Cycles through every AI-extractable content kind so the probe schema
+// matches a real mixed-type workflow batch rather than N copies of the
+// cheapest shape.
+const syntheticProperty = (index: number): AIBatchProperty => {
+  const kind = BATCH_CONTENT_KINDS[index % BATCH_CONTENT_KINDS.length];
+  if (kind === undefined) {
+    return panic("BATCH_CONTENT_KINDS must not be empty.");
+  }
+  return {
+    id: brandDerivedPropertyId(`budget-edge-probe-${index}`),
+    status: "stale",
+    content: contentForKind(kind),
+    dependencies: [],
+    tool: {
+      version: 1,
+      type: "ai-model",
+      prompt: `Extract the ${kind} value for synthetic budget-edge field ${index}.`,
+    },
+  };
+};
+
+export type BudgetEdgeSchema = {
+  /** The projected schema `checkStructuredOutputBudget` already confirmed fits. */
+  outputSchema: ReturnType<typeof buildBatchSchema>;
+  propertyCount: number;
+  measured: StructuredOutputMeasure;
+  budget: ReturnType<typeof resolveStructuredOutputBudget>["budget"];
+  /** The provider whose grammar compiler the schema was sized against. */
+  compiler: StructuredOutputTarget["provider"];
+};
+
+/**
+ * Builds the largest workflow-batch-shaped structured-output schema that
+ * still fits `target`'s resolved budget, one synthetic mixed-type property
+ * at a time — the same shape `buildBatchSchema` sends in production, so the
+ * edge this finds is the edge a real batch would hit.
+ *
+ * For a measured or documented budget (Anthropic, OpenAI) that edge sits
+ * just under `maxSchemaBytes`. For a placeholder budget the edge is capped
+ * at `PLACEHOLDER_BUDGET_PROBE_MAX_BYTES`: nothing is known about the real
+ * ceiling, so the probe only needs to land somewhere reasonably large, not
+ * find an exact number.
+ *
+ * Each property in this batch shape carries the full justification
+ * sub-schema (~1.1-1.5 KB projected), so growth moves in coarse, per-property
+ * steps. For Anthropic that means the byte edge binds at 4-5 properties,
+ * carrying 5-6 union-typed `answer` fields — well under its 16-parameter
+ * union cap, which this batch shape cannot reach without first breaking the
+ * byte budget. The union cap still gets exercised (via
+ * `checkStructuredOutputBudget` below); it just is not this probe's binding
+ * constraint today.
+ */
+export const buildBudgetEdgeSchema = ({
+  provider,
+  modelId,
+}: StructuredOutputTarget): BudgetEdgeSchema => {
+  const { provider: compiler, budget } = resolveStructuredOutputBudget({
+    provider,
+    modelId,
+  });
+  const byteCeiling =
+    budget.basis === "placeholder"
+      ? Math.min(budget.maxSchemaBytes, PLACEHOLDER_BUDGET_PROBE_MAX_BYTES)
+      : budget.maxSchemaBytes;
+
+  let properties: AIBatchProperty[] = [];
+  let accepted: {
+    outputSchema: ReturnType<typeof buildBatchSchema>;
+    measured: StructuredOutputMeasure;
+  } | null = null;
+
+  for (let index = 0; ; index += 1) {
+    const candidateProperties = [...properties, syntheticProperty(index)];
+    const outputSchema = buildBatchSchema(candidateProperties, []);
+    const wireSchema = structuredOutputWireJsonSchema({
+      outputSchema,
+      provider,
+    });
+    const check = checkStructuredOutputBudget({
+      provider,
+      modelId,
+      schema: wireSchema,
+    });
+    if (Result.isError(check) || check.value.bytes > byteCeiling) {
+      break;
+    }
+    properties = candidateProperties;
+    accepted = { outputSchema, measured: check.value };
+  }
+
+  // Unreachable for the current budgets: the first synthetic property alone
+  // (~1.1-1.5 KB) fits under every provider's byte ceiling, placeholder cap
+  // included. Guarded rather than assumed, so a budget tightened well below
+  // that floor fails loudly here instead of returning an empty schema.
+  if (accepted === null) {
+    return panic(
+      `No synthetic property fits the ${compiler} structured-output budget ` +
+        `(${byteCeiling} bytes); the budget-edge probe cannot build a schema.`,
+    );
+  }
+
+  return {
+    outputSchema: accepted.outputSchema,
+    propertyCount: properties.length,
+    measured: accepted.measured,
+    budget,
+    compiler,
+  };
+};

--- a/apps/api/src/lib/structured-output-budget.ts
+++ b/apps/api/src/lib/structured-output-budget.ts
@@ -17,6 +17,12 @@ import type { TanStackAIProvider } from "@stll/ai-catalog";
 export type StructuredOutputBudget = {
   maxSchemaBytes: number;
   maxUnionParameters: number;
+  /**
+   * How the numbers above were established, so a caller (the budget-edge
+   * canary probe, a reviewer) can tell a provider-quoted ceiling from a
+   * guard against a runaway schema without re-reading these comments.
+   */
+  basis: "measured" | "documented" | "placeholder";
 };
 
 export const STRUCTURED_OUTPUT_BUDGETS = {
@@ -28,20 +34,44 @@ export const STRUCTURED_OUTPUT_BUDGETS = {
   // The union cap is quoted by Anthropic's second rejection: "limit: 16
   // parameters with unions". Sharing sub-schemas through `$defs`/`$ref` does
   // not help; the grammar is compiled from the inlined schema either way.
-  anthropic: { maxSchemaBytes: 5600, maxUnionParameters: 16 },
+  anthropic: {
+    maxSchemaBytes: 5600,
+    maxUnionParameters: 16,
+    basis: "measured",
+  },
   // Documented: OpenAI's strict structured outputs allow 120 000 total
   // characters across the schema. 100_000 keeps headroom for request framing.
   // The union cap is a placeholder; OpenAI publishes no union-parameter limit.
-  openai: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
+  openai: {
+    maxSchemaBytes: 100_000,
+    maxUnionParameters: 1000,
+    basis: "documented",
+  },
   // Placeholders. No schema-size or union limit is published for these
   // providers, so these values only stop a runaway schema rather than
   // encoding a known ceiling; tighten one from a measurement, not a guess.
   // OpenRouter's applies only to an id whose upstream is unknown:
   // `resolveStructuredOutputBudget` reads the upstream off the id first.
-  bedrock: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
-  google: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
-  mistral: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
-  openrouter: { maxSchemaBytes: 100_000, maxUnionParameters: 1000 },
+  bedrock: {
+    maxSchemaBytes: 100_000,
+    maxUnionParameters: 1000,
+    basis: "placeholder",
+  },
+  google: {
+    maxSchemaBytes: 100_000,
+    maxUnionParameters: 1000,
+    basis: "placeholder",
+  },
+  mistral: {
+    maxSchemaBytes: 100_000,
+    maxUnionParameters: 1000,
+    basis: "placeholder",
+  },
+  openrouter: {
+    maxSchemaBytes: 100_000,
+    maxUnionParameters: 1000,
+    basis: "placeholder",
+  },
 } as const satisfies Record<TanStackAIProvider, StructuredOutputBudget>;
 
 /**


### PR DESCRIPTION
## Summary
- Add `buildBudgetEdgeSchema` (`structured-output-budget-probe.ts`): grows a workflow-batch-shaped schema, one synthetic mixed-type property at a time, up to a provider's resolved structured-output budget; unit-tested for every provider plus the OpenRouter/Bedrock ids routed to Anthropic.
- Add a daily `structured-output-budget-edge` capability probe that asks the provider to fill that edge schema, so a provider tightening its constrained-decoding limits shows up in the canary instead of a user's workflow run. Placeholder-budget providers (no measured/documented ceiling) are capped at 20 000 bytes rather than probed at their 100 000-byte placeholder.
- Add a `basis` discriminator (`measured`/`documented`/`placeholder`) to `STRUCTURED_OUTPUT_BUDGETS` and `structuredOutputBudgetEdgeMaxOutputTokens` (the edge schema's answer grows with property count, so the fixed "fast"-role output ceiling truncated the largest schemas).

## Test plan
- [x] `bun test` on the new and existing structured-output-budget/canary suites (102 pass)
- [x] `bun run lint`
- [x] Ran the daily canary locally against Anthropic (`4 properties, 5395/5600 bytes, 5/16 unions`) and OpenRouter (`74 properties, 99993/100000 bytes, 89/1000 unions`, resolved to the OpenAI compiler) — both pass