### PR TITLE
fix(evals): report a rejected model stream as an error turn

### DIFF
--- a/apps/api/evals/agent-orientation.ts
+++ b/apps/api/evals/agent-orientation.ts
@@ -53,7 +53,6 @@ import {
   systemPromptsPatch,
 } from "@/api/lib/tanstack-ai-generate";
 import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
-import { tokenUsageFromRunFinishedChunk } from "@/api/lib/tanstack-ai-usage";
 import { toMcpTools } from "@/api/mcp/gateway/list-tools";
 import { getMcpInstructions } from "@/api/mcp/instructions";
 import { listStaticMcpToolDefinitions } from "@/api/mcp/static-tool-definitions";
@@ -74,6 +73,7 @@ import type {
   RegistryToolListing,
   RouteNode,
 } from "../../../packages/cli/src/route-types";
+import { runEvalModelTurn } from "./lib/model-turn";
 
 // A bare id resolves through whichever configured provider rates it (GPT
 // models may come from OpenAI or OpenRouter); Claude ids are pinned to
@@ -681,110 +681,102 @@ const runModelTurn = async ({
     role: "chat",
     scopeKey: null,
   });
-  const start = performance.now();
-  const abortController = new AbortController();
-  const abortTimer = setTimeout(
-    () => abortController.abort(),
-    MODEL_REQUEST_TIMEOUT_MS,
-  );
-  const stream = chat({
-    abortController,
-    adapter: model.adapter,
-    messages: [{ role: "user", content: request }],
-    // The run ends at the first tool call (or at the model's text reply on
-    // the CLI surface, which registers no tools at all); nothing executes.
-    agentLoopStrategy: maxIterations(1),
-    ...systemPromptsPatch({ caching, model, system }),
-    modelOptions: mergeGenerationOptions({
-      caching,
-      model,
-      maxOutputTokens: MAX_OUTPUT_TOKENS,
-      serviceTier: "standard",
-      temperature: 0,
-    }),
-    tools,
-  });
-
   let finalText = "";
-  let usage: TokenUsage | null = null;
-  let error: string | null = null;
   const toolNames = new Map<string, string>();
   const argumentTexts = new Map<string, string>();
   const parsedInputs = new Map<string, unknown>();
-  for await (const chunk of stream) {
-    // Exhaustive over ChatStream's real chunk union (`AGUIEvent`, 22
-    // members — narrower than the full `EventType` enum, which also
-    // declares deprecated/unused values this stream never emits) instead
-    // of an if-chain: a renamed or newly added chunk type fails
-    // typechecking at the `satisfies never` default instead of being
-    // silently ignored, which for THIS eval would misclassify a run as
-    // no-call/pass instead of failing loudly.
-    //
-    // TOOL_CALL_START, TOOL_CALL_END, and CUSTOM carry a plain string
-    // literal `type` (not the `EventType` enum member) by design — see
-    // `ToolCallStartEvent`/`ToolCallEndEvent`/`CustomEvent` in
-    // `@tanstack/ai`'s types — so those three cases match on the literal
-    // string instead of the enum member.
-    switch (chunk.type) {
-      case EventType.TEXT_MESSAGE_CONTENT: {
-        finalText += chunk.delta;
-        break;
-      }
-      case EventType.TOOL_CALL_ARGS: {
-        argumentTexts.set(
-          chunk.toolCallId,
-          (argumentTexts.get(chunk.toolCallId) ?? "") + chunk.delta,
-        );
-        break;
-      }
-      case "TOOL_CALL_START": {
-        toolNames.set(chunk.toolCallId, chunk.toolCallName);
-        break;
-      }
-      case "TOOL_CALL_END": {
-        if (chunk.input !== undefined) {
-          parsedInputs.set(chunk.toolCallId, chunk.input);
+  const { error, latencyMs, usage } = await runEvalModelTurn({
+    timeoutMs: MODEL_REQUEST_TIMEOUT_MS,
+    chat: (abortController) =>
+      chat({
+        abortController,
+        adapter: model.adapter,
+        messages: [{ role: "user", content: request }],
+        // The run ends at the first tool call (or at the model's text reply
+        // on the CLI surface, which registers no tools at all); nothing
+        // executes.
+        agentLoopStrategy: maxIterations(1),
+        ...systemPromptsPatch({ caching, model, system }),
+        modelOptions: mergeGenerationOptions({
+          caching,
+          model,
+          maxOutputTokens: MAX_OUTPUT_TOKENS,
+          serviceTier: "standard",
+          temperature: 0,
+        }),
+        tools,
+      }),
+    onChunk: (chunk) => {
+      // Exhaustive over ChatStream's real chunk union (`AGUIEvent`, 22
+      // members — narrower than the full `EventType` enum, which also
+      // declares deprecated/unused values this stream never emits) instead
+      // of an if-chain: a renamed or newly added chunk type fails
+      // typechecking at the `satisfies never` default instead of being
+      // silently ignored, which for THIS eval would misclassify a run as
+      // no-call/pass instead of failing loudly.
+      //
+      // TOOL_CALL_START, TOOL_CALL_END, and CUSTOM carry a plain string
+      // literal `type` (not the `EventType` enum member) by design — see
+      // `ToolCallStartEvent`/`ToolCallEndEvent`/`CustomEvent` in
+      // `@tanstack/ai`'s types — so those three cases match on the literal
+      // string instead of the enum member.
+      switch (chunk.type) {
+        case EventType.TEXT_MESSAGE_CONTENT: {
+          finalText += chunk.delta;
+          break;
         }
-        break;
+        case EventType.TOOL_CALL_ARGS: {
+          argumentTexts.set(
+            chunk.toolCallId,
+            (argumentTexts.get(chunk.toolCallId) ?? "") + chunk.delta,
+          );
+          break;
+        }
+        case "TOOL_CALL_START": {
+          toolNames.set(chunk.toolCallId, chunk.toolCallName);
+          break;
+        }
+        case "TOOL_CALL_END": {
+          if (chunk.input !== undefined) {
+            parsedInputs.set(chunk.toolCallId, chunk.input);
+          }
+          break;
+        }
+        // The run-turn helper captures the error message and usage from
+        // these; this eval scores neither beyond what it already returns.
+        case EventType.RUN_ERROR:
+        case EventType.RUN_FINISHED: {
+          break;
+        }
+        // Every other chunk type carries nothing this eval scores on: only
+        // the first tool call's name/args/input and the final text/usage/error
+        // matter here. Listed explicitly (not folded into an implicit
+        // default) so the ignored set is visible in the diff whenever it grows.
+        case EventType.TEXT_MESSAGE_START:
+        case EventType.TEXT_MESSAGE_END:
+        case EventType.TOOL_CALL_RESULT:
+        case EventType.STATE_SNAPSHOT:
+        case EventType.STATE_DELTA:
+        case EventType.MESSAGES_SNAPSHOT:
+        case "CUSTOM":
+        case EventType.RUN_STARTED:
+        case EventType.STEP_STARTED:
+        case EventType.STEP_FINISHED:
+        case EventType.REASONING_START:
+        case EventType.REASONING_MESSAGE_START:
+        case EventType.REASONING_MESSAGE_CONTENT:
+        case EventType.REASONING_MESSAGE_END:
+        case EventType.REASONING_ENCRYPTED_VALUE:
+        case EventType.REASONING_END: {
+          break;
+        }
+        default: {
+          chunk satisfies never;
+          break;
+        }
       }
-      case EventType.RUN_ERROR: {
-        error = chunk.message;
-        break;
-      }
-      case EventType.RUN_FINISHED: {
-        usage = tokenUsageFromRunFinishedChunk(chunk) ?? null;
-        break;
-      }
-      // Every other chunk type carries nothing this eval scores on: only
-      // the first tool call's name/args/input and the final text/usage/error
-      // matter here. Listed explicitly (not folded into an implicit
-      // default) so the ignored set is visible in the diff whenever it grows.
-      case EventType.TEXT_MESSAGE_START:
-      case EventType.TEXT_MESSAGE_END:
-      case EventType.TOOL_CALL_RESULT:
-      case EventType.STATE_SNAPSHOT:
-      case EventType.STATE_DELTA:
-      case EventType.MESSAGES_SNAPSHOT:
-      case "CUSTOM":
-      case EventType.RUN_STARTED:
-      case EventType.STEP_STARTED:
-      case EventType.STEP_FINISHED:
-      case EventType.REASONING_START:
-      case EventType.REASONING_MESSAGE_START:
-      case EventType.REASONING_MESSAGE_CONTENT:
-      case EventType.REASONING_MESSAGE_END:
-      case EventType.REASONING_ENCRYPTED_VALUE:
-      case EventType.REASONING_END: {
-        break;
-      }
-      default: {
-        chunk satisfies never;
-        break;
-      }
-    }
-  }
-  clearTimeout(abortTimer);
-  const latencyMs = Math.round(performance.now() - start);
+    },
+  });
 
   const firstCallId = [...argumentTexts.keys(), ...parsedInputs.keys()].at(0);
   if (firstCallId === undefined) {

--- a/apps/api/evals/create-document-drafting.ts
+++ b/apps/api/evals/create-document-drafting.ts
@@ -55,7 +55,8 @@ import {
   systemPromptsPatch,
 } from "@/api/lib/tanstack-ai-generate";
 import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
-import { tokenUsageFromRunFinishedChunk } from "@/api/lib/tanstack-ai-usage";
+
+import { runEvalModelTurn } from "./lib/model-turn";
 
 // A bare id resolves through whichever configured provider rates it (GPT
 // models may come from OpenAI or OpenRouter); Claude ids are pinned to
@@ -259,80 +260,56 @@ const runModelTurn = async (
     role: "fast",
     scopeKey: null,
   });
-  const start = performance.now();
-  const abortController = new AbortController();
-  const abortTimer = setTimeout(
-    () => abortController.abort(),
-    MODEL_REQUEST_TIMEOUT_MS,
-  );
   let finalText = "";
-  let usage: TokenUsage | null = null;
-  let turnError: string | null = null;
   const argumentTexts = new Map<string, string>();
   const parsedInputs = new Map<string, unknown>();
-  // `chat()` or its stream can reject mid-turn (adapter error, dropped
-  // connection); this boundary must still report an "error" turn and
-  // always clear the abort timer.
-  try {
-    const stream = chat({
-      abortController,
-      adapter: model.adapter,
-      messages: [{ role: "user", content: prompt }],
-      // The tool is client-executed in production; here nobody answers it, so
-      // the run ends after the first tool call.
-      agentLoopStrategy: maxIterations(1),
-      ...systemPromptsPatch({ caching, model, system: SYSTEM_PROMPT }),
-      modelOptions: mergeGenerationOptions({
-        caching,
-        model,
-        maxOutputTokens: MAX_OUTPUT_TOKENS,
-        serviceTier: "standard",
-        temperature: 0,
+  const { error, latencyMs, usage } = await runEvalModelTurn({
+    timeoutMs: MODEL_REQUEST_TIMEOUT_MS,
+    chat: (abortController) =>
+      chat({
+        abortController,
+        adapter: model.adapter,
+        messages: [{ role: "user", content: prompt }],
+        // The tool is client-executed in production; here nobody answers it,
+        // so the run ends after the first tool call.
+        agentLoopStrategy: maxIterations(1),
+        ...systemPromptsPatch({ caching, model, system: SYSTEM_PROMPT }),
+        modelOptions: mergeGenerationOptions({
+          caching,
+          model,
+          maxOutputTokens: MAX_OUTPUT_TOKENS,
+          serviceTier: "standard",
+          temperature: 0,
+        }),
+        tools: [createCreateDocumentTool()],
       }),
-      tools: [createCreateDocumentTool()],
-    });
-    for await (const chunk of stream) {
+    onChunk: (chunk) => {
       if (chunk.type === EventType.TEXT_MESSAGE_CONTENT) {
         finalText += chunk.delta;
-        continue;
+        return;
       }
       if (chunk.type === EventType.TOOL_CALL_ARGS) {
         argumentTexts.set(
           chunk.toolCallId,
           (argumentTexts.get(chunk.toolCallId) ?? "") + chunk.delta,
         );
-        continue;
+        return;
       }
-      if (chunk.type === EventType.TOOL_CALL_END) {
-        if (chunk.input !== undefined) {
-          parsedInputs.set(chunk.toolCallId, chunk.input);
-        }
-        continue;
+      if (chunk.type === EventType.TOOL_CALL_END && chunk.input !== undefined) {
+        parsedInputs.set(chunk.toolCallId, chunk.input);
       }
-      if (chunk.type === EventType.RUN_ERROR) {
-        turnError = chunk.message;
-        continue;
-      }
-      if (chunk.type === EventType.RUN_FINISHED) {
-        usage = tokenUsageFromRunFinishedChunk(chunk) ?? null;
-      }
-    }
-  } catch (error: unknown) {
-    turnError = error instanceof Error ? error.message : String(error);
-  } finally {
-    clearTimeout(abortTimer);
-  }
-  const latencyMs = Math.round(performance.now() - start);
+    },
+  });
 
   const firstCallId = [...argumentTexts.keys(), ...parsedInputs.keys()].at(0);
   if (firstCallId === undefined) {
-    return { call: null, error: turnError, finalText, latencyMs, usage };
+    return { call: null, error, finalText, latencyMs, usage };
   }
   const argumentText = argumentTexts.get(firstCallId) ?? "";
   const input = parsedInputs.get(firstCallId) ?? parseJsonOrNull(argumentText);
   return {
     call: { argumentText, input },
-    error: turnError,
+    error,
     finalText,
     latencyMs,
     usage,

--- a/apps/api/evals/create-document-drafting.ts
+++ b/apps/api/evals/create-document-drafting.ts
@@ -265,65 +265,78 @@ const runModelTurn = async (
     () => abortController.abort(),
     MODEL_REQUEST_TIMEOUT_MS,
   );
-  const stream = chat({
-    abortController,
-    adapter: model.adapter,
-    messages: [{ role: "user", content: prompt }],
-    // The tool is client-executed in production; here nobody answers it, so
-    // the run ends after the first tool call.
-    agentLoopStrategy: maxIterations(1),
-    ...systemPromptsPatch({ caching, model, system: SYSTEM_PROMPT }),
-    modelOptions: mergeGenerationOptions({
-      caching,
-      model,
-      maxOutputTokens: MAX_OUTPUT_TOKENS,
-      serviceTier: "standard",
-      temperature: 0,
-    }),
-    tools: [createCreateDocumentTool()],
-  });
-
   let finalText = "";
   let usage: TokenUsage | null = null;
-  let error: string | null = null;
+  let turnError: string | null = null;
   const argumentTexts = new Map<string, string>();
   const parsedInputs = new Map<string, unknown>();
-  for await (const chunk of stream) {
-    if (chunk.type === EventType.TEXT_MESSAGE_CONTENT) {
-      finalText += chunk.delta;
-      continue;
-    }
-    if (chunk.type === EventType.TOOL_CALL_ARGS) {
-      argumentTexts.set(
-        chunk.toolCallId,
-        (argumentTexts.get(chunk.toolCallId) ?? "") + chunk.delta,
-      );
-      continue;
-    }
-    if (chunk.type === EventType.TOOL_CALL_END) {
-      if (chunk.input !== undefined) {
-        parsedInputs.set(chunk.toolCallId, chunk.input);
+  // `chat()` or its stream can reject mid-turn (adapter error, dropped
+  // connection); this boundary must still report an "error" turn and
+  // always clear the abort timer.
+  try {
+    const stream = chat({
+      abortController,
+      adapter: model.adapter,
+      messages: [{ role: "user", content: prompt }],
+      // The tool is client-executed in production; here nobody answers it, so
+      // the run ends after the first tool call.
+      agentLoopStrategy: maxIterations(1),
+      ...systemPromptsPatch({ caching, model, system: SYSTEM_PROMPT }),
+      modelOptions: mergeGenerationOptions({
+        caching,
+        model,
+        maxOutputTokens: MAX_OUTPUT_TOKENS,
+        serviceTier: "standard",
+        temperature: 0,
+      }),
+      tools: [createCreateDocumentTool()],
+    });
+    for await (const chunk of stream) {
+      if (chunk.type === EventType.TEXT_MESSAGE_CONTENT) {
+        finalText += chunk.delta;
+        continue;
       }
-      continue;
+      if (chunk.type === EventType.TOOL_CALL_ARGS) {
+        argumentTexts.set(
+          chunk.toolCallId,
+          (argumentTexts.get(chunk.toolCallId) ?? "") + chunk.delta,
+        );
+        continue;
+      }
+      if (chunk.type === EventType.TOOL_CALL_END) {
+        if (chunk.input !== undefined) {
+          parsedInputs.set(chunk.toolCallId, chunk.input);
+        }
+        continue;
+      }
+      if (chunk.type === EventType.RUN_ERROR) {
+        turnError = chunk.message;
+        continue;
+      }
+      if (chunk.type === EventType.RUN_FINISHED) {
+        usage = tokenUsageFromRunFinishedChunk(chunk) ?? null;
+      }
     }
-    if (chunk.type === EventType.RUN_ERROR) {
-      error = chunk.message;
-      continue;
-    }
-    if (chunk.type === EventType.RUN_FINISHED) {
-      usage = tokenUsageFromRunFinishedChunk(chunk) ?? null;
-    }
+  } catch (error: unknown) {
+    turnError = error instanceof Error ? error.message : String(error);
+  } finally {
+    clearTimeout(abortTimer);
   }
-  clearTimeout(abortTimer);
   const latencyMs = Math.round(performance.now() - start);
 
   const firstCallId = [...argumentTexts.keys(), ...parsedInputs.keys()].at(0);
   if (firstCallId === undefined) {
-    return { call: null, error, finalText, latencyMs, usage };
+    return { call: null, error: turnError, finalText, latencyMs, usage };
   }
   const argumentText = argumentTexts.get(firstCallId) ?? "";
   const input = parsedInputs.get(firstCallId) ?? parseJsonOrNull(argumentText);
-  return { call: { argumentText, input }, error, finalText, latencyMs, usage };
+  return {
+    call: { argumentText, input },
+    error: turnError,
+    finalText,
+    latencyMs,
+    usage,
+  };
 };
 
 // Boundary decode of model output: malformed JSON is a benchmark finding,

--- a/apps/api/evals/lib/model-turn.test.ts
+++ b/apps/api/evals/lib/model-turn.test.ts
@@ -1,0 +1,131 @@
+import { EventType } from "@tanstack/ai";
+import type { StreamChunk, TokenUsage } from "@tanstack/ai";
+import { describe, expect, test } from "bun:test";
+
+import { runEvalModelTurn } from "./model-turn";
+
+type TextMessageContentChunk = Extract<
+  StreamChunk,
+  { type: "TEXT_MESSAGE_CONTENT" }
+>;
+type RunErrorChunk = Extract<StreamChunk, { type: "RUN_ERROR" }>;
+type RunFinishedChunk = Extract<StreamChunk, { type: "RUN_FINISHED" }>;
+
+const textChunk = (delta: string) =>
+  ({
+    type: EventType.TEXT_MESSAGE_CONTENT,
+    messageId: "msg-1",
+    delta,
+  }) satisfies TextMessageContentChunk;
+
+const runErrorChunk = (message: string) =>
+  ({ type: EventType.RUN_ERROR, message }) satisfies RunErrorChunk;
+
+const runFinishedChunk = (usage: TokenUsage) =>
+  ({
+    type: EventType.RUN_FINISHED,
+    runId: "run-1",
+    threadId: "thread-1",
+    usage,
+  }) satisfies RunFinishedChunk;
+
+/**
+ * Wraps the real timer functions so a test can assert `clearTimer` ran
+ * (proof the `finally` clause fired) without a fake, unsafely-typed
+ * `Timeout` handle. `timeoutMs` is generous enough in every test that the
+ * abort callback never fires before the turn resolves and clears it.
+ */
+const fakeTimer = () => {
+  const cleared: ReturnType<typeof setTimeout>[] = [];
+  return {
+    cleared,
+    setTimer: (callback: () => void, ms: number) => setTimeout(callback, ms),
+    clearTimer: (handle: ReturnType<typeof setTimeout>) => {
+      cleared.push(handle);
+      clearTimeout(handle);
+    },
+  };
+};
+
+describe("runEvalModelTurn", () => {
+  test("a stream that yields partial text then throws: error is set, the partial text was delivered, and the timer was cleared", async () => {
+    const timer = fakeTimer();
+    let finalText = "";
+
+    async function* partialThenThrow() {
+      yield textChunk("Hello ");
+      yield textChunk("world");
+      throw new Error("stream dropped mid-turn");
+    }
+
+    const result = await runEvalModelTurn({
+      chat: () => partialThenThrow(),
+      timeoutMs: 30_000,
+      onChunk: (chunk) => {
+        if (chunk.type === EventType.TEXT_MESSAGE_CONTENT) {
+          finalText += chunk.delta;
+        }
+      },
+      setTimer: timer.setTimer,
+      clearTimer: timer.clearTimer,
+    });
+
+    expect(result.error).toBe("stream dropped mid-turn");
+    expect(finalText).toBe("Hello world");
+    expect(timer.cleared.length).toBe(1);
+  });
+
+  test("a stream that completes: error is null and usage is captured", async () => {
+    const timer = fakeTimer();
+    let finalText = "";
+    const usage: TokenUsage = {
+      promptTokens: 10,
+      completionTokens: 5,
+      totalTokens: 15,
+    };
+
+    async function* completes() {
+      yield textChunk("Hello");
+      yield runFinishedChunk(usage);
+    }
+
+    const result = await runEvalModelTurn({
+      chat: () => completes(),
+      timeoutMs: 30_000,
+      onChunk: (chunk) => {
+        if (chunk.type === EventType.TEXT_MESSAGE_CONTENT) {
+          finalText += chunk.delta;
+        }
+      },
+      setTimer: timer.setTimer,
+      clearTimer: timer.clearTimer,
+    });
+
+    expect(result.error).toBeNull();
+    expect(finalText).toBe("Hello");
+    expect(result.usage).toEqual(usage);
+    expect(timer.cleared.length).toBe(1);
+  });
+
+  test("a RUN_ERROR chunk: error is set from its message", async () => {
+    const timer = fakeTimer();
+
+    async function* runErrors() {
+      yield runErrorChunk("provider refused the request");
+    }
+
+    const result = await runEvalModelTurn({
+      chat: () => runErrors(),
+      timeoutMs: 30_000,
+      onChunk: () => {
+        // This eval scores nothing else on this turn.
+      },
+      setTimer: timer.setTimer,
+      clearTimer: timer.clearTimer,
+    });
+
+    expect(result.error).toBe("provider refused the request");
+    expect(result.usage).toBeNull();
+    expect(timer.cleared.length).toBe(1);
+  });
+});

--- a/apps/api/evals/lib/model-turn.ts
+++ b/apps/api/evals/lib/model-turn.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared model-turn loop for the evals under `apps/api/evals/`: owns the
+ * abort timer, drains a `chat()` stream, and reports a rejected stream as an
+ * error turn instead of an uncaught rejection. Every eval's loop differed
+ * only in which chunks it accumulated (final text, tool-call arguments, tool
+ * names, ...), so this helper takes over everything else and hands each
+ * chunk to the caller unchanged.
+ */
+import type { ChatStream, TokenUsage } from "@tanstack/ai";
+import { EventType } from "@tanstack/ai";
+
+import { tokenUsageFromRunFinishedChunk } from "@/api/lib/tanstack-ai-usage";
+
+// The element type of the stream `chat()` returns; not exported by
+// `@tanstack/ai` under its own name.
+type ChatStreamChunk =
+  ChatStream extends AsyncIterable<infer Chunk> ? Chunk : never;
+
+export type EvalModelTurnResult = {
+  /** The provider's run error, or the stream/`chat()` rejection message. */
+  error: string | null;
+  latencyMs: number;
+  usage: TokenUsage | null;
+};
+
+export type RunEvalModelTurnOptions = {
+  /**
+   * Starts the model call. Receives the `AbortController` this helper owns
+   * so the caller can pass it straight into `chat()`.
+   */
+  chat: (abortController: AbortController) => ChatStream;
+  /** Aborts the run, and unblocks a hung stream, after this many ms. */
+  timeoutMs: number;
+  /**
+   * Invoked for every chunk the stream yields, in order, so the caller can
+   * accumulate whatever it scores on (text, tool-call arguments, ...).
+   */
+  onChunk: (chunk: ChatStreamChunk) => void;
+  /** Injectable for tests; defaults to the global timer functions. */
+  setTimer?: (
+    callback: () => void,
+    ms: number,
+  ) => ReturnType<typeof setTimeout>;
+  clearTimer?: (handle: ReturnType<typeof setTimeout>) => void;
+};
+
+/**
+ * Runs one model turn: creates the abort timer, iterates the stream, and
+ * always clears the timer, even when `chat()` or the stream it returns
+ * rejects mid-turn (adapter error, dropped connection). Callers combine the
+ * returned `error`/`usage`/`latencyMs` with whatever `onChunk` accumulated.
+ */
+export const runEvalModelTurn = async ({
+  chat,
+  timeoutMs,
+  onChunk,
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+}: RunEvalModelTurnOptions): Promise<EvalModelTurnResult> => {
+  const start = performance.now();
+  const abortController = new AbortController();
+  const abortTimer = setTimer(() => abortController.abort(), timeoutMs);
+  let usage: TokenUsage | null = null;
+  let error: string | null = null;
+  try {
+    const stream = chat(abortController);
+    for await (const chunk of stream) {
+      onChunk(chunk);
+      if (chunk.type === EventType.RUN_ERROR) {
+        error = chunk.message;
+        continue;
+      }
+      if (chunk.type === EventType.RUN_FINISHED) {
+        usage = tokenUsageFromRunFinishedChunk(chunk) ?? null;
+      }
+    }
+  } catch (caughtError: unknown) {
+    error =
+      caughtError instanceof Error ? caughtError.message : String(caughtError);
+  } finally {
+    clearTimer(abortTimer);
+  }
+  return { error, latencyMs: Math.round(performance.now() - start), usage };
+};

--- a/apps/api/evals/suggest-changes-precision.ts
+++ b/apps/api/evals/suggest-changes-precision.ts
@@ -416,41 +416,48 @@ const runModelTurn = async ({
     () => abortController.abort(),
     MODEL_REQUEST_TIMEOUT_MS,
   );
-  const stream = chat({
-    abortController,
-    adapter: model.adapter,
-    messages: [{ role: "user", content: request }],
-    agentLoopStrategy: maxIterations(MAX_ITERATIONS),
-    ...systemPromptsPatch({ caching, model, system }),
-    modelOptions: mergeGenerationOptions({
-      caching,
-      model,
-      maxOutputTokens: MAX_OUTPUT_TOKENS,
-      serviceTier: "standard",
-      temperature: 0,
-    }),
-    tools,
-  });
-
   let finalText = "";
   let usage: TokenUsage | null = null;
-  let error: string | null = null;
-  for await (const chunk of stream) {
-    if (chunk.type === EventType.TEXT_MESSAGE_CONTENT) {
-      finalText += chunk.delta;
-      continue;
+  let turnError: string | null = null;
+  // `chat()` or its stream can reject mid-turn (adapter error, dropped
+  // connection); this boundary must still report an "error" turn and
+  // always clear the abort timer.
+  try {
+    const stream = chat({
+      abortController,
+      adapter: model.adapter,
+      messages: [{ role: "user", content: request }],
+      agentLoopStrategy: maxIterations(MAX_ITERATIONS),
+      ...systemPromptsPatch({ caching, model, system }),
+      modelOptions: mergeGenerationOptions({
+        caching,
+        model,
+        maxOutputTokens: MAX_OUTPUT_TOKENS,
+        serviceTier: "standard",
+        temperature: 0,
+      }),
+      tools,
+    });
+    for await (const chunk of stream) {
+      if (chunk.type === EventType.TEXT_MESSAGE_CONTENT) {
+        finalText += chunk.delta;
+        continue;
+      }
+      if (chunk.type === EventType.RUN_ERROR) {
+        turnError = chunk.message;
+        continue;
+      }
+      if (chunk.type === EventType.RUN_FINISHED) {
+        usage = tokenUsageFromRunFinishedChunk(chunk) ?? null;
+      }
     }
-    if (chunk.type === EventType.RUN_ERROR) {
-      error = chunk.message;
-      continue;
-    }
-    if (chunk.type === EventType.RUN_FINISHED) {
-      usage = tokenUsageFromRunFinishedChunk(chunk) ?? null;
-    }
+  } catch (error: unknown) {
+    turnError = error instanceof Error ? error.message : String(error);
+  } finally {
+    clearTimeout(abortTimer);
   }
-  clearTimeout(abortTimer);
   return {
-    error,
+    error: turnError,
     finalText,
     latencyMs: Math.round(performance.now() - start),
     usage,

--- a/apps/api/evals/suggest-changes-precision.ts
+++ b/apps/api/evals/suggest-changes-precision.ts
@@ -52,7 +52,8 @@ import {
   systemPromptsPatch,
 } from "@/api/lib/tanstack-ai-generate";
 import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
-import { tokenUsageFromRunFinishedChunk } from "@/api/lib/tanstack-ai-usage";
+
+import { runEvalModelTurn } from "./lib/model-turn";
 
 // A bare id resolves through whichever configured provider rates it (GPT
 // models may come from OpenAI or OpenRouter); Claude ids are pinned to
@@ -410,58 +411,32 @@ const runModelTurn = async ({
     scopeKey: null,
   });
   const system = `${SYSTEM_PROMPT}\nEditable DOCX blocks:\n\`\`\`json\n${renderEditableBlocks(snapshot)}\n\`\`\``;
-  const start = performance.now();
-  const abortController = new AbortController();
-  const abortTimer = setTimeout(
-    () => abortController.abort(),
-    MODEL_REQUEST_TIMEOUT_MS,
-  );
   let finalText = "";
-  let usage: TokenUsage | null = null;
-  let turnError: string | null = null;
-  // `chat()` or its stream can reject mid-turn (adapter error, dropped
-  // connection); this boundary must still report an "error" turn and
-  // always clear the abort timer.
-  try {
-    const stream = chat({
-      abortController,
-      adapter: model.adapter,
-      messages: [{ role: "user", content: request }],
-      agentLoopStrategy: maxIterations(MAX_ITERATIONS),
-      ...systemPromptsPatch({ caching, model, system }),
-      modelOptions: mergeGenerationOptions({
-        caching,
-        model,
-        maxOutputTokens: MAX_OUTPUT_TOKENS,
-        serviceTier: "standard",
-        temperature: 0,
+  const { error, latencyMs, usage } = await runEvalModelTurn({
+    timeoutMs: MODEL_REQUEST_TIMEOUT_MS,
+    chat: (abortController) =>
+      chat({
+        abortController,
+        adapter: model.adapter,
+        messages: [{ role: "user", content: request }],
+        agentLoopStrategy: maxIterations(MAX_ITERATIONS),
+        ...systemPromptsPatch({ caching, model, system }),
+        modelOptions: mergeGenerationOptions({
+          caching,
+          model,
+          maxOutputTokens: MAX_OUTPUT_TOKENS,
+          serviceTier: "standard",
+          temperature: 0,
+        }),
+        tools,
       }),
-      tools,
-    });
-    for await (const chunk of stream) {
+    onChunk: (chunk) => {
       if (chunk.type === EventType.TEXT_MESSAGE_CONTENT) {
         finalText += chunk.delta;
-        continue;
       }
-      if (chunk.type === EventType.RUN_ERROR) {
-        turnError = chunk.message;
-        continue;
-      }
-      if (chunk.type === EventType.RUN_FINISHED) {
-        usage = tokenUsageFromRunFinishedChunk(chunk) ?? null;
-      }
-    }
-  } catch (error: unknown) {
-    turnError = error instanceof Error ? error.message : String(error);
-  } finally {
-    clearTimeout(abortTimer);
-  }
-  return {
-    error: turnError,
-    finalText,
-    latencyMs: Math.round(performance.now() - start),
-    usage,
-  };
+    },
+  });
+  return { error, finalText, latencyMs, usage };
 };
 
 type SuggestChangesFacts = {

--- a/apps/api/evals/template-fill.ts
+++ b/apps/api/evals/template-fill.ts
@@ -57,7 +57,6 @@ import {
   systemPromptsPatch,
 } from "@/api/lib/tanstack-ai-generate";
 import type { ResolvedTanStackTextModel } from "@/api/lib/tanstack-ai-models";
-import { tokenUsageFromRunFinishedChunk } from "@/api/lib/tanstack-ai-usage";
 import {
   fillTemplateDocx,
   type FillTemplateSource,
@@ -65,6 +64,8 @@ import {
 import { isFillableTemplateInputField } from "@/api/lib/templates/template-input-contract";
 import { isTemplateFieldRequired } from "@/api/lib/templates/template-optional-defaults";
 import { mintAuthProviderId } from "@/api/tests/helpers/auth-provider-id";
+
+import { runEvalModelTurn } from "./lib/model-turn";
 
 // A bare id resolves through whichever configured provider rates it (GPT
 // models may come from OpenAI or OpenRouter); Claude ids are pinned to
@@ -805,60 +806,33 @@ const runModelTurn = async ({
     fillCalls,
   });
   const system = `${SYSTEM_PROMPT}\nTemplate id: ${task.fixture.templateId}`;
-  const start = performance.now();
-  const abortController = new AbortController();
-  const abortTimer = setTimeout(
-    () => abortController.abort(),
-    MODEL_REQUEST_TIMEOUT_MS,
-  );
   let finalText = "";
-  let usage: TokenUsage | null = null;
-  let turnError: string | null = null;
-  // `chat()` or the stream it returns can reject mid-turn (adapter error,
-  // dropped connection); a try/finally here is the boundary that must still
-  // report an `EvalRun` with an "error" score and always clear the abort
-  // timer, matching how the other evals' model turns are structured.
-  try {
-    const stream = chat({
-      abortController,
-      adapter: model.adapter,
-      messages: [{ role: "user", content: task.prompt }],
-      agentLoopStrategy: maxIterations(MAX_ITERATIONS),
-      ...systemPromptsPatch({ caching, model, system }),
-      modelOptions: mergeGenerationOptions({
-        caching,
-        model,
-        maxOutputTokens: MAX_OUTPUT_TOKENS,
-        serviceTier: "standard",
-        temperature: 0,
+  const { error, latencyMs, usage } = await runEvalModelTurn({
+    timeoutMs: MODEL_REQUEST_TIMEOUT_MS,
+    chat: (abortController) =>
+      chat({
+        abortController,
+        adapter: model.adapter,
+        messages: [{ role: "user", content: task.prompt }],
+        agentLoopStrategy: maxIterations(MAX_ITERATIONS),
+        ...systemPromptsPatch({ caching, model, system }),
+        modelOptions: mergeGenerationOptions({
+          caching,
+          model,
+          maxOutputTokens: MAX_OUTPUT_TOKENS,
+          serviceTier: "standard",
+          temperature: 0,
+        }),
+        tools,
       }),
-      tools,
-    });
-    for await (const chunk of stream) {
+    onChunk: (chunk) => {
       if (chunk.type === EventType.TEXT_MESSAGE_CONTENT) {
         finalText += chunk.delta;
-        continue;
       }
-      if (chunk.type === EventType.RUN_ERROR) {
-        turnError = chunk.message;
-        continue;
-      }
-      if (chunk.type === EventType.RUN_FINISHED) {
-        usage = tokenUsageFromRunFinishedChunk(chunk) ?? null;
-      }
-    }
-  } catch (error: unknown) {
-    turnError = error instanceof Error ? error.message : String(error);
-  } finally {
-    clearTimeout(abortTimer);
-  }
-  return {
-    turn: {
-      error: turnError,
-      finalText,
-      latencyMs: Math.round(performance.now() - start),
-      usage,
     },
+  });
+  return {
+    turn: { error, finalText, latencyMs, usage },
     trace,
     fillCalls,
   };

--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -397,11 +397,24 @@ const runPreparedTestBatches = async ({
 
 // A fresh process per test batch makes module memory reclaimable. One
 // process for the full suite grows until the hosted runner terminates it.
-const regularExitCode = await runTestBatches({
-  batchSize: REGULAR_TEST_BATCH_SIZE,
+// `evals/` unit tests get their own batches after the `src/` ones so adding
+// one never shifts the composition of a `src/` batch (a shift changes which
+// files share a process, and that has surfaced order-dependent failures).
+const EVALS_TEST_PREFIX = "evals/";
+const regularSrcTests = regularTests.filter(
+  (testPath) => !testPath.startsWith(EVALS_TEST_PREFIX),
+);
+const regularEvalTests = regularTests.filter((testPath) =>
+  testPath.startsWith(EVALS_TEST_PREFIX),
+);
+const regularExitCode = await runPreparedTestBatches({
+  batchStart: 0,
   isolate: false,
   maxPeakRssMb: MAX_LOGIC_BATCH_PEAK_RSS_MB,
-  testFiles: regularTests,
+  testBatches: [
+    ...composeTestBatches(regularSrcTests, REGULAR_TEST_BATCH_SIZE),
+    ...composeTestBatches(regularEvalTests, REGULAR_TEST_BATCH_SIZE),
+  ],
 });
 if (regularExitCode !== 0) {
   process.exit(regularExitCode);

--- a/apps/api/scripts/run-tests.ts
+++ b/apps/api/scripts/run-tests.ts
@@ -22,7 +22,10 @@ import {
 import { partitionRunnerArguments, selectTestPaths } from "./test-path-filters";
 
 const PROPERTY_FLAG = "--property";
-const TEST_FILE_GLOB = "src/**/*.test.{ts,tsx}";
+// `evals/` carries only its own colocated unit tests (e.g.
+// `evals/lib/model-turn.test.ts`), never the eval scripts themselves, which
+// call paid models and run on demand.
+const TEST_FILE_GLOB = "{src,evals}/**/*.test.{ts,tsx}";
 // Non-test helper modules live here; some install a module mock at import.
 const TEST_HELPER_GLOB = "src/tests/**/*.ts";
 const MODULE_MOCK_PATTERN = /\bmock\.module\s*\(/u;


### PR DESCRIPTION
The create-document and suggest_changes evals let a rejected \`chat()\` stream escape \`runModelTurn\`, aborting the whole run and leaking the abort timer. Both now catch at that boundary, record the failure as the turn's \`error\`, and clear the timer in \`finally\`, matching the template-fill eval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation runs by consistently handling stream errors, timeouts, latency, and token usage.
  * Ensured timers are cleared reliably when model responses complete or fail.

* **Tests**
  * Added coverage for successful responses, partial responses followed by errors, and reported run errors.
  * Included evaluation tests in the standard test process, with dedicated sequential batching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->