### PR TITLE
fix(properties): make the AI property scope converge in the database

### DIFF
--- a/apps/api/drizzle/20260902123000_properties_kinds_convergence/migration.sql
+++ b/apps/api/drizzle/20260902123000_properties_kinds_convergence/migration.sql
@@ -1,0 +1,33 @@
+SET LOCAL lock_timeout = '1s';--> statement-breakpoint
+SET LOCAL statement_timeout = '60s';--> statement-breakpoint
+
+-- An AI-extracted property (ai-model, playbook-verdict) can only ever hold
+-- a value on a document, so its scope is derived, never chosen. The
+-- application derives it on every write path, but during a rolling deploy an
+-- older process may still insert or update a row with a null scope after the
+-- one-shot backfill ran. This trigger makes the rule converge in the
+-- database regardless of which writer runs: a null scope on an AI tool is
+-- rewritten to documents before the row lands. Explicit scopes are left as
+-- they are.
+CREATE OR REPLACE FUNCTION "derive_property_kinds"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW."kinds" IS NULL AND (NEW."tool"->>'type') IN ('ai-model', 'playbook-verdict') THEN
+    NEW."kinds" := ARRAY['document']::varchar(64)[];
+  END IF;
+  RETURN NEW;
+END;
+$$;--> statement-breakpoint
+
+CREATE TRIGGER "properties_derive_kinds"
+BEFORE INSERT OR UPDATE OF "kinds", "tool" ON "properties"
+FOR EACH ROW
+EXECUTE FUNCTION "derive_property_kinds"();--> statement-breakpoint
+
+-- Rows written between the first backfill and this trigger.
+UPDATE "properties"
+   SET "kinds" = ARRAY['document']::varchar(64)[]
+ WHERE "kinds" IS NULL
+   AND "tool"->>'type' IN ('ai-model', 'playbook-verdict');

--- a/apps/api/src/handlers/properties/update.ts
+++ b/apps/api/src/handlers/properties/update.ts
@@ -36,7 +36,7 @@ import {
   PROPERTY_DEPENDENCY_LIMITS,
   propertyDependencyReadLimit,
 } from "@/api/lib/properties/dependency-limits";
-import { propertyKindsForTool } from "@/api/lib/properties/property-kinds";
+import { propertyKindsForUpdate } from "@/api/lib/properties/property-kinds";
 import { lockWorkspacePropertyWrites } from "@/api/lib/properties/property-lock";
 
 type PropertyWithDeps = {
@@ -304,6 +304,7 @@ const updateProperty = createSafeHandler(
             name: properties.name,
             content: properties.content,
             tool: properties.tool,
+            kinds: properties.kinds,
             role: properties.role,
             status: properties.status,
             playbookSourceId: properties.playbookSourceId,
@@ -460,7 +461,10 @@ const updateProperty = createSafeHandler(
             name,
             content,
             tool: dbTool,
-            kinds: propertyKindsForTool(dbTool),
+            kinds: propertyKindsForUpdate({
+              previous: oldProperty,
+              next: dbTool,
+            }),
             role: nextRole,
             status: isStale ? "stale" : "fresh",
           })

--- a/apps/api/src/lib/properties/property-kinds.test.ts
+++ b/apps/api/src/lib/properties/property-kinds.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { propertyKindsForTool } from "@/api/lib/properties/property-kinds";
+import {
+  propertyKindsForTool,
+  propertyKindsForUpdate,
+} from "@/api/lib/properties/property-kinds";
 
 // PropertyTool (apps/api/src/db/schema-validators.ts) is a union of three
 // TypeBox object schemas, not a const array of tool types, so there is no
@@ -21,5 +24,48 @@ describe("propertyKindsForTool", () => {
 
   test("manual-input applies to every kind", () => {
     expect(propertyKindsForTool({ type: "manual-input" })).toBeNull();
+  });
+});
+
+describe("propertyKindsForUpdate", () => {
+  const manual = { version: 1, type: "manual-input" } as const;
+
+  test("a manual property keeps its stored scope across a manual update", () => {
+    expect(
+      propertyKindsForUpdate({
+        previous: { tool: manual, kinds: ["document"] },
+        next: manual,
+      }),
+    ).toEqual(["document"]);
+  });
+
+  test("an unscoped manual property stays unscoped", () => {
+    expect(
+      propertyKindsForUpdate({
+        previous: { tool: manual, kinds: null },
+        next: manual,
+      }),
+    ).toBeNull();
+  });
+
+  test("switching a manual property to an AI tool narrows it to documents", () => {
+    expect(
+      propertyKindsForUpdate({
+        previous: { tool: manual, kinds: null },
+        next: { type: "ai-model" },
+      }),
+    ).toEqual(["document"]);
+  });
+
+  test("switching an AI property to manual input re-derives an open scope", () => {
+    expect(
+      propertyKindsForUpdate({
+        previous: {
+          tool: { version: 1, type: "ai-model", prompt: "" },
+          kinds: ["document"],
+        },
+        next: manual,
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/api/src/lib/properties/property-kinds.ts
+++ b/apps/api/src/lib/properties/property-kinds.ts
@@ -1,5 +1,6 @@
 import type { EntityKind } from "@stll/api-contract";
 
+import type { properties } from "@/api/db/schema";
 import type { PropertyTool } from "@/api/db/schema-validators";
 
 /**
@@ -29,3 +30,25 @@ export const propertyKindsForTool = (
       return tool.type satisfies never;
   }
 };
+
+type PropertyKindsForUpdateParams = {
+  /** The stored row before the update: its tool and its stored scope. */
+  previous: Pick<typeof properties.$inferSelect, "kinds" | "tool">;
+  /** The tool the update writes. */
+  next: Pick<PropertyTool, "type">;
+};
+
+/**
+ * The scope an update writes. A manual-input property keeps whatever scope
+ * it already stores: only server code ever narrows a manual property (the
+ * workspace's system file property is created with `["document"]`), and a
+ * rename must not widen it to every kind. Any change of tool type re-derives
+ * the scope from the new tool.
+ */
+export const propertyKindsForUpdate = ({
+  previous,
+  next,
+}: PropertyKindsForUpdateParams): EntityKind[] | null =>
+  next.type === "manual-input" && previous.tool.type === "manual-input"
+    ? previous.kinds
+    : propertyKindsForTool(next);

--- a/apps/api/src/lib/views/template-properties.ts
+++ b/apps/api/src/lib/views/template-properties.ts
@@ -22,6 +22,7 @@ import {
   assertPropertyDependencyReadWithinLimit,
   propertyDependencyReadLimit,
 } from "@/api/lib/properties/dependency-limits";
+import { propertyKindsForTool } from "@/api/lib/properties/property-kinds";
 import { lockWorkspacePropertyWrites } from "@/api/lib/properties/property-lock";
 import { brandPersistedPropertyId } from "@/api/lib/safe-id-boundaries";
 import { sortDeep } from "@/api/lib/sort-deep";
@@ -342,6 +343,7 @@ export const resolveTemplateProperties = async ({
         name: templateProperty.name,
         content: templateProperty.content,
         tool: sanitizeTemplatePropertyTool(templateProperty.tool),
+        kinds: propertyKindsForTool(templateProperty.tool),
         role: resolveTemplatePropertyRole(templateProperty, roleResolution),
         status: templateProperty.tool.type === "ai-model" ? "stale" : "fresh",
       })

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.test.ts
@@ -159,6 +159,22 @@ describe("view entity kinds", () => {
       ]),
     ).toEqual(["task"]);
   });
+  test("an empty or group leaves the view unrestricted", () => {
+    expect(
+      viewEntityKinds([{ type: "group", combinator: "or", children: [] }]),
+    ).toBeNull();
+    expect(
+      viewEntityKinds([
+        {
+          type: "predicate",
+          operand: { type: "kind" },
+          op: "in",
+          value: ["task"],
+        },
+        { type: "group", combinator: "or", children: [] },
+      ]),
+    ).toEqual(["task"]);
+  });
 });
 
 describe("List view detection", () => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
@@ -91,10 +91,18 @@ const admittedKindsForAnd = (
   return result;
 };
 
-/** Union of children, but only when every child is itself restricted. */
+/**
+ * Union of children, but only when every child is itself restricted. An `or`
+ * with no children admits everything: the filter builder can leave such a
+ * group behind after its last child is removed, and the query compiler drops
+ * it, so the view is unrestricted.
+ */
 const admittedKindsForOr = (
   nodes: readonly ConditionNode[],
 ): ReadonlySet<EntityKind> | null => {
+  if (nodes.length === 0) {
+    return null;
+  }
   const kinds = new Set<EntityKind>();
   for (const node of nodes) {
     const childKinds = admittedKinds(node);


### PR DESCRIPTION
## Summary

Addresses the four Codex findings on #2810.

- **P1, backfill race during rolling deploy.** Migration `20260902123000_properties_kinds_convergence` adds a `BEFORE INSERT OR UPDATE OF kinds, tool` trigger that sets `kinds = [document]` whenever an `ai-model` or `playbook-verdict` row arrives with a null scope, then re-runs the backfill behind it. The rule now converges regardless of which process writes; the application-side derivation stays as the explicit, typed path. `check-migration-safety` and `squawk` clean.
- **P2, template-created properties.** `lib/views/template-properties.ts` derives `kinds` through `propertyKindsForTool` like every other writer.
- **P2, manual update widened explicit scopes.** `propertyKindsForUpdate` keeps the stored scope when a manual property stays manual (the system file property keeps `[document]` across a rename) and re-derives it on any tool change. The update handler now selects `kinds` for that. Four unit tests.
- **P2, empty `or` group.** `viewEntityKinds` treats an `or` with no children as unrestricted, matching the query compiler that drops it. Test added.

## Verification

API and web typechecks clean on the touched files; type-aware oxlint and oxfmt clean; `bun test` on property-kinds (7), view-kind-filters (11), and `lib/views`.