### PR TITLE
fix(views): a dropped filter group never widens the kinds a view admits

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.test.ts
@@ -175,6 +175,58 @@ describe("view entity kinds", () => {
       ]),
     ).toEqual(["task"]);
   });
+
+  test("a dropped group inside an or does not widen its siblings", () => {
+    // The query compiler discards the empty group and keeps the task
+    // restriction, so the view can only return tasks.
+    expect(
+      viewEntityKinds([
+        {
+          type: "group",
+          combinator: "or",
+          children: [
+            {
+              type: "predicate",
+              operand: { type: "kind" },
+              op: "in",
+              value: ["task"],
+            },
+            { type: "group", combinator: "or", children: [] },
+          ],
+        },
+      ]),
+    ).toEqual(["task"]);
+  });
+
+  test("a group whose children are all dropped is dropped itself", () => {
+    expect(
+      viewEntityKinds([
+        {
+          type: "group",
+          combinator: "and",
+          children: [
+            { type: "group", combinator: "or", children: [] },
+            { type: "group", combinator: "and", negated: true, children: [] },
+          ],
+        },
+      ]),
+    ).toBeNull();
+    expect(
+      viewEntityKinds([
+        {
+          type: "predicate",
+          operand: { type: "kind" },
+          op: "in",
+          value: ["message"],
+        },
+        {
+          type: "group",
+          combinator: "or",
+          children: [{ type: "group", combinator: "or", children: [] }],
+        },
+      ]),
+    ).toEqual(["message"]);
+  });
 });
 
 describe("List view detection", () => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-kind-filters.ts
@@ -14,24 +14,43 @@ export const includesListItems = (filters: readonly ConditionNode[]): boolean =>
 /**
  * The entity kinds a view's filters admit, read from its `kind in […]`
  * predicates, or `null` when the view does not provably restrict the kind.
- * An `and` intersects the sets its restricted children admit (an unrestricted
- * child is ignored, not treated as "everything"); an `or` is restricted only
- * when every child is, and is then their union. A negated group, and any
- * predicate or compare node other than `kind in […]`, is treated as
- * unrestricted: we do not compute the complement a negation would admit.
+ *
+ * The rules mirror how the API compiles a filter to SQL: a group with no
+ * compiled children is dropped, and never counts as a restriction or as an
+ * "everything" branch of its parent; an `and` intersects the sets its
+ * restricted children admit (an unrestricted child is ignored); an `or` is
+ * restricted only when every remaining child is, and is then their union;
+ * a negated group, and any predicate or compare node other than
+ * `kind in […]`, is unrestricted: we do not compute the complement a negation
+ * would admit.
  */
 export const viewEntityKinds = (
   filters: readonly ConditionNode[],
 ): readonly EntityKind[] | null => {
-  const kinds = admittedKindsForAnd(filters);
-  return kinds ? [...kinds] : null;
+  const admitted = admittedKindsForAnd(filters);
+  return admitted.type === "kinds" ? [...admitted.kinds] : null;
 };
 
-/** The kinds a single condition node admits, or `null` when unrestricted. */
-const admittedKinds = (node: ConditionNode): ReadonlySet<EntityKind> | null => {
+/**
+ * What a node contributes to the kinds a view admits. `dropped` is a node
+ * the query compiler discards (an empty group, recursively), which must not
+ * be confused with `unrestricted`: an `or` over a task restriction and a
+ * dropped group still shows only tasks.
+ */
+type AdmittedKinds =
+  | { type: "dropped" }
+  | { type: "unrestricted" }
+  | { type: "kinds"; kinds: ReadonlySet<EntityKind> };
+
+const DROPPED = { type: "dropped" } as const satisfies AdmittedKinds;
+const UNRESTRICTED = {
+  type: "unrestricted",
+} as const satisfies AdmittedKinds;
+
+const admittedKinds = (node: ConditionNode): AdmittedKinds => {
   switch (node.type) {
     case "compare":
-      return null;
+      return UNRESTRICTED;
     case "predicate":
       return admittedKindsForPredicate(node);
     case "group":
@@ -41,15 +60,13 @@ const admittedKinds = (node: ConditionNode): ReadonlySet<EntityKind> | null => {
   }
 };
 
-const admittedKindsForPredicate = (
-  node: PredicateNode,
-): ReadonlySet<EntityKind> | null => {
+const admittedKindsForPredicate = (node: PredicateNode): AdmittedKinds => {
   if (
     node.operand.type !== "kind" ||
     node.op !== "in" ||
     !Array.isArray(node.value)
   ) {
-    return null;
+    return UNRESTRICTED;
   }
   const kinds = new Set<EntityKind>();
   for (const value of node.value) {
@@ -57,63 +74,59 @@ const admittedKindsForPredicate = (
       kinds.add(value);
     }
   }
-  return kinds;
+  return { type: "kinds", kinds };
 };
 
-const admittedKindsForGroup = (
-  node: GroupNode,
-): ReadonlySet<EntityKind> | null => {
+const admittedKindsForGroup = (node: GroupNode): AdmittedKinds => {
+  const children = node.children
+    .map(admittedKinds)
+    .filter((child) => child.type !== "dropped");
+  if (children.length === 0) {
+    return DROPPED;
+  }
   if (node.negated) {
-    return null;
+    return UNRESTRICTED;
   }
   switch (node.combinator) {
     case "and":
-      return admittedKindsForAnd(node.children);
+      return combineAnd(children);
     case "or":
-      return admittedKindsForOr(node.children);
+      return combineOr(children);
     default:
       return node.combinator satisfies never;
   }
 };
 
+/** The implicit `and` over a filter list; an all-dropped list restricts nothing. */
+const admittedKindsForAnd = (nodes: readonly ConditionNode[]): AdmittedKinds =>
+  combineAnd(
+    nodes.map(admittedKinds).filter((child) => child.type !== "dropped"),
+  );
+
 /** Intersection of restricted children; unrestricted children are ignored. */
-const admittedKindsForAnd = (
-  nodes: readonly ConditionNode[],
-): ReadonlySet<EntityKind> | null => {
+const combineAnd = (children: readonly AdmittedKinds[]): AdmittedKinds => {
   let result: ReadonlySet<EntityKind> | null = null;
-  for (const node of nodes) {
-    const childKinds = admittedKinds(node);
-    if (!childKinds) {
+  for (const child of children) {
+    if (child.type !== "kinds") {
       continue;
     }
-    result = result ? intersect(result, childKinds) : childKinds;
+    result = result ? intersect(result, child.kinds) : child.kinds;
   }
-  return result;
+  return result ? { type: "kinds", kinds: result } : UNRESTRICTED;
 };
 
-/**
- * Union of children, but only when every child is itself restricted. An `or`
- * with no children admits everything: the filter builder can leave such a
- * group behind after its last child is removed, and the query compiler drops
- * it, so the view is unrestricted.
- */
-const admittedKindsForOr = (
-  nodes: readonly ConditionNode[],
-): ReadonlySet<EntityKind> | null => {
-  if (nodes.length === 0) {
-    return null;
-  }
+/** Union of children, but only when every child is itself restricted. */
+const combineOr = (children: readonly AdmittedKinds[]): AdmittedKinds => {
   const kinds = new Set<EntityKind>();
-  for (const node of nodes) {
-    const childKinds = admittedKinds(node);
-    if (!childKinds) {
-      return null;
+  for (const child of children) {
+    if (child.type !== "kinds") {
+      return UNRESTRICTED;
     }
-    for (const kind of childKinds) {
+    for (const kind of child.kinds) {
       kinds.add(kind);
     }
   }
-  return kinds;
+  return { type: "kinds", kinds };
 };
 
 const intersect = (


### PR DESCRIPTION
## Summary

Addresses the Codex finding on #2814: `or(kind in [task], empty-or)` returned `null` because the empty child was read as "unrestricted", while the API's `compileGroup` drops it and keeps the task restriction.

- `viewEntityKinds` now folds a three-state result (`dropped`, `unrestricted`, restricted set) that mirrors `compileGroup`: a group's dropped children are filtered out before the combinator is applied, and a group with no remaining children is `dropped` for its parent. An all-dropped top-level list is unrestricted.
- Tests: dropped group inside an `or` keeps the sibling's restriction; a group whose children are all dropped is dropped itself; a nested all-dropped `or` next to a message restriction still admits only messages. 13 tests pass.

## Note

This is the third divergence found between this helper and the compiler. The durable fix is to expose the compiler's pruning as a shared helper in `@stll/conditions` so both sides share one implementation. Filed as a follow-up.
