### PR TITLE
chore(api): check every resource projection against its table in both directions

### DIFF
--- a/apps/api/src/handlers/contacts/list-query.ts
+++ b/apps/api/src/handlers/contacts/list-query.ts
@@ -13,7 +13,48 @@ import {
   encodePaginationCursor,
   isUuidPaginationCursorPart,
 } from "@/api/lib/pagination";
+import type {
+  UnbackedProjectionKeys,
+  UnprojectedColumns,
+} from "@/api/lib/projection-totality";
 import { brandPersistedContactId } from "@/api/lib/safe-id-boundaries";
+
+type ContactRow = typeof contacts.$inferSelect;
+
+// Columns intentionally not sent by this page. The address book is a
+// directory summary, not the full contact record — `contacts.get` returns
+// the rest. A new schema column must either be added to the `.select()`
+// below or added here with a reason, or the totality check further down
+// fails to typecheck.
+const UNPROJECTED_CONTACT_LIST_COLUMNS = [
+  // Tenant scope, implied by the caller's active organization.
+  "organizationId",
+  // Person-only fields the directory summary omits; full detail is on
+  // contacts.get.
+  "prefix",
+  "middleName",
+  "suffix",
+  // Free-text notes are a detail-view field, not a directory summary field.
+  "notes",
+  "addresses",
+  "metadata",
+  // Billing fields belong to the invoicing surface, not the address-book
+  // summary; contacts.get returns them.
+  "registrationNumber",
+  "taxId",
+  "bankAccounts",
+  "billingAddress",
+  "defaultHourlyRate",
+  "currency",
+  "paymentTermDays",
+  // Attorney assignment surfaces on the matter (workspace) contact fields,
+  // not the standalone directory row.
+  "originatingAttorneyId",
+  "responsibleAttorneyId",
+  // Authorship/edit metadata is a detail-view field.
+  "createdBy",
+  "updatedAt",
+] as const satisfies readonly (keyof ContactRow)[];
 
 type ListContactsQuery = {
   cursor?: string;
@@ -77,6 +118,42 @@ const decodeCursor = (cursor: string): DecodedCursor | null => {
 
 const encodeCursor = (displayName: string, id: string): string =>
   encodePaginationCursor([displayName, id]);
+
+// The shape the `.select({...})` below must project, plus the one
+// aggregate (`clientMatterCount`) that traces back to no single column.
+type ContactListItem = Pick<
+  ContactRow,
+  | "id"
+  | "type"
+  | "displayName"
+  | "firstName"
+  | "lastName"
+  | "organizationName"
+  | "emails"
+  | "phones"
+  | "tags"
+  | "color"
+  | "createdAt"
+> & { clientMatterCount: number };
+
+// Totality guard, bidirectional: every schema column must be projected onto
+// the response or explicitly excused above, and the projection cannot carry
+// a field that traces back to no real column, aside from the join-derived
+// `clientMatterCount`.
+type MissingProjectedContactListColumn = UnprojectedColumns<
+  ContactRow,
+  ContactListItem,
+  (typeof UNPROJECTED_CONTACT_LIST_COLUMNS)[number]
+>;
+type UnexpectedProjectedContactListColumn = UnbackedProjectionKeys<
+  ContactRow,
+  Omit<ContactListItem, "clientMatterCount">
+>;
+
+true satisfies MissingProjectedContactListColumn extends never ? true : never;
+true satisfies UnexpectedProjectedContactListColumn extends never
+  ? true
+  : never;
 
 /** One tenant-scoped contact-directory query shared by HTTP and MCP. */
 export const listContactsPage = async ({
@@ -145,8 +222,12 @@ export const listContactsPage = async ({
       .orderBy(contacts.displayName, contacts.id)
       .limit(limit + 1);
 
+    // Ties the `.select({...})` above to `ContactListItem`: if either drops
+    // a field the other still names, this check stops typechecking.
+    const projectedRows = rows satisfies ContactListItem[];
+
     return createCursorPage({
-      rows,
+      rows: projectedRows,
       limit,
       cursorForItem: (item) => encodeCursor(item.displayName, item.id),
     });

--- a/apps/api/src/handlers/notifications/read-model.ts
+++ b/apps/api/src/handlers/notifications/read-model.ts
@@ -12,7 +12,25 @@ import { notifications } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { createTimestampIdCursorCodec } from "@/api/lib/db-pagination";
+import type {
+  UnbackedProjectionKeys,
+  UnprojectedColumns,
+} from "@/api/lib/projection-totality";
 import { brandPersistedNotificationId } from "@/api/lib/safe-id-boundaries";
+
+type NotificationRow = typeof notifications.$inferSelect;
+
+// Columns intentionally not sent to the client.
+const UNPROJECTED_NOTIFICATION_COLUMNS = [
+  // RLS already pins every row to the caller; re-stating it client-side
+  // would be redundant with the identity the client already has.
+  "userId",
+  // The list endpoint scopes to the caller's active organization, which the
+  // client already knows from its own session.
+  "organizationId",
+  // Producer-only dedup key for replay-safe inserts; never read back.
+  "idempotencyKey",
+] as const satisfies readonly (keyof NotificationRow)[];
 
 export const notificationParamsSchema = t.Object({
   notificationId: tSafeId("notification"),
@@ -59,6 +77,24 @@ export const toNotificationListItem = (row: {
   readAt: row.readAt?.toISOString() ?? null,
   createdAt: row.createdAt.toISOString(),
 });
+
+// Totality guard, bidirectional: every schema column must be projected onto
+// the response or explicitly excused above, and the projection cannot carry
+// a field that traces back to no real column.
+type MissingProjectedNotificationColumn = UnprojectedColumns<
+  NotificationRow,
+  NotificationListItem,
+  (typeof UNPROJECTED_NOTIFICATION_COLUMNS)[number]
+>;
+type UnexpectedProjectedNotificationColumn = UnbackedProjectionKeys<
+  NotificationRow,
+  NotificationListItem
+>;
+
+true satisfies MissingProjectedNotificationColumn extends never ? true : never;
+true satisfies UnexpectedProjectedNotificationColumn extends never
+  ? true
+  : never;
 
 /**
  * Unread notifications for one user in one organization.

--- a/apps/api/src/handlers/playbooks/read.ts
+++ b/apps/api/src/handlers/playbooks/read.ts
@@ -13,9 +13,73 @@ import {
   encodePaginationCursor,
   isUuidPaginationCursorPart,
 } from "@/api/lib/pagination";
+import type {
+  UnbackedProjectionKeys,
+  UnprojectedColumns,
+} from "@/api/lib/projection-totality";
 import { brandPersistedPlaybookDefinitionId } from "@/api/lib/safe-id-boundaries";
 
+type PlaybookDefinitionRow = typeof playbookDefinitions.$inferSelect;
+
 // ── List ────────────────────────────────────────────
+
+// Columns intentionally not sent by the list summary. A new schema column
+// must either be projected by `toPlaybookDefinitionListItem` below or added
+// here with a reason, or the totality check further down fails to
+// typecheck.
+const UNPROJECTED_PLAYBOOK_LIST_COLUMNS = [
+  // Tenant scope, implied by the caller's active organization.
+  "organizationId",
+  // Server-only bundled-starter correlation id; never read back (see the
+  // `starterId` doc comment on the schema column).
+  "starterId",
+  // unprojected as of 2026-09-02; review — the config description below
+  // claims this list carries "scope ... and approval metadata", but neither
+  // `scope`/`positions` nor `approvedAt`/`approvedBy` are actually selected
+  // or mapped here. Full detail is available via playbooks.get; flagging
+  // rather than silently adding fields that may not belong on the summary.
+  "scope",
+  "positions",
+  "approvedAt",
+  "approvedBy",
+] as const satisfies readonly (keyof PlaybookDefinitionRow)[];
+
+// The shape the list `.select({...})` below must project.
+type PlaybookDefinitionListRow = Pick<
+  PlaybookDefinitionRow,
+  "id" | "name" | "description" | "status" | "createdAt" | "updatedAt"
+>;
+
+const toPlaybookDefinitionListItem = (row: PlaybookDefinitionListRow) => ({
+  id: row.id,
+  name: row.name,
+  description: row.description,
+  status: row.status,
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+});
+
+type PlaybookDefinitionListItem = ReturnType<
+  typeof toPlaybookDefinitionListItem
+>;
+
+// Totality guard, bidirectional: every schema column must be projected onto
+// the response or explicitly excused above, and the projection cannot carry
+// a field that traces back to no real column.
+type MissingProjectedPlaybookListColumn = UnprojectedColumns<
+  PlaybookDefinitionRow,
+  PlaybookDefinitionListItem,
+  (typeof UNPROJECTED_PLAYBOOK_LIST_COLUMNS)[number]
+>;
+type UnexpectedProjectedPlaybookListColumn = UnbackedProjectionKeys<
+  PlaybookDefinitionRow,
+  PlaybookDefinitionListItem
+>;
+
+true satisfies MissingProjectedPlaybookListColumn extends never ? true : never;
+true satisfies UnexpectedProjectedPlaybookListColumn extends never
+  ? true
+  : never;
 
 export const listPlaybookDefinitionsQuerySchema = t.Object({
   limit: t.Optional(
@@ -129,18 +193,74 @@ export const listPlaybookDefinitionsHandler = async function* ({
 
   return Result.ok({
     ...page,
-    items: page.items.map((row) => ({
-      id: row.id,
-      name: row.name,
-      description: row.description,
-      status: row.status,
-      createdAt: row.createdAt.toISOString(),
-      updatedAt: row.updatedAt.toISOString(),
-    })),
+    items: page.items.map(toPlaybookDefinitionListItem),
   });
 };
 
 // ── Get ─────────────────────────────────────────────
+
+// Columns intentionally not sent by the detail read. A new schema column
+// must either be projected by `toPlaybookDefinitionDetail` below or added
+// here with a reason, or the totality check further down fails to
+// typecheck.
+const UNPROJECTED_PLAYBOOK_DETAIL_COLUMNS = [
+  // Tenant scope, implied by the caller's active organization.
+  "organizationId",
+  // Server-only bundled-starter correlation id; never read back.
+  "starterId",
+  // unprojected as of 2026-09-02; review — set on approval
+  // (`playbooks/approve.ts`) but never read back to the client anywhere;
+  // possibly a real gap ("approved by whom") rather than deliberate.
+  "approvedBy",
+] as const satisfies readonly (keyof PlaybookDefinitionRow)[];
+
+// The shape the get `columns: {...}` query below must project.
+type PlaybookDefinitionDetailRow = Pick<
+  PlaybookDefinitionRow,
+  | "id"
+  | "name"
+  | "description"
+  | "scope"
+  | "positions"
+  | "status"
+  | "approvedAt"
+  | "createdAt"
+  | "updatedAt"
+>;
+
+const toPlaybookDefinitionDetail = (row: PlaybookDefinitionDetailRow) => ({
+  id: row.id,
+  name: row.name,
+  description: row.description,
+  scope: row.scope,
+  positions: row.positions,
+  status: row.status,
+  approvedAt: row.approvedAt ? row.approvedAt.toISOString() : null,
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+});
+
+type PlaybookDefinitionDetail = ReturnType<typeof toPlaybookDefinitionDetail>;
+
+// Totality guard, bidirectional: every schema column must be projected onto
+// the response or explicitly excused above, and the projection cannot carry
+// a field that traces back to no real column.
+type MissingProjectedPlaybookDetailColumn = UnprojectedColumns<
+  PlaybookDefinitionRow,
+  PlaybookDefinitionDetail,
+  (typeof UNPROJECTED_PLAYBOOK_DETAIL_COLUMNS)[number]
+>;
+type UnexpectedProjectedPlaybookDetailColumn = UnbackedProjectionKeys<
+  PlaybookDefinitionRow,
+  PlaybookDefinitionDetail
+>;
+
+true satisfies MissingProjectedPlaybookDetailColumn extends never
+  ? true
+  : never;
+true satisfies UnexpectedProjectedPlaybookDetailColumn extends never
+  ? true
+  : never;
 
 type GetPlaybookDefinitionProps = {
   safeDb: SafeDb;
@@ -181,15 +301,5 @@ export const getPlaybookDefinitionHandler = async function* ({
     );
   }
 
-  return Result.ok({
-    id: playbook.id,
-    name: playbook.name,
-    description: playbook.description,
-    scope: playbook.scope,
-    positions: playbook.positions,
-    status: playbook.status,
-    approvedAt: playbook.approvedAt ? playbook.approvedAt.toISOString() : null,
-    createdAt: playbook.createdAt.toISOString(),
-    updatedAt: playbook.updatedAt.toISOString(),
-  });
+  return Result.ok(toPlaybookDefinitionDetail(playbook));
 };

--- a/apps/api/src/handlers/properties/list.ts
+++ b/apps/api/src/handlers/properties/list.ts
@@ -5,6 +5,10 @@ import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { LIMITS } from "@/api/lib/limits";
 import { deserializeAITool } from "@/api/lib/markdown/ai-tool";
+import type {
+  UnbackedProjectionKeys,
+  UnprojectedColumns,
+} from "@/api/lib/projection-totality";
 
 type PropertyRow = typeof properties.$inferSelect;
 
@@ -26,8 +30,6 @@ const UNPROJECTED_PROPERTY_COLUMNS = [
   "playbookSourceId",
   "playbookDefinitionId",
 ] as const satisfies readonly (keyof PropertyRow)[];
-
-type UnprojectedPropertyColumn = (typeof UNPROJECTED_PROPERTY_COLUMNS)[number];
 
 const toPropertyListItem = (
   property: PropertyRow,
@@ -75,21 +77,17 @@ const toPropertyListItem = (
 
 type PropertyListItem = ReturnType<typeof toPropertyListItem>;
 
-type ProjectedPropertyColumn = Exclude<
-  keyof PropertyRow,
-  UnprojectedPropertyColumn
->;
-
 // Totality guard, bidirectional: every schema column must be projected onto
 // the response or explicitly excused above, and the projection cannot carry
 // a field that traces back to no real column.
-type MissingProjectedPropertyColumn = Exclude<
-  ProjectedPropertyColumn,
-  keyof PropertyListItem
+type MissingProjectedPropertyColumn = UnprojectedColumns<
+  PropertyRow,
+  PropertyListItem,
+  (typeof UNPROJECTED_PROPERTY_COLUMNS)[number]
 >;
-type UnexpectedProjectedPropertyColumn = Exclude<
-  keyof PropertyListItem,
-  ProjectedPropertyColumn
+type UnexpectedProjectedPropertyColumn = UnbackedProjectionKeys<
+  PropertyRow,
+  PropertyListItem
 >;
 
 true satisfies MissingProjectedPropertyColumn extends never ? true : never;

--- a/apps/api/src/handlers/saved-searches/response.ts
+++ b/apps/api/src/handlers/saved-searches/response.ts
@@ -1,11 +1,45 @@
 import type { savedSearches } from "@/api/db/schema";
+import type {
+  UnbackedProjectionKeys,
+  UnprojectedColumns,
+} from "@/api/lib/projection-totality";
 
-export const toSavedSearchResponse = (
-  savedSearch: typeof savedSearches.$inferSelect,
-) => ({
+type SavedSearchRow = typeof savedSearches.$inferSelect;
+
+// Columns intentionally not sent to the client.
+const UNPROJECTED_SAVED_SEARCH_COLUMNS = [
+  // The list endpoint scopes to the caller's active organization, which the
+  // client already knows from its own session.
+  "organizationId",
+  // Saved searches are private to the caller; the owner id is redundant with
+  // the identity the client already has.
+  "userId",
+] as const satisfies readonly (keyof SavedSearchRow)[];
+
+export const toSavedSearchResponse = (savedSearch: SavedSearchRow) => ({
   id: savedSearch.id,
   name: savedSearch.name,
   criteria: savedSearch.criteria,
   createdAt: savedSearch.createdAt.toISOString(),
   updatedAt: savedSearch.updatedAt.toISOString(),
 });
+
+type SavedSearchResponse = ReturnType<typeof toSavedSearchResponse>;
+
+// Totality guard, bidirectional: every schema column must be projected onto
+// the response or explicitly excused above, and the projection cannot carry
+// a field that traces back to no real column.
+type MissingProjectedSavedSearchColumn = UnprojectedColumns<
+  SavedSearchRow,
+  SavedSearchResponse,
+  (typeof UNPROJECTED_SAVED_SEARCH_COLUMNS)[number]
+>;
+type UnexpectedProjectedSavedSearchColumn = UnbackedProjectionKeys<
+  SavedSearchRow,
+  SavedSearchResponse
+>;
+
+true satisfies MissingProjectedSavedSearchColumn extends never ? true : never;
+true satisfies UnexpectedProjectedSavedSearchColumn extends never
+  ? true
+  : never;

--- a/apps/api/src/handlers/skills/comments/list.ts
+++ b/apps/api/src/handlers/skills/comments/list.ts
@@ -9,6 +9,57 @@ import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
+import type {
+  UnbackedProjectionKeys,
+  UnprojectedColumns,
+} from "@/api/lib/projection-totality";
+
+type AgentSkillCommentRow = typeof agentSkillComments.$inferSelect;
+
+// Columns intentionally not sent to the client.
+const UNPROJECTED_SKILL_COMMENT_COLUMNS = [
+  // The route is already scoped to one skill via params.skillId; restating
+  // it per-comment would be redundant.
+  "skillId",
+  // Tenant scope, implied by the caller's active organization.
+  "organizationId",
+] as const satisfies readonly (keyof AgentSkillCommentRow)[];
+
+// The shape the `.select({...})` below must project. Kept as an explicit
+// type (rather than derived) so the totality guard has something concrete
+// to check both directions against.
+type SkillCommentListItem = Pick<
+  AgentSkillCommentRow,
+  | "id"
+  | "revisionId"
+  | "proposalId"
+  | "rangeStart"
+  | "rangeEnd"
+  | "anchorText"
+  | "body"
+  | "authorId"
+  | "resolvedAt"
+  | "resolvedBy"
+  | "createdAt"
+>;
+
+// Totality guard, bidirectional: every schema column must be projected onto
+// the response or explicitly excused above, and the projection cannot carry
+// a field that traces back to no real column.
+type MissingProjectedSkillCommentColumn = UnprojectedColumns<
+  AgentSkillCommentRow,
+  SkillCommentListItem,
+  (typeof UNPROJECTED_SKILL_COMMENT_COLUMNS)[number]
+>;
+type UnexpectedProjectedSkillCommentColumn = UnbackedProjectionKeys<
+  AgentSkillCommentRow,
+  SkillCommentListItem
+>;
+
+true satisfies MissingProjectedSkillCommentColumn extends never ? true : never;
+true satisfies UnexpectedProjectedSkillCommentColumn extends never
+  ? true
+  : never;
 
 const listSkillCommentsParamsSchema = t.Object({
   skillId: tSafeId("agentSkill"),
@@ -67,7 +118,12 @@ const listSkillComments = createSafeRootHandler(
       }),
     );
 
-    return Result.ok({ items });
+    // Ties the `.select({...})` above to `SkillCommentListItem`: if either
+    // drops a field the other still names, this assignment stops
+    // typechecking.
+    const projectedItems = items satisfies SkillCommentListItem[];
+
+    return Result.ok({ items: projectedItems });
   },
 );
 

--- a/apps/api/src/handlers/templates/list.ts
+++ b/apps/api/src/handlers/templates/list.ts
@@ -17,7 +17,41 @@ import {
   encodePaginationCursor,
   isUuidPaginationCursorPart,
 } from "@/api/lib/pagination";
+import type {
+  UnbackedProjectionKeys,
+  UnprojectedColumns,
+} from "@/api/lib/projection-totality";
 import { brandPersistedTemplateId } from "@/api/lib/safe-id-boundaries";
+
+type TemplateRow = typeof templates.$inferSelect;
+
+// Columns intentionally not sent by this page. A new schema column must
+// either be added to the `.select()` below or added here with a reason, or
+// the totality check further down fails to typecheck.
+const UNPROJECTED_TEMPLATE_LIST_COLUMNS = [
+  // Tenant scope, implied by the caller's active organization.
+  "organizationId",
+  // Document vs report discriminator: as of 2026-09-02 nothing filters or
+  // surfaces `kind` on this list (or on templates.get), so a "report" kind
+  // template is indistinguishable from a "document" one here. Flagged as a
+  // real gap for review rather than fixed inline.
+  "kind",
+  // Internal object storage location; never sent to the client.
+  "s3Key",
+  // Large structural manifest, parsed at get-time only; omitted from the
+  // list view for payload size.
+  "manifest",
+  // Internal write-side counter for optimistic content-rotation locking.
+  // The client sees version numbers via templates.versions, not this row.
+  "currentVersion",
+  // Full provenance detail (pack attribution) belongs to the get view;
+  // the list view only ranks/filters by category.
+  "originType",
+  "origin",
+  // Resolved to authorName/authorImage via the member/user join below;
+  // the raw id is not needed client-side.
+  "createdBy",
+] as const satisfies readonly (keyof TemplateRow)[];
 
 const UNCATEGORIZED = "uncategorized" as const;
 
@@ -44,6 +78,46 @@ export const decodeTemplateListCursor = (
 
 export const encodeTemplateListCursor = (id: SafeId<"template">): string =>
   encodePaginationCursor([id]);
+
+// The shape the `.select({...})` below must project, plus the two
+// author-identity fields that come from the joined `user` row rather than
+// from `templates` itself.
+type TemplateListItem = Pick<
+  TemplateRow,
+  | "id"
+  | "name"
+  | "fileName"
+  | "fieldCount"
+  | "sizeBytes"
+  | "categoryId"
+  | "createdAt"
+  | "updatedAt"
+  | "lastUsedAt"
+  | "useCount"
+  | "tags"
+  | "languages"
+  | "whenToUse"
+  | "whenNotToUse"
+> & { authorName: string | null; authorImage: string | null };
+
+// Totality guard, bidirectional: every schema column must be projected onto
+// the response or explicitly excused above, and the projection cannot carry
+// a field that traces back to no real column, aside from the joined
+// authorName/authorImage.
+type MissingProjectedTemplateListColumn = UnprojectedColumns<
+  TemplateRow,
+  TemplateListItem,
+  (typeof UNPROJECTED_TEMPLATE_LIST_COLUMNS)[number]
+>;
+type UnexpectedProjectedTemplateListColumn = UnbackedProjectionKeys<
+  TemplateRow,
+  Omit<TemplateListItem, "authorName" | "authorImage">
+>;
+
+true satisfies MissingProjectedTemplateListColumn extends never ? true : never;
+true satisfies UnexpectedProjectedTemplateListColumn extends never
+  ? true
+  : never;
 
 type ListTemplatesProps = {
   safeDb: SafeDb;
@@ -125,8 +199,12 @@ export const listTemplatesHandler = async function* ({
     ),
   );
 
+  // Ties the `.select({...})` above to `TemplateListItem`: if either drops
+  // a field the other still names, this check stops typechecking.
+  const projectedResult = result satisfies TemplateListItem[];
+
   const page = createCursorPage({
-    rows: result,
+    rows: projectedResult,
     limit,
     cursorForItem: (item) => encodeTemplateListCursor(item.id),
   });

--- a/apps/api/src/handlers/workspaces/workspace-members-read.ts
+++ b/apps/api/src/handlers/workspaces/workspace-members-read.ts
@@ -1,6 +1,53 @@
 import type { ScopedDb } from "@/api/db/safe-db";
+import type { workspaceMembers } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
+import type {
+  UnbackedProjectionKeys,
+  UnprojectedColumns,
+} from "@/api/lib/projection-totality";
+
+type WorkspaceMemberRow = typeof workspaceMembers.$inferSelect;
+
+// Columns intentionally not sent to the client. A new schema column must
+// either be added to `WORKSPACE_MEMBER_COLUMNS` below or added here with a
+// reason, or the totality check further down fails to typecheck.
+const UNPROJECTED_WORKSPACE_MEMBER_COLUMNS = [
+  // The route is already scoped to one workspace via the workspaceId
+  // parameter; restating it per-member would be redundant.
+  "workspaceId",
+] as const satisfies readonly (keyof WorkspaceMemberRow)[];
+
+// The exact `columns:` selection passed to `findMany` below. Reused there
+// so the selection and the totality guard can never drift apart. The
+// nested `user` profile (see `with:` below) is a separate, intentionally
+// narrow picker-style projection (for display only), not "the resource"
+// this guard covers.
+const WORKSPACE_MEMBER_COLUMNS = {
+  id: true,
+  userId: true,
+  createdAt: true,
+} as const;
+
+// Totality guard, bidirectional: every schema column must be projected onto
+// the response or explicitly excused above, and the projection cannot carry
+// a field that traces back to no real column.
+type MissingProjectedWorkspaceMemberColumn = UnprojectedColumns<
+  WorkspaceMemberRow,
+  typeof WORKSPACE_MEMBER_COLUMNS,
+  (typeof UNPROJECTED_WORKSPACE_MEMBER_COLUMNS)[number]
+>;
+type UnexpectedProjectedWorkspaceMemberColumn = UnbackedProjectionKeys<
+  WorkspaceMemberRow,
+  typeof WORKSPACE_MEMBER_COLUMNS
+>;
+
+true satisfies MissingProjectedWorkspaceMemberColumn extends never
+  ? true
+  : never;
+true satisfies UnexpectedProjectedWorkspaceMemberColumn extends never
+  ? true
+  : never;
 
 type ReadWorkspaceMembersHandlerProps = {
   scopedDb: ScopedDb;
@@ -15,11 +62,7 @@ export const readWorkspaceMembersHandler = async ({
     tx.query.workspaceMembers.findMany({
       where: { workspaceId: { eq: workspaceId } },
       limit: LIMITS.workspaceMembersCount,
-      columns: {
-        id: true,
-        userId: true,
-        createdAt: true,
-      },
+      columns: WORKSPACE_MEMBER_COLUMNS,
       with: {
         user: {
           columns: {

--- a/apps/api/src/lib/projection-totality.ts
+++ b/apps/api/src/lib/projection-totality.ts
@@ -1,0 +1,47 @@
+/**
+ * A schema column can go silently unprojected: a handler hand-lists the
+ * fields it sends to the client, a migration adds a column to the table, and
+ * nothing forces the handler back open. `properties/list.ts` shipped exactly
+ * this bug — `kinds` landed on the table with no branch projecting it, so
+ * the web client had no way to scope properties by entity kind, and nothing
+ * failed until someone noticed by hand.
+ *
+ * These two type helpers turn that silence into a compile error. Pair them at
+ * the bottom of a projection module with the idiom below: one line fails if a
+ * row column is neither projected nor named in an explicit, reasoned
+ * `Excused` list, and the other fails if the projection carries a key that
+ * traces back to no real column (a typo, or a column since dropped).
+ *
+ * ```ts
+ * const UNPROJECTED_WIDGET_COLUMNS = [
+ *   // One reason per excused column, not just its name.
+ *   "internalCorrelationId",
+ * ] as const satisfies readonly (keyof WidgetRow)[];
+ *
+ * type MissingProjectedWidgetColumn = UnprojectedColumns<
+ *   WidgetRow,
+ *   WidgetListItem,
+ *   (typeof UNPROJECTED_WIDGET_COLUMNS)[number]
+ * >;
+ * type UnexpectedProjectedWidgetColumn = UnbackedProjectionKeys<
+ *   WidgetRow,
+ *   WidgetListItem
+ * >;
+ *
+ * true satisfies MissingProjectedWidgetColumn extends never ? true : never;
+ * true satisfies UnexpectedProjectedWidgetColumn extends never ? true : never;
+ * ```
+ */
+
+/** Columns of Row that Projection neither carries nor Excused names. */
+export type UnprojectedColumns<
+  Row,
+  Projection,
+  Excused extends keyof Row = never,
+> = Exclude<Exclude<keyof Row, Excused>, keyof Projection>;
+
+/** Keys of Projection that no Row column backs. */
+export type UnbackedProjectionKeys<Row, Projection> = Exclude<
+  keyof Projection,
+  keyof Row
+>;


### PR DESCRIPTION
## Summary

Generalizes the projection guard introduced for the property list in #2809 and applies it across the resource handlers.

- **`apps/api/src/lib/projection-totality.ts`**: two type helpers, `UnprojectedColumns<Row, Projection, Excused>` and `UnbackedProjectionKeys<Row, Projection>`, with the usage idiom documented (`true satisfies X extends never ? true : never`). Type-only, no runtime.
- **Guarded handlers** (each with an `UNPROJECTED_*_COLUMNS` allowlist carrying one reason per column): `properties/list` (refactored onto the helper), `notifications/read-model`, `saved-searches/response`, `skills/comments/list`, `contacts/list-query`, `templates/list`, `playbooks/read` (list and detail; the duplicated hand-listing became `toPlaybookDefinitionListItem` / `toPlaybookDefinitionDetail`), `workspaces/workspace-members-read`.
- Where the projection is a `.select({...})`, a `result satisfies <Item>[]` check ties the query to the item type the guard inspects.

## Gaps the sweep found (excused with `review` notes, not changed here)

- `templates.kind` (document vs report) is never sent by `templates/list` or `templates/get`, yet `reports/clone-builtin` creates report-kind templates. A report template is indistinguishable from a document template in the list.
- `playbooks/list` describes itself as carrying scope, status, and approval metadata, but never projected `scope`, `positions`, `approvedAt`, or `approvedBy`.
- `playbookDefinitions.approvedBy` is set on approval and never read back, including on `playbooks/get`.

## Verification

- Every guard proven: removing one projected key fails the API typecheck at the guard's line with `Type 'true' does not satisfy the expected type 'never'`, then restored.
- API typecheck clean; type-aware oxlint and oxfmt clean on the nine files; tests adjacent to every touched handler pass (contacts, saved searches, templates, skill comments, notifications, playbooks, workspace members, MCP registry projection contract).
