### PR TITLE
chore(ci): fail when a schema column is referenced nowhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1035,6 +1035,14 @@ jobs:
           bun test scripts/check-migration-order.test.ts
           bun test scripts/merge-bar.test.ts
 
+      # Self-test the dead-columns reference matcher: a regression here
+      # would either silently stop flagging genuinely unreferenced columns
+      # or start flagging live ones, in both cases undermining the
+      # check:dead-columns gate in the code-quality job.
+      - name: Test dead-columns reference matching
+        if: needs.ci-plan.outputs.package_checks_required == 'true'
+        run: bun test scripts/check-dead-columns.test.ts
+
       # Fail PRs that change the desktop bridge surface without
       # bumping BRIDGE_VERSION in apps/desktop/src-tauri/src/types.rs.
       # See scripts/check-bridge-version.sh for rationale.
@@ -1102,6 +1110,9 @@ jobs:
             exit 0
           fi
           bun run code-check:affected -- --base "origin/$BASE_REF"
+
+      - name: Dead columns
+        run: bun run check:dead-columns
 
       - name: Result consumption
         env:

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "canary:mcp": "bun --filter @stll/api canary:mcp",
     "check:auth-md-spec": "bun packages/scripts/src/auth-md-spec-drift.ts",
     "check:resolutions": "bun scripts/check-resolution-ranges.ts",
+    "check:dead-columns": "bun scripts/check-dead-columns.ts",
     "check:result-consumption": "bun packages/scripts/src/result-consumption.ts",
     "check:docs-sources": "bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings .claude/mcp/doc-sources.ts",
     "check:railway-template-draft": "bun scripts/check-railway-template-draft.ts",

--- a/scripts/check-dead-columns.test.ts
+++ b/scripts/check-dead-columns.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+
+import { isColumnReferenced, shouldScanFile } from "./check-dead-columns";
+
+describe("isColumnReferenced", () => {
+  test("finds a member-access reference by TS key", () => {
+    expect(
+      isColumnReferenced({
+        corpus: "const value = row.autoInvokeHint;",
+        tsKey: "autoInvokeHint",
+        sqlName: "auto_invoke_hint",
+      }),
+    ).toBe(true);
+  });
+
+  test("finds a shorthand destructure reference by TS key", () => {
+    expect(
+      isColumnReferenced({
+        corpus: "const { autoInvokeHint } = row;",
+        tsKey: "autoInvokeHint",
+        sqlName: "auto_invoke_hint",
+      }),
+    ).toBe(true);
+  });
+
+  test("finds a quoted-string columns-map reference by TS key", () => {
+    expect(
+      isColumnReferenced({
+        corpus:
+          'tx.query.agentSkills.findMany({ columns: { "autoInvokeHint": true } });',
+        tsKey: "autoInvokeHint",
+        sqlName: "auto_invoke_hint",
+      }),
+    ).toBe(true);
+  });
+
+  test("finds a SQL-name-only reference inside a sql template", () => {
+    expect(
+      isColumnReferenced({
+        corpus: "sql`SELECT auto_invoke_hint FROM agent_skills`",
+        tsKey: "autoInvokeHint",
+        sqlName: "auto_invoke_hint",
+      }),
+    ).toBe(true);
+  });
+
+  test("reports no reference when neither the TS key nor the SQL name appears", () => {
+    expect(
+      isColumnReferenced({
+        corpus: "const value = row.someOtherField;",
+        tsKey: "autoInvokeHint",
+        sqlName: "auto_invoke_hint",
+      }),
+    ).toBe(false);
+  });
+
+  test("does not match a key as a substring of a longer identifier", () => {
+    expect(
+      isColumnReferenced({
+        corpus: "const value = row.notAutoInvokeHintAtAll;",
+        tsKey: "autoInvokeHint",
+        sqlName: "auto_invoke_hint",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldScanFile", () => {
+  test("scans ordinary application source", () => {
+    expect(shouldScanFile("apps/api/src/handlers/skills/create.ts")).toBe(true);
+    expect(shouldScanFile("apps/web/src/components/search-dialog.tsx")).toBe(
+      true,
+    );
+  });
+
+  test("excludes the schema definitions", () => {
+    expect(shouldScanFile("apps/api/src/db/schema.ts")).toBe(false);
+    expect(shouldScanFile("apps/api/src/db/schema/properties.ts")).toBe(false);
+  });
+
+  test("excludes test files, including integration and property suites", () => {
+    expect(shouldScanFile("apps/api/src/handlers/skills/create.test.ts")).toBe(
+      false,
+    );
+    expect(
+      shouldScanFile("apps/api/src/lib/workspace-deletion.integration.test.ts"),
+    ).toBe(false);
+    expect(
+      shouldScanFile("scripts/prepare-maintenance-release.property.test.ts"),
+    ).toBe(false);
+    expect(shouldScanFile("apps/api/src/db/schema/entities.test.ts")).toBe(
+      false,
+    );
+  });
+
+  test("excludes generated typings, migrations, and node_modules", () => {
+    expect(shouldScanFile("apps/api/src/env.d.ts")).toBe(false);
+    expect(
+      shouldScanFile("apps/api/drizzle/20260101000000_x/migration.ts"),
+    ).toBe(false);
+    expect(shouldScanFile("apps/api/node_modules/foo/index.ts")).toBe(false);
+  });
+
+  test("excludes non-TypeScript files", () => {
+    expect(shouldScanFile("apps/api/src/handlers/skills/README.md")).toBe(
+      false,
+    );
+  });
+});

--- a/scripts/check-dead-columns.ts
+++ b/scripts/check-dead-columns.ts
@@ -1,0 +1,270 @@
+#!/usr/bin/env bun
+// A column can ship on a table, be written by no handler, and be read by no
+// consumer for months -- `properties.kinds` did exactly that until the gap
+// surfaced as a user-visible defect (the web client had no way to scope
+// properties by entity kind; see apps/api/src/handlers/properties/list.ts).
+// The type system cannot flag something that is consistently *absent* from
+// call sites, so this script greps application source for every schema
+// column instead and fails CI when one is referenced nowhere.
+//
+// Usage: bun scripts/check-dead-columns.ts
+
+import { panic } from "better-result";
+import { getColumns, getTableName, is } from "drizzle-orm";
+import { PgTable } from "drizzle-orm/pg-core";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+import * as schema from "../apps/api/src/db/schema";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "..");
+const ALLOWLIST_PATH = path.join(
+  REPO_ROOT,
+  "scripts/dead-columns.allowlist.json",
+);
+const SOURCE_ROOTS = ["apps", "packages"] as const;
+
+// Present on nearly every table and referenced so pervasively (auth
+// middleware, RLS scoping, base row shapes) that checking them adds no
+// signal. Every other column -- including other foreign keys -- stays
+// checked; a merely *common* name (e.g. "name") will simply be found
+// somewhere in the corpus rather than being excluded, so it never produces a
+// false "dead" report. The failure mode this check accepts is one-directional:
+// a column referenced nowhere is always reported, a common name never is.
+const IGNORED_COLUMN_KEYS = new Set([
+  "id",
+  "createdAt",
+  "updatedAt",
+  "workspaceId",
+  "organizationId",
+  "deletedAt",
+]);
+
+// The schema definitions themselves obviously reference every column; excluding
+// them is what makes this a "used elsewhere" check rather than a tautology.
+const EXCLUDED_PATH_PREFIXES = ["apps/api/src/db/schema"] as const;
+// Migrations replay column names verbatim and would make every column look
+// referenced; generated/vendor output belongs out for the same reason.
+const EXCLUDED_PATH_SEGMENTS = new Set(["node_modules", "drizzle"]);
+
+type ColumnInfo = {
+  table: string;
+  tsKey: string;
+  sqlName: string;
+};
+
+type AllowlistEntry = {
+  table: string;
+  column: string;
+  reason: string;
+};
+
+const allowlistKey = (table: string, column: string): string =>
+  `${table}.${column}`;
+
+/**
+ * Enumerates every `pgTable` the schema module exports, along with each
+ * column's TypeScript property key and its underlying SQL column name.
+ */
+const collectColumns = (): ColumnInfo[] => {
+  const columns: ColumnInfo[] = [];
+  for (const value of Object.values(schema)) {
+    if (!is(value, PgTable)) {
+      continue;
+    }
+    const table = getTableName(value);
+    const tableColumns = getColumns(value);
+    for (const [tsKey, column] of Object.entries(tableColumns)) {
+      if (IGNORED_COLUMN_KEYS.has(tsKey)) {
+        continue;
+      }
+      columns.push({ table, tsKey, sqlName: column.name });
+    }
+  }
+  return columns;
+};
+
+/**
+ * True when `relativePath` (posix-separated, relative to the repo root)
+ * should be scanned for column references: application `.ts`/`.tsx` source,
+ * excluding the schema definitions, migrations, generated typings, and tests.
+ */
+export const shouldScanFile = (relativePath: string): boolean => {
+  if (!(relativePath.endsWith(".ts") || relativePath.endsWith(".tsx"))) {
+    return false;
+  }
+  if (relativePath.endsWith(".d.ts")) {
+    return false;
+  }
+  // Also excludes *.integration.test.ts and *.property.test.ts, which share
+  // this suffix.
+  if (relativePath.endsWith(".test.ts") || relativePath.endsWith(".test.tsx")) {
+    return false;
+  }
+  if (
+    EXCLUDED_PATH_PREFIXES.some((prefix) => relativePath.startsWith(prefix))
+  ) {
+    return false;
+  }
+  const segments = relativePath.split("/");
+  return !segments.some((segment) => EXCLUDED_PATH_SEGMENTS.has(segment));
+};
+
+const walk = (directory: string, out: string[]): void => {
+  for (const entry of readdirSync(directory)) {
+    const absolute = path.join(directory, entry);
+    const stats = statSync(absolute);
+    if (stats.isDirectory()) {
+      if (EXCLUDED_PATH_SEGMENTS.has(entry)) {
+        continue;
+      }
+      walk(absolute, out);
+    } else if (stats.isFile()) {
+      out.push(absolute);
+    }
+  }
+};
+
+/** Every candidate source file under each workspace's `src` directory. */
+const collectSourceFiles = (): string[] => {
+  const files: string[] = [];
+  for (const root of SOURCE_ROOTS) {
+    const rootDirectory = path.join(REPO_ROOT, root);
+    for (const workspaceName of readdirSync(rootDirectory)) {
+      const srcDirectory = path.join(rootDirectory, workspaceName, "src");
+      if (!statSync(srcDirectory, { throwIfNoEntry: false })?.isDirectory()) {
+        continue;
+      }
+      walk(srcDirectory, files);
+    }
+  }
+  return files.filter((absolute) =>
+    shouldScanFile(
+      path.relative(REPO_ROOT, absolute).split(path.sep).join("/"),
+    ),
+  );
+};
+
+const buildCorpus = (files: readonly string[]): string =>
+  files.map((file) => readFileSync(file, "utf-8")).join("\n");
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+
+/**
+ * A column counts as referenced when its TS key or SQL name appears as a
+ * whole word anywhere in the corpus. `\b` word boundaries alone cover every
+ * shape called out by the spec -- `.key` member access, `key:` object
+ * literal/destructure keys (including shorthand `{ key }`), quoted `"key"`
+ * string keys, and `${key}` template interpolation -- because each of those
+ * contexts places a non-word character (`.`, `:`, quote, `{`/`}`) directly
+ * against the identifier. It also matches the SQL name inside a `` sql`...` ``
+ * template or a plain string for the same reason.
+ */
+export const isColumnReferenced = ({
+  corpus,
+  tsKey,
+  sqlName,
+}: {
+  corpus: string;
+  tsKey: string;
+  sqlName: string;
+}): boolean => {
+  const tsKeyPattern = new RegExp(`\\b${escapeRegExp(tsKey)}\\b`, "u");
+  if (tsKeyPattern.test(corpus)) {
+    return true;
+  }
+  if (sqlName === tsKey) {
+    return false;
+  }
+  const sqlNamePattern = new RegExp(`\\b${escapeRegExp(sqlName)}\\b`, "u");
+  return sqlNamePattern.test(corpus);
+};
+
+const isAllowlistEntry = (value: unknown): value is AllowlistEntry =>
+  typeof value === "object" &&
+  value !== null &&
+  "table" in value &&
+  "column" in value &&
+  "reason" in value &&
+  typeof value.table === "string" &&
+  typeof value.column === "string" &&
+  typeof value.reason === "string";
+
+const loadAllowlist = (): AllowlistEntry[] => {
+  const raw = readFileSync(ALLOWLIST_PATH, "utf-8");
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed) || !parsed.every(isAllowlistEntry)) {
+    return panic(
+      `${path.relative(REPO_ROOT, ALLOWLIST_PATH)} must be a JSON array of { table, column, reason } entries`,
+    );
+  }
+  return parsed;
+};
+
+const main = (): void => {
+  const columns = collectColumns();
+  const files = collectSourceFiles();
+  const corpus = buildCorpus(files);
+
+  const deadColumns = columns.filter(
+    (column) =>
+      !isColumnReferenced({
+        corpus,
+        tsKey: column.tsKey,
+        sqlName: column.sqlName,
+      }),
+  );
+  const deadColumnKeys = new Set(
+    deadColumns.map((column) => allowlistKey(column.table, column.tsKey)),
+  );
+  const validColumnKeys = new Set(
+    columns.map((column) => allowlistKey(column.table, column.tsKey)),
+  );
+
+  const allowlist = loadAllowlist();
+  let failed = false;
+
+  for (const entry of allowlist) {
+    const key = allowlistKey(entry.table, entry.column);
+    if (!validColumnKeys.has(key)) {
+      failed = true;
+      console.error(
+        `stale allowlist entry: ${entry.table}.${entry.column} does not match any current schema column -- remove it from ${path.relative(REPO_ROOT, ALLOWLIST_PATH)}`,
+      );
+    } else if (!deadColumnKeys.has(key)) {
+      failed = true;
+      console.error(
+        `stale allowlist entry: ${entry.table}.${entry.column} is no longer dead -- remove it from ${path.relative(REPO_ROOT, ALLOWLIST_PATH)}`,
+      );
+    }
+  }
+
+  const allowlistedKeys = new Set(
+    allowlist.map((entry) => allowlistKey(entry.table, entry.column)),
+  );
+  const unallowlistedDead = deadColumns.filter(
+    (column) => !allowlistedKeys.has(allowlistKey(column.table, column.tsKey)),
+  );
+
+  for (const column of unallowlistedDead) {
+    failed = true;
+    console.error(
+      `dead column: ${column.table}.${column.tsKey} (sql ${column.sqlName})`,
+    );
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+
+  const tableCount = new Set(columns.map((column) => column.table)).size;
+  const referencedCount = columns.length - deadColumns.length;
+  console.log(
+    `check-dead-columns: OK, ${referencedCount} columns across ${tableCount} tables referenced.`,
+  );
+};
+
+if (import.meta.main) {
+  main();
+}

--- a/scripts/dead-columns.allowlist.json
+++ b/scripts/dead-columns.allowlist.json
@@ -1,0 +1,62 @@
+[
+  {
+    "table": "agent_skills",
+    "column": "autoInvokeHint",
+    "reason": "unreferenced as of 2026-09-02; decide: wire or drop"
+  },
+  {
+    "table": "ai_memories",
+    "column": "supersededById",
+    "reason": "unreferenced as of 2026-09-02; decide: wire or drop"
+  },
+  {
+    "table": "bilingual_translation_runs",
+    "column": "modelRef",
+    "reason": "unreferenced as of 2026-09-02; decide: wire or drop"
+  },
+  {
+    "table": "document_review_runs",
+    "column": "modelRef",
+    "reason": "unreferenced as of 2026-09-02; decide: wire or drop"
+  },
+  {
+    "table": "document_translation_runs",
+    "column": "modelRef",
+    "reason": "unreferenced as of 2026-09-02; decide: wire or drop"
+  },
+  {
+    "table": "usage_provider_webhook_events",
+    "column": "processedAt",
+    "reason": "unreferenced as of 2026-09-02; decide: wire or drop"
+  },
+  {
+    "table": "organization_settings",
+    "column": "documentStampEnabled",
+    "reason": "unreferenced as of 2026-09-02; decide: wire or drop"
+  },
+  {
+    "table": "buffer_object_cleanup_intents",
+    "column": "writerUserId",
+    "reason": "not app-code dead: default expression pulls the PostgreSQL session var and the column only appears inside the RLS policy predicate built alongside the table in schema/entities.ts, which this check excludes as the definitions. Allowlisted rather than a scanner fix -- picking it up would require reading inside the excluded schema files, defeating the point of the exclusion."
+  },
+  {
+    "table": "corpus_index_projection_revisions",
+    "column": "transactionId",
+    "reason": "not app-code dead: populated only by migration-owned triggers (apps/api/drizzle/20260901060000_concurrent_corpus_projection_revision_fence/migration.sql) for ON CONFLICT dedup; app code only ever selects `revision`. Migrations are excluded by design, so this column is invisible to the check even though it is live."
+  },
+  {
+    "table": "case_law_corpus_jurisdictions",
+    "column": "firstObservedAt",
+    "reason": "not app-code dead: append-only audit timestamp written by a migration-owned trigger (see schema/case-law.ts comment); census.ts only ever selects `country`. Migrations are excluded by design."
+  },
+  {
+    "table": "case_law_citation_resolution_census_runs",
+    "column": "keysScanned",
+    "reason": "dormant feature: citation-resolution-census-consts.ts is explicitly headed 'Dormant closed vocabularies of the citation-resolution census' -- the whole table is scaffolded ahead of a census feature that has not landed; only referenced in branded-id registries and RLS/schema-invariant tests."
+  },
+  {
+    "table": "case_law_citation_resolution_census_runs",
+    "column": "cursorKey",
+    "reason": "dormant feature: see case_law_citation_resolution_census_runs.keysScanned -- same not-yet-landed census feature."
+  }
+]

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -3,9 +3,21 @@
   "compilerOptions": {
     "tsBuildInfoFile": "${configDir}/.cache/tsbuildinfo.scripts.json",
     "paths": {
-      "@/api/*": ["./apps/api/src/*"]
+      "@/api/*": ["./apps/api/src/*"],
+      // scripts/check-dead-columns.ts loads apps/api/src/db/schema at
+      // runtime for introspection, and its trailing type re-exports reach
+      // into apps/api/src/handlers/**. Mirror the pieces of
+      // apps/api/tsconfig.json that graph needs so it resolves the same way
+      // it does inside the API's own project: the path mapping this package
+      // needs (its own package.json isn't resolvable under Bundler
+      // resolution), and JSX for one handler-adjacent module that renders an
+      // email template.
+      "@stll/infosoud": ["./packages/infosoud/src/index.ts"]
     },
-    "types": ["bun-types"]
+    "types": ["bun-types"],
+    "jsx": "react-jsx"
   },
-  "include": ["scripts/**/*.ts"]
+  // "types" is the shared ambient-module root (asset imports like *.docx and
+  // *.wasm) that the same schema-import graph also reaches.
+  "include": ["scripts/**/*.ts", "types"]
 }


### PR DESCRIPTION
## Summary

`scripts/check-dead-columns.ts`, wired as `bun run check:dead-columns` in the `code-quality` job (its matcher self-test runs in `ci-checks`).

- Enumerates every `pgTable` column from `apps/api/src/db/schema` at runtime (`getColumns`, `getTableName`).
- Scans `.ts`/`.tsx` under each workspace's `src/` (schema definitions, migrations, tests, `.d.ts` excluded) for the column's TS key as member access, object key, quoted key, or template interpolation, and for its SQL name inside `sql` templates or strings, with word boundaries.
- `scripts/dead-columns.allowlist.json` carries one reason per entry; an entry that is no longer dead fails the check, so the list cannot rot.
- Limitation, documented in the header: common names (`name`, `status`) are referenced by other tables' code and never fail. The check is for columns referenced nowhere.

## What it found on today's tree (all allowlisted with a reason; none changed here)

Dead and worth a decision:
- `organization_settings.documentStampEnabled`: a per-organization toggle with no reader anywhere.
- `bilingual_translation_runs.modelRef`, `document_review_runs.modelRef`, `document_translation_runs.modelRef`: provenance never populated.
- `agent_skills.autoInvokeHint`, `ai_memories.supersededById`, `usage_provider_webhook_events.processedAt` (indexed, never queried).

Referenced only from places the scan excludes by design (RLS predicates in the schema file, migration-owned triggers): `buffer_object_cleanup_intents.writerUserId`, `corpus_index_projection_revisions.transactionId`, `case_law_corpus_jurisdictions.firstObservedAt`.

Dormant scaffold: `case_law_citation_resolution_census_runs.keysScanned`, `.cursorKey`.

## Also in this PR

`tsconfig.scripts.json` gains the `@stll/infosoud` path mapping, `jsx`, and the shared `types` include: loading the schema module for introspection reaches handler-adjacent modules that need them, exactly as `apps/api/tsconfig.json` already provides.

## Verification

`bun scripts/check-dead-columns.ts` exits 0; `bun test scripts/check-dead-columns.test.ts` 11 pass; type-aware oxlint and oxfmt clean; `bun run typecheck:repo` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Added automated checks to identify database fields that are no longer referenced by application code.
  - Added validation to ensure documented exceptions remain accurate and up to date.
  - Expanded coverage for reference detection, exclusions, and edge cases.

- **Chores**
  - Integrated the new checks into continuous integration, helping prevent unused database fields from going unnoticed.
  - Updated script configuration to support broader project analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->